### PR TITLE
feat(evm64): add loop handler status bridge

### DIFF
--- a/EvmAsm/Evm64/HandlerLoopBridge.lean
+++ b/EvmAsm/Evm64/HandlerLoopBridge.lean
@@ -57,6 +57,17 @@ theorem stepWithTableHandler_of_lookup_status
       (handler state).status := by
   rw [stepWithTableHandler_of_lookup h_decode h_lookup]
 
+theorem stepWithTableHandler_of_lookup_preserves_status
+    {table : HandlerTable} {state : EvmState} {opcode : EvmOpcode}
+    {handler : OpcodeHandler}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some opcode)
+    (h_lookup : table opcode = some handler)
+    (h_status : ∀ state : EvmState, (handler state).status = state.status) :
+    (InterpreterLoop.stepWithHandler (toLoopHandler table) state).status =
+      state.status := by
+  rw [stepWithTableHandler_of_lookup_status h_decode h_lookup]
+  exact h_status state
+
 theorem stepWithTableHandler_missing_invalid
     {table : HandlerTable} {state : EvmState} {opcode : EvmOpcode}
     (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some opcode)


### PR DESCRIPTION
## Summary
- add stepWithTableHandler_of_lookup_preserves_status to HandlerLoopBridge
- compose decoded table lookup status with a handler status-preservation hypothesis

## Verification
- lake build EvmAsm.Evm64.HandlerLoopBridge
- lake build
- scripts/check-file-size.sh
- git diff --check
- rg forbidden-pattern check on EvmAsm/Evm64/HandlerLoopBridge.lean (no matches)

Authored by @pirapira; implemented by Codex.

Closes evm-asm-d121g