### PR TITLE
chore(sdiv): hide outer let-chain in saveRa_signs_abs_then_divisorAbs theorem signature

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/DivisorAbsSequence.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivisorAbsSequence.lean
@@ -17,16 +17,24 @@ open EvmAsm.Rv64
 
 /-- Precondition for the SDIV save-ra/signs/dividendAbs/divisorAbs block
     (entry to the wrapper, just after the saved-`ra` slot is materialized
-    in `x1`). Wrapped `@[irreducible]` so downstream proofs do not
-    re-reduce the 18-atom sepConj at each use site. -/
+    in `x1`). Takes only the bare wrapper inputs; the `sp`-relative
+    dividend/divisor memory addresses are computed internally so the
+    huge let-chain that previously lived in the theorem signature stays
+    hidden inside this `@[irreducible]` def. -/
 @[irreducible]
 def saveRaSignsAbsThenDivisorAbsPre
     (vRa vSavedOld sp sDividendOld sDivisorOld
       dividendMaskOld dividendValueOld dividendCarryOld
-      dividendMem0 dividendMem1 dividendMem2 dividendMem3
       dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-      divisorMem0 divisorMem1 divisorMem2 divisorMem3
       divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word) : Assertion :=
+  let dividendMem0 := sp + signExtend12 (0 : BitVec 12)
+  let dividendMem1 := sp + signExtend12 (8 : BitVec 12)
+  let dividendMem2 := sp + signExtend12 (16 : BitVec 12)
+  let dividendMem3 := sp + signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff
+  let divisorMem0 := sp + signExtend12 (32 : BitVec 12)
+  let divisorMem1 := sp + signExtend12 (40 : BitVec 12)
+  let divisorMem2 := sp + signExtend12 (48 : BitVec 12)
+  let divisorMem3 := sp + signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff
   ((((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ vSavedOld)) **
       ((.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sDividendOld) **
        (dividendMem3 ↦ₘ dividendTop))) **
@@ -43,44 +51,70 @@ def saveRaSignsAbsThenDivisorAbsPre
 theorem saveRaSignsAbsThenDivisorAbsPre_unfold
     {vRa vSavedOld sp sDividendOld sDivisorOld
       dividendMaskOld dividendValueOld dividendCarryOld
-      dividendMem0 dividendMem1 dividendMem2 dividendMem3
       dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-      divisorMem0 divisorMem1 divisorMem2 divisorMem3
       divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word} :
     saveRaSignsAbsThenDivisorAbsPre vRa vSavedOld sp sDividendOld sDivisorOld
         dividendMaskOld dividendValueOld dividendCarryOld
-        dividendMem0 dividendMem1 dividendMem2 dividendMem3
         dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-        divisorMem0 divisorMem1 divisorMem2 divisorMem3
         divisorLimb0 divisorLimb1 divisorLimb2 divisorTop =
-      ((((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ vSavedOld)) **
-          ((.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sDividendOld) **
-           (dividendMem3 ↦ₘ dividendTop))) **
-         ((.x9 ↦ᵣ sDivisorOld) ** (divisorMem3 ↦ₘ divisorTop))) **
-        (((.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ dividendMaskOld) **
-          (.x7 ↦ᵣ dividendValueOld) ** (.x11 ↦ᵣ dividendCarryOld)) **
-         ((dividendMem0 ↦ₘ dividendLimb0) **
-          (dividendMem1 ↦ₘ dividendLimb1) **
-          (dividendMem2 ↦ₘ dividendLimb2)))) **
-       ((divisorMem0 ↦ₘ divisorLimb0) **
-        (divisorMem1 ↦ₘ divisorLimb1) **
-        (divisorMem2 ↦ₘ divisorLimb2))) := by
+      (let dividendMem0 := sp + signExtend12 (0 : BitVec 12)
+       let dividendMem1 := sp + signExtend12 (8 : BitVec 12)
+       let dividendMem2 := sp + signExtend12 (16 : BitVec 12)
+       let dividendMem3 := sp + signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff
+       let divisorMem0 := sp + signExtend12 (32 : BitVec 12)
+       let divisorMem1 := sp + signExtend12 (40 : BitVec 12)
+       let divisorMem2 := sp + signExtend12 (48 : BitVec 12)
+       let divisorMem3 := sp + signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff
+       ((((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ vSavedOld)) **
+           ((.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sDividendOld) **
+            (dividendMem3 ↦ₘ dividendTop))) **
+          ((.x9 ↦ᵣ sDivisorOld) ** (divisorMem3 ↦ₘ divisorTop))) **
+         (((.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ dividendMaskOld) **
+           (.x7 ↦ᵣ dividendValueOld) ** (.x11 ↦ᵣ dividendCarryOld)) **
+          ((dividendMem0 ↦ₘ dividendLimb0) **
+           (dividendMem1 ↦ₘ dividendLimb1) **
+           (dividendMem2 ↦ₘ dividendLimb2)))) **
+        ((divisorMem0 ↦ₘ divisorLimb0) **
+         (divisorMem1 ↦ₘ divisorLimb1) **
+         (divisorMem2 ↦ₘ divisorLimb2)))) := by
   delta saveRaSignsAbsThenDivisorAbsPre
   rfl
 
-/-- Postcondition for the SDIV save-ra/signs/dividendAbs/divisorAbs block:
-    `ra` saved to the spill slot, both signs in `x8`/`x9`, both
-    absolute-value sequences materialized in memory, with the divisor's
-    intermediate sum/carry scratch in `x10`/`x7`/`x11`. Wrapped
-    `@[irreducible]` to hide the 22-atom sepConj from downstream proofs. -/
+/-- Postcondition for the SDIV save-ra/signs/dividendAbs/divisorAbs block.
+    Takes only the bare wrapper inputs; the sign/mask/sum/carry
+    let-chain (~30 derived values) is computed internally so the
+    theorem signature stays flat. Wrapped `@[irreducible]`. -/
 @[irreducible]
 def saveRaSignsAbsThenDivisorAbsPost
-    (vRa sp dividendSign divisorSign divisorMask
-      divisorSum3 divisorCarry3
-      dividendMem0 dividendMem1 dividendMem2 dividendMem3
-      dividendSum0 dividendSum1 dividendSum2 dividendSum3
-      divisorMem0 divisorMem1 divisorMem2 divisorMem3
-      divisorSum0 divisorSum1 divisorSum2 : Word) : Assertion :=
+    (vRa sp dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word) : Assertion :=
+  let dividendSign := dividendTop >>> (63 : BitVec 6).toNat
+  let divisorSign := divisorTop >>> (63 : BitVec 6).toNat
+  let dividendMem0 := sp + signExtend12 (0 : BitVec 12)
+  let dividendMem1 := sp + signExtend12 (8 : BitVec 12)
+  let dividendMem2 := sp + signExtend12 (16 : BitVec 12)
+  let dividendMem3 := sp + signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff
+  let divisorMem0 := sp + signExtend12 (32 : BitVec 12)
+  let divisorMem1 := sp + signExtend12 (40 : BitVec 12)
+  let divisorMem2 := sp + signExtend12 (48 : BitVec 12)
+  let divisorMem3 := sp + signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff
+  let dividendMask := (0 : Word) - dividendSign
+  let dividendSum0 := (dividendLimb0 ^^^ dividendMask) + dividendSign
+  let dividendCarry0 := if BitVec.ult dividendSum0 dividendSign then (1 : Word) else 0
+  let dividendSum1 := (dividendLimb1 ^^^ dividendMask) + dividendCarry0
+  let dividendCarry1 := if BitVec.ult dividendSum1 dividendCarry0 then (1 : Word) else 0
+  let dividendSum2 := (dividendLimb2 ^^^ dividendMask) + dividendCarry1
+  let dividendCarry2 := if BitVec.ult dividendSum2 dividendCarry1 then (1 : Word) else 0
+  let dividendSum3 := (dividendTop ^^^ dividendMask) + dividendCarry2
+  let divisorMask := (0 : Word) - divisorSign
+  let divisorSum0 := (divisorLimb0 ^^^ divisorMask) + divisorSign
+  let divisorCarry0 := if BitVec.ult divisorSum0 divisorSign then (1 : Word) else 0
+  let divisorSum1 := (divisorLimb1 ^^^ divisorMask) + divisorCarry0
+  let divisorCarry1 := if BitVec.ult divisorSum1 divisorCarry0 then (1 : Word) else 0
+  let divisorSum2 := (divisorLimb2 ^^^ divisorMask) + divisorCarry1
+  let divisorCarry2 := if BitVec.ult divisorSum2 divisorCarry1 then (1 : Word) else 0
+  let divisorSum3 := (divisorTop ^^^ divisorMask) + divisorCarry2
+  let divisorCarry3 := if BitVec.ult divisorSum3 divisorCarry2 then (1 : Word) else 0
   (((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12)))) **
     ((.x8 ↦ᵣ dividendSign) **
      (dividendMem0 ↦ₘ dividendSum0) **
@@ -94,29 +128,49 @@ def saveRaSignsAbsThenDivisorAbsPost
     (divisorMem2 ↦ₘ divisorSum2) ** (divisorMem3 ↦ₘ divisorSum3))
 
 theorem saveRaSignsAbsThenDivisorAbsPost_unfold
-    {vRa sp dividendSign divisorSign divisorMask
-      divisorSum3 divisorCarry3
-      dividendMem0 dividendMem1 dividendMem2 dividendMem3
-      dividendSum0 dividendSum1 dividendSum2 dividendSum3
-      divisorMem0 divisorMem1 divisorMem2 divisorMem3
-      divisorSum0 divisorSum1 divisorSum2 : Word} :
-    saveRaSignsAbsThenDivisorAbsPost vRa sp dividendSign divisorSign
-        divisorMask divisorSum3 divisorCarry3
-        dividendMem0 dividendMem1 dividendMem2 dividendMem3
-        dividendSum0 dividendSum1 dividendSum2 dividendSum3
-        divisorMem0 divisorMem1 divisorMem2 divisorMem3
-        divisorSum0 divisorSum1 divisorSum2 =
-      ((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12)))) **
-        ((.x8 ↦ᵣ dividendSign) **
-         (dividendMem0 ↦ₘ dividendSum0) **
-         (dividendMem1 ↦ₘ dividendSum1) **
-         (dividendMem2 ↦ₘ dividendSum2) **
-         (dividendMem3 ↦ₘ dividendSum3))) **
-       ((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ divisorSign) **
-        (.x10 ↦ᵣ divisorMask) ** (.x7 ↦ᵣ divisorSum3) **
-        (.x11 ↦ᵣ divisorCarry3) **
-        (divisorMem0 ↦ₘ divisorSum0) ** (divisorMem1 ↦ₘ divisorSum1) **
-        (divisorMem2 ↦ₘ divisorSum2) ** (divisorMem3 ↦ₘ divisorSum3))) := by
+    {vRa sp dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word} :
+    saveRaSignsAbsThenDivisorAbsPost vRa sp
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop =
+      (let dividendSign := dividendTop >>> (63 : BitVec 6).toNat
+       let divisorSign := divisorTop >>> (63 : BitVec 6).toNat
+       let dividendMem0 := sp + signExtend12 (0 : BitVec 12)
+       let dividendMem1 := sp + signExtend12 (8 : BitVec 12)
+       let dividendMem2 := sp + signExtend12 (16 : BitVec 12)
+       let dividendMem3 := sp + signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff
+       let divisorMem0 := sp + signExtend12 (32 : BitVec 12)
+       let divisorMem1 := sp + signExtend12 (40 : BitVec 12)
+       let divisorMem2 := sp + signExtend12 (48 : BitVec 12)
+       let divisorMem3 := sp + signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff
+       let dividendMask := (0 : Word) - dividendSign
+       let dividendSum0 := (dividendLimb0 ^^^ dividendMask) + dividendSign
+       let dividendCarry0 := if BitVec.ult dividendSum0 dividendSign then (1 : Word) else 0
+       let dividendSum1 := (dividendLimb1 ^^^ dividendMask) + dividendCarry0
+       let dividendCarry1 := if BitVec.ult dividendSum1 dividendCarry0 then (1 : Word) else 0
+       let dividendSum2 := (dividendLimb2 ^^^ dividendMask) + dividendCarry1
+       let dividendCarry2 := if BitVec.ult dividendSum2 dividendCarry1 then (1 : Word) else 0
+       let dividendSum3 := (dividendTop ^^^ dividendMask) + dividendCarry2
+       let divisorMask := (0 : Word) - divisorSign
+       let divisorSum0 := (divisorLimb0 ^^^ divisorMask) + divisorSign
+       let divisorCarry0 := if BitVec.ult divisorSum0 divisorSign then (1 : Word) else 0
+       let divisorSum1 := (divisorLimb1 ^^^ divisorMask) + divisorCarry0
+       let divisorCarry1 := if BitVec.ult divisorSum1 divisorCarry0 then (1 : Word) else 0
+       let divisorSum2 := (divisorLimb2 ^^^ divisorMask) + divisorCarry1
+       let divisorCarry2 := if BitVec.ult divisorSum2 divisorCarry1 then (1 : Word) else 0
+       let divisorSum3 := (divisorTop ^^^ divisorMask) + divisorCarry2
+       let divisorCarry3 := if BitVec.ult divisorSum3 divisorCarry2 then (1 : Word) else 0
+       (((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12)))) **
+         ((.x8 ↦ᵣ dividendSign) **
+          (dividendMem0 ↦ₘ dividendSum0) **
+          (dividendMem1 ↦ₘ dividendSum1) **
+          (dividendMem2 ↦ₘ dividendSum2) **
+          (dividendMem3 ↦ₘ dividendSum3))) **
+        ((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ divisorSign) **
+         (.x10 ↦ᵣ divisorMask) ** (.x7 ↦ᵣ divisorSum3) **
+         (.x11 ↦ᵣ divisorCarry3) **
+         (divisorMem0 ↦ₘ divisorSum0) ** (divisorMem1 ↦ₘ divisorSum1) **
+         (divisorMem2 ↦ₘ divisorSum2) ** (divisorMem3 ↦ₘ divisorSum3))) := by
   delta saveRaSignsAbsThenDivisorAbsPost
   rfl
 
@@ -126,62 +180,53 @@ theorem saveRa_signs_abs_then_divisorAbs_spec_in_sdivCode
       dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
       divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word)
     (base : Word) :
-    let dividendSign := dividendTop >>> (63 : BitVec 6).toNat
-    let divisorSign := divisorTop >>> (63 : BitVec 6).toNat
-    let dividendMem0 := sp + signExtend12 (0 : BitVec 12)
-    let dividendMem1 := sp + signExtend12 (8 : BitVec 12)
-    let dividendMem2 := sp + signExtend12 (16 : BitVec 12)
-    let dividendMem3 := sp + signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff
-    let divisorMem0 := sp + signExtend12 (32 : BitVec 12)
-    let divisorMem1 := sp + signExtend12 (40 : BitVec 12)
-    let divisorMem2 := sp + signExtend12 (48 : BitVec 12)
-    let divisorMem3 := sp + signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff
-    let dividendMask := (0 : Word) - dividendSign
-    let dividendXored0 := dividendLimb0 ^^^ dividendMask
-    let dividendSum0 := dividendXored0 + dividendSign
-    let dividendCarry0 := if BitVec.ult dividendSum0 dividendSign then (1 : Word) else 0
-    let dividendXored1 := dividendLimb1 ^^^ dividendMask
-    let dividendSum1 := dividendXored1 + dividendCarry0
-    let dividendCarry1 := if BitVec.ult dividendSum1 dividendCarry0 then (1 : Word) else 0
-    let dividendXored2 := dividendLimb2 ^^^ dividendMask
-    let dividendSum2 := dividendXored2 + dividendCarry1
-    let dividendCarry2 := if BitVec.ult dividendSum2 dividendCarry1 then (1 : Word) else 0
-    let dividendXored3 := dividendTop ^^^ dividendMask
-    let dividendSum3 := dividendXored3 + dividendCarry2
-    let divisorMask := (0 : Word) - divisorSign
-    let divisorXored0 := divisorLimb0 ^^^ divisorMask
-    let divisorSum0 := divisorXored0 + divisorSign
-    let divisorCarry0 := if BitVec.ult divisorSum0 divisorSign then (1 : Word) else 0
-    let divisorXored1 := divisorLimb1 ^^^ divisorMask
-    let divisorSum1 := divisorXored1 + divisorCarry0
-    let divisorCarry1 := if BitVec.ult divisorSum1 divisorCarry0 then (1 : Word) else 0
-    let divisorXored2 := divisorLimb2 ^^^ divisorMask
-    let divisorSum2 := divisorXored2 + divisorCarry1
-    let divisorCarry2 := if BitVec.ult divisorSum2 divisorCarry1 then (1 : Word) else 0
-    let divisorXored3 := divisorTop ^^^ divisorMask
-    let divisorSum3 := divisorXored3 + divisorCarry2
-    let divisorCarry3 := if BitVec.ult divisorSum3 divisorCarry2 then (1 : Word) else 0
     cpsTripleWithin 47 base ((base + divisorAbsOff) + 84) (sdivCode base)
       (saveRaSignsAbsThenDivisorAbsPre vRa vSavedOld sp sDividendOld sDivisorOld
         dividendMaskOld dividendValueOld dividendCarryOld
-        dividendMem0 dividendMem1 dividendMem2 dividendMem3
         dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-        divisorMem0 divisorMem1 divisorMem2 divisorMem3
         divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
-      (saveRaSignsAbsThenDivisorAbsPost vRa sp dividendSign divisorSign
-        divisorMask divisorSum3 divisorCarry3
-        dividendMem0 dividendMem1 dividendMem2 dividendMem3
-        dividendSum0 dividendSum1 dividendSum2 dividendSum3
-        divisorMem0 divisorMem1 divisorMem2 divisorMem3
-        divisorSum0 divisorSum1 divisorSum2) := by
-  intro dividendSign divisorSign dividendMem0 dividendMem1 dividendMem2
-    dividendMem3 divisorMem0 divisorMem1 divisorMem2 divisorMem3
-    dividendMask dividendXored0 dividendSum0 dividendCarry0 dividendXored1
-    dividendSum1 dividendCarry1 dividendXored2 dividendSum2 dividendCarry2
-    dividendXored3 dividendSum3 divisorMask divisorXored0
-    divisorSum0 divisorCarry0 divisorXored1 divisorSum1 divisorCarry1
-    divisorXored2 divisorSum2 divisorCarry2 divisorXored3 divisorSum3
-    divisorCarry3
+      (saveRaSignsAbsThenDivisorAbsPost vRa sp
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) := by
+  rw [saveRaSignsAbsThenDivisorAbsPre_unfold,
+      saveRaSignsAbsThenDivisorAbsPost_unfold]
+  -- Re-introduce the let-chain locally so the existing composition proof
+  -- (which references these derived names) keeps working unchanged.
+  let dividendSign := dividendTop >>> (63 : BitVec 6).toNat
+  let divisorSign := divisorTop >>> (63 : BitVec 6).toNat
+  let dividendMem0 := sp + signExtend12 (0 : BitVec 12)
+  let dividendMem1 := sp + signExtend12 (8 : BitVec 12)
+  let dividendMem2 := sp + signExtend12 (16 : BitVec 12)
+  let dividendMem3 := sp + signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff
+  let divisorMem0 := sp + signExtend12 (32 : BitVec 12)
+  let divisorMem1 := sp + signExtend12 (40 : BitVec 12)
+  let divisorMem2 := sp + signExtend12 (48 : BitVec 12)
+  let divisorMem3 := sp + signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff
+  let dividendMask := (0 : Word) - dividendSign
+  let dividendXored0 := dividendLimb0 ^^^ dividendMask
+  let dividendSum0 := dividendXored0 + dividendSign
+  let dividendCarry0 := if BitVec.ult dividendSum0 dividendSign then (1 : Word) else 0
+  let dividendXored1 := dividendLimb1 ^^^ dividendMask
+  let dividendSum1 := dividendXored1 + dividendCarry0
+  let dividendCarry1 := if BitVec.ult dividendSum1 dividendCarry0 then (1 : Word) else 0
+  let dividendXored2 := dividendLimb2 ^^^ dividendMask
+  let dividendSum2 := dividendXored2 + dividendCarry1
+  let dividendCarry2 := if BitVec.ult dividendSum2 dividendCarry1 then (1 : Word) else 0
+  let dividendXored3 := dividendTop ^^^ dividendMask
+  let dividendSum3 := dividendXored3 + dividendCarry2
+  let divisorMask := (0 : Word) - divisorSign
+  let divisorXored0 := divisorLimb0 ^^^ divisorMask
+  let divisorSum0 := divisorXored0 + divisorSign
+  let divisorCarry0 := if BitVec.ult divisorSum0 divisorSign then (1 : Word) else 0
+  let divisorXored1 := divisorLimb1 ^^^ divisorMask
+  let divisorSum1 := divisorXored1 + divisorCarry0
+  let divisorCarry1 := if BitVec.ult divisorSum1 divisorCarry0 then (1 : Word) else 0
+  let divisorXored2 := divisorLimb2 ^^^ divisorMask
+  let divisorSum2 := divisorXored2 + divisorCarry1
+  let divisorCarry2 := if BitVec.ult divisorSum2 divisorCarry1 then (1 : Word) else 0
+  let divisorXored3 := divisorTop ^^^ divisorMask
+  let divisorSum3 := divisorXored3 + divisorCarry2
+  let divisorCarry3 := if BitVec.ult divisorSum3 divisorCarry2 then (1 : Word) else 0
   let dividendCarry3 := if BitVec.ult dividendSum3 dividendCarry2 then (1 : Word) else 0
   let divisorLower : Assertion :=
     ((divisorMem0 ↦ₘ divisorLimb0) ** (divisorMem1 ↦ₘ divisorLimb1) **
@@ -278,8 +323,6 @@ theorem saveRa_signs_abs_then_divisorAbs_spec_in_sdivCode
     (fun h hp => by
       dsimp [mid, absPre, divisorLower] at hp ⊢
       xperm_hyp hp) hPrefix hAbs
-  rw [saveRaSignsAbsThenDivisorAbsPre_unfold,
-      saveRaSignsAbsThenDivisorAbsPost_unfold]
   simpa [pre, post] using hSeq
 
 end EvmAsm.Evm64.SDiv.Compose


### PR DESCRIPTION
## Summary
Follow-up to PR #3647 / bead `evm-asm-n2vmv`. That earlier PR wrapped the trailing sepConj of `saveRa_signs_abs_then_divisorAbs_spec_in_sdivCode` in `@[irreducible]` Pre/Post defs, but preserved the 35-line let-chain (signs / mems / masks / xored / sums / carries) in the theorem signature so the existing `intro`-based proof body kept working.

This PR moves the entire let-chain INTO the Pre/Post `@[irreducible]` defs:
- `saveRaSignsAbsThenDivisorAbsPre` now takes only the bare wrapper inputs (`vRa`, `vSavedOld`, `sp`, `sDividendOld`, `sDivisorOld`, `dividendMaskOld`, `dividendValueOld`, `dividendCarryOld`, `dividendLimb0..2`, `dividendTop`, `divisorLimb0..2`, `divisorTop`). The `sp`-relative dividend/divisor memory addresses are computed via `let`-bindings inside the def body.
- `saveRaSignsAbsThenDivisorAbsPost` now takes only the bare result-relevant inputs (`vRa`, `sp`, `dividendLimb0..2`, `dividendTop`, `divisorLimb0..2`, `divisorTop`). The dividend/divisor signs, masks, sums, carries, and memory addresses (~30 derived values) are computed via `let`-bindings inside the def body.
- The theorem statement becomes a flat `cpsTripleWithin n base exitPC (sdivCode base) Pre Post` with NO outer let-chain — consumers see a clean signature.
- Proof body opens with `rw [..._unfold, ..._unfold]` then re-introduces the let-chain via tactic-level `let`-bindings so the existing `have hPrefix / have hAbs / have hSeq` composition keeps working unchanged.

Refs #90. Bead: evm-asm-5i2sk. Stacked on `feat/sdiv-compose-divisor-abs-sequence` (PR #3593).

## Verification
- lake build EvmAsm.Evm64.SDiv.Compose.DivisorAbsSequence
- scripts/check-file-size.sh
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/DivisorAbsSequence.lean
- lake build (full)

Authored by @pirapira; implemented by Claude Code