### PR TITLE
feat(bls12-g1-msm): add statusWord + a0-decode lemmas to Bls12G1MsmEcallBridge

### DIFF
--- a/EvmAsm/EL/Bls12G1MsmEcallBridge.lean
+++ b/EvmAsm/EL/Bls12G1MsmEcallBridge.lean
@@ -6,6 +6,7 @@
 
 import EvmAsm.EL.Bls12G1MsmInputBridge
 import EvmAsm.EL.Bls12G1MsmResultBridge
+import EvmAsm.Evm64.Accelerators.Status
 import EvmAsm.Evm64.Accelerators.SyscallIds
 
 namespace EvmAsm.EL
@@ -92,6 +93,53 @@ theorem executeBls12G1MsmEcall_fromMemory_outputPoint
       (accelerator
         (Bls12G1MsmInputBridge.bls12G1MsmInputFromMemory
           memory pairsStart numPairs)).output.point := rfl
+
+/-- RV64 `a0` return-register `Word` for the accelerator status, mirroring
+`Sha256EcallBridge.statusWord`. The accelerator places the `zkvm_status`
+return code in `a0` after the ECALL; this projection extracts that word from
+a `Bls12G1MsmResult` for postcondition reasoning. -/
+def statusWord (result : Bls12G1MsmResult) : BitVec 64 :=
+  EvmAsm.Rv64.zkvmStatusToWord result.status
+
+theorem statusWord_eok
+    {result : Bls12G1MsmResult} (h_status : result.status = .eok) :
+    statusWord result = EvmAsm.Rv64.zkvmStatusEokWord := by
+  show EvmAsm.Rv64.zkvmStatusToWord result.status = _
+  rw [h_status]; rfl
+
+theorem statusWord_efail
+    {result : Bls12G1MsmResult} (h_status : result.status = .efail) :
+    statusWord result = EvmAsm.Rv64.zkvmStatusEfailWord := by
+  show EvmAsm.Rv64.zkvmStatusToWord result.status = _
+  rw [h_status]; rfl
+
+/-- The `a0` word is `ZKVM_EOK` iff the accelerator reported success. -/
+theorem statusWord_eq_eokWord_iff (result : Bls12G1MsmResult) :
+    statusWord result = EvmAsm.Rv64.zkvmStatusEokWord ↔ result.status = .eok := by
+  cases h_st : result.status with
+  | eok => simp [statusWord_eok h_st]
+  | efail =>
+    rw [statusWord_efail h_st]
+    constructor
+    · intro h; exact absurd h.symm EvmAsm.Rv64.zkvmStatusEokWord_ne_efailWord
+    · intro h; simp at h
+
+/-- The `a0` word decodes back to the original status. -/
+theorem zkvmStatusFromWord?_statusWord (result : Bls12G1MsmResult) :
+    EvmAsm.Rv64.zkvmStatusFromWord? (statusWord result) = some result.status :=
+  EvmAsm.Rv64.zkvmStatusFromWord?_toWord result.status
+
+/-- Push `statusWord` through `executeBls12G1MsmEcall`: the returned `a0` word is
+the accelerator-supplied status encoded via `zkvmStatusToWord`. This bridge
+uses the `AcceleratorResult` struct shape (status as a named field), so the
+push-through reads `(accelerator request.input).status`. -/
+theorem executeBls12G1MsmEcall_statusWord
+    (accelerator : Bls12G1MsmInputBridge.AcceleratorInput →
+      Bls12G1MsmResultBridge.AcceleratorResult)
+    (request : Bls12G1MsmRequest) :
+    statusWord (executeBls12G1MsmEcall accelerator request) =
+      EvmAsm.Rv64.zkvmStatusToWord (accelerator request.input).status := by
+  rfl
 
 end Bls12G1MsmEcallBridge
 


### PR DESCRIPTION
Mirrors the BLS12-G1-ADD pattern (#3114), itself parallel to BN254-G1-ADD/MUL (#3112/#3113) and SHA256/RIPEMD160/BLAKE2F (#3038/#3041/#3100):

- `def statusWord (result : Bls12G1MsmResult) : BitVec 64`
- `statusWord_eok` / `statusWord_efail`
- `statusWord_eq_eokWord_iff`
- `zkvmStatusFromWord?_statusWord` round-trip
- `executeBls12G1MsmEcall_statusWord` push-through

Bridge uses the `AcceleratorResult`-struct shape (status as a named field), same as Bls12G1AddEcallBridge.

Refs beads evm-asm-g5qix, parent evm-asm-bc3sd, grandparent evm-asm-nr2sk (zkvm_accelerators.h audit, GH N/A).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).