### PR TITLE
feat(interpreter): add trace loop state projections

### DIFF
--- a/EvmAsm/Evm64/InterpreterTraceSimulation.lean
+++ b/EvmAsm/Evm64/InterpreterTraceSimulation.lean
@@ -90,6 +90,87 @@ theorem loopFuelAndTrace_matchesSpec_status
   exact congrArg (fun result => result.1.status)
     (loopFuelAndTrace_matchesSpec h_match nSteps state)
 
+theorem loopFuelAndTrace_matchesSpec_pc
+    {impl spec : InterpreterLoop.Handler}
+    (h_match : InterpreterSimulation.HandlerMatchesSpec impl spec)
+    (nSteps : Nat) (state : EvmState) :
+    (InterpreterLoop.loopFuel impl nSteps state).pc =
+      (InterpreterLoop.loopFuel spec nSteps state).pc := by
+  exact congrArg (fun result => result.1.pc)
+    (loopFuelAndTrace_matchesSpec h_match nSteps state)
+
+theorem loopFuelAndTrace_matchesSpec_gas
+    {impl spec : InterpreterLoop.Handler}
+    (h_match : InterpreterSimulation.HandlerMatchesSpec impl spec)
+    (nSteps : Nat) (state : EvmState) :
+    (InterpreterLoop.loopFuel impl nSteps state).gas =
+      (InterpreterLoop.loopFuel spec nSteps state).gas := by
+  exact congrArg (fun result => result.1.gas)
+    (loopFuelAndTrace_matchesSpec h_match nSteps state)
+
+theorem loopFuelAndTrace_matchesSpec_stack
+    {impl spec : InterpreterLoop.Handler}
+    (h_match : InterpreterSimulation.HandlerMatchesSpec impl spec)
+    (nSteps : Nat) (state : EvmState) :
+    (InterpreterLoop.loopFuel impl nSteps state).stack =
+      (InterpreterLoop.loopFuel spec nSteps state).stack := by
+  exact congrArg (fun result => result.1.stack)
+    (loopFuelAndTrace_matchesSpec h_match nSteps state)
+
+theorem loopFuelAndTrace_matchesSpec_memoryCells
+    {impl spec : InterpreterLoop.Handler}
+    (h_match : InterpreterSimulation.HandlerMatchesSpec impl spec)
+    (nSteps : Nat) (state : EvmState) :
+    (InterpreterLoop.loopFuel impl nSteps state).memoryCells =
+      (InterpreterLoop.loopFuel spec nSteps state).memoryCells := by
+  exact congrArg (fun result => result.1.memoryCells)
+    (loopFuelAndTrace_matchesSpec h_match nSteps state)
+
+theorem loopFuelAndTrace_matchesSpec_memory
+    {impl spec : InterpreterLoop.Handler}
+    (h_match : InterpreterSimulation.HandlerMatchesSpec impl spec)
+    (nSteps : Nat) (state : EvmState) (addr : Nat) :
+    (InterpreterLoop.loopFuel impl nSteps state).memory addr =
+      (InterpreterLoop.loopFuel spec nSteps state).memory addr := by
+  exact congrFun (congrArg (fun result => result.1.memory)
+    (loopFuelAndTrace_matchesSpec h_match nSteps state)) addr
+
+theorem loopFuelAndTrace_matchesSpec_memSize
+    {impl spec : InterpreterLoop.Handler}
+    (h_match : InterpreterSimulation.HandlerMatchesSpec impl spec)
+    (nSteps : Nat) (state : EvmState) :
+    (InterpreterLoop.loopFuel impl nSteps state).memSize =
+      (InterpreterLoop.loopFuel spec nSteps state).memSize := by
+  exact congrArg (fun result => result.1.memSize)
+    (loopFuelAndTrace_matchesSpec h_match nSteps state)
+
+theorem loopFuelAndTrace_matchesSpec_code
+    {impl spec : InterpreterLoop.Handler}
+    (h_match : InterpreterSimulation.HandlerMatchesSpec impl spec)
+    (nSteps : Nat) (state : EvmState) :
+    (InterpreterLoop.loopFuel impl nSteps state).code =
+      (InterpreterLoop.loopFuel spec nSteps state).code := by
+  exact congrArg (fun result => result.1.code)
+    (loopFuelAndTrace_matchesSpec h_match nSteps state)
+
+theorem loopFuelAndTrace_matchesSpec_codeLen
+    {impl spec : InterpreterLoop.Handler}
+    (h_match : InterpreterSimulation.HandlerMatchesSpec impl spec)
+    (nSteps : Nat) (state : EvmState) :
+    (InterpreterLoop.loopFuel impl nSteps state).codeLen =
+      (InterpreterLoop.loopFuel spec nSteps state).codeLen := by
+  exact congrArg (fun result => result.1.codeLen)
+    (loopFuelAndTrace_matchesSpec h_match nSteps state)
+
+theorem loopFuelAndTrace_matchesSpec_env
+    {impl spec : InterpreterLoop.Handler}
+    (h_match : InterpreterSimulation.HandlerMatchesSpec impl spec)
+    (nSteps : Nat) (state : EvmState) :
+    (InterpreterLoop.loopFuel impl nSteps state).env =
+      (InterpreterLoop.loopFuel spec nSteps state).env := by
+  exact congrArg (fun result => result.1.env)
+    (loopFuelAndTrace_matchesSpec h_match nSteps state)
+
 theorem loopFuelAndTrace_matchesSpec_trace_length
     {impl spec : InterpreterLoop.Handler}
     (h_match : InterpreterSimulation.HandlerMatchesSpec impl spec)


### PR DESCRIPTION
## Summary
- add final-state field projections for InterpreterTraceSimulation.loopFuelAndTrace_matchesSpec
- cover pc, gas, stack, memoryCells, memory, memSize, code, codeLen, and env from the combined loopFuel/loopTrace bridge

Refs #109.
Beads: evm-asm-fyia.

## Verification
- lake build EvmAsm.Evm64.InterpreterTraceSimulation
- lake build
- git diff --check
- rg 'set_option maxHeartbeats|set_option maxRecDepth|sorry|admit' EvmAsm/Evm64/InterpreterTraceSimulation.lean