### PR TITLE
feat(mload): add framed prologue stack spec

### DIFF
--- a/EvmAsm/Evm64/ArithmeticHandlers.lean
+++ b/EvmAsm/Evm64/ArithmeticHandlers.lean
@@ -5,6 +5,8 @@
 -/
 
 import EvmAsm.Evm64.HandlerTable
+import EvmAsm.Evm64.EvmWordArith.SDiv
+import EvmAsm.Evm64.EvmWordArith.SMod
 
 namespace EvmAsm.Evm64
 namespace ArithmeticHandlers
@@ -33,14 +35,22 @@ def subHandler : OpcodeHandler :=
 def mulHandler : OpcodeHandler :=
   binaryHandler (fun a b => a * b)
 
-/-- Lookup surface for the basic arithmetic handlers proved so far. -/
+def sdivHandler : OpcodeHandler :=
+  binaryHandler EvmWord.sdiv
+
+def smodHandler : OpcodeHandler :=
+  binaryHandler EvmWord.smod
+
+/-- Lookup surface for the arithmetic handlers proved so far. -/
 def arithmeticHandler? : EvmOpcode → Option OpcodeHandler
   | .ADD => some addHandler
   | .SUB => some subHandler
   | .MUL => some mulHandler
+  | .SDIV => some sdivHandler
+  | .SMOD => some smodHandler
   | _ => none
 
-/-- Handler table containing ADD/SUB/MUL entries.
+/-- Handler table containing currently supported arithmetic entries.
     Distinctive token: ArithmeticHandlers.arithmeticHandlerTable #107. -/
 def arithmeticHandlerTable : HandlerTable :=
   arithmeticHandler?
@@ -116,6 +126,16 @@ theorem binaryHandler_status_of_binaryStack?_none
     (mulHandler { state with stack := a :: b :: rest }).stack =
       (a * b) :: rest := rfl
 
+@[simp] theorem sdivHandler_stack
+    (a b : EvmWord) (rest : List EvmWord) (state : EvmState) :
+    (sdivHandler { state with stack := a :: b :: rest }).stack =
+      EvmWord.sdiv a b :: rest := rfl
+
+@[simp] theorem smodHandler_stack
+    (a b : EvmWord) (rest : List EvmWord) (state : EvmState) :
+    (smodHandler { state with stack := a :: b :: rest }).stack =
+      EvmWord.smod a b :: rest := rfl
+
 @[simp] theorem arithmeticHandlerTable_eq :
     arithmeticHandlerTable = arithmeticHandler? := rfl
 
@@ -127,6 +147,12 @@ theorem binaryHandler_status_of_binaryStack?_none
 
 @[simp] theorem arithmeticHandler?_MUL :
     arithmeticHandler? .MUL = some mulHandler := rfl
+
+@[simp] theorem arithmeticHandler?_SDIV :
+    arithmeticHandler? .SDIV = some sdivHandler := rfl
+
+@[simp] theorem arithmeticHandler?_SMOD :
+    arithmeticHandler? .SMOD = some smodHandler := rfl
 
 @[simp] theorem eq_addHandler_iff (handler : OpcodeHandler) :
     addHandler = handler ↔ handler = addHandler := by
@@ -140,18 +166,29 @@ theorem binaryHandler_status_of_binaryStack?_none
     mulHandler = handler ↔ handler = mulHandler := by
   constructor <;> intro h_eq <;> exact h_eq.symm
 
+@[simp] theorem eq_sdivHandler_iff (handler : OpcodeHandler) :
+    sdivHandler = handler ↔ handler = sdivHandler := by
+  constructor <;> intro h_eq <;> exact h_eq.symm
+
+@[simp] theorem eq_smodHandler_iff (handler : OpcodeHandler) :
+    smodHandler = handler ↔ handler = smodHandler := by
+  constructor <;> intro h_eq <;> exact h_eq.symm
+
 theorem arithmeticHandler?_eq_some_iff
     (opcode : EvmOpcode) (handler : OpcodeHandler) :
     arithmeticHandler? opcode = some handler ↔
       (opcode = .ADD ∧ handler = addHandler) ∨
         (opcode = .SUB ∧ handler = subHandler) ∨
-          (opcode = .MUL ∧ handler = mulHandler) := by
+          (opcode = .MUL ∧ handler = mulHandler) ∨
+            (opcode = .SDIV ∧ handler = sdivHandler) ∨
+              (opcode = .SMOD ∧ handler = smodHandler) := by
   cases opcode <;> simp [arithmeticHandler?]
 
 theorem arithmeticHandler?_eq_none_iff
     (opcode : EvmOpcode) :
     arithmeticHandler? opcode = none ↔
-      opcode ≠ .ADD ∧ opcode ≠ .SUB ∧ opcode ≠ .MUL := by
+      opcode ≠ .ADD ∧ opcode ≠ .SUB ∧ opcode ≠ .MUL ∧
+        opcode ≠ .SDIV ∧ opcode ≠ .SMOD := by
   cases opcode <;> simp [arithmeticHandler?]
 
 theorem dispatchOpcode?_arithmeticHandlerTable_ADD
@@ -172,6 +209,18 @@ theorem dispatchOpcode?_arithmeticHandlerTable_MUL
       some (mulHandler state) := by
   exact HandlerTable.dispatchOpcode?_some arithmeticHandler?_MUL state
 
+theorem dispatchOpcode?_arithmeticHandlerTable_SDIV
+    (state : EvmState) :
+    HandlerTable.dispatchOpcode? arithmeticHandlerTable .SDIV state =
+      some (sdivHandler state) := by
+  exact HandlerTable.dispatchOpcode?_some arithmeticHandler?_SDIV state
+
+theorem dispatchOpcode?_arithmeticHandlerTable_SMOD
+    (state : EvmState) :
+    HandlerTable.dispatchOpcode? arithmeticHandlerTable .SMOD state =
+      some (smodHandler state) := by
+  exact HandlerTable.dispatchOpcode?_some arithmeticHandler?_SMOD state
+
 theorem dispatchOpcode_arithmeticHandlerTable_ADD
     (state : EvmState) :
     HandlerTable.dispatchOpcode arithmeticHandlerTable .ADD state =
@@ -189,6 +238,18 @@ theorem dispatchOpcode_arithmeticHandlerTable_MUL
     HandlerTable.dispatchOpcode arithmeticHandlerTable .MUL state =
       mulHandler state := by
   exact HandlerTable.dispatchOpcode_some arithmeticHandler?_MUL state
+
+theorem dispatchOpcode_arithmeticHandlerTable_SDIV
+    (state : EvmState) :
+    HandlerTable.dispatchOpcode arithmeticHandlerTable .SDIV state =
+      sdivHandler state := by
+  exact HandlerTable.dispatchOpcode_some arithmeticHandler?_SDIV state
+
+theorem dispatchOpcode_arithmeticHandlerTable_SMOD
+    (state : EvmState) :
+    HandlerTable.dispatchOpcode arithmeticHandlerTable .SMOD state =
+      smodHandler state := by
+  exact HandlerTable.dispatchOpcode_some arithmeticHandler?_SMOD state
 
 theorem dispatchOpcode_arithmeticHandlerTable_ADD_status_of_some
     {state : EvmState} {stack' : List EvmWord}
@@ -213,6 +274,22 @@ theorem dispatchOpcode_arithmeticHandlerTable_MUL_status_of_some
       state.status := by
   rw [dispatchOpcode_arithmeticHandlerTable_MUL state]
   simp [mulHandler, binaryHandler, h_stack, EvmState.withStack]
+
+theorem dispatchOpcode_arithmeticHandlerTable_SDIV_status_of_some
+    {state : EvmState} {stack' : List EvmWord}
+    (h_stack : binaryStack? EvmWord.sdiv state.stack = some stack') :
+    (HandlerTable.dispatchOpcode arithmeticHandlerTable .SDIV state).status =
+      state.status := by
+  rw [dispatchOpcode_arithmeticHandlerTable_SDIV state]
+  simp [sdivHandler, binaryHandler, h_stack, EvmState.withStack]
+
+theorem dispatchOpcode_arithmeticHandlerTable_SMOD_status_of_some
+    {state : EvmState} {stack' : List EvmWord}
+    (h_stack : binaryStack? EvmWord.smod state.stack = some stack') :
+    (HandlerTable.dispatchOpcode arithmeticHandlerTable .SMOD state).status =
+      state.status := by
+  rw [dispatchOpcode_arithmeticHandlerTable_SMOD state]
+  simp [smodHandler, binaryHandler, h_stack, EvmState.withStack]
 
 end ArithmeticHandlers
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Dispatch.lean
+++ b/EvmAsm/Evm64/Dispatch.lean
@@ -22,7 +22,9 @@ def decodeByte? : Nat → Option EvmOpcode
   | 0x02 => some MUL
   | 0x03 => some SUB
   | 0x04 => some DIV
+  | 0x05 => some SDIV
   | 0x06 => some MOD
+  | 0x07 => some SMOD
   | 0x0a => some EXP
   | 0x0b => some SIGNEXTEND
   | 0x10 => some LT
@@ -318,8 +320,12 @@ theorem byte?_roundtrip_SUB :
     byte? SUB = some 0x03 ∧ decodeByte? 0x03 = some SUB := ⟨rfl, rfl⟩
 theorem byte?_roundtrip_DIV :
     byte? DIV = some 0x04 ∧ decodeByte? 0x04 = some DIV := ⟨rfl, rfl⟩
+theorem byte?_roundtrip_SDIV :
+    byte? SDIV = some 0x05 ∧ decodeByte? 0x05 = some SDIV := ⟨rfl, rfl⟩
 theorem byte?_roundtrip_MOD :
     byte? MOD = some 0x06 ∧ decodeByte? 0x06 = some MOD := ⟨rfl, rfl⟩
+theorem byte?_roundtrip_SMOD :
+    byte? SMOD = some 0x07 ∧ decodeByte? 0x07 = some SMOD := ⟨rfl, rfl⟩
 theorem byte?_roundtrip_EXP :
     byte? EXP = some 0x0a ∧ decodeByte? 0x0a = some EXP := ⟨rfl, rfl⟩
 theorem byte?_roundtrip_SIGNEXTEND :

--- a/EvmAsm/Evm64/EvmWordArith/SDiv.lean
+++ b/EvmAsm/Evm64/EvmWordArith/SDiv.lean
@@ -61,6 +61,13 @@ theorem sdiv_intMin_neg_one : sdiv (BitVec.intMin 256) (-1) = BitVec.intMin 256 
   have h : (-1 : BitVec 256) = -1#256 := by decide
   rw [h, BitVec.intMin_sdiv_neg_one]
 
+-- Closed truncation examples used by the opcode-level edge-case suite.
+theorem sdiv_neg_one_two : sdiv (-1 : EvmWord) 2 = 0 := by
+  native_decide
+
+theorem sdiv_pos_neg_trunc : sdiv (7 : EvmWord) (-2) = (-3 : EvmWord) := by
+  native_decide
+
 -- ============================================================================
 -- Correctness vs `Int.tdiv` (the spec formula)
 -- ============================================================================

--- a/EvmAsm/Evm64/EvmWordArith/SMod.lean
+++ b/EvmAsm/Evm64/EvmWordArith/SMod.lean
@@ -56,6 +56,16 @@ theorem zero_smod_left {b : EvmWord} : smod 0 b = 0 := by
   · rfl
   · simp [BitVec.zero_srem]
 
+-- Closed sign-of-dividend examples used by the opcode-level edge-case suite.
+theorem smod_neg_pos_sign : smod (-3 : EvmWord) 2 = (-1 : EvmWord) := by
+  native_decide
+
+theorem smod_pos_neg_sign : smod (3 : EvmWord) (-2) = (1 : EvmWord) := by
+  native_decide
+
+theorem smod_neg_neg_sign : smod (-3 : EvmWord) (-2) = (-1 : EvmWord) := by
+  native_decide
+
 -- ============================================================================
 -- Correctness vs `Int.tmod` (the spec formula)
 -- ============================================================================

--- a/EvmAsm/Evm64/ExecutableSpecOpcodeBridge.lean
+++ b/EvmAsm/Evm64/ExecutableSpecOpcodeBridge.lean
@@ -18,6 +18,8 @@ namespace ExecutableSpecOpcodeBridge
 namespace Ops
 
 def STOP : Nat := 0x00
+def SDIV : Nat := 0x05
+def SMOD : Nat := 0x07
 def KECCAK : Nat := 0x20
 def CALLDATALOAD : Nat := 0x35
 def CALLDATASIZE : Nat := 0x36
@@ -172,6 +174,16 @@ theorem roundtrip_execSpec_STOP :
 theorem roundtrip_execSpec_KECCAK :
     EvmOpcode.byte? EvmOpcode.KECCAK256 = some Ops.KECCAK ∧
       EvmOpcode.decodeByte? Ops.KECCAK = some EvmOpcode.KECCAK256 := by
+  exact ⟨rfl, rfl⟩
+
+theorem roundtrip_execSpec_SDIV :
+    EvmOpcode.byte? EvmOpcode.SDIV = some Ops.SDIV ∧
+      EvmOpcode.decodeByte? Ops.SDIV = some EvmOpcode.SDIV := by
+  exact ⟨rfl, rfl⟩
+
+theorem roundtrip_execSpec_SMOD :
+    EvmOpcode.byte? EvmOpcode.SMOD = some Ops.SMOD ∧
+      EvmOpcode.decodeByte? Ops.SMOD = some EvmOpcode.SMOD := by
   exact ⟨rfl, rfl⟩
 
 /-- Distinctive token:

--- a/EvmAsm/Evm64/Exp/Args.lean
+++ b/EvmAsm/Evm64/Exp/Args.lean
@@ -85,6 +85,15 @@ theorem expResultFromArgs_zero_right (base : EvmWord) :
     expResultFromArgs (expArgs base 0) = 1 := by
   exact EvmWord.exp_zero_right base
 
+theorem expResultFromArgs_one_left (exponent : EvmWord) :
+    expResultFromArgs (expArgs 1 exponent) = 1 := by
+  exact EvmWord.exp_one_left exponent
+
+theorem expResultFromArgs_zero_left_of_ne_zero (exponent : EvmWord)
+    (h : exponent ≠ 0) :
+    expResultFromArgs (expArgs 0 exponent) = 0 := by
+  exact EvmWord.exp_zero_left_of_ne_zero exponent h
+
 theorem expResultFromArgs_one_right (base : EvmWord) :
     expResultFromArgs (expArgs base 1) = base := by
   exact EvmWord.exp_one_right base
@@ -100,6 +109,16 @@ theorem expResultFromArgs_two_256 :
 theorem expTotalGasFromArgs_zero_exponent (base : EvmWord) :
     expTotalGasFromArgs (expArgs base 0) = 10 := by
   exact ExpGas.expTotalGasFromExponent_zero
+
+theorem expDynamicCostFromArgs_256_exponent (base : EvmWord) :
+    expDynamicCostFromArgs (expArgs base 256) = 100 := by
+  simp only [expDynamicCostFromArgs, expArgs, ExpGas.expDynamicCostFromExponent,
+    ExpGas.expGasPerByte, ExpGas.exponentByteLength]
+  native_decide
+
+theorem expTotalGasFromArgs_256_exponent (base : EvmWord) :
+    expTotalGasFromArgs (expArgs base 256) = 110 := by
+  exact ExpGas.expTotalGasFromExponent_256
 
 end ExpArgs
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Exp/Args.lean
+++ b/EvmAsm/Evm64/Exp/Args.lean
@@ -120,5 +120,13 @@ theorem expTotalGasFromArgs_256_exponent (base : EvmWord) :
     expTotalGasFromArgs (expArgs base 256) = 110 := by
   exact ExpGas.expTotalGasFromExponent_256
 
+theorem expDynamicCostFromArgs_max_exponent (base : EvmWord) :
+    expDynamicCostFromArgs (expArgs base (-1)) = 1600 := by
+  exact ExpGas.expDynamicCostFromExponent_max
+
+theorem expTotalGasFromArgs_max_exponent (base : EvmWord) :
+    expTotalGasFromArgs (expArgs base (-1)) = 1610 := by
+  exact ExpGas.expTotalGasFromExponent_max
+
 end ExpArgs
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Exp/Gas.lean
+++ b/EvmAsm/Evm64/Exp/Gas.lean
@@ -72,6 +72,9 @@ theorem exponentByteLength_256 : exponentByteLength (256 : EvmWord) = 2 := by
   unfold exponentByteLength
   native_decide
 
+theorem exponentByteLength_max : exponentByteLength (-1 : EvmWord) = 32 := by
+  native_decide
+
 theorem expDynamicCostFromExponent_zero :
     expDynamicCostFromExponent (0 : EvmWord) = 0 := by
   unfold expDynamicCostFromExponent expGasPerByte
@@ -100,6 +103,17 @@ theorem expTotalGasFromExponent_256 :
     expTotalGasFromExponent (256 : EvmWord) = 110 := by
   unfold expTotalGasFromExponent expDynamicCostFromExponent expGasPerByte
   rw [exponentByteLength_256]
+  rfl
+
+theorem expDynamicCostFromExponent_max :
+    expDynamicCostFromExponent (-1 : EvmWord) = 1600 := by
+  unfold expDynamicCostFromExponent expGasPerByte
+  rw [exponentByteLength_max]
+
+theorem expTotalGasFromExponent_max :
+    expTotalGasFromExponent (-1 : EvmWord) = 1610 := by
+  unfold expTotalGasFromExponent
+  rw [expDynamicCostFromExponent_max]
   rfl
 
 end EvmAsm.Evm64.ExpGas

--- a/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
+++ b/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
@@ -228,6 +228,18 @@ theorem runExpStack?_max_exponent_gas
   rw [ExpArgs.expDynamicCostFromArgs_max_exponent]
   rw [ExpArgs.expTotalGasFromArgs_max_exponent]
 
+theorem runExpStack?_zero_max_exponent
+    (rest : List EvmWord) :
+    runExpStack? { stack := (0 : EvmWord) :: (-1 : EvmWord) :: rest } =
+      some
+        { effects := { stackWords := [0], dynamicGas := 1600, totalGas := 1610 }
+          stack := rest } := by
+  rw [runExpStack?_cons]
+  rw [ExpArgs.expResultFromArgs_zero_left_of_ne_zero]
+  rw [ExpArgs.expDynamicCostFromArgs_max_exponent]
+  rw [ExpArgs.expTotalGasFromArgs_max_exponent]
+  decide
+
 end ExpStackExecutionBridge
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
+++ b/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
@@ -219,6 +219,15 @@ theorem runExpStack?_two_256
   rw [ExpArgs.expDynamicCostFromArgs_256_exponent]
   rw [ExpArgs.expTotalGasFromArgs_256_exponent]
 
+theorem runExpStack?_max_exponent_gas
+    (base : EvmWord) (rest : List EvmWord) :
+    (runExpStack? { stack := base :: (-1 : EvmWord) :: rest }).map
+      (fun out => (out.effects.dynamicGas, out.effects.totalGas)) =
+      some (1600, 1610) := by
+  rw [runExpStack?_gas]
+  rw [ExpArgs.expDynamicCostFromArgs_max_exponent]
+  rw [ExpArgs.expTotalGasFromArgs_max_exponent]
+
 end ExpStackExecutionBridge
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
+++ b/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
@@ -197,6 +197,28 @@ theorem runExpStack?_gas
         ( ExpArgs.expDynamicCostFromArgs (ExpArgs.expArgs base exponent)
         , ExpArgs.expTotalGasFromArgs (ExpArgs.expArgs base exponent)) := rfl
 
+theorem runExpStack?_zero_exponent
+    (base : EvmWord) (rest : List EvmWord) :
+    runExpStack? { stack := base :: 0 :: rest } =
+      some
+        { effects := { stackWords := [1], dynamicGas := 0, totalGas := 10 }
+          stack := rest } := by
+  rw [runExpStack?_cons]
+  rw [ExpArgs.expResultFromArgs_zero_right]
+  rw [ExpArgs.expDynamicCostFromArgs_zero_exponent]
+  rw [ExpArgs.expTotalGasFromArgs_zero_exponent]
+
+theorem runExpStack?_two_256
+    (rest : List EvmWord) :
+    runExpStack? { stack := (2 : EvmWord) :: 256 :: rest } =
+      some
+        { effects := { stackWords := [0], dynamicGas := 100, totalGas := 110 }
+          stack := rest } := by
+  rw [runExpStack?_cons]
+  rw [ExpArgs.expResultFromArgs_two_256]
+  rw [ExpArgs.expDynamicCostFromArgs_256_exponent]
+  rw [ExpArgs.expTotalGasFromArgs_256_exponent]
+
 end ExpStackExecutionBridge
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Gas.lean
+++ b/EvmAsm/Evm64/Gas.lean
@@ -24,7 +24,9 @@ inductive EvmOpcode where
   | MUL
   | SUB
   | DIV
+  | SDIV
   | MOD
+  | SMOD
   | EXP
   | SIGNEXTEND
   | KECCAK256
@@ -114,7 +116,9 @@ def byte? : EvmOpcode → Option Nat
   | MUL => some 0x02
   | SUB => some 0x03
   | DIV => some 0x04
+  | SDIV => some 0x05
   | MOD => some 0x06
+  | SMOD => some 0x07
   | EXP => some 0x0a
   | SIGNEXTEND => some 0x0b
   | KECCAK256 => some 0x20
@@ -188,7 +192,9 @@ def staticGasCost : EvmOpcode → Nat
   | MUL => 5
   | SUB => 3
   | DIV => 5
+  | SDIV => 5
   | MOD => 5
+  | SMOD => 5
   | EXP => 10
   | SIGNEXTEND => 5
   | KECCAK256 => 30

--- a/EvmAsm/Evm64/InterpreterExecutableFetchBridge.lean
+++ b/EvmAsm/Evm64/InterpreterExecutableFetchBridge.lean
@@ -130,6 +130,46 @@ theorem stepWithHandler_of_execSpecLogByte
   exact InterpreterLoop.stepWithHandler_of_decode handler
     (decodeCurrentOpcode?_of_execSpecLogByte kind h_pc h_code)
 
+theorem decodeCurrentOpcode?_of_execSpec_SDIV
+    {state : EvmState}
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] = (ExecutableSpecOpcodeBridge.Ops.SDIV : BitVec 8)) :
+    InterpreterLoop.decodeCurrentOpcode? state = some EvmOpcode.SDIV := by
+  exact decodeCurrentOpcode?_of_execSpecByte h_pc h_code (by
+    simp [ExecutableSpecOpcodeBridge.Ops.SDIV, EvmOpcode.decodeByte?])
+
+theorem stepWithHandler_of_execSpec_SDIV
+    (handler : InterpreterLoop.Handler)
+    {state : EvmState}
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] = (ExecutableSpecOpcodeBridge.Ops.SDIV : BitVec 8)) :
+    InterpreterLoop.stepWithHandler handler state =
+      handler EvmOpcode.SDIV state := by
+  exact InterpreterLoop.stepWithHandler_of_decode handler
+    (decodeCurrentOpcode?_of_execSpec_SDIV h_pc h_code)
+
+theorem decodeCurrentOpcode?_of_execSpec_SMOD
+    {state : EvmState}
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] = (ExecutableSpecOpcodeBridge.Ops.SMOD : BitVec 8)) :
+    InterpreterLoop.decodeCurrentOpcode? state = some EvmOpcode.SMOD := by
+  exact decodeCurrentOpcode?_of_execSpecByte h_pc h_code (by
+    simp [ExecutableSpecOpcodeBridge.Ops.SMOD, EvmOpcode.decodeByte?])
+
+theorem stepWithHandler_of_execSpec_SMOD
+    (handler : InterpreterLoop.Handler)
+    {state : EvmState}
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] = (ExecutableSpecOpcodeBridge.Ops.SMOD : BitVec 8)) :
+    InterpreterLoop.stepWithHandler handler state =
+      handler EvmOpcode.SMOD state := by
+  exact InterpreterLoop.stepWithHandler_of_decode handler
+    (decodeCurrentOpcode?_of_execSpec_SMOD h_pc h_code)
+
 theorem decodeCurrentOpcode?_of_execSpec_CALL
     {state : EvmState}
     (h_pc : state.pc < state.code.length)

--- a/EvmAsm/Evm64/InterpreterExecutableStepBridge.lean
+++ b/EvmAsm/Evm64/InterpreterExecutableStepBridge.lean
@@ -190,6 +190,44 @@ theorem loopFuel_one_supported_execSpec_SMOD_stack_of_runSModStack?_some
   exact SModStackExecutionBridge.smodHandler_stack_of_runSModStack?_some
     h_run
 
+theorem loopFuel_one_supported_execSpec_SDIV_status_of_none
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SDIV : BitVec 8))
+    (h_run :
+      SDivStackExecutionBridge.runSDivStack? { stack := state.stack } = none) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      state).status = .error := by
+  rw [loopFuel_one_of_execSpec_SDIV SupportedLoopBridge.supportedLoopHandler
+    h_status h_pc h_code]
+  rw [SupportedLoopBridge.supportedLoopHandler_apply]
+  rw [SupportedHandlers.dispatchOpcode_of_lookup
+    SupportedHandlers.supportedHandlerTable_SDIV]
+  exact SDivStackExecutionBridge.sdivHandler_status_of_runSDivStack?_none
+    h_run
+
+theorem loopFuel_one_supported_execSpec_SMOD_status_of_none
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SMOD : BitVec 8))
+    (h_run :
+      SModStackExecutionBridge.runSModStack? { stack := state.stack } = none) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      state).status = .error := by
+  rw [loopFuel_one_of_execSpec_SMOD SupportedLoopBridge.supportedLoopHandler
+    h_status h_pc h_code]
+  rw [SupportedLoopBridge.supportedLoopHandler_apply]
+  rw [SupportedHandlers.dispatchOpcode_of_lookup
+    SupportedHandlers.supportedHandlerTable_SMOD]
+  exact SModStackExecutionBridge.smodHandler_status_of_runSModStack?_none
+    h_run
+
 theorem loopFuel_one_supported_execSpec_SDIV_stack_zero_divisor
     {state : EvmState} (dividend : EvmWord) (rest : List EvmWord)
     (h_status : state.status = .running)

--- a/EvmAsm/Evm64/InterpreterExecutableStepBridge.lean
+++ b/EvmAsm/Evm64/InterpreterExecutableStepBridge.lean
@@ -258,6 +258,106 @@ theorem loopFuel_one_supported_execSpec_SMOD_status_of_none
   exact SModStackExecutionBridge.smodHandler_status_of_runSModStack?_none
     h_run
 
+theorem loopFuel_one_supported_execSpec_SDIV_status_empty_stack
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SDIV : BitVec 8)) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      { state with stack := [] }).status = .error := by
+  have h_status' :
+      ({ state with stack := [] } : EvmState).status = .running := by
+    simpa using h_status
+  have h_pc' :
+      ({ state with stack := [] } : EvmState).pc <
+        ({ state with stack := [] } : EvmState).code.length := by
+    simpa using h_pc
+  have h_code' :
+      ({ state with stack := [] } : EvmState).code[
+        ({ state with stack := [] } : EvmState).pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SDIV : BitVec 8) := by
+    simpa using h_code
+  rw [loopFuel_one_supported_execSpec_SDIV h_status' h_pc' h_code']
+  exact SDivStackExecutionBridge.sdivHandler_status_empty_stack state
+
+theorem loopFuel_one_supported_execSpec_SDIV_status_singleton_stack
+    {state : EvmState} (dividend : EvmWord)
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SDIV : BitVec 8)) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      { state with stack := [dividend] }).status = .error := by
+  have h_status' :
+      ({ state with stack := [dividend] } : EvmState).status =
+        .running := by
+    simpa using h_status
+  have h_pc' :
+      ({ state with stack := [dividend] } : EvmState).pc <
+        ({ state with stack := [dividend] } : EvmState).code.length := by
+    simpa using h_pc
+  have h_code' :
+      ({ state with stack := [dividend] } : EvmState).code[
+        ({ state with stack := [dividend] } : EvmState).pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SDIV : BitVec 8) := by
+    simpa using h_code
+  rw [loopFuel_one_supported_execSpec_SDIV h_status' h_pc' h_code']
+  exact SDivStackExecutionBridge.sdivHandler_status_singleton_stack
+    state dividend
+
+theorem loopFuel_one_supported_execSpec_SMOD_status_empty_stack
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SMOD : BitVec 8)) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      { state with stack := [] }).status = .error := by
+  have h_status' :
+      ({ state with stack := [] } : EvmState).status = .running := by
+    simpa using h_status
+  have h_pc' :
+      ({ state with stack := [] } : EvmState).pc <
+        ({ state with stack := [] } : EvmState).code.length := by
+    simpa using h_pc
+  have h_code' :
+      ({ state with stack := [] } : EvmState).code[
+        ({ state with stack := [] } : EvmState).pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SMOD : BitVec 8) := by
+    simpa using h_code
+  rw [loopFuel_one_supported_execSpec_SMOD h_status' h_pc' h_code']
+  exact SModStackExecutionBridge.smodHandler_status_empty_stack state
+
+theorem loopFuel_one_supported_execSpec_SMOD_status_singleton_stack
+    {state : EvmState} (dividend : EvmWord)
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SMOD : BitVec 8)) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      { state with stack := [dividend] }).status = .error := by
+  have h_status' :
+      ({ state with stack := [dividend] } : EvmState).status =
+        .running := by
+    simpa using h_status
+  have h_pc' :
+      ({ state with stack := [dividend] } : EvmState).pc <
+        ({ state with stack := [dividend] } : EvmState).code.length := by
+    simpa using h_pc
+  have h_code' :
+      ({ state with stack := [dividend] } : EvmState).code[
+        ({ state with stack := [dividend] } : EvmState).pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SMOD : BitVec 8) := by
+    simpa using h_code
+  rw [loopFuel_one_supported_execSpec_SMOD h_status' h_pc' h_code']
+  exact SModStackExecutionBridge.smodHandler_status_singleton_stack
+    state dividend
+
 theorem loopFuel_one_supported_execSpec_SDIV_stack_zero_divisor
     {state : EvmState} (dividend : EvmWord) (rest : List EvmWord)
     (h_status : state.status = .running)

--- a/EvmAsm/Evm64/InterpreterExecutableStepBridge.lean
+++ b/EvmAsm/Evm64/InterpreterExecutableStepBridge.lean
@@ -112,6 +112,36 @@ theorem loopFuel_one_of_execSpec_SMOD
   exact InterpreterExecutableFetchBridge.stepWithHandler_of_execSpec_SMOD
     handler h_pc h_code
 
+theorem loopFuel_one_supported_execSpec_SDIV
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SDIV : BitVec 8)) :
+    InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1 state =
+      ArithmeticHandlers.sdivHandler state := by
+  rw [loopFuel_one_of_execSpec_SDIV SupportedLoopBridge.supportedLoopHandler
+    h_status h_pc h_code]
+  rw [SupportedLoopBridge.supportedLoopHandler_apply]
+  exact SupportedHandlers.dispatchOpcode_of_lookup
+    SupportedHandlers.supportedHandlerTable_SDIV state
+
+theorem loopFuel_one_supported_execSpec_SMOD
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SMOD : BitVec 8)) :
+    InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1 state =
+      ArithmeticHandlers.smodHandler state := by
+  rw [loopFuel_one_of_execSpec_SMOD SupportedLoopBridge.supportedLoopHandler
+    h_status h_pc h_code]
+  rw [SupportedLoopBridge.supportedLoopHandler_apply]
+  exact SupportedHandlers.dispatchOpcode_of_lookup
+    SupportedHandlers.supportedHandlerTable_SMOD state
+
 theorem loopFuel_one_supported_execSpec_SDIV_status_of_some
     {state : EvmState} {stack' : List EvmWord}
     (h_status : state.status = .running)

--- a/EvmAsm/Evm64/InterpreterExecutableStepBridge.lean
+++ b/EvmAsm/Evm64/InterpreterExecutableStepBridge.lean
@@ -262,6 +262,32 @@ theorem loopFuel_one_supported_execSpec_SMOD_env
   rw [loopFuel_one_supported_execSpec_SMOD h_status h_pc h_code]
   exact SModStackExecutionBridge.smodHandler_env state
 
+theorem loopFuel_one_supported_execSpec_SDIV_codeLenMatches
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SDIV : BitVec 8))
+    (h_codeLen : state.codeLenMatches) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      state).codeLenMatches := by
+  rw [loopFuel_one_supported_execSpec_SDIV h_status h_pc h_code]
+  exact SDivStackExecutionBridge.sdivHandler_codeLenMatches state h_codeLen
+
+theorem loopFuel_one_supported_execSpec_SMOD_codeLenMatches
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SMOD : BitVec 8))
+    (h_codeLen : state.codeLenMatches) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      state).codeLenMatches := by
+  rw [loopFuel_one_supported_execSpec_SMOD h_status h_pc h_code]
+  exact SModStackExecutionBridge.smodHandler_codeLenMatches state h_codeLen
+
 theorem loopFuel_one_supported_execSpec_SDIV_memoryCells
     {state : EvmState}
     (h_status : state.status = .running)

--- a/EvmAsm/Evm64/InterpreterExecutableStepBridge.lean
+++ b/EvmAsm/Evm64/InterpreterExecutableStepBridge.lean
@@ -142,6 +142,30 @@ theorem loopFuel_one_supported_execSpec_SMOD
   exact SupportedHandlers.dispatchOpcode_of_lookup
     SupportedHandlers.supportedHandlerTable_SMOD state
 
+theorem loopFuel_one_supported_execSpec_SDIV_pc
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SDIV : BitVec 8)) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      state).pc = state.pc := by
+  rw [loopFuel_one_supported_execSpec_SDIV h_status h_pc h_code]
+  exact SDivStackExecutionBridge.sdivHandler_pc state
+
+theorem loopFuel_one_supported_execSpec_SMOD_pc
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SMOD : BitVec 8)) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      state).pc = state.pc := by
+  rw [loopFuel_one_supported_execSpec_SMOD h_status h_pc h_code]
+  exact SModStackExecutionBridge.smodHandler_pc state
+
 theorem loopFuel_one_supported_execSpec_SDIV_status_of_some
     {state : EvmState} {stack' : List EvmWord}
     (h_status : state.status = .running)

--- a/EvmAsm/Evm64/InterpreterExecutableStepBridge.lean
+++ b/EvmAsm/Evm64/InterpreterExecutableStepBridge.lean
@@ -220,6 +220,38 @@ theorem loopFuel_one_supported_execSpec_SMOD_stack_of_runSModStack?_some
   exact SModStackExecutionBridge.smodHandler_stack_of_runSModStack?_some
     h_run
 
+theorem loopFuel_one_supported_execSpec_SDIV_status_of_runSDivStack?_some
+    {state : EvmState} {out : SDivStackExecutionBridge.SDivStackResult}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SDIV : BitVec 8))
+    (h_run :
+      SDivStackExecutionBridge.runSDivStack? { stack := state.stack } =
+        some out) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      state).status = state.status := by
+  rw [loopFuel_one_supported_execSpec_SDIV h_status h_pc h_code]
+  exact SDivStackExecutionBridge.sdivHandler_status_of_runSDivStack?_some
+    h_run
+
+theorem loopFuel_one_supported_execSpec_SMOD_status_of_runSModStack?_some
+    {state : EvmState} {out : SModStackExecutionBridge.SModStackResult}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SMOD : BitVec 8))
+    (h_run :
+      SModStackExecutionBridge.runSModStack? { stack := state.stack } =
+        some out) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      state).status = state.status := by
+  rw [loopFuel_one_supported_execSpec_SMOD h_status h_pc h_code]
+  exact SModStackExecutionBridge.smodHandler_status_of_runSModStack?_some
+    h_run
+
 theorem loopFuel_one_supported_execSpec_SDIV_status_of_none
     {state : EvmState}
     (h_status : state.status = .running)

--- a/EvmAsm/Evm64/InterpreterExecutableStepBridge.lean
+++ b/EvmAsm/Evm64/InterpreterExecutableStepBridge.lean
@@ -166,6 +166,30 @@ theorem loopFuel_one_supported_execSpec_SMOD_pc
   rw [loopFuel_one_supported_execSpec_SMOD h_status h_pc h_code]
   exact SModStackExecutionBridge.smodHandler_pc state
 
+theorem loopFuel_one_supported_execSpec_SDIV_gas
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SDIV : BitVec 8)) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      state).gas = state.gas := by
+  rw [loopFuel_one_supported_execSpec_SDIV h_status h_pc h_code]
+  exact SDivStackExecutionBridge.sdivHandler_gas state
+
+theorem loopFuel_one_supported_execSpec_SMOD_gas
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SMOD : BitVec 8)) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      state).gas = state.gas := by
+  rw [loopFuel_one_supported_execSpec_SMOD h_status h_pc h_code]
+  exact SModStackExecutionBridge.smodHandler_gas state
+
 theorem loopFuel_one_supported_execSpec_SDIV_status_of_some
     {state : EvmState} {stack' : List EvmWord}
     (h_status : state.status = .running)

--- a/EvmAsm/Evm64/InterpreterExecutableStepBridge.lean
+++ b/EvmAsm/Evm64/InterpreterExecutableStepBridge.lean
@@ -150,6 +150,46 @@ theorem loopFuel_one_supported_execSpec_SMOD_status_of_some
   simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler,
     h_stack, EvmState.withStack]
 
+theorem loopFuel_one_supported_execSpec_SDIV_stack_of_runSDivStack?_some
+    {state : EvmState} {out : SDivStackExecutionBridge.SDivStackResult}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SDIV : BitVec 8))
+    (h_run :
+      SDivStackExecutionBridge.runSDivStack? { stack := state.stack } =
+        some out) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      state).stack = out.effects.stackWords ++ out.stack := by
+  rw [loopFuel_one_of_execSpec_SDIV SupportedLoopBridge.supportedLoopHandler
+    h_status h_pc h_code]
+  rw [SupportedLoopBridge.supportedLoopHandler_apply]
+  rw [SupportedHandlers.dispatchOpcode_of_lookup
+    SupportedHandlers.supportedHandlerTable_SDIV]
+  exact SDivStackExecutionBridge.sdivHandler_stack_of_runSDivStack?_some
+    h_run
+
+theorem loopFuel_one_supported_execSpec_SMOD_stack_of_runSModStack?_some
+    {state : EvmState} {out : SModStackExecutionBridge.SModStackResult}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SMOD : BitVec 8))
+    (h_run :
+      SModStackExecutionBridge.runSModStack? { stack := state.stack } =
+        some out) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      state).stack = out.effects.stackWords ++ out.stack := by
+  rw [loopFuel_one_of_execSpec_SMOD SupportedLoopBridge.supportedLoopHandler
+    h_status h_pc h_code]
+  rw [SupportedLoopBridge.supportedLoopHandler_apply]
+  rw [SupportedHandlers.dispatchOpcode_of_lookup
+    SupportedHandlers.supportedHandlerTable_SMOD]
+  exact SModStackExecutionBridge.smodHandler_stack_of_runSModStack?_some
+    h_run
+
 theorem loopFuel_one_supported_execSpec_SDIV_stack_zero_divisor
     {state : EvmState} (dividend : EvmWord) (rest : List EvmWord)
     (h_status : state.status = .running)

--- a/EvmAsm/Evm64/InterpreterExecutableStepBridge.lean
+++ b/EvmAsm/Evm64/InterpreterExecutableStepBridge.lean
@@ -83,6 +83,34 @@ theorem loopFuel_one_of_execSpecLogByte
   exact InterpreterExecutableFetchBridge.stepWithHandler_of_execSpecLogByte
     handler kind h_pc h_code
 
+theorem loopFuel_one_of_execSpec_SDIV
+    (handler : InterpreterLoop.Handler)
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SDIV : BitVec 8)) :
+    InterpreterLoop.loopFuel handler 1 state =
+      handler EvmOpcode.SDIV state := by
+  rw [InterpreterLoop.loopFuel_succ_running handler 0 state h_status]
+  exact InterpreterExecutableFetchBridge.stepWithHandler_of_execSpec_SDIV
+    handler h_pc h_code
+
+theorem loopFuel_one_of_execSpec_SMOD
+    (handler : InterpreterLoop.Handler)
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SMOD : BitVec 8)) :
+    InterpreterLoop.loopFuel handler 1 state =
+      handler EvmOpcode.SMOD state := by
+  rw [InterpreterLoop.loopFuel_succ_running handler 0 state h_status]
+  exact InterpreterExecutableFetchBridge.stepWithHandler_of_execSpec_SMOD
+    handler h_pc h_code
+
 theorem loopFuel_one_of_unsupported
     (handler : InterpreterLoop.Handler)
     {state : EvmState} {byte : BitVec 8}

--- a/EvmAsm/Evm64/InterpreterExecutableStepBridge.lean
+++ b/EvmAsm/Evm64/InterpreterExecutableStepBridge.lean
@@ -112,6 +112,44 @@ theorem loopFuel_one_of_execSpec_SMOD
   exact InterpreterExecutableFetchBridge.stepWithHandler_of_execSpec_SMOD
     handler h_pc h_code
 
+theorem loopFuel_one_supported_execSpec_SDIV_status_of_some
+    {state : EvmState} {stack' : List EvmWord}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SDIV : BitVec 8))
+    (h_stack : ArithmeticHandlers.binaryStack? EvmWord.sdiv state.stack =
+      some stack') :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      state).status = state.status := by
+  rw [loopFuel_one_of_execSpec_SDIV SupportedLoopBridge.supportedLoopHandler
+    h_status h_pc h_code]
+  rw [SupportedLoopBridge.supportedLoopHandler_apply]
+  rw [SupportedHandlers.dispatchOpcode_of_lookup
+    SupportedHandlers.supportedHandlerTable_SDIV]
+  simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler,
+    h_stack, EvmState.withStack]
+
+theorem loopFuel_one_supported_execSpec_SMOD_status_of_some
+    {state : EvmState} {stack' : List EvmWord}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SMOD : BitVec 8))
+    (h_stack : ArithmeticHandlers.binaryStack? EvmWord.smod state.stack =
+      some stack') :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      state).status = state.status := by
+  rw [loopFuel_one_of_execSpec_SMOD SupportedLoopBridge.supportedLoopHandler
+    h_status h_pc h_code]
+  rw [SupportedLoopBridge.supportedLoopHandler_apply]
+  rw [SupportedHandlers.dispatchOpcode_of_lookup
+    SupportedHandlers.supportedHandlerTable_SMOD]
+  simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler,
+    h_stack, EvmState.withStack]
+
 theorem loopFuel_one_supported_execSpec_SDIV_stack_zero_divisor
     {state : EvmState} (dividend : EvmWord) (rest : List EvmWord)
     (h_status : state.status = .running)

--- a/EvmAsm/Evm64/InterpreterExecutableStepBridge.lean
+++ b/EvmAsm/Evm64/InterpreterExecutableStepBridge.lean
@@ -190,6 +190,78 @@ theorem loopFuel_one_supported_execSpec_SMOD_gas
   rw [loopFuel_one_supported_execSpec_SMOD h_status h_pc h_code]
   exact SModStackExecutionBridge.smodHandler_gas state
 
+theorem loopFuel_one_supported_execSpec_SDIV_code
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SDIV : BitVec 8)) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      state).code = state.code := by
+  rw [loopFuel_one_supported_execSpec_SDIV h_status h_pc h_code]
+  exact SDivStackExecutionBridge.sdivHandler_code state
+
+theorem loopFuel_one_supported_execSpec_SMOD_code
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SMOD : BitVec 8)) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      state).code = state.code := by
+  rw [loopFuel_one_supported_execSpec_SMOD h_status h_pc h_code]
+  exact SModStackExecutionBridge.smodHandler_code state
+
+theorem loopFuel_one_supported_execSpec_SDIV_codeLen
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SDIV : BitVec 8)) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      state).codeLen = state.codeLen := by
+  rw [loopFuel_one_supported_execSpec_SDIV h_status h_pc h_code]
+  exact SDivStackExecutionBridge.sdivHandler_codeLen state
+
+theorem loopFuel_one_supported_execSpec_SMOD_codeLen
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SMOD : BitVec 8)) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      state).codeLen = state.codeLen := by
+  rw [loopFuel_one_supported_execSpec_SMOD h_status h_pc h_code]
+  exact SModStackExecutionBridge.smodHandler_codeLen state
+
+theorem loopFuel_one_supported_execSpec_SDIV_env
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SDIV : BitVec 8)) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      state).env = state.env := by
+  rw [loopFuel_one_supported_execSpec_SDIV h_status h_pc h_code]
+  exact SDivStackExecutionBridge.sdivHandler_env state
+
+theorem loopFuel_one_supported_execSpec_SMOD_env
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SMOD : BitVec 8)) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      state).env = state.env := by
+  rw [loopFuel_one_supported_execSpec_SMOD h_status h_pc h_code]
+  exact SModStackExecutionBridge.smodHandler_env state
+
 theorem loopFuel_one_supported_execSpec_SDIV_memoryCells
     {state : EvmState}
     (h_status : state.status = .running)

--- a/EvmAsm/Evm64/InterpreterExecutableStepBridge.lean
+++ b/EvmAsm/Evm64/InterpreterExecutableStepBridge.lean
@@ -190,6 +190,78 @@ theorem loopFuel_one_supported_execSpec_SMOD_gas
   rw [loopFuel_one_supported_execSpec_SMOD h_status h_pc h_code]
   exact SModStackExecutionBridge.smodHandler_gas state
 
+theorem loopFuel_one_supported_execSpec_SDIV_memoryCells
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SDIV : BitVec 8)) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      state).memoryCells = state.memoryCells := by
+  rw [loopFuel_one_supported_execSpec_SDIV h_status h_pc h_code]
+  exact SDivStackExecutionBridge.sdivHandler_memoryCells state
+
+theorem loopFuel_one_supported_execSpec_SDIV_memory
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SDIV : BitVec 8)) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      state).memory = state.memory := by
+  rw [loopFuel_one_supported_execSpec_SDIV h_status h_pc h_code]
+  exact SDivStackExecutionBridge.sdivHandler_memory state
+
+theorem loopFuel_one_supported_execSpec_SDIV_memSize
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SDIV : BitVec 8)) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      state).memSize = state.memSize := by
+  rw [loopFuel_one_supported_execSpec_SDIV h_status h_pc h_code]
+  exact SDivStackExecutionBridge.sdivHandler_memSize state
+
+theorem loopFuel_one_supported_execSpec_SMOD_memoryCells
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SMOD : BitVec 8)) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      state).memoryCells = state.memoryCells := by
+  rw [loopFuel_one_supported_execSpec_SMOD h_status h_pc h_code]
+  exact SModStackExecutionBridge.smodHandler_memoryCells state
+
+theorem loopFuel_one_supported_execSpec_SMOD_memory
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SMOD : BitVec 8)) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      state).memory = state.memory := by
+  rw [loopFuel_one_supported_execSpec_SMOD h_status h_pc h_code]
+  exact SModStackExecutionBridge.smodHandler_memory state
+
+theorem loopFuel_one_supported_execSpec_SMOD_memSize
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SMOD : BitVec 8)) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      state).memSize = state.memSize := by
+  rw [loopFuel_one_supported_execSpec_SMOD h_status h_pc h_code]
+  exact SModStackExecutionBridge.smodHandler_memSize state
+
 theorem loopFuel_one_supported_execSpec_SDIV_status_of_some
     {state : EvmState} {stack' : List EvmWord}
     (h_status : state.status = .running)

--- a/EvmAsm/Evm64/InterpreterExecutableStepBridge.lean
+++ b/EvmAsm/Evm64/InterpreterExecutableStepBridge.lean
@@ -6,6 +6,7 @@
 -/
 
 import EvmAsm.Evm64.InterpreterExecutableFetchBridge
+import EvmAsm.Evm64.SupportedLoopBridge
 
 namespace EvmAsm.Evm64
 
@@ -110,6 +111,278 @@ theorem loopFuel_one_of_execSpec_SMOD
   rw [InterpreterLoop.loopFuel_succ_running handler 0 state h_status]
   exact InterpreterExecutableFetchBridge.stepWithHandler_of_execSpec_SMOD
     handler h_pc h_code
+
+theorem loopFuel_one_supported_execSpec_SDIV_stack_zero_divisor
+    {state : EvmState} (dividend : EvmWord) (rest : List EvmWord)
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SDIV : BitVec 8)) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      { state with stack := dividend :: 0 :: rest }).stack =
+        0 :: rest := by
+  have h_status' :
+      ({ state with stack := dividend :: 0 :: rest } : EvmState).status =
+        .running := by
+    simpa using h_status
+  have h_pc' :
+      ({ state with stack := dividend :: 0 :: rest } : EvmState).pc <
+        ({ state with stack := dividend :: 0 :: rest } : EvmState).code.length := by
+    simpa using h_pc
+  have h_code' :
+      ({ state with stack := dividend :: 0 :: rest } : EvmState).code[
+        ({ state with stack := dividend :: 0 :: rest } : EvmState).pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SDIV : BitVec 8) := by
+    simpa using h_code
+  rw [loopFuel_one_of_execSpec_SDIV SupportedLoopBridge.supportedLoopHandler
+    h_status' h_pc' h_code']
+  rw [SupportedLoopBridge.supportedLoopHandler_apply]
+  rw [SupportedHandlers.dispatchOpcode_of_lookup
+    SupportedHandlers.supportedHandlerTable_SDIV]
+  exact SDivStackExecutionBridge.sdivHandler_stack_zero_divisor
+    state dividend rest
+
+theorem loopFuel_one_supported_execSpec_SDIV_stack_intMin_neg_one
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SDIV : BitVec 8)) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      { state with stack := BitVec.intMin 256 :: (-1 : EvmWord) :: state.stack }).stack =
+        BitVec.intMin 256 :: state.stack := by
+  have h_status' :
+      ({ state with stack := BitVec.intMin 256 :: (-1 : EvmWord) :: state.stack } :
+        EvmState).status = .running := by
+    simpa using h_status
+  have h_pc' :
+      ({ state with stack := BitVec.intMin 256 :: (-1 : EvmWord) :: state.stack } :
+        EvmState).pc <
+        ({ state with stack := BitVec.intMin 256 :: (-1 : EvmWord) :: state.stack } :
+          EvmState).code.length := by
+    simpa using h_pc
+  have h_code' :
+      ({ state with stack := BitVec.intMin 256 :: (-1 : EvmWord) :: state.stack } :
+        EvmState).code[
+        ({ state with stack := BitVec.intMin 256 :: (-1 : EvmWord) :: state.stack } :
+          EvmState).pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SDIV : BitVec 8) := by
+    simpa using h_code
+  rw [loopFuel_one_of_execSpec_SDIV SupportedLoopBridge.supportedLoopHandler
+    h_status' h_pc' h_code']
+  rw [SupportedLoopBridge.supportedLoopHandler_apply]
+  rw [SupportedHandlers.dispatchOpcode_of_lookup
+    SupportedHandlers.supportedHandlerTable_SDIV]
+  exact SDivStackExecutionBridge.sdivHandler_stack_intMin_neg_one
+    state state.stack
+
+theorem loopFuel_one_supported_execSpec_SDIV_stack_neg_one_two
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SDIV : BitVec 8)) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      { state with stack := (-1 : EvmWord) :: 2 :: state.stack }).stack =
+        0 :: state.stack := by
+  have h_status' :
+      ({ state with stack := (-1 : EvmWord) :: 2 :: state.stack } :
+        EvmState).status = .running := by
+    simpa using h_status
+  have h_pc' :
+      ({ state with stack := (-1 : EvmWord) :: 2 :: state.stack } :
+        EvmState).pc <
+        ({ state with stack := (-1 : EvmWord) :: 2 :: state.stack } :
+          EvmState).code.length := by
+    simpa using h_pc
+  have h_code' :
+      ({ state with stack := (-1 : EvmWord) :: 2 :: state.stack } :
+        EvmState).code[
+        ({ state with stack := (-1 : EvmWord) :: 2 :: state.stack } :
+          EvmState).pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SDIV : BitVec 8) := by
+    simpa using h_code
+  rw [loopFuel_one_of_execSpec_SDIV SupportedLoopBridge.supportedLoopHandler
+    h_status' h_pc' h_code']
+  rw [SupportedLoopBridge.supportedLoopHandler_apply]
+  rw [SupportedHandlers.dispatchOpcode_of_lookup
+    SupportedHandlers.supportedHandlerTable_SDIV]
+  exact SDivStackExecutionBridge.sdivHandler_stack_neg_one_two
+    state state.stack
+
+theorem loopFuel_one_supported_execSpec_SDIV_stack_pos_neg_trunc
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SDIV : BitVec 8)) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      { state with stack := (7 : EvmWord) :: (-2 : EvmWord) :: state.stack }).stack =
+        (-3 : EvmWord) :: state.stack := by
+  have h_status' :
+      ({ state with stack := (7 : EvmWord) :: (-2 : EvmWord) :: state.stack } :
+        EvmState).status = .running := by
+    simpa using h_status
+  have h_pc' :
+      ({ state with stack := (7 : EvmWord) :: (-2 : EvmWord) :: state.stack } :
+        EvmState).pc <
+        ({ state with stack := (7 : EvmWord) :: (-2 : EvmWord) :: state.stack } :
+          EvmState).code.length := by
+    simpa using h_pc
+  have h_code' :
+      ({ state with stack := (7 : EvmWord) :: (-2 : EvmWord) :: state.stack } :
+        EvmState).code[
+        ({ state with stack := (7 : EvmWord) :: (-2 : EvmWord) :: state.stack } :
+          EvmState).pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SDIV : BitVec 8) := by
+    simpa using h_code
+  rw [loopFuel_one_of_execSpec_SDIV SupportedLoopBridge.supportedLoopHandler
+    h_status' h_pc' h_code']
+  rw [SupportedLoopBridge.supportedLoopHandler_apply]
+  rw [SupportedHandlers.dispatchOpcode_of_lookup
+    SupportedHandlers.supportedHandlerTable_SDIV]
+  exact SDivStackExecutionBridge.sdivHandler_stack_pos_neg_trunc
+    state state.stack
+
+theorem loopFuel_one_supported_execSpec_SMOD_stack_zero_divisor
+    {state : EvmState} (dividend : EvmWord) (rest : List EvmWord)
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SMOD : BitVec 8)) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      { state with stack := dividend :: 0 :: rest }).stack =
+        0 :: rest := by
+  have h_status' :
+      ({ state with stack := dividend :: 0 :: rest } : EvmState).status =
+        .running := by
+    simpa using h_status
+  have h_pc' :
+      ({ state with stack := dividend :: 0 :: rest } : EvmState).pc <
+        ({ state with stack := dividend :: 0 :: rest } : EvmState).code.length := by
+    simpa using h_pc
+  have h_code' :
+      ({ state with stack := dividend :: 0 :: rest } : EvmState).code[
+        ({ state with stack := dividend :: 0 :: rest } : EvmState).pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SMOD : BitVec 8) := by
+    simpa using h_code
+  rw [loopFuel_one_of_execSpec_SMOD SupportedLoopBridge.supportedLoopHandler
+    h_status' h_pc' h_code']
+  rw [SupportedLoopBridge.supportedLoopHandler_apply]
+  rw [SupportedHandlers.dispatchOpcode_of_lookup
+    SupportedHandlers.supportedHandlerTable_SMOD]
+  exact SModStackExecutionBridge.smodHandler_stack_zero_divisor
+    state dividend rest
+
+theorem loopFuel_one_supported_execSpec_SMOD_stack_neg_pos_sign
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SMOD : BitVec 8)) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      { state with stack := (-3 : EvmWord) :: 2 :: state.stack }).stack =
+        (-1 : EvmWord) :: state.stack := by
+  have h_status' :
+      ({ state with stack := (-3 : EvmWord) :: 2 :: state.stack } :
+        EvmState).status = .running := by
+    simpa using h_status
+  have h_pc' :
+      ({ state with stack := (-3 : EvmWord) :: 2 :: state.stack } :
+        EvmState).pc <
+        ({ state with stack := (-3 : EvmWord) :: 2 :: state.stack } :
+          EvmState).code.length := by
+    simpa using h_pc
+  have h_code' :
+      ({ state with stack := (-3 : EvmWord) :: 2 :: state.stack } :
+        EvmState).code[
+        ({ state with stack := (-3 : EvmWord) :: 2 :: state.stack } :
+          EvmState).pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SMOD : BitVec 8) := by
+    simpa using h_code
+  rw [loopFuel_one_of_execSpec_SMOD SupportedLoopBridge.supportedLoopHandler
+    h_status' h_pc' h_code']
+  rw [SupportedLoopBridge.supportedLoopHandler_apply]
+  rw [SupportedHandlers.dispatchOpcode_of_lookup
+    SupportedHandlers.supportedHandlerTable_SMOD]
+  exact SModStackExecutionBridge.smodHandler_stack_neg_pos_sign
+    state state.stack
+
+theorem loopFuel_one_supported_execSpec_SMOD_stack_pos_neg_sign
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SMOD : BitVec 8)) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      { state with stack := (3 : EvmWord) :: (-2 : EvmWord) :: state.stack }).stack =
+        (1 : EvmWord) :: state.stack := by
+  have h_status' :
+      ({ state with stack := (3 : EvmWord) :: (-2 : EvmWord) :: state.stack } :
+        EvmState).status = .running := by
+    simpa using h_status
+  have h_pc' :
+      ({ state with stack := (3 : EvmWord) :: (-2 : EvmWord) :: state.stack } :
+        EvmState).pc <
+        ({ state with stack := (3 : EvmWord) :: (-2 : EvmWord) :: state.stack } :
+          EvmState).code.length := by
+    simpa using h_pc
+  have h_code' :
+      ({ state with stack := (3 : EvmWord) :: (-2 : EvmWord) :: state.stack } :
+        EvmState).code[
+        ({ state with stack := (3 : EvmWord) :: (-2 : EvmWord) :: state.stack } :
+          EvmState).pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SMOD : BitVec 8) := by
+    simpa using h_code
+  rw [loopFuel_one_of_execSpec_SMOD SupportedLoopBridge.supportedLoopHandler
+    h_status' h_pc' h_code']
+  rw [SupportedLoopBridge.supportedLoopHandler_apply]
+  rw [SupportedHandlers.dispatchOpcode_of_lookup
+    SupportedHandlers.supportedHandlerTable_SMOD]
+  exact SModStackExecutionBridge.smodHandler_stack_pos_neg_sign
+    state state.stack
+
+theorem loopFuel_one_supported_execSpec_SMOD_stack_neg_neg_sign
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SMOD : BitVec 8)) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      { state with stack := (-3 : EvmWord) :: (-2 : EvmWord) :: state.stack }).stack =
+        (-1 : EvmWord) :: state.stack := by
+  have h_status' :
+      ({ state with stack := (-3 : EvmWord) :: (-2 : EvmWord) :: state.stack } :
+        EvmState).status = .running := by
+    simpa using h_status
+  have h_pc' :
+      ({ state with stack := (-3 : EvmWord) :: (-2 : EvmWord) :: state.stack } :
+        EvmState).pc <
+        ({ state with stack := (-3 : EvmWord) :: (-2 : EvmWord) :: state.stack } :
+          EvmState).code.length := by
+    simpa using h_pc
+  have h_code' :
+      ({ state with stack := (-3 : EvmWord) :: (-2 : EvmWord) :: state.stack } :
+        EvmState).code[
+        ({ state with stack := (-3 : EvmWord) :: (-2 : EvmWord) :: state.stack } :
+          EvmState).pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SMOD : BitVec 8) := by
+    simpa using h_code
+  rw [loopFuel_one_of_execSpec_SMOD SupportedLoopBridge.supportedLoopHandler
+    h_status' h_pc' h_code']
+  rw [SupportedLoopBridge.supportedLoopHandler_apply]
+  rw [SupportedHandlers.dispatchOpcode_of_lookup
+    SupportedHandlers.supportedHandlerTable_SMOD]
+  exact SModStackExecutionBridge.smodHandler_stack_neg_neg_sign
+    state state.stack
 
 theorem loopFuel_one_of_unsupported
     (handler : InterpreterLoop.Handler)

--- a/EvmAsm/Evm64/MLoad/StackSpec.lean
+++ b/EvmAsm/Evm64/MLoad/StackSpec.lean
@@ -1150,6 +1150,22 @@ theorem mloadStackOutputPost_evmWordIs_fold
   rw [mloadStackOutputWordFromDwordPairs_eq_mloadLoadedWordFromDwordPairs]
   rw [mloadLoadedWordFromDwordPairs_evmWordIs_fold]
 
+theorem mloadStackOutputPost_evmStackIs_fold
+    (sp : Word)
+    (lo0 hi0 : Word) (start0 : Nat)
+    (lo1 hi1 : Word) (start1 : Nat)
+    (lo2 hi2 : Word) (start2 : Nat)
+    (lo3 hi3 : Word) (start3 : Nat)
+    (rest : List EvmWord) :
+    (mloadStackOutputPost sp
+      lo0 hi0 start0 lo1 hi1 start1 lo2 hi2 start2 lo3 hi3 start3 **
+      evmStackIs (sp + 32) rest) =
+    evmStackIs sp
+      (mloadStackOutputWordFromDwordPairs
+        lo0 hi0 start0 lo1 hi1 start1 lo2 hi2 start2 lo3 hi3 start3 :: rest) := by
+  rw [mloadStackOutputPost_unfold]
+  rfl
+
 /--
   The 256-bit value loaded by a 32-byte unaligned MLOAD window spanning five
   consecutive RV64 dwords. The single `start` byte offset applies to each

--- a/EvmAsm/Evm64/MLoad/UnalignedFramedStackSpec.lean
+++ b/EvmAsm/Evm64/MLoad/UnalignedFramedStackSpec.lean
@@ -1355,4 +1355,73 @@ theorem evm_mload_unaligned_full_stack_spec_within_public_stack_pre
     (fun _ hp => by sep_perm hp)
     hCore
 
+/--
+Canonical public MLOAD stack spec entry point.
+
+This aliases the full unaligned public stack-pre theorem under the conventional
+name used by the topmost-spec audit.
+-/
+theorem evm_mload_stack_spec_within
+    (offReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset offOld addrOld memBase byteOld accOld : Word)
+    (offsetWord : EvmWord) (rest : List EvmWord)
+    (dstOld1 dstOld2 dstOld3 : Word)
+    (loAddr0 hiAddr0 loVal0 hiVal0 : Word)
+    (loAddr1 hiAddr1 loVal1 hiVal1 : Word)
+    (loAddr2 hiAddr2 loVal2 hiVal2 : Word)
+    (loAddr3 hiAddr3 loVal3 hiVal3 : Word)
+    (start : Nat) (base : Word)
+    (h_offset0 : offsetWord.getLimbN 0 = offset)
+    (h_offset1 : offsetWord.getLimbN 1 = dstOld1)
+    (h_offset2 : offsetWord.getLimbN 2 = dstOld2)
+    (h_offset3 : offsetWord.getLimbN 3 = dstOld3)
+    (h_off_ne_x0 : offReg ≠ .x0)
+    (h_addr_ne_x0 : addrReg ≠ .x0)
+    (h_byte_ne_x0 : byteReg ≠ .x0)
+    (h_acc_ne_x0 : accReg ≠ .x0)
+    (h_window0 : mloadLimbWindowOk (memBase + offset) loAddr0 hiAddr0 start
+                  24 25 26 27 28 29 30 31)
+    (h_window1 : mloadLimbWindowOk (memBase + offset) loAddr1 hiAddr1 start
+                  16 17 18 19 20 21 22 23)
+    (h_window2 : mloadLimbWindowOk (memBase + offset) loAddr2 hiAddr2 start
+                  8 9 10 11 12 13 14 15)
+    (h_window3 : mloadLimbWindowOk (memBase + offset) loAddr3 hiAddr3 start
+                  0 1 2 3 4 5 6 7) :
+    let loaded3 := mloadPackedLimbFromDwordPair loVal3 hiVal3 start
+    cpsTripleWithin (2 + (23 + 23 + 23 + 23)) base (base + 376)
+      (evm_mload_code offReg byteReg accReg addrReg memBaseReg base)
+      (((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offOld) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ addrOld) **
+        evmStackIs sp (offsetWord :: rest)) **
+       ((byteReg ↦ᵣ byteOld) ** (accReg ↦ᵣ accOld) **
+        (loAddr0 ↦ₘ loVal0) ** (hiAddr0 ↦ₘ hiVal0) **
+        (loAddr1 ↦ₘ loVal1) ** (hiAddr1 ↦ₘ hiVal1) **
+        (loAddr2 ↦ₘ loVal2) ** (hiAddr2 ↦ₘ hiVal2) **
+        (loAddr3 ↦ₘ loVal3) ** (hiAddr3 ↦ₘ hiVal3))))
+      (evmStackIs sp
+        (mloadStackOutputWordFromDwordPairs
+          loVal0 hiVal0 start loVal1 hiVal1 start
+          loVal2 hiVal2 start loVal3 hiVal3 start :: rest) **
+       (((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+        (byteReg ↦ᵣ
+          (mloadByteFromDwordPair loVal3 hiVal3 start 7).zeroExtend 64) **
+        (accReg ↦ᵣ loaded3) **
+        (loAddr0 ↦ₘ loVal0) ** (hiAddr0 ↦ₘ hiVal0) **
+        (loAddr1 ↦ₘ loVal1) ** (hiAddr1 ↦ₘ hiVal1) **
+        (loAddr2 ↦ₘ loVal2) ** (hiAddr2 ↦ₘ hiVal2) **
+        (loAddr3 ↦ₘ loVal3) ** (hiAddr3 ↦ₘ hiVal3))) := by
+  exact evm_mload_unaligned_full_stack_spec_within_public_stack_pre
+    offReg byteReg accReg addrReg memBaseReg
+    sp offset offOld addrOld memBase byteOld accOld
+    offsetWord rest dstOld1 dstOld2 dstOld3
+    loAddr0 hiAddr0 loVal0 hiVal0
+    loAddr1 hiAddr1 loVal1 hiVal1
+    loAddr2 hiAddr2 loVal2 hiVal2
+    loAddr3 hiAddr3 loVal3 hiVal3
+    start base
+    h_offset0 h_offset1 h_offset2 h_offset3
+    h_off_ne_x0 h_addr_ne_x0 h_byte_ne_x0 h_acc_ne_x0
+    h_window0 h_window1 h_window2 h_window3
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/MLoad/UnalignedFramedStackSpec.lean
+++ b/EvmAsm/Evm64/MLoad/UnalignedFramedStackSpec.lean
@@ -444,6 +444,44 @@ theorem evm_mload_public_one_limb_sequence_spec_within
     h3
 
 /--
+Permutation-aware public-code MLOAD q0..q3 composition.
+
+This variant lets callers stitch concrete quarter specs whose postconditions
+match the next precondition only after rearranging or weakening separation
+conjunction atoms.
+
+Distinctive token: evm_mload_public_one_limb_sequence_spec_within_perm #53.
+-/
+theorem evm_mload_public_one_limb_sequence_spec_within_perm
+    {n0 n1 n2 n3 : Nat}
+    {P0 P1 P1' P2 P2' P3 P3' P4 : Assertion}
+    (offReg byteReg accReg addrReg memBaseReg : Reg) (base : Word)
+    (h0 :
+      cpsTripleWithin n0 (base + 8) (base + 100)
+        (evm_mload_code offReg byteReg accReg addrReg memBaseReg base) P0 P1)
+    (h01 : ∀ s, P1 s → P1' s)
+    (h1 :
+      cpsTripleWithin n1 (base + 100) (base + 192)
+        (evm_mload_code offReg byteReg accReg addrReg memBaseReg base) P1' P2)
+    (h12 : ∀ s, P2 s → P2' s)
+    (h2 :
+      cpsTripleWithin n2 (base + 192) (base + 284)
+        (evm_mload_code offReg byteReg accReg addrReg memBaseReg base) P2' P3)
+    (h23 : ∀ s, P3 s → P3' s)
+    (h3 :
+      cpsTripleWithin n3 (base + 284) (base + 376)
+        (evm_mload_code offReg byteReg accReg addrReg memBaseReg base) P3' P4) :
+    cpsTripleWithin (n0 + n1 + n2 + n3) (base + 8) (base + 376)
+      (evm_mload_code offReg byteReg accReg addrReg memBaseReg base) P0 P4 := by
+  exact cpsTripleWithin_seq_perm_same_cr
+    h23
+    (cpsTripleWithin_seq_perm_same_cr
+      h12
+      (cpsTripleWithin_seq_perm_same_cr h01 h0 h1)
+      h2)
+    h3
+
+/--
 Compose the framed MLOAD prologue with four public-code one-limb quarter
 triples.
 

--- a/EvmAsm/Evm64/MLoad/UnalignedFramedStackSpec.lean
+++ b/EvmAsm/Evm64/MLoad/UnalignedFramedStackSpec.lean
@@ -98,6 +98,59 @@ theorem evm_mload_prologue_stack_spec_within_framed
       h_off_ne_x0 h_addr_ne_x0)
 
 /--
+Framed version of `evm_mload_combined_one_limb_sequence_stack_spec_within`.
+
+This wrapper preserves an arbitrary `pcFree` frame across the whole prologue
+plus four-quarter byte-pack sequence, which is useful once the concrete q0..q3
+lemmas have been composed into a single MLOAD sequence triple.
+
+Distinctive token:
+evm_mload_combined_one_limb_sequence_stack_spec_within_framed #53.
+-/
+theorem evm_mload_combined_one_limb_sequence_stack_spec_within_framed
+    {n0 n1 n2 n3 : Nat} {P1 P2 P3 Q : Assertion}
+    (offReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset offOld addrOld memBase : Word) (base : Word)
+    (F : Assertion) (hF : F.pcFree)
+    (h_off_ne_x0 : offReg ≠ .x0)
+    (h_addr_ne_x0 : addrReg ≠ .x0)
+    (h0 :
+      cpsTripleWithin n0 (base + 8) (base + 100)
+        (mloadOneLimbCode addrReg byteReg accReg
+          24 25 26 27 28 29 30 31 0 (base + 8))
+        (((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+         (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+         (sp ↦ₘ offset))
+        P1)
+    (h1 :
+      cpsTripleWithin n1 (base + 100) (base + 192)
+        (mloadOneLimbCode addrReg byteReg accReg
+          16 17 18 19 20 21 22 23 8 (base + 100)) P1 P2)
+    (h2 :
+      cpsTripleWithin n2 (base + 192) (base + 284)
+        (mloadOneLimbCode addrReg byteReg accReg
+          8 9 10 11 12 13 14 15 16 (base + 192)) P2 P3)
+    (h3 :
+      cpsTripleWithin n3 (base + 284) (base + 376)
+        (mloadOneLimbCode addrReg byteReg accReg
+          0 1 2 3 4 5 6 7 24 (base + 284)) P3 Q) :
+    cpsTripleWithin (2 + (n0 + n1 + n2 + n3)) base (base + 376)
+      (evm_mload_code offReg byteReg accReg addrReg memBaseReg base)
+      ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offOld) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ addrOld) **
+        (sp ↦ₘ offset)) ** F)
+      (Q ** F) := by
+  have framed := cpsTripleWithin_frameL (F := F) hF
+    (evm_mload_combined_one_limb_sequence_stack_spec_within
+      offReg byteReg accReg addrReg memBaseReg
+      sp offset offOld addrOld memBase base
+      h_off_ne_x0 h_addr_ne_x0 h0 h1 h2 h3)
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by sep_perm hp)
+    (fun _ hp => by sep_perm hp)
+    framed
+
+/--
 Sibling-framed q0 stack spec: `evm_mload_unaligned_one_limb_q0_stack_spec_within`
 with an arbitrary `pcFree` assertion `F` framed on both pre and post.
 

--- a/EvmAsm/Evm64/MLoad/UnalignedFramedStackSpec.lean
+++ b/EvmAsm/Evm64/MLoad/UnalignedFramedStackSpec.lean
@@ -529,6 +529,58 @@ theorem evm_mload_public_one_limb_sequence_with_prologue_framed
       offReg byteReg accReg addrReg memBaseReg base h0 h1 h2 h3)
 
 /--
+Compose the framed MLOAD prologue with a permutation-aware public-code q0..q3
+one-limb sequence.
+
+This is the concrete-compose entry point for quarter specs whose intermediate
+postconditions need `sep_perm`/weakening callbacks before the next quarter.
+
+Distinctive token:
+evm_mload_public_one_limb_sequence_with_prologue_framed_perm #53.
+-/
+theorem evm_mload_public_one_limb_sequence_with_prologue_framed_perm
+    {n0 n1 n2 n3 : Nat}
+    {P1 P1' P2 P2' P3 P3' Q : Assertion}
+    (offReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset offOld addrOld memBase : Word) (base : Word)
+    (F : Assertion) (hF : F.pcFree)
+    (h_off_ne_x0 : offReg ≠ .x0)
+    (h_addr_ne_x0 : addrReg ≠ .x0)
+    (h0 :
+      cpsTripleWithin n0 (base + 8) (base + 100)
+        (evm_mload_code offReg byteReg accReg addrReg memBaseReg base)
+        ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+          (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+          (sp ↦ₘ offset)) ** F)
+        P1)
+    (h01 : ∀ s, P1 s → P1' s)
+    (h1 :
+      cpsTripleWithin n1 (base + 100) (base + 192)
+        (evm_mload_code offReg byteReg accReg addrReg memBaseReg base) P1' P2)
+    (h12 : ∀ s, P2 s → P2' s)
+    (h2 :
+      cpsTripleWithin n2 (base + 192) (base + 284)
+        (evm_mload_code offReg byteReg accReg addrReg memBaseReg base) P2' P3)
+    (h23 : ∀ s, P3 s → P3' s)
+    (h3 :
+      cpsTripleWithin n3 (base + 284) (base + 376)
+        (evm_mload_code offReg byteReg accReg addrReg memBaseReg base) P3' Q) :
+    cpsTripleWithin (2 + (n0 + n1 + n2 + n3)) base (base + 376)
+      (evm_mload_code offReg byteReg accReg addrReg memBaseReg base)
+      ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offOld) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ addrOld) **
+        (sp ↦ₘ offset)) ** F)
+      Q := by
+  exact cpsTripleWithin_seq_same_cr
+    (evm_mload_prologue_stack_spec_within_framed
+      offReg byteReg accReg addrReg memBaseReg
+      sp offset offOld addrOld memBase base F hF
+      h_off_ne_x0 h_addr_ne_x0)
+    (evm_mload_public_one_limb_sequence_spec_within_perm
+      offReg byteReg accReg addrReg memBaseReg base
+      h0 h01 h1 h12 h2 h23 h3)
+
+/--
 Generic public-code MLOAD prologue/body composition with a framed prologue.
 
 This lets callers plug in any body triple over `evm_mload_code` that starts

--- a/EvmAsm/Evm64/MLoad/UnalignedFramedStackSpec.lean
+++ b/EvmAsm/Evm64/MLoad/UnalignedFramedStackSpec.lean
@@ -323,6 +323,39 @@ theorem cpsTripleWithin_evm_mload_of_one_limb_q3
       offReg byteReg accReg addrReg memBaseReg base)
 
 /--
+Compose four public-code MLOAD one-limb triples into a single q0..q3 body
+triple over `evm_mload_code`.
+
+This is the public-code counterpart of `mload_one_limb_sequence_spec_within`:
+callers that already transported each quarter to `evm_mload_code` can sequence
+them without returning to the smaller `mloadFourLimbsCode` surface.
+
+Distinctive token: evm_mload_public_one_limb_sequence_spec_within #53.
+-/
+theorem evm_mload_public_one_limb_sequence_spec_within
+    {n0 n1 n2 n3 : Nat} {P0 P1 P2 P3 P4 : Assertion}
+    (offReg byteReg accReg addrReg memBaseReg : Reg) (base : Word)
+    (h0 :
+      cpsTripleWithin n0 (base + 8) (base + 100)
+        (evm_mload_code offReg byteReg accReg addrReg memBaseReg base) P0 P1)
+    (h1 :
+      cpsTripleWithin n1 (base + 100) (base + 192)
+        (evm_mload_code offReg byteReg accReg addrReg memBaseReg base) P1 P2)
+    (h2 :
+      cpsTripleWithin n2 (base + 192) (base + 284)
+        (evm_mload_code offReg byteReg accReg addrReg memBaseReg base) P2 P3)
+    (h3 :
+      cpsTripleWithin n3 (base + 284) (base + 376)
+        (evm_mload_code offReg byteReg accReg addrReg memBaseReg base) P3 P4) :
+    cpsTripleWithin (n0 + n1 + n2 + n3) (base + 8) (base + 376)
+      (evm_mload_code offReg byteReg accReg addrReg memBaseReg base) P0 P4 := by
+  exact cpsTripleWithin_seq_same_cr
+    (cpsTripleWithin_seq_same_cr
+      (cpsTripleWithin_seq_same_cr h0 h1)
+      h2)
+    h3
+
+/--
 Sibling-framed q0 stack spec: `evm_mload_unaligned_one_limb_q0_stack_spec_within`
 with an arbitrary `pcFree` assertion `F` framed on both pre and post.
 

--- a/EvmAsm/Evm64/MLoad/UnalignedFramedStackSpec.lean
+++ b/EvmAsm/Evm64/MLoad/UnalignedFramedStackSpec.lean
@@ -207,6 +207,62 @@ theorem evm_mload_combined_one_limb_sequence_stack_spec_within_threaded_frame
           addrReg byteReg accReg base h0 h1 h2 h3)))
 
 /--
+Public-code subsumption for the q0 MLOAD one-limb byte-pack block.
+
+This bridges the concrete quarter block directly to `evm_mload_code`, avoiding
+repeat composition through `mloadFourLimbsCode` and `mloadStackCode` at call
+sites that transport individual framed quarter specs.
+
+Distinctive token: evm_mload_code_one_limb_q0_sub #53.
+-/
+theorem evm_mload_code_one_limb_q0_sub
+    (offReg byteReg accReg addrReg memBaseReg : Reg) (base : Word) :
+    ∀ a i,
+      (mloadOneLimbCode addrReg byteReg accReg
+        24 25 26 27 28 29 30 31 0 (base + 8)) a = some i →
+      (evm_mload_code offReg byteReg accReg addrReg memBaseReg base) a = some i := by
+  intro a i h
+  exact evm_mload_code_stack_sub offReg byteReg accReg addrReg memBaseReg base a i
+    (mloadStackCode_four_limbs_sub offReg byteReg accReg addrReg memBaseReg base a i
+      (mloadFourLimbsCode_one_limb_q0_sub addrReg byteReg accReg base a i h))
+
+/-- Public-code subsumption for the q1 MLOAD one-limb byte-pack block. -/
+theorem evm_mload_code_one_limb_q1_sub
+    (offReg byteReg accReg addrReg memBaseReg : Reg) (base : Word) :
+    ∀ a i,
+      (mloadOneLimbCode addrReg byteReg accReg
+        16 17 18 19 20 21 22 23 8 (base + 100)) a = some i →
+      (evm_mload_code offReg byteReg accReg addrReg memBaseReg base) a = some i := by
+  intro a i h
+  exact evm_mload_code_stack_sub offReg byteReg accReg addrReg memBaseReg base a i
+    (mloadStackCode_four_limbs_sub offReg byteReg accReg addrReg memBaseReg base a i
+      (mloadFourLimbsCode_one_limb_q1_sub addrReg byteReg accReg base a i h))
+
+/-- Public-code subsumption for the q2 MLOAD one-limb byte-pack block. -/
+theorem evm_mload_code_one_limb_q2_sub
+    (offReg byteReg accReg addrReg memBaseReg : Reg) (base : Word) :
+    ∀ a i,
+      (mloadOneLimbCode addrReg byteReg accReg
+        8 9 10 11 12 13 14 15 16 (base + 192)) a = some i →
+      (evm_mload_code offReg byteReg accReg addrReg memBaseReg base) a = some i := by
+  intro a i h
+  exact evm_mload_code_stack_sub offReg byteReg accReg addrReg memBaseReg base a i
+    (mloadStackCode_four_limbs_sub offReg byteReg accReg addrReg memBaseReg base a i
+      (mloadFourLimbsCode_one_limb_q2_sub addrReg byteReg accReg base a i h))
+
+/-- Public-code subsumption for the q3 MLOAD one-limb byte-pack block. -/
+theorem evm_mload_code_one_limb_q3_sub
+    (offReg byteReg accReg addrReg memBaseReg : Reg) (base : Word) :
+    ∀ a i,
+      (mloadOneLimbCode addrReg byteReg accReg
+        0 1 2 3 4 5 6 7 24 (base + 284)) a = some i →
+      (evm_mload_code offReg byteReg accReg addrReg memBaseReg base) a = some i := by
+  intro a i h
+  exact evm_mload_code_stack_sub offReg byteReg accReg addrReg memBaseReg base a i
+    (mloadStackCode_four_limbs_sub offReg byteReg accReg addrReg memBaseReg base a i
+      (mloadFourLimbsCode_one_limb_q3_sub addrReg byteReg accReg base a i h))
+
+/--
 Sibling-framed q0 stack spec: `evm_mload_unaligned_one_limb_q0_stack_spec_within`
 with an arbitrary `pcFree` assertion `F` framed on both pre and post.
 

--- a/EvmAsm/Evm64/MLoad/UnalignedFramedStackSpec.lean
+++ b/EvmAsm/Evm64/MLoad/UnalignedFramedStackSpec.lean
@@ -151,6 +151,62 @@ theorem evm_mload_combined_one_limb_sequence_stack_spec_within_framed
     framed
 
 /--
+Threaded-frame variant of `evm_mload_combined_one_limb_sequence_stack_spec_within`.
+
+Unlike the whole-sequence frame wrapper above, this theorem starts q0 from the
+prologue postcondition already combined with `F`. That matches the concrete
+q0..q3 sibling-framed MLOAD lemmas below, where the frame carries the other
+window cells through each quarter.
+
+Distinctive token:
+evm_mload_combined_one_limb_sequence_stack_spec_within_threaded_frame #53.
+-/
+theorem evm_mload_combined_one_limb_sequence_stack_spec_within_threaded_frame
+    {n0 n1 n2 n3 : Nat} {P1 P2 P3 Q : Assertion}
+    (offReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset offOld addrOld memBase : Word) (base : Word)
+    (F : Assertion) (hF : F.pcFree)
+    (h_off_ne_x0 : offReg ≠ .x0)
+    (h_addr_ne_x0 : addrReg ≠ .x0)
+    (h0 :
+      cpsTripleWithin n0 (base + 8) (base + 100)
+        (mloadOneLimbCode addrReg byteReg accReg
+          24 25 26 27 28 29 30 31 0 (base + 8))
+        ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+          (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+          (sp ↦ₘ offset)) ** F)
+        P1)
+    (h1 :
+      cpsTripleWithin n1 (base + 100) (base + 192)
+        (mloadOneLimbCode addrReg byteReg accReg
+          16 17 18 19 20 21 22 23 8 (base + 100)) P1 P2)
+    (h2 :
+      cpsTripleWithin n2 (base + 192) (base + 284)
+        (mloadOneLimbCode addrReg byteReg accReg
+          8 9 10 11 12 13 14 15 16 (base + 192)) P2 P3)
+    (h3 :
+      cpsTripleWithin n3 (base + 284) (base + 376)
+        (mloadOneLimbCode addrReg byteReg accReg
+          0 1 2 3 4 5 6 7 24 (base + 284)) P3 Q) :
+    cpsTripleWithin (2 + (n0 + n1 + n2 + n3)) base (base + 376)
+      (evm_mload_code offReg byteReg accReg addrReg memBaseReg base)
+      ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offOld) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ addrOld) **
+        (sp ↦ₘ offset)) ** F)
+      Q := by
+  exact cpsTripleWithin_evm_mload_of_stack
+    offReg byteReg accReg addrReg memBaseReg base (base + 376)
+    (cpsTripleWithin_seq_same_cr
+      (mload_prologue_stack_spec_within_framed
+        offReg byteReg accReg addrReg memBaseReg
+        sp offset offOld addrOld memBase base F hF
+        h_off_ne_x0 h_addr_ne_x0)
+      (mload_four_limbs_stack_spec_within
+        offReg byteReg accReg addrReg memBaseReg base
+        (mload_one_limb_sequence_spec_within
+          addrReg byteReg accReg base h0 h1 h2 h3)))
+
+/--
 Sibling-framed q0 stack spec: `evm_mload_unaligned_one_limb_q0_stack_spec_within`
 with an arbitrary `pcFree` assertion `F` framed on both pre and post.
 

--- a/EvmAsm/Evm64/MLoad/UnalignedFramedStackSpec.lean
+++ b/EvmAsm/Evm64/MLoad/UnalignedFramedStackSpec.lean
@@ -24,11 +24,48 @@
   sibling-quarter cells #53.
 -/
 
+import EvmAsm.Evm64.MLoad.StackSpec
 import EvmAsm.Evm64.MLoad.UnalignedStackSpec
 
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
+
+/--
+Sibling-framed MLOAD prologue stack spec: `mload_prologue_stack_spec_within`
+with an arbitrary `pcFree` assertion `F` framed on both pre and post.
+
+This is the prologue counterpart to the q0..q3 sibling-framed lemmas below.
+The full unaligned MLOAD compose slice uses it to preserve the byte-window and
+destination-cell frame while the initial stack offset is loaded and the
+absolute memory address is computed.
+
+Distinctive token: mload_prologue_stack_spec_within_framed sibling-quarter
+cells #53.
+-/
+theorem mload_prologue_stack_spec_within_framed
+    (offReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset offOld addrOld memBase : Word) (base : Word)
+    (F : Assertion) (hF : F.pcFree)
+    (h_off_ne_x0 : offReg ≠ .x0)
+    (h_addr_ne_x0 : addrReg ≠ .x0) :
+    cpsTripleWithin 2 base (base + 8)
+      (mloadStackCode offReg byteReg accReg addrReg memBaseReg base)
+      ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offOld) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ addrOld) **
+        (sp ↦ₘ offset)) ** F)
+      ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+        (sp ↦ₘ offset)) ** F) := by
+  have core := mload_prologue_stack_spec_within
+    offReg byteReg accReg addrReg memBaseReg
+    sp offset offOld addrOld memBase base
+    h_off_ne_x0 h_addr_ne_x0
+  have framed := cpsTripleWithin_frameL (F := F) hF core
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by sep_perm hp)
+    (fun _ hp => by sep_perm hp)
+    framed
 
 /--
 Sibling-framed q0 stack spec: `evm_mload_unaligned_one_limb_q0_stack_spec_within`

--- a/EvmAsm/Evm64/MLoad/UnalignedFramedStackSpec.lean
+++ b/EvmAsm/Evm64/MLoad/UnalignedFramedStackSpec.lean
@@ -151,6 +151,46 @@ theorem evm_mload_combined_one_limb_sequence_stack_spec_within_framed
     framed
 
 /--
+Framed version of `evm_mload_combined_stack_spec_within`.
+
+This is the coarse-body counterpart of
+`evm_mload_combined_one_limb_sequence_stack_spec_within_framed`: callers that
+already produce one consolidated MLOAD body triple can preserve an arbitrary
+`pcFree` frame across the public prologue/body composition.
+
+Distinctive token: evm_mload_combined_stack_spec_within_framed #53.
+-/
+theorem evm_mload_combined_stack_spec_within_framed
+    {n : Nat} {Q : Assertion}
+    (offReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset offOld addrOld memBase : Word) (base : Word)
+    (F : Assertion) (hF : F.pcFree)
+    (h_off_ne_x0 : offReg ≠ .x0)
+    (h_addr_ne_x0 : addrReg ≠ .x0)
+    (h4 :
+      cpsTripleWithin n (base + 8) (base + 376)
+        (mloadStackCode offReg byteReg accReg addrReg memBaseReg base)
+        (((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+         (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+         (sp ↦ₘ offset))
+        Q) :
+    cpsTripleWithin (2 + n) base (base + 376)
+      (evm_mload_code offReg byteReg accReg addrReg memBaseReg base)
+      ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offOld) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ addrOld) **
+        (sp ↦ₘ offset)) ** F)
+      (Q ** F) := by
+  have framed := cpsTripleWithin_frameL (F := F) hF
+    (evm_mload_combined_stack_spec_within
+      offReg byteReg accReg addrReg memBaseReg
+      sp offset offOld addrOld memBase base
+      h_off_ne_x0 h_addr_ne_x0 h4)
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by sep_perm hp)
+    (fun _ hp => by sep_perm hp)
+    framed
+
+/--
 Threaded-frame variant of `evm_mload_combined_one_limb_sequence_stack_spec_within`.
 
 Unlike the whole-sequence frame wrapper above, this theorem starts q0 from the

--- a/EvmAsm/Evm64/MLoad/UnalignedFramedStackSpec.lean
+++ b/EvmAsm/Evm64/MLoad/UnalignedFramedStackSpec.lean
@@ -1189,4 +1189,88 @@ theorem evm_mload_unaligned_full_stack_spec_within_public_folded
       h_off_ne_x0 h_addr_ne_x0 h_byte_ne_x0 h_acc_ne_x0
       h_window0 h_window1 h_window2 h_window3)
 
+/--
+Stack-tail variant of the folded public unaligned MLOAD composition.
+
+This frames a remaining EVM stack tail around the folded postcondition and
+folds the produced word plus tail into `evmStackIs`.
+
+Distinctive token:
+evm_mload_unaligned_full_stack_spec_within_public_stack_tail #53.
+-/
+theorem evm_mload_unaligned_full_stack_spec_within_public_stack_tail
+    (offReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset offOld addrOld memBase byteOld accOld : Word)
+    (dstOld1 dstOld2 dstOld3 : Word)
+    (loAddr0 hiAddr0 loVal0 hiVal0 : Word)
+    (loAddr1 hiAddr1 loVal1 hiVal1 : Word)
+    (loAddr2 hiAddr2 loVal2 hiVal2 : Word)
+    (loAddr3 hiAddr3 loVal3 hiVal3 : Word)
+    (start : Nat) (base : Word) (rest : List EvmWord)
+    (h_off_ne_x0 : offReg ≠ .x0)
+    (h_addr_ne_x0 : addrReg ≠ .x0)
+    (h_byte_ne_x0 : byteReg ≠ .x0)
+    (h_acc_ne_x0 : accReg ≠ .x0)
+    (h_window0 : mloadLimbWindowOk (memBase + offset) loAddr0 hiAddr0 start
+                  24 25 26 27 28 29 30 31)
+    (h_window1 : mloadLimbWindowOk (memBase + offset) loAddr1 hiAddr1 start
+                  16 17 18 19 20 21 22 23)
+    (h_window2 : mloadLimbWindowOk (memBase + offset) loAddr2 hiAddr2 start
+                  8 9 10 11 12 13 14 15)
+    (h_window3 : mloadLimbWindowOk (memBase + offset) loAddr3 hiAddr3 start
+                  0 1 2 3 4 5 6 7) :
+    let loaded3 := mloadPackedLimbFromDwordPair loVal3 hiVal3 start
+    cpsTripleWithin (2 + (23 + 23 + 23 + 23)) base (base + 376)
+      (evm_mload_code offReg byteReg accReg addrReg memBaseReg base)
+      (((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offOld) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ addrOld) **
+        (sp ↦ₘ offset)) **
+       ((byteReg ↦ᵣ byteOld) ** (accReg ↦ᵣ accOld) **
+        (sp + 8 ↦ₘ dstOld1) ** (sp + 16 ↦ₘ dstOld2) **
+        (sp + 24 ↦ₘ dstOld3) **
+        (loAddr0 ↦ₘ loVal0) ** (hiAddr0 ↦ₘ hiVal0) **
+        (loAddr1 ↦ₘ loVal1) ** (hiAddr1 ↦ₘ hiVal1) **
+        (loAddr2 ↦ₘ loVal2) ** (hiAddr2 ↦ₘ hiVal2) **
+        (loAddr3 ↦ₘ loVal3) ** (hiAddr3 ↦ₘ hiVal3))) **
+       evmStackIs (sp + 32) rest)
+      (evmStackIs sp
+        (mloadStackOutputWordFromDwordPairs
+          loVal0 hiVal0 start loVal1 hiVal1 start
+          loVal2 hiVal2 start loVal3 hiVal3 start :: rest) **
+       (((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+        (byteReg ↦ᵣ
+          (mloadByteFromDwordPair loVal3 hiVal3 start 7).zeroExtend 64) **
+        (accReg ↦ᵣ loaded3) **
+        (loAddr0 ↦ₘ loVal0) ** (hiAddr0 ↦ₘ hiVal0) **
+        (loAddr1 ↦ₘ loVal1) ** (hiAddr1 ↦ₘ hiVal1) **
+        (loAddr2 ↦ₘ loVal2) ** (hiAddr2 ↦ₘ hiVal2) **
+        (loAddr3 ↦ₘ loVal3) ** (hiAddr3 ↦ₘ hiVal3))) := by
+  dsimp only
+  have hCore :=
+    cpsTripleWithin_frameR (evmStackIs (sp + 32) rest) (by pcFree)
+      (evm_mload_unaligned_full_stack_spec_within_public_folded
+        offReg byteReg accReg addrReg memBaseReg
+        sp offset offOld addrOld memBase byteOld accOld
+        dstOld1 dstOld2 dstOld3
+        loAddr0 hiAddr0 loVal0 hiVal0
+        loAddr1 hiAddr1 loVal1 hiVal1
+        loAddr2 hiAddr2 loVal2 hiVal2
+        loAddr3 hiAddr3 loVal3 hiVal3
+        start base
+        h_off_ne_x0 h_addr_ne_x0 h_byte_ne_x0 h_acc_ne_x0
+        h_window0 h_window1 h_window2 h_window3)
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by sep_perm hp)
+    (fun _ hp => by
+      rw [← mloadStackOutputPost_evmStackIs_fold
+        sp
+        loVal0 hiVal0 start
+        loVal1 hiVal1 start
+        loVal2 hiVal2 start
+        loVal3 hiVal3 start
+        rest]
+      sep_perm hp)
+    hCore
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/MLoad/UnalignedFramedStackSpec.lean
+++ b/EvmAsm/Evm64/MLoad/UnalignedFramedStackSpec.lean
@@ -545,6 +545,51 @@ theorem evm_mload_unaligned_one_limb_q2_stack_spec_within_framed
     framed
 
 /--
+Public-code q2 framed MLOAD spec: transports
+`evm_mload_unaligned_one_limb_q2_stack_spec_within_framed` from the q2
+one-limb block to the full `evm_mload_code` code requirement.
+
+Distinctive token:
+evm_mload_unaligned_one_limb_q2_spec_within_framed_public_code #53.
+-/
+theorem evm_mload_unaligned_one_limb_q2_spec_within_framed_public_code
+    (offReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset memBase byteOld accOld : Word)
+    (q0Old q1Old : Word)
+    (loAddr2 hiAddr2 loVal2 hiVal2 : Word) (start : Nat)
+    (dstOld : Word)
+    (base : Word)
+    (F : Assertion) (hF : F.pcFree)
+    (h_byte_ne_x0 : byteReg ≠ .x0) (h_acc_ne_x0 : accReg ≠ .x0)
+    (h_window : mloadLimbWindowOk (memBase + offset) loAddr2 hiAddr2 start
+                  8 9 10 11 12 13 14 15) :
+    cpsTripleWithin 23 (base + 192) (base + 284)
+      (evm_mload_code offReg byteReg accReg addrReg memBaseReg base)
+      ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+        (sp ↦ₘ q0Old) **
+        (sp + 8 ↦ₘ q1Old) **
+        (sp + 16 ↦ₘ dstOld) **
+        ((byteReg ↦ᵣ byteOld) ** (accReg ↦ᵣ accOld) **
+         (loAddr2 ↦ₘ loVal2) ** (hiAddr2 ↦ₘ hiVal2))) ** F)
+      ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+        (sp ↦ₘ q0Old) **
+        (sp + 8 ↦ₘ q1Old) **
+        (sp + 16 ↦ₘ mloadPackedLimbFromDwordPair loVal2 hiVal2 start) **
+        ((byteReg ↦ᵣ
+           (mloadByteFromDwordPair loVal2 hiVal2 start 7).zeroExtend 64) **
+         (accReg ↦ᵣ mloadPackedLimbFromDwordPair loVal2 hiVal2 start) **
+         (loAddr2 ↦ₘ loVal2) ** (hiAddr2 ↦ₘ hiVal2))) ** F) := by
+  exact cpsTripleWithin_evm_mload_of_one_limb_q2
+    offReg byteReg accReg addrReg memBaseReg base
+    (evm_mload_unaligned_one_limb_q2_stack_spec_within_framed
+      offReg byteReg accReg addrReg memBaseReg
+      sp offset memBase byteOld accOld q0Old q1Old
+      loAddr2 hiAddr2 loVal2 hiVal2 start dstOld base F hF
+      h_byte_ne_x0 h_acc_ne_x0 h_window)
+
+/--
 Sibling-framed q3 stack spec: `evm_mload_unaligned_one_limb_q3_stack_spec_within`
 with an arbitrary `pcFree` assertion `F` framed on both pre and post.
 

--- a/EvmAsm/Evm64/MLoad/UnalignedFramedStackSpec.lean
+++ b/EvmAsm/Evm64/MLoad/UnalignedFramedStackSpec.lean
@@ -1273,4 +1273,86 @@ theorem evm_mload_unaligned_full_stack_spec_within_public_stack_tail
       sep_perm hp)
     hCore
 
+/--
+Stack-pre variant of the public unaligned MLOAD stack-tail composition.
+
+This exposes the consumed offset word as an `evmStackIs` precondition while
+threading the remaining tail through the existing public stack-tail theorem.
+
+Distinctive token:
+evm_mload_unaligned_full_stack_spec_within_public_stack_pre #53.
+-/
+theorem evm_mload_unaligned_full_stack_spec_within_public_stack_pre
+    (offReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset offOld addrOld memBase byteOld accOld : Word)
+    (offsetWord : EvmWord) (rest : List EvmWord)
+    (dstOld1 dstOld2 dstOld3 : Word)
+    (loAddr0 hiAddr0 loVal0 hiVal0 : Word)
+    (loAddr1 hiAddr1 loVal1 hiVal1 : Word)
+    (loAddr2 hiAddr2 loVal2 hiVal2 : Word)
+    (loAddr3 hiAddr3 loVal3 hiVal3 : Word)
+    (start : Nat) (base : Word)
+    (h_offset0 : offsetWord.getLimbN 0 = offset)
+    (h_offset1 : offsetWord.getLimbN 1 = dstOld1)
+    (h_offset2 : offsetWord.getLimbN 2 = dstOld2)
+    (h_offset3 : offsetWord.getLimbN 3 = dstOld3)
+    (h_off_ne_x0 : offReg ≠ .x0)
+    (h_addr_ne_x0 : addrReg ≠ .x0)
+    (h_byte_ne_x0 : byteReg ≠ .x0)
+    (h_acc_ne_x0 : accReg ≠ .x0)
+    (h_window0 : mloadLimbWindowOk (memBase + offset) loAddr0 hiAddr0 start
+                  24 25 26 27 28 29 30 31)
+    (h_window1 : mloadLimbWindowOk (memBase + offset) loAddr1 hiAddr1 start
+                  16 17 18 19 20 21 22 23)
+    (h_window2 : mloadLimbWindowOk (memBase + offset) loAddr2 hiAddr2 start
+                  8 9 10 11 12 13 14 15)
+    (h_window3 : mloadLimbWindowOk (memBase + offset) loAddr3 hiAddr3 start
+                  0 1 2 3 4 5 6 7) :
+    let loaded3 := mloadPackedLimbFromDwordPair loVal3 hiVal3 start
+    cpsTripleWithin (2 + (23 + 23 + 23 + 23)) base (base + 376)
+      (evm_mload_code offReg byteReg accReg addrReg memBaseReg base)
+      (((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offOld) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ addrOld) **
+        evmStackIs sp (offsetWord :: rest)) **
+       ((byteReg ↦ᵣ byteOld) ** (accReg ↦ᵣ accOld) **
+        (loAddr0 ↦ₘ loVal0) ** (hiAddr0 ↦ₘ hiVal0) **
+        (loAddr1 ↦ₘ loVal1) ** (hiAddr1 ↦ₘ hiVal1) **
+        (loAddr2 ↦ₘ loVal2) ** (hiAddr2 ↦ₘ hiVal2) **
+        (loAddr3 ↦ₘ loVal3) ** (hiAddr3 ↦ₘ hiVal3))))
+      (evmStackIs sp
+        (mloadStackOutputWordFromDwordPairs
+          loVal0 hiVal0 start loVal1 hiVal1 start
+          loVal2 hiVal2 start loVal3 hiVal3 start :: rest) **
+       (((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+        (byteReg ↦ᵣ
+          (mloadByteFromDwordPair loVal3 hiVal3 start 7).zeroExtend 64) **
+        (accReg ↦ᵣ loaded3) **
+        (loAddr0 ↦ₘ loVal0) ** (hiAddr0 ↦ₘ hiVal0) **
+        (loAddr1 ↦ₘ loVal1) ** (hiAddr1 ↦ₘ hiVal1) **
+        (loAddr2 ↦ₘ loVal2) ** (hiAddr2 ↦ₘ hiVal2) **
+        (loAddr3 ↦ₘ loVal3) ** (hiAddr3 ↦ₘ hiVal3))) := by
+  dsimp only
+  have hCore :=
+    evm_mload_unaligned_full_stack_spec_within_public_stack_tail
+      offReg byteReg accReg addrReg memBaseReg
+      sp offset offOld addrOld memBase byteOld accOld
+      dstOld1 dstOld2 dstOld3
+      loAddr0 hiAddr0 loVal0 hiVal0
+      loAddr1 hiAddr1 loVal1 hiVal1
+      loAddr2 hiAddr2 loVal2 hiVal2
+      loAddr3 hiAddr3 loVal3 hiVal3
+      start base rest
+      h_off_ne_x0 h_addr_ne_x0 h_byte_ne_x0 h_acc_ne_x0
+      h_window0 h_window1 h_window2 h_window3
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by
+      rw [evmStackIs_cons] at hp
+      rw [evmWordIs_sp_limbs_eq sp offsetWord
+        offset dstOld1 dstOld2 dstOld3
+        h_offset0 h_offset1 h_offset2 h_offset3] at hp
+      sep_perm hp)
+    (fun _ hp => by sep_perm hp)
+    hCore
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/MLoad/UnalignedFramedStackSpec.lean
+++ b/EvmAsm/Evm64/MLoad/UnalignedFramedStackSpec.lean
@@ -639,4 +639,51 @@ theorem evm_mload_unaligned_one_limb_q3_stack_spec_within_framed
     (fun _ hp => by sep_perm hp)
     framed
 
+/--
+Public-code q3 framed MLOAD spec: transports
+`evm_mload_unaligned_one_limb_q3_stack_spec_within_framed` from the q3
+one-limb block to the full `evm_mload_code` code requirement.
+
+Distinctive token:
+evm_mload_unaligned_one_limb_q3_spec_within_framed_public_code #53.
+-/
+theorem evm_mload_unaligned_one_limb_q3_spec_within_framed_public_code
+    (offReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset memBase byteOld accOld : Word)
+    (q0Old q1Old q2Old : Word)
+    (loAddr3 hiAddr3 loVal3 hiVal3 : Word) (start : Nat)
+    (dstOld : Word)
+    (base : Word)
+    (F : Assertion) (hF : F.pcFree)
+    (h_byte_ne_x0 : byteReg ≠ .x0) (h_acc_ne_x0 : accReg ≠ .x0)
+    (h_window : mloadLimbWindowOk (memBase + offset) loAddr3 hiAddr3 start
+                  0 1 2 3 4 5 6 7) :
+    cpsTripleWithin 23 (base + 284) (base + 376)
+      (evm_mload_code offReg byteReg accReg addrReg memBaseReg base)
+      ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+        (sp ↦ₘ q0Old) **
+        (sp + 8 ↦ₘ q1Old) **
+        (sp + 16 ↦ₘ q2Old) **
+        (sp + 24 ↦ₘ dstOld) **
+        ((byteReg ↦ᵣ byteOld) ** (accReg ↦ᵣ accOld) **
+         (loAddr3 ↦ₘ loVal3) ** (hiAddr3 ↦ₘ hiVal3))) ** F)
+      ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+        (sp ↦ₘ q0Old) **
+        (sp + 8 ↦ₘ q1Old) **
+        (sp + 16 ↦ₘ q2Old) **
+        (sp + 24 ↦ₘ mloadPackedLimbFromDwordPair loVal3 hiVal3 start) **
+        ((byteReg ↦ᵣ
+           (mloadByteFromDwordPair loVal3 hiVal3 start 7).zeroExtend 64) **
+         (accReg ↦ᵣ mloadPackedLimbFromDwordPair loVal3 hiVal3 start) **
+         (loAddr3 ↦ₘ loVal3) ** (hiAddr3 ↦ₘ hiVal3))) ** F) := by
+  exact cpsTripleWithin_evm_mload_of_one_limb_q3
+    offReg byteReg accReg addrReg memBaseReg base
+    (evm_mload_unaligned_one_limb_q3_stack_spec_within_framed
+      offReg byteReg accReg addrReg memBaseReg
+      sp offset memBase byteOld accOld q0Old q1Old q2Old
+      loAddr3 hiAddr3 loVal3 hiVal3 start dstOld base F hF
+      h_byte_ne_x0 h_acc_ne_x0 h_window)
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/MLoad/UnalignedFramedStackSpec.lean
+++ b/EvmAsm/Evm64/MLoad/UnalignedFramedStackSpec.lean
@@ -262,6 +262,66 @@ theorem evm_mload_code_one_limb_q3_sub
     (mloadStackCode_four_limbs_sub offReg byteReg accReg addrReg memBaseReg base a i
       (mloadFourLimbsCode_one_limb_q3_sub addrReg byteReg accReg base a i h))
 
+/-- Transport a q0 MLOAD one-limb triple to the public `evm_mload_code`. -/
+theorem cpsTripleWithin_evm_mload_of_one_limb_q0
+    {n : Nat} {P Q : Assertion}
+    (offReg byteReg accReg addrReg memBaseReg : Reg) (base : Word)
+    (h :
+      cpsTripleWithin n (base + 8) (base + 100)
+        (mloadOneLimbCode addrReg byteReg accReg
+          24 25 26 27 28 29 30 31 0 (base + 8)) P Q) :
+    cpsTripleWithin n (base + 8) (base + 100)
+      (evm_mload_code offReg byteReg accReg addrReg memBaseReg base) P Q :=
+  cpsTripleWithin_extend_code
+    (h := h)
+    (hmono := evm_mload_code_one_limb_q0_sub
+      offReg byteReg accReg addrReg memBaseReg base)
+
+/-- Transport a q1 MLOAD one-limb triple to the public `evm_mload_code`. -/
+theorem cpsTripleWithin_evm_mload_of_one_limb_q1
+    {n : Nat} {P Q : Assertion}
+    (offReg byteReg accReg addrReg memBaseReg : Reg) (base : Word)
+    (h :
+      cpsTripleWithin n (base + 100) (base + 192)
+        (mloadOneLimbCode addrReg byteReg accReg
+          16 17 18 19 20 21 22 23 8 (base + 100)) P Q) :
+    cpsTripleWithin n (base + 100) (base + 192)
+      (evm_mload_code offReg byteReg accReg addrReg memBaseReg base) P Q :=
+  cpsTripleWithin_extend_code
+    (h := h)
+    (hmono := evm_mload_code_one_limb_q1_sub
+      offReg byteReg accReg addrReg memBaseReg base)
+
+/-- Transport a q2 MLOAD one-limb triple to the public `evm_mload_code`. -/
+theorem cpsTripleWithin_evm_mload_of_one_limb_q2
+    {n : Nat} {P Q : Assertion}
+    (offReg byteReg accReg addrReg memBaseReg : Reg) (base : Word)
+    (h :
+      cpsTripleWithin n (base + 192) (base + 284)
+        (mloadOneLimbCode addrReg byteReg accReg
+          8 9 10 11 12 13 14 15 16 (base + 192)) P Q) :
+    cpsTripleWithin n (base + 192) (base + 284)
+      (evm_mload_code offReg byteReg accReg addrReg memBaseReg base) P Q :=
+  cpsTripleWithin_extend_code
+    (h := h)
+    (hmono := evm_mload_code_one_limb_q2_sub
+      offReg byteReg accReg addrReg memBaseReg base)
+
+/-- Transport a q3 MLOAD one-limb triple to the public `evm_mload_code`. -/
+theorem cpsTripleWithin_evm_mload_of_one_limb_q3
+    {n : Nat} {P Q : Assertion}
+    (offReg byteReg accReg addrReg memBaseReg : Reg) (base : Word)
+    (h :
+      cpsTripleWithin n (base + 284) (base + 376)
+        (mloadOneLimbCode addrReg byteReg accReg
+          0 1 2 3 4 5 6 7 24 (base + 284)) P Q) :
+    cpsTripleWithin n (base + 284) (base + 376)
+      (evm_mload_code offReg byteReg accReg addrReg memBaseReg base) P Q :=
+  cpsTripleWithin_extend_code
+    (h := h)
+    (hmono := evm_mload_code_one_limb_q3_sub
+      offReg byteReg accReg addrReg memBaseReg base)
+
 /--
 Sibling-framed q0 stack spec: `evm_mload_unaligned_one_limb_q0_stack_spec_within`
 with an arbitrary `pcFree` assertion `F` framed on both pre and post.

--- a/EvmAsm/Evm64/MLoad/UnalignedFramedStackSpec.lean
+++ b/EvmAsm/Evm64/MLoad/UnalignedFramedStackSpec.lean
@@ -191,6 +191,54 @@ theorem evm_mload_combined_stack_spec_within_framed
     framed
 
 /--
+Framed version of `evm_mload_combined_four_limb_sequence_stack_spec_within`.
+
+This wrapper preserves an arbitrary `pcFree` frame around the public MLOAD
+prologue plus four `mloadFourLimbsCode` quarter triples.
+
+Distinctive token:
+evm_mload_combined_four_limb_sequence_stack_spec_within_framed #53.
+-/
+theorem evm_mload_combined_four_limb_sequence_stack_spec_within_framed
+    {n0 n1 n2 n3 : Nat} {P1 P2 P3 Q : Assertion}
+    (offReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset offOld addrOld memBase : Word) (base : Word)
+    (F : Assertion) (hF : F.pcFree)
+    (h_off_ne_x0 : offReg ≠ .x0)
+    (h_addr_ne_x0 : addrReg ≠ .x0)
+    (h0 :
+      cpsTripleWithin n0 (base + 8) (base + 100)
+        (mloadFourLimbsCode addrReg byteReg accReg base)
+        (((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+         (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+         (sp ↦ₘ offset))
+        P1)
+    (h1 :
+      cpsTripleWithin n1 (base + 100) (base + 192)
+        (mloadFourLimbsCode addrReg byteReg accReg base) P1 P2)
+    (h2 :
+      cpsTripleWithin n2 (base + 192) (base + 284)
+        (mloadFourLimbsCode addrReg byteReg accReg base) P2 P3)
+    (h3 :
+      cpsTripleWithin n3 (base + 284) (base + 376)
+        (mloadFourLimbsCode addrReg byteReg accReg base) P3 Q) :
+    cpsTripleWithin (2 + (n0 + n1 + n2 + n3)) base (base + 376)
+      (evm_mload_code offReg byteReg accReg addrReg memBaseReg base)
+      ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offOld) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ addrOld) **
+        (sp ↦ₘ offset)) ** F)
+      (Q ** F) := by
+  have framed := cpsTripleWithin_frameL (F := F) hF
+    (evm_mload_combined_four_limb_sequence_stack_spec_within
+      offReg byteReg accReg addrReg memBaseReg
+      sp offset offOld addrOld memBase base
+      h_off_ne_x0 h_addr_ne_x0 h0 h1 h2 h3)
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by sep_perm hp)
+    (fun _ hp => by sep_perm hp)
+    framed
+
+/--
 Threaded-frame variant of `evm_mload_combined_one_limb_sequence_stack_spec_within`.
 
 Unlike the whole-sequence frame wrapper above, this theorem starts q0 from the

--- a/EvmAsm/Evm64/MLoad/UnalignedFramedStackSpec.lean
+++ b/EvmAsm/Evm64/MLoad/UnalignedFramedStackSpec.lean
@@ -454,6 +454,49 @@ theorem evm_mload_unaligned_one_limb_q1_stack_spec_within_framed
     framed
 
 /--
+Public-code q1 framed MLOAD spec: transports
+`evm_mload_unaligned_one_limb_q1_stack_spec_within_framed` from the q1
+one-limb block to the full `evm_mload_code` code requirement.
+
+Distinctive token:
+evm_mload_unaligned_one_limb_q1_spec_within_framed_public_code #53.
+-/
+theorem evm_mload_unaligned_one_limb_q1_spec_within_framed_public_code
+    (offReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset memBase byteOld accOld : Word)
+    (q0Old : Word)
+    (loAddr1 hiAddr1 loVal1 hiVal1 : Word) (start : Nat)
+    (dstOld : Word)
+    (base : Word)
+    (F : Assertion) (hF : F.pcFree)
+    (h_byte_ne_x0 : byteReg ≠ .x0) (h_acc_ne_x0 : accReg ≠ .x0)
+    (h_window : mloadLimbWindowOk (memBase + offset) loAddr1 hiAddr1 start
+                  16 17 18 19 20 21 22 23) :
+    cpsTripleWithin 23 (base + 100) (base + 192)
+      (evm_mload_code offReg byteReg accReg addrReg memBaseReg base)
+      ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+        (sp ↦ₘ q0Old) **
+        (sp + 8 ↦ₘ dstOld) **
+        ((byteReg ↦ᵣ byteOld) ** (accReg ↦ᵣ accOld) **
+         (loAddr1 ↦ₘ loVal1) ** (hiAddr1 ↦ₘ hiVal1))) ** F)
+      ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+        (sp ↦ₘ q0Old) **
+        (sp + 8 ↦ₘ mloadPackedLimbFromDwordPair loVal1 hiVal1 start) **
+        ((byteReg ↦ᵣ
+           (mloadByteFromDwordPair loVal1 hiVal1 start 7).zeroExtend 64) **
+         (accReg ↦ᵣ mloadPackedLimbFromDwordPair loVal1 hiVal1 start) **
+         (loAddr1 ↦ₘ loVal1) ** (hiAddr1 ↦ₘ hiVal1))) ** F) := by
+  exact cpsTripleWithin_evm_mload_of_one_limb_q1
+    offReg byteReg accReg addrReg memBaseReg base
+    (evm_mload_unaligned_one_limb_q1_stack_spec_within_framed
+      offReg byteReg accReg addrReg memBaseReg
+      sp offset memBase byteOld accOld q0Old
+      loAddr1 hiAddr1 loVal1 hiVal1 start dstOld base F hF
+      h_byte_ne_x0 h_acc_ne_x0 h_window)
+
+/--
 Sibling-framed q2 stack spec: `evm_mload_unaligned_one_limb_q2_stack_spec_within`
 with an arbitrary `pcFree` assertion `F` framed on both pre and post.
 

--- a/EvmAsm/Evm64/MLoad/UnalignedFramedStackSpec.lean
+++ b/EvmAsm/Evm64/MLoad/UnalignedFramedStackSpec.lean
@@ -356,6 +356,53 @@ theorem evm_mload_public_one_limb_sequence_spec_within
     h3
 
 /--
+Compose the framed MLOAD prologue with four public-code one-limb quarter
+triples.
+
+This is useful once q0..q3 have already been transported to `evm_mload_code`;
+the theorem supplies the prologue step and sequences the public body in one
+call.
+
+Distinctive token: evm_mload_public_one_limb_sequence_with_prologue_framed #53.
+-/
+theorem evm_mload_public_one_limb_sequence_with_prologue_framed
+    {n0 n1 n2 n3 : Nat} {P1 P2 P3 Q : Assertion}
+    (offReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset offOld addrOld memBase : Word) (base : Word)
+    (F : Assertion) (hF : F.pcFree)
+    (h_off_ne_x0 : offReg ≠ .x0)
+    (h_addr_ne_x0 : addrReg ≠ .x0)
+    (h0 :
+      cpsTripleWithin n0 (base + 8) (base + 100)
+        (evm_mload_code offReg byteReg accReg addrReg memBaseReg base)
+        ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+          (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+          (sp ↦ₘ offset)) ** F)
+        P1)
+    (h1 :
+      cpsTripleWithin n1 (base + 100) (base + 192)
+        (evm_mload_code offReg byteReg accReg addrReg memBaseReg base) P1 P2)
+    (h2 :
+      cpsTripleWithin n2 (base + 192) (base + 284)
+        (evm_mload_code offReg byteReg accReg addrReg memBaseReg base) P2 P3)
+    (h3 :
+      cpsTripleWithin n3 (base + 284) (base + 376)
+        (evm_mload_code offReg byteReg accReg addrReg memBaseReg base) P3 Q) :
+    cpsTripleWithin (2 + (n0 + n1 + n2 + n3)) base (base + 376)
+      (evm_mload_code offReg byteReg accReg addrReg memBaseReg base)
+      ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offOld) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ addrOld) **
+        (sp ↦ₘ offset)) ** F)
+      Q := by
+  exact cpsTripleWithin_seq_same_cr
+    (evm_mload_prologue_stack_spec_within_framed
+      offReg byteReg accReg addrReg memBaseReg
+      sp offset offOld addrOld memBase base F hF
+      h_off_ne_x0 h_addr_ne_x0)
+    (evm_mload_public_one_limb_sequence_spec_within
+      offReg byteReg accReg addrReg memBaseReg base h0 h1 h2 h3)
+
+/--
 Sibling-framed q0 stack spec: `evm_mload_unaligned_one_limb_q0_stack_spec_within`
 with an arbitrary `pcFree` assertion `F` framed on both pre and post.
 

--- a/EvmAsm/Evm64/MLoad/UnalignedFramedStackSpec.lean
+++ b/EvmAsm/Evm64/MLoad/UnalignedFramedStackSpec.lean
@@ -979,4 +979,136 @@ theorem evm_mload_unaligned_one_limb_q3_spec_within_framed_public_code
       loAddr3 hiAddr3 loVal3 hiVal3 start dstOld base F hF
       h_byte_ne_x0 h_acc_ne_x0 h_window)
 
+/--
+Concrete public-code composition of the four unaligned MLOAD quarter specs.
+
+The theorem instantiates q0..q3 with sibling frames that thread the remaining
+destination stack cells and byte-window cells, then uses `sep_perm` at each
+midpoint.
+
+Distinctive token: evm_mload_unaligned_full_stack_spec_within_public #53.
+-/
+theorem evm_mload_unaligned_full_stack_spec_within_public
+    (offReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset offOld addrOld memBase byteOld accOld : Word)
+    (dstOld1 dstOld2 dstOld3 : Word)
+    (loAddr0 hiAddr0 loVal0 hiVal0 : Word)
+    (loAddr1 hiAddr1 loVal1 hiVal1 : Word)
+    (loAddr2 hiAddr2 loVal2 hiVal2 : Word)
+    (loAddr3 hiAddr3 loVal3 hiVal3 : Word)
+    (start : Nat) (base : Word)
+    (h_off_ne_x0 : offReg ≠ .x0)
+    (h_addr_ne_x0 : addrReg ≠ .x0)
+    (h_byte_ne_x0 : byteReg ≠ .x0)
+    (h_acc_ne_x0 : accReg ≠ .x0)
+    (h_window0 : mloadLimbWindowOk (memBase + offset) loAddr0 hiAddr0 start
+                  24 25 26 27 28 29 30 31)
+    (h_window1 : mloadLimbWindowOk (memBase + offset) loAddr1 hiAddr1 start
+                  16 17 18 19 20 21 22 23)
+    (h_window2 : mloadLimbWindowOk (memBase + offset) loAddr2 hiAddr2 start
+                  8 9 10 11 12 13 14 15)
+    (h_window3 : mloadLimbWindowOk (memBase + offset) loAddr3 hiAddr3 start
+                  0 1 2 3 4 5 6 7) :
+    let loaded0 := mloadPackedLimbFromDwordPair loVal0 hiVal0 start
+    let loaded1 := mloadPackedLimbFromDwordPair loVal1 hiVal1 start
+    let loaded2 := mloadPackedLimbFromDwordPair loVal2 hiVal2 start
+    let loaded3 := mloadPackedLimbFromDwordPair loVal3 hiVal3 start
+    cpsTripleWithin (2 + (23 + 23 + 23 + 23)) base (base + 376)
+      (evm_mload_code offReg byteReg accReg addrReg memBaseReg base)
+      ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offOld) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ addrOld) **
+        (sp ↦ₘ offset)) **
+       ((byteReg ↦ᵣ byteOld) ** (accReg ↦ᵣ accOld) **
+        (sp + 8 ↦ₘ dstOld1) ** (sp + 16 ↦ₘ dstOld2) **
+        (sp + 24 ↦ₘ dstOld3) **
+        (loAddr0 ↦ₘ loVal0) ** (hiAddr0 ↦ₘ hiVal0) **
+        (loAddr1 ↦ₘ loVal1) ** (hiAddr1 ↦ₘ hiVal1) **
+        (loAddr2 ↦ₘ loVal2) ** (hiAddr2 ↦ₘ hiVal2) **
+        (loAddr3 ↦ₘ loVal3) ** (hiAddr3 ↦ₘ hiVal3)))
+      ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+        (sp ↦ₘ loaded0) ** (sp + 8 ↦ₘ loaded1) **
+        (sp + 16 ↦ₘ loaded2) ** (sp + 24 ↦ₘ loaded3) **
+        ((byteReg ↦ᵣ
+           (mloadByteFromDwordPair loVal3 hiVal3 start 7).zeroExtend 64) **
+         (accReg ↦ᵣ loaded3) **
+         (loAddr3 ↦ₘ loVal3) ** (hiAddr3 ↦ₘ hiVal3))) **
+       ((loAddr0 ↦ₘ loVal0) ** (hiAddr0 ↦ₘ hiVal0) **
+        (loAddr1 ↦ₘ loVal1) ** (hiAddr1 ↦ₘ hiVal1) **
+        (loAddr2 ↦ₘ loVal2) ** (hiAddr2 ↦ₘ hiVal2))) := by
+  let Fpre : Assertion :=
+    (byteReg ↦ᵣ byteOld) ** (accReg ↦ᵣ accOld) **
+    (sp + 8 ↦ₘ dstOld1) ** (sp + 16 ↦ₘ dstOld2) **
+    (sp + 24 ↦ₘ dstOld3) **
+    (loAddr0 ↦ₘ loVal0) ** (hiAddr0 ↦ₘ hiVal0) **
+    (loAddr1 ↦ₘ loVal1) ** (hiAddr1 ↦ₘ hiVal1) **
+    (loAddr2 ↦ₘ loVal2) ** (hiAddr2 ↦ₘ hiVal2) **
+    (loAddr3 ↦ₘ loVal3) ** (hiAddr3 ↦ₘ hiVal3)
+  let loaded0 := mloadPackedLimbFromDwordPair loVal0 hiVal0 start
+  let loaded1 := mloadPackedLimbFromDwordPair loVal1 hiVal1 start
+  let loaded2 := mloadPackedLimbFromDwordPair loVal2 hiVal2 start
+  let byte0 := (mloadByteFromDwordPair loVal0 hiVal0 start 7).zeroExtend 64
+  let byte1 := (mloadByteFromDwordPair loVal1 hiVal1 start 7).zeroExtend 64
+  let byte2 := (mloadByteFromDwordPair loVal2 hiVal2 start 7).zeroExtend 64
+  let F0 : Assertion :=
+    (sp + 8 ↦ₘ dstOld1) ** (sp + 16 ↦ₘ dstOld2) **
+    (sp + 24 ↦ₘ dstOld3) **
+    (loAddr1 ↦ₘ loVal1) ** (hiAddr1 ↦ₘ hiVal1) **
+    (loAddr2 ↦ₘ loVal2) ** (hiAddr2 ↦ₘ hiVal2) **
+    (loAddr3 ↦ₘ loVal3) ** (hiAddr3 ↦ₘ hiVal3)
+  let F1 : Assertion :=
+    (loAddr0 ↦ₘ loVal0) ** (hiAddr0 ↦ₘ hiVal0) **
+    (sp + 16 ↦ₘ dstOld2) ** (sp + 24 ↦ₘ dstOld3) **
+    (loAddr2 ↦ₘ loVal2) ** (hiAddr2 ↦ₘ hiVal2) **
+    (loAddr3 ↦ₘ loVal3) ** (hiAddr3 ↦ₘ hiVal3)
+  let F2 : Assertion :=
+    (loAddr0 ↦ₘ loVal0) ** (hiAddr0 ↦ₘ hiVal0) **
+    (loAddr1 ↦ₘ loVal1) ** (hiAddr1 ↦ₘ hiVal1) **
+    (sp + 24 ↦ₘ dstOld3) **
+    (loAddr3 ↦ₘ loVal3) ** (hiAddr3 ↦ₘ hiVal3)
+  let F3 : Assertion :=
+    (loAddr0 ↦ₘ loVal0) ** (hiAddr0 ↦ₘ hiVal0) **
+    (loAddr1 ↦ₘ loVal1) ** (hiAddr1 ↦ₘ hiVal1) **
+    (loAddr2 ↦ₘ loVal2) ** (hiAddr2 ↦ₘ hiVal2)
+  dsimp only
+  exact cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by
+      dsimp only [Fpre, F0] at hp ⊢
+      sep_perm hp)
+    (evm_mload_prologue_stack_spec_within_framed
+      offReg byteReg accReg addrReg memBaseReg
+      sp offset offOld addrOld memBase base Fpre (by pcFree)
+      h_off_ne_x0 h_addr_ne_x0)
+    (evm_mload_public_one_limb_sequence_spec_within_perm
+      offReg byteReg accReg addrReg memBaseReg base
+      (evm_mload_unaligned_one_limb_q0_spec_within_framed_public_code
+        offReg byteReg accReg addrReg memBaseReg
+        sp offset memBase byteOld accOld
+        loAddr0 hiAddr0 loVal0 hiVal0 start base F0 (by pcFree)
+        h_byte_ne_x0 h_acc_ne_x0 h_window0)
+      (fun _ hp => by
+        dsimp only [F0, F1, loaded0, byte0] at hp ⊢
+        sep_perm hp)
+      (evm_mload_unaligned_one_limb_q1_spec_within_framed_public_code
+        offReg byteReg accReg addrReg memBaseReg
+        sp offset memBase byte0 loaded0 loaded0
+        loAddr1 hiAddr1 loVal1 hiVal1 start dstOld1 base F1 (by pcFree)
+        h_byte_ne_x0 h_acc_ne_x0 h_window1)
+      (fun _ hp => by
+        dsimp only [F1, F2, loaded1, byte1] at hp ⊢
+        sep_perm hp)
+      (evm_mload_unaligned_one_limb_q2_spec_within_framed_public_code
+        offReg byteReg accReg addrReg memBaseReg
+        sp offset memBase byte1 loaded1 loaded0 loaded1
+        loAddr2 hiAddr2 loVal2 hiVal2 start dstOld2 base F2 (by pcFree)
+        h_byte_ne_x0 h_acc_ne_x0 h_window2)
+      (fun _ hp => by
+        dsimp only [F2, F3, loaded2, byte2] at hp ⊢
+        sep_perm hp)
+      (evm_mload_unaligned_one_limb_q3_spec_within_framed_public_code
+        offReg byteReg accReg addrReg memBaseReg
+        sp offset memBase byte2 loaded2 loaded0 loaded1 loaded2
+        loAddr3 hiAddr3 loVal3 hiVal3 start dstOld3 base F3 (by pcFree)
+        h_byte_ne_x0 h_acc_ne_x0 h_window3))
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/MLoad/UnalignedFramedStackSpec.lean
+++ b/EvmAsm/Evm64/MLoad/UnalignedFramedStackSpec.lean
@@ -403,6 +403,41 @@ theorem evm_mload_public_one_limb_sequence_with_prologue_framed
       offReg byteReg accReg addrReg memBaseReg base h0 h1 h2 h3)
 
 /--
+Generic public-code MLOAD prologue/body composition with a framed prologue.
+
+This lets callers plug in any body triple over `evm_mload_code` that starts
+from the framed prologue postcondition, not just the q0..q3 one-limb sequence.
+
+Distinctive token: evm_mload_public_body_with_prologue_framed #53.
+-/
+theorem evm_mload_public_body_with_prologue_framed
+    {n : Nat} {Q : Assertion}
+    (offReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset offOld addrOld memBase : Word) (base pcEnd : Word)
+    (F : Assertion) (hF : F.pcFree)
+    (h_off_ne_x0 : offReg ≠ .x0)
+    (h_addr_ne_x0 : addrReg ≠ .x0)
+    (hbody :
+      cpsTripleWithin n (base + 8) pcEnd
+        (evm_mload_code offReg byteReg accReg addrReg memBaseReg base)
+        ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+          (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+          (sp ↦ₘ offset)) ** F)
+        Q) :
+    cpsTripleWithin (2 + n) base pcEnd
+      (evm_mload_code offReg byteReg accReg addrReg memBaseReg base)
+      ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offOld) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ addrOld) **
+        (sp ↦ₘ offset)) ** F)
+      Q := by
+  exact cpsTripleWithin_seq_same_cr
+    (evm_mload_prologue_stack_spec_within_framed
+      offReg byteReg accReg addrReg memBaseReg
+      sp offset offOld addrOld memBase base F hF
+      h_off_ne_x0 h_addr_ne_x0)
+    hbody
+
+/--
 Sibling-framed q0 stack spec: `evm_mload_unaligned_one_limb_q0_stack_spec_within`
 with an arbitrary `pcFree` assertion `F` framed on both pre and post.
 

--- a/EvmAsm/Evm64/MLoad/UnalignedFramedStackSpec.lean
+++ b/EvmAsm/Evm64/MLoad/UnalignedFramedStackSpec.lean
@@ -369,6 +369,45 @@ theorem evm_mload_unaligned_one_limb_q0_stack_spec_within_framed
     framed
 
 /--
+Public-code q0 framed MLOAD spec: transports
+`evm_mload_unaligned_one_limb_q0_stack_spec_within_framed` from the q0
+one-limb block to the full `evm_mload_code` code requirement.
+
+Distinctive token:
+evm_mload_unaligned_one_limb_q0_spec_within_framed_public_code #53.
+-/
+theorem evm_mload_unaligned_one_limb_q0_spec_within_framed_public_code
+    (offReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset memBase byteOld accOld : Word)
+    (loAddr hiAddr loVal hiVal : Word) (start : Nat)
+    (base : Word)
+    (F : Assertion) (hF : F.pcFree)
+    (h_byte_ne_x0 : byteReg ≠ .x0) (h_acc_ne_x0 : accReg ≠ .x0)
+    (h_window : mloadLimbWindowOk (memBase + offset) loAddr hiAddr start
+                  24 25 26 27 28 29 30 31) :
+    cpsTripleWithin 23 (base + 8) (base + 100)
+      (evm_mload_code offReg byteReg accReg addrReg memBaseReg base)
+      ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+        (sp ↦ₘ offset) **
+        ((byteReg ↦ᵣ byteOld) ** (accReg ↦ᵣ accOld) **
+         (loAddr ↦ₘ loVal) ** (hiAddr ↦ₘ hiVal))) ** F)
+      ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+        (sp ↦ₘ mloadPackedLimbFromDwordPair loVal hiVal start) **
+        ((byteReg ↦ᵣ
+           (mloadByteFromDwordPair loVal hiVal start 7).zeroExtend 64) **
+         (accReg ↦ᵣ mloadPackedLimbFromDwordPair loVal hiVal start) **
+         (loAddr ↦ₘ loVal) ** (hiAddr ↦ₘ hiVal))) ** F) := by
+  exact cpsTripleWithin_evm_mload_of_one_limb_q0
+    offReg byteReg accReg addrReg memBaseReg base
+    (evm_mload_unaligned_one_limb_q0_stack_spec_within_framed
+      offReg byteReg accReg addrReg memBaseReg
+      sp offset memBase byteOld accOld
+      loAddr hiAddr loVal hiVal start base F hF
+      h_byte_ne_x0 h_acc_ne_x0 h_window)
+
+/--
 Sibling-framed q1 stack spec: `evm_mload_unaligned_one_limb_q1_stack_spec_within`
 with an arbitrary `pcFree` assertion `F` framed on both pre and post.
 

--- a/EvmAsm/Evm64/MLoad/UnalignedFramedStackSpec.lean
+++ b/EvmAsm/Evm64/MLoad/UnalignedFramedStackSpec.lean
@@ -68,6 +68,36 @@ theorem mload_prologue_stack_spec_within_framed
     framed
 
 /--
+EVM-code transport of `mload_prologue_stack_spec_within_framed`.
+
+Later full-stack unaligned MLOAD composition can use this theorem directly at
+the public `evm_mload_code` boundary instead of carrying an extra stack-code
+transport step.
+
+Distinctive token: evm_mload_prologue_stack_spec_within_framed #53.
+-/
+theorem evm_mload_prologue_stack_spec_within_framed
+    (offReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset offOld addrOld memBase : Word) (base : Word)
+    (F : Assertion) (hF : F.pcFree)
+    (h_off_ne_x0 : offReg ≠ .x0)
+    (h_addr_ne_x0 : addrReg ≠ .x0) :
+    cpsTripleWithin 2 base (base + 8)
+      (evm_mload_code offReg byteReg accReg addrReg memBaseReg base)
+      ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offOld) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ addrOld) **
+        (sp ↦ₘ offset)) ** F)
+      ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+        (sp ↦ₘ offset)) ** F) := by
+  exact cpsTripleWithin_evm_mload_of_stack
+    offReg byteReg accReg addrReg memBaseReg base (base + 8)
+    (mload_prologue_stack_spec_within_framed
+      offReg byteReg accReg addrReg memBaseReg
+      sp offset offOld addrOld memBase base F hF
+      h_off_ne_x0 h_addr_ne_x0)
+
+/--
 Sibling-framed q0 stack spec: `evm_mload_unaligned_one_limb_q0_stack_spec_within`
 with an arbitrary `pcFree` assertion `F` framed on both pre and post.
 

--- a/EvmAsm/Evm64/MLoad/UnalignedFramedStackSpec.lean
+++ b/EvmAsm/Evm64/MLoad/UnalignedFramedStackSpec.lean
@@ -1111,4 +1111,82 @@ theorem evm_mload_unaligned_full_stack_spec_within_public
         loAddr3 hiAddr3 loVal3 hiVal3 start dstOld3 base F3 (by pcFree)
         h_byte_ne_x0 h_acc_ne_x0 h_window3))
 
+/--
+Folded-post variant of `evm_mload_unaligned_full_stack_spec_within_public`.
+
+This keeps the same concrete public-code composition but exposes the produced
+four stack limbs as the compact `mloadStackOutputPost` assertion.
+
+Distinctive token:
+evm_mload_unaligned_full_stack_spec_within_public_folded #53.
+-/
+theorem evm_mload_unaligned_full_stack_spec_within_public_folded
+    (offReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset offOld addrOld memBase byteOld accOld : Word)
+    (dstOld1 dstOld2 dstOld3 : Word)
+    (loAddr0 hiAddr0 loVal0 hiVal0 : Word)
+    (loAddr1 hiAddr1 loVal1 hiVal1 : Word)
+    (loAddr2 hiAddr2 loVal2 hiVal2 : Word)
+    (loAddr3 hiAddr3 loVal3 hiVal3 : Word)
+    (start : Nat) (base : Word)
+    (h_off_ne_x0 : offReg ≠ .x0)
+    (h_addr_ne_x0 : addrReg ≠ .x0)
+    (h_byte_ne_x0 : byteReg ≠ .x0)
+    (h_acc_ne_x0 : accReg ≠ .x0)
+    (h_window0 : mloadLimbWindowOk (memBase + offset) loAddr0 hiAddr0 start
+                  24 25 26 27 28 29 30 31)
+    (h_window1 : mloadLimbWindowOk (memBase + offset) loAddr1 hiAddr1 start
+                  16 17 18 19 20 21 22 23)
+    (h_window2 : mloadLimbWindowOk (memBase + offset) loAddr2 hiAddr2 start
+                  8 9 10 11 12 13 14 15)
+    (h_window3 : mloadLimbWindowOk (memBase + offset) loAddr3 hiAddr3 start
+                  0 1 2 3 4 5 6 7) :
+    let loaded3 := mloadPackedLimbFromDwordPair loVal3 hiVal3 start
+    cpsTripleWithin (2 + (23 + 23 + 23 + 23)) base (base + 376)
+      (evm_mload_code offReg byteReg accReg addrReg memBaseReg base)
+      ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offOld) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ addrOld) **
+        (sp ↦ₘ offset)) **
+       ((byteReg ↦ᵣ byteOld) ** (accReg ↦ᵣ accOld) **
+        (sp + 8 ↦ₘ dstOld1) ** (sp + 16 ↦ₘ dstOld2) **
+        (sp + 24 ↦ₘ dstOld3) **
+        (loAddr0 ↦ₘ loVal0) ** (hiAddr0 ↦ₘ hiVal0) **
+        (loAddr1 ↦ₘ loVal1) ** (hiAddr1 ↦ₘ hiVal1) **
+        (loAddr2 ↦ₘ loVal2) ** (hiAddr2 ↦ₘ hiVal2) **
+        (loAddr3 ↦ₘ loVal3) ** (hiAddr3 ↦ₘ hiVal3)))
+      (mloadStackOutputPost sp
+        loVal0 hiVal0 start loVal1 hiVal1 start
+        loVal2 hiVal2 start loVal3 hiVal3 start **
+       (((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+        (byteReg ↦ᵣ
+          (mloadByteFromDwordPair loVal3 hiVal3 start 7).zeroExtend 64) **
+        (accReg ↦ᵣ loaded3) **
+        (loAddr0 ↦ₘ loVal0) ** (hiAddr0 ↦ₘ hiVal0) **
+        (loAddr1 ↦ₘ loVal1) ** (hiAddr1 ↦ₘ hiVal1) **
+        (loAddr2 ↦ₘ loVal2) ** (hiAddr2 ↦ₘ hiVal2) **
+        (loAddr3 ↦ₘ loVal3) ** (hiAddr3 ↦ₘ hiVal3))) := by
+  dsimp only
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by sep_perm hp)
+    (fun _ hp => by
+      rw [← mloadStackOutputPost_evmWordIs_fold
+        sp
+        loVal0 hiVal0 start
+        loVal1 hiVal1 start
+        loVal2 hiVal2 start
+        loVal3 hiVal3 start]
+      sep_perm hp)
+    (evm_mload_unaligned_full_stack_spec_within_public
+      offReg byteReg accReg addrReg memBaseReg
+      sp offset offOld addrOld memBase byteOld accOld
+      dstOld1 dstOld2 dstOld3
+      loAddr0 hiAddr0 loVal0 hiVal0
+      loAddr1 hiAddr1 loVal1 hiVal1
+      loAddr2 hiAddr2 loVal2 hiVal2
+      loAddr3 hiAddr3 loVal3 hiVal3
+      start base
+      h_off_ne_x0 h_addr_ne_x0 h_byte_ne_x0 h_acc_ne_x0
+      h_window0 h_window1 h_window2 h_window3)
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/MStore/StackSpec.lean
+++ b/EvmAsm/Evm64/MStore/StackSpec.lean
@@ -106,6 +106,43 @@ theorem evm_mstore_combined_one_limb_sequence_stack_spec_within
       h0 h1 h2 h3)
 
 /--
+MSTORE evm_mstore_code lift of `mstore_combined_stack_spec_within`: the same
+combined prologue + single caller-supplied body triple, transported from
+`mstoreStackCode` to `evm_mstore_code` via `cpsTripleWithin_evm_mstore_of_stack`.
+
+This is the coarse-granularity counterpart of
+`evm_mstore_combined_one_limb_sequence_stack_spec_within`: callers that already
+assemble the whole four-limbs body as one triple can land the public-code
+prologue/body composition without bundling it into quarter hypotheses.
+
+Distinctive token: evm_mstore_combined_stack_spec_within #53.
+-/
+theorem evm_mstore_combined_stack_spec_within
+    {n : Nat} {Q : Assertion}
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset offOld addrOld memBase : Word) (base : Word)
+    (h_off_ne_x0 : offReg ≠ .x0)
+    (h_addr_ne_x0 : addrReg ≠ .x0)
+    (h4 :
+      cpsTripleWithin n (base + 8) (base + 280)
+        (mstoreStackCode offReg byteReg accReg addrReg memBaseReg base)
+        (((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+         (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+         (sp ↦ₘ offset))
+        Q) :
+    cpsTripleWithin (2 + n) base (base + 280)
+      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base)
+      (((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offOld) **
+       (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ addrOld) **
+       (sp ↦ₘ offset))
+      Q :=
+  cpsTripleWithin_evm_mstore_of_stack
+    offReg valReg byteReg accReg addrReg memBaseReg base (base + 280)
+    (mstore_combined_stack_spec_within
+      offReg byteReg accReg addrReg memBaseReg
+      sp offset offOld addrOld memBase base h_off_ne_x0 h_addr_ne_x0 h4)
+
+/--
 MSTORE evm_mstore_code lift of `mstore_full_stack_spec_within`: the same
 prologue + caller-supplied four-limbs core triple + framed epilogue
 composition, transported from `mstoreStackCode` to `evm_mstore_code` via

--- a/EvmAsm/Evm64/MStore/UnalignedFramedStackSpec.lean
+++ b/EvmAsm/Evm64/MStore/UnalignedFramedStackSpec.lean
@@ -148,6 +148,46 @@ theorem evm_mstore_combined_one_limb_sequence_stack_spec_within_framed
     framed
 
 /--
+Framed version of `evm_mstore_combined_stack_spec_within`.
+
+This is the coarse-body counterpart of
+`evm_mstore_combined_one_limb_sequence_stack_spec_within_framed`: callers that
+already produce one consolidated MSTORE body triple can preserve an arbitrary
+`pcFree` frame across the public prologue/body composition.
+
+Distinctive token: evm_mstore_combined_stack_spec_within_framed #53.
+-/
+theorem evm_mstore_combined_stack_spec_within_framed
+    {n : Nat} {Q : Assertion}
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset offOld addrOld memBase : Word) (base : Word)
+    (F : Assertion) (hF : F.pcFree)
+    (h_off_ne_x0 : offReg ≠ .x0)
+    (h_addr_ne_x0 : addrReg ≠ .x0)
+    (h4 :
+      cpsTripleWithin n (base + 8) (base + 280)
+        (mstoreStackCode offReg byteReg accReg addrReg memBaseReg base)
+        (((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+         (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+         (sp ↦ₘ offset))
+        Q) :
+    cpsTripleWithin (2 + n) base (base + 280)
+      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base)
+      ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offOld) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ addrOld) **
+        (sp ↦ₘ offset)) ** F)
+      (Q ** F) := by
+  have framed := cpsTripleWithin_frameL (F := F) hF
+    (evm_mstore_combined_stack_spec_within
+      offReg valReg byteReg accReg addrReg memBaseReg
+      sp offset offOld addrOld memBase base
+      h_off_ne_x0 h_addr_ne_x0 h4)
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by sep_perm hp)
+    (fun _ hp => by sep_perm hp)
+    framed
+
+/--
 Threaded-frame variant of `evm_mstore_combined_one_limb_sequence_stack_spec_within`.
 
 Unlike the whole-sequence frame wrapper above, this theorem starts q0 from the

--- a/EvmAsm/Evm64/MStore/UnalignedFramedStackSpec.lean
+++ b/EvmAsm/Evm64/MStore/UnalignedFramedStackSpec.lean
@@ -260,6 +260,66 @@ theorem evm_mstore_code_one_limb_q3_sub
     (mstoreStackCode_four_limbs_sub offReg byteReg accReg addrReg memBaseReg base a i
       (mstoreFourLimbsCode_limb3_sub addrReg byteReg accReg base a i h))
 
+/-- Transport a q0 MSTORE one-limb triple to the public `evm_mstore_code`. -/
+theorem cpsTripleWithin_evm_mstore_of_one_limb_q0
+    {n : Nat} {P Q : Assertion}
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg) (base : Word)
+    (h :
+      cpsTripleWithin n (base + 8) (base + 76)
+        (mstoreOneLimbCode addrReg byteReg accReg
+          32 24 25 26 27 28 29 30 31 (base + 8)) P Q) :
+    cpsTripleWithin n (base + 8) (base + 76)
+      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base) P Q :=
+  cpsTripleWithin_extend_code
+    (h := h)
+    (hmono := evm_mstore_code_one_limb_q0_sub
+      offReg valReg byteReg accReg addrReg memBaseReg base)
+
+/-- Transport a q1 MSTORE one-limb triple to the public `evm_mstore_code`. -/
+theorem cpsTripleWithin_evm_mstore_of_one_limb_q1
+    {n : Nat} {P Q : Assertion}
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg) (base : Word)
+    (h :
+      cpsTripleWithin n (base + 76) (base + 144)
+        (mstoreOneLimbCode addrReg byteReg accReg
+          40 16 17 18 19 20 21 22 23 (base + 76)) P Q) :
+    cpsTripleWithin n (base + 76) (base + 144)
+      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base) P Q :=
+  cpsTripleWithin_extend_code
+    (h := h)
+    (hmono := evm_mstore_code_one_limb_q1_sub
+      offReg valReg byteReg accReg addrReg memBaseReg base)
+
+/-- Transport a q2 MSTORE one-limb triple to the public `evm_mstore_code`. -/
+theorem cpsTripleWithin_evm_mstore_of_one_limb_q2
+    {n : Nat} {P Q : Assertion}
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg) (base : Word)
+    (h :
+      cpsTripleWithin n (base + 144) (base + 212)
+        (mstoreOneLimbCode addrReg byteReg accReg
+          48 8 9 10 11 12 13 14 15 (base + 144)) P Q) :
+    cpsTripleWithin n (base + 144) (base + 212)
+      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base) P Q :=
+  cpsTripleWithin_extend_code
+    (h := h)
+    (hmono := evm_mstore_code_one_limb_q2_sub
+      offReg valReg byteReg accReg addrReg memBaseReg base)
+
+/-- Transport a q3 MSTORE one-limb triple to the public `evm_mstore_code`. -/
+theorem cpsTripleWithin_evm_mstore_of_one_limb_q3
+    {n : Nat} {P Q : Assertion}
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg) (base : Word)
+    (h :
+      cpsTripleWithin n (base + 212) (base + 280)
+        (mstoreOneLimbCode addrReg byteReg accReg
+          56 0 1 2 3 4 5 6 7 (base + 212)) P Q) :
+    cpsTripleWithin n (base + 212) (base + 280)
+      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base) P Q :=
+  cpsTripleWithin_extend_code
+    (h := h)
+    (hmono := evm_mstore_code_one_limb_q3_sub
+      offReg valReg byteReg accReg addrReg memBaseReg base)
+
 /--
 Sibling-framed q0 stack spec: `evm_mstore_unaligned_one_limb_q0_stack_spec_within`
 with an arbitrary `pcFree` assertion `F` framed on both pre and post.

--- a/EvmAsm/Evm64/MStore/UnalignedFramedStackSpec.lean
+++ b/EvmAsm/Evm64/MStore/UnalignedFramedStackSpec.lean
@@ -23,6 +23,7 @@
 
 import EvmAsm.Evm64.MStore.StackSpec
 import EvmAsm.Evm64.MStore.UnalignedStackSpec
+import EvmAsm.Evm64.Stack
 
 namespace EvmAsm.Evm64
 
@@ -1204,5 +1205,86 @@ theorem evm_mstore_unaligned_full_stack_spec_within_public_epilogue
     (mstore_epilogue_evm_mstore_frame_spec_within
       offReg valReg byteReg accReg addrReg memBaseReg sp base
       FPost (by pcFree))
+
+/--
+Stack-tail variant of the public unaligned MSTORE epilogue composition.
+
+This frames the remaining EVM stack tail at `sp + 64`, matching MSTORE's
+two-word stack pop after the epilogue advances `.x12`.
+
+Distinctive token:
+evm_mstore_unaligned_full_stack_spec_within_public_stack_tail #53.
+-/
+theorem evm_mstore_unaligned_full_stack_spec_within_public_stack_tail
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset offOld addrOld memBase byteOld accOld : Word)
+    (limb0 limb1 limb2 limb3 : Word)
+    (loAddr0 hiAddr0 loVal0 hiVal0 : Word)
+    (loAddr1 hiAddr1 loVal1 hiVal1 : Word)
+    (loAddr2 hiAddr2 loVal2 hiVal2 : Word)
+    (loAddr3 hiAddr3 loVal3 hiVal3 : Word)
+    (start : Nat) (base : Word) (rest : List EvmWord)
+    (h_off_ne_x0 : offReg ≠ .x0)
+    (h_addr_ne_x0 : addrReg ≠ .x0)
+    (h_byte_ne_x0 : byteReg ≠ .x0)
+    (h_acc_ne_x0 : accReg ≠ .x0)
+    (h_window0 : mstoreLimbWindowOk (memBase + offset) loAddr0 hiAddr0 start
+                  24 25 26 27 28 29 30 31)
+    (h_window1 : mstoreLimbWindowOk (memBase + offset) loAddr1 hiAddr1 start
+                  16 17 18 19 20 21 22 23)
+    (h_window2 : mstoreLimbWindowOk (memBase + offset) loAddr2 hiAddr2 start
+                  8 9 10 11 12 13 14 15)
+    (h_window3 : mstoreLimbWindowOk (memBase + offset) loAddr3 hiAddr3 start
+                  0 1 2 3 4 5 6 7) :
+    let stored0 := MStore.mstoreDwordPairStoreLimb loVal0 hiVal0 limb0 start
+    let stored1 := MStore.mstoreDwordPairStoreLimb loVal1 hiVal1 limb1 start
+    let stored2 := MStore.mstoreDwordPairStoreLimb loVal2 hiVal2 limb2 start
+    let stored3 := MStore.mstoreDwordPairStoreLimb loVal3 hiVal3 limb3 start
+    cpsTripleWithin (2 + (17 + 17 + 17 + 17) + 1) base (base + 284)
+      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base)
+      (((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offOld) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ addrOld) **
+        (sp ↦ₘ offset)) **
+       ((byteReg ↦ᵣ byteOld) ** (accReg ↦ᵣ accOld) **
+        (loAddr0 ↦ₘ loVal0) ** (hiAddr0 ↦ₘ hiVal0) **
+        ((sp + signExtend12 (32 : BitVec 12)) ↦ₘ limb0) **
+        (loAddr1 ↦ₘ loVal1) ** (hiAddr1 ↦ₘ hiVal1) **
+        ((sp + signExtend12 (40 : BitVec 12)) ↦ₘ limb1) **
+        (loAddr2 ↦ₘ loVal2) ** (hiAddr2 ↦ₘ hiVal2) **
+        ((sp + signExtend12 (48 : BitVec 12)) ↦ₘ limb2) **
+        (loAddr3 ↦ₘ loVal3) ** (hiAddr3 ↦ₘ hiVal3) **
+        ((sp + signExtend12 (56 : BitVec 12)) ↦ₘ limb3))) **
+       evmStackIs (sp + 64) rest)
+      (((.x12 : Reg) ↦ᵣ (sp + 64)) **
+       evmStackIs (sp + 64) rest **
+       ((offReg ↦ᵣ offset) ** (memBaseReg ↦ᵣ memBase) **
+        (addrReg ↦ᵣ (memBase + offset)) ** (sp ↦ₘ offset) **
+        (byteReg ↦ᵣ limb3) ** (accReg ↦ᵣ limb3) **
+        (loAddr3 ↦ₘ stored3.1) ** (hiAddr3 ↦ₘ stored3.2) **
+        ((sp + signExtend12 (56 : BitVec 12)) ↦ₘ limb3) **
+        (loAddr0 ↦ₘ stored0.1) ** (hiAddr0 ↦ₘ stored0.2) **
+        ((sp + signExtend12 (32 : BitVec 12)) ↦ₘ limb0) **
+        (loAddr1 ↦ₘ stored1.1) ** (hiAddr1 ↦ₘ stored1.2) **
+        ((sp + signExtend12 (40 : BitVec 12)) ↦ₘ limb1) **
+        (loAddr2 ↦ₘ stored2.1) ** (hiAddr2 ↦ₘ stored2.2) **
+        ((sp + signExtend12 (48 : BitVec 12)) ↦ₘ limb2))) := by
+  dsimp only
+  have hCore :=
+    cpsTripleWithin_frameR (evmStackIs (sp + 64) rest) (by pcFree)
+      (evm_mstore_unaligned_full_stack_spec_within_public_epilogue
+        offReg valReg byteReg accReg addrReg memBaseReg
+        sp offset offOld addrOld memBase byteOld accOld
+        limb0 limb1 limb2 limb3
+        loAddr0 hiAddr0 loVal0 hiVal0
+        loAddr1 hiAddr1 loVal1 hiVal1
+        loAddr2 hiAddr2 loVal2 hiVal2
+        loAddr3 hiAddr3 loVal3 hiVal3
+        start base
+        h_off_ne_x0 h_addr_ne_x0 h_byte_ne_x0 h_acc_ne_x0
+        h_window0 h_window1 h_window2 h_window3)
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by sep_perm hp)
+    (fun _ hp => by sep_perm hp)
+    hCore
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/MStore/UnalignedFramedStackSpec.lean
+++ b/EvmAsm/Evm64/MStore/UnalignedFramedStackSpec.lean
@@ -1400,4 +1400,90 @@ theorem evm_mstore_unaligned_full_stack_spec_within_public_stack_pre
       sep_perm hp)
     hCore
 
+/--
+Canonical public MSTORE stack spec entry point.
+
+This aliases the full unaligned public stack-pre theorem under the conventional
+name used by the topmost-spec audit.
+-/
+theorem evm_mstore_stack_spec_within
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset offOld addrOld memBase byteOld accOld : Word)
+    (offsetWord valueWord : EvmWord) (rest : List EvmWord)
+    (offsetHigh1 offsetHigh2 offsetHigh3 : Word)
+    (limb0 limb1 limb2 limb3 : Word)
+    (loAddr0 hiAddr0 loVal0 hiVal0 : Word)
+    (loAddr1 hiAddr1 loVal1 hiVal1 : Word)
+    (loAddr2 hiAddr2 loVal2 hiVal2 : Word)
+    (loAddr3 hiAddr3 loVal3 hiVal3 : Word)
+    (start : Nat) (base : Word)
+    (h_offset0 : offsetWord.getLimbN 0 = offset)
+    (h_offset1 : offsetWord.getLimbN 1 = offsetHigh1)
+    (h_offset2 : offsetWord.getLimbN 2 = offsetHigh2)
+    (h_offset3 : offsetWord.getLimbN 3 = offsetHigh3)
+    (h_value0 : valueWord.getLimbN 0 = limb0)
+    (h_value1 : valueWord.getLimbN 1 = limb1)
+    (h_value2 : valueWord.getLimbN 2 = limb2)
+    (h_value3 : valueWord.getLimbN 3 = limb3)
+    (h_off_ne_x0 : offReg ≠ .x0)
+    (h_addr_ne_x0 : addrReg ≠ .x0)
+    (h_byte_ne_x0 : byteReg ≠ .x0)
+    (h_acc_ne_x0 : accReg ≠ .x0)
+    (h_window0 : mstoreLimbWindowOk (memBase + offset) loAddr0 hiAddr0 start
+                  24 25 26 27 28 29 30 31)
+    (h_window1 : mstoreLimbWindowOk (memBase + offset) loAddr1 hiAddr1 start
+                  16 17 18 19 20 21 22 23)
+    (h_window2 : mstoreLimbWindowOk (memBase + offset) loAddr2 hiAddr2 start
+                  8 9 10 11 12 13 14 15)
+    (h_window3 : mstoreLimbWindowOk (memBase + offset) loAddr3 hiAddr3 start
+                  0 1 2 3 4 5 6 7) :
+    let stored0 := MStore.mstoreDwordPairStoreLimb loVal0 hiVal0 limb0 start
+    let stored1 := MStore.mstoreDwordPairStoreLimb loVal1 hiVal1 limb1 start
+    let stored2 := MStore.mstoreDwordPairStoreLimb loVal2 hiVal2 limb2 start
+    let stored3 := MStore.mstoreDwordPairStoreLimb loVal3 hiVal3 limb3 start
+    cpsTripleWithin (2 + (17 + 17 + 17 + 17) + 1) base (base + 284)
+      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base)
+      (((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offOld) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ addrOld) **
+        evmStackIs sp (offsetWord :: valueWord :: rest)) **
+       ((byteReg ↦ᵣ byteOld) ** (accReg ↦ᵣ accOld) **
+        (loAddr0 ↦ₘ loVal0) ** (hiAddr0 ↦ₘ hiVal0) **
+        (loAddr1 ↦ₘ loVal1) ** (hiAddr1 ↦ₘ hiVal1) **
+        (loAddr2 ↦ₘ loVal2) ** (hiAddr2 ↦ₘ hiVal2) **
+        (loAddr3 ↦ₘ loVal3) ** (hiAddr3 ↦ₘ hiVal3))))
+      (((.x12 : Reg) ↦ᵣ (sp + 64)) **
+       evmStackIs (sp + 64) rest **
+       evmWordIs sp offsetWord ** evmWordIs (sp + 32) valueWord **
+       ((offReg ↦ᵣ offset) ** (memBaseReg ↦ᵣ memBase) **
+        (addrReg ↦ᵣ (memBase + offset)) **
+        (byteReg ↦ᵣ limb3) ** (accReg ↦ᵣ limb3) **
+        (loAddr3 ↦ₘ stored3.1) ** (hiAddr3 ↦ₘ stored3.2) **
+        (loAddr0 ↦ₘ stored0.1) ** (hiAddr0 ↦ₘ stored0.2) **
+        (loAddr1 ↦ₘ stored1.1) ** (hiAddr1 ↦ₘ stored1.2) **
+        (loAddr2 ↦ₘ stored2.1) ** (hiAddr2 ↦ₘ stored2.2))) := by
+  have hCore :=
+    evm_mstore_unaligned_full_stack_spec_within_public_stack_pre
+      offReg valReg byteReg accReg addrReg memBaseReg
+      sp offset offOld addrOld memBase byteOld accOld
+      offsetWord valueWord rest
+      offsetHigh1 offsetHigh2 offsetHigh3
+      limb0 limb1 limb2 limb3
+      loAddr0 hiAddr0 loVal0 hiVal0
+      loAddr1 hiAddr1 loVal1 hiVal1
+      loAddr2 hiAddr2 loVal2 hiVal2
+      loAddr3 hiAddr3 loVal3 hiVal3
+      start base
+      h_offset0 h_offset1 h_offset2 h_offset3
+      h_value0 h_value1 h_value2 h_value3
+      h_off_ne_x0 h_addr_ne_x0 h_byte_ne_x0 h_acc_ne_x0
+      h_window0 h_window1 h_window2 h_window3
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by sep_perm hp)
+    (fun _ hp => by
+      rw [evmStackIs_cons] at hp
+      rw [evmStackIs_cons] at hp
+      rw [show (sp + 32 + 32 : Word) = sp + 64 from by bv_addr] at hp
+      sep_perm hp)
+    hCore
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/MStore/UnalignedFramedStackSpec.lean
+++ b/EvmAsm/Evm64/MStore/UnalignedFramedStackSpec.lean
@@ -630,4 +630,46 @@ theorem evm_mstore_unaligned_one_limb_q3_stack_spec_within_framed
     (fun _ hp => by sep_perm hp)
     framed
 
+/--
+Public-code q3 framed MSTORE spec: transports
+`evm_mstore_unaligned_one_limb_q3_stack_spec_within_framed` from the q3
+one-limb block to the full `evm_mstore_code` code requirement.
+
+Distinctive token:
+evm_mstore_unaligned_one_limb_q3_spec_within_framed_public_code #53.
+-/
+theorem evm_mstore_unaligned_one_limb_q3_spec_within_framed_public_code
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset memBase byteOld accOld limbVal : Word)
+    (loAddr hiAddr loVal hiVal : Word) (start : Nat)
+    (base : Word)
+    (F : Assertion) (hF : F.pcFree)
+    (h_byte_ne_x0 : byteReg ≠ .x0)
+    (h_acc_ne_x0 : accReg ≠ .x0)
+    (h_window : mstoreLimbWindowOk (memBase + offset) loAddr hiAddr start
+                  0 1 2 3 4 5 6 7) :
+    cpsTripleWithin 17 (base + 212) (base + 280)
+      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base)
+      ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+        (sp ↦ₘ offset) **
+        ((byteReg ↦ᵣ byteOld) ** (accReg ↦ᵣ accOld) **
+         (loAddr ↦ₘ loVal) ** (hiAddr ↦ₘ hiVal) **
+         ((sp + signExtend12 (56 : BitVec 12)) ↦ₘ limbVal))) ** F)
+      ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+        (sp ↦ₘ offset) **
+        (let stored :=
+          MStore.mstoreDwordPairStoreLimb loVal hiVal limbVal start
+         (byteReg ↦ᵣ limbVal) ** (accReg ↦ᵣ limbVal) **
+         (loAddr ↦ₘ stored.1) ** (hiAddr ↦ₘ stored.2) **
+         ((sp + signExtend12 (56 : BitVec 12)) ↦ₘ limbVal))) ** F) := by
+  exact cpsTripleWithin_evm_mstore_of_one_limb_q3
+    offReg valReg byteReg accReg addrReg memBaseReg base
+    (evm_mstore_unaligned_one_limb_q3_stack_spec_within_framed
+      offReg byteReg accReg addrReg memBaseReg
+      sp offset memBase byteOld accOld limbVal
+      loAddr hiAddr loVal hiVal start base F hF
+      h_byte_ne_x0 h_acc_ne_x0 h_window)
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/MStore/UnalignedFramedStackSpec.lean
+++ b/EvmAsm/Evm64/MStore/UnalignedFramedStackSpec.lean
@@ -21,11 +21,48 @@
   sibling-quarter cells #53.
 -/
 
+import EvmAsm.Evm64.MStore.Spec
 import EvmAsm.Evm64.MStore.UnalignedStackSpec
 
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
+
+/--
+Sibling-framed MSTORE prologue stack spec: `mstore_prologue_stack_spec_within`
+with an arbitrary `pcFree` assertion `F` framed on both pre and post.
+
+This is the prologue counterpart to the q0..q3 sibling-framed lemmas below.
+The full unaligned MSTORE compose slice uses it to preserve the byte-window and
+source-limb frame while the initial stack offset is loaded and the absolute
+memory address is computed.
+
+Distinctive token: mstore_prologue_stack_spec_within_framed sibling-quarter
+cells #53.
+-/
+theorem mstore_prologue_stack_spec_within_framed
+    (offReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset offOld addrOld memBase : Word) (base : Word)
+    (F : Assertion) (hF : F.pcFree)
+    (h_off_ne_x0 : offReg ≠ .x0)
+    (h_addr_ne_x0 : addrReg ≠ .x0) :
+    cpsTripleWithin 2 base (base + 8)
+      (mstoreStackCode offReg byteReg accReg addrReg memBaseReg base)
+      ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offOld) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ addrOld) **
+        (sp ↦ₘ offset)) ** F)
+      ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+        (sp ↦ₘ offset)) ** F) := by
+  have core := mstore_prologue_stack_spec_within
+    offReg byteReg accReg addrReg memBaseReg
+    sp offset offOld addrOld memBase base
+    h_off_ne_x0 h_addr_ne_x0
+  have framed := cpsTripleWithin_frameL (F := F) hF core
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by sep_perm hp)
+    (fun _ hp => by sep_perm hp)
+    framed
 
 /--
 Sibling-framed q0 stack spec: `evm_mstore_unaligned_one_limb_q0_stack_spec_within`

--- a/EvmAsm/Evm64/MStore/UnalignedFramedStackSpec.lean
+++ b/EvmAsm/Evm64/MStore/UnalignedFramedStackSpec.lean
@@ -188,6 +188,54 @@ theorem evm_mstore_combined_stack_spec_within_framed
     framed
 
 /--
+Framed version of `evm_mstore_combined_four_limb_sequence_stack_spec_within`.
+
+This wrapper preserves an arbitrary `pcFree` frame around the public MSTORE
+prologue plus four `mstoreFourLimbsCode` quarter triples.
+
+Distinctive token:
+evm_mstore_combined_four_limb_sequence_stack_spec_within_framed #53.
+-/
+theorem evm_mstore_combined_four_limb_sequence_stack_spec_within_framed
+    {n0 n1 n2 n3 : Nat} {P1 P2 P3 Q : Assertion}
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset offOld addrOld memBase : Word) (base : Word)
+    (F : Assertion) (hF : F.pcFree)
+    (h_off_ne_x0 : offReg ≠ .x0)
+    (h_addr_ne_x0 : addrReg ≠ .x0)
+    (h0 :
+      cpsTripleWithin n0 (base + 8) (base + 76)
+        (mstoreFourLimbsCode addrReg byteReg accReg base)
+        (((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+         (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+         (sp ↦ₘ offset))
+        P1)
+    (h1 :
+      cpsTripleWithin n1 (base + 76) (base + 144)
+        (mstoreFourLimbsCode addrReg byteReg accReg base) P1 P2)
+    (h2 :
+      cpsTripleWithin n2 (base + 144) (base + 212)
+        (mstoreFourLimbsCode addrReg byteReg accReg base) P2 P3)
+    (h3 :
+      cpsTripleWithin n3 (base + 212) (base + 280)
+        (mstoreFourLimbsCode addrReg byteReg accReg base) P3 Q) :
+    cpsTripleWithin (2 + (n0 + n1 + n2 + n3)) base (base + 280)
+      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base)
+      ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offOld) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ addrOld) **
+        (sp ↦ₘ offset)) ** F)
+      (Q ** F) := by
+  have framed := cpsTripleWithin_frameL (F := F) hF
+    (evm_mstore_combined_four_limb_sequence_stack_spec_within
+      offReg valReg byteReg accReg addrReg memBaseReg
+      sp offset offOld addrOld memBase base
+      h_off_ne_x0 h_addr_ne_x0 h0 h1 h2 h3)
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by sep_perm hp)
+    (fun _ hp => by sep_perm hp)
+    framed
+
+/--
 Threaded-frame variant of `evm_mstore_combined_one_limb_sequence_stack_spec_within`.
 
 Unlike the whole-sequence frame wrapper above, this theorem starts q0 from the

--- a/EvmAsm/Evm64/MStore/UnalignedFramedStackSpec.lean
+++ b/EvmAsm/Evm64/MStore/UnalignedFramedStackSpec.lean
@@ -148,6 +148,63 @@ theorem evm_mstore_combined_one_limb_sequence_stack_spec_within_framed
     framed
 
 /--
+Threaded-frame variant of `evm_mstore_combined_one_limb_sequence_stack_spec_within`.
+
+Unlike the whole-sequence frame wrapper above, this theorem starts q0 from the
+prologue postcondition already combined with `F`. That matches the concrete
+q0..q3 sibling-framed MSTORE lemmas below, where the frame carries the other
+window cells through each quarter.
+
+Distinctive token:
+evm_mstore_combined_one_limb_sequence_stack_spec_within_threaded_frame #53.
+-/
+theorem evm_mstore_combined_one_limb_sequence_stack_spec_within_threaded_frame
+    {n0 n1 n2 n3 : Nat} {P1 P2 P3 Q : Assertion}
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset offOld addrOld memBase : Word) (base : Word)
+    (F : Assertion) (hF : F.pcFree)
+    (h_off_ne_x0 : offReg ≠ .x0)
+    (h_addr_ne_x0 : addrReg ≠ .x0)
+    (h0 :
+      cpsTripleWithin n0 (base + 8) (base + 76)
+        (mstoreOneLimbCode addrReg byteReg accReg
+          32 24 25 26 27 28 29 30 31 (base + 8))
+        ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+          (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+          (sp ↦ₘ offset)) ** F)
+        P1)
+    (h1 :
+      cpsTripleWithin n1 (base + 76) (base + 144)
+        (mstoreOneLimbCode addrReg byteReg accReg
+          40 16 17 18 19 20 21 22 23 (base + 76)) P1 P2)
+    (h2 :
+      cpsTripleWithin n2 (base + 144) (base + 212)
+        (mstoreOneLimbCode addrReg byteReg accReg
+          48 8 9 10 11 12 13 14 15 (base + 144)) P2 P3)
+    (h3 :
+      cpsTripleWithin n3 (base + 212) (base + 280)
+        (mstoreOneLimbCode addrReg byteReg accReg
+          56 0 1 2 3 4 5 6 7 (base + 212)) P3 Q) :
+    cpsTripleWithin (2 + (n0 + n1 + n2 + n3)) base (base + 280)
+      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base)
+      ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offOld) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ addrOld) **
+        (sp ↦ₘ offset)) ** F)
+      Q := by
+  exact cpsTripleWithin_evm_mstore_of_stack
+    offReg valReg byteReg accReg addrReg memBaseReg base (base + 280)
+    (cpsTripleWithin_seq_same_cr
+      (mstore_prologue_stack_spec_within_framed
+        offReg byteReg accReg addrReg memBaseReg
+        sp offset offOld addrOld memBase base F hF
+        h_off_ne_x0 h_addr_ne_x0)
+      (cpsTripleWithin_extend_code
+        (h := mstore_one_limb_sequence_spec_within
+          addrReg byteReg accReg base h0 h1 h2 h3)
+        (hmono := mstoreStackCode_four_limbs_sub
+          offReg byteReg accReg addrReg memBaseReg base)))
+
+/--
 Sibling-framed q0 stack spec: `evm_mstore_unaligned_one_limb_q0_stack_spec_within`
 with an arbitrary `pcFree` assertion `F` framed on both pre and post.
 

--- a/EvmAsm/Evm64/MStore/UnalignedFramedStackSpec.lean
+++ b/EvmAsm/Evm64/MStore/UnalignedFramedStackSpec.lean
@@ -442,6 +442,44 @@ theorem evm_mstore_public_one_limb_sequence_spec_within
     h3
 
 /--
+Permutation-aware public-code MSTORE q0..q3 composition.
+
+This variant lets callers stitch concrete quarter specs whose postconditions
+match the next precondition only after rearranging or weakening separation
+conjunction atoms.
+
+Distinctive token: evm_mstore_public_one_limb_sequence_spec_within_perm #53.
+-/
+theorem evm_mstore_public_one_limb_sequence_spec_within_perm
+    {n0 n1 n2 n3 : Nat}
+    {P0 P1 P1' P2 P2' P3 P3' P4 : Assertion}
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg) (base : Word)
+    (h0 :
+      cpsTripleWithin n0 (base + 8) (base + 76)
+        (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base) P0 P1)
+    (h01 : ∀ s, P1 s → P1' s)
+    (h1 :
+      cpsTripleWithin n1 (base + 76) (base + 144)
+        (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base) P1' P2)
+    (h12 : ∀ s, P2 s → P2' s)
+    (h2 :
+      cpsTripleWithin n2 (base + 144) (base + 212)
+        (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base) P2' P3)
+    (h23 : ∀ s, P3 s → P3' s)
+    (h3 :
+      cpsTripleWithin n3 (base + 212) (base + 280)
+        (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base) P3' P4) :
+    cpsTripleWithin (n0 + n1 + n2 + n3) (base + 8) (base + 280)
+      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base) P0 P4 := by
+  exact cpsTripleWithin_seq_perm_same_cr
+    h23
+    (cpsTripleWithin_seq_perm_same_cr
+      h12
+      (cpsTripleWithin_seq_perm_same_cr h01 h0 h1)
+      h2)
+    h3
+
+/--
 Compose the framed MSTORE prologue with four public-code one-limb quarter
 triples.
 

--- a/EvmAsm/Evm64/MStore/UnalignedFramedStackSpec.lean
+++ b/EvmAsm/Evm64/MStore/UnalignedFramedStackSpec.lean
@@ -457,6 +457,48 @@ theorem evm_mstore_unaligned_one_limb_q1_stack_spec_within_framed
     framed
 
 /--
+Public-code q1 framed MSTORE spec: transports
+`evm_mstore_unaligned_one_limb_q1_stack_spec_within_framed` from the q1
+one-limb block to the full `evm_mstore_code` code requirement.
+
+Distinctive token:
+evm_mstore_unaligned_one_limb_q1_spec_within_framed_public_code #53.
+-/
+theorem evm_mstore_unaligned_one_limb_q1_spec_within_framed_public_code
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset memBase byteOld accOld limbVal : Word)
+    (loAddr hiAddr loVal hiVal : Word) (start : Nat)
+    (base : Word)
+    (F : Assertion) (hF : F.pcFree)
+    (h_byte_ne_x0 : byteReg ≠ .x0)
+    (h_acc_ne_x0 : accReg ≠ .x0)
+    (h_window : mstoreLimbWindowOk (memBase + offset) loAddr hiAddr start
+                  16 17 18 19 20 21 22 23) :
+    cpsTripleWithin 17 (base + 76) (base + 144)
+      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base)
+      ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+        (sp ↦ₘ offset) **
+        ((byteReg ↦ᵣ byteOld) ** (accReg ↦ᵣ accOld) **
+         (loAddr ↦ₘ loVal) ** (hiAddr ↦ₘ hiVal) **
+         ((sp + signExtend12 (40 : BitVec 12)) ↦ₘ limbVal))) ** F)
+      ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+        (sp ↦ₘ offset) **
+        (let stored :=
+          MStore.mstoreDwordPairStoreLimb loVal hiVal limbVal start
+         (byteReg ↦ᵣ limbVal) ** (accReg ↦ᵣ limbVal) **
+         (loAddr ↦ₘ stored.1) ** (hiAddr ↦ₘ stored.2) **
+         ((sp + signExtend12 (40 : BitVec 12)) ↦ₘ limbVal))) ** F) := by
+  exact cpsTripleWithin_evm_mstore_of_one_limb_q1
+    offReg valReg byteReg accReg addrReg memBaseReg base
+    (evm_mstore_unaligned_one_limb_q1_stack_spec_within_framed
+      offReg byteReg accReg addrReg memBaseReg
+      sp offset memBase byteOld accOld limbVal
+      loAddr hiAddr loVal hiVal start base F hF
+      h_byte_ne_x0 h_acc_ne_x0 h_window)
+
+/--
 Sibling-framed q2 stack spec: `evm_mstore_unaligned_one_limb_q2_stack_spec_within`
 with an arbitrary `pcFree` assertion `F` framed on both pre and post.
 

--- a/EvmAsm/Evm64/MStore/UnalignedFramedStackSpec.lean
+++ b/EvmAsm/Evm64/MStore/UnalignedFramedStackSpec.lean
@@ -205,6 +205,62 @@ theorem evm_mstore_combined_one_limb_sequence_stack_spec_within_threaded_frame
           offReg byteReg accReg addrReg memBaseReg base)))
 
 /--
+Public-code subsumption for the q0 MSTORE one-limb byte-window write block.
+
+This bridges the concrete quarter block directly to `evm_mstore_code`, avoiding
+repeat composition through `mstoreFourLimbsCode` and `mstoreStackCode` at call
+sites that transport individual framed quarter specs.
+
+Distinctive token: evm_mstore_code_one_limb_q0_sub #53.
+-/
+theorem evm_mstore_code_one_limb_q0_sub
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg) (base : Word) :
+    ∀ a i,
+      (mstoreOneLimbCode addrReg byteReg accReg
+        32 24 25 26 27 28 29 30 31 (base + 8)) a = some i →
+      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base) a = some i := by
+  intro a i h
+  exact evm_mstore_code_stack_sub offReg valReg byteReg accReg addrReg memBaseReg base a i
+    (mstoreStackCode_four_limbs_sub offReg byteReg accReg addrReg memBaseReg base a i
+      (mstoreFourLimbsCode_limb0_sub addrReg byteReg accReg base a i h))
+
+/-- Public-code subsumption for the q1 MSTORE one-limb byte-window write block. -/
+theorem evm_mstore_code_one_limb_q1_sub
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg) (base : Word) :
+    ∀ a i,
+      (mstoreOneLimbCode addrReg byteReg accReg
+        40 16 17 18 19 20 21 22 23 (base + 76)) a = some i →
+      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base) a = some i := by
+  intro a i h
+  exact evm_mstore_code_stack_sub offReg valReg byteReg accReg addrReg memBaseReg base a i
+    (mstoreStackCode_four_limbs_sub offReg byteReg accReg addrReg memBaseReg base a i
+      (mstoreFourLimbsCode_limb1_sub addrReg byteReg accReg base a i h))
+
+/-- Public-code subsumption for the q2 MSTORE one-limb byte-window write block. -/
+theorem evm_mstore_code_one_limb_q2_sub
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg) (base : Word) :
+    ∀ a i,
+      (mstoreOneLimbCode addrReg byteReg accReg
+        48 8 9 10 11 12 13 14 15 (base + 144)) a = some i →
+      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base) a = some i := by
+  intro a i h
+  exact evm_mstore_code_stack_sub offReg valReg byteReg accReg addrReg memBaseReg base a i
+    (mstoreStackCode_four_limbs_sub offReg byteReg accReg addrReg memBaseReg base a i
+      (mstoreFourLimbsCode_limb2_sub addrReg byteReg accReg base a i h))
+
+/-- Public-code subsumption for the q3 MSTORE one-limb byte-window write block. -/
+theorem evm_mstore_code_one_limb_q3_sub
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg) (base : Word) :
+    ∀ a i,
+      (mstoreOneLimbCode addrReg byteReg accReg
+        56 0 1 2 3 4 5 6 7 (base + 212)) a = some i →
+      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base) a = some i := by
+  intro a i h
+  exact evm_mstore_code_stack_sub offReg valReg byteReg accReg addrReg memBaseReg base a i
+    (mstoreStackCode_four_limbs_sub offReg byteReg accReg addrReg memBaseReg base a i
+      (mstoreFourLimbsCode_limb3_sub addrReg byteReg accReg base a i h))
+
+/--
 Sibling-framed q0 stack spec: `evm_mstore_unaligned_one_limb_q0_stack_spec_within`
 with an arbitrary `pcFree` assertion `F` framed on both pre and post.
 

--- a/EvmAsm/Evm64/MStore/UnalignedFramedStackSpec.lean
+++ b/EvmAsm/Evm64/MStore/UnalignedFramedStackSpec.lean
@@ -95,6 +95,59 @@ theorem evm_mstore_prologue_stack_spec_within_framed
       h_off_ne_x0 h_addr_ne_x0)
 
 /--
+Framed version of `evm_mstore_combined_one_limb_sequence_stack_spec_within`.
+
+This wrapper preserves an arbitrary `pcFree` frame across the whole prologue
+plus four-quarter byte-window write sequence, which is useful once the concrete
+q0..q3 lemmas have been composed into a single MSTORE sequence triple.
+
+Distinctive token:
+evm_mstore_combined_one_limb_sequence_stack_spec_within_framed #53.
+-/
+theorem evm_mstore_combined_one_limb_sequence_stack_spec_within_framed
+    {n0 n1 n2 n3 : Nat} {P1 P2 P3 Q : Assertion}
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset offOld addrOld memBase : Word) (base : Word)
+    (F : Assertion) (hF : F.pcFree)
+    (h_off_ne_x0 : offReg ≠ .x0)
+    (h_addr_ne_x0 : addrReg ≠ .x0)
+    (h0 :
+      cpsTripleWithin n0 (base + 8) (base + 76)
+        (mstoreOneLimbCode addrReg byteReg accReg
+          32 24 25 26 27 28 29 30 31 (base + 8))
+        (((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+         (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+         (sp ↦ₘ offset))
+        P1)
+    (h1 :
+      cpsTripleWithin n1 (base + 76) (base + 144)
+        (mstoreOneLimbCode addrReg byteReg accReg
+          40 16 17 18 19 20 21 22 23 (base + 76)) P1 P2)
+    (h2 :
+      cpsTripleWithin n2 (base + 144) (base + 212)
+        (mstoreOneLimbCode addrReg byteReg accReg
+          48 8 9 10 11 12 13 14 15 (base + 144)) P2 P3)
+    (h3 :
+      cpsTripleWithin n3 (base + 212) (base + 280)
+        (mstoreOneLimbCode addrReg byteReg accReg
+          56 0 1 2 3 4 5 6 7 (base + 212)) P3 Q) :
+    cpsTripleWithin (2 + (n0 + n1 + n2 + n3)) base (base + 280)
+      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base)
+      ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offOld) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ addrOld) **
+        (sp ↦ₘ offset)) ** F)
+      (Q ** F) := by
+  have framed := cpsTripleWithin_frameL (F := F) hF
+    (evm_mstore_combined_one_limb_sequence_stack_spec_within
+      offReg valReg byteReg accReg addrReg memBaseReg
+      sp offset offOld addrOld memBase base
+      h_off_ne_x0 h_addr_ne_x0 h0 h1 h2 h3)
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by sep_perm hp)
+    (fun _ hp => by sep_perm hp)
+    framed
+
+/--
 Sibling-framed q0 stack spec: `evm_mstore_unaligned_one_limb_q0_stack_spec_within`
 with an arbitrary `pcFree` assertion `F` framed on both pre and post.
 

--- a/EvmAsm/Evm64/MStore/UnalignedFramedStackSpec.lean
+++ b/EvmAsm/Evm64/MStore/UnalignedFramedStackSpec.lean
@@ -544,6 +544,48 @@ theorem evm_mstore_unaligned_one_limb_q2_stack_spec_within_framed
     framed
 
 /--
+Public-code q2 framed MSTORE spec: transports
+`evm_mstore_unaligned_one_limb_q2_stack_spec_within_framed` from the q2
+one-limb block to the full `evm_mstore_code` code requirement.
+
+Distinctive token:
+evm_mstore_unaligned_one_limb_q2_spec_within_framed_public_code #53.
+-/
+theorem evm_mstore_unaligned_one_limb_q2_spec_within_framed_public_code
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset memBase byteOld accOld limbVal : Word)
+    (loAddr hiAddr loVal hiVal : Word) (start : Nat)
+    (base : Word)
+    (F : Assertion) (hF : F.pcFree)
+    (h_byte_ne_x0 : byteReg ≠ .x0)
+    (h_acc_ne_x0 : accReg ≠ .x0)
+    (h_window : mstoreLimbWindowOk (memBase + offset) loAddr hiAddr start
+                  8 9 10 11 12 13 14 15) :
+    cpsTripleWithin 17 (base + 144) (base + 212)
+      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base)
+      ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+        (sp ↦ₘ offset) **
+        ((byteReg ↦ᵣ byteOld) ** (accReg ↦ᵣ accOld) **
+         (loAddr ↦ₘ loVal) ** (hiAddr ↦ₘ hiVal) **
+         ((sp + signExtend12 (48 : BitVec 12)) ↦ₘ limbVal))) ** F)
+      ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+        (sp ↦ₘ offset) **
+        (let stored :=
+          MStore.mstoreDwordPairStoreLimb loVal hiVal limbVal start
+         (byteReg ↦ᵣ limbVal) ** (accReg ↦ᵣ limbVal) **
+         (loAddr ↦ₘ stored.1) ** (hiAddr ↦ₘ stored.2) **
+         ((sp + signExtend12 (48 : BitVec 12)) ↦ₘ limbVal))) ** F) := by
+  exact cpsTripleWithin_evm_mstore_of_one_limb_q2
+    offReg valReg byteReg accReg addrReg memBaseReg base
+    (evm_mstore_unaligned_one_limb_q2_stack_spec_within_framed
+      offReg byteReg accReg addrReg memBaseReg
+      sp offset memBase byteOld accOld limbVal
+      loAddr hiAddr loVal hiVal start base F hF
+      h_byte_ne_x0 h_acc_ne_x0 h_window)
+
+/--
 Sibling-framed q3 stack spec: `evm_mstore_unaligned_one_limb_q3_stack_spec_within`
 with an arbitrary `pcFree` assertion `F` framed on both pre and post.
 

--- a/EvmAsm/Evm64/MStore/UnalignedFramedStackSpec.lean
+++ b/EvmAsm/Evm64/MStore/UnalignedFramedStackSpec.lean
@@ -321,6 +321,39 @@ theorem cpsTripleWithin_evm_mstore_of_one_limb_q3
       offReg valReg byteReg accReg addrReg memBaseReg base)
 
 /--
+Compose four public-code MSTORE one-limb triples into a single q0..q3 body
+triple over `evm_mstore_code`.
+
+This is the public-code counterpart of `mstore_one_limb_sequence_spec_within`:
+callers that already transported each quarter to `evm_mstore_code` can sequence
+them without returning to the smaller `mstoreFourLimbsCode` surface.
+
+Distinctive token: evm_mstore_public_one_limb_sequence_spec_within #53.
+-/
+theorem evm_mstore_public_one_limb_sequence_spec_within
+    {n0 n1 n2 n3 : Nat} {P0 P1 P2 P3 P4 : Assertion}
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg) (base : Word)
+    (h0 :
+      cpsTripleWithin n0 (base + 8) (base + 76)
+        (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base) P0 P1)
+    (h1 :
+      cpsTripleWithin n1 (base + 76) (base + 144)
+        (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base) P1 P2)
+    (h2 :
+      cpsTripleWithin n2 (base + 144) (base + 212)
+        (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base) P2 P3)
+    (h3 :
+      cpsTripleWithin n3 (base + 212) (base + 280)
+        (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base) P3 P4) :
+    cpsTripleWithin (n0 + n1 + n2 + n3) (base + 8) (base + 280)
+      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base) P0 P4 := by
+  exact cpsTripleWithin_seq_same_cr
+    (cpsTripleWithin_seq_same_cr
+      (cpsTripleWithin_seq_same_cr h0 h1)
+      h2)
+    h3
+
+/--
 Sibling-framed q0 stack spec: `evm_mstore_unaligned_one_limb_q0_stack_spec_within`
 with an arbitrary `pcFree` assertion `F` framed on both pre and post.
 

--- a/EvmAsm/Evm64/MStore/UnalignedFramedStackSpec.lean
+++ b/EvmAsm/Evm64/MStore/UnalignedFramedStackSpec.lean
@@ -528,6 +528,58 @@ theorem evm_mstore_public_one_limb_sequence_with_prologue_framed
       offReg valReg byteReg accReg addrReg memBaseReg base h0 h1 h2 h3)
 
 /--
+Compose the framed MSTORE prologue with a permutation-aware public-code q0..q3
+one-limb sequence.
+
+This is the concrete-compose entry point for quarter specs whose intermediate
+postconditions need `sep_perm`/weakening callbacks before the next quarter.
+
+Distinctive token:
+evm_mstore_public_one_limb_sequence_with_prologue_framed_perm #53.
+-/
+theorem evm_mstore_public_one_limb_sequence_with_prologue_framed_perm
+    {n0 n1 n2 n3 : Nat}
+    {P1 P1' P2 P2' P3 P3' Q : Assertion}
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset offOld addrOld memBase : Word) (base : Word)
+    (F : Assertion) (hF : F.pcFree)
+    (h_off_ne_x0 : offReg ≠ .x0)
+    (h_addr_ne_x0 : addrReg ≠ .x0)
+    (h0 :
+      cpsTripleWithin n0 (base + 8) (base + 76)
+        (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base)
+        ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+          (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+          (sp ↦ₘ offset)) ** F)
+        P1)
+    (h01 : ∀ s, P1 s → P1' s)
+    (h1 :
+      cpsTripleWithin n1 (base + 76) (base + 144)
+        (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base) P1' P2)
+    (h12 : ∀ s, P2 s → P2' s)
+    (h2 :
+      cpsTripleWithin n2 (base + 144) (base + 212)
+        (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base) P2' P3)
+    (h23 : ∀ s, P3 s → P3' s)
+    (h3 :
+      cpsTripleWithin n3 (base + 212) (base + 280)
+        (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base) P3' Q) :
+    cpsTripleWithin (2 + (n0 + n1 + n2 + n3)) base (base + 280)
+      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base)
+      ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offOld) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ addrOld) **
+        (sp ↦ₘ offset)) ** F)
+      Q := by
+  exact cpsTripleWithin_seq_same_cr
+    (evm_mstore_prologue_stack_spec_within_framed
+      offReg valReg byteReg accReg addrReg memBaseReg
+      sp offset offOld addrOld memBase base F hF
+      h_off_ne_x0 h_addr_ne_x0)
+    (evm_mstore_public_one_limb_sequence_spec_within_perm
+      offReg valReg byteReg accReg addrReg memBaseReg base
+      h0 h01 h1 h12 h2 h23 h3)
+
+/--
 Generic public-code MSTORE prologue/body composition with a framed prologue.
 
 This lets callers plug in any body triple over `evm_mstore_code` that starts

--- a/EvmAsm/Evm64/MStore/UnalignedFramedStackSpec.lean
+++ b/EvmAsm/Evm64/MStore/UnalignedFramedStackSpec.lean
@@ -1287,4 +1287,117 @@ theorem evm_mstore_unaligned_full_stack_spec_within_public_stack_tail
     (fun _ hp => by sep_perm hp)
     hCore
 
+/--
+Stack-pre variant of the public unaligned MSTORE stack-tail composition.
+
+This exposes the consumed offset and value words as an `evmStackIs`
+precondition. The postcondition keeps those below-stack memory cells folded,
+while `.x12` advances to `sp + 64`.
+
+Distinctive token:
+evm_mstore_unaligned_full_stack_spec_within_public_stack_pre #53.
+-/
+theorem evm_mstore_unaligned_full_stack_spec_within_public_stack_pre
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset offOld addrOld memBase byteOld accOld : Word)
+    (offsetWord valueWord : EvmWord) (rest : List EvmWord)
+    (offsetHigh1 offsetHigh2 offsetHigh3 : Word)
+    (limb0 limb1 limb2 limb3 : Word)
+    (loAddr0 hiAddr0 loVal0 hiVal0 : Word)
+    (loAddr1 hiAddr1 loVal1 hiVal1 : Word)
+    (loAddr2 hiAddr2 loVal2 hiVal2 : Word)
+    (loAddr3 hiAddr3 loVal3 hiVal3 : Word)
+    (start : Nat) (base : Word)
+    (h_offset0 : offsetWord.getLimbN 0 = offset)
+    (h_offset1 : offsetWord.getLimbN 1 = offsetHigh1)
+    (h_offset2 : offsetWord.getLimbN 2 = offsetHigh2)
+    (h_offset3 : offsetWord.getLimbN 3 = offsetHigh3)
+    (h_value0 : valueWord.getLimbN 0 = limb0)
+    (h_value1 : valueWord.getLimbN 1 = limb1)
+    (h_value2 : valueWord.getLimbN 2 = limb2)
+    (h_value3 : valueWord.getLimbN 3 = limb3)
+    (h_off_ne_x0 : offReg ≠ .x0)
+    (h_addr_ne_x0 : addrReg ≠ .x0)
+    (h_byte_ne_x0 : byteReg ≠ .x0)
+    (h_acc_ne_x0 : accReg ≠ .x0)
+    (h_window0 : mstoreLimbWindowOk (memBase + offset) loAddr0 hiAddr0 start
+                  24 25 26 27 28 29 30 31)
+    (h_window1 : mstoreLimbWindowOk (memBase + offset) loAddr1 hiAddr1 start
+                  16 17 18 19 20 21 22 23)
+    (h_window2 : mstoreLimbWindowOk (memBase + offset) loAddr2 hiAddr2 start
+                  8 9 10 11 12 13 14 15)
+    (h_window3 : mstoreLimbWindowOk (memBase + offset) loAddr3 hiAddr3 start
+                  0 1 2 3 4 5 6 7) :
+    let stored0 := MStore.mstoreDwordPairStoreLimb loVal0 hiVal0 limb0 start
+    let stored1 := MStore.mstoreDwordPairStoreLimb loVal1 hiVal1 limb1 start
+    let stored2 := MStore.mstoreDwordPairStoreLimb loVal2 hiVal2 limb2 start
+    let stored3 := MStore.mstoreDwordPairStoreLimb loVal3 hiVal3 limb3 start
+    cpsTripleWithin (2 + (17 + 17 + 17 + 17) + 1) base (base + 284)
+      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base)
+      (((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offOld) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ addrOld) **
+        evmStackIs sp (offsetWord :: valueWord :: rest)) **
+       ((byteReg ↦ᵣ byteOld) ** (accReg ↦ᵣ accOld) **
+        (loAddr0 ↦ₘ loVal0) ** (hiAddr0 ↦ₘ hiVal0) **
+        (loAddr1 ↦ₘ loVal1) ** (hiAddr1 ↦ₘ hiVal1) **
+        (loAddr2 ↦ₘ loVal2) ** (hiAddr2 ↦ₘ hiVal2) **
+        (loAddr3 ↦ₘ loVal3) ** (hiAddr3 ↦ₘ hiVal3))))
+      (((.x12 : Reg) ↦ᵣ (sp + 64)) **
+       evmStackIs sp (offsetWord :: valueWord :: rest) **
+       ((offReg ↦ᵣ offset) ** (memBaseReg ↦ᵣ memBase) **
+        (addrReg ↦ᵣ (memBase + offset)) **
+        (byteReg ↦ᵣ limb3) ** (accReg ↦ᵣ limb3) **
+        (loAddr3 ↦ₘ stored3.1) ** (hiAddr3 ↦ₘ stored3.2) **
+        (loAddr0 ↦ₘ stored0.1) ** (hiAddr0 ↦ₘ stored0.2) **
+        (loAddr1 ↦ₘ stored1.1) ** (hiAddr1 ↦ₘ stored1.2) **
+        (loAddr2 ↦ₘ stored2.1) ** (hiAddr2 ↦ₘ stored2.2))) := by
+  dsimp only
+  let offsetHighFrame : Assertion :=
+    ((sp + 8) ↦ₘ offsetHigh1) **
+    ((sp + 16) ↦ₘ offsetHigh2) **
+    ((sp + 24) ↦ₘ offsetHigh3)
+  have hCore :=
+    cpsTripleWithin_frameR offsetHighFrame (by pcFree)
+      (evm_mstore_unaligned_full_stack_spec_within_public_stack_tail
+        offReg valReg byteReg accReg addrReg memBaseReg
+        sp offset offOld addrOld memBase byteOld accOld
+        limb0 limb1 limb2 limb3
+        loAddr0 hiAddr0 loVal0 hiVal0
+        loAddr1 hiAddr1 loVal1 hiVal1
+        loAddr2 hiAddr2 loVal2 hiVal2
+        loAddr3 hiAddr3 loVal3 hiVal3
+        start base rest
+        h_off_ne_x0 h_addr_ne_x0 h_byte_ne_x0 h_acc_ne_x0
+        h_window0 h_window1 h_window2 h_window3)
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by
+      rw [evmStackIs_cons] at hp
+      rw [evmWordIs_sp_limbs_eq sp offsetWord
+        offset offsetHigh1 offsetHigh2 offsetHigh3
+        h_offset0 h_offset1 h_offset2 h_offset3] at hp
+      rw [evmStackIs_cons] at hp
+      rw [evmWordIs_sp32_limbs_eq sp valueWord
+        limb0 limb1 limb2 limb3
+        h_value0 h_value1 h_value2 h_value3] at hp
+      rw [show (sp + 32 + 32 : Word) = sp + 64 from by bv_addr] at hp
+      simp only [signExtend12_32, signExtend12_40, signExtend12_48,
+        signExtend12_56] at hp ⊢
+      dsimp only [offsetHighFrame] at hp ⊢
+      sep_perm hp)
+    (fun _ hp => by
+      rw [evmStackIs_cons]
+      rw [evmWordIs_sp_limbs_eq sp offsetWord
+        offset offsetHigh1 offsetHigh2 offsetHigh3
+        h_offset0 h_offset1 h_offset2 h_offset3]
+      rw [evmStackIs_cons]
+      rw [evmWordIs_sp32_limbs_eq sp valueWord
+        limb0 limb1 limb2 limb3
+        h_value0 h_value1 h_value2 h_value3]
+      rw [show (sp + 32 + 32 : Word) = sp + 64 from by bv_addr]
+      simp only [signExtend12_32, signExtend12_40, signExtend12_48,
+        signExtend12_56] at hp ⊢
+      dsimp only [offsetHighFrame] at hp ⊢
+      sep_perm hp)
+    hCore
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/MStore/UnalignedFramedStackSpec.lean
+++ b/EvmAsm/Evm64/MStore/UnalignedFramedStackSpec.lean
@@ -354,6 +354,54 @@ theorem evm_mstore_public_one_limb_sequence_spec_within
     h3
 
 /--
+Compose the framed MSTORE prologue with four public-code one-limb quarter
+triples.
+
+This is useful once q0..q3 have already been transported to `evm_mstore_code`;
+the theorem supplies the prologue step and sequences the public body in one
+call.
+
+Distinctive token:
+evm_mstore_public_one_limb_sequence_with_prologue_framed #53.
+-/
+theorem evm_mstore_public_one_limb_sequence_with_prologue_framed
+    {n0 n1 n2 n3 : Nat} {P1 P2 P3 Q : Assertion}
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset offOld addrOld memBase : Word) (base : Word)
+    (F : Assertion) (hF : F.pcFree)
+    (h_off_ne_x0 : offReg ≠ .x0)
+    (h_addr_ne_x0 : addrReg ≠ .x0)
+    (h0 :
+      cpsTripleWithin n0 (base + 8) (base + 76)
+        (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base)
+        ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+          (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+          (sp ↦ₘ offset)) ** F)
+        P1)
+    (h1 :
+      cpsTripleWithin n1 (base + 76) (base + 144)
+        (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base) P1 P2)
+    (h2 :
+      cpsTripleWithin n2 (base + 144) (base + 212)
+        (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base) P2 P3)
+    (h3 :
+      cpsTripleWithin n3 (base + 212) (base + 280)
+        (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base) P3 Q) :
+    cpsTripleWithin (2 + (n0 + n1 + n2 + n3)) base (base + 280)
+      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base)
+      ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offOld) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ addrOld) **
+        (sp ↦ₘ offset)) ** F)
+      Q := by
+  exact cpsTripleWithin_seq_same_cr
+    (evm_mstore_prologue_stack_spec_within_framed
+      offReg valReg byteReg accReg addrReg memBaseReg
+      sp offset offOld addrOld memBase base F hF
+      h_off_ne_x0 h_addr_ne_x0)
+    (evm_mstore_public_one_limb_sequence_spec_within
+      offReg valReg byteReg accReg addrReg memBaseReg base h0 h1 h2 h3)
+
+/--
 Sibling-framed q0 stack spec: `evm_mstore_unaligned_one_limb_q0_stack_spec_within`
 with an arbitrary `pcFree` assertion `F` framed on both pre and post.
 

--- a/EvmAsm/Evm64/MStore/UnalignedFramedStackSpec.lean
+++ b/EvmAsm/Evm64/MStore/UnalignedFramedStackSpec.lean
@@ -966,4 +966,145 @@ theorem evm_mstore_unaligned_one_limb_q3_spec_within_framed_public_code
       loAddr hiAddr loVal hiVal start base F hF
       h_byte_ne_x0 h_acc_ne_x0 h_window)
 
+/--
+Concrete public-code composition of the four unaligned MSTORE quarter specs.
+
+The theorem instantiates q0..q3 with sibling frames that thread the remaining
+source limbs and memory windows, then uses `sep_perm` at each midpoint.
+
+Distinctive token: evm_mstore_unaligned_full_stack_spec_within_public #53.
+-/
+theorem evm_mstore_unaligned_full_stack_spec_within_public
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset offOld addrOld memBase byteOld accOld : Word)
+    (limb0 limb1 limb2 limb3 : Word)
+    (loAddr0 hiAddr0 loVal0 hiVal0 : Word)
+    (loAddr1 hiAddr1 loVal1 hiVal1 : Word)
+    (loAddr2 hiAddr2 loVal2 hiVal2 : Word)
+    (loAddr3 hiAddr3 loVal3 hiVal3 : Word)
+    (start : Nat) (base : Word)
+    (h_off_ne_x0 : offReg ≠ .x0)
+    (h_addr_ne_x0 : addrReg ≠ .x0)
+    (h_byte_ne_x0 : byteReg ≠ .x0)
+    (h_acc_ne_x0 : accReg ≠ .x0)
+    (h_window0 : mstoreLimbWindowOk (memBase + offset) loAddr0 hiAddr0 start
+                  24 25 26 27 28 29 30 31)
+    (h_window1 : mstoreLimbWindowOk (memBase + offset) loAddr1 hiAddr1 start
+                  16 17 18 19 20 21 22 23)
+    (h_window2 : mstoreLimbWindowOk (memBase + offset) loAddr2 hiAddr2 start
+                  8 9 10 11 12 13 14 15)
+    (h_window3 : mstoreLimbWindowOk (memBase + offset) loAddr3 hiAddr3 start
+                  0 1 2 3 4 5 6 7) :
+    let stored0 := MStore.mstoreDwordPairStoreLimb loVal0 hiVal0 limb0 start
+    let stored1 := MStore.mstoreDwordPairStoreLimb loVal1 hiVal1 limb1 start
+    let stored2 := MStore.mstoreDwordPairStoreLimb loVal2 hiVal2 limb2 start
+    let stored3 := MStore.mstoreDwordPairStoreLimb loVal3 hiVal3 limb3 start
+    cpsTripleWithin (2 + (17 + 17 + 17 + 17)) base (base + 280)
+      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base)
+      ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offOld) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ addrOld) **
+        (sp ↦ₘ offset)) **
+       ((byteReg ↦ᵣ byteOld) ** (accReg ↦ᵣ accOld) **
+        (loAddr0 ↦ₘ loVal0) ** (hiAddr0 ↦ₘ hiVal0) **
+        ((sp + signExtend12 (32 : BitVec 12)) ↦ₘ limb0) **
+        (loAddr1 ↦ₘ loVal1) ** (hiAddr1 ↦ₘ hiVal1) **
+        ((sp + signExtend12 (40 : BitVec 12)) ↦ₘ limb1) **
+        (loAddr2 ↦ₘ loVal2) ** (hiAddr2 ↦ₘ hiVal2) **
+        ((sp + signExtend12 (48 : BitVec 12)) ↦ₘ limb2) **
+        (loAddr3 ↦ₘ loVal3) ** (hiAddr3 ↦ₘ hiVal3) **
+        ((sp + signExtend12 (56 : BitVec 12)) ↦ₘ limb3)))
+      ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+        (sp ↦ₘ offset) **
+        ((byteReg ↦ᵣ limb3) ** (accReg ↦ᵣ limb3) **
+         (loAddr3 ↦ₘ stored3.1) ** (hiAddr3 ↦ₘ stored3.2) **
+         ((sp + signExtend12 (56 : BitVec 12)) ↦ₘ limb3))) **
+       ((loAddr0 ↦ₘ stored0.1) ** (hiAddr0 ↦ₘ stored0.2) **
+        ((sp + signExtend12 (32 : BitVec 12)) ↦ₘ limb0) **
+        (loAddr1 ↦ₘ stored1.1) ** (hiAddr1 ↦ₘ stored1.2) **
+        ((sp + signExtend12 (40 : BitVec 12)) ↦ₘ limb1) **
+        (loAddr2 ↦ₘ stored2.1) ** (hiAddr2 ↦ₘ stored2.2) **
+        ((sp + signExtend12 (48 : BitVec 12)) ↦ₘ limb2))) := by
+  let Fpre : Assertion :=
+    (byteReg ↦ᵣ byteOld) ** (accReg ↦ᵣ accOld) **
+    (loAddr0 ↦ₘ loVal0) ** (hiAddr0 ↦ₘ hiVal0) **
+    ((sp + signExtend12 (32 : BitVec 12)) ↦ₘ limb0) **
+    (loAddr1 ↦ₘ loVal1) ** (hiAddr1 ↦ₘ hiVal1) **
+    ((sp + signExtend12 (40 : BitVec 12)) ↦ₘ limb1) **
+    (loAddr2 ↦ₘ loVal2) ** (hiAddr2 ↦ₘ hiVal2) **
+    ((sp + signExtend12 (48 : BitVec 12)) ↦ₘ limb2) **
+    (loAddr3 ↦ₘ loVal3) ** (hiAddr3 ↦ₘ hiVal3) **
+    ((sp + signExtend12 (56 : BitVec 12)) ↦ₘ limb3)
+  let stored0 := MStore.mstoreDwordPairStoreLimb loVal0 hiVal0 limb0 start
+  let stored1 := MStore.mstoreDwordPairStoreLimb loVal1 hiVal1 limb1 start
+  let stored2 := MStore.mstoreDwordPairStoreLimb loVal2 hiVal2 limb2 start
+  let F0 : Assertion :=
+    (loAddr1 ↦ₘ loVal1) ** (hiAddr1 ↦ₘ hiVal1) **
+    ((sp + signExtend12 (40 : BitVec 12)) ↦ₘ limb1) **
+    (loAddr2 ↦ₘ loVal2) ** (hiAddr2 ↦ₘ hiVal2) **
+    ((sp + signExtend12 (48 : BitVec 12)) ↦ₘ limb2) **
+    (loAddr3 ↦ₘ loVal3) ** (hiAddr3 ↦ₘ hiVal3) **
+    ((sp + signExtend12 (56 : BitVec 12)) ↦ₘ limb3)
+  let F1 : Assertion :=
+    (loAddr0 ↦ₘ stored0.1) ** (hiAddr0 ↦ₘ stored0.2) **
+    ((sp + signExtend12 (32 : BitVec 12)) ↦ₘ limb0) **
+    (loAddr2 ↦ₘ loVal2) ** (hiAddr2 ↦ₘ hiVal2) **
+    ((sp + signExtend12 (48 : BitVec 12)) ↦ₘ limb2) **
+    (loAddr3 ↦ₘ loVal3) ** (hiAddr3 ↦ₘ hiVal3) **
+    ((sp + signExtend12 (56 : BitVec 12)) ↦ₘ limb3)
+  let F2 : Assertion :=
+    (loAddr0 ↦ₘ stored0.1) ** (hiAddr0 ↦ₘ stored0.2) **
+    ((sp + signExtend12 (32 : BitVec 12)) ↦ₘ limb0) **
+    (loAddr1 ↦ₘ stored1.1) ** (hiAddr1 ↦ₘ stored1.2) **
+    ((sp + signExtend12 (40 : BitVec 12)) ↦ₘ limb1) **
+    (loAddr3 ↦ₘ loVal3) ** (hiAddr3 ↦ₘ hiVal3) **
+    ((sp + signExtend12 (56 : BitVec 12)) ↦ₘ limb3)
+  let F3 : Assertion :=
+    (loAddr0 ↦ₘ stored0.1) ** (hiAddr0 ↦ₘ stored0.2) **
+    ((sp + signExtend12 (32 : BitVec 12)) ↦ₘ limb0) **
+    (loAddr1 ↦ₘ stored1.1) ** (hiAddr1 ↦ₘ stored1.2) **
+    ((sp + signExtend12 (40 : BitVec 12)) ↦ₘ limb1) **
+    (loAddr2 ↦ₘ stored2.1) ** (hiAddr2 ↦ₘ stored2.2) **
+    ((sp + signExtend12 (48 : BitVec 12)) ↦ₘ limb2)
+  dsimp only
+  exact cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by
+      dsimp only [Fpre, F0] at hp ⊢
+      sep_perm hp)
+    (evm_mstore_prologue_stack_spec_within_framed
+      offReg valReg byteReg accReg addrReg memBaseReg
+      sp offset offOld addrOld memBase base Fpre (by pcFree)
+      h_off_ne_x0 h_addr_ne_x0)
+    (evm_mstore_public_one_limb_sequence_spec_within_perm
+      offReg valReg byteReg accReg addrReg memBaseReg base
+      (evm_mstore_unaligned_one_limb_q0_spec_within_framed_public_code
+        offReg valReg byteReg accReg addrReg memBaseReg
+        sp offset memBase byteOld accOld limb0
+        loAddr0 hiAddr0 loVal0 hiVal0 start base F0 (by pcFree)
+        h_byte_ne_x0 h_acc_ne_x0 h_window0)
+      (fun _ hp => by
+        dsimp only [F0, F1, stored0] at hp ⊢
+        sep_perm hp)
+      (evm_mstore_unaligned_one_limb_q1_spec_within_framed_public_code
+        offReg valReg byteReg accReg addrReg memBaseReg
+        sp offset memBase limb0 limb0 limb1
+        loAddr1 hiAddr1 loVal1 hiVal1 start base F1 (by pcFree)
+        h_byte_ne_x0 h_acc_ne_x0 h_window1)
+      (fun _ hp => by
+        dsimp only [F1, F2, stored1] at hp ⊢
+        sep_perm hp)
+      (evm_mstore_unaligned_one_limb_q2_spec_within_framed_public_code
+        offReg valReg byteReg accReg addrReg memBaseReg
+        sp offset memBase limb1 limb1 limb2
+        loAddr2 hiAddr2 loVal2 hiVal2 start base F2 (by pcFree)
+        h_byte_ne_x0 h_acc_ne_x0 h_window2)
+      (fun _ hp => by
+        dsimp only [F2, F3, stored2] at hp ⊢
+        sep_perm hp)
+      (evm_mstore_unaligned_one_limb_q3_spec_within_framed_public_code
+        offReg valReg byteReg accReg addrReg memBaseReg
+        sp offset memBase limb2 limb2 limb3
+        loAddr3 hiAddr3 loVal3 hiVal3 start base F3 (by pcFree)
+        h_byte_ne_x0 h_acc_ne_x0 h_window3))
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/MStore/UnalignedFramedStackSpec.lean
+++ b/EvmAsm/Evm64/MStore/UnalignedFramedStackSpec.lean
@@ -402,6 +402,41 @@ theorem evm_mstore_public_one_limb_sequence_with_prologue_framed
       offReg valReg byteReg accReg addrReg memBaseReg base h0 h1 h2 h3)
 
 /--
+Generic public-code MSTORE prologue/body composition with a framed prologue.
+
+This lets callers plug in any body triple over `evm_mstore_code` that starts
+from the framed prologue postcondition, not just the q0..q3 one-limb sequence.
+
+Distinctive token: evm_mstore_public_body_with_prologue_framed #53.
+-/
+theorem evm_mstore_public_body_with_prologue_framed
+    {n : Nat} {Q : Assertion}
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset offOld addrOld memBase : Word) (base pcEnd : Word)
+    (F : Assertion) (hF : F.pcFree)
+    (h_off_ne_x0 : offReg ≠ .x0)
+    (h_addr_ne_x0 : addrReg ≠ .x0)
+    (hbody :
+      cpsTripleWithin n (base + 8) pcEnd
+        (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base)
+        ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+          (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+          (sp ↦ₘ offset)) ** F)
+        Q) :
+    cpsTripleWithin (2 + n) base pcEnd
+      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base)
+      ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offOld) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ addrOld) **
+        (sp ↦ₘ offset)) ** F)
+      Q := by
+  exact cpsTripleWithin_seq_same_cr
+    (evm_mstore_prologue_stack_spec_within_framed
+      offReg valReg byteReg accReg addrReg memBaseReg
+      sp offset offOld addrOld memBase base F hF
+      h_off_ne_x0 h_addr_ne_x0)
+    hbody
+
+/--
 Sibling-framed q0 stack spec: `evm_mstore_unaligned_one_limb_q0_stack_spec_within`
 with an arbitrary `pcFree` assertion `F` framed on both pre and post.
 

--- a/EvmAsm/Evm64/MStore/UnalignedFramedStackSpec.lean
+++ b/EvmAsm/Evm64/MStore/UnalignedFramedStackSpec.lean
@@ -21,7 +21,7 @@
   sibling-quarter cells #53.
 -/
 
-import EvmAsm.Evm64.MStore.Spec
+import EvmAsm.Evm64.MStore.StackSpec
 import EvmAsm.Evm64.MStore.UnalignedStackSpec
 
 namespace EvmAsm.Evm64
@@ -63,6 +63,36 @@ theorem mstore_prologue_stack_spec_within_framed
     (fun _ hp => by sep_perm hp)
     (fun _ hp => by sep_perm hp)
     framed
+
+/--
+EVM-code transport of `mstore_prologue_stack_spec_within_framed`.
+
+Later full-stack unaligned MSTORE composition can use this theorem directly at
+the public `evm_mstore_code` boundary instead of carrying an extra stack-code
+transport step.
+
+Distinctive token: evm_mstore_prologue_stack_spec_within_framed #53.
+-/
+theorem evm_mstore_prologue_stack_spec_within_framed
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset offOld addrOld memBase : Word) (base : Word)
+    (F : Assertion) (hF : F.pcFree)
+    (h_off_ne_x0 : offReg ≠ .x0)
+    (h_addr_ne_x0 : addrReg ≠ .x0) :
+    cpsTripleWithin 2 base (base + 8)
+      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base)
+      ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offOld) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ addrOld) **
+        (sp ↦ₘ offset)) ** F)
+      ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+        (sp ↦ₘ offset)) ** F) := by
+  exact cpsTripleWithin_evm_mstore_of_stack
+    offReg valReg byteReg accReg addrReg memBaseReg base (base + 8)
+    (mstore_prologue_stack_spec_within_framed
+      offReg byteReg accReg addrReg memBaseReg
+      sp offset offOld addrOld memBase base F hF
+      h_off_ne_x0 h_addr_ne_x0)
 
 /--
 Sibling-framed q0 stack spec: `evm_mstore_unaligned_one_limb_q0_stack_spec_within`

--- a/EvmAsm/Evm64/MStore/UnalignedFramedStackSpec.lean
+++ b/EvmAsm/Evm64/MStore/UnalignedFramedStackSpec.lean
@@ -370,6 +370,48 @@ theorem evm_mstore_unaligned_one_limb_q0_stack_spec_within_framed
     framed
 
 /--
+Public-code q0 framed MSTORE spec: transports
+`evm_mstore_unaligned_one_limb_q0_stack_spec_within_framed` from the q0
+one-limb block to the full `evm_mstore_code` code requirement.
+
+Distinctive token:
+evm_mstore_unaligned_one_limb_q0_spec_within_framed_public_code #53.
+-/
+theorem evm_mstore_unaligned_one_limb_q0_spec_within_framed_public_code
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset memBase byteOld accOld limbVal : Word)
+    (loAddr hiAddr loVal hiVal : Word) (start : Nat)
+    (base : Word)
+    (F : Assertion) (hF : F.pcFree)
+    (h_byte_ne_x0 : byteReg ≠ .x0)
+    (h_acc_ne_x0 : accReg ≠ .x0)
+    (h_window : mstoreLimbWindowOk (memBase + offset) loAddr hiAddr start
+                  24 25 26 27 28 29 30 31) :
+    cpsTripleWithin 17 (base + 8) (base + 76)
+      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base)
+      ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+        (sp ↦ₘ offset) **
+        ((byteReg ↦ᵣ byteOld) ** (accReg ↦ᵣ accOld) **
+         (loAddr ↦ₘ loVal) ** (hiAddr ↦ₘ hiVal) **
+         ((sp + signExtend12 (32 : BitVec 12)) ↦ₘ limbVal))) ** F)
+      ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+        (sp ↦ₘ offset) **
+        (let stored :=
+          MStore.mstoreDwordPairStoreLimb loVal hiVal limbVal start
+         (byteReg ↦ᵣ limbVal) ** (accReg ↦ᵣ limbVal) **
+         (loAddr ↦ₘ stored.1) ** (hiAddr ↦ₘ stored.2) **
+         ((sp + signExtend12 (32 : BitVec 12)) ↦ₘ limbVal))) ** F) := by
+  exact cpsTripleWithin_evm_mstore_of_one_limb_q0
+    offReg valReg byteReg accReg addrReg memBaseReg base
+    (evm_mstore_unaligned_one_limb_q0_stack_spec_within_framed
+      offReg byteReg accReg addrReg memBaseReg
+      sp offset memBase byteOld accOld limbVal
+      loAddr hiAddr loVal hiVal start base F hF
+      h_byte_ne_x0 h_acc_ne_x0 h_window)
+
+/--
 Sibling-framed q1 stack spec: `evm_mstore_unaligned_one_limb_q1_stack_spec_within`
 with an arbitrary `pcFree` assertion `F` framed on both pre and post.
 

--- a/EvmAsm/Evm64/MStore/UnalignedFramedStackSpec.lean
+++ b/EvmAsm/Evm64/MStore/UnalignedFramedStackSpec.lean
@@ -1107,4 +1107,102 @@ theorem evm_mstore_unaligned_full_stack_spec_within_public
         loAddr3 hiAddr3 loVal3 hiVal3 start base F3 (by pcFree)
         h_byte_ne_x0 h_acc_ne_x0 h_window3))
 
+/--
+Concrete public-code composition of unaligned MSTORE through the epilogue.
+
+This wraps `evm_mstore_unaligned_full_stack_spec_within_public` with the
+public-code epilogue so the final stack pointer is advanced to `sp + 64`.
+
+Distinctive token:
+evm_mstore_unaligned_full_stack_spec_within_public_epilogue #53.
+-/
+theorem evm_mstore_unaligned_full_stack_spec_within_public_epilogue
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset offOld addrOld memBase byteOld accOld : Word)
+    (limb0 limb1 limb2 limb3 : Word)
+    (loAddr0 hiAddr0 loVal0 hiVal0 : Word)
+    (loAddr1 hiAddr1 loVal1 hiVal1 : Word)
+    (loAddr2 hiAddr2 loVal2 hiVal2 : Word)
+    (loAddr3 hiAddr3 loVal3 hiVal3 : Word)
+    (start : Nat) (base : Word)
+    (h_off_ne_x0 : offReg ≠ .x0)
+    (h_addr_ne_x0 : addrReg ≠ .x0)
+    (h_byte_ne_x0 : byteReg ≠ .x0)
+    (h_acc_ne_x0 : accReg ≠ .x0)
+    (h_window0 : mstoreLimbWindowOk (memBase + offset) loAddr0 hiAddr0 start
+                  24 25 26 27 28 29 30 31)
+    (h_window1 : mstoreLimbWindowOk (memBase + offset) loAddr1 hiAddr1 start
+                  16 17 18 19 20 21 22 23)
+    (h_window2 : mstoreLimbWindowOk (memBase + offset) loAddr2 hiAddr2 start
+                  8 9 10 11 12 13 14 15)
+    (h_window3 : mstoreLimbWindowOk (memBase + offset) loAddr3 hiAddr3 start
+                  0 1 2 3 4 5 6 7) :
+    let stored0 := MStore.mstoreDwordPairStoreLimb loVal0 hiVal0 limb0 start
+    let stored1 := MStore.mstoreDwordPairStoreLimb loVal1 hiVal1 limb1 start
+    let stored2 := MStore.mstoreDwordPairStoreLimb loVal2 hiVal2 limb2 start
+    let stored3 := MStore.mstoreDwordPairStoreLimb loVal3 hiVal3 limb3 start
+    cpsTripleWithin (2 + (17 + 17 + 17 + 17) + 1) base (base + 284)
+      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base)
+      ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offOld) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ addrOld) **
+        (sp ↦ₘ offset)) **
+       ((byteReg ↦ᵣ byteOld) ** (accReg ↦ᵣ accOld) **
+        (loAddr0 ↦ₘ loVal0) ** (hiAddr0 ↦ₘ hiVal0) **
+        ((sp + signExtend12 (32 : BitVec 12)) ↦ₘ limb0) **
+        (loAddr1 ↦ₘ loVal1) ** (hiAddr1 ↦ₘ hiVal1) **
+        ((sp + signExtend12 (40 : BitVec 12)) ↦ₘ limb1) **
+        (loAddr2 ↦ₘ loVal2) ** (hiAddr2 ↦ₘ hiVal2) **
+        ((sp + signExtend12 (48 : BitVec 12)) ↦ₘ limb2) **
+        (loAddr3 ↦ₘ loVal3) ** (hiAddr3 ↦ₘ hiVal3) **
+        ((sp + signExtend12 (56 : BitVec 12)) ↦ₘ limb3)))
+      (((.x12 : Reg) ↦ᵣ (sp + 64)) **
+       ((offReg ↦ᵣ offset) ** (memBaseReg ↦ᵣ memBase) **
+        (addrReg ↦ᵣ (memBase + offset)) ** (sp ↦ₘ offset) **
+        (byteReg ↦ᵣ limb3) ** (accReg ↦ᵣ limb3) **
+        (loAddr3 ↦ₘ stored3.1) ** (hiAddr3 ↦ₘ stored3.2) **
+        ((sp + signExtend12 (56 : BitVec 12)) ↦ₘ limb3) **
+        (loAddr0 ↦ₘ stored0.1) ** (hiAddr0 ↦ₘ stored0.2) **
+        ((sp + signExtend12 (32 : BitVec 12)) ↦ₘ limb0) **
+        (loAddr1 ↦ₘ stored1.1) ** (hiAddr1 ↦ₘ stored1.2) **
+        ((sp + signExtend12 (40 : BitVec 12)) ↦ₘ limb1) **
+        (loAddr2 ↦ₘ stored2.1) ** (hiAddr2 ↦ₘ stored2.2) **
+        ((sp + signExtend12 (48 : BitVec 12)) ↦ₘ limb2))) := by
+  let stored0 := MStore.mstoreDwordPairStoreLimb loVal0 hiVal0 limb0 start
+  let stored1 := MStore.mstoreDwordPairStoreLimb loVal1 hiVal1 limb1 start
+  let stored2 := MStore.mstoreDwordPairStoreLimb loVal2 hiVal2 limb2 start
+  let stored3 := MStore.mstoreDwordPairStoreLimb loVal3 hiVal3 limb3 start
+  let FPost : Assertion :=
+    (offReg ↦ᵣ offset) ** (memBaseReg ↦ᵣ memBase) **
+    (addrReg ↦ᵣ (memBase + offset)) ** (sp ↦ₘ offset) **
+    (byteReg ↦ᵣ limb3) ** (accReg ↦ᵣ limb3) **
+    (loAddr3 ↦ₘ stored3.1) ** (hiAddr3 ↦ₘ stored3.2) **
+    ((sp + signExtend12 (56 : BitVec 12)) ↦ₘ limb3) **
+    (loAddr0 ↦ₘ stored0.1) ** (hiAddr0 ↦ₘ stored0.2) **
+    ((sp + signExtend12 (32 : BitVec 12)) ↦ₘ limb0) **
+    (loAddr1 ↦ₘ stored1.1) ** (hiAddr1 ↦ₘ stored1.2) **
+    ((sp + signExtend12 (40 : BitVec 12)) ↦ₘ limb1) **
+    (loAddr2 ↦ₘ stored2.1) ** (hiAddr2 ↦ₘ stored2.2) **
+    ((sp + signExtend12 (48 : BitVec 12)) ↦ₘ limb2)
+  dsimp only
+  exact cpsTripleWithin_seq_same_cr
+    (cpsTripleWithin_weaken
+      (fun _ hp => by sep_perm hp)
+      (fun _ hp => by
+        dsimp only [FPost, stored0, stored1, stored2, stored3] at hp ⊢
+        sep_perm hp)
+      (evm_mstore_unaligned_full_stack_spec_within_public
+        offReg valReg byteReg accReg addrReg memBaseReg
+        sp offset offOld addrOld memBase byteOld accOld
+        limb0 limb1 limb2 limb3
+        loAddr0 hiAddr0 loVal0 hiVal0
+        loAddr1 hiAddr1 loVal1 hiVal1
+        loAddr2 hiAddr2 loVal2 hiVal2
+        loAddr3 hiAddr3 loVal3 hiVal3
+        start base
+        h_off_ne_x0 h_addr_ne_x0 h_byte_ne_x0 h_acc_ne_x0
+        h_window0 h_window1 h_window2 h_window3))
+    (mstore_epilogue_evm_mstore_frame_spec_within
+      offReg valReg byteReg accReg addrReg memBaseReg sp base
+      FPost (by pcFree))
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/SDiv.lean
+++ b/EvmAsm/Evm64/SDiv.lean
@@ -14,6 +14,7 @@ import EvmAsm.Evm64.SDiv.AddrNormAttr
 import EvmAsm.Evm64.SDiv.Layout
 import EvmAsm.Evm64.SDiv.Args
 import EvmAsm.Evm64.SDiv.ArgsStackDecode
+import EvmAsm.Evm64.SDiv.StackExecutionBridge
 import EvmAsm.Evm64.SDiv.Program
 import EvmAsm.Evm64.SDiv.LimbSpec
 import EvmAsm.Evm64.SDiv.AddrNorm

--- a/EvmAsm/Evm64/SDiv.lean
+++ b/EvmAsm/Evm64/SDiv.lean
@@ -13,6 +13,7 @@
 import EvmAsm.Evm64.SDiv.AddrNormAttr
 import EvmAsm.Evm64.SDiv.Layout
 import EvmAsm.Evm64.SDiv.Args
+import EvmAsm.Evm64.SDiv.ArgsStackDecode
 import EvmAsm.Evm64.SDiv.Program
 import EvmAsm.Evm64.SDiv.LimbSpec
 import EvmAsm.Evm64.SDiv.AddrNorm

--- a/EvmAsm/Evm64/SDiv.lean
+++ b/EvmAsm/Evm64/SDiv.lean
@@ -12,6 +12,7 @@
 
 import EvmAsm.Evm64.SDiv.AddrNormAttr
 import EvmAsm.Evm64.SDiv.Layout
+import EvmAsm.Evm64.SDiv.Args
 import EvmAsm.Evm64.SDiv.Program
 import EvmAsm.Evm64.SDiv.LimbSpec
 import EvmAsm.Evm64.SDiv.AddrNorm

--- a/EvmAsm/Evm64/SDiv.lean
+++ b/EvmAsm/Evm64/SDiv.lean
@@ -15,6 +15,7 @@ import EvmAsm.Evm64.SDiv.Layout
 import EvmAsm.Evm64.SDiv.Args
 import EvmAsm.Evm64.SDiv.ArgsStackDecode
 import EvmAsm.Evm64.SDiv.StackExecutionBridge
+import EvmAsm.Evm64.SDiv.HandlerBridge
 import EvmAsm.Evm64.SDiv.Program
 import EvmAsm.Evm64.SDiv.LimbSpec
 import EvmAsm.Evm64.SDiv.AddrNorm

--- a/EvmAsm/Evm64/SDiv/Args.lean
+++ b/EvmAsm/Evm64/SDiv/Args.lean
@@ -1,0 +1,78 @@
+/-
+  EvmAsm.Evm64.SDiv.Args
+
+  Pure stack-argument bridge for SDIV (GH #90).
+-/
+
+import EvmAsm.Evm64.EvmWordArith.SDiv
+
+namespace EvmAsm.Evm64
+namespace SDivArgs
+
+/-- SDIV stack arguments: dividend and divisor. -/
+structure Args where
+  dividend : EvmWord
+  divisor : EvmWord
+  deriving Repr
+
+/-- SDIV pops two stack words: dividend and divisor. -/
+def stackArgumentCount : Nat := 2
+
+/-- SDIV pushes one result word. -/
+def resultCount : Nat := 1
+
+/-- Convenience builder for SDIV stack arguments. -/
+def sdivArgs (dividend divisor : EvmWord) : Args :=
+  { dividend := dividend, divisor := divisor }
+
+/-- SDIV result computed from decoded stack arguments. -/
+def sdivResultFromArgs (args : Args) : EvmWord :=
+  EvmWord.sdiv args.dividend args.divisor
+
+/-- Stack after the SDIV result replaces the two operands. -/
+def stackAfterSDiv (args : Args) (rest : List EvmWord) : List EvmWord :=
+  sdivResultFromArgs args :: rest
+
+theorem stackArgumentCount_eq_two : stackArgumentCount = 2 := rfl
+
+theorem resultCount_eq_one : resultCount = 1 := rfl
+
+theorem sdivArgs_dividend (dividend divisor : EvmWord) :
+    (sdivArgs dividend divisor).dividend = dividend := rfl
+
+theorem sdivArgs_divisor (dividend divisor : EvmWord) :
+    (sdivArgs dividend divisor).divisor = divisor := rfl
+
+theorem sdivResultFromArgs_eq (args : Args) :
+    sdivResultFromArgs args = EvmWord.sdiv args.dividend args.divisor := rfl
+
+theorem stackAfterSDiv_eq (args : Args) (rest : List EvmWord) :
+    stackAfterSDiv args rest = sdivResultFromArgs args :: rest := rfl
+
+@[simp] theorem stackAfterSDiv_length (args : Args) (rest : List EvmWord) :
+    (stackAfterSDiv args rest).length = rest.length + 1 := by
+  simp [stackAfterSDiv]
+
+@[simp] theorem sdivResultFromArgs_zero_divisor (dividend : EvmWord) :
+    sdivResultFromArgs (sdivArgs dividend 0) = 0 := by
+  exact EvmWord.sdiv_zero_right
+
+@[simp] theorem sdivResultFromArgs_zero_dividend (divisor : EvmWord) :
+    sdivResultFromArgs (sdivArgs 0 divisor) = 0 := by
+  exact EvmWord.zero_sdiv_left
+
+theorem sdivResultFromArgs_intMin_neg_one :
+    sdivResultFromArgs (sdivArgs (BitVec.intMin 256) (-1)) =
+      BitVec.intMin 256 := by
+  exact EvmWord.sdiv_intMin_neg_one
+
+theorem sdivResultFromArgs_neg_one_two :
+    sdivResultFromArgs (sdivArgs (-1) 2) = 0 := by
+  exact EvmWord.sdiv_neg_one_two
+
+theorem sdivResultFromArgs_pos_neg_trunc :
+    sdivResultFromArgs (sdivArgs 7 (-2)) = (-3 : EvmWord) := by
+  exact EvmWord.sdiv_pos_neg_trunc
+
+end SDivArgs
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/SDiv/ArgsStackDecode.lean
+++ b/EvmAsm/Evm64/SDiv/ArgsStackDecode.lean
@@ -1,0 +1,83 @@
+/-
+  EvmAsm.Evm64.SDiv.ArgsStackDecode
+
+  Pure top-of-stack decoder for SDIV executable-spec bridges (GH #90).
+-/
+
+import EvmAsm.Evm64.SDiv.Args
+
+namespace EvmAsm.Evm64
+namespace SDivArgsStackDecode
+
+/--
+Decode SDIV stack arguments from the top-of-stack list order:
+`dividend, divisor`.
+-/
+def decodeSDivStack? : List EvmWord → Option SDivArgs.Args
+  | dividend :: divisor :: _ => some (SDivArgs.sdivArgs dividend divisor)
+  | _ => none
+
+theorem decodeSDivStack?_cons
+    (dividend divisor : EvmWord) (rest : List EvmWord) :
+    decodeSDivStack? (dividend :: divisor :: rest) =
+      some (SDivArgs.sdivArgs dividend divisor) := rfl
+
+theorem decodeSDivStack?_eq_some_iff
+    {stack : List EvmWord} {args : SDivArgs.Args} :
+    decodeSDivStack? stack = some args ↔
+      ∃ dividend divisor rest,
+        stack = dividend :: divisor :: rest ∧
+          args = SDivArgs.sdivArgs dividend divisor := by
+  constructor
+  · cases stack with
+    | nil => simp [decodeSDivStack?]
+    | cons dividend tail =>
+        cases tail with
+        | nil => simp [decodeSDivStack?]
+        | cons divisor rest =>
+            intro h
+            injection h with h_args
+            subst h_args
+            exact ⟨dividend, divisor, rest, rfl, rfl⟩
+  · rintro ⟨dividend, divisor, rest, rfl, rfl⟩
+    rfl
+
+theorem decodeSDivStack?_eq_none_iff
+    {stack : List EvmWord} :
+    decodeSDivStack? stack = none ↔
+      stack = [] ∨ ∃ dividend, stack = [dividend] := by
+  constructor
+  · cases stack with
+    | nil =>
+        intro _h
+        exact Or.inl rfl
+    | cons dividend tail =>
+        cases tail with
+        | nil =>
+            intro _h
+            exact Or.inr ⟨dividend, rfl⟩
+        | cons divisor rest =>
+            simp [decodeSDivStack?]
+  · rintro (rfl | ⟨dividend, rfl⟩) <;> rfl
+
+theorem decodeSDivStack?_none_of_empty :
+    decodeSDivStack? [] = none := rfl
+
+theorem decodeSDivStack?_none_of_one
+    (dividend : EvmWord) :
+    decodeSDivStack? [dividend] = none := rfl
+
+theorem decodeSDivStack?_dividend
+    (dividend divisor : EvmWord) (rest : List EvmWord) :
+    Option.map (fun args => args.dividend)
+      (decodeSDivStack? (dividend :: divisor :: rest)) =
+      some dividend := rfl
+
+theorem decodeSDivStack?_divisor
+    (dividend divisor : EvmWord) (rest : List EvmWord) :
+    Option.map (fun args => args.divisor)
+      (decodeSDivStack? (dividend :: divisor :: rest)) =
+      some divisor := rfl
+
+end SDivArgsStackDecode
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/SDiv/HandlerBridge.lean
+++ b/EvmAsm/Evm64/SDiv/HandlerBridge.lean
@@ -49,6 +49,18 @@ theorem sdivHandler_status_of_runSDivStack?_none
           simp [runSDivStack?, SDivArgsStackDecode.decodeSDivStack?,
             stackRestAfterSDiv?, Option.bind, h_stack, h_tail] at h_run
 
+theorem sdivHandler_status_empty_stack
+    (state : EvmState) :
+    (ArithmeticHandlers.sdivHandler { state with stack := [] }).status =
+      .error := by
+  simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler]
+
+theorem sdivHandler_status_singleton_stack
+    (state : EvmState) (dividend : EvmWord) :
+    (ArithmeticHandlers.sdivHandler
+      { state with stack := [dividend] }).status = .error := by
+  simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler]
+
 theorem sdivHandler_stack_zero_divisor
     (state : EvmState) (dividend : EvmWord) (rest : List EvmWord) :
     (ArithmeticHandlers.sdivHandler

--- a/EvmAsm/Evm64/SDiv/HandlerBridge.lean
+++ b/EvmAsm/Evm64/SDiv/HandlerBridge.lean
@@ -17,6 +17,13 @@ theorem sdivHandler_pc
     simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler,
       EvmState.withStack, EvmState.invalid, EvmState.withStatus, h_stack]
 
+theorem sdivHandler_gas
+    (state : EvmState) :
+    (ArithmeticHandlers.sdivHandler state).gas = state.gas := by
+  cases h_stack : ArithmeticHandlers.binaryStack? EvmWord.sdiv state.stack <;>
+    simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler,
+      EvmState.withStack, EvmState.invalid, EvmState.withStatus, h_stack]
+
 theorem sdivHandler_stack_of_runSDivStack?_some
     {state : EvmState} {out : SDivStackResult}
     (h_run : runSDivStack? { stack := state.stack } = some out) :

--- a/EvmAsm/Evm64/SDiv/HandlerBridge.lean
+++ b/EvmAsm/Evm64/SDiv/HandlerBridge.lean
@@ -49,5 +49,37 @@ theorem sdivHandler_status_of_runSDivStack?_none
           simp [runSDivStack?, SDivArgsStackDecode.decodeSDivStack?,
             stackRestAfterSDiv?, Option.bind, h_stack, h_tail] at h_run
 
+theorem sdivHandler_stack_zero_divisor
+    (state : EvmState) (dividend : EvmWord) (rest : List EvmWord) :
+    (ArithmeticHandlers.sdivHandler
+      { state with stack := dividend :: 0 :: rest }).stack =
+        0 :: rest := by
+  simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler]
+  exact EvmWord.sdiv_zero_right
+
+theorem sdivHandler_stack_intMin_neg_one
+    (state : EvmState) (rest : List EvmWord) :
+    (ArithmeticHandlers.sdivHandler
+      { state with stack := BitVec.intMin 256 :: (-1 : EvmWord) :: rest }).stack =
+        BitVec.intMin 256 :: rest := by
+  simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler]
+  exact EvmWord.sdiv_intMin_neg_one
+
+theorem sdivHandler_stack_neg_one_two
+    (state : EvmState) (rest : List EvmWord) :
+    (ArithmeticHandlers.sdivHandler
+      { state with stack := (-1 : EvmWord) :: 2 :: rest }).stack =
+        0 :: rest := by
+  simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler]
+  exact EvmWord.sdiv_neg_one_two
+
+theorem sdivHandler_stack_pos_neg_trunc
+    (state : EvmState) (rest : List EvmWord) :
+    (ArithmeticHandlers.sdivHandler
+      { state with stack := (7 : EvmWord) :: (-2 : EvmWord) :: rest }).stack =
+        (-3 : EvmWord) :: rest := by
+  simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler]
+  exact EvmWord.sdiv_pos_neg_trunc
+
 end SDivStackExecutionBridge
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/SDiv/HandlerBridge.lean
+++ b/EvmAsm/Evm64/SDiv/HandlerBridge.lean
@@ -67,6 +67,13 @@ theorem sdivHandler_env
     simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler,
       EvmState.withStack, EvmState.invalid, EvmState.withStatus, h_stack]
 
+theorem sdivHandler_codeLenMatches
+    (state : EvmState) (h_codeLen : state.codeLenMatches) :
+    (ArithmeticHandlers.sdivHandler state).codeLenMatches := by
+  unfold EvmState.codeLenMatches at h_codeLen ⊢
+  rw [sdivHandler_codeLen, sdivHandler_code]
+  exact h_codeLen
+
 theorem sdivHandler_stack_of_runSDivStack?_some
     {state : EvmState} {out : SDivStackResult}
     (h_run : runSDivStack? { stack := state.stack } = some out) :

--- a/EvmAsm/Evm64/SDiv/HandlerBridge.lean
+++ b/EvmAsm/Evm64/SDiv/HandlerBridge.lean
@@ -46,6 +46,27 @@ theorem sdivHandler_memSize
     simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler,
       EvmState.withStack, EvmState.invalid, EvmState.withStatus, h_stack]
 
+theorem sdivHandler_code
+    (state : EvmState) :
+    (ArithmeticHandlers.sdivHandler state).code = state.code := by
+  cases h_stack : ArithmeticHandlers.binaryStack? EvmWord.sdiv state.stack <;>
+    simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler,
+      EvmState.withStack, EvmState.invalid, EvmState.withStatus, h_stack]
+
+theorem sdivHandler_codeLen
+    (state : EvmState) :
+    (ArithmeticHandlers.sdivHandler state).codeLen = state.codeLen := by
+  cases h_stack : ArithmeticHandlers.binaryStack? EvmWord.sdiv state.stack <;>
+    simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler,
+      EvmState.withStack, EvmState.invalid, EvmState.withStatus, h_stack]
+
+theorem sdivHandler_env
+    (state : EvmState) :
+    (ArithmeticHandlers.sdivHandler state).env = state.env := by
+  cases h_stack : ArithmeticHandlers.binaryStack? EvmWord.sdiv state.stack <;>
+    simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler,
+      EvmState.withStack, EvmState.invalid, EvmState.withStatus, h_stack]
+
 theorem sdivHandler_stack_of_runSDivStack?_some
     {state : EvmState} {out : SDivStackResult}
     (h_run : runSDivStack? { stack := state.stack } = some out) :

--- a/EvmAsm/Evm64/SDiv/HandlerBridge.lean
+++ b/EvmAsm/Evm64/SDiv/HandlerBridge.lean
@@ -24,6 +24,28 @@ theorem sdivHandler_gas
     simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler,
       EvmState.withStack, EvmState.invalid, EvmState.withStatus, h_stack]
 
+theorem sdivHandler_memoryCells
+    (state : EvmState) :
+    (ArithmeticHandlers.sdivHandler state).memoryCells =
+      state.memoryCells := by
+  cases h_stack : ArithmeticHandlers.binaryStack? EvmWord.sdiv state.stack <;>
+    simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler,
+      EvmState.withStack, EvmState.invalid, EvmState.withStatus, h_stack]
+
+theorem sdivHandler_memory
+    (state : EvmState) :
+    (ArithmeticHandlers.sdivHandler state).memory = state.memory := by
+  cases h_stack : ArithmeticHandlers.binaryStack? EvmWord.sdiv state.stack <;>
+    simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler,
+      EvmState.withStack, EvmState.invalid, EvmState.withStatus, h_stack]
+
+theorem sdivHandler_memSize
+    (state : EvmState) :
+    (ArithmeticHandlers.sdivHandler state).memSize = state.memSize := by
+  cases h_stack : ArithmeticHandlers.binaryStack? EvmWord.sdiv state.stack <;>
+    simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler,
+      EvmState.withStack, EvmState.invalid, EvmState.withStatus, h_stack]
+
 theorem sdivHandler_stack_of_runSDivStack?_some
     {state : EvmState} {out : SDivStackResult}
     (h_run : runSDivStack? { stack := state.stack } = some out) :

--- a/EvmAsm/Evm64/SDiv/HandlerBridge.lean
+++ b/EvmAsm/Evm64/SDiv/HandlerBridge.lean
@@ -1,0 +1,53 @@
+/-
+  EvmAsm.Evm64.SDiv.HandlerBridge
+
+  Connects the pure SDIV opcode handler to the SDIV stack-execution bridge.
+-/
+
+import EvmAsm.Evm64.ArithmeticHandlers
+import EvmAsm.Evm64.SDiv.StackExecutionBridge
+
+namespace EvmAsm.Evm64
+namespace SDivStackExecutionBridge
+
+theorem sdivHandler_stack_of_runSDivStack?_some
+    {state : EvmState} {out : SDivStackResult}
+    (h_run : runSDivStack? { stack := state.stack } = some out) :
+    (ArithmeticHandlers.sdivHandler state).stack =
+      out.effects.stackWords ++ out.stack := by
+  rw [runSDivStack?_eq_some_iff] at h_run
+  rcases h_run with ⟨dividend, divisor, rest, h_stack, h_out⟩
+  simp at h_stack
+  subst h_out
+  simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler,
+    SDivArgs.sdivResultFromArgs_eq, SDivArgs.sdivArgs, h_stack]
+
+theorem sdivHandler_status_of_runSDivStack?_some
+    {state : EvmState} {out : SDivStackResult}
+    (h_run : runSDivStack? { stack := state.stack } = some out) :
+    (ArithmeticHandlers.sdivHandler state).status = state.status := by
+  rw [runSDivStack?_eq_some_iff] at h_run
+  rcases h_run with ⟨dividend, divisor, rest, h_stack, h_out⟩
+  simp at h_stack
+  simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler,
+    EvmState.withStack, h_stack]
+
+theorem sdivHandler_status_of_runSDivStack?_none
+    {state : EvmState}
+    (h_run : runSDivStack? { stack := state.stack } = none) :
+    (ArithmeticHandlers.sdivHandler state).status = .error := by
+  cases h_stack : state.stack with
+  | nil =>
+      simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler,
+        h_stack]
+  | cons dividend tail =>
+      cases h_tail : tail with
+      | nil =>
+          simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler,
+            h_stack, h_tail]
+      | cons divisor rest =>
+          simp [runSDivStack?, SDivArgsStackDecode.decodeSDivStack?,
+            stackRestAfterSDiv?, Option.bind, h_stack, h_tail] at h_run
+
+end SDivStackExecutionBridge
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/SDiv/HandlerBridge.lean
+++ b/EvmAsm/Evm64/SDiv/HandlerBridge.lean
@@ -10,6 +10,13 @@ import EvmAsm.Evm64.SDiv.StackExecutionBridge
 namespace EvmAsm.Evm64
 namespace SDivStackExecutionBridge
 
+theorem sdivHandler_pc
+    (state : EvmState) :
+    (ArithmeticHandlers.sdivHandler state).pc = state.pc := by
+  cases h_stack : ArithmeticHandlers.binaryStack? EvmWord.sdiv state.stack <;>
+    simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler,
+      EvmState.withStack, EvmState.invalid, EvmState.withStatus, h_stack]
+
 theorem sdivHandler_stack_of_runSDivStack?_some
     {state : EvmState} {out : SDivStackResult}
     (h_run : runSDivStack? { stack := state.stack } = some out) :

--- a/EvmAsm/Evm64/SDiv/StackExecutionBridge.lean
+++ b/EvmAsm/Evm64/SDiv/StackExecutionBridge.lean
@@ -65,6 +65,98 @@ theorem stackRestAfterSDiv?_none_of_one
     (dividend : EvmWord) :
     stackRestAfterSDiv? [dividend] = none := rfl
 
+theorem stackRestAfterSDiv?_eq_none_iff
+    {stack : List EvmWord} :
+    stackRestAfterSDiv? stack = none ↔
+      stack = [] ∨ ∃ dividend, stack = [dividend] := by
+  constructor
+  · cases stack with
+    | nil =>
+        intro _h
+        exact Or.inl rfl
+    | cons dividend tail =>
+        cases tail with
+        | nil =>
+            intro _h
+            exact Or.inr ⟨dividend, rfl⟩
+        | cons divisor rest =>
+            simp [stackRestAfterSDiv?]
+  · rintro (rfl | ⟨dividend, rfl⟩) <;> rfl
+
+theorem runSDivStack?_eq_none_iff
+    {state : SDivStackState} :
+    runSDivStack? state = none ↔
+      state.stack = [] ∨ ∃ dividend, state.stack = [dividend] := by
+  cases state with
+  | mk stack =>
+      cases stack with
+      | nil =>
+          simp [runSDivStack?, SDivArgsStackDecode.decodeSDivStack?,
+            stackRestAfterSDiv?, Option.bind]
+      | cons dividend tail =>
+          cases tail with
+          | nil =>
+              simp [runSDivStack?, SDivArgsStackDecode.decodeSDivStack?,
+                stackRestAfterSDiv?, Option.bind]
+          | cons divisor rest =>
+              simp [runSDivStack?, SDivArgsStackDecode.decodeSDivStack?,
+                stackRestAfterSDiv?, Option.bind]
+
+theorem runSDivStack?_eq_some_iff
+    {state : SDivStackState} {out : SDivStackResult} :
+    runSDivStack? state = some out ↔
+      ∃ dividend divisor rest,
+        state.stack = dividend :: divisor :: rest ∧
+          out =
+            { effects :=
+                { stackWords := [SDivArgs.sdivResultFromArgs
+                    (SDivArgs.sdivArgs dividend divisor)] }
+              stack := rest } := by
+  constructor
+  · cases state with
+    | mk stack =>
+        cases stack with
+        | nil =>
+            simp [runSDivStack?, SDivArgsStackDecode.decodeSDivStack?,
+              stackRestAfterSDiv?, Option.bind]
+        | cons dividend tail =>
+            cases tail with
+            | nil =>
+                simp [runSDivStack?, SDivArgsStackDecode.decodeSDivStack?,
+                  stackRestAfterSDiv?, Option.bind]
+            | cons divisor rest =>
+                intro h_run
+                simp [runSDivStack?, SDivArgsStackDecode.decodeSDivStack?,
+                  stackRestAfterSDiv?, Option.bind] at h_run
+                cases h_run
+                exact ⟨dividend, divisor, rest, rfl, rfl⟩
+  · rintro ⟨dividend, divisor, rest, h_stack, h_out⟩
+    cases state with
+    | mk stack =>
+        simp at h_stack
+        subst h_stack
+        subst h_out
+        exact runSDivStack?_cons dividend divisor rest
+
+theorem runSDivStack?_stack_length
+    {state : SDivStackState} {out : SDivStackResult}
+    (h_run : runSDivStack? state = some out) :
+    out.stack.length + out.effects.stackWords.length + argumentCount =
+      state.stack.length + resultCount := by
+  cases state with
+  | mk stack =>
+      cases stack with
+      | nil =>
+          simp [runSDivStack?, SDivArgsStackDecode.decodeSDivStack?] at h_run
+      | cons dividend tail =>
+          cases tail with
+          | nil => simp [runSDivStack?, stackRestAfterSDiv?] at h_run
+          | cons divisor rest =>
+              simp [runSDivStack?, stackRestAfterSDiv?] at h_run
+              cases h_run
+              simp [argumentCount, resultCount, SDivArgs.stackArgumentCount,
+                SDivArgs.resultCount]
+
 theorem runSDivStack?_head?
     (dividend divisor : EvmWord) (rest : List EvmWord) :
     (runSDivStack? { stack := dividend :: divisor :: rest }).map

--- a/EvmAsm/Evm64/SDiv/StackExecutionBridge.lean
+++ b/EvmAsm/Evm64/SDiv/StackExecutionBridge.lean
@@ -1,0 +1,90 @@
+/-
+  EvmAsm.Evm64.SDiv.StackExecutionBridge
+
+  Pure stack-execution bridge for SDIV (GH #90).
+-/
+
+import EvmAsm.Evm64.SDiv.ArgsStackDecode
+
+namespace EvmAsm.Evm64
+namespace SDivStackExecutionBridge
+
+/-- Caller-visible stack effects of SDIV at the executable-spec layer. -/
+structure SDivVisibleEffects where
+  stackWords : List EvmWord
+  deriving Repr
+
+structure SDivStackState where
+  stack : List EvmWord
+  deriving Repr
+
+structure SDivStackResult where
+  effects : SDivVisibleEffects
+  stack : List EvmWord
+  deriving Repr
+
+def argumentCount : Nat := SDivArgs.stackArgumentCount
+
+def resultCount : Nat := SDivArgs.resultCount
+
+def stackRestAfterSDiv? : List EvmWord → Option (List EvmWord)
+  | _dividend :: _divisor :: rest => some rest
+  | _ => none
+
+/-- Execute the SDIV stack transition using the pure argument decoder. -/
+def runSDivStack? (state : SDivStackState) : Option SDivStackResult := do
+  let args ← SDivArgsStackDecode.decodeSDivStack? state.stack
+  let rest ← stackRestAfterSDiv? state.stack
+  some
+    { effects := { stackWords := [SDivArgs.sdivResultFromArgs args] }
+      stack := rest }
+
+theorem stackRestAfterSDiv?_cons
+    (dividend divisor : EvmWord) (rest : List EvmWord) :
+    stackRestAfterSDiv? (dividend :: divisor :: rest) = some rest := rfl
+
+theorem runSDivStack?_cons
+    (dividend divisor : EvmWord) (rest : List EvmWord) :
+    runSDivStack? { stack := dividend :: divisor :: rest } =
+      some
+        { effects :=
+            { stackWords := [SDivArgs.sdivResultFromArgs
+                (SDivArgs.sdivArgs dividend divisor)] }
+          stack := rest } := rfl
+
+theorem runSDivStack?_underflow_nil :
+    runSDivStack? { stack := [] } = none := rfl
+
+theorem runSDivStack?_underflow_one (dividend : EvmWord) :
+    runSDivStack? { stack := [dividend] } = none := rfl
+
+theorem stackRestAfterSDiv?_none_of_empty :
+    stackRestAfterSDiv? [] = none := rfl
+
+theorem stackRestAfterSDiv?_none_of_one
+    (dividend : EvmWord) :
+    stackRestAfterSDiv? [dividend] = none := rfl
+
+theorem runSDivStack?_head?
+    (dividend divisor : EvmWord) (rest : List EvmWord) :
+    (runSDivStack? { stack := dividend :: divisor :: rest }).map
+      (fun out => out.effects.stackWords.head?) =
+      some (some (SDivArgs.sdivResultFromArgs
+        (SDivArgs.sdivArgs dividend divisor))) := rfl
+
+theorem runSDivStack?_zero_divisor
+    (dividend : EvmWord) (rest : List EvmWord) :
+    runSDivStack? { stack := dividend :: 0 :: rest } =
+      some { effects := { stackWords := [0] }, stack := rest } := by
+  rw [runSDivStack?_cons]
+  rw [SDivArgs.sdivResultFromArgs_zero_divisor]
+
+theorem runSDivStack?_intMin_neg_one
+    (rest : List EvmWord) :
+    runSDivStack? { stack := BitVec.intMin 256 :: (-1 : EvmWord) :: rest } =
+      some { effects := { stackWords := [BitVec.intMin 256] }, stack := rest } := by
+  rw [runSDivStack?_cons]
+  rw [SDivArgs.sdivResultFromArgs_intMin_neg_one]
+
+end SDivStackExecutionBridge
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/SDiv/StackExecutionBridge.lean
+++ b/EvmAsm/Evm64/SDiv/StackExecutionBridge.lean
@@ -178,5 +178,19 @@ theorem runSDivStack?_intMin_neg_one
   rw [runSDivStack?_cons]
   rw [SDivArgs.sdivResultFromArgs_intMin_neg_one]
 
+theorem runSDivStack?_neg_one_two
+    (rest : List EvmWord) :
+    runSDivStack? { stack := (-1 : EvmWord) :: 2 :: rest } =
+      some { effects := { stackWords := [0] }, stack := rest } := by
+  rw [runSDivStack?_cons]
+  rw [SDivArgs.sdivResultFromArgs_neg_one_two]
+
+theorem runSDivStack?_pos_neg_trunc
+    (rest : List EvmWord) :
+    runSDivStack? { stack := (7 : EvmWord) :: (-2 : EvmWord) :: rest } =
+      some { effects := { stackWords := [(-3 : EvmWord)] }, stack := rest } := by
+  rw [runSDivStack?_cons]
+  rw [SDivArgs.sdivResultFromArgs_pos_neg_trunc]
+
 end SDivStackExecutionBridge
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/SMod.lean
+++ b/EvmAsm/Evm64/SMod.lean
@@ -14,6 +14,7 @@ import EvmAsm.Evm64.SMod.AddrNormAttr
 import EvmAsm.Evm64.SMod.Layout
 import EvmAsm.Evm64.SMod.Args
 import EvmAsm.Evm64.SMod.ArgsStackDecode
+import EvmAsm.Evm64.SMod.StackExecutionBridge
 import EvmAsm.Evm64.SMod.Program
 import EvmAsm.Evm64.SMod.LimbSpec
 import EvmAsm.Evm64.SMod.AddrNorm

--- a/EvmAsm/Evm64/SMod.lean
+++ b/EvmAsm/Evm64/SMod.lean
@@ -12,6 +12,7 @@
 
 import EvmAsm.Evm64.SMod.AddrNormAttr
 import EvmAsm.Evm64.SMod.Layout
+import EvmAsm.Evm64.SMod.Args
 import EvmAsm.Evm64.SMod.Program
 import EvmAsm.Evm64.SMod.LimbSpec
 import EvmAsm.Evm64.SMod.AddrNorm

--- a/EvmAsm/Evm64/SMod.lean
+++ b/EvmAsm/Evm64/SMod.lean
@@ -13,6 +13,7 @@
 import EvmAsm.Evm64.SMod.AddrNormAttr
 import EvmAsm.Evm64.SMod.Layout
 import EvmAsm.Evm64.SMod.Args
+import EvmAsm.Evm64.SMod.ArgsStackDecode
 import EvmAsm.Evm64.SMod.Program
 import EvmAsm.Evm64.SMod.LimbSpec
 import EvmAsm.Evm64.SMod.AddrNorm

--- a/EvmAsm/Evm64/SMod.lean
+++ b/EvmAsm/Evm64/SMod.lean
@@ -15,6 +15,7 @@ import EvmAsm.Evm64.SMod.Layout
 import EvmAsm.Evm64.SMod.Args
 import EvmAsm.Evm64.SMod.ArgsStackDecode
 import EvmAsm.Evm64.SMod.StackExecutionBridge
+import EvmAsm.Evm64.SMod.HandlerBridge
 import EvmAsm.Evm64.SMod.Program
 import EvmAsm.Evm64.SMod.LimbSpec
 import EvmAsm.Evm64.SMod.AddrNorm

--- a/EvmAsm/Evm64/SMod/Args.lean
+++ b/EvmAsm/Evm64/SMod/Args.lean
@@ -1,0 +1,77 @@
+/-
+  EvmAsm.Evm64.SMod.Args
+
+  Pure stack-argument bridge for SMOD (GH #90).
+-/
+
+import EvmAsm.Evm64.EvmWordArith.SMod
+
+namespace EvmAsm.Evm64
+namespace SModArgs
+
+/-- SMOD stack arguments: dividend and divisor. -/
+structure Args where
+  dividend : EvmWord
+  divisor : EvmWord
+  deriving Repr
+
+/-- SMOD pops two stack words: dividend and divisor. -/
+def stackArgumentCount : Nat := 2
+
+/-- SMOD pushes one result word. -/
+def resultCount : Nat := 1
+
+/-- Convenience builder for SMOD stack arguments. -/
+def smodArgs (dividend divisor : EvmWord) : Args :=
+  { dividend := dividend, divisor := divisor }
+
+/-- SMOD result computed from decoded stack arguments. -/
+def smodResultFromArgs (args : Args) : EvmWord :=
+  EvmWord.smod args.dividend args.divisor
+
+/-- Stack after the SMOD result replaces the two operands. -/
+def stackAfterSMod (args : Args) (rest : List EvmWord) : List EvmWord :=
+  smodResultFromArgs args :: rest
+
+theorem stackArgumentCount_eq_two : stackArgumentCount = 2 := rfl
+
+theorem resultCount_eq_one : resultCount = 1 := rfl
+
+theorem smodArgs_dividend (dividend divisor : EvmWord) :
+    (smodArgs dividend divisor).dividend = dividend := rfl
+
+theorem smodArgs_divisor (dividend divisor : EvmWord) :
+    (smodArgs dividend divisor).divisor = divisor := rfl
+
+theorem smodResultFromArgs_eq (args : Args) :
+    smodResultFromArgs args = EvmWord.smod args.dividend args.divisor := rfl
+
+theorem stackAfterSMod_eq (args : Args) (rest : List EvmWord) :
+    stackAfterSMod args rest = smodResultFromArgs args :: rest := rfl
+
+@[simp] theorem stackAfterSMod_length (args : Args) (rest : List EvmWord) :
+    (stackAfterSMod args rest).length = rest.length + 1 := by
+  simp [stackAfterSMod]
+
+@[simp] theorem smodResultFromArgs_zero_divisor (dividend : EvmWord) :
+    smodResultFromArgs (smodArgs dividend 0) = 0 := by
+  exact EvmWord.smod_zero_right
+
+@[simp] theorem smodResultFromArgs_zero_dividend (divisor : EvmWord) :
+    smodResultFromArgs (smodArgs 0 divisor) = 0 := by
+  exact EvmWord.zero_smod_left
+
+theorem smodResultFromArgs_neg_pos_sign :
+    smodResultFromArgs (smodArgs (-3) 2) = (-1 : EvmWord) := by
+  exact EvmWord.smod_neg_pos_sign
+
+theorem smodResultFromArgs_pos_neg_sign :
+    smodResultFromArgs (smodArgs 3 (-2)) = (1 : EvmWord) := by
+  exact EvmWord.smod_pos_neg_sign
+
+theorem smodResultFromArgs_neg_neg_sign :
+    smodResultFromArgs (smodArgs (-3) (-2)) = (-1 : EvmWord) := by
+  exact EvmWord.smod_neg_neg_sign
+
+end SModArgs
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/SMod/ArgsStackDecode.lean
+++ b/EvmAsm/Evm64/SMod/ArgsStackDecode.lean
@@ -1,0 +1,83 @@
+/-
+  EvmAsm.Evm64.SMod.ArgsStackDecode
+
+  Pure top-of-stack decoder for SMOD executable-spec bridges (GH #90).
+-/
+
+import EvmAsm.Evm64.SMod.Args
+
+namespace EvmAsm.Evm64
+namespace SModArgsStackDecode
+
+/--
+Decode SMOD stack arguments from the top-of-stack list order:
+`dividend, divisor`.
+-/
+def decodeSModStack? : List EvmWord → Option SModArgs.Args
+  | dividend :: divisor :: _ => some (SModArgs.smodArgs dividend divisor)
+  | _ => none
+
+theorem decodeSModStack?_cons
+    (dividend divisor : EvmWord) (rest : List EvmWord) :
+    decodeSModStack? (dividend :: divisor :: rest) =
+      some (SModArgs.smodArgs dividend divisor) := rfl
+
+theorem decodeSModStack?_eq_some_iff
+    {stack : List EvmWord} {args : SModArgs.Args} :
+    decodeSModStack? stack = some args ↔
+      ∃ dividend divisor rest,
+        stack = dividend :: divisor :: rest ∧
+          args = SModArgs.smodArgs dividend divisor := by
+  constructor
+  · cases stack with
+    | nil => simp [decodeSModStack?]
+    | cons dividend tail =>
+        cases tail with
+        | nil => simp [decodeSModStack?]
+        | cons divisor rest =>
+            intro h
+            injection h with h_args
+            subst h_args
+            exact ⟨dividend, divisor, rest, rfl, rfl⟩
+  · rintro ⟨dividend, divisor, rest, rfl, rfl⟩
+    rfl
+
+theorem decodeSModStack?_eq_none_iff
+    {stack : List EvmWord} :
+    decodeSModStack? stack = none ↔
+      stack = [] ∨ ∃ dividend, stack = [dividend] := by
+  constructor
+  · cases stack with
+    | nil =>
+        intro _h
+        exact Or.inl rfl
+    | cons dividend tail =>
+        cases tail with
+        | nil =>
+            intro _h
+            exact Or.inr ⟨dividend, rfl⟩
+        | cons divisor rest =>
+            simp [decodeSModStack?]
+  · rintro (rfl | ⟨dividend, rfl⟩) <;> rfl
+
+theorem decodeSModStack?_none_of_empty :
+    decodeSModStack? [] = none := rfl
+
+theorem decodeSModStack?_none_of_one
+    (dividend : EvmWord) :
+    decodeSModStack? [dividend] = none := rfl
+
+theorem decodeSModStack?_dividend
+    (dividend divisor : EvmWord) (rest : List EvmWord) :
+    Option.map (fun args => args.dividend)
+      (decodeSModStack? (dividend :: divisor :: rest)) =
+      some dividend := rfl
+
+theorem decodeSModStack?_divisor
+    (dividend divisor : EvmWord) (rest : List EvmWord) :
+    Option.map (fun args => args.divisor)
+      (decodeSModStack? (dividend :: divisor :: rest)) =
+      some divisor := rfl
+
+end SModArgsStackDecode
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/SMod/HandlerBridge.lean
+++ b/EvmAsm/Evm64/SMod/HandlerBridge.lean
@@ -67,6 +67,13 @@ theorem smodHandler_env
     simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler,
       EvmState.withStack, EvmState.invalid, EvmState.withStatus, h_stack]
 
+theorem smodHandler_codeLenMatches
+    (state : EvmState) (h_codeLen : state.codeLenMatches) :
+    (ArithmeticHandlers.smodHandler state).codeLenMatches := by
+  unfold EvmState.codeLenMatches at h_codeLen ⊢
+  rw [smodHandler_codeLen, smodHandler_code]
+  exact h_codeLen
+
 theorem smodHandler_stack_of_runSModStack?_some
     {state : EvmState} {out : SModStackResult}
     (h_run : runSModStack? { stack := state.stack } = some out) :

--- a/EvmAsm/Evm64/SMod/HandlerBridge.lean
+++ b/EvmAsm/Evm64/SMod/HandlerBridge.lean
@@ -17,6 +17,13 @@ theorem smodHandler_pc
     simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler,
       EvmState.withStack, EvmState.invalid, EvmState.withStatus, h_stack]
 
+theorem smodHandler_gas
+    (state : EvmState) :
+    (ArithmeticHandlers.smodHandler state).gas = state.gas := by
+  cases h_stack : ArithmeticHandlers.binaryStack? EvmWord.smod state.stack <;>
+    simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler,
+      EvmState.withStack, EvmState.invalid, EvmState.withStatus, h_stack]
+
 theorem smodHandler_stack_of_runSModStack?_some
     {state : EvmState} {out : SModStackResult}
     (h_run : runSModStack? { stack := state.stack } = some out) :

--- a/EvmAsm/Evm64/SMod/HandlerBridge.lean
+++ b/EvmAsm/Evm64/SMod/HandlerBridge.lean
@@ -49,6 +49,18 @@ theorem smodHandler_status_of_runSModStack?_none
           simp [runSModStack?, SModArgsStackDecode.decodeSModStack?,
             stackRestAfterSMod?, Option.bind, h_stack, h_tail] at h_run
 
+theorem smodHandler_status_empty_stack
+    (state : EvmState) :
+    (ArithmeticHandlers.smodHandler { state with stack := [] }).status =
+      .error := by
+  simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler]
+
+theorem smodHandler_status_singleton_stack
+    (state : EvmState) (dividend : EvmWord) :
+    (ArithmeticHandlers.smodHandler
+      { state with stack := [dividend] }).status = .error := by
+  simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler]
+
 theorem smodHandler_stack_zero_divisor
     (state : EvmState) (dividend : EvmWord) (rest : List EvmWord) :
     (ArithmeticHandlers.smodHandler

--- a/EvmAsm/Evm64/SMod/HandlerBridge.lean
+++ b/EvmAsm/Evm64/SMod/HandlerBridge.lean
@@ -49,5 +49,37 @@ theorem smodHandler_status_of_runSModStack?_none
           simp [runSModStack?, SModArgsStackDecode.decodeSModStack?,
             stackRestAfterSMod?, Option.bind, h_stack, h_tail] at h_run
 
+theorem smodHandler_stack_zero_divisor
+    (state : EvmState) (dividend : EvmWord) (rest : List EvmWord) :
+    (ArithmeticHandlers.smodHandler
+      { state with stack := dividend :: 0 :: rest }).stack =
+        0 :: rest := by
+  simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler]
+  exact EvmWord.smod_zero_right
+
+theorem smodHandler_stack_neg_pos_sign
+    (state : EvmState) (rest : List EvmWord) :
+    (ArithmeticHandlers.smodHandler
+      { state with stack := (-3 : EvmWord) :: 2 :: rest }).stack =
+        (-1 : EvmWord) :: rest := by
+  simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler]
+  exact EvmWord.smod_neg_pos_sign
+
+theorem smodHandler_stack_pos_neg_sign
+    (state : EvmState) (rest : List EvmWord) :
+    (ArithmeticHandlers.smodHandler
+      { state with stack := (3 : EvmWord) :: (-2 : EvmWord) :: rest }).stack =
+        (1 : EvmWord) :: rest := by
+  simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler]
+  exact EvmWord.smod_pos_neg_sign
+
+theorem smodHandler_stack_neg_neg_sign
+    (state : EvmState) (rest : List EvmWord) :
+    (ArithmeticHandlers.smodHandler
+      { state with stack := (-3 : EvmWord) :: (-2 : EvmWord) :: rest }).stack =
+        (-1 : EvmWord) :: rest := by
+  simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler]
+  exact EvmWord.smod_neg_neg_sign
+
 end SModStackExecutionBridge
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/SMod/HandlerBridge.lean
+++ b/EvmAsm/Evm64/SMod/HandlerBridge.lean
@@ -24,6 +24,28 @@ theorem smodHandler_gas
     simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler,
       EvmState.withStack, EvmState.invalid, EvmState.withStatus, h_stack]
 
+theorem smodHandler_memoryCells
+    (state : EvmState) :
+    (ArithmeticHandlers.smodHandler state).memoryCells =
+      state.memoryCells := by
+  cases h_stack : ArithmeticHandlers.binaryStack? EvmWord.smod state.stack <;>
+    simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler,
+      EvmState.withStack, EvmState.invalid, EvmState.withStatus, h_stack]
+
+theorem smodHandler_memory
+    (state : EvmState) :
+    (ArithmeticHandlers.smodHandler state).memory = state.memory := by
+  cases h_stack : ArithmeticHandlers.binaryStack? EvmWord.smod state.stack <;>
+    simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler,
+      EvmState.withStack, EvmState.invalid, EvmState.withStatus, h_stack]
+
+theorem smodHandler_memSize
+    (state : EvmState) :
+    (ArithmeticHandlers.smodHandler state).memSize = state.memSize := by
+  cases h_stack : ArithmeticHandlers.binaryStack? EvmWord.smod state.stack <;>
+    simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler,
+      EvmState.withStack, EvmState.invalid, EvmState.withStatus, h_stack]
+
 theorem smodHandler_stack_of_runSModStack?_some
     {state : EvmState} {out : SModStackResult}
     (h_run : runSModStack? { stack := state.stack } = some out) :

--- a/EvmAsm/Evm64/SMod/HandlerBridge.lean
+++ b/EvmAsm/Evm64/SMod/HandlerBridge.lean
@@ -46,6 +46,27 @@ theorem smodHandler_memSize
     simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler,
       EvmState.withStack, EvmState.invalid, EvmState.withStatus, h_stack]
 
+theorem smodHandler_code
+    (state : EvmState) :
+    (ArithmeticHandlers.smodHandler state).code = state.code := by
+  cases h_stack : ArithmeticHandlers.binaryStack? EvmWord.smod state.stack <;>
+    simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler,
+      EvmState.withStack, EvmState.invalid, EvmState.withStatus, h_stack]
+
+theorem smodHandler_codeLen
+    (state : EvmState) :
+    (ArithmeticHandlers.smodHandler state).codeLen = state.codeLen := by
+  cases h_stack : ArithmeticHandlers.binaryStack? EvmWord.smod state.stack <;>
+    simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler,
+      EvmState.withStack, EvmState.invalid, EvmState.withStatus, h_stack]
+
+theorem smodHandler_env
+    (state : EvmState) :
+    (ArithmeticHandlers.smodHandler state).env = state.env := by
+  cases h_stack : ArithmeticHandlers.binaryStack? EvmWord.smod state.stack <;>
+    simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler,
+      EvmState.withStack, EvmState.invalid, EvmState.withStatus, h_stack]
+
 theorem smodHandler_stack_of_runSModStack?_some
     {state : EvmState} {out : SModStackResult}
     (h_run : runSModStack? { stack := state.stack } = some out) :

--- a/EvmAsm/Evm64/SMod/HandlerBridge.lean
+++ b/EvmAsm/Evm64/SMod/HandlerBridge.lean
@@ -10,6 +10,13 @@ import EvmAsm.Evm64.SMod.StackExecutionBridge
 namespace EvmAsm.Evm64
 namespace SModStackExecutionBridge
 
+theorem smodHandler_pc
+    (state : EvmState) :
+    (ArithmeticHandlers.smodHandler state).pc = state.pc := by
+  cases h_stack : ArithmeticHandlers.binaryStack? EvmWord.smod state.stack <;>
+    simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler,
+      EvmState.withStack, EvmState.invalid, EvmState.withStatus, h_stack]
+
 theorem smodHandler_stack_of_runSModStack?_some
     {state : EvmState} {out : SModStackResult}
     (h_run : runSModStack? { stack := state.stack } = some out) :

--- a/EvmAsm/Evm64/SMod/HandlerBridge.lean
+++ b/EvmAsm/Evm64/SMod/HandlerBridge.lean
@@ -1,0 +1,53 @@
+/-
+  EvmAsm.Evm64.SMod.HandlerBridge
+
+  Connects the pure SMOD opcode handler to the SMOD stack-execution bridge.
+-/
+
+import EvmAsm.Evm64.ArithmeticHandlers
+import EvmAsm.Evm64.SMod.StackExecutionBridge
+
+namespace EvmAsm.Evm64
+namespace SModStackExecutionBridge
+
+theorem smodHandler_stack_of_runSModStack?_some
+    {state : EvmState} {out : SModStackResult}
+    (h_run : runSModStack? { stack := state.stack } = some out) :
+    (ArithmeticHandlers.smodHandler state).stack =
+      out.effects.stackWords ++ out.stack := by
+  rw [runSModStack?_eq_some_iff] at h_run
+  rcases h_run with ⟨dividend, divisor, rest, h_stack, h_out⟩
+  simp at h_stack
+  subst h_out
+  simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler,
+    SModArgs.smodResultFromArgs_eq, SModArgs.smodArgs, h_stack]
+
+theorem smodHandler_status_of_runSModStack?_some
+    {state : EvmState} {out : SModStackResult}
+    (h_run : runSModStack? { stack := state.stack } = some out) :
+    (ArithmeticHandlers.smodHandler state).status = state.status := by
+  rw [runSModStack?_eq_some_iff] at h_run
+  rcases h_run with ⟨dividend, divisor, rest, h_stack, h_out⟩
+  simp at h_stack
+  simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler,
+    EvmState.withStack, h_stack]
+
+theorem smodHandler_status_of_runSModStack?_none
+    {state : EvmState}
+    (h_run : runSModStack? { stack := state.stack } = none) :
+    (ArithmeticHandlers.smodHandler state).status = .error := by
+  cases h_stack : state.stack with
+  | nil =>
+      simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler,
+        h_stack]
+  | cons dividend tail =>
+      cases h_tail : tail with
+      | nil =>
+          simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler,
+            h_stack, h_tail]
+      | cons divisor rest =>
+          simp [runSModStack?, SModArgsStackDecode.decodeSModStack?,
+            stackRestAfterSMod?, Option.bind, h_stack, h_tail] at h_run
+
+end SModStackExecutionBridge
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/SMod/StackExecutionBridge.lean
+++ b/EvmAsm/Evm64/SMod/StackExecutionBridge.lean
@@ -65,6 +65,98 @@ theorem stackRestAfterSMod?_none_of_one
     (dividend : EvmWord) :
     stackRestAfterSMod? [dividend] = none := rfl
 
+theorem stackRestAfterSMod?_eq_none_iff
+    {stack : List EvmWord} :
+    stackRestAfterSMod? stack = none ↔
+      stack = [] ∨ ∃ dividend, stack = [dividend] := by
+  constructor
+  · cases stack with
+    | nil =>
+        intro _h
+        exact Or.inl rfl
+    | cons dividend tail =>
+        cases tail with
+        | nil =>
+            intro _h
+            exact Or.inr ⟨dividend, rfl⟩
+        | cons divisor rest =>
+            simp [stackRestAfterSMod?]
+  · rintro (rfl | ⟨dividend, rfl⟩) <;> rfl
+
+theorem runSModStack?_eq_none_iff
+    {state : SModStackState} :
+    runSModStack? state = none ↔
+      state.stack = [] ∨ ∃ dividend, state.stack = [dividend] := by
+  cases state with
+  | mk stack =>
+      cases stack with
+      | nil =>
+          simp [runSModStack?, SModArgsStackDecode.decodeSModStack?,
+            stackRestAfterSMod?, Option.bind]
+      | cons dividend tail =>
+          cases tail with
+          | nil =>
+              simp [runSModStack?, SModArgsStackDecode.decodeSModStack?,
+                stackRestAfterSMod?, Option.bind]
+          | cons divisor rest =>
+              simp [runSModStack?, SModArgsStackDecode.decodeSModStack?,
+                stackRestAfterSMod?, Option.bind]
+
+theorem runSModStack?_eq_some_iff
+    {state : SModStackState} {out : SModStackResult} :
+    runSModStack? state = some out ↔
+      ∃ dividend divisor rest,
+        state.stack = dividend :: divisor :: rest ∧
+          out =
+            { effects :=
+                { stackWords := [SModArgs.smodResultFromArgs
+                    (SModArgs.smodArgs dividend divisor)] }
+              stack := rest } := by
+  constructor
+  · cases state with
+    | mk stack =>
+        cases stack with
+        | nil =>
+            simp [runSModStack?, SModArgsStackDecode.decodeSModStack?,
+              stackRestAfterSMod?, Option.bind]
+        | cons dividend tail =>
+            cases tail with
+            | nil =>
+                simp [runSModStack?, SModArgsStackDecode.decodeSModStack?,
+                  stackRestAfterSMod?, Option.bind]
+            | cons divisor rest =>
+                intro h_run
+                simp [runSModStack?, SModArgsStackDecode.decodeSModStack?,
+                  stackRestAfterSMod?, Option.bind] at h_run
+                cases h_run
+                exact ⟨dividend, divisor, rest, rfl, rfl⟩
+  · rintro ⟨dividend, divisor, rest, h_stack, h_out⟩
+    cases state with
+    | mk stack =>
+        simp at h_stack
+        subst h_stack
+        subst h_out
+        exact runSModStack?_cons dividend divisor rest
+
+theorem runSModStack?_stack_length
+    {state : SModStackState} {out : SModStackResult}
+    (h_run : runSModStack? state = some out) :
+    out.stack.length + out.effects.stackWords.length + argumentCount =
+      state.stack.length + resultCount := by
+  cases state with
+  | mk stack =>
+      cases stack with
+      | nil =>
+          simp [runSModStack?, SModArgsStackDecode.decodeSModStack?] at h_run
+      | cons dividend tail =>
+          cases tail with
+          | nil => simp [runSModStack?, stackRestAfterSMod?] at h_run
+          | cons divisor rest =>
+              simp [runSModStack?, stackRestAfterSMod?] at h_run
+              cases h_run
+              simp [argumentCount, resultCount, SModArgs.stackArgumentCount,
+                SModArgs.resultCount]
+
 theorem runSModStack?_head?
     (dividend divisor : EvmWord) (rest : List EvmWord) :
     (runSModStack? { stack := dividend :: divisor :: rest }).map

--- a/EvmAsm/Evm64/SMod/StackExecutionBridge.lean
+++ b/EvmAsm/Evm64/SMod/StackExecutionBridge.lean
@@ -1,0 +1,90 @@
+/-
+  EvmAsm.Evm64.SMod.StackExecutionBridge
+
+  Pure stack-execution bridge for SMOD (GH #90).
+-/
+
+import EvmAsm.Evm64.SMod.ArgsStackDecode
+
+namespace EvmAsm.Evm64
+namespace SModStackExecutionBridge
+
+/-- Caller-visible stack effects of SMOD at the executable-spec layer. -/
+structure SModVisibleEffects where
+  stackWords : List EvmWord
+  deriving Repr
+
+structure SModStackState where
+  stack : List EvmWord
+  deriving Repr
+
+structure SModStackResult where
+  effects : SModVisibleEffects
+  stack : List EvmWord
+  deriving Repr
+
+def argumentCount : Nat := SModArgs.stackArgumentCount
+
+def resultCount : Nat := SModArgs.resultCount
+
+def stackRestAfterSMod? : List EvmWord → Option (List EvmWord)
+  | _dividend :: _divisor :: rest => some rest
+  | _ => none
+
+/-- Execute the SMOD stack transition using the pure argument decoder. -/
+def runSModStack? (state : SModStackState) : Option SModStackResult := do
+  let args ← SModArgsStackDecode.decodeSModStack? state.stack
+  let rest ← stackRestAfterSMod? state.stack
+  some
+    { effects := { stackWords := [SModArgs.smodResultFromArgs args] }
+      stack := rest }
+
+theorem stackRestAfterSMod?_cons
+    (dividend divisor : EvmWord) (rest : List EvmWord) :
+    stackRestAfterSMod? (dividend :: divisor :: rest) = some rest := rfl
+
+theorem runSModStack?_cons
+    (dividend divisor : EvmWord) (rest : List EvmWord) :
+    runSModStack? { stack := dividend :: divisor :: rest } =
+      some
+        { effects :=
+            { stackWords := [SModArgs.smodResultFromArgs
+                (SModArgs.smodArgs dividend divisor)] }
+          stack := rest } := rfl
+
+theorem runSModStack?_underflow_nil :
+    runSModStack? { stack := [] } = none := rfl
+
+theorem runSModStack?_underflow_one (dividend : EvmWord) :
+    runSModStack? { stack := [dividend] } = none := rfl
+
+theorem stackRestAfterSMod?_none_of_empty :
+    stackRestAfterSMod? [] = none := rfl
+
+theorem stackRestAfterSMod?_none_of_one
+    (dividend : EvmWord) :
+    stackRestAfterSMod? [dividend] = none := rfl
+
+theorem runSModStack?_head?
+    (dividend divisor : EvmWord) (rest : List EvmWord) :
+    (runSModStack? { stack := dividend :: divisor :: rest }).map
+      (fun out => out.effects.stackWords.head?) =
+      some (some (SModArgs.smodResultFromArgs
+        (SModArgs.smodArgs dividend divisor))) := rfl
+
+theorem runSModStack?_zero_divisor
+    (dividend : EvmWord) (rest : List EvmWord) :
+    runSModStack? { stack := dividend :: 0 :: rest } =
+      some { effects := { stackWords := [0] }, stack := rest } := by
+  rw [runSModStack?_cons]
+  rw [SModArgs.smodResultFromArgs_zero_divisor]
+
+theorem runSModStack?_neg_pos_sign
+    (rest : List EvmWord) :
+    runSModStack? { stack := (-3 : EvmWord) :: 2 :: rest } =
+      some { effects := { stackWords := [(-1 : EvmWord)] }, stack := rest } := by
+  rw [runSModStack?_cons]
+  rw [SModArgs.smodResultFromArgs_neg_pos_sign]
+
+end SModStackExecutionBridge
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/SMod/StackExecutionBridge.lean
+++ b/EvmAsm/Evm64/SMod/StackExecutionBridge.lean
@@ -178,5 +178,19 @@ theorem runSModStack?_neg_pos_sign
   rw [runSModStack?_cons]
   rw [SModArgs.smodResultFromArgs_neg_pos_sign]
 
+theorem runSModStack?_pos_neg_sign
+    (rest : List EvmWord) :
+    runSModStack? { stack := (3 : EvmWord) :: (-2 : EvmWord) :: rest } =
+      some { effects := { stackWords := [(1 : EvmWord)] }, stack := rest } := by
+  rw [runSModStack?_cons]
+  rw [SModArgs.smodResultFromArgs_pos_neg_sign]
+
+theorem runSModStack?_neg_neg_sign
+    (rest : List EvmWord) :
+    runSModStack? { stack := (-3 : EvmWord) :: (-2 : EvmWord) :: rest } =
+      some { effects := { stackWords := [(-1 : EvmWord)] }, stack := rest } := by
+  rw [runSModStack?_cons]
+  rw [SModArgs.smodResultFromArgs_neg_neg_sign]
+
 end SModStackExecutionBridge
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/SupportedHandlerByte.lean
+++ b/EvmAsm/Evm64/SupportedHandlerByte.lean
@@ -127,6 +127,42 @@ theorem dispatchByte_supported_INVALID_byte
   rw [dispatchByte_supported_INVALID_byte]
   exact EvmState.invalid_status state
 
+theorem dispatchByte_supported_SDIV_byte
+    (state : EvmState) :
+    HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x05, by decide⟩ : Fin 256) state =
+        ArithmeticHandlers.sdivHandler state := by
+  exact dispatchByte_supported_of_lookup rfl
+    SupportedHandlers.supportedHandlerTable_SDIV state
+
+theorem dispatchByte_supported_SMOD_byte
+    (state : EvmState) :
+    HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x07, by decide⟩ : Fin 256) state =
+        ArithmeticHandlers.smodHandler state := by
+  exact dispatchByte_supported_of_lookup rfl
+    SupportedHandlers.supportedHandlerTable_SMOD state
+
+@[simp] theorem dispatchByte_supported_SDIV_byte_status_of_some
+    {state : EvmState} {stack' : List EvmWord}
+    (h_stack : ArithmeticHandlers.binaryStack? EvmWord.sdiv state.stack =
+      some stack') :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x05, by decide⟩ : Fin 256) state).status = state.status := by
+  rw [dispatchByte_supported_SDIV_byte]
+  simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler,
+    h_stack, EvmState.withStack]
+
+@[simp] theorem dispatchByte_supported_SMOD_byte_status_of_some
+    {state : EvmState} {stack' : List EvmWord}
+    (h_stack : ArithmeticHandlers.binaryStack? EvmWord.smod state.stack =
+      some stack') :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x07, by decide⟩ : Fin 256) state).status = state.status := by
+  rw [dispatchByte_supported_SMOD_byte]
+  simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler,
+    h_stack, EvmState.withStack]
+
 theorem dispatchByte_supported_undecoded
     {b : Fin 256} (h_decode : EvmOpcode.decodeByte? b.val = none)
     (state : EvmState) :

--- a/EvmAsm/Evm64/SupportedHandlerByte.lean
+++ b/EvmAsm/Evm64/SupportedHandlerByte.lean
@@ -243,6 +243,30 @@ theorem dispatchByte_supported_SMOD_byte_stack_of_runSModStack?_some
   exact SModStackExecutionBridge.smodHandler_stack_of_runSModStack?_some
     h_run
 
+theorem dispatchByte_supported_SDIV_byte_status_of_runSDivStack?_some
+    {state : EvmState} {out : SDivStackExecutionBridge.SDivStackResult}
+    (h_run :
+      SDivStackExecutionBridge.runSDivStack? { stack := state.stack } =
+        some out) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x05, by decide⟩ : Fin 256) state).status =
+        state.status := by
+  rw [dispatchByte_supported_SDIV_byte]
+  exact SDivStackExecutionBridge.sdivHandler_status_of_runSDivStack?_some
+    h_run
+
+theorem dispatchByte_supported_SMOD_byte_status_of_runSModStack?_some
+    {state : EvmState} {out : SModStackExecutionBridge.SModStackResult}
+    (h_run :
+      SModStackExecutionBridge.runSModStack? { stack := state.stack } =
+        some out) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x07, by decide⟩ : Fin 256) state).status =
+        state.status := by
+  rw [dispatchByte_supported_SMOD_byte]
+  exact SModStackExecutionBridge.smodHandler_status_of_runSModStack?_some
+    h_run
+
 theorem dispatchByte_supported_SDIV_byte_status_empty_stack
     (state : EvmState) :
     (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable

--- a/EvmAsm/Evm64/SupportedHandlerByte.lean
+++ b/EvmAsm/Evm64/SupportedHandlerByte.lean
@@ -145,6 +145,20 @@ theorem dispatchByte_supported_SMOD_byte
   exact dispatchByte_supported_of_lookup rfl
     SupportedHandlers.supportedHandlerTable_SMOD state
 
+theorem dispatchByte_supported_SDIV_byte_pc
+    (state : EvmState) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x05, by decide⟩ : Fin 256) state).pc = state.pc := by
+  rw [dispatchByte_supported_SDIV_byte]
+  exact SDivStackExecutionBridge.sdivHandler_pc state
+
+theorem dispatchByte_supported_SMOD_byte_pc
+    (state : EvmState) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x07, by decide⟩ : Fin 256) state).pc = state.pc := by
+  rw [dispatchByte_supported_SMOD_byte]
+  exact SModStackExecutionBridge.smodHandler_pc state
+
 theorem dispatchByte_supported_SDIV_byte_stack_zero_divisor
     (state : EvmState) (dividend : EvmWord) (rest : List EvmWord) :
     (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable

--- a/EvmAsm/Evm64/SupportedHandlerByte.lean
+++ b/EvmAsm/Evm64/SupportedHandlerByte.lean
@@ -219,6 +219,40 @@ theorem dispatchByte_supported_SMOD_byte_stack_neg_neg_sign
   rw [dispatchByte_supported_SMOD_byte]
   exact SModStackExecutionBridge.smodHandler_stack_neg_neg_sign state rest
 
+theorem dispatchByte_supported_SDIV_byte_status_empty_stack
+    (state : EvmState) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x05, by decide⟩ : Fin 256)
+      { state with stack := [] }).status = .error := by
+  rw [dispatchByte_supported_SDIV_byte]
+  exact SDivStackExecutionBridge.sdivHandler_status_empty_stack state
+
+theorem dispatchByte_supported_SDIV_byte_status_singleton_stack
+    (state : EvmState) (dividend : EvmWord) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x05, by decide⟩ : Fin 256)
+      { state with stack := [dividend] }).status = .error := by
+  rw [dispatchByte_supported_SDIV_byte]
+  exact SDivStackExecutionBridge.sdivHandler_status_singleton_stack
+    state dividend
+
+theorem dispatchByte_supported_SMOD_byte_status_empty_stack
+    (state : EvmState) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x07, by decide⟩ : Fin 256)
+      { state with stack := [] }).status = .error := by
+  rw [dispatchByte_supported_SMOD_byte]
+  exact SModStackExecutionBridge.smodHandler_status_empty_stack state
+
+theorem dispatchByte_supported_SMOD_byte_status_singleton_stack
+    (state : EvmState) (dividend : EvmWord) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x07, by decide⟩ : Fin 256)
+      { state with stack := [dividend] }).status = .error := by
+  rw [dispatchByte_supported_SMOD_byte]
+  exact SModStackExecutionBridge.smodHandler_status_singleton_stack
+    state dividend
+
 @[simp] theorem dispatchByte_supported_SDIV_byte_status_of_some
     {state : EvmState} {stack' : List EvmWord}
     (h_stack : ArithmeticHandlers.binaryStack? EvmWord.sdiv state.stack =

--- a/EvmAsm/Evm64/SupportedHandlerByte.lean
+++ b/EvmAsm/Evm64/SupportedHandlerByte.lean
@@ -253,6 +253,28 @@ theorem dispatchByte_supported_SMOD_byte_status_singleton_stack
   exact SModStackExecutionBridge.smodHandler_status_singleton_stack
     state dividend
 
+theorem dispatchByte_supported_SDIV_byte_status_of_runSDivStack?_none
+    {state : EvmState}
+    (h_run :
+      SDivStackExecutionBridge.runSDivStack? { stack := state.stack } =
+        none) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x05, by decide⟩ : Fin 256) state).status = .error := by
+  rw [dispatchByte_supported_SDIV_byte]
+  exact SDivStackExecutionBridge.sdivHandler_status_of_runSDivStack?_none
+    h_run
+
+theorem dispatchByte_supported_SMOD_byte_status_of_runSModStack?_none
+    {state : EvmState}
+    (h_run :
+      SModStackExecutionBridge.runSModStack? { stack := state.stack } =
+        none) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x07, by decide⟩ : Fin 256) state).status = .error := by
+  rw [dispatchByte_supported_SMOD_byte]
+  exact SModStackExecutionBridge.smodHandler_status_of_runSModStack?_none
+    h_run
+
 @[simp] theorem dispatchByte_supported_SDIV_byte_status_of_some
     {state : EvmState} {stack' : List EvmWord}
     (h_stack : ArithmeticHandlers.binaryStack? EvmWord.sdiv state.stack =

--- a/EvmAsm/Evm64/SupportedHandlerByte.lean
+++ b/EvmAsm/Evm64/SupportedHandlerByte.lean
@@ -173,6 +173,52 @@ theorem dispatchByte_supported_SMOD_byte_gas
   rw [dispatchByte_supported_SMOD_byte]
   exact SModStackExecutionBridge.smodHandler_gas state
 
+theorem dispatchByte_supported_SDIV_byte_memoryCells
+    (state : EvmState) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x05, by decide⟩ : Fin 256) state).memoryCells =
+        state.memoryCells := by
+  rw [dispatchByte_supported_SDIV_byte]
+  exact SDivStackExecutionBridge.sdivHandler_memoryCells state
+
+theorem dispatchByte_supported_SDIV_byte_memory
+    (state : EvmState) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x05, by decide⟩ : Fin 256) state).memory = state.memory := by
+  rw [dispatchByte_supported_SDIV_byte]
+  exact SDivStackExecutionBridge.sdivHandler_memory state
+
+theorem dispatchByte_supported_SDIV_byte_memSize
+    (state : EvmState) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x05, by decide⟩ : Fin 256) state).memSize =
+        state.memSize := by
+  rw [dispatchByte_supported_SDIV_byte]
+  exact SDivStackExecutionBridge.sdivHandler_memSize state
+
+theorem dispatchByte_supported_SMOD_byte_memoryCells
+    (state : EvmState) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x07, by decide⟩ : Fin 256) state).memoryCells =
+        state.memoryCells := by
+  rw [dispatchByte_supported_SMOD_byte]
+  exact SModStackExecutionBridge.smodHandler_memoryCells state
+
+theorem dispatchByte_supported_SMOD_byte_memory
+    (state : EvmState) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x07, by decide⟩ : Fin 256) state).memory = state.memory := by
+  rw [dispatchByte_supported_SMOD_byte]
+  exact SModStackExecutionBridge.smodHandler_memory state
+
+theorem dispatchByte_supported_SMOD_byte_memSize
+    (state : EvmState) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x07, by decide⟩ : Fin 256) state).memSize =
+        state.memSize := by
+  rw [dispatchByte_supported_SMOD_byte]
+  exact SModStackExecutionBridge.smodHandler_memSize state
+
 theorem dispatchByte_supported_SDIV_byte_stack_zero_divisor
     (state : EvmState) (dividend : EvmWord) (rest : List EvmWord) :
     (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable

--- a/EvmAsm/Evm64/SupportedHandlerByte.lean
+++ b/EvmAsm/Evm64/SupportedHandlerByte.lean
@@ -217,6 +217,20 @@ theorem dispatchByte_supported_SMOD_byte_env
   rw [dispatchByte_supported_SMOD_byte]
   exact SModStackExecutionBridge.smodHandler_env state
 
+theorem dispatchByte_supported_SDIV_byte_codeLenMatches
+    (state : EvmState) (h_codeLen : state.codeLenMatches) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x05, by decide⟩ : Fin 256) state).codeLenMatches := by
+  rw [dispatchByte_supported_SDIV_byte]
+  exact SDivStackExecutionBridge.sdivHandler_codeLenMatches state h_codeLen
+
+theorem dispatchByte_supported_SMOD_byte_codeLenMatches
+    (state : EvmState) (h_codeLen : state.codeLenMatches) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x07, by decide⟩ : Fin 256) state).codeLenMatches := by
+  rw [dispatchByte_supported_SMOD_byte]
+  exact SModStackExecutionBridge.smodHandler_codeLenMatches state h_codeLen
+
 theorem dispatchByte_supported_SDIV_byte_memoryCells
     (state : EvmState) :
     (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable

--- a/EvmAsm/Evm64/SupportedHandlerByte.lean
+++ b/EvmAsm/Evm64/SupportedHandlerByte.lean
@@ -173,6 +173,50 @@ theorem dispatchByte_supported_SMOD_byte_gas
   rw [dispatchByte_supported_SMOD_byte]
   exact SModStackExecutionBridge.smodHandler_gas state
 
+theorem dispatchByte_supported_SDIV_byte_code
+    (state : EvmState) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x05, by decide⟩ : Fin 256) state).code = state.code := by
+  rw [dispatchByte_supported_SDIV_byte]
+  exact SDivStackExecutionBridge.sdivHandler_code state
+
+theorem dispatchByte_supported_SMOD_byte_code
+    (state : EvmState) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x07, by decide⟩ : Fin 256) state).code = state.code := by
+  rw [dispatchByte_supported_SMOD_byte]
+  exact SModStackExecutionBridge.smodHandler_code state
+
+theorem dispatchByte_supported_SDIV_byte_codeLen
+    (state : EvmState) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x05, by decide⟩ : Fin 256) state).codeLen =
+        state.codeLen := by
+  rw [dispatchByte_supported_SDIV_byte]
+  exact SDivStackExecutionBridge.sdivHandler_codeLen state
+
+theorem dispatchByte_supported_SMOD_byte_codeLen
+    (state : EvmState) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x07, by decide⟩ : Fin 256) state).codeLen =
+        state.codeLen := by
+  rw [dispatchByte_supported_SMOD_byte]
+  exact SModStackExecutionBridge.smodHandler_codeLen state
+
+theorem dispatchByte_supported_SDIV_byte_env
+    (state : EvmState) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x05, by decide⟩ : Fin 256) state).env = state.env := by
+  rw [dispatchByte_supported_SDIV_byte]
+  exact SDivStackExecutionBridge.sdivHandler_env state
+
+theorem dispatchByte_supported_SMOD_byte_env
+    (state : EvmState) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x07, by decide⟩ : Fin 256) state).env = state.env := by
+  rw [dispatchByte_supported_SMOD_byte]
+  exact SModStackExecutionBridge.smodHandler_env state
+
 theorem dispatchByte_supported_SDIV_byte_memoryCells
     (state : EvmState) :
     (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable

--- a/EvmAsm/Evm64/SupportedHandlerByte.lean
+++ b/EvmAsm/Evm64/SupportedHandlerByte.lean
@@ -6,6 +6,8 @@
 -/
 
 import EvmAsm.Evm64.HandlerTableByte
+import EvmAsm.Evm64.SDiv.HandlerBridge
+import EvmAsm.Evm64.SMod.HandlerBridge
 import EvmAsm.Evm64.SupportedHandlers
 
 namespace EvmAsm.Evm64
@@ -142,6 +144,80 @@ theorem dispatchByte_supported_SMOD_byte
         ArithmeticHandlers.smodHandler state := by
   exact dispatchByte_supported_of_lookup rfl
     SupportedHandlers.supportedHandlerTable_SMOD state
+
+theorem dispatchByte_supported_SDIV_byte_stack_zero_divisor
+    (state : EvmState) (dividend : EvmWord) (rest : List EvmWord) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x05, by decide⟩ : Fin 256)
+      { state with stack := dividend :: 0 :: rest }).stack =
+        0 :: rest := by
+  rw [dispatchByte_supported_SDIV_byte]
+  exact SDivStackExecutionBridge.sdivHandler_stack_zero_divisor
+    state dividend rest
+
+theorem dispatchByte_supported_SDIV_byte_stack_intMin_neg_one
+    (state : EvmState) (rest : List EvmWord) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x05, by decide⟩ : Fin 256)
+      { state with stack := BitVec.intMin 256 :: (-1 : EvmWord) :: rest }).stack =
+        BitVec.intMin 256 :: rest := by
+  rw [dispatchByte_supported_SDIV_byte]
+  exact SDivStackExecutionBridge.sdivHandler_stack_intMin_neg_one state rest
+
+theorem dispatchByte_supported_SDIV_byte_stack_neg_one_two
+    (state : EvmState) (rest : List EvmWord) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x05, by decide⟩ : Fin 256)
+      { state with stack := (-1 : EvmWord) :: 2 :: rest }).stack =
+        0 :: rest := by
+  rw [dispatchByte_supported_SDIV_byte]
+  exact SDivStackExecutionBridge.sdivHandler_stack_neg_one_two state rest
+
+theorem dispatchByte_supported_SDIV_byte_stack_pos_neg_trunc
+    (state : EvmState) (rest : List EvmWord) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x05, by decide⟩ : Fin 256)
+      { state with stack := (7 : EvmWord) :: (-2 : EvmWord) :: rest }).stack =
+        (-3 : EvmWord) :: rest := by
+  rw [dispatchByte_supported_SDIV_byte]
+  exact SDivStackExecutionBridge.sdivHandler_stack_pos_neg_trunc state rest
+
+theorem dispatchByte_supported_SMOD_byte_stack_zero_divisor
+    (state : EvmState) (dividend : EvmWord) (rest : List EvmWord) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x07, by decide⟩ : Fin 256)
+      { state with stack := dividend :: 0 :: rest }).stack =
+        0 :: rest := by
+  rw [dispatchByte_supported_SMOD_byte]
+  exact SModStackExecutionBridge.smodHandler_stack_zero_divisor
+    state dividend rest
+
+theorem dispatchByte_supported_SMOD_byte_stack_neg_pos_sign
+    (state : EvmState) (rest : List EvmWord) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x07, by decide⟩ : Fin 256)
+      { state with stack := (-3 : EvmWord) :: 2 :: rest }).stack =
+        (-1 : EvmWord) :: rest := by
+  rw [dispatchByte_supported_SMOD_byte]
+  exact SModStackExecutionBridge.smodHandler_stack_neg_pos_sign state rest
+
+theorem dispatchByte_supported_SMOD_byte_stack_pos_neg_sign
+    (state : EvmState) (rest : List EvmWord) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x07, by decide⟩ : Fin 256)
+      { state with stack := (3 : EvmWord) :: (-2 : EvmWord) :: rest }).stack =
+        (1 : EvmWord) :: rest := by
+  rw [dispatchByte_supported_SMOD_byte]
+  exact SModStackExecutionBridge.smodHandler_stack_pos_neg_sign state rest
+
+theorem dispatchByte_supported_SMOD_byte_stack_neg_neg_sign
+    (state : EvmState) (rest : List EvmWord) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x07, by decide⟩ : Fin 256)
+      { state with stack := (-3 : EvmWord) :: (-2 : EvmWord) :: rest }).stack =
+        (-1 : EvmWord) :: rest := by
+  rw [dispatchByte_supported_SMOD_byte]
+  exact SModStackExecutionBridge.smodHandler_stack_neg_neg_sign state rest
 
 @[simp] theorem dispatchByte_supported_SDIV_byte_status_of_some
     {state : EvmState} {stack' : List EvmWord}

--- a/EvmAsm/Evm64/SupportedHandlerByte.lean
+++ b/EvmAsm/Evm64/SupportedHandlerByte.lean
@@ -219,6 +219,30 @@ theorem dispatchByte_supported_SMOD_byte_stack_neg_neg_sign
   rw [dispatchByte_supported_SMOD_byte]
   exact SModStackExecutionBridge.smodHandler_stack_neg_neg_sign state rest
 
+theorem dispatchByte_supported_SDIV_byte_stack_of_runSDivStack?_some
+    {state : EvmState} {out : SDivStackExecutionBridge.SDivStackResult}
+    (h_run :
+      SDivStackExecutionBridge.runSDivStack? { stack := state.stack } =
+        some out) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x05, by decide⟩ : Fin 256) state).stack =
+        out.effects.stackWords ++ out.stack := by
+  rw [dispatchByte_supported_SDIV_byte]
+  exact SDivStackExecutionBridge.sdivHandler_stack_of_runSDivStack?_some
+    h_run
+
+theorem dispatchByte_supported_SMOD_byte_stack_of_runSModStack?_some
+    {state : EvmState} {out : SModStackExecutionBridge.SModStackResult}
+    (h_run :
+      SModStackExecutionBridge.runSModStack? { stack := state.stack } =
+        some out) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x07, by decide⟩ : Fin 256) state).stack =
+        out.effects.stackWords ++ out.stack := by
+  rw [dispatchByte_supported_SMOD_byte]
+  exact SModStackExecutionBridge.smodHandler_stack_of_runSModStack?_some
+    h_run
+
 theorem dispatchByte_supported_SDIV_byte_status_empty_stack
     (state : EvmState) :
     (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable

--- a/EvmAsm/Evm64/SupportedHandlerByte.lean
+++ b/EvmAsm/Evm64/SupportedHandlerByte.lean
@@ -159,6 +159,20 @@ theorem dispatchByte_supported_SMOD_byte_pc
   rw [dispatchByte_supported_SMOD_byte]
   exact SModStackExecutionBridge.smodHandler_pc state
 
+theorem dispatchByte_supported_SDIV_byte_gas
+    (state : EvmState) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x05, by decide⟩ : Fin 256) state).gas = state.gas := by
+  rw [dispatchByte_supported_SDIV_byte]
+  exact SDivStackExecutionBridge.sdivHandler_gas state
+
+theorem dispatchByte_supported_SMOD_byte_gas
+    (state : EvmState) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x07, by decide⟩ : Fin 256) state).gas = state.gas := by
+  rw [dispatchByte_supported_SMOD_byte]
+  exact SModStackExecutionBridge.smodHandler_gas state
+
 theorem dispatchByte_supported_SDIV_byte_stack_zero_divisor
     (state : EvmState) (dividend : EvmWord) (rest : List EvmWord) :
     (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable

--- a/EvmAsm/Evm64/SupportedHandlers.lean
+++ b/EvmAsm/Evm64/SupportedHandlers.lean
@@ -420,6 +420,36 @@ theorem dispatchOpcode_of_lookup_status
     (by simp [CodeHandlers.codeHandlerTable, CodeHandlers.codeHandler?])
     MemoryHandlers.msizeHandlerTable_MSIZE
 
+@[simp] theorem supportedHandlerTable_SDIV :
+    supportedHandlerTable .SDIV =
+      some ArithmeticHandlers.sdivHandler := by
+  exact lookup_of_arithmetic
+    (by simp [TerminatingHandlers.terminatingHandlerTable, HandlerTable.setHandler])
+    (by simp [StackHandlers.stackHandlerTable, HandlerTable.setHandler])
+    (by simp [PushHandlers.pushHandlerTable, PushHandlers.pushHandler?])
+    (by simp [ControlHandlers.controlHandlerTable, ControlHandlers.controlHandler?])
+    (by rfl)
+    (by simp [ReturnDataHandlers.returnDataSizeHandlerTable,
+      ReturnDataHandlers.returnDataHandler?])
+    (by simp [CodeHandlers.codeHandlerTable, CodeHandlers.codeHandler?])
+    (by simp [MemoryHandlers.msizeHandlerTable, MemoryHandlers.memoryHandler?])
+    ArithmeticHandlers.arithmeticHandler?_SDIV
+
+@[simp] theorem supportedHandlerTable_SMOD :
+    supportedHandlerTable .SMOD =
+      some ArithmeticHandlers.smodHandler := by
+  exact lookup_of_arithmetic
+    (by simp [TerminatingHandlers.terminatingHandlerTable, HandlerTable.setHandler])
+    (by simp [StackHandlers.stackHandlerTable, HandlerTable.setHandler])
+    (by simp [PushHandlers.pushHandlerTable, PushHandlers.pushHandler?])
+    (by simp [ControlHandlers.controlHandlerTable, ControlHandlers.controlHandler?])
+    (by rfl)
+    (by simp [ReturnDataHandlers.returnDataSizeHandlerTable,
+      ReturnDataHandlers.returnDataHandler?])
+    (by simp [CodeHandlers.codeHandlerTable, CodeHandlers.codeHandler?])
+    (by simp [MemoryHandlers.msizeHandlerTable, MemoryHandlers.memoryHandler?])
+    ArithmeticHandlers.arithmeticHandler?_SMOD
+
 @[simp] theorem supportedHandlerTable_CALLDATASIZE :
     supportedHandlerTable .CALLDATASIZE =
       some CalldataHandlers.callDataSizeHandler := by

--- a/EvmAsm/Evm64/SupportedLoopBridge.lean
+++ b/EvmAsm/Evm64/SupportedLoopBridge.lean
@@ -113,6 +113,44 @@ theorem stepWithSupportedHandler_SWAP_status_of_some
   exact SupportedHandlers.dispatchOpcode_supportedHandlerTable_SWAP_of_valid_status_of_some
     h_valid h_stack
 
+theorem stepWithSupportedHandler_SDIV
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SDIV) :
+    InterpreterLoop.stepWithHandler supportedLoopHandler state =
+      ArithmeticHandlers.sdivHandler state := by
+  exact stepWithSupportedHandler_of_lookup h_decode
+    SupportedHandlers.supportedHandlerTable_SDIV
+
+theorem stepWithSupportedHandler_SMOD
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SMOD) :
+    InterpreterLoop.stepWithHandler supportedLoopHandler state =
+      ArithmeticHandlers.smodHandler state := by
+  exact stepWithSupportedHandler_of_lookup h_decode
+    SupportedHandlers.supportedHandlerTable_SMOD
+
+theorem stepWithSupportedHandler_SDIV_status_of_some
+    {state : EvmState} {stack' : List EvmWord}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SDIV)
+    (h_stack : ArithmeticHandlers.binaryStack? EvmWord.sdiv state.stack =
+      some stack') :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).status =
+      state.status := by
+  rw [stepWithSupportedHandler_SDIV h_decode]
+  simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler,
+    h_stack, EvmState.withStack]
+
+theorem stepWithSupportedHandler_SMOD_status_of_some
+    {state : EvmState} {stack' : List EvmWord}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SMOD)
+    (h_stack : ArithmeticHandlers.binaryStack? EvmWord.smod state.stack =
+      some stack') :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).status =
+      state.status := by
+  rw [stepWithSupportedHandler_SMOD h_decode]
+  simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler,
+    h_stack, EvmState.withStack]
+
 /--
 When the combined supported loop decodes STOP, one interpreter step terminates
 successfully.
@@ -272,6 +310,26 @@ theorem loopFuel_supported_succ_running_INVALID_status
       .error := by
   rw [loopFuel_supported_succ_running_INVALID nSteps h_status h_decode]
   exact loopFuel_supported_invalid_fixed_status nSteps state
+
+theorem loopFuel_supported_succ_running_SDIV
+    (nSteps : Nat) {state : EvmState}
+    (h_status : state.status = .running)
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SDIV) :
+    InterpreterLoop.loopFuel supportedLoopHandler (nSteps + 1) state =
+      InterpreterLoop.loopFuel supportedLoopHandler nSteps
+        (ArithmeticHandlers.sdivHandler state) := by
+  exact loopFuel_supported_succ_running_lookup nSteps h_status h_decode
+    SupportedHandlers.supportedHandlerTable_SDIV
+
+theorem loopFuel_supported_succ_running_SMOD
+    (nSteps : Nat) {state : EvmState}
+    (h_status : state.status = .running)
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SMOD) :
+    InterpreterLoop.loopFuel supportedLoopHandler (nSteps + 1) state =
+      InterpreterLoop.loopFuel supportedLoopHandler nSteps
+        (ArithmeticHandlers.smodHandler state) := by
+  exact loopFuel_supported_succ_running_lookup nSteps h_status h_decode
+    SupportedHandlers.supportedHandlerTable_SMOD
 
 theorem loopFuel_supported_missing_invalid
     (nSteps : Nat) {state : EvmState} {opcode : EvmOpcode}

--- a/EvmAsm/Evm64/SupportedLoopBridge.lean
+++ b/EvmAsm/Evm64/SupportedLoopBridge.lean
@@ -243,6 +243,30 @@ theorem stepWithSupportedHandler_SMOD_status_of_runSModStack?_none
   exact SModStackExecutionBridge.smodHandler_status_of_runSModStack?_none
     h_run
 
+theorem stepWithSupportedHandler_SDIV_status_of_runSDivStack?_some
+    {state : EvmState} {out : SDivStackExecutionBridge.SDivStackResult}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SDIV)
+    (h_run :
+      SDivStackExecutionBridge.runSDivStack? { stack := state.stack } =
+        some out) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).status =
+      state.status := by
+  rw [stepWithSupportedHandler_SDIV h_decode]
+  exact SDivStackExecutionBridge.sdivHandler_status_of_runSDivStack?_some
+    h_run
+
+theorem stepWithSupportedHandler_SMOD_status_of_runSModStack?_some
+    {state : EvmState} {out : SModStackExecutionBridge.SModStackResult}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SMOD)
+    (h_run :
+      SModStackExecutionBridge.runSModStack? { stack := state.stack } =
+        some out) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).status =
+      state.status := by
+  rw [stepWithSupportedHandler_SMOD h_decode]
+  exact SModStackExecutionBridge.smodHandler_status_of_runSModStack?_some
+    h_run
+
 theorem stepWithSupportedHandler_SDIV_stack_zero_divisor
     {state : EvmState} (dividend : EvmWord) (rest : List EvmWord)
     (h_decode :

--- a/EvmAsm/Evm64/SupportedLoopBridge.lean
+++ b/EvmAsm/Evm64/SupportedLoopBridge.lean
@@ -211,6 +211,22 @@ theorem stepWithSupportedHandler_SMOD_env
   rw [stepWithSupportedHandler_SMOD h_decode]
   exact SModStackExecutionBridge.smodHandler_env state
 
+theorem stepWithSupportedHandler_SDIV_codeLenMatches
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SDIV)
+    (h_codeLen : state.codeLenMatches) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).codeLenMatches := by
+  rw [stepWithSupportedHandler_SDIV h_decode]
+  exact SDivStackExecutionBridge.sdivHandler_codeLenMatches state h_codeLen
+
+theorem stepWithSupportedHandler_SMOD_codeLenMatches
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SMOD)
+    (h_codeLen : state.codeLenMatches) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).codeLenMatches := by
+  rw [stepWithSupportedHandler_SMOD h_decode]
+  exact SModStackExecutionBridge.smodHandler_codeLenMatches state h_codeLen
+
 theorem stepWithSupportedHandler_SDIV_memoryCells
     {state : EvmState}
     (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SDIV) :

--- a/EvmAsm/Evm64/SupportedLoopBridge.lean
+++ b/EvmAsm/Evm64/SupportedLoopBridge.lean
@@ -163,6 +163,54 @@ theorem stepWithSupportedHandler_SMOD_gas
   rw [stepWithSupportedHandler_SMOD h_decode]
   exact SModStackExecutionBridge.smodHandler_gas state
 
+theorem stepWithSupportedHandler_SDIV_code
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SDIV) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).code =
+      state.code := by
+  rw [stepWithSupportedHandler_SDIV h_decode]
+  exact SDivStackExecutionBridge.sdivHandler_code state
+
+theorem stepWithSupportedHandler_SMOD_code
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SMOD) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).code =
+      state.code := by
+  rw [stepWithSupportedHandler_SMOD h_decode]
+  exact SModStackExecutionBridge.smodHandler_code state
+
+theorem stepWithSupportedHandler_SDIV_codeLen
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SDIV) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).codeLen =
+      state.codeLen := by
+  rw [stepWithSupportedHandler_SDIV h_decode]
+  exact SDivStackExecutionBridge.sdivHandler_codeLen state
+
+theorem stepWithSupportedHandler_SMOD_codeLen
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SMOD) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).codeLen =
+      state.codeLen := by
+  rw [stepWithSupportedHandler_SMOD h_decode]
+  exact SModStackExecutionBridge.smodHandler_codeLen state
+
+theorem stepWithSupportedHandler_SDIV_env
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SDIV) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).env =
+      state.env := by
+  rw [stepWithSupportedHandler_SDIV h_decode]
+  exact SDivStackExecutionBridge.sdivHandler_env state
+
+theorem stepWithSupportedHandler_SMOD_env
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SMOD) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).env =
+      state.env := by
+  rw [stepWithSupportedHandler_SMOD h_decode]
+  exact SModStackExecutionBridge.smodHandler_env state
+
 theorem stepWithSupportedHandler_SDIV_memoryCells
     {state : EvmState}
     (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SDIV) :

--- a/EvmAsm/Evm64/SupportedLoopBridge.lean
+++ b/EvmAsm/Evm64/SupportedLoopBridge.lean
@@ -147,6 +147,22 @@ theorem stepWithSupportedHandler_SMOD_pc
   rw [stepWithSupportedHandler_SMOD h_decode]
   exact SModStackExecutionBridge.smodHandler_pc state
 
+theorem stepWithSupportedHandler_SDIV_gas
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SDIV) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).gas =
+      state.gas := by
+  rw [stepWithSupportedHandler_SDIV h_decode]
+  exact SDivStackExecutionBridge.sdivHandler_gas state
+
+theorem stepWithSupportedHandler_SMOD_gas
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SMOD) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).gas =
+      state.gas := by
+  rw [stepWithSupportedHandler_SMOD h_decode]
+  exact SModStackExecutionBridge.smodHandler_gas state
+
 theorem stepWithSupportedHandler_SDIV_status_of_some
     {state : EvmState} {stack' : List EvmWord}
     (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SDIV)

--- a/EvmAsm/Evm64/SupportedLoopBridge.lean
+++ b/EvmAsm/Evm64/SupportedLoopBridge.lean
@@ -177,6 +177,48 @@ theorem stepWithSupportedHandler_SMOD_stack_of_runSModStack?_some
   exact SModStackExecutionBridge.smodHandler_stack_of_runSModStack?_some
     h_run
 
+theorem stepWithSupportedHandler_SDIV_status_empty_stack
+    {state : EvmState}
+    (h_decode :
+      InterpreterLoop.decodeCurrentOpcode? { state with stack := [] } =
+        some .SDIV) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler
+      { state with stack := [] }).status = .error := by
+  rw [stepWithSupportedHandler_SDIV h_decode]
+  exact SDivStackExecutionBridge.sdivHandler_status_empty_stack state
+
+theorem stepWithSupportedHandler_SDIV_status_singleton_stack
+    {state : EvmState} (dividend : EvmWord)
+    (h_decode :
+      InterpreterLoop.decodeCurrentOpcode?
+        { state with stack := [dividend] } = some .SDIV) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler
+      { state with stack := [dividend] }).status = .error := by
+  rw [stepWithSupportedHandler_SDIV h_decode]
+  exact SDivStackExecutionBridge.sdivHandler_status_singleton_stack
+    state dividend
+
+theorem stepWithSupportedHandler_SMOD_status_empty_stack
+    {state : EvmState}
+    (h_decode :
+      InterpreterLoop.decodeCurrentOpcode? { state with stack := [] } =
+        some .SMOD) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler
+      { state with stack := [] }).status = .error := by
+  rw [stepWithSupportedHandler_SMOD h_decode]
+  exact SModStackExecutionBridge.smodHandler_status_empty_stack state
+
+theorem stepWithSupportedHandler_SMOD_status_singleton_stack
+    {state : EvmState} (dividend : EvmWord)
+    (h_decode :
+      InterpreterLoop.decodeCurrentOpcode?
+        { state with stack := [dividend] } = some .SMOD) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler
+      { state with stack := [dividend] }).status = .error := by
+  rw [stepWithSupportedHandler_SMOD h_decode]
+  exact SModStackExecutionBridge.smodHandler_status_singleton_stack
+    state dividend
+
 theorem stepWithSupportedHandler_SDIV_stack_zero_divisor
     {state : EvmState} (dividend : EvmWord) (rest : List EvmWord)
     (h_decode :

--- a/EvmAsm/Evm64/SupportedLoopBridge.lean
+++ b/EvmAsm/Evm64/SupportedLoopBridge.lean
@@ -163,6 +163,54 @@ theorem stepWithSupportedHandler_SMOD_gas
   rw [stepWithSupportedHandler_SMOD h_decode]
   exact SModStackExecutionBridge.smodHandler_gas state
 
+theorem stepWithSupportedHandler_SDIV_memoryCells
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SDIV) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).memoryCells =
+      state.memoryCells := by
+  rw [stepWithSupportedHandler_SDIV h_decode]
+  exact SDivStackExecutionBridge.sdivHandler_memoryCells state
+
+theorem stepWithSupportedHandler_SDIV_memory
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SDIV) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).memory =
+      state.memory := by
+  rw [stepWithSupportedHandler_SDIV h_decode]
+  exact SDivStackExecutionBridge.sdivHandler_memory state
+
+theorem stepWithSupportedHandler_SDIV_memSize
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SDIV) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).memSize =
+      state.memSize := by
+  rw [stepWithSupportedHandler_SDIV h_decode]
+  exact SDivStackExecutionBridge.sdivHandler_memSize state
+
+theorem stepWithSupportedHandler_SMOD_memoryCells
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SMOD) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).memoryCells =
+      state.memoryCells := by
+  rw [stepWithSupportedHandler_SMOD h_decode]
+  exact SModStackExecutionBridge.smodHandler_memoryCells state
+
+theorem stepWithSupportedHandler_SMOD_memory
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SMOD) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).memory =
+      state.memory := by
+  rw [stepWithSupportedHandler_SMOD h_decode]
+  exact SModStackExecutionBridge.smodHandler_memory state
+
+theorem stepWithSupportedHandler_SMOD_memSize
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SMOD) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).memSize =
+      state.memSize := by
+  rw [stepWithSupportedHandler_SMOD h_decode]
+  exact SModStackExecutionBridge.smodHandler_memSize state
+
 theorem stepWithSupportedHandler_SDIV_status_of_some
     {state : EvmState} {stack' : List EvmWord}
     (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SDIV)

--- a/EvmAsm/Evm64/SupportedLoopBridge.lean
+++ b/EvmAsm/Evm64/SupportedLoopBridge.lean
@@ -131,6 +131,22 @@ theorem stepWithSupportedHandler_SMOD
   exact stepWithSupportedHandler_of_lookup h_decode
     SupportedHandlers.supportedHandlerTable_SMOD
 
+theorem stepWithSupportedHandler_SDIV_pc
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SDIV) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).pc =
+      state.pc := by
+  rw [stepWithSupportedHandler_SDIV h_decode]
+  exact SDivStackExecutionBridge.sdivHandler_pc state
+
+theorem stepWithSupportedHandler_SMOD_pc
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SMOD) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).pc =
+      state.pc := by
+  rw [stepWithSupportedHandler_SMOD h_decode]
+  exact SModStackExecutionBridge.smodHandler_pc state
+
 theorem stepWithSupportedHandler_SDIV_status_of_some
     {state : EvmState} {stack' : List EvmWord}
     (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SDIV)

--- a/EvmAsm/Evm64/SupportedLoopBridge.lean
+++ b/EvmAsm/Evm64/SupportedLoopBridge.lean
@@ -7,6 +7,8 @@
 
 import EvmAsm.Evm64.HandlerLoopBridge
 import EvmAsm.Evm64.SupportedHandlers
+import EvmAsm.Evm64.SDiv.HandlerBridge
+import EvmAsm.Evm64.SMod.HandlerBridge
 
 namespace EvmAsm.Evm64
 
@@ -150,6 +152,30 @@ theorem stepWithSupportedHandler_SMOD_status_of_some
   rw [stepWithSupportedHandler_SMOD h_decode]
   simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler,
     h_stack, EvmState.withStack]
+
+theorem stepWithSupportedHandler_SDIV_stack_of_runSDivStack?_some
+    {state : EvmState} {out : SDivStackExecutionBridge.SDivStackResult}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SDIV)
+    (h_run :
+      SDivStackExecutionBridge.runSDivStack? { stack := state.stack } =
+        some out) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).stack =
+      out.effects.stackWords ++ out.stack := by
+  rw [stepWithSupportedHandler_SDIV h_decode]
+  exact SDivStackExecutionBridge.sdivHandler_stack_of_runSDivStack?_some
+    h_run
+
+theorem stepWithSupportedHandler_SMOD_stack_of_runSModStack?_some
+    {state : EvmState} {out : SModStackExecutionBridge.SModStackResult}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SMOD)
+    (h_run :
+      SModStackExecutionBridge.runSModStack? { stack := state.stack } =
+        some out) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).stack =
+      out.effects.stackWords ++ out.stack := by
+  rw [stepWithSupportedHandler_SMOD h_decode]
+  exact SModStackExecutionBridge.smodHandler_stack_of_runSModStack?_some
+    h_run
 
 /--
 When the combined supported loop decodes STOP, one interpreter step terminates

--- a/EvmAsm/Evm64/SupportedLoopBridge.lean
+++ b/EvmAsm/Evm64/SupportedLoopBridge.lean
@@ -177,6 +177,102 @@ theorem stepWithSupportedHandler_SMOD_stack_of_runSModStack?_some
   exact SModStackExecutionBridge.smodHandler_stack_of_runSModStack?_some
     h_run
 
+theorem stepWithSupportedHandler_SDIV_stack_zero_divisor
+    {state : EvmState} (dividend : EvmWord) (rest : List EvmWord)
+    (h_decode :
+      InterpreterLoop.decodeCurrentOpcode?
+        { state with stack := dividend :: 0 :: rest } = some .SDIV)
+    :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler
+      { state with stack := dividend :: 0 :: rest }).stack =
+        0 :: rest := by
+  rw [stepWithSupportedHandler_SDIV h_decode]
+  exact SDivStackExecutionBridge.sdivHandler_stack_zero_divisor state
+    dividend rest
+
+theorem stepWithSupportedHandler_SDIV_stack_intMin_neg_one
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode?
+      { state with stack := BitVec.intMin 256 :: (-1 : EvmWord) :: state.stack } =
+        some .SDIV) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler
+      { state with stack := BitVec.intMin 256 :: (-1 : EvmWord) :: state.stack }).stack =
+        BitVec.intMin 256 :: state.stack := by
+  rw [stepWithSupportedHandler_SDIV h_decode]
+  exact SDivStackExecutionBridge.sdivHandler_stack_intMin_neg_one state
+    state.stack
+
+theorem stepWithSupportedHandler_SDIV_stack_neg_one_two
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode?
+      { state with stack := (-1 : EvmWord) :: 2 :: state.stack } = some .SDIV) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler
+      { state with stack := (-1 : EvmWord) :: 2 :: state.stack }).stack =
+        0 :: state.stack := by
+  rw [stepWithSupportedHandler_SDIV h_decode]
+  exact SDivStackExecutionBridge.sdivHandler_stack_neg_one_two state
+    state.stack
+
+theorem stepWithSupportedHandler_SDIV_stack_pos_neg_trunc
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode?
+      { state with stack := (7 : EvmWord) :: (-2 : EvmWord) :: state.stack } =
+        some .SDIV) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler
+      { state with stack := (7 : EvmWord) :: (-2 : EvmWord) :: state.stack }).stack =
+        (-3 : EvmWord) :: state.stack := by
+  rw [stepWithSupportedHandler_SDIV h_decode]
+  exact SDivStackExecutionBridge.sdivHandler_stack_pos_neg_trunc state
+    state.stack
+
+theorem stepWithSupportedHandler_SMOD_stack_zero_divisor
+    {state : EvmState} (dividend : EvmWord) (rest : List EvmWord)
+    (h_decode :
+      InterpreterLoop.decodeCurrentOpcode?
+        { state with stack := dividend :: 0 :: rest } = some .SMOD)
+    :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler
+      { state with stack := dividend :: 0 :: rest }).stack =
+        0 :: rest := by
+  rw [stepWithSupportedHandler_SMOD h_decode]
+  exact SModStackExecutionBridge.smodHandler_stack_zero_divisor state
+    dividend rest
+
+theorem stepWithSupportedHandler_SMOD_stack_neg_pos_sign
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode?
+      { state with stack := (-3 : EvmWord) :: 2 :: state.stack } = some .SMOD) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler
+      { state with stack := (-3 : EvmWord) :: 2 :: state.stack }).stack =
+        (-1 : EvmWord) :: state.stack := by
+  rw [stepWithSupportedHandler_SMOD h_decode]
+  exact SModStackExecutionBridge.smodHandler_stack_neg_pos_sign state
+    state.stack
+
+theorem stepWithSupportedHandler_SMOD_stack_pos_neg_sign
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode?
+      { state with stack := (3 : EvmWord) :: (-2 : EvmWord) :: state.stack } =
+        some .SMOD) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler
+      { state with stack := (3 : EvmWord) :: (-2 : EvmWord) :: state.stack }).stack =
+        (1 : EvmWord) :: state.stack := by
+  rw [stepWithSupportedHandler_SMOD h_decode]
+  exact SModStackExecutionBridge.smodHandler_stack_pos_neg_sign state
+    state.stack
+
+theorem stepWithSupportedHandler_SMOD_stack_neg_neg_sign
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode?
+      { state with stack := (-3 : EvmWord) :: (-2 : EvmWord) :: state.stack } =
+        some .SMOD) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler
+      { state with stack := (-3 : EvmWord) :: (-2 : EvmWord) :: state.stack }).stack =
+        (-1 : EvmWord) :: state.stack := by
+  rw [stepWithSupportedHandler_SMOD h_decode]
+  exact SModStackExecutionBridge.smodHandler_stack_neg_neg_sign state
+    state.stack
+
 /--
 When the combined supported loop decodes STOP, one interpreter step terminates
 successfully.

--- a/EvmAsm/Evm64/SupportedLoopBridge.lean
+++ b/EvmAsm/Evm64/SupportedLoopBridge.lean
@@ -219,6 +219,30 @@ theorem stepWithSupportedHandler_SMOD_status_singleton_stack
   exact SModStackExecutionBridge.smodHandler_status_singleton_stack
     state dividend
 
+theorem stepWithSupportedHandler_SDIV_status_of_runSDivStack?_none
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SDIV)
+    (h_run :
+      SDivStackExecutionBridge.runSDivStack? { stack := state.stack } =
+        none) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).status =
+      .error := by
+  rw [stepWithSupportedHandler_SDIV h_decode]
+  exact SDivStackExecutionBridge.sdivHandler_status_of_runSDivStack?_none
+    h_run
+
+theorem stepWithSupportedHandler_SMOD_status_of_runSModStack?_none
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SMOD)
+    (h_run :
+      SModStackExecutionBridge.runSModStack? { stack := state.stack } =
+        none) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).status =
+      .error := by
+  rw [stepWithSupportedHandler_SMOD h_decode]
+  exact SModStackExecutionBridge.smodHandler_status_of_runSModStack?_none
+    h_run
+
 theorem stepWithSupportedHandler_SDIV_stack_zero_divisor
     {state : EvmState} (dividend : EvmWord) (rest : List EvmWord)
     (h_decode :


### PR DESCRIPTION
## Summary
- add a sibling-framed MLOAD prologue stack spec
- align the prologue with the existing framed q0-q3 MLOAD unaligned stack specs
- keep this as an additive compose prerequisite for evm-asm-75z1x / GH #53 follow-up

## Tests
- lake build EvmAsm.Evm64.MLoad.UnalignedFramedStackSpec