### PR TITLE
docs(AGENTS): add bead closure rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,6 +157,46 @@ Pitfalls:
   `fix(shr): address canonicalization in sign-fill path`). The PR summary bot
   flags titles that don't match this format.
 
+## Bead closure rules (`bd close`)
+
+The beads tracker is the source of truth for outstanding work. Closing a bead
+incorrectly hides unfinished obligations and bumping its priority later does
+nothing because the bead is no longer in the queue. Before running
+`bd close <id>`, satisfy **all** of the following:
+
+1. **The named deliverable must exist on `origin/main`.** If the bead title
+   says "prove `foo_spec_within`", "define `evm_foo`", or "lift X to Y", that
+   exact declaration has to be present on `origin/main` — not on a feature
+   branch, not in an unmerged stacked PR. Verify with:
+   `git fetch origin && git grep -n '<decl name>' origin/main -- '<expected path>'`.
+   If the grep is empty, **do not close the bead**.
+
+2. **A "related" PR merging is not the same as the deliverable shipping.** A
+   PR titled similarly, or that adds scaffolding, wrappers, or preparation
+   lemmas around the deliverable, does not satisfy the bead. If the named
+   theorem is still a `placeholder`, `sorry`, or absent, the bead stays open.
+
+3. **Stacked PRs into feature branches don't count.** A PR merged into
+   `feat/foo` instead of `main` has not landed. Wait for the bottom of the
+   stack to merge into `main`, then verify per (1) before closing the
+   dependent beads.
+
+4. **`close_reason` must be truthful.** `"shipped in PR #N"` is only valid
+   when PR #N's merge commit is an ancestor of `origin/main` *and* the named
+   deliverable is grep-visible there. Otherwise use
+   `"superseded by <bead-id>"` or `"duplicate of <bead-id>"`. Never close as
+   "shipped" against a PR that merged into a feature branch.
+
+5. **If you finished real work but the named theorem isn't done yet**,
+   prefer adding a `bd comment` with status, or filing a follow-up bead, or
+   updating the existing bead's description — instead of closing the wrong
+   thing.
+
+Recent violations to learn from: `evm-asm-01uh` (SDIV), `evm-asm-6snn` and
+`evm-asm-w5mk` (EXP) — all closed as "shipped in PR #…" while the named
+theorem was still a placeholder on `main` (and in the EXP cases the PR was
+merged into a feature branch, not `main`). All three had to be reopened.
+
 ## References
 
 - **Accelerator C ABI (source of truth)**:


### PR DESCRIPTION
Adds a 'Bead closure rules' section to AGENTS.md (CLAUDE.md inherits via pointer) so agents stop closing beads as 'shipped in PR #…' when the named deliverable isn't on main.

## Why

Audit of recent Codex-assigned P1 beads found 3 closures where the named theorem was still a placeholder on main:

- `evm-asm-01uh` — SDIV slice 4. Closed via PR #3333 (merged to main), but `EvmAsm/Evm64/SDiv/Spec.lean` still contains only a placeholder; `evm_sdiv_stack_spec_within` is not defined anywhere in the SDiv subtree on main.
- `evm-asm-6snn` — EXP slice 6 semantic stack-spec. Closed via PR #3450, but #3450 merged into a feature branch (`feat/exp-squaring-mul-call-top-specs`), not main; `Exp/Semantic.lean` does not exist on main.
- `evm-asm-w5mk` — EXP slice 5 full-loop composition. Closed via PR #3425, also into a feature branch chain, and the PR title was unrelated to the bead's deliverable; no full-loop theorem exists on main.

All three have been reopened.

## Rules added

1. Named deliverable must be grep-visible on `origin/main` before close.
2. "Related" PRs merging doesn't satisfy the bead.
3. PRs merged into feature branches don't count.
4. `close_reason` must be truthful — only use "shipped in PR #N" when that PR's merge commit is an ancestor of main.
5. Prefer `bd comment` / follow-up beads over wrong closures.

Co-Authored-By: Hermes-bot <hermes@flamingoponderado.com>