### PR TITLE
feat(create): add CREATE/CREATE2 stack decode iff bridges

### DIFF
--- a/EvmAsm/Evm64/CreateArgsStackDecode.lean
+++ b/EvmAsm/Evm64/CreateArgsStackDecode.lean
@@ -86,6 +86,113 @@ theorem decodedArgumentCount_create (value offset size : EvmWord) :
 theorem decodedArgumentCount_create2 (value offset size salt : EvmWord) :
     decodedArgumentCount (.create2 (mkCreate2 value offset size salt)) = 4 := rfl
 
+/--
+CREATE stack decoding succeeds exactly when the stack has at least
+`value, offset, size` on top.
+
+Distinctive token: CreateArgsStackDecode.decodeCreateStack?_create_eq_some_iff #115.
+-/
+theorem decodeCreateStack?_create_eq_some_iff
+    (stack : List EvmWord) (decoded : Decoded) :
+    decodeCreateStack? .create stack = some decoded ↔
+      ∃ value offset size rest,
+        stack = value :: offset :: size :: rest ∧
+        decoded = .create (mkCreate value offset size) := by
+  constructor
+  · intro h_decode
+    rcases stack with _ | ⟨value, _ | ⟨offset, _ | ⟨size, rest⟩⟩⟩ <;>
+      simp [decodeCreateStack?] at h_decode
+    cases h_decode
+    exact ⟨value, offset, size, rest, rfl, rfl⟩
+  · rintro ⟨value, offset, size, rest, rfl, rfl⟩
+    rfl
+
+/--
+CREATE2 stack decoding succeeds exactly when the stack has at least
+`value, offset, size, salt` on top.
+
+Distinctive token: CreateArgsStackDecode.decodeCreateStack?_create2_eq_some_iff #115.
+-/
+theorem decodeCreateStack?_create2_eq_some_iff
+    (stack : List EvmWord) (decoded : Decoded) :
+    decodeCreateStack? .create2 stack = some decoded ↔
+      ∃ value offset size salt rest,
+        stack = value :: offset :: size :: salt :: rest ∧
+        decoded = .create2 (mkCreate2 value offset size salt) := by
+  constructor
+  · intro h_decode
+    rcases stack with _ | ⟨value, _ | ⟨offset, _ | ⟨size, _ | ⟨salt, rest⟩⟩⟩⟩ <;>
+      simp [decodeCreateStack?] at h_decode
+    cases h_decode
+    exact ⟨value, offset, size, salt, rest, rfl, rfl⟩
+  · rintro ⟨value, offset, size, salt, rest, rfl, rfl⟩
+    rfl
+
+/--
+CREATE stack decoding fails exactly when the stack is shorter than the
+required argument count.
+
+Distinctive token: CreateArgsStackDecode.decodeCreateStack?_create_eq_none_iff #115.
+-/
+theorem decodeCreateStack?_create_eq_none_iff
+    (stack : List EvmWord) :
+    decodeCreateStack? .create stack = none ↔
+      stack.length < argumentCount .create := by
+  constructor
+  · intro h_decode
+    rcases stack with _ | ⟨_, _ | ⟨_, _ | ⟨_, _⟩⟩⟩
+    · simp [argumentCount]
+    · simp [argumentCount]
+    · simp [argumentCount]
+    · simp [decodeCreateStack?] at h_decode
+  · intro h_len
+    rcases stack with _ | ⟨_, _ | ⟨_, _ | ⟨_, _⟩⟩⟩
+    · rfl
+    · rfl
+    · rfl
+    · simp [argumentCount] at h_len
+      omega
+
+/--
+CREATE2 stack decoding fails exactly when the stack is shorter than the
+required argument count.
+
+Distinctive token: CreateArgsStackDecode.decodeCreateStack?_create2_eq_none_iff #115.
+-/
+theorem decodeCreateStack?_create2_eq_none_iff
+    (stack : List EvmWord) :
+    decodeCreateStack? .create2 stack = none ↔
+      stack.length < argumentCount .create2 := by
+  constructor
+  · intro h_decode
+    rcases stack with _ | ⟨_, _ | ⟨_, _ | ⟨_, _ | ⟨_, _⟩⟩⟩⟩
+    · simp [argumentCount]
+    · simp [argumentCount]
+    · simp [argumentCount]
+    · simp [argumentCount]
+    · simp [decodeCreateStack?] at h_decode
+  · intro h_len
+    rcases stack with _ | ⟨_, _ | ⟨_, _ | ⟨_, _ | ⟨_, _⟩⟩⟩⟩
+    · rfl
+    · rfl
+    · rfl
+    · rfl
+    · simp [argumentCount] at h_len
+      omega
+
+/--
+Generic CREATE-family stack decoding failure characterization.
+
+Distinctive token: CreateArgsStackDecode.decodeCreateStack?_eq_none_iff #115.
+-/
+theorem decodeCreateStack?_eq_none_iff
+    (kind : Kind) (stack : List EvmWord) :
+    decodeCreateStack? kind stack = none ↔
+      stack.length < argumentCount kind := by
+  cases kind with
+  | create => exact decodeCreateStack?_create_eq_none_iff stack
+  | create2 => exact decodeCreateStack?_create2_eq_none_iff stack
+
 end CreateArgsStackDecode
 
 end EvmAsm.Evm64


### PR DESCRIPTION
Adds direct success/failure characterization lemmas for the CREATE-family stack argument decoder in `EvmAsm/Evm64/CreateArgsStackDecode.lean`:

- `decodeCreateStack?_create_eq_some_iff`
- `decodeCreateStack?_create2_eq_some_iff`
- `decodeCreateStack?_create_eq_none_iff`
- `decodeCreateStack?_create2_eq_none_iff`
- `decodeCreateStack?_eq_none_iff` (generic dispatch)

Mirrors the LOG / Call / Keccak / Calldata stack-decode iff bridges; intended consumers are upcoming stack-level CREATE handler specs.

Local checks: `lake build EvmAsm.Evm64.CreateArgsStackDecode`, full `lake build`, `scripts/check-file-size.sh`, `git diff --check`. No new `sorry`/`admit`/`set_option`.

Refs GH #115. Beads: evm-asm-qjcj2.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).