### PR TITLE
feat(exp): add branch offset addr lemmas

### DIFF
--- a/EvmAsm/Evm64/Exp/AddrNorm.lean
+++ b/EvmAsm/Evm64/Exp/AddrNorm.lean
@@ -18,6 +18,12 @@ namespace EvmAsm.Evm64.Exp.AddrNorm
 
 open EvmAsm.Rv64
 
+@[exp_addr, grind =] theorem exp_se13_108 :
+    signExtend13 (108 : BitVec 13) = (108 : Word) := by decide
+
+@[exp_addr, grind =] theorem exp_se13_neg228 :
+    signExtend13 ((-228 : BitVec 13)) = (18446744073709551388 : Word) := by decide
+
 attribute [exp_addr]
   signExtend12_0 signExtend12_1 signExtend12_8 signExtend12_16
   signExtend12_24 signExtend12_32 signExtend12_40 signExtend12_48


### PR DESCRIPTION
Refs #92.\n\nBead: evm-asm-560xf\n\n## Summary\n- add exp_addr normalization for canonical EXP cond-mul skip offset 108\n- add exp_addr normalization for canonical EXP loop back-edge offset -228\n\n## Verification\n- lake build EvmAsm.Evm64.Exp.AddrNorm\n- scripts/check-file-size.sh\n- lake build