### PR TITLE
fix(exp): expose epilogue full stack shape

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBoundarySeq.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBoundarySeq.lean
@@ -6,6 +6,7 @@
 -/
 
 import EvmAsm.Evm64.Exp.Compose.SavedBitWithMul
+import EvmAsm.Rv64.Tactics.XCancelStruct
 
 namespace EvmAsm.Evm64.Exp.Compose
 
@@ -379,5 +380,51 @@ theorem exp_pointer_restore_then_epilogue_full_post_stack_clean_pointer_evm_exp_
   exact exp_pointer_restore_then_epilogue_full_post_stack_evm_exp_msb_saved_bit_two_mul_with_mul_spec_within
     sp evmSp iterCountNew tOld r0 r1 r2 r3 d0 d1 d2 d3 baseWord rest exitCond
     squaringMulOff condMulOff skipOff backOff base mulTarget
+
+/-- Full visible-stack view of pointer-restore followed by the EXP epilogue.
+    The precondition exposes the preserved base operand, the old destination
+    stack word, and the caller tail as one `evmStackIs` prefix; the
+    postcondition replaces the destination word with the assembled result. -/
+theorem exp_pointer_restore_then_epilogue_full_stack_evm_exp_msb_saved_bit_two_mul_with_mul_spec_within
+    (sp evmSp iterCountNew tOld r0 r1 r2 r3 d0 d1 d2 d3 : Word)
+    (baseWord : EvmWord) (rest : List EvmWord)
+    (exitCond : Prop)
+    (squaringMulOff condMulOff : BitVec 21) (skipOff backOff : BitVec 13)
+    (base mulTarget : Word) :
+    let exitControl : Assertion :=
+      (.x9 ↦ᵣ iterCountNew) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜exitCond⌝
+    cpsTripleWithin (1 + 9) (base + 264) (base + 304)
+      (evmExpMsbSavedBitTwoMulWithMulCode
+        base mulTarget squaringMulOff condMulOff skipOff backOff)
+      (exitControl **
+       ((.x12 ↦ᵣ (evmSp + signExtend12 (64 : BitVec 12))) **
+        ((.x2 ↦ᵣ sp) ** (.x5 ↦ᵣ tOld) **
+         ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+         ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+         ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+         ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3))) **
+       evmStackIs evmSp (baseWord :: expResultWord d0 d1 d2 d3 :: rest))
+      (exitControl **
+       ((.x2 ↦ᵣ sp) **
+        (.x12 ↦ᵣ (evmSp + 32)) **
+        (.x5 ↦ᵣ r3) **
+        ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+        ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+        ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+        ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+        evmStackIs evmSp (baseWord :: expResultWord r0 r1 r2 r3 :: rest))) := by
+  intro exitControl
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by
+      dsimp [exitControl] at hp ⊢
+      rw [evmStackIs_cons, evmStackIs_cons] at hp
+      rw [← exp_epilogue_result_word_right evmSp d0 d1 d2 d3
+        (evmStackIs (evmSp + 32 + 32) rest)] at hp
+      rw [show evmSp + 32 + 32 = evmSp + 64#64 from by bv_addr] at hp
+      xcancel_struct hp)
+    (fun _ hp => hp)
+    (exp_pointer_restore_then_epilogue_full_post_stack_clean_pointer_evm_exp_msb_saved_bit_two_mul_with_mul_spec_within
+      sp evmSp iterCountNew tOld r0 r1 r2 r3 d0 d1 d2 d3 baseWord rest exitCond
+      squaringMulOff condMulOff skipOff backOff base mulTarget)
 
 end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- add a full visible-stack adapter for the two-MUL saved-bit pointer-restore + epilogue sequence
- expose the precondition as evmStackIs evmSp (baseWord :: oldDestinationWord :: rest)
- keep the postcondition in the clean stack-pointer form from the previous slice

## Verification
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitBoundarySeq
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/Compose/SavedBitBoundarySeq.lean
- wc -l EvmAsm/Evm64/Exp/Compose/SavedBitBoundarySeq.lean
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build