### PR TITLE
feat(exp): lift cond-mul BEQ skip-gate into top/full-loop bundles

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/FullLoop.lean
+++ b/EvmAsm/Evm64/Exp/Compose/FullLoop.lean
@@ -248,4 +248,19 @@ theorem exp_squaring_un_marshal_and_restore_evm_exp_with_mul_spec_within
     (exp_squaring_un_marshal_and_restore_evm_exp_spec_within
       mulOff skipOff backOff sp evmSp tOld r0 r1 r2 r3 d0 d1 d2 d3 base)
 
+/-- Conditional-multiply BEQ skip-gate lifted to the full-loop EXP+MUL code
+    bundle. -/
+theorem exp_cond_mul_beq_evm_exp_with_mul_spec_within
+    (mulOff : BitVec 21) (skipOff backOff : BitVec 13)
+    (v10 : Word) (base mulTarget target : Word)
+    (htarget : (base + 144 : Word) + signExtend13 skipOff = target) :
+    cpsBranchWithin 1 (base + 144)
+      (evmExpWithMulCode base mulTarget mulOff skipOff backOff)
+      ((.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)))
+      target ((.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜v10 = 0⌝)
+      (base + 148) ((.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜v10 ≠ 0⌝) :=
+  cpsBranchWithin_extend_evmExpWithMulCode
+    (exp_cond_mul_beq_evm_exp_spec_within
+      mulOff skipOff backOff v10 base target htarget)
+
 end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/TopCodeSpecs.lean
+++ b/EvmAsm/Evm64/Exp/Compose/TopCodeSpecs.lean
@@ -419,4 +419,25 @@ theorem exp_squaring_un_marshal_and_restore_evm_exp_spec_within
   exact cpsTripleWithin_extend_code (h := h)
     (hmono := evmExpCode_squaring_un_marshal_and_restore_sub)
 
+/-- Conditional-multiply BEQ skip-gate spec lifted to the top-level EXP code
+    bundle: at offset `base + 144`, branches on `x10 == 0` to the cond-mul
+    skip target `(base + 144) + signExtend13 skipOff`, otherwise falls
+    through to `base + 148` (the cond-mul JAL). -/
+theorem exp_cond_mul_beq_evm_exp_spec_within
+    (mulOff : BitVec 21) (skipOff backOff : BitVec 13)
+    (v10 : Word) (base target : Word)
+    (htarget : (base + 144 : Word) + signExtend13 skipOff = target) :
+    cpsBranchWithin 1 (base + 144)
+      (evmExpCode base mulOff skipOff backOff)
+      ((.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)))
+      target ((.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜v10 = 0⌝)
+      (base + 148) ((.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜v10 ≠ 0⌝) := by
+  have h := EvmAsm.Rv64.beq_spec_within .x10 .x0 skipOff v10 (0 : Word)
+    (base + 144)
+  rw [htarget] at h
+  have hnext : ((base + 144 : Word) + 4) = base + 148 := by bv_omega
+  rw [hnext] at h
+  exact cpsBranchWithin_extend_code (h := h)
+    (hmono := evmExpCode_cond_mul_beq_sub)
+
 end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- Lift the 1-instruction conditional-multiply BEQ skip-gate into both EXP composition bundles:
  - `exp_cond_mul_beq_evm_exp_spec_within` (in `Compose/TopCodeSpecs.lean`, `evmExpCode`)
  - `exp_cond_mul_beq_evm_exp_with_mul_spec_within` (in `Compose/FullLoop.lean`, `evmExpWithMulCode`)
- At offset `base + 144`, branches on `x10 == 0` to the cond-mul skip target `(base + 144) + signExtend13 skipOff`, otherwise falls through to `base + 148` (the cond-mul JAL into `mul_callable`).
- Together with the marshal lifts in PR #3637 (merged) and PR #3638 (open), this completes basic-block coverage for the full conditional-multiply prefix at both bundles.

Refs #92. Bead: evm-asm-vgrkq.

## Verification
- `lake build EvmAsm.Evm64.Exp.Compose.TopCodeSpecs`
- `lake build EvmAsm.Evm64.Exp.Compose.FullLoop`
- `scripts/check-file-size.sh`
- `rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth'` on touched files (no hits)
- `lake build`

Authored by @pirapira; implemented by Claude Code
