### PR TITLE
feat(copy): characterize stack decode failures

### DIFF
--- a/EvmAsm/Evm64/Code/CopyArgsStackDecode.lean
+++ b/EvmAsm/Evm64/Code/CopyArgsStackDecode.lean
@@ -50,6 +50,23 @@ theorem decodeCodeCopyStack?_eq_some_iff
   · rintro ⟨destOffset, codeOffset, size, rest, rfl, rfl⟩
     rfl
 
+theorem decodeCodeCopyStack?_eq_none_iff (stack : List EvmWord) :
+    decodeCodeCopyStack? stack = none ↔ stack.length < 3 := by
+  constructor
+  · intro h_decode
+    rcases stack with _ | ⟨_, _ | ⟨_, _ | ⟨_, _⟩⟩⟩
+    · simp
+    · simp
+    · simp
+    · simp [decodeCodeCopyStack?] at h_decode
+  · intro h_len
+    rcases stack with _ | ⟨_, _ | ⟨_, _ | ⟨_, _⟩⟩⟩
+    · rfl
+    · rfl
+    · rfl
+    · simp at h_len
+      omega
+
 theorem decodeCodeCopyStack?_destOffset
     (destOffset codeOffset size : EvmWord) (rest : List EvmWord) :
     Option.map (fun args => args.destOffset)

--- a/EvmAsm/Evm64/ReturnData/CopyArgsStackDecode.lean
+++ b/EvmAsm/Evm64/ReturnData/CopyArgsStackDecode.lean
@@ -51,6 +51,23 @@ theorem decodeReturnDataCopyStack?_eq_some_iff
   · rintro ⟨destOffset, dataOffset, size, rest, rfl, rfl⟩
     rfl
 
+theorem decodeReturnDataCopyStack?_eq_none_iff (stack : List EvmWord) :
+    decodeReturnDataCopyStack? stack = none ↔ stack.length < 3 := by
+  constructor
+  · intro h_decode
+    rcases stack with _ | ⟨_, _ | ⟨_, _ | ⟨_, _⟩⟩⟩
+    · simp
+    · simp
+    · simp
+    · simp [decodeReturnDataCopyStack?] at h_decode
+  · intro h_len
+    rcases stack with _ | ⟨_, _ | ⟨_, _ | ⟨_, _⟩⟩⟩
+    · rfl
+    · rfl
+    · rfl
+    · simp at h_len
+      omega
+
 theorem decodeReturnDataCopyStack?_destOffset
     (destOffset dataOffset size : EvmWord) (rest : List EvmWord) :
     Option.map (fun args => args.destOffset)


### PR DESCRIPTION
## Summary
- add decodeCodeCopyStack?_eq_none_iff for CODECOPY stack decoding
- add decodeReturnDataCopyStack?_eq_none_iff for RETURNDATACOPY stack decoding

Authored by @pirapira; implemented by Codex.

## Local checks
- lake build EvmAsm.Evm64.Code.CopyArgsStackDecode
- lake build EvmAsm.Evm64.ReturnData.CopyArgsStackDecode
- lake build
- scripts/check-file-size.sh
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception" EvmAsm/Evm64/Code/CopyArgsStackDecode.lean EvmAsm/Evm64/ReturnData/CopyArgsStackDecode.lean (no matches)