### PR TITLE
feat(evm64): dispatchTableIs entry/rest split lemma (#106 slice 3a)

### DIFF
--- a/EvmAsm/Evm64/JumpTable.lean
+++ b/EvmAsm/Evm64/JumpTable.lean
@@ -132,4 +132,96 @@ theorem dispatchTableIs_getMem
     apply Fin.ext; simp
   simpa [Nat.zero_add, hfin] using h
 
+/-! ### Entry / rest split.
+
+The dispatch RV64 program needs to LD one specific table entry; the LD
+spec consumes a single `↦ₘ` cell. To frame it against the 256-entry
+chain we expose the entry as a head and bundle the surrounding entries
+into a residual `Assertion`. The split lives at the layout level
+(equality of `Assertion`s), so callers can directly rewrite both the
+hypothesis and the goal during the dispatch_spec proof (slice 3,
+`evm-asm-afkny`).
+
+The construction uses two `aux` chains glued either side of the chosen
+entry; this is symmetric in both directions, unlike the existing
+`aux_getMem` projection which only goes layout → memory.
+-/
+
+namespace dispatchTableIs
+
+/-- Split a generic `aux` chain at one interior position.
+
+If `start + a + 1 + b ≤ 256`, then the `(a + 1 + b)`-cell auxiliary
+chain decomposes into:
+
+* the prefix of the first `a` cells (`aux base handlers start a`),
+* the singled-out entry at index `start + a`,
+* the suffix of the next `b` cells (`aux base handlers (start+a+1) b`).
+-/
+theorem aux_split (base : Word) (handlers : Fin 256 → Word)
+    (start a b : Nat) (h : start + a + 1 + b ≤ 256) :
+    aux base handlers start (a + 1 + b)
+      = (aux base handlers start a
+        ** ((base + BitVec.ofNat 64 (8 * (start + a))) ↦ₘ handlers ⟨start + a, by omega⟩)
+        ** aux base handlers (start + a + 1) b) := by
+  induction a generalizing start with
+  | zero =>
+    -- prefix is empty, suffix carries the rest.
+    have hstart : start < 256 := by omega
+    have hsum' : start + 1 + b ≤ 256 := by omega
+    have h1 : (0 + 1 + b : Nat) = b + 1 := by omega
+    rw [h1, aux_succ base handlers hstart b]
+    simp only [aux, sepConj_emp_left', Nat.add_zero]
+  | succ a ih =>
+    -- Peel one entry off the front, recurse on the tail with start+1.
+    have hstart : start < 256 := by omega
+    have hrec : (start + 1) + a + 1 + b ≤ 256 := by omega
+    have h1 : ((a + 1) + 1 + b : Nat) = (a + 1 + b) + 1 := by omega
+    rw [h1, aux_succ base handlers hstart (a + 1 + b),
+        ih (start + 1) hrec, aux_succ base handlers hstart a]
+    -- Massage the `start + (a + 1)` indices to match `(start + 1) + a`.
+    have hidx : start + (a + 1) = (start + 1) + a := by omega
+    have hfin :
+        (⟨start + (a + 1), by omega⟩ : Fin 256)
+          = ⟨(start + 1) + a, by omega⟩ := by
+      apply Fin.ext; exact hidx
+    rw [hfin, show start + (a + 1) + 1 = (start + 1) + a + 1 from by omega,
+        show 8 * (start + (a + 1)) = 8 * ((start + 1) + a) from by omega,
+        ← sepConj_assoc']
+
+end dispatchTableIs
+
+/-- **Entry/rest split.** The 256-entry jump-table layout decomposes
+    into the singled-out entry at `opcode` and a residual chain
+    `dispatchTableIs.rest` covering all other indices. This is the form
+    the dispatch RV64 program's LD step consumes during the slice-3
+    Hoare-triple proof. -/
+def dispatchTableIs.rest (base : Word) (handlers : Fin 256 → Word)
+    (opcode : Fin 256) : Assertion :=
+  dispatchTableIs.aux base handlers 0 opcode.val
+    ** dispatchTableIs.aux base handlers (opcode.val + 1) (255 - opcode.val)
+
+theorem dispatchTableIs_split (base : Word) (handlers : Fin 256 → Word)
+    (opcode : Fin 256) :
+    dispatchTableIs base handlers
+      = (((base + BitVec.ofNat 64 (8 * opcode.val)) ↦ₘ handlers opcode)
+        ** dispatchTableIs.rest base handlers opcode) := by
+  have hk : opcode.val < 256 := opcode.isLt
+  have h : (0 : Nat) + opcode.val + 1 + (255 - opcode.val) ≤ 256 := by omega
+  have heq : opcode.val + 1 + (255 - opcode.val) = 256 := by omega
+  have hsplit := dispatchTableIs.aux_split base handlers 0 opcode.val (255 - opcode.val) h
+  -- Rewrite count `0 + opcode.val + 1 + (255 - opcode.val) = 256`.
+  rw [show (opcode.val + 1 + (255 - opcode.val) : Nat) = 256 from heq] at hsplit
+  -- Realign Fin indexing: `⟨0 + opcode.val, _⟩ = opcode`.
+  have hfin :
+      (⟨0 + opcode.val, by omega⟩ : Fin 256) = opcode := by
+    apply Fin.ext; simp
+  rw [hfin] at hsplit
+  -- `dispatchTableIs` and `rest` are direct unfoldings.
+  show dispatchTableIs.aux base handlers 0 256 = _
+  rw [hsplit]
+  unfold dispatchTableIs.rest
+  -- Goal: `prefix ** entry ** suffix = entry ** prefix ** suffix`.
+  ac_rfl
+
 end EvmAsm.Evm64


### PR DESCRIPTION
Adds the entry/rest decomposition for `dispatchTableIs` needed by the slice-3 `dispatch_spec` Hoare triple (parent evm-asm-77w8s, slice evm-asm-afkny).

## What

Two new lemmas in `EvmAsm/Evm64/JumpTable.lean`:

- `dispatchTableIs.aux_split` — generic decomposition of the auxiliary 256-cell chain at any interior index `(start + a)` into prefix + entry + suffix.
- `dispatchTableIs_split` — corollary that rewrites the full `dispatchTableIs base handlers` as `((base + 8·opcode) ↦ₘ handlers opcode) ** dispatchTableIs.rest base handlers opcode`, exposing the chosen entry as the head so the LD step in the dispatch RV64 program can consume it via `ld_spec_within`.
- New helper `def dispatchTableIs.rest` bundling the (prefix-suffix) residual.

Pure additive: no existing declarations are modified or deleted.

## Why

The slice-3 dispatch_spec proof needs to frame a single `↦ₘ` cell out of the 256-entry layout. Without this split, the LD step had no way to talk about one specific entry without hand-rolling the recursion every time. Landing it as a separate slice keeps the upcoming dispatch_spec PR (slice 3) focused on the program semantics rather than re-deriving the layout decomposition.

## Refs

- GH #106
- Parent beads: `evm-asm-77w8s`
- This slice: `evm-asm-b7efv`
- Unblocks: `evm-asm-afkny` (slice 3 dispatch_spec)

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).