### PR TITLE
feat(dispatch): add modeled byte bridges

### DIFF
--- a/EvmAsm/Evm64/Dispatch.lean
+++ b/EvmAsm/Evm64/Dispatch.lean
@@ -159,6 +159,16 @@ def decodeByte? : Nat → Option EvmOpcode
 def modeledByte (b : Nat) : Prop :=
   (decodeByte? b).isSome
 
+theorem modeledByte_iff_exists_decode {b : Nat} :
+    modeledByte b ↔ ∃ opcode, decodeByte? b = some opcode := by
+  unfold modeledByte
+  cases decodeByte? b <;> simp
+
+theorem not_modeledByte_iff_decode_none {b : Nat} :
+    ¬ modeledByte b ↔ decodeByte? b = none := by
+  unfold modeledByte
+  cases decodeByte? b <;> simp
+
 theorem decodeByte?_ADD : decodeByte? 0x01 = some ADD := rfl
 theorem decodeByte?_STOP : decodeByte? 0x00 = some STOP := rfl
 theorem decodeByte?_MUL : decodeByte? 0x02 = some MUL := rfl


### PR DESCRIPTION
## Summary
- add generic modeledByte bridge lemmas connecting dispatch support to decodeByte? witnesses and none results

## Verification
- lake build EvmAsm.Evm64.Dispatch
- lake build
- scripts/check-file-size.sh
- git diff --check
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception' EvmAsm/Evm64/Dispatch.lean (no matches)

Refs GH #106.
Bead: evm-asm-8z50e.