### PR TITLE
feat(sdiv): prove conditional negate limb step

### DIFF
--- a/EvmAsm/Evm64/SDiv/LimbSpec.lean
+++ b/EvmAsm/Evm64/SDiv/LimbSpec.lean
@@ -46,6 +46,50 @@ theorem evm_sdiv_sign_bit_block_spec_within
               (base + 4) hsign_ne_x0
   runBlock L S
 
+/-- CodeReq for one conditional-negation limb step at byte offset `base`. -/
+abbrev evm_sdiv_cond_negate_limb_step_code
+    (addrReg carryInReg maskReg valueReg carryReg : Reg)
+    (limbOff : BitVec 12) (base : Word) : CodeReq :=
+  CodeReq.ofProg base
+    (evm_sdiv_cond_negate_limb_step addrReg carryInReg maskReg valueReg carryReg
+      limbOff)
+
+/-- 5-instruction conditional-negation limb step with the incoming carry
+    held in a separate register: `LD; XOR; ADD; SLTU; SD`. This is the
+    leaf used for limb 0 of the 256-bit SDIV conditional-negation block,
+    where `carryInReg` is the sign register. -/
+theorem evm_sdiv_cond_negate_limb_step_spec_within
+    (addrReg carryInReg maskReg valueReg carryReg : Reg)
+    (limbOff : BitVec 12)
+    (vAddr carryIn mask valueOld carryOld limbVal : Word) (base : Word)
+    (hvalue_ne_x0 : valueReg ≠ .x0) (hcarry_ne_x0 : carryReg ≠ .x0) :
+    let mem := vAddr + signExtend12 limbOff
+    let xored := limbVal ^^^ mask
+    let sum := xored + carryIn
+    let carryOut := if BitVec.ult sum carryIn then (1 : Word) else 0
+    let code :=
+      evm_sdiv_cond_negate_limb_step_code addrReg carryInReg maskReg valueReg
+        carryReg limbOff base
+    cpsTripleWithin 5 base (base + 20) code
+      ((addrReg ↦ᵣ vAddr) ** (carryInReg ↦ᵣ carryIn) **
+       (maskReg ↦ᵣ mask) ** (valueReg ↦ᵣ valueOld) **
+       (carryReg ↦ᵣ carryOld) ** (mem ↦ₘ limbVal))
+      ((addrReg ↦ᵣ vAddr) ** (carryInReg ↦ᵣ carryIn) **
+       (maskReg ↦ᵣ mask) ** (valueReg ↦ᵣ sum) **
+       (carryReg ↦ᵣ carryOut) ** (mem ↦ₘ sum)) := by
+  intro mem xored sum carryOut code
+  have L := ld_spec_gen_within valueReg addrReg vAddr valueOld limbVal
+    limbOff base hvalue_ne_x0
+  have X := xor_spec_gen_rd_eq_rs1_within valueReg maskReg limbVal mask
+    (base + 4) hvalue_ne_x0
+  have A := add_spec_gen_rd_eq_rs1_within valueReg carryInReg xored carryIn
+    (base + 8) hvalue_ne_x0
+  have C := sltu_spec_gen_within carryReg valueReg carryInReg carryOld sum carryIn
+    (base + 12) hcarry_ne_x0
+  have S := sd_spec_gen_within addrReg valueReg vAddr sum limbVal limbOff
+    (base + 16)
+  runBlock L X A C S
+
 /-- CodeReq for `evm_sdiv_save_ra_block` at byte offset `base`. -/
 abbrev evm_sdiv_save_ra_block_code (savedRaReg : Reg) (base : Word) : CodeReq :=
   CodeReq.ofProg base (evm_sdiv_save_ra_block savedRaReg)


### PR DESCRIPTION
## Summary
- add a CodeReq handle for the named SDIV conditional-negation limb step
- prove the 5-instruction LD/XOR/ADD/SLTU/SD leaf spec when the carry input is held in a separate sign register
- prepare the first-limb piece needed to compose the full 21-instruction conditional-negation block

Depends on #3583.
Refs #90.
Bead: evm-asm-01uh.

## Verification
- lake build EvmAsm.Evm64.SDiv.LimbSpec
- scripts/check-file-size.sh
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/LimbSpec.lean
- lake build