### PR TITLE
chore(shake): noshake AddMod/Compose/Base.lean LimbSpec+AddrNorm false positives

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -105,6 +105,8 @@
   "EvmAsm.Evm64.Exp.AddrNormAttr": ["Lean.Meta.Tactic.Simp.RegisterCommand"],
   "EvmAsm.Evm64.AddMod.AddrNormAttr": ["Lean.Meta.Tactic.Simp.RegisterCommand"],
   "EvmAsm.Evm64.AddMod.LimbSpec": ["EvmAsm.Evm64.Add.Spec"],
+  "EvmAsm.Evm64.AddMod.Compose.Base":
+  ["EvmAsm.Evm64.AddMod.LimbSpec", "EvmAsm.Evm64.AddMod.AddrNorm"],
   "EvmAsm.Evm64.MulMod.AddrNormAttr": ["Lean.Meta.Tactic.Simp.RegisterCommand"],
   "EvmAsm.Rv64.Tactics.XCancelStruct":
   ["EvmAsm.Rv64.SepLogic"],


### PR DESCRIPTION
shake (`lake exe shake EvmAsm`) flags `EvmAsm/Evm64/AddMod/Compose/Base.lean` as importing `EvmAsm.Evm64.AddMod.LimbSpec` and `EvmAsm.Evm64.AddMod.AddrNorm` without using them. Both imports are actually required:

- **LimbSpec** transitively brings in the `EvmAsm.Rv64.Tactics` namespace (`open EvmAsm.Rv64.Tactics`) and the `CodeReq.ofProg_mono_sub` shape used by every per-block subsumption.
- **AddrNorm** registers the AddMod-flavoured `addrNorm` grindset that the `bv_omega` / `decide` steps in the `evm_addmod_slice_rfl` tactic rely on for byte-offset arithmetic.

Confirmed false positive locally — dropping either import breaks the build with `unknown namespace EvmAsm.Rv64.Tactics` and `Unknown identifier CodeReq.ofProg`. Marking both as `noshake`-ignored for this module so the suggestion list stops re-flagging the file across import-hygiene sweeps.

Refs evm-asm-6h8ci, parent evm-asm-9tq (#1045 import hygiene).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).