### PR TITLE
feat(loop): add non-running status bridge

### DIFF
--- a/EvmAsm/Evm64/InterpreterLoopStatus.lean
+++ b/EvmAsm/Evm64/InterpreterLoopStatus.lean
@@ -43,6 +43,12 @@ theorem loopFuel_nonRunning
       cases h_status : state.status <;>
         simp [InterpreterLoop.loopFuel, h_status, nonRunning] at h_nonRunning ⊢
 
+theorem loopFuel_nonRunning_status
+    (handler : Handler) (nSteps : Nat) (state : EvmState)
+    (h_nonRunning : nonRunning state) :
+    (InterpreterLoop.loopFuel handler nSteps state).status = state.status := by
+  rw [loopFuel_nonRunning handler nSteps state h_nonRunning]
+
 theorem loopFuel_stopped
     (handler : Handler) (nSteps : Nat) (state : EvmState)
     (h_status : state.status = .stopped) :


### PR DESCRIPTION
## Summary
- add loopFuel_nonRunning_status as the status projection companion to loopFuel_nonRunning

## Verification
- lake build EvmAsm.Evm64.InterpreterLoopStatus
- lake build
- scripts/check-file-size.sh
- git diff --check
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception' EvmAsm/Evm64/InterpreterLoopStatus.lean (no matches)

Authored by @pirapira; implemented by Codex.