### PR TITLE
feat(rv64): reshape commit as write_output

### DIFF
--- a/EvmAsm/Evm64/Accelerators/SyscallIds.lean
+++ b/EvmAsm/Evm64/Accelerators/SyscallIds.lean
@@ -16,7 +16,7 @@
   Existing reserved selector values used elsewhere in this repo:
 
       0x00  HALT       (`Rv64.Program.HALT`)
-      0x10  COMMIT
+      0x10  write_output  (`Rv64.Execution.step_ecall_write_output`)
       0xF0  HINT_LEN   (`Rv64.HintSpecs`, `Rv64.RLP.Phase4HintLen`)
       0xF1  HINT_READ  (`Rv64.RLP.Phase4HintRead`)
 
@@ -107,7 +107,7 @@ disjointness check below covers the full active selector space. -/
 /-- HALT framing selector (matches `Rv64.Program.HALT`). -/
 def halt : Nat := 0x00
 
-/-- COMMIT framing selector. -/
+/-- Host `write_output(ptr, size)` framing selector. -/
 def commit : Nat := 0x10
 
 /-- HINT_LEN framing selector (matches `Rv64.HintSpecs`). -/
@@ -256,7 +256,7 @@ def secp256r1_verify : Word := BitVec.ofNat 64 SyscallId.secp256r1_verify
 /-- HALT framing selector as RV64 `Word`. -/
 def halt : Word := BitVec.ofNat 64 SyscallId.halt
 
-/-- COMMIT framing selector as RV64 `Word`. -/
+/-- Host `write_output(ptr, size)` framing selector as RV64 `Word`. -/
 def commit : Word := BitVec.ofNat 64 SyscallId.commit
 
 /-- HINT_LEN framing selector as RV64 `Word`. -/

--- a/EvmAsm/Rv64/Basic.lean
+++ b/EvmAsm/Rv64/Basic.lean
@@ -368,9 +368,9 @@ structure MachineState where
   code : Word → Option Instr := fun _ => none
   /-- Program counter -/
   pc   : Word
-  /-- Committed public outputs (a0, a1) from COMMIT syscalls -/
+  /-- Legacy SP1 word-pair commits, retained for compatibility with old examples. -/
   committed : List (Word × Word) := []
-  /-- Accumulated public values from WRITE syscalls (flat byte stream) -/
+  /-- Accumulated public output bytes from `write_output`/WRITE syscalls. -/
   publicValues : List (BitVec 8) := []
   /-- Private input stream (flat byte list, consumed by HINT_READ) -/
   privateInput : List (BitVec 8) := []
@@ -457,6 +457,10 @@ def readBytes (s : MachineState) (base : Word) : Nat → List (BitVec 8)
   | 0 => []
   | n + 1 => s.getByte base :: readBytes s (base + 1) n
 
+/-- zkvm-standards `write_output(ptr, size)`: append bytes read from guest memory. -/
+def writeOutput (s : MachineState) (ptr size : Word) : MachineState :=
+  s.appendPublicValues (s.readBytes ptr size.toNat)
+
 end MachineState
 
 /-- Convert up to 8 bytes (little-endian) into a 64-bit word, zero-padding if fewer than 8. -/
@@ -526,6 +530,9 @@ termination_by l => l.length
 @[simp] theorem code_appendPublicValues {s : MachineState} {bytes : List (BitVec 8)} :
     (s.appendPublicValues bytes).code = s.code := by simp [appendPublicValues]
 
+@[simp] theorem code_writeOutput {s : MachineState} {ptr size : Word} :
+    (s.writeOutput ptr size).code = s.code := by simp [writeOutput]
+
 @[simp] theorem code_writeWords {s : MachineState} {base : Word} {words : List Word} :
     (s.writeWords base words).code = s.code := by
   induction words generalizing s base with
@@ -572,6 +579,10 @@ theorem getReg_setReg_eq {s : MachineState} {r : Reg} {v : Word}
 @[simp] theorem committed_setPC {s : MachineState} {v : Word} :
     (s.setPC v).committed = s.committed := by simp [setPC]
 
+@[simp] theorem committed_writeOutput {s : MachineState} {ptr size : Word} :
+    (s.writeOutput ptr size).committed = s.committed := by
+  simp [writeOutput, appendPublicValues]
+
 @[simp] theorem publicValues_setReg {s : MachineState} {r : Reg} {v : Word} :
     (s.setReg r v).publicValues = s.publicValues := by cases r <;> rfl
 
@@ -586,6 +597,11 @@ theorem getReg_setReg_eq {s : MachineState} {r : Reg} {v : Word}
 
 @[simp] theorem publicValues_setPC {s : MachineState} {v : Word} :
     (s.setPC v).publicValues = s.publicValues := by simp [setPC]
+
+@[simp] theorem publicValues_writeOutput {s : MachineState} {ptr size : Word} :
+    (s.writeOutput ptr size).publicValues =
+      s.publicValues ++ s.readBytes ptr size.toNat := by
+  simp [writeOutput, appendPublicValues]
 
 @[simp] theorem publicValues_appendCommit {s : MachineState} {a0 a1 : Word} :
     (s.appendCommit a0 a1).publicValues = s.publicValues := by simp [appendCommit]
@@ -626,11 +642,17 @@ theorem getReg_setReg_eq {s : MachineState} {r : Reg} {v : Word}
 @[simp] theorem privateInput_appendPublicValues {s : MachineState} {bytes : List (BitVec 8)} :
     (s.appendPublicValues bytes).privateInput = s.privateInput := by simp [appendPublicValues]
 
+@[simp] theorem privateInput_writeOutput {s : MachineState} {ptr size : Word} :
+    (s.writeOutput ptr size).privateInput = s.privateInput := by simp [writeOutput]
+
 @[simp] theorem inputBufBase_appendCommit {s : MachineState} {a0 a1 : Word} :
     (s.appendCommit a0 a1).inputBufBase = s.inputBufBase := by simp [appendCommit]
 
 @[simp] theorem inputBufBase_appendPublicValues {s : MachineState} {bytes : List (BitVec 8)} :
     (s.appendPublicValues bytes).inputBufBase = s.inputBufBase := by simp [appendPublicValues]
+
+@[simp] theorem inputBufBase_writeOutput {s : MachineState} {ptr size : Word} :
+    (s.writeOutput ptr size).inputBufBase = s.inputBufBase := by simp [writeOutput]
 
 -- appendCommit preservation lemmas
 
@@ -663,6 +685,17 @@ theorem getReg_setReg_eq {s : MachineState} {r : Reg} {v : Word}
 @[simp] theorem publicValues_appendPublicValues {s : MachineState} {bytes : List (BitVec 8)} :
     (s.appendPublicValues bytes).publicValues = s.publicValues ++ bytes := by
   simp [appendPublicValues]
+
+-- writeOutput preservation lemmas
+
+@[simp] theorem getReg_writeOutput {s : MachineState} {ptr size : Word} {r : Reg} :
+    (s.writeOutput ptr size).getReg r = s.getReg r := by cases r <;> rfl
+
+@[simp] theorem getMem_writeOutput (s : MachineState) (ptr size a : Word) :
+    (s.writeOutput ptr size).getMem a = s.getMem a := by simp [writeOutput]
+
+@[simp] theorem pc_writeOutput (s : MachineState) (ptr size : Word) :
+    (s.writeOutput ptr size).pc = s.pc := by simp [writeOutput]
 
 -- readWords / writeWords simp lemmas
 

--- a/EvmAsm/Rv64/Execution.lean
+++ b/EvmAsm/Rv64/Execution.lean
@@ -328,7 +328,8 @@ theorem loadProgram_programAt {base : Word} {prog : List Instr}
     LH/LHU/SH trap on misaligned or out-of-range addresses.
     EBREAK traps (returns none).
     WRITE (t0 = 0x02) to fd 13 appends bytes from memory to public values.
-    COMMIT (t0 = 0x10) appends (a0, a1) to committed outputs.
+    write_output (t0 = 0x10) appends a1 bytes from memory at a0 to public
+    output bytes.
     Other ECALLs continue execution. -/
 def step (s : MachineState) : Option MachineState :=
   match s.code s.pc with
@@ -402,8 +403,8 @@ def step (s : MachineState) : Option MachineState :=
         some ((s.appendPublicValues bytes).setPC (s.pc + 4))
       else
         some (s.setPC (s.pc + 4))  -- other fd: continue
-    else if t0 == (0x10 : Word) then  -- COMMIT syscall
-      some ((s.appendCommit (s.getReg .x10) (s.getReg .x11)).setPC (s.pc + 4))
+    else if t0 == (0x10 : Word) then  -- write_output syscall
+      some ((s.writeOutput (s.getReg .x10) (s.getReg .x11)).setPC (s.pc + 4))
     else if t0 == (0xF0 : Word) then  -- HINT_LEN syscall
       -- SP1: returns actual byte count of input stream
       let len := BitVec.ofNat 64 s.privateInput.length
@@ -620,19 +621,27 @@ theorem step_ecall_continue {s : MachineState}
     (hfetch : s.code s.pc = some .ECALL)
     (ht0 : s.getReg .x5 ≠ 0)
     (ht0_nw : s.getReg .x5 ≠ (0x02 : Word))
-    (ht0_nc : s.getReg .x5 ≠ (0x10 : Word))
+    (ht0_nwo : s.getReg .x5 ≠ (0x10 : Word))
     (ht0_nhl : s.getReg .x5 ≠ (0xF0 : Word))
     (ht0_nhr : s.getReg .x5 ≠ (0xF1 : Word)) :
     step s = some (execInstrBr s .ECALL) := by
-  simp only [step, hfetch, beq_iff_eq, ht0, ht0_nw, ht0_nc, ht0_nhl, ht0_nhr, ↓reduceIte]
+  simp only [step, hfetch, beq_iff_eq, ht0, ht0_nw, ht0_nwo, ht0_nhl, ht0_nhr, ↓reduceIte]
 
-/-- COMMIT syscall (SP1 convention: t0 = 0x10) appends (a0, a1) to committed outputs. -/
+/-- `write_output` syscall (t0 = 0x10) appends a1 bytes from memory at a0. -/
+theorem step_ecall_write_output {s : MachineState}
+    (hfetch : s.code s.pc = some .ECALL)
+    (ht0 : s.getReg .x5 = BitVec.ofNat 64 0x10) :
+    step s =
+      some ((s.writeOutput (s.getReg .x10) (s.getReg .x11)).setPC (s.pc + 4)) := by
+  simp [step, hfetch, ht0]
+
+@[deprecated step_ecall_write_output (since := "2026-05-08")]
 theorem step_ecall_commit {s : MachineState}
     (hfetch : s.code s.pc = some .ECALL)
     (ht0 : s.getReg .x5 = BitVec.ofNat 64 0x10) :
     step s =
-      some ((s.appendCommit (s.getReg .x10) (s.getReg .x11)).setPC (s.pc + 4)) := by
-  simp [step, hfetch, ht0]
+      some ((s.writeOutput (s.getReg .x10) (s.getReg .x11)).setPC (s.pc + 4)) :=
+  step_ecall_write_output hfetch ht0
 
 /-- WRITE syscall to FD_PUBLIC_VALUES (t0 = 0x02, fd = 13) appends bytes from memory. -/
 theorem step_ecall_write_public {s : MachineState}

--- a/docs/zkvm-host-io-interface.md
+++ b/docs/zkvm-host-io-interface.md
@@ -71,7 +71,7 @@ following ECALL syscalls (all selected by `t0 = x5`):
 |----------|-------------|----------------------|----------------------------|
 | `0x00`   | HALT        | `step_ecall_halt` (returns `none`)        | (no counterpart — see Open question) |
 | `0x02`   | WRITE fd=13 | append a1..a1+a2 bytes from memory to public values | `write_output(output, size)` (shape-compatible: ptr+size, concatenating) |
-| `0x10`   | COMMIT      | `s.appendCommit (a0, a1)` (word-pair commit) | conceptually subsumed by `write_output` (concatenating bytes) |
+| `0x10`   | COMMIT selector, reshaped | `s.writeOutput a0 a1` appends bytes from memory to public values | `write_output(output, size)` |
 | `0xF0`   | HINT_LEN    | returns `privateInput.length` in a0       | replaced by `read_input` (length is `*buf_size` out-parameter; no separate length call) |
 | `0xF1`   | HINT_READ   | streams `(a1)` bytes from `privateInput` into guest memory at `a0` as LE dwords | replaced by `read_input` (no streaming — input lives in a single buffer the guest indexes into) |
 
@@ -97,7 +97,8 @@ shape changes are:
 2. **ECALL handlers.** Replace the `HINT_LEN`/`HINT_READ` cases of
    `step` with a single `read_input` handler (ptr+len-out semantics).
    Reshape `COMMIT` (and/or `WRITE fd=13`) into a `write_output`
-   handler. Keep SP1 syscall IDs as the dispatch numbers for now;
+   handler. The `0x10` branch now has the `write_output(ptr, size)`
+   shape; `WRITE fd=13` remains as a compatibility spelling. Keep SP1 syscall IDs as the dispatch numbers for now;
    document that the IDs are handler-side, not ABI.
 3. **RLP wrappers.** Rewrite `Phase4HintLen.lean` and `Phase4HintRead.lean`
    to consume the `read_input` ptr+len once and index into the buffer,


### PR DESCRIPTION
## Summary
- add MachineState.writeOutput for zkvm-standards write_output(ptr, size)
- reshape the t0=0x10 ECALL branch to append bytes from memory into publicValues
- add step_ecall_write_output and keep step_ecall_commit as a deprecated compatibility alias
- update selector-table and host-I/O ADR wording for the reshaped 0x10 branch

## References
- beads: evm-asm-rv8pv
- parent beads: evm-asm-96ysd
- GH #114
- GH #116

## Testing
- lake build EvmAsm.Rv64.Execution
- lake build
- lake build EvmAsm.Rv64.Execution EvmAsm.Evm64.Accelerators.SyscallIds