### PR TITLE
feat(trace): add one-step trace length bridges

### DIFF
--- a/EvmAsm/Evm64/InterpreterTrace.lean
+++ b/EvmAsm/Evm64/InterpreterTrace.lean
@@ -49,6 +49,14 @@ theorem loopTrace_one_decode
   rw [loopTrace_succ_decode handler 0 h_status h_decode]
   rfl
 
+theorem loopTrace_one_decode_length
+    (handler : Handler) {state : EvmState} {opcode : EvmOpcode}
+    (h_status : state.status = .running)
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some opcode) :
+    (loopTrace handler 1 state).length = 1 := by
+  rw [loopTrace_one_decode handler h_status h_decode]
+  rfl
+
 theorem loopTrace_succ_unsupported
     (handler : Handler) (nSteps : Nat) {state : EvmState}
     (h_status : state.status = .running)
@@ -62,6 +70,14 @@ theorem loopTrace_one_unsupported
     (h_decode : InterpreterLoop.decodeCurrentOpcode? state = none) :
     loopTrace handler 1 state = [] := by
   exact loopTrace_succ_unsupported handler 0 h_status h_decode
+
+theorem loopTrace_one_unsupported_length
+    (handler : Handler) {state : EvmState}
+    (h_status : state.status = .running)
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = none) :
+    (loopTrace handler 1 state).length = 0 := by
+  rw [loopTrace_one_unsupported handler h_status h_decode]
+  rfl
 
 theorem loopTrace_succ_stopped
     (handler : Handler) (nSteps : Nat) {state : EvmState}


### PR DESCRIPTION
## Summary
- add one-step decoded trace length bridge
- add one-step unsupported trace length bridge

## Verification
- lake build EvmAsm.Evm64.InterpreterTrace
- lake build
- scripts/check-file-size.sh
- git diff --check
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception' EvmAsm/Evm64/InterpreterTrace.lean (no matches)

Refs GH #108.
Bead: evm-asm-32tl.4.