### PR TITLE
feat(exp): add stack two-to-64 wrapper

### DIFF
--- a/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
+++ b/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
@@ -325,6 +325,22 @@ theorem runExpStack?_one_left
   rw [runExpStack?_cons]
   rw [ExpArgs.expResultFromArgs_one_left]
 
+theorem runExpStack?_two_64
+    (rest : List EvmWord) :
+    runExpStack? { stack := (2 : EvmWord) :: 64 :: rest } =
+      some
+        { effects :=
+            { stackWords := [BitVec.ofNat 256 (2^64)]
+              dynamicGas := 50
+              totalGas := 60 }
+          stack := rest } := by
+  rw [runExpStack?_cons]
+  simp only [ExpArgs.expResultFromArgs, ExpArgs.expArgs,
+    ExpArgs.expDynamicCostFromArgs, ExpArgs.expTotalGasFromArgs]
+  rw [EvmWord.exp_two_64]
+  rw [ExpGas.expDynamicCostFromExponent_of_pos_lt_256 (by decide) (by decide)]
+  rw [ExpGas.expTotalGasFromExponent_of_pos_lt_256 (by decide) (by decide)]
+
 theorem runExpStack?_two_256
     (rest : List EvmWord) :
     runExpStack? { stack := (2 : EvmWord) :: 256 :: rest } =


### PR DESCRIPTION
## Summary
- add runExpStack?_two_64 for the EXP stack execution bridge
- expose the EXP(2,64) result with one-byte EXP gas at stack level

Refs GH #92.
Refs beads evm-asm-le0ca.

## Verification
- lake build EvmAsm.Evm64.Exp.StackExecutionBridge
- scripts/check-file-size.sh
- lake build
- rg -n sorry/admit/maxHeartbeats/maxRecDepth EvmAsm/Evm64/Exp/StackExecutionBridge.lean