### PR TITLE
feat(evm64): add code dispatch status bridge

### DIFF
--- a/EvmAsm/Evm64/CodeHandlers.lean
+++ b/EvmAsm/Evm64/CodeHandlers.lean
@@ -77,5 +77,12 @@ theorem dispatchOpcode_codeHandlerTable_CODESIZE
   exact HandlerTable.dispatchOpcode_some
     codeHandlerTable_CODESIZE state
 
+theorem dispatchOpcode_codeHandlerTable_CODESIZE_status
+    (state : EvmState) :
+    (HandlerTable.dispatchOpcode codeHandlerTable .CODESIZE state).status =
+      state.status := by
+  rw [dispatchOpcode_codeHandlerTable_CODESIZE state]
+  exact codeSizeHandler_status state
+
 end CodeHandlers
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add a dispatch-status companion for CODESIZE handler-table dispatch
- reuse the existing dispatch equality and code handler status lemmas

## Verification
- lake build EvmAsm.Evm64.CodeHandlers
- lake build
- scripts/check-file-size.sh
- git diff --check
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception' EvmAsm/Evm64/CodeHandlers.lean

Bead: evm-asm-yhkx5

Authored by @pirapira; implemented by Codex.