### PR TITLE
feat(evm64): add public quarter sequence specs

### DIFF
--- a/EvmAsm/Evm64/MLoad/UnalignedFramedStackSpec.lean
+++ b/EvmAsm/Evm64/MLoad/UnalignedFramedStackSpec.lean
@@ -323,6 +323,39 @@ theorem cpsTripleWithin_evm_mload_of_one_limb_q3
       offReg byteReg accReg addrReg memBaseReg base)
 
 /--
+Compose four public-code MLOAD one-limb triples into a single q0..q3 body
+triple over `evm_mload_code`.
+
+This is the public-code counterpart of `mload_one_limb_sequence_spec_within`:
+callers that already transported each quarter to `evm_mload_code` can sequence
+them without returning to the smaller `mloadFourLimbsCode` surface.
+
+Distinctive token: evm_mload_public_one_limb_sequence_spec_within #53.
+-/
+theorem evm_mload_public_one_limb_sequence_spec_within
+    {n0 n1 n2 n3 : Nat} {P0 P1 P2 P3 P4 : Assertion}
+    (offReg byteReg accReg addrReg memBaseReg : Reg) (base : Word)
+    (h0 :
+      cpsTripleWithin n0 (base + 8) (base + 100)
+        (evm_mload_code offReg byteReg accReg addrReg memBaseReg base) P0 P1)
+    (h1 :
+      cpsTripleWithin n1 (base + 100) (base + 192)
+        (evm_mload_code offReg byteReg accReg addrReg memBaseReg base) P1 P2)
+    (h2 :
+      cpsTripleWithin n2 (base + 192) (base + 284)
+        (evm_mload_code offReg byteReg accReg addrReg memBaseReg base) P2 P3)
+    (h3 :
+      cpsTripleWithin n3 (base + 284) (base + 376)
+        (evm_mload_code offReg byteReg accReg addrReg memBaseReg base) P3 P4) :
+    cpsTripleWithin (n0 + n1 + n2 + n3) (base + 8) (base + 376)
+      (evm_mload_code offReg byteReg accReg addrReg memBaseReg base) P0 P4 := by
+  exact cpsTripleWithin_seq_same_cr
+    (cpsTripleWithin_seq_same_cr
+      (cpsTripleWithin_seq_same_cr h0 h1)
+      h2)
+    h3
+
+/--
 Sibling-framed q0 stack spec: `evm_mload_unaligned_one_limb_q0_stack_spec_within`
 with an arbitrary `pcFree` assertion `F` framed on both pre and post.
 

--- a/EvmAsm/Evm64/MStore/UnalignedFramedStackSpec.lean
+++ b/EvmAsm/Evm64/MStore/UnalignedFramedStackSpec.lean
@@ -321,6 +321,39 @@ theorem cpsTripleWithin_evm_mstore_of_one_limb_q3
       offReg valReg byteReg accReg addrReg memBaseReg base)
 
 /--
+Compose four public-code MSTORE one-limb triples into a single q0..q3 body
+triple over `evm_mstore_code`.
+
+This is the public-code counterpart of `mstore_one_limb_sequence_spec_within`:
+callers that already transported each quarter to `evm_mstore_code` can sequence
+them without returning to the smaller `mstoreFourLimbsCode` surface.
+
+Distinctive token: evm_mstore_public_one_limb_sequence_spec_within #53.
+-/
+theorem evm_mstore_public_one_limb_sequence_spec_within
+    {n0 n1 n2 n3 : Nat} {P0 P1 P2 P3 P4 : Assertion}
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg) (base : Word)
+    (h0 :
+      cpsTripleWithin n0 (base + 8) (base + 76)
+        (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base) P0 P1)
+    (h1 :
+      cpsTripleWithin n1 (base + 76) (base + 144)
+        (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base) P1 P2)
+    (h2 :
+      cpsTripleWithin n2 (base + 144) (base + 212)
+        (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base) P2 P3)
+    (h3 :
+      cpsTripleWithin n3 (base + 212) (base + 280)
+        (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base) P3 P4) :
+    cpsTripleWithin (n0 + n1 + n2 + n3) (base + 8) (base + 280)
+      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base) P0 P4 := by
+  exact cpsTripleWithin_seq_same_cr
+    (cpsTripleWithin_seq_same_cr
+      (cpsTripleWithin_seq_same_cr h0 h1)
+      h2)
+    h3
+
+/--
 Sibling-framed q0 stack spec: `evm_mstore_unaligned_one_limb_q0_stack_spec_within`
 with an arbitrary `pcFree` assertion `F` framed on both pre and post.
 


### PR DESCRIPTION
## Summary
- add a public-code q0..q3 sequence helper for MLOAD over evm_mload_code
- add a public-code q0..q3 sequence helper for MSTORE over evm_mstore_code
- stack this sequencing layer on top of #3158 for full-stack MLOAD/MSTORE composition work

## Stack
- Base PR: #3158
- Previous PRs: #3157, #3156, #3155, #3154, #3153, #3152, #3151, #3150, #3149, #3148, #3147, #3145, #3144, #3143

## Tests
- lake build EvmAsm.Evm64.MLoad.UnalignedFramedStackSpec EvmAsm.Evm64.MStore.UnalignedFramedStackSpec