### PR TITLE
feat(calldata): characterize stack execution success

### DIFF
--- a/EvmAsm/EL/CalldataStackExecutionBridge.lean
+++ b/EvmAsm/EL/CalldataStackExecutionBridge.lean
@@ -148,6 +148,150 @@ theorem runCalldataStack?_copy
                     destOffset dataOffset size) }
           stack := rest } := rfl
 
+/--
+CALLDATALOAD stack execution succeeds exactly when the operand stack has an
+offset word, returning the loaded word and the remaining stack tail.
+
+Distinctive token:
+CalldataStackExecutionBridge.runCalldataStack?_load_eq_some_iff #104 #107.
+-/
+theorem runCalldataStack?_load_eq_some_iff
+    {data : List (BitVec 8)} {stack : List EvmWord} {out : CalldataStackResult} :
+    runCalldataStack? .callDataLoad { data := data, stack := stack } = some out ↔
+      ∃ offset rest,
+        stack = offset :: rest ∧
+          out =
+            { effects :=
+                { stackWords :=
+                    [EvmAsm.Evm64.CallDataLoadArgs.loadedWordFromArgs data
+                      (EvmAsm.Evm64.CallDataLoadArgs.loadArgs offset)]
+                  copiedBytes := [] }
+              stack := rest } := by
+  constructor
+  · cases stack with
+    | nil =>
+        simp [runCalldataStack?,
+          EvmAsm.Evm64.CallDataLoadArgsStackDecode.decodeCallDataLoadStack?]
+    | cons offset rest =>
+        intro h_run
+        simp [runCalldataStack?, stackRestAfterCalldata?] at h_run
+        cases h_run
+        exact ⟨offset, rest, rfl, rfl⟩
+  · rintro ⟨offset, rest, h_stack, h_out⟩
+    subst h_stack
+    subst h_out
+    exact runCalldataStack?_load data offset rest
+
+/--
+CALLDATASIZE stack execution is total and leaves the stack tail unchanged.
+
+Distinctive token:
+CalldataStackExecutionBridge.runCalldataStack?_size_eq_some_iff #104 #107.
+-/
+theorem runCalldataStack?_size_eq_some_iff
+    {data : List (BitVec 8)} {stack : List EvmWord} {out : CalldataStackResult} :
+    runCalldataStack? .callDataSize { data := data, stack := stack } = some out ↔
+      out =
+        { effects :=
+            { stackWords := [EvmAsm.Evm64.Calldata.callDataSizeOf data]
+              copiedBytes := [] }
+          stack := stack } := by
+  constructor
+  · intro h_run
+    symm
+    simpa [runCalldataStack?] using h_run
+  · intro h_out
+    subst h_out
+    exact runCalldataStack?_size data stack
+
+/--
+CALLDATACOPY stack execution succeeds exactly when three operand words are
+available, returning no stack word and the copied byte sequence.
+
+Distinctive token:
+CalldataStackExecutionBridge.runCalldataStack?_copy_eq_some_iff #104 #107.
+-/
+theorem runCalldataStack?_copy_eq_some_iff
+    {data : List (BitVec 8)} {stack : List EvmWord} {out : CalldataStackResult} :
+    runCalldataStack? .callDataCopy { data := data, stack := stack } = some out ↔
+      ∃ destOffset dataOffset size rest,
+        stack = destOffset :: dataOffset :: size :: rest ∧
+          out =
+            { effects :=
+                { stackWords := []
+                  copiedBytes :=
+                    EvmAsm.Evm64.CallDataCopyExec.copiedBytesFromArgs data
+                      (EvmAsm.Evm64.CallDataCopyArgs.copyArgs
+                        destOffset dataOffset size) }
+              stack := rest } := by
+  constructor
+  · cases stack with
+    | nil =>
+        simp [runCalldataStack?,
+          EvmAsm.Evm64.CallDataCopyArgsStackDecode.decodeCallDataCopyStack?]
+    | cons destOffset tail =>
+        cases tail with
+        | nil =>
+            simp [runCalldataStack?, stackRestAfterCalldata?,
+              EvmAsm.Evm64.CallDataCopyArgsStackDecode.decodeCallDataCopyStack?]
+        | cons dataOffset tail =>
+            cases tail with
+            | nil =>
+                simp [runCalldataStack?, stackRestAfterCalldata?,
+                  EvmAsm.Evm64.CallDataCopyArgsStackDecode.decodeCallDataCopyStack?]
+            | cons size rest =>
+                intro h_run
+                simp [runCalldataStack?, stackRestAfterCalldata?] at h_run
+                cases h_run
+                exact ⟨destOffset, dataOffset, size, rest, rfl, rfl⟩
+  · rintro ⟨destOffset, dataOffset, size, rest, h_stack, h_out⟩
+    subst h_stack
+    subst h_out
+    exact runCalldataStack?_copy data destOffset dataOffset size rest
+
+/--
+Kind-indexed success characterization for calldata stack execution.
+
+Distinctive token:
+CalldataStackExecutionBridge.runCalldataStack?_kind_eq_some_iff #104 #107.
+-/
+theorem runCalldataStack?_eq_some_iff
+    {kind : Kind} {data : List (BitVec 8)} {stack : List EvmWord}
+    {out : CalldataStackResult} :
+    runCalldataStack? kind { data := data, stack := stack } = some out ↔
+      match kind with
+      | .callDataLoad =>
+          ∃ offset rest,
+            stack = offset :: rest ∧
+              out =
+                { effects :=
+                    { stackWords :=
+                        [EvmAsm.Evm64.CallDataLoadArgs.loadedWordFromArgs data
+                          (EvmAsm.Evm64.CallDataLoadArgs.loadArgs offset)]
+                      copiedBytes := [] }
+                  stack := rest }
+      | .callDataSize =>
+          out =
+            { effects :=
+                { stackWords := [EvmAsm.Evm64.Calldata.callDataSizeOf data]
+                  copiedBytes := [] }
+              stack := stack }
+      | .callDataCopy =>
+          ∃ destOffset dataOffset size rest,
+            stack = destOffset :: dataOffset :: size :: rest ∧
+              out =
+                { effects :=
+                    { stackWords := []
+                      copiedBytes :=
+                        EvmAsm.Evm64.CallDataCopyExec.copiedBytesFromArgs data
+                          (EvmAsm.Evm64.CallDataCopyArgs.copyArgs
+                            destOffset dataOffset size) }
+                  stack := rest } := by
+  cases kind
+  · exact runCalldataStack?_load_eq_some_iff
+  · exact runCalldataStack?_size_eq_some_iff
+  · exact runCalldataStack?_copy_eq_some_iff
+
 theorem runCalldataStack?_load_underflow (data : List (BitVec 8)) :
     runCalldataStack? .callDataLoad { data := data, stack := [] } = none := rfl
 


### PR DESCRIPTION
Refs evm-asm-brtj6, GH #104, and GH #107.

Adds semantic success characterizations for calldata stack execution:

- CalldataStackExecutionBridge.runCalldataStack?_load_eq_some_iff
- CalldataStackExecutionBridge.runCalldataStack?_size_eq_some_iff
- CalldataStackExecutionBridge.runCalldataStack?_copy_eq_some_iff
- CalldataStackExecutionBridge.runCalldataStack?_eq_some_iff

Local checks:
- lake build EvmAsm.EL.CalldataStackExecutionBridge
- lake build
- scripts/check-file-size.sh --report
- forbidden proof-escape scan
- git diff --check

Authored by @pirapira; implemented by Codex.