### PR TITLE
feat(handlers): add supported handler codeLenMatches bridge

### DIFF
--- a/EvmAsm/Evm64/SupportedHandlers.lean
+++ b/EvmAsm/Evm64/SupportedHandlers.lean
@@ -429,6 +429,16 @@ theorem dispatchOpcode_of_lookup_codeLen
       (handler state).codeLen := by
   rw [dispatchOpcode_of_lookup h_lookup state]
 
+theorem dispatchOpcode_of_lookup_preserves_codeLenMatches
+    {opcode : EvmOpcode} {handler : OpcodeHandler}
+    (h_lookup : supportedHandlerTable opcode = some handler)
+    (h_codeLen : ∀ state : EvmState,
+      state.codeLenMatches → (handler state).codeLenMatches)
+    (state : EvmState) (h_state : state.codeLenMatches) :
+    (HandlerTable.dispatchOpcode supportedHandlerTable opcode state).codeLenMatches := by
+  rw [dispatchOpcode_of_lookup h_lookup state]
+  exact h_codeLen state h_state
+
 theorem dispatchOpcode_of_lookup_env
     {opcode : EvmOpcode} {handler : OpcodeHandler}
     (h_lookup : supportedHandlerTable opcode = some handler)


### PR DESCRIPTION
## Summary
- add a generic supported-handler dispatch codeLenMatches transfer lemma
- mirror the supported byte-dispatch codeLenMatches bridge at the opcode-dispatch level

Refs #107
Beads: evm-asm-2hwhg

## Verification
- lake build EvmAsm.Evm64.SupportedHandlers
- lake build
- git diff --check
- rg "set_option maxHeartbeats|set_option maxRecDepth|sorry|admit" EvmAsm/Evm64/SupportedHandlers.lean