### PR TITLE
feat(code): add conformance vector IDs

### DIFF
--- a/EvmAsm/EL/Conformance/Code.lean
+++ b/EvmAsm/EL/Conformance/Code.lean
@@ -122,6 +122,28 @@ theorem codeCopyStackUnderflowVector_errored :
       stack := [(64 : EvmWord), (1 : EvmWord)] }
     runCodeCopyStack_underflow
 
+/-- Vector IDs for code executable-helper conformance coverage.
+    Distinctive token: codeConformanceVectorIds #125 #107 #118. -/
+def codeConformanceVectorIds : List String :=
+  [ codeCopyZeroPadVector.id
+  , codeCopyStackVector.id
+  , codeCopyStackUnderflowVector.id
+  ]
+
+theorem codeConformanceVectorIds_eq :
+    codeConformanceVectorIds =
+      [ "codecopy-zero-pad"
+      , "codecopy-stack-decode"
+      , "codecopy-stack-underflow"
+      ] := rfl
+
+theorem codeConformanceVectorIds_length :
+    codeConformanceVectorIds.length = 3 := rfl
+
+theorem codeConformanceVectorIds_nodup :
+    codeConformanceVectorIds.Nodup := by
+  decide
+
 /-- Compact checked-vector batch for code executable helpers.
     Distinctive token: codeConformanceVectors #125 #107 #118. -/
 def codeConformanceVectors : List CheckResult :=


### PR DESCRIPTION
## Summary
- add CODECOPY conformance vector ID bookkeeping
- prove exact IDs, count, and nodup invariants for the existing code conformance vectors

Refs GH #125.
Refs GH #107.
Refs GH #118.
Beads: evm-asm-sjo3c.

## Verification
- lake build EvmAsm.EL.Conformance.Code
- lake build
- git diff --check
- forbidden option/proof-escape scan on EvmAsm/EL/Conformance/Code.lean (no matches)