### PR TITLE
chore(shake): drop unused imports in ReturnData.Basic and Dispatch.EntryAddrBridge

### DIFF
--- a/EvmAsm/Evm64/Dispatch/EntryAddrBridge.lean
+++ b/EvmAsm/Evm64/Dispatch/EntryAddrBridge.lean
@@ -22,7 +22,11 @@
   Refs GH #106, beads `evm-asm-b11gg`, parent `evm-asm-77w8s`.
 -/
 
-import EvmAsm.Evm64.Dispatch.Program
+-- Only `Word` (= `BitVec 64`) and standard `BitVec` lemmas are used here; pull
+-- them in directly via `EvmAsm.Rv64.Program` (which transitively imports
+-- `EvmAsm.Rv64.Basic` where the `Word` notation lives) instead of the larger
+-- `EvmAsm.Evm64.Dispatch.Program`. Slice of #1045.
+import EvmAsm.Rv64.Program
 
 namespace EvmAsm.Evm64
 namespace Dispatch

--- a/EvmAsm/Evm64/ReturnData/Basic.lean
+++ b/EvmAsm/Evm64/ReturnData/Basic.lean
@@ -5,7 +5,8 @@
   (GH #107 / GH #114).
 -/
 
-import EvmAsm.Evm64.Basic
+-- (No `import EvmAsm.Evm64.Basic`: this module only uses `BitVec 8`,
+-- not anything from `Evm64.Basic`; dropped per shake hygiene, slice of #1045.)
 
 namespace EvmAsm.Evm64
 namespace ReturnData


### PR DESCRIPTION
Slice of GH #1045 (import hygiene sweep, parent bead evm-asm-9tq, this slice evm-asm-nnrim).

Two `lake exe shake EvmAsm` suggestions, both confirmed by hand-audit and survived `scripts/shake-filter.py` false-positive heuristics:

- `EvmAsm/Evm64/ReturnData/Basic.lean` only manipulates `List (BitVec 8)`. Nothing from `EvmAsm.Evm64.Basic` (`EvmWord`, `getLimb`, `fromLimbs`, ...) is referenced. Drop the import.
- `EvmAsm/Evm64/Dispatch/EntryAddrBridge.lean` only does `Word` (= `BitVec 64`) arithmetic. Switch from `EvmAsm.Evm64.Dispatch.Program` (which itself only adds `Rv64.Program` for the `Word` notation, plus the much heavier `evm_dispatch` program defs) to `EvmAsm.Rv64.Program` directly.

Verification:
- `lake build` green.
- `lake exe shake EvmAsm` (filtered) no longer flags either file.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).