### PR TITLE
feat(exp): add squaring marshal pair sub

### DIFF
--- a/EvmAsm/Evm64/Exp/SquaringCall.lean
+++ b/EvmAsm/Evm64/Exp/SquaringCall.lean
@@ -28,6 +28,7 @@
   normalization). Authored by @pirapira; implemented by Hermes-bot.
 -/
 
+import EvmAsm.Evm64.Exp.MarshalPair
 import EvmAsm.Evm64.Stack
 import EvmAsm.Evm64.Exp.LimbSpec
 
@@ -159,5 +160,17 @@ theorem exp_squaring_call_block_code_block_subs
     exp_squaring_call_block_code_marshal_result_to_factor2_sub base mulOff,
     exp_squaring_call_block_code_square_sub base mulOff,
     exp_squaring_call_block_code_un_marshal_and_restore_sub base mulOff⟩
+
+/-- The two-block squaring marshal-pair prefix is contained in the full
+    squaring call block code. -/
+theorem exp_squaring_call_block_code_marshal_pair_sub
+    (base : Word) (mulOff : BitVec 21) :
+    ∀ a i, (exp_loop_squaring_marshal_pair_code base) a = some i →
+      (exp_squaring_call_block_code base mulOff) a = some i := by
+  intro a i h
+  exact CodeReq.union_sub
+    (exp_squaring_call_block_code_marshal_factor1_sub base mulOff)
+    (exp_squaring_call_block_code_marshal_result_to_factor2_sub base mulOff)
+    a i h
 
 end EvmAsm.Evm64


### PR DESCRIPTION
Refs #92.\n\nBead: evm-asm-g1rwo\n\n## Summary\n- import the EXP squaring marshal-pair code helper into SquaringCall\n- add exp_squaring_call_block_code_marshal_pair_sub for extending the two-block prefix into the full squaring call code\n\n## Verification\n- lake build EvmAsm.Evm64.Exp.SquaringCall\n- scripts/check-file-size.sh\n- lake build