### PR TITLE
feat(exp): add two-to-255 word helper

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/Exp.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Exp.lean
@@ -97,6 +97,11 @@ theorem exp_succ_right_of_toNat_lt (base exponent : EvmWord)
   rw [Nat.mul_mod]
   rw [Nat.mod_eq_of_lt base.isLt]
 
+/-- The GH #92 pre-wrap boundary case `EXP(2, 255)` is the high bit. -/
+theorem exp_two_255 : exp (2 : EvmWord) (255 : EvmWord) =
+    BitVec.ofNat 256 (2^255) := by
+  native_decide
+
 /-- The GH #92 boundary case `EXP(2, 256)` wraps to zero modulo `2^256`. -/
 theorem exp_two_256 : exp (2 : EvmWord) (256 : EvmWord) = 0 := by
   native_decide


### PR DESCRIPTION
Refs GH #92.\n\nBead: evm-asm-s9nzn\n\nSummary:\n- add EvmWord.exp_two_255 as the pre-wrap EXP(2,255) boundary helper\n\nVerification:\n- lake build EvmAsm.Evm64.EvmWordArith.Exp\n- scripts/check-file-size.sh\n- lake build