### PR TITLE
chore(shake): whitelist Phase1E{2,3}FullPath false-positive imports

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -15,6 +15,10 @@
   "EvmAsm.Rv64.RLP.Phase1CascadePrefixE3": ["EvmAsm.Rv64.RLP.Phase1Disjoint"],
   "EvmAsm.Rv64.RLP.Phase1CascadePrefixE4": ["EvmAsm.Rv64.RLP.Phase1Disjoint"],
   "EvmAsm.Rv64.RLP.Phase1CascadePrefixE5": ["EvmAsm.Rv64.RLP.Phase1Disjoint"],
+  "EvmAsm.Rv64.RLP.Phase1E2FullPath":
+  ["EvmAsm.Rv64.RLP.Phase1CascadePrefixE2", "EvmAsm.Rv64.RLP.Phase1Disjoint"],
+  "EvmAsm.Rv64.RLP.Phase1E3FullPath":
+  ["EvmAsm.Rv64.RLP.Phase1CascadePrefixE3", "EvmAsm.Rv64.RLP.Phase1Disjoint"],
   "EvmAsm.Rv64.RLP.Phase2LongLoad":
   ["EvmAsm.Rv64.Tactics.XSimp"],
   "EvmAsm.Rv64.Tactics.XPerm":


### PR DESCRIPTION
shake flagged `EvmAsm/Rv64/RLP/Phase1E2FullPath.lean` and `EvmAsm/Rv64/RLP/Phase1E3FullPath.lean` as having unused imports of `Phase1CascadePrefixE{2,3}` and `Phase1Disjoint`, suggesting `Phase1` alone. Both are **false positives**:

- The FullPath specs reference `rlp_phase1_cascade_prefix_e{2,3}_spec_within` (defined in `CascadePrefixE{2,3}`).
- They also use `rlp_phase1_step_code_disjoint_8(_at_8/_16)` (defined in `Phase1Disjoint`).

Verified by dropping them and observing build failure with `Unknown identifier rlp_phase1_step_code_disjoint_8`.

Mirror the existing `CascadePrefixE2/E3/E4/E5` noshake entries for the two FullPath modules.

Refs GH #1045
Beads: `evm-asm-6votq` (slice of `evm-asm-6qj`)

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).