### PR TITLE
chore(shake): noshake Phase4HintReadLoop SyscallSpecs false-positive

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -45,7 +45,7 @@
   ["EvmAsm.Rv64.HintSpecs", "EvmAsm.Rv64.AddrNorm",
    "EvmAsm.Rv64.Tactics.RunBlock", "EvmAsm.Rv64.Tactics.XSimp"],
   "EvmAsm.Rv64.RLP.Phase4HintReadLoop":
-  ["EvmAsm.Rv64.Tactics.SeqFrame"],
+  ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.SeqFrame"],
   "EvmAsm.Rv64.RLP.Phase4HintLen":
   ["EvmAsm.Rv64.HintSpecs", "EvmAsm.Rv64.AddrNorm",
    "EvmAsm.Rv64.Tactics.XSimp"],


### PR DESCRIPTION
Shake suggested dropping `EvmAsm.Rv64.SyscallSpecs` from `EvmAsm/Rv64/RLP/Phase4HintReadLoop.lean`. Verified false positive: removing the import causes `addi_spec_gen_same_within` (looked up via the `@[spec_gen_rv64]` attribute registry — shake does not track attribute-driven references) to fail to elaborate at line 161:

```
error: Unknown identifier `addi_spec_gen_same_within`
```

Pin `SyscallSpecs` in `scripts/noshake.json` alongside the existing `SeqFrame` entry. Verified `lake build` clean and `lake exe shake EvmAsm` no longer flags this file.

Refs GH #1045, beads `evm-asm-xxxwy`.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).