### PR TITLE
feat(sdiv): add stack truncation cases

### DIFF
--- a/EvmAsm/Evm64/SDiv/StackExecutionBridge.lean
+++ b/EvmAsm/Evm64/SDiv/StackExecutionBridge.lean
@@ -178,5 +178,19 @@ theorem runSDivStack?_intMin_neg_one
   rw [runSDivStack?_cons]
   rw [SDivArgs.sdivResultFromArgs_intMin_neg_one]
 
+theorem runSDivStack?_neg_one_two
+    (rest : List EvmWord) :
+    runSDivStack? { stack := (-1 : EvmWord) :: 2 :: rest } =
+      some { effects := { stackWords := [0] }, stack := rest } := by
+  rw [runSDivStack?_cons]
+  rw [SDivArgs.sdivResultFromArgs_neg_one_two]
+
+theorem runSDivStack?_pos_neg_trunc
+    (rest : List EvmWord) :
+    runSDivStack? { stack := (7 : EvmWord) :: (-2 : EvmWord) :: rest } =
+      some { effects := { stackWords := [(-3 : EvmWord)] }, stack := rest } := by
+  rw [runSDivStack?_cons]
+  rw [SDivArgs.sdivResultFromArgs_pos_neg_trunc]
+
 end SDivStackExecutionBridge
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add pure stack execution case for SDIV(-1, 2) truncating to zero
- add pure stack execution case for SDIV(7, -2) truncating toward zero

## Verification
- lake build EvmAsm.Evm64.SDiv.StackExecutionBridge
- scripts/check-file-size.sh --report

Refs evm-asm-34sg / GH #90.