### PR TITLE
chore(shake): SyscallIds drops Status import; consumers import Status directly

### DIFF
--- a/EvmAsm/EL/Blake2fEcallBridge.lean
+++ b/EvmAsm/EL/Blake2fEcallBridge.lean
@@ -10,6 +10,7 @@
 
 import EvmAsm.EL.Blake2fInputBridge
 import EvmAsm.EL.Blake2fResultBridge
+import EvmAsm.Evm64.Accelerators.Status
 import EvmAsm.Evm64.Accelerators.SyscallIds
 
 namespace EvmAsm.EL

--- a/EvmAsm/EL/Bn254G1AddEcallBridge.lean
+++ b/EvmAsm/EL/Bn254G1AddEcallBridge.lean
@@ -10,6 +10,7 @@
 
 import EvmAsm.EL.Bn254G1AddInputBridge
 import EvmAsm.EL.Bn254G1AddResultBridge
+import EvmAsm.Evm64.Accelerators.Status
 import EvmAsm.Evm64.Accelerators.SyscallIds
 
 namespace EvmAsm.EL

--- a/EvmAsm/EL/Ripemd160EcallBridge.lean
+++ b/EvmAsm/EL/Ripemd160EcallBridge.lean
@@ -7,6 +7,7 @@
 
 import EvmAsm.EL.Ripemd160InputBridge
 import EvmAsm.EL.Ripemd160ResultBridge
+import EvmAsm.Evm64.Accelerators.Status
 import EvmAsm.Evm64.Accelerators.SyscallIds
 
 namespace EvmAsm.EL

--- a/EvmAsm/EL/Secp256k1VerifyEcallBridge.lean
+++ b/EvmAsm/EL/Secp256k1VerifyEcallBridge.lean
@@ -10,6 +10,7 @@
 
 import EvmAsm.EL.Secp256k1VerifyInputBridge
 import EvmAsm.EL.Secp256k1VerifyResultBridge
+import EvmAsm.Evm64.Accelerators.Status
 import EvmAsm.Evm64.Accelerators.SyscallIds
 
 namespace EvmAsm.EL

--- a/EvmAsm/EL/Sha256EcallBridge.lean
+++ b/EvmAsm/EL/Sha256EcallBridge.lean
@@ -7,6 +7,7 @@
 
 import EvmAsm.EL.Sha256InputBridge
 import EvmAsm.EL.Sha256ResultBridge
+import EvmAsm.Evm64.Accelerators.Status
 import EvmAsm.Evm64.Accelerators.SyscallIds
 
 namespace EvmAsm.EL

--- a/EvmAsm/Evm64/Accelerators/Dispatch.lean
+++ b/EvmAsm/Evm64/Accelerators/Dispatch.lean
@@ -31,6 +31,7 @@
   Refs: parent beads task `evm-asm-nr2sk`, slice `evm-asm-xofw2`.
 -/
 
+import EvmAsm.Evm64.Accelerators.Status
 import EvmAsm.Evm64.Accelerators.SyscallIds
 
 namespace EvmAsm

--- a/EvmAsm/Evm64/Accelerators/SyscallIds.lean
+++ b/EvmAsm/Evm64/Accelerators/SyscallIds.lean
@@ -30,7 +30,7 @@
   Refs: parent beads task `evm-asm-nr2sk`, slice `evm-asm-yv3qz`.
 -/
 
-import EvmAsm.Evm64.Accelerators.Status
+import EvmAsm.Rv64.Basic
 
 namespace EvmAsm
 namespace Accelerators

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -118,6 +118,8 @@
   ["EvmAsm.Rv64.Basic", "Std.Tactic.BVDecide"],
  "EvmAsm.Evm64.SpAddr":
   ["EvmAsm.Rv64.Tactics.SeqFrame"],
+ "EvmAsm.Evm64.Accelerators.SyscallIds":
+  ["EvmAsm.Rv64.Basic"],
   "EvmAsm.Evm64.Dispatch.EntrySpec":
   ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.RunBlock", "EvmAsm.Rv64.Tactics.XSimp"],
   "EvmAsm.Evm64.Stack":


### PR DESCRIPTION
Shake hygiene slice under parent #1045 / evm-asm-9tq / evm-asm-6qj.

`lake exe shake EvmAsm | scripts/shake-filter.py` flags `EvmAsm.Evm64.Accelerators.Status` as unused in `SyscallIds.lean`. The file uses only `Word` (from `Rv64.Basic`) and `Nat` — no `ZkvmStatus` references. The 6 downstream consumers all reference `ZkvmStatus` and were reaching `Status` transitively through `SyscallIds`.

Changes:
- `SyscallIds.lean`: `import EvmAsm.Evm64.Accelerators.Status` → `import EvmAsm.Rv64.Basic`.
- Added direct `import EvmAsm.Evm64.Accelerators.Status` to: `Accelerators/Dispatch.lean`, `EL/Sha256EcallBridge.lean`, `EL/Blake2fEcallBridge.lean`, `EL/Secp256k1VerifyEcallBridge.lean`, `EL/Ripemd160EcallBridge.lean`, `EL/Bn254G1AddEcallBridge.lean`.
- `scripts/noshake.json`: pinned `EvmAsm.Evm64.Accelerators.SyscallIds → [EvmAsm.Rv64.Basic]` (Word notation false-positive — the literal `notation "Word"` marker that `shake-filter` checks for doesn't appear in this file, so a noshake entry is needed).

Verification: `lake build` green; `lake exe shake EvmAsm | scripts/shake-filter.py` no longer reports `SyscallIds` (only the pre-existing #3070 `Bn254G1AddResultBridge` survivor remains, handled in that PR).

Refs: GH #1045, beads `evm-asm-el51s` (parent `evm-asm-6qj` / `evm-asm-9tq`).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).