### PR TITLE
feat(push): add push handler table

### DIFF
--- a/EvmAsm/Evm64.lean
+++ b/EvmAsm/Evm64.lean
@@ -104,6 +104,7 @@ import EvmAsm.Evm64.ExecutableSpecOpcodeBridge
 import EvmAsm.Evm64.HandlerTable
 import EvmAsm.Evm64.HandlerTableCompose
 import EvmAsm.Evm64.StackHandlers
+import EvmAsm.Evm64.PushHandlers
 import EvmAsm.Evm64.ControlHandlers
 import EvmAsm.Evm64.TerminatingHandlers
 import EvmAsm.Evm64.ShiftHandlers

--- a/EvmAsm/Evm64/PushHandlers.lean
+++ b/EvmAsm/Evm64/PushHandlers.lean
@@ -1,0 +1,89 @@
+/-
+  EvmAsm.Evm64.PushHandlers
+
+  Pure PUSH1-32 handler entries for the interpreter handler table
+  (GH #101 / GH #107).
+-/
+
+import EvmAsm.Evm64.HandlerTable
+import EvmAsm.Evm64.Push.ExecEffect
+
+namespace EvmAsm.Evm64
+
+namespace PushHandlers
+
+/-- PUSHn handler over the abstract interpreter state. The handler uses the
+    executable PUSH immediate bridge and advances the EVM PC by 1+n. -/
+def pushHandler (n : Nat) : OpcodeHandler :=
+  fun state =>
+    (state.withPc
+      (PushExecEffect.pcAfterPushFromCode state.code state.pc n)).withStack
+      (PushExecEffect.stackAfterPush state.code state.pc n state.stack)
+
+/-- Lookup surface for generic PUSH1-32 handlers. Invalid widths stay
+    unimplemented rather than installing nonsensical handlers. -/
+def pushHandler? : EvmOpcode → Option OpcodeHandler
+  | .PUSH n =>
+      if EvmOpcode.validPushWidth n then
+        some (pushHandler n)
+      else
+        none
+  | _ => none
+
+/-- Handler table containing the generic PUSH1-32 entries.
+    Distinctive token: PushHandlers.pushHandlerTable #101 #107. -/
+def pushHandlerTable : HandlerTable :=
+  pushHandler?
+
+@[simp] theorem pushHandlerTable_eq :
+    pushHandlerTable = pushHandler? := rfl
+
+theorem pushHandler?_PUSH_of_valid {n : Nat}
+    (h_valid : EvmOpcode.validPushWidth n = true) :
+    pushHandler? (.PUSH n) = some (pushHandler n) := by
+  simp [pushHandler?, h_valid]
+
+theorem pushHandler?_PUSH_of_invalid {n : Nat}
+    (h_valid : EvmOpcode.validPushWidth n = false) :
+    pushHandler? (.PUSH n) = none := by
+  simp [pushHandler?, h_valid]
+
+@[simp] theorem pushHandler_stack (n : Nat) (state : EvmState) :
+    (pushHandler n state).stack =
+      PushExecEffect.stackAfterPush state.code state.pc n state.stack := rfl
+
+@[simp] theorem pushHandler_pc (n : Nat) (state : EvmState) :
+    (pushHandler n state).pc =
+      PushExecEffect.pcAfterPushFromCode state.code state.pc n := rfl
+
+@[simp] theorem pushHandler_status (n : Nat) (state : EvmState) :
+    (pushHandler n state).status = state.status := rfl
+
+theorem pushHandler_stack_eq
+    (n : Nat) (state : EvmState) :
+    (pushHandler n state).stack =
+      PushExecEffect.pushedWordFromCode state.code state.pc n :: state.stack := rfl
+
+theorem pushHandler_pc_eq
+    (n : Nat) (state : EvmState) :
+    (pushHandler n state).pc = state.pc + 1 + n := rfl
+
+theorem dispatchOpcode?_pushHandlerTable_PUSH_of_valid
+    {n : Nat} (h_valid : EvmOpcode.validPushWidth n = true)
+    (state : EvmState) :
+    HandlerTable.dispatchOpcode? pushHandlerTable (.PUSH n) state =
+      some (pushHandler n state) := by
+  exact HandlerTable.dispatchOpcode?_some
+    (pushHandler?_PUSH_of_valid h_valid) state
+
+theorem dispatchOpcode_pushHandlerTable_PUSH_of_valid
+    {n : Nat} (h_valid : EvmOpcode.validPushWidth n = true)
+    (state : EvmState) :
+    HandlerTable.dispatchOpcode pushHandlerTable (.PUSH n) state =
+      pushHandler n state := by
+  exact HandlerTable.dispatchOpcode_some
+    (pushHandler?_PUSH_of_valid h_valid) state
+
+end PushHandlers
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/SupportedHandlers.lean
+++ b/EvmAsm/Evm64/SupportedHandlers.lean
@@ -8,6 +8,7 @@
 import EvmAsm.Evm64.HandlerTableCompose
 import EvmAsm.Evm64.TerminatingHandlers
 import EvmAsm.Evm64.StackHandlers
+import EvmAsm.Evm64.PushHandlers
 import EvmAsm.Evm64.ControlHandlers
 import EvmAsm.Evm64.EnvHandlers
 import EvmAsm.Evm64.ArithmeticHandlers
@@ -28,6 +29,7 @@ Distinctive token: SupportedHandlers.supportedHandlerTable #107.
 def supportedHandlerTable : HandlerTable :=
   HandlerTable.orElse TerminatingHandlers.terminatingHandlerTable <|
   HandlerTable.orElse StackHandlers.stackHandlerTable <|
+  HandlerTable.orElse PushHandlers.pushHandlerTable <|
   HandlerTable.orElse ControlHandlers.controlHandlerTable <|
   HandlerTable.orElse EnvHandlers.simpleEnvHandlerTable <|
   HandlerTable.orElse ArithmeticHandlers.arithmeticHandlerTable <|
@@ -58,7 +60,21 @@ theorem lookup_of_control
     (h_terminating :
       TerminatingHandlers.terminatingHandlerTable opcode = none)
     (h_stack : StackHandlers.stackHandlerTable opcode = none)
+    (h_push : PushHandlers.pushHandlerTable opcode = none)
     (h_lookup : ControlHandlers.controlHandlerTable opcode = some handler) :
+    supportedHandlerTable opcode = some handler := by
+  unfold supportedHandlerTable
+  rw [HandlerTable.orElse_left_none h_terminating]
+  rw [HandlerTable.orElse_left_none h_stack]
+  rw [HandlerTable.orElse_left_none h_push]
+  exact HandlerTable.orElse_left_some h_lookup
+
+theorem lookup_of_push
+    {opcode : EvmOpcode} {handler : OpcodeHandler}
+    (h_terminating :
+      TerminatingHandlers.terminatingHandlerTable opcode = none)
+    (h_stack : StackHandlers.stackHandlerTable opcode = none)
+    (h_lookup : PushHandlers.pushHandlerTable opcode = some handler) :
     supportedHandlerTable opcode = some handler := by
   unfold supportedHandlerTable
   rw [HandlerTable.orElse_left_none h_terminating]
@@ -70,12 +86,14 @@ theorem lookup_of_env
     (h_terminating :
       TerminatingHandlers.terminatingHandlerTable opcode = none)
     (h_stack : StackHandlers.stackHandlerTable opcode = none)
+    (h_push : PushHandlers.pushHandlerTable opcode = none)
     (h_control : ControlHandlers.controlHandlerTable opcode = none)
     (h_lookup : EnvHandlers.simpleEnvHandlerTable opcode = some handler) :
     supportedHandlerTable opcode = some handler := by
   unfold supportedHandlerTable
   rw [HandlerTable.orElse_left_none h_terminating]
   rw [HandlerTable.orElse_left_none h_stack]
+  rw [HandlerTable.orElse_left_none h_push]
   rw [HandlerTable.orElse_left_none h_control]
   exact HandlerTable.orElse_left_some h_lookup
 
@@ -84,6 +102,7 @@ theorem lookup_of_arithmetic
     (h_terminating :
       TerminatingHandlers.terminatingHandlerTable opcode = none)
     (h_stack : StackHandlers.stackHandlerTable opcode = none)
+    (h_push : PushHandlers.pushHandlerTable opcode = none)
     (h_control : ControlHandlers.controlHandlerTable opcode = none)
     (h_env : EnvHandlers.simpleEnvHandlerTable opcode = none)
     (h_lookup : ArithmeticHandlers.arithmeticHandlerTable opcode = some handler) :
@@ -91,6 +110,7 @@ theorem lookup_of_arithmetic
   unfold supportedHandlerTable
   rw [HandlerTable.orElse_left_none h_terminating]
   rw [HandlerTable.orElse_left_none h_stack]
+  rw [HandlerTable.orElse_left_none h_push]
   rw [HandlerTable.orElse_left_none h_control]
   rw [HandlerTable.orElse_left_none h_env]
   exact HandlerTable.orElse_left_some h_lookup
@@ -100,6 +120,7 @@ theorem lookup_of_bitwise
     (h_terminating :
       TerminatingHandlers.terminatingHandlerTable opcode = none)
     (h_stack : StackHandlers.stackHandlerTable opcode = none)
+    (h_push : PushHandlers.pushHandlerTable opcode = none)
     (h_control : ControlHandlers.controlHandlerTable opcode = none)
     (h_env : EnvHandlers.simpleEnvHandlerTable opcode = none)
     (h_arithmetic : ArithmeticHandlers.arithmeticHandlerTable opcode = none)
@@ -108,6 +129,7 @@ theorem lookup_of_bitwise
   unfold supportedHandlerTable
   rw [HandlerTable.orElse_left_none h_terminating]
   rw [HandlerTable.orElse_left_none h_stack]
+  rw [HandlerTable.orElse_left_none h_push]
   rw [HandlerTable.orElse_left_none h_control]
   rw [HandlerTable.orElse_left_none h_env]
   rw [HandlerTable.orElse_left_none h_arithmetic]
@@ -118,6 +140,7 @@ theorem lookup_of_comparison
     (h_terminating :
       TerminatingHandlers.terminatingHandlerTable opcode = none)
     (h_stack : StackHandlers.stackHandlerTable opcode = none)
+    (h_push : PushHandlers.pushHandlerTable opcode = none)
     (h_control : ControlHandlers.controlHandlerTable opcode = none)
     (h_env : EnvHandlers.simpleEnvHandlerTable opcode = none)
     (h_arithmetic : ArithmeticHandlers.arithmeticHandlerTable opcode = none)
@@ -127,6 +150,7 @@ theorem lookup_of_comparison
   unfold supportedHandlerTable
   rw [HandlerTable.orElse_left_none h_terminating]
   rw [HandlerTable.orElse_left_none h_stack]
+  rw [HandlerTable.orElse_left_none h_push]
   rw [HandlerTable.orElse_left_none h_control]
   rw [HandlerTable.orElse_left_none h_env]
   rw [HandlerTable.orElse_left_none h_arithmetic]
@@ -138,6 +162,7 @@ theorem lookup_of_shift
     (h_terminating :
       TerminatingHandlers.terminatingHandlerTable opcode = none)
     (h_stack : StackHandlers.stackHandlerTable opcode = none)
+    (h_push : PushHandlers.pushHandlerTable opcode = none)
     (h_control : ControlHandlers.controlHandlerTable opcode = none)
     (h_env : EnvHandlers.simpleEnvHandlerTable opcode = none)
     (h_arithmetic : ArithmeticHandlers.arithmeticHandlerTable opcode = none)
@@ -148,6 +173,7 @@ theorem lookup_of_shift
   unfold supportedHandlerTable
   rw [HandlerTable.orElse_left_none h_terminating]
   rw [HandlerTable.orElse_left_none h_stack]
+  rw [HandlerTable.orElse_left_none h_push]
   rw [HandlerTable.orElse_left_none h_control]
   rw [HandlerTable.orElse_left_none h_env]
   rw [HandlerTable.orElse_left_none h_arithmetic]
@@ -182,6 +208,15 @@ theorem dispatchOpcode_of_lookup
   exact lookup_of_stack
     (by simp [TerminatingHandlers.terminatingHandlerTable, HandlerTable.setHandler])
     StackHandlers.stackHandlerTable_PUSH0
+
+theorem supportedHandlerTable_PUSH_of_valid
+    {n : Nat} (h_valid : EvmOpcode.validPushWidth n = true) :
+    supportedHandlerTable (.PUSH n) =
+      some (PushHandlers.pushHandler n) := by
+  exact lookup_of_push
+    (by simp [TerminatingHandlers.terminatingHandlerTable, HandlerTable.setHandler])
+    (by simp [StackHandlers.stackHandlerTable, HandlerTable.setHandler])
+    (PushHandlers.pushHandler?_PUSH_of_valid h_valid)
 
 end SupportedHandlers
 


### PR DESCRIPTION
Stacked on #2724.

Adds EvmAsm.Evm64.PushHandlers with a generic PUSH1..32 pure interpreter handler over EvmState.code/pc/stack. The handler reuses PushExecEffect.pushedWordFromCode and pcAfterPushFromCode, exposes pushHandlerTable, and adds lookup/dispatch/projection lemmas. The stacked diff also wires the family into SupportedHandlers.supportedHandlerTable.

Local verification:
- lake build EvmAsm.Evm64.PushHandlers
- lake build EvmAsm.Evm64.SupportedHandlers
- git diff --check
- scripts/check-file-size.sh --report
- forbidden proof-option/sorry scan on touched files
- lake build

Refs evm-asm-ykiz5, GH #101, and GH #107.

Authored by @pirapira; implemented by Codex.