### PR TITLE
feat(exp): add stackAfterExp length effect

### DIFF
--- a/EvmAsm/Evm64/Exp/Args.lean
+++ b/EvmAsm/Evm64/Exp/Args.lean
@@ -95,6 +95,12 @@ theorem stackAfterExp_length_eq_counts (args : Args) (rest : List EvmWord) :
       (args.base :: args.exponent :: rest).length + resultCount := by
   simp [stackAfterExp, stackArgumentCount, resultCount]
 
+theorem stackAfterExp_length_succ_eq_input_length
+    (args : Args) (rest : List EvmWord) :
+    (stackAfterExp args rest).length + 1 =
+      (args.base :: args.exponent :: rest).length := by
+  simp [stackAfterExp, Nat.add_comm]
+
 theorem stackAfterExp_ne_nil (args : Args) (rest : List EvmWord) :
     stackAfterExp args rest ≠ [] := by
   simp [stackAfterExp]


### PR DESCRIPTION
Refs #92
Bead: evm-asm-ym4ry

Summary:
- add a direct stackAfterExp length equality for decoded EXP input stacks

Verification:
- rg -n forbidden scan on EvmAsm/Evm64/Exp/Args.lean
- lake build EvmAsm.Evm64.Exp.Args
- scripts/check-file-size.sh
- lake build