### PR TITLE
feat(calldata): characterize copy write indices

### DIFF
--- a/EvmAsm/Evm64/Calldata/CopyMemory.lean
+++ b/EvmAsm/Evm64/Calldata/CopyMemory.lean
@@ -63,6 +63,18 @@ theorem writesAddress_at_destination_add
     CallDataCopyArgs.sizeNat
   omega
 
+theorem writesAddress_iff_exists_index
+    (args : CallDataCopyArgs.Args) (addr : Nat) :
+    writesAddress args addr ↔
+      ∃ i, i < args.size.toNat ∧ addr = destinationStart args + i := by
+  unfold writesAddress destinationEnd destinationStart CallDataCopyArgs.destinationOffsetNat
+    CallDataCopyArgs.sizeNat
+  constructor
+  · intro h
+    refine ⟨addr - args.destOffset.toNat, ?_, ?_⟩ <;> omega
+  · rintro ⟨i, h_lt, rfl⟩
+    omega
+
 theorem writeIndex_at_destination_add
     (args : CallDataCopyArgs.Args) (i : Nat) :
     writeIndex args (destinationStart args + i) = i := by


### PR DESCRIPTION
Refs evm-asm-047sv and GH #104.\n\nAdds CallDataCopyMemory.writesAddress_iff_exists_index, a reusable bridge from arbitrary destination-memory addresses back to the CALLDATACOPY destination-relative byte index.\n\nLocal checks:\n- lake build EvmAsm.Evm64.Calldata.CopyMemory\n- lake build\n- scripts/check-file-size.sh --report\n- git diff --check\n- rg forbidden proof escapes in EvmAsm/Evm64/Calldata/CopyMemory.lean\n\nAuthored by @pirapira; implemented by Codex.