### PR TITLE
feat(handlers): add signed underflow lemmas

### DIFF
--- a/EvmAsm/Evm64/SDiv/HandlerBridge.lean
+++ b/EvmAsm/Evm64/SDiv/HandlerBridge.lean
@@ -49,6 +49,18 @@ theorem sdivHandler_status_of_runSDivStack?_none
           simp [runSDivStack?, SDivArgsStackDecode.decodeSDivStack?,
             stackRestAfterSDiv?, Option.bind, h_stack, h_tail] at h_run
 
+theorem sdivHandler_status_empty_stack
+    (state : EvmState) :
+    (ArithmeticHandlers.sdivHandler { state with stack := [] }).status =
+      .error := by
+  simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler]
+
+theorem sdivHandler_status_singleton_stack
+    (state : EvmState) (dividend : EvmWord) :
+    (ArithmeticHandlers.sdivHandler
+      { state with stack := [dividend] }).status = .error := by
+  simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler]
+
 theorem sdivHandler_stack_zero_divisor
     (state : EvmState) (dividend : EvmWord) (rest : List EvmWord) :
     (ArithmeticHandlers.sdivHandler

--- a/EvmAsm/Evm64/SMod/HandlerBridge.lean
+++ b/EvmAsm/Evm64/SMod/HandlerBridge.lean
@@ -49,6 +49,18 @@ theorem smodHandler_status_of_runSModStack?_none
           simp [runSModStack?, SModArgsStackDecode.decodeSModStack?,
             stackRestAfterSMod?, Option.bind, h_stack, h_tail] at h_run
 
+theorem smodHandler_status_empty_stack
+    (state : EvmState) :
+    (ArithmeticHandlers.smodHandler { state with stack := [] }).status =
+      .error := by
+  simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler]
+
+theorem smodHandler_status_singleton_stack
+    (state : EvmState) (dividend : EvmWord) :
+    (ArithmeticHandlers.smodHandler
+      { state with stack := [dividend] }).status = .error := by
+  simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler]
+
 theorem smodHandler_stack_zero_divisor
     (state : EvmState) (dividend : EvmWord) (rest : List EvmWord) :
     (ArithmeticHandlers.smodHandler


### PR DESCRIPTION
## Summary
- add SDIV handler status lemmas for empty and singleton stack underflow
- add SMOD handler status lemmas for empty and singleton stack underflow
- expose concrete failure cases for later byte and interpreter bridge slices

## Verification
- lake build EvmAsm.Evm64.SDiv.HandlerBridge
- lake build EvmAsm.Evm64.SMod.HandlerBridge
- lake build EvmAsm.Evm64.SDiv EvmAsm.Evm64.SMod
- scripts/check-file-size.sh --report