### PR TITLE
docs(accelerators): add bridge coverage table

### DIFF
--- a/docs/zkvm-accelerators-interface.md
+++ b/docs/zkvm-accelerators-interface.md
@@ -43,7 +43,7 @@ In short: function set + argument layout + status framing come from
 also uses; concrete syscall IDs are handler-side and tracked
 separately.
 
-## Coverage map
+## Coverage audit table
 
 The header declares 19 entry points. Each one is (or will be) bridged by
 a Lean payload type, a syscall-ID constant tying the ECALL handler to
@@ -51,35 +51,38 @@ the function, and a Hoare triple linking the RISC-V state transition to
 the pure result. Per-function status is tracked in the children of
 `evm-asm-nr2sk`.
 
-Non-precompile accelerators:
+Selector constants live in
+`EvmAsm/Evm64/Accelerators/SyscallIds.lean` as both `Nat` IDs under
+`EvmAsm.Accelerators.SyscallId` and RV64 words under
+`EvmAsm.Rv64.SyscallIdWord`; the `allSelectors_pairwiseDistinct` and
+`accelerator_ids_in_range` theorems pin the table mechanically.
 
-| C symbol | Status |
-|----------|--------|
-| `zkvm_keccak256` | partial (input/result payload bridges in `EvmAsm/EL/KeccakInputBridge.lean`, `KeccakResultBridge.lean`); `zkvm_status` plumbing pending |
-| `zkvm_secp256k1_verify` | not yet bridged |
+| Surface | C symbol | Selector | Lean payload bridge | ECALL / execution bridge status |
+|---------|----------|----------|---------------------|---------------------------------|
+| KECCAK256 opcode | `zkvm_keccak256` | `keccak256` / `0x100` | `EvmAsm/EL/KeccakInputBridge.lean`, `EvmAsm/EL/KeccakResultBridge.lean` | `EvmAsm/EL/KeccakEcallBridge.lean`, `EvmAsm/EL/KeccakExecutionBridge.lean`, `EvmAsm/EL/KeccakStackBridge.lean`, `EvmAsm/EL/KeccakStackExecutionBridge.lean` |
+| secp256k1 signature verify | `zkvm_secp256k1_verify` | `secp256k1_verify` / `0x101` | `EvmAsm/EL/Secp256k1VerifyInputBridge.lean`, `EvmAsm/EL/Secp256k1VerifyResultBridge.lean` | `EvmAsm/EL/Secp256k1VerifyEcallBridge.lean` |
+| ECRECOVER `0x01` | `zkvm_secp256k1_ecrecover` | `secp256k1_ecrecover` / `0x102` | `EvmAsm/EL/Secp256k1EcrecoverInputBridge.lean`, `EvmAsm/EL/Secp256k1EcrecoverResultBridge.lean` | `EvmAsm/EL/Secp256k1EcrecoverEcallBridge.lean` |
+| SHA256 `0x02` | `zkvm_sha256` | `sha256` / `0x103` | `EvmAsm/EL/Sha256InputBridge.lean`, `EvmAsm/EL/Sha256ResultBridge.lean` | `EvmAsm/EL/Sha256EcallBridge.lean` |
+| RIPEMD160 `0x03` | `zkvm_ripemd160` | `ripemd160` / `0x104` | `EvmAsm/EL/Ripemd160InputBridge.lean`, `EvmAsm/EL/Ripemd160ResultBridge.lean` | `EvmAsm/EL/Ripemd160EcallBridge.lean` |
+| IDENTITY `0x04` | none | none | pure memory copy path, no accelerator payload | not applicable |
+| MODEXP `0x05` | `zkvm_modexp` | `modexp` / `0x105` | `EvmAsm/EL/ModexpInputBridge.lean`, `EvmAsm/EL/ModexpResultBridge.lean` | `EvmAsm/EL/ModexpEcallBridge.lean` |
+| BN254 G1 ADD `0x06` | `zkvm_bn254_g1_add` | `bn254_g1_add` / `0x106` | `EvmAsm/EL/Bn254G1AddInputBridge.lean`, `EvmAsm/EL/Bn254G1AddResultBridge.lean` | `EvmAsm/EL/Bn254G1AddEcallBridge.lean` |
+| BN254 G1 MUL `0x07` | `zkvm_bn254_g1_mul` | `bn254_g1_mul` / `0x107` | `EvmAsm/EL/Bn254G1MulInputBridge.lean`, `EvmAsm/EL/Bn254G1MulResultBridge.lean` | `EvmAsm/EL/Bn254G1MulEcallBridge.lean` |
+| BN254 PAIRING `0x08` | `zkvm_bn254_pairing` | `bn254_pairing` / `0x108` | `EvmAsm/EL/Bn254PairingInputBridge.lean`, `EvmAsm/EL/Bn254PairingResultBridge.lean` | `EvmAsm/EL/Bn254PairingEcallBridge.lean` |
+| BLAKE2F `0x09` | `zkvm_blake2f` | `blake2f` / `0x109` | `EvmAsm/EL/Blake2fInputBridge.lean`, `EvmAsm/EL/Blake2fResultBridge.lean` | `EvmAsm/EL/Blake2fEcallBridge.lean` |
+| KZG POINT EVAL `0x0a` | `zkvm_kzg_point_eval` | `kzg_point_eval` / `0x10a` | `EvmAsm/EL/KzgPointEvalInputBridge.lean`, `EvmAsm/EL/KzgPointEvalResultBridge.lean` | `EvmAsm/EL/KzgPointEvalEcallBridge.lean` |
+| BLS12 G1 ADD `0x0b` | `zkvm_bls12_g1_add` | `bls12_g1_add` / `0x10b` | `EvmAsm/EL/Bls12G1AddInputBridge.lean`, `EvmAsm/EL/Bls12G1AddResultBridge.lean` | `EvmAsm/EL/Bls12G1AddEcallBridge.lean` |
+| BLS12 G1 MSM `0x0c` | `zkvm_bls12_g1_msm` | `bls12_g1_msm` / `0x10c` | `EvmAsm/EL/Bls12G1MsmInputBridge.lean`, `EvmAsm/EL/Bls12G1MsmResultBridge.lean` | `EvmAsm/EL/Bls12G1MsmEcallBridge.lean` |
+| BLS12 G2 ADD `0x0d` | `zkvm_bls12_g2_add` | `bls12_g2_add` / `0x10d` | `EvmAsm/EL/Bls12G2AddInputBridge.lean`, `EvmAsm/EL/Bls12G2AddResultBridge.lean` | `EvmAsm/EL/Bls12G2AddEcallBridge.lean` |
+| BLS12 G2 MSM `0x0e` | `zkvm_bls12_g2_msm` | `bls12_g2_msm` / `0x10e` | `EvmAsm/EL/Bls12G2MsmInputBridge.lean`, `EvmAsm/EL/Bls12G2MsmResultBridge.lean` | `EvmAsm/EL/Bls12G2MsmEcallBridge.lean` |
+| BLS12 PAIRING `0x0f` | `zkvm_bls12_pairing` | `bls12_pairing` / `0x10f` | `EvmAsm/EL/Bls12PairingInputBridge.lean`, `EvmAsm/EL/Bls12PairingResultBridge.lean` | `EvmAsm/EL/Bls12PairingEcallBridge.lean` |
+| BLS12 MAP FP TO G1 `0x10` | `zkvm_bls12_map_fp_to_g1` | `bls12_map_fp_to_g1` / `0x110` | `EvmAsm/EL/Bls12MapFpToG1InputBridge.lean`, `EvmAsm/EL/Bls12MapFpToG1ResultBridge.lean` | `EvmAsm/EL/Bls12MapFpToG1EcallBridge.lean` |
+| BLS12 MAP FP2 TO G2 `0x11` | `zkvm_bls12_map_fp2_to_g2` | `bls12_map_fp2_to_g2` / `0x111` | `EvmAsm/EL/Bls12MapFp2ToG2InputBridge.lean`, `EvmAsm/EL/Bls12MapFp2ToG2ResultBridge.lean` | `EvmAsm/EL/Bls12MapFp2ToG2EcallBridge.lean` |
+| secp256r1 verify `0x100` | `zkvm_secp256r1_verify` | `secp256r1_verify` / `0x112` | `EvmAsm/EL/Secp256r1VerifyInputBridge.lean`, `EvmAsm/EL/Secp256r1VerifyResultBridge.lean` | `EvmAsm/EL/Secp256r1VerifyEcallBridge.lean` |
 
-Precompiles `0x01`–`0x11` and `0x100`:
-
-| Precompile | Address | C symbol |
-|------------|---------|----------|
-| ECRECOVER | `0x01` | `zkvm_secp256k1_ecrecover` |
-| SHA256 | `0x02` | `zkvm_sha256` |
-| RIPEMD160 | `0x03` | `zkvm_ripemd160` |
-| IDENTITY | `0x04` | (no accelerator — pure memcpy) |
-| MODEXP | `0x05` | `zkvm_modexp` |
-| BN254 G1 ADD | `0x06` | `zkvm_bn254_g1_add` |
-| BN254 G1 MUL | `0x07` | `zkvm_bn254_g1_mul` |
-| BN254 PAIRING | `0x08` | `zkvm_bn254_pairing` |
-| BLAKE2F | `0x09` | `zkvm_blake2f` |
-| KZG POINT EVAL | `0x0a` | `zkvm_kzg_point_eval` |
-| BLS12 G1 ADD | `0x0b` | `zkvm_bls12_g1_add` |
-| BLS12 G1 MSM | `0x0c` | `zkvm_bls12_g1_msm` |
-| BLS12 G2 ADD | `0x0d` | `zkvm_bls12_g2_add` |
-| BLS12 G2 MSM | `0x0e` | `zkvm_bls12_g2_msm` |
-| BLS12 PAIRING | `0x0f` | `zkvm_bls12_pairing` |
-| BLS12 MAP FP→G1 | `0x10` | `zkvm_bls12_map_fp_to_g1` |
-| BLS12 MAP FP2→G2 | `0x11` | `zkvm_bls12_map_fp2_to_g2` |
-| secp256r1 verify | `0x100` | `zkvm_secp256r1_verify` |
+The table is intentionally path-based: if a bridge module is renamed or split,
+this audit should be updated in the same PR so downstream readers can trace
+from the C symbol to the Lean payload and ECALL surface.
 
 ## Calling convention
 

--- a/docs/zkvm-accelerators-interface.md
+++ b/docs/zkvm-accelerators-interface.md
@@ -43,7 +43,7 @@ In short: function set + argument layout + status framing come from
 also uses; concrete syscall IDs are handler-side and tracked
 separately.
 
-## Coverage audit table
+## Coverage table
 
 The header declares 19 entry points. Each one is (or will be) bridged by
 a Lean payload type, a syscall-ID constant tying the ECALL handler to
@@ -81,7 +81,7 @@ Selector constants live in
 | secp256r1 verify `0x100` | `zkvm_secp256r1_verify` | `secp256r1_verify` / `0x112` | `EvmAsm/EL/Secp256r1VerifyInputBridge.lean`, `EvmAsm/EL/Secp256r1VerifyResultBridge.lean` | `EvmAsm/EL/Secp256r1VerifyEcallBridge.lean` |
 
 The table is intentionally path-based: if a bridge module is renamed or split,
-this audit should be updated in the same PR so downstream readers can trace
+this table should be updated in the same PR so downstream readers can trace
 from the C symbol to the Lean payload and ECALL surface.
 
 ## Calling convention


### PR DESCRIPTION
## Summary
- expand the zkvm_accelerators ADR coverage section into a per-symbol audit table
- list selector constants from Accelerators.SyscallIds for each accelerator
- map each C symbol to the current Lean payload bridge and ECALL/execution bridge modules

## Verification
- git diff --check
- scripts/check-file-size.sh --report

Note: this PR is intentionally not enqueued by me.