### PR TITLE
feat(dispatch): prove tail-call block

### DIFF
--- a/EvmAsm/Evm64.lean
+++ b/EvmAsm/Evm64.lean
@@ -100,6 +100,7 @@ import EvmAsm.Evm64.StorageArgs
 import EvmAsm.Evm64.Dispatch
 import EvmAsm.Evm64.Dispatch.Program
 import EvmAsm.Evm64.Dispatch.EntrySpec
+import EvmAsm.Evm64.Dispatch.TailSpec
 import EvmAsm.Evm64.JumpTable
 import EvmAsm.Evm64.ExecutableSpecOpcodeBridge
 import EvmAsm.Evm64.HandlerTable

--- a/EvmAsm/Evm64/Dispatch/TailSpec.lean
+++ b/EvmAsm/Evm64/Dispatch/TailSpec.lean
@@ -1,0 +1,46 @@
+/-
+  EvmAsm.Evm64.Dispatch.TailSpec
+
+  LD/JALR tail-call sub-spec for the RV64 opcode dispatch sequence (GH #106).
+-/
+
+import EvmAsm.Evm64.Dispatch.Program
+import EvmAsm.Rv64.ControlFlow
+import EvmAsm.Rv64.SyscallSpecs
+import EvmAsm.Rv64.Tactics.RunBlock
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+namespace Dispatch
+
+open EvmAsm.Rv64
+
+/-- CodeReq for the dispatch tail block: `LD rOp rOp 0`, then
+    `JALR x0 rOp 0`. -/
+def tailCode (base : Word) : CodeReq :=
+  (CodeReq.singleton base (.LD rOp rOp handlerLdOff)).union
+    (CodeReq.singleton (base + 4) (.JALR .x0 rOp handlerJumpOff))
+
+/-- Final two-step tail of `evm_dispatch`.
+
+    Starting with `rOp` holding the selected jump-table entry address,
+    the tail loads the handler address from that cell and jumps to it
+    with `JALR x0`, preserving the table-entry memory cell. -/
+theorem evm_dispatch_tail_spec_within
+    (base entryAddr handlerAddr : Word) :
+    cpsTripleWithin 2 base
+      ((handlerAddr + signExtend12 handlerJumpOff) &&& ~~~1)
+      (tailCode base)
+      ((rOp ↦ᵣ entryAddr) **
+        ((entryAddr + signExtend12 handlerLdOff) ↦ₘ handlerAddr))
+      ((rOp ↦ᵣ handlerAddr) **
+        ((entryAddr + signExtend12 handlerLdOff) ↦ₘ handlerAddr)) := by
+  have L := ld_spec_gen_same_within rOp entryAddr handlerAddr
+    handlerLdOff base (by decide)
+  have J := jalr_x0_spec_gen_within rOp handlerAddr
+    handlerJumpOff (base + 4)
+  runBlock L J
+
+end Dispatch
+end EvmAsm.Evm64


### PR DESCRIPTION
Adds EvmAsm.Evm64.Dispatch.TailSpec for GH #106.

This proves the final two instructions of evm_dispatch after entry-address computation:
- LD rOp 0(rOp) loads the selected handler address from the jump-table entry cell
- JALR x0 rOp 0 tail-calls to the aligned handler address while preserving that memory cell

Refs evm-asm-1jz84, GH #106.

Verification:
- lake build EvmAsm.Evm64.Dispatch.TailSpec
- lake build
- git diff --check
- scripts/check-file-size.sh --report
- forbidden proof-option/sorry scan on touched files

Authored by @pirapira; implemented by Codex.