### PR TITLE
feat(evm64): add public prologue quarter perm specs

### DIFF
--- a/EvmAsm/Evm64/MLoad/UnalignedFramedStackSpec.lean
+++ b/EvmAsm/Evm64/MLoad/UnalignedFramedStackSpec.lean
@@ -529,6 +529,58 @@ theorem evm_mload_public_one_limb_sequence_with_prologue_framed
       offReg byteReg accReg addrReg memBaseReg base h0 h1 h2 h3)
 
 /--
+Compose the framed MLOAD prologue with a permutation-aware public-code q0..q3
+one-limb sequence.
+
+This is the concrete-compose entry point for quarter specs whose intermediate
+postconditions need `sep_perm`/weakening callbacks before the next quarter.
+
+Distinctive token:
+evm_mload_public_one_limb_sequence_with_prologue_framed_perm #53.
+-/
+theorem evm_mload_public_one_limb_sequence_with_prologue_framed_perm
+    {n0 n1 n2 n3 : Nat}
+    {P1 P1' P2 P2' P3 P3' Q : Assertion}
+    (offReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset offOld addrOld memBase : Word) (base : Word)
+    (F : Assertion) (hF : F.pcFree)
+    (h_off_ne_x0 : offReg ≠ .x0)
+    (h_addr_ne_x0 : addrReg ≠ .x0)
+    (h0 :
+      cpsTripleWithin n0 (base + 8) (base + 100)
+        (evm_mload_code offReg byteReg accReg addrReg memBaseReg base)
+        ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+          (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+          (sp ↦ₘ offset)) ** F)
+        P1)
+    (h01 : ∀ s, P1 s → P1' s)
+    (h1 :
+      cpsTripleWithin n1 (base + 100) (base + 192)
+        (evm_mload_code offReg byteReg accReg addrReg memBaseReg base) P1' P2)
+    (h12 : ∀ s, P2 s → P2' s)
+    (h2 :
+      cpsTripleWithin n2 (base + 192) (base + 284)
+        (evm_mload_code offReg byteReg accReg addrReg memBaseReg base) P2' P3)
+    (h23 : ∀ s, P3 s → P3' s)
+    (h3 :
+      cpsTripleWithin n3 (base + 284) (base + 376)
+        (evm_mload_code offReg byteReg accReg addrReg memBaseReg base) P3' Q) :
+    cpsTripleWithin (2 + (n0 + n1 + n2 + n3)) base (base + 376)
+      (evm_mload_code offReg byteReg accReg addrReg memBaseReg base)
+      ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offOld) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ addrOld) **
+        (sp ↦ₘ offset)) ** F)
+      Q := by
+  exact cpsTripleWithin_seq_same_cr
+    (evm_mload_prologue_stack_spec_within_framed
+      offReg byteReg accReg addrReg memBaseReg
+      sp offset offOld addrOld memBase base F hF
+      h_off_ne_x0 h_addr_ne_x0)
+    (evm_mload_public_one_limb_sequence_spec_within_perm
+      offReg byteReg accReg addrReg memBaseReg base
+      h0 h01 h1 h12 h2 h23 h3)
+
+/--
 Generic public-code MLOAD prologue/body composition with a framed prologue.
 
 This lets callers plug in any body triple over `evm_mload_code` that starts

--- a/EvmAsm/Evm64/MStore/UnalignedFramedStackSpec.lean
+++ b/EvmAsm/Evm64/MStore/UnalignedFramedStackSpec.lean
@@ -528,6 +528,58 @@ theorem evm_mstore_public_one_limb_sequence_with_prologue_framed
       offReg valReg byteReg accReg addrReg memBaseReg base h0 h1 h2 h3)
 
 /--
+Compose the framed MSTORE prologue with a permutation-aware public-code q0..q3
+one-limb sequence.
+
+This is the concrete-compose entry point for quarter specs whose intermediate
+postconditions need `sep_perm`/weakening callbacks before the next quarter.
+
+Distinctive token:
+evm_mstore_public_one_limb_sequence_with_prologue_framed_perm #53.
+-/
+theorem evm_mstore_public_one_limb_sequence_with_prologue_framed_perm
+    {n0 n1 n2 n3 : Nat}
+    {P1 P1' P2 P2' P3 P3' Q : Assertion}
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset offOld addrOld memBase : Word) (base : Word)
+    (F : Assertion) (hF : F.pcFree)
+    (h_off_ne_x0 : offReg ≠ .x0)
+    (h_addr_ne_x0 : addrReg ≠ .x0)
+    (h0 :
+      cpsTripleWithin n0 (base + 8) (base + 76)
+        (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base)
+        ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+          (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+          (sp ↦ₘ offset)) ** F)
+        P1)
+    (h01 : ∀ s, P1 s → P1' s)
+    (h1 :
+      cpsTripleWithin n1 (base + 76) (base + 144)
+        (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base) P1' P2)
+    (h12 : ∀ s, P2 s → P2' s)
+    (h2 :
+      cpsTripleWithin n2 (base + 144) (base + 212)
+        (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base) P2' P3)
+    (h23 : ∀ s, P3 s → P3' s)
+    (h3 :
+      cpsTripleWithin n3 (base + 212) (base + 280)
+        (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base) P3' Q) :
+    cpsTripleWithin (2 + (n0 + n1 + n2 + n3)) base (base + 280)
+      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base)
+      ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offOld) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ addrOld) **
+        (sp ↦ₘ offset)) ** F)
+      Q := by
+  exact cpsTripleWithin_seq_same_cr
+    (evm_mstore_prologue_stack_spec_within_framed
+      offReg valReg byteReg accReg addrReg memBaseReg
+      sp offset offOld addrOld memBase base F hF
+      h_off_ne_x0 h_addr_ne_x0)
+    (evm_mstore_public_one_limb_sequence_spec_within_perm
+      offReg valReg byteReg accReg addrReg memBaseReg base
+      h0 h01 h1 h12 h2 h23 h3)
+
+/--
 Generic public-code MSTORE prologue/body composition with a framed prologue.
 
 This lets callers plug in any body triple over `evm_mstore_code` that starts


### PR DESCRIPTION
## Summary
- add framed-prologue plus permutation-aware q0..q3 sequence helper for MLOAD
- add the symmetric framed-prologue plus permutation-aware q0..q3 sequence helper for MSTORE
- provide a direct composition entry point for full unaligned quarter proofs that need sep-permutation callbacks between quarters

## Stack
- Base PR: #3166
- Previous PRs: #3165, #3164, #3162, #3161, #3160, #3159, #3158, #3157, #3156, #3155, #3154, #3153, #3152, #3151, #3150, #3149, #3148, #3147, #3145, #3144, #3143

## Tests
- lake build EvmAsm.Evm64.MLoad.UnalignedFramedStackSpec EvmAsm.Evm64.MStore.UnalignedFramedStackSpec
- scripts/check-file-size.sh --report