### PR TITLE
chore(shake): noshake EvmAsm.Rv64.RLP.Phase2Short — false positives

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -9,6 +9,8 @@
   ["Mathlib.Tactic.IntervalCases", "Mathlib.Tactic.FinCases", "Mathlib.Data.Fintype.Basic"],
   "EvmAsm.Rv64.RLP.Phase1":
   ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Rv64.Tactics.ExtractPure"],
+  "EvmAsm.Rv64.RLP.Phase2Short":
+  ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.RunBlock"],
   "EvmAsm.Rv64.RLP.Phase3SingleByte":
   ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.XSimp"],
   "EvmAsm.Rv64.RLP.Phase1CascadePrefixE2": ["EvmAsm.Rv64.RLP.Phase1Disjoint"],


### PR DESCRIPTION
shake suggests removing `EvmAsm.Rv64.SyscallSpecs` and `EvmAsm.Rv64.Tactics.RunBlock` from `EvmAsm/Rv64/RLP/Phase2Short.lean`. Both are false positives:

- `EvmAsm.Rv64.SyscallSpecs` provides the instruction-spec database consumed by `runBlock` via the `@[spec_gen_rv64]` attribute. shake doesn't track tactic-elaboration usage (well-known false-positive class — see beads `evm-asm-o6y`).
- `EvmAsm.Rv64.Tactics.RunBlock` supplies the `runBlock` tactic invoked at line 96 to discharge the `cpsTripleWithin` goal. shake misses tactic invocations.

Whitelisted in `scripts/noshake.json`. Build remains clean; `lake exe shake EvmAsm` no longer reports `Phase2Short.lean`.

Refs evm-asm-rtxte, parent evm-asm-6qj, GH #1045.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).