### PR TITLE
chore(shake): drop unused LoopDefs.Iter import in LoopDefs/IterV4.lean

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopDefs/IterV4.lean
+++ b/EvmAsm/Evm64/DivMod/LoopDefs/IterV4.lean
@@ -33,7 +33,7 @@
   Issue #1337 algorithm fix migration / Issue #61 stack spec closure.
 -/
 
-import EvmAsm.Evm64.DivMod.LoopDefs.Iter
+import EvmAsm.Evm64.DivMod.LimbSpec.Div128ProdCheck2
 
 namespace EvmAsm.Evm64
 


### PR DESCRIPTION
Shake flagged that `EvmAsm/Evm64/DivMod/LoopDefs/IterV4.lean` does not directly reference anything from `EvmAsm.Evm64.DivMod.LoopDefs.Iter`. The file only needs `div128Quot_phase2b_q0'`, which is defined in `EvmAsm.Evm64.DivMod.LimbSpec.Div128ProdCheck2` (the indirect `LoopDefs.Iter` import was pulling in `Div128ProdCheck2` transitively for the same symbol).

Replace the indirect import with the direct one. Build remains green; `lake exe shake EvmAsm` reports no remaining suggestion for this file.

Refs: GH #1045, beads `evm-asm-zrzs2` (parent `evm-asm-9tq`).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).