### PR TITLE
feat(keccak): characterize stack request failures

### DIFF
--- a/EvmAsm/EL/KeccakStackExecutionBridge.lean
+++ b/EvmAsm/EL/KeccakStackExecutionBridge.lean
@@ -99,6 +99,35 @@ theorem requestFromStack?_eq_some_iff
     (memory : MemoryReader) (offset : EvmWord) :
     requestFromStack? memory [offset] = none := rfl
 
+/--
+The stack-to-request bridge fails exactly on stacks missing the KECCAK256
+`offset, size` pair.
+
+Distinctive token: KeccakStackExecutionBridge.requestFromStack?_eq_none_iff #111.
+-/
+theorem requestFromStack?_eq_none_iff
+    (memory : MemoryReader) (stack : List EvmWord) :
+    requestFromStack? memory stack = none ↔ stack.length < 2 := by
+  constructor
+  · intro h_request
+    cases stack with
+    | nil => simp
+    | cons offset tail =>
+        cases tail with
+        | nil => simp
+        | cons size rest =>
+            simp [requestFromStack?,
+              EvmAsm.Evm64.KeccakArgsStackDecode.decodeKeccakStack?] at h_request
+  · intro h_len
+    cases stack with
+    | nil => rfl
+    | cons offset tail =>
+        cases tail with
+        | nil => rfl
+        | cons size rest =>
+            simp at h_len
+            omega
+
 theorem resultFromStack?_some
     (accelerator : Accelerator) (memory : MemoryReader)
     (offset size : EvmWord) (rest : List EvmWord) :
@@ -137,6 +166,30 @@ theorem resultFromStack?_eq_some_iff
             exact ⟨offset, size, rest, rfl, rfl⟩
   · rintro ⟨offset, size, rest, rfl, rfl⟩
     rfl
+
+theorem resultFromStack?_eq_none_iff
+    (accelerator : Accelerator) (memory : MemoryReader)
+    (stack : List EvmWord) :
+    resultFromStack? accelerator memory stack = none ↔ stack.length < 2 := by
+  constructor
+  · intro h_result
+    cases stack with
+    | nil => simp
+    | cons offset tail =>
+        cases tail with
+        | nil => simp
+        | cons size rest =>
+            simp [resultFromStack?, requestFromStack?,
+              EvmAsm.Evm64.KeccakArgsStackDecode.decodeKeccakStack?] at h_result
+  · intro h_len
+    cases stack with
+    | nil => rfl
+    | cons offset tail =>
+        cases tail with
+        | nil => rfl
+        | cons size rest =>
+            simp at h_len
+            omega
 
 theorem runKeccakStack?_some
     (accelerator : Accelerator) (memory : MemoryReader)


### PR DESCRIPTION
Stacked on #2857.\n\nAdds KECCAK stack helper failure bridges for GH #111, complementing the request/result success characterizations.\n\nChanges:\n- characterize requestFromStack? failure as stack length < 2\n- characterize resultFromStack? failure as stack length < 2\n\nDistinctive token: KeccakStackExecutionBridge.requestFromStack?_eq_none_iff #111.\n\nLocal checks:\n- lake build EvmAsm.EL.KeccakStackExecutionBridge\n- lake build\n- scripts/check-file-size.sh\n- rg forbidden-pattern check on EvmAsm/EL/KeccakStackExecutionBridge.lean\n\nAuthored by @pirapira; implemented by Codex.\n\nRefs #111. Bead: evm-asm-6bpia.