### PR TITLE
feat(evm64): add supported dispatch status bridge

### DIFF
--- a/EvmAsm/Evm64/SupportedHandlers.lean
+++ b/EvmAsm/Evm64/SupportedHandlers.lean
@@ -357,6 +357,14 @@ theorem dispatchOpcode_of_lookup
       handler state :=
   HandlerTable.dispatchOpcode_some h_lookup state
 
+theorem dispatchOpcode_of_lookup_status
+    {opcode : EvmOpcode} {handler : OpcodeHandler}
+    (h_lookup : supportedHandlerTable opcode = some handler)
+    (state : EvmState) :
+    (HandlerTable.dispatchOpcode supportedHandlerTable opcode state).status =
+      (handler state).status := by
+  rw [dispatchOpcode_of_lookup h_lookup state]
+
 @[simp] theorem supportedHandlerTable_STOP :
     supportedHandlerTable .STOP =
       some TerminatingHandlers.stopHandler := by


### PR DESCRIPTION
## Summary
- add SupportedHandlers.dispatchOpcode_of_lookup_status

## Verification
- lake build EvmAsm.Evm64.SupportedHandlers
- lake build
- scripts/check-file-size.sh
- git diff --check
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception' EvmAsm/Evm64/SupportedHandlers.lean (no matches)

Bead: evm-asm-jaeo.26

Authored by @pirapira; implemented by Codex.