### PR TITLE
fix(exp): frame pointer restore epilogue exit

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBoundarySeq.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBoundarySeq.lean
@@ -180,4 +180,55 @@ theorem exp_pointer_restore_then_epilogue_evm_exp_msb_saved_bit_two_mul_with_mul
     (fun _ hp => hp)
     hSeq
 
+/-- Exit-control framed view of pointer-restore followed by the EXP epilogue.
+    The one-iteration branch exits carry `x9`, `x0`, and a pure loop-exit
+    condition; this adapter preserves that control frame through final
+    writeback. -/
+theorem exp_pointer_restore_then_epilogue_exit_control_evm_exp_msb_saved_bit_two_mul_with_mul_spec_within
+    (sp evmSp iterCountNew tOld r0 r1 r2 r3 d0 d1 d2 d3 : Word)
+    (exitCond : Prop)
+    (squaringMulOff condMulOff : BitVec 21) (skipOff backOff : BitVec 13)
+    (base mulTarget : Word) :
+    let exitControl : Assertion :=
+      (.x9 ↦ᵣ iterCountNew) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜exitCond⌝
+    cpsTripleWithin (1 + 9) (base + 264) (base + 304)
+      (evmExpMsbSavedBitTwoMulWithMulCode
+        base mulTarget squaringMulOff condMulOff skipOff backOff)
+      (exitControl **
+       ((.x12 ↦ᵣ (evmSp + signExtend12 (64 : BitVec 12))) **
+        ((.x2 ↦ᵣ sp) ** (.x5 ↦ᵣ tOld) **
+         ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+         ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+         ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+         ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+         ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ d0) **
+         ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ d1) **
+         ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ d2) **
+         ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ d3))))
+      (exitControl **
+       ((.x2 ↦ᵣ sp) **
+        (.x12 ↦ᵣ (evmSp + signExtend12 (32 : BitVec 12))) **
+        (.x5 ↦ᵣ r3) **
+        ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+        ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+        ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+        ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+        evmWordIs (evmSp + 32) (expResultWord r0 r1 r2 r3))) := by
+  intro exitControl
+  have hBase :=
+    exp_pointer_restore_then_epilogue_evm_exp_msb_saved_bit_two_mul_with_mul_spec_within
+      sp evmSp tOld r0 r1 r2 r3 d0 d1 d2 d3
+      squaringMulOff condMulOff skipOff backOff base mulTarget
+  have hFramed := cpsTripleWithin_frameR exitControl (by
+    dsimp [exitControl]
+    pcFree) hBase
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by
+      dsimp [exitControl] at hp ⊢
+      xperm_hyp hp)
+    (fun _ hp => by
+      dsimp [exitControl] at hp ⊢
+      xperm_hyp hp)
+    hFramed
+
 end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- add an exit-control framed adapter for pointer-restore followed by the EXP epilogue
- preserve the loop-exit control frame (x9, x0, and the pure exit condition) through final writeback

## Verification
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitBoundarySeq
- git diff --check
- rg -n "sorry|admit|placeholder|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/Compose/SavedBitBoundarySeq.lean
- wc -l EvmAsm/Evm64/Exp/Compose/SavedBitBoundarySeq.lean
- scripts/check-file-size.sh EvmAsm/Evm64/Exp/Compose/SavedBitBoundarySeq.lean
- scripts/check-unimported.sh
- lake build