### PR TITLE
feat(dispatch): entry-address 3-step Hoare triple

### DIFF
--- a/EvmAsm/Evm64.lean
+++ b/EvmAsm/Evm64.lean
@@ -99,6 +99,7 @@ import EvmAsm.Evm64.StorageArgs
 -- Opcode dispatch surface (#106)
 import EvmAsm.Evm64.Dispatch
 import EvmAsm.Evm64.Dispatch.Program
+import EvmAsm.Evm64.Dispatch.EntrySpec
 import EvmAsm.Evm64.JumpTable
 import EvmAsm.Evm64.ExecutableSpecOpcodeBridge
 import EvmAsm.Evm64.HandlerTable

--- a/EvmAsm/Evm64/Dispatch/EntrySpec.lean
+++ b/EvmAsm/Evm64/Dispatch/EntrySpec.lean
@@ -1,0 +1,91 @@
+/-
+  EvmAsm.Evm64.Dispatch.EntrySpec
+
+  Slice 3b of GH #106 (parent `evm-asm-77w8s`, this slice
+  `evm-asm-96efo`).  Hoare triple for the first three instructions of
+  `evm_dispatch`:
+
+      LBU  rOp   rOpPtr opcodeLbuOff   -- opcode byte ← (rOpPtr)[0]
+      SLLI rOp   rOp    entryShiftAmt  -- opcode_byte * 8
+      ADD  rOp   rOp    rTable         -- table_base + 8 * opcode_byte
+
+  After this block, `rOp` holds the absolute byte address of the
+  jump-table entry (`tableBase + (opcodeByte <<< 3)`); `rOpPtr` and
+  `rTable` are unchanged, and the source dword carrying the opcode
+  byte is preserved.
+
+  This is a structural sub-step toward `dispatch_spec` (slice 3,
+  beads `evm-asm-afkny`).  Splitting out the entry-address chunk lets
+  the eventual `dispatch_spec` proof handle the table-entry `LD` and
+  the `JALR` separately, with the `dispatchTableIs` layout split
+  (`dispatchTableIs_split`) framing the table cell into the LD step.
+
+  Authored by @pirapira; implemented by Hermes-bot (evm-hermes).
+-/
+
+import EvmAsm.Evm64.Dispatch.Program
+import EvmAsm.Rv64.SyscallSpecs
+import EvmAsm.Rv64.Tactics.RunBlock
+import EvmAsm.Rv64.Tactics.XSimp
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+namespace Dispatch
+
+open EvmAsm.Rv64
+
+/-- CodeReq for the dispatch entry-address block: the LBU/SLLI/ADD
+    triple at addresses `base`, `base + 4`, `base + 8`.  Pulled out so
+    callers and `dispatch_spec` can refer to the code requirement
+    symbolically. -/
+def entryAddrCode (base : Word) : CodeReq :=
+  (CodeReq.singleton base (.LBU rOp rOpPtr opcodeLbuOff)).union
+    ((CodeReq.singleton (base + 4) (.SLLI rOp rOp entryShiftAmt)).union
+     (CodeReq.singleton (base + 8) (.ADD rOp rOp rTable)))
+
+/-- Three-step entry-address spec for `evm_dispatch`.
+
+    Starting from the dispatch entry frame (`rOpPtr` points at the
+    next opcode byte, `rTable` holds the jump-table base, `rOp` is a
+    scratch), the LBU+SLLI+ADD prefix:
+
+    * loads the opcode byte from `(pcAddr)` into `rOp` (zero-extended
+      to 64 bits);
+    * shifts it left by 3 (so the value becomes `8 * opcodeByte`);
+    * adds the table base, leaving `rOp` holding
+      `(opcodeByte <<< 3) + tableBase`, the address of the
+      corresponding jump-table entry.
+
+    The dword containing the opcode byte (`dwordAddr ↦ₘ wordVal`) is
+    preserved, as are `rOpPtr` and `rTable`.  Distinctness assumptions
+    cover the registers used by all three instructions.  No
+    `maxHeartbeats`/`maxRecDepth` overrides; the proof is a flat
+    `runBlock` of the three leaf specs. -/
+theorem evm_dispatch_entry_addr_spec_within
+    (base pcAddr tableBase rOpInit wordVal dwordAddr : Word)
+    (h_align : alignToDword (pcAddr + signExtend12 opcodeLbuOff) = dwordAddr)
+    (h_valid : isValidByteAccess (pcAddr + signExtend12 opcodeLbuOff) = true) :
+    let opcodeByte :=
+      (extractByte wordVal
+        (byteOffset (pcAddr + signExtend12 opcodeLbuOff))).zeroExtend 64
+    cpsTripleWithin 3 base (base + 12) (entryAddrCode base)
+      ((rOpPtr  ↦ᵣ pcAddr) ** (rTable ↦ᵣ tableBase) **
+       (rOp    ↦ᵣ rOpInit) ** (dwordAddr ↦ₘ wordVal))
+      ((rOpPtr  ↦ᵣ pcAddr) ** (rTable ↦ᵣ tableBase) **
+       (rOp    ↦ᵣ ((opcodeByte <<< (entryShiftAmt.toNat)) + tableBase)) **
+       (dwordAddr ↦ₘ wordVal)) := by
+  intro opcodeByte
+  -- Leaf specs:
+  have L := lbu_spec_gen_within rOp rOpPtr pcAddr rOpInit opcodeLbuOff base
+              dwordAddr wordVal (by decide) h_align h_valid
+  have I := slli_spec_gen_same_within rOp opcodeByte entryShiftAmt (base + 4)
+              (by decide)
+  have A := add_spec_gen_rd_eq_rs1_within rOp rTable
+              (opcodeByte <<< (entryShiftAmt.toNat)) tableBase (base + 8)
+              (by decide)
+  runBlock L I A
+
+end Dispatch
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

Adds the **3-step entry-address Hoare triple** for the `evm_dispatch` jump-table dispatch sequence (GH #106), splitting it out of the larger 5-step `dispatch_spec` proof (slice 3, beads `evm-asm-afkny`) where prior runBlock attempts struggled with frame inference around `dispatchTableIs.rest`.

The first three instructions of `evm_dispatch`:

```
LBU  rOp   rOpPtr opcodeLbuOff   -- opcode byte ← (rOpPtr)[0]
SLLI rOp   rOp    entryShiftAmt  -- opcode_byte * 8
ADD  rOp   rOp    rTable         -- table_base + 8 * opcode_byte
```

land `rOp` at the absolute byte address of the corresponding jump-table entry (`tableBase + (opcodeByte <<< 3)`). After this, the LD step in the eventual `dispatch_spec` only needs the entry cell — `dispatchTableIs_split` peels exactly that cell out of the table layout.

## Changes

- **New** `EvmAsm/Evm64/Dispatch/EntrySpec.lean`
  - `entryAddrCode (base : Word) : CodeReq` — code requirement for the LBU/SLLI/ADD triple.
  - `evm_dispatch_entry_addr_spec_within` — flat `runBlock` of the three leaf specs (`lbu_spec_gen_within`, `slli_spec_gen_same_within`, `add_spec_gen_rd_eq_rs1_within`).
- **Wire-in** `EvmAsm/Evm64.lean` imports the new module.
- No `set_option maxHeartbeats`/`maxRecDepth`. No new `sorry`. `lake build` clean (1653 jobs).

## Refs

- GH #106 — RV64 jump-table dispatch
- Beads `evm-asm-96efo` (this slice), parent `evm-asm-77w8s`, blocks slice 3 `evm-asm-afkny`.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).
