### PR TITLE
feat(evm64): add direct invalid step status lemmas

### DIFF
--- a/EvmAsm/Evm64/InterpreterLoopStatus.lean
+++ b/EvmAsm/Evm64/InterpreterLoopStatus.lean
@@ -97,6 +97,20 @@ theorem loopFuel_error_status
     (InterpreterLoop.loopFuel handler nSteps state).status = .error := by
   rw [loopFuel_error handler nSteps state h_status, h_status]
 
+theorem stepWithHandler_eof_invalid_status
+    (handler : Handler) {state : EvmState}
+    (h_pc : state.code.length ≤ state.pc) :
+    (InterpreterLoop.stepWithHandler handler state).status = .error := by
+  rw [InterpreterLoop.stepWithHandler_eof_invalid handler h_pc]
+  exact EvmState.invalid_status state
+
+theorem stepWithHandler_unsupported_invalid_status
+    (handler : Handler) {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = none) :
+    (InterpreterLoop.stepWithHandler handler state).status = .error := by
+  rw [InterpreterLoop.stepWithHandler_of_unsupported handler h_decode]
+  exact EvmState.invalid_status state
+
 theorem loopFuel_one_eof_invalid
     (handler : Handler) {state : EvmState}
     (h_status : state.status = .running)


### PR DESCRIPTION
## Summary
- add direct stepWithHandler status lemmas for EOF and unsupported decode invalid paths
- complement existing one-step loopFuel invalid status bridges in InterpreterLoopStatus

## Verification
- lake build EvmAsm.Evm64.InterpreterLoopStatus
- lake build
- scripts/check-file-size.sh
- git diff --check
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception' EvmAsm/Evm64/InterpreterLoopStatus.lean (no matches)

Authored by @pirapira; implemented by Codex.

Bead: evm-asm-32tl.9