### PR TITLE
feat(handlers): add signed arithmetic handlers

### DIFF
--- a/EvmAsm/Evm64/ArithmeticHandlers.lean
+++ b/EvmAsm/Evm64/ArithmeticHandlers.lean
@@ -5,6 +5,8 @@
 -/
 
 import EvmAsm.Evm64.HandlerTable
+import EvmAsm.Evm64.EvmWordArith.SDiv
+import EvmAsm.Evm64.EvmWordArith.SMod
 
 namespace EvmAsm.Evm64
 namespace ArithmeticHandlers
@@ -33,14 +35,22 @@ def subHandler : OpcodeHandler :=
 def mulHandler : OpcodeHandler :=
   binaryHandler (fun a b => a * b)
 
-/-- Lookup surface for the basic arithmetic handlers proved so far. -/
+def sdivHandler : OpcodeHandler :=
+  binaryHandler EvmWord.sdiv
+
+def smodHandler : OpcodeHandler :=
+  binaryHandler EvmWord.smod
+
+/-- Lookup surface for the arithmetic handlers proved so far. -/
 def arithmeticHandler? : EvmOpcode → Option OpcodeHandler
   | .ADD => some addHandler
   | .SUB => some subHandler
   | .MUL => some mulHandler
+  | .SDIV => some sdivHandler
+  | .SMOD => some smodHandler
   | _ => none
 
-/-- Handler table containing ADD/SUB/MUL entries.
+/-- Handler table containing currently supported arithmetic entries.
     Distinctive token: ArithmeticHandlers.arithmeticHandlerTable #107. -/
 def arithmeticHandlerTable : HandlerTable :=
   arithmeticHandler?
@@ -116,6 +126,16 @@ theorem binaryHandler_status_of_binaryStack?_none
     (mulHandler { state with stack := a :: b :: rest }).stack =
       (a * b) :: rest := rfl
 
+@[simp] theorem sdivHandler_stack
+    (a b : EvmWord) (rest : List EvmWord) (state : EvmState) :
+    (sdivHandler { state with stack := a :: b :: rest }).stack =
+      EvmWord.sdiv a b :: rest := rfl
+
+@[simp] theorem smodHandler_stack
+    (a b : EvmWord) (rest : List EvmWord) (state : EvmState) :
+    (smodHandler { state with stack := a :: b :: rest }).stack =
+      EvmWord.smod a b :: rest := rfl
+
 @[simp] theorem arithmeticHandlerTable_eq :
     arithmeticHandlerTable = arithmeticHandler? := rfl
 
@@ -127,6 +147,12 @@ theorem binaryHandler_status_of_binaryStack?_none
 
 @[simp] theorem arithmeticHandler?_MUL :
     arithmeticHandler? .MUL = some mulHandler := rfl
+
+@[simp] theorem arithmeticHandler?_SDIV :
+    arithmeticHandler? .SDIV = some sdivHandler := rfl
+
+@[simp] theorem arithmeticHandler?_SMOD :
+    arithmeticHandler? .SMOD = some smodHandler := rfl
 
 @[simp] theorem eq_addHandler_iff (handler : OpcodeHandler) :
     addHandler = handler ↔ handler = addHandler := by
@@ -140,18 +166,29 @@ theorem binaryHandler_status_of_binaryStack?_none
     mulHandler = handler ↔ handler = mulHandler := by
   constructor <;> intro h_eq <;> exact h_eq.symm
 
+@[simp] theorem eq_sdivHandler_iff (handler : OpcodeHandler) :
+    sdivHandler = handler ↔ handler = sdivHandler := by
+  constructor <;> intro h_eq <;> exact h_eq.symm
+
+@[simp] theorem eq_smodHandler_iff (handler : OpcodeHandler) :
+    smodHandler = handler ↔ handler = smodHandler := by
+  constructor <;> intro h_eq <;> exact h_eq.symm
+
 theorem arithmeticHandler?_eq_some_iff
     (opcode : EvmOpcode) (handler : OpcodeHandler) :
     arithmeticHandler? opcode = some handler ↔
       (opcode = .ADD ∧ handler = addHandler) ∨
         (opcode = .SUB ∧ handler = subHandler) ∨
-          (opcode = .MUL ∧ handler = mulHandler) := by
+          (opcode = .MUL ∧ handler = mulHandler) ∨
+            (opcode = .SDIV ∧ handler = sdivHandler) ∨
+              (opcode = .SMOD ∧ handler = smodHandler) := by
   cases opcode <;> simp [arithmeticHandler?]
 
 theorem arithmeticHandler?_eq_none_iff
     (opcode : EvmOpcode) :
     arithmeticHandler? opcode = none ↔
-      opcode ≠ .ADD ∧ opcode ≠ .SUB ∧ opcode ≠ .MUL := by
+      opcode ≠ .ADD ∧ opcode ≠ .SUB ∧ opcode ≠ .MUL ∧
+        opcode ≠ .SDIV ∧ opcode ≠ .SMOD := by
   cases opcode <;> simp [arithmeticHandler?]
 
 theorem dispatchOpcode?_arithmeticHandlerTable_ADD
@@ -172,6 +209,18 @@ theorem dispatchOpcode?_arithmeticHandlerTable_MUL
       some (mulHandler state) := by
   exact HandlerTable.dispatchOpcode?_some arithmeticHandler?_MUL state
 
+theorem dispatchOpcode?_arithmeticHandlerTable_SDIV
+    (state : EvmState) :
+    HandlerTable.dispatchOpcode? arithmeticHandlerTable .SDIV state =
+      some (sdivHandler state) := by
+  exact HandlerTable.dispatchOpcode?_some arithmeticHandler?_SDIV state
+
+theorem dispatchOpcode?_arithmeticHandlerTable_SMOD
+    (state : EvmState) :
+    HandlerTable.dispatchOpcode? arithmeticHandlerTable .SMOD state =
+      some (smodHandler state) := by
+  exact HandlerTable.dispatchOpcode?_some arithmeticHandler?_SMOD state
+
 theorem dispatchOpcode_arithmeticHandlerTable_ADD
     (state : EvmState) :
     HandlerTable.dispatchOpcode arithmeticHandlerTable .ADD state =
@@ -189,6 +238,18 @@ theorem dispatchOpcode_arithmeticHandlerTable_MUL
     HandlerTable.dispatchOpcode arithmeticHandlerTable .MUL state =
       mulHandler state := by
   exact HandlerTable.dispatchOpcode_some arithmeticHandler?_MUL state
+
+theorem dispatchOpcode_arithmeticHandlerTable_SDIV
+    (state : EvmState) :
+    HandlerTable.dispatchOpcode arithmeticHandlerTable .SDIV state =
+      sdivHandler state := by
+  exact HandlerTable.dispatchOpcode_some arithmeticHandler?_SDIV state
+
+theorem dispatchOpcode_arithmeticHandlerTable_SMOD
+    (state : EvmState) :
+    HandlerTable.dispatchOpcode arithmeticHandlerTable .SMOD state =
+      smodHandler state := by
+  exact HandlerTable.dispatchOpcode_some arithmeticHandler?_SMOD state
 
 theorem dispatchOpcode_arithmeticHandlerTable_ADD_status_of_some
     {state : EvmState} {stack' : List EvmWord}
@@ -213,6 +274,22 @@ theorem dispatchOpcode_arithmeticHandlerTable_MUL_status_of_some
       state.status := by
   rw [dispatchOpcode_arithmeticHandlerTable_MUL state]
   simp [mulHandler, binaryHandler, h_stack, EvmState.withStack]
+
+theorem dispatchOpcode_arithmeticHandlerTable_SDIV_status_of_some
+    {state : EvmState} {stack' : List EvmWord}
+    (h_stack : binaryStack? EvmWord.sdiv state.stack = some stack') :
+    (HandlerTable.dispatchOpcode arithmeticHandlerTable .SDIV state).status =
+      state.status := by
+  rw [dispatchOpcode_arithmeticHandlerTable_SDIV state]
+  simp [sdivHandler, binaryHandler, h_stack, EvmState.withStack]
+
+theorem dispatchOpcode_arithmeticHandlerTable_SMOD_status_of_some
+    {state : EvmState} {stack' : List EvmWord}
+    (h_stack : binaryStack? EvmWord.smod state.stack = some stack') :
+    (HandlerTable.dispatchOpcode arithmeticHandlerTable .SMOD state).status =
+      state.status := by
+  rw [dispatchOpcode_arithmeticHandlerTable_SMOD state]
+  simp [smodHandler, binaryHandler, h_stack, EvmState.withStack]
 
 end ArithmeticHandlers
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add pure SDIV and SMOD handlers backed by EvmWord.sdiv/smod
- include SDIV and SMOD in the arithmetic handler table lookup surface
- add lookup, dispatch, stack, and status lemmas for the new handlers

## Verification
- lake build EvmAsm.Evm64.ArithmeticHandlers
- lake build EvmAsm.Evm64.SupportedHandlers
- scripts/check-file-size.sh --report

Refs evm-asm-34sg / GH #90.