### PR TITLE
chore(shake): drop unused SepLogic import in Exp/Layout

### DIFF
--- a/EvmAsm/Evm64/Exp/Layout.lean
+++ b/EvmAsm/Evm64/Exp/Layout.lean
@@ -38,8 +38,6 @@
   Authored by @pirapira; implemented by Hermes-bot (evm-hermes).
 -/
 
-import EvmAsm.Rv64.SepLogic
-
 namespace EvmAsm.Evm64
 
 /-- Layout of the EXP routine's `sp`-relative internal scratch cells.


### PR DESCRIPTION
`lake exe shake EvmAsm` flagged `EvmAsm.Rv64.SepLogic` as unused in `EvmAsm/Evm64/Exp/Layout.lean`. The file declares the empty `ExpScratchpadLayout` placeholder (struct + `.Valid` + canonical instance + canonical `Valid` theorem) and references no SepLogic content — no `Assertion`, no `sepConj`, no `Reg`, no memory accessors. The Multiply/Layout pilot it mirrors does not import SepLogic either.

Local checks:
- lake build green (1698 jobs)
- shake no longer flags the file

Refs GH #1045, beads `evm-asm-ksv34`, parent `evm-asm-9tq`.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).