### PR TITLE
feat(divmod): per-block subsumption for evm_div/mod_callable_code

### DIFF
--- a/EvmAsm/Evm64/DivMod/Callable.lean
+++ b/EvmAsm/Evm64/DivMod/Callable.lean
@@ -133,4 +133,270 @@ abbrev evm_mod_callable_code (base : Word) : CodeReq :=
     CodeReq.ofProg (base + div128Off)     divK_div128
   ]
 
+-- ============================================================================
+-- Per-block subsumption lemmas for evm_div_callable_code / evm_mod_callable_code
+--
+-- Mirror the `shared_b*_div` / `shared_b*_mod` pattern from
+-- `EvmAsm.Evm64.DivMod.Compose.Base`. Index `N` uses the divCode/modCode
+-- block numbering (0..13). Block 12 is `cc_ret_code (base + nopOff)`
+-- instead of the NOP — the offset is identical (both length 1), so the
+-- disjointness side conditions match modulo a `cc_ret.length = 1` fact.
+-- ============================================================================
+
+/-- `cc_ret = JALR x0 x1 0` is exactly one instruction. -/
+theorem cc_ret_len : cc_ret.length = 1 := by decide
+
+/-- Variant of `skipBlock` (from `Compose.Base`) that also knows
+    `cc_ret.length = 1`. Needed when the block-being-skipped is
+    `cc_ret_code` rather than an `ofProg`-of-named-program, since the
+    disjointness `bv_omega` asks for the program length. -/
+macro "skipBlockCC" : tactic =>
+  `(tactic| apply CodeReq.mono_union_right
+      (CodeReq.ofProg_disjoint_range (fun k1 k2 hk1 hk2 => by
+        simp only [divK_phaseA_len, divK_phaseB_len, divK_clz_len, divK_phaseC2_len,
+          divK_normB_len, divK_normA_len, divK_copyAU_len, divK_loopSetup_len,
+          divK_loopBody_len, divK_denorm_len, divK_divEpilogue_len,
+          divK_zeroPath_len, divK_nop_len, divK_div128_len, divK_div128_v2_len,
+          divK_div128_v4_len, divK_modEpilogue_len, cc_ret_len] at hk1 hk2
+        bv_omega)))
+
+-- ----------------------------------------------------------------------------
+-- DIV side
+-- ----------------------------------------------------------------------------
+
+private theorem callable_b0_div {b : Word} :
+    ∀ a i, (CodeReq.ofProg b (divK_phaseA 1020)) a = some i →
+      (evm_div_callable_code b) a = some i := by
+  unfold evm_div_callable_code; simp only [CodeReq.unionAll_cons]
+  exact CodeReq.union_mono_left
+private theorem callable_b1_div {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + phaseBOff) divK_phaseB) a = some i →
+      (evm_div_callable_code b) a = some i := by
+  unfold evm_div_callable_code; simp only [CodeReq.unionAll_cons]
+  skipBlock; exact CodeReq.union_mono_left
+private theorem callable_b2_div {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + clzOff) divK_clz) a = some i →
+      (evm_div_callable_code b) a = some i := by
+  unfold evm_div_callable_code; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock; exact CodeReq.union_mono_left
+private theorem callable_b3_div {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + phaseC2Off) (divK_phaseC2 172)) a = some i →
+      (evm_div_callable_code b) a = some i := by
+  unfold evm_div_callable_code; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
+private theorem callable_b4_div {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + normBOff) divK_normB) a = some i →
+      (evm_div_callable_code b) a = some i := by
+  unfold evm_div_callable_code; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
+private theorem callable_b5_div {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + normAOff) (divK_normA 40)) a = some i →
+      (evm_div_callable_code b) a = some i := by
+  unfold evm_div_callable_code; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
+private theorem callable_b6_div {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + copyAUOff) divK_copyAU) a = some i →
+      (evm_div_callable_code b) a = some i := by
+  unfold evm_div_callable_code; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
+private theorem callable_b7_div {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + loopSetupOff) (divK_loopSetup 464)) a = some i →
+      (evm_div_callable_code b) a = some i := by
+  unfold evm_div_callable_code; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
+  exact CodeReq.union_mono_left
+private theorem callable_b8_div {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + loopBodyOff) (divK_loopBody 560 7736)) a = some i →
+      (evm_div_callable_code b) a = some i := by
+  unfold evm_div_callable_code; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
+  exact CodeReq.union_mono_left
+private theorem callable_b9_div {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + denormOff) divK_denorm) a = some i →
+      (evm_div_callable_code b) a = some i := by
+  unfold evm_div_callable_code; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
+  skipBlock; exact CodeReq.union_mono_left
+private theorem callable_b10_div {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + epilogueOff) (divK_div_epilogue 24)) a = some i →
+      (evm_div_callable_code b) a = some i := by
+  unfold evm_div_callable_code; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
+  skipBlock; skipBlock; exact CodeReq.union_mono_left
+private theorem callable_b11_div {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + zeroPathOff) divK_zeroPath) a = some i →
+      (evm_div_callable_code b) a = some i := by
+  unfold evm_div_callable_code; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
+  skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
+private theorem callable_b12_div {b : Word} :
+    ∀ a i, (cc_ret_code (b + nopOff)) a = some i →
+      (evm_div_callable_code b) a = some i := by
+  unfold evm_div_callable_code; simp only [CodeReq.unionAll_cons]
+  skipBlockCC; skipBlockCC; skipBlockCC; skipBlockCC; skipBlockCC; skipBlockCC
+  skipBlockCC; skipBlockCC; skipBlockCC; skipBlockCC; skipBlockCC; skipBlockCC
+  exact CodeReq.union_mono_left
+private theorem callable_b13_div {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + div128Off) divK_div128) a = some i →
+      (evm_div_callable_code b) a = some i := by
+  unfold evm_div_callable_code; simp only [CodeReq.unionAll_cons, cc_ret_code]
+  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
+  skipBlock; skipBlock; skipBlock; skipBlock; skipBlockCC; exact CodeReq.union_mono_left
+
+/-- Bundle: every per-block subsumption for `evm_div_callable_code`. Mirrors
+    `mul_callable_code_block_subs` (Multiply/Callable.lean) so downstream
+    composition slices can destructure ⟨b0, b1, …, b13⟩ in one shot. -/
+theorem evm_div_callable_code_block_subs (base : Word) :
+    (∀ a i, (CodeReq.ofProg base (divK_phaseA 1020)) a = some i →
+      (evm_div_callable_code base) a = some i) ∧
+    (∀ a i, (CodeReq.ofProg (base + phaseBOff) divK_phaseB) a = some i →
+      (evm_div_callable_code base) a = some i) ∧
+    (∀ a i, (CodeReq.ofProg (base + clzOff) divK_clz) a = some i →
+      (evm_div_callable_code base) a = some i) ∧
+    (∀ a i, (CodeReq.ofProg (base + phaseC2Off) (divK_phaseC2 172)) a = some i →
+      (evm_div_callable_code base) a = some i) ∧
+    (∀ a i, (CodeReq.ofProg (base + normBOff) divK_normB) a = some i →
+      (evm_div_callable_code base) a = some i) ∧
+    (∀ a i, (CodeReq.ofProg (base + normAOff) (divK_normA 40)) a = some i →
+      (evm_div_callable_code base) a = some i) ∧
+    (∀ a i, (CodeReq.ofProg (base + copyAUOff) divK_copyAU) a = some i →
+      (evm_div_callable_code base) a = some i) ∧
+    (∀ a i, (CodeReq.ofProg (base + loopSetupOff) (divK_loopSetup 464)) a = some i →
+      (evm_div_callable_code base) a = some i) ∧
+    (∀ a i, (CodeReq.ofProg (base + loopBodyOff) (divK_loopBody 560 7736)) a = some i →
+      (evm_div_callable_code base) a = some i) ∧
+    (∀ a i, (CodeReq.ofProg (base + denormOff) divK_denorm) a = some i →
+      (evm_div_callable_code base) a = some i) ∧
+    (∀ a i, (CodeReq.ofProg (base + epilogueOff) (divK_div_epilogue 24)) a = some i →
+      (evm_div_callable_code base) a = some i) ∧
+    (∀ a i, (CodeReq.ofProg (base + zeroPathOff) divK_zeroPath) a = some i →
+      (evm_div_callable_code base) a = some i) ∧
+    (∀ a i, (cc_ret_code (base + nopOff)) a = some i →
+      (evm_div_callable_code base) a = some i) ∧
+    (∀ a i, (CodeReq.ofProg (base + div128Off) divK_div128) a = some i →
+      (evm_div_callable_code base) a = some i) :=
+  ⟨callable_b0_div, callable_b1_div, callable_b2_div, callable_b3_div,
+   callable_b4_div, callable_b5_div, callable_b6_div, callable_b7_div,
+   callable_b8_div, callable_b9_div, callable_b10_div, callable_b11_div,
+   callable_b12_div, callable_b13_div⟩
+
+-- ----------------------------------------------------------------------------
+-- MOD side (block 10 uses divK_mod_epilogue; everything else identical)
+-- ----------------------------------------------------------------------------
+
+private theorem callable_b0_mod {b : Word} :
+    ∀ a i, (CodeReq.ofProg b (divK_phaseA 1020)) a = some i →
+      (evm_mod_callable_code b) a = some i := by
+  unfold evm_mod_callable_code; simp only [CodeReq.unionAll_cons]
+  exact CodeReq.union_mono_left
+private theorem callable_b1_mod {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + phaseBOff) divK_phaseB) a = some i →
+      (evm_mod_callable_code b) a = some i := by
+  unfold evm_mod_callable_code; simp only [CodeReq.unionAll_cons]
+  skipBlock; exact CodeReq.union_mono_left
+private theorem callable_b2_mod {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + clzOff) divK_clz) a = some i →
+      (evm_mod_callable_code b) a = some i := by
+  unfold evm_mod_callable_code; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock; exact CodeReq.union_mono_left
+private theorem callable_b3_mod {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + phaseC2Off) (divK_phaseC2 172)) a = some i →
+      (evm_mod_callable_code b) a = some i := by
+  unfold evm_mod_callable_code; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
+private theorem callable_b4_mod {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + normBOff) divK_normB) a = some i →
+      (evm_mod_callable_code b) a = some i := by
+  unfold evm_mod_callable_code; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
+private theorem callable_b5_mod {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + normAOff) (divK_normA 40)) a = some i →
+      (evm_mod_callable_code b) a = some i := by
+  unfold evm_mod_callable_code; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
+private theorem callable_b6_mod {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + copyAUOff) divK_copyAU) a = some i →
+      (evm_mod_callable_code b) a = some i := by
+  unfold evm_mod_callable_code; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
+private theorem callable_b7_mod {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + loopSetupOff) (divK_loopSetup 464)) a = some i →
+      (evm_mod_callable_code b) a = some i := by
+  unfold evm_mod_callable_code; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
+  exact CodeReq.union_mono_left
+private theorem callable_b8_mod {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + loopBodyOff) (divK_loopBody 560 7736)) a = some i →
+      (evm_mod_callable_code b) a = some i := by
+  unfold evm_mod_callable_code; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
+  exact CodeReq.union_mono_left
+private theorem callable_b9_mod {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + denormOff) divK_denorm) a = some i →
+      (evm_mod_callable_code b) a = some i := by
+  unfold evm_mod_callable_code; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
+  skipBlock; exact CodeReq.union_mono_left
+private theorem callable_b10_mod {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + epilogueOff) (divK_mod_epilogue 24)) a = some i →
+      (evm_mod_callable_code b) a = some i := by
+  unfold evm_mod_callable_code; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
+  skipBlock; skipBlock; exact CodeReq.union_mono_left
+private theorem callable_b11_mod {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + zeroPathOff) divK_zeroPath) a = some i →
+      (evm_mod_callable_code b) a = some i := by
+  unfold evm_mod_callable_code; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
+  skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
+private theorem callable_b12_mod {b : Word} :
+    ∀ a i, (cc_ret_code (b + nopOff)) a = some i →
+      (evm_mod_callable_code b) a = some i := by
+  unfold evm_mod_callable_code; simp only [CodeReq.unionAll_cons]
+  skipBlockCC; skipBlockCC; skipBlockCC; skipBlockCC; skipBlockCC; skipBlockCC
+  skipBlockCC; skipBlockCC; skipBlockCC; skipBlockCC; skipBlockCC; skipBlockCC
+  exact CodeReq.union_mono_left
+private theorem callable_b13_mod {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + div128Off) divK_div128) a = some i →
+      (evm_mod_callable_code b) a = some i := by
+  unfold evm_mod_callable_code; simp only [CodeReq.unionAll_cons, cc_ret_code]
+  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
+  skipBlock; skipBlock; skipBlock; skipBlock; skipBlockCC; exact CodeReq.union_mono_left
+
+/-- Bundle: every per-block subsumption for `evm_mod_callable_code`. Mirror
+    of `evm_div_callable_code_block_subs`. -/
+theorem evm_mod_callable_code_block_subs (base : Word) :
+    (∀ a i, (CodeReq.ofProg base (divK_phaseA 1020)) a = some i →
+      (evm_mod_callable_code base) a = some i) ∧
+    (∀ a i, (CodeReq.ofProg (base + phaseBOff) divK_phaseB) a = some i →
+      (evm_mod_callable_code base) a = some i) ∧
+    (∀ a i, (CodeReq.ofProg (base + clzOff) divK_clz) a = some i →
+      (evm_mod_callable_code base) a = some i) ∧
+    (∀ a i, (CodeReq.ofProg (base + phaseC2Off) (divK_phaseC2 172)) a = some i →
+      (evm_mod_callable_code base) a = some i) ∧
+    (∀ a i, (CodeReq.ofProg (base + normBOff) divK_normB) a = some i →
+      (evm_mod_callable_code base) a = some i) ∧
+    (∀ a i, (CodeReq.ofProg (base + normAOff) (divK_normA 40)) a = some i →
+      (evm_mod_callable_code base) a = some i) ∧
+    (∀ a i, (CodeReq.ofProg (base + copyAUOff) divK_copyAU) a = some i →
+      (evm_mod_callable_code base) a = some i) ∧
+    (∀ a i, (CodeReq.ofProg (base + loopSetupOff) (divK_loopSetup 464)) a = some i →
+      (evm_mod_callable_code base) a = some i) ∧
+    (∀ a i, (CodeReq.ofProg (base + loopBodyOff) (divK_loopBody 560 7736)) a = some i →
+      (evm_mod_callable_code base) a = some i) ∧
+    (∀ a i, (CodeReq.ofProg (base + denormOff) divK_denorm) a = some i →
+      (evm_mod_callable_code base) a = some i) ∧
+    (∀ a i, (CodeReq.ofProg (base + epilogueOff) (divK_mod_epilogue 24)) a = some i →
+      (evm_mod_callable_code base) a = some i) ∧
+    (∀ a i, (CodeReq.ofProg (base + zeroPathOff) divK_zeroPath) a = some i →
+      (evm_mod_callable_code base) a = some i) ∧
+    (∀ a i, (cc_ret_code (base + nopOff)) a = some i →
+      (evm_mod_callable_code base) a = some i) ∧
+    (∀ a i, (CodeReq.ofProg (base + div128Off) divK_div128) a = some i →
+      (evm_mod_callable_code base) a = some i) :=
+  ⟨callable_b0_mod, callable_b1_mod, callable_b2_mod, callable_b3_mod,
+   callable_b4_mod, callable_b5_mod, callable_b6_mod, callable_b7_mod,
+   callable_b8_mod, callable_b9_mod, callable_b10_mod, callable_b11_mod,
+   callable_b12_mod, callable_b13_mod⟩
+
 end EvmAsm.Evm64


### PR DESCRIPTION
Slice of evm-asm-1eq44 (parent evm-asm-8pfe / GH #90).

Adds 14 per-block subsumption lemmas + a destructurable bundle for each of
`evm_div_callable_code` and `evm_mod_callable_code` in
`EvmAsm/Evm64/DivMod/Callable.lean`. These mirror the
`shared_b*_div` / `shared_b*_mod` pattern in
`EvmAsm/Evm64/DivMod/Compose/Base.lean`, with one twist: block 12 is
`cc_ret_code (base + nopOff)` (the NOP↔cc_ret swap) instead of an
`ofProg` of the divK NOP.

A small `skipBlockCC` tactic variant adds `cc_ret_len` to the simp set
used by the existing `skipBlock`'s `bv_omega` disjointness side condition;
otherwise omega cannot see the length of `cc_ret` when crossing block 12.

Together with `evm_div_stack_spec_within` (over `divCode`) and
`ret_spec_within'` (over `cc_ret_code (base + nopOff)`), the bundles
unblock the `evm_div_callable_function_spec` composition in evm-asm-8pfe.

- lake build green
- 0 sorry, 0 `maxHeartbeats` / `maxRecDepth` overrides
- pure additions; no existing proof touched

Refs evm-asm-1eq44, evm-asm-8pfe, GH #90.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).