### PR TITLE
feat(exp): add exp_squaring_call_block_spec_within (full call-block compose)

### DIFF
--- a/EvmAsm/Evm64/Exp/CondMulPairThenMulCall.lean
+++ b/EvmAsm/Evm64/Exp/CondMulPairThenMulCall.lean
@@ -23,6 +23,7 @@
 
 import EvmAsm.Evm64.Exp.CondMulCallSeq
 import EvmAsm.Evm64.Exp.SquaringMarshalPairPost
+import EvmAsm.Evm64.Exp.SquaringPairThenMulCall
 import EvmAsm.Evm64.Multiply.Callable
 
 open EvmAsm.Rv64.Tactics
@@ -177,6 +178,109 @@ theorem exp_cond_mul_marshal_pair_then_mul_call_spec_within
         hpairFramed)
       hmulFramed
   -- Re-associate entry pre and exit post into the natural shapes declared.
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by xperm_hyp hp)
+    (fun _ hp => by xperm_hyp hp)
+    hseq
+
+/-- Cond-mul full call-block: sequence the cond-mul marshal-pair + JAL +
+    mul_callable round-trip with `un_marshal_and_restore` to obtain a single
+    `cpsTripleWithin` from `base` to `base + 104` over the disjoint union of
+    `exp_cond_mul_call_block_code base mulOff` and `mul_callable_code
+    mul_target`. Result word `r * a` (the multiply of running result
+    `expResultWord r0..r3` by base operand `expResultWord a0..a3`) is
+    delivered into the EXP-local scratch frame at `sp` and the LP64 frame at
+    `evmSp + 32`. The EVM-stack base operand at `evmSp[-64..-40]` is
+    preserved. Slice 5 micro evm-asm-c03pg, cond-mul sibling of
+    `exp_squaring_call_block_spec_within`. -/
+theorem exp_cond_mul_call_block_spec_within
+    (sp evmSp tOld vOld r0 r1 r2 r3 a0 a1 a2 a3 d0 d1 d2 d3 e0 e1 e2 e3
+      v6 v7 v10 v11 mul_target : Word)
+    (mulOff : BitVec 21) (base : Word)
+    (hbase : base &&& 1 = 0)
+    (hmt : mul_target = (base + 64) + signExtend21 mulOff)
+    (hd : CodeReq.Disjoint
+            (exp_cond_mul_call_block_code base mulOff)
+            (mul_callable_code mul_target)) :
+    let r := expResultWord r0 r1 r2 r3
+    let aw := expResultWord a0 a1 a2 a3
+    cpsTripleWithin (17 + 64 + 9) base (base + 104)
+      ((exp_cond_mul_call_block_code base mulOff).union
+        (mul_callable_code mul_target))
+      ((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+       ((evmSp + signExtend12 (0 : BitVec 12)) ↦ₘ d0) **
+       ((evmSp + signExtend12 (8 : BitVec 12)) ↦ₘ d1) **
+       ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ d2) **
+       ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ d3) **
+       ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ e0) **
+       ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ e1) **
+       ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ e2) **
+       ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ e3) **
+       ((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
+       ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **
+       ((evmSp + signExtend12 ((-48) : BitVec 12)) ↦ₘ a2) **
+       ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) **
+       (.x1 ↦ᵣ vOld))
+      ((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) **
+       (.x5 ↦ᵣ (r * aw).getLimbN 3) **
+       ((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
+       ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **
+       ((evmSp + signExtend12 ((-48) : BitVec 12)) ↦ₘ a2) **
+       ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3) **
+       evmWordIs sp (r * aw) ** evmWordIs (evmSp + 32) (r * aw) **
+       regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
+       memOwn evmSp ** memOwn (evmSp + 8) **
+       memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
+       (.x1 ↦ᵣ (base + 68))) := by
+  intro r aw
+  -- (1) Marshal-pair + JAL + mul_callable: 81 instrs, exit (base+68) &&& ~~~1.
+  have h1 := exp_cond_mul_marshal_pair_then_mul_call_spec_within
+    sp evmSp tOld vOld r0 r1 r2 r3 a0 a1 a2 a3 d0 d1 d2 d3 e0 e1 e2 e3
+    v6 v7 v10 v11 mul_target mulOff base hmt hd
+  -- (2) Alignment under base &&& 1 = 0.
+  have halign : (base + 68 : Word) &&& ~~~(1 : Word) = base + 68 := by bv_decide
+  rw [halign] at h1
+  -- (3) un_marshal_and_restore_word at offset (base+68) with w' = r * aw.
+  have h2_raw := exp_loop_un_marshal_and_restore_word_spec_within_regOwn5
+    sp evmSp r0 r1 r2 r3 (base + 68) (r * aw)
+  -- Lift code: ofProg (base+68) un_marshal_and_restore ⊆ union.
+  have h2_lifted : cpsTripleWithin 9 (base + 68) ((base + 68) + 36)
+      ((exp_cond_mul_call_block_code base mulOff).union
+        (mul_callable_code mul_target)) _ _ :=
+    cpsTripleWithin_extend_code
+      (hmono := fun a i h =>
+        CodeReq.union_mono_left (cr2 := mul_callable_code mul_target) a i
+          (exp_cond_mul_call_block_code_un_marshal_and_restore_sub base mulOff a i h))
+      h2_raw
+  -- Frame on the LEFT extras not consumed by un_marshal: a-source slots,
+  -- regOwn x6/x7/x10/x11, memOwn evmSp[0..24], (.x1 ↦ (base+68)).
+  have h2_framed :=
+    cpsTripleWithin_frameL
+      (((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
+       ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **
+       ((evmSp + signExtend12 ((-48) : BitVec 12)) ↦ₘ a2) **
+       ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3) **
+       regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
+       memOwn evmSp ** memOwn (evmSp + 8) **
+       memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
+       (.x1 ↦ᵣ (base + 68)))
+      (by pcFree) h2_lifted
+  have hexit : (base + 68 : Word) + 36 = base + 104 := by bv_omega
+  rw [hexit] at h2_framed
+  -- (4) Compose with mid-point permutation.
+  have hseq : cpsTripleWithin (17 + 64 + 9) base (base + 104)
+      ((exp_cond_mul_call_block_code base mulOff).union
+        (mul_callable_code mul_target)) _ _ :=
+    cpsTripleWithin_seq_perm_same_cr
+      (fun _ hp => by
+        delta evmMulStackPost at hp
+        xperm_hyp hp)
+      h1 h2_framed
   exact cpsTripleWithin_weaken
     (fun _ hp => by xperm_hyp hp)
     (fun _ hp => by xperm_hyp hp)

--- a/EvmAsm/Evm64/Exp/SquaringPairThenMulCall.lean
+++ b/EvmAsm/Evm64/Exp/SquaringPairThenMulCall.lean
@@ -336,4 +336,93 @@ theorem exp_squaring_marshal_pair_then_mul_call_spec_within
     (fun _ hp => by xperm_hyp hp)
     hseq
 
+/-- Squaring full call-block: sequence the marshal-pair + JAL + mul_callable
+    round-trip with `un_marshal_and_restore` to obtain a single
+    `cpsTripleWithin` from `base` to `base + 104` over the disjoint union of
+    `exp_squaring_call_block_code base mulOff` and `mul_callable_code
+    mul_target`. The result word `w * w` (the squaring of `expResultWord
+    r0..r3`) is delivered into the EXP-local scratch frame at `sp` and the
+    LP64 frame at `evmSp + 32`. Slice 5 micro evm-asm-ifaon. -/
+theorem exp_squaring_call_block_spec_within
+    (sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+      v6 v7 v10 v11 mul_target : Word)
+    (mulOff : BitVec 21) (base : Word)
+    (hbase : base &&& 1 = 0)
+    (hmt : mul_target = (base + 64) + signExtend21 mulOff)
+    (hd : CodeReq.Disjoint
+            (exp_squaring_call_block_code base mulOff)
+            (mul_callable_code mul_target)) :
+    let w := expResultWord r0 r1 r2 r3
+    cpsTripleWithin (17 + 64 + 9) base (base + 104)
+      ((exp_squaring_call_block_code base mulOff).union
+        (mul_callable_code mul_target))
+      ((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+       ((evmSp + signExtend12 (0 : BitVec 12)) ↦ₘ d0) **
+       ((evmSp + signExtend12 (8 : BitVec 12)) ↦ₘ d1) **
+       ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ d2) **
+       ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ d3) **
+       ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ e0) **
+       ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ e1) **
+       ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ e2) **
+       ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ e3) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) **
+       (.x1 ↦ᵣ vOld))
+      ((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) **
+       (.x5 ↦ᵣ (w * w).getLimbN 3) **
+       evmWordIs sp (w * w) ** evmWordIs (evmSp + 32) (w * w) **
+       regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
+       memOwn evmSp ** memOwn (evmSp + 8) **
+       memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
+       (.x1 ↦ᵣ (base + 68))) := by
+  intro w
+  -- (1) Marshal-pair + JAL + mul_callable: 81 instrs, exit (base+68) &&& ~~~1.
+  have h1 := exp_squaring_marshal_pair_then_mul_call_spec_within
+    sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+    v6 v7 v10 v11 mul_target mulOff base hmt hd
+  -- (2) Alignment: under base &&& 1 = 0, (base+68) &&& ~~~1 = base+68.
+  have halign : (base + 68 : Word) &&& ~~~(1 : Word) = base + 68 := by bv_decide
+  rw [halign] at h1
+  -- (3) un_marshal_and_restore_word at offset (base+68), with w' = w*w.
+  have h2_raw := exp_loop_un_marshal_and_restore_word_spec_within_regOwn5
+    sp evmSp r0 r1 r2 r3 (base + 68) (w * w)
+  -- Lift code: ofProg (base+68) un_marshal_and_restore ⊆ union.
+  have h2_lifted := cpsTripleWithin_extend_code
+    (hmono := fun a i h =>
+      exp_squaring_call_with_mul_code_block_sub base mul_target mulOff a i
+        (exp_squaring_call_block_code_un_marshal_and_restore_sub base mulOff a i h))
+    h2_raw
+  -- Frame on the LEFT the extra atoms not consumed by un_marshal:
+  --   regOwn .x6/.x7/.x10/.x11 ** memOwn evmSp[0..24] ** (.x1 ↦ (base+68)).
+  have h2_framed :=
+    cpsTripleWithin_frameL
+      (regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
+       memOwn evmSp ** memOwn (evmSp + 8) **
+       memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
+       (.x1 ↦ᵣ (base + 68)))
+      (by pcFree) h2_lifted
+  -- Exit pcs: (base+68) + 36 = base + 104.
+  have hexit : (base + 68 : Word) + 36 = base + 104 := by bv_omega
+  rw [hexit] at h2_framed
+  -- (4) Compose with mid-point permutation: align h1's post (which carries
+  --     `evmMulStackPost evmSp w w`) with h2_framed's pre.
+  have hpcFreeMulPost : (evmMulStackPost evmSp w w).pcFree := by
+    delta evmMulStackPost; pcFree
+  have hseq : cpsTripleWithin (17 + 64 + 9) base (base + 104)
+      ((exp_squaring_call_block_code base mulOff).union
+        (mul_callable_code mul_target)) _ _ :=
+    cpsTripleWithin_seq_perm_same_cr
+      (fun _ hp => by
+        delta evmMulStackPost at hp
+        xperm_hyp hp)
+      h1 h2_framed
+  -- Re-associate to the natural post shape.
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by xperm_hyp hp)
+    (fun _ hp => by xperm_hyp hp)
+    hseq
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Add `exp_squaring_call_block_spec_within` in `EvmAsm/Evm64/Exp/SquaringPairThenMulCall.lean`.
- Sequences the squaring `marshal_pair + JAL + mul_callable` round-trip (`exp_squaring_marshal_pair_then_mul_call_spec_within`, on main) with `exp_loop_un_marshal_and_restore_word_spec_within_regOwn5` (PR #3675) into a single `cpsTripleWithin` from `base` to `base + 104` over the disjoint union of `exp_squaring_call_block_code base mulOff` and `mul_callable_code mul_target`.
- Result word `w * w` (squaring of `expResultWord r0..r3`) is delivered into the EXP-local scratch frame at `sp` (via `evmWordIs sp (w*w)`) and the LP64 frame at `evmSp + 32` (via `evmWordIs (evmSp+32) (w*w)`).
- Requires `base &&& 1 = 0` (standard RV PC-alignment invariant) so the JALR low-bit mask `(base+68) &&& ~~~1` reduces to `base + 68`.

Stacked on #3675. Refs #92. Bead: evm-asm-ifaon.

## Verification
- lake build EvmAsm.Evm64.Exp.SquaringPairThenMulCall
- scripts/check-file-size.sh
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/SquaringPairThenMulCall.lean
- lake build

Authored by @pirapira; implemented by Claude Code