### PR TITLE
feat(evm64): add supported dup swap status bridges

### DIFF
--- a/EvmAsm/Evm64/SupportedHandlers.lean
+++ b/EvmAsm/Evm64/SupportedHandlers.lean
@@ -526,6 +526,26 @@ theorem supportedHandlerTable_SWAP_of_valid
       CalldataHandlers.calldataHandler?])
     (DupSwapHandlers.dupSwapHandler?_SWAP_of_valid h_valid)
 
+theorem dispatchOpcode_supportedHandlerTable_DUP_of_valid_status_of_some
+    {n : Nat} (h_valid : EvmOpcode.validDupIndex n = true)
+    {state : EvmState} {stack' : List EvmWord}
+    (h_stack : DupSwapHandlers.dupStack? n state.stack = some stack') :
+    (HandlerTable.dispatchOpcode supportedHandlerTable (.DUP n) state).status =
+      state.status := by
+  rw [HandlerTable.dispatchOpcode_some
+    (supportedHandlerTable_DUP_of_valid h_valid) state]
+  simp [DupSwapHandlers.dupHandler, h_stack, EvmState.withStack]
+
+theorem dispatchOpcode_supportedHandlerTable_SWAP_of_valid_status_of_some
+    {n : Nat} (h_valid : EvmOpcode.validSwapIndex n = true)
+    {state : EvmState} {stack' : List EvmWord}
+    (h_stack : DupSwapHandlers.swapStack? n state.stack = some stack') :
+    (HandlerTable.dispatchOpcode supportedHandlerTable (.SWAP n) state).status =
+      state.status := by
+  rw [HandlerTable.dispatchOpcode_some
+    (supportedHandlerTable_SWAP_of_valid h_valid) state]
+  simp [DupSwapHandlers.swapHandler, h_stack, EvmState.withStack]
+
 end SupportedHandlers
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add successful valid DUP status projection for supportedHandlerTable dispatch
- add successful valid SWAP status projection for supportedHandlerTable dispatch

## Verification
- lake build EvmAsm.Evm64.SupportedHandlers
- lake build
- scripts/check-file-size.sh
- git diff --check
- rg forbidden-pattern check on EvmAsm/Evm64/SupportedHandlers.lean (no matches)

Authored by @pirapira; implemented by Codex.

Closes evm-asm-q1ph2