### PR TITLE
feat(evm64): add trace simulation status bridge

### DIFF
--- a/EvmAsm/Evm64/InterpreterTraceSimulation.lean
+++ b/EvmAsm/Evm64/InterpreterTraceSimulation.lean
@@ -57,6 +57,15 @@ theorem loopFuelAndTrace_matchesSpec
     InterpreterSimulation.loopFuel_matchesSpec h_match nSteps state,
     loopTrace_matchesSpec h_match nSteps state]
 
+theorem loopFuelAndTrace_matchesSpec_status
+    {impl spec : InterpreterLoop.Handler}
+    (h_match : InterpreterSimulation.HandlerMatchesSpec impl spec)
+    (nSteps : Nat) (state : EvmState) :
+    (InterpreterLoop.loopFuel impl nSteps state).status =
+      (InterpreterLoop.loopFuel spec nSteps state).status := by
+  exact congrArg (fun result => result.1.status)
+    (loopFuelAndTrace_matchesSpec h_match nSteps state)
+
 end InterpreterTraceSimulation
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add InterpreterTraceSimulation.loopFuelAndTrace_matchesSpec_status as a status projection companion for the pair bridge

## Verification
- lake build EvmAsm.Evm64.InterpreterTraceSimulation
- lake build
- scripts/check-file-size.sh
- git diff --check
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception' EvmAsm/Evm64/InterpreterTraceSimulation.lean (no matches)

Bead: evm-asm-fyia.12

Authored by @pirapira; implemented by Codex.