### PR TITLE
feat(exp): expose iter subblocks in evm_exp code

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/TopCodeSpecs.lean
+++ b/EvmAsm/Evm64/Exp/Compose/TopCodeSpecs.lean
@@ -88,4 +88,45 @@ theorem exp_epilogue_evm_exp_spec_within
   rw [hnext] at h
   exact cpsTripleWithin_extend_code (h := h) (hmono := evmExpCode_epilogue_sub)
 
+/-- Bit-test sub-block directly included in the top-level EXP code bundle. -/
+theorem evmExpCode_iter_bit_test_sub {base : Word}
+    {mulOff : BitVec 21} {skipOff backOff : BitVec 13} :
+    ∀ a i, (CodeReq.ofProg (base + 28) EvmAsm.Evm64.exp_bit_test_block) a = some i →
+      (evmExpCode base mulOff skipOff backOff) a = some i := by
+  intro a i h
+  exact evmExpCode_iter_body_sub a i (expIterBodyFullCode_bit_test_sub a i h)
+
+/-- Squaring-call sub-block directly included in the top-level EXP code bundle. -/
+theorem evmExpCode_iter_squaring_sub {base : Word}
+    {mulOff : BitVec 21} {skipOff backOff : BitVec 13} :
+    ∀ a i, (exp_squaring_call_block_code (base + 40) mulOff) a = some i →
+      (evmExpCode base mulOff skipOff backOff) a = some i := by
+  intro a i h
+  have haddr : (base + 40 : Word) = base + 28 + 12 := by bv_omega
+  rw [haddr] at h
+  exact evmExpCode_iter_body_sub a i (expIterBodyFullCode_squaring_sub a i h)
+
+/-- Conditional-multiply sub-block directly included in the top-level EXP code
+    bundle. -/
+theorem evmExpCode_iter_cond_mul_sub {base : Word}
+    {mulOff : BitVec 21} {skipOff backOff : BitVec 13} :
+    ∀ a i, (EvmAsm.Evm64.exp_cond_mul_call_with_skip_block_code
+      (base + 144) mulOff skipOff) a = some i →
+      (evmExpCode base mulOff skipOff backOff) a = some i := by
+  intro a i h
+  have haddr : (base + 144 : Word) = base + 28 + 116 := by bv_omega
+  rw [haddr] at h
+  exact evmExpCode_iter_body_sub a i (expIterBodyFullCode_cond_mul_sub a i h)
+
+/-- Loop-back sub-block directly included in the top-level EXP code bundle. -/
+theorem evmExpCode_iter_loop_back_sub {base : Word}
+    {mulOff : BitVec 21} {skipOff backOff : BitVec 13} :
+    ∀ a i, (CodeReq.ofProg (base + 252)
+      (EvmAsm.Evm64.exp_loop_back backOff)) a = some i →
+      (evmExpCode base mulOff skipOff backOff) a = some i := by
+  intro a i h
+  have haddr : (base + 252 : Word) = base + 28 + 224 := by bv_omega
+  rw [haddr] at h
+  exact evmExpCode_iter_body_sub a i (expIterBodyFullCode_loop_back_sub a i h)
+
 end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- add direct evmExpCode inclusion lemmas for the bit-test, squaring-call, conditional-multiply-with-skip, and loop-back sub-blocks inside exp_iter_body_full
- keep the helpers in Compose/TopCodeSpecs so Compose/Base.lean remains under the line cap

Stacked on #3428.
Refs #92
Beads: evm-asm-loh1n, evm-asm-w5mk

## Verification
- wc -l EvmAsm/Evm64/Exp/Compose/Base.lean EvmAsm/Evm64/Exp/Compose/TopCodeSpecs.lean
- lake build EvmAsm.Evm64.Exp.Compose.TopCodeSpecs
- lake build