### PR TITLE
feat(exp): add layout canonical uniqueness

### DIFF
--- a/EvmAsm/Evm64/Exp/Layout.lean
+++ b/EvmAsm/Evm64/Exp/Layout.lean
@@ -95,6 +95,13 @@ theorem ExpScratchpadLayout.valid_iff_true
     today's hardcoded `sp + 0 .. sp + 24` accumulator cells. -/
 def canonicalExpScratchpadLayout : ExpScratchpadLayout := {}
 
+/-- Every current EXP scratchpad layout is the canonical empty layout. -/
+theorem ExpScratchpadLayout.eq_canonical
+    (L : ExpScratchpadLayout) :
+    L = canonicalExpScratchpadLayout := by
+  cases L
+  rfl
+
 /-- The canonical EXP scratchpad layout is `Valid`. Trivially discharged
     because the layout struct is empty. -/
 theorem canonicalExpScratchpadLayout_valid :


### PR DESCRIPTION
Refs #92
Bead: evm-asm-y6ezq

Summary:
- add ExpScratchpadLayout.eq_canonical for the current empty EXP layout
- keep the helper next to canonicalExpScratchpadLayout for future layout-param specs

Verification:
- rg -n sorry/admit/set_option checks in EvmAsm/Evm64/Exp/Layout.lean (no matches)
- lake build EvmAsm.Evm64.Exp.Layout
- scripts/check-file-size.sh
- lake build