### PR TITLE
chore(shake): noshake FullPathN2Bundle.Full → Bridge false-positive

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -54,6 +54,8 @@
   "EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.Bridge":
   ["EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.BridgeFalse",
    "EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.BridgeTrue"],
+  "EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.Full":
+  ["EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.Bridge"],
   "EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.BridgeFalse":
   ["EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.Branches"],
   "EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.BridgeTrue":


### PR DESCRIPTION
lake exe shake EvmAsm suggests swapping the import of `EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.Bridge` for `...Bundle.State` in `FullPathN2Bundle/Full.lean`. Verified false positive: replacing Bridge with State breaks the proof at line 106 (`preloopN2UnifiedPost_to_fullDivN2DenormPre_frame` becomes unknown). The Bridge module re-exports the Branches/BridgeFalse/BridgeTrue chain that Full.lean consumes.\n\nAdd a `noshake.json` entry pinning Bridge in FullPathN2Bundle.Full.\n\nRefs evm-asm-0yh8h / evm-asm-6qj / GH #1045.\n\nAuthored by @pirapira; implemented by Hermes-bot (evm-hermes).