### PR TITLE
chore(mulmod): drop unused Stack import in Layout.lean

### DIFF
--- a/EvmAsm/Evm64/MulMod/Layout.lean
+++ b/EvmAsm/Evm64/MulMod/Layout.lean
@@ -4,8 +4,6 @@
   Scratchpad-layout scaffold for the MULMOD opcode (GH #91).
 -/
 
-import EvmAsm.Evm64.Stack
-
 namespace EvmAsm.Evm64
 
 /-- Layout of the MULMOD routine's `sp`-relative internal scratch cells.


### PR DESCRIPTION
## Summary
- Drop `import EvmAsm.Evm64.Stack` from `EvmAsm/Evm64/MulMod/Layout.lean`.
- The file is a scaffold defining only an empty `MulModScratchpadLayout` structure; nothing from `Stack` is referenced.

Per `lake exe shake EvmAsm` suggestion. Refs #1045. Bead: evm-asm-hvefy.

## Verification
- lake build EvmAsm.Evm64.MulMod.Layout
- scripts/check-file-size.sh
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/MulMod/Layout.lean
- lake build (full)

Authored by @pirapira; implemented by Claude Code