### PR TITLE
chore(divmod): wrap divK_normA_full_spec_within_noNop pre/post in irreducible defs

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose.lean
+++ b/EvmAsm/Evm64/DivMod/Compose.lean
@@ -26,6 +26,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN3
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1
 import EvmAsm.Evm64.DivMod.Compose.PhaseABNoNop
+import EvmAsm.Evm64.DivMod.Compose.FullPathN1NoNop
 import EvmAsm.Evm64.DivMod.Compose.ModFullPath
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN3
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN2

--- a/EvmAsm/Evm64/DivMod/Compose.lean
+++ b/EvmAsm/Evm64/DivMod/Compose.lean
@@ -25,6 +25,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPath
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1
+import EvmAsm.Evm64.DivMod.Compose.PhaseABNoNop
 import EvmAsm.Evm64.DivMod.Compose.ModFullPath
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN3
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN2

--- a/EvmAsm/Evm64/DivMod/Compose/CLZ.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/CLZ.lean
@@ -27,6 +27,14 @@ private theorem divK_clz_code_sub_divCode {base : Word} :
   skipBlock; skipBlock
   exact CodeReq.union_mono_left
 
+/-- CLZ code (block 2) is subsumed by divCode_noNop. -/
+private theorem divK_clz_code_sub_divCode_noNop {base : Word} :
+    ∀ a i, (CodeReq.ofProg (base + clzOff) divK_clz) a = some i →
+      (divCode_noNop base) a = some i := by
+  unfold divCode_noNop; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock
+  exact CodeReq.union_mono_left
+
 /-- Helper: CLZ stage at instruction index k is subsumed by divCode.
     The stage has 4 instructions starting at index k of divK_clz. -/
 private theorem clz_stage_sub {base : Word}
@@ -39,6 +47,20 @@ private theorem clz_stage_sub {base : Word}
       (divCode base) a = some i := by
   intro a i h
   exact divK_clz_code_sub_divCode a i
+    (CodeReq.ofProg_mono_sub (base + clzOff) _ divK_clz _ k
+      rfl hslice hk hbound a i h)
+
+/-- Helper: CLZ stage at instruction index k is subsumed by divCode_noNop. -/
+private theorem clz_stage_sub_noNop {base : Word}
+    (K M_s : BitVec 6) (M_a : BitVec 12) (k : Nat)
+    (hk : k + (divK_clz_stage_prog K M_s M_a).length ≤ divK_clz.length)
+    (hslice : (divK_clz.drop k).take (divK_clz_stage_prog K M_s M_a).length =
+      divK_clz_stage_prog K M_s M_a)
+    (hbound : 4 * divK_clz.length < 2 ^ 64) :
+    ∀ a i, (divK_clz_stage_code K M_s M_a ((base + clzOff) + BitVec.ofNat 64 (4 * k))) a = some i →
+      (divCode_noNop base) a = some i := by
+  intro a i h
+  exact divK_clz_code_sub_divCode_noNop a i
     (CodeReq.ofProg_mono_sub (base + clzOff) _ divK_clz _ k
       rfl hslice hk hbound a i h)
 
@@ -55,12 +77,34 @@ private theorem clz_last_sub {base : Word} (k : Nat)
     (CodeReq.ofProg_mono_sub (base + clzOff) _ divK_clz _ k
       rfl hslice hk hbound a i h)
 
+/-- Helper: CLZ last stage at instruction index k is subsumed by divCode_noNop. -/
+private theorem clz_last_sub_noNop {base : Word} (k : Nat)
+    (hk : k + divK_clz_last_prog.length ≤ divK_clz.length)
+    (hslice : (divK_clz.drop k).take divK_clz_last_prog.length = divK_clz_last_prog)
+    (hbound : 4 * divK_clz.length < 2 ^ 64) :
+    ∀ a i, (divK_clz_last_code ((base + clzOff) + BitVec.ofNat 64 (4 * k))) a = some i →
+      (divCode_noNop base) a = some i := by
+  intro a i h
+  exact divK_clz_code_sub_divCode_noNop a i
+    (CodeReq.ofProg_mono_sub (base + clzOff) _ divK_clz _ k
+      rfl hslice hk hbound a i h)
+
 /-- Helper: CLZ init singleton (ADDI x6 x0 0 at base+116) is subsumed by divCode. -/
 private theorem clz_init_sub {base : Word} :
     ∀ a i, (CodeReq.singleton (base + clzOff) (.ADDI .x6 .x0 0)) a = some i →
       (divCode base) a = some i := by
   intro a i h
   exact divK_clz_code_sub_divCode a i
+    (CodeReq.singleton_mono (CodeReq.ofProg_lookup (base + clzOff) divK_clz 0
+      (by decide) (by decide)) a i (by rwa [show (base + clzOff : Word) =
+        base + clzOff + BitVec.ofNat 64 (4 * 0) from by bv_addr] at h))
+
+/-- Helper: CLZ init singleton (ADDI x6 x0 0 at base+116) is subsumed by divCode_noNop. -/
+private theorem clz_init_sub_noNop {base : Word} :
+    ∀ a i, (CodeReq.singleton (base + clzOff) (.ADDI .x6 .x0 0)) a = some i →
+      (divCode_noNop base) a = some i := by
+  intro a i h
+  exact divK_clz_code_sub_divCode_noNop a i
     (CodeReq.singleton_mono (CodeReq.ofProg_lookup (base + clzOff) divK_clz 0
       (by decide) (by decide)) a i (by rwa [show (base + clzOff : Word) =
         base + clzOff + BitVec.ofNat 64 (4 * 0) from by bv_addr] at h))
@@ -230,3 +274,76 @@ theorem divK_clz_spec_within (val v6Old v7Old : Word) (base : Word) :
     (fun h hq => by xperm_hyp hq)
     IefS0eS1eS2eS3eS4eS5e
 
+theorem divK_clz_spec_within_noNop (val v6Old v7Old : Word) (base : Word) :
+    cpsTripleWithin 24 (base + clzOff) (base + phaseC2Off) (divCode_noNop base)
+      ((.x5 ↦ᵣ val) ** (.x6 ↦ᵣ v6Old) ** (.x7 ↦ᵣ v7Old) ** (.x0 ↦ᵣ (0 : Word)))
+      ((.x5 ↦ᵣ (clzResult val).2) ** (.x6 ↦ᵣ (clzResult val).1) **
+       (.x7 ↦ᵣ (clzResult val).2 >>> (63 : Nat)) ** (.x0 ↦ᵣ (0 : Word))) := by
+  unfold clzResult
+  have I := divK_clz_init_spec_within v6Old (base + clzOff)
+  have Ie := cpsTripleWithin_extend_code (hmono := clz_init_sub_noNop) I
+  have Ief := cpsTripleWithin_frameR
+    ((.x5 ↦ᵣ val) ** (.x7 ↦ᵣ v7Old)) (by pcFree) Ie
+  have S0 := divK_clz_stage_combined_within 32 32 32 val (signExtend12 0) v7Old
+    ((base + clzOff) + BitVec.ofNat 64 (4 * 1))
+  dsimp only [] at S0
+  have S0e := cpsTripleWithin_extend_code (hmono := clz_stage_sub_noNop 32 32 32 1
+    (by decide) (by decide) (by decide)) S0
+  rw [show (base + clzOff : Word) + BitVec.ofNat 64 (4 * 1) = base + clzOff + 4 from by bv_addr] at S0e
+  rw [clz_addr1] at S0e
+  seqFrame Ief S0e
+  let v0 := if val >>> (32 : BitVec 6).toNat ≠ 0 then val else val <<< (32 : BitVec 6).toNat
+  let c0 := if val >>> (32 : BitVec 6).toNat ≠ 0 then signExtend12 (0 : BitVec 12)
+    else signExtend12 (0 : BitVec 12) + signExtend12 (32 : BitVec 12)
+  have S1 := divK_clz_stage_combined_within 48 16 16 v0 c0 (val >>> (32 : BitVec 6).toNat)
+    ((base + clzOff) + BitVec.ofNat 64 (4 * 5))
+  dsimp only [] at S1
+  have S1e := cpsTripleWithin_extend_code (hmono := clz_stage_sub_noNop 48 16 16 5
+    (by decide) (by decide) (by decide)) S1
+  rw [show (base + clzOff : Word) + BitVec.ofNat 64 (4 * 5) = base + clzOff + 20 from by bv_addr] at S1e
+  rw [clz_addr2] at S1e
+  seqFrame IefS0e S1e
+  let v1 := if v0 >>> (48 : BitVec 6).toNat ≠ 0 then v0 else v0 <<< (16 : BitVec 6).toNat
+  let c1 := if v0 >>> (48 : BitVec 6).toNat ≠ 0 then c0 else c0 + signExtend12 (16 : BitVec 12)
+  have S2 := divK_clz_stage_combined_within 56 8 8 v1 c1 (v0 >>> (48 : BitVec 6).toNat)
+    ((base + clzOff) + BitVec.ofNat 64 (4 * 9))
+  dsimp only [] at S2
+  have S2e := cpsTripleWithin_extend_code (hmono := clz_stage_sub_noNop 56 8 8 9
+    (by decide) (by decide) (by decide)) S2
+  rw [show (base + clzOff : Word) + BitVec.ofNat 64 (4 * 9) = base + clzOff + 36 from by bv_addr] at S2e
+  rw [clz_addr3] at S2e
+  seqFrame IefS0eS1e S2e
+  let v2 := if v1 >>> (56 : BitVec 6).toNat ≠ 0 then v1 else v1 <<< (8 : BitVec 6).toNat
+  let c2 := if v1 >>> (56 : BitVec 6).toNat ≠ 0 then c1 else c1 + signExtend12 (8 : BitVec 12)
+  have S3 := divK_clz_stage_combined_within 60 4 4 v2 c2 (v1 >>> (56 : BitVec 6).toNat)
+    ((base + clzOff) + BitVec.ofNat 64 (4 * 13))
+  dsimp only [] at S3
+  have S3e := cpsTripleWithin_extend_code (hmono := clz_stage_sub_noNop 60 4 4 13
+    (by decide) (by decide) (by decide)) S3
+  rw [show (base + clzOff : Word) + BitVec.ofNat 64 (4 * 13) = base + clzOff + 52 from by bv_addr] at S3e
+  rw [clz_addr4] at S3e
+  seqFrame IefS0eS1eS2e S3e
+  let v3 := if v2 >>> (60 : BitVec 6).toNat ≠ 0 then v2 else v2 <<< (4 : BitVec 6).toNat
+  let c3 := if v2 >>> (60 : BitVec 6).toNat ≠ 0 then c2 else c2 + signExtend12 (4 : BitVec 12)
+  have S4 := divK_clz_stage_combined_within 62 2 2 v3 c3 (v2 >>> (60 : BitVec 6).toNat)
+    ((base + clzOff) + BitVec.ofNat 64 (4 * 17))
+  dsimp only [] at S4
+  have S4e := cpsTripleWithin_extend_code (hmono := clz_stage_sub_noNop 62 2 2 17
+    (by decide) (by decide) (by decide)) S4
+  rw [show (base + clzOff : Word) + BitVec.ofNat 64 (4 * 17) = base + clzOff + 68 from by bv_addr] at S4e
+  rw [clz_addr5] at S4e
+  seqFrame IefS0eS1eS2eS3e S4e
+  let v4 := if v3 >>> (62 : BitVec 6).toNat ≠ 0 then v3 else v3 <<< (2 : BitVec 6).toNat
+  let c4 := if v3 >>> (62 : BitVec 6).toNat ≠ 0 then c3 else c3 + signExtend12 (2 : BitVec 12)
+  have S5 := divK_clz_last_combined_within v4 c4 (v3 >>> (62 : BitVec 6).toNat)
+    ((base + clzOff) + BitVec.ofNat 64 (4 * 21))
+  dsimp only [] at S5
+  have S5e := cpsTripleWithin_extend_code (hmono := clz_last_sub_noNop 21
+    (by decide) (by decide) (by decide)) S5
+  rw [show (base + clzOff : Word) + BitVec.ofNat 64 (4 * 21) = base + clzOff + 84 from by bv_addr] at S5e
+  rw [clz_addr6] at S5e
+  seqFrame IefS0eS1eS2eS3eS4e S5e
+  exact cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    IefS0eS1eS2eS3eS4eS5e

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1LoopUnified.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1LoopUnified.lean
@@ -14,6 +14,7 @@
 -/
 
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1Loop
+import EvmAsm.Evm64.DivMod.Compose.FullPathN1NoNop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3Loop
 import EvmAsm.Evm64.EvmWordArith.CLZLemmas
 import EvmAsm.Evm64.EvmWordArith.DenormLemmas
@@ -268,6 +269,103 @@ theorem evm_div_n1_preloop_loop_unified_spec
      ((sp + signExtend12 3992) ↦ₘ (clzResult b0).1))
     (by pcFree) hLoop
   -- 3. Compose preloop + loop
+  have hFull := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by
+      delta loopSetupPost at hp
+      simp only [x1_val_n1] at hp
+      delta loopN1PreWithScratch loopN1Pre
+      simp only []
+      simp only [n1_ub3_off0, n1_ub3_off4088, n1_ub3_off4080,
+                  n1_ub3_off4072, n1_ub3_off4064,
+                  n2_ub2_off0,
+                  n3_ub1_off0,
+                  n3_ub0_off0,
+                  n1_qa3, n2_qa2, n3_qa1, n3_qa0,
+                  se12_32, se12_40, se12_48, se12_56]
+      xperm_hyp hp) hPreF hLoopF
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by delta preloopN1UnifiedPost; xperm_hyp hq)
+    hFull
+
+/-- Unified preloop+loop for n=1, using the no-NOP preloop code before extending
+    it back to `divCode` for composition with the existing unified loop. -/
+theorem evm_div_n1_noNop_preloop_loop_unified_spec
+    (bltu_3 bltu_2 bltu_1 bltu_0 : Bool) (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1z : b1 = 0)
+    (hshift_nz : (clzResult b0).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu_3 : isTrialN1_j3 bltu_3 a3 b0)
+    (hbltu_2 : isTrialN1_j2 bltu_3 bltu_2 a2 a3 b0 b1 b2 b3)
+    (hbltu_1 : isTrialN1_j1 bltu_3 bltu_2 bltu_1 a1 a2 a3 b0 b1 b2 b3)
+    (hbltu_0 : isTrialN1_j0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3)
+    (hcarry2 : Carry2NzAll (b0 <<< (((clzResult b0).1).toNat % 64))
+      ((b1 <<< (((clzResult b0).1).toNat % 64)) ||| (b0 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b0).1).toNat % 64)))
+      ((b2 <<< (((clzResult b0).1).toNat % 64)) ||| (b1 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b0).1).toNat % 64)))
+      ((b3 <<< (((clzResult b0).1).toNat % 64)) ||| (b2 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b0).1).toNat % 64)))) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 808) base (base + denormOff) (divCode base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b0).2 >>> (63 : Nat)) **
+       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x11 ↦ᵣ v11Old) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+       ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+       ((sp + signExtend12 4024) ↦ₘ u4Old) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem) **
+       ((sp + signExtend12 3976) ↦ₘ jMem) **
+       ((sp + signExtend12 3968) ↦ₘ retMem) **
+       ((sp + signExtend12 3960) ↦ₘ dMem) **
+       ((sp + signExtend12 3952) ↦ₘ dloMem) **
+       ((sp + signExtend12 3944) ↦ₘ scratch_un0))
+      (preloopN1UnifiedPost bltu_3 bltu_2 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
+        retMem dMem dloMem scratch_un0) := by
+  -- 1. No-NOP pre-loop, extended back into the full `divCode` code request.
+  have hPreNoNop := evm_div_n1_to_loopSetup_spec_within_noNop sp base
+    a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem
+    hbnz hb3z hb2z hb1z hshift_nz
+  have hPre := cpsTripleWithin_extend_code (hmono := divCode_noNop_sub_divCode) hPreNoNop
+  have hPreF := cpsTripleWithin_frameR
+    ((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
+     (sp + signExtend12 3968 ↦ₘ retMem) **
+     (sp + signExtend12 3960 ↦ₘ dMem) **
+     (sp + signExtend12 3952 ↦ₘ dloMem) **
+     (sp + signExtend12 3944 ↦ₘ scratch_un0))
+    (by pcFree) hPre
+  -- 2. Existing unified loop: base+448 → base+904.
+  have hLoop := evm_div_n1_loop_unified_inst bltu_3 bltu_2 bltu_1 bltu_0 sp base
+    (clzResult b0).1 (signExtend12 (0 : BitVec 12) - (clzResult b0).1)
+    (b0 <<< (((clzResult b0).1).toNat % 64))
+    ((b1 <<< (((clzResult b0).1).toNat % 64)) ||| (b0 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b0).1).toNat % 64)))
+    ((b2 <<< (((clzResult b0).1).toNat % 64)) ||| (b1 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b0).1).toNat % 64)))
+    ((b3 <<< (((clzResult b0).1).toNat % 64)) ||| (b2 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b0).1).toNat % 64)))
+    (a0 <<< (((clzResult b0).1).toNat % 64))
+    ((a1 <<< (((clzResult b0).1).toNat % 64)) ||| (a0 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b0).1).toNat % 64)))
+    ((a2 <<< (((clzResult b0).1).toNat % 64)) ||| (a1 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b0).1).toNat % 64)))
+    ((a3 <<< (((clzResult b0).1).toNat % 64)) ||| (a2 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b0).1).toNat % 64)))
+    (a3 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b0).1).toNat % 64))
+    (a0 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b0).1).toNat % 64))
+    v11Old jMem
+    retMem dMem dloMem scratch_un0 halign
+    hbltu_3 hbltu_2 hbltu_1 hbltu_0 hcarry2
+  have hLoopF := cpsTripleWithin_frameR
+    (((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 3992) ↦ₘ (clzResult b0).1))
+    (by pcFree) hLoop
+  -- 3. Compose no-NOP preloop + loop.
   have hFull := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by
       delta loopSetupPost at hp

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1LoopUnified.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1LoopUnified.lean
@@ -729,4 +729,75 @@ theorem evm_div_n1_full_unified_spec
         sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 h hq)
     hFull
 
+/-- Full n=1 unified DIV path whose available no-NOP fragments are used before
+    extending back to `divCode` for the current public full-path boundary. -/
+theorem evm_div_n1_noNop_full_unified_spec
+    (bltu_3 bltu_2 bltu_1 bltu_0 : Bool) (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1z : b1 = 0)
+    (hshift_nz : (clzResult b0).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu_3 : isTrialN1_j3 bltu_3 a3 b0)
+    (hbltu_2 : isTrialN1_j2 bltu_3 bltu_2 a2 a3 b0 b1 b2 b3)
+    (hbltu_1 : isTrialN1_j1 bltu_3 bltu_2 bltu_1 a1 a2 a3 b0 b1 b2 b3)
+    (hbltu_0 : isTrialN1_j0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3)
+    (hcarry2 : Carry2NzAll (b0 <<< (((clzResult b0).1).toNat % 64))
+      ((b1 <<< (((clzResult b0).1).toNat % 64)) ||| (b0 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b0).1).toNat % 64)))
+      ((b2 <<< (((clzResult b0).1).toNat % 64)) ||| (b1 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b0).1).toNat % 64)))
+      ((b3 <<< (((clzResult b0).1).toNat % 64)) ||| (b2 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b0).1).toNat % 64)))) :
+    cpsTripleWithin 946 base (base + nopOff) (divCode base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b0).2 >>> (63 : Nat)) **
+       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x11 ↦ᵣ v11Old) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+       ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+       ((sp + signExtend12 4024) ↦ₘ u4Old) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem) **
+       ((sp + signExtend12 3976) ↦ₘ jMem) **
+       ((sp + signExtend12 3968) ↦ₘ retMem) **
+       ((sp + signExtend12 3960) ↦ₘ dMem) **
+       ((sp + signExtend12 3952) ↦ₘ dloMem) **
+       ((sp + signExtend12 3944) ↦ₘ scratch_un0))
+      (fullDivN1UnifiedPost bltu_3 bltu_2 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
+        retMem dMem dloMem scratch_un0) := by
+  have hA := evm_div_n1_noNop_preloop_loop_unified_spec bltu_3 bltu_2 bltu_1 bltu_0 sp base
+    a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem
+    retMem dMem dloMem scratch_un0
+    hbnz hb3z hb2z hb1z hshift_nz halign
+    hbltu_3 hbltu_2 hbltu_1 hbltu_0 hcarry2
+  have hshift_nz' : fullDivN1Shift b0 ≠ 0 := by
+    rw [fullDivN1Shift_unfold]
+    exact hshift_nz
+  have hBNoNop := evm_div_n1_denorm_epilogue_bundled_spec_noNop
+    bltu_3 bltu_2 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3 hshift_nz'
+  have hB := cpsTripleWithin_extend_code (hmono := divCode_noNop_sub_divCode) hBNoNop
+  have hBF := cpsTripleWithin_frameR
+    (fullDivN1Frame bltu_3 bltu_2 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
+      retMem dMem dloMem scratch_un0)
+    (by delta fullDivN1Frame fullDivN1Scratch; pcFree) hB
+  have hFull := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp =>
+      preloopN1UnifiedPost_to_fullDivN1DenormPre_frame
+        bltu_3 bltu_2 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
+        retMem dMem dloMem scratch_un0 h hp) hA hBF
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq =>
+      fullDivN1UnifiedPost_weaken bltu_3 bltu_2 bltu_1 bltu_0
+        sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 h hq)
+    hFull
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1NoNop.lean
@@ -7,6 +7,7 @@
 import EvmAsm.Evm64.DivMod.Compose.PhaseABNoNop
 import EvmAsm.Evm64.DivMod.Compose.CLZ
 import EvmAsm.Evm64.DivMod.Compose.Norm
+import EvmAsm.Evm64.DivMod.Compose.NormA
 
 open EvmAsm.Rv64.Tactics
 
@@ -163,6 +164,94 @@ theorem evm_div_phaseAB_n1_clz_c2_normB_spec_within_noNop (sp base : Word)
   exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hq => by xperm_hyp hq)
+    hFull
+
+theorem evm_div_n1_to_loopSetup_spec_within_noNop (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1z : b1 = 0)
+    (hshift_nz : (clzResult b0).1 ≠ 0) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4) base (base + loopBodyOff) (divCode_noNop base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b0).2 >>> (63 : Nat)) **
+       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+       ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+       ((sp + signExtend12 4024) ↦ₘ u4Old) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
+      (loopSetupPost sp (1 : Word) (clzResult b0).1 a0 a1 a2 a3 b0 b1 b2 b3) := by
+  let shift := (clzResult b0).1
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+  let b0' := b0 <<< (shift.toNat % 64)
+  let u4 := a3 >>> (antiShift.toNat % 64)
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
+  let u0 := a0 <<< (shift.toNat % 64)
+  have hNB := evm_div_phaseAB_n1_clz_c2_normB_spec_within_noNop sp base
+    b0 b1 b2 b3 v5 v6 v7 v10 q0 q1 q2 q3 u5 u6 u7 nMem shiftMem
+    hbnz hb3z hb2z hb1z hshift_nz
+  have hNBf := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+     ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+     ((sp + signExtend12 4024) ↦ₘ u4Old))
+    (by pcFree) hNB
+  have hNormA := divK_normA_full_spec_within_noNop sp a0 a1 a2 a3
+    b0' (b0 >>> (antiShift.toNat % 64)) b3 shift antiShift
+    u0Old u1Old u2Old u3Old u4Old base
+  intro_lets at hNormA
+  have hNormAf := cpsTripleWithin_frameR
+    ((.x0 ↦ᵣ (0 : Word)) **
+     (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
+     ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3') **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (1 : Word)) **
+     ((sp + signExtend12 3992) ↦ₘ shift))
+    (by pcFree) hNormA
+  have hNA := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hNBf hNormAf
+  have hLS := divK_loopSetup_ntaken_spec_within_noNop sp (1 : Word)
+    (signExtend12 (4 : BitVec 12) - (4 : Word)) u1 base
+    (by decide)
+  have hLSf := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ (a0 >>> (antiShift.toNat % 64))) **
+     (.x6 ↦ᵣ shift) ** (.x7 ↦ᵣ u0) ** (.x2 ↦ᵣ antiShift) **
+     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
+     ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3') **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
+     ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3) **
+     ((sp + signExtend12 4024) ↦ₘ u4) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3992) ↦ₘ shift))
+    (by pcFree) hLS
+  have hFull := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hNA hLSf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by delta loopSetupPost; xperm_hyp hq)
     hFull
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1NoNop.lean
@@ -6,6 +6,7 @@
 
 import EvmAsm.Evm64.DivMod.Compose.PhaseABNoNop
 import EvmAsm.Evm64.DivMod.Compose.CLZ
+import EvmAsm.Evm64.DivMod.Compose.Norm
 
 open EvmAsm.Rv64.Tactics
 
@@ -55,5 +56,58 @@ theorem evm_div_phaseAB_n1_clz_spec_within_noNop (sp base : Word)
     (fun h hp => by xperm_hyp hp)
     (fun h hq => by xperm_hyp hq)
     hABCLZ
+
+/-- DIV PhaseAB(n=1) + CLZ + PhaseC2(ntaken) over `divCode_noNop`.
+    This is the shift≠0 prefix that reaches NormB. -/
+theorem evm_div_phaseAB_n1_clz_c2_spec_within_noNop (sp base : Word)
+    (b0 b1 b2 b3 v5 v6 v7 v10 : Word)
+    (q0 q1 q2 q3 u5 u6 u7 nMem shiftMem : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1z : b1 = 0)
+    (hshift_nz : (clzResult b0).1 ≠ 0) :
+    cpsTripleWithin (8 + 21 + 24 + 4) base (base + normBOff) (divCode_noNop base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b0).2 >>> (63 : Nat)) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (clzResult b0).2) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ (clzResult b0).1) **
+       (.x7 ↦ᵣ (clzResult b0).2 >>> (63 : Nat)) **
+       (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - (clzResult b0).1)) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (1 : Word)) **
+       ((sp + signExtend12 3992) ↦ₘ (clzResult b0).1)) := by
+  have hABCLZ := evm_div_phaseAB_n1_clz_spec_within_noNop sp base b0 b1 b2 b3
+    v5 v6 v7 v10 q0 q1 q2 q3 u5 u6 u7 nMem hbnz hb3z hb2z hb1z
+  have hABCLZf := cpsTripleWithin_frameR
+    ((.x2 ↦ᵣ (clzResult b0).2 >>> (63 : Nat)) ** ((sp + signExtend12 3992) ↦ₘ shiftMem))
+    (by pcFree) hABCLZ
+  have hC2 := divK_phaseC2_ntaken_spec_within_noNop sp (clzResult b0).1
+    ((clzResult b0).2 >>> (63 : Nat)) shiftMem base hshift_nz
+  have hC2f := cpsTripleWithin_frameR
+    ((.x5 ↦ᵣ (clzResult b0).2) ** (.x10 ↦ᵣ b3) **
+     (.x7 ↦ᵣ (clzResult b0).2 >>> (63 : Nat)) **
+     ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+     ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (1 : Word)))
+    (by pcFree) hC2
+  have hABC2 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hABCLZf hC2f
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    hABC2
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1NoNop.lean
@@ -215,6 +215,7 @@ theorem evm_div_n1_to_loopSetup_spec_within_noNop (sp base : Word)
     b0' (b0 >>> (antiShift.toNat % 64)) b3 shift antiShift
     u0Old u1Old u2Old u3Old u4Old base
   intro_lets at hNormA
+  rw [divKNormAFullPreNoNop_unfold, divKNormAFullPostNoNop_unfold] at hNormA
   have hNormAf := cpsTripleWithin_frameR
     ((.x0 ↦ᵣ (0 : Word)) **
      (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1NoNop.lean
@@ -110,4 +110,59 @@ theorem evm_div_phaseAB_n1_clz_c2_spec_within_noNop (sp base : Word)
     (fun h hq => by xperm_hyp hq)
     hABC2
 
+/-- DIV N1 no-NOP prefix through NormB for the shift≠0 path. -/
+theorem evm_div_phaseAB_n1_clz_c2_normB_spec_within_noNop (sp base : Word)
+    (b0 b1 b2 b3 v5 v6 v7 v10 : Word)
+    (q0 q1 q2 q3 u5 u6 u7 nMem shiftMem : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1z : b1 = 0)
+    (hshift_nz : (clzResult b0).1 ≠ 0) :
+    let shift := (clzResult b0).1
+    let antiShift := signExtend12 (0 : BitVec 12) - shift
+    let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+    let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+    let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+    let b0' := b0 <<< (shift.toNat % 64)
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21) base (base + normAOff) (divCode_noNop base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b0).2 >>> (63 : Nat)) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b0') ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ shift) ** (.x7 ↦ᵣ (b0 >>> (antiShift.toNat % 64))) ** (.x2 ↦ᵣ antiShift) **
+       ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
+       ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3') **
+       ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (1 : Word)) **
+       ((sp + signExtend12 3992) ↦ₘ shift)) := by
+  intro shift antiShift b3' b2' b1' b0'
+  have hC2 := evm_div_phaseAB_n1_clz_c2_spec_within_noNop sp base
+    b0 b1 b2 b3 v5 v6 v7 v10 q0 q1 q2 q3 u5 u6 u7 nMem shiftMem
+    hbnz hb3z hb2z hb1z hshift_nz
+  have hNB := divK_normB_full_spec_within_noNop sp b0 b1 b2 b3
+    (clzResult b0).2 ((clzResult b0).2 >>> (63 : Nat))
+    shift antiShift base
+  intro_lets at hNB
+  have hNBf := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (1 : Word)) **
+     ((sp + signExtend12 3992) ↦ₘ shift))
+    (by pcFree) hNB
+  have hFull := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hC2 hNBf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    hFull
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1NoNop.lean
@@ -1,0 +1,59 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN1NoNop
+
+  No-NOP prefix composition for the b[3]=b[2]=b[1]=0 (n=1) DIV path.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.PhaseABNoNop
+import EvmAsm.Evm64.DivMod.Compose.CLZ
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- DIV PhaseAB(n=1) + CLZ over `divCode_noNop`.
+    b≠0, b[3]=b[2]=b[1]=0; base → base+212. -/
+theorem evm_div_phaseAB_n1_clz_spec_within_noNop (sp base : Word)
+    (b0 b1 b2 b3 v5 v6 v7 v10 : Word)
+    (q0 q1 q2 q3 u5 u6 u7 nMem : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1z : b1 = 0) :
+    cpsTripleWithin (8 + 21 + 24) base (base + phaseC2Off) (divCode_noNop base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem))
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (clzResult b0).2) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ (clzResult b0).1) ** (.x7 ↦ᵣ (clzResult b0).2 >>> (63 : Nat)) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (1 : Word))) := by
+  have hAB := evm_div_phaseAB_n1_spec_within_noNop sp base b0 b1 b2 b3 v5 v6 v7 v10
+    q0 q1 q2 q3 u5 u6 u7 nMem hbnz hb3z hb2z hb1z
+  have hCLZ := divK_clz_spec_within_noNop b0 b1 b2 base
+  have hCLZf := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ b3) **
+     ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+     ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (1 : Word)))
+    (by pcFree) hCLZ
+  have hABCLZ := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hAB hCLZf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    hABCLZ
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/Norm.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Norm.lean
@@ -168,6 +168,14 @@ private theorem divK_normB_code_sub_divCode {base : Word} :
   skipBlock; skipBlock; skipBlock; skipBlock
   exact CodeReq.union_mono_left
 
+/-- NormB code (block 4) is subsumed by divCode_noNop. -/
+private theorem divK_normB_code_sub_divCode_noNop {base : Word} :
+    ∀ a i, (CodeReq.ofProg (base + normBOff) divK_normB) a = some i →
+      (divCode_noNop base) a = some i := by
+  unfold divCode_noNop; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock; skipBlock; skipBlock
+  exact CodeReq.union_mono_left
+
 -- se12_32, se12_40, se12_48, se12_56 are in Base.lean
 
 /-- NormB first half: merge1 (b[3] with b[2]) + merge2 (b[2] with b[1]).
@@ -280,6 +288,118 @@ theorem divK_normB_full_spec_within (sp b0 b1 b2 b3 v5 v7 shift antiShift : Word
   intro b3' b2' b1' b0'
   have h1 := divK_normB_half1_within sp b0 b1 b2 b3 v5 v7 shift antiShift base
   have h2 := divK_normB_half2_within sp b0 b1 b2' b3' shift antiShift base
+  exact cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    (cpsTripleWithin_seq_perm_same_cr
+      (fun h hp => by xperm_hyp hp) h1 h2)
+
+private theorem divK_normB_half1_within_noNop
+    (sp b0 b1 b2 b3 v5 v7 shift antiShift : Word) (base : Word) :
+    let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+    let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+    cpsTripleWithin 12 (base + normBOff) (base + normBOff + 48) (divCode_noNop base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) **
+       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3))
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b2') ** (.x7 ↦ᵣ (b1 >>> (antiShift.toNat % 64))) **
+       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3')) := by
+  intro b3' b2'
+  have hm1 := divK_normB_merge_spec_within 56 48 sp b3 b2 v5 v7 shift antiShift (base + normBOff)
+  simp only [se12_56, se12_48] at hm1
+  have hm1e := cpsTripleWithin_extend_code (hmono := fun a i h =>
+    divK_normB_code_sub_divCode_noNop a i
+      (CodeReq.ofProg_mono_sub (base + normBOff) (base + normBOff) divK_normB
+        (divK_normB_merge_prog 56 48) 0
+        (by bv_addr) (by decide) (by decide) (by decide) a i h)) hm1
+  have hm1ef := cpsTripleWithin_frameR
+    (((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1))
+    (by pcFree) hm1e
+  have hm2 := divK_normB_merge_spec_within 48 40 sp b2 b1 b3' (b2 >>> (antiShift.toNat % 64))
+    shift antiShift (base + normBOff + 24)
+  simp only [se12_48, se12_40] at hm2
+  rw [show (base + normBOff + 24 : Word) + 24 = base + normBOff + 48 from by bv_addr] at hm2
+  have hm2e := cpsTripleWithin_extend_code (hmono := fun a i h =>
+    divK_normB_code_sub_divCode_noNop a i
+      (CodeReq.ofProg_mono_sub (base + normBOff) (base + normBOff + 24) divK_normB
+        (divK_normB_merge_prog 48 40) 6
+        (by bv_addr) (by decide) (by decide) (by decide) a i h)) hm2
+  have hm2ef := cpsTripleWithin_frameR
+    (((sp + 32) ↦ₘ b0) ** ((sp + 56) ↦ₘ b3'))
+    (by pcFree) hm2e
+  have h12 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hm1ef hm2ef
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    h12
+
+private theorem divK_normB_half2_within_noNop
+    (sp b0 b1 b2' b3' shift antiShift : Word) (base : Word) :
+    let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+    let b0' := b0 <<< (shift.toNat % 64)
+    cpsTripleWithin 9 (base + normBOff + 48) (base + normAOff) (divCode_noNop base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b2') ** (.x7 ↦ᵣ (b1 >>> (antiShift.toNat % 64))) **
+       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3'))
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b0') ** (.x7 ↦ᵣ (b0 >>> (antiShift.toNat % 64))) **
+       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
+       ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
+       ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3')) := by
+  intro b1' b0'
+  have hm3 := divK_normB_merge_spec_within 40 32 sp b1 b0
+    b2' (b1 >>> (antiShift.toNat % 64)) shift antiShift (base + normBOff + 48)
+  simp only [se12_40, se12_32] at hm3
+  rw [show (base + normBOff + 48 : Word) + 24 = base + normBOff + 72 from by bv_addr] at hm3
+  have hm3e := cpsTripleWithin_extend_code (hmono := fun a i h =>
+    divK_normB_code_sub_divCode_noNop a i
+      (CodeReq.ofProg_mono_sub (base + normBOff) (base + normBOff + 48) divK_normB
+        (divK_normB_merge_prog 40 32) 12
+        (by bv_addr) (by decide) (by decide) (by decide) a i h)) hm3
+  have hm3ef := cpsTripleWithin_frameR
+    (((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3'))
+    (by pcFree) hm3e
+  have hl := divK_normB_last_spec_within 32 sp b0 b1' shift (base + normBOff + 72)
+  simp only [se12_32] at hl
+  rw [show (base + normBOff + 72 : Word) + 12 = base + normAOff from by bv_addr] at hl
+  have hle := cpsTripleWithin_extend_code (hmono := fun a i h =>
+    divK_normB_code_sub_divCode_noNop a i
+      (CodeReq.ofProg_mono_sub (base + normBOff) (base + normBOff + 72) divK_normB
+        (divK_normB_last_prog 32) 18
+        (by bv_addr) (by decide) (by decide) (by decide) a i h)) hl
+  have hlef := cpsTripleWithin_frameR
+    ((.x7 ↦ᵣ (b0 >>> (antiShift.toNat % 64))) ** (.x2 ↦ᵣ antiShift) **
+     ((sp + 40) ↦ₘ b1') ** ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3'))
+    (by pcFree) hle
+  have h34 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hm3ef hlef
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    h34
+
+theorem divK_normB_full_spec_within_noNop
+    (sp b0 b1 b2 b3 v5 v7 shift antiShift : Word) (base : Word) :
+    let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+    let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+    let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+    let b0' := b0 <<< (shift.toNat % 64)
+    cpsTripleWithin 21 (base + normBOff) (base + normAOff) (divCode_noNop base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) **
+       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3))
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b0') ** (.x7 ↦ᵣ (b0 >>> (antiShift.toNat % 64))) **
+       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
+       ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
+       ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3')) := by
+  intro b3' b2' b1' b0'
+  have h1 := divK_normB_half1_within_noNop sp b0 b1 b2 b3 v5 v7 shift antiShift base
+  have h2 := divK_normB_half2_within_noNop sp b0 b1 b2' b3' shift antiShift base
   exact cpsTripleWithin_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hq => by xperm_hyp hq)

--- a/EvmAsm/Evm64/DivMod/Compose/Norm.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Norm.lean
@@ -21,6 +21,14 @@ private theorem divK_phaseC2_code_sub_divCode {base : Word} :
   skipBlock; skipBlock; skipBlock
   exact CodeReq.union_mono_left
 
+/-- Phase C2 code (block 3) is subsumed by divCode_noNop. -/
+private theorem divK_phaseC2_code_sub_divCode_noNop {base : Word} :
+    ∀ a i, (divK_phaseC2_code 172 (base + phaseC2Off)) a = some i →
+      (divCode_noNop base) a = some i := by
+  unfold divCode_noNop divK_phaseC2_code; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock; skipBlock
+  exact CodeReq.union_mono_left
+
 /-- BEQ x6 x0 172 singleton at base+224 (index 3 of phaseC2) is subsumed by divCode. -/
 private theorem beq_shift_sub_divCode {base : Word} :
     ∀ a i, (CodeReq.singleton (base + phaseC2Off + 12) (.BEQ .x6 .x0 172)) a = some i →
@@ -30,6 +38,17 @@ private theorem beq_shift_sub_divCode {base : Word} :
     (by decide) (by decide)
   rw [bv64_4mul_3] at hlookup
   exact divK_phaseC2_code_sub_divCode a i
+    (CodeReq.singleton_mono hlookup a i h)
+
+/-- BEQ x6 x0 172 singleton at base+224 (index 3 of phaseC2) is subsumed by divCode_noNop. -/
+private theorem beq_shift_sub_divCode_noNop {base : Word} :
+    ∀ a i, (CodeReq.singleton (base + phaseC2Off + 12) (.BEQ .x6 .x0 172)) a = some i →
+      (divCode_noNop base) a = some i := by
+  intro a i h
+  have hlookup := CodeReq.ofProg_lookup (base + phaseC2Off) (divK_phaseC2 172) 3
+    (by decide) (by decide)
+  rw [bv64_4mul_3] at hlookup
+  exact divK_phaseC2_code_sub_divCode_noNop a i
     (CodeReq.singleton_mono hlookup a i h)
 
 -- `se13_172` moved to `Compose/Base.lean` (shared with ModNorm).
@@ -44,6 +63,17 @@ private theorem divK_phaseC2_body_divCode_within (sp shift v2 shiftMem : Word) (
        (.x0 ↦ᵣ (0 : Word)) ** ((sp + signExtend12 3992) ↦ₘ shift)) := by
   have hbody := divK_phaseC2_body_spec_within sp shift v2 shiftMem 172 (base + phaseC2Off)
   exact cpsTripleWithin_extend_code divK_phaseC2_code_sub_divCode hbody
+
+/-- Phase C2 body over divCode_noNop. -/
+private theorem divK_phaseC2_body_divCode_noNop_within
+    (sp shift v2 shiftMem : Word) (base : Word) :
+    cpsTripleWithin 3 (base + phaseC2Off) (base + phaseC2Off + 12) (divCode_noNop base)
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - shift)) **
+       (.x0 ↦ᵣ (0 : Word)) ** ((sp + signExtend12 3992) ↦ₘ shift)) := by
+  have hbody := divK_phaseC2_body_spec_within sp shift v2 shiftMem 172 (base + phaseC2Off)
+  exact cpsTripleWithin_extend_code divK_phaseC2_code_sub_divCode_noNop hbody
 
 theorem divK_phaseC2_ntaken_spec_within (sp shift v2 shiftMem : Word) (base : Word)
     (hshift_nz : shift ≠ 0) :
@@ -61,6 +91,33 @@ theorem divK_phaseC2_ntaken_spec_within (sp shift v2 shiftMem : Word) (base : Wo
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
       exact absurd ((sepConj_pure_right _).mp h_rest).2 (show shift ≠ (0 : Word) from hshift_nz))
   have hbeq := cpsTripleWithin_extend_code beq_shift_sub_divCode hbeq_clean
+  have hbeqf := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - shift)) **
+     ((sp + signExtend12 3992) ↦ₘ shift))
+    (by pcFree) hbeq
+  have hC2 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hbody hbeqf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    hC2
+
+theorem divK_phaseC2_ntaken_spec_within_noNop (sp shift v2 shiftMem : Word) (base : Word)
+    (hshift_nz : shift ≠ 0) :
+    cpsTripleWithin 4 (base + phaseC2Off) (base + normBOff) (divCode_noNop base)
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - shift)) **
+       (.x0 ↦ᵣ (0 : Word)) ** ((sp + signExtend12 3992) ↦ₘ shift)) := by
+  have hbody := divK_phaseC2_body_divCode_noNop_within sp shift v2 shiftMem base
+  have hbeq_raw := beq_spec_gen_within .x6 .x0 172 shift (0 : Word) (base + phaseC2Off + 12)
+  rw [show (base + phaseC2Off + 12 : Word) + signExtend13 172 = base + copyAUOff from by rv64_addr,
+      show (base + phaseC2Off + 12 : Word) + 4 = base + normBOff from by bv_addr] at hbeq_raw
+  have hbeq_clean := cpsBranchWithin_ntakenStripPure2 hbeq_raw
+    (fun hp hQt => by
+      obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
+      exact absurd ((sepConj_pure_right _).mp h_rest).2 (show shift ≠ (0 : Word) from hshift_nz))
+  have hbeq := cpsTripleWithin_extend_code beq_shift_sub_divCode_noNop hbeq_clean
   have hbeqf := cpsTripleWithin_frameR
     ((.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - shift)) **
      ((sp + signExtend12 3992) ↦ₘ shift))

--- a/EvmAsm/Evm64/DivMod/Compose/NormA.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/NormA.lean
@@ -389,6 +389,14 @@ private theorem divK_loopSetup_code_sub_divCode {base : Word} :
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
   exact CodeReq.union_mono_left
 
+/-- LoopSetup code (block 7) is subsumed by divCode_noNop. -/
+private theorem divK_loopSetup_code_sub_divCode_noNop {base : Word} :
+    ∀ a i, (divK_loopSetup_code 464 (base + loopSetupOff)) a = some i →
+      (divCode_noNop base) a = some i := by
+  unfold divCode_noNop divK_loopSetup_code; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
+  exact CodeReq.union_mono_left
+
 /-- BLT singleton at base+loopSetupOff+12 (index 3 of loopSetup) is subsumed by divCode. -/
 private theorem blt_loopSetup_sub_divCode {base : Word} :
     ∀ a i, (CodeReq.singleton (base + loopSetupOff + 12) (.BLT .x1 .x0 464)) a = some i →
@@ -398,6 +406,17 @@ private theorem blt_loopSetup_sub_divCode {base : Word} :
     (by decide) (by decide)
   rw [bv64_4mul_3] at hlookup
   exact divK_loopSetup_code_sub_divCode a i
+    (CodeReq.singleton_mono hlookup a i h)
+
+/-- BLT singleton at base+loopSetupOff+12 is subsumed by divCode_noNop. -/
+private theorem blt_loopSetup_sub_divCode_noNop {base : Word} :
+    ∀ a i, (CodeReq.singleton (base + loopSetupOff + 12) (.BLT .x1 .x0 464)) a = some i →
+      (divCode_noNop base) a = some i := by
+  intro a i h
+  have hlookup := CodeReq.ofProg_lookup (base + loopSetupOff) (divK_loopSetup 464) 3
+    (by decide) (by decide)
+  rw [bv64_4mul_3] at hlookup
+  exact divK_loopSetup_code_sub_divCode_noNop a i
     (CodeReq.singleton_mono hlookup a i h)
 
 -- `se13_464` moved to `Compose/Base.lean` (shared with ModNormA).
@@ -423,6 +442,35 @@ theorem divK_loopSetup_ntaken_spec_within (sp n v1 v5 : Word) (base : Word)
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
       exact absurd ((sepConj_pure_right _).mp h_rest).2 hm_ge)
   have hblte := cpsTripleWithin_extend_code blt_loopSetup_sub_divCode hblt_clean
+  have hbltef := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ n) ** ((sp + signExtend12 3984) ↦ₘ n))
+    (by pcFree) hblte
+  have h12 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hbodye hbltef
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    h12
+
+theorem divK_loopSetup_ntaken_spec_within_noNop (sp n v1 v5 : Word) (base : Word)
+    (hm_ge : ¬BitVec.slt (signExtend12 (4 : BitVec 12) - n) (0 : Word)) :
+    let m := signExtend12 (4 : BitVec 12) - n
+    cpsTripleWithin 4 (base + loopSetupOff) (base + loopBodyOff) (divCode_noNop base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x1 ↦ᵣ v1) ** (.x0 ↦ᵣ (0 : Word)) **
+       ((sp + signExtend12 3984) ↦ₘ n))
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ n) ** (.x1 ↦ᵣ m) ** (.x0 ↦ᵣ (0 : Word)) **
+       ((sp + signExtend12 3984) ↦ₘ n)) := by
+  intro m
+  have hbody := divK_loopSetup_body_spec_within sp n v1 v5 464 (base + loopSetupOff)
+  have hbodye := cpsTripleWithin_extend_code divK_loopSetup_code_sub_divCode_noNop hbody
+  have hblt_raw := blt_spec_gen_within .x1 .x0 464 m (0 : Word) (base + loopSetupOff + 12)
+  rw [show (base + loopSetupOff + 12 : Word) + signExtend13 464 = base + denormOff from by rv64_addr,
+      show (base + loopSetupOff + 12 : Word) + 4 = base + loopBodyOff from by bv_addr] at hblt_raw
+  have hblt_clean := cpsBranchWithin_ntakenStripPure2 hblt_raw
+    (fun hp hQt => by
+      obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
+      exact absurd ((sepConj_pure_right _).mp h_rest).2 hm_ge)
+  have hblte := cpsTripleWithin_extend_code blt_loopSetup_sub_divCode_noNop hblt_clean
   have hbltef := cpsTripleWithin_frameR
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ n) ** ((sp + signExtend12 3984) ↦ₘ n))
     (by pcFree) hblte

--- a/EvmAsm/Evm64/DivMod/Compose/NormA.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/NormA.lean
@@ -329,6 +329,14 @@ private theorem divK_copyAU_code_sub_divCode {base : Word} :
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
   exact CodeReq.union_mono_left
 
+/-- CopyAU code (block 6) is subsumed by divCode_noNop. -/
+private theorem divK_copyAU_code_sub_divCode_noNop {base : Word} :
+    ∀ a i, (divK_copyAU_code (base + copyAUOff)) a = some i →
+      (divCode_noNop base) a = some i := by
+  unfold divCode_noNop divK_copyAU_code; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
+  exact CodeReq.union_mono_left
+
 /-- Full CopyAU: copy a[0..3] to u[0..3], set u[4]=0.
     base+396 → base+432 (9 instructions). -/
 theorem divK_copyAU_full_spec_within (sp : Word)
@@ -349,6 +357,25 @@ theorem divK_copyAU_full_spec_within (sp : Word)
   have hcopy := divK_copyAU_spec_within sp (base + copyAUOff) a0 a1 a2 a3 u0 u1 u2 u3 u4 v5
   rw [show (base + copyAUOff : Word) + 36 = base + loopSetupOff from by bv_addr] at hcopy
   exact cpsTripleWithin_extend_code divK_copyAU_code_sub_divCode hcopy
+
+theorem divK_copyAU_full_spec_within_noNop (sp : Word)
+    (a0 a1 a2 a3 : Word) (u0 u1 u2 u3 u4 v5 : Word) (base : Word) :
+    cpsTripleWithin 9 (base + copyAUOff) (base + loopSetupOff) (divCode_noNop base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) **
+       ((sp + signExtend12 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
+       ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3) **
+       ((sp + signExtend12 4024) ↦ₘ u4))
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ a3) **
+       ((sp + signExtend12 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + signExtend12 4056) ↦ₘ a0) ** ((sp + signExtend12 4048) ↦ₘ a1) **
+       ((sp + signExtend12 4040) ↦ₘ a2) ** ((sp + signExtend12 4032) ↦ₘ a3) **
+       ((sp + signExtend12 4024) ↦ₘ (0 : Word))) := by
+  have hcopy := divK_copyAU_spec_within sp (base + copyAUOff) a0 a1 a2 a3 u0 u1 u2 u3 u4 v5
+  rw [show (base + copyAUOff : Word) + 36 = base + loopSetupOff from by bv_addr] at hcopy
+  exact cpsTripleWithin_extend_code divK_copyAU_code_sub_divCode_noNop hcopy
 
 -- ============================================================================
 -- Section 10k: LoopSetup composition (4 instructions at base+432)

--- a/EvmAsm/Evm64/DivMod/Compose/NormA.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/NormA.lean
@@ -25,6 +25,14 @@ private theorem divK_normA_code_sub_divCode {base : Word} :
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
   exact CodeReq.union_mono_left
 
+/-- NormA code (block 5) is subsumed by divCode_noNop. -/
+private theorem divK_normA_code_sub_divCode_noNop {base : Word} :
+    ∀ a i, (CodeReq.ofProg (base + normAOff) (divK_normA 40)) a = some i →
+      (divCode_noNop base) a = some i := by
+  unfold divCode_noNop; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
+  exact CodeReq.union_mono_left
+
 -- signExtend12 rewrites pulled from the divmod_addr global set (AddrNorm.lean).
 open EvmAsm.Evm64.DivMod.AddrNorm (se12_0 se12_8 se12_16 se12_24)
 -- signExtend13/21 rewrites pulled from the rv64_addr global set (Rv64/AddrNorm.lean).
@@ -165,6 +173,139 @@ theorem divK_normA_full_spec_within (sp a0 a1 a2 a3 v5 v7 v10 shift antiShift : 
   -- Since JAL has empAssertion pre/post and frame is postAll, the result is (empAssertion ** postAll).
   -- Use consequence to strip empAssertion from both sides.
   have hjal_clean : cpsTripleWithin 1 (base + normAOff + 80) (base + loopSetupOff) (divCode base) postAll postAll :=
+    cpsTripleWithin_weaken
+      (fun h hp => by show (empAssertion ** postAll) h; rw [sepConj_emp_left']; exact hp)
+      (fun h hp => by rw [sepConj_emp_left'] at hp; exact hp)
+      hjalef
+  have h123456 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) h12345 hjal_clean
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    h123456
+
+/-- Full NormA over divCode_noNop. -/
+theorem divK_normA_full_spec_within_noNop (sp a0 a1 a2 a3 v5 v7 v10 shift antiShift : Word)
+    (u0Old u1Old u2Old u3Old u4Old : Word) (base : Word) :
+    let u4 := a3 >>> (antiShift.toNat % 64)
+    let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+    let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+    let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
+    let u0 := a0 <<< (shift.toNat % 64)
+    cpsTripleWithin 21 (base + normAOff) (base + loopSetupOff) (divCode_noNop base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) ** (.x10 ↦ᵣ v10) **
+       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + signExtend12 4024) ↦ₘ u4Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+       ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+       ((sp + signExtend12 4056) ↦ₘ u0Old))
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ u1) ** (.x7 ↦ᵣ u0) ** (.x10 ↦ᵣ (a0 >>> (antiShift.toNat % 64))) **
+       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4032) ↦ₘ u3) **
+       ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4048) ↦ₘ u1) **
+       ((sp + signExtend12 4056) ↦ₘ u0)) := by
+  intro u4 u3 u2 u1 u0
+  have htop := divK_normA_top_spec_within 24 4024 sp a3 v5 v7 antiShift u4Old (base + normAOff)
+  simp only [se12_24] at htop
+  have htope := cpsTripleWithin_extend_code (hmono := fun a i h =>
+    divK_normA_code_sub_divCode_noNop a i
+      (CodeReq.ofProg_mono_sub (base + normAOff) (base + normAOff) (divK_normA 40)
+        (divK_normA_top_prog 24 4024) 0
+        (by bv_addr) (by decide) (by decide) (by decide) a i h)) htop
+  have htopef := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ v10) ** (.x6 ↦ᵣ shift) **
+     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) **
+     ((sp + signExtend12 4032) ↦ₘ u3Old) **
+     ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+     ((sp + signExtend12 4056) ↦ₘ u0Old))
+    (by pcFree) htope
+  have hma1 := divK_normA_mergeA_spec_within 16 4032 sp a3 a2 u4 v10 shift antiShift u3Old (base + normAOff + 12)
+  simp only [se12_16] at hma1
+  rw [show (base + normAOff + 12 : Word) + 20 = base + normAOff + 32 from by bv_addr] at hma1
+  have hma1e := cpsTripleWithin_extend_code (hmono := fun a i h =>
+    divK_normA_code_sub_divCode_noNop a i
+      (CodeReq.ofProg_mono_sub (base + normAOff) (base + normAOff + 12) (divK_normA 40)
+        (divK_normA_mergeA_prog 16 4032) 3
+        (by bv_addr) (by decide) (by decide) (by decide) a i h)) hma1
+  have hma1ef := cpsTripleWithin_frameR
+    (((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 4024) ↦ₘ u4) **
+     ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+     ((sp + signExtend12 4056) ↦ₘ u0Old))
+    (by pcFree) hma1e
+  have h12 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) htopef hma1ef
+  have hmb := divK_normA_mergeB_spec_within 8 4040 sp a2 a1 u3 (a2 >>> (antiShift.toNat % 64))
+    shift antiShift u2Old (base + normAOff + 32)
+  simp only [se12_8] at hmb
+  rw [show (base + normAOff + 32 : Word) + 20 = base + normAOff + 52 from by bv_addr] at hmb
+  have hmbe := cpsTripleWithin_extend_code (hmono := fun a i h =>
+    divK_normA_code_sub_divCode_noNop a i
+      (CodeReq.ofProg_mono_sub (base + normAOff) (base + normAOff + 32) (divK_normA 40)
+        (divK_normA_mergeB_prog 8 4040) 8
+        (by bv_addr) (by decide) (by decide) (by decide) a i h)) hmb
+  have hmbef := cpsTripleWithin_frameR
+    (((sp + 0) ↦ₘ a0) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4032) ↦ₘ u3) **
+     ((sp + signExtend12 4048) ↦ₘ u1Old) ** ((sp + signExtend12 4056) ↦ₘ u0Old))
+    (by pcFree) hmbe
+  have h123 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) h12 hmbef
+  have hma2 := divK_normA_mergeA_spec_within 0 4048 sp a1 a0 u2 (a1 >>> (antiShift.toNat % 64))
+    shift antiShift u1Old (base + normAOff + 52)
+  simp only [se12_0] at hma2
+  rw [show (base + normAOff + 52 : Word) + 20 = base + normAOff + 72 from by bv_addr] at hma2
+  have hma2e := cpsTripleWithin_extend_code (hmono := fun a i h =>
+    divK_normA_code_sub_divCode_noNop a i
+      (CodeReq.ofProg_mono_sub (base + normAOff) (base + normAOff + 52) (divK_normA 40)
+        (divK_normA_mergeA_prog 0 4048) 13
+        (by bv_addr) (by decide) (by decide) (by decide) a i h)) hma2
+  have hma2ef := cpsTripleWithin_frameR
+    (((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4032) ↦ₘ u3) **
+     ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4056) ↦ₘ u0Old))
+    (by pcFree) hma2e
+  have h1234 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) h123 hma2ef
+  have hlast := divK_normA_last_spec_within 4056 sp a0 shift u0Old (base + normAOff + 72)
+  rw [show (base + normAOff + 72 : Word) + 8 = base + normAOff + 80 from by bv_addr] at hlast
+  have hlaste := cpsTripleWithin_extend_code (hmono := fun a i h =>
+    divK_normA_code_sub_divCode_noNop a i
+      (CodeReq.ofProg_mono_sub (base + normAOff) (base + normAOff + 72) (divK_normA 40)
+        (divK_normA_last_prog 4056) 18
+        (by bv_addr) (by decide) (by decide) (by decide) a i h)) hlast
+  have hlastef := cpsTripleWithin_frameR
+    ((.x5 ↦ᵣ u1) ** (.x10 ↦ᵣ (a0 >>> (antiShift.toNat % 64))) ** (.x2 ↦ᵣ antiShift) **
+     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4032) ↦ₘ u3) **
+     ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4048) ↦ₘ u1))
+    (by pcFree) hlaste
+  have h12345 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) h1234 hlastef
+  have hjal := jal_x0_spec_gen_within 40 (base + normAOff + 80)
+  rw [show (base + normAOff + 80 : Word) + signExtend21 40 = base + loopSetupOff from by rv64_addr] at hjal
+  have hjale := cpsTripleWithin_extend_code (hmono := by
+    intro a i h
+    exact divK_normA_code_sub_divCode_noNop a i
+      (CodeReq.singleton_mono (by
+        have hlookup := CodeReq.ofProg_lookup (base + normAOff) (divK_normA 40) 20
+          (by decide) (by decide)
+        rw [show (base + normAOff : Word) + BitVec.ofNat 64 (4 * 20) = base + normAOff + 80 from by bv_addr]
+          at hlookup
+        exact hlookup) a i h)) hjal
+  let postAll := (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ u1) ** (.x7 ↦ᵣ u0) **
+    (.x10 ↦ᵣ (a0 >>> (antiShift.toNat % 64))) **
+    (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
+    ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+    ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4032) ↦ₘ u3) **
+    ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4048) ↦ₘ u1) **
+    ((sp + signExtend12 4056) ↦ₘ u0)
+  have hjalef := cpsTripleWithin_frameR postAll (by pcFree) hjale
+  have hjal_clean : cpsTripleWithin 1 (base + normAOff + 80) (base + loopSetupOff) (divCode_noNop base) postAll postAll :=
     cpsTripleWithin_weaken
       (fun h hp => by show (empAssertion ** postAll) h; rw [sepConj_emp_left']; exact hp)
       (fun h hp => by rw [sepConj_emp_left'] at hp; exact hp)

--- a/EvmAsm/Evm64/DivMod/Compose/NormA.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/NormA.lean
@@ -184,7 +184,63 @@ theorem divK_normA_full_spec_within (sp a0 a1 a2 a3 v5 v7 v10 shift antiShift : 
     (fun h hq => by xperm_hyp hq)
     h123456
 
-/-- Full NormA over divCode_noNop. -/
+/-- Precondition for the no-NOP NormA block: entry registers + the
+    pre-normalized `a[]` limbs in scratch slots. Wrapped `@[irreducible]`
+    so downstream proofs do not re-reduce the 15-atom sepConj. -/
+@[irreducible]
+def divKNormAFullPreNoNop
+    (sp v5 v7 v10 shift antiShift
+      a0 a1 a2 a3 u0Old u1Old u2Old u3Old u4Old : Word) : Assertion :=
+  (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) ** (.x10 ↦ᵣ v10) **
+  (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
+  ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+  ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+  ((sp + signExtend12 4024) ↦ₘ u4Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+  ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+  ((sp + signExtend12 4056) ↦ₘ u0Old)
+
+theorem divKNormAFullPreNoNop_unfold
+    {sp v5 v7 v10 shift antiShift
+      a0 a1 a2 a3 u0Old u1Old u2Old u3Old u4Old : Word} :
+    divKNormAFullPreNoNop sp v5 v7 v10 shift antiShift
+        a0 a1 a2 a3 u0Old u1Old u2Old u3Old u4Old =
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) ** (.x10 ↦ᵣ v10) **
+       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + signExtend12 4024) ↦ₘ u4Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+       ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+       ((sp + signExtend12 4056) ↦ₘ u0Old)) := by
+  delta divKNormAFullPreNoNop
+  rfl
+
+/-- Postcondition for the no-NOP NormA block: the normalized `u[]`
+    sequence written to scratch slots, with `x5`/`x7`/`x10` holding the
+    top-of-the-shift intermediate values. Wrapped `@[irreducible]`. -/
+@[irreducible]
+def divKNormAFullPostNoNop
+    (sp shift antiShift a0 a1 a2 a3 u0 u1 u2 u3 u4 : Word) : Assertion :=
+  (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ u1) ** (.x7 ↦ᵣ u0) ** (.x10 ↦ᵣ (a0 >>> (antiShift.toNat % 64))) **
+  (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
+  ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+  ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+  ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4032) ↦ₘ u3) **
+  ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4048) ↦ₘ u1) **
+  ((sp + signExtend12 4056) ↦ₘ u0)
+
+theorem divKNormAFullPostNoNop_unfold
+    {sp shift antiShift a0 a1 a2 a3 u0 u1 u2 u3 u4 : Word} :
+    divKNormAFullPostNoNop sp shift antiShift a0 a1 a2 a3 u0 u1 u2 u3 u4 =
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ u1) ** (.x7 ↦ᵣ u0) ** (.x10 ↦ᵣ (a0 >>> (antiShift.toNat % 64))) **
+       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4032) ↦ₘ u3) **
+       ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4048) ↦ₘ u1) **
+       ((sp + signExtend12 4056) ↦ₘ u0)) := by
+  delta divKNormAFullPostNoNop
+  rfl
+
 theorem divK_normA_full_spec_within_noNop (sp a0 a1 a2 a3 v5 v7 v10 shift antiShift : Word)
     (u0Old u1Old u2Old u3Old u4Old : Word) (base : Word) :
     let u4 := a3 >>> (antiShift.toNat % 64)
@@ -193,21 +249,11 @@ theorem divK_normA_full_spec_within_noNop (sp a0 a1 a2 a3 v5 v7 v10 shift antiSh
     let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
     let u0 := a0 <<< (shift.toNat % 64)
     cpsTripleWithin 21 (base + normAOff) (base + loopSetupOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) ** (.x10 ↦ᵣ v10) **
-       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
-       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
-       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
-       ((sp + signExtend12 4024) ↦ₘ u4Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
-       ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
-       ((sp + signExtend12 4056) ↦ₘ u0Old))
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ u1) ** (.x7 ↦ᵣ u0) ** (.x10 ↦ᵣ (a0 >>> (antiShift.toNat % 64))) **
-       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
-       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
-       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
-       ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4032) ↦ₘ u3) **
-       ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4048) ↦ₘ u1) **
-       ((sp + signExtend12 4056) ↦ₘ u0)) := by
+      (divKNormAFullPreNoNop sp v5 v7 v10 shift antiShift
+        a0 a1 a2 a3 u0Old u1Old u2Old u3Old u4Old)
+      (divKNormAFullPostNoNop sp shift antiShift a0 a1 a2 a3 u0 u1 u2 u3 u4) := by
   intro u4 u3 u2 u1 u0
+  rw [divKNormAFullPreNoNop_unfold, divKNormAFullPostNoNop_unfold]
   have htop := divK_normA_top_spec_within 24 4024 sp a3 v5 v7 antiShift u4Old (base + normAOff)
   simp only [se12_24] at htop
   have htope := cpsTripleWithin_extend_code (hmono := fun a i h =>

--- a/EvmAsm/Evm64/DivMod/Compose/PhaseABNoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/PhaseABNoNop.lean
@@ -1,0 +1,422 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.PhaseABNoNop
+
+  No-NOP DIV Phase A/B wrappers used by callable DIV/SDIV composition.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.PhaseAB
+import EvmAsm.Rv64.Tactics.XPermChunked
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm
+  (bv64_4mul_9 bv64_4mul_10 bv64_4mul_11 bv64_4mul_12 bv64_4mul_13
+   bv64_4mul_14 bv64_4mul_15)
+
+private theorem phB_i2_8 {base : Word} :
+    (base + phaseBInit2Off : Word) + 8 = base + phaseBStep0Off := by bv_addr
+private theorem phB_addi_4 {base : Word} :
+    (base + phaseBStep0Off : Word) + 4 = base + phaseBBneOff := by bv_addr
+private theorem phB_bne_4 {base : Word} :
+    (base + phaseBBneOff : Word) + 4 = base + phaseBStep1Off := by bv_addr
+private theorem phB_step1_4 {base : Word} :
+    (base + phaseBStep1Off : Word) + 4 = base + phaseBBne2Off := by bv_addr
+private theorem phB_step1_8 {base : Word} :
+    (base + phaseBBne2Off : Word) + 4 = base + phaseBStep2Off := by bv_addr
+private theorem phB_step2_4 {base : Word} :
+    (base + phaseBStep2Off : Word) + 4 = base + phaseBBne3Off := by bv_addr
+private theorem phB_step2_8 {base : Word} :
+    (base + phaseBBne3Off : Word) + 4 = base + phaseBStep3Off := by bv_addr
+private theorem phB_fall_4 {base : Word} :
+    (base + phaseBStep3Off : Word) + 4 = base + phaseBTailOff := by bv_addr
+private theorem phB_t_20 {base : Word} :
+    (base + phaseBTailOff : Word) + 20 = base + clzOff := by bv_addr
+private theorem divK_phaseB_n1_nm1_x8 :
+    ((1 : Word) + signExtend12 (4095 : BitVec 12)) <<< (3 : BitVec 6).toNat = (0 : Word) := by
+  decide
+private theorem phB_sp0_32 {sp : Word} : (sp + (0 : Word) + (32 : Word)) = sp + 32 := by
+  bv_addr
+
+private theorem sub_divCodeNoNop_of_phaseB_left {base : Word} {rest : CodeReq} :
+    ∀ a i,
+      CodeReq.ofProg (base + phaseBOff) divK_phaseB a = some i →
+      ((CodeReq.ofProg base (divK_phaseA 1020)).union
+        ((CodeReq.ofProg (base + phaseBOff) divK_phaseB).union rest)) a = some i :=
+  CodeReq.mono_union_right
+    (CodeReq.ofProg_disjoint_range
+      (fun k1 k2 hk1 hk2 => by
+        simp only [divK_phaseA_len, divK_phaseB_len] at hk1 hk2; bv_omega))
+    (CodeReq.union_mono_left)
+
+private theorem divK_phaseA_code_sub_divCode_noNop {base : Word} :
+    ∀ a i, (divK_phaseA_code base) a = some i → (divCode_noNop base) a = some i := by
+  unfold divCode_noNop divK_phaseA_code; simp only [CodeReq.unionAll_cons]
+  exact CodeReq.union_mono_left
+
+private theorem beq_singleton_sub_divCode_noNop {base : Word} :
+    ∀ a i, (CodeReq.singleton (base + phaseABeqOff) (.BEQ .x5 .x0 1020)) a = some i →
+      (divCode_noNop base) a = some i := by
+  unfold divCode_noNop; simp only [CodeReq.unionAll_cons]
+  intro a i h
+  exact CodeReq.union_mono_left a i
+    (CodeReq.singleton_mono (CodeReq.ofProg_lookup base (divK_phaseA 1020) 7
+      (by decide) (by decide)) a i h)
+
+private theorem divK_phaseB_init1_code_sub_divCode_noNop {base : Word} :
+    ∀ a i, (divK_phaseB_init1_code (base + phaseBOff)) a = some i →
+      (divCode_noNop base) a = some i := by
+  unfold divCode_noNop; simp only [CodeReq.unionAll_cons]
+  intro a i h
+  have h1 := CodeReq.ofProg_mono_sub (base + phaseBOff) (base + phaseBOff) divK_phaseB
+    (divK_phaseB.take 7) 0
+    (by bv_addr) (by decide) (by decide) (by decide) a i h
+  exact sub_divCodeNoNop_of_phaseB_left a i h1
+
+private theorem divK_phaseB_init2_code_sub_divCode_noNop {base : Word} :
+    ∀ a i, (divK_phaseB_init2_code (base + phaseBInit2Off)) a = some i →
+      (divCode_noNop base) a = some i := by
+  unfold divCode_noNop; simp only [CodeReq.unionAll_cons]
+  intro a i h
+  have h1 := CodeReq.ofProg_mono_sub (base + phaseBOff) (base + phaseBInit2Off) divK_phaseB
+    (divK_phaseB.drop 7 |>.take 2) 7
+    (by bv_addr) (by decide) (by decide) (by decide) a i h
+  exact sub_divCodeNoNop_of_phaseB_left a i h1
+
+private theorem divK_phaseB_tail_code_sub_divCode_noNop {base : Word} :
+    ∀ a i, (divK_phaseB_tail_code (base + phaseBTailOff)) a = some i →
+      (divCode_noNop base) a = some i := by
+  unfold divCode_noNop; simp only [CodeReq.unionAll_cons]
+  intro a i h
+  have h1 := CodeReq.ofProg_mono_sub (base + phaseBOff) (base + phaseBTailOff) divK_phaseB
+    (divK_phaseB.drop 16) 16
+    (by bv_addr) (by decide) (by decide) (by decide) a i h
+  exact sub_divCodeNoNop_of_phaseB_left a i h1
+
+private theorem addi_x5_singleton_sub_divCode_noNop {base : Word} :
+    ∀ a i, (CodeReq.singleton (base + phaseBStep0Off) (.ADDI .x5 .x0 4)) a = some i →
+      (divCode_noNop base) a = some i := by
+  unfold divCode_noNop; simp only [CodeReq.unionAll_cons]
+  intro a i h
+  have hlookup := CodeReq.ofProg_lookup (base + phaseBOff) divK_phaseB 9
+    (by decide) (by decide)
+  rw [bv64_4mul_9,
+      show (base + phaseBOff : Word) + 36 = base + phaseBStep0Off from by bv_addr] at hlookup
+  exact sub_divCodeNoNop_of_phaseB_left a i (CodeReq.singleton_mono hlookup a i h)
+
+private theorem bne_x10_singleton_sub_divCode_noNop {base : Word} :
+    ∀ a i, (CodeReq.singleton (base + phaseBBneOff) (.BNE .x10 .x0 24)) a = some i →
+      (divCode_noNop base) a = some i := by
+  unfold divCode_noNop; simp only [CodeReq.unionAll_cons]
+  intro a i h
+  have hlookup := CodeReq.ofProg_lookup (base + phaseBOff) divK_phaseB 10
+    (by decide) (by decide)
+  rw [bv64_4mul_10,
+      show (base + phaseBOff : Word) + 40 = base + phaseBBneOff from by bv_addr] at hlookup
+  exact sub_divCodeNoNop_of_phaseB_left a i (CodeReq.singleton_mono hlookup a i h)
+
+private theorem addi_x5_3_sub_divCode_noNop {base : Word} :
+    ∀ a i, (CodeReq.singleton (base + phaseBStep1Off) (.ADDI .x5 .x0 3)) a = some i →
+      (divCode_noNop base) a = some i := by
+  unfold divCode_noNop; simp only [CodeReq.unionAll_cons]
+  intro a i h
+  have hlookup := CodeReq.ofProg_lookup (base + phaseBOff) divK_phaseB 11
+    (by decide) (by decide)
+  rw [bv64_4mul_11,
+      show (base + phaseBOff : Word) + 44 = base + phaseBStep1Off from by bv_addr] at hlookup
+  exact sub_divCodeNoNop_of_phaseB_left a i (CodeReq.singleton_mono hlookup a i h)
+
+private theorem bne_x7_16_sub_divCode_noNop {base : Word} :
+    ∀ a i, (CodeReq.singleton (base + phaseBBne2Off) (.BNE .x7 .x0 16)) a = some i →
+      (divCode_noNop base) a = some i := by
+  unfold divCode_noNop; simp only [CodeReq.unionAll_cons]
+  intro a i h
+  have hlookup := CodeReq.ofProg_lookup (base + phaseBOff) divK_phaseB 12
+    (by decide) (by decide)
+  rw [bv64_4mul_12,
+      show (base + phaseBOff : Word) + 48 = base + phaseBBne2Off from by bv_addr] at hlookup
+  exact sub_divCodeNoNop_of_phaseB_left a i (CodeReq.singleton_mono hlookup a i h)
+
+private theorem addi_x5_2_sub_divCode_noNop {base : Word} :
+    ∀ a i, (CodeReq.singleton (base + phaseBStep2Off) (.ADDI .x5 .x0 2)) a = some i →
+      (divCode_noNop base) a = some i := by
+  unfold divCode_noNop; simp only [CodeReq.unionAll_cons]
+  intro a i h
+  have hlookup := CodeReq.ofProg_lookup (base + phaseBOff) divK_phaseB 13
+    (by decide) (by decide)
+  rw [bv64_4mul_13,
+      show (base + phaseBOff : Word) + 52 = base + phaseBStep2Off from by bv_addr] at hlookup
+  exact sub_divCodeNoNop_of_phaseB_left a i (CodeReq.singleton_mono hlookup a i h)
+
+private theorem bne_x6_8_sub_divCode_noNop {base : Word} :
+    ∀ a i, (CodeReq.singleton (base + phaseBBne3Off) (.BNE .x6 .x0 8)) a = some i →
+      (divCode_noNop base) a = some i := by
+  unfold divCode_noNop; simp only [CodeReq.unionAll_cons]
+  intro a i h
+  have hlookup := CodeReq.ofProg_lookup (base + phaseBOff) divK_phaseB 14
+    (by decide) (by decide)
+  rw [bv64_4mul_14,
+      show (base + phaseBOff : Word) + 56 = base + phaseBBne3Off from by bv_addr] at hlookup
+  exact sub_divCodeNoNop_of_phaseB_left a i (CodeReq.singleton_mono hlookup a i h)
+
+private theorem addi_x5_1_sub_divCode_noNop {base : Word} :
+    ∀ a i, (CodeReq.singleton (base + phaseBStep3Off) (.ADDI .x5 .x0 1)) a = some i →
+      (divCode_noNop base) a = some i := by
+  unfold divCode_noNop; simp only [CodeReq.unionAll_cons]
+  intro a i h
+  have hlookup := CodeReq.ofProg_lookup (base + phaseBOff) divK_phaseB 15
+    (by decide) (by decide)
+  rw [bv64_4mul_15,
+      show (base + phaseBOff : Word) + 60 = base + phaseBStep3Off from by bv_addr] at hlookup
+  exact sub_divCodeNoNop_of_phaseB_left a i (CodeReq.singleton_mono hlookup a i h)
+
+theorem evm_div_phaseA_ntaken_spec_within_noNop (sp base : Word)
+    (b0 b1 b2 b3 v5 v10 : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0) :
+    cpsTripleWithin 8 base (base + phaseBOff) (divCode_noNop base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3))
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (b0 ||| b1 ||| b2 ||| b3)) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3)) := by
+  have hbody := cpsTripleWithin_extend_code divK_phaseA_code_sub_divCode_noNop
+    (divK_phaseA_body_spec_within sp base b0 b1 b2 b3 v5 v10)
+  have hbeq_raw := beq_spec_gen_within .x5 .x0 1020 (b0 ||| b1 ||| b2 ||| b3) (0 : Word) (base + phaseABeqOff)
+  rw [show (base + phaseABeqOff : Word) + signExtend13 1020 = base + zeroPathOff from by rv64_addr,
+      show (base + phaseABeqOff : Word) + 4 = base + phaseBOff from by bv_addr] at hbeq_raw
+  have hbeq_clean := cpsBranchWithin_ntakenStripPure2 hbeq_raw
+    (fun hp hQt => by
+      obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
+      exact absurd ((sepConj_pure_right _).mp h_rest).2 hbnz)
+  have hbeq := cpsTripleWithin_extend_code beq_singleton_sub_divCode_noNop hbeq_clean
+  have hbeq_framed := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ b3) **
+     ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+     ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3))
+    (by pcFree) hbeq
+  have hAB := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hbody hbeq_framed
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    hAB
+
+theorem evm_div_phaseB_n1_spec_within_noNop (sp base : Word)
+    (b0 b1 b2 b3 : Word) (v5 v6 v7 : Word)
+    (q0 q1 q2 q3 u5 u6 u7 nMem : Word)
+    (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1z : b1 = 0) :
+    cpsTripleWithin 21 (base + phaseBOff) (base + clzOff) (divCode_noNop base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) **
+       ((sp + signExtend12 3984) ↦ₘ nMem))
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b0) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 3984) ↦ₘ (1 : Word))) := by
+  have hinit1_raw := divK_phaseB_init1_spec_within sp (base + phaseBOff) q0 q1 q2 q3 u5 u6 u7
+  simp only [phB_off_28] at hinit1_raw
+  have hinit1 := cpsTripleWithin_extend_code divK_phaseB_init1_code_sub_divCode_noNop hinit1_raw
+  have hinit1f := cpsTripleWithin_frameR
+    ((.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+     ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 3984) ↦ₘ nMem))
+    (by pcFree) hinit1
+  have hinit2_raw := divK_phaseB_init2_spec_within sp (base + phaseBInit2Off) b1 b2 v6 v7
+  simp only [phB_i2_8] at hinit2_raw
+  have hinit2 := cpsTripleWithin_extend_code divK_phaseB_init2_code_sub_divCode_noNop hinit2_raw
+  have hinit2f := cpsTripleWithin_frameR
+    ((.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
+     ((sp + 32) ↦ₘ b0) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3984) ↦ₘ nMem))
+    (by pcFree) hinit2
+  have h12 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hinit1f hinit2f
+  have haddi0_raw := addi_x0_spec_gen_within .x5 v5 4 (base + phaseBStep0Off) (by nofun)
+  simp only [phB_addi_4, signExtend12_4] at haddi0_raw
+  have haddi0 := cpsTripleWithin_extend_code addi_x5_singleton_sub_divCode_noNop haddi0_raw
+  have haddi0f := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ b3) ** (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
+     ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3984) ↦ₘ nMem))
+    (by pcFree) haddi0
+  have h123 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) h12 haddi0f
+  have hbne0_raw := bne_spec_gen_within .x10 .x0 24 b3 (0 : Word) (base + phaseBBneOff)
+  rw [show (base + phaseBBneOff : Word) + signExtend13 24 = base + phaseBTailOff from by
+        rv64_addr, phB_bne_4] at hbne0_raw
+  have hbne0_clean := cpsBranchWithin_ntakenStripPure2 hbne0_raw
+    (fun hp hQt => by
+      obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
+      exact absurd hb3z ((sepConj_pure_right _).mp h_rest).2)
+  have hbne0 := cpsTripleWithin_extend_code bne_x10_singleton_sub_divCode_noNop hbne0_clean
+  have hbne0f := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (4 : Word)) ** (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
+     ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3984) ↦ₘ nMem))
+    (by pcFree) hbne0
+  have h1234 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) h123 hbne0f
+  have haddi1_raw := addi_x0_spec_gen_within .x5 (4 : Word) 3 (base + phaseBStep1Off) (by nofun)
+  simp only [phB_step1_4, signExtend12_3] at haddi1_raw
+  have haddi1 := cpsTripleWithin_extend_code addi_x5_3_sub_divCode_noNop haddi1_raw
+  have haddi1f := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ b3) ** (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
+     ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3984) ↦ₘ nMem))
+    (by pcFree) haddi1
+  have h12345 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) h1234 haddi1f
+  have hbne1_raw := bne_spec_gen_within .x7 .x0 16 b2 (0 : Word) (base + phaseBBne2Off)
+  rw [show (base + phaseBBne2Off : Word) + signExtend13 16 = base + phaseBTailOff from by
+        rv64_addr, phB_step1_8] at hbne1_raw
+  have hbne1_clean := cpsBranchWithin_ntakenStripPure2 hbne1_raw
+    (fun hp hQt => by
+      obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
+      exact absurd hb2z ((sepConj_pure_right _).mp h_rest).2)
+  have hbne1 := cpsTripleWithin_extend_code bne_x7_16_sub_divCode_noNop hbne1_clean
+  have hbne1f := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (3 : Word)) ** (.x10 ↦ᵣ b3) ** (.x6 ↦ᵣ b1) **
+     ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3984) ↦ₘ nMem))
+    (by pcFree) hbne1
+  have h123456 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) h12345 hbne1f
+  have haddi2_raw := addi_x0_spec_gen_within .x5 (3 : Word) 2 (base + phaseBStep2Off) (by nofun)
+  simp only [phB_step2_4, signExtend12_2] at haddi2_raw
+  have haddi2 := cpsTripleWithin_extend_code addi_x5_2_sub_divCode_noNop haddi2_raw
+  have haddi2f := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ b3) ** (.x7 ↦ᵣ b2) ** (.x6 ↦ᵣ b1) **
+     ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3984) ↦ₘ nMem))
+    (by pcFree) haddi2
+  have h1234567 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) h123456 haddi2f
+  have hbne2_raw := bne_spec_gen_within .x6 .x0 8 b1 (0 : Word) (base + phaseBBne3Off)
+  rw [show (base + phaseBBne3Off : Word) + signExtend13 8 = base + phaseBTailOff from by
+        rv64_addr, phB_step2_8] at hbne2_raw
+  have hbne2_clean := cpsBranchWithin_ntakenStripPure2 hbne2_raw
+    (fun hp hQt => by
+      obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
+      exact absurd hb1z ((sepConj_pure_right _).mp h_rest).2)
+  have hbne2 := cpsTripleWithin_extend_code bne_x6_8_sub_divCode_noNop hbne2_clean
+  have hbne2f := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (2 : Word)) ** (.x10 ↦ᵣ b3) ** (.x7 ↦ᵣ b2) **
+     ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3984) ↦ₘ nMem))
+    (by pcFree) hbne2
+  have h12345678 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) h1234567 hbne2f
+  have haddi3_raw := addi_x0_spec_gen_within .x5 (2 : Word) 1 (base + phaseBStep3Off) (by nofun)
+  simp only [phB_fall_4, signExtend12_1] at haddi3_raw
+  have haddi3 := cpsTripleWithin_extend_code addi_x5_1_sub_divCode_noNop haddi3_raw
+  have haddi3f := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ b3) ** (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
+     ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3984) ↦ₘ nMem))
+    (by pcFree) haddi3
+  have h123456789 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_chunked hp) h12345678 haddi3f
+  have htail_raw := divK_phaseB_tail_spec_within sp (1 : Word) b0 nMem (base + phaseBTailOff)
+  simp only [divK_phaseB_tail_pre_unfold, divK_phaseB_tail_post_unfold,
+             phB_t_20, divK_phaseB_n1_nm1_x8, signExtend12_32, phB_sp0_32] at htail_raw
+  have htail := cpsTripleWithin_extend_code divK_phaseB_tail_code_sub_divCode_noNop htail_raw
+  have htailf := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) ** (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
+     ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)))
+    (by pcFree) htail
+  have hphaseB := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_chunked hp) h123456789 htailf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_chunked hp)
+    (fun h hq => by xperm_chunked hq)
+    hphaseB
+
+theorem evm_div_phaseAB_n1_spec_within_noNop (sp base : Word)
+    (b0 b1 b2 b3 v5 v6 v7 v10 : Word)
+    (q0 q1 q2 q3 u5 u6 u7 nMem : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1z : b1 = 0) :
+    cpsTripleWithin (8 + 21) base (base + clzOff) (divCode_noNop base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem))
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b0) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (1 : Word))) := by
+  have hA := evm_div_phaseA_ntaken_spec_within_noNop sp base b0 b1 b2 b3 v5 v10 hbnz
+  have hAf := cpsTripleWithin_frameR
+    ((.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+     ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+     ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+     ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+     ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem))
+    (by pcFree) hA
+  have hB := evm_div_phaseB_n1_spec_within_noNop sp base b0 b1 b2 b3
+    (b0 ||| b1 ||| b2 ||| b3) v6 v7 q0 q1 q2 q3 u5 u6 u7 nMem
+    hb3z hb2z hb1z
+  have hAB := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_chunked hp) hAf hB
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_chunked hp)
+    (fun h hq => by xperm_chunked hq)
+    hAB
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Add `divKNormAFullPreNoNop` / `divKNormAFullPostNoNop` as `@[irreducible]` defs with matching `_unfold` lemmas in `EvmAsm/Evm64/DivMod/Compose/NormA.lean`.
- Restate `divK_normA_full_spec_within_noNop` to reference them; outer `let`-chain preserved so the existing `intro u4 u3 u2 u1 u0` proof body works unchanged. Adds `rw [..._unfold, ..._unfold]` right after the intro.
- Update the downstream `evm_div_n1_to_loopSetup_spec_within_noNop` proof (`FullPathN1NoNop.lean`) to do `rw [..._unfold, ..._unfold] at hNormA` after the existing `intro_lets at hNormA`, so `xperm_hyp` can still see the underlying atoms.

Same pattern as PRs #3647–#3653.

Refs #90. Bead: evm-asm-np31o. Originally targeted PR #3614 / `feat/divmod-no-nop-n1-norma`, which has since been merged — retargeting at `main`.

## Verification
- lake build EvmAsm.Evm64.DivMod.Compose.NormA
- lake build EvmAsm.Evm64.DivMod.Compose.FullPathN1NoNop
- scripts/check-file-size.sh
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" on the two edited files
- lake build (full)

Authored by @pirapira; implemented by Claude Code