### PR TITLE
feat(smod): characterize stack execution

### DIFF
--- a/EvmAsm/Evm64/SMod/StackExecutionBridge.lean
+++ b/EvmAsm/Evm64/SMod/StackExecutionBridge.lean
@@ -65,6 +65,98 @@ theorem stackRestAfterSMod?_none_of_one
     (dividend : EvmWord) :
     stackRestAfterSMod? [dividend] = none := rfl
 
+theorem stackRestAfterSMod?_eq_none_iff
+    {stack : List EvmWord} :
+    stackRestAfterSMod? stack = none ↔
+      stack = [] ∨ ∃ dividend, stack = [dividend] := by
+  constructor
+  · cases stack with
+    | nil =>
+        intro _h
+        exact Or.inl rfl
+    | cons dividend tail =>
+        cases tail with
+        | nil =>
+            intro _h
+            exact Or.inr ⟨dividend, rfl⟩
+        | cons divisor rest =>
+            simp [stackRestAfterSMod?]
+  · rintro (rfl | ⟨dividend, rfl⟩) <;> rfl
+
+theorem runSModStack?_eq_none_iff
+    {state : SModStackState} :
+    runSModStack? state = none ↔
+      state.stack = [] ∨ ∃ dividend, state.stack = [dividend] := by
+  cases state with
+  | mk stack =>
+      cases stack with
+      | nil =>
+          simp [runSModStack?, SModArgsStackDecode.decodeSModStack?,
+            stackRestAfterSMod?, Option.bind]
+      | cons dividend tail =>
+          cases tail with
+          | nil =>
+              simp [runSModStack?, SModArgsStackDecode.decodeSModStack?,
+                stackRestAfterSMod?, Option.bind]
+          | cons divisor rest =>
+              simp [runSModStack?, SModArgsStackDecode.decodeSModStack?,
+                stackRestAfterSMod?, Option.bind]
+
+theorem runSModStack?_eq_some_iff
+    {state : SModStackState} {out : SModStackResult} :
+    runSModStack? state = some out ↔
+      ∃ dividend divisor rest,
+        state.stack = dividend :: divisor :: rest ∧
+          out =
+            { effects :=
+                { stackWords := [SModArgs.smodResultFromArgs
+                    (SModArgs.smodArgs dividend divisor)] }
+              stack := rest } := by
+  constructor
+  · cases state with
+    | mk stack =>
+        cases stack with
+        | nil =>
+            simp [runSModStack?, SModArgsStackDecode.decodeSModStack?,
+              stackRestAfterSMod?, Option.bind]
+        | cons dividend tail =>
+            cases tail with
+            | nil =>
+                simp [runSModStack?, SModArgsStackDecode.decodeSModStack?,
+                  stackRestAfterSMod?, Option.bind]
+            | cons divisor rest =>
+                intro h_run
+                simp [runSModStack?, SModArgsStackDecode.decodeSModStack?,
+                  stackRestAfterSMod?, Option.bind] at h_run
+                cases h_run
+                exact ⟨dividend, divisor, rest, rfl, rfl⟩
+  · rintro ⟨dividend, divisor, rest, h_stack, h_out⟩
+    cases state with
+    | mk stack =>
+        simp at h_stack
+        subst h_stack
+        subst h_out
+        exact runSModStack?_cons dividend divisor rest
+
+theorem runSModStack?_stack_length
+    {state : SModStackState} {out : SModStackResult}
+    (h_run : runSModStack? state = some out) :
+    out.stack.length + out.effects.stackWords.length + argumentCount =
+      state.stack.length + resultCount := by
+  cases state with
+  | mk stack =>
+      cases stack with
+      | nil =>
+          simp [runSModStack?, SModArgsStackDecode.decodeSModStack?] at h_run
+      | cons dividend tail =>
+          cases tail with
+          | nil => simp [runSModStack?, stackRestAfterSMod?] at h_run
+          | cons divisor rest =>
+              simp [runSModStack?, stackRestAfterSMod?] at h_run
+              cases h_run
+              simp [argumentCount, resultCount, SModArgs.stackArgumentCount,
+                SModArgs.resultCount]
+
 theorem runSModStack?_head?
     (dividend divisor : EvmWord) (rest : List EvmWord) :
     (runSModStack? { stack := dividend :: divisor :: rest }).map


### PR DESCRIPTION
## Summary
- add none/some characterizations for pure SMOD stack execution
- add stack length preservation theorem for SMOD execution results
- add rest-underflow characterization for the helper decoder

## Verification
- lake build EvmAsm.Evm64.SMod.StackExecutionBridge
- scripts/check-file-size.sh --report

Refs evm-asm-34sg / GH #90.