### PR TITLE
feat(sim): add trace length bridge

### DIFF
--- a/EvmAsm/Evm64/InterpreterTraceSimulation.lean
+++ b/EvmAsm/Evm64/InterpreterTraceSimulation.lean
@@ -35,6 +35,14 @@ theorem loopTrace_matchesSpec
           simp [loopTrace_matchesSpec h_match nSteps
             (InterpreterLoop.stepWithHandler spec state)]
 
+theorem loopTrace_length_matchesSpec
+    {impl spec : InterpreterLoop.Handler}
+    (h_match : InterpreterSimulation.HandlerMatchesSpec impl spec)
+    (nSteps : Nat) (state : EvmState) :
+    (InterpreterTrace.loopTrace impl nSteps state).length =
+      (InterpreterTrace.loopTrace spec nSteps state).length := by
+  rw [loopTrace_matchesSpec h_match nSteps state]
+
 /-- Handler agreement preserves both the final nSteps-loop state and its decoded
     trace. -/
 theorem loopFuelAndTrace_matchesSpec


### PR DESCRIPTION
## Summary
- add trace-length projection bridge for InterpreterTraceSimulation.loopTrace_matchesSpec

## Verification
- lake build EvmAsm.Evm64.InterpreterTraceSimulation
- lake build
- scripts/check-file-size.sh
- git diff --check
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception' EvmAsm/Evm64/InterpreterTraceSimulation.lean (no matches)

Refs GH #109.
Bead: evm-asm-fyia.6.