### PR TITLE
feat(handlers): bridge supported byte dispatch

### DIFF
--- a/EvmAsm/Evm64.lean
+++ b/EvmAsm/Evm64.lean
@@ -116,6 +116,7 @@ import EvmAsm.Evm64.ComparisonHandlers
 import EvmAsm.Evm64.BitwiseHandlers
 import EvmAsm.Evm64.ArithmeticHandlers
 import EvmAsm.Evm64.SupportedHandlers
+import EvmAsm.Evm64.SupportedHandlerByte
 import EvmAsm.Evm64.InterpreterFetchProgram
 import EvmAsm.Evm64.HandlerLoopBridge
 import EvmAsm.Evm64.TerminatingLoopBridge

--- a/EvmAsm/Evm64/SupportedHandlerByte.lean
+++ b/EvmAsm/Evm64/SupportedHandlerByte.lean
@@ -1,0 +1,53 @@
+/-
+  EvmAsm.Evm64.SupportedHandlerByte
+
+  Raw-byte dispatch bridge for the combined supported interpreter handler
+  table (GH #106 / GH #107).
+-/
+
+import EvmAsm.Evm64.HandlerTableByte
+import EvmAsm.Evm64.SupportedHandlers
+
+namespace EvmAsm.Evm64
+namespace SupportedHandlerByte
+
+theorem dispatchByte_supported_of_lookup
+    {b : Fin 256} {opcode : EvmOpcode} {handler : OpcodeHandler}
+    (h_decode : EvmOpcode.decodeByte? b.val = some opcode)
+    (h_lookup :
+      SupportedHandlers.supportedHandlerTable opcode = some handler)
+    (state : EvmState) :
+    HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable b state =
+      handler state := by
+  rw [HandlerTable.dispatchByte_decoded
+    SupportedHandlers.supportedHandlerTable b opcode state h_decode]
+  exact SupportedHandlers.dispatchOpcode_of_lookup h_lookup state
+
+theorem dispatchByte_supported_of_decode
+    {b : Fin 256} {opcode : EvmOpcode}
+    (h_decode : EvmOpcode.decodeByte? b.val = some opcode)
+    (state : EvmState) :
+    HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable b state =
+      HandlerTable.dispatchOpcode SupportedHandlers.supportedHandlerTable
+        opcode state := by
+  exact HandlerTable.dispatchByte_decoded
+    SupportedHandlers.supportedHandlerTable b opcode state h_decode
+
+theorem dispatchByte_supported_undecoded
+    {b : Fin 256} (h_decode : EvmOpcode.decodeByte? b.val = none)
+    (state : EvmState) :
+    HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable b state =
+      state.invalid := by
+  exact HandlerTable.dispatchByte_undecoded
+    SupportedHandlers.supportedHandlerTable b state h_decode
+
+theorem dispatchByte_supported_undecoded_status
+    {b : Fin 256} (h_decode : EvmOpcode.decodeByte? b.val = none)
+    (state : EvmState) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable b state).status =
+      .error := by
+  exact HandlerTable.dispatchByte_undecoded_status
+    SupportedHandlers.supportedHandlerTable b state h_decode
+
+end SupportedHandlerByte
+end EvmAsm.Evm64


### PR DESCRIPTION
Stacked on #2726.

Adds EvmAsm.Evm64.SupportedHandlerByte, a raw-byte dispatch bridge for SupportedHandlers.supportedHandlerTable:
- decoded byte + supported table lookup reduces dispatchByte to the selected handler
- decoded byte reduces dispatchByte to supported dispatchOpcode
- undecoded byte returns invalid with error status

Refs evm-asm-jywi1, GH #106, GH #107.

Verification:
- lake build EvmAsm.Evm64.SupportedHandlerByte
- lake build
- git diff --check
- scripts/check-file-size.sh --report
- forbidden proof-option/sorry scan on touched files

Authored by @pirapira; implemented by Codex.