### PR TITLE
feat(terminating): characterize handler lookup

### DIFF
--- a/EvmAsm/Evm64/TerminatingHandlers.lean
+++ b/EvmAsm/Evm64/TerminatingHandlers.lean
@@ -37,6 +37,27 @@ def terminatingHandlerTable : HandlerTable :=
 @[simp] theorem terminatingHandler?_INVALID :
     terminatingHandler? .INVALID = some invalidHandler := rfl
 
+@[simp] theorem eq_stopHandler_iff (handler : OpcodeHandler) :
+    stopHandler = handler ↔ handler = stopHandler := by
+  constructor <;> intro h_eq <;> exact h_eq.symm
+
+@[simp] theorem eq_invalidHandler_iff (handler : OpcodeHandler) :
+    invalidHandler = handler ↔ handler = invalidHandler := by
+  constructor <;> intro h_eq <;> exact h_eq.symm
+
+theorem terminatingHandler?_eq_some_iff
+    (opcode : EvmOpcode) (handler : OpcodeHandler) :
+    terminatingHandler? opcode = some handler ↔
+      (opcode = .STOP ∧ handler = stopHandler) ∨
+        (opcode = .INVALID ∧ handler = invalidHandler) := by
+  cases opcode <;> simp [terminatingHandler?]
+
+theorem terminatingHandler?_eq_none_iff
+    (opcode : EvmOpcode) :
+    terminatingHandler? opcode = none ↔
+      opcode ≠ .STOP ∧ opcode ≠ .INVALID := by
+  cases opcode <;> simp [terminatingHandler?]
+
 @[simp] theorem stopHandler_status (state : EvmState) :
     (stopHandler state).status = .stopped := rfl
 


### PR DESCRIPTION
## Summary
- add success/failure iff bridges for terminatingHandler?
- characterize STOP/INVALID support versus unsupported opcodes

## Checks
- lake build EvmAsm.Evm64.TerminatingHandlers
- lake build
- scripts/check-file-size.sh
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception" EvmAsm/Evm64/TerminatingHandlers.lean (no matches)

Bead: evm-asm-ud0al

Authored by @pirapira; implemented by Codex.