### PR TITLE
feat(interpreter): add handler loop codeLenMatches bridge

### DIFF
--- a/EvmAsm/Evm64/HandlerLoopBridge.lean
+++ b/EvmAsm/Evm64/HandlerLoopBridge.lean
@@ -68,6 +68,18 @@ theorem stepWithTableHandler_of_lookup_preserves_status
   rw [stepWithTableHandler_of_lookup_status h_decode h_lookup]
   exact h_status state
 
+theorem stepWithTableHandler_of_lookup_preserves_codeLenMatches
+    {table : HandlerTable} {state : EvmState} {opcode : EvmOpcode}
+    {handler : OpcodeHandler}
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some opcode)
+    (h_lookup : table opcode = some handler)
+    (h_codeLen : ∀ state : EvmState,
+      state.codeLenMatches → (handler state).codeLenMatches)
+    (h_state : state.codeLenMatches) :
+    (InterpreterLoop.stepWithHandler (toLoopHandler table) state).codeLenMatches := by
+  rw [stepWithTableHandler_of_lookup h_decode h_lookup]
+  exact h_codeLen state h_state
+
 theorem stepWithTableHandler_missing_invalid
     {table : HandlerTable} {state : EvmState} {opcode : EvmOpcode}
     (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some opcode)


### PR DESCRIPTION
Refs GH #107.\n\nBeads: evm-asm-1tz7f.\n\n## Summary\n- add lower-level stepWithTableHandler_of_lookup_preserves_codeLenMatches\n- mirror the existing status-preservation lookup bridge for codeLenMatches\n\n## Verification\n- lake build EvmAsm.Evm64.HandlerLoopBridge\n- lake build\n- git diff --check\n- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/HandlerLoopBridge.lean