### PR TITLE
feat(smod): add executable wrapper layout

### DIFF
--- a/EvmAsm/Evm64/SMod/Program.lean
+++ b/EvmAsm/Evm64/SMod/Program.lean
@@ -4,10 +4,7 @@
   Signed remainder opcode SMOD (`SMOD(a, b)` = signed-remainder under EVM
   rules) as a 64-bit RISC-V program.
 
-  Skeleton placeholder for GH #90 (beads slice evm-asm-kyp6).
-
-  The actual `evm_smod : Program` will be defined in slice
-  evm-asm-bjnb. Per `docs/sdiv-smod-design.md` the algorithm is
+  Per `docs/sdiv-smod-design.md` the algorithm is
 
       1. extract sign of each operand (top bit of limb 3)
       2. conditionally two's-complement negate operands so both are
@@ -16,17 +13,93 @@
       4. conditionally negate the remainder based on `sign(a)`
          (EVM SMOD takes the sign of the dividend)
 
-  This file currently has no `evm_smod` definition; later slices will
-  add it without breaking the umbrella import graph.
+  This file fixes the executable layout used by the later composition
+  proof. The unsigned modulo body is appended after the SMOD wrapper and
+  reached by a near `JAL`, so it is present in code memory but not in the
+  wrapper fall-through path.
 -/
 
 import EvmAsm.Evm64.Stack
+import EvmAsm.Evm64.SDiv.Program
+import EvmAsm.Evm64.DivMod.Callable
 
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 
--- Placeholder: `evm_smod : Program` lands in slice 5 (evm-asm-bjnb).
--- See `docs/sdiv-smod-design.md` for the algorithm and reuse points.
+def evm_smodDividendTopLimbOff : BitVec 12 := 24
+def evm_smodDivisorTopLimbOff : BitVec 12 := 56
+def evm_smodCallOff : BitVec 21 := 92
+
+/-- Copy the current return address to a preserved scratch register. -/
+def evm_smod_save_ra_block (savedRaReg : Reg) : Program :=
+  ADDI savedRaReg .x1 0
+
+theorem evm_smod_save_ra_block_length (savedRaReg : Reg) :
+    (evm_smod_save_ra_block savedRaReg).length = 1 := rfl
+
+theorem evm_smod_save_ra_block_byte_length (savedRaReg : Reg) :
+    4 * (evm_smod_save_ra_block savedRaReg).length = 4 := by
+  rw [evm_smod_save_ra_block_length]
+
+/-- Return to the address saved before the nested MOD call. -/
+def evm_smod_saved_ra_ret_block (savedRaReg : Reg) : Program :=
+  JALR .x0 savedRaReg 0
+
+theorem evm_smod_saved_ra_ret_block_length (savedRaReg : Reg) :
+    (evm_smod_saved_ra_ret_block savedRaReg).length = 1 := rfl
+
+theorem evm_smod_saved_ra_ret_block_byte_length (savedRaReg : Reg) :
+    4 * (evm_smod_saved_ra_ret_block savedRaReg).length = 4 := by
+  rw [evm_smod_saved_ra_ret_block_length]
+
+/-- The executable SMOD wrapper, excluding the appended unsigned MOD callable.
+
+    Register layout:
+    * `x18` saves the caller return address across the nested `JAL`.
+    * `x8` stores `sign(dividend)` and drives the final remainder correction.
+    * `x9` stores `sign(divisor)` only for absolute-value normalization.
+    * `x10`, `x11`, and `x7` are scratch registers for conditional negation.
+
+    Memory layout matches `evm_mod_callable`: dividend at `sp + 0..24`,
+    divisor at `sp + 32..56`, remainder result at `sp + 32..56`. -/
+def evm_smod_wrapper : Program :=
+  evm_smod_save_ra_block .x18 ;;
+  evm_sdiv_sign_bit_block .x12 .x8 evm_smodDividendTopLimbOff ;;
+  evm_sdiv_sign_bit_block .x12 .x9 evm_smodDivisorTopLimbOff ;;
+  evm_sdiv_cond_negate_256_block .x12 .x8 .x10 .x7 .x11 0 8 16 24 ;;
+  evm_sdiv_cond_negate_256_block .x12 .x9 .x10 .x7 .x11 32 40 48 56 ;;
+  evm_sdiv_div_call_block evm_smodCallOff ;;
+  evm_sdiv_cond_negate_256_block .x12 .x8 .x10 .x7 .x11 32 40 48 56 ;;
+  evm_smod_saved_ra_ret_block .x18
+
+theorem evm_smod_wrapper_length : evm_smod_wrapper.length = 70 := by
+  native_decide
+
+theorem evm_smod_wrapper_byte_length :
+    4 * evm_smod_wrapper.length = 280 := by
+  rw [evm_smod_wrapper_length]
+
+theorem evm_smod_call_target_byte_offset :
+    4 *
+      ((evm_smod_save_ra_block .x18).length +
+       (evm_sdiv_sign_bit_block .x12 .x8 evm_smodDividendTopLimbOff).length +
+       (evm_sdiv_sign_bit_block .x12 .x9 evm_smodDivisorTopLimbOff).length +
+       (evm_sdiv_cond_negate_256_block .x12 .x8 .x10 .x7 .x11 0 8 16 24).length +
+       (evm_sdiv_cond_negate_256_block .x12 .x9 .x10 .x7 .x11 32 40 48 56).length) +
+      signExtend21 evm_smodCallOff =
+    4 * evm_smod_wrapper.length := by
+  native_decide
+
+/-- Full SMOD code region. The wrapper returns via `x18`; the appended
+    `evm_mod_callable` block is reached only by the wrapper's near call. -/
+def evm_smod : Program :=
+  evm_smod_wrapper ;; evm_mod_callable
+
+theorem evm_smod_length : evm_smod.length = 389 := by
+  native_decide
+
+theorem evm_smod_byte_length : 4 * evm_smod.length = 1556 := by
+  rw [evm_smod_length]
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add the concrete SMOD wrapper program around the existing unsigned MOD callable
- pin the saved-return, sign-extraction, normalization, call, sign-correction, and return layout with length/call-target lemmas
- define the full evm_smod code region as wrapper plus appended evm_mod_callable

Refs GH #90.
Refs beads evm-asm-bjnb.

## Testing
- lake build