### PR TITLE
chore: shake hygiene — Blake2fResultBridge import swap; noshake Phase4HintReadLoop SeqFrame

### DIFF
--- a/EvmAsm/EL/Blake2fResultBridge.lean
+++ b/EvmAsm/EL/Blake2fResultBridge.lean
@@ -9,7 +9,7 @@
   output framing is left to a downstream slice.
 -/
 
-import EvmAsm.EL.KeccakInputBridge
+import EvmAsm.EL.WorldState
 
 namespace EvmAsm.EL
 

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -43,6 +43,8 @@
   "EvmAsm.Rv64.RLP.Phase4HintRead":
   ["EvmAsm.Rv64.HintSpecs", "EvmAsm.Rv64.AddrNorm",
    "EvmAsm.Rv64.Tactics.RunBlock", "EvmAsm.Rv64.Tactics.XSimp"],
+  "EvmAsm.Rv64.RLP.Phase4HintReadLoop":
+  ["EvmAsm.Rv64.Tactics.SeqFrame"],
   "EvmAsm.Rv64.RLP.Phase4HintLen":
   ["EvmAsm.Rv64.HintSpecs", "EvmAsm.Rv64.AddrNorm",
    "EvmAsm.Rv64.Tactics.XSimp"],


### PR DESCRIPTION
Two confirmed shake survivors after PR #3066.

1. `EvmAsm/EL/Blake2fResultBridge.lean` — replace `EvmAsm.EL.KeccakInputBridge` with `EvmAsm.EL.WorldState`. The file only uses the `Byte` abbrev (`BitVec 8`), which is defined in `WorldState`; `KeccakInputBridge` merely re-exports it.

2. `EvmAsm/Rv64/RLP/Phase4HintReadLoop.lean` — `EvmAsm.Rv64.Tactics.SeqFrame` is required for the `bv_addr` macro at L77 (dropping the import makes `bv_addr` an unknown tactic), so we add a `noshake.json` entry instead. Mirrors the existing `EvmAsm.Evm64.SpAddr` pattern at `noshake.json` L117–118.

Verification:
- `lake build` green
- `scripts/check-unimported.sh` 652/652 reachable
- `lake exe shake EvmAsm | scripts/shake-filter.py` reports only the pre-existing `#3037` (`Accelerators/SyscallIds`) survivor

Refs: GH #1045, parent beads `evm-asm-9tq`, slice `evm-asm-js3dl`.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).