### PR TITLE
feat(evm64): add bitwise dispatch status bridges

### DIFF
--- a/EvmAsm/Evm64/BitwiseHandlers.lean
+++ b/EvmAsm/Evm64/BitwiseHandlers.lean
@@ -294,5 +294,37 @@ theorem dispatchOpcode_bitwiseHandlerTable_NOT
       notHandler state := by
   exact HandlerTable.dispatchOpcode_some bitwiseHandler?_NOT state
 
+theorem dispatchOpcode_bitwiseHandlerTable_AND_status_of_some
+    {state : EvmState} {stack' : List EvmWord}
+    (h_stack : binaryStack? (fun a b => a &&& b) state.stack = some stack') :
+    (HandlerTable.dispatchOpcode bitwiseHandlerTable .AND state).status =
+      state.status := by
+  rw [dispatchOpcode_bitwiseHandlerTable_AND state]
+  simp [andHandler, binaryHandler, h_stack, EvmState.withStack]
+
+theorem dispatchOpcode_bitwiseHandlerTable_OR_status_of_some
+    {state : EvmState} {stack' : List EvmWord}
+    (h_stack : binaryStack? (fun a b => a ||| b) state.stack = some stack') :
+    (HandlerTable.dispatchOpcode bitwiseHandlerTable .OR state).status =
+      state.status := by
+  rw [dispatchOpcode_bitwiseHandlerTable_OR state]
+  simp [orHandler, binaryHandler, h_stack, EvmState.withStack]
+
+theorem dispatchOpcode_bitwiseHandlerTable_XOR_status_of_some
+    {state : EvmState} {stack' : List EvmWord}
+    (h_stack : binaryStack? (fun a b => a ^^^ b) state.stack = some stack') :
+    (HandlerTable.dispatchOpcode bitwiseHandlerTable .XOR state).status =
+      state.status := by
+  rw [dispatchOpcode_bitwiseHandlerTable_XOR state]
+  simp [xorHandler, binaryHandler, h_stack, EvmState.withStack]
+
+theorem dispatchOpcode_bitwiseHandlerTable_NOT_status_of_some
+    {state : EvmState} {stack' : List EvmWord}
+    (h_stack : unaryStack? (fun a => ~~~a) state.stack = some stack') :
+    (HandlerTable.dispatchOpcode bitwiseHandlerTable .NOT state).status =
+      state.status := by
+  rw [dispatchOpcode_bitwiseHandlerTable_NOT state]
+  simp [notHandler, unaryHandler, h_stack, EvmState.withStack]
+
 end BitwiseHandlers
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add dispatch-status companions for successful AND, OR, XOR, and NOT handler-table dispatch
- reuse existing dispatch equality lemmas and successful stack-transform hypotheses

## Verification
- lake build EvmAsm.Evm64.BitwiseHandlers
- lake build
- scripts/check-file-size.sh
- git diff --check
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception' EvmAsm/Evm64/BitwiseHandlers.lean

Bead: evm-asm-cympi

Authored by @pirapira; implemented by Codex.