### PR TITLE
feat(push): bridge supported loop effect

### DIFF
--- a/EvmAsm/Evm64/SupportedLoopBridge.lean
+++ b/EvmAsm/Evm64/SupportedLoopBridge.lean
@@ -42,6 +42,27 @@ theorem stepWithSupportedHandler_of_lookup
   rw [stepWithSupportedHandler_of_decode h_decode]
   exact SupportedHandlers.dispatchOpcode_of_lookup h_lookup state
 
+/--
+When the supported interpreter loop decodes a valid PUSH opcode, the one-step
+handler has the same bundled PC and stack effect as the executable PUSH bridge.
+
+Distinctive token:
+SupportedLoopBridge.stepWithSupportedHandler_PUSH_effectFromCode
+#101 #107 #108.
+-/
+theorem stepWithSupportedHandler_PUSH_effectFromCode
+    {state : EvmState} {n : Nat}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state =
+      some (EvmOpcode.PUSH n))
+    (h_valid : EvmOpcode.validPushWidth n = true) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).pc =
+        (PushExecEffect.effectFromCode state.code state.pc n state.stack).pc ∧
+      (InterpreterLoop.stepWithHandler supportedLoopHandler state).stack =
+        (PushExecEffect.effectFromCode state.code state.pc n state.stack).stack := by
+  rw [stepWithSupportedHandler_of_decode h_decode]
+  exact SupportedHandlers.dispatchOpcode_supportedHandlerTable_PUSH_effectFromCode
+    h_valid state
+
 theorem stepWithSupportedHandler_missing_invalid
     {state : EvmState} {opcode : EvmOpcode}
     (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some opcode)


### PR DESCRIPTION
Adds a focused loop-level PUSH bridge for GH #101/#107/#108.\n\nChange:\n- when the supported interpreter loop decodes a valid PUSHn opcode, prove the one-step handler has the same bundled PC and stack effect as PushExecEffect.effectFromCode\n\nDistinctive token: SupportedLoopBridge.stepWithSupportedHandler_PUSH_effectFromCode #101 #107 #108.\n\nLocal checks:\n- lake build EvmAsm.Evm64.SupportedLoopBridge\n- lake build\n- scripts/check-file-size.sh\n- rg forbidden-pattern check on EvmAsm/Evm64/SupportedLoopBridge.lean\n\nAuthored by @pirapira; implemented by Codex.\n\nRefs #101. Refs #107. Refs #108. Bead: evm-asm-9jm50.