### PR TITLE
feat(accelerators): add BLS12 G2 add ECALL bridge surface

### DIFF
--- a/EvmAsm/EL.lean
+++ b/EvmAsm/EL.lean
@@ -77,3 +77,6 @@ import EvmAsm.EL.TransactionExecution
 import EvmAsm.EL.TransactionExecutionShape
 import EvmAsm.EL.Block
 import EvmAsm.EL.BlockTrace
+import EvmAsm.EL.Bls12G2AddInputBridge
+import EvmAsm.EL.Bls12G2AddResultBridge
+import EvmAsm.EL.Bls12G2AddEcallBridge

--- a/EvmAsm/EL/Bls12G2AddEcallBridge.lean
+++ b/EvmAsm/EL/Bls12G2AddEcallBridge.lean
@@ -1,0 +1,98 @@
+/-
+  EvmAsm.EL.Bls12G2AddEcallBridge
+
+  Pure zkVM BLS12-381 G2 addition accelerator ECALL surface.
+-/
+
+import EvmAsm.EL.Bls12G2AddInputBridge
+import EvmAsm.EL.Bls12G2AddResultBridge
+import EvmAsm.Evm64.Accelerators.SyscallIds
+
+namespace EvmAsm.EL
+
+namespace Bls12G2AddEcallBridge
+
+abbrev Rv64Word := BitVec 64
+abbrev ZkvmStatus := EvmAsm.Accelerators.ZkvmStatus
+
+/-- Selector reserved for the BLS12-381 G2 add accelerator ECALL surface. -/
+def bls12G2AddSelector : Rv64Word := EvmAsm.Rv64.SyscallIdWord.bls12_g2_add
+
+/-- ECALL request passed to the zkVM BLS12-381 G2 add accelerator. -/
+structure Bls12G2AddRequest where
+  selector : Rv64Word
+  input : Bls12G2AddInputBridge.AcceleratorInput
+
+/-- ECALL result returned by the zkVM BLS12-381 G2 add accelerator. -/
+structure Bls12G2AddResult where
+  status : ZkvmStatus
+  output : Bls12G2AddResultBridge.AcceleratorOutput
+
+/-- Build the BLS12-381 G2 add accelerator request from already-loaded input points. -/
+def requestFromInput
+    (input : Bls12G2AddInputBridge.AcceleratorInput) : Bls12G2AddRequest :=
+  { selector := bls12G2AddSelector, input := input }
+
+/-- Project the output point exposed by a successful BLS12-381 G2 add result. -/
+def outputPointFromResult (result : Bls12G2AddResult) :
+    Bls12G2AddInputBridge.G2PointBytes :=
+  result.output.point
+
+/--
+Pure execution boundary for the BLS12-381 G2 add ECALL. The curve operation
+itself is supplied by the accelerator model; this bridge fixes the
+request/result shape, selector, status code, and output buffer.
+-/
+def executeBls12G2AddEcall
+    (accelerator : Bls12G2AddInputBridge.AcceleratorInput →
+      Bls12G2AddResultBridge.AcceleratorResult)
+    (request : Bls12G2AddRequest) : Bls12G2AddResult :=
+  let result := accelerator request.input
+  { status := result.status, output := result.output }
+
+theorem requestFromInput_selector
+    (input : Bls12G2AddInputBridge.AcceleratorInput) :
+    (requestFromInput input).selector = bls12G2AddSelector := rfl
+
+theorem requestFromInput_input
+    (input : Bls12G2AddInputBridge.AcceleratorInput) :
+    (requestFromInput input).input = input := rfl
+
+theorem executeBls12G2AddEcall_status
+    (accelerator : Bls12G2AddInputBridge.AcceleratorInput →
+      Bls12G2AddResultBridge.AcceleratorResult)
+    (request : Bls12G2AddRequest) :
+    (executeBls12G2AddEcall accelerator request).status =
+      (accelerator request.input).status := rfl
+
+theorem executeBls12G2AddEcall_output
+    (accelerator : Bls12G2AddInputBridge.AcceleratorInput →
+      Bls12G2AddResultBridge.AcceleratorResult)
+    (request : Bls12G2AddRequest) :
+    (executeBls12G2AddEcall accelerator request).output =
+      (accelerator request.input).output := rfl
+
+theorem executeBls12G2AddEcall_outputPoint
+    (accelerator : Bls12G2AddInputBridge.AcceleratorInput →
+      Bls12G2AddResultBridge.AcceleratorResult)
+    (request : Bls12G2AddRequest) :
+    outputPointFromResult (executeBls12G2AddEcall accelerator request) =
+      (accelerator request.input).output.point := rfl
+
+theorem executeBls12G2AddEcall_fromMemory_outputPoint
+    (accelerator : Bls12G2AddInputBridge.AcceleratorInput →
+      Bls12G2AddResultBridge.AcceleratorResult)
+    (memory : Bls12G2AddInputBridge.MemoryReader)
+    (p1Start p2Start : Nat) :
+    outputPointFromResult
+        (executeBls12G2AddEcall accelerator
+          (requestFromInput
+            (Bls12G2AddInputBridge.bls12G2AddInputFromMemory
+              memory p1Start p2Start))) =
+      (accelerator
+        (Bls12G2AddInputBridge.bls12G2AddInputFromMemory
+          memory p1Start p2Start)).output.point := rfl
+
+end Bls12G2AddEcallBridge
+
+end EvmAsm.EL

--- a/EvmAsm/EL/Bls12G2AddInputBridge.lean
+++ b/EvmAsm/EL/Bls12G2AddInputBridge.lean
@@ -1,0 +1,64 @@
+/-
+  EvmAsm.EL.Bls12G2AddInputBridge
+
+  Bridge from executable memory to the input payload consumed by the
+  `zkvm_bls12_g2_add` accelerator.
+-/
+
+import EvmAsm.EL.KeccakInputBridge
+
+namespace EvmAsm.EL
+
+namespace Bls12G2AddInputBridge
+
+/-- A byte-addressed executable memory reader. -/
+abbrev MemoryReader := KeccakInputBridge.MemoryReader
+
+/-- A BLS12-381 G2 point as represented by `zkvm_bls12_381_g2_point`
+(`zkvm_bytes_192`). -/
+abbrev G2PointBytes := Fin 192 → Byte
+
+/-- Input payload passed to `zkvm_bls12_g2_add(p1, p2, result)`. -/
+structure AcceleratorInput where
+  p1 : G2PointBytes
+  p2 : G2PointBytes
+
+/-- Read one fixed-width BLS12-381 G2 point from executable memory. -/
+def g2PointFromMemory (memory : MemoryReader) (start : Nat) : G2PointBytes :=
+  fun i => memory (start + i.toNat)
+
+/--
+Distinctive token: Bls12G2AddInputBridge.bls12G2AddInputFromMemory.
+-/
+def bls12G2AddInputFromMemory
+    (memory : MemoryReader) (p1Start p2Start : Nat) : AcceleratorInput :=
+  { p1 := g2PointFromMemory memory p1Start
+    p2 := g2PointFromMemory memory p2Start }
+
+theorem g2PointFromMemory_apply
+    (memory : MemoryReader) (start : Nat) (i : Fin 192) :
+    g2PointFromMemory memory start i = memory (start + i.toNat) := rfl
+
+theorem bls12G2AddInputFromMemory_p1
+    (memory : MemoryReader) (p1Start p2Start : Nat) :
+    (bls12G2AddInputFromMemory memory p1Start p2Start).p1 =
+      g2PointFromMemory memory p1Start := rfl
+
+theorem bls12G2AddInputFromMemory_p2
+    (memory : MemoryReader) (p1Start p2Start : Nat) :
+    (bls12G2AddInputFromMemory memory p1Start p2Start).p2 =
+      g2PointFromMemory memory p2Start := rfl
+
+theorem bls12G2AddInputFromMemory_p1_apply
+    (memory : MemoryReader) (p1Start p2Start : Nat) (i : Fin 192) :
+    (bls12G2AddInputFromMemory memory p1Start p2Start).p1 i =
+      memory (p1Start + i.toNat) := rfl
+
+theorem bls12G2AddInputFromMemory_p2_apply
+    (memory : MemoryReader) (p1Start p2Start : Nat) (i : Fin 192) :
+    (bls12G2AddInputFromMemory memory p1Start p2Start).p2 i =
+      memory (p2Start + i.toNat) := rfl
+
+end Bls12G2AddInputBridge
+
+end EvmAsm.EL

--- a/EvmAsm/EL/Bls12G2AddResultBridge.lean
+++ b/EvmAsm/EL/Bls12G2AddResultBridge.lean
@@ -1,0 +1,47 @@
+/-
+  EvmAsm.EL.Bls12G2AddResultBridge
+
+  Bridge from the `zkvm_bls12_g2_add` accelerator output to the executable
+  precompile-result surface.
+-/
+
+import EvmAsm.Evm64.Accelerators.Status
+import EvmAsm.EL.Bls12G2AddInputBridge
+
+namespace EvmAsm.EL
+
+namespace Bls12G2AddResultBridge
+
+abbrev ZkvmStatus := EvmAsm.Accelerators.ZkvmStatus
+abbrev G2PointBytes := Bls12G2AddInputBridge.G2PointBytes
+
+/-- Accelerator output payload for `zkvm_bls12_g2_add`. -/
+structure AcceleratorOutput where
+  point : G2PointBytes
+
+/-- Full ECALL result: status code plus output buffer contents. -/
+structure AcceleratorResult where
+  status : ZkvmStatus
+  output : AcceleratorOutput
+
+def g2PointBytesList (point : G2PointBytes) : List Byte :=
+  List.ofFn point
+
+theorem g2PointBytesList_length (point : G2PointBytes) :
+    (g2PointBytesList point).length = 192 := by
+  unfold g2PointBytesList
+  exact List.length_ofFn
+
+theorem acceleratorResult_status (result : AcceleratorResult) :
+    result.status = result.status := rfl
+
+theorem acceleratorResult_output (result : AcceleratorResult) :
+    result.output = result.output := rfl
+
+theorem acceleratorOutput_point_length (output : AcceleratorOutput) :
+    (g2PointBytesList output.point).length = 192 :=
+  g2PointBytesList_length output.point
+
+end Bls12G2AddResultBridge
+
+end EvmAsm.EL


### PR DESCRIPTION
Add the executable bridge surface for the `zkvm_bls12_g2_add` accelerator (BLS12-381 G2 point addition, precompile `0x0d`). Mirrors the structure of the BLS12 G1 add bridge from #3053.

## What

- `EvmAsm/EL/Bls12G2AddInputBridge.lean` — `AcceleratorInput` bundling two 192-byte G2 points (`zkvm_bytes_192`) read from executable memory via the shared `MemoryReader` abstraction, with projection lemmas.
- `EvmAsm/EL/Bls12G2AddResultBridge.lean` — `AcceleratorOutput` wrapping the single G2-point output buffer plus `AcceleratorResult { status, output }`.
- `EvmAsm/EL/Bls12G2AddEcallBridge.lean` — ECALL request/result records, selector tied to `EvmAsm.Rv64.SyscallIdWord.bls12_g2_add`, executable ECALL helper plus `rfl`-projection lemmas.

No Hoare triple yet — this slice fixes the request/result shape, selector, and output buffer surface so subsequent slices can wire RISC-V ECALL state transitions to the pure curve-arithmetic spec.

## Tests

`lake build` clean, no `sorry`, no `maxHeartbeats` / `maxRecDepth` bumps.

Refs parent evm-asm-bc3sd / evm-asm-nr2sk (zkvm_accelerators.h audit). Sibling of #3053 (G1 add), #3052 (KZG), #3051 (BN254 pairing), #3050 (BN254 G1 mul), #3049 (BLAKE2F), #3048 (BN254 G1 add), #3046 (Secp256k1 verify), #3041 (RIPEMD160), #3038 (SHA256).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).