### PR TITLE
feat(exp): add zero-one stack conformance

### DIFF
--- a/EvmAsm/EL/Conformance/All.lean
+++ b/EvmAsm/EL/Conformance/All.lean
@@ -44,11 +44,11 @@ def allConformanceVectorCount : Nat :=
   allConformanceVectors.length
 
 theorem allConformanceVectors_length :
-    allConformanceVectors.length = 52 := by
+    allConformanceVectors.length = 53 := by
   native_decide
 
 theorem allConformanceVectorCount_eq :
-    allConformanceVectorCount = 52 := by
+    allConformanceVectorCount = 53 := by
   native_decide
 
 def unexpectedConformanceFailures : List CheckResult :=
@@ -115,7 +115,7 @@ theorem expectedConformanceErrorCount_eq :
   native_decide
 
 theorem successfulConformanceResultCount_eq :
-    successfulConformanceResultCount = 42 := by
+    successfulConformanceResultCount = 43 := by
   native_decide
 
 end Conformance

--- a/EvmAsm/EL/Conformance/ExpStackExecution.lean
+++ b/EvmAsm/EL/Conformance/ExpStackExecution.lean
@@ -65,6 +65,17 @@ def expStackOneExponentVector : TestVector ExpStackState ExpStackResult :=
               totalGas := 60 }
           stack := [99] } }
 
+def expStackZeroOneVector : TestVector ExpStackState ExpStackResult :=
+  { id := "exp-stack-zero-one"
+    input := { stack := [0, 1, 99] }
+    expected :=
+      .value
+        { effects :=
+            { stackWords := [0]
+              dynamicGas := 50
+              totalGas := 60 }
+          stack := [99] } }
+
 def expStackTwo64Vector : TestVector ExpStackState ExpStackResult :=
   { id := "exp-stack-two-64"
     input := { stack := [2, 64, 99] }
@@ -88,6 +99,7 @@ def expStackConformanceTestVectors : List (TestVector ExpStackState ExpStackResu
   [ expStackValueVector
   , expStackZeroZeroVector
   , expStackOneExponentVector
+  , expStackZeroOneVector
   , expStackTwo64Vector
   , expStackUnderflowVector
   ]
@@ -96,19 +108,20 @@ def expStackConformanceVectorIds : List String :=
   expStackConformanceTestVectors.map TestVector.id
 
 theorem expStackConformanceTestVectors_length :
-    expStackConformanceTestVectors.length = 5 := rfl
+    expStackConformanceTestVectors.length = 6 := rfl
 
 theorem expStackConformanceVectorIds_eq :
     expStackConformanceVectorIds =
       [ "exp-stack-value"
       , "exp-stack-zero-zero"
       , "exp-stack-one-exponent"
+      , "exp-stack-zero-one"
       , "exp-stack-two-64"
       , "exp-stack-underflow"
       ] := rfl
 
 theorem expStackConformanceVectorIds_length :
-    expStackConformanceVectorIds.length = 5 := rfl
+    expStackConformanceVectorIds.length = 6 := rfl
 
 theorem expStackConformanceVectorIds_nodup :
     expStackConformanceVectorIds.Nodup := by
@@ -118,6 +131,7 @@ def expStackValueVectorIds : List String :=
   [ "exp-stack-value"
   , "exp-stack-zero-zero"
   , "exp-stack-one-exponent"
+  , "exp-stack-zero-one"
   , "exp-stack-two-64"
   ]
 
@@ -165,6 +179,17 @@ theorem runExpStack?_one_exponent :
               totalGas := 60 }
           stack := [(99 : EvmWord)] } := by
   native_decide
+
+theorem runExpStack?_zero_one :
+    runExpStack? { stack := [(0 : EvmWord), (1 : EvmWord), (99 : EvmWord)] } =
+      some
+        { effects :=
+            { stackWords := [(0 : EvmWord)]
+              dynamicGas := 50
+              totalGas := 60 }
+          stack := [(99 : EvmWord)] } := by
+  exact EvmAsm.Evm64.ExpStackExecutionBridge.runExpStack?_zero_one
+    [(99 : EvmWord)]
 
 theorem runExpStack?_two_64 :
     runExpStack? { stack := [(2 : EvmWord), (64 : EvmWord), (99 : EvmWord)] } =
@@ -215,6 +240,18 @@ theorem expStackOneExponentVector_passed :
       stack := [(99 : EvmWord)] }
     runExpStack?_one_exponent
 
+theorem expStackZeroOneVector_passed :
+    checkVector? runExpStack? expStackZeroOneVector = .passed :=
+  checkVector?_some_passed runExpStack?
+    "exp-stack-zero-one"
+    { stack := [(0 : EvmWord), (1 : EvmWord), (99 : EvmWord)] }
+    { effects :=
+        { stackWords := [(0 : EvmWord)]
+          dynamicGas := 50
+          totalGas := 60 }
+      stack := [(99 : EvmWord)] }
+    runExpStack?_zero_one
+
 theorem expStackTwo64Vector_passed :
     checkVector? runExpStack? expStackTwo64Vector = .passed :=
   checkVector?_some_passed runExpStack?
@@ -247,12 +284,13 @@ theorem expStackConformanceVectors_passed :
       , .passed
       , .passed
       , .passed
+      , .passed
       , .errored "exp-stack-underflow" "stack-underflow"
       ] := by
   simp [expStackConformanceVectors, expStackConformanceTestVectors,
     expStackValueVector_passed, expStackZeroZeroVector_passed,
-    expStackOneExponentVector_passed, expStackTwo64Vector_passed,
-    expStackUnderflowVector_passed]
+    expStackOneExponentVector_passed, expStackZeroOneVector_passed,
+    expStackTwo64Vector_passed, expStackUnderflowVector_passed]
 
 end ExpStackExecution
 end Conformance


### PR DESCRIPTION
Refs GH #92 and GH #125.\n\nBead: evm-asm-ytnfz.\n\nAdds a Lean-side EXP stack conformance vector for EXP(0, 1), reusing the landed runExpStack?_zero_one stack bridge and updating the aggregate conformance counts.\n\nVerification:\n- lake build EvmAsm.EL.Conformance.ExpStackExecution\n- lake build EvmAsm.EL.Conformance.All\n- scripts/check-file-size.sh\n- lake build