### PR TITLE
feat(exp): add Nat byte length 255 helper

### DIFF
--- a/EvmAsm/Evm64/Exp/Gas.lean
+++ b/EvmAsm/Evm64/Exp/Gas.lean
@@ -42,6 +42,9 @@ theorem exponentByteLengthNat_of_pos_lt_256 {n : Nat} (h_pos : 0 < n) (h_lt : n 
 theorem exponentByteLengthNat_256 : exponentByteLengthNat 256 = 2 := by
   native_decide
 
+theorem exponentByteLengthNat_255 : exponentByteLengthNat 255 = 1 := by
+  exact exponentByteLengthNat_of_pos_lt_256 (by decide) (by decide)
+
 /-- Number of exponent bytes seen by EXP dynamic gas accounting. -/
 def exponentByteLength (exponent : EvmWord) : Nat :=
   exponentByteLengthNat exponent.toNat


### PR DESCRIPTION
## Summary
- add Nat-level exponentByteLengthNat_255
- mirror the existing word-level 255 EXP gas helper for downstream rewrites

## Verification
- lake build EvmAsm.Evm64.Exp.Gas
- scripts/check-file-size.sh
- lake build

Refs #92
Bead: evm-asm-4ue5o