### PR TITLE
feat(exp): bridge run stack to stackAfterExp

### DIFF
--- a/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
+++ b/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
@@ -216,6 +216,12 @@ theorem runExpStack?_head?_of_some
   subst h_out
   rfl
 
+theorem runExpStack?_stackAfterExp
+    (base exponent : EvmWord) (rest : List EvmWord) :
+    (runExpStack? { stack := base :: exponent :: rest }).map
+      (fun out => out.effects.stackWords ++ out.stack) =
+      some (ExpArgs.stackAfterExp (ExpArgs.expArgs base exponent) rest) := rfl
+
 theorem runExpStack?_gas
     (base exponent : EvmWord) (rest : List EvmWord) :
     (runExpStack? { stack := base :: exponent :: rest }).map


### PR DESCRIPTION
## Summary
- add runExpStack?_stackAfterExp for the pure EXP stack executor
- expose that visible pushed words plus returned tail equals ExpArgs.stackAfterExp
- keep the EXP file-size guardrail green

Refs #92.
Beads: evm-asm-5qhf1, evm-asm-20z6.

## Verification
- lake build EvmAsm.Evm64.Exp.StackExecutionBridge
- scripts/check-file-size.sh
- lake build