### PR TITLE
chore(shake): drop unused EvmAsm.Evm64.Basic import in Code/Basic.lean

### DIFF
--- a/EvmAsm/Evm64/Code/Basic.lean
+++ b/EvmAsm/Evm64/Code/Basic.lean
@@ -5,8 +5,6 @@
   (GH #107 / GH #118).
 -/
 
-import EvmAsm.Evm64.Basic
-
 namespace EvmAsm.Evm64
 namespace Code
 


### PR DESCRIPTION
Drop the unused `import EvmAsm.Evm64.Basic` from `EvmAsm/Evm64/Code/Basic.lean`. The file only uses `Nat`, `BitVec 8`, and `List` operations — no `EvmAsm.Evm64.*` symbols.

Flagged by `lake exe shake EvmAsm`. `lake build` passes locally.

Refs #1045, beads `evm-asm-xtkwx` (parent `evm-asm-9tq`).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).