### PR TITLE
feat(exp): lift full-loop branches into code bundle

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/FullLoop.lean
+++ b/EvmAsm/Evm64/Exp/Compose/FullLoop.lean
@@ -46,6 +46,21 @@ theorem cpsTripleWithin_extend_evmExpWithMulCode {nSteps : Nat}
       (evmExpWithMulCode base mulTarget mulOff skipOff backOff) P Q :=
   cpsTripleWithin_extend_code (hmono := evmExpWithMulCode_exp_sub) h
 
+/-- Lift a top-level EXP-body branch spec into the combined EXP+MUL code
+    bundle.  The full loop uses this for the conditional multiply skip gate and
+    the iteration back-edge. -/
+theorem cpsBranchWithin_extend_evmExpWithMulCode {nSteps : Nat}
+    {entry base mulTarget : Word}
+    {mulOff : BitVec 21} {skipOff backOff : BitVec 13}
+    {P : Assertion} {exit_t : Word} {Q_t : Assertion} {exit_f : Word}
+    {Q_f : Assertion}
+    (h : cpsBranchWithin nSteps entry
+      (evmExpCode base mulOff skipOff backOff) P exit_t Q_t exit_f Q_f) :
+    cpsBranchWithin nSteps entry
+      (evmExpWithMulCode base mulTarget mulOff skipOff backOff)
+      P exit_t Q_t exit_f Q_f :=
+  cpsBranchWithin_extend_code (hmono := evmExpWithMulCode_exp_sub) h
+
 /-- Lift a multiply-callable spec into the combined EXP+MUL code bundle. -/
 theorem cpsTripleWithin_extend_mulCallable_evmExpWithMulCode {nSteps : Nat}
     {entry exit_ base mulTarget : Word}


### PR DESCRIPTION
Refs #92.

Beads: evm-asm-w5mk.
Depends on #3620.

This adds cpsBranchWithin_extend_evmExpWithMulCode, lifting top-level EXP branch specs into the combined evmExpWithMulCode bundle. The upcoming full-loop composition needs this for the conditional multiply skip branch and the loop back-edge while sharing the same EXP+mul_callable code request.

Verification:
- lake build EvmAsm.Evm64.Exp.Compose.FullLoop
- scripts/check-file-size.sh
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/Compose/FullLoop.lean (no matches)
- lake build