### PR TITLE
feat(accelerators): characterize unknown status words

### DIFF
--- a/EvmAsm/Evm64/Accelerators/Status.lean
+++ b/EvmAsm/Evm64/Accelerators/Status.lean
@@ -144,5 +144,21 @@ theorem zkvmStatusFromWord?_some_eq_toWord
       · simpa [zkvmStatusToWord] using h_efail
       · simp [zkvmStatusFromWord?, h_eok, h_efail] at h_status
 
+theorem zkvmStatusFromWord?_eq_none_iff (word : Word) :
+    zkvmStatusFromWord? word = none ↔
+      word ≠ zkvmStatusEokWord ∧ word ≠ zkvmStatusEfailWord := by
+  by_cases h_eok : word = zkvmStatusEokWord
+  · simp [zkvmStatusFromWord?, h_eok]
+  · by_cases h_efail : word = zkvmStatusEfailWord
+    · simp [zkvmStatusFromWord?, h_efail, zkvmStatusEokWord_ne_efailWord.symm]
+    · simp [zkvmStatusFromWord?, h_eok, h_efail]
+
+theorem zkvmStatusFromWord?_eq_none_of_ne_status_words
+    {word : Word}
+    (h_eok : word ≠ zkvmStatusEokWord)
+    (h_efail : word ≠ zkvmStatusEfailWord) :
+    zkvmStatusFromWord? word = none :=
+  (zkvmStatusFromWord?_eq_none_iff word).2 ⟨h_eok, h_efail⟩
+
 end Rv64
 end EvmAsm


### PR DESCRIPTION
## Summary
- characterize exactly when zkvmStatusFromWord? returns none
- add a direct helper for unknown RV64 status words distinct from EOK and EFAIL encodings

## Verification
- lake build EvmAsm.Evm64.Accelerators.Status
- lake build
- scripts/check-file-size.sh
- git diff --check
- forbidden-pattern scan over EvmAsm/Evm64/Accelerators/Status.lean produced no matches

Authored by @pirapira; implemented by Codex.

Refs evm-asm-nr2sk.