### PR TITLE
feat(handlers): bridge signed handlers to stack execution

### DIFF
--- a/EvmAsm/Evm64/SDiv.lean
+++ b/EvmAsm/Evm64/SDiv.lean
@@ -15,6 +15,7 @@ import EvmAsm.Evm64.SDiv.Layout
 import EvmAsm.Evm64.SDiv.Args
 import EvmAsm.Evm64.SDiv.ArgsStackDecode
 import EvmAsm.Evm64.SDiv.StackExecutionBridge
+import EvmAsm.Evm64.SDiv.HandlerBridge
 import EvmAsm.Evm64.SDiv.Program
 import EvmAsm.Evm64.SDiv.LimbSpec
 import EvmAsm.Evm64.SDiv.AddrNorm

--- a/EvmAsm/Evm64/SDiv/HandlerBridge.lean
+++ b/EvmAsm/Evm64/SDiv/HandlerBridge.lean
@@ -1,0 +1,53 @@
+/-
+  EvmAsm.Evm64.SDiv.HandlerBridge
+
+  Connects the pure SDIV opcode handler to the SDIV stack-execution bridge.
+-/
+
+import EvmAsm.Evm64.ArithmeticHandlers
+import EvmAsm.Evm64.SDiv.StackExecutionBridge
+
+namespace EvmAsm.Evm64
+namespace SDivStackExecutionBridge
+
+theorem sdivHandler_stack_of_runSDivStack?_some
+    {state : EvmState} {out : SDivStackResult}
+    (h_run : runSDivStack? { stack := state.stack } = some out) :
+    (ArithmeticHandlers.sdivHandler state).stack =
+      out.effects.stackWords ++ out.stack := by
+  rw [runSDivStack?_eq_some_iff] at h_run
+  rcases h_run with ⟨dividend, divisor, rest, h_stack, h_out⟩
+  simp at h_stack
+  subst h_out
+  simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler,
+    SDivArgs.sdivResultFromArgs_eq, SDivArgs.sdivArgs, h_stack]
+
+theorem sdivHandler_status_of_runSDivStack?_some
+    {state : EvmState} {out : SDivStackResult}
+    (h_run : runSDivStack? { stack := state.stack } = some out) :
+    (ArithmeticHandlers.sdivHandler state).status = state.status := by
+  rw [runSDivStack?_eq_some_iff] at h_run
+  rcases h_run with ⟨dividend, divisor, rest, h_stack, h_out⟩
+  simp at h_stack
+  simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler,
+    EvmState.withStack, h_stack]
+
+theorem sdivHandler_status_of_runSDivStack?_none
+    {state : EvmState}
+    (h_run : runSDivStack? { stack := state.stack } = none) :
+    (ArithmeticHandlers.sdivHandler state).status = .error := by
+  cases h_stack : state.stack with
+  | nil =>
+      simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler,
+        h_stack]
+  | cons dividend tail =>
+      cases h_tail : tail with
+      | nil =>
+          simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler,
+            h_stack, h_tail]
+      | cons divisor rest =>
+          simp [runSDivStack?, SDivArgsStackDecode.decodeSDivStack?,
+            stackRestAfterSDiv?, Option.bind, h_stack, h_tail] at h_run
+
+end SDivStackExecutionBridge
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/SMod.lean
+++ b/EvmAsm/Evm64/SMod.lean
@@ -15,6 +15,7 @@ import EvmAsm.Evm64.SMod.Layout
 import EvmAsm.Evm64.SMod.Args
 import EvmAsm.Evm64.SMod.ArgsStackDecode
 import EvmAsm.Evm64.SMod.StackExecutionBridge
+import EvmAsm.Evm64.SMod.HandlerBridge
 import EvmAsm.Evm64.SMod.Program
 import EvmAsm.Evm64.SMod.LimbSpec
 import EvmAsm.Evm64.SMod.AddrNorm

--- a/EvmAsm/Evm64/SMod/HandlerBridge.lean
+++ b/EvmAsm/Evm64/SMod/HandlerBridge.lean
@@ -1,0 +1,53 @@
+/-
+  EvmAsm.Evm64.SMod.HandlerBridge
+
+  Connects the pure SMOD opcode handler to the SMOD stack-execution bridge.
+-/
+
+import EvmAsm.Evm64.ArithmeticHandlers
+import EvmAsm.Evm64.SMod.StackExecutionBridge
+
+namespace EvmAsm.Evm64
+namespace SModStackExecutionBridge
+
+theorem smodHandler_stack_of_runSModStack?_some
+    {state : EvmState} {out : SModStackResult}
+    (h_run : runSModStack? { stack := state.stack } = some out) :
+    (ArithmeticHandlers.smodHandler state).stack =
+      out.effects.stackWords ++ out.stack := by
+  rw [runSModStack?_eq_some_iff] at h_run
+  rcases h_run with ⟨dividend, divisor, rest, h_stack, h_out⟩
+  simp at h_stack
+  subst h_out
+  simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler,
+    SModArgs.smodResultFromArgs_eq, SModArgs.smodArgs, h_stack]
+
+theorem smodHandler_status_of_runSModStack?_some
+    {state : EvmState} {out : SModStackResult}
+    (h_run : runSModStack? { stack := state.stack } = some out) :
+    (ArithmeticHandlers.smodHandler state).status = state.status := by
+  rw [runSModStack?_eq_some_iff] at h_run
+  rcases h_run with ⟨dividend, divisor, rest, h_stack, h_out⟩
+  simp at h_stack
+  simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler,
+    EvmState.withStack, h_stack]
+
+theorem smodHandler_status_of_runSModStack?_none
+    {state : EvmState}
+    (h_run : runSModStack? { stack := state.stack } = none) :
+    (ArithmeticHandlers.smodHandler state).status = .error := by
+  cases h_stack : state.stack with
+  | nil =>
+      simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler,
+        h_stack]
+  | cons dividend tail =>
+      cases h_tail : tail with
+      | nil =>
+          simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler,
+            h_stack, h_tail]
+      | cons divisor rest =>
+          simp [runSModStack?, SModArgsStackDecode.decodeSModStack?,
+            stackRestAfterSMod?, Option.bind, h_stack, h_tail] at h_run
+
+end SModStackExecutionBridge
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add SDIV and SMOD handler bridge files connecting pure handlers to stack-execution bridges
- prove handler stack output agrees with successful stack execution results
- prove handler status for successful and underflowing SDIV/SMOD stack execution paths
- wire the new bridge files into the SDIV and SMOD umbrellas

## Verification
- lake build EvmAsm.Evm64.SDiv.HandlerBridge
- lake build EvmAsm.Evm64.SMod.HandlerBridge
- lake build EvmAsm.Evm64.SDiv EvmAsm.Evm64.SMod
- scripts/check-file-size.sh --report

Refs evm-asm-34sg / GH #90.