### PR TITLE
chore(shake): noshake CompensationCases Un21Bridge false-positive

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -313,6 +313,8 @@
   ["EvmAsm.Evm64.EvmWordArith.Div128KnuthLower"],
   "EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV2.Un21Bridge":
   ["EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV2.QuotientBounds"],
+  "EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV2.CompensationCases":
+  ["EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV2.Un21Bridge"],
   "EvmAsm.Evm64.DivMod.Compose.ModPhaseBn3":
   ["EvmAsm.Evm64.DivMod.Compose.ModPhaseB"],
   "EvmAsm.Evm64.DivMod.LoopBody.TrialMax":


### PR DESCRIPTION
Mirrors PR #3081 (`evm-asm-241u3`) — adds a noshake entry for another confirmed false positive in the CallSkipLowerBoundV2 chain.

`EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV2/CompensationCases.lean` imports `Un21Bridge` for the 178+ `algorithmUn21` references in the file. `lake exe shake EvmAsm` suggests dropping `Un21Bridge` and adding `Algorithm.lean` directly. Verified that the rm-only swap breaks `lake build` — `algorithmUn21_lt_vTop`-style helpers are introduced through the QuotientBounds → Un21Bridge chain, not Algorithm.lean.

Suppress the false positive in `scripts/noshake.json` next to the existing `Un21Bridge` / `ModPhaseBn3` / `TrialMax` entries.

Refs evm-asm-zr7jf / evm-asm-9tq / GH #1045.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).