### PR TITLE
chore(noshake): annotate Phase2LongIter + AddBackFinalLoopControl false-positives

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -30,6 +30,9 @@
   "EvmAsm.Rv64.RLP.Phase2LongAcc":
   ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.AddrNorm",
    "EvmAsm.Rv64.Tactics.RunBlock"],
+ "EvmAsm.Rv64.RLP.Phase2LongIter":
+  ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.AddrNorm",
+   "EvmAsm.Rv64.Tactics.XSimp"],
   "EvmAsm.Rv64.RLP.Phase4HintRead":
   ["EvmAsm.Rv64.HintSpecs", "EvmAsm.Rv64.AddrNorm",
    "EvmAsm.Rv64.Tactics.RunBlock", "EvmAsm.Rv64.Tactics.XSimp"],
@@ -174,6 +177,10 @@
    "EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Rv64.Tactics.RunBlock"],
   "EvmAsm.Evm64.DivMod.LimbSpec.ZeroPath":
   ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.ControlFlow",
+   "EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Rv64.Tactics.RunBlock"],
+  "EvmAsm.Evm64.DivMod.LimbSpec.AddBackFinalLoopControl":
+  ["EvmAsm.Evm64.DivMod.Program", "EvmAsm.Rv64.SyscallSpecs",
+   "EvmAsm.Rv64.ControlFlow",
    "EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Rv64.Tactics.RunBlock"],
   "EvmAsm.Evm64.DivMod.LimbSpec.Div128Step1v2":
   ["EvmAsm.Evm64.DivMod.LimbSpec.Div128Step1", "EvmAsm.Rv64.Tactics.DropPure"],


### PR DESCRIPTION
Adds two confirmed shake false-positive entries to `scripts/noshake.json`:

- `EvmAsm.Rv64.RLP.Phase2LongIter`: SyscallSpecs + AddrNorm + Tactics.XSimp are all needed (SyscallSpecs / XSimp transitively bring the SepLogic notations `↦ᵣ` / `↦ₘ` and `CodeReq`; AddrNorm is required for the namespace `open` of `se12_0` / `se12_1` / `bv6_toNat_8`).
- `EvmAsm.Evm64.DivMod.LimbSpec.AddBackFinalLoopControl`: DivMod.Program + SyscallSpecs + ControlFlow + Tactics.XSimp + Tactics.RunBlock are all needed (the file uses `*_spec_gen_within` lemmas resolved via these imports, and `open EvmAsm.Rv64.Tactics` requires the tactic namespaces).

Verified by removing each entry locally and observing build failure. After this patch, `lake exe shake EvmAsm` no longer flags either file.

Refs GH #1045. Beads: evm-asm-3qyhn.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).