### PR TITLE
feat(calldata): add stack conformance bridge

### DIFF
--- a/EvmAsm/EL/Conformance/Calldata.lean
+++ b/EvmAsm/EL/Conformance/Calldata.lean
@@ -8,6 +8,7 @@
 import EvmAsm.EL.Conformance
 import EvmAsm.Evm64.Calldata.Basic
 import EvmAsm.Evm64.Calldata.Size
+import EvmAsm.Evm64.Calldata.LoadArgsStackDecode
 
 namespace EvmAsm.EL
 namespace Conformance
@@ -19,6 +20,12 @@ abbrev EvmWord := EvmAsm.Evm64.EvmWord
 structure CallDataLoadInput where
   data : List (BitVec 8)
   offset : Nat
+  deriving Repr
+
+/-- Input shape for a CALLDATALOAD stack-decoder conformance vector. -/
+structure CallDataLoadStackInput where
+  data : List (BitVec 8)
+  stack : List EvmWord
   deriving Repr
 
 /-- Input shape for a CALLDATASIZE executable-helper conformance vector. -/
@@ -36,6 +43,11 @@ structure CallDataCopyInput where
 def runCallDataLoad (input : CallDataLoadInput) : EvmWord :=
   EvmAsm.Evm64.Calldata.callDataLoadWord input.data input.offset
 
+def runCallDataLoadStack? (input : CallDataLoadStackInput) :
+    Option EvmWord :=
+  EvmAsm.Evm64.CallDataLoadArgsStackDecode.decodeCallDataLoadStack? input.stack
+    |>.map (EvmAsm.Evm64.CallDataLoadArgs.loadedWordFromArgs input.data)
+
 def runCallDataSize (input : CallDataSizeInput) : EvmWord :=
   EvmAsm.Evm64.Calldata.callDataSizeOf input.data
 
@@ -49,6 +61,20 @@ def callDataLoadOutOfBoundsVector : TestVector CallDataLoadInput EvmWord :=
   { id := "calldataload-oob-zero"
     input := { data := [(0x12 : BitVec 8)], offset := 1 }
     expected := .value 0 }
+
+/-- Stack-decoded CALLDATALOAD uses the top EVM stack word as its calldata
+    byte offset. Distinctive token: runCallDataLoadStack? #104 #125. -/
+def callDataLoadStackVector : TestVector CallDataLoadStackInput EvmWord :=
+  { id := "calldataload-stack-decode"
+    input := { data := [(0x12 : BitVec 8)], stack := [(1 : EvmWord), 0] }
+    expected := .value 0 }
+
+/-- CALLDATALOAD stack decoding fails when the input stack is empty. -/
+def callDataLoadStackUnderflowVector :
+    TestVector CallDataLoadStackInput EvmWord :=
+  { id := "calldataload-stack-underflow"
+    input := { data := [(0x12 : BitVec 8)], stack := [] }
+    expected := .error "stack-underflow" }
 
 /-- CALLDATASIZE pushes the byte length of calldata as an EVM word. -/
 def callDataSizeTwoBytesVector : TestVector CallDataSizeInput EvmWord :=
@@ -68,6 +94,22 @@ theorem runCallDataLoad_outOfBounds :
     runCallDataLoad { data := [(0x12 : BitVec 8)], offset := 1 } = 0 := by
   exact EvmAsm.Evm64.Calldata.callDataLoadWord_of_ge_length (by decide)
 
+theorem runCallDataLoadStack_decoded :
+    runCallDataLoadStack?
+      { data := [(0x12 : BitVec 8)], stack := [(1 : EvmWord), 0] } =
+      some 0 := by
+  unfold runCallDataLoadStack?
+  rw [EvmAsm.Evm64.CallDataLoadArgsStackDecode.decodeCallDataLoadStack?_cons]
+  simp [EvmAsm.Evm64.CallDataLoadArgs.loadedWordFromArgs,
+    EvmAsm.Evm64.CallDataLoadArgs.loadArgs,
+    EvmAsm.Evm64.CallDataLoadArgs.offsetNat]
+  exact EvmAsm.Evm64.Calldata.callDataLoadWord_of_ge_length
+    (data := [(0x12 : BitVec 8)]) (offset := 1) (by decide)
+
+theorem runCallDataLoadStack_underflow :
+    runCallDataLoadStack?
+      { data := [(0x12 : BitVec 8)], stack := [] } = none := rfl
+
 theorem runCallDataSize_twoBytes :
     runCallDataSize { data := [(0xaa : BitVec 8), (0xbb : BitVec 8)] } =
       (2 : EvmWord) := rfl
@@ -84,6 +126,23 @@ theorem callDataLoadOutOfBoundsVector_passed :
     { data := [(0x12 : BitVec 8)], offset := 1 }
     (0 : EvmWord)
     runCallDataLoad_outOfBounds
+
+theorem callDataLoadStackVector_passed :
+    checkVector? runCallDataLoadStack? callDataLoadStackVector = .passed :=
+  checkVector?_some_passed runCallDataLoadStack?
+    "calldataload-stack-decode"
+    { data := [(0x12 : BitVec 8)], stack := [(1 : EvmWord), 0] }
+    (0 : EvmWord)
+    runCallDataLoadStack_decoded
+
+theorem callDataLoadStackUnderflowVector_errored :
+    checkVector? runCallDataLoadStack? callDataLoadStackUnderflowVector =
+      .errored "calldataload-stack-underflow" "stack-underflow" :=
+  checkVector?_none_error runCallDataLoadStack?
+    "calldataload-stack-underflow"
+    "stack-underflow"
+    { data := [(0x12 : BitVec 8)], stack := [] }
+    runCallDataLoadStack_underflow
 
 theorem callDataSizeTwoBytesVector_passed :
     checkVector runCallDataSize callDataSizeTwoBytesVector = .passed :=
@@ -105,13 +164,18 @@ theorem callDataCopyZeroPadVector_passed :
     Distinctive token: calldataConformanceVectors. -/
 def calldataConformanceVectors : List CheckResult :=
   [ checkVector runCallDataLoad callDataLoadOutOfBoundsVector
+  , checkVector? runCallDataLoadStack? callDataLoadStackVector
+  , checkVector? runCallDataLoadStack? callDataLoadStackUnderflowVector
   , checkVector runCallDataSize callDataSizeTwoBytesVector
   , checkVector runCallDataCopy callDataCopyZeroPadVector
   ]
 
 theorem calldataConformanceVectors_passed :
-    calldataConformanceVectors = [.passed, .passed, .passed] := by
+    calldataConformanceVectors =
+      [.passed, .passed, .errored "calldataload-stack-underflow" "stack-underflow",
+        .passed, .passed] := by
   simp [calldataConformanceVectors, callDataLoadOutOfBoundsVector_passed,
+    callDataLoadStackVector_passed, callDataLoadStackUnderflowVector_errored,
     callDataSizeTwoBytesVector_passed, callDataCopyZeroPadVector_passed]
 
 end Calldata


### PR DESCRIPTION
Extends calldata conformance coverage with a partial CALLDATALOAD stack-decoder bridge. The new runner decodes stack arguments through CallDataLoadArgsStackDecode.decodeCallDataLoadStack? and evaluates CallDataLoadArgs.loadedWordFromArgs, with checked success and stack-underflow vectors.

Refs evm-asm-tguk5, GH #104, and GH #125.

Local verification:
- lake build EvmAsm.EL.Conformance.Calldata
- lake build
- scripts/check-file-size.sh --report
- git diff --check
- forbidden proof-option/sorry scan on EvmAsm/EL/Conformance/Calldata.lean

Authored by @pirapira; implemented by Codex.