### PR TITLE
feat(handlers): add dispatch state projections

### DIFF
--- a/EvmAsm/Evm64/HandlerTable.lean
+++ b/EvmAsm/Evm64/HandlerTable.lean
@@ -150,6 +150,24 @@ theorem dispatchOpcode_some_status {table : HandlerTable} {opcode : EvmOpcode}
     (dispatchOpcode table opcode state).status = (handler state).status := by
   rw [dispatchOpcode_some h_lookup state]
 
+theorem dispatchOpcode_some_pc {table : HandlerTable} {opcode : EvmOpcode}
+    {handler : OpcodeHandler} (h_lookup : table opcode = some handler)
+    (state : EvmState) :
+    (dispatchOpcode table opcode state).pc = (handler state).pc := by
+  rw [dispatchOpcode_some h_lookup state]
+
+theorem dispatchOpcode_some_gas {table : HandlerTable} {opcode : EvmOpcode}
+    {handler : OpcodeHandler} (h_lookup : table opcode = some handler)
+    (state : EvmState) :
+    (dispatchOpcode table opcode state).gas = (handler state).gas := by
+  rw [dispatchOpcode_some h_lookup state]
+
+theorem dispatchOpcode_some_stack {table : HandlerTable} {opcode : EvmOpcode}
+    {handler : OpcodeHandler} (h_lookup : table opcode = some handler)
+    (state : EvmState) :
+    (dispatchOpcode table opcode state).stack = (handler state).stack := by
+  rw [dispatchOpcode_some h_lookup state]
+
 theorem dispatchOpcode_some_preserves_status
     {table : HandlerTable} {opcode : EvmOpcode} {handler : OpcodeHandler}
     (h_lookup : table opcode = some handler)


### PR DESCRIPTION
## Summary
- add generic `dispatchOpcode_some_pc`
- add matching gas and stack projections for handler-table dispatch hits

Refs GH #107
Beads: evm-asm-o1k0v

## Verification
- lake build EvmAsm.Evm64.HandlerTable
- lake build
- git diff --check