### PR TITLE
feat(conformance): count unexpected failures

### DIFF
--- a/EvmAsm/EL/Conformance/All.lean
+++ b/EvmAsm/EL/Conformance/All.lean
@@ -61,6 +61,9 @@ def unexpectedConformanceFailures : List CheckResult :=
 def allConformanceNoUnexpectedFailures : Bool :=
   unexpectedConformanceFailures.isEmpty
 
+def unexpectedConformanceFailureCount : Nat :=
+  unexpectedConformanceFailures.length
+
 theorem unexpectedConformanceFailures_empty :
     unexpectedConformanceFailures = [] := by
   simp [unexpectedConformanceFailures, allConformanceVectors,
@@ -82,6 +85,10 @@ theorem unexpectedConformanceFailures_empty :
 theorem allConformanceNoUnexpectedFailures_eq_true :
     allConformanceNoUnexpectedFailures = true := by
   simp [allConformanceNoUnexpectedFailures, unexpectedConformanceFailures_empty]
+
+theorem unexpectedConformanceFailureCount_eq_zero :
+    unexpectedConformanceFailureCount = 0 := by
+  simp [unexpectedConformanceFailureCount, unexpectedConformanceFailures_empty]
 
 end Conformance
 end EvmAsm.EL


### PR DESCRIPTION
## Summary
- add unexpectedConformanceFailureCount as a Nat metric for the aggregate GH #125 conformance batch
- prove the current unexpected failure count is zero from the existing empty-failure theorem

Refs GH #125.
Refs beads: evm-asm-sxou.

## Verification
- lake build EvmAsm.EL.Conformance.All
- lake build
- git diff --check
- rg -n "set_option maxHeartbeats|set_option maxRecDepth|sorry|admit" EvmAsm/EL/Conformance/All.lean