### PR TITLE
fix(sdiv): compose callable post through signfix

### DIFF
--- a/EvmAsm/Evm64/SDiv.lean
+++ b/EvmAsm/Evm64/SDiv.lean
@@ -25,6 +25,7 @@ import EvmAsm.Evm64.SDiv.Compose.DivisorAbsSequence
 import EvmAsm.Evm64.SDiv.Compose.SignXorSequence
 import EvmAsm.Evm64.SDiv.Compose.DivCall
 import EvmAsm.Evm64.SDiv.Compose.DivCallDispatch
+import EvmAsm.Evm64.SDiv.Compose.DivCallResultSignFix
 import EvmAsm.Evm64.SDiv.Compose.DivCallDispatchZeroDivisor
 import EvmAsm.Evm64.SDiv.Compose.ResultSignFixOwn
 import EvmAsm.Evm64.SDiv.Spec

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallResultSignFix.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallResultSignFix.lean
@@ -1,0 +1,92 @@
+import EvmAsm.Evm64.SDiv.Compose.DivCallDispatch
+
+namespace EvmAsm.Evm64.SDiv.Compose
+
+open EvmAsm.Rv64.Tactics
+open EvmAsm.Rv64
+
+/-- SDIV wrapper prefix followed by any exact unsigned-DIV callable proof,
+    then through result-sign-fix over the produced quotient word. -/
+theorem saveRa_signs_abs_signXor_then_divCall_then_resultSignFix_of_callable_post_spec_in_sdivCode
+    {nSteps : Nat}
+    (vRa vSavedOld sp sDividendOld sDivisorOld
+      dividendMaskOld dividendValueOld dividendCarryOld
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+      v2 v5 v6 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (base : Word)
+    (hCallable :
+      cpsTripleWithin nSteps (base + wrapperEndOff) (base + resultSignFixOff) (sdivCode base)
+        (saveRaDivCallDispatchReadyPost vRa sp base
+          dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+          divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+          v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+        (saveRaDivCallBzeroCallablePost vRa sp base
+          dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+          divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)) :
+    cpsTripleWithin ((49 + nSteps) + 21)
+      base ((base + resultSignFixOff) + 84) (sdivCode base)
+      (saveRaSignsAbsSignXorThenDivCallPre vRa vSavedOld sp sDividendOld sDivisorOld
+        dividendMaskOld dividendValueOld dividendCarryOld
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
+       ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
+        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0))
+      (let dividendAbsWord :=
+         sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+       let divisorAbsWord :=
+         sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+       let quotientWord := EvmWord.div dividendAbsWord divisorAbsWord
+       let resultSign :=
+         (dividendTop >>> (63 : BitVec 6).toNat) ^^^
+           (divisorTop >>> (63 : BitVec 6).toNat)
+       let divisorSign := divisorTop >>> (63 : BitVec 6).toNat
+       resultSignFixPost (sp + 32) resultSign
+         (quotientWord.getLimbN 0) (quotientWord.getLimbN 1)
+         (quotientWord.getLimbN 2) (quotientWord.getLimbN 3) **
+       saveRaDivCallBzeroResultSignFixFrame vRa sp base divisorSign dividendAbsWord) := by
+  let dividendAbsWord :=
+    sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+  let divisorAbsWord :=
+    sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+  let quotientWord := EvmWord.div dividendAbsWord divisorAbsWord
+  let resultSign :=
+    (dividendTop >>> (63 : BitVec 6).toNat) ^^^
+      (divisorTop >>> (63 : BitVec 6).toNat)
+  let divisorSign := divisorTop >>> (63 : BitVec 6).toNat
+  have hPrefix :=
+    saveRa_signs_abs_signXor_then_divCall_then_exact_callable_spec_in_sdivCode
+      vRa vSavedOld sp sDividendOld sDivisorOld
+      dividendMaskOld dividendValueOld dividendCarryOld
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+      v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0
+      base (base + resultSignFixOff) hCallable
+  have hFramePc :
+      (saveRaDivCallBzeroResultSignFixFrame
+        vRa sp base divisorSign dividendAbsWord).pcFree := by
+    rw [saveRaDivCallBzeroResultSignFixFrame_unfold,
+      EvmAsm.Evm64.divScratchOwnCall_unfold,
+      EvmAsm.Evm64.divScratchOwn_unfold]
+    pcFree
+  have hFix :=
+    cpsTripleWithin_frameR
+      (saveRaDivCallBzeroResultSignFixFrame
+        vRa sp base divisorSign dividendAbsWord)
+      hFramePc
+      (resultSignFix_regOwn_scratch_spec_in_sdivCode
+        (sp + 32) resultSign
+        (quotientWord.getLimbN 0) (quotientWord.getLimbN 1)
+        (quotientWord.getLimbN 2) (quotientWord.getLimbN 3) base)
+  exact cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by
+      rw [saveRaDivCallBzeroCallablePost_resultSignFixPreOwnScratch_quotient] at hp
+      exact hp)
+    hPrefix hFix
+
+end EvmAsm.Evm64.SDiv.Compose


### PR DESCRIPTION
## Summary
- add a split SDIV compose file for the callable-post-to-result-sign-fix theorem
- compose the save-ra/sign/abs/divCall prefix with any exact unsigned-DIV callable proof and then result-sign-fix over the produced quotient limbs
- import the new split file from the SDIV umbrella

## Verification
- lake build EvmAsm.Evm64.SDiv.Compose.DivCallResultSignFix
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/DivCallDispatch.lean EvmAsm/Evm64/SDiv/Compose/DivCallResultSignFix.lean EvmAsm/Evm64/SDiv.lean (no matches)
- wc -l EvmAsm/Evm64/SDiv/Compose/DivCallDispatch.lean EvmAsm/Evm64/SDiv/Compose/DivCallResultSignFix.lean EvmAsm/Evm64/SDiv.lean
- scripts/check-file-size.sh EvmAsm/Evm64/SDiv/Compose/DivCallDispatch.lean EvmAsm/Evm64/SDiv/Compose/DivCallResultSignFix.lean EvmAsm/Evm64/SDiv.lean
- scripts/check-unimported.sh
- lake build