### PR TITLE
feat(evmword): add evmWordIs_fromLimbs generic shape lemma

### DIFF
--- a/EvmAsm/Evm64/Basic.lean
+++ b/EvmAsm/Evm64/Basic.lean
@@ -591,6 +591,24 @@ theorem getLimbN_fromLimbs_const_3 {w : Word} :
     (fromLimbs (fun _ => w)).getLimbN 3 = w := by
   rw [getLimbN_fromLimbs_const, if_pos (by decide)]
 
+/-- Generic `k`-specialized `getLimbN` of `fromLimbs` for an arbitrary
+    `limbs : Fin 4 → Word`. Generalizes `getLimbN_fromLimbs_const_k` to
+    non-constant limb functions; complements
+    `EvmAsm.Evm64.EvmWordArith.DivLimbBridge.getLimbN_fromLimbs_k` which
+    bakes a `match`-on-`Fin 4` shape into the limb function. -/
+theorem getLimbN_fromLimbs_gen_0 {limbs : Fin 4 → Word} :
+    (fromLimbs limbs).getLimbN 0 = limbs 0 := by
+  rw [getLimbN_lt _ _ (by decide), getLimb_fromLimbs]; rfl
+theorem getLimbN_fromLimbs_gen_1 {limbs : Fin 4 → Word} :
+    (fromLimbs limbs).getLimbN 1 = limbs 1 := by
+  rw [getLimbN_lt _ _ (by decide), getLimb_fromLimbs]; rfl
+theorem getLimbN_fromLimbs_gen_2 {limbs : Fin 4 → Word} :
+    (fromLimbs limbs).getLimbN 2 = limbs 2 := by
+  rw [getLimbN_lt _ _ (by decide), getLimb_fromLimbs]; rfl
+theorem getLimbN_fromLimbs_gen_3 {limbs : Fin 4 → Word} :
+    (fromLimbs limbs).getLimbN 3 = limbs 3 := by
+  rw [getLimbN_lt _ _ (by decide), getLimb_fromLimbs]; rfl
+
 end EvmWord
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Stack.lean
+++ b/EvmAsm/Evm64/Stack.lean
@@ -413,6 +413,32 @@ theorem evmWordIs_fromLimbs_const {addr : Word} (w : Word) :
   rw [EvmWord.getLimbN_fromLimbs_const_0, EvmWord.getLimbN_fromLimbs_const_1,
       EvmWord.getLimbN_fromLimbs_const_2, EvmWord.getLimbN_fromLimbs_const_3]
 
+/-- Generalization of `evmWordIs_fromLimbs_const` to a non-constant
+    `limbs : Fin 4 → Word`: unfolds `evmWordIs addr (fromLimbs limbs)`
+    into four `↦ₘ`-atoms holding `limbs 0..3`. Used by callers that
+    have already bridged each limb's value through `getLimbN_fromLimbs_gen_k`
+    and want to fold the four memIs atoms back into a single
+    `evmWordIs addr (fromLimbs limbs)`. -/
+theorem evmWordIs_fromLimbs {addr : Word} (limbs : Fin 4 → Word) :
+    evmWordIs addr (EvmWord.fromLimbs limbs) =
+    ((addr ↦ₘ limbs 0) ** ((addr + 8) ↦ₘ limbs 1) **
+     ((addr + 16) ↦ₘ limbs 2) ** ((addr + 24) ↦ₘ limbs 3)) := by
+  unfold evmWordIs
+  rw [EvmWord.getLimbN_fromLimbs_gen_0, EvmWord.getLimbN_fromLimbs_gen_1,
+      EvmWord.getLimbN_fromLimbs_gen_2, EvmWord.getLimbN_fromLimbs_gen_3]
+
+/-- Mid-tree variant of `evmWordIs_fromLimbs`: threads a remainder `Q`
+    so `rw ←` can fold four limb memIs atoms back into
+    `evmWordIs addr (fromLimbs limbs)` even when they sit in the
+    middle of a longer sepConj chain. -/
+theorem evmWordIs_fromLimbs_right {addr : Word} (limbs : Fin 4 → Word)
+    (Q : Assertion) :
+    ((addr ↦ₘ limbs 0) ** ((addr + 8) ↦ₘ limbs 1) **
+     ((addr + 16) ↦ₘ limbs 2) ** ((addr + 24) ↦ₘ limbs 3) ** Q) =
+    (evmWordIs addr (EvmWord.fromLimbs limbs) ** Q) := by
+  rw [evmWordIs_fromLimbs]
+  rw [sepConj_assoc', sepConj_assoc', sepConj_assoc']
+
 /-- Mid-tree variant of `evmWordIs_fromLimbs_const`: threads a remainder
     `Q` so `rw ←` can fold four identical-valued memIs atoms back into
     `evmWordIs addr (fromLimbs (fun _ => w))` even when they sit in the


### PR DESCRIPTION
Add `EvmWord.getLimbN_fromLimbs_gen_{0,1,2,3}` for arbitrary `limbs : Fin 4 → Word`, generalizing `getLimbN_fromLimbs_const_k`. Use them to prove `evmWordIs_fromLimbs` (and a mid-tree `_right` variant) in `Evm64.Stack`: unfolds `evmWordIs addr (fromLimbs limbs)` into the four `↦ₘ`-atoms holding `limbs 0..3`, with a remainder-threading variant for folding via `rw ←` in the middle of a sepConj chain.

Prereq for evm-asm-nrfpf (#92 slice 4 squaring-call spec): callers folding individual `↦ₘ` assertions back into `evmWordIs` in EXP loop iteration postconditions need a non-constant, non-match-on-Fin-shape variant of `getLimbN_fromLimbs`. The existing `getLimbN_fromLimbs_k` in `EvmWordArith.DivLimbBridge` bakes a match on `Fin 4` into the limb function and is awkward when the limb function is a generic `Fin 4 → Word`.

Refs GH #92, beads `evm-asm-q145r`.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).