### PR TITLE
feat(exp): add layout validity helper

### DIFF
--- a/EvmAsm/Evm64/Exp/Layout.lean
+++ b/EvmAsm/Evm64/Exp/Layout.lean
@@ -70,6 +70,14 @@ structure ExpScratchpadLayout : Type where
     accumulator-limb cells (currently inlined as `sp + 0 .. sp + 24`). -/
 structure ExpScratchpadLayout.Valid (_L : ExpScratchpadLayout) : Prop where
 
+/-- Every current EXP scratchpad layout is valid.
+
+    This is a convenience wrapper for downstream specs that already take an
+    `ExpScratchpadLayout` parameter while the layout is still empty. -/
+theorem ExpScratchpadLayout.valid_any_empty
+    (L : ExpScratchpadLayout) :
+    L.Valid := {}
+
 /-- The canonical EXP scratchpad layout.
 
     Trivial: there is nothing to choose, so canonical = the unique value.


### PR DESCRIPTION
## Summary
- add ExpScratchpadLayout.valid_any_empty for the current empty EXP layout
- support downstream EXP specs that already carry layout parameters

## Verification
- lake build EvmAsm.Evm64.Exp.Layout
- scripts/check-file-size.sh
- lake build

Refs #92
Bead: evm-asm-mqr3y