### PR TITLE
fix(sdiv): name bzero callable post

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/DivCallDispatch.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallDispatch.lean
@@ -337,4 +337,78 @@ theorem saveRa_signs_abs_signXor_then_divCall_bzero_callable_spec_in_sdivCode
       base (base + resultSignFixOff) hCallable
   simpa [dividendAbsWord, divisorAbsWord, divisorSign, resultSign, signFrame] using hSeq
 
+/-- Named postcondition after the SDIV prefix has called the unsigned DIV
+    callable along the zero-divisor branch. This keeps the sign frame and the
+    concrete return address bundled for the following result-sign-fix step. -/
+@[irreducible]
+def saveRaDivCallBzeroCallablePost
+    (vRa sp base : Word)
+    (dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word) : Assertion :=
+  let resultSign :=
+    (dividendTop >>> (63 : BitVec 6).toNat) ^^^
+      (divisorTop >>> (63 : BitVec 6).toNat)
+  let divisorSign := divisorTop >>> (63 : BitVec 6).toNat
+  ((EvmAsm.Evm64.divStackDispatchPostNoX1 sp
+      (sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+      (sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) **
+    (.x1 ↦ᵣ ((base + divCallOff) + 4))) **
+   ((.x8 ↦ᵣ resultSign) ** (.x9 ↦ᵣ divisorSign) **
+    (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12)))))
+
+theorem saveRaDivCallBzeroCallablePost_unfold
+    {vRa sp base : Word}
+    {dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word} :
+    saveRaDivCallBzeroCallablePost vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop =
+      (let resultSign :=
+         (dividendTop >>> (63 : BitVec 6).toNat) ^^^
+           (divisorTop >>> (63 : BitVec 6).toNat)
+       let divisorSign := divisorTop >>> (63 : BitVec 6).toNat
+       ((EvmAsm.Evm64.divStackDispatchPostNoX1 sp
+           (sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+           (sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) **
+         (.x1 ↦ᵣ ((base + divCallOff) + 4))) **
+        ((.x8 ↦ᵣ resultSign) ** (.x9 ↦ᵣ divisorSign) **
+         (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12)))))) := by
+  delta saveRaDivCallBzeroCallablePost
+  rfl
+
+/-- SDIV wrapper prefix followed by the zero-divisor unsigned-DIV callable,
+    using the named postcondition consumed by later composition slices. -/
+theorem saveRa_signs_abs_signXor_then_divCall_bzero_callable_named_post_spec_in_sdivCode
+    (vRa vSavedOld sp sDividendOld sDivisorOld
+      dividendMaskOld dividendValueOld dividendCarryOld
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+      v2 v5 v6 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (base : Word) (hbase : base &&& 1 = 0)
+    (hbz : sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop = 0) :
+    cpsTripleWithin (49 + (EvmAsm.Evm64.unifiedDivBound + 1))
+      base (base + resultSignFixOff) (sdivCode base)
+      (saveRaSignsAbsSignXorThenDivCallPre vRa vSavedOld sp sDividendOld sDivisorOld
+        dividendMaskOld dividendValueOld dividendCarryOld
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
+       ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
+        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0))
+      (saveRaDivCallBzeroCallablePost vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) := by
+  have h :=
+    saveRa_signs_abs_signXor_then_divCall_bzero_callable_spec_in_sdivCode
+      vRa vSavedOld sp sDividendOld sDivisorOld
+      dividendMaskOld dividendValueOld dividendCarryOld
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+      v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 base hbase hbz
+  rw [saveRaDivCallBzeroCallablePost_unfold]
+  exact h
+
 end EvmAsm.Evm64.SDiv.Compose


### PR DESCRIPTION
## Summary
- add saveRaDivCallBzeroCallablePost as an irreducible postcondition for the SDIV prefix plus zero-divisor DIV callable path
- add a named-post wrapper theorem over the existing bzero callable handoff theorem

## Verification
- lake build EvmAsm.Evm64.SDiv.Compose.DivCallDispatch
- git diff --check
- rg -n "sorry|admit|axiom|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/DivCallDispatch.lean
- scripts/check-unimported.sh
- lake build