### PR TITLE
feat(loop): add simulation status bridge

### DIFF
--- a/EvmAsm/Evm64/InterpreterSimulation.lean
+++ b/EvmAsm/Evm64/InterpreterSimulation.lean
@@ -68,6 +68,13 @@ theorem loopFuel_matchesSpec
       rw [stepWithHandler_matchesSpec h_match]
       exact loopFuel_matchesSpec h_match nSteps (InterpreterLoop.stepWithHandler spec state)
 
+theorem loopFuel_matchesSpec_status
+    {impl spec : Handler} (h_match : HandlerMatchesSpec impl spec)
+    (nSteps : Nat) (state : EvmState) :
+    (InterpreterLoop.loopFuel impl nSteps state).status =
+      (InterpreterLoop.loopFuel spec nSteps state).status := by
+  rw [loopFuel_matchesSpec h_match nSteps state]
+
 end InterpreterSimulation
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add loopFuel_matchesSpec_status as the status projection companion to loopFuel_matchesSpec

## Verification
- lake build EvmAsm.Evm64.InterpreterSimulation
- lake build
- scripts/check-file-size.sh
- git diff --check
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception' EvmAsm/Evm64/InterpreterSimulation.lean (no matches)

Authored by @pirapira; implemented by Codex.