### PR TITLE
feat(exp): characterize decode underflow length

### DIFF
--- a/EvmAsm/Evm64/Exp/ArgsStackDecode.lean
+++ b/EvmAsm/Evm64/Exp/ArgsStackDecode.lean
@@ -90,6 +90,19 @@ theorem decodeExpStack?_eq_none_iff
             simp [decodeExpStack?]
   · rintro (rfl | ⟨base, rfl⟩) <;> rfl
 
+theorem decodeExpStack?_eq_none_iff_length_lt_two
+    {stack : List EvmWord} :
+    decodeExpStack? stack = none ↔ stack.length < 2 := by
+  cases stack with
+  | nil =>
+      simp [decodeExpStack?]
+  | cons base tail =>
+      cases tail with
+      | nil =>
+          simp [decodeExpStack?]
+      | cons exponent rest =>
+          simp [decodeExpStack?]
+
 theorem decodeExpStack?_none_of_empty :
     decodeExpStack? [] = none := rfl
 


### PR DESCRIPTION
Refs #92.\n\nBeads: evm-asm-0275n, evm-asm-20z6.\n\nSummary:\n- add decodeExpStack?_eq_none_iff_length_lt_two\n\nVerification:\n- lake build EvmAsm.Evm64.Exp.ArgsStackDecode\n- scripts/check-file-size.sh\n- lake build