### PR TITLE
feat(divmod): divCode_noNop / modCode_noNop CodeReq abbrevs + 4 subsumptions

### DIFF
--- a/EvmAsm/Evm64/DivMod/Callable.lean
+++ b/EvmAsm/Evm64/DivMod/Callable.lean
@@ -522,4 +522,59 @@ theorem evm_mod_callable_code_block_subs (base : Word) :
    callable_b8_mod, callable_b9_mod, callable_b10_mod, callable_b11_mod,
    callable_b12_mod, callable_b13_mod⟩
 
+-- ============================================================================
+-- noNop ⊆ callable_code subsumptions
+--
+-- `divCode_noNop` (Compose/Base.lean) drops block 12 (the NOP at `nopOff`)
+-- from `divCode`. `evm_div_callable_code` *replaces* that NOP with `cc_ret`,
+-- but every other block is at the same offset. So every `divCode_noNop`
+-- block also occurs in `evm_div_callable_code`, and the per-block lemmas
+-- `callable_b*_div` (above) cover exactly the right blocks.
+-- ============================================================================
+
+/-- divCode_noNop ⊆ evm_div_callable_code: each block of divCode_noNop is
+    also in evm_div_callable_code. Used by evm-asm-ak8r1 (#90 prep-D) to
+    lift `evm_div_stack_spec` from divCode_noNop to evm_div_callable_code
+    via `cpsTripleWithin_extend_code`. -/
+theorem divCode_noNop_sub_div_callable_code {base : Word} :
+    ∀ a i, (divCode_noNop base) a = some i →
+           (evm_div_callable_code base) a = some i := by
+  unfold divCode_noNop; simp only [CodeReq.unionAll_cons]
+  exact CodeReq.union_split_mono callable_b0_div
+    (CodeReq.union_split_mono callable_b1_div
+    (CodeReq.union_split_mono callable_b2_div
+    (CodeReq.union_split_mono callable_b3_div
+    (CodeReq.union_split_mono callable_b4_div
+    (CodeReq.union_split_mono callable_b5_div
+    (CodeReq.union_split_mono callable_b6_div
+    (CodeReq.union_split_mono callable_b7_div
+    (CodeReq.union_split_mono callable_b8_div
+    (CodeReq.union_split_mono callable_b9_div
+    (CodeReq.union_split_mono callable_b10_div
+    (CodeReq.union_split_mono callable_b11_div
+    -- noNop block 12 (div128) maps to callable block 13.
+    (CodeReq.union_split_mono callable_b13_div
+    (fun _ _ h => by simp [CodeReq.unionAll_nil, CodeReq.empty] at h)))))))))))))
+
+/-- modCode_noNop ⊆ evm_mod_callable_code. Mirror of
+    `divCode_noNop_sub_div_callable_code` for the MOD epilogue. -/
+theorem modCode_noNop_sub_mod_callable_code {base : Word} :
+    ∀ a i, (modCode_noNop base) a = some i →
+           (evm_mod_callable_code base) a = some i := by
+  unfold modCode_noNop; simp only [CodeReq.unionAll_cons]
+  exact CodeReq.union_split_mono callable_b0_mod
+    (CodeReq.union_split_mono callable_b1_mod
+    (CodeReq.union_split_mono callable_b2_mod
+    (CodeReq.union_split_mono callable_b3_mod
+    (CodeReq.union_split_mono callable_b4_mod
+    (CodeReq.union_split_mono callable_b5_mod
+    (CodeReq.union_split_mono callable_b6_mod
+    (CodeReq.union_split_mono callable_b7_mod
+    (CodeReq.union_split_mono callable_b8_mod
+    (CodeReq.union_split_mono callable_b9_mod
+    (CodeReq.union_split_mono callable_b10_mod
+    (CodeReq.union_split_mono callable_b11_mod
+    (CodeReq.union_split_mono callable_b13_mod
+    (fun _ _ h => by simp [CodeReq.unionAll_nil, CodeReq.empty] at h)))))))))))))
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Base.lean
@@ -259,6 +259,191 @@ theorem shared_b12_div128_v4_sub {b : Word} :
   exact CodeReq.union_mono_left
 
 -- ============================================================================
+-- noNop variants: divCode / modCode minus block 12 (NOP at base + nopOff)
+--
+-- These 13-block CodeReq abbreviations are identical to `divCode` / `modCode`
+-- except they drop the `ADDI .x0 .x0 0` block at `base + nopOff` (block 12).
+--
+-- Motivation (evm-asm-ak8r1, GH #90 prep-D): the LP64-callable shims
+-- `evm_div_callable` / `evm_mod_callable` (Evm64/DivMod/Callable.lean) replace
+-- the NOP at the exit slot with `cc_ret`, leaving every other block at the
+-- same offset. So:
+--
+--   divCode_noNop ⊆ divCode               -- (NOP block dropped)
+--   divCode_noNop ⊆ evm_div_callable_code -- (NOP block dropped, same offsets)
+--   modCode_noNop ⊆ modCode
+--   modCode_noNop ⊆ evm_mod_callable_code
+--
+-- The first two are proved here; the callable_code subsumptions live in
+-- `DivMod/Callable.lean` next to the callable_code definitions.
+--
+-- Downstream use: refactor `evm_div_stack_spec` over `divCode_noNop` rather
+-- than `divCode`; then `cpsTripleWithin_extend_code` lifts to either
+-- `divCode` (existing wrappers) or `evm_div_callable_code` (new callable
+-- spec) in a single step.
+-- ============================================================================
+
+/-- 13-block CodeReq for `evm_div`'s phases minus the NOP at `nopOff`. -/
+abbrev divCode_noNop (base : Word) : CodeReq :=
+  CodeReq.unionAll [
+    CodeReq.ofProg  base                  (divK_phaseA 1020),     -- block 0
+    CodeReq.ofProg (base + phaseBOff)     divK_phaseB,            -- block 1
+    CodeReq.ofProg (base + clzOff)        divK_clz,               -- block 2
+    CodeReq.ofProg (base + phaseC2Off)    (divK_phaseC2 172),     -- block 3
+    CodeReq.ofProg (base + normBOff)      divK_normB,             -- block 4
+    CodeReq.ofProg (base + normAOff)      (divK_normA 40),        -- block 5
+    CodeReq.ofProg (base + copyAUOff)     divK_copyAU,            -- block 6
+    CodeReq.ofProg (base + loopSetupOff)  (divK_loopSetup 464),   -- block 7
+    CodeReq.ofProg (base + loopBodyOff)   (divK_loopBody 560 7736),-- block 8
+    CodeReq.ofProg (base + denormOff)     divK_denorm,            -- block 9
+    CodeReq.ofProg (base + epilogueOff)   (divK_div_epilogue 24), -- block 10
+    CodeReq.ofProg (base + zeroPathOff)   divK_zeroPath,          -- block 11
+    -- NO NOP block (block 12 omitted)
+    CodeReq.ofProg (base + div128Off)     divK_div128             -- block 12 (was 13)
+  ]
+
+/-- 13-block CodeReq for `evm_mod`'s phases minus the NOP at `nopOff`.
+    Identical to `divCode_noNop` except block 10 uses `divK_mod_epilogue`. -/
+abbrev modCode_noNop (base : Word) : CodeReq :=
+  CodeReq.unionAll [
+    CodeReq.ofProg  base                  (divK_phaseA 1020),
+    CodeReq.ofProg (base + phaseBOff)     divK_phaseB,
+    CodeReq.ofProg (base + clzOff)        divK_clz,
+    CodeReq.ofProg (base + phaseC2Off)    (divK_phaseC2 172),
+    CodeReq.ofProg (base + normBOff)      divK_normB,
+    CodeReq.ofProg (base + normAOff)      (divK_normA 40),
+    CodeReq.ofProg (base + copyAUOff)     divK_copyAU,
+    CodeReq.ofProg (base + loopSetupOff)  (divK_loopSetup 464),
+    CodeReq.ofProg (base + loopBodyOff)   (divK_loopBody 560 7736),
+    CodeReq.ofProg (base + denormOff)     divK_denorm,
+    CodeReq.ofProg (base + epilogueOff)   (divK_mod_epilogue 24), -- block 10 differs
+    CodeReq.ofProg (base + zeroPathOff)   divK_zeroPath,
+    CodeReq.ofProg (base + div128Off)     divK_div128
+  ]
+
+-- Per-block subsumption: each noNop block ⊆ divCode. Blocks 0-11 sit at the
+-- same union positions in both; the trailing div128 block is at position 12
+-- in noNop but position 13 in divCode (one extra skipBlock to bypass NOP).
+private theorem noNop_b0_div {b : Word} :
+    ∀ a i, (CodeReq.ofProg b (divK_phaseA 1020)) a = some i → (divCode b) a = some i := by
+  unfold divCode; simp only [CodeReq.unionAll_cons]; exact CodeReq.union_mono_left
+private theorem noNop_b1_div {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + phaseBOff) divK_phaseB) a = some i → (divCode b) a = some i := by
+  unfold divCode; simp only [CodeReq.unionAll_cons]; skipBlock; exact CodeReq.union_mono_left
+private theorem noNop_b2_div {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + clzOff) divK_clz) a = some i → (divCode b) a = some i := by
+  unfold divCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; exact CodeReq.union_mono_left
+private theorem noNop_b3_div {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + phaseC2Off) (divK_phaseC2 172)) a = some i → (divCode b) a = some i := by
+  unfold divCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
+private theorem noNop_b4_div {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + normBOff) divK_normB) a = some i → (divCode b) a = some i := by
+  unfold divCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
+private theorem noNop_b5_div {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + normAOff) (divK_normA 40)) a = some i → (divCode b) a = some i := by
+  unfold divCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
+private theorem noNop_b6_div {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + copyAUOff) divK_copyAU) a = some i → (divCode b) a = some i := by
+  unfold divCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
+private theorem noNop_b7_div {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + loopSetupOff) (divK_loopSetup 464)) a = some i → (divCode b) a = some i := by
+  unfold divCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
+private theorem noNop_b8_div {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + loopBodyOff) (divK_loopBody 560 7736)) a = some i → (divCode b) a = some i := by
+  unfold divCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
+private theorem noNop_b9_div {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + denormOff) divK_denorm) a = some i → (divCode b) a = some i := by
+  unfold divCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
+private theorem noNop_b10_div {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + epilogueOff) (divK_div_epilogue 24)) a = some i → (divCode b) a = some i := by
+  unfold divCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
+private theorem noNop_b11_div {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + zeroPathOff) divK_zeroPath) a = some i → (divCode b) a = some i := by
+  unfold divCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
+private theorem noNop_b12_div {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + div128Off) divK_div128) a = some i → (divCode b) a = some i := by
+  unfold divCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
+
+/-- divCode_noNop ⊆ divCode: every noNop block also occurs in divCode. -/
+theorem divCode_noNop_sub_divCode {base : Word} :
+    ∀ a i, (divCode_noNop base) a = some i → (divCode base) a = some i := by
+  unfold divCode_noNop; simp only [CodeReq.unionAll_cons]
+  exact CodeReq.union_split_mono noNop_b0_div
+    (CodeReq.union_split_mono noNop_b1_div
+    (CodeReq.union_split_mono noNop_b2_div
+    (CodeReq.union_split_mono noNop_b3_div
+    (CodeReq.union_split_mono noNop_b4_div
+    (CodeReq.union_split_mono noNop_b5_div
+    (CodeReq.union_split_mono noNop_b6_div
+    (CodeReq.union_split_mono noNop_b7_div
+    (CodeReq.union_split_mono noNop_b8_div
+    (CodeReq.union_split_mono noNop_b9_div
+    (CodeReq.union_split_mono noNop_b10_div
+    (CodeReq.union_split_mono noNop_b11_div
+    (CodeReq.union_split_mono noNop_b12_div
+    (fun _ _ h => by simp [CodeReq.unionAll_nil, CodeReq.empty] at h)))))))))))))
+
+-- MOD side mirror.
+private theorem noNop_b0_mod {b : Word} :
+    ∀ a i, (CodeReq.ofProg b (divK_phaseA 1020)) a = some i → (modCode b) a = some i := by
+  unfold modCode; simp only [CodeReq.unionAll_cons]; exact CodeReq.union_mono_left
+private theorem noNop_b1_mod {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + phaseBOff) divK_phaseB) a = some i → (modCode b) a = some i := by
+  unfold modCode; simp only [CodeReq.unionAll_cons]; skipBlock; exact CodeReq.union_mono_left
+private theorem noNop_b2_mod {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + clzOff) divK_clz) a = some i → (modCode b) a = some i := by
+  unfold modCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; exact CodeReq.union_mono_left
+private theorem noNop_b3_mod {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + phaseC2Off) (divK_phaseC2 172)) a = some i → (modCode b) a = some i := by
+  unfold modCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
+private theorem noNop_b4_mod {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + normBOff) divK_normB) a = some i → (modCode b) a = some i := by
+  unfold modCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
+private theorem noNop_b5_mod {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + normAOff) (divK_normA 40)) a = some i → (modCode b) a = some i := by
+  unfold modCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
+private theorem noNop_b6_mod {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + copyAUOff) divK_copyAU) a = some i → (modCode b) a = some i := by
+  unfold modCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
+private theorem noNop_b7_mod {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + loopSetupOff) (divK_loopSetup 464)) a = some i → (modCode b) a = some i := by
+  unfold modCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
+private theorem noNop_b8_mod {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + loopBodyOff) (divK_loopBody 560 7736)) a = some i → (modCode b) a = some i := by
+  unfold modCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
+private theorem noNop_b9_mod {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + denormOff) divK_denorm) a = some i → (modCode b) a = some i := by
+  unfold modCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
+private theorem noNop_b10_mod {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + epilogueOff) (divK_mod_epilogue 24)) a = some i → (modCode b) a = some i := by
+  unfold modCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
+private theorem noNop_b11_mod {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + zeroPathOff) divK_zeroPath) a = some i → (modCode b) a = some i := by
+  unfold modCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
+private theorem noNop_b12_mod {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + div128Off) divK_div128) a = some i → (modCode b) a = some i := by
+  unfold modCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
+
+/-- modCode_noNop ⊆ modCode: every noNop block also occurs in modCode. -/
+theorem modCode_noNop_sub_modCode {base : Word} :
+    ∀ a i, (modCode_noNop base) a = some i → (modCode base) a = some i := by
+  unfold modCode_noNop; simp only [CodeReq.unionAll_cons]
+  exact CodeReq.union_split_mono noNop_b0_mod
+    (CodeReq.union_split_mono noNop_b1_mod
+    (CodeReq.union_split_mono noNop_b2_mod
+    (CodeReq.union_split_mono noNop_b3_mod
+    (CodeReq.union_split_mono noNop_b4_mod
+    (CodeReq.union_split_mono noNop_b5_mod
+    (CodeReq.union_split_mono noNop_b6_mod
+    (CodeReq.union_split_mono noNop_b7_mod
+    (CodeReq.union_split_mono noNop_b8_mod
+    (CodeReq.union_split_mono noNop_b9_mod
+    (CodeReq.union_split_mono noNop_b10_mod
+    (CodeReq.union_split_mono noNop_b11_mod
+    (CodeReq.union_split_mono noNop_b12_mod
+    (fun _ _ h => by simp [CodeReq.unionAll_nil, CodeReq.empty] at h)))))))))))))
+
+-- ============================================================================
 -- Postcondition bundle for loopSetup (shift ≠ 0) path
 -- Encapsulates 11 let bindings (shift normalization of b[] and a[]) plus
 -- the full 30-atom assertion chain into a single opaque Assertion.


### PR DESCRIPTION
Sub-slice of `evm-asm-19wm2` / parent `evm-asm-ak8r1` (GH #90 prep-D `evm_{div,mod}_callable_spec_within`).

Introduces 13-block CodeReq abbrevs that drop the NOP at `base + nopOff` (block 12) from `divCode` / `modCode`, plus four subsumption lemmas:

- `divCode_noNop ⊆ divCode`
- `modCode_noNop ⊆ modCode`
- `divCode_noNop ⊆ evm_div_callable_code`
- `modCode_noNop ⊆ evm_mod_callable_code`

**Motivation.** The LP64-callable shims `evm_div_callable` / `evm_mod_callable` replace the NOP at the exit slot with `cc_ret`, leaving every other block at the same offset. `divCode` is NOT a sub-CodeReq of `evm_div_callable_code` (block 12 differs), so `cpsTripleWithin_extend_code` cannot lift `evm_div_stack_spec` directly. With these subsumptions, downstream slices can refactor `evm_div_stack_spec` over `divCode_noNop` and then lift to either `divCode` (existing wrappers) or `evm_div_callable_code` (callable spec) in a single `extend_code` step.

No semantic changes to existing specs.

Refs GH #90; beads `evm-asm-19wm2` (this slice) under parent `evm-asm-ak8r1`.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).