### PR TITLE
chore: shake hygiene — Bn254G1AddResultBridge swap KeccakInputBridge to WorldState

### DIFF
--- a/EvmAsm/EL/Bn254G1AddResultBridge.lean
+++ b/EvmAsm/EL/Bn254G1AddResultBridge.lean
@@ -9,7 +9,7 @@
   stack word) — precompile-output framing is left to a downstream slice.
 -/
 
-import EvmAsm.EL.KeccakInputBridge
+import EvmAsm.EL.WorldState
 
 namespace EvmAsm.EL
 


### PR DESCRIPTION
Single shake-filter survivor after the recent BN254 G1 add bridge landing (commit e8f1645a / PR #3048): `EvmAsm/EL/Bn254G1AddResultBridge.lean` imports `EvmAsm.EL.KeccakInputBridge` but only uses the `Byte` abbrev (= `BitVec 8`), which is canonically defined in `EvmAsm.EL.WorldState`. `KeccakInputBridge` merely re-exports it.

Same pattern as the Blake2fResultBridge swap in commit 3e061bdd / slice evm-asm-js3dl.

### Verification
- `lake build` green (1733 jobs).
- `scripts/check-unimported.sh`: 670/670 reachable, 0 orphans.
- `lake exe shake EvmAsm | scripts/shake-filter.py` now shows only the pre-existing #3037 `SyscallIds` survivor; the `Bn254G1AddResultBridge` block is gone.

Refs: GH #1045, parent beads `evm-asm-9tq`, slice `evm-asm-izwxk`.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).