### PR TITLE
feat(handlers): bridge supported PUSH dispatch effect

### DIFF
--- a/EvmAsm/Evm64/SupportedHandlers.lean
+++ b/EvmAsm/Evm64/SupportedHandlers.lean
@@ -437,6 +437,25 @@ theorem supportedHandlerTable_PUSH_of_valid
     (by simp [StackHandlers.stackHandlerTable, HandlerTable.setHandler])
     (PushHandlers.pushHandler?_PUSH_of_valid h_valid)
 
+/--
+Dispatching a valid PUSH opcode through the combined supported-handler table
+has the same program-counter and stack effect as the executable PUSH bridge.
+
+Distinctive token:
+SupportedHandlers.dispatchOpcode_supportedHandlerTable_PUSH_effectFromCode
+#101 #107.
+-/
+theorem dispatchOpcode_supportedHandlerTable_PUSH_effectFromCode
+    {n : Nat} (h_valid : EvmOpcode.validPushWidth n = true)
+    (state : EvmState) :
+    (HandlerTable.dispatchOpcode supportedHandlerTable (.PUSH n) state).pc =
+        (PushExecEffect.effectFromCode state.code state.pc n state.stack).pc ∧
+      (HandlerTable.dispatchOpcode supportedHandlerTable (.PUSH n) state).stack =
+        (PushExecEffect.effectFromCode state.code state.pc n state.stack).stack := by
+  rw [HandlerTable.dispatchOpcode_some
+    (supportedHandlerTable_PUSH_of_valid h_valid) state]
+  exact PushHandlers.pushHandler_eq_effectFromCode n state
+
 theorem supportedHandlerTable_DUP_of_valid
     {n : Nat} (h_valid : EvmOpcode.validDupIndex n = true) :
     supportedHandlerTable (.DUP n) =


### PR DESCRIPTION
Refs evm-asm-9j4kv, GH #101, and GH #107.\n\nAdds SupportedHandlers.dispatchOpcode_supportedHandlerTable_PUSH_effectFromCode, connecting valid PUSH dispatch through the combined supported-handler table to the executable PUSH effect's pc and stack outputs.\n\nLocal checks:\n- lake build EvmAsm.Evm64.SupportedHandlers\n- lake build\n- scripts/check-file-size.sh --report\n- git diff --check\n- rg forbidden proof escapes in EvmAsm/Evm64/SupportedHandlers.lean\n\nAuthored by @pirapira; implemented by Codex.