### PR TITLE
feat(accelerators): add Secp256k1Verify ECALL bridge surface

### DIFF
--- a/EvmAsm/EL.lean
+++ b/EvmAsm/EL.lean
@@ -23,6 +23,9 @@ import EvmAsm.EL.LogStackExecutionBridge
 import EvmAsm.EL.KeccakInputBridge
 import EvmAsm.EL.KeccakEcallBridge
 import EvmAsm.EL.KeccakResultBridge
+import EvmAsm.EL.Secp256k1VerifyInputBridge
+import EvmAsm.EL.Secp256k1VerifyResultBridge
+import EvmAsm.EL.Secp256k1VerifyEcallBridge
 import EvmAsm.EL.KeccakStackBridge
 import EvmAsm.EL.KeccakExecutionBridge
 import EvmAsm.EL.KeccakStackExecutionBridge

--- a/EvmAsm/EL/Secp256k1VerifyEcallBridge.lean
+++ b/EvmAsm/EL/Secp256k1VerifyEcallBridge.lean
@@ -1,0 +1,108 @@
+/-
+  EvmAsm.EL.Secp256k1VerifyEcallBridge
+
+  Pure zkVM `zkvm_secp256k1_verify` accelerator ECALL surface. Unlike the
+  precompile bridges (KECCAK / SHA256 / RIPEMD160), this is the non-precompile
+  accelerator used by EL transaction-validation paths (#122 work) and does not
+  produce a stack word — its result is a `Bool` `verified` flag plus the
+  accelerator-level `ZkvmStatus`.
+-/
+
+import EvmAsm.EL.Secp256k1VerifyInputBridge
+import EvmAsm.EL.Secp256k1VerifyResultBridge
+import EvmAsm.Evm64.Accelerators.SyscallIds
+
+namespace EvmAsm.EL
+
+namespace Secp256k1VerifyEcallBridge
+
+/-- Selector reserved for the `zkvm_secp256k1_verify` accelerator ECALL. -/
+def secp256k1VerifySelector : BitVec 64 :=
+  EvmAsm.Rv64.SyscallIdWord.secp256k1_verify
+
+/-- ECALL request passed to the zkVM secp256k1-verify accelerator. -/
+structure Secp256k1VerifyRequest where
+  selector : BitVec 64
+  input    : Secp256k1VerifyInputBridge.AcceleratorInput
+
+/-- ECALL result returned by the zkVM secp256k1-verify accelerator. -/
+structure Secp256k1VerifyResult where
+  status : EvmAsm.Accelerators.ZkvmStatus
+  output : Secp256k1VerifyResultBridge.AcceleratorOutput
+
+/-- Build the secp256k1-verify accelerator request from already-loaded input. -/
+def requestFromInput
+    (input : Secp256k1VerifyInputBridge.AcceleratorInput) : Secp256k1VerifyRequest :=
+  { selector := secp256k1VerifySelector, input := input }
+
+/-- Boolean `verified` flag exposed by a secp256k1-verify accelerator result. -/
+def verifiedFromResult (result : Secp256k1VerifyResult) : Bool :=
+  Secp256k1VerifyResultBridge.verifiedFromOutput result.output
+
+/--
+Pure execution boundary for the secp256k1-verify ECALL. The signature-check
+itself is supplied by the accelerator model; this bridge fixes the
+request/result shape, the status return, and the verified flag extracted from
+the returned output buffer.
+
+Distinctive token: Secp256k1VerifyEcallBridge.executeSecp256k1VerifyEcall.
+-/
+def executeSecp256k1VerifyEcall
+    (accelerator : Secp256k1VerifyInputBridge.AcceleratorInput →
+      EvmAsm.Accelerators.ZkvmStatus × Secp256k1VerifyResultBridge.AcceleratorOutput)
+    (request : Secp256k1VerifyRequest) : Secp256k1VerifyResult :=
+  let result := accelerator request.input
+  { status := result.1, output := result.2 }
+
+theorem requestFromInput_selector
+    (input : Secp256k1VerifyInputBridge.AcceleratorInput) :
+    (requestFromInput input).selector = secp256k1VerifySelector := rfl
+
+theorem requestFromInput_input
+    (input : Secp256k1VerifyInputBridge.AcceleratorInput) :
+    (requestFromInput input).input = input := rfl
+
+theorem executeSecp256k1VerifyEcall_status
+    (accelerator : Secp256k1VerifyInputBridge.AcceleratorInput →
+      EvmAsm.Accelerators.ZkvmStatus × Secp256k1VerifyResultBridge.AcceleratorOutput)
+    (request : Secp256k1VerifyRequest) :
+    (executeSecp256k1VerifyEcall accelerator request).status =
+      (accelerator request.input).1 := by
+  rfl
+
+theorem executeSecp256k1VerifyEcall_output
+    (accelerator : Secp256k1VerifyInputBridge.AcceleratorInput →
+      EvmAsm.Accelerators.ZkvmStatus × Secp256k1VerifyResultBridge.AcceleratorOutput)
+    (request : Secp256k1VerifyRequest) :
+    (executeSecp256k1VerifyEcall accelerator request).output =
+      (accelerator request.input).2 := by
+  rfl
+
+theorem executeSecp256k1VerifyEcall_verified
+    (accelerator : Secp256k1VerifyInputBridge.AcceleratorInput →
+      EvmAsm.Accelerators.ZkvmStatus × Secp256k1VerifyResultBridge.AcceleratorOutput)
+    (request : Secp256k1VerifyRequest) :
+    verifiedFromResult (executeSecp256k1VerifyEcall accelerator request) =
+      Secp256k1VerifyResultBridge.verifiedFromOutput
+        (accelerator request.input).2 := by
+  rfl
+
+theorem executeSecp256k1VerifyEcall_fromMemory_verified
+    (accelerator : Secp256k1VerifyInputBridge.AcceleratorInput →
+      EvmAsm.Accelerators.ZkvmStatus × Secp256k1VerifyResultBridge.AcceleratorOutput)
+    (memory : Secp256k1VerifyInputBridge.MemoryReader)
+    (msgStart sigStart pubkeyStart : Nat) :
+    verifiedFromResult
+        (executeSecp256k1VerifyEcall accelerator
+          (requestFromInput
+            (Secp256k1VerifyInputBridge.acceleratorInputFromMemory
+              memory msgStart sigStart pubkeyStart))) =
+      Secp256k1VerifyResultBridge.verifiedFromOutput
+        (accelerator
+          (Secp256k1VerifyInputBridge.acceleratorInputFromMemory
+            memory msgStart sigStart pubkeyStart)).2 := by
+  rfl
+
+end Secp256k1VerifyEcallBridge
+
+end EvmAsm.EL

--- a/EvmAsm/EL/Secp256k1VerifyInputBridge.lean
+++ b/EvmAsm/EL/Secp256k1VerifyInputBridge.lean
@@ -1,0 +1,93 @@
+/-
+  EvmAsm.EL.Secp256k1VerifyInputBridge
+
+  Bridge from secp256k1 ECDSA verification call data to the byte-buffer input
+  consumed by the zkVM `zkvm_secp256k1_verify` accelerator.
+-/
+
+import EvmAsm.EL.KeccakInputBridge
+
+namespace EvmAsm.EL
+
+namespace Secp256k1VerifyInputBridge
+
+/-- A byte-addressed executable memory reader. -/
+abbrev MemoryReader := KeccakInputBridge.MemoryReader
+
+/-- The 32-byte message hash payload (`zkvm_secp256k1_hash`). -/
+abbrev MsgBytes := Fin 32 → Byte
+
+/-- The 64-byte signature payload (`zkvm_secp256k1_signature`). -/
+abbrev SigBytes := Fin 64 → Byte
+
+/-- The 64-byte public-key payload (`zkvm_secp256k1_pubkey`). -/
+abbrev PubkeyBytes := Fin 64 → Byte
+
+/--
+Input payload passed to the
+`zkvm_secp256k1_verify(msg, sig, pubkey, *verified)` accelerator.
+
+Distinctive token: Secp256k1VerifyInputBridge.AcceleratorInput zkvm_secp256k1_verify.
+-/
+structure AcceleratorInput where
+  msg    : MsgBytes
+  sig    : SigBytes
+  pubkey : PubkeyBytes
+
+/-- Read a fixed `n`-byte block starting at `start` from a `MemoryReader`. -/
+def readFixed (n : Nat) (memory : MemoryReader) (start : Nat) : Fin n → Byte :=
+  fun i => memory (start + i.val)
+
+/-- Build the message-hash payload by reading 32 bytes from memory. -/
+def msgBytesFromMemory (memory : MemoryReader) (start : Nat) : MsgBytes :=
+  readFixed 32 memory start
+
+/-- Build the signature payload by reading 64 bytes from memory. -/
+def sigBytesFromMemory (memory : MemoryReader) (start : Nat) : SigBytes :=
+  readFixed 64 memory start
+
+/-- Build the public-key payload by reading 64 bytes from memory. -/
+def pubkeyBytesFromMemory (memory : MemoryReader) (start : Nat) : PubkeyBytes :=
+  readFixed 64 memory start
+
+/--
+Accelerator-call input assembled from three byte-addressed memory slices, one
+per fixed-width payload field.
+-/
+def acceleratorInputFromMemory
+    (memory : MemoryReader)
+    (msgStart sigStart pubkeyStart : Nat) : AcceleratorInput :=
+  { msg    := msgBytesFromMemory memory msgStart
+    sig    := sigBytesFromMemory memory sigStart
+    pubkey := pubkeyBytesFromMemory memory pubkeyStart }
+
+theorem readFixed_apply (n : Nat) (memory : MemoryReader) (start : Nat) (i : Fin n) :
+    readFixed n memory start i = memory (start + i.val) := rfl
+
+theorem msgBytesFromMemory_apply (memory : MemoryReader) (start : Nat) (i : Fin 32) :
+    msgBytesFromMemory memory start i = memory (start + i.val) := rfl
+
+theorem sigBytesFromMemory_apply (memory : MemoryReader) (start : Nat) (i : Fin 64) :
+    sigBytesFromMemory memory start i = memory (start + i.val) := rfl
+
+theorem pubkeyBytesFromMemory_apply (memory : MemoryReader) (start : Nat) (i : Fin 64) :
+    pubkeyBytesFromMemory memory start i = memory (start + i.val) := rfl
+
+theorem acceleratorInputFromMemory_msg
+    (memory : MemoryReader) (msgStart sigStart pubkeyStart : Nat) :
+    (acceleratorInputFromMemory memory msgStart sigStart pubkeyStart).msg =
+      msgBytesFromMemory memory msgStart := rfl
+
+theorem acceleratorInputFromMemory_sig
+    (memory : MemoryReader) (msgStart sigStart pubkeyStart : Nat) :
+    (acceleratorInputFromMemory memory msgStart sigStart pubkeyStart).sig =
+      sigBytesFromMemory memory sigStart := rfl
+
+theorem acceleratorInputFromMemory_pubkey
+    (memory : MemoryReader) (msgStart sigStart pubkeyStart : Nat) :
+    (acceleratorInputFromMemory memory msgStart sigStart pubkeyStart).pubkey =
+      pubkeyBytesFromMemory memory pubkeyStart := rfl
+
+end Secp256k1VerifyInputBridge
+
+end EvmAsm.EL

--- a/EvmAsm/EL/Secp256k1VerifyResultBridge.lean
+++ b/EvmAsm/EL/Secp256k1VerifyResultBridge.lean
@@ -1,0 +1,35 @@
+/-
+  EvmAsm.EL.Secp256k1VerifyResultBridge
+
+  Bridge from the zkVM `zkvm_secp256k1_verify` accelerator output (a single
+  boolean `verified` flag) to the Lean-level result consumed by EL transaction
+  validation paths. Unlike precompile bridges, this surface does NOT produce a
+  stack word — secp256k1_verify is a non-precompile accelerator used by
+  `EvmAsm.EL.Transaction` validation.
+-/
+
+namespace EvmAsm.EL
+
+namespace Secp256k1VerifyResultBridge
+
+/--
+Accelerator output payload for `zkvm_secp256k1_verify`. The C signature writes
+into a `bool* verified` out-parameter; we model that as a single field.
+-/
+structure AcceleratorOutput where
+  verified : Bool
+  deriving Repr, DecidableEq
+
+/-- Distinctive token: Secp256k1VerifyResultBridge.verifiedFromOutput. -/
+def verifiedFromOutput (output : AcceleratorOutput) : Bool :=
+  output.verified
+
+@[simp] theorem verifiedFromOutput_eq (output : AcceleratorOutput) :
+    verifiedFromOutput output = output.verified := rfl
+
+@[simp] theorem verifiedFromOutput_mk (b : Bool) :
+    verifiedFromOutput { verified := b } = b := rfl
+
+end Secp256k1VerifyResultBridge
+
+end EvmAsm.EL


### PR DESCRIPTION
Adds the ECALL bridge surface for the non-precompile `zkvm_secp256k1_verify` accelerator under parent beads `evm-asm-g8tgi` (secp256k1 sub-umbrella) / `evm-asm-nr2sk` (zkvm_accelerators.h audit).

Mirrors:
- PR #3038 — SHA256 ECALL bridge surface
- PR #3041 — RIPEMD160 ECALL bridge surface

Three new files under `EvmAsm/EL/`, wired into `EvmAsm/EL.lean`:

- `Secp256k1VerifyInputBridge.lean` — `AcceleratorInput` record bundling the three fixed-width payload fields per `zkvm_accelerators.h`: `Fin 32 → Byte` msg hash (`zkvm_secp256k1_hash`), `Fin 64 → Byte` signature, `Fin 64 → Byte` pubkey. Includes per-field `*FromMemory` helpers and an `acceleratorInputFromMemory` builder.
- `Secp256k1VerifyResultBridge.lean` — `AcceleratorOutput` wrapping the single `Bool verified` flag returned via the C `bool* verified` out-parameter. No stack word (non-precompile).
- `Secp256k1VerifyEcallBridge.lean` — request/result records, selector reuses `Rv64.SyscallIdWord.secp256k1_verify`, `executeSecp256k1VerifyEcall` boundary plus `rfl` lemmas (selector / status / output / verified, including a `fromMemory` chained variant).

Acceptance:
- `lake build` green.
- 0 new sorry, no `maxHeartbeats` overrides.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes). Refs parent beads `evm-asm-g8tgi`, child slice `evm-asm-l4a1y`.
