### PR TITLE
fix(exp): compose pointer restore epilogue

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBoundarySeq.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBoundarySeq.lean
@@ -103,4 +103,81 @@ theorem exp_prologue_then_pointer_advance_evm_exp_msb_saved_bit_two_mul_with_mul
       xperm_hyp hp)
     hFramed
 
+/-- Pointer-restore followed by the EXP epilogue in the two-MUL saved-bit
+    EXP+MUL code bundle. This packages the loop-exit boundary from
+    `base + 264` through the final stack-facing writeback at `base + 304`. -/
+theorem exp_pointer_restore_then_epilogue_evm_exp_msb_saved_bit_two_mul_with_mul_spec_within
+    (sp evmSp tOld r0 r1 r2 r3 d0 d1 d2 d3 : Word)
+    (squaringMulOff condMulOff : BitVec 21) (skipOff backOff : BitVec 13)
+    (base mulTarget : Word) :
+    cpsTripleWithin (1 + 9) (base + 264) (base + 304)
+      (evmExpMsbSavedBitTwoMulWithMulCode
+        base mulTarget squaringMulOff condMulOff skipOff backOff)
+      ((.x12 ↦ᵣ (evmSp + signExtend12 (64 : BitVec 12))) **
+       ((.x2 ↦ᵣ sp) ** (.x5 ↦ᵣ tOld) **
+        ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+        ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+        ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+        ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+        ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ d0) **
+        ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ d1) **
+        ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ d2) **
+        ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ d3)))
+      ((.x2 ↦ᵣ sp) **
+       (.x12 ↦ᵣ (evmSp + signExtend12 (32 : BitVec 12))) **
+       (.x5 ↦ᵣ r3) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+       evmWordIs (evmSp + 32) (expResultWord r0 r1 r2 r3)) := by
+  let epilogueFrame : Assertion :=
+    (.x2 ↦ᵣ sp) ** (.x5 ↦ᵣ tOld) **
+    ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+    ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+    ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+    ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+    ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ d0) **
+    ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ d1) **
+    ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ d2) **
+    ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ d3)
+  have hRestore :=
+    exp_loop_pointer_restore_evm_exp_msb_saved_bit_two_mul_with_mul_spec_within
+      (evmSp + signExtend12 (64 : BitVec 12))
+      squaringMulOff condMulOff skipOff backOff base mulTarget
+  have hRestoreFramed := cpsTripleWithin_frameR epilogueFrame (by
+    dsimp [epilogueFrame]
+    pcFree) hRestore
+  have hPtr : (evmSp + signExtend12 (64 : BitVec 12)) +
+      signExtend12 ((-64) : BitVec 12) = evmSp := by
+    have hNeg64 :
+        signExtend12 ((-64) : BitVec 12) =
+          (18446744073709551552 : Word) := by decide
+    rw [signExtend12_64, hNeg64]
+    bv_decide
+  have hRestoreFramed' :
+      cpsTripleWithin 1 (base + 264) (base + 268)
+        (evmExpMsbSavedBitTwoMulWithMulCode
+          base mulTarget squaringMulOff condMulOff skipOff backOff)
+        ((.x12 ↦ᵣ (evmSp + signExtend12 (64 : BitVec 12))) ** epilogueFrame)
+        ((.x12 ↦ᵣ evmSp) ** epilogueFrame) := by
+    rw [hPtr] at hRestoreFramed
+    exact hRestoreFramed
+  have hEpilogue :=
+    exp_epilogue_evm_exp_msb_saved_bit_two_mul_with_mul_spec_within
+      sp evmSp tOld r0 r1 r2 r3 d0 d1 d2 d3
+      squaringMulOff condMulOff skipOff backOff base mulTarget
+  have hSeq :=
+    cpsTripleWithin_seq_perm_same_cr
+      (fun _ hp => by
+        dsimp [epilogueFrame] at hp ⊢
+        xperm_hyp hp)
+      hRestoreFramed' hEpilogue
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by
+      dsimp [epilogueFrame] at hp ⊢
+      xperm_hyp hp)
+    (fun _ hp => hp)
+    hSeq
+
 end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- add exp_pointer_restore_then_epilogue_evm_exp_msb_saved_bit_two_mul_with_mul_spec_within
- compose the two-MUL saved-bit EXP+MUL pointer-restore boundary with the epilogue writeback from base + 264 to base + 304
- keep the proof within existing recursion and heartbeat settings

## Verification
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitBoundarySeq
- git diff --check
- rg -n forbidden marker scan on EvmAsm/Evm64/Exp/Compose/SavedBitBoundarySeq.lean (no matches)
- wc -l EvmAsm/Evm64/Exp/Compose/SavedBitBoundarySeq.lean
- scripts/check-file-size.sh EvmAsm/Evm64/Exp/Compose/SavedBitBoundarySeq.lean
- scripts/check-unimported.sh
- lake build