### PR TITLE
feat(precompile): add gas cost existence bridges

### DIFF
--- a/EvmAsm/Evm64/Precompile.lean
+++ b/EvmAsm/Evm64/Precompile.lean
@@ -158,6 +158,15 @@ theorem precompileGasCost?_eq_none_iff (p : Precompile) (inputLen : Nat) :
     precompileGasCost? p inputLen = none ↔ p = modexp ∨ p = blake2f := by
   cases p <;> simp [precompileGasCost?, gasSchedule]
 
+theorem precompileGasCost?_isSome_iff (p : Precompile) (inputLen : Nat) :
+    (precompileGasCost? p inputLen).isSome ↔ p ≠ modexp ∧ p ≠ blake2f := by
+  cases p <;> simp [precompileGasCost?, gasSchedule]
+
+theorem precompileGasCost?_exists_some_iff (p : Precompile) (inputLen : Nat) :
+    (∃ cost, precompileGasCost? p inputLen = some cost) ↔
+      p ≠ modexp ∧ p ≠ blake2f := by
+  cases p <;> simp [precompileGasCost?, gasSchedule]
+
 theorem blake2fGas_eq_rounds (rounds : Nat) :
     blake2fGas rounds = rounds := rfl
 


### PR DESCRIPTION
## Summary
- add an isSome iff bridge for Precompile.precompileGasCost?
- add an existential some-result iff bridge matching the existing none characterization

## Verification
- lake build EvmAsm.Evm64.Precompile
- lake build
- scripts/check-file-size.sh
- git diff --check
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception' EvmAsm/Evm64/Precompile.lean (no matches)

Authored by @pirapira; implemented by Codex.

Refs GH #116.
Bead: evm-asm-fsbve.