### PR TITLE
feat(exp): bridge squaring unmarshal word

### DIFF
--- a/EvmAsm/Evm64/Exp/SquaringPairThenMulCall.lean
+++ b/EvmAsm/Evm64/Exp/SquaringPairThenMulCall.lean
@@ -90,6 +90,79 @@ theorem exp_squaring_call_with_mul_code_block_subs
      exp_squaring_call_with_mul_code_mul_callable_sub
         base mulTarget mulOff hd⟩
 
+/-- Bridge the post-call MUL result word at `evmSp + 32` into the
+    unmarshal/restore block, producing the same word in the local EXP scratch
+    frame at `sp`. -/
+theorem exp_loop_un_marshal_and_restore_word_spec_within
+    (sp evmSp tOld r0 r1 r2 r3 base : Word) (w : EvmWord) :
+    cpsTripleWithin 9 base (base + 36)
+      (CodeReq.ofProg base exp_loop_un_marshal_and_restore)
+      ((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ (evmSp + 32)) ** (.x5 ↦ᵣ tOld) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+       evmWordIs (evmSp + 32) w)
+      ((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ w.getLimbN 3) **
+       evmWordIs sp w ** evmWordIs (evmSp + 32) w) := by
+  have h_unmarshal := exp_loop_un_marshal_and_restore_ofProg_spec_within
+    sp (evmSp + 32) tOld r0 r1 r2 r3
+    (w.getLimbN 0) (w.getLimbN 1) (w.getLimbN 2) (w.getLimbN 3) base
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by
+      have h0 : ((evmSp + 32) + signExtend12 (0 : BitVec 12) : Word) =
+          evmSp + 32 := by
+        unfold signExtend12; bv_decide
+      have h8 : ((evmSp + 32) + signExtend12 (8 : BitVec 12) : Word) =
+          evmSp + 40 := by
+        unfold signExtend12; bv_decide
+      have h16 : ((evmSp + 32) + signExtend12 (16 : BitVec 12) : Word) =
+          evmSp + 48 := by
+        unfold signExtend12; bv_decide
+      have h24 : ((evmSp + 32) + signExtend12 (24 : BitVec 12) : Word) =
+          evmSp + 56 := by
+        unfold signExtend12; bv_decide
+      rw [h0, h8, h16, h24]
+      unfold evmWordIs at hp
+      have hSrc8 : ((evmSp + 32) + 8 : Word) = evmSp + 40 := by bv_omega
+      have hSrc16 : ((evmSp + 32) + 16 : Word) = evmSp + 48 := by bv_omega
+      have hSrc24 : ((evmSp + 32) + 24 : Word) = evmSp + 56 := by bv_omega
+      rw [hSrc8, hSrc16, hSrc24] at hp
+      xperm_hyp hp)
+    (fun _ hp => by
+      have hRestore : ((evmSp + 32) + signExtend12 (-32 : BitVec 12) : Word) =
+          evmSp := by
+        unfold signExtend12; bv_decide
+      have h0 : ((evmSp + 32) + signExtend12 (0 : BitVec 12) : Word) =
+          evmSp + 32 := by
+        unfold signExtend12; bv_decide
+      have h8 : ((evmSp + 32) + signExtend12 (8 : BitVec 12) : Word) =
+          evmSp + 40 := by
+        unfold signExtend12; bv_decide
+      have h16 : ((evmSp + 32) + signExtend12 (16 : BitVec 12) : Word) =
+          evmSp + 48 := by
+        unfold signExtend12; bv_decide
+      have h24 : ((evmSp + 32) + signExtend12 (24 : BitVec 12) : Word) =
+          evmSp + 56 := by
+        unfold signExtend12; bv_decide
+      rw [hRestore, h0, h8, h16, h24] at hp
+      have hSp0 : (sp + signExtend12 (0 : BitVec 12) : Word) = sp := by
+        unfold signExtend12; bv_decide
+      have hSp8 : (sp + signExtend12 (8 : BitVec 12) : Word) = sp + 8 := by
+        unfold signExtend12; bv_decide
+      have hSp16 : (sp + signExtend12 (16 : BitVec 12) : Word) = sp + 16 := by
+        unfold signExtend12; bv_decide
+      have hSp24 : (sp + signExtend12 (24 : BitVec 12) : Word) = sp + 24 := by
+        unfold signExtend12; bv_decide
+      have hSrc8 : ((evmSp + 32) + 8 : Word) = evmSp + 40 := by bv_omega
+      have hSrc16 : ((evmSp + 32) + 16 : Word) = evmSp + 48 := by bv_omega
+      have hSrc24 : ((evmSp + 32) + 24 : Word) = evmSp + 56 := by bv_omega
+      rw [hSp0, hSp8, hSp16, hSp24] at hp
+      unfold evmWordIs
+      rw [hSrc8, hSrc16, hSrc24]
+      xperm_hyp hp)
+    h_unmarshal
+
 /-- Compose the squaring marshal pair (16 instr) plus its trailing JAL
     (1 instr) with `mul_callable_spec_within` (64 instr) at the JAL target.
 


### PR DESCRIPTION
## Summary
- add exp_loop_un_marshal_and_restore_word_spec_within
- bridge an evmWordIs result at evmSp + 32 through the unmarshal block into the local EXP scratch word

## Verification
- lake build EvmAsm.Evm64.Exp.SquaringPairThenMulCall
- lake build

Refs #92
Beads: evm-asm-mtj3, evm-asm-nrfpf, evm-asm-vgsif
Depends on #3419