### PR TITLE
fix(divmod): bridge bzero post without x1 own

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/Unified.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/Unified.lean
@@ -203,6 +203,56 @@ theorem divBzeroDispatchPostPreservingX1Frame_unfold
   delta divBzeroDispatchPostPreservingX1Frame
   rfl
 
+theorem divStackDispatchPostNoX1_weaken_bzero_frame
+    (sp : Word) (a b : EvmWord)
+    {v1 v2 v6 v7 v11 : Word}
+    {q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratch_un0 : Word} :
+    ∀ h,
+      (((.x12 ↦ᵣ (sp + 32)) **
+        (.x2 ↦ᵣ v2) ** regOwn .x5 ** (.x6 ↦ᵣ v6) **
+        (.x7 ↦ᵣ v7) ** regOwn .x10 ** (.x11 ↦ᵣ v11) **
+        (.x0 ↦ᵣ (0 : Word)) **
+        evmWordIs sp a ** evmWordIs (sp + 32) (EvmWord.div a b) **
+        divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratch_un0) **
+       (.x1 ↦ᵣ v1)) h →
+      (divStackDispatchPostNoX1 sp a b ** (.x1 ↦ᵣ v1)) h := by
+  intro h hp
+  rw [divStackDispatchPostNoX1_unfold]
+  apply sepConj_mono_left _ h hp
+  intro hLeft hpLeft
+  apply sepConj_mono_right
+  apply sepConj_mono (regIs_implies_regOwn .x2 (v := v2))
+  apply sepConj_mono_right
+  apply sepConj_mono (regIs_implies_regOwn .x6 (v := v6))
+  apply sepConj_mono (regIs_implies_regOwn .x7 (v := v7))
+  apply sepConj_mono_right
+  apply sepConj_mono (regIs_implies_regOwn .x11 (v := v11))
+  apply sepConj_mono_right
+  apply sepConj_mono_right
+  apply sepConj_mono_right
+  exact divScratchValuesCall_implies_divScratchOwnCall
+    sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem
+      retMem dMem dloMem scratch_un0
+  exact hpLeft
+
+theorem divBzeroDispatchPostPreservingX1Frame_weaken_noX1
+    (sp : Word) (a b : EvmWord)
+    {v1 v2 v6 v7 v11 : Word}
+    {q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratch_un0 : Word} :
+    ∀ h,
+      divBzeroDispatchPostPreservingX1Frame sp a b v1 v2 v6 v7 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0 h →
+      (divStackDispatchPostNoX1 sp a b ** (.x1 ↦ᵣ v1)) h := by
+  intro h hp
+  rw [divBzeroDispatchPostPreservingX1Frame_unfold] at hp
+  simp only [sepConj_assoc', sepConj_comm', sepConj_left_comm'] at hp ⊢
+  exact divStackDispatchPostNoX1_weaken_bzero_frame
+    (sp := sp) (a := a) (b := b) h (by xperm_hyp hp)
+
 /-- Zero-divisor DIV dispatcher over `divCode_noNop`, preserving the exact
     incoming `x1` value in a named framed postcondition. -/
 theorem evm_div_bzero_stack_spec_within_dispatch_noNop_preserving_x1_frame_uni
@@ -249,6 +299,28 @@ theorem evm_div_bzero_stack_spec_within_dispatch_noNop_preserving_x1_frame_uni
         simp only [sepConj_assoc', sepConj_comm', sepConj_left_comm'] at hq ⊢
         exact hq)
       hFramed
+
+/-- Zero-divisor DIV dispatcher over `divCode_noNop`, preserving the exact
+    incoming `x1` value in the callable-ready post shape. -/
+theorem evm_div_bzero_stack_spec_within_dispatch_noNop_preserving_x1_uni
+    (sp base : Word)
+    (a b : EvmWord) (v1 v2 v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratch_un0 : Word)
+    (hbz : b = 0) :
+    cpsTripleWithin unifiedDivBound base (base + nopOff) (divCode_noNop base)
+      (divModStackDispatchPre sp a b
+        v1 v2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0)
+      (divStackDispatchPostNoX1 sp a b ** (.x1 ↦ᵣ v1)) := by
+  exact cpsTripleWithin_weaken (fun _ hp => hp) (fun h hp =>
+    divBzeroDispatchPostPreservingX1Frame_weaken_noX1
+      (sp := sp) (a := a) (b := b) h hp)
+    (evm_div_bzero_stack_spec_within_dispatch_noNop_preserving_x1_frame_uni
+      sp base a b v1 v2 v5 v6 v7 v10 v11
+      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      nMem shiftMem jMem retMem dMem dloMem scratch_un0 hbz)
 
 theorem modStackDispatchPost_weaken_bzero_frame
     (sp : Word) (a b : EvmWord)


### PR DESCRIPTION
## Summary
- add divStackDispatchPostNoX1_weaken_bzero_frame to weaken the bzero framed post while preserving concrete x1 separately
- add divBzeroDispatchPostPreservingX1Frame_weaken_noX1
- expose evm_div_bzero_stack_spec_within_dispatch_noNop_preserving_x1_uni in the callable-ready post shape

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.Unified
- git diff --check
- rg -n "sorry|admit|axiom|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/Spec/Unified.lean
- wc -l EvmAsm/Evm64/DivMod/Spec/Unified.lean
- scripts/check-unimported.sh
- lake build