### PR TITLE
feat(evm64): add supported push dispatch status bridge

### DIFF
--- a/EvmAsm/Evm64/SupportedHandlers.lean
+++ b/EvmAsm/Evm64/SupportedHandlers.lean
@@ -469,6 +469,15 @@ theorem dispatchOpcode_supportedHandlerTable_PUSH_effectFromCode
     (supportedHandlerTable_PUSH_of_valid h_valid) state]
   exact PushHandlers.pushHandler_eq_effectFromCode n state
 
+theorem dispatchOpcode_supportedHandlerTable_PUSH_of_valid_status
+    {n : Nat} (h_valid : EvmOpcode.validPushWidth n = true)
+    (state : EvmState) :
+    (HandlerTable.dispatchOpcode supportedHandlerTable (.PUSH n) state).status =
+      state.status := by
+  rw [HandlerTable.dispatchOpcode_some
+    (supportedHandlerTable_PUSH_of_valid h_valid) state]
+  exact PushHandlers.pushHandler_status n state
+
 theorem supportedHandlerTable_DUP_of_valid
     {n : Nat} (h_valid : EvmOpcode.validDupIndex n = true) :
     supportedHandlerTable (.DUP n) =


### PR DESCRIPTION
## Summary
- add a valid PUSH dispatch-status companion at the supported-handler table layer
- reuse the concrete supported PUSH lookup and push handler status lemma

## Verification
- lake build EvmAsm.Evm64.SupportedHandlers
- lake build
- scripts/check-file-size.sh
- git diff --check
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception' EvmAsm/Evm64/SupportedHandlers.lean

Bead: evm-asm-ssc2v

Authored by @pirapira; implemented by Codex.