### PR TITLE
feat(trace): add one-step trace bridges

### DIFF
--- a/EvmAsm/Evm64/InterpreterTrace.lean
+++ b/EvmAsm/Evm64/InterpreterTrace.lean
@@ -41,12 +41,27 @@ theorem loopTrace_succ_decode
       opcode :: loopTrace handler nSteps (InterpreterLoop.stepWithHandler handler state) := by
   simp [loopTrace, h_status, h_decode]
 
+theorem loopTrace_one_decode
+    (handler : Handler) {state : EvmState} {opcode : EvmOpcode}
+    (h_status : state.status = .running)
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some opcode) :
+    loopTrace handler 1 state = [opcode] := by
+  rw [loopTrace_succ_decode handler 0 h_status h_decode]
+  rfl
+
 theorem loopTrace_succ_unsupported
     (handler : Handler) (nSteps : Nat) {state : EvmState}
     (h_status : state.status = .running)
     (h_decode : InterpreterLoop.decodeCurrentOpcode? state = none) :
     loopTrace handler (nSteps + 1) state = [] := by
   simp [loopTrace, h_status, h_decode]
+
+theorem loopTrace_one_unsupported
+    (handler : Handler) {state : EvmState}
+    (h_status : state.status = .running)
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = none) :
+    loopTrace handler 1 state = [] := by
+  exact loopTrace_succ_unsupported handler 0 h_status h_decode
 
 theorem loopTrace_succ_stopped
     (handler : Handler) (nSteps : Nat) {state : EvmState}


### PR DESCRIPTION
## Summary
- add one-step decoded trace bridge
- add one-step unsupported trace bridge

## Verification
- lake build EvmAsm.Evm64.InterpreterTrace
- lake build
- scripts/check-file-size.sh
- git diff --check
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception' EvmAsm/Evm64/InterpreterTrace.lean (no matches)

Refs GH #108.
Bead: evm-asm-32tl.3.