### PR TITLE
feat(rlp): characterize list-payload success

### DIFF
--- a/EvmAsm/EL/RLP/ListDecodeBridge.lean
+++ b/EvmAsm/EL/RLP/ListDecodeBridge.lean
@@ -23,6 +23,24 @@ theorem decodeListPayload_eq_some_of_decodeItems_empty
     decodeListPayload nDepth payload = some items := by
   simp [decodeListPayload, h_decode]
 
+/--
+List-payload decode succeeds exactly when recursive item decoding consumes the
+whole payload.
+
+Distinctive token: ListDecodeBridge.decodeListPayload_eq_some_iff #120.
+-/
+theorem decodeListPayload_eq_some_iff
+    (nDepth : Nat) (payload : List Byte) (items : List RLPItem) :
+    decodeListPayload nDepth payload = some items ↔
+      decodeItems nDepth payload = some (items, []) := by
+  unfold decodeListPayload
+  cases h_decode : decodeItems nDepth payload with
+  | none => simp
+  | some decoded =>
+      cases decoded with
+      | mk decodedItems leftover =>
+          cases leftover <;> simp
+
 theorem decodeListPayload_eq_none_of_decodeItems_none
     {nDepth : Nat} {payload : List Byte}
     (h_decode : decodeItems nDepth payload = none) :


### PR DESCRIPTION
Adds a reusable success characterization for RLP list-payload decoding:

- `decodeListPayload nDepth payload = some items` iff `decodeItems nDepth payload = some (items, [])`

Refs evm-asm-h6mz.9. Refs GH #120.

Authored by @pirapira; implemented by Codex.

Local checks:
- `lake build EvmAsm.EL.RLP.ListDecodeBridge`
- `lake build`
- `scripts/check-file-size.sh --report`
