### PR TITLE
feat(exp): add max-one stack wrapper

### DIFF
--- a/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
+++ b/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
@@ -311,6 +311,14 @@ theorem runExpStack?_one_exponent
   rw [ExpArgs.expDynamicCostFromArgs_one_exponent]
   rw [ExpArgs.expTotalGasFromArgs_one_exponent]
 
+theorem runExpStack?_max_one_exponent
+    (rest : List EvmWord) :
+    runExpStack? { stack := (-1 : EvmWord) :: 1 :: rest } =
+      some
+        { effects := { stackWords := [(-1 : EvmWord)], dynamicGas := 50, totalGas := 60 }
+          stack := rest } := by
+  exact runExpStack?_one_exponent (-1 : EvmWord) rest
+
 theorem runExpStack?_one_left
     (exponent : EvmWord) (rest : List EvmWord) :
     runExpStack? { stack := (1 : EvmWord) :: exponent :: rest } =


### PR DESCRIPTION
Summary:
- add runExpStack?_max_one_exponent as a named EXP stack bridge edge case
- specialize the existing one-exponent bridge for max base

Refs GH #92
Bead: evm-asm-208tj

Verification:
- lake build EvmAsm.Evm64.Exp.StackExecutionBridge
- scripts/check-file-size.sh
- lake build