### PR TITLE
feat(terminating): add fixed loop status bridges

### DIFF
--- a/EvmAsm/Evm64/TerminatingLoopBridge.lean
+++ b/EvmAsm/Evm64/TerminatingLoopBridge.lean
@@ -72,12 +72,26 @@ theorem loopFuel_stop_fixed :
   | fuel + 1, state => by
       simp [InterpreterLoop.loopFuel]
 
+theorem loopFuel_stop_fixed_status
+    (fuel : Nat) (state : EvmState) :
+    (InterpreterLoop.loopFuel terminatingLoopHandler fuel state.stop).status =
+      .stopped := by
+  rw [loopFuel_stop_fixed fuel state]
+  exact EvmState.stop_status state
+
 theorem loopFuel_invalid_fixed :
     ∀ (fuel : Nat) (state : EvmState),
       InterpreterLoop.loopFuel terminatingLoopHandler fuel state.invalid = state.invalid
   | 0, _ => rfl
   | fuel + 1, state => by
       simp [InterpreterLoop.loopFuel]
+
+theorem loopFuel_invalid_fixed_status
+    (fuel : Nat) (state : EvmState) :
+    (InterpreterLoop.loopFuel terminatingLoopHandler fuel state.invalid).status =
+      .error := by
+  rw [loopFuel_invalid_fixed fuel state]
+  exact EvmState.invalid_status state
 
 theorem loopFuel_succ_running_STOP
     (fuel : Nat) {state : EvmState}


### PR DESCRIPTION
## Summary
- add status projection companions for loopFuel_stop_fixed and loopFuel_invalid_fixed

## Verification
- lake build EvmAsm.Evm64.TerminatingLoopBridge
- lake build
- scripts/check-file-size.sh
- git diff --check
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception' EvmAsm/Evm64/TerminatingLoopBridge.lean (no matches)

Authored by @pirapira; implemented by Codex.