### PR TITLE
feat(exp): add canonical layout valid iff

### DIFF
--- a/EvmAsm/Evm64/Exp/Layout.lean
+++ b/EvmAsm/Evm64/Exp/Layout.lean
@@ -107,4 +107,9 @@ theorem ExpScratchpadLayout.eq_canonical
 theorem canonicalExpScratchpadLayout_valid :
     canonicalExpScratchpadLayout.Valid := {}
 
+/-- The canonical EXP scratchpad layout validity predicate is trivial. -/
+theorem canonicalExpScratchpadLayout_valid_iff_true :
+    canonicalExpScratchpadLayout.Valid ↔ True :=
+  ExpScratchpadLayout.valid_iff_true canonicalExpScratchpadLayout
+
 end EvmAsm.Evm64


### PR DESCRIPTION
Refs #92
Bead: evm-asm-du8m7

Summary:
- add canonicalExpScratchpadLayout_valid_iff_true
- specialize the empty EXP layout Valid iff to the canonical layout

Verification:
- rg -n sorry/admit/set_option checks in EvmAsm/Evm64/Exp/Layout.lean (no matches)
- lake build EvmAsm.Evm64.Exp.Layout
- scripts/check-file-size.sh
- lake build