### PR TITLE
chore(shake): noshake LoopSemantic LoopDefs umbrella false-positive

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -253,7 +253,11 @@
  "EvmAsm.Evm64.EvmWordArith.DivMulSubLimb":
   ["EvmAsm.Evm64.EvmWordArith.DivLimbBridge", "EvmAsm.Evm64.EvmWordArith.DivBridge", "EvmAsm.Rv64.AddrNorm"],
  "EvmAsm.Evm64.DivMod.LoopSemantic":
-  ["EvmAsm.Evm64.EvmWordArith.DivMulSubCarry", "EvmAsm.Evm64.EvmWordArith.DivAddbackCarry"],
+  [
+    "EvmAsm.Evm64.DivMod.LoopDefs",
+    "EvmAsm.Evm64.EvmWordArith.DivMulSubCarry",
+    "EvmAsm.Evm64.EvmWordArith.DivAddbackCarry"
+  ],
  "EvmAsm.Evm64.EvmWordArith.DivAccumulate": ["EvmAsm.Evm64.EvmWordArith.DivRemainderBound"],
  "EvmAsm.Evm64.EvmWordArith.DivN4Overestimate":
   [


### PR DESCRIPTION
Adds `EvmAsm.Evm64.DivMod.LoopDefs` to the noshake.json entry for `EvmAsm.Evm64.DivMod.LoopSemantic`.

After PR #2700 / #2701 etc., `scripts/shake-filter.py` was still reporting one residual kept block:

```
EvmAsm/Evm64/DivMod/LoopSemantic.lean:
  remove #[EvmAsm.Evm64.DivMod.LoopDefs]
  add    #[EvmAsm.Evm64.DivMod.LoopDefs.Iter]
```

`LoopSemantic` only references `mulsubN4` / `addbackN4` / `addbackN4_carry` (all in `LoopDefs.Iter`), but the `LoopDefs` umbrella re-exports `LoopDefs.Post` and `LoopDefs.Bundle` transitively to ~9 downstream `Loop{Iter,Compose,Unified}{N1..N4}` files via `LoopSemantic`. Swapping the umbrella for `LoopDefs.Iter` was tried in `evm-asm-xdypj` and closed as too broad (would force explicit Post/Bundle imports on every downstream consumer).

The correct fix at this stage is to flag the suggestion as a known false positive in `scripts/noshake.json`. After this change, `lake exe shake EvmAsm | scripts/shake-filter.py` reports **0 kept blocks** (118 dropped — all known false positives).

Verification:
- `lake build` clean
- `lake exe shake EvmAsm | scripts/shake-filter.py` → `0 kept, 118 dropped`

Refs GH #1045, parent `evm-asm-6qj`, slice `evm-asm-syr1r`.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).