### PR TITLE
feat(exp): add gas helper for 255 exponent

### DIFF
--- a/EvmAsm/Evm64/Exp/Gas.lean
+++ b/EvmAsm/Evm64/Exp/Gas.lean
@@ -107,6 +107,10 @@ theorem expTotalGasFromExponent_one :
     expTotalGasFromExponent (1 : EvmWord) = 60 := by
   exact expTotalGasFromExponent_of_pos_lt_256 (by decide) (by decide)
 
+theorem expTotalGasFromExponent_255 :
+    expTotalGasFromExponent (255 : EvmWord) = 60 := by
+  exact expTotalGasFromExponent_of_pos_lt_256 (by decide) (by decide)
+
 theorem expDynamicCostFromExponent_256 :
     expDynamicCostFromExponent (256 : EvmWord) = 100 := by
   unfold expDynamicCostFromExponent expGasPerByte


### PR DESCRIPTION
Refs #92.

Beads: evm-asm-kx8bf, evm-asm-20z6.

Summary:
- add expTotalGasFromExponent_255 for the one-byte upper exponent boundary

Verification:
- lake build EvmAsm.Evm64.Exp.Gas
- scripts/check-file-size.sh
- lake build