### PR TITLE
feat(exp): lift squaring mul-call to evm_exp code

### DIFF
--- a/EvmAsm/Evm64/Exp.lean
+++ b/EvmAsm/Evm64/Exp.lean
@@ -29,6 +29,7 @@ import EvmAsm.Evm64.Exp.Compose.Base
 import EvmAsm.Evm64.Exp.Compose.TopCodeSubs
 import EvmAsm.Evm64.Exp.Compose.LoopCodeSpecs
 import EvmAsm.Evm64.Exp.Compose.TopCodeSpecs
+import EvmAsm.Evm64.Exp.Compose.CondMulSkip
 import EvmAsm.Evm64.Exp.Layout
 import EvmAsm.Evm64.Exp.Spec
 import EvmAsm.Evm64.Exp.Semantic

--- a/EvmAsm/Evm64/Exp.lean
+++ b/EvmAsm/Evm64/Exp.lean
@@ -22,6 +22,7 @@ import EvmAsm.Evm64.Exp.SquaringCallSeq
 import EvmAsm.Evm64.Exp.SquaringMarshalPairPost
 import EvmAsm.Evm64.Exp.SquaringPairThenMulCall
 import EvmAsm.Evm64.Exp.CondMulMarshalPair
+import EvmAsm.Evm64.Exp.CondMulMarshalPairPost
 import EvmAsm.Evm64.Exp.CondMulCall
 import EvmAsm.Evm64.Exp.AddrNorm
 import EvmAsm.Evm64.Exp.Compose.Base

--- a/EvmAsm/Evm64/Exp.lean
+++ b/EvmAsm/Evm64/Exp.lean
@@ -31,4 +31,5 @@ import EvmAsm.Evm64.Exp.Compose.LoopCodeSpecs
 import EvmAsm.Evm64.Exp.Compose.TopCodeSpecs
 import EvmAsm.Evm64.Exp.Layout
 import EvmAsm.Evm64.Exp.Spec
+import EvmAsm.Evm64.Exp.Semantic
 import EvmAsm.Evm64.Exp.StackExecutionBridge

--- a/EvmAsm/Evm64/Exp.lean
+++ b/EvmAsm/Evm64/Exp.lean
@@ -30,6 +30,7 @@ import EvmAsm.Evm64.Exp.Compose.TopCodeSubs
 import EvmAsm.Evm64.Exp.Compose.LoopCodeSpecs
 import EvmAsm.Evm64.Exp.Compose.TopCodeSpecs
 import EvmAsm.Evm64.Exp.Compose.CondMulSkip
+import EvmAsm.Evm64.Exp.Compose.SquaringStep
 import EvmAsm.Evm64.Exp.Layout
 import EvmAsm.Evm64.Exp.Spec
 import EvmAsm.Evm64.Exp.Semantic

--- a/EvmAsm/Evm64/Exp/Compose/CondMulSkip.lean
+++ b/EvmAsm/Evm64/Exp/Compose/CondMulSkip.lean
@@ -86,4 +86,60 @@ theorem exp_cond_mul_skip_then_triple_evm_exp_union_spec_within
     frame hframe v10 mulOff skipOff backOff base skipTarget mulTarget hskip
   exact cpsBranchWithin_seq_cpsTripleWithin_same_cr hbeq hfalse (fun _ hp => hp)
 
+/-- Existing conditional-MUL callable path framed with the false-branch facts
+    produced by the preceding BEQ skip gate. -/
+theorem exp_cond_mul_marshal_pair_then_mul_call_false_branch_spec_within
+    (sp evmSp tOld vOld r0 r1 r2 r3 a0 a1 a2 a3 d0 d1 d2 d3 e0 e1 e2 e3
+      v6 v7 v10 v11 mulTarget : Word)
+    (mulOff : BitVec 21) (skipOff backOff : BitVec 13) (base : Word)
+    (hmt : mulTarget = (base + 212) + signExtend21 mulOff)
+    (hd : CodeReq.Disjoint
+            (evmExpCode base mulOff skipOff backOff)
+            (mul_callable_code mulTarget)) :
+    let callPre :=
+      ((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+       ((evmSp + signExtend12 (0 : BitVec 12)) ↦ₘ d0) **
+       ((evmSp + signExtend12 (8 : BitVec 12)) ↦ₘ d1) **
+       ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ d2) **
+       ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ d3) **
+       ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ e0) **
+       ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ e1) **
+       ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ e2) **
+       ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ e3) **
+       ((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
+       ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **
+       ((evmSp + signExtend12 ((-48) : BitVec 12)) ↦ₘ a2) **
+       ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) **
+       (.x1 ↦ᵣ vOld))
+    let callPost :=
+      ((.x2 ↦ᵣ sp) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+       ((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
+       ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **
+       ((evmSp + signExtend12 ((-48) : BitVec 12)) ↦ₘ a2) **
+       ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3) **
+       evmMulStackPost evmSp (expResultWord r0 r1 r2 r3)
+                              (expResultWord a0 a1 a2 a3) **
+       (.x1 ↦ᵣ (base + 216)))
+    cpsTripleWithin (17 + 64) (base + 148) ((base + 216) &&& ~~~1)
+      ((evmExpCode base mulOff skipOff backOff).union
+        (mul_callable_code mulTarget))
+      (callPre ** ((.x0 ↦ᵣ (0 : Word)) ** ⌜v10 ≠ 0⌝))
+      (callPost ** ((.x0 ↦ᵣ (0 : Word)) ** ⌜v10 ≠ 0⌝)) := by
+  intro callPre callPost
+  have hcall := exp_cond_mul_marshal_pair_then_mul_call_evm_exp_spec_within
+    sp evmSp tOld vOld r0 r1 r2 r3 a0 a1 a2 a3 d0 d1 d2 d3 e0 e1 e2 e3
+    v6 v7 v10 v11 mulTarget mulOff skipOff backOff base hmt hd
+  have hframed :=
+    cpsTripleWithin_frameR ((.x0 ↦ᵣ (0 : Word)) ** ⌜v10 ≠ 0⌝) (by pcFree) hcall
+  simpa [callPre, callPost] using hframed
+
 end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/CondMulSkip.lean
+++ b/EvmAsm/Evm64/Exp/Compose/CondMulSkip.lean
@@ -39,4 +39,27 @@ theorem exp_cond_mul_beq_evm_exp_union_spec_within
         (base := base) (mulOff := mulOff) (skipOff := skipOff)
         (backOff := backOff) a i hcode))
 
+/-- Permuted-frame variant of `exp_cond_mul_beq_evm_exp_union_spec_within`,
+    matching the frame-first shape used by the following callable composition. -/
+theorem exp_cond_mul_beq_evm_exp_union_spec_within_frameL
+    (frame : Assertion) (hframe : frame.pcFree)
+    (v10 : Word) (mulOff : BitVec 21) (skipOff backOff : BitVec 13)
+    (base skipTarget mulTarget : Word)
+    (hskip : ((base + 144) + signExtend13 skipOff : Word) = skipTarget) :
+    cpsBranchWithin 1 (base + 144)
+      ((evmExpCode base mulOff skipOff backOff).union
+        (mul_callable_code mulTarget))
+      (frame ** ((.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word))))
+      skipTarget
+        (frame ** ((.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜v10 = 0⌝))
+      (base + 148)
+        (frame ** ((.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜v10 ≠ 0⌝)) := by
+  have h := exp_cond_mul_beq_evm_exp_union_spec_within
+    frame hframe v10 mulOff skipOff backOff base skipTarget mulTarget hskip
+  exact cpsBranchWithin_weaken
+    (fun _ hp => by xperm_hyp hp)
+    (fun _ hp => by xperm_hyp hp)
+    (fun _ hp => by xperm_hyp hp)
+    h
+
 end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/CondMulSkip.lean
+++ b/EvmAsm/Evm64/Exp/Compose/CondMulSkip.lean
@@ -142,4 +142,65 @@ theorem exp_cond_mul_marshal_pair_then_mul_call_false_branch_spec_within
     cpsTripleWithin_frameR ((.x0 ↦ᵣ (0 : Word)) ** ⌜v10 ≠ 0⌝) (by pcFree) hcall
   simpa [callPre, callPost] using hframed
 
+/-- Frame-shaped version of the conditional-MUL callable false branch, with
+    `x10`, `x0`, and the nonzero fact separated for the skip adapter. -/
+theorem exp_cond_mul_marshal_pair_then_mul_call_false_branch_frame_spec_within
+    (sp evmSp tOld vOld r0 r1 r2 r3 a0 a1 a2 a3 d0 d1 d2 d3 e0 e1 e2 e3
+      v6 v7 v10 v11 mulTarget : Word)
+    (mulOff : BitVec 21) (skipOff backOff : BitVec 13) (base : Word)
+    (hmt : mulTarget = (base + 212) + signExtend21 mulOff)
+    (hd : CodeReq.Disjoint
+            (evmExpCode base mulOff skipOff backOff)
+            (mul_callable_code mulTarget)) :
+    let callFrame :=
+      ((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+       ((evmSp + signExtend12 (0 : BitVec 12)) ↦ₘ d0) **
+       ((evmSp + signExtend12 (8 : BitVec 12)) ↦ₘ d1) **
+       ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ d2) **
+       ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ d3) **
+       ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ e0) **
+       ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ e1) **
+       ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ e2) **
+       ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ e3) **
+       ((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
+       ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **
+       ((evmSp + signExtend12 ((-48) : BitVec 12)) ↦ₘ a2) **
+       ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x11 ↦ᵣ v11) **
+       (.x1 ↦ᵣ vOld))
+    let callPost :=
+      ((.x2 ↦ᵣ sp) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+       ((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
+       ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **
+       ((evmSp + signExtend12 ((-48) : BitVec 12)) ↦ₘ a2) **
+       ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3) **
+       evmMulStackPost evmSp (expResultWord r0 r1 r2 r3)
+                              (expResultWord a0 a1 a2 a3) **
+       (.x1 ↦ᵣ (base + 216)))
+    cpsTripleWithin (17 + 64) (base + 148) ((base + 216) &&& ~~~1)
+      ((evmExpCode base mulOff skipOff backOff).union
+        (mul_callable_code mulTarget))
+      (callFrame ** ((.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜v10 ≠ 0⌝))
+      (callPost ** ((.x0 ↦ᵣ (0 : Word)) ** ⌜v10 ≠ 0⌝)) := by
+  intro callFrame callPost
+  have h := exp_cond_mul_marshal_pair_then_mul_call_false_branch_spec_within
+    sp evmSp tOld vOld r0 r1 r2 r3 a0 a1 a2 a3 d0 d1 d2 d3 e0 e1 e2 e3
+    v6 v7 v10 v11 mulTarget mulOff skipOff backOff base hmt hd
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by
+      dsimp [callFrame] at hp ⊢
+      xperm_hyp hp)
+    (fun _ hp => by
+      dsimp [callPost] at hp ⊢
+      xperm_hyp hp)
+    h
+
 end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/CondMulSkip.lean
+++ b/EvmAsm/Evm64/Exp/Compose/CondMulSkip.lean
@@ -203,4 +203,69 @@ theorem exp_cond_mul_marshal_pair_then_mul_call_false_branch_frame_spec_within
       xperm_hyp hp)
     h
 
+/-- Conditional-multiply skip gate composed with the full MUL-call false path. -/
+theorem exp_cond_mul_skip_then_mul_call_evm_exp_spec_within
+    (sp evmSp tOld vOld r0 r1 r2 r3 a0 a1 a2 a3 d0 d1 d2 d3 e0 e1 e2 e3
+      v6 v7 v10 v11 mulTarget : Word)
+    (mulOff : BitVec 21) (skipOff backOff : BitVec 13)
+    (base skipTarget : Word)
+    (hskip : ((base + 144) + signExtend13 skipOff : Word) = skipTarget)
+    (hmt : mulTarget = (base + 212) + signExtend21 mulOff)
+    (hd : CodeReq.Disjoint
+            (evmExpCode base mulOff skipOff backOff)
+            (mul_callable_code mulTarget)) :
+    let callFrame :=
+      ((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+       ((evmSp + signExtend12 (0 : BitVec 12)) ↦ₘ d0) **
+       ((evmSp + signExtend12 (8 : BitVec 12)) ↦ₘ d1) **
+       ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ d2) **
+       ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ d3) **
+       ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ e0) **
+       ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ e1) **
+       ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ e2) **
+       ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ e3) **
+       ((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
+       ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **
+       ((evmSp + signExtend12 ((-48) : BitVec 12)) ↦ₘ a2) **
+       ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x11 ↦ᵣ v11) **
+       (.x1 ↦ᵣ vOld))
+    let callPost :=
+      ((.x2 ↦ᵣ sp) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+       ((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
+       ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **
+       ((evmSp + signExtend12 ((-48) : BitVec 12)) ↦ₘ a2) **
+       ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3) **
+       evmMulStackPost evmSp (expResultWord r0 r1 r2 r3)
+                              (expResultWord a0 a1 a2 a3) **
+       (.x1 ↦ᵣ (base + 216)))
+    cpsBranchWithin (1 + (17 + 64)) (base + 144)
+      ((evmExpCode base mulOff skipOff backOff).union
+        (mul_callable_code mulTarget))
+      (callFrame ** ((.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word))))
+      skipTarget
+        (callFrame ** ((.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜v10 = 0⌝))
+      ((base + 216) &&& ~~~1)
+        (callPost ** ((.x0 ↦ᵣ (0 : Word)) ** ⌜v10 ≠ 0⌝)) := by
+  intro callFrame callPost
+  have hfalse := exp_cond_mul_marshal_pair_then_mul_call_false_branch_frame_spec_within
+    sp evmSp tOld vOld r0 r1 r2 r3 a0 a1 a2 a3 d0 d1 d2 d3 e0 e1 e2 e3
+    v6 v7 v10 v11 mulTarget mulOff skipOff backOff base hmt hd
+  exact exp_cond_mul_skip_then_triple_evm_exp_union_spec_within
+    (frame := callFrame)
+    (postFalse := callPost ** ((.x0 ↦ᵣ (0 : Word)) ** ⌜v10 ≠ 0⌝))
+    (by
+      dsimp [callFrame]
+      pcFree)
+    v10 mulOff skipOff backOff base skipTarget mulTarget
+    (((base + 216) &&& ~~~1)) hskip hfalse
+
 end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/CondMulSkip.lean
+++ b/EvmAsm/Evm64/Exp/Compose/CondMulSkip.lean
@@ -1,0 +1,42 @@
+/-
+  EvmAsm.Evm64.Exp.Compose.CondMulSkip
+
+  Small EXP full-loop building blocks around the conditional-multiply skip gate.
+-/
+
+import EvmAsm.Evm64.Exp.Compose.TopCodeSpecs
+
+namespace EvmAsm.Evm64.Exp.Compose
+
+open EvmAsm.Rv64.Tactics
+open EvmAsm.Rv64
+
+/-- Conditional-multiply BEQ skip gate lifted to the top-level EXP code bundle
+    unioned with the shared `mul_callable` code.  Full-loop composition uses
+    this code shape when the nonzero branch continues into the callable path. -/
+theorem exp_cond_mul_beq_evm_exp_union_spec_within
+    (frame : Assertion) (hframe : frame.pcFree)
+    (v10 : Word) (mulOff : BitVec 21) (skipOff backOff : BitVec 13)
+    (base skipTarget mulTarget : Word)
+    (hskip : ((base + 144) + signExtend13 skipOff : Word) = skipTarget) :
+    cpsBranchWithin 1 (base + 144)
+      ((evmExpCode base mulOff skipOff backOff).union
+        (mul_callable_code mulTarget))
+      (((.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word))) ** frame)
+      skipTarget
+        (((.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜v10 = 0⌝) ** frame)
+      (base + 148)
+        (((.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜v10 ≠ 0⌝) ** frame) := by
+  have hbeq := beq_spec_within .x10 .x0 skipOff v10 (0 : Word) (base + 144)
+  rw [hskip] at hbeq
+  have hnext : ((base + 144 : Word) + 4) = base + 148 := by bv_omega
+  rw [hnext] at hbeq
+  have hframed := cpsBranchWithin_frameR frame hframe hbeq
+  exact cpsBranchWithin_extend_code (h := hframed) (hmono := by
+    intro a i hcode
+    exact CodeReq.union_mono_left a i
+      (evmExpCode_cond_mul_beq_sub
+        (base := base) (mulOff := mulOff) (skipOff := skipOff)
+        (backOff := backOff) a i hcode))
+
+end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/CondMulSkip.lean
+++ b/EvmAsm/Evm64/Exp/Compose/CondMulSkip.lean
@@ -62,4 +62,28 @@ theorem exp_cond_mul_beq_evm_exp_union_spec_within_frameL
     (fun _ hp => by xperm_hyp hp)
     h
 
+/-- Compose the lifted EXP conditional-multiply skip gate with an arbitrary
+    false-branch continuation over the same top-level/callable code region. -/
+theorem exp_cond_mul_skip_then_triple_evm_exp_union_spec_within
+    {nSteps : Nat} {frame postFalse : Assertion} (hframe : frame.pcFree)
+    (v10 : Word) (mulOff : BitVec 21) (skipOff backOff : BitVec 13)
+    (base skipTarget mulTarget exitFalse : Word)
+    (hskip : ((base + 144) + signExtend13 skipOff : Word) = skipTarget)
+    (hfalse :
+      cpsTripleWithin nSteps (base + 148) exitFalse
+        ((evmExpCode base mulOff skipOff backOff).union
+          (mul_callable_code mulTarget))
+        (frame ** ((.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜v10 ≠ 0⌝))
+        postFalse) :
+    cpsBranchWithin (1 + nSteps) (base + 144)
+      ((evmExpCode base mulOff skipOff backOff).union
+        (mul_callable_code mulTarget))
+      (frame ** ((.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word))))
+      skipTarget
+        (frame ** ((.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜v10 = 0⌝))
+      exitFalse postFalse := by
+  have hbeq := exp_cond_mul_beq_evm_exp_union_spec_within_frameL
+    frame hframe v10 mulOff skipOff backOff base skipTarget mulTarget hskip
+  exact cpsBranchWithin_seq_cpsTripleWithin_same_cr hbeq hfalse (fun _ hp => hp)
+
 end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/SquaringStep.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SquaringStep.lean
@@ -1,0 +1,37 @@
+/-
+  EvmAsm.Evm64.Exp.Compose.SquaringStep
+
+  Small EXP full-loop building blocks around the squaring call path.
+-/
+
+import EvmAsm.Evm64.Exp.Compose.TopCodeSpecs
+
+namespace EvmAsm.Evm64.Exp.Compose
+
+open EvmAsm.Rv64.Tactics
+open EvmAsm.Rv64
+
+/-- Squaring unmarshal word spec lifted to the top-level EXP code bundle
+    unioned with the shared `mul_callable` code. -/
+theorem exp_squaring_un_marshal_word_evm_exp_union_spec_within
+    (sp evmSp tOld r0 r1 r2 r3 mulTarget : Word) (w : EvmWord)
+    (mulOff : BitVec 21) (skipOff backOff : BitVec 13)
+    (base : Word) :
+    cpsTripleWithin 9 (base + 108) (base + 144)
+      ((evmExpCode base mulOff skipOff backOff).union
+        (mul_callable_code mulTarget))
+      ((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ (evmSp + 32)) ** (.x5 ↦ᵣ tOld) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+       evmWordIs (evmSp + 32) w)
+      ((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ w.getLimbN 3) **
+       evmWordIs sp w ** evmWordIs (evmSp + 32) w) := by
+  have h := exp_squaring_un_marshal_word_evm_exp_spec_within
+    sp evmSp tOld r0 r1 r2 r3 w mulOff skipOff backOff base
+  exact cpsTripleWithin_extend_code (h := h) (hmono := by
+    intro a i hcode
+    exact CodeReq.union_mono_left a i hcode)
+
+end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/SquaringStep.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SquaringStep.lean
@@ -61,4 +61,68 @@ theorem exp_squaring_un_marshal_word_evm_exp_union_regOwn5_spec_within
     (fun _ hp => hp)
     h
 
+/-- Sequence the squaring MUL-call path into the squaring unmarshal step. -/
+theorem exp_squaring_mul_call_then_unmarshal_evm_exp_spec_within
+    (sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+      v6 v7 v10 v11 mulTarget : Word)
+    (mulOff : BitVec 21) (skipOff backOff : BitVec 13) (base : Word)
+    (hmt : mulTarget = (base + 104) + signExtend21 mulOff)
+    (halign : ((base + 108) &&& ~~~(1 : Word)) = base + 108)
+    (hd : CodeReq.Disjoint
+            (evmExpCode base mulOff skipOff backOff)
+            (mul_callable_code mulTarget)) :
+    let w := expResultWord r0 r1 r2 r3
+    let sq := w * w
+    let frame :=
+      ((.x1 ↦ᵣ (base + 108)) ** regOwn .x6 ** regOwn .x7 **
+       regOwn .x10 ** regOwn .x11 **
+       memOwn evmSp ** memOwn (evmSp + 8) **
+       memOwn (evmSp + 16) ** memOwn (evmSp + 24))
+    cpsTripleWithin ((17 + 64) + 9) (base + 40) (base + 144)
+      ((evmExpCode base mulOff skipOff backOff).union
+        (mul_callable_code mulTarget))
+      ((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+       ((evmSp + signExtend12 (0 : BitVec 12)) ↦ₘ d0) **
+       ((evmSp + signExtend12 (8 : BitVec 12)) ↦ₘ d1) **
+       ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ d2) **
+       ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ d3) **
+       ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ e0) **
+       ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ e1) **
+       ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ e2) **
+       ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ e3) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) **
+       (.x1 ↦ᵣ vOld))
+      (((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ sq.getLimbN 3) **
+        evmWordIs sp sq ** evmWordIs (evmSp + 32) sq) ** frame) := by
+  intro w sq frame
+  have hcall := exp_squaring_marshal_pair_then_mul_call_evm_exp_spec_within
+    sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+    v6 v7 v10 v11 mulTarget mulOff skipOff backOff base hmt hd
+  rw [halign] at hcall
+  have hunm := exp_squaring_un_marshal_word_evm_exp_union_regOwn5_spec_within
+    sp evmSp r0 r1 r2 r3 mulTarget sq mulOff skipOff backOff base
+  have hunmFramed :=
+    cpsTripleWithin_frameR frame (by
+      dsimp [frame]
+      pcFree) hunm
+  have hseq : cpsTripleWithin ((17 + 64) + 9) (base + 40) (base + 144)
+      ((evmExpCode base mulOff skipOff backOff).union
+        (mul_callable_code mulTarget)) _ _ :=
+    cpsTripleWithin_seq_perm_same_cr
+      (fun _ hp => by
+        dsimp [frame, w, sq] at hp ⊢
+        delta evmMulStackPost at hp
+        sep_perm hp)
+      hcall hunmFramed
+  exact cpsTripleWithin_weaken
+    (fun _ hp => hp)
+    (fun _ hp => by
+      dsimp [frame, sq] at hp ⊢
+      sep_perm hp)
+    hseq
+
 end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/SquaringStep.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SquaringStep.lean
@@ -34,4 +34,31 @@ theorem exp_squaring_un_marshal_word_evm_exp_union_spec_within
     intro a i hcode
     exact CodeReq.union_mono_left a i hcode)
 
+/-- Ownership-form variant of the squaring unmarshal word spec.  This matches
+    the `regOwn .x5` produced by `mul_callable` in the squaring path. -/
+theorem exp_squaring_un_marshal_word_evm_exp_union_regOwn5_spec_within
+    (sp evmSp r0 r1 r2 r3 mulTarget : Word) (w : EvmWord)
+    (mulOff : BitVec 21) (skipOff backOff : BitVec 13)
+    (base : Word) :
+    cpsTripleWithin 9 (base + 108) (base + 144)
+      ((evmExpCode base mulOff skipOff backOff).union
+        (mul_callable_code mulTarget))
+      (((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ (evmSp + 32)) **
+        ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+        ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+        ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+        ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+        evmWordIs (evmSp + 32) w) ** regOwn .x5)
+      ((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ w.getLimbN 3) **
+       evmWordIs sp w ** evmWordIs (evmSp + 32) w) := by
+  refine cpsTripleWithin_of_forall_regIs_to_regOwn ?_
+  intro tOld
+  have h := exp_squaring_un_marshal_word_evm_exp_union_spec_within
+    sp evmSp tOld r0 r1 r2 r3 mulTarget w mulOff skipOff backOff base
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by
+      xperm_hyp hp)
+    (fun _ hp => hp)
+    h
+
 end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/TopCodeSpecs.lean
+++ b/EvmAsm/Evm64/Exp/Compose/TopCodeSpecs.lean
@@ -389,6 +389,77 @@ theorem exp_squaring_un_marshal_word_evm_exp_spec_within
   exact cpsTripleWithin_extend_code (h := h)
     (hmono := evmExpCode_squaring_un_marshal_and_restore_sub)
 
+/-- Squaring marshal/JAL plus MUL-call spec lifted to the top-level EXP code bundle. -/
+theorem exp_squaring_marshal_pair_then_mul_call_evm_exp_spec_within
+    (sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+      v6 v7 v10 v11 mulTarget : Word)
+    (mulOff : BitVec 21) (skipOff backOff : BitVec 13) (base : Word)
+    (hmt : mulTarget = (base + 104) + signExtend21 mulOff)
+    (hd : CodeReq.Disjoint
+            (evmExpCode base mulOff skipOff backOff)
+            (mul_callable_code mulTarget)) :
+    cpsTripleWithin (17 + 64) (base + 40) ((base + 108) &&& ~~~1)
+      ((evmExpCode base mulOff skipOff backOff).union
+        (mul_callable_code mulTarget))
+      ((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+       ((evmSp + signExtend12 (0 : BitVec 12)) ↦ₘ d0) **
+       ((evmSp + signExtend12 (8 : BitVec 12)) ↦ₘ d1) **
+       ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ d2) **
+       ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ d3) **
+       ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ e0) **
+       ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ e1) **
+       ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ e2) **
+       ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ e3) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) **
+       (.x1 ↦ᵣ vOld))
+      ((.x2 ↦ᵣ sp) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+       evmMulStackPost evmSp (expResultWord r0 r1 r2 r3)
+                              (expResultWord r0 r1 r2 r3) **
+       (.x1 ↦ᵣ (base + 108))) := by
+  have hmt' : mulTarget = ((base + 40) + 64) + signExtend21 mulOff := by
+    rw [show ((base + 40 : Word) + 64) = base + 104 by bv_omega]
+    exact hmt
+  have hdLower : CodeReq.Disjoint
+      (exp_squaring_call_block_code (base + 40) mulOff)
+      (mul_callable_code mulTarget) := by
+    intro a
+    rcases hd a with hev | hmul
+    · left
+      cases hcode : exp_squaring_call_block_code (base + 40) mulOff a with
+      | none => rfl
+      | some instr =>
+          have hev' := evmExpCode_iter_squaring_sub
+            (base := base) (mulOff := mulOff) (skipOff := skipOff)
+            (backOff := backOff) a instr hcode
+          rw [hev] at hev'
+          contradiction
+    · right
+      exact hmul
+  have h := EvmAsm.Evm64.exp_squaring_marshal_pair_then_mul_call_spec_within
+    sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+    v6 v7 v10 v11 mulTarget mulOff (base + 40) hmt' hdLower
+  have hret : (((base + 40 : Word) + 68) &&& ~~~1) = ((base + 108) &&& ~~~1) := by
+    rw [show ((base + 40 : Word) + 68) = base + 108 by bv_omega]
+  rw [hret] at h
+  have hlink : ((base + 40 : Word) + 68) = base + 108 := by bv_omega
+  rw [hlink] at h
+  exact cpsTripleWithin_extend_code (h := h) (hmono := by
+    exact CodeReq.union_sub
+      (fun a i hcode =>
+        CodeReq.union_mono_left a i
+          (evmExpCode_iter_squaring_sub
+            (base := base) (mulOff := mulOff) (skipOff := skipOff)
+            (backOff := backOff) a i hcode))
+      (CodeReq.mono_union_right hd (fun _ _ hcode => hcode)))
+
 /-- Conditional-multiply marshal pair lifted to the top-level EXP code bundle. -/
 theorem exp_cond_mul_marshal_pair_evm_exp_spec_within
     (sp evmSp tOld r0 r1 r2 r3 a0 a1 a2 a3 d0 d1 d2 d3 e0 e1 e2 e3 : Word)

--- a/EvmAsm/Evm64/Exp/Compose/TopCodeSpecs.lean
+++ b/EvmAsm/Evm64/Exp/Compose/TopCodeSpecs.lean
@@ -6,6 +6,7 @@
 -/
 
 import EvmAsm.Evm64.Exp.Compose.TopCodeSubs
+import EvmAsm.Evm64.Exp.CondMulMarshalPairPost
 import EvmAsm.Evm64.Exp.CondMulMarshalPair
 import EvmAsm.Evm64.Exp.SquaringCallSeq
 import EvmAsm.Evm64.Exp.SquaringPairThenMulCall
@@ -623,6 +624,120 @@ theorem exp_cond_mul_un_marshal_word_evm_exp_spec_within
   rw [hnext] at h
   exact cpsTripleWithin_extend_code (h := h)
     (hmono := evmExpCode_cond_mul_un_marshal_and_restore_sub)
+
+/-- Conditional-multiply marshal/JAL plus MUL-call spec lifted to the top-level EXP code bundle. -/
+theorem exp_cond_mul_marshal_pair_then_mul_call_evm_exp_spec_within
+    (sp evmSp tOld vOld r0 r1 r2 r3 a0 a1 a2 a3 d0 d1 d2 d3 e0 e1 e2 e3
+      v6 v7 v10 v11 mulTarget : Word)
+    (mulOff : BitVec 21) (skipOff backOff : BitVec 13) (base : Word)
+    (hmt : mulTarget = (base + 212) + signExtend21 mulOff)
+    (hd : CodeReq.Disjoint
+            (evmExpCode base mulOff skipOff backOff)
+            (mul_callable_code mulTarget)) :
+    cpsTripleWithin (17 + 64) (base + 148) ((base + 216) &&& ~~~1)
+      ((evmExpCode base mulOff skipOff backOff).union
+        (mul_callable_code mulTarget))
+      ((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+       ((evmSp + signExtend12 (0 : BitVec 12)) ↦ₘ d0) **
+       ((evmSp + signExtend12 (8 : BitVec 12)) ↦ₘ d1) **
+       ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ d2) **
+       ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ d3) **
+       ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ e0) **
+       ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ e1) **
+       ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ e2) **
+       ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ e3) **
+       ((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
+       ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **
+       ((evmSp + signExtend12 ((-48) : BitVec 12)) ↦ₘ a2) **
+       ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) **
+       (.x1 ↦ᵣ vOld))
+      ((.x2 ↦ᵣ sp) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+       ((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
+       ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **
+       ((evmSp + signExtend12 ((-48) : BitVec 12)) ↦ₘ a2) **
+       ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3) **
+       evmMulStackPost evmSp (expResultWord r0 r1 r2 r3)
+                              (expResultWord a0 a1 a2 a3) **
+       (.x1 ↦ᵣ (base + 216))) := by
+  have htarget : ((base + 212) + signExtend21 mulOff : Word) = mulTarget := by
+    exact hmt.symm
+  have hpair := exp_cond_mul_marshal_pair_then_square_evm_exp_spec_within
+    sp evmSp tOld vOld r0 r1 r2 r3 a0 a1 a2 a3 d0 d1 d2 d3 e0 e1 e2 e3
+    mulOff skipOff backOff base mulTarget htarget
+  have hpairFramed :=
+    cpsTripleWithin_frameR
+      ((.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11))
+      (by pcFree) hpair
+  have hmul := mul_callable_spec_within
+    evmSp mulTarget (base + 216)
+    (expResultWord r0 r1 r2 r3) (expResultWord a0 a1 a2 a3)
+    a3 v6 v7 v10 v11
+  have hmulFramed :=
+    cpsTripleWithin_frameL
+      ((.x2 ↦ᵣ sp) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+       ((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
+       ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **
+       ((evmSp + signExtend12 ((-48) : BitVec 12)) ↦ₘ a2) **
+       ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3))
+      (by pcFree) hmul
+  have hseq :
+      cpsTripleWithin (17 + 64) (base + 148) ((base + 216) &&& ~~~1)
+        ((evmExpCode base mulOff skipOff backOff).union
+          (mul_callable_code mulTarget)) _ _ :=
+    cpsTripleWithin_seq hd
+      (cpsTripleWithin_weaken
+        (fun _ hp => hp)
+        (fun _ hp => by
+          have h0  : (evmSp + signExtend12 (0  : BitVec 12) : Word) = evmSp       := by
+            unfold signExtend12; bv_decide
+          have h8  : (evmSp + signExtend12 (8  : BitVec 12) : Word) = evmSp + 8   := by
+            unfold signExtend12; bv_decide
+          have h16 : (evmSp + signExtend12 (16 : BitVec 12) : Word) = evmSp + 16  := by
+            unfold signExtend12; bv_decide
+          have h24 : (evmSp + signExtend12 (24 : BitVec 12) : Word) = evmSp + 24  := by
+            unfold signExtend12; bv_decide
+          have h32 : (evmSp + signExtend12 (32 : BitVec 12) : Word) = evmSp + 32  := by
+            unfold signExtend12; bv_decide
+          have h40 : (evmSp + signExtend12 (40 : BitVec 12) : Word) = evmSp + 40  := by
+            unfold signExtend12; bv_decide
+          have h48 : (evmSp + signExtend12 (48 : BitVec 12) : Word) = evmSp + 48  := by
+            unfold signExtend12; bv_decide
+          have h56 : (evmSp + signExtend12 (56 : BitVec 12) : Word) = evmSp + 56  := by
+            unfold signExtend12; bv_decide
+          rw [h0, h8, h16, h24, h32, h40, h48, h56] at hp
+          have hL : evmWordIs evmSp (expResultWord r0 r1 r2 r3) = _ :=
+            evmWordIs_sp_limbs_eq evmSp (expResultWord r0 r1 r2 r3) r0 r1 r2 r3
+              (expResultWord_getLimbN_0 r0 r1 r2 r3)
+              (expResultWord_getLimbN_1 r0 r1 r2 r3)
+              (expResultWord_getLimbN_2 r0 r1 r2 r3)
+              (expResultWord_getLimbN_3 r0 r1 r2 r3)
+          have hR : evmWordIs (evmSp + 32) (expResultWord a0 a1 a2 a3) = _ :=
+            evmWordIs_sp32_limbs_eq evmSp (expResultWord a0 a1 a2 a3) a0 a1 a2 a3
+              (expResultWord_getLimbN_0 a0 a1 a2 a3)
+              (expResultWord_getLimbN_1 a0 a1 a2 a3)
+              (expResultWord_getLimbN_2 a0 a1 a2 a3)
+              (expResultWord_getLimbN_3 a0 a1 a2 a3)
+          rw [hL, hR]
+          xperm_hyp hp)
+        hpairFramed)
+      hmulFramed
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by xperm_hyp hp)
+    (fun _ hp => by xperm_hyp hp)
+    hseq
 
 /-- Conditional-multiply skip gate and call prefix lifted to the top-level EXP code bundle. -/
 theorem exp_cond_mul_call_with_skip_evm_exp_spec_within

--- a/EvmAsm/Evm64/Exp/CondMulMarshalPairPost.lean
+++ b/EvmAsm/Evm64/Exp/CondMulMarshalPairPost.lean
@@ -1,0 +1,96 @@
+/-
+  EvmAsm.Evm64.Exp.CondMulMarshalPairPost
+
+  Bridge: fold the 8 limb-level memIs atoms produced by the post-state of
+  `exp_loop_cond_mul_marshal_pair_spec_within` into the two `evmWordIs`
+  predicates expected by `mul_callable_spec_within`.
+-/
+
+import EvmAsm.Evm64.Exp.CondMulMarshalPair
+import EvmAsm.Evm64.Exp.SquaringMarshalPairPost
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Fold the 8-atom post-state of `exp_loop_cond_mul_marshal_pair_spec_within`
+    into two `evmWordIs` atoms: factor 1 is the running result `r0..r3`, and
+    factor 2 is the fixed EXP base `a0..a3`. -/
+theorem exp_cond_mul_marshal_pair_post_evmWordIs
+    (evmSp r0 r1 r2 r3 a0 a1 a2 a3 : Word) :
+    (((evmSp + signExtend12 (0  : BitVec 12)) ↦ₘ r0) **
+     ((evmSp + signExtend12 (8  : BitVec 12)) ↦ₘ r1) **
+     ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+     ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+     ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ a0) **
+     ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ a1) **
+     ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ a2) **
+     ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ a3)) =
+    (evmWordIs evmSp (expResultWord r0 r1 r2 r3) **
+      evmWordIs (evmSp + 32) (expResultWord a0 a1 a2 a3)) := by
+  have h0  : (evmSp + signExtend12 (0  : BitVec 12) : Word) = evmSp       := by
+    unfold signExtend12; bv_decide
+  have h8  : (evmSp + signExtend12 (8  : BitVec 12) : Word) = evmSp + 8   := by
+    unfold signExtend12; bv_decide
+  have h16 : (evmSp + signExtend12 (16 : BitVec 12) : Word) = evmSp + 16  := by
+    unfold signExtend12; bv_decide
+  have h24 : (evmSp + signExtend12 (24 : BitVec 12) : Word) = evmSp + 24  := by
+    unfold signExtend12; bv_decide
+  have h32 : (evmSp + signExtend12 (32 : BitVec 12) : Word) = evmSp + 32  := by
+    unfold signExtend12; bv_decide
+  have h40 : (evmSp + signExtend12 (40 : BitVec 12) : Word) = evmSp + 40  := by
+    unfold signExtend12; bv_decide
+  have h48 : (evmSp + signExtend12 (48 : BitVec 12) : Word) = evmSp + 48  := by
+    unfold signExtend12; bv_decide
+  have h56 : (evmSp + signExtend12 (56 : BitVec 12) : Word) = evmSp + 56  := by
+    unfold signExtend12; bv_decide
+  rw [h0, h8, h16, h24, h32, h40, h48, h56]
+  rw [evmWordIs_sp_limbs_eq evmSp (expResultWord r0 r1 r2 r3) r0 r1 r2 r3
+        (expResultWord_getLimbN_0 r0 r1 r2 r3)
+        (expResultWord_getLimbN_1 r0 r1 r2 r3)
+        (expResultWord_getLimbN_2 r0 r1 r2 r3)
+        (expResultWord_getLimbN_3 r0 r1 r2 r3)]
+  rw [evmWordIs_sp32_limbs_eq evmSp (expResultWord a0 a1 a2 a3) a0 a1 a2 a3
+        (expResultWord_getLimbN_0 a0 a1 a2 a3)
+        (expResultWord_getLimbN_1 a0 a1 a2 a3)
+        (expResultWord_getLimbN_2 a0 a1 a2 a3)
+        (expResultWord_getLimbN_3 a0 a1 a2 a3)]
+  rw [sepConj_assoc', sepConj_assoc', sepConj_assoc']
+
+/-- Mid-tree variant of `exp_cond_mul_marshal_pair_post_evmWordIs`, for
+    folding the cond-mul post bridge inside a longer sep-conjunction chain. -/
+theorem exp_cond_mul_marshal_pair_post_evmWordIs_right
+    (evmSp r0 r1 r2 r3 a0 a1 a2 a3 : Word) (Q : Assertion) :
+    (((evmSp + signExtend12 (0  : BitVec 12)) ↦ₘ r0) **
+     ((evmSp + signExtend12 (8  : BitVec 12)) ↦ₘ r1) **
+     ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+     ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+     ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ a0) **
+     ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ a1) **
+     ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ a2) **
+     ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ a3) ** Q) =
+    (evmWordIs evmSp (expResultWord r0 r1 r2 r3) **
+      evmWordIs (evmSp + 32) (expResultWord a0 a1 a2 a3) ** Q) := by
+  rw [show
+      (((evmSp + signExtend12 (0  : BitVec 12)) ↦ₘ r0) **
+       ((evmSp + signExtend12 (8  : BitVec 12)) ↦ₘ r1) **
+       ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+       ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+       ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ a0) **
+       ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ a1) **
+       ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ a2) **
+       ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ a3) ** Q) =
+      ((((evmSp + signExtend12 (0  : BitVec 12)) ↦ₘ r0) **
+        ((evmSp + signExtend12 (8  : BitVec 12)) ↦ₘ r1) **
+        ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+        ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+        ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ a0) **
+        ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ a1) **
+        ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ a2) **
+        ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ a3)) ** Q) from by
+      rw [sepConj_assoc', sepConj_assoc', sepConj_assoc', sepConj_assoc',
+          sepConj_assoc', sepConj_assoc', sepConj_assoc']]
+  rw [exp_cond_mul_marshal_pair_post_evmWordIs]
+  rw [sepConj_assoc']
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Exp/Semantic.lean
+++ b/EvmAsm/Evm64/Exp/Semantic.lean
@@ -1,0 +1,25 @@
+/-
+  EvmAsm.Evm64.Exp.Semantic
+
+  Stack-level semantic scaffolding for EXP.  The final
+  `evm_exp_stack_spec_within` proof will live here once the full-loop
+  composition is connected to `EvmWord.exp`.
+-/
+
+import EvmAsm.Evm64.Exp.Spec
+
+namespace EvmAsm.Evm64
+
+/-- EXP edge case required by GH #92: `0^0 = 1`. -/
+example : EvmWord.exp (0 : EvmWord) (0 : EvmWord) = 1 := by
+  exact EvmWord.exp_zero_zero
+
+/-- EXP edge case required by GH #92: `x^1 = x`. -/
+example (x : EvmWord) : EvmWord.exp x 1 = x := by
+  exact EvmWord.exp_one_right x
+
+/-- EXP edge case required by GH #92: `2^256 = 0 mod 2^256`. -/
+example : EvmWord.exp (2 : EvmWord) (256 : EvmWord) = 0 := by
+  exact EvmWord.exp_two_256
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Exp/Semantic.lean
+++ b/EvmAsm/Evm64/Exp/Semantic.lean
@@ -6,6 +6,7 @@
   composition is connected to `EvmWord.exp`.
 -/
 
+import EvmAsm.Evm64.Exp.Args
 import EvmAsm.Evm64.Exp.Spec
 
 namespace EvmAsm.Evm64
@@ -36,6 +37,31 @@ theorem evm_exp_zero_exponent_stack_spec_within
        evmStackIs evmSp (baseWord :: EvmWord.exp baseWord 0 :: rest)) := by
   exact exp_boundary_result_exp_zero_full_post_stack_shape_clean_regs_spec_within
     sp evmSp cOld tOld m0 m1 m2 m3 base baseWord exponentWord rest
+
+/-- Semantic-facing zero-exponent wrapper phrased through the pure EXP stack
+    argument bridge. -/
+theorem evm_exp_zero_exponent_args_stack_spec_within
+    (sp evmSp cOld tOld m0 m1 m2 m3 : Word) (base : Word)
+    (baseWord : EvmWord) (rest : List EvmWord) :
+    cpsTripleWithin 15 base (base + 60) (expBoundaryProgramCode base)
+      ((.x2 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) ** (.x9 ↦ᵣ cOld) **
+       (.x5 ↦ᵣ tOld) ** (.x12 ↦ᵣ evmSp) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ m0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ m1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ m2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ m3) **
+       evmStackIs evmSp (baseWord :: (0 : EvmWord) :: rest))
+      ((.x2 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x9 ↦ᵣ (256 : Word)) **
+       (.x12 ↦ᵣ (evmSp + 32)) **
+       (.x5 ↦ᵣ (0 : Word)) **
+       evmWordIs sp (1 : EvmWord) **
+       evmStackIs evmSp
+         (baseWord ::
+          ExpArgs.expResultFromArgs (ExpArgs.expArgs baseWord 0) :: rest)) := by
+  simpa [ExpArgs.expResultFromArgs, ExpArgs.expArgs] using
+    evm_exp_zero_exponent_stack_spec_within
+      sp evmSp cOld tOld m0 m1 m2 m3 base baseWord (0 : EvmWord) rest
 
 /-- EXP edge case required by GH #92: `0^0 = 1`. -/
 example : EvmWord.exp (0 : EvmWord) (0 : EvmWord) = 1 := by

--- a/EvmAsm/Evm64/Exp/Semantic.lean
+++ b/EvmAsm/Evm64/Exp/Semantic.lean
@@ -8,6 +8,7 @@
 
 import EvmAsm.Evm64.Exp.Args
 import EvmAsm.Evm64.Exp.Spec
+import EvmAsm.Evm64.Exp.StackExecutionBridge
 
 namespace EvmAsm.Evm64
 
@@ -62,6 +63,16 @@ theorem evm_exp_zero_exponent_args_stack_spec_within
   simpa [ExpArgs.expResultFromArgs, ExpArgs.expArgs] using
     evm_exp_zero_exponent_stack_spec_within
       sp evmSp cOld tOld m0 m1 m2 m3 base baseWord (0 : EvmWord) rest
+
+/-- Semantic-facing alias for the pure EXP stack executor's zero-exponent
+    edge case.  Distinctive token: evm_exp_zero_exponent_run_stack?_semantic. -/
+theorem evm_exp_zero_exponent_run_stack_semantic
+    (base : EvmWord) (rest : List EvmWord) :
+    ExpStackExecutionBridge.runExpStack? { stack := base :: 0 :: rest } =
+      some
+        { effects := { stackWords := [1], dynamicGas := 0, totalGas := 10 }
+          stack := rest } := by
+  exact ExpStackExecutionBridge.runExpStack?_zero_exponent base rest
 
 /-- EXP edge case required by GH #92: `0^0 = 1`. -/
 example : EvmWord.exp (0 : EvmWord) (0 : EvmWord) = 1 := by

--- a/EvmAsm/Evm64/Exp/Semantic.lean
+++ b/EvmAsm/Evm64/Exp/Semantic.lean
@@ -10,6 +10,33 @@ import EvmAsm.Evm64.Exp.Spec
 
 namespace EvmAsm.Evm64
 
+open EvmAsm.Rv64
+open EvmAsm.Evm64.Exp.Compose
+
+/-- Semantic-facing stack wrapper for the proven boundary case where the
+    exponent is zero.  The full EXP loop spec will generalize this to arbitrary
+    exponents; this wrapper keeps the zero-exponent stack shape in the semantic
+    leaf. -/
+theorem evm_exp_zero_exponent_stack_spec_within
+    (sp evmSp cOld tOld m0 m1 m2 m3 : Word) (base : Word)
+    (baseWord exponentWord : EvmWord) (rest : List EvmWord) :
+    cpsTripleWithin 15 base (base + 60) (expBoundaryProgramCode base)
+      ((.x2 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) ** (.x9 ↦ᵣ cOld) **
+       (.x5 ↦ᵣ tOld) ** (.x12 ↦ᵣ evmSp) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ m0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ m1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ m2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ m3) **
+       evmStackIs evmSp (baseWord :: exponentWord :: rest))
+      ((.x2 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x9 ↦ᵣ (256 : Word)) **
+       (.x12 ↦ᵣ (evmSp + 32)) **
+       (.x5 ↦ᵣ (0 : Word)) **
+       evmWordIs sp (1 : EvmWord) **
+       evmStackIs evmSp (baseWord :: EvmWord.exp baseWord 0 :: rest)) := by
+  exact exp_boundary_result_exp_zero_full_post_stack_shape_clean_regs_spec_within
+    sp evmSp cOld tOld m0 m1 m2 m3 base baseWord exponentWord rest
+
 /-- EXP edge case required by GH #92: `0^0 = 1`. -/
 example : EvmWord.exp (0 : EvmWord) (0 : EvmWord) = 1 := by
   exact EvmWord.exp_zero_zero


### PR DESCRIPTION
## Summary
- lift the existing EXP squaring marshal/JAL plus mul_callable composition to top-level evmExpCode union mul_callable_code
- derive the lower call-block disjointness from the top-level disjointness and existing evmExpCode sub-block inclusion
- keep Compose/Base.lean under the file-size guardrail

Refs #92.
Beads: evm-asm-xzs0f, evm-asm-w5mk.

## Verification
- lake build EvmAsm.Evm64.Exp.Compose.TopCodeSpecs
- scripts/check-file-size.sh
- lake build