### PR TITLE
feat(exp): add one-left run stack bridge

### DIFF
--- a/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
+++ b/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
@@ -301,6 +301,20 @@ theorem runExpStack?_one_exponent
   rw [ExpArgs.expDynamicCostFromArgs_one_exponent]
   rw [ExpArgs.expTotalGasFromArgs_one_exponent]
 
+theorem runExpStack?_one_left
+    (exponent : EvmWord) (rest : List EvmWord) :
+    runExpStack? { stack := (1 : EvmWord) :: exponent :: rest } =
+      some
+        { effects :=
+            { stackWords := [1]
+              dynamicGas := ExpArgs.expDynamicCostFromArgs
+                (ExpArgs.expArgs 1 exponent)
+              totalGas := ExpArgs.expTotalGasFromArgs
+                (ExpArgs.expArgs 1 exponent) }
+          stack := rest } := by
+  rw [runExpStack?_cons]
+  rw [ExpArgs.expResultFromArgs_one_left]
+
 theorem runExpStack?_two_256
     (rest : List EvmWord) :
     runExpStack? { stack := (2 : EvmWord) :: 256 :: rest } =


### PR DESCRIPTION
Refs #92.

Beads: evm-asm-s3rtf, evm-asm-20z6.

Summary:
- add runExpStack?_one_left for base = 1 with symbolic gas fields

Verification:
- lake build EvmAsm.Evm64.Exp.StackExecutionBridge
- scripts/check-file-size.sh
- lake build