### PR TITLE
feat(handlers): add signed byte stack bridges

### DIFF
--- a/EvmAsm/Evm64/SupportedHandlerByte.lean
+++ b/EvmAsm/Evm64/SupportedHandlerByte.lean
@@ -219,6 +219,30 @@ theorem dispatchByte_supported_SMOD_byte_stack_neg_neg_sign
   rw [dispatchByte_supported_SMOD_byte]
   exact SModStackExecutionBridge.smodHandler_stack_neg_neg_sign state rest
 
+theorem dispatchByte_supported_SDIV_byte_stack_of_runSDivStack?_some
+    {state : EvmState} {out : SDivStackExecutionBridge.SDivStackResult}
+    (h_run :
+      SDivStackExecutionBridge.runSDivStack? { stack := state.stack } =
+        some out) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x05, by decide⟩ : Fin 256) state).stack =
+        out.effects.stackWords ++ out.stack := by
+  rw [dispatchByte_supported_SDIV_byte]
+  exact SDivStackExecutionBridge.sdivHandler_stack_of_runSDivStack?_some
+    h_run
+
+theorem dispatchByte_supported_SMOD_byte_stack_of_runSModStack?_some
+    {state : EvmState} {out : SModStackExecutionBridge.SModStackResult}
+    (h_run :
+      SModStackExecutionBridge.runSModStack? { stack := state.stack } =
+        some out) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x07, by decide⟩ : Fin 256) state).stack =
+        out.effects.stackWords ++ out.stack := by
+  rw [dispatchByte_supported_SMOD_byte]
+  exact SModStackExecutionBridge.smodHandler_stack_of_runSModStack?_some
+    h_run
+
 theorem dispatchByte_supported_SDIV_byte_status_empty_stack
     (state : EvmState) :
     (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable


### PR DESCRIPTION
## Summary
- add concrete byte-dispatch SDIV stack bridge from runSDivStack?
- add concrete byte-dispatch SMOD stack bridge from runSModStack?
- reuse the signed handler stack bridge facts through concrete opcode bytes

## Verification
- lake build EvmAsm.Evm64.SupportedHandlerByte
- scripts/check-file-size.sh --report