### PR TITLE
feat(exp): lift square jal specs to evm_exp code

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/TopCodeSpecs.lean
+++ b/EvmAsm/Evm64/Exp/Compose/TopCodeSpecs.lean
@@ -288,4 +288,34 @@ theorem evmExpCode_cond_mul_beq_sub {base : Word}
     (EvmAsm.Evm64.exp_cond_mul_call_with_skip_block_code_beq_sub
       (base + 144) mulOff skipOff a i h)
 
+/-- Squaring-call JAL spec lifted to the top-level EXP code bundle. -/
+theorem exp_squaring_square_evm_exp_spec_within
+    (mulOff : BitVec 21) (skipOff backOff : BitVec 13)
+    (vOld : Word) (base mulTarget : Word)
+    (hmul : ((base + 104) + signExtend21 mulOff : Word) = mulTarget) :
+    cpsTripleWithin 1 (base + 104) mulTarget
+      (evmExpCode base mulOff skipOff backOff)
+      (.x1 ↦ᵣ vOld)
+      (.x1 ↦ᵣ (base + 108)) := by
+  have h := EvmAsm.Evm64.exp_square_block_spec_within mulOff vOld (base + 104)
+  rw [hmul] at h
+  have hret : ((base + 104 : Word) + 4) = base + 108 := by bv_omega
+  rw [hret] at h
+  exact cpsTripleWithin_extend_code (h := h) (hmono := evmExpCode_squaring_square_sub)
+
+/-- Conditional-multiply JAL spec lifted to the top-level EXP code bundle. -/
+theorem exp_cond_mul_square_evm_exp_spec_within
+    (mulOff : BitVec 21) (skipOff backOff : BitVec 13)
+    (vOld : Word) (base mulTarget : Word)
+    (hmul : ((base + 212) + signExtend21 mulOff : Word) = mulTarget) :
+    cpsTripleWithin 1 (base + 212) mulTarget
+      (evmExpCode base mulOff skipOff backOff)
+      (.x1 ↦ᵣ vOld)
+      (.x1 ↦ᵣ (base + 216)) := by
+  have h := EvmAsm.Evm64.exp_square_block_spec_within mulOff vOld (base + 212)
+  rw [hmul] at h
+  have hret : ((base + 212 : Word) + 4) = base + 216 := by bv_omega
+  rw [hret] at h
+  exact cpsTripleWithin_extend_code (h := h) (hmono := evmExpCode_cond_mul_square_sub)
+
 end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- lift the squaring-call JAL spec to the top-level evmExpCode bundle
- lift the conditional-multiply JAL spec to the top-level evmExpCode bundle
- keep the new proofs in TopCodeSpecs.lean so Compose/Base.lean remains under the file-size guardrail

Stacked after #3433, which has merged into this stack base.
Refs #92.
Beads: evm-asm-vqjhc, evm-asm-w5mk.

## Verification
- lake build EvmAsm.Evm64.Exp.Compose.TopCodeSpecs
- scripts/check-file-size.sh
- wc -l EvmAsm/Evm64/Exp/Compose/Base.lean EvmAsm/Evm64/Exp/Compose/TopCodeSpecs.lean  # Base.lean = 1199, TopCodeSpecs.lean = 321
- lake build