### PR TITLE
feat(loop): add one-step composition status bridges

### DIFF
--- a/EvmAsm/Evm64/InterpreterLoopCompose.lean
+++ b/EvmAsm/Evm64/InterpreterLoopCompose.lean
@@ -54,12 +54,26 @@ theorem loopFuel_one_add
         (InterpreterLoop.loopFuel handler 1 state) := by
   exact loopFuel_add handler 1 nSteps state
 
+theorem loopFuel_one_add_status
+    (handler : Handler) (nSteps : Nat) (state : EvmState) :
+    (InterpreterLoop.loopFuel handler (1 + nSteps) state).status =
+      (InterpreterLoop.loopFuel handler nSteps
+        (InterpreterLoop.loopFuel handler 1 state)).status := by
+  rw [loopFuel_one_add handler nSteps state]
+
 theorem loopFuel_add_one
     (handler : Handler) (nSteps : Nat) (state : EvmState) :
     InterpreterLoop.loopFuel handler (nSteps + 1) state =
       InterpreterLoop.loopFuel handler 1
         (InterpreterLoop.loopFuel handler nSteps state) := by
   exact loopFuel_add handler nSteps 1 state
+
+theorem loopFuel_add_one_status
+    (handler : Handler) (nSteps : Nat) (state : EvmState) :
+    (InterpreterLoop.loopFuel handler (nSteps + 1) state).status =
+      (InterpreterLoop.loopFuel handler 1
+        (InterpreterLoop.loopFuel handler nSteps state)).status := by
+  rw [loopFuel_add_one handler nSteps state]
 
 end InterpreterLoopCompose
 


### PR DESCRIPTION
## Summary
- add status projection companions for loopFuel_one_add and loopFuel_add_one

## Verification
- lake build EvmAsm.Evm64.InterpreterLoopCompose
- lake build
- scripts/check-file-size.sh
- git diff --check
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception' EvmAsm/Evm64/InterpreterLoopCompose.lean (no matches)

Authored by @pirapira; implemented by Codex.