### PR TITLE
feat(exp): add stack-rest underflow facts

### DIFF
--- a/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
+++ b/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
@@ -73,6 +73,13 @@ theorem runExpStack?_underflow_nil :
 theorem runExpStack?_underflow_one (base : EvmWord) :
     runExpStack? { stack := [base] } = none := rfl
 
+theorem stackRestAfterExp?_none_of_empty :
+    stackRestAfterExp? [] = none := rfl
+
+theorem stackRestAfterExp?_none_of_one
+    (base : EvmWord) :
+    stackRestAfterExp? [base] = none := rfl
+
 theorem stackRestAfterExp?_eq_none_iff
     {stack : List EvmWord} :
     stackRestAfterExp? stack = none ↔


### PR DESCRIPTION
## Summary
- add direct stackRestAfterExp? underflow facts for empty and one-word stacks

## Verification
- lake build EvmAsm.Evm64.Exp.StackExecutionBridge
- lake build
- scripts/check-file-size.sh
- git diff --check
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception' EvmAsm/Evm64/Exp/StackExecutionBridge.lean

Authored by @pirapira; implemented by Codex.

Refs GH #92.
Bead: evm-asm-od047.