### PR TITLE
feat(log): add stack decode failure facts

### DIFF
--- a/EvmAsm/Evm64/LogArgsStackDecode.lean
+++ b/EvmAsm/Evm64/LogArgsStackDecode.lean
@@ -308,6 +308,81 @@ theorem decodeLogStack?_eq_none_iff
   | log3 => exact decodeLogStack?_log3_eq_none_iff stack
   | log4 => exact decodeLogStack?_log4_eq_none_iff stack
 
+theorem decodeLogStack?_log0_none_of_empty :
+    decodeLogStack? .log0 [] = none := rfl
+
+theorem decodeLogStack?_log0_none_of_one
+    (offset : EvmWord) :
+    decodeLogStack? .log0 [offset] = none := rfl
+
+theorem decodeLogStack?_log1_none_of_empty :
+    decodeLogStack? .log1 [] = none := rfl
+
+theorem decodeLogStack?_log1_none_of_one
+    (offset : EvmWord) :
+    decodeLogStack? .log1 [offset] = none := rfl
+
+theorem decodeLogStack?_log1_none_of_two
+    (offset size : EvmWord) :
+    decodeLogStack? .log1 [offset, size] = none := rfl
+
+theorem decodeLogStack?_log2_none_of_empty :
+    decodeLogStack? .log2 [] = none := rfl
+
+theorem decodeLogStack?_log2_none_of_one
+    (offset : EvmWord) :
+    decodeLogStack? .log2 [offset] = none := rfl
+
+theorem decodeLogStack?_log2_none_of_two
+    (offset size : EvmWord) :
+    decodeLogStack? .log2 [offset, size] = none := rfl
+
+theorem decodeLogStack?_log2_none_of_three
+    (offset size topic0 : EvmWord) :
+    decodeLogStack? .log2 [offset, size, topic0] = none := rfl
+
+theorem decodeLogStack?_log3_none_of_empty :
+    decodeLogStack? .log3 [] = none := rfl
+
+theorem decodeLogStack?_log3_none_of_one
+    (offset : EvmWord) :
+    decodeLogStack? .log3 [offset] = none := rfl
+
+theorem decodeLogStack?_log3_none_of_two
+    (offset size : EvmWord) :
+    decodeLogStack? .log3 [offset, size] = none := rfl
+
+theorem decodeLogStack?_log3_none_of_three
+    (offset size topic0 : EvmWord) :
+    decodeLogStack? .log3 [offset, size, topic0] = none := rfl
+
+theorem decodeLogStack?_log3_none_of_four
+    (offset size topic0 topic1 : EvmWord) :
+    decodeLogStack? .log3 [offset, size, topic0, topic1] = none := rfl
+
+theorem decodeLogStack?_log4_none_of_empty :
+    decodeLogStack? .log4 [] = none := rfl
+
+theorem decodeLogStack?_log4_none_of_one
+    (offset : EvmWord) :
+    decodeLogStack? .log4 [offset] = none := rfl
+
+theorem decodeLogStack?_log4_none_of_two
+    (offset size : EvmWord) :
+    decodeLogStack? .log4 [offset, size] = none := rfl
+
+theorem decodeLogStack?_log4_none_of_three
+    (offset size topic0 : EvmWord) :
+    decodeLogStack? .log4 [offset, size, topic0] = none := rfl
+
+theorem decodeLogStack?_log4_none_of_four
+    (offset size topic0 topic1 : EvmWord) :
+    decodeLogStack? .log4 [offset, size, topic0, topic1] = none := rfl
+
+theorem decodeLogStack?_log4_none_of_five
+    (offset size topic0 topic1 topic2 : EvmWord) :
+    decodeLogStack? .log4 [offset, size, topic0, topic1, topic2] = none := rfl
+
 theorem decodeLogStack?_log0_topicCountOk
     (offset size : EvmWord) (_rest : List EvmWord) :
     topicCountOk .log0 (mkArgs offset size []) := rfl


### PR DESCRIPTION
## Summary
- add concrete short-stack failure lemmas for LOG0 through LOG4 decoding
- keep the generic failure characterization unchanged and add direct rewrite facts for each arity

## Verification
- lake build EvmAsm.Evm64.LogArgsStackDecode
- lake build
- scripts/check-file-size.sh
- git diff --check
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception' EvmAsm/Evm64/LogArgsStackDecode.lean

Authored by @pirapira; implemented by Codex.

Refs GH #112.
Bead: evm-asm-rz4wk.