### PR TITLE
chore(shake): noshake N2DivStackSpec/N2ModStackSpec swap false-positives

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -238,6 +238,10 @@
    "EvmAsm.Evm64.DivMod.Spec.N3DivStackSpec",
    "EvmAsm.Evm64.DivMod.Spec.N3ModBridge",
    "EvmAsm.Evm64.DivMod.N4StackSpecWithin"],
+ "EvmAsm.Evm64.DivMod.Spec.N2DivStackSpec":
+  ["EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.Full"],
+ "EvmAsm.Evm64.DivMod.Spec.N2ModStackSpec":
+  ["EvmAsm.Evm64.DivMod.Spec.N2ModBridge"],
  "EvmAsm.Rv64.RLP.Phase2LongLoopTwo":   ["EvmAsm.Rv64.RLP.Phase2LongLoopOne"],
  "EvmAsm.Rv64.RLP.Phase1E3LongStringOne": ["EvmAsm.Rv64.RLP.Phase1E3FullPath", "EvmAsm.Rv64.RLP.Phase2LongLoopOne"],
  "EvmAsm.Rv64.RLP.Phase2LongLoopThree": ["EvmAsm.Rv64.RLP.Phase2LongLoopTwo"],


### PR DESCRIPTION
Pin two false-positive shake swap suggestions on DivMod stack-spec files via `noshake.json`.

`lake exe shake EvmAsm` flags:
- `EvmAsm/Evm64/DivMod/Spec/N2DivStackSpec.lean`: swap import `EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.Full` → `State`.
- `EvmAsm/Evm64/DivMod/Spec/N2ModStackSpec.lean`: swap import `EvmAsm.Evm64.DivMod.Spec.N2ModBridge` → `Dispatcher`.

Verified locally that each swap breaks the proof — the `cpsTripleWithin` dispatch goal in `evm_div_n2_stack_spec_within` / `evm_mod_n2_stack_spec_within` cannot close without the originally imported module's downstream re-exports. Adding noshake entries pinning the originals.

Refs `evm-asm-9iixf` (parent `evm-asm-6qj`) / GH #1045.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).
