### PR TITLE
feat(rlp): characterize length-field failures

### DIFF
--- a/EvmAsm/EL/RLP/ReadLengthBridge.lean
+++ b/EvmAsm/EL/RLP/ReadLengthBridge.lean
@@ -54,6 +54,15 @@ theorem decodeLengthField?_none_of_readLength_none
     decodeLengthField? bs n = none := by
   simp [decodeLengthField?, h_read]
 
+theorem decodeLengthField?_eq_none_iff (bs : List Byte) (n : Nat) :
+    decodeLengthField? bs n = none ↔ readLength bs n = none := by
+  unfold decodeLengthField?
+  cases h_read : readLength bs n with
+  | none => simp
+  | some decoded =>
+      cases decoded
+      simp
+
 theorem decodeLengthField?_some_of_readLength
     {bs rest : List Byte} {n lenVal : Nat}
     (h_read : readLength bs n = some (lenVal, rest)) :


### PR DESCRIPTION
Refs evm-asm-031fi and GH #120.\n\nAdds ReadLengthBridge.decodeLengthField?_eq_none_iff, a reusable bridge equating length-field bridge failure with raw readLength failure.\n\nLocal checks:\n- lake build EvmAsm.EL.RLP.ReadLengthBridge\n- lake build\n- scripts/check-file-size.sh --report\n- git diff --check\n- rg forbidden proof escapes in EvmAsm/EL/RLP/ReadLengthBridge.lean\n\nAuthored by @pirapira; implemented by Codex.