### PR TITLE
feat(exp): frame cond-mul call false branch

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/CondMulSkip.lean
+++ b/EvmAsm/Evm64/Exp/Compose/CondMulSkip.lean
@@ -86,4 +86,60 @@ theorem exp_cond_mul_skip_then_triple_evm_exp_union_spec_within
     frame hframe v10 mulOff skipOff backOff base skipTarget mulTarget hskip
   exact cpsBranchWithin_seq_cpsTripleWithin_same_cr hbeq hfalse (fun _ hp => hp)
 
+/-- Existing conditional-MUL callable path framed with the false-branch facts
+    produced by the preceding BEQ skip gate. -/
+theorem exp_cond_mul_marshal_pair_then_mul_call_false_branch_spec_within
+    (sp evmSp tOld vOld r0 r1 r2 r3 a0 a1 a2 a3 d0 d1 d2 d3 e0 e1 e2 e3
+      v6 v7 v10 v11 mulTarget : Word)
+    (mulOff : BitVec 21) (skipOff backOff : BitVec 13) (base : Word)
+    (hmt : mulTarget = (base + 212) + signExtend21 mulOff)
+    (hd : CodeReq.Disjoint
+            (evmExpCode base mulOff skipOff backOff)
+            (mul_callable_code mulTarget)) :
+    let callPre :=
+      ((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+       ((evmSp + signExtend12 (0 : BitVec 12)) ↦ₘ d0) **
+       ((evmSp + signExtend12 (8 : BitVec 12)) ↦ₘ d1) **
+       ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ d2) **
+       ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ d3) **
+       ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ e0) **
+       ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ e1) **
+       ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ e2) **
+       ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ e3) **
+       ((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
+       ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **
+       ((evmSp + signExtend12 ((-48) : BitVec 12)) ↦ₘ a2) **
+       ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) **
+       (.x1 ↦ᵣ vOld))
+    let callPost :=
+      ((.x2 ↦ᵣ sp) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+       ((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
+       ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **
+       ((evmSp + signExtend12 ((-48) : BitVec 12)) ↦ₘ a2) **
+       ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3) **
+       evmMulStackPost evmSp (expResultWord r0 r1 r2 r3)
+                              (expResultWord a0 a1 a2 a3) **
+       (.x1 ↦ᵣ (base + 216)))
+    cpsTripleWithin (17 + 64) (base + 148) ((base + 216) &&& ~~~1)
+      ((evmExpCode base mulOff skipOff backOff).union
+        (mul_callable_code mulTarget))
+      (callPre ** ((.x0 ↦ᵣ (0 : Word)) ** ⌜v10 ≠ 0⌝))
+      (callPost ** ((.x0 ↦ᵣ (0 : Word)) ** ⌜v10 ≠ 0⌝)) := by
+  intro callPre callPost
+  have hcall := exp_cond_mul_marshal_pair_then_mul_call_evm_exp_spec_within
+    sp evmSp tOld vOld r0 r1 r2 r3 a0 a1 a2 a3 d0 d1 d2 d3 e0 e1 e2 e3
+    v6 v7 v10 v11 mulTarget mulOff skipOff backOff base hmt hd
+  have hframed :=
+    cpsTripleWithin_frameR ((.x0 ↦ᵣ (0 : Word)) ** ⌜v10 ≠ 0⌝) (by pcFree) hcall
+  simpa [callPre, callPost] using hframed
+
 end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- frame the conditional MUL callable path with the BEQ false-branch facts
- expose a theorem whose precondition includes x0 = 0 and v10 != 0
- prepare direct instantiation of the skip continuation adapter from #3599

Depends on #3599.
Refs #92.
Bead: evm-asm-w5mk.

## Verification
- lake build EvmAsm.Evm64.Exp.Compose.CondMulSkip
- scripts/check-file-size.sh
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/Compose/CondMulSkip.lean
- lake build