### PR TITLE
feat(worldstate): add projection update preservation

### DIFF
--- a/EvmAsm/EL/WorldState.lean
+++ b/EvmAsm/EL/WorldState.lean
@@ -227,6 +227,20 @@ theorem getAccount_setAccountCode_ne
   cases h_account : getAccount state addr <;>
     simp [getAccount_setAccount_ne, h_ne]
 
+theorem accountCode?_setAccountCode_ne
+    (state : WorldState) {addr other : Address} (codeHash : Hash256) (code : List Byte)
+    (h_ne : other ≠ addr) :
+    accountCode? (setAccountCode state addr codeHash code) other =
+      accountCode? state other := by
+  simp [accountCode?, getAccount_setAccountCode_ne state codeHash code h_ne]
+
+theorem accountCodeHash?_setAccountCode_ne
+    (state : WorldState) {addr other : Address} (codeHash : Hash256) (code : List Byte)
+    (h_ne : other ≠ addr) :
+    accountCodeHash? (setAccountCode state addr codeHash code) other =
+      accountCodeHash? state other := by
+  simp [accountCodeHash?, getAccount_setAccountCode_ne state codeHash code h_ne]
+
 @[simp] theorem accountBalance?_empty (addr : Address) :
     accountBalance? empty addr = none := rfl
 
@@ -292,6 +306,13 @@ theorem getAccount_setAccountBalance_ne
   | some account =>
       exact getAccount_setAccount_ne state { account with balance := balance } h_ne
 
+theorem accountBalance?_setAccountBalance_ne
+    {state : WorldState} {addr other : Address} {balance : Word256}
+    (h_ne : other ≠ addr) :
+    accountBalance? (setAccountBalance state addr balance) other =
+      accountBalance? state other := by
+  simp [accountBalance?, getAccount_setAccountBalance_ne h_ne]
+
 @[simp] theorem accountNonce?_empty (addr : Address) :
     accountNonce? empty addr = none := rfl
 
@@ -356,6 +377,13 @@ theorem getAccount_setAccountNonce_ne
   | none => rfl
   | some account =>
       exact getAccount_setAccount_ne state { account with nonce := nonce } h_ne
+
+theorem accountNonce?_setAccountNonce_ne
+    {state : WorldState} {addr other : Address} {nonce : Nat}
+    (h_ne : other ≠ addr) :
+    accountNonce? (setAccountNonce state addr nonce) other =
+      accountNonce? state other := by
+  simp [accountNonce?, getAccount_setAccountNonce_ne h_ne]
 
 @[simp] theorem getStorage_setStorage_same
     (state : WorldState) (addr : Address) (key : StorageKey) (value : Word256) :


### PR DESCRIPTION
## Summary
- add other-address preservation lemmas for accountCode? and accountCodeHash? under setAccountCode
- add matching preservation lemmas for accountBalance? under setAccountBalance and accountNonce? under setAccountNonce

## Verification
- lake build EvmAsm.EL.WorldState
- lake build
- scripts/check-file-size.sh
- git diff --check
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception' EvmAsm/EL/WorldState.lean (no matches)

Authored by @pirapira; implemented by Codex.

Refs GH #123.
Bead: evm-asm-tvezp.