### PR TITLE
feat(evm64): add public quarter triple transports

### DIFF
--- a/EvmAsm/Evm64/MLoad/UnalignedFramedStackSpec.lean
+++ b/EvmAsm/Evm64/MLoad/UnalignedFramedStackSpec.lean
@@ -262,6 +262,66 @@ theorem evm_mload_code_one_limb_q3_sub
     (mloadStackCode_four_limbs_sub offReg byteReg accReg addrReg memBaseReg base a i
       (mloadFourLimbsCode_one_limb_q3_sub addrReg byteReg accReg base a i h))
 
+/-- Transport a q0 MLOAD one-limb triple to the public `evm_mload_code`. -/
+theorem cpsTripleWithin_evm_mload_of_one_limb_q0
+    {n : Nat} {P Q : Assertion}
+    (offReg byteReg accReg addrReg memBaseReg : Reg) (base : Word)
+    (h :
+      cpsTripleWithin n (base + 8) (base + 100)
+        (mloadOneLimbCode addrReg byteReg accReg
+          24 25 26 27 28 29 30 31 0 (base + 8)) P Q) :
+    cpsTripleWithin n (base + 8) (base + 100)
+      (evm_mload_code offReg byteReg accReg addrReg memBaseReg base) P Q :=
+  cpsTripleWithin_extend_code
+    (h := h)
+    (hmono := evm_mload_code_one_limb_q0_sub
+      offReg byteReg accReg addrReg memBaseReg base)
+
+/-- Transport a q1 MLOAD one-limb triple to the public `evm_mload_code`. -/
+theorem cpsTripleWithin_evm_mload_of_one_limb_q1
+    {n : Nat} {P Q : Assertion}
+    (offReg byteReg accReg addrReg memBaseReg : Reg) (base : Word)
+    (h :
+      cpsTripleWithin n (base + 100) (base + 192)
+        (mloadOneLimbCode addrReg byteReg accReg
+          16 17 18 19 20 21 22 23 8 (base + 100)) P Q) :
+    cpsTripleWithin n (base + 100) (base + 192)
+      (evm_mload_code offReg byteReg accReg addrReg memBaseReg base) P Q :=
+  cpsTripleWithin_extend_code
+    (h := h)
+    (hmono := evm_mload_code_one_limb_q1_sub
+      offReg byteReg accReg addrReg memBaseReg base)
+
+/-- Transport a q2 MLOAD one-limb triple to the public `evm_mload_code`. -/
+theorem cpsTripleWithin_evm_mload_of_one_limb_q2
+    {n : Nat} {P Q : Assertion}
+    (offReg byteReg accReg addrReg memBaseReg : Reg) (base : Word)
+    (h :
+      cpsTripleWithin n (base + 192) (base + 284)
+        (mloadOneLimbCode addrReg byteReg accReg
+          8 9 10 11 12 13 14 15 16 (base + 192)) P Q) :
+    cpsTripleWithin n (base + 192) (base + 284)
+      (evm_mload_code offReg byteReg accReg addrReg memBaseReg base) P Q :=
+  cpsTripleWithin_extend_code
+    (h := h)
+    (hmono := evm_mload_code_one_limb_q2_sub
+      offReg byteReg accReg addrReg memBaseReg base)
+
+/-- Transport a q3 MLOAD one-limb triple to the public `evm_mload_code`. -/
+theorem cpsTripleWithin_evm_mload_of_one_limb_q3
+    {n : Nat} {P Q : Assertion}
+    (offReg byteReg accReg addrReg memBaseReg : Reg) (base : Word)
+    (h :
+      cpsTripleWithin n (base + 284) (base + 376)
+        (mloadOneLimbCode addrReg byteReg accReg
+          0 1 2 3 4 5 6 7 24 (base + 284)) P Q) :
+    cpsTripleWithin n (base + 284) (base + 376)
+      (evm_mload_code offReg byteReg accReg addrReg memBaseReg base) P Q :=
+  cpsTripleWithin_extend_code
+    (h := h)
+    (hmono := evm_mload_code_one_limb_q3_sub
+      offReg byteReg accReg addrReg memBaseReg base)
+
 /--
 Sibling-framed q0 stack spec: `evm_mload_unaligned_one_limb_q0_stack_spec_within`
 with an arbitrary `pcFree` assertion `F` framed on both pre and post.

--- a/EvmAsm/Evm64/MStore/UnalignedFramedStackSpec.lean
+++ b/EvmAsm/Evm64/MStore/UnalignedFramedStackSpec.lean
@@ -260,6 +260,66 @@ theorem evm_mstore_code_one_limb_q3_sub
     (mstoreStackCode_four_limbs_sub offReg byteReg accReg addrReg memBaseReg base a i
       (mstoreFourLimbsCode_limb3_sub addrReg byteReg accReg base a i h))
 
+/-- Transport a q0 MSTORE one-limb triple to the public `evm_mstore_code`. -/
+theorem cpsTripleWithin_evm_mstore_of_one_limb_q0
+    {n : Nat} {P Q : Assertion}
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg) (base : Word)
+    (h :
+      cpsTripleWithin n (base + 8) (base + 76)
+        (mstoreOneLimbCode addrReg byteReg accReg
+          32 24 25 26 27 28 29 30 31 (base + 8)) P Q) :
+    cpsTripleWithin n (base + 8) (base + 76)
+      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base) P Q :=
+  cpsTripleWithin_extend_code
+    (h := h)
+    (hmono := evm_mstore_code_one_limb_q0_sub
+      offReg valReg byteReg accReg addrReg memBaseReg base)
+
+/-- Transport a q1 MSTORE one-limb triple to the public `evm_mstore_code`. -/
+theorem cpsTripleWithin_evm_mstore_of_one_limb_q1
+    {n : Nat} {P Q : Assertion}
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg) (base : Word)
+    (h :
+      cpsTripleWithin n (base + 76) (base + 144)
+        (mstoreOneLimbCode addrReg byteReg accReg
+          40 16 17 18 19 20 21 22 23 (base + 76)) P Q) :
+    cpsTripleWithin n (base + 76) (base + 144)
+      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base) P Q :=
+  cpsTripleWithin_extend_code
+    (h := h)
+    (hmono := evm_mstore_code_one_limb_q1_sub
+      offReg valReg byteReg accReg addrReg memBaseReg base)
+
+/-- Transport a q2 MSTORE one-limb triple to the public `evm_mstore_code`. -/
+theorem cpsTripleWithin_evm_mstore_of_one_limb_q2
+    {n : Nat} {P Q : Assertion}
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg) (base : Word)
+    (h :
+      cpsTripleWithin n (base + 144) (base + 212)
+        (mstoreOneLimbCode addrReg byteReg accReg
+          48 8 9 10 11 12 13 14 15 (base + 144)) P Q) :
+    cpsTripleWithin n (base + 144) (base + 212)
+      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base) P Q :=
+  cpsTripleWithin_extend_code
+    (h := h)
+    (hmono := evm_mstore_code_one_limb_q2_sub
+      offReg valReg byteReg accReg addrReg memBaseReg base)
+
+/-- Transport a q3 MSTORE one-limb triple to the public `evm_mstore_code`. -/
+theorem cpsTripleWithin_evm_mstore_of_one_limb_q3
+    {n : Nat} {P Q : Assertion}
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg) (base : Word)
+    (h :
+      cpsTripleWithin n (base + 212) (base + 280)
+        (mstoreOneLimbCode addrReg byteReg accReg
+          56 0 1 2 3 4 5 6 7 (base + 212)) P Q) :
+    cpsTripleWithin n (base + 212) (base + 280)
+      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base) P Q :=
+  cpsTripleWithin_extend_code
+    (h := h)
+    (hmono := evm_mstore_code_one_limb_q3_sub
+      offReg valReg byteReg accReg addrReg memBaseReg base)
+
 /--
 Sibling-framed q0 stack spec: `evm_mstore_unaligned_one_limb_q0_stack_spec_within`
 with an arbitrary `pcFree` assertion `F` framed on both pre and post.


### PR DESCRIPTION
## Summary
- add generic q0-q3 MLOAD one-limb cpsTripleWithin transports into evm_mload_code
- add generic q0-q3 MSTORE one-limb cpsTripleWithin transports into evm_mstore_code
- stack this transport layer on top of #3149 for full-stack MLOAD/MSTORE composition work

## Stack
- Base PR: #3149
- Previous PRs: #3148, #3147, #3145, #3144, #3143

## Tests
- lake build EvmAsm.Evm64.MLoad.UnalignedFramedStackSpec EvmAsm.Evm64.MStore.UnalignedFramedStackSpec