### PR TITLE
chore(sdiv): wrap resultSignFix spec pre/post in irreducible defs

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/Base.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/Base.lean
@@ -648,38 +648,86 @@ theorem divCall_spec_in_sdivCode
     (EvmAsm.Evm64.evm_sdiv_div_call_block_spec_within
       EvmAsm.Evm64.evm_sdivCallOff vOld (base + divCallOff))
 
+/-- Precondition for the SDIV result sign-fixup (conditional 2's-complement
+    negation) block. Mirrors `divisorAbsPre` but with the sign in `x8`
+    (post-`signXor` result sign) — same divisor memory slots `+32…+56`
+    that the result is written back to. Wrapped `@[irreducible]` so
+    downstream proofs do not re-unfold the sepConj atoms at each use
+    site. -/
+@[irreducible]
+def resultSignFixPre (sp sign maskOld valueOld carryOld
+    limb0 limb1 limb2 limb3 : Word) : Assertion :=
+  (.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sign) **
+  (.x10 ↦ᵣ maskOld) ** (.x7 ↦ᵣ valueOld) ** (.x11 ↦ᵣ carryOld) **
+  ((sp + signExtend12 (32 : BitVec 12)) ↦ₘ limb0) **
+  ((sp + signExtend12 (40 : BitVec 12)) ↦ₘ limb1) **
+  ((sp + signExtend12 (48 : BitVec 12)) ↦ₘ limb2) **
+  ((sp + signExtend12 (56 : BitVec 12)) ↦ₘ limb3)
+
+theorem resultSignFixPre_unfold
+    {sp sign maskOld valueOld carryOld limb0 limb1 limb2 limb3 : Word} :
+    resultSignFixPre sp sign maskOld valueOld carryOld
+        limb0 limb1 limb2 limb3 =
+      ((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sign) **
+       (.x10 ↦ᵣ maskOld) ** (.x7 ↦ᵣ valueOld) ** (.x11 ↦ᵣ carryOld) **
+       ((sp + signExtend12 (32 : BitVec 12)) ↦ₘ limb0) **
+       ((sp + signExtend12 (40 : BitVec 12)) ↦ₘ limb1) **
+       ((sp + signExtend12 (48 : BitVec 12)) ↦ₘ limb2) **
+       ((sp + signExtend12 (56 : BitVec 12)) ↦ₘ limb3)) := by
+  delta resultSignFixPre
+  rfl
+
+/-- Postcondition for the SDIV result sign-fixup block: mirrors
+    `divisorAbsPost` but with the sign register `x8`. Wrapped
+    `@[irreducible]` to hide the let chain from downstream proofs. -/
+@[irreducible]
+def resultSignFixPost (sp sign limb0 limb1 limb2 limb3 : Word) : Assertion :=
+  let mask := (0 : Word) - sign
+  let sum0 := (limb0 ^^^ mask) + sign
+  let carry0 := if BitVec.ult sum0 sign then (1 : Word) else 0
+  let sum1 := (limb1 ^^^ mask) + carry0
+  let carry1 := if BitVec.ult sum1 carry0 then (1 : Word) else 0
+  let sum2 := (limb2 ^^^ mask) + carry1
+  let carry2 := if BitVec.ult sum2 carry1 then (1 : Word) else 0
+  let sum3 := (limb3 ^^^ mask) + carry2
+  let carry3 := if BitVec.ult sum3 carry2 then (1 : Word) else 0
+  (.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sign) **
+  (.x10 ↦ᵣ mask) ** (.x7 ↦ᵣ sum3) ** (.x11 ↦ᵣ carry3) **
+  ((sp + signExtend12 (32 : BitVec 12)) ↦ₘ sum0) **
+  ((sp + signExtend12 (40 : BitVec 12)) ↦ₘ sum1) **
+  ((sp + signExtend12 (48 : BitVec 12)) ↦ₘ sum2) **
+  ((sp + signExtend12 (56 : BitVec 12)) ↦ₘ sum3)
+
+theorem resultSignFixPost_unfold
+    {sp sign limb0 limb1 limb2 limb3 : Word} :
+    resultSignFixPost sp sign limb0 limb1 limb2 limb3 =
+      (let mask := (0 : Word) - sign
+       let sum0 := (limb0 ^^^ mask) + sign
+       let carry0 := if BitVec.ult sum0 sign then (1 : Word) else 0
+       let sum1 := (limb1 ^^^ mask) + carry0
+       let carry1 := if BitVec.ult sum1 carry0 then (1 : Word) else 0
+       let sum2 := (limb2 ^^^ mask) + carry1
+       let carry2 := if BitVec.ult sum2 carry1 then (1 : Word) else 0
+       let sum3 := (limb3 ^^^ mask) + carry2
+       let carry3 := if BitVec.ult sum3 carry2 then (1 : Word) else 0
+       (.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sign) **
+       (.x10 ↦ᵣ mask) ** (.x7 ↦ᵣ sum3) ** (.x11 ↦ᵣ carry3) **
+       ((sp + signExtend12 (32 : BitVec 12)) ↦ₘ sum0) **
+       ((sp + signExtend12 (40 : BitVec 12)) ↦ₘ sum1) **
+       ((sp + signExtend12 (48 : BitVec 12)) ↦ₘ sum2) **
+       ((sp + signExtend12 (56 : BitVec 12)) ↦ₘ sum3)) := by
+  delta resultSignFixPost
+  rfl
+
 theorem resultSignFix_spec_in_sdivCode
     (sp sign maskOld valueOld carryOld limb0 limb1 limb2 limb3 : Word)
     (base : Word) :
-    let mem0 := sp + signExtend12 (32 : BitVec 12)
-    let mem1 := sp + signExtend12 (40 : BitVec 12)
-    let mem2 := sp + signExtend12 (48 : BitVec 12)
-    let mem3 := sp + signExtend12 (56 : BitVec 12)
-    let mask := (0 : Word) - sign
-    let xored0 := limb0 ^^^ mask
-    let sum0 := xored0 + sign
-    let carry0 := if BitVec.ult sum0 sign then (1 : Word) else 0
-    let xored1 := limb1 ^^^ mask
-    let sum1 := xored1 + carry0
-    let carry1 := if BitVec.ult sum1 carry0 then (1 : Word) else 0
-    let xored2 := limb2 ^^^ mask
-    let sum2 := xored2 + carry1
-    let carry2 := if BitVec.ult sum2 carry1 then (1 : Word) else 0
-    let xored3 := limb3 ^^^ mask
-    let sum3 := xored3 + carry2
-    let carry3 := if BitVec.ult sum3 carry2 then (1 : Word) else 0
     cpsTripleWithin 21 (base + resultSignFixOff)
       ((base + resultSignFixOff) + 84) (sdivCode base)
-      ((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sign) **
-       (.x10 ↦ᵣ maskOld) ** (.x7 ↦ᵣ valueOld) ** (.x11 ↦ᵣ carryOld) **
-       (mem0 ↦ₘ limb0) ** (mem1 ↦ₘ limb1) **
-       (mem2 ↦ₘ limb2) ** (mem3 ↦ₘ limb3))
-      ((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sign) **
-       (.x10 ↦ᵣ mask) ** (.x7 ↦ᵣ sum3) ** (.x11 ↦ᵣ carry3) **
-       (mem0 ↦ₘ sum0) ** (mem1 ↦ₘ sum1) **
-       (mem2 ↦ₘ sum2) ** (mem3 ↦ₘ sum3)) := by
-  intro mem0 mem1 mem2 mem3 mask xored0 sum0 carry0 xored1 sum1 carry1
-    xored2 sum2 carry2 xored3 sum3 carry3
+      (resultSignFixPre sp sign maskOld valueOld carryOld
+        limb0 limb1 limb2 limb3)
+      (resultSignFixPost sp sign limb0 limb1 limb2 limb3) := by
+  rw [resultSignFixPre_unfold, resultSignFixPost_unfold]
   have hmono :
       ∀ a i,
         (EvmAsm.Evm64.evm_sdiv_cond_negate_256_block_code


### PR DESCRIPTION
## Summary
- Add `resultSignFixPre` / `resultSignFixPost` as `@[irreducible]` defs with matching `_unfold` lemmas, mirroring `dividendAbsPre` / `dividendAbsPost` already on `main` and `divisorAbsPre` / `divisorAbsPost` introduced by PR #3650 on the same branch.
- Restate `resultSignFix_spec_in_sdivCode` with the clean Pre/Post signature — drop the outer `let`-chain, `rw [..._unfold, ..._unfold]` at the top, then delegate to `evm_sdiv_cond_negate_256_block_spec_within`.

Pattern: sign reg `.x8` (the post-`signXor` result sign), divisor memory slots `+32…+56` (reused for the result).

Refs #90. Bead: evm-asm-rhu4z. Stacked on `feat/sdiv-compose-lift-divisor-abs` (PR #3588).

## Verification
- lake build EvmAsm.Evm64.SDiv.Compose.Base
- scripts/check-file-size.sh
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/Base.lean
- lake build (full)

Authored by @pirapira; implemented by Claude Code