### PR TITLE
feat(handlers): add step memory/code/env projections

### DIFF
--- a/EvmAsm/Evm64/HandlerLoopSimulationBridge.lean
+++ b/EvmAsm/Evm64/HandlerLoopSimulationBridge.lean
@@ -52,6 +52,66 @@ theorem stepWithTable_matchesSpec_status
       (InterpreterLoop.stepWithHandler spec state).status := by
   rw [stepWithTable_matchesSpec table spec h_dispatch state]
 
+theorem stepWithTable_matchesSpec_memoryCells
+    (table : HandlerTable) (spec : InterpreterLoop.Handler)
+    (h_dispatch : ∀ (opcode : EvmOpcode) (state : EvmState),
+      InterpreterLoop.decodeCurrentOpcode? state = some opcode →
+        HandlerTable.dispatchOpcode table opcode state = spec opcode state)
+    (state : EvmState) :
+    (InterpreterLoop.stepWithHandler (HandlerLoopBridge.toLoopHandler table) state).memoryCells =
+      (InterpreterLoop.stepWithHandler spec state).memoryCells := by
+  rw [stepWithTable_matchesSpec table spec h_dispatch state]
+
+theorem stepWithTable_matchesSpec_memory
+    (table : HandlerTable) (spec : InterpreterLoop.Handler)
+    (h_dispatch : ∀ (opcode : EvmOpcode) (state : EvmState),
+      InterpreterLoop.decodeCurrentOpcode? state = some opcode →
+        HandlerTable.dispatchOpcode table opcode state = spec opcode state)
+    (state : EvmState) (addr : Nat) :
+    (InterpreterLoop.stepWithHandler (HandlerLoopBridge.toLoopHandler table) state).memory addr =
+      (InterpreterLoop.stepWithHandler spec state).memory addr := by
+  rw [stepWithTable_matchesSpec table spec h_dispatch state]
+
+theorem stepWithTable_matchesSpec_memSize
+    (table : HandlerTable) (spec : InterpreterLoop.Handler)
+    (h_dispatch : ∀ (opcode : EvmOpcode) (state : EvmState),
+      InterpreterLoop.decodeCurrentOpcode? state = some opcode →
+        HandlerTable.dispatchOpcode table opcode state = spec opcode state)
+    (state : EvmState) :
+    (InterpreterLoop.stepWithHandler (HandlerLoopBridge.toLoopHandler table) state).memSize =
+      (InterpreterLoop.stepWithHandler spec state).memSize := by
+  rw [stepWithTable_matchesSpec table spec h_dispatch state]
+
+theorem stepWithTable_matchesSpec_code
+    (table : HandlerTable) (spec : InterpreterLoop.Handler)
+    (h_dispatch : ∀ (opcode : EvmOpcode) (state : EvmState),
+      InterpreterLoop.decodeCurrentOpcode? state = some opcode →
+        HandlerTable.dispatchOpcode table opcode state = spec opcode state)
+    (state : EvmState) :
+    (InterpreterLoop.stepWithHandler (HandlerLoopBridge.toLoopHandler table) state).code =
+      (InterpreterLoop.stepWithHandler spec state).code := by
+  rw [stepWithTable_matchesSpec table spec h_dispatch state]
+
+theorem stepWithTable_matchesSpec_codeLen
+    (table : HandlerTable) (spec : InterpreterLoop.Handler)
+    (h_dispatch : ∀ (opcode : EvmOpcode) (state : EvmState),
+      InterpreterLoop.decodeCurrentOpcode? state = some opcode →
+        HandlerTable.dispatchOpcode table opcode state = spec opcode state)
+    (state : EvmState) :
+    (InterpreterLoop.stepWithHandler (HandlerLoopBridge.toLoopHandler table) state).codeLen =
+      (InterpreterLoop.stepWithHandler spec state).codeLen := by
+  rw [stepWithTable_matchesSpec table spec h_dispatch state]
+
+theorem stepWithTable_matchesSpec_env
+    (table : HandlerTable) (spec : InterpreterLoop.Handler)
+    (h_dispatch : ∀ (opcode : EvmOpcode) (state : EvmState),
+      InterpreterLoop.decodeCurrentOpcode? state = some opcode →
+        HandlerTable.dispatchOpcode table opcode state = spec opcode state)
+    (state : EvmState) :
+    (InterpreterLoop.stepWithHandler (HandlerLoopBridge.toLoopHandler table) state).env =
+      (InterpreterLoop.stepWithHandler spec state).env := by
+  rw [stepWithTable_matchesSpec table spec h_dispatch state]
+
 theorem stepWithTable_matchesSpec_pc
     (table : HandlerTable) (spec : InterpreterLoop.Handler)
     (h_dispatch : ∀ (opcode : EvmOpcode) (state : EvmState),


### PR DESCRIPTION
## Summary
- add stepWithTable_matchesSpec_memoryCells / _memory / _memSize / _code / _codeLen / _env projection companions for HandlerLoopSimulationBridge
- mirror the existing pc/gas/stack projections (PR #3373) and loopFuel memory projections (PR #3371); each is a single rw of the underlying step equality

Refs GH #109, GH #107.
Refs beads: evm-asm-chko6, evm-asm-fyia, evm-asm-jaeo.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).

## Verification
- lake build EvmAsm.Evm64.HandlerLoopSimulationBridge
- lake build (full)
- git diff --check
- forbidden option/proof-escape scan on EvmAsm/Evm64/HandlerLoopSimulationBridge.lean (no matches)