### PR TITLE
chore(shake): noshake EvmAsm.Evm64.DivMod.AddrNorm — false positives

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -43,6 +43,8 @@
   ["EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Evm64.Stack"],
   "EvmAsm.Evm64.SignExtend.Compose": ["EvmAsm.Evm64.EvmWordArith.Common"],
   "EvmAsm.Evm64.EvmWordArith.Normalization": ["EvmAsm.Evm64.EvmWordArith.MulSubChain"],
+  "EvmAsm.Evm64.DivMod.AddrNorm":
+  ["EvmAsm.Rv64.AddrNorm", "EvmAsm.Evm64.DivMod.AddrNormAttr"],
   "EvmAsm.Evm64.DivMod.Spec.N1V4DivBridge":
   ["EvmAsm.Evm64.DivMod.Compose.FullPathN1RemainderV4"],
   "EvmAsm.Evm64.DivMod.Spec.N1V4ModBridge":


### PR DESCRIPTION
shake suggests removing `EvmAsm.Rv64.AddrNorm` and `EvmAsm.Evm64.DivMod.AddrNormAttr` from `EvmAsm/Evm64/DivMod/AddrNorm.lean`. Both are false positives:

- `EvmAsm.Rv64.AddrNorm` provides the kernel-level `se12_*` and `bv6_toNat_*` lemmas that this file tags with `@[divmod_addr]` and re-exports via `export EvmAsm.Rv64.AddrNorm (...)` so existing `open EvmAsm.Evm64.DivMod.AddrNorm` clauses keep resolving these names. shake doesn't track attribute-tagging or `export` as a usage.
- `EvmAsm.Evm64.DivMod.AddrNormAttr` declares the `register_simp_attr divmod_addr` attribute that this file uses in `@[divmod_addr, grind =]` tags. shake doesn't track `register_simp_attr` usage (well-known false-positive class — see beads `evm-asm-o6y`).

Whitelisted in `scripts/noshake.json`. Build remains clean; `lake exe shake EvmAsm` no longer reports `DivMod/AddrNorm.lean`.

Refs evm-asm-m7gln, parent evm-asm-6qj, GH #1045.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).