### PR TITLE
feat(memory): add canonical stack spec names

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/SDiv.lean
+++ b/EvmAsm/Evm64/EvmWordArith/SDiv.lean
@@ -61,6 +61,13 @@ theorem sdiv_intMin_neg_one : sdiv (BitVec.intMin 256) (-1) = BitVec.intMin 256 
   have h : (-1 : BitVec 256) = -1#256 := by decide
   rw [h, BitVec.intMin_sdiv_neg_one]
 
+-- Closed truncation examples used by the opcode-level edge-case suite.
+theorem sdiv_neg_one_two : sdiv (-1 : EvmWord) 2 = 0 := by
+  native_decide
+
+theorem sdiv_pos_neg_trunc : sdiv (7 : EvmWord) (-2) = (-3 : EvmWord) := by
+  native_decide
+
 -- ============================================================================
 -- Correctness vs `Int.tdiv` (the spec formula)
 -- ============================================================================

--- a/EvmAsm/Evm64/EvmWordArith/SMod.lean
+++ b/EvmAsm/Evm64/EvmWordArith/SMod.lean
@@ -56,6 +56,16 @@ theorem zero_smod_left {b : EvmWord} : smod 0 b = 0 := by
   · rfl
   · simp [BitVec.zero_srem]
 
+-- Closed sign-of-dividend examples used by the opcode-level edge-case suite.
+theorem smod_neg_pos_sign : smod (-3 : EvmWord) 2 = (-1 : EvmWord) := by
+  native_decide
+
+theorem smod_pos_neg_sign : smod (3 : EvmWord) (-2) = (1 : EvmWord) := by
+  native_decide
+
+theorem smod_neg_neg_sign : smod (-3 : EvmWord) (-2) = (-1 : EvmWord) := by
+  native_decide
+
 -- ============================================================================
 -- Correctness vs `Int.tmod` (the spec formula)
 -- ============================================================================

--- a/EvmAsm/Evm64/MLoad/UnalignedFramedStackSpec.lean
+++ b/EvmAsm/Evm64/MLoad/UnalignedFramedStackSpec.lean
@@ -1355,4 +1355,73 @@ theorem evm_mload_unaligned_full_stack_spec_within_public_stack_pre
     (fun _ hp => by sep_perm hp)
     hCore
 
+/--
+Canonical public MLOAD stack spec entry point.
+
+This aliases the full unaligned public stack-pre theorem under the conventional
+name used by the topmost-spec audit.
+-/
+theorem evm_mload_stack_spec_within
+    (offReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset offOld addrOld memBase byteOld accOld : Word)
+    (offsetWord : EvmWord) (rest : List EvmWord)
+    (dstOld1 dstOld2 dstOld3 : Word)
+    (loAddr0 hiAddr0 loVal0 hiVal0 : Word)
+    (loAddr1 hiAddr1 loVal1 hiVal1 : Word)
+    (loAddr2 hiAddr2 loVal2 hiVal2 : Word)
+    (loAddr3 hiAddr3 loVal3 hiVal3 : Word)
+    (start : Nat) (base : Word)
+    (h_offset0 : offsetWord.getLimbN 0 = offset)
+    (h_offset1 : offsetWord.getLimbN 1 = dstOld1)
+    (h_offset2 : offsetWord.getLimbN 2 = dstOld2)
+    (h_offset3 : offsetWord.getLimbN 3 = dstOld3)
+    (h_off_ne_x0 : offReg ≠ .x0)
+    (h_addr_ne_x0 : addrReg ≠ .x0)
+    (h_byte_ne_x0 : byteReg ≠ .x0)
+    (h_acc_ne_x0 : accReg ≠ .x0)
+    (h_window0 : mloadLimbWindowOk (memBase + offset) loAddr0 hiAddr0 start
+                  24 25 26 27 28 29 30 31)
+    (h_window1 : mloadLimbWindowOk (memBase + offset) loAddr1 hiAddr1 start
+                  16 17 18 19 20 21 22 23)
+    (h_window2 : mloadLimbWindowOk (memBase + offset) loAddr2 hiAddr2 start
+                  8 9 10 11 12 13 14 15)
+    (h_window3 : mloadLimbWindowOk (memBase + offset) loAddr3 hiAddr3 start
+                  0 1 2 3 4 5 6 7) :
+    let loaded3 := mloadPackedLimbFromDwordPair loVal3 hiVal3 start
+    cpsTripleWithin (2 + (23 + 23 + 23 + 23)) base (base + 376)
+      (evm_mload_code offReg byteReg accReg addrReg memBaseReg base)
+      (((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offOld) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ addrOld) **
+        evmStackIs sp (offsetWord :: rest)) **
+       ((byteReg ↦ᵣ byteOld) ** (accReg ↦ᵣ accOld) **
+        (loAddr0 ↦ₘ loVal0) ** (hiAddr0 ↦ₘ hiVal0) **
+        (loAddr1 ↦ₘ loVal1) ** (hiAddr1 ↦ₘ hiVal1) **
+        (loAddr2 ↦ₘ loVal2) ** (hiAddr2 ↦ₘ hiVal2) **
+        (loAddr3 ↦ₘ loVal3) ** (hiAddr3 ↦ₘ hiVal3))))
+      (evmStackIs sp
+        (mloadStackOutputWordFromDwordPairs
+          loVal0 hiVal0 start loVal1 hiVal1 start
+          loVal2 hiVal2 start loVal3 hiVal3 start :: rest) **
+       (((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+        (byteReg ↦ᵣ
+          (mloadByteFromDwordPair loVal3 hiVal3 start 7).zeroExtend 64) **
+        (accReg ↦ᵣ loaded3) **
+        (loAddr0 ↦ₘ loVal0) ** (hiAddr0 ↦ₘ hiVal0) **
+        (loAddr1 ↦ₘ loVal1) ** (hiAddr1 ↦ₘ hiVal1) **
+        (loAddr2 ↦ₘ loVal2) ** (hiAddr2 ↦ₘ hiVal2) **
+        (loAddr3 ↦ₘ loVal3) ** (hiAddr3 ↦ₘ hiVal3))) := by
+  exact evm_mload_unaligned_full_stack_spec_within_public_stack_pre
+    offReg byteReg accReg addrReg memBaseReg
+    sp offset offOld addrOld memBase byteOld accOld
+    offsetWord rest dstOld1 dstOld2 dstOld3
+    loAddr0 hiAddr0 loVal0 hiVal0
+    loAddr1 hiAddr1 loVal1 hiVal1
+    loAddr2 hiAddr2 loVal2 hiVal2
+    loAddr3 hiAddr3 loVal3 hiVal3
+    start base
+    h_offset0 h_offset1 h_offset2 h_offset3
+    h_off_ne_x0 h_addr_ne_x0 h_byte_ne_x0 h_acc_ne_x0
+    h_window0 h_window1 h_window2 h_window3
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/MStore/UnalignedFramedStackSpec.lean
+++ b/EvmAsm/Evm64/MStore/UnalignedFramedStackSpec.lean
@@ -1400,4 +1400,90 @@ theorem evm_mstore_unaligned_full_stack_spec_within_public_stack_pre
       sep_perm hp)
     hCore
 
+/--
+Canonical public MSTORE stack spec entry point.
+
+This aliases the full unaligned public stack-pre theorem under the conventional
+name used by the topmost-spec audit.
+-/
+theorem evm_mstore_stack_spec_within
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset offOld addrOld memBase byteOld accOld : Word)
+    (offsetWord valueWord : EvmWord) (rest : List EvmWord)
+    (offsetHigh1 offsetHigh2 offsetHigh3 : Word)
+    (limb0 limb1 limb2 limb3 : Word)
+    (loAddr0 hiAddr0 loVal0 hiVal0 : Word)
+    (loAddr1 hiAddr1 loVal1 hiVal1 : Word)
+    (loAddr2 hiAddr2 loVal2 hiVal2 : Word)
+    (loAddr3 hiAddr3 loVal3 hiVal3 : Word)
+    (start : Nat) (base : Word)
+    (h_offset0 : offsetWord.getLimbN 0 = offset)
+    (h_offset1 : offsetWord.getLimbN 1 = offsetHigh1)
+    (h_offset2 : offsetWord.getLimbN 2 = offsetHigh2)
+    (h_offset3 : offsetWord.getLimbN 3 = offsetHigh3)
+    (h_value0 : valueWord.getLimbN 0 = limb0)
+    (h_value1 : valueWord.getLimbN 1 = limb1)
+    (h_value2 : valueWord.getLimbN 2 = limb2)
+    (h_value3 : valueWord.getLimbN 3 = limb3)
+    (h_off_ne_x0 : offReg ≠ .x0)
+    (h_addr_ne_x0 : addrReg ≠ .x0)
+    (h_byte_ne_x0 : byteReg ≠ .x0)
+    (h_acc_ne_x0 : accReg ≠ .x0)
+    (h_window0 : mstoreLimbWindowOk (memBase + offset) loAddr0 hiAddr0 start
+                  24 25 26 27 28 29 30 31)
+    (h_window1 : mstoreLimbWindowOk (memBase + offset) loAddr1 hiAddr1 start
+                  16 17 18 19 20 21 22 23)
+    (h_window2 : mstoreLimbWindowOk (memBase + offset) loAddr2 hiAddr2 start
+                  8 9 10 11 12 13 14 15)
+    (h_window3 : mstoreLimbWindowOk (memBase + offset) loAddr3 hiAddr3 start
+                  0 1 2 3 4 5 6 7) :
+    let stored0 := MStore.mstoreDwordPairStoreLimb loVal0 hiVal0 limb0 start
+    let stored1 := MStore.mstoreDwordPairStoreLimb loVal1 hiVal1 limb1 start
+    let stored2 := MStore.mstoreDwordPairStoreLimb loVal2 hiVal2 limb2 start
+    let stored3 := MStore.mstoreDwordPairStoreLimb loVal3 hiVal3 limb3 start
+    cpsTripleWithin (2 + (17 + 17 + 17 + 17) + 1) base (base + 284)
+      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base)
+      (((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offOld) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ addrOld) **
+        evmStackIs sp (offsetWord :: valueWord :: rest)) **
+       ((byteReg ↦ᵣ byteOld) ** (accReg ↦ᵣ accOld) **
+        (loAddr0 ↦ₘ loVal0) ** (hiAddr0 ↦ₘ hiVal0) **
+        (loAddr1 ↦ₘ loVal1) ** (hiAddr1 ↦ₘ hiVal1) **
+        (loAddr2 ↦ₘ loVal2) ** (hiAddr2 ↦ₘ hiVal2) **
+        (loAddr3 ↦ₘ loVal3) ** (hiAddr3 ↦ₘ hiVal3))))
+      (((.x12 : Reg) ↦ᵣ (sp + 64)) **
+       evmStackIs (sp + 64) rest **
+       evmWordIs sp offsetWord ** evmWordIs (sp + 32) valueWord **
+       ((offReg ↦ᵣ offset) ** (memBaseReg ↦ᵣ memBase) **
+        (addrReg ↦ᵣ (memBase + offset)) **
+        (byteReg ↦ᵣ limb3) ** (accReg ↦ᵣ limb3) **
+        (loAddr3 ↦ₘ stored3.1) ** (hiAddr3 ↦ₘ stored3.2) **
+        (loAddr0 ↦ₘ stored0.1) ** (hiAddr0 ↦ₘ stored0.2) **
+        (loAddr1 ↦ₘ stored1.1) ** (hiAddr1 ↦ₘ stored1.2) **
+        (loAddr2 ↦ₘ stored2.1) ** (hiAddr2 ↦ₘ stored2.2))) := by
+  have hCore :=
+    evm_mstore_unaligned_full_stack_spec_within_public_stack_pre
+      offReg valReg byteReg accReg addrReg memBaseReg
+      sp offset offOld addrOld memBase byteOld accOld
+      offsetWord valueWord rest
+      offsetHigh1 offsetHigh2 offsetHigh3
+      limb0 limb1 limb2 limb3
+      loAddr0 hiAddr0 loVal0 hiVal0
+      loAddr1 hiAddr1 loVal1 hiVal1
+      loAddr2 hiAddr2 loVal2 hiVal2
+      loAddr3 hiAddr3 loVal3 hiVal3
+      start base
+      h_offset0 h_offset1 h_offset2 h_offset3
+      h_value0 h_value1 h_value2 h_value3
+      h_off_ne_x0 h_addr_ne_x0 h_byte_ne_x0 h_acc_ne_x0
+      h_window0 h_window1 h_window2 h_window3
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by sep_perm hp)
+    (fun _ hp => by
+      rw [evmStackIs_cons] at hp
+      rw [evmStackIs_cons] at hp
+      rw [show (sp + 32 + 32 : Word) = sp + 64 from by bv_addr] at hp
+      sep_perm hp)
+    hCore
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add canonical evm_mload_stack_spec_within entry point over the public MLOAD stack-pre theorem
- add canonical evm_mstore_stack_spec_within entry point over the public MSTORE stack-pre theorem

## Verification
- lake build EvmAsm.Evm64.MLoad.UnalignedFramedStackSpec
- lake build EvmAsm.Evm64.MStore.UnalignedFramedStackSpec
- scripts/check-file-size.sh --report