### PR TITLE
chore(shake): pin Rv64.ControlFlow as false-positive for Slt/Sgt Spec

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -125,8 +125,8 @@
   "EvmAsm.Evm64.Eq.Spec":      ["EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Evm64.Eq.LimbSpec", "EvmAsm.Evm64.EvmWordArith.Eq"],
   "EvmAsm.Evm64.IsZero.Spec":  ["EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Evm64.IsZero.LimbSpec", "EvmAsm.Evm64.EvmWordArith.IsZero"],
   "EvmAsm.Evm64.Byte.Spec":    ["EvmAsm.Rv64.AddrNorm"],
-  "EvmAsm.Evm64.Slt.Spec":     ["EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Evm64.Compare.LimbSpec", "EvmAsm.Evm64.EvmWordArith.Comparison", "EvmAsm.Rv64.AddrNorm"],
-  "EvmAsm.Evm64.Sgt.Spec":     ["EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Evm64.Compare.LimbSpec", "EvmAsm.Evm64.EvmWordArith.Comparison", "EvmAsm.Rv64.AddrNorm"],
+  "EvmAsm.Evm64.Slt.Spec":     ["EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Evm64.Compare.LimbSpec", "EvmAsm.Evm64.EvmWordArith.Comparison", "EvmAsm.Rv64.AddrNorm", "EvmAsm.Rv64.ControlFlow"],
+  "EvmAsm.Evm64.Sgt.Spec":     ["EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Evm64.Compare.LimbSpec", "EvmAsm.Evm64.EvmWordArith.Comparison", "EvmAsm.Rv64.AddrNorm", "EvmAsm.Rv64.ControlFlow"],
   "EvmAsm.Evm64.Multiply.Spec":["EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Evm64.EvmWordArith.MulCorrect"],
   "EvmAsm.Evm64.DivMod.LimbSpec.CopyAU":
   ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.ControlFlow",


### PR DESCRIPTION
## Summary

`lake exe shake EvmAsm` flags `EvmAsm.Rv64.ControlFlow` as unused in
`EvmAsm/Evm64/Slt/Spec.lean` and `EvmAsm/Evm64/Sgt/Spec.lean`. This is a
false positive: ControlFlow provides `jal_x0_spec_gen_within`, which both
files use at the spec-elaboration site (Slt/Spec.lean:100, Sgt/Spec.lean:101 —
removing the import causes `Unknown identifier` errors).

Added the import to each module's `scripts/noshake.json` entry.

## Verification

- `lake build` ✅
- `lake exe shake EvmAsm` no longer flags ControlFlow on Slt/Sgt Spec.

Refs #1045. Beads: parent `evm-asm-9tq`, slice `evm-asm-8a27k`.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).