### PR TITLE
feat(exp): add stack two-to-128 wrapper

### DIFF
--- a/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
+++ b/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
@@ -336,6 +336,22 @@ theorem runExpStack?_two_256
   rw [ExpArgs.expDynamicCostFromArgs_256_exponent]
   rw [ExpArgs.expTotalGasFromArgs_256_exponent]
 
+theorem runExpStack?_two_128
+    (rest : List EvmWord) :
+    runExpStack? { stack := (2 : EvmWord) :: 128 :: rest } =
+      some
+        { effects :=
+            { stackWords := [BitVec.ofNat 256 (2^128)]
+              dynamicGas := 50
+              totalGas := 60 }
+          stack := rest } := by
+  rw [runExpStack?_cons]
+  simp only [ExpArgs.expResultFromArgs, ExpArgs.expArgs,
+    ExpArgs.expDynamicCostFromArgs, ExpArgs.expTotalGasFromArgs]
+  rw [EvmWord.exp_two_128]
+  rw [ExpGas.expDynamicCostFromExponent_of_pos_lt_256 (by decide) (by decide)]
+  rw [ExpGas.expTotalGasFromExponent_of_pos_lt_256 (by decide) (by decide)]
+
 theorem runExpStack?_max_exponent_gas
     (base : EvmWord) (rest : List EvmWord) :
     (runExpStack? { stack := base :: (-1 : EvmWord) :: rest }).map


### PR DESCRIPTION
## Summary
- add runExpStack?_two_128 for the EXP stack execution bridge
- expose the EXP(2,128) result with one-byte EXP gas at stack level

Refs GH #92.
Refs beads evm-asm-1e920.

## Verification
- lake build EvmAsm.Evm64.Exp.StackExecutionBridge
- scripts/check-file-size.sh
- lake build
- rg -n sorry/admit/maxHeartbeats/maxRecDepth EvmAsm/Evm64/Exp/StackExecutionBridge.lean