### PR TITLE
feat(evm64): add handler loop status bridges

### DIFF
--- a/EvmAsm/Evm64/HandlerLoopBridge.lean
+++ b/EvmAsm/Evm64/HandlerLoopBridge.lean
@@ -83,6 +83,15 @@ theorem loopFuel_succ_running_decode
   rw [InterpreterLoop.loopFuel_succ_running (toLoopHandler table) nSteps state h_status]
   rw [stepWithTableHandler_of_decode table h_decode]
 
+theorem loopFuel_succ_running_decode_status
+    (table : HandlerTable) (nSteps : Nat) {state : EvmState} {opcode : EvmOpcode}
+    (h_status : state.status = .running)
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some opcode) :
+    (InterpreterLoop.loopFuel (toLoopHandler table) (nSteps + 1) state).status =
+      (InterpreterLoop.loopFuel (toLoopHandler table) nSteps
+        (HandlerTable.dispatchOpcode table opcode state)).status := by
+  rw [loopFuel_succ_running_decode table nSteps h_status h_decode]
+
 theorem loopFuel_succ_running_lookup
     {table : HandlerTable} (nSteps : Nat) {state : EvmState}
     {opcode : EvmOpcode} {handler : OpcodeHandler}
@@ -93,6 +102,16 @@ theorem loopFuel_succ_running_lookup
       InterpreterLoop.loopFuel (toLoopHandler table) nSteps (handler state) := by
   rw [loopFuel_succ_running_decode table nSteps h_status h_decode]
   rw [HandlerTable.dispatchOpcode_some h_lookup state]
+
+theorem loopFuel_succ_running_lookup_status
+    {table : HandlerTable} (nSteps : Nat) {state : EvmState}
+    {opcode : EvmOpcode} {handler : OpcodeHandler}
+    (h_status : state.status = .running)
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some opcode)
+    (h_lookup : table opcode = some handler) :
+    (InterpreterLoop.loopFuel (toLoopHandler table) (nSteps + 1) state).status =
+      (InterpreterLoop.loopFuel (toLoopHandler table) nSteps (handler state)).status := by
+  rw [loopFuel_succ_running_lookup nSteps h_status h_decode h_lookup]
 
 theorem loopFuel_succ_running_missing_invalid
     {table : HandlerTable} (nSteps : Nat) {state : EvmState}


### PR DESCRIPTION
## Summary
- add status projection companion for HandlerLoopBridge.loopFuel_succ_running_decode
- add status projection companion for HandlerLoopBridge.loopFuel_succ_running_lookup

## Verification
- lake build EvmAsm.Evm64.HandlerLoopBridge
- lake build
- scripts/check-file-size.sh
- git diff --check
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception' EvmAsm/Evm64/HandlerLoopBridge.lean (no matches)

Bead: evm-asm-jaeo.20

Authored by @pirapira; implemented by Codex.