### PR TITLE
feat(handlers): add signed byte pc lemmas

### DIFF
--- a/EvmAsm/Evm64/SupportedHandlerByte.lean
+++ b/EvmAsm/Evm64/SupportedHandlerByte.lean
@@ -145,6 +145,20 @@ theorem dispatchByte_supported_SMOD_byte
   exact dispatchByte_supported_of_lookup rfl
     SupportedHandlers.supportedHandlerTable_SMOD state
 
+theorem dispatchByte_supported_SDIV_byte_pc
+    (state : EvmState) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x05, by decide⟩ : Fin 256) state).pc = state.pc := by
+  rw [dispatchByte_supported_SDIV_byte]
+  exact SDivStackExecutionBridge.sdivHandler_pc state
+
+theorem dispatchByte_supported_SMOD_byte_pc
+    (state : EvmState) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x07, by decide⟩ : Fin 256) state).pc = state.pc := by
+  rw [dispatchByte_supported_SMOD_byte]
+  exact SModStackExecutionBridge.smodHandler_pc state
+
 theorem dispatchByte_supported_SDIV_byte_stack_zero_divisor
     (state : EvmState) (dividend : EvmWord) (rest : List EvmWord) :
     (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable


### PR DESCRIPTION
## Summary
- add concrete byte-dispatch SDIV PC preservation lemma
- add concrete byte-dispatch SMOD PC preservation lemma
- reuse the signed handler PC preservation facts through concrete opcode bytes

## Verification
- lake build EvmAsm.Evm64.SupportedHandlerByte
- scripts/check-file-size.sh --report