### PR TITLE
feat(exp): add layout valid transport

### DIFF
--- a/EvmAsm/Evm64/Exp/Layout.lean
+++ b/EvmAsm/Evm64/Exp/Layout.lean
@@ -107,6 +107,14 @@ theorem ExpScratchpadLayout.eq_canonical
 theorem canonicalExpScratchpadLayout_valid :
     canonicalExpScratchpadLayout.Valid := {}
 
+/-- A layout equal to the current canonical EXP scratchpad layout is valid. -/
+theorem ExpScratchpadLayout.valid_of_eq_canonical
+    {L : ExpScratchpadLayout}
+    (h_eq : L = canonicalExpScratchpadLayout) :
+    L.Valid := by
+  subst h_eq
+  exact canonicalExpScratchpadLayout_valid
+
 /-- The canonical EXP scratchpad layout validity predicate is trivial. -/
 theorem canonicalExpScratchpadLayout_valid_iff_true :
     canonicalExpScratchpadLayout.Valid ↔ True :=


### PR DESCRIPTION
Refs #92
Bead: evm-asm-ljc7w

Summary:
- add ExpScratchpadLayout.valid_of_eq_canonical for transporting validity from canonical layout equality

Verification:
- rg -n forbidden scan on EvmAsm/Evm64/Exp/Layout.lean
- lake build EvmAsm.Evm64.Exp.Layout
- scripts/check-file-size.sh
- lake build