### PR TITLE
feat(log): add data conformance vector IDs

### DIFF
--- a/EvmAsm/EL/Conformance/Log.lean
+++ b/EvmAsm/EL/Conformance/Log.lean
@@ -78,6 +78,26 @@ theorem logDataZeroSizeVector_passed :
     []
     runLogData_zeroSize
 
+/-- Vector IDs for LOG data-memory conformance coverage.
+    Distinctive token: logDataConformanceVectorIds #125 #112. -/
+def logDataConformanceVectorIds : List String :=
+  [ logDataSliceVector.id
+  , logDataZeroSizeVector.id
+  ]
+
+theorem logDataConformanceVectorIds_eq :
+    logDataConformanceVectorIds =
+      [ "log-data-slice"
+      , "log-data-zero-size"
+      ] := rfl
+
+theorem logDataConformanceVectorIds_length :
+    logDataConformanceVectorIds.length = 2 := rfl
+
+theorem logDataConformanceVectorIds_nodup :
+    logDataConformanceVectorIds.Nodup := by
+  decide
+
 /-- Compact checked-vector batch for LOG data memory helpers.
     Distinctive token: Log.logDataConformanceVectors #125 #112. -/
 def logDataConformanceVectors : List CheckResult :=


### PR DESCRIPTION
## Summary
- add LOG data conformance vector ID bookkeeping
- prove exact IDs, count, and nodup invariants for the existing LOG data conformance vectors

Refs GH #125.
Refs GH #112.
Beads: evm-asm-ljddl.

## Verification
- lake build EvmAsm.EL.Conformance.Log
- lake build
- git diff --check
- forbidden option/proof-escape scan on EvmAsm/EL/Conformance/Log.lean (no matches)