### PR TITLE
chore(shake): noshake XCancelStruct XSimp false positive

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -111,7 +111,7 @@
   ["EvmAsm.Evm64.AddMod.LimbSpec", "EvmAsm.Evm64.AddMod.AddrNorm"],
   "EvmAsm.Evm64.MulMod.AddrNormAttr": ["Lean.Meta.Tactic.Simp.RegisterCommand"],
   "EvmAsm.Rv64.Tactics.XCancelStruct":
-  ["EvmAsm.Rv64.SepLogic"],
+  ["EvmAsm.Rv64.SepLogic", "EvmAsm.Rv64.Tactics.XSimp"],
   "EvmAsm.Rv64.Tactics.SymStep":
   ["EvmAsm.Rv64.Execution"],
   "EvmAsm.Evm64.Accelerators.Status":


### PR DESCRIPTION
## Summary
- `lake exe shake EvmAsm` flags `EvmAsm.Rv64.Tactics.XSimp` as unused in `EvmAsm/Rv64/Tactics/XCancelStruct.lean`, but the `xcancel_struct` macro_rules at lines 99-106 expand to syntax requiring `sep_perm`, which is defined in `XSimp.lean`. Removing the import breaks the build (xcancelStructTac not implemented).
- Extend the existing XCancelStruct noshake entry to include `XSimp`.

Refs #1045. Bead: evm-asm-7fh7v.

## Verification
- lake build EvmAsm.Rv64.Tactics.XCancelStruct
- scripts/check-file-size.sh
- lake build (full)
- lake exe shake EvmAsm no longer flags this file

Authored by @pirapira; implemented by Claude Code