### PR TITLE
feat(exp): add stack edge bridges

### DIFF
--- a/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
+++ b/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
@@ -197,6 +197,28 @@ theorem runExpStack?_gas
         ( ExpArgs.expDynamicCostFromArgs (ExpArgs.expArgs base exponent)
         , ExpArgs.expTotalGasFromArgs (ExpArgs.expArgs base exponent)) := rfl
 
+theorem runExpStack?_zero_exponent
+    (base : EvmWord) (rest : List EvmWord) :
+    runExpStack? { stack := base :: 0 :: rest } =
+      some
+        { effects := { stackWords := [1], dynamicGas := 0, totalGas := 10 }
+          stack := rest } := by
+  rw [runExpStack?_cons]
+  rw [ExpArgs.expResultFromArgs_zero_right]
+  rw [ExpArgs.expDynamicCostFromArgs_zero_exponent]
+  rw [ExpArgs.expTotalGasFromArgs_zero_exponent]
+
+theorem runExpStack?_two_256
+    (rest : List EvmWord) :
+    runExpStack? { stack := (2 : EvmWord) :: 256 :: rest } =
+      some
+        { effects := { stackWords := [0], dynamicGas := 100, totalGas := 110 }
+          stack := rest } := by
+  rw [runExpStack?_cons]
+  rw [ExpArgs.expResultFromArgs_two_256]
+  rw [ExpArgs.expDynamicCostFromArgs_256_exponent]
+  rw [ExpArgs.expTotalGasFromArgs_256_exponent]
+
 end ExpStackExecutionBridge
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add pure stack-execution bridge theorem for zero EXP exponent
- add pure stack-execution bridge theorem for the EXP(2, 256) boundary including gas

## Verification
- lake build EvmAsm.Evm64.Exp.StackExecutionBridge
- scripts/check-file-size.sh --report

Refs evm-asm-20z6 / GH #92.