### PR TITLE
feat(exp): add exp_loop_un_marshal_and_restore_word_spec_within_regOwn5

### DIFF
--- a/EvmAsm/Evm64/Exp/SquaringPairThenMulCall.lean
+++ b/EvmAsm/Evm64/Exp/SquaringPairThenMulCall.lean
@@ -163,6 +163,32 @@ theorem exp_loop_un_marshal_and_restore_word_spec_within
       xperm_hyp hp)
     h_unmarshal
 
+/-- Weakened-pre variant of `exp_loop_un_marshal_and_restore_word_spec_within`:
+    consumes `regOwn .x5` in place of a concrete `(.x5 ↦ᵣ tOld)`. The
+    un_marshal block loads `w.getLimbN 3` into `.x5`, so it does not care
+    about the prior value — any old value works. This bridges the seq
+    composition with `mul_callable_spec_within`'s post (which carries
+    `regOwn .x5` via `evmMulStackPost`) and the un_marshal entry. Slice 4
+    micro evm-asm-xdmss. -/
+theorem exp_loop_un_marshal_and_restore_word_spec_within_regOwn5
+    (sp evmSp r0 r1 r2 r3 base : Word) (w : EvmWord) :
+    cpsTripleWithin 9 base (base + 36)
+      (CodeReq.ofProg base exp_loop_un_marshal_and_restore)
+      (((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ (evmSp + 32)) **
+        ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+        ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+        ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+        ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+        evmWordIs (evmSp + 32) w) ** regOwn .x5)
+      ((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ w.getLimbN 3) **
+       evmWordIs sp w ** evmWordIs (evmSp + 32) w) :=
+  cpsTripleWithin_of_forall_regIs_to_regOwn (fun tOld =>
+    cpsTripleWithin_weaken
+      (fun _ hp => by xperm_hyp hp)
+      (fun _ hp => hp)
+      (exp_loop_un_marshal_and_restore_word_spec_within sp evmSp tOld
+        r0 r1 r2 r3 base w))
+
 /-- Compose the squaring marshal pair (16 instr) plus its trailing JAL
     (1 instr) with `mul_callable_spec_within` (64 instr) at the JAL target.
 


### PR DESCRIPTION
## Summary
- Add `exp_loop_un_marshal_and_restore_word_spec_within_regOwn5` in `EvmAsm/Evm64/Exp/SquaringPairThenMulCall.lean`.
- Weakened-pre variant of `exp_loop_un_marshal_and_restore_word_spec_within`: consumes `regOwn .x5` in place of a concrete `(.x5 ↦ᵣ tOld)`. The un_marshal block writes `w.getLimbN 3` into `.x5`, so the prior value is irrelevant.
- Proof: `cpsTripleWithin_of_forall_regIs_to_regOwn` wraps the existing tOld-parameterized spec with an `xperm`-permuted precondition placing `(.x5 ↦ᵣ tOld)` at the sepConj's end.
- Bridges the seq composition with `mul_callable_spec_within`'s post (which carries `regOwn .x5` via `evmMulStackPost`). Unblocks evm-asm-ifaon (`exp_squaring_call_block_spec_within` full call-block compose).

Refs #92. Bead: evm-asm-xdmss.

## Verification
- lake build EvmAsm.Evm64.Exp.SquaringPairThenMulCall
- scripts/check-file-size.sh
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/SquaringPairThenMulCall.lean
- lake build

Authored by @pirapira; implemented by Claude Code