### PR TITLE
feat(exp): bundle iter-body code

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/Base.lean
+++ b/EvmAsm/Evm64/Exp/Compose/Base.lean
@@ -548,6 +548,95 @@ theorem exp_squaring_call_block_code_block_subs {base : Word}
     exp_squaring_call_block_code_square_sub,
     exp_squaring_call_block_code_un_marshal_and_restore_sub⟩
 
+/-- CodeReq decomposition for the 6-instruction `exp_iter_body`: bit-test,
+    square JAL, and conditional-multiply branch/call. This body-only handle is
+    the direct target for the `exp_iter_body_spec_within` composition; the
+    existing `expOneIterCode` adds the loop-back tail at `base + 24`. -/
+abbrev expIterBodyCode (base : Word)
+    (mulOff : BitVec 21) (skipOff : BitVec 13) : CodeReq :=
+  CodeReq.unionAll [
+    CodeReq.ofProg base EvmAsm.Evm64.exp_bit_test_block,
+    CodeReq.ofProg (base + 12) (EvmAsm.Evm64.exp_square_block mulOff),
+    CodeReq.ofProg (base + 16) (EvmAsm.Evm64.exp_cond_mul_block mulOff skipOff)
+  ]
+
+theorem expIterBodyCode_bit_test_sub {base : Word}
+    {mulOff : BitVec 21} {skipOff : BitVec 13} :
+    ∀ a i, (CodeReq.ofProg base EvmAsm.Evm64.exp_bit_test_block) a = some i →
+      (expIterBodyCode base mulOff skipOff) a = some i := by
+  unfold expIterBodyCode
+  simp only [CodeReq.unionAll_cons]
+  exact CodeReq.union_mono_left
+
+theorem expIterBodyCode_square_sub {base : Word}
+    {mulOff : BitVec 21} {skipOff : BitVec 13} :
+    ∀ a i, (CodeReq.ofProg (base + 12)
+      (EvmAsm.Evm64.exp_square_block mulOff)) a = some i →
+      (expIterBodyCode base mulOff skipOff) a = some i := by
+  unfold expIterBodyCode
+  simp only [CodeReq.unionAll_cons]
+  apply CodeReq.mono_union_right
+    (CodeReq.ofProg_disjoint_range (fun k1 k2 hk1 hk2 => by
+      simp only [exp_bit_test_block_len, exp_square_block_len] at hk1 hk2
+      bv_omega))
+  exact CodeReq.union_mono_left
+
+theorem expIterBodyCode_cond_mul_sub {base : Word}
+    {mulOff : BitVec 21} {skipOff : BitVec 13} :
+    ∀ a i, (CodeReq.ofProg (base + 16)
+      (EvmAsm.Evm64.exp_cond_mul_block mulOff skipOff)) a = some i →
+      (expIterBodyCode base mulOff skipOff) a = some i := by
+  unfold expIterBodyCode
+  simp only [CodeReq.unionAll_cons]
+  apply CodeReq.mono_union_right
+    (CodeReq.ofProg_disjoint_range (fun k1 k2 hk1 hk2 => by
+      simp only [exp_bit_test_block_len, exp_cond_mul_block_len] at hk1 hk2
+      bv_omega))
+  apply CodeReq.mono_union_right
+    (CodeReq.ofProg_disjoint_range (fun k1 k2 hk1 hk2 => by
+      simp only [exp_square_block_len, exp_cond_mul_block_len] at hk1 hk2
+      bv_omega))
+  exact CodeReq.union_mono_left
+
+theorem expIterBodyCode_block_subs {base : Word}
+    {mulOff : BitVec 21} {skipOff : BitVec 13} :
+    (∀ a i, (CodeReq.ofProg base EvmAsm.Evm64.exp_bit_test_block) a = some i →
+      (expIterBodyCode base mulOff skipOff) a = some i) ∧
+    (∀ a i, (CodeReq.ofProg (base + 12)
+      (EvmAsm.Evm64.exp_square_block mulOff)) a = some i →
+      (expIterBodyCode base mulOff skipOff) a = some i) ∧
+    (∀ a i, (CodeReq.ofProg (base + 16)
+      (EvmAsm.Evm64.exp_cond_mul_block mulOff skipOff)) a = some i →
+      (expIterBodyCode base mulOff skipOff) a = some i) := by
+  exact ⟨expIterBodyCode_bit_test_sub, expIterBodyCode_square_sub,
+    expIterBodyCode_cond_mul_sub⟩
+
+theorem expIterBodyCode_eq_ofProg (base : Word)
+    (mulOff : BitVec 21) (skipOff : BitVec 13) :
+    expIterBodyCode base mulOff skipOff =
+      CodeReq.ofProg base (EvmAsm.Evm64.exp_iter_body mulOff skipOff) := by
+  unfold expIterBodyCode
+  unfold EvmAsm.Evm64.exp_iter_body
+  simp only [EvmAsm.Rv64.seq]
+  unfold Program
+  symm
+  rw [CodeReq.ofProg_append]
+  have h12 :
+      base + BitVec.ofNat 64 (4 *
+        (EvmAsm.Evm64.exp_bit_test_block).length) = base + 12 := by
+    rw [EvmAsm.Evm64.exp_bit_test_block_length]
+    rfl
+  rw [h12]
+  rw [CodeReq.ofProg_append]
+  have h16 :
+      (base + 12 : Word) + BitVec.ofNat 64 (4 *
+        (EvmAsm.Evm64.exp_square_block mulOff).length) = base + 16 := by
+    rw [EvmAsm.Evm64.exp_square_block_length]
+    bv_addr
+  rw [h16]
+  simp only [CodeReq.unionAll_cons, CodeReq.unionAll_nil]
+  rw [CodeReq.union_empty_right]
+
 /-- CodeReq decomposition for one EXP loop iteration. This mirrors
     `exp_loop`: bit-test (3 instructions), square call (1), conditional
     multiply branch/call (2), and loop-back (2). -/


### PR DESCRIPTION
## Summary
- add expIterBodyCode for the 6-instruction EXP iteration body
- add bit-test/square/conditional-multiply sub-block inclusions
- prove expIterBodyCode_eq_ofProg for exp_iter_body

## Verification
- lake build EvmAsm.Evm64.Exp.Compose.Base
- lake build

Refs #92
Beads: evm-asm-epgh, evm-asm-160a5