### PR TITLE
chore(noshake): annotate Phase2LongLoopBody Phase2LongIter false-positive

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -34,7 +34,8 @@
   ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.AddrNorm",
    "EvmAsm.Rv64.Tactics.XSimp"],
   "EvmAsm.Rv64.RLP.Phase2LongLoopBody":
-  ["EvmAsm.Rv64.Tactics.ExtractPure", "EvmAsm.Rv64.Tactics.XPermPure"],
+  ["EvmAsm.Rv64.RLP.Phase2LongIter",
+   "EvmAsm.Rv64.Tactics.ExtractPure", "EvmAsm.Rv64.Tactics.XPermPure"],
   "EvmAsm.EL.RLP.ProgramSpec":
   ["EvmAsm.Rv64.AddrNorm", "EvmAsm.Rv64.ControlFlow",
    "EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.RunBlock",


### PR DESCRIPTION
Annotates `EvmAsm.Rv64.RLP.Phase2LongLoopBody` in `scripts/noshake.json` to silence a `lake exe shake EvmAsm` false-positive.

Shake suggested:
```
remove #[EvmAsm.Rv64.RLP.Phase2LongIter]
add    #[EvmAsm.Rv64.CPSSpec, EvmAsm.Rv64.Program]
```

`EvmAsm.Rv64.RLP.Phase2LongIter` is the file that *defines* `rlp_phase2_long_iter_prog`, `rlp_phase2_long_iter_spec_within`, and `rlp_phase2_long_iter_post_unfold`, all of which `Phase2LongLoopBody.lean` directly references on lines 144, 152, 172, 174, 222, 229. Drop-and-replace would not compile.

After this patch, `lake exe shake EvmAsm` no longer flags `Phase2LongLoopBody` (verified locally). Only `scripts/noshake.json` changes; built oleans remain valid.

Refs GH #1045. Beads: evm-asm-q2gus.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).
