### PR TITLE
feat(sdiv): sequence result sign xor

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/Base.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/Base.lean
@@ -888,6 +888,111 @@ theorem signXor_spec_in_sdivCode
     (xor_spec_gen_rd_eq_rs1_within .x8 .x9 signDividend signDivisor
       (base + signXorOff) (by decide))
 
+/-- Precondition for the SDIV save-ra/signs/dividendAbs/divisorAbs/signXor
+    block: identical to the entry shape consumed by the divisorAbs
+    sequence. Wrapped `@[irreducible]` so downstream proofs do not
+    re-reduce the 18-atom sepConj at each use site. -/
+@[irreducible]
+def saveRaSignsAbsThenSignXorPre
+    (vRa vSavedOld sp sDividendOld sDivisorOld
+      dividendMaskOld dividendValueOld dividendCarryOld
+      dividendMem0 dividendMem1 dividendMem2 dividendMem3
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorMem0 divisorMem1 divisorMem2 divisorMem3
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word) : Assertion :=
+  (((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ vSavedOld)) **
+      ((.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sDividendOld) **
+       (dividendMem3 ↦ₘ dividendTop))) **
+     ((.x9 ↦ᵣ sDivisorOld) ** (divisorMem3 ↦ₘ divisorTop))) **
+    (((.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ dividendMaskOld) **
+      (.x7 ↦ᵣ dividendValueOld) ** (.x11 ↦ᵣ dividendCarryOld)) **
+     ((dividendMem0 ↦ₘ dividendLimb0) **
+      (dividendMem1 ↦ₘ dividendLimb1) **
+      (dividendMem2 ↦ₘ dividendLimb2)))) **
+   ((divisorMem0 ↦ₘ divisorLimb0) **
+    (divisorMem1 ↦ₘ divisorLimb1) **
+    (divisorMem2 ↦ₘ divisorLimb2))
+
+theorem saveRaSignsAbsThenSignXorPre_unfold
+    {vRa vSavedOld sp sDividendOld sDivisorOld
+      dividendMaskOld dividendValueOld dividendCarryOld
+      dividendMem0 dividendMem1 dividendMem2 dividendMem3
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorMem0 divisorMem1 divisorMem2 divisorMem3
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word} :
+    saveRaSignsAbsThenSignXorPre vRa vSavedOld sp sDividendOld sDivisorOld
+        dividendMaskOld dividendValueOld dividendCarryOld
+        dividendMem0 dividendMem1 dividendMem2 dividendMem3
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorMem0 divisorMem1 divisorMem2 divisorMem3
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop =
+      ((((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ vSavedOld)) **
+           ((.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sDividendOld) **
+            (dividendMem3 ↦ₘ dividendTop))) **
+          ((.x9 ↦ᵣ sDivisorOld) ** (divisorMem3 ↦ₘ divisorTop))) **
+         (((.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ dividendMaskOld) **
+           (.x7 ↦ᵣ dividendValueOld) ** (.x11 ↦ᵣ dividendCarryOld)) **
+          ((dividendMem0 ↦ₘ dividendLimb0) **
+           (dividendMem1 ↦ₘ dividendLimb1) **
+           (dividendMem2 ↦ₘ dividendLimb2)))) **
+        ((divisorMem0 ↦ₘ divisorLimb0) **
+         (divisorMem1 ↦ₘ divisorLimb1) **
+         (divisorMem2 ↦ₘ divisorLimb2))) := by
+  delta saveRaSignsAbsThenSignXorPre
+  rfl
+
+/-- Postcondition for the SDIV save-ra/signs/dividendAbs/divisorAbs/signXor
+    block: `x8` holds the result sign (dividendSign ⊕ divisorSign),
+    `x9` holds the divisor sign, the rest of the frame matches the
+    divisorAbs postcondition. Wrapped `@[irreducible]` to hide the
+    22-atom sepConj from downstream proofs. -/
+@[irreducible]
+def saveRaSignsAbsThenSignXorPost
+    (vRa sp divisorSign resultSign divisorMask
+      divisorSum3 divisorCarry3
+      dividendMem0 dividendMem1 dividendMem2 dividendMem3
+      dividendSum0 dividendSum1 dividendSum2 dividendSum3
+      divisorMem0 divisorMem1 divisorMem2 divisorMem3
+      divisorSum0 divisorSum1 divisorSum2 : Word) : Assertion :=
+  (((.x8 ↦ᵣ resultSign) ** (.x9 ↦ᵣ divisorSign)) **
+   (((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12)))) **
+    ((dividendMem0 ↦ₘ dividendSum0) **
+     (dividendMem1 ↦ₘ dividendSum1) **
+     (dividendMem2 ↦ₘ dividendSum2) **
+     (dividendMem3 ↦ₘ dividendSum3) **
+     (.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) **
+     (.x10 ↦ᵣ divisorMask) ** (.x7 ↦ᵣ divisorSum3) **
+     (.x11 ↦ᵣ divisorCarry3) **
+     (divisorMem0 ↦ₘ divisorSum0) ** (divisorMem1 ↦ₘ divisorSum1) **
+     (divisorMem2 ↦ₘ divisorSum2) ** (divisorMem3 ↦ₘ divisorSum3))))
+
+theorem saveRaSignsAbsThenSignXorPost_unfold
+    {vRa sp divisorSign resultSign divisorMask
+      divisorSum3 divisorCarry3
+      dividendMem0 dividendMem1 dividendMem2 dividendMem3
+      dividendSum0 dividendSum1 dividendSum2 dividendSum3
+      divisorMem0 divisorMem1 divisorMem2 divisorMem3
+      divisorSum0 divisorSum1 divisorSum2 : Word} :
+    saveRaSignsAbsThenSignXorPost vRa sp divisorSign resultSign
+        divisorMask divisorSum3 divisorCarry3
+        dividendMem0 dividendMem1 dividendMem2 dividendMem3
+        dividendSum0 dividendSum1 dividendSum2 dividendSum3
+        divisorMem0 divisorMem1 divisorMem2 divisorMem3
+        divisorSum0 divisorSum1 divisorSum2 =
+      (((.x8 ↦ᵣ resultSign) ** (.x9 ↦ᵣ divisorSign)) **
+       (((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12)))) **
+        ((dividendMem0 ↦ₘ dividendSum0) **
+         (dividendMem1 ↦ₘ dividendSum1) **
+         (dividendMem2 ↦ₘ dividendSum2) **
+         (dividendMem3 ↦ₘ dividendSum3) **
+         (.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) **
+         (.x10 ↦ᵣ divisorMask) ** (.x7 ↦ᵣ divisorSum3) **
+         (.x11 ↦ᵣ divisorCarry3) **
+         (divisorMem0 ↦ₘ divisorSum0) ** (divisorMem1 ↦ₘ divisorSum1) **
+         (divisorMem2 ↦ₘ divisorSum2) ** (divisorMem3 ↦ₘ divisorSum3)))) := by
+  delta saveRaSignsAbsThenSignXorPost
+  rfl
+
 theorem saveRa_signs_abs_then_signXor_spec_in_sdivCode
     (vRa vSavedOld sp sDividendOld sDivisorOld
       dividendMaskOld dividendValueOld dividendCarryOld
@@ -931,29 +1036,18 @@ theorem saveRa_signs_abs_then_signXor_spec_in_sdivCode
     let divisorSum3 := divisorXored3 + divisorCarry2
     let divisorCarry3 := if BitVec.ult divisorSum3 divisorCarry2 then (1 : Word) else 0
     cpsTripleWithin 48 base ((base + signXorOff) + 4) (sdivCode base)
-      ((((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ vSavedOld)) **
-          ((.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sDividendOld) **
-           (dividendMem3 ↦ₘ dividendTop))) **
-         ((.x9 ↦ᵣ sDivisorOld) ** (divisorMem3 ↦ₘ divisorTop))) **
-        (((.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ dividendMaskOld) **
-          (.x7 ↦ᵣ dividendValueOld) ** (.x11 ↦ᵣ dividendCarryOld)) **
-         ((dividendMem0 ↦ₘ dividendLimb0) **
-          (dividendMem1 ↦ₘ dividendLimb1) **
-          (dividendMem2 ↦ₘ dividendLimb2)))) **
-       ((divisorMem0 ↦ₘ divisorLimb0) **
-        (divisorMem1 ↦ₘ divisorLimb1) **
-        (divisorMem2 ↦ₘ divisorLimb2)))
-      (((.x8 ↦ᵣ resultSign) ** (.x9 ↦ᵣ divisorSign)) **
-       (((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12)))) **
-        ((dividendMem0 ↦ₘ dividendSum0) **
-         (dividendMem1 ↦ₘ dividendSum1) **
-         (dividendMem2 ↦ₘ dividendSum2) **
-         (dividendMem3 ↦ₘ dividendSum3) **
-         (.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) **
-         (.x10 ↦ᵣ divisorMask) ** (.x7 ↦ᵣ divisorSum3) **
-         (.x11 ↦ᵣ divisorCarry3) **
-         (divisorMem0 ↦ₘ divisorSum0) ** (divisorMem1 ↦ₘ divisorSum1) **
-         (divisorMem2 ↦ₘ divisorSum2) ** (divisorMem3 ↦ₘ divisorSum3)))) := by
+      (saveRaSignsAbsThenSignXorPre vRa vSavedOld sp sDividendOld sDivisorOld
+        dividendMaskOld dividendValueOld dividendCarryOld
+        dividendMem0 dividendMem1 dividendMem2 dividendMem3
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorMem0 divisorMem1 divisorMem2 divisorMem3
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+      (saveRaSignsAbsThenSignXorPost vRa sp divisorSign resultSign
+        divisorMask divisorSum3 divisorCarry3
+        dividendMem0 dividendMem1 dividendMem2 dividendMem3
+        dividendSum0 dividendSum1 dividendSum2 dividendSum3
+        divisorMem0 divisorMem1 divisorMem2 divisorMem3
+        divisorSum0 divisorSum1 divisorSum2) := by
   intro dividendSign divisorSign resultSign dividendMem0 dividendMem1 dividendMem2
     dividendMem3 divisorMem0 divisorMem1 divisorMem2 divisorMem3
     dividendMask dividendXored0 dividendSum0 dividendCarry0 dividendXored1
@@ -1028,6 +1122,8 @@ theorem saveRa_signs_abs_then_signXor_spec_in_sdivCode
     (fun h hp => by
       dsimp [prefixPost, signPre, signFrame] at hp ⊢
       xperm_hyp hp) hPrefix hXor
+  rw [saveRaSignsAbsThenSignXorPre_unfold,
+      saveRaSignsAbsThenSignXorPost_unfold]
   simpa [pre, post] using hSeq
 
 theorem savedRaRet_spec_in_sdivCode

--- a/EvmAsm/Evm64/SDiv/Compose/Base.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/Base.lean
@@ -888,6 +888,148 @@ theorem signXor_spec_in_sdivCode
     (xor_spec_gen_rd_eq_rs1_within .x8 .x9 signDividend signDivisor
       (base + signXorOff) (by decide))
 
+theorem saveRa_signs_abs_then_signXor_spec_in_sdivCode
+    (vRa vSavedOld sp sDividendOld sDivisorOld
+      dividendMaskOld dividendValueOld dividendCarryOld
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word)
+    (base : Word) :
+    let dividendSign := dividendTop >>> (63 : BitVec 6).toNat
+    let divisorSign := divisorTop >>> (63 : BitVec 6).toNat
+    let resultSign := dividendSign ^^^ divisorSign
+    let dividendMem0 := sp + signExtend12 (0 : BitVec 12)
+    let dividendMem1 := sp + signExtend12 (8 : BitVec 12)
+    let dividendMem2 := sp + signExtend12 (16 : BitVec 12)
+    let dividendMem3 := sp + signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff
+    let divisorMem0 := sp + signExtend12 (32 : BitVec 12)
+    let divisorMem1 := sp + signExtend12 (40 : BitVec 12)
+    let divisorMem2 := sp + signExtend12 (48 : BitVec 12)
+    let divisorMem3 := sp + signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff
+    let dividendMask := (0 : Word) - dividendSign
+    let dividendXored0 := dividendLimb0 ^^^ dividendMask
+    let dividendSum0 := dividendXored0 + dividendSign
+    let dividendCarry0 := if BitVec.ult dividendSum0 dividendSign then (1 : Word) else 0
+    let dividendXored1 := dividendLimb1 ^^^ dividendMask
+    let dividendSum1 := dividendXored1 + dividendCarry0
+    let dividendCarry1 := if BitVec.ult dividendSum1 dividendCarry0 then (1 : Word) else 0
+    let dividendXored2 := dividendLimb2 ^^^ dividendMask
+    let dividendSum2 := dividendXored2 + dividendCarry1
+    let dividendCarry2 := if BitVec.ult dividendSum2 dividendCarry1 then (1 : Word) else 0
+    let dividendXored3 := dividendTop ^^^ dividendMask
+    let dividendSum3 := dividendXored3 + dividendCarry2
+    let divisorMask := (0 : Word) - divisorSign
+    let divisorXored0 := divisorLimb0 ^^^ divisorMask
+    let divisorSum0 := divisorXored0 + divisorSign
+    let divisorCarry0 := if BitVec.ult divisorSum0 divisorSign then (1 : Word) else 0
+    let divisorXored1 := divisorLimb1 ^^^ divisorMask
+    let divisorSum1 := divisorXored1 + divisorCarry0
+    let divisorCarry1 := if BitVec.ult divisorSum1 divisorCarry0 then (1 : Word) else 0
+    let divisorXored2 := divisorLimb2 ^^^ divisorMask
+    let divisorSum2 := divisorXored2 + divisorCarry1
+    let divisorCarry2 := if BitVec.ult divisorSum2 divisorCarry1 then (1 : Word) else 0
+    let divisorXored3 := divisorTop ^^^ divisorMask
+    let divisorSum3 := divisorXored3 + divisorCarry2
+    let divisorCarry3 := if BitVec.ult divisorSum3 divisorCarry2 then (1 : Word) else 0
+    cpsTripleWithin 48 base ((base + signXorOff) + 4) (sdivCode base)
+      ((((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ vSavedOld)) **
+          ((.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sDividendOld) **
+           (dividendMem3 ↦ₘ dividendTop))) **
+         ((.x9 ↦ᵣ sDivisorOld) ** (divisorMem3 ↦ₘ divisorTop))) **
+        (((.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ dividendMaskOld) **
+          (.x7 ↦ᵣ dividendValueOld) ** (.x11 ↦ᵣ dividendCarryOld)) **
+         ((dividendMem0 ↦ₘ dividendLimb0) **
+          (dividendMem1 ↦ₘ dividendLimb1) **
+          (dividendMem2 ↦ₘ dividendLimb2)))) **
+       ((divisorMem0 ↦ₘ divisorLimb0) **
+        (divisorMem1 ↦ₘ divisorLimb1) **
+        (divisorMem2 ↦ₘ divisorLimb2)))
+      (((.x8 ↦ᵣ resultSign) ** (.x9 ↦ᵣ divisorSign)) **
+       (((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12)))) **
+        ((dividendMem0 ↦ₘ dividendSum0) **
+         (dividendMem1 ↦ₘ dividendSum1) **
+         (dividendMem2 ↦ₘ dividendSum2) **
+         (dividendMem3 ↦ₘ dividendSum3) **
+         (.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) **
+         (.x10 ↦ᵣ divisorMask) ** (.x7 ↦ᵣ divisorSum3) **
+         (.x11 ↦ᵣ divisorCarry3) **
+         (divisorMem0 ↦ₘ divisorSum0) ** (divisorMem1 ↦ₘ divisorSum1) **
+         (divisorMem2 ↦ₘ divisorSum2) ** (divisorMem3 ↦ₘ divisorSum3)))) := by
+  intro dividendSign divisorSign resultSign dividendMem0 dividendMem1 dividendMem2
+    dividendMem3 divisorMem0 divisorMem1 divisorMem2 divisorMem3
+    dividendMask dividendXored0 dividendSum0 dividendCarry0 dividendXored1
+    dividendSum1 dividendCarry1 dividendXored2 dividendSum2 dividendCarry2
+    dividendXored3 dividendSum3 divisorMask divisorXored0 divisorSum0
+    divisorCarry0 divisorXored1 divisorSum1 divisorCarry1 divisorXored2
+    divisorSum2 divisorCarry2 divisorXored3 divisorSum3 divisorCarry3
+  let pre : Assertion :=
+    ((((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ vSavedOld)) **
+        ((.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sDividendOld) **
+         (dividendMem3 ↦ₘ dividendTop))) **
+       ((.x9 ↦ᵣ sDivisorOld) ** (divisorMem3 ↦ₘ divisorTop))) **
+      (((.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ dividendMaskOld) **
+        (.x7 ↦ᵣ dividendValueOld) ** (.x11 ↦ᵣ dividendCarryOld)) **
+       ((dividendMem0 ↦ₘ dividendLimb0) **
+        (dividendMem1 ↦ₘ dividendLimb1) **
+        (dividendMem2 ↦ₘ dividendLimb2)))) **
+     ((divisorMem0 ↦ₘ divisorLimb0) **
+      (divisorMem1 ↦ₘ divisorLimb1) **
+      (divisorMem2 ↦ₘ divisorLimb2)))
+  let prefixPost : Assertion :=
+    ((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12)))) **
+      ((.x8 ↦ᵣ dividendSign) **
+       (dividendMem0 ↦ₘ dividendSum0) **
+       (dividendMem1 ↦ₘ dividendSum1) **
+       (dividendMem2 ↦ₘ dividendSum2) **
+       (dividendMem3 ↦ₘ dividendSum3))) **
+     ((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ divisorSign) **
+      (.x10 ↦ᵣ divisorMask) ** (.x7 ↦ᵣ divisorSum3) **
+      (.x11 ↦ᵣ divisorCarry3) **
+      (divisorMem0 ↦ₘ divisorSum0) ** (divisorMem1 ↦ₘ divisorSum1) **
+      (divisorMem2 ↦ₘ divisorSum2) ** (divisorMem3 ↦ₘ divisorSum3)))
+  let signFrame : Assertion :=
+    (((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12)))) **
+     ((dividendMem0 ↦ₘ dividendSum0) **
+      (dividendMem1 ↦ₘ dividendSum1) **
+      (dividendMem2 ↦ₘ dividendSum2) **
+      (dividendMem3 ↦ₘ dividendSum3) **
+      (.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) **
+      (.x10 ↦ᵣ divisorMask) ** (.x7 ↦ᵣ divisorSum3) **
+      (.x11 ↦ᵣ divisorCarry3) **
+      (divisorMem0 ↦ₘ divisorSum0) ** (divisorMem1 ↦ₘ divisorSum1) **
+      (divisorMem2 ↦ₘ divisorSum2) ** (divisorMem3 ↦ₘ divisorSum3)))
+  let signPre : Assertion :=
+    (((.x8 ↦ᵣ dividendSign) ** (.x9 ↦ᵣ divisorSign)) ** signFrame)
+  let post : Assertion :=
+    (((.x8 ↦ᵣ resultSign) ** (.x9 ↦ᵣ divisorSign)) ** signFrame)
+  have hPrefix : cpsTripleWithin 47 base (base + signXorOff)
+      (sdivCode base) pre prefixPost := by
+    dsimp [pre, prefixPost, dividendSign, divisorSign, dividendMem0,
+      dividendMem1, dividendMem2, dividendMem3, divisorMem0, divisorMem1,
+      divisorMem2, divisorMem3, EvmAsm.Evm64.evm_sdivDividendTopLimbOff,
+      EvmAsm.Evm64.evm_sdivDivisorTopLimbOff, dividendMask, dividendXored0,
+      dividendSum0, dividendCarry0, dividendXored1, dividendSum1,
+      dividendCarry1, dividendXored2, dividendSum2, dividendCarry2,
+      dividendXored3, dividendSum3, divisorMask, divisorXored0, divisorSum0,
+      divisorCarry0, divisorXored1, divisorSum1, divisorCarry1,
+      divisorXored2, divisorSum2, divisorCarry2, divisorXored3, divisorSum3,
+      divisorCarry3]
+    simpa [divisorAbsOff, signXorOff, BitVec.add_assoc] using
+      (saveRa_signs_abs_then_divisorAbs_spec_in_sdivCode
+        vRa vSavedOld sp sDividendOld sDivisorOld
+        dividendMaskOld dividendValueOld dividendCarryOld
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop base)
+  have hXor : cpsTripleWithin 1 (base + signXorOff) ((base + signXorOff) + 4)
+      (sdivCode base) signPre post := by
+    dsimp [signPre, post, signFrame, resultSign]
+    exact cpsTripleWithin_frameR signFrame (by pcFree)
+      (signXor_spec_in_sdivCode dividendSign divisorSign base)
+  have hSeq := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by
+      dsimp [prefixPost, signPre, signFrame] at hp ⊢
+      xperm_hyp hp) hPrefix hXor
+  simpa [pre, post] using hSeq
+
 theorem savedRaRet_spec_in_sdivCode
     (vSavedRa : Word) (base : Word) :
     cpsTripleWithin 1 (base + savedRaRetOff)


### PR DESCRIPTION
## Summary
- compose the normalized-operand SDIV prefix through the result sign XOR instruction
- preserve normalized dividend/divisor limb state while computing the result sign in x8
- expose the 48-instruction prefix postcondition after the sign selection step

Depends on #3593.
Refs #90.
Bead: evm-asm-01uh.

## Verification
- lake build EvmAsm.Evm64.SDiv.Compose.Base
- scripts/check-file-size.sh
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/Base.lean
- lake build