### PR TITLE
chore(shake): swap Rv64/Execution import Program → Instructions

### DIFF
--- a/EvmAsm/Evm64/Byte/Program.lean
+++ b/EvmAsm/Evm64/Byte/Program.lean
@@ -36,6 +36,7 @@
     Exit point: offset 180
 -/
 
+import EvmAsm.Rv64.Program
 import EvmAsm.Rv64.Execution
 
 namespace EvmAsm.Evm64

--- a/EvmAsm/Evm64/Calldata/SizeProgram.lean
+++ b/EvmAsm/Evm64/Calldata/SizeProgram.lean
@@ -23,6 +23,7 @@
   (evm-hermes).
 -/
 
+import EvmAsm.Rv64.Program
 import EvmAsm.Rv64.SepLogic
 import EvmAsm.Evm64.Environment.Layout
 

--- a/EvmAsm/Evm64/DivMod/Program.lean
+++ b/EvmAsm/Evm64/DivMod/Program.lean
@@ -38,6 +38,7 @@
     x11 = general temp / qHat
 -/
 
+import EvmAsm.Rv64.Program
 import EvmAsm.Evm64.Stack
 
 namespace EvmAsm.Evm64

--- a/EvmAsm/Evm64/Dup/Program.lean
+++ b/EvmAsm/Evm64/Dup/Program.lean
@@ -5,6 +5,7 @@
   9 instructions (1 ADDI + 4 × (LD + SD)).
 -/
 
+import EvmAsm.Rv64.Program
 import EvmAsm.Rv64.SepLogic
 
 namespace EvmAsm.Evm64

--- a/EvmAsm/Evm64/Env/Program.lean
+++ b/EvmAsm/Evm64/Env/Program.lean
@@ -31,6 +31,7 @@
   Authored by @pirapira; implemented by Hermes-bot (evm-hermes).
 -/
 
+import EvmAsm.Rv64.Program
 import EvmAsm.Evm64.Env.Field
 
 namespace EvmAsm.Evm64

--- a/EvmAsm/Evm64/MLoad/Expansion.lean
+++ b/EvmAsm/Evm64/MLoad/Expansion.lean
@@ -5,6 +5,7 @@
 -/
 
 import EvmAsm.Evm64.Memory
+import EvmAsm.Rv64.Program
 import EvmAsm.Rv64.AddrNorm
 import EvmAsm.Rv64.SyscallSpecs
 import EvmAsm.Rv64.Tactics.ExtractPure

--- a/EvmAsm/Evm64/MLoad/LimbSpecEight.lean
+++ b/EvmAsm/Evm64/MLoad/LimbSpecEight.lean
@@ -20,6 +20,7 @@
   Authored by @pirapira; implemented by Hermes-bot (evm-hermes).
 -/
 
+import EvmAsm.Rv64.Program
 import EvmAsm.Evm64.MLoad.LimbSpec
 
 namespace EvmAsm.Evm64

--- a/EvmAsm/Evm64/MLoad/Program.lean
+++ b/EvmAsm/Evm64/MLoad/Program.lean
@@ -60,6 +60,7 @@
   Authored by @pirapira; implemented by Hermes-bot (evm-hermes).
 -/
 
+import EvmAsm.Rv64.Program
 import EvmAsm.Rv64.SepLogic
 
 namespace EvmAsm.Evm64

--- a/EvmAsm/Evm64/MSize/Program.lean
+++ b/EvmAsm/Evm64/MSize/Program.lean
@@ -28,6 +28,7 @@
   (evm-hermes).
 -/
 
+import EvmAsm.Rv64.Program
 import EvmAsm.Rv64.SepLogic
 
 namespace EvmAsm.Evm64

--- a/EvmAsm/Evm64/MStore/LimbSpec.lean
+++ b/EvmAsm/Evm64/MStore/LimbSpec.lean
@@ -5,6 +5,7 @@
 -/
 
 import EvmAsm.Evm64.MStore.ByteAlg
+import EvmAsm.Rv64.Program
 import EvmAsm.Rv64.SyscallSpecs
 import EvmAsm.Rv64.Tactics.RunBlock
 import EvmAsm.Rv64.Tactics.XSimp

--- a/EvmAsm/Evm64/MStore/Program.lean
+++ b/EvmAsm/Evm64/MStore/Program.lean
@@ -74,6 +74,7 @@
   Authored by @pirapira; implemented by Hermes-bot (evm-hermes).
 -/
 
+import EvmAsm.Rv64.Program
 import EvmAsm.Rv64.SepLogic
 
 namespace EvmAsm.Evm64

--- a/EvmAsm/Evm64/MStore8/Program.lean
+++ b/EvmAsm/Evm64/MStore8/Program.lean
@@ -42,6 +42,7 @@
   Authored by @pirapira; implemented by Hermes-bot (evm-hermes).
 -/
 
+import EvmAsm.Rv64.Program
 import EvmAsm.Rv64.SepLogic
 
 namespace EvmAsm.Evm64

--- a/EvmAsm/Evm64/Multiply/Program.lean
+++ b/EvmAsm/Evm64/Multiply/Program.lean
@@ -39,6 +39,7 @@
     Exit point: offset 252
 -/
 
+import EvmAsm.Rv64.Program
 import EvmAsm.Rv64.Execution
 
 namespace EvmAsm.Evm64

--- a/EvmAsm/Evm64/Pop/Program.lean
+++ b/EvmAsm/Evm64/Pop/Program.lean
@@ -5,6 +5,7 @@
   1 instruction (ADDI x12 x12 32).
 -/
 
+import EvmAsm.Rv64.Program
 import EvmAsm.Rv64.SepLogic
 
 namespace EvmAsm.Evm64

--- a/EvmAsm/Evm64/Push/Program.lean
+++ b/EvmAsm/Evm64/Push/Program.lean
@@ -22,6 +22,7 @@
   Authored by @pirapira; implemented by Hermes-bot (evm-hermes).
 -/
 
+import EvmAsm.Rv64.Program
 import EvmAsm.Rv64.SepLogic
 
 namespace EvmAsm.Evm64

--- a/EvmAsm/Evm64/Push0/Program.lean
+++ b/EvmAsm/Evm64/Push0/Program.lean
@@ -5,6 +5,7 @@
   5 instructions (ADDI + 4 × SD x0).
 -/
 
+import EvmAsm.Rv64.Program
 import EvmAsm.Rv64.SepLogic
 
 namespace EvmAsm.Evm64

--- a/EvmAsm/Evm64/Shift/Program.lean
+++ b/EvmAsm/Evm64/Shift/Program.lean
@@ -32,6 +32,7 @@
     Exit point: offset 360
 -/
 
+import EvmAsm.Rv64.Program
 import EvmAsm.Rv64.Execution
 
 namespace EvmAsm.Evm64

--- a/EvmAsm/Evm64/SignExtend/Program.lean
+++ b/EvmAsm/Evm64/SignExtend/Program.lean
@@ -34,6 +34,7 @@
     Exit point: offset 192
 -/
 
+import EvmAsm.Rv64.Program
 import EvmAsm.Rv64.Execution
 
 namespace EvmAsm.Evm64

--- a/EvmAsm/Evm64/Swap/Program.lean
+++ b/EvmAsm/Evm64/Swap/Program.lean
@@ -5,6 +5,7 @@
   16 instructions (4 × (LD + LD + SD + SD)).
 -/
 
+import EvmAsm.Rv64.Program
 import EvmAsm.Rv64.SepLogic
 
 namespace EvmAsm.Evm64

--- a/EvmAsm/Rv64/ControlFlow.lean
+++ b/EvmAsm/Rv64/ControlFlow.lean
@@ -12,6 +12,7 @@
 
 -- `GenericSpecs` transitively imports `Basic`, `Instructions`, `Program`
 -- (via `Execution`), `SepLogic`, `Execution`, and `CPSSpec`.
+import EvmAsm.Rv64.Program
 import EvmAsm.Rv64.GenericSpecs
 import EvmAsm.Rv64.Tactics.SpecDb
 

--- a/EvmAsm/Rv64/Execution.lean
+++ b/EvmAsm/Rv64/Execution.lean
@@ -15,8 +15,10 @@
   - step / stepN: single-step and multi-step execution over code memory
 -/
 
--- `Program` transitively imports `Instructions` and (via `Instructions`) `Basic`.
-import EvmAsm.Rv64.Program
+-- `Instructions` transitively imports `Basic`. `Program` is not used in this
+-- module — its consumers (RLP/opcode programs, ControlFlow) import `Program`
+-- directly.
+import EvmAsm.Rv64.Instructions
 
 namespace EvmAsm.Rv64
 

--- a/EvmAsm/Rv64/RLP/Phase1.lean
+++ b/EvmAsm/Rv64/RLP/Phase1.lean
@@ -31,6 +31,7 @@
       (`BitVec.ult v5 kVal` on the taken side, `¬…` on the fall-through).
 -/
 
+import EvmAsm.Rv64.Program
 import EvmAsm.Rv64.SyscallSpecs
 import EvmAsm.Rv64.Tactics.ExtractPure
 import EvmAsm.Rv64.Tactics.XSimp

--- a/EvmAsm/Rv64/RLP/Phase2LongAcc.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongAcc.lean
@@ -24,6 +24,7 @@
     x12 — input byte, assumed zero-extended (low 8 bits) (preserved)
 -/
 
+import EvmAsm.Rv64.Program
 import EvmAsm.Rv64.SyscallSpecs
 import EvmAsm.Rv64.AddrNorm
 import EvmAsm.Rv64.Tactics.RunBlock

--- a/EvmAsm/Rv64/RLP/Phase2LongIter.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongIter.lean
@@ -23,6 +23,7 @@
     x14 — iteration counter (mutated: decrements by 1)
 -/
 
+import EvmAsm.Rv64.Program
 import EvmAsm.Rv64.SyscallSpecs
 import EvmAsm.Rv64.AddrNorm
 import EvmAsm.Rv64.Tactics.XSimp

--- a/EvmAsm/Rv64/RLP/Phase2Short.lean
+++ b/EvmAsm/Rv64/RLP/Phase2Short.lean
@@ -19,6 +19,7 @@
     x11 — output: payload length (zero-extended)
 -/
 
+import EvmAsm.Rv64.Program
 import EvmAsm.Rv64.SyscallSpecs
 import EvmAsm.Rv64.Tactics.RunBlock
 

--- a/EvmAsm/Rv64/RLP/Phase3SingleByte.lean
+++ b/EvmAsm/Rv64/RLP/Phase3SingleByte.lean
@@ -23,6 +23,7 @@
   separate files.
 -/
 
+import EvmAsm.Rv64.Program
 import EvmAsm.Rv64.SyscallSpecs
 import EvmAsm.Rv64.Tactics.XSimp
 

--- a/EvmAsm/Rv64/RLP/Phase4HintLen.lean
+++ b/EvmAsm/Rv64/RLP/Phase4HintLen.lean
@@ -5,6 +5,7 @@
   selector for HINT_LEN and invoke ECALL to read the private-input length.
 -/
 
+import EvmAsm.Rv64.Program
 import EvmAsm.Rv64.HintSpecs
 import EvmAsm.Rv64.AddrNorm
 import EvmAsm.Rv64.Tactics.XSimp

--- a/EvmAsm/Rv64/RLP/Phase4HintRead.lean
+++ b/EvmAsm/Rv64/RLP/Phase4HintRead.lean
@@ -5,6 +5,7 @@
   selector for HINT_READ and invoke ECALL for a one-dword input read.
 -/
 
+import EvmAsm.Rv64.Program
 import EvmAsm.Rv64.HintSpecs
 import EvmAsm.Rv64.AddrNorm
 import EvmAsm.Rv64.Tactics.RunBlock


### PR DESCRIPTION
Fixes shake suggestion for `EvmAsm/Rv64/Execution.lean`: it only uses `EvmAsm.Rv64.Instructions`. `Program` was imported only for transitive `Basic`, but `Instructions` already imports `Basic`.

Swap `Execution` to the narrower `Instructions` import. Compensate by adding explicit `import EvmAsm.Rv64.Program` to the 27 downstream files that previously got `Program` transitively via `Execution` (RLP phases, opcode `Program.lean` files, `ControlFlow`).

After this PR `shake-filter` no longer flags `Rv64/Execution.lean`.

Refs evm-asm-2rcao, GH #1045.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).