### PR TITLE
docs(exp): refresh addr norm attr header

### DIFF
--- a/EvmAsm/Evm64/Exp/AddrNormAttr.lean
+++ b/EvmAsm/Evm64/Exp/AddrNormAttr.lean
@@ -5,14 +5,13 @@
 
   Split out from `AddrNorm.lean` because Lean 4 does not allow an attribute
   to be used in the same file in which it is declared. Downstream code should
-  import `Exp/AddrNorm.lean` (which imports this file) — not this file directly.
-
-  Skeleton placeholder for GH #92 (EXP opcode). No tagged lemmas yet.
+  import `Exp/AddrNorm.lean` (which imports this file) rather than this file
+  directly; tagged EXP address lemmas live there.
 -/
 
 import Lean.Meta.Tactic.Simp.RegisterCommand
 
-/-- Simp set for EXP address arithmetic. Will collect atomic evaluations of
-    `signExtend12`, `<<<`, and `BitVec.toNat` on concrete literals that arise
+/-- Simp set for EXP address arithmetic: atomic evaluations of `signExtend12`,
+    `signExtend13`, shifts, and `BitVec.toNat` on concrete literals that arise
     in EXP composition proofs. -/
 register_simp_attr exp_addr


### PR DESCRIPTION
## Summary
- update Exp/AddrNormAttr.lean's stale skeleton wording now that tagged EXP address lemmas live in AddrNorm.lean
- mention signExtend13 coverage in the exp_addr attribute docstring

Refs #92.
Bead: evm-asm-41jmk.

## Verification
- lake build EvmAsm.Evm64.Exp.AddrNormAttr
- scripts/check-file-size.sh
- lake build
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/AddrNormAttr.lean