### PR TITLE
feat(interpreter): add supported loop codeLenMatches bridge

### DIFF
--- a/EvmAsm/Evm64/SupportedLoopBridge.lean
+++ b/EvmAsm/Evm64/SupportedLoopBridge.lean
@@ -124,6 +124,17 @@ theorem stepWithSupportedHandler_of_lookup_codeLen
       (handler state).codeLen := by
   rw [stepWithSupportedHandler_of_lookup h_decode h_lookup]
 
+theorem stepWithSupportedHandler_of_lookup_preserves_codeLenMatches
+    {state : EvmState} {opcode : EvmOpcode} {handler : OpcodeHandler}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some opcode)
+    (h_lookup : SupportedHandlers.supportedHandlerTable opcode = some handler)
+    (h_codeLen : ∀ state : EvmState,
+      state.codeLenMatches → (handler state).codeLenMatches)
+    (h_state : state.codeLenMatches) :
+    (InterpreterLoop.stepWithHandler supportedLoopHandler state).codeLenMatches := by
+  rw [stepWithSupportedHandler_of_lookup h_decode h_lookup]
+  exact h_codeLen state h_state
+
 theorem stepWithSupportedHandler_of_lookup_env
     {state : EvmState} {opcode : EvmOpcode} {handler : OpcodeHandler}
     (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some opcode)


### PR DESCRIPTION
Refs GH #107 and GH #108.\n\nBeads: evm-asm-et3to.\n\n## Summary\n- add generic stepWithSupportedHandler_of_lookup_preserves_codeLenMatches\n- mirror the supported-handler lookup preservation surface at the interpreter step layer\n\n## Verification\n- lake build EvmAsm.Evm64.SupportedLoopBridge\n- lake build\n- git diff --check\n- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SupportedLoopBridge.lean