### PR TITLE
feat(calldata): q2 one-limb window stack spec via mload subsumption

### DIFF
--- a/EvmAsm/Evm64/Calldata/LoadStackCode.lean
+++ b/EvmAsm/Evm64/Calldata/LoadStackCode.lean
@@ -461,5 +461,38 @@ theorem calldataload_window_one_limb_q1_stack_spec_within
     offReg byteReg accReg addrReg envPtrReg base a i
     (mloadFourLimbsCode_one_limb_q1_sub addrReg byteReg accReg base a i hq)
 
+/--
+CALLDATALOAD window q2 one-limb stack spec: transport a concrete
+`mloadOneLimbCode` byte-load triple at `base + 192 .. base + 284` (the
+third one-limb byte-pack block within `mloadFourLimbsCode`) to the
+program-identical `evm_calldataload_window_code`.
+
+Sister to `calldataload_window_one_limb_q0_stack_spec_within` and
+`calldataload_window_one_limb_q1_stack_spec_within`. Lets followup slices
+instantiate `h2` of
+`calldataload_window_combined_four_limb_sequence_stack_spec_within`
+directly with a concrete byte-load triple. q3 quarter lands in a
+followup sub-slice.
+
+Distinctive token:
+Calldata.LoadStackCode.calldataload_window_one_limb_q2_stack_spec_within #104.
+-/
+theorem calldataload_window_one_limb_q2_stack_spec_within
+    {n : Nat} {P Q : Assertion}
+    (offReg byteReg accReg addrReg envPtrReg : Reg) (base : Word)
+    (h :
+      cpsTripleWithin n (base + 192) (base + 284)
+        (mloadOneLimbCode addrReg byteReg accReg
+          8 9 10 11 12 13 14 15 16 (base + 192)) P Q) :
+    cpsTripleWithin n (base + 192) (base + 284)
+      (evm_calldataload_window_code offReg byteReg accReg addrReg envPtrReg base)
+      P Q := by
+  rw [evm_calldataload_window_code_eq_mloadStackCode]
+  refine cpsTripleWithin_extend_code (hmono := ?_) h
+  intro a i hq
+  exact mloadStackCode_four_limbs_sub
+    offReg byteReg accReg addrReg envPtrReg base a i
+    (mloadFourLimbsCode_one_limb_q2_sub addrReg byteReg accReg base a i hq)
+
 end Calldata
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/MLoad/StackSpec.lean
+++ b/EvmAsm/Evm64/MLoad/StackSpec.lean
@@ -217,6 +217,61 @@ theorem mloadFourLimbsCode_one_limb_q1_sub
     (mloadFourLimbs_q0_disjoint_q1 addrReg byteReg accReg base)
     CodeReq.union_mono_left
 
+/-- Disjointness of the q0 and q2 one-limb byte-pack blocks within
+    `mloadFourLimbsCode`. q0 spans `base + 8 .. base + 100`, q2 spans
+    `base + 192 .. base + 284`; both are 23-instruction `mloadOneLimbProg`
+    blocks expressible as `CodeReq.ofProg`. -/
+private theorem mloadFourLimbs_q0_disjoint_q2
+    (addrReg byteReg accReg : Reg) (base : Word) :
+    CodeReq.Disjoint
+      (mloadOneLimbCode addrReg byteReg accReg
+        24 25 26 27 28 29 30 31 0 (base + 8))
+      (mloadOneLimbCode addrReg byteReg accReg
+        8 9 10 11 12 13 14 15 16 (base + 192)) := by
+  rw [mloadOneLimbCode_eq_ofProg, mloadOneLimbCode_eq_ofProg]
+  refine CodeReq.ofProg_disjoint_range_len _ _ 23 _ _ 23 ?_ ?_ ?_
+  · unfold mloadOneLimbProg mloadBytePackEightProg LBU SLLI OR' SD single seq; rfl
+  · unfold mloadOneLimbProg mloadBytePackEightProg LBU SLLI OR' SD single seq; rfl
+  · intro k1 k2 hk1 hk2; bv_omega
+
+/-- Disjointness of the q1 and q2 one-limb byte-pack blocks within
+    `mloadFourLimbsCode`. q1 spans `base + 100 .. base + 192`, q2 spans
+    `base + 192 .. base + 284`; both are 23-instruction `mloadOneLimbProg`
+    blocks expressible as `CodeReq.ofProg`. -/
+private theorem mloadFourLimbs_q1_disjoint_q2
+    (addrReg byteReg accReg : Reg) (base : Word) :
+    CodeReq.Disjoint
+      (mloadOneLimbCode addrReg byteReg accReg
+        16 17 18 19 20 21 22 23 8 (base + 100))
+      (mloadOneLimbCode addrReg byteReg accReg
+        8 9 10 11 12 13 14 15 16 (base + 192)) := by
+  rw [mloadOneLimbCode_eq_ofProg, mloadOneLimbCode_eq_ofProg]
+  refine CodeReq.ofProg_disjoint_range_len _ _ 23 _ _ 23 ?_ ?_ ?_
+  · unfold mloadOneLimbProg mloadBytePackEightProg LBU SLLI OR' SD single seq; rfl
+  · unfold mloadOneLimbProg mloadBytePackEightProg LBU SLLI OR' SD single seq; rfl
+  · intro k1 k2 hk1 hk2; bv_omega
+
+/-- Subsumption witness: the q2 one-limb byte-pack block, placed at
+    `base + 192 .. base + 284`, is the third union member of
+    `mloadFourLimbsCode`. Proved by stepping past q0 and q1 with
+    `mono_union_right` (using disjointness with each), then taking
+    `union_mono_left` into the leftmost position of the innermost union.
+
+    Consumer: `calldataload_window_one_limb_q2_stack_spec_within`
+    (Calldata/LoadStackCode.lean) — sister to the q0 / q1 witnesses. -/
+theorem mloadFourLimbsCode_one_limb_q2_sub
+    (addrReg byteReg accReg : Reg) (base : Word) :
+    ∀ a i,
+      (mloadOneLimbCode addrReg byteReg accReg
+          8 9 10 11 12 13 14 15 16 (base + 192)) a = some i →
+      (mloadFourLimbsCode addrReg byteReg accReg base) a = some i := by
+  unfold mloadFourLimbsCode
+  exact CodeReq.mono_union_right
+    (mloadFourLimbs_q0_disjoint_q2 addrReg byteReg accReg base)
+    (CodeReq.mono_union_right
+      (mloadFourLimbs_q1_disjoint_q2 addrReg byteReg accReg base)
+      CodeReq.union_mono_left)
+
 theorem mload_four_limbs_stack_spec_within
     {n : Nat} {P Q : Assertion}
     (offReg byteReg accReg addrReg memBaseReg : Reg) (base : Word)


### PR DESCRIPTION
Sub-slice toward evm-asm-pgeuo (#104) — sister to PR #2981 (q0) and PR #2987 (q1).

Adds:
- `mloadFourLimbsCode_one_limb_q2_sub`: subsumption witness for the q2 (third) one-limb byte-pack block at `base + 192 .. base + 284` within `mloadFourLimbsCode`. Proved by `mono_union_right` past q0 (using `mloadFourLimbs_q0_disjoint_q2`), then `mono_union_right` past q1 (using `mloadFourLimbs_q1_disjoint_q2`), and finally `union_mono_left` into the leftmost position of the innermost union.
- `calldataload_window_one_limb_q2_stack_spec_within`: paired transport in `Calldata/LoadStackCode.lean` lifting a concrete `mloadOneLimbCode` byte-load triple at q2 to the program-identical `evm_calldataload_window_code`.

Disjointness of q0/q2 and q1/q2 is established by `ofProg_disjoint_range_len` on the 23-instruction one-limb byte-pack programs (8/192 and 100/192 base offsets do not collide).

Lets followup slices instantiate `h2` of `calldataload_window_combined_four_limb_sequence_stack_spec_within` directly with a concrete byte-load triple. q3 lands in a followup sub-slice (last quarter — past q0/q1/q2).

`lake build` clean, no sorry, no maxHeartbeats/maxRecDepth bumps.

Refs evm-asm-d66u9, evm-asm-pgeuo, GH #104.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).