### PR TITLE
feat(evm64): add calldata dispatch status bridge

### DIFF
--- a/EvmAsm/Evm64/CalldataHandlers.lean
+++ b/EvmAsm/Evm64/CalldataHandlers.lean
@@ -78,5 +78,12 @@ theorem dispatchOpcode_calldataHandlerTable_CALLDATASIZE
   exact HandlerTable.dispatchOpcode_some
     calldataHandlerTable_CALLDATASIZE state
 
+theorem dispatchOpcode_calldataHandlerTable_CALLDATASIZE_status
+    (state : EvmState) :
+    (HandlerTable.dispatchOpcode calldataHandlerTable .CALLDATASIZE state).status =
+      state.status := by
+  rw [dispatchOpcode_calldataHandlerTable_CALLDATASIZE state]
+  exact callDataSizeHandler_status state
+
 end CalldataHandlers
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add a dispatch-status companion for CALLDATASIZE handler-table dispatch
- reuse the existing dispatch equality and calldata handler status lemmas

## Verification
- lake build EvmAsm.Evm64.CalldataHandlers
- lake build
- scripts/check-file-size.sh
- git diff --check
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception' EvmAsm/Evm64/CalldataHandlers.lean

Bead: evm-asm-mk02t

Authored by @pirapira; implemented by Codex.