### PR TITLE
feat(code): characterize handler lookup

### DIFF
--- a/EvmAsm/Evm64/CodeHandlers.lean
+++ b/EvmAsm/Evm64/CodeHandlers.lean
@@ -45,6 +45,21 @@ def codeHandlerTable : HandlerTable :=
 @[simp] theorem codeHandler?_CODESIZE :
     codeHandler? .CODESIZE = some codeSizeHandler := rfl
 
+@[simp] theorem eq_codeSizeHandler_iff (handler : OpcodeHandler) :
+    codeSizeHandler = handler ↔ handler = codeSizeHandler := by
+  constructor <;> intro h_eq <;> exact h_eq.symm
+
+theorem codeHandler?_eq_some_iff
+    (opcode : EvmOpcode) (handler : OpcodeHandler) :
+    codeHandler? opcode = some handler ↔
+      opcode = .CODESIZE ∧ handler = codeSizeHandler := by
+  cases opcode <;> simp [codeHandler?]
+
+theorem codeHandler?_eq_none_iff
+    (opcode : EvmOpcode) :
+    codeHandler? opcode = none ↔ opcode ≠ .CODESIZE := by
+  cases opcode <;> simp [codeHandler?]
+
 @[simp] theorem codeHandlerTable_CODESIZE :
     codeHandlerTable .CODESIZE = some codeSizeHandler := rfl
 


### PR DESCRIPTION
## Summary
- add success/failure iff bridges for `codeHandler?`
- characterize CODESIZE support versus unsupported opcodes

Mirrors the control-handler (PR #2881) and stack-handler (PR #2884)
characterizations for GH #107.

## Checks
- `lake build EvmAsm.Evm64.CodeHandlers`
- `lake build` (full)
- `scripts/check-file-size.sh`
- `git diff --check`
- forbidden-pattern scan: no sorry/admit/maxHeartbeats/maxRecDepth/file-size-exception

Bead: evm-asm-5rnjg
Refs GH #107.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).