### PR TITLE
feat(call): add kind-indexed stack decoder

### DIFF
--- a/EvmAsm/Evm64/CallArgsStackDecode.lean
+++ b/EvmAsm/Evm64/CallArgsStackDecode.lean
@@ -12,6 +12,55 @@ namespace CallArgsStackDecode
 
 open CallArgs
 
+inductive Decoded where
+  | call (args : Call)
+  | staticcall (args : StaticCall)
+  | delegatecall (args : DelegateCall)
+  deriving Repr
+
+def mkCall
+    (gas to value inputOffset inputSize outputOffset outputSize : EvmWord) :
+    Call :=
+  { gas := gas
+    to := to
+    value := value
+    input := { offset := inputOffset, size := inputSize }
+    output := { offset := outputOffset, size := outputSize } }
+
+def mkStaticCall
+    (gas to inputOffset inputSize outputOffset outputSize : EvmWord) :
+    StaticCall :=
+  { gas := gas
+    to := to
+    input := { offset := inputOffset, size := inputSize }
+    output := { offset := outputOffset, size := outputSize } }
+
+def mkDelegateCall
+    (gas to inputOffset inputSize outputOffset outputSize : EvmWord) :
+    DelegateCall :=
+  { gas := gas
+    to := to
+    input := { offset := inputOffset, size := inputSize }
+    output := { offset := outputOffset, size := outputSize } }
+
+def decodedKind : Decoded → Kind
+  | .call _ => .call
+  | .staticcall _ => .staticcall
+  | .delegatecall _ => .delegatecall
+
+def decodedInput : Decoded → MemoryRange
+  | .call args => args.input
+  | .staticcall args => args.input
+  | .delegatecall args => args.input
+
+def decodedOutput : Decoded → MemoryRange
+  | .call args => args.output
+  | .staticcall args => args.output
+  | .delegatecall args => args.output
+
+def decodedArgumentCount (decoded : Decoded) : Nat :=
+  argumentCount (decodedKind decoded)
+
 /--
 Decode CALL stack arguments from the top-of-stack list order:
 `gas, to, value, input_offset, input_size, output_offset, output_size`.
@@ -49,11 +98,27 @@ Decode DELEGATECALL stack arguments from the top-of-stack list order:
 def decodeDelegateCallStack? : List EvmWord → Option DelegateCall
   | gas :: to :: inputOffset :: inputSize :: outputOffset :: outputSize :: _ =>
       some
-        { gas := gas
-          to := to
-          input := { offset := inputOffset, size := inputSize }
-          output := { offset := outputOffset, size := outputSize } }
+        (mkDelegateCall gas to inputOffset inputSize outputOffset outputSize)
   | _ => none
+
+/--
+Decode CALL-family stack arguments by opcode kind.
+
+Distinctive token: CallArgsStackDecode.decodeCallFamilyStack? #114.
+-/
+def decodeCallFamilyStack? : Kind → List EvmWord → Option Decoded
+  | .call, gas :: to :: value :: inputOffset :: inputSize :: outputOffset ::
+      outputSize :: _ =>
+      some (.call (mkCall gas to value inputOffset inputSize outputOffset outputSize))
+  | .staticcall, gas :: to :: inputOffset :: inputSize :: outputOffset ::
+      outputSize :: _ =>
+      some (.staticcall
+        (mkStaticCall gas to inputOffset inputSize outputOffset outputSize))
+  | .delegatecall, gas :: to :: inputOffset :: inputSize :: outputOffset ::
+      outputSize :: _ =>
+      some (.delegatecall
+        (mkDelegateCall gas to inputOffset inputSize outputOffset outputSize))
+  | _, _ => none
 
 theorem decodeCallStack?_cons
     (gas to value inputOffset inputSize outputOffset outputSize : EvmWord)
@@ -91,6 +156,33 @@ theorem decodeDelegateCallStack?_cons
           to := to
           input := { offset := inputOffset, size := inputSize }
           output := { offset := outputOffset, size := outputSize } } := rfl
+
+theorem decodeCallFamilyStack?_call
+    (gas to value inputOffset inputSize outputOffset outputSize : EvmWord)
+    (rest : List EvmWord) :
+    decodeCallFamilyStack? .call
+      (gas :: to :: value :: inputOffset :: inputSize :: outputOffset ::
+        outputSize :: rest) =
+      some (.call
+        (mkCall gas to value inputOffset inputSize outputOffset outputSize)) := rfl
+
+theorem decodeCallFamilyStack?_staticcall
+    (gas to inputOffset inputSize outputOffset outputSize : EvmWord)
+    (rest : List EvmWord) :
+    decodeCallFamilyStack? .staticcall
+      (gas :: to :: inputOffset :: inputSize :: outputOffset ::
+        outputSize :: rest) =
+      some (.staticcall
+        (mkStaticCall gas to inputOffset inputSize outputOffset outputSize)) := rfl
+
+theorem decodeCallFamilyStack?_delegatecall
+    (gas to inputOffset inputSize outputOffset outputSize : EvmWord)
+    (rest : List EvmWord) :
+    decodeCallFamilyStack? .delegatecall
+      (gas :: to :: inputOffset :: inputSize :: outputOffset ::
+        outputSize :: rest) =
+      some (.delegatecall
+        (mkDelegateCall gas to inputOffset inputSize outputOffset outputSize)) := rfl
 
 theorem decodeCallStack?_eq_some_iff {stack : List EvmWord} {args : Call} :
     decodeCallStack? stack = some args ↔
@@ -215,6 +307,108 @@ theorem decodeDelegateCallStack?_eq_some_iff
       rfl, rfl⟩
     rfl
 
+theorem decodeCallFamilyStack?_call_eq_some_iff
+    (stack : List EvmWord) (decoded : Decoded) :
+    decodeCallFamilyStack? .call stack = some decoded ↔
+      ∃ gas to value inputOffset inputSize outputOffset outputSize rest,
+        stack =
+          gas :: to :: value :: inputOffset :: inputSize :: outputOffset ::
+            outputSize :: rest ∧
+        decoded =
+          .call
+            (mkCall gas to value inputOffset inputSize outputOffset outputSize) := by
+  constructor
+  · intro h_decode
+    rcases stack with
+      _ | ⟨gas, _ | ⟨to, _ | ⟨value, _ | ⟨inputOffset,
+        _ | ⟨inputSize, _ | ⟨outputOffset, _ | ⟨outputSize, rest⟩⟩⟩⟩⟩⟩⟩ <;>
+      simp [decodeCallFamilyStack?] at h_decode
+    cases h_decode
+    exact ⟨gas, to, value, inputOffset, inputSize, outputOffset,
+      outputSize, rest, rfl, rfl⟩
+  · rintro ⟨gas, to, value, inputOffset, inputSize, outputOffset, outputSize,
+      rest, rfl, rfl⟩
+    rfl
+
+theorem decodeCallFamilyStack?_staticcall_eq_some_iff
+    (stack : List EvmWord) (decoded : Decoded) :
+    decodeCallFamilyStack? .staticcall stack = some decoded ↔
+      ∃ gas to inputOffset inputSize outputOffset outputSize rest,
+        stack =
+          gas :: to :: inputOffset :: inputSize :: outputOffset ::
+            outputSize :: rest ∧
+        decoded =
+          .staticcall
+            (mkStaticCall gas to inputOffset inputSize outputOffset outputSize) := by
+  constructor
+  · intro h_decode
+    rcases stack with
+      _ | ⟨gas, _ | ⟨to, _ | ⟨inputOffset,
+        _ | ⟨inputSize, _ | ⟨outputOffset, _ | ⟨outputSize, rest⟩⟩⟩⟩⟩⟩ <;>
+      simp [decodeCallFamilyStack?] at h_decode
+    cases h_decode
+    exact ⟨gas, to, inputOffset, inputSize, outputOffset, outputSize,
+      rest, rfl, rfl⟩
+  · rintro ⟨gas, to, inputOffset, inputSize, outputOffset, outputSize, rest,
+      rfl, rfl⟩
+    rfl
+
+theorem decodeCallFamilyStack?_delegatecall_eq_some_iff
+    (stack : List EvmWord) (decoded : Decoded) :
+    decodeCallFamilyStack? .delegatecall stack = some decoded ↔
+      ∃ gas to inputOffset inputSize outputOffset outputSize rest,
+        stack =
+          gas :: to :: inputOffset :: inputSize :: outputOffset ::
+            outputSize :: rest ∧
+        decoded =
+          .delegatecall
+            (mkDelegateCall gas to inputOffset inputSize outputOffset outputSize) := by
+  constructor
+  · intro h_decode
+    rcases stack with
+      _ | ⟨gas, _ | ⟨to, _ | ⟨inputOffset,
+        _ | ⟨inputSize, _ | ⟨outputOffset, _ | ⟨outputSize, rest⟩⟩⟩⟩⟩⟩ <;>
+      simp [decodeCallFamilyStack?] at h_decode
+    cases h_decode
+    exact ⟨gas, to, inputOffset, inputSize, outputOffset, outputSize,
+      rest, rfl, rfl⟩
+  · rintro ⟨gas, to, inputOffset, inputSize, outputOffset, outputSize, rest,
+      rfl, rfl⟩
+    rfl
+
+theorem decodeCallFamilyStack?_eq_some_iff
+    (kind : Kind) (stack : List EvmWord) (decoded : Decoded) :
+    decodeCallFamilyStack? kind stack = some decoded ↔
+      match kind with
+      | .call =>
+          ∃ gas to value inputOffset inputSize outputOffset outputSize rest,
+            stack =
+              gas :: to :: value :: inputOffset :: inputSize :: outputOffset ::
+                outputSize :: rest ∧
+            decoded =
+              .call
+                (mkCall gas to value inputOffset inputSize outputOffset outputSize)
+      | .staticcall =>
+          ∃ gas to inputOffset inputSize outputOffset outputSize rest,
+            stack =
+              gas :: to :: inputOffset :: inputSize :: outputOffset ::
+                outputSize :: rest ∧
+            decoded =
+              .staticcall
+                (mkStaticCall gas to inputOffset inputSize outputOffset outputSize)
+      | .delegatecall =>
+          ∃ gas to inputOffset inputSize outputOffset outputSize rest,
+            stack =
+              gas :: to :: inputOffset :: inputSize :: outputOffset ::
+                outputSize :: rest ∧
+            decoded =
+              .delegatecall
+                (mkDelegateCall gas to inputOffset inputSize outputOffset outputSize) := by
+  cases kind with
+  | call => exact decodeCallFamilyStack?_call_eq_some_iff stack decoded
+  | staticcall => exact decodeCallFamilyStack?_staticcall_eq_some_iff stack decoded
+  | delegatecall => exact decodeCallFamilyStack?_delegatecall_eq_some_iff stack decoded
+
 theorem decodeCallStack?_eq_none_iff (stack : List EvmWord) :
     decodeCallStack? stack = none ↔ stack.length < 7 := by
   constructor
@@ -292,6 +486,92 @@ theorem decodeDelegateCallStack?_eq_none_iff (stack : List EvmWord) :
     · simp at h_len
       omega
 
+theorem decodeCallFamilyStack?_call_eq_none_iff (stack : List EvmWord) :
+    decodeCallFamilyStack? .call stack = none ↔ stack.length < argumentCount .call := by
+  constructor
+  · intro h_decode
+    rcases stack with
+      _ | ⟨_, _ | ⟨_, _ | ⟨_, _ | ⟨_, _ | ⟨_, _ | ⟨_, _ | ⟨_, _⟩⟩⟩⟩⟩⟩⟩
+    · simp [argumentCount]
+    · simp [argumentCount]
+    · simp [argumentCount]
+    · simp [argumentCount]
+    · simp [argumentCount]
+    · simp [argumentCount]
+    · simp [argumentCount]
+    · simp [decodeCallFamilyStack?] at h_decode
+  · intro h_len
+    rcases stack with
+      _ | ⟨_, _ | ⟨_, _ | ⟨_, _ | ⟨_, _ | ⟨_, _ | ⟨_, _ | ⟨_, _⟩⟩⟩⟩⟩⟩⟩
+    · rfl
+    · rfl
+    · rfl
+    · rfl
+    · rfl
+    · rfl
+    · rfl
+    · simp [argumentCount] at h_len
+      omega
+
+theorem decodeCallFamilyStack?_staticcall_eq_none_iff (stack : List EvmWord) :
+    decodeCallFamilyStack? .staticcall stack = none ↔
+      stack.length < argumentCount .staticcall := by
+  constructor
+  · intro h_decode
+    rcases stack with
+      _ | ⟨_, _ | ⟨_, _ | ⟨_, _ | ⟨_, _ | ⟨_, _ | ⟨_, _⟩⟩⟩⟩⟩⟩
+    · simp [argumentCount]
+    · simp [argumentCount]
+    · simp [argumentCount]
+    · simp [argumentCount]
+    · simp [argumentCount]
+    · simp [argumentCount]
+    · simp [decodeCallFamilyStack?] at h_decode
+  · intro h_len
+    rcases stack with
+      _ | ⟨_, _ | ⟨_, _ | ⟨_, _ | ⟨_, _ | ⟨_, _ | ⟨_, _⟩⟩⟩⟩⟩⟩
+    · rfl
+    · rfl
+    · rfl
+    · rfl
+    · rfl
+    · rfl
+    · simp [argumentCount] at h_len
+      omega
+
+theorem decodeCallFamilyStack?_delegatecall_eq_none_iff (stack : List EvmWord) :
+    decodeCallFamilyStack? .delegatecall stack = none ↔
+      stack.length < argumentCount .delegatecall := by
+  constructor
+  · intro h_decode
+    rcases stack with
+      _ | ⟨_, _ | ⟨_, _ | ⟨_, _ | ⟨_, _ | ⟨_, _ | ⟨_, _⟩⟩⟩⟩⟩⟩
+    · simp [argumentCount]
+    · simp [argumentCount]
+    · simp [argumentCount]
+    · simp [argumentCount]
+    · simp [argumentCount]
+    · simp [argumentCount]
+    · simp [decodeCallFamilyStack?] at h_decode
+  · intro h_len
+    rcases stack with
+      _ | ⟨_, _ | ⟨_, _ | ⟨_, _ | ⟨_, _ | ⟨_, _ | ⟨_, _⟩⟩⟩⟩⟩⟩
+    · rfl
+    · rfl
+    · rfl
+    · rfl
+    · rfl
+    · rfl
+    · simp [argumentCount] at h_len
+      omega
+
+theorem decodeCallFamilyStack?_eq_none_iff (kind : Kind) (stack : List EvmWord) :
+    decodeCallFamilyStack? kind stack = none ↔ stack.length < argumentCount kind := by
+  cases kind with
+  | call => exact decodeCallFamilyStack?_call_eq_none_iff stack
+  | staticcall => exact decodeCallFamilyStack?_staticcall_eq_none_iff stack
+  | delegatecall => exact decodeCallFamilyStack?_delegatecall_eq_none_iff stack
+
 theorem decodeCallStack?_none_of_empty :
     decodeCallStack? [] = none := rfl
 
@@ -367,6 +647,125 @@ theorem decodeDelegateCallStack?_none_of_five
     (gas to inputOffset inputSize outputOffset : EvmWord) :
     decodeDelegateCallStack?
       [gas, to, inputOffset, inputSize, outputOffset] = none := rfl
+
+theorem decodeCallFamilyStack?_call_none_of_empty :
+    decodeCallFamilyStack? .call [] = none := rfl
+
+theorem decodeCallFamilyStack?_call_none_of_one
+    (gas : EvmWord) :
+    decodeCallFamilyStack? .call [gas] = none := rfl
+
+theorem decodeCallFamilyStack?_call_none_of_two
+    (gas to : EvmWord) :
+    decodeCallFamilyStack? .call [gas, to] = none := rfl
+
+theorem decodeCallFamilyStack?_call_none_of_three
+    (gas to value : EvmWord) :
+    decodeCallFamilyStack? .call [gas, to, value] = none := rfl
+
+theorem decodeCallFamilyStack?_call_none_of_four
+    (gas to value inputOffset : EvmWord) :
+    decodeCallFamilyStack? .call [gas, to, value, inputOffset] = none := rfl
+
+theorem decodeCallFamilyStack?_call_none_of_five
+    (gas to value inputOffset inputSize : EvmWord) :
+    decodeCallFamilyStack? .call
+      [gas, to, value, inputOffset, inputSize] = none := rfl
+
+theorem decodeCallFamilyStack?_call_none_of_six
+    (gas to value inputOffset inputSize outputOffset : EvmWord) :
+    decodeCallFamilyStack? .call
+      [gas, to, value, inputOffset, inputSize, outputOffset] = none := rfl
+
+theorem decodeCallFamilyStack?_staticcall_none_of_empty :
+    decodeCallFamilyStack? .staticcall [] = none := rfl
+
+theorem decodeCallFamilyStack?_staticcall_none_of_one
+    (gas : EvmWord) :
+    decodeCallFamilyStack? .staticcall [gas] = none := rfl
+
+theorem decodeCallFamilyStack?_staticcall_none_of_two
+    (gas to : EvmWord) :
+    decodeCallFamilyStack? .staticcall [gas, to] = none := rfl
+
+theorem decodeCallFamilyStack?_staticcall_none_of_three
+    (gas to inputOffset : EvmWord) :
+    decodeCallFamilyStack? .staticcall [gas, to, inputOffset] = none := rfl
+
+theorem decodeCallFamilyStack?_staticcall_none_of_four
+    (gas to inputOffset inputSize : EvmWord) :
+    decodeCallFamilyStack? .staticcall
+      [gas, to, inputOffset, inputSize] = none := rfl
+
+theorem decodeCallFamilyStack?_staticcall_none_of_five
+    (gas to inputOffset inputSize outputOffset : EvmWord) :
+    decodeCallFamilyStack? .staticcall
+      [gas, to, inputOffset, inputSize, outputOffset] = none := rfl
+
+theorem decodeCallFamilyStack?_delegatecall_none_of_empty :
+    decodeCallFamilyStack? .delegatecall [] = none := rfl
+
+theorem decodeCallFamilyStack?_delegatecall_none_of_one
+    (gas : EvmWord) :
+    decodeCallFamilyStack? .delegatecall [gas] = none := rfl
+
+theorem decodeCallFamilyStack?_delegatecall_none_of_two
+    (gas to : EvmWord) :
+    decodeCallFamilyStack? .delegatecall [gas, to] = none := rfl
+
+theorem decodeCallFamilyStack?_delegatecall_none_of_three
+    (gas to inputOffset : EvmWord) :
+    decodeCallFamilyStack? .delegatecall [gas, to, inputOffset] = none := rfl
+
+theorem decodeCallFamilyStack?_delegatecall_none_of_four
+    (gas to inputOffset inputSize : EvmWord) :
+    decodeCallFamilyStack? .delegatecall
+      [gas, to, inputOffset, inputSize] = none := rfl
+
+theorem decodeCallFamilyStack?_delegatecall_none_of_five
+    (gas to inputOffset inputSize outputOffset : EvmWord) :
+    decodeCallFamilyStack? .delegatecall
+      [gas, to, inputOffset, inputSize, outputOffset] = none := rfl
+
+theorem decodedKind_call
+    (gas to value inputOffset inputSize outputOffset outputSize : EvmWord) :
+    decodedKind
+      (.call (mkCall gas to value inputOffset inputSize outputOffset outputSize)) =
+        .call := rfl
+
+theorem decodedKind_staticcall
+    (gas to inputOffset inputSize outputOffset outputSize : EvmWord) :
+    decodedKind
+      (.staticcall
+        (mkStaticCall gas to inputOffset inputSize outputOffset outputSize)) =
+        .staticcall := rfl
+
+theorem decodedKind_delegatecall
+    (gas to inputOffset inputSize outputOffset outputSize : EvmWord) :
+    decodedKind
+      (.delegatecall
+        (mkDelegateCall gas to inputOffset inputSize outputOffset outputSize)) =
+        .delegatecall := rfl
+
+theorem decodedArgumentCount_call
+    (gas to value inputOffset inputSize outputOffset outputSize : EvmWord) :
+    decodedArgumentCount
+      (.call (mkCall gas to value inputOffset inputSize outputOffset outputSize)) =
+        7 := rfl
+
+theorem decodedArgumentCount_staticcall
+    (gas to inputOffset inputSize outputOffset outputSize : EvmWord) :
+    decodedArgumentCount
+      (.staticcall
+        (mkStaticCall gas to inputOffset inputSize outputOffset outputSize)) =
+        6 := rfl
+
+theorem decodedArgumentCount_delegatecall
+    (gas to inputOffset inputSize outputOffset outputSize : EvmWord) :
+    decodedArgumentCount
+      (.delegatecall
+        (mkDelegateCall gas to inputOffset inputSize outputOffset outputSize)) =
+        6 := rfl
 
 end CallArgsStackDecode
 


### PR DESCRIPTION
Refs: #114
Beads: evm-asm-53l7e
Parent: evm-asm-b37o

## Summary
- add `CallArgsStackDecode.Decoded` for CALL / STATICCALL / DELEGATECALL stack arguments
- add `decodeCallFamilyStack? : CallArgs.Kind -> List EvmWord -> Option Decoded`
- prove success/failure characterizations and basic decoded-kind/count helpers, mirroring the Storage/Create decoder pattern

## Verification
- `lake build EvmAsm.Evm64.CallArgsStackDecode`
- `lake build`