### PR TITLE
docs: count aggregate conformance vectors

### DIFF
--- a/EvmAsm/EL/Conformance/All.lean
+++ b/EvmAsm/EL/Conformance/All.lean
@@ -40,6 +40,17 @@ def allConformanceVectors : List CheckResult :=
   StorageStackExecution.storageStackConformanceVectors ++
   TerminatingStackExecution.terminatingStackConformanceVectors
 
+def allConformanceVectorCount : Nat :=
+  allConformanceVectors.length
+
+theorem allConformanceVectors_length :
+    allConformanceVectors.length = 45 := by
+  native_decide
+
+theorem allConformanceVectorCount_eq :
+    allConformanceVectorCount = 45 := by
+  native_decide
+
 def unexpectedConformanceFailures : List CheckResult :=
   allConformanceVectors.filter
     (fun result =>


### PR DESCRIPTION
## Summary
- add an aggregate Lean-side conformance vector count for the GH #125 batch
- prove the current aggregate contains 45 checked results

Refs GH #125.
Refs beads evm-asm-sxou.

## Testing
- lake build EvmAsm.EL.Conformance.All
- lake build