### PR TITLE
feat(mulmod): add scratchpad layout scaffold

### DIFF
--- a/EvmAsm/Evm64/MulMod.lean
+++ b/EvmAsm/Evm64/MulMod.lean
@@ -11,6 +11,7 @@
 -/
 
 import EvmAsm.Evm64.MulMod.AddrNormAttr
+import EvmAsm.Evm64.MulMod.Layout
 import EvmAsm.Evm64.MulMod.Program
 import EvmAsm.Evm64.MulMod.LimbSpec
 import EvmAsm.Evm64.MulMod.AddrNorm

--- a/EvmAsm/Evm64/MulMod/Layout.lean
+++ b/EvmAsm/Evm64/MulMod/Layout.lean
@@ -1,0 +1,39 @@
+/-
+  EvmAsm.Evm64.MulMod.Layout
+
+  Scratchpad-layout scaffold for the MULMOD opcode (GH #91).
+-/
+
+import EvmAsm.Evm64.Stack
+
+namespace EvmAsm.Evm64
+
+/-- Layout of the MULMOD routine's `sp`-relative internal scratch cells.
+
+    The current MULMOD subtree is still at the program/spec scaffold stage,
+    so no concrete scratch cells have been assigned yet. The struct is kept
+    empty for now to establish the naming and parameter-passing convention
+    before `evm_mulmod` starts threading its 512-bit product / reduction
+    workspace through specs. -/
+structure MulModScratchpadLayout : Type where
+  deriving Repr
+
+/-- Validity bundle for `MulModScratchpadLayout`.
+
+    With zero fields there are no access-validity or disjointness obligations
+    yet. Future MULMOD slices should add named fields here, then extend
+    `Valid` with the corresponding `isValidDwordAccess` and disjointness
+    constraints rather than hardcoding offsets in specs. -/
+structure MulModScratchpadLayout.Valid (_L : MulModScratchpadLayout) : Prop where
+
+/-- Canonical MULMOD scratchpad layout.
+
+    Trivial while the layout has no fields; later slices should preserve this
+    name and fill it with the default offsets used by the assembled program. -/
+def canonicalMulModScratchpadLayout : MulModScratchpadLayout := {}
+
+/-- The canonical MULMOD scratchpad layout is valid. -/
+theorem canonicalMulModScratchpadLayout_valid :
+    canonicalMulModScratchpadLayout.Valid := {}
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add `MulModScratchpadLayout` with the canonical empty-layout shape used by scratchpad-parameterized opcode specs
- add `MulModScratchpadLayout.Valid` and `canonicalMulModScratchpadLayout_valid` so later MULMOD program/spec slices can thread layout parameters without hardcoded offsets
- import the new layout module from the MULMOD umbrella

## Verification
- `lake build EvmAsm.Evm64.MulMod.Layout`
- `lake build EvmAsm.Evm64.MulMod`
- `lake build`

Refs #91
Beads: evm-asm-m4wu