### PR TITLE
feat(accelerators): link coverage rows to dispatch

### DIFF
--- a/EvmAsm/Evm64/Accelerators/Coverage.lean
+++ b/EvmAsm/Evm64/Accelerators/Coverage.lean
@@ -115,6 +115,18 @@ theorem acceleratorCoverageSelectors_eq_dispatch :
   rw [acceleratorCoverageSelectors_eq]
   rfl
 
+/-- Every selector row in the coverage table is routed by accelerator dispatch. -/
+theorem acceleratorCoverageSelectors_are_accelerators :
+    ∀ id ∈ acceleratorCoverageSelectors, isAccelerator id := by
+  intro id h_id
+  rw [acceleratorCoverageSelectors_eq_dispatch] at h_id
+  exact h_id
+
+/-- Every coverage-table row has a selector recognised by accelerator dispatch. -/
+theorem acceleratorCoverageTable_selectors_are_accelerators :
+    ∀ row ∈ acceleratorCoverageTable, isAccelerator row.selector := by
+  decide
+
 /-- The coverage table does not assign the same selector twice. -/
 theorem acceleratorCoverageSelectors_nodup :
     acceleratorCoverageSelectors.Nodup := by


### PR DESCRIPTION
## Summary
- prove acceleratorCoverageSelectors is accepted by isAccelerator
- prove each acceleratorCoverageTable row has a selector recognized by dispatch
- keep the checked coverage table tied to the dispatch selector predicate

## Verification
- lake build EvmAsm.Evm64.Accelerators.Coverage
- lake build EvmAsm.Evm64
- scripts/check-file-size.sh --report

Stacked on #3253. I am not enqueueing this PR.