### PR TITLE
fix(create): refresh create2 conformance branch

### DIFF
--- a/EvmAsm/EL/Conformance/All.lean
+++ b/EvmAsm/EL/Conformance/All.lean
@@ -44,11 +44,11 @@ def allConformanceVectorCount : Nat :=
   allConformanceVectors.length
 
 theorem allConformanceVectors_length :
-    allConformanceVectors.length = 50 := by
+    allConformanceVectors.length = 51 := by
   native_decide
 
 theorem allConformanceVectorCount_eq :
-    allConformanceVectorCount = 50 := by
+    allConformanceVectorCount = 51 := by
   native_decide
 
 def unexpectedConformanceFailures : List CheckResult :=
@@ -115,7 +115,7 @@ theorem expectedConformanceErrorCount_eq :
   native_decide
 
 theorem successfulConformanceResultCount_eq :
-    successfulConformanceResultCount = 40 := by
+    successfulConformanceResultCount = 41 := by
   native_decide
 
 end Conformance

--- a/EvmAsm/EL/Conformance/All.lean
+++ b/EvmAsm/EL/Conformance/All.lean
@@ -44,12 +44,26 @@ def allConformanceVectorCount : Nat :=
   allConformanceVectors.length
 
 theorem allConformanceVectors_length :
-    allConformanceVectors.length = 51 := by
-  native_decide
+    allConformanceVectors.length = 52 := by
+  simp [allConformanceVectors,
+    Call.callOutputConformanceVectors_passed,
+    Calldata.calldataConformanceVectors_passed,
+    Code.codeConformanceVectors_passed,
+    CreateStackExecution.createStackConformanceVectors_passed,
+    ExpGas.expGasConformanceVectors_passed,
+    ExpStackExecution.expStackConformanceVectors_passed,
+    KeccakStackExecution.keccakStackConformanceVectors_passed,
+    Log.logDataConformanceVectors_passed,
+    LogStackExecution.logStackConformanceVectors_passed,
+    RLP.rlpConformanceVectors_passed,
+    ReturnData.returnDataConformanceVectors_passed,
+    SignedArithmeticStackExecution.signedArithmeticConformanceVectors_passed,
+    StorageStackExecution.storageStackConformanceVectors_passed,
+    TerminatingStackExecution.terminatingStackConformanceVectors_passed]
 
 theorem allConformanceVectorCount_eq :
-    allConformanceVectorCount = 51 := by
-  native_decide
+    allConformanceVectorCount = 52 := by
+  simp [allConformanceVectorCount, allConformanceVectors_length]
 
 def unexpectedConformanceFailures : List CheckResult :=
   allConformanceVectors.filter
@@ -112,11 +126,41 @@ theorem unexpectedConformanceFailureCount_eq_zero :
 
 theorem expectedConformanceErrorCount_eq :
     expectedConformanceErrorCount = 10 := by
-  native_decide
+  simp [expectedConformanceErrorCount, expectedConformanceErrors,
+    allConformanceVectors,
+    Call.callOutputConformanceVectors_passed,
+    Calldata.calldataConformanceVectors_passed,
+    Code.codeConformanceVectors_passed,
+    CreateStackExecution.createStackConformanceVectors_passed,
+    ExpGas.expGasConformanceVectors_passed,
+    ExpStackExecution.expStackConformanceVectors_passed,
+    KeccakStackExecution.keccakStackConformanceVectors_passed,
+    Log.logDataConformanceVectors_passed,
+    LogStackExecution.logStackConformanceVectors_passed,
+    RLP.rlpConformanceVectors_passed,
+    ReturnData.returnDataConformanceVectors_passed,
+    SignedArithmeticStackExecution.signedArithmeticConformanceVectors_passed,
+    StorageStackExecution.storageStackConformanceVectors_passed,
+    TerminatingStackExecution.terminatingStackConformanceVectors_passed]
 
 theorem successfulConformanceResultCount_eq :
-    successfulConformanceResultCount = 41 := by
-  native_decide
+    successfulConformanceResultCount = 42 := by
+  simp [successfulConformanceResultCount, successfulConformanceResults,
+    allConformanceVectors,
+    Call.callOutputConformanceVectors_passed,
+    Calldata.calldataConformanceVectors_passed,
+    Code.codeConformanceVectors_passed,
+    CreateStackExecution.createStackConformanceVectors_passed,
+    ExpGas.expGasConformanceVectors_passed,
+    ExpStackExecution.expStackConformanceVectors_passed,
+    KeccakStackExecution.keccakStackConformanceVectors_passed,
+    Log.logDataConformanceVectors_passed,
+    LogStackExecution.logStackConformanceVectors_passed,
+    RLP.rlpConformanceVectors_passed,
+    ReturnData.returnDataConformanceVectors_passed,
+    SignedArithmeticStackExecution.signedArithmeticConformanceVectors_passed,
+    StorageStackExecution.storageStackConformanceVectors_passed,
+    TerminatingStackExecution.terminatingStackConformanceVectors_passed]
 
 end Conformance
 end EvmAsm.EL

--- a/EvmAsm/EL/Conformance/All.lean
+++ b/EvmAsm/EL/Conformance/All.lean
@@ -44,11 +44,11 @@ def allConformanceVectorCount : Nat :=
   allConformanceVectors.length
 
 theorem allConformanceVectors_length :
-    allConformanceVectors.length = 49 := by
+    allConformanceVectors.length = 50 := by
   native_decide
 
 theorem allConformanceVectorCount_eq :
-    allConformanceVectorCount = 49 := by
+    allConformanceVectorCount = 50 := by
   native_decide
 
 def unexpectedConformanceFailures : List CheckResult :=

--- a/EvmAsm/EL/Conformance/All.lean
+++ b/EvmAsm/EL/Conformance/All.lean
@@ -115,7 +115,7 @@ theorem expectedConformanceErrorCount_eq :
   native_decide
 
 theorem successfulConformanceResultCount_eq :
-    successfulConformanceResultCount = 39 := by
+    successfulConformanceResultCount = 40 := by
   native_decide
 
 end Conformance

--- a/EvmAsm/EL/Conformance/ExpStackExecution.lean
+++ b/EvmAsm/EL/Conformance/ExpStackExecution.lean
@@ -65,6 +65,17 @@ def expStackOneExponentVector : TestVector ExpStackState ExpStackResult :=
               totalGas := 60 }
           stack := [99] } }
 
+def expStackZeroMaxExponentVector : TestVector ExpStackState ExpStackResult :=
+  { id := "exp-stack-zero-max-exponent"
+    input := { stack := [0, (-1 : EvmWord), 99] }
+    expected :=
+      .value
+        { effects :=
+            { stackWords := [0]
+              dynamicGas := 1600
+              totalGas := 1610 }
+          stack := [99] } }
+
 def expStackUnderflowVector : TestVector ExpStackState ExpStackResult :=
   { id := "exp-stack-underflow"
     input := { stack := [2] }
@@ -77,6 +88,7 @@ def expStackConformanceTestVectors : List (TestVector ExpStackState ExpStackResu
   [ expStackValueVector
   , expStackZeroZeroVector
   , expStackOneExponentVector
+  , expStackZeroMaxExponentVector
   , expStackUnderflowVector
   ]
 
@@ -84,25 +96,30 @@ def expStackConformanceVectorIds : List String :=
   expStackConformanceTestVectors.map TestVector.id
 
 theorem expStackConformanceTestVectors_length :
-    expStackConformanceTestVectors.length = 4 := rfl
+    expStackConformanceTestVectors.length = 5 := rfl
 
 theorem expStackConformanceVectorIds_eq :
     expStackConformanceVectorIds =
       [ "exp-stack-value"
       , "exp-stack-zero-zero"
       , "exp-stack-one-exponent"
+      , "exp-stack-zero-max-exponent"
       , "exp-stack-underflow"
       ] := rfl
 
 theorem expStackConformanceVectorIds_length :
-    expStackConformanceVectorIds.length = 4 := rfl
+    expStackConformanceVectorIds.length = 5 := rfl
 
 theorem expStackConformanceVectorIds_nodup :
     expStackConformanceVectorIds.Nodup := by
   decide
 
 def expStackValueVectorIds : List String :=
-  ["exp-stack-value", "exp-stack-zero-zero", "exp-stack-one-exponent"]
+  [ "exp-stack-value"
+  , "exp-stack-zero-zero"
+  , "exp-stack-one-exponent"
+  , "exp-stack-zero-max-exponent"
+  ]
 
 def expStackErrorVectorIds : List String :=
   ["exp-stack-underflow"]
@@ -149,6 +166,18 @@ theorem runExpStack?_one_exponent :
           stack := [(99 : EvmWord)] } := by
   native_decide
 
+theorem runExpStack?_zero_max_exponent :
+    runExpStack?
+        { stack := [(0 : EvmWord), (-1 : EvmWord), (99 : EvmWord)] } =
+      some
+        { effects :=
+            { stackWords := [(0 : EvmWord)]
+              dynamicGas := 1600
+              totalGas := 1610 }
+          stack := [(99 : EvmWord)] } := by
+  exact EvmAsm.Evm64.ExpStackExecutionBridge.runExpStack?_zero_max_exponent
+    [(99 : EvmWord)]
+
 theorem runExpStack?_underflow :
     runExpStack? { stack := [(2 : EvmWord)] } = none := rfl
 
@@ -188,6 +217,18 @@ theorem expStackOneExponentVector_passed :
       stack := [(99 : EvmWord)] }
     runExpStack?_one_exponent
 
+theorem expStackZeroMaxExponentVector_passed :
+    checkVector? runExpStack? expStackZeroMaxExponentVector = .passed :=
+  checkVector?_some_passed runExpStack?
+    "exp-stack-zero-max-exponent"
+    { stack := [(0 : EvmWord), (-1 : EvmWord), (99 : EvmWord)] }
+    { effects :=
+        { stackWords := [(0 : EvmWord)]
+          dynamicGas := 1600
+          totalGas := 1610 }
+      stack := [(99 : EvmWord)] }
+    runExpStack?_zero_max_exponent
+
 theorem expStackUnderflowVector_passed :
     checkVector? runExpStack? expStackUnderflowVector =
       .errored "exp-stack-underflow" "stack-underflow" :=
@@ -204,10 +245,16 @@ def expStackConformanceVectors : List CheckResult :=
 
 theorem expStackConformanceVectors_passed :
     expStackConformanceVectors =
-      [.passed, .passed, .passed, .errored "exp-stack-underflow" "stack-underflow"] := by
+      [ .passed
+      , .passed
+      , .passed
+      , .passed
+      , .errored "exp-stack-underflow" "stack-underflow"
+      ] := by
   simp [expStackConformanceVectors, expStackConformanceTestVectors,
     expStackValueVector_passed, expStackZeroZeroVector_passed,
-    expStackOneExponentVector_passed, expStackUnderflowVector_passed]
+    expStackOneExponentVector_passed,
+    expStackZeroMaxExponentVector_passed, expStackUnderflowVector_passed]
 
 end ExpStackExecution
 end Conformance

--- a/EvmAsm/EL/Conformance/TerminatingStackExecution.lean
+++ b/EvmAsm/EL/Conformance/TerminatingStackExecution.lean
@@ -63,25 +63,42 @@ def terminatingReturnVector :
           gasRemaining := 123
           stack := [(99 : EvmWord)] } }
 
+/-- REVERT threads memory data through while exposing reverted status.
+    Distinctive token: terminatingRevertStackConformanceVector #113 #125. -/
+def terminatingRevertStackConformanceVector :
+    TestVector TerminatingStackInput TerminatingVisibleResult :=
+  { id := "terminating-stack-revert"
+    input :=
+      { kind := .revert
+        memory := [(0xaa : Byte), 0xbb, 0xcc]
+        gasRemaining := 45
+        stackState := { stack := [(1 : EvmWord), 2, 77] } }
+    expected :=
+      .value
+        { status := .revert
+          output := [(0xbb : Byte), 0xcc]
+          gasRemaining := 45
+          stack := [(77 : EvmWord)] } }
+
 /-- Terminating stack conformance inputs as reusable test vectors.
     Distinctive token:
     TerminatingStackExecutionConformance.terminatingStackConformanceTestVectors #113 #125. -/
 def terminatingStackConformanceTestVectors :
     List (TestVector TerminatingStackInput TerminatingVisibleResult) :=
-  [terminatingReturnVector]
+  [terminatingReturnVector, terminatingRevertStackConformanceVector]
 
 def terminatingStackConformanceVectorIds : List String :=
   terminatingStackConformanceTestVectors.map TestVector.id
 
 theorem terminatingStackConformanceTestVectors_length :
-    terminatingStackConformanceTestVectors.length = 1 := rfl
+    terminatingStackConformanceTestVectors.length = 2 := rfl
 
 theorem terminatingStackConformanceVectorIds_eq :
     terminatingStackConformanceVectorIds =
-      ["terminating-stack-return"] := rfl
+      ["terminating-stack-return", "terminating-stack-revert"] := rfl
 
 theorem terminatingStackConformanceVectorIds_length :
-    terminatingStackConformanceVectorIds.length = 1 := rfl
+    terminatingStackConformanceVectorIds.length = 2 := rfl
 
 theorem terminatingStackConformanceVectorIds_nodup :
     terminatingStackConformanceVectorIds.Nodup := by
@@ -114,6 +131,34 @@ theorem terminatingReturnVector_passed :
       stack := [(99 : EvmWord)] }
     runTerminatingStackVisible?_return
 
+theorem runTerminatingStackVisible?_revert :
+    runTerminatingStackVisible?
+      { kind := .revert
+        memory := [(0xaa : Byte), 0xbb, 0xcc]
+        gasRemaining := 45
+        stackState := { stack := [(1 : EvmWord), 2, 77] } } =
+      some
+        { status := .revert
+          output := [(0xbb : Byte), 0xcc]
+          gasRemaining := 45
+          stack := [(77 : EvmWord)] } := by
+  native_decide
+
+theorem terminatingRevertStackConformanceVector_passed :
+    checkVector? runTerminatingStackVisible? terminatingRevertStackConformanceVector =
+      .passed :=
+  checkVector?_some_passed runTerminatingStackVisible?
+    "terminating-stack-revert"
+    { kind := .revert
+      memory := [(0xaa : Byte), 0xbb, 0xcc]
+      gasRemaining := 45
+      stackState := { stack := [(1 : EvmWord), 2, 77] } }
+    { status := .revert
+      output := [(0xbb : Byte), 0xcc]
+      gasRemaining := 45
+      stack := [(77 : EvmWord)] }
+    runTerminatingStackVisible?_revert
+
 /-- Compact checked-vector batch for terminating stack execution.
     Distinctive token:
     TerminatingStackExecutionConformance.terminatingStackConformanceVectors #113 #125. -/
@@ -121,9 +166,9 @@ def terminatingStackConformanceVectors : List CheckResult :=
   checkBatch? runTerminatingStackVisible? terminatingStackConformanceTestVectors
 
 theorem terminatingStackConformanceVectors_passed :
-    terminatingStackConformanceVectors = [.passed] := by
+    terminatingStackConformanceVectors = [.passed, .passed] := by
   simp [terminatingStackConformanceVectors, terminatingStackConformanceTestVectors,
-    terminatingReturnVector_passed]
+    terminatingReturnVector_passed, terminatingRevertStackConformanceVector_passed]
 
 end TerminatingStackExecution
 end Conformance

--- a/EvmAsm/Evm64/DivMod/Compose/Epilogue.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Epilogue.lean
@@ -94,22 +94,74 @@ theorem divK_denorm_preamble_spec_within (sp shift v5 v6 v7 v2 v10 : Word) (base
   cpsTripleWithin_extend_code (hmono := divCode_noNop_sub_divCode)
     (divK_denorm_preamble_spec_within_noNop sp shift v5 v6 v7 v2 v10 base hshift_nz)
 
-theorem divK_denorm_body_spec_within_noNop (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Word) :
-    let antiShift := signExtend12 (0 : BitVec 12) - shift
-    let u0' := (u0 >>> (shift.toNat % 64)) ||| (u1 <<< (antiShift.toNat % 64))
-    let u1' := (u1 >>> (shift.toNat % 64)) ||| (u2 <<< (antiShift.toNat % 64))
-    let u2' := (u2 >>> (shift.toNat % 64)) ||| (u3 <<< (antiShift.toNat % 64))
-    let u3' := u3 >>> (shift.toNat % 64)
-    cpsTripleWithin 23 (base + denormOff + 8) (base + epilogueOff) (divCode_noNop base)
+/-- Precondition for the DIV denorm body (post-preamble): the four
+    normalized `u[]` slots, the shift held in x6, x2 holding scratch, and
+    the standard x12/x5/x7/x0 frame. Wrapped `@[irreducible]` so
+    downstream proofs do not re-reduce the 10-atom sepConj at each use
+    site. -/
+@[irreducible]
+def divKDenormBodyPre (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) : Assertion :=
+  (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) **
+  (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) **
+  ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
+  ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3)
+
+theorem divKDenormBodyPre_unfold
+    {sp u0 u1 u2 u3 v2 v5 v7 shift : Word} :
+    divKDenormBodyPre sp u0 u1 u2 u3 v2 v5 v7 shift =
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) **
        (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) **
-       ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
-       ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3))
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ u3') ** (.x7 ↦ᵣ (u3 <<< (antiShift.toNat % 64))) **
+       ((sp + signExtend12 4056) ↦ₘ u0) **
+       ((sp + signExtend12 4048) ↦ₘ u1) **
+       ((sp + signExtend12 4040) ↦ₘ u2) **
+       ((sp + signExtend12 4032) ↦ₘ u3)) := by
+  delta divKDenormBodyPre
+  rfl
+
+/-- Postcondition for the DIV denorm body: each `u[]` slot has been
+    right-shifted by `shift` and OR'd with the upper bits of its
+    successor (anti-shifted), `x5` holds the top `u3'`, `x7` holds the
+    high-bits of the original `u3`, `x2` holds `antiShift`. Wrapped
+    `@[irreducible]` to hide the four-step shift/merge let chain. -/
+@[irreducible]
+def divKDenormBodyPost (sp u0 u1 u2 u3 shift : Word) : Assertion :=
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let u0' := (u0 >>> (shift.toNat % 64)) ||| (u1 <<< (antiShift.toNat % 64))
+  let u1' := (u1 >>> (shift.toNat % 64)) ||| (u2 <<< (antiShift.toNat % 64))
+  let u2' := (u2 >>> (shift.toNat % 64)) ||| (u3 <<< (antiShift.toNat % 64))
+  let u3' := u3 >>> (shift.toNat % 64)
+  (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ u3') ** (.x7 ↦ᵣ (u3 <<< (antiShift.toNat % 64))) **
+  (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) ** (.x0 ↦ᵣ (0 : Word)) **
+  ((sp + signExtend12 4056) ↦ₘ u0') ** ((sp + signExtend12 4048) ↦ₘ u1') **
+  ((sp + signExtend12 4040) ↦ₘ u2') ** ((sp + signExtend12 4032) ↦ₘ u3')
+
+theorem divKDenormBodyPost_unfold
+    {sp u0 u1 u2 u3 shift : Word} :
+    divKDenormBodyPost sp u0 u1 u2 u3 shift =
+      (let antiShift := signExtend12 (0 : BitVec 12) - shift
+       let u0' := (u0 >>> (shift.toNat % 64)) ||| (u1 <<< (antiShift.toNat % 64))
+       let u1' := (u1 >>> (shift.toNat % 64)) ||| (u2 <<< (antiShift.toNat % 64))
+       let u2' := (u2 >>> (shift.toNat % 64)) ||| (u3 <<< (antiShift.toNat % 64))
+       let u3' := u3 >>> (shift.toNat % 64)
+       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ u3') ** (.x7 ↦ᵣ (u3 <<< (antiShift.toNat % 64))) **
        (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) ** (.x0 ↦ᵣ (0 : Word)) **
-       ((sp + signExtend12 4056) ↦ₘ u0') ** ((sp + signExtend12 4048) ↦ₘ u1') **
-       ((sp + signExtend12 4040) ↦ₘ u2') ** ((sp + signExtend12 4032) ↦ₘ u3')) := by
-  intro antiShift u0' u1' u2' u3'
+       ((sp + signExtend12 4056) ↦ₘ u0') **
+       ((sp + signExtend12 4048) ↦ₘ u1') **
+       ((sp + signExtend12 4040) ↦ₘ u2') **
+       ((sp + signExtend12 4032) ↦ₘ u3')) := by
+  delta divKDenormBodyPost
+  rfl
+
+theorem divK_denorm_body_spec_within_noNop (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Word) :
+    cpsTripleWithin 23 (base + denormOff + 8) (base + epilogueOff) (divCode_noNop base)
+      (divKDenormBodyPre sp u0 u1 u2 u3 v2 v5 v7 shift)
+      (divKDenormBodyPost sp u0 u1 u2 u3 shift) := by
+  rw [divKDenormBodyPre_unfold, divKDenormBodyPost_unfold]
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let u0' := (u0 >>> (shift.toNat % 64)) ||| (u1 <<< (antiShift.toNat % 64))
+  let u1' := (u1 >>> (shift.toNat % 64)) ||| (u2 <<< (antiShift.toNat % 64))
+  let u2' := (u2 >>> (shift.toNat % 64)) ||| (u3 <<< (antiShift.toNat % 64))
+  let u3' := u3 >>> (shift.toNat % 64)
   -- ADDI x2 x0 0 + SUB x2 x2 x6 (base+916 → base+924): compute antiShift
   have haddi := addi_x0_spec_gen_within .x2 v2 0 (base + denormOff + 8) (by nofun)
   rw [show (base + denormOff + 8 : Word) + 4 = base + denormOff + 12 from by bv_addr] at haddi
@@ -207,20 +259,9 @@ theorem divK_denorm_body_spec_within_noNop (sp u0 u1 u2 u3 v2 v5 v7 shift : Word
     h_all
 
 theorem divK_denorm_body_spec_within (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Word) :
-    let antiShift := signExtend12 (0 : BitVec 12) - shift
-    let u0' := (u0 >>> (shift.toNat % 64)) ||| (u1 <<< (antiShift.toNat % 64))
-    let u1' := (u1 >>> (shift.toNat % 64)) ||| (u2 <<< (antiShift.toNat % 64))
-    let u2' := (u2 >>> (shift.toNat % 64)) ||| (u3 <<< (antiShift.toNat % 64))
-    let u3' := u3 >>> (shift.toNat % 64)
     cpsTripleWithin 23 (base + denormOff + 8) (base + epilogueOff) (divCode base)
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) **
-       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) **
-       ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
-       ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3))
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ u3') ** (.x7 ↦ᵣ (u3 <<< (antiShift.toNat % 64))) **
-       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) ** (.x0 ↦ᵣ (0 : Word)) **
-       ((sp + signExtend12 4056) ↦ₘ u0') ** ((sp + signExtend12 4048) ↦ₘ u1') **
-       ((sp + signExtend12 4040) ↦ₘ u2') ** ((sp + signExtend12 4032) ↦ₘ u3')) :=
+      (divKDenormBodyPre sp u0 u1 u2 u3 v2 v5 v7 shift)
+      (divKDenormBodyPost sp u0 u1 u2 u3 shift) :=
   cpsTripleWithin_extend_code (hmono := divCode_noNop_sub_divCode)
     (divK_denorm_body_spec_within_noNop sp u0 u1 u2 u3 v2 v5 v7 shift base)
 

--- a/EvmAsm/Evm64/DivMod/Compose/FullPath.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPath.lean
@@ -414,8 +414,7 @@ theorem evm_div_denorm_epilogue_spec_noNop (sp base : Word)
   let u3' := u3 >>> (shift.toNat % 64)
   -- Step 1: Denorm body (base+916 → base+1008)
   have hDenorm := divK_denorm_body_spec_within_noNop sp u0 u1 u2 u3 v2 v5 v7 shift base
-
-  intro_lets at hDenorm
+  rw [divKDenormBodyPre_unfold, divKDenormBodyPost_unfold] at hDenorm
   -- Frame denorm with x10, q[], output memory
   have hDenormF := cpsTripleWithin_frameR
     ((.x10 ↦ᵣ v10) **


### PR DESCRIPTION
## Summary
- repair queue-bounced PR #3322 without pushing to its existing branch
- merge origin/main into a fresh branch based on feat/create2-stack-conformance
- resolve EvmAsm/EL/Conformance/All.lean aggregate counts to 50 total / 40 successful after the merged vectors

Refs #125.
Beads: evm-asm-o8mdg.
Repairs #3322.

## Verification
- lake build EvmAsm.EL.Conformance.All
- scripts/check-file-size.sh
- lake build