### PR TITLE
chore(shake): noshake EvmAsm.Evm64.Dispatch.EntrySpec false-positives

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -89,6 +89,8 @@
   ["EvmAsm.Rv64.Basic", "Std.Tactic.BVDecide"],
  "EvmAsm.Evm64.SpAddr":
   ["EvmAsm.Rv64.Tactics.SeqFrame"],
+  "EvmAsm.Evm64.Dispatch.EntrySpec":
+  ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.RunBlock", "EvmAsm.Rv64.Tactics.XSimp"],
   "EvmAsm.Evm64.Stack":
   ["EvmAsm.Evm64.SpAddr"],
   "EvmAsm.Evm64.MSize.Spec":


### PR DESCRIPTION
Adds a `noshake.json` entry for `EvmAsm.Evm64.Dispatch.EntrySpec`.

Shake suggested removing `EvmAsm.Rv64.SyscallSpecs`, `EvmAsm.Rv64.Tactics.RunBlock`, and `EvmAsm.Rv64.Tactics.XSimp` (and adding `EvmAsm.Rv64.CPSSpec`), but the proof of `evm_dispatch_entry_addr_spec_within` uses:

- `runBlock` (from `Tactics.RunBlock`) to chain three leaf specs;
- `@[spec_gen_rv64]` leaf specs `lbu_spec_gen_within`, `slli_spec_gen_same_within`, `add_spec_gen_rd_eq_rs1_within` (from `SyscallSpecs`);
- normalisation produced by `runBlock` that depends on `Tactics.XSimp`.

Shake doesn't track tactic registries or `@[spec_gen_*]` attributes, so this is a textbook false positive. After this entry, `lake exe shake EvmAsm` no longer prints the suggestion. Build remains green.

Refs GH #1045 (parent `evm-asm-6qj`); closes `evm-asm-tgb66`.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).