### PR TITLE
feat(exp): add Nat byte length max helper

### DIFF
--- a/EvmAsm/Evm64/Exp/Gas.lean
+++ b/EvmAsm/Evm64/Exp/Gas.lean
@@ -48,6 +48,9 @@ theorem exponentByteLengthNat_one : exponentByteLengthNat 1 = 1 := by
 theorem exponentByteLengthNat_255 : exponentByteLengthNat 255 = 1 := by
   exact exponentByteLengthNat_of_pos_lt_256 (by decide) (by decide)
 
+theorem exponentByteLengthNat_max : exponentByteLengthNat (2^256 - 1) = 32 := by
+  native_decide
+
 /-- Number of exponent bytes seen by EXP dynamic gas accounting. -/
 def exponentByteLength (exponent : EvmWord) : Nat :=
   exponentByteLengthNat exponent.toNat


### PR DESCRIPTION
Refs #92
Bead: evm-asm-df1lj

Summary:
- add exponentByteLengthNat_max for the uint256 max exponent Nat value
- support max-exponent gas reasoning at the Nat byte-length layer

Verification:
- rg -n sorry/admit/set_option checks in EvmAsm/Evm64/Exp/Gas.lean (no matches)
- lake build EvmAsm.Evm64.Exp.Gas
- scripts/check-file-size.sh
- lake build