### PR TITLE
feat(terminating): add stack failure bridge

### DIFF
--- a/EvmAsm/EL/LogStackExecutionBridge.lean
+++ b/EvmAsm/EL/LogStackExecutionBridge.lean
@@ -96,23 +96,6 @@ theorem stackRestAfterLog?_log4
 @[simp] theorem stackRestAfterLog?_singleton (kind : LogKind) (offset : EvmWord) :
     stackRestAfterLog? kind [offset] = none := rfl
 
-theorem runLogStack?_eq_none_iff
-    (kind : LogKind) (emitter : Address) (readByte : MemoryReader)
-    (state : LogStackState) :
-    runLogStack? kind emitter readByte state = none ↔
-      EvmAsm.Evm64.LogArgsStackDecode.decodeLogStack? kind state.stack = none ∨
-        stackRestAfterLog? kind state.stack = none := by
-  cases state with
-  | mk effects stack =>
-      simp [runLogStack?]
-      cases h_decode :
-          EvmAsm.Evm64.LogArgsStackDecode.decodeLogStack? kind stack with
-      | none => simp
-      | some args =>
-          cases h_rest : stackRestAfterLog? kind stack with
-          | none => simp
-          | some rest => simp
-
 theorem runLogStack?_log0
     (effects : CallSideEffects) (emitter : Address) (readByte : MemoryReader)
     (offset size : EvmWord) (rest : List EvmWord) :

--- a/EvmAsm/EL/TerminatingStackExecutionBridge.lean
+++ b/EvmAsm/EL/TerminatingStackExecutionBridge.lean
@@ -155,6 +155,22 @@ theorem runTerminatingStack?_selfdestruct
               (EvmAsm.Evm64.TerminatingArgs.returnArgs 0 0)
           stack := rest } := rfl
 
+theorem runTerminatingStack?_eq_none_iff
+    (kind : TerminatingKind) (state : WorldState) (readByte : MemoryReader)
+    (gasRemaining : Nat) (stackState : TerminatingStackState) :
+    runTerminatingStack? kind state readByte gasRemaining stackState = none ↔
+      argsFromStack? kind stackState.stack = none ∨
+        stackRestAfterTerminating? kind stackState.stack = none := by
+  cases stackState with
+  | mk stack =>
+      simp [runTerminatingStack?]
+      cases h_args : argsFromStack? kind stack with
+      | none => simp
+      | some args =>
+          cases h_rest : stackRestAfterTerminating? kind stack with
+          | none => simp
+          | some rest => simp
+
 theorem runTerminatingStack?_stack_length
     {kind : TerminatingKind} {state : WorldState} {readByte : MemoryReader}
     {gasRemaining : Nat} {stackState : TerminatingStackState}


### PR DESCRIPTION
Adds `runTerminatingStack?_eq_none_iff` to `EvmAsm/EL/TerminatingStackExecutionBridge.lean` so downstream executable-spec wrappers can discharge STOP/RETURN/REVERT/INVALID/SELFDESTRUCT failure paths through a single bridge instead of duplicating per-kind stack-shape matches.

Mirrors the shape of `LogStackExecutionBridge.runLogStack?_eq_none_iff` from PR #2840:
- failure ↔ `argsFromStack? = none ∨ stackRestAfterTerminating? = none`
- proof: cases stackState; simp [runTerminatingStack?]; cases on each option

References evm-asm-3oqmn and GH #113 / #107.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).
