### PR TITLE
feat(calldata): bridge decoder failure cases

### DIFF
--- a/EvmAsm/Evm64/Calldata/CopyArgsStackDecode.lean
+++ b/EvmAsm/Evm64/Calldata/CopyArgsStackDecode.lean
@@ -51,6 +51,37 @@ theorem decodeCallDataCopyStack?_eq_some_iff
   · rintro ⟨destOffset, dataOffset, size, rest, rfl, rfl⟩
     rfl
 
+/--
+CALLDATACOPY stack decoding fails exactly when fewer than three stack words are
+available.
+
+Distinctive token:
+CallDataCopyArgsStackDecode.decodeCallDataCopyStack?_eq_none_iff #104 #107.
+-/
+theorem decodeCallDataCopyStack?_eq_none_iff
+    (stack : List EvmWord) :
+    decodeCallDataCopyStack? stack = none ↔ stack.length < 3 := by
+  cases stack with
+  | nil => simp [decodeCallDataCopyStack?]
+  | cons destOffset s1 =>
+      cases s1 with
+      | nil => simp [decodeCallDataCopyStack?]
+      | cons dataOffset s2 =>
+          cases s2 with
+          | nil => simp [decodeCallDataCopyStack?]
+          | cons size rest => simp [decodeCallDataCopyStack?]
+
+theorem decodeCallDataCopyStack?_none_of_empty :
+    decodeCallDataCopyStack? [] = none := rfl
+
+theorem decodeCallDataCopyStack?_none_of_one
+    (destOffset : EvmWord) :
+    decodeCallDataCopyStack? [destOffset] = none := rfl
+
+theorem decodeCallDataCopyStack?_none_of_two
+    (destOffset dataOffset : EvmWord) :
+    decodeCallDataCopyStack? [destOffset, dataOffset] = none := rfl
+
 theorem decodeCallDataCopyStack?_destOffset
     (destOffset dataOffset size : EvmWord) (rest : List EvmWord) :
     Option.map (fun args => args.destOffset)

--- a/EvmAsm/Evm64/Calldata/LoadArgsStackDecode.lean
+++ b/EvmAsm/Evm64/Calldata/LoadArgsStackDecode.lean
@@ -43,6 +43,22 @@ theorem decodeCallDataLoadStack?_eq_some_iff
   · rintro ⟨offset, rest, rfl, rfl⟩
     rfl
 
+/--
+CALLDATALOAD stack decoding fails exactly when the stack is empty.
+
+Distinctive token:
+CallDataLoadArgsStackDecode.decodeCallDataLoadStack?_eq_none_iff #104 #107.
+-/
+theorem decodeCallDataLoadStack?_eq_none_iff
+    (stack : List EvmWord) :
+    decodeCallDataLoadStack? stack = none ↔ stack = [] := by
+  cases stack with
+  | nil => simp [decodeCallDataLoadStack?]
+  | cons offset rest => simp [decodeCallDataLoadStack?]
+
+theorem decodeCallDataLoadStack?_none_of_empty :
+    decodeCallDataLoadStack? [] = none := rfl
+
 theorem decodeCallDataLoadStack?_offset
     (offset : EvmWord) (rest : List EvmWord) :
     Option.map (fun args => args.offset)


### PR DESCRIPTION
Adds executable-spec bridge lemmas for CALLDATALOAD/CALLDATACOPY stack decoder failure cases.

- `decodeCallDataLoadStack? = none` iff the stack is empty
- `decodeCallDataCopyStack? = none` iff fewer than three stack words are available

Refs evm-asm-pq9ac.1. Refs GH #104 and GH #107.

Authored by @pirapira; implemented by Codex.

Local checks:
- `lake build EvmAsm.Evm64.Calldata.LoadArgsStackDecode`
- `lake build EvmAsm.Evm64.Calldata.CopyArgsStackDecode`
- `lake build`
- `scripts/check-file-size.sh --report`
