### PR TITLE
fix(divmod): expose callable bzero x1 post

### DIFF
--- a/EvmAsm/Evm64/DivMod/Callable.lean
+++ b/EvmAsm/Evm64/DivMod/Callable.lean
@@ -669,6 +669,32 @@ theorem evm_div_callable_spec_from_noNop_preserving_x1 (sp base raVal : Word)
     cpsTripleWithin_frameL (divStackDispatchPostNoX1 sp a b) hpcFreePost hRet
   exact cpsTripleWithin_seq_same_cr hStackCall hRetFramed
 
+/-- Zero-divisor DIV callable wrapper that preserves the exact incoming `x1`
+    return address. This is the callable-ready specialization needed by SDIV
+    when the absolute divisor is zero. -/
+theorem evm_div_callable_bzero_preserving_x1_spec (sp base raVal : Word)
+    (a b : EvmWord) (v2 v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (hbz : b = 0) :
+    cpsTripleWithin (unifiedDivBound + 1) base (raVal &&& ~~~1)
+      (evm_div_callable_code base)
+      (divModStackDispatchPre sp a b
+        raVal v2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+      (divStackDispatchPostNoX1 sp a b ** (.x1 ↦ᵣ raVal)) := by
+  have hStack :=
+    evm_div_bzero_stack_spec_within_dispatch_noNop_preserving_x1_uni
+      sp base a b raVal v2 v5 v6 v7 v10 v11
+      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      nMem shiftMem jMem retMem dMem dloMem scratchUn0 hbz
+  exact evm_div_callable_spec_from_noNop_preserving_x1
+    sp base raVal a b v5 v6 v7 v10 v11
+    q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0
+    (DivStackSpecCase.bzero raVal v2 hbz) hStack
+
 theorem evm_mod_callable_spec_from_noNop (sp base raVal : Word)
     (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7


### PR DESCRIPTION
## Summary
- add evm_div_callable_bzero_preserving_x1_spec
- instantiate the no-NOP zero-divisor dispatcher proof with the callable return address in x1
- reuse evm_div_callable_spec_from_noNop_preserving_x1 to compose the swapped cc_ret

## Verification
- lake build EvmAsm.Evm64.DivMod.Callable
- git diff --check
- rg -n "sorry|admit|axiom|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/Callable.lean
- wc -l EvmAsm/Evm64/DivMod/Callable.lean
- scripts/check-unimported.sh
- lake build