### PR TITLE
feat(exp): add byte length helper for 255 exponent

### DIFF
--- a/EvmAsm/Evm64/Exp/Gas.lean
+++ b/EvmAsm/Evm64/Exp/Gas.lean
@@ -68,6 +68,9 @@ theorem exponentByteLength_of_pos_lt_256 {exponent : EvmWord}
 theorem exponentByteLength_one : exponentByteLength (1 : EvmWord) = 1 := by
   exact exponentByteLength_of_pos_lt_256 (by decide) (by decide)
 
+theorem exponentByteLength_255 : exponentByteLength (255 : EvmWord) = 1 := by
+  exact exponentByteLength_of_pos_lt_256 (by decide) (by decide)
+
 theorem exponentByteLength_256 : exponentByteLength (256 : EvmWord) = 2 := by
   unfold exponentByteLength
   native_decide


### PR DESCRIPTION
Refs #92.

Beads: evm-asm-jyben, evm-asm-20z6.

Summary:
- add exponentByteLength_255 for the one-byte upper exponent boundary

Verification:
- lake build EvmAsm.Evm64.Exp.Gas
- scripts/check-file-size.sh
- lake build