### PR TITLE
chore: noshake 6 false-positive shake drop-only suggestions

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -309,4 +309,23 @@
 "EvmAsm.Evm64.ExecutableSpecOpcodeBridge": ["Mathlib.Tactic.IntervalCases"],
 "EvmAsm.Evm64.InterpreterExecutableStepBridge": ["EvmAsm.Evm64.InterpreterExecutableFetchBridge"],
 "EvmAsm.EL.RLP.ListDecodeBridge": ["EvmAsm.EL.RLP.PrefixDecode"],
-"EvmAsm.EL.CallOutputMemory": ["Mathlib.Data.List.GetD"]}}
+"EvmAsm.EL.CallOutputMemory": ["Mathlib.Data.List.GetD"],
+"EvmAsm.Evm64.Dispatch.Compose": ["EvmAsm.Evm64.Dispatch.EntryAddrBridge"],
+"EvmAsm.Evm64.DivMod.Compose.FullPath":
+ ["EvmAsm.Evm64.DivMod.Compose.PhaseAB", "EvmAsm.Evm64.DivMod.Compose.Norm",
+  "EvmAsm.Evm64.DivMod.Compose.NormA", "EvmAsm.Evm64.DivMod.Compose.Epilogue",
+  "EvmAsm.Evm64.DivMod.Compose.ModEpilogue"],
+"EvmAsm.Evm64.DivMod.Compose.FullPathN1":
+ ["EvmAsm.Evm64.DivMod.Compose.PhaseAB", "EvmAsm.Evm64.DivMod.Compose.Norm",
+  "EvmAsm.Evm64.DivMod.Compose.NormA"],
+"EvmAsm.Evm64.DivMod.Compose.FullPathN2":
+ ["EvmAsm.Evm64.DivMod.Compose.PhaseAB", "EvmAsm.Evm64.DivMod.Compose.Norm",
+  "EvmAsm.Evm64.DivMod.Compose.NormA"],
+"EvmAsm.Evm64.DivMod.Compose.FullPathN3":
+ ["EvmAsm.Evm64.DivMod.Compose.PhaseAB", "EvmAsm.Evm64.DivMod.Compose.Norm",
+  "EvmAsm.Evm64.DivMod.Compose.NormA"],
+"EvmAsm.Evm64.DivMod.Spec.CallSkip":
+ ["EvmAsm.Evm64.EvmWordArith.Div128Shift0",
+  "EvmAsm.Evm64.EvmWordArith.AddbackBorrowExtract",
+  "EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV2",
+  "EvmAsm.Evm64.DivMod.Spec.CallSkipOverestimateBridge"]}}


### PR DESCRIPTION
Six drop-only `lake exe shake` suggestions are false positives — each deletion produces 'Unknown identifier' errors when attempted. Add explicit `scripts/noshake.json` entries so they don't recur:

- `EvmAsm.Evm64.Dispatch.Compose` keeps `Dispatch.EntryAddrBridge` (uses `entry_addr_bridge_fin`)
- `EvmAsm.Evm64.DivMod.Compose.FullPath{,N1,N2,N3}` keep `Compose.PhaseAB` / `Compose.Norm` / `Compose.NormA` (use `evm_div_phaseAB_n4_spec_within` / `evm_div_phaseA_ntaken_spec_within`); `FullPath` also keeps `Compose.Epilogue` and `Compose.ModEpilogue`
- `EvmAsm.Evm64.DivMod.Spec.CallSkip` keeps `EvmWordArith.Div128Shift0` / `EvmWordArith.AddbackBorrowExtract` / `EvmWordArith.CallSkipLowerBoundV2` / `Spec.CallSkipOverestimateBridge` (uses `div128Quot_call_skip_ge_val256_div_v2`, `div128Quot_call_skip_mul_val256_b_le_val256_a`)

Verified locally: `lake exe shake EvmAsm` no longer flags any of the six files; `lake build` succeeds.

Refs #1045 (parent `evm-asm-6qj`), bead `evm-asm-oths0`.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).