### PR TITLE
feat(el): add CALL stack zero-flag bridges

### DIFF
--- a/EvmAsm/EL/CallStackBridge.lean
+++ b/EvmAsm/EL/CallStackBridge.lean
@@ -62,6 +62,17 @@ theorem callStackResult_get_zero_eq_one_iff (result : CallResult) :
   simpa [callStackResult]
     using CallOutputBridge.callResultSuccessFlag_eq_one_iff result
 
+theorem callStackResult_head_eq_zero_iff (result : CallResult) :
+    (callStackResult result).head? = some 0 ↔ result.status ≠ .success := by
+  cases result with
+  | mk status state output gasRemaining =>
+      cases status <;> simp [callStackResult, CallOutputBridge.callResultSuccessFlag]
+
+theorem callStackResult_get_zero_eq_zero_iff (result : CallResult) :
+    (callStackResult result)[0]? = some 0 ↔ result.status ≠ .success := by
+  simpa [callStackResult]
+    using CallOutputBridge.callResultSuccessFlag_eq_zero_iff result
+
 end CallStackBridge
 
 end EvmAsm.EL


### PR DESCRIPTION
## Summary
- add `callStackResult_head_eq_zero_iff` for CALL-family stack result success flags
- add the matching index-0 bridge via `callResultSuccessFlag_eq_zero_iff`

Refs GH #114
Beads: evm-asm-4ltgq

## Verification
- lake build EvmAsm.EL.CallStackBridge
- lake build
- git diff --check