### PR TITLE
feat(call): characterize stack rest underflow

### DIFF
--- a/EvmAsm/EL/CallStackExecutionBridge.lean
+++ b/EvmAsm/EL/CallStackExecutionBridge.lean
@@ -182,6 +182,22 @@ theorem stackRestAfterCall?_delegatecall_none_of_five
         [gas, to, inputOffset, inputSize, outputOffset] =
       none := rfl
 
+theorem stackRestAfterCall?_eq_none_iff
+    (kind : CallKind) (stack : List EvmWord) :
+    stackRestAfterCall? kind stack = none ↔
+      stack.length < EvmAsm.Evm64.CallArgs.argumentCount kind := by
+  cases kind
+  · rcases stack with
+      _ | ⟨_, _ | ⟨_, _ | ⟨_, _ | ⟨_, _ | ⟨_, _ | ⟨_, _ | ⟨_,
+          rest⟩⟩⟩⟩⟩⟩⟩ <;>
+      simp [stackRestAfterCall?, EvmAsm.Evm64.CallArgs.argumentCount]
+  · rcases stack with
+      _ | ⟨_, _ | ⟨_, _ | ⟨_, _ | ⟨_, _ | ⟨_, _ | ⟨_, rest⟩⟩⟩⟩⟩⟩ <;>
+      simp [stackRestAfterCall?, EvmAsm.Evm64.CallArgs.argumentCount]
+  · rcases stack with
+      _ | ⟨_, _ | ⟨_, _ | ⟨_, _ | ⟨_, _ | ⟨_, _ | ⟨_, rest⟩⟩⟩⟩⟩⟩ <;>
+      simp [stackRestAfterCall?, EvmAsm.Evm64.CallArgs.argumentCount]
+
 theorem runCallStack?_call
     (state : WorldState) (caller callee : Address) (apparentValue : Word256)
     (readByte : MemoryReader) (isStatic : Bool) (executor : CallExecutor)


### PR DESCRIPTION
## Summary
- add stackRestAfterCall?_eq_none_iff for CALL-family stack trimming
- characterize stack-rest failure as stack.length below CallArgs.argumentCount kind

Refs GH #114
Refs beads: evm-asm-xth1p

## Verification
- lake build EvmAsm.EL.CallStackExecutionBridge
- lake build
- git diff --check
- forbidden proof escape scan on EvmAsm/EL/CallStackExecutionBridge.lean