### PR TITLE
docs: link zkvm-host-io-interface ADR from README and AGENTS References

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,6 +171,12 @@ Pitfalls:
   is the source of truth for accelerator function signatures, argument
   layouts, and `zkvm_status` framing used by all EVM precompile and
   KECCAK256 bridges. See [`docs/zkvm-accelerators-interface.md`](docs/zkvm-accelerators-interface.md).
+- **Host I/O C ABI**: `EvmAsm/Evm64/zkvm-standards/standards/io-interface/README.md`
+  defines the canonical host-I/O surface (`read_input` / `write_output`).
+  See [`docs/zkvm-host-io-interface.md`](docs/zkvm-host-io-interface.md)
+  for the decision record and SP1 `HINT_LEN` / `HINT_READ` / `COMMIT` →
+  zkvm-standards mapping. Migration tracked under beads parent
+  `evm-asm-96ysd` (GH #114 / #116).
 - **SP1 zkVM**: https://github.com/succinctlabs/sp1 (RISC-V `ECALL`
   framing only; function set follows `zkvm_accelerators.h`)
 - **RISC-V ISA**: https://riscv.org/technical/specifications/

--- a/README.md
+++ b/README.md
@@ -321,6 +321,13 @@ This is a **prototype** demonstrating the approach. Current state:
   [`docs/zkvm-accelerators-interface.md`](docs/zkvm-accelerators-interface.md)
   for the decision record, full design note, and per-precompile coverage /
   EVM-precompile → accelerator mapping table.
+- Host I/O C ABI (source of truth):
+  `EvmAsm/Evm64/zkvm-standards/standards/io-interface/README.md`
+  defines the canonical host-I/O surface (`read_input` / `write_output`).
+  See [`docs/zkvm-host-io-interface.md`](docs/zkvm-host-io-interface.md)
+  for the decision record, the SP1 `HINT_LEN` / `HINT_READ` / `COMMIT` →
+  zkvm-standards mapping, and the migration plan tracked under beads
+  parent `evm-asm-96ysd` (GH #114 / #116).
 - SP1 zkVM: https://github.com/succinctlabs/sp1
   The RISC-V `ECALL` framing (instruction encoding, register
   convention, return-via-`a0`) follows the same mechanism SP1 uses;


### PR DESCRIPTION
Sub-slice of host I/O migration parent `evm-asm-96ysd` (GH #114 / #116).

PR #3065 landed `docs/zkvm-host-io-interface.md` (the host-I/O ADR mirroring the accelerator ADR pattern), but the `References` sections in `README.md` and `AGENTS.md` still only signposted `docs/zkvm-accelerators-interface.md`. Readers landing on either entry point had no pointer to the host-I/O ADR.

This PR adds parallel bullets to both `References` sections:

- pointer to `EvmAsm/Evm64/zkvm-standards/standards/io-interface/README.md` as the canonical host-I/O C ABI surface (`read_input` / `write_output`);
- pointer to `docs/zkvm-host-io-interface.md` for the decision record, the SP1 `HINT_LEN` / `HINT_READ` / `COMMIT` → zkvm-standards mapping, and the migration plan;
- backref to beads parent `evm-asm-96ysd` so future readers can find the open migration work.

Doc-only; no Lean changes.

Refs: parent beads `evm-asm-96ysd`, slice `evm-asm-nltvz`, prior ADR slice `evm-asm-plo9i` (shipped in #3065).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).
