### PR TITLE
fix(sdiv): bridge callable quotient to signfix

### DIFF
--- a/EvmAsm/Evm64/SDiv.lean
+++ b/EvmAsm/Evm64/SDiv.lean
@@ -25,6 +25,7 @@ import EvmAsm.Evm64.SDiv.Compose.DivisorAbsSequence
 import EvmAsm.Evm64.SDiv.Compose.SignXorSequence
 import EvmAsm.Evm64.SDiv.Compose.DivCall
 import EvmAsm.Evm64.SDiv.Compose.DivCallDispatch
+import EvmAsm.Evm64.SDiv.Compose.DivCallResultSignFix
 import EvmAsm.Evm64.SDiv.Compose.DivCallDispatchZeroDivisor
 import EvmAsm.Evm64.SDiv.Compose.ResultSignFixOwn
 import EvmAsm.Evm64.SDiv.Spec

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallDispatch.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallDispatch.lean
@@ -617,6 +617,40 @@ theorem saveRaDivCallBzeroCallablePost_resultSignFixPreOwnScratch
   rw [show (sp + 32 + signExtend12 (24 : BitVec 12) : Word) = (sp + 32) + 24 by bv_addr]
   xperm
 
+/-- Callable post reshaped as the result-sign-fix precondition over the
+    unsigned DIV quotient plus the saved-RA/sign frame. The zero-divisor
+    specialization below is the same shape with the quotient reduced to zero. -/
+theorem saveRaDivCallBzeroCallablePost_resultSignFixPreOwnScratch_quotient
+    {vRa sp base : Word}
+    {dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word} :
+    saveRaDivCallBzeroCallablePost vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop =
+      (let dividendAbsWord :=
+         sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+       let divisorAbsWord :=
+         sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+       let quotientWord := EvmWord.div dividendAbsWord divisorAbsWord
+       let resultSign :=
+         (dividendTop >>> (63 : BitVec 6).toNat) ^^^
+           (divisorTop >>> (63 : BitVec 6).toNat)
+       let divisorSign := divisorTop >>> (63 : BitVec 6).toNat
+       resultSignFixPreOwnScratch (sp + 32) resultSign
+         (quotientWord.getLimbN 0) (quotientWord.getLimbN 1)
+         (quotientWord.getLimbN 2) (quotientWord.getLimbN 3) **
+       saveRaDivCallBzeroResultSignFixFrame vRa sp base divisorSign dividendAbsWord) := by
+  rw [saveRaDivCallBzeroCallablePost_unfold,
+    EvmAsm.Evm64.divStackDispatchPostNoX1_unfold]
+  dsimp only
+  rw [resultSignFixPreOwnScratch_unfold,
+    saveRaDivCallBzeroResultSignFixFrame_unfold, evmWordIs_sp32_unfold]
+  rw [show (sp + 32 + signExtend12 (0 : BitVec 12) : Word) = sp + 32 by bv_addr]
+  rw [show (sp + 32 + signExtend12 (8 : BitVec 12) : Word) = sp + 40 by bv_addr]
+  rw [show (sp + 32 + signExtend12 (16 : BitVec 12) : Word) = sp + 48 by bv_addr]
+  rw [show (sp + 32 + signExtend12 (24 : BitVec 12) : Word) = sp + 56 by bv_addr]
+  xperm
+
 /-- SDIV wrapper prefix followed by the zero-divisor unsigned-DIV callable,
     using the named postcondition consumed by later composition slices. -/
 theorem saveRa_signs_abs_signXor_then_divCall_bzero_callable_named_post_spec_in_sdivCode

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallResultSignFix.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallResultSignFix.lean
@@ -1,0 +1,92 @@
+import EvmAsm.Evm64.SDiv.Compose.DivCallDispatch
+
+namespace EvmAsm.Evm64.SDiv.Compose
+
+open EvmAsm.Rv64.Tactics
+open EvmAsm.Rv64
+
+/-- SDIV wrapper prefix followed by any exact unsigned-DIV callable proof,
+    then through result-sign-fix over the produced quotient word. -/
+theorem saveRa_signs_abs_signXor_then_divCall_then_resultSignFix_of_callable_post_spec_in_sdivCode
+    {nSteps : Nat}
+    (vRa vSavedOld sp sDividendOld sDivisorOld
+      dividendMaskOld dividendValueOld dividendCarryOld
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+      v2 v5 v6 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (base : Word)
+    (hCallable :
+      cpsTripleWithin nSteps (base + wrapperEndOff) (base + resultSignFixOff) (sdivCode base)
+        (saveRaDivCallDispatchReadyPost vRa sp base
+          dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+          divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+          v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+        (saveRaDivCallBzeroCallablePost vRa sp base
+          dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+          divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)) :
+    cpsTripleWithin ((49 + nSteps) + 21)
+      base ((base + resultSignFixOff) + 84) (sdivCode base)
+      (saveRaSignsAbsSignXorThenDivCallPre vRa vSavedOld sp sDividendOld sDivisorOld
+        dividendMaskOld dividendValueOld dividendCarryOld
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
+       ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
+        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0))
+      (let dividendAbsWord :=
+         sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+       let divisorAbsWord :=
+         sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+       let quotientWord := EvmWord.div dividendAbsWord divisorAbsWord
+       let resultSign :=
+         (dividendTop >>> (63 : BitVec 6).toNat) ^^^
+           (divisorTop >>> (63 : BitVec 6).toNat)
+       let divisorSign := divisorTop >>> (63 : BitVec 6).toNat
+       resultSignFixPost (sp + 32) resultSign
+         (quotientWord.getLimbN 0) (quotientWord.getLimbN 1)
+         (quotientWord.getLimbN 2) (quotientWord.getLimbN 3) **
+       saveRaDivCallBzeroResultSignFixFrame vRa sp base divisorSign dividendAbsWord) := by
+  let dividendAbsWord :=
+    sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+  let divisorAbsWord :=
+    sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+  let quotientWord := EvmWord.div dividendAbsWord divisorAbsWord
+  let resultSign :=
+    (dividendTop >>> (63 : BitVec 6).toNat) ^^^
+      (divisorTop >>> (63 : BitVec 6).toNat)
+  let divisorSign := divisorTop >>> (63 : BitVec 6).toNat
+  have hPrefix :=
+    saveRa_signs_abs_signXor_then_divCall_then_exact_callable_spec_in_sdivCode
+      vRa vSavedOld sp sDividendOld sDivisorOld
+      dividendMaskOld dividendValueOld dividendCarryOld
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+      v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0
+      base (base + resultSignFixOff) hCallable
+  have hFramePc :
+      (saveRaDivCallBzeroResultSignFixFrame
+        vRa sp base divisorSign dividendAbsWord).pcFree := by
+    rw [saveRaDivCallBzeroResultSignFixFrame_unfold,
+      EvmAsm.Evm64.divScratchOwnCall_unfold,
+      EvmAsm.Evm64.divScratchOwn_unfold]
+    pcFree
+  have hFix :=
+    cpsTripleWithin_frameR
+      (saveRaDivCallBzeroResultSignFixFrame
+        vRa sp base divisorSign dividendAbsWord)
+      hFramePc
+      (resultSignFix_regOwn_scratch_spec_in_sdivCode
+        (sp + 32) resultSign
+        (quotientWord.getLimbN 0) (quotientWord.getLimbN 1)
+        (quotientWord.getLimbN 2) (quotientWord.getLimbN 3) base)
+  exact cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by
+      rw [saveRaDivCallBzeroCallablePost_resultSignFixPreOwnScratch_quotient] at hp
+      exact hp)
+    hPrefix hFix
+
+end EvmAsm.Evm64.SDiv.Compose


### PR DESCRIPTION
## Summary
- add a quotient-shaped bridge from the SDIV unsigned-DIV callable post to the result-sign-fix precondition
- expose the computed EvmWord.div limbs at sp + 32 while preserving the saved-RA/sign frame

## Verification
- lake build EvmAsm.Evm64.SDiv.Compose.DivCallDispatch
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/DivCallDispatch.lean (no matches)
- wc -l EvmAsm/Evm64/SDiv/Compose/DivCallDispatch.lean
- scripts/check-file-size.sh EvmAsm/Evm64/SDiv/Compose/DivCallDispatch.lean
- scripts/check-unimported.sh
- lake build