### PR TITLE
feat(keccak): add stack failure bridge

### DIFF
--- a/EvmAsm/EL/KeccakStackExecutionBridge.lean
+++ b/EvmAsm/EL/KeccakStackExecutionBridge.lean
@@ -92,6 +92,29 @@ theorem runKeccakStack?_some
     (accelerator : Accelerator) (memory : MemoryReader) (offset : EvmWord) :
     runKeccakStack? accelerator memory [offset] = none := rfl
 
+theorem runKeccakStack?_eq_none_iff
+    (accelerator : Accelerator) (memory : MemoryReader)
+    (stack : List EvmWord) :
+    runKeccakStack? accelerator memory stack = none ↔ stack.length < 2 := by
+  constructor
+  · intro h_run
+    cases stack with
+    | nil => simp
+    | cons offset tail =>
+        cases tail with
+        | nil => simp
+        | cons size rest =>
+            simp [runKeccakStack?] at h_run
+  · intro h_len
+    cases stack with
+    | nil => rfl
+    | cons offset tail =>
+        cases tail with
+        | nil => rfl
+        | cons size rest =>
+            simp at h_len
+            omega
+
 theorem runKeccakStack?_length
     {accelerator : Accelerator} {memory : MemoryReader}
     {stack out : List EvmWord}


### PR DESCRIPTION
Adds a generic failure characterization for the pure KECCAK stack execution bridge.

Slice: evm-asm-pz2hg
GH issues: #111 #107

Local verification:
- lake build EvmAsm.EL.KeccakStackExecutionBridge
- lake build
- scripts/check-file-size.sh
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception" EvmAsm/EL/KeccakStackExecutionBridge.lean

Authored by @pirapira; implemented by Codex.
