### PR TITLE
feat(exp): add stackAfter zero-zero helper

### DIFF
--- a/EvmAsm/Evm64/Exp/Args.lean
+++ b/EvmAsm/Evm64/Exp/Args.lean
@@ -128,6 +128,10 @@ theorem stackAfterExp_zero_exponent (base : EvmWord) (rest : List EvmWord) :
     stackAfterExp (expArgs base 0) rest = 1 :: rest := by
   rw [stackAfterExp, expResultFromArgs_zero_right]
 
+theorem stackAfterExp_zero_zero (rest : List EvmWord) :
+    stackAfterExp (expArgs 0 0) rest = 1 :: rest := by
+  rw [stackAfterExp, expResultFromArgs_zero_zero]
+
 theorem stackAfterExp_zero_left_of_ne_zero
     (exponent : EvmWord) (rest : List EvmWord) (h : exponent ≠ 0) :
     stackAfterExp (expArgs 0 exponent) rest = 0 :: rest := by


### PR DESCRIPTION
Refs #92.

Beads: evm-asm-fz2v6, evm-asm-20z6.

Summary:
- add stackAfterExp_zero_zero for the EXP 0^0 stack result edge case

Verification:
- lake build EvmAsm.Evm64.Exp.Args
- scripts/check-file-size.sh
- lake build