### PR TITLE
feat(call): add output conformance vector IDs

### DIFF
--- a/EvmAsm/EL/Conformance/Call.lean
+++ b/EvmAsm/EL/Conformance/Call.lean
@@ -118,18 +118,44 @@ theorem callOutputFailureVector_passed :
     []
     runCallOutput_failure
 
+/-- Test-vector surface for CALL output bridge helpers.
+    Distinctive token: Call.callOutputConformanceVectorIds #125 #114. -/
+def callOutputConformanceTestVectors : List (TestVector CallOutputInput (List Byte)) :=
+  [ callOutputClipVector
+  , callOutputZeroSizeVector
+  , callOutputFailureVector
+  ]
+
+def callOutputConformanceVectorIds : List String :=
+  callOutputConformanceTestVectors.map TestVector.id
+
+theorem callOutputConformanceTestVectors_length :
+    callOutputConformanceTestVectors.length = 3 := rfl
+
+theorem callOutputConformanceVectorIds_eq :
+    callOutputConformanceVectorIds =
+      [ "call-output-clip"
+      , "call-output-zero-size"
+      , "call-output-failure-empty"
+      ] := rfl
+
+theorem callOutputConformanceVectorIds_length :
+    callOutputConformanceVectorIds.length = 3 := rfl
+
+theorem callOutputConformanceVectorIds_nodup :
+    callOutputConformanceVectorIds.Nodup := by
+  decide
+
 /-- Compact checked-vector batch for CALL output bridge helpers.
     Distinctive token: Call.callOutputConformanceVectors #125 #114. -/
 def callOutputConformanceVectors : List CheckResult :=
-  [ checkVector runCallOutput callOutputClipVector
-  , checkVector runCallOutput callOutputZeroSizeVector
-  , checkVector runCallOutput callOutputFailureVector
-  ]
+  callOutputConformanceTestVectors.map (checkVector runCallOutput)
 
 theorem callOutputConformanceVectors_passed :
     callOutputConformanceVectors = [.passed, .passed, .passed] := by
-  simp [callOutputConformanceVectors, callOutputClipVector_passed,
-    callOutputZeroSizeVector_passed, callOutputFailureVector_passed]
+  simp [callOutputConformanceVectors, callOutputConformanceTestVectors,
+    callOutputClipVector_passed, callOutputZeroSizeVector_passed,
+    callOutputFailureVector_passed]
 
 end Call
 end Conformance


### PR DESCRIPTION
## Summary
- add the CALL output conformance test-vector list and vector ID list
- prove length, exact IDs, and nodup invariants
- derive the checked-result batch by mapping over the test-vector list

Refs GH #125.
Refs GH #114.
Beads: evm-asm-cs3g8.

## Verification
- lake build EvmAsm.EL.Conformance.Call
- lake build
- git diff --check
- forbidden option/proof-escape scan on EvmAsm/EL/Conformance/Call.lean (no matches)