### PR TITLE
feat(sim): add loop status bridge

### DIFF
--- a/EvmAsm/Evm64/InterpreterLoopSimulation.lean
+++ b/EvmAsm/Evm64/InterpreterLoopSimulation.lean
@@ -52,6 +52,13 @@ theorem loopFuel_eq_of_loopResultsMatch
       InterpreterLoop.loopFuel spec fuel state :=
   h_match fuel state
 
+theorem loopFuel_status_eq_of_loopResultsMatch
+    {impl spec : Handler} (h_match : LoopResultsMatch impl spec)
+    (fuel : Nat) (state : EvmState) :
+    (InterpreterLoop.loopFuel impl fuel state).status =
+      (InterpreterLoop.loopFuel spec fuel state).status := by
+  rw [loopFuel_eq_of_loopResultsMatch h_match fuel state]
+
 theorem loopResultsMatch_of_eq
     {impl spec : Handler}
     (h_eq : ∀ (opcode : EvmOpcode) (state : EvmState), impl opcode state = spec opcode state) :


### PR DESCRIPTION
## Summary
- add status projection bridge for InterpreterLoopSimulation.LoopResultsMatch

## Verification
- lake build EvmAsm.Evm64.InterpreterLoopSimulation
- lake build
- scripts/check-file-size.sh
- git diff --check
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception' EvmAsm/Evm64/InterpreterLoopSimulation.lean (no matches)

Refs GH #109.
Bead: evm-asm-fyia.5.