### PR TITLE
feat(accelerators): expose dispatch return word

### DIFF
--- a/EvmAsm/Evm64/Accelerators/Dispatch.lean
+++ b/EvmAsm/Evm64/Accelerators/Dispatch.lean
@@ -72,6 +72,18 @@ def dispatch (_id : Nat) : ZkvmStatus := ZkvmStatus.efail
 @[simp] theorem dispatch_isOk_false (id : Nat) :
     (dispatch id).isOk = false := rfl
 
+/-- RV64 `a0` return-register encoding for the skeletal accelerator dispatch. -/
+def dispatchWord (id : Nat) : BitVec 64 :=
+  Rv64.zkvmStatusToWord (dispatch id)
+
+@[simp] theorem dispatchWord_eq_efailWord (id : Nat) :
+    dispatchWord id = Rv64.zkvmStatusEfailWord := rfl
+
+theorem dispatchWord_ne_eokWord (id : Nat) :
+    dispatchWord id ≠ Rv64.zkvmStatusEokWord := by
+  rw [dispatchWord_eq_efailWord]
+  exact Rv64.zkvmStatusEokWord_ne_efailWord.symm
+
 /-! ## Sanity properties
 
 These confirm the framing/accelerator partition without forcing any


### PR DESCRIPTION
## Summary
- add dispatchWord as the RV64 a0 encoding of accelerator dispatch results
- prove the current skeletal dispatch return word is ZKVM_EFAIL and not ZKVM_EOK

## Verification
- lake build EvmAsm.Evm64.Accelerators.Dispatch
- lake build
- scripts/check-file-size.sh
- git diff --check
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception' EvmAsm/Evm64/Accelerators/Dispatch.lean (no matches)

Authored by @pirapira; implemented by Codex.

Bead: evm-asm-nr2sk.3