### PR TITLE
feat(exp): seed address simp offsets

### DIFF
--- a/EvmAsm/Evm64/Exp/AddrNorm.lean
+++ b/EvmAsm/Evm64/Exp/AddrNorm.lean
@@ -18,4 +18,9 @@ namespace EvmAsm.Evm64.Exp.AddrNorm
 
 open EvmAsm.Rv64
 
+attribute [exp_addr]
+  signExtend12_0 signExtend12_1 signExtend12_8 signExtend12_16
+  signExtend12_24 signExtend12_32 signExtend12_40 signExtend12_48
+  signExtend12_56 signExtend12_64
+
 end EvmAsm.Evm64.Exp.AddrNorm


### PR DESCRIPTION
## Summary
- register common EXP stack/scratch signExtend12 offsets in the exp_addr simp set
- seed Exp.AddrNorm for downstream composition and stack-spec address rewrites

## Verification
- lake build EvmAsm.Evm64.Exp.AddrNorm
- scripts/check-file-size.sh
- lake build

Refs #92
Bead: evm-asm-6dgc8