### PR TITLE
feat(accelerators): prove selector table sanity

### DIFF
--- a/EvmAsm/Evm64/Accelerators/Dispatch.lean
+++ b/EvmAsm/Evm64/Accelerators/Dispatch.lean
@@ -50,6 +50,16 @@ def acceleratorSelectors : List Nat :=
    bls12_pairing, bls12_map_fp_to_g1, bls12_map_fp2_to_g2,
    secp256r1_verify]
 
+/-- The canonical accelerator selector table contains exactly 19 entries. -/
+theorem acceleratorSelectors_length :
+    acceleratorSelectors.length = 19 := by
+  decide
+
+/-- The canonical accelerator selector table has no duplicate IDs. -/
+theorem acceleratorSelectors_nodup :
+    acceleratorSelectors.Nodup := by
+  decide
+
 /-- Decidable predicate: `id` is one of the accelerator selectors. -/
 def isAccelerator (id : Nat) : Prop := id ∈ acceleratorSelectors
 


### PR DESCRIPTION
## Summary
- prove the canonical accelerator selector table has exactly 19 entries
- prove the selector table has no duplicate IDs

## Verification
- lake build EvmAsm.Evm64.Accelerators.Dispatch
- lake build
- scripts/check-file-size.sh
- git diff --check
- forbidden-pattern scan over EvmAsm/Evm64/Accelerators/Dispatch.lean produced no matches

Authored by @pirapira; implemented by Codex.

Refs evm-asm-nr2sk.