### PR TITLE
chore(noshake): annotate ProgramSpec + Phase2LongLoopBody false-positives

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -33,6 +33,12 @@
  "EvmAsm.Rv64.RLP.Phase2LongIter":
   ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.AddrNorm",
    "EvmAsm.Rv64.Tactics.XSimp"],
+  "EvmAsm.Rv64.RLP.Phase2LongLoopBody":
+  ["EvmAsm.Rv64.Tactics.ExtractPure", "EvmAsm.Rv64.Tactics.XPermPure"],
+  "EvmAsm.EL.RLP.ProgramSpec":
+  ["EvmAsm.Rv64.AddrNorm", "EvmAsm.Rv64.ControlFlow",
+   "EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.RunBlock",
+   "EvmAsm.Rv64.Tactics.XSimp"],
   "EvmAsm.Rv64.RLP.Phase4HintRead":
   ["EvmAsm.Rv64.HintSpecs", "EvmAsm.Rv64.AddrNorm",
    "EvmAsm.Rv64.Tactics.RunBlock", "EvmAsm.Rv64.Tactics.XSimp"],


### PR DESCRIPTION
Two more shake false-positives flagged by `lake exe shake EvmAsm`:

- `EvmAsm.EL.RLP.ProgramSpec` depends on `AddrNorm` (`rv64_addr`/`bv_addr` macros), `ControlFlow` (`cpsBranch*` infrastructure), `SyscallSpecs` + `RunBlock` (`*_spec_gen_within` registry attributes), `XSimp` (`xperm_hyp` tactic).
- `EvmAsm.Rv64.RLP.Phase2LongLoopBody` depends on `ExtractPure` (`extract_pure` tactic at line 111) and `XPermPure` (`xperm_hyp` at lines 188-216).

Same playbook as PR #2949 / #2952 / #2814: tactic- and macro-only imports are invisible to shake, so `noshake.json` has to encode the dependency explicitly. Verified locally: `lake build` clean, `lake exe shake EvmAsm` no longer flags either file.

Refs GH #1045, beads `evm-asm-j9axl` (parent `evm-asm-6qj`).
Distinctive token: `noshake ProgramSpec Phase2LongLoopBody`.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).