### PR TITLE
feat(exp): add Args zero-one helpers

### DIFF
--- a/EvmAsm/Evm64/Exp/Args.lean
+++ b/EvmAsm/Evm64/Exp/Args.lean
@@ -138,6 +138,10 @@ theorem expResultFromArgs_one_right (base : EvmWord) :
     expResultFromArgs (expArgs base 1) = base := by
   exact EvmWord.exp_one_right base
 
+theorem expResultFromArgs_zero_one :
+    expResultFromArgs (expArgs 0 1) = 0 := by
+  exact expResultFromArgs_one_right 0
+
 theorem expResultFromArgs_max_one_right :
     expResultFromArgs (expArgs (-1 : EvmWord) 1) = (-1 : EvmWord) := by
   exact expResultFromArgs_one_right (-1 : EvmWord)
@@ -179,6 +183,10 @@ theorem stackAfterExp_one_left (exponent : EvmWord) (rest : List EvmWord) :
 theorem stackAfterExp_one_exponent (base : EvmWord) (rest : List EvmWord) :
     stackAfterExp (expArgs base 1) rest = base :: rest := by
   rw [stackAfterExp, expResultFromArgs_one_right]
+
+theorem stackAfterExp_zero_one (rest : List EvmWord) :
+    stackAfterExp (expArgs 0 1) rest = 0 :: rest := by
+  rw [stackAfterExp, expResultFromArgs_zero_one]
 
 theorem stackAfterExp_max_one_exponent (rest : List EvmWord) :
     stackAfterExp (expArgs (-1 : EvmWord) 1) rest = (-1 : EvmWord) :: rest := by


### PR DESCRIPTION
Refs #92
Bead: evm-asm-kwz82

Summary:
- add Args-level EXP zero-base one-exponent result helper
- add matching stackAfterExp wrapper

Verification:
- rg -n forbidden scan on EvmAsm/Evm64/Exp/Args.lean
- lake build EvmAsm.Evm64.Exp.Args
- scripts/check-file-size.sh
- lake build