### PR TITLE
feat(mload): re-land mload_combined_one_limb_sequence_stack_spec_within

### DIFF
--- a/EvmAsm/Evm64/MLoad/StackSpec.lean
+++ b/EvmAsm/Evm64/MLoad/StackSpec.lean
@@ -577,6 +577,63 @@ theorem mload_one_limb_sequence_spec_within
     (mload_one_limb_q3_spec_within addrReg byteReg accReg base h3)
 
 /--
+MLOAD combined one-limb sequence stack spec: combine the prologue half
+(`mload_prologue_stack_spec_within`) with the four byte-window quarter
+triples on `mloadOneLimbCode` (composed via
+`mload_one_limb_sequence_spec_within`) and lifted to `mloadStackCode`
+via `mload_four_limbs_stack_spec_within`, into a single triple from
+`base` to `base + 376` over `mloadStackCode`.
+
+Direct MLOAD analog of
+`Calldata.LoadStackCode.calldataload_window_combined_four_limb_sequence_stack_spec_within`
+but at the smaller `mloadOneLimbCode` granularity: subsequent slices
+instantiate each `hN` with a concrete byte-load triple to land the full
+`evm_mload_stack_spec_within` (evm-asm-lrhou / GH #53 follow-up) without
+re-doing the prologue + per-quarter subsumption + transport plumbing.
+
+Distinctive token: mload_combined_one_limb_sequence_stack_spec_within #53.
+-/
+theorem mload_combined_one_limb_sequence_stack_spec_within
+    {n0 n1 n2 n3 : Nat} {P1 P2 P3 Q : Assertion}
+    (offReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset offOld addrOld memBase : Word) (base : Word)
+    (h_off_ne_x0 : offReg ≠ .x0)
+    (h_addr_ne_x0 : addrReg ≠ .x0)
+    (h0 :
+      cpsTripleWithin n0 (base + 8) (base + 100)
+        (mloadOneLimbCode addrReg byteReg accReg
+          24 25 26 27 28 29 30 31 0 (base + 8))
+        (((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+         (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+         (sp ↦ₘ offset))
+        P1)
+    (h1 :
+      cpsTripleWithin n1 (base + 100) (base + 192)
+        (mloadOneLimbCode addrReg byteReg accReg
+          16 17 18 19 20 21 22 23 8 (base + 100)) P1 P2)
+    (h2 :
+      cpsTripleWithin n2 (base + 192) (base + 284)
+        (mloadOneLimbCode addrReg byteReg accReg
+          8 9 10 11 12 13 14 15 16 (base + 192)) P2 P3)
+    (h3 :
+      cpsTripleWithin n3 (base + 284) (base + 376)
+        (mloadOneLimbCode addrReg byteReg accReg
+          0 1 2 3 4 5 6 7 24 (base + 284)) P3 Q) :
+    cpsTripleWithin (2 + (n0 + n1 + n2 + n3)) base (base + 376)
+      (mloadStackCode offReg byteReg accReg addrReg memBaseReg base)
+      (((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offOld) **
+       (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ addrOld) **
+       (sp ↦ₘ offset))
+      Q :=
+  mload_combined_stack_spec_within
+    offReg byteReg accReg addrReg memBaseReg
+    sp offset offOld addrOld memBase base h_off_ne_x0 h_addr_ne_x0
+    (mload_four_limbs_stack_spec_within
+      offReg byteReg accReg addrReg memBaseReg base
+      (mload_one_limb_sequence_spec_within
+        addrReg byteReg accReg base h0 h1 h2 h3))
+
+/--
   The 256-bit value loaded by MLOAD when each output limb is assembled from
   an adjacent low/high dword pair. The four limbs are stored in EVM-stack
   little-endian order: limb 0 at `sp`, limb 3 at `sp + 24`.


### PR DESCRIPTION
Re-lands `mload_combined_one_limb_sequence_stack_spec_within` in `EvmAsm/Evm64/MLoad/StackSpec.lean`.

The previous slice (evm-asm-so5fo / PR #3085) was closed as "shipped", but the merge commit landed in a stacked branch (`feat/mload-one-limb-sequence-spec-v2`) and never reached `origin/main`:

```
$ git log origin/main -S "mload_combined_one_limb_sequence_stack_spec_within"
(no output)
$ grep mload_combined_one_limb EvmAsm/Evm64/MLoad/StackSpec.lean
(no output)
```

This PR re-adds the lemma. It composes `mload_combined_stack_spec_within` with `mload_four_limbs_stack_spec_within` (transport `mloadFourLimbsCode` → `mloadStackCode`) and `mload_one_limb_sequence_spec_within` into a single triple from `base` to `base + 376` over `mloadStackCode`, taking four per-quarter `mloadOneLimbCode` triples directly.

Foundation lemma toward `evm_mload_stack_spec_within` (evm-asm-lrhou / GH #53 follow-up): subsequent slices instantiate each `hN` with a concrete byte-load triple to land the topmost MLOAD stack spec without re-doing the prologue + per-quarter subsumption + transport plumbing.

One-line composition; no heartbeat/recDepth bumps; `lake build` green.

Distinctive token: `mload_combined_one_limb_sequence_stack_spec_within` #53.

Refs evm-asm-1iwl9, evm-asm-so5fo (closed-but-never-merged predecessor), parent evm-asm-lrhou, evm-asm-or06a, GH #53.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).