### PR TITLE
feat(sdiv): name wrapper compose code blocks

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/Base.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/Base.lean
@@ -316,4 +316,44 @@ theorem divisorSign_spec_in_sdivCode
       EvmAsm.Evm64.evm_sdivDivisorTopLimbOff sp sOld divisorTop
       (base + divisorSignOff) (by decide))
 
+theorem divCall_spec_in_sdivCode
+    (vOld : Word) (base : Word) :
+    cpsTripleWithin 1 (base + divCallOff)
+        ((base + divCallOff) + signExtend21 EvmAsm.Evm64.evm_sdivCallOff)
+      (sdivCode base)
+      (.x1 ↦ᵣ vOld)
+      (.x1 ↦ᵣ ((base + divCallOff) + 4)) := by
+  have hmono :
+      ∀ a i,
+        (EvmAsm.Evm64.evm_sdiv_div_call_block_code
+          EvmAsm.Evm64.evm_sdivCallOff (base + divCallOff)) a = some i →
+        (sdivCode base) a = some i := by
+    intro a i h
+    exact sdivCode_divCall_sub (base := base) a i
+      (by simpa [divCallCode,
+        EvmAsm.Evm64.evm_sdiv_div_call_block_code] using h)
+  exact cpsTripleWithin_extend_code hmono
+    (EvmAsm.Evm64.evm_sdiv_div_call_block_spec_within
+      EvmAsm.Evm64.evm_sdivCallOff vOld (base + divCallOff))
+
+theorem savedRaRet_spec_in_sdivCode
+    (vSavedRa : Word) (base : Word) :
+    cpsTripleWithin 1 (base + savedRaRetOff)
+        ((vSavedRa + signExtend12 (0 : BitVec 12)) &&& ~~~1)
+      (sdivCode base)
+      (.x18 ↦ᵣ vSavedRa)
+      (.x18 ↦ᵣ vSavedRa) := by
+  have hmono :
+      ∀ a i,
+        (EvmAsm.Evm64.evm_sdiv_saved_ra_ret_block_code .x18
+          (base + savedRaRetOff)) a = some i →
+        (sdivCode base) a = some i := by
+    intro a i h
+    exact sdivCode_savedRaRet_sub (base := base) a i
+      (by simpa [savedRaRetCode,
+        EvmAsm.Evm64.evm_sdiv_saved_ra_ret_block_code] using h)
+  exact cpsTripleWithin_extend_code hmono
+    (EvmAsm.Evm64.evm_sdiv_saved_ra_ret_block_spec_within .x18
+      vSavedRa (base + savedRaRetOff))
+
 end EvmAsm.Evm64.SDiv.Compose

--- a/EvmAsm/Evm64/SDiv/Compose/Base.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/Base.lean
@@ -19,7 +19,105 @@ namespace EvmAsm.Evm64.SDiv.Compose
 open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
--- Composition helpers (skipBlock subsumptions, length lemmas, etc.)
--- land alongside the Compose/<Phase>.lean files in later slices.
+/-- Byte offset of the saved-`ra` prologue inside `evm_sdiv_wrapper`. -/
+def saveRaOff : Nat := 0
+
+/-- Byte offset of the dividend sign probe inside `evm_sdiv_wrapper`. -/
+def dividendSignOff : Nat := 4
+
+/-- Byte offset of the divisor sign probe inside `evm_sdiv_wrapper`. -/
+def divisorSignOff : Nat := 12
+
+/-- Byte offset of the in-place dividend absolute-value block. -/
+def dividendAbsOff : Nat := 20
+
+/-- Byte offset of the in-place divisor absolute-value block. -/
+def divisorAbsOff : Nat := 104
+
+/-- Byte offset of the sign-xor instruction selecting result negation. -/
+def signXorOff : Nat := 188
+
+/-- Byte offset of the near call into `evm_div_callable`. -/
+def divCallOff : Nat := 192
+
+/-- Byte offset of the in-place quotient sign-fixup block. -/
+def resultSignFixOff : Nat := 196
+
+/-- Byte offset of the saved-`ra` return instruction. -/
+def savedRaRetOff : Nat := 280
+
+/-- Byte offset at the end of the SDIV wrapper. The appended unsigned
+    divider callable starts here. -/
+def wrapperEndOff : Nat := 284
+
+/-- Bundled byte offsets for the concrete SDIV wrapper layout. -/
+theorem sdiv_wrapper_block_byte_offsets :
+    saveRaOff = 0 ∧
+    dividendSignOff = 4 ∧
+    divisorSignOff = 12 ∧
+    dividendAbsOff = 20 ∧
+    divisorAbsOff = 104 ∧
+    signXorOff = 188 ∧
+    divCallOff = 192 ∧
+    resultSignFixOff = 196 ∧
+    savedRaRetOff = 280 ∧
+    wrapperEndOff = 284 := by
+  native_decide
+
+/-- Full SDIV code region handle: wrapper followed by `evm_div_callable`. -/
+abbrev sdivCode (base : Word) : CodeReq :=
+  CodeReq.ofProg base EvmAsm.Evm64.evm_sdiv
+
+/-- Code handle for the saved-`ra` prologue block. -/
+abbrev saveRaCode (base : Word) : CodeReq :=
+  CodeReq.ofProg (base + saveRaOff) (EvmAsm.Evm64.evm_sdiv_save_ra_block .x18)
+
+/-- Code handle for the dividend sign-bit probe. -/
+abbrev dividendSignCode (base : Word) : CodeReq :=
+  CodeReq.ofProg (base + dividendSignOff)
+    (EvmAsm.Evm64.evm_sdiv_sign_bit_block .x12 .x8
+      EvmAsm.Evm64.evm_sdivDividendTopLimbOff)
+
+/-- Code handle for the divisor sign-bit probe. -/
+abbrev divisorSignCode (base : Word) : CodeReq :=
+  CodeReq.ofProg (base + divisorSignOff)
+    (EvmAsm.Evm64.evm_sdiv_sign_bit_block .x12 .x9
+      EvmAsm.Evm64.evm_sdivDivisorTopLimbOff)
+
+/-- Code handle for the in-place dividend absolute-value block. -/
+abbrev dividendAbsCode (base : Word) : CodeReq :=
+  CodeReq.ofProg (base + dividendAbsOff)
+    (EvmAsm.Evm64.evm_sdiv_cond_negate_256_block .x12 .x8 .x10 .x7 .x11
+      0 8 16 24)
+
+/-- Code handle for the in-place divisor absolute-value block. -/
+abbrev divisorAbsCode (base : Word) : CodeReq :=
+  CodeReq.ofProg (base + divisorAbsOff)
+    (EvmAsm.Evm64.evm_sdiv_cond_negate_256_block .x12 .x9 .x10 .x7 .x11
+      32 40 48 56)
+
+/-- Code handle for the sign-xor instruction selecting result negation. -/
+abbrev signXorCode (base : Word) : CodeReq :=
+  CodeReq.ofProg (base + signXorOff) (EvmAsm.Rv64.XOR' .x8 .x8 .x9)
+
+/-- Code handle for the near call into `evm_div_callable`. -/
+abbrev divCallCode (base : Word) : CodeReq :=
+  CodeReq.ofProg (base + divCallOff)
+    (EvmAsm.Evm64.evm_sdiv_div_call_block EvmAsm.Evm64.evm_sdivCallOff)
+
+/-- Code handle for the in-place quotient sign-fixup block. -/
+abbrev resultSignFixCode (base : Word) : CodeReq :=
+  CodeReq.ofProg (base + resultSignFixOff)
+    (EvmAsm.Evm64.evm_sdiv_cond_negate_256_block .x12 .x8 .x10 .x7 .x11
+      32 40 48 56)
+
+/-- Code handle for the saved-`ra` return instruction. -/
+abbrev savedRaRetCode (base : Word) : CodeReq :=
+  CodeReq.ofProg (base + savedRaRetOff)
+    (EvmAsm.Evm64.evm_sdiv_saved_ra_ret_block .x18)
+
+/-- Code handle for the appended unsigned divider callable. -/
+abbrev divCallableCode (base : Word) : CodeReq :=
+  CodeReq.ofProg (base + wrapperEndOff) EvmAsm.Evm64.evm_div_callable
 
 end EvmAsm.Evm64.SDiv.Compose

--- a/EvmAsm/Evm64/SDiv/Compose/Base.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/Base.lean
@@ -120,4 +120,132 @@ abbrev savedRaRetCode (base : Word) : CodeReq :=
 abbrev divCallableCode (base : Word) : CodeReq :=
   CodeReq.ofProg (base + wrapperEndOff) EvmAsm.Evm64.evm_div_callable
 
+theorem sdivCode_saveRa_sub {base : Word} :
+    ∀ a i, (saveRaCode base) a = some i → (sdivCode base) a = some i := by
+  unfold saveRaCode sdivCode
+  exact CodeReq.ofProg_mono_sub base (base + saveRaOff)
+    EvmAsm.Evm64.evm_sdiv (EvmAsm.Evm64.evm_sdiv_save_ra_block .x18) 0
+    (by simp [saveRaOff])
+    (by native_decide)
+    (by native_decide)
+    (by rw [EvmAsm.Evm64.evm_sdiv_length]; norm_num)
+
+theorem sdivCode_dividendSign_sub {base : Word} :
+    ∀ a i, (dividendSignCode base) a = some i → (sdivCode base) a = some i := by
+  unfold dividendSignCode sdivCode
+  exact CodeReq.ofProg_mono_sub base (base + dividendSignOff)
+    EvmAsm.Evm64.evm_sdiv
+    (EvmAsm.Evm64.evm_sdiv_sign_bit_block .x12 .x8
+      EvmAsm.Evm64.evm_sdivDividendTopLimbOff) 1
+    (by simp [dividendSignOff])
+    (by native_decide)
+    (by native_decide)
+    (by rw [EvmAsm.Evm64.evm_sdiv_length]; norm_num)
+
+theorem sdivCode_divisorSign_sub {base : Word} :
+    ∀ a i, (divisorSignCode base) a = some i → (sdivCode base) a = some i := by
+  unfold divisorSignCode sdivCode
+  exact CodeReq.ofProg_mono_sub base (base + divisorSignOff)
+    EvmAsm.Evm64.evm_sdiv
+    (EvmAsm.Evm64.evm_sdiv_sign_bit_block .x12 .x9
+      EvmAsm.Evm64.evm_sdivDivisorTopLimbOff) 3
+    (by simp [divisorSignOff])
+    (by native_decide)
+    (by native_decide)
+    (by rw [EvmAsm.Evm64.evm_sdiv_length]; norm_num)
+
+theorem sdivCode_dividendAbs_sub {base : Word} :
+    ∀ a i, (dividendAbsCode base) a = some i → (sdivCode base) a = some i := by
+  unfold dividendAbsCode sdivCode
+  exact CodeReq.ofProg_mono_sub base (base + dividendAbsOff)
+    EvmAsm.Evm64.evm_sdiv
+    (EvmAsm.Evm64.evm_sdiv_cond_negate_256_block .x12 .x8 .x10 .x7 .x11
+      0 8 16 24) 5
+    (by simp [dividendAbsOff])
+    (by native_decide)
+    (by native_decide)
+    (by rw [EvmAsm.Evm64.evm_sdiv_length]; norm_num)
+
+theorem sdivCode_divisorAbs_sub {base : Word} :
+    ∀ a i, (divisorAbsCode base) a = some i → (sdivCode base) a = some i := by
+  unfold divisorAbsCode sdivCode
+  exact CodeReq.ofProg_mono_sub base (base + divisorAbsOff)
+    EvmAsm.Evm64.evm_sdiv
+    (EvmAsm.Evm64.evm_sdiv_cond_negate_256_block .x12 .x9 .x10 .x7 .x11
+      32 40 48 56) 26
+    (by simp [divisorAbsOff])
+    (by native_decide)
+    (by native_decide)
+    (by rw [EvmAsm.Evm64.evm_sdiv_length]; norm_num)
+
+theorem sdivCode_signXor_sub {base : Word} :
+    ∀ a i, (signXorCode base) a = some i → (sdivCode base) a = some i := by
+  unfold signXorCode sdivCode
+  exact CodeReq.ofProg_mono_sub base (base + signXorOff)
+    EvmAsm.Evm64.evm_sdiv (EvmAsm.Rv64.XOR' .x8 .x8 .x9) 47
+    (by simp [signXorOff])
+    (by native_decide)
+    (by native_decide)
+    (by rw [EvmAsm.Evm64.evm_sdiv_length]; norm_num)
+
+theorem sdivCode_divCall_sub {base : Word} :
+    ∀ a i, (divCallCode base) a = some i → (sdivCode base) a = some i := by
+  unfold divCallCode sdivCode
+  exact CodeReq.ofProg_mono_sub base (base + divCallOff)
+    EvmAsm.Evm64.evm_sdiv
+    (EvmAsm.Evm64.evm_sdiv_div_call_block EvmAsm.Evm64.evm_sdivCallOff) 48
+    (by simp [divCallOff])
+    (by native_decide)
+    (by native_decide)
+    (by rw [EvmAsm.Evm64.evm_sdiv_length]; norm_num)
+
+theorem sdivCode_resultSignFix_sub {base : Word} :
+    ∀ a i, (resultSignFixCode base) a = some i → (sdivCode base) a = some i := by
+  unfold resultSignFixCode sdivCode
+  exact CodeReq.ofProg_mono_sub base (base + resultSignFixOff)
+    EvmAsm.Evm64.evm_sdiv
+    (EvmAsm.Evm64.evm_sdiv_cond_negate_256_block .x12 .x8 .x10 .x7 .x11
+      32 40 48 56) 49
+    (by simp [resultSignFixOff])
+    (by native_decide)
+    (by native_decide)
+    (by rw [EvmAsm.Evm64.evm_sdiv_length]; norm_num)
+
+theorem sdivCode_savedRaRet_sub {base : Word} :
+    ∀ a i, (savedRaRetCode base) a = some i → (sdivCode base) a = some i := by
+  unfold savedRaRetCode sdivCode
+  exact CodeReq.ofProg_mono_sub base (base + savedRaRetOff)
+    EvmAsm.Evm64.evm_sdiv (EvmAsm.Evm64.evm_sdiv_saved_ra_ret_block .x18) 70
+    (by simp [savedRaRetOff])
+    (by native_decide)
+    (by native_decide)
+    (by rw [EvmAsm.Evm64.evm_sdiv_length]; norm_num)
+
+theorem sdivCode_divCallable_sub {base : Word} :
+    ∀ a i, (divCallableCode base) a = some i → (sdivCode base) a = some i := by
+  unfold divCallableCode sdivCode
+  exact CodeReq.ofProg_mono_sub base (base + wrapperEndOff)
+    EvmAsm.Evm64.evm_sdiv EvmAsm.Evm64.evm_div_callable 71
+    (by simp [wrapperEndOff])
+    (by native_decide)
+    (by native_decide)
+    (by rw [EvmAsm.Evm64.evm_sdiv_length]; norm_num)
+
+theorem sdivCode_block_subs {base : Word} :
+    (∀ a i, (saveRaCode base) a = some i → (sdivCode base) a = some i) ∧
+    (∀ a i, (dividendSignCode base) a = some i → (sdivCode base) a = some i) ∧
+    (∀ a i, (divisorSignCode base) a = some i → (sdivCode base) a = some i) ∧
+    (∀ a i, (dividendAbsCode base) a = some i → (sdivCode base) a = some i) ∧
+    (∀ a i, (divisorAbsCode base) a = some i → (sdivCode base) a = some i) ∧
+    (∀ a i, (signXorCode base) a = some i → (sdivCode base) a = some i) ∧
+    (∀ a i, (divCallCode base) a = some i → (sdivCode base) a = some i) ∧
+    (∀ a i, (resultSignFixCode base) a = some i → (sdivCode base) a = some i) ∧
+    (∀ a i, (savedRaRetCode base) a = some i → (sdivCode base) a = some i) ∧
+    (∀ a i, (divCallableCode base) a = some i → (sdivCode base) a = some i) := by
+  exact ⟨sdivCode_saveRa_sub, sdivCode_dividendSign_sub,
+    sdivCode_divisorSign_sub, sdivCode_dividendAbs_sub,
+    sdivCode_divisorAbs_sub, sdivCode_signXor_sub, sdivCode_divCall_sub,
+    sdivCode_resultSignFix_sub, sdivCode_savedRaRet_sub,
+    sdivCode_divCallable_sub⟩
+
 end EvmAsm.Evm64.SDiv.Compose

--- a/EvmAsm/Evm64/SDiv/Compose/Base.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/Base.lean
@@ -248,4 +248,72 @@ theorem sdivCode_block_subs {base : Word} :
     sdivCode_resultSignFix_sub, sdivCode_savedRaRet_sub,
     sdivCode_divCallable_sub⟩
 
+theorem saveRa_spec_in_sdivCode
+    (vRa vSavedOld : Word) (base : Word) :
+    cpsTripleWithin 1 base (base + 4) (sdivCode base)
+      ((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ vSavedOld))
+      ((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12)))) := by
+  have hmono :
+      ∀ a i, (EvmAsm.Evm64.evm_sdiv_save_ra_block_code .x18 base) a = some i →
+        (sdivCode base) a = some i := by
+    intro a i h
+    exact sdivCode_saveRa_sub (base := base) a i
+      (by simpa [saveRaCode, saveRaOff,
+        EvmAsm.Evm64.evm_sdiv_save_ra_block_code] using h)
+  exact cpsTripleWithin_extend_code hmono
+    (EvmAsm.Evm64.evm_sdiv_save_ra_block_spec_within .x18
+      vRa vSavedOld base (by decide))
+
+theorem dividendSign_spec_in_sdivCode
+    (sp sOld dividendTop : Word) (base : Word) :
+    cpsTripleWithin 2 (base + dividendSignOff) ((base + dividendSignOff) + 8)
+      (sdivCode base)
+      ((.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sOld) **
+       ((sp + signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ
+         dividendTop))
+      ((.x12 ↦ᵣ sp) **
+       (.x8 ↦ᵣ (dividendTop >>> (63 : BitVec 6).toNat)) **
+       ((sp + signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ
+         dividendTop)) := by
+  have hmono :
+      ∀ a i,
+        (EvmAsm.Evm64.evm_sdiv_sign_bit_block_code .x12 .x8
+          EvmAsm.Evm64.evm_sdivDividendTopLimbOff
+          (base + dividendSignOff)) a = some i →
+        (sdivCode base) a = some i := by
+    intro a i h
+    exact sdivCode_dividendSign_sub (base := base) a i
+      (by simpa [dividendSignCode,
+        EvmAsm.Evm64.evm_sdiv_sign_bit_block_code] using h)
+  exact cpsTripleWithin_extend_code hmono
+    (EvmAsm.Evm64.evm_sdiv_sign_bit_block_spec_within .x12 .x8
+      EvmAsm.Evm64.evm_sdivDividendTopLimbOff sp sOld dividendTop
+      (base + dividendSignOff) (by decide))
+
+theorem divisorSign_spec_in_sdivCode
+    (sp sOld divisorTop : Word) (base : Word) :
+    cpsTripleWithin 2 (base + divisorSignOff) ((base + divisorSignOff) + 8)
+      (sdivCode base)
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ sOld) **
+       ((sp + signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff) ↦ₘ
+         divisorTop))
+      ((.x12 ↦ᵣ sp) **
+       (.x9 ↦ᵣ (divisorTop >>> (63 : BitVec 6).toNat)) **
+       ((sp + signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff) ↦ₘ
+         divisorTop)) := by
+  have hmono :
+      ∀ a i,
+        (EvmAsm.Evm64.evm_sdiv_sign_bit_block_code .x12 .x9
+          EvmAsm.Evm64.evm_sdivDivisorTopLimbOff
+          (base + divisorSignOff)) a = some i →
+        (sdivCode base) a = some i := by
+    intro a i h
+    exact sdivCode_divisorSign_sub (base := base) a i
+      (by simpa [divisorSignCode,
+        EvmAsm.Evm64.evm_sdiv_sign_bit_block_code] using h)
+  exact cpsTripleWithin_extend_code hmono
+    (EvmAsm.Evm64.evm_sdiv_sign_bit_block_spec_within .x12 .x9
+      EvmAsm.Evm64.evm_sdivDivisorTopLimbOff sp sOld divisorTop
+      (base + divisorSignOff) (by decide))
+
 end EvmAsm.Evm64.SDiv.Compose

--- a/EvmAsm/Evm64/SDiv/Compose/Base.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/Base.lean
@@ -64,6 +64,19 @@ theorem sdiv_wrapper_block_byte_offsets :
     wrapperEndOff = 284 := by
   native_decide
 
+/-- Successive fall-through byte offsets for the concrete SDIV wrapper. -/
+theorem sdiv_wrapper_fallthrough_offsets :
+    saveRaOff + 4 = dividendSignOff ∧
+    dividendSignOff + 8 = divisorSignOff ∧
+    divisorSignOff + 8 = dividendAbsOff ∧
+    dividendAbsOff + 84 = divisorAbsOff ∧
+    divisorAbsOff + 84 = signXorOff ∧
+    signXorOff + 4 = divCallOff ∧
+    divCallOff + 4 = resultSignFixOff ∧
+    resultSignFixOff + 84 = savedRaRetOff ∧
+    savedRaRetOff + 4 = wrapperEndOff := by
+  native_decide
+
 /-- Full SDIV code region handle: wrapper followed by `evm_div_callable`. -/
 abbrev sdivCode (base : Word) : CodeReq :=
   CodeReq.ofProg base EvmAsm.Evm64.evm_sdiv

--- a/EvmAsm/Evm64/SDiv/Compose/Base.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/Base.lean
@@ -336,6 +336,25 @@ theorem divCall_spec_in_sdivCode
     (EvmAsm.Evm64.evm_sdiv_div_call_block_spec_within
       EvmAsm.Evm64.evm_sdivCallOff vOld (base + divCallOff))
 
+theorem signXor_spec_in_sdivCode
+    (signDividend signDivisor : Word) (base : Word) :
+    cpsTripleWithin 1 (base + signXorOff) ((base + signXorOff) + 4)
+      (sdivCode base)
+      ((.x8 ↦ᵣ signDividend) ** (.x9 ↦ᵣ signDivisor))
+      ((.x8 ↦ᵣ (signDividend ^^^ signDivisor)) ** (.x9 ↦ᵣ signDivisor)) := by
+  have hmono :
+      ∀ a i, (CodeReq.singleton (base + signXorOff) (.XOR .x8 .x8 .x9)) a = some i →
+        (sdivCode base) a = some i := by
+    intro a i h
+    exact sdivCode_signXor_sub (base := base) a i
+      (by
+        rw [signXorCode, EvmAsm.Rv64.XOR', EvmAsm.Rv64.single,
+          CodeReq.ofProg_singleton]
+        exact h)
+  exact cpsTripleWithin_extend_code hmono
+    (xor_spec_gen_rd_eq_rs1_within .x8 .x9 signDividend signDivisor
+      (base + signXorOff) (by decide))
+
 theorem savedRaRet_spec_in_sdivCode
     (vSavedRa : Word) (base : Word) :
     cpsTripleWithin 1 (base + savedRaRetOff)

--- a/EvmAsm/Evm64/SDiv/Program.lean
+++ b/EvmAsm/Evm64/SDiv/Program.lean
@@ -56,6 +56,32 @@ theorem evm_sdiv_sign_bit_block_byte_length
     4 * (evm_sdiv_sign_bit_block addrReg signReg topLimbOff).length = 8 := by
   rw [evm_sdiv_sign_bit_block_length]
 
+/-- One limb of the conditional 256-bit negation loop.
+
+    The caller has already materialized `maskReg = 0 - sign`. This step
+    loads one limb, xors it with the mask, adds the incoming carry, stores
+    the resulting carry in `carryReg`, and writes the limb back in place.
+    Limb 0 passes the sign register as `carryInReg`; later limbs pass
+    `carryReg` itself.
+
+    5 instructions: `LD; XOR; ADD; SLTU; SD`. -/
+def evm_sdiv_cond_negate_limb_step
+    (addrReg carryInReg maskReg valueReg carryReg : Reg)
+    (limbOff : BitVec 12) : Program :=
+  LD valueReg addrReg limbOff ;;
+  XOR' valueReg valueReg maskReg ;;
+  ADD valueReg valueReg carryInReg ;;
+  SLTU carryReg valueReg carryInReg ;;
+  SD addrReg valueReg limbOff
+
+theorem evm_sdiv_cond_negate_limb_step_length
+    (addrReg carryInReg maskReg valueReg carryReg : Reg)
+    (limbOff : BitVec 12) :
+    (evm_sdiv_cond_negate_limb_step addrReg carryInReg maskReg valueReg carryReg
+      limbOff).length = 5 := by
+  unfold evm_sdiv_cond_negate_limb_step LD XOR' ADD SLTU SD single seq Program
+  rfl
+
 /-- Conditionally negate a 256-bit word in place.
 
     `signReg` must hold `0` or `1`. The block computes
@@ -74,33 +100,18 @@ def evm_sdiv_cond_negate_256_block
     (addrReg signReg maskReg valueReg carryReg : Reg)
     (limb0Off limb1Off limb2Off limb3Off : BitVec 12) : Program :=
   SUB maskReg .x0 signReg ;;
-  LD valueReg addrReg limb0Off ;;
-  XOR' valueReg valueReg maskReg ;;
-  ADD valueReg valueReg signReg ;;
-  SLTU carryReg valueReg signReg ;;
-  SD addrReg valueReg limb0Off ;;
-  LD valueReg addrReg limb1Off ;;
-  XOR' valueReg valueReg maskReg ;;
-  ADD valueReg valueReg carryReg ;;
-  SLTU carryReg valueReg carryReg ;;
-  SD addrReg valueReg limb1Off ;;
-  LD valueReg addrReg limb2Off ;;
-  XOR' valueReg valueReg maskReg ;;
-  ADD valueReg valueReg carryReg ;;
-  SLTU carryReg valueReg carryReg ;;
-  SD addrReg valueReg limb2Off ;;
-  LD valueReg addrReg limb3Off ;;
-  XOR' valueReg valueReg maskReg ;;
-  ADD valueReg valueReg carryReg ;;
-  SLTU carryReg valueReg carryReg ;;
-  SD addrReg valueReg limb3Off
+  evm_sdiv_cond_negate_limb_step addrReg signReg maskReg valueReg carryReg limb0Off ;;
+  evm_sdiv_cond_negate_limb_step addrReg carryReg maskReg valueReg carryReg limb1Off ;;
+  evm_sdiv_cond_negate_limb_step addrReg carryReg maskReg valueReg carryReg limb2Off ;;
+  evm_sdiv_cond_negate_limb_step addrReg carryReg maskReg valueReg carryReg limb3Off
 
 theorem evm_sdiv_cond_negate_256_block_length
     (addrReg signReg maskReg valueReg carryReg : Reg)
     (limb0Off limb1Off limb2Off limb3Off : BitVec 12) :
     (evm_sdiv_cond_negate_256_block addrReg signReg maskReg valueReg carryReg
       limb0Off limb1Off limb2Off limb3Off).length = 21 := by
-  unfold evm_sdiv_cond_negate_256_block SUB LD XOR' ADD SLTU SD single seq Program
+  unfold evm_sdiv_cond_negate_256_block evm_sdiv_cond_negate_limb_step
+    SUB LD XOR' ADD SLTU SD single seq Program
   rfl
 
 theorem evm_sdiv_cond_negate_256_block_byte_length


### PR DESCRIPTION
## Summary
- add named byte offsets for each block in the concrete SDIV wrapper layout
- add reusable CodeReq handles for the wrapper leaf blocks and appended evm_div_callable
- prepare Compose/Base for the eventual evm_sdiv_stack_spec_within composition proof

Refs #90.
Bead: evm-asm-01uh.

## Verification
- lake build EvmAsm.Evm64.SDiv.Compose.Base
- scripts/check-file-size.sh
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/Base.lean
- lake build