### PR TITLE
fix(sdiv): pin div call return alignment

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/Base.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/Base.lean
@@ -1107,4 +1107,16 @@ theorem base_add_resultSignFixOff_andn_one
   show (base + (196 : Word)) &&& ~~~(1 : Word) = base + (196 : Word)
   bv_decide
 
+/-- The return address written by the SDIV wrapper's near `divCall` is exactly
+    the result-sign-fixup entry, and masking bit 0 for the eventual `JALR`
+    keeps it there.  This is the concrete `raVal &&& ~~~1` alignment fact
+    needed when composing the wrapper prefix with `evm_div_callable`. -/
+theorem divCall_return_andn_one_eq_resultSignFixOff
+    (base : Word) (hbase : base &&& 1 = 0) :
+    (((base + divCallOff) + 4 : Word) &&& ~~~(1 : Word)) =
+      base + resultSignFixOff := by
+  show (((base + (192 : Word)) + (4 : Word)) &&& ~~~(1 : Word)) =
+      base + (196 : Word)
+  bv_decide
+
 end EvmAsm.Evm64.SDiv.Compose


### PR DESCRIPTION
## Summary\n- adds divCall_return_andn_one_eq_resultSignFixOff for the concrete SDIV wrapper layout\n- pins the post-divCall return address ((base + divCallOff) + 4) after JALR bit-0 masking to base + resultSignFixOff\n- closes one small alignment prerequisite for composing the wrapper prefix with evm_div_callable\n\n## Verification\n- lake build EvmAsm.Evm64.SDiv.Compose.Base\n- scripts/check-file-size.sh EvmAsm/Evm64/SDiv/Compose/Base.lean\n- rg -n "sorry|admit|placeholder|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/Base.lean (only pre-existing header comment contains "placeholder"; diff adds none)\n- git diff --check\n- lake build\n- scripts/check-unimported.sh