### PR TITLE
fix(sdiv): expose bzero return frame

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/DivCallDispatch.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallDispatch.lean
@@ -428,6 +428,36 @@ theorem saveRaDivCallBzeroResultSignFixFrame_unfold
   delta saveRaDivCallBzeroResultSignFixFrame
   rfl
 
+/-- Frame remaining after exposing `x18` for the saved-RA return. -/
+@[irreducible]
+def saveRaDivCallBzeroSavedRaRetFrame
+    (sp base divisorSign : Word) (dividendAbsWord : EvmWord) : Assertion :=
+  regOwn .x2 ** regOwn .x5 ** regOwn .x6 **
+  evmWordIs sp dividendAbsWord ** EvmAsm.Evm64.divScratchOwnCall sp **
+  (.x1 ↦ᵣ ((base + divCallOff) + 4)) **
+  (.x9 ↦ᵣ divisorSign)
+
+theorem saveRaDivCallBzeroSavedRaRetFrame_unfold
+    {sp base divisorSign : Word} {dividendAbsWord : EvmWord} :
+    saveRaDivCallBzeroSavedRaRetFrame sp base divisorSign dividendAbsWord =
+      (regOwn .x2 ** regOwn .x5 ** regOwn .x6 **
+       evmWordIs sp dividendAbsWord ** EvmAsm.Evm64.divScratchOwnCall sp **
+       (.x1 ↦ᵣ ((base + divCallOff) + 4)) **
+       (.x9 ↦ᵣ divisorSign)) := by
+  delta saveRaDivCallBzeroSavedRaRetFrame
+  rfl
+
+/-- Expose the saved return address atom from the bzero result-sign-fix
+    frame, leaving the rest as an explicit return frame. -/
+theorem saveRaDivCallBzeroResultSignFixFrame_to_savedRaRet
+    {vRa sp base divisorSign : Word} {dividendAbsWord : EvmWord} :
+    saveRaDivCallBzeroResultSignFixFrame vRa sp base divisorSign dividendAbsWord =
+      ((.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12))) **
+       saveRaDivCallBzeroSavedRaRetFrame sp base divisorSign dividendAbsWord) := by
+  rw [saveRaDivCallBzeroResultSignFixFrame_unfold,
+    saveRaDivCallBzeroSavedRaRetFrame_unfold]
+  xperm
+
 /-- Zero-divisor callable post reshaped as the result-sign-fix precondition
     over the current quotient cell plus an explicit frame. -/
 theorem saveRaDivCallBzeroCallablePost_resultSignFixPreOwnScratch


### PR DESCRIPTION
## Summary
- add saveRaDivCallBzeroSavedRaRetFrame
- add saveRaDivCallBzeroResultSignFixFrame_to_savedRaRet, exposing the x18 atom for savedRaRet_spec_in_sdivCode
- keep the rest of the zero-divisor resultSignFix frame bundled for the next sequencing slice

## Verification
- lake build EvmAsm.Evm64.SDiv.Compose.DivCallDispatch
- git diff --check
- forbidden marker scan on touched file
- scripts/check-unimported.sh
- scripts/check-file-size.sh EvmAsm/Evm64/SDiv/Compose/DivCallDispatch.lean
- lake build