### PR TITLE
feat(calldata): add load stack decoder

### DIFF
--- a/EvmAsm/Evm64.lean
+++ b/EvmAsm/Evm64.lean
@@ -171,6 +171,7 @@ import EvmAsm.Evm64.MLoad
 -- Calldata helpers (issue #104)
 import EvmAsm.Evm64.Calldata.Basic
 import EvmAsm.Evm64.Calldata.LoadArgs
+import EvmAsm.Evm64.Calldata.LoadArgsStackDecode
 import EvmAsm.Evm64.Calldata.Size
 import EvmAsm.Evm64.Calldata.SizeProgram
 import EvmAsm.Evm64.Calldata.SizeSpec

--- a/EvmAsm/Evm64/Calldata/LoadArgsStackDecode.lean
+++ b/EvmAsm/Evm64/Calldata/LoadArgsStackDecode.lean
@@ -1,0 +1,54 @@
+/-
+  EvmAsm.Evm64.Calldata.LoadArgsStackDecode
+
+  Pure top-of-stack decoder for CALLDATALOAD executable-spec bridges
+  (GH #104 / GH #107).
+-/
+
+import EvmAsm.Evm64.Calldata.LoadArgs
+
+namespace EvmAsm.Evm64
+
+namespace CallDataLoadArgsStackDecode
+
+/--
+Decode CALLDATALOAD stack arguments from the top-of-stack list order:
+`offset`.
+
+Distinctive token:
+CallDataLoadArgsStackDecode.decodeCallDataLoadStack? #104 #107.
+-/
+def decodeCallDataLoadStack? : List EvmWord → Option CallDataLoadArgs.Args
+  | offset :: _ => some (CallDataLoadArgs.loadArgs offset)
+  | _ => none
+
+theorem decodeCallDataLoadStack?_cons
+    (offset : EvmWord) (rest : List EvmWord) :
+    decodeCallDataLoadStack? (offset :: rest) =
+      some (CallDataLoadArgs.loadArgs offset) := rfl
+
+theorem decodeCallDataLoadStack?_eq_some_iff
+    {stack : List EvmWord} {args : CallDataLoadArgs.Args} :
+    decodeCallDataLoadStack? stack = some args ↔
+      ∃ offset rest,
+        stack = offset :: rest ∧ args = CallDataLoadArgs.loadArgs offset := by
+  constructor
+  · cases stack with
+    | nil => simp [decodeCallDataLoadStack?]
+    | cons offset rest =>
+      intro h
+      injection h with h_args
+      subst h_args
+      exact ⟨offset, rest, rfl, rfl⟩
+  · rintro ⟨offset, rest, rfl, rfl⟩
+    rfl
+
+theorem decodeCallDataLoadStack?_offset
+    (offset : EvmWord) (rest : List EvmWord) :
+    Option.map (fun args => args.offset)
+      (decodeCallDataLoadStack? (offset :: rest)) =
+      some offset := rfl
+
+end CallDataLoadArgsStackDecode
+
+end EvmAsm.Evm64


### PR DESCRIPTION
Adds a pure top-of-stack decoder for CALLDATALOAD arguments in EVM order: offset.\n\nVerification:\n- lake build EvmAsm.Evm64.Calldata.LoadArgsStackDecode\n- lake build\n- scripts/check-file-size.sh --report\n- git diff --check\n\nRefs evm-asm-xjk8.4; GH #104; GH #107.\n\nAuthored by @pirapira; implemented by Codex.