### PR TITLE
feat(mstore): evm_mstore_unaligned_one_limb_q2_stack_spec_within

### DIFF
--- a/EvmAsm/Evm64/MStore/UnalignedStackSpec.lean
+++ b/EvmAsm/Evm64/MStore/UnalignedStackSpec.lean
@@ -161,4 +161,69 @@ theorem evm_mstore_unaligned_one_limb_q1_stack_spec_within
     (fun _ hp => by sep_perm hp)
     framed
 
+/--
+MSTORE q2 framed per-quarter stack spec: thin frame around
+`mstore_one_limb_spec_within` for the third limb of the
+big-endian MSTORE write (source offset `48`, byte offsets `8..15`).
+
+Pre/post are stated in the same shape as `h2` of
+`evm_mstore_combined_one_limb_sequence_stack_spec_within`
+(`EvmAsm/Evm64/MStore/StackSpec.lean`), so subsequent compose slices
+can plug this in directly.
+
+Sub-slice toward `evm_mstore_stack_spec_within` (evm-asm-31pfy / parent
+evm-asm-ln8t5 / GH #53 follow-up): together with q0/q1/q3 siblings, feeds
+`evm_mstore_combined_one_limb_sequence_stack_spec_within` to land the
+topmost stack-level MSTORE theorem.
+
+Distinctive token: evm_mstore_unaligned_one_limb_q2_stack_spec_within #53.
+-/
+theorem evm_mstore_unaligned_one_limb_q2_stack_spec_within
+    (offReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset memBase byteOld accOld limbVal : Word)
+    (loAddr hiAddr loVal hiVal : Word) (start : Nat)
+    (base : Word)
+    (h_byte_ne_x0 : byteReg ≠ .x0)
+    (h_acc_ne_x0 : accReg ≠ .x0)
+    (h_window : mstoreLimbWindowOk (memBase + offset) loAddr hiAddr start
+                  8 9 10 11 12 13 14 15) :
+    cpsTripleWithin 17 (base + 144) (base + 212)
+      (mstoreOneLimbCode addrReg byteReg accReg
+        48 8 9 10 11 12 13 14 15 (base + 144))
+      (((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+       (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+       (sp ↦ₘ offset) **
+       ((byteReg ↦ᵣ byteOld) ** (accReg ↦ᵣ accOld) **
+        (loAddr ↦ₘ loVal) ** (hiAddr ↦ₘ hiVal) **
+        ((sp + signExtend12 (48 : BitVec 12)) ↦ₘ limbVal)))
+      (((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+       (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+       (sp ↦ₘ offset) **
+       (let stored :=
+         MStore.mstoreDwordPairStoreLimb loVal hiVal limbVal start
+        (byteReg ↦ᵣ limbVal) ** (accReg ↦ᵣ limbVal) **
+        (loAddr ↦ₘ stored.1) ** (hiAddr ↦ₘ stored.2) **
+        ((sp + signExtend12 (48 : BitVec 12)) ↦ₘ limbVal))) := by
+  -- Underlying one-limb MSTORE spec at q2 (srcOff = 48, dst byte offsets 8..15).
+  have core := mstore_one_limb_spec_within addrReg byteReg accReg
+    (memBase + offset) byteOld accOld loVal hiVal loAddr hiAddr sp limbVal
+    start
+    (48 : BitVec 12) 8 9 10 11 12 13 14 15 (base + 144)
+    h_byte_ne_x0 h_acc_ne_x0 h_window
+  rw [mstoreOneLimbPre_unfold, mstoreOneLimbPost_unfold] at core
+  dsimp only [] at core
+  -- Normalize endpoint: `base + 144 + 68 = base + 212`.
+  have hpc : ((base + 144) + 68 : Word) = base + 212 := by bv_omega
+  rw [show ((base + 144) + 68 : Word) = base + 212 from hpc] at core
+  -- Frame the prologue-threaded cells:
+  --   (offReg ↦ᵣ offset) ** (memBaseReg ↦ᵣ memBase) ** (sp ↦ₘ offset).
+  have framed := cpsTripleWithin_frameL
+    (F := (offReg ↦ᵣ offset) ** (memBaseReg ↦ᵣ memBase) ** (sp ↦ₘ offset))
+    (by pcFree) core
+  -- Permute pre/post into the goal's grouping.
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by sep_perm hp)
+    (fun _ hp => by sep_perm hp)
+    framed
+
 end EvmAsm.Evm64


### PR DESCRIPTION
Sub-slice toward `evm_mstore_stack_spec_within` (parent evm-asm-ln8t5 / GH #53 follow-up). Sibling of q0 (PR #3122) and q1 (PR #3128).

Adds the framed per-quarter byte-write spec for h2 of `evm_mstore_combined_one_limb_sequence_stack_spec_within`:

- srcOff = 48
- byte offsets 8..15
- range base+144 .. base+212

Same shape as the q0/q1 wrappers — thin frame around `mstore_one_limb_spec_within` with prologue-threaded cells (offReg, memBaseReg, sp ↦ₘ offset).

Together with the soon-to-land q3 sibling, this completes the four per-quarter wrappers needed to compose the topmost `evm_mstore_stack_spec_within`.

Refs evm-asm-31pfy / evm-asm-ln8t5 / GH #53.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).