### PR TITLE
feat(evm64): add environment dispatch status bridge

### DIFF
--- a/EvmAsm/Evm64/EnvHandlers.lean
+++ b/EvmAsm/Evm64/EnvHandlers.lean
@@ -110,6 +110,13 @@ theorem dispatchOpcode_simpleEnvHandlerTable_of_field
   exact HandlerTable.dispatchOpcode_some
     (simpleEnvHandler?_of_field field) state
 
+theorem dispatchOpcode_simpleEnvHandlerTable_of_field_status
+    (field : SimpleEnvField) (state : EvmState) :
+    (HandlerTable.dispatchOpcode simpleEnvHandlerTable field.opcode state).status =
+      state.status := by
+  rw [dispatchOpcode_simpleEnvHandlerTable_of_field field state]
+  exact simpleEnvHandler_status field state
+
 @[simp] theorem fieldOfOpcode?_ADDRESS :
     fieldOfOpcode? .ADDRESS = some .address := rfl
 


### PR DESCRIPTION
## Summary
- add a generic dispatch-status companion for simple environment handler-table dispatch
- reuse the existing dispatch equality and simple environment handler status lemmas

## Verification
- lake build EvmAsm.Evm64.EnvHandlers
- lake build
- scripts/check-file-size.sh
- git diff --check
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception' EvmAsm/Evm64/EnvHandlers.lean

Bead: evm-asm-hhtag

Authored by @pirapira; implemented by Codex.