### PR TITLE
feat(accelerators): lift syscall ids to words

### DIFF
--- a/EvmAsm/Evm64/Accelerators/SyscallIds.lean
+++ b/EvmAsm/Evm64/Accelerators/SyscallIds.lean
@@ -146,6 +146,24 @@ theorem accelerator_ids_in_range :
       0x100 ≤ id ∧ id < 0x113 := by
   decide
 
+/-! ## RV64 selector words -/
+
+/-- RV64 `t0` selector-register encoding for a syscall ID. -/
+def toWord (id : Nat) : BitVec 64 := BitVec.ofNat 64 id
+
+/-- The active framing and accelerator selectors remain pairwise distinct after
+lifting to RV64 selector-register words. -/
+theorem allSelectorWords_pairwiseDistinct :
+    [toWord halt, toWord commit, toWord hintLen, toWord hintRead,
+     toWord keccak256, toWord secp256k1_verify,
+     toWord secp256k1_ecrecover, toWord sha256, toWord ripemd160, toWord modexp,
+     toWord bn254_g1_add, toWord bn254_g1_mul, toWord bn254_pairing,
+     toWord blake2f, toWord kzg_point_eval,
+     toWord bls12_g1_add, toWord bls12_g1_msm, toWord bls12_g2_add, toWord bls12_g2_msm,
+     toWord bls12_pairing, toWord bls12_map_fp_to_g1, toWord bls12_map_fp2_to_g2,
+     toWord secp256r1_verify].Nodup := by
+  decide
+
 end SyscallId
 end Accelerators
 end EvmAsm


### PR DESCRIPTION
## Summary
- add SyscallId.toWord for RV64 selector-register encodings
- prove active framing and accelerator selectors remain pairwise distinct after Word lifting

## Verification
- lake build EvmAsm.Evm64.Accelerators.SyscallIds
- lake build
- scripts/check-file-size.sh
- git diff --check
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception' EvmAsm/Evm64/Accelerators/SyscallIds.lean (no matches)

Authored by @pirapira; implemented by Codex.

Bead: evm-asm-nr2sk.2