### PR TITLE
feat(handlers): add signed handler memory lemmas

### DIFF
--- a/EvmAsm/Evm64/SDiv/HandlerBridge.lean
+++ b/EvmAsm/Evm64/SDiv/HandlerBridge.lean
@@ -24,6 +24,28 @@ theorem sdivHandler_gas
     simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler,
       EvmState.withStack, EvmState.invalid, EvmState.withStatus, h_stack]
 
+theorem sdivHandler_memoryCells
+    (state : EvmState) :
+    (ArithmeticHandlers.sdivHandler state).memoryCells =
+      state.memoryCells := by
+  cases h_stack : ArithmeticHandlers.binaryStack? EvmWord.sdiv state.stack <;>
+    simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler,
+      EvmState.withStack, EvmState.invalid, EvmState.withStatus, h_stack]
+
+theorem sdivHandler_memory
+    (state : EvmState) :
+    (ArithmeticHandlers.sdivHandler state).memory = state.memory := by
+  cases h_stack : ArithmeticHandlers.binaryStack? EvmWord.sdiv state.stack <;>
+    simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler,
+      EvmState.withStack, EvmState.invalid, EvmState.withStatus, h_stack]
+
+theorem sdivHandler_memSize
+    (state : EvmState) :
+    (ArithmeticHandlers.sdivHandler state).memSize = state.memSize := by
+  cases h_stack : ArithmeticHandlers.binaryStack? EvmWord.sdiv state.stack <;>
+    simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler,
+      EvmState.withStack, EvmState.invalid, EvmState.withStatus, h_stack]
+
 theorem sdivHandler_stack_of_runSDivStack?_some
     {state : EvmState} {out : SDivStackResult}
     (h_run : runSDivStack? { stack := state.stack } = some out) :

--- a/EvmAsm/Evm64/SMod/HandlerBridge.lean
+++ b/EvmAsm/Evm64/SMod/HandlerBridge.lean
@@ -24,6 +24,28 @@ theorem smodHandler_gas
     simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler,
       EvmState.withStack, EvmState.invalid, EvmState.withStatus, h_stack]
 
+theorem smodHandler_memoryCells
+    (state : EvmState) :
+    (ArithmeticHandlers.smodHandler state).memoryCells =
+      state.memoryCells := by
+  cases h_stack : ArithmeticHandlers.binaryStack? EvmWord.smod state.stack <;>
+    simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler,
+      EvmState.withStack, EvmState.invalid, EvmState.withStatus, h_stack]
+
+theorem smodHandler_memory
+    (state : EvmState) :
+    (ArithmeticHandlers.smodHandler state).memory = state.memory := by
+  cases h_stack : ArithmeticHandlers.binaryStack? EvmWord.smod state.stack <;>
+    simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler,
+      EvmState.withStack, EvmState.invalid, EvmState.withStatus, h_stack]
+
+theorem smodHandler_memSize
+    (state : EvmState) :
+    (ArithmeticHandlers.smodHandler state).memSize = state.memSize := by
+  cases h_stack : ArithmeticHandlers.binaryStack? EvmWord.smod state.stack <;>
+    simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler,
+      EvmState.withStack, EvmState.invalid, EvmState.withStatus, h_stack]
+
 theorem smodHandler_stack_of_runSModStack?_some
     {state : EvmState} {out : SModStackResult}
     (h_run : runSModStack? { stack := state.stack } = some out) :


### PR DESCRIPTION
## Summary
- add SDIV handler preservation lemmas for memoryCells, memory, and memSize
- add SMOD handler preservation lemmas for memoryCells, memory, and memSize
- cover both successful stack updates and invalid underflow paths

## Verification
- lake build EvmAsm.Evm64.SDiv.HandlerBridge
- lake build EvmAsm.Evm64.SMod.HandlerBridge
- lake build EvmAsm.Evm64.SDiv EvmAsm.Evm64.SMod
- scripts/check-file-size.sh --report