### PR TITLE
feat(sim): add loop compose status bridge

### DIFF
--- a/EvmAsm/Evm64/InterpreterLoopCompose.lean
+++ b/EvmAsm/Evm64/InterpreterLoopCompose.lean
@@ -40,6 +40,13 @@ theorem loopFuel_add
       · simp [InterpreterLoop.loopFuel, h_status, loopFuel_of_not_running]
       · simp [InterpreterLoop.loopFuel, h_status, loopFuel_of_not_running]
 
+theorem loopFuel_add_status
+    (handler : Handler) (nStepsA nStepsB : Nat) (state : EvmState) :
+    (InterpreterLoop.loopFuel handler (nStepsA + nStepsB) state).status =
+      (InterpreterLoop.loopFuel handler nStepsB
+        (InterpreterLoop.loopFuel handler nStepsA state)).status := by
+  rw [loopFuel_add handler nStepsA nStepsB state]
+
 theorem loopFuel_one_add
     (handler : Handler) (nSteps : Nat) (state : EvmState) :
     InterpreterLoop.loopFuel handler (1 + nSteps) state =


### PR DESCRIPTION
## Summary
- add status projection bridge for InterpreterLoopCompose.loopFuel_add

## Verification
- lake build EvmAsm.Evm64.InterpreterLoopCompose
- lake build
- scripts/check-file-size.sh
- git diff --check
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception' EvmAsm/Evm64/InterpreterLoopCompose.lean (no matches)

Refs GH #109.
Bead: evm-asm-fyia.7.