### PR TITLE
feat(interpreter): add code length match projections

### DIFF
--- a/EvmAsm/Evm64/InterpreterLoopSimulation.lean
+++ b/EvmAsm/Evm64/InterpreterLoopSimulation.lean
@@ -115,6 +115,21 @@ theorem loopFuel_codeLen_eq_of_loopResultsMatch
       (InterpreterLoop.loopFuel spec fuel state).codeLen := by
   rw [loopFuel_eq_of_loopResultsMatch h_match fuel state]
 
+theorem loopFuel_codeLenMatches_iff_of_loopResultsMatch
+    {impl spec : Handler} (h_match : LoopResultsMatch impl spec)
+    (fuel : Nat) (state : EvmState) :
+    (InterpreterLoop.loopFuel impl fuel state).codeLenMatches ↔
+      (InterpreterLoop.loopFuel spec fuel state).codeLenMatches := by
+  rw [loopFuel_eq_of_loopResultsMatch h_match fuel state]
+
+theorem loopFuel_codeLenMatches_of_loopResultsMatch
+    {impl spec : Handler} (h_match : LoopResultsMatch impl spec)
+    (fuel : Nat) (state : EvmState)
+    (h_codeLen : (InterpreterLoop.loopFuel spec fuel state).codeLenMatches) :
+    (InterpreterLoop.loopFuel impl fuel state).codeLenMatches := by
+  rw [loopFuel_eq_of_loopResultsMatch h_match fuel state]
+  exact h_codeLen
+
 theorem loopFuel_env_eq_of_loopResultsMatch
     {impl spec : Handler} (h_match : LoopResultsMatch impl spec)
     (fuel : Nat) (state : EvmState) :

--- a/EvmAsm/Evm64/InterpreterTraceSimulation.lean
+++ b/EvmAsm/Evm64/InterpreterTraceSimulation.lean
@@ -162,6 +162,23 @@ theorem loopFuelAndTrace_matchesSpec_codeLen
   exact congrArg (fun result => result.1.codeLen)
     (loopFuelAndTrace_matchesSpec h_match nSteps state)
 
+theorem loopFuelAndTrace_matchesSpec_codeLenMatches_iff
+    {impl spec : InterpreterLoop.Handler}
+    (h_match : InterpreterSimulation.HandlerMatchesSpec impl spec)
+    (nSteps : Nat) (state : EvmState) :
+    (InterpreterLoop.loopFuel impl nSteps state).codeLenMatches ↔
+      (InterpreterLoop.loopFuel spec nSteps state).codeLenMatches := by
+  rw [loopFuelAndTrace_matchesSpec_state h_match nSteps state]
+
+theorem loopFuelAndTrace_matchesSpec_codeLenMatches
+    {impl spec : InterpreterLoop.Handler}
+    (h_match : InterpreterSimulation.HandlerMatchesSpec impl spec)
+    (nSteps : Nat) (state : EvmState)
+    (h_codeLen : (InterpreterLoop.loopFuel spec nSteps state).codeLenMatches) :
+    (InterpreterLoop.loopFuel impl nSteps state).codeLenMatches := by
+  rw [loopFuelAndTrace_matchesSpec_state h_match nSteps state]
+  exact h_codeLen
+
 theorem loopFuelAndTrace_matchesSpec_env
     {impl spec : InterpreterLoop.Handler}
     (h_match : InterpreterSimulation.HandlerMatchesSpec impl spec)


### PR DESCRIPTION
## Summary
- add LoopResultsMatch bridges for final-state codeLenMatches equivalence and transfer
- add matching loopFuel/loopTrace simulation codeLenMatches projections for downstream interpreter proofs

Refs #109.
Beads: evm-asm-fyia.

## Verification
- lake build EvmAsm.Evm64.InterpreterTraceSimulation
- lake build
- git diff --check
- rg 'set_option maxHeartbeats|set_option maxRecDepth|sorry|admit' EvmAsm/Evm64/InterpreterLoopSimulation.lean EvmAsm/Evm64/InterpreterTraceSimulation.lean