### PR TITLE
feat(evm64): add supported loop dup swap status bridges

### DIFF
--- a/EvmAsm/Evm64/SupportedLoopBridge.lean
+++ b/EvmAsm/Evm64/SupportedLoopBridge.lean
@@ -89,6 +89,30 @@ theorem stepWithSupportedHandler_PUSH_status
   exact SupportedHandlers.dispatchOpcode_supportedHandlerTable_PUSH_of_valid_status
     h_valid state
 
+theorem stepWithSupportedHandler_DUP_status_of_some
+    {state : EvmState} {n : Nat} {stack' : List EvmWord}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state =
+      some (EvmOpcode.DUP n))
+    (h_valid : EvmOpcode.validDupIndex n = true)
+    (h_stack : DupSwapHandlers.dupStack? n state.stack = some stack') :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).status =
+      state.status := by
+  rw [stepWithSupportedHandler_of_decode h_decode]
+  exact SupportedHandlers.dispatchOpcode_supportedHandlerTable_DUP_of_valid_status_of_some
+    h_valid h_stack
+
+theorem stepWithSupportedHandler_SWAP_status_of_some
+    {state : EvmState} {n : Nat} {stack' : List EvmWord}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state =
+      some (EvmOpcode.SWAP n))
+    (h_valid : EvmOpcode.validSwapIndex n = true)
+    (h_stack : DupSwapHandlers.swapStack? n state.stack = some stack') :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).status =
+      state.status := by
+  rw [stepWithSupportedHandler_of_decode h_decode]
+  exact SupportedHandlers.dispatchOpcode_supportedHandlerTable_SWAP_of_valid_status_of_some
+    h_valid h_stack
+
 /--
 When the combined supported loop decodes STOP, one interpreter step terminates
 successfully.


### PR DESCRIPTION
## Summary
- add supported-loop status bridge for decoded valid DUP success paths
- add supported-loop status bridge for decoded valid SWAP success paths

## Verification
- lake build EvmAsm.Evm64.SupportedLoopBridge
- lake build
- scripts/check-file-size.sh
- git diff --check
- rg forbidden-pattern check on EvmAsm/Evm64/SupportedLoopBridge.lean (no matches)

Authored by @pirapira; implemented by Codex.

Closes evm-asm-cxr6b