### PR TITLE
feat(exp): add args two-to-64 wrappers

### DIFF
--- a/EvmAsm/Evm64/Exp/Args.lean
+++ b/EvmAsm/Evm64/Exp/Args.lean
@@ -150,6 +150,10 @@ theorem expResultFromArgs_max_one_right :
     expResultFromArgs (expArgs (-1 : EvmWord) 1) = (-1 : EvmWord) := by
   exact expResultFromArgs_one_right (-1 : EvmWord)
 
+theorem expResultFromArgs_two_64 :
+    expResultFromArgs (expArgs 2 64) = BitVec.ofNat 256 (2^64) := by
+  exact EvmWord.exp_two_64
+
 theorem expResultFromArgs_two_128 :
     expResultFromArgs (expArgs 2 128) = BitVec.ofNat 256 (2^128) := by
   exact EvmWord.exp_two_128
@@ -203,6 +207,11 @@ theorem stackAfterExp_two_one (rest : List EvmWord) :
 theorem stackAfterExp_max_one_exponent (rest : List EvmWord) :
     stackAfterExp (expArgs (-1 : EvmWord) 1) rest = (-1 : EvmWord) :: rest := by
   rw [stackAfterExp, expResultFromArgs_max_one_right]
+
+theorem stackAfterExp_two_64 (rest : List EvmWord) :
+    stackAfterExp (expArgs 2 64) rest =
+      BitVec.ofNat 256 (2^64) :: rest := by
+  rw [stackAfterExp, expResultFromArgs_two_64]
 
 theorem stackAfterExp_two_128 (rest : List EvmWord) :
     stackAfterExp (expArgs 2 128) rest =


### PR DESCRIPTION
## Summary
- add expResultFromArgs_two_64 for the EXP Args layer
- add stackAfterExp_two_64 for the matching stack result shape

Refs GH #92.
Refs beads evm-asm-i49ot.

## Verification
- lake build EvmAsm.Evm64.Exp.Args
- scripts/check-file-size.sh
- lake build
- rg -n sorry/admit/maxHeartbeats/maxRecDepth EvmAsm/Evm64/Exp/Args.lean