### PR TITLE
feat(sdiv): add negative positive stack bridge case

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/SDiv.lean
+++ b/EvmAsm/Evm64/EvmWordArith/SDiv.lean
@@ -68,6 +68,9 @@ theorem sdiv_neg_one_two : sdiv (-1 : EvmWord) 2 = 0 := by
 theorem sdiv_pos_neg_trunc : sdiv (7 : EvmWord) (-2) = (-3 : EvmWord) := by
   native_decide
 
+theorem sdiv_neg_pos_trunc : sdiv (-7 : EvmWord) 2 = (-3 : EvmWord) := by
+  native_decide
+
 -- ============================================================================
 -- Correctness vs `Int.tdiv` (the spec formula)
 -- ============================================================================

--- a/EvmAsm/Evm64/SDiv/Args.lean
+++ b/EvmAsm/Evm64/SDiv/Args.lean
@@ -74,5 +74,9 @@ theorem sdivResultFromArgs_pos_neg_trunc :
     sdivResultFromArgs (sdivArgs 7 (-2)) = (-3 : EvmWord) := by
   exact EvmWord.sdiv_pos_neg_trunc
 
+theorem sdivResultFromArgs_neg_pos_trunc :
+    sdivResultFromArgs (sdivArgs (-7) 2) = (-3 : EvmWord) := by
+  exact EvmWord.sdiv_neg_pos_trunc
+
 end SDivArgs
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/SDiv/StackExecutionBridge.lean
+++ b/EvmAsm/Evm64/SDiv/StackExecutionBridge.lean
@@ -192,5 +192,12 @@ theorem runSDivStack?_pos_neg_trunc
   rw [runSDivStack?_cons]
   rw [SDivArgs.sdivResultFromArgs_pos_neg_trunc]
 
+theorem runSDivStack?_neg_pos_trunc
+    (rest : List EvmWord) :
+    runSDivStack? { stack := (-7 : EvmWord) :: 2 :: rest } =
+      some { effects := { stackWords := [(-3 : EvmWord)] }, stack := rest } := by
+  rw [runSDivStack?_cons]
+  rw [SDivArgs.sdivResultFromArgs_neg_pos_trunc]
+
 end SDivStackExecutionBridge
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add the closed EvmWord SDIV example for (-7) / 2 truncating toward zero
- thread that result through SDivArgs and the stack execution bridge
- keep this as a small helper slice toward evm_sdiv_stack_spec_within

Refs #90.
Bead: evm-asm-01uh.

## Verification
- lake build EvmAsm.Evm64.SDiv.StackExecutionBridge
- scripts/check-file-size.sh
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/EvmWordArith/SDiv.lean EvmAsm/Evm64/SDiv/Args.lean EvmAsm/Evm64/SDiv/StackExecutionBridge.lean
- lake build