### PR TITLE
feat(mload): add public stack-pre spec

### DIFF
--- a/EvmAsm/Evm64/MLoad/UnalignedFramedStackSpec.lean
+++ b/EvmAsm/Evm64/MLoad/UnalignedFramedStackSpec.lean
@@ -1273,4 +1273,86 @@ theorem evm_mload_unaligned_full_stack_spec_within_public_stack_tail
       sep_perm hp)
     hCore
 
+/--
+Stack-pre variant of the public unaligned MLOAD stack-tail composition.
+
+This exposes the consumed offset word as an `evmStackIs` precondition while
+threading the remaining tail through the existing public stack-tail theorem.
+
+Distinctive token:
+evm_mload_unaligned_full_stack_spec_within_public_stack_pre #53.
+-/
+theorem evm_mload_unaligned_full_stack_spec_within_public_stack_pre
+    (offReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset offOld addrOld memBase byteOld accOld : Word)
+    (offsetWord : EvmWord) (rest : List EvmWord)
+    (dstOld1 dstOld2 dstOld3 : Word)
+    (loAddr0 hiAddr0 loVal0 hiVal0 : Word)
+    (loAddr1 hiAddr1 loVal1 hiVal1 : Word)
+    (loAddr2 hiAddr2 loVal2 hiVal2 : Word)
+    (loAddr3 hiAddr3 loVal3 hiVal3 : Word)
+    (start : Nat) (base : Word)
+    (h_offset0 : offsetWord.getLimbN 0 = offset)
+    (h_offset1 : offsetWord.getLimbN 1 = dstOld1)
+    (h_offset2 : offsetWord.getLimbN 2 = dstOld2)
+    (h_offset3 : offsetWord.getLimbN 3 = dstOld3)
+    (h_off_ne_x0 : offReg ≠ .x0)
+    (h_addr_ne_x0 : addrReg ≠ .x0)
+    (h_byte_ne_x0 : byteReg ≠ .x0)
+    (h_acc_ne_x0 : accReg ≠ .x0)
+    (h_window0 : mloadLimbWindowOk (memBase + offset) loAddr0 hiAddr0 start
+                  24 25 26 27 28 29 30 31)
+    (h_window1 : mloadLimbWindowOk (memBase + offset) loAddr1 hiAddr1 start
+                  16 17 18 19 20 21 22 23)
+    (h_window2 : mloadLimbWindowOk (memBase + offset) loAddr2 hiAddr2 start
+                  8 9 10 11 12 13 14 15)
+    (h_window3 : mloadLimbWindowOk (memBase + offset) loAddr3 hiAddr3 start
+                  0 1 2 3 4 5 6 7) :
+    let loaded3 := mloadPackedLimbFromDwordPair loVal3 hiVal3 start
+    cpsTripleWithin (2 + (23 + 23 + 23 + 23)) base (base + 376)
+      (evm_mload_code offReg byteReg accReg addrReg memBaseReg base)
+      (((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offOld) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ addrOld) **
+        evmStackIs sp (offsetWord :: rest)) **
+       ((byteReg ↦ᵣ byteOld) ** (accReg ↦ᵣ accOld) **
+        (loAddr0 ↦ₘ loVal0) ** (hiAddr0 ↦ₘ hiVal0) **
+        (loAddr1 ↦ₘ loVal1) ** (hiAddr1 ↦ₘ hiVal1) **
+        (loAddr2 ↦ₘ loVal2) ** (hiAddr2 ↦ₘ hiVal2) **
+        (loAddr3 ↦ₘ loVal3) ** (hiAddr3 ↦ₘ hiVal3))))
+      (evmStackIs sp
+        (mloadStackOutputWordFromDwordPairs
+          loVal0 hiVal0 start loVal1 hiVal1 start
+          loVal2 hiVal2 start loVal3 hiVal3 start :: rest) **
+       (((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+        (byteReg ↦ᵣ
+          (mloadByteFromDwordPair loVal3 hiVal3 start 7).zeroExtend 64) **
+        (accReg ↦ᵣ loaded3) **
+        (loAddr0 ↦ₘ loVal0) ** (hiAddr0 ↦ₘ hiVal0) **
+        (loAddr1 ↦ₘ loVal1) ** (hiAddr1 ↦ₘ hiVal1) **
+        (loAddr2 ↦ₘ loVal2) ** (hiAddr2 ↦ₘ hiVal2) **
+        (loAddr3 ↦ₘ loVal3) ** (hiAddr3 ↦ₘ hiVal3))) := by
+  dsimp only
+  have hCore :=
+    evm_mload_unaligned_full_stack_spec_within_public_stack_tail
+      offReg byteReg accReg addrReg memBaseReg
+      sp offset offOld addrOld memBase byteOld accOld
+      dstOld1 dstOld2 dstOld3
+      loAddr0 hiAddr0 loVal0 hiVal0
+      loAddr1 hiAddr1 loVal1 hiVal1
+      loAddr2 hiAddr2 loVal2 hiVal2
+      loAddr3 hiAddr3 loVal3 hiVal3
+      start base rest
+      h_off_ne_x0 h_addr_ne_x0 h_byte_ne_x0 h_acc_ne_x0
+      h_window0 h_window1 h_window2 h_window3
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by
+      rw [evmStackIs_cons] at hp
+      rw [evmWordIs_sp_limbs_eq sp offsetWord
+        offset dstOld1 dstOld2 dstOld3
+        h_offset0 h_offset1 h_offset2 h_offset3] at hp
+      sep_perm hp)
+    (fun _ hp => by sep_perm hp)
+    hCore
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add a public MLOAD stack-pre wrapper that accepts evmStackIs for the consumed offset word plus tail
- bridge the offset word limbs into the existing raw public stack-tail theorem

## Verification
- lake build EvmAsm.Evm64.MLoad.UnalignedFramedStackSpec
- scripts/check-file-size.sh --report