### PR TITLE
feat(exp): add Args two-byte upper gas helpers

### DIFF
--- a/EvmAsm/Evm64/Exp/Args.lean
+++ b/EvmAsm/Evm64/Exp/Args.lean
@@ -242,6 +242,14 @@ theorem expTotalGasFromArgs_256_exponent (base : EvmWord) :
     expTotalGasFromArgs (expArgs base 256) = 110 := by
   exact ExpGas.expTotalGasFromExponent_256
 
+theorem expDynamicCostFromArgs_65535_exponent (base : EvmWord) :
+    expDynamicCostFromArgs (expArgs base 65535) = 100 := by
+  exact ExpGas.expDynamicCostFromExponent_65535
+
+theorem expTotalGasFromArgs_65535_exponent (base : EvmWord) :
+    expTotalGasFromArgs (expArgs base 65535) = 110 := by
+  exact ExpGas.expTotalGasFromExponent_65535
+
 theorem expDynamicCostFromArgs_max_exponent (base : EvmWord) :
     expDynamicCostFromArgs (expArgs base (-1)) = 1600 := by
   exact ExpGas.expDynamicCostFromExponent_max


### PR DESCRIPTION
Refs #92
Bead: evm-asm-irups

Summary:
- add Args-level EXP dynamic and total gas wrappers for exponent 65535

Verification:
- rg -n forbidden scan on EvmAsm/Evm64/Exp/Args.lean
- lake build EvmAsm.Evm64.Exp.Args
- scripts/check-file-size.sh
- lake build