### PR TITLE
feat(mstore): add mstoreStackCode = evm_mstore_code bridge

### DIFF
--- a/EvmAsm/Evm64/MStore.lean
+++ b/EvmAsm/Evm64/MStore.lean
@@ -2,5 +2,6 @@ import EvmAsm.Evm64.MStore.Program
 import EvmAsm.Evm64.MStore.ByteAlg
 import EvmAsm.Evm64.MStore.LimbSpec
 import EvmAsm.Evm64.MStore.Spec
+import EvmAsm.Evm64.MStore.StackSpec
 import EvmAsm.Evm64.MStore.CombinedSequenceSpec
 import EvmAsm.Evm64.MStore.FullSpec

--- a/EvmAsm/Evm64/MStore/Spec.lean
+++ b/EvmAsm/Evm64/MStore/Spec.lean
@@ -467,44 +467,6 @@ theorem evm_mstore_code_four_limbs_sub
     offReg valReg byteReg accReg addrReg memBaseReg base]
   exact mstoreStackCode_four_limbs_sub offReg byteReg accReg addrReg memBaseReg base
 
-/-- Sub-monotonicity: `mstoreStackCode` is contained in `evm_mstore_code` (they
-    are in fact equal by `mstoreStackCode_eq_evm_mstore_code`).  Direct MSTORE
-    analog of `evm_mload_code_stack_sub` (PR #3102, evm-asm-rw24y).
-
-    Distinctive token: evm_mstore_code_stack_sub #53. -/
-theorem evm_mstore_code_stack_sub
-    (offReg valReg byteReg accReg addrReg memBaseReg : Reg) (base : Word) :
-    ∀ a i,
-      (mstoreStackCode offReg byteReg accReg addrReg memBaseReg base) a = some i →
-      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base) a = some i := by
-  rw [mstoreStackCode_eq_evm_mstore_code
-    offReg valReg byteReg accReg addrReg memBaseReg base]
-  intro _ _ h; exact h
-
-/-- Transport a `cpsTripleWithin` over `mstoreStackCode` to one over
-    `evm_mstore_code`.  Subsequent slices use this to land
-    `evm_mstore_stack_spec_within` (evm-asm-ln8t5 / GH #53 follow-up) by
-    composing the existing `mstore_combined_*_stack_spec_within` lemmas
-    (over `mstoreStackCode`) with concrete byte-window write triples.
-
-    Direct MSTORE analog of `cpsTripleWithin_evm_mload_of_stack`
-    (PR #3102, evm-asm-rw24y).
-
-    Distinctive token: cpsTripleWithin_evm_mstore_of_stack #53. -/
-theorem cpsTripleWithin_evm_mstore_of_stack
-    {n : Nat} {P Q : Assertion}
-    (offReg valReg byteReg accReg addrReg memBaseReg : Reg)
-    (base pcEnd : Word)
-    (h :
-      cpsTripleWithin n base pcEnd
-        (mstoreStackCode offReg byteReg accReg addrReg memBaseReg base) P Q) :
-    cpsTripleWithin n base pcEnd
-      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base) P Q :=
-  cpsTripleWithin_extend_code
-    (h := h)
-    (hmono := evm_mstore_code_stack_sub
-      offReg valReg byteReg accReg addrReg memBaseReg base)
-
 theorem mstore_four_limbs_evm_mstore_spec_within
     {nSteps : Nat} {P Q : Assertion}
     (offReg valReg byteReg accReg addrReg memBaseReg : Reg) (base : Word)

--- a/EvmAsm/Evm64/MStore/Spec.lean
+++ b/EvmAsm/Evm64/MStore/Spec.lean
@@ -467,6 +467,44 @@ theorem evm_mstore_code_four_limbs_sub
     offReg valReg byteReg accReg addrReg memBaseReg base]
   exact mstoreStackCode_four_limbs_sub offReg byteReg accReg addrReg memBaseReg base
 
+/-- Sub-monotonicity: `mstoreStackCode` is contained in `evm_mstore_code` (they
+    are in fact equal by `mstoreStackCode_eq_evm_mstore_code`).  Direct MSTORE
+    analog of `evm_mload_code_stack_sub` (PR #3102, evm-asm-rw24y).
+
+    Distinctive token: evm_mstore_code_stack_sub #53. -/
+theorem evm_mstore_code_stack_sub
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg) (base : Word) :
+    ∀ a i,
+      (mstoreStackCode offReg byteReg accReg addrReg memBaseReg base) a = some i →
+      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base) a = some i := by
+  rw [mstoreStackCode_eq_evm_mstore_code
+    offReg valReg byteReg accReg addrReg memBaseReg base]
+  intro _ _ h; exact h
+
+/-- Transport a `cpsTripleWithin` over `mstoreStackCode` to one over
+    `evm_mstore_code`.  Subsequent slices use this to land
+    `evm_mstore_stack_spec_within` (evm-asm-ln8t5 / GH #53 follow-up) by
+    composing the existing `mstore_combined_*_stack_spec_within` lemmas
+    (over `mstoreStackCode`) with concrete byte-window write triples.
+
+    Direct MSTORE analog of `cpsTripleWithin_evm_mload_of_stack`
+    (PR #3102, evm-asm-rw24y).
+
+    Distinctive token: cpsTripleWithin_evm_mstore_of_stack #53. -/
+theorem cpsTripleWithin_evm_mstore_of_stack
+    {n : Nat} {P Q : Assertion}
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg)
+    (base pcEnd : Word)
+    (h :
+      cpsTripleWithin n base pcEnd
+        (mstoreStackCode offReg byteReg accReg addrReg memBaseReg base) P Q) :
+    cpsTripleWithin n base pcEnd
+      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base) P Q :=
+  cpsTripleWithin_extend_code
+    (h := h)
+    (hmono := evm_mstore_code_stack_sub
+      offReg valReg byteReg accReg addrReg memBaseReg base)
+
 theorem mstore_four_limbs_evm_mstore_spec_within
     {nSteps : Nat} {P Q : Assertion}
     (offReg valReg byteReg accReg addrReg memBaseReg : Reg) (base : Word)

--- a/EvmAsm/Evm64/MStore/StackSpec.lean
+++ b/EvmAsm/Evm64/MStore/StackSpec.lean
@@ -1,0 +1,53 @@
+/-
+  EvmAsm.Evm64.MStore.StackSpec
+
+  Stack-level bridge helpers for MSTORE.  Direct MSTORE analogs of the
+  `MLoad/StackSpec.lean` lemmas: lift triples over `mstoreStackCode`
+  to triples over `evm_mstore_code`.
+-/
+
+import EvmAsm.Evm64.MStore.Spec
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Sub-monotonicity: `mstoreStackCode` is contained in `evm_mstore_code` (they
+    are in fact equal by `mstoreStackCode_eq_evm_mstore_code`).  Direct MSTORE
+    analog of `evm_mload_code_stack_sub` (PR #3102, evm-asm-rw24y).
+
+    Distinctive token: evm_mstore_code_stack_sub #53. -/
+theorem evm_mstore_code_stack_sub
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg) (base : Word) :
+    ∀ a i,
+      (mstoreStackCode offReg byteReg accReg addrReg memBaseReg base) a = some i →
+      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base) a = some i := by
+  rw [mstoreStackCode_eq_evm_mstore_code
+    offReg valReg byteReg accReg addrReg memBaseReg base]
+  intro _ _ h; exact h
+
+/-- Transport a `cpsTripleWithin` over `mstoreStackCode` to one over
+    `evm_mstore_code`.  Subsequent slices use this to land
+    `evm_mstore_stack_spec_within` (evm-asm-ln8t5 / GH #53 follow-up) by
+    composing the existing `mstore_combined_*_stack_spec_within` lemmas
+    (over `mstoreStackCode`) with concrete byte-window write triples.
+
+    Direct MSTORE analog of `cpsTripleWithin_evm_mload_of_stack`
+    (PR #3102, evm-asm-rw24y).
+
+    Distinctive token: cpsTripleWithin_evm_mstore_of_stack #53. -/
+theorem cpsTripleWithin_evm_mstore_of_stack
+    {n : Nat} {P Q : Assertion}
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg)
+    (base pcEnd : Word)
+    (h :
+      cpsTripleWithin n base pcEnd
+        (mstoreStackCode offReg byteReg accReg addrReg memBaseReg base) P Q) :
+    cpsTripleWithin n base pcEnd
+      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base) P Q :=
+  cpsTripleWithin_extend_code
+    (h := h)
+    (hmono := evm_mstore_code_stack_sub
+      offReg valReg byteReg accReg addrReg memBaseReg base)
+
+end EvmAsm.Evm64


### PR DESCRIPTION
Direct MSTORE analog of the MLOAD lemmas shipped in PR #3102 (evm-asm-rw24y).

Adds two lemmas to `EvmAsm/Evm64/MStore/Spec.lean` next to `evm_mstore_code_four_limbs_sub`:

- `evm_mstore_code_stack_sub`: `mstoreStackCode` is contained in `evm_mstore_code` (they are in fact equal by `mstoreStackCode_eq_evm_mstore_code`).
- `cpsTripleWithin_evm_mstore_of_stack`: transport a `cpsTripleWithin` over `mstoreStackCode` to one over `evm_mstore_code` via `cpsTripleWithin_extend_code`.

These are the missing transport bricks for the eventual `evm_mstore_stack_spec_within` (evm-asm-ln8t5 / GH #53 follow-up) — composing slices state stack-level triples over `mstoreStackCode` (where the existing `mstore_combined_*_stack_spec_within` lemmas live) and lift to `evm_mstore_code` at the end.

`lake build` clean, no `maxHeartbeats` / `maxRecDepth` bumps.

Refs evm-asm-guagc, parent evm-asm-ln8t5, GH #53.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).