### PR TITLE
feat(code): add codecopy exec bridge

### DIFF
--- a/EvmAsm/Evm64.lean
+++ b/EvmAsm/Evm64.lean
@@ -113,6 +113,7 @@ import EvmAsm.Evm64.HandlerTableCompose
 import EvmAsm.Evm64.StackHandlers
 import EvmAsm.Evm64.Code.Basic
 import EvmAsm.Evm64.Code.CopyArgs
+import EvmAsm.Evm64.Code.CopyExec
 import EvmAsm.Evm64.CodeHandlers
 import EvmAsm.Evm64.PushHandlers
 import EvmAsm.Evm64.ControlHandlers

--- a/EvmAsm/Evm64/Code/CopyExec.lean
+++ b/EvmAsm/Evm64/Code/CopyExec.lean
@@ -1,0 +1,70 @@
+/-
+  EvmAsm.Evm64.Code.CopyExec
+
+  Bridge from CODECOPY stack arguments to executable code bytes
+  (GH #107 / GH #118).
+-/
+
+import EvmAsm.Evm64.Code.Basic
+import EvmAsm.Evm64.Code.CopyArgs
+
+namespace EvmAsm.Evm64
+namespace CodeCopyExec
+
+/-- Bytes written by CODECOPY for a decoded stack-argument record.
+    Distinctive token: CodeCopyExec.copiedBytesFromArgs. -/
+def copiedBytesFromArgs
+    (code : List (BitVec 8)) (args : CodeCopyArgs.Args) : List (BitVec 8) :=
+  Code.copyBytes
+    code (CodeCopyArgs.sourceOffsetNat args) (CodeCopyArgs.sizeNat args)
+
+theorem copiedBytesFromArgs_eq
+    (code : List (BitVec 8)) (args : CodeCopyArgs.Args) :
+    copiedBytesFromArgs code args =
+      Code.copyBytes code args.codeOffset.toNat args.size.toNat := rfl
+
+@[simp] theorem copiedBytesFromArgs_length
+    (code : List (BitVec 8)) (args : CodeCopyArgs.Args) :
+    (copiedBytesFromArgs code args).length = args.size.toNat := by
+  simp [copiedBytesFromArgs, CodeCopyArgs.sizeNat]
+
+@[simp] theorem copiedBytesFromArgs_zero_size
+    (code : List (BitVec 8)) (destOffset codeOffset : EvmWord) :
+    copiedBytesFromArgs code (CodeCopyArgs.copyArgs destOffset codeOffset 0) = [] := by
+  simp [copiedBytesFromArgs, CodeCopyArgs.copyArgs,
+    CodeCopyArgs.sourceOffsetNat, CodeCopyArgs.sizeNat]
+
+theorem copiedBytesFromArgs_get
+    {code : List (BitVec 8)} {args : CodeCopyArgs.Args} {i : Nat}
+    (h : i < args.size.toNat) :
+    (copiedBytesFromArgs code args)[i]'(by
+      simpa [copiedBytesFromArgs_length] using h)
+      = Code.byte code (args.codeOffset.toNat + i) := by
+  unfold copiedBytesFromArgs CodeCopyArgs.sourceOffsetNat CodeCopyArgs.sizeNat
+  exact Code.copyBytes_get h
+
+theorem copiedBytesFromArgs_get_of_in_bounds
+    {code : List (BitVec 8)} {args : CodeCopyArgs.Args} {i : Nat}
+    (h : i < args.size.toNat)
+    (hsrc : args.codeOffset.toNat + i < code.length) :
+    (copiedBytesFromArgs code args)[i]'(by
+      simpa [copiedBytesFromArgs_length] using h)
+      = code[args.codeOffset.toNat + i] := by
+  rw [copiedBytesFromArgs_get h, Code.byte_of_lt hsrc]
+
+theorem copiedBytesFromArgs_get_of_out_of_bounds
+    {code : List (BitVec 8)} {args : CodeCopyArgs.Args} {i : Nat}
+    (h : i < args.size.toNat)
+    (hsrc : code.length ≤ args.codeOffset.toNat + i) :
+    (copiedBytesFromArgs code args)[i]'(by
+      simpa [copiedBytesFromArgs_length] using h)
+      = 0 := by
+  rw [copiedBytesFromArgs_get h, Code.byte_of_ge hsrc]
+
+@[simp] theorem copiedBytesFromArgs_nil
+    (args : CodeCopyArgs.Args) :
+    copiedBytesFromArgs [] args = List.replicate args.size.toNat 0 := by
+  simp [copiedBytesFromArgs_eq]
+
+end CodeCopyExec
+end EvmAsm.Evm64


### PR DESCRIPTION
Adds the CODECOPY executable-spec bridge for GH #107 / GH #118. Originally stacked on #2748; #2748 merged before PR creation, so this now targets main.\n\nSummary:\n- add EvmAsm.Evm64.Code.CopyExec\n- define CodeCopyExec.copiedBytesFromArgs over CodeCopyArgs.Args\n- add length/get/in-bounds/out-of-bounds/zero-size/nil lemmas\n- wire the module into EvmAsm.Evm64\n\nVerification:\n- lake build EvmAsm.Evm64.Code.CopyExec\n- lake build\n- scripts/check-file-size.sh --report\n- git diff --check\n- forbidden proof-option/sorry scan on touched files\n\nRefs evm-asm-jaeo.3; GH #107; GH #118.\n\nAuthored by @pirapira; implemented by Codex.