### PR TITLE
feat(evm64): add handler match status bridge

### DIFF
--- a/EvmAsm/Evm64/InterpreterSimulation.lean
+++ b/EvmAsm/Evm64/InterpreterSimulation.lean
@@ -40,6 +40,13 @@ theorem HandlerMatchesSpec.trans
   intro opcode state h_decode
   exact (h_left opcode state h_decode).trans (h_right opcode state h_decode)
 
+theorem HandlerMatchesSpec.status_eq
+    {impl spec : Handler} (h_match : HandlerMatchesSpec impl spec)
+    {opcode : EvmOpcode} {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some opcode) :
+    (impl opcode state).status = (spec opcode state).status := by
+  rw [h_match opcode state h_decode]
+
 theorem stepWithHandler_matchesSpec
     {impl spec : Handler} (h_match : HandlerMatchesSpec impl spec) (state : EvmState) :
     InterpreterLoop.stepWithHandler impl state =


### PR DESCRIPTION
## Summary
- add InterpreterSimulation.HandlerMatchesSpec.status_eq for decoded opcode status projection

## Verification
- lake build EvmAsm.Evm64.InterpreterSimulation
- lake build
- scripts/check-file-size.sh
- git diff --check
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception' EvmAsm/Evm64/InterpreterSimulation.lean (no matches)

Bead: evm-asm-fyia.11

Authored by @pirapira; implemented by Codex.