### PR TITLE
feat(interpreter): bridge unsupported opcode bytes to invalid

### DIFF
--- a/EvmAsm/Evm64/InterpreterLoop.lean
+++ b/EvmAsm/Evm64/InterpreterLoop.lean
@@ -62,6 +62,13 @@ theorem decodeCurrentOpcode?_of_fetch
     decodeCurrentOpcode? state = EvmOpcode.decodeByte? byte.toNat := by
   simp [decodeCurrentOpcode?, h_fetch]
 
+theorem decodeCurrentOpcode?_of_fetch_unsupported
+    {state : EvmState} {byte : BitVec 8}
+    (h_fetch : fetchOpcodeByte? state = some byte)
+    (h_decode : EvmOpcode.decodeByte? byte.toNat = none) :
+    decodeCurrentOpcode? state = none := by
+  rw [decodeCurrentOpcode?_of_fetch h_fetch, h_decode]
+
 theorem decodeCurrentOpcode?_of_eof
     {state : EvmState} (h_fetch : fetchOpcodeByte? state = none) :
     decodeCurrentOpcode? state = none := by
@@ -78,6 +85,14 @@ theorem stepWithHandler_of_unsupported
     (h_decode : decodeCurrentOpcode? state = none) :
     stepWithHandler handler state = state.invalid := by
   simp [stepWithHandler, h_decode]
+
+theorem stepWithHandler_of_fetch_unsupported
+    (handler : Handler) {state : EvmState} {byte : BitVec 8}
+    (h_fetch : fetchOpcodeByte? state = some byte)
+    (h_decode : EvmOpcode.decodeByte? byte.toNat = none) :
+    stepWithHandler handler state = state.invalid :=
+  stepWithHandler_of_unsupported handler
+    (decodeCurrentOpcode?_of_fetch_unsupported h_fetch h_decode)
 
 @[simp] theorem loopFuel_zero (handler : Handler) (state : EvmState) :
     loopFuel handler 0 state = state := rfl

--- a/EvmAsm/Evm64/InterpreterLoopStatus.lean
+++ b/EvmAsm/Evm64/InterpreterLoopStatus.lean
@@ -83,6 +83,15 @@ theorem loopFuel_one_unsupported_invalid
   rw [InterpreterLoop.loopFuel_succ_running handler 0 state h_status]
   simp [InterpreterLoop.stepWithHandler_of_unsupported handler h_decode]
 
+theorem loopFuel_one_fetch_unsupported_invalid
+    (handler : Handler) {state : EvmState} {byte : BitVec 8}
+    (h_status : state.status = .running)
+    (h_fetch : InterpreterLoop.fetchOpcodeByte? state = some byte)
+    (h_decode : EvmOpcode.decodeByte? byte.toNat = none) :
+    InterpreterLoop.loopFuel handler 1 state = state.invalid :=
+  loopFuel_one_unsupported_invalid handler h_status
+    (InterpreterLoop.decodeCurrentOpcode?_of_fetch_unsupported h_fetch h_decode)
+
 theorem loopFuel_one_decode
     (handler : Handler) {state : EvmState} {opcode : EvmOpcode}
     (h_status : state.status = .running)


### PR DESCRIPTION
Adds a small executable-spec bridge for GH #106/#108: fetched opcode bytes whose decoder returns none now directly imply decodeCurrentOpcode? = none, stepWithHandler = state.invalid, and one running loopFuel step = state.invalid.\n\nBead: evm-asm-v69j6\nRefs: GH #106, GH #108\n\nLocal verification:\n- lake build EvmAsm.Evm64.InterpreterLoopStatus\n- lake build\n- git diff --check\n- forbidden proof-escape scan on touched files\n\nAuthored by @pirapira; implemented by Codex.