### PR TITLE
feat(mstore): add public q2 framed spec

### DIFF
--- a/EvmAsm/Evm64/MStore/UnalignedFramedStackSpec.lean
+++ b/EvmAsm/Evm64/MStore/UnalignedFramedStackSpec.lean
@@ -544,6 +544,48 @@ theorem evm_mstore_unaligned_one_limb_q2_stack_spec_within_framed
     framed
 
 /--
+Public-code q2 framed MSTORE spec: transports
+`evm_mstore_unaligned_one_limb_q2_stack_spec_within_framed` from the q2
+one-limb block to the full `evm_mstore_code` code requirement.
+
+Distinctive token:
+evm_mstore_unaligned_one_limb_q2_spec_within_framed_public_code #53.
+-/
+theorem evm_mstore_unaligned_one_limb_q2_spec_within_framed_public_code
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset memBase byteOld accOld limbVal : Word)
+    (loAddr hiAddr loVal hiVal : Word) (start : Nat)
+    (base : Word)
+    (F : Assertion) (hF : F.pcFree)
+    (h_byte_ne_x0 : byteReg ≠ .x0)
+    (h_acc_ne_x0 : accReg ≠ .x0)
+    (h_window : mstoreLimbWindowOk (memBase + offset) loAddr hiAddr start
+                  8 9 10 11 12 13 14 15) :
+    cpsTripleWithin 17 (base + 144) (base + 212)
+      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base)
+      ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+        (sp ↦ₘ offset) **
+        ((byteReg ↦ᵣ byteOld) ** (accReg ↦ᵣ accOld) **
+         (loAddr ↦ₘ loVal) ** (hiAddr ↦ₘ hiVal) **
+         ((sp + signExtend12 (48 : BitVec 12)) ↦ₘ limbVal))) ** F)
+      ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+        (sp ↦ₘ offset) **
+        (let stored :=
+          MStore.mstoreDwordPairStoreLimb loVal hiVal limbVal start
+         (byteReg ↦ᵣ limbVal) ** (accReg ↦ᵣ limbVal) **
+         (loAddr ↦ₘ stored.1) ** (hiAddr ↦ₘ stored.2) **
+         ((sp + signExtend12 (48 : BitVec 12)) ↦ₘ limbVal))) ** F) := by
+  exact cpsTripleWithin_evm_mstore_of_one_limb_q2
+    offReg valReg byteReg accReg addrReg memBaseReg base
+    (evm_mstore_unaligned_one_limb_q2_stack_spec_within_framed
+      offReg byteReg accReg addrReg memBaseReg
+      sp offset memBase byteOld accOld limbVal
+      loAddr hiAddr loVal hiVal start base F hF
+      h_byte_ne_x0 h_acc_ne_x0 h_window)
+
+/--
 Sibling-framed q3 stack spec: `evm_mstore_unaligned_one_limb_q3_stack_spec_within`
 with an arbitrary `pcFree` assertion `F` framed on both pre and post.
 


### PR DESCRIPTION
## Summary
- add a public-code q2 framed MSTORE theorem over evm_mstore_code
- consume the generic q2 one-limb transport from #3150
- continue the concrete public quarter wrapper stack for MSTORE full-stack composition

## Stack
- Base PR: #3156
- Previous PRs: #3155, #3154, #3153, #3152, #3151, #3150, #3149, #3148, #3147, #3145, #3144, #3143

## Tests
- lake build EvmAsm.Evm64.MStore.UnalignedFramedStackSpec