### PR TITLE
chore(shake): drop unused IterV4 import in IterV4InvariantsHelpers

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopDefs/IterV4InvariantsHelpers.lean
+++ b/EvmAsm/Evm64/DivMod/LoopDefs/IterV4InvariantsHelpers.lean
@@ -21,7 +21,6 @@
   Authored by @pirapira; implemented by Hermes-bot (evm-hermes).
 -/
 
-import EvmAsm.Evm64.DivMod.LoopDefs.IterV4
 import EvmAsm.Evm64.DivMod.SpecCall
 
 namespace EvmAsm.Evm64


### PR DESCRIPTION
Drops a single unused import flagged by `lake exe shake EvmAsm`:

```
EvmAsm/Evm64/DivMod/LoopDefs/IterV4InvariantsHelpers.lean:
  remove #[EvmAsm.Evm64.DivMod.LoopDefs.IterV4]
```

The file only mentions `IterV4` in a doc-comment cross-reference; no declaration from it is used. The existing `noshake.json` entry covering this file (`SpecCall`) stays — `SpecCall` IS still a real use.

Verified with `lake build` green.

Refs GH #1045. Beads: evm-asm-637n7 (parent evm-asm-6qj).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).