### PR TITLE
feat(evm64): derive running step simulation

### DIFF
--- a/EvmAsm/Evm64/InterpreterLoopSimulation.lean
+++ b/EvmAsm/Evm64/InterpreterLoopSimulation.lean
@@ -81,6 +81,23 @@ theorem loopResultsMatch_step_one_status
       (InterpreterLoop.loopFuel spec 1 state).status := by
   rw [loopResultsMatch_step_one h_match state]
 
+theorem stepWithHandler_eq_of_loopResultsMatch_running
+    {impl spec : Handler} (h_match : LoopResultsMatch impl spec)
+    {state : EvmState} (h_status : state.status = .running) :
+    InterpreterLoop.stepWithHandler impl state =
+      InterpreterLoop.stepWithHandler spec state := by
+  have h_loop := loopResultsMatch_step_one h_match state
+  rw [InterpreterLoop.loopFuel_succ_running impl 0 state h_status] at h_loop
+  rw [InterpreterLoop.loopFuel_succ_running spec 0 state h_status] at h_loop
+  exact h_loop
+
+theorem stepWithHandler_status_eq_of_loopResultsMatch_running
+    {impl spec : Handler} (h_match : LoopResultsMatch impl spec)
+    {state : EvmState} (h_status : state.status = .running) :
+    (InterpreterLoop.stepWithHandler impl state).status =
+      (InterpreterLoop.stepWithHandler spec state).status := by
+  rw [stepWithHandler_eq_of_loopResultsMatch_running h_match h_status]
+
 end InterpreterLoopSimulation
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- derive direct stepWithHandler equality from LoopResultsMatch for running states
- add the corresponding status projection lemma

## Verification
- lake build EvmAsm.Evm64.InterpreterLoopSimulation
- lake build
- scripts/check-file-size.sh
- git diff --check
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception' EvmAsm/Evm64/InterpreterLoopSimulation.lean (no matches)

Authored by @pirapira; implemented by Codex.

Bead: evm-asm-fyia.13