### PR TITLE
fix(sdiv): expose signfix x7 ownership

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/ResultSignFixOwn.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/ResultSignFixOwn.lean
@@ -56,4 +56,48 @@ theorem resultSignFix_regOwn_x10_spec_in_sdivCode
     (resultSignFix_spec_in_sdivCode sp sign maskOld valueOld carryOld
       limb0 limb1 limb2 limb3 base)
 
+/-- Result sign-fix precondition with `x10` and `x7` hidden behind ownership. -/
+@[irreducible]
+def resultSignFixPreOwnX10X7 (sp sign carryOld
+    limb0 limb1 limb2 limb3 : Word) : Assertion :=
+  (((((((((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp)) ** (.x8 ↦ᵣ sign)) **
+    (.x11 ↦ᵣ carryOld)) **
+    ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ limb0)) **
+    ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ limb1)) **
+    ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ limb2)) **
+    ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ limb3)) **
+    regOwn .x10) ** regOwn .x7
+
+theorem resultSignFixPreOwnX10X7_unfold
+    {sp sign carryOld limb0 limb1 limb2 limb3 : Word} :
+    resultSignFixPreOwnX10X7 sp sign carryOld limb0 limb1 limb2 limb3 =
+      ((((((((((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp)) ** (.x8 ↦ᵣ sign)) **
+        (.x11 ↦ᵣ carryOld)) **
+        ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ limb0)) **
+        ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ limb1)) **
+        ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ limb2)) **
+        ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ limb3)) **
+        regOwn .x10) ** regOwn .x7) := by
+  delta resultSignFixPreOwnX10X7
+  rfl
+
+/-- SDIV result sign-fix spec that consumes owned `x10` and `x7`, leaving
+    only the old `x11` carry value concrete. -/
+theorem resultSignFix_regOwn_x10_x7_spec_in_sdivCode
+    (sp sign carryOld limb0 limb1 limb2 limb3 : Word) (base : Word) :
+    cpsTripleWithin 21 (base + resultSignFixOff)
+      ((base + resultSignFixOff) + 84) (sdivCode base)
+      (resultSignFixPreOwnX10X7 sp sign carryOld limb0 limb1 limb2 limb3)
+      (resultSignFixPost sp sign limb0 limb1 limb2 limb3) := by
+  rw [resultSignFixPreOwnX10X7_unfold]
+  apply cpsTripleWithin_of_forall_regIs_to_regOwn
+  intro valueOld
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by
+      rw [resultSignFixPreOwnX10_unfold]
+      xperm_hyp hp)
+    (fun _ hq => hq)
+    (resultSignFix_regOwn_x10_spec_in_sdivCode sp sign valueOld carryOld
+      limb0 limb1 limb2 limb3 base)
+
 end EvmAsm.Evm64.SDiv.Compose


### PR DESCRIPTION
## Summary
- add `resultSignFixPreOwnX10X7`
- prove `resultSignFix_regOwn_x10_x7_spec_in_sdivCode` by lifting `x7` ownership on top of the `x10`-owned resultSignFix spec
- leave only `x11` concrete for the next scratch-register ownership bridge

## Verification
- lake build EvmAsm.Evm64.SDiv.Compose.ResultSignFixOwn
- git diff --check
- forbidden marker scan on touched file
- scripts/check-unimported.sh
- scripts/check-file-size.sh EvmAsm/Evm64/SDiv/Compose/ResultSignFixOwn.lean
- lake build