### PR TITLE
feat(terminating): add stack success bridge

### DIFF
--- a/EvmAsm/EL/TerminatingStackExecutionBridge.lean
+++ b/EvmAsm/EL/TerminatingStackExecutionBridge.lean
@@ -171,6 +171,38 @@ theorem runTerminatingStack?_eq_none_iff
           | none => simp
           | some rest => simp
 
+/--
+Distinctive token: TerminatingStackExecutionBridge.runTerminatingStack?_eq_some_iff #113 #107.
+-/
+theorem runTerminatingStack?_eq_some_iff
+    (kind : TerminatingKind) (state : WorldState) (readByte : MemoryReader)
+    (gasRemaining : Nat) (stackState : TerminatingStackState)
+    (out : TerminatingStackResult) :
+    runTerminatingStack? kind state readByte gasRemaining stackState = some out ↔
+      ∃ args rest,
+        argsFromStack? kind stackState.stack = some args ∧
+        stackRestAfterTerminating? kind stackState.stack = some rest ∧
+        out =
+          { result :=
+              TerminatingDataMemory.resultFromMemory
+                kind state readByte gasRemaining args
+            stack := rest } := by
+  cases stackState with
+  | mk stack =>
+      constructor
+      · intro h_run
+        simp [runTerminatingStack?] at h_run
+        cases h_args : argsFromStack? kind stack with
+        | none => simp [h_args] at h_run
+        | some args =>
+            cases h_rest : stackRestAfterTerminating? kind stack with
+            | none => simp [h_args, h_rest] at h_run
+            | some rest =>
+                simp [h_args, h_rest] at h_run
+                exact ⟨args, rest, rfl, rfl, h_run.symm⟩
+      · rintro ⟨args, rest, h_args, h_rest, rfl⟩
+        simp [runTerminatingStack?, h_args, h_rest]
+
 theorem runTerminatingStack?_stack_length
     {kind : TerminatingKind} {state : WorldState} {readByte : MemoryReader}
     {gasRemaining : Nat} {stackState : TerminatingStackState}


### PR DESCRIPTION
Refs GH #113 and GH #107. Bead: evm-asm-n3xr9.\n\nAdds runTerminatingStack?_eq_some_iff, characterizing successful terminating-opcode stack execution by decoded args, remaining stack, and the corresponding resultFromMemory output.\n\nLocal checks:\n- lake build EvmAsm.EL.TerminatingStackExecutionBridge\n- lake build\n- scripts/check-file-size.sh\n- rg forbidden-pattern scan on changed file\n\nAuthored by @pirapira; implemented by Codex.