### PR TITLE
feat(handlers): support returndatasize dispatch

### DIFF
--- a/EvmAsm/Evm64/SupportedHandlers.lean
+++ b/EvmAsm/Evm64/SupportedHandlers.lean
@@ -10,6 +10,7 @@ import EvmAsm.Evm64.TerminatingHandlers
 import EvmAsm.Evm64.StackHandlers
 import EvmAsm.Evm64.ControlHandlers
 import EvmAsm.Evm64.EnvHandlers
+import EvmAsm.Evm64.ReturnDataHandlers
 import EvmAsm.Evm64.ArithmeticHandlers
 import EvmAsm.Evm64.BitwiseHandlers
 import EvmAsm.Evm64.ComparisonHandlers
@@ -31,6 +32,7 @@ def supportedHandlerTable : HandlerTable :=
   HandlerTable.orElse StackHandlers.stackHandlerTable <|
   HandlerTable.orElse ControlHandlers.controlHandlerTable <|
   HandlerTable.orElse EnvHandlers.simpleEnvHandlerTable <|
+  HandlerTable.orElse ReturnDataHandlers.returnDataSizeHandlerTable <|
   HandlerTable.orElse ArithmeticHandlers.arithmeticHandlerTable <|
   HandlerTable.orElse BitwiseHandlers.bitwiseHandlerTable <|
   HandlerTable.orElse ComparisonHandlers.comparisonHandlerTable
@@ -88,7 +90,25 @@ theorem lookup_of_arithmetic
     (h_stack : StackHandlers.stackHandlerTable opcode = none)
     (h_control : ControlHandlers.controlHandlerTable opcode = none)
     (h_env : EnvHandlers.simpleEnvHandlerTable opcode = none)
+    (h_returnData : ReturnDataHandlers.returnDataSizeHandlerTable opcode = none)
     (h_lookup : ArithmeticHandlers.arithmeticHandlerTable opcode = some handler) :
+    supportedHandlerTable opcode = some handler := by
+  unfold supportedHandlerTable
+  rw [HandlerTable.orElse_left_none h_terminating]
+  rw [HandlerTable.orElse_left_none h_stack]
+  rw [HandlerTable.orElse_left_none h_control]
+  rw [HandlerTable.orElse_left_none h_env]
+  rw [HandlerTable.orElse_left_none h_returnData]
+  exact HandlerTable.orElse_left_some h_lookup
+
+theorem lookup_of_returnData
+    {opcode : EvmOpcode} {handler : OpcodeHandler}
+    (h_terminating :
+      TerminatingHandlers.terminatingHandlerTable opcode = none)
+    (h_stack : StackHandlers.stackHandlerTable opcode = none)
+    (h_control : ControlHandlers.controlHandlerTable opcode = none)
+    (h_env : EnvHandlers.simpleEnvHandlerTable opcode = none)
+    (h_lookup : ReturnDataHandlers.returnDataSizeHandlerTable opcode = some handler) :
     supportedHandlerTable opcode = some handler := by
   unfold supportedHandlerTable
   rw [HandlerTable.orElse_left_none h_terminating]
@@ -104,6 +124,7 @@ theorem lookup_of_bitwise
     (h_stack : StackHandlers.stackHandlerTable opcode = none)
     (h_control : ControlHandlers.controlHandlerTable opcode = none)
     (h_env : EnvHandlers.simpleEnvHandlerTable opcode = none)
+    (h_returnData : ReturnDataHandlers.returnDataSizeHandlerTable opcode = none)
     (h_arithmetic : ArithmeticHandlers.arithmeticHandlerTable opcode = none)
     (h_lookup : BitwiseHandlers.bitwiseHandlerTable opcode = some handler) :
     supportedHandlerTable opcode = some handler := by
@@ -112,6 +133,7 @@ theorem lookup_of_bitwise
   rw [HandlerTable.orElse_left_none h_stack]
   rw [HandlerTable.orElse_left_none h_control]
   rw [HandlerTable.orElse_left_none h_env]
+  rw [HandlerTable.orElse_left_none h_returnData]
   rw [HandlerTable.orElse_left_none h_arithmetic]
   exact HandlerTable.orElse_left_some h_lookup
 
@@ -122,6 +144,7 @@ theorem lookup_of_comparison
     (h_stack : StackHandlers.stackHandlerTable opcode = none)
     (h_control : ControlHandlers.controlHandlerTable opcode = none)
     (h_env : EnvHandlers.simpleEnvHandlerTable opcode = none)
+    (h_returnData : ReturnDataHandlers.returnDataSizeHandlerTable opcode = none)
     (h_arithmetic : ArithmeticHandlers.arithmeticHandlerTable opcode = none)
     (h_bitwise : BitwiseHandlers.bitwiseHandlerTable opcode = none)
     (h_lookup : ComparisonHandlers.comparisonHandlerTable opcode = some handler) :
@@ -131,6 +154,7 @@ theorem lookup_of_comparison
   rw [HandlerTable.orElse_left_none h_stack]
   rw [HandlerTable.orElse_left_none h_control]
   rw [HandlerTable.orElse_left_none h_env]
+  rw [HandlerTable.orElse_left_none h_returnData]
   rw [HandlerTable.orElse_left_none h_arithmetic]
   rw [HandlerTable.orElse_left_none h_bitwise]
   exact HandlerTable.orElse_left_some h_lookup
@@ -142,6 +166,7 @@ theorem lookup_of_shift
     (h_stack : StackHandlers.stackHandlerTable opcode = none)
     (h_control : ControlHandlers.controlHandlerTable opcode = none)
     (h_env : EnvHandlers.simpleEnvHandlerTable opcode = none)
+    (h_returnData : ReturnDataHandlers.returnDataSizeHandlerTable opcode = none)
     (h_arithmetic : ArithmeticHandlers.arithmeticHandlerTable opcode = none)
     (h_bitwise : BitwiseHandlers.bitwiseHandlerTable opcode = none)
     (h_comparison : ComparisonHandlers.comparisonHandlerTable opcode = none)
@@ -152,6 +177,7 @@ theorem lookup_of_shift
   rw [HandlerTable.orElse_left_none h_stack]
   rw [HandlerTable.orElse_left_none h_control]
   rw [HandlerTable.orElse_left_none h_env]
+  rw [HandlerTable.orElse_left_none h_returnData]
   rw [HandlerTable.orElse_left_none h_arithmetic]
   rw [HandlerTable.orElse_left_none h_bitwise]
   rw [HandlerTable.orElse_left_none h_comparison]
@@ -164,6 +190,7 @@ theorem lookup_of_dupSwap
     (h_stack : StackHandlers.stackHandlerTable opcode = none)
     (h_control : ControlHandlers.controlHandlerTable opcode = none)
     (h_env : EnvHandlers.simpleEnvHandlerTable opcode = none)
+    (h_returnData : ReturnDataHandlers.returnDataSizeHandlerTable opcode = none)
     (h_arithmetic : ArithmeticHandlers.arithmeticHandlerTable opcode = none)
     (h_bitwise : BitwiseHandlers.bitwiseHandlerTable opcode = none)
     (h_comparison : ComparisonHandlers.comparisonHandlerTable opcode = none)
@@ -175,6 +202,7 @@ theorem lookup_of_dupSwap
   rw [HandlerTable.orElse_left_none h_stack]
   rw [HandlerTable.orElse_left_none h_control]
   rw [HandlerTable.orElse_left_none h_env]
+  rw [HandlerTable.orElse_left_none h_returnData]
   rw [HandlerTable.orElse_left_none h_arithmetic]
   rw [HandlerTable.orElse_left_none h_bitwise]
   rw [HandlerTable.orElse_left_none h_comparison]
@@ -209,6 +237,16 @@ theorem dispatchOpcode_of_lookup
     (by simp [TerminatingHandlers.terminatingHandlerTable, HandlerTable.setHandler])
     StackHandlers.stackHandlerTable_PUSH0
 
+@[simp] theorem supportedHandlerTable_RETURNDATASIZE :
+    supportedHandlerTable .RETURNDATASIZE =
+      some ReturnDataHandlers.returnDataSizeHandler := by
+  exact lookup_of_returnData
+    (by simp [TerminatingHandlers.terminatingHandlerTable, HandlerTable.setHandler])
+    (by simp [StackHandlers.stackHandlerTable, HandlerTable.setHandler])
+    (by simp [ControlHandlers.controlHandlerTable, ControlHandlers.controlHandler?])
+    (by rfl)
+    ReturnDataHandlers.returnDataSizeHandlerTable_RETURNDATASIZE
+
 theorem supportedHandlerTable_DUP_of_valid
     {n : Nat} (h_valid : EvmOpcode.validDupIndex n = true) :
     supportedHandlerTable (.DUP n) =
@@ -218,6 +256,8 @@ theorem supportedHandlerTable_DUP_of_valid
     (by simp [StackHandlers.stackHandlerTable, HandlerTable.setHandler])
     (by simp [ControlHandlers.controlHandlerTable, ControlHandlers.controlHandler?])
     (by rfl)
+    (by simp [ReturnDataHandlers.returnDataSizeHandlerTable,
+      ReturnDataHandlers.returnDataHandler?])
     (by simp [ArithmeticHandlers.arithmeticHandlerTable,
       ArithmeticHandlers.arithmeticHandler?])
     (by simp [BitwiseHandlers.bitwiseHandlerTable, BitwiseHandlers.bitwiseHandler?])
@@ -235,6 +275,8 @@ theorem supportedHandlerTable_SWAP_of_valid
     (by simp [StackHandlers.stackHandlerTable, HandlerTable.setHandler])
     (by simp [ControlHandlers.controlHandlerTable, ControlHandlers.controlHandler?])
     (by rfl)
+    (by simp [ReturnDataHandlers.returnDataSizeHandlerTable,
+      ReturnDataHandlers.returnDataHandler?])
     (by simp [ArithmeticHandlers.arithmeticHandlerTable,
       ArithmeticHandlers.arithmeticHandler?])
     (by simp [BitwiseHandlers.bitwiseHandlerTable, BitwiseHandlers.bitwiseHandler?])


### PR DESCRIPTION
Wires the merged RETURNDATASIZE handler into the aggregate supported handler table for GH #107.\n\nSummary:\n- add ReturnDataHandlers.returnDataSizeHandlerTable to SupportedHandlers.supportedHandlerTable\n- add lookup_of_returnData\n- add supportedHandlerTable_RETURNDATASIZE\n- thread the new table through later lookup lemmas\n\nLocal verification:\n- lake build EvmAsm.Evm64.SupportedHandlers\n- lake build\n- git diff --check\n- scripts/check-file-size.sh --report\n- forbidden proof-option/sorry scan on touched file\n\nBead: evm-asm-41q4r\nRefs: #107\n\nAuthored by @pirapira; implemented by Codex.