### PR TITLE
feat(interpreter): add supported loop bridge

### DIFF
--- a/EvmAsm/Evm64.lean
+++ b/EvmAsm/Evm64.lean
@@ -135,6 +135,7 @@ import EvmAsm.Evm64.BitwiseHandlers
 import EvmAsm.Evm64.ArithmeticHandlers
 import EvmAsm.Evm64.SupportedHandlers
 import EvmAsm.Evm64.SupportedHandlerByte
+import EvmAsm.Evm64.SupportedLoopBridge
 import EvmAsm.Evm64.InterpreterFetchProgram
 import EvmAsm.Evm64.HandlerLoopBridge
 import EvmAsm.Evm64.TerminatingLoopBridge

--- a/EvmAsm/Evm64/SupportedLoopBridge.lean
+++ b/EvmAsm/Evm64/SupportedLoopBridge.lean
@@ -1,0 +1,85 @@
+/-
+  EvmAsm.Evm64.SupportedLoopBridge
+
+  Concrete adapter from the supported pure handler table to the interpreter
+  loop (GH #107 / GH #108).
+-/
+
+import EvmAsm.Evm64.HandlerLoopBridge
+import EvmAsm.Evm64.SupportedHandlers
+
+namespace EvmAsm.Evm64
+
+namespace SupportedLoopBridge
+
+/--
+Interpreter-loop handler backed by every pure opcode handler currently wired
+into `SupportedHandlers.supportedHandlerTable`.
+
+Distinctive token: SupportedLoopBridge.supportedLoopHandler #107 #108.
+-/
+def supportedLoopHandler : InterpreterLoop.Handler :=
+  HandlerLoopBridge.toLoopHandler SupportedHandlers.supportedHandlerTable
+
+@[simp] theorem supportedLoopHandler_apply
+    (opcode : EvmOpcode) (state : EvmState) :
+    supportedLoopHandler opcode state =
+      HandlerTable.dispatchOpcode SupportedHandlers.supportedHandlerTable opcode state := rfl
+
+theorem stepWithSupportedHandler_of_decode
+    {state : EvmState} {opcode : EvmOpcode}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some opcode) :
+    InterpreterLoop.stepWithHandler supportedLoopHandler state =
+      HandlerTable.dispatchOpcode SupportedHandlers.supportedHandlerTable opcode state := by
+  exact HandlerLoopBridge.stepWithTableHandler_of_decode
+    SupportedHandlers.supportedHandlerTable h_decode
+
+theorem stepWithSupportedHandler_of_lookup
+    {state : EvmState} {opcode : EvmOpcode} {handler : OpcodeHandler}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some opcode)
+    (h_lookup : SupportedHandlers.supportedHandlerTable opcode = some handler) :
+    InterpreterLoop.stepWithHandler supportedLoopHandler state = handler state := by
+  rw [stepWithSupportedHandler_of_decode h_decode]
+  exact SupportedHandlers.dispatchOpcode_of_lookup h_lookup state
+
+theorem stepWithSupportedHandler_missing_invalid
+    {state : EvmState} {opcode : EvmOpcode}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some opcode)
+    (h_lookup : SupportedHandlers.supportedHandlerTable opcode = none) :
+    InterpreterLoop.stepWithHandler supportedLoopHandler state = state.invalid := by
+  exact HandlerLoopBridge.stepWithTableHandler_missing_invalid h_decode h_lookup
+
+theorem loopFuel_supported_succ_running_decode
+    (nSteps : Nat) {state : EvmState} {opcode : EvmOpcode}
+    (h_status : state.status = .running)
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some opcode) :
+    InterpreterLoop.loopFuel supportedLoopHandler (nSteps + 1) state =
+      InterpreterLoop.loopFuel supportedLoopHandler nSteps
+        (HandlerTable.dispatchOpcode SupportedHandlers.supportedHandlerTable opcode state) := by
+  exact HandlerLoopBridge.loopFuel_succ_running_decode
+    SupportedHandlers.supportedHandlerTable nSteps h_status h_decode
+
+theorem loopFuel_supported_succ_running_lookup
+    (nSteps : Nat) {state : EvmState} {opcode : EvmOpcode} {handler : OpcodeHandler}
+    (h_status : state.status = .running)
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some opcode)
+    (h_lookup : SupportedHandlers.supportedHandlerTable opcode = some handler) :
+    InterpreterLoop.loopFuel supportedLoopHandler (nSteps + 1) state =
+      InterpreterLoop.loopFuel supportedLoopHandler nSteps (handler state) := by
+  rw [loopFuel_supported_succ_running_decode nSteps h_status h_decode]
+  rw [SupportedHandlers.dispatchOpcode_of_lookup h_lookup state]
+
+theorem loopFuel_supported_missing_invalid
+    (nSteps : Nat) {state : EvmState} {opcode : EvmOpcode}
+    (h_status : state.status = .running)
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some opcode)
+    (h_lookup : SupportedHandlers.supportedHandlerTable opcode = none) :
+    InterpreterLoop.loopFuel supportedLoopHandler (nSteps + 1) state =
+      InterpreterLoop.loopFuel supportedLoopHandler nSteps state.invalid := by
+  rw [loopFuel_supported_succ_running_decode nSteps h_status h_decode]
+  exact congrArg (InterpreterLoop.loopFuel supportedLoopHandler nSteps)
+    (HandlerTable.dispatchOpcode_none h_lookup state)
+
+end SupportedLoopBridge
+
+end EvmAsm.Evm64


### PR DESCRIPTION
Adds a concrete #107/#108 bridge from SupportedHandlers.supportedHandlerTable into the pure InterpreterLoop handler surface.\n\nBead: evm-asm-wyecb\nRefs: GH #107, GH #108\n\nLocal verification:\n- lake build EvmAsm.Evm64.SupportedLoopBridge\n- lake build\n- scripts/check-file-size.sh --report\n- git diff --check\n- forbidden proof-option/sorry scan on touched files\n\nAuthored by @pirapira; implemented by Codex.