### PR TITLE
feat(exp): add args gas helper for 255 exponent

### DIFF
--- a/EvmAsm/Evm64/Exp/Args.lean
+++ b/EvmAsm/Evm64/Exp/Args.lean
@@ -157,6 +157,12 @@ theorem expTotalGasFromArgs_one_exponent (base : EvmWord) :
   change ExpGas.expTotalGasFromExponent (1 : EvmWord) = 60
   exact ExpGas.expTotalGasFromExponent_of_pos_lt_256 (by decide) (by decide)
 
+theorem expTotalGasFromArgs_255_exponent (base : EvmWord) :
+    expTotalGasFromArgs (expArgs base 255) = 60 := by
+  unfold expTotalGasFromArgs expArgs
+  change ExpGas.expTotalGasFromExponent (255 : EvmWord) = 60
+  exact ExpGas.expTotalGasFromExponent_of_pos_lt_256 (by decide) (by decide)
+
 @[simp] theorem expDynamicCostFromArgs_zero_exponent (base : EvmWord) :
     expDynamicCostFromArgs (expArgs base 0) = 0 := by
   exact ExpGas.expDynamicCostFromExponent_zero


### PR DESCRIPTION
Refs #92.

Beads: evm-asm-i3u6v, evm-asm-20z6.

Summary:
- add expTotalGasFromArgs_255_exponent for the one-byte upper exponent boundary

Verification:
- lake build EvmAsm.Evm64.Exp.Args
- scripts/check-file-size.sh
- lake build