### PR TITLE
chore(shake): noshake DivMod/Compose/FullPathN4Shift0 → FullPathN4Beq false-positive

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -317,6 +317,8 @@
   ["EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV2.Un21Bridge"],
   "EvmAsm.Evm64.DivMod.Compose.ModPhaseBn3":
   ["EvmAsm.Evm64.DivMod.Compose.ModPhaseB"],
+  "EvmAsm.Evm64.DivMod.Compose.FullPathN4Shift0":
+  ["EvmAsm.Evm64.DivMod.Compose.FullPathN4Beq"],
   "EvmAsm.Evm64.DivMod.LoopBody.TrialMax":
   ["EvmAsm.Evm64.DivMod.LoopBody"],
   "EvmAsm.Evm64.DivMod.LoopBody":


### PR DESCRIPTION
shake suggests dropping (or swapping) the `FullPathN4Beq` import from `EvmAsm/Evm64/DivMod/Compose/FullPathN4Shift0.lean`. Verified locally: removing the import breaks the build (declarations needed by the file are reached transitively through `FullPathN4Beq`).

Add a `noshake.json` entry to suppress the suggestion. No code changes.

Refs evm-asm-qpxr6, GH #1045.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).