### PR TITLE
fix(exp): branch after saved-bit squaring

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFullLoop.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFullLoop.lean
@@ -312,6 +312,98 @@ theorem exp_msb_saved_bit_prefix_then_squaring_call_evm_exp_msb_saved_bit_with_m
     (fun _ hp => by xperm_hyp hp)
     hSeq
 
+/-- Prefix plus squaring side followed by the saved-bit BEQ.  This is the
+    branch handoff immediately before the optional conditional multiply. -/
+theorem exp_msb_saved_bit_prefix_squaring_then_beq_evm_exp_msb_saved_bit_with_mul_spec_within
+    (e c v10 v18 sp evmSp vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+      v7 v11 mulTarget : Word)
+    (mulOff : BitVec 21) (skipOff backOff : BitVec 13) (base target : Word)
+    (hbase : base &&& 1 = 0)
+    (hmt : mulTarget = ((base + 44) + 64) + signExtend21 mulOff)
+    (hd : CodeReq.Disjoint
+            (evmExpMsbSavedBitCode base mulOff skipOff backOff)
+            (mul_callable_code mulTarget))
+    (htarget : (base + 148 : Word) + signExtend13 skipOff = target) :
+    let bit := e >>> (63 : BitVec 6).toNat
+    let w := expResultWord r0 r1 r2 r3
+    cpsBranchWithin (3 + 1 + (17 + 64 + 9) + 1) (base + 28)
+      (evmExpMsbSavedBitWithMulCode base mulTarget mulOff skipOff backOff)
+      ((.x5 ↦ᵣ e) ** (.x6 ↦ᵣ c) ** (.x10 ↦ᵣ v10) ** (.x18 ↦ᵣ v18) **
+       (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+       ((evmSp + signExtend12 (0 : BitVec 12)) ↦ₘ d0) **
+       ((evmSp + signExtend12 (8 : BitVec 12)) ↦ₘ d1) **
+       ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ d2) **
+       ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ d3) **
+       ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ e0) **
+       ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ e1) **
+       ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ e2) **
+       ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ e3) **
+       (.x7 ↦ᵣ v7) ** (.x11 ↦ᵣ v11) ** (.x1 ↦ᵣ vOld) **
+       (.x0 ↦ᵣ (0 : Word)))
+      target
+        ((.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
+         (.x0 ↦ᵣ (0 : Word)) ** ⌜bit + signExtend12 (0 : BitVec 12) = 0⌝ **
+         (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) **
+         (.x5 ↦ᵣ (w * w).getLimbN 3) **
+         evmWordIs sp (w * w) ** evmWordIs (evmSp + 32) (w * w) **
+         regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
+         memOwn evmSp ** memOwn (evmSp + 8) **
+         memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
+         (.x1 ↦ᵣ ((base + 44) + 68)))
+      (base + 152)
+        ((.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
+         (.x0 ↦ᵣ (0 : Word)) ** ⌜bit + signExtend12 (0 : BitVec 12) ≠ 0⌝ **
+         (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) **
+         (.x5 ↦ᵣ (w * w).getLimbN 3) **
+         evmWordIs sp (w * w) ** evmWordIs (evmSp + 32) (w * w) **
+         regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
+         memOwn evmSp ** memOwn (evmSp + 8) **
+         memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
+         (.x1 ↦ᵣ ((base + 44) + 68))) := by
+  intro bit w
+  let rest : Assertion :=
+    (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) **
+    (.x5 ↦ᵣ (w * w).getLimbN 3) **
+    evmWordIs sp (w * w) ** evmWordIs (evmSp + 32) (w * w) **
+    regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
+    memOwn evmSp ** memOwn (evmSp + 8) **
+    memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
+    (.x1 ↦ᵣ ((base + 44) + 68))
+  have hPrefixSquare :=
+    exp_msb_saved_bit_prefix_then_squaring_call_evm_exp_msb_saved_bit_with_mul_spec_within
+      e c v10 v18 sp evmSp vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+      v7 v11 mulTarget mulOff skipOff backOff base hbase hmt hd
+  have hPrefixSquareFramed :=
+    cpsTripleWithin_frameR (.x0 ↦ᵣ (0 : Word)) (by pcFree) hPrefixSquare
+  have hBeq := exp_cond_mul_saved_bit_beq_evm_exp_msb_saved_bit_with_mul_spec_within
+    mulOff skipOff backOff (bit + signExtend12 (0 : BitVec 12))
+    base mulTarget target htarget
+  have hBeqFramed := cpsBranchWithin_frameR rest (by
+    dsimp [rest]
+    pcFree) hBeq
+  have hSeq :
+      cpsBranchWithin (3 + 1 + (17 + 64 + 9) + 1) (base + 28)
+        (evmExpMsbSavedBitWithMulCode base mulTarget mulOff skipOff backOff)
+        _ target _ (base + 152) _ :=
+    cpsTripleWithin_seq_cpsBranchWithin_perm_same_cr
+      (fun _ hp => by
+        dsimp [rest, bit] at hp ⊢
+        xperm_hyp hp)
+      hPrefixSquareFramed hBeqFramed
+  exact cpsBranchWithin_weaken
+    (fun _ hp => by xperm_hyp hp)
+    (fun _ hp => by
+      dsimp [rest] at hp ⊢
+      xperm_hyp hp)
+    (fun _ hp => by
+      dsimp [rest] at hp ⊢
+      xperm_hyp hp)
+    hSeq
+
 /-- Conditional-multiply taken call-block lifted to the corrected saved-bit
     EXP+MUL code bundle.  The leading BEQ is handled separately; this theorem
     starts at the taken block `base + 152` and exits at `base + 256`. -/


### PR DESCRIPTION
Stacked on #3690.

Summary:
- add the saved-bit branch handoff theorem after the prefix and full squaring call-block
- preserve x18 across squaring and compose the saved-bit BEQ, splitting into skip and taken conditional-multiply paths

Verification:
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitFullLoop
- scripts/check-file-size.sh EvmAsm/Evm64/Exp/Compose/SavedBitFullLoop.lean
- rg -n forbidden marker scan on touched file
- git diff --check
- lake build
- scripts/check-unimported.sh