### PR TITLE
feat(interpreter): add terminating executable opcode bridge

### DIFF
--- a/EvmAsm/Evm64/ExecutableSpecOpcodeBridge.lean
+++ b/EvmAsm/Evm64/ExecutableSpecOpcodeBridge.lean
@@ -7,6 +7,7 @@
 -/
 
 import EvmAsm.Evm64.Dispatch
+import EvmAsm.Evm64.TerminatingArgs
 import Mathlib.Tactic.IntervalCases
 
 namespace EvmAsm.Evm64
@@ -41,6 +42,22 @@ def execSpecPushByte (n : Nat) : Nat :=
 def execSpecLogByte (kind : LogArgs.Kind) : Nat :=
   0xa0 + LogArgs.topicCount kind
 
+/-- EVM opcode represented by a frame-terminating opcode classifier. -/
+def opcodeOfTerminatingKind : TerminatingArgs.Kind → EvmOpcode
+  | .stop => .STOP
+  | .return_ => .RETURN
+  | .revert => .REVERT
+  | .invalid => .INVALID
+  | .selfdestruct => .SELFDESTRUCT
+
+/-- Executable-spec byte for a frame-terminating opcode classifier. -/
+def execSpecTerminatingByte : TerminatingArgs.Kind → Nat
+  | .stop => Ops.STOP
+  | .return_ => Ops.RETURN
+  | .revert => Ops.REVERT
+  | .invalid => Ops.INVALID
+  | .selfdestruct => Ops.SELFDESTRUCT
+
 theorem decode_execSpecPushByte_of_valid
     {n : Nat} (h_low : 1 ≤ n) (h_high : n ≤ 32) :
     EvmOpcode.decodeByte? (execSpecPushByte n) = some (EvmOpcode.PUSH n) := by
@@ -72,6 +89,20 @@ theorem roundtrip_execSpecLog (kind : LogArgs.Kind) :
     EvmOpcode.byte? (EvmOpcode.LOG kind) = some (execSpecLogByte kind) ∧
       EvmOpcode.decodeByte? (execSpecLogByte kind) = some (EvmOpcode.LOG kind) :=
   ⟨byte?_execSpecLog kind, decode_execSpecLogByte kind⟩
+
+/--
+Executable-spec roundtrip for STOP, RETURN, REVERT, INVALID, and
+SELFDESTRUCT as one opcode family.
+
+Distinctive token:
+ExecutableSpecOpcodeBridge.roundtrip_execSpecTerminatingKind #109 #113.
+-/
+theorem roundtrip_execSpecTerminatingKind (kind : TerminatingArgs.Kind) :
+    EvmOpcode.byte? (opcodeOfTerminatingKind kind) =
+        some (execSpecTerminatingByte kind) ∧
+      EvmOpcode.decodeByte? (execSpecTerminatingByte kind) =
+        some (opcodeOfTerminatingKind kind) := by
+  cases kind <;> exact ⟨rfl, rfl⟩
 
 theorem roundtrip_execSpec_STOP :
     EvmOpcode.byte? EvmOpcode.STOP = some Ops.STOP ∧


### PR DESCRIPTION
Refs evm-asm-ad0as, GH #109, and GH #113.

Adds a compact executable-spec opcode family bridge for TerminatingArgs.Kind, covering STOP, RETURN, REVERT, INVALID, and SELFDESTRUCT with shared byte/opcode maps and a roundtrip theorem.

Local checks:
- lake build EvmAsm.Evm64.ExecutableSpecOpcodeBridge
- lake build
- scripts/check-file-size.sh --report
- git diff --check

Authored by @pirapira; implemented by Codex.