### PR TITLE
feat(evm64): add non-running loop status bridges

### DIFF
--- a/EvmAsm/Evm64/InterpreterLoopStatus.lean
+++ b/EvmAsm/Evm64/InterpreterLoopStatus.lean
@@ -55,11 +55,23 @@ theorem loopFuel_stopped
     InterpreterLoop.loopFuel handler nSteps state = state :=
   loopFuel_nonRunning handler nSteps state (nonRunning_of_stopped h_status)
 
+theorem loopFuel_stopped_status
+    (handler : Handler) (nSteps : Nat) (state : EvmState)
+    (h_status : state.status = .stopped) :
+    (InterpreterLoop.loopFuel handler nSteps state).status = .stopped := by
+  rw [loopFuel_stopped handler nSteps state h_status, h_status]
+
 theorem loopFuel_returned
     (handler : Handler) (nSteps : Nat) (state : EvmState) (data : List (BitVec 8))
     (h_status : state.status = .returned data) :
     InterpreterLoop.loopFuel handler nSteps state = state :=
   loopFuel_nonRunning handler nSteps state (nonRunning_of_returned h_status)
+
+theorem loopFuel_returned_status
+    (handler : Handler) (nSteps : Nat) (state : EvmState) (data : List (BitVec 8))
+    (h_status : state.status = .returned data) :
+    (InterpreterLoop.loopFuel handler nSteps state).status = .returned data := by
+  rw [loopFuel_returned handler nSteps state data h_status, h_status]
 
 theorem loopFuel_reverted
     (handler : Handler) (nSteps : Nat) (state : EvmState) (data : List (BitVec 8))
@@ -67,11 +79,23 @@ theorem loopFuel_reverted
     InterpreterLoop.loopFuel handler nSteps state = state :=
   loopFuel_nonRunning handler nSteps state (nonRunning_of_reverted h_status)
 
+theorem loopFuel_reverted_status
+    (handler : Handler) (nSteps : Nat) (state : EvmState) (data : List (BitVec 8))
+    (h_status : state.status = .reverted data) :
+    (InterpreterLoop.loopFuel handler nSteps state).status = .reverted data := by
+  rw [loopFuel_reverted handler nSteps state data h_status, h_status]
+
 theorem loopFuel_error
     (handler : Handler) (nSteps : Nat) (state : EvmState)
     (h_status : state.status = .error) :
     InterpreterLoop.loopFuel handler nSteps state = state :=
   loopFuel_nonRunning handler nSteps state (nonRunning_of_error h_status)
+
+theorem loopFuel_error_status
+    (handler : Handler) (nSteps : Nat) (state : EvmState)
+    (h_status : state.status = .error) :
+    (InterpreterLoop.loopFuel handler nSteps state).status = .error := by
+  rw [loopFuel_error handler nSteps state h_status, h_status]
 
 theorem loopFuel_one_eof_invalid
     (handler : Handler) {state : EvmState}


### PR DESCRIPTION
## Summary
- add concrete status projection bridge for stopped loop states
- add concrete status projection bridges for returned, reverted, and error loop states

## Verification
- lake build EvmAsm.Evm64.InterpreterLoopStatus
- lake build
- scripts/check-file-size.sh
- git diff --check
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception' EvmAsm/Evm64/InterpreterLoopStatus.lean (no matches)

Bead: evm-asm-32tl.7

Authored by @pirapira; implemented by Codex.