### PR TITLE
chore(shake): noshake EL ResultBridge → InputBridge false-positives

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -490,6 +490,8 @@
 "EvmAsm.Rv64.RLP.Phase3ShortString":
  ["EvmAsm.EL.RLP.ProgramSpec", "EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.XSimp"],
 "EvmAsm.EL.RLP.ReadLengthBridge": ["EvmAsm.EL.RLP.ReadLength"],
+"EvmAsm.EL.Secp256k1EcrecoverResultBridge": ["EvmAsm.EL.Secp256k1EcrecoverInputBridge"],
+"EvmAsm.EL.Bls12MapFp2ToG2ResultBridge": ["EvmAsm.EL.Bls12MapFp2ToG2InputBridge"],
 "EvmAsm.Evm64.Dispatch.Compose": ["EvmAsm.Evm64.Dispatch.EntryAddrBridge"],
 "EvmAsm.Evm64.Dispatch.Spec": ["EvmAsm.Evm64.Dispatch.Compose"],
 "EvmAsm.Evm64.DivMod.Compose.FullPath":


### PR DESCRIPTION
Suppresses two `lake exe shake EvmAsm` false positives:

- `EvmAsm.EL.Secp256k1EcrecoverResultBridge` → `EvmAsm.EL.Secp256k1EcrecoverInputBridge`
- `EvmAsm.EL.Bls12MapFp2ToG2ResultBridge` → `EvmAsm.EL.Bls12MapFp2ToG2InputBridge`

Both ResultBridge files use `Fin N → Byte` abbrevs, and `Byte` is reached through the sibling InputBridge (which imports KeccakInputBridge → Rv64.Basic). Shake suggested replacing the InputBridge import with WorldState, but neither file references WorldState; dropping the import breaks `Byte` resolution (verified locally: `error: Unknown identifier \`Byte\``).

Adds two entries to `scripts/noshake.json`. `lake build` green; `lake exe shake EvmAsm` no longer flags these two files.

Refs evm-asm-ma21s, parent evm-asm-9tq (#1045).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).