### PR TITLE
feat(jumptable): add HandlerTable.dispatchByte invalid-default

### DIFF
--- a/EvmAsm/Evm64.lean
+++ b/EvmAsm/Evm64.lean
@@ -102,6 +102,7 @@ import EvmAsm.Evm64.Dispatch.Program
 import EvmAsm.Evm64.JumpTable
 import EvmAsm.Evm64.ExecutableSpecOpcodeBridge
 import EvmAsm.Evm64.HandlerTable
+import EvmAsm.Evm64.HandlerTableByte
 import EvmAsm.Evm64.HandlerTableCompose
 import EvmAsm.Evm64.StackHandlers
 import EvmAsm.Evm64.ControlHandlers

--- a/EvmAsm/Evm64/HandlerTableByte.lean
+++ b/EvmAsm/Evm64/HandlerTableByte.lean
@@ -1,0 +1,80 @@
+/-
+  EvmAsm.Evm64.HandlerTableByte
+
+  Byte-level (raw 0..255) dispatch surface for `HandlerTable`, sitting
+  on top of `EvmOpcode.decodeByte?` and threading undecoded opcode
+  bytes through to the INVALID/error step on `EvmState`.
+
+  This is layer (b) of GH #106 slice 4 (beads `evm-asm-3ho93`): for any
+  opcode byte with `EvmOpcode.decodeByte? = none`, dispatching through
+  the byte surface must drive the EVM state into the error status, so
+  that the future RV64 dispatch program (slice 3, `evm-asm-afkny`)
+  composed with the JALR-to-invalidHandler default jump (slice 1's
+  `dispatchTableIs` × layer (a)'s `jumpTableOfOpcodes`) lands in a
+  well-defined invalid state.
+
+  Layer (a) — the `Fin 256 → Word` table with `invalidHandler` default —
+  already lives in `EvmAsm/Evm64/JumpTable.lean` as `jumpTableOfOpcodes`
+  with the byte-level `_decode_none` / `_decode_some` projections. This
+  file is the matching semantic surface on `HandlerTable`.
+
+  Authored by @pirapira; implemented by Hermes-bot (evm-hermes).
+-/
+
+import EvmAsm.Evm64.HandlerTable
+import EvmAsm.Evm64.Dispatch
+import EvmAsm.Evm64.Termination
+
+namespace EvmAsm.Evm64
+namespace HandlerTable
+
+/-- Byte-level dispatch: decode the raw opcode byte, dispatch the
+    resulting `EvmOpcode` through `table`, and on undecoded bytes
+    fall through to the INVALID/error step on `EvmState`.
+
+    Distinctive token: `HandlerTable.dispatchByte #106-slice4`. -/
+def dispatchByte (table : HandlerTable) (b : Fin 256)
+    (state : EvmState) : EvmState :=
+  match EvmOpcode.decodeByte? b.val with
+  | some opcode => HandlerTable.dispatchOpcode table opcode state
+  | none => state.invalid
+
+@[simp] theorem dispatchByte_decoded
+    (table : HandlerTable) (b : Fin 256) (opcode : EvmOpcode)
+    (state : EvmState)
+    (h_decode : EvmOpcode.decodeByte? b.val = some opcode) :
+    dispatchByte table b state =
+      HandlerTable.dispatchOpcode table opcode state := by
+  simp [dispatchByte, h_decode]
+
+@[simp] theorem dispatchByte_undecoded
+    (table : HandlerTable) (b : Fin 256) (state : EvmState)
+    (h_decode : EvmOpcode.decodeByte? b.val = none) :
+    dispatchByte table b state = state.invalid := by
+  simp [dispatchByte, h_decode]
+
+theorem dispatchByte_undecoded_status
+    (table : HandlerTable) (b : Fin 256) (state : EvmState)
+    (h_decode : EvmOpcode.decodeByte? b.val = none) :
+    (dispatchByte table b state).status = .error := by
+  rw [dispatchByte_undecoded table b state h_decode]
+  exact EvmState.invalid_status state
+
+/-- Empty handler table dispatches every byte to the INVALID step. -/
+@[simp] theorem dispatchByte_empty (b : Fin 256) (state : EvmState) :
+    dispatchByte HandlerTable.empty b state = state.invalid := by
+  unfold dispatchByte
+  cases h : EvmOpcode.decodeByte? b.val with
+  | none => rfl
+  | some opcode =>
+    simp [HandlerTable.dispatchOpcode, HandlerTable.dispatchOpcode?,
+      HandlerTable.empty]
+
+/-- Status after empty-table byte dispatch is always `.error`. -/
+theorem dispatchByte_empty_status (b : Fin 256) (state : EvmState) :
+    (dispatchByte HandlerTable.empty b state).status = .error := by
+  rw [dispatchByte_empty b state]
+  exact EvmState.invalid_status state
+
+end HandlerTable
+end EvmAsm.Evm64


### PR DESCRIPTION
Layer (b) of GH #106 slice 4 (beads `evm-asm-3ho93`, parent `evm-asm-77w8s`).

Adds a byte-level dispatch surface `HandlerTable.dispatchByte` that decodes a raw opcode byte via `EvmOpcode.decodeByte?` and dispatches through the partial handler table, falling back to the INVALID/error step on `EvmState` for any byte with no decoded opcode. Companion projection lemmas:

- `dispatchByte_decoded` / `dispatchByte_undecoded`  (definitional)
- `dispatchByte_undecoded_status` : `.error`
- `dispatchByte_empty` / `dispatchByte_empty_status`

Layer (a) — the matching `Fin 256 → Word` table with the `invalidHandler` default address — already shipped in `EvmAsm.Evm64.JumpTable` as `jumpTableOfOpcodes` with byte-level `_decode_none` / `_decode_some` projections (PR #2719). Together they give the future RV64 `dispatch_spec` proof a clean closed pair: at the layout level the JALR target resolves to `invalidHandler` when decode fails, and at the handler level the dispatched step ends in `.error`. Wiring into the top-level interpreter loop is a follow-up slice once the RV64 `dispatch_spec` (slice 3, `evm-asm-afkny`) lands.

No new tactics, no edits to existing files beyond the umbrella import. Local verification:

- `lake build EvmAsm.Evm64.HandlerTableByte` ✔
- `lake build` ✔ (1653 jobs, 0 errors, 0 warnings)
- 0 `sorry` / `admit` / `maxHeartbeats` / `maxRecDepth` in the new file
- `scripts/check-file-size.sh --report` clean

Refs GH #106. Distinctive token: `dispatch-invalid-default-slice4-#106`.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).