### PR TITLE
feat(mload): mload_combined_stack_spec_within (prologue + four-limbs seq)

### DIFF
--- a/EvmAsm/Evm64/MLoad/StackSpec.lean
+++ b/EvmAsm/Evm64/MLoad/StackSpec.lean
@@ -361,6 +361,52 @@ theorem mload_four_limbs_stack_spec_within
       offReg byteReg accReg addrReg memBaseReg base)
 
 /--
+MLOAD combined stack spec: sequentially compose the prologue half
+(`mload_prologue_stack_spec_within`) with a caller-supplied four-limbs
+core triple (over `mloadStackCode`) via `cpsTripleWithin_seq_same_cr`.
+
+Direct MLOAD analog of
+`Calldata.LoadStackCode.calldataload_window_combined_stack_spec_within`.
+The prologue threads `(sp ↦ₘ offset)` and the resolved address registers
+through to the four-limbs side; the caller only needs to supply a
+four-limbs triple whose precondition matches the prologue's postcondition
+(after the `addrReg ← memBase + offset` resolve) and whose postcondition
+is an arbitrary `Q`.
+
+Foundation lemma toward the upcoming `evm_mload_stack_spec_within`
+(evm-asm-lrhou / GH #53 follow-up): subsequent slices instantiate the
+four-limbs hypothesis with a concrete byte-window read (e.g. via
+`mload_four_limbs_stack_spec_within` together with a concrete byte-window
+core spec).
+
+Distinctive token: mload_combined_stack_spec_within #53.
+-/
+theorem mload_combined_stack_spec_within
+    {n : Nat} {Q : Assertion}
+    (offReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset offOld addrOld memBase : Word) (base : Word)
+    (h_off_ne_x0 : offReg ≠ .x0)
+    (h_addr_ne_x0 : addrReg ≠ .x0)
+    (h4 :
+      cpsTripleWithin n (base + 8) (base + 376)
+        (mloadStackCode offReg byteReg accReg addrReg memBaseReg base)
+        (((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+         (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+         (sp ↦ₘ offset))
+        Q) :
+    cpsTripleWithin (2 + n) base (base + 376)
+      (mloadStackCode offReg byteReg accReg addrReg memBaseReg base)
+      (((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offOld) **
+       (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ addrOld) **
+       (sp ↦ₘ offset))
+      Q :=
+  cpsTripleWithin_seq_same_cr
+    (mload_prologue_stack_spec_within
+      offReg byteReg accReg addrReg memBaseReg
+      sp offset offOld addrOld memBase base h_off_ne_x0 h_addr_ne_x0)
+    h4
+
+/--
   The 256-bit value loaded by MLOAD when each output limb is assembled from
   an adjacent low/high dword pair. The four limbs are stored in EVM-stack
   little-endian order: limb 0 at `sp`, limb 3 at `sp + 24`.

--- a/EvmAsm/Evm64/MLoad/StackSpec.lean
+++ b/EvmAsm/Evm64/MLoad/StackSpec.lean
@@ -407,6 +407,62 @@ theorem mload_combined_stack_spec_within
     h4
 
 /--
+MLOAD combined four-limb sequence stack spec: combine the prologue half
+(`mload_prologue_stack_spec_within`) with the four byte-window quarter
+triples (composed via `mload_four_limb_sequence_spec_within`) into a single
+triple from `base` to `base + 376` over `mloadStackCode`.
+
+Direct MLOAD analog of
+`Calldata.LoadStackCode.calldataload_window_combined_four_limb_sequence_stack_spec_within`.
+This is a one-line composition of `mload_combined_stack_spec_within` (which
+takes a single four-limbs core triple over `mloadStackCode`) with
+`mload_four_limb_sequence_spec_within` (which produces that consolidated
+four-limbs triple from four quarter triples over `mloadFourLimbsCode`),
+transported to `mloadStackCode` via `mload_four_limbs_stack_spec_within`.
+
+Subsequent slices instantiate each `hN` with a concrete byte-load triple
+to land the full `evm_mload_stack_spec_within` (evm-asm-lrhou /
+GH #53 follow-up) without re-doing the prologue/transport plumbing.
+
+Distinctive token: mload_combined_four_limb_sequence_stack_spec_within #53.
+-/
+theorem mload_combined_four_limb_sequence_stack_spec_within
+    {n0 n1 n2 n3 : Nat} {P1 P2 P3 Q : Assertion}
+    (offReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset offOld addrOld memBase : Word) (base : Word)
+    (h_off_ne_x0 : offReg ≠ .x0)
+    (h_addr_ne_x0 : addrReg ≠ .x0)
+    (h0 :
+      cpsTripleWithin n0 (base + 8) (base + 100)
+        (mloadFourLimbsCode addrReg byteReg accReg base)
+        (((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+         (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+         (sp ↦ₘ offset))
+        P1)
+    (h1 :
+      cpsTripleWithin n1 (base + 100) (base + 192)
+        (mloadFourLimbsCode addrReg byteReg accReg base) P1 P2)
+    (h2 :
+      cpsTripleWithin n2 (base + 192) (base + 284)
+        (mloadFourLimbsCode addrReg byteReg accReg base) P2 P3)
+    (h3 :
+      cpsTripleWithin n3 (base + 284) (base + 376)
+        (mloadFourLimbsCode addrReg byteReg accReg base) P3 Q) :
+    cpsTripleWithin (2 + (n0 + n1 + n2 + n3)) base (base + 376)
+      (mloadStackCode offReg byteReg accReg addrReg memBaseReg base)
+      (((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offOld) **
+       (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ addrOld) **
+       (sp ↦ₘ offset))
+      Q :=
+  mload_combined_stack_spec_within
+    offReg byteReg accReg addrReg memBaseReg
+    sp offset offOld addrOld memBase base h_off_ne_x0 h_addr_ne_x0
+    (mload_four_limbs_stack_spec_within
+      offReg byteReg accReg addrReg memBaseReg base
+      (mload_four_limb_sequence_spec_within
+        addrReg byteReg accReg base h0 h1 h2 h3))
+
+/--
   The 256-bit value loaded by MLOAD when each output limb is assembled from
   an adjacent low/high dword pair. The four limbs are stored in EVM-stack
   little-endian order: limb 0 at `sp`, limb 3 at `sp + 24`.


### PR DESCRIPTION
Direct MLOAD analog of `Calldata.LoadStackCode.calldataload_window_combined_stack_spec_within`: one-line composition of `mload_prologue_stack_spec_within` with a caller-supplied four-limbs core triple over `mloadStackCode` via `cpsTripleWithin_seq_same_cr`.

Foundation lemma toward `evm_mload_stack_spec_within` (evm-asm-lrhou / GH #53 follow-up): subsequent slices instantiate the four-limbs hypothesis with a concrete byte-window read.

Refs evm-asm-d7u58 (this slice), evm-asm-lrhou (parent topmost-stack-spec slice), evm-asm-or06a, GH #53.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).