### PR TITLE
feat(exp): accept owned x5 in squaring unmarshal

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SquaringStep.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SquaringStep.lean
@@ -34,4 +34,31 @@ theorem exp_squaring_un_marshal_word_evm_exp_union_spec_within
     intro a i hcode
     exact CodeReq.union_mono_left a i hcode)
 
+/-- Ownership-form variant of the squaring unmarshal word spec.  This matches
+    the `regOwn .x5` produced by `mul_callable` in the squaring path. -/
+theorem exp_squaring_un_marshal_word_evm_exp_union_regOwn5_spec_within
+    (sp evmSp r0 r1 r2 r3 mulTarget : Word) (w : EvmWord)
+    (mulOff : BitVec 21) (skipOff backOff : BitVec 13)
+    (base : Word) :
+    cpsTripleWithin 9 (base + 108) (base + 144)
+      ((evmExpCode base mulOff skipOff backOff).union
+        (mul_callable_code mulTarget))
+      (((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ (evmSp + 32)) **
+        ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+        ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+        ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+        ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+        evmWordIs (evmSp + 32) w) ** regOwn .x5)
+      ((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ w.getLimbN 3) **
+       evmWordIs sp w ** evmWordIs (evmSp + 32) w) := by
+  refine cpsTripleWithin_of_forall_regIs_to_regOwn ?_
+  intro tOld
+  have h := exp_squaring_un_marshal_word_evm_exp_union_spec_within
+    sp evmSp tOld r0 r1 r2 r3 mulTarget w mulOff skipOff backOff base
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by
+      xperm_hyp hp)
+    (fun _ hp => hp)
+    h
+
 end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- add an ownership-form squaring unmarshal wrapper in Compose/SquaringStep.lean
- allow the unmarshal step to consume regOwn x5 produced by mul_callable
- prepare sequencing the squaring MUL-call postcondition into the unmarshal step

Depends on #3603.
Refs #92.
Bead: evm-asm-w5mk.

## Verification
- lake build EvmAsm.Evm64.Exp.Compose.SquaringStep
- scripts/check-file-size.sh
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/Compose/SquaringStep.lean
- lake build