### PR TITLE
feat(call): add visible output source bound

### DIFF
--- a/EvmAsm/EL/CallResultEffectsBridge.lean
+++ b/EvmAsm/EL/CallResultEffectsBridge.lean
@@ -45,6 +45,12 @@ theorem callVisibleEffects_output_length_le_range
     (callVisibleEffects result outputRange).outputBytes.length ≤ outputRange.size.toNat := by
   exact CallOutputBridge.copiedOutputForRange_length_le_range result outputRange
 
+theorem callVisibleEffects_output_length_le_output
+    (result : CallResult) (outputRange : MemoryRange) :
+    (callVisibleEffects result outputRange).outputBytes.length ≤
+      (MessageCallExecution.propagatedOutput result).length := by
+  exact CallOutputBridge.copiedOutputForRange_length_le_output result outputRange
+
 theorem callVisibleEffects_success
     (state : WorldState) (output : List Byte) (gasRemaining : Nat)
     (outputRange : MemoryRange) :


### PR DESCRIPTION
## Summary
- add callVisibleEffects_output_length_le_output for CALL-family visible effects
- prove copied caller-visible output bytes are bounded by propagated message-call output length

Refs GH #114
Refs beads: evm-asm-oqorr

## Verification
- lake build EvmAsm.EL.CallResultEffectsBridge
- lake build
- git diff --check
- forbidden proof escape scan on EvmAsm/EL/CallResultEffectsBridge.lean