### PR TITLE
feat(rlp): add conformance vector IDs

### DIFF
--- a/EvmAsm/EL/Conformance/RLP.lean
+++ b/EvmAsm/EL/Conformance/RLP.lean
@@ -103,6 +103,30 @@ theorem rlpLongBytesDecodeVector_passed :
     (.bytes (List.replicate 56 (0x7f : Byte)))
     runDecodeFully_longBytes
 
+/-- Vector IDs for RLP executable-decoding conformance coverage.
+    Distinctive token: rlpConformanceVectorIds #125 #120. -/
+def rlpConformanceVectorIds : List String :=
+  [ rlpNestedListDecodeVector.id
+  , rlpNoncanonicalSingletonVector.id
+  , rlpEmptyListDecodeVector.id
+  , rlpLongBytesDecodeVector.id
+  ]
+
+theorem rlpConformanceVectorIds_eq :
+    rlpConformanceVectorIds =
+      [ "rlp-nested-list-decode"
+      , "rlp-noncanonical-singleton"
+      , "rlp-empty-list-decode"
+      , "rlp-long-bytes-decode"
+      ] := rfl
+
+theorem rlpConformanceVectorIds_length :
+    rlpConformanceVectorIds.length = 4 := rfl
+
+theorem rlpConformanceVectorIds_nodup :
+    rlpConformanceVectorIds.Nodup := by
+  decide
+
 /-- Compact checked-vector batch for RLP executable decoding.
     Distinctive token: RLP.rlpConformanceVectors #125 #120. -/
 def rlpConformanceVectors : List CheckResult :=


### PR DESCRIPTION
## Summary
- add RLP conformance vector ID bookkeeping
- prove exact IDs, count, and nodup invariants for the existing RLP conformance vectors

Refs GH #125.
Refs GH #120.
Beads: evm-asm-h8vpf.

## Verification
- lake build EvmAsm.EL.Conformance.RLP
- lake build
- git diff --check
- forbidden option/proof-escape scan on EvmAsm/EL/Conformance/RLP.lean (no matches)