### PR TITLE
feat(create): add stack failure bridge

### DIFF
--- a/EvmAsm/EL/CreateStackExecutionBridge.lean
+++ b/EvmAsm/EL/CreateStackExecutionBridge.lean
@@ -82,6 +82,26 @@ theorem stackRestAfterCreate?_create2
     (kind : CreateKind) (value : EvmWord) :
     stackRestAfterCreate? kind [value] = none := rfl
 
+/--
+Distinctive token: CreateStackExecutionBridge.runCreateStack?_eq_none_iff #115 #107.
+-/
+theorem runCreateStack?_eq_none_iff
+    (kind : CreateKind) (creator : Address) (readByte : MemoryReader)
+    (gas : EvmWord) (executor : Executor) (state : CreateStackState) :
+    runCreateStack? kind creator readByte gas executor state = none ↔
+      requestFromStack? kind creator readByte gas state.stack = none ∨
+        stackRestAfterCreate? kind state.stack = none := by
+  cases state with
+  | mk stack =>
+      simp [runCreateStack?]
+      cases h_request :
+          requestFromStack? kind creator readByte gas stack with
+      | none => simp
+      | some request =>
+          cases h_rest : stackRestAfterCreate? kind stack with
+          | none => simp
+          | some rest => simp
+
 theorem requestFromStack?_create
     (creator : Address) (readByte : MemoryReader) (gas : EvmWord)
     (value offset size : EvmWord) (rest : List EvmWord) :


### PR DESCRIPTION
Refs GH #115 and GH #107. Bead: evm-asm-4nxxr.\n\nAdds runCreateStack?_eq_none_iff, characterizing CREATE/CREATE2 stack execution failure as request decoding failure or stack-rest extraction failure.\n\nLocal checks:\n- lake build EvmAsm.EL.CreateStackExecutionBridge\n- lake build\n- scripts/check-file-size.sh\n- rg forbidden-pattern scan on changed file\n\nAuthored by @pirapira; implemented by Codex.