### PR TITLE
feat(exp): add negative addr simp offsets

### DIFF
--- a/EvmAsm/Evm64/Exp/AddrNorm.lean
+++ b/EvmAsm/Evm64/Exp/AddrNorm.lean
@@ -22,5 +22,10 @@ attribute [exp_addr]
   signExtend12_0 signExtend12_1 signExtend12_8 signExtend12_16
   signExtend12_24 signExtend12_32 signExtend12_40 signExtend12_48
   signExtend12_56 signExtend12_64
+  signExtend12_4095 signExtend12_4088 signExtend12_4080 signExtend12_4072
+  signExtend12_4064 signExtend12_4056 signExtend12_4048 signExtend12_4040
+  signExtend12_4032 signExtend12_4024 signExtend12_4016 signExtend12_4008
+  signExtend12_4000 signExtend12_3992 signExtend12_3984 signExtend12_3976
+  signExtend12_3968 signExtend12_3960 signExtend12_3952 signExtend12_3944
 
 end EvmAsm.Evm64.Exp.AddrNorm


### PR DESCRIPTION
Refs #92
Bead: evm-asm-udxfl

Summary:
- register existing negative signExtend12 offsets with exp_addr
- prepare EXP composition proofs to normalize stack/frame offsets through the local addr grindset

Verification:
- rg -n sorry/admit/set_option checks in EvmAsm/Evm64/Exp/AddrNorm.lean (no matches)
- lake build EvmAsm.Evm64.Exp.AddrNorm
- scripts/check-file-size.sh
- lake build