### PR TITLE
chore(shake): move Stack import from DivMod/Program to ModBridgeAssemble

### DIFF
--- a/EvmAsm/Evm64/DivMod/Program.lean
+++ b/EvmAsm/Evm64/DivMod/Program.lean
@@ -39,7 +39,6 @@
 -/
 
 import EvmAsm.Rv64.Program
-import EvmAsm.Evm64.Stack
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/EvmWordArith/ModBridgeAssemble.lean
+++ b/EvmAsm/Evm64/EvmWordArith/ModBridgeAssemble.lean
@@ -24,6 +24,7 @@
 -/
 
 import EvmAsm.Evm64.EvmWordArith.ModBridgeUtop
+import EvmAsm.Evm64.Stack
 
 namespace EvmAsm.Evm64
 


### PR DESCRIPTION
Shake reports that `EvmAsm.Evm64.DivMod.Program.lean` does not use the `EvmAsm.Evm64.Stack` import directly (no `Stack.*` references), and that the actual consumer is `EvmAsm.Evm64.EvmWordArith.ModBridgeAssemble` (without the import, `evmWordIs_sp32_limbs_eq` fails to elaborate). Move the import to its consumer.

`lake build` green locally.

Refs GH #1045 (import hygiene sweep via `lake exe shake`).
Beads: evm-asm-hh4lu (parent: evm-asm-6qj).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).