### PR TITLE
feat(exp): expose run stack tail

### DIFF
--- a/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
+++ b/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
@@ -216,6 +216,15 @@ theorem runExpStack?_head?_of_some
   subst h_out
   rfl
 
+theorem runExpStack?_tail_of_some
+    {base exponent : EvmWord} {rest : List EvmWord} {out : ExpStackResult}
+    (h_run : runExpStack? { stack := base :: exponent :: rest } = some out) :
+    out.stack = rest := by
+  rw [runExpStack?_cons] at h_run
+  injection h_run with h_out
+  subst h_out
+  rfl
+
 theorem runExpStack?_gas
     (base exponent : EvmWord) (rest : List EvmWord) :
     (runExpStack? { stack := base :: exponent :: rest }).map


### PR DESCRIPTION
## Summary
- add runExpStack?_tail_of_some for successful EXP stack execution
- expose that the returned stack tail is exactly the input rest
- keep the EXP file-size guardrail green

Refs #92.
Beads: evm-asm-ewbgg, evm-asm-20z6.

## Verification
- lake build EvmAsm.Evm64.Exp.StackExecutionBridge
- scripts/check-file-size.sh
- lake build