### PR TITLE
feat(sdiv): sequence divisor sign probe

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/Base.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/Base.lean
@@ -355,6 +355,88 @@ theorem divisorSign_spec_in_sdivCode
       EvmAsm.Evm64.evm_sdivDivisorTopLimbOff sp sOld divisorTop
       (base + divisorSignOff) (by decide))
 
+theorem saveRa_dividendSign_then_divisorSign_spec_in_sdivCode
+    (vRa vSavedOld sp sDividendOld dividendTop sDivisorOld divisorTop : Word)
+    (base : Word) :
+    cpsTripleWithin 5 base ((base + divisorSignOff) + 8) (sdivCode base)
+      ((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ vSavedOld)) **
+        ((.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sDividendOld) **
+         ((sp + signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ
+           dividendTop))) **
+       ((.x9 ↦ᵣ sDivisorOld) **
+        ((sp + signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff) ↦ₘ
+          divisorTop)))
+      ((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12)))) **
+        ((.x8 ↦ᵣ (dividendTop >>> (63 : BitVec 6).toNat)) **
+         ((sp + signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ
+           dividendTop))) **
+       ((.x12 ↦ᵣ sp) **
+        (.x9 ↦ᵣ (divisorTop >>> (63 : BitVec 6).toNat)) **
+        ((sp + signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff) ↦ₘ
+          divisorTop))) := by
+  let pre : Assertion :=
+    ((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ vSavedOld)) **
+      ((.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sDividendOld) **
+       ((sp + signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ
+         dividendTop))) **
+     ((.x9 ↦ᵣ sDivisorOld) **
+      ((sp + signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff) ↦ₘ
+        divisorTop)))
+  let mid : Assertion :=
+    ((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12)))) **
+      ((.x12 ↦ᵣ sp) **
+       (.x8 ↦ᵣ (dividendTop >>> (63 : BitVec 6).toNat)) **
+       ((sp + signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ
+         dividendTop))) **
+     ((.x9 ↦ᵣ sDivisorOld) **
+      ((sp + signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff) ↦ₘ
+        divisorTop)))
+  let midDivisor : Assertion :=
+    ((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12)))) **
+      ((.x8 ↦ᵣ (dividendTop >>> (63 : BitVec 6).toNat)) **
+       ((sp + signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ
+         dividendTop))) **
+     ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ sDivisorOld) **
+      ((sp + signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff) ↦ₘ
+        divisorTop)))
+  let post : Assertion :=
+    ((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12)))) **
+      ((.x8 ↦ᵣ (dividendTop >>> (63 : BitVec 6).toNat)) **
+       ((sp + signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ
+         dividendTop))) **
+     ((.x12 ↦ᵣ sp) **
+      (.x9 ↦ᵣ (divisorTop >>> (63 : BitVec 6).toNat)) **
+      ((sp + signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff) ↦ₘ
+        divisorTop)))
+  have hPrefix : cpsTripleWithin 3 base (base + divisorSignOff)
+      (sdivCode base) pre mid := by
+    dsimp [pre, mid]
+    simpa [dividendSignOff, divisorSignOff, BitVec.add_assoc] using
+      (cpsTripleWithin_frameR
+        ((.x9 ↦ᵣ sDivisorOld) **
+         ((sp + signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff) ↦ₘ
+          divisorTop))
+        (by pcFree)
+        (saveRa_then_dividendSign_spec_in_sdivCode
+          vRa vSavedOld sp sDividendOld dividendTop base))
+  have hDivisor : cpsTripleWithin 2 (base + divisorSignOff)
+      ((base + divisorSignOff) + 8) (sdivCode base) midDivisor post := by
+    dsimp [midDivisor, post]
+    exact
+      cpsTripleWithin_frameL
+        (((.x1 ↦ᵣ vRa) **
+          (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12)))) **
+         ((.x8 ↦ᵣ (dividendTop >>> (63 : BitVec 6).toNat)) **
+          ((sp + signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ
+            dividendTop)))
+        (by pcFree)
+        (divisorSign_spec_in_sdivCode sp sDivisorOld divisorTop base)
+  have hSeq := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by
+      dsimp [mid, midDivisor] at hp ⊢
+      xperm_hyp hp) hPrefix hDivisor
+  simpa [pre, post] using hSeq
+
 theorem dividendAbs_spec_in_sdivCode
     (sp sign maskOld valueOld carryOld limb0 limb1 limb2 limb3 : Word)
     (base : Word) :


### PR DESCRIPTION
## Summary
- compose the saved-return-address and dividend-sign prefix through the divisor sign-bit probe inside sdivCode
- frame untouched divisor state across the prefix and frame saved-ra/dividend-sign state across the divisor probe
- use the wrapper fallthrough offset normalization to connect the 5-instruction SDIV entry prefix

Depends on #3590.
Refs #90.
Bead: evm-asm-01uh.

## Verification
- lake build EvmAsm.Evm64.SDiv.Compose.Base
- scripts/check-file-size.sh
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/Base.lean
- lake build