### PR TITLE
feat(exp): add stack decode failure facts

### DIFF
--- a/EvmAsm/Evm64/Exp/ArgsStackDecode.lean
+++ b/EvmAsm/Evm64/Exp/ArgsStackDecode.lean
@@ -63,6 +63,13 @@ theorem decodeExpStack?_eq_none_iff
             simp [decodeExpStack?]
   · rintro (rfl | ⟨base, rfl⟩) <;> rfl
 
+theorem decodeExpStack?_none_of_empty :
+    decodeExpStack? [] = none := rfl
+
+theorem decodeExpStack?_none_of_one
+    (base : EvmWord) :
+    decodeExpStack? [base] = none := rfl
+
 theorem decodeExpStack?_base
     (base exponent : EvmWord) (rest : List EvmWord) :
     Option.map (fun args => args.base)


### PR DESCRIPTION
## Summary
- add concrete empty/singleton failure lemmas for EXP stack decoding
- mirror the small decoder API style used by other stack decoders

## Verification
- lake build EvmAsm.Evm64.Exp.ArgsStackDecode
- lake build
- scripts/check-file-size.sh
- git diff --check
- forbidden-pattern scan on EvmAsm/Evm64/Exp/ArgsStackDecode.lean

Authored by @pirapira; implemented by Codex.

Refs GH #92. Bead: evm-asm-20z6.12.