### PR TITLE
fix(sdiv): expose bzero semantic result

### DIFF
--- a/EvmAsm/Evm64/SDiv.lean
+++ b/EvmAsm/Evm64/SDiv.lean
@@ -25,5 +25,6 @@ import EvmAsm.Evm64.SDiv.Compose.DivisorAbsSequence
 import EvmAsm.Evm64.SDiv.Compose.SignXorSequence
 import EvmAsm.Evm64.SDiv.Compose.DivCall
 import EvmAsm.Evm64.SDiv.Compose.DivCallDispatch
+import EvmAsm.Evm64.SDiv.Compose.DivCallDispatchZeroDivisor
 import EvmAsm.Evm64.SDiv.Compose.ResultSignFixOwn
 import EvmAsm.Evm64.SDiv.Spec

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallDispatchZeroDivisor.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallDispatchZeroDivisor.lean
@@ -1,0 +1,70 @@
+/-
+  EvmAsm.Evm64.SDiv.Compose.DivCallDispatchZeroDivisor
+
+  Stack-semantic adapters for the SDIV zero-divisor dispatch path.
+-/
+
+import EvmAsm.Evm64.SDiv.Args
+import EvmAsm.Evm64.SDiv.Compose.DivCallDispatch
+
+namespace EvmAsm.Evm64.SDiv.Compose
+
+open EvmAsm.Rv64.Tactics
+open EvmAsm.Rv64
+
+/-- Caller-visible zero-divisor SDIV path with the produced stack word named
+    through the executable-spec argument bridge. This is the same bzero
+    stack-entry path as
+    `saveRa_signs_abs_signXor_then_divCall_bzero_stack_entry_zero_divisor_spec_in_sdivCode`,
+    but its postcondition exposes the result as
+    `EvmAsm.Evm64.SDivArgs.sdivResultFromArgs
+    (EvmAsm.Evm64.SDivArgs.sdivArgs dividend 0)`. -/
+theorem saveRa_signs_abs_signXor_then_divCall_bzero_stack_entry_zero_divisor_result_spec_in_sdivCode
+    (vRa vSavedOld sp sDividendOld sDivisorOld
+      dividendMaskOld dividendValueOld dividendCarryOld
+      v2 v5 v6 : Word)
+    (dividend : EvmWord) (rest : List EvmWord)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (base : Word) (hbase : base &&& 1 = 0) :
+    cpsTripleWithin (((49 + (EvmAsm.Evm64.unifiedDivBound + 1)) + 21) + 1)
+      base (vRa &&& ~~~(1 : Word)) (sdivCode base)
+      ((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ vSavedOld) ** (.x12 ↦ᵣ sp) **
+         (.x8 ↦ᵣ sDividendOld) ** (.x9 ↦ᵣ sDivisorOld) **
+         (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ dividendMaskOld) **
+         (.x7 ↦ᵣ dividendValueOld) ** (.x11 ↦ᵣ dividendCarryOld)) **
+        evmStackIs sp (dividend :: (0 : EvmWord) :: rest)) **
+       ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
+        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0))
+      (let result := EvmAsm.Evm64.SDivArgs.sdivResultFromArgs
+          (EvmAsm.Evm64.SDivArgs.sdivArgs dividend 0)
+       let dividendAbsWord :=
+         sdivAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
+           (dividend.getLimbN 2) (dividend.getLimbN 3)
+       let divisorSign := (0 : Word) >>> (63 : BitVec 6).toNat
+       let resultSign :=
+         (dividend.getLimbN 3 >>> (63 : BitVec 6).toNat) ^^^ divisorSign
+       let mask := (0 : Word) - resultSign
+       let sum0 := ((0 : Word) ^^^ mask) + resultSign
+       let carry0 := if BitVec.ult sum0 resultSign then (1 : Word) else 0
+       let sum1 := ((0 : Word) ^^^ mask) + carry0
+       let carry1 := if BitVec.ult sum1 carry0 then (1 : Word) else 0
+       let sum2 := ((0 : Word) ^^^ mask) + carry1
+       let carry2 := if BitVec.ult sum2 carry1 then (1 : Word) else 0
+       let sum3 := ((0 : Word) ^^^ mask) + carry2
+       let carry3 := if BitVec.ult sum3 carry2 then (1 : Word) else 0
+       (.x18 ↦ᵣ vRa) **
+       (((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ (sp + 32)) ** (.x8 ↦ᵣ resultSign) **
+         (.x10 ↦ᵣ mask) ** (.x7 ↦ᵣ (0 : Word)) ** (.x11 ↦ᵣ carry3) **
+         evmStackIs (sp + 32) (result :: rest)) **
+        saveRaDivCallBzeroSavedRaRetFrame sp base divisorSign dividendAbsWord)) := by
+  simpa only [EvmAsm.Evm64.SDivArgs.sdivResultFromArgs_zero_divisor] using
+    (saveRa_signs_abs_signXor_then_divCall_bzero_stack_entry_zero_divisor_spec_in_sdivCode
+      vRa vSavedOld sp sDividendOld sDivisorOld
+      dividendMaskOld dividendValueOld dividendCarryOld
+      v2 v5 v6 dividend rest
+      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 base hbase)
+
+end EvmAsm.Evm64.SDiv.Compose


### PR DESCRIPTION
## Summary
- add a small SDIV compose leaf for zero-divisor stack-semantic adapters
- expose the bzero stack-entry result as `SDivArgs.sdivResultFromArgs (SDivArgs.sdivArgs dividend 0)` instead of a bare zero word
- import the new leaf through the SDIV umbrella

## Verification
- lake build EvmAsm.Evm64.SDiv.Compose.DivCallDispatchZeroDivisor
- git diff --check
- rg -n "sorry|admit|placeholder|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/DivCallDispatchZeroDivisor.lean EvmAsm/Evm64/SDiv.lean
- wc -l EvmAsm/Evm64/SDiv/Compose/DivCallDispatchZeroDivisor.lean EvmAsm/Evm64/SDiv.lean
- scripts/check-file-size.sh EvmAsm/Evm64/SDiv/Compose/DivCallDispatchZeroDivisor.lean EvmAsm/Evm64/SDiv.lean
- scripts/check-unimported.sh
- lake build