### PR TITLE
chore(shake): noshake Exp/LimbSpec SyscallSpecs/XSimp/RunBlock false positives

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -102,6 +102,8 @@
   ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.RunBlock"],
  "EvmAsm.Evm64.Sub.LimbSpec":
   ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.RunBlock"],
+ "EvmAsm.Evm64.Exp.LimbSpec":
+  ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Rv64.Tactics.RunBlock"],
  "EvmAsm.Evm64.Eq.LimbSpec":
   ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.RunBlock"],
  "EvmAsm.Evm64.IsZero.LimbSpec":


### PR DESCRIPTION
Pins three imports flagged false-positive by `lake exe shake EvmAsm` on `EvmAsm/Evm64/Exp/LimbSpec.lean`:

- `EvmAsm.Rv64.SyscallSpecs`
- `EvmAsm.Rv64.Tactics.XSimp`
- `EvmAsm.Rv64.Tactics.RunBlock`

The file uses `runBlock`, syscall specs, and XSimp tactics in cpsTriple proofs (4 occurrences). Shake does not track tactic registries / `@[spec_gen_*]` attributes that elaborate via tactic macros, so these flags are confirmed false-positives. Pattern matches existing entries for Add.LimbSpec / Sub.LimbSpec / Eq.LimbSpec / IsZero.LimbSpec.

Verification:
- `lake build` green
- `lake exe shake EvmAsm` no longer flags Exp/LimbSpec.lean

Refs #1045, beads evm-asm-ypkak.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).