### PR TITLE
feat(env): characterize handler lookup

### DIFF
--- a/EvmAsm/Evm64/EnvHandlers.lean
+++ b/EvmAsm/Evm64/EnvHandlers.lean
@@ -40,6 +40,33 @@ def simpleEnvHandler? (opcode : EvmOpcode) : Option OpcodeHandler :=
   | some field => some (simpleEnvHandler field)
   | none => none
 
+theorem simpleEnvHandler?_eq_some_iff
+    (opcode : EvmOpcode) (handler : OpcodeHandler) :
+    simpleEnvHandler? opcode = some handler ↔
+      ∃ field, fieldOfOpcode? opcode = some field ∧
+        handler = simpleEnvHandler field := by
+  constructor
+  · intro h_handler
+    unfold simpleEnvHandler? at h_handler
+    cases h_field : fieldOfOpcode? opcode with
+    | none =>
+        simp [h_field] at h_handler
+    | some field =>
+        simp [h_field] at h_handler
+        exact ⟨field, rfl, h_handler.symm⟩
+  · rintro ⟨field, h_field, rfl⟩
+    simp [simpleEnvHandler?, h_field]
+
+theorem simpleEnvHandler?_eq_none_iff
+    (opcode : EvmOpcode) :
+    simpleEnvHandler? opcode = none ↔ fieldOfOpcode? opcode = none := by
+  unfold simpleEnvHandler?
+  cases h_field : fieldOfOpcode? opcode with
+  | none =>
+      simp
+  | some field =>
+      simp
+
 /-- Handler table containing the generic simple environment opcode entries.
     Distinctive token: EnvHandlers.simpleEnvHandlerTable #107. -/
 def simpleEnvHandlerTable : HandlerTable :=


### PR DESCRIPTION
## Summary
- add structural success/failure iff bridges for simpleEnvHandler?
- expose the underlying fieldOfOpcode? decision in the lookup characterization

## Checks
- lake build EvmAsm.Evm64.EnvHandlers
- lake build
- scripts/check-file-size.sh
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception" EvmAsm/Evm64/EnvHandlers.lean (no matches)

Bead: evm-asm-miiti

Authored by @pirapira; implemented by Codex.