### PR TITLE
feat(bls12-g1-add): add statusWord + a0-decode lemmas to Bls12G1AddEcallBridge

### DIFF
--- a/EvmAsm/EL/Bls12G1AddEcallBridge.lean
+++ b/EvmAsm/EL/Bls12G1AddEcallBridge.lean
@@ -6,6 +6,7 @@
 
 import EvmAsm.EL.Bls12G1AddInputBridge
 import EvmAsm.EL.Bls12G1AddResultBridge
+import EvmAsm.Evm64.Accelerators.Status
 import EvmAsm.Evm64.Accelerators.SyscallIds
 
 namespace EvmAsm.EL
@@ -92,6 +93,53 @@ theorem executeBls12G1AddEcall_fromMemory_outputPoint
       (accelerator
         (Bls12G1AddInputBridge.bls12G1AddInputFromMemory
           memory p1Start p2Start)).output.point := rfl
+
+/-- RV64 `a0` return-register `Word` for the accelerator status, mirroring
+`Sha256EcallBridge.statusWord`. The accelerator places the `zkvm_status`
+return code in `a0` after the ECALL; this projection extracts that word from
+a `Bls12G1AddResult` for postcondition reasoning. -/
+def statusWord (result : Bls12G1AddResult) : BitVec 64 :=
+  EvmAsm.Rv64.zkvmStatusToWord result.status
+
+theorem statusWord_eok
+    {result : Bls12G1AddResult} (h_status : result.status = .eok) :
+    statusWord result = EvmAsm.Rv64.zkvmStatusEokWord := by
+  show EvmAsm.Rv64.zkvmStatusToWord result.status = _
+  rw [h_status]; rfl
+
+theorem statusWord_efail
+    {result : Bls12G1AddResult} (h_status : result.status = .efail) :
+    statusWord result = EvmAsm.Rv64.zkvmStatusEfailWord := by
+  show EvmAsm.Rv64.zkvmStatusToWord result.status = _
+  rw [h_status]; rfl
+
+/-- The `a0` word is `ZKVM_EOK` iff the accelerator reported success. -/
+theorem statusWord_eq_eokWord_iff (result : Bls12G1AddResult) :
+    statusWord result = EvmAsm.Rv64.zkvmStatusEokWord ↔ result.status = .eok := by
+  cases h_st : result.status with
+  | eok => simp [statusWord_eok h_st]
+  | efail =>
+    rw [statusWord_efail h_st]
+    constructor
+    · intro h; exact absurd h.symm EvmAsm.Rv64.zkvmStatusEokWord_ne_efailWord
+    · intro h; simp at h
+
+/-- The `a0` word decodes back to the original status. -/
+theorem zkvmStatusFromWord?_statusWord (result : Bls12G1AddResult) :
+    EvmAsm.Rv64.zkvmStatusFromWord? (statusWord result) = some result.status :=
+  EvmAsm.Rv64.zkvmStatusFromWord?_toWord result.status
+
+/-- Push `statusWord` through `executeBls12G1AddEcall`: the returned `a0` word is
+the accelerator-supplied status encoded via `zkvmStatusToWord`. This bridge
+uses the `AcceleratorResult` struct shape (status as a named field), so the
+push-through reads `(accelerator request.input).status`. -/
+theorem executeBls12G1AddEcall_statusWord
+    (accelerator : Bls12G1AddInputBridge.AcceleratorInput →
+      Bls12G1AddResultBridge.AcceleratorResult)
+    (request : Bls12G1AddRequest) :
+    statusWord (executeBls12G1AddEcall accelerator request) =
+      EvmAsm.Rv64.zkvmStatusToWord (accelerator request.input).status := by
+  rfl
 
 end Bls12G1AddEcallBridge
 


### PR DESCRIPTION
Adds the `statusWord` projection + a0-decode lemmas to
`EvmAsm/EL/Bls12G1AddEcallBridge.lean`, mirroring the pattern shipped for
SHA256 (#3038), RIPEMD160 (#3041), and BN254 G1 ADD (#3112).

New definitions:
- `def statusWord (result : Bls12G1AddResult) : BitVec 64`
- `statusWord_eok` / `statusWord_efail`
- `statusWord_eq_eokWord_iff`
- `zkvmStatusFromWord?_statusWord` (round-trip through the option decoder)
- `executeBls12G1AddEcall_statusWord` (push `statusWord` through the pure
  execution boundary)

This bridge uses the `AcceleratorResult` struct shape (status as a named
field) rather than the `ZkvmStatus × Output` product variant used by the
hash-family bridges, so the push-through reads
`(accelerator request.input).status` rather than `.1`.

Refs `evm-asm-fmg2q`, parent `evm-asm-bc3sd`, grandparent `evm-asm-nr2sk`.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).