### PR TITLE
chore(noshake): annotate CallingConvention + Multiply/Byte/SignExtend LimbSpec false-positives

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -163,6 +163,18 @@
   "EvmAsm.Evm64.Slt.Spec":     ["EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Evm64.Compare.LimbSpec", "EvmAsm.Evm64.EvmWordArith.Comparison", "EvmAsm.Rv64.AddrNorm", "EvmAsm.Rv64.ControlFlow"],
   "EvmAsm.Evm64.Sgt.Spec":     ["EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Evm64.Compare.LimbSpec", "EvmAsm.Evm64.EvmWordArith.Comparison", "EvmAsm.Rv64.AddrNorm", "EvmAsm.Rv64.ControlFlow"],
   "EvmAsm.Evm64.Multiply.Spec":["EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Evm64.EvmWordArith.MulCorrect"],
+  "EvmAsm.Evm64.CallingConvention":
+  ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.ControlFlow",
+   "EvmAsm.Rv64.Tactics.RunBlock"],
+  "EvmAsm.Evm64.Multiply.LimbSpec":
+  ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.RunBlock"],
+  "EvmAsm.Evm64.Byte.LimbSpec":
+  ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.ControlFlow",
+   "EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Rv64.Tactics.RunBlock"],
+  "EvmAsm.Evm64.SignExtend.LimbSpec":
+  ["EvmAsm.Rv64.AddrNorm", "EvmAsm.Rv64.SyscallSpecs",
+   "EvmAsm.Rv64.ControlFlow", "EvmAsm.Rv64.Tactics.XSimp",
+   "EvmAsm.Rv64.Tactics.RunBlock"],
   "EvmAsm.Evm64.DivMod.LimbSpec.CopyAU":
   ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.ControlFlow",
    "EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Rv64.Tactics.RunBlock"],


### PR DESCRIPTION
Slice of evm-asm-6qj (#1045 Import hygiene sweep). Annotates four files with the standard SyscallSpecs/ControlFlow/RunBlock/XSimp/AddrNorm false-positive set:

- `EvmAsm/Evm64/CallingConvention.lean` — needs SyscallSpecs (gen-spec attributes for ADDI/SD/LD/JAL/JALR), ControlFlow (cpsTriple + signExtend12_*), RunBlock (`runBlock` tactic in cc_prologue/epilogue specs).
- `EvmAsm/Evm64/Multiply/LimbSpec.lean` — SyscallSpecs + RunBlock.
- `EvmAsm/Evm64/Byte/LimbSpec.lean` — SyscallSpecs + ControlFlow + XSimp + RunBlock.
- `EvmAsm/Evm64/SignExtend/LimbSpec.lean` — AddrNorm (rv64_addr / bv_addr macros) + the standard four.

All five categories are tactic-driven attribute registries / term-elaborator macros / notation references that shake doesn't track — same playbook as PRs #2949 / #2952 / #2958 / #2814.

Verified: `lake build` clean; `lake exe shake EvmAsm` no longer flags any of the four files.

Refs GH #1045. Beads slice evm-asm-jwh7w (parent evm-asm-6qj).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).