### PR TITLE
feat(handlers): add supported lookup projections

### DIFF
--- a/EvmAsm/Evm64/SupportedHandlers.lean
+++ b/EvmAsm/Evm64/SupportedHandlers.lean
@@ -365,6 +365,30 @@ theorem dispatchOpcode_of_lookup_status
       (handler state).status := by
   rw [dispatchOpcode_of_lookup h_lookup state]
 
+theorem dispatchOpcode_of_lookup_pc
+    {opcode : EvmOpcode} {handler : OpcodeHandler}
+    (h_lookup : supportedHandlerTable opcode = some handler)
+    (state : EvmState) :
+    (HandlerTable.dispatchOpcode supportedHandlerTable opcode state).pc =
+      (handler state).pc := by
+  rw [dispatchOpcode_of_lookup h_lookup state]
+
+theorem dispatchOpcode_of_lookup_gas
+    {opcode : EvmOpcode} {handler : OpcodeHandler}
+    (h_lookup : supportedHandlerTable opcode = some handler)
+    (state : EvmState) :
+    (HandlerTable.dispatchOpcode supportedHandlerTable opcode state).gas =
+      (handler state).gas := by
+  rw [dispatchOpcode_of_lookup h_lookup state]
+
+theorem dispatchOpcode_of_lookup_stack
+    {opcode : EvmOpcode} {handler : OpcodeHandler}
+    (h_lookup : supportedHandlerTable opcode = some handler)
+    (state : EvmState) :
+    (HandlerTable.dispatchOpcode supportedHandlerTable opcode state).stack =
+      (handler state).stack := by
+  rw [dispatchOpcode_of_lookup h_lookup state]
+
 @[simp] theorem supportedHandlerTable_STOP :
     supportedHandlerTable .STOP =
       some TerminatingHandlers.stopHandler := by

--- a/EvmAsm/Evm64/SupportedLoopBridge.lean
+++ b/EvmAsm/Evm64/SupportedLoopBridge.lean
@@ -59,6 +59,30 @@ theorem stepWithSupportedHandler_of_lookup_status
       (handler state).status := by
   rw [stepWithSupportedHandler_of_lookup h_decode h_lookup]
 
+theorem stepWithSupportedHandler_of_lookup_pc
+    {state : EvmState} {opcode : EvmOpcode} {handler : OpcodeHandler}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some opcode)
+    (h_lookup : SupportedHandlers.supportedHandlerTable opcode = some handler) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).pc =
+      (handler state).pc := by
+  rw [stepWithSupportedHandler_of_lookup h_decode h_lookup]
+
+theorem stepWithSupportedHandler_of_lookup_gas
+    {state : EvmState} {opcode : EvmOpcode} {handler : OpcodeHandler}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some opcode)
+    (h_lookup : SupportedHandlers.supportedHandlerTable opcode = some handler) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).gas =
+      (handler state).gas := by
+  rw [stepWithSupportedHandler_of_lookup h_decode h_lookup]
+
+theorem stepWithSupportedHandler_of_lookup_stack
+    {state : EvmState} {opcode : EvmOpcode} {handler : OpcodeHandler}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some opcode)
+    (h_lookup : SupportedHandlers.supportedHandlerTable opcode = some handler) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).stack =
+      (handler state).stack := by
+  rw [stepWithSupportedHandler_of_lookup h_decode h_lookup]
+
 /--
 When the supported interpreter loop decodes a valid PUSH opcode, the one-step
 handler has the same bundled PC and stack effect as the executable PUSH bridge.


### PR DESCRIPTION
## Summary
- add supported-handler dispatch lookup projections for pc, gas, and stack
- add matching supported-loop step projections for decoded opcodes with a supported-table lookup

Refs #107.
Beads: evm-asm-jaeo.

## Verification
- lake build EvmAsm.Evm64.SupportedLoopBridge
- lake build
- git diff --check
- rg 'set_option maxHeartbeats|set_option maxRecDepth|sorry|admit' EvmAsm/Evm64/SupportedHandlers.lean EvmAsm/Evm64/SupportedLoopBridge.lean