### PR TITLE
chore: noshake DivMod/Compose/ModPhaseBn21 → ModPhaseB false-positive

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -317,6 +317,8 @@
   ["EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV2.Un21Bridge"],
   "EvmAsm.Evm64.DivMod.Compose.ModPhaseBn3":
   ["EvmAsm.Evm64.DivMod.Compose.ModPhaseB"],
+  "EvmAsm.Evm64.DivMod.Compose.ModPhaseBn21":
+  ["EvmAsm.Evm64.DivMod.Compose.ModPhaseB"],
   "EvmAsm.Evm64.DivMod.Compose.FullPathN4Shift0":
   ["EvmAsm.Evm64.DivMod.Compose.FullPathN4Beq"],
   "EvmAsm.Evm64.DivMod.LoopBody.TrialMax":


### PR DESCRIPTION
ModPhaseBn21.lean uses divK_phaseB_init1_code_sub_modCode, divK_phaseB_init2_code_sub_modCode, divK_phaseB_tail_code_sub_modCode, mod_phB_i2_8, and divK_phaseB_tail_pre_unfold/post_unfold from ModPhaseB. shake misses these references because they appear inside `have …_raw := …`, `simp only [...]` and `rw` tactic blocks. Mirror the existing `ModPhaseBn3 → ModPhaseB` noshake entry.

`lake exe shake EvmAsm` no longer flags ModPhaseBn21. `lake build` green.

Refs evm-asm-6eknw / parent evm-asm-6qj (GH #1045).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).