### PR TITLE
chore(shake): noshake EntryAddrBridge + Code/ReturnData CopyMemory

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -260,6 +260,9 @@
  "EvmAsm.Evm64.Push.Spec":
   ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.RunBlock", "EvmAsm.Rv64.Tactics.XSimp"],
  "EvmAsm.Evm64.Calldata.CopyMemory": ["Mathlib.Data.List.GetD"],
+ "EvmAsm.Evm64.Code.CopyMemory": ["Mathlib.Data.List.GetD"],
+ "EvmAsm.Evm64.ReturnData.CopyMemory": ["Mathlib.Data.List.GetD"],
+ "EvmAsm.Evm64.Dispatch.EntryAddrBridge": ["EvmAsm.Rv64.Program"],
  "EvmAsm.Evm64.EvmWordArith.DivAddbackCarry": ["EvmAsm.Evm64.EvmWordArith.DivAddbackLimb"],
  "EvmAsm.Evm64.EvmWordArith.DivAddbackLimb": ["EvmAsm.Evm64.EvmWordArith.DivMulSubLimb"],
  "EvmAsm.Evm64.EvmWordArith.DivRemainderBound": ["EvmAsm.Evm64.EvmWordArith.DivAddbackLimb"],


### PR DESCRIPTION
Three remaining shake suggestions are notation/lemma-reference false positives:

- `EvmAsm.Evm64.Dispatch.EntryAddrBridge` uses the `Word` notation (= `BitVec 64`) declared in `EvmAsm.Rv64.Basic`; shake does not track notation references. The import goes via `EvmAsm.Rv64.Program` (which transitively imports `Rv64.Basic`), so we list `Rv64.Program` in noshake.
- `EvmAsm.Evm64.Code.CopyMemory` and `EvmAsm.Evm64.ReturnData.CopyMemory` both use `List.getD_eq_getElem` from `Mathlib.Data.List.GetD`, the same pattern already whitelisted for `EvmAsm.Evm64.Calldata.CopyMemory`.

After this patch, `lake exe shake EvmAsm 2>/dev/null | scripts/shake-filter.py` reports `1 block(s) kept, 112 dropped` (down from 4 kept) — the only surviving suggestion is the `EvmAsm.Evm64.Code.Basic` drop already claimed by in-progress slice `evm-asm-xtkwx`.

Refs GH #1045, beads `evm-asm-nirf4` (parent `evm-asm-9tq`).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).
