### PR TITLE
feat(accelerators): add BLAKE2F ECALL bridge surface

### DIFF
--- a/EvmAsm/EL.lean
+++ b/EvmAsm/EL.lean
@@ -23,6 +23,9 @@ import EvmAsm.EL.LogStackExecutionBridge
 import EvmAsm.EL.KeccakInputBridge
 import EvmAsm.EL.KeccakEcallBridge
 import EvmAsm.EL.KeccakResultBridge
+import EvmAsm.EL.Blake2fInputBridge
+import EvmAsm.EL.Blake2fResultBridge
+import EvmAsm.EL.Blake2fEcallBridge
 import EvmAsm.EL.KeccakStackBridge
 import EvmAsm.EL.KeccakExecutionBridge
 import EvmAsm.EL.KeccakStackExecutionBridge

--- a/EvmAsm/EL/Blake2fEcallBridge.lean
+++ b/EvmAsm/EL/Blake2fEcallBridge.lean
@@ -1,0 +1,107 @@
+/-
+  EvmAsm.EL.Blake2fEcallBridge
+
+  Pure zkVM `zkvm_blake2f` accelerator ECALL surface. Mirrors the
+  SHA256/RIPEMD160/Bn254G1Add ECALL bridge skeletons: fixes the request and
+  result shapes, the selector binding (via `SyscallIdWord.blake2f`), and
+  exposes a pure execution boundary `executeBlake2fEcall` parameterised by
+  an accelerator model.
+-/
+
+import EvmAsm.EL.Blake2fInputBridge
+import EvmAsm.EL.Blake2fResultBridge
+import EvmAsm.Evm64.Accelerators.SyscallIds
+
+namespace EvmAsm.EL
+
+namespace Blake2fEcallBridge
+
+/-- Selector reserved for the `zkvm_blake2f` accelerator ECALL. -/
+def blake2fSelector : BitVec 64 :=
+  EvmAsm.Rv64.SyscallIdWord.blake2f
+
+/-- ECALL request passed to the zkVM BLAKE2F accelerator. -/
+structure Blake2fRequest where
+  selector : BitVec 64
+  input    : Blake2fInputBridge.AcceleratorInput
+
+/-- ECALL result returned by the zkVM BLAKE2F accelerator. -/
+structure Blake2fResult where
+  status : EvmAsm.Accelerators.ZkvmStatus
+  output : Blake2fResultBridge.AcceleratorOutput
+
+/-- Build the BLAKE2F accelerator request from already-loaded input. -/
+def requestFromInput
+    (input : Blake2fInputBridge.AcceleratorInput) : Blake2fRequest :=
+  { selector := blake2fSelector, input := input }
+
+/-- Output byte list (length 64) exposed by a BLAKE2F accelerator result. -/
+def outputBytesList (result : Blake2fResult) : List Byte :=
+  Blake2fResultBridge.outputBytesList result.output
+
+/--
+Pure execution boundary for the BLAKE2F ECALL. The compression itself is
+supplied by the accelerator model; this bridge fixes the request/result
+shape, the status return, and the output bytes extracted from the returned
+state buffer.
+
+Distinctive token: Blake2fEcallBridge.executeBlake2fEcall.
+-/
+def executeBlake2fEcall
+    (accelerator : Blake2fInputBridge.AcceleratorInput →
+      EvmAsm.Accelerators.ZkvmStatus × Blake2fResultBridge.AcceleratorOutput)
+    (request : Blake2fRequest) : Blake2fResult :=
+  let result := accelerator request.input
+  { status := result.1, output := result.2 }
+
+theorem requestFromInput_selector
+    (input : Blake2fInputBridge.AcceleratorInput) :
+    (requestFromInput input).selector = blake2fSelector := rfl
+
+theorem requestFromInput_input
+    (input : Blake2fInputBridge.AcceleratorInput) :
+    (requestFromInput input).input = input := rfl
+
+theorem executeBlake2fEcall_status
+    (accelerator : Blake2fInputBridge.AcceleratorInput →
+      EvmAsm.Accelerators.ZkvmStatus × Blake2fResultBridge.AcceleratorOutput)
+    (request : Blake2fRequest) :
+    (executeBlake2fEcall accelerator request).status =
+      (accelerator request.input).1 := by
+  rfl
+
+theorem executeBlake2fEcall_output
+    (accelerator : Blake2fInputBridge.AcceleratorInput →
+      EvmAsm.Accelerators.ZkvmStatus × Blake2fResultBridge.AcceleratorOutput)
+    (request : Blake2fRequest) :
+    (executeBlake2fEcall accelerator request).output =
+      (accelerator request.input).2 := by
+  rfl
+
+theorem executeBlake2fEcall_outputBytes
+    (accelerator : Blake2fInputBridge.AcceleratorInput →
+      EvmAsm.Accelerators.ZkvmStatus × Blake2fResultBridge.AcceleratorOutput)
+    (request : Blake2fRequest) :
+    outputBytesList (executeBlake2fEcall accelerator request) =
+      Blake2fResultBridge.outputBytesList (accelerator request.input).2 := by
+  rfl
+
+theorem executeBlake2fEcall_fromMemory_outputBytes
+    (accelerator : Blake2fInputBridge.AcceleratorInput →
+      EvmAsm.Accelerators.ZkvmStatus × Blake2fResultBridge.AcceleratorOutput)
+    (memory : Blake2fInputBridge.MemoryReader)
+    (rounds : UInt32) (hStart mStart tStart : Nat) (f : Byte) :
+    outputBytesList
+        (executeBlake2fEcall accelerator
+          (requestFromInput
+            (Blake2fInputBridge.blake2fInputFromMemory
+              memory rounds hStart mStart tStart f))) =
+      Blake2fResultBridge.outputBytesList
+        (accelerator
+          (Blake2fInputBridge.blake2fInputFromMemory
+            memory rounds hStart mStart tStart f)).2 := by
+  rfl
+
+end Blake2fEcallBridge
+
+end EvmAsm.EL

--- a/EvmAsm/EL/Blake2fInputBridge.lean
+++ b/EvmAsm/EL/Blake2fInputBridge.lean
@@ -1,0 +1,140 @@
+/-
+  EvmAsm.EL.Blake2fInputBridge
+
+  Bridge from EVM BLAKE2F precompile call data to the byte-buffer inputs
+  consumed by the zkVM `zkvm_blake2f` accelerator. The accelerator C
+  signature is
+
+      zkvm_status zkvm_blake2f(uint32_t rounds,
+                               zkvm_blake2f_state* h,
+                               const zkvm_blake2f_message* m,
+                               const zkvm_blake2f_offset* t,
+                               uint8_t f);
+
+  where `zkvm_blake2f_state` is `zkvm_bytes_64`, `zkvm_blake2f_message` is
+  `zkvm_bytes_128`, and `zkvm_blake2f_offset` is `zkvm_bytes_16`. This
+  module fixes the input payload shape (rounds + h + m + t + f) and exposes
+  per-field memory-read decompositions; the result-buffer shape and pure
+  execution boundary live in the sibling `Result`/`Ecall` bridges.
+-/
+
+import EvmAsm.EL.KeccakInputBridge
+
+namespace EvmAsm.EL
+
+namespace Blake2fInputBridge
+
+/-- A byte-addressed executable memory reader. -/
+abbrev MemoryReader := KeccakInputBridge.MemoryReader
+
+/-- The 64-byte BLAKE2F state payload (`zkvm_blake2f_state`). -/
+abbrev StateBytes := Fin 64 → Byte
+
+/-- The 128-byte BLAKE2F message payload (`zkvm_blake2f_message`). -/
+abbrev MessageBytes := Fin 128 → Byte
+
+/-- The 16-byte BLAKE2F offset payload (`zkvm_blake2f_offset`). -/
+abbrev OffsetBytes := Fin 16 → Byte
+
+/--
+Input payload passed to the
+`zkvm_blake2f(rounds, h, m, t, f)` accelerator.
+
+Distinctive token: Blake2fInputBridge.AcceleratorInput zkvm_blake2f.
+-/
+structure AcceleratorInput where
+  rounds : UInt32
+  h      : StateBytes
+  m      : MessageBytes
+  t      : OffsetBytes
+  f      : Byte
+
+/-- Read a fixed `n`-byte block starting at `start` from a `MemoryReader`. -/
+def readFixed (n : Nat) (memory : MemoryReader) (start : Nat) : Fin n → Byte :=
+  fun i => memory (start + i.val)
+
+/-- Build the `h` 64-byte state payload by reading from memory. -/
+def stateBytesFromMemory (memory : MemoryReader) (start : Nat) : StateBytes :=
+  readFixed 64 memory start
+
+/-- Build the `m` 128-byte message payload by reading from memory. -/
+def messageBytesFromMemory (memory : MemoryReader) (start : Nat) : MessageBytes :=
+  readFixed 128 memory start
+
+/-- Build the `t` 16-byte offset payload by reading from memory. -/
+def offsetBytesFromMemory (memory : MemoryReader) (start : Nat) : OffsetBytes :=
+  readFixed 16 memory start
+
+/--
+Accelerator-call input assembled from a byte-addressed memory plus the scalar
+`rounds` and `f` fields read from the EVM call data prefix.
+
+Distinctive token: Blake2fInputBridge.blake2fInputFromMemory.
+-/
+def blake2fInputFromMemory
+    (memory : MemoryReader) (rounds : UInt32)
+    (hStart mStart tStart : Nat) (f : Byte) : AcceleratorInput :=
+  { rounds := rounds
+    h      := stateBytesFromMemory memory hStart
+    m      := messageBytesFromMemory memory mStart
+    t      := offsetBytesFromMemory memory tStart
+    f      := f }
+
+/-- Compatibility alias matching the SHA256/BN254 bridge naming. -/
+def acceleratorInputFromMemory
+    (memory : MemoryReader) (rounds : UInt32)
+    (hStart mStart tStart : Nat) (f : Byte) : AcceleratorInput :=
+  blake2fInputFromMemory memory rounds hStart mStart tStart f
+
+theorem readFixed_apply (n : Nat) (memory : MemoryReader) (start : Nat) (i : Fin n) :
+    readFixed n memory start i = memory (start + i.val) := rfl
+
+theorem stateBytesFromMemory_apply
+    (memory : MemoryReader) (start : Nat) (i : Fin 64) :
+    stateBytesFromMemory memory start i = memory (start + i.val) := rfl
+
+theorem messageBytesFromMemory_apply
+    (memory : MemoryReader) (start : Nat) (i : Fin 128) :
+    messageBytesFromMemory memory start i = memory (start + i.val) := rfl
+
+theorem offsetBytesFromMemory_apply
+    (memory : MemoryReader) (start : Nat) (i : Fin 16) :
+    offsetBytesFromMemory memory start i = memory (start + i.val) := rfl
+
+theorem blake2fInputFromMemory_rounds
+    (memory : MemoryReader) (rounds : UInt32)
+    (hStart mStart tStart : Nat) (f : Byte) :
+    (blake2fInputFromMemory memory rounds hStart mStart tStart f).rounds = rounds := rfl
+
+theorem blake2fInputFromMemory_h
+    (memory : MemoryReader) (rounds : UInt32)
+    (hStart mStart tStart : Nat) (f : Byte) :
+    (blake2fInputFromMemory memory rounds hStart mStart tStart f).h =
+      stateBytesFromMemory memory hStart := rfl
+
+theorem blake2fInputFromMemory_m
+    (memory : MemoryReader) (rounds : UInt32)
+    (hStart mStart tStart : Nat) (f : Byte) :
+    (blake2fInputFromMemory memory rounds hStart mStart tStart f).m =
+      messageBytesFromMemory memory mStart := rfl
+
+theorem blake2fInputFromMemory_t
+    (memory : MemoryReader) (rounds : UInt32)
+    (hStart mStart tStart : Nat) (f : Byte) :
+    (blake2fInputFromMemory memory rounds hStart mStart tStart f).t =
+      offsetBytesFromMemory memory tStart := rfl
+
+theorem blake2fInputFromMemory_f
+    (memory : MemoryReader) (rounds : UInt32)
+    (hStart mStart tStart : Nat) (f : Byte) :
+    (blake2fInputFromMemory memory rounds hStart mStart tStart f).f = f := rfl
+
+theorem acceleratorInputFromMemory_eq
+    (memory : MemoryReader) (rounds : UInt32)
+    (hStart mStart tStart : Nat) (f : Byte) :
+    acceleratorInputFromMemory memory rounds hStart mStart tStart f =
+      blake2fInputFromMemory memory rounds hStart mStart tStart f := rfl
+
+end Blake2fInputBridge
+
+end EvmAsm.EL

--- a/EvmAsm/EL/Blake2fResultBridge.lean
+++ b/EvmAsm/EL/Blake2fResultBridge.lean
@@ -1,0 +1,46 @@
+/-
+  EvmAsm.EL.Blake2fResultBridge
+
+  Bridge from the zkVM `zkvm_blake2f` accelerator output buffer (the 64-byte
+  state written back through the `h` pointer) to the byte-list view consumed
+  by EL precompile return-data assembly. Mirrors the BN254 G1 add result
+  bridge skeleton; we do NOT compute a stack word here because the BLAKE2F
+  output is 64 bytes (does not fit into one EVM stack word) — precompile
+  output framing is left to a downstream slice.
+-/
+
+import EvmAsm.EL.KeccakInputBridge
+
+namespace EvmAsm.EL
+
+namespace Blake2fResultBridge
+
+/-- The 64-byte BLAKE2F state payload (`zkvm_blake2f_state`). -/
+abbrev StateBytes := Fin 64 → Byte
+
+/-- Accelerator output payload for `zkvm_blake2f` (the updated state). -/
+structure AcceleratorOutput where
+  state : StateBytes
+
+/-- Materialise the output state as a byte list (length 64). -/
+def stateBytesList (state : StateBytes) : List Byte :=
+  List.ofFn state
+
+/-- Distinctive token: Blake2fResultBridge.outputBytesList. -/
+def outputBytesList (output : AcceleratorOutput) : List Byte :=
+  stateBytesList output.state
+
+theorem stateBytesList_length (state : StateBytes) :
+    (stateBytesList state).length = 64 := by
+  simp [stateBytesList]
+
+theorem outputBytesList_length (output : AcceleratorOutput) :
+    (outputBytesList output).length = 64 := by
+  simp [outputBytesList, stateBytesList_length]
+
+theorem outputBytesList_eq (output : AcceleratorOutput) :
+    outputBytesList output = stateBytesList output.state := rfl
+
+end Blake2fResultBridge
+
+end EvmAsm.EL


### PR DESCRIPTION
## Summary
- Add BLAKE2F (precompile 0x09) zkVM accelerator ECALL bridge surface, mirroring the SHA256 / RIPEMD160 / BN254 G1-add bridges.
- `EvmAsm/EL/Blake2fInputBridge.lean`: `AcceleratorInput { rounds, h : 64B, m : 128B, t : 16B, f }` plus per-field `MemoryReader` constructors (`readFixed n`).
- `EvmAsm/EL/Blake2fResultBridge.lean`: 64-byte updated-state output and `outputBytesList` view (no stack word — the BLAKE2F output is 64 bytes).
- `EvmAsm/EL/Blake2fEcallBridge.lean`: selector pinned to `SyscallIdWord.blake2f`, request/result records, and a pure `executeBlake2fEcall` boundary parameterised by an accelerator model, with companion lemmas (`_status`, `_output`, `_outputBytes`, `_fromMemory_outputBytes`).
- Wires the three modules into `EvmAsm/EL.lean` next to the SHA256 imports.

Distinctive token: `Blake2fEcallBridge.executeBlake2fEcall`.

## Verification
- `lake build EvmAsm.EL.Blake2fEcallBridge`
- `lake build`
- `scripts/check-file-size.sh`
- `rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception' EvmAsm/EL/Blake2fInputBridge.lean EvmAsm/EL/Blake2fResultBridge.lean EvmAsm/EL/Blake2fEcallBridge.lean EvmAsm/EL.lean` (no matches)

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).

Refs evm-asm-yvfgi (parent evm-asm-nr2sk, GH #116-class accelerator audit).