### PR TITLE
chore(shake): noshake SupportedHandlerByte/LoopBridge + MStore.UnalignedFramedStackSpec false-positives

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -127,7 +127,11 @@
  "EvmAsm.Evm64.MStore.StackSpec":
   ["EvmAsm.Evm64.MStore.CombinedSequenceSpec"],
  "EvmAsm.Evm64.MStore.UnalignedFramedStackSpec":
-  ["EvmAsm.Evm64.MStore.UnalignedStackSpec"],
+  ["EvmAsm.Evm64.MStore.UnalignedStackSpec", "EvmAsm.Evm64.MStore.StackSpec"],
+ "EvmAsm.Evm64.SupportedHandlerByte":
+  ["EvmAsm.Evm64.SDiv.HandlerBridge", "EvmAsm.Evm64.SMod.HandlerBridge"],
+ "EvmAsm.Evm64.SupportedLoopBridge":
+  ["EvmAsm.Evm64.SDiv.HandlerBridge", "EvmAsm.Evm64.SMod.HandlerBridge"],
  "EvmAsm.Evm64.MLoad.UnalignedFramedStackSpec":
   ["EvmAsm.Evm64.MLoad.UnalignedStackSpec"],
  "EvmAsm.Evm64.MLoad.ByteAlg":


### PR DESCRIPTION
Three shake suggestions in `lake exe shake EvmAsm` were false positives — namespace-spanning declarations that shake's import tracker doesn't follow. Add noshake.json entries instead of dropping the imports.

- `EvmAsm.Evm64.SupportedHandlerByte` and `EvmAsm.Evm64.SupportedLoopBridge` use `SDivStackExecutionBridge.*` / `SModStackExecutionBridge.*` declarations that live in `SDiv/HandlerBridge.lean` and `SMod/HandlerBridge.lean` (those files declare into the *StackExecutionBridge namespaces). Dropping the HandlerBridge imports removes the declarations and the build breaks.
- `EvmAsm.Evm64.MStore.UnalignedFramedStackSpec` uses `mstore_prologue_stack_spec_within`, declared in `MStore.Spec` and re-exposed through `MStore.StackSpec`.

Verified locally: `lake build` passes; `lake exe shake EvmAsm | scripts/shake-filter.py` reports `0 block(s) kept`.

Refs evm-asm-kr5f0, parent evm-asm-6qj, GH #1045.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).