### PR TITLE
fix(exp): refresh zero-one stack wrapper branch

### DIFF
--- a/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
+++ b/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
@@ -300,6 +300,14 @@ theorem runExpStack?_zero_exponent
   rw [ExpArgs.expDynamicCostFromArgs_zero_exponent]
   rw [ExpArgs.expTotalGasFromArgs_zero_exponent]
 
+theorem runExpStack?_max_zero_exponent
+    (rest : List EvmWord) :
+    runExpStack? { stack := (-1 : EvmWord) :: 0 :: rest } =
+      some
+        { effects := { stackWords := [1], dynamicGas := 0, totalGas := 10 }
+          stack := rest } := by
+  exact runExpStack?_zero_exponent (-1 : EvmWord) rest
+
 theorem runExpStack?_one_exponent
     (base : EvmWord) (rest : List EvmWord) :
     runExpStack? { stack := base :: 1 :: rest } =
@@ -318,6 +326,14 @@ theorem runExpStack?_zero_one
         { effects := { stackWords := [0], dynamicGas := 50, totalGas := 60 }
           stack := rest } := by
   exact runExpStack?_one_exponent 0 rest
+
+theorem runExpStack?_max_one_exponent
+    (rest : List EvmWord) :
+    runExpStack? { stack := (-1 : EvmWord) :: 1 :: rest } =
+      some
+        { effects := { stackWords := [(-1 : EvmWord)], dynamicGas := 50, totalGas := 60 }
+          stack := rest } := by
+  exact runExpStack?_one_exponent (-1 : EvmWord) rest
 
 theorem runExpStack?_one_left
     (exponent : EvmWord) (rest : List EvmWord) :


### PR DESCRIPTION
Summary:
- merge origin/main into a fresh helper branch for PR #3549
- resolve the EXP stack bridge conflict by keeping both zero-one and max-one wrappers

Refs GH #92
Bead: evm-asm-4up2l
Unblocks PR #3549

Verification:
- lake build EvmAsm.Evm64.Exp.StackExecutionBridge
- scripts/check-file-size.sh
- lake build