### PR TITLE
chore(rlp): swap ReadLength → Decode import in LongForm

### DIFF
--- a/EvmAsm/EL/RLP/LongForm.lean
+++ b/EvmAsm/EL/RLP/LongForm.lean
@@ -3,7 +3,7 @@
 
   Branch lemmas for long-form byte-string and list decoding.
 -/
-import EvmAsm.EL.RLP.ReadLength
+import EvmAsm.EL.RLP.Decode
 
 namespace EvmAsm.EL.RLP
 


### PR DESCRIPTION
Shake suggestion: `EvmAsm/EL/RLP/LongForm.lean` only uses `readLength`, `takeBytes`, `decodeAux`, `decodeItems`, all defined in `EvmAsm.EL.RLP.Decode`. None of the lemmas in `EvmAsm.EL.RLP.ReadLength` are referenced from this file.

Drop the indirect `import EvmAsm.EL.RLP.ReadLength` in favor of the direct `import EvmAsm.EL.RLP.Decode` (which `ReadLength` already imports transitively).

Verification:
- `lake build` green.
- `lake exe shake EvmAsm` no longer prints the `LongForm` suggestion.

Refs: #1045 (import hygiene sweep). Beads: evm-asm-ndbja.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).