### PR TITLE
chore(shake): dedup repo-wide duplicate imports (10 files)

### DIFF
--- a/EvmAsm/Evm64.lean
+++ b/EvmAsm/Evm64.lean
@@ -153,7 +153,6 @@ import EvmAsm.Evm64.InterpreterLoopSimulation
 import EvmAsm.Evm64.InterpreterTrace
 import EvmAsm.Evm64.InterpreterTraceSimulation
 import EvmAsm.Evm64.InterpreterLoopCompose
-import EvmAsm.Evm64.ExecutableSpecOpcodeBridge
 import EvmAsm.Evm64.InterpreterExecutableFetchBridge
 import EvmAsm.Evm64.InterpreterExecutableStepBridge
 

--- a/EvmAsm/Evm64/Byte/Spec.lean
+++ b/EvmAsm/Evm64/Byte/Spec.lean
@@ -16,7 +16,6 @@
 -- `Byte.LimbSpec → Byte.Program → Stack → SpAddr`.
 import EvmAsm.Evm64.Stack
 import EvmAsm.Evm64.Byte.LimbSpec
-import EvmAsm.Evm64.Stack
 import EvmAsm.Evm64.EvmWordArith.ByteOps
 import EvmAsm.Rv64.AddrNorm
 import Mathlib.Tactic.Set

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -27,4 +27,3 @@ import EvmAsm.Evm64.DivMod.Compose.ModFullPathN2LoopUnified
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3LoopUnified
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN3LoopUnified
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle
-import EvmAsm.Evm64.DivMod.Compose.FullPathN3LoopUnified

--- a/EvmAsm/Evm64/Exp/LimbSpec.lean
+++ b/EvmAsm/Evm64/Exp/LimbSpec.lean
@@ -12,7 +12,6 @@
 
 import EvmAsm.Evm64.Stack
 import EvmAsm.Evm64.Exp.Program
-import EvmAsm.Evm64.Stack
 import EvmAsm.Rv64.SyscallSpecs
 import EvmAsm.Rv64.Tactics.XSimp
 import EvmAsm.Rv64.Tactics.RunBlock

--- a/EvmAsm/Evm64/MLoad/Spec.lean
+++ b/EvmAsm/Evm64/MLoad/Spec.lean
@@ -12,7 +12,6 @@
 import EvmAsm.Evm64.Stack
 import EvmAsm.Evm64.MLoad.Program
 import EvmAsm.Evm64.MLoad.LimbSpecEight
-import EvmAsm.Evm64.Stack
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/Multiply/Spec.lean
+++ b/EvmAsm/Evm64/Multiply/Spec.lean
@@ -16,7 +16,6 @@
 -- `Multiply.LimbSpec → Multiply.Program → Stack`.
 import EvmAsm.Evm64.Stack
 import EvmAsm.Evm64.Multiply.LimbSpec
-import EvmAsm.Evm64.Stack
 import EvmAsm.Evm64.EvmWordArith.MulCorrect
 import EvmAsm.Rv64.Tactics.XSimp
 

--- a/EvmAsm/Evm64/Shift/Compose.lean
+++ b/EvmAsm/Evm64/Shift/Compose.lean
@@ -10,7 +10,6 @@
 -- `Shift.ComposeBase → Shift.LimbSpec → Shift.Program → Evm64.Stack → SpAddr`.
 import EvmAsm.Evm64.Stack
 import EvmAsm.Evm64.Shift.ComposeBase
-import EvmAsm.Evm64.Stack
 import Mathlib.Tactic.Set
 
 open EvmAsm.Rv64.Tactics

--- a/EvmAsm/Evm64/Shift/SarCompose.lean
+++ b/EvmAsm/Evm64/Shift/SarCompose.lean
@@ -12,7 +12,6 @@
 -- `Shift.ComposeBase → Shift.LimbSpec → Shift.Program → Evm64.Stack → SpAddr`.
 import EvmAsm.Evm64.Stack
 import EvmAsm.Evm64.Shift.SarSpec
-import EvmAsm.Evm64.Stack
 import EvmAsm.Evm64.Shift.ComposeBase
 import Mathlib.Tactic.Set
 

--- a/EvmAsm/Evm64/Shift/ShlCompose.lean
+++ b/EvmAsm/Evm64/Shift/ShlCompose.lean
@@ -12,7 +12,6 @@
 -- `Shift.ComposeBase → Shift.LimbSpec → Shift.Program → Evm64.Stack → SpAddr`.
 import EvmAsm.Evm64.Stack
 import EvmAsm.Evm64.Shift.ShlSpec
-import EvmAsm.Evm64.Stack
 import EvmAsm.Evm64.Shift.ComposeBase
 import Mathlib.Tactic.Set
 

--- a/EvmAsm/Evm64/SignExtend/Spec.lean
+++ b/EvmAsm/Evm64/SignExtend/Spec.lean
@@ -9,7 +9,6 @@
 -- `SignExtend.Compose → SignExtend.LimbSpec → SignExtend.Program → Stack → SpAddr`.
 import EvmAsm.Evm64.Stack
 import EvmAsm.Evm64.SignExtend.Compose
-import EvmAsm.Evm64.Stack
 
 open EvmAsm.Rv64.Tactics
 


### PR DESCRIPTION
Repo-wide audit of `EvmAsm/` found 10 `.lean` files with literal duplicate `import` lines (sibling of PR #3092 / `evm-asm-y7of3`, which handled `AddMod/LimbSpec`). Pure mechanical dedup; each listed import already exists once in the file, so removing the second copy is semantically a no-op.

| File | duplicated import |
| --- | --- |
| `EvmAsm/Evm64/Exp/LimbSpec.lean` | `EvmAsm.Evm64.Stack` |
| `EvmAsm/Evm64/SignExtend/Spec.lean` | `EvmAsm.Evm64.Stack` |
| `EvmAsm/Evm64/Shift/SarCompose.lean` | `EvmAsm.Evm64.Stack` |
| `EvmAsm/Evm64/Shift/Compose.lean` | `EvmAsm.Evm64.Stack` |
| `EvmAsm/Evm64/Shift/ShlCompose.lean` | `EvmAsm.Evm64.Stack` |
| `EvmAsm/Evm64/Multiply/Spec.lean` | `EvmAsm.Evm64.Stack` |
| `EvmAsm/Evm64/Byte/Spec.lean` | `EvmAsm.Evm64.Stack` |
| `EvmAsm/Evm64/MLoad/Spec.lean` | `EvmAsm.Evm64.Stack` |
| `EvmAsm/Evm64/DivMod.lean` | `EvmAsm.Evm64.DivMod.Compose.FullPathN3LoopUnified` |
| `EvmAsm/Evm64.lean` | `EvmAsm.Evm64.ExecutableSpecOpcodeBridge` |

Surfaced by a repo-wide awk scan rather than `lake exe shake` (which does not always flag verbatim duplicate imports). `lake build` is green.

Refs: beads `evm-asm-k2plo`, parent `evm-asm-6qj` (GH #1045 — Import hygiene sweep), sibling PR #3092 / `evm-asm-y7of3`.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).