### PR TITLE
feat(exp): add stack execution bridge

### DIFF
--- a/EvmAsm/Evm64/Exp.lean
+++ b/EvmAsm/Evm64/Exp.lean
@@ -14,7 +14,9 @@ import EvmAsm.Evm64.Exp.AddrNormAttr
 import EvmAsm.Evm64.Exp.Program
 import EvmAsm.Evm64.Exp.Gas
 import EvmAsm.Evm64.Exp.Args
+import EvmAsm.Evm64.Exp.ArgsStackDecode
 import EvmAsm.Evm64.Exp.LimbSpec
 import EvmAsm.Evm64.Exp.AddrNorm
 import EvmAsm.Evm64.Exp.Compose.Base
 import EvmAsm.Evm64.Exp.Spec
+import EvmAsm.Evm64.Exp.StackExecutionBridge

--- a/EvmAsm/Evm64/Exp/ArgsStackDecode.lean
+++ b/EvmAsm/Evm64/Exp/ArgsStackDecode.lean
@@ -1,0 +1,62 @@
+/-
+  EvmAsm.Evm64.Exp.ArgsStackDecode
+
+  Pure top-of-stack decoder for EXP executable-spec bridges (GH #92).
+-/
+
+import EvmAsm.Evm64.Exp.Args
+
+namespace EvmAsm.Evm64
+
+namespace ExpArgsStackDecode
+
+/--
+Decode EXP stack arguments from the top-of-stack list order:
+`base, exponent`.
+
+Distinctive token: ExpArgsStackDecode.decodeExpStack? #92.
+-/
+def decodeExpStack? : List EvmWord → Option ExpArgs.Args
+  | base :: exponent :: _ => some (ExpArgs.expArgs base exponent)
+  | _ => none
+
+theorem decodeExpStack?_cons
+    (base exponent : EvmWord) (rest : List EvmWord) :
+    decodeExpStack? (base :: exponent :: rest) =
+      some (ExpArgs.expArgs base exponent) := rfl
+
+theorem decodeExpStack?_eq_some_iff
+    {stack : List EvmWord} {args : ExpArgs.Args} :
+    decodeExpStack? stack = some args ↔
+      ∃ base exponent rest,
+        stack = base :: exponent :: rest ∧
+          args = ExpArgs.expArgs base exponent := by
+  constructor
+  · cases stack with
+    | nil => simp [decodeExpStack?]
+    | cons base s1 =>
+      cases s1 with
+      | nil => simp [decodeExpStack?]
+      | cons exponent rest =>
+        intro h
+        injection h with h_args
+        subst h_args
+        exact ⟨base, exponent, rest, rfl, rfl⟩
+  · rintro ⟨base, exponent, rest, rfl, rfl⟩
+    rfl
+
+theorem decodeExpStack?_base
+    (base exponent : EvmWord) (rest : List EvmWord) :
+    Option.map (fun args => args.base)
+      (decodeExpStack? (base :: exponent :: rest)) =
+      some base := rfl
+
+theorem decodeExpStack?_exponent
+    (base exponent : EvmWord) (rest : List EvmWord) :
+    Option.map (fun args => args.exponent)
+      (decodeExpStack? (base :: exponent :: rest)) =
+      some exponent := rfl
+
+end ExpArgsStackDecode
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
+++ b/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
@@ -1,0 +1,112 @@
+/-
+  EvmAsm.Evm64.Exp.StackExecutionBridge
+
+  Pure stack-execution bridge for EXP (GH #92).
+-/
+
+import EvmAsm.Evm64.Exp.ArgsStackDecode
+
+namespace EvmAsm.Evm64
+
+namespace ExpStackExecutionBridge
+
+/-- Caller-visible effects of EXP at the executable-spec layer. -/
+structure ExpVisibleEffects where
+  stackWords : List EvmWord
+  dynamicGas : Nat
+  totalGas : Nat
+  deriving Repr
+
+structure ExpStackState where
+  stack : List EvmWord
+  deriving Repr
+
+structure ExpStackResult where
+  effects : ExpVisibleEffects
+  stack : List EvmWord
+  deriving Repr
+
+def argumentCount : Nat := ExpArgs.stackArgumentCount
+
+def resultCount : Nat := ExpArgs.resultCount
+
+def stackRestAfterExp? : List EvmWord → Option (List EvmWord)
+  | _base :: _exponent :: rest => some rest
+  | _ => none
+
+/--
+Execute the EXP stack transition using the pure EXP argument decoder and
+the existing word-level EXP result/gas bridge.
+
+Distinctive token: ExpStackExecutionBridge.runExpStack? #92.
+-/
+def runExpStack? (state : ExpStackState) : Option ExpStackResult := do
+  let args ← ExpArgsStackDecode.decodeExpStack? state.stack
+  let rest ← stackRestAfterExp? state.stack
+  some
+    { effects :=
+        { stackWords := [ExpArgs.expResultFromArgs args]
+          dynamicGas := ExpArgs.expDynamicCostFromArgs args
+          totalGas := ExpArgs.expTotalGasFromArgs args }
+      stack := rest }
+
+theorem stackRestAfterExp?_cons
+    (base exponent : EvmWord) (rest : List EvmWord) :
+    stackRestAfterExp? (base :: exponent :: rest) = some rest := rfl
+
+theorem runExpStack?_cons
+    (base exponent : EvmWord) (rest : List EvmWord) :
+    runExpStack? { stack := base :: exponent :: rest } =
+      some
+        { effects :=
+            { stackWords := [ExpArgs.expResultFromArgs
+                (ExpArgs.expArgs base exponent)]
+              dynamicGas := ExpArgs.expDynamicCostFromArgs
+                (ExpArgs.expArgs base exponent)
+              totalGas := ExpArgs.expTotalGasFromArgs
+                (ExpArgs.expArgs base exponent) }
+          stack := rest } := rfl
+
+theorem runExpStack?_underflow_nil :
+    runExpStack? { stack := [] } = none := rfl
+
+theorem runExpStack?_underflow_one (base : EvmWord) :
+    runExpStack? { stack := [base] } = none := rfl
+
+theorem runExpStack?_stack_length
+    {state : ExpStackState} {out : ExpStackResult}
+    (h_run : runExpStack? state = some out) :
+    out.stack.length + out.effects.stackWords.length + argumentCount =
+      state.stack.length + resultCount := by
+  cases state with
+  | mk stack =>
+      cases stack with
+      | nil =>
+          simp [runExpStack?, ExpArgsStackDecode.decodeExpStack?] at h_run
+      | cons base tail =>
+          cases tail with
+          | nil => simp [runExpStack?, stackRestAfterExp?] at h_run
+          | cons exponent rest =>
+              simp [runExpStack?, stackRestAfterExp?] at h_run
+              cases h_run
+              simp [argumentCount, resultCount, ExpArgs.stackArgumentCount,
+                ExpArgs.resultCount]
+
+theorem runExpStack?_head?
+    (base exponent : EvmWord) (rest : List EvmWord) :
+    (runExpStack? { stack := base :: exponent :: rest }).map
+      (fun out => out.effects.stackWords.head?) =
+      some (some (ExpArgs.expResultFromArgs
+        (ExpArgs.expArgs base exponent))) := rfl
+
+theorem runExpStack?_gas
+    (base exponent : EvmWord) (rest : List EvmWord) :
+    (runExpStack? { stack := base :: exponent :: rest }).map
+      (fun out => (out.effects.dynamicGas, out.effects.totalGas)) =
+      some
+        ( ExpArgs.expDynamicCostFromArgs (ExpArgs.expArgs base exponent)
+        , ExpArgs.expTotalGasFromArgs (ExpArgs.expArgs base exponent)) := rfl
+
+end ExpStackExecutionBridge
+
+end EvmAsm.Evm64


### PR DESCRIPTION
Refs evm-asm-xwkfv and GH #92.

Adds pure EXP stack argument decoding and a stack execution bridge that exposes the result word plus dynamic and total gas computed from the decoded exponent.

Local checks:
- lake build EvmAsm.Evm64.Exp.StackExecutionBridge
- lake build
- scripts/check-file-size.sh --report
- git diff --check

Authored by @pirapira; implemented by Codex.