### PR TITLE
chore(shake): tighten Lean import in Rv64/Tactics/PerfTrace.lean

### DIFF
--- a/EvmAsm/Rv64/Tactics/PerfTrace.lean
+++ b/EvmAsm/Rv64/Tactics/PerfTrace.lean
@@ -9,7 +9,7 @@
   Use with `set_option trace.profiler true` for wall-clock timing.
 -/
 
-import Lean
+import Lean.Util.Trace
 
 initialize Lean.registerTraceClass `runBlock.perf (inherited := true)
 initialize Lean.registerTraceClass `runBlock.perf.normalize (inherited := true)


### PR DESCRIPTION
Replace blanket `import Lean` with the targeted `import Lean.Util.Trace` in `EvmAsm/Rv64/Tactics/PerfTrace.lean`. The file only uses `Lean.registerTraceClass`, which lives in `Lean.Util.Trace`.

Suggested by `lake exe shake EvmAsm` (filtered) under #1045. Verified with a clean `lake build`.

Refs #1045 / evm-asm-9tq / evm-asm-hzp95.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).