### PR TITLE
chore(shake): noshake Phase4Hint{Read,Len} false-positives

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -25,6 +25,12 @@
   ["EvmAsm.Rv64.RLP.Phase1CascadePrefixE5", "EvmAsm.Rv64.RLP.Phase1Disjoint"],
   "EvmAsm.Rv64.RLP.Phase2LongLoad":
   ["EvmAsm.Rv64.Tactics.XSimp"],
+  "EvmAsm.Rv64.RLP.Phase4HintRead":
+  ["EvmAsm.Rv64.HintSpecs", "EvmAsm.Rv64.AddrNorm",
+   "EvmAsm.Rv64.Tactics.RunBlock", "EvmAsm.Rv64.Tactics.XSimp"],
+  "EvmAsm.Rv64.RLP.Phase4HintLen":
+  ["EvmAsm.Rv64.HintSpecs", "EvmAsm.Rv64.AddrNorm",
+   "EvmAsm.Rv64.Tactics.XSimp"],
   "EvmAsm.Rv64.Tactics.XPerm":
   ["EvmAsm.Rv64.SepLogic"],
   "EvmAsm.Rv64.Tactics.XPermPure":


### PR DESCRIPTION
lake exe shake EvmAsm flags drop-only suggestions for two Phase 4 RLP files that are false positives — verified locally by attempting deletion, each removal breaks the build:

- `EvmAsm/Rv64/RLP/Phase4HintRead.lean` needs `Rv64.HintSpecs` + `Rv64.AddrNorm` + `Rv64.Tactics.RunBlock` + `Rv64.Tactics.XSimp` (drives `li_spec_gen_own_within`, `hint_read_spec_*`, and the open `EvmAsm.Rv64.Tactics` namespace).
- `EvmAsm/Rv64/RLP/Phase4HintLen.lean` needs `Rv64.HintSpecs` + `Rv64.AddrNorm` + `Rv64.Tactics.XSimp` (same `li_spec_gen_own_within` / Tactics namespace dependency).

Removal errors: `unknown namespace EvmAsm.Rv64.Tactics`, `Unknown identifier li_spec_gen_own_within`, unsolved `cpsTripleWithin` goal.

Fix is a `noshake.json`-only patch pinning these imports. After this patch `lake exe shake EvmAsm` output shrinks 419 → 410 lines and the two Phase4Hint entries no longer appear; `lake build` clean.

Beads: evm-asm-2s9ke (parent evm-asm-6qj). Refs #1045.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).