### PR TITLE
feat(storage): add SLOAD underflow conformance vector

### DIFF
--- a/EvmAsm/EL/Conformance/All.lean
+++ b/EvmAsm/EL/Conformance/All.lean
@@ -44,11 +44,11 @@ def allConformanceVectorCount : Nat :=
   allConformanceVectors.length
 
 theorem allConformanceVectors_length :
-    allConformanceVectors.length = 46 := by
+    allConformanceVectors.length = 47 := by
   native_decide
 
 theorem allConformanceVectorCount_eq :
-    allConformanceVectorCount = 46 := by
+    allConformanceVectorCount = 47 := by
   native_decide
 
 def unexpectedConformanceFailures : List CheckResult :=
@@ -101,7 +101,7 @@ theorem unexpectedConformanceFailureCount_eq_zero :
   simp [unexpectedConformanceFailureCount, unexpectedConformanceFailures_empty]
 
 theorem expectedConformanceErrorCount_eq :
-    expectedConformanceErrorCount = 9 := by
+    expectedConformanceErrorCount = 10 := by
   native_decide
 
 end Conformance

--- a/EvmAsm/EL/Conformance/All.lean
+++ b/EvmAsm/EL/Conformance/All.lean
@@ -44,11 +44,11 @@ def allConformanceVectorCount : Nat :=
   allConformanceVectors.length
 
 theorem allConformanceVectors_length :
-    allConformanceVectors.length = 45 := by
+    allConformanceVectors.length = 46 := by
   native_decide
 
 theorem allConformanceVectorCount_eq :
-    allConformanceVectorCount = 45 := by
+    allConformanceVectorCount = 46 := by
   native_decide
 
 def unexpectedConformanceFailures : List CheckResult :=

--- a/EvmAsm/EL/Conformance/StorageStackExecution.lean
+++ b/EvmAsm/EL/Conformance/StorageStackExecution.lean
@@ -66,6 +66,19 @@ def storageSstoreUnderflowConformanceVector :
         stackState := { stack := [7] } }
     expected := .error "stack-underflow" }
 
+/-- SLOAD requires a slot stack operand.
+    Distinctive token: storageSloadUnderflowConformanceVector #110 #125. -/
+def storageSloadUnderflowConformanceVector :
+    TestVector StorageStackInput StorageStackState :=
+  { id := "storage-stack-sload-underflow"
+    input :=
+      { kind := .sload
+        world := WorldState.empty
+        accesses := []
+        address := 0x1234
+        stackState := { stack := [] } }
+    expected := .error "stack-underflow" }
+
 /-- Storage stack conformance inputs as reusable test vectors.
     Distinctive token:
     StorageStackExecutionConformance.storageStackConformanceTestVectors #110 #125. -/
@@ -74,23 +87,25 @@ def storageStackConformanceTestVectors :
   [ storageStackSloadVector
   , storageStackSstoreVector
   , storageSstoreUnderflowConformanceVector
+  , storageSloadUnderflowConformanceVector
   ]
 
 def storageStackConformanceVectorIds : List String :=
   storageStackConformanceTestVectors.map TestVector.id
 
 theorem storageStackConformanceTestVectors_length :
-    storageStackConformanceTestVectors.length = 3 := rfl
+    storageStackConformanceTestVectors.length = 4 := rfl
 
 theorem storageStackConformanceVectorIds_eq :
     storageStackConformanceVectorIds =
       [ "storage-stack-sload"
       , "storage-stack-sstore"
       , "storage-stack-sstore-underflow"
+      , "storage-stack-sload-underflow"
       ] := rfl
 
 theorem storageStackConformanceVectorIds_length :
-    storageStackConformanceVectorIds.length = 3 := rfl
+    storageStackConformanceVectorIds.length = 4 := rfl
 
 theorem storageStackConformanceVectorIds_nodup :
     storageStackConformanceVectorIds.Nodup := by
@@ -161,6 +176,28 @@ theorem storageSstoreUnderflowConformanceVector_errored :
       stackState := { stack := [(7 : EvmWord)] } }
     runStorageStack?_sstore_underflow
 
+theorem runStorageStack?_sload_underflow :
+    runStorageStack?
+      { kind := .sload
+        world := WorldState.empty
+        accesses := []
+        address := (0x1234 : Address)
+        stackState := { stack := [] } } =
+      none := rfl
+
+theorem storageSloadUnderflowConformanceVector_errored :
+    checkVector? runStorageStack? storageSloadUnderflowConformanceVector =
+      .errored "storage-stack-sload-underflow" "stack-underflow" :=
+  checkVector?_none_error runStorageStack?
+    "storage-stack-sload-underflow"
+    "stack-underflow"
+    { kind := .sload
+      world := WorldState.empty
+      accesses := []
+      address := (0x1234 : Address)
+      stackState := { stack := [] } }
+    runStorageStack?_sload_underflow
+
 /-- Compact checked-vector batch for storage stack execution.
     Distinctive token:
     StorageStackExecutionConformance.storageStackConformanceVectors #110 #125. -/
@@ -169,10 +206,15 @@ def storageStackConformanceVectors : List CheckResult :=
 
 theorem storageStackConformanceVectors_passed :
     storageStackConformanceVectors =
-      [.passed, .passed, .errored "storage-stack-sstore-underflow" "stack-underflow"] := by
+      [ .passed
+      , .passed
+      , .errored "storage-stack-sstore-underflow" "stack-underflow"
+      , .errored "storage-stack-sload-underflow" "stack-underflow"
+      ] := by
   simp [storageStackConformanceVectors, storageStackConformanceTestVectors,
     storageStackSloadVector_passed, storageStackSstoreVector_passed,
-    storageSstoreUnderflowConformanceVector_errored]
+    storageSstoreUnderflowConformanceVector_errored,
+    storageSloadUnderflowConformanceVector_errored]
 
 end StorageStackExecution
 end Conformance


### PR DESCRIPTION
Mirrors `storageSstoreUnderflowConformanceVector` with an SLOAD-on-empty-stack vector in `EvmAsm/EL/Conformance/StorageStackExecution.lean`. Wires `storageSloadUnderflowConformanceVector` into the test-vector list and updates the length/id/batch theorems plus the aggregate count in `EvmAsm/EL/Conformance/All.lean`.

Distinctive token: `storageSloadUnderflowConformanceVector` #110 #125.

Refs GH #110, #125. Beads: `evm-asm-1qdyd` (parent `evm-asm-8zv5`).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).