### PR TITLE
feat(interpreter): add simple env executable opcode bridge

### DIFF
--- a/EvmAsm/Evm64/ExecutableSpecOpcodeBridge.lean
+++ b/EvmAsm/Evm64/ExecutableSpecOpcodeBridge.lean
@@ -7,6 +7,7 @@
 -/
 
 import EvmAsm.Evm64.Dispatch
+import EvmAsm.Evm64.Env.Gas
 import EvmAsm.Evm64.TerminatingArgs
 import Mathlib.Tactic.IntervalCases
 
@@ -108,6 +109,18 @@ theorem roundtrip_execSpecTerminatingKind (kind : TerminatingArgs.Kind) :
       EvmOpcode.decodeByte? (execSpecTerminatingByte kind) =
         some (opcodeOfTerminatingKind kind) := by
   cases kind <;> exact ⟨rfl, rfl⟩
+
+/--
+Executable-spec roundtrip for the simple environment opcode family.
+
+Distinctive token:
+ExecutableSpecOpcodeBridge.roundtrip_execSpecSimpleEnvField #109 #103.
+-/
+theorem roundtrip_execSpecSimpleEnvField
+    (field : Env.SimpleEnvField) :
+    EvmOpcode.byte? field.opcode = some field.opcodeByte ∧
+      EvmOpcode.decodeByte? field.opcodeByte = some field.opcode := by
+  cases field <;> exact ⟨rfl, rfl⟩
 
 theorem roundtrip_execSpec_STOP :
     EvmOpcode.byte? EvmOpcode.STOP = some Ops.STOP ∧


### PR DESCRIPTION
Refs evm-asm-nptge, GH #109, and GH #103.

Adds a compact executable-spec opcode family roundtrip bridge for Env.SimpleEnvField, covering ADDRESS, ORIGIN, CALLER, CALLVALUE, GASPRICE, COINBASE, TIMESTAMP, NUMBER, PREVRANDAO, GASLIMIT, CHAINID, BASEFEE, and SELFBALANCE through the existing SimpleEnvField opcode/byte mapping.

Local checks:
- lake build EvmAsm.Evm64.ExecutableSpecOpcodeBridge
- lake build
- scripts/check-file-size.sh --report
- git diff --check

Authored by @pirapira; implemented by Codex.