### PR TITLE
feat(loop): add one-step loop results status bridge

### DIFF
--- a/EvmAsm/Evm64/InterpreterLoopSimulation.lean
+++ b/EvmAsm/Evm64/InterpreterLoopSimulation.lean
@@ -74,6 +74,13 @@ theorem loopResultsMatch_step_one
       InterpreterLoop.loopFuel spec 1 state :=
   h_match 1 state
 
+theorem loopResultsMatch_step_one_status
+    {impl spec : Handler} (h_match : LoopResultsMatch impl spec)
+    (state : EvmState) :
+    (InterpreterLoop.loopFuel impl 1 state).status =
+      (InterpreterLoop.loopFuel spec 1 state).status := by
+  rw [loopResultsMatch_step_one h_match state]
+
 end InterpreterLoopSimulation
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add loopResultsMatch_step_one_status as the status projection companion to loopResultsMatch_step_one

## Verification
- lake build EvmAsm.Evm64.InterpreterLoopSimulation
- lake build
- scripts/check-file-size.sh
- git diff --check
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception' EvmAsm/Evm64/InterpreterLoopSimulation.lean (no matches)

Authored by @pirapira; implemented by Codex.