### PR TITLE
feat(loop): add signed error status lemmas

### DIFF
--- a/EvmAsm/Evm64/SupportedLoopBridge.lean
+++ b/EvmAsm/Evm64/SupportedLoopBridge.lean
@@ -219,6 +219,30 @@ theorem stepWithSupportedHandler_SMOD_status_singleton_stack
   exact SModStackExecutionBridge.smodHandler_status_singleton_stack
     state dividend
 
+theorem stepWithSupportedHandler_SDIV_status_of_runSDivStack?_none
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SDIV)
+    (h_run :
+      SDivStackExecutionBridge.runSDivStack? { stack := state.stack } =
+        none) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).status =
+      .error := by
+  rw [stepWithSupportedHandler_SDIV h_decode]
+  exact SDivStackExecutionBridge.sdivHandler_status_of_runSDivStack?_none
+    h_run
+
+theorem stepWithSupportedHandler_SMOD_status_of_runSModStack?_none
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SMOD)
+    (h_run :
+      SModStackExecutionBridge.runSModStack? { stack := state.stack } =
+        none) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).status =
+      .error := by
+  rw [stepWithSupportedHandler_SMOD h_decode]
+  exact SModStackExecutionBridge.smodHandler_status_of_runSModStack?_none
+    h_run
+
 theorem stepWithSupportedHandler_SDIV_stack_zero_divisor
     {state : EvmState} (dividend : EvmWord) (rest : List EvmWord)
     (h_decode :


### PR DESCRIPTION
## Summary
- add supported-loop SDIV error status when runSDivStack? fails
- add supported-loop SMOD error status when runSModStack? fails
- reuse signed handler failure-status bridge facts through decoded loop dispatch

## Verification
- lake build EvmAsm.Evm64.SupportedLoopBridge
- scripts/check-file-size.sh --report