### PR TITLE
chore(shake): noshake DivMod/LoopBody → DivN4Overestimate false-positive

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -319,6 +319,8 @@
   ["EvmAsm.Evm64.DivMod.Compose.ModPhaseB"],
   "EvmAsm.Evm64.DivMod.LoopBody.TrialMax":
   ["EvmAsm.Evm64.DivMod.LoopBody"],
+  "EvmAsm.Evm64.DivMod.LoopBody":
+  ["EvmAsm.Evm64.EvmWordArith.DivN4Overestimate"],
   "EvmAsm.Evm64.Shift.ShlCompose":
   ["EvmAsm.Evm64.Shift.ComposeBase"],
   "EvmAsm.Evm64.Shift.SarCompose":


### PR DESCRIPTION
Shake suggested dropping the `EvmAsm.Evm64.EvmWordArith.DivN4Overestimate`
import from `EvmAsm/Evm64/DivMod/LoopBody.lean`, but the import is
structurally load-bearing: `DivN4Overestimate` is the upstream of
`LoopSemantic` / `LoopDefs` / `LoopDefs.Iter` / `LoopDefs.Post`,
which downstream consumers of `LoopBody` (`LoopBodyN1`,
`LoopIterN1/Max`, `LoopIterN3`, `SpecPredicates`, …) reach
transitively through this file. Removing the import breaks
`EvmWord.getLimbN` dot-notation elaboration in `SpecPredicates` and
removes `loopBodyN{1,3}SkipPost`, `loopBodyN1AddbackBeqPost`, and
`addbackN4_carry` from the consumers — `lake build` fails in 4+
files. Adding the import to a single intermediate (e.g.
`LoopDefs.Iter`) doesn't help because consumers also need the
`Post` re-exports.

Mark as a `scripts/noshake.json` false-positive so future shake runs
ignore it. Closes `evm-asm-hu39q` (P3 sub-slice of evm-asm-9tq /
GH #1045).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes). Refs GH #1045.