### PR TITLE
feat: add opt-in chunked xperm prototype

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopComposeN3.lean
+++ b/EvmAsm/Evm64/DivMod/LoopComposeN3.lean
@@ -10,6 +10,7 @@
 -/
 
 import EvmAsm.Evm64.DivMod.LoopIterN3
+import EvmAsm.Rv64.Tactics.XPermChunked
 
 open EvmAsm.Rv64.Tactics
 
@@ -344,7 +345,7 @@ theorem divK_loop_n3_max_max_spec_within
       rw [hj', u_j1_0_eq_j0_4088, u_j1_4088_eq_j0_4080,
           u_j1_4080_eq_j0_4072, u_j1_4072_eq_j0_4064] at hp
       rw [sepConj_assoc'] at hp
-      xperm_hyp hp)
+      xperm_chunked hp)
     J1f J0f
   -- 5. Clean up postcondition
   exact cpsTripleWithin_weaken

--- a/EvmAsm/Rv64.lean
+++ b/EvmAsm/Rv64.lean
@@ -19,6 +19,8 @@ import EvmAsm.Rv64.Tactics.ExtractPure
 -- XPermPartial: design stub for #156 (slice 1, beads evm-asm-a7k).
 import EvmAsm.Rv64.Tactics.XPermPartial
 import EvmAsm.Rv64.Tactics.XPermPure
+-- XPermChunked: opt-in prototype for large sepConj chains (#265 slice 3).
+import EvmAsm.Rv64.Tactics.XPermChunked
 -- DropPure: pure-stripping rebind tactic (#1435, beads evm-asm-ww8).
 import EvmAsm.Rv64.Tactics.DropPure
 -- XCancelStruct: structural cancellation tactic (#245 slice 3, beads evm-asm-otgf).

--- a/EvmAsm/Rv64/Tactics/XPermChunked.lean
+++ b/EvmAsm/Rv64/Tactics/XPermChunked.lean
@@ -1,0 +1,34 @@
+/-
+  EvmAsm.Rv64.Tactics.XPermChunked
+
+  Opt-in surface for chunked sepConj permutation experiments.
+-/
+
+import Lean
+import EvmAsm.Rv64.Tactics.XPerm
+
+open Lean Meta Elab Tactic
+
+namespace EvmAsm.Rv64.Tactics
+
+/--
+`xperm_chunked h` has the same user-facing semantics as `xperm_hyp h`:
+given `h : P s`, close a goal `Q s` when `P` and `Q` are sepConj
+permutations.
+
+This prototype is deliberately opt-in. It routes through the existing
+proved permutation builder so call sites can migrate one at a time while
+the chunk partition pre-pass evolves behind the same surface.
+-/
+macro "xperm_chunked" hyp:ident : tactic =>
+  `(tactic| exact (congrFun (show _ = _ by xperm) _).mp $hyp)
+
+/-- Debug spelling reserved by the chunked-xperm design. -/
+macro "xperm_chunked" hyp:ident "only" : tactic =>
+  `(tactic| exact (congrFun (show _ = _ by xperm) _).mp $hyp)
+
+/-- Debug spelling reserved by the chunked-xperm design. -/
+macro "xperm_chunked" hyp:ident "with" "strict" : tactic =>
+  `(tactic| exact (congrFun (show _ = _ by xperm) _).mp $hyp)
+
+end EvmAsm.Rv64.Tactics


### PR DESCRIPTION
## Summary
- add an opt-in `xperm_chunked` tactic surface for the chunked sepConj permutation prototype
- import it through the Rv64 umbrella
- migrate one `LoopComposeN3` two-iteration composition site from `xperm_hyp` to `xperm_chunked`

## Verification
- `lake build EvmAsm.Rv64.Tactics.XPermChunked`
- `lake build EvmAsm.Evm64.DivMod.LoopComposeN3`
- `lake build`

Refs #265
Beads: evm-asm-57l1