### PR TITLE
feat(addmod): evm_addmod_program_code + per-block subsumption helpers

### DIFF
--- a/EvmAsm/Evm64/AddMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/AddMod/Compose/Base.lean
@@ -1,14 +1,17 @@
 /-
   EvmAsm.Evm64.AddMod.Compose.Base
 
-  Shared composition infrastructure for ADDMOD: `addmodCode` (the union
-  of all sub-block `CodeReq`s), subsumption helpers tying sub-block codes
-  back to `addmodCode`, and shared length lemmas.
+  Shared composition infrastructure for ADDMOD: `evm_addmod_program_code`
+  (the `CodeReq.ofProg` handle for the assembled top-level `evm_addmod`
+  Program from slice 3c, beads `evm-asm-xl2jn`), plus per-block
+  subsumption helpers tying each sub-block's `CodeReq.ofProg` handle
+  back to `evm_addmod_program_code` for use by the slice-3d composition
+  (`evm-asm-s7v49`, `evm_addmod_stack_spec_within`).
 
-  Skeleton placeholder for GH #91 (beads slice evm-asm-w1s0). Concrete
-  definitions will be added once `evm_addmod` is laid out (slice
-  evm-asm-sord) and the per-block specs from `LimbSpec.lean` start
-  composing.
+  Mirrors `EvmAsm.Evm64.Byte.Spec` §"CodeReq subsumption" — each helper
+  is a thin wrapper around `CodeReq.ofProg_mono_sub` with the byte
+  offset / instruction index / range bound discharged by `decide` /
+  `bv_omega`. No proof engineering beyond structural slicing.
 -/
 
 import EvmAsm.Evm64.AddMod.LimbSpec
@@ -18,8 +21,120 @@ namespace EvmAsm.Evm64.AddMod.Compose
 
 open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
+open EvmAsm.Evm64
 
--- Composition helpers (skipBlock subsumptions, length lemmas, etc.)
--- land alongside the Compose/<Phase>.lean files in later slices.
+-- ============================================================================
+-- Top-level program-code handle
+-- ============================================================================
+
+/-- `CodeReq.ofProg` handle for the assembled top-level `evm_addmod`
+    Program (33 instructions, 132 bytes). The single-parameter `modOff`
+    is the signed 21-bit byte offset from the phase-2 JAL site to the
+    entry of `evm_mod_callable`; it is threaded through unchanged from
+    the surrounding caller frame. -/
+abbrev evm_addmod_program_code (base : Word) (modOff : BitVec 21) : CodeReq :=
+  CodeReq.ofProg base (evm_addmod modOff)
+
+-- ============================================================================
+-- Per-block CodeReq subsumption: each sub-block code ⊆ evm_addmod_program_code
+-- ============================================================================
+--
+-- Block layout (mirrors `evm_addmod_*_byte_off` lemmas in `AddMod/Program.lean`):
+--
+--   prologue       : instr  0 .. 29  (length 30, bytes   0 ..119)
+--   phase1_carry   : instr 30        (length  1, byte  120)
+--   phase2_reduce  : instr 31        (length  1, byte  124)
+--   epilogue       : instr 32        (length  1, byte  128)
+
+/-- Common slice-equation tactic for the four `mono_sub` calls below.
+    `evm_addmod`, `evm_addmod_prologue`, `evm_addmod_phase1_carry`,
+    `evm_addmod_phase2_reduce`, and `evm_addmod_epilogue` all reduce to
+    plain `List Instr` literals once `seq` and `single` are unfolded;
+    `rfl` closes the resulting `List.take .. (List.drop ..) = ..` goal
+    since the only remaining free variable `modOff` appears identically
+    on both sides as a single concrete `JAL .x1 modOff` constructor. -/
+local macro "evm_addmod_slice_rfl" : tactic =>
+  `(tactic| (
+      unfold evm_addmod evm_addmod_prologue evm_add
+        evm_addmod_phase1_carry evm_addmod_phase2_reduce
+        evm_addmod_phase2_mod_call evm_addmod_epilogue
+      simp only [seq, single]
+      rfl))
+
+/-- The `evm_addmod_prologue` sub-block (30 instrs at offset 0) is
+    subsumed by `evm_addmod_program_code`. -/
+theorem evm_addmod_program_code_prologue_sub
+    {base : Word} {modOff : BitVec 21} :
+    ∀ a i, (CodeReq.ofProg base evm_addmod_prologue) a = some i →
+      (evm_addmod_program_code base modOff) a = some i := by
+  unfold evm_addmod_program_code
+  refine CodeReq.ofProg_mono_sub base base (evm_addmod modOff)
+    evm_addmod_prologue 0
+    (by bv_omega) ?_ ?_ ?_
+  · evm_addmod_slice_rfl
+  · rw [evm_addmod_length, evm_addmod_prologue_length]; decide
+  · rw [evm_addmod_length]; decide
+
+/-- The `evm_addmod_phase1_carry` sub-block (1 instr at offset 120) is
+    subsumed by `evm_addmod_program_code`. -/
+theorem evm_addmod_program_code_phase1_carry_sub
+    {base : Word} {modOff : BitVec 21} :
+    ∀ a i, (CodeReq.ofProg (base + 120) evm_addmod_phase1_carry) a = some i →
+      (evm_addmod_program_code base modOff) a = some i := by
+  unfold evm_addmod_program_code
+  refine CodeReq.ofProg_mono_sub base (base + 120) (evm_addmod modOff)
+    evm_addmod_phase1_carry 30
+    (by bv_omega) ?_ ?_ ?_
+  · evm_addmod_slice_rfl
+  · rw [evm_addmod_length, evm_addmod_phase1_carry_length]; decide
+  · rw [evm_addmod_length]; decide
+
+/-- The `evm_addmod_phase2_reduce` sub-block (1 instr at offset 124) is
+    subsumed by `evm_addmod_program_code`. -/
+theorem evm_addmod_program_code_phase2_reduce_sub
+    {base : Word} {modOff : BitVec 21} :
+    ∀ a i, (CodeReq.ofProg (base + 124)
+        (evm_addmod_phase2_reduce modOff)) a = some i →
+      (evm_addmod_program_code base modOff) a = some i := by
+  unfold evm_addmod_program_code
+  refine CodeReq.ofProg_mono_sub base (base + 124) (evm_addmod modOff)
+    (evm_addmod_phase2_reduce modOff) 31
+    (by bv_omega) ?_ ?_ ?_
+  · evm_addmod_slice_rfl
+  · rw [evm_addmod_length, evm_addmod_phase2_reduce_length]; decide
+  · rw [evm_addmod_length]; decide
+
+/-- The `evm_addmod_epilogue` sub-block (1 instr at offset 128) is
+    subsumed by `evm_addmod_program_code`. -/
+theorem evm_addmod_program_code_epilogue_sub
+    {base : Word} {modOff : BitVec 21} :
+    ∀ a i, (CodeReq.ofProg (base + 128) evm_addmod_epilogue) a = some i →
+      (evm_addmod_program_code base modOff) a = some i := by
+  unfold evm_addmod_program_code
+  refine CodeReq.ofProg_mono_sub base (base + 128) (evm_addmod modOff)
+    evm_addmod_epilogue 32
+    (by bv_omega) ?_ ?_ ?_
+  · evm_addmod_slice_rfl
+  · rw [evm_addmod_length, evm_addmod_epilogue_length]
+  · rw [evm_addmod_length]; decide
+
+/-- Bundled per-block subsumptions for `evm_addmod_program_code`, used by
+    slice 3d (`evm-asm-s7v49`) when wiring per-block cpsTriple specs into
+    the full `evm_addmod_stack_spec_within` composition. -/
+theorem evm_addmod_program_code_block_subs
+    {base : Word} {modOff : BitVec 21} :
+    (∀ a i, (CodeReq.ofProg base evm_addmod_prologue) a = some i →
+      (evm_addmod_program_code base modOff) a = some i) ∧
+    (∀ a i, (CodeReq.ofProg (base + 120) evm_addmod_phase1_carry) a = some i →
+      (evm_addmod_program_code base modOff) a = some i) ∧
+    (∀ a i, (CodeReq.ofProg (base + 124)
+        (evm_addmod_phase2_reduce modOff)) a = some i →
+      (evm_addmod_program_code base modOff) a = some i) ∧
+    (∀ a i, (CodeReq.ofProg (base + 128) evm_addmod_epilogue) a = some i →
+      (evm_addmod_program_code base modOff) a = some i) :=
+  ⟨evm_addmod_program_code_prologue_sub,
+    evm_addmod_program_code_phase1_carry_sub,
+    evm_addmod_program_code_phase2_reduce_sub,
+    evm_addmod_program_code_epilogue_sub⟩
 
 end EvmAsm.Evm64.AddMod.Compose


### PR DESCRIPTION
Adds the top-level `CodeReq` handle `evm_addmod_program_code base modOff` for the assembled `evm_addmod modOff` Program from slice 3c (`evm-asm-xl2jn`, 33 instructions = prologue + phase1_carry + phase2_reduce + epilogue), plus the four per-block subsumption lemmas tying each sub-block's `CodeReq.ofProg` handle back to it.

| sub-block               | byte offset | instr count |
|-------------------------|------------:|------------:|
| prologue (= evm_add)    |           0 |          30 |
| phase1_carry            |         120 |           1 |
| phase2_reduce modOff    |         124 |           1 |
| epilogue                |         128 |           1 |

Each `*_sub` is a thin `CodeReq.ofProg_mono_sub` wrapper; the slice-equation side condition uses a local `evm_addmod_slice_rfl` macro that unfolds `evm_addmod` / `evm_add` / `seq` / `single` so plain `rfl` discharges the `List.take .. (List.drop ..) = sub` shape (the only remaining free variable `modOff` appears identically on both sides as a single `JAL .x1 modOff` constructor — no `decide` over a free `BitVec 21`).

`evm_addmod_program_code_block_subs` packages the four into a single bundle for compact use by slice 3d (`evm-asm-s7v49`, `evm_addmod_stack_spec_within`).

Mirrors `Byte.Spec` §"CodeReq subsumption" and the EXP boundary `expBoundaryProgramCode_*_sub` family in `Exp/Compose/Base.lean`.

Distinctive token: `evm_addmod_program_code` #91.
`lake build` green; 0 sorry; no `maxHeartbeats` / `maxRecDepth` bumps.

Refs GH #91, parent beads `evm-asm-s7v49`, slice `evm-asm-pbfzq`.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).