### PR TITLE
feat(mstore): add evm_mstore_combined_four_limb_sequence_stack_spec_within transport

### DIFF
--- a/EvmAsm/Evm64/MStore/StackSpec.lean
+++ b/EvmAsm/Evm64/MStore/StackSpec.lean
@@ -146,4 +146,56 @@ theorem evm_mstore_full_stack_spec_within
       offReg byteReg accReg addrReg memBaseReg
       sp offset offOld addrOld memBase base hF h_off_ne_x0 h_addr_ne_x0 h4)
 
+/--
+MSTORE evm_mstore_code lift of `mstore_combined_four_limb_sequence_stack_spec_within`:
+the same combined prologue + four `mstoreFourLimbsCode` quarter triples,
+transported from `mstoreStackCode` to `evm_mstore_code` via
+`cpsTripleWithin_evm_mstore_of_stack`.
+
+Sister of `evm_mstore_combined_one_limb_sequence_stack_spec_within` but at the
+coarser `mstoreFourLimbsCode` granularity: callers supply each quarter triple
+over the four-limbs body program (not over the per-byte one-limb program),
+useful when the concrete byte-window write triple is naturally produced at
+that surface (e.g. via `mstore_four_limb_sequence_spec_within` composition
+with byte-window subspecs). Direct MSTORE analog of
+`evm_mload_combined_four_limb_sequence_stack_spec_within` (PR #3110,
+evm-asm-7jxqa).
+
+Distinctive token: evm_mstore_combined_four_limb_sequence_stack_spec_within #53.
+-/
+theorem evm_mstore_combined_four_limb_sequence_stack_spec_within
+    {n0 n1 n2 n3 : Nat} {P1 P2 P3 Q : Assertion}
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset offOld addrOld memBase : Word) (base : Word)
+    (h_off_ne_x0 : offReg ≠ .x0)
+    (h_addr_ne_x0 : addrReg ≠ .x0)
+    (h0 :
+      cpsTripleWithin n0 (base + 8) (base + 76)
+        (mstoreFourLimbsCode addrReg byteReg accReg base)
+        (((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+         (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+         (sp ↦ₘ offset))
+        P1)
+    (h1 :
+      cpsTripleWithin n1 (base + 76) (base + 144)
+        (mstoreFourLimbsCode addrReg byteReg accReg base) P1 P2)
+    (h2 :
+      cpsTripleWithin n2 (base + 144) (base + 212)
+        (mstoreFourLimbsCode addrReg byteReg accReg base) P2 P3)
+    (h3 :
+      cpsTripleWithin n3 (base + 212) (base + 280)
+        (mstoreFourLimbsCode addrReg byteReg accReg base) P3 Q) :
+    cpsTripleWithin (2 + (n0 + n1 + n2 + n3)) base (base + 280)
+      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base)
+      (((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offOld) **
+       (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ addrOld) **
+       (sp ↦ₘ offset))
+      Q :=
+  cpsTripleWithin_evm_mstore_of_stack
+    offReg valReg byteReg accReg addrReg memBaseReg base (base + 280)
+    (mstore_combined_four_limb_sequence_stack_spec_within
+      offReg byteReg accReg addrReg memBaseReg
+      sp offset offOld addrOld memBase base h_off_ne_x0 h_addr_ne_x0
+      h0 h1 h2 h3)
+
 end EvmAsm.Evm64


### PR DESCRIPTION
Direct MSTORE analog of PR #3110 (evm-asm-7jxqa / `evm_mload_combined_four_limb_sequence_stack_spec_within`).

Lifts `mstore_combined_four_limb_sequence_stack_spec_within` (over `mstoreStackCode`, taking four `mstoreFourLimbsCode` quarter triples) through `cpsTripleWithin_evm_mstore_of_stack`, yielding the same triple over `evm_mstore_code`.

Sister of `evm_mstore_combined_one_limb_sequence_stack_spec_within` (PR #3106) but at the coarser `mstoreFourLimbsCode` quarter granularity: useful when the concrete byte-window write triple is naturally produced at that surface (e.g. via `mstore_four_limb_sequence_spec_within` composition with byte-window subspecs) rather than at the per-byte one-limb program surface.

Toward `evm_mstore_stack_spec_within` (evm-asm-ln8t5 / GH #53 follow-up).

Stacked on top of #3109.

Refs evm-asm-azv84, parent evm-asm-or06a, GH #53.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).