### PR TITLE
feat(interp): bridge supported STOP loop

### DIFF
--- a/EvmAsm/Evm64/SupportedLoopBridge.lean
+++ b/EvmAsm/Evm64/SupportedLoopBridge.lean
@@ -42,6 +42,19 @@ theorem stepWithSupportedHandler_of_lookup
   rw [stepWithSupportedHandler_of_decode h_decode]
   exact SupportedHandlers.dispatchOpcode_of_lookup h_lookup state
 
+/--
+When the combined supported loop decodes STOP, one interpreter step terminates
+successfully.
+
+Distinctive token: SupportedLoopBridge.stepWithSupportedHandler_STOP #107 #108 #113.
+-/
+theorem stepWithSupportedHandler_STOP
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .STOP) :
+    InterpreterLoop.stepWithHandler supportedLoopHandler state = state.stop := by
+  exact stepWithSupportedHandler_of_lookup h_decode
+    SupportedHandlers.supportedHandlerTable_STOP
+
 theorem stepWithSupportedHandler_missing_invalid
     {state : EvmState} {opcode : EvmOpcode}
     (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some opcode)
@@ -68,6 +81,15 @@ theorem loopFuel_supported_succ_running_lookup
       InterpreterLoop.loopFuel supportedLoopHandler nSteps (handler state) := by
   rw [loopFuel_supported_succ_running_decode nSteps h_status h_decode]
   rw [SupportedHandlers.dispatchOpcode_of_lookup h_lookup state]
+
+theorem loopFuel_supported_succ_running_STOP
+    (nSteps : Nat) {state : EvmState}
+    (h_status : state.status = .running)
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .STOP) :
+    InterpreterLoop.loopFuel supportedLoopHandler (nSteps + 1) state =
+      InterpreterLoop.loopFuel supportedLoopHandler nSteps state.stop := by
+  exact loopFuel_supported_succ_running_lookup nSteps h_status h_decode
+    SupportedHandlers.supportedHandlerTable_STOP
 
 theorem loopFuel_supported_missing_invalid
     (nSteps : Nat) {state : EvmState} {opcode : EvmOpcode}


### PR DESCRIPTION
Adds concrete supported-loop STOP bridge lemmas for GH #107/#108/#113.\n\nChanges:\n- prove stepWithHandler over the combined supported loop yields state.stop when decoding STOP\n- prove a running one-fuel supported loop step continues from state.stop\n\nDistinctive token: SupportedLoopBridge.stepWithSupportedHandler_STOP #107 #108 #113.\n\nLocal checks:\n- lake build EvmAsm.Evm64.SupportedLoopBridge\n- lake build\n- scripts/check-file-size.sh\n- rg forbidden-pattern check on EvmAsm/Evm64/SupportedLoopBridge.lean\n\nAuthored by @pirapira; implemented by Codex.\n\nRefs #107. Refs #108. Refs #113. Bead: evm-asm-3dp24.