### PR TITLE
feat(calldata): fold load output into evmWordIs

### DIFF
--- a/EvmAsm/Evm64/Calldata/LoadStackCode.lean
+++ b/EvmAsm/Evm64/Calldata/LoadStackCode.lean
@@ -351,6 +351,55 @@ theorem getLimbN_calldataLoadWindowOutputWordFromArgs_3
 
 /--
 Fold the four MLOAD-style packed output limbs produced by the CALLDATALOAD
+window core into the EVM word selected by decoded calldata arguments.
+
+Distinctive token:
+Calldata.LoadStackCode.calldataLoadWindowOutputWordFromArgs_evmWordIs_fold #104.
+-/
+theorem calldataLoadWindowOutputWordFromArgs_evmWordIs_fold
+    (sp : Word) (data : List (BitVec 8)) (args : CallDataLoadArgs.Args) :
+    ((sp ↦ₘ mloadPackedLimb
+        (CallDataLoadArgs.windowByteFromArgs data args 24)
+        (CallDataLoadArgs.windowByteFromArgs data args 25)
+        (CallDataLoadArgs.windowByteFromArgs data args 26)
+        (CallDataLoadArgs.windowByteFromArgs data args 27)
+        (CallDataLoadArgs.windowByteFromArgs data args 28)
+        (CallDataLoadArgs.windowByteFromArgs data args 29)
+        (CallDataLoadArgs.windowByteFromArgs data args 30)
+        (CallDataLoadArgs.windowByteFromArgs data args 31)) **
+      ((sp + 8) ↦ₘ mloadPackedLimb
+        (CallDataLoadArgs.windowByteFromArgs data args 16)
+        (CallDataLoadArgs.windowByteFromArgs data args 17)
+        (CallDataLoadArgs.windowByteFromArgs data args 18)
+        (CallDataLoadArgs.windowByteFromArgs data args 19)
+        (CallDataLoadArgs.windowByteFromArgs data args 20)
+        (CallDataLoadArgs.windowByteFromArgs data args 21)
+        (CallDataLoadArgs.windowByteFromArgs data args 22)
+        (CallDataLoadArgs.windowByteFromArgs data args 23)) **
+      ((sp + 16) ↦ₘ mloadPackedLimb
+        (CallDataLoadArgs.windowByteFromArgs data args 8)
+        (CallDataLoadArgs.windowByteFromArgs data args 9)
+        (CallDataLoadArgs.windowByteFromArgs data args 10)
+        (CallDataLoadArgs.windowByteFromArgs data args 11)
+        (CallDataLoadArgs.windowByteFromArgs data args 12)
+        (CallDataLoadArgs.windowByteFromArgs data args 13)
+        (CallDataLoadArgs.windowByteFromArgs data args 14)
+        (CallDataLoadArgs.windowByteFromArgs data args 15)) **
+      ((sp + 24) ↦ₘ mloadPackedLimb
+        (CallDataLoadArgs.windowByteFromArgs data args 0)
+        (CallDataLoadArgs.windowByteFromArgs data args 1)
+        (CallDataLoadArgs.windowByteFromArgs data args 2)
+        (CallDataLoadArgs.windowByteFromArgs data args 3)
+        (CallDataLoadArgs.windowByteFromArgs data args 4)
+        (CallDataLoadArgs.windowByteFromArgs data args 5)
+        (CallDataLoadArgs.windowByteFromArgs data args 6)
+        (CallDataLoadArgs.windowByteFromArgs data args 7))) =
+    evmWordIs sp (calldataLoadWindowOutputWordFromArgs data args) := by
+  unfold calldataLoadWindowOutputWordFromArgs
+  rw [mloadLoadedWordFromBytes_evmWordIs_fold]
+
+/--
+Fold the four MLOAD-style packed output limbs produced by the CALLDATALOAD
 window core into the EVM stack word selected by decoded calldata arguments.
 -/
 theorem calldataLoadWindowOutputWordFromArgs_evmStackIs_fold


### PR DESCRIPTION
## Summary
- add `calldataLoadWindowOutputWordFromArgs_evmWordIs_fold`
- reuse the MLOAD byte-window `evmWordIs` fold for CALLDATALOAD output limbs

Refs GH #104
Beads: evm-asm-gerig

## Verification
- lake build EvmAsm.Evm64.Calldata.LoadStackCode
- lake build
- git diff --check