### PR TITLE
feat(handler): add decoded byte dispatch bridges

### DIFF
--- a/EvmAsm/Evm64/HandlerTableByte.lean
+++ b/EvmAsm/Evm64/HandlerTableByte.lean
@@ -53,11 +53,38 @@ def dispatchByte (table : HandlerTable) (b : Fin 256)
     dispatchByte table b state = state.invalid := by
   simp [dispatchByte, h_decode]
 
+theorem dispatchByte_decoded_lookup
+    {table : HandlerTable} {b : Fin 256} {opcode : EvmOpcode}
+    {handler : OpcodeHandler} (state : EvmState)
+    (h_decode : EvmOpcode.decodeByte? b.val = some opcode)
+    (h_lookup : table opcode = some handler) :
+    dispatchByte table b state = handler state := by
+  rw [dispatchByte_decoded table b opcode state h_decode]
+  exact HandlerTable.dispatchOpcode_some h_lookup state
+
+theorem dispatchByte_decoded_missing
+    {table : HandlerTable} {b : Fin 256} {opcode : EvmOpcode}
+    (state : EvmState)
+    (h_decode : EvmOpcode.decodeByte? b.val = some opcode)
+    (h_lookup : table opcode = none) :
+    dispatchByte table b state = state.invalid := by
+  rw [dispatchByte_decoded table b opcode state h_decode]
+  exact HandlerTable.dispatchOpcode_none h_lookup state
+
 theorem dispatchByte_undecoded_status
     (table : HandlerTable) (b : Fin 256) (state : EvmState)
     (h_decode : EvmOpcode.decodeByte? b.val = none) :
     (dispatchByte table b state).status = .error := by
   rw [dispatchByte_undecoded table b state h_decode]
+  exact EvmState.invalid_status state
+
+theorem dispatchByte_decoded_missing_status
+    {table : HandlerTable} {b : Fin 256} {opcode : EvmOpcode}
+    (state : EvmState)
+    (h_decode : EvmOpcode.decodeByte? b.val = some opcode)
+    (h_lookup : table opcode = none) :
+    (dispatchByte table b state).status = .error := by
+  rw [dispatchByte_decoded_missing state h_decode h_lookup]
   exact EvmState.invalid_status state
 
 /-- Empty handler table dispatches every byte to the INVALID step. -/


### PR DESCRIPTION
## Summary
- add HandlerTable.dispatchByte bridges for decoded bytes with successful handler lookup
- add missing-handler INVALID/status bridges for decoded bytes

## Verification
- lake build EvmAsm.Evm64.HandlerTableByte
- lake build
- scripts/check-file-size.sh
- git diff --check
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception' EvmAsm/Evm64/HandlerTableByte.lean (no matches)

Refs GH #106.
Refs GH #107.
Bead: evm-asm-jaeo.11.