### PR TITLE
feat(divmod): expose div n1 no-nop tail

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Epilogue.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Epilogue.lean
@@ -19,19 +19,20 @@ open EvmAsm.Rv64.AddrNorm (bv64_4mul_3)
 -- LD shift, BEQ skip, ADDI+SUB anti, 3×merge + last
 -- ============================================================================
 
-/-- Denorm code (block 9) is subsumed by divCode. -/
-private theorem divK_denorm_code_sub_divCode {base : Word} :
-    ∀ a i, (CodeReq.ofProg (base + denormOff) divK_denorm) a = some i → (divCode base) a = some i := by
-  unfold divCode; simp only [CodeReq.unionAll_cons]
+/-- Denorm code (block 9) is subsumed by divCode_noNop. -/
+private theorem divK_denorm_code_sub_divCode_noNop {base : Word} :
+    ∀ a i, (CodeReq.ofProg (base + denormOff) divK_denorm) a = some i →
+      (divCode_noNop base) a = some i := by
+  unfold divCode_noNop; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
   skipBlock; skipBlock; skipBlock; skipBlock
   exact CodeReq.union_mono_left
 
 /-- Denorm preamble for shift≠0: LD shift from memory + BEQ not taken.
     base+908 → base+916. Bridges the gap between loop body exit and denorm body. -/
-theorem divK_denorm_preamble_spec_within (sp shift v5 v6 v7 v2 v10 : Word) (base : Word)
+theorem divK_denorm_preamble_spec_within_noNop (sp shift v5 v6 v7 v2 v10 : Word) (base : Word)
     (hshift_nz : shift ≠ 0) :
-    cpsTripleWithin 2 (base + denormOff) (base + denormOff + 8) (divCode base)
+    cpsTripleWithin 2 (base + denormOff) (base + denormOff + 8) (divCode_noNop base)
       ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ v6) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ v2) ** (.x10 ↦ᵣ v10) **
        ((sp + signExtend12 3992) ↦ₘ shift))
@@ -42,7 +43,7 @@ theorem divK_denorm_preamble_spec_within (sp shift v5 v6 v7 v2 v10 : Word) (base
   have hld := ld_spec_gen_within .x6 .x12 sp v6 shift (3992 : BitVec 12) (base + denormOff) (by nofun)
   have hlde := cpsTripleWithin_extend_code (hmono := by
     intro a i h
-    exact divK_denorm_code_sub_divCode a i
+    exact divK_denorm_code_sub_divCode_noNop a i
       (CodeReq.ofProg_mono_sub (base + denormOff) (base + denormOff) divK_denorm
         [.LD .x6 .x12 3992] 0 (by bv_addr) (by decide) (by decide) (by decide) a i h)) hld
   -- 2. BEQ x6 x0 96 at base+912 (denorm instr [1])
@@ -51,7 +52,7 @@ theorem divK_denorm_preamble_spec_within (sp shift v5 v6 v7 v2 v10 : Word) (base
       show (base + denormOff + 4 : Word) + 4 = base + denormOff + 8 from by bv_addr] at hbeq
   have hbeqe := cpsBranchWithin_extend_code (hmono := by
     intro a i h
-    exact divK_denorm_code_sub_divCode a i
+    exact divK_denorm_code_sub_divCode_noNop a i
       (CodeReq.ofProg_mono_sub (base + denormOff) (base + denormOff + 4) divK_denorm
         [.BEQ .x6 .x0 96] 1 (by bv_addr) (by decide) (by decide) (by decide) a i h)) hbeq
   -- 3. Eliminate taken branch: shift ≠ 0 means BEQ not taken
@@ -81,13 +82,25 @@ theorem divK_denorm_preamble_spec_within (sp shift v5 v6 v7 v2 v10 : Word) (base
     (fun h hq => by xperm_hyp hq)
     full
 
-theorem divK_denorm_body_spec_within (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Word) :
+theorem divK_denorm_preamble_spec_within (sp shift v5 v6 v7 v2 v10 : Word) (base : Word)
+    (hshift_nz : shift ≠ 0) :
+    cpsTripleWithin 2 (base + denormOff) (base + denormOff + 8) (divCode base)
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ v6) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ v2) ** (.x10 ↦ᵣ v10) **
+       ((sp + signExtend12 3992) ↦ₘ shift))
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ v2) ** (.x10 ↦ᵣ v10) **
+       ((sp + signExtend12 3992) ↦ₘ shift)) :=
+  cpsTripleWithin_extend_code (hmono := divCode_noNop_sub_divCode)
+    (divK_denorm_preamble_spec_within_noNop sp shift v5 v6 v7 v2 v10 base hshift_nz)
+
+theorem divK_denorm_body_spec_within_noNop (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Word) :
     let antiShift := signExtend12 (0 : BitVec 12) - shift
     let u0' := (u0 >>> (shift.toNat % 64)) ||| (u1 <<< (antiShift.toNat % 64))
     let u1' := (u1 >>> (shift.toNat % 64)) ||| (u2 <<< (antiShift.toNat % 64))
     let u2' := (u2 >>> (shift.toNat % 64)) ||| (u3 <<< (antiShift.toNat % 64))
     let u3' := u3 >>> (shift.toNat % 64)
-    cpsTripleWithin 23 (base + denormOff + 8) (base + epilogueOff) (divCode base)
+    cpsTripleWithin 23 (base + denormOff + 8) (base + epilogueOff) (divCode_noNop base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) **
        (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) **
        ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
@@ -101,7 +114,7 @@ theorem divK_denorm_body_spec_within (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (bas
   have haddi := addi_x0_spec_gen_within .x2 v2 0 (base + denormOff + 8) (by nofun)
   rw [show (base + denormOff + 8 : Word) + 4 = base + denormOff + 12 from by bv_addr] at haddi
   have haddie := cpsTripleWithin_extend_code (hmono := fun a i h =>
-    divK_denorm_code_sub_divCode a i
+    divK_denorm_code_sub_divCode_noNop a i
       (CodeReq.ofProg_mono_sub (base + denormOff) (base + denormOff + 8) divK_denorm
         [.ADDI .x2 .x0 0] 2
         (by bv_addr) (by decide) (by decide) (by decide) a i h)) haddi
@@ -115,7 +128,7 @@ theorem divK_denorm_body_spec_within (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (bas
     (signExtend12 (0 : BitVec 12)) shift (base + denormOff + 12) (by nofun)
   rw [show (base + denormOff + 12 : Word) + 4 = base + denormOff + 16 from by bv_addr] at hsub
   have hsube := cpsTripleWithin_extend_code (hmono := fun a i h =>
-    divK_denorm_code_sub_divCode a i
+    divK_denorm_code_sub_divCode_noNop a i
       (CodeReq.singleton_mono (by
         have hlookup := CodeReq.ofProg_lookup (base + denormOff) divK_denorm 3
           (by decide) (by decide)
@@ -133,7 +146,7 @@ theorem divK_denorm_body_spec_within (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (bas
   have hm0 := divK_denorm_merge_spec_within 4056 4048 sp u0 u1 v5 v7 shift antiShift (base + denormOff + 16)
   rw [show (base + denormOff + 16 : Word) + 24 = base + denormOff + 40 from by bv_addr] at hm0
   have hm0e := cpsTripleWithin_extend_code (hmono := fun a i h =>
-    divK_denorm_code_sub_divCode a i
+    divK_denorm_code_sub_divCode_noNop a i
       (CodeReq.ofProg_mono_sub (base + denormOff) (base + denormOff + 16) divK_denorm
         (divK_denorm_merge_prog 4056 4048) 4
         (by bv_addr) (by decide) (by decide) (by decide) a i h)) hm0
@@ -148,7 +161,7 @@ theorem divK_denorm_body_spec_within (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (bas
     u0' (u1 <<< (antiShift.toNat % 64)) shift antiShift (base + denormOff + 40)
   rw [show (base + denormOff + 40 : Word) + 24 = base + denormOff + 64 from by bv_addr] at hm1
   have hm1e := cpsTripleWithin_extend_code (hmono := fun a i h =>
-    divK_denorm_code_sub_divCode a i
+    divK_denorm_code_sub_divCode_noNop a i
       (CodeReq.ofProg_mono_sub (base + denormOff) (base + denormOff + 40) divK_denorm
         (divK_denorm_merge_prog 4048 4040) 10
         (by bv_addr) (by decide) (by decide) (by decide) a i h)) hm1
@@ -163,7 +176,7 @@ theorem divK_denorm_body_spec_within (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (bas
     u1' (u2 <<< (antiShift.toNat % 64)) shift antiShift (base + denormOff + 64)
   rw [show (base + denormOff + 64 : Word) + 24 = base + denormOff + 88 from by bv_addr] at hm2
   have hm2e := cpsTripleWithin_extend_code (hmono := fun a i h =>
-    divK_denorm_code_sub_divCode a i
+    divK_denorm_code_sub_divCode_noNop a i
       (CodeReq.ofProg_mono_sub (base + denormOff) (base + denormOff + 64) divK_denorm
         (divK_denorm_merge_prog 4040 4032) 16
         (by bv_addr) (by decide) (by decide) (by decide) a i h)) hm2
@@ -177,7 +190,7 @@ theorem divK_denorm_body_spec_within (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (bas
   have hl := divK_denorm_last_spec_within 4032 sp u3 u2' shift (base + denormOff + 88)
   rw [show (base + denormOff + 88 : Word) + 12 = base + epilogueOff from by bv_addr] at hl
   have hle := cpsTripleWithin_extend_code (hmono := fun a i h =>
-    divK_denorm_code_sub_divCode a i
+    divK_denorm_code_sub_divCode_noNop a i
       (CodeReq.ofProg_mono_sub (base + denormOff) (base + denormOff + 88) divK_denorm
         (divK_denorm_last_prog 4032) 22
         (by bv_addr) (by decide) (by decide) (by decide) a i h)) hl
@@ -193,25 +206,43 @@ theorem divK_denorm_body_spec_within (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (bas
     (fun h hq => by xperm_hyp hq)
     h_all
 
+theorem divK_denorm_body_spec_within (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Word) :
+    let antiShift := signExtend12 (0 : BitVec 12) - shift
+    let u0' := (u0 >>> (shift.toNat % 64)) ||| (u1 <<< (antiShift.toNat % 64))
+    let u1' := (u1 >>> (shift.toNat % 64)) ||| (u2 <<< (antiShift.toNat % 64))
+    let u2' := (u2 >>> (shift.toNat % 64)) ||| (u3 <<< (antiShift.toNat % 64))
+    let u3' := u3 >>> (shift.toNat % 64)
+    cpsTripleWithin 23 (base + denormOff + 8) (base + epilogueOff) (divCode base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) **
+       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) **
+       ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
+       ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3))
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ u3') ** (.x7 ↦ᵣ (u3 <<< (antiShift.toNat % 64))) **
+       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) ** (.x0 ↦ᵣ (0 : Word)) **
+       ((sp + signExtend12 4056) ↦ₘ u0') ** ((sp + signExtend12 4048) ↦ₘ u1') **
+       ((sp + signExtend12 4040) ↦ₘ u2') ** ((sp + signExtend12 4032) ↦ₘ u3')) :=
+  cpsTripleWithin_extend_code (hmono := divCode_noNop_sub_divCode)
+    (divK_denorm_body_spec_within_noNop sp u0 u1 u2 u3 v2 v5 v7 shift base)
+
 -- ============================================================================
 -- Section 10m: DIV Epilogue composition (10 instructions at base+1008)
 -- Load q[0..3], ADDI sp+32, store to output, JAL to NOP
 -- ============================================================================
 
-/-- DIV epilogue code (block 10) is subsumed by divCode. -/
-private theorem divK_divEpilogue_code_sub_divCode {base : Word} :
+/-- DIV epilogue code (block 10) is subsumed by divCode_noNop. -/
+private theorem divK_divEpilogue_code_sub_divCode_noNop {base : Word} :
     ∀ a i, (CodeReq.ofProg (base + epilogueOff) (divK_div_epilogue 24)) a = some i →
-      (divCode base) a = some i := by
-  unfold divCode; simp only [CodeReq.unionAll_cons]
+      (divCode_noNop base) a = some i := by
+  unfold divCode_noNop; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
   exact CodeReq.union_mono_left
 
 /-- Full DIV epilogue: load q[0..3] from scratch, advance sp, store to output, JAL to NOP.
     base+1008 → base+1068 (10 instructions). -/
-theorem divK_div_epilogue_spec_within (sp : Word) (base : Word)
+theorem divK_div_epilogue_spec_within_noNop (sp : Word) (base : Word)
     (q0 q1 q2 q3 v5 v6 v7 v10 m0 m8 m16 m24 : Word) :
-    cpsTripleWithin 10 (base + epilogueOff) (base + nopOff) (divCode base)
+    cpsTripleWithin 10 (base + epilogueOff) (base + nopOff) (divCode_noNop base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x10 ↦ᵣ v10) **
        ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
        ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
@@ -226,7 +257,7 @@ theorem divK_div_epilogue_spec_within (sp : Word) (base : Word)
   have hload := divK_epilogue_load_spec_within 4088 4080 4072 4064 sp q0 q1 q2 q3 v5 v6 v7 v10
     (base + epilogueOff)
   have hloade := cpsTripleWithin_extend_code (hmono := fun a i h =>
-    divK_divEpilogue_code_sub_divCode a i
+    divK_divEpilogue_code_sub_divCode_noNop a i
       (CodeReq.ofProg_mono_sub (base + epilogueOff) (base + epilogueOff) (divK_div_epilogue 24)
         (divK_epilogue_load_prog 4088 4080 4072 4064) 0
         (by bv_addr) (by decide) (by decide) (by decide) a i h)) hload
@@ -235,7 +266,7 @@ theorem divK_div_epilogue_spec_within (sp : Word) (base : Word)
   rw [show (base + epilogueOff + 16 : Word) + 20 + signExtend21 24 = base + nopOff from by rv64_addr]
     at hstore
   have hstoree := cpsTripleWithin_extend_code (hmono := fun a i h =>
-    divK_divEpilogue_code_sub_divCode a i
+    divK_divEpilogue_code_sub_divCode_noNop a i
       (CodeReq.ofProg_mono_sub (base + epilogueOff) (base + epilogueOff + 16) (divK_div_epilogue 24)
         (divK_epilogue_store_prog 24) 4
         (by bv_addr) (by decide) (by decide) (by decide) a i h)) hstore
@@ -254,6 +285,22 @@ theorem divK_div_epilogue_spec_within (sp : Word) (base : Word)
     (fun h hp => by xperm_hyp hp)
     (fun h hq => by xperm_hyp hq)
     h12
+
+theorem divK_div_epilogue_spec_within (sp : Word) (base : Word)
+    (q0 q1 q2 q3 v5 v6 v7 v10 m0 m8 m16 m24 : Word) :
+    cpsTripleWithin 10 (base + epilogueOff) (base + nopOff) (divCode base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x10 ↦ᵣ v10) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + 32) ↦ₘ m0) ** ((sp + 40) ↦ₘ m8) **
+       ((sp + 48) ↦ₘ m16) ** ((sp + 56) ↦ₘ m24))
+      ((.x12 ↦ᵣ (sp + 32)) ** (.x5 ↦ᵣ q0) ** (.x6 ↦ᵣ q1) ** (.x7 ↦ᵣ q2) ** (.x10 ↦ᵣ q3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + 32) ↦ₘ q0) ** ((sp + 40) ↦ₘ q1) **
+       ((sp + 48) ↦ₘ q2) ** ((sp + 56) ↦ₘ q3)) :=
+  cpsTripleWithin_extend_code (hmono := divCode_noNop_sub_divCode)
+    (divK_div_epilogue_spec_within_noNop sp base q0 q1 q2 q3 v5 v6 v7 v10 m0 m8 m16 m24)
 
 -- ============================================================================
 -- Section 11: MOD program code infrastructure

--- a/EvmAsm/Evm64/DivMod/Compose/FullPath.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPath.lean
@@ -392,12 +392,12 @@ theorem evm_div_n4_shift0_to_loopSetup_spec (sp base : Word)
 -- Denormalize u[] then load q[] to output.
 -- ============================================================================
 
-/-- Post-loop chain for DIV: denormalize u[], then load q[] to output.
+/-- Post-loop chain for DIV over `divCode_noNop`: denormalize u[], then load q[] to output.
     base+916 → base+1068. Shift ≠ 0 case (denorm body executed). -/
-theorem evm_div_denorm_epilogue_spec (sp base : Word)
+theorem evm_div_denorm_epilogue_spec_noNop (sp base : Word)
     (u0 u1 u2 u3 v2 v5 v7 v10 shift : Word)
     (q0 q1 q2 q3 m0 m8 m16 m24 : Word) :
-    cpsTripleWithin (23 + 10) (base + denormOff + 8) (base + nopOff) (divCode base)
+    cpsTripleWithin (23 + 10) (base + denormOff + 8) (base + nopOff) (divCode_noNop base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ shift) ** (.x7 ↦ᵣ v7) **
        (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10) **
        ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
@@ -413,7 +413,7 @@ theorem evm_div_denorm_epilogue_spec (sp base : Word)
   let u2' := (u2 >>> (shift.toNat % 64)) ||| (u3 <<< (antiShift.toNat % 64))
   let u3' := u3 >>> (shift.toNat % 64)
   -- Step 1: Denorm body (base+916 → base+1008)
-  have hDenorm := divK_denorm_body_spec_within sp u0 u1 u2 u3 v2 v5 v7 shift base
+  have hDenorm := divK_denorm_body_spec_within_noNop sp u0 u1 u2 u3 v2 v5 v7 shift base
 
   intro_lets at hDenorm
   -- Frame denorm with x10, q[], output memory
@@ -426,7 +426,7 @@ theorem evm_div_denorm_epilogue_spec (sp base : Word)
     (by pcFree) hDenorm
   -- Step 2: DIV epilogue (base+1008 → base+1068)
   -- After denorm: x5=u3', x6=shift, x7=(u3<<<antiShift%64), x10=v10
-  have hEpi := divK_div_epilogue_spec_within sp base q0 q1 q2 q3
+  have hEpi := divK_div_epilogue_spec_within_noNop sp base q0 q1 q2 q3
     u3' shift (u3 <<< (antiShift.toNat % 64)) v10 m0 m8 m16 m24
 
   -- Frame epilogue with x2, x0, u'[]
@@ -443,13 +443,75 @@ theorem evm_div_denorm_epilogue_spec (sp base : Word)
     (fun h hq => by delta denormDivPost; xperm_hyp hq)
     hFull
 
+/-- Compatibility wrapper for the DIV denorm+epilogue tail over `divCode`. -/
+theorem evm_div_denorm_epilogue_spec (sp base : Word)
+    (u0 u1 u2 u3 v2 v5 v7 v10 shift : Word)
+    (q0 q1 q2 q3 m0 m8 m16 m24 : Word) :
+    cpsTripleWithin (23 + 10) (base + denormOff + 8) (base + nopOff) (divCode base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ shift) ** (.x7 ↦ᵣ v7) **
+       (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10) **
+       ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
+       ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + 32) ↦ₘ m0) ** ((sp + 40) ↦ₘ m8) **
+       ((sp + 48) ↦ₘ m16) ** ((sp + 56) ↦ₘ m24))
+      (denormDivPost sp shift u0 u1 u2 u3 q0 q1 q2 q3) :=
+  cpsTripleWithin_extend_code (hmono := divCode_noNop_sub_divCode)
+    (evm_div_denorm_epilogue_spec_noNop sp base u0 u1 u2 u3 v2 v5 v7 v10 shift
+      q0 q1 q2 q3 m0 m8 m16 m24)
+
 -- ============================================================================
 -- Post-loop chain with preamble: Preamble → Denorm → DIV Epilogue (base+908 → base+1068)
 -- Loads shift from memory, denormalizes u[], then loads q[] to output.
 -- ============================================================================
 
-/-- Post-loop chain for DIV with preamble: loads shift, denormalizes u[], outputs q[].
+/-- Post-loop chain for DIV with preamble over `divCode_noNop`:
+    loads shift, denormalizes u[], outputs q[].
     base+908 → base+1068. Shift ≠ 0 case. -/
+theorem evm_div_preamble_denorm_epilogue_spec_noNop (sp base : Word)
+    (u0 u1 u2 u3 shift v2 v5 v6 v7 v10 : Word)
+    (q0 q1 q2 q3 m0 m8 m16 m24 : Word)
+    (hshift_nz : shift ≠ 0) :
+    cpsTripleWithin (2 + 23 + 10) (base + denormOff) (base + nopOff) (divCode_noNop base)
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ v6) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ v2) ** (.x10 ↦ᵣ v10) **
+       ((sp + signExtend12 3992) ↦ₘ shift) **
+       ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
+       ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + 32) ↦ₘ m0) ** ((sp + 40) ↦ₘ m8) **
+       ((sp + 48) ↦ₘ m16) ** ((sp + 56) ↦ₘ m24))
+      (denormDivPost sp shift u0 u1 u2 u3 q0 q1 q2 q3 **
+       ((sp + signExtend12 3992) ↦ₘ shift)) := by
+  -- Step 1: Preamble (base+908 → base+916)
+  have hPre := divK_denorm_preamble_spec_within_noNop sp shift v5 v6 v7 v2 v10 base hshift_nz
+  -- Frame preamble with u[], q[], output memory
+  have hPreF := cpsTripleWithin_frameR
+    (((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
+     ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3) **
+     ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+     ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+     ((sp + 32) ↦ₘ m0) ** ((sp + 40) ↦ₘ m8) **
+     ((sp + 48) ↦ₘ m16) ** ((sp + 56) ↦ₘ m24))
+    (by pcFree) hPre
+  -- Step 2: Denorm + Epilogue (base+916 → base+1068)
+  have hDE := evm_div_denorm_epilogue_spec_noNop sp base u0 u1 u2 u3 v2 v5 v7 v10 shift
+    q0 q1 q2 q3 m0 m8 m16 m24
+  -- Frame epilogue with shiftMem
+  have hDEF := cpsTripleWithin_frameR
+    (((sp + signExtend12 3992) ↦ₘ shift))
+    (by pcFree) hDE
+  -- Compose preamble → denorm+epilogue
+  have hFull := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hPreF hDEF
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    hFull
+
+/-- Compatibility wrapper for the DIV preamble+denorm+epilogue tail over `divCode`. -/
 theorem evm_div_preamble_denorm_epilogue_spec (sp base : Word)
     (u0 u1 u2 u3 shift v2 v5 v6 v7 v10 : Word)
     (q0 q1 q2 q3 m0 m8 m16 m24 : Word)
@@ -465,32 +527,10 @@ theorem evm_div_preamble_denorm_epilogue_spec (sp base : Word)
        ((sp + 32) ↦ₘ m0) ** ((sp + 40) ↦ₘ m8) **
        ((sp + 48) ↦ₘ m16) ** ((sp + 56) ↦ₘ m24))
       (denormDivPost sp shift u0 u1 u2 u3 q0 q1 q2 q3 **
-       ((sp + signExtend12 3992) ↦ₘ shift)) := by
-  -- Step 1: Preamble (base+908 → base+916)
-  have hPre := divK_denorm_preamble_spec_within sp shift v5 v6 v7 v2 v10 base hshift_nz
-  -- Frame preamble with u[], q[], output memory
-  have hPreF := cpsTripleWithin_frameR
-    (((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
-     ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3) **
-     ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
-     ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
-     ((sp + 32) ↦ₘ m0) ** ((sp + 40) ↦ₘ m8) **
-     ((sp + 48) ↦ₘ m16) ** ((sp + 56) ↦ₘ m24))
-    (by pcFree) hPre
-  -- Step 2: Denorm + Epilogue (base+916 → base+1068)
-  have hDE := evm_div_denorm_epilogue_spec sp base u0 u1 u2 u3 v2 v5 v7 v10 shift
-    q0 q1 q2 q3 m0 m8 m16 m24
-  -- Frame epilogue with shiftMem
-  have hDEF := cpsTripleWithin_frameR
-    (((sp + signExtend12 3992) ↦ₘ shift))
-    (by pcFree) hDE
-  -- Compose preamble → denorm+epilogue
-  have hFull := cpsTripleWithin_seq_perm_same_cr
-    (fun h hp => by xperm_hyp hp) hPreF hDEF
-  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
-    (fun h hp => by xperm_hyp hp)
-    (fun h hq => by xperm_hyp hq)
-    hFull
+       ((sp + signExtend12 3992) ↦ₘ shift)) :=
+  cpsTripleWithin_extend_code (hmono := divCode_noNop_sub_divCode)
+    (evm_div_preamble_denorm_epilogue_spec_noNop sp base u0 u1 u2 u3 shift
+      v2 v5 v6 v7 v10 q0 q1 q2 q3 m0 m8 m16 m24 hshift_nz)
 
 -- ============================================================================
 -- Denorm code subsumption for modCode (re-proved here since private in ModEpilogue)

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1LoopUnified.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1LoopUnified.lean
@@ -495,6 +495,37 @@ theorem evm_div_n1_denorm_epilogue_bundled_spec
       xperm_hyp hq)
     h
 
+theorem evm_div_n1_denorm_epilogue_bundled_spec_noNop
+    (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
+    (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hshift_nz : fullDivN1Shift b0 ≠ 0) :
+    cpsTripleWithin (2 + 23 + 10) (base + denormOff) (base + nopOff) (divCode_noNop base)
+      (fullDivN1DenormPre bltu_3 bltu_2 bltu_1 bltu_0 sp a0 a1 a2 a3 b0 b1 b2 b3)
+      (fullDivN1DenormPost bltu_3 bltu_2 bltu_1 bltu_0 sp a0 a1 a2 a3 b0 b1 b2 b3) := by
+  let shift := fullDivN1Shift b0
+  let v := fullDivN1NormV b0 b1 b2 b3
+  let r3 := fullDivN1R3 bltu_3 a0 a1 a2 a3 b0 b1 b2 b3
+  let r2 := fullDivN1R2 bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3
+  let r1 := fullDivN1R1 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+  let r0 := fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+  let c3 := fullDivN1C3 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+  have h := evm_div_preamble_denorm_epilogue_spec_noNop sp base
+    r0.2.1 r0.2.2.1 r0.2.2.2.1 r0.2.2.2.2.1 shift
+    r0.2.2.2.2.1 (0 : Word) (sp + signExtend12 4056) (sp + signExtend12 4088)
+    c3 r0.1 r1.1 r2.1 r3.1
+    v.1 v.2.1 v.2.2.1 v.2.2.2 hshift_nz
+  exact cpsTripleWithin_weaken
+    (fun h hp => by
+      subst shift; subst v; subst r3; subst r2; subst r1; subst r0; subst c3
+      delta fullDivN1DenormPre at hp
+      simp only [se12_32, se12_40, se12_48, se12_56] at hp
+      xperm_hyp hp)
+    (fun h hq => by
+      subst shift; subst r3; subst r2; subst r1; subst r0
+      delta fullDivN1DenormPost
+      xperm_hyp hq)
+    h
+
 theorem fullDivN1UnifiedPost_weaken (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
     (sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 : Word)
     (h : PartialState)


### PR DESCRIPTION
Refs #90.\n\nBead: evm-asm-01uh\nDepends on: #3608\n\n## Summary\n- add no-NOP DIV denorm preamble/body/epilogue wrappers while preserving the existing divCode theorem names as compatibility wrappers\n- add no-NOP composed DIV denorm+epilogue and preamble+denorm+epilogue tail specs\n- expose the N1 bundled denorm+epilogue tail over divCode_noNop for the next no-NOP N1 full-path composition slice\n\n## Verification\n- lake build EvmAsm.Evm64.DivMod.Compose.Epilogue\n- lake build EvmAsm.Evm64.DivMod.Compose.FullPath\n- lake build EvmAsm.Evm64.DivMod.Compose.FullPathN1LoopUnified\n- scripts/check-file-size.sh\n- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/Compose/Epilogue.lean EvmAsm/Evm64/DivMod/Compose/FullPath.lean EvmAsm/Evm64/DivMod/Compose/FullPathN1LoopUnified.lean\n- lake build