### PR TITLE
feat(terminating): characterize stack decode failures

### DIFF
--- a/EvmAsm/Evm64/TerminatingArgsStackDecode.lean
+++ b/EvmAsm/Evm64/TerminatingArgsStackDecode.lean
@@ -107,6 +107,62 @@ theorem decodeSelfdestructStack?_eq_some_iff
   · rintro ⟨rest, rfl⟩
     rfl
 
+/--
+Failure characterization for `decodeReturnStack?`: the decoder returns `none`
+exactly when the stack has fewer than 2 elements.
+
+Distinctive token: TerminatingArgsStackDecode.decodeReturnStack?_eq_none_iff #113.
+-/
+theorem decodeReturnStack?_eq_none_iff (stack : List EvmWord) :
+    decodeReturnStack? stack = none ↔ stack.length < 2 := by
+  constructor
+  · intro h_decode
+    rcases stack with _ | ⟨_, _ | ⟨_, _⟩⟩
+    · simp
+    · simp
+    · simp [decodeReturnStack?] at h_decode
+  · intro h_len
+    rcases stack with _ | ⟨_, _ | ⟨_, _⟩⟩
+    · rfl
+    · rfl
+    · simp at h_len
+      omega
+
+/--
+Failure characterization for `decodeRevertStack?`: the decoder returns `none`
+exactly when the stack has fewer than 2 elements.
+-/
+theorem decodeRevertStack?_eq_none_iff (stack : List EvmWord) :
+    decodeRevertStack? stack = none ↔ stack.length < 2 := by
+  constructor
+  · intro h_decode
+    rcases stack with _ | ⟨_, _ | ⟨_, _⟩⟩
+    · simp
+    · simp
+    · simp [decodeRevertStack?] at h_decode
+  · intro h_len
+    rcases stack with _ | ⟨_, _ | ⟨_, _⟩⟩
+    · rfl
+    · rfl
+    · simp at h_len
+      omega
+
+/--
+Failure characterization for `decodeSelfdestructStack?`: the decoder returns
+`none` exactly when the stack is empty.
+-/
+theorem decodeSelfdestructStack?_eq_none_iff (stack : List EvmWord) :
+    decodeSelfdestructStack? stack = none ↔ stack.length < 1 := by
+  constructor
+  · intro h_decode
+    rcases stack with _ | ⟨_, _⟩
+    · simp
+    · simp [decodeSelfdestructStack?] at h_decode
+  · intro h_len
+    rcases stack with _ | ⟨_, _⟩
+    · rfl
+    · simp at h_len
+
 theorem decodeReturnStack?_dataRange
     (offset size : EvmWord) (rest : List EvmWord) :
     dataRange (Option.getD


### PR DESCRIPTION
Add direct failure-characterization lemmas for GH #113 terminating opcode stack argument decoders in `EvmAsm/Evm64/TerminatingArgsStackDecode.lean`:

- `decodeReturnStack?_eq_none_iff`
- `decodeRevertStack?_eq_none_iff`
- `decodeSelfdestructStack?_eq_none_iff`

Each lemma states that the corresponding decoder returns `none` iff the stack has fewer elements than the opcode requires (2 for RETURN/REVERT, 1 for SELFDESTRUCT). Pattern follows the existing CALL/STATICCALL/DELEGATECALL `_eq_none_iff` bridges in `CallArgsStackDecode.lean`.

Local checks: `lake build EvmAsm.Evm64.TerminatingArgsStackDecode`, full `lake build`, `scripts/check-file-size.sh`, no new `sorry`/`admit`/`maxHeartbeats`/`maxRecDepth`.

Refs GH #113. Beads: evm-asm-a5419.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).