### PR TITLE
feat(loop): add unsupported decode loopFuel status bridges

### DIFF
--- a/EvmAsm/Evm64/HandlerLoopBridge.lean
+++ b/EvmAsm/Evm64/HandlerLoopBridge.lean
@@ -131,6 +131,24 @@ theorem loopFuel_succ_running_missing_invalid_status
   rw [loopFuel_succ_running_missing_invalid nSteps h_status h_decode h_lookup]
   exact loopFuel_table_invalid_fixed_status table nSteps state
 
+theorem loopFuel_succ_running_unsupported_invalid
+    (table : HandlerTable) (nSteps : Nat) {state : EvmState}
+    (h_status : state.status = .running)
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = none) :
+    InterpreterLoop.loopFuel (toLoopHandler table) (nSteps + 1) state =
+      InterpreterLoop.loopFuel (toLoopHandler table) nSteps state.invalid := by
+  rw [InterpreterLoop.loopFuel_succ_running (toLoopHandler table) nSteps state h_status]
+  rw [InterpreterLoop.stepWithHandler_of_unsupported (toLoopHandler table) h_decode]
+
+theorem loopFuel_succ_running_unsupported_invalid_status
+    (table : HandlerTable) (nSteps : Nat) {state : EvmState}
+    (h_status : state.status = .running)
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = none) :
+    (InterpreterLoop.loopFuel (toLoopHandler table) (nSteps + 1) state).status =
+      .error := by
+  rw [loopFuel_succ_running_unsupported_invalid table nSteps h_status h_decode]
+  exact loopFuel_table_invalid_fixed_status table nSteps state
+
 theorem loopFuel_empty_succ_running_decode
     (nSteps : Nat) {state : EvmState} {opcode : EvmOpcode}
     (h_status : state.status = .running)

--- a/EvmAsm/Evm64/SupportedLoopBridge.lean
+++ b/EvmAsm/Evm64/SupportedLoopBridge.lean
@@ -244,6 +244,24 @@ theorem loopFuel_supported_missing_invalid_status
   rw [loopFuel_supported_missing_invalid nSteps h_status h_decode h_lookup]
   exact loopFuel_supported_invalid_fixed_status nSteps state
 
+theorem loopFuel_supported_succ_running_unsupported_invalid
+    (nSteps : Nat) {state : EvmState}
+    (h_status : state.status = .running)
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = none) :
+    InterpreterLoop.loopFuel supportedLoopHandler (nSteps + 1) state =
+      InterpreterLoop.loopFuel supportedLoopHandler nSteps state.invalid :=
+  HandlerLoopBridge.loopFuel_succ_running_unsupported_invalid
+    SupportedHandlers.supportedHandlerTable nSteps h_status h_decode
+
+theorem loopFuel_supported_succ_running_unsupported_status
+    (nSteps : Nat) {state : EvmState}
+    (h_status : state.status = .running)
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = none) :
+    (InterpreterLoop.loopFuel supportedLoopHandler (nSteps + 1) state).status =
+      .error := by
+  rw [loopFuel_supported_succ_running_unsupported_invalid nSteps h_status h_decode]
+  exact loopFuel_supported_invalid_fixed_status nSteps state
+
 end SupportedLoopBridge
 
 end EvmAsm.Evm64


### PR DESCRIPTION
Adds `loopFuel_succ_running_unsupported_invalid` and its status companion in `HandlerLoopBridge`, plus `loopFuel_supported_succ_running_unsupported_invalid` and `_unsupported_status` in `SupportedLoopBridge`. Covers the `decodeCurrentOpcode? = none` (EOF / unsupported byte) one-step loopFuel path parallel to the existing missing-lookup bridges.

Refs evm-asm-1bc80, GH #107 #108.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).