### PR TITLE
feat(exp): expose stackWords nonempty

### DIFF
--- a/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
+++ b/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
@@ -180,6 +180,15 @@ theorem runExpStack?_effects_stackWords_length
               cases h_run
               simp [resultCount, ExpArgs.resultCount]
 
+theorem runExpStack?_effects_stackWords_ne_nil
+    {state : ExpStackState} {out : ExpStackResult}
+    (h_run : runExpStack? state = some out) :
+    out.effects.stackWords ≠ [] := by
+  have h_len := runExpStack?_effects_stackWords_length h_run
+  intro h_nil
+  rw [h_nil] at h_len
+  simp [resultCount, ExpArgs.resultCount] at h_len
+
 theorem runExpStack?_stack_length
     {state : ExpStackState} {out : ExpStackResult}
     (h_run : runExpStack? state = some out) :


### PR DESCRIPTION
Refs #92.

Beads: evm-asm-0i0tj, evm-asm-20z6.

Summary:
- add runExpStack?_effects_stackWords_ne_nil for successful EXP stack execution results

Verification:
- lake build EvmAsm.Evm64.Exp.StackExecutionBridge
- scripts/check-file-size.sh
- lake build