### PR TITLE
feat(call): add visible effect head bridges

### DIFF
--- a/EvmAsm/EL/CallExecutionBridge.lean
+++ b/EvmAsm/EL/CallExecutionBridge.lean
@@ -115,6 +115,27 @@ theorem delegateCallVisibleEffectsFromResult_stack_length
     (result : CallResult) (args : DelegateCallArgs) :
     (delegateCallVisibleEffectsFromResult result args).stackWords.length = 1 := rfl
 
+theorem callVisibleEffectsFromResult_stack_head_eq_one_iff
+    (result : CallResult) (args : CallArgs) :
+    (callVisibleEffectsFromResult result args).stackWords.head? = some 1 ↔
+      result.status = .success := by
+  exact CallResultEffectsBridge.callVisibleEffects_stack_head_eq_one_iff
+    result (CallArgsBridge.callOutputRange args)
+
+theorem staticCallVisibleEffectsFromResult_stack_head_eq_one_iff
+    (result : CallResult) (args : StaticCallArgs) :
+    (staticCallVisibleEffectsFromResult result args).stackWords.head? = some 1 ↔
+      result.status = .success := by
+  exact CallResultEffectsBridge.callVisibleEffects_stack_head_eq_one_iff
+    result (CallArgsBridge.staticCallOutputRange args)
+
+theorem delegateCallVisibleEffectsFromResult_stack_head_eq_one_iff
+    (result : CallResult) (args : DelegateCallArgs) :
+    (delegateCallVisibleEffectsFromResult result args).stackWords.head? = some 1 ↔
+      result.status = .success := by
+  exact CallResultEffectsBridge.callVisibleEffects_stack_head_eq_one_iff
+    result (CallArgsBridge.delegateCallOutputRange args)
+
 theorem callVisibleEffectsFromResult_output_length_le
     (result : CallResult) (args : CallArgs) :
     (callVisibleEffectsFromResult result args).outputBytes.length ≤ args.output.size.toNat := by


### PR DESCRIPTION
## Summary
- add CALL visible-effect stack head/status iff bridge
- add STATICCALL and DELEGATECALL variants using their output ranges

Refs #114
Beads: evm-asm-uywgn
Parent: evm-asm-b37o

## Verification
- lake build EvmAsm.EL.CallExecutionBridge
- lake build