### PR TITLE
feat(comparison): characterize stack helpers

### DIFF
--- a/EvmAsm/Evm64/ComparisonHandlers.lean
+++ b/EvmAsm/Evm64/ComparisonHandlers.lean
@@ -95,6 +95,85 @@ def comparisonHandlerTable : HandlerTable :=
     (cmp : EvmWord → Bool) :
     unaryStack? cmp [] = none := rfl
 
+theorem binaryStack?_eq_some_iff
+    (cmp : EvmWord → EvmWord → Bool) (stack stack' : List EvmWord) :
+    binaryStack? cmp stack = some stack' ↔
+      ∃ a b rest, stack = a :: b :: rest ∧
+        stack' = boolWord (cmp a b) :: rest := by
+  constructor
+  · intro h_stack
+    cases stack with
+    | nil =>
+        simp [binaryStack?] at h_stack
+    | cons a stackTail =>
+        cases stackTail with
+        | nil =>
+            simp [binaryStack?] at h_stack
+        | cons b rest =>
+            simp [binaryStack?] at h_stack
+            exact ⟨a, b, rest, rfl, h_stack.symm⟩
+  · rintro ⟨a, b, rest, rfl, rfl⟩
+    simp [binaryStack?]
+
+theorem binaryStack?_eq_none_iff
+    (cmp : EvmWord → EvmWord → Bool) (stack : List EvmWord) :
+    binaryStack? cmp stack = none ↔ stack.length < 2 := by
+  constructor
+  · intro h_stack
+    cases stack with
+    | nil =>
+        simp
+    | cons a stackTail =>
+        cases stackTail with
+        | nil =>
+            simp
+        | cons b rest =>
+            simp [binaryStack?] at h_stack
+  · intro h_len
+    cases stack with
+    | nil =>
+        simp [binaryStack?]
+    | cons a stackTail =>
+        cases stackTail with
+        | nil =>
+            simp [binaryStack?]
+        | cons b rest =>
+            exfalso
+            simp at h_len
+            omega
+
+theorem unaryStack?_eq_some_iff
+    (cmp : EvmWord → Bool) (stack stack' : List EvmWord) :
+    unaryStack? cmp stack = some stack' ↔
+      ∃ a rest, stack = a :: rest ∧ stack' = boolWord (cmp a) :: rest := by
+  constructor
+  · intro h_stack
+    cases stack with
+    | nil =>
+        simp [unaryStack?] at h_stack
+    | cons a rest =>
+        simp [unaryStack?] at h_stack
+        exact ⟨a, rest, rfl, h_stack.symm⟩
+  · rintro ⟨a, rest, rfl, rfl⟩
+    simp [unaryStack?]
+
+theorem unaryStack?_eq_none_iff
+    (cmp : EvmWord → Bool) (stack : List EvmWord) :
+    unaryStack? cmp stack = none ↔ stack.length < 1 := by
+  constructor
+  · intro h_stack
+    cases stack with
+    | nil =>
+        simp
+    | cons a rest =>
+        simp [unaryStack?] at h_stack
+  · intro h_len
+    cases stack with
+    | nil =>
+        simp [unaryStack?]
+    | cons a rest =>
+        simp at h_len
+
 theorem binaryHandler_stack_of_binaryStack?_some
     {cmp : EvmWord → EvmWord → Bool}
     {state : EvmState} {stack' : List EvmWord}


### PR DESCRIPTION
## Summary
- add success/failure iff bridges for comparison binaryStack?
- add success/failure iff bridges for comparison unaryStack?

## Checks
- lake build EvmAsm.Evm64.ComparisonHandlers
- lake build
- scripts/check-file-size.sh
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception" EvmAsm/Evm64/ComparisonHandlers.lean (no matches)

Bead: evm-asm-zeuvh

Authored by @pirapira; implemented by Codex.