### PR TITLE
fix(sdiv): expose callable x1 post shape

### DIFF
--- a/EvmAsm/Evm64/DivMod/Callable.lean
+++ b/EvmAsm/Evm64/DivMod/Callable.lean
@@ -637,6 +637,38 @@ theorem evm_div_callable_spec_from_noNop (sp base raVal : Word)
     cpsTripleWithin_frameL (divStackDispatchPost sp a b) hpcFreePost hRet
   exact cpsTripleWithin_seq_same_cr hStackFramed hRetFramed
 
+theorem evm_div_callable_spec_from_noNop_preserving_x1 (sp base raVal : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (branch : DivStackSpecCase base a b)
+    (hStack :
+      cpsTripleWithin unifiedDivBound base (base + nopOff) (divCode_noNop base)
+        (divModStackDispatchPre sp a b
+          branch.x1 branch.x2 v5 v6 v7 v10 v11
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+        (divStackDispatchPostNoX1 sp a b ** (.x1 ↦ᵣ raVal))) :
+    cpsTripleWithin (unifiedDivBound + 1) base (raVal &&& ~~~1)
+      (evm_div_callable_code base)
+      (divModStackDispatchPre sp a b
+        branch.x1 branch.x2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+      (divStackDispatchPostNoX1 sp a b ** (.x1 ↦ᵣ raVal)) := by
+  have hpcFreePost : (divStackDispatchPostNoX1 sp a b).pcFree := by
+    rw [divStackDispatchPostNoX1_unfold]
+    rw [divScratchOwnCall_unfold, divScratchOwn_unfold]
+    pcFree
+  have hStackCall :=
+    cpsTripleWithin_extend_code (hmono := divCode_noNop_sub_div_callable_code) hStack
+  have hRet :=
+    cpsTripleWithin_extend_code (hmono := evm_div_callable_code_ret_sub (base := base))
+      (ret_spec_within' (base + nopOff) raVal)
+  have hRetFramed :=
+    cpsTripleWithin_frameL (divStackDispatchPostNoX1 sp a b) hpcFreePost hRet
+  exact cpsTripleWithin_seq_same_cr hStackCall hRetFramed
+
 theorem evm_mod_callable_spec_from_noNop (sp base raVal : Word)
     (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7

--- a/EvmAsm/Evm64/DivMod/Spec/Dispatcher.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/Dispatcher.lean
@@ -67,6 +67,27 @@ theorem divStackDispatchPost_unfold {sp : Word} {a b : EvmWord} :
   delta divStackDispatchPost
   rfl
 
+/-- Final DIV stack-dispatch postcondition with `x1` omitted from the generic
+    owned-register frame. Callable wrappers use this shape when they need to
+    preserve the exact return address for the following `cc_ret`. -/
+@[irreducible]
+def divStackDispatchPostNoX1 (sp : Word) (a b : EvmWord) : Assertion :=
+  (.x12 ↦ᵣ (sp + 32)) ** regOwn .x2 **
+  regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+  regOwn .x10 ** regOwn .x11 ** (.x0 ↦ᵣ (0 : Word)) **
+  evmWordIs sp a ** evmWordIs (sp + 32) (EvmWord.div a b) **
+  divScratchOwnCall sp
+
+theorem divStackDispatchPostNoX1_unfold {sp : Word} {a b : EvmWord} :
+    divStackDispatchPostNoX1 sp a b =
+    ((.x12 ↦ᵣ (sp + 32)) ** regOwn .x2 **
+     regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+     regOwn .x10 ** regOwn .x11 ** (.x0 ↦ᵣ (0 : Word)) **
+     evmWordIs sp a ** evmWordIs (sp + 32) (EvmWord.div a b) **
+     divScratchOwnCall sp) := by
+  delta divStackDispatchPostNoX1
+  rfl
+
 theorem divStackDispatchPost_weaken
     (sp : Word) (a b : EvmWord)
     {v1 v2 v5 v6 v7 v10 v11 : Word}

--- a/EvmAsm/Evm64/SDiv/Compose/DivCall.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCall.lean
@@ -56,6 +56,35 @@ theorem evm_div_callable_spec_in_sdivCode
       q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
       nMem shiftMem jMem retMem dMem dloMem scratchUn0 branch hStack)
 
+theorem evm_div_callable_preserving_x1_spec_in_sdivCode
+    (sp base raVal : Word) (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (branch : EvmAsm.Evm64.DivStackSpecCase (base + wrapperEndOff) a b)
+    (hStack :
+      cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
+        (base + wrapperEndOff)
+        ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
+        (EvmAsm.Evm64.divCode_noNop (base + wrapperEndOff))
+        (EvmAsm.Evm64.divModStackDispatchPre sp a b
+          branch.x1 branch.x2 v5 v6 v7 v10 v11
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+        (EvmAsm.Evm64.divStackDispatchPostNoX1 sp a b ** (.x1 ↦ᵣ raVal))) :
+    cpsTripleWithin (EvmAsm.Evm64.unifiedDivBound + 1)
+      (base + wrapperEndOff) (raVal &&& ~~~1) (sdivCode base)
+      (EvmAsm.Evm64.divModStackDispatchPre sp a b
+        branch.x1 branch.x2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+      (EvmAsm.Evm64.divStackDispatchPostNoX1 sp a b ** (.x1 ↦ᵣ raVal)) := by
+  exact cpsTripleWithin_extend_code
+    (hmono := evm_div_callable_code_sub_sdivCode (base := base))
+    (EvmAsm.Evm64.evm_div_callable_spec_from_noNop_preserving_x1
+      sp (base + wrapperEndOff) raVal a b v5 v6 v7 v10 v11
+      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      nMem shiftMem jMem retMem dMem dloMem scratchUn0 branch hStack)
+
 /-- Precondition for the SDIV save-ra/signs/dividendAbs/divisorAbs/signXor
     /divCall block: same entry shape as the divisor-abs and signXor
     sequences. Wrapped `@[irreducible]` so downstream proofs do not


### PR DESCRIPTION
## Summary
- add `divStackDispatchPostNoX1`, a DIV dispatcher postcondition that omits `x1` from the generic owned-register bundle
- add `evm_div_callable_spec_from_noNop_preserving_x1`, which sequences the DIV body with `cc_ret` while carrying the exact return address once
- add the SDIV code-region wrapper `evm_div_callable_preserving_x1_spec_in_sdivCode`

## Verification
- `lake build EvmAsm.Evm64.DivMod.Spec.Dispatcher`
- `lake build EvmAsm.Evm64.DivMod.Callable`
- `lake build EvmAsm.Evm64.SDiv.Compose.DivCall` (rerun serially after a parallel Lake artifact race)
- `scripts/check-file-size.sh EvmAsm/Evm64/DivMod/Spec/Dispatcher.lean EvmAsm/Evm64/DivMod/Callable.lean EvmAsm/Evm64/SDiv/Compose/DivCall.lean`
- `git diff --check`
- `rg -n "sorry|admit|placeholder|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/Spec/Dispatcher.lean EvmAsm/Evm64/DivMod/Callable.lean EvmAsm/Evm64/SDiv/Compose/DivCall.lean`
- `lake build`
- `scripts/check-unimported.sh`