### PR TITLE
feat(sdiv): sequence dividend abs block

### DIFF
--- a/EvmAsm/EL/Conformance/All.lean
+++ b/EvmAsm/EL/Conformance/All.lean
@@ -44,11 +44,11 @@ def allConformanceVectorCount : Nat :=
   allConformanceVectors.length
 
 theorem allConformanceVectors_length :
-    allConformanceVectors.length = 46 := by
+    allConformanceVectors.length = 47 := by
   native_decide
 
 theorem allConformanceVectorCount_eq :
-    allConformanceVectorCount = 46 := by
+    allConformanceVectorCount = 47 := by
   native_decide
 
 def unexpectedConformanceFailures : List CheckResult :=

--- a/EvmAsm/EL/Conformance/All.lean
+++ b/EvmAsm/EL/Conformance/All.lean
@@ -44,7 +44,7 @@ def allConformanceVectorCount : Nat :=
   allConformanceVectors.length
 
 theorem allConformanceVectors_length :
-    allConformanceVectors.length = 64 := by
+    allConformanceVectors.length = 65 := by
   simp [allConformanceVectors,
     Call.callOutputConformanceVectors_passed,
     Calldata.calldataConformanceVectors_passed,
@@ -62,7 +62,7 @@ theorem allConformanceVectors_length :
     TerminatingStackExecution.terminatingStackConformanceVectors_passed]
 
 theorem allConformanceVectorCount_eq :
-    allConformanceVectorCount = 64 := by
+    allConformanceVectorCount = 65 := by
   simp [allConformanceVectorCount, allConformanceVectors_length]
 
 def unexpectedConformanceFailures : List CheckResult :=
@@ -144,7 +144,7 @@ theorem expectedConformanceErrorCount_eq :
     TerminatingStackExecution.terminatingStackConformanceVectors_passed]
 
 theorem successfulConformanceResultCount_eq :
-    successfulConformanceResultCount = 54 := by
+    successfulConformanceResultCount = 55 := by
   simp [successfulConformanceResultCount, successfulConformanceResults,
     allConformanceVectors,
     Call.callOutputConformanceVectors_passed,

--- a/EvmAsm/EL/Conformance/All.lean
+++ b/EvmAsm/EL/Conformance/All.lean
@@ -44,11 +44,11 @@ def allConformanceVectorCount : Nat :=
   allConformanceVectors.length
 
 theorem allConformanceVectors_length :
-    allConformanceVectors.length = 50 := by
+    allConformanceVectors.length = 51 := by
   native_decide
 
 theorem allConformanceVectorCount_eq :
-    allConformanceVectorCount = 50 := by
+    allConformanceVectorCount = 51 := by
   native_decide
 
 def unexpectedConformanceFailures : List CheckResult :=
@@ -115,7 +115,7 @@ theorem expectedConformanceErrorCount_eq :
   native_decide
 
 theorem successfulConformanceResultCount_eq :
-    successfulConformanceResultCount = 40 := by
+    successfulConformanceResultCount = 41 := by
   native_decide
 
 end Conformance

--- a/EvmAsm/EL/Conformance/All.lean
+++ b/EvmAsm/EL/Conformance/All.lean
@@ -44,12 +44,26 @@ def allConformanceVectorCount : Nat :=
   allConformanceVectors.length
 
 theorem allConformanceVectors_length :
-    allConformanceVectors.length = 51 := by
-  native_decide
+    allConformanceVectors.length = 52 := by
+  simp [allConformanceVectors,
+    Call.callOutputConformanceVectors_passed,
+    Calldata.calldataConformanceVectors_passed,
+    Code.codeConformanceVectors_passed,
+    CreateStackExecution.createStackConformanceVectors_passed,
+    ExpGas.expGasConformanceVectors_passed,
+    ExpStackExecution.expStackConformanceVectors_passed,
+    KeccakStackExecution.keccakStackConformanceVectors_passed,
+    Log.logDataConformanceVectors_passed,
+    LogStackExecution.logStackConformanceVectors_passed,
+    RLP.rlpConformanceVectors_passed,
+    ReturnData.returnDataConformanceVectors_passed,
+    SignedArithmeticStackExecution.signedArithmeticConformanceVectors_passed,
+    StorageStackExecution.storageStackConformanceVectors_passed,
+    TerminatingStackExecution.terminatingStackConformanceVectors_passed]
 
 theorem allConformanceVectorCount_eq :
-    allConformanceVectorCount = 51 := by
-  native_decide
+    allConformanceVectorCount = 52 := by
+  simp [allConformanceVectorCount, allConformanceVectors_length]
 
 def unexpectedConformanceFailures : List CheckResult :=
   allConformanceVectors.filter
@@ -112,11 +126,41 @@ theorem unexpectedConformanceFailureCount_eq_zero :
 
 theorem expectedConformanceErrorCount_eq :
     expectedConformanceErrorCount = 10 := by
-  native_decide
+  simp [expectedConformanceErrorCount, expectedConformanceErrors,
+    allConformanceVectors,
+    Call.callOutputConformanceVectors_passed,
+    Calldata.calldataConformanceVectors_passed,
+    Code.codeConformanceVectors_passed,
+    CreateStackExecution.createStackConformanceVectors_passed,
+    ExpGas.expGasConformanceVectors_passed,
+    ExpStackExecution.expStackConformanceVectors_passed,
+    KeccakStackExecution.keccakStackConformanceVectors_passed,
+    Log.logDataConformanceVectors_passed,
+    LogStackExecution.logStackConformanceVectors_passed,
+    RLP.rlpConformanceVectors_passed,
+    ReturnData.returnDataConformanceVectors_passed,
+    SignedArithmeticStackExecution.signedArithmeticConformanceVectors_passed,
+    StorageStackExecution.storageStackConformanceVectors_passed,
+    TerminatingStackExecution.terminatingStackConformanceVectors_passed]
 
 theorem successfulConformanceResultCount_eq :
-    successfulConformanceResultCount = 41 := by
-  native_decide
+    successfulConformanceResultCount = 42 := by
+  simp [successfulConformanceResultCount, successfulConformanceResults,
+    allConformanceVectors,
+    Call.callOutputConformanceVectors_passed,
+    Calldata.calldataConformanceVectors_passed,
+    Code.codeConformanceVectors_passed,
+    CreateStackExecution.createStackConformanceVectors_passed,
+    ExpGas.expGasConformanceVectors_passed,
+    ExpStackExecution.expStackConformanceVectors_passed,
+    KeccakStackExecution.keccakStackConformanceVectors_passed,
+    Log.logDataConformanceVectors_passed,
+    LogStackExecution.logStackConformanceVectors_passed,
+    RLP.rlpConformanceVectors_passed,
+    ReturnData.returnDataConformanceVectors_passed,
+    SignedArithmeticStackExecution.signedArithmeticConformanceVectors_passed,
+    StorageStackExecution.storageStackConformanceVectors_passed,
+    TerminatingStackExecution.terminatingStackConformanceVectors_passed]
 
 end Conformance
 end EvmAsm.EL

--- a/EvmAsm/EL/Conformance/All.lean
+++ b/EvmAsm/EL/Conformance/All.lean
@@ -44,11 +44,11 @@ def allConformanceVectorCount : Nat :=
   allConformanceVectors.length
 
 theorem allConformanceVectors_length :
-    allConformanceVectors.length = 49 := by
+    allConformanceVectors.length = 50 := by
   native_decide
 
 theorem allConformanceVectorCount_eq :
-    allConformanceVectorCount = 49 := by
+    allConformanceVectorCount = 50 := by
   native_decide
 
 def unexpectedConformanceFailures : List CheckResult :=

--- a/EvmAsm/EL/Conformance/All.lean
+++ b/EvmAsm/EL/Conformance/All.lean
@@ -44,11 +44,11 @@ def allConformanceVectorCount : Nat :=
   allConformanceVectors.length
 
 theorem allConformanceVectors_length :
-    allConformanceVectors.length = 47 := by
+    allConformanceVectors.length = 48 := by
   native_decide
 
 theorem allConformanceVectorCount_eq :
-    allConformanceVectorCount = 47 := by
+    allConformanceVectorCount = 48 := by
   native_decide
 
 def unexpectedConformanceFailures : List CheckResult :=

--- a/EvmAsm/EL/Conformance/All.lean
+++ b/EvmAsm/EL/Conformance/All.lean
@@ -44,11 +44,11 @@ def allConformanceVectorCount : Nat :=
   allConformanceVectors.length
 
 theorem allConformanceVectors_length :
-    allConformanceVectors.length = 49 := by
+    allConformanceVectors.length = 50 := by
   native_decide
 
 theorem allConformanceVectorCount_eq :
-    allConformanceVectorCount = 49 := by
+    allConformanceVectorCount = 50 := by
   native_decide
 
 def unexpectedConformanceFailures : List CheckResult :=
@@ -115,7 +115,7 @@ theorem expectedConformanceErrorCount_eq :
   native_decide
 
 theorem successfulConformanceResultCount_eq :
-    successfulConformanceResultCount = 39 := by
+    successfulConformanceResultCount = 40 := by
   native_decide
 
 end Conformance

--- a/EvmAsm/EL/Conformance/All.lean
+++ b/EvmAsm/EL/Conformance/All.lean
@@ -44,11 +44,11 @@ def allConformanceVectorCount : Nat :=
   allConformanceVectors.length
 
 theorem allConformanceVectors_length :
-    allConformanceVectors.length = 51 := by
+    allConformanceVectors.length = 52 := by
   native_decide
 
 theorem allConformanceVectorCount_eq :
-    allConformanceVectorCount = 51 := by
+    allConformanceVectorCount = 52 := by
   native_decide
 
 def unexpectedConformanceFailures : List CheckResult :=
@@ -115,7 +115,7 @@ theorem expectedConformanceErrorCount_eq :
   native_decide
 
 theorem successfulConformanceResultCount_eq :
-    successfulConformanceResultCount = 41 := by
+    successfulConformanceResultCount = 42 := by
   native_decide
 
 end Conformance

--- a/EvmAsm/EL/Conformance/All.lean
+++ b/EvmAsm/EL/Conformance/All.lean
@@ -44,11 +44,11 @@ def allConformanceVectorCount : Nat :=
   allConformanceVectors.length
 
 theorem allConformanceVectors_length :
-    allConformanceVectors.length = 54 := by
+    allConformanceVectors.length = 55 := by
   native_decide
 
 theorem allConformanceVectorCount_eq :
-    allConformanceVectorCount = 54 := by
+    allConformanceVectorCount = 55 := by
   native_decide
 
 def unexpectedConformanceFailures : List CheckResult :=
@@ -115,7 +115,7 @@ theorem expectedConformanceErrorCount_eq :
   native_decide
 
 theorem successfulConformanceResultCount_eq :
-    successfulConformanceResultCount = 44 := by
+    successfulConformanceResultCount = 45 := by
   native_decide
 
 end Conformance

--- a/EvmAsm/EL/Conformance/All.lean
+++ b/EvmAsm/EL/Conformance/All.lean
@@ -115,7 +115,7 @@ theorem expectedConformanceErrorCount_eq :
   native_decide
 
 theorem successfulConformanceResultCount_eq :
-    successfulConformanceResultCount = 39 := by
+    successfulConformanceResultCount = 40 := by
   native_decide
 
 end Conformance

--- a/EvmAsm/EL/Conformance/All.lean
+++ b/EvmAsm/EL/Conformance/All.lean
@@ -44,11 +44,11 @@ def allConformanceVectorCount : Nat :=
   allConformanceVectors.length
 
 theorem allConformanceVectors_length :
-    allConformanceVectors.length = 45 := by
+    allConformanceVectors.length = 47 := by
   native_decide
 
 theorem allConformanceVectorCount_eq :
-    allConformanceVectorCount = 45 := by
+    allConformanceVectorCount = 47 := by
   native_decide
 
 def unexpectedConformanceFailures : List CheckResult :=

--- a/EvmAsm/EL/Conformance/All.lean
+++ b/EvmAsm/EL/Conformance/All.lean
@@ -44,11 +44,11 @@ def allConformanceVectorCount : Nat :=
   allConformanceVectors.length
 
 theorem allConformanceVectors_length :
-    allConformanceVectors.length = 48 := by
+    allConformanceVectors.length = 49 := by
   native_decide
 
 theorem allConformanceVectorCount_eq :
-    allConformanceVectorCount = 48 := by
+    allConformanceVectorCount = 49 := by
   native_decide
 
 def unexpectedConformanceFailures : List CheckResult :=

--- a/EvmAsm/EL/Conformance/CreateStackExecution.lean
+++ b/EvmAsm/EL/Conformance/CreateStackExecution.lean
@@ -32,6 +32,7 @@ def readByteAt (memory : List Byte) (addr : Nat) : Byte :=
   memory.getD addr 0
 
 def deployedAddress : Address := 0x1234
+def create2DeployedAddress : Address := 0x5678
 
 def vectorExecutor (request : CreateRequest) : CreateResult :=
   if request.kind = .create ∧ request.initcode = [(0xbb : Byte), 0xcc] ∧
@@ -41,6 +42,13 @@ def vectorExecutor (request : CreateRequest) : CreateResult :=
       state := WorldState.empty
       returndata := []
       gasRemaining := 300 }
+  else if request.kind = .create2 ∧ request.initcode = [(0xbb : Byte), 0xcc] ∧
+      request.value = 11 ∧ request.gas = 654 ∧ request.salt? = some 0x55 then
+    { status := .deployed
+      address? := some create2DeployedAddress
+      state := WorldState.empty
+      returndata := []
+      gasRemaining := 600 }
   else
     { status := .failed
       address? := none
@@ -64,24 +72,38 @@ def createStackVector : TestVector CreateStackInput CreateStackState :=
     expected :=
       .value { stack := [(deployedAddress.zeroExtend 256 : EvmWord), 99] } }
 
+/-- CREATE2 consumes its salt operand and pushes the deployed address.
+    Distinctive token: create2StackConformanceVector #115 #125. -/
+def create2StackConformanceVector : TestVector CreateStackInput CreateStackState :=
+  { id := "create2-stack-execution"
+    input :=
+      { kind := .create2
+        creator := 0xabcd
+        memory := [(0xaa : Byte), 0xbb, 0xcc]
+        gas := 654
+        stackState := { stack := [(11 : EvmWord), 1, 2, 0x55, 88] } }
+    expected :=
+      .value { stack := [(create2DeployedAddress.zeroExtend 256 : EvmWord), 88] } }
+
 /-- CREATE stack conformance inputs as reusable test vectors.
     Distinctive token:
     CreateStackExecutionConformance.createStackConformanceTestVectors #115 #125. -/
 def createStackConformanceTestVectors :
     List (TestVector CreateStackInput CreateStackState) :=
-  [createStackVector]
+  [createStackVector, create2StackConformanceVector]
 
 def createStackConformanceVectorIds : List String :=
   createStackConformanceTestVectors.map TestVector.id
 
 theorem createStackConformanceTestVectors_length :
-    createStackConformanceTestVectors.length = 1 := rfl
+    createStackConformanceTestVectors.length = 2 := rfl
 
 theorem createStackConformanceVectorIds_eq :
-    createStackConformanceVectorIds = ["create-stack-execution"] := rfl
+    createStackConformanceVectorIds =
+      ["create-stack-execution", "create2-stack-execution"] := rfl
 
 theorem createStackConformanceVectorIds_length :
-    createStackConformanceVectorIds.length = 1 := rfl
+    createStackConformanceVectorIds.length = 2 := rfl
 
 theorem createStackConformanceVectorIds_nodup :
     createStackConformanceVectorIds.Nodup := by
@@ -109,6 +131,28 @@ theorem createStackVector_passed :
     { stack := [(deployedAddress.zeroExtend 256 : EvmWord), 99] }
     runCreateStackVector?_create
 
+theorem runCreateStackVector?_create2 :
+    runCreateStackVector?
+      { kind := .create2
+        creator := (0xabcd : Address)
+        memory := [(0xaa : Byte), 0xbb, 0xcc]
+        gas := (654 : EvmWord)
+        stackState := { stack := [(11 : EvmWord), 1, 2, 0x55, 88] } } =
+      some { stack := [(create2DeployedAddress.zeroExtend 256 : EvmWord), 88] } := by
+  native_decide
+
+theorem create2StackConformanceVector_passed :
+    checkVector? runCreateStackVector? create2StackConformanceVector = .passed :=
+  checkVector?_some_passed runCreateStackVector?
+    "create2-stack-execution"
+    { kind := .create2
+      creator := (0xabcd : Address)
+      memory := [(0xaa : Byte), 0xbb, 0xcc]
+      gas := (654 : EvmWord)
+      stackState := { stack := [(11 : EvmWord), 1, 2, 0x55, 88] } }
+    { stack := [(create2DeployedAddress.zeroExtend 256 : EvmWord), 88] }
+    runCreateStackVector?_create2
+
 /-- Compact checked-vector batch for CREATE stack execution.
     Distinctive token:
     CreateStackExecutionConformance.createStackConformanceVectors #115 #125. -/
@@ -116,9 +160,9 @@ def createStackConformanceVectors : List CheckResult :=
   checkBatch? runCreateStackVector? createStackConformanceTestVectors
 
 theorem createStackConformanceVectors_passed :
-    createStackConformanceVectors = [.passed] := by
+    createStackConformanceVectors = [.passed, .passed] := by
   simp [createStackConformanceVectors, createStackConformanceTestVectors,
-    createStackVector_passed]
+    createStackVector_passed, create2StackConformanceVector_passed]
 
 end CreateStackExecution
 end Conformance

--- a/EvmAsm/EL/Conformance/ExpStackExecution.lean
+++ b/EvmAsm/EL/Conformance/ExpStackExecution.lean
@@ -65,6 +65,17 @@ def expStackOneExponentVector : TestVector ExpStackState ExpStackResult :=
               totalGas := 60 }
           stack := [99] } }
 
+def expStackZeroMaxExponentVector : TestVector ExpStackState ExpStackResult :=
+  { id := "exp-stack-zero-max-exponent"
+    input := { stack := [0, (-1 : EvmWord), 99] }
+    expected :=
+      .value
+        { effects :=
+            { stackWords := [0]
+              dynamicGas := 1600
+              totalGas := 1610 }
+          stack := [99] } }
+
 def expStackUnderflowVector : TestVector ExpStackState ExpStackResult :=
   { id := "exp-stack-underflow"
     input := { stack := [2] }
@@ -77,6 +88,7 @@ def expStackConformanceTestVectors : List (TestVector ExpStackState ExpStackResu
   [ expStackValueVector
   , expStackZeroZeroVector
   , expStackOneExponentVector
+  , expStackZeroMaxExponentVector
   , expStackUnderflowVector
   ]
 
@@ -84,25 +96,30 @@ def expStackConformanceVectorIds : List String :=
   expStackConformanceTestVectors.map TestVector.id
 
 theorem expStackConformanceTestVectors_length :
-    expStackConformanceTestVectors.length = 4 := rfl
+    expStackConformanceTestVectors.length = 5 := rfl
 
 theorem expStackConformanceVectorIds_eq :
     expStackConformanceVectorIds =
       [ "exp-stack-value"
       , "exp-stack-zero-zero"
       , "exp-stack-one-exponent"
+      , "exp-stack-zero-max-exponent"
       , "exp-stack-underflow"
       ] := rfl
 
 theorem expStackConformanceVectorIds_length :
-    expStackConformanceVectorIds.length = 4 := rfl
+    expStackConformanceVectorIds.length = 5 := rfl
 
 theorem expStackConformanceVectorIds_nodup :
     expStackConformanceVectorIds.Nodup := by
   decide
 
 def expStackValueVectorIds : List String :=
-  ["exp-stack-value", "exp-stack-zero-zero", "exp-stack-one-exponent"]
+  [ "exp-stack-value"
+  , "exp-stack-zero-zero"
+  , "exp-stack-one-exponent"
+  , "exp-stack-zero-max-exponent"
+  ]
 
 def expStackErrorVectorIds : List String :=
   ["exp-stack-underflow"]
@@ -149,6 +166,18 @@ theorem runExpStack?_one_exponent :
           stack := [(99 : EvmWord)] } := by
   native_decide
 
+theorem runExpStack?_zero_max_exponent :
+    runExpStack?
+        { stack := [(0 : EvmWord), (-1 : EvmWord), (99 : EvmWord)] } =
+      some
+        { effects :=
+            { stackWords := [(0 : EvmWord)]
+              dynamicGas := 1600
+              totalGas := 1610 }
+          stack := [(99 : EvmWord)] } := by
+  exact EvmAsm.Evm64.ExpStackExecutionBridge.runExpStack?_zero_max_exponent
+    [(99 : EvmWord)]
+
 theorem runExpStack?_underflow :
     runExpStack? { stack := [(2 : EvmWord)] } = none := rfl
 
@@ -188,6 +217,18 @@ theorem expStackOneExponentVector_passed :
       stack := [(99 : EvmWord)] }
     runExpStack?_one_exponent
 
+theorem expStackZeroMaxExponentVector_passed :
+    checkVector? runExpStack? expStackZeroMaxExponentVector = .passed :=
+  checkVector?_some_passed runExpStack?
+    "exp-stack-zero-max-exponent"
+    { stack := [(0 : EvmWord), (-1 : EvmWord), (99 : EvmWord)] }
+    { effects :=
+        { stackWords := [(0 : EvmWord)]
+          dynamicGas := 1600
+          totalGas := 1610 }
+      stack := [(99 : EvmWord)] }
+    runExpStack?_zero_max_exponent
+
 theorem expStackUnderflowVector_passed :
     checkVector? runExpStack? expStackUnderflowVector =
       .errored "exp-stack-underflow" "stack-underflow" :=
@@ -204,10 +245,16 @@ def expStackConformanceVectors : List CheckResult :=
 
 theorem expStackConformanceVectors_passed :
     expStackConformanceVectors =
-      [.passed, .passed, .passed, .errored "exp-stack-underflow" "stack-underflow"] := by
+      [ .passed
+      , .passed
+      , .passed
+      , .passed
+      , .errored "exp-stack-underflow" "stack-underflow"
+      ] := by
   simp [expStackConformanceVectors, expStackConformanceTestVectors,
     expStackValueVector_passed, expStackZeroZeroVector_passed,
-    expStackOneExponentVector_passed, expStackUnderflowVector_passed]
+    expStackOneExponentVector_passed,
+    expStackZeroMaxExponentVector_passed, expStackUnderflowVector_passed]
 
 end ExpStackExecution
 end Conformance

--- a/EvmAsm/EL/Conformance/ExpStackExecution.lean
+++ b/EvmAsm/EL/Conformance/ExpStackExecution.lean
@@ -52,6 +52,19 @@ def expStackZeroZeroVector : TestVector ExpStackState ExpStackResult :=
               totalGas := 10 }
           stack := [99] } }
 
+/-- EXP with max base and zero exponent returns one with no dynamic gas.
+    Distinctive token: exp-stack-max-zero-exponent #92 #125. -/
+def expStackMaxZeroExponentVector : TestVector ExpStackState ExpStackResult :=
+  { id := "exp-stack-max-zero-exponent"
+    input := { stack := [(-1 : EvmWord), 0, 99] }
+    expected :=
+      .value
+        { effects :=
+            { stackWords := [1]
+              dynamicGas := 0
+              totalGas := 10 }
+          stack := [99] } }
+
 /-- EXP with exponent one returns the base word.
     Distinctive token: expStackOneExponentVector #92 #125. -/
 def expStackOneExponentVector : TestVector ExpStackState ExpStackResult :=
@@ -76,6 +89,7 @@ def expStackUnderflowVector : TestVector ExpStackState ExpStackResult :=
 def expStackConformanceTestVectors : List (TestVector ExpStackState ExpStackResult) :=
   [ expStackValueVector
   , expStackZeroZeroVector
+  , expStackMaxZeroExponentVector
   , expStackOneExponentVector
   , expStackUnderflowVector
   ]
@@ -84,25 +98,30 @@ def expStackConformanceVectorIds : List String :=
   expStackConformanceTestVectors.map TestVector.id
 
 theorem expStackConformanceTestVectors_length :
-    expStackConformanceTestVectors.length = 4 := rfl
+    expStackConformanceTestVectors.length = 5 := rfl
 
 theorem expStackConformanceVectorIds_eq :
     expStackConformanceVectorIds =
       [ "exp-stack-value"
       , "exp-stack-zero-zero"
+      , "exp-stack-max-zero-exponent"
       , "exp-stack-one-exponent"
       , "exp-stack-underflow"
       ] := rfl
 
 theorem expStackConformanceVectorIds_length :
-    expStackConformanceVectorIds.length = 4 := rfl
+    expStackConformanceVectorIds.length = 5 := rfl
 
 theorem expStackConformanceVectorIds_nodup :
     expStackConformanceVectorIds.Nodup := by
   decide
 
 def expStackValueVectorIds : List String :=
-  ["exp-stack-value", "exp-stack-zero-zero", "exp-stack-one-exponent"]
+  [ "exp-stack-value"
+  , "exp-stack-zero-zero"
+  , "exp-stack-max-zero-exponent"
+  , "exp-stack-one-exponent"
+  ]
 
 def expStackErrorVectorIds : List String :=
   ["exp-stack-underflow"]
@@ -138,6 +157,26 @@ theorem runExpStack?_zero_zero :
               totalGas := 10 }
           stack := [(99 : EvmWord)] } := by
   native_decide
+
+theorem runExpStack?_max_zero_exponent :
+    runExpStack?
+        { stack := [(-1 : EvmWord), (0 : EvmWord), (99 : EvmWord)] } =
+      some
+        { effects :=
+            { stackWords := [(1 : EvmWord)]
+              dynamicGas := 0
+              totalGas := 10 }
+          stack := [(99 : EvmWord)] } := by
+  change EvmAsm.Evm64.ExpStackExecutionBridge.runExpStack?
+      { stack := [(-1 : EvmWord), (0 : EvmWord), (99 : EvmWord)] } =
+    some
+      { effects :=
+          { stackWords := [(1 : EvmWord)]
+            dynamicGas := 0
+            totalGas := 10 }
+        stack := [(99 : EvmWord)] }
+  exact EvmAsm.Evm64.ExpStackExecutionBridge.runExpStack?_max_zero_exponent
+    [(99 : EvmWord)]
 
 theorem runExpStack?_one_exponent :
     runExpStack? { stack := [(7 : EvmWord), (1 : EvmWord), (99 : EvmWord)] } =
@@ -176,6 +215,18 @@ theorem expStackZeroZeroVector_passed :
       stack := [(99 : EvmWord)] }
     runExpStack?_zero_zero
 
+theorem expStackMaxZeroExponentVector_passed :
+    checkVector? runExpStack? expStackMaxZeroExponentVector = .passed :=
+  checkVector?_some_passed runExpStack?
+    "exp-stack-max-zero-exponent"
+    { stack := [(-1 : EvmWord), (0 : EvmWord), (99 : EvmWord)] }
+    { effects :=
+        { stackWords := [(1 : EvmWord)]
+          dynamicGas := 0
+          totalGas := 10 }
+      stack := [(99 : EvmWord)] }
+    runExpStack?_max_zero_exponent
+
 theorem expStackOneExponentVector_passed :
     checkVector? runExpStack? expStackOneExponentVector = .passed :=
   checkVector?_some_passed runExpStack?
@@ -204,10 +255,16 @@ def expStackConformanceVectors : List CheckResult :=
 
 theorem expStackConformanceVectors_passed :
     expStackConformanceVectors =
-      [.passed, .passed, .passed, .errored "exp-stack-underflow" "stack-underflow"] := by
+      [ .passed
+      , .passed
+      , .passed
+      , .passed
+      , .errored "exp-stack-underflow" "stack-underflow"
+      ] := by
   simp [expStackConformanceVectors, expStackConformanceTestVectors,
     expStackValueVector_passed, expStackZeroZeroVector_passed,
-    expStackOneExponentVector_passed, expStackUnderflowVector_passed]
+    expStackMaxZeroExponentVector_passed, expStackOneExponentVector_passed,
+    expStackUnderflowVector_passed]
 
 end ExpStackExecution
 end Conformance

--- a/EvmAsm/EL/Conformance/ExpStackExecution.lean
+++ b/EvmAsm/EL/Conformance/ExpStackExecution.lean
@@ -65,6 +65,19 @@ def expStackOneExponentVector : TestVector ExpStackState ExpStackResult :=
               totalGas := 60 }
           stack := [99] } }
 
+/-- EXP edge vector required by GH #92: `2^256 = 0 mod 2^256`.
+    Distinctive token: expStackTwo256Vector #92 #125. -/
+def expStackTwo256Vector : TestVector ExpStackState ExpStackResult :=
+  { id := "exp-stack-two-256"
+    input := { stack := [2, 256, 99] }
+    expected :=
+      .value
+        { effects :=
+            { stackWords := [0]
+              dynamicGas := 100
+              totalGas := 110 }
+          stack := [99] } }
+
 def expStackUnderflowVector : TestVector ExpStackState ExpStackResult :=
   { id := "exp-stack-underflow"
     input := { stack := [2] }
@@ -77,6 +90,7 @@ def expStackConformanceTestVectors : List (TestVector ExpStackState ExpStackResu
   [ expStackValueVector
   , expStackZeroZeroVector
   , expStackOneExponentVector
+  , expStackTwo256Vector
   , expStackUnderflowVector
   ]
 
@@ -84,25 +98,30 @@ def expStackConformanceVectorIds : List String :=
   expStackConformanceTestVectors.map TestVector.id
 
 theorem expStackConformanceTestVectors_length :
-    expStackConformanceTestVectors.length = 4 := rfl
+    expStackConformanceTestVectors.length = 5 := rfl
 
 theorem expStackConformanceVectorIds_eq :
     expStackConformanceVectorIds =
       [ "exp-stack-value"
       , "exp-stack-zero-zero"
       , "exp-stack-one-exponent"
+      , "exp-stack-two-256"
       , "exp-stack-underflow"
       ] := rfl
 
 theorem expStackConformanceVectorIds_length :
-    expStackConformanceVectorIds.length = 4 := rfl
+    expStackConformanceVectorIds.length = 5 := rfl
 
 theorem expStackConformanceVectorIds_nodup :
     expStackConformanceVectorIds.Nodup := by
   decide
 
 def expStackValueVectorIds : List String :=
-  ["exp-stack-value", "exp-stack-zero-zero", "exp-stack-one-exponent"]
+  [ "exp-stack-value"
+  , "exp-stack-zero-zero"
+  , "exp-stack-one-exponent"
+  , "exp-stack-two-256"
+  ]
 
 def expStackErrorVectorIds : List String :=
   ["exp-stack-underflow"]
@@ -149,6 +168,16 @@ theorem runExpStack?_one_exponent :
           stack := [(99 : EvmWord)] } := by
   native_decide
 
+theorem runExpStack?_two_256 :
+    runExpStack? { stack := [(2 : EvmWord), (256 : EvmWord), (99 : EvmWord)] } =
+      some
+        { effects :=
+            { stackWords := [(0 : EvmWord)]
+              dynamicGas := 100
+              totalGas := 110 }
+          stack := [(99 : EvmWord)] } := by
+  exact EvmAsm.Evm64.ExpStackExecutionBridge.runExpStack?_two_256 [(99 : EvmWord)]
+
 theorem runExpStack?_underflow :
     runExpStack? { stack := [(2 : EvmWord)] } = none := rfl
 
@@ -188,6 +217,18 @@ theorem expStackOneExponentVector_passed :
       stack := [(99 : EvmWord)] }
     runExpStack?_one_exponent
 
+theorem expStackTwo256Vector_passed :
+    checkVector? runExpStack? expStackTwo256Vector = .passed :=
+  checkVector?_some_passed runExpStack?
+    "exp-stack-two-256"
+    { stack := [(2 : EvmWord), (256 : EvmWord), (99 : EvmWord)] }
+    { effects :=
+        { stackWords := [(0 : EvmWord)]
+          dynamicGas := 100
+          totalGas := 110 }
+      stack := [(99 : EvmWord)] }
+    runExpStack?_two_256
+
 theorem expStackUnderflowVector_passed :
     checkVector? runExpStack? expStackUnderflowVector =
       .errored "exp-stack-underflow" "stack-underflow" :=
@@ -204,10 +245,11 @@ def expStackConformanceVectors : List CheckResult :=
 
 theorem expStackConformanceVectors_passed :
     expStackConformanceVectors =
-      [.passed, .passed, .passed, .errored "exp-stack-underflow" "stack-underflow"] := by
+      [.passed, .passed, .passed, .passed, .errored "exp-stack-underflow" "stack-underflow"] := by
   simp [expStackConformanceVectors, expStackConformanceTestVectors,
     expStackValueVector_passed, expStackZeroZeroVector_passed,
-    expStackOneExponentVector_passed, expStackUnderflowVector_passed]
+    expStackOneExponentVector_passed, expStackTwo256Vector_passed,
+    expStackUnderflowVector_passed]
 
 end ExpStackExecution
 end Conformance

--- a/EvmAsm/EL/Conformance/LogStackExecution.lean
+++ b/EvmAsm/EL/Conformance/LogStackExecution.lean
@@ -109,6 +109,32 @@ def logStackLog2Vector : TestVector LogStackInput LogStackState :=
               touchedAccounts := [] }
           stack := [(77 : EvmWord)] } }
 
+/-- LOG3 appends a log entry with three topics and consumes offset/size/topics.
+    Distinctive token: logStackLog3Vector #112 #125. -/
+def logStackLog3Vector : TestVector LogStackInput LogStackState :=
+  { id := "log-stack-log3"
+    input :=
+      { kind := .log3
+        emitter := 0x3456
+        memory := [(0xaa : Byte), 0xbb, 0xcc, 0xdd, 0xee]
+        state :=
+          { effects := EvmAsm.EL.MessageCallExecution.CallSideEffects.empty
+            stack := [(2 : EvmWord), 3, 0x111, 0x222, 0x333, 88] } }
+    expected :=
+      .value
+        { effects :=
+            { refundCounter := 0
+              logs :=
+                { entries :=
+                    [ { emitter := 0x3456
+                        topics :=
+                          [(0x111 : EvmWord), (0x222 : EvmWord),
+                           (0x333 : EvmWord)]
+                        data := [(0xcc : Byte), 0xdd, 0xee] } ] }
+              accountsToDelete := []
+              touchedAccounts := [] }
+          stack := [(88 : EvmWord)] } }
+
 def logStackLog4Vector : TestVector LogStackInput LogStackState :=
   { id := "log-stack-log4"
     input :=
@@ -141,6 +167,7 @@ def logStackConformanceTestVectors : List (TestVector LogStackInput LogStackStat
   [ log0StackConformanceVector
   , logStackVector
   , logStackLog2Vector
+  , logStackLog3Vector
   , logStackLog4Vector
   ]
 
@@ -148,14 +175,14 @@ def logStackConformanceVectorIds : List String :=
   logStackConformanceTestVectors.map TestVector.id
 
 theorem logStackConformanceTestVectors_length :
-    logStackConformanceTestVectors.length = 4 := rfl
+    logStackConformanceTestVectors.length = 5 := rfl
 
 theorem logStackConformanceVectorIds_eq :
     logStackConformanceVectorIds =
-      ["log-stack-log0", "log-stack-log1", "log-stack-log2", "log-stack-log4"] := rfl
+      ["log-stack-log0", "log-stack-log1", "log-stack-log2", "log-stack-log3", "log-stack-log4"] := rfl
 
 theorem logStackConformanceVectorIds_length :
-    logStackConformanceVectorIds.length = 4 := rfl
+    logStackConformanceVectorIds.length = 5 := rfl
 
 theorem logStackConformanceVectorIds_nodup :
     logStackConformanceVectorIds.Nodup := by
@@ -220,6 +247,28 @@ theorem runLogStack?_log2_vector :
               accountsToDelete := []
               touchedAccounts := [] }
           stack := [(77 : EvmWord)] } := rfl
+
+theorem runLogStack?_log3_vector :
+    runLogStack?
+      { kind := .log3
+        emitter := (0x3456 : Address)
+        memory := [(0xaa : Byte), 0xbb, 0xcc, 0xdd, 0xee]
+        state :=
+          { effects := EvmAsm.EL.MessageCallExecution.CallSideEffects.empty
+            stack := [(2 : EvmWord), 3, 0x111, 0x222, 0x333, 88] } } =
+      some
+        { effects :=
+            { refundCounter := 0
+              logs :=
+                { entries :=
+                    [ { emitter := (0x3456 : Address)
+                        topics :=
+                          [(0x111 : EvmWord), (0x222 : EvmWord),
+                           (0x333 : EvmWord)]
+                        data := [(0xcc : Byte), 0xdd, 0xee] } ] }
+              accountsToDelete := []
+              touchedAccounts := [] }
+          stack := [(88 : EvmWord)] } := rfl
 
 theorem runLogStack?_log4_vector :
     runLogStack?
@@ -310,6 +359,30 @@ theorem logStackLog2Vector_passed :
       stack := [(77 : EvmWord)] }
     runLogStack?_log2_vector
 
+theorem logStackLog3Vector_passed :
+    checkVector? runLogStack? logStackLog3Vector = .passed :=
+  checkVector?_some_passed runLogStack?
+    "log-stack-log3"
+    { kind := .log3
+      emitter := (0x3456 : Address)
+      memory := [(0xaa : Byte), 0xbb, 0xcc, 0xdd, 0xee]
+      state :=
+        { effects := EvmAsm.EL.MessageCallExecution.CallSideEffects.empty
+          stack := [(2 : EvmWord), 3, 0x111, 0x222, 0x333, 88] } }
+    { effects :=
+        { refundCounter := 0
+          logs :=
+            { entries :=
+                [ { emitter := (0x3456 : Address)
+                    topics :=
+                      [(0x111 : EvmWord), (0x222 : EvmWord),
+                       (0x333 : EvmWord)]
+                    data := [(0xcc : Byte), 0xdd, 0xee] } ] }
+          accountsToDelete := []
+          touchedAccounts := [] }
+      stack := [(88 : EvmWord)] }
+    runLogStack?_log3_vector
+
 theorem logStackLog4Vector_passed :
     checkVector? runLogStack? logStackLog4Vector = .passed :=
   checkVector?_some_passed runLogStack?
@@ -342,10 +415,11 @@ def logStackConformanceVectors : List CheckResult :=
   checkBatch? runLogStack? logStackConformanceTestVectors
 
 theorem logStackConformanceVectors_passed :
-    logStackConformanceVectors = [.passed, .passed, .passed, .passed] := by
+    logStackConformanceVectors = [.passed, .passed, .passed, .passed, .passed] := by
   simp [logStackConformanceVectors, logStackConformanceTestVectors,
     log0StackConformanceVector_passed, logStackVector_passed,
-    logStackLog2Vector_passed, logStackLog4Vector_passed]
+    logStackLog2Vector_passed, logStackLog3Vector_passed,
+    logStackLog4Vector_passed]
 
 end LogStackExecution
 end Conformance

--- a/EvmAsm/EL/Conformance/TerminatingStackExecution.lean
+++ b/EvmAsm/EL/Conformance/TerminatingStackExecution.lean
@@ -63,25 +63,42 @@ def terminatingReturnVector :
           gasRemaining := 123
           stack := [(99 : EvmWord)] } }
 
+/-- REVERT threads memory data through while exposing reverted status.
+    Distinctive token: terminatingRevertStackConformanceVector #113 #125. -/
+def terminatingRevertStackConformanceVector :
+    TestVector TerminatingStackInput TerminatingVisibleResult :=
+  { id := "terminating-stack-revert"
+    input :=
+      { kind := .revert
+        memory := [(0xaa : Byte), 0xbb, 0xcc]
+        gasRemaining := 45
+        stackState := { stack := [(1 : EvmWord), 2, 77] } }
+    expected :=
+      .value
+        { status := .revert
+          output := [(0xbb : Byte), 0xcc]
+          gasRemaining := 45
+          stack := [(77 : EvmWord)] } }
+
 /-- Terminating stack conformance inputs as reusable test vectors.
     Distinctive token:
     TerminatingStackExecutionConformance.terminatingStackConformanceTestVectors #113 #125. -/
 def terminatingStackConformanceTestVectors :
     List (TestVector TerminatingStackInput TerminatingVisibleResult) :=
-  [terminatingReturnVector]
+  [terminatingReturnVector, terminatingRevertStackConformanceVector]
 
 def terminatingStackConformanceVectorIds : List String :=
   terminatingStackConformanceTestVectors.map TestVector.id
 
 theorem terminatingStackConformanceTestVectors_length :
-    terminatingStackConformanceTestVectors.length = 1 := rfl
+    terminatingStackConformanceTestVectors.length = 2 := rfl
 
 theorem terminatingStackConformanceVectorIds_eq :
     terminatingStackConformanceVectorIds =
-      ["terminating-stack-return"] := rfl
+      ["terminating-stack-return", "terminating-stack-revert"] := rfl
 
 theorem terminatingStackConformanceVectorIds_length :
-    terminatingStackConformanceVectorIds.length = 1 := rfl
+    terminatingStackConformanceVectorIds.length = 2 := rfl
 
 theorem terminatingStackConformanceVectorIds_nodup :
     terminatingStackConformanceVectorIds.Nodup := by
@@ -114,6 +131,34 @@ theorem terminatingReturnVector_passed :
       stack := [(99 : EvmWord)] }
     runTerminatingStackVisible?_return
 
+theorem runTerminatingStackVisible?_revert :
+    runTerminatingStackVisible?
+      { kind := .revert
+        memory := [(0xaa : Byte), 0xbb, 0xcc]
+        gasRemaining := 45
+        stackState := { stack := [(1 : EvmWord), 2, 77] } } =
+      some
+        { status := .revert
+          output := [(0xbb : Byte), 0xcc]
+          gasRemaining := 45
+          stack := [(77 : EvmWord)] } := by
+  native_decide
+
+theorem terminatingRevertStackConformanceVector_passed :
+    checkVector? runTerminatingStackVisible? terminatingRevertStackConformanceVector =
+      .passed :=
+  checkVector?_some_passed runTerminatingStackVisible?
+    "terminating-stack-revert"
+    { kind := .revert
+      memory := [(0xaa : Byte), 0xbb, 0xcc]
+      gasRemaining := 45
+      stackState := { stack := [(1 : EvmWord), 2, 77] } }
+    { status := .revert
+      output := [(0xbb : Byte), 0xcc]
+      gasRemaining := 45
+      stack := [(77 : EvmWord)] }
+    runTerminatingStackVisible?_revert
+
 /-- Compact checked-vector batch for terminating stack execution.
     Distinctive token:
     TerminatingStackExecutionConformance.terminatingStackConformanceVectors #113 #125. -/
@@ -121,9 +166,9 @@ def terminatingStackConformanceVectors : List CheckResult :=
   checkBatch? runTerminatingStackVisible? terminatingStackConformanceTestVectors
 
 theorem terminatingStackConformanceVectors_passed :
-    terminatingStackConformanceVectors = [.passed] := by
+    terminatingStackConformanceVectors = [.passed, .passed] := by
   simp [terminatingStackConformanceVectors, terminatingStackConformanceTestVectors,
-    terminatingReturnVector_passed]
+    terminatingReturnVector_passed, terminatingRevertStackConformanceVector_passed]
 
 end TerminatingStackExecution
 end Conformance

--- a/EvmAsm/Evm64/DivMod/Compose/Epilogue.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Epilogue.lean
@@ -94,22 +94,74 @@ theorem divK_denorm_preamble_spec_within (sp shift v5 v6 v7 v2 v10 : Word) (base
   cpsTripleWithin_extend_code (hmono := divCode_noNop_sub_divCode)
     (divK_denorm_preamble_spec_within_noNop sp shift v5 v6 v7 v2 v10 base hshift_nz)
 
-theorem divK_denorm_body_spec_within_noNop (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Word) :
-    let antiShift := signExtend12 (0 : BitVec 12) - shift
-    let u0' := (u0 >>> (shift.toNat % 64)) ||| (u1 <<< (antiShift.toNat % 64))
-    let u1' := (u1 >>> (shift.toNat % 64)) ||| (u2 <<< (antiShift.toNat % 64))
-    let u2' := (u2 >>> (shift.toNat % 64)) ||| (u3 <<< (antiShift.toNat % 64))
-    let u3' := u3 >>> (shift.toNat % 64)
-    cpsTripleWithin 23 (base + denormOff + 8) (base + epilogueOff) (divCode_noNop base)
+/-- Precondition for the DIV denorm body (post-preamble): the four
+    normalized `u[]` slots, the shift held in x6, x2 holding scratch, and
+    the standard x12/x5/x7/x0 frame. Wrapped `@[irreducible]` so
+    downstream proofs do not re-reduce the 10-atom sepConj at each use
+    site. -/
+@[irreducible]
+def divKDenormBodyPre (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) : Assertion :=
+  (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) **
+  (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) **
+  ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
+  ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3)
+
+theorem divKDenormBodyPre_unfold
+    {sp u0 u1 u2 u3 v2 v5 v7 shift : Word} :
+    divKDenormBodyPre sp u0 u1 u2 u3 v2 v5 v7 shift =
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) **
        (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) **
-       ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
-       ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3))
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ u3') ** (.x7 ↦ᵣ (u3 <<< (antiShift.toNat % 64))) **
+       ((sp + signExtend12 4056) ↦ₘ u0) **
+       ((sp + signExtend12 4048) ↦ₘ u1) **
+       ((sp + signExtend12 4040) ↦ₘ u2) **
+       ((sp + signExtend12 4032) ↦ₘ u3)) := by
+  delta divKDenormBodyPre
+  rfl
+
+/-- Postcondition for the DIV denorm body: each `u[]` slot has been
+    right-shifted by `shift` and OR'd with the upper bits of its
+    successor (anti-shifted), `x5` holds the top `u3'`, `x7` holds the
+    high-bits of the original `u3`, `x2` holds `antiShift`. Wrapped
+    `@[irreducible]` to hide the four-step shift/merge let chain. -/
+@[irreducible]
+def divKDenormBodyPost (sp u0 u1 u2 u3 shift : Word) : Assertion :=
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let u0' := (u0 >>> (shift.toNat % 64)) ||| (u1 <<< (antiShift.toNat % 64))
+  let u1' := (u1 >>> (shift.toNat % 64)) ||| (u2 <<< (antiShift.toNat % 64))
+  let u2' := (u2 >>> (shift.toNat % 64)) ||| (u3 <<< (antiShift.toNat % 64))
+  let u3' := u3 >>> (shift.toNat % 64)
+  (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ u3') ** (.x7 ↦ᵣ (u3 <<< (antiShift.toNat % 64))) **
+  (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) ** (.x0 ↦ᵣ (0 : Word)) **
+  ((sp + signExtend12 4056) ↦ₘ u0') ** ((sp + signExtend12 4048) ↦ₘ u1') **
+  ((sp + signExtend12 4040) ↦ₘ u2') ** ((sp + signExtend12 4032) ↦ₘ u3')
+
+theorem divKDenormBodyPost_unfold
+    {sp u0 u1 u2 u3 shift : Word} :
+    divKDenormBodyPost sp u0 u1 u2 u3 shift =
+      (let antiShift := signExtend12 (0 : BitVec 12) - shift
+       let u0' := (u0 >>> (shift.toNat % 64)) ||| (u1 <<< (antiShift.toNat % 64))
+       let u1' := (u1 >>> (shift.toNat % 64)) ||| (u2 <<< (antiShift.toNat % 64))
+       let u2' := (u2 >>> (shift.toNat % 64)) ||| (u3 <<< (antiShift.toNat % 64))
+       let u3' := u3 >>> (shift.toNat % 64)
+       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ u3') ** (.x7 ↦ᵣ (u3 <<< (antiShift.toNat % 64))) **
        (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) ** (.x0 ↦ᵣ (0 : Word)) **
-       ((sp + signExtend12 4056) ↦ₘ u0') ** ((sp + signExtend12 4048) ↦ₘ u1') **
-       ((sp + signExtend12 4040) ↦ₘ u2') ** ((sp + signExtend12 4032) ↦ₘ u3')) := by
-  intro antiShift u0' u1' u2' u3'
+       ((sp + signExtend12 4056) ↦ₘ u0') **
+       ((sp + signExtend12 4048) ↦ₘ u1') **
+       ((sp + signExtend12 4040) ↦ₘ u2') **
+       ((sp + signExtend12 4032) ↦ₘ u3')) := by
+  delta divKDenormBodyPost
+  rfl
+
+theorem divK_denorm_body_spec_within_noNop (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Word) :
+    cpsTripleWithin 23 (base + denormOff + 8) (base + epilogueOff) (divCode_noNop base)
+      (divKDenormBodyPre sp u0 u1 u2 u3 v2 v5 v7 shift)
+      (divKDenormBodyPost sp u0 u1 u2 u3 shift) := by
+  rw [divKDenormBodyPre_unfold, divKDenormBodyPost_unfold]
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let u0' := (u0 >>> (shift.toNat % 64)) ||| (u1 <<< (antiShift.toNat % 64))
+  let u1' := (u1 >>> (shift.toNat % 64)) ||| (u2 <<< (antiShift.toNat % 64))
+  let u2' := (u2 >>> (shift.toNat % 64)) ||| (u3 <<< (antiShift.toNat % 64))
+  let u3' := u3 >>> (shift.toNat % 64)
   -- ADDI x2 x0 0 + SUB x2 x2 x6 (base+916 → base+924): compute antiShift
   have haddi := addi_x0_spec_gen_within .x2 v2 0 (base + denormOff + 8) (by nofun)
   rw [show (base + denormOff + 8 : Word) + 4 = base + denormOff + 12 from by bv_addr] at haddi
@@ -207,20 +259,9 @@ theorem divK_denorm_body_spec_within_noNop (sp u0 u1 u2 u3 v2 v5 v7 shift : Word
     h_all
 
 theorem divK_denorm_body_spec_within (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Word) :
-    let antiShift := signExtend12 (0 : BitVec 12) - shift
-    let u0' := (u0 >>> (shift.toNat % 64)) ||| (u1 <<< (antiShift.toNat % 64))
-    let u1' := (u1 >>> (shift.toNat % 64)) ||| (u2 <<< (antiShift.toNat % 64))
-    let u2' := (u2 >>> (shift.toNat % 64)) ||| (u3 <<< (antiShift.toNat % 64))
-    let u3' := u3 >>> (shift.toNat % 64)
     cpsTripleWithin 23 (base + denormOff + 8) (base + epilogueOff) (divCode base)
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) **
-       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) **
-       ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
-       ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3))
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ u3') ** (.x7 ↦ᵣ (u3 <<< (antiShift.toNat % 64))) **
-       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) ** (.x0 ↦ᵣ (0 : Word)) **
-       ((sp + signExtend12 4056) ↦ₘ u0') ** ((sp + signExtend12 4048) ↦ₘ u1') **
-       ((sp + signExtend12 4040) ↦ₘ u2') ** ((sp + signExtend12 4032) ↦ₘ u3')) :=
+      (divKDenormBodyPre sp u0 u1 u2 u3 v2 v5 v7 shift)
+      (divKDenormBodyPost sp u0 u1 u2 u3 shift) :=
   cpsTripleWithin_extend_code (hmono := divCode_noNop_sub_divCode)
     (divK_denorm_body_spec_within_noNop sp u0 u1 u2 u3 v2 v5 v7 shift base)
 

--- a/EvmAsm/Evm64/DivMod/Compose/FullPath.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPath.lean
@@ -414,8 +414,7 @@ theorem evm_div_denorm_epilogue_spec_noNop (sp base : Word)
   let u3' := u3 >>> (shift.toNat % 64)
   -- Step 1: Denorm body (base+916 → base+1008)
   have hDenorm := divK_denorm_body_spec_within_noNop sp u0 u1 u2 u3 v2 v5 v7 shift base
-
-  intro_lets at hDenorm
+  rw [divKDenormBodyPre_unfold, divKDenormBodyPost_unfold] at hDenorm
   -- Frame denorm with x10, q[], output memory
   have hDenormF := cpsTripleWithin_frameR
     ((.x10 ↦ᵣ v10) **

--- a/EvmAsm/Evm64/SDiv/Compose/Base.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/Base.lean
@@ -418,11 +418,14 @@ theorem dividendAbs_spec_in_sdivCode
     exact sdivCode_dividendAbs_sub (base := base) a i
       (by simpa [dividendAbsCode,
         EvmAsm.Evm64.evm_sdiv_cond_negate_256_block_code] using h)
-  exact cpsTripleWithin_extend_code hmono
-    (EvmAsm.Evm64.evm_sdiv_cond_negate_256_block_spec_within
+  have hSpec :=
+    EvmAsm.Evm64.evm_sdiv_cond_negate_256_block_spec_within
       .x12 .x8 .x10 .x7 .x11 0 8 16 24
       sp sign maskOld valueOld carryOld limb0 limb1 limb2 limb3
-      (base + dividendAbsOff) (by decide) (by decide) (by decide))
+      (base + dividendAbsOff) (by decide) (by decide) (by decide)
+  rw [EvmAsm.Evm64.condNegate256BlockPre_unfold,
+    EvmAsm.Evm64.condNegate256BlockPost_unfold] at hSpec
+  exact cpsTripleWithin_extend_code hmono hSpec
 
 theorem divCall_spec_in_sdivCode
     (vOld : Word) (base : Word) :

--- a/EvmAsm/Evm64/SDiv/Compose/Base.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/Base.lean
@@ -485,6 +485,70 @@ theorem dividendAbs_spec_in_sdivCode
       sp sign maskOld valueOld carryOld limb0 limb1 limb2 limb3
       (base + dividendAbsOff) (by decide) (by decide) (by decide))
 
+/-- Precondition for the SDIV save-ra + dividend/divisor signs +
+    dividendAbs prefix. Wrapped `@[irreducible]` so downstream proofs do
+    not re-reduce the 13-atom sepConj at each use site. -/
+@[irreducible]
+def saveRaSignsThenDividendAbsPre
+    (vRa vSavedOld sp sDividendOld sDivisorOld divisorTop
+      maskOld valueOld carryOld
+      mem0 mem1 mem2 mem3 divisorMem3
+      limb0 limb1 limb2 dividendTop : Word) : Assertion :=
+  ((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ vSavedOld)) **
+     ((.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sDividendOld) ** (mem3 ↦ₘ dividendTop))) **
+    ((.x9 ↦ᵣ sDivisorOld) ** (divisorMem3 ↦ₘ divisorTop))) **
+   (((.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ maskOld) **
+     (.x7 ↦ᵣ valueOld) ** (.x11 ↦ᵣ carryOld)) **
+    ((mem0 ↦ₘ limb0) ** (mem1 ↦ₘ limb1) ** (mem2 ↦ₘ limb2)))
+
+theorem saveRaSignsThenDividendAbsPre_unfold
+    {vRa vSavedOld sp sDividendOld sDivisorOld divisorTop
+      maskOld valueOld carryOld
+      mem0 mem1 mem2 mem3 divisorMem3
+      limb0 limb1 limb2 dividendTop : Word} :
+    saveRaSignsThenDividendAbsPre vRa vSavedOld sp sDividendOld sDivisorOld divisorTop
+        maskOld valueOld carryOld
+        mem0 mem1 mem2 mem3 divisorMem3
+        limb0 limb1 limb2 dividendTop =
+      (((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ vSavedOld)) **
+          ((.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sDividendOld) ** (mem3 ↦ₘ dividendTop))) **
+         ((.x9 ↦ᵣ sDivisorOld) ** (divisorMem3 ↦ₘ divisorTop))) **
+        (((.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ maskOld) **
+          (.x7 ↦ᵣ valueOld) ** (.x11 ↦ᵣ carryOld)) **
+         ((mem0 ↦ₘ limb0) ** (mem1 ↦ₘ limb1) ** (mem2 ↦ₘ limb2)))) := by
+  delta saveRaSignsThenDividendAbsPre
+  rfl
+
+/-- Postcondition for the SDIV save-ra/signs/dividendAbs prefix. Wrapped
+    `@[irreducible]` to hide the 12-atom sepConj from downstream proofs. -/
+@[irreducible]
+def saveRaSignsThenDividendAbsPost
+    (vRa sp divisorTop divisorSign sign mask sum3 carry3
+      mem0 mem1 mem2 mem3 divisorMem3
+      sum0 sum1 sum2 : Word) : Assertion :=
+  (((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12)))) **
+    ((.x9 ↦ᵣ divisorSign) ** (divisorMem3 ↦ₘ divisorTop))) **
+   ((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sign) **
+    (.x10 ↦ᵣ mask) ** (.x7 ↦ᵣ sum3) ** (.x11 ↦ᵣ carry3) **
+    (mem0 ↦ₘ sum0) ** (mem1 ↦ₘ sum1) **
+    (mem2 ↦ₘ sum2) ** (mem3 ↦ₘ sum3))
+
+theorem saveRaSignsThenDividendAbsPost_unfold
+    {vRa sp divisorTop divisorSign sign mask sum3 carry3
+      mem0 mem1 mem2 mem3 divisorMem3
+      sum0 sum1 sum2 : Word} :
+    saveRaSignsThenDividendAbsPost vRa sp divisorTop divisorSign sign mask sum3 carry3
+        mem0 mem1 mem2 mem3 divisorMem3
+        sum0 sum1 sum2 =
+      ((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12)))) **
+         ((.x9 ↦ᵣ divisorSign) ** (divisorMem3 ↦ₘ divisorTop))) **
+        ((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sign) **
+         (.x10 ↦ᵣ mask) ** (.x7 ↦ᵣ sum3) ** (.x11 ↦ᵣ carry3) **
+         (mem0 ↦ₘ sum0) ** (mem1 ↦ₘ sum1) **
+         (mem2 ↦ₘ sum2) ** (mem3 ↦ₘ sum3))) := by
+  delta saveRaSignsThenDividendAbsPost
+  rfl
+
 theorem saveRa_signs_then_dividendAbs_spec_in_sdivCode
     (vRa vSavedOld sp sDividendOld sDivisorOld divisorTop
       maskOld valueOld carryOld limb0 limb1 limb2 dividendTop : Word)
@@ -510,18 +574,13 @@ theorem saveRa_signs_then_dividendAbs_spec_in_sdivCode
     let sum3 := xored3 + carry2
     let carry3 := if BitVec.ult sum3 carry2 then (1 : Word) else 0
     cpsTripleWithin 26 base ((base + dividendAbsOff) + 84) (sdivCode base)
-      (((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ vSavedOld)) **
-         ((.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sDividendOld) ** (mem3 ↦ₘ dividendTop))) **
-        ((.x9 ↦ᵣ sDivisorOld) ** (divisorMem3 ↦ₘ divisorTop))) **
-       (((.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ maskOld) **
-         (.x7 ↦ᵣ valueOld) ** (.x11 ↦ᵣ carryOld)) **
-        ((mem0 ↦ₘ limb0) ** (mem1 ↦ₘ limb1) ** (mem2 ↦ₘ limb2))))
-      ((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12)))) **
-        ((.x9 ↦ᵣ divisorSign) ** (divisorMem3 ↦ₘ divisorTop))) **
-       ((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sign) **
-        (.x10 ↦ᵣ mask) ** (.x7 ↦ᵣ sum3) ** (.x11 ↦ᵣ carry3) **
-        (mem0 ↦ₘ sum0) ** (mem1 ↦ₘ sum1) **
-        (mem2 ↦ₘ sum2) ** (mem3 ↦ₘ sum3))) := by
+      (saveRaSignsThenDividendAbsPre vRa vSavedOld sp sDividendOld sDivisorOld
+        divisorTop maskOld valueOld carryOld
+        mem0 mem1 mem2 mem3 divisorMem3
+        limb0 limb1 limb2 dividendTop)
+      (saveRaSignsThenDividendAbsPost vRa sp divisorTop divisorSign sign mask
+        sum3 carry3 mem0 mem1 mem2 mem3 divisorMem3
+        sum0 sum1 sum2) := by
   intro sign divisorSign mem0 mem1 mem2 mem3 divisorMem3 mask xored0 sum0
     carry0 xored1 sum1 carry1 xored2 sum2 carry2 xored3 sum3 carry3
   let extra : Assertion :=
@@ -582,6 +641,8 @@ theorem saveRa_signs_then_dividendAbs_spec_in_sdivCode
     (fun h hp => by
       dsimp [mid, absPre, extra] at hp ⊢
       xperm_hyp hp) hPrefix hAbs
+  rw [saveRaSignsThenDividendAbsPre_unfold,
+      saveRaSignsThenDividendAbsPost_unfold]
   simpa [pre, post] using hSeq
 
 theorem divisorAbs_spec_in_sdivCode

--- a/EvmAsm/Evm64/SDiv/Compose/Base.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/Base.lean
@@ -485,6 +485,105 @@ theorem dividendAbs_spec_in_sdivCode
       sp sign maskOld valueOld carryOld limb0 limb1 limb2 limb3
       (base + dividendAbsOff) (by decide) (by decide) (by decide))
 
+theorem saveRa_signs_then_dividendAbs_spec_in_sdivCode
+    (vRa vSavedOld sp sDividendOld sDivisorOld divisorTop
+      maskOld valueOld carryOld limb0 limb1 limb2 dividendTop : Word)
+    (base : Word) :
+    let sign := dividendTop >>> (63 : BitVec 6).toNat
+    let divisorSign := divisorTop >>> (63 : BitVec 6).toNat
+    let mem0 := sp + signExtend12 (0 : BitVec 12)
+    let mem1 := sp + signExtend12 (8 : BitVec 12)
+    let mem2 := sp + signExtend12 (16 : BitVec 12)
+    let mem3 := sp + signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff
+    let divisorMem3 := sp + signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff
+    let mask := (0 : Word) - sign
+    let xored0 := limb0 ^^^ mask
+    let sum0 := xored0 + sign
+    let carry0 := if BitVec.ult sum0 sign then (1 : Word) else 0
+    let xored1 := limb1 ^^^ mask
+    let sum1 := xored1 + carry0
+    let carry1 := if BitVec.ult sum1 carry0 then (1 : Word) else 0
+    let xored2 := limb2 ^^^ mask
+    let sum2 := xored2 + carry1
+    let carry2 := if BitVec.ult sum2 carry1 then (1 : Word) else 0
+    let xored3 := dividendTop ^^^ mask
+    let sum3 := xored3 + carry2
+    let carry3 := if BitVec.ult sum3 carry2 then (1 : Word) else 0
+    cpsTripleWithin 26 base ((base + dividendAbsOff) + 84) (sdivCode base)
+      (((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ vSavedOld)) **
+         ((.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sDividendOld) ** (mem3 ↦ₘ dividendTop))) **
+        ((.x9 ↦ᵣ sDivisorOld) ** (divisorMem3 ↦ₘ divisorTop))) **
+       (((.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ maskOld) **
+         (.x7 ↦ᵣ valueOld) ** (.x11 ↦ᵣ carryOld)) **
+        ((mem0 ↦ₘ limb0) ** (mem1 ↦ₘ limb1) ** (mem2 ↦ₘ limb2))))
+      ((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12)))) **
+        ((.x9 ↦ᵣ divisorSign) ** (divisorMem3 ↦ₘ divisorTop))) **
+       ((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sign) **
+        (.x10 ↦ᵣ mask) ** (.x7 ↦ᵣ sum3) ** (.x11 ↦ᵣ carry3) **
+        (mem0 ↦ₘ sum0) ** (mem1 ↦ₘ sum1) **
+        (mem2 ↦ₘ sum2) ** (mem3 ↦ₘ sum3))) := by
+  intro sign divisorSign mem0 mem1 mem2 mem3 divisorMem3 mask xored0 sum0
+    carry0 xored1 sum1 carry1 xored2 sum2 carry2 xored3 sum3 carry3
+  let extra : Assertion :=
+    (((.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ maskOld) **
+      (.x7 ↦ᵣ valueOld) ** (.x11 ↦ᵣ carryOld)) **
+     ((mem0 ↦ₘ limb0) ** (mem1 ↦ₘ limb1) ** (mem2 ↦ₘ limb2)))
+  let pre : Assertion :=
+    (((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ vSavedOld)) **
+       ((.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sDividendOld) ** (mem3 ↦ₘ dividendTop))) **
+      ((.x9 ↦ᵣ sDivisorOld) ** (divisorMem3 ↦ₘ divisorTop))) **
+     extra)
+  let mid : Assertion :=
+    (((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12)))) **
+       ((.x8 ↦ᵣ sign) ** (mem3 ↦ₘ dividendTop))) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ divisorSign) ** (divisorMem3 ↦ₘ divisorTop))) **
+     extra)
+  let absPre : Assertion :=
+    ((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12)))) **
+      ((.x9 ↦ᵣ divisorSign) ** (divisorMem3 ↦ₘ divisorTop))) **
+     ((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sign) **
+      (.x10 ↦ᵣ maskOld) ** (.x7 ↦ᵣ valueOld) ** (.x11 ↦ᵣ carryOld) **
+      (mem0 ↦ₘ limb0) ** (mem1 ↦ₘ limb1) **
+      (mem2 ↦ₘ limb2) ** (mem3 ↦ₘ dividendTop)))
+  let post : Assertion :=
+    ((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12)))) **
+      ((.x9 ↦ᵣ divisorSign) ** (divisorMem3 ↦ₘ divisorTop))) **
+     ((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sign) **
+      (.x10 ↦ᵣ mask) ** (.x7 ↦ᵣ sum3) ** (.x11 ↦ᵣ carry3) **
+      (mem0 ↦ₘ sum0) ** (mem1 ↦ₘ sum1) **
+      (mem2 ↦ₘ sum2) ** (mem3 ↦ₘ sum3)))
+  have hPrefix : cpsTripleWithin 5 base (base + dividendAbsOff)
+      (sdivCode base) pre mid := by
+    dsimp [pre, mid, extra, mem3, divisorMem3, sign, divisorSign]
+    simpa [divisorSignOff, dividendAbsOff, BitVec.add_assoc] using
+      (cpsTripleWithin_frameR
+        (((.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ maskOld) **
+          (.x7 ↦ᵣ valueOld) ** (.x11 ↦ᵣ carryOld)) **
+         ((mem0 ↦ₘ limb0) ** (mem1 ↦ₘ limb1) ** (mem2 ↦ₘ limb2)))
+        (by pcFree)
+        (saveRa_dividendSign_then_divisorSign_spec_in_sdivCode
+          vRa vSavedOld sp sDividendOld dividendTop sDivisorOld divisorTop
+          base))
+  have hAbs : cpsTripleWithin 21 (base + dividendAbsOff)
+      ((base + dividendAbsOff) + 84) (sdivCode base) absPre post := by
+    simpa [absPre, post, mem0, mem1, mem2, mem3,
+      EvmAsm.Evm64.evm_sdivDividendTopLimbOff, mask, xored0, sum0,
+      carry0, xored1, sum1, carry1, xored2, sum2, carry2, xored3, sum3,
+      carry3] using
+      cpsTripleWithin_frameL
+        ((((.x1 ↦ᵣ vRa) **
+          (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12)))) **
+          ((.x9 ↦ᵣ divisorSign) ** (divisorMem3 ↦ₘ divisorTop))))
+        (by pcFree)
+        (dividendAbs_spec_in_sdivCode
+          sp sign maskOld valueOld carryOld limb0 limb1 limb2 dividendTop
+          base)
+  have hSeq := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by
+      dsimp [mid, absPre, extra] at hp ⊢
+      xperm_hyp hp) hPrefix hAbs
+  simpa [pre, post] using hSeq
+
 theorem divisorAbs_spec_in_sdivCode
     (sp sign maskOld valueOld carryOld limb0 limb1 limb2 limb3 : Word)
     (base : Word) :

--- a/EvmAsm/Evm64/SDiv/LimbSpec.lean
+++ b/EvmAsm/Evm64/SDiv/LimbSpec.lean
@@ -185,6 +185,91 @@ abbrev evm_sdiv_cond_negate_256_block_code
     (evm_sdiv_cond_negate_256_block addrReg signReg maskReg valueReg carryReg
       limb0Off limb1Off limb2Off limb3Off)
 
+/-- Precondition for the 21-instruction SDIV conditional-negation block.
+    Wrapped `@[irreducible]` so downstream consumers do not re-reduce the
+    sepConj atoms at each use site. -/
+@[irreducible]
+def condNegate256BlockPre
+    (addrReg signReg maskReg valueReg carryReg : Reg)
+    (limb0Off limb1Off limb2Off limb3Off : BitVec 12)
+    (vAddr sign maskOld valueOld carryOld limb0 limb1 limb2 limb3 : Word) :
+    Assertion :=
+  (.x0 ↦ᵣ (0 : Word)) ** (addrReg ↦ᵣ vAddr) **
+  (signReg ↦ᵣ sign) ** (maskReg ↦ᵣ maskOld) **
+  (valueReg ↦ᵣ valueOld) ** (carryReg ↦ᵣ carryOld) **
+  ((vAddr + signExtend12 limb0Off) ↦ₘ limb0) **
+  ((vAddr + signExtend12 limb1Off) ↦ₘ limb1) **
+  ((vAddr + signExtend12 limb2Off) ↦ₘ limb2) **
+  ((vAddr + signExtend12 limb3Off) ↦ₘ limb3)
+
+theorem condNegate256BlockPre_unfold
+    {addrReg signReg maskReg valueReg carryReg : Reg}
+    {limb0Off limb1Off limb2Off limb3Off : BitVec 12}
+    {vAddr sign maskOld valueOld carryOld limb0 limb1 limb2 limb3 : Word} :
+    condNegate256BlockPre addrReg signReg maskReg valueReg carryReg
+        limb0Off limb1Off limb2Off limb3Off
+        vAddr sign maskOld valueOld carryOld limb0 limb1 limb2 limb3 =
+      ((.x0 ↦ᵣ (0 : Word)) ** (addrReg ↦ᵣ vAddr) **
+       (signReg ↦ᵣ sign) ** (maskReg ↦ᵣ maskOld) **
+       (valueReg ↦ᵣ valueOld) ** (carryReg ↦ᵣ carryOld) **
+       ((vAddr + signExtend12 limb0Off) ↦ₘ limb0) **
+       ((vAddr + signExtend12 limb1Off) ↦ₘ limb1) **
+       ((vAddr + signExtend12 limb2Off) ↦ₘ limb2) **
+       ((vAddr + signExtend12 limb3Off) ↦ₘ limb3)) := by
+  delta condNegate256BlockPre
+  rfl
+
+/-- Postcondition for the 21-instruction SDIV conditional-negation block:
+    materialize `mask = -sign` and propagate the ripple-carry add across
+    four limbs. Wrapped `@[irreducible]` to hide the 16-step let chain. -/
+@[irreducible]
+def condNegate256BlockPost
+    (addrReg signReg maskReg valueReg carryReg : Reg)
+    (limb0Off limb1Off limb2Off limb3Off : BitVec 12)
+    (vAddr sign limb0 limb1 limb2 limb3 : Word) : Assertion :=
+  let mask := (0 : Word) - sign
+  let sum0 := (limb0 ^^^ mask) + sign
+  let carry0 := if BitVec.ult sum0 sign then (1 : Word) else 0
+  let sum1 := (limb1 ^^^ mask) + carry0
+  let carry1 := if BitVec.ult sum1 carry0 then (1 : Word) else 0
+  let sum2 := (limb2 ^^^ mask) + carry1
+  let carry2 := if BitVec.ult sum2 carry1 then (1 : Word) else 0
+  let sum3 := (limb3 ^^^ mask) + carry2
+  let carry3 := if BitVec.ult sum3 carry2 then (1 : Word) else 0
+  (.x0 ↦ᵣ (0 : Word)) ** (addrReg ↦ᵣ vAddr) **
+  (signReg ↦ᵣ sign) ** (maskReg ↦ᵣ mask) **
+  (valueReg ↦ᵣ sum3) ** (carryReg ↦ᵣ carry3) **
+  ((vAddr + signExtend12 limb0Off) ↦ₘ sum0) **
+  ((vAddr + signExtend12 limb1Off) ↦ₘ sum1) **
+  ((vAddr + signExtend12 limb2Off) ↦ₘ sum2) **
+  ((vAddr + signExtend12 limb3Off) ↦ₘ sum3)
+
+theorem condNegate256BlockPost_unfold
+    {addrReg signReg maskReg valueReg carryReg : Reg}
+    {limb0Off limb1Off limb2Off limb3Off : BitVec 12}
+    {vAddr sign limb0 limb1 limb2 limb3 : Word} :
+    condNegate256BlockPost addrReg signReg maskReg valueReg carryReg
+        limb0Off limb1Off limb2Off limb3Off
+        vAddr sign limb0 limb1 limb2 limb3 =
+      (let mask := (0 : Word) - sign
+       let sum0 := (limb0 ^^^ mask) + sign
+       let carry0 := if BitVec.ult sum0 sign then (1 : Word) else 0
+       let sum1 := (limb1 ^^^ mask) + carry0
+       let carry1 := if BitVec.ult sum1 carry0 then (1 : Word) else 0
+       let sum2 := (limb2 ^^^ mask) + carry1
+       let carry2 := if BitVec.ult sum2 carry1 then (1 : Word) else 0
+       let sum3 := (limb3 ^^^ mask) + carry2
+       let carry3 := if BitVec.ult sum3 carry2 then (1 : Word) else 0
+       (.x0 ↦ᵣ (0 : Word)) ** (addrReg ↦ᵣ vAddr) **
+       (signReg ↦ᵣ sign) ** (maskReg ↦ᵣ mask) **
+       (valueReg ↦ᵣ sum3) ** (carryReg ↦ᵣ carry3) **
+       ((vAddr + signExtend12 limb0Off) ↦ₘ sum0) **
+       ((vAddr + signExtend12 limb1Off) ↦ₘ sum1) **
+       ((vAddr + signExtend12 limb2Off) ↦ₘ sum2) **
+       ((vAddr + signExtend12 limb3Off) ↦ₘ sum3)) := by
+  delta condNegate256BlockPost
+  rfl
+
 /-- 21-instruction conditional-negation block spec: materialize the mask
     `0 - sign`, then apply the four limb-step updates in place. -/
 theorem evm_sdiv_cond_negate_256_block_spec_within
@@ -195,39 +280,35 @@ theorem evm_sdiv_cond_negate_256_block_spec_within
     (hmask_ne_x0 : maskReg ≠ .x0)
     (hvalue_ne_x0 : valueReg ≠ .x0)
     (hcarry_ne_x0 : carryReg ≠ .x0) :
-    let mem0 := vAddr + signExtend12 limb0Off
-    let mem1 := vAddr + signExtend12 limb1Off
-    let mem2 := vAddr + signExtend12 limb2Off
-    let mem3 := vAddr + signExtend12 limb3Off
-    let mask := (0 : Word) - sign
-    let xored0 := limb0 ^^^ mask
-    let sum0 := xored0 + sign
-    let carry0 := if BitVec.ult sum0 sign then (1 : Word) else 0
-    let xored1 := limb1 ^^^ mask
-    let sum1 := xored1 + carry0
-    let carry1 := if BitVec.ult sum1 carry0 then (1 : Word) else 0
-    let xored2 := limb2 ^^^ mask
-    let sum2 := xored2 + carry1
-    let carry2 := if BitVec.ult sum2 carry1 then (1 : Word) else 0
-    let xored3 := limb3 ^^^ mask
-    let sum3 := xored3 + carry2
-    let carry3 := if BitVec.ult sum3 carry2 then (1 : Word) else 0
     let code :=
       evm_sdiv_cond_negate_256_block_code addrReg signReg maskReg valueReg
         carryReg limb0Off limb1Off limb2Off limb3Off base
     cpsTripleWithin 21 base (base + 84) code
-      ((.x0 ↦ᵣ (0 : Word)) ** (addrReg ↦ᵣ vAddr) **
-       (signReg ↦ᵣ sign) ** (maskReg ↦ᵣ maskOld) **
-       (valueReg ↦ᵣ valueOld) ** (carryReg ↦ᵣ carryOld) **
-       (mem0 ↦ₘ limb0) ** (mem1 ↦ₘ limb1) **
-       (mem2 ↦ₘ limb2) ** (mem3 ↦ₘ limb3))
-      ((.x0 ↦ᵣ (0 : Word)) ** (addrReg ↦ᵣ vAddr) **
-       (signReg ↦ᵣ sign) ** (maskReg ↦ᵣ mask) **
-       (valueReg ↦ᵣ sum3) ** (carryReg ↦ᵣ carry3) **
-       (mem0 ↦ₘ sum0) ** (mem1 ↦ₘ sum1) **
-       (mem2 ↦ₘ sum2) ** (mem3 ↦ₘ sum3)) := by
-  intro mem0 mem1 mem2 mem3 mask xored0 sum0 carry0 xored1 sum1 carry1
-    xored2 sum2 carry2 xored3 sum3 carry3 code
+      (condNegate256BlockPre addrReg signReg maskReg valueReg carryReg
+        limb0Off limb1Off limb2Off limb3Off
+        vAddr sign maskOld valueOld carryOld limb0 limb1 limb2 limb3)
+      (condNegate256BlockPost addrReg signReg maskReg valueReg carryReg
+        limb0Off limb1Off limb2Off limb3Off
+        vAddr sign limb0 limb1 limb2 limb3) := by
+  intro code
+  rw [condNegate256BlockPre_unfold, condNegate256BlockPost_unfold]
+  let mem0 := vAddr + signExtend12 limb0Off
+  let mem1 := vAddr + signExtend12 limb1Off
+  let mem2 := vAddr + signExtend12 limb2Off
+  let mem3 := vAddr + signExtend12 limb3Off
+  let mask := (0 : Word) - sign
+  let xored0 := limb0 ^^^ mask
+  let sum0 := xored0 + sign
+  let carry0 := if BitVec.ult sum0 sign then (1 : Word) else 0
+  let xored1 := limb1 ^^^ mask
+  let sum1 := xored1 + carry0
+  let carry1 := if BitVec.ult sum1 carry0 then (1 : Word) else 0
+  let xored2 := limb2 ^^^ mask
+  let sum2 := xored2 + carry1
+  let carry2 := if BitVec.ult sum2 carry1 then (1 : Word) else 0
+  let xored3 := limb3 ^^^ mask
+  let sum3 := xored3 + carry2
+  let carry3 := if BitVec.ult sum3 carry2 then (1 : Word) else 0
   have M := sub_spec_gen_within maskReg .x0 signReg (0 : Word) sign maskOld
     base hmask_ne_x0
   have L0 := ld_spec_gen_within valueReg addrReg vAddr valueOld limb0

--- a/docs/notable-specs.md
+++ b/docs/notable-specs.md
@@ -383,22 +383,6 @@ specs.
 | `cc_epilogue_spec_within` | [`CallingConvention.lean:129`](https://github.com/Verified-zkEVM/evm-asm/blob/59692ad6e22d2eacbb72b471fd7142a23b8947e4/EvmAsm/Evm64/CallingConvention.lean#L129) | Block spec for the 3-instruction epilogue: `ra` restored, `sp` incremented by 16, jumps to saved `ra`. |
 
 
-## EL / Conformance
-
-The aggregate conformance surface collects the executable-spec vector batches
-and exposes small proof obligations for CI and closeout checks: total vector
-count, expected errors, successful results, and absence of unexpected failures.
-
-| Declaration / Theorem | Defined at | Meaning |
-|---|---|---|
-| `allConformanceVectors` | [`All.lean#L27`](https://github.com/Verified-zkEVM/evm-asm/blob/d6e74a34eb5c473c927d10f30ab1d3817d4df319/EvmAsm/EL/Conformance/All.lean#L27) | Concatenates every checked conformance batch currently imported by `EvmAsm.EL.Conformance.All`. |
-| `allConformanceVectorCount` | [`All.lean#L43`](https://github.com/Verified-zkEVM/evm-asm/blob/d6e74a34eb5c473c927d10f30ab1d3817d4df319/EvmAsm/EL/Conformance/All.lean#L43) | Named count used by status and CI-facing checks. |
-| `allConformanceVectorCount_eq` | [`All.lean#L50`](https://github.com/Verified-zkEVM/evm-asm/blob/d6e74a34eb5c473c927d10f30ab1d3817d4df319/EvmAsm/EL/Conformance/All.lean#L50) | Proves the aggregate currently contains 56 vector results. |
-| `allConformanceNoUnexpectedFailures_eq_true` | [`All.lean#L105`](https://github.com/Verified-zkEVM/evm-asm/blob/d6e74a34eb5c473c927d10f30ab1d3817d4df319/EvmAsm/EL/Conformance/All.lean#L105) | Boolean gate proving the aggregate has no unexpected failures. |
-| `unexpectedConformanceFailureCount_eq_zero` | [`All.lean#L109`](https://github.com/Verified-zkEVM/evm-asm/blob/d6e74a34eb5c473c927d10f30ab1d3817d4df319/EvmAsm/EL/Conformance/All.lean#L109) | Numeric form of the no-unexpected-failure proof. |
-| `expectedConformanceErrorCount_eq` | [`All.lean#L113`](https://github.com/Verified-zkEVM/evm-asm/blob/d6e74a34eb5c473c927d10f30ab1d3817d4df319/EvmAsm/EL/Conformance/All.lean#L113) | Proves there are 10 expected-error results in the aggregate. |
-| `successfulConformanceResultCount_eq` | [`All.lean#L117`](https://github.com/Verified-zkEVM/evm-asm/blob/d6e74a34eb5c473c927d10f30ab1d3817d4df319/EvmAsm/EL/Conformance/All.lean#L117) | Proves there are 46 successful results in the aggregate. |
-
 ## Maintenance
 
 - See parent backlog: `evm-asm-prwe` / GH issue tracking forthcoming.

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -111,7 +111,7 @@
   ["EvmAsm.Evm64.AddMod.LimbSpec", "EvmAsm.Evm64.AddMod.AddrNorm"],
   "EvmAsm.Evm64.MulMod.AddrNormAttr": ["Lean.Meta.Tactic.Simp.RegisterCommand"],
   "EvmAsm.Rv64.Tactics.XCancelStruct":
-  ["EvmAsm.Rv64.SepLogic"],
+  ["EvmAsm.Rv64.SepLogic", "EvmAsm.Rv64.Tactics.XSimp"],
   "EvmAsm.Rv64.Tactics.SymStep":
   ["EvmAsm.Rv64.Execution"],
   "EvmAsm.Evm64.Accelerators.Status":


### PR DESCRIPTION
## Summary
- compose the 5-instruction SDIV sign prefix through the in-place dividend absolute-value block
- share the probed dividend top limb as the fourth negation limb and frame divisor sign state across the block
- expose the 26-instruction prefix postcondition with normalized dividend limbs and carry state

Depends on #3591.
Refs #90.
Bead: evm-asm-01uh.

## Verification
- lake build EvmAsm.Evm64.SDiv.Compose.Base
- scripts/check-file-size.sh
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/Base.lean
- lake build