### PR TITLE
docs(exp): refresh skeleton comments

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/Base.lean
+++ b/EvmAsm/Evm64/Exp/Compose/Base.lean
@@ -5,8 +5,9 @@
   sub-block `CodeReq`s), subsumption helpers tying sub-block codes back to
   `expCode`, and shared length lemmas.
 
-  Skeleton placeholder for GH #92 (beads slice evm-asm-cf2c). Concrete
-  definitions will be added in the loop-composition slice (evm-asm-w5mk).
+  GH #92 composition work lands here and in sibling `Compose` modules.  This
+  file keeps the shared layout, byte-offset, and boundary/loop code facts small
+  enough for downstream top-code and semantic slices to import directly.
 -/
 
 import EvmAsm.Evm64.Stack

--- a/EvmAsm/Evm64/Exp/Program.lean
+++ b/EvmAsm/Evm64/Exp/Program.lean
@@ -4,18 +4,11 @@
   256-bit EVM EXP opcode (`EXP(a, b) = a^b mod 2^256`) as a 64-bit RISC-V
   program.
 
-  Skeleton placeholder for GH #92 (beads slice evm-asm-cf2c).
-
-  The actual Program will be defined in the Program-definition slice
-  (evm-asm-ahaz). Per `docs/92-exp-survey.md` the algorithm is binary
-  square-and-multiply over 256 bits of exponent, invoking `evm_mul`
-  (made callable via a `cc_ret` shim) once per squaring and conditionally
-  once per set bit. The full bytecode will be assembled from sub-blocks
-  `exp_prologue`, `exp_square_block`, `exp_cond_mul_block`, `exp_iter_body`,
-  `exp_loop`, `exp_epilogue`.
-
-  This file currently has no `evm_exp` definition; later slices will add
-  it without breaking the umbrella import graph.
+  GH #92 builds EXP by binary square-and-multiply over all 256 exponent bits,
+  invoking `evm_mul` through the callable shim once per squaring and
+  conditionally once per set bit.  This file contains the concrete sub-blocks,
+  loop body, stack-pointer shims, and top-level `evm_exp` assembly used by the
+  composition and semantic proof layers.
 -/
 
 import EvmAsm.Rv64.Program

--- a/EvmAsm/Evm64/Exp/Spec.lean
+++ b/EvmAsm/Evm64/Exp/Spec.lean
@@ -5,9 +5,10 @@
   bridging the limb-level loop composition to a single `evmWordIs`
   pre/post pair.
 
-  Skeleton placeholder for GH #92 (beads slice evm-asm-cf2c). The actual
-  `evm_exp_stack_spec` / `evm_exp_stack_spec_within` theorem lands in the
-  semantic slice (evm-asm-6snn).
+  This file currently exposes stack-shaped boundary-program bridges that feed
+  the semantic layer.  The final full-loop `evm_exp_stack_spec_within` belongs
+  in `EvmAsm.Evm64.Exp.Semantic` once the 256-iteration composition is tied to
+  `EvmWord.exp`.
 -/
 
 import EvmAsm.Evm64.Stack


### PR DESCRIPTION
## Summary
- refresh stale EXP Program header comments now that evm_exp exists
- clarify current Spec and Compose/Base roles for boundary, composition, and semantic layers
- keep EXP files under the file-size guardrail

Refs #92.
Beads: evm-asm-ybccr, evm-asm-20z6.

## Verification
- lake build EvmAsm.Evm64.Exp
- scripts/check-file-size.sh
- lake build