### PR TITLE
feat(exp): add one-exponent run stack bridge

### DIFF
--- a/EvmAsm/Evm64/Exp/Args.lean
+++ b/EvmAsm/Evm64/Exp/Args.lean
@@ -111,6 +111,18 @@ theorem expResultFromArgs_two_256 :
     expResultFromArgs (expArgs 2 256) = 0 := by
   exact EvmWord.exp_two_256
 
+theorem expDynamicCostFromArgs_one_exponent (base : EvmWord) :
+    expDynamicCostFromArgs (expArgs base 1) = 50 := by
+  unfold expDynamicCostFromArgs expArgs
+  change ExpGas.expDynamicCostFromExponent (1 : EvmWord) = 50
+  exact ExpGas.expDynamicCostFromExponent_of_pos_lt_256 (by decide) (by decide)
+
+theorem expTotalGasFromArgs_one_exponent (base : EvmWord) :
+    expTotalGasFromArgs (expArgs base 1) = 60 := by
+  unfold expTotalGasFromArgs expArgs
+  change ExpGas.expTotalGasFromExponent (1 : EvmWord) = 60
+  exact ExpGas.expTotalGasFromExponent_of_pos_lt_256 (by decide) (by decide)
+
 @[simp] theorem expDynamicCostFromArgs_zero_exponent (base : EvmWord) :
     expDynamicCostFromArgs (expArgs base 0) = 0 := by
   exact ExpGas.expDynamicCostFromExponent_zero

--- a/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
+++ b/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
@@ -246,6 +246,17 @@ theorem runExpStack?_zero_exponent
   rw [ExpArgs.expDynamicCostFromArgs_zero_exponent]
   rw [ExpArgs.expTotalGasFromArgs_zero_exponent]
 
+theorem runExpStack?_one_exponent
+    (base : EvmWord) (rest : List EvmWord) :
+    runExpStack? { stack := base :: 1 :: rest } =
+      some
+        { effects := { stackWords := [base], dynamicGas := 50, totalGas := 60 }
+          stack := rest } := by
+  rw [runExpStack?_cons]
+  rw [ExpArgs.expResultFromArgs_one_right]
+  rw [ExpArgs.expDynamicCostFromArgs_one_exponent]
+  rw [ExpArgs.expTotalGasFromArgs_one_exponent]
+
 theorem runExpStack?_two_256
     (rest : List EvmWord) :
     runExpStack? { stack := (2 : EvmWord) :: 256 :: rest } =


### PR DESCRIPTION
## Summary
- add EXP Args gas helpers for exponent 1
- prove runExpStack?_one_exponent for the pure EXP stack executor
- keep the previous EXP file-size hotspot under the guardrail

Refs #92.
Beads: evm-asm-8rkvq, evm-asm-20z6.

## Verification
- lake build EvmAsm.Evm64.Exp.StackExecutionBridge
- scripts/check-file-size.sh
- lake build