### PR TITLE
chore(shake): noshake Phase2LongAcc SyscallSpecs/AddrNorm/RunBlock false-positives

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -27,6 +27,9 @@
   ["EvmAsm.Rv64.RLP.Phase1CascadePrefixE5", "EvmAsm.Rv64.RLP.Phase1Disjoint"],
   "EvmAsm.Rv64.RLP.Phase2LongLoad":
   ["EvmAsm.Rv64.Tactics.XSimp"],
+  "EvmAsm.Rv64.RLP.Phase2LongAcc":
+  ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.AddrNorm",
+   "EvmAsm.Rv64.Tactics.RunBlock"],
   "EvmAsm.Rv64.RLP.Phase4HintRead":
   ["EvmAsm.Rv64.HintSpecs", "EvmAsm.Rv64.AddrNorm",
    "EvmAsm.Rv64.Tactics.RunBlock", "EvmAsm.Rv64.Tactics.XSimp"],


### PR DESCRIPTION
Whitelist three false-positive imports that `lake exe shake EvmAsm`
suggests removing from `EvmAsm/Rv64/RLP/Phase2LongAcc.lean`:

- `EvmAsm.Rv64.SyscallSpecs` — needed by `runBlock` for instruction-spec lookup.
- `EvmAsm.Rv64.AddrNorm` — `open`ed at line 35 for `bv6_toNat_8` (used at line 99).
- `EvmAsm.Rv64.Tactics.RunBlock` — provides the `runBlock` tactic (line 100).

shake does not track tactic-elaboration usage or open-namespace lemma references,
so we add an entry to `scripts/noshake.json`.

Verification: `lake exe shake EvmAsm` no longer reports Phase2LongAcc.lean; `lake build` clean (1700 jobs).

Refs #1045, beads evm-asm-tp8eq.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).