### PR TITLE
feat(loop): add supported missing status bridge

### DIFF
--- a/EvmAsm/Evm64/SupportedLoopBridge.lean
+++ b/EvmAsm/Evm64/SupportedLoopBridge.lean
@@ -216,6 +216,16 @@ theorem loopFuel_supported_missing_invalid
   exact congrArg (InterpreterLoop.loopFuel supportedLoopHandler nSteps)
     (HandlerTable.dispatchOpcode_none h_lookup state)
 
+theorem loopFuel_supported_missing_invalid_status
+    (nSteps : Nat) {state : EvmState} {opcode : EvmOpcode}
+    (h_status : state.status = .running)
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some opcode)
+    (h_lookup : SupportedHandlers.supportedHandlerTable opcode = none) :
+    (InterpreterLoop.loopFuel supportedLoopHandler (nSteps + 1) state).status =
+      .error := by
+  rw [loopFuel_supported_missing_invalid nSteps h_status h_decode h_lookup]
+  exact loopFuel_supported_invalid_fixed_status nSteps state
+
 end SupportedLoopBridge
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add the supported-loop missing-handler loopFuel status projection

## Verification
- lake build EvmAsm.Evm64.SupportedLoopBridge
- lake build
- scripts/check-file-size.sh
- git diff --check
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception' EvmAsm/Evm64/SupportedLoopBridge.lean (no matches)

Authored by @pirapira; implemented by Codex.