### PR TITLE
feat(exp): add stackAfter length positivity

### DIFF
--- a/EvmAsm/Evm64/Exp/Args.lean
+++ b/EvmAsm/Evm64/Exp/Args.lean
@@ -86,6 +86,10 @@ theorem stackAfterExp_tail (args : Args) (rest : List EvmWord) :
     (stackAfterExp args rest).length = rest.length + 1 := by
   simp [stackAfterExp]
 
+theorem stackAfterExp_length_pos (args : Args) (rest : List EvmWord) :
+    0 < (stackAfterExp args rest).length := by
+  simp [stackAfterExp]
+
 theorem stackAfterExp_length_eq_counts (args : Args) (rest : List EvmWord) :
     (stackAfterExp args rest).length + stackArgumentCount =
       (args.base :: args.exponent :: rest).length + resultCount := by


### PR DESCRIPTION
Refs #92.

Beads: evm-asm-bej05, evm-asm-20z6.

Summary:
- add stackAfterExp_length_pos for nonempty EXP stack results

Verification:
- lake build EvmAsm.Evm64.Exp.Args
- scripts/check-file-size.sh
- lake build