### PR TITLE
feat(sdiv): add sign bit block leaf spec

### DIFF
--- a/EvmAsm/Evm64/SDiv/LimbSpec.lean
+++ b/EvmAsm/Evm64/SDiv/LimbSpec.lean
@@ -4,9 +4,8 @@
   Per-block / per-limb cpsTriple specs for SDIV sub-blocks (sign
   extraction, abs negation, callable-divide JAL, sign-correction).
 
-  Skeleton placeholder for GH #90 (beads slice evm-asm-kyp6). Per
-  `OPCODE_TEMPLATE.md`, each sub-block will get exactly one cpsTriple
-  lemma once the Compose layer pins the layout.
+  Per `OPCODE_TEMPLATE.md`, each sub-block gets exactly one cpsTriple
+  lemma; later Compose slices chain them.
 -/
 
 import EvmAsm.Evm64.SDiv.Program
@@ -18,6 +17,33 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 
--- Per-block specs land in slices evm-asm-01uh and below.
+/-- CodeReq for `evm_sdiv_sign_bit_block` at byte offset `base`. -/
+abbrev evm_sdiv_sign_bit_block_code
+    (addrReg signReg : Reg) (topLimbOff : BitVec 12) (base : Word) : CodeReq :=
+  CodeReq.ofProg base (evm_sdiv_sign_bit_block addrReg signReg topLimbOff)
+
+/-- 2-instruction leaf spec: load `topLimbOff(addrReg)` into `signReg`,
+    then shift right logically by 63 to expose the top bit. The
+    post-state's `signReg` holds `topLimbVal >>> 63` (i.e. `0` for
+    non-negative inputs and `1` for negative inputs).
+
+    Requires `signReg ≠ x0`; separation of `(addrReg ↦ᵣ _)` and
+    `(signReg ↦ᵣ _)` in the precondition implicitly forces
+    `addrReg ≠ signReg`. -/
+theorem evm_sdiv_sign_bit_block_spec_within
+    (addrReg signReg : Reg) (topLimbOff : BitVec 12)
+    (vAddr sOld topLimbVal : Word) (base : Word)
+    (hsign_ne_x0 : signReg ≠ .x0) :
+    let code := evm_sdiv_sign_bit_block_code addrReg signReg topLimbOff base
+    cpsTripleWithin 2 base (base + 8) code
+      ((addrReg ↦ᵣ vAddr) ** (signReg ↦ᵣ sOld) **
+       ((vAddr + signExtend12 topLimbOff) ↦ₘ topLimbVal))
+      ((addrReg ↦ᵣ vAddr) ** (signReg ↦ᵣ (topLimbVal >>> (63 : BitVec 6).toNat)) **
+       ((vAddr + signExtend12 topLimbOff) ↦ₘ topLimbVal)) := by
+  have L := ld_spec_gen_within signReg addrReg vAddr sOld topLimbVal
+              topLimbOff base hsign_ne_x0
+  have S := srli_spec_gen_same_within signReg topLimbVal (63 : BitVec 6)
+              (base + 4) hsign_ne_x0
+  runBlock L S
 
 end EvmAsm.Evm64


### PR DESCRIPTION
Sub-slice of #90 slice 4 (beads `evm-asm-ld9dl`, parent `evm-asm-01uh`).

Adds `evm_sdiv_sign_bit_block_spec_within` (in `EvmAsm/Evm64/SDiv/LimbSpec.lean`) — the 2-instruction cpsTripleWithin leaf for `evm_sdiv_sign_bit_block` (`LD ;; SRLI 63`). Post-state's `signReg` holds `topLimbVal >>> 63`, exposing the operand's sign bit (`0` for non-negative, `1` for negative).

The lemma is register-parametric (any `addrReg`, any `signReg ≠ x0`, any `topLimbOff : BitVec 12`) so SDIV and SMOD can share it for dividend and divisor sign probes before normalizing operands in place.

Also introduces the `evm_sdiv_sign_bit_block_code` CodeReq abbreviation (`CodeReq.ofProg` of the program at `base`).

Composition shape: `runBlock L S` from `ld_spec_gen_within` + `srli_spec_gen_same_within`.

## Verification
- `lake build` green.
- 0 new sorry.
- No `maxHeartbeats` / `maxRecDepth` bumps.

Refs GH #90, beads `evm-asm-ld9dl` (parent `evm-asm-01uh`).
Authored by @pirapira; implemented by Hermes-bot (evm-hermes).