### PR TITLE
feat(interp): bridge supported INVALID loop

### DIFF
--- a/EvmAsm/Evm64/SupportedHandlers.lean
+++ b/EvmAsm/Evm64/SupportedHandlers.lean
@@ -362,6 +362,11 @@ theorem dispatchOpcode_of_lookup
       some TerminatingHandlers.stopHandler := by
   exact lookup_of_terminating TerminatingHandlers.terminatingHandlerTable_STOP
 
+@[simp] theorem supportedHandlerTable_INVALID :
+    supportedHandlerTable .INVALID =
+      some TerminatingHandlers.invalidHandler := by
+  exact lookup_of_terminating TerminatingHandlers.terminatingHandlerTable_INVALID
+
 @[simp] theorem supportedHandlerTable_PUSH0 :
     supportedHandlerTable .PUSH0 =
       some StackHandlers.push0Handler := by

--- a/EvmAsm/Evm64/SupportedLoopBridge.lean
+++ b/EvmAsm/Evm64/SupportedLoopBridge.lean
@@ -55,6 +55,19 @@ theorem stepWithSupportedHandler_STOP
   exact stepWithSupportedHandler_of_lookup h_decode
     SupportedHandlers.supportedHandlerTable_STOP
 
+/--
+When the combined supported loop decodes INVALID, one interpreter step enters
+the invalid/error state.
+
+Distinctive token: SupportedLoopBridge.stepWithSupportedHandler_INVALID #107 #108 #113.
+-/
+theorem stepWithSupportedHandler_INVALID
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .INVALID) :
+    InterpreterLoop.stepWithHandler supportedLoopHandler state = state.invalid := by
+  exact stepWithSupportedHandler_of_lookup h_decode
+    SupportedHandlers.supportedHandlerTable_INVALID
+
 theorem stepWithSupportedHandler_missing_invalid
     {state : EvmState} {opcode : EvmOpcode}
     (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some opcode)
@@ -90,6 +103,15 @@ theorem loopFuel_supported_succ_running_STOP
       InterpreterLoop.loopFuel supportedLoopHandler nSteps state.stop := by
   exact loopFuel_supported_succ_running_lookup nSteps h_status h_decode
     SupportedHandlers.supportedHandlerTable_STOP
+
+theorem loopFuel_supported_succ_running_INVALID
+    (nSteps : Nat) {state : EvmState}
+    (h_status : state.status = .running)
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .INVALID) :
+    InterpreterLoop.loopFuel supportedLoopHandler (nSteps + 1) state =
+      InterpreterLoop.loopFuel supportedLoopHandler nSteps state.invalid := by
+  exact loopFuel_supported_succ_running_lookup nSteps h_status h_decode
+    SupportedHandlers.supportedHandlerTable_INVALID
 
 theorem loopFuel_supported_missing_invalid
     (nSteps : Nat) {state : EvmState} {opcode : EvmOpcode}


### PR DESCRIPTION
Stacked on #2855.\n\nAdds concrete supported-loop INVALID bridge lemmas for GH #107/#108/#113.\n\nChanges:\n- prove stepWithHandler over the combined supported loop yields state.invalid when decoding INVALID\n- prove a running one-fuel supported loop step continues from state.invalid\n- include the supportedHandlerTable INVALID lookup locally because the stack base predates that main change\n\nDistinctive token: SupportedLoopBridge.stepWithSupportedHandler_INVALID #107 #108 #113.\n\nLocal checks:\n- lake build EvmAsm.Evm64.SupportedLoopBridge\n- lake build\n- scripts/check-file-size.sh\n- rg forbidden-pattern check on changed files\n\nAuthored by @pirapira; implemented by Codex.\n\nRefs #107. Refs #108. Refs #113. Bead: evm-asm-vqr0o.