### PR TITLE
feat(terminating): add stack decode failure facts

### DIFF
--- a/EvmAsm/Evm64/TerminatingArgsStackDecode.lean
+++ b/EvmAsm/Evm64/TerminatingArgsStackDecode.lean
@@ -163,6 +163,23 @@ theorem decodeSelfdestructStack?_eq_none_iff (stack : List EvmWord) :
     · rfl
     · simp at h_len
 
+theorem decodeReturnStack?_none_of_empty :
+    decodeReturnStack? [] = none := rfl
+
+theorem decodeReturnStack?_none_of_one
+    (offset : EvmWord) :
+    decodeReturnStack? [offset] = none := rfl
+
+theorem decodeRevertStack?_none_of_empty :
+    decodeRevertStack? [] = none := rfl
+
+theorem decodeRevertStack?_none_of_one
+    (offset : EvmWord) :
+    decodeRevertStack? [offset] = none := rfl
+
+theorem decodeSelfdestructStack?_none_of_empty :
+    decodeSelfdestructStack? [] = none := rfl
+
 theorem decodeReturnStack?_dataRange
     (offset size : EvmWord) (rest : List EvmWord) :
     dataRange (Option.getD


### PR DESCRIPTION
## Summary
- add concrete failure lemmas for empty and one-element RETURN/REVERT stack decodes
- add the empty-stack SELFDESTRUCT decode failure lemma

## Verification
- lake build EvmAsm.Evm64.TerminatingArgsStackDecode
- lake build
- scripts/check-file-size.sh
- git diff --check
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception' EvmAsm/Evm64/TerminatingArgsStackDecode.lean

Authored by @pirapira; implemented by Codex.

Refs GH #113.
Bead: evm-asm-lb52.2.