### PR TITLE
feat(code): add codecopy stack decoder

### DIFF
--- a/EvmAsm/Evm64.lean
+++ b/EvmAsm/Evm64.lean
@@ -113,6 +113,7 @@ import EvmAsm.Evm64.HandlerTableCompose
 import EvmAsm.Evm64.StackHandlers
 import EvmAsm.Evm64.Code.Basic
 import EvmAsm.Evm64.Code.CopyArgs
+import EvmAsm.Evm64.Code.CopyArgsStackDecode
 import EvmAsm.Evm64.Code.CopyExec
 import EvmAsm.Evm64.Code.CopyMemory
 import EvmAsm.Evm64.CodeHandlers

--- a/EvmAsm/Evm64/Code/CopyArgsStackDecode.lean
+++ b/EvmAsm/Evm64/Code/CopyArgsStackDecode.lean
@@ -1,0 +1,73 @@
+/-
+  EvmAsm.Evm64.Code.CopyArgsStackDecode
+
+  Pure top-of-stack decoder for CODECOPY executable-spec bridges
+  (GH #107 / GH #118).
+-/
+
+import EvmAsm.Evm64.Code.CopyArgs
+
+namespace EvmAsm.Evm64
+
+namespace CodeCopyArgsStackDecode
+
+/--
+Decode CODECOPY stack arguments from the top-of-stack list order:
+`destOffset, codeOffset, size`.
+
+Distinctive token: CodeCopyArgsStackDecode.decodeCodeCopyStack? #107 #118.
+-/
+def decodeCodeCopyStack? : List EvmWord → Option CodeCopyArgs.Args
+  | destOffset :: codeOffset :: size :: _ =>
+      some (CodeCopyArgs.copyArgs destOffset codeOffset size)
+  | _ => none
+
+theorem decodeCodeCopyStack?_cons
+    (destOffset codeOffset size : EvmWord) (rest : List EvmWord) :
+    decodeCodeCopyStack? (destOffset :: codeOffset :: size :: rest) =
+      some (CodeCopyArgs.copyArgs destOffset codeOffset size) := rfl
+
+theorem decodeCodeCopyStack?_eq_some_iff
+    {stack : List EvmWord} {args : CodeCopyArgs.Args} :
+    decodeCodeCopyStack? stack = some args ↔
+      ∃ destOffset codeOffset size rest,
+        stack = destOffset :: codeOffset :: size :: rest ∧
+          args = CodeCopyArgs.copyArgs destOffset codeOffset size := by
+  constructor
+  · cases stack with
+    | nil => simp [decodeCodeCopyStack?]
+    | cons destOffset s1 =>
+      cases s1 with
+      | nil => simp [decodeCodeCopyStack?]
+      | cons codeOffset s2 =>
+        cases s2 with
+        | nil => simp [decodeCodeCopyStack?]
+        | cons size rest =>
+          intro h
+          injection h with h_args
+          subst h_args
+          exact ⟨destOffset, codeOffset, size, rest, rfl, rfl⟩
+  · rintro ⟨destOffset, codeOffset, size, rest, rfl, rfl⟩
+    rfl
+
+theorem decodeCodeCopyStack?_destOffset
+    (destOffset codeOffset size : EvmWord) (rest : List EvmWord) :
+    Option.map (fun args => args.destOffset)
+      (decodeCodeCopyStack? (destOffset :: codeOffset :: size :: rest)) =
+      some destOffset := rfl
+
+theorem decodeCodeCopyStack?_codeOffset
+    (destOffset codeOffset size : EvmWord) (rest : List EvmWord) :
+    Option.map (fun args => args.codeOffset)
+      (decodeCodeCopyStack? (destOffset :: codeOffset :: size :: rest)) =
+      some codeOffset := rfl
+
+theorem decodeCodeCopyStack?_size
+    (destOffset codeOffset size : EvmWord) (rest : List EvmWord) :
+    Option.map (fun args => args.size)
+      (decodeCodeCopyStack? (destOffset :: codeOffset :: size :: rest)) =
+      some size := rfl
+
+end CodeCopyArgsStackDecode
+
+end EvmAsm.Evm64


### PR DESCRIPTION
Adds a pure top-of-stack decoder for CODECOPY arguments in EVM order: destOffset, codeOffset, size.\n\nVerification:\n- lake build EvmAsm.Evm64.Code.CopyArgsStackDecode\n- lake build\n- scripts/check-file-size.sh --report\n- git diff --check\n\nRefs evm-asm-jaeo.5; GH #107; GH #118.\n\nAuthored by @pirapira; implemented by Codex.