### PR TITLE
fix(sdiv): compose bzero callable handoff

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/DivCallDispatch.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallDispatch.lean
@@ -233,4 +233,108 @@ theorem saveRa_signs_abs_signXor_then_divCall_then_exact_callable_spec_in_sdivCo
     exact hPrefixRaw
   exact cpsTripleWithin_seq_same_cr hPrefix hCallable
 
+/-- SDIV wrapper prefix followed by the zero-divisor branch of the unsigned DIV
+    callable, stopping at the result-sign-fixup entry. The hypothesis `hbz`
+    is over the already-normalized divisor word produced by the SDIV absolute
+    value prefix. -/
+theorem saveRa_signs_abs_signXor_then_divCall_bzero_callable_spec_in_sdivCode
+    (vRa vSavedOld sp sDividendOld sDivisorOld
+      dividendMaskOld dividendValueOld dividendCarryOld
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+      v2 v5 v6 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (base : Word) (hbase : base &&& 1 = 0)
+    (hbz : sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop = 0) :
+    cpsTripleWithin (49 + (EvmAsm.Evm64.unifiedDivBound + 1))
+      base (base + resultSignFixOff) (sdivCode base)
+      (saveRaSignsAbsSignXorThenDivCallPre vRa vSavedOld sp sDividendOld sDivisorOld
+        dividendMaskOld dividendValueOld dividendCarryOld
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
+       ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
+        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0))
+      ((EvmAsm.Evm64.divStackDispatchPostNoX1 sp
+          (sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+          (sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) **
+        (.x1 ↦ᵣ ((base + divCallOff) + 4))) **
+       ((.x8 ↦ᵣ ((dividendTop >>> (63 : BitVec 6).toNat) ^^^
+          (divisorTop >>> (63 : BitVec 6).toNat))) **
+        (.x9 ↦ᵣ (divisorTop >>> (63 : BitVec 6).toNat)) **
+        (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12))))) := by
+  let dividendAbsWord :=
+    sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+  let divisorAbsWord :=
+    sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+  let divisorSign := divisorTop >>> (63 : BitVec 6).toNat
+  let divisorMask := (0 : Word) - divisorSign
+  let divisorSum0 := (divisorLimb0 ^^^ divisorMask) + divisorSign
+  let divisorCarry0 := if BitVec.ult divisorSum0 divisorSign then (1 : Word) else 0
+  let divisorSum1 := (divisorLimb1 ^^^ divisorMask) + divisorCarry0
+  let divisorCarry1 := if BitVec.ult divisorSum1 divisorCarry0 then (1 : Word) else 0
+  let divisorSum2 := (divisorLimb2 ^^^ divisorMask) + divisorCarry1
+  let divisorCarry2 := if BitVec.ult divisorSum2 divisorCarry1 then (1 : Word) else 0
+  let divisorSum3 := (divisorTop ^^^ divisorMask) + divisorCarry2
+  let divisorCarry3 := if BitVec.ult divisorSum3 divisorCarry2 then (1 : Word) else 0
+  let resultSign :=
+    (dividendTop >>> (63 : BitVec 6).toNat) ^^^ divisorSign
+  let signFrame : Assertion :=
+    ((.x8 ↦ᵣ resultSign) ** (.x9 ↦ᵣ divisorSign) **
+      (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12))))
+  have hCallableRaw :=
+    EvmAsm.Evm64.evm_div_callable_bzero_preserving_x1_spec
+      sp (base + wrapperEndOff) ((base + divCallOff) + 4)
+      dividendAbsWord divisorAbsWord v2 v5 v6 divisorSum3 divisorMask divisorCarry3
+      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      nMem shiftMem jMem retMem dMem dloMem scratchUn0
+      (by simpa [divisorAbsWord] using hbz)
+  have hCallableCode :=
+    cpsTripleWithin_extend_code
+      (hmono := evm_div_callable_code_sub_sdivCode (base := base)) hCallableRaw
+  have hCallableFramed :=
+    cpsTripleWithin_frameR signFrame (by
+      dsimp [signFrame]
+      pcFree) hCallableCode
+  have hCallableFramedExit :
+      cpsTripleWithin (EvmAsm.Evm64.unifiedDivBound + 1)
+        (base + wrapperEndOff) (base + resultSignFixOff) (sdivCode base)
+        (EvmAsm.Evm64.divModStackDispatchPre sp dividendAbsWord divisorAbsWord
+          ((base + divCallOff) + 4) v2 v5 v6 divisorSum3 divisorMask divisorCarry3
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0 ** signFrame)
+        ((EvmAsm.Evm64.divStackDispatchPostNoX1 sp dividendAbsWord divisorAbsWord **
+          (.x1 ↦ᵣ ((base + divCallOff) + 4))) ** signFrame) := by
+    rw [← divCall_return_andn_one_eq_resultSignFixOff base hbase]
+    exact hCallableFramed
+  have hCallable :
+      cpsTripleWithin (EvmAsm.Evm64.unifiedDivBound + 1)
+        (base + wrapperEndOff) (base + resultSignFixOff) (sdivCode base)
+        (saveRaDivCallDispatchReadyPost vRa sp base
+          dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+          divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+          v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+        ((EvmAsm.Evm64.divStackDispatchPostNoX1 sp dividendAbsWord divisorAbsWord **
+          (.x1 ↦ᵣ ((base + divCallOff) + 4))) ** signFrame) := by
+    exact cpsTripleWithin_weaken (fun h hp => by
+      rw [saveRaDivCallDispatchReadyPost_unfold] at hp
+      dsimp [dividendAbsWord, divisorAbsWord, divisorSign, divisorMask, divisorSum0,
+        divisorCarry0, divisorSum1, divisorCarry1, divisorSum2, divisorCarry2,
+        divisorSum3, divisorCarry3, resultSign, signFrame] at hp ⊢
+      exact hp) (fun h hp => by
+      dsimp [signFrame] at hp ⊢
+      exact hp) hCallableFramedExit
+  have hSeq :=
+    saveRa_signs_abs_signXor_then_divCall_then_exact_callable_spec_in_sdivCode
+      vRa vSavedOld sp sDividendOld sDivisorOld
+      dividendMaskOld dividendValueOld dividendCarryOld
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+      v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0
+      base (base + resultSignFixOff) hCallable
+  simpa [dividendAbsWord, divisorAbsWord, divisorSign, resultSign, signFrame] using hSeq
+
 end EvmAsm.Evm64.SDiv.Compose


### PR DESCRIPTION
## Summary
- add saveRa_signs_abs_signXor_then_divCall_bzero_callable_spec_in_sdivCode
- compose the SDIV prefix through the zero-divisor branch of the unsigned DIV callable
- preserve the SDIV sign frame and normalize the callable return PC to resultSignFixOff

## Verification
- lake build EvmAsm.Evm64.SDiv.Compose.DivCallDispatch
- git diff --check
- rg -n "sorry|admit|axiom|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/DivCallDispatch.lean
- wc -l EvmAsm/Evm64/SDiv/Compose/DivCallDispatch.lean
- scripts/check-unimported.sh
- lake build