### PR TITLE
feat(accelerators): decode skeletal dispatch words

### DIFF
--- a/EvmAsm/Evm64/Accelerators/Dispatch.lean
+++ b/EvmAsm/Evm64/Accelerators/Dispatch.lean
@@ -94,6 +94,10 @@ theorem dispatchWord_ne_eokWord (id : Nat) :
   rw [dispatchWord_eq_efailWord]
   exact Rv64.zkvmStatusEokWord_ne_efailWord.symm
 
+theorem dispatchWord_decodes_efail (id : Nat) :
+    Rv64.zkvmStatusFromWord? (dispatchWord id) = some ZkvmStatus.efail := by
+  simp [dispatchWord]
+
 /-! ## Sanity properties
 
 These confirm the framing/accelerator partition without forcing any


### PR DESCRIPTION
## Summary
- prove the skeletal accelerator dispatch return word decodes as ZkvmStatus.efail
- connect dispatchWord to the RV64 status-word decoder for later ECALL postcondition proofs

## Verification
- lake build EvmAsm.Evm64.Accelerators.Dispatch
- lake build
- scripts/check-file-size.sh
- git diff --check
- forbidden-pattern scan over EvmAsm/Evm64/Accelerators/Dispatch.lean produced no matches

Authored by @pirapira; implemented by Codex.

Refs evm-asm-nr2sk.