### PR TITLE
feat(returndata): add conformance vector IDs

### DIFF
--- a/EvmAsm/EL/Conformance/ReturnData.lean
+++ b/EvmAsm/EL/Conformance/ReturnData.lean
@@ -122,6 +122,28 @@ theorem returnDataCopyStackUnderflowVector_errored :
       stack := [(32 : EvmWord), (1 : EvmWord)] }
     runReturnDataCopyStack_underflow
 
+/-- Vector IDs for returndata executable-helper conformance coverage.
+    Distinctive token: returnDataConformanceVectorIds #125 #114. -/
+def returnDataConformanceVectorIds : List String :=
+  [ returnDataCopyZeroPadVector.id
+  , returnDataCopyStackVector.id
+  , returnDataCopyStackUnderflowVector.id
+  ]
+
+theorem returnDataConformanceVectorIds_eq :
+    returnDataConformanceVectorIds =
+      [ "returndatacopy-zero-pad"
+      , "returndatacopy-stack-decode"
+      , "returndatacopy-stack-underflow"
+      ] := rfl
+
+theorem returnDataConformanceVectorIds_length :
+    returnDataConformanceVectorIds.length = 3 := rfl
+
+theorem returnDataConformanceVectorIds_nodup :
+    returnDataConformanceVectorIds.Nodup := by
+  decide
+
 /-- Compact checked-vector batch for returndata executable helpers.
     Distinctive token: returnDataConformanceVectors #125 #114. -/
 def returnDataConformanceVectors : List CheckResult :=


### PR DESCRIPTION
## Summary
- add RETURNDATACOPY conformance vector ID bookkeeping
- prove exact IDs, count, and nodup invariants for the existing returndata conformance vectors

Refs GH #125.
Refs GH #114.
Beads: evm-asm-y0f3b.

## Verification
- lake build EvmAsm.EL.Conformance.ReturnData
- lake build
- git diff --check
- forbidden option/proof-escape scan on EvmAsm/EL/Conformance/ReturnData.lean (no matches)