### PR TITLE
feat(rlp): bridge empty-list decode vector through decodeFully

### DIFF
--- a/EvmAsm/EL/Conformance/RLPFullDecodeBridge.lean
+++ b/EvmAsm/EL/Conformance/RLPFullDecodeBridge.lean
@@ -51,6 +51,19 @@ theorem rlpNoncanonicalSingletonVector_errored_via_decodeFully :
   rw [← checkVector?_runDecodeFully_eq_decodeFully]
   exact RLP.rlpNoncanonicalSingletonVector_errored
 
+/--
+Bridge the empty-list RLP decode conformance vector through the reusable
+top-level full-decode wrapper, mirroring the nested-list and
+noncanonical-singleton bridges above.
+
+Distinctive token: rlpEmptyListDecodeVector_passed_via_decodeFully #120 #125.
+-/
+theorem rlpEmptyListDecodeVector_passed_via_decodeFully :
+    checkVector? (fun input => EvmAsm.EL.RLP.decodeFully input.bytes)
+        RLP.rlpEmptyListDecodeVector = .passed := by
+  rw [← checkVector?_runDecodeFully_eq_decodeFully]
+  exact RLP.rlpEmptyListDecodeVector_passed
+
 end RLPConformanceFullDecodeBridge
 end Conformance
 end EvmAsm.EL


### PR DESCRIPTION
Mirrors the nested-list and noncanonical-singleton bridges in `EvmAsm/EL/Conformance/RLPFullDecodeBridge.lean` by adding `rlpEmptyListDecodeVector_passed_via_decodeFully`, routing the empty-list RLP conformance vector through the reusable top-level `EvmAsm.EL.RLP.decodeFully` wrapper.

Refs GH #125 / GH #120; beads evm-asm-uq1na.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).