### PR TITLE
feat(conformance): expose aggregate failure gate

### DIFF
--- a/EvmAsm/EL/Conformance/All.lean
+++ b/EvmAsm/EL/Conformance/All.lean
@@ -58,6 +58,9 @@ def unexpectedConformanceFailures : List CheckResult :=
       | .failed _ => true
       | _ => false)
 
+def allConformanceNoUnexpectedFailures : Bool :=
+  unexpectedConformanceFailures.isEmpty
+
 theorem unexpectedConformanceFailures_empty :
     unexpectedConformanceFailures = [] := by
   simp [unexpectedConformanceFailures, allConformanceVectors,
@@ -75,6 +78,10 @@ theorem unexpectedConformanceFailures_empty :
     SignedArithmeticStackExecution.signedArithmeticConformanceVectors_passed,
     StorageStackExecution.storageStackConformanceVectors_passed,
     TerminatingStackExecution.terminatingStackConformanceVectors_passed]
+
+theorem allConformanceNoUnexpectedFailures_eq_true :
+    allConformanceNoUnexpectedFailures = true := by
+  simp [allConformanceNoUnexpectedFailures, unexpectedConformanceFailures_empty]
 
 end Conformance
 end EvmAsm.EL


### PR DESCRIPTION
## Summary
- add `allConformanceNoUnexpectedFailures` as a reusable boolean over the aggregate failure filter
- prove the gate evaluates to true from the existing `unexpectedConformanceFailures_empty` theorem

Refs GH #125
Beads: evm-asm-x24nf

## Verification
- lake build EvmAsm.EL.Conformance.All
- lake build
- git diff --check