### PR TITLE
feat(push): bridge handler to executable effect

### DIFF
--- a/EvmAsm/Evm64/PushHandlers.lean
+++ b/EvmAsm/Evm64/PushHandlers.lean
@@ -68,6 +68,21 @@ theorem pushHandler_pc_eq
     (n : Nat) (state : EvmState) :
     (pushHandler n state).pc = state.pc + 1 + n := rfl
 
+/--
+The pure PUSH handler updates the interpreter state with the same stack and
+program-counter components as the bundled executable PUSH effect.
+
+Distinctive token:
+PushHandlers.pushHandler_eq_effectFromCode #101 #107.
+-/
+theorem pushHandler_eq_effectFromCode
+    (n : Nat) (state : EvmState) :
+    (pushHandler n state).pc =
+        (PushExecEffect.effectFromCode state.code state.pc n state.stack).pc ∧
+      (pushHandler n state).stack =
+        (PushExecEffect.effectFromCode state.code state.pc n state.stack).stack := by
+  constructor <;> rfl
+
 theorem dispatchOpcode?_pushHandlerTable_PUSH_of_valid
     {n : Nat} (h_valid : EvmOpcode.validPushWidth n = true)
     (state : EvmState) :


### PR DESCRIPTION
Refs evm-asm-blq8x and GH #101, GH #107.

Adds a reusable theorem connecting the pure PUSH handler to PushExecEffect.effectFromCode: the handler result's pc and stack components match the bundled executable PUSH effect for the same state/code/pc/stack. This gives later interpreter proofs a canonical PUSH effect bridge without adding per-width examples.

Local checks:
- lake build EvmAsm.Evm64.PushHandlers
- lake build
- scripts/check-file-size.sh --report
- git diff --check

Authored by @pirapira; implemented by Codex.