### PR TITLE
feat(calldata): q1 one-limb window stack spec via mload subsumption

### DIFF
--- a/EvmAsm/Evm64/Calldata/LoadStackCode.lean
+++ b/EvmAsm/Evm64/Calldata/LoadStackCode.lean
@@ -429,5 +429,37 @@ theorem calldataload_window_one_limb_q0_stack_spec_within
     offReg byteReg accReg addrReg envPtrReg base a i
     (mloadFourLimbsCode_one_limb_q0_sub addrReg byteReg accReg base a i hq)
 
+/--
+CALLDATALOAD window q1 one-limb stack spec: transport a concrete
+`mloadOneLimbCode` byte-load triple at `base + 100 .. base + 192` (the
+second one-limb byte-pack block within `mloadFourLimbsCode`) to the
+program-identical `evm_calldataload_window_code`.
+
+Sister to `calldataload_window_one_limb_q0_stack_spec_within`. Lets
+followup slices instantiate `h1` of
+`calldataload_window_combined_four_limb_sequence_stack_spec_within`
+directly with a concrete byte-load triple. q2/q3 quarters land in
+followup sub-slices.
+
+Distinctive token:
+Calldata.LoadStackCode.calldataload_window_one_limb_q1_stack_spec_within #104.
+-/
+theorem calldataload_window_one_limb_q1_stack_spec_within
+    {n : Nat} {P Q : Assertion}
+    (offReg byteReg accReg addrReg envPtrReg : Reg) (base : Word)
+    (h :
+      cpsTripleWithin n (base + 100) (base + 192)
+        (mloadOneLimbCode addrReg byteReg accReg
+          16 17 18 19 20 21 22 23 8 (base + 100)) P Q) :
+    cpsTripleWithin n (base + 100) (base + 192)
+      (evm_calldataload_window_code offReg byteReg accReg addrReg envPtrReg base)
+      P Q := by
+  rw [evm_calldataload_window_code_eq_mloadStackCode]
+  refine cpsTripleWithin_extend_code (hmono := ?_) h
+  intro a i hq
+  exact mloadStackCode_four_limbs_sub
+    offReg byteReg accReg addrReg envPtrReg base a i
+    (mloadFourLimbsCode_one_limb_q1_sub addrReg byteReg accReg base a i hq)
+
 end Calldata
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/MLoad/StackSpec.lean
+++ b/EvmAsm/Evm64/MLoad/StackSpec.lean
@@ -181,6 +181,42 @@ theorem mloadFourLimbsCode_one_limb_q0_sub
   unfold mloadFourLimbsCode
   exact CodeReq.union_mono_left
 
+/-- Disjointness of the q0 and q1 one-limb byte-pack blocks within
+    `mloadFourLimbsCode`. q0 spans `base + 8 .. base + 100`, q1 spans
+    `base + 100 .. base + 192`; both are 23-instruction `mloadOneLimbProg`
+    blocks expressible as `CodeReq.ofProg`. -/
+private theorem mloadFourLimbs_q0_disjoint_q1
+    (addrReg byteReg accReg : Reg) (base : Word) :
+    CodeReq.Disjoint
+      (mloadOneLimbCode addrReg byteReg accReg
+        24 25 26 27 28 29 30 31 0 (base + 8))
+      (mloadOneLimbCode addrReg byteReg accReg
+        16 17 18 19 20 21 22 23 8 (base + 100)) := by
+  rw [mloadOneLimbCode_eq_ofProg, mloadOneLimbCode_eq_ofProg]
+  refine CodeReq.ofProg_disjoint_range_len _ _ 23 _ _ 23 ?_ ?_ ?_
+  · unfold mloadOneLimbProg mloadBytePackEightProg LBU SLLI OR' SD single seq; rfl
+  · unfold mloadOneLimbProg mloadBytePackEightProg LBU SLLI OR' SD single seq; rfl
+  · intro k1 k2 hk1 hk2; bv_omega
+
+/-- Subsumption witness: the q1 one-limb byte-pack block, placed at
+    `base + 100 .. base + 192`, is the second union member of
+    `mloadFourLimbsCode`. Proved by stepping past the q0 head with
+    `mono_union_right` (using disjointness with q0) into the leftmost
+    position of the inner union via `union_mono_left`.
+
+    Consumer: `calldataload_window_one_limb_q1_stack_spec_within`
+    (Calldata/LoadStackCode.lean) — sister to the q0 witness. -/
+theorem mloadFourLimbsCode_one_limb_q1_sub
+    (addrReg byteReg accReg : Reg) (base : Word) :
+    ∀ a i,
+      (mloadOneLimbCode addrReg byteReg accReg
+          16 17 18 19 20 21 22 23 8 (base + 100)) a = some i →
+      (mloadFourLimbsCode addrReg byteReg accReg base) a = some i := by
+  unfold mloadFourLimbsCode
+  exact CodeReq.mono_union_right
+    (mloadFourLimbs_q0_disjoint_q1 addrReg byteReg accReg base)
+    CodeReq.union_mono_left
+
 theorem mload_four_limbs_stack_spec_within
     {n : Nat} {P Q : Assertion}
     (offReg byteReg accReg addrReg memBaseReg : Reg) (base : Word)


### PR DESCRIPTION
Sub-slice toward evm-asm-pgeuo (#104) — sister to PR #2981 (q0).

Adds:
- `mloadFourLimbsCode_one_limb_q1_sub`: subsumption witness for the q1 (second) one-limb byte-pack block at `base + 100 .. base + 192` within `mloadFourLimbsCode`. Proved by `mono_union_right` past q0 (using a disjointness fact derived from `ofProg_disjoint_range_len` on the 23-instruction one-limb byte-pack programs) plus `union_mono_left` into the inner union.
- `calldataload_window_one_limb_q1_stack_spec_within`: paired transport in `Calldata/LoadStackCode.lean` lifting a concrete `mloadOneLimbCode` byte-load triple at q1 to the program-identical `evm_calldataload_window_code`.

Lets followup slices instantiate `h1` of `calldataload_window_combined_four_limb_sequence_stack_spec_within` directly with a concrete byte-load triple. q2/q3 land in followup sub-slices.

`lake build` clean, no sorry, no maxHeartbeats/maxRecDepth bumps.

Refs evm-asm-9exsg, evm-asm-pgeuo, GH #104.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).