### PR TITLE
feat(returndata): add copy decode failure facts

### DIFF
--- a/EvmAsm/Evm64/ReturnData/CopyArgsStackDecode.lean
+++ b/EvmAsm/Evm64/ReturnData/CopyArgsStackDecode.lean
@@ -68,6 +68,17 @@ theorem decodeReturnDataCopyStack?_eq_none_iff (stack : List EvmWord) :
     · simp at h_len
       omega
 
+theorem decodeReturnDataCopyStack?_none_of_empty :
+    decodeReturnDataCopyStack? [] = none := rfl
+
+theorem decodeReturnDataCopyStack?_none_of_one
+    (destOffset : EvmWord) :
+    decodeReturnDataCopyStack? [destOffset] = none := rfl
+
+theorem decodeReturnDataCopyStack?_none_of_two
+    (destOffset dataOffset : EvmWord) :
+    decodeReturnDataCopyStack? [destOffset, dataOffset] = none := rfl
+
 theorem decodeReturnDataCopyStack?_destOffset
     (destOffset dataOffset size : EvmWord) (rest : List EvmWord) :
     Option.map (fun args => args.destOffset)


### PR DESCRIPTION
## Summary
- add concrete empty/one/two-word failure lemmas for RETURNDATACOPY stack decoding
- align the returndata copy decoder API with the existing CALLDATACOPY decoder facts

## Verification
- lake build EvmAsm.Evm64.ReturnData.CopyArgsStackDecode
- lake build
- scripts/check-file-size.sh
- git diff --check
- forbidden-pattern scan on EvmAsm/Evm64/ReturnData/CopyArgsStackDecode.lean

Authored by @pirapira; implemented by Codex.

Refs GH #114. Bead: evm-asm-b37o.8.