### PR TITLE
chore(shake): noshake InterpreterFetchProgram SyscallSpecs/RunBlock false positives

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -248,6 +248,8 @@
   ["EvmAsm.Rv64.AddrNorm", "EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.ExtractPure", "EvmAsm.Rv64.Tactics.RunBlock", "EvmAsm.Rv64.Tactics.XSimp"],
  "EvmAsm.Evm64.Calldata.SizeSpec":
   ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Rv64.Tactics.RunBlock"],
+ "EvmAsm.Evm64.InterpreterFetchProgram":
+  ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.RunBlock"],
  "EvmAsm.Evm64.Push.Spec":
   ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.RunBlock", "EvmAsm.Rv64.Tactics.XSimp"],
  "EvmAsm.Evm64.Calldata.CopyMemory": ["Mathlib.Data.List.GetD"],


### PR DESCRIPTION
lake exe shake EvmAsm flags `EvmAsm/Evm64/InterpreterFetchProgram.lean` as having unused `EvmAsm.Rv64.SyscallSpecs` and `EvmAsm.Rv64.Tactics.RunBlock` imports. Confirmed false-positive: the file uses `runBlock` combined with `add_spec_gen_within` / `lbu_spec_gen_within` in `evm_fetch_opcode_spec_within`. Pin both imports in `scripts/noshake.json`, matching the existing pattern for `Calldata.SizeSpec`, `MStore8.Spec`, `Push.Spec`, etc.

Verification:
- `lake build` clean.
- `lake exe shake EvmAsm` no longer reports `InterpreterFetchProgram`.

Refs GH #1045. Beads: evm-asm-ker06.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).