### PR TITLE
feat(addmod): phase2 reduce + epilogue sub-programs (#91 slice 3b)

### DIFF
--- a/EvmAsm/Evm64/AddMod/Program.lean
+++ b/EvmAsm/Evm64/AddMod/Program.lean
@@ -85,4 +85,182 @@ theorem evm_addmod_phase1_carry_byte_length :
     4 * evm_addmod_phase1_carry.length = 4 := by
   rw [evm_addmod_phase1_carry_length]
 
+-- ============================================================================
+-- Slice 3b — Phase 2 (modulus reduction) + Epilogue program skeletons
+-- ============================================================================
+--
+-- Per `docs/91-addmod-mulmod-survey.md` §5.1, after the prologue + phase 1
+-- finish, the runtime state is:
+--
+--   * `x12 = sp + 32` (advanced by `evm_add`'s trailing `ADDI x12, x12, 32`)
+--   * Top stack cell at `x12 + 0..24` holds `r := (a + b) (mod 2^256)`
+--   * Stack cell at `x12 + 32..58` holds `N` (the modulus) — untouched
+--   * `x7` holds the 257th carry bit `c ∈ {0, 1}` of `a.toNat + b.toNat`
+--
+-- The remaining work decomposes into three bite-sized blocks (as four
+-- separate `Program`s here, plus the assembled phase-2 wrapper in slice
+-- 3c). All branch / call distances are passed in as `BitVec`-typed
+-- parameters so the assembled `evm_addmod` Program in slice 3c
+-- (`evm-asm-xl2jn`) can pin the concrete offsets without re-rolling
+-- this file.
+--
+-- This slice introduces only the program text and length lemmas; per
+-- `evm-asm-f027s` acceptance, no `cpsTriple` proofs are required.
+-- The actual stack-level `evm_addmod_stack_spec` is the job of slice 3d
+-- (`evm-asm-s7v49`).
+
+/-- Phase 2 — short-circuit test for `N = 0`.
+
+    OR-folds the four 64-bit limbs of `N` (currently at `x12 + 32..56`,
+    since the prologue advanced `x12` by 32 and `N` was originally the
+    third stack cell) into scratch register `x6`, then takes a
+    forward `BEQ x6, x0, skipOff` branch to the zero-store path when
+    `N` is identically zero. The `BEQ` byte offset `skipOff` is the
+    distance from this BEQ instruction to the entry of
+    `evm_addmod_phase2_zero_path`; the concrete value is pinned in
+    slice 3c when `evm_addmod` is assembled.
+
+    8 instructions:
+
+      LD  x6, x12, 32     -- N limb 0
+      LD  x5, x12, 40     -- N limb 1
+      OR  x6, x6, x5
+      LD  x5, x12, 48     -- N limb 2
+      OR  x6, x6, x5
+      LD  x5, x12, 56     -- N limb 3
+      OR  x6, x6, x5
+      BEQ x6, x0, skipOff -- if N = 0, branch to zero-store path
+-/
+def evm_addmod_phase2_n_zero_test (skipOff : BitVec 13) : Program :=
+  LD .x6 .x12 32 ;;
+  LD .x5 .x12 40 ;;
+  OR' .x6 .x6 .x5 ;;
+  LD .x5 .x12 48 ;;
+  OR' .x6 .x6 .x5 ;;
+  LD .x5 .x12 56 ;;
+  OR' .x6 .x6 .x5 ;;
+  single (.BEQ .x6 .x0 skipOff)
+
+theorem evm_addmod_phase2_n_zero_test_length (skipOff : BitVec 13) :
+    (evm_addmod_phase2_n_zero_test skipOff).length = 8 := by
+  show ((((((((LD .x6 .x12 32 ;; LD .x5 .x12 40) ;; OR' .x6 .x6 .x5) ;;
+              LD .x5 .x12 48) ;; OR' .x6 .x6 .x5) ;;
+            LD .x5 .x12 56) ;; OR' .x6 .x6 .x5) ;;
+          single (.BEQ .x6 .x0 skipOff)) : Program).length = 8
+  simp only [seq, Program.length_append]
+  rfl
+
+theorem evm_addmod_phase2_n_zero_test_byte_length (skipOff : BitVec 13) :
+    4 * (evm_addmod_phase2_n_zero_test skipOff).length = 32 := by
+  rw [evm_addmod_phase2_n_zero_test_length]
+
+/-- Phase 2 — modulus-reduction call site.
+
+    Single-instruction near `JAL` invocation of `evm_mod_callable`
+    (the LP64 shim around `evm_mod`, see
+    `EvmAsm/Evm64/DivMod/Callable.lean`). The full reduction
+    pipeline per the survey is
+
+       1. compute `m := 2^256 mod N`        (a near-call to `evm_mod`)
+       2. compute `(c · m + r) mod N`       (a second near-call to
+                                              `evm_mod` after a
+                                              257-bit accumulate)
+
+    Both call sites share the same `JAL x1, modOff` shape; this
+    block is a single such call. The surrounding scaffolding
+    (argument marshalling, post-call result move, the conditional
+    use of the carry bit `c`) lives in slice 3c (`evm-asm-xl2jn`)
+    when the loop layout is final.
+
+    The `modOff : BitVec 21` parameter is the signed 21-bit byte
+    offset from the JAL site to the entry of `evm_mod_callable`;
+    the concrete numeric value is pinned in slice 3c.
+
+    1 instruction. -/
+def evm_addmod_phase2_mod_call (modOff : BitVec 21) : Program :=
+  JAL .x1 modOff
+
+theorem evm_addmod_phase2_mod_call_length (modOff : BitVec 21) :
+    (evm_addmod_phase2_mod_call modOff).length = 1 := rfl
+
+theorem evm_addmod_phase2_mod_call_byte_length (modOff : BitVec 21) :
+    4 * (evm_addmod_phase2_mod_call modOff).length = 4 := by
+  rw [evm_addmod_phase2_mod_call_length]
+
+/-- Phase 2 — composite reduce body (the non-zero-N path).
+
+    Sequences the modulus-reduction call into a structural block.
+    For the no-proofs slice we keep this thin: a single
+    `JAL x1, modOff` near-call. Slice 3c may either wrap this in
+    additional marshalling instructions or replace it with a richer
+    composition of `evm_addmod_phase2_mod_call` invocations once the
+    full m / accumulate pipeline is laid out.
+
+    Currently 1 instruction; the parameter shape is fixed so slice
+    3c does not need to re-derive offsets if the body grows.
+
+    The trailing `JAL x0, exitOff` (an unconditional branch past the
+    zero-store path to the epilogue entry) is *not* part of this
+    block — slice 3c emits it inline so that the zero-store path
+    can BEQ-skip exactly past the reduce body without extra
+    bookkeeping. -/
+def evm_addmod_phase2_reduce (modOff : BitVec 21) : Program :=
+  evm_addmod_phase2_mod_call modOff
+
+theorem evm_addmod_phase2_reduce_length (modOff : BitVec 21) :
+    (evm_addmod_phase2_reduce modOff).length = 1 := rfl
+
+theorem evm_addmod_phase2_reduce_byte_length (modOff : BitVec 21) :
+    4 * (evm_addmod_phase2_reduce modOff).length = 4 := by
+  rw [evm_addmod_phase2_reduce_length]
+
+/-- Phase 2 — zero-store path (taken when `N = 0`).
+
+    On entry: `x12 = sp + 32`, the result cell is at `x12 + 32 .. 56`
+    (currently holding `N = 0`, but we overwrite to be explicit and
+    to make the instruction sequence symmetric with the non-zero
+    path's writeback). 4 `SD x12, x0, k` stores write zero into
+    each of the four output limbs; the epilogue (separate block)
+    handles the trailing `ADDI x12, x12, 32` that ADDMOD shares
+    between both paths.
+
+    4 instructions. -/
+def evm_addmod_phase2_zero_path : Program :=
+  SD .x12 .x0 32 ;;
+  SD .x12 .x0 40 ;;
+  SD .x12 .x0 48 ;;
+  SD .x12 .x0 56
+
+theorem evm_addmod_phase2_zero_path_length :
+    evm_addmod_phase2_zero_path.length = 4 := by decide
+
+theorem evm_addmod_phase2_zero_path_byte_length :
+    4 * evm_addmod_phase2_zero_path.length = 16 := by
+  rw [evm_addmod_phase2_zero_path_length]
+
+/-- ADDMOD epilogue: shared writeback / pointer-advance suffix that
+    runs after either the reduce-via-mod path or the zero-store path
+    has placed the 256-bit result into the four limb cells at
+    `x12 + 32 .. 56`.
+
+    On entry: `x12 = sp + 32` (advanced once by the prologue's
+    `evm_add`), result at `x12 + 32..58`. On exit: `x12 = sp + 64`
+    (the original ADDMOD top-of-stack after popping `[a, b, N]` and
+    pushing one cell), with the result now occupying `x12 + 0..24`.
+
+    A single `ADDI x12, x12, 32` performs the final pointer advance.
+    The result limbs are already in place from the upstream blocks —
+    the epilogue does not move data, only the pointer.
+
+    1 instruction. -/
+def evm_addmod_epilogue : Program :=
+  ADDI .x12 .x12 32
+
+theorem evm_addmod_epilogue_length :
+    evm_addmod_epilogue.length = 1 := by decide
+
+theorem evm_addmod_epilogue_byte_length :
+    4 * evm_addmod_epilogue.length = 4 := by
+  rw [evm_addmod_epilogue_length]
+
 end EvmAsm.Evm64


### PR DESCRIPTION
Sub-slice of evm-asm-sord (#91 slice 3): adds the second batch of ADDMOD building blocks per `docs/91-addmod-mulmod-survey.md` §5.1, stacked on #2940 (slice 3a).

New parameterized sub-programs in `EvmAsm/Evm64/AddMod/Program.lean`:

- `evm_addmod_phase2_n_zero_test (skipOff)` — 8 instr OR-fold of `N`'s four limbs into `x6` followed by `BEQ x6, x0, skipOff` to short-circuit to the zero-store path when `N = 0`.
- `evm_addmod_phase2_mod_call (modOff)` — 1 instr near `JAL` into `evm_mod_callable` (LP64 shim from `EvmAsm/Evm64/DivMod/Callable.lean`).
- `evm_addmod_phase2_reduce (modOff)` — composite reduce body (currently a thin wrapper around the mod call; slice 3c may grow it).
- `evm_addmod_phase2_zero_path` — 4 `SD x12, x0` stores to write zero into the four output limbs.
- `evm_addmod_epilogue` — 1 instr `ADDI x12, x12, 32` pointer advance.

All branch / call distances are passed as `BitVec` parameters so slice 3c (`evm-asm-xl2jn`) can pin the concrete offsets when `evm_addmod` is finally assembled. No `cpsTriple` proofs in this slice (per the acceptance criteria of `evm-asm-f027s`); length and `byte_length` lemmas only.

Stacked on #2940; merge that first (or wait for it to land in main).

Refs GH #91, beads `evm-asm-f027s` (parent `evm-asm-sord`).
Distinctive token: `evm_addmod_phase2_reduce evm_addmod_epilogue`.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).