### PR TITLE
fix(shake-filter): rebase shake's absolute paths to local worktree

### DIFF
--- a/scripts/shake-filter.py
+++ b/scripts/shake-filter.py
@@ -170,6 +170,27 @@ def main(argv: list[str] | None = None) -> int:
         path = Path(path_str)
         if not path.is_absolute():
             path = (Path(args.root) / path_str).resolve()
+        else:
+            # shake output may carry absolute paths from a different build
+            # host (e.g. /home/yoichi-bkp/evm-asm/EvmAsm/...). Re-anchor the
+            # `EvmAsm/...` suffix under --root so marker-file reads succeed
+            # in the local worktree. `path.exists()` may raise
+            # PermissionError when traversing the foreign prefix, so guard
+            # the existence check.
+            try:
+                local_ok = path.exists()
+            except OSError:
+                local_ok = False
+            if not local_ok:
+                parts = path.parts
+                if "EvmAsm" in parts:
+                    idx = parts.index("EvmAsm")
+                    rebased = (Path(args.root).resolve()).joinpath(*parts[idx:])
+                    try:
+                        if rebased.exists():
+                            path = rebased
+                    except OSError:
+                        pass
         hits = file_markers(path)
         if hits:
             dropped += 1


### PR DESCRIPTION
scripts/shake-filter.py reads each shake-output block's header path
and checks the file body for marker tokens (xperm, runBlock,
@[spec_gen ...], custom simp attrs, …) to decide whether the block
is a known false positive. When shake emits absolute paths from a
different build host (e.g. `/home/yoichi-bkp/evm-asm/EvmAsm/...` —
the original build host whose paths leak through .olean metadata),
the script took the absolute branch unconditionally, `file_markers()`
hit OSError reading non-existent files (suppressed), and every block
was kept — the filter became a no-op.

This rebases unreadable absolute paths onto `--root` by re-anchoring
the `EvmAsm/...` suffix; permission and existence checks are guarded
against `OSError` so traversing the foreign prefix never crashes.

Verification on this worktree (b1):
- pre-fix: 210 blocks kept, 0 dropped
- post-fix: 69 kept, 141 dropped — identical result whether the input
  carries the foreign `/home/yoichi-bkp/...` prefix or already-local
  worktree paths.

No behavior change for callers that already see local paths. The
script's CLI surface is unchanged.

Refs evm-asm-nh054, evm-asm-9tq, evm-asm-6qj, evm-asm-o6y. Refs GH #1045.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).