### PR TITLE
feat(call): add generic stack output bound

### DIFF
--- a/EvmAsm/EL/CallStackExecutionBridge.lean
+++ b/EvmAsm/EL/CallStackExecutionBridge.lean
@@ -579,6 +579,44 @@ theorem runCallStack?_delegatecall_outputBytes_length_le
           readByte isStatic args))
       args⟩
 
+theorem runCallStack?_outputBytes_length_le
+    {kind : CallKind} {state : WorldState} {caller callee : Address}
+    {apparentValue : Word256} {readByte : MemoryReader} {isStatic : Bool}
+    {executor : CallExecutor} {stackState : CallStackState} {out : CallStackResult}
+    (h_run :
+      runCallStack? kind state caller callee apparentValue readByte isStatic executor
+        stackState = some out) :
+    ∃ outputSize : Nat,
+      out.effects.outputBytes.length ≤ outputSize ∧
+        ((kind = .call ∧
+            ∃ args,
+              EvmAsm.Evm64.CallArgsStackDecode.decodeCallStack? stackState.stack =
+                some args ∧
+              outputSize = args.output.size.toNat) ∨
+          (kind = .staticcall ∧
+            ∃ args,
+              EvmAsm.Evm64.CallArgsStackDecode.decodeStaticCallStack?
+                  stackState.stack = some args ∧
+              outputSize = args.output.size.toNat) ∨
+          (kind = .delegatecall ∧
+            ∃ args,
+              EvmAsm.Evm64.CallArgsStackDecode.decodeDelegateCallStack?
+                  stackState.stack = some args ∧
+              outputSize = args.output.size.toNat)) := by
+  cases kind
+  · rcases runCallStack?_call_outputBytes_length_le h_run with
+      ⟨args, h_decode, h_le⟩
+    exact ⟨args.output.size.toNat, h_le,
+      Or.inl ⟨rfl, args, h_decode, rfl⟩⟩
+  · rcases runCallStack?_staticcall_outputBytes_length_le h_run with
+      ⟨args, h_decode, h_le⟩
+    exact ⟨args.output.size.toNat, h_le,
+      Or.inr <| Or.inl ⟨rfl, args, h_decode, rfl⟩⟩
+  · rcases runCallStack?_delegatecall_outputBytes_length_le h_run with
+      ⟨args, h_decode, h_le⟩
+    exact ⟨args.output.size.toNat, h_le,
+      Or.inr <| Or.inr ⟨rfl, args, h_decode, rfl⟩⟩
+
 theorem runCallStack?_stack_length
     {kind : CallKind} {state : WorldState} {caller callee : Address}
     {apparentValue : Word256} {readByte : MemoryReader} {isStatic : Bool}


### PR DESCRIPTION
## Summary
- add a kind-indexed runCallStack?_outputBytes_length_le bridge over CALL/STATICCALL/DELEGATECALL stack execution
- reuse the existing per-kind output-byte bound lemmas and expose the decoded output-size witness by kind

Refs GH #114
Refs beads: evm-asm-4o25v

## Verification
- lake build EvmAsm.EL.CallStackExecutionBridge
- lake build
- git diff --check
- forbidden proof escape scan on EvmAsm/EL/CallStackExecutionBridge.lean