### PR TITLE
feat(mload): add stack output post fold

### DIFF
--- a/EvmAsm/Evm64/MLoad/StackSpec.lean
+++ b/EvmAsm/Evm64/MLoad/StackSpec.lean
@@ -1150,6 +1150,22 @@ theorem mloadStackOutputPost_evmWordIs_fold
   rw [mloadStackOutputWordFromDwordPairs_eq_mloadLoadedWordFromDwordPairs]
   rw [mloadLoadedWordFromDwordPairs_evmWordIs_fold]
 
+theorem mloadStackOutputPost_evmStackIs_fold
+    (sp : Word)
+    (lo0 hi0 : Word) (start0 : Nat)
+    (lo1 hi1 : Word) (start1 : Nat)
+    (lo2 hi2 : Word) (start2 : Nat)
+    (lo3 hi3 : Word) (start3 : Nat)
+    (rest : List EvmWord) :
+    (mloadStackOutputPost sp
+      lo0 hi0 start0 lo1 hi1 start1 lo2 hi2 start2 lo3 hi3 start3 **
+      evmStackIs (sp + 32) rest) =
+    evmStackIs sp
+      (mloadStackOutputWordFromDwordPairs
+        lo0 hi0 start0 lo1 hi1 start1 lo2 hi2 start2 lo3 hi3 start3 :: rest) := by
+  rw [mloadStackOutputPost_unfold]
+  rfl
+
 /--
   The 256-bit value loaded by a 32-byte unaligned MLOAD window spanning five
   consecutive RV64 dwords. The single `start` byte offset applies to each

--- a/EvmAsm/Evm64/MLoad/UnalignedFramedStackSpec.lean
+++ b/EvmAsm/Evm64/MLoad/UnalignedFramedStackSpec.lean
@@ -1189,4 +1189,88 @@ theorem evm_mload_unaligned_full_stack_spec_within_public_folded
       h_off_ne_x0 h_addr_ne_x0 h_byte_ne_x0 h_acc_ne_x0
       h_window0 h_window1 h_window2 h_window3)
 
+/--
+Stack-tail variant of the folded public unaligned MLOAD composition.
+
+This frames a remaining EVM stack tail around the folded postcondition and
+folds the produced word plus tail into `evmStackIs`.
+
+Distinctive token:
+evm_mload_unaligned_full_stack_spec_within_public_stack_tail #53.
+-/
+theorem evm_mload_unaligned_full_stack_spec_within_public_stack_tail
+    (offReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset offOld addrOld memBase byteOld accOld : Word)
+    (dstOld1 dstOld2 dstOld3 : Word)
+    (loAddr0 hiAddr0 loVal0 hiVal0 : Word)
+    (loAddr1 hiAddr1 loVal1 hiVal1 : Word)
+    (loAddr2 hiAddr2 loVal2 hiVal2 : Word)
+    (loAddr3 hiAddr3 loVal3 hiVal3 : Word)
+    (start : Nat) (base : Word) (rest : List EvmWord)
+    (h_off_ne_x0 : offReg ≠ .x0)
+    (h_addr_ne_x0 : addrReg ≠ .x0)
+    (h_byte_ne_x0 : byteReg ≠ .x0)
+    (h_acc_ne_x0 : accReg ≠ .x0)
+    (h_window0 : mloadLimbWindowOk (memBase + offset) loAddr0 hiAddr0 start
+                  24 25 26 27 28 29 30 31)
+    (h_window1 : mloadLimbWindowOk (memBase + offset) loAddr1 hiAddr1 start
+                  16 17 18 19 20 21 22 23)
+    (h_window2 : mloadLimbWindowOk (memBase + offset) loAddr2 hiAddr2 start
+                  8 9 10 11 12 13 14 15)
+    (h_window3 : mloadLimbWindowOk (memBase + offset) loAddr3 hiAddr3 start
+                  0 1 2 3 4 5 6 7) :
+    let loaded3 := mloadPackedLimbFromDwordPair loVal3 hiVal3 start
+    cpsTripleWithin (2 + (23 + 23 + 23 + 23)) base (base + 376)
+      (evm_mload_code offReg byteReg accReg addrReg memBaseReg base)
+      (((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offOld) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ addrOld) **
+        (sp ↦ₘ offset)) **
+       ((byteReg ↦ᵣ byteOld) ** (accReg ↦ᵣ accOld) **
+        (sp + 8 ↦ₘ dstOld1) ** (sp + 16 ↦ₘ dstOld2) **
+        (sp + 24 ↦ₘ dstOld3) **
+        (loAddr0 ↦ₘ loVal0) ** (hiAddr0 ↦ₘ hiVal0) **
+        (loAddr1 ↦ₘ loVal1) ** (hiAddr1 ↦ₘ hiVal1) **
+        (loAddr2 ↦ₘ loVal2) ** (hiAddr2 ↦ₘ hiVal2) **
+        (loAddr3 ↦ₘ loVal3) ** (hiAddr3 ↦ₘ hiVal3))) **
+       evmStackIs (sp + 32) rest)
+      (evmStackIs sp
+        (mloadStackOutputWordFromDwordPairs
+          loVal0 hiVal0 start loVal1 hiVal1 start
+          loVal2 hiVal2 start loVal3 hiVal3 start :: rest) **
+       (((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+        (byteReg ↦ᵣ
+          (mloadByteFromDwordPair loVal3 hiVal3 start 7).zeroExtend 64) **
+        (accReg ↦ᵣ loaded3) **
+        (loAddr0 ↦ₘ loVal0) ** (hiAddr0 ↦ₘ hiVal0) **
+        (loAddr1 ↦ₘ loVal1) ** (hiAddr1 ↦ₘ hiVal1) **
+        (loAddr2 ↦ₘ loVal2) ** (hiAddr2 ↦ₘ hiVal2) **
+        (loAddr3 ↦ₘ loVal3) ** (hiAddr3 ↦ₘ hiVal3))) := by
+  dsimp only
+  have hCore :=
+    cpsTripleWithin_frameR (evmStackIs (sp + 32) rest) (by pcFree)
+      (evm_mload_unaligned_full_stack_spec_within_public_folded
+        offReg byteReg accReg addrReg memBaseReg
+        sp offset offOld addrOld memBase byteOld accOld
+        dstOld1 dstOld2 dstOld3
+        loAddr0 hiAddr0 loVal0 hiVal0
+        loAddr1 hiAddr1 loVal1 hiVal1
+        loAddr2 hiAddr2 loVal2 hiVal2
+        loAddr3 hiAddr3 loVal3 hiVal3
+        start base
+        h_off_ne_x0 h_addr_ne_x0 h_byte_ne_x0 h_acc_ne_x0
+        h_window0 h_window1 h_window2 h_window3)
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by sep_perm hp)
+    (fun _ hp => by
+      rw [← mloadStackOutputPost_evmStackIs_fold
+        sp
+        loVal0 hiVal0 start
+        loVal1 hiVal1 start
+        loVal2 hiVal2 start
+        loVal3 hiVal3 start
+        rest]
+      sep_perm hp)
+    hCore
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/MStore/UnalignedFramedStackSpec.lean
+++ b/EvmAsm/Evm64/MStore/UnalignedFramedStackSpec.lean
@@ -23,6 +23,7 @@
 
 import EvmAsm.Evm64.MStore.StackSpec
 import EvmAsm.Evm64.MStore.UnalignedStackSpec
+import EvmAsm.Evm64.Stack
 
 namespace EvmAsm.Evm64
 
@@ -1204,5 +1205,86 @@ theorem evm_mstore_unaligned_full_stack_spec_within_public_epilogue
     (mstore_epilogue_evm_mstore_frame_spec_within
       offReg valReg byteReg accReg addrReg memBaseReg sp base
       FPost (by pcFree))
+
+/--
+Stack-tail variant of the public unaligned MSTORE epilogue composition.
+
+This frames the remaining EVM stack tail at `sp + 64`, matching MSTORE's
+two-word stack pop after the epilogue advances `.x12`.
+
+Distinctive token:
+evm_mstore_unaligned_full_stack_spec_within_public_stack_tail #53.
+-/
+theorem evm_mstore_unaligned_full_stack_spec_within_public_stack_tail
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset offOld addrOld memBase byteOld accOld : Word)
+    (limb0 limb1 limb2 limb3 : Word)
+    (loAddr0 hiAddr0 loVal0 hiVal0 : Word)
+    (loAddr1 hiAddr1 loVal1 hiVal1 : Word)
+    (loAddr2 hiAddr2 loVal2 hiVal2 : Word)
+    (loAddr3 hiAddr3 loVal3 hiVal3 : Word)
+    (start : Nat) (base : Word) (rest : List EvmWord)
+    (h_off_ne_x0 : offReg ≠ .x0)
+    (h_addr_ne_x0 : addrReg ≠ .x0)
+    (h_byte_ne_x0 : byteReg ≠ .x0)
+    (h_acc_ne_x0 : accReg ≠ .x0)
+    (h_window0 : mstoreLimbWindowOk (memBase + offset) loAddr0 hiAddr0 start
+                  24 25 26 27 28 29 30 31)
+    (h_window1 : mstoreLimbWindowOk (memBase + offset) loAddr1 hiAddr1 start
+                  16 17 18 19 20 21 22 23)
+    (h_window2 : mstoreLimbWindowOk (memBase + offset) loAddr2 hiAddr2 start
+                  8 9 10 11 12 13 14 15)
+    (h_window3 : mstoreLimbWindowOk (memBase + offset) loAddr3 hiAddr3 start
+                  0 1 2 3 4 5 6 7) :
+    let stored0 := MStore.mstoreDwordPairStoreLimb loVal0 hiVal0 limb0 start
+    let stored1 := MStore.mstoreDwordPairStoreLimb loVal1 hiVal1 limb1 start
+    let stored2 := MStore.mstoreDwordPairStoreLimb loVal2 hiVal2 limb2 start
+    let stored3 := MStore.mstoreDwordPairStoreLimb loVal3 hiVal3 limb3 start
+    cpsTripleWithin (2 + (17 + 17 + 17 + 17) + 1) base (base + 284)
+      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base)
+      (((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offOld) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ addrOld) **
+        (sp ↦ₘ offset)) **
+       ((byteReg ↦ᵣ byteOld) ** (accReg ↦ᵣ accOld) **
+        (loAddr0 ↦ₘ loVal0) ** (hiAddr0 ↦ₘ hiVal0) **
+        ((sp + signExtend12 (32 : BitVec 12)) ↦ₘ limb0) **
+        (loAddr1 ↦ₘ loVal1) ** (hiAddr1 ↦ₘ hiVal1) **
+        ((sp + signExtend12 (40 : BitVec 12)) ↦ₘ limb1) **
+        (loAddr2 ↦ₘ loVal2) ** (hiAddr2 ↦ₘ hiVal2) **
+        ((sp + signExtend12 (48 : BitVec 12)) ↦ₘ limb2) **
+        (loAddr3 ↦ₘ loVal3) ** (hiAddr3 ↦ₘ hiVal3) **
+        ((sp + signExtend12 (56 : BitVec 12)) ↦ₘ limb3))) **
+       evmStackIs (sp + 64) rest)
+      (((.x12 : Reg) ↦ᵣ (sp + 64)) **
+       evmStackIs (sp + 64) rest **
+       ((offReg ↦ᵣ offset) ** (memBaseReg ↦ᵣ memBase) **
+        (addrReg ↦ᵣ (memBase + offset)) ** (sp ↦ₘ offset) **
+        (byteReg ↦ᵣ limb3) ** (accReg ↦ᵣ limb3) **
+        (loAddr3 ↦ₘ stored3.1) ** (hiAddr3 ↦ₘ stored3.2) **
+        ((sp + signExtend12 (56 : BitVec 12)) ↦ₘ limb3) **
+        (loAddr0 ↦ₘ stored0.1) ** (hiAddr0 ↦ₘ stored0.2) **
+        ((sp + signExtend12 (32 : BitVec 12)) ↦ₘ limb0) **
+        (loAddr1 ↦ₘ stored1.1) ** (hiAddr1 ↦ₘ stored1.2) **
+        ((sp + signExtend12 (40 : BitVec 12)) ↦ₘ limb1) **
+        (loAddr2 ↦ₘ stored2.1) ** (hiAddr2 ↦ₘ stored2.2) **
+        ((sp + signExtend12 (48 : BitVec 12)) ↦ₘ limb2))) := by
+  dsimp only
+  have hCore :=
+    cpsTripleWithin_frameR (evmStackIs (sp + 64) rest) (by pcFree)
+      (evm_mstore_unaligned_full_stack_spec_within_public_epilogue
+        offReg valReg byteReg accReg addrReg memBaseReg
+        sp offset offOld addrOld memBase byteOld accOld
+        limb0 limb1 limb2 limb3
+        loAddr0 hiAddr0 loVal0 hiVal0
+        loAddr1 hiAddr1 loVal1 hiVal1
+        loAddr2 hiAddr2 loVal2 hiVal2
+        loAddr3 hiAddr3 loVal3 hiVal3
+        start base
+        h_off_ne_x0 h_addr_ne_x0 h_byte_ne_x0 h_acc_ne_x0
+        h_window0 h_window1 h_window2 h_window3)
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by sep_perm hp)
+    (fun _ hp => by sep_perm hp)
+    hCore
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add the dword-pair mloadStackOutputPost to evmStackIs fold lemma
- mirror the existing five-dword stack-output fold shape
- prepare folded public MLOAD specs for downstream stack-tail consumers

## Stack
- Base PR: #3171
- Previous PRs: #3170, #3169, #3168, #3167, #3166, #3165, #3164, #3162, #3161, #3160, #3159, #3158, #3157, #3156, #3155, #3154, #3153, #3152, #3151, #3150, #3149, #3148, #3147, #3145, #3144, #3143

## Tests
- lake build EvmAsm.Evm64.MLoad.StackSpec
- scripts/check-file-size.sh --report