### PR TITLE
feat(handlers): add supported byte codeLenMatches bridge

### DIFF
--- a/EvmAsm/Evm64/SupportedHandlerByte.lean
+++ b/EvmAsm/Evm64/SupportedHandlerByte.lean
@@ -143,6 +143,24 @@ theorem dispatchByte_supported_of_lookup_preserves_status
   rw [dispatchByte_supported_of_lookup_status h_decode h_lookup state]
   exact h_status state
 
+/--
+Decoded byte dispatch through the supported table preserves `codeLenMatches`
+whenever the looked-up handler does.
+
+Distinctive token: supportedByteLookupPreservesCodeLenMatches #107.
+-/
+theorem dispatchByte_supported_of_lookup_preserves_codeLenMatches
+    {b : Fin 256} {opcode : EvmOpcode} {handler : OpcodeHandler}
+    (h_decode : EvmOpcode.decodeByte? b.val = some opcode)
+    (h_lookup :
+      SupportedHandlers.supportedHandlerTable opcode = some handler)
+    (h_codeLen : ∀ state : EvmState,
+      state.codeLenMatches → (handler state).codeLenMatches)
+    (state : EvmState) (h_state : state.codeLenMatches) :
+    (HandlerTable.dispatchByte SupportedHandlers.supportedHandlerTable b state).codeLenMatches := by
+  rw [dispatchByte_supported_of_lookup h_decode h_lookup state]
+  exact h_codeLen state h_state
+
 theorem dispatchByte_supported_of_decode
     {b : Fin 256} {opcode : EvmOpcode}
     (h_decode : EvmOpcode.decodeByte? b.val = some opcode)


### PR DESCRIPTION
## Summary
- add a generic supported byte-dispatch codeLenMatches transfer lemma
- mirror the existing supported byte lookup status preservation helper for handlers that preserve code length validity

Refs #107
Beads: evm-asm-m4eho

## Verification
- lake build EvmAsm.Evm64.SupportedHandlerByte
- lake build
- git diff --check
- rg "set_option maxHeartbeats|set_option maxRecDepth|sorry|admit" EvmAsm/Evm64/SupportedHandlerByte.lean