### PR TITLE
feat(returndata): add copy stack conformance bridge

### DIFF
--- a/EvmAsm/EL/Conformance/ReturnData.lean
+++ b/EvmAsm/EL/Conformance/ReturnData.lean
@@ -7,6 +7,7 @@
 
 import EvmAsm.EL.Conformance
 import EvmAsm.Evm64.ReturnData.CopyExec
+import EvmAsm.Evm64.ReturnData.CopyArgsStackDecode
 
 namespace EvmAsm.EL
 namespace Conformance
@@ -22,11 +23,22 @@ structure ReturnDataCopyInput where
   size : EvmWord
   deriving Repr
 
+/-- Input shape for a RETURNDATACOPY stack-decoder conformance vector. -/
+structure ReturnDataCopyStackInput where
+  data : List (BitVec 8)
+  stack : List EvmWord
+  deriving Repr
+
 def runReturnDataCopy (input : ReturnDataCopyInput) : List (BitVec 8) :=
   EvmAsm.Evm64.ReturnDataCopyExec.copiedBytesFromArgs
     input.data
     (EvmAsm.Evm64.ReturnDataCopyArgs.copyArgs
       input.destOffset input.dataOffset input.size)
+
+def runReturnDataCopyStack? (input : ReturnDataCopyStackInput) :
+    Option (List (BitVec 8)) :=
+  EvmAsm.Evm64.ReturnDataCopyArgsStackDecode.decodeReturnDataCopyStack? input.stack
+    |>.map (EvmAsm.Evm64.ReturnDataCopyExec.copiedBytesFromArgs input.data)
 
 /-- RETURNDATACOPY zero-pads bytes copied past the end of returndata.
     Distinctive token: returnDataCopyZeroPadVector #125 #114. -/
@@ -40,6 +52,27 @@ def returnDataCopyZeroPadVector :
         size := 4 }
     expected := .value [(0xbb : BitVec 8), 0, 0, 0] }
 
+/-- Stack-decoded RETURNDATACOPY uses stack words as
+    `destOffset, dataOffset, size`; the executable helper here returns only
+    the copied byte sequence. Distinctive token: runReturnDataCopyStack?
+    #107 #114 #125. -/
+def returnDataCopyStackVector :
+    TestVector ReturnDataCopyStackInput (List (BitVec 8)) :=
+  { id := "returndatacopy-stack-decode"
+    input :=
+      { data := [(0xaa : BitVec 8), (0xbb : BitVec 8)]
+        stack := [(32 : EvmWord), (1 : EvmWord), (4 : EvmWord)] }
+    expected := .value [(0xbb : BitVec 8), 0, 0, 0] }
+
+/-- RETURNDATACOPY stack decoding fails unless all three stack operands exist. -/
+def returnDataCopyStackUnderflowVector :
+    TestVector ReturnDataCopyStackInput (List (BitVec 8)) :=
+  { id := "returndatacopy-stack-underflow"
+    input :=
+      { data := [(0xaa : BitVec 8), (0xbb : BitVec 8)]
+        stack := [(32 : EvmWord), (1 : EvmWord)] }
+    expected := .error "stack-underflow" }
+
 theorem runReturnDataCopy_zeroPad :
     runReturnDataCopy
       { data := [(0xaa : BitVec 8), (0xbb : BitVec 8)]
@@ -47,6 +80,17 @@ theorem runReturnDataCopy_zeroPad :
         dataOffset := 1
         size := 4 } =
       [(0xbb : BitVec 8), 0, 0, 0] := rfl
+
+theorem runReturnDataCopyStack_decoded :
+    runReturnDataCopyStack?
+      { data := [(0xaa : BitVec 8), (0xbb : BitVec 8)]
+        stack := [(32 : EvmWord), (1 : EvmWord), (4 : EvmWord)] } =
+      some [(0xbb : BitVec 8), 0, 0, 0] := rfl
+
+theorem runReturnDataCopyStack_underflow :
+    runReturnDataCopyStack?
+      { data := [(0xaa : BitVec 8), (0xbb : BitVec 8)]
+        stack := [(32 : EvmWord), (1 : EvmWord)] } = none := rfl
 
 theorem returnDataCopyZeroPadVector_passed :
     checkVector runReturnDataCopy returnDataCopyZeroPadVector = .passed :=
@@ -59,14 +103,40 @@ theorem returnDataCopyZeroPadVector_passed :
     [(0xbb : BitVec 8), 0, 0, 0]
     runReturnDataCopy_zeroPad
 
+theorem returnDataCopyStackVector_passed :
+    checkVector? runReturnDataCopyStack? returnDataCopyStackVector = .passed :=
+  checkVector?_some_passed runReturnDataCopyStack?
+    "returndatacopy-stack-decode"
+    { data := [(0xaa : BitVec 8), (0xbb : BitVec 8)]
+      stack := [(32 : EvmWord), (1 : EvmWord), (4 : EvmWord)] }
+    [(0xbb : BitVec 8), 0, 0, 0]
+    runReturnDataCopyStack_decoded
+
+theorem returnDataCopyStackUnderflowVector_errored :
+    checkVector? runReturnDataCopyStack? returnDataCopyStackUnderflowVector =
+      .errored "returndatacopy-stack-underflow" "stack-underflow" :=
+  checkVector?_none_error runReturnDataCopyStack?
+    "returndatacopy-stack-underflow"
+    "stack-underflow"
+    { data := [(0xaa : BitVec 8), (0xbb : BitVec 8)]
+      stack := [(32 : EvmWord), (1 : EvmWord)] }
+    runReturnDataCopyStack_underflow
+
 /-- Compact checked-vector batch for returndata executable helpers.
     Distinctive token: returnDataConformanceVectors #125 #114. -/
 def returnDataConformanceVectors : List CheckResult :=
-  [checkVector runReturnDataCopy returnDataCopyZeroPadVector]
+  [ checkVector runReturnDataCopy returnDataCopyZeroPadVector
+  , checkVector? runReturnDataCopyStack? returnDataCopyStackVector
+  , checkVector? runReturnDataCopyStack? returnDataCopyStackUnderflowVector
+  ]
 
 theorem returnDataConformanceVectors_passed :
-    returnDataConformanceVectors = [.passed] := by
+    returnDataConformanceVectors =
+      [.passed, .passed,
+        .errored "returndatacopy-stack-underflow" "stack-underflow"] := by
   simp [returnDataConformanceVectors, returnDataCopyZeroPadVector_passed]
+  exact ⟨returnDataCopyStackVector_passed,
+    returnDataCopyStackUnderflowVector_errored⟩
 
 end ReturnData
 end Conformance


### PR DESCRIPTION
Extends RETURNDATACOPY conformance coverage with a partial stack-decoder bridge. The new runner decodes stack arguments through ReturnDataCopyArgsStackDecode.decodeReturnDataCopyStack? and evaluates ReturnDataCopyExec.copiedBytesFromArgs, with checked success and stack-underflow vectors.

Refs evm-asm-bfbwf, GH #107, GH #114, and GH #125.

Local verification:
- lake build EvmAsm.EL.Conformance.ReturnData
- lake build
- scripts/check-file-size.sh --report
- git diff --check
- forbidden proof-option/sorry scan on EvmAsm/EL/Conformance/ReturnData.lean

Authored by @pirapira; implemented by Codex.