### PR TITLE
feat(accelerators): add ZkvmStatus + a0 word-constant bridge for zkvm_status

### DIFF
--- a/EvmAsm/Evm64.lean
+++ b/EvmAsm/Evm64.lean
@@ -8,6 +8,9 @@
 -- opcode Program file via Stack → Basic).
 import EvmAsm.Evm64.CodeRegion
 
+-- Accelerator C ABI bridges (zkvm_accelerators.h)
+import EvmAsm.Evm64.Accelerators.Status
+
 -- Stack operations
 import EvmAsm.Evm64.Pop
 import EvmAsm.Evm64.Push0

--- a/EvmAsm/Evm64/Accelerators/Status.lean
+++ b/EvmAsm/Evm64/Accelerators/Status.lean
@@ -1,0 +1,90 @@
+/-
+  EvmAsm.Evm64.Accelerators.Status
+
+  Lean bridge for the `zkvm_status` enum from
+  `EvmAsm/Evm64/zkvm-standards/standards/c-interface-accelerators/zkvm_accelerators.h`.
+
+  The C header (current upstream version) defines exactly two return codes:
+
+      typedef enum {
+          ZKVM_EOK   =  0,   /* Success */
+          ZKVM_EFAIL = -1    /* Failure */
+      } zkvm_status;
+
+  This module mirrors that enum, provides the matching `Int32` numeric encoding,
+  and exposes the `a0` return-register `Word` constants used to bridge accelerator
+  ECALL postconditions to RISC-V state.
+
+  Refs: parent beads task `evm-asm-nr2sk`, slice `evm-asm-hzmi6`.
+-/
+
+import EvmAsm.Rv64.Basic
+
+namespace EvmAsm
+namespace Accelerators
+
+/-- Status codes returned by zkVM accelerator functions, mirroring the
+`zkvm_status` C enum. The C enum is signed (`ZKVM_EFAIL = -1`); we model it
+as a Lean inductive and provide a 32-bit signed encoding. -/
+inductive ZkvmStatus where
+  | eok    -- ZKVM_EOK   =  0  (Success)
+  | efail  -- ZKVM_EFAIL = -1  (Failure)
+  deriving DecidableEq, Repr, Inhabited
+
+namespace ZkvmStatus
+
+/-- 32-bit signed encoding matching the C enum's numeric values exactly.
+`ZKVM_EOK` is `0`; `ZKVM_EFAIL` is `-1`, encoded as the all-ones `Int32`
+bit-pattern `0xFFFFFFFF`. -/
+def toInt32 : ZkvmStatus → Int32
+  | .eok   => 0
+  | .efail => -1
+
+/-- Predicate identifying the success status. -/
+def isOk : ZkvmStatus → Bool
+  | .eok   => true
+  | .efail => false
+
+@[simp] theorem isOk_eok   : isOk .eok   = true  := rfl
+@[simp] theorem isOk_efail : isOk .efail = false := rfl
+
+/-- `isOk` agrees with structural equality against `eok`. -/
+theorem isOk_iff_eq_eok (s : ZkvmStatus) : s.isOk = true ↔ s = .eok := by
+  cases s <;> simp [isOk]
+
+/-- The two encodings are distinct. -/
+theorem toInt32_eok_ne_efail : (ZkvmStatus.eok).toInt32 ≠ (ZkvmStatus.efail).toInt32 := by
+  decide
+
+/-- The encoding is injective. -/
+theorem toInt32_injective : Function.Injective ZkvmStatus.toInt32 := by
+  intro a b h
+  cases a <;> cases b <;> simp [toInt32] at h ⊢
+  all_goals (first | rfl | exact (h rfl).elim | exact absurd h (by decide))
+
+end ZkvmStatus
+
+end Accelerators
+end EvmAsm
+
+namespace EvmAsm
+namespace Rv64
+
+/-- RISC-V `a0` return-register `Word` value corresponding to `ZKVM_EOK`.
+Accelerator ECALL handlers that succeed leave `0` in `a0`; this constant
+names that value for postcondition reasoning. -/
+def zkvmStatusEokWord : Word := 0
+
+/-- RISC-V `a0` return-register `Word` value corresponding to `ZKVM_EFAIL`.
+The C enum value is `-1` (signed `Int32`). On the RV64 ABI, accelerator
+return codes occupy `a0` (a 64-bit register) sign-extended from `Int32`,
+so `ZKVM_EFAIL` is the all-ones 64-bit word `0xFFFFFFFFFFFFFFFF`. -/
+def zkvmStatusEfailWord : Word := BitVec.allOnes 64
+
+/-- The two status words are distinct. -/
+theorem zkvmStatusEokWord_ne_efailWord :
+    zkvmStatusEokWord ≠ zkvmStatusEfailWord := by
+  decide
+
+end Rv64
+end EvmAsm


### PR DESCRIPTION
Foundational slice for the `zkvm_accelerators.h` audit (parent beads `evm-asm-nr2sk`, slice `evm-asm-hzmi6`).

Adds `EvmAsm/Evm64/Accelerators/Status.lean`:

- `inductive ZkvmStatus { eok, efail }` mirroring the C `zkvm_status` enum from `EvmAsm/Evm64/zkvm-standards/standards/c-interface-accelerators/zkvm_accelerators.h` (current upstream header declares only these two codes: `ZKVM_EOK = 0`, `ZKVM_EFAIL = -1`).
- `ZkvmStatus.toInt32 : ZkvmStatus → Int32` matching the C numeric values exactly; injectivity and distinctness lemmas.
- `ZkvmStatus.isOk` convenience predicate with simp lemmas.
- `Rv64.zkvmStatusEokWord` / `zkvmStatusEfailWord` — `a0` return-register `Word` constants for ECALL postcondition reasoning. Failure word is `BitVec.allOnes 64` (sign-extended `-1`).

Wired into the `EvmAsm.Evm64` umbrella so downstream bridges can import it.

No Hoare triples in this slice, as specified — purely the type + constants + matching values. Existing partial KECCAK bridges (`EvmAsm/EL/KeccakInputBridge.lean`, `KeccakResultBridge.lean`) currently lack any `zkvm_status` plumbing; this slice unblocks adding it consistently across all accelerator bridges (next slice: `evm-asm-acve1`).

### Note on enum scope

The slice description anticipated a longer enum (`ZKVM_EINVAL`, `ZKVM_EOOR`, `ZKVM_EFAULT`, `ZKVM_EOVERFLOW`, `ZKVM_ENOMEM`, `ZKVM_ENOTSUP`). The current upstream header only declares `EOK`/`EFAIL`, so this PR mirrors the header (truth source). If the C enum is extended later, both `ZkvmStatus` and its `toInt32` encoding can be extended without breaking call sites.

### Verification

`lake build EvmAsm.Evm64` clean (1428 jobs).

Refs parent beads `evm-asm-nr2sk` (`zkvm_accelerators.h` per-precompile audit), slice `evm-asm-hzmi6`. Cross-refs GH #114, #116.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).