### PR TITLE
docs: target zkvm_accelerators.h as canonical accelerator C ABI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,7 +161,12 @@ Pitfalls:
 
 - **Original paper**: Kennedy et al., "Coq: The world's best macro assembler?" PPDP 2013
   https://www.microsoft.com/en-us/research/publication/coq-worlds-best-macro-assembler/
-- **SP1 zkVM**: https://github.com/succinctlabs/sp1
+- **zkvm_accelerators.h**: `EvmAsm/Evm64/zkvm-standards/standards/c-interface-accelerators/zkvm_accelerators.h`
+  is the source of truth for accelerator function signatures, argument
+  layouts, and `zkvm_status` framing used by all EVM precompile and
+  KECCAK256 bridges. See [`docs/zkvm-accelerators-interface.md`](docs/zkvm-accelerators-interface.md).
+- **SP1 zkVM**: https://github.com/succinctlabs/sp1 (RISC-V `ECALL`
+  framing only; function set follows `zkvm_accelerators.h`)
 - **RISC-V ISA**: https://riscv.org/technical/specifications/
 - **sail-riscv-lean**: https://github.com/opencompl/sail-riscv-lean (same toolchain)
 - **Lean 4 docs**: https://lean-lang.org/documentation/

--- a/PLAN.md
+++ b/PLAN.md
@@ -826,16 +826,26 @@ This is the heart of the STF — the inner loop that executes EVM bytecode.
   SSTORE updates `storage[key] := value`.
 
 #### 8.2 Precompiles (via zkvm_accelerators)
-- Map EVM precompile addresses (0x01-0x11) to `zkvm_accelerators.h` calls.
+- The canonical C ABI is the vendored header
+  `EvmAsm/Evm64/zkvm-standards/standards/c-interface-accelerators/zkvm_accelerators.h`
+  (eth-act zkvm-standards). See
+  [`docs/zkvm-accelerators-interface.md`](docs/zkvm-accelerators-interface.md)
+  for the ADR; per-function bridge progress is tracked in beads parent
+  `evm-asm-nr2sk`.
+- Map EVM precompile addresses (0x01-0x11, 0x100) to `zkvm_accelerators.h` calls.
 - ECRECOVER (0x01) → `zkvm_secp256k1_ecrecover`
 - SHA256 (0x02) → `zkvm_sha256`
 - RIPEMD160 (0x03) → `zkvm_ripemd160`
+- IDENTITY (0x04) → no accelerator (pure memcpy)
 - MODEXP (0x05) → `zkvm_modexp`
-- BN254 (0x06-0x08) → `zkvm_bn254_*`
+- BN254 G1 ADD/MUL/PAIRING (0x06–0x08) → `zkvm_bn254_g1_add` / `zkvm_bn254_g1_mul` / `zkvm_bn254_pairing`
 - BLAKE2f (0x09) → `zkvm_blake2f`
-- KZG (0x0a) → `zkvm_kzg_point_eval`
-- BLS12-381 (0x0b-0x11) → `zkvm_bls12_*`
-- secp256r1 (0x100) → `zkvm_secp256r1_verify`
+- KZG point eval (0x0a) → `zkvm_kzg_point_eval`
+- BLS12-381 G1/G2 ADD/MSM, PAIRING, MAP_FP/FP2 (0x0b–0x11) → `zkvm_bls12_*`
+- secp256r1 verify (0x100) → `zkvm_secp256r1_verify`
+- Non-precompile accelerators reused elsewhere: `zkvm_keccak256` (KECCAK256
+  opcode, §8.3), `zkvm_secp256k1_verify` (transaction signature
+  verification).
 
 #### 8.3 KECCAK256 (via accelerator)
 - Pop offset+size, hash EVM memory region.

--- a/README.md
+++ b/README.md
@@ -312,9 +312,19 @@ This is a **prototype** demonstrating the approach. Current state:
 - Knuth, D.E. (1997). *The Art of Computer Programming, Volume 2:
   Seminumerical Algorithms* (3rd ed.), §4.3.1 "The Classical Algorithms."
   Addison-Wesley. Algorithm D is used for the DIV/MOD opcodes in `Evm64/DivMod.lean`.
-- SP1 zkVM: https://github.com/succinctlabs/sp1
-  The `ECALL`-based syscall mechanism follows SP1's conventions.
 - zkvm-standards: https://github.com/eth-act/zkvm-standards
-  Tentative standards for zkVM RISC-V target, I/O interface, and C-interface accelerators.
+  Standards for zkVM RISC-V target, I/O interface, and C-interface
+  accelerators. The vendored header at
+  `EvmAsm/Evm64/zkvm-standards/standards/c-interface-accelerators/zkvm_accelerators.h`
+  is the canonical accelerator C ABI targeted by the verified guest;
+  see [`docs/zkvm-accelerators-interface.md`](docs/zkvm-accelerators-interface.md)
+  for the decision record and per-precompile coverage map.
+- SP1 zkVM: https://github.com/succinctlabs/sp1
+  The RISC-V `ECALL` framing (instruction encoding, register
+  convention, return-via-`a0`) follows the same mechanism SP1 uses;
+  the *function set* and argument layout follow `zkvm_accelerators.h`,
+  not SP1's syscall table. Concrete syscall IDs are a host detail
+  remapped in the ECALL handler and tracked per-bridge in beads
+  parent `evm-asm-nr2sk`.
 - sail-riscv-lean: https://github.com/opencompl/sail-riscv-lean
 - RISC-V ISA specification: https://riscv.org/technical/specifications/

--- a/docs/zkvm-accelerators-interface.md
+++ b/docs/zkvm-accelerators-interface.md
@@ -1,0 +1,106 @@
+# ADR: zkvm_accelerators.h as the canonical accelerator C ABI
+
+Status: Accepted (2026-05-06)
+Authors: @pirapira (decision); Hermes-bot (drafting)
+Refs: beads `evm-asm-y4o09`, `evm-asm-nr2sk`; GH #114, #116
+
+## Decision
+
+The canonical C interface that the verified RISC-V guest targets for
+cryptographic accelerators is the header
+
+  `EvmAsm/Evm64/zkvm-standards/standards/c-interface-accelerators/zkvm_accelerators.h`
+
+(vendored from <https://github.com/eth-act/zkvm-standards>). All EVM
+precompile dispatch (`0x01`–`0x11`, `0x100`) and the non-precompile
+accelerators `KECCAK256` and `secp256k1_verify` lower onto a function
+declared in that header. The header — not a particular zkVM — is the
+source of truth for argument layout, return-value framing
+(`zkvm_status` / `ZKVM_EOK`), and per-function preconditions.
+
+## Why this is non-obvious from the code today
+
+`README.md` historically said "the ECALL-based syscall mechanism follows
+SP1's conventions." That is a statement about the *mechanism* (RISC-V
+`ECALL` with syscall ID in `a7`/`t0`, args in `a0`–`a2`, etc.), not
+about the *function set or signatures*. SP1 ships its own list of
+syscall IDs and accelerator argument shapes; the EVM-asm proofs
+target the eth-act zkvm-standards function set described in
+`zkvm_accelerators.h`. The two coexist:
+
+- The dispatch *mechanism* (instruction encoding, register convention,
+  return-via-`a0`) reuses SP1's RISC-V `ECALL` framing because it is
+  the same mechanism every RISC-V zkVM uses; nothing in
+  `zkvm_accelerators.h` constrains it.
+- The *syscall ID table* — which integer in `a7`/`t0` selects which
+  accelerator — is an implementation detail of the host zkVM, not of
+  the C ABI. We track concrete IDs in the per-precompile bridge beads
+  (parent `evm-asm-nr2sk`); a host that ships a different ID table
+  remaps in its ECALL handler without affecting the verified guest.
+
+In short: function set + argument layout + status framing come from
+`zkvm_accelerators.h`; ECALL framing follows the RISC-V convention SP1
+also uses; concrete syscall IDs are handler-side and tracked
+separately.
+
+## Coverage map
+
+The header declares 19 entry points. Each one is (or will be) bridged by
+a Lean payload type, a syscall-ID constant tying the ECALL handler to
+the function, and a Hoare triple linking the RISC-V state transition to
+the pure result. Per-function status is tracked in the children of
+`evm-asm-nr2sk`.
+
+Non-precompile accelerators:
+
+| C symbol | Status |
+|----------|--------|
+| `zkvm_keccak256` | partial (input/result payload bridges in `EvmAsm/EL/KeccakInputBridge.lean`, `KeccakResultBridge.lean`); `zkvm_status` plumbing pending |
+| `zkvm_secp256k1_verify` | not yet bridged |
+
+Precompiles `0x01`–`0x11` and `0x100`:
+
+| Precompile | Address | C symbol |
+|------------|---------|----------|
+| ECRECOVER | `0x01` | `zkvm_secp256k1_ecrecover` |
+| SHA256 | `0x02` | `zkvm_sha256` |
+| RIPEMD160 | `0x03` | `zkvm_ripemd160` |
+| IDENTITY | `0x04` | (no accelerator — pure memcpy) |
+| MODEXP | `0x05` | `zkvm_modexp` |
+| BN254 G1 ADD | `0x06` | `zkvm_bn254_g1_add` |
+| BN254 G1 MUL | `0x07` | `zkvm_bn254_g1_mul` |
+| BN254 PAIRING | `0x08` | `zkvm_bn254_pairing` |
+| BLAKE2F | `0x09` | `zkvm_blake2f` |
+| KZG POINT EVAL | `0x0a` | `zkvm_kzg_point_eval` |
+| BLS12 G1 ADD | `0x0b` | `zkvm_bls12_g1_add` |
+| BLS12 G1 MSM | `0x0c` | `zkvm_bls12_g1_msm` |
+| BLS12 G2 ADD | `0x0d` | `zkvm_bls12_g2_add` |
+| BLS12 G2 MSM | `0x0e` | `zkvm_bls12_g2_msm` |
+| BLS12 PAIRING | `0x0f` | `zkvm_bls12_pairing` |
+| BLS12 MAP FP→G1 | `0x10` | `zkvm_bls12_map_fp_to_g1` |
+| BLS12 MAP FP2→G2 | `0x11` | `zkvm_bls12_map_fp2_to_g2` |
+| secp256r1 verify | `0x100` | `zkvm_secp256r1_verify` |
+
+## Calling convention
+
+The guest follows LP64 as documented in
+[`EvmAsm/Evm64/CallingConvention.lean`](../EvmAsm/Evm64/CallingConvention.lean):
+arguments in `a0`–`a2` (`x10`–`x12`), return value in `a0`, `sp` saved
+by the callee, `ra` saved by the caller of non-leaf routines. Each
+accelerator wrapper marshals its `zkvm_accelerators.h` arguments into
+that register layout, issues an `ECALL`, and reads back the
+`zkvm_status` from `a0`. Concrete bridges live (or will live) under
+`EvmAsm/EL/` next to the existing keccak bridges.
+
+## Maintenance
+
+Update this ADR when:
+
+- The vendored `zkvm_accelerators.h` is bumped (record the source
+  commit).
+- A bridge child of `evm-asm-nr2sk` lands and the coverage table above
+  needs ticking.
+- The decision itself is revisited (e.g. eth-act zkvm-standards is
+  superseded).
+
+Authored by @pirapira; implemented by Hermes-bot (evm-hermes).


### PR DESCRIPTION
Resolves the README/PLAN/AGENTS ambiguity around "follows SP1 conventions" by recording the actual decision: the vendored `zkvm_accelerators.h` (eth-act zkvm-standards) is the canonical function set, argument layout, and `zkvm_status` framing. The RISC-V ECALL framing reuses SP1's mechanism, but the syscall ID table is a host implementation detail tracked per-bridge under beads parent `evm-asm-nr2sk`.

Changes:
- New ADR `docs/zkvm-accelerators-interface.md` with full coverage map for precompiles 0x01–0x11, 0x100, plus the non-precompile accelerators `zkvm_keccak256` and `zkvm_secp256k1_verify`.
- README references rewritten: zkvm-standards promoted to source of truth; SP1 entry scoped to ECALL framing.
- AGENTS.md one-liner pointing future agents at the header.
- PLAN.md 8.2 expanded with full per-address C-symbol map and link to the ADR + tracker bead.

No Lean changes; pure documentation.

Refs beads `evm-asm-y4o09`, `evm-asm-nr2sk`; GH #114, #116.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).