### PR TITLE
feat(evm64): add byte dispatch status preservation bridge

### DIFF
--- a/EvmAsm/Evm64/HandlerTableByte.lean
+++ b/EvmAsm/Evm64/HandlerTableByte.lean
@@ -78,6 +78,24 @@ theorem dispatchByte_decoded_lookup_status
     (dispatchByte table b state).status = (handler state).status := by
   rw [dispatchByte_decoded_lookup state h_decode h_lookup]
 
+/--
+If the decoded opcode byte looks up a status-preserving handler, byte-level
+dispatch preserves the incoming interpreter status.
+
+Distinctive token:
+HandlerTable.dispatchByte_decoded_lookup_preserves_status #106 #107.
+-/
+theorem dispatchByte_decoded_lookup_preserves_status
+    {table : HandlerTable} {b : Fin 256} {opcode : EvmOpcode}
+    {handler : OpcodeHandler}
+    (h_decode : EvmOpcode.decodeByte? b.val = some opcode)
+    (h_lookup : table opcode = some handler)
+    (h_status : ∀ state : EvmState, (handler state).status = state.status)
+    (state : EvmState) :
+    (dispatchByte table b state).status = state.status := by
+  rw [dispatchByte_decoded_lookup_status state h_decode h_lookup]
+  exact h_status state
+
 theorem dispatchByte_decoded_missing
     {table : HandlerTable} {b : Fin 256} {opcode : EvmOpcode}
     (state : EvmState)


### PR DESCRIPTION
## Summary
- add dispatchByte_decoded_lookup_preserves_status to HandlerTableByte
- compose decoded byte lookup status with a handler status-preservation hypothesis

## Verification
- lake build EvmAsm.Evm64.HandlerTableByte
- lake build
- scripts/check-file-size.sh
- git diff --check
- rg forbidden-pattern check on EvmAsm/Evm64/HandlerTableByte.lean (no matches)

Authored by @pirapira; implemented by Codex.

Closes evm-asm-tnngn