### PR TITLE
feat(storage): add stack failure bridge

### DIFF
--- a/EvmAsm/EL/StorageStackExecutionBridge.lean
+++ b/EvmAsm/EL/StorageStackExecutionBridge.lean
@@ -66,6 +66,23 @@ theorem stackRestAfterStorage?_sstore
 @[simp] theorem stackRestAfterStorage?_nil (kind : StorageKind) :
     stackRestAfterStorage? kind [] = none := rfl
 
+theorem runStorageStack?_eq_none_iff
+    (kind : StorageKind) (state : WorldState) (accesses : StorageAccessList)
+    (address : Address) (stackState : StorageStackState) :
+    runStorageStack? kind state accesses address stackState = none ↔
+      EvmAsm.Evm64.StorageArgs.decodeStorageStack? kind stackState.stack = none ∨
+        stackRestAfterStorage? kind stackState.stack = none := by
+  cases stackState with
+  | mk stack =>
+      simp [runStorageStack?]
+      cases h_decode :
+          EvmAsm.Evm64.StorageArgs.decodeStorageStack? kind stack with
+      | none => simp
+      | some decoded =>
+          cases h_rest : stackRestAfterStorage? kind stack with
+          | none => simp
+          | some rest => simp
+
 theorem stackWordsFromDecoded_sload
     (state : WorldState) (accesses : StorageAccessList) (address : Address)
     (slot : EvmWord) :


### PR DESCRIPTION
Adds a generic failure characterization for the pure SLOAD/SSTORE stack execution bridge.

Slice: evm-asm-pg950
GH issues: #110 #107

Local verification:
- lake build EvmAsm.EL.StorageStackExecutionBridge
- lake build
- scripts/check-file-size.sh
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception" EvmAsm/EL/StorageStackExecutionBridge.lean

Authored by @pirapira; implemented by Codex.
