### PR TITLE
feat(exp): add stack head success bridge

### DIFF
--- a/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
+++ b/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
@@ -189,6 +189,16 @@ theorem runExpStack?_head?
       some (some (ExpArgs.expResultFromArgs
         (ExpArgs.expArgs base exponent))) := rfl
 
+theorem runExpStack?_head?_of_some
+    {base exponent : EvmWord} {rest : List EvmWord} {out : ExpStackResult}
+    (h_run : runExpStack? { stack := base :: exponent :: rest } = some out) :
+    out.effects.stackWords.head? =
+      some (ExpArgs.expResultFromArgs (ExpArgs.expArgs base exponent)) := by
+  rw [runExpStack?_cons] at h_run
+  injection h_run with h_out
+  subst h_out
+  rfl
+
 theorem runExpStack?_gas
     (base exponent : EvmWord) (rest : List EvmWord) :
     (runExpStack? { stack := base :: exponent :: rest }).map


### PR DESCRIPTION
## Summary
- add a success-elimination bridge for EXP stack execution result head
- keep the helper next to the existing concrete runExpStack? head projection

Refs #92
Beads: evm-asm-75v9z
Parent: evm-asm-20z6

## Verification
- lake build EvmAsm.Evm64.Exp.StackExecutionBridge
- lake build