### PR TITLE
feat(exp): characterize stack execution success

### DIFF
--- a/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
+++ b/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
@@ -110,6 +110,52 @@ theorem runExpStack?_eq_none_iff
               simp [runExpStack?, ExpArgsStackDecode.decodeExpStack?,
                 stackRestAfterExp?, Option.bind]
 
+/--
+EXP stack execution succeeds exactly on a stack with at least two words, and
+the output is the decoded EXP result/effects plus the remaining stack tail.
+
+Distinctive token: ExpStackExecutionBridge.runExpStack?_eq_some_iff #92.
+-/
+theorem runExpStack?_eq_some_iff
+    {state : ExpStackState} {out : ExpStackResult} :
+    runExpStack? state = some out ↔
+      ∃ base exponent rest,
+        state.stack = base :: exponent :: rest ∧
+          out =
+            { effects :=
+                { stackWords := [ExpArgs.expResultFromArgs
+                    (ExpArgs.expArgs base exponent)]
+                  dynamicGas := ExpArgs.expDynamicCostFromArgs
+                    (ExpArgs.expArgs base exponent)
+                  totalGas := ExpArgs.expTotalGasFromArgs
+                    (ExpArgs.expArgs base exponent) }
+              stack := rest } := by
+  constructor
+  · cases state with
+    | mk stack =>
+        cases stack with
+        | nil =>
+            simp [runExpStack?, ExpArgsStackDecode.decodeExpStack?,
+              stackRestAfterExp?, Option.bind]
+        | cons base tail =>
+            cases tail with
+            | nil =>
+                simp [runExpStack?, ExpArgsStackDecode.decodeExpStack?,
+                  stackRestAfterExp?, Option.bind]
+            | cons exponent rest =>
+                intro h_run
+                simp [runExpStack?, ExpArgsStackDecode.decodeExpStack?,
+                  stackRestAfterExp?, Option.bind] at h_run
+                cases h_run
+                exact ⟨base, exponent, rest, rfl, rfl⟩
+  · rintro ⟨base, exponent, rest, h_stack, h_out⟩
+    cases state with
+    | mk stack =>
+        simp at h_stack
+        subst h_stack
+        subst h_out
+        exact runExpStack?_cons base exponent rest
+
 theorem runExpStack?_stack_length
     {state : ExpStackState} {out : ExpStackResult}
     (h_run : runExpStack? state = some out) :


### PR DESCRIPTION
Stacked on #2821.

Refs evm-asm-sviy3 and GH #92.

Adds a success characterization for the EXP executable stack bridge:

- `ExpStackExecutionBridge.runExpStack?_eq_some_iff`

The theorem exposes the exact two-word stack shape, decoded result word, dynamic gas, total gas, and remaining stack tail for any successful EXP stack execution.

Local checks:
- `lake build EvmAsm.Evm64.Exp.StackExecutionBridge`
- `lake build`
- `scripts/check-file-size.sh --report`
- `git diff --check`

Authored by @pirapira; implemented by Codex.
