### PR TITLE
feat(sdiv): add evmWordIs_eq_quadMem_sp32 divisor-side bridge lemma

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/Base.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/Base.lean
@@ -1122,4 +1122,27 @@ theorem evmWordIs_eq_quadMem (sp : Word) (limbs : Fin 4 → Word) :
   rw [h0, h8, h16, h24]
   exact (evmWordIs_fromLimbs (addr := sp) limbs).symm
 
+/-- Divisor-slot companion to `evmWordIs_eq_quadMem`: four `↦ₘ`-memory atoms
+    at `sp + signExtend12 (32/40/48/56)` fold into a single
+    `evmWordIs (sp + 32)` atom. Bite-sized helper for slice 4 (evm-asm-j8ity):
+    the post-`abs` divisor limbs live at `sp + signExtend12 (32..56)` while
+    `evm_div_callable_spec_in_sdivCode` consumes them as
+    `evmWordIs (sp + 32) b`; this lemma bridges the two shapes. -/
+theorem evmWordIs_eq_quadMem_sp32 (sp : Word) (limbs : Fin 4 → Word) :
+    (((sp + signExtend12 (32 : BitVec 12)) ↦ₘ limbs 0) **
+     ((sp + signExtend12 (40 : BitVec 12)) ↦ₘ limbs 1) **
+     ((sp + signExtend12 (48 : BitVec 12)) ↦ₘ limbs 2) **
+     ((sp + signExtend12 (56 : BitVec 12)) ↦ₘ limbs 3)) =
+    evmWordIs (sp + 32) (EvmWord.fromLimbs limbs) := by
+  have h32 : (sp + signExtend12 (32 : BitVec 12) : Word) = sp + 32 := by
+    unfold signExtend12; bv_decide
+  have h40 : (sp + signExtend12 (40 : BitVec 12) : Word) = (sp + 32) + 8 := by
+    unfold signExtend12; bv_decide
+  have h48 : (sp + signExtend12 (48 : BitVec 12) : Word) = (sp + 32) + 16 := by
+    unfold signExtend12; bv_decide
+  have h56 : (sp + signExtend12 (56 : BitVec 12) : Word) = (sp + 32) + 24 := by
+    unfold signExtend12; bv_decide
+  rw [h32, h40, h48, h56]
+  exact (evmWordIs_fromLimbs (addr := sp + 32) limbs).symm
+
 end EvmAsm.Evm64.SDiv.Compose


### PR DESCRIPTION
## Summary
- Add `evmWordIs_eq_quadMem_sp32` in `EvmAsm/Evm64/SDiv/Compose/Base.lean` — folds four `↦ₘ` atoms at `sp + signExtend12 (32/40/48/56)` into `evmWordIs (sp + 32) (EvmWord.fromLimbs limbs)`.
- Companion to `evmWordIs_eq_quadMem` (PR #3664). Together the two lemmas bridge the post-`abs` memory-quad shape to the `evmWordIs sp a` / `evmWordIs (sp+32) b` inputs of `evm_div_callable_spec_in_sdivCode`, unblocking the next step in evm-asm-48gpp (slice 4 child composition).

Refs #90. Bead: evm-asm-j8ity.

## Verification
- lake build EvmAsm.Evm64.SDiv.Compose.Base
- scripts/check-file-size.sh
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/Base.lean
- lake build

Authored by @pirapira; implemented by Claude Code