### PR TITLE
feat(dispatch): add signed opcode byte roundtrips

### DIFF
--- a/EvmAsm/Evm64/Dispatch.lean
+++ b/EvmAsm/Evm64/Dispatch.lean
@@ -22,7 +22,9 @@ def decodeByte? : Nat → Option EvmOpcode
   | 0x02 => some MUL
   | 0x03 => some SUB
   | 0x04 => some DIV
+  | 0x05 => some SDIV
   | 0x06 => some MOD
+  | 0x07 => some SMOD
   | 0x0a => some EXP
   | 0x0b => some SIGNEXTEND
   | 0x10 => some LT
@@ -318,8 +320,12 @@ theorem byte?_roundtrip_SUB :
     byte? SUB = some 0x03 ∧ decodeByte? 0x03 = some SUB := ⟨rfl, rfl⟩
 theorem byte?_roundtrip_DIV :
     byte? DIV = some 0x04 ∧ decodeByte? 0x04 = some DIV := ⟨rfl, rfl⟩
+theorem byte?_roundtrip_SDIV :
+    byte? SDIV = some 0x05 ∧ decodeByte? 0x05 = some SDIV := ⟨rfl, rfl⟩
 theorem byte?_roundtrip_MOD :
     byte? MOD = some 0x06 ∧ decodeByte? 0x06 = some MOD := ⟨rfl, rfl⟩
+theorem byte?_roundtrip_SMOD :
+    byte? SMOD = some 0x07 ∧ decodeByte? 0x07 = some SMOD := ⟨rfl, rfl⟩
 theorem byte?_roundtrip_EXP :
     byte? EXP = some 0x0a ∧ decodeByte? 0x0a = some EXP := ⟨rfl, rfl⟩
 theorem byte?_roundtrip_SIGNEXTEND :

--- a/EvmAsm/Evm64/ExecutableSpecOpcodeBridge.lean
+++ b/EvmAsm/Evm64/ExecutableSpecOpcodeBridge.lean
@@ -18,6 +18,8 @@ namespace ExecutableSpecOpcodeBridge
 namespace Ops
 
 def STOP : Nat := 0x00
+def SDIV : Nat := 0x05
+def SMOD : Nat := 0x07
 def KECCAK : Nat := 0x20
 def CALLDATALOAD : Nat := 0x35
 def CALLDATASIZE : Nat := 0x36
@@ -172,6 +174,16 @@ theorem roundtrip_execSpec_STOP :
 theorem roundtrip_execSpec_KECCAK :
     EvmOpcode.byte? EvmOpcode.KECCAK256 = some Ops.KECCAK ∧
       EvmOpcode.decodeByte? Ops.KECCAK = some EvmOpcode.KECCAK256 := by
+  exact ⟨rfl, rfl⟩
+
+theorem roundtrip_execSpec_SDIV :
+    EvmOpcode.byte? EvmOpcode.SDIV = some Ops.SDIV ∧
+      EvmOpcode.decodeByte? Ops.SDIV = some EvmOpcode.SDIV := by
+  exact ⟨rfl, rfl⟩
+
+theorem roundtrip_execSpec_SMOD :
+    EvmOpcode.byte? EvmOpcode.SMOD = some Ops.SMOD ∧
+      EvmOpcode.decodeByte? Ops.SMOD = some EvmOpcode.SMOD := by
   exact ⟨rfl, rfl⟩
 
 /-- Distinctive token:

--- a/EvmAsm/Evm64/Gas.lean
+++ b/EvmAsm/Evm64/Gas.lean
@@ -24,7 +24,9 @@ inductive EvmOpcode where
   | MUL
   | SUB
   | DIV
+  | SDIV
   | MOD
+  | SMOD
   | EXP
   | SIGNEXTEND
   | KECCAK256
@@ -114,7 +116,9 @@ def byte? : EvmOpcode → Option Nat
   | MUL => some 0x02
   | SUB => some 0x03
   | DIV => some 0x04
+  | SDIV => some 0x05
   | MOD => some 0x06
+  | SMOD => some 0x07
   | EXP => some 0x0a
   | SIGNEXTEND => some 0x0b
   | KECCAK256 => some 0x20
@@ -188,7 +192,9 @@ def staticGasCost : EvmOpcode → Nat
   | MUL => 5
   | SUB => 3
   | DIV => 5
+  | SDIV => 5
   | MOD => 5
+  | SMOD => 5
   | EXP => 10
   | SIGNEXTEND => 5
   | KECCAK256 => 30


### PR DESCRIPTION
## Summary
- add SDIV and SMOD opcode identifiers with static gas costs
- add byte/decode mappings for opcode bytes 0x05 and 0x07
- add dispatch and executable-spec roundtrip lemmas for SDIV/SMOD

## Verification
- lake build EvmAsm.Evm64.Gas
- lake build EvmAsm.Evm64.Dispatch
- lake build EvmAsm.Evm64.ExecutableSpecOpcodeBridge
- lake build EvmAsm.Evm64.ArithmeticHandlers
- scripts/check-file-size.sh --report

Refs evm-asm-34sg / GH #90.