### PR TITLE
chore: drop unused InputBridge imports in 5 BLS12/BN254 ResultBridge files

### DIFF
--- a/EvmAsm/EL/Bls12G1AddResultBridge.lean
+++ b/EvmAsm/EL/Bls12G1AddResultBridge.lean
@@ -6,14 +6,14 @@
 -/
 
 import EvmAsm.Evm64.Accelerators.Status
-import EvmAsm.EL.Bls12G1AddInputBridge
+import EvmAsm.EL.WorldState
 
 namespace EvmAsm.EL
 
 namespace Bls12G1AddResultBridge
 
 abbrev ZkvmStatus := EvmAsm.Accelerators.ZkvmStatus
-abbrev G1PointBytes := Bls12G1AddInputBridge.G1PointBytes
+abbrev G1PointBytes := Fin 96 → Byte
 
 /-- Accelerator output payload for `zkvm_bls12_g1_add`. -/
 structure AcceleratorOutput where

--- a/EvmAsm/EL/Bls12G1MsmResultBridge.lean
+++ b/EvmAsm/EL/Bls12G1MsmResultBridge.lean
@@ -6,14 +6,14 @@
 -/
 
 import EvmAsm.Evm64.Accelerators.Status
-import EvmAsm.EL.Bls12G1MsmInputBridge
+import EvmAsm.EL.WorldState
 
 namespace EvmAsm.EL
 
 namespace Bls12G1MsmResultBridge
 
 abbrev ZkvmStatus := EvmAsm.Accelerators.ZkvmStatus
-abbrev G1PointBytes := Bls12G1MsmInputBridge.G1PointBytes
+abbrev G1PointBytes := Fin 96 → Byte
 
 /-- Accelerator output payload for `zkvm_bls12_g1_msm`. -/
 structure AcceleratorOutput where

--- a/EvmAsm/EL/Bls12G2AddResultBridge.lean
+++ b/EvmAsm/EL/Bls12G2AddResultBridge.lean
@@ -6,14 +6,14 @@
 -/
 
 import EvmAsm.Evm64.Accelerators.Status
-import EvmAsm.EL.Bls12G2AddInputBridge
+import EvmAsm.EL.WorldState
 
 namespace EvmAsm.EL
 
 namespace Bls12G2AddResultBridge
 
 abbrev ZkvmStatus := EvmAsm.Accelerators.ZkvmStatus
-abbrev G2PointBytes := Bls12G2AddInputBridge.G2PointBytes
+abbrev G2PointBytes := Fin 192 → Byte
 
 /-- Accelerator output payload for `zkvm_bls12_g2_add`. -/
 structure AcceleratorOutput where

--- a/EvmAsm/EL/Bls12G2MsmResultBridge.lean
+++ b/EvmAsm/EL/Bls12G2MsmResultBridge.lean
@@ -6,14 +6,14 @@
 -/
 
 import EvmAsm.Evm64.Accelerators.Status
-import EvmAsm.EL.Bls12G2MsmInputBridge
+import EvmAsm.EL.WorldState
 
 namespace EvmAsm.EL
 
 namespace Bls12G2MsmResultBridge
 
 abbrev ZkvmStatus := EvmAsm.Accelerators.ZkvmStatus
-abbrev G2PointBytes := Bls12G2MsmInputBridge.G2PointBytes
+abbrev G2PointBytes := Fin 192 → Byte
 
 /-- Accelerator output payload for `zkvm_bls12_g2_msm`. -/
 structure AcceleratorOutput where

--- a/EvmAsm/EL/Bn254G1MulResultBridge.lean
+++ b/EvmAsm/EL/Bn254G1MulResultBridge.lean
@@ -6,14 +6,14 @@
 -/
 
 import EvmAsm.Evm64.Accelerators.Status
-import EvmAsm.EL.Bn254G1MulInputBridge
+import EvmAsm.EL.WorldState
 
 namespace EvmAsm.EL
 
 namespace Bn254G1MulResultBridge
 
 abbrev ZkvmStatus := EvmAsm.Accelerators.ZkvmStatus
-abbrev G1PointBytes := Bn254G1MulInputBridge.G1PointBytes
+abbrev G1PointBytes := Fin 64 → Byte
 
 /-- Accelerator output payload for `zkvm_bn254_g1_mul`. -/
 structure AcceleratorOutput where


### PR DESCRIPTION
Mirrors #3146 for the remaining BLS12/BN254 ResultBridge files. Each only used `Byte` (from `EL.WorldState`), not the full `InputBridge` module — the `GNPointBytes` alias is inlined to `Fin N → Byte`.

Files touched:
- `EvmAsm/EL/Bls12G1AddResultBridge.lean`
- `EvmAsm/EL/Bls12G1MsmResultBridge.lean`
- `EvmAsm/EL/Bls12G2AddResultBridge.lean`
- `EvmAsm/EL/Bls12G2MsmResultBridge.lean`
- `EvmAsm/EL/Bn254G1MulResultBridge.lean`

Verified no external consumers of `<Result>.GNPointBytes` (only the result bridge itself uses the alias). Flagged by `lake exe shake EvmAsm`. `lake build` passes.

Refs evm-asm-yasef / GH #1045.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).