### PR TITLE
feat(exp): add two-one stack wrapper

### DIFF
--- a/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
+++ b/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
@@ -319,6 +319,14 @@ theorem runExpStack?_one_exponent
   rw [ExpArgs.expDynamicCostFromArgs_one_exponent]
   rw [ExpArgs.expTotalGasFromArgs_one_exponent]
 
+theorem runExpStack?_two_one
+    (rest : List EvmWord) :
+    runExpStack? { stack := (2 : EvmWord) :: 1 :: rest } =
+      some
+        { effects := { stackWords := [2], dynamicGas := 50, totalGas := 60 }
+          stack := rest } := by
+  exact runExpStack?_one_exponent 2 rest
+
 theorem runExpStack?_one_left
     (exponent : EvmWord) (rest : List EvmWord) :
     runExpStack? { stack := (1 : EvmWord) :: exponent :: rest } =


### PR DESCRIPTION
Summary:
- add runExpStack?_two_one as a named EXP stack bridge edge case
- specialize the existing one-exponent bridge for base two

Refs GH #92
Bead: evm-asm-dwhl1

Verification:
- lake build EvmAsm.Evm64.Exp.StackExecutionBridge
- scripts/check-file-size.sh
- lake build