### PR TITLE
feat(conformance): count expected errors

### DIFF
--- a/EvmAsm/EL/Conformance/All.lean
+++ b/EvmAsm/EL/Conformance/All.lean
@@ -64,6 +64,16 @@ def allConformanceNoUnexpectedFailures : Bool :=
 def unexpectedConformanceFailureCount : Nat :=
   unexpectedConformanceFailures.length
 
+def expectedConformanceErrors : List CheckResult :=
+  allConformanceVectors.filter
+    (fun result =>
+      match result with
+      | .errored _ _ => true
+      | _ => false)
+
+def expectedConformanceErrorCount : Nat :=
+  expectedConformanceErrors.length
+
 theorem unexpectedConformanceFailures_empty :
     unexpectedConformanceFailures = [] := by
   simp [unexpectedConformanceFailures, allConformanceVectors,
@@ -89,6 +99,10 @@ theorem allConformanceNoUnexpectedFailures_eq_true :
 theorem unexpectedConformanceFailureCount_eq_zero :
     unexpectedConformanceFailureCount = 0 := by
   simp [unexpectedConformanceFailureCount, unexpectedConformanceFailures_empty]
+
+theorem expectedConformanceErrorCount_eq :
+    expectedConformanceErrorCount = 9 := by
+  native_decide
 
 end Conformance
 end EvmAsm.EL


### PR DESCRIPTION
## Summary
- add expectedConformanceErrors and expectedConformanceErrorCount for the aggregate GH #125 conformance batch
- prove the current aggregate includes 9 expected-error vectors, separate from unexpected failures

Refs GH #125.
Refs beads: evm-asm-sxou.

## Verification
- lake build EvmAsm.EL.Conformance.All
- lake build
- git diff --check
- rg -n "set_option maxHeartbeats|set_option maxRecDepth|sorry|admit" EvmAsm/EL/Conformance/All.lean