### PR TITLE
feat: add shift scratchpad layout

### DIFF
--- a/EvmAsm/Evm64/Shift.lean
+++ b/EvmAsm/Evm64/Shift.lean
@@ -1,5 +1,6 @@
 -- The three Semantic leaves transitively cover Program / LimbSpec /
 -- {Shr,Shl,Sar}Spec / Compose / ComposeBase.
+import EvmAsm.Evm64.Shift.Layout
 import EvmAsm.Evm64.Shift.Semantic
 import EvmAsm.Evm64.Shift.ShlSemantic
 import EvmAsm.Evm64.Shift.SarSemantic

--- a/EvmAsm/Evm64/Shift/Layout.lean
+++ b/EvmAsm/Evm64/Shift/Layout.lean
@@ -1,0 +1,44 @@
+/-
+  EvmAsm.Evm64.Shift.Layout
+
+  Scratchpad-layout pilot for the Shift routine family (GH #334, beads
+  evm-asm-vst1).
+
+  Shift proofs currently thread the working-limb pointer as `sp + 32` into
+  the SHL/SHR/SAR limb specs. This file names that placement as a layout
+  field so follow-up DivMod/Shift parameterization can replace the hardcoded
+  offset without changing call sites again.
+-/
+
+import EvmAsm.Rv64.Basic
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Layout of the Shift routine's `sp`-relative internal scratch cells. -/
+structure ShiftScratchpadLayout : Type where
+  /-- Offset from the caller `sp` to the working-limb scratch block. -/
+  limbOff : Word
+  deriving Repr
+
+/-- Validity bundle for `ShiftScratchpadLayout`.
+
+    The first additive slice only names the existing field. Later migration
+    of the Shift specs can strengthen this with address-validity and
+    disjointness obligations once the field is consumed by proofs. -/
+structure ShiftScratchpadLayout.Valid (_L : ShiftScratchpadLayout) : Prop where
+
+/-- The canonical Shift scratchpad layout matching today's hardcoded
+    `sp + 32` working-limb pointer. -/
+def canonicalShiftScratchpadLayout : ShiftScratchpadLayout where
+  limbOff := 32
+
+theorem canonicalShiftScratchpadLayout_limbOff :
+    canonicalShiftScratchpadLayout.limbOff = 32 := rfl
+
+/-- The canonical Shift scratchpad layout is `Valid`. -/
+theorem canonicalShiftScratchpadLayout_valid :
+    canonicalShiftScratchpadLayout.Valid := {}
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add EvmAsm.Evm64.Shift.Layout with ShiftScratchpadLayout and canonicalShiftScratchpadLayout
- name the current working-limb offset as limbOff = 32 for follow-up #334 Shift parameterization
- import the layout module from the Shift umbrella

Refs GH #334.
Refs beads evm-asm-vst1.

## Testing
- lake build EvmAsm.Evm64.Shift
- lake build