### PR TITLE
feat(handlers): add supported state projections

### DIFF
--- a/EvmAsm/Evm64/SupportedHandlers.lean
+++ b/EvmAsm/Evm64/SupportedHandlers.lean
@@ -389,6 +389,54 @@ theorem dispatchOpcode_of_lookup_stack
       (handler state).stack := by
   rw [dispatchOpcode_of_lookup h_lookup state]
 
+theorem dispatchOpcode_of_lookup_memoryCells
+    {opcode : EvmOpcode} {handler : OpcodeHandler}
+    (h_lookup : supportedHandlerTable opcode = some handler)
+    (state : EvmState) :
+    (HandlerTable.dispatchOpcode supportedHandlerTable opcode state).memoryCells =
+      (handler state).memoryCells := by
+  rw [dispatchOpcode_of_lookup h_lookup state]
+
+theorem dispatchOpcode_of_lookup_memory
+    {opcode : EvmOpcode} {handler : OpcodeHandler}
+    (h_lookup : supportedHandlerTable opcode = some handler)
+    (state : EvmState) (addr : Nat) :
+    (HandlerTable.dispatchOpcode supportedHandlerTable opcode state).memory addr =
+      (handler state).memory addr := by
+  rw [dispatchOpcode_of_lookup h_lookup state]
+
+theorem dispatchOpcode_of_lookup_memSize
+    {opcode : EvmOpcode} {handler : OpcodeHandler}
+    (h_lookup : supportedHandlerTable opcode = some handler)
+    (state : EvmState) :
+    (HandlerTable.dispatchOpcode supportedHandlerTable opcode state).memSize =
+      (handler state).memSize := by
+  rw [dispatchOpcode_of_lookup h_lookup state]
+
+theorem dispatchOpcode_of_lookup_code
+    {opcode : EvmOpcode} {handler : OpcodeHandler}
+    (h_lookup : supportedHandlerTable opcode = some handler)
+    (state : EvmState) :
+    (HandlerTable.dispatchOpcode supportedHandlerTable opcode state).code =
+      (handler state).code := by
+  rw [dispatchOpcode_of_lookup h_lookup state]
+
+theorem dispatchOpcode_of_lookup_codeLen
+    {opcode : EvmOpcode} {handler : OpcodeHandler}
+    (h_lookup : supportedHandlerTable opcode = some handler)
+    (state : EvmState) :
+    (HandlerTable.dispatchOpcode supportedHandlerTable opcode state).codeLen =
+      (handler state).codeLen := by
+  rw [dispatchOpcode_of_lookup h_lookup state]
+
+theorem dispatchOpcode_of_lookup_env
+    {opcode : EvmOpcode} {handler : OpcodeHandler}
+    (h_lookup : supportedHandlerTable opcode = some handler)
+    (state : EvmState) :
+    (HandlerTable.dispatchOpcode supportedHandlerTable opcode state).env =
+      (handler state).env := by
+  rw [dispatchOpcode_of_lookup h_lookup state]
+
 @[simp] theorem supportedHandlerTable_STOP :
     supportedHandlerTable .STOP =
       some TerminatingHandlers.stopHandler := by

--- a/EvmAsm/Evm64/SupportedLoopBridge.lean
+++ b/EvmAsm/Evm64/SupportedLoopBridge.lean
@@ -83,6 +83,55 @@ theorem stepWithSupportedHandler_of_lookup_stack
       (handler state).stack := by
   rw [stepWithSupportedHandler_of_lookup h_decode h_lookup]
 
+theorem stepWithSupportedHandler_of_lookup_memoryCells
+    {state : EvmState} {opcode : EvmOpcode} {handler : OpcodeHandler}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some opcode)
+    (h_lookup : SupportedHandlers.supportedHandlerTable opcode = some handler) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).memoryCells =
+      (handler state).memoryCells := by
+  rw [stepWithSupportedHandler_of_lookup h_decode h_lookup]
+
+theorem stepWithSupportedHandler_of_lookup_memory
+    {state : EvmState} {opcode : EvmOpcode} {handler : OpcodeHandler}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some opcode)
+    (h_lookup : SupportedHandlers.supportedHandlerTable opcode = some handler)
+    (addr : Nat) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).memory addr =
+      (handler state).memory addr := by
+  rw [stepWithSupportedHandler_of_lookup h_decode h_lookup]
+
+theorem stepWithSupportedHandler_of_lookup_memSize
+    {state : EvmState} {opcode : EvmOpcode} {handler : OpcodeHandler}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some opcode)
+    (h_lookup : SupportedHandlers.supportedHandlerTable opcode = some handler) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).memSize =
+      (handler state).memSize := by
+  rw [stepWithSupportedHandler_of_lookup h_decode h_lookup]
+
+theorem stepWithSupportedHandler_of_lookup_code
+    {state : EvmState} {opcode : EvmOpcode} {handler : OpcodeHandler}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some opcode)
+    (h_lookup : SupportedHandlers.supportedHandlerTable opcode = some handler) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).code =
+      (handler state).code := by
+  rw [stepWithSupportedHandler_of_lookup h_decode h_lookup]
+
+theorem stepWithSupportedHandler_of_lookup_codeLen
+    {state : EvmState} {opcode : EvmOpcode} {handler : OpcodeHandler}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some opcode)
+    (h_lookup : SupportedHandlers.supportedHandlerTable opcode = some handler) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).codeLen =
+      (handler state).codeLen := by
+  rw [stepWithSupportedHandler_of_lookup h_decode h_lookup]
+
+theorem stepWithSupportedHandler_of_lookup_env
+    {state : EvmState} {opcode : EvmOpcode} {handler : OpcodeHandler}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some opcode)
+    (h_lookup : SupportedHandlers.supportedHandlerTable opcode = some handler) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).env =
+      (handler state).env := by
+  rw [stepWithSupportedHandler_of_lookup h_decode h_lookup]
+
 /--
 When the supported interpreter loop decodes a valid PUSH opcode, the one-step
 handler has the same bundled PC and stack effect as the executable PUSH bridge.


### PR DESCRIPTION
## Summary
- add supported-handler dispatch lookup projections for memoryCells, memory, memSize, code, codeLen, and env
- add matching supported-loop step projections for decoded opcodes with a supported-table lookup

Refs #107.
Beads: evm-asm-jaeo.

## Verification
- lake build EvmAsm.Evm64.SupportedLoopBridge
- lake build
- git diff --check
- rg 'set_option maxHeartbeats|set_option maxRecDepth|sorry|admit' EvmAsm/Evm64/SupportedHandlers.lean EvmAsm/Evm64/SupportedLoopBridge.lean