### PR TITLE
feat(mload): add unaligned public full compose spec

### DIFF
--- a/EvmAsm/Evm64/MLoad/UnalignedFramedStackSpec.lean
+++ b/EvmAsm/Evm64/MLoad/UnalignedFramedStackSpec.lean
@@ -979,4 +979,136 @@ theorem evm_mload_unaligned_one_limb_q3_spec_within_framed_public_code
       loAddr3 hiAddr3 loVal3 hiVal3 start dstOld base F hF
       h_byte_ne_x0 h_acc_ne_x0 h_window)
 
+/--
+Concrete public-code composition of the four unaligned MLOAD quarter specs.
+
+The theorem instantiates q0..q3 with sibling frames that thread the remaining
+destination stack cells and byte-window cells, then uses `sep_perm` at each
+midpoint.
+
+Distinctive token: evm_mload_unaligned_full_stack_spec_within_public #53.
+-/
+theorem evm_mload_unaligned_full_stack_spec_within_public
+    (offReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset offOld addrOld memBase byteOld accOld : Word)
+    (dstOld1 dstOld2 dstOld3 : Word)
+    (loAddr0 hiAddr0 loVal0 hiVal0 : Word)
+    (loAddr1 hiAddr1 loVal1 hiVal1 : Word)
+    (loAddr2 hiAddr2 loVal2 hiVal2 : Word)
+    (loAddr3 hiAddr3 loVal3 hiVal3 : Word)
+    (start : Nat) (base : Word)
+    (h_off_ne_x0 : offReg ≠ .x0)
+    (h_addr_ne_x0 : addrReg ≠ .x0)
+    (h_byte_ne_x0 : byteReg ≠ .x0)
+    (h_acc_ne_x0 : accReg ≠ .x0)
+    (h_window0 : mloadLimbWindowOk (memBase + offset) loAddr0 hiAddr0 start
+                  24 25 26 27 28 29 30 31)
+    (h_window1 : mloadLimbWindowOk (memBase + offset) loAddr1 hiAddr1 start
+                  16 17 18 19 20 21 22 23)
+    (h_window2 : mloadLimbWindowOk (memBase + offset) loAddr2 hiAddr2 start
+                  8 9 10 11 12 13 14 15)
+    (h_window3 : mloadLimbWindowOk (memBase + offset) loAddr3 hiAddr3 start
+                  0 1 2 3 4 5 6 7) :
+    let loaded0 := mloadPackedLimbFromDwordPair loVal0 hiVal0 start
+    let loaded1 := mloadPackedLimbFromDwordPair loVal1 hiVal1 start
+    let loaded2 := mloadPackedLimbFromDwordPair loVal2 hiVal2 start
+    let loaded3 := mloadPackedLimbFromDwordPair loVal3 hiVal3 start
+    cpsTripleWithin (2 + (23 + 23 + 23 + 23)) base (base + 376)
+      (evm_mload_code offReg byteReg accReg addrReg memBaseReg base)
+      ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offOld) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ addrOld) **
+        (sp ↦ₘ offset)) **
+       ((byteReg ↦ᵣ byteOld) ** (accReg ↦ᵣ accOld) **
+        (sp + 8 ↦ₘ dstOld1) ** (sp + 16 ↦ₘ dstOld2) **
+        (sp + 24 ↦ₘ dstOld3) **
+        (loAddr0 ↦ₘ loVal0) ** (hiAddr0 ↦ₘ hiVal0) **
+        (loAddr1 ↦ₘ loVal1) ** (hiAddr1 ↦ₘ hiVal1) **
+        (loAddr2 ↦ₘ loVal2) ** (hiAddr2 ↦ₘ hiVal2) **
+        (loAddr3 ↦ₘ loVal3) ** (hiAddr3 ↦ₘ hiVal3)))
+      ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+        (sp ↦ₘ loaded0) ** (sp + 8 ↦ₘ loaded1) **
+        (sp + 16 ↦ₘ loaded2) ** (sp + 24 ↦ₘ loaded3) **
+        ((byteReg ↦ᵣ
+           (mloadByteFromDwordPair loVal3 hiVal3 start 7).zeroExtend 64) **
+         (accReg ↦ᵣ loaded3) **
+         (loAddr3 ↦ₘ loVal3) ** (hiAddr3 ↦ₘ hiVal3))) **
+       ((loAddr0 ↦ₘ loVal0) ** (hiAddr0 ↦ₘ hiVal0) **
+        (loAddr1 ↦ₘ loVal1) ** (hiAddr1 ↦ₘ hiVal1) **
+        (loAddr2 ↦ₘ loVal2) ** (hiAddr2 ↦ₘ hiVal2))) := by
+  let Fpre : Assertion :=
+    (byteReg ↦ᵣ byteOld) ** (accReg ↦ᵣ accOld) **
+    (sp + 8 ↦ₘ dstOld1) ** (sp + 16 ↦ₘ dstOld2) **
+    (sp + 24 ↦ₘ dstOld3) **
+    (loAddr0 ↦ₘ loVal0) ** (hiAddr0 ↦ₘ hiVal0) **
+    (loAddr1 ↦ₘ loVal1) ** (hiAddr1 ↦ₘ hiVal1) **
+    (loAddr2 ↦ₘ loVal2) ** (hiAddr2 ↦ₘ hiVal2) **
+    (loAddr3 ↦ₘ loVal3) ** (hiAddr3 ↦ₘ hiVal3)
+  let loaded0 := mloadPackedLimbFromDwordPair loVal0 hiVal0 start
+  let loaded1 := mloadPackedLimbFromDwordPair loVal1 hiVal1 start
+  let loaded2 := mloadPackedLimbFromDwordPair loVal2 hiVal2 start
+  let byte0 := (mloadByteFromDwordPair loVal0 hiVal0 start 7).zeroExtend 64
+  let byte1 := (mloadByteFromDwordPair loVal1 hiVal1 start 7).zeroExtend 64
+  let byte2 := (mloadByteFromDwordPair loVal2 hiVal2 start 7).zeroExtend 64
+  let F0 : Assertion :=
+    (sp + 8 ↦ₘ dstOld1) ** (sp + 16 ↦ₘ dstOld2) **
+    (sp + 24 ↦ₘ dstOld3) **
+    (loAddr1 ↦ₘ loVal1) ** (hiAddr1 ↦ₘ hiVal1) **
+    (loAddr2 ↦ₘ loVal2) ** (hiAddr2 ↦ₘ hiVal2) **
+    (loAddr3 ↦ₘ loVal3) ** (hiAddr3 ↦ₘ hiVal3)
+  let F1 : Assertion :=
+    (loAddr0 ↦ₘ loVal0) ** (hiAddr0 ↦ₘ hiVal0) **
+    (sp + 16 ↦ₘ dstOld2) ** (sp + 24 ↦ₘ dstOld3) **
+    (loAddr2 ↦ₘ loVal2) ** (hiAddr2 ↦ₘ hiVal2) **
+    (loAddr3 ↦ₘ loVal3) ** (hiAddr3 ↦ₘ hiVal3)
+  let F2 : Assertion :=
+    (loAddr0 ↦ₘ loVal0) ** (hiAddr0 ↦ₘ hiVal0) **
+    (loAddr1 ↦ₘ loVal1) ** (hiAddr1 ↦ₘ hiVal1) **
+    (sp + 24 ↦ₘ dstOld3) **
+    (loAddr3 ↦ₘ loVal3) ** (hiAddr3 ↦ₘ hiVal3)
+  let F3 : Assertion :=
+    (loAddr0 ↦ₘ loVal0) ** (hiAddr0 ↦ₘ hiVal0) **
+    (loAddr1 ↦ₘ loVal1) ** (hiAddr1 ↦ₘ hiVal1) **
+    (loAddr2 ↦ₘ loVal2) ** (hiAddr2 ↦ₘ hiVal2)
+  dsimp only
+  exact cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by
+      dsimp only [Fpre, F0] at hp ⊢
+      sep_perm hp)
+    (evm_mload_prologue_stack_spec_within_framed
+      offReg byteReg accReg addrReg memBaseReg
+      sp offset offOld addrOld memBase base Fpre (by pcFree)
+      h_off_ne_x0 h_addr_ne_x0)
+    (evm_mload_public_one_limb_sequence_spec_within_perm
+      offReg byteReg accReg addrReg memBaseReg base
+      (evm_mload_unaligned_one_limb_q0_spec_within_framed_public_code
+        offReg byteReg accReg addrReg memBaseReg
+        sp offset memBase byteOld accOld
+        loAddr0 hiAddr0 loVal0 hiVal0 start base F0 (by pcFree)
+        h_byte_ne_x0 h_acc_ne_x0 h_window0)
+      (fun _ hp => by
+        dsimp only [F0, F1, loaded0, byte0] at hp ⊢
+        sep_perm hp)
+      (evm_mload_unaligned_one_limb_q1_spec_within_framed_public_code
+        offReg byteReg accReg addrReg memBaseReg
+        sp offset memBase byte0 loaded0 loaded0
+        loAddr1 hiAddr1 loVal1 hiVal1 start dstOld1 base F1 (by pcFree)
+        h_byte_ne_x0 h_acc_ne_x0 h_window1)
+      (fun _ hp => by
+        dsimp only [F1, F2, loaded1, byte1] at hp ⊢
+        sep_perm hp)
+      (evm_mload_unaligned_one_limb_q2_spec_within_framed_public_code
+        offReg byteReg accReg addrReg memBaseReg
+        sp offset memBase byte1 loaded1 loaded0 loaded1
+        loAddr2 hiAddr2 loVal2 hiVal2 start dstOld2 base F2 (by pcFree)
+        h_byte_ne_x0 h_acc_ne_x0 h_window2)
+      (fun _ hp => by
+        dsimp only [F2, F3, loaded2, byte2] at hp ⊢
+        sep_perm hp)
+      (evm_mload_unaligned_one_limb_q3_spec_within_framed_public_code
+        offReg byteReg accReg addrReg memBaseReg
+        sp offset memBase byte2 loaded2 loaded0 loaded1 loaded2
+        loAddr3 hiAddr3 loVal3 hiVal3 start dstOld3 base F3 (by pcFree)
+        h_byte_ne_x0 h_acc_ne_x0 h_window3))
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- compose the concrete public q0..q3 unaligned MLOAD quarter specs after the framed prologue
- thread loaded limbs, destination slots, and byte-window cells through sibling frames
- advance bead evm-asm-75z1x toward the topmost MLOAD stack spec

## Stack
- Base PR: #3168
- Previous PRs: #3167, #3166, #3165, #3164, #3162, #3161, #3160, #3159, #3158, #3157, #3156, #3155, #3154, #3153, #3152, #3151, #3150, #3149, #3148, #3147, #3145, #3144, #3143

## Tests
- lake build EvmAsm.Evm64.MLoad.UnalignedFramedStackSpec
- scripts/check-file-size.sh --report