### PR TITLE
feat(sha256): statusWord + a0-decode lemmas on Sha256EcallBridge

### DIFF
--- a/EvmAsm/EL/Sha256EcallBridge.lean
+++ b/EvmAsm/EL/Sha256EcallBridge.lean
@@ -94,6 +94,51 @@ theorem executeSha256Ecall_fromMemory_stackWord
           (Sha256InputBridge.acceleratorInputFromMemory memory start size)).2 := by
   rfl
 
+/-- RV64 `a0` return-register `Word` for the accelerator status, mirroring
+`KeccakStatusBridge.statusWord`. The accelerator places the `zkvm_status`
+return code in `a0` after the ECALL; this projection extracts that word from
+a `Sha256Result` for postcondition reasoning. -/
+def statusWord (result : Sha256Result) : BitVec 64 :=
+  EvmAsm.Rv64.zkvmStatusToWord result.status
+
+theorem statusWord_eok
+    {result : Sha256Result} (h_status : result.status = .eok) :
+    statusWord result = EvmAsm.Rv64.zkvmStatusEokWord := by
+  show EvmAsm.Rv64.zkvmStatusToWord result.status = _
+  rw [h_status]; rfl
+
+theorem statusWord_efail
+    {result : Sha256Result} (h_status : result.status = .efail) :
+    statusWord result = EvmAsm.Rv64.zkvmStatusEfailWord := by
+  show EvmAsm.Rv64.zkvmStatusToWord result.status = _
+  rw [h_status]; rfl
+
+/-- The `a0` word is `ZKVM_EOK` iff the accelerator reported success. -/
+theorem statusWord_eq_eokWord_iff (result : Sha256Result) :
+    statusWord result = EvmAsm.Rv64.zkvmStatusEokWord ↔ result.status = .eok := by
+  cases h_st : result.status with
+  | eok => simp [statusWord_eok h_st]
+  | efail =>
+    rw [statusWord_efail h_st]
+    constructor
+    · intro h; exact absurd h.symm EvmAsm.Rv64.zkvmStatusEokWord_ne_efailWord
+    · intro h; simp at h
+
+/-- The `a0` word decodes back to the original status. -/
+theorem zkvmStatusFromWord?_statusWord (result : Sha256Result) :
+    EvmAsm.Rv64.zkvmStatusFromWord? (statusWord result) = some result.status :=
+  EvmAsm.Rv64.zkvmStatusFromWord?_toWord result.status
+
+/-- Push `statusWord` through `executeSha256Ecall`: the returned `a0` word is
+the accelerator-supplied status encoded via `zkvmStatusToWord`. -/
+theorem executeSha256Ecall_statusWord
+    (accelerator : Sha256InputBridge.AcceleratorInput →
+      EvmAsm.Accelerators.ZkvmStatus × Sha256ResultBridge.AcceleratorOutput)
+    (request : Sha256Request) :
+    statusWord (executeSha256Ecall accelerator request) =
+      EvmAsm.Rv64.zkvmStatusToWord (accelerator request.input).1 := by
+  rfl
+
 end Sha256EcallBridge
 
 end EvmAsm.EL


### PR DESCRIPTION
Add the standard 5-lemma `statusWord` projection bundle to `EvmAsm/EL/Sha256EcallBridge.lean`, mirroring the pattern in `EvmAsm/EL/KeccakStatusBridge.lean`:

- `statusWord (result : Sha256Result) : BitVec 64` — RV64 a0 word
- `statusWord_eok` / `statusWord_efail`
- `statusWord_eq_eokWord_iff` — iff with success status
- `zkvmStatusFromWord?_statusWord` — decode round-trip
- `executeSha256Ecall_statusWord` — push through `executeSha256Ecall`

Purely additive on top of the existing `Sha256Result.status` field; no semantic change, no new imports. Useful for downstream Hoare-triple bridges that need to assert the `a0` register state after the SHA256 ECALL.

Refs: bead `evm-asm-5q8sv` (under sub-umbrella `evm-asm-yvfgi`, parent `evm-asm-nr2sk`); GH #114, #116.

`lake build` clean.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).