### PR TITLE
feat(exp): add Args three-byte lower gas helpers

### DIFF
--- a/EvmAsm/Evm64/Exp/Args.lean
+++ b/EvmAsm/Evm64/Exp/Args.lean
@@ -250,6 +250,14 @@ theorem expTotalGasFromArgs_65535_exponent (base : EvmWord) :
     expTotalGasFromArgs (expArgs base 65535) = 110 := by
   exact ExpGas.expTotalGasFromExponent_65535
 
+theorem expDynamicCostFromArgs_65536_exponent (base : EvmWord) :
+    expDynamicCostFromArgs (expArgs base 65536) = 150 := by
+  exact ExpGas.expDynamicCostFromExponent_65536
+
+theorem expTotalGasFromArgs_65536_exponent (base : EvmWord) :
+    expTotalGasFromArgs (expArgs base 65536) = 160 := by
+  exact ExpGas.expTotalGasFromExponent_65536
+
 theorem expDynamicCostFromArgs_max_exponent (base : EvmWord) :
     expDynamicCostFromArgs (expArgs base (-1)) = 1600 := by
   exact ExpGas.expDynamicCostFromExponent_max


### PR DESCRIPTION
Refs GH #92.\n\nBead: evm-asm-w720o\n\nSummary:\n- add decoded Args wrappers for EXP exponent 65536 dynamic and total gas\n\nVerification:\n- lake build EvmAsm.Evm64.Exp.Args\n- scripts/check-file-size.sh\n- lake build