### PR TITLE
feat(exp): add stack two-to-255 wrapper

### DIFF
--- a/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
+++ b/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
@@ -352,6 +352,22 @@ theorem runExpStack?_two_128
   rw [ExpGas.expDynamicCostFromExponent_of_pos_lt_256 (by decide) (by decide)]
   rw [ExpGas.expTotalGasFromExponent_of_pos_lt_256 (by decide) (by decide)]
 
+theorem runExpStack?_two_255
+    (rest : List EvmWord) :
+    runExpStack? { stack := (2 : EvmWord) :: 255 :: rest } =
+      some
+        { effects :=
+            { stackWords := [BitVec.ofNat 256 (2^255)]
+              dynamicGas := 50
+              totalGas := 60 }
+          stack := rest } := by
+  rw [runExpStack?_cons]
+  simp only [ExpArgs.expResultFromArgs, ExpArgs.expArgs,
+    ExpArgs.expDynamicCostFromArgs, ExpArgs.expTotalGasFromArgs]
+  rw [EvmWord.exp_two_255]
+  rw [ExpGas.expDynamicCostFromExponent_of_pos_lt_256 (by decide) (by decide)]
+  rw [ExpGas.expTotalGasFromExponent_of_pos_lt_256 (by decide) (by decide)]
+
 theorem runExpStack?_max_exponent_gas
     (base : EvmWord) (rest : List EvmWord) :
     (runExpStack? { stack := base :: (-1 : EvmWord) :: rest }).map


### PR DESCRIPTION
## Summary
- add runExpStack?_two_255 for the EXP stack execution bridge
- expose the EXP(2,255) high-bit result with one-byte EXP gas at stack level

Refs GH #92.
Refs beads evm-asm-r4goa.

## Verification
- lake build EvmAsm.Evm64.Exp.StackExecutionBridge
- scripts/check-file-size.sh
- lake build
- rg -n sorry/admit/maxHeartbeats/maxRecDepth EvmAsm/Evm64/Exp/StackExecutionBridge.lean