### PR TITLE
fix(exp): refresh two-one stack wrapper branch again

### DIFF
--- a/EvmAsm/EL/Conformance/All.lean
+++ b/EvmAsm/EL/Conformance/All.lean
@@ -44,11 +44,11 @@ def allConformanceVectorCount : Nat :=
   allConformanceVectors.length
 
 theorem allConformanceVectors_length :
-    allConformanceVectors.length = 51 := by
+    allConformanceVectors.length = 52 := by
   native_decide
 
 theorem allConformanceVectorCount_eq :
-    allConformanceVectorCount = 51 := by
+    allConformanceVectorCount = 52 := by
   native_decide
 
 def unexpectedConformanceFailures : List CheckResult :=
@@ -115,7 +115,7 @@ theorem expectedConformanceErrorCount_eq :
   native_decide
 
 theorem successfulConformanceResultCount_eq :
-    successfulConformanceResultCount = 41 := by
+    successfulConformanceResultCount = 42 := by
   native_decide
 
 end Conformance

--- a/EvmAsm/EL/Conformance/ExpStackExecution.lean
+++ b/EvmAsm/EL/Conformance/ExpStackExecution.lean
@@ -65,6 +65,17 @@ def expStackOneExponentVector : TestVector ExpStackState ExpStackResult :=
               totalGas := 60 }
           stack := [99] } }
 
+def expStackTwo64Vector : TestVector ExpStackState ExpStackResult :=
+  { id := "exp-stack-two-64"
+    input := { stack := [2, 64, 99] }
+    expected :=
+      .value
+        { effects :=
+            { stackWords := [BitVec.ofNat 256 (2^64)]
+              dynamicGas := 50
+              totalGas := 60 }
+          stack := [99] } }
+
 def expStackUnderflowVector : TestVector ExpStackState ExpStackResult :=
   { id := "exp-stack-underflow"
     input := { stack := [2] }
@@ -77,6 +88,7 @@ def expStackConformanceTestVectors : List (TestVector ExpStackState ExpStackResu
   [ expStackValueVector
   , expStackZeroZeroVector
   , expStackOneExponentVector
+  , expStackTwo64Vector
   , expStackUnderflowVector
   ]
 
@@ -84,25 +96,30 @@ def expStackConformanceVectorIds : List String :=
   expStackConformanceTestVectors.map TestVector.id
 
 theorem expStackConformanceTestVectors_length :
-    expStackConformanceTestVectors.length = 4 := rfl
+    expStackConformanceTestVectors.length = 5 := rfl
 
 theorem expStackConformanceVectorIds_eq :
     expStackConformanceVectorIds =
       [ "exp-stack-value"
       , "exp-stack-zero-zero"
       , "exp-stack-one-exponent"
+      , "exp-stack-two-64"
       , "exp-stack-underflow"
       ] := rfl
 
 theorem expStackConformanceVectorIds_length :
-    expStackConformanceVectorIds.length = 4 := rfl
+    expStackConformanceVectorIds.length = 5 := rfl
 
 theorem expStackConformanceVectorIds_nodup :
     expStackConformanceVectorIds.Nodup := by
   decide
 
 def expStackValueVectorIds : List String :=
-  ["exp-stack-value", "exp-stack-zero-zero", "exp-stack-one-exponent"]
+  [ "exp-stack-value"
+  , "exp-stack-zero-zero"
+  , "exp-stack-one-exponent"
+  , "exp-stack-two-64"
+  ]
 
 def expStackErrorVectorIds : List String :=
   ["exp-stack-underflow"]
@@ -149,6 +166,16 @@ theorem runExpStack?_one_exponent :
           stack := [(99 : EvmWord)] } := by
   native_decide
 
+theorem runExpStack?_two_64 :
+    runExpStack? { stack := [(2 : EvmWord), (64 : EvmWord), (99 : EvmWord)] } =
+      some
+        { effects :=
+            { stackWords := [BitVec.ofNat 256 (2^64)]
+              dynamicGas := 50
+              totalGas := 60 }
+          stack := [(99 : EvmWord)] } := by
+  native_decide
+
 theorem runExpStack?_underflow :
     runExpStack? { stack := [(2 : EvmWord)] } = none := rfl
 
@@ -188,6 +215,18 @@ theorem expStackOneExponentVector_passed :
       stack := [(99 : EvmWord)] }
     runExpStack?_one_exponent
 
+theorem expStackTwo64Vector_passed :
+    checkVector? runExpStack? expStackTwo64Vector = .passed :=
+  checkVector?_some_passed runExpStack?
+    "exp-stack-two-64"
+    { stack := [(2 : EvmWord), (64 : EvmWord), (99 : EvmWord)] }
+    { effects :=
+        { stackWords := [BitVec.ofNat 256 (2^64)]
+          dynamicGas := 50
+          totalGas := 60 }
+      stack := [(99 : EvmWord)] }
+    runExpStack?_two_64
+
 theorem expStackUnderflowVector_passed :
     checkVector? runExpStack? expStackUnderflowVector =
       .errored "exp-stack-underflow" "stack-underflow" :=
@@ -204,10 +243,16 @@ def expStackConformanceVectors : List CheckResult :=
 
 theorem expStackConformanceVectors_passed :
     expStackConformanceVectors =
-      [.passed, .passed, .passed, .errored "exp-stack-underflow" "stack-underflow"] := by
+      [ .passed
+      , .passed
+      , .passed
+      , .passed
+      , .errored "exp-stack-underflow" "stack-underflow"
+      ] := by
   simp [expStackConformanceVectors, expStackConformanceTestVectors,
     expStackValueVector_passed, expStackZeroZeroVector_passed,
-    expStackOneExponentVector_passed, expStackUnderflowVector_passed]
+    expStackOneExponentVector_passed, expStackTwo64Vector_passed,
+    expStackUnderflowVector_passed]
 
 end ExpStackExecution
 end Conformance

--- a/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
+++ b/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
@@ -341,6 +341,21 @@ theorem runExpStack?_one_left
   rw [runExpStack?_cons]
   rw [ExpArgs.expResultFromArgs_one_left]
 
+theorem runExpStack?_zero_left_of_toNat_pos
+    (exponent : EvmWord) (h_pos : 0 < exponent.toNat)
+    (rest : List EvmWord) :
+    runExpStack? { stack := (0 : EvmWord) :: exponent :: rest } =
+      some
+        { effects :=
+            { stackWords := [0]
+              dynamicGas := ExpArgs.expDynamicCostFromArgs
+                (ExpArgs.expArgs 0 exponent)
+              totalGas := ExpArgs.expTotalGasFromArgs
+                (ExpArgs.expArgs 0 exponent) }
+          stack := rest } := by
+  rw [runExpStack?_cons]
+  rw [ExpArgs.expResultFromArgs_zero_left_of_toNat_pos exponent h_pos]
+
 theorem runExpStack?_two_64
     (rest : List EvmWord) :
     runExpStack? { stack := (2 : EvmWord) :: 64 :: rest } =

--- a/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
+++ b/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
@@ -300,6 +300,14 @@ theorem runExpStack?_zero_exponent
   rw [ExpArgs.expDynamicCostFromArgs_zero_exponent]
   rw [ExpArgs.expTotalGasFromArgs_zero_exponent]
 
+theorem runExpStack?_zero_zero
+    (rest : List EvmWord) :
+    runExpStack? { stack := (0 : EvmWord) :: 0 :: rest } =
+      some
+        { effects := { stackWords := [1], dynamicGas := 0, totalGas := 10 }
+          stack := rest } := by
+  exact runExpStack?_zero_exponent 0 rest
+
 theorem runExpStack?_max_zero_exponent
     (rest : List EvmWord) :
     runExpStack? { stack := (-1 : EvmWord) :: 0 :: rest } =

--- a/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
+++ b/EvmAsm/Evm64/Exp/StackExecutionBridge.lean
@@ -311,6 +311,14 @@ theorem runExpStack?_one_exponent
   rw [ExpArgs.expDynamicCostFromArgs_one_exponent]
   rw [ExpArgs.expTotalGasFromArgs_one_exponent]
 
+theorem runExpStack?_zero_one
+    (rest : List EvmWord) :
+    runExpStack? { stack := (0 : EvmWord) :: 1 :: rest } =
+      some
+        { effects := { stackWords := [0], dynamicGas := 50, totalGas := 60 }
+          stack := rest } := by
+  exact runExpStack?_one_exponent 0 rest
+
 theorem runExpStack?_one_left
     (exponent : EvmWord) (rest : List EvmWord) :
     runExpStack? { stack := (1 : EvmWord) :: exponent :: rest } =


### PR DESCRIPTION
Refs GH #92.\n\nBead: evm-asm-bq5g9.\n\nThis refreshes PR #3550 by merging origin/main into a fresh repair branch after the previous repair landed but #3550 remained conflicting. The conflict in EvmAsm/Evm64/Exp/StackExecutionBridge.lean is resolved by keeping both runExpStack?_two_one and runExpStack?_zero_one.\n\nVerification:\n- lake build EvmAsm.Evm64.Exp.StackExecutionBridge\n- scripts/check-file-size.sh\n- lake build