### PR TITLE
chore(shake): drop unused Div128KnuthLower import in Div128PhaseNoWrap

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/Div128PhaseNoWrap.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128PhaseNoWrap.lean
@@ -18,7 +18,7 @@
   See `project_un21_lt_vTop_plan.md` for the full plan.
 -/
 
-import EvmAsm.Evm64.EvmWordArith.Div128KnuthLower
+import EvmAsm.Evm64.EvmWordArith.Div128QuotientBounds
 
 namespace EvmAsm.Evm64
 


### PR DESCRIPTION
Shake-hygiene slice (parent evm-asm-9tq, GH #1045).

`EvmAsm/Evm64/EvmWordArith/Div128PhaseNoWrap.lean` imported `Div128KnuthLower` but only used declarations from `Div128QuotientBounds` (the transitive parent). Replace the import with `Div128QuotientBounds` directly.

Verified locally: `lake build` green; no other diff.

Refs GH #1045, beads evm-asm-x5lck.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).