### PR TITLE
chore(shake): noshake MStore.StackSpec → CombinedSequenceSpec false-positive

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -122,6 +122,8 @@
   ["EvmAsm.Rv64.ByteOps"],
  "EvmAsm.Evm64.MStore.ByteAlg":
   ["Std.Tactic.BVDecide", "Mathlib.Tactic.IntervalCases"],
+ "EvmAsm.Evm64.MStore.StackSpec":
+  ["EvmAsm.Evm64.MStore.CombinedSequenceSpec"],
  "EvmAsm.Evm64.MLoad.ByteAlg":
   ["EvmAsm.Rv64.Basic", "Std.Tactic.BVDecide"],
  "EvmAsm.Evm64.SpAddr":


### PR DESCRIPTION
`lake exe shake EvmAsm` flags `EvmAsm.Evm64.MStore.CombinedSequenceSpec` as droppable from `EvmAsm/Evm64/MStore/StackSpec.lean`, but the import is genuine: `StackSpec.lean` calls `mstore_combined_one_limb_sequence_stack_spec_within` (declared in `CombinedSequenceSpec.lean`). The sibling import `EvmAsm.Evm64.MStore.Spec` does not transitively pull in `CombinedSequenceSpec`, so removing the explicit import yields `Unknown identifier`.

Add a `scripts/noshake.json` entry to suppress the false positive.

Refs GH #1045, beads evm-asm-anhsg / parent evm-asm-6qj.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).