### PR TITLE
feat(addmod): evm_addmod_epilogue_spec_within (1-instr ADDI cpsTripleWithin)

### DIFF
--- a/EvmAsm/Evm64/AddMod/LimbSpec.lean
+++ b/EvmAsm/Evm64/AddMod/LimbSpec.lean
@@ -18,6 +18,30 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 
--- Per-block specs land in slice evm-asm-sord and below.
+-- ============================================================================
+-- evm_addmod_epilogue (1 instruction, slice evm-asm-hsybl toward evm-asm-s7v49)
+-- ============================================================================
+--
+-- `evm_addmod_epilogue` (defined in `Evm64/AddMod/Program.lean`) is the
+-- single-instruction `ADDI x12 x12 32` block that performs the final
+-- EVM stack-pointer advance after the result limbs have been written
+-- by the upstream phase blocks. Mirrors the shape of
+-- `exp_loop_pointer_advance_spec_within` (Exp/LimbSpec.lean §4.5):
+-- a `CodeReq.ofProg → singleton` rewrite plus `addi_spec_gen_same_within`.
+
+abbrev evm_addmod_epilogue_code (base : Word) : CodeReq :=
+  CodeReq.ofProg base evm_addmod_epilogue
+
+theorem evm_addmod_epilogue_spec_within
+    (vOld : Word) (base : Word) :
+    let code := evm_addmod_epilogue_code base
+    cpsTripleWithin 1 base (base + 4) code
+      (.x12 ↦ᵣ vOld)
+      (.x12 ↦ᵣ (vOld + signExtend12 (32 : BitVec 12))) := by
+  show cpsTripleWithin 1 base (base + 4)
+    (CodeReq.ofProg base evm_addmod_epilogue) _ _
+  rw [show CodeReq.ofProg base evm_addmod_epilogue =
+      CodeReq.singleton base (.ADDI .x12 .x12 32) from CodeReq.ofProg_singleton]
+  exact addi_spec_gen_same_within .x12 vOld 32 base (by nofun)
 
 end EvmAsm.Evm64


### PR DESCRIPTION
Tiny per-block spec for ADDMOD. Adds `evm_addmod_epilogue_spec_within` to `EvmAsm/Evm64/AddMod/LimbSpec.lean`: a 1-instruction `cpsTripleWithin` for `evm_addmod_epilogue` (= `ADDI x12 x12 32`).

Mirrors the shape of `exp_loop_pointer_advance_spec_within` (Exp/LimbSpec.lean §4.5):
- `CodeReq.ofProg → singleton` rewrite via `CodeReq.ofProg_singleton`
- `addi_spec_gen_same_within` to discharge the goal

Building block toward `evm_addmod_stack_spec_within` composition (#91 slice 3d, parent beads evm-asm-s7v49).

`lake build` green, 0 sorry, no `maxHeartbeats` / `maxRecDepth` bumps.

Refs GH #91, beads evm-asm-hsybl.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).