### PR TITLE
chore(shake): noshake AddMod.LimbSpec SyscallSpecs/Tactics.RunBlock false-positives

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -104,7 +104,8 @@
   "EvmAsm.Evm64.SMod.AddrNormAttr": ["Lean.Meta.Tactic.Simp.RegisterCommand"],
   "EvmAsm.Evm64.Exp.AddrNormAttr": ["Lean.Meta.Tactic.Simp.RegisterCommand"],
   "EvmAsm.Evm64.AddMod.AddrNormAttr": ["Lean.Meta.Tactic.Simp.RegisterCommand"],
-  "EvmAsm.Evm64.AddMod.LimbSpec": ["EvmAsm.Evm64.Add.Spec"],
+  "EvmAsm.Evm64.AddMod.LimbSpec":
+  ["EvmAsm.Evm64.Add.Spec", "EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.RunBlock"],
   "EvmAsm.Evm64.AddMod.Compose.Base":
   ["EvmAsm.Evm64.AddMod.LimbSpec", "EvmAsm.Evm64.AddMod.AddrNorm"],
   "EvmAsm.Evm64.MulMod.AddrNormAttr": ["Lean.Meta.Tactic.Simp.RegisterCommand"],


### PR DESCRIPTION
shake flags EvmAsm.Rv64.SyscallSpecs and EvmAsm.Rv64.Tactics.RunBlock as unused in EvmAsm/Evm64/AddMod/LimbSpec.lean. Both are real uses shake fails to track:

- **SyscallSpecs** supplies the @[spec_gen_rv64]-attributed leaf specs (addi_spec_gen_same_within, addi_spec_gen_within, ld_spec_gen_within, or_spec_gen_*, sd_x0_spec_gen_within, beq_spec_gen_within, …) referenced throughout. shake doesn't track @[spec_gen_*] tactic registries.
- **Tactics.RunBlock** supplies the 'runBlock' custom tactic used directly in proofs.

Same false-positive pattern is already annotated for sibling Add.LimbSpec / Sub.LimbSpec / Eq.LimbSpec / IsZero.LimbSpec / And.LimbSpec entries in scripts/noshake.json. Extend the existing AddMod.LimbSpec entry (which only covered Add.Spec) to cover both imports.

`lake build` green; `lake exe shake EvmAsm` no longer flags this file.

Refs: beads evm-asm-dv45u, parent evm-asm-6qj (GH #1045 import hygiene sweep).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).