### PR TITLE
chore(divmod): delete 2 dead fullDivN1Shift_toNat helpers

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1LoopUnified.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1LoopUnified.lean
@@ -464,21 +464,6 @@ theorem fullDivN1Shift_unfold (b0 : Word) :
   delta fullDivN1Shift
   rfl
 
-theorem fullDivN1Shift_toNat_pos_of_ne_zero {b0 : Word}
-    (hshift_nz : fullDivN1Shift b0 ≠ 0) :
-    0 < (fullDivN1Shift b0).toNat := by
-  rcases Nat.eq_zero_or_pos (fullDivN1Shift b0).toNat with h0 | hpos
-  · exfalso
-    apply hshift_nz
-    exact BitVec.eq_of_toNat_eq h0
-  · exact hpos
-
-theorem fullDivN1Shift_toNat_lt_64 (b0 : Word) :
-    (fullDivN1Shift b0).toNat < 64 := by
-  rw [fullDivN1Shift_unfold]
-  have hle := clzResult_fst_toNat_le b0
-  omega
-
 theorem evm_div_n1_denorm_epilogue_bundled_spec
     (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
     (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word)


### PR DESCRIPTION
Two theorems in `EvmAsm/Evm64/DivMod/Compose/FullPathN1LoopUnified.lean` (lines 467, 476) are unused project-wide:

- `fullDivN1Shift_toNat_pos_of_ne_zero`
- `fullDivN1Shift_toNat_lt_64`

PR #2644 deleted the `val256_eq_scaled` chain that consumed them, and follow-up commit `5b2c5b40` removed the rest of the `AntiShift` cluster, but these two arithmetic helpers were inadvertently kept on main with no remaining consumers (`rg -wn` returns only the declaration line for each).

Component #61 (DIV/MOD stack-spec) is closed; no open slice under `evm-asm-sboz` / `evm-asm-vgx` / `evm-asm-wfyv` consumes them.

- -15 LOC
- `lake build` green (1671 jobs); 0 sorries

Refs: GH #61 follow-up, beads `evm-asm-5j30d`, parent `evm-asm-sboz`.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).