### PR TITLE
feat(exp): add decode result map helper

### DIFF
--- a/EvmAsm/Evm64/Exp/ArgsStackDecode.lean
+++ b/EvmAsm/Evm64/Exp/ArgsStackDecode.lean
@@ -210,6 +210,21 @@ theorem decodeExpStack?_map_exponent_eq
       | nil => rfl
       | cons exponent rest => rfl
 
+theorem decodeExpStack?_map_result_eq
+    (stack : List EvmWord) :
+    Option.map (fun args => ExpArgs.expResultFromArgs args)
+      (decodeExpStack? stack) =
+      match stack with
+      | base :: exponent :: _rest =>
+          some (ExpArgs.expResultFromArgs (ExpArgs.expArgs base exponent))
+      | _ => none := by
+  cases stack with
+  | nil => rfl
+  | cons base tail =>
+      cases tail with
+      | nil => rfl
+      | cons exponent rest => rfl
+
 theorem decodeExpStack?_map_base_of_some
     {stack : List EvmWord} {args : ExpArgs.Args}
     (h : decodeExpStack? stack = some args) :


### PR DESCRIPTION
Refs GH #92.\n\nBead: evm-asm-dm4ew\n\nSummary:\n- add decodeExpStack?_map_result_eq for rewriting decoded EXP stack results\n\nVerification:\n- lake build EvmAsm.Evm64.Exp.ArgsStackDecode\n- scripts/check-file-size.sh\n- lake build