### PR TITLE
shake: drop unused KeccakStackBridge import in KeccakStackExecutionBridge.lean

### DIFF
--- a/EvmAsm/EL/KeccakStackExecutionBridge.lean
+++ b/EvmAsm/EL/KeccakStackExecutionBridge.lean
@@ -6,7 +6,6 @@
 
 import EvmAsm.Evm64.KeccakArgsStackDecode
 import EvmAsm.EL.KeccakEcallBridge
-import EvmAsm.EL.KeccakStackBridge
 
 namespace EvmAsm.EL
 


### PR DESCRIPTION
Identified by `lake exe shake EvmAsm` (pure-remove suggestion, no add).

`EvmAsm/EL/KeccakStackExecutionBridge.lean` imports `EvmAsm.EL.KeccakStackBridge` but does not reference any declaration from it (verified by grep — no `KeccakStackBridge` namespace use, no `keccakStackResult*` references). Drop the import.

`lake build` green. `lake exe shake EvmAsm` no longer flags this file.

Refs: GH #1045 (parent bead evm-asm-9tq), bead evm-asm-0bb6v.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).