### PR TITLE
fix(exp): frame epilogue stack tail

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBoundarySeq.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBoundarySeq.lean
@@ -231,4 +231,62 @@ theorem exp_pointer_restore_then_epilogue_exit_control_evm_exp_msb_saved_bit_two
       xperm_hyp hp)
     hFramed
 
+/-- Stack-tail framed view of pointer-restore followed by the EXP epilogue.
+    This keeps the base operand and caller stack tail around the final
+    writeback, and folds the produced result word into the visible post stack
+    rooted at `evmSp + 32`. -/
+theorem exp_pointer_restore_then_epilogue_stack_tail_evm_exp_msb_saved_bit_two_mul_with_mul_spec_within
+    (sp evmSp iterCountNew tOld r0 r1 r2 r3 d0 d1 d2 d3 : Word)
+    (baseWord : EvmWord) (rest : List EvmWord)
+    (exitCond : Prop)
+    (squaringMulOff condMulOff : BitVec 21) (skipOff backOff : BitVec 13)
+    (base mulTarget : Word) :
+    let exitControl : Assertion :=
+      (.x9 ↦ᵣ iterCountNew) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜exitCond⌝
+    let stackTail : Assertion :=
+      evmWordIs evmSp baseWord ** evmStackIs (evmSp + 64) rest
+    cpsTripleWithin (1 + 9) (base + 264) (base + 304)
+      (evmExpMsbSavedBitTwoMulWithMulCode
+        base mulTarget squaringMulOff condMulOff skipOff backOff)
+      ((exitControl **
+        ((.x12 ↦ᵣ (evmSp + signExtend12 (64 : BitVec 12))) **
+         ((.x2 ↦ᵣ sp) ** (.x5 ↦ᵣ tOld) **
+          ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+          ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+          ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+          ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+          ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ d0) **
+          ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ d1) **
+          ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ d2) **
+          ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ d3)))) **
+       stackTail)
+      (exitControl **
+       ((.x2 ↦ᵣ sp) **
+        (.x12 ↦ᵣ (evmSp + signExtend12 (32 : BitVec 12))) **
+        (.x5 ↦ᵣ r3) **
+        ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+        ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+        ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+        ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+        evmWordIs evmSp baseWord **
+        evmStackIs (evmSp + 32) (expResultWord r0 r1 r2 r3 :: rest))) := by
+  intro exitControl stackTail
+  have hBase :=
+    exp_pointer_restore_then_epilogue_exit_control_evm_exp_msb_saved_bit_two_mul_with_mul_spec_within
+      sp evmSp iterCountNew tOld r0 r1 r2 r3 d0 d1 d2 d3 exitCond
+      squaringMulOff condMulOff skipOff backOff base mulTarget
+  have hFramed := cpsTripleWithin_frameR stackTail (by
+    dsimp [stackTail]
+    pcFree) hBase
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by
+      dsimp [exitControl, stackTail] at hp ⊢
+      xperm_hyp hp)
+    (fun _ hp => by
+      dsimp [exitControl, stackTail] at hp ⊢
+      rw [evmStackIs_cons]
+      rw [show evmSp + 64#64 = evmSp + 32#64 + 32#64 from by bv_addr] at hp
+      xperm_hyp hp)
+    hFramed
+
 end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- add a stack-tail framed view of the two-MUL saved-bit pointer-restore + epilogue sequence
- preserve the base operand and caller stack tail through final writeback
- fold the result word and tail into the visible post stack at evmSp + 32

## Verification
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitBoundarySeq
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/Compose/SavedBitBoundarySeq.lean
- wc -l EvmAsm/Evm64/Exp/Compose/SavedBitBoundarySeq.lean
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build