### PR TITLE
feat(storage): add stack decode failure facts

### DIFF
--- a/EvmAsm/Evm64/StorageArgs.lean
+++ b/EvmAsm/Evm64/StorageArgs.lean
@@ -169,6 +169,16 @@ theorem decodeStorageStack?_eq_none_iff
   | sload => exact decodeStorageStack?_sload_eq_none_iff stack
   | sstore => exact decodeStorageStack?_sstore_eq_none_iff stack
 
+theorem decodeStorageStack?_sload_none_of_empty :
+    decodeStorageStack? .sload [] = none := rfl
+
+theorem decodeStorageStack?_sstore_none_of_empty :
+    decodeStorageStack? .sstore [] = none := rfl
+
+theorem decodeStorageStack?_sstore_none_of_one
+    (slot : EvmWord) :
+    decodeStorageStack? .sstore [slot] = none := rfl
+
 theorem decodedKind_sload (slot : EvmWord) :
     decodedKind (.sload (mkSLoad slot)) = .sload := rfl
 


### PR DESCRIPTION
## Summary
- add concrete empty-stack failure lemma for SLOAD decoding
- add concrete short-stack failure lemmas for SSTORE decoding

## Verification
- lake build EvmAsm.Evm64.StorageArgs
- lake build
- scripts/check-file-size.sh
- git diff --check
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception' EvmAsm/Evm64/StorageArgs.lean

Authored by @pirapira; implemented by Codex.

Refs GH #110.
Bead: evm-asm-itlt3.