### PR TITLE
feat(blake2f): statusWord + a0-decode lemmas on Blake2fEcallBridge

### DIFF
--- a/EvmAsm/EL/Blake2fEcallBridge.lean
+++ b/EvmAsm/EL/Blake2fEcallBridge.lean
@@ -103,6 +103,52 @@ theorem executeBlake2fEcall_fromMemory_outputBytes
             memory rounds hStart mStart tStart f)).2 := by
   rfl
 
+/-- RV64 `a0` return-register `Word` for the accelerator status, mirroring
+`KeccakStatusBridge.statusWord` and `Sha256EcallBridge.statusWord`. The
+accelerator places the `zkvm_status` return code in `a0` after the ECALL;
+this projection extracts that word from a `Blake2fResult` for postcondition
+reasoning. -/
+def statusWord (result : Blake2fResult) : BitVec 64 :=
+  EvmAsm.Rv64.zkvmStatusToWord result.status
+
+theorem statusWord_eok
+    {result : Blake2fResult} (h_status : result.status = .eok) :
+    statusWord result = EvmAsm.Rv64.zkvmStatusEokWord := by
+  show EvmAsm.Rv64.zkvmStatusToWord result.status = _
+  rw [h_status]; rfl
+
+theorem statusWord_efail
+    {result : Blake2fResult} (h_status : result.status = .efail) :
+    statusWord result = EvmAsm.Rv64.zkvmStatusEfailWord := by
+  show EvmAsm.Rv64.zkvmStatusToWord result.status = _
+  rw [h_status]; rfl
+
+/-- The `a0` word is `ZKVM_EOK` iff the accelerator reported success. -/
+theorem statusWord_eq_eokWord_iff (result : Blake2fResult) :
+    statusWord result = EvmAsm.Rv64.zkvmStatusEokWord ↔ result.status = .eok := by
+  cases h_st : result.status with
+  | eok => simp [statusWord_eok h_st]
+  | efail =>
+    rw [statusWord_efail h_st]
+    constructor
+    · intro h; exact absurd h.symm EvmAsm.Rv64.zkvmStatusEokWord_ne_efailWord
+    · intro h; simp at h
+
+/-- The `a0` word decodes back to the original status. -/
+theorem zkvmStatusFromWord?_statusWord (result : Blake2fResult) :
+    EvmAsm.Rv64.zkvmStatusFromWord? (statusWord result) = some result.status :=
+  EvmAsm.Rv64.zkvmStatusFromWord?_toWord result.status
+
+/-- Push `statusWord` through `executeBlake2fEcall`: the returned `a0` word is
+the accelerator-supplied status encoded via `zkvmStatusToWord`. -/
+theorem executeBlake2fEcall_statusWord
+    (accelerator : Blake2fInputBridge.AcceleratorInput →
+      EvmAsm.Accelerators.ZkvmStatus × Blake2fResultBridge.AcceleratorOutput)
+    (request : Blake2fRequest) :
+    statusWord (executeBlake2fEcall accelerator request) =
+      EvmAsm.Rv64.zkvmStatusToWord (accelerator request.input).1 := by
+  rfl
+
 end Blake2fEcallBridge
 
 end EvmAsm.EL


### PR DESCRIPTION
Add `statusWord` projection plus the standard 5 lemmas to `EvmAsm/EL/Blake2fEcallBridge.lean`, mirroring `Sha256EcallBridge.statusWord` (PR #3088) and `KeccakStatusBridge.statusWord`:

- `statusWord (result : Blake2fResult) : BitVec 64 := zkvmStatusToWord result.status`
- `statusWord_eok` / `statusWord_efail`
- `statusWord_eq_eokWord_iff`
- `zkvmStatusFromWord?_statusWord` (decode round-trip)
- `executeBlake2fEcall_statusWord` (push through `executeBlake2fEcall`)

Purely additive; `Blake2fResult` already carries `status : ZkvmStatus`. No semantic change, no new imports beyond already-imported `Evm64.Accelerators.Status`.

Useful for downstream Hoare-triple bridges that need to assert the `a0` register state after the BLAKE2F ECALL.

Refs evm-asm-7nw9q (sub-umbrella evm-asm-yvfgi — SHA256/RIPEMD160/BLAKE2F; parent evm-asm-nr2sk #114, #116).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).