### PR TITLE
feat(sdiv,smod): leaf specs for save_ra and saved_ra_ret blocks

### DIFF
--- a/EvmAsm/Evm64/SDiv/LimbSpec.lean
+++ b/EvmAsm/Evm64/SDiv/LimbSpec.lean
@@ -46,6 +46,48 @@ theorem evm_sdiv_sign_bit_block_spec_within
               (base + 4) hsign_ne_x0
   runBlock L S
 
+/-- CodeReq for `evm_sdiv_save_ra_block` at byte offset `base`. -/
+abbrev evm_sdiv_save_ra_block_code (savedRaReg : Reg) (base : Word) : CodeReq :=
+  CodeReq.ofProg base (evm_sdiv_save_ra_block savedRaReg)
+
+/-- 1-instruction leaf spec: `ADDI savedRaReg, x1, 0` copies the current
+    `x1` (return address) into a preserved scratch register. The block is
+    used to save `ra` across a nested `JAL` to `evm_div_callable` (which
+    clobbers `x1`). Mirrors `evm_sdiv_div_call_block_spec_within`. -/
+theorem evm_sdiv_save_ra_block_spec_within
+    (savedRaReg : Reg) (vRa vSavedOld : Word) (base : Word)
+    (hsaved_ne_x0 : savedRaReg ≠ .x0) :
+    let code := evm_sdiv_save_ra_block_code savedRaReg base
+    cpsTripleWithin 1 base (base + 4) code
+      ((.x1 ↦ᵣ vRa) ** (savedRaReg ↦ᵣ vSavedOld))
+      ((.x1 ↦ᵣ vRa) ** (savedRaReg ↦ᵣ (vRa + signExtend12 (0 : BitVec 12)))) := by
+  show cpsTripleWithin 1 base (base + 4)
+    (CodeReq.ofProg base (evm_sdiv_save_ra_block savedRaReg)) _ _
+  rw [show CodeReq.ofProg base (evm_sdiv_save_ra_block savedRaReg) =
+      CodeReq.singleton base (.ADDI savedRaReg .x1 0) from CodeReq.ofProg_singleton]
+  exact addi_spec_within savedRaReg .x1 vRa vSavedOld 0 base hsaved_ne_x0
+
+/-- CodeReq for `evm_sdiv_saved_ra_ret_block` at byte offset `base`. -/
+abbrev evm_sdiv_saved_ra_ret_block_code (savedRaReg : Reg) (base : Word) : CodeReq :=
+  CodeReq.ofProg base (evm_sdiv_saved_ra_ret_block savedRaReg)
+
+/-- 1-instruction leaf spec: `JALR x0, savedRaReg, 0` returns to the
+    address saved by `evm_sdiv_save_ra_block`. Exit pc is
+    `(vSavedRa + 0) &&& ~~~1` per the standard `JALR x0` semantics. The
+    `savedRaReg` value is preserved. Mirrors `ret_spec_within`. -/
+theorem evm_sdiv_saved_ra_ret_block_spec_within
+    (savedRaReg : Reg) (vSavedRa : Word) (base : Word) :
+    let code := evm_sdiv_saved_ra_ret_block_code savedRaReg base
+    cpsTripleWithin 1 base
+        ((vSavedRa + signExtend12 (0 : BitVec 12)) &&& ~~~1) code
+      (savedRaReg ↦ᵣ vSavedRa)
+      (savedRaReg ↦ᵣ vSavedRa) := by
+  show cpsTripleWithin 1 base _
+    (CodeReq.ofProg base (evm_sdiv_saved_ra_ret_block savedRaReg)) _ _
+  rw [show CodeReq.ofProg base (evm_sdiv_saved_ra_ret_block savedRaReg) =
+      CodeReq.singleton base (.JALR .x0 savedRaReg 0) from CodeReq.ofProg_singleton]
+  exact jalr_x0_spec_gen_within savedRaReg vSavedRa 0 base
+
 /-- CodeReq for `evm_sdiv_div_call_block` at byte offset `base`. -/
 abbrev evm_sdiv_div_call_block_code (divOff : BitVec 21) (base : Word) : CodeReq :=
   CodeReq.ofProg base (evm_sdiv_div_call_block divOff)

--- a/EvmAsm/Evm64/SMod/LimbSpec.lean
+++ b/EvmAsm/Evm64/SMod/LimbSpec.lean
@@ -20,4 +20,45 @@ open EvmAsm.Rv64
 
 -- Per-block specs land in slice evm-asm-bjnb and below.
 
+/-- CodeReq for `evm_smod_save_ra_block` at byte offset `base`. -/
+abbrev evm_smod_save_ra_block_code (savedRaReg : Reg) (base : Word) : CodeReq :=
+  CodeReq.ofProg base (evm_smod_save_ra_block savedRaReg)
+
+/-- 1-instruction leaf spec: `ADDI savedRaReg, x1, 0` copies the current
+    `x1` (return address) into a preserved scratch register. Used to save
+    `ra` across the nested `JAL` to `evm_mod_callable` in the SMOD wrapper
+    (mirror of `evm_sdiv_save_ra_block_spec_within`). -/
+theorem evm_smod_save_ra_block_spec_within
+    (savedRaReg : Reg) (vRa vSavedOld : Word) (base : Word)
+    (hsaved_ne_x0 : savedRaReg ≠ .x0) :
+    let code := evm_smod_save_ra_block_code savedRaReg base
+    cpsTripleWithin 1 base (base + 4) code
+      ((.x1 ↦ᵣ vRa) ** (savedRaReg ↦ᵣ vSavedOld))
+      ((.x1 ↦ᵣ vRa) ** (savedRaReg ↦ᵣ (vRa + signExtend12 (0 : BitVec 12)))) := by
+  show cpsTripleWithin 1 base (base + 4)
+    (CodeReq.ofProg base (evm_smod_save_ra_block savedRaReg)) _ _
+  rw [show CodeReq.ofProg base (evm_smod_save_ra_block savedRaReg) =
+      CodeReq.singleton base (.ADDI savedRaReg .x1 0) from CodeReq.ofProg_singleton]
+  exact addi_spec_within savedRaReg .x1 vRa vSavedOld 0 base hsaved_ne_x0
+
+/-- CodeReq for `evm_smod_saved_ra_ret_block` at byte offset `base`. -/
+abbrev evm_smod_saved_ra_ret_block_code (savedRaReg : Reg) (base : Word) : CodeReq :=
+  CodeReq.ofProg base (evm_smod_saved_ra_ret_block savedRaReg)
+
+/-- 1-instruction leaf spec: `JALR x0, savedRaReg, 0` returns to the
+    address saved by `evm_smod_save_ra_block`. Exit pc is
+    `(vSavedRa + 0) &&& ~~~1` per the standard `JALR x0` semantics. -/
+theorem evm_smod_saved_ra_ret_block_spec_within
+    (savedRaReg : Reg) (vSavedRa : Word) (base : Word) :
+    let code := evm_smod_saved_ra_ret_block_code savedRaReg base
+    cpsTripleWithin 1 base
+        ((vSavedRa + signExtend12 (0 : BitVec 12)) &&& ~~~1) code
+      (savedRaReg ↦ᵣ vSavedRa)
+      (savedRaReg ↦ᵣ vSavedRa) := by
+  show cpsTripleWithin 1 base _
+    (CodeReq.ofProg base (evm_smod_saved_ra_ret_block savedRaReg)) _ _
+  rw [show CodeReq.ofProg base (evm_smod_saved_ra_ret_block savedRaReg) =
+      CodeReq.singleton base (.JALR .x0 savedRaReg 0) from CodeReq.ofProg_singleton]
+  exact jalr_x0_spec_gen_within savedRaReg vSavedRa 0 base
+
 end EvmAsm.Evm64


### PR DESCRIPTION
Adds four 1-instruction `cpsTripleWithin` leaf specs covering the save-`ra` ADDI and the saved-`ra` `JALR x0` return blocks for both SDIV and SMOD wrappers:

- `evm_sdiv_save_ra_block_spec_within` (`EvmAsm/Evm64/SDiv/LimbSpec.lean`)
- `evm_sdiv_saved_ra_ret_block_spec_within`
- `evm_smod_save_ra_block_spec_within` (`EvmAsm/Evm64/SMod/LimbSpec.lean`)
- `evm_smod_saved_ra_ret_block_spec_within`

Each is a thin wrapper over an existing `GenericSpecs`/`ControlFlow` lemma (`addi_spec_within` / `jalr_x0_spec_gen_within`) following the same shape as the already-merged `evm_sdiv_div_call_block_spec_within`. They unblock the forthcoming SDIV/SMOD wrapper composition slices under parent `evm-asm-34sg` (#90).

`lake build` green, no `maxHeartbeats` / `maxRecDepth` bumps.

Refs GH #90, beads `evm-asm-5n242`.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).