### PR TITLE
feat(exp): add decode success projections

### DIFF
--- a/EvmAsm/Evm64/Exp/ArgsStackDecode.lean
+++ b/EvmAsm/Evm64/Exp/ArgsStackDecode.lean
@@ -210,6 +210,22 @@ theorem decodeExpStack?_map_exponent_eq
       | nil => rfl
       | cons exponent rest => rfl
 
+theorem decodeExpStack?_map_base_of_some
+    {stack : List EvmWord} {args : ExpArgs.Args}
+    (h : decodeExpStack? stack = some args) :
+    Option.map (fun args => args.base) (decodeExpStack? stack) =
+      some args.base := by
+  rw [h]
+  simp
+
+theorem decodeExpStack?_map_exponent_of_some
+    {stack : List EvmWord} {args : ExpArgs.Args}
+    (h : decodeExpStack? stack = some args) :
+    Option.map (fun args => args.exponent) (decodeExpStack? stack) =
+      some args.exponent := by
+  rw [h]
+  simp
+
 end ExpArgsStackDecode
 
 end EvmAsm.Evm64


### PR DESCRIPTION
Refs #92
Bead: evm-asm-b70c7

Summary:
- add successful-decode projection rewrites for EXP decoded base and exponent fields

Verification:
- rg -n forbidden scan on EvmAsm/Evm64/Exp/ArgsStackDecode.lean
- lake build EvmAsm.Evm64.Exp.ArgsStackDecode
- scripts/check-file-size.sh
- lake build