### PR TITLE
feat(mload): mload_one_limb_sequence_spec_within (per-quarter subsumption)

### DIFF
--- a/EvmAsm/Evm64/MLoad/StackSpec.lean
+++ b/EvmAsm/Evm64/MLoad/StackSpec.lean
@@ -361,6 +361,52 @@ theorem mload_four_limbs_stack_spec_within
       offReg byteReg accReg addrReg memBaseReg base)
 
 /--
+MLOAD combined stack spec: sequentially compose the prologue half
+(`mload_prologue_stack_spec_within`) with a caller-supplied four-limbs
+core triple (over `mloadStackCode`) via `cpsTripleWithin_seq_same_cr`.
+
+Direct MLOAD analog of
+`Calldata.LoadStackCode.calldataload_window_combined_stack_spec_within`.
+The prologue threads `(sp ↦ₘ offset)` and the resolved address registers
+through to the four-limbs side; the caller only needs to supply a
+four-limbs triple whose precondition matches the prologue's postcondition
+(after the `addrReg ← memBase + offset` resolve) and whose postcondition
+is an arbitrary `Q`.
+
+Foundation lemma toward the upcoming `evm_mload_stack_spec_within`
+(evm-asm-lrhou / GH #53 follow-up): subsequent slices instantiate the
+four-limbs hypothesis with a concrete byte-window read (e.g. via
+`mload_four_limbs_stack_spec_within` together with a concrete byte-window
+core spec).
+
+Distinctive token: mload_combined_stack_spec_within #53.
+-/
+theorem mload_combined_stack_spec_within
+    {n : Nat} {Q : Assertion}
+    (offReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset offOld addrOld memBase : Word) (base : Word)
+    (h_off_ne_x0 : offReg ≠ .x0)
+    (h_addr_ne_x0 : addrReg ≠ .x0)
+    (h4 :
+      cpsTripleWithin n (base + 8) (base + 376)
+        (mloadStackCode offReg byteReg accReg addrReg memBaseReg base)
+        (((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+         (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+         (sp ↦ₘ offset))
+        Q) :
+    cpsTripleWithin (2 + n) base (base + 376)
+      (mloadStackCode offReg byteReg accReg addrReg memBaseReg base)
+      (((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offOld) **
+       (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ addrOld) **
+       (sp ↦ₘ offset))
+      Q :=
+  cpsTripleWithin_seq_same_cr
+    (mload_prologue_stack_spec_within
+      offReg byteReg accReg addrReg memBaseReg
+      sp offset offOld addrOld memBase base h_off_ne_x0 h_addr_ne_x0)
+    h4
+
+/--
   The 256-bit value loaded by MLOAD when each output limb is assembled from
   an adjacent low/high dword pair. The four limbs are stored in EVM-stack
   little-endian order: limb 0 at `sp`, limb 3 at `sp + 24`.

--- a/EvmAsm/Evm64/MLoad/StackSpec.lean
+++ b/EvmAsm/Evm64/MLoad/StackSpec.lean
@@ -521,6 +521,63 @@ theorem mload_combined_stack_spec_within
     h4
 
 /--
+MLOAD combined one-limb sequence stack spec: combine the prologue half
+(`mload_prologue_stack_spec_within`) with the four byte-window quarter
+triples on `mloadOneLimbCode` (composed via
+`mload_one_limb_sequence_spec_within`) and lifted to `mloadStackCode`
+via `mload_four_limbs_stack_spec_within`, into a single triple from
+`base` to `base + 376` over `mloadStackCode`.
+
+Direct MLOAD analog of
+`Calldata.LoadStackCode.calldataload_window_combined_four_limb_sequence_stack_spec_within`
+but at the smaller `mloadOneLimbCode` granularity: subsequent slices
+instantiate each `hN` with a concrete byte-load triple to land the full
+`evm_mload_stack_spec_within` (evm-asm-lrhou / GH #53 follow-up) without
+re-doing the prologue + per-quarter subsumption + transport plumbing.
+
+Distinctive token: mload_combined_one_limb_sequence_stack_spec_within #53.
+-/
+theorem mload_combined_one_limb_sequence_stack_spec_within
+    {n0 n1 n2 n3 : Nat} {P1 P2 P3 Q : Assertion}
+    (offReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset offOld addrOld memBase : Word) (base : Word)
+    (h_off_ne_x0 : offReg ≠ .x0)
+    (h_addr_ne_x0 : addrReg ≠ .x0)
+    (h0 :
+      cpsTripleWithin n0 (base + 8) (base + 100)
+        (mloadOneLimbCode addrReg byteReg accReg
+          24 25 26 27 28 29 30 31 0 (base + 8))
+        (((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+         (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+         (sp ↦ₘ offset))
+        P1)
+    (h1 :
+      cpsTripleWithin n1 (base + 100) (base + 192)
+        (mloadOneLimbCode addrReg byteReg accReg
+          16 17 18 19 20 21 22 23 8 (base + 100)) P1 P2)
+    (h2 :
+      cpsTripleWithin n2 (base + 192) (base + 284)
+        (mloadOneLimbCode addrReg byteReg accReg
+          8 9 10 11 12 13 14 15 16 (base + 192)) P2 P3)
+    (h3 :
+      cpsTripleWithin n3 (base + 284) (base + 376)
+        (mloadOneLimbCode addrReg byteReg accReg
+          0 1 2 3 4 5 6 7 24 (base + 284)) P3 Q) :
+    cpsTripleWithin (2 + (n0 + n1 + n2 + n3)) base (base + 376)
+      (mloadStackCode offReg byteReg accReg addrReg memBaseReg base)
+      (((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offOld) **
+       (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ addrOld) **
+       (sp ↦ₘ offset))
+      Q :=
+  mload_combined_stack_spec_within
+    offReg byteReg accReg addrReg memBaseReg
+    sp offset offOld addrOld memBase base h_off_ne_x0 h_addr_ne_x0
+    (mload_four_limbs_stack_spec_within
+      offReg byteReg accReg addrReg memBaseReg base
+      (mload_one_limb_sequence_spec_within
+        addrReg byteReg accReg base h0 h1 h2 h3))
+
+/--
   The 256-bit value loaded by MLOAD when each output limb is assembled from
   an adjacent low/high dword pair. The four limbs are stored in EVM-stack
   little-endian order: limb 0 at `sp`, limb 3 at `sp + 24`.

--- a/EvmAsm/Evm64/MLoad/StackSpec.lean
+++ b/EvmAsm/Evm64/MLoad/StackSpec.lean
@@ -361,6 +361,120 @@ theorem mload_four_limbs_stack_spec_within
       offReg byteReg accReg addrReg memBaseReg base)
 
 /--
+MLOAD q0 one-limb spec on `mloadFourLimbsCode`: transport a concrete
+`mloadOneLimbCode` byte-load triple at `base + 8 .. base + 100` (the
+leftmost one-limb byte-pack block within `mloadFourLimbsCode`) to the
+larger `mloadFourLimbsCode` surface via `mloadFourLimbsCode_one_limb_q0_sub`.
+
+Lets followup MLOAD slices instantiate `h0` of
+`mload_four_limb_sequence_spec_within` directly with a concrete byte-load
+triple, mirroring the calldata `calldataload_window_one_limb_q0_stack_spec_within`
+shape but at the `mloadFourLimbsCode` level (no prologue / `mloadStackCode`
+lift).
+
+Distinctive token: mload_one_limb_q0_spec_within #53.
+-/
+theorem mload_one_limb_q0_spec_within
+    {n : Nat} {P Q : Assertion}
+    (addrReg byteReg accReg : Reg) (base : Word)
+    (h :
+      cpsTripleWithin n (base + 8) (base + 100)
+        (mloadOneLimbCode addrReg byteReg accReg
+          24 25 26 27 28 29 30 31 0 (base + 8)) P Q) :
+    cpsTripleWithin n (base + 8) (base + 100)
+      (mloadFourLimbsCode addrReg byteReg accReg base) P Q :=
+  cpsTripleWithin_extend_code
+    (h := h)
+    (hmono := mloadFourLimbsCode_one_limb_q0_sub addrReg byteReg accReg base)
+
+/-- MLOAD q1 one-limb spec on `mloadFourLimbsCode`: sister to
+`mload_one_limb_q0_spec_within` for the second one-limb byte-pack block
+at `base + 100 .. base + 192`. -/
+theorem mload_one_limb_q1_spec_within
+    {n : Nat} {P Q : Assertion}
+    (addrReg byteReg accReg : Reg) (base : Word)
+    (h :
+      cpsTripleWithin n (base + 100) (base + 192)
+        (mloadOneLimbCode addrReg byteReg accReg
+          16 17 18 19 20 21 22 23 8 (base + 100)) P Q) :
+    cpsTripleWithin n (base + 100) (base + 192)
+      (mloadFourLimbsCode addrReg byteReg accReg base) P Q :=
+  cpsTripleWithin_extend_code
+    (h := h)
+    (hmono := mloadFourLimbsCode_one_limb_q1_sub addrReg byteReg accReg base)
+
+/-- MLOAD q2 one-limb spec on `mloadFourLimbsCode`: sister to
+`mload_one_limb_q0/q1_spec_within` for the third one-limb byte-pack block
+at `base + 192 .. base + 284`. -/
+theorem mload_one_limb_q2_spec_within
+    {n : Nat} {P Q : Assertion}
+    (addrReg byteReg accReg : Reg) (base : Word)
+    (h :
+      cpsTripleWithin n (base + 192) (base + 284)
+        (mloadOneLimbCode addrReg byteReg accReg
+          8 9 10 11 12 13 14 15 16 (base + 192)) P Q) :
+    cpsTripleWithin n (base + 192) (base + 284)
+      (mloadFourLimbsCode addrReg byteReg accReg base) P Q :=
+  cpsTripleWithin_extend_code
+    (h := h)
+    (hmono := mloadFourLimbsCode_one_limb_q2_sub addrReg byteReg accReg base)
+
+/-- MLOAD q3 one-limb spec on `mloadFourLimbsCode`: sister to
+`mload_one_limb_q{0,1,2}_spec_within` for the fourth (most-significant)
+one-limb byte-pack block at `base + 284 .. base + 376`. -/
+theorem mload_one_limb_q3_spec_within
+    {n : Nat} {P Q : Assertion}
+    (addrReg byteReg accReg : Reg) (base : Word)
+    (h :
+      cpsTripleWithin n (base + 284) (base + 376)
+        (mloadOneLimbCode addrReg byteReg accReg
+          0 1 2 3 4 5 6 7 24 (base + 284)) P Q) :
+    cpsTripleWithin n (base + 284) (base + 376)
+      (mloadFourLimbsCode addrReg byteReg accReg base) P Q :=
+  cpsTripleWithin_extend_code
+    (h := h)
+    (hmono := mloadFourLimbsCode_one_limb_q3_sub addrReg byteReg accReg base)
+
+/--
+MLOAD one-limb sequence spec on `mloadFourLimbsCode`: compose the four
+per-quarter `mload_one_limb_q{0,1,2,3}_spec_within` transports into a
+single `cpsTripleWithin` over `(base + 8) .. (base + 376)` taking four
+concrete `mloadOneLimbCode` byte-load triples (h0, h1, h2, h3) directly.
+Mirrors `mload_four_limb_sequence_spec_within` but on the smaller
+`mloadOneLimbCode` surface — eliminates an intermediate transport step
+when wiring concrete byte-load triples for the upcoming
+`evm_mload_stack_spec_within`.
+
+Distinctive token: mload_one_limb_sequence_spec_within #53.
+-/
+theorem mload_one_limb_sequence_spec_within
+    {n0 n1 n2 n3 : Nat} {P0 P1 P2 P3 P4 : Assertion}
+    (addrReg byteReg accReg : Reg) (base : Word)
+    (h0 :
+      cpsTripleWithin n0 (base + 8) (base + 100)
+        (mloadOneLimbCode addrReg byteReg accReg
+          24 25 26 27 28 29 30 31 0 (base + 8)) P0 P1)
+    (h1 :
+      cpsTripleWithin n1 (base + 100) (base + 192)
+        (mloadOneLimbCode addrReg byteReg accReg
+          16 17 18 19 20 21 22 23 8 (base + 100)) P1 P2)
+    (h2 :
+      cpsTripleWithin n2 (base + 192) (base + 284)
+        (mloadOneLimbCode addrReg byteReg accReg
+          8 9 10 11 12 13 14 15 16 (base + 192)) P2 P3)
+    (h3 :
+      cpsTripleWithin n3 (base + 284) (base + 376)
+        (mloadOneLimbCode addrReg byteReg accReg
+          0 1 2 3 4 5 6 7 24 (base + 284)) P3 P4) :
+    cpsTripleWithin (n0 + n1 + n2 + n3) (base + 8) (base + 376)
+      (mloadFourLimbsCode addrReg byteReg accReg base) P0 P4 :=
+  mload_four_limb_sequence_spec_within addrReg byteReg accReg base
+    (mload_one_limb_q0_spec_within addrReg byteReg accReg base h0)
+    (mload_one_limb_q1_spec_within addrReg byteReg accReg base h1)
+    (mload_one_limb_q2_spec_within addrReg byteReg accReg base h2)
+    (mload_one_limb_q3_spec_within addrReg byteReg accReg base h3)
+
+/--
   The 256-bit value loaded by MLOAD when each output limb is assembled from
   an adjacent low/high dword pair. The four limbs are stored in EVM-stack
   little-endian order: limb 0 at `sp`, limb 3 at `sp + 24`.


### PR DESCRIPTION
Adds five theorems in `EvmAsm/Evm64/MLoad/StackSpec.lean` toward `evm_mload_stack_spec_within` (parent evm-asm-lrhou / GH #53 follow-up):

- `mload_one_limb_q{0,1,2,3}_spec_within` — per-quarter transports of a concrete `mloadOneLimbCode` byte-load `cpsTripleWithin` onto the larger `mloadFourLimbsCode` surface via the existing `mloadFourLimbsCode_one_limb_q{0,1,2,3}_sub` subsumption witnesses.
- `mload_one_limb_sequence_spec_within` — composes the four per-quarter transports through `mload_four_limb_sequence_spec_within` into a single `cpsTripleWithin` over `(base + 8)..(base + 376)` on `mloadFourLimbsCode` taking four concrete `mloadOneLimbCode` triples (`h0,h1,h2,h3`) directly.

MLOAD analog of `Calldata.LoadStackCode.calldataload_window_one_limb_sequence_stack_spec_within` but at the `mloadFourLimbsCode` level (no prologue / `mloadStackCode` lift). Eliminates an intermediate transport step in followup slices that wire concrete byte-load triples for the upcoming `evm_mload_stack_spec_within`.

All five proofs are one-liners using the existing subsumption lemmas; no new `maxHeartbeats`/`maxRecDepth` bumps; `lake build` green.

Distinctive token: `mload_one_limb_sequence_spec_within` #53.

Refs evm-asm-gajux, evm-asm-lrhou, GH #53.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).