### PR TITLE
feat(calldata): bridge copied byte length

### DIFF
--- a/EvmAsm/EL/CalldataStackExecutionBridge.lean
+++ b/EvmAsm/EL/CalldataStackExecutionBridge.lean
@@ -292,6 +292,33 @@ theorem runCalldataStack?_eq_some_iff
   · exact runCalldataStack?_size_eq_some_iff
   · exact runCalldataStack?_copy_eq_some_iff
 
+/--
+Successful CALLDATACOPY stack execution exposes exactly `size.toNat` copied
+bytes from the decoded operand triple.
+
+Distinctive token:
+CalldataStackExecutionBridge.runCalldataStack?_copy_copiedBytes_length #104 #107.
+-/
+theorem runCalldataStack?_copy_copiedBytes_length
+    {data : List (BitVec 8)} {stack : List EvmWord} {out : CalldataStackResult}
+    {destOffset dataOffset size : EvmWord} {rest : List EvmWord}
+    (h_run : runCalldataStack? .callDataCopy { data := data, stack := stack } =
+      some out)
+    (h_stack : stack = destOffset :: dataOffset :: size :: rest) :
+    out.effects.copiedBytes.length = size.toNat := by
+  have h_shape :=
+    (runCalldataStack?_copy_eq_some_iff.mp h_run)
+  rcases h_shape with
+    ⟨destOffset', dataOffset', size', rest', h_stack', h_out⟩
+  have h_stack_eq :
+      destOffset :: dataOffset :: size :: rest =
+        destOffset' :: dataOffset' :: size' :: rest' := by
+    rw [← h_stack]
+    exact h_stack'
+  cases h_stack_eq
+  subst h_out
+  simp [EvmAsm.Evm64.CallDataCopyArgs.copyArgs]
+
 theorem runCalldataStack?_load_underflow (data : List (BitVec 8)) :
     runCalldataStack? .callDataLoad { data := data, stack := [] } = none := rfl
 


### PR DESCRIPTION
Stacked on #2833.

Refs evm-asm-su1re, GH #104, and GH #107.

Adds CalldataStackExecutionBridge.runCalldataStack?_copy_copiedBytes_length, showing that successful CALLDATACOPY stack execution exposes copied bytes whose length equals the decoded size.toNat operand.

Local checks:
- lake build EvmAsm.EL.CalldataStackExecutionBridge
- lake build
- scripts/check-file-size.sh --report
- forbidden proof-escape scan
- git diff --check

Authored by @pirapira; implemented by Codex.
