### PR TITLE
feat(exp): add args dynamic gas helper for 255 exponent

### DIFF
--- a/EvmAsm/Evm64/Exp/Args.lean
+++ b/EvmAsm/Evm64/Exp/Args.lean
@@ -163,6 +163,12 @@ theorem expTotalGasFromArgs_255_exponent (base : EvmWord) :
   change ExpGas.expTotalGasFromExponent (255 : EvmWord) = 60
   exact ExpGas.expTotalGasFromExponent_of_pos_lt_256 (by decide) (by decide)
 
+theorem expDynamicCostFromArgs_255_exponent (base : EvmWord) :
+    expDynamicCostFromArgs (expArgs base 255) = 50 := by
+  unfold expDynamicCostFromArgs expArgs
+  change ExpGas.expDynamicCostFromExponent (255 : EvmWord) = 50
+  exact ExpGas.expDynamicCostFromExponent_of_pos_lt_256 (by decide) (by decide)
+
 @[simp] theorem expDynamicCostFromArgs_zero_exponent (base : EvmWord) :
     expDynamicCostFromArgs (expArgs base 0) = 0 := by
   exact ExpGas.expDynamicCostFromExponent_zero


### PR DESCRIPTION
Refs #92.

Beads: evm-asm-zxz51, evm-asm-20z6.

Summary:
- add expDynamicCostFromArgs_255_exponent for the one-byte upper exponent boundary

Verification:
- lake build EvmAsm.Evm64.Exp.Args
- scripts/check-file-size.sh
- lake build