### PR TITLE
feat(rlp): Phase4HintReadLoop step-lift helpers (LI + 2× ADDI)

### DIFF
--- a/EvmAsm/Rv64/RLP/Phase4HintReadLoop.lean
+++ b/EvmAsm/Rv64/RLP/Phase4HintReadLoop.lean
@@ -36,6 +36,7 @@
 
 import EvmAsm.Rv64.Program
 import EvmAsm.Rv64.SepLogic
+import EvmAsm.Rv64.SyscallSpecs
 import EvmAsm.Rv64.Tactics.SeqFrame
 
 namespace EvmAsm.Rv64.RLP
@@ -75,5 +76,93 @@ theorem rlp_phase4_hint_read_loop_code_eq_ofProg (base : Word) :
   simp only [rlp_phase4_hint_read_loop_prog, CodeReq.ofProg_cons,
     CodeReq.ofProg_nil, CodeReq.union_empty_right]
   bv_addr
+
+/-- The LI .x5 0xF1 spec at instruction offset 0 of the multi-dword
+    HINT_READ loop body, lifted to the full 5-instruction loop CodeReq.
+
+    Mirrors the `hli_ext` shape inside
+    `rlp_phase4_hint_read_one_word_spec_within` (Phase4HintRead.lean).
+
+    First helper of the four step-lift lemmas planned for the eventual
+    `rlp_phase4_hint_read_loop_body_step_spec_within` composition (beads
+    `evm-asm-yccms`). -/
+theorem rlp_phase4_hint_read_loop_li_step_lift_spec_within (base : Word) :
+    cpsTripleWithin 1 base (base + 4)
+      (CodeReq.ofProg base rlp_phase4_hint_read_loop_prog)
+      (regOwn .x5)
+      (.x5 ↦ᵣ (BitVec.ofNat 64 0xF1)) := by
+  have hli := li_spec_gen_own_within .x5 (BitVec.ofNat 64 0xF1) base (by nofun)
+  apply cpsTripleWithin_extend_code
+    (cr' := CodeReq.ofProg base rlp_phase4_hint_read_loop_prog)
+    (hmono := ?_) (h := hli)
+  rw [rlp_phase4_hint_read_loop_code_eq_ofProg]
+  exact CodeReq.union_mono_left
+
+/-- Helper: the loop CodeReq has the ADDI .x10 .x10 8 instruction at slot
+    `base + 8`. -/
+theorem rlp_phase4_hint_read_loop_addi_advance_get (base : Word) :
+    (CodeReq.ofProg base rlp_phase4_hint_read_loop_prog) (base + 8) =
+      some (.ADDI .x10 .x10 8) := by
+  rw [rlp_phase4_hint_read_loop_code_eq_ofProg]
+  refine CodeReq.union_skip ?_ ?_
+  · exact CodeReq.singleton_miss (a := base) (a' := base + 8)
+      (i := .LI .x5 (BitVec.ofNat 64 0xF1)) (by bv_omega)
+  refine CodeReq.union_skip ?_ ?_
+  · exact CodeReq.singleton_miss (a := base + 4) (a' := base + 8)
+      (i := .ECALL) (by bv_omega)
+  exact CodeReq.union_hit (CodeReq.singleton_get (base + 8) _)
+
+/-- Helper: the loop CodeReq has the ADDI .x11 .x11 (-8) instruction at slot
+    `base + 12`. -/
+theorem rlp_phase4_hint_read_loop_addi_dec_get (base : Word) :
+    (CodeReq.ofProg base rlp_phase4_hint_read_loop_prog) (base + 12) =
+      some (.ADDI .x11 .x11 (-8)) := by
+  rw [rlp_phase4_hint_read_loop_code_eq_ofProg]
+  refine CodeReq.union_skip ?_ ?_
+  · exact CodeReq.singleton_miss (a := base) (a' := base + 12)
+      (i := .LI .x5 (BitVec.ofNat 64 0xF1)) (by bv_omega)
+  refine CodeReq.union_skip ?_ ?_
+  · exact CodeReq.singleton_miss (a := base + 4) (a' := base + 12)
+      (i := .ECALL) (by bv_omega)
+  refine CodeReq.union_skip ?_ ?_
+  · exact CodeReq.singleton_miss (a := base + 8) (a' := base + 12)
+      (i := .ADDI .x10 .x10 8) (by bv_omega)
+  exact CodeReq.union_hit (CodeReq.singleton_get (base + 12) _)
+
+/-- The ADDI .x10 .x10 8 spec at instruction offset 8 (third instruction)
+    of the multi-dword HINT_READ loop body, lifted to the full
+    5-instruction loop CodeReq.
+
+    Second helper toward `rlp_phase4_hint_read_loop_body_step_spec_within`
+    (beads `evm-asm-yccms`). -/
+theorem rlp_phase4_hint_read_loop_addi_advance_step_lift_spec_within
+    (base : Word) (v10 : Word) :
+    cpsTripleWithin 1 (base + 8) ((base + 8) + 4)
+      (CodeReq.ofProg base rlp_phase4_hint_read_loop_prog)
+      (.x10 ↦ᵣ v10)
+      (.x10 ↦ᵣ (v10 + signExtend12 (8 : BitVec 12))) := by
+  have h := addi_spec_gen_same_within .x10 v10 (8 : BitVec 12) (base + 8) (by nofun)
+  apply cpsTripleWithin_extend_code
+    (cr' := CodeReq.ofProg base rlp_phase4_hint_read_loop_prog)
+    (hmono := ?_) (h := h)
+  exact CodeReq.singleton_mono (rlp_phase4_hint_read_loop_addi_advance_get base)
+
+/-- The ADDI .x11 .x11 (-8) spec at instruction offset 12 (fourth
+    instruction) of the multi-dword HINT_READ loop body, lifted to the
+    full 5-instruction loop CodeReq.
+
+    Third helper toward `rlp_phase4_hint_read_loop_body_step_spec_within`
+    (beads `evm-asm-yccms`). -/
+theorem rlp_phase4_hint_read_loop_addi_dec_step_lift_spec_within
+    (base : Word) (v11 : Word) :
+    cpsTripleWithin 1 (base + 12) ((base + 12) + 4)
+      (CodeReq.ofProg base rlp_phase4_hint_read_loop_prog)
+      (.x11 ↦ᵣ v11)
+      (.x11 ↦ᵣ (v11 + signExtend12 (-8 : BitVec 12))) := by
+  have h := addi_spec_gen_same_within .x11 v11 (-8 : BitVec 12) (base + 12) (by nofun)
+  apply cpsTripleWithin_extend_code
+    (cr' := CodeReq.ofProg base rlp_phase4_hint_read_loop_prog)
+    (hmono := ?_) (h := h)
+  exact CodeReq.singleton_mono (rlp_phase4_hint_read_loop_addi_dec_get base)
 
 end EvmAsm.Rv64.RLP


### PR DESCRIPTION
Adds three step-lift `cpsTripleWithin` helpers and two `CodeReq` lookup helpers in `EvmAsm/Rv64/RLP/Phase4HintReadLoop.lean`, each lifting a single per-instruction spec onto the full 5-instruction `rlp_phase4_hint_read_loop_prog` CodeReq:

- `rlp_phase4_hint_read_loop_li_step_lift_spec_within`
- `rlp_phase4_hint_read_loop_addi_advance_step_lift_spec_within`
- `rlp_phase4_hint_read_loop_addi_dec_step_lift_spec_within`
- `rlp_phase4_hint_read_loop_addi_advance_get` / `_addi_dec_get` (CodeReq lookup helpers)

Mirrors the `hli_ext` shape used inside `rlp_phase4_hint_read_one_word_spec_within` (Phase4HintRead.lean).

These are the recommended decomposition for the eventual `rlp_phase4_hint_read_loop_body_step_spec_within` composition (beads `evm-asm-yccms`). Per the prior worker's note, splitting per-step lifts and chaining via `cpsTripleWithin_seq_perm_same_cr` × 3 is more tractable than a single 4-instr seq_perm composition. The ECALL step lift and the body-step composition follow in subsequent slices.

`lake build` green; 0 sorry; no `maxHeartbeats` / `maxRecDepth` bumps.

Refs GH #120, beads `evm-asm-yccms` (parent slice) / `evm-asm-fvoat` (multi-dword loop wrapper).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).