### PR TITLE
chore(shake): dedup duplicate SyscallSpecs/RunBlock imports in AddMod/LimbSpec

### DIFF
--- a/EvmAsm/Evm64/AddMod/LimbSpec.lean
+++ b/EvmAsm/Evm64/AddMod/LimbSpec.lean
@@ -14,8 +14,6 @@ import EvmAsm.Evm64.Add.Spec
 import EvmAsm.Rv64.SyscallSpecs
 import EvmAsm.Rv64.Tactics.RunBlock
 import EvmAsm.Evm64.Stack
-import EvmAsm.Rv64.SyscallSpecs
-import EvmAsm.Rv64.Tactics.RunBlock
 
 open EvmAsm.Rv64.Tactics
 


### PR DESCRIPTION
EvmAsm/Evm64/AddMod/LimbSpec.lean had four duplicate imports — `EvmAsm.Rv64.SyscallSpecs` and `EvmAsm.Rv64.Tactics.RunBlock` were each listed twice. Drop the second pair; the first pair is still consumed by `runBlock` invocations and the `@[spec_gen_rv64]` registry, so the file remains semantically unchanged.

Surfaced by `lake exe shake EvmAsm`. Pure mechanical dedup. `lake build` is green.

Refs: beads `evm-asm-y7of3`, parent `evm-asm-6qj` (GH #1045 import hygiene sweep).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).