### PR TITLE
feat(terminating): add stack bridge underflow facts

### DIFF
--- a/EvmAsm/EL/TerminatingStackExecutionBridge.lean
+++ b/EvmAsm/EL/TerminatingStackExecutionBridge.lean
@@ -86,6 +86,23 @@ theorem stackRestAfterTerminating?_selfdestruct
     stackRestAfterTerminating? .selfdestruct (beneficiary :: rest) =
       some rest := rfl
 
+theorem stackRestAfterTerminating?_return_none_of_empty :
+    stackRestAfterTerminating? .return_ [] = none := rfl
+
+theorem stackRestAfterTerminating?_return_none_of_one
+    (offset : EvmWord) :
+    stackRestAfterTerminating? .return_ [offset] = none := rfl
+
+theorem stackRestAfterTerminating?_revert_none_of_empty :
+    stackRestAfterTerminating? .revert [] = none := rfl
+
+theorem stackRestAfterTerminating?_revert_none_of_one
+    (offset : EvmWord) :
+    stackRestAfterTerminating? .revert [offset] = none := rfl
+
+theorem stackRestAfterTerminating?_selfdestruct_none_of_empty :
+    stackRestAfterTerminating? .selfdestruct [] = none := rfl
+
 theorem argsFromStack?_return
     (offset size : EvmWord) (rest : List EvmWord) :
     argsFromStack? .return_ (offset :: size :: rest) =
@@ -100,6 +117,23 @@ theorem argsFromStack?_selfdestruct
     (beneficiary : EvmWord) (rest : List EvmWord) :
     argsFromStack? .selfdestruct (beneficiary :: rest) =
       some (EvmAsm.Evm64.TerminatingArgs.returnArgs 0 0) := rfl
+
+theorem argsFromStack?_return_none_of_empty :
+    argsFromStack? .return_ [] = none := rfl
+
+theorem argsFromStack?_return_none_of_one
+    (offset : EvmWord) :
+    argsFromStack? .return_ [offset] = none := rfl
+
+theorem argsFromStack?_revert_none_of_empty :
+    argsFromStack? .revert [] = none := rfl
+
+theorem argsFromStack?_revert_none_of_one
+    (offset : EvmWord) :
+    argsFromStack? .revert [offset] = none := rfl
+
+theorem argsFromStack?_selfdestruct_none_of_empty :
+    argsFromStack? .selfdestruct [] = none := rfl
 
 theorem runTerminatingStack?_stop
     (state : WorldState) (readByte : MemoryReader) (gasRemaining : Nat)
@@ -154,6 +188,36 @@ theorem runTerminatingStack?_selfdestruct
               .selfdestruct state readByte gasRemaining
               (EvmAsm.Evm64.TerminatingArgs.returnArgs 0 0)
           stack := rest } := rfl
+
+theorem runTerminatingStack?_return_none_of_empty
+    (state : WorldState) (readByte : MemoryReader) (gasRemaining : Nat) :
+    runTerminatingStack? .return_ state readByte gasRemaining { stack := [] } =
+      none := rfl
+
+theorem runTerminatingStack?_return_none_of_one
+    (state : WorldState) (readByte : MemoryReader) (gasRemaining : Nat)
+    (offset : EvmWord) :
+    runTerminatingStack? .return_ state readByte gasRemaining
+        { stack := [offset] } =
+      none := rfl
+
+theorem runTerminatingStack?_revert_none_of_empty
+    (state : WorldState) (readByte : MemoryReader) (gasRemaining : Nat) :
+    runTerminatingStack? .revert state readByte gasRemaining { stack := [] } =
+      none := rfl
+
+theorem runTerminatingStack?_revert_none_of_one
+    (state : WorldState) (readByte : MemoryReader) (gasRemaining : Nat)
+    (offset : EvmWord) :
+    runTerminatingStack? .revert state readByte gasRemaining
+        { stack := [offset] } =
+      none := rfl
+
+theorem runTerminatingStack?_selfdestruct_none_of_empty
+    (state : WorldState) (readByte : MemoryReader) (gasRemaining : Nat) :
+    runTerminatingStack? .selfdestruct state readByte gasRemaining
+        { stack := [] } =
+      none := rfl
 
 theorem runTerminatingStack?_eq_none_iff
     (kind : TerminatingKind) (state : WorldState) (readByte : MemoryReader)


### PR DESCRIPTION
## Summary
- add concrete stack-rest and argsFromStack? underflow facts for RETURN, REVERT, and SELFDESTRUCT
- add matching runTerminatingStack? underflow facts for short stacks

## Verification
- lake build EvmAsm.EL.TerminatingStackExecutionBridge
- lake build
- scripts/check-file-size.sh
- git diff --check
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception' EvmAsm/EL/TerminatingStackExecutionBridge.lean

Authored by @pirapira; implemented by Codex.

Refs GH #113.
Bead: evm-asm-qnrh2.