### PR TITLE
feat(interpreter): add signed exec-step pc lemmas

### DIFF
--- a/EvmAsm/Evm64/InterpreterExecutableStepBridge.lean
+++ b/EvmAsm/Evm64/InterpreterExecutableStepBridge.lean
@@ -142,6 +142,30 @@ theorem loopFuel_one_supported_execSpec_SMOD
   exact SupportedHandlers.dispatchOpcode_of_lookup
     SupportedHandlers.supportedHandlerTable_SMOD state
 
+theorem loopFuel_one_supported_execSpec_SDIV_pc
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SDIV : BitVec 8)) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      state).pc = state.pc := by
+  rw [loopFuel_one_supported_execSpec_SDIV h_status h_pc h_code]
+  exact SDivStackExecutionBridge.sdivHandler_pc state
+
+theorem loopFuel_one_supported_execSpec_SMOD_pc
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SMOD : BitVec 8)) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      state).pc = state.pc := by
+  rw [loopFuel_one_supported_execSpec_SMOD h_status h_pc h_code]
+  exact SModStackExecutionBridge.smodHandler_pc state
+
 theorem loopFuel_one_supported_execSpec_SDIV_status_of_some
     {state : EvmState} {stack' : List EvmWord}
     (h_status : state.status = .running)


### PR DESCRIPTION
## Summary
- add executable-spec SDIV one-step PC preservation lemma
- add executable-spec SMOD one-step PC preservation lemma
- reuse direct supported handler bridge and signed handler PC facts

## Verification
- lake build EvmAsm.Evm64.InterpreterExecutableStepBridge
- scripts/check-file-size.sh --report