### PR TITLE
fix(exp): expose two-mul iter branch view

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCond.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCond.lean
@@ -681,4 +681,101 @@ theorem exp_msb_saved_bit_two_mul_full_iter_merged_exit_spec_within
       right
       simpa [skipExit, skipRest, baseFrame] using hp
 
+/-- Branch-shaped view of the merged two-MUL saved-bit one-iteration theorem.
+    This is just `cpsNBranchWithin_as_cpsBranchWithin` applied to the merged
+    two-exit N-branch, keeping downstream composition code on the ordinary
+    branch interface. -/
+theorem exp_msb_saved_bit_two_mul_full_iter_branch_spec_within
+    (e c iterCount v10 v18 sp evmSp vOld r0 r1 r2 r3 d0 d1 d2 d3
+      e0 e1 e2 e3 a0 a1 a2 a3 v7 v11 mulTarget : Word)
+    (squaringMulOff condMulOff : BitVec 21) (skipOff backOff : BitVec 13)
+    (base loopTarget : Word)
+    (hbase : base &&& 1 = 0)
+    (hsqmt : mulTarget = ((base + 44) + 64) + signExtend21 squaringMulOff)
+    (hcondmt : mulTarget = ((base + 152) + 64) + signExtend21 condMulOff)
+    (hd : CodeReq.Disjoint
+            (evmExpMsbSavedBitTwoMulCode
+              base squaringMulOff condMulOff skipOff backOff)
+            (mul_callable_code mulTarget))
+    (hskip : (base + 148 : Word) + signExtend13 skipOff = base + 256)
+    (hback : ((base + 256) + 4 : Word) + signExtend13 backOff = loopTarget) :
+    let bit := e >>> (63 : BitVec 6).toNat
+    let w := expResultWord r0 r1 r2 r3
+    let aw := expResultWord a0 a1 a2 a3
+    let rw := (w * w) * aw
+    let iterCountNew := iterCount + signExtend12 ((-1 : BitVec 12))
+    let baseFrame : Assertion :=
+      ((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
+      ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **
+      ((evmSp + signExtend12 ((-48) : BitVec 12)) ↦ₘ a2) **
+      ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3)
+    let skipRest : Assertion :=
+      (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
+      ⌜bit + signExtend12 (0 : BitVec 12) = 0⌝ **
+      (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) **
+      (.x5 ↦ᵣ (w * w).getLimbN 3) **
+      evmWordIs sp (w * w) ** evmWordIs (evmSp + 32) (w * w) **
+      regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
+      memOwn evmSp ** memOwn (evmSp + 8) **
+      memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
+      (.x1 ↦ᵣ ((base + 44) + 68))
+    let condRest : Assertion :=
+      (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) **
+      (.x5 ↦ᵣ rw.getLimbN 3) **
+      ((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
+      ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **
+      ((evmSp + signExtend12 ((-48) : BitVec 12)) ↦ₘ a2) **
+      ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3) **
+      evmWordIs sp rw ** evmWordIs (evmSp + 32) rw **
+      regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
+      memOwn evmSp ** memOwn (evmSp + 8) **
+      memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
+      (.x1 ↦ᵣ ((base + 152) + 68))
+    let condFrame : Assertion :=
+      (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
+      ⌜bit + signExtend12 (0 : BitVec 12) ≠ 0⌝
+    let condLoop : Assertion :=
+      (((.x9 ↦ᵣ iterCountNew) ** (.x0 ↦ᵣ (0 : Word)) **
+       ⌜iterCountNew ≠ 0⌝) ** condRest) ** condFrame
+    let condExit : Assertion :=
+      (((.x9 ↦ᵣ iterCountNew) ** (.x0 ↦ᵣ (0 : Word)) **
+       ⌜iterCountNew = 0⌝) ** condRest) ** condFrame
+    let skipLoop : Assertion :=
+      (((.x9 ↦ᵣ iterCountNew) ** (.x0 ↦ᵣ (0 : Word)) **
+       ⌜iterCountNew ≠ 0⌝) ** skipRest) ** baseFrame
+    let skipExit : Assertion :=
+      (((.x9 ↦ᵣ iterCountNew) ** (.x0 ↦ᵣ (0 : Word)) **
+       ⌜iterCountNew = 0⌝) ** skipRest) ** baseFrame
+    cpsBranchWithin
+      (((3 + 1 + (17 + 64 + 9) + 1) + 2) + ((17 + 64 + 9) + 2))
+      (base + 28)
+      (evmExpMsbSavedBitTwoMulWithMulCode
+        base mulTarget squaringMulOff condMulOff skipOff backOff)
+      (((.x5 ↦ᵣ e) ** (.x6 ↦ᵣ c) ** (.x10 ↦ᵣ v10) ** (.x18 ↦ᵣ v18) **
+        (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) **
+        ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+        ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+        ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+        ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+        ((evmSp + signExtend12 (0 : BitVec 12)) ↦ₘ d0) **
+        ((evmSp + signExtend12 (8 : BitVec 12)) ↦ₘ d1) **
+        ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ d2) **
+        ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ d3) **
+        ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ e0) **
+        ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ e1) **
+        ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ e2) **
+        ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ e3) **
+        (.x7 ↦ᵣ v7) ** (.x11 ↦ᵣ v11) ** (.x1 ↦ᵣ vOld) **
+        (.x0 ↦ᵣ (0 : Word)) ** (.x9 ↦ᵣ iterCount)) ** baseFrame)
+      loopTarget (fun h => condLoop h ∨ skipLoop h)
+      (base + 264) (fun h => condExit h ∨ skipExit h) := by
+  intro bit w aw rw iterCountNew baseFrame skipRest condRest condFrame
+    condLoop condExit skipLoop skipExit
+  exact cpsNBranchWithin_as_cpsBranchWithin
+    (exp_msb_saved_bit_two_mul_full_iter_merged_exit_spec_within
+      e c iterCount v10 v18 sp evmSp vOld r0 r1 r2 r3 d0 d1 d2 d3
+      e0 e1 e2 e3 a0 a1 a2 a3 v7 v11 mulTarget
+      squaringMulOff condMulOff skipOff backOff base loopTarget
+      hbase hsqmt hcondmt hd hskip hback)
+
 end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- expose the merged two-MUL saved-bit one-iteration N-branch from #3714 as a regular cpsBranchWithin theorem
- keep loop and terminal exits at loopTarget and base + 264 with assertion-level disjunction postconditions
- provide a thinner downstream interface for later full-loop composition

## Verification
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitTwoMulCond
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCond.lean
- wc -l EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCond.lean
- scripts/check-unimported.sh
- lake build