### PR TITLE
chore(noshake): annotate Compare/LimbSpec + Shift/LimbSpec false-positives

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -196,6 +196,12 @@
   ["EvmAsm.Evm64.Shift.ComposeBase"],
   "EvmAsm.Evm64.Shift.SarCompose":
   ["EvmAsm.Evm64.Shift.ComposeBase"],
+  "EvmAsm.Evm64.Compare.LimbSpec":
+  ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.RunBlock"],
+  "EvmAsm.Evm64.Shift.LimbSpec":
+  ["EvmAsm.Rv64.AddrNorm", "EvmAsm.Rv64.SyscallSpecs",
+   "EvmAsm.Rv64.ControlFlow",
+   "EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Rv64.Tactics.RunBlock"],
   "EvmAsm.Evm64.DivMod.NormDefs":
   ["EvmAsm.Rv64.Basic"],
   "EvmAsm.Evm64.DivMod.LoopBodyN1":


### PR DESCRIPTION
Two more shake false-positives annotated, following the playbook from PRs #2949 / #2952 / #2958.

## Files

- `EvmAsm/Evm64/Compare/LimbSpec.lean`: `SyscallSpecs` supplies the `spec_gen_rv64` / `spec_within_rv64` attributes used by 11 `spec_gen` sites (LD/SLTU/SUB/ADDI/BEQ/LI). `Tactics.RunBlock` brings the `runBlock` tactic (3 uses) and the `spec_within` attribute infrastructure.
- `EvmAsm/Evm64/Shift/LimbSpec.lean`: the standard 5-import false-positive set (`AddrNorm` rv64_addr/se12 lemmas, `ControlFlow` `if_eq` macro + `cpsBranch*`, `SyscallSpecs` + `RunBlock` for `spec_gen` / `spec_within` attributes, `XSimp` for `xperm_hyp`).

## Verification

- `lake build` clean.
- `lake exe shake EvmAsm` no longer flags either file.

Refs GH #1045. beads evm-asm-efen9 (parent evm-asm-6qj).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).