### PR TITLE
feat(divmod): add n1 clz no-nop wrapper

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose.lean
+++ b/EvmAsm/Evm64/DivMod/Compose.lean
@@ -26,6 +26,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN3
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1
 import EvmAsm.Evm64.DivMod.Compose.PhaseABNoNop
+import EvmAsm.Evm64.DivMod.Compose.FullPathN1NoNop
 import EvmAsm.Evm64.DivMod.Compose.ModFullPath
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN3
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN2

--- a/EvmAsm/Evm64/DivMod/Compose/CLZ.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/CLZ.lean
@@ -27,6 +27,14 @@ private theorem divK_clz_code_sub_divCode {base : Word} :
   skipBlock; skipBlock
   exact CodeReq.union_mono_left
 
+/-- CLZ code (block 2) is subsumed by divCode_noNop. -/
+private theorem divK_clz_code_sub_divCode_noNop {base : Word} :
+    ∀ a i, (CodeReq.ofProg (base + clzOff) divK_clz) a = some i →
+      (divCode_noNop base) a = some i := by
+  unfold divCode_noNop; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock
+  exact CodeReq.union_mono_left
+
 /-- Helper: CLZ stage at instruction index k is subsumed by divCode.
     The stage has 4 instructions starting at index k of divK_clz. -/
 private theorem clz_stage_sub {base : Word}
@@ -39,6 +47,20 @@ private theorem clz_stage_sub {base : Word}
       (divCode base) a = some i := by
   intro a i h
   exact divK_clz_code_sub_divCode a i
+    (CodeReq.ofProg_mono_sub (base + clzOff) _ divK_clz _ k
+      rfl hslice hk hbound a i h)
+
+/-- Helper: CLZ stage at instruction index k is subsumed by divCode_noNop. -/
+private theorem clz_stage_sub_noNop {base : Word}
+    (K M_s : BitVec 6) (M_a : BitVec 12) (k : Nat)
+    (hk : k + (divK_clz_stage_prog K M_s M_a).length ≤ divK_clz.length)
+    (hslice : (divK_clz.drop k).take (divK_clz_stage_prog K M_s M_a).length =
+      divK_clz_stage_prog K M_s M_a)
+    (hbound : 4 * divK_clz.length < 2 ^ 64) :
+    ∀ a i, (divK_clz_stage_code K M_s M_a ((base + clzOff) + BitVec.ofNat 64 (4 * k))) a = some i →
+      (divCode_noNop base) a = some i := by
+  intro a i h
+  exact divK_clz_code_sub_divCode_noNop a i
     (CodeReq.ofProg_mono_sub (base + clzOff) _ divK_clz _ k
       rfl hslice hk hbound a i h)
 
@@ -55,12 +77,34 @@ private theorem clz_last_sub {base : Word} (k : Nat)
     (CodeReq.ofProg_mono_sub (base + clzOff) _ divK_clz _ k
       rfl hslice hk hbound a i h)
 
+/-- Helper: CLZ last stage at instruction index k is subsumed by divCode_noNop. -/
+private theorem clz_last_sub_noNop {base : Word} (k : Nat)
+    (hk : k + divK_clz_last_prog.length ≤ divK_clz.length)
+    (hslice : (divK_clz.drop k).take divK_clz_last_prog.length = divK_clz_last_prog)
+    (hbound : 4 * divK_clz.length < 2 ^ 64) :
+    ∀ a i, (divK_clz_last_code ((base + clzOff) + BitVec.ofNat 64 (4 * k))) a = some i →
+      (divCode_noNop base) a = some i := by
+  intro a i h
+  exact divK_clz_code_sub_divCode_noNop a i
+    (CodeReq.ofProg_mono_sub (base + clzOff) _ divK_clz _ k
+      rfl hslice hk hbound a i h)
+
 /-- Helper: CLZ init singleton (ADDI x6 x0 0 at base+116) is subsumed by divCode. -/
 private theorem clz_init_sub {base : Word} :
     ∀ a i, (CodeReq.singleton (base + clzOff) (.ADDI .x6 .x0 0)) a = some i →
       (divCode base) a = some i := by
   intro a i h
   exact divK_clz_code_sub_divCode a i
+    (CodeReq.singleton_mono (CodeReq.ofProg_lookup (base + clzOff) divK_clz 0
+      (by decide) (by decide)) a i (by rwa [show (base + clzOff : Word) =
+        base + clzOff + BitVec.ofNat 64 (4 * 0) from by bv_addr] at h))
+
+/-- Helper: CLZ init singleton (ADDI x6 x0 0 at base+116) is subsumed by divCode_noNop. -/
+private theorem clz_init_sub_noNop {base : Word} :
+    ∀ a i, (CodeReq.singleton (base + clzOff) (.ADDI .x6 .x0 0)) a = some i →
+      (divCode_noNop base) a = some i := by
+  intro a i h
+  exact divK_clz_code_sub_divCode_noNop a i
     (CodeReq.singleton_mono (CodeReq.ofProg_lookup (base + clzOff) divK_clz 0
       (by decide) (by decide)) a i (by rwa [show (base + clzOff : Word) =
         base + clzOff + BitVec.ofNat 64 (4 * 0) from by bv_addr] at h))
@@ -230,3 +274,76 @@ theorem divK_clz_spec_within (val v6Old v7Old : Word) (base : Word) :
     (fun h hq => by xperm_hyp hq)
     IefS0eS1eS2eS3eS4eS5e
 
+theorem divK_clz_spec_within_noNop (val v6Old v7Old : Word) (base : Word) :
+    cpsTripleWithin 24 (base + clzOff) (base + phaseC2Off) (divCode_noNop base)
+      ((.x5 ↦ᵣ val) ** (.x6 ↦ᵣ v6Old) ** (.x7 ↦ᵣ v7Old) ** (.x0 ↦ᵣ (0 : Word)))
+      ((.x5 ↦ᵣ (clzResult val).2) ** (.x6 ↦ᵣ (clzResult val).1) **
+       (.x7 ↦ᵣ (clzResult val).2 >>> (63 : Nat)) ** (.x0 ↦ᵣ (0 : Word))) := by
+  unfold clzResult
+  have I := divK_clz_init_spec_within v6Old (base + clzOff)
+  have Ie := cpsTripleWithin_extend_code (hmono := clz_init_sub_noNop) I
+  have Ief := cpsTripleWithin_frameR
+    ((.x5 ↦ᵣ val) ** (.x7 ↦ᵣ v7Old)) (by pcFree) Ie
+  have S0 := divK_clz_stage_combined_within 32 32 32 val (signExtend12 0) v7Old
+    ((base + clzOff) + BitVec.ofNat 64 (4 * 1))
+  dsimp only [] at S0
+  have S0e := cpsTripleWithin_extend_code (hmono := clz_stage_sub_noNop 32 32 32 1
+    (by decide) (by decide) (by decide)) S0
+  rw [show (base + clzOff : Word) + BitVec.ofNat 64 (4 * 1) = base + clzOff + 4 from by bv_addr] at S0e
+  rw [clz_addr1] at S0e
+  seqFrame Ief S0e
+  let v0 := if val >>> (32 : BitVec 6).toNat ≠ 0 then val else val <<< (32 : BitVec 6).toNat
+  let c0 := if val >>> (32 : BitVec 6).toNat ≠ 0 then signExtend12 (0 : BitVec 12)
+    else signExtend12 (0 : BitVec 12) + signExtend12 (32 : BitVec 12)
+  have S1 := divK_clz_stage_combined_within 48 16 16 v0 c0 (val >>> (32 : BitVec 6).toNat)
+    ((base + clzOff) + BitVec.ofNat 64 (4 * 5))
+  dsimp only [] at S1
+  have S1e := cpsTripleWithin_extend_code (hmono := clz_stage_sub_noNop 48 16 16 5
+    (by decide) (by decide) (by decide)) S1
+  rw [show (base + clzOff : Word) + BitVec.ofNat 64 (4 * 5) = base + clzOff + 20 from by bv_addr] at S1e
+  rw [clz_addr2] at S1e
+  seqFrame IefS0e S1e
+  let v1 := if v0 >>> (48 : BitVec 6).toNat ≠ 0 then v0 else v0 <<< (16 : BitVec 6).toNat
+  let c1 := if v0 >>> (48 : BitVec 6).toNat ≠ 0 then c0 else c0 + signExtend12 (16 : BitVec 12)
+  have S2 := divK_clz_stage_combined_within 56 8 8 v1 c1 (v0 >>> (48 : BitVec 6).toNat)
+    ((base + clzOff) + BitVec.ofNat 64 (4 * 9))
+  dsimp only [] at S2
+  have S2e := cpsTripleWithin_extend_code (hmono := clz_stage_sub_noNop 56 8 8 9
+    (by decide) (by decide) (by decide)) S2
+  rw [show (base + clzOff : Word) + BitVec.ofNat 64 (4 * 9) = base + clzOff + 36 from by bv_addr] at S2e
+  rw [clz_addr3] at S2e
+  seqFrame IefS0eS1e S2e
+  let v2 := if v1 >>> (56 : BitVec 6).toNat ≠ 0 then v1 else v1 <<< (8 : BitVec 6).toNat
+  let c2 := if v1 >>> (56 : BitVec 6).toNat ≠ 0 then c1 else c1 + signExtend12 (8 : BitVec 12)
+  have S3 := divK_clz_stage_combined_within 60 4 4 v2 c2 (v1 >>> (56 : BitVec 6).toNat)
+    ((base + clzOff) + BitVec.ofNat 64 (4 * 13))
+  dsimp only [] at S3
+  have S3e := cpsTripleWithin_extend_code (hmono := clz_stage_sub_noNop 60 4 4 13
+    (by decide) (by decide) (by decide)) S3
+  rw [show (base + clzOff : Word) + BitVec.ofNat 64 (4 * 13) = base + clzOff + 52 from by bv_addr] at S3e
+  rw [clz_addr4] at S3e
+  seqFrame IefS0eS1eS2e S3e
+  let v3 := if v2 >>> (60 : BitVec 6).toNat ≠ 0 then v2 else v2 <<< (4 : BitVec 6).toNat
+  let c3 := if v2 >>> (60 : BitVec 6).toNat ≠ 0 then c2 else c2 + signExtend12 (4 : BitVec 12)
+  have S4 := divK_clz_stage_combined_within 62 2 2 v3 c3 (v2 >>> (60 : BitVec 6).toNat)
+    ((base + clzOff) + BitVec.ofNat 64 (4 * 17))
+  dsimp only [] at S4
+  have S4e := cpsTripleWithin_extend_code (hmono := clz_stage_sub_noNop 62 2 2 17
+    (by decide) (by decide) (by decide)) S4
+  rw [show (base + clzOff : Word) + BitVec.ofNat 64 (4 * 17) = base + clzOff + 68 from by bv_addr] at S4e
+  rw [clz_addr5] at S4e
+  seqFrame IefS0eS1eS2eS3e S4e
+  let v4 := if v3 >>> (62 : BitVec 6).toNat ≠ 0 then v3 else v3 <<< (2 : BitVec 6).toNat
+  let c4 := if v3 >>> (62 : BitVec 6).toNat ≠ 0 then c3 else c3 + signExtend12 (2 : BitVec 12)
+  have S5 := divK_clz_last_combined_within v4 c4 (v3 >>> (62 : BitVec 6).toNat)
+    ((base + clzOff) + BitVec.ofNat 64 (4 * 21))
+  dsimp only [] at S5
+  have S5e := cpsTripleWithin_extend_code (hmono := clz_last_sub_noNop 21
+    (by decide) (by decide) (by decide)) S5
+  rw [show (base + clzOff : Word) + BitVec.ofNat 64 (4 * 21) = base + clzOff + 84 from by bv_addr] at S5e
+  rw [clz_addr6] at S5e
+  seqFrame IefS0eS1eS2eS3eS4e S5e
+  exact cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    IefS0eS1eS2eS3eS4eS5e

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1NoNop.lean
@@ -1,0 +1,59 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN1NoNop
+
+  No-NOP prefix composition for the b[3]=b[2]=b[1]=0 (n=1) DIV path.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.PhaseABNoNop
+import EvmAsm.Evm64.DivMod.Compose.CLZ
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- DIV PhaseAB(n=1) + CLZ over `divCode_noNop`.
+    b≠0, b[3]=b[2]=b[1]=0; base → base+212. -/
+theorem evm_div_phaseAB_n1_clz_spec_within_noNop (sp base : Word)
+    (b0 b1 b2 b3 v5 v6 v7 v10 : Word)
+    (q0 q1 q2 q3 u5 u6 u7 nMem : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1z : b1 = 0) :
+    cpsTripleWithin (8 + 21 + 24) base (base + phaseC2Off) (divCode_noNop base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem))
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (clzResult b0).2) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ (clzResult b0).1) ** (.x7 ↦ᵣ (clzResult b0).2 >>> (63 : Nat)) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (1 : Word))) := by
+  have hAB := evm_div_phaseAB_n1_spec_within_noNop sp base b0 b1 b2 b3 v5 v6 v7 v10
+    q0 q1 q2 q3 u5 u6 u7 nMem hbnz hb3z hb2z hb1z
+  have hCLZ := divK_clz_spec_within_noNop b0 b1 b2 base
+  have hCLZf := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ b3) **
+     ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+     ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (1 : Word)))
+    (by pcFree) hCLZ
+  have hABCLZ := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hAB hCLZf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    hABCLZ
+
+end EvmAsm.Evm64


### PR DESCRIPTION
Refs #90. Bead: evm-asm-01uh. Depends on #3610.\n\nSummary:\n- add no-NOP CLZ code subsumption and divK_clz_spec_within_noNop over divCode_noNop\n- add evm_div_phaseAB_n1_clz_spec_within_noNop as the next N1 preloop wrapper\n- import the wrapper through the DivMod Compose umbrella\n\nVerification:\n- lake build EvmAsm.Evm64.DivMod.Compose.CLZ\n- lake build EvmAsm.Evm64.DivMod.Compose.FullPathN1NoNop\n- lake build EvmAsm.Evm64.DivMod.Compose\n- scripts/check-file-size.sh\n- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/Compose/CLZ.lean EvmAsm/Evm64/DivMod/Compose/FullPathN1NoNop.lean EvmAsm/Evm64/DivMod/Compose.lean\n- lake build