### PR TITLE
chore(shake): noshake Phase4HintReadLoop HintSpecs (false positive)

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -45,7 +45,8 @@
   ["EvmAsm.Rv64.HintSpecs", "EvmAsm.Rv64.AddrNorm",
    "EvmAsm.Rv64.Tactics.RunBlock", "EvmAsm.Rv64.Tactics.XSimp"],
   "EvmAsm.Rv64.RLP.Phase4HintReadLoop":
-  ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.SeqFrame"],
+  ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.SeqFrame",
+   "EvmAsm.Rv64.HintSpecs"],
   "EvmAsm.Rv64.RLP.Phase4HintLen":
   ["EvmAsm.Rv64.HintSpecs", "EvmAsm.Rv64.AddrNorm",
    "EvmAsm.Rv64.Tactics.XSimp"],


### PR DESCRIPTION
shake reports `EvmAsm.Rv64.HintSpecs` as removable from `EvmAsm/Rv64/RLP/Phase4HintReadLoop.lean`, but the file uses `privateInputIs` and the `@[spec_gen_rv64]`-tagged `ecall_hint_read_one_word_spec_gen_within` from `HintSpecs`. Removing the import fails the build (verified locally: `Phase4HintReadLoop` errors out on `privateInputIs` / `Reg.x5 ↦ᵣ 241`).

shake does not track tactic-registry attributes such as `@[spec_gen_rv64]`; this is the same false-positive class already handled for `SyscallSpecs` / `SeqFrame` in this entry (PR #3137).

Verified locally:
- `lake build` green.
- `lake exe shake EvmAsm 2>&1 | grep Phase4HintReadLoop` no longer suggests dropping `HintSpecs`.

Refs evm-asm-eqq1o, GH #1045 (import hygiene sweep).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).