### PR TITLE
feat(exp): add stack effect count bridge

### DIFF
--- a/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
+++ b/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
@@ -163,6 +163,23 @@ theorem runExpStack?_eq_some_iff
         subst h_out
         exact runExpStack?_cons base exponent rest
 
+theorem runExpStack?_effects_stackWords_length
+    {state : ExpStackState} {out : ExpStackResult}
+    (h_run : runExpStack? state = some out) :
+    out.effects.stackWords.length = resultCount := by
+  cases state with
+  | mk stack =>
+      cases stack with
+      | nil =>
+          simp [runExpStack?, ExpArgsStackDecode.decodeExpStack?] at h_run
+      | cons base tail =>
+          cases tail with
+          | nil => simp [runExpStack?, stackRestAfterExp?] at h_run
+          | cons exponent rest =>
+              simp [runExpStack?, stackRestAfterExp?] at h_run
+              cases h_run
+              simp [resultCount, ExpArgs.resultCount]
+
 theorem runExpStack?_stack_length
     {state : ExpStackState} {out : ExpStackResult}
     (h_run : runExpStack? state = some out) :


### PR DESCRIPTION
Refs #92

Beads: evm-asm-21u8e
Parent: evm-asm-20z6

Summary:
- add a successful runExpStack? visible stack-word count bridge

Verification:
- lake build EvmAsm.Evm64.Exp.StackExecutionBridge
- lake build