### PR TITLE
feat(call): add visible zero-head bridges

### DIFF
--- a/EvmAsm/EL/CallExecutionBridge.lean
+++ b/EvmAsm/EL/CallExecutionBridge.lean
@@ -136,6 +136,27 @@ theorem delegateCallVisibleEffectsFromResult_stack_head_eq_one_iff
   exact CallResultEffectsBridge.callVisibleEffects_stack_head_eq_one_iff
     result (CallArgsBridge.delegateCallOutputRange args)
 
+theorem callVisibleEffectsFromResult_stack_head_eq_zero_iff
+    (result : CallResult) (args : CallArgs) :
+    (callVisibleEffectsFromResult result args).stackWords.head? = some 0 ↔
+      result.status ≠ .success := by
+  exact CallResultEffectsBridge.callVisibleEffects_stack_head_eq_zero_iff
+    result (CallArgsBridge.callOutputRange args)
+
+theorem staticCallVisibleEffectsFromResult_stack_head_eq_zero_iff
+    (result : CallResult) (args : StaticCallArgs) :
+    (staticCallVisibleEffectsFromResult result args).stackWords.head? = some 0 ↔
+      result.status ≠ .success := by
+  exact CallResultEffectsBridge.callVisibleEffects_stack_head_eq_zero_iff
+    result (CallArgsBridge.staticCallOutputRange args)
+
+theorem delegateCallVisibleEffectsFromResult_stack_head_eq_zero_iff
+    (result : CallResult) (args : DelegateCallArgs) :
+    (delegateCallVisibleEffectsFromResult result args).stackWords.head? = some 0 ↔
+      result.status ≠ .success := by
+  exact CallResultEffectsBridge.callVisibleEffects_stack_head_eq_zero_iff
+    result (CallArgsBridge.delegateCallOutputRange args)
+
 theorem callVisibleEffectsFromResult_output_length_le
     (result : CallResult) (args : CallArgs) :
     (callVisibleEffectsFromResult result args).outputBytes.length ≤ args.output.size.toNat := by

--- a/EvmAsm/EL/CallResultEffectsBridge.lean
+++ b/EvmAsm/EL/CallResultEffectsBridge.lean
@@ -84,6 +84,13 @@ theorem callVisibleEffects_stack_head_eq_one_iff
   simpa [callVisibleEffects] using
     CallStackBridge.callStackResult_head_eq_one_iff result
 
+theorem callVisibleEffects_stack_head_eq_zero_iff
+    (result : CallResult) (outputRange : MemoryRange) :
+    (callVisibleEffects result outputRange).stackWords.head? = some 0 ↔
+      result.status ≠ .success := by
+  simpa [callVisibleEffects] using
+    CallStackBridge.callStackResult_head_eq_zero_iff result
+
 end CallResultEffectsBridge
 
 end EvmAsm.EL


### PR DESCRIPTION
## Summary
- add `callVisibleEffects_stack_head_eq_zero_iff`
- add CALL, STATICCALL, and DELEGATECALL visible-effects zero-head wrappers

Refs GH #114
Beads: evm-asm-luk4j

## Verification
- lake build EvmAsm.EL.CallExecutionBridge
- lake build
- git diff --check