### PR TITLE
feat(code): add codecopy bytes helper

### DIFF
--- a/EvmAsm/Evm64.lean
+++ b/EvmAsm/Evm64.lean
@@ -111,6 +111,7 @@ import EvmAsm.Evm64.HandlerTable
 import EvmAsm.Evm64.HandlerTableByte
 import EvmAsm.Evm64.HandlerTableCompose
 import EvmAsm.Evm64.StackHandlers
+import EvmAsm.Evm64.Code.Basic
 import EvmAsm.Evm64.CodeHandlers
 import EvmAsm.Evm64.PushHandlers
 import EvmAsm.Evm64.ControlHandlers

--- a/EvmAsm/Evm64/Code/Basic.lean
+++ b/EvmAsm/Evm64/Code/Basic.lean
@@ -1,0 +1,79 @@
+/-
+  EvmAsm.Evm64.Code.Basic
+
+  Pure byte helpers for CODECOPY executable-spec bridges
+  (GH #107 / GH #118).
+-/
+
+import EvmAsm.Evm64.Basic
+
+namespace EvmAsm.Evm64
+namespace Code
+
+/-- Read one byte from executable code, returning zero past the end. -/
+def byte (code : List (BitVec 8)) (idx : Nat) : BitVec 8 :=
+  if h : idx < code.length then code[idx] else 0
+
+/-- Bytes written by CODECOPY:
+    `size` bytes from `code` starting at `codeOffset`, with out-of-bounds
+    reads producing zero. Distinctive token: Code.copyBytes #107 #118. -/
+def copyBytes
+    (code : List (BitVec 8)) (codeOffset size : Nat) : List (BitVec 8) :=
+  (List.range size).map (fun i => byte code (codeOffset + i))
+
+theorem byte_of_lt {code : List (BitVec 8)} {idx : Nat}
+    (h : idx < code.length) :
+    byte code idx = code[idx] := by
+  simp [byte, h]
+
+theorem byte_of_ge {code : List (BitVec 8)} {idx : Nat}
+    (h : code.length ≤ idx) :
+    byte code idx = 0 := by
+  simp [byte, show ¬idx < code.length from by omega]
+
+@[simp] theorem byte_nil (idx : Nat) :
+    byte [] idx = 0 := by
+  exact byte_of_ge (code := []) (idx := idx) (by simp)
+
+@[simp] theorem copyBytes_length
+    (code : List (BitVec 8)) (codeOffset size : Nat) :
+    (copyBytes code codeOffset size).length = size := by
+  simp [copyBytes]
+
+@[simp] theorem copyBytes_zero
+    (code : List (BitVec 8)) (codeOffset : Nat) :
+    copyBytes code codeOffset 0 = [] := by
+  simp [copyBytes]
+
+theorem copyBytes_get
+    {code : List (BitVec 8)} {codeOffset size i : Nat}
+    (h : i < size) :
+    (copyBytes code codeOffset size)[i]'(by
+      simpa [copyBytes_length] using h)
+      = byte code (codeOffset + i) := by
+  simp [copyBytes]
+
+theorem copyBytes_get_of_in_bounds
+    {code : List (BitVec 8)} {codeOffset size i : Nat}
+    (h : i < size)
+    (hsrc : codeOffset + i < code.length) :
+    (copyBytes code codeOffset size)[i]'(by
+      simpa [copyBytes_length] using h)
+      = code[codeOffset + i] := by
+  rw [copyBytes_get h, byte_of_lt hsrc]
+
+theorem copyBytes_get_of_out_of_bounds
+    {code : List (BitVec 8)} {codeOffset size i : Nat}
+    (h : i < size)
+    (hsrc : code.length ≤ codeOffset + i) :
+    (copyBytes code codeOffset size)[i]'(by
+      simpa [copyBytes_length] using h)
+      = 0 := by
+  rw [copyBytes_get h, byte_of_ge hsrc]
+
+@[simp] theorem copyBytes_nil (codeOffset size : Nat) :
+    copyBytes [] codeOffset size = List.replicate size 0 := by
+  simp [copyBytes, List.map_const']
+
+end Code
+end EvmAsm.Evm64


### PR DESCRIPTION
Adds the CODECOPY executable bytes helper for GH #107 / GH #118.\n\nSummary:\n- add EvmAsm.Evm64.Code.Basic\n- define Code.byte and Code.copyBytes\n- add length/get/in-bounds/out-of-bounds/zero-size/nil lemmas\n- wire the module into EvmAsm.Evm64\n\nVerification:\n- lake build EvmAsm.Evm64.Code.Basic\n- lake build\n- scripts/check-file-size.sh --report\n- git diff --check\n- forbidden proof-option/sorry scan on touched files\n\nRefs evm-asm-jaeo.1; GH #107; GH #118.\n\nAuthored by @pirapira; implemented by Codex.