### PR TITLE
feat(mstore): add evm_mstore_full_stack_spec_within transport

### DIFF
--- a/EvmAsm/Evm64/MStore/StackSpec.lean
+++ b/EvmAsm/Evm64/MStore/StackSpec.lean
@@ -146,4 +146,56 @@ theorem evm_mstore_full_stack_spec_within
       offReg byteReg accReg addrReg memBaseReg
       sp offset offOld addrOld memBase base hF h_off_ne_x0 h_addr_ne_x0 h4)
 
+/--
+MSTORE evm_mstore_code lift of `mstore_combined_four_limb_sequence_stack_spec_within`:
+the same combined prologue + four `mstoreFourLimbsCode` quarter triples,
+transported from `mstoreStackCode` to `evm_mstore_code` via
+`cpsTripleWithin_evm_mstore_of_stack`.
+
+Sister of `evm_mstore_combined_one_limb_sequence_stack_spec_within` but at the
+coarser `mstoreFourLimbsCode` granularity: callers supply each quarter triple
+over the four-limbs body program (not over the per-byte one-limb program),
+useful when the concrete byte-window write triple is naturally produced at
+that surface (e.g. via `mstore_four_limb_sequence_spec_within` composition
+with byte-window subspecs). Direct MSTORE analog of
+`evm_mload_combined_four_limb_sequence_stack_spec_within` (PR #3110,
+evm-asm-7jxqa).
+
+Distinctive token: evm_mstore_combined_four_limb_sequence_stack_spec_within #53.
+-/
+theorem evm_mstore_combined_four_limb_sequence_stack_spec_within
+    {n0 n1 n2 n3 : Nat} {P1 P2 P3 Q : Assertion}
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset offOld addrOld memBase : Word) (base : Word)
+    (h_off_ne_x0 : offReg ≠ .x0)
+    (h_addr_ne_x0 : addrReg ≠ .x0)
+    (h0 :
+      cpsTripleWithin n0 (base + 8) (base + 76)
+        (mstoreFourLimbsCode addrReg byteReg accReg base)
+        (((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+         (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+         (sp ↦ₘ offset))
+        P1)
+    (h1 :
+      cpsTripleWithin n1 (base + 76) (base + 144)
+        (mstoreFourLimbsCode addrReg byteReg accReg base) P1 P2)
+    (h2 :
+      cpsTripleWithin n2 (base + 144) (base + 212)
+        (mstoreFourLimbsCode addrReg byteReg accReg base) P2 P3)
+    (h3 :
+      cpsTripleWithin n3 (base + 212) (base + 280)
+        (mstoreFourLimbsCode addrReg byteReg accReg base) P3 Q) :
+    cpsTripleWithin (2 + (n0 + n1 + n2 + n3)) base (base + 280)
+      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base)
+      (((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offOld) **
+       (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ addrOld) **
+       (sp ↦ₘ offset))
+      Q :=
+  cpsTripleWithin_evm_mstore_of_stack
+    offReg valReg byteReg accReg addrReg memBaseReg base (base + 280)
+    (mstore_combined_four_limb_sequence_stack_spec_within
+      offReg byteReg accReg addrReg memBaseReg
+      sp offset offOld addrOld memBase base h_off_ne_x0 h_addr_ne_x0
+      h0 h1 h2 h3)
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/MStore/StackSpec.lean
+++ b/EvmAsm/Evm64/MStore/StackSpec.lean
@@ -105,4 +105,45 @@ theorem evm_mstore_combined_one_limb_sequence_stack_spec_within
       sp offset offOld addrOld memBase base h_off_ne_x0 h_addr_ne_x0
       h0 h1 h2 h3)
 
+/--
+MSTORE evm_mstore_code lift of `mstore_full_stack_spec_within`: the same
+prologue + caller-supplied four-limbs core triple + framed epilogue
+composition, transported from `mstoreStackCode` to `evm_mstore_code` via
+`cpsTripleWithin_evm_mstore_of_stack`.
+
+Subsequent slices toward `evm_mstore_stack_spec_within` (evm-asm-ln8t5 /
+GH #53 follow-up) instantiate `h4` with a concrete four-limbs byte-window
+write triple over `mstoreStackCode` and apply this helper to land the
+full `base .. base + 284` triple over `evm_mstore_code` in one step,
+without re-applying the stack-code → evm_mstore_code transport at every
+call site.
+
+Distinctive token: evm_mstore_full_stack_spec_within #53.
+-/
+theorem evm_mstore_full_stack_spec_within
+    {n : Nat} {F : Assertion}
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset offOld addrOld memBase : Word) (base : Word)
+    (hF : F.pcFree)
+    (h_off_ne_x0 : offReg ≠ .x0)
+    (h_addr_ne_x0 : addrReg ≠ .x0)
+    (h4 :
+      cpsTripleWithin n (base + 8) (base + 280)
+        (mstoreStackCode offReg byteReg accReg addrReg memBaseReg base)
+        (((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+         (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+         (sp ↦ₘ offset))
+        (((.x12 : Reg) ↦ᵣ sp) ** F)) :
+    cpsTripleWithin (2 + n + 1) base (base + 284)
+      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base)
+      (((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offOld) **
+       (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ addrOld) **
+       (sp ↦ₘ offset))
+      (((.x12 : Reg) ↦ᵣ (sp + 64)) ** F) :=
+  cpsTripleWithin_evm_mstore_of_stack
+    offReg valReg byteReg accReg addrReg memBaseReg base (base + 284)
+    (mstore_full_stack_spec_within
+      offReg byteReg accReg addrReg memBaseReg
+      sp offset offOld addrOld memBase base hF h_off_ne_x0 h_addr_ne_x0 h4)
+
 end EvmAsm.Evm64


### PR DESCRIPTION
Tiny followup toward `evm_mstore_stack_spec_within` (evm-asm-ln8t5 / GH #53 follow-up).

Stacked on top of #3106 (`feat/evm-mstore-combined-one-limb-sequence-transport`).

Adds `evm_mstore_full_stack_spec_within` in `EvmAsm/Evm64/MStore/StackSpec.lean`: a one-line transport via `cpsTripleWithin_evm_mstore_of_stack` (PR #3104) that lifts `mstore_full_stack_spec_within` (over `mstoreStackCode`, `EvmAsm/Evm64/MStore/Spec.lean:1458`) onto `evm_mstore_code`, yielding the full `base .. base + 284` triple in one step.

This mirrors PR #3106 (`evm_mstore_combined_one_limb_sequence_stack_spec_within` transport) but exposes the `mstore_full_stack_spec_within` shape, which already includes the framed epilogue. Subsequent slices instantiate the `h4` four-limbs core hypothesis with a concrete byte-window write triple to land `evm_mstore_stack_spec_within` end-to-end without re-doing the prologue + epilogue plumbing or the stack-code transport at every call site.

Local `lake build EvmAsm.Evm64.MStore.StackSpec` succeeds (879/879).

Refs evm-asm-q5w12, parent evm-asm-ln8t5 / evm-asm-or06a, GH #53.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).