### PR TITLE
fix(exp): refresh 3544 repair branch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,6 +157,46 @@ Pitfalls:
   `fix(shr): address canonicalization in sign-fill path`). The PR summary bot
   flags titles that don't match this format.
 
+## Bead closure rules (`bd close`)
+
+The beads tracker is the source of truth for outstanding work. Closing a bead
+incorrectly hides unfinished obligations and bumping its priority later does
+nothing because the bead is no longer in the queue. Before running
+`bd close <id>`, satisfy **all** of the following:
+
+1. **The named deliverable must exist on `origin/main`.** If the bead title
+   says "prove `foo_spec_within`", "define `evm_foo`", or "lift X to Y", that
+   exact declaration has to be present on `origin/main` — not on a feature
+   branch, not in an unmerged stacked PR. Verify with:
+   `git fetch origin && git grep -n '<decl name>' origin/main -- '<expected path>'`.
+   If the grep is empty, **do not close the bead**.
+
+2. **A "related" PR merging is not the same as the deliverable shipping.** A
+   PR titled similarly, or that adds scaffolding, wrappers, or preparation
+   lemmas around the deliverable, does not satisfy the bead. If the named
+   theorem is still a `placeholder`, `sorry`, or absent, the bead stays open.
+
+3. **Stacked PRs into feature branches don't count.** A PR merged into
+   `feat/foo` instead of `main` has not landed. Wait for the bottom of the
+   stack to merge into `main`, then verify per (1) before closing the
+   dependent beads.
+
+4. **`close_reason` must be truthful.** `"shipped in PR #N"` is only valid
+   when PR #N's merge commit is an ancestor of `origin/main` *and* the named
+   deliverable is grep-visible there. Otherwise use
+   `"superseded by <bead-id>"` or `"duplicate of <bead-id>"`. Never close as
+   "shipped" against a PR that merged into a feature branch.
+
+5. **If you finished real work but the named theorem isn't done yet**,
+   prefer adding a `bd comment` with status, or filing a follow-up bead, or
+   updating the existing bead's description — instead of closing the wrong
+   thing.
+
+Recent violations to learn from: `evm-asm-01uh` (SDIV), `evm-asm-6snn` and
+`evm-asm-w5mk` (EXP) — all closed as "shipped in PR #…" while the named
+theorem was still a placeholder on `main` (and in the EXP cases the PR was
+merged into a feature branch, not `main`). All three had to be reopened.
+
 ## References
 
 - **Accelerator C ABI (source of truth)**:

--- a/EvmAsm/Evm64/EvmWordArith/SDiv.lean
+++ b/EvmAsm/Evm64/EvmWordArith/SDiv.lean
@@ -68,6 +68,9 @@ theorem sdiv_neg_one_two : sdiv (-1 : EvmWord) 2 = 0 := by
 theorem sdiv_pos_neg_trunc : sdiv (7 : EvmWord) (-2) = (-3 : EvmWord) := by
   native_decide
 
+theorem sdiv_neg_pos_trunc : sdiv (-7 : EvmWord) 2 = (-3 : EvmWord) := by
+  native_decide
+
 -- ============================================================================
 -- Correctness vs `Int.tdiv` (the spec formula)
 -- ============================================================================

--- a/EvmAsm/Evm64/SDiv/Args.lean
+++ b/EvmAsm/Evm64/SDiv/Args.lean
@@ -74,5 +74,9 @@ theorem sdivResultFromArgs_pos_neg_trunc :
     sdivResultFromArgs (sdivArgs 7 (-2)) = (-3 : EvmWord) := by
   exact EvmWord.sdiv_pos_neg_trunc
 
+theorem sdivResultFromArgs_neg_pos_trunc :
+    sdivResultFromArgs (sdivArgs (-7) 2) = (-3 : EvmWord) := by
+  exact EvmWord.sdiv_neg_pos_trunc
+
 end SDivArgs
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/SDiv/StackExecutionBridge.lean
+++ b/EvmAsm/Evm64/SDiv/StackExecutionBridge.lean
@@ -192,5 +192,12 @@ theorem runSDivStack?_pos_neg_trunc
   rw [runSDivStack?_cons]
   rw [SDivArgs.sdivResultFromArgs_pos_neg_trunc]
 
+theorem runSDivStack?_neg_pos_trunc
+    (rest : List EvmWord) :
+    runSDivStack? { stack := (-7 : EvmWord) :: 2 :: rest } =
+      some { effects := { stackWords := [(-3 : EvmWord)] }, stack := rest } := by
+  rw [runSDivStack?_cons]
+  rw [SDivArgs.sdivResultFromArgs_neg_pos_trunc]
+
 end SDivStackExecutionBridge
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- merge origin/main into a fresh repair branch for PR #3565 without pushing to its branch directly
- resolve the EXP stack conformance conflict by preserving the shared exp-stack-two-128 / exp-stack-max-one-exponent vector set
- leave aggregate conformance totals unchanged after the merge

Repairs #3565.
Refs #92.
Refs #125.
Bead: evm-asm-uwlju.

## Verification
- lake build EvmAsm.EL.Conformance.ExpStackExecution EvmAsm.EL.Conformance.All
- scripts/check-file-size.sh
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/EL/Conformance/ExpStackExecution.lean
- lake build