### PR TITLE
chore(shake): noshake Phase1E3LongStringOne false-positive

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -231,6 +231,7 @@
    "EvmAsm.Evm64.DivMod.Spec.N3ModBridge",
    "EvmAsm.Evm64.DivMod.N4StackSpecWithin"],
  "EvmAsm.Rv64.RLP.Phase2LongLoopTwo":   ["EvmAsm.Rv64.RLP.Phase2LongLoopOne"],
+ "EvmAsm.Rv64.RLP.Phase1E3LongStringOne": ["EvmAsm.Rv64.RLP.Phase1E3FullPath", "EvmAsm.Rv64.RLP.Phase2LongLoopOne"],
  "EvmAsm.Rv64.RLP.Phase2LongLoopThree": ["EvmAsm.Rv64.RLP.Phase2LongLoopTwo"],
  "EvmAsm.Rv64.RLP.Phase2LongLoopFour":  ["EvmAsm.Rv64.RLP.Phase2LongLoopThree"],
  "EvmAsm.Rv64.RLP.Phase2LongLoopFive":  ["EvmAsm.Rv64.RLP.Phase2LongLoopFour"],


### PR DESCRIPTION
shake suggested removing `EvmAsm.Rv64.RLP.Phase1E3FullPath` and `EvmAsm.Rv64.RLP.Phase2LongLoopOne` from `EvmAsm/Rv64/RLP/Phase1E3LongStringOne.lean` and adding three other modules. Verified false positive — removing them breaks the build:

- `rlp_phase1_e3_full_path_spec'_within` (from Phase1E3FullPath) is used at line 89.
- `rlp_phase2_long_loop_one_byte_spec_within` and `rlp_phase2_long_loop_one_byte_post_unfold` (from Phase2LongLoopOne) are used at lines 114 and 117.

Add a `noshake.json` entry to silence the suggestion. Local `lake build` is green and the file no longer appears in `lake exe shake EvmAsm` output.

Refs: bead evm-asm-ava3l, parent evm-asm-6qj, GH #1045.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).