### PR TITLE
chore(noshake): flag Rv64/Tactics/SymStep Execution false-positive

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -75,6 +75,8 @@
   "EvmAsm.Evm64.MulMod.AddrNormAttr": ["Lean.Meta.Tactic.Simp.RegisterCommand"],
   "EvmAsm.Rv64.Tactics.XCancelStruct":
   ["EvmAsm.Rv64.SepLogic"],
+  "EvmAsm.Rv64.Tactics.SymStep":
+  ["EvmAsm.Rv64.Execution"],
  "EvmAsm.Evm64.Basic":
   ["Std.Tactic.BVDecide", "EvmAsm.Rv64.Basic"],
  "EvmAsm.Evm64.CodeRegion":


### PR DESCRIPTION
`lake exe shake EvmAsm` suggests dropping `EvmAsm.Rv64.Execution` from `EvmAsm/Rv64/Tactics/SymStep.lean`. Verified false positive: the `sym_step` macro and the smoke-test examples reference `MachineState`, `step`, `step_non_ecall_non_mem`, `execInstrBr`, and `Instr.isMemAccess` without qualification, so the import must remain. Removing it produces errors at lines 117/121/124.

Adds a `noshake.json` entry to silence the suggestion.

Refs evm-asm-90fqu, parent #1045 / evm-asm-9tq.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).