### PR TITLE
feat(evm64): add memory dispatch status bridge

### DIFF
--- a/EvmAsm/Evm64/MemoryHandlers.lean
+++ b/EvmAsm/Evm64/MemoryHandlers.lean
@@ -71,6 +71,13 @@ theorem memoryHandler?_eq_none_iff
       msizeHandler state := by
   simp [HandlerTable.dispatchOpcode]
 
+theorem dispatchOpcode_msizeHandlerTable_MSIZE_status
+    (state : EvmState) :
+    (HandlerTable.dispatchOpcode msizeHandlerTable .MSIZE state).status =
+      state.status := by
+  rw [dispatchOpcode_msizeHandlerTable_MSIZE state]
+  exact msizeHandler_status state
+
 end MemoryHandlers
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add a dispatch-status companion for MSIZE handler-table dispatch
- reuse the existing dispatch equality and msize handler status lemmas

## Verification
- lake build EvmAsm.Evm64.MemoryHandlers
- lake build
- scripts/check-file-size.sh
- git diff --check
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception' EvmAsm/Evm64/MemoryHandlers.lean

Bead: evm-asm-8odmp

Authored by @pirapira; implemented by Codex.