### PR TITLE
feat(code): add copy decode failure facts

### DIFF
--- a/EvmAsm/Evm64/Code/CopyArgsStackDecode.lean
+++ b/EvmAsm/Evm64/Code/CopyArgsStackDecode.lean
@@ -67,6 +67,17 @@ theorem decodeCodeCopyStack?_eq_none_iff (stack : List EvmWord) :
     · simp at h_len
       omega
 
+theorem decodeCodeCopyStack?_none_of_empty :
+    decodeCodeCopyStack? [] = none := rfl
+
+theorem decodeCodeCopyStack?_none_of_one
+    (destOffset : EvmWord) :
+    decodeCodeCopyStack? [destOffset] = none := rfl
+
+theorem decodeCodeCopyStack?_none_of_two
+    (destOffset codeOffset : EvmWord) :
+    decodeCodeCopyStack? [destOffset, codeOffset] = none := rfl
+
 theorem decodeCodeCopyStack?_destOffset
     (destOffset codeOffset size : EvmWord) (rest : List EvmWord) :
     Option.map (fun args => args.destOffset)


### PR DESCRIPTION
## Summary
- add concrete empty/one/two-word failure lemmas for CODECOPY stack decoding
- align the code copy decoder API with existing CALLDATACOPY decoder facts

## Verification
- lake build EvmAsm.Evm64.Code.CopyArgsStackDecode
- lake build
- scripts/check-file-size.sh
- git diff --check
- forbidden-pattern scan on EvmAsm/Evm64/Code/CopyArgsStackDecode.lean

Authored by @pirapira; implemented by Codex.

Refs GH #118. Refs GH #107. Bead: evm-asm-jaeo.9.