### PR TITLE
feat(sdiv): add signed edge-case lemmas

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/SDiv.lean
+++ b/EvmAsm/Evm64/EvmWordArith/SDiv.lean
@@ -61,6 +61,13 @@ theorem sdiv_intMin_neg_one : sdiv (BitVec.intMin 256) (-1) = BitVec.intMin 256 
   have h : (-1 : BitVec 256) = -1#256 := by decide
   rw [h, BitVec.intMin_sdiv_neg_one]
 
+-- Closed truncation examples used by the opcode-level edge-case suite.
+theorem sdiv_neg_one_two : sdiv (-1 : EvmWord) 2 = 0 := by
+  native_decide
+
+theorem sdiv_pos_neg_trunc : sdiv (7 : EvmWord) (-2) = (-3 : EvmWord) := by
+  native_decide
+
 -- ============================================================================
 -- Correctness vs `Int.tdiv` (the spec formula)
 -- ============================================================================

--- a/EvmAsm/Evm64/EvmWordArith/SMod.lean
+++ b/EvmAsm/Evm64/EvmWordArith/SMod.lean
@@ -56,6 +56,16 @@ theorem zero_smod_left {b : EvmWord} : smod 0 b = 0 := by
   · rfl
   · simp [BitVec.zero_srem]
 
+-- Closed sign-of-dividend examples used by the opcode-level edge-case suite.
+theorem smod_neg_pos_sign : smod (-3 : EvmWord) 2 = (-1 : EvmWord) := by
+  native_decide
+
+theorem smod_pos_neg_sign : smod (3 : EvmWord) (-2) = (1 : EvmWord) := by
+  native_decide
+
+theorem smod_neg_neg_sign : smod (-3 : EvmWord) (-2) = (-1 : EvmWord) := by
+  native_decide
+
 -- ============================================================================
 -- Correctness vs `Int.tmod` (the spec formula)
 -- ============================================================================


### PR DESCRIPTION
## Summary
- add closed SDIV truncation edge-case lemmas for signed negative inputs
- add closed SMOD sign-of-dividend lemmas across mixed-sign divisors

## Verification
- lake build EvmAsm.Evm64.EvmWordArith.SDiv
- lake build EvmAsm.Evm64.EvmWordArith.SMod
- scripts/check-file-size.sh --report

Refs evm-asm-34sg / GH #90.