### PR TITLE
feat(exp): characterize stack execution failures

### DIFF
--- a/EvmAsm/Evm64/Exp/ArgsStackDecode.lean
+++ b/EvmAsm/Evm64/Exp/ArgsStackDecode.lean
@@ -45,6 +45,24 @@ theorem decodeExpStack?_eq_some_iff
   · rintro ⟨base, exponent, rest, rfl, rfl⟩
     rfl
 
+theorem decodeExpStack?_eq_none_iff
+    {stack : List EvmWord} :
+    decodeExpStack? stack = none ↔
+      stack = [] ∨ ∃ base, stack = [base] := by
+  constructor
+  · cases stack with
+    | nil =>
+        intro _h
+        exact Or.inl rfl
+    | cons base tail =>
+        cases tail with
+        | nil =>
+            intro _h
+            exact Or.inr ⟨base, rfl⟩
+        | cons exponent rest =>
+            simp [decodeExpStack?]
+  · rintro (rfl | ⟨base, rfl⟩) <;> rfl
+
 theorem decodeExpStack?_base
     (base exponent : EvmWord) (rest : List EvmWord) :
     Option.map (fun args => args.base)

--- a/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
+++ b/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
@@ -73,6 +73,43 @@ theorem runExpStack?_underflow_nil :
 theorem runExpStack?_underflow_one (base : EvmWord) :
     runExpStack? { stack := [base] } = none := rfl
 
+theorem stackRestAfterExp?_eq_none_iff
+    {stack : List EvmWord} :
+    stackRestAfterExp? stack = none ↔
+      stack = [] ∨ ∃ base, stack = [base] := by
+  constructor
+  · cases stack with
+    | nil =>
+        intro _h
+        exact Or.inl rfl
+    | cons base tail =>
+        cases tail with
+        | nil =>
+            intro _h
+            exact Or.inr ⟨base, rfl⟩
+        | cons exponent rest =>
+            simp [stackRestAfterExp?]
+  · rintro (rfl | ⟨base, rfl⟩) <;> rfl
+
+theorem runExpStack?_eq_none_iff
+    {state : ExpStackState} :
+    runExpStack? state = none ↔
+      state.stack = [] ∨ ∃ base, state.stack = [base] := by
+  cases state with
+  | mk stack =>
+      cases stack with
+      | nil =>
+          simp [runExpStack?, ExpArgsStackDecode.decodeExpStack?,
+            stackRestAfterExp?, Option.bind]
+      | cons base tail =>
+          cases tail with
+          | nil =>
+              simp [runExpStack?, ExpArgsStackDecode.decodeExpStack?,
+                stackRestAfterExp?, Option.bind]
+          | cons exponent rest =>
+              simp [runExpStack?, ExpArgsStackDecode.decodeExpStack?,
+                stackRestAfterExp?, Option.bind]
+
 theorem runExpStack?_stack_length
     {state : ExpStackState} {out : ExpStackResult}
     (h_run : runExpStack? state = some out) :


### PR DESCRIPTION
Stacked on #2783.

Refs evm-asm-ttokx and GH #92.

Adds failure-characterization bridges for the EXP executable stack surface:

- `ExpArgsStackDecode.decodeExpStack?_eq_none_iff`
- `ExpStackExecutionBridge.stackRestAfterExp?_eq_none_iff`
- `ExpStackExecutionBridge.runExpStack?_eq_none_iff`

Local checks:
- `lake build EvmAsm.Evm64.Exp.StackExecutionBridge`
- `lake build`
- `scripts/check-file-size.sh --report`
- `git diff --check`

Authored by @pirapira; implemented by Codex.
