### PR TITLE
fix(exp): add saved-bit composition code

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBase.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBase.lean
@@ -1,0 +1,419 @@
+/-
+  EvmAsm.Evm64.Exp.Compose.SavedBitBase
+
+  Shared composition infrastructure for the corrected MSB-first saved-bit EXP
+  layout.  This stays separate from `Compose/Base.lean` to keep the common
+  composition foundation under the file-size guardrail.
+-/
+
+import EvmAsm.Evm64.Exp.Compose.Base
+
+namespace EvmAsm.Evm64.Exp.Compose
+
+open EvmAsm.Rv64.Tactics
+open EvmAsm.Rv64
+
+theorem exp_msb_bit_test_block_len :
+    (EvmAsm.Evm64.exp_msb_bit_test_block).length = 3 := by
+  exact EvmAsm.Evm64.exp_msb_bit_test_block_length
+
+theorem exp_save_bit_block_len : (EvmAsm.Evm64.exp_save_bit_block).length = 1 := by
+  exact EvmAsm.Evm64.exp_save_bit_block_length
+
+theorem exp_cond_mul_call_with_saved_bit_skip_block_len
+    (mulOff : BitVec 21) (skipOff : BitVec 13) :
+    (EvmAsm.Evm64.exp_cond_mul_call_with_saved_bit_skip_block
+      mulOff skipOff).length = 27 := by
+  exact EvmAsm.Evm64.exp_cond_mul_call_with_saved_bit_skip_block_length
+    mulOff skipOff
+
+theorem exp_iter_body_full_msb_saved_bit_len
+    (mulOff : BitVec 21) (skipOff backOff : BitVec 13) :
+    (EvmAsm.Evm64.exp_iter_body_full_msb_saved_bit
+      mulOff skipOff backOff).length = 59 := by
+  exact EvmAsm.Evm64.exp_iter_body_full_msb_saved_bit_length
+    mulOff skipOff backOff
+
+theorem evm_exp_msb_saved_bit_len
+    (mulOff : BitVec 21) (skipOff backOff : BitVec 13) :
+    (EvmAsm.Evm64.evm_exp_msb_saved_bit mulOff skipOff backOff).length = 76 := by
+  exact EvmAsm.Evm64.evm_exp_msb_saved_bit_length mulOff skipOff backOff
+
+/-- CodeReq decomposition for the corrected EXP square-and-multiply
+    iteration: MSB bit-test, save bit, squaring call, saved-bit conditional
+    multiply call, and trailing loop back-edge. -/
+abbrev expIterBodyFullMsbSavedBitCode (base : Word)
+    (mulOff : BitVec 21) (skipOff backOff : BitVec 13) : CodeReq :=
+  CodeReq.unionAll [
+    CodeReq.ofProg base EvmAsm.Evm64.exp_msb_bit_test_block,
+    CodeReq.ofProg (base + 12) EvmAsm.Evm64.exp_save_bit_block,
+    exp_squaring_call_block_code (base + 16) mulOff,
+    EvmAsm.Evm64.exp_cond_mul_call_with_saved_bit_skip_block_code
+      (base + 120) mulOff skipOff,
+    CodeReq.ofProg (base + 228) (EvmAsm.Evm64.exp_loop_back backOff)
+  ]
+
+theorem expIterBodyFullMsbSavedBitCode_eq_ofProg (base : Word)
+    (mulOff : BitVec 21) (skipOff backOff : BitVec 13) :
+    expIterBodyFullMsbSavedBitCode base mulOff skipOff backOff =
+      CodeReq.ofProg base
+        (EvmAsm.Evm64.exp_iter_body_full_msb_saved_bit
+          mulOff skipOff backOff) := by
+  unfold expIterBodyFullMsbSavedBitCode
+  unfold EvmAsm.Evm64.exp_iter_body_full_msb_saved_bit
+  simp only [EvmAsm.Rv64.seq]
+  unfold Program
+  rw [CodeReq.ofProg_append]
+  have h12 :
+      base + BitVec.ofNat 64 (4 *
+        (EvmAsm.Evm64.exp_msb_bit_test_block).length) = base + 12 := by
+    rw [EvmAsm.Evm64.exp_msb_bit_test_block_length]
+    rfl
+  rw [h12]
+  rw [CodeReq.ofProg_append]
+  have h16 :
+      (base + 12 : Word) + BitVec.ofNat 64 (4 *
+        (EvmAsm.Evm64.exp_save_bit_block).length) = base + 16 := by
+    rw [EvmAsm.Evm64.exp_save_bit_block_length]
+    bv_addr
+  rw [h16]
+  rw [CodeReq.ofProg_append]
+  have h120 :
+      (base + 16 : Word) + BitVec.ofNat 64 (4 *
+        (EvmAsm.Evm64.exp_squaring_call_block mulOff).length) =
+        base + 120 := by
+    rw [EvmAsm.Evm64.exp_squaring_call_block_length]
+    bv_addr
+  rw [h120]
+  rw [CodeReq.ofProg_append]
+  have h228 :
+      (base + 120 : Word) + BitVec.ofNat 64 (4 *
+        (EvmAsm.Evm64.exp_cond_mul_call_with_saved_bit_skip_block
+          mulOff skipOff).length) = base + 228 := by
+    rw [EvmAsm.Evm64.exp_cond_mul_call_with_saved_bit_skip_block_length]
+    bv_addr
+  rw [h228]
+  rw [← exp_squaring_call_block_code_eq_ofProg (base + 16) mulOff]
+  rw [← EvmAsm.Evm64.exp_cond_mul_call_with_saved_bit_skip_block_code_eq_ofProg
+    (base + 120) mulOff skipOff]
+  simp only [CodeReq.unionAll_cons, CodeReq.unionAll_nil, CodeReq.union_empty_right]
+
+theorem expIterBodyFullMsbSavedBitCode_bit_test_sub {base : Word}
+    {mulOff : BitVec 21} {skipOff backOff : BitVec 13} :
+    ∀ a i, (CodeReq.ofProg base EvmAsm.Evm64.exp_msb_bit_test_block)
+      a = some i →
+      (expIterBodyFullMsbSavedBitCode base mulOff skipOff backOff)
+        a = some i := by
+  rw [expIterBodyFullMsbSavedBitCode_eq_ofProg]
+  exact CodeReq.ofProg_mono_sub base base
+    (EvmAsm.Evm64.exp_iter_body_full_msb_saved_bit mulOff skipOff backOff)
+    EvmAsm.Evm64.exp_msb_bit_test_block 0
+    (by bv_omega)
+    (by
+      unfold EvmAsm.Evm64.exp_iter_body_full_msb_saved_bit
+      simp only [EvmAsm.Rv64.seq]
+      unfold Program
+      rfl)
+    (by
+      simp only [exp_iter_body_full_msb_saved_bit_len, exp_msb_bit_test_block_len]
+      omega)
+    (by
+      simp only [exp_iter_body_full_msb_saved_bit_len]
+      norm_num)
+
+theorem expIterBodyFullMsbSavedBitCode_save_bit_sub {base : Word}
+    {mulOff : BitVec 21} {skipOff backOff : BitVec 13} :
+    ∀ a i, (CodeReq.ofProg (base + 12) EvmAsm.Evm64.exp_save_bit_block)
+      a = some i →
+      (expIterBodyFullMsbSavedBitCode base mulOff skipOff backOff)
+        a = some i := by
+  rw [expIterBodyFullMsbSavedBitCode_eq_ofProg]
+  exact CodeReq.ofProg_mono_sub base (base + 12)
+    (EvmAsm.Evm64.exp_iter_body_full_msb_saved_bit mulOff skipOff backOff)
+    EvmAsm.Evm64.exp_save_bit_block 3
+    (by bv_omega)
+    (by
+      unfold EvmAsm.Evm64.exp_iter_body_full_msb_saved_bit
+      simp only [EvmAsm.Rv64.seq]
+      unfold Program
+      rfl)
+    (by
+      simp only [exp_iter_body_full_msb_saved_bit_len, exp_save_bit_block_len]
+      omega)
+    (by
+      simp only [exp_iter_body_full_msb_saved_bit_len]
+      norm_num)
+
+theorem expIterBodyFullMsbSavedBitCode_squaring_sub {base : Word}
+    {mulOff : BitVec 21} {skipOff backOff : BitVec 13} :
+    ∀ a i, (exp_squaring_call_block_code (base + 16) mulOff) a = some i →
+      (expIterBodyFullMsbSavedBitCode base mulOff skipOff backOff)
+        a = some i := by
+  rw [expIterBodyFullMsbSavedBitCode_eq_ofProg,
+    exp_squaring_call_block_code_eq_ofProg]
+  exact CodeReq.ofProg_mono_sub base (base + 16)
+    (EvmAsm.Evm64.exp_iter_body_full_msb_saved_bit mulOff skipOff backOff)
+    (EvmAsm.Evm64.exp_squaring_call_block mulOff) 4
+    (by bv_omega)
+    (by
+      unfold EvmAsm.Evm64.exp_iter_body_full_msb_saved_bit
+      simp only [EvmAsm.Rv64.seq]
+      unfold Program
+      rfl)
+    (by
+      simp only [exp_iter_body_full_msb_saved_bit_len, exp_squaring_call_block_len]
+      omega)
+    (by
+      simp only [exp_iter_body_full_msb_saved_bit_len]
+      norm_num)
+
+theorem expIterBodyFullMsbSavedBitCode_cond_mul_sub {base : Word}
+    {mulOff : BitVec 21} {skipOff backOff : BitVec 13} :
+    ∀ a i, (EvmAsm.Evm64.exp_cond_mul_call_with_saved_bit_skip_block_code
+      (base + 120) mulOff skipOff) a = some i →
+      (expIterBodyFullMsbSavedBitCode base mulOff skipOff backOff)
+        a = some i := by
+  rw [expIterBodyFullMsbSavedBitCode_eq_ofProg,
+    EvmAsm.Evm64.exp_cond_mul_call_with_saved_bit_skip_block_code_eq_ofProg]
+  exact CodeReq.ofProg_mono_sub base (base + 120)
+    (EvmAsm.Evm64.exp_iter_body_full_msb_saved_bit mulOff skipOff backOff)
+    (EvmAsm.Evm64.exp_cond_mul_call_with_saved_bit_skip_block mulOff skipOff) 30
+    (by bv_omega)
+    (by
+      unfold EvmAsm.Evm64.exp_iter_body_full_msb_saved_bit
+      simp only [EvmAsm.Rv64.seq]
+      unfold Program
+      rfl)
+    (by
+      simp only [exp_iter_body_full_msb_saved_bit_len,
+        exp_cond_mul_call_with_saved_bit_skip_block_len]
+      omega)
+    (by
+      simp only [exp_iter_body_full_msb_saved_bit_len]
+      norm_num)
+
+theorem expIterBodyFullMsbSavedBitCode_loop_back_sub {base : Word}
+    {mulOff : BitVec 21} {skipOff backOff : BitVec 13} :
+    ∀ a i, (CodeReq.ofProg (base + 228)
+      (EvmAsm.Evm64.exp_loop_back backOff)) a = some i →
+      (expIterBodyFullMsbSavedBitCode base mulOff skipOff backOff)
+        a = some i := by
+  rw [expIterBodyFullMsbSavedBitCode_eq_ofProg]
+  exact CodeReq.ofProg_mono_sub base (base + 228)
+    (EvmAsm.Evm64.exp_iter_body_full_msb_saved_bit mulOff skipOff backOff)
+    (EvmAsm.Evm64.exp_loop_back backOff) 57
+    (by bv_omega)
+    (by
+      unfold EvmAsm.Evm64.exp_iter_body_full_msb_saved_bit
+      simp only [EvmAsm.Rv64.seq]
+      unfold Program
+      rfl)
+    (by
+      simp only [exp_iter_body_full_msb_saved_bit_len, exp_loop_back_len]
+      omega)
+    (by
+      simp only [exp_iter_body_full_msb_saved_bit_len]
+      norm_num)
+
+theorem expIterBodyFullMsbSavedBitCode_block_subs {base : Word}
+    {mulOff : BitVec 21} {skipOff backOff : BitVec 13} :
+    (∀ a i, (CodeReq.ofProg base EvmAsm.Evm64.exp_msb_bit_test_block)
+      a = some i →
+      (expIterBodyFullMsbSavedBitCode base mulOff skipOff backOff)
+        a = some i) ∧
+    (∀ a i, (CodeReq.ofProg (base + 12) EvmAsm.Evm64.exp_save_bit_block)
+      a = some i →
+      (expIterBodyFullMsbSavedBitCode base mulOff skipOff backOff)
+        a = some i) ∧
+    (∀ a i, (exp_squaring_call_block_code (base + 16) mulOff) a = some i →
+      (expIterBodyFullMsbSavedBitCode base mulOff skipOff backOff)
+        a = some i) ∧
+    (∀ a i, (EvmAsm.Evm64.exp_cond_mul_call_with_saved_bit_skip_block_code
+      (base + 120) mulOff skipOff) a = some i →
+      (expIterBodyFullMsbSavedBitCode base mulOff skipOff backOff)
+        a = some i) ∧
+    (∀ a i, (CodeReq.ofProg (base + 228)
+      (EvmAsm.Evm64.exp_loop_back backOff)) a = some i →
+      (expIterBodyFullMsbSavedBitCode base mulOff skipOff backOff)
+        a = some i) := by
+  exact ⟨expIterBodyFullMsbSavedBitCode_bit_test_sub,
+    expIterBodyFullMsbSavedBitCode_save_bit_sub,
+    expIterBodyFullMsbSavedBitCode_squaring_sub,
+    expIterBodyFullMsbSavedBitCode_cond_mul_sub,
+    expIterBodyFullMsbSavedBitCode_loop_back_sub⟩
+
+/-- Top-level CodeReq decomposition for the corrected MSB-first saved-bit EXP
+    opcode program. -/
+abbrev evmExpMsbSavedBitCode (base : Word)
+    (mulOff : BitVec 21) (skipOff backOff : BitVec 13) : CodeReq :=
+  CodeReq.unionAll [
+    CodeReq.ofProg base EvmAsm.Evm64.exp_prologue,
+    CodeReq.ofProg (base + 24) EvmAsm.Evm64.exp_loop_pointer_advance,
+    expIterBodyFullMsbSavedBitCode (base + 28) mulOff skipOff backOff,
+    CodeReq.ofProg (base + 264) EvmAsm.Evm64.exp_loop_pointer_restore,
+    CodeReq.ofProg (base + 268) EvmAsm.Evm64.exp_epilogue
+  ]
+
+theorem evmExpMsbSavedBitCode_eq_ofProg (base : Word)
+    (mulOff : BitVec 21) (skipOff backOff : BitVec 13) :
+    evmExpMsbSavedBitCode base mulOff skipOff backOff =
+      CodeReq.ofProg base
+        (EvmAsm.Evm64.evm_exp_msb_saved_bit mulOff skipOff backOff) := by
+  unfold evmExpMsbSavedBitCode
+  unfold EvmAsm.Evm64.evm_exp_msb_saved_bit
+  simp only [EvmAsm.Rv64.seq]
+  unfold Program
+  rw [CodeReq.ofProg_append]
+  have h24 :
+      base + BitVec.ofNat 64 (4 * (EvmAsm.Evm64.exp_prologue).length) =
+        base + 24 := by
+    rw [EvmAsm.Evm64.exp_prologue_length]
+    rfl
+  rw [h24]
+  rw [CodeReq.ofProg_append]
+  have h28 :
+      (base + 24 : Word) + BitVec.ofNat 64 (4 *
+        (EvmAsm.Evm64.exp_loop_pointer_advance).length) = base + 28 := by
+    rw [EvmAsm.Evm64.exp_loop_pointer_advance_length]
+    bv_addr
+  rw [h28]
+  rw [CodeReq.ofProg_append]
+  have h264 :
+      (base + 28 : Word) + BitVec.ofNat 64 (4 *
+        (EvmAsm.Evm64.exp_iter_body_full_msb_saved_bit
+          mulOff skipOff backOff).length) = base + 264 := by
+    rw [EvmAsm.Evm64.exp_iter_body_full_msb_saved_bit_length]
+    bv_addr
+  rw [h264]
+  rw [CodeReq.ofProg_append]
+  have h268 :
+      (base + 264 : Word) + BitVec.ofNat 64 (4 *
+        (EvmAsm.Evm64.exp_loop_pointer_restore).length) = base + 268 := by
+    rw [EvmAsm.Evm64.exp_loop_pointer_restore_length]
+    bv_addr
+  rw [h268]
+  rw [← expIterBodyFullMsbSavedBitCode_eq_ofProg
+    (base + 28) mulOff skipOff backOff]
+  simp only [CodeReq.unionAll_cons, CodeReq.unionAll_nil, CodeReq.union_empty_right]
+
+theorem evmExpMsbSavedBitCode_prologue_sub {base : Word}
+    {mulOff : BitVec 21} {skipOff backOff : BitVec 13} :
+    ∀ a i, (CodeReq.ofProg base EvmAsm.Evm64.exp_prologue) a = some i →
+      (evmExpMsbSavedBitCode base mulOff skipOff backOff) a = some i := by
+  unfold evmExpMsbSavedBitCode
+  simp only [CodeReq.unionAll_cons]
+  exact CodeReq.union_mono_left
+
+theorem evmExpMsbSavedBitCode_pointer_advance_sub {base : Word}
+    {mulOff : BitVec 21} {skipOff backOff : BitVec 13} :
+    ∀ a i, (CodeReq.ofProg (base + 24)
+      EvmAsm.Evm64.exp_loop_pointer_advance) a = some i →
+      (evmExpMsbSavedBitCode base mulOff skipOff backOff) a = some i := by
+  rw [evmExpMsbSavedBitCode_eq_ofProg]
+  exact CodeReq.ofProg_mono_sub base (base + 24)
+    (EvmAsm.Evm64.evm_exp_msb_saved_bit mulOff skipOff backOff)
+    EvmAsm.Evm64.exp_loop_pointer_advance 6
+    (by bv_omega)
+    (by
+      unfold EvmAsm.Evm64.evm_exp_msb_saved_bit
+      simp only [EvmAsm.Rv64.seq]
+      unfold Program
+      rfl)
+    (by
+      simp only [evm_exp_msb_saved_bit_len, exp_loop_pointer_advance_len]
+      omega)
+    (by
+      simp only [evm_exp_msb_saved_bit_len]
+      norm_num)
+
+theorem evmExpMsbSavedBitCode_iter_body_sub {base : Word}
+    {mulOff : BitVec 21} {skipOff backOff : BitVec 13} :
+    ∀ a i, (expIterBodyFullMsbSavedBitCode (base + 28)
+      mulOff skipOff backOff) a = some i →
+      (evmExpMsbSavedBitCode base mulOff skipOff backOff) a = some i := by
+  rw [evmExpMsbSavedBitCode_eq_ofProg,
+    expIterBodyFullMsbSavedBitCode_eq_ofProg]
+  exact CodeReq.ofProg_mono_sub base (base + 28)
+    (EvmAsm.Evm64.evm_exp_msb_saved_bit mulOff skipOff backOff)
+    (EvmAsm.Evm64.exp_iter_body_full_msb_saved_bit mulOff skipOff backOff) 7
+    (by bv_omega)
+    (by
+      unfold EvmAsm.Evm64.evm_exp_msb_saved_bit
+      simp only [EvmAsm.Rv64.seq]
+      unfold Program
+      rfl)
+    (by
+      simp only [evm_exp_msb_saved_bit_len,
+        exp_iter_body_full_msb_saved_bit_len]
+      omega)
+    (by
+      simp only [evm_exp_msb_saved_bit_len]
+      norm_num)
+
+theorem evmExpMsbSavedBitCode_pointer_restore_sub {base : Word}
+    {mulOff : BitVec 21} {skipOff backOff : BitVec 13} :
+    ∀ a i, (CodeReq.ofProg (base + 264)
+      EvmAsm.Evm64.exp_loop_pointer_restore) a = some i →
+      (evmExpMsbSavedBitCode base mulOff skipOff backOff) a = some i := by
+  rw [evmExpMsbSavedBitCode_eq_ofProg]
+  exact CodeReq.ofProg_mono_sub base (base + 264)
+    (EvmAsm.Evm64.evm_exp_msb_saved_bit mulOff skipOff backOff)
+    EvmAsm.Evm64.exp_loop_pointer_restore 66
+    (by bv_omega)
+    (by
+      unfold EvmAsm.Evm64.evm_exp_msb_saved_bit
+      simp only [EvmAsm.Rv64.seq]
+      unfold Program
+      rfl)
+    (by
+      simp only [evm_exp_msb_saved_bit_len, exp_loop_pointer_restore_len]
+      omega)
+    (by
+      simp only [evm_exp_msb_saved_bit_len]
+      norm_num)
+
+theorem evmExpMsbSavedBitCode_epilogue_sub {base : Word}
+    {mulOff : BitVec 21} {skipOff backOff : BitVec 13} :
+    ∀ a i, (CodeReq.ofProg (base + 268) EvmAsm.Evm64.exp_epilogue)
+      a = some i →
+      (evmExpMsbSavedBitCode base mulOff skipOff backOff) a = some i := by
+  rw [evmExpMsbSavedBitCode_eq_ofProg]
+  exact CodeReq.ofProg_mono_sub base (base + 268)
+    (EvmAsm.Evm64.evm_exp_msb_saved_bit mulOff skipOff backOff)
+    EvmAsm.Evm64.exp_epilogue 67
+    (by bv_omega)
+    (by
+      unfold EvmAsm.Evm64.evm_exp_msb_saved_bit
+      simp only [EvmAsm.Rv64.seq]
+      unfold Program
+      rfl)
+    (by
+      simp only [evm_exp_msb_saved_bit_len, exp_epilogue_len]
+      omega)
+    (by
+      simp only [evm_exp_msb_saved_bit_len]
+      norm_num)
+
+theorem evmExpMsbSavedBitCode_block_subs {base : Word}
+    {mulOff : BitVec 21} {skipOff backOff : BitVec 13} :
+    (∀ a i, (CodeReq.ofProg base EvmAsm.Evm64.exp_prologue) a = some i →
+      (evmExpMsbSavedBitCode base mulOff skipOff backOff) a = some i) ∧
+    (∀ a i, (CodeReq.ofProg (base + 24)
+      EvmAsm.Evm64.exp_loop_pointer_advance) a = some i →
+      (evmExpMsbSavedBitCode base mulOff skipOff backOff) a = some i) ∧
+    (∀ a i, (expIterBodyFullMsbSavedBitCode (base + 28)
+      mulOff skipOff backOff) a = some i →
+      (evmExpMsbSavedBitCode base mulOff skipOff backOff) a = some i) ∧
+    (∀ a i, (CodeReq.ofProg (base + 264)
+      EvmAsm.Evm64.exp_loop_pointer_restore) a = some i →
+      (evmExpMsbSavedBitCode base mulOff skipOff backOff) a = some i) ∧
+    (∀ a i, (CodeReq.ofProg (base + 268) EvmAsm.Evm64.exp_epilogue)
+      a = some i →
+      (evmExpMsbSavedBitCode base mulOff skipOff backOff) a = some i) := by
+  exact ⟨evmExpMsbSavedBitCode_prologue_sub,
+    evmExpMsbSavedBitCode_pointer_advance_sub,
+    evmExpMsbSavedBitCode_iter_body_sub,
+    evmExpMsbSavedBitCode_pointer_restore_sub,
+    evmExpMsbSavedBitCode_epilogue_sub⟩
+
+end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/TopCodeSpecs.lean
+++ b/EvmAsm/Evm64/Exp/Compose/TopCodeSpecs.lean
@@ -5,6 +5,7 @@
   keep the base composition module under the Compose file-size guardrail.
 -/
 
+import EvmAsm.Evm64.Exp.Compose.SavedBitBase
 import EvmAsm.Evm64.Exp.Compose.TopCodeSubs
 import EvmAsm.Evm64.Exp.CondMulMarshalPair
 import EvmAsm.Evm64.Exp.SquaringCallSeq
@@ -120,6 +121,80 @@ theorem evmExpCode_iter_cond_mul_sub {base : Word}
   rw [haddr] at h
   exact evmExpCode_iter_body_sub a i (expIterBodyFullCode_cond_mul_sub a i h)
 
+/-- MSB bit-test sub-block directly included in the corrected saved-bit
+    top-level EXP code bundle. -/
+theorem evmExpMsbSavedBitCode_iter_bit_test_sub {base : Word}
+    {mulOff : BitVec 21} {skipOff backOff : BitVec 13} :
+    ∀ a i, (CodeReq.ofProg (base + 28) EvmAsm.Evm64.exp_msb_bit_test_block)
+      a = some i →
+      (evmExpMsbSavedBitCode base mulOff skipOff backOff) a = some i := by
+  intro a i h
+  exact evmExpMsbSavedBitCode_iter_body_sub a i
+    (expIterBodyFullMsbSavedBitCode_bit_test_sub a i h)
+
+/-- Save-bit sub-block directly included in the corrected saved-bit top-level
+    EXP code bundle. -/
+theorem evmExpMsbSavedBitCode_iter_save_bit_sub {base : Word}
+    {mulOff : BitVec 21} {skipOff backOff : BitVec 13} :
+    ∀ a i, (CodeReq.ofProg (base + 40) EvmAsm.Evm64.exp_save_bit_block)
+      a = some i →
+      (evmExpMsbSavedBitCode base mulOff skipOff backOff) a = some i := by
+  intro a i h
+  have haddr : (base + 40 : Word) = base + 28 + 12 := by bv_omega
+  rw [haddr] at h
+  exact evmExpMsbSavedBitCode_iter_body_sub a i
+    (expIterBodyFullMsbSavedBitCode_save_bit_sub a i h)
+
+/-- Squaring-call sub-block directly included in the corrected saved-bit
+    top-level EXP code bundle. -/
+theorem evmExpMsbSavedBitCode_iter_squaring_sub {base : Word}
+    {mulOff : BitVec 21} {skipOff backOff : BitVec 13} :
+    ∀ a i, (exp_squaring_call_block_code (base + 44) mulOff) a = some i →
+      (evmExpMsbSavedBitCode base mulOff skipOff backOff) a = some i := by
+  intro a i h
+  have haddr : (base + 44 : Word) = base + 28 + 16 := by bv_omega
+  rw [haddr] at h
+  exact evmExpMsbSavedBitCode_iter_body_sub a i
+    (expIterBodyFullMsbSavedBitCode_squaring_sub a i h)
+
+/-- Saved-bit conditional-multiply sub-block directly included in the
+    corrected saved-bit top-level EXP code bundle. -/
+theorem evmExpMsbSavedBitCode_iter_cond_mul_sub {base : Word}
+    {mulOff : BitVec 21} {skipOff backOff : BitVec 13} :
+    ∀ a i, (EvmAsm.Evm64.exp_cond_mul_call_with_saved_bit_skip_block_code
+      (base + 148) mulOff skipOff) a = some i →
+      (evmExpMsbSavedBitCode base mulOff skipOff backOff) a = some i := by
+  intro a i h
+  have haddr : (base + 148 : Word) = base + 28 + 120 := by bv_omega
+  rw [haddr] at h
+  exact evmExpMsbSavedBitCode_iter_body_sub a i
+    (expIterBodyFullMsbSavedBitCode_cond_mul_sub a i h)
+
+/-- Saved-bit loop-back sub-block directly included in the corrected saved-bit
+    top-level EXP code bundle. -/
+theorem evmExpMsbSavedBitCode_iter_loop_back_sub {base : Word}
+    {mulOff : BitVec 21} {skipOff backOff : BitVec 13} :
+    ∀ a i, (CodeReq.ofProg (base + 256)
+      (EvmAsm.Evm64.exp_loop_back backOff)) a = some i →
+      (evmExpMsbSavedBitCode base mulOff skipOff backOff) a = some i := by
+  intro a i h
+  have haddr : (base + 256 : Word) = base + 28 + 228 := by bv_omega
+  rw [haddr] at h
+  exact evmExpMsbSavedBitCode_iter_body_sub a i
+    (expIterBodyFullMsbSavedBitCode_loop_back_sub a i h)
+
+/-- Saved-bit conditional-multiply BEQ skip-gate directly included in the
+    corrected saved-bit top-level EXP code bundle. -/
+theorem evmExpMsbSavedBitCode_cond_mul_beq_sub {base : Word}
+    {mulOff : BitVec 21} {skipOff backOff : BitVec 13} :
+    ∀ a i, (CodeReq.singleton (base + 148) (.BEQ .x18 .x0 skipOff))
+      a = some i →
+      (evmExpMsbSavedBitCode base mulOff skipOff backOff) a = some i := by
+  intro a i h
+  exact evmExpMsbSavedBitCode_iter_cond_mul_sub a i
+    (EvmAsm.Evm64.exp_cond_mul_call_with_saved_bit_skip_block_code_beq_sub
+      (base + 148) mulOff skipOff a i h)
+
 /-- Loop-back sub-block directly included in the top-level EXP code bundle. -/
 theorem evmExpCode_iter_loop_back_sub {base : Word}
     {mulOff : BitVec 21} {skipOff backOff : BitVec 13} :
@@ -145,6 +220,38 @@ theorem exp_bit_test_evm_exp_spec_within
   have hnext : ((base + 28 : Word) + 12) = base + 40 := by bv_omega
   rw [hnext] at h
   exact cpsTripleWithin_extend_code (h := h) (hmono := evmExpCode_iter_bit_test_sub)
+
+/-- MSB bit-test block lifted to the corrected saved-bit top-level EXP code
+    bundle. -/
+theorem exp_msb_bit_test_evm_exp_msb_saved_bit_spec_within
+    (e c v10 : Word) (mulOff : BitVec 21) (skipOff backOff : BitVec 13)
+    (base : Word) :
+    cpsTripleWithin 3 (base + 28) (base + 40)
+      (evmExpMsbSavedBitCode base mulOff skipOff backOff)
+      ((.x5 ↦ᵣ e) ** (.x6 ↦ᵣ c) ** (.x10 ↦ᵣ v10))
+      ((.x5 ↦ᵣ (e <<< (1 : BitVec 6).toNat)) **
+       (.x6 ↦ᵣ (c + signExtend12 ((-1) : BitVec 12))) **
+       (.x10 ↦ᵣ (e >>> (63 : BitVec 6).toNat))) := by
+  have h := EvmAsm.Evm64.exp_msb_bit_test_block_spec_within e c v10 (base + 28)
+  have hnext : ((base + 28 : Word) + 12) = base + 40 := by bv_omega
+  rw [hnext] at h
+  exact cpsTripleWithin_extend_code (h := h)
+    (hmono := evmExpMsbSavedBitCode_iter_bit_test_sub)
+
+/-- Save-bit block lifted to the corrected saved-bit top-level EXP code
+    bundle. -/
+theorem exp_save_bit_evm_exp_msb_saved_bit_spec_within
+    (bit v18 : Word) (mulOff : BitVec 21) (skipOff backOff : BitVec 13)
+    (base : Word) :
+    cpsTripleWithin 1 (base + 40) (base + 44)
+      (evmExpMsbSavedBitCode base mulOff skipOff backOff)
+      ((.x10 ↦ᵣ bit) ** (.x18 ↦ᵣ v18))
+      ((.x10 ↦ᵣ bit) ** (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12)))) := by
+  have h := EvmAsm.Evm64.exp_save_bit_block_spec_within bit v18 (base + 40)
+  have hnext : ((base + 40 : Word) + 4) = base + 44 := by bv_omega
+  rw [hnext] at h
+  exact cpsTripleWithin_extend_code (h := h)
+    (hmono := evmExpMsbSavedBitCode_iter_save_bit_sub)
 
 /-- Loop-back block lifted to the top-level EXP code bundle. -/
 theorem exp_loop_back_evm_exp_spec_within (c : Word)
@@ -543,6 +650,27 @@ theorem exp_cond_mul_beq_evm_exp_spec_within
   rw [hnext] at h
   exact cpsBranchWithin_extend_code (h := h)
     (hmono := evmExpCode_cond_mul_beq_sub)
+
+/-- Saved-bit conditional-multiply BEQ skip-gate spec lifted to the corrected
+    saved-bit top-level EXP code bundle: at offset `base + 148`, branches on
+    `x18 == 0` to the cond-mul skip target, otherwise falls through to
+    `base + 152` (the cond-mul taken block). -/
+theorem exp_cond_mul_saved_bit_beq_evm_exp_msb_saved_bit_spec_within
+    (mulOff : BitVec 21) (skipOff backOff : BitVec 13)
+    (v18 : Word) (base target : Word)
+    (htarget : (base + 148 : Word) + signExtend13 skipOff = target) :
+    cpsBranchWithin 1 (base + 148)
+      (evmExpMsbSavedBitCode base mulOff skipOff backOff)
+      ((.x18 ↦ᵣ v18) ** (.x0 ↦ᵣ (0 : Word)))
+      target ((.x18 ↦ᵣ v18) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜v18 = 0⌝)
+      (base + 152) ((.x18 ↦ᵣ v18) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜v18 ≠ 0⌝) := by
+  have h := EvmAsm.Rv64.beq_spec_within .x18 .x0 skipOff v18 (0 : Word)
+    (base + 148)
+  rw [htarget] at h
+  have hnext : ((base + 148 : Word) + 4) = base + 152 := by bv_omega
+  rw [hnext] at h
+  exact cpsBranchWithin_extend_code (h := h)
+    (hmono := evmExpMsbSavedBitCode_cond_mul_beq_sub)
 
 
 /-- Squaring-call marshal prefix and JAL lifted to the top-level EXP code bundle. -/

--- a/EvmAsm/Evm64/Exp/CondMulCall.lean
+++ b/EvmAsm/Evm64/Exp/CondMulCall.lean
@@ -213,4 +213,80 @@ theorem exp_cond_mul_call_with_skip_block_code_block_subs
   exact ⟨exp_cond_mul_call_with_skip_block_code_beq_sub base mulOff skipOff,
     exp_cond_mul_call_with_skip_block_code_call_sub base mulOff skipOff⟩
 
+/-- CodeReq decomposition for the conditional-multiply step with its leading
+    BEQ skip gate, branching on the saved bit in `x18`. The BEQ lives at
+    `base`; the taken call block starts at `base + 4` and is skipped when
+    the saved exponent bit is zero. -/
+abbrev exp_cond_mul_call_with_saved_bit_skip_block_code
+    (base : Word) (mulOff : BitVec 21) (skipOff : BitVec 13) : CodeReq :=
+  CodeReq.unionAll [
+    CodeReq.singleton base (.BEQ .x18 .x0 skipOff),
+    exp_cond_mul_call_block_code (base + 4) mulOff
+  ]
+
+theorem exp_cond_mul_call_with_saved_bit_skip_block_code_eq_ofProg
+    (base : Word) (mulOff : BitVec 21) (skipOff : BitVec 13) :
+    exp_cond_mul_call_with_saved_bit_skip_block_code base mulOff skipOff =
+      CodeReq.ofProg base
+        (exp_cond_mul_call_with_saved_bit_skip_block mulOff skipOff) := by
+  unfold exp_cond_mul_call_with_saved_bit_skip_block_code
+  unfold exp_cond_mul_call_with_saved_bit_skip_block
+  simp only [CodeReq.unionAll_cons, CodeReq.unionAll_nil,
+    CodeReq.union_empty_right]
+  unfold single seq Program
+  symm
+  rw [CodeReq.ofProg_append]
+  rw [show base + BitVec.ofNat 64 (4 * [Instr.BEQ .x18 .x0 skipOff].length) =
+      base + 4 by rfl]
+  rw [CodeReq.ofProg_singleton]
+  rw [← exp_cond_mul_call_block_code_eq_ofProg (base + 4) mulOff]
+  unfold exp_cond_mul_call_block_code
+  simp only [CodeReq.unionAll_cons, CodeReq.unionAll_nil, CodeReq.union_empty_right]
+
+theorem exp_cond_mul_call_with_saved_bit_skip_block_code_beq_sub
+    (base : Word) (mulOff : BitVec 21) (skipOff : BitVec 13) :
+    ∀ a i, (CodeReq.singleton base (.BEQ .x18 .x0 skipOff)) a = some i →
+      (exp_cond_mul_call_with_saved_bit_skip_block_code base mulOff skipOff)
+        a = some i := by
+  unfold exp_cond_mul_call_with_saved_bit_skip_block_code
+  simp only [CodeReq.unionAll_cons]
+  exact CodeReq.union_mono_left
+
+theorem exp_cond_mul_call_with_saved_bit_skip_block_code_call_sub
+    (base : Word) (mulOff : BitVec 21) (skipOff : BitVec 13) :
+    ∀ a i, (exp_cond_mul_call_block_code (base + 4) mulOff) a = some i →
+      (exp_cond_mul_call_with_saved_bit_skip_block_code base mulOff skipOff)
+        a = some i := by
+  rw [exp_cond_mul_call_with_saved_bit_skip_block_code_eq_ofProg,
+    exp_cond_mul_call_block_code_eq_ofProg]
+  exact CodeReq.ofProg_mono_sub base (base + 4)
+    (exp_cond_mul_call_with_saved_bit_skip_block mulOff skipOff)
+    (exp_cond_mul_call_block mulOff) 1
+    (by bv_omega)
+    (by
+      unfold exp_cond_mul_call_with_saved_bit_skip_block single
+      simp only [seq]
+      unfold Program
+      rfl)
+    (by
+      simp only [exp_cond_mul_call_with_saved_bit_skip_block_length,
+        exp_cond_mul_call_block_length]
+      omega)
+    (by
+      simp only [exp_cond_mul_call_with_saved_bit_skip_block_length]
+      norm_num)
+
+theorem exp_cond_mul_call_with_saved_bit_skip_block_code_block_subs
+    (base : Word) (mulOff : BitVec 21) (skipOff : BitVec 13) :
+    (∀ a i, (CodeReq.singleton base (.BEQ .x18 .x0 skipOff)) a = some i →
+      (exp_cond_mul_call_with_saved_bit_skip_block_code base mulOff skipOff)
+        a = some i) ∧
+    (∀ a i, (exp_cond_mul_call_block_code (base + 4) mulOff) a = some i →
+      (exp_cond_mul_call_with_saved_bit_skip_block_code base mulOff skipOff)
+        a = some i) := by
+  exact ⟨exp_cond_mul_call_with_saved_bit_skip_block_code_beq_sub
+      base mulOff skipOff,
+    exp_cond_mul_call_with_saved_bit_skip_block_code_call_sub
+      base mulOff skipOff⟩
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add CodeReq decomposition for the saved-bit conditional multiply skip block (BEQ x18)
- add EvmAsm.Evm64.Exp.Compose.SavedBitBase for the corrected MSB-first saved-bit iteration and top-level code bundles
- lift MSB bit-test, save-bit, and saved-bit BEQ specs into the corrected top-level EXP code bundle

## Verification
- lake build EvmAsm.Evm64.Exp.Compose.TopCodeSpecs
- scripts/check-file-size.sh
- git diff --check
- marker scan for sorry/admit/placeholder and forbidden local options in touched files
- lake build
- scripts/check-unimported.sh

Progresses bead evm-asm-kncg7 by moving the single-iteration EXP composition target onto the saved-bit x18 layout instead of the old clobbered x10 branch condition.