### PR TITLE
feat(create): add stack decode failure facts

### DIFF
--- a/EvmAsm/Evm64/CreateArgsStackDecode.lean
+++ b/EvmAsm/Evm64/CreateArgsStackDecode.lean
@@ -148,6 +148,32 @@ theorem decodeCreateStack?_eq_none_iff (kind : Kind) (stack : List EvmWord) :
   | create => exact decodeCreateStack?_create_eq_none_iff stack
   | create2 => exact decodeCreateStack?_create2_eq_none_iff stack
 
+theorem decodeCreateStack?_create_none_of_empty :
+    decodeCreateStack? .create [] = none := rfl
+
+theorem decodeCreateStack?_create_none_of_one
+    (value : EvmWord) :
+    decodeCreateStack? .create [value] = none := rfl
+
+theorem decodeCreateStack?_create_none_of_two
+    (value offset : EvmWord) :
+    decodeCreateStack? .create [value, offset] = none := rfl
+
+theorem decodeCreateStack?_create2_none_of_empty :
+    decodeCreateStack? .create2 [] = none := rfl
+
+theorem decodeCreateStack?_create2_none_of_one
+    (value : EvmWord) :
+    decodeCreateStack? .create2 [value] = none := rfl
+
+theorem decodeCreateStack?_create2_none_of_two
+    (value offset : EvmWord) :
+    decodeCreateStack? .create2 [value, offset] = none := rfl
+
+theorem decodeCreateStack?_create2_none_of_three
+    (value offset size : EvmWord) :
+    decodeCreateStack? .create2 [value, offset, size] = none := rfl
+
 theorem decodedKind_create (value offset size : EvmWord) :
     decodedKind (.create (mkCreate value offset size)) = .create := rfl
 


### PR DESCRIPTION
## Summary
- add concrete short-stack failure lemmas for CREATE stack decoding
- add matching short-stack failure lemmas for CREATE2 stack decoding

## Verification
- lake build EvmAsm.Evm64.CreateArgsStackDecode
- lake build
- scripts/check-file-size.sh
- git diff --check
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception' EvmAsm/Evm64/CreateArgsStackDecode.lean

Authored by @pirapira; implemented by Codex.

Refs GH #115.
Bead: evm-asm-v1rz2.