### PR TITLE
feat(accelerators): add zkvm payload type aliases

### DIFF
--- a/EvmAsm/Evm64.lean
+++ b/EvmAsm/Evm64.lean
@@ -9,6 +9,7 @@
 import EvmAsm.Evm64.CodeRegion
 
 -- Accelerator C ABI bridges (zkvm_accelerators.h)
+import EvmAsm.Evm64.Accelerators.Types
 import EvmAsm.Evm64.Accelerators.Status
 import EvmAsm.Evm64.Accelerators.SyscallIds
 import EvmAsm.Evm64.Accelerators.Dispatch

--- a/EvmAsm/Evm64/Accelerators/Types.lean
+++ b/EvmAsm/Evm64/Accelerators/Types.lean
@@ -1,0 +1,173 @@
+/-
+  EvmAsm.Evm64.Accelerators.Types
+
+  Lean-side payload type aliases for the fixed-size byte structs declared in
+  `zkvm_accelerators.h`.
+-/
+
+namespace EvmAsm
+namespace Accelerators
+
+/-- C `uint8_t`, used by the accelerator ABI payload structs. -/
+abbrev Byte := BitVec 8
+
+/-- Fixed-size C byte array payload, matching `struct { uint8_t data[n]; }`. -/
+structure ByteArray (n : Nat) where
+  data : Fin n → Byte
+
+namespace ByteArray
+
+/-- Convert a fixed-size byte payload to a Lean list in index order. -/
+def toList {n : Nat} (bytes : ByteArray n) : List Byte :=
+  List.ofFn bytes.data
+
+theorem toList_length {n : Nat} (bytes : ByteArray n) :
+    bytes.toList.length = n := by
+  simp [toList]
+
+theorem toList_get? {n : Nat} (bytes : ByteArray n) (i : Nat) (h_i : i < n) :
+    bytes.toList[i]? = some (bytes.data ⟨i, h_i⟩) := by
+  simp [toList, h_i]
+
+@[simp] theorem toList_zero (bytes : ByteArray 0) :
+    bytes.toList = [] := by
+  simp [toList]
+
+end ByteArray
+
+/-! ## Common byte array structs -/
+
+/-- C `zkvm_bytes_16`. -/
+abbrev ZkvmBytes16 := ByteArray 16
+
+/-- C `zkvm_bytes_32`. -/
+abbrev ZkvmBytes32 := ByteArray 32
+
+/-- C `zkvm_bytes_48`. -/
+abbrev ZkvmBytes48 := ByteArray 48
+
+/-- C `zkvm_bytes_64`. -/
+abbrev ZkvmBytes64 := ByteArray 64
+
+/-- C `zkvm_bytes_96`. -/
+abbrev ZkvmBytes96 := ByteArray 96
+
+/-- C `zkvm_bytes_128`. -/
+abbrev ZkvmBytes128 := ByteArray 128
+
+/-- C `zkvm_bytes_192`. -/
+abbrev ZkvmBytes192 := ByteArray 192
+
+/-! ## Hash and signature aliases -/
+
+/-- C `zkvm_keccak256_hash`. -/
+abbrev ZkvmKeccak256Hash := ZkvmBytes32
+
+/-- C `zkvm_sha256_hash`. -/
+abbrev ZkvmSha256Hash := ZkvmBytes32
+
+/-- C `zkvm_ripemd160_hash`: 20-byte hash padded to 32 bytes. -/
+abbrev ZkvmRipemd160Hash := ZkvmBytes32
+
+/-- C `zkvm_secp256k1_hash`. -/
+abbrev ZkvmSecp256k1Hash := ZkvmBytes32
+
+/-- C `zkvm_secp256k1_signature`. -/
+abbrev ZkvmSecp256k1Signature := ZkvmBytes64
+
+/-- C `zkvm_secp256k1_pubkey`. -/
+abbrev ZkvmSecp256k1Pubkey := ZkvmBytes64
+
+/-- C `zkvm_secp256r1_hash`. -/
+abbrev ZkvmSecp256r1Hash := ZkvmBytes32
+
+/-- C `zkvm_secp256r1_signature`. -/
+abbrev ZkvmSecp256r1Signature := ZkvmBytes64
+
+/-- C `zkvm_secp256r1_pubkey`. -/
+abbrev ZkvmSecp256r1Pubkey := ZkvmBytes64
+
+/-! ## BN254 aliases -/
+
+/-- C `zkvm_bn254_g1_point`. -/
+abbrev ZkvmBn254G1Point := ZkvmBytes64
+
+/-- C `zkvm_bn254_g2_point`. -/
+abbrev ZkvmBn254G2Point := ZkvmBytes128
+
+/-- C `zkvm_bn254_scalar`. -/
+abbrev ZkvmBn254Scalar := ZkvmBytes32
+
+/-- C `zkvm_bn254_pairing_pair`. -/
+structure ZkvmBn254PairingPair where
+  g1 : ZkvmBn254G1Point
+  g2 : ZkvmBn254G2Point
+
+/-! ## BLS12-381 aliases -/
+
+/-- C `zkvm_bls12_381_g1_point`. -/
+abbrev ZkvmBls12_381G1Point := ZkvmBytes96
+
+/-- C `zkvm_bls12_381_g2_point`. -/
+abbrev ZkvmBls12_381G2Point := ZkvmBytes192
+
+/-- C `zkvm_bls12_381_scalar`. -/
+abbrev ZkvmBls12_381Scalar := ZkvmBytes32
+
+/-- C `zkvm_bls12_381_fp`. -/
+abbrev ZkvmBls12_381Fp := ZkvmBytes48
+
+/-- C `zkvm_bls12_381_fp2`. -/
+abbrev ZkvmBls12_381Fp2 := ZkvmBytes96
+
+/-- C `zkvm_bls12_381_g1_msm_pair`. -/
+structure ZkvmBls12_381G1MsmPair where
+  point : ZkvmBls12_381G1Point
+  scalar : ZkvmBls12_381Scalar
+
+/-- C `zkvm_bls12_381_g2_msm_pair`. -/
+structure ZkvmBls12_381G2MsmPair where
+  point : ZkvmBls12_381G2Point
+  scalar : ZkvmBls12_381Scalar
+
+/-- C `zkvm_bls12_381_pairing_pair`. -/
+structure ZkvmBls12_381PairingPair where
+  g1 : ZkvmBls12_381G1Point
+  g2 : ZkvmBls12_381G2Point
+
+/-! ## BLAKE2F and KZG aliases -/
+
+/-- C `zkvm_blake2f_state`. -/
+abbrev ZkvmBlake2fState := ZkvmBytes64
+
+/-- C `zkvm_blake2f_message`. -/
+abbrev ZkvmBlake2fMessage := ZkvmBytes128
+
+/-- C `zkvm_blake2f_offset`. -/
+abbrev ZkvmBlake2fOffset := ZkvmBytes16
+
+/-- C `zkvm_kzg_commitment`. -/
+abbrev ZkvmKzgCommitment := ZkvmBytes48
+
+/-- C `zkvm_kzg_proof`. -/
+abbrev ZkvmKzgProof := ZkvmBytes48
+
+/-- C `zkvm_kzg_field_element`. -/
+abbrev ZkvmKzgFieldElement := ZkvmBytes32
+
+/-! ## Length sanity checks for common output payloads -/
+
+theorem zkvmSha256Hash_length (hash : ZkvmSha256Hash) :
+    hash.toList.length = 32 :=
+  ByteArray.toList_length hash
+
+theorem zkvmRipemd160Hash_length (hash : ZkvmRipemd160Hash) :
+    hash.toList.length = 32 :=
+  ByteArray.toList_length hash
+
+theorem zkvmBlake2fState_length (state : ZkvmBlake2fState) :
+    state.toList.length = 64 :=
+  ByteArray.toList_length state
+
+end Accelerators
+end EvmAsm


### PR DESCRIPTION
## Summary
- add a shared accelerator ByteArray payload wrapper matching fixed-size uint8_t data[n] C structs
- define Lean aliases for the zkvm_accelerators.h hash, signature, curve, BLAKE2F, and KZG payload types
- import the payload type module from the Evm64 umbrella

## Verification
- lake build EvmAsm.Evm64.Accelerators.Types
- lake build
- scripts/check-file-size.sh
- git diff --check
- forbidden-pattern scan over EvmAsm/Evm64/Accelerators/Types.lean and EvmAsm/Evm64.lean produced no matches

Authored by @pirapira; implemented by Codex.

Refs evm-asm-nr2sk, evm-asm-yvfgi, evm-asm-g8tgi, evm-asm-bc3sd.