### PR TITLE
feat(exp): lift exp_squaring_marshal_pair_then_mul_call into evmExpWithMulCode

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/FullLoop.lean
+++ b/EvmAsm/Evm64/Exp/Compose/FullLoop.lean
@@ -7,6 +7,7 @@
 -/
 
 import EvmAsm.Evm64.Exp.Compose.TopCodeSpecs
+import EvmAsm.Evm64.Exp.SquaringPairThenMulCall
 import EvmAsm.Evm64.Multiply.Callable
 
 namespace EvmAsm.Evm64.Exp.Compose
@@ -354,5 +355,70 @@ theorem exp_cond_mul_beq_evm_exp_with_mul_spec_within
   cpsBranchWithin_extend_evmExpWithMulCode
     (exp_cond_mul_beq_evm_exp_spec_within
       mulOff skipOff backOff v10 base target htarget)
+
+/-- Squaring-side marshal-pair + JAL + `mul_callable` round-trip lifted from
+    the disjoint-union code `exp_squaring_call_block_code.union mul_callable_code`
+    into the combined `evmExpWithMulCode` bundle. Iteration body composition
+    needs the round-trip spec stated over the full-loop code, not the local
+    union. Reuses `EvmAsm.Evm64.exp_squaring_marshal_pair_then_mul_call_spec_within`
+    instantiated at offset `base + 40` (the squaring-call sub-block entry inside
+    the iteration body). -/
+theorem exp_squaring_marshal_pair_then_mul_call_evm_exp_with_mul_spec_within
+    (sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+      v6 v7 v10 v11 mulTarget : Word)
+    (mulOff : BitVec 21) (skipOff backOff : BitVec 13) (base : Word)
+    (hmt : mulTarget = ((base + 40) + 64) + signExtend21 mulOff)
+    (hd : CodeReq.Disjoint
+            (evmExpCode base mulOff skipOff backOff)
+            (mul_callable_code mulTarget)) :
+    cpsTripleWithin (17 + 64) (base + 40) (((base + 40) + 68) &&& ~~~1)
+      (evmExpWithMulCode base mulTarget mulOff skipOff backOff)
+      ((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+       ((evmSp + signExtend12 (0 : BitVec 12)) ↦ₘ d0) **
+       ((evmSp + signExtend12 (8 : BitVec 12)) ↦ₘ d1) **
+       ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ d2) **
+       ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ d3) **
+       ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ e0) **
+       ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ e1) **
+       ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ e2) **
+       ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ e3) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) **
+       (.x1 ↦ᵣ vOld))
+      ((.x2 ↦ᵣ sp) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+       evmMulStackPost evmSp (expResultWord r0 r1 r2 r3)
+                              (expResultWord r0 r1 r2 r3) **
+       (.x1 ↦ᵣ ((base + 40) + 68))) := by
+  have hd_inner : CodeReq.Disjoint
+      (exp_squaring_call_block_code (base + 40) mulOff)
+      (mul_callable_code mulTarget) := by
+    intro a
+    rcases hd a with hExp | hMul
+    · left
+      cases hsub : exp_squaring_call_block_code (base + 40) mulOff a with
+      | none => rfl
+      | some i =>
+        have hev := evmExpCode_iter_squaring_sub
+          (base := base) (mulOff := mulOff)
+          (skipOff := skipOff) (backOff := backOff) a i hsub
+        exact absurd (hev.symm.trans hExp) (by simp)
+    · right; exact hMul
+  have hbase := EvmAsm.Evm64.exp_squaring_marshal_pair_then_mul_call_spec_within
+    sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+    v6 v7 v10 v11 mulTarget mulOff (base + 40) hmt hd_inner
+  exact cpsTripleWithin_extend_code
+    (hmono := CodeReq.union_sub
+      (fun a i h => evmExpWithMulCode_exp_sub a i
+        (evmExpCode_iter_squaring_sub
+          (base := base) (mulOff := mulOff)
+          (skipOff := skipOff) (backOff := backOff) a i h))
+      (fun a i h => evmExpWithMulCode_mul_sub hd a i h)) hbase
 
 end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- Add `exp_squaring_marshal_pair_then_mul_call_evm_exp_with_mul_spec_within` in `EvmAsm/Evm64/Exp/Compose/FullLoop.lean` — the squaring-side marshal-pair + JAL + `mul_callable` round-trip stated over `evmExpWithMulCode` (the EXP+MUL code bundle) instead of the local disjoint union `exp_squaring_call_block_code.union mul_callable_code`.
- Bridge: derive sub-block disjointness from the bundle-level disjointness hypothesis, then `cpsTripleWithin_extend_code` via `CodeReq.union_sub` + `evmExpCode_iter_squaring_sub` + `evmExpWithMulCode_mul_sub`.
- Unblocks single-iteration body composition for evm-asm-w5mk slice 5. The cond-mul-side analogue is the natural follow-up (needs an analogous `*PairThenMulCall` basic-block spec, which doesn't yet exist as a file).

Refs #92. Bead: evm-asm-vl5uy.

## Verification
- lake build EvmAsm.Evm64.Exp.Compose.FullLoop
- scripts/check-file-size.sh
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/Compose/FullLoop.lean
- lake build

Authored by @pirapira; implemented by Claude Code