### PR TITLE
feat(exp): add max gas conformance vector

### DIFF
--- a/EvmAsm/EL/Conformance/All.lean
+++ b/EvmAsm/EL/Conformance/All.lean
@@ -44,11 +44,11 @@ def allConformanceVectorCount : Nat :=
   allConformanceVectors.length
 
 theorem allConformanceVectors_length :
-    allConformanceVectors.length = 49 := by
+    allConformanceVectors.length = 50 := by
   native_decide
 
 theorem allConformanceVectorCount_eq :
-    allConformanceVectorCount = 49 := by
+    allConformanceVectorCount = 50 := by
   native_decide
 
 def unexpectedConformanceFailures : List CheckResult :=
@@ -115,7 +115,7 @@ theorem expectedConformanceErrorCount_eq :
   native_decide
 
 theorem successfulConformanceResultCount_eq :
-    successfulConformanceResultCount = 39 := by
+    successfulConformanceResultCount = 40 := by
   native_decide
 
 end Conformance

--- a/EvmAsm/EL/Conformance/ExpGas.lean
+++ b/EvmAsm/EL/Conformance/ExpGas.lean
@@ -41,6 +41,12 @@ def expGasTwoByteThresholdVector : TestVector ExpGasInput Nat :=
     input := { exponent := 256 }
     expected := .value 110 }
 
+/-- The maximum 256-bit exponent occupies all 32 bytes. -/
+def expGasMaxExponentVector : TestVector ExpGasInput Nat :=
+  { id := "exp-gas-max-exponent"
+    input := { exponent := -1 }
+    expected := .value 1610 }
+
 theorem runExpGas_zero :
     runExpGas { exponent := (0 : EvmWord) } = 10 :=
   EvmAsm.Evm64.ExpGas.expTotalGasFromExponent_zero
@@ -53,6 +59,10 @@ theorem runExpGas_one :
 theorem runExpGas_256 :
     runExpGas { exponent := (256 : EvmWord) } = 110 :=
   EvmAsm.Evm64.ExpGas.expTotalGasFromExponent_256
+
+theorem runExpGas_max :
+    runExpGas { exponent := (-1 : EvmWord) } = 1610 :=
+  EvmAsm.Evm64.ExpGas.expTotalGasFromExponent_max
 
 theorem expGasZeroExponentVector_passed :
     checkVector runExpGas expGasZeroExponentVector = .passed :=
@@ -78,12 +88,21 @@ theorem expGasTwoByteThresholdVector_passed :
     110
     runExpGas_256
 
+theorem expGasMaxExponentVector_passed :
+    checkVector runExpGas expGasMaxExponentVector = .passed :=
+  checkVector_value_passed runExpGas
+    "exp-gas-max-exponent"
+    { exponent := (-1 : EvmWord) }
+    1610
+    runExpGas_max
+
 /-- Vector IDs for EXP gas executable-helper conformance coverage.
     Distinctive token: expGasConformanceVectorIds #125 #92. -/
 def expGasConformanceVectorIds : List String :=
   [ expGasZeroExponentVector.id
   , expGasOneByteExponentVector.id
   , expGasTwoByteThresholdVector.id
+  , expGasMaxExponentVector.id
   ]
 
 theorem expGasConformanceVectorIds_eq :
@@ -91,10 +110,11 @@ theorem expGasConformanceVectorIds_eq :
       [ "exp-gas-zero-exponent"
       , "exp-gas-one-byte-exponent"
       , "exp-gas-two-byte-threshold"
+      , "exp-gas-max-exponent"
       ] := rfl
 
 theorem expGasConformanceVectorIds_length :
-    expGasConformanceVectorIds.length = 3 := rfl
+    expGasConformanceVectorIds.length = 4 := rfl
 
 theorem expGasConformanceVectorIds_nodup :
     expGasConformanceVectorIds.Nodup := by
@@ -106,12 +126,14 @@ def expGasConformanceVectors : List CheckResult :=
   [ checkVector runExpGas expGasZeroExponentVector
   , checkVector runExpGas expGasOneByteExponentVector
   , checkVector runExpGas expGasTwoByteThresholdVector
+  , checkVector runExpGas expGasMaxExponentVector
   ]
 
 theorem expGasConformanceVectors_passed :
-    expGasConformanceVectors = [.passed, .passed, .passed] := by
+    expGasConformanceVectors = [.passed, .passed, .passed, .passed] := by
   simp [expGasConformanceVectors, expGasZeroExponentVector_passed,
-    expGasOneByteExponentVector_passed, expGasTwoByteThresholdVector_passed]
+    expGasOneByteExponentVector_passed, expGasTwoByteThresholdVector_passed,
+    expGasMaxExponentVector_passed]
 
 end ExpGas
 end Conformance


### PR DESCRIPTION
## Summary
- add the EXP gas conformance vector for the max 256-bit exponent
- prove it through expTotalGasFromExponent_max
- update aggregate conformance counts

Refs #92, #125.
Beads: evm-asm-shzte, evm-asm-20z6.

## Verification
- lake build EvmAsm.EL.Conformance.ExpGas
- lake build EvmAsm.EL.Conformance.All
- scripts/check-file-size.sh
- lake build