### PR TITLE
feat(exp): add args two-to-255 wrappers

### DIFF
--- a/EvmAsm/Evm64/Exp/Args.lean
+++ b/EvmAsm/Evm64/Exp/Args.lean
@@ -154,6 +154,10 @@ theorem expResultFromArgs_two_128 :
     expResultFromArgs (expArgs 2 128) = BitVec.ofNat 256 (2^128) := by
   exact EvmWord.exp_two_128
 
+theorem expResultFromArgs_two_255 :
+    expResultFromArgs (expArgs 2 255) = BitVec.ofNat 256 (2^255) := by
+  exact EvmWord.exp_two_255
+
 theorem expResultFromArgs_two_256 :
     expResultFromArgs (expArgs 2 256) = 0 := by
   exact EvmWord.exp_two_256
@@ -208,6 +212,11 @@ theorem stackAfterExp_two_128 (rest : List EvmWord) :
     stackAfterExp (expArgs 2 128) rest =
       BitVec.ofNat 256 (2^128) :: rest := by
   rw [stackAfterExp, expResultFromArgs_two_128]
+
+theorem stackAfterExp_two_255 (rest : List EvmWord) :
+    stackAfterExp (expArgs 2 255) rest =
+      BitVec.ofNat 256 (2^255) :: rest := by
+  rw [stackAfterExp, expResultFromArgs_two_255]
 
 theorem stackAfterExp_two_256 (rest : List EvmWord) :
     stackAfterExp (expArgs 2 256) rest = 0 :: rest := by


### PR DESCRIPTION
## Summary
- add expResultFromArgs_two_255 for the EXP Args layer
- add stackAfterExp_two_255 for the matching pre-wrap stack result shape

Refs GH #92.
Refs beads evm-asm-ejk5q.

## Verification
- lake build EvmAsm.Evm64.Exp.Args
- scripts/check-file-size.sh
- lake build
- rg -n sorry/admit/maxHeartbeats/maxRecDepth EvmAsm/Evm64/Exp/Args.lean