### PR TITLE
feat(calldata): add q0 one-limb window stack spec via mload subsumption

### DIFF
--- a/EvmAsm/Evm64/Calldata/LoadStackCode.lean
+++ b/EvmAsm/Evm64/Calldata/LoadStackCode.lean
@@ -397,5 +397,37 @@ theorem calldataLoadWindowOutputWordFromArgs_evmStackIs_fold
   unfold calldataLoadWindowOutputWordFromArgs
   rw [mloadLoadedWordFromBytes_evmStackIs_fold]
 
+/--
+CALLDATALOAD window q0 one-limb stack spec: transport a concrete
+`mloadOneLimbCode` byte-load triple at `base + 8 .. base + 100` (the
+least-significant one-limb byte-pack block within `mloadFourLimbsCode`)
+to the program-identical `evm_calldataload_window_code`.
+
+Lets followup slices instantiate `h0` of
+`calldataload_window_combined_four_limb_sequence_stack_spec_within`
+directly with a concrete byte-load triple, without first wrapping in
+`mloadFourLimbsCode`. q1/q2/q3 quarters land in followup sub-slices
+(each needs its own subsumption witness).
+
+Distinctive token:
+Calldata.LoadStackCode.calldataload_window_one_limb_q0_stack_spec_within #104.
+-/
+theorem calldataload_window_one_limb_q0_stack_spec_within
+    {n : Nat} {P Q : Assertion}
+    (offReg byteReg accReg addrReg envPtrReg : Reg) (base : Word)
+    (h :
+      cpsTripleWithin n (base + 8) (base + 100)
+        (mloadOneLimbCode addrReg byteReg accReg
+          24 25 26 27 28 29 30 31 0 (base + 8)) P Q) :
+    cpsTripleWithin n (base + 8) (base + 100)
+      (evm_calldataload_window_code offReg byteReg accReg addrReg envPtrReg base)
+      P Q := by
+  rw [evm_calldataload_window_code_eq_mloadStackCode]
+  refine cpsTripleWithin_extend_code (hmono := ?_) h
+  intro a i hq
+  exact mloadStackCode_four_limbs_sub
+    offReg byteReg accReg addrReg envPtrReg base a i
+    (mloadFourLimbsCode_one_limb_q0_sub addrReg byteReg accReg base a i hq)
+
 end Calldata
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/MLoad/StackSpec.lean
+++ b/EvmAsm/Evm64/MLoad/StackSpec.lean
@@ -163,6 +163,24 @@ theorem mload_four_limb_sequence_spec_within
       h2)
     h3
 
+/-- Subsumption witness: the q0 (least-significant) one-limb byte-pack block,
+    placed at `base + 8 .. base + 100`, is the leftmost union member of
+    `mloadFourLimbsCode`. Proved by left-bias of `CodeReq.union`.
+
+    Consumer: `calldataload_window_one_limb_q0_stack_spec_within`
+    (Calldata/LoadStackCode.lean) which lets callers supply a concrete
+    `mloadOneLimbCode` byte-load triple in place of an `mloadFourLimbsCode`
+    triple when wiring the four-limb byte-window read in
+    `evm_calldataload_stack_spec` (evm-asm-pgeuo / GH #104). -/
+theorem mloadFourLimbsCode_one_limb_q0_sub
+    (addrReg byteReg accReg : Reg) (base : Word) :
+    ∀ a i,
+      (mloadOneLimbCode addrReg byteReg accReg
+          24 25 26 27 28 29 30 31 0 (base + 8)) a = some i →
+      (mloadFourLimbsCode addrReg byteReg accReg base) a = some i := by
+  unfold mloadFourLimbsCode
+  exact CodeReq.union_mono_left
+
 theorem mload_four_limbs_stack_spec_within
     {n : Nat} {P Q : Assertion}
     (offReg byteReg accReg addrReg memBaseReg : Reg) (base : Word)


### PR DESCRIPTION
Sub-slice toward evm-asm-pgeuo / GH #104.

Adds two helper lemmas:

- `mloadFourLimbsCode_one_limb_q0_sub` (EvmAsm/Evm64/MLoad/StackSpec.lean) — subsumption witness that the q0 (least-significant) one-limb byte-pack block at `base + 8 .. base + 100` is contained in `mloadFourLimbsCode`. One line via left-bias of `CodeReq.union`.
- `calldataload_window_one_limb_q0_stack_spec_within` (EvmAsm/Evm64/Calldata/LoadStackCode.lean) — transport that lifts a concrete `mloadOneLimbCode` byte-load triple at `base + 8 .. base + 100` to the program-identical `evm_calldataload_window_code`.

Lets followup sub-slices instantiate `h0` of `calldataload_window_combined_four_limb_sequence_stack_spec_within` directly with a concrete byte-load triple, without first wrapping in `mloadFourLimbsCode`. q1/q2/q3 quarters land in followup sub-slices (each needs its own subsumption witness).

Distinctive token: `Calldata.LoadStackCode.calldataload_window_one_limb_q0_stack_spec_within #104`.

Refs evm-asm-z2ewk, GH #104.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).
