### PR TITLE
feat(sdiv): add base_add_resultSignFixOff_andn_one alignment lemma

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/Base.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/Base.lean
@@ -1122,4 +1122,16 @@ theorem evmWordIs_eq_quadMem (sp : Word) (limbs : Fin 4 → Word) :
   rw [h0, h8, h16, h24]
   exact (evmWordIs_fromLimbs (addr := sp) limbs).symm
 
+/-- Under the standard RV PC-alignment invariant (`base` has its low bit
+    clear), the JALR low-bit mask `&&& ~~~1` on the post-`divCall` return
+    address `base + resultSignFixOff` is the identity. Bite-sized helper
+    for slice 4 (evm-asm-tdlsu): used to align the exit PC of
+    `evm_div_callable_spec_in_sdivCode` (which returns to `saved_ra &&& ~~~1`
+    via JALR) with the SDIV wrapper's `resultSignFix` entry. -/
+theorem base_add_resultSignFixOff_andn_one
+    (base : Word) (hbase : base &&& 1 = 0) :
+    (base + resultSignFixOff) &&& ~~~(1 : Word) = base + resultSignFixOff := by
+  show (base + (196 : Word)) &&& ~~~(1 : Word) = base + (196 : Word)
+  bv_decide
+
 end EvmAsm.Evm64.SDiv.Compose


### PR DESCRIPTION
## Summary
- Add `base_add_resultSignFixOff_andn_one` in `EvmAsm/Evm64/SDiv/Compose/Base.lean` — under the standard RV PC-alignment invariant `base &&& 1 = 0`, the JALR low-bit mask is the identity on `base + resultSignFixOff`.
- Bite-sized helper for evm-asm-48gpp item (d): aligns the exit PC of `evm_div_callable_spec_in_sdivCode` (which returns to `saved_ra &&& ~~~1` via JALR) with the SDIV wrapper's `resultSignFix` entry.

Refs #90. Bead: evm-asm-tdlsu.

## Verification
- lake build EvmAsm.Evm64.SDiv.Compose.Base
- scripts/check-file-size.sh
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/Base.lean
- lake build

Authored by @pirapira; implemented by Claude Code