### PR TITLE
feat(exp): expose run stack gas fields

### DIFF
--- a/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
+++ b/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
@@ -230,6 +230,26 @@ theorem runExpStack?_gas
         ( ExpArgs.expDynamicCostFromArgs (ExpArgs.expArgs base exponent)
         , ExpArgs.expTotalGasFromArgs (ExpArgs.expArgs base exponent)) := rfl
 
+theorem runExpStack?_dynamicGas_of_some
+    {base exponent : EvmWord} {rest : List EvmWord} {out : ExpStackResult}
+    (h_run : runExpStack? { stack := base :: exponent :: rest } = some out) :
+    out.effects.dynamicGas =
+      ExpArgs.expDynamicCostFromArgs (ExpArgs.expArgs base exponent) := by
+  rw [runExpStack?_cons] at h_run
+  injection h_run with h_out
+  subst h_out
+  rfl
+
+theorem runExpStack?_totalGas_of_some
+    {base exponent : EvmWord} {rest : List EvmWord} {out : ExpStackResult}
+    (h_run : runExpStack? { stack := base :: exponent :: rest } = some out) :
+    out.effects.totalGas =
+      ExpArgs.expTotalGasFromArgs (ExpArgs.expArgs base exponent) := by
+  rw [runExpStack?_cons] at h_run
+  injection h_run with h_out
+  subst h_out
+  rfl
+
 theorem runExpStack?_totalGas_eq_dynamicGas_add_static
     {state : ExpStackState} {out : ExpStackResult}
     (h_run : runExpStack? state = some out) :


### PR DESCRIPTION
Refs #92.\n\nBeads: evm-asm-khuvz, evm-asm-20z6.\n\nSummary:\n- add runExpStack?_dynamicGas_of_some\n- add runExpStack?_totalGas_of_some\n\nVerification:\n- lake build EvmAsm.Evm64.Exp.StackExecutionBridge\n- scripts/check-file-size.sh\n- lake build