### PR TITLE
feat(exp): add Nat byte length one helper

### DIFF
--- a/EvmAsm/Evm64/Exp/Gas.lean
+++ b/EvmAsm/Evm64/Exp/Gas.lean
@@ -42,6 +42,9 @@ theorem exponentByteLengthNat_of_pos_lt_256 {n : Nat} (h_pos : 0 < n) (h_lt : n 
 theorem exponentByteLengthNat_256 : exponentByteLengthNat 256 = 2 := by
   native_decide
 
+theorem exponentByteLengthNat_one : exponentByteLengthNat 1 = 1 := by
+  exact exponentByteLengthNat_of_pos_lt_256 (by decide) (by decide)
+
 theorem exponentByteLengthNat_255 : exponentByteLengthNat 255 = 1 := by
   exact exponentByteLengthNat_of_pos_lt_256 (by decide) (by decide)
 


### PR DESCRIPTION
## Summary
- add Nat-level exponentByteLengthNat_one
- mirror the existing EvmWord-level one-byte EXP gas helper for downstream rewrites

## Verification
- lake build EvmAsm.Evm64.Exp.Gas
- scripts/check-file-size.sh
- lake build

Refs #92
Bead: evm-asm-hsa8u