### PR TITLE
feat(exp): add gas conformance vector IDs

### DIFF
--- a/EvmAsm/EL/Conformance/ExpGas.lean
+++ b/EvmAsm/EL/Conformance/ExpGas.lean
@@ -78,6 +78,28 @@ theorem expGasTwoByteThresholdVector_passed :
     110
     runExpGas_256
 
+/-- Vector IDs for EXP gas executable-helper conformance coverage.
+    Distinctive token: expGasConformanceVectorIds #125 #92. -/
+def expGasConformanceVectorIds : List String :=
+  [ expGasZeroExponentVector.id
+  , expGasOneByteExponentVector.id
+  , expGasTwoByteThresholdVector.id
+  ]
+
+theorem expGasConformanceVectorIds_eq :
+    expGasConformanceVectorIds =
+      [ "exp-gas-zero-exponent"
+      , "exp-gas-one-byte-exponent"
+      , "exp-gas-two-byte-threshold"
+      ] := rfl
+
+theorem expGasConformanceVectorIds_length :
+    expGasConformanceVectorIds.length = 3 := rfl
+
+theorem expGasConformanceVectorIds_nodup :
+    expGasConformanceVectorIds.Nodup := by
+  decide
+
 /-- Compact checked-vector batch for EXP gas executable helpers.
     Distinctive token: expGasConformanceVectors. -/
 def expGasConformanceVectors : List CheckResult :=


### PR DESCRIPTION
## Summary
- add EXP gas conformance vector ID bookkeeping
- prove exact IDs, count, and nodup invariants for the existing EXP gas conformance vectors

Refs GH #125.
Refs GH #92.
Beads: evm-asm-p8pgh.

## Verification
- lake build EvmAsm.EL.Conformance.ExpGas
- lake build
- git diff --check
- forbidden option/proof-escape scan on EvmAsm/EL/Conformance/ExpGas.lean (no matches)