### PR TITLE
feat(exp): exp_loop_un_marshal_and_restore_spec_within (#92)

### DIFF
--- a/EvmAsm/Evm64/Exp/LimbSpec.lean
+++ b/EvmAsm/Evm64/Exp/LimbSpec.lean
@@ -824,4 +824,123 @@ theorem exp_loop_marshal_result_to_factor2_ofProg_spec_within
   exact exp_loop_marshal_result_to_factor2_spec_within sp evmSp tOld
     r0 r1 r2 r3 d0 d1 d2 d3 base
 
+-- ============================================================================
+-- Section: exp_loop_un_marshal_and_restore (9 instructions, slice
+-- evm-asm-9vqmo — sub-slice of evm-asm-mtj3 / #92)
+-- ============================================================================
+--
+-- `exp_loop_un_marshal_and_restore` (defined in `Exp/Program.lean`) copies the
+-- four limbs of MUL's output from the LP64 result slot at `x12 + 0..+24`
+-- back into the local scratch frame at `sp + 0..+24`, then issues
+-- `ADDI .x12 .x12 (-32)` to undo the pre-call `ADDI .x12 .x12 32` pointer
+-- advance:
+--
+--     LD .x5 .x12 0  ;; SD .x2 .x5 0  ;;
+--     LD .x5 .x12 8  ;; SD .x2 .x5 8  ;;
+--     LD .x5 .x12 16 ;; SD .x2 .x5 16 ;;
+--     LD .x5 .x12 24 ;; SD .x2 .x5 24 ;;
+--     ADDI .x12 .x12 (-32)
+--
+-- Mirrors `exp_epilogue_spec_within` with the LD/SD source/destination
+-- registers swapped (factor1/result marshalling reads x2→x12; un_marshal
+-- reads x12→x2) and a negative pointer-restore offset.
+
+def exp_loop_un_marshal_and_restore_code (base : Word) : CodeReq :=
+  (CodeReq.singleton base (.LD .x5 .x12 0)).union
+    ((CodeReq.singleton (base + 4) (.SD .x2 .x5 0)).union
+      ((CodeReq.singleton (base + 8) (.LD .x5 .x12 8)).union
+        ((CodeReq.singleton (base + 12) (.SD .x2 .x5 8)).union
+          ((CodeReq.singleton (base + 16) (.LD .x5 .x12 16)).union
+            ((CodeReq.singleton (base + 20) (.SD .x2 .x5 16)).union
+              ((CodeReq.singleton (base + 24) (.LD .x5 .x12 24)).union
+                ((CodeReq.singleton (base + 28) (.SD .x2 .x5 24)).union
+                  (CodeReq.singleton (base + 32) (.ADDI .x12 .x12 (-32))))))))))
+
+theorem exp_loop_un_marshal_and_restore_code_eq_ofProg (base : Word) :
+    exp_loop_un_marshal_and_restore_code base =
+      CodeReq.ofProg base exp_loop_un_marshal_and_restore := by
+  unfold exp_loop_un_marshal_and_restore_code
+    exp_loop_un_marshal_and_restore LD SD ADDI single seq
+  change _ = CodeReq.ofProg base
+    [.LD .x5 .x12 0, .SD .x2 .x5 0, .LD .x5 .x12 8,
+     .SD .x2 .x5 8, .LD .x5 .x12 16, .SD .x2 .x5 16,
+     .LD .x5 .x12 24, .SD .x2 .x5 24, .ADDI .x12 .x12 (-32)]
+  rw [CodeReq.ofProg_cons, CodeReq.ofProg_cons, CodeReq.ofProg_cons,
+    CodeReq.ofProg_cons, CodeReq.ofProg_cons, CodeReq.ofProg_cons,
+    CodeReq.ofProg_cons, CodeReq.ofProg_cons, CodeReq.ofProg_singleton]
+  bv_addr
+
+theorem exp_loop_un_marshal_and_restore_spec_within
+    (sp evmSp tOld r0 r1 r2 r3 d0 d1 d2 d3 : Word) (base : Word) :
+    cpsTripleWithin 9 base (base + 36)
+      (exp_loop_un_marshal_and_restore_code base)
+      ((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+       ((evmSp + signExtend12 (0 : BitVec 12)) ↦ₘ d0) **
+       ((evmSp + signExtend12 (8 : BitVec 12)) ↦ₘ d1) **
+       ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ d2) **
+       ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ d3))
+      ((.x2 ↦ᵣ sp) **
+       (.x12 ↦ᵣ (evmSp + signExtend12 (-32 : BitVec 12))) **
+       (.x5 ↦ᵣ d3) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ d0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ d1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ d2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ d3) **
+       ((evmSp + signExtend12 (0 : BitVec 12)) ↦ₘ d0) **
+       ((evmSp + signExtend12 (8 : BitVec 12)) ↦ₘ d1) **
+       ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ d2) **
+       ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ d3)) := by
+  unfold exp_loop_un_marshal_and_restore_code
+  have hLd0 := ld_spec_gen_within .x5 .x12 evmSp tOld d0
+    (0 : BitVec 12) base (by decide)
+  have hSd0 := generic_sd_spec_within .x2 .x5 sp d0 r0
+    (0 : BitVec 12) (base + 4)
+  have hLd1 := ld_spec_gen_within .x5 .x12 evmSp d0 d1
+    (8 : BitVec 12) (base + 8) (by decide)
+  have hSd1 := generic_sd_spec_within .x2 .x5 sp d1 r1
+    (8 : BitVec 12) (base + 12)
+  have hLd2 := ld_spec_gen_within .x5 .x12 evmSp d1 d2
+    (16 : BitVec 12) (base + 16) (by decide)
+  have hSd2 := generic_sd_spec_within .x2 .x5 sp d2 r2
+    (16 : BitVec 12) (base + 20)
+  have hLd3 := ld_spec_gen_within .x5 .x12 evmSp d2 d3
+    (24 : BitVec 12) (base + 24) (by decide)
+  have hSd3 := generic_sd_spec_within .x2 .x5 sp d3 r3
+    (24 : BitVec 12) (base + 28)
+  have hAddSp := addi_spec_gen_same_within .x12 evmSp
+    (-32 : BitVec 12) (base + 32) (by decide)
+  runBlock hLd0 hSd0 hLd1 hSd1 hLd2 hSd2 hLd3 hSd3 hAddSp
+
+theorem exp_loop_un_marshal_and_restore_ofProg_spec_within
+    (sp evmSp tOld r0 r1 r2 r3 d0 d1 d2 d3 : Word) (base : Word) :
+    cpsTripleWithin 9 base (base + 36)
+      (CodeReq.ofProg base exp_loop_un_marshal_and_restore)
+      ((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+       ((evmSp + signExtend12 (0 : BitVec 12)) ↦ₘ d0) **
+       ((evmSp + signExtend12 (8 : BitVec 12)) ↦ₘ d1) **
+       ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ d2) **
+       ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ d3))
+      ((.x2 ↦ᵣ sp) **
+       (.x12 ↦ᵣ (evmSp + signExtend12 (-32 : BitVec 12))) **
+       (.x5 ↦ᵣ d3) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ d0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ d1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ d2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ d3) **
+       ((evmSp + signExtend12 (0 : BitVec 12)) ↦ₘ d0) **
+       ((evmSp + signExtend12 (8 : BitVec 12)) ↦ₘ d1) **
+       ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ d2) **
+       ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ d3)) := by
+  rw [← exp_loop_un_marshal_and_restore_code_eq_ofProg]
+  exact exp_loop_un_marshal_and_restore_spec_within sp evmSp tOld
+    r0 r1 r2 r3 d0 d1 d2 d3 base
+
 end EvmAsm.Evm64


### PR DESCRIPTION
Add cpsTripleWithin spec for `exp_loop_un_marshal_and_restore` (9 instr, range `base..base+36`): 4 LD/SD pairs copying the LP64 MUL output from `x12 + 0..24` back into the local scratch frame at `sp + 0..24`, plus a trailing `ADDI .x12 .x12 (-32)` that undoes the pre-call pointer advance.

Mirrors `exp_epilogue_spec_within` with LD/SD source/destination registers swapped (un_marshal reads x12 → writes x2; epilogue reads x2 → writes x12) and a negative ADDI offset.

Sub-slice of `evm-asm-mtj3` (#92 EXP slice 4 limb-level specs). Sibling of `exp_loop_marshal_factor1_spec_within` and `exp_loop_marshal_result_to_factor2_spec_within`.

- 0 sorry
- no `maxHeartbeats` / `maxRecDepth` bumps
- `lake build` green

Refs `evm-asm-9vqmo`, GH #92.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).