### PR TITLE
feat(exp): add args two-to-128 wrappers

### DIFF
--- a/EvmAsm/Evm64/Exp/Args.lean
+++ b/EvmAsm/Evm64/Exp/Args.lean
@@ -150,6 +150,10 @@ theorem expResultFromArgs_max_one_right :
     expResultFromArgs (expArgs (-1 : EvmWord) 1) = (-1 : EvmWord) := by
   exact expResultFromArgs_one_right (-1 : EvmWord)
 
+theorem expResultFromArgs_two_128 :
+    expResultFromArgs (expArgs 2 128) = BitVec.ofNat 256 (2^128) := by
+  exact EvmWord.exp_two_128
+
 theorem expResultFromArgs_two_256 :
     expResultFromArgs (expArgs 2 256) = 0 := by
   exact EvmWord.exp_two_256
@@ -199,6 +203,11 @@ theorem stackAfterExp_two_one (rest : List EvmWord) :
 theorem stackAfterExp_max_one_exponent (rest : List EvmWord) :
     stackAfterExp (expArgs (-1 : EvmWord) 1) rest = (-1 : EvmWord) :: rest := by
   rw [stackAfterExp, expResultFromArgs_max_one_right]
+
+theorem stackAfterExp_two_128 (rest : List EvmWord) :
+    stackAfterExp (expArgs 2 128) rest =
+      BitVec.ofNat 256 (2^128) :: rest := by
+  rw [stackAfterExp, expResultFromArgs_two_128]
 
 theorem stackAfterExp_two_256 (rest : List EvmWord) :
     stackAfterExp (expArgs 2 256) rest = 0 :: rest := by


### PR DESCRIPTION
## Summary
- add Args-level EXP(2,128) result wrapper
- add stackAfterExp wrapper for EXP(2,128)

Refs GH #92.
Refs beads evm-asm-m433h.

## Verification
- lake build EvmAsm.Evm64.Exp.Args
- scripts/check-file-size.sh
- lake build
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/Args.lean