### PR TITLE
feat(log): characterize stack decoding

### DIFF
--- a/EvmAsm/Evm64/LogArgsStackDecode.lean
+++ b/EvmAsm/Evm64/LogArgsStackDecode.lean
@@ -62,6 +62,210 @@ theorem decodeLogStack?_log4
       (offset :: size :: topic0 :: topic1 :: topic2 :: topic3 :: rest) =
       some (mkArgs offset size [topic0, topic1, topic2, topic3]) := rfl
 
+/--
+LOG0 stack decoding succeeds exactly when the stack has at least an
+`offset, size` pair on top.
+
+Distinctive token: LogArgsStackDecode.decodeLogStack?_log0_eq_some_iff #112.
+-/
+theorem decodeLogStack?_log0_eq_some_iff
+    (stack : List EvmWord) (decoded : Args) :
+    decodeLogStack? .log0 stack = some decoded ↔
+      ∃ offset size rest,
+        stack = offset :: size :: rest ∧
+        decoded = mkArgs offset size [] := by
+  constructor
+  · intro h_decode
+    cases stack with
+    | nil => simp [decodeLogStack?] at h_decode
+    | cons offset tail =>
+        cases tail with
+        | nil => simp [decodeLogStack?] at h_decode
+        | cons size rest =>
+            simp [decodeLogStack?] at h_decode
+            cases h_decode
+            exact ⟨offset, size, rest, rfl, rfl⟩
+  · rintro ⟨offset, size, rest, rfl, rfl⟩
+    rfl
+
+theorem decodeLogStack?_log1_eq_some_iff
+    (stack : List EvmWord) (decoded : Args) :
+    decodeLogStack? .log1 stack = some decoded ↔
+      ∃ offset size topic0 rest,
+        stack = offset :: size :: topic0 :: rest ∧
+        decoded = mkArgs offset size [topic0] := by
+  constructor
+  · intro h_decode
+    rcases stack with _ | ⟨offset, _ | ⟨size, _ | ⟨topic0, rest⟩⟩⟩ <;>
+      simp [decodeLogStack?] at h_decode
+    cases h_decode
+    exact ⟨offset, size, topic0, rest, rfl, rfl⟩
+  · rintro ⟨offset, size, topic0, rest, rfl, rfl⟩
+    rfl
+
+theorem decodeLogStack?_log2_eq_some_iff
+    (stack : List EvmWord) (decoded : Args) :
+    decodeLogStack? .log2 stack = some decoded ↔
+      ∃ offset size topic0 topic1 rest,
+        stack = offset :: size :: topic0 :: topic1 :: rest ∧
+        decoded = mkArgs offset size [topic0, topic1] := by
+  constructor
+  · intro h_decode
+    rcases stack with _ | ⟨offset, _ | ⟨size, _ | ⟨topic0, _ | ⟨topic1, rest⟩⟩⟩⟩ <;>
+      simp [decodeLogStack?] at h_decode
+    cases h_decode
+    exact ⟨offset, size, topic0, topic1, rest, rfl, rfl⟩
+  · rintro ⟨offset, size, topic0, topic1, rest, rfl, rfl⟩
+    rfl
+
+theorem decodeLogStack?_log3_eq_some_iff
+    (stack : List EvmWord) (decoded : Args) :
+    decodeLogStack? .log3 stack = some decoded ↔
+      ∃ offset size topic0 topic1 topic2 rest,
+        stack = offset :: size :: topic0 :: topic1 :: topic2 :: rest ∧
+        decoded = mkArgs offset size [topic0, topic1, topic2] := by
+  constructor
+  · intro h_decode
+    rcases stack with
+      _ | ⟨offset, _ | ⟨size, _ | ⟨topic0, _ | ⟨topic1, _ | ⟨topic2, rest⟩⟩⟩⟩⟩ <;>
+      simp [decodeLogStack?] at h_decode
+    cases h_decode
+    exact ⟨offset, size, topic0, topic1, topic2, rest, rfl, rfl⟩
+  · rintro ⟨offset, size, topic0, topic1, topic2, rest, rfl, rfl⟩
+    rfl
+
+theorem decodeLogStack?_log4_eq_some_iff
+    (stack : List EvmWord) (decoded : Args) :
+    decodeLogStack? .log4 stack = some decoded ↔
+      ∃ offset size topic0 topic1 topic2 topic3 rest,
+        stack = offset :: size :: topic0 :: topic1 :: topic2 :: topic3 :: rest ∧
+        decoded = mkArgs offset size [topic0, topic1, topic2, topic3] := by
+  constructor
+  · intro h_decode
+    rcases stack with
+      _ | ⟨offset, _ | ⟨size, _ | ⟨topic0, _ | ⟨topic1, _ | ⟨topic2, _ | ⟨topic3, rest⟩⟩⟩⟩⟩⟩ <;>
+      simp [decodeLogStack?] at h_decode
+    cases h_decode
+    exact ⟨offset, size, topic0, topic1, topic2, topic3, rest, rfl, rfl⟩
+  · rintro ⟨offset, size, topic0, topic1, topic2, topic3, rest, rfl, rfl⟩
+    rfl
+
+/--
+LOG-family stack decoding fails exactly when the stack is shorter than the
+required number of stack arguments for that kind.
+
+Distinctive token: LogArgsStackDecode.decodeLogStack?_log0_eq_none_iff #112.
+-/
+theorem decodeLogStack?_log0_eq_none_iff
+    (stack : List EvmWord) :
+    decodeLogStack? .log0 stack = none ↔
+      stack.length < stackArgumentCount .log0 := by
+  constructor
+  · intro h_decode
+    cases stack with
+    | nil => simp [stackArgumentCount, topicCount]
+    | cons _ tail =>
+        cases tail with
+        | nil => simp [stackArgumentCount, topicCount]
+        | cons _ _ => simp [decodeLogStack?] at h_decode
+  · intro h_len
+    cases stack with
+    | nil => rfl
+    | cons _ tail =>
+        cases tail with
+        | nil => rfl
+        | cons _ _ =>
+            simp [stackArgumentCount, topicCount] at h_len
+            omega
+
+theorem decodeLogStack?_log1_eq_none_iff
+    (stack : List EvmWord) :
+    decodeLogStack? .log1 stack = none ↔
+      stack.length < stackArgumentCount .log1 := by
+  constructor
+  · intro h_decode
+    rcases stack with _ | ⟨_, _ | ⟨_, _ | ⟨_, _⟩⟩⟩
+    · simp [stackArgumentCount, topicCount]
+    · simp [stackArgumentCount, topicCount]
+    · simp [stackArgumentCount, topicCount]
+    · simp [decodeLogStack?] at h_decode
+  · intro h_len
+    rcases stack with _ | ⟨_, _ | ⟨_, _ | ⟨_, _⟩⟩⟩
+    · rfl
+    · rfl
+    · rfl
+    · simp [stackArgumentCount, topicCount] at h_len
+      omega
+
+theorem decodeLogStack?_log2_eq_none_iff
+    (stack : List EvmWord) :
+    decodeLogStack? .log2 stack = none ↔
+      stack.length < stackArgumentCount .log2 := by
+  constructor
+  · intro h_decode
+    rcases stack with _ | ⟨_, _ | ⟨_, _ | ⟨_, _ | ⟨_, _⟩⟩⟩⟩
+    · simp [stackArgumentCount, topicCount]
+    · simp [stackArgumentCount, topicCount]
+    · simp [stackArgumentCount, topicCount]
+    · simp [stackArgumentCount, topicCount]
+    · simp [decodeLogStack?] at h_decode
+  · intro h_len
+    rcases stack with _ | ⟨_, _ | ⟨_, _ | ⟨_, _ | ⟨_, _⟩⟩⟩⟩
+    · rfl
+    · rfl
+    · rfl
+    · rfl
+    · simp [stackArgumentCount, topicCount] at h_len
+      omega
+
+theorem decodeLogStack?_log3_eq_none_iff
+    (stack : List EvmWord) :
+    decodeLogStack? .log3 stack = none ↔
+      stack.length < stackArgumentCount .log3 := by
+  constructor
+  · intro h_decode
+    rcases stack with _ | ⟨_, _ | ⟨_, _ | ⟨_, _ | ⟨_, _ | ⟨_, _⟩⟩⟩⟩⟩
+    · simp [stackArgumentCount, topicCount]
+    · simp [stackArgumentCount, topicCount]
+    · simp [stackArgumentCount, topicCount]
+    · simp [stackArgumentCount, topicCount]
+    · simp [stackArgumentCount, topicCount]
+    · simp [decodeLogStack?] at h_decode
+  · intro h_len
+    rcases stack with _ | ⟨_, _ | ⟨_, _ | ⟨_, _ | ⟨_, _ | ⟨_, _⟩⟩⟩⟩⟩
+    · rfl
+    · rfl
+    · rfl
+    · rfl
+    · rfl
+    · simp [stackArgumentCount, topicCount] at h_len
+      omega
+
+theorem decodeLogStack?_log4_eq_none_iff
+    (stack : List EvmWord) :
+    decodeLogStack? .log4 stack = none ↔
+      stack.length < stackArgumentCount .log4 := by
+  constructor
+  · intro h_decode
+    rcases stack with _ | ⟨_, _ | ⟨_, _ | ⟨_, _ | ⟨_, _ | ⟨_, _ | ⟨_, _⟩⟩⟩⟩⟩⟩
+    · simp [stackArgumentCount, topicCount]
+    · simp [stackArgumentCount, topicCount]
+    · simp [stackArgumentCount, topicCount]
+    · simp [stackArgumentCount, topicCount]
+    · simp [stackArgumentCount, topicCount]
+    · simp [stackArgumentCount, topicCount]
+    · simp [decodeLogStack?] at h_decode
+  · intro h_len
+    rcases stack with _ | ⟨_, _ | ⟨_, _ | ⟨_, _ | ⟨_, _ | ⟨_, _ | ⟨_, _⟩⟩⟩⟩⟩⟩
+    · rfl
+    · rfl
+    · rfl
+    · rfl
+    · rfl
+    · rfl
+    · simp [stackArgumentCount, topicCount] at h_len
+      omega
+
 theorem decodeLogStack?_log0_topicCountOk
     (offset size : EvmWord) (_rest : List EvmWord) :
     topicCountOk .log0 (mkArgs offset size []) := rfl


### PR DESCRIPTION
Adds direct LOG stack-argument decode characterizations for GH #112.

Changes:
- characterize LOG0..LOG4 decode success by stack shape (decodeLogStack?_log{0..4}_eq_some_iff)
- characterize LOG0..LOG4 decode failure by stack length against stackArgumentCount (decodeLogStack?_log{0..4}_eq_none_iff)

Distinctive token: LogArgsStackDecode.decodeLogStack?_log0_eq_some_iff #112.

Local checks:
- lake build EvmAsm.Evm64.LogArgsStackDecode
- lake build
- scripts/check-file-size.sh
- rg forbidden-pattern check on EvmAsm/Evm64/LogArgsStackDecode.lean

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).

Refs #112. Bead: evm-asm-ls28e.