### PR TITLE
chore(sdiv): hide outer let-chain in saveRa_signs_abs_then_signXor signature

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/SignXorSequence.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/SignXorSequence.lean
@@ -18,16 +18,24 @@ open EvmAsm.Rv64
 
 /-- Precondition for the SDIV save-ra/signs/dividendAbs/divisorAbs/signXor
     block: identical to the entry shape consumed by the divisorAbs
-    sequence. Wrapped `@[irreducible]` so downstream proofs do not
-    re-reduce the 18-atom sepConj at each use site. -/
+    sequence. The memory-slot addresses (`dividendMem0..3`, `divisorMem0..3`)
+    are computed internally from `sp` so the theorem signature stays flat.
+    Wrapped `@[irreducible]` so downstream proofs do not re-reduce the
+    18-atom sepConj at each use site. -/
 @[irreducible]
 def saveRaSignsAbsThenSignXorPre
     (vRa vSavedOld sp sDividendOld sDivisorOld
       dividendMaskOld dividendValueOld dividendCarryOld
-      dividendMem0 dividendMem1 dividendMem2 dividendMem3
       dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-      divisorMem0 divisorMem1 divisorMem2 divisorMem3
       divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word) : Assertion :=
+  let dividendMem0 := sp + signExtend12 (0 : BitVec 12)
+  let dividendMem1 := sp + signExtend12 (8 : BitVec 12)
+  let dividendMem2 := sp + signExtend12 (16 : BitVec 12)
+  let dividendMem3 := sp + signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff
+  let divisorMem0 := sp + signExtend12 (32 : BitVec 12)
+  let divisorMem1 := sp + signExtend12 (40 : BitVec 12)
+  let divisorMem2 := sp + signExtend12 (48 : BitVec 12)
+  let divisorMem3 := sp + signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff
   (((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ vSavedOld)) **
       ((.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sDividendOld) **
        (dividendMem3 ↦ₘ dividendTop))) **
@@ -44,17 +52,21 @@ def saveRaSignsAbsThenSignXorPre
 theorem saveRaSignsAbsThenSignXorPre_unfold
     {vRa vSavedOld sp sDividendOld sDivisorOld
       dividendMaskOld dividendValueOld dividendCarryOld
-      dividendMem0 dividendMem1 dividendMem2 dividendMem3
       dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-      divisorMem0 divisorMem1 divisorMem2 divisorMem3
       divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word} :
     saveRaSignsAbsThenSignXorPre vRa vSavedOld sp sDividendOld sDivisorOld
         dividendMaskOld dividendValueOld dividendCarryOld
-        dividendMem0 dividendMem1 dividendMem2 dividendMem3
         dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-        divisorMem0 divisorMem1 divisorMem2 divisorMem3
         divisorLimb0 divisorLimb1 divisorLimb2 divisorTop =
-      ((((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ vSavedOld)) **
+      (let dividendMem0 := sp + signExtend12 (0 : BitVec 12)
+       let dividendMem1 := sp + signExtend12 (8 : BitVec 12)
+       let dividendMem2 := sp + signExtend12 (16 : BitVec 12)
+       let dividendMem3 := sp + signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff
+       let divisorMem0 := sp + signExtend12 (32 : BitVec 12)
+       let divisorMem1 := sp + signExtend12 (40 : BitVec 12)
+       let divisorMem2 := sp + signExtend12 (48 : BitVec 12)
+       let divisorMem3 := sp + signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff
+       (((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ vSavedOld)) **
            ((.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sDividendOld) **
             (dividendMem3 ↦ₘ dividendTop))) **
           ((.x9 ↦ᵣ sDivisorOld) ** (divisorMem3 ↦ₘ divisorTop))) **
@@ -72,16 +84,41 @@ theorem saveRaSignsAbsThenSignXorPre_unfold
 /-- Postcondition for the SDIV save-ra/signs/dividendAbs/divisorAbs/signXor
     block: `x8` holds the result sign (dividendSign ⊕ divisorSign),
     `x9` holds the divisor sign, the rest of the frame matches the
-    divisorAbs postcondition. Wrapped `@[irreducible]` to hide the
-    22-atom sepConj from downstream proofs. -/
+    divisorAbs postcondition. The full ~30-line derived-value let-chain
+    (signs, masks, mems, sums, carries) is computed internally so the
+    theorem signature stays flat. Wrapped `@[irreducible]`. -/
 @[irreducible]
 def saveRaSignsAbsThenSignXorPost
-    (vRa sp divisorSign resultSign divisorMask
-      divisorSum3 divisorCarry3
-      dividendMem0 dividendMem1 dividendMem2 dividendMem3
-      dividendSum0 dividendSum1 dividendSum2 dividendSum3
-      divisorMem0 divisorMem1 divisorMem2 divisorMem3
-      divisorSum0 divisorSum1 divisorSum2 : Word) : Assertion :=
+    (vRa sp dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word) : Assertion :=
+  let dividendSign := dividendTop >>> (63 : BitVec 6).toNat
+  let divisorSign := divisorTop >>> (63 : BitVec 6).toNat
+  let resultSign := dividendSign ^^^ divisorSign
+  let dividendMem0 := sp + signExtend12 (0 : BitVec 12)
+  let dividendMem1 := sp + signExtend12 (8 : BitVec 12)
+  let dividendMem2 := sp + signExtend12 (16 : BitVec 12)
+  let dividendMem3 := sp + signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff
+  let divisorMem0 := sp + signExtend12 (32 : BitVec 12)
+  let divisorMem1 := sp + signExtend12 (40 : BitVec 12)
+  let divisorMem2 := sp + signExtend12 (48 : BitVec 12)
+  let divisorMem3 := sp + signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff
+  let dividendMask := (0 : Word) - dividendSign
+  let dividendSum0 := (dividendLimb0 ^^^ dividendMask) + dividendSign
+  let dividendCarry0 := if BitVec.ult dividendSum0 dividendSign then (1 : Word) else 0
+  let dividendSum1 := (dividendLimb1 ^^^ dividendMask) + dividendCarry0
+  let dividendCarry1 := if BitVec.ult dividendSum1 dividendCarry0 then (1 : Word) else 0
+  let dividendSum2 := (dividendLimb2 ^^^ dividendMask) + dividendCarry1
+  let dividendCarry2 := if BitVec.ult dividendSum2 dividendCarry1 then (1 : Word) else 0
+  let dividendSum3 := (dividendTop ^^^ dividendMask) + dividendCarry2
+  let divisorMask := (0 : Word) - divisorSign
+  let divisorSum0 := (divisorLimb0 ^^^ divisorMask) + divisorSign
+  let divisorCarry0 := if BitVec.ult divisorSum0 divisorSign then (1 : Word) else 0
+  let divisorSum1 := (divisorLimb1 ^^^ divisorMask) + divisorCarry0
+  let divisorCarry1 := if BitVec.ult divisorSum1 divisorCarry0 then (1 : Word) else 0
+  let divisorSum2 := (divisorLimb2 ^^^ divisorMask) + divisorCarry1
+  let divisorCarry2 := if BitVec.ult divisorSum2 divisorCarry1 then (1 : Word) else 0
+  let divisorSum3 := (divisorTop ^^^ divisorMask) + divisorCarry2
+  let divisorCarry3 := if BitVec.ult divisorSum3 divisorCarry2 then (1 : Word) else 0
   (((.x8 ↦ᵣ resultSign) ** (.x9 ↦ᵣ divisorSign)) **
    (((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12)))) **
     ((dividendMem0 ↦ₘ dividendSum0) **
@@ -95,29 +132,50 @@ def saveRaSignsAbsThenSignXorPost
      (divisorMem2 ↦ₘ divisorSum2) ** (divisorMem3 ↦ₘ divisorSum3))))
 
 theorem saveRaSignsAbsThenSignXorPost_unfold
-    {vRa sp divisorSign resultSign divisorMask
-      divisorSum3 divisorCarry3
-      dividendMem0 dividendMem1 dividendMem2 dividendMem3
-      dividendSum0 dividendSum1 dividendSum2 dividendSum3
-      divisorMem0 divisorMem1 divisorMem2 divisorMem3
-      divisorSum0 divisorSum1 divisorSum2 : Word} :
-    saveRaSignsAbsThenSignXorPost vRa sp divisorSign resultSign
-        divisorMask divisorSum3 divisorCarry3
-        dividendMem0 dividendMem1 dividendMem2 dividendMem3
-        dividendSum0 dividendSum1 dividendSum2 dividendSum3
-        divisorMem0 divisorMem1 divisorMem2 divisorMem3
-        divisorSum0 divisorSum1 divisorSum2 =
-      (((.x8 ↦ᵣ resultSign) ** (.x9 ↦ᵣ divisorSign)) **
-       (((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12)))) **
-        ((dividendMem0 ↦ₘ dividendSum0) **
-         (dividendMem1 ↦ₘ dividendSum1) **
-         (dividendMem2 ↦ₘ dividendSum2) **
-         (dividendMem3 ↦ₘ dividendSum3) **
-         (.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) **
-         (.x10 ↦ᵣ divisorMask) ** (.x7 ↦ᵣ divisorSum3) **
-         (.x11 ↦ᵣ divisorCarry3) **
-         (divisorMem0 ↦ₘ divisorSum0) ** (divisorMem1 ↦ₘ divisorSum1) **
-         (divisorMem2 ↦ₘ divisorSum2) ** (divisorMem3 ↦ₘ divisorSum3)))) := by
+    {vRa sp dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word} :
+    saveRaSignsAbsThenSignXorPost vRa sp
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop =
+      (let dividendSign := dividendTop >>> (63 : BitVec 6).toNat
+       let divisorSign := divisorTop >>> (63 : BitVec 6).toNat
+       let resultSign := dividendSign ^^^ divisorSign
+       let dividendMem0 := sp + signExtend12 (0 : BitVec 12)
+       let dividendMem1 := sp + signExtend12 (8 : BitVec 12)
+       let dividendMem2 := sp + signExtend12 (16 : BitVec 12)
+       let dividendMem3 := sp + signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff
+       let divisorMem0 := sp + signExtend12 (32 : BitVec 12)
+       let divisorMem1 := sp + signExtend12 (40 : BitVec 12)
+       let divisorMem2 := sp + signExtend12 (48 : BitVec 12)
+       let divisorMem3 := sp + signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff
+       let dividendMask := (0 : Word) - dividendSign
+       let dividendSum0 := (dividendLimb0 ^^^ dividendMask) + dividendSign
+       let dividendCarry0 := if BitVec.ult dividendSum0 dividendSign then (1 : Word) else 0
+       let dividendSum1 := (dividendLimb1 ^^^ dividendMask) + dividendCarry0
+       let dividendCarry1 := if BitVec.ult dividendSum1 dividendCarry0 then (1 : Word) else 0
+       let dividendSum2 := (dividendLimb2 ^^^ dividendMask) + dividendCarry1
+       let dividendCarry2 := if BitVec.ult dividendSum2 dividendCarry1 then (1 : Word) else 0
+       let dividendSum3 := (dividendTop ^^^ dividendMask) + dividendCarry2
+       let divisorMask := (0 : Word) - divisorSign
+       let divisorSum0 := (divisorLimb0 ^^^ divisorMask) + divisorSign
+       let divisorCarry0 := if BitVec.ult divisorSum0 divisorSign then (1 : Word) else 0
+       let divisorSum1 := (divisorLimb1 ^^^ divisorMask) + divisorCarry0
+       let divisorCarry1 := if BitVec.ult divisorSum1 divisorCarry0 then (1 : Word) else 0
+       let divisorSum2 := (divisorLimb2 ^^^ divisorMask) + divisorCarry1
+       let divisorCarry2 := if BitVec.ult divisorSum2 divisorCarry1 then (1 : Word) else 0
+       let divisorSum3 := (divisorTop ^^^ divisorMask) + divisorCarry2
+       let divisorCarry3 := if BitVec.ult divisorSum3 divisorCarry2 then (1 : Word) else 0
+       (((.x8 ↦ᵣ resultSign) ** (.x9 ↦ᵣ divisorSign)) **
+        (((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12)))) **
+         ((dividendMem0 ↦ₘ dividendSum0) **
+          (dividendMem1 ↦ₘ dividendSum1) **
+          (dividendMem2 ↦ₘ dividendSum2) **
+          (dividendMem3 ↦ₘ dividendSum3) **
+          (.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) **
+          (.x10 ↦ᵣ divisorMask) ** (.x7 ↦ᵣ divisorSum3) **
+          (.x11 ↦ᵣ divisorCarry3) **
+          (divisorMem0 ↦ₘ divisorSum0) ** (divisorMem1 ↦ₘ divisorSum1) **
+          (divisorMem2 ↦ₘ divisorSum2) ** (divisorMem3 ↦ₘ divisorSum3))))) := by
   delta saveRaSignsAbsThenSignXorPost
   rfl
 
@@ -127,62 +185,54 @@ theorem saveRa_signs_abs_then_signXor_spec_in_sdivCode
       dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
       divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word)
     (base : Word) :
-    let dividendSign := dividendTop >>> (63 : BitVec 6).toNat
-    let divisorSign := divisorTop >>> (63 : BitVec 6).toNat
-    let resultSign := dividendSign ^^^ divisorSign
-    let dividendMem0 := sp + signExtend12 (0 : BitVec 12)
-    let dividendMem1 := sp + signExtend12 (8 : BitVec 12)
-    let dividendMem2 := sp + signExtend12 (16 : BitVec 12)
-    let dividendMem3 := sp + signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff
-    let divisorMem0 := sp + signExtend12 (32 : BitVec 12)
-    let divisorMem1 := sp + signExtend12 (40 : BitVec 12)
-    let divisorMem2 := sp + signExtend12 (48 : BitVec 12)
-    let divisorMem3 := sp + signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff
-    let dividendMask := (0 : Word) - dividendSign
-    let dividendXored0 := dividendLimb0 ^^^ dividendMask
-    let dividendSum0 := dividendXored0 + dividendSign
-    let dividendCarry0 := if BitVec.ult dividendSum0 dividendSign then (1 : Word) else 0
-    let dividendXored1 := dividendLimb1 ^^^ dividendMask
-    let dividendSum1 := dividendXored1 + dividendCarry0
-    let dividendCarry1 := if BitVec.ult dividendSum1 dividendCarry0 then (1 : Word) else 0
-    let dividendXored2 := dividendLimb2 ^^^ dividendMask
-    let dividendSum2 := dividendXored2 + dividendCarry1
-    let dividendCarry2 := if BitVec.ult dividendSum2 dividendCarry1 then (1 : Word) else 0
-    let dividendXored3 := dividendTop ^^^ dividendMask
-    let dividendSum3 := dividendXored3 + dividendCarry2
-    let divisorMask := (0 : Word) - divisorSign
-    let divisorXored0 := divisorLimb0 ^^^ divisorMask
-    let divisorSum0 := divisorXored0 + divisorSign
-    let divisorCarry0 := if BitVec.ult divisorSum0 divisorSign then (1 : Word) else 0
-    let divisorXored1 := divisorLimb1 ^^^ divisorMask
-    let divisorSum1 := divisorXored1 + divisorCarry0
-    let divisorCarry1 := if BitVec.ult divisorSum1 divisorCarry0 then (1 : Word) else 0
-    let divisorXored2 := divisorLimb2 ^^^ divisorMask
-    let divisorSum2 := divisorXored2 + divisorCarry1
-    let divisorCarry2 := if BitVec.ult divisorSum2 divisorCarry1 then (1 : Word) else 0
-    let divisorXored3 := divisorTop ^^^ divisorMask
-    let divisorSum3 := divisorXored3 + divisorCarry2
-    let divisorCarry3 := if BitVec.ult divisorSum3 divisorCarry2 then (1 : Word) else 0
     cpsTripleWithin 48 base ((base + signXorOff) + 4) (sdivCode base)
       (saveRaSignsAbsThenSignXorPre vRa vSavedOld sp sDividendOld sDivisorOld
         dividendMaskOld dividendValueOld dividendCarryOld
-        dividendMem0 dividendMem1 dividendMem2 dividendMem3
         dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-        divisorMem0 divisorMem1 divisorMem2 divisorMem3
         divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
-      (saveRaSignsAbsThenSignXorPost vRa sp divisorSign resultSign
-        divisorMask divisorSum3 divisorCarry3
-        dividendMem0 dividendMem1 dividendMem2 dividendMem3
-        dividendSum0 dividendSum1 dividendSum2 dividendSum3
-        divisorMem0 divisorMem1 divisorMem2 divisorMem3
-        divisorSum0 divisorSum1 divisorSum2) := by
-  intro dividendSign divisorSign resultSign dividendMem0 dividendMem1 dividendMem2
-    dividendMem3 divisorMem0 divisorMem1 divisorMem2 divisorMem3
-    dividendMask dividendXored0 dividendSum0 dividendCarry0 dividendXored1
-    dividendSum1 dividendCarry1 dividendXored2 dividendSum2 dividendCarry2
-    dividendXored3 dividendSum3 divisorMask divisorXored0 divisorSum0
-    divisorCarry0 divisorXored1 divisorSum1 divisorCarry1 divisorXored2
-    divisorSum2 divisorCarry2 divisorXored3 divisorSum3 divisorCarry3
+      (saveRaSignsAbsThenSignXorPost vRa sp
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) := by
+  rw [saveRaSignsAbsThenSignXorPre_unfold,
+      saveRaSignsAbsThenSignXorPost_unfold]
+  -- Re-introduce the let-chain locally so the existing composition proof
+  -- (which references these derived names) keeps working unchanged.
+  let dividendSign := dividendTop >>> (63 : BitVec 6).toNat
+  let divisorSign := divisorTop >>> (63 : BitVec 6).toNat
+  let resultSign := dividendSign ^^^ divisorSign
+  let dividendMem0 := sp + signExtend12 (0 : BitVec 12)
+  let dividendMem1 := sp + signExtend12 (8 : BitVec 12)
+  let dividendMem2 := sp + signExtend12 (16 : BitVec 12)
+  let dividendMem3 := sp + signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff
+  let divisorMem0 := sp + signExtend12 (32 : BitVec 12)
+  let divisorMem1 := sp + signExtend12 (40 : BitVec 12)
+  let divisorMem2 := sp + signExtend12 (48 : BitVec 12)
+  let divisorMem3 := sp + signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff
+  let dividendMask := (0 : Word) - dividendSign
+  let dividendXored0 := dividendLimb0 ^^^ dividendMask
+  let dividendSum0 := dividendXored0 + dividendSign
+  let dividendCarry0 := if BitVec.ult dividendSum0 dividendSign then (1 : Word) else 0
+  let dividendXored1 := dividendLimb1 ^^^ dividendMask
+  let dividendSum1 := dividendXored1 + dividendCarry0
+  let dividendCarry1 := if BitVec.ult dividendSum1 dividendCarry0 then (1 : Word) else 0
+  let dividendXored2 := dividendLimb2 ^^^ dividendMask
+  let dividendSum2 := dividendXored2 + dividendCarry1
+  let dividendCarry2 := if BitVec.ult dividendSum2 dividendCarry1 then (1 : Word) else 0
+  let dividendXored3 := dividendTop ^^^ dividendMask
+  let dividendSum3 := dividendXored3 + dividendCarry2
+  let divisorMask := (0 : Word) - divisorSign
+  let divisorXored0 := divisorLimb0 ^^^ divisorMask
+  let divisorSum0 := divisorXored0 + divisorSign
+  let divisorCarry0 := if BitVec.ult divisorSum0 divisorSign then (1 : Word) else 0
+  let divisorXored1 := divisorLimb1 ^^^ divisorMask
+  let divisorSum1 := divisorXored1 + divisorCarry0
+  let divisorCarry1 := if BitVec.ult divisorSum1 divisorCarry0 then (1 : Word) else 0
+  let divisorXored2 := divisorLimb2 ^^^ divisorMask
+  let divisorSum2 := divisorXored2 + divisorCarry1
+  let divisorCarry2 := if BitVec.ult divisorSum2 divisorCarry1 then (1 : Word) else 0
+  let divisorXored3 := divisorTop ^^^ divisorMask
+  let divisorSum3 := divisorXored3 + divisorCarry2
+  let divisorCarry3 := if BitVec.ult divisorSum3 divisorCarry2 then (1 : Word) else 0
   let pre : Assertion :=
     ((((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ vSavedOld)) **
         ((.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sDividendOld) **
@@ -252,8 +302,6 @@ theorem saveRa_signs_abs_then_signXor_spec_in_sdivCode
     (fun h hp => by
       dsimp [prefixPost, signPre, signFrame] at hp ⊢
       xperm_hyp hp) hPrefix hXor
-  rw [saveRaSignsAbsThenSignXorPre_unfold,
-      saveRaSignsAbsThenSignXorPost_unfold]
   simpa [pre, post] using hSeq
 
 end EvmAsm.Evm64.SDiv.Compose


### PR DESCRIPTION
## Summary
- Move the 36-line outer let-chain (dividendSign/divisorSign/resultSign/masks/mems/sums/carries) into the `@[irreducible]` `saveRaSignsAbsThenSignXorPre` and `saveRaSignsAbsThenSignXorPost` defs so `saveRa_signs_abs_then_signXor_spec_in_sdivCode` has a flat `cpsTripleWithin n base exitPC code Pre Post` signature.
- Pre/Post defs now take only raw inputs (sp, vRa, dividendLimb0..2, dividendTop, divisorLimb0..2, divisorTop and prologue values); their `_unfold` lemmas expose the full let-chain so existing composition proofs that reference derived names still compose unchanged.
- Same wrap pattern as PR #3662 (saveRa_signs_abs_then_divisorAbs).

Stacked on #3593. Refs #90.

## Verification
- lake build EvmAsm.Evm64.SDiv.Compose.SignXorSequence
- lake build EvmAsm.Evm64.SDiv.Compose.DivCall
- scripts/check-file-size.sh
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/SignXorSequence.lean
- lake build

Authored by @pirapira; implemented by Claude Code