### PR TITLE
feat(calldata): q3 one-limb window stack spec via mload subsumption

### DIFF
--- a/EvmAsm/Evm64/Calldata/LoadStackCode.lean
+++ b/EvmAsm/Evm64/Calldata/LoadStackCode.lean
@@ -494,5 +494,39 @@ theorem calldataload_window_one_limb_q2_stack_spec_within
     offReg byteReg accReg addrReg envPtrReg base a i
     (mloadFourLimbsCode_one_limb_q2_sub addrReg byteReg accReg base a i hq)
 
+/--
+CALLDATALOAD window q3 one-limb stack spec: transport a concrete
+`mloadOneLimbCode` byte-load triple at `base + 284 .. base + 376` (the
+fourth/rightmost one-limb byte-pack block within `mloadFourLimbsCode`)
+to the program-identical `evm_calldataload_window_code`.
+
+Sister to `calldataload_window_one_limb_q0_stack_spec_within`,
+`_q1_stack_spec_within`, and `_q2_stack_spec_within`. Closes the four
+quarter sub-slices toward `evm-asm-pgeuo` (#104) — lets followup slices
+instantiate `h3` of
+`calldataload_window_combined_four_limb_sequence_stack_spec_within`
+directly with a concrete byte-load triple, without first wrapping in
+`mloadFourLimbsCode`.
+
+Distinctive token:
+Calldata.LoadStackCode.calldataload_window_one_limb_q3_stack_spec_within #104.
+-/
+theorem calldataload_window_one_limb_q3_stack_spec_within
+    {n : Nat} {P Q : Assertion}
+    (offReg byteReg accReg addrReg envPtrReg : Reg) (base : Word)
+    (h :
+      cpsTripleWithin n (base + 284) (base + 376)
+        (mloadOneLimbCode addrReg byteReg accReg
+          0 1 2 3 4 5 6 7 24 (base + 284)) P Q) :
+    cpsTripleWithin n (base + 284) (base + 376)
+      (evm_calldataload_window_code offReg byteReg accReg addrReg envPtrReg base)
+      P Q := by
+  rw [evm_calldataload_window_code_eq_mloadStackCode]
+  refine cpsTripleWithin_extend_code (hmono := ?_) h
+  intro a i hq
+  exact mloadStackCode_four_limbs_sub
+    offReg byteReg accReg addrReg envPtrReg base a i
+    (mloadFourLimbsCode_one_limb_q3_sub addrReg byteReg accReg base a i hq)
+
 end Calldata
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/MLoad/StackSpec.lean
+++ b/EvmAsm/Evm64/MLoad/StackSpec.lean
@@ -272,6 +272,81 @@ theorem mloadFourLimbsCode_one_limb_q2_sub
       (mloadFourLimbs_q1_disjoint_q2 addrReg byteReg accReg base)
       CodeReq.union_mono_left)
 
+/-- Disjointness of the q0 and q3 one-limb byte-pack blocks within
+    `mloadFourLimbsCode`. q0 spans `base + 8 .. base + 100`, q3 spans
+    `base + 284 .. base + 376`; both are 23-instruction `mloadOneLimbProg`
+    blocks expressible as `CodeReq.ofProg`. -/
+private theorem mloadFourLimbs_q0_disjoint_q3
+    (addrReg byteReg accReg : Reg) (base : Word) :
+    CodeReq.Disjoint
+      (mloadOneLimbCode addrReg byteReg accReg
+        24 25 26 27 28 29 30 31 0 (base + 8))
+      (mloadOneLimbCode addrReg byteReg accReg
+        0 1 2 3 4 5 6 7 24 (base + 284)) := by
+  rw [mloadOneLimbCode_eq_ofProg, mloadOneLimbCode_eq_ofProg]
+  refine CodeReq.ofProg_disjoint_range_len _ _ 23 _ _ 23 ?_ ?_ ?_
+  · unfold mloadOneLimbProg mloadBytePackEightProg LBU SLLI OR' SD single seq; rfl
+  · unfold mloadOneLimbProg mloadBytePackEightProg LBU SLLI OR' SD single seq; rfl
+  · intro k1 k2 hk1 hk2; bv_omega
+
+/-- Disjointness of the q1 and q3 one-limb byte-pack blocks within
+    `mloadFourLimbsCode`. q1 spans `base + 100 .. base + 192`, q3 spans
+    `base + 284 .. base + 376`; both are 23-instruction `mloadOneLimbProg`
+    blocks expressible as `CodeReq.ofProg`. -/
+private theorem mloadFourLimbs_q1_disjoint_q3
+    (addrReg byteReg accReg : Reg) (base : Word) :
+    CodeReq.Disjoint
+      (mloadOneLimbCode addrReg byteReg accReg
+        16 17 18 19 20 21 22 23 8 (base + 100))
+      (mloadOneLimbCode addrReg byteReg accReg
+        0 1 2 3 4 5 6 7 24 (base + 284)) := by
+  rw [mloadOneLimbCode_eq_ofProg, mloadOneLimbCode_eq_ofProg]
+  refine CodeReq.ofProg_disjoint_range_len _ _ 23 _ _ 23 ?_ ?_ ?_
+  · unfold mloadOneLimbProg mloadBytePackEightProg LBU SLLI OR' SD single seq; rfl
+  · unfold mloadOneLimbProg mloadBytePackEightProg LBU SLLI OR' SD single seq; rfl
+  · intro k1 k2 hk1 hk2; bv_omega
+
+/-- Disjointness of the q2 and q3 one-limb byte-pack blocks within
+    `mloadFourLimbsCode`. q2 spans `base + 192 .. base + 284`, q3 spans
+    `base + 284 .. base + 376`; both are 23-instruction `mloadOneLimbProg`
+    blocks expressible as `CodeReq.ofProg`. -/
+private theorem mloadFourLimbs_q2_disjoint_q3
+    (addrReg byteReg accReg : Reg) (base : Word) :
+    CodeReq.Disjoint
+      (mloadOneLimbCode addrReg byteReg accReg
+        8 9 10 11 12 13 14 15 16 (base + 192))
+      (mloadOneLimbCode addrReg byteReg accReg
+        0 1 2 3 4 5 6 7 24 (base + 284)) := by
+  rw [mloadOneLimbCode_eq_ofProg, mloadOneLimbCode_eq_ofProg]
+  refine CodeReq.ofProg_disjoint_range_len _ _ 23 _ _ 23 ?_ ?_ ?_
+  · unfold mloadOneLimbProg mloadBytePackEightProg LBU SLLI OR' SD single seq; rfl
+  · unfold mloadOneLimbProg mloadBytePackEightProg LBU SLLI OR' SD single seq; rfl
+  · intro k1 k2 hk1 hk2; bv_omega
+
+/-- Subsumption witness: the q3 one-limb byte-pack block, placed at
+    `base + 284 .. base + 376`, is the fourth (rightmost) union member of
+    `mloadFourLimbsCode`. Proved by stepping past q0, q1, and q2 with
+    `mono_union_right` (using disjointness with each), reaching the tail
+    position of the innermost union which is itself the q3 block.
+
+    Consumer: `calldataload_window_one_limb_q3_stack_spec_within`
+    (Calldata/LoadStackCode.lean) — sister to the q0 / q1 / q2 witnesses,
+    closing the four sub-slices of `evm-asm-pgeuo` (#104). -/
+theorem mloadFourLimbsCode_one_limb_q3_sub
+    (addrReg byteReg accReg : Reg) (base : Word) :
+    ∀ a i,
+      (mloadOneLimbCode addrReg byteReg accReg
+          0 1 2 3 4 5 6 7 24 (base + 284)) a = some i →
+      (mloadFourLimbsCode addrReg byteReg accReg base) a = some i := by
+  unfold mloadFourLimbsCode
+  exact CodeReq.mono_union_right
+    (mloadFourLimbs_q0_disjoint_q3 addrReg byteReg accReg base)
+    (CodeReq.mono_union_right
+      (mloadFourLimbs_q1_disjoint_q3 addrReg byteReg accReg base)
+      (CodeReq.mono_union_right
+        (mloadFourLimbs_q2_disjoint_q3 addrReg byteReg accReg base)
+        (fun _ _ h => h)))
+
 theorem mload_four_limbs_stack_spec_within
     {n : Nat} {P Q : Assertion}
     (offReg byteReg accReg addrReg memBaseReg : Reg) (base : Word)


### PR DESCRIPTION
Add the fourth/rightmost-quarter subsumption witness and stack-code transport, closing the four quarter sub-slices toward `evm-asm-pgeuo` (#104).

- `mloadFourLimbsCode_one_limb_q3_sub` in `EvmAsm/Evm64/MLoad/StackSpec.lean`: q3 byte-pack block at `base + 284 .. base + 376` is the fourth union member of `mloadFourLimbsCode`. Proved by stepping past q0, q1, q2 via `mono_union_right` (each disjointness via `ofProg_disjoint_range_len` on 23-instruction `mloadOneLimbProg` blocks), reaching the innermost-union tail position which is itself the q3 block.
- `calldataload_window_one_limb_q3_stack_spec_within` in `EvmAsm/Evm64/Calldata/LoadStackCode.lean`: transport from the concrete `mloadOneLimbCode` byte-load triple to the program-identical `evm_calldataload_window_code`.

Sister to PR #2987 (q0), #2989 (q1), #2990 (q2). Stacks on #2990; rebases to main once that lands.

Refs evm-asm-8lrmr, GH #104, parent evm-asm-pgeuo.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).