### PR TITLE
feat(push): expose executable effect fields

### DIFF
--- a/EvmAsm/Evm64/Push/ExecEffect.lean
+++ b/EvmAsm/Evm64/Push/ExecEffect.lean
@@ -94,6 +94,21 @@ theorem effectFromCode_stack
     (code : List (BitVec 8)) (pc n : Nat) (stack : List EvmWord) :
     (effectFromCode code pc n stack).stack = stackAfterPush code pc n stack := rfl
 
+/--
+The executable PUSH effect stack is exactly its decoded word consed onto the
+input stack.
+
+Distinctive token: PushExecEffect.effectFromCode_stack_eq_word_cons #101 #107.
+-/
+theorem effectFromCode_stack_eq_word_cons
+    (code : List (BitVec 8)) (pc n : Nat) (stack : List EvmWord) :
+    (effectFromCode code pc n stack).stack =
+      (effectFromCode code pc n stack).word :: stack := rfl
+
+theorem effectFromCode_pc_eq_pc_plus_width
+    (code : List (BitVec 8)) (pc n : Nat) (stack : List EvmWord) :
+    (effectFromCode code pc n stack).pc = pc + 1 + n := rfl
+
 theorem effectFromCode_stack_head
     (code : List (BitVec 8)) (pc n : Nat) (stack : List EvmWord) :
     (effectFromCode code pc n stack).stack.head? =


### PR DESCRIPTION
Adds a focused PUSH executable-effect field bridge for GH #101/#107.\n\nChanges:\n- prove the bundled effect stack is the bundled decoded word consed onto the input stack\n- expose the direct PC increment form for the bundled effect\n\nDistinctive token: PushExecEffect.effectFromCode_stack_eq_word_cons #101 #107.\n\nLocal checks:\n- lake build EvmAsm.Evm64.Push.ExecEffect\n- lake build\n- scripts/check-file-size.sh\n- rg forbidden-pattern check on EvmAsm/Evm64/Push/ExecEffect.lean\n\nAuthored by @pirapira; implemented by Codex.\n\nRefs #101. Refs #107. Bead: evm-asm-c7xep.