### PR TITLE
fix(exp): lift saved-bit two-mul calls

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBase.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBase.lean
@@ -316,6 +316,56 @@ theorem expIterBodyFullMsbSavedBitTwoMulCode_eq_ofProg (base : Word)
     (base + 120) condMulOff skipOff]
   simp only [CodeReq.unionAll_cons, CodeReq.unionAll_nil, CodeReq.union_empty_right]
 
+theorem expIterBodyFullMsbSavedBitTwoMulCode_bit_test_sub {base : Word}
+    {squaringMulOff condMulOff : BitVec 21} {skipOff backOff : BitVec 13} :
+    ∀ a i, (CodeReq.ofProg base EvmAsm.Evm64.exp_msb_bit_test_block)
+      a = some i →
+      (expIterBodyFullMsbSavedBitTwoMulCode
+        base squaringMulOff condMulOff skipOff backOff) a = some i := by
+  rw [expIterBodyFullMsbSavedBitTwoMulCode_eq_ofProg]
+  exact CodeReq.ofProg_mono_sub base base
+    (EvmAsm.Evm64.exp_iter_body_full_msb_saved_bit_two_mul
+      squaringMulOff condMulOff skipOff backOff)
+    EvmAsm.Evm64.exp_msb_bit_test_block 0
+    (by bv_omega)
+    (by
+      unfold EvmAsm.Evm64.exp_iter_body_full_msb_saved_bit_two_mul
+      simp only [EvmAsm.Rv64.seq]
+      unfold Program
+      rfl)
+    (by
+      simp only [exp_iter_body_full_msb_saved_bit_two_mul_len,
+        exp_msb_bit_test_block_len]
+      omega)
+    (by
+      simp only [exp_iter_body_full_msb_saved_bit_two_mul_len]
+      norm_num)
+
+theorem expIterBodyFullMsbSavedBitTwoMulCode_save_bit_sub {base : Word}
+    {squaringMulOff condMulOff : BitVec 21} {skipOff backOff : BitVec 13} :
+    ∀ a i, (CodeReq.ofProg (base + 12) EvmAsm.Evm64.exp_save_bit_block)
+      a = some i →
+      (expIterBodyFullMsbSavedBitTwoMulCode
+        base squaringMulOff condMulOff skipOff backOff) a = some i := by
+  rw [expIterBodyFullMsbSavedBitTwoMulCode_eq_ofProg]
+  exact CodeReq.ofProg_mono_sub base (base + 12)
+    (EvmAsm.Evm64.exp_iter_body_full_msb_saved_bit_two_mul
+      squaringMulOff condMulOff skipOff backOff)
+    EvmAsm.Evm64.exp_save_bit_block 3
+    (by bv_omega)
+    (by
+      unfold EvmAsm.Evm64.exp_iter_body_full_msb_saved_bit_two_mul
+      simp only [EvmAsm.Rv64.seq]
+      unfold Program
+      rfl)
+    (by
+      simp only [exp_iter_body_full_msb_saved_bit_two_mul_len,
+        exp_save_bit_block_len]
+      omega)
+    (by
+      simp only [exp_iter_body_full_msb_saved_bit_two_mul_len]
+      norm_num)
+
 theorem expIterBodyFullMsbSavedBitTwoMulCode_squaring_sub {base : Word}
     {squaringMulOff condMulOff : BitVec 21} {skipOff backOff : BitVec 13} :
     ∀ a i, (exp_squaring_call_block_code (base + 16) squaringMulOff)

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFullLoop.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFullLoop.lean
@@ -21,12 +21,32 @@ abbrev evmExpMsbSavedBitWithMulCode (base mulTarget : Word)
   (evmExpMsbSavedBitCode base mulOff skipOff backOff).union
     (mul_callable_code mulTarget)
 
+/-- Corrected saved-bit EXP program with independent JAL offsets for the
+    squaring and conditional-multiply call sites, plus the external
+    `mul_callable` body both sites target. -/
+abbrev evmExpMsbSavedBitTwoMulWithMulCode (base mulTarget : Word)
+    (squaringMulOff condMulOff : BitVec 21)
+    (skipOff backOff : BitVec 13) : CodeReq :=
+  (evmExpMsbSavedBitTwoMulCode
+    base squaringMulOff condMulOff skipOff backOff).union
+    (mul_callable_code mulTarget)
+
 theorem evmExpMsbSavedBitWithMulCode_exp_sub {base mulTarget : Word}
     {mulOff : BitVec 21} {skipOff backOff : BitVec 13} :
     ∀ a i, (evmExpMsbSavedBitCode base mulOff skipOff backOff) a = some i →
       (evmExpMsbSavedBitWithMulCode base mulTarget mulOff skipOff backOff)
         a = some i := by
   unfold evmExpMsbSavedBitWithMulCode
+  exact CodeReq.union_mono_left
+
+theorem evmExpMsbSavedBitTwoMulWithMulCode_exp_sub {base mulTarget : Word}
+    {squaringMulOff condMulOff : BitVec 21} {skipOff backOff : BitVec 13} :
+    ∀ a i,
+      (evmExpMsbSavedBitTwoMulCode
+        base squaringMulOff condMulOff skipOff backOff) a = some i →
+      (evmExpMsbSavedBitTwoMulWithMulCode
+        base mulTarget squaringMulOff condMulOff skipOff backOff) a = some i := by
+  unfold evmExpMsbSavedBitTwoMulWithMulCode
   exact CodeReq.union_mono_left
 
 theorem evmExpMsbSavedBitWithMulCode_mul_sub {base mulTarget : Word}
@@ -38,6 +58,18 @@ theorem evmExpMsbSavedBitWithMulCode_mul_sub {base mulTarget : Word}
       (evmExpMsbSavedBitWithMulCode base mulTarget mulOff skipOff backOff)
         a = some i := by
   unfold evmExpMsbSavedBitWithMulCode
+  exact CodeReq.mono_union_right hd (fun _ _ h => h)
+
+theorem evmExpMsbSavedBitTwoMulWithMulCode_mul_sub {base mulTarget : Word}
+    {squaringMulOff condMulOff : BitVec 21} {skipOff backOff : BitVec 13}
+    (hd : CodeReq.Disjoint
+      (evmExpMsbSavedBitTwoMulCode
+        base squaringMulOff condMulOff skipOff backOff)
+      (mul_callable_code mulTarget)) :
+    ∀ a i, (mul_callable_code mulTarget) a = some i →
+      (evmExpMsbSavedBitTwoMulWithMulCode
+        base mulTarget squaringMulOff condMulOff skipOff backOff) a = some i := by
+  unfold evmExpMsbSavedBitTwoMulWithMulCode
   exact CodeReq.mono_union_right hd (fun _ _ h => h)
 
 /-- Lift a corrected saved-bit top-level EXP spec into the combined EXP+MUL
@@ -52,6 +84,21 @@ theorem cpsTripleWithin_extend_evmExpMsbSavedBitWithMulCode {nSteps : Nat}
       (evmExpMsbSavedBitWithMulCode base mulTarget mulOff skipOff backOff) P Q :=
   cpsTripleWithin_extend_code
     (hmono := evmExpMsbSavedBitWithMulCode_exp_sub) h
+
+/-- Lift a two-offset corrected saved-bit EXP spec into the combined EXP+MUL
+    code bundle. -/
+theorem cpsTripleWithin_extend_evmExpMsbSavedBitTwoMulWithMulCode {nSteps : Nat}
+    {entry exit_ base mulTarget : Word}
+    {squaringMulOff condMulOff : BitVec 21} {skipOff backOff : BitVec 13}
+    {P Q : Assertion}
+    (h : cpsTripleWithin nSteps entry exit_
+      (evmExpMsbSavedBitTwoMulCode
+        base squaringMulOff condMulOff skipOff backOff) P Q) :
+    cpsTripleWithin nSteps entry exit_
+      (evmExpMsbSavedBitTwoMulWithMulCode
+        base mulTarget squaringMulOff condMulOff skipOff backOff) P Q :=
+  cpsTripleWithin_extend_code
+    (hmono := evmExpMsbSavedBitTwoMulWithMulCode_exp_sub) h
 
 /-- Lift a corrected saved-bit top-level EXP branch spec into the combined
     EXP+MUL code bundle. -/
@@ -227,6 +274,82 @@ theorem exp_squaring_call_block_evm_exp_msb_saved_bit_with_mul_spec_within
           (base := base) (mulOff := mulOff)
           (skipOff := skipOff) (backOff := backOff) a i h))
       (fun a i h => evmExpMsbSavedBitWithMulCode_mul_sub hd a i h))
+    hbase_spec
+
+/-- Squaring-side call-block lifted to the two-MUL-offset saved-bit EXP+MUL
+    code bundle.  This uses the squaring JAL offset only; the conditional
+    multiply offset is independent. -/
+theorem exp_squaring_call_block_evm_exp_msb_saved_bit_two_mul_with_mul_spec_within
+    (sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+      v6 v7 v10 v11 mulTarget : Word)
+    (squaringMulOff condMulOff : BitVec 21) (skipOff backOff : BitVec 13)
+    (base : Word)
+    (hbase : base &&& 1 = 0)
+    (hmt : mulTarget = ((base + 44) + 64) + signExtend21 squaringMulOff)
+    (hd : CodeReq.Disjoint
+            (evmExpMsbSavedBitTwoMulCode
+              base squaringMulOff condMulOff skipOff backOff)
+            (mul_callable_code mulTarget)) :
+    let w := expResultWord r0 r1 r2 r3
+    cpsTripleWithin (17 + 64 + 9) (base + 44) ((base + 44) + 104)
+      (evmExpMsbSavedBitTwoMulWithMulCode
+        base mulTarget squaringMulOff condMulOff skipOff backOff)
+      ((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+       ((evmSp + signExtend12 (0 : BitVec 12)) ↦ₘ d0) **
+       ((evmSp + signExtend12 (8 : BitVec 12)) ↦ₘ d1) **
+       ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ d2) **
+       ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ d3) **
+       ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ e0) **
+       ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ e1) **
+       ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ e2) **
+       ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ e3) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) **
+       (.x1 ↦ᵣ vOld))
+      ((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) **
+       (.x5 ↦ᵣ (w * w).getLimbN 3) **
+       evmWordIs sp (w * w) ** evmWordIs (evmSp + 32) (w * w) **
+       regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
+       memOwn evmSp ** memOwn (evmSp + 8) **
+       memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
+       (.x1 ↦ᵣ ((base + 44) + 68))) := by
+  intro w
+  have hbase' : (base + 44 : Word) &&& 1 = 0 := by bv_decide
+  have hSquareSub : ∀ a i,
+      exp_squaring_call_block_code (base + 44) squaringMulOff a = some i →
+      evmExpMsbSavedBitTwoMulCode
+        base squaringMulOff condMulOff skipOff backOff a = some i := by
+    intro a i h
+    have hiter : (base + 44 : Word) = (base + 28) + 16 := by bv_omega
+    rw [hiter] at h
+    exact evmExpMsbSavedBitTwoMulCode_iter_body_sub
+      (base := base) (squaringMulOff := squaringMulOff)
+      (condMulOff := condMulOff) (skipOff := skipOff) (backOff := backOff)
+      a i (expIterBodyFullMsbSavedBitTwoMulCode_squaring_sub a i h)
+  have hd_inner : CodeReq.Disjoint
+      (exp_squaring_call_block_code (base + 44) squaringMulOff)
+      (mul_callable_code mulTarget) := by
+    intro a
+    rcases hd a with hExp | hMul
+    · left
+      cases hsub : exp_squaring_call_block_code (base + 44) squaringMulOff a with
+      | none => rfl
+      | some i =>
+        have hev := hSquareSub a i hsub
+        exact absurd (hev.symm.trans hExp) (by simp)
+    · right; exact hMul
+  have hbase_spec := EvmAsm.Evm64.exp_squaring_call_block_spec_within
+    sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+    v6 v7 v10 v11 mulTarget squaringMulOff (base + 44)
+    hbase' hmt hd_inner
+  exact cpsTripleWithin_extend_code
+    (hmono := CodeReq.union_sub
+      (fun a i h => evmExpMsbSavedBitTwoMulWithMulCode_exp_sub a i
+        (hSquareSub a i h))
+      (fun a i h => evmExpMsbSavedBitTwoMulWithMulCode_mul_sub hd a i h))
     hbase_spec
 
 /-- Prefix plus squaring side of one corrected EXP iteration.  This carries
@@ -671,6 +794,92 @@ theorem exp_cond_mul_call_block_evm_exp_msb_saved_bit_with_mul_spec_within
     (hmono := CodeReq.union_sub
       (fun a i h => evmExpMsbSavedBitWithMulCode_exp_sub a i (hCondSub a i h))
       (fun a i h => evmExpMsbSavedBitWithMulCode_mul_sub hd a i h))
+    hbase_spec
+
+/-- Conditional-multiply taken call-block lifted to the two-MUL-offset
+    saved-bit EXP+MUL code bundle.  This uses the conditional-multiply JAL
+    offset only; the squaring offset is independent. -/
+theorem exp_cond_mul_call_block_evm_exp_msb_saved_bit_two_mul_with_mul_spec_within
+    (sp evmSp tOld vOld r0 r1 r2 r3 a0 a1 a2 a3 d0 d1 d2 d3 e0 e1 e2 e3
+      v6 v7 v10 v11 mulTarget : Word)
+    (squaringMulOff condMulOff : BitVec 21) (skipOff backOff : BitVec 13)
+    (base : Word)
+    (hbase : base &&& 1 = 0)
+    (hmt : mulTarget = ((base + 152) + 64) + signExtend21 condMulOff)
+    (hd : CodeReq.Disjoint
+            (evmExpMsbSavedBitTwoMulCode
+              base squaringMulOff condMulOff skipOff backOff)
+            (mul_callable_code mulTarget)) :
+    let r := expResultWord r0 r1 r2 r3
+    let aw := expResultWord a0 a1 a2 a3
+    cpsTripleWithin (17 + 64 + 9) (base + 152) ((base + 152) + 104)
+      (evmExpMsbSavedBitTwoMulWithMulCode
+        base mulTarget squaringMulOff condMulOff skipOff backOff)
+      ((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+       ((evmSp + signExtend12 (0 : BitVec 12)) ↦ₘ d0) **
+       ((evmSp + signExtend12 (8 : BitVec 12)) ↦ₘ d1) **
+       ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ d2) **
+       ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ d3) **
+       ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ e0) **
+       ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ e1) **
+       ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ e2) **
+       ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ e3) **
+       ((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
+       ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **
+       ((evmSp + signExtend12 ((-48) : BitVec 12)) ↦ₘ a2) **
+       ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) **
+       (.x1 ↦ᵣ vOld))
+      ((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) **
+       (.x5 ↦ᵣ (r * aw).getLimbN 3) **
+       ((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
+       ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **
+       ((evmSp + signExtend12 ((-48) : BitVec 12)) ↦ₘ a2) **
+       ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3) **
+       evmWordIs sp (r * aw) ** evmWordIs (evmSp + 32) (r * aw) **
+       regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
+       memOwn evmSp ** memOwn (evmSp + 8) **
+       memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
+       (.x1 ↦ᵣ ((base + 152) + 68))) := by
+  intro r aw
+  have hbase' : (base + 152 : Word) &&& 1 = 0 := by bv_decide
+  have hCondSub : ∀ a i,
+      exp_cond_mul_call_block_code (base + 152) condMulOff a = some i →
+      evmExpMsbSavedBitTwoMulCode
+        base squaringMulOff condMulOff skipOff backOff a = some i := by
+    intro a i h
+    have hskip : (base + 152 : Word) = (base + 28) + 120 + 4 := by bv_omega
+    rw [hskip] at h
+    exact evmExpMsbSavedBitTwoMulCode_iter_body_sub
+      (base := base) (squaringMulOff := squaringMulOff)
+      (condMulOff := condMulOff) (skipOff := skipOff) (backOff := backOff)
+      a i (expIterBodyFullMsbSavedBitTwoMulCode_cond_mul_sub a i
+        (EvmAsm.Evm64.exp_cond_mul_call_with_saved_bit_skip_block_code_call_sub
+          ((base + 28) + 120) condMulOff skipOff a i h))
+  have hd_inner : CodeReq.Disjoint
+      (exp_cond_mul_call_block_code (base + 152) condMulOff)
+      (mul_callable_code mulTarget) := by
+    intro a
+    rcases hd a with hExp | hMul
+    · left
+      cases hsub : exp_cond_mul_call_block_code (base + 152) condMulOff a with
+      | none => rfl
+      | some i =>
+        have hev := hCondSub a i hsub
+        exact absurd (hev.symm.trans hExp) (by simp)
+    · right; exact hMul
+  have hbase_spec := EvmAsm.Evm64.exp_cond_mul_call_block_spec_within
+    sp evmSp tOld vOld r0 r1 r2 r3 a0 a1 a2 a3 d0 d1 d2 d3 e0 e1 e2 e3
+    v6 v7 v10 v11 mulTarget condMulOff (base + 152) hbase' hmt hd_inner
+  exact cpsTripleWithin_extend_code
+    (hmono := CodeReq.union_sub
+      (fun a i h => evmExpMsbSavedBitTwoMulWithMulCode_exp_sub a i
+        (hCondSub a i h))
+      (fun a i h => evmExpMsbSavedBitTwoMulWithMulCode_mul_sub hd a i h))
     hbase_spec
 
 end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFullLoop.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFullLoop.lean
@@ -130,6 +130,29 @@ theorem exp_msb_bit_test_evm_exp_msb_saved_bit_with_mul_spec_within
     (exp_msb_bit_test_evm_exp_msb_saved_bit_spec_within
       e c v10 mulOff skipOff backOff base)
 
+/-- MSB bit-test block lifted to the two-MUL-offset saved-bit EXP+MUL bundle. -/
+theorem exp_msb_bit_test_evm_exp_msb_saved_bit_two_mul_with_mul_spec_within
+    (e c v10 : Word) (squaringMulOff condMulOff : BitVec 21)
+    (skipOff backOff : BitVec 13) (base mulTarget : Word) :
+    cpsTripleWithin 3 (base + 28) (base + 40)
+      (evmExpMsbSavedBitTwoMulWithMulCode
+        base mulTarget squaringMulOff condMulOff skipOff backOff)
+      ((.x5 ↦ᵣ e) ** (.x6 ↦ᵣ c) ** (.x10 ↦ᵣ v10))
+      ((.x5 ↦ᵣ (e <<< (1 : BitVec 6).toNat)) **
+       (.x6 ↦ᵣ (c + signExtend12 ((-1) : BitVec 12))) **
+       (.x10 ↦ᵣ (e >>> (63 : BitVec 6).toNat))) := by
+  have h := EvmAsm.Evm64.exp_msb_bit_test_block_spec_within e c v10 (base + 28)
+  have hnext : ((base + 28 : Word) + 12) = base + 40 := by bv_omega
+  rw [hnext] at h
+  exact cpsTripleWithin_extend_code
+    (h := h)
+    (hmono := fun a i hi =>
+      evmExpMsbSavedBitTwoMulWithMulCode_exp_sub a i
+        (evmExpMsbSavedBitTwoMulCode_iter_body_sub
+          (base := base) (squaringMulOff := squaringMulOff)
+          (condMulOff := condMulOff) (skipOff := skipOff) (backOff := backOff)
+          a i (expIterBodyFullMsbSavedBitTwoMulCode_bit_test_sub a i hi)))
+
 /-- Save-bit block lifted to the corrected saved-bit EXP+MUL code bundle. -/
 theorem exp_save_bit_evm_exp_msb_saved_bit_with_mul_spec_within
     (bit v18 : Word) (mulOff : BitVec 21) (skipOff backOff : BitVec 13)
@@ -141,6 +164,29 @@ theorem exp_save_bit_evm_exp_msb_saved_bit_with_mul_spec_within
   cpsTripleWithin_extend_evmExpMsbSavedBitWithMulCode
     (exp_save_bit_evm_exp_msb_saved_bit_spec_within
       bit v18 mulOff skipOff backOff base)
+
+/-- Save-bit block lifted to the two-MUL-offset saved-bit EXP+MUL bundle. -/
+theorem exp_save_bit_evm_exp_msb_saved_bit_two_mul_with_mul_spec_within
+    (bit v18 : Word) (squaringMulOff condMulOff : BitVec 21)
+    (skipOff backOff : BitVec 13) (base mulTarget : Word) :
+    cpsTripleWithin 1 (base + 40) (base + 44)
+      (evmExpMsbSavedBitTwoMulWithMulCode
+        base mulTarget squaringMulOff condMulOff skipOff backOff)
+      ((.x10 ↦ᵣ bit) ** (.x18 ↦ᵣ v18))
+      ((.x10 ↦ᵣ bit) ** (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12)))) := by
+  have h := EvmAsm.Evm64.exp_save_bit_block_spec_within bit v18 (base + 40)
+  have hnext : ((base + 40 : Word) + 4) = base + 44 := by bv_omega
+  rw [hnext] at h
+  exact cpsTripleWithin_extend_code
+    (h := h)
+    (hmono := fun a i hi => by
+      have hentry : (base + 40 : Word) = (base + 28) + 12 := by bv_omega
+      rw [hentry] at hi
+      exact evmExpMsbSavedBitTwoMulWithMulCode_exp_sub a i
+        (evmExpMsbSavedBitTwoMulCode_iter_body_sub
+          (base := base) (squaringMulOff := squaringMulOff)
+          (condMulOff := condMulOff) (skipOff := skipOff) (backOff := backOff)
+          a i (expIterBodyFullMsbSavedBitTwoMulCode_save_bit_sub a i hi)))
 
 /-- Prefix of one corrected EXP iteration: extract the current MSB into `x10`
     and save the same bit in callee-saved `x18` before the squaring call. -/
@@ -162,6 +208,40 @@ theorem exp_msb_bit_test_then_save_bit_evm_exp_msb_saved_bit_with_mul_spec_withi
     cpsTripleWithin_frameR (.x18 ↦ᵣ v18) (by pcFree) hBit
   have hSave := exp_save_bit_evm_exp_msb_saved_bit_with_mul_spec_within
     bit v18 mulOff skipOff backOff base mulTarget
+  have hSaveFramed :=
+    cpsTripleWithin_frameL
+      ((.x5 ↦ᵣ (e <<< (1 : BitVec 6).toNat)) **
+       (.x6 ↦ᵣ (c + signExtend12 ((-1) : BitVec 12))))
+      (by pcFree) hSave
+  have hSeq :=
+    cpsTripleWithin_seq_perm_same_cr
+      (fun _ hp => by xperm_hyp hp) hBitFramed hSaveFramed
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by xperm_hyp hp)
+    (fun _ hp => by xperm_hyp hp)
+    hSeq
+
+/-- Two-MUL-offset prefix of one corrected EXP iteration: extract the current
+    MSB into `x10` and save the same bit in `x18` before the squaring call. -/
+theorem exp_msb_bit_test_then_save_bit_evm_exp_msb_saved_bit_two_mul_with_mul_spec_within
+    (e c v10 v18 : Word) (squaringMulOff condMulOff : BitVec 21)
+    (skipOff backOff : BitVec 13) (base mulTarget : Word) :
+    let bit := e >>> (63 : BitVec 6).toNat
+    cpsTripleWithin (3 + 1) (base + 28) (base + 44)
+      (evmExpMsbSavedBitTwoMulWithMulCode
+        base mulTarget squaringMulOff condMulOff skipOff backOff)
+      ((.x5 ↦ᵣ e) ** (.x6 ↦ᵣ c) ** (.x10 ↦ᵣ v10) ** (.x18 ↦ᵣ v18))
+      ((.x5 ↦ᵣ (e <<< (1 : BitVec 6).toNat)) **
+       (.x6 ↦ᵣ (c + signExtend12 ((-1) : BitVec 12))) **
+       (.x10 ↦ᵣ bit) **
+       (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12)))) := by
+  intro bit
+  have hBit := exp_msb_bit_test_evm_exp_msb_saved_bit_two_mul_with_mul_spec_within
+    e c v10 squaringMulOff condMulOff skipOff backOff base mulTarget
+  have hBitFramed :=
+    cpsTripleWithin_frameR (.x18 ↦ᵣ v18) (by pcFree) hBit
+  have hSave := exp_save_bit_evm_exp_msb_saved_bit_two_mul_with_mul_spec_within
+    bit v18 squaringMulOff condMulOff skipOff backOff base mulTarget
   have hSaveFramed :=
     cpsTripleWithin_frameL
       ((.x5 ↦ᵣ (e <<< (1 : BitVec 6).toNat)) **


### PR DESCRIPTION
## Summary
- add `evmExpMsbSavedBitTwoMulWithMulCode`, the two-offset saved-bit EXP code bundle plus shared `mul_callable`
- add EXP and MUL sub-code lifting helpers for that bundle
- lift squaring and conditional-multiply full call-block specs to the two-offset saved-bit EXP+MUL code bundle

## Why
This follows #3697 by giving downstream single-iteration composition separate `hmt` hypotheses: squaring uses `squaringMulOff`, conditional multiply uses `condMulOff`. That removes the impossible single-offset requirement for two distinct JAL PCs to reach the same callable target.

## Verification
- `lake build EvmAsm.Evm64.Exp.Compose.SavedBitFullLoop`
- `scripts/check-file-size.sh EvmAsm/Evm64/Exp/Compose/SavedBitFullLoop.lean`
- `git diff --check`
- `rg -n "sorry|admit|placeholder|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/Compose/SavedBitFullLoop.lean`
- `lake build`
- `scripts/check-unimported.sh`