### PR TITLE
test(returndata): add copy conformance vector

### DIFF
--- a/EvmAsm/EL.lean
+++ b/EvmAsm/EL.lean
@@ -26,6 +26,7 @@ import EvmAsm.EL.KeccakExecutionBridge
 import EvmAsm.EL.Conformance
 import EvmAsm.EL.Conformance.Call
 import EvmAsm.EL.Conformance.Calldata
+import EvmAsm.EL.Conformance.ReturnData
 import EvmAsm.EL.Conformance.Log
 import EvmAsm.EL.Conformance.ExpGas
 import EvmAsm.EL.Conformance.RLP

--- a/EvmAsm/EL/Conformance/ReturnData.lean
+++ b/EvmAsm/EL/Conformance/ReturnData.lean
@@ -1,0 +1,73 @@
+/-
+  EvmAsm.EL.Conformance.ReturnData
+
+  Initial Lean-side conformance vector for executable returndata helpers
+  (GH #125 / GH #114).
+-/
+
+import EvmAsm.EL.Conformance
+import EvmAsm.Evm64.ReturnData.CopyExec
+
+namespace EvmAsm.EL
+namespace Conformance
+namespace ReturnData
+
+abbrev EvmWord := EvmAsm.Evm64.EvmWord
+
+/-- Input shape for a RETURNDATACOPY executable-helper conformance vector. -/
+structure ReturnDataCopyInput where
+  data : List (BitVec 8)
+  destOffset : EvmWord
+  dataOffset : EvmWord
+  size : EvmWord
+  deriving Repr
+
+def runReturnDataCopy (input : ReturnDataCopyInput) : List (BitVec 8) :=
+  EvmAsm.Evm64.ReturnDataCopyExec.copiedBytesFromArgs
+    input.data
+    (EvmAsm.Evm64.ReturnDataCopyArgs.copyArgs
+      input.destOffset input.dataOffset input.size)
+
+/-- RETURNDATACOPY zero-pads bytes copied past the end of returndata.
+    Distinctive token: returnDataCopyZeroPadVector #125 #114. -/
+def returnDataCopyZeroPadVector :
+    TestVector ReturnDataCopyInput (List (BitVec 8)) :=
+  { id := "returndatacopy-zero-pad"
+    input :=
+      { data := [(0xaa : BitVec 8), (0xbb : BitVec 8)]
+        destOffset := 32
+        dataOffset := 1
+        size := 4 }
+    expected := .value [(0xbb : BitVec 8), 0, 0, 0] }
+
+theorem runReturnDataCopy_zeroPad :
+    runReturnDataCopy
+      { data := [(0xaa : BitVec 8), (0xbb : BitVec 8)]
+        destOffset := 32
+        dataOffset := 1
+        size := 4 } =
+      [(0xbb : BitVec 8), 0, 0, 0] := rfl
+
+theorem returnDataCopyZeroPadVector_passed :
+    checkVector runReturnDataCopy returnDataCopyZeroPadVector = .passed :=
+  checkVector_value_passed runReturnDataCopy
+    "returndatacopy-zero-pad"
+    { data := [(0xaa : BitVec 8), (0xbb : BitVec 8)]
+      destOffset := (32 : EvmWord)
+      dataOffset := (1 : EvmWord)
+      size := (4 : EvmWord) }
+    [(0xbb : BitVec 8), 0, 0, 0]
+    runReturnDataCopy_zeroPad
+
+/-- Compact checked-vector batch for returndata executable helpers.
+    Distinctive token: returnDataConformanceVectors #125 #114. -/
+def returnDataConformanceVectors : List CheckResult :=
+  [checkVector runReturnDataCopy returnDataCopyZeroPadVector]
+
+theorem returnDataConformanceVectors_passed :
+    returnDataConformanceVectors = [.passed] := by
+  simp [returnDataConformanceVectors, returnDataCopyZeroPadVector_passed]
+
+end ReturnData
+end Conformance
+end EvmAsm.EL


### PR DESCRIPTION
Stacked on #2744.\n\nAdds one focused RETURNDATACOPY executable-helper conformance vector for GH #125 / GH #114.\n\nSummary:\n- add EvmAsm.EL.Conformance.ReturnData\n- define runReturnDataCopy over ReturnDataCopyExec.copiedBytesFromArgs\n- add returnDataCopyZeroPadVector and passed theorem\n- wire the module into EvmAsm.EL\n\nVerification:\n- lake build EvmAsm.EL.Conformance.ReturnData\n- lake build\n- scripts/check-file-size.sh --report\n- git diff --check\n- forbidden proof-option/sorry scan on touched files\n\nRefs evm-asm-sxou.4; GH #125; GH #114.\n\nAuthored by @pirapira; implemented by Codex.