### PR TITLE
feat(exp): add max-zero stack wrapper

### DIFF
--- a/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
+++ b/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
@@ -300,6 +300,14 @@ theorem runExpStack?_zero_exponent
   rw [ExpArgs.expDynamicCostFromArgs_zero_exponent]
   rw [ExpArgs.expTotalGasFromArgs_zero_exponent]
 
+theorem runExpStack?_max_zero_exponent
+    (rest : List EvmWord) :
+    runExpStack? { stack := (-1 : EvmWord) :: 0 :: rest } =
+      some
+        { effects := { stackWords := [1], dynamicGas := 0, totalGas := 10 }
+          stack := rest } := by
+  exact runExpStack?_zero_exponent (-1 : EvmWord) rest
+
 theorem runExpStack?_one_exponent
     (base : EvmWord) (rest : List EvmWord) :
     runExpStack? { stack := base :: 1 :: rest } =


### PR DESCRIPTION
Summary:
- add runExpStack?_max_zero_exponent as a named EXP stack bridge edge case
- specialize the existing zero-exponent bridge for max base

Refs GH #92
Bead: evm-asm-jahje

Verification:
- lake build EvmAsm.Evm64.Exp.StackExecutionBridge
- scripts/check-file-size.sh
- lake build