### PR TITLE
fix(sdiv): prove divcall dispatch-ready prefix

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/Bridges.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/Bridges.lean
@@ -110,4 +110,54 @@ theorem divModStackDispatchPre_unfold_explicit
   rw [EvmAsm.Evm64.divModStackDispatchPre_unfold,
       evmWordIs_sp_unfold, evmWordIs_sp32_unfold]
 
+/-- SDIV-offset-shaped version of `divModStackDispatchPre_unfold_explicit`.
+    It keeps the stack slots in the same `sp + signExtend12 ...` form produced
+    by the SDIV wrapper postcondition, avoiding a separate address
+    normalization step before `xperm_hyp`. -/
+theorem divModStackDispatchPre_unfold_explicit_sdiv
+    {sp : Word} {a b : EvmWord}
+    {v1 v2 v5 v6 v7 v10 v11 : Word}
+    {q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem
+     retMem dMem dloMem scratch_un0 : Word} :
+    EvmAsm.Evm64.divModStackDispatchPre sp a b v1 v2 v5 v6 v7 v10 v11
+      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem
+      retMem dMem dloMem scratch_un0 =
+    ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ v1) ** (.x2 ↦ᵣ v2) **
+     (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+     (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) ** (.x0 ↦ᵣ (0 : Word)) **
+     (((sp + signExtend12 (0 : BitVec 12)) ↦ₘ a.getLimbN 0) **
+      ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ a.getLimbN 1) **
+      ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ a.getLimbN 2) **
+      ((sp + signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ
+        a.getLimbN 3)) **
+     (((sp + signExtend12 (32 : BitVec 12)) ↦ₘ b.getLimbN 0) **
+      ((sp + signExtend12 (40 : BitVec 12)) ↦ₘ b.getLimbN 1) **
+      ((sp + signExtend12 (48 : BitVec 12)) ↦ₘ b.getLimbN 2) **
+      ((sp + signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff) ↦ₘ
+        b.getLimbN 3)) **
+    EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+       shiftMem nMem jMem retMem dMem dloMem scratch_un0) := by
+  rw [divModStackDispatchPre_unfold_explicit]
+  rw [show (sp + signExtend12 (0 : BitVec 12)) = sp by
+    rw [show signExtend12 (0 : BitVec 12) = (0 : Word) by decide]
+    simp]
+  rw [show (sp + signExtend12 (8 : BitVec 12)) = sp + 8 by
+    rw [show signExtend12 (8 : BitVec 12) = (8 : Word) by decide]]
+  rw [show (sp + signExtend12 (16 : BitVec 12)) = sp + 16 by
+    rw [show signExtend12 (16 : BitVec 12) = (16 : Word) by decide]]
+  rw [show (sp + signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) =
+      sp + 24 by
+    unfold EvmAsm.Evm64.evm_sdivDividendTopLimbOff
+    rw [show signExtend12 (24 : BitVec 12) = (24 : Word) by decide]]
+  rw [show (sp + signExtend12 (32 : BitVec 12)) = sp + 32 by
+    rw [show signExtend12 (32 : BitVec 12) = (32 : Word) by decide]]
+  rw [show (sp + signExtend12 (40 : BitVec 12)) = sp + 40 by
+    rw [show signExtend12 (40 : BitVec 12) = (40 : Word) by decide]]
+  rw [show (sp + signExtend12 (48 : BitVec 12)) = sp + 48 by
+    rw [show signExtend12 (48 : BitVec 12) = (48 : Word) by decide]]
+  rw [show (sp + signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff) =
+      sp + 56 by
+    unfold EvmAsm.Evm64.evm_sdivDivisorTopLimbOff
+    rw [show signExtend12 (56 : BitVec 12) = (56 : Word) by decide]]
+
 end EvmAsm.Evm64.SDiv.Compose

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallDispatch.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallDispatch.lean
@@ -18,6 +18,7 @@ import EvmAsm.Evm64.SDiv.Compose.Bridges
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
+open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
 /-- Post-shape consumed by `evm_div_callable_spec_in_sdivCode`: the
@@ -113,5 +114,47 @@ theorem saveRaDivCallDispatchReadyPost_unfold
          ((.x8 ↦ᵣ resultSign) ** (.x9 ↦ᵣ divisorSign) **
           (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12))))) := by
   delta saveRaDivCallDispatchReadyPost; rfl
+
+/-- Prefix through the SDIV `divCall`, weakened to the exact dispatch-ready
+    postcondition consumed by `evm_div_callable_spec_in_sdivCode`. -/
+theorem saveRa_signs_abs_signXor_then_divCall_dispatchReady_spec_in_sdivCode
+    (vRa vSavedOld sp sDividendOld sDivisorOld
+      dividendMaskOld dividendValueOld dividendCarryOld
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+      v2 v5 v6 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (base : Word) :
+    cpsTripleWithin 49 base
+      ((base + divCallOff) + signExtend21 EvmAsm.Evm64.evm_sdivCallOff)
+      (sdivCode base)
+      (saveRaSignsAbsSignXorThenDivCallPre vRa vSavedOld sp sDividendOld sDivisorOld
+        dividendMaskOld dividendValueOld dividendCarryOld
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
+       ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
+        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0))
+      (saveRaDivCallDispatchReadyPost vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+        v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0) := by
+  have hPrefix :=
+    saveRa_signs_abs_signXor_then_divCall_framed_for_dispatch_spec_in_sdivCode
+      vRa vSavedOld sp sDividendOld sDivisorOld
+      dividendMaskOld dividendValueOld dividendCarryOld
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+      v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 base
+  exact cpsTripleWithin_weaken (fun _ hp => hp) (fun h hq => by
+    rw [saveRaSignsAbsSignXorThenDivCallPost_unfold] at hq
+    rw [saveRaDivCallDispatchReadyPost_unfold]
+    dsimp only at hq ⊢
+    rw [divModStackDispatchPre_unfold_explicit_sdiv]
+    simp [EvmWord.getLimbN, EvmWord.getLimb_fromLimbs] at hq ⊢
+    xperm_hyp hq) hPrefix
 
 end EvmAsm.Evm64.SDiv.Compose


### PR DESCRIPTION
## Summary
- add an SDIV-offset-shaped explicit unfold for divModStackDispatchPre
- prove saveRa_signs_abs_signXor_then_divCall_dispatchReady_spec_in_sdivCode
- use the explicit SDIV-shaped unfold plus xperm_hyp to bridge the framed divCall post into saveRaDivCallDispatchReadyPost

## Verification
- lake build EvmAsm.Evm64.SDiv.Compose.DivCallDispatch
- scripts/check-file-size.sh
- git diff --check
- marker scan for sorry/admit/placeholder and forbidden local options in touched files
- lake build
- scripts/check-unimported.sh

Closes bead evm-asm-j8bfz once merged to main.