### PR TITLE
fix(exp): decompose conditional multiply call block

### DIFF
--- a/EvmAsm/Evm64/Exp.lean
+++ b/EvmAsm/Evm64/Exp.lean
@@ -17,6 +17,7 @@ import EvmAsm.Evm64.Exp.Args
 import EvmAsm.Evm64.Exp.ArgsStackDecode
 import EvmAsm.Evm64.Exp.LimbSpec
 import EvmAsm.Evm64.Exp.SquaringCall
+import EvmAsm.Evm64.Exp.CondMulCall
 import EvmAsm.Evm64.Exp.AddrNorm
 import EvmAsm.Evm64.Exp.Compose.Base
 import EvmAsm.Evm64.Exp.Layout

--- a/EvmAsm/Evm64/Exp/CondMulCall.lean
+++ b/EvmAsm/Evm64/Exp/CondMulCall.lean
@@ -1,0 +1,135 @@
+/-
+  EvmAsm.Evm64.Exp.CondMulCall
+
+  CodeReq decomposition for the conditional-multiply taken-branch call block.
+  This mirrors `Exp/SquaringCall.lean`, but the second marshal block sources
+  the fixed base `a` into MUL factor2 instead of copying the running result.
+
+  Refs: GH #92, beads `evm-asm-b4asy`.
+-/
+
+import EvmAsm.Evm64.Exp.SquaringCall
+import EvmAsm.Evm64.Multiply.Callable
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- 4-block `unionAll` decomposition of `exp_cond_mul_call_block mulOff`.
+    The block layout is:
+
+    * offset 0:  marshal running result into MUL factor1
+    * offset 32: marshal fixed base `a` into MUL factor2
+    * offset 64: JAL to `mul_callable`
+    * offset 68: unmarshal MUL output and restore `x12`
+-/
+abbrev exp_cond_mul_call_block_code (base : Word) (mulOff : BitVec 21) : CodeReq :=
+  CodeReq.unionAll [
+    CodeReq.ofProg base                exp_loop_marshal_factor1,
+    CodeReq.ofProg (base + 32)         exp_loop_marshal_a_to_factor2,
+    CodeReq.ofProg (base + 64)         (exp_square_block mulOff),
+    CodeReq.ofProg (base + 68)         exp_loop_un_marshal_and_restore
+  ]
+
+theorem exp_cond_mul_call_block_code_eq_ofProg (base : Word) (mulOff : BitVec 21) :
+    exp_cond_mul_call_block_code base mulOff =
+      CodeReq.ofProg base (exp_cond_mul_call_block mulOff) := by
+  unfold exp_cond_mul_call_block_code exp_cond_mul_call_block
+  simp only [CodeReq.unionAll_cons, CodeReq.unionAll_nil,
+    CodeReq.union_empty_right]
+  unfold seq
+  unfold Program
+  symm
+  rw [CodeReq.ofProg_append]
+  rw [show base + BitVec.ofNat 64 (4 * exp_loop_marshal_factor1.length) =
+        base + 32 by rw [exp_loop_marshal_factor1_length]; rfl]
+  rw [CodeReq.ofProg_append]
+  rw [show (base + 32) +
+        BitVec.ofNat 64 (4 * exp_loop_marshal_a_to_factor2.length) =
+        base + 64 by
+    rw [exp_loop_marshal_a_to_factor2_length]; bv_omega]
+  rw [CodeReq.ofProg_append]
+  rw [show (base + 64) + BitVec.ofNat 64 (4 * (exp_square_block mulOff).length) =
+        base + 68 by
+    rw [exp_square_block_length]; bv_omega]
+
+theorem exp_cond_mul_call_block_code_marshal_factor1_sub
+    (base : Word) (mulOff : BitVec 21) :
+    ∀ a i, (CodeReq.ofProg base exp_loop_marshal_factor1) a = some i →
+      (exp_cond_mul_call_block_code base mulOff) a = some i := by
+  unfold exp_cond_mul_call_block_code
+  simp only [CodeReq.unionAll_cons]
+  exact CodeReq.union_mono_left
+
+theorem exp_cond_mul_call_block_code_marshal_a_to_factor2_sub
+    (base : Word) (mulOff : BitVec 21) :
+    ∀ a i, (CodeReq.ofProg (base + 32)
+      exp_loop_marshal_a_to_factor2) a = some i →
+      (exp_cond_mul_call_block_code base mulOff) a = some i := by
+  unfold exp_cond_mul_call_block_code
+  simp only [CodeReq.unionAll_cons]
+  apply CodeReq.mono_union_right
+    (CodeReq.ofProg_disjoint_range (fun k1 k2 hk1 hk2 => by
+      simp only [exp_loop_marshal_factor1_length,
+        exp_loop_marshal_a_to_factor2_length] at hk1 hk2
+      bv_omega))
+  exact CodeReq.union_mono_left
+
+theorem exp_cond_mul_call_block_code_square_sub
+    (base : Word) (mulOff : BitVec 21) :
+    ∀ a i, (CodeReq.ofProg (base + 64) (exp_square_block mulOff)) a = some i →
+      (exp_cond_mul_call_block_code base mulOff) a = some i := by
+  unfold exp_cond_mul_call_block_code
+  simp only [CodeReq.unionAll_cons]
+  apply CodeReq.mono_union_right
+    (CodeReq.ofProg_disjoint_range (fun k1 k2 hk1 hk2 => by
+      simp only [exp_loop_marshal_factor1_length,
+        exp_square_block_length] at hk1 hk2
+      bv_omega))
+  apply CodeReq.mono_union_right
+    (CodeReq.ofProg_disjoint_range (fun k1 k2 hk1 hk2 => by
+      simp only [exp_loop_marshal_a_to_factor2_length,
+        exp_square_block_length] at hk1 hk2
+      bv_omega))
+  exact CodeReq.union_mono_left
+
+theorem exp_cond_mul_call_block_code_un_marshal_and_restore_sub
+    (base : Word) (mulOff : BitVec 21) :
+    ∀ a i, (CodeReq.ofProg (base + 68) exp_loop_un_marshal_and_restore) a = some i →
+      (exp_cond_mul_call_block_code base mulOff) a = some i := by
+  unfold exp_cond_mul_call_block_code
+  simp only [CodeReq.unionAll_cons]
+  apply CodeReq.mono_union_right
+    (CodeReq.ofProg_disjoint_range (fun k1 k2 hk1 hk2 => by
+      simp only [exp_loop_marshal_factor1_length,
+        exp_loop_un_marshal_and_restore_length] at hk1 hk2
+      bv_omega))
+  apply CodeReq.mono_union_right
+    (CodeReq.ofProg_disjoint_range (fun k1 k2 hk1 hk2 => by
+      simp only [exp_loop_marshal_a_to_factor2_length,
+        exp_loop_un_marshal_and_restore_length] at hk1 hk2
+      bv_omega))
+  apply CodeReq.mono_union_right
+    (CodeReq.ofProg_disjoint_range (fun k1 k2 hk1 hk2 => by
+      simp only [exp_square_block_length,
+        exp_loop_un_marshal_and_restore_length] at hk1 hk2
+      bv_omega))
+  exact CodeReq.union_mono_left
+
+theorem exp_cond_mul_call_block_code_block_subs
+    (base : Word) (mulOff : BitVec 21) :
+    (∀ a i, (CodeReq.ofProg base exp_loop_marshal_factor1) a = some i →
+      (exp_cond_mul_call_block_code base mulOff) a = some i) ∧
+    (∀ a i, (CodeReq.ofProg (base + 32)
+      exp_loop_marshal_a_to_factor2) a = some i →
+      (exp_cond_mul_call_block_code base mulOff) a = some i) ∧
+    (∀ a i, (CodeReq.ofProg (base + 64) (exp_square_block mulOff)) a = some i →
+      (exp_cond_mul_call_block_code base mulOff) a = some i) ∧
+    (∀ a i, (CodeReq.ofProg (base + 68) exp_loop_un_marshal_and_restore) a = some i →
+      (exp_cond_mul_call_block_code base mulOff) a = some i) := by
+  exact ⟨exp_cond_mul_call_block_code_marshal_factor1_sub base mulOff,
+    exp_cond_mul_call_block_code_marshal_a_to_factor2_sub base mulOff,
+    exp_cond_mul_call_block_code_square_sub base mulOff,
+    exp_cond_mul_call_block_code_un_marshal_and_restore_sub base mulOff⟩
+
+end EvmAsm.Evm64


### PR DESCRIPTION
Refs #92.

Beads: evm-asm-b4asy

## Summary
- add Exp/CondMulCall.lean with exp_cond_mul_call_block_code
- prove the CodeReq.ofProg bridge for exp_cond_mul_call_block
- prove per-sub-block inclusion lemmas for factor1 marshal, base-to-factor2 marshal, JAL, and unmarshal/restore

## Note
This is the code-decomposition prerequisite for the full exp_cond_mul_call_block_spec_within composition over mul_callable.

## Verification
- lake build EvmAsm.Evm64.Exp.CondMulCall
- lake build