### PR TITLE
feat(returndata): add returndatasize handler

### DIFF
--- a/EvmAsm/Evm64.lean
+++ b/EvmAsm/Evm64.lean
@@ -112,6 +112,7 @@ import EvmAsm.Evm64.TerminatingHandlers
 import EvmAsm.Evm64.DupSwapHandlers
 import EvmAsm.Evm64.ShiftHandlers
 import EvmAsm.Evm64.EnvHandlers
+import EvmAsm.Evm64.ReturnDataHandlers
 import EvmAsm.Evm64.ComparisonHandlers
 import EvmAsm.Evm64.BitwiseHandlers
 import EvmAsm.Evm64.ArithmeticHandlers

--- a/EvmAsm/Evm64/ReturnDataHandlers.lean
+++ b/EvmAsm/Evm64/ReturnDataHandlers.lean
@@ -1,0 +1,63 @@
+/-
+  EvmAsm.Evm64.ReturnDataHandlers
+
+  Pure RETURNDATASIZE handler-table entry for the interpreter handler layer
+  (GH #107).
+-/
+
+import EvmAsm.Evm64.HandlerTable
+
+namespace EvmAsm.Evm64
+
+namespace ReturnDataHandlers
+
+/-- EVM word pushed by RETURNDATASIZE for the current abstract state. -/
+def returnDataSizeWord (state : EvmState) : EvmWord :=
+  BitVec.ofNat 256 state.env.returnDataSize.toNat
+
+/-- RETURNDATASIZE pushes the current returndata buffer length in bytes. -/
+def returnDataSizeHandler : OpcodeHandler :=
+  fun state => state.withStack (returnDataSizeWord state :: state.stack)
+
+/-- Lookup just the returndata handler introduced in this slice. -/
+def returnDataHandler? : EvmOpcode → Option OpcodeHandler
+  | .RETURNDATASIZE => some returnDataSizeHandler
+  | _ => none
+
+/-- Handler table fragment containing the RETURNDATASIZE entry.
+    Distinctive token: ReturnDataHandlers.returnDataSizeHandlerTable #107. -/
+def returnDataSizeHandlerTable : HandlerTable :=
+  returnDataHandler?
+
+@[simp] theorem returnDataHandler?_RETURNDATASIZE :
+    returnDataHandler? .RETURNDATASIZE = some returnDataSizeHandler := rfl
+
+@[simp] theorem returnDataSizeHandler_stack (state : EvmState) :
+    (returnDataSizeHandler state).stack =
+      returnDataSizeWord state :: state.stack := rfl
+
+@[simp] theorem returnDataSizeHandler_status (state : EvmState) :
+    (returnDataSizeHandler state).status = state.status := rfl
+
+@[simp] theorem returnDataSizeHandler_env (state : EvmState) :
+    (returnDataSizeHandler state).env = state.env := rfl
+
+@[simp] theorem returnDataSizeHandlerTable_RETURNDATASIZE :
+    returnDataSizeHandlerTable .RETURNDATASIZE =
+      some returnDataSizeHandler := rfl
+
+@[simp] theorem dispatchOpcode?_returnDataSizeHandlerTable_RETURNDATASIZE
+    (state : EvmState) :
+    HandlerTable.dispatchOpcode? returnDataSizeHandlerTable .RETURNDATASIZE state =
+      some (returnDataSizeHandler state) := by
+  simp [HandlerTable.dispatchOpcode?]
+
+@[simp] theorem dispatchOpcode_returnDataSizeHandlerTable_RETURNDATASIZE
+    (state : EvmState) :
+    HandlerTable.dispatchOpcode returnDataSizeHandlerTable .RETURNDATASIZE state =
+      returnDataSizeHandler state := by
+  simp [HandlerTable.dispatchOpcode]
+
+end ReturnDataHandlers
+
+end EvmAsm.Evm64


### PR DESCRIPTION
Adds a pure RETURNDATASIZE handler-table fragment for GH #107.\n\nSummary:\n- add EvmAsm.Evm64.ReturnDataHandlers with returnDataSizeWord, returnDataSizeHandler, and returnDataSizeHandlerTable\n- prove lookup, dispatch, stack/status/env projection lemmas\n- wire the module into the Evm64 umbrella import\n\nLocal verification:\n- lake build EvmAsm.Evm64.ReturnDataHandlers\n- lake build\n- git diff --check\n- scripts/check-file-size.sh --report\n- forbidden proof-option/sorry scan on touched files\n\nBead: evm-asm-5ekb4\nRefs: #107\n\nAuthored by @pirapira; implemented by Codex.