### PR TITLE
feat(exp): add decode isSome projection helpers

### DIFF
--- a/EvmAsm/Evm64/Exp/ArgsStackDecode.lean
+++ b/EvmAsm/Evm64/Exp/ArgsStackDecode.lean
@@ -125,6 +125,18 @@ theorem decodeExpStack?_isSome_iff_length_ge_two
       | cons exponent rest =>
           simp [decodeExpStack?]
 
+theorem decodeExpStack?_length_ge_two_of_isSome
+    {stack : List EvmWord}
+    (h_some : (decodeExpStack? stack).isSome) :
+    2 ≤ stack.length :=
+  decodeExpStack?_isSome_iff_length_ge_two.mp h_some
+
+theorem decodeExpStack?_isSome_of_length_ge_two
+    {stack : List EvmWord}
+    (h_len : 2 ≤ stack.length) :
+    (decodeExpStack? stack).isSome :=
+  decodeExpStack?_isSome_iff_length_ge_two.mpr h_len
+
 theorem decodeExpStack?_none_of_empty :
     decodeExpStack? [] = none := rfl
 


### PR DESCRIPTION
## Summary
- add named projection lemmas for EXP stack decode isSome/length equivalence
- keep this as a small semantic-prep slice for downstream EXP stack proofs

## Verification
- lake build EvmAsm.Evm64.Exp.ArgsStackDecode
- scripts/check-file-size.sh
- lake build

Refs #92
Bead: evm-asm-jrr0p