### PR TITLE
feat(exp): add zero-zero stack bridge

### DIFF
--- a/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
+++ b/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
@@ -300,6 +300,14 @@ theorem runExpStack?_zero_exponent
   rw [ExpArgs.expDynamicCostFromArgs_zero_exponent]
   rw [ExpArgs.expTotalGasFromArgs_zero_exponent]
 
+theorem runExpStack?_zero_zero
+    (rest : List EvmWord) :
+    runExpStack? { stack := (0 : EvmWord) :: 0 :: rest } =
+      some
+        { effects := { stackWords := [1], dynamicGas := 0, totalGas := 10 }
+          stack := rest } := by
+  exact runExpStack?_zero_exponent 0 rest
+
 theorem runExpStack?_max_zero_exponent
     (rest : List EvmWord) :
     runExpStack? { stack := (-1 : EvmWord) :: 0 :: rest } =


### PR DESCRIPTION
Summary:
- add StackExecutionBridge.runExpStack?_zero_zero as a named EXP stack edge case
- specialize the existing zero-exponent bridge for base zero

Refs GH #92
Bead: evm-asm-yh9q8

Verification:
- lake build EvmAsm.Evm64.Exp.StackExecutionBridge
- scripts/check-file-size.sh
- lake build