### PR TITLE
chore(shake): noshake Phase1Disjoint+CascadePrefix in Phase1E4/E5 FullPath

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -15,6 +15,10 @@
   "EvmAsm.Rv64.RLP.Phase1CascadePrefixE3": ["EvmAsm.Rv64.RLP.Phase1Disjoint"],
   "EvmAsm.Rv64.RLP.Phase1CascadePrefixE4": ["EvmAsm.Rv64.RLP.Phase1Disjoint"],
   "EvmAsm.Rv64.RLP.Phase1CascadePrefixE5": ["EvmAsm.Rv64.RLP.Phase1Disjoint"],
+ "EvmAsm.Rv64.RLP.Phase1E4FullPath":
+ ["EvmAsm.Rv64.RLP.Phase1CascadePrefixE4", "EvmAsm.Rv64.RLP.Phase1Disjoint"],
+ "EvmAsm.Rv64.RLP.Phase1E5FullPath":
+ ["EvmAsm.Rv64.RLP.Phase1CascadePrefixE5", "EvmAsm.Rv64.RLP.Phase1Disjoint"],
   "EvmAsm.Rv64.RLP.Phase2LongLoad":
   ["EvmAsm.Rv64.Tactics.XSimp"],
   "EvmAsm.Rv64.Tactics.XPerm":


### PR DESCRIPTION
Mirror PR #2699 for the e4/e5 FullPath modules.

`lake exe shake EvmAsm` flags the same false positive on `EvmAsm/Rv64/RLP/Phase1E4FullPath.lean` / `EvmAsm/Rv64/RLP/Phase1E5FullPath.lean` that PR #2699 already addressed for E2/E3:

- `Phase1CascadePrefixE{4,5}` is genuinely used (`rlp_phase1_cascade_prefix_e{4,5}_spec'_within`).
- `Phase1Disjoint` is genuinely used (the `.Disjoint` lemma on `rlp_phase1_step_code 0xF8 ...`).

Shake misses these because they go through tactic-driven simp / open-namespace lookups that shake doesn't track. Whitelist the imports in `scripts/noshake.json`, mirroring the pattern already in place for the four `Phase1CascadePrefixE{2,3,4,5}` modules and the E2/E3 FullPath entries from #2699.

Verification:
- `lake build` clean
- `lake exe shake EvmAsm` no longer flags `Phase1E4FullPath.lean` / `Phase1E5FullPath.lean`

Refs GH #1045, beads evm-asm-k9fib (parent evm-asm-6qj).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).