### PR TITLE
feat(rlp): characterize long-list decode success

### DIFF
--- a/EvmAsm/EL/RLP/ListDecodeBridge.lean
+++ b/EvmAsm/EL/RLP/ListDecodeBridge.lean
@@ -178,6 +178,92 @@ theorem decodeAux_cons_longList_eq_decodeListPayload
                 rcases pair'' with ⟨items, leftover⟩
                 cases leftover <;> simp [decodeListPayload, h_short, h_take, h_decode]
 
+/--
+Classified long-list decode succeeds exactly when the long-form length field is
+canonical, the payload slice is available, and list-payload decoding consumes
+that payload exactly.
+
+Distinctive token:
+ListDecodeBridge.decodeAux_cons_longList_eq_some_iff #120.
+-/
+theorem decodeAux_cons_longList_eq_some_iff
+    (nDepth : Nat) (pfx : Byte) (rest : List Byte)
+    (h_class : classifyPrefix pfx = .longList)
+    (items : List RLPItem) (outRest : List Byte) :
+    decodeAux (nDepth + 1) (pfx :: rest) = some (.list items, outRest) ↔
+      ∃ lenVal rest' payload,
+        readLength rest (rlpPrefixLongListLenOfLen pfx) = some (lenVal, rest') ∧
+          55 < lenVal ∧
+            takeBytes rest' lenVal = some (payload, outRest) ∧
+              decodeListPayload nDepth payload = some items := by
+  rw [decodeAux_cons_longList_eq_decodeListPayload nDepth pfx rest h_class]
+  cases h_read : readLength rest (rlpPrefixLongListLenOfLen pfx) with
+  | none =>
+      simp
+  | some pair =>
+      rcases pair with ⟨lenVal, rest'⟩
+      by_cases h_short : lenVal ≤ 55
+      · constructor
+        · intro h_some
+          simp [h_short] at h_some
+        · rintro ⟨lenVal', rest'', payload', h_read', h_long', h_take',
+            h_decode'⟩
+          have h_read_pair : (lenVal, rest') = (lenVal', rest'') := by
+            simpa [h_read] using h_read'
+          have h_len_eq : lenVal = lenVal' := congrArg Prod.fst h_read_pair
+          omega
+      · cases h_take : takeBytes rest' lenVal with
+        | none =>
+            simp [h_short, h_take, Option.bind]
+        | some pair' =>
+            rcases pair' with ⟨payload, slicedRest⟩
+            cases h_payload : decodeListPayload nDepth payload with
+            | none =>
+                simp [h_short, h_take, h_payload, Option.bind]
+            | some decodedItems =>
+                constructor
+                · intro h_some
+                  simp [h_short, h_take, h_payload, Option.bind] at h_some
+                  have h_long : 55 < lenVal := by omega
+                  have h_take_out :
+                      takeBytes rest' lenVal = some (payload, outRest) := by
+                    rw [← h_some.2]
+                    exact h_take
+                  have h_decode_items :
+                      decodeListPayload nDepth payload = some items := by
+                    rw [← h_some.1]
+                    exact h_payload
+                  refine Exists.intro lenVal ?_
+                  refine Exists.intro rest' ?_
+                  refine Exists.intro payload ?_
+                  constructor
+                  · rfl
+                  constructor
+                  · exact h_long
+                  constructor
+                  · exact h_take_out
+                  · exact h_decode_items
+                · rintro ⟨lenVal', rest'', payload', h_read', _h_long',
+                    h_take', h_decode'⟩
+                  have h_read_pair : (lenVal, rest') = (lenVal', rest'') := by
+                    simpa [h_read] using h_read'
+                  have h_len_eq : lenVal = lenVal' := congrArg Prod.fst h_read_pair
+                  have h_rest_eq : rest' = rest'' := congrArg Prod.snd h_read_pair
+                  have h_take_payload :
+                      takeBytes rest' lenVal = some (payload', outRest) := by
+                    simpa [h_len_eq, h_rest_eq] using h_take'
+                  have h_take_pair : (payload, slicedRest) = (payload', outRest) := by
+                    simpa [h_take] using h_take_payload
+                  have h_payload_eq : payload = payload' := congrArg Prod.fst h_take_pair
+                  have h_sliced_eq : slicedRest = outRest := congrArg Prod.snd h_take_pair
+                  have h_decode_payload :
+                      decodeListPayload nDepth payload = some items := by
+                    simpa [h_payload_eq] using h_decode'
+                  have h_items : decodedItems = items :=
+                    Option.some.inj (h_payload.symm.trans h_decode_payload)
+                  simp [h_short, h_take, h_payload, h_items, h_sliced_eq,
+                    Option.bind]
+
 end ListDecodeBridge
 
 end EvmAsm.EL.RLP


### PR DESCRIPTION
Previously stacked on #2828; #2828 has merged, so this PR targets main.

Refs evm-asm-2ux3p and GH #120.

Adds a semantic success characterization for classified long-list decoding:

- `ListDecodeBridge.decodeAux_cons_longList_eq_some_iff`

The theorem states that a classified long-list `decodeAux` succeeds exactly when `readLength` succeeds with `55 < lenVal`, `takeBytes` extracts the payload/rest slice, and `decodeListPayload` succeeds on that payload.

Local checks:
- `lake build EvmAsm.EL.RLP.ListDecodeBridge`
- `lake build`
- `scripts/check-file-size.sh --report`
- `git diff --check`

Authored by @pirapira; implemented by Codex.
