### PR TITLE
feat(exp): expose zero-exponent stack wrapper

### DIFF
--- a/EvmAsm/Evm64/Exp/Semantic.lean
+++ b/EvmAsm/Evm64/Exp/Semantic.lean
@@ -6,6 +6,7 @@
   composition is connected to `EvmWord.exp`.
 -/
 
+import EvmAsm.Evm64.Exp.Args
 import EvmAsm.Evm64.Exp.Spec
 
 namespace EvmAsm.Evm64
@@ -36,6 +37,31 @@ theorem evm_exp_zero_exponent_stack_spec_within
        evmStackIs evmSp (baseWord :: EvmWord.exp baseWord 0 :: rest)) := by
   exact exp_boundary_result_exp_zero_full_post_stack_shape_clean_regs_spec_within
     sp evmSp cOld tOld m0 m1 m2 m3 base baseWord exponentWord rest
+
+/-- Semantic-facing zero-exponent wrapper phrased through the pure EXP stack
+    argument bridge. -/
+theorem evm_exp_zero_exponent_args_stack_spec_within
+    (sp evmSp cOld tOld m0 m1 m2 m3 : Word) (base : Word)
+    (baseWord : EvmWord) (rest : List EvmWord) :
+    cpsTripleWithin 15 base (base + 60) (expBoundaryProgramCode base)
+      ((.x2 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) ** (.x9 ↦ᵣ cOld) **
+       (.x5 ↦ᵣ tOld) ** (.x12 ↦ᵣ evmSp) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ m0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ m1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ m2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ m3) **
+       evmStackIs evmSp (baseWord :: (0 : EvmWord) :: rest))
+      ((.x2 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x9 ↦ᵣ (256 : Word)) **
+       (.x12 ↦ᵣ (evmSp + 32)) **
+       (.x5 ↦ᵣ (0 : Word)) **
+       evmWordIs sp (1 : EvmWord) **
+       evmStackIs evmSp
+         (baseWord ::
+          ExpArgs.expResultFromArgs (ExpArgs.expArgs baseWord 0) :: rest)) := by
+  simpa [ExpArgs.expResultFromArgs, ExpArgs.expArgs] using
+    evm_exp_zero_exponent_stack_spec_within
+      sp evmSp cOld tOld m0 m1 m2 m3 base baseWord (0 : EvmWord) rest
 
 /-- EXP edge case required by GH #92: `0^0 = 1`. -/
 example : EvmWord.exp (0 : EvmWord) (0 : EvmWord) = 1 := by

--- a/EvmAsm/Evm64/Exp/Semantic.lean
+++ b/EvmAsm/Evm64/Exp/Semantic.lean
@@ -8,6 +8,7 @@
 
 import EvmAsm.Evm64.Exp.Args
 import EvmAsm.Evm64.Exp.Spec
+import EvmAsm.Evm64.Exp.StackExecutionBridge
 
 namespace EvmAsm.Evm64
 
@@ -62,6 +63,16 @@ theorem evm_exp_zero_exponent_args_stack_spec_within
   simpa [ExpArgs.expResultFromArgs, ExpArgs.expArgs] using
     evm_exp_zero_exponent_stack_spec_within
       sp evmSp cOld tOld m0 m1 m2 m3 base baseWord (0 : EvmWord) rest
+
+/-- Semantic-facing alias for the pure EXP stack executor's zero-exponent
+    edge case.  Distinctive token: evm_exp_zero_exponent_run_stack?_semantic. -/
+theorem evm_exp_zero_exponent_run_stack_semantic
+    (base : EvmWord) (rest : List EvmWord) :
+    ExpStackExecutionBridge.runExpStack? { stack := base :: 0 :: rest } =
+      some
+        { effects := { stackWords := [1], dynamicGas := 0, totalGas := 10 }
+          stack := rest } := by
+  exact ExpStackExecutionBridge.runExpStack?_zero_exponent base rest
 
 /-- EXP edge case required by GH #92: `0^0 = 1`. -/
 example : EvmWord.exp (0 : EvmWord) (0 : EvmWord) = 1 := by

--- a/EvmAsm/Evm64/Exp/Semantic.lean
+++ b/EvmAsm/Evm64/Exp/Semantic.lean
@@ -10,6 +10,33 @@ import EvmAsm.Evm64.Exp.Spec
 
 namespace EvmAsm.Evm64
 
+open EvmAsm.Rv64
+open EvmAsm.Evm64.Exp.Compose
+
+/-- Semantic-facing stack wrapper for the proven boundary case where the
+    exponent is zero.  The full EXP loop spec will generalize this to arbitrary
+    exponents; this wrapper keeps the zero-exponent stack shape in the semantic
+    leaf. -/
+theorem evm_exp_zero_exponent_stack_spec_within
+    (sp evmSp cOld tOld m0 m1 m2 m3 : Word) (base : Word)
+    (baseWord exponentWord : EvmWord) (rest : List EvmWord) :
+    cpsTripleWithin 15 base (base + 60) (expBoundaryProgramCode base)
+      ((.x2 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) ** (.x9 ↦ᵣ cOld) **
+       (.x5 ↦ᵣ tOld) ** (.x12 ↦ᵣ evmSp) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ m0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ m1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ m2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ m3) **
+       evmStackIs evmSp (baseWord :: exponentWord :: rest))
+      ((.x2 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x9 ↦ᵣ (256 : Word)) **
+       (.x12 ↦ᵣ (evmSp + 32)) **
+       (.x5 ↦ᵣ (0 : Word)) **
+       evmWordIs sp (1 : EvmWord) **
+       evmStackIs evmSp (baseWord :: EvmWord.exp baseWord 0 :: rest)) := by
+  exact exp_boundary_result_exp_zero_full_post_stack_shape_clean_regs_spec_within
+    sp evmSp cOld tOld m0 m1 m2 m3 base baseWord exponentWord rest
+
 /-- EXP edge case required by GH #92: `0^0 = 1`. -/
 example : EvmWord.exp (0 : EvmWord) (0 : EvmWord) = 1 := by
   exact EvmWord.exp_zero_zero


### PR DESCRIPTION
## Summary
- add a semantic-facing EXP zero-exponent stack wrapper in EvmAsm/Evm64/Exp/Semantic.lean
- reuse the existing boundary zero-exponent stack theorem
- keep the EXP Compose base under the file-size guardrail

Refs #92.
Beads: evm-asm-d19j9, evm-asm-20z6.

## Verification
- lake build EvmAsm.Evm64.Exp.Semantic
- scripts/check-file-size.sh
- lake build