### PR TITLE
feat(log): add stack success bridge

### DIFF
--- a/EvmAsm/EL/LogStackExecutionBridge.lean
+++ b/EvmAsm/EL/LogStackExecutionBridge.lean
@@ -156,6 +156,36 @@ theorem runLogStack?_log4
                 [topic0, topic1, topic2, topic3])
           stack := rest } := rfl
 
+theorem runLogStack?_eq_some_iff
+    (kind : LogKind) (emitter : Address) (readByte : MemoryReader)
+    (state out : LogStackState) :
+    runLogStack? kind emitter readByte state = some out ↔
+      ∃ args rest,
+        EvmAsm.Evm64.LogArgsStackDecode.decodeLogStack? kind state.stack =
+          some args ∧
+        stackRestAfterLog? kind state.stack = some rest ∧
+        out =
+          { effects :=
+              LogExecutionBridge.appendLogFromMemory
+                state.effects emitter readByte args
+            stack := rest } := by
+  cases state with
+  | mk effects stack =>
+      constructor
+      · intro h_run
+        simp [runLogStack?] at h_run
+        cases h_decode :
+            EvmAsm.Evm64.LogArgsStackDecode.decodeLogStack? kind stack with
+        | none => simp [h_decode] at h_run
+        | some args =>
+            cases h_rest : stackRestAfterLog? kind stack with
+            | none => simp [h_decode, h_rest] at h_run
+            | some rest =>
+                simp [h_decode, h_rest] at h_run
+                exact ⟨args, rest, rfl, rfl, h_run.symm⟩
+      · rintro ⟨args, rest, h_decode, h_rest, rfl⟩
+        simp [runLogStack?, h_decode, h_rest]
+
 theorem runLogStack?_stack_length
     {kind : LogKind} {emitter : Address} {readByte : MemoryReader}
     {state out : LogStackState}


### PR DESCRIPTION
Adds a generic success characterization for the pure LOG stack execution bridge across LOG0 through LOG4.

Slice: evm-asm-ks9dw
GH issues: #112 #107

Local verification:
- lake build EvmAsm.EL.LogStackExecutionBridge
- lake build
- scripts/check-file-size.sh
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception" EvmAsm/EL/LogStackExecutionBridge.lean

Authored by @pirapira; implemented by Codex.
