### PR TITLE
chore(divmod): wrap divK_loopSetup_ntaken_spec_within_noNop pre/post in irreducible defs

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1NoNop.lean
@@ -289,6 +289,8 @@ theorem evm_div_n1_to_loopSetup_spec_within_noNop (sp base : Word)
   have hLS := divK_loopSetup_ntaken_spec_within_noNop sp (1 : Word)
     (signExtend12 (4 : BitVec 12) - (4 : Word)) u1 base
     (by decide)
+  simp only [divKLoopSetupNtakenPreNoNop_unfold,
+      divKLoopSetupNtakenPostNoNop_unfold] at hLS
   have hLSf := cpsTripleWithin_frameR
     ((.x10 ↦ᵣ (a0 >>> (antiShift.toNat % 64))) **
      (.x6 ↦ᵣ shift) ** (.x7 ↦ᵣ u0) ** (.x2 ↦ᵣ antiShift) **

--- a/EvmAsm/Evm64/DivMod/Compose/NormA.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/NormA.lean
@@ -498,15 +498,45 @@ theorem divK_loopSetup_ntaken_spec_within (sp n v1 v5 : Word) (base : Word)
     (fun h hq => by xperm_hyp hq)
     h12
 
+/-- Precondition for the no-NOP loopSetup-ntaken block: entry registers
+    (sp/v5/v1/x0) plus the n-memory cell. Wrapped `@[irreducible]` so
+    downstream proofs see an opaque atom instead of the 5-atom sepConj. -/
+@[irreducible]
+def divKLoopSetupNtakenPreNoNop (sp v5 v1 n : Word) : Assertion :=
+  (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x1 ↦ᵣ v1) ** (.x0 ↦ᵣ (0 : Word)) **
+  ((sp + signExtend12 3984) ↦ₘ n)
+
+theorem divKLoopSetupNtakenPreNoNop_unfold
+    {sp v5 v1 n : Word} :
+    divKLoopSetupNtakenPreNoNop sp v5 v1 n =
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x1 ↦ᵣ v1) ** (.x0 ↦ᵣ (0 : Word)) **
+       ((sp + signExtend12 3984) ↦ₘ n)) := by
+  delta divKLoopSetupNtakenPreNoNop
+  rfl
+
+/-- Postcondition for the no-NOP loopSetup-ntaken block: `x5 ← n`,
+    `x1 ← m = signExtend12 4 − n`. Wrapped `@[irreducible]`. -/
+@[irreducible]
+def divKLoopSetupNtakenPostNoNop (sp n m : Word) : Assertion :=
+  (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ n) ** (.x1 ↦ᵣ m) ** (.x0 ↦ᵣ (0 : Word)) **
+  ((sp + signExtend12 3984) ↦ₘ n)
+
+theorem divKLoopSetupNtakenPostNoNop_unfold
+    {sp n m : Word} :
+    divKLoopSetupNtakenPostNoNop sp n m =
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ n) ** (.x1 ↦ᵣ m) ** (.x0 ↦ᵣ (0 : Word)) **
+       ((sp + signExtend12 3984) ↦ₘ n)) := by
+  delta divKLoopSetupNtakenPostNoNop
+  rfl
+
 theorem divK_loopSetup_ntaken_spec_within_noNop (sp n v1 v5 : Word) (base : Word)
     (hm_ge : ¬BitVec.slt (signExtend12 (4 : BitVec 12) - n) (0 : Word)) :
     let m := signExtend12 (4 : BitVec 12) - n
     cpsTripleWithin 4 (base + loopSetupOff) (base + loopBodyOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x1 ↦ᵣ v1) ** (.x0 ↦ᵣ (0 : Word)) **
-       ((sp + signExtend12 3984) ↦ₘ n))
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ n) ** (.x1 ↦ᵣ m) ** (.x0 ↦ᵣ (0 : Word)) **
-       ((sp + signExtend12 3984) ↦ₘ n)) := by
+      (divKLoopSetupNtakenPreNoNop sp v5 v1 n)
+      (divKLoopSetupNtakenPostNoNop sp n m) := by
   intro m
+  rw [divKLoopSetupNtakenPreNoNop_unfold, divKLoopSetupNtakenPostNoNop_unfold]
   have hbody := divK_loopSetup_body_spec_within sp n v1 v5 464 (base + loopSetupOff)
   have hbodye := cpsTripleWithin_extend_code divK_loopSetup_code_sub_divCode_noNop hbody
   have hblt_raw := blt_spec_gen_within .x1 .x0 464 m (0 : Word) (base + loopSetupOff + 12)


### PR DESCRIPTION
## Summary
- Add `divKLoopSetupNtakenPreNoNop` / `divKLoopSetupNtakenPostNoNop` as `@[irreducible]` defs with matching `_unfold` lemmas in `EvmAsm/Evm64/DivMod/Compose/NormA.lean`.
- Restate `divK_loopSetup_ntaken_spec_within_noNop` to reference them; outer `let m := ...` chain preserved so the existing `intro m` proof body works unchanged. Adds one `rw [..._unfold, ..._unfold]` right after the `intro`.
- Downstream consumer `evm_div_n1_to_loopSetup_spec_within_noNop` (`FullPathN1NoNop.lean`) adds `simp only [..._unfold] at hLS` after the application so `xperm_hyp` can still see the underlying atoms.

Refs #90. Bead: evm-asm-414ab.

## Verification
- lake build EvmAsm.Evm64.DivMod.Compose.NormA
- lake build EvmAsm.Evm64.DivMod.Compose.FullPathN1NoNop
- scripts/check-file-size.sh
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" on the two touched files
- lake build (full)

Authored by @pirapira; implemented by Claude Code