### PR TITLE
feat(evm64): add table loop eof status bridges

### DIFF
--- a/EvmAsm/Evm64/HandlerLoopBridge.lean
+++ b/EvmAsm/Evm64/HandlerLoopBridge.lean
@@ -100,6 +100,19 @@ theorem stepWithTableHandler_empty_of_decode_status
   rw [stepWithTableHandler_empty_of_decode h_decode]
   exact EvmState.invalid_status state
 
+theorem stepWithTableHandler_eof_invalid
+    (table : HandlerTable) {state : EvmState}
+    (h_pc : state.code.length ≤ state.pc) :
+    InterpreterLoop.stepWithHandler (toLoopHandler table) state = state.invalid := by
+  exact InterpreterLoop.stepWithHandler_eof_invalid (toLoopHandler table) h_pc
+
+theorem stepWithTableHandler_eof_invalid_status
+    (table : HandlerTable) {state : EvmState}
+    (h_pc : state.code.length ≤ state.pc) :
+    (InterpreterLoop.stepWithHandler (toLoopHandler table) state).status = .error := by
+  rw [stepWithTableHandler_eof_invalid table h_pc]
+  exact EvmState.invalid_status state
+
 theorem loopFuel_succ_running_decode
     (table : HandlerTable) (nSteps : Nat) {state : EvmState} {opcode : EvmOpcode}
     (h_status : state.status = .running)
@@ -193,6 +206,24 @@ theorem loopFuel_succ_running_unsupported_invalid_status
     (InterpreterLoop.loopFuel (toLoopHandler table) (nSteps + 1) state).status =
       .error := by
   rw [loopFuel_succ_running_unsupported_invalid table nSteps h_status h_decode]
+  exact loopFuel_table_invalid_fixed_status table nSteps state
+
+theorem loopFuel_succ_running_eof_invalid
+    (table : HandlerTable) (nSteps : Nat) {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.code.length ≤ state.pc) :
+    InterpreterLoop.loopFuel (toLoopHandler table) (nSteps + 1) state =
+      InterpreterLoop.loopFuel (toLoopHandler table) nSteps state.invalid := by
+  rw [InterpreterLoop.loopFuel_succ_running (toLoopHandler table) nSteps state h_status]
+  rw [stepWithTableHandler_eof_invalid table h_pc]
+
+theorem loopFuel_succ_running_eof_invalid_status
+    (table : HandlerTable) (nSteps : Nat) {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.code.length ≤ state.pc) :
+    (InterpreterLoop.loopFuel (toLoopHandler table) (nSteps + 1) state).status =
+      .error := by
+  rw [loopFuel_succ_running_eof_invalid table nSteps h_status h_pc]
   exact loopFuel_table_invalid_fixed_status table nSteps state
 
 theorem loopFuel_empty_succ_running_decode


### PR DESCRIPTION
## Summary
- add table-backed stepWithHandler EOF invalid/status bridge lemmas
- add successor loopFuel EOF invalid/status bridge lemmas for table-backed handlers

## Verification
- lake build EvmAsm.Evm64.HandlerLoopBridge
- lake build
- scripts/check-file-size.sh
- git diff --check
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception' EvmAsm/Evm64/HandlerLoopBridge.lean (no matches)

Authored by @pirapira; implemented by Codex.

Bead: evm-asm-32tl.10