### PR TITLE
feat(evm64): terminating loop missing-entry status bridge

### DIFF
--- a/EvmAsm/Evm64/TerminatingLoopBridge.lean
+++ b/EvmAsm/Evm64/TerminatingLoopBridge.lean
@@ -65,6 +65,32 @@ theorem stepWithTerminatingHandler_INVALID_status
   rw [stepWithTerminatingHandler_INVALID h_decode]
   exact EvmState.invalid_status state
 
+/--
+Decoded opcodes absent from `terminatingHandlerTable` step to `state.invalid`
+through the terminating loop handler.
+
+Distinctive token: TerminatingLoopBridge.stepWithTerminatingHandler_missing_invalid #113.
+-/
+theorem stepWithTerminatingHandler_missing_invalid
+    {state : EvmState} {opcode : EvmOpcode}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some opcode)
+    (h_lookup : TerminatingHandlers.terminatingHandlerTable opcode = none) :
+    InterpreterLoop.stepWithHandler terminatingLoopHandler state = state.invalid :=
+  HandlerLoopBridge.stepWithTableHandler_missing_invalid h_decode h_lookup
+
+/--
+Status projection of `stepWithTerminatingHandler_missing_invalid`: missing-entry
+opcodes step to `.error`.
+-/
+theorem stepWithTerminatingHandler_missing_invalid_status
+    {state : EvmState} {opcode : EvmOpcode}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some opcode)
+    (h_lookup : TerminatingHandlers.terminatingHandlerTable opcode = none) :
+    (InterpreterLoop.stepWithHandler terminatingLoopHandler state).status =
+      .error := by
+  rw [stepWithTerminatingHandler_missing_invalid h_decode h_lookup]
+  exact EvmState.invalid_status state
+
 theorem loopFuel_stop_fixed :
     ∀ (fuel : Nat) (state : EvmState),
       InterpreterLoop.loopFuel terminatingLoopHandler fuel state.stop = state.stop


### PR DESCRIPTION
Adds two theorems to `EvmAsm/Evm64/TerminatingLoopBridge.lean` per beads `evm-asm-hrd2i`:

- `stepWithTerminatingHandler_missing_invalid` — decoded opcodes absent from `terminatingHandlerTable` step to `state.invalid` through the terminating loop handler (delegates to `HandlerLoopBridge.stepWithTableHandler_missing_invalid`).
- `stepWithTerminatingHandler_missing_invalid_status` — status projection yields `.error`.

`lake build` clean; no `sorry`/`admit`/`set_option`.

Refs GH #113, beads `evm-asm-hrd2i`.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).