### PR TITLE
feat(evm64): add control dispatch status bridges

### DIFF
--- a/EvmAsm/Evm64/ControlHandlers.lean
+++ b/EvmAsm/Evm64/ControlHandlers.lean
@@ -132,6 +132,24 @@ theorem controlHandler?_eq_none_iff
       jumpdestHandler state := by
   simp [HandlerTable.dispatchOpcode]
 
+theorem dispatchOpcode_controlHandlerTable_PC_status (state : EvmState) :
+    (HandlerTable.dispatchOpcode controlHandlerTable .PC state).status =
+      state.status := by
+  rw [dispatchOpcode_controlHandlerTable_PC state]
+  exact pcHandler_status state
+
+theorem dispatchOpcode_controlHandlerTable_GAS_status (state : EvmState) :
+    (HandlerTable.dispatchOpcode controlHandlerTable .GAS state).status =
+      state.status := by
+  rw [dispatchOpcode_controlHandlerTable_GAS state]
+  exact gasHandler_status state
+
+theorem dispatchOpcode_controlHandlerTable_JUMPDEST_status (state : EvmState) :
+    (HandlerTable.dispatchOpcode controlHandlerTable .JUMPDEST state).status =
+      state.status := by
+  rw [dispatchOpcode_controlHandlerTable_JUMPDEST state]
+  rfl
+
 end ControlHandlers
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add dispatch-status companions for PC, GAS, and JUMPDEST handler-table dispatch
- reuse the existing dispatch equality and handler status/identity lemmas

## Verification
- lake build EvmAsm.Evm64.ControlHandlers
- lake build
- scripts/check-file-size.sh
- git diff --check
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception' EvmAsm/Evm64/ControlHandlers.lean

Bead: evm-asm-u794d

Authored by @pirapira; implemented by Codex.