### PR TITLE
feat(exp): add max exponent gas lemmas

### DIFF
--- a/EvmAsm/Evm64/ArithmeticHandlers.lean
+++ b/EvmAsm/Evm64/ArithmeticHandlers.lean
@@ -5,6 +5,8 @@
 -/
 
 import EvmAsm.Evm64.HandlerTable
+import EvmAsm.Evm64.EvmWordArith.SDiv
+import EvmAsm.Evm64.EvmWordArith.SMod
 
 namespace EvmAsm.Evm64
 namespace ArithmeticHandlers
@@ -33,14 +35,22 @@ def subHandler : OpcodeHandler :=
 def mulHandler : OpcodeHandler :=
   binaryHandler (fun a b => a * b)
 
-/-- Lookup surface for the basic arithmetic handlers proved so far. -/
+def sdivHandler : OpcodeHandler :=
+  binaryHandler EvmWord.sdiv
+
+def smodHandler : OpcodeHandler :=
+  binaryHandler EvmWord.smod
+
+/-- Lookup surface for the arithmetic handlers proved so far. -/
 def arithmeticHandler? : EvmOpcode → Option OpcodeHandler
   | .ADD => some addHandler
   | .SUB => some subHandler
   | .MUL => some mulHandler
+  | .SDIV => some sdivHandler
+  | .SMOD => some smodHandler
   | _ => none
 
-/-- Handler table containing ADD/SUB/MUL entries.
+/-- Handler table containing currently supported arithmetic entries.
     Distinctive token: ArithmeticHandlers.arithmeticHandlerTable #107. -/
 def arithmeticHandlerTable : HandlerTable :=
   arithmeticHandler?
@@ -116,6 +126,16 @@ theorem binaryHandler_status_of_binaryStack?_none
     (mulHandler { state with stack := a :: b :: rest }).stack =
       (a * b) :: rest := rfl
 
+@[simp] theorem sdivHandler_stack
+    (a b : EvmWord) (rest : List EvmWord) (state : EvmState) :
+    (sdivHandler { state with stack := a :: b :: rest }).stack =
+      EvmWord.sdiv a b :: rest := rfl
+
+@[simp] theorem smodHandler_stack
+    (a b : EvmWord) (rest : List EvmWord) (state : EvmState) :
+    (smodHandler { state with stack := a :: b :: rest }).stack =
+      EvmWord.smod a b :: rest := rfl
+
 @[simp] theorem arithmeticHandlerTable_eq :
     arithmeticHandlerTable = arithmeticHandler? := rfl
 
@@ -127,6 +147,12 @@ theorem binaryHandler_status_of_binaryStack?_none
 
 @[simp] theorem arithmeticHandler?_MUL :
     arithmeticHandler? .MUL = some mulHandler := rfl
+
+@[simp] theorem arithmeticHandler?_SDIV :
+    arithmeticHandler? .SDIV = some sdivHandler := rfl
+
+@[simp] theorem arithmeticHandler?_SMOD :
+    arithmeticHandler? .SMOD = some smodHandler := rfl
 
 @[simp] theorem eq_addHandler_iff (handler : OpcodeHandler) :
     addHandler = handler ↔ handler = addHandler := by
@@ -140,18 +166,29 @@ theorem binaryHandler_status_of_binaryStack?_none
     mulHandler = handler ↔ handler = mulHandler := by
   constructor <;> intro h_eq <;> exact h_eq.symm
 
+@[simp] theorem eq_sdivHandler_iff (handler : OpcodeHandler) :
+    sdivHandler = handler ↔ handler = sdivHandler := by
+  constructor <;> intro h_eq <;> exact h_eq.symm
+
+@[simp] theorem eq_smodHandler_iff (handler : OpcodeHandler) :
+    smodHandler = handler ↔ handler = smodHandler := by
+  constructor <;> intro h_eq <;> exact h_eq.symm
+
 theorem arithmeticHandler?_eq_some_iff
     (opcode : EvmOpcode) (handler : OpcodeHandler) :
     arithmeticHandler? opcode = some handler ↔
       (opcode = .ADD ∧ handler = addHandler) ∨
         (opcode = .SUB ∧ handler = subHandler) ∨
-          (opcode = .MUL ∧ handler = mulHandler) := by
+          (opcode = .MUL ∧ handler = mulHandler) ∨
+            (opcode = .SDIV ∧ handler = sdivHandler) ∨
+              (opcode = .SMOD ∧ handler = smodHandler) := by
   cases opcode <;> simp [arithmeticHandler?]
 
 theorem arithmeticHandler?_eq_none_iff
     (opcode : EvmOpcode) :
     arithmeticHandler? opcode = none ↔
-      opcode ≠ .ADD ∧ opcode ≠ .SUB ∧ opcode ≠ .MUL := by
+      opcode ≠ .ADD ∧ opcode ≠ .SUB ∧ opcode ≠ .MUL ∧
+        opcode ≠ .SDIV ∧ opcode ≠ .SMOD := by
   cases opcode <;> simp [arithmeticHandler?]
 
 theorem dispatchOpcode?_arithmeticHandlerTable_ADD
@@ -172,6 +209,18 @@ theorem dispatchOpcode?_arithmeticHandlerTable_MUL
       some (mulHandler state) := by
   exact HandlerTable.dispatchOpcode?_some arithmeticHandler?_MUL state
 
+theorem dispatchOpcode?_arithmeticHandlerTable_SDIV
+    (state : EvmState) :
+    HandlerTable.dispatchOpcode? arithmeticHandlerTable .SDIV state =
+      some (sdivHandler state) := by
+  exact HandlerTable.dispatchOpcode?_some arithmeticHandler?_SDIV state
+
+theorem dispatchOpcode?_arithmeticHandlerTable_SMOD
+    (state : EvmState) :
+    HandlerTable.dispatchOpcode? arithmeticHandlerTable .SMOD state =
+      some (smodHandler state) := by
+  exact HandlerTable.dispatchOpcode?_some arithmeticHandler?_SMOD state
+
 theorem dispatchOpcode_arithmeticHandlerTable_ADD
     (state : EvmState) :
     HandlerTable.dispatchOpcode arithmeticHandlerTable .ADD state =
@@ -189,6 +238,18 @@ theorem dispatchOpcode_arithmeticHandlerTable_MUL
     HandlerTable.dispatchOpcode arithmeticHandlerTable .MUL state =
       mulHandler state := by
   exact HandlerTable.dispatchOpcode_some arithmeticHandler?_MUL state
+
+theorem dispatchOpcode_arithmeticHandlerTable_SDIV
+    (state : EvmState) :
+    HandlerTable.dispatchOpcode arithmeticHandlerTable .SDIV state =
+      sdivHandler state := by
+  exact HandlerTable.dispatchOpcode_some arithmeticHandler?_SDIV state
+
+theorem dispatchOpcode_arithmeticHandlerTable_SMOD
+    (state : EvmState) :
+    HandlerTable.dispatchOpcode arithmeticHandlerTable .SMOD state =
+      smodHandler state := by
+  exact HandlerTable.dispatchOpcode_some arithmeticHandler?_SMOD state
 
 theorem dispatchOpcode_arithmeticHandlerTable_ADD_status_of_some
     {state : EvmState} {stack' : List EvmWord}
@@ -213,6 +274,22 @@ theorem dispatchOpcode_arithmeticHandlerTable_MUL_status_of_some
       state.status := by
   rw [dispatchOpcode_arithmeticHandlerTable_MUL state]
   simp [mulHandler, binaryHandler, h_stack, EvmState.withStack]
+
+theorem dispatchOpcode_arithmeticHandlerTable_SDIV_status_of_some
+    {state : EvmState} {stack' : List EvmWord}
+    (h_stack : binaryStack? EvmWord.sdiv state.stack = some stack') :
+    (HandlerTable.dispatchOpcode arithmeticHandlerTable .SDIV state).status =
+      state.status := by
+  rw [dispatchOpcode_arithmeticHandlerTable_SDIV state]
+  simp [sdivHandler, binaryHandler, h_stack, EvmState.withStack]
+
+theorem dispatchOpcode_arithmeticHandlerTable_SMOD_status_of_some
+    {state : EvmState} {stack' : List EvmWord}
+    (h_stack : binaryStack? EvmWord.smod state.stack = some stack') :
+    (HandlerTable.dispatchOpcode arithmeticHandlerTable .SMOD state).status =
+      state.status := by
+  rw [dispatchOpcode_arithmeticHandlerTable_SMOD state]
+  simp [smodHandler, binaryHandler, h_stack, EvmState.withStack]
 
 end ArithmeticHandlers
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Dispatch.lean
+++ b/EvmAsm/Evm64/Dispatch.lean
@@ -22,7 +22,9 @@ def decodeByte? : Nat → Option EvmOpcode
   | 0x02 => some MUL
   | 0x03 => some SUB
   | 0x04 => some DIV
+  | 0x05 => some SDIV
   | 0x06 => some MOD
+  | 0x07 => some SMOD
   | 0x0a => some EXP
   | 0x0b => some SIGNEXTEND
   | 0x10 => some LT
@@ -318,8 +320,12 @@ theorem byte?_roundtrip_SUB :
     byte? SUB = some 0x03 ∧ decodeByte? 0x03 = some SUB := ⟨rfl, rfl⟩
 theorem byte?_roundtrip_DIV :
     byte? DIV = some 0x04 ∧ decodeByte? 0x04 = some DIV := ⟨rfl, rfl⟩
+theorem byte?_roundtrip_SDIV :
+    byte? SDIV = some 0x05 ∧ decodeByte? 0x05 = some SDIV := ⟨rfl, rfl⟩
 theorem byte?_roundtrip_MOD :
     byte? MOD = some 0x06 ∧ decodeByte? 0x06 = some MOD := ⟨rfl, rfl⟩
+theorem byte?_roundtrip_SMOD :
+    byte? SMOD = some 0x07 ∧ decodeByte? 0x07 = some SMOD := ⟨rfl, rfl⟩
 theorem byte?_roundtrip_EXP :
     byte? EXP = some 0x0a ∧ decodeByte? 0x0a = some EXP := ⟨rfl, rfl⟩
 theorem byte?_roundtrip_SIGNEXTEND :

--- a/EvmAsm/Evm64/ExecutableSpecOpcodeBridge.lean
+++ b/EvmAsm/Evm64/ExecutableSpecOpcodeBridge.lean
@@ -18,6 +18,8 @@ namespace ExecutableSpecOpcodeBridge
 namespace Ops
 
 def STOP : Nat := 0x00
+def SDIV : Nat := 0x05
+def SMOD : Nat := 0x07
 def KECCAK : Nat := 0x20
 def CALLDATALOAD : Nat := 0x35
 def CALLDATASIZE : Nat := 0x36
@@ -172,6 +174,16 @@ theorem roundtrip_execSpec_STOP :
 theorem roundtrip_execSpec_KECCAK :
     EvmOpcode.byte? EvmOpcode.KECCAK256 = some Ops.KECCAK ∧
       EvmOpcode.decodeByte? Ops.KECCAK = some EvmOpcode.KECCAK256 := by
+  exact ⟨rfl, rfl⟩
+
+theorem roundtrip_execSpec_SDIV :
+    EvmOpcode.byte? EvmOpcode.SDIV = some Ops.SDIV ∧
+      EvmOpcode.decodeByte? Ops.SDIV = some EvmOpcode.SDIV := by
+  exact ⟨rfl, rfl⟩
+
+theorem roundtrip_execSpec_SMOD :
+    EvmOpcode.byte? EvmOpcode.SMOD = some Ops.SMOD ∧
+      EvmOpcode.decodeByte? Ops.SMOD = some EvmOpcode.SMOD := by
   exact ⟨rfl, rfl⟩
 
 /-- Distinctive token:

--- a/EvmAsm/Evm64/Exp/Args.lean
+++ b/EvmAsm/Evm64/Exp/Args.lean
@@ -120,5 +120,13 @@ theorem expTotalGasFromArgs_256_exponent (base : EvmWord) :
     expTotalGasFromArgs (expArgs base 256) = 110 := by
   exact ExpGas.expTotalGasFromExponent_256
 
+theorem expDynamicCostFromArgs_max_exponent (base : EvmWord) :
+    expDynamicCostFromArgs (expArgs base (-1)) = 1600 := by
+  exact ExpGas.expDynamicCostFromExponent_max
+
+theorem expTotalGasFromArgs_max_exponent (base : EvmWord) :
+    expTotalGasFromArgs (expArgs base (-1)) = 1610 := by
+  exact ExpGas.expTotalGasFromExponent_max
+
 end ExpArgs
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Exp/Gas.lean
+++ b/EvmAsm/Evm64/Exp/Gas.lean
@@ -72,6 +72,9 @@ theorem exponentByteLength_256 : exponentByteLength (256 : EvmWord) = 2 := by
   unfold exponentByteLength
   native_decide
 
+theorem exponentByteLength_max : exponentByteLength (-1 : EvmWord) = 32 := by
+  native_decide
+
 theorem expDynamicCostFromExponent_zero :
     expDynamicCostFromExponent (0 : EvmWord) = 0 := by
   unfold expDynamicCostFromExponent expGasPerByte
@@ -100,6 +103,17 @@ theorem expTotalGasFromExponent_256 :
     expTotalGasFromExponent (256 : EvmWord) = 110 := by
   unfold expTotalGasFromExponent expDynamicCostFromExponent expGasPerByte
   rw [exponentByteLength_256]
+  rfl
+
+theorem expDynamicCostFromExponent_max :
+    expDynamicCostFromExponent (-1 : EvmWord) = 1600 := by
+  unfold expDynamicCostFromExponent expGasPerByte
+  rw [exponentByteLength_max]
+
+theorem expTotalGasFromExponent_max :
+    expTotalGasFromExponent (-1 : EvmWord) = 1610 := by
+  unfold expTotalGasFromExponent
+  rw [expDynamicCostFromExponent_max]
   rfl
 
 end EvmAsm.Evm64.ExpGas

--- a/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
+++ b/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
@@ -228,6 +228,18 @@ theorem runExpStack?_max_exponent_gas
   rw [ExpArgs.expDynamicCostFromArgs_max_exponent]
   rw [ExpArgs.expTotalGasFromArgs_max_exponent]
 
+theorem runExpStack?_zero_max_exponent
+    (rest : List EvmWord) :
+    runExpStack? { stack := (0 : EvmWord) :: (-1 : EvmWord) :: rest } =
+      some
+        { effects := { stackWords := [0], dynamicGas := 1600, totalGas := 1610 }
+          stack := rest } := by
+  rw [runExpStack?_cons]
+  rw [ExpArgs.expResultFromArgs_zero_left_of_ne_zero]
+  rw [ExpArgs.expDynamicCostFromArgs_max_exponent]
+  rw [ExpArgs.expTotalGasFromArgs_max_exponent]
+  decide
+
 end ExpStackExecutionBridge
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
+++ b/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
@@ -219,6 +219,15 @@ theorem runExpStack?_two_256
   rw [ExpArgs.expDynamicCostFromArgs_256_exponent]
   rw [ExpArgs.expTotalGasFromArgs_256_exponent]
 
+theorem runExpStack?_max_exponent_gas
+    (base : EvmWord) (rest : List EvmWord) :
+    (runExpStack? { stack := base :: (-1 : EvmWord) :: rest }).map
+      (fun out => (out.effects.dynamicGas, out.effects.totalGas)) =
+      some (1600, 1610) := by
+  rw [runExpStack?_gas]
+  rw [ExpArgs.expDynamicCostFromArgs_max_exponent]
+  rw [ExpArgs.expTotalGasFromArgs_max_exponent]
+
 end ExpStackExecutionBridge
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Gas.lean
+++ b/EvmAsm/Evm64/Gas.lean
@@ -24,7 +24,9 @@ inductive EvmOpcode where
   | MUL
   | SUB
   | DIV
+  | SDIV
   | MOD
+  | SMOD
   | EXP
   | SIGNEXTEND
   | KECCAK256
@@ -114,7 +116,9 @@ def byte? : EvmOpcode → Option Nat
   | MUL => some 0x02
   | SUB => some 0x03
   | DIV => some 0x04
+  | SDIV => some 0x05
   | MOD => some 0x06
+  | SMOD => some 0x07
   | EXP => some 0x0a
   | SIGNEXTEND => some 0x0b
   | KECCAK256 => some 0x20
@@ -188,7 +192,9 @@ def staticGasCost : EvmOpcode → Nat
   | MUL => 5
   | SUB => 3
   | DIV => 5
+  | SDIV => 5
   | MOD => 5
+  | SMOD => 5
   | EXP => 10
   | SIGNEXTEND => 5
   | KECCAK256 => 30

--- a/EvmAsm/Evm64/InterpreterExecutableFetchBridge.lean
+++ b/EvmAsm/Evm64/InterpreterExecutableFetchBridge.lean
@@ -130,6 +130,46 @@ theorem stepWithHandler_of_execSpecLogByte
   exact InterpreterLoop.stepWithHandler_of_decode handler
     (decodeCurrentOpcode?_of_execSpecLogByte kind h_pc h_code)
 
+theorem decodeCurrentOpcode?_of_execSpec_SDIV
+    {state : EvmState}
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] = (ExecutableSpecOpcodeBridge.Ops.SDIV : BitVec 8)) :
+    InterpreterLoop.decodeCurrentOpcode? state = some EvmOpcode.SDIV := by
+  exact decodeCurrentOpcode?_of_execSpecByte h_pc h_code (by
+    simp [ExecutableSpecOpcodeBridge.Ops.SDIV, EvmOpcode.decodeByte?])
+
+theorem stepWithHandler_of_execSpec_SDIV
+    (handler : InterpreterLoop.Handler)
+    {state : EvmState}
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] = (ExecutableSpecOpcodeBridge.Ops.SDIV : BitVec 8)) :
+    InterpreterLoop.stepWithHandler handler state =
+      handler EvmOpcode.SDIV state := by
+  exact InterpreterLoop.stepWithHandler_of_decode handler
+    (decodeCurrentOpcode?_of_execSpec_SDIV h_pc h_code)
+
+theorem decodeCurrentOpcode?_of_execSpec_SMOD
+    {state : EvmState}
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] = (ExecutableSpecOpcodeBridge.Ops.SMOD : BitVec 8)) :
+    InterpreterLoop.decodeCurrentOpcode? state = some EvmOpcode.SMOD := by
+  exact decodeCurrentOpcode?_of_execSpecByte h_pc h_code (by
+    simp [ExecutableSpecOpcodeBridge.Ops.SMOD, EvmOpcode.decodeByte?])
+
+theorem stepWithHandler_of_execSpec_SMOD
+    (handler : InterpreterLoop.Handler)
+    {state : EvmState}
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] = (ExecutableSpecOpcodeBridge.Ops.SMOD : BitVec 8)) :
+    InterpreterLoop.stepWithHandler handler state =
+      handler EvmOpcode.SMOD state := by
+  exact InterpreterLoop.stepWithHandler_of_decode handler
+    (decodeCurrentOpcode?_of_execSpec_SMOD h_pc h_code)
+
 theorem decodeCurrentOpcode?_of_execSpec_CALL
     {state : EvmState}
     (h_pc : state.pc < state.code.length)

--- a/EvmAsm/Evm64/InterpreterExecutableStepBridge.lean
+++ b/EvmAsm/Evm64/InterpreterExecutableStepBridge.lean
@@ -190,6 +190,44 @@ theorem loopFuel_one_supported_execSpec_SMOD_stack_of_runSModStack?_some
   exact SModStackExecutionBridge.smodHandler_stack_of_runSModStack?_some
     h_run
 
+theorem loopFuel_one_supported_execSpec_SDIV_status_of_none
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SDIV : BitVec 8))
+    (h_run :
+      SDivStackExecutionBridge.runSDivStack? { stack := state.stack } = none) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      state).status = .error := by
+  rw [loopFuel_one_of_execSpec_SDIV SupportedLoopBridge.supportedLoopHandler
+    h_status h_pc h_code]
+  rw [SupportedLoopBridge.supportedLoopHandler_apply]
+  rw [SupportedHandlers.dispatchOpcode_of_lookup
+    SupportedHandlers.supportedHandlerTable_SDIV]
+  exact SDivStackExecutionBridge.sdivHandler_status_of_runSDivStack?_none
+    h_run
+
+theorem loopFuel_one_supported_execSpec_SMOD_status_of_none
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SMOD : BitVec 8))
+    (h_run :
+      SModStackExecutionBridge.runSModStack? { stack := state.stack } = none) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      state).status = .error := by
+  rw [loopFuel_one_of_execSpec_SMOD SupportedLoopBridge.supportedLoopHandler
+    h_status h_pc h_code]
+  rw [SupportedLoopBridge.supportedLoopHandler_apply]
+  rw [SupportedHandlers.dispatchOpcode_of_lookup
+    SupportedHandlers.supportedHandlerTable_SMOD]
+  exact SModStackExecutionBridge.smodHandler_status_of_runSModStack?_none
+    h_run
+
 theorem loopFuel_one_supported_execSpec_SDIV_stack_zero_divisor
     {state : EvmState} (dividend : EvmWord) (rest : List EvmWord)
     (h_status : state.status = .running)

--- a/EvmAsm/Evm64/InterpreterExecutableStepBridge.lean
+++ b/EvmAsm/Evm64/InterpreterExecutableStepBridge.lean
@@ -258,6 +258,106 @@ theorem loopFuel_one_supported_execSpec_SMOD_status_of_none
   exact SModStackExecutionBridge.smodHandler_status_of_runSModStack?_none
     h_run
 
+theorem loopFuel_one_supported_execSpec_SDIV_status_empty_stack
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SDIV : BitVec 8)) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      { state with stack := [] }).status = .error := by
+  have h_status' :
+      ({ state with stack := [] } : EvmState).status = .running := by
+    simpa using h_status
+  have h_pc' :
+      ({ state with stack := [] } : EvmState).pc <
+        ({ state with stack := [] } : EvmState).code.length := by
+    simpa using h_pc
+  have h_code' :
+      ({ state with stack := [] } : EvmState).code[
+        ({ state with stack := [] } : EvmState).pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SDIV : BitVec 8) := by
+    simpa using h_code
+  rw [loopFuel_one_supported_execSpec_SDIV h_status' h_pc' h_code']
+  exact SDivStackExecutionBridge.sdivHandler_status_empty_stack state
+
+theorem loopFuel_one_supported_execSpec_SDIV_status_singleton_stack
+    {state : EvmState} (dividend : EvmWord)
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SDIV : BitVec 8)) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      { state with stack := [dividend] }).status = .error := by
+  have h_status' :
+      ({ state with stack := [dividend] } : EvmState).status =
+        .running := by
+    simpa using h_status
+  have h_pc' :
+      ({ state with stack := [dividend] } : EvmState).pc <
+        ({ state with stack := [dividend] } : EvmState).code.length := by
+    simpa using h_pc
+  have h_code' :
+      ({ state with stack := [dividend] } : EvmState).code[
+        ({ state with stack := [dividend] } : EvmState).pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SDIV : BitVec 8) := by
+    simpa using h_code
+  rw [loopFuel_one_supported_execSpec_SDIV h_status' h_pc' h_code']
+  exact SDivStackExecutionBridge.sdivHandler_status_singleton_stack
+    state dividend
+
+theorem loopFuel_one_supported_execSpec_SMOD_status_empty_stack
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SMOD : BitVec 8)) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      { state with stack := [] }).status = .error := by
+  have h_status' :
+      ({ state with stack := [] } : EvmState).status = .running := by
+    simpa using h_status
+  have h_pc' :
+      ({ state with stack := [] } : EvmState).pc <
+        ({ state with stack := [] } : EvmState).code.length := by
+    simpa using h_pc
+  have h_code' :
+      ({ state with stack := [] } : EvmState).code[
+        ({ state with stack := [] } : EvmState).pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SMOD : BitVec 8) := by
+    simpa using h_code
+  rw [loopFuel_one_supported_execSpec_SMOD h_status' h_pc' h_code']
+  exact SModStackExecutionBridge.smodHandler_status_empty_stack state
+
+theorem loopFuel_one_supported_execSpec_SMOD_status_singleton_stack
+    {state : EvmState} (dividend : EvmWord)
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SMOD : BitVec 8)) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      { state with stack := [dividend] }).status = .error := by
+  have h_status' :
+      ({ state with stack := [dividend] } : EvmState).status =
+        .running := by
+    simpa using h_status
+  have h_pc' :
+      ({ state with stack := [dividend] } : EvmState).pc <
+        ({ state with stack := [dividend] } : EvmState).code.length := by
+    simpa using h_pc
+  have h_code' :
+      ({ state with stack := [dividend] } : EvmState).code[
+        ({ state with stack := [dividend] } : EvmState).pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SMOD : BitVec 8) := by
+    simpa using h_code
+  rw [loopFuel_one_supported_execSpec_SMOD h_status' h_pc' h_code']
+  exact SModStackExecutionBridge.smodHandler_status_singleton_stack
+    state dividend
+
 theorem loopFuel_one_supported_execSpec_SDIV_stack_zero_divisor
     {state : EvmState} (dividend : EvmWord) (rest : List EvmWord)
     (h_status : state.status = .running)

--- a/EvmAsm/Evm64/InterpreterExecutableStepBridge.lean
+++ b/EvmAsm/Evm64/InterpreterExecutableStepBridge.lean
@@ -112,6 +112,36 @@ theorem loopFuel_one_of_execSpec_SMOD
   exact InterpreterExecutableFetchBridge.stepWithHandler_of_execSpec_SMOD
     handler h_pc h_code
 
+theorem loopFuel_one_supported_execSpec_SDIV
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SDIV : BitVec 8)) :
+    InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1 state =
+      ArithmeticHandlers.sdivHandler state := by
+  rw [loopFuel_one_of_execSpec_SDIV SupportedLoopBridge.supportedLoopHandler
+    h_status h_pc h_code]
+  rw [SupportedLoopBridge.supportedLoopHandler_apply]
+  exact SupportedHandlers.dispatchOpcode_of_lookup
+    SupportedHandlers.supportedHandlerTable_SDIV state
+
+theorem loopFuel_one_supported_execSpec_SMOD
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SMOD : BitVec 8)) :
+    InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1 state =
+      ArithmeticHandlers.smodHandler state := by
+  rw [loopFuel_one_of_execSpec_SMOD SupportedLoopBridge.supportedLoopHandler
+    h_status h_pc h_code]
+  rw [SupportedLoopBridge.supportedLoopHandler_apply]
+  exact SupportedHandlers.dispatchOpcode_of_lookup
+    SupportedHandlers.supportedHandlerTable_SMOD state
+
 theorem loopFuel_one_supported_execSpec_SDIV_status_of_some
     {state : EvmState} {stack' : List EvmWord}
     (h_status : state.status = .running)

--- a/EvmAsm/Evm64/InterpreterExecutableStepBridge.lean
+++ b/EvmAsm/Evm64/InterpreterExecutableStepBridge.lean
@@ -262,6 +262,32 @@ theorem loopFuel_one_supported_execSpec_SMOD_env
   rw [loopFuel_one_supported_execSpec_SMOD h_status h_pc h_code]
   exact SModStackExecutionBridge.smodHandler_env state
 
+theorem loopFuel_one_supported_execSpec_SDIV_codeLenMatches
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SDIV : BitVec 8))
+    (h_codeLen : state.codeLenMatches) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      state).codeLenMatches := by
+  rw [loopFuel_one_supported_execSpec_SDIV h_status h_pc h_code]
+  exact SDivStackExecutionBridge.sdivHandler_codeLenMatches state h_codeLen
+
+theorem loopFuel_one_supported_execSpec_SMOD_codeLenMatches
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SMOD : BitVec 8))
+    (h_codeLen : state.codeLenMatches) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      state).codeLenMatches := by
+  rw [loopFuel_one_supported_execSpec_SMOD h_status h_pc h_code]
+  exact SModStackExecutionBridge.smodHandler_codeLenMatches state h_codeLen
+
 theorem loopFuel_one_supported_execSpec_SDIV_memoryCells
     {state : EvmState}
     (h_status : state.status = .running)

--- a/EvmAsm/Evm64/InterpreterExecutableStepBridge.lean
+++ b/EvmAsm/Evm64/InterpreterExecutableStepBridge.lean
@@ -142,6 +142,30 @@ theorem loopFuel_one_supported_execSpec_SMOD
   exact SupportedHandlers.dispatchOpcode_of_lookup
     SupportedHandlers.supportedHandlerTable_SMOD state
 
+theorem loopFuel_one_supported_execSpec_SDIV_pc
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SDIV : BitVec 8)) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      state).pc = state.pc := by
+  rw [loopFuel_one_supported_execSpec_SDIV h_status h_pc h_code]
+  exact SDivStackExecutionBridge.sdivHandler_pc state
+
+theorem loopFuel_one_supported_execSpec_SMOD_pc
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SMOD : BitVec 8)) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      state).pc = state.pc := by
+  rw [loopFuel_one_supported_execSpec_SMOD h_status h_pc h_code]
+  exact SModStackExecutionBridge.smodHandler_pc state
+
 theorem loopFuel_one_supported_execSpec_SDIV_status_of_some
     {state : EvmState} {stack' : List EvmWord}
     (h_status : state.status = .running)

--- a/EvmAsm/Evm64/InterpreterExecutableStepBridge.lean
+++ b/EvmAsm/Evm64/InterpreterExecutableStepBridge.lean
@@ -220,6 +220,38 @@ theorem loopFuel_one_supported_execSpec_SMOD_stack_of_runSModStack?_some
   exact SModStackExecutionBridge.smodHandler_stack_of_runSModStack?_some
     h_run
 
+theorem loopFuel_one_supported_execSpec_SDIV_status_of_runSDivStack?_some
+    {state : EvmState} {out : SDivStackExecutionBridge.SDivStackResult}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SDIV : BitVec 8))
+    (h_run :
+      SDivStackExecutionBridge.runSDivStack? { stack := state.stack } =
+        some out) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      state).status = state.status := by
+  rw [loopFuel_one_supported_execSpec_SDIV h_status h_pc h_code]
+  exact SDivStackExecutionBridge.sdivHandler_status_of_runSDivStack?_some
+    h_run
+
+theorem loopFuel_one_supported_execSpec_SMOD_status_of_runSModStack?_some
+    {state : EvmState} {out : SModStackExecutionBridge.SModStackResult}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SMOD : BitVec 8))
+    (h_run :
+      SModStackExecutionBridge.runSModStack? { stack := state.stack } =
+        some out) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      state).status = state.status := by
+  rw [loopFuel_one_supported_execSpec_SMOD h_status h_pc h_code]
+  exact SModStackExecutionBridge.smodHandler_status_of_runSModStack?_some
+    h_run
+
 theorem loopFuel_one_supported_execSpec_SDIV_status_of_none
     {state : EvmState}
     (h_status : state.status = .running)

--- a/EvmAsm/Evm64/InterpreterExecutableStepBridge.lean
+++ b/EvmAsm/Evm64/InterpreterExecutableStepBridge.lean
@@ -166,6 +166,30 @@ theorem loopFuel_one_supported_execSpec_SMOD_pc
   rw [loopFuel_one_supported_execSpec_SMOD h_status h_pc h_code]
   exact SModStackExecutionBridge.smodHandler_pc state
 
+theorem loopFuel_one_supported_execSpec_SDIV_gas
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SDIV : BitVec 8)) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      state).gas = state.gas := by
+  rw [loopFuel_one_supported_execSpec_SDIV h_status h_pc h_code]
+  exact SDivStackExecutionBridge.sdivHandler_gas state
+
+theorem loopFuel_one_supported_execSpec_SMOD_gas
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SMOD : BitVec 8)) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      state).gas = state.gas := by
+  rw [loopFuel_one_supported_execSpec_SMOD h_status h_pc h_code]
+  exact SModStackExecutionBridge.smodHandler_gas state
+
 theorem loopFuel_one_supported_execSpec_SDIV_status_of_some
     {state : EvmState} {stack' : List EvmWord}
     (h_status : state.status = .running)

--- a/EvmAsm/Evm64/InterpreterExecutableStepBridge.lean
+++ b/EvmAsm/Evm64/InterpreterExecutableStepBridge.lean
@@ -150,6 +150,46 @@ theorem loopFuel_one_supported_execSpec_SMOD_status_of_some
   simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler,
     h_stack, EvmState.withStack]
 
+theorem loopFuel_one_supported_execSpec_SDIV_stack_of_runSDivStack?_some
+    {state : EvmState} {out : SDivStackExecutionBridge.SDivStackResult}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SDIV : BitVec 8))
+    (h_run :
+      SDivStackExecutionBridge.runSDivStack? { stack := state.stack } =
+        some out) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      state).stack = out.effects.stackWords ++ out.stack := by
+  rw [loopFuel_one_of_execSpec_SDIV SupportedLoopBridge.supportedLoopHandler
+    h_status h_pc h_code]
+  rw [SupportedLoopBridge.supportedLoopHandler_apply]
+  rw [SupportedHandlers.dispatchOpcode_of_lookup
+    SupportedHandlers.supportedHandlerTable_SDIV]
+  exact SDivStackExecutionBridge.sdivHandler_stack_of_runSDivStack?_some
+    h_run
+
+theorem loopFuel_one_supported_execSpec_SMOD_stack_of_runSModStack?_some
+    {state : EvmState} {out : SModStackExecutionBridge.SModStackResult}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SMOD : BitVec 8))
+    (h_run :
+      SModStackExecutionBridge.runSModStack? { stack := state.stack } =
+        some out) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      state).stack = out.effects.stackWords ++ out.stack := by
+  rw [loopFuel_one_of_execSpec_SMOD SupportedLoopBridge.supportedLoopHandler
+    h_status h_pc h_code]
+  rw [SupportedLoopBridge.supportedLoopHandler_apply]
+  rw [SupportedHandlers.dispatchOpcode_of_lookup
+    SupportedHandlers.supportedHandlerTable_SMOD]
+  exact SModStackExecutionBridge.smodHandler_stack_of_runSModStack?_some
+    h_run
+
 theorem loopFuel_one_supported_execSpec_SDIV_stack_zero_divisor
     {state : EvmState} (dividend : EvmWord) (rest : List EvmWord)
     (h_status : state.status = .running)

--- a/EvmAsm/Evm64/InterpreterExecutableStepBridge.lean
+++ b/EvmAsm/Evm64/InterpreterExecutableStepBridge.lean
@@ -83,6 +83,34 @@ theorem loopFuel_one_of_execSpecLogByte
   exact InterpreterExecutableFetchBridge.stepWithHandler_of_execSpecLogByte
     handler kind h_pc h_code
 
+theorem loopFuel_one_of_execSpec_SDIV
+    (handler : InterpreterLoop.Handler)
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SDIV : BitVec 8)) :
+    InterpreterLoop.loopFuel handler 1 state =
+      handler EvmOpcode.SDIV state := by
+  rw [InterpreterLoop.loopFuel_succ_running handler 0 state h_status]
+  exact InterpreterExecutableFetchBridge.stepWithHandler_of_execSpec_SDIV
+    handler h_pc h_code
+
+theorem loopFuel_one_of_execSpec_SMOD
+    (handler : InterpreterLoop.Handler)
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SMOD : BitVec 8)) :
+    InterpreterLoop.loopFuel handler 1 state =
+      handler EvmOpcode.SMOD state := by
+  rw [InterpreterLoop.loopFuel_succ_running handler 0 state h_status]
+  exact InterpreterExecutableFetchBridge.stepWithHandler_of_execSpec_SMOD
+    handler h_pc h_code
+
 theorem loopFuel_one_of_unsupported
     (handler : InterpreterLoop.Handler)
     {state : EvmState} {byte : BitVec 8}

--- a/EvmAsm/Evm64/InterpreterExecutableStepBridge.lean
+++ b/EvmAsm/Evm64/InterpreterExecutableStepBridge.lean
@@ -112,6 +112,44 @@ theorem loopFuel_one_of_execSpec_SMOD
   exact InterpreterExecutableFetchBridge.stepWithHandler_of_execSpec_SMOD
     handler h_pc h_code
 
+theorem loopFuel_one_supported_execSpec_SDIV_status_of_some
+    {state : EvmState} {stack' : List EvmWord}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SDIV : BitVec 8))
+    (h_stack : ArithmeticHandlers.binaryStack? EvmWord.sdiv state.stack =
+      some stack') :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      state).status = state.status := by
+  rw [loopFuel_one_of_execSpec_SDIV SupportedLoopBridge.supportedLoopHandler
+    h_status h_pc h_code]
+  rw [SupportedLoopBridge.supportedLoopHandler_apply]
+  rw [SupportedHandlers.dispatchOpcode_of_lookup
+    SupportedHandlers.supportedHandlerTable_SDIV]
+  simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler,
+    h_stack, EvmState.withStack]
+
+theorem loopFuel_one_supported_execSpec_SMOD_status_of_some
+    {state : EvmState} {stack' : List EvmWord}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SMOD : BitVec 8))
+    (h_stack : ArithmeticHandlers.binaryStack? EvmWord.smod state.stack =
+      some stack') :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      state).status = state.status := by
+  rw [loopFuel_one_of_execSpec_SMOD SupportedLoopBridge.supportedLoopHandler
+    h_status h_pc h_code]
+  rw [SupportedLoopBridge.supportedLoopHandler_apply]
+  rw [SupportedHandlers.dispatchOpcode_of_lookup
+    SupportedHandlers.supportedHandlerTable_SMOD]
+  simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler,
+    h_stack, EvmState.withStack]
+
 theorem loopFuel_one_supported_execSpec_SDIV_stack_zero_divisor
     {state : EvmState} (dividend : EvmWord) (rest : List EvmWord)
     (h_status : state.status = .running)

--- a/EvmAsm/Evm64/InterpreterExecutableStepBridge.lean
+++ b/EvmAsm/Evm64/InterpreterExecutableStepBridge.lean
@@ -190,6 +190,78 @@ theorem loopFuel_one_supported_execSpec_SMOD_gas
   rw [loopFuel_one_supported_execSpec_SMOD h_status h_pc h_code]
   exact SModStackExecutionBridge.smodHandler_gas state
 
+theorem loopFuel_one_supported_execSpec_SDIV_code
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SDIV : BitVec 8)) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      state).code = state.code := by
+  rw [loopFuel_one_supported_execSpec_SDIV h_status h_pc h_code]
+  exact SDivStackExecutionBridge.sdivHandler_code state
+
+theorem loopFuel_one_supported_execSpec_SMOD_code
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SMOD : BitVec 8)) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      state).code = state.code := by
+  rw [loopFuel_one_supported_execSpec_SMOD h_status h_pc h_code]
+  exact SModStackExecutionBridge.smodHandler_code state
+
+theorem loopFuel_one_supported_execSpec_SDIV_codeLen
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SDIV : BitVec 8)) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      state).codeLen = state.codeLen := by
+  rw [loopFuel_one_supported_execSpec_SDIV h_status h_pc h_code]
+  exact SDivStackExecutionBridge.sdivHandler_codeLen state
+
+theorem loopFuel_one_supported_execSpec_SMOD_codeLen
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SMOD : BitVec 8)) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      state).codeLen = state.codeLen := by
+  rw [loopFuel_one_supported_execSpec_SMOD h_status h_pc h_code]
+  exact SModStackExecutionBridge.smodHandler_codeLen state
+
+theorem loopFuel_one_supported_execSpec_SDIV_env
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SDIV : BitVec 8)) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      state).env = state.env := by
+  rw [loopFuel_one_supported_execSpec_SDIV h_status h_pc h_code]
+  exact SDivStackExecutionBridge.sdivHandler_env state
+
+theorem loopFuel_one_supported_execSpec_SMOD_env
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SMOD : BitVec 8)) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      state).env = state.env := by
+  rw [loopFuel_one_supported_execSpec_SMOD h_status h_pc h_code]
+  exact SModStackExecutionBridge.smodHandler_env state
+
 theorem loopFuel_one_supported_execSpec_SDIV_memoryCells
     {state : EvmState}
     (h_status : state.status = .running)

--- a/EvmAsm/Evm64/InterpreterExecutableStepBridge.lean
+++ b/EvmAsm/Evm64/InterpreterExecutableStepBridge.lean
@@ -190,6 +190,78 @@ theorem loopFuel_one_supported_execSpec_SMOD_gas
   rw [loopFuel_one_supported_execSpec_SMOD h_status h_pc h_code]
   exact SModStackExecutionBridge.smodHandler_gas state
 
+theorem loopFuel_one_supported_execSpec_SDIV_memoryCells
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SDIV : BitVec 8)) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      state).memoryCells = state.memoryCells := by
+  rw [loopFuel_one_supported_execSpec_SDIV h_status h_pc h_code]
+  exact SDivStackExecutionBridge.sdivHandler_memoryCells state
+
+theorem loopFuel_one_supported_execSpec_SDIV_memory
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SDIV : BitVec 8)) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      state).memory = state.memory := by
+  rw [loopFuel_one_supported_execSpec_SDIV h_status h_pc h_code]
+  exact SDivStackExecutionBridge.sdivHandler_memory state
+
+theorem loopFuel_one_supported_execSpec_SDIV_memSize
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SDIV : BitVec 8)) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      state).memSize = state.memSize := by
+  rw [loopFuel_one_supported_execSpec_SDIV h_status h_pc h_code]
+  exact SDivStackExecutionBridge.sdivHandler_memSize state
+
+theorem loopFuel_one_supported_execSpec_SMOD_memoryCells
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SMOD : BitVec 8)) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      state).memoryCells = state.memoryCells := by
+  rw [loopFuel_one_supported_execSpec_SMOD h_status h_pc h_code]
+  exact SModStackExecutionBridge.smodHandler_memoryCells state
+
+theorem loopFuel_one_supported_execSpec_SMOD_memory
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SMOD : BitVec 8)) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      state).memory = state.memory := by
+  rw [loopFuel_one_supported_execSpec_SMOD h_status h_pc h_code]
+  exact SModStackExecutionBridge.smodHandler_memory state
+
+theorem loopFuel_one_supported_execSpec_SMOD_memSize
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SMOD : BitVec 8)) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      state).memSize = state.memSize := by
+  rw [loopFuel_one_supported_execSpec_SMOD h_status h_pc h_code]
+  exact SModStackExecutionBridge.smodHandler_memSize state
+
 theorem loopFuel_one_supported_execSpec_SDIV_status_of_some
     {state : EvmState} {stack' : List EvmWord}
     (h_status : state.status = .running)

--- a/EvmAsm/Evm64/InterpreterExecutableStepBridge.lean
+++ b/EvmAsm/Evm64/InterpreterExecutableStepBridge.lean
@@ -6,6 +6,7 @@
 -/
 
 import EvmAsm.Evm64.InterpreterExecutableFetchBridge
+import EvmAsm.Evm64.SupportedLoopBridge
 
 namespace EvmAsm.Evm64
 
@@ -110,6 +111,278 @@ theorem loopFuel_one_of_execSpec_SMOD
   rw [InterpreterLoop.loopFuel_succ_running handler 0 state h_status]
   exact InterpreterExecutableFetchBridge.stepWithHandler_of_execSpec_SMOD
     handler h_pc h_code
+
+theorem loopFuel_one_supported_execSpec_SDIV_stack_zero_divisor
+    {state : EvmState} (dividend : EvmWord) (rest : List EvmWord)
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SDIV : BitVec 8)) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      { state with stack := dividend :: 0 :: rest }).stack =
+        0 :: rest := by
+  have h_status' :
+      ({ state with stack := dividend :: 0 :: rest } : EvmState).status =
+        .running := by
+    simpa using h_status
+  have h_pc' :
+      ({ state with stack := dividend :: 0 :: rest } : EvmState).pc <
+        ({ state with stack := dividend :: 0 :: rest } : EvmState).code.length := by
+    simpa using h_pc
+  have h_code' :
+      ({ state with stack := dividend :: 0 :: rest } : EvmState).code[
+        ({ state with stack := dividend :: 0 :: rest } : EvmState).pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SDIV : BitVec 8) := by
+    simpa using h_code
+  rw [loopFuel_one_of_execSpec_SDIV SupportedLoopBridge.supportedLoopHandler
+    h_status' h_pc' h_code']
+  rw [SupportedLoopBridge.supportedLoopHandler_apply]
+  rw [SupportedHandlers.dispatchOpcode_of_lookup
+    SupportedHandlers.supportedHandlerTable_SDIV]
+  exact SDivStackExecutionBridge.sdivHandler_stack_zero_divisor
+    state dividend rest
+
+theorem loopFuel_one_supported_execSpec_SDIV_stack_intMin_neg_one
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SDIV : BitVec 8)) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      { state with stack := BitVec.intMin 256 :: (-1 : EvmWord) :: state.stack }).stack =
+        BitVec.intMin 256 :: state.stack := by
+  have h_status' :
+      ({ state with stack := BitVec.intMin 256 :: (-1 : EvmWord) :: state.stack } :
+        EvmState).status = .running := by
+    simpa using h_status
+  have h_pc' :
+      ({ state with stack := BitVec.intMin 256 :: (-1 : EvmWord) :: state.stack } :
+        EvmState).pc <
+        ({ state with stack := BitVec.intMin 256 :: (-1 : EvmWord) :: state.stack } :
+          EvmState).code.length := by
+    simpa using h_pc
+  have h_code' :
+      ({ state with stack := BitVec.intMin 256 :: (-1 : EvmWord) :: state.stack } :
+        EvmState).code[
+        ({ state with stack := BitVec.intMin 256 :: (-1 : EvmWord) :: state.stack } :
+          EvmState).pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SDIV : BitVec 8) := by
+    simpa using h_code
+  rw [loopFuel_one_of_execSpec_SDIV SupportedLoopBridge.supportedLoopHandler
+    h_status' h_pc' h_code']
+  rw [SupportedLoopBridge.supportedLoopHandler_apply]
+  rw [SupportedHandlers.dispatchOpcode_of_lookup
+    SupportedHandlers.supportedHandlerTable_SDIV]
+  exact SDivStackExecutionBridge.sdivHandler_stack_intMin_neg_one
+    state state.stack
+
+theorem loopFuel_one_supported_execSpec_SDIV_stack_neg_one_two
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SDIV : BitVec 8)) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      { state with stack := (-1 : EvmWord) :: 2 :: state.stack }).stack =
+        0 :: state.stack := by
+  have h_status' :
+      ({ state with stack := (-1 : EvmWord) :: 2 :: state.stack } :
+        EvmState).status = .running := by
+    simpa using h_status
+  have h_pc' :
+      ({ state with stack := (-1 : EvmWord) :: 2 :: state.stack } :
+        EvmState).pc <
+        ({ state with stack := (-1 : EvmWord) :: 2 :: state.stack } :
+          EvmState).code.length := by
+    simpa using h_pc
+  have h_code' :
+      ({ state with stack := (-1 : EvmWord) :: 2 :: state.stack } :
+        EvmState).code[
+        ({ state with stack := (-1 : EvmWord) :: 2 :: state.stack } :
+          EvmState).pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SDIV : BitVec 8) := by
+    simpa using h_code
+  rw [loopFuel_one_of_execSpec_SDIV SupportedLoopBridge.supportedLoopHandler
+    h_status' h_pc' h_code']
+  rw [SupportedLoopBridge.supportedLoopHandler_apply]
+  rw [SupportedHandlers.dispatchOpcode_of_lookup
+    SupportedHandlers.supportedHandlerTable_SDIV]
+  exact SDivStackExecutionBridge.sdivHandler_stack_neg_one_two
+    state state.stack
+
+theorem loopFuel_one_supported_execSpec_SDIV_stack_pos_neg_trunc
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SDIV : BitVec 8)) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      { state with stack := (7 : EvmWord) :: (-2 : EvmWord) :: state.stack }).stack =
+        (-3 : EvmWord) :: state.stack := by
+  have h_status' :
+      ({ state with stack := (7 : EvmWord) :: (-2 : EvmWord) :: state.stack } :
+        EvmState).status = .running := by
+    simpa using h_status
+  have h_pc' :
+      ({ state with stack := (7 : EvmWord) :: (-2 : EvmWord) :: state.stack } :
+        EvmState).pc <
+        ({ state with stack := (7 : EvmWord) :: (-2 : EvmWord) :: state.stack } :
+          EvmState).code.length := by
+    simpa using h_pc
+  have h_code' :
+      ({ state with stack := (7 : EvmWord) :: (-2 : EvmWord) :: state.stack } :
+        EvmState).code[
+        ({ state with stack := (7 : EvmWord) :: (-2 : EvmWord) :: state.stack } :
+          EvmState).pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SDIV : BitVec 8) := by
+    simpa using h_code
+  rw [loopFuel_one_of_execSpec_SDIV SupportedLoopBridge.supportedLoopHandler
+    h_status' h_pc' h_code']
+  rw [SupportedLoopBridge.supportedLoopHandler_apply]
+  rw [SupportedHandlers.dispatchOpcode_of_lookup
+    SupportedHandlers.supportedHandlerTable_SDIV]
+  exact SDivStackExecutionBridge.sdivHandler_stack_pos_neg_trunc
+    state state.stack
+
+theorem loopFuel_one_supported_execSpec_SMOD_stack_zero_divisor
+    {state : EvmState} (dividend : EvmWord) (rest : List EvmWord)
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SMOD : BitVec 8)) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      { state with stack := dividend :: 0 :: rest }).stack =
+        0 :: rest := by
+  have h_status' :
+      ({ state with stack := dividend :: 0 :: rest } : EvmState).status =
+        .running := by
+    simpa using h_status
+  have h_pc' :
+      ({ state with stack := dividend :: 0 :: rest } : EvmState).pc <
+        ({ state with stack := dividend :: 0 :: rest } : EvmState).code.length := by
+    simpa using h_pc
+  have h_code' :
+      ({ state with stack := dividend :: 0 :: rest } : EvmState).code[
+        ({ state with stack := dividend :: 0 :: rest } : EvmState).pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SMOD : BitVec 8) := by
+    simpa using h_code
+  rw [loopFuel_one_of_execSpec_SMOD SupportedLoopBridge.supportedLoopHandler
+    h_status' h_pc' h_code']
+  rw [SupportedLoopBridge.supportedLoopHandler_apply]
+  rw [SupportedHandlers.dispatchOpcode_of_lookup
+    SupportedHandlers.supportedHandlerTable_SMOD]
+  exact SModStackExecutionBridge.smodHandler_stack_zero_divisor
+    state dividend rest
+
+theorem loopFuel_one_supported_execSpec_SMOD_stack_neg_pos_sign
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SMOD : BitVec 8)) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      { state with stack := (-3 : EvmWord) :: 2 :: state.stack }).stack =
+        (-1 : EvmWord) :: state.stack := by
+  have h_status' :
+      ({ state with stack := (-3 : EvmWord) :: 2 :: state.stack } :
+        EvmState).status = .running := by
+    simpa using h_status
+  have h_pc' :
+      ({ state with stack := (-3 : EvmWord) :: 2 :: state.stack } :
+        EvmState).pc <
+        ({ state with stack := (-3 : EvmWord) :: 2 :: state.stack } :
+          EvmState).code.length := by
+    simpa using h_pc
+  have h_code' :
+      ({ state with stack := (-3 : EvmWord) :: 2 :: state.stack } :
+        EvmState).code[
+        ({ state with stack := (-3 : EvmWord) :: 2 :: state.stack } :
+          EvmState).pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SMOD : BitVec 8) := by
+    simpa using h_code
+  rw [loopFuel_one_of_execSpec_SMOD SupportedLoopBridge.supportedLoopHandler
+    h_status' h_pc' h_code']
+  rw [SupportedLoopBridge.supportedLoopHandler_apply]
+  rw [SupportedHandlers.dispatchOpcode_of_lookup
+    SupportedHandlers.supportedHandlerTable_SMOD]
+  exact SModStackExecutionBridge.smodHandler_stack_neg_pos_sign
+    state state.stack
+
+theorem loopFuel_one_supported_execSpec_SMOD_stack_pos_neg_sign
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SMOD : BitVec 8)) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      { state with stack := (3 : EvmWord) :: (-2 : EvmWord) :: state.stack }).stack =
+        (1 : EvmWord) :: state.stack := by
+  have h_status' :
+      ({ state with stack := (3 : EvmWord) :: (-2 : EvmWord) :: state.stack } :
+        EvmState).status = .running := by
+    simpa using h_status
+  have h_pc' :
+      ({ state with stack := (3 : EvmWord) :: (-2 : EvmWord) :: state.stack } :
+        EvmState).pc <
+        ({ state with stack := (3 : EvmWord) :: (-2 : EvmWord) :: state.stack } :
+          EvmState).code.length := by
+    simpa using h_pc
+  have h_code' :
+      ({ state with stack := (3 : EvmWord) :: (-2 : EvmWord) :: state.stack } :
+        EvmState).code[
+        ({ state with stack := (3 : EvmWord) :: (-2 : EvmWord) :: state.stack } :
+          EvmState).pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SMOD : BitVec 8) := by
+    simpa using h_code
+  rw [loopFuel_one_of_execSpec_SMOD SupportedLoopBridge.supportedLoopHandler
+    h_status' h_pc' h_code']
+  rw [SupportedLoopBridge.supportedLoopHandler_apply]
+  rw [SupportedHandlers.dispatchOpcode_of_lookup
+    SupportedHandlers.supportedHandlerTable_SMOD]
+  exact SModStackExecutionBridge.smodHandler_stack_pos_neg_sign
+    state state.stack
+
+theorem loopFuel_one_supported_execSpec_SMOD_stack_neg_neg_sign
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SMOD : BitVec 8)) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      { state with stack := (-3 : EvmWord) :: (-2 : EvmWord) :: state.stack }).stack =
+        (-1 : EvmWord) :: state.stack := by
+  have h_status' :
+      ({ state with stack := (-3 : EvmWord) :: (-2 : EvmWord) :: state.stack } :
+        EvmState).status = .running := by
+    simpa using h_status
+  have h_pc' :
+      ({ state with stack := (-3 : EvmWord) :: (-2 : EvmWord) :: state.stack } :
+        EvmState).pc <
+        ({ state with stack := (-3 : EvmWord) :: (-2 : EvmWord) :: state.stack } :
+          EvmState).code.length := by
+    simpa using h_pc
+  have h_code' :
+      ({ state with stack := (-3 : EvmWord) :: (-2 : EvmWord) :: state.stack } :
+        EvmState).code[
+        ({ state with stack := (-3 : EvmWord) :: (-2 : EvmWord) :: state.stack } :
+          EvmState).pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SMOD : BitVec 8) := by
+    simpa using h_code
+  rw [loopFuel_one_of_execSpec_SMOD SupportedLoopBridge.supportedLoopHandler
+    h_status' h_pc' h_code']
+  rw [SupportedLoopBridge.supportedLoopHandler_apply]
+  rw [SupportedHandlers.dispatchOpcode_of_lookup
+    SupportedHandlers.supportedHandlerTable_SMOD]
+  exact SModStackExecutionBridge.smodHandler_stack_neg_neg_sign
+    state state.stack
 
 theorem loopFuel_one_of_unsupported
     (handler : InterpreterLoop.Handler)

--- a/EvmAsm/Evm64/SDiv.lean
+++ b/EvmAsm/Evm64/SDiv.lean
@@ -14,6 +14,7 @@ import EvmAsm.Evm64.SDiv.AddrNormAttr
 import EvmAsm.Evm64.SDiv.Layout
 import EvmAsm.Evm64.SDiv.Args
 import EvmAsm.Evm64.SDiv.ArgsStackDecode
+import EvmAsm.Evm64.SDiv.StackExecutionBridge
 import EvmAsm.Evm64.SDiv.Program
 import EvmAsm.Evm64.SDiv.LimbSpec
 import EvmAsm.Evm64.SDiv.AddrNorm

--- a/EvmAsm/Evm64/SDiv.lean
+++ b/EvmAsm/Evm64/SDiv.lean
@@ -13,6 +13,7 @@
 import EvmAsm.Evm64.SDiv.AddrNormAttr
 import EvmAsm.Evm64.SDiv.Layout
 import EvmAsm.Evm64.SDiv.Args
+import EvmAsm.Evm64.SDiv.ArgsStackDecode
 import EvmAsm.Evm64.SDiv.Program
 import EvmAsm.Evm64.SDiv.LimbSpec
 import EvmAsm.Evm64.SDiv.AddrNorm

--- a/EvmAsm/Evm64/SDiv.lean
+++ b/EvmAsm/Evm64/SDiv.lean
@@ -12,6 +12,7 @@
 
 import EvmAsm.Evm64.SDiv.AddrNormAttr
 import EvmAsm.Evm64.SDiv.Layout
+import EvmAsm.Evm64.SDiv.Args
 import EvmAsm.Evm64.SDiv.Program
 import EvmAsm.Evm64.SDiv.LimbSpec
 import EvmAsm.Evm64.SDiv.AddrNorm

--- a/EvmAsm/Evm64/SDiv.lean
+++ b/EvmAsm/Evm64/SDiv.lean
@@ -15,6 +15,7 @@ import EvmAsm.Evm64.SDiv.Layout
 import EvmAsm.Evm64.SDiv.Args
 import EvmAsm.Evm64.SDiv.ArgsStackDecode
 import EvmAsm.Evm64.SDiv.StackExecutionBridge
+import EvmAsm.Evm64.SDiv.HandlerBridge
 import EvmAsm.Evm64.SDiv.Program
 import EvmAsm.Evm64.SDiv.LimbSpec
 import EvmAsm.Evm64.SDiv.AddrNorm

--- a/EvmAsm/Evm64/SDiv/Args.lean
+++ b/EvmAsm/Evm64/SDiv/Args.lean
@@ -1,0 +1,78 @@
+/-
+  EvmAsm.Evm64.SDiv.Args
+
+  Pure stack-argument bridge for SDIV (GH #90).
+-/
+
+import EvmAsm.Evm64.EvmWordArith.SDiv
+
+namespace EvmAsm.Evm64
+namespace SDivArgs
+
+/-- SDIV stack arguments: dividend and divisor. -/
+structure Args where
+  dividend : EvmWord
+  divisor : EvmWord
+  deriving Repr
+
+/-- SDIV pops two stack words: dividend and divisor. -/
+def stackArgumentCount : Nat := 2
+
+/-- SDIV pushes one result word. -/
+def resultCount : Nat := 1
+
+/-- Convenience builder for SDIV stack arguments. -/
+def sdivArgs (dividend divisor : EvmWord) : Args :=
+  { dividend := dividend, divisor := divisor }
+
+/-- SDIV result computed from decoded stack arguments. -/
+def sdivResultFromArgs (args : Args) : EvmWord :=
+  EvmWord.sdiv args.dividend args.divisor
+
+/-- Stack after the SDIV result replaces the two operands. -/
+def stackAfterSDiv (args : Args) (rest : List EvmWord) : List EvmWord :=
+  sdivResultFromArgs args :: rest
+
+theorem stackArgumentCount_eq_two : stackArgumentCount = 2 := rfl
+
+theorem resultCount_eq_one : resultCount = 1 := rfl
+
+theorem sdivArgs_dividend (dividend divisor : EvmWord) :
+    (sdivArgs dividend divisor).dividend = dividend := rfl
+
+theorem sdivArgs_divisor (dividend divisor : EvmWord) :
+    (sdivArgs dividend divisor).divisor = divisor := rfl
+
+theorem sdivResultFromArgs_eq (args : Args) :
+    sdivResultFromArgs args = EvmWord.sdiv args.dividend args.divisor := rfl
+
+theorem stackAfterSDiv_eq (args : Args) (rest : List EvmWord) :
+    stackAfterSDiv args rest = sdivResultFromArgs args :: rest := rfl
+
+@[simp] theorem stackAfterSDiv_length (args : Args) (rest : List EvmWord) :
+    (stackAfterSDiv args rest).length = rest.length + 1 := by
+  simp [stackAfterSDiv]
+
+@[simp] theorem sdivResultFromArgs_zero_divisor (dividend : EvmWord) :
+    sdivResultFromArgs (sdivArgs dividend 0) = 0 := by
+  exact EvmWord.sdiv_zero_right
+
+@[simp] theorem sdivResultFromArgs_zero_dividend (divisor : EvmWord) :
+    sdivResultFromArgs (sdivArgs 0 divisor) = 0 := by
+  exact EvmWord.zero_sdiv_left
+
+theorem sdivResultFromArgs_intMin_neg_one :
+    sdivResultFromArgs (sdivArgs (BitVec.intMin 256) (-1)) =
+      BitVec.intMin 256 := by
+  exact EvmWord.sdiv_intMin_neg_one
+
+theorem sdivResultFromArgs_neg_one_two :
+    sdivResultFromArgs (sdivArgs (-1) 2) = 0 := by
+  exact EvmWord.sdiv_neg_one_two
+
+theorem sdivResultFromArgs_pos_neg_trunc :
+    sdivResultFromArgs (sdivArgs 7 (-2)) = (-3 : EvmWord) := by
+  exact EvmWord.sdiv_pos_neg_trunc
+
+end SDivArgs
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/SDiv/ArgsStackDecode.lean
+++ b/EvmAsm/Evm64/SDiv/ArgsStackDecode.lean
@@ -1,0 +1,83 @@
+/-
+  EvmAsm.Evm64.SDiv.ArgsStackDecode
+
+  Pure top-of-stack decoder for SDIV executable-spec bridges (GH #90).
+-/
+
+import EvmAsm.Evm64.SDiv.Args
+
+namespace EvmAsm.Evm64
+namespace SDivArgsStackDecode
+
+/--
+Decode SDIV stack arguments from the top-of-stack list order:
+`dividend, divisor`.
+-/
+def decodeSDivStack? : List EvmWord → Option SDivArgs.Args
+  | dividend :: divisor :: _ => some (SDivArgs.sdivArgs dividend divisor)
+  | _ => none
+
+theorem decodeSDivStack?_cons
+    (dividend divisor : EvmWord) (rest : List EvmWord) :
+    decodeSDivStack? (dividend :: divisor :: rest) =
+      some (SDivArgs.sdivArgs dividend divisor) := rfl
+
+theorem decodeSDivStack?_eq_some_iff
+    {stack : List EvmWord} {args : SDivArgs.Args} :
+    decodeSDivStack? stack = some args ↔
+      ∃ dividend divisor rest,
+        stack = dividend :: divisor :: rest ∧
+          args = SDivArgs.sdivArgs dividend divisor := by
+  constructor
+  · cases stack with
+    | nil => simp [decodeSDivStack?]
+    | cons dividend tail =>
+        cases tail with
+        | nil => simp [decodeSDivStack?]
+        | cons divisor rest =>
+            intro h
+            injection h with h_args
+            subst h_args
+            exact ⟨dividend, divisor, rest, rfl, rfl⟩
+  · rintro ⟨dividend, divisor, rest, rfl, rfl⟩
+    rfl
+
+theorem decodeSDivStack?_eq_none_iff
+    {stack : List EvmWord} :
+    decodeSDivStack? stack = none ↔
+      stack = [] ∨ ∃ dividend, stack = [dividend] := by
+  constructor
+  · cases stack with
+    | nil =>
+        intro _h
+        exact Or.inl rfl
+    | cons dividend tail =>
+        cases tail with
+        | nil =>
+            intro _h
+            exact Or.inr ⟨dividend, rfl⟩
+        | cons divisor rest =>
+            simp [decodeSDivStack?]
+  · rintro (rfl | ⟨dividend, rfl⟩) <;> rfl
+
+theorem decodeSDivStack?_none_of_empty :
+    decodeSDivStack? [] = none := rfl
+
+theorem decodeSDivStack?_none_of_one
+    (dividend : EvmWord) :
+    decodeSDivStack? [dividend] = none := rfl
+
+theorem decodeSDivStack?_dividend
+    (dividend divisor : EvmWord) (rest : List EvmWord) :
+    Option.map (fun args => args.dividend)
+      (decodeSDivStack? (dividend :: divisor :: rest)) =
+      some dividend := rfl
+
+theorem decodeSDivStack?_divisor
+    (dividend divisor : EvmWord) (rest : List EvmWord) :
+    Option.map (fun args => args.divisor)
+      (decodeSDivStack? (dividend :: divisor :: rest)) =
+      some divisor := rfl
+
+end SDivArgsStackDecode
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/SDiv/HandlerBridge.lean
+++ b/EvmAsm/Evm64/SDiv/HandlerBridge.lean
@@ -49,6 +49,18 @@ theorem sdivHandler_status_of_runSDivStack?_none
           simp [runSDivStack?, SDivArgsStackDecode.decodeSDivStack?,
             stackRestAfterSDiv?, Option.bind, h_stack, h_tail] at h_run
 
+theorem sdivHandler_status_empty_stack
+    (state : EvmState) :
+    (ArithmeticHandlers.sdivHandler { state with stack := [] }).status =
+      .error := by
+  simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler]
+
+theorem sdivHandler_status_singleton_stack
+    (state : EvmState) (dividend : EvmWord) :
+    (ArithmeticHandlers.sdivHandler
+      { state with stack := [dividend] }).status = .error := by
+  simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler]
+
 theorem sdivHandler_stack_zero_divisor
     (state : EvmState) (dividend : EvmWord) (rest : List EvmWord) :
     (ArithmeticHandlers.sdivHandler

--- a/EvmAsm/Evm64/SDiv/HandlerBridge.lean
+++ b/EvmAsm/Evm64/SDiv/HandlerBridge.lean
@@ -17,6 +17,13 @@ theorem sdivHandler_pc
     simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler,
       EvmState.withStack, EvmState.invalid, EvmState.withStatus, h_stack]
 
+theorem sdivHandler_gas
+    (state : EvmState) :
+    (ArithmeticHandlers.sdivHandler state).gas = state.gas := by
+  cases h_stack : ArithmeticHandlers.binaryStack? EvmWord.sdiv state.stack <;>
+    simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler,
+      EvmState.withStack, EvmState.invalid, EvmState.withStatus, h_stack]
+
 theorem sdivHandler_stack_of_runSDivStack?_some
     {state : EvmState} {out : SDivStackResult}
     (h_run : runSDivStack? { stack := state.stack } = some out) :

--- a/EvmAsm/Evm64/SDiv/HandlerBridge.lean
+++ b/EvmAsm/Evm64/SDiv/HandlerBridge.lean
@@ -49,5 +49,37 @@ theorem sdivHandler_status_of_runSDivStack?_none
           simp [runSDivStack?, SDivArgsStackDecode.decodeSDivStack?,
             stackRestAfterSDiv?, Option.bind, h_stack, h_tail] at h_run
 
+theorem sdivHandler_stack_zero_divisor
+    (state : EvmState) (dividend : EvmWord) (rest : List EvmWord) :
+    (ArithmeticHandlers.sdivHandler
+      { state with stack := dividend :: 0 :: rest }).stack =
+        0 :: rest := by
+  simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler]
+  exact EvmWord.sdiv_zero_right
+
+theorem sdivHandler_stack_intMin_neg_one
+    (state : EvmState) (rest : List EvmWord) :
+    (ArithmeticHandlers.sdivHandler
+      { state with stack := BitVec.intMin 256 :: (-1 : EvmWord) :: rest }).stack =
+        BitVec.intMin 256 :: rest := by
+  simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler]
+  exact EvmWord.sdiv_intMin_neg_one
+
+theorem sdivHandler_stack_neg_one_two
+    (state : EvmState) (rest : List EvmWord) :
+    (ArithmeticHandlers.sdivHandler
+      { state with stack := (-1 : EvmWord) :: 2 :: rest }).stack =
+        0 :: rest := by
+  simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler]
+  exact EvmWord.sdiv_neg_one_two
+
+theorem sdivHandler_stack_pos_neg_trunc
+    (state : EvmState) (rest : List EvmWord) :
+    (ArithmeticHandlers.sdivHandler
+      { state with stack := (7 : EvmWord) :: (-2 : EvmWord) :: rest }).stack =
+        (-3 : EvmWord) :: rest := by
+  simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler]
+  exact EvmWord.sdiv_pos_neg_trunc
+
 end SDivStackExecutionBridge
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/SDiv/HandlerBridge.lean
+++ b/EvmAsm/Evm64/SDiv/HandlerBridge.lean
@@ -67,6 +67,13 @@ theorem sdivHandler_env
     simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler,
       EvmState.withStack, EvmState.invalid, EvmState.withStatus, h_stack]
 
+theorem sdivHandler_codeLenMatches
+    (state : EvmState) (h_codeLen : state.codeLenMatches) :
+    (ArithmeticHandlers.sdivHandler state).codeLenMatches := by
+  unfold EvmState.codeLenMatches at h_codeLen ⊢
+  rw [sdivHandler_codeLen, sdivHandler_code]
+  exact h_codeLen
+
 theorem sdivHandler_stack_of_runSDivStack?_some
     {state : EvmState} {out : SDivStackResult}
     (h_run : runSDivStack? { stack := state.stack } = some out) :

--- a/EvmAsm/Evm64/SDiv/HandlerBridge.lean
+++ b/EvmAsm/Evm64/SDiv/HandlerBridge.lean
@@ -46,6 +46,27 @@ theorem sdivHandler_memSize
     simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler,
       EvmState.withStack, EvmState.invalid, EvmState.withStatus, h_stack]
 
+theorem sdivHandler_code
+    (state : EvmState) :
+    (ArithmeticHandlers.sdivHandler state).code = state.code := by
+  cases h_stack : ArithmeticHandlers.binaryStack? EvmWord.sdiv state.stack <;>
+    simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler,
+      EvmState.withStack, EvmState.invalid, EvmState.withStatus, h_stack]
+
+theorem sdivHandler_codeLen
+    (state : EvmState) :
+    (ArithmeticHandlers.sdivHandler state).codeLen = state.codeLen := by
+  cases h_stack : ArithmeticHandlers.binaryStack? EvmWord.sdiv state.stack <;>
+    simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler,
+      EvmState.withStack, EvmState.invalid, EvmState.withStatus, h_stack]
+
+theorem sdivHandler_env
+    (state : EvmState) :
+    (ArithmeticHandlers.sdivHandler state).env = state.env := by
+  cases h_stack : ArithmeticHandlers.binaryStack? EvmWord.sdiv state.stack <;>
+    simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler,
+      EvmState.withStack, EvmState.invalid, EvmState.withStatus, h_stack]
+
 theorem sdivHandler_stack_of_runSDivStack?_some
     {state : EvmState} {out : SDivStackResult}
     (h_run : runSDivStack? { stack := state.stack } = some out) :

--- a/EvmAsm/Evm64/SDiv/HandlerBridge.lean
+++ b/EvmAsm/Evm64/SDiv/HandlerBridge.lean
@@ -24,6 +24,28 @@ theorem sdivHandler_gas
     simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler,
       EvmState.withStack, EvmState.invalid, EvmState.withStatus, h_stack]
 
+theorem sdivHandler_memoryCells
+    (state : EvmState) :
+    (ArithmeticHandlers.sdivHandler state).memoryCells =
+      state.memoryCells := by
+  cases h_stack : ArithmeticHandlers.binaryStack? EvmWord.sdiv state.stack <;>
+    simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler,
+      EvmState.withStack, EvmState.invalid, EvmState.withStatus, h_stack]
+
+theorem sdivHandler_memory
+    (state : EvmState) :
+    (ArithmeticHandlers.sdivHandler state).memory = state.memory := by
+  cases h_stack : ArithmeticHandlers.binaryStack? EvmWord.sdiv state.stack <;>
+    simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler,
+      EvmState.withStack, EvmState.invalid, EvmState.withStatus, h_stack]
+
+theorem sdivHandler_memSize
+    (state : EvmState) :
+    (ArithmeticHandlers.sdivHandler state).memSize = state.memSize := by
+  cases h_stack : ArithmeticHandlers.binaryStack? EvmWord.sdiv state.stack <;>
+    simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler,
+      EvmState.withStack, EvmState.invalid, EvmState.withStatus, h_stack]
+
 theorem sdivHandler_stack_of_runSDivStack?_some
     {state : EvmState} {out : SDivStackResult}
     (h_run : runSDivStack? { stack := state.stack } = some out) :

--- a/EvmAsm/Evm64/SDiv/HandlerBridge.lean
+++ b/EvmAsm/Evm64/SDiv/HandlerBridge.lean
@@ -1,0 +1,53 @@
+/-
+  EvmAsm.Evm64.SDiv.HandlerBridge
+
+  Connects the pure SDIV opcode handler to the SDIV stack-execution bridge.
+-/
+
+import EvmAsm.Evm64.ArithmeticHandlers
+import EvmAsm.Evm64.SDiv.StackExecutionBridge
+
+namespace EvmAsm.Evm64
+namespace SDivStackExecutionBridge
+
+theorem sdivHandler_stack_of_runSDivStack?_some
+    {state : EvmState} {out : SDivStackResult}
+    (h_run : runSDivStack? { stack := state.stack } = some out) :
+    (ArithmeticHandlers.sdivHandler state).stack =
+      out.effects.stackWords ++ out.stack := by
+  rw [runSDivStack?_eq_some_iff] at h_run
+  rcases h_run with ⟨dividend, divisor, rest, h_stack, h_out⟩
+  simp at h_stack
+  subst h_out
+  simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler,
+    SDivArgs.sdivResultFromArgs_eq, SDivArgs.sdivArgs, h_stack]
+
+theorem sdivHandler_status_of_runSDivStack?_some
+    {state : EvmState} {out : SDivStackResult}
+    (h_run : runSDivStack? { stack := state.stack } = some out) :
+    (ArithmeticHandlers.sdivHandler state).status = state.status := by
+  rw [runSDivStack?_eq_some_iff] at h_run
+  rcases h_run with ⟨dividend, divisor, rest, h_stack, h_out⟩
+  simp at h_stack
+  simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler,
+    EvmState.withStack, h_stack]
+
+theorem sdivHandler_status_of_runSDivStack?_none
+    {state : EvmState}
+    (h_run : runSDivStack? { stack := state.stack } = none) :
+    (ArithmeticHandlers.sdivHandler state).status = .error := by
+  cases h_stack : state.stack with
+  | nil =>
+      simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler,
+        h_stack]
+  | cons dividend tail =>
+      cases h_tail : tail with
+      | nil =>
+          simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler,
+            h_stack, h_tail]
+      | cons divisor rest =>
+          simp [runSDivStack?, SDivArgsStackDecode.decodeSDivStack?,
+            stackRestAfterSDiv?, Option.bind, h_stack, h_tail] at h_run
+
+end SDivStackExecutionBridge
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/SDiv/HandlerBridge.lean
+++ b/EvmAsm/Evm64/SDiv/HandlerBridge.lean
@@ -10,6 +10,13 @@ import EvmAsm.Evm64.SDiv.StackExecutionBridge
 namespace EvmAsm.Evm64
 namespace SDivStackExecutionBridge
 
+theorem sdivHandler_pc
+    (state : EvmState) :
+    (ArithmeticHandlers.sdivHandler state).pc = state.pc := by
+  cases h_stack : ArithmeticHandlers.binaryStack? EvmWord.sdiv state.stack <;>
+    simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler,
+      EvmState.withStack, EvmState.invalid, EvmState.withStatus, h_stack]
+
 theorem sdivHandler_stack_of_runSDivStack?_some
     {state : EvmState} {out : SDivStackResult}
     (h_run : runSDivStack? { stack := state.stack } = some out) :

--- a/EvmAsm/Evm64/SDiv/StackExecutionBridge.lean
+++ b/EvmAsm/Evm64/SDiv/StackExecutionBridge.lean
@@ -65,6 +65,98 @@ theorem stackRestAfterSDiv?_none_of_one
     (dividend : EvmWord) :
     stackRestAfterSDiv? [dividend] = none := rfl
 
+theorem stackRestAfterSDiv?_eq_none_iff
+    {stack : List EvmWord} :
+    stackRestAfterSDiv? stack = none ↔
+      stack = [] ∨ ∃ dividend, stack = [dividend] := by
+  constructor
+  · cases stack with
+    | nil =>
+        intro _h
+        exact Or.inl rfl
+    | cons dividend tail =>
+        cases tail with
+        | nil =>
+            intro _h
+            exact Or.inr ⟨dividend, rfl⟩
+        | cons divisor rest =>
+            simp [stackRestAfterSDiv?]
+  · rintro (rfl | ⟨dividend, rfl⟩) <;> rfl
+
+theorem runSDivStack?_eq_none_iff
+    {state : SDivStackState} :
+    runSDivStack? state = none ↔
+      state.stack = [] ∨ ∃ dividend, state.stack = [dividend] := by
+  cases state with
+  | mk stack =>
+      cases stack with
+      | nil =>
+          simp [runSDivStack?, SDivArgsStackDecode.decodeSDivStack?,
+            stackRestAfterSDiv?, Option.bind]
+      | cons dividend tail =>
+          cases tail with
+          | nil =>
+              simp [runSDivStack?, SDivArgsStackDecode.decodeSDivStack?,
+                stackRestAfterSDiv?, Option.bind]
+          | cons divisor rest =>
+              simp [runSDivStack?, SDivArgsStackDecode.decodeSDivStack?,
+                stackRestAfterSDiv?, Option.bind]
+
+theorem runSDivStack?_eq_some_iff
+    {state : SDivStackState} {out : SDivStackResult} :
+    runSDivStack? state = some out ↔
+      ∃ dividend divisor rest,
+        state.stack = dividend :: divisor :: rest ∧
+          out =
+            { effects :=
+                { stackWords := [SDivArgs.sdivResultFromArgs
+                    (SDivArgs.sdivArgs dividend divisor)] }
+              stack := rest } := by
+  constructor
+  · cases state with
+    | mk stack =>
+        cases stack with
+        | nil =>
+            simp [runSDivStack?, SDivArgsStackDecode.decodeSDivStack?,
+              stackRestAfterSDiv?, Option.bind]
+        | cons dividend tail =>
+            cases tail with
+            | nil =>
+                simp [runSDivStack?, SDivArgsStackDecode.decodeSDivStack?,
+                  stackRestAfterSDiv?, Option.bind]
+            | cons divisor rest =>
+                intro h_run
+                simp [runSDivStack?, SDivArgsStackDecode.decodeSDivStack?,
+                  stackRestAfterSDiv?, Option.bind] at h_run
+                cases h_run
+                exact ⟨dividend, divisor, rest, rfl, rfl⟩
+  · rintro ⟨dividend, divisor, rest, h_stack, h_out⟩
+    cases state with
+    | mk stack =>
+        simp at h_stack
+        subst h_stack
+        subst h_out
+        exact runSDivStack?_cons dividend divisor rest
+
+theorem runSDivStack?_stack_length
+    {state : SDivStackState} {out : SDivStackResult}
+    (h_run : runSDivStack? state = some out) :
+    out.stack.length + out.effects.stackWords.length + argumentCount =
+      state.stack.length + resultCount := by
+  cases state with
+  | mk stack =>
+      cases stack with
+      | nil =>
+          simp [runSDivStack?, SDivArgsStackDecode.decodeSDivStack?] at h_run
+      | cons dividend tail =>
+          cases tail with
+          | nil => simp [runSDivStack?, stackRestAfterSDiv?] at h_run
+          | cons divisor rest =>
+              simp [runSDivStack?, stackRestAfterSDiv?] at h_run
+              cases h_run
+              simp [argumentCount, resultCount, SDivArgs.stackArgumentCount,
+                SDivArgs.resultCount]
+
 theorem runSDivStack?_head?
     (dividend divisor : EvmWord) (rest : List EvmWord) :
     (runSDivStack? { stack := dividend :: divisor :: rest }).map

--- a/EvmAsm/Evm64/SDiv/StackExecutionBridge.lean
+++ b/EvmAsm/Evm64/SDiv/StackExecutionBridge.lean
@@ -1,0 +1,90 @@
+/-
+  EvmAsm.Evm64.SDiv.StackExecutionBridge
+
+  Pure stack-execution bridge for SDIV (GH #90).
+-/
+
+import EvmAsm.Evm64.SDiv.ArgsStackDecode
+
+namespace EvmAsm.Evm64
+namespace SDivStackExecutionBridge
+
+/-- Caller-visible stack effects of SDIV at the executable-spec layer. -/
+structure SDivVisibleEffects where
+  stackWords : List EvmWord
+  deriving Repr
+
+structure SDivStackState where
+  stack : List EvmWord
+  deriving Repr
+
+structure SDivStackResult where
+  effects : SDivVisibleEffects
+  stack : List EvmWord
+  deriving Repr
+
+def argumentCount : Nat := SDivArgs.stackArgumentCount
+
+def resultCount : Nat := SDivArgs.resultCount
+
+def stackRestAfterSDiv? : List EvmWord → Option (List EvmWord)
+  | _dividend :: _divisor :: rest => some rest
+  | _ => none
+
+/-- Execute the SDIV stack transition using the pure argument decoder. -/
+def runSDivStack? (state : SDivStackState) : Option SDivStackResult := do
+  let args ← SDivArgsStackDecode.decodeSDivStack? state.stack
+  let rest ← stackRestAfterSDiv? state.stack
+  some
+    { effects := { stackWords := [SDivArgs.sdivResultFromArgs args] }
+      stack := rest }
+
+theorem stackRestAfterSDiv?_cons
+    (dividend divisor : EvmWord) (rest : List EvmWord) :
+    stackRestAfterSDiv? (dividend :: divisor :: rest) = some rest := rfl
+
+theorem runSDivStack?_cons
+    (dividend divisor : EvmWord) (rest : List EvmWord) :
+    runSDivStack? { stack := dividend :: divisor :: rest } =
+      some
+        { effects :=
+            { stackWords := [SDivArgs.sdivResultFromArgs
+                (SDivArgs.sdivArgs dividend divisor)] }
+          stack := rest } := rfl
+
+theorem runSDivStack?_underflow_nil :
+    runSDivStack? { stack := [] } = none := rfl
+
+theorem runSDivStack?_underflow_one (dividend : EvmWord) :
+    runSDivStack? { stack := [dividend] } = none := rfl
+
+theorem stackRestAfterSDiv?_none_of_empty :
+    stackRestAfterSDiv? [] = none := rfl
+
+theorem stackRestAfterSDiv?_none_of_one
+    (dividend : EvmWord) :
+    stackRestAfterSDiv? [dividend] = none := rfl
+
+theorem runSDivStack?_head?
+    (dividend divisor : EvmWord) (rest : List EvmWord) :
+    (runSDivStack? { stack := dividend :: divisor :: rest }).map
+      (fun out => out.effects.stackWords.head?) =
+      some (some (SDivArgs.sdivResultFromArgs
+        (SDivArgs.sdivArgs dividend divisor))) := rfl
+
+theorem runSDivStack?_zero_divisor
+    (dividend : EvmWord) (rest : List EvmWord) :
+    runSDivStack? { stack := dividend :: 0 :: rest } =
+      some { effects := { stackWords := [0] }, stack := rest } := by
+  rw [runSDivStack?_cons]
+  rw [SDivArgs.sdivResultFromArgs_zero_divisor]
+
+theorem runSDivStack?_intMin_neg_one
+    (rest : List EvmWord) :
+    runSDivStack? { stack := BitVec.intMin 256 :: (-1 : EvmWord) :: rest } =
+      some { effects := { stackWords := [BitVec.intMin 256] }, stack := rest } := by
+  rw [runSDivStack?_cons]
+  rw [SDivArgs.sdivResultFromArgs_intMin_neg_one]
+
+end SDivStackExecutionBridge
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/SDiv/StackExecutionBridge.lean
+++ b/EvmAsm/Evm64/SDiv/StackExecutionBridge.lean
@@ -178,5 +178,19 @@ theorem runSDivStack?_intMin_neg_one
   rw [runSDivStack?_cons]
   rw [SDivArgs.sdivResultFromArgs_intMin_neg_one]
 
+theorem runSDivStack?_neg_one_two
+    (rest : List EvmWord) :
+    runSDivStack? { stack := (-1 : EvmWord) :: 2 :: rest } =
+      some { effects := { stackWords := [0] }, stack := rest } := by
+  rw [runSDivStack?_cons]
+  rw [SDivArgs.sdivResultFromArgs_neg_one_two]
+
+theorem runSDivStack?_pos_neg_trunc
+    (rest : List EvmWord) :
+    runSDivStack? { stack := (7 : EvmWord) :: (-2 : EvmWord) :: rest } =
+      some { effects := { stackWords := [(-3 : EvmWord)] }, stack := rest } := by
+  rw [runSDivStack?_cons]
+  rw [SDivArgs.sdivResultFromArgs_pos_neg_trunc]
+
 end SDivStackExecutionBridge
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/SMod.lean
+++ b/EvmAsm/Evm64/SMod.lean
@@ -14,6 +14,7 @@ import EvmAsm.Evm64.SMod.AddrNormAttr
 import EvmAsm.Evm64.SMod.Layout
 import EvmAsm.Evm64.SMod.Args
 import EvmAsm.Evm64.SMod.ArgsStackDecode
+import EvmAsm.Evm64.SMod.StackExecutionBridge
 import EvmAsm.Evm64.SMod.Program
 import EvmAsm.Evm64.SMod.LimbSpec
 import EvmAsm.Evm64.SMod.AddrNorm

--- a/EvmAsm/Evm64/SMod.lean
+++ b/EvmAsm/Evm64/SMod.lean
@@ -12,6 +12,7 @@
 
 import EvmAsm.Evm64.SMod.AddrNormAttr
 import EvmAsm.Evm64.SMod.Layout
+import EvmAsm.Evm64.SMod.Args
 import EvmAsm.Evm64.SMod.Program
 import EvmAsm.Evm64.SMod.LimbSpec
 import EvmAsm.Evm64.SMod.AddrNorm

--- a/EvmAsm/Evm64/SMod.lean
+++ b/EvmAsm/Evm64/SMod.lean
@@ -13,6 +13,7 @@
 import EvmAsm.Evm64.SMod.AddrNormAttr
 import EvmAsm.Evm64.SMod.Layout
 import EvmAsm.Evm64.SMod.Args
+import EvmAsm.Evm64.SMod.ArgsStackDecode
 import EvmAsm.Evm64.SMod.Program
 import EvmAsm.Evm64.SMod.LimbSpec
 import EvmAsm.Evm64.SMod.AddrNorm

--- a/EvmAsm/Evm64/SMod.lean
+++ b/EvmAsm/Evm64/SMod.lean
@@ -15,6 +15,7 @@ import EvmAsm.Evm64.SMod.Layout
 import EvmAsm.Evm64.SMod.Args
 import EvmAsm.Evm64.SMod.ArgsStackDecode
 import EvmAsm.Evm64.SMod.StackExecutionBridge
+import EvmAsm.Evm64.SMod.HandlerBridge
 import EvmAsm.Evm64.SMod.Program
 import EvmAsm.Evm64.SMod.LimbSpec
 import EvmAsm.Evm64.SMod.AddrNorm

--- a/EvmAsm/Evm64/SMod/Args.lean
+++ b/EvmAsm/Evm64/SMod/Args.lean
@@ -1,0 +1,77 @@
+/-
+  EvmAsm.Evm64.SMod.Args
+
+  Pure stack-argument bridge for SMOD (GH #90).
+-/
+
+import EvmAsm.Evm64.EvmWordArith.SMod
+
+namespace EvmAsm.Evm64
+namespace SModArgs
+
+/-- SMOD stack arguments: dividend and divisor. -/
+structure Args where
+  dividend : EvmWord
+  divisor : EvmWord
+  deriving Repr
+
+/-- SMOD pops two stack words: dividend and divisor. -/
+def stackArgumentCount : Nat := 2
+
+/-- SMOD pushes one result word. -/
+def resultCount : Nat := 1
+
+/-- Convenience builder for SMOD stack arguments. -/
+def smodArgs (dividend divisor : EvmWord) : Args :=
+  { dividend := dividend, divisor := divisor }
+
+/-- SMOD result computed from decoded stack arguments. -/
+def smodResultFromArgs (args : Args) : EvmWord :=
+  EvmWord.smod args.dividend args.divisor
+
+/-- Stack after the SMOD result replaces the two operands. -/
+def stackAfterSMod (args : Args) (rest : List EvmWord) : List EvmWord :=
+  smodResultFromArgs args :: rest
+
+theorem stackArgumentCount_eq_two : stackArgumentCount = 2 := rfl
+
+theorem resultCount_eq_one : resultCount = 1 := rfl
+
+theorem smodArgs_dividend (dividend divisor : EvmWord) :
+    (smodArgs dividend divisor).dividend = dividend := rfl
+
+theorem smodArgs_divisor (dividend divisor : EvmWord) :
+    (smodArgs dividend divisor).divisor = divisor := rfl
+
+theorem smodResultFromArgs_eq (args : Args) :
+    smodResultFromArgs args = EvmWord.smod args.dividend args.divisor := rfl
+
+theorem stackAfterSMod_eq (args : Args) (rest : List EvmWord) :
+    stackAfterSMod args rest = smodResultFromArgs args :: rest := rfl
+
+@[simp] theorem stackAfterSMod_length (args : Args) (rest : List EvmWord) :
+    (stackAfterSMod args rest).length = rest.length + 1 := by
+  simp [stackAfterSMod]
+
+@[simp] theorem smodResultFromArgs_zero_divisor (dividend : EvmWord) :
+    smodResultFromArgs (smodArgs dividend 0) = 0 := by
+  exact EvmWord.smod_zero_right
+
+@[simp] theorem smodResultFromArgs_zero_dividend (divisor : EvmWord) :
+    smodResultFromArgs (smodArgs 0 divisor) = 0 := by
+  exact EvmWord.zero_smod_left
+
+theorem smodResultFromArgs_neg_pos_sign :
+    smodResultFromArgs (smodArgs (-3) 2) = (-1 : EvmWord) := by
+  exact EvmWord.smod_neg_pos_sign
+
+theorem smodResultFromArgs_pos_neg_sign :
+    smodResultFromArgs (smodArgs 3 (-2)) = (1 : EvmWord) := by
+  exact EvmWord.smod_pos_neg_sign
+
+theorem smodResultFromArgs_neg_neg_sign :
+    smodResultFromArgs (smodArgs (-3) (-2)) = (-1 : EvmWord) := by
+  exact EvmWord.smod_neg_neg_sign
+
+end SModArgs
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/SMod/ArgsStackDecode.lean
+++ b/EvmAsm/Evm64/SMod/ArgsStackDecode.lean
@@ -1,0 +1,83 @@
+/-
+  EvmAsm.Evm64.SMod.ArgsStackDecode
+
+  Pure top-of-stack decoder for SMOD executable-spec bridges (GH #90).
+-/
+
+import EvmAsm.Evm64.SMod.Args
+
+namespace EvmAsm.Evm64
+namespace SModArgsStackDecode
+
+/--
+Decode SMOD stack arguments from the top-of-stack list order:
+`dividend, divisor`.
+-/
+def decodeSModStack? : List EvmWord → Option SModArgs.Args
+  | dividend :: divisor :: _ => some (SModArgs.smodArgs dividend divisor)
+  | _ => none
+
+theorem decodeSModStack?_cons
+    (dividend divisor : EvmWord) (rest : List EvmWord) :
+    decodeSModStack? (dividend :: divisor :: rest) =
+      some (SModArgs.smodArgs dividend divisor) := rfl
+
+theorem decodeSModStack?_eq_some_iff
+    {stack : List EvmWord} {args : SModArgs.Args} :
+    decodeSModStack? stack = some args ↔
+      ∃ dividend divisor rest,
+        stack = dividend :: divisor :: rest ∧
+          args = SModArgs.smodArgs dividend divisor := by
+  constructor
+  · cases stack with
+    | nil => simp [decodeSModStack?]
+    | cons dividend tail =>
+        cases tail with
+        | nil => simp [decodeSModStack?]
+        | cons divisor rest =>
+            intro h
+            injection h with h_args
+            subst h_args
+            exact ⟨dividend, divisor, rest, rfl, rfl⟩
+  · rintro ⟨dividend, divisor, rest, rfl, rfl⟩
+    rfl
+
+theorem decodeSModStack?_eq_none_iff
+    {stack : List EvmWord} :
+    decodeSModStack? stack = none ↔
+      stack = [] ∨ ∃ dividend, stack = [dividend] := by
+  constructor
+  · cases stack with
+    | nil =>
+        intro _h
+        exact Or.inl rfl
+    | cons dividend tail =>
+        cases tail with
+        | nil =>
+            intro _h
+            exact Or.inr ⟨dividend, rfl⟩
+        | cons divisor rest =>
+            simp [decodeSModStack?]
+  · rintro (rfl | ⟨dividend, rfl⟩) <;> rfl
+
+theorem decodeSModStack?_none_of_empty :
+    decodeSModStack? [] = none := rfl
+
+theorem decodeSModStack?_none_of_one
+    (dividend : EvmWord) :
+    decodeSModStack? [dividend] = none := rfl
+
+theorem decodeSModStack?_dividend
+    (dividend divisor : EvmWord) (rest : List EvmWord) :
+    Option.map (fun args => args.dividend)
+      (decodeSModStack? (dividend :: divisor :: rest)) =
+      some dividend := rfl
+
+theorem decodeSModStack?_divisor
+    (dividend divisor : EvmWord) (rest : List EvmWord) :
+    Option.map (fun args => args.divisor)
+      (decodeSModStack? (dividend :: divisor :: rest)) =
+      some divisor := rfl
+
+end SModArgsStackDecode
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/SMod/HandlerBridge.lean
+++ b/EvmAsm/Evm64/SMod/HandlerBridge.lean
@@ -67,6 +67,13 @@ theorem smodHandler_env
     simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler,
       EvmState.withStack, EvmState.invalid, EvmState.withStatus, h_stack]
 
+theorem smodHandler_codeLenMatches
+    (state : EvmState) (h_codeLen : state.codeLenMatches) :
+    (ArithmeticHandlers.smodHandler state).codeLenMatches := by
+  unfold EvmState.codeLenMatches at h_codeLen ⊢
+  rw [smodHandler_codeLen, smodHandler_code]
+  exact h_codeLen
+
 theorem smodHandler_stack_of_runSModStack?_some
     {state : EvmState} {out : SModStackResult}
     (h_run : runSModStack? { stack := state.stack } = some out) :

--- a/EvmAsm/Evm64/SMod/HandlerBridge.lean
+++ b/EvmAsm/Evm64/SMod/HandlerBridge.lean
@@ -17,6 +17,13 @@ theorem smodHandler_pc
     simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler,
       EvmState.withStack, EvmState.invalid, EvmState.withStatus, h_stack]
 
+theorem smodHandler_gas
+    (state : EvmState) :
+    (ArithmeticHandlers.smodHandler state).gas = state.gas := by
+  cases h_stack : ArithmeticHandlers.binaryStack? EvmWord.smod state.stack <;>
+    simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler,
+      EvmState.withStack, EvmState.invalid, EvmState.withStatus, h_stack]
+
 theorem smodHandler_stack_of_runSModStack?_some
     {state : EvmState} {out : SModStackResult}
     (h_run : runSModStack? { stack := state.stack } = some out) :

--- a/EvmAsm/Evm64/SMod/HandlerBridge.lean
+++ b/EvmAsm/Evm64/SMod/HandlerBridge.lean
@@ -49,6 +49,18 @@ theorem smodHandler_status_of_runSModStack?_none
           simp [runSModStack?, SModArgsStackDecode.decodeSModStack?,
             stackRestAfterSMod?, Option.bind, h_stack, h_tail] at h_run
 
+theorem smodHandler_status_empty_stack
+    (state : EvmState) :
+    (ArithmeticHandlers.smodHandler { state with stack := [] }).status =
+      .error := by
+  simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler]
+
+theorem smodHandler_status_singleton_stack
+    (state : EvmState) (dividend : EvmWord) :
+    (ArithmeticHandlers.smodHandler
+      { state with stack := [dividend] }).status = .error := by
+  simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler]
+
 theorem smodHandler_stack_zero_divisor
     (state : EvmState) (dividend : EvmWord) (rest : List EvmWord) :
     (ArithmeticHandlers.smodHandler

--- a/EvmAsm/Evm64/SMod/HandlerBridge.lean
+++ b/EvmAsm/Evm64/SMod/HandlerBridge.lean
@@ -49,5 +49,37 @@ theorem smodHandler_status_of_runSModStack?_none
           simp [runSModStack?, SModArgsStackDecode.decodeSModStack?,
             stackRestAfterSMod?, Option.bind, h_stack, h_tail] at h_run
 
+theorem smodHandler_stack_zero_divisor
+    (state : EvmState) (dividend : EvmWord) (rest : List EvmWord) :
+    (ArithmeticHandlers.smodHandler
+      { state with stack := dividend :: 0 :: rest }).stack =
+        0 :: rest := by
+  simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler]
+  exact EvmWord.smod_zero_right
+
+theorem smodHandler_stack_neg_pos_sign
+    (state : EvmState) (rest : List EvmWord) :
+    (ArithmeticHandlers.smodHandler
+      { state with stack := (-3 : EvmWord) :: 2 :: rest }).stack =
+        (-1 : EvmWord) :: rest := by
+  simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler]
+  exact EvmWord.smod_neg_pos_sign
+
+theorem smodHandler_stack_pos_neg_sign
+    (state : EvmState) (rest : List EvmWord) :
+    (ArithmeticHandlers.smodHandler
+      { state with stack := (3 : EvmWord) :: (-2 : EvmWord) :: rest }).stack =
+        (1 : EvmWord) :: rest := by
+  simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler]
+  exact EvmWord.smod_pos_neg_sign
+
+theorem smodHandler_stack_neg_neg_sign
+    (state : EvmState) (rest : List EvmWord) :
+    (ArithmeticHandlers.smodHandler
+      { state with stack := (-3 : EvmWord) :: (-2 : EvmWord) :: rest }).stack =
+        (-1 : EvmWord) :: rest := by
+  simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler]
+  exact EvmWord.smod_neg_neg_sign
+
 end SModStackExecutionBridge
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/SMod/HandlerBridge.lean
+++ b/EvmAsm/Evm64/SMod/HandlerBridge.lean
@@ -24,6 +24,28 @@ theorem smodHandler_gas
     simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler,
       EvmState.withStack, EvmState.invalid, EvmState.withStatus, h_stack]
 
+theorem smodHandler_memoryCells
+    (state : EvmState) :
+    (ArithmeticHandlers.smodHandler state).memoryCells =
+      state.memoryCells := by
+  cases h_stack : ArithmeticHandlers.binaryStack? EvmWord.smod state.stack <;>
+    simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler,
+      EvmState.withStack, EvmState.invalid, EvmState.withStatus, h_stack]
+
+theorem smodHandler_memory
+    (state : EvmState) :
+    (ArithmeticHandlers.smodHandler state).memory = state.memory := by
+  cases h_stack : ArithmeticHandlers.binaryStack? EvmWord.smod state.stack <;>
+    simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler,
+      EvmState.withStack, EvmState.invalid, EvmState.withStatus, h_stack]
+
+theorem smodHandler_memSize
+    (state : EvmState) :
+    (ArithmeticHandlers.smodHandler state).memSize = state.memSize := by
+  cases h_stack : ArithmeticHandlers.binaryStack? EvmWord.smod state.stack <;>
+    simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler,
+      EvmState.withStack, EvmState.invalid, EvmState.withStatus, h_stack]
+
 theorem smodHandler_stack_of_runSModStack?_some
     {state : EvmState} {out : SModStackResult}
     (h_run : runSModStack? { stack := state.stack } = some out) :

--- a/EvmAsm/Evm64/SMod/HandlerBridge.lean
+++ b/EvmAsm/Evm64/SMod/HandlerBridge.lean
@@ -46,6 +46,27 @@ theorem smodHandler_memSize
     simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler,
       EvmState.withStack, EvmState.invalid, EvmState.withStatus, h_stack]
 
+theorem smodHandler_code
+    (state : EvmState) :
+    (ArithmeticHandlers.smodHandler state).code = state.code := by
+  cases h_stack : ArithmeticHandlers.binaryStack? EvmWord.smod state.stack <;>
+    simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler,
+      EvmState.withStack, EvmState.invalid, EvmState.withStatus, h_stack]
+
+theorem smodHandler_codeLen
+    (state : EvmState) :
+    (ArithmeticHandlers.smodHandler state).codeLen = state.codeLen := by
+  cases h_stack : ArithmeticHandlers.binaryStack? EvmWord.smod state.stack <;>
+    simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler,
+      EvmState.withStack, EvmState.invalid, EvmState.withStatus, h_stack]
+
+theorem smodHandler_env
+    (state : EvmState) :
+    (ArithmeticHandlers.smodHandler state).env = state.env := by
+  cases h_stack : ArithmeticHandlers.binaryStack? EvmWord.smod state.stack <;>
+    simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler,
+      EvmState.withStack, EvmState.invalid, EvmState.withStatus, h_stack]
+
 theorem smodHandler_stack_of_runSModStack?_some
     {state : EvmState} {out : SModStackResult}
     (h_run : runSModStack? { stack := state.stack } = some out) :

--- a/EvmAsm/Evm64/SMod/HandlerBridge.lean
+++ b/EvmAsm/Evm64/SMod/HandlerBridge.lean
@@ -10,6 +10,13 @@ import EvmAsm.Evm64.SMod.StackExecutionBridge
 namespace EvmAsm.Evm64
 namespace SModStackExecutionBridge
 
+theorem smodHandler_pc
+    (state : EvmState) :
+    (ArithmeticHandlers.smodHandler state).pc = state.pc := by
+  cases h_stack : ArithmeticHandlers.binaryStack? EvmWord.smod state.stack <;>
+    simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler,
+      EvmState.withStack, EvmState.invalid, EvmState.withStatus, h_stack]
+
 theorem smodHandler_stack_of_runSModStack?_some
     {state : EvmState} {out : SModStackResult}
     (h_run : runSModStack? { stack := state.stack } = some out) :

--- a/EvmAsm/Evm64/SMod/HandlerBridge.lean
+++ b/EvmAsm/Evm64/SMod/HandlerBridge.lean
@@ -1,0 +1,53 @@
+/-
+  EvmAsm.Evm64.SMod.HandlerBridge
+
+  Connects the pure SMOD opcode handler to the SMOD stack-execution bridge.
+-/
+
+import EvmAsm.Evm64.ArithmeticHandlers
+import EvmAsm.Evm64.SMod.StackExecutionBridge
+
+namespace EvmAsm.Evm64
+namespace SModStackExecutionBridge
+
+theorem smodHandler_stack_of_runSModStack?_some
+    {state : EvmState} {out : SModStackResult}
+    (h_run : runSModStack? { stack := state.stack } = some out) :
+    (ArithmeticHandlers.smodHandler state).stack =
+      out.effects.stackWords ++ out.stack := by
+  rw [runSModStack?_eq_some_iff] at h_run
+  rcases h_run with ⟨dividend, divisor, rest, h_stack, h_out⟩
+  simp at h_stack
+  subst h_out
+  simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler,
+    SModArgs.smodResultFromArgs_eq, SModArgs.smodArgs, h_stack]
+
+theorem smodHandler_status_of_runSModStack?_some
+    {state : EvmState} {out : SModStackResult}
+    (h_run : runSModStack? { stack := state.stack } = some out) :
+    (ArithmeticHandlers.smodHandler state).status = state.status := by
+  rw [runSModStack?_eq_some_iff] at h_run
+  rcases h_run with ⟨dividend, divisor, rest, h_stack, h_out⟩
+  simp at h_stack
+  simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler,
+    EvmState.withStack, h_stack]
+
+theorem smodHandler_status_of_runSModStack?_none
+    {state : EvmState}
+    (h_run : runSModStack? { stack := state.stack } = none) :
+    (ArithmeticHandlers.smodHandler state).status = .error := by
+  cases h_stack : state.stack with
+  | nil =>
+      simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler,
+        h_stack]
+  | cons dividend tail =>
+      cases h_tail : tail with
+      | nil =>
+          simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler,
+            h_stack, h_tail]
+      | cons divisor rest =>
+          simp [runSModStack?, SModArgsStackDecode.decodeSModStack?,
+            stackRestAfterSMod?, Option.bind, h_stack, h_tail] at h_run
+
+end SModStackExecutionBridge
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/SMod/StackExecutionBridge.lean
+++ b/EvmAsm/Evm64/SMod/StackExecutionBridge.lean
@@ -65,6 +65,98 @@ theorem stackRestAfterSMod?_none_of_one
     (dividend : EvmWord) :
     stackRestAfterSMod? [dividend] = none := rfl
 
+theorem stackRestAfterSMod?_eq_none_iff
+    {stack : List EvmWord} :
+    stackRestAfterSMod? stack = none ↔
+      stack = [] ∨ ∃ dividend, stack = [dividend] := by
+  constructor
+  · cases stack with
+    | nil =>
+        intro _h
+        exact Or.inl rfl
+    | cons dividend tail =>
+        cases tail with
+        | nil =>
+            intro _h
+            exact Or.inr ⟨dividend, rfl⟩
+        | cons divisor rest =>
+            simp [stackRestAfterSMod?]
+  · rintro (rfl | ⟨dividend, rfl⟩) <;> rfl
+
+theorem runSModStack?_eq_none_iff
+    {state : SModStackState} :
+    runSModStack? state = none ↔
+      state.stack = [] ∨ ∃ dividend, state.stack = [dividend] := by
+  cases state with
+  | mk stack =>
+      cases stack with
+      | nil =>
+          simp [runSModStack?, SModArgsStackDecode.decodeSModStack?,
+            stackRestAfterSMod?, Option.bind]
+      | cons dividend tail =>
+          cases tail with
+          | nil =>
+              simp [runSModStack?, SModArgsStackDecode.decodeSModStack?,
+                stackRestAfterSMod?, Option.bind]
+          | cons divisor rest =>
+              simp [runSModStack?, SModArgsStackDecode.decodeSModStack?,
+                stackRestAfterSMod?, Option.bind]
+
+theorem runSModStack?_eq_some_iff
+    {state : SModStackState} {out : SModStackResult} :
+    runSModStack? state = some out ↔
+      ∃ dividend divisor rest,
+        state.stack = dividend :: divisor :: rest ∧
+          out =
+            { effects :=
+                { stackWords := [SModArgs.smodResultFromArgs
+                    (SModArgs.smodArgs dividend divisor)] }
+              stack := rest } := by
+  constructor
+  · cases state with
+    | mk stack =>
+        cases stack with
+        | nil =>
+            simp [runSModStack?, SModArgsStackDecode.decodeSModStack?,
+              stackRestAfterSMod?, Option.bind]
+        | cons dividend tail =>
+            cases tail with
+            | nil =>
+                simp [runSModStack?, SModArgsStackDecode.decodeSModStack?,
+                  stackRestAfterSMod?, Option.bind]
+            | cons divisor rest =>
+                intro h_run
+                simp [runSModStack?, SModArgsStackDecode.decodeSModStack?,
+                  stackRestAfterSMod?, Option.bind] at h_run
+                cases h_run
+                exact ⟨dividend, divisor, rest, rfl, rfl⟩
+  · rintro ⟨dividend, divisor, rest, h_stack, h_out⟩
+    cases state with
+    | mk stack =>
+        simp at h_stack
+        subst h_stack
+        subst h_out
+        exact runSModStack?_cons dividend divisor rest
+
+theorem runSModStack?_stack_length
+    {state : SModStackState} {out : SModStackResult}
+    (h_run : runSModStack? state = some out) :
+    out.stack.length + out.effects.stackWords.length + argumentCount =
+      state.stack.length + resultCount := by
+  cases state with
+  | mk stack =>
+      cases stack with
+      | nil =>
+          simp [runSModStack?, SModArgsStackDecode.decodeSModStack?] at h_run
+      | cons dividend tail =>
+          cases tail with
+          | nil => simp [runSModStack?, stackRestAfterSMod?] at h_run
+          | cons divisor rest =>
+              simp [runSModStack?, stackRestAfterSMod?] at h_run
+              cases h_run
+              simp [argumentCount, resultCount, SModArgs.stackArgumentCount,
+                SModArgs.resultCount]
+
 theorem runSModStack?_head?
     (dividend divisor : EvmWord) (rest : List EvmWord) :
     (runSModStack? { stack := dividend :: divisor :: rest }).map

--- a/EvmAsm/Evm64/SMod/StackExecutionBridge.lean
+++ b/EvmAsm/Evm64/SMod/StackExecutionBridge.lean
@@ -1,0 +1,90 @@
+/-
+  EvmAsm.Evm64.SMod.StackExecutionBridge
+
+  Pure stack-execution bridge for SMOD (GH #90).
+-/
+
+import EvmAsm.Evm64.SMod.ArgsStackDecode
+
+namespace EvmAsm.Evm64
+namespace SModStackExecutionBridge
+
+/-- Caller-visible stack effects of SMOD at the executable-spec layer. -/
+structure SModVisibleEffects where
+  stackWords : List EvmWord
+  deriving Repr
+
+structure SModStackState where
+  stack : List EvmWord
+  deriving Repr
+
+structure SModStackResult where
+  effects : SModVisibleEffects
+  stack : List EvmWord
+  deriving Repr
+
+def argumentCount : Nat := SModArgs.stackArgumentCount
+
+def resultCount : Nat := SModArgs.resultCount
+
+def stackRestAfterSMod? : List EvmWord → Option (List EvmWord)
+  | _dividend :: _divisor :: rest => some rest
+  | _ => none
+
+/-- Execute the SMOD stack transition using the pure argument decoder. -/
+def runSModStack? (state : SModStackState) : Option SModStackResult := do
+  let args ← SModArgsStackDecode.decodeSModStack? state.stack
+  let rest ← stackRestAfterSMod? state.stack
+  some
+    { effects := { stackWords := [SModArgs.smodResultFromArgs args] }
+      stack := rest }
+
+theorem stackRestAfterSMod?_cons
+    (dividend divisor : EvmWord) (rest : List EvmWord) :
+    stackRestAfterSMod? (dividend :: divisor :: rest) = some rest := rfl
+
+theorem runSModStack?_cons
+    (dividend divisor : EvmWord) (rest : List EvmWord) :
+    runSModStack? { stack := dividend :: divisor :: rest } =
+      some
+        { effects :=
+            { stackWords := [SModArgs.smodResultFromArgs
+                (SModArgs.smodArgs dividend divisor)] }
+          stack := rest } := rfl
+
+theorem runSModStack?_underflow_nil :
+    runSModStack? { stack := [] } = none := rfl
+
+theorem runSModStack?_underflow_one (dividend : EvmWord) :
+    runSModStack? { stack := [dividend] } = none := rfl
+
+theorem stackRestAfterSMod?_none_of_empty :
+    stackRestAfterSMod? [] = none := rfl
+
+theorem stackRestAfterSMod?_none_of_one
+    (dividend : EvmWord) :
+    stackRestAfterSMod? [dividend] = none := rfl
+
+theorem runSModStack?_head?
+    (dividend divisor : EvmWord) (rest : List EvmWord) :
+    (runSModStack? { stack := dividend :: divisor :: rest }).map
+      (fun out => out.effects.stackWords.head?) =
+      some (some (SModArgs.smodResultFromArgs
+        (SModArgs.smodArgs dividend divisor))) := rfl
+
+theorem runSModStack?_zero_divisor
+    (dividend : EvmWord) (rest : List EvmWord) :
+    runSModStack? { stack := dividend :: 0 :: rest } =
+      some { effects := { stackWords := [0] }, stack := rest } := by
+  rw [runSModStack?_cons]
+  rw [SModArgs.smodResultFromArgs_zero_divisor]
+
+theorem runSModStack?_neg_pos_sign
+    (rest : List EvmWord) :
+    runSModStack? { stack := (-3 : EvmWord) :: 2 :: rest } =
+      some { effects := { stackWords := [(-1 : EvmWord)] }, stack := rest } := by
+  rw [runSModStack?_cons]
+  rw [SModArgs.smodResultFromArgs_neg_pos_sign]
+
+end SModStackExecutionBridge
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/SMod/StackExecutionBridge.lean
+++ b/EvmAsm/Evm64/SMod/StackExecutionBridge.lean
@@ -178,5 +178,19 @@ theorem runSModStack?_neg_pos_sign
   rw [runSModStack?_cons]
   rw [SModArgs.smodResultFromArgs_neg_pos_sign]
 
+theorem runSModStack?_pos_neg_sign
+    (rest : List EvmWord) :
+    runSModStack? { stack := (3 : EvmWord) :: (-2 : EvmWord) :: rest } =
+      some { effects := { stackWords := [(1 : EvmWord)] }, stack := rest } := by
+  rw [runSModStack?_cons]
+  rw [SModArgs.smodResultFromArgs_pos_neg_sign]
+
+theorem runSModStack?_neg_neg_sign
+    (rest : List EvmWord) :
+    runSModStack? { stack := (-3 : EvmWord) :: (-2 : EvmWord) :: rest } =
+      some { effects := { stackWords := [(-1 : EvmWord)] }, stack := rest } := by
+  rw [runSModStack?_cons]
+  rw [SModArgs.smodResultFromArgs_neg_neg_sign]
+
 end SModStackExecutionBridge
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/SupportedHandlerByte.lean
+++ b/EvmAsm/Evm64/SupportedHandlerByte.lean
@@ -127,6 +127,42 @@ theorem dispatchByte_supported_INVALID_byte
   rw [dispatchByte_supported_INVALID_byte]
   exact EvmState.invalid_status state
 
+theorem dispatchByte_supported_SDIV_byte
+    (state : EvmState) :
+    HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x05, by decide⟩ : Fin 256) state =
+        ArithmeticHandlers.sdivHandler state := by
+  exact dispatchByte_supported_of_lookup rfl
+    SupportedHandlers.supportedHandlerTable_SDIV state
+
+theorem dispatchByte_supported_SMOD_byte
+    (state : EvmState) :
+    HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x07, by decide⟩ : Fin 256) state =
+        ArithmeticHandlers.smodHandler state := by
+  exact dispatchByte_supported_of_lookup rfl
+    SupportedHandlers.supportedHandlerTable_SMOD state
+
+@[simp] theorem dispatchByte_supported_SDIV_byte_status_of_some
+    {state : EvmState} {stack' : List EvmWord}
+    (h_stack : ArithmeticHandlers.binaryStack? EvmWord.sdiv state.stack =
+      some stack') :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x05, by decide⟩ : Fin 256) state).status = state.status := by
+  rw [dispatchByte_supported_SDIV_byte]
+  simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler,
+    h_stack, EvmState.withStack]
+
+@[simp] theorem dispatchByte_supported_SMOD_byte_status_of_some
+    {state : EvmState} {stack' : List EvmWord}
+    (h_stack : ArithmeticHandlers.binaryStack? EvmWord.smod state.stack =
+      some stack') :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x07, by decide⟩ : Fin 256) state).status = state.status := by
+  rw [dispatchByte_supported_SMOD_byte]
+  simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler,
+    h_stack, EvmState.withStack]
+
 theorem dispatchByte_supported_undecoded
     {b : Fin 256} (h_decode : EvmOpcode.decodeByte? b.val = none)
     (state : EvmState) :

--- a/EvmAsm/Evm64/SupportedHandlerByte.lean
+++ b/EvmAsm/Evm64/SupportedHandlerByte.lean
@@ -243,6 +243,30 @@ theorem dispatchByte_supported_SMOD_byte_stack_of_runSModStack?_some
   exact SModStackExecutionBridge.smodHandler_stack_of_runSModStack?_some
     h_run
 
+theorem dispatchByte_supported_SDIV_byte_status_of_runSDivStack?_some
+    {state : EvmState} {out : SDivStackExecutionBridge.SDivStackResult}
+    (h_run :
+      SDivStackExecutionBridge.runSDivStack? { stack := state.stack } =
+        some out) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x05, by decide⟩ : Fin 256) state).status =
+        state.status := by
+  rw [dispatchByte_supported_SDIV_byte]
+  exact SDivStackExecutionBridge.sdivHandler_status_of_runSDivStack?_some
+    h_run
+
+theorem dispatchByte_supported_SMOD_byte_status_of_runSModStack?_some
+    {state : EvmState} {out : SModStackExecutionBridge.SModStackResult}
+    (h_run :
+      SModStackExecutionBridge.runSModStack? { stack := state.stack } =
+        some out) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x07, by decide⟩ : Fin 256) state).status =
+        state.status := by
+  rw [dispatchByte_supported_SMOD_byte]
+  exact SModStackExecutionBridge.smodHandler_status_of_runSModStack?_some
+    h_run
+
 theorem dispatchByte_supported_SDIV_byte_status_empty_stack
     (state : EvmState) :
     (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable

--- a/EvmAsm/Evm64/SupportedHandlerByte.lean
+++ b/EvmAsm/Evm64/SupportedHandlerByte.lean
@@ -145,6 +145,20 @@ theorem dispatchByte_supported_SMOD_byte
   exact dispatchByte_supported_of_lookup rfl
     SupportedHandlers.supportedHandlerTable_SMOD state
 
+theorem dispatchByte_supported_SDIV_byte_pc
+    (state : EvmState) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x05, by decide⟩ : Fin 256) state).pc = state.pc := by
+  rw [dispatchByte_supported_SDIV_byte]
+  exact SDivStackExecutionBridge.sdivHandler_pc state
+
+theorem dispatchByte_supported_SMOD_byte_pc
+    (state : EvmState) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x07, by decide⟩ : Fin 256) state).pc = state.pc := by
+  rw [dispatchByte_supported_SMOD_byte]
+  exact SModStackExecutionBridge.smodHandler_pc state
+
 theorem dispatchByte_supported_SDIV_byte_stack_zero_divisor
     (state : EvmState) (dividend : EvmWord) (rest : List EvmWord) :
     (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable

--- a/EvmAsm/Evm64/SupportedHandlerByte.lean
+++ b/EvmAsm/Evm64/SupportedHandlerByte.lean
@@ -219,6 +219,40 @@ theorem dispatchByte_supported_SMOD_byte_stack_neg_neg_sign
   rw [dispatchByte_supported_SMOD_byte]
   exact SModStackExecutionBridge.smodHandler_stack_neg_neg_sign state rest
 
+theorem dispatchByte_supported_SDIV_byte_status_empty_stack
+    (state : EvmState) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x05, by decide⟩ : Fin 256)
+      { state with stack := [] }).status = .error := by
+  rw [dispatchByte_supported_SDIV_byte]
+  exact SDivStackExecutionBridge.sdivHandler_status_empty_stack state
+
+theorem dispatchByte_supported_SDIV_byte_status_singleton_stack
+    (state : EvmState) (dividend : EvmWord) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x05, by decide⟩ : Fin 256)
+      { state with stack := [dividend] }).status = .error := by
+  rw [dispatchByte_supported_SDIV_byte]
+  exact SDivStackExecutionBridge.sdivHandler_status_singleton_stack
+    state dividend
+
+theorem dispatchByte_supported_SMOD_byte_status_empty_stack
+    (state : EvmState) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x07, by decide⟩ : Fin 256)
+      { state with stack := [] }).status = .error := by
+  rw [dispatchByte_supported_SMOD_byte]
+  exact SModStackExecutionBridge.smodHandler_status_empty_stack state
+
+theorem dispatchByte_supported_SMOD_byte_status_singleton_stack
+    (state : EvmState) (dividend : EvmWord) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x07, by decide⟩ : Fin 256)
+      { state with stack := [dividend] }).status = .error := by
+  rw [dispatchByte_supported_SMOD_byte]
+  exact SModStackExecutionBridge.smodHandler_status_singleton_stack
+    state dividend
+
 @[simp] theorem dispatchByte_supported_SDIV_byte_status_of_some
     {state : EvmState} {stack' : List EvmWord}
     (h_stack : ArithmeticHandlers.binaryStack? EvmWord.sdiv state.stack =

--- a/EvmAsm/Evm64/SupportedHandlerByte.lean
+++ b/EvmAsm/Evm64/SupportedHandlerByte.lean
@@ -253,6 +253,28 @@ theorem dispatchByte_supported_SMOD_byte_status_singleton_stack
   exact SModStackExecutionBridge.smodHandler_status_singleton_stack
     state dividend
 
+theorem dispatchByte_supported_SDIV_byte_status_of_runSDivStack?_none
+    {state : EvmState}
+    (h_run :
+      SDivStackExecutionBridge.runSDivStack? { stack := state.stack } =
+        none) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x05, by decide⟩ : Fin 256) state).status = .error := by
+  rw [dispatchByte_supported_SDIV_byte]
+  exact SDivStackExecutionBridge.sdivHandler_status_of_runSDivStack?_none
+    h_run
+
+theorem dispatchByte_supported_SMOD_byte_status_of_runSModStack?_none
+    {state : EvmState}
+    (h_run :
+      SModStackExecutionBridge.runSModStack? { stack := state.stack } =
+        none) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x07, by decide⟩ : Fin 256) state).status = .error := by
+  rw [dispatchByte_supported_SMOD_byte]
+  exact SModStackExecutionBridge.smodHandler_status_of_runSModStack?_none
+    h_run
+
 @[simp] theorem dispatchByte_supported_SDIV_byte_status_of_some
     {state : EvmState} {stack' : List EvmWord}
     (h_stack : ArithmeticHandlers.binaryStack? EvmWord.sdiv state.stack =

--- a/EvmAsm/Evm64/SupportedHandlerByte.lean
+++ b/EvmAsm/Evm64/SupportedHandlerByte.lean
@@ -173,6 +173,52 @@ theorem dispatchByte_supported_SMOD_byte_gas
   rw [dispatchByte_supported_SMOD_byte]
   exact SModStackExecutionBridge.smodHandler_gas state
 
+theorem dispatchByte_supported_SDIV_byte_memoryCells
+    (state : EvmState) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x05, by decide⟩ : Fin 256) state).memoryCells =
+        state.memoryCells := by
+  rw [dispatchByte_supported_SDIV_byte]
+  exact SDivStackExecutionBridge.sdivHandler_memoryCells state
+
+theorem dispatchByte_supported_SDIV_byte_memory
+    (state : EvmState) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x05, by decide⟩ : Fin 256) state).memory = state.memory := by
+  rw [dispatchByte_supported_SDIV_byte]
+  exact SDivStackExecutionBridge.sdivHandler_memory state
+
+theorem dispatchByte_supported_SDIV_byte_memSize
+    (state : EvmState) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x05, by decide⟩ : Fin 256) state).memSize =
+        state.memSize := by
+  rw [dispatchByte_supported_SDIV_byte]
+  exact SDivStackExecutionBridge.sdivHandler_memSize state
+
+theorem dispatchByte_supported_SMOD_byte_memoryCells
+    (state : EvmState) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x07, by decide⟩ : Fin 256) state).memoryCells =
+        state.memoryCells := by
+  rw [dispatchByte_supported_SMOD_byte]
+  exact SModStackExecutionBridge.smodHandler_memoryCells state
+
+theorem dispatchByte_supported_SMOD_byte_memory
+    (state : EvmState) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x07, by decide⟩ : Fin 256) state).memory = state.memory := by
+  rw [dispatchByte_supported_SMOD_byte]
+  exact SModStackExecutionBridge.smodHandler_memory state
+
+theorem dispatchByte_supported_SMOD_byte_memSize
+    (state : EvmState) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x07, by decide⟩ : Fin 256) state).memSize =
+        state.memSize := by
+  rw [dispatchByte_supported_SMOD_byte]
+  exact SModStackExecutionBridge.smodHandler_memSize state
+
 theorem dispatchByte_supported_SDIV_byte_stack_zero_divisor
     (state : EvmState) (dividend : EvmWord) (rest : List EvmWord) :
     (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable

--- a/EvmAsm/Evm64/SupportedHandlerByte.lean
+++ b/EvmAsm/Evm64/SupportedHandlerByte.lean
@@ -217,6 +217,20 @@ theorem dispatchByte_supported_SMOD_byte_env
   rw [dispatchByte_supported_SMOD_byte]
   exact SModStackExecutionBridge.smodHandler_env state
 
+theorem dispatchByte_supported_SDIV_byte_codeLenMatches
+    (state : EvmState) (h_codeLen : state.codeLenMatches) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x05, by decide⟩ : Fin 256) state).codeLenMatches := by
+  rw [dispatchByte_supported_SDIV_byte]
+  exact SDivStackExecutionBridge.sdivHandler_codeLenMatches state h_codeLen
+
+theorem dispatchByte_supported_SMOD_byte_codeLenMatches
+    (state : EvmState) (h_codeLen : state.codeLenMatches) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x07, by decide⟩ : Fin 256) state).codeLenMatches := by
+  rw [dispatchByte_supported_SMOD_byte]
+  exact SModStackExecutionBridge.smodHandler_codeLenMatches state h_codeLen
+
 theorem dispatchByte_supported_SDIV_byte_memoryCells
     (state : EvmState) :
     (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable

--- a/EvmAsm/Evm64/SupportedHandlerByte.lean
+++ b/EvmAsm/Evm64/SupportedHandlerByte.lean
@@ -173,6 +173,50 @@ theorem dispatchByte_supported_SMOD_byte_gas
   rw [dispatchByte_supported_SMOD_byte]
   exact SModStackExecutionBridge.smodHandler_gas state
 
+theorem dispatchByte_supported_SDIV_byte_code
+    (state : EvmState) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x05, by decide⟩ : Fin 256) state).code = state.code := by
+  rw [dispatchByte_supported_SDIV_byte]
+  exact SDivStackExecutionBridge.sdivHandler_code state
+
+theorem dispatchByte_supported_SMOD_byte_code
+    (state : EvmState) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x07, by decide⟩ : Fin 256) state).code = state.code := by
+  rw [dispatchByte_supported_SMOD_byte]
+  exact SModStackExecutionBridge.smodHandler_code state
+
+theorem dispatchByte_supported_SDIV_byte_codeLen
+    (state : EvmState) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x05, by decide⟩ : Fin 256) state).codeLen =
+        state.codeLen := by
+  rw [dispatchByte_supported_SDIV_byte]
+  exact SDivStackExecutionBridge.sdivHandler_codeLen state
+
+theorem dispatchByte_supported_SMOD_byte_codeLen
+    (state : EvmState) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x07, by decide⟩ : Fin 256) state).codeLen =
+        state.codeLen := by
+  rw [dispatchByte_supported_SMOD_byte]
+  exact SModStackExecutionBridge.smodHandler_codeLen state
+
+theorem dispatchByte_supported_SDIV_byte_env
+    (state : EvmState) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x05, by decide⟩ : Fin 256) state).env = state.env := by
+  rw [dispatchByte_supported_SDIV_byte]
+  exact SDivStackExecutionBridge.sdivHandler_env state
+
+theorem dispatchByte_supported_SMOD_byte_env
+    (state : EvmState) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x07, by decide⟩ : Fin 256) state).env = state.env := by
+  rw [dispatchByte_supported_SMOD_byte]
+  exact SModStackExecutionBridge.smodHandler_env state
+
 theorem dispatchByte_supported_SDIV_byte_memoryCells
     (state : EvmState) :
     (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable

--- a/EvmAsm/Evm64/SupportedHandlerByte.lean
+++ b/EvmAsm/Evm64/SupportedHandlerByte.lean
@@ -6,6 +6,8 @@
 -/
 
 import EvmAsm.Evm64.HandlerTableByte
+import EvmAsm.Evm64.SDiv.HandlerBridge
+import EvmAsm.Evm64.SMod.HandlerBridge
 import EvmAsm.Evm64.SupportedHandlers
 
 namespace EvmAsm.Evm64
@@ -142,6 +144,80 @@ theorem dispatchByte_supported_SMOD_byte
         ArithmeticHandlers.smodHandler state := by
   exact dispatchByte_supported_of_lookup rfl
     SupportedHandlers.supportedHandlerTable_SMOD state
+
+theorem dispatchByte_supported_SDIV_byte_stack_zero_divisor
+    (state : EvmState) (dividend : EvmWord) (rest : List EvmWord) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x05, by decide⟩ : Fin 256)
+      { state with stack := dividend :: 0 :: rest }).stack =
+        0 :: rest := by
+  rw [dispatchByte_supported_SDIV_byte]
+  exact SDivStackExecutionBridge.sdivHandler_stack_zero_divisor
+    state dividend rest
+
+theorem dispatchByte_supported_SDIV_byte_stack_intMin_neg_one
+    (state : EvmState) (rest : List EvmWord) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x05, by decide⟩ : Fin 256)
+      { state with stack := BitVec.intMin 256 :: (-1 : EvmWord) :: rest }).stack =
+        BitVec.intMin 256 :: rest := by
+  rw [dispatchByte_supported_SDIV_byte]
+  exact SDivStackExecutionBridge.sdivHandler_stack_intMin_neg_one state rest
+
+theorem dispatchByte_supported_SDIV_byte_stack_neg_one_two
+    (state : EvmState) (rest : List EvmWord) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x05, by decide⟩ : Fin 256)
+      { state with stack := (-1 : EvmWord) :: 2 :: rest }).stack =
+        0 :: rest := by
+  rw [dispatchByte_supported_SDIV_byte]
+  exact SDivStackExecutionBridge.sdivHandler_stack_neg_one_two state rest
+
+theorem dispatchByte_supported_SDIV_byte_stack_pos_neg_trunc
+    (state : EvmState) (rest : List EvmWord) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x05, by decide⟩ : Fin 256)
+      { state with stack := (7 : EvmWord) :: (-2 : EvmWord) :: rest }).stack =
+        (-3 : EvmWord) :: rest := by
+  rw [dispatchByte_supported_SDIV_byte]
+  exact SDivStackExecutionBridge.sdivHandler_stack_pos_neg_trunc state rest
+
+theorem dispatchByte_supported_SMOD_byte_stack_zero_divisor
+    (state : EvmState) (dividend : EvmWord) (rest : List EvmWord) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x07, by decide⟩ : Fin 256)
+      { state with stack := dividend :: 0 :: rest }).stack =
+        0 :: rest := by
+  rw [dispatchByte_supported_SMOD_byte]
+  exact SModStackExecutionBridge.smodHandler_stack_zero_divisor
+    state dividend rest
+
+theorem dispatchByte_supported_SMOD_byte_stack_neg_pos_sign
+    (state : EvmState) (rest : List EvmWord) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x07, by decide⟩ : Fin 256)
+      { state with stack := (-3 : EvmWord) :: 2 :: rest }).stack =
+        (-1 : EvmWord) :: rest := by
+  rw [dispatchByte_supported_SMOD_byte]
+  exact SModStackExecutionBridge.smodHandler_stack_neg_pos_sign state rest
+
+theorem dispatchByte_supported_SMOD_byte_stack_pos_neg_sign
+    (state : EvmState) (rest : List EvmWord) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x07, by decide⟩ : Fin 256)
+      { state with stack := (3 : EvmWord) :: (-2 : EvmWord) :: rest }).stack =
+        (1 : EvmWord) :: rest := by
+  rw [dispatchByte_supported_SMOD_byte]
+  exact SModStackExecutionBridge.smodHandler_stack_pos_neg_sign state rest
+
+theorem dispatchByte_supported_SMOD_byte_stack_neg_neg_sign
+    (state : EvmState) (rest : List EvmWord) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x07, by decide⟩ : Fin 256)
+      { state with stack := (-3 : EvmWord) :: (-2 : EvmWord) :: rest }).stack =
+        (-1 : EvmWord) :: rest := by
+  rw [dispatchByte_supported_SMOD_byte]
+  exact SModStackExecutionBridge.smodHandler_stack_neg_neg_sign state rest
 
 @[simp] theorem dispatchByte_supported_SDIV_byte_status_of_some
     {state : EvmState} {stack' : List EvmWord}

--- a/EvmAsm/Evm64/SupportedHandlerByte.lean
+++ b/EvmAsm/Evm64/SupportedHandlerByte.lean
@@ -219,6 +219,30 @@ theorem dispatchByte_supported_SMOD_byte_stack_neg_neg_sign
   rw [dispatchByte_supported_SMOD_byte]
   exact SModStackExecutionBridge.smodHandler_stack_neg_neg_sign state rest
 
+theorem dispatchByte_supported_SDIV_byte_stack_of_runSDivStack?_some
+    {state : EvmState} {out : SDivStackExecutionBridge.SDivStackResult}
+    (h_run :
+      SDivStackExecutionBridge.runSDivStack? { stack := state.stack } =
+        some out) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x05, by decide⟩ : Fin 256) state).stack =
+        out.effects.stackWords ++ out.stack := by
+  rw [dispatchByte_supported_SDIV_byte]
+  exact SDivStackExecutionBridge.sdivHandler_stack_of_runSDivStack?_some
+    h_run
+
+theorem dispatchByte_supported_SMOD_byte_stack_of_runSModStack?_some
+    {state : EvmState} {out : SModStackExecutionBridge.SModStackResult}
+    (h_run :
+      SModStackExecutionBridge.runSModStack? { stack := state.stack } =
+        some out) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x07, by decide⟩ : Fin 256) state).stack =
+        out.effects.stackWords ++ out.stack := by
+  rw [dispatchByte_supported_SMOD_byte]
+  exact SModStackExecutionBridge.smodHandler_stack_of_runSModStack?_some
+    h_run
+
 theorem dispatchByte_supported_SDIV_byte_status_empty_stack
     (state : EvmState) :
     (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable

--- a/EvmAsm/Evm64/SupportedHandlerByte.lean
+++ b/EvmAsm/Evm64/SupportedHandlerByte.lean
@@ -159,6 +159,20 @@ theorem dispatchByte_supported_SMOD_byte_pc
   rw [dispatchByte_supported_SMOD_byte]
   exact SModStackExecutionBridge.smodHandler_pc state
 
+theorem dispatchByte_supported_SDIV_byte_gas
+    (state : EvmState) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x05, by decide⟩ : Fin 256) state).gas = state.gas := by
+  rw [dispatchByte_supported_SDIV_byte]
+  exact SDivStackExecutionBridge.sdivHandler_gas state
+
+theorem dispatchByte_supported_SMOD_byte_gas
+    (state : EvmState) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x07, by decide⟩ : Fin 256) state).gas = state.gas := by
+  rw [dispatchByte_supported_SMOD_byte]
+  exact SModStackExecutionBridge.smodHandler_gas state
+
 theorem dispatchByte_supported_SDIV_byte_stack_zero_divisor
     (state : EvmState) (dividend : EvmWord) (rest : List EvmWord) :
     (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable

--- a/EvmAsm/Evm64/SupportedHandlers.lean
+++ b/EvmAsm/Evm64/SupportedHandlers.lean
@@ -420,6 +420,36 @@ theorem dispatchOpcode_of_lookup_status
     (by simp [CodeHandlers.codeHandlerTable, CodeHandlers.codeHandler?])
     MemoryHandlers.msizeHandlerTable_MSIZE
 
+@[simp] theorem supportedHandlerTable_SDIV :
+    supportedHandlerTable .SDIV =
+      some ArithmeticHandlers.sdivHandler := by
+  exact lookup_of_arithmetic
+    (by simp [TerminatingHandlers.terminatingHandlerTable, HandlerTable.setHandler])
+    (by simp [StackHandlers.stackHandlerTable, HandlerTable.setHandler])
+    (by simp [PushHandlers.pushHandlerTable, PushHandlers.pushHandler?])
+    (by simp [ControlHandlers.controlHandlerTable, ControlHandlers.controlHandler?])
+    (by rfl)
+    (by simp [ReturnDataHandlers.returnDataSizeHandlerTable,
+      ReturnDataHandlers.returnDataHandler?])
+    (by simp [CodeHandlers.codeHandlerTable, CodeHandlers.codeHandler?])
+    (by simp [MemoryHandlers.msizeHandlerTable, MemoryHandlers.memoryHandler?])
+    ArithmeticHandlers.arithmeticHandler?_SDIV
+
+@[simp] theorem supportedHandlerTable_SMOD :
+    supportedHandlerTable .SMOD =
+      some ArithmeticHandlers.smodHandler := by
+  exact lookup_of_arithmetic
+    (by simp [TerminatingHandlers.terminatingHandlerTable, HandlerTable.setHandler])
+    (by simp [StackHandlers.stackHandlerTable, HandlerTable.setHandler])
+    (by simp [PushHandlers.pushHandlerTable, PushHandlers.pushHandler?])
+    (by simp [ControlHandlers.controlHandlerTable, ControlHandlers.controlHandler?])
+    (by rfl)
+    (by simp [ReturnDataHandlers.returnDataSizeHandlerTable,
+      ReturnDataHandlers.returnDataHandler?])
+    (by simp [CodeHandlers.codeHandlerTable, CodeHandlers.codeHandler?])
+    (by simp [MemoryHandlers.msizeHandlerTable, MemoryHandlers.memoryHandler?])
+    ArithmeticHandlers.arithmeticHandler?_SMOD
+
 @[simp] theorem supportedHandlerTable_CALLDATASIZE :
     supportedHandlerTable .CALLDATASIZE =
       some CalldataHandlers.callDataSizeHandler := by

--- a/EvmAsm/Evm64/SupportedLoopBridge.lean
+++ b/EvmAsm/Evm64/SupportedLoopBridge.lean
@@ -113,6 +113,44 @@ theorem stepWithSupportedHandler_SWAP_status_of_some
   exact SupportedHandlers.dispatchOpcode_supportedHandlerTable_SWAP_of_valid_status_of_some
     h_valid h_stack
 
+theorem stepWithSupportedHandler_SDIV
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SDIV) :
+    InterpreterLoop.stepWithHandler supportedLoopHandler state =
+      ArithmeticHandlers.sdivHandler state := by
+  exact stepWithSupportedHandler_of_lookup h_decode
+    SupportedHandlers.supportedHandlerTable_SDIV
+
+theorem stepWithSupportedHandler_SMOD
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SMOD) :
+    InterpreterLoop.stepWithHandler supportedLoopHandler state =
+      ArithmeticHandlers.smodHandler state := by
+  exact stepWithSupportedHandler_of_lookup h_decode
+    SupportedHandlers.supportedHandlerTable_SMOD
+
+theorem stepWithSupportedHandler_SDIV_status_of_some
+    {state : EvmState} {stack' : List EvmWord}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SDIV)
+    (h_stack : ArithmeticHandlers.binaryStack? EvmWord.sdiv state.stack =
+      some stack') :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).status =
+      state.status := by
+  rw [stepWithSupportedHandler_SDIV h_decode]
+  simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler,
+    h_stack, EvmState.withStack]
+
+theorem stepWithSupportedHandler_SMOD_status_of_some
+    {state : EvmState} {stack' : List EvmWord}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SMOD)
+    (h_stack : ArithmeticHandlers.binaryStack? EvmWord.smod state.stack =
+      some stack') :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).status =
+      state.status := by
+  rw [stepWithSupportedHandler_SMOD h_decode]
+  simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler,
+    h_stack, EvmState.withStack]
+
 /--
 When the combined supported loop decodes STOP, one interpreter step terminates
 successfully.
@@ -272,6 +310,26 @@ theorem loopFuel_supported_succ_running_INVALID_status
       .error := by
   rw [loopFuel_supported_succ_running_INVALID nSteps h_status h_decode]
   exact loopFuel_supported_invalid_fixed_status nSteps state
+
+theorem loopFuel_supported_succ_running_SDIV
+    (nSteps : Nat) {state : EvmState}
+    (h_status : state.status = .running)
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SDIV) :
+    InterpreterLoop.loopFuel supportedLoopHandler (nSteps + 1) state =
+      InterpreterLoop.loopFuel supportedLoopHandler nSteps
+        (ArithmeticHandlers.sdivHandler state) := by
+  exact loopFuel_supported_succ_running_lookup nSteps h_status h_decode
+    SupportedHandlers.supportedHandlerTable_SDIV
+
+theorem loopFuel_supported_succ_running_SMOD
+    (nSteps : Nat) {state : EvmState}
+    (h_status : state.status = .running)
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SMOD) :
+    InterpreterLoop.loopFuel supportedLoopHandler (nSteps + 1) state =
+      InterpreterLoop.loopFuel supportedLoopHandler nSteps
+        (ArithmeticHandlers.smodHandler state) := by
+  exact loopFuel_supported_succ_running_lookup nSteps h_status h_decode
+    SupportedHandlers.supportedHandlerTable_SMOD
 
 theorem loopFuel_supported_missing_invalid
     (nSteps : Nat) {state : EvmState} {opcode : EvmOpcode}

--- a/EvmAsm/Evm64/SupportedLoopBridge.lean
+++ b/EvmAsm/Evm64/SupportedLoopBridge.lean
@@ -243,6 +243,30 @@ theorem stepWithSupportedHandler_SMOD_status_of_runSModStack?_none
   exact SModStackExecutionBridge.smodHandler_status_of_runSModStack?_none
     h_run
 
+theorem stepWithSupportedHandler_SDIV_status_of_runSDivStack?_some
+    {state : EvmState} {out : SDivStackExecutionBridge.SDivStackResult}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SDIV)
+    (h_run :
+      SDivStackExecutionBridge.runSDivStack? { stack := state.stack } =
+        some out) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).status =
+      state.status := by
+  rw [stepWithSupportedHandler_SDIV h_decode]
+  exact SDivStackExecutionBridge.sdivHandler_status_of_runSDivStack?_some
+    h_run
+
+theorem stepWithSupportedHandler_SMOD_status_of_runSModStack?_some
+    {state : EvmState} {out : SModStackExecutionBridge.SModStackResult}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SMOD)
+    (h_run :
+      SModStackExecutionBridge.runSModStack? { stack := state.stack } =
+        some out) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).status =
+      state.status := by
+  rw [stepWithSupportedHandler_SMOD h_decode]
+  exact SModStackExecutionBridge.smodHandler_status_of_runSModStack?_some
+    h_run
+
 theorem stepWithSupportedHandler_SDIV_stack_zero_divisor
     {state : EvmState} (dividend : EvmWord) (rest : List EvmWord)
     (h_decode :

--- a/EvmAsm/Evm64/SupportedLoopBridge.lean
+++ b/EvmAsm/Evm64/SupportedLoopBridge.lean
@@ -211,6 +211,22 @@ theorem stepWithSupportedHandler_SMOD_env
   rw [stepWithSupportedHandler_SMOD h_decode]
   exact SModStackExecutionBridge.smodHandler_env state
 
+theorem stepWithSupportedHandler_SDIV_codeLenMatches
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SDIV)
+    (h_codeLen : state.codeLenMatches) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).codeLenMatches := by
+  rw [stepWithSupportedHandler_SDIV h_decode]
+  exact SDivStackExecutionBridge.sdivHandler_codeLenMatches state h_codeLen
+
+theorem stepWithSupportedHandler_SMOD_codeLenMatches
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SMOD)
+    (h_codeLen : state.codeLenMatches) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).codeLenMatches := by
+  rw [stepWithSupportedHandler_SMOD h_decode]
+  exact SModStackExecutionBridge.smodHandler_codeLenMatches state h_codeLen
+
 theorem stepWithSupportedHandler_SDIV_memoryCells
     {state : EvmState}
     (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SDIV) :

--- a/EvmAsm/Evm64/SupportedLoopBridge.lean
+++ b/EvmAsm/Evm64/SupportedLoopBridge.lean
@@ -163,6 +163,54 @@ theorem stepWithSupportedHandler_SMOD_gas
   rw [stepWithSupportedHandler_SMOD h_decode]
   exact SModStackExecutionBridge.smodHandler_gas state
 
+theorem stepWithSupportedHandler_SDIV_code
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SDIV) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).code =
+      state.code := by
+  rw [stepWithSupportedHandler_SDIV h_decode]
+  exact SDivStackExecutionBridge.sdivHandler_code state
+
+theorem stepWithSupportedHandler_SMOD_code
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SMOD) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).code =
+      state.code := by
+  rw [stepWithSupportedHandler_SMOD h_decode]
+  exact SModStackExecutionBridge.smodHandler_code state
+
+theorem stepWithSupportedHandler_SDIV_codeLen
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SDIV) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).codeLen =
+      state.codeLen := by
+  rw [stepWithSupportedHandler_SDIV h_decode]
+  exact SDivStackExecutionBridge.sdivHandler_codeLen state
+
+theorem stepWithSupportedHandler_SMOD_codeLen
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SMOD) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).codeLen =
+      state.codeLen := by
+  rw [stepWithSupportedHandler_SMOD h_decode]
+  exact SModStackExecutionBridge.smodHandler_codeLen state
+
+theorem stepWithSupportedHandler_SDIV_env
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SDIV) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).env =
+      state.env := by
+  rw [stepWithSupportedHandler_SDIV h_decode]
+  exact SDivStackExecutionBridge.sdivHandler_env state
+
+theorem stepWithSupportedHandler_SMOD_env
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SMOD) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).env =
+      state.env := by
+  rw [stepWithSupportedHandler_SMOD h_decode]
+  exact SModStackExecutionBridge.smodHandler_env state
+
 theorem stepWithSupportedHandler_SDIV_memoryCells
     {state : EvmState}
     (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SDIV) :

--- a/EvmAsm/Evm64/SupportedLoopBridge.lean
+++ b/EvmAsm/Evm64/SupportedLoopBridge.lean
@@ -147,6 +147,22 @@ theorem stepWithSupportedHandler_SMOD_pc
   rw [stepWithSupportedHandler_SMOD h_decode]
   exact SModStackExecutionBridge.smodHandler_pc state
 
+theorem stepWithSupportedHandler_SDIV_gas
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SDIV) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).gas =
+      state.gas := by
+  rw [stepWithSupportedHandler_SDIV h_decode]
+  exact SDivStackExecutionBridge.sdivHandler_gas state
+
+theorem stepWithSupportedHandler_SMOD_gas
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SMOD) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).gas =
+      state.gas := by
+  rw [stepWithSupportedHandler_SMOD h_decode]
+  exact SModStackExecutionBridge.smodHandler_gas state
+
 theorem stepWithSupportedHandler_SDIV_status_of_some
     {state : EvmState} {stack' : List EvmWord}
     (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SDIV)

--- a/EvmAsm/Evm64/SupportedLoopBridge.lean
+++ b/EvmAsm/Evm64/SupportedLoopBridge.lean
@@ -177,6 +177,48 @@ theorem stepWithSupportedHandler_SMOD_stack_of_runSModStack?_some
   exact SModStackExecutionBridge.smodHandler_stack_of_runSModStack?_some
     h_run
 
+theorem stepWithSupportedHandler_SDIV_status_empty_stack
+    {state : EvmState}
+    (h_decode :
+      InterpreterLoop.decodeCurrentOpcode? { state with stack := [] } =
+        some .SDIV) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler
+      { state with stack := [] }).status = .error := by
+  rw [stepWithSupportedHandler_SDIV h_decode]
+  exact SDivStackExecutionBridge.sdivHandler_status_empty_stack state
+
+theorem stepWithSupportedHandler_SDIV_status_singleton_stack
+    {state : EvmState} (dividend : EvmWord)
+    (h_decode :
+      InterpreterLoop.decodeCurrentOpcode?
+        { state with stack := [dividend] } = some .SDIV) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler
+      { state with stack := [dividend] }).status = .error := by
+  rw [stepWithSupportedHandler_SDIV h_decode]
+  exact SDivStackExecutionBridge.sdivHandler_status_singleton_stack
+    state dividend
+
+theorem stepWithSupportedHandler_SMOD_status_empty_stack
+    {state : EvmState}
+    (h_decode :
+      InterpreterLoop.decodeCurrentOpcode? { state with stack := [] } =
+        some .SMOD) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler
+      { state with stack := [] }).status = .error := by
+  rw [stepWithSupportedHandler_SMOD h_decode]
+  exact SModStackExecutionBridge.smodHandler_status_empty_stack state
+
+theorem stepWithSupportedHandler_SMOD_status_singleton_stack
+    {state : EvmState} (dividend : EvmWord)
+    (h_decode :
+      InterpreterLoop.decodeCurrentOpcode?
+        { state with stack := [dividend] } = some .SMOD) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler
+      { state with stack := [dividend] }).status = .error := by
+  rw [stepWithSupportedHandler_SMOD h_decode]
+  exact SModStackExecutionBridge.smodHandler_status_singleton_stack
+    state dividend
+
 theorem stepWithSupportedHandler_SDIV_stack_zero_divisor
     {state : EvmState} (dividend : EvmWord) (rest : List EvmWord)
     (h_decode :

--- a/EvmAsm/Evm64/SupportedLoopBridge.lean
+++ b/EvmAsm/Evm64/SupportedLoopBridge.lean
@@ -163,6 +163,54 @@ theorem stepWithSupportedHandler_SMOD_gas
   rw [stepWithSupportedHandler_SMOD h_decode]
   exact SModStackExecutionBridge.smodHandler_gas state
 
+theorem stepWithSupportedHandler_SDIV_memoryCells
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SDIV) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).memoryCells =
+      state.memoryCells := by
+  rw [stepWithSupportedHandler_SDIV h_decode]
+  exact SDivStackExecutionBridge.sdivHandler_memoryCells state
+
+theorem stepWithSupportedHandler_SDIV_memory
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SDIV) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).memory =
+      state.memory := by
+  rw [stepWithSupportedHandler_SDIV h_decode]
+  exact SDivStackExecutionBridge.sdivHandler_memory state
+
+theorem stepWithSupportedHandler_SDIV_memSize
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SDIV) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).memSize =
+      state.memSize := by
+  rw [stepWithSupportedHandler_SDIV h_decode]
+  exact SDivStackExecutionBridge.sdivHandler_memSize state
+
+theorem stepWithSupportedHandler_SMOD_memoryCells
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SMOD) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).memoryCells =
+      state.memoryCells := by
+  rw [stepWithSupportedHandler_SMOD h_decode]
+  exact SModStackExecutionBridge.smodHandler_memoryCells state
+
+theorem stepWithSupportedHandler_SMOD_memory
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SMOD) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).memory =
+      state.memory := by
+  rw [stepWithSupportedHandler_SMOD h_decode]
+  exact SModStackExecutionBridge.smodHandler_memory state
+
+theorem stepWithSupportedHandler_SMOD_memSize
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SMOD) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).memSize =
+      state.memSize := by
+  rw [stepWithSupportedHandler_SMOD h_decode]
+  exact SModStackExecutionBridge.smodHandler_memSize state
+
 theorem stepWithSupportedHandler_SDIV_status_of_some
     {state : EvmState} {stack' : List EvmWord}
     (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SDIV)

--- a/EvmAsm/Evm64/SupportedLoopBridge.lean
+++ b/EvmAsm/Evm64/SupportedLoopBridge.lean
@@ -131,6 +131,22 @@ theorem stepWithSupportedHandler_SMOD
   exact stepWithSupportedHandler_of_lookup h_decode
     SupportedHandlers.supportedHandlerTable_SMOD
 
+theorem stepWithSupportedHandler_SDIV_pc
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SDIV) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).pc =
+      state.pc := by
+  rw [stepWithSupportedHandler_SDIV h_decode]
+  exact SDivStackExecutionBridge.sdivHandler_pc state
+
+theorem stepWithSupportedHandler_SMOD_pc
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SMOD) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).pc =
+      state.pc := by
+  rw [stepWithSupportedHandler_SMOD h_decode]
+  exact SModStackExecutionBridge.smodHandler_pc state
+
 theorem stepWithSupportedHandler_SDIV_status_of_some
     {state : EvmState} {stack' : List EvmWord}
     (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SDIV)

--- a/EvmAsm/Evm64/SupportedLoopBridge.lean
+++ b/EvmAsm/Evm64/SupportedLoopBridge.lean
@@ -7,6 +7,8 @@
 
 import EvmAsm.Evm64.HandlerLoopBridge
 import EvmAsm.Evm64.SupportedHandlers
+import EvmAsm.Evm64.SDiv.HandlerBridge
+import EvmAsm.Evm64.SMod.HandlerBridge
 
 namespace EvmAsm.Evm64
 
@@ -150,6 +152,30 @@ theorem stepWithSupportedHandler_SMOD_status_of_some
   rw [stepWithSupportedHandler_SMOD h_decode]
   simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler,
     h_stack, EvmState.withStack]
+
+theorem stepWithSupportedHandler_SDIV_stack_of_runSDivStack?_some
+    {state : EvmState} {out : SDivStackExecutionBridge.SDivStackResult}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SDIV)
+    (h_run :
+      SDivStackExecutionBridge.runSDivStack? { stack := state.stack } =
+        some out) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).stack =
+      out.effects.stackWords ++ out.stack := by
+  rw [stepWithSupportedHandler_SDIV h_decode]
+  exact SDivStackExecutionBridge.sdivHandler_stack_of_runSDivStack?_some
+    h_run
+
+theorem stepWithSupportedHandler_SMOD_stack_of_runSModStack?_some
+    {state : EvmState} {out : SModStackExecutionBridge.SModStackResult}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SMOD)
+    (h_run :
+      SModStackExecutionBridge.runSModStack? { stack := state.stack } =
+        some out) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).stack =
+      out.effects.stackWords ++ out.stack := by
+  rw [stepWithSupportedHandler_SMOD h_decode]
+  exact SModStackExecutionBridge.smodHandler_stack_of_runSModStack?_some
+    h_run
 
 /--
 When the combined supported loop decodes STOP, one interpreter step terminates

--- a/EvmAsm/Evm64/SupportedLoopBridge.lean
+++ b/EvmAsm/Evm64/SupportedLoopBridge.lean
@@ -177,6 +177,102 @@ theorem stepWithSupportedHandler_SMOD_stack_of_runSModStack?_some
   exact SModStackExecutionBridge.smodHandler_stack_of_runSModStack?_some
     h_run
 
+theorem stepWithSupportedHandler_SDIV_stack_zero_divisor
+    {state : EvmState} (dividend : EvmWord) (rest : List EvmWord)
+    (h_decode :
+      InterpreterLoop.decodeCurrentOpcode?
+        { state with stack := dividend :: 0 :: rest } = some .SDIV)
+    :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler
+      { state with stack := dividend :: 0 :: rest }).stack =
+        0 :: rest := by
+  rw [stepWithSupportedHandler_SDIV h_decode]
+  exact SDivStackExecutionBridge.sdivHandler_stack_zero_divisor state
+    dividend rest
+
+theorem stepWithSupportedHandler_SDIV_stack_intMin_neg_one
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode?
+      { state with stack := BitVec.intMin 256 :: (-1 : EvmWord) :: state.stack } =
+        some .SDIV) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler
+      { state with stack := BitVec.intMin 256 :: (-1 : EvmWord) :: state.stack }).stack =
+        BitVec.intMin 256 :: state.stack := by
+  rw [stepWithSupportedHandler_SDIV h_decode]
+  exact SDivStackExecutionBridge.sdivHandler_stack_intMin_neg_one state
+    state.stack
+
+theorem stepWithSupportedHandler_SDIV_stack_neg_one_two
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode?
+      { state with stack := (-1 : EvmWord) :: 2 :: state.stack } = some .SDIV) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler
+      { state with stack := (-1 : EvmWord) :: 2 :: state.stack }).stack =
+        0 :: state.stack := by
+  rw [stepWithSupportedHandler_SDIV h_decode]
+  exact SDivStackExecutionBridge.sdivHandler_stack_neg_one_two state
+    state.stack
+
+theorem stepWithSupportedHandler_SDIV_stack_pos_neg_trunc
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode?
+      { state with stack := (7 : EvmWord) :: (-2 : EvmWord) :: state.stack } =
+        some .SDIV) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler
+      { state with stack := (7 : EvmWord) :: (-2 : EvmWord) :: state.stack }).stack =
+        (-3 : EvmWord) :: state.stack := by
+  rw [stepWithSupportedHandler_SDIV h_decode]
+  exact SDivStackExecutionBridge.sdivHandler_stack_pos_neg_trunc state
+    state.stack
+
+theorem stepWithSupportedHandler_SMOD_stack_zero_divisor
+    {state : EvmState} (dividend : EvmWord) (rest : List EvmWord)
+    (h_decode :
+      InterpreterLoop.decodeCurrentOpcode?
+        { state with stack := dividend :: 0 :: rest } = some .SMOD)
+    :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler
+      { state with stack := dividend :: 0 :: rest }).stack =
+        0 :: rest := by
+  rw [stepWithSupportedHandler_SMOD h_decode]
+  exact SModStackExecutionBridge.smodHandler_stack_zero_divisor state
+    dividend rest
+
+theorem stepWithSupportedHandler_SMOD_stack_neg_pos_sign
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode?
+      { state with stack := (-3 : EvmWord) :: 2 :: state.stack } = some .SMOD) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler
+      { state with stack := (-3 : EvmWord) :: 2 :: state.stack }).stack =
+        (-1 : EvmWord) :: state.stack := by
+  rw [stepWithSupportedHandler_SMOD h_decode]
+  exact SModStackExecutionBridge.smodHandler_stack_neg_pos_sign state
+    state.stack
+
+theorem stepWithSupportedHandler_SMOD_stack_pos_neg_sign
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode?
+      { state with stack := (3 : EvmWord) :: (-2 : EvmWord) :: state.stack } =
+        some .SMOD) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler
+      { state with stack := (3 : EvmWord) :: (-2 : EvmWord) :: state.stack }).stack =
+        (1 : EvmWord) :: state.stack := by
+  rw [stepWithSupportedHandler_SMOD h_decode]
+  exact SModStackExecutionBridge.smodHandler_stack_pos_neg_sign state
+    state.stack
+
+theorem stepWithSupportedHandler_SMOD_stack_neg_neg_sign
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode?
+      { state with stack := (-3 : EvmWord) :: (-2 : EvmWord) :: state.stack } =
+        some .SMOD) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler
+      { state with stack := (-3 : EvmWord) :: (-2 : EvmWord) :: state.stack }).stack =
+        (-1 : EvmWord) :: state.stack := by
+  rw [stepWithSupportedHandler_SMOD h_decode]
+  exact SModStackExecutionBridge.smodHandler_stack_neg_neg_sign state
+    state.stack
+
 /--
 When the combined supported loop decodes STOP, one interpreter step terminates
 successfully.

--- a/EvmAsm/Evm64/SupportedLoopBridge.lean
+++ b/EvmAsm/Evm64/SupportedLoopBridge.lean
@@ -219,6 +219,30 @@ theorem stepWithSupportedHandler_SMOD_status_singleton_stack
   exact SModStackExecutionBridge.smodHandler_status_singleton_stack
     state dividend
 
+theorem stepWithSupportedHandler_SDIV_status_of_runSDivStack?_none
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SDIV)
+    (h_run :
+      SDivStackExecutionBridge.runSDivStack? { stack := state.stack } =
+        none) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).status =
+      .error := by
+  rw [stepWithSupportedHandler_SDIV h_decode]
+  exact SDivStackExecutionBridge.sdivHandler_status_of_runSDivStack?_none
+    h_run
+
+theorem stepWithSupportedHandler_SMOD_status_of_runSModStack?_none
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SMOD)
+    (h_run :
+      SModStackExecutionBridge.runSModStack? { stack := state.stack } =
+        none) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).status =
+      .error := by
+  rw [stepWithSupportedHandler_SMOD h_decode]
+  exact SModStackExecutionBridge.smodHandler_status_of_runSModStack?_none
+    h_run
+
 theorem stepWithSupportedHandler_SDIV_stack_zero_divisor
     {state : EvmState} (dividend : EvmWord) (rest : List EvmWord)
     (h_decode :


### PR DESCRIPTION
## Summary
- add EXP exponent-byte-length lemma for the maximum 256-bit exponent
- add dynamic and total gas lemmas for the maximum exponent boundary

## Verification
- lake build EvmAsm.Evm64.Exp.Gas
- scripts/check-file-size.sh --report

Refs evm-asm-20z6 / GH #92.