### PR TITLE
feat(interpreter): preserve signed code length invariant

### DIFF
--- a/EvmAsm/Evm64/InterpreterExecutableStepBridge.lean
+++ b/EvmAsm/Evm64/InterpreterExecutableStepBridge.lean
@@ -262,6 +262,32 @@ theorem loopFuel_one_supported_execSpec_SMOD_env
   rw [loopFuel_one_supported_execSpec_SMOD h_status h_pc h_code]
   exact SModStackExecutionBridge.smodHandler_env state
 
+theorem loopFuel_one_supported_execSpec_SDIV_codeLenMatches
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SDIV : BitVec 8))
+    (h_codeLen : state.codeLenMatches) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      state).codeLenMatches := by
+  rw [loopFuel_one_supported_execSpec_SDIV h_status h_pc h_code]
+  exact SDivStackExecutionBridge.sdivHandler_codeLenMatches state h_codeLen
+
+theorem loopFuel_one_supported_execSpec_SMOD_codeLenMatches
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code :
+      state.code[state.pc] =
+        (ExecutableSpecOpcodeBridge.Ops.SMOD : BitVec 8))
+    (h_codeLen : state.codeLenMatches) :
+    (InterpreterLoop.loopFuel SupportedLoopBridge.supportedLoopHandler 1
+      state).codeLenMatches := by
+  rw [loopFuel_one_supported_execSpec_SMOD h_status h_pc h_code]
+  exact SModStackExecutionBridge.smodHandler_codeLenMatches state h_codeLen
+
 theorem loopFuel_one_supported_execSpec_SDIV_memoryCells
     {state : EvmState}
     (h_status : state.status = .running)

--- a/EvmAsm/Evm64/SDiv/HandlerBridge.lean
+++ b/EvmAsm/Evm64/SDiv/HandlerBridge.lean
@@ -67,6 +67,13 @@ theorem sdivHandler_env
     simp [ArithmeticHandlers.sdivHandler, ArithmeticHandlers.binaryHandler,
       EvmState.withStack, EvmState.invalid, EvmState.withStatus, h_stack]
 
+theorem sdivHandler_codeLenMatches
+    (state : EvmState) (h_codeLen : state.codeLenMatches) :
+    (ArithmeticHandlers.sdivHandler state).codeLenMatches := by
+  unfold EvmState.codeLenMatches at h_codeLen ⊢
+  rw [sdivHandler_codeLen, sdivHandler_code]
+  exact h_codeLen
+
 theorem sdivHandler_stack_of_runSDivStack?_some
     {state : EvmState} {out : SDivStackResult}
     (h_run : runSDivStack? { stack := state.stack } = some out) :

--- a/EvmAsm/Evm64/SMod/HandlerBridge.lean
+++ b/EvmAsm/Evm64/SMod/HandlerBridge.lean
@@ -67,6 +67,13 @@ theorem smodHandler_env
     simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler,
       EvmState.withStack, EvmState.invalid, EvmState.withStatus, h_stack]
 
+theorem smodHandler_codeLenMatches
+    (state : EvmState) (h_codeLen : state.codeLenMatches) :
+    (ArithmeticHandlers.smodHandler state).codeLenMatches := by
+  unfold EvmState.codeLenMatches at h_codeLen ⊢
+  rw [smodHandler_codeLen, smodHandler_code]
+  exact h_codeLen
+
 theorem smodHandler_stack_of_runSModStack?_some
     {state : EvmState} {out : SModStackResult}
     (h_run : runSModStack? { stack := state.stack } = some out) :

--- a/EvmAsm/Evm64/SupportedHandlerByte.lean
+++ b/EvmAsm/Evm64/SupportedHandlerByte.lean
@@ -217,6 +217,20 @@ theorem dispatchByte_supported_SMOD_byte_env
   rw [dispatchByte_supported_SMOD_byte]
   exact SModStackExecutionBridge.smodHandler_env state
 
+theorem dispatchByte_supported_SDIV_byte_codeLenMatches
+    (state : EvmState) (h_codeLen : state.codeLenMatches) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x05, by decide⟩ : Fin 256) state).codeLenMatches := by
+  rw [dispatchByte_supported_SDIV_byte]
+  exact SDivStackExecutionBridge.sdivHandler_codeLenMatches state h_codeLen
+
+theorem dispatchByte_supported_SMOD_byte_codeLenMatches
+    (state : EvmState) (h_codeLen : state.codeLenMatches) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable
+      (⟨0x07, by decide⟩ : Fin 256) state).codeLenMatches := by
+  rw [dispatchByte_supported_SMOD_byte]
+  exact SModStackExecutionBridge.smodHandler_codeLenMatches state h_codeLen
+
 theorem dispatchByte_supported_SDIV_byte_memoryCells
     (state : EvmState) :
     (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable

--- a/EvmAsm/Evm64/SupportedLoopBridge.lean
+++ b/EvmAsm/Evm64/SupportedLoopBridge.lean
@@ -211,6 +211,22 @@ theorem stepWithSupportedHandler_SMOD_env
   rw [stepWithSupportedHandler_SMOD h_decode]
   exact SModStackExecutionBridge.smodHandler_env state
 
+theorem stepWithSupportedHandler_SDIV_codeLenMatches
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SDIV)
+    (h_codeLen : state.codeLenMatches) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).codeLenMatches := by
+  rw [stepWithSupportedHandler_SDIV h_decode]
+  exact SDivStackExecutionBridge.sdivHandler_codeLenMatches state h_codeLen
+
+theorem stepWithSupportedHandler_SMOD_codeLenMatches
+    {state : EvmState}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SMOD)
+    (h_codeLen : state.codeLenMatches) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).codeLenMatches := by
+  rw [stepWithSupportedHandler_SMOD h_decode]
+  exact SModStackExecutionBridge.smodHandler_codeLenMatches state h_codeLen
+
 theorem stepWithSupportedHandler_SDIV_memoryCells
     {state : EvmState}
     (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some .SDIV) :


### PR DESCRIPTION
## Summary
- prove SDIV and SMOD handlers preserve EvmState.codeLenMatches
- lift the invariant through signed byte dispatch and supported loop steps
- lift the invariant through one executable-spec SDIV/SMOD interpreter step

## Verification
- lake build EvmAsm.Evm64.InterpreterExecutableStepBridge
- lake build EvmAsm.Evm64.SDiv.HandlerBridge EvmAsm.Evm64.SMod.HandlerBridge
- scripts/check-file-size.sh --report