### PR TITLE
fix(exp): add result word limb repack lemma

### DIFF
--- a/EvmAsm/Evm64/Exp/LimbSpec.lean
+++ b/EvmAsm/Evm64/Exp/LimbSpec.lean
@@ -568,6 +568,14 @@ theorem expResultWord_getLimbN_4 (r0 r1 r2 r3 : Word) :
     (expResultWord r0 r1 r2 r3).getLimbN 4 = 0 := by
   simp [EvmWord.getLimbN]
 
+/-- Repacking the four concrete limbs of an EVM word with `expResultWord`
+    returns the original word. -/
+theorem expResultWord_getLimbN_self (r : EvmWord) :
+    expResultWord (r.getLimbN 0) (r.getLimbN 1) (r.getLimbN 2) (r.getLimbN 3) = r := by
+  apply EvmWord.eq_iff_limbs.mpr
+  intro i
+  fin_cases i <;> unfold expResultWord <;> rw [EvmWord.getLimb_fromLimbs] <;> rfl
+
 /-- The four limbs written by `exp_epilogue` fold to the assembled EXP result
     word in the output stack slot at `evmSp + 32`. -/
 theorem exp_epilogue_result_word


### PR DESCRIPTION
## Summary
- add expResultWord_getLimbN_self for repacking an EVM word from its four concrete limbs
- place the lemma next to the existing expResultWord limb projection lemmas

## Verification
- lake build EvmAsm.Evm64.Exp.LimbSpec
- git diff --check
- rg -n "sorry|admit|placeholder|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/LimbSpec.lean
- wc -l EvmAsm/Evm64/Exp/LimbSpec.lean
- scripts/check-unimported.sh
- lake build