### PR TITLE
feat(exp): add max base one helper

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/Exp.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Exp.lean
@@ -66,6 +66,10 @@ theorem exp_one_right (base : EvmWord) : exp base 1 = base := by
   rw [exp_correct]
   simp [Nat.mod_eq_of_lt base.isLt]
 
+/-- The maximum EVM word raised to one remains the maximum EVM word. -/
+theorem exp_max_one_right : exp (-1 : EvmWord) 1 = (-1 : EvmWord) := by
+  exact exp_one_right (-1 : EvmWord)
+
 /-- Successor recurrence for EXP when the exponent increment does not wrap. -/
 theorem exp_succ_right_of_toNat_lt (base exponent : EvmWord)
     (h : exponent.toNat + 1 < 2^256) :


### PR DESCRIPTION
Refs #92
Bead: evm-asm-9szvh

Summary:
- add EvmWord.exp_max_one_right for the max EVM word raised to one
- expose the edge case via the existing exp_one_right theorem

Verification:
- rg -n sorry/admit/set_option checks in EvmAsm/Evm64/EvmWordArith/Exp.lean (no matches)
- lake build EvmAsm.Evm64.EvmWordArith.Exp
- scripts/check-file-size.sh
- lake build