### PR TITLE
feat(handlers): support codesize dispatch

### DIFF
--- a/EvmAsm/Evm64/SupportedHandlers.lean
+++ b/EvmAsm/Evm64/SupportedHandlers.lean
@@ -11,6 +11,7 @@ import EvmAsm.Evm64.StackHandlers
 import EvmAsm.Evm64.ControlHandlers
 import EvmAsm.Evm64.EnvHandlers
 import EvmAsm.Evm64.ReturnDataHandlers
+import EvmAsm.Evm64.CodeHandlers
 import EvmAsm.Evm64.ArithmeticHandlers
 import EvmAsm.Evm64.BitwiseHandlers
 import EvmAsm.Evm64.ComparisonHandlers
@@ -33,6 +34,7 @@ def supportedHandlerTable : HandlerTable :=
   HandlerTable.orElse ControlHandlers.controlHandlerTable <|
   HandlerTable.orElse EnvHandlers.simpleEnvHandlerTable <|
   HandlerTable.orElse ReturnDataHandlers.returnDataSizeHandlerTable <|
+  HandlerTable.orElse CodeHandlers.codeHandlerTable <|
   HandlerTable.orElse ArithmeticHandlers.arithmeticHandlerTable <|
   HandlerTable.orElse BitwiseHandlers.bitwiseHandlerTable <|
   HandlerTable.orElse ComparisonHandlers.comparisonHandlerTable
@@ -91,6 +93,7 @@ theorem lookup_of_arithmetic
     (h_control : ControlHandlers.controlHandlerTable opcode = none)
     (h_env : EnvHandlers.simpleEnvHandlerTable opcode = none)
     (h_returnData : ReturnDataHandlers.returnDataSizeHandlerTable opcode = none)
+    (h_code : CodeHandlers.codeHandlerTable opcode = none)
     (h_lookup : ArithmeticHandlers.arithmeticHandlerTable opcode = some handler) :
     supportedHandlerTable opcode = some handler := by
   unfold supportedHandlerTable
@@ -99,6 +102,7 @@ theorem lookup_of_arithmetic
   rw [HandlerTable.orElse_left_none h_control]
   rw [HandlerTable.orElse_left_none h_env]
   rw [HandlerTable.orElse_left_none h_returnData]
+  rw [HandlerTable.orElse_left_none h_code]
   exact HandlerTable.orElse_left_some h_lookup
 
 theorem lookup_of_returnData
@@ -117,6 +121,24 @@ theorem lookup_of_returnData
   rw [HandlerTable.orElse_left_none h_env]
   exact HandlerTable.orElse_left_some h_lookup
 
+theorem lookup_of_code
+    {opcode : EvmOpcode} {handler : OpcodeHandler}
+    (h_terminating :
+      TerminatingHandlers.terminatingHandlerTable opcode = none)
+    (h_stack : StackHandlers.stackHandlerTable opcode = none)
+    (h_control : ControlHandlers.controlHandlerTable opcode = none)
+    (h_env : EnvHandlers.simpleEnvHandlerTable opcode = none)
+    (h_returnData : ReturnDataHandlers.returnDataSizeHandlerTable opcode = none)
+    (h_lookup : CodeHandlers.codeHandlerTable opcode = some handler) :
+    supportedHandlerTable opcode = some handler := by
+  unfold supportedHandlerTable
+  rw [HandlerTable.orElse_left_none h_terminating]
+  rw [HandlerTable.orElse_left_none h_stack]
+  rw [HandlerTable.orElse_left_none h_control]
+  rw [HandlerTable.orElse_left_none h_env]
+  rw [HandlerTable.orElse_left_none h_returnData]
+  exact HandlerTable.orElse_left_some h_lookup
+
 theorem lookup_of_bitwise
     {opcode : EvmOpcode} {handler : OpcodeHandler}
     (h_terminating :
@@ -125,6 +147,7 @@ theorem lookup_of_bitwise
     (h_control : ControlHandlers.controlHandlerTable opcode = none)
     (h_env : EnvHandlers.simpleEnvHandlerTable opcode = none)
     (h_returnData : ReturnDataHandlers.returnDataSizeHandlerTable opcode = none)
+    (h_code : CodeHandlers.codeHandlerTable opcode = none)
     (h_arithmetic : ArithmeticHandlers.arithmeticHandlerTable opcode = none)
     (h_lookup : BitwiseHandlers.bitwiseHandlerTable opcode = some handler) :
     supportedHandlerTable opcode = some handler := by
@@ -134,6 +157,7 @@ theorem lookup_of_bitwise
   rw [HandlerTable.orElse_left_none h_control]
   rw [HandlerTable.orElse_left_none h_env]
   rw [HandlerTable.orElse_left_none h_returnData]
+  rw [HandlerTable.orElse_left_none h_code]
   rw [HandlerTable.orElse_left_none h_arithmetic]
   exact HandlerTable.orElse_left_some h_lookup
 
@@ -145,6 +169,7 @@ theorem lookup_of_comparison
     (h_control : ControlHandlers.controlHandlerTable opcode = none)
     (h_env : EnvHandlers.simpleEnvHandlerTable opcode = none)
     (h_returnData : ReturnDataHandlers.returnDataSizeHandlerTable opcode = none)
+    (h_code : CodeHandlers.codeHandlerTable opcode = none)
     (h_arithmetic : ArithmeticHandlers.arithmeticHandlerTable opcode = none)
     (h_bitwise : BitwiseHandlers.bitwiseHandlerTable opcode = none)
     (h_lookup : ComparisonHandlers.comparisonHandlerTable opcode = some handler) :
@@ -155,6 +180,7 @@ theorem lookup_of_comparison
   rw [HandlerTable.orElse_left_none h_control]
   rw [HandlerTable.orElse_left_none h_env]
   rw [HandlerTable.orElse_left_none h_returnData]
+  rw [HandlerTable.orElse_left_none h_code]
   rw [HandlerTable.orElse_left_none h_arithmetic]
   rw [HandlerTable.orElse_left_none h_bitwise]
   exact HandlerTable.orElse_left_some h_lookup
@@ -167,6 +193,7 @@ theorem lookup_of_shift
     (h_control : ControlHandlers.controlHandlerTable opcode = none)
     (h_env : EnvHandlers.simpleEnvHandlerTable opcode = none)
     (h_returnData : ReturnDataHandlers.returnDataSizeHandlerTable opcode = none)
+    (h_code : CodeHandlers.codeHandlerTable opcode = none)
     (h_arithmetic : ArithmeticHandlers.arithmeticHandlerTable opcode = none)
     (h_bitwise : BitwiseHandlers.bitwiseHandlerTable opcode = none)
     (h_comparison : ComparisonHandlers.comparisonHandlerTable opcode = none)
@@ -178,6 +205,7 @@ theorem lookup_of_shift
   rw [HandlerTable.orElse_left_none h_control]
   rw [HandlerTable.orElse_left_none h_env]
   rw [HandlerTable.orElse_left_none h_returnData]
+  rw [HandlerTable.orElse_left_none h_code]
   rw [HandlerTable.orElse_left_none h_arithmetic]
   rw [HandlerTable.orElse_left_none h_bitwise]
   rw [HandlerTable.orElse_left_none h_comparison]
@@ -191,6 +219,7 @@ theorem lookup_of_dupSwap
     (h_control : ControlHandlers.controlHandlerTable opcode = none)
     (h_env : EnvHandlers.simpleEnvHandlerTable opcode = none)
     (h_returnData : ReturnDataHandlers.returnDataSizeHandlerTable opcode = none)
+    (h_code : CodeHandlers.codeHandlerTable opcode = none)
     (h_arithmetic : ArithmeticHandlers.arithmeticHandlerTable opcode = none)
     (h_bitwise : BitwiseHandlers.bitwiseHandlerTable opcode = none)
     (h_comparison : ComparisonHandlers.comparisonHandlerTable opcode = none)
@@ -203,6 +232,7 @@ theorem lookup_of_dupSwap
   rw [HandlerTable.orElse_left_none h_control]
   rw [HandlerTable.orElse_left_none h_env]
   rw [HandlerTable.orElse_left_none h_returnData]
+  rw [HandlerTable.orElse_left_none h_code]
   rw [HandlerTable.orElse_left_none h_arithmetic]
   rw [HandlerTable.orElse_left_none h_bitwise]
   rw [HandlerTable.orElse_left_none h_comparison]
@@ -247,6 +277,18 @@ theorem dispatchOpcode_of_lookup
     (by rfl)
     ReturnDataHandlers.returnDataSizeHandlerTable_RETURNDATASIZE
 
+@[simp] theorem supportedHandlerTable_CODESIZE :
+    supportedHandlerTable .CODESIZE =
+      some CodeHandlers.codeSizeHandler := by
+  exact lookup_of_code
+    (by simp [TerminatingHandlers.terminatingHandlerTable, HandlerTable.setHandler])
+    (by simp [StackHandlers.stackHandlerTable, HandlerTable.setHandler])
+    (by simp [ControlHandlers.controlHandlerTable, ControlHandlers.controlHandler?])
+    (by rfl)
+    (by simp [ReturnDataHandlers.returnDataSizeHandlerTable,
+      ReturnDataHandlers.returnDataHandler?])
+    CodeHandlers.codeHandlerTable_CODESIZE
+
 theorem supportedHandlerTable_DUP_of_valid
     {n : Nat} (h_valid : EvmOpcode.validDupIndex n = true) :
     supportedHandlerTable (.DUP n) =
@@ -258,6 +300,7 @@ theorem supportedHandlerTable_DUP_of_valid
     (by rfl)
     (by simp [ReturnDataHandlers.returnDataSizeHandlerTable,
       ReturnDataHandlers.returnDataHandler?])
+    (by simp [CodeHandlers.codeHandlerTable, CodeHandlers.codeHandler?])
     (by simp [ArithmeticHandlers.arithmeticHandlerTable,
       ArithmeticHandlers.arithmeticHandler?])
     (by simp [BitwiseHandlers.bitwiseHandlerTable, BitwiseHandlers.bitwiseHandler?])
@@ -277,6 +320,7 @@ theorem supportedHandlerTable_SWAP_of_valid
     (by rfl)
     (by simp [ReturnDataHandlers.returnDataSizeHandlerTable,
       ReturnDataHandlers.returnDataHandler?])
+    (by simp [CodeHandlers.codeHandlerTable, CodeHandlers.codeHandler?])
     (by simp [ArithmeticHandlers.arithmeticHandlerTable,
       ArithmeticHandlers.arithmeticHandler?])
     (by simp [BitwiseHandlers.bitwiseHandlerTable, BitwiseHandlers.bitwiseHandler?])


### PR DESCRIPTION
Stacked on #2740.\n\nWires the merged CODESIZE handler into the aggregate supported handler table for GH #107.\n\nSummary:\n- add CodeHandlers.codeHandlerTable to SupportedHandlers.supportedHandlerTable\n- add lookup_of_code\n- add supportedHandlerTable_CODESIZE\n- thread the new table through later lookup lemmas\n\nLocal verification:\n- lake build EvmAsm.Evm64.SupportedHandlers\n- lake build\n- git diff --check\n- scripts/check-file-size.sh --report\n- forbidden proof-option/sorry scan on touched file\n\nBead: evm-asm-4abel\nRefs: #107\n\nAuthored by @pirapira; implemented by Codex.