### PR TITLE
chore: noshake Rv64/ControlFlow.lean GenericSpecs/SpecDb false-positives

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -265,6 +265,8 @@
   ["EvmAsm.Rv64.AddrNorm", "EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.ExtractPure", "EvmAsm.Rv64.Tactics.RunBlock", "EvmAsm.Rv64.Tactics.XSimp"],
  "EvmAsm.Evm64.Calldata.SizeSpec":
   ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Rv64.Tactics.RunBlock"],
+ "EvmAsm.Rv64.ControlFlow":
+  ["EvmAsm.Rv64.GenericSpecs", "EvmAsm.Rv64.Tactics.SpecDb"],
  "EvmAsm.Evm64.InterpreterFetchProgram":
   ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.RunBlock"],
  "EvmAsm.Evm64.Push.Spec":


### PR DESCRIPTION
lake exe shake flags `EvmAsm.Rv64.GenericSpecs` and `EvmAsm.Rv64.Tactics.SpecDb` as removable in `EvmAsm/Rv64/ControlFlow.lean`, but locally removing them breaks the build:

- `generic_nop_spec_within` is defined in `Rv64.GenericSpecs`
- the `[spec_gen_rv64]` attribute is registered in `Rv64.Tactics.SpecDb`

Adds the entry to `scripts/noshake.json` so future shake runs do not re-flag these.

Refs evm-asm-890nd, parent evm-asm-6qj (GH #1045).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).