### PR TITLE
fix(divmod): unfold ClzC2NormB Pre/Post for n1_to_loopSetup downstream xperm

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1NoNop.lean
@@ -258,6 +258,8 @@ theorem evm_div_n1_to_loopSetup_spec_within_noNop (sp base : Word)
   have hNB := evm_div_phaseAB_n1_clz_c2_normB_spec_within_noNop sp base
     b0 b1 b2 b3 v5 v6 v7 v10 q0 q1 q2 q3 u5 u6 u7 nMem shiftMem
     hbnz hb3z hb2z hb1z hshift_nz
+  simp only [evmDivPhaseABN1ClzC2NormBPre_unfold,
+      evmDivPhaseABN1ClzC2NormBPost_unfold] at hNB
   have hNBf := cpsTripleWithin_frameR
     ((.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
      ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **


### PR DESCRIPTION
## Summary
- After PR #3653 wrapped `evm_div_phaseAB_n1_clz_c2_normB_spec_within_noNop`'s pre/post in `@[irreducible]` defs, the downstream `evm_div_n1_to_loopSetup_spec_within_noNop` proof in `FullPathN1NoNop.lean` fails with `xperm: could not find atom in LHS matching RHS atom` at the seq-perm steps, because `xperm_hyp` can't see through the irreducible Pre/Post.
- Fix: `simp only [evmDivPhaseABN1ClzC2NormBPre_unfold, evmDivPhaseABN1ClzC2NormBPost_unfold] at hNB` right after the application. (Plain `rw` fails because the `let`-chain in the theorem signature wraps the rewrite pattern.)
- Without this, `lake build EvmAsm.Evm64.DivMod.Compose.FullPathN1NoNop` fails on the current `feat/divmod-no-nop-n1-preloop` HEAD.

Refs #90. Bead: evm-asm-osued.

## Verification
- lake build EvmAsm.Evm64.DivMod.Compose.FullPathN1NoNop
- scripts/check-file-size.sh
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/Compose/FullPathN1NoNop.lean
- lake build (full)

Authored by @pirapira; implemented by Claude Code