### PR TITLE
feat(evm64): add byte push dispatch status bridge

### DIFF
--- a/EvmAsm/Evm64/SupportedHandlerByte.lean
+++ b/EvmAsm/Evm64/SupportedHandlerByte.lean
@@ -74,6 +74,25 @@ theorem dispatchByte_supported_PUSH_effectFromCode
     h_valid state
 
 /--
+Status projection for byte-level dispatch of a decoded valid PUSH opcode
+through the combined supported-handler table.
+
+Distinctive token:
+SupportedHandlerByte.dispatchByte_supported_PUSH_status #101 #107.
+-/
+theorem dispatchByte_supported_PUSH_status
+    {b : Fin 256} {n : Nat}
+    (h_decode : EvmOpcode.decodeByte? b.val = some (EvmOpcode.PUSH n))
+    (h_valid : EvmOpcode.validPushWidth n = true)
+    (state : EvmState) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable b state).status =
+      state.status := by
+  rw [dispatchByte_supported_of_decode h_decode state]
+  rw [HandlerTable.dispatchOpcode_some
+    (SupportedHandlers.supportedHandlerTable_PUSH_of_valid h_valid) state]
+  exact PushHandlers.pushHandler_status n state
+
+/--
 Concrete STOP byte dispatch through the combined supported-handler table
 terminates the state successfully.
 


### PR DESCRIPTION
## Summary
- add dispatchByte_supported_PUSH_status for decoded valid PUSH byte dispatch through the supported handler table
- reuse the existing byte decode bridge, supported PUSH lookup, and push handler status projection

## Verification
- lake build EvmAsm.Evm64.SupportedHandlerByte
- lake build
- scripts/check-file-size.sh
- git diff --check
- rg forbidden-pattern check on EvmAsm/Evm64/SupportedHandlerByte.lean (no matches)

Authored by @pirapira; implemented by Codex.

Closes evm-asm-cht4w