### PR TITLE
feat(evm64): add returndata dispatch status bridge

### DIFF
--- a/EvmAsm/Evm64/ReturnDataHandlers.lean
+++ b/EvmAsm/Evm64/ReturnDataHandlers.lean
@@ -73,6 +73,13 @@ theorem returnDataHandler?_eq_none_iff
       returnDataSizeHandler state := by
   simp [HandlerTable.dispatchOpcode]
 
+theorem dispatchOpcode_returnDataSizeHandlerTable_RETURNDATASIZE_status
+    (state : EvmState) :
+    (HandlerTable.dispatchOpcode returnDataSizeHandlerTable .RETURNDATASIZE state).status =
+      state.status := by
+  rw [dispatchOpcode_returnDataSizeHandlerTable_RETURNDATASIZE state]
+  exact returnDataSizeHandler_status state
+
 end ReturnDataHandlers
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add a dispatch-status companion for RETURNDATASIZE handler-table dispatch
- reuse the existing dispatch equality and returndata handler status lemmas

## Verification
- lake build EvmAsm.Evm64.ReturnDataHandlers
- lake build
- scripts/check-file-size.sh
- git diff --check
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception' EvmAsm/Evm64/ReturnDataHandlers.lean

Bead: evm-asm-fgtgk

Authored by @pirapira; implemented by Codex.