### PR TITLE
feat(exp): add canonical program wrapper

### DIFF
--- a/EvmAsm/Evm64/Exp/Program.lean
+++ b/EvmAsm/Evm64/Exp/Program.lean
@@ -892,6 +892,18 @@ def evm_exp (mulOff : BitVec 21) (skipOff backOff : BitVec 13) : Program :=
   exp_loop_pointer_restore ;;
   exp_epilogue
 
+/-- Canonical BEQ offset for skipping the conditional-multiply taken branch. -/
+def canonicalExpCondMulSkipOff : BitVec 13 := 108
+
+/-- Canonical BNE back-edge offset from the loop tail to the iteration top. -/
+def canonicalExpLoopBackOff : BitVec 13 := -228
+
+/-- EXP program with the internal branch offsets pinned by the canonical layout.
+    The MUL call offset remains external because it depends on the caller's
+    placement of `mul_callable`. -/
+def evm_exp_canonical (mulOff : BitVec 21) : Program :=
+  evm_exp mulOff canonicalExpCondMulSkipOff canonicalExpLoopBackOff
+
 theorem evm_exp_length (mulOff : BitVec 21) (skipOff backOff : BitVec 13) :
     (evm_exp mulOff skipOff backOff).length = 75 := by
   show ((((exp_prologue ;;
@@ -909,5 +921,14 @@ theorem evm_exp_length (mulOff : BitVec 21) (skipOff backOff : BitVec 13) :
 theorem evm_exp_byte_length (mulOff : BitVec 21) (skipOff backOff : BitVec 13) :
     4 * (evm_exp mulOff skipOff backOff).length = 300 := by
   rw [evm_exp_length]
+
+theorem evm_exp_canonical_length (mulOff : BitVec 21) :
+    (evm_exp_canonical mulOff).length = 75 := by
+  unfold evm_exp_canonical
+  rw [evm_exp_length]
+
+theorem evm_exp_canonical_byte_length (mulOff : BitVec 21) :
+    4 * (evm_exp_canonical mulOff).length = 300 := by
+  rw [evm_exp_canonical_length]
 
 end EvmAsm.Evm64


### PR DESCRIPTION
Refs #92
Bead: evm-asm-k8vy5

Summary:
- add named canonical EXP skip/back offsets
- add evm_exp_canonical and length/byte-length lemmas

Verification:
- rg -n forbidden scan on EvmAsm/Evm64/Exp/Program.lean
- lake build EvmAsm.Evm64.Exp.Program
- scripts/check-file-size.sh
- lake build