### PR TITLE
fix(exp): refresh two-one stack wrapper branch

### DIFF
--- a/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
+++ b/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
@@ -311,6 +311,14 @@ theorem runExpStack?_one_exponent
   rw [ExpArgs.expDynamicCostFromArgs_one_exponent]
   rw [ExpArgs.expTotalGasFromArgs_one_exponent]
 
+theorem runExpStack?_max_one_exponent
+    (rest : List EvmWord) :
+    runExpStack? { stack := (-1 : EvmWord) :: 1 :: rest } =
+      some
+        { effects := { stackWords := [(-1 : EvmWord)], dynamicGas := 50, totalGas := 60 }
+          stack := rest } := by
+  exact runExpStack?_one_exponent (-1 : EvmWord) rest
+
 theorem runExpStack?_one_left
     (exponent : EvmWord) (rest : List EvmWord) :
     runExpStack? { stack := (1 : EvmWord) :: exponent :: rest } =


### PR DESCRIPTION
Summary:
- merge origin/main into a fresh helper branch for PR #3550
- resolve the EXP stack bridge conflict by keeping both two-one and max-one wrappers

Refs GH #92
Bead: evm-asm-bq5g9
Unblocks PR #3550

Verification:
- lake build EvmAsm.Evm64.Exp.StackExecutionBridge
- scripts/check-file-size.sh
- lake build