### PR TITLE
feat(exp): expose zero-exponent args stack wrapper

### DIFF
--- a/EvmAsm/Evm64/Exp/Semantic.lean
+++ b/EvmAsm/Evm64/Exp/Semantic.lean
@@ -6,6 +6,7 @@
   composition is connected to `EvmWord.exp`.
 -/
 
+import EvmAsm.Evm64.Exp.Args
 import EvmAsm.Evm64.Exp.Spec
 
 namespace EvmAsm.Evm64
@@ -36,6 +37,31 @@ theorem evm_exp_zero_exponent_stack_spec_within
        evmStackIs evmSp (baseWord :: EvmWord.exp baseWord 0 :: rest)) := by
   exact exp_boundary_result_exp_zero_full_post_stack_shape_clean_regs_spec_within
     sp evmSp cOld tOld m0 m1 m2 m3 base baseWord exponentWord rest
+
+/-- Semantic-facing zero-exponent wrapper phrased through the pure EXP stack
+    argument bridge. -/
+theorem evm_exp_zero_exponent_args_stack_spec_within
+    (sp evmSp cOld tOld m0 m1 m2 m3 : Word) (base : Word)
+    (baseWord : EvmWord) (rest : List EvmWord) :
+    cpsTripleWithin 15 base (base + 60) (expBoundaryProgramCode base)
+      ((.x2 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) ** (.x9 ↦ᵣ cOld) **
+       (.x5 ↦ᵣ tOld) ** (.x12 ↦ᵣ evmSp) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ m0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ m1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ m2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ m3) **
+       evmStackIs evmSp (baseWord :: (0 : EvmWord) :: rest))
+      ((.x2 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x9 ↦ᵣ (256 : Word)) **
+       (.x12 ↦ᵣ (evmSp + 32)) **
+       (.x5 ↦ᵣ (0 : Word)) **
+       evmWordIs sp (1 : EvmWord) **
+       evmStackIs evmSp
+         (baseWord ::
+          ExpArgs.expResultFromArgs (ExpArgs.expArgs baseWord 0) :: rest)) := by
+  simpa [ExpArgs.expResultFromArgs, ExpArgs.expArgs] using
+    evm_exp_zero_exponent_stack_spec_within
+      sp evmSp cOld tOld m0 m1 m2 m3 base baseWord (0 : EvmWord) rest
 
 /-- EXP edge case required by GH #92: `0^0 = 1`. -/
 example : EvmWord.exp (0 : EvmWord) (0 : EvmWord) = 1 := by


### PR DESCRIPTION
## Summary
- add a semantic-facing EXP zero-exponent stack wrapper phrased through ExpArgs.expResultFromArgs
- use a literal zero exponent precondition while reusing the proven boundary stack wrapper
- keep EXP Compose files under the file-size guardrail

Refs #92.
Beads: evm-asm-bexnr, evm-asm-20z6.

## Verification
- lake build EvmAsm.Evm64.Exp.Semantic
- scripts/check-file-size.sh
- lake build