### PR TITLE
chore(shake): drop unused SyscallSpecs/RunBlock imports in AddMod/LimbSpec

### DIFF
--- a/EvmAsm/Evm64/AddMod/LimbSpec.lean
+++ b/EvmAsm/Evm64/AddMod/LimbSpec.lean
@@ -11,8 +11,6 @@
 
 import EvmAsm.Evm64.AddMod.Program
 import EvmAsm.Evm64.Add.Spec
-import EvmAsm.Rv64.SyscallSpecs
-import EvmAsm.Rv64.Tactics.RunBlock
 import EvmAsm.Evm64.Stack
 
 open EvmAsm.Rv64.Tactics


### PR DESCRIPTION
After PR #3092 deduped duplicate imports in `AddMod/LimbSpec.lean`, `lake exe shake EvmAsm` flagged the remaining single copies of `EvmAsm.Rv64.SyscallSpecs` and `EvmAsm.Rv64.Tactics.RunBlock` as truly unused (pure-drop suggestion, no `add`/`instead`).

`lake build` remains green after removing both. Pure import-hygiene change.

Refs: GH #1045, beads evm-asm-wge6s (parent evm-asm-6qj).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).