### PR TITLE
feat(evm64): add dup swap dispatch status bridges

### DIFF
--- a/EvmAsm/Evm64/DupSwapHandlers.lean
+++ b/EvmAsm/Evm64/DupSwapHandlers.lean
@@ -242,6 +242,24 @@ theorem dispatchOpcode_dupSwapHandlerTable_SWAP_of_valid
   exact HandlerTable.dispatchOpcode_some
     (dupSwapHandler?_SWAP_of_valid h_valid) state
 
+theorem dispatchOpcode_dupSwapHandlerTable_DUP_of_valid_status_of_some
+    {n : Nat} (h_valid : EvmOpcode.validDupIndex n = true)
+    {state : EvmState} {stack' : List EvmWord}
+    (h_stack : dupStack? n state.stack = some stack') :
+    (HandlerTable.dispatchOpcode dupSwapHandlerTable (.DUP n) state).status =
+      state.status := by
+  rw [dispatchOpcode_dupSwapHandlerTable_DUP_of_valid h_valid state]
+  simp [dupHandler, h_stack, EvmState.withStack]
+
+theorem dispatchOpcode_dupSwapHandlerTable_SWAP_of_valid_status_of_some
+    {n : Nat} (h_valid : EvmOpcode.validSwapIndex n = true)
+    {state : EvmState} {stack' : List EvmWord}
+    (h_stack : swapStack? n state.stack = some stack') :
+    (HandlerTable.dispatchOpcode dupSwapHandlerTable (.SWAP n) state).status =
+      state.status := by
+  rw [dispatchOpcode_dupSwapHandlerTable_SWAP_of_valid h_valid state]
+  simp [swapHandler, h_stack, EvmState.withStack]
+
 theorem dispatchOpcode?_dupSwapHandlerTable_DUP_of_valid
     {n : Nat} (h_valid : EvmOpcode.validDupIndex n = true)
     (state : EvmState) :


### PR DESCRIPTION
## Summary
- add dispatch-status companions for successful DUP and SWAP handler-table dispatch
- prove the status preservation from the existing dispatch equality plus the stack-transform success hypotheses

## Verification
- lake build EvmAsm.Evm64.DupSwapHandlers
- lake build
- scripts/check-file-size.sh
- git diff --check
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception' EvmAsm/Evm64/DupSwapHandlers.lean

Bead: evm-asm-yqmk9

Authored by @pirapira; implemented by Codex.