### PR TITLE
chore(divmod): delete dead div128Quot_phase2b_q0_eq_self_of_no_bltu

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopDefs/IterV4.lean
+++ b/EvmAsm/Evm64/DivMod/LoopDefs/IterV4.lean
@@ -97,27 +97,4 @@ def div128Quot_v4 (uHi uLo vTop : Word) : Word :=
   let q0'' := div128Quot_phase2b_q0' q0' rhat2' dLo div_un0
   (q1'' <<< (32 : BitVec 6).toNat) ||| q0''
 
-/-- Idempotency of `div128Quot_phase2b_q0'` when its inner BLTU doesn't
-    fire on q's mul. If the outer guard `rhat >>> 32 = 0` fails OR the
-    inner BLTU `(rhat << 32) | divUn < q * dLo` fails, the helper
-    returns its input `q` unchanged.
-
-    A small reusable algebraic identity, useful any time we need to
-    show a `phase2b_q0'` call is a no-op (e.g. when the algorithm has
-    already converged at a given correction step). -/
-theorem div128Quot_phase2b_q0'_eq_self_of_no_bltu
-    (q rhat dLo divUn : Word)
-    (h : ¬ (rhat >>> (32 : BitVec 6).toNat = 0 ∧
-        BitVec.ult ((rhat <<< (32 : BitVec 6).toNat) ||| divUn) (q * dLo))) :
-    div128Quot_phase2b_q0' q rhat dLo divUn = q := by
-  unfold div128Quot_phase2b_q0'
-  by_cases h_guard : rhat >>> (32 : BitVec 6).toNat = 0
-  · simp only [h_guard, if_true]
-    have h_bltu : ¬ BitVec.ult ((rhat <<< (32 : BitVec 6).toNat) ||| divUn) (q * dLo) :=
-      fun hb => h ⟨h_guard, hb⟩
-    simp only [Bool.not_eq_true] at h_bltu
-    rw [h_bltu]
-    rfl
-  · simp only [h_guard, if_false]
-
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

Delete dead theorem `div128Quot_phase2b_q0'_eq_self_of_no_bltu` in `EvmAsm/Evm64/DivMod/LoopDefs/IterV4.lean`.

## Why dead

- Single occurrence in the entire codebase: its own definition (verified via `rg`/`gh search code`).
- Added alongside the v3 → v4 migration in commit ff83983c but never wired into any v4 caller.
- Component status: parent #61 (DIV/MOD stack-level spec) is closed and there are no open DivMod slices that would plausibly consume an idempotency identity for `phase2b_q0'` (per the dead-code rule in AGENTS.md).
- Re-derivable in a few lines from the unfold of `div128Quot_phase2b_q0'` if any future caller needs it; safe to delete pre-completion because it's a structural no-op identity, not a building block on any open slice.

## Verification

- `lake build` green (1700 jobs, 0 errors, 0 sorries).

Refs evm-asm-sboz (DivMod cleanup parent), evm-asm-kbi70 (this slice).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).
