### PR TITLE
fix(sdiv): expose signfix x11 ownership

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/ResultSignFixOwn.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/ResultSignFixOwn.lean
@@ -100,4 +100,45 @@ theorem resultSignFix_regOwn_x10_x7_spec_in_sdivCode
     (resultSignFix_regOwn_x10_spec_in_sdivCode sp sign valueOld carryOld
       limb0 limb1 limb2 limb3 base)
 
+/-- Result sign-fix precondition with all scratch registers hidden behind
+    ownership. -/
+@[irreducible]
+def resultSignFixPreOwnScratch (sp sign limb0 limb1 limb2 limb3 : Word) : Assertion :=
+  (((((((((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp)) ** (.x8 ↦ᵣ sign)) **
+    ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ limb0)) **
+    ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ limb1)) **
+    ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ limb2)) **
+    ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ limb3)) **
+    regOwn .x10) ** regOwn .x7) ** regOwn .x11
+
+theorem resultSignFixPreOwnScratch_unfold
+    {sp sign limb0 limb1 limb2 limb3 : Word} :
+    resultSignFixPreOwnScratch sp sign limb0 limb1 limb2 limb3 =
+      ((((((((((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp)) ** (.x8 ↦ᵣ sign)) **
+        ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ limb0)) **
+        ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ limb1)) **
+        ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ limb2)) **
+        ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ limb3)) **
+        regOwn .x10) ** regOwn .x7) ** regOwn .x11) := by
+  delta resultSignFixPreOwnScratch
+  rfl
+
+/-- SDIV result sign-fix spec that consumes owned `x10`, `x7`, and `x11`. -/
+theorem resultSignFix_regOwn_scratch_spec_in_sdivCode
+    (sp sign limb0 limb1 limb2 limb3 : Word) (base : Word) :
+    cpsTripleWithin 21 (base + resultSignFixOff)
+      ((base + resultSignFixOff) + 84) (sdivCode base)
+      (resultSignFixPreOwnScratch sp sign limb0 limb1 limb2 limb3)
+      (resultSignFixPost sp sign limb0 limb1 limb2 limb3) := by
+  rw [resultSignFixPreOwnScratch_unfold]
+  apply cpsTripleWithin_of_forall_regIs_to_regOwn
+  intro carryOld
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by
+      rw [resultSignFixPreOwnX10X7_unfold]
+      xperm_hyp hp)
+    (fun _ hq => hq)
+    (resultSignFix_regOwn_x10_x7_spec_in_sdivCode sp sign carryOld
+      limb0 limb1 limb2 limb3 base)
+
 end EvmAsm.Evm64.SDiv.Compose


### PR DESCRIPTION
## Summary
- add `resultSignFixPreOwnScratch`
- prove `resultSignFix_regOwn_scratch_spec_in_sdivCode`, consuming owned `x10`, `x7`, and `x11`
- complete the scratch-register ownership bridge needed between the zero-divisor DIV callable post and resultSignFix

## Verification
- lake build EvmAsm.Evm64.SDiv.Compose.ResultSignFixOwn
- git diff --check
- forbidden marker scan on touched file
- scripts/check-unimported.sh
- scripts/check-file-size.sh EvmAsm/Evm64/SDiv/Compose/ResultSignFixOwn.lean
- lake build