### PR TITLE
feat(accelerators): add BLS12 G2 MSM ECALL bridge surface

### DIFF
--- a/EvmAsm/EL.lean
+++ b/EvmAsm/EL.lean
@@ -26,6 +26,9 @@ import EvmAsm.EL.KeccakResultBridge
 import EvmAsm.EL.KeccakStackBridge
 import EvmAsm.EL.KeccakExecutionBridge
 import EvmAsm.EL.KeccakStackExecutionBridge
+import EvmAsm.EL.Bls12G2MsmInputBridge
+import EvmAsm.EL.Bls12G2MsmResultBridge
+import EvmAsm.EL.Bls12G2MsmEcallBridge
 import EvmAsm.EL.Conformance
 import EvmAsm.EL.Conformance.Call
 import EvmAsm.EL.Conformance.Calldata

--- a/EvmAsm/EL/Bls12G2MsmEcallBridge.lean
+++ b/EvmAsm/EL/Bls12G2MsmEcallBridge.lean
@@ -1,0 +1,98 @@
+/-
+  EvmAsm.EL.Bls12G2MsmEcallBridge
+
+  Pure zkVM BLS12-381 G2 MSM accelerator ECALL surface.
+-/
+
+import EvmAsm.EL.Bls12G2MsmInputBridge
+import EvmAsm.EL.Bls12G2MsmResultBridge
+import EvmAsm.Evm64.Accelerators.SyscallIds
+
+namespace EvmAsm.EL
+
+namespace Bls12G2MsmEcallBridge
+
+abbrev Rv64Word := BitVec 64
+abbrev ZkvmStatus := EvmAsm.Accelerators.ZkvmStatus
+
+/-- Selector reserved for the BLS12-381 G2 MSM accelerator ECALL surface. -/
+def bls12G2MsmSelector : Rv64Word := EvmAsm.Rv64.SyscallIdWord.bls12_g2_msm
+
+/-- ECALL request passed to the zkVM BLS12-381 G2 MSM accelerator. -/
+structure Bls12G2MsmRequest where
+  selector : Rv64Word
+  input : Bls12G2MsmInputBridge.AcceleratorInput
+
+/-- ECALL result returned by the zkVM BLS12-381 G2 MSM accelerator. -/
+structure Bls12G2MsmResult where
+  status : ZkvmStatus
+  output : Bls12G2MsmResultBridge.AcceleratorOutput
+
+/-- Build the BLS12-381 G2 MSM accelerator request from already-loaded input pairs. -/
+def requestFromInput
+    (input : Bls12G2MsmInputBridge.AcceleratorInput) : Bls12G2MsmRequest :=
+  { selector := bls12G2MsmSelector, input := input }
+
+/-- Project the output point exposed by a successful BLS12-381 G2 MSM result. -/
+def outputPointFromResult (result : Bls12G2MsmResult) :
+    Bls12G2MsmInputBridge.G2PointBytes :=
+  result.output.point
+
+/--
+Pure execution boundary for the BLS12-381 G2 MSM ECALL. The curve operation
+itself is supplied by the accelerator model; this bridge fixes the
+request/result shape, selector, status code, and output buffer.
+-/
+def executeBls12G2MsmEcall
+    (accelerator : Bls12G2MsmInputBridge.AcceleratorInput →
+      Bls12G2MsmResultBridge.AcceleratorResult)
+    (request : Bls12G2MsmRequest) : Bls12G2MsmResult :=
+  let result := accelerator request.input
+  { status := result.status, output := result.output }
+
+theorem requestFromInput_selector
+    (input : Bls12G2MsmInputBridge.AcceleratorInput) :
+    (requestFromInput input).selector = bls12G2MsmSelector := rfl
+
+theorem requestFromInput_input
+    (input : Bls12G2MsmInputBridge.AcceleratorInput) :
+    (requestFromInput input).input = input := rfl
+
+theorem executeBls12G2MsmEcall_status
+    (accelerator : Bls12G2MsmInputBridge.AcceleratorInput →
+      Bls12G2MsmResultBridge.AcceleratorResult)
+    (request : Bls12G2MsmRequest) :
+    (executeBls12G2MsmEcall accelerator request).status =
+      (accelerator request.input).status := rfl
+
+theorem executeBls12G2MsmEcall_output
+    (accelerator : Bls12G2MsmInputBridge.AcceleratorInput →
+      Bls12G2MsmResultBridge.AcceleratorResult)
+    (request : Bls12G2MsmRequest) :
+    (executeBls12G2MsmEcall accelerator request).output =
+      (accelerator request.input).output := rfl
+
+theorem executeBls12G2MsmEcall_outputPoint
+    (accelerator : Bls12G2MsmInputBridge.AcceleratorInput →
+      Bls12G2MsmResultBridge.AcceleratorResult)
+    (request : Bls12G2MsmRequest) :
+    outputPointFromResult (executeBls12G2MsmEcall accelerator request) =
+      (accelerator request.input).output.point := rfl
+
+theorem executeBls12G2MsmEcall_fromMemory_outputPoint
+    (accelerator : Bls12G2MsmInputBridge.AcceleratorInput →
+      Bls12G2MsmResultBridge.AcceleratorResult)
+    (memory : Bls12G2MsmInputBridge.MemoryReader)
+    (pairsStart numPairs : Nat) :
+    outputPointFromResult
+        (executeBls12G2MsmEcall accelerator
+          (requestFromInput
+            (Bls12G2MsmInputBridge.bls12G2MsmInputFromMemory
+              memory pairsStart numPairs))) =
+      (accelerator
+        (Bls12G2MsmInputBridge.bls12G2MsmInputFromMemory
+          memory pairsStart numPairs)).output.point := rfl
+
+end Bls12G2MsmEcallBridge
+
+end EvmAsm.EL

--- a/EvmAsm/EL/Bls12G2MsmInputBridge.lean
+++ b/EvmAsm/EL/Bls12G2MsmInputBridge.lean
@@ -1,0 +1,102 @@
+/-
+  EvmAsm.EL.Bls12G2MsmInputBridge
+
+  Bridge from executable memory to the input payload consumed by the
+  `zkvm_bls12_g2_msm` accelerator.
+-/
+
+import EvmAsm.EL.KeccakInputBridge
+
+namespace EvmAsm.EL
+
+namespace Bls12G2MsmInputBridge
+
+/-- A byte-addressed executable memory reader. -/
+abbrev MemoryReader := KeccakInputBridge.MemoryReader
+
+/-- A BLS12-381 G2 point as represented by `zkvm_bls12_381_g2_point`
+(`zkvm_bytes_192`). -/
+abbrev G2PointBytes := Fin 192 → Byte
+
+/-- A BLS12-381 scalar as represented by `zkvm_bls12_381_scalar`. -/
+abbrev ScalarBytes := Fin 32 → Byte
+
+/-- One `zkvm_bls12_381_g2_msm_pair` payload. -/
+structure MsmPair where
+  point : G2PointBytes
+  scalar : ScalarBytes
+
+/-- Input payload passed to `zkvm_bls12_g2_msm(pairs, num_pairs, result)`. -/
+structure AcceleratorInput where
+  pairs : List MsmPair
+  numPairs : Nat
+
+/-- Read one fixed-width BLS12-381 G2 point from executable memory. -/
+def g2PointFromMemory (memory : MemoryReader) (start : Nat) : G2PointBytes :=
+  fun i => memory (start + i.toNat)
+
+/-- Read one fixed-width BLS12-381 scalar from executable memory. -/
+def scalarFromMemory (memory : MemoryReader) (start : Nat) : ScalarBytes :=
+  fun i => memory (start + i.toNat)
+
+/-- Read one `zkvm_bls12_381_g2_msm_pair` from executable memory.
+The pair layout is the 192-byte G2 point followed by the 32-byte scalar
+(224 bytes total per pair). -/
+def msmPairFromMemory (memory : MemoryReader) (start : Nat) : MsmPair :=
+  { point := g2PointFromMemory memory start
+    scalar := scalarFromMemory memory (start + 192) }
+
+/-- Read `numPairs` consecutive 224-byte G2 MSM pairs from executable memory. -/
+def msmPairsFromMemory
+    (memory : MemoryReader) (pairsStart numPairs : Nat) : List MsmPair :=
+  (List.range numPairs).map
+    (fun i => msmPairFromMemory memory (pairsStart + 224 * i))
+
+/--
+Distinctive token: Bls12G2MsmInputBridge.bls12G2MsmInputFromMemory.
+-/
+def bls12G2MsmInputFromMemory
+    (memory : MemoryReader) (pairsStart numPairs : Nat) : AcceleratorInput :=
+  { pairs := msmPairsFromMemory memory pairsStart numPairs
+    numPairs := numPairs }
+
+theorem g2PointFromMemory_apply
+    (memory : MemoryReader) (start : Nat) (i : Fin 192) :
+    g2PointFromMemory memory start i = memory (start + i.toNat) := rfl
+
+theorem scalarFromMemory_apply
+    (memory : MemoryReader) (start : Nat) (i : Fin 32) :
+    scalarFromMemory memory start i = memory (start + i.toNat) := rfl
+
+theorem msmPairFromMemory_point
+    (memory : MemoryReader) (start : Nat) :
+    (msmPairFromMemory memory start).point =
+      g2PointFromMemory memory start := rfl
+
+theorem msmPairFromMemory_scalar
+    (memory : MemoryReader) (start : Nat) :
+    (msmPairFromMemory memory start).scalar =
+      scalarFromMemory memory (start + 192) := rfl
+
+theorem msmPairsFromMemory_length
+    (memory : MemoryReader) (pairsStart numPairs : Nat) :
+    (msmPairsFromMemory memory pairsStart numPairs).length = numPairs := by
+  simp [msmPairsFromMemory]
+
+theorem bls12G2MsmInputFromMemory_pairs
+    (memory : MemoryReader) (pairsStart numPairs : Nat) :
+    (bls12G2MsmInputFromMemory memory pairsStart numPairs).pairs =
+      msmPairsFromMemory memory pairsStart numPairs := rfl
+
+theorem bls12G2MsmInputFromMemory_numPairs
+    (memory : MemoryReader) (pairsStart numPairs : Nat) :
+    (bls12G2MsmInputFromMemory memory pairsStart numPairs).numPairs = numPairs := rfl
+
+theorem bls12G2MsmInputFromMemory_pairs_length
+    (memory : MemoryReader) (pairsStart numPairs : Nat) :
+    (bls12G2MsmInputFromMemory memory pairsStart numPairs).pairs.length = numPairs := by
+  simp [bls12G2MsmInputFromMemory, msmPairsFromMemory_length]
+
+end Bls12G2MsmInputBridge
+
+end EvmAsm.EL

--- a/EvmAsm/EL/Bls12G2MsmResultBridge.lean
+++ b/EvmAsm/EL/Bls12G2MsmResultBridge.lean
@@ -1,0 +1,47 @@
+/-
+  EvmAsm.EL.Bls12G2MsmResultBridge
+
+  Bridge from the `zkvm_bls12_g2_msm` accelerator output to the executable
+  precompile-result surface.
+-/
+
+import EvmAsm.Evm64.Accelerators.Status
+import EvmAsm.EL.Bls12G2MsmInputBridge
+
+namespace EvmAsm.EL
+
+namespace Bls12G2MsmResultBridge
+
+abbrev ZkvmStatus := EvmAsm.Accelerators.ZkvmStatus
+abbrev G2PointBytes := Bls12G2MsmInputBridge.G2PointBytes
+
+/-- Accelerator output payload for `zkvm_bls12_g2_msm`. -/
+structure AcceleratorOutput where
+  point : G2PointBytes
+
+/-- Full ECALL result: status code plus output buffer contents. -/
+structure AcceleratorResult where
+  status : ZkvmStatus
+  output : AcceleratorOutput
+
+def g2PointBytesList (point : G2PointBytes) : List Byte :=
+  List.ofFn point
+
+theorem g2PointBytesList_length (point : G2PointBytes) :
+    (g2PointBytesList point).length = 192 := by
+  unfold g2PointBytesList
+  exact List.length_ofFn
+
+theorem acceleratorResult_status (result : AcceleratorResult) :
+    result.status = result.status := rfl
+
+theorem acceleratorResult_output (result : AcceleratorResult) :
+    result.output = result.output := rfl
+
+theorem acceleratorOutput_point_length (output : AcceleratorOutput) :
+    (g2PointBytesList output.point).length = 192 :=
+  g2PointBytesList_length output.point
+
+end Bls12G2MsmResultBridge
+
+end EvmAsm.EL


### PR DESCRIPTION
Add the executable bridge surface for the `zkvm_bls12_g2_msm` accelerator (BLS12-381 G2 multi-scalar multiplication, precompile `0x0e`). Mirrors the BLS12 G1 MSM bridge from #3055 but with 192-byte G2 points and 224-byte (192+32) MSM pairs:

- `EvmAsm/EL/Bls12G2MsmInputBridge.lean` — `MsmPair` (G2 point + scalar), `AcceleratorInput { pairs, numPairs }`, memory-reader helpers (`g2PointFromMemory`, `scalarFromMemory`, `msmPairFromMemory`, `msmPairsFromMemory`), `bls12G2MsmInputFromMemory`, projection/length lemmas.
- `EvmAsm/EL/Bls12G2MsmResultBridge.lean` — `AcceleratorOutput { point : G2PointBytes }`, `AcceleratorResult { status, output }`, byte-list helper.
- `EvmAsm/EL/Bls12G2MsmEcallBridge.lean` — `Bls12G2MsmRequest/Result`, selector `EvmAsm.Rv64.SyscallIdWord.bls12_g2_msm`, `executeBls12G2MsmEcall`, rfl-projection lemmas.

No Hoare triple yet — this slice fixes the request/result shape, selector, and output buffer surface so subsequent slices can wire RISC-V ECALL state transitions to the pure curve-arithmetic spec.

Refs parent evm-asm-bc3sd / evm-asm-nr2sk (zkvm_accelerators.h audit). Beads: evm-asm-u6szt.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).
