### PR TITLE
feat(exp): add two-to-128 word helper

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/Exp.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Exp.lean
@@ -106,6 +106,11 @@ theorem exp_two_64 : exp (2 : EvmWord) (64 : EvmWord) =
     BitVec.ofNat 256 (2^64) := by
   native_decide
 
+/-- The GH #92 mid-word boundary case `EXP(2, 128)`. -/
+theorem exp_two_128 : exp (2 : EvmWord) (128 : EvmWord) =
+    BitVec.ofNat 256 (2^128) := by
+  native_decide
+
 /-- The GH #92 pre-wrap boundary case `EXP(2, 255)` is the high bit. -/
 theorem exp_two_255 : exp (2 : EvmWord) (255 : EvmWord) =
     BitVec.ofNat 256 (2^255) := by


### PR DESCRIPTION
## Summary
- add EvmWord.exp_two_128 for the EXP(2,128) mid-word boundary case

Refs #92.
Bead: evm-asm-vx3q7.

## Verification
- lake build EvmAsm.Evm64.EvmWordArith.Exp
- scripts/check-file-size.sh
- lake build
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/EvmWordArith/Exp.lean