### PR TITLE
feat(smod): add stack sign cases

### DIFF
--- a/EvmAsm/Evm64/SMod/StackExecutionBridge.lean
+++ b/EvmAsm/Evm64/SMod/StackExecutionBridge.lean
@@ -178,5 +178,19 @@ theorem runSModStack?_neg_pos_sign
   rw [runSModStack?_cons]
   rw [SModArgs.smodResultFromArgs_neg_pos_sign]
 
+theorem runSModStack?_pos_neg_sign
+    (rest : List EvmWord) :
+    runSModStack? { stack := (3 : EvmWord) :: (-2 : EvmWord) :: rest } =
+      some { effects := { stackWords := [(1 : EvmWord)] }, stack := rest } := by
+  rw [runSModStack?_cons]
+  rw [SModArgs.smodResultFromArgs_pos_neg_sign]
+
+theorem runSModStack?_neg_neg_sign
+    (rest : List EvmWord) :
+    runSModStack? { stack := (-3 : EvmWord) :: (-2 : EvmWord) :: rest } =
+      some { effects := { stackWords := [(-1 : EvmWord)] }, stack := rest } := by
+  rw [runSModStack?_cons]
+  rw [SModArgs.smodResultFromArgs_neg_neg_sign]
+
 end SModStackExecutionBridge
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add pure stack execution case for SMOD(3, -2)
- add pure stack execution case for SMOD(-3, -2)
- completes stack-level forwarding for the SMOD sign-of-dividend examples

## Verification
- lake build EvmAsm.Evm64.SMod.StackExecutionBridge
- scripts/check-file-size.sh --report

Refs evm-asm-34sg / GH #90.