### PR TITLE
feat(evm64): add supported loop push status bridge

### DIFF
--- a/EvmAsm/Evm64/SupportedLoopBridge.lean
+++ b/EvmAsm/Evm64/SupportedLoopBridge.lean
@@ -78,6 +78,17 @@ theorem stepWithSupportedHandler_PUSH_effectFromCode
   exact SupportedHandlers.dispatchOpcode_supportedHandlerTable_PUSH_effectFromCode
     h_valid state
 
+theorem stepWithSupportedHandler_PUSH_status
+    {state : EvmState} {n : Nat}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state =
+      some (EvmOpcode.PUSH n))
+    (h_valid : EvmOpcode.validPushWidth n = true) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).status =
+      state.status := by
+  rw [stepWithSupportedHandler_of_decode h_decode]
+  exact SupportedHandlers.dispatchOpcode_supportedHandlerTable_PUSH_of_valid_status
+    h_valid state
+
 /--
 When the combined supported loop decodes STOP, one interpreter step terminates
 successfully.


### PR DESCRIPTION
## Summary
- add stepWithSupportedHandler_PUSH_status to SupportedLoopBridge
- reuse the supported handler-table valid PUSH status projection

## Verification
- lake build EvmAsm.Evm64.SupportedLoopBridge
- lake build
- scripts/check-file-size.sh
- git diff --check
- rg forbidden-pattern check on EvmAsm/Evm64/SupportedLoopBridge.lean (no matches)

Authored by @pirapira; implemented by Codex.

Closes evm-asm-p0v1p