### PR TITLE
docs(host-io): document HALT convention (option (a))

### DIFF
--- a/docs/zkvm-host-io-interface.md
+++ b/docs/zkvm-host-io-interface.md
@@ -69,7 +69,7 @@ following ECALL syscalls (all selected by `t0 = x5`):
 
 | t0 (hex) | SP1 syscall | Current Lean handler | zkvm-standards counterpart |
 |----------|-------------|----------------------|----------------------------|
-| `0x00`   | HALT        | `step_ecall_halt` (returns `none`)        | (no counterpart — see Open question) |
+| `0x00`   | HALT        | `step_ecall_halt` (returns `none`)        | (no zkvm-standards counterpart — see §HALT below for the local convention) |
 | `0x02`   | WRITE fd=13 | append a1..a1+a2 bytes from memory to public values | `write_output(output, size)` (shape-compatible: ptr+size, concatenating) |
 | `0x10`   | COMMIT      | `s.appendCommit (a0, a1)` (word-pair commit) | conceptually subsumed by `write_output` (concatenating bytes) |
 | `0xF0`   | HINT_LEN    | returns `privateInput.length` in a0       | replaced by `read_input` (length is `*buf_size` out-parameter; no separate length call) |
@@ -106,15 +106,41 @@ shape changes are:
    replace the "follows SP1 hint/commit conventions" wording with a
    pointer to this ADR.
 
-## Open question: HALT
+## HALT
 
-zkvm-standards' I/O interface README is silent on halt/termination. The
-current code uses SP1's `t0 = 0x00` HALT (yields `none` from `step`).
-This ADR does **not** prescribe a halt convention — it is tracked as a
-follow-up under parent `evm-asm-96ysd`. Options when that follow-up
-lands: keep SP1 t0=0 as-is, propose a halt addition to the
-zkvm-standards spec upstream, or pick a local convention and document
-it here.
+zkvm-standards' I/O interface README is silent on halt/termination, so
+HALT is not part of the canonical C ABI this ADR adopts. EVM-asm's
+local convention is to **keep SP1's `t0 = 0x00` HALT semantics** as the
+guest's termination signal:
+
+- Encoding: `ECALL` with `x5` (alias `t0`) set to `0x00`.
+- Effect: `EvmAsm/Rv64/Execution.lean :: step` returns `none`, ending
+  the verified execution. No further state transition is defined.
+- Status code: today the handler ignores any register payload. If a
+  future revision wants to surface a `zkvm_status`-style exit code, the
+  natural choice is `a0` (matching the accelerator return-code
+  convention in
+  [`docs/zkvm-accelerators-interface.md`](zkvm-accelerators-interface.md)).
+
+This is a **local** convention, not a zkvm-standards one — the same
+caveat that applies to syscall ID numbering in §"Mapping" above. We
+choose option (a) from the design follow-up (beads `evm-asm-zgd4y`):
+
+- (a) Keep SP1 `t0=0` as the local halt convention and document it
+  here. **Adopted.** Cheapest; no upstream coordination; preserves the
+  existing `step_ecall_halt` Hoare triple surface.
+- (b) Propose a `halt(zkvm_status)` addition to zkvm-standards
+  upstream. Filed as a longer-running follow-up; not blocking the
+  read_input / write_output migration under `evm-asm-96ysd`.
+- (c) Treat exhaustion of the `read_input` buffer as implicit halt.
+  Rejected — guests need to signal failure status, not just "input
+  drained."
+
+A guest that wants to return a non-zero exit status today can write a
+status word via `write_output` immediately before HALT; the verifier
+inspects committed output, not register state at halt. If/when (b) is
+adopted upstream, this section is updated and the dispatch table in
+§"Mapping" gains a `halt(zkvm_status)` row.
 
 ## Maintenance
 


### PR DESCRIPTION
Adopt SP1 `t0=0x00` HALT as the local halt convention while
zkvm-standards' I/O interface remains silent on termination. Replaces
the prior "Open question: HALT" subsection with a §HALT decision
section per beads evm-asm-zgd4y option (a). The mapping-table cell for
`t0=0x00` is updated to point at the new section.

Refs: GH #114, #116, parent evm-asm-96ysd, beads evm-asm-zgd4y.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).
