### PR TITLE
chore(shake): noshake Un21Bridge / ModPhaseBn3 / LoopBody.TrialMax false-positives

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -291,6 +291,12 @@
   ["EvmAsm.Evm64.EvmWordArith.Div128KB6Composition"],
   "EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV2.QuotientBounds":
   ["EvmAsm.Evm64.EvmWordArith.Div128KnuthLower"],
+  "EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV2.Un21Bridge":
+  ["EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV2.QuotientBounds"],
+  "EvmAsm.Evm64.DivMod.Compose.ModPhaseBn3":
+  ["EvmAsm.Evm64.DivMod.Compose.ModPhaseB"],
+  "EvmAsm.Evm64.DivMod.LoopBody.TrialMax":
+  ["EvmAsm.Evm64.DivMod.LoopBody"],
   "EvmAsm.Evm64.Shift.ShlCompose":
   ["EvmAsm.Evm64.Shift.ComposeBase"],
   "EvmAsm.Evm64.Shift.SarCompose":


### PR DESCRIPTION
Three confirmed shake false-positives flagged in `scripts/noshake.json`:

- `CallSkipLowerBoundV2.Un21Bridge` needs `QuotientBounds` (Algorithm alone is insufficient — proofs draw on lemmas in the QuotientBounds chain).
- `DivMod.Compose.ModPhaseBn3` needs `ModPhaseB` (`spec_gen`-attributed lemmas registered there are required; `Compose.Base` alone is not enough).
- `DivMod.LoopBody.TrialMax` needs `LoopBody` (umbrella registers tactic entries; `Compose.Base` alone misses them).

Each was verified by attempting the rm-only swap proposed by `lake exe shake EvmAsm`; all three break `lake build`. Annotated as false positives in `scripts/noshake.json` so future shake runs do not re-suggest them.

Refs evm-asm-241u3, evm-asm-9tq, evm-asm-o6y, GH #1045.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).