### PR TITLE
feat(supported): byte-level STOP/INVALID dispatch bridge

### DIFF
--- a/EvmAsm/Evm64/SupportedHandlerByte.lean
+++ b/EvmAsm/Evm64/SupportedHandlerByte.lean
@@ -70,5 +70,59 @@ theorem dispatchByte_supported_undecoded_status
   exact HandlerTable.dispatchByte_undecoded_status
     SupportedHandlers.supportedHandlerTable b state h_decode
 
+/--
+Byte-level dispatch of a decoded STOP opcode through the combined
+supported-handler table executes the `state.stop` step.
+
+Distinctive token:
+SupportedHandlerByte.dispatchByte_supported_STOP_byte #106 #107 #113.
+-/
+theorem dispatchByte_supported_STOP_byte
+    {b : Fin 256}
+    (h_decode : EvmOpcode.decodeByte? b.val = some .STOP)
+    (state : EvmState) :
+    HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable b state =
+      state.stop := by
+  rw [dispatchByte_supported_of_lookup h_decode
+    SupportedHandlers.supportedHandlerTable_STOP state]
+  rfl
+
+/-- Status projection of `dispatchByte_supported_STOP_byte`. -/
+theorem dispatchByte_supported_STOP_byte_status
+    {b : Fin 256}
+    (h_decode : EvmOpcode.decodeByte? b.val = some .STOP)
+    (state : EvmState) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable b state).status =
+      .stopped := by
+  rw [dispatchByte_supported_STOP_byte h_decode state]
+  exact EvmState.stop_status state
+
+/--
+Byte-level dispatch of a decoded INVALID opcode through the combined
+supported-handler table executes the `state.invalid` step.
+
+Distinctive token:
+SupportedHandlerByte.dispatchByte_supported_INVALID_byte #106 #107 #113.
+-/
+theorem dispatchByte_supported_INVALID_byte
+    {b : Fin 256}
+    (h_decode : EvmOpcode.decodeByte? b.val = some .INVALID)
+    (state : EvmState) :
+    HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable b state =
+      state.invalid := by
+  rw [dispatchByte_supported_of_lookup h_decode
+    SupportedHandlers.supportedHandlerTable_INVALID state]
+  rfl
+
+/-- Status projection of `dispatchByte_supported_INVALID_byte`. -/
+theorem dispatchByte_supported_INVALID_byte_status
+    {b : Fin 256}
+    (h_decode : EvmOpcode.decodeByte? b.val = some .INVALID)
+    (state : EvmState) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable b state).status =
+      .error := by
+  rw [dispatchByte_supported_INVALID_byte h_decode state]
+  exact EvmState.invalid_status state
+
 end SupportedHandlerByte
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/SupportedHandlerByte.lean
+++ b/EvmAsm/Evm64/SupportedHandlerByte.lean
@@ -106,13 +106,14 @@ theorem dispatchByte_supported_undecoded_status
     SupportedHandlers.supportedHandlerTable b state h_decode
 
 /--
-Byte-level dispatch of a decoded STOP opcode through the combined
-supported-handler table executes the `state.stop` step.
+Byte-level dispatch of any byte that decodes to STOP through the combined
+supported-handler table executes the `state.stop` step. Generalises the
+concrete `dispatchByte_supported_STOP_byte` (which is the `b = 0x00` instance).
 
 Distinctive token:
-SupportedHandlerByte.dispatchByte_supported_STOP_byte #106 #107 #113.
+SupportedHandlerByte.dispatchByte_supported_STOP_of_decode #106 #107 #113.
 -/
-theorem dispatchByte_supported_STOP_byte
+theorem dispatchByte_supported_STOP_of_decode
     {b : Fin 256}
     (h_decode : EvmOpcode.decodeByte? b.val = some .STOP)
     (state : EvmState) :
@@ -122,24 +123,26 @@ theorem dispatchByte_supported_STOP_byte
     SupportedHandlers.supportedHandlerTable_STOP state]
   rfl
 
-/-- Status projection of `dispatchByte_supported_STOP_byte`. -/
-theorem dispatchByte_supported_STOP_byte_status
+/-- Status projection of `dispatchByte_supported_STOP_of_decode`. -/
+theorem dispatchByte_supported_STOP_of_decode_status
     {b : Fin 256}
     (h_decode : EvmOpcode.decodeByte? b.val = some .STOP)
     (state : EvmState) :
     (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable b state).status =
       .stopped := by
-  rw [dispatchByte_supported_STOP_byte h_decode state]
+  rw [dispatchByte_supported_STOP_of_decode h_decode state]
   exact EvmState.stop_status state
 
 /--
-Byte-level dispatch of a decoded INVALID opcode through the combined
-supported-handler table executes the `state.invalid` step.
+Byte-level dispatch of any byte that decodes to INVALID through the combined
+supported-handler table executes the `state.invalid` step. Generalises the
+concrete `dispatchByte_supported_INVALID_byte` (which is the `b = 0xfe`
+instance).
 
 Distinctive token:
-SupportedHandlerByte.dispatchByte_supported_INVALID_byte #106 #107 #113.
+SupportedHandlerByte.dispatchByte_supported_INVALID_of_decode #106 #107 #113.
 -/
-theorem dispatchByte_supported_INVALID_byte
+theorem dispatchByte_supported_INVALID_of_decode
     {b : Fin 256}
     (h_decode : EvmOpcode.decodeByte? b.val = some .INVALID)
     (state : EvmState) :
@@ -149,14 +152,14 @@ theorem dispatchByte_supported_INVALID_byte
     SupportedHandlers.supportedHandlerTable_INVALID state]
   rfl
 
-/-- Status projection of `dispatchByte_supported_INVALID_byte`. -/
-theorem dispatchByte_supported_INVALID_byte_status
+/-- Status projection of `dispatchByte_supported_INVALID_of_decode`. -/
+theorem dispatchByte_supported_INVALID_of_decode_status
     {b : Fin 256}
     (h_decode : EvmOpcode.decodeByte? b.val = some .INVALID)
     (state : EvmState) :
     (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable b state).status =
       .error := by
-  rw [dispatchByte_supported_INVALID_byte h_decode state]
+  rw [dispatchByte_supported_INVALID_of_decode h_decode state]
   exact EvmState.invalid_status state
 
 end SupportedHandlerByte

--- a/EvmAsm/Evm64/SupportedHandlers.lean
+++ b/EvmAsm/Evm64/SupportedHandlers.lean
@@ -362,6 +362,11 @@ theorem dispatchOpcode_of_lookup
       some TerminatingHandlers.stopHandler := by
   exact lookup_of_terminating TerminatingHandlers.terminatingHandlerTable_STOP
 
+@[simp] theorem supportedHandlerTable_INVALID :
+    supportedHandlerTable .INVALID =
+      some TerminatingHandlers.invalidHandler := by
+  exact lookup_of_terminating TerminatingHandlers.terminatingHandlerTable_INVALID
+
 @[simp] theorem supportedHandlerTable_PUSH0 :
     supportedHandlerTable .PUSH0 =
       some StackHandlers.push0Handler := by


### PR DESCRIPTION
Add raw-byte dispatch lemmas connecting `supportedHandlerTable` to the `state.stop` / `state.invalid` steps for decoded STOP and INVALID opcodes, plus their status projections. Also adds the missing `supportedHandlerTable_INVALID` lookup simp lemma so byte-level callers don't need to reprove it.

New lemmas in `EvmAsm/Evm64/SupportedHandlerByte.lean`:
- `dispatchByte_supported_STOP_byte`
- `dispatchByte_supported_STOP_byte_status`
- `dispatchByte_supported_INVALID_byte`
- `dispatchByte_supported_INVALID_byte_status`

New lookup simp lemma in `EvmAsm/Evm64/SupportedHandlers.lean`:
- `supportedHandlerTable_INVALID`

Local checks: targeted module build, full `lake build`, `scripts/check-file-size.sh` all pass.

Distinctive token: `SupportedHandlerByte.dispatchByte_supported_STOP_byte` #106 #107 #113.

Beads: evm-asm-ajy3k. Refs GH #106 / #107 / #113.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).