### PR TITLE
feat(log): characterize stack decoding

### DIFF
--- a/EvmAsm/Evm64/LogArgsStackDecode.lean
+++ b/EvmAsm/Evm64/LogArgsStackDecode.lean
@@ -62,6 +62,277 @@ theorem decodeLogStack?_log4
       (offset :: size :: topic0 :: topic1 :: topic2 :: topic3 :: rest) =
       some (mkArgs offset size [topic0, topic1, topic2, topic3]) := rfl
 
+theorem decodeLogStack?_log0_eq_some_iff
+    (stack : List EvmWord) (args : Args) :
+    decodeLogStack? .log0 stack = some args ↔
+      ∃ offset size rest,
+        stack = offset :: size :: rest ∧
+          args = mkArgs offset size [] := by
+  cases stack with
+  | nil =>
+      simp [decodeLogStack?]
+  | cons offset stack =>
+      cases stack with
+      | nil =>
+          simp [decodeLogStack?]
+      | cons size rest =>
+          constructor
+          · intro h_some
+            injection h_some with h_args
+            subst args
+            exact ⟨offset, size, rest, rfl, rfl⟩
+          · rintro ⟨_, _, _, h_stack, h_args⟩
+            injection h_stack with h_offset h_tail
+            injection h_tail with h_size h_rest
+            subst_vars
+            simp [decodeLogStack?]
+
+theorem decodeLogStack?_log1_eq_some_iff
+    (stack : List EvmWord) (args : Args) :
+    decodeLogStack? .log1 stack = some args ↔
+      ∃ offset size topic0 rest,
+        stack = offset :: size :: topic0 :: rest ∧
+          args = mkArgs offset size [topic0] := by
+  cases stack with
+  | nil =>
+      simp [decodeLogStack?]
+  | cons offset stack =>
+      cases stack with
+      | nil =>
+          simp [decodeLogStack?]
+      | cons size stack =>
+          cases stack with
+          | nil =>
+              simp [decodeLogStack?]
+          | cons topic0 rest =>
+              constructor
+              · intro h_some
+                injection h_some with h_args
+                subst args
+                exact ⟨offset, size, topic0, rest, rfl, rfl⟩
+              · rintro ⟨_, _, _, _, h_stack, h_args⟩
+                injection h_stack with h_offset h_tail
+                injection h_tail with h_size h_tail'
+                injection h_tail' with h_topic0 h_rest
+                subst_vars
+                simp [decodeLogStack?]
+
+theorem decodeLogStack?_log2_eq_some_iff
+    (stack : List EvmWord) (args : Args) :
+    decodeLogStack? .log2 stack = some args ↔
+      ∃ offset size topic0 topic1 rest,
+        stack = offset :: size :: topic0 :: topic1 :: rest ∧
+          args = mkArgs offset size [topic0, topic1] := by
+  cases stack with
+  | nil =>
+      simp [decodeLogStack?]
+  | cons offset stack =>
+      cases stack with
+      | nil =>
+          simp [decodeLogStack?]
+      | cons size stack =>
+          cases stack with
+          | nil =>
+              simp [decodeLogStack?]
+          | cons topic0 stack =>
+              cases stack with
+              | nil =>
+                  simp [decodeLogStack?]
+              | cons topic1 rest =>
+                  constructor
+                  · intro h_some
+                    injection h_some with h_args
+                    subst args
+                    exact ⟨offset, size, topic0, topic1, rest, rfl, rfl⟩
+                  · rintro ⟨_, _, _, _, _, h_stack, h_args⟩
+                    injection h_stack with h_offset h_tail
+                    injection h_tail with h_size h_tail'
+                    injection h_tail' with h_topic0 h_tail''
+                    injection h_tail'' with h_topic1 h_rest
+                    subst_vars
+                    simp [decodeLogStack?]
+
+theorem decodeLogStack?_log3_eq_some_iff
+    (stack : List EvmWord) (args : Args) :
+    decodeLogStack? .log3 stack = some args ↔
+      ∃ offset size topic0 topic1 topic2 rest,
+        stack = offset :: size :: topic0 :: topic1 :: topic2 :: rest ∧
+          args = mkArgs offset size [topic0, topic1, topic2] := by
+  cases stack with
+  | nil =>
+      simp [decodeLogStack?]
+  | cons offset stack =>
+      cases stack with
+      | nil =>
+          simp [decodeLogStack?]
+      | cons size stack =>
+          cases stack with
+          | nil =>
+              simp [decodeLogStack?]
+          | cons topic0 stack =>
+              cases stack with
+              | nil =>
+                  simp [decodeLogStack?]
+              | cons topic1 stack =>
+                  cases stack with
+                  | nil =>
+                      simp [decodeLogStack?]
+                  | cons topic2 rest =>
+                      constructor
+                      · intro h_some
+                        injection h_some with h_args
+                        subst args
+                        exact ⟨offset, size, topic0, topic1, topic2, rest, rfl, rfl⟩
+                      · rintro ⟨_, _, _, _, _, _, h_stack, h_args⟩
+                        injection h_stack with h_offset h_tail
+                        injection h_tail with h_size h_tail'
+                        injection h_tail' with h_topic0 h_tail''
+                        injection h_tail'' with h_topic1 h_tail'''
+                        injection h_tail''' with h_topic2 h_rest
+                        subst_vars
+                        simp [decodeLogStack?]
+
+theorem decodeLogStack?_log4_eq_some_iff
+    (stack : List EvmWord) (args : Args) :
+    decodeLogStack? .log4 stack = some args ↔
+      ∃ offset size topic0 topic1 topic2 topic3 rest,
+        stack = offset :: size :: topic0 :: topic1 :: topic2 :: topic3 :: rest ∧
+          args = mkArgs offset size [topic0, topic1, topic2, topic3] := by
+  cases stack with
+  | nil =>
+      simp [decodeLogStack?]
+  | cons offset stack =>
+      cases stack with
+      | nil =>
+          simp [decodeLogStack?]
+      | cons size stack =>
+          cases stack with
+          | nil =>
+              simp [decodeLogStack?]
+          | cons topic0 stack =>
+              cases stack with
+              | nil =>
+                  simp [decodeLogStack?]
+              | cons topic1 stack =>
+                  cases stack with
+                  | nil =>
+                      simp [decodeLogStack?]
+                  | cons topic2 stack =>
+                      cases stack with
+                      | nil =>
+                          simp [decodeLogStack?]
+                      | cons topic3 rest =>
+                          constructor
+                          · intro h_some
+                            injection h_some with h_args
+                            subst args
+                            exact ⟨offset, size, topic0, topic1, topic2, topic3, rest, rfl, rfl⟩
+                          · rintro ⟨_, _, _, _, _, _, _, h_stack, h_args⟩
+                            injection h_stack with h_offset h_tail
+                            injection h_tail with h_size h_tail'
+                            injection h_tail' with h_topic0 h_tail''
+                            injection h_tail'' with h_topic1 h_tail'''
+                            injection h_tail''' with h_topic2 h_tail''''
+                            injection h_tail'''' with h_topic3 h_rest
+                            subst_vars
+                            simp [decodeLogStack?]
+
+theorem decodeLogStack?_eq_none_iff
+    (kind : Kind) (stack : List EvmWord) :
+    decodeLogStack? kind stack = none ↔
+      stack.length < stackArgumentCount kind := by
+  cases kind with
+  | log0 =>
+      cases stack with
+      | nil =>
+          simp [decodeLogStack?, stackArgumentCount, topicCount]
+      | cons offset stack =>
+          cases stack with
+          | nil =>
+              simp [decodeLogStack?, stackArgumentCount, topicCount]
+          | cons size rest =>
+              simp [decodeLogStack?, stackArgumentCount, topicCount]
+  | log1 =>
+      cases stack with
+      | nil =>
+          simp [decodeLogStack?, stackArgumentCount, topicCount]
+      | cons offset stack =>
+          cases stack with
+          | nil =>
+              simp [decodeLogStack?, stackArgumentCount, topicCount]
+          | cons size stack =>
+              cases stack with
+              | nil =>
+                  simp [decodeLogStack?, stackArgumentCount, topicCount]
+              | cons topic0 rest =>
+                  simp [decodeLogStack?, stackArgumentCount, topicCount]
+  | log2 =>
+      cases stack with
+      | nil =>
+          simp [decodeLogStack?, stackArgumentCount, topicCount]
+      | cons offset stack =>
+          cases stack with
+          | nil =>
+              simp [decodeLogStack?, stackArgumentCount, topicCount]
+          | cons size stack =>
+              cases stack with
+              | nil =>
+                  simp [decodeLogStack?, stackArgumentCount, topicCount]
+              | cons topic0 stack =>
+                  cases stack with
+                  | nil =>
+                      simp [decodeLogStack?, stackArgumentCount, topicCount]
+                  | cons topic1 rest =>
+                      simp [decodeLogStack?, stackArgumentCount, topicCount]
+  | log3 =>
+      cases stack with
+      | nil =>
+          simp [decodeLogStack?, stackArgumentCount, topicCount]
+      | cons offset stack =>
+          cases stack with
+          | nil =>
+              simp [decodeLogStack?, stackArgumentCount, topicCount]
+          | cons size stack =>
+              cases stack with
+              | nil =>
+                  simp [decodeLogStack?, stackArgumentCount, topicCount]
+              | cons topic0 stack =>
+                  cases stack with
+                  | nil =>
+                      simp [decodeLogStack?, stackArgumentCount, topicCount]
+                  | cons topic1 stack =>
+                      cases stack with
+                      | nil =>
+                          simp [decodeLogStack?, stackArgumentCount, topicCount]
+                      | cons topic2 rest =>
+                          simp [decodeLogStack?, stackArgumentCount, topicCount]
+  | log4 =>
+      cases stack with
+      | nil =>
+          simp [decodeLogStack?, stackArgumentCount, topicCount]
+      | cons offset stack =>
+          cases stack with
+          | nil =>
+              simp [decodeLogStack?, stackArgumentCount, topicCount]
+          | cons size stack =>
+              cases stack with
+              | nil =>
+                  simp [decodeLogStack?, stackArgumentCount, topicCount]
+              | cons topic0 stack =>
+                  cases stack with
+                  | nil =>
+                      simp [decodeLogStack?, stackArgumentCount, topicCount]
+                  | cons topic1 stack =>
+                      cases stack with
+                      | nil =>
+                          simp [decodeLogStack?, stackArgumentCount, topicCount]
+                      | cons topic2 stack =>
+                          cases stack with
+                          | nil =>
+                              simp [decodeLogStack?, stackArgumentCount, topicCount]
+                          | cons topic3 rest =>
+                              simp [decodeLogStack?, stackArgumentCount, topicCount]
+
 theorem decodeLogStack?_log0_topicCountOk
     (offset size : EvmWord) (_rest : List EvmWord) :
     topicCountOk .log0 (mkArgs offset size []) := rfl


### PR DESCRIPTION
## Summary
- add LOG0-LOG4 decodeLogStack? success iff bridge lemmas
- add a generic decodeLogStack? failure iff bridge based on stackArgumentCount

Authored by @pirapira; implemented by Codex.

## Local checks
- lake build EvmAsm.Evm64.LogArgsStackDecode
- lake build
- scripts/check-file-size.sh
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception" EvmAsm/Evm64/LogArgsStackDecode.lean (no matches)