### PR TITLE
chore(shake): noshake AddMod/LimbSpec.lean Add.Spec false-positive

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -103,6 +103,7 @@
   "EvmAsm.Evm64.SMod.AddrNormAttr": ["Lean.Meta.Tactic.Simp.RegisterCommand"],
   "EvmAsm.Evm64.Exp.AddrNormAttr": ["Lean.Meta.Tactic.Simp.RegisterCommand"],
   "EvmAsm.Evm64.AddMod.AddrNormAttr": ["Lean.Meta.Tactic.Simp.RegisterCommand"],
+  "EvmAsm.Evm64.AddMod.LimbSpec": ["EvmAsm.Evm64.Add.Spec"],
   "EvmAsm.Evm64.MulMod.AddrNormAttr": ["Lean.Meta.Tactic.Simp.RegisterCommand"],
   "EvmAsm.Rv64.Tactics.XCancelStruct":
   ["EvmAsm.Rv64.SepLogic"],


### PR DESCRIPTION
shake -E flags `import EvmAsm.Evm64.Add.Spec` in `EvmAsm/Evm64/AddMod/LimbSpec.lean` as unused, but it is genuinely required:

- `evm_addmod_prologue_spec_within` and `evm_addmod_prologue_stack_spec_within` (added in #3071) refer to `evm_add_code`, which is defined in `Add/Spec.lean`.
- They also use `addi_spec_gen_same_within` / `addi_spec_gen_within` from the spec_gen tactic registry, which are populated through `Add.Spec`'s transitive imports.

Dropping the import produces 4 unknown-identifier errors:

```
EvmAsm/Evm64/AddMod/LimbSpec.lean:66:45: Unknown identifier `evm_add_code`
EvmAsm/Evm64/AddMod/LimbSpec.lean:101:45: Unknown identifier `evm_add_code`
EvmAsm/Evm64/AddMod/LimbSpec.lean:128:8: Unknown identifier `addi_spec_gen_same_within`
EvmAsm/Evm64/AddMod/LimbSpec.lean:159:8: Unknown identifier `addi_spec_gen_within`
```

Add a `scripts/noshake.json` entry so the shake-driven sweep skips this suggestion (matches the existing pattern for spec_gen-bearing files like Phase3SingleByte / Phase3LongList / etc.).

Refs evm-asm-mz9im, parent evm-asm-9tq (#1045).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).
