### PR TITLE
feat(addmod): compose prologue + phase1_carry into 31-instr cpsTripleWithin

### DIFF
--- a/EvmAsm/Evm64/AddMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/AddMod/Compose/Base.lean
@@ -233,4 +233,92 @@ theorem evm_addmod_epilogue_evm_addmod_spec_within
     (hmono := evm_addmod_program_code_epilogue_sub)
     (h := evm_addmod_epilogue_spec_within vOld (base + 128))
 
+-- ============================================================================
+-- Multi-block composition (toward `evm_addmod_stack_spec_within`)
+-- ============================================================================
+
+/-- Compose `evm_addmod_prologue_evm_addmod_spec_within` (30 instr, bytes
+    0..120) with `evm_addmod_phase1_carry_evm_addmod_spec_within` (1 instr,
+    byte 120..124) into a single 31-instruction `cpsTripleWithin` over
+    `evm_addmod_program_code base modOff`, threading the 257th carry bit
+    `carry3` from `x5` into `x7` via the `ADDI x7 x5 0` MV instruction.
+
+    First compose step toward the full `evm_addmod_stack_spec_within`
+    (slice 3d, beads `evm-asm-s7v49`).
+
+    Distinctive token: evm_addmod_prologue_phase1_spec_within #91. -/
+theorem evm_addmod_prologue_phase1_spec_within
+    (sp : Word) (base : Word) (modOff : BitVec 21)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (v7 v6 v5 v11 : Word) :
+    let sum0 := a0 + b0
+    let carry0 := if BitVec.ult sum0 b0 then (1 : Word) else 0
+    let psum1 := a1 + b1
+    let carry1a := if BitVec.ult psum1 b1 then (1 : Word) else 0
+    let result1 := psum1 + carry0
+    let carry1b := if BitVec.ult result1 carry0 then (1 : Word) else 0
+    let carry1 := carry1a ||| carry1b
+    let psum2 := a2 + b2
+    let carry2a := if BitVec.ult psum2 b2 then (1 : Word) else 0
+    let result2 := psum2 + carry1
+    let carry2b := if BitVec.ult result2 carry1 then (1 : Word) else 0
+    let carry2 := carry2a ||| carry2b
+    let psum3 := a3 + b3
+    let carry3a := if BitVec.ult psum3 b3 then (1 : Word) else 0
+    let result3 := psum3 + carry2
+    let carry3b := if BitVec.ult result3 carry2 then (1 : Word) else 0
+    let carry3 := carry3a ||| carry3b
+    cpsTripleWithin (30 + 1) base (base + 124)
+      (evm_addmod_program_code base modOff)
+      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7) ** (.x6 ↦ᵣ v6) ** (.x5 ↦ᵣ v5) ** (.x11 ↦ᵣ v11) **
+       (sp ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3))
+      ((.x12 ↦ᵣ (sp + 32)) **
+       (.x7 ↦ᵣ (carry3 + signExtend12 (0 : BitVec 12))) **
+       (.x6 ↦ᵣ carry3b) ** (.x5 ↦ᵣ carry3) ** (.x11 ↦ᵣ carry3a) **
+       (sp ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ sum0) ** ((sp + 40) ↦ₘ result1) **
+       ((sp + 48) ↦ₘ result2) ** ((sp + 56) ↦ₘ result3)) := by
+  intro sum0 carry0 psum1 carry1a result1 carry1b carry1
+        psum2 carry2a result2 carry2b carry2
+        psum3 carry3a result3 carry3b carry3
+  -- Step 1: prologue spec (30 instr, base..base+120)
+  have h1 := evm_addmod_prologue_evm_addmod_spec_within sp base modOff
+    a0 a1 a2 a3 b0 b1 b2 b3 v7 v6 v5 v11
+  -- Step 2: phase1_carry spec (1 instr, base+120..base+124).
+  -- Instantiate with v5 := carry3, vOld := result3 (from prologue post).
+  have h2 := evm_addmod_phase1_carry_evm_addmod_spec_within carry3 result3 base modOff
+  -- Frame phase1 with the remaining cells (everything except x5/x7).
+  have h2f := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ (sp + 32)) ** (.x6 ↦ᵣ carry3b) ** (.x11 ↦ᵣ carry3a) **
+     (sp ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + 32) ↦ₘ sum0) ** ((sp + 40) ↦ₘ result1) **
+     ((sp + 48) ↦ₘ result2) ** ((sp + 56) ↦ₘ result3))
+    (by pcFree) h2
+  -- Normalize exit PC: (base + 120) + 4 = base + 124.
+  have h_exit : (base + 120 : Word) + 4 = base + 124 := by bv_omega
+  rw [h_exit] at h2f
+  -- Permute h2f's pre/post (which are left-assoc `(x5 ** x7) ** F`) into
+  -- right-assoc form matching h1's post, so that `seq_perm_same_cr` only
+  -- needs one xperm step (between h1.post and h2f.pre).
+  have h2p : cpsTripleWithin 1 (base + 120) (base + 124)
+      (evm_addmod_program_code base modOff)
+      ((.x12 ↦ᵣ (sp + 32)) ** (.x7 ↦ᵣ result3) ** (.x6 ↦ᵣ carry3b) **
+       (.x5 ↦ᵣ carry3) ** (.x11 ↦ᵣ carry3a) **
+       (sp ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ sum0) ** ((sp + 40) ↦ₘ result1) **
+       ((sp + 48) ↦ₘ result2) ** ((sp + 56) ↦ₘ result3))
+      ((.x12 ↦ᵣ (sp + 32)) **
+       (.x7 ↦ᵣ (carry3 + signExtend12 (0 : BitVec 12))) **
+       (.x6 ↦ᵣ carry3b) ** (.x5 ↦ᵣ carry3) ** (.x11 ↦ᵣ carry3a) **
+       (sp ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ sum0) ** ((sp + 40) ↦ₘ result1) **
+       ((sp + 48) ↦ₘ result2) ** ((sp + 56) ↦ₘ result3)) :=
+    cpsTripleWithin_weaken
+      (fun _ hp => by xperm_hyp hp)
+      (fun _ hp => by xperm_hyp hp)
+      h2f
+  -- Compose: h1.post matches h2p.pre exactly.
+  exact cpsTripleWithin_seq_same_cr h1 h2p
+
 end EvmAsm.Evm64.AddMod.Compose


### PR DESCRIPTION
Sub-slice of `evm-asm-s7v49` (#91 slice 3d). First multi-block composition step toward `evm_addmod_stack_spec_within`.

Adds `evm_addmod_prologue_phase1_spec_within` in `EvmAsm/Evm64/AddMod/Compose/Base.lean`, sequencing:

- `evm_addmod_prologue_evm_addmod_spec_within` — 30 instructions, `base..base+120`, computes 257-bit `a + b` with the carry-out `carry3` in `x5`;
- `evm_addmod_phase1_carry_evm_addmod_spec_within` — 1 instruction (`ADDI x7 x5 0`), `base+120..base+124`, threads `carry3` from `x5` into `x7`.

Result: 31-instruction `cpsTripleWithin` over `evm_addmod_program_code base modOff`, ending at `base + 124`. Composition uses `cpsTripleWithin_frameR` to add the surrounding cells onto the phase1 spec, then `cpsTripleWithin_weaken` + `xperm_hyp` to align the left-associated `(x5 ** x7) ** F` shape with the prologue post's right-associated chain, then `cpsTripleWithin_seq_same_cr`.

- `lake build` green, 0 sorry, no `maxHeartbeats` / `maxRecDepth` bumps.

Refs GH #91, beads `evm-asm-8zsqe` (sub-slice of `evm-asm-s7v49`).
Distinctive token: `evm_addmod_prologue_phase1_spec_within #91`.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).