### PR TITLE
feat(interp): bridge terminating byte dispatch

### DIFF
--- a/EvmAsm/Evm64/SupportedHandlerByte.lean
+++ b/EvmAsm/Evm64/SupportedHandlerByte.lean
@@ -54,6 +54,41 @@ theorem dispatchByte_supported_PUSH_effectFromCode
   exact SupportedHandlers.dispatchOpcode_supportedHandlerTable_PUSH_effectFromCode
     h_valid state
 
+/--
+Concrete STOP byte dispatch through the combined supported-handler table
+terminates the state successfully.
+
+Distinctive token:
+SupportedHandlerByte.dispatchByte_supported_STOP_byte #106 #107 #113.
+-/
+theorem dispatchByte_supported_STOP_byte
+    (state : EvmState) :
+    HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x00, by decide⟩ : Fin 256) state = state.stop := by
+  exact dispatchByte_supported_of_lookup EvmOpcode.decodeByte?_STOP
+    SupportedHandlers.supportedHandlerTable_STOP state
+
+@[simp] theorem dispatchByte_supported_STOP_byte_status
+    (state : EvmState) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x00, by decide⟩ : Fin 256) state).status = .stopped := by
+  rw [dispatchByte_supported_STOP_byte]
+  exact EvmState.stop_status state
+
+theorem dispatchByte_supported_INVALID_byte
+    (state : EvmState) :
+    HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0xfe, by decide⟩ : Fin 256) state = state.invalid := by
+  exact dispatchByte_supported_of_lookup EvmOpcode.decodeByte?_INVALID
+    SupportedHandlers.supportedHandlerTable_INVALID state
+
+@[simp] theorem dispatchByte_supported_INVALID_byte_status
+    (state : EvmState) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0xfe, by decide⟩ : Fin 256) state).status = .error := by
+  rw [dispatchByte_supported_INVALID_byte]
+  exact EvmState.invalid_status state
+
 theorem dispatchByte_supported_undecoded
     {b : Fin 256} (h_decode : EvmOpcode.decodeByte? b.val = none)
     (state : EvmState) :

--- a/EvmAsm/Evm64/SupportedHandlers.lean
+++ b/EvmAsm/Evm64/SupportedHandlers.lean
@@ -362,6 +362,11 @@ theorem dispatchOpcode_of_lookup
       some TerminatingHandlers.stopHandler := by
   exact lookup_of_terminating TerminatingHandlers.terminatingHandlerTable_STOP
 
+@[simp] theorem supportedHandlerTable_INVALID :
+    supportedHandlerTable .INVALID =
+      some TerminatingHandlers.invalidHandler := by
+  exact lookup_of_terminating TerminatingHandlers.terminatingHandlerTable_INVALID
+
 @[simp] theorem supportedHandlerTable_PUSH0 :
     supportedHandlerTable .PUSH0 =
       some StackHandlers.push0Handler := by


### PR DESCRIPTION
Adds concrete supported byte-dispatch bridges for terminating opcodes, covering GH #106/#107/#113.\n\nChanges:\n- add the missing supportedHandlerTable INVALID lookup lemma\n- prove concrete STOP byte dispatch through the supported handler table yields state.stop and .stopped status\n- prove concrete INVALID byte dispatch through the supported handler table yields state.invalid and .error status\n\nDistinctive token: SupportedHandlerByte.dispatchByte_supported_STOP_byte #106 #107 #113.\n\nLocal checks:\n- lake build EvmAsm.Evm64.SupportedHandlerByte\n- lake build\n- scripts/check-file-size.sh\n- rg forbidden-pattern check on changed files\n\nAuthored by @pirapira; implemented by Codex.\n\nRefs #106. Refs #107. Refs #113. Bead: evm-asm-ajy3k.