### PR TITLE
chore(noshake): annotate Shift/Compose + Shl/SarSpec false-positives

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -202,6 +202,12 @@
   ["EvmAsm.Evm64.Shift.ComposeBase"],
   "EvmAsm.Evm64.Shift.SarCompose":
   ["EvmAsm.Evm64.Shift.ComposeBase"],
+  "EvmAsm.Evm64.Shift.Compose":
+  ["EvmAsm.Evm64.Shift.ComposeBase"],
+  "EvmAsm.Evm64.Shift.ShlSpec":
+  ["EvmAsm.Evm64.Shift.LimbSpec"],
+  "EvmAsm.Evm64.Shift.SarSpec":
+  ["EvmAsm.Evm64.Shift.LimbSpec"],
   "EvmAsm.Evm64.Compare.LimbSpec":
   ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.RunBlock"],
   "EvmAsm.Evm64.Shift.LimbSpec":


### PR DESCRIPTION
Slice of evm-asm-6qj (#1045 Import hygiene sweep). Annotates three Shift files that shake flagged with the standard tactic-registry false-positive set, mirroring PRs #2949 / #2952 / #2958 / #2960 / #2967.

- `EvmAsm/Evm64/Shift/Compose.lean` — needs `Shift.ComposeBase` (transitively brings in shift body length lemmas + Stack tactics chain used by runBlock-driven proofs).
- `EvmAsm/Evm64/Shift/ShlSpec.lean` — needs `Shift.LimbSpec` (brings in the SyscallSpecs / ControlFlow / RunBlock / XSimp tactic registries used to discharge the per-limb merge specs).
- `EvmAsm/Evm64/Shift/SarSpec.lean` — needs `Shift.LimbSpec` (same).

All categories are tactic-driven attribute registries / term-elaborator macros that shake does not track.

Verified: `lake build` clean; `lake exe shake EvmAsm` no longer flags any of the three files.

Refs GH #1045. Beads slice evm-asm-3k010 (parent evm-asm-6qj).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).
