### PR TITLE
chore(shake): noshake EvmAsm.Rv64.Basic for Accelerators/Status

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -102,6 +102,8 @@
   ["EvmAsm.Rv64.SepLogic"],
   "EvmAsm.Rv64.Tactics.SymStep":
   ["EvmAsm.Rv64.Execution"],
+  "EvmAsm.Evm64.Accelerators.Status":
+  ["EvmAsm.Rv64.Basic"],
  "EvmAsm.Evm64.Basic":
   ["Std.Tactic.BVDecide", "EvmAsm.Rv64.Basic"],
  "EvmAsm.Evm64.CodeRegion":


### PR DESCRIPTION
Add a noshake.json entry for `EvmAsm.Evm64.Accelerators.Status` so `lake exe shake EvmAsm` stops flagging `EvmAsm.Rv64.Basic` as an unused import.

`Status.lean` declares `zkvmStatusEokWord` / `zkvmStatusEfailWord` whose types use the `Word` (= `BitVec 64`) notation defined in `EvmAsm.Rv64.Basic`. Verified by removing the import locally — the build fails with implicit-argument synthesis errors on the two `def`s and the inequality theorem. The shake-filter Word-notation marker matches the literal text `notation "Word"`, which Status.lean does not contain (it just uses `Word` as a type), so the survivor slipped past the filter.

After this edit, `lake exe shake EvmAsm 2>/dev/null | scripts/shake-filter.py` prints `0 block(s) kept, 53 dropped` — survivor list is empty.

Refs GH #1045, parent beads `evm-asm-9tq`, slice `evm-asm-vxa9e`.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).