### PR TITLE
feat(sdiv): add executable wrapper layout

### DIFF
--- a/EvmAsm/Evm64/SDiv/Program.lean
+++ b/EvmAsm/Evm64/SDiv/Program.lean
@@ -4,24 +4,28 @@
   Signed division opcode SDIV (`SDIV(a, b)` = signed-quotient under EVM
   rules) as a 64-bit RISC-V program.
 
-  Skeleton placeholder for GH #90 (beads slice evm-asm-kyp6).
-
-  The actual `evm_sdiv : Program` will be defined in slice
-  evm-asm-01uh. Per `docs/sdiv-smod-design.md` the algorithm is
+  Per `docs/sdiv-smod-design.md` the algorithm is
 
       1. extract sign of each operand (top bit of limb 3)
       2. conditionally two's-complement negate operands so both are
          non-negative; remember the sign-pair
       3. JAL to an `evm_div_callable` shim (LP64) for unsigned division
-      4. conditionally negate the quotient based on `sign(a) XOR sign(b)`
-      5. apply the SDIV(-2^255, -1) = -2^255 fast-path overflow rule
+      4. conditionally negate the quotient based on `sign(a) XOR sign(b)`.
 
-  This file currently has no `evm_sdiv` definition; later slices will
-  add it without breaking the umbrella import graph.
+  The `SDIV(-2^255, -1)` case follows this same bitvector path: the
+  two's-complement "absolute value" of `-2^255` is the unsigned word
+  `2^255`, division by `1` returns that word, and the equal signs skip
+  the final negation.
+
+  This file fixes the executable layout used by the later composition
+  proof. The unsigned divider body is appended after the SDIV wrapper and
+  reached by a near `JAL`, so it is present in code memory but not in the
+  wrapper fall-through path.
 -/
 
 import EvmAsm.Rv64.Program
 import EvmAsm.Evm64.Stack
+import EvmAsm.Evm64.DivMod.Callable
 
 namespace EvmAsm.Evm64
 
@@ -118,6 +122,85 @@ theorem evm_sdiv_div_call_block_length (divOff : BitVec 21) :
 theorem evm_sdiv_div_call_block_byte_length (divOff : BitVec 21) :
     4 * (evm_sdiv_div_call_block divOff).length = 4 := by
   rw [evm_sdiv_div_call_block_length]
+
+/-- Copy the current return address to a preserved scratch register. SDIV
+    cannot use `cc_prologue` / `cc_epilogue` around `evm_div_callable`
+    because the divider body owns `x2` as a scratch/link register. -/
+def evm_sdiv_save_ra_block (savedRaReg : Reg) : Program :=
+  ADDI savedRaReg .x1 0
+
+theorem evm_sdiv_save_ra_block_length (savedRaReg : Reg) :
+    (evm_sdiv_save_ra_block savedRaReg).length = 1 := rfl
+
+theorem evm_sdiv_save_ra_block_byte_length (savedRaReg : Reg) :
+    4 * (evm_sdiv_save_ra_block savedRaReg).length = 4 := by
+  rw [evm_sdiv_save_ra_block_length]
+
+/-- Return to the address saved before the nested DIV call. -/
+def evm_sdiv_saved_ra_ret_block (savedRaReg : Reg) : Program :=
+  JALR .x0 savedRaReg 0
+
+theorem evm_sdiv_saved_ra_ret_block_length (savedRaReg : Reg) :
+    (evm_sdiv_saved_ra_ret_block savedRaReg).length = 1 := rfl
+
+theorem evm_sdiv_saved_ra_ret_block_byte_length (savedRaReg : Reg) :
+    4 * (evm_sdiv_saved_ra_ret_block savedRaReg).length = 4 := by
+  rw [evm_sdiv_saved_ra_ret_block_length]
+
+def evm_sdivDividendTopLimbOff : BitVec 12 := 24
+def evm_sdivDivisorTopLimbOff : BitVec 12 := 56
+def evm_sdivCallOff : BitVec 21 := 92
+
+/-- The executable SDIV wrapper, excluding the appended unsigned DIV callable.
+
+    Register layout:
+    * `x18` saves the caller return address across the nested `JAL`.
+    * `x8` stores `sign(dividend)` and then `sign(dividend) XOR sign(divisor)`.
+    * `x9` stores `sign(divisor)`.
+    * `x10`, `x11`, and `x7` are scratch registers for conditional negation.
+
+    Memory layout matches `evm_div_callable`: dividend at `sp + 0..24`,
+    divisor at `sp + 32..56`, quotient result at `sp + 32..56`. -/
+def evm_sdiv_wrapper : Program :=
+  evm_sdiv_save_ra_block .x18 ;;
+  evm_sdiv_sign_bit_block .x12 .x8 evm_sdivDividendTopLimbOff ;;
+  evm_sdiv_sign_bit_block .x12 .x9 evm_sdivDivisorTopLimbOff ;;
+  evm_sdiv_cond_negate_256_block .x12 .x8 .x10 .x7 .x11 0 8 16 24 ;;
+  evm_sdiv_cond_negate_256_block .x12 .x9 .x10 .x7 .x11 32 40 48 56 ;;
+  XOR' .x8 .x8 .x9 ;;
+  evm_sdiv_div_call_block evm_sdivCallOff ;;
+  evm_sdiv_cond_negate_256_block .x12 .x8 .x10 .x7 .x11 32 40 48 56 ;;
+  evm_sdiv_saved_ra_ret_block .x18
+
+theorem evm_sdiv_wrapper_length : evm_sdiv_wrapper.length = 71 := by
+  native_decide
+
+theorem evm_sdiv_wrapper_byte_length :
+    4 * evm_sdiv_wrapper.length = 284 := by
+  rw [evm_sdiv_wrapper_length]
+
+theorem evm_sdiv_call_target_byte_offset :
+    4 *
+      ((evm_sdiv_save_ra_block .x18).length +
+       (evm_sdiv_sign_bit_block .x12 .x8 evm_sdivDividendTopLimbOff).length +
+       (evm_sdiv_sign_bit_block .x12 .x9 evm_sdivDivisorTopLimbOff).length +
+       (evm_sdiv_cond_negate_256_block .x12 .x8 .x10 .x7 .x11 0 8 16 24).length +
+       (evm_sdiv_cond_negate_256_block .x12 .x9 .x10 .x7 .x11 32 40 48 56).length +
+       (XOR' .x8 .x8 .x9).length) +
+      signExtend21 evm_sdivCallOff =
+    4 * evm_sdiv_wrapper.length := by
+  native_decide
+
+/-- Full SDIV code region. The wrapper returns via `x18`; the appended
+    `evm_div_callable` block is reached only by the wrapper's near call. -/
+def evm_sdiv : Program :=
+  evm_sdiv_wrapper ;; evm_div_callable
+
+theorem evm_sdiv_length : evm_sdiv.length = 390 := by
+  native_decide
+
+theorem evm_sdiv_byte_length : 4 * evm_sdiv.length = 1560 := by
+  rw [evm_sdiv_length]
 
 example :
     (evm_sdiv_sign_bit_block .x12 .x5 24).length +


### PR DESCRIPTION
## Summary
- add the concrete SDIV wrapper program around the existing unsigned DIV callable
- pin the saved-return, sign-extraction, normalization, call, sign-correction, and return layout with length/call-target lemmas
- define the full evm_sdiv code region as wrapper plus appended evm_div_callable

Refs GH #90.
Refs beads evm-asm-01uh.

## Testing
- lake build