### PR TITLE
feat(keccak): add stack head projection

### DIFF
--- a/EvmAsm/EL/KeccakStackExecutionBridge.lean
+++ b/EvmAsm/EL/KeccakStackExecutionBridge.lean
@@ -306,6 +306,24 @@ theorem runKeccakStack?_tail_eq_drop
     ⟨offset, size, rest, rfl, rfl⟩
   simp
 
+theorem runKeccakStack?_head_eq_of_some
+    {accelerator : Accelerator} {memory : MemoryReader}
+    {stack out : List EvmWord}
+    (h_run : runKeccakStack? accelerator memory stack = some out) :
+    ∃ offset size rest,
+      stack = offset :: size :: rest ∧
+        out.head? =
+          some
+            (KeccakResultBridge.stackWordFromAcceleratorOutput
+              (accelerator
+                (KeccakInputBridge.acceleratorInputFromArgs memory
+                  (EvmAsm.Evm64.KeccakArgs.keccakArgs offset size)))) := by
+  rcases (runKeccakStack?_eq_some_iff accelerator memory stack out).mp h_run with
+    ⟨offset, size, rest, h_stack, h_out⟩
+  subst stack
+  subst out
+  exact ⟨offset, size, rest, rfl, rfl⟩
+
 theorem runKeccakStack?_head?
     (accelerator : Accelerator) (memory : MemoryReader)
     (offset size : EvmWord) (rest : List EvmWord) :


### PR DESCRIPTION
## Summary
- add `runKeccakStack?_head_eq_of_some`
- characterize the pushed hash word for arbitrary successful KECCAK stack execution

Refs GH #111
Beads: evm-asm-g3e88

## Verification
- lake build EvmAsm.EL.KeccakStackExecutionBridge
- lake build
- git diff --check