### PR TITLE
feat(exp): add signed neg16 addr simp

### DIFF
--- a/EvmAsm/Evm64/Exp/AddrNorm.lean
+++ b/EvmAsm/Evm64/Exp/AddrNorm.lean
@@ -22,6 +22,7 @@ attribute [exp_addr]
   signExtend12_0 signExtend12_1 signExtend12_8 signExtend12_16
   signExtend12_24 signExtend12_32 signExtend12_40 signExtend12_48
   signExtend12_56 signExtend12_64
+  signExtend12_neg16
   signExtend12_4095 signExtend12_4088 signExtend12_4080 signExtend12_4072
   signExtend12_4064 signExtend12_4056 signExtend12_4048 signExtend12_4040
   signExtend12_4032 signExtend12_4024 signExtend12_4016 signExtend12_4008


### PR DESCRIPTION
Refs #92
Bead: evm-asm-4106f

Summary:
- register signExtend12_neg16 with exp_addr
- let EXP composition proofs normalize signed-syntax negative 12-bit immediates

Verification:
- rg -n sorry/admit/set_option checks in EvmAsm/Evm64/Exp/AddrNorm.lean (no matches)
- lake build EvmAsm.Evm64.Exp.AddrNorm
- scripts/check-file-size.sh
- lake build