### PR TITLE
fix(exp): split saved-bit mul offsets

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBase.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBase.lean
@@ -34,10 +34,24 @@ theorem exp_iter_body_full_msb_saved_bit_len
   exact EvmAsm.Evm64.exp_iter_body_full_msb_saved_bit_length
     mulOff skipOff backOff
 
+theorem exp_iter_body_full_msb_saved_bit_two_mul_len
+    (squaringMulOff condMulOff : BitVec 21) (skipOff backOff : BitVec 13) :
+    (EvmAsm.Evm64.exp_iter_body_full_msb_saved_bit_two_mul
+      squaringMulOff condMulOff skipOff backOff).length = 59 := by
+  exact EvmAsm.Evm64.exp_iter_body_full_msb_saved_bit_two_mul_length
+    squaringMulOff condMulOff skipOff backOff
+
 theorem evm_exp_msb_saved_bit_len
     (mulOff : BitVec 21) (skipOff backOff : BitVec 13) :
     (EvmAsm.Evm64.evm_exp_msb_saved_bit mulOff skipOff backOff).length = 76 := by
   exact EvmAsm.Evm64.evm_exp_msb_saved_bit_length mulOff skipOff backOff
+
+theorem evm_exp_msb_saved_bit_two_mul_len
+    (squaringMulOff condMulOff : BitVec 21) (skipOff backOff : BitVec 13) :
+    (EvmAsm.Evm64.evm_exp_msb_saved_bit_two_mul
+      squaringMulOff condMulOff skipOff backOff).length = 76 := by
+  exact EvmAsm.Evm64.evm_exp_msb_saved_bit_two_mul_length
+    squaringMulOff condMulOff skipOff backOff
 
 /-- CodeReq decomposition for the corrected EXP square-and-multiply
     iteration: MSB bit-test, save bit, squaring call, saved-bit conditional
@@ -242,6 +256,119 @@ theorem expIterBodyFullMsbSavedBitCode_block_subs {base : Word}
     expIterBodyFullMsbSavedBitCode_cond_mul_sub,
     expIterBodyFullMsbSavedBitCode_loop_back_sub⟩
 
+/-- CodeReq decomposition for the corrected saved-bit iteration with separate
+    MUL-call offsets at the squaring and conditional-multiply JAL sites. -/
+abbrev expIterBodyFullMsbSavedBitTwoMulCode (base : Word)
+    (squaringMulOff condMulOff : BitVec 21)
+    (skipOff backOff : BitVec 13) : CodeReq :=
+  CodeReq.unionAll [
+    CodeReq.ofProg base EvmAsm.Evm64.exp_msb_bit_test_block,
+    CodeReq.ofProg (base + 12) EvmAsm.Evm64.exp_save_bit_block,
+    exp_squaring_call_block_code (base + 16) squaringMulOff,
+    EvmAsm.Evm64.exp_cond_mul_call_with_saved_bit_skip_block_code
+      (base + 120) condMulOff skipOff,
+    CodeReq.ofProg (base + 228) (EvmAsm.Evm64.exp_loop_back backOff)
+  ]
+
+theorem expIterBodyFullMsbSavedBitTwoMulCode_eq_ofProg (base : Word)
+    (squaringMulOff condMulOff : BitVec 21) (skipOff backOff : BitVec 13) :
+    expIterBodyFullMsbSavedBitTwoMulCode
+        base squaringMulOff condMulOff skipOff backOff =
+      CodeReq.ofProg base
+        (EvmAsm.Evm64.exp_iter_body_full_msb_saved_bit_two_mul
+          squaringMulOff condMulOff skipOff backOff) := by
+  unfold expIterBodyFullMsbSavedBitTwoMulCode
+  unfold EvmAsm.Evm64.exp_iter_body_full_msb_saved_bit_two_mul
+  simp only [EvmAsm.Rv64.seq]
+  unfold Program
+  rw [CodeReq.ofProg_append]
+  have h12 :
+      base + BitVec.ofNat 64 (4 *
+        (EvmAsm.Evm64.exp_msb_bit_test_block).length) = base + 12 := by
+    rw [EvmAsm.Evm64.exp_msb_bit_test_block_length]
+    rfl
+  rw [h12]
+  rw [CodeReq.ofProg_append]
+  have h16 :
+      (base + 12 : Word) + BitVec.ofNat 64 (4 *
+        (EvmAsm.Evm64.exp_save_bit_block).length) = base + 16 := by
+    rw [EvmAsm.Evm64.exp_save_bit_block_length]
+    bv_addr
+  rw [h16]
+  rw [CodeReq.ofProg_append]
+  have h120 :
+      (base + 16 : Word) + BitVec.ofNat 64 (4 *
+        (EvmAsm.Evm64.exp_squaring_call_block squaringMulOff).length) =
+        base + 120 := by
+    rw [EvmAsm.Evm64.exp_squaring_call_block_length]
+    bv_addr
+  rw [h120]
+  rw [CodeReq.ofProg_append]
+  have h228 :
+      (base + 120 : Word) + BitVec.ofNat 64 (4 *
+        (EvmAsm.Evm64.exp_cond_mul_call_with_saved_bit_skip_block
+          condMulOff skipOff).length) = base + 228 := by
+    rw [EvmAsm.Evm64.exp_cond_mul_call_with_saved_bit_skip_block_length]
+    bv_addr
+  rw [h228]
+  rw [← exp_squaring_call_block_code_eq_ofProg (base + 16) squaringMulOff]
+  rw [← EvmAsm.Evm64.exp_cond_mul_call_with_saved_bit_skip_block_code_eq_ofProg
+    (base + 120) condMulOff skipOff]
+  simp only [CodeReq.unionAll_cons, CodeReq.unionAll_nil, CodeReq.union_empty_right]
+
+theorem expIterBodyFullMsbSavedBitTwoMulCode_squaring_sub {base : Word}
+    {squaringMulOff condMulOff : BitVec 21} {skipOff backOff : BitVec 13} :
+    ∀ a i, (exp_squaring_call_block_code (base + 16) squaringMulOff)
+      a = some i →
+      (expIterBodyFullMsbSavedBitTwoMulCode
+        base squaringMulOff condMulOff skipOff backOff) a = some i := by
+  rw [expIterBodyFullMsbSavedBitTwoMulCode_eq_ofProg,
+    exp_squaring_call_block_code_eq_ofProg]
+  exact CodeReq.ofProg_mono_sub base (base + 16)
+    (EvmAsm.Evm64.exp_iter_body_full_msb_saved_bit_two_mul
+      squaringMulOff condMulOff skipOff backOff)
+    (EvmAsm.Evm64.exp_squaring_call_block squaringMulOff) 4
+    (by bv_omega)
+    (by
+      unfold EvmAsm.Evm64.exp_iter_body_full_msb_saved_bit_two_mul
+      simp only [EvmAsm.Rv64.seq]
+      unfold Program
+      rfl)
+    (by
+      simp only [exp_iter_body_full_msb_saved_bit_two_mul_len,
+        exp_squaring_call_block_len]
+      omega)
+    (by
+      simp only [exp_iter_body_full_msb_saved_bit_two_mul_len]
+      norm_num)
+
+theorem expIterBodyFullMsbSavedBitTwoMulCode_cond_mul_sub {base : Word}
+    {squaringMulOff condMulOff : BitVec 21} {skipOff backOff : BitVec 13} :
+    ∀ a i, (EvmAsm.Evm64.exp_cond_mul_call_with_saved_bit_skip_block_code
+      (base + 120) condMulOff skipOff) a = some i →
+      (expIterBodyFullMsbSavedBitTwoMulCode
+        base squaringMulOff condMulOff skipOff backOff) a = some i := by
+  rw [expIterBodyFullMsbSavedBitTwoMulCode_eq_ofProg,
+    EvmAsm.Evm64.exp_cond_mul_call_with_saved_bit_skip_block_code_eq_ofProg]
+  exact CodeReq.ofProg_mono_sub base (base + 120)
+    (EvmAsm.Evm64.exp_iter_body_full_msb_saved_bit_two_mul
+      squaringMulOff condMulOff skipOff backOff)
+    (EvmAsm.Evm64.exp_cond_mul_call_with_saved_bit_skip_block
+      condMulOff skipOff) 30
+    (by bv_omega)
+    (by
+      unfold EvmAsm.Evm64.exp_iter_body_full_msb_saved_bit_two_mul
+      simp only [EvmAsm.Rv64.seq]
+      unfold Program
+      rfl)
+    (by
+      simp only [exp_iter_body_full_msb_saved_bit_two_mul_len,
+        exp_cond_mul_call_with_saved_bit_skip_block_len]
+      omega)
+    (by
+      simp only [exp_iter_body_full_msb_saved_bit_two_mul_len]
+      norm_num)
+
 /-- Top-level CodeReq decomposition for the corrected MSB-first saved-bit EXP
     opcode program. -/
 abbrev evmExpMsbSavedBitCode (base : Word)
@@ -295,6 +422,91 @@ theorem evmExpMsbSavedBitCode_eq_ofProg (base : Word)
   rw [← expIterBodyFullMsbSavedBitCode_eq_ofProg
     (base + 28) mulOff skipOff backOff]
   simp only [CodeReq.unionAll_cons, CodeReq.unionAll_nil, CodeReq.union_empty_right]
+
+/-- Top-level CodeReq decomposition for the corrected saved-bit EXP opcode
+    with independent MUL-call offsets at the two JAL sites. -/
+abbrev evmExpMsbSavedBitTwoMulCode (base : Word)
+    (squaringMulOff condMulOff : BitVec 21)
+    (skipOff backOff : BitVec 13) : CodeReq :=
+  CodeReq.unionAll [
+    CodeReq.ofProg base EvmAsm.Evm64.exp_prologue,
+    CodeReq.ofProg (base + 24) EvmAsm.Evm64.exp_loop_pointer_advance,
+    expIterBodyFullMsbSavedBitTwoMulCode
+      (base + 28) squaringMulOff condMulOff skipOff backOff,
+    CodeReq.ofProg (base + 264) EvmAsm.Evm64.exp_loop_pointer_restore,
+    CodeReq.ofProg (base + 268) EvmAsm.Evm64.exp_epilogue
+  ]
+
+theorem evmExpMsbSavedBitTwoMulCode_eq_ofProg (base : Word)
+    (squaringMulOff condMulOff : BitVec 21) (skipOff backOff : BitVec 13) :
+    evmExpMsbSavedBitTwoMulCode
+        base squaringMulOff condMulOff skipOff backOff =
+      CodeReq.ofProg base
+        (EvmAsm.Evm64.evm_exp_msb_saved_bit_two_mul
+          squaringMulOff condMulOff skipOff backOff) := by
+  unfold evmExpMsbSavedBitTwoMulCode
+  unfold EvmAsm.Evm64.evm_exp_msb_saved_bit_two_mul
+  simp only [EvmAsm.Rv64.seq]
+  unfold Program
+  rw [CodeReq.ofProg_append]
+  have h24 :
+      base + BitVec.ofNat 64 (4 * (EvmAsm.Evm64.exp_prologue).length) =
+        base + 24 := by
+    rw [EvmAsm.Evm64.exp_prologue_length]
+    rfl
+  rw [h24]
+  rw [CodeReq.ofProg_append]
+  have h28 :
+      (base + 24 : Word) + BitVec.ofNat 64 (4 *
+        (EvmAsm.Evm64.exp_loop_pointer_advance).length) = base + 28 := by
+    rw [EvmAsm.Evm64.exp_loop_pointer_advance_length]
+    bv_addr
+  rw [h28]
+  rw [CodeReq.ofProg_append]
+  have h264 :
+      (base + 28 : Word) + BitVec.ofNat 64 (4 *
+        (EvmAsm.Evm64.exp_iter_body_full_msb_saved_bit_two_mul
+          squaringMulOff condMulOff skipOff backOff).length) = base + 264 := by
+    rw [EvmAsm.Evm64.exp_iter_body_full_msb_saved_bit_two_mul_length]
+    bv_addr
+  rw [h264]
+  rw [CodeReq.ofProg_append]
+  have h268 :
+      (base + 264 : Word) + BitVec.ofNat 64 (4 *
+        (EvmAsm.Evm64.exp_loop_pointer_restore).length) = base + 268 := by
+    rw [EvmAsm.Evm64.exp_loop_pointer_restore_length]
+    bv_addr
+  rw [h268]
+  rw [← expIterBodyFullMsbSavedBitTwoMulCode_eq_ofProg
+    (base + 28) squaringMulOff condMulOff skipOff backOff]
+  simp only [CodeReq.unionAll_cons, CodeReq.unionAll_nil, CodeReq.union_empty_right]
+
+theorem evmExpMsbSavedBitTwoMulCode_iter_body_sub {base : Word}
+    {squaringMulOff condMulOff : BitVec 21} {skipOff backOff : BitVec 13} :
+    ∀ a i, (expIterBodyFullMsbSavedBitTwoMulCode
+      (base + 28) squaringMulOff condMulOff skipOff backOff) a = some i →
+      (evmExpMsbSavedBitTwoMulCode
+        base squaringMulOff condMulOff skipOff backOff) a = some i := by
+  rw [evmExpMsbSavedBitTwoMulCode_eq_ofProg,
+    expIterBodyFullMsbSavedBitTwoMulCode_eq_ofProg]
+  exact CodeReq.ofProg_mono_sub base (base + 28)
+    (EvmAsm.Evm64.evm_exp_msb_saved_bit_two_mul
+      squaringMulOff condMulOff skipOff backOff)
+    (EvmAsm.Evm64.exp_iter_body_full_msb_saved_bit_two_mul
+      squaringMulOff condMulOff skipOff backOff) 7
+    (by bv_omega)
+    (by
+      unfold EvmAsm.Evm64.evm_exp_msb_saved_bit_two_mul
+      simp only [EvmAsm.Rv64.seq]
+      unfold Program
+      rfl)
+    (by
+      simp only [evm_exp_msb_saved_bit_two_mul_len,
+        exp_iter_body_full_msb_saved_bit_two_mul_len]
+      omega)
+    (by
+      simp only [evm_exp_msb_saved_bit_two_mul_len]
+      norm_num)
 
 theorem evmExpMsbSavedBitCode_prologue_sub {base : Word}
     {mulOff : BitVec 21} {skipOff backOff : BitVec 13} :

--- a/EvmAsm/Evm64/Exp/Program.lean
+++ b/EvmAsm/Evm64/Exp/Program.lean
@@ -812,6 +812,19 @@ def exp_iter_body_full_msb_saved_bit
   exp_cond_mul_call_with_saved_bit_skip_block mulOff skipOff ;;
   exp_loop_back backOff
 
+/-- Corrected EXP iteration body with independent MUL-call offsets for the
+    unconditional squaring call and the conditional-multiply call.  The two
+    call sites sit at different PCs, so a single encoded JAL offset cannot
+    target one shared `mul_callable` body from both sites. -/
+def exp_iter_body_full_msb_saved_bit_two_mul
+    (squaringMulOff condMulOff : BitVec 21)
+    (skipOff backOff : BitVec 13) : Program :=
+  exp_msb_bit_test_block ;;
+  exp_save_bit_block ;;
+  exp_squaring_call_block squaringMulOff ;;
+  exp_cond_mul_call_with_saved_bit_skip_block condMulOff skipOff ;;
+  exp_loop_back backOff
+
 theorem exp_iter_body_full_length
     (mulOff : BitVec 21) (skipOff backOff : BitVec 13) :
     (exp_iter_body_full mulOff skipOff backOff).length = 58 := by
@@ -849,6 +862,28 @@ theorem exp_iter_body_full_msb_saved_bit_byte_length
     (mulOff : BitVec 21) (skipOff backOff : BitVec 13) :
     4 * (exp_iter_body_full_msb_saved_bit mulOff skipOff backOff).length = 236 := by
   rw [exp_iter_body_full_msb_saved_bit_length]
+
+theorem exp_iter_body_full_msb_saved_bit_two_mul_length
+    (squaringMulOff condMulOff : BitVec 21) (skipOff backOff : BitVec 13) :
+    (exp_iter_body_full_msb_saved_bit_two_mul
+      squaringMulOff condMulOff skipOff backOff).length = 59 := by
+  show ((((exp_msb_bit_test_block ;;
+          exp_save_bit_block) ;;
+          exp_squaring_call_block squaringMulOff) ;;
+         exp_cond_mul_call_with_saved_bit_skip_block condMulOff skipOff) ;;
+        exp_loop_back backOff).length = 59
+  simp only [seq, Program.length_append,
+    exp_msb_bit_test_block_length,
+    exp_save_bit_block_length,
+    exp_squaring_call_block_length,
+    exp_cond_mul_call_with_saved_bit_skip_block_length,
+    exp_loop_back_length]
+
+theorem exp_iter_body_full_msb_saved_bit_two_mul_byte_length
+    (squaringMulOff condMulOff : BitVec 21) (skipOff backOff : BitVec 13) :
+    4 * (exp_iter_body_full_msb_saved_bit_two_mul
+      squaringMulOff condMulOff skipOff backOff).length = 236 := by
+  rw [exp_iter_body_full_msb_saved_bit_two_mul_length]
 
 
 -- ----------------------------------------------------------------------------
@@ -974,6 +1009,18 @@ def evm_exp_msb_saved_bit
   exp_loop_pointer_restore ;;
   exp_epilogue
 
+/-- Corrected EXP opcode Program with independent MUL-call offsets for the
+    squaring and conditional-multiply JAL sites. -/
+def evm_exp_msb_saved_bit_two_mul
+    (squaringMulOff condMulOff : BitVec 21)
+    (skipOff backOff : BitVec 13) : Program :=
+  exp_prologue ;;
+  exp_loop_pointer_advance ;;
+  exp_iter_body_full_msb_saved_bit_two_mul
+    squaringMulOff condMulOff skipOff backOff ;;
+  exp_loop_pointer_restore ;;
+  exp_epilogue
+
 /-- Canonical BEQ offset for skipping the conditional-multiply taken branch. -/
 def canonicalExpCondMulSkipOff : BitVec 13 := 108
 
@@ -995,6 +1042,13 @@ def evm_exp_msb_saved_bit_canonical (mulOff : BitVec 21) : Program :=
   evm_exp_msb_saved_bit mulOff
     canonicalExpCondMulSkipOff canonicalExpMsbSavedBitLoopBackOff
 
+/-- Corrected EXP program with canonical internal branch offsets and separate
+    external MUL-call offsets for the two JAL sites. -/
+def evm_exp_msb_saved_bit_two_mul_canonical
+    (squaringMulOff condMulOff : BitVec 21) : Program :=
+  evm_exp_msb_saved_bit_two_mul squaringMulOff condMulOff
+    canonicalExpCondMulSkipOff canonicalExpMsbSavedBitLoopBackOff
+
 theorem canonicalExpCondMulSkipOff_eq :
     canonicalExpCondMulSkipOff = 108 := rfl
 
@@ -1011,6 +1065,12 @@ theorem evm_exp_canonical_eq (mulOff : BitVec 21) :
 theorem evm_exp_msb_saved_bit_canonical_eq (mulOff : BitVec 21) :
     evm_exp_msb_saved_bit_canonical mulOff =
       evm_exp_msb_saved_bit mulOff
+        canonicalExpCondMulSkipOff canonicalExpMsbSavedBitLoopBackOff := rfl
+
+theorem evm_exp_msb_saved_bit_two_mul_canonical_eq
+    (squaringMulOff condMulOff : BitVec 21) :
+    evm_exp_msb_saved_bit_two_mul_canonical squaringMulOff condMulOff =
+      evm_exp_msb_saved_bit_two_mul squaringMulOff condMulOff
         canonicalExpCondMulSkipOff canonicalExpMsbSavedBitLoopBackOff := rfl
 
 theorem evm_exp_length (mulOff : BitVec 21) (skipOff backOff : BitVec 13) :
@@ -1051,6 +1111,29 @@ theorem evm_exp_msb_saved_bit_byte_length
     4 * (evm_exp_msb_saved_bit mulOff skipOff backOff).length = 304 := by
   rw [evm_exp_msb_saved_bit_length]
 
+theorem evm_exp_msb_saved_bit_two_mul_length
+    (squaringMulOff condMulOff : BitVec 21) (skipOff backOff : BitVec 13) :
+    (evm_exp_msb_saved_bit_two_mul
+      squaringMulOff condMulOff skipOff backOff).length = 76 := by
+  show ((((exp_prologue ;;
+            exp_loop_pointer_advance) ;;
+            exp_iter_body_full_msb_saved_bit_two_mul
+              squaringMulOff condMulOff skipOff backOff) ;;
+            exp_loop_pointer_restore) ;;
+          exp_epilogue).length = 76
+  simp only [seq, Program.length_append,
+    exp_prologue_length,
+    exp_loop_pointer_advance_length,
+    exp_iter_body_full_msb_saved_bit_two_mul_length,
+    exp_loop_pointer_restore_length,
+    exp_epilogue_length]
+
+theorem evm_exp_msb_saved_bit_two_mul_byte_length
+    (squaringMulOff condMulOff : BitVec 21) (skipOff backOff : BitVec 13) :
+    4 * (evm_exp_msb_saved_bit_two_mul
+      squaringMulOff condMulOff skipOff backOff).length = 304 := by
+  rw [evm_exp_msb_saved_bit_two_mul_length]
+
 theorem evm_exp_canonical_length (mulOff : BitVec 21) :
     (evm_exp_canonical mulOff).length = 75 := by
   unfold evm_exp_canonical
@@ -1068,5 +1151,18 @@ theorem evm_exp_msb_saved_bit_canonical_length (mulOff : BitVec 21) :
 theorem evm_exp_msb_saved_bit_canonical_byte_length (mulOff : BitVec 21) :
     4 * (evm_exp_msb_saved_bit_canonical mulOff).length = 304 := by
   rw [evm_exp_msb_saved_bit_canonical_length]
+
+theorem evm_exp_msb_saved_bit_two_mul_canonical_length
+    (squaringMulOff condMulOff : BitVec 21) :
+    (evm_exp_msb_saved_bit_two_mul_canonical
+      squaringMulOff condMulOff).length = 76 := by
+  unfold evm_exp_msb_saved_bit_two_mul_canonical
+  rw [evm_exp_msb_saved_bit_two_mul_length]
+
+theorem evm_exp_msb_saved_bit_two_mul_canonical_byte_length
+    (squaringMulOff condMulOff : BitVec 21) :
+    4 * (evm_exp_msb_saved_bit_two_mul_canonical
+      squaringMulOff condMulOff).length = 304 := by
+  rw [evm_exp_msb_saved_bit_two_mul_canonical_length]
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add `exp_iter_body_full_msb_saved_bit_two_mul` and `evm_exp_msb_saved_bit_two_mul` with independent JAL offsets for squaring and conditional-multiply MUL calls
- add length/canonical lemmas for the two-offset saved-bit EXP program shape
- add iteration/top-level CodeReq decompositions and sub-code lemmas for the two-offset saved-bit layout

## Why
The saved-bit single-iteration composition currently needs one shared `mul_callable` body from two different JAL PCs. A single encoded `mulOff` cannot target the same callable from both the squaring and conditional-multiply call sites, so downstream composition needs a layout with separate offsets.

## Verification
- `lake build EvmAsm.Evm64.Exp.Program`
- `lake build EvmAsm.Evm64.Exp.Compose.SavedBitBase`
- `lake build EvmAsm.Evm64.Exp.Compose.SavedBitFullLoop`
- `scripts/check-file-size.sh EvmAsm/Evm64/Exp/Program.lean EvmAsm/Evm64/Exp/Compose/SavedBitBase.lean`
- `git diff --check`
- `rg -n "sorry|admit|placeholder|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/Program.lean EvmAsm/Evm64/Exp/Compose/SavedBitBase.lean`
- `lake build`
- `scripts/check-unimported.sh`