### PR TITLE
feat(handler-table): characterize orElse lookup with eq_some/none_iff

### DIFF
--- a/EvmAsm/Evm64/HandlerTableCompose.lean
+++ b/EvmAsm/Evm64/HandlerTableCompose.lean
@@ -75,6 +75,35 @@ theorem dispatchOpcode_orElse_right
       dispatchOpcode right opcode state := by
   simp [dispatchOpcode, dispatchOpcode?_orElse_right h_left state]
 
+/-- Lookup-result characterization of `orElse` returning `some`. The combined
+    table delegates to the right operand only when the left operand has no
+    entry, so a `some handler` result decomposes into "left owns it" or
+    "left misses and right owns it".
+
+    Distinctive token: `HandlerTable.orElse_eq_some_iff #107`. -/
+theorem orElse_eq_some_iff
+    {left right : HandlerTable} {opcode : EvmOpcode} {handler : OpcodeHandler} :
+    orElse left right opcode = some handler ↔
+      left opcode = some handler ∨
+        (left opcode = none ∧ right opcode = some handler) := by
+  unfold orElse
+  cases h_left : left opcode with
+  | none => simp
+  | some h => simp
+
+/-- Lookup-result characterization of `orElse` returning `none`. The combined
+    table is undefined at `opcode` exactly when both operands are.
+
+    Distinctive token: `HandlerTable.orElse_eq_none_iff #107`. -/
+theorem orElse_eq_none_iff
+    {left right : HandlerTable} {opcode : EvmOpcode} :
+    orElse left right opcode = none ↔
+      left opcode = none ∧ right opcode = none := by
+  unfold orElse
+  cases h_left : left opcode with
+  | none => simp
+  | some h => simp
+
 end HandlerTable
 
 end EvmAsm.Evm64


### PR DESCRIPTION
Adds `HandlerTable.orElse_eq_some_iff` and `HandlerTable.orElse_eq_none_iff` to `EvmAsm/Evm64/HandlerTableCompose.lean`, characterizing the result of `orElse left right opcode` against the underlying operand lookups.

These complement the existing directional rewrites (`orElse_left_some` / `orElse_left_none`) and let downstream handler-table composition proofs reason about whether a combined table is or is not defined at a given opcode without committing to which operand answers.

- `orElse_eq_some_iff`: `some handler` ↔ `left = some handler ∨ (left = none ∧ right = some handler)`
- `orElse_eq_none_iff`: `none` ↔ `left = none ∧ right = none`

`lake build` green, 0 sorry, no heartbeat / recursion-depth bumps.

Refs GH #107, beads evm-asm-pz3y5.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).