### PR TITLE
docs(storage): track storage opcode kinds

### DIFF
--- a/EvmAsm/Evm64/StorageArgs.lean
+++ b/EvmAsm/Evm64/StorageArgs.lean
@@ -26,6 +26,10 @@ inductive Kind where
   | sstore
   deriving DecidableEq, Repr
 
+/-- The storage opcode kinds covered by GH #110. -/
+def allKinds : List Kind :=
+  [.sload, .sstore]
+
 inductive Decoded where
   | sload (args : SLoad)
   | sstore (args : SStore)
@@ -42,6 +46,23 @@ def resultCount : Kind → Nat
 def writesStorage : Kind → Bool
   | .sload => false
   | .sstore => true
+
+theorem allKinds_nodup :
+    allKinds.Nodup := by
+  decide
+
+theorem mem_allKinds (kind : Kind) :
+    kind ∈ allKinds := by
+  cases kind <;> decide
+
+theorem allKinds_argumentCounts :
+    allKinds.map argumentCount = [1, 2] := rfl
+
+theorem allKinds_resultCounts :
+    allKinds.map resultCount = [1, 0] := rfl
+
+theorem allKinds_writesStorage :
+    allKinds.map writesStorage = [false, true] := rfl
 
 def mkSLoad (slot : EvmWord) : SLoad :=
   { slot := slot }


### PR DESCRIPTION
## Summary
- add StorageArgs.allKinds for the SLOAD/SSTORE family
- prove nodup and total membership over StorageArgs.Kind
- add checked argument/result/write-effect projections for the family list

## References
- beads: evm-asm-8zv5
- GH #110

## Testing
- lake build EvmAsm.Evm64.StorageArgs
- lake build