### PR TITLE
feat(call): add stack rest length bridge

### DIFF
--- a/EvmAsm/EL/CallStackExecutionBridge.lean
+++ b/EvmAsm/EL/CallStackExecutionBridge.lean
@@ -182,6 +182,28 @@ theorem stackRestAfterCall?_delegatecall_none_of_five
         [gas, to, inputOffset, inputSize, outputOffset] =
       none := rfl
 
+theorem stackRestAfterCall?_length_of_some
+    {kind : CallKind} {stack rest : List EvmWord}
+    (h_rest : stackRestAfterCall? kind stack = some rest) :
+    stack.length = rest.length + EvmAsm.Evm64.CallArgs.argumentCount kind := by
+  cases kind
+  · rcases stack with
+      _ | ⟨_, _ | ⟨_, _ | ⟨_, _ | ⟨_, _ | ⟨_, _ | ⟨_, _ | ⟨_,
+          rest'⟩⟩⟩⟩⟩⟩⟩ <;>
+      simp [stackRestAfterCall?, EvmAsm.Evm64.CallArgs.argumentCount] at h_rest ⊢
+    cases h_rest
+    simp
+  · rcases stack with
+      _ | ⟨_, _ | ⟨_, _ | ⟨_, _ | ⟨_, _ | ⟨_, _ | ⟨_, rest'⟩⟩⟩⟩⟩⟩ <;>
+      simp [stackRestAfterCall?, EvmAsm.Evm64.CallArgs.argumentCount] at h_rest ⊢
+    cases h_rest
+    simp
+  · rcases stack with
+      _ | ⟨_, _ | ⟨_, _ | ⟨_, _ | ⟨_, _ | ⟨_, _ | ⟨_, rest'⟩⟩⟩⟩⟩⟩ <;>
+      simp [stackRestAfterCall?, EvmAsm.Evm64.CallArgs.argumentCount] at h_rest ⊢
+    cases h_rest
+    simp
+
 theorem runCallStack?_call
     (state : WorldState) (caller callee : Address) (apparentValue : Word256)
     (readByte : MemoryReader) (isStatic : Bool) (executor : CallExecutor)


### PR DESCRIPTION
## Summary
- add stackRestAfterCall?_length_of_some for CALL-family stack trimming
- prove successful stackRestAfterCall? removes exactly CallArgs.argumentCount kind words

Refs GH #114
Refs beads: evm-asm-1vg8l

## Verification
- lake build EvmAsm.EL.CallStackExecutionBridge
- lake build
- git diff --check
- forbidden proof escape scan on EvmAsm/EL/CallStackExecutionBridge.lean