### PR TITLE
feat(handlers): add signed byte dispatch lemmas

### DIFF
--- a/EvmAsm/Evm64/SupportedHandlerByte.lean
+++ b/EvmAsm/Evm64/SupportedHandlerByte.lean
@@ -127,6 +127,42 @@ theorem dispatchByte_supported_INVALID_byte
   rw [dispatchByte_supported_INVALID_byte]
   exact EvmState.invalid_status state
 
+theorem dispatchByte_supported_SDIV_byte
+    (state : EvmState) :
+    HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x05, by decide⟩ : Fin 256) state =
+        ArithmeticHandlers.sdivHandler state := by
+  exact dispatchByte_supported_of_lookup rfl
+    SupportedHandlers.supportedHandlerTable_SDIV state
+
+theorem dispatchByte_supported_SMOD_byte
+    (state : EvmState) :
+    HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x07, by decide⟩ : Fin 256) state =
+        ArithmeticHandlers.smodHandler state := by
+  exact dispatchByte_supported_of_lookup rfl
+    SupportedHandlers.supportedHandlerTable_SMOD state
+
+@[simp] theorem dispatchByte_supported_SDIV_byte_status_of_some
+    {state : EvmState} {stack' : List EvmWord}
+    (h_stack : ArithmeticHandlers.binaryStack? EvmWord.sdiv state.stack =
+      some stack') :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x05, by decide⟩ : Fin 256) state).status = state.status := by
+  rw [dispatchByte_supported_SDIV_byte]
+  simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler,
+    h_stack, EvmState.withStack]
+
+@[simp] theorem dispatchByte_supported_SMOD_byte_status_of_some
+    {state : EvmState} {stack' : List EvmWord}
+    (h_stack : ArithmeticHandlers.binaryStack? EvmWord.smod state.stack =
+      some stack') :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x07, by decide⟩ : Fin 256) state).status = state.status := by
+  rw [dispatchByte_supported_SMOD_byte]
+  simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler,
+    h_stack, EvmState.withStack]
+
 theorem dispatchByte_supported_undecoded
     {b : Fin 256} (h_decode : EvmOpcode.decodeByte? b.val = none)
     (state : EvmState) :

--- a/EvmAsm/Evm64/SupportedHandlers.lean
+++ b/EvmAsm/Evm64/SupportedHandlers.lean
@@ -420,6 +420,36 @@ theorem dispatchOpcode_of_lookup_status
     (by simp [CodeHandlers.codeHandlerTable, CodeHandlers.codeHandler?])
     MemoryHandlers.msizeHandlerTable_MSIZE
 
+@[simp] theorem supportedHandlerTable_SDIV :
+    supportedHandlerTable .SDIV =
+      some ArithmeticHandlers.sdivHandler := by
+  exact lookup_of_arithmetic
+    (by simp [TerminatingHandlers.terminatingHandlerTable, HandlerTable.setHandler])
+    (by simp [StackHandlers.stackHandlerTable, HandlerTable.setHandler])
+    (by simp [PushHandlers.pushHandlerTable, PushHandlers.pushHandler?])
+    (by simp [ControlHandlers.controlHandlerTable, ControlHandlers.controlHandler?])
+    (by rfl)
+    (by simp [ReturnDataHandlers.returnDataSizeHandlerTable,
+      ReturnDataHandlers.returnDataHandler?])
+    (by simp [CodeHandlers.codeHandlerTable, CodeHandlers.codeHandler?])
+    (by simp [MemoryHandlers.msizeHandlerTable, MemoryHandlers.memoryHandler?])
+    ArithmeticHandlers.arithmeticHandler?_SDIV
+
+@[simp] theorem supportedHandlerTable_SMOD :
+    supportedHandlerTable .SMOD =
+      some ArithmeticHandlers.smodHandler := by
+  exact lookup_of_arithmetic
+    (by simp [TerminatingHandlers.terminatingHandlerTable, HandlerTable.setHandler])
+    (by simp [StackHandlers.stackHandlerTable, HandlerTable.setHandler])
+    (by simp [PushHandlers.pushHandlerTable, PushHandlers.pushHandler?])
+    (by simp [ControlHandlers.controlHandlerTable, ControlHandlers.controlHandler?])
+    (by rfl)
+    (by simp [ReturnDataHandlers.returnDataSizeHandlerTable,
+      ReturnDataHandlers.returnDataHandler?])
+    (by simp [CodeHandlers.codeHandlerTable, CodeHandlers.codeHandler?])
+    (by simp [MemoryHandlers.msizeHandlerTable, MemoryHandlers.memoryHandler?])
+    ArithmeticHandlers.arithmeticHandler?_SMOD
+
 @[simp] theorem supportedHandlerTable_CALLDATASIZE :
     supportedHandlerTable .CALLDATASIZE =
       some CalldataHandlers.callDataSizeHandler := by


### PR DESCRIPTION
## Summary
- add supported-handler table projections for SDIV and SMOD
- add concrete byte dispatch lemmas for opcode bytes 0x05 and 0x07
- prove successful signed byte dispatch preserves status when stack decoding succeeds

## Verification
- lake build EvmAsm.Evm64.SupportedHandlers
- lake build EvmAsm.Evm64.SupportedHandlerByte
- scripts/check-file-size.sh --report

Refs evm-asm-34sg / GH #90.