### PR TITLE
feat(returndata): add copy exec bridge

### DIFF
--- a/EvmAsm/Evm64.lean
+++ b/EvmAsm/Evm64.lean
@@ -74,6 +74,7 @@ import EvmAsm.Evm64.Environment.Layout
 import EvmAsm.Evm64.Environment.Assertion
 import EvmAsm.Evm64.ReturnData.Basic
 import EvmAsm.Evm64.ReturnData.CopyArgs
+import EvmAsm.Evm64.ReturnData.CopyExec
 import EvmAsm.Evm64.Env.Field
 import EvmAsm.Evm64.Env.Semantics
 import EvmAsm.Evm64.Env.Program

--- a/EvmAsm/Evm64/ReturnData/CopyExec.lean
+++ b/EvmAsm/Evm64/ReturnData/CopyExec.lean
@@ -1,0 +1,70 @@
+/-
+  EvmAsm.Evm64.ReturnData.CopyExec
+
+  Bridge from RETURNDATACOPY stack arguments to executable returndata bytes
+  (GH #107 / GH #114).
+-/
+
+import EvmAsm.Evm64.ReturnData.Basic
+import EvmAsm.Evm64.ReturnData.CopyArgs
+
+namespace EvmAsm.Evm64
+namespace ReturnDataCopyExec
+
+/-- Bytes written by RETURNDATACOPY for a decoded stack-argument record.
+    Distinctive token: ReturnDataCopyExec.copiedBytesFromArgs. -/
+def copiedBytesFromArgs
+    (data : List (BitVec 8)) (args : ReturnDataCopyArgs.Args) : List (BitVec 8) :=
+  ReturnData.copyBytes
+    data (ReturnDataCopyArgs.sourceOffsetNat args) (ReturnDataCopyArgs.sizeNat args)
+
+theorem copiedBytesFromArgs_eq
+    (data : List (BitVec 8)) (args : ReturnDataCopyArgs.Args) :
+    copiedBytesFromArgs data args =
+      ReturnData.copyBytes data args.dataOffset.toNat args.size.toNat := rfl
+
+@[simp] theorem copiedBytesFromArgs_length
+    (data : List (BitVec 8)) (args : ReturnDataCopyArgs.Args) :
+    (copiedBytesFromArgs data args).length = args.size.toNat := by
+  simp [copiedBytesFromArgs, ReturnDataCopyArgs.sizeNat]
+
+@[simp] theorem copiedBytesFromArgs_zero_size
+    (data : List (BitVec 8)) (destOffset dataOffset : EvmWord) :
+    copiedBytesFromArgs data (ReturnDataCopyArgs.copyArgs destOffset dataOffset 0) = [] := by
+  simp [copiedBytesFromArgs, ReturnDataCopyArgs.copyArgs,
+    ReturnDataCopyArgs.sourceOffsetNat, ReturnDataCopyArgs.sizeNat]
+
+theorem copiedBytesFromArgs_get
+    {data : List (BitVec 8)} {args : ReturnDataCopyArgs.Args} {i : Nat}
+    (h : i < args.size.toNat) :
+    (copiedBytesFromArgs data args)[i]'(by
+      simpa [copiedBytesFromArgs_length] using h)
+      = ReturnData.byte data (args.dataOffset.toNat + i) := by
+  unfold copiedBytesFromArgs ReturnDataCopyArgs.sourceOffsetNat ReturnDataCopyArgs.sizeNat
+  exact ReturnData.copyBytes_get h
+
+theorem copiedBytesFromArgs_get_of_in_bounds
+    {data : List (BitVec 8)} {args : ReturnDataCopyArgs.Args} {i : Nat}
+    (h : i < args.size.toNat)
+    (hsrc : args.dataOffset.toNat + i < data.length) :
+    (copiedBytesFromArgs data args)[i]'(by
+      simpa [copiedBytesFromArgs_length] using h)
+      = data[args.dataOffset.toNat + i] := by
+  rw [copiedBytesFromArgs_get h, ReturnData.byte_of_lt hsrc]
+
+theorem copiedBytesFromArgs_get_of_out_of_bounds
+    {data : List (BitVec 8)} {args : ReturnDataCopyArgs.Args} {i : Nat}
+    (h : i < args.size.toNat)
+    (hsrc : data.length ≤ args.dataOffset.toNat + i) :
+    (copiedBytesFromArgs data args)[i]'(by
+      simpa [copiedBytesFromArgs_length] using h)
+      = 0 := by
+  rw [copiedBytesFromArgs_get h, ReturnData.byte_of_ge hsrc]
+
+@[simp] theorem copiedBytesFromArgs_nil
+    (args : ReturnDataCopyArgs.Args) :
+    copiedBytesFromArgs [] args = List.replicate args.size.toNat 0 := by
+  simp [copiedBytesFromArgs_eq]
+
+end ReturnDataCopyExec
+end EvmAsm.Evm64


### PR DESCRIPTION
Adds the RETURNDATACOPY executable-spec bridge for GH #107 / GH #114.\n\nSummary:\n- add EvmAsm.Evm64.ReturnData.CopyExec\n- define ReturnDataCopyExec.copiedBytesFromArgs over ReturnDataCopyArgs.Args\n- add length/get/in-bounds/out-of-bounds/zero-size/nil lemmas\n- wire the module into EvmAsm.Evm64\n\nVerification:\n- lake build EvmAsm.Evm64.ReturnData.CopyExec\n- lake build\n- scripts/check-file-size.sh --report\n- git diff --check\n- forbidden proof-option/sorry scan on touched files\n\nRefs evm-asm-b37o.5; GH #107; GH #114.\n\nAuthored by @pirapira; implemented by Codex.