### PR TITLE
chore(shake): drop unused SyscallSpecs in AddMod/LimbSpec, import Evm64.Stack

### DIFF
--- a/EvmAsm/Evm64/AddMod/LimbSpec.lean
+++ b/EvmAsm/Evm64/AddMod/LimbSpec.lean
@@ -11,7 +11,7 @@
 
 import EvmAsm.Evm64.AddMod.Program
 import EvmAsm.Evm64.Add.Spec
-import EvmAsm.Rv64.SyscallSpecs
+import EvmAsm.Evm64.Stack
 
 namespace EvmAsm.Evm64
 


### PR DESCRIPTION
Shake survivor: `EvmAsm/Evm64/AddMod/LimbSpec.lean` imports `EvmAsm.Rv64.SyscallSpecs` but references no declaration from it. The file states stack-level specs over `evmWordIs`, whose canonical owner is `EvmAsm.Evm64.Stack` (already pulled in transitively by `Add.Spec`). This swap is the literal shake recommendation.

### Verification
- `lake build` green (1733 jobs).
- The two affected theorems (`evm_addmod_prologue_spec_within`, `evm_addmod_prologue_stack_spec_within`) still elaborate (they reuse `evm_add_spec_within` / `evm_add_stack_spec_within` from `Add.Spec`, plus the singleton-rewrite shape for the 1-instruction blocks — none of which need anything from `SyscallSpecs`).

Refs: GH #1045, parent beads `evm-asm-9tq`, slice `evm-asm-cdg1d`.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).