### PR TITLE
feat(evm64): add push dispatch status bridge

### DIFF
--- a/EvmAsm/Evm64/PushHandlers.lean
+++ b/EvmAsm/Evm64/PushHandlers.lean
@@ -116,6 +116,14 @@ theorem dispatchOpcode_pushHandlerTable_PUSH_of_valid
   exact HandlerTable.dispatchOpcode_some
     (pushHandler?_PUSH_of_valid h_valid) state
 
+theorem dispatchOpcode_pushHandlerTable_PUSH_of_valid_status
+    {n : Nat} (h_valid : EvmOpcode.validPushWidth n = true)
+    (state : EvmState) :
+    (HandlerTable.dispatchOpcode pushHandlerTable (.PUSH n) state).status =
+      state.status := by
+  rw [dispatchOpcode_pushHandlerTable_PUSH_of_valid h_valid state]
+  exact pushHandler_status n state
+
 end PushHandlers
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add a dispatch-status companion for valid PUSH handler-table dispatch
- reuse the existing dispatch equality and push handler status lemmas

## Verification
- lake build EvmAsm.Evm64.PushHandlers
- lake build
- scripts/check-file-size.sh
- git diff --check
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception' EvmAsm/Evm64/PushHandlers.lean

Bead: evm-asm-jus35

Authored by @pirapira; implemented by Codex.