### PR TITLE
fix(conformance): refresh revert stack branch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,6 +157,46 @@ Pitfalls:
   `fix(shr): address canonicalization in sign-fill path`). The PR summary bot
   flags titles that don't match this format.
 
+## Bead closure rules (`bd close`)
+
+The beads tracker is the source of truth for outstanding work. Closing a bead
+incorrectly hides unfinished obligations and bumping its priority later does
+nothing because the bead is no longer in the queue. Before running
+`bd close <id>`, satisfy **all** of the following:
+
+1. **The named deliverable must exist on `origin/main`.** If the bead title
+   says "prove `foo_spec_within`", "define `evm_foo`", or "lift X to Y", that
+   exact declaration has to be present on `origin/main` — not on a feature
+   branch, not in an unmerged stacked PR. Verify with:
+   `git fetch origin && git grep -n '<decl name>' origin/main -- '<expected path>'`.
+   If the grep is empty, **do not close the bead**.
+
+2. **A "related" PR merging is not the same as the deliverable shipping.** A
+   PR titled similarly, or that adds scaffolding, wrappers, or preparation
+   lemmas around the deliverable, does not satisfy the bead. If the named
+   theorem is still a `placeholder`, `sorry`, or absent, the bead stays open.
+
+3. **Stacked PRs into feature branches don't count.** A PR merged into
+   `feat/foo` instead of `main` has not landed. Wait for the bottom of the
+   stack to merge into `main`, then verify per (1) before closing the
+   dependent beads.
+
+4. **`close_reason` must be truthful.** `"shipped in PR #N"` is only valid
+   when PR #N's merge commit is an ancestor of `origin/main` *and* the named
+   deliverable is grep-visible there. Otherwise use
+   `"superseded by <bead-id>"` or `"duplicate of <bead-id>"`. Never close as
+   "shipped" against a PR that merged into a feature branch.
+
+5. **If you finished real work but the named theorem isn't done yet**,
+   prefer adding a `bd comment` with status, or filing a follow-up bead, or
+   updating the existing bead's description — instead of closing the wrong
+   thing.
+
+Recent violations to learn from: `evm-asm-01uh` (SDIV), `evm-asm-6snn` and
+`evm-asm-w5mk` (EXP) — all closed as "shipped in PR #…" while the named
+theorem was still a placeholder on `main` (and in the EXP cases the PR was
+merged into a feature branch, not `main`). All three had to be reopened.
+
 ## References
 
 - **Accelerator C ABI (source of truth)**:

--- a/EvmAsm/EL/Conformance/All.lean
+++ b/EvmAsm/EL/Conformance/All.lean
@@ -44,11 +44,11 @@ def allConformanceVectorCount : Nat :=
   allConformanceVectors.length
 
 theorem allConformanceVectors_length :
-    allConformanceVectors.length = 50 := by
+    allConformanceVectors.length = 51 := by
   native_decide
 
 theorem allConformanceVectorCount_eq :
-    allConformanceVectorCount = 50 := by
+    allConformanceVectorCount = 51 := by
   native_decide
 
 def unexpectedConformanceFailures : List CheckResult :=
@@ -115,7 +115,7 @@ theorem expectedConformanceErrorCount_eq :
   native_decide
 
 theorem successfulConformanceResultCount_eq :
-    successfulConformanceResultCount = 40 := by
+    successfulConformanceResultCount = 41 := by
   native_decide
 
 end Conformance

--- a/EvmAsm/EL/Conformance/All.lean
+++ b/EvmAsm/EL/Conformance/All.lean
@@ -44,11 +44,11 @@ def allConformanceVectorCount : Nat :=
   allConformanceVectors.length
 
 theorem allConformanceVectors_length :
-    allConformanceVectors.length = 49 := by
+    allConformanceVectors.length = 50 := by
   native_decide
 
 theorem allConformanceVectorCount_eq :
-    allConformanceVectorCount = 49 := by
+    allConformanceVectorCount = 50 := by
   native_decide
 
 def unexpectedConformanceFailures : List CheckResult :=
@@ -115,7 +115,7 @@ theorem expectedConformanceErrorCount_eq :
   native_decide
 
 theorem successfulConformanceResultCount_eq :
-    successfulConformanceResultCount = 39 := by
+    successfulConformanceResultCount = 40 := by
   native_decide
 
 end Conformance

--- a/EvmAsm/EL/Conformance/All.lean
+++ b/EvmAsm/EL/Conformance/All.lean
@@ -44,11 +44,11 @@ def allConformanceVectorCount : Nat :=
   allConformanceVectors.length
 
 theorem allConformanceVectors_length :
-    allConformanceVectors.length = 51 := by
+    allConformanceVectors.length = 52 := by
   native_decide
 
 theorem allConformanceVectorCount_eq :
-    allConformanceVectorCount = 51 := by
+    allConformanceVectorCount = 52 := by
   native_decide
 
 def unexpectedConformanceFailures : List CheckResult :=
@@ -115,7 +115,7 @@ theorem expectedConformanceErrorCount_eq :
   native_decide
 
 theorem successfulConformanceResultCount_eq :
-    successfulConformanceResultCount = 41 := by
+    successfulConformanceResultCount = 42 := by
   native_decide
 
 end Conformance

--- a/EvmAsm/EL/Conformance/ExpGas.lean
+++ b/EvmAsm/EL/Conformance/ExpGas.lean
@@ -41,6 +41,12 @@ def expGasTwoByteThresholdVector : TestVector ExpGasInput Nat :=
     input := { exponent := 256 }
     expected := .value 110 }
 
+/-- The maximum 256-bit exponent occupies all 32 bytes. -/
+def expGasMaxExponentVector : TestVector ExpGasInput Nat :=
+  { id := "exp-gas-max-exponent"
+    input := { exponent := -1 }
+    expected := .value 1610 }
+
 theorem runExpGas_zero :
     runExpGas { exponent := (0 : EvmWord) } = 10 :=
   EvmAsm.Evm64.ExpGas.expTotalGasFromExponent_zero
@@ -53,6 +59,10 @@ theorem runExpGas_one :
 theorem runExpGas_256 :
     runExpGas { exponent := (256 : EvmWord) } = 110 :=
   EvmAsm.Evm64.ExpGas.expTotalGasFromExponent_256
+
+theorem runExpGas_max :
+    runExpGas { exponent := (-1 : EvmWord) } = 1610 :=
+  EvmAsm.Evm64.ExpGas.expTotalGasFromExponent_max
 
 theorem expGasZeroExponentVector_passed :
     checkVector runExpGas expGasZeroExponentVector = .passed :=
@@ -78,12 +88,21 @@ theorem expGasTwoByteThresholdVector_passed :
     110
     runExpGas_256
 
+theorem expGasMaxExponentVector_passed :
+    checkVector runExpGas expGasMaxExponentVector = .passed :=
+  checkVector_value_passed runExpGas
+    "exp-gas-max-exponent"
+    { exponent := (-1 : EvmWord) }
+    1610
+    runExpGas_max
+
 /-- Vector IDs for EXP gas executable-helper conformance coverage.
     Distinctive token: expGasConformanceVectorIds #125 #92. -/
 def expGasConformanceVectorIds : List String :=
   [ expGasZeroExponentVector.id
   , expGasOneByteExponentVector.id
   , expGasTwoByteThresholdVector.id
+  , expGasMaxExponentVector.id
   ]
 
 theorem expGasConformanceVectorIds_eq :
@@ -91,10 +110,11 @@ theorem expGasConformanceVectorIds_eq :
       [ "exp-gas-zero-exponent"
       , "exp-gas-one-byte-exponent"
       , "exp-gas-two-byte-threshold"
+      , "exp-gas-max-exponent"
       ] := rfl
 
 theorem expGasConformanceVectorIds_length :
-    expGasConformanceVectorIds.length = 3 := rfl
+    expGasConformanceVectorIds.length = 4 := rfl
 
 theorem expGasConformanceVectorIds_nodup :
     expGasConformanceVectorIds.Nodup := by
@@ -106,12 +126,14 @@ def expGasConformanceVectors : List CheckResult :=
   [ checkVector runExpGas expGasZeroExponentVector
   , checkVector runExpGas expGasOneByteExponentVector
   , checkVector runExpGas expGasTwoByteThresholdVector
+  , checkVector runExpGas expGasMaxExponentVector
   ]
 
 theorem expGasConformanceVectors_passed :
-    expGasConformanceVectors = [.passed, .passed, .passed] := by
+    expGasConformanceVectors = [.passed, .passed, .passed, .passed] := by
   simp [expGasConformanceVectors, expGasZeroExponentVector_passed,
-    expGasOneByteExponentVector_passed, expGasTwoByteThresholdVector_passed]
+    expGasOneByteExponentVector_passed, expGasTwoByteThresholdVector_passed,
+    expGasMaxExponentVector_passed]
 
 end ExpGas
 end Conformance

--- a/EvmAsm/EL/Conformance/ExpStackExecution.lean
+++ b/EvmAsm/EL/Conformance/ExpStackExecution.lean
@@ -65,6 +65,17 @@ def expStackOneExponentVector : TestVector ExpStackState ExpStackResult :=
               totalGas := 60 }
           stack := [99] } }
 
+def expStackTwo64Vector : TestVector ExpStackState ExpStackResult :=
+  { id := "exp-stack-two-64"
+    input := { stack := [2, 64, 99] }
+    expected :=
+      .value
+        { effects :=
+            { stackWords := [BitVec.ofNat 256 (2^64)]
+              dynamicGas := 50
+              totalGas := 60 }
+          stack := [99] } }
+
 def expStackUnderflowVector : TestVector ExpStackState ExpStackResult :=
   { id := "exp-stack-underflow"
     input := { stack := [2] }
@@ -77,6 +88,7 @@ def expStackConformanceTestVectors : List (TestVector ExpStackState ExpStackResu
   [ expStackValueVector
   , expStackZeroZeroVector
   , expStackOneExponentVector
+  , expStackTwo64Vector
   , expStackUnderflowVector
   ]
 
@@ -84,25 +96,30 @@ def expStackConformanceVectorIds : List String :=
   expStackConformanceTestVectors.map TestVector.id
 
 theorem expStackConformanceTestVectors_length :
-    expStackConformanceTestVectors.length = 4 := rfl
+    expStackConformanceTestVectors.length = 5 := rfl
 
 theorem expStackConformanceVectorIds_eq :
     expStackConformanceVectorIds =
       [ "exp-stack-value"
       , "exp-stack-zero-zero"
       , "exp-stack-one-exponent"
+      , "exp-stack-two-64"
       , "exp-stack-underflow"
       ] := rfl
 
 theorem expStackConformanceVectorIds_length :
-    expStackConformanceVectorIds.length = 4 := rfl
+    expStackConformanceVectorIds.length = 5 := rfl
 
 theorem expStackConformanceVectorIds_nodup :
     expStackConformanceVectorIds.Nodup := by
   decide
 
 def expStackValueVectorIds : List String :=
-  ["exp-stack-value", "exp-stack-zero-zero", "exp-stack-one-exponent"]
+  [ "exp-stack-value"
+  , "exp-stack-zero-zero"
+  , "exp-stack-one-exponent"
+  , "exp-stack-two-64"
+  ]
 
 def expStackErrorVectorIds : List String :=
   ["exp-stack-underflow"]
@@ -149,6 +166,16 @@ theorem runExpStack?_one_exponent :
           stack := [(99 : EvmWord)] } := by
   native_decide
 
+theorem runExpStack?_two_64 :
+    runExpStack? { stack := [(2 : EvmWord), (64 : EvmWord), (99 : EvmWord)] } =
+      some
+        { effects :=
+            { stackWords := [BitVec.ofNat 256 (2^64)]
+              dynamicGas := 50
+              totalGas := 60 }
+          stack := [(99 : EvmWord)] } := by
+  native_decide
+
 theorem runExpStack?_underflow :
     runExpStack? { stack := [(2 : EvmWord)] } = none := rfl
 
@@ -188,6 +215,18 @@ theorem expStackOneExponentVector_passed :
       stack := [(99 : EvmWord)] }
     runExpStack?_one_exponent
 
+theorem expStackTwo64Vector_passed :
+    checkVector? runExpStack? expStackTwo64Vector = .passed :=
+  checkVector?_some_passed runExpStack?
+    "exp-stack-two-64"
+    { stack := [(2 : EvmWord), (64 : EvmWord), (99 : EvmWord)] }
+    { effects :=
+        { stackWords := [BitVec.ofNat 256 (2^64)]
+          dynamicGas := 50
+          totalGas := 60 }
+      stack := [(99 : EvmWord)] }
+    runExpStack?_two_64
+
 theorem expStackUnderflowVector_passed :
     checkVector? runExpStack? expStackUnderflowVector =
       .errored "exp-stack-underflow" "stack-underflow" :=
@@ -204,10 +243,16 @@ def expStackConformanceVectors : List CheckResult :=
 
 theorem expStackConformanceVectors_passed :
     expStackConformanceVectors =
-      [.passed, .passed, .passed, .errored "exp-stack-underflow" "stack-underflow"] := by
+      [ .passed
+      , .passed
+      , .passed
+      , .passed
+      , .errored "exp-stack-underflow" "stack-underflow"
+      ] := by
   simp [expStackConformanceVectors, expStackConformanceTestVectors,
     expStackValueVector_passed, expStackZeroZeroVector_passed,
-    expStackOneExponentVector_passed, expStackUnderflowVector_passed]
+    expStackOneExponentVector_passed, expStackTwo64Vector_passed,
+    expStackUnderflowVector_passed]
 
 end ExpStackExecution
 end Conformance

--- a/EvmAsm/EL/Conformance/ExpStackExecution.lean
+++ b/EvmAsm/EL/Conformance/ExpStackExecution.lean
@@ -65,6 +65,19 @@ def expStackOneExponentVector : TestVector ExpStackState ExpStackResult :=
               totalGas := 60 }
           stack := [99] } }
 
+/-- EXP with max base and exponent one returns the max word.
+    Distinctive token: exp-stack-max-one-exponent #92 #125. -/
+def expStackMaxOneExponentVector : TestVector ExpStackState ExpStackResult :=
+  { id := "exp-stack-max-one-exponent"
+    input := { stack := [(-1 : EvmWord), 1, 99] }
+    expected :=
+      .value
+        { effects :=
+            { stackWords := [(-1 : EvmWord)]
+              dynamicGas := 50
+              totalGas := 60 }
+          stack := [99] } }
+
 def expStackUnderflowVector : TestVector ExpStackState ExpStackResult :=
   { id := "exp-stack-underflow"
     input := { stack := [2] }
@@ -77,6 +90,7 @@ def expStackConformanceTestVectors : List (TestVector ExpStackState ExpStackResu
   [ expStackValueVector
   , expStackZeroZeroVector
   , expStackOneExponentVector
+  , expStackMaxOneExponentVector
   , expStackUnderflowVector
   ]
 
@@ -84,25 +98,30 @@ def expStackConformanceVectorIds : List String :=
   expStackConformanceTestVectors.map TestVector.id
 
 theorem expStackConformanceTestVectors_length :
-    expStackConformanceTestVectors.length = 4 := rfl
+    expStackConformanceTestVectors.length = 5 := rfl
 
 theorem expStackConformanceVectorIds_eq :
     expStackConformanceVectorIds =
       [ "exp-stack-value"
       , "exp-stack-zero-zero"
       , "exp-stack-one-exponent"
+      , "exp-stack-max-one-exponent"
       , "exp-stack-underflow"
       ] := rfl
 
 theorem expStackConformanceVectorIds_length :
-    expStackConformanceVectorIds.length = 4 := rfl
+    expStackConformanceVectorIds.length = 5 := rfl
 
 theorem expStackConformanceVectorIds_nodup :
     expStackConformanceVectorIds.Nodup := by
   decide
 
 def expStackValueVectorIds : List String :=
-  ["exp-stack-value", "exp-stack-zero-zero", "exp-stack-one-exponent"]
+  [ "exp-stack-value"
+  , "exp-stack-zero-zero"
+  , "exp-stack-one-exponent"
+  , "exp-stack-max-one-exponent"
+  ]
 
 def expStackErrorVectorIds : List String :=
   ["exp-stack-underflow"]
@@ -149,6 +168,26 @@ theorem runExpStack?_one_exponent :
           stack := [(99 : EvmWord)] } := by
   native_decide
 
+theorem runExpStack?_max_one_exponent :
+    runExpStack?
+        { stack := [(-1 : EvmWord), (1 : EvmWord), (99 : EvmWord)] } =
+      some
+        { effects :=
+            { stackWords := [(-1 : EvmWord)]
+              dynamicGas := 50
+              totalGas := 60 }
+          stack := [(99 : EvmWord)] } := by
+  change EvmAsm.Evm64.ExpStackExecutionBridge.runExpStack?
+      { stack := [(-1 : EvmWord), (1 : EvmWord), (99 : EvmWord)] } =
+    some
+      { effects :=
+          { stackWords := [(-1 : EvmWord)]
+            dynamicGas := 50
+            totalGas := 60 }
+        stack := [(99 : EvmWord)] }
+  exact EvmAsm.Evm64.ExpStackExecutionBridge.runExpStack?_max_one_exponent
+    [(99 : EvmWord)]
+
 theorem runExpStack?_underflow :
     runExpStack? { stack := [(2 : EvmWord)] } = none := rfl
 
@@ -188,6 +227,18 @@ theorem expStackOneExponentVector_passed :
       stack := [(99 : EvmWord)] }
     runExpStack?_one_exponent
 
+theorem expStackMaxOneExponentVector_passed :
+    checkVector? runExpStack? expStackMaxOneExponentVector = .passed :=
+  checkVector?_some_passed runExpStack?
+    "exp-stack-max-one-exponent"
+    { stack := [(-1 : EvmWord), (1 : EvmWord), (99 : EvmWord)] }
+    { effects :=
+        { stackWords := [(-1 : EvmWord)]
+          dynamicGas := 50
+          totalGas := 60 }
+      stack := [(99 : EvmWord)] }
+    runExpStack?_max_one_exponent
+
 theorem expStackUnderflowVector_passed :
     checkVector? runExpStack? expStackUnderflowVector =
       .errored "exp-stack-underflow" "stack-underflow" :=
@@ -204,10 +255,16 @@ def expStackConformanceVectors : List CheckResult :=
 
 theorem expStackConformanceVectors_passed :
     expStackConformanceVectors =
-      [.passed, .passed, .passed, .errored "exp-stack-underflow" "stack-underflow"] := by
+      [ .passed
+      , .passed
+      , .passed
+      , .passed
+      , .errored "exp-stack-underflow" "stack-underflow"
+      ] := by
   simp [expStackConformanceVectors, expStackConformanceTestVectors,
     expStackValueVector_passed, expStackZeroZeroVector_passed,
-    expStackOneExponentVector_passed, expStackUnderflowVector_passed]
+    expStackOneExponentVector_passed, expStackMaxOneExponentVector_passed,
+    expStackUnderflowVector_passed]
 
 end ExpStackExecution
 end Conformance

--- a/EvmAsm/Evm64/EvmWordArith/Exp.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Exp.lean
@@ -101,6 +101,11 @@ theorem exp_succ_right_of_toNat_lt (base exponent : EvmWord)
   rw [Nat.mul_mod]
   rw [Nat.mod_eq_of_lt base.isLt]
 
+/-- The GH #92 cross-limb boundary case `EXP(2, 64)`. -/
+theorem exp_two_64 : exp (2 : EvmWord) (64 : EvmWord) =
+    BitVec.ofNat 256 (2^64) := by
+  native_decide
+
 /-- The GH #92 pre-wrap boundary case `EXP(2, 255)` is the high bit. -/
 theorem exp_two_255 : exp (2 : EvmWord) (255 : EvmWord) =
     BitVec.ofNat 256 (2^255) := by

--- a/EvmAsm/Evm64/EvmWordArith/Exp.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Exp.lean
@@ -106,6 +106,11 @@ theorem exp_two_64 : exp (2 : EvmWord) (64 : EvmWord) =
     BitVec.ofNat 256 (2^64) := by
   native_decide
 
+/-- The GH #92 mid-word boundary case `EXP(2, 128)`. -/
+theorem exp_two_128 : exp (2 : EvmWord) (128 : EvmWord) =
+    BitVec.ofNat 256 (2^128) := by
+  native_decide
+
 /-- The GH #92 pre-wrap boundary case `EXP(2, 255)` is the high bit. -/
 theorem exp_two_255 : exp (2 : EvmWord) (255 : EvmWord) =
     BitVec.ofNat 256 (2^255) := by

--- a/EvmAsm/Evm64/Exp/AddrNormAttr.lean
+++ b/EvmAsm/Evm64/Exp/AddrNormAttr.lean
@@ -5,14 +5,13 @@
 
   Split out from `AddrNorm.lean` because Lean 4 does not allow an attribute
   to be used in the same file in which it is declared. Downstream code should
-  import `Exp/AddrNorm.lean` (which imports this file) — not this file directly.
-
-  Skeleton placeholder for GH #92 (EXP opcode). No tagged lemmas yet.
+  import `Exp/AddrNorm.lean` (which imports this file) rather than this file
+  directly; tagged EXP address lemmas live there.
 -/
 
 import Lean.Meta.Tactic.Simp.RegisterCommand
 
-/-- Simp set for EXP address arithmetic. Will collect atomic evaluations of
-    `signExtend12`, `<<<`, and `BitVec.toNat` on concrete literals that arise
+/-- Simp set for EXP address arithmetic: atomic evaluations of `signExtend12`,
+    `signExtend13`, shifts, and `BitVec.toNat` on concrete literals that arise
     in EXP composition proofs. -/
 register_simp_attr exp_addr

--- a/EvmAsm/Evm64/Exp/Args.lean
+++ b/EvmAsm/Evm64/Exp/Args.lean
@@ -150,6 +150,10 @@ theorem expResultFromArgs_max_one_right :
     expResultFromArgs (expArgs (-1 : EvmWord) 1) = (-1 : EvmWord) := by
   exact expResultFromArgs_one_right (-1 : EvmWord)
 
+theorem expResultFromArgs_two_64 :
+    expResultFromArgs (expArgs 2 64) = BitVec.ofNat 256 (2^64) := by
+  exact EvmWord.exp_two_64
+
 theorem expResultFromArgs_two_128 :
     expResultFromArgs (expArgs 2 128) = BitVec.ofNat 256 (2^128) := by
   exact EvmWord.exp_two_128
@@ -203,6 +207,11 @@ theorem stackAfterExp_two_one (rest : List EvmWord) :
 theorem stackAfterExp_max_one_exponent (rest : List EvmWord) :
     stackAfterExp (expArgs (-1 : EvmWord) 1) rest = (-1 : EvmWord) :: rest := by
   rw [stackAfterExp, expResultFromArgs_max_one_right]
+
+theorem stackAfterExp_two_64 (rest : List EvmWord) :
+    stackAfterExp (expArgs 2 64) rest =
+      BitVec.ofNat 256 (2^64) :: rest := by
+  rw [stackAfterExp, expResultFromArgs_two_64]
 
 theorem stackAfterExp_two_128 (rest : List EvmWord) :
     stackAfterExp (expArgs 2 128) rest =

--- a/EvmAsm/Evm64/Exp/Args.lean
+++ b/EvmAsm/Evm64/Exp/Args.lean
@@ -150,6 +150,10 @@ theorem expResultFromArgs_max_one_right :
     expResultFromArgs (expArgs (-1 : EvmWord) 1) = (-1 : EvmWord) := by
   exact expResultFromArgs_one_right (-1 : EvmWord)
 
+theorem expResultFromArgs_two_128 :
+    expResultFromArgs (expArgs 2 128) = BitVec.ofNat 256 (2^128) := by
+  exact EvmWord.exp_two_128
+
 theorem expResultFromArgs_two_256 :
     expResultFromArgs (expArgs 2 256) = 0 := by
   exact EvmWord.exp_two_256
@@ -199,6 +203,11 @@ theorem stackAfterExp_two_one (rest : List EvmWord) :
 theorem stackAfterExp_max_one_exponent (rest : List EvmWord) :
     stackAfterExp (expArgs (-1 : EvmWord) 1) rest = (-1 : EvmWord) :: rest := by
   rw [stackAfterExp, expResultFromArgs_max_one_right]
+
+theorem stackAfterExp_two_128 (rest : List EvmWord) :
+    stackAfterExp (expArgs 2 128) rest =
+      BitVec.ofNat 256 (2^128) :: rest := by
+  rw [stackAfterExp, expResultFromArgs_two_128]
 
 theorem stackAfterExp_two_256 (rest : List EvmWord) :
     stackAfterExp (expArgs 2 256) rest = 0 :: rest := by

--- a/EvmAsm/Evm64/Exp/Args.lean
+++ b/EvmAsm/Evm64/Exp/Args.lean
@@ -154,6 +154,10 @@ theorem expResultFromArgs_two_128 :
     expResultFromArgs (expArgs 2 128) = BitVec.ofNat 256 (2^128) := by
   exact EvmWord.exp_two_128
 
+theorem expResultFromArgs_two_255 :
+    expResultFromArgs (expArgs 2 255) = BitVec.ofNat 256 (2^255) := by
+  exact EvmWord.exp_two_255
+
 theorem expResultFromArgs_two_256 :
     expResultFromArgs (expArgs 2 256) = 0 := by
   exact EvmWord.exp_two_256
@@ -208,6 +212,11 @@ theorem stackAfterExp_two_128 (rest : List EvmWord) :
     stackAfterExp (expArgs 2 128) rest =
       BitVec.ofNat 256 (2^128) :: rest := by
   rw [stackAfterExp, expResultFromArgs_two_128]
+
+theorem stackAfterExp_two_255 (rest : List EvmWord) :
+    stackAfterExp (expArgs 2 255) rest =
+      BitVec.ofNat 256 (2^255) :: rest := by
+  rw [stackAfterExp, expResultFromArgs_two_255]
 
 theorem stackAfterExp_two_256 (rest : List EvmWord) :
     stackAfterExp (expArgs 2 256) rest = 0 :: rest := by

--- a/EvmAsm/Evm64/Exp/SquaringCallSeq.lean
+++ b/EvmAsm/Evm64/Exp/SquaringCallSeq.lean
@@ -128,4 +128,45 @@ theorem exp_loop_squaring_marshal_pair_then_square_spec_within
     (fun _ hp => by xperm_hyp hp)
     hseq
 
+/-- Right-framed wrapper for
+    `exp_loop_squaring_marshal_pair_then_square_spec_within`, useful when the
+    squaring prefix is spliced into a larger composition with an untouched
+    frame. -/
+theorem exp_loop_squaring_marshal_pair_then_square_spec_within_right
+    (sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 : Word)
+    (mulOff : BitVec 21) (base : Word) (Q : Assertion) (hQ : Q.pcFree) :
+    cpsTripleWithin 17 base ((base + 64) + signExtend21 mulOff)
+      (exp_squaring_call_block_code base mulOff)
+      (((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+       ((evmSp + signExtend12 (0 : BitVec 12)) ↦ₘ d0) **
+       ((evmSp + signExtend12 (8 : BitVec 12)) ↦ₘ d1) **
+       ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ d2) **
+       ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ d3) **
+       ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ e0) **
+       ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ e1) **
+       ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ e2) **
+       ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ e3) **
+       (.x1 ↦ᵣ vOld)) ** Q)
+      (((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ r3) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+       ((evmSp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+       ((evmSp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+       ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+       ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+       ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ r0) **
+       ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ r1) **
+       ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ r2) **
+       ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ r3) **
+       (.x1 ↦ᵣ (base + 68))) ** Q) := by
+  exact cpsTripleWithin_frameR Q hQ
+    (exp_loop_squaring_marshal_pair_then_square_spec_within
+      sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 mulOff base)
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
+++ b/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
@@ -336,6 +336,22 @@ theorem runExpStack?_two_256
   rw [ExpArgs.expDynamicCostFromArgs_256_exponent]
   rw [ExpArgs.expTotalGasFromArgs_256_exponent]
 
+theorem runExpStack?_two_128
+    (rest : List EvmWord) :
+    runExpStack? { stack := (2 : EvmWord) :: 128 :: rest } =
+      some
+        { effects :=
+            { stackWords := [BitVec.ofNat 256 (2^128)]
+              dynamicGas := 50
+              totalGas := 60 }
+          stack := rest } := by
+  rw [runExpStack?_cons]
+  simp only [ExpArgs.expResultFromArgs, ExpArgs.expArgs,
+    ExpArgs.expDynamicCostFromArgs, ExpArgs.expTotalGasFromArgs]
+  rw [EvmWord.exp_two_128]
+  rw [ExpGas.expDynamicCostFromExponent_of_pos_lt_256 (by decide) (by decide)]
+  rw [ExpGas.expTotalGasFromExponent_of_pos_lt_256 (by decide) (by decide)]
+
 theorem runExpStack?_max_exponent_gas
     (base : EvmWord) (rest : List EvmWord) :
     (runExpStack? { stack := base :: (-1 : EvmWord) :: rest }).map

--- a/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
+++ b/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
@@ -341,6 +341,21 @@ theorem runExpStack?_one_left
   rw [runExpStack?_cons]
   rw [ExpArgs.expResultFromArgs_one_left]
 
+theorem runExpStack?_zero_left_of_toNat_pos
+    (exponent : EvmWord) (h_pos : 0 < exponent.toNat)
+    (rest : List EvmWord) :
+    runExpStack? { stack := (0 : EvmWord) :: exponent :: rest } =
+      some
+        { effects :=
+            { stackWords := [0]
+              dynamicGas := ExpArgs.expDynamicCostFromArgs
+                (ExpArgs.expArgs 0 exponent)
+              totalGas := ExpArgs.expTotalGasFromArgs
+                (ExpArgs.expArgs 0 exponent) }
+          stack := rest } := by
+  rw [runExpStack?_cons]
+  rw [ExpArgs.expResultFromArgs_zero_left_of_toNat_pos exponent h_pos]
+
 theorem runExpStack?_two_64
     (rest : List EvmWord) :
     runExpStack? { stack := (2 : EvmWord) :: 64 :: rest } =

--- a/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
+++ b/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
@@ -352,6 +352,22 @@ theorem runExpStack?_two_128
   rw [ExpGas.expDynamicCostFromExponent_of_pos_lt_256 (by decide) (by decide)]
   rw [ExpGas.expTotalGasFromExponent_of_pos_lt_256 (by decide) (by decide)]
 
+theorem runExpStack?_two_255
+    (rest : List EvmWord) :
+    runExpStack? { stack := (2 : EvmWord) :: 255 :: rest } =
+      some
+        { effects :=
+            { stackWords := [BitVec.ofNat 256 (2^255)]
+              dynamicGas := 50
+              totalGas := 60 }
+          stack := rest } := by
+  rw [runExpStack?_cons]
+  simp only [ExpArgs.expResultFromArgs, ExpArgs.expArgs,
+    ExpArgs.expDynamicCostFromArgs, ExpArgs.expTotalGasFromArgs]
+  rw [EvmWord.exp_two_255]
+  rw [ExpGas.expDynamicCostFromExponent_of_pos_lt_256 (by decide) (by decide)]
+  rw [ExpGas.expTotalGasFromExponent_of_pos_lt_256 (by decide) (by decide)]
+
 theorem runExpStack?_max_exponent_gas
     (base : EvmWord) (rest : List EvmWord) :
     (runExpStack? { stack := base :: (-1 : EvmWord) :: rest }).map

--- a/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
+++ b/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
@@ -341,6 +341,21 @@ theorem runExpStack?_one_left
   rw [runExpStack?_cons]
   rw [ExpArgs.expResultFromArgs_one_left]
 
+theorem runExpStack?_zero_left_of_ne_zero
+    (exponent : EvmWord) (h_ne : exponent ≠ 0)
+    (rest : List EvmWord) :
+    runExpStack? { stack := (0 : EvmWord) :: exponent :: rest } =
+      some
+        { effects :=
+            { stackWords := [0]
+              dynamicGas := ExpArgs.expDynamicCostFromArgs
+                (ExpArgs.expArgs 0 exponent)
+              totalGas := ExpArgs.expTotalGasFromArgs
+                (ExpArgs.expArgs 0 exponent) }
+          stack := rest } := by
+  rw [runExpStack?_cons]
+  rw [ExpArgs.expResultFromArgs_zero_left_of_ne_zero exponent h_ne]
+
 theorem runExpStack?_two_64
     (rest : List EvmWord) :
     runExpStack? { stack := (2 : EvmWord) :: 64 :: rest } =

--- a/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
+++ b/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
@@ -300,6 +300,14 @@ theorem runExpStack?_zero_exponent
   rw [ExpArgs.expDynamicCostFromArgs_zero_exponent]
   rw [ExpArgs.expTotalGasFromArgs_zero_exponent]
 
+theorem runExpStack?_zero_zero
+    (rest : List EvmWord) :
+    runExpStack? { stack := (0 : EvmWord) :: 0 :: rest } =
+      some
+        { effects := { stackWords := [1], dynamicGas := 0, totalGas := 10 }
+          stack := rest } := by
+  exact runExpStack?_zero_exponent 0 rest
+
 theorem runExpStack?_max_zero_exponent
     (rest : List EvmWord) :
     runExpStack? { stack := (-1 : EvmWord) :: 0 :: rest } =

--- a/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
+++ b/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
@@ -311,6 +311,14 @@ theorem runExpStack?_one_exponent
   rw [ExpArgs.expDynamicCostFromArgs_one_exponent]
   rw [ExpArgs.expTotalGasFromArgs_one_exponent]
 
+theorem runExpStack?_max_one_exponent
+    (rest : List EvmWord) :
+    runExpStack? { stack := (-1 : EvmWord) :: 1 :: rest } =
+      some
+        { effects := { stackWords := [(-1 : EvmWord)], dynamicGas := 50, totalGas := 60 }
+          stack := rest } := by
+  exact runExpStack?_one_exponent (-1 : EvmWord) rest
+
 theorem runExpStack?_one_left
     (exponent : EvmWord) (rest : List EvmWord) :
     runExpStack? { stack := (1 : EvmWord) :: exponent :: rest } =

--- a/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
+++ b/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
@@ -300,6 +300,14 @@ theorem runExpStack?_zero_exponent
   rw [ExpArgs.expDynamicCostFromArgs_zero_exponent]
   rw [ExpArgs.expTotalGasFromArgs_zero_exponent]
 
+theorem runExpStack?_max_zero_exponent
+    (rest : List EvmWord) :
+    runExpStack? { stack := (-1 : EvmWord) :: 0 :: rest } =
+      some
+        { effects := { stackWords := [1], dynamicGas := 0, totalGas := 10 }
+          stack := rest } := by
+  exact runExpStack?_zero_exponent (-1 : EvmWord) rest
+
 theorem runExpStack?_one_exponent
     (base : EvmWord) (rest : List EvmWord) :
     runExpStack? { stack := base :: 1 :: rest } =

--- a/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
+++ b/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
@@ -319,6 +319,14 @@ theorem runExpStack?_one_exponent
   rw [ExpArgs.expDynamicCostFromArgs_one_exponent]
   rw [ExpArgs.expTotalGasFromArgs_one_exponent]
 
+theorem runExpStack?_two_one
+    (rest : List EvmWord) :
+    runExpStack? { stack := (2 : EvmWord) :: 1 :: rest } =
+      some
+        { effects := { stackWords := [2], dynamicGas := 50, totalGas := 60 }
+          stack := rest } := by
+  exact runExpStack?_one_exponent 2 rest
+
 theorem runExpStack?_one_left
     (exponent : EvmWord) (rest : List EvmWord) :
     runExpStack? { stack := (1 : EvmWord) :: exponent :: rest } =

--- a/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
+++ b/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
@@ -325,6 +325,22 @@ theorem runExpStack?_one_left
   rw [runExpStack?_cons]
   rw [ExpArgs.expResultFromArgs_one_left]
 
+theorem runExpStack?_two_64
+    (rest : List EvmWord) :
+    runExpStack? { stack := (2 : EvmWord) :: 64 :: rest } =
+      some
+        { effects :=
+            { stackWords := [BitVec.ofNat 256 (2^64)]
+              dynamicGas := 50
+              totalGas := 60 }
+          stack := rest } := by
+  rw [runExpStack?_cons]
+  simp only [ExpArgs.expResultFromArgs, ExpArgs.expArgs,
+    ExpArgs.expDynamicCostFromArgs, ExpArgs.expTotalGasFromArgs]
+  rw [EvmWord.exp_two_64]
+  rw [ExpGas.expDynamicCostFromExponent_of_pos_lt_256 (by decide) (by decide)]
+  rw [ExpGas.expTotalGasFromExponent_of_pos_lt_256 (by decide) (by decide)]
+
 theorem runExpStack?_two_256
     (rest : List EvmWord) :
     runExpStack? { stack := (2 : EvmWord) :: 256 :: rest } =

--- a/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
+++ b/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
@@ -311,6 +311,14 @@ theorem runExpStack?_one_exponent
   rw [ExpArgs.expDynamicCostFromArgs_one_exponent]
   rw [ExpArgs.expTotalGasFromArgs_one_exponent]
 
+theorem runExpStack?_zero_one
+    (rest : List EvmWord) :
+    runExpStack? { stack := (0 : EvmWord) :: 1 :: rest } =
+      some
+        { effects := { stackWords := [0], dynamicGas := 50, totalGas := 60 }
+          stack := rest } := by
+  exact runExpStack?_one_exponent 0 rest
+
 theorem runExpStack?_one_left
     (exponent : EvmWord) (rest : List EvmWord) :
     runExpStack? { stack := (1 : EvmWord) :: exponent :: rest } =


### PR DESCRIPTION
## Summary
- merge origin/main into PR #3441's branch on a fresh fix branch
- update aggregate conformance counts from 50/40 to 51/41 after the merged vector set
- leave the original PR branch untouched per worker branch-boundary rules

Refs #125.
Refs #3441.
Bead: evm-asm-fjuzn.

## Verification
- scripts/check-file-size.sh
- rg -n "<<<<<<<|=======|>>>>>>>" EvmAsm/EL/Conformance/All.lean EvmAsm/EL/Conformance/StorageStackExecution.lean EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle/Scratch.lean EvmAsm/Evm64/Exp/SquaringPairThenMulCall.lean
- lake build EvmAsm.EL.Conformance.All
- lake build
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/EL/Conformance/All.lean EvmAsm/EL/Conformance/StorageStackExecution.lean EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle/Scratch.lean EvmAsm/Evm64/Exp/SquaringPairThenMulCall.lean