### PR TITLE
feat(returndata): add copy stack decoder

### DIFF
--- a/EvmAsm/Evm64.lean
+++ b/EvmAsm/Evm64.lean
@@ -74,6 +74,7 @@ import EvmAsm.Evm64.Environment.Layout
 import EvmAsm.Evm64.Environment.Assertion
 import EvmAsm.Evm64.ReturnData.Basic
 import EvmAsm.Evm64.ReturnData.CopyArgs
+import EvmAsm.Evm64.ReturnData.CopyArgsStackDecode
 import EvmAsm.Evm64.ReturnData.CopyExec
 import EvmAsm.Evm64.ReturnData.CopyMemory
 import EvmAsm.Evm64.Env.Field

--- a/EvmAsm/Evm64/ReturnData/CopyArgsStackDecode.lean
+++ b/EvmAsm/Evm64/ReturnData/CopyArgsStackDecode.lean
@@ -1,0 +1,74 @@
+/-
+  EvmAsm.Evm64.ReturnData.CopyArgsStackDecode
+
+  Pure top-of-stack decoder for RETURNDATACOPY executable-spec bridges
+  (GH #107 / GH #114).
+-/
+
+import EvmAsm.Evm64.ReturnData.CopyArgs
+
+namespace EvmAsm.Evm64
+
+namespace ReturnDataCopyArgsStackDecode
+
+/--
+Decode RETURNDATACOPY stack arguments from the top-of-stack list order:
+`destOffset, dataOffset, size`.
+
+Distinctive token:
+ReturnDataCopyArgsStackDecode.decodeReturnDataCopyStack? #107 #114.
+-/
+def decodeReturnDataCopyStack? : List EvmWord → Option ReturnDataCopyArgs.Args
+  | destOffset :: dataOffset :: size :: _ =>
+      some (ReturnDataCopyArgs.copyArgs destOffset dataOffset size)
+  | _ => none
+
+theorem decodeReturnDataCopyStack?_cons
+    (destOffset dataOffset size : EvmWord) (rest : List EvmWord) :
+    decodeReturnDataCopyStack? (destOffset :: dataOffset :: size :: rest) =
+      some (ReturnDataCopyArgs.copyArgs destOffset dataOffset size) := rfl
+
+theorem decodeReturnDataCopyStack?_eq_some_iff
+    {stack : List EvmWord} {args : ReturnDataCopyArgs.Args} :
+    decodeReturnDataCopyStack? stack = some args ↔
+      ∃ destOffset dataOffset size rest,
+        stack = destOffset :: dataOffset :: size :: rest ∧
+          args = ReturnDataCopyArgs.copyArgs destOffset dataOffset size := by
+  constructor
+  · cases stack with
+    | nil => simp [decodeReturnDataCopyStack?]
+    | cons destOffset s1 =>
+      cases s1 with
+      | nil => simp [decodeReturnDataCopyStack?]
+      | cons dataOffset s2 =>
+        cases s2 with
+        | nil => simp [decodeReturnDataCopyStack?]
+        | cons size rest =>
+          intro h
+          injection h with h_args
+          subst h_args
+          exact ⟨destOffset, dataOffset, size, rest, rfl, rfl⟩
+  · rintro ⟨destOffset, dataOffset, size, rest, rfl, rfl⟩
+    rfl
+
+theorem decodeReturnDataCopyStack?_destOffset
+    (destOffset dataOffset size : EvmWord) (rest : List EvmWord) :
+    Option.map (fun args => args.destOffset)
+      (decodeReturnDataCopyStack? (destOffset :: dataOffset :: size :: rest)) =
+      some destOffset := rfl
+
+theorem decodeReturnDataCopyStack?_dataOffset
+    (destOffset dataOffset size : EvmWord) (rest : List EvmWord) :
+    Option.map (fun args => args.dataOffset)
+      (decodeReturnDataCopyStack? (destOffset :: dataOffset :: size :: rest)) =
+      some dataOffset := rfl
+
+theorem decodeReturnDataCopyStack?_size
+    (destOffset dataOffset size : EvmWord) (rest : List EvmWord) :
+    Option.map (fun args => args.size)
+      (decodeReturnDataCopyStack? (destOffset :: dataOffset :: size :: rest)) =
+      some size := rfl
+
+end ReturnDataCopyArgsStackDecode
+
+end EvmAsm.Evm64


### PR DESCRIPTION
Adds a pure top-of-stack decoder for RETURNDATACOPY arguments in EVM order: destOffset, dataOffset, size.\n\nVerification:\n- lake build EvmAsm.Evm64.ReturnData.CopyArgsStackDecode\n- lake build\n- scripts/check-file-size.sh --report\n- git diff --check\n\nRefs evm-asm-b37o.7; GH #107; GH #114.\n\nAuthored by @pirapira; implemented by Codex.