### PR TITLE
chore: drop unused Shift0Dispatcher import in DivMod/N4StackSpec.lean

### DIFF
--- a/EvmAsm/Evm64/DivMod/N4StackSpec.lean
+++ b/EvmAsm/Evm64/DivMod/N4StackSpec.lean
@@ -17,7 +17,6 @@
   Refs: GH #61, beads `evm-asm-17hg` (precursor under `evm-asm-pb40`).
 -/
 
-import EvmAsm.Evm64.DivMod.Shift0Dispatcher
 import EvmAsm.Evm64.DivMod.Spec.CallAddbackMod
 
 namespace EvmAsm.Evm64


### PR DESCRIPTION
Tiny shake-hygiene slice under parent `evm-asm-6qj` (#1045).

`lake exe shake EvmAsm` flags `EvmAsm.Evm64.DivMod.Shift0Dispatcher` as unused in `EvmAsm/Evm64/DivMod/N4StackSpec.lean`. Verified: the only mention is in a doc comment referencing the sibling file, not an actual symbol use. `lake build` green after removal; shake no longer flags the file.

Refs `evm-asm-6q3ui`, parent `evm-asm-6qj` (#1045).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).