### PR TITLE
feat(precompile): add result projection bridges

### DIFF
--- a/EvmAsm/Evm64/PrecompileResult.lean
+++ b/EvmAsm/Evm64/PrecompileResult.lean
@@ -51,22 +51,58 @@ def preservesGasBound (input : PrecompileInput) (result : PrecompileResult) : Pr
 def outputMatches (result : PrecompileResult) (out : List (BitVec 8)) : Prop :=
   result.status = .success ∧ result.output = out
 
+@[simp] theorem ok_status (out : List (BitVec 8)) (gasRemaining : Nat) :
+    (ok out gasRemaining).status = .success := rfl
+
+@[simp] theorem ok_output (out : List (BitVec 8)) (gasRemaining : Nat) :
+    (ok out gasRemaining).output = out := rfl
+
+@[simp] theorem ok_gasRemaining (out : List (BitVec 8)) (gasRemaining : Nat) :
+    (ok out gasRemaining).gasRemaining = gasRemaining := rfl
+
+@[simp] theorem fail_status (gasRemaining : Nat) :
+    (fail gasRemaining).status = .failure := rfl
+
+@[simp] theorem fail_output (gasRemaining : Nat) :
+    (fail gasRemaining).output = ([] : List (BitVec 8)) := rfl
+
+@[simp] theorem fail_gasRemaining (gasRemaining : Nat) :
+    (fail gasRemaining).gasRemaining = gasRemaining := rfl
+
 theorem succeeded_ok (out : List (BitVec 8)) (gasRemaining : Nat) :
     succeeded (ok out gasRemaining) := rfl
 
 theorem failed_fail (gasRemaining : Nat) :
     failed (fail gasRemaining) := rfl
 
-theorem output_fail (gasRemaining : Nat) :
+@[simp] theorem output_fail (gasRemaining : Nat) :
     (fail gasRemaining).output = ([] : List (BitVec 8)) := rfl
 
 theorem outputMatches_ok (out : List (BitVec 8)) (gasRemaining : Nat) :
     outputMatches (ok out gasRemaining) out := by
   exact ⟨rfl, rfl⟩
 
+theorem not_failed_ok (out : List (BitVec 8)) (gasRemaining : Nat) :
+    ¬ failed (ok out gasRemaining) := by
+  simp [failed]
+
 theorem not_succeeded_fail (gasRemaining : Nat) :
     ¬ succeeded (fail gasRemaining) := by
   simp [succeeded, fail]
+
+theorem not_outputMatches_fail (out : List (BitVec 8)) (gasRemaining : Nat) :
+    ¬ outputMatches (fail gasRemaining) out := by
+  simp [outputMatches]
+
+theorem preservesGasBound_ok_iff
+    (input : PrecompileInput) (out : List (BitVec 8)) (gasRemaining : Nat) :
+    preservesGasBound input (ok out gasRemaining) ↔ gasRemaining ≤ input.gas := by
+  simp [preservesGasBound]
+
+theorem preservesGasBound_fail_iff
+    (input : PrecompileInput) (gasRemaining : Nat) :
+    preservesGasBound input (fail gasRemaining) ↔ gasRemaining ≤ input.gas := by
+  simp [preservesGasBound]
 
 theorem preservesGasBound_same (input : PrecompileInput) :
     preservesGasBound input (ok ([] : List (BitVec 8)) input.gas) := by


### PR DESCRIPTION
## Summary
- add simp field projections for PrecompileResult.ok and fail
- add failed/outputMatches negative facts and preservesGasBound iff bridges for ok/fail results

## Verification
- lake build EvmAsm.Evm64.PrecompileResult
- lake build
- scripts/check-file-size.sh
- git diff --check
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception' EvmAsm/Evm64/PrecompileResult.lean (no matches)

Authored by @pirapira; implemented by Codex.

Refs GH #116.
Bead: evm-asm-12c3b.