### PR TITLE
feat(exp): compose cond-mul skip continuations

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/CondMulSkip.lean
+++ b/EvmAsm/Evm64/Exp/Compose/CondMulSkip.lean
@@ -62,4 +62,28 @@ theorem exp_cond_mul_beq_evm_exp_union_spec_within_frameL
     (fun _ hp => by xperm_hyp hp)
     h
 
+/-- Compose the lifted EXP conditional-multiply skip gate with an arbitrary
+    false-branch continuation over the same top-level/callable code region. -/
+theorem exp_cond_mul_skip_then_triple_evm_exp_union_spec_within
+    {nSteps : Nat} {frame postFalse : Assertion} (hframe : frame.pcFree)
+    (v10 : Word) (mulOff : BitVec 21) (skipOff backOff : BitVec 13)
+    (base skipTarget mulTarget exitFalse : Word)
+    (hskip : ((base + 144) + signExtend13 skipOff : Word) = skipTarget)
+    (hfalse :
+      cpsTripleWithin nSteps (base + 148) exitFalse
+        ((evmExpCode base mulOff skipOff backOff).union
+          (mul_callable_code mulTarget))
+        (frame ** ((.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜v10 ≠ 0⌝))
+        postFalse) :
+    cpsBranchWithin (1 + nSteps) (base + 144)
+      ((evmExpCode base mulOff skipOff backOff).union
+        (mul_callable_code mulTarget))
+      (frame ** ((.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word))))
+      skipTarget
+        (frame ** ((.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜v10 = 0⌝))
+      exitFalse postFalse := by
+  have hbeq := exp_cond_mul_beq_evm_exp_union_spec_within_frameL
+    frame hframe v10 mulOff skipOff backOff base skipTarget mulTarget hskip
+  exact cpsBranchWithin_seq_cpsTripleWithin_same_cr hbeq hfalse (fun _ hp => hp)
+
 end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- add a reusable EXP skip-gate continuation adapter over evmExpCode union mul_callable_code
- sequence the lifted conditional-multiply BEQ with an arbitrary false-branch triple
- prepare the concrete composition with exp_cond_mul_marshal_pair_then_mul_call_evm_exp_spec_within

Depends on #3598.
Refs #92.
Bead: evm-asm-w5mk.

## Verification
- lake build EvmAsm.Evm64.Exp.Compose.CondMulSkip
- scripts/check-file-size.sh
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/Compose/CondMulSkip.lean
- lake build