### PR TITLE
fix(exp): preserve base frame through skip path

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFullLoop.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFullLoop.lean
@@ -514,6 +514,87 @@ theorem exp_msb_saved_bit_prefix_squaring_beq_skip_then_loop_back_evm_exp_msb_sa
       (fun _ hp => by xperm_hyp hp) hSeq
   exact hSeqPre
 
+/-- Frame-preserving variant of the zero-bit skip path that carries the saved
+    base operand window needed by the conditional-multiply handoff. -/
+theorem exp_msb_saved_bit_prefix_squaring_beq_skip_then_loop_back_with_base_frame_evm_exp_msb_saved_bit_with_mul_spec_within
+    (e c iterCount v10 v18 sp evmSp vOld r0 r1 r2 r3 d0 d1 d2 d3
+      e0 e1 e2 e3 a0 a1 a2 a3 v7 v11 mulTarget : Word)
+    (mulOff : BitVec 21) (skipOff backOff : BitVec 13)
+    (base loopTarget : Word)
+    (hbase : base &&& 1 = 0)
+    (hmt : mulTarget = ((base + 44) + 64) + signExtend21 mulOff)
+    (hd : CodeReq.Disjoint
+            (evmExpMsbSavedBitCode base mulOff skipOff backOff)
+            (mul_callable_code mulTarget))
+    (hskip : (base + 148 : Word) + signExtend13 skipOff = base + 256)
+    (hback : ((base + 256) + 4 : Word) + signExtend13 backOff = loopTarget) :
+    let bit := e >>> (63 : BitVec 6).toNat
+    let w := expResultWord r0 r1 r2 r3
+    let iterCountNew := iterCount + signExtend12 ((-1 : BitVec 12))
+    let baseFrame : Assertion :=
+      ((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
+      ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **
+      ((evmSp + signExtend12 ((-48) : BitVec 12)) ↦ₘ a2) **
+      ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3)
+    let rest : Assertion :=
+      (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
+      ⌜bit + signExtend12 (0 : BitVec 12) = 0⌝ **
+      (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) **
+      (.x5 ↦ᵣ (w * w).getLimbN 3) **
+      evmWordIs sp (w * w) ** evmWordIs (evmSp + 32) (w * w) **
+      regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
+      memOwn evmSp ** memOwn (evmSp + 8) **
+      memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
+      (.x1 ↦ᵣ ((base + 44) + 68))
+    cpsNBranchWithin ((3 + 1 + (17 + 64 + 9) + 1) + 2) (base + 28)
+      (evmExpMsbSavedBitWithMulCode base mulTarget mulOff skipOff backOff)
+      (((.x5 ↦ᵣ e) ** (.x6 ↦ᵣ c) ** (.x10 ↦ᵣ v10) ** (.x18 ↦ᵣ v18) **
+        (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) **
+        ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+        ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+        ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+        ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+        ((evmSp + signExtend12 (0 : BitVec 12)) ↦ₘ d0) **
+        ((evmSp + signExtend12 (8 : BitVec 12)) ↦ₘ d1) **
+        ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ d2) **
+        ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ d3) **
+        ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ e0) **
+        ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ e1) **
+        ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ e2) **
+        ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ e3) **
+        (.x7 ↦ᵣ v7) ** (.x11 ↦ᵣ v11) ** (.x1 ↦ᵣ vOld) **
+        (.x0 ↦ᵣ (0 : Word)) ** (.x9 ↦ᵣ iterCount)) ** baseFrame)
+      [((base + 152),
+          (((.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
+           (.x0 ↦ᵣ (0 : Word)) ** ⌜bit + signExtend12 (0 : BitVec 12) ≠ 0⌝ **
+           (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) **
+           (.x5 ↦ᵣ (w * w).getLimbN 3) **
+           evmWordIs sp (w * w) ** evmWordIs (evmSp + 32) (w * w) **
+           regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
+           memOwn evmSp ** memOwn (evmSp + 8) **
+           memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
+           (.x1 ↦ᵣ ((base + 44) + 68))) ** (.x9 ↦ᵣ iterCount)) ** baseFrame),
+        (loopTarget,
+          ((((.x9 ↦ᵣ iterCountNew) ** (.x0 ↦ᵣ (0 : Word)) **
+           ⌜iterCountNew ≠ 0⌝) ** rest) ** baseFrame)),
+        (base + 264,
+          ((((.x9 ↦ᵣ iterCountNew) ** (.x0 ↦ᵣ (0 : Word)) **
+           ⌜iterCountNew = 0⌝) ** rest) ** baseFrame))] := by
+  intro bit w iterCountNew baseFrame rest
+  have h :=
+    exp_msb_saved_bit_prefix_squaring_beq_skip_then_loop_back_evm_exp_msb_saved_bit_with_mul_spec_within
+      e c iterCount v10 v18 sp evmSp vOld r0 r1 r2 r3 d0 d1 d2 d3
+      e0 e1 e2 e3 v7 v11 mulTarget mulOff skipOff backOff base loopTarget
+      hbase hmt hd hskip hback
+  have hBaseFramePcFree : baseFrame.pcFree := by
+    dsimp only [baseFrame]
+    exact pcFree_sepConj pcFree_memIs
+      (pcFree_sepConj pcFree_memIs
+        (pcFree_sepConj pcFree_memIs pcFree_memIs))
+  have hf := cpsNBranchWithin_frameR hBaseFramePcFree h
+  exact cpsNBranchWithin_weaken_pre
+    (fun _ hp => by xperm_hyp hp) hf
+
 /-- Conditional-multiply taken call-block lifted to the corrected saved-bit
     EXP+MUL code bundle.  The leading BEQ is handled separately; this theorem
     starts at the taken block `base + 152` and exits at `base + 256`. -/


### PR DESCRIPTION
Stacked on #3692.\n\n## Summary\n- adds a base-frame preserving variant of the saved-bit zero-branch skip/loop-back composition\n- carries the saved base operand window at evmSp[-64..-40] through the nonzero conditional-multiply handoff and loop-back exits\n- uses a direct pcFree proof for the four-cell frame to avoid expensive automation\n\n## Verification\n- lake build EvmAsm.Evm64.Exp.Compose.SavedBitFullLoop\n- scripts/check-file-size.sh EvmAsm/Evm64/Exp/Compose/SavedBitFullLoop.lean\n- rg -n "sorry|admit|placeholder|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/Compose/SavedBitFullLoop.lean\n- git diff --check\n- lake build\n- scripts/check-unimported.sh