### PR TITLE
feat(mload): add public q2 framed spec

### DIFF
--- a/EvmAsm/Evm64/MLoad/UnalignedFramedStackSpec.lean
+++ b/EvmAsm/Evm64/MLoad/UnalignedFramedStackSpec.lean
@@ -545,6 +545,51 @@ theorem evm_mload_unaligned_one_limb_q2_stack_spec_within_framed
     framed
 
 /--
+Public-code q2 framed MLOAD spec: transports
+`evm_mload_unaligned_one_limb_q2_stack_spec_within_framed` from the q2
+one-limb block to the full `evm_mload_code` code requirement.
+
+Distinctive token:
+evm_mload_unaligned_one_limb_q2_spec_within_framed_public_code #53.
+-/
+theorem evm_mload_unaligned_one_limb_q2_spec_within_framed_public_code
+    (offReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset memBase byteOld accOld : Word)
+    (q0Old q1Old : Word)
+    (loAddr2 hiAddr2 loVal2 hiVal2 : Word) (start : Nat)
+    (dstOld : Word)
+    (base : Word)
+    (F : Assertion) (hF : F.pcFree)
+    (h_byte_ne_x0 : byteReg ≠ .x0) (h_acc_ne_x0 : accReg ≠ .x0)
+    (h_window : mloadLimbWindowOk (memBase + offset) loAddr2 hiAddr2 start
+                  8 9 10 11 12 13 14 15) :
+    cpsTripleWithin 23 (base + 192) (base + 284)
+      (evm_mload_code offReg byteReg accReg addrReg memBaseReg base)
+      ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+        (sp ↦ₘ q0Old) **
+        (sp + 8 ↦ₘ q1Old) **
+        (sp + 16 ↦ₘ dstOld) **
+        ((byteReg ↦ᵣ byteOld) ** (accReg ↦ᵣ accOld) **
+         (loAddr2 ↦ₘ loVal2) ** (hiAddr2 ↦ₘ hiVal2))) ** F)
+      ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+        (sp ↦ₘ q0Old) **
+        (sp + 8 ↦ₘ q1Old) **
+        (sp + 16 ↦ₘ mloadPackedLimbFromDwordPair loVal2 hiVal2 start) **
+        ((byteReg ↦ᵣ
+           (mloadByteFromDwordPair loVal2 hiVal2 start 7).zeroExtend 64) **
+         (accReg ↦ᵣ mloadPackedLimbFromDwordPair loVal2 hiVal2 start) **
+         (loAddr2 ↦ₘ loVal2) ** (hiAddr2 ↦ₘ hiVal2))) ** F) := by
+  exact cpsTripleWithin_evm_mload_of_one_limb_q2
+    offReg byteReg accReg addrReg memBaseReg base
+    (evm_mload_unaligned_one_limb_q2_stack_spec_within_framed
+      offReg byteReg accReg addrReg memBaseReg
+      sp offset memBase byteOld accOld q0Old q1Old
+      loAddr2 hiAddr2 loVal2 hiVal2 start dstOld base F hF
+      h_byte_ne_x0 h_acc_ne_x0 h_window)
+
+/--
 Sibling-framed q3 stack spec: `evm_mload_unaligned_one_limb_q3_stack_spec_within`
 with an arbitrary `pcFree` assertion `F` framed on both pre and post.
 


### PR DESCRIPTION
## Summary
- add a public-code q2 framed MLOAD theorem over evm_mload_code
- consume the generic q2 one-limb transport from #3150
- continue the concrete public quarter wrapper stack for MLOAD full-stack composition

## Stack
- Base PR: #3152
- Previous PRs: #3151, #3150, #3149, #3148, #3147, #3145, #3144, #3143

## Tests
- lake build EvmAsm.Evm64.MLoad.UnalignedFramedStackSpec