### PR TITLE
feat(rlp): bridge long-bytes vector to decodeFully

### DIFF
--- a/EvmAsm/EL/Conformance/RLPFullDecodeBridge.lean
+++ b/EvmAsm/EL/Conformance/RLPFullDecodeBridge.lean
@@ -51,6 +51,12 @@ theorem rlpNoncanonicalSingletonVector_errored_via_decodeFully :
   rw [← checkVector?_runDecodeFully_eq_decodeFully]
   exact RLP.rlpNoncanonicalSingletonVector_errored
 
+theorem rlpLongBytesDecodeVector_passed_via_decodeFully :
+    checkVector? (fun input => EvmAsm.EL.RLP.decodeFully input.bytes)
+        RLP.rlpLongBytesDecodeVector = .passed := by
+  rw [← checkVector?_runDecodeFully_eq_decodeFully]
+  exact RLP.rlpLongBytesDecodeVector_passed
+
 end RLPConformanceFullDecodeBridge
 end Conformance
 end EvmAsm.EL


### PR DESCRIPTION
## Summary
- add the RLP full-decode bridge theorem for the existing long-bytes conformance vector
- reuse the generic checkVector runner equality, matching the existing nested-list and noncanonical-singleton bridge pattern

Refs GH #125.
Refs GH #120.
Beads: evm-asm-47056.

## Verification
- lake build EvmAsm.EL.Conformance.RLPFullDecodeBridge
- lake build
- git diff --check
- forbidden option/proof-escape scan on EvmAsm/EL/Conformance/RLPFullDecodeBridge.lean (no matches)