### PR TITLE
fix(exp): compose two-mul skip loop-back

### DIFF
--- a/EvmAsm/Evm64/Exp.lean
+++ b/EvmAsm/Evm64/Exp.lean
@@ -32,6 +32,7 @@ import EvmAsm.Evm64.Exp.Compose.LoopCodeSpecs
 import EvmAsm.Evm64.Exp.Compose.TopCodeSpecs
 import EvmAsm.Evm64.Exp.Compose.FullLoop
 import EvmAsm.Evm64.Exp.Compose.SavedBitFullLoop
+import EvmAsm.Evm64.Exp.Compose.SavedBitTwoMulSkip
 import EvmAsm.Evm64.Exp.Layout
 import EvmAsm.Evm64.Exp.Spec
 import EvmAsm.Evm64.Exp.StackExecutionBridge

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBase.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBase.lean
@@ -419,6 +419,31 @@ theorem expIterBodyFullMsbSavedBitTwoMulCode_cond_mul_sub {base : Word}
       simp only [exp_iter_body_full_msb_saved_bit_two_mul_len]
       norm_num)
 
+theorem expIterBodyFullMsbSavedBitTwoMulCode_loop_back_sub {base : Word}
+    {squaringMulOff condMulOff : BitVec 21} {skipOff backOff : BitVec 13} :
+    ∀ a i, (CodeReq.ofProg (base + 228)
+      (EvmAsm.Evm64.exp_loop_back backOff)) a = some i →
+      (expIterBodyFullMsbSavedBitTwoMulCode
+        base squaringMulOff condMulOff skipOff backOff) a = some i := by
+  rw [expIterBodyFullMsbSavedBitTwoMulCode_eq_ofProg]
+  exact CodeReq.ofProg_mono_sub base (base + 228)
+    (EvmAsm.Evm64.exp_iter_body_full_msb_saved_bit_two_mul
+      squaringMulOff condMulOff skipOff backOff)
+    (EvmAsm.Evm64.exp_loop_back backOff) 57
+    (by bv_omega)
+    (by
+      unfold EvmAsm.Evm64.exp_iter_body_full_msb_saved_bit_two_mul
+      simp only [EvmAsm.Rv64.seq]
+      unfold Program
+      rfl)
+    (by
+      simp only [exp_iter_body_full_msb_saved_bit_two_mul_len,
+        exp_loop_back_len]
+      omega)
+    (by
+      simp only [exp_iter_body_full_msb_saved_bit_two_mul_len]
+      norm_num)
+
 /-- Top-level CodeReq decomposition for the corrected MSB-first saved-bit EXP
     opcode program. -/
 abbrev evmExpMsbSavedBitCode (base : Word)

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulSkip.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulSkip.lean
@@ -1,0 +1,153 @@
+/-
+  EvmAsm.Evm64.Exp.Compose.SavedBitTwoMulSkip
+
+  Two-MUL-offset saved-bit EXP skip-path composition.  This is split out of
+  `SavedBitFullLoop.lean` to keep the compose files under the size guardrail.
+-/
+
+import EvmAsm.Evm64.Exp.Compose.SavedBitFullLoop
+
+namespace EvmAsm.Evm64.Exp.Compose
+
+open EvmAsm.Rv64.Tactics
+open EvmAsm.Rv64
+
+/-- Saved-bit loop-back block lifted to the two-MUL-offset EXP+MUL code
+    bundle. -/
+theorem exp_loop_back_evm_exp_msb_saved_bit_two_mul_with_mul_spec_within
+    (c : Word)
+    (squaringMulOff condMulOff : BitVec 21) (skipOff backOff : BitVec 13)
+    (base mulTarget target : Word)
+    (htarget : ((base + 256) + 4 : Word) + signExtend13 backOff = target) :
+    let cNew := c + signExtend12 ((-1 : BitVec 12))
+    cpsBranchWithin 2 (base + 256)
+      (evmExpMsbSavedBitTwoMulWithMulCode
+        base mulTarget squaringMulOff condMulOff skipOff backOff)
+      ((.x9 ↦ᵣ c) ** (.x0 ↦ᵣ (0 : Word)))
+      target ((.x9 ↦ᵣ cNew) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜cNew ≠ 0⌝)
+      (base + 264) ((.x9 ↦ᵣ cNew) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜cNew = 0⌝) := by
+  have h := EvmAsm.Evm64.exp_loop_back_spec_within c backOff (base + 256)
+    target htarget
+  have hnext : ((base + 256 : Word) + 8) = base + 264 := by bv_omega
+  rw [hnext] at h
+  exact cpsBranchWithin_extend_code (h := h)
+    (hmono := fun a i hi =>
+      evmExpMsbSavedBitTwoMulWithMulCode_exp_sub a i
+        (evmExpMsbSavedBitTwoMulCode_iter_loop_back_sub a i hi))
+
+/-- Zero-bit path through the two-MUL-offset saved-bit BEQ, followed by the
+    loop-back counter update.  The nonzero conditional-multiply path is left
+    as the first exit for the next composition slice. -/
+theorem exp_msb_saved_bit_prefix_squaring_beq_skip_then_loop_back_evm_exp_msb_saved_bit_two_mul_with_mul_spec_within
+    (e c iterCount v10 v18 sp evmSp vOld r0 r1 r2 r3 d0 d1 d2 d3
+      e0 e1 e2 e3 v7 v11 mulTarget : Word)
+    (squaringMulOff condMulOff : BitVec 21) (skipOff backOff : BitVec 13)
+    (base loopTarget : Word)
+    (hbase : base &&& 1 = 0)
+    (hmt : mulTarget = ((base + 44) + 64) + signExtend21 squaringMulOff)
+    (hd : CodeReq.Disjoint
+            (evmExpMsbSavedBitTwoMulCode
+              base squaringMulOff condMulOff skipOff backOff)
+            (mul_callable_code mulTarget))
+    (hskip : (base + 148 : Word) + signExtend13 skipOff = base + 256)
+    (hback : ((base + 256) + 4 : Word) + signExtend13 backOff = loopTarget) :
+    let bit := e >>> (63 : BitVec 6).toNat
+    let w := expResultWord r0 r1 r2 r3
+    let iterCountNew := iterCount + signExtend12 ((-1 : BitVec 12))
+    let rest : Assertion :=
+      (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
+      ⌜bit + signExtend12 (0 : BitVec 12) = 0⌝ **
+      (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) **
+      (.x5 ↦ᵣ (w * w).getLimbN 3) **
+      evmWordIs sp (w * w) ** evmWordIs (evmSp + 32) (w * w) **
+      regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
+      memOwn evmSp ** memOwn (evmSp + 8) **
+      memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
+      (.x1 ↦ᵣ ((base + 44) + 68))
+    cpsNBranchWithin ((3 + 1 + (17 + 64 + 9) + 1) + 2) (base + 28)
+      (evmExpMsbSavedBitTwoMulWithMulCode
+        base mulTarget squaringMulOff condMulOff skipOff backOff)
+      ((.x5 ↦ᵣ e) ** (.x6 ↦ᵣ c) ** (.x10 ↦ᵣ v10) ** (.x18 ↦ᵣ v18) **
+       (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+       ((evmSp + signExtend12 (0 : BitVec 12)) ↦ₘ d0) **
+       ((evmSp + signExtend12 (8 : BitVec 12)) ↦ₘ d1) **
+       ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ d2) **
+       ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ d3) **
+       ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ e0) **
+       ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ e1) **
+       ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ e2) **
+       ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ e3) **
+       (.x7 ↦ᵣ v7) ** (.x11 ↦ᵣ v11) ** (.x1 ↦ᵣ vOld) **
+       (.x0 ↦ᵣ (0 : Word)) ** (.x9 ↦ᵣ iterCount))
+      [((base + 152),
+          ((.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
+           (.x0 ↦ᵣ (0 : Word)) ** ⌜bit + signExtend12 (0 : BitVec 12) ≠ 0⌝ **
+           (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) **
+           (.x5 ↦ᵣ (w * w).getLimbN 3) **
+           evmWordIs sp (w * w) ** evmWordIs (evmSp + 32) (w * w) **
+           regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
+           memOwn evmSp ** memOwn (evmSp + 8) **
+           memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
+           (.x1 ↦ᵣ ((base + 44) + 68))) ** (.x9 ↦ᵣ iterCount)),
+        (loopTarget,
+          (((.x9 ↦ᵣ iterCountNew) ** (.x0 ↦ᵣ (0 : Word)) **
+           ⌜iterCountNew ≠ 0⌝) ** rest)),
+        (base + 264,
+          (((.x9 ↦ᵣ iterCountNew) ** (.x0 ↦ᵣ (0 : Word)) **
+           ⌜iterCountNew = 0⌝) ** rest))] := by
+  intro bit w iterCountNew rest
+  have hBranch :=
+    exp_msb_saved_bit_prefix_squaring_then_beq_evm_exp_msb_saved_bit_two_mul_with_mul_spec_within
+      e c v10 v18 sp evmSp vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+      v7 v11 mulTarget squaringMulOff condMulOff skipOff backOff base
+      (base + 256) hbase hmt hd hskip
+  have hBranchFramed :=
+    cpsBranchWithin_frameR (.x9 ↦ᵣ iterCount) (by pcFree) hBranch
+  have hBranchSwapped := cpsBranchWithin_swap hBranchFramed
+  have hLoop := exp_loop_back_evm_exp_msb_saved_bit_two_mul_with_mul_spec_within
+    iterCount squaringMulOff condMulOff skipOff backOff base mulTarget
+    loopTarget hback
+  have hLoopFramed := cpsBranchWithin_frameR rest (by
+    dsimp [rest]
+    pcFree) hLoop
+  have hLoopN := cpsBranchWithin_as_cpsNBranchWithin hLoopFramed
+  have hSeq :
+      cpsNBranchWithin ((3 + 1 + (17 + 64 + 9) + 1) + 2) (base + 28)
+        (evmExpMsbSavedBitTwoMulWithMulCode
+          base mulTarget squaringMulOff condMulOff skipOff backOff)
+        _ _ :=
+    cpsBranchWithin_cons_cpsNBranchWithin_with_perm_same_cr
+      (fun _ hp => by
+        dsimp [rest, bit] at hp ⊢
+        xperm_hyp hp)
+      hBranchSwapped hLoopN
+  have hSeqPre :
+      cpsNBranchWithin ((3 + 1 + (17 + 64 + 9) + 1) + 2) (base + 28)
+        (evmExpMsbSavedBitTwoMulWithMulCode
+          base mulTarget squaringMulOff condMulOff skipOff backOff)
+        ((.x5 ↦ᵣ e) ** (.x6 ↦ᵣ c) ** (.x10 ↦ᵣ v10) ** (.x18 ↦ᵣ v18) **
+         (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) **
+         ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+         ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+         ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+         ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+         ((evmSp + signExtend12 (0 : BitVec 12)) ↦ₘ d0) **
+         ((evmSp + signExtend12 (8 : BitVec 12)) ↦ₘ d1) **
+         ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ d2) **
+         ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ d3) **
+         ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ e0) **
+         ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ e1) **
+         ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ e2) **
+         ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ e3) **
+         (.x7 ↦ᵣ v7) ** (.x11 ↦ᵣ v11) ** (.x1 ↦ᵣ vOld) **
+         (.x0 ↦ᵣ (0 : Word)) ** (.x9 ↦ᵣ iterCount))
+        _ :=
+    cpsNBranchWithin_weaken_pre
+      (fun _ hp => by xperm_hyp hp) hSeq
+  exact hSeqPre
+
+end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/TopCodeSpecs.lean
+++ b/EvmAsm/Evm64/Exp/Compose/TopCodeSpecs.lean
@@ -183,6 +183,18 @@ theorem evmExpMsbSavedBitCode_iter_loop_back_sub {base : Word}
   exact evmExpMsbSavedBitCode_iter_body_sub a i
     (expIterBodyFullMsbSavedBitCode_loop_back_sub a i h)
 
+theorem evmExpMsbSavedBitTwoMulCode_iter_loop_back_sub {base : Word}
+    {squaringMulOff condMulOff : BitVec 21} {skipOff backOff : BitVec 13} :
+    ∀ a i, (CodeReq.ofProg (base + 256)
+      (EvmAsm.Evm64.exp_loop_back backOff)) a = some i →
+      (evmExpMsbSavedBitTwoMulCode
+        base squaringMulOff condMulOff skipOff backOff) a = some i := by
+  intro a i h
+  have haddr : (base + 256 : Word) = base + 28 + 228 := by bv_omega
+  rw [haddr] at h
+  exact evmExpMsbSavedBitTwoMulCode_iter_body_sub a i
+    (expIterBodyFullMsbSavedBitTwoMulCode_loop_back_sub a i h)
+
 /-- Saved-bit conditional-multiply BEQ skip-gate directly included in the
     corrected saved-bit top-level EXP code bundle. -/
 theorem evmExpMsbSavedBitCode_cond_mul_beq_sub {base : Word}


### PR DESCRIPTION
## Summary
- add two-MUL loop-back subcode helpers for the saved-bit EXP code bundle
- split two-MUL skip-path composition into `SavedBitTwoMulSkip.lean` to keep compose files under the guardrail
- prove `exp_msb_saved_bit_prefix_squaring_beq_skip_then_loop_back_evm_exp_msb_saved_bit_two_mul_with_mul_spec_within`

## Verification
- `lake build EvmAsm.Evm64.Exp.Compose.SavedBitTwoMulSkip`
- `scripts/check-file-size.sh EvmAsm/Evm64/Exp/Compose/SavedBitBase.lean EvmAsm/Evm64/Exp/Compose/TopCodeSpecs.lean EvmAsm/Evm64/Exp/Compose/SavedBitFullLoop.lean EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulSkip.lean EvmAsm/Evm64/Exp.lean`
- `git diff --check`
- `rg -n "sorry|admit|placeholder|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/Compose/SavedBitBase.lean EvmAsm/Evm64/Exp/Compose/TopCodeSpecs.lean EvmAsm/Evm64/Exp/Compose/SavedBitFullLoop.lean EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulSkip.lean EvmAsm/Evm64/Exp.lean`
- `lake build`
- `scripts/check-unimported.sh`