### PR TITLE
feat(call): add symmetric classifier exclusions

### DIFF
--- a/EvmAsm/Evm64/CallArgs.lean
+++ b/EvmAsm/Evm64/CallArgs.lean
@@ -176,8 +176,20 @@ theorem hasValueArgument_not_preservesCallerContext (kind : Kind)
     (h : hasValueArgument kind = true) : preservesCallerContext kind = false := by
   cases kind <;> simp_all (config := { decide := true })
 
+theorem isStatic_not_hasValueArgument (kind : Kind)
+    (h : isStatic kind = true) : hasValueArgument kind = false := by
+  cases kind <;> simp_all (config := { decide := true })
+
 theorem isStatic_not_preservesCallerContext (kind : Kind)
     (h : isStatic kind = true) : preservesCallerContext kind = false := by
+  cases kind <;> simp_all (config := { decide := true })
+
+theorem preservesCallerContext_not_hasValueArgument (kind : Kind)
+    (h : preservesCallerContext kind = true) : hasValueArgument kind = false := by
+  cases kind <;> simp_all (config := { decide := true })
+
+theorem preservesCallerContext_not_isStatic (kind : Kind)
+    (h : preservesCallerContext kind = true) : isStatic kind = false := by
   cases kind <;> simp_all (config := { decide := true })
 
 end CallArgs


### PR DESCRIPTION
## Summary
- add the missing isStatic-to-not-hasValueArgument classifier exclusion
- add preservesCallerContext exclusions against value and static classifiers

## Verification
- lake build EvmAsm.Evm64.CallArgs
- lake build

Refs #114
Bead: evm-asm-kzxtv