### PR TITLE
feat(mstore): evm_mstore_unaligned_one_limb_q3_stack_spec_within

### DIFF
--- a/EvmAsm/Evm64/MStore/UnalignedStackSpec.lean
+++ b/EvmAsm/Evm64/MStore/UnalignedStackSpec.lean
@@ -161,4 +161,69 @@ theorem evm_mstore_unaligned_one_limb_q1_stack_spec_within
     (fun _ hp => by sep_perm hp)
     framed
 
+/--
+MSTORE q3 framed per-quarter stack spec: thin frame around
+`mstore_one_limb_spec_within` for the least-significant limb of the
+big-endian MSTORE write (source offset `56`, byte offsets `0..7`).
+
+Pre/post are stated in the same shape as `h3` of
+`evm_mstore_combined_one_limb_sequence_stack_spec_within`
+(`EvmAsm/Evm64/MStore/StackSpec.lean`), so subsequent compose slices
+can plug this in directly.
+
+Sub-slice toward `evm_mstore_stack_spec_within` (evm-asm-joqg6 / parent
+evm-asm-ln8t5 / GH #53 follow-up): together with q0/q1/q2 siblings, feeds
+`evm_mstore_combined_one_limb_sequence_stack_spec_within` to land the
+topmost stack-level MSTORE theorem.
+
+Distinctive token: evm_mstore_unaligned_one_limb_q3_stack_spec_within #53.
+-/
+theorem evm_mstore_unaligned_one_limb_q3_stack_spec_within
+    (offReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset memBase byteOld accOld limbVal : Word)
+    (loAddr hiAddr loVal hiVal : Word) (start : Nat)
+    (base : Word)
+    (h_byte_ne_x0 : byteReg ≠ .x0)
+    (h_acc_ne_x0 : accReg ≠ .x0)
+    (h_window : mstoreLimbWindowOk (memBase + offset) loAddr hiAddr start
+                  0 1 2 3 4 5 6 7) :
+    cpsTripleWithin 17 (base + 212) (base + 280)
+      (mstoreOneLimbCode addrReg byteReg accReg
+        56 0 1 2 3 4 5 6 7 (base + 212))
+      (((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+       (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+       (sp ↦ₘ offset) **
+       ((byteReg ↦ᵣ byteOld) ** (accReg ↦ᵣ accOld) **
+        (loAddr ↦ₘ loVal) ** (hiAddr ↦ₘ hiVal) **
+        ((sp + signExtend12 (56 : BitVec 12)) ↦ₘ limbVal)))
+      (((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+       (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+       (sp ↦ₘ offset) **
+       (let stored :=
+         MStore.mstoreDwordPairStoreLimb loVal hiVal limbVal start
+        (byteReg ↦ᵣ limbVal) ** (accReg ↦ᵣ limbVal) **
+        (loAddr ↦ₘ stored.1) ** (hiAddr ↦ₘ stored.2) **
+        ((sp + signExtend12 (56 : BitVec 12)) ↦ₘ limbVal))) := by
+  -- Underlying one-limb MSTORE spec at q3 (srcOff = 56, dst byte offsets 0..7).
+  have core := mstore_one_limb_spec_within addrReg byteReg accReg
+    (memBase + offset) byteOld accOld loVal hiVal loAddr hiAddr sp limbVal
+    start
+    (56 : BitVec 12) 0 1 2 3 4 5 6 7 (base + 212)
+    h_byte_ne_x0 h_acc_ne_x0 h_window
+  rw [mstoreOneLimbPre_unfold, mstoreOneLimbPost_unfold] at core
+  dsimp only [] at core
+  -- Normalize endpoint: `base + 212 + 68 = base + 280`.
+  have hpc : ((base + 212) + 68 : Word) = base + 280 := by bv_omega
+  rw [show ((base + 212) + 68 : Word) = base + 280 from hpc] at core
+  -- Frame the prologue-threaded cells:
+  --   (offReg ↦ᵣ offset) ** (memBaseReg ↦ᵣ memBase) ** (sp ↦ₘ offset).
+  have framed := cpsTripleWithin_frameL
+    (F := (offReg ↦ᵣ offset) ** (memBaseReg ↦ᵣ memBase) ** (sp ↦ₘ offset))
+    (by pcFree) core
+  -- Permute pre/post into the goal's grouping.
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by sep_perm hp)
+    (fun _ hp => by sep_perm hp)
+    framed
+
 end EvmAsm.Evm64


### PR DESCRIPTION
Add the q3 (least-significant limb) framed per-quarter MSTORE stack spec.

Mirrors the existing q0/q1/q2 wrappers in `EvmAsm/Evm64/MStore/UnalignedStackSpec.lean`. Frames the prologue-threaded cells (`offReg`, `memBaseReg`, `sp ↦ₘ offset`) on top of `mstore_one_limb_spec_within` for source offset `56`, byte offsets `0..7`. Range `base+212 .. base+280`, the final quarter consumed by `h3` of `evm_mstore_combined_one_limb_sequence_stack_spec_within`.

With this slice, all four quarter wrappers (q0/q1/q2/q3) for MSTORE are in place, ready to compose into the topmost `evm_mstore_stack_spec_within`.

Refs evm-asm-joqg6 (parent evm-asm-ln8t5 / GH #53 follow-up).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).