### PR TITLE
feat(exp): sequence squaring call into unmarshal

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SquaringStep.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SquaringStep.lean
@@ -61,4 +61,68 @@ theorem exp_squaring_un_marshal_word_evm_exp_union_regOwn5_spec_within
     (fun _ hp => hp)
     h
 
+/-- Sequence the squaring MUL-call path into the squaring unmarshal step. -/
+theorem exp_squaring_mul_call_then_unmarshal_evm_exp_spec_within
+    (sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+      v6 v7 v10 v11 mulTarget : Word)
+    (mulOff : BitVec 21) (skipOff backOff : BitVec 13) (base : Word)
+    (hmt : mulTarget = (base + 104) + signExtend21 mulOff)
+    (halign : ((base + 108) &&& ~~~(1 : Word)) = base + 108)
+    (hd : CodeReq.Disjoint
+            (evmExpCode base mulOff skipOff backOff)
+            (mul_callable_code mulTarget)) :
+    let w := expResultWord r0 r1 r2 r3
+    let sq := w * w
+    let frame :=
+      ((.x1 ↦ᵣ (base + 108)) ** regOwn .x6 ** regOwn .x7 **
+       regOwn .x10 ** regOwn .x11 **
+       memOwn evmSp ** memOwn (evmSp + 8) **
+       memOwn (evmSp + 16) ** memOwn (evmSp + 24))
+    cpsTripleWithin ((17 + 64) + 9) (base + 40) (base + 144)
+      ((evmExpCode base mulOff skipOff backOff).union
+        (mul_callable_code mulTarget))
+      ((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+       ((evmSp + signExtend12 (0 : BitVec 12)) ↦ₘ d0) **
+       ((evmSp + signExtend12 (8 : BitVec 12)) ↦ₘ d1) **
+       ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ d2) **
+       ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ d3) **
+       ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ e0) **
+       ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ e1) **
+       ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ e2) **
+       ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ e3) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) **
+       (.x1 ↦ᵣ vOld))
+      (((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ sq.getLimbN 3) **
+        evmWordIs sp sq ** evmWordIs (evmSp + 32) sq) ** frame) := by
+  intro w sq frame
+  have hcall := exp_squaring_marshal_pair_then_mul_call_evm_exp_spec_within
+    sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+    v6 v7 v10 v11 mulTarget mulOff skipOff backOff base hmt hd
+  rw [halign] at hcall
+  have hunm := exp_squaring_un_marshal_word_evm_exp_union_regOwn5_spec_within
+    sp evmSp r0 r1 r2 r3 mulTarget sq mulOff skipOff backOff base
+  have hunmFramed :=
+    cpsTripleWithin_frameR frame (by
+      dsimp [frame]
+      pcFree) hunm
+  have hseq : cpsTripleWithin ((17 + 64) + 9) (base + 40) (base + 144)
+      ((evmExpCode base mulOff skipOff backOff).union
+        (mul_callable_code mulTarget)) _ _ :=
+    cpsTripleWithin_seq_perm_same_cr
+      (fun _ hp => by
+        dsimp [frame, w, sq] at hp ⊢
+        delta evmMulStackPost at hp
+        sep_perm hp)
+      hcall hunmFramed
+  exact cpsTripleWithin_weaken
+    (fun _ hp => hp)
+    (fun _ hp => by
+      dsimp [frame, sq] at hp ⊢
+      sep_perm hp)
+    hseq
+
 end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- sequence the EXP squaring MUL-call path into the owned-x5 unmarshal wrapper
- expose the post-unmarshal square as evmWordIs at the local and EVM scratch locations
- carry the required aligned JALR return fact explicitly for the composed helper

Depends on #3604.
Refs #92.
Bead: evm-asm-w5mk.

## Verification
- lake build EvmAsm.Evm64.Exp.Compose.SquaringStep
- scripts/check-file-size.sh
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/Compose/SquaringStep.lean
- lake build