### PR TITLE
feat(terminating): concrete stack decode failure facts

### DIFF
--- a/EvmAsm/Evm64/TerminatingArgsStackDecode.lean
+++ b/EvmAsm/Evm64/TerminatingArgsStackDecode.lean
@@ -163,6 +163,41 @@ theorem decodeSelfdestructStack?_eq_none_iff (stack : List EvmWord) :
     · rfl
     · simp at h_len
 
+/--
+`decodeReturnStack?` returns `none` on the empty stack.
+
+Distinctive token: TerminatingArgsStackDecode.decodeReturnStack?_none_of_empty #113.
+-/
+theorem decodeReturnStack?_none_of_empty :
+    decodeReturnStack? ([] : List EvmWord) = none := rfl
+
+/--
+`decodeReturnStack?` returns `none` when the stack has only one element
+(RETURN consumes two: offset and size).
+-/
+theorem decodeReturnStack?_none_of_one (offset : EvmWord) :
+    decodeReturnStack? [offset] = none := rfl
+
+/--
+`decodeRevertStack?` returns `none` on the empty stack.
+-/
+theorem decodeRevertStack?_none_of_empty :
+    decodeRevertStack? ([] : List EvmWord) = none := rfl
+
+/--
+`decodeRevertStack?` returns `none` when the stack has only one element
+(REVERT consumes two: offset and size).
+-/
+theorem decodeRevertStack?_none_of_one (offset : EvmWord) :
+    decodeRevertStack? [offset] = none := rfl
+
+/--
+`decodeSelfdestructStack?` returns `none` on the empty stack
+(SELFDESTRUCT consumes one: beneficiary).
+-/
+theorem decodeSelfdestructStack?_none_of_empty :
+    decodeSelfdestructStack? ([] : List EvmWord) = none := rfl
+
 theorem decodeReturnStack?_dataRange
     (offset size : EvmWord) (rest : List EvmWord) :
     dataRange (Option.getD


### PR DESCRIPTION
Add five concrete failure-by-shape lemmas to `EvmAsm/Evm64/TerminatingArgsStackDecode.lean`:

- `decodeReturnStack?_none_of_empty` / `_none_of_one`
- `decodeRevertStack?_none_of_empty` / `_none_of_one`
- `decodeSelfdestructStack?_none_of_empty`

Each is a one-line `rfl` since the decoders are defined by pattern-match on the head of the stack. These complement the existing `_eq_none_iff` length-based characterizations and are friendlier rewrite targets for downstream callers that want to discharge a too-short-stack obligation directly from the empty/one-element shape.

Refs GH #113, beads `evm-asm-lb52.2` (parent `evm-asm-lb52`).
Distinctive token: `TerminatingArgsStackDecode.decodeReturnStack?_none_of_empty #113`.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).
