### PR TITLE
chore(shake): noshake MLoad/MStore UnalignedFramedStackSpec false positives

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -126,6 +126,10 @@
   ["Std.Tactic.BVDecide", "Mathlib.Tactic.IntervalCases"],
  "EvmAsm.Evm64.MStore.StackSpec":
   ["EvmAsm.Evm64.MStore.CombinedSequenceSpec"],
+ "EvmAsm.Evm64.MStore.UnalignedFramedStackSpec":
+  ["EvmAsm.Evm64.MStore.UnalignedStackSpec"],
+ "EvmAsm.Evm64.MLoad.UnalignedFramedStackSpec":
+  ["EvmAsm.Evm64.MLoad.UnalignedStackSpec"],
  "EvmAsm.Evm64.MLoad.ByteAlg":
   ["EvmAsm.Rv64.Basic", "Std.Tactic.BVDecide"],
  "EvmAsm.Evm64.SpAddr":


### PR DESCRIPTION
## Summary

`lake exe shake EvmAsm` flags `EvmAsm/Evm64/MLoad/UnalignedFramedStackSpec.lean` and `EvmAsm/Evm64/MStore/UnalignedFramedStackSpec.lean` for dropping their `UnalignedStackSpec` import, but those imports supply the `evm_m{load,store}_unaligned_one_limb_q{0..3}_stack_spec_within` lemmas used in each file's four `have core := ...` invocations. Verified by experiment (swapped to the next lower dep, `lake build` failed).

Adds `noshake.json` entries for both modules so the standard `scripts/shake-filter.py` post-processor drops these blocks alongside the other documented false positives. After this change, `lake exe shake EvmAsm | shake-filter.py` reports only the two EL ResultBridge blocks already addressed by PR #3146.

Refs evm-asm-in1tk / parent evm-asm-6qj / GH #1045.

## Tests
- `lake build`
- `lake exe shake EvmAsm | scripts/shake-filter.py` — 2 blocks kept (the EL ResultBridge ones, addressed in #3146); 44 dropped.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).