### PR TITLE
feat(keccak): add stack decode failure facts

### DIFF
--- a/EvmAsm/Evm64/KeccakArgsStackDecode.lean
+++ b/EvmAsm/Evm64/KeccakArgsStackDecode.lean
@@ -67,6 +67,13 @@ theorem decodeKeccakStack?_eq_none_iff
       | nil => simp [decodeKeccakStack?]
       | cons size rest => simp [decodeKeccakStack?]
 
+theorem decodeKeccakStack?_none_of_empty :
+    decodeKeccakStack? [] = none := rfl
+
+theorem decodeKeccakStack?_none_of_one
+    (offset : EvmWord) :
+    decodeKeccakStack? [offset] = none := rfl
+
 theorem decoded_inputRange (offset size : EvmWord) :
     inputRange (keccakArgs offset size) =
       { offset := offset, size := size } := rfl


### PR DESCRIPTION
## Summary
- add concrete empty/singleton failure lemmas for KECCAK256/SHA3 stack decoding
- mirror the small decoder API style used by other two-argument decoders

## Verification
- lake build EvmAsm.Evm64.KeccakArgsStackDecode
- lake build
- scripts/check-file-size.sh
- git diff --check
- forbidden-pattern scan on EvmAsm/Evm64/KeccakArgsStackDecode.lean

Authored by @pirapira; implemented by Codex.

Refs GH #111. Bead: evm-asm-sj7q.3.