### PR TITLE
feat(handlers): add loop state projections

### DIFF
--- a/EvmAsm/Evm64/HandlerLoopSimulationBridge.lean
+++ b/EvmAsm/Evm64/HandlerLoopSimulationBridge.lean
@@ -72,6 +72,36 @@ theorem loopFuel_table_matchesSpec_at_status
       (InterpreterLoop.loopFuel spec nSteps state).status := by
   rw [loopFuel_table_matchesSpec_at table spec h_dispatch nSteps state]
 
+theorem loopFuel_table_matchesSpec_at_pc
+    (table : HandlerTable) (spec : InterpreterLoop.Handler)
+    (h_dispatch : ∀ (opcode : EvmOpcode) (state : EvmState),
+      InterpreterLoop.decodeCurrentOpcode? state = some opcode →
+        HandlerTable.dispatchOpcode table opcode state = spec opcode state)
+    (nSteps : Nat) (state : EvmState) :
+    (InterpreterLoop.loopFuel (HandlerLoopBridge.toLoopHandler table) nSteps state).pc =
+      (InterpreterLoop.loopFuel spec nSteps state).pc := by
+  rw [loopFuel_table_matchesSpec_at table spec h_dispatch nSteps state]
+
+theorem loopFuel_table_matchesSpec_at_gas
+    (table : HandlerTable) (spec : InterpreterLoop.Handler)
+    (h_dispatch : ∀ (opcode : EvmOpcode) (state : EvmState),
+      InterpreterLoop.decodeCurrentOpcode? state = some opcode →
+        HandlerTable.dispatchOpcode table opcode state = spec opcode state)
+    (nSteps : Nat) (state : EvmState) :
+    (InterpreterLoop.loopFuel (HandlerLoopBridge.toLoopHandler table) nSteps state).gas =
+      (InterpreterLoop.loopFuel spec nSteps state).gas := by
+  rw [loopFuel_table_matchesSpec_at table spec h_dispatch nSteps state]
+
+theorem loopFuel_table_matchesSpec_at_stack
+    (table : HandlerTable) (spec : InterpreterLoop.Handler)
+    (h_dispatch : ∀ (opcode : EvmOpcode) (state : EvmState),
+      InterpreterLoop.decodeCurrentOpcode? state = some opcode →
+        HandlerTable.dispatchOpcode table opcode state = spec opcode state)
+    (nSteps : Nat) (state : EvmState) :
+    (InterpreterLoop.loopFuel (HandlerLoopBridge.toLoopHandler table) nSteps state).stack =
+      (InterpreterLoop.loopFuel spec nSteps state).stack := by
+  rw [loopFuel_table_matchesSpec_at table spec h_dispatch nSteps state]
+
 /--
 Handler-table dispatch agreement also preserves the decoded opcode trace.
 


### PR DESCRIPTION
## Summary
- add PC, gas, and stack projection companions for table-backed loop/spec equality
- keep the existing handler table simulation theorem as the single proof source via rewriting

Refs GH #109 and GH #107.
Refs beads: evm-asm-fyia, evm-asm-jaeo.

## Verification
- lake build EvmAsm.Evm64.HandlerLoopSimulationBridge
- lake build
- git diff --check
- rg -n "set_option maxHeartbeats|set_option maxRecDepth|sorry|admit" EvmAsm/Evm64/HandlerLoopSimulationBridge.lean