### PR TITLE
feat(mload): evm_mload_unaligned_one_limb_q2_stack_spec_within

### DIFF
--- a/EvmAsm/Evm64/MLoad/StackSpec.lean
+++ b/EvmAsm/Evm64/MLoad/StackSpec.lean
@@ -1231,4 +1231,81 @@ theorem mloadStackOutputPostFiveDwords_evmStackIs_fold
   rw [mloadStackOutputPostFiveDwords_unfold]
   rfl
 
+/--
+MLOAD q2 unaligned per-quarter stack spec: a fully-instantiated unaligned
+byte-load triple at `(base + 192) .. (base + 284)` over the q2 byte-pack
+program slot of `evm_mload_code`, shaped to match the `h2` hypothesis of
+`evm_mload_combined_one_limb_sequence_stack_spec_within` (above).
+
+For q2 the destination dword offset is `16`, so the stored limb lands at
+`sp + 16` — a fresh limb slot DISTINCT from both the prologue-threaded
+`(sp ↦ₘ offset)` cell at `sp + 0` (now holding the q0 packed limb) and
+the q1 packed-limb cell at `sp + 8`. The q0 cell at `sp` and the q1 cell
+at `sp + 8` are threaded UNCHANGED through q2's pre/post (sitting in the
+right-side frame of the underlying unaligned spec).
+
+Sub-slice toward `evm_mload_stack_spec_within` (evm-asm-lrhou / GH #53
+follow-up): together with q0/q1/q3 siblings, feeds
+`evm_mload_combined_one_limb_sequence_stack_spec_within` to land the
+topmost stack-level MLOAD theorem.
+
+Distinctive token: evm_mload_unaligned_one_limb_q2_stack_spec_within #53.
+-/
+theorem evm_mload_unaligned_one_limb_q2_stack_spec_within
+    (offReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset memBase byteOld accOld : Word)
+    (q0Old q1Old : Word)
+    (loAddr2 hiAddr2 loVal2 hiVal2 : Word) (start : Nat)
+    (dstOld : Word)
+    (base : Word)
+    (h_byte_ne_x0 : byteReg ≠ .x0) (h_acc_ne_x0 : accReg ≠ .x0)
+    (h_window : mloadLimbWindowOk (memBase + offset) loAddr2 hiAddr2 start
+                  8 9 10 11 12 13 14 15) :
+    cpsTripleWithin 23 (base + 192) (base + 284)
+      (mloadOneLimbCode addrReg byteReg accReg
+        8 9 10 11 12 13 14 15 16 (base + 192))
+      (((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+       (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+       (sp ↦ₘ q0Old) **
+       (sp + 8 ↦ₘ q1Old) **
+       (sp + 16 ↦ₘ dstOld) **
+       ((byteReg ↦ᵣ byteOld) ** (accReg ↦ᵣ accOld) **
+        (loAddr2 ↦ₘ loVal2) ** (hiAddr2 ↦ₘ hiVal2)))
+      (((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+       (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+       (sp ↦ₘ q0Old) **
+       (sp + 8 ↦ₘ q1Old) **
+       (sp + 16 ↦ₘ mloadPackedLimbFromDwordPair loVal2 hiVal2 start) **
+       ((byteReg ↦ᵣ
+          (mloadByteFromDwordPair loVal2 hiVal2 start 7).zeroExtend 64) **
+        (accReg ↦ᵣ mloadPackedLimbFromDwordPair loVal2 hiVal2 start) **
+        (loAddr2 ↦ₘ loVal2) ** (hiAddr2 ↦ₘ hiVal2))) := by
+  -- Underlying unaligned one-limb spec at the q2 slot, with dstOff = 16
+  -- and dstWordOld = dstOld stored at `sp + signExtend12 16 = sp + 16`.
+  have core := mload_one_limb_unaligned_spec_within addrReg byteReg accReg
+    (memBase + offset) accOld byteOld loVal2 hiVal2 loAddr2 hiAddr2 sp dstOld
+    8 9 10 11 12 13 14 15 (16 : BitVec 12) start (base + 192)
+    h_byte_ne_x0 h_acc_ne_x0 h_window
+  rw [mloadOneLimbUnalignedPre_unfold, mloadOneLimbUnalignedPost_unfold] at core
+  -- `signExtend12 16 = 16` so `sp + signExtend12 16 = sp + 16`.
+  have hsig : sp + signExtend12 (16 : BitVec 12) = sp + 16 := by
+    have : signExtend12 (16 : BitVec 12) = (16 : Word) := by decide
+    rw [this]
+  rw [hsig] at core
+  -- Normalize endpoint: `base + 192 + 92 = base + 284`.
+  have hpc : (base + 192 + 92 : Word) = base + 284 := by bv_omega
+  rw [hpc] at core
+  -- Frame the prologue-threaded `(offReg ↦ᵣ offset) ** (memBaseReg ↦ᵣ memBase)`
+  -- and the q0/q1 packed-limb cells `(sp ↦ₘ q0Old) ** (sp + 8 ↦ₘ q1Old)`
+  -- on the left.
+  have framed := cpsTripleWithin_frameL
+    (F := (offReg ↦ᵣ offset) ** (memBaseReg ↦ᵣ memBase) **
+          (sp ↦ₘ q0Old) ** (sp + 8 ↦ₘ q1Old))
+    (by pcFree) core
+  -- Permute pre/post into the goal's grouping.
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by sep_perm hp)
+    (fun _ hp => by sep_perm hp)
+    framed
+
 end EvmAsm.Evm64


### PR DESCRIPTION
Add per-quarter unaligned MLOAD stack spec for q2 (sibling of q0/q1 from PRs #3123/#3124), shaped to match the `h2` hypothesis of `evm_mload_combined_one_limb_sequence_stack_spec_within`.

Q2 stores at `sp + 16` (a fresh limb slot, distinct from the prologue slot at `sp+0` holding q0's packed limb and from `sp+8` holding q1). The q0 and q1 packed-limb cells are threaded UNCHANGED through q2's pre/post (sitting in the right-side frame of the underlying unaligned spec).

Derived from `mload_one_limb_unaligned_spec_within` with `dstOff = 16`: `signExtend12 16 = 16`, frame `offReg`/`memBaseReg`/`(sp ↦ₘ q0Old)`/`(sp+8 ↦ₘ q1Old)` on the left, then permute pre/post into the goal grouping.

Sub-slice toward `evm_mload_stack_spec_within` (evm-asm-lrhou / GH #53 follow-up). Sibling slice q3 (dstOff=24) to follow.

- 0 sorry; `lake build` green; no `maxHeartbeats`/`maxRecDepth` bumps.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).
Refs evm-asm-xt8kf, evm-asm-lrhou, GH #53.