### PR TITLE
fix(exp): name two-mul loop exit posts

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitIterPosts.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitIterPosts.lean
@@ -169,6 +169,48 @@ theorem expTwoMulIterSkipPost_pcFree
     expTwoMulIterBaseFrame_unfold, evmWordIs_sp_unfold, evmWordIs_sp32_unfold]
   pcFree
 
+@[irreducible]
+def expTwoMulIterLoopPost
+    (iterCountNew bit sp evmSp base a0 a1 a2 a3 : Word)
+    (w rw : EvmWord) : Assertion :=
+  fun h =>
+    expTwoMulIterCondPost iterCountNew bit sp evmSp base a0 a1 a2 a3 rw
+      (iterCountNew ≠ 0) h ∨
+    expTwoMulIterSkipPost iterCountNew bit sp evmSp base a0 a1 a2 a3 w
+      (iterCountNew ≠ 0) h
+
+theorem expTwoMulIterLoopPost_unfold
+    {iterCountNew bit sp evmSp base a0 a1 a2 a3 : Word} {w rw : EvmWord} :
+    expTwoMulIterLoopPost iterCountNew bit sp evmSp base a0 a1 a2 a3 w rw =
+      (fun h =>
+        expTwoMulIterCondPost iterCountNew bit sp evmSp base a0 a1 a2 a3 rw
+          (iterCountNew ≠ 0) h ∨
+        expTwoMulIterSkipPost iterCountNew bit sp evmSp base a0 a1 a2 a3 w
+          (iterCountNew ≠ 0) h) := by
+  delta expTwoMulIterLoopPost
+  rfl
+
+@[irreducible]
+def expTwoMulIterExitPost
+    (iterCountNew bit sp evmSp base a0 a1 a2 a3 : Word)
+    (w rw : EvmWord) : Assertion :=
+  fun h =>
+    expTwoMulIterCondPost iterCountNew bit sp evmSp base a0 a1 a2 a3 rw
+      (iterCountNew = 0) h ∨
+    expTwoMulIterSkipPost iterCountNew bit sp evmSp base a0 a1 a2 a3 w
+      (iterCountNew = 0) h
+
+theorem expTwoMulIterExitPost_unfold
+    {iterCountNew bit sp evmSp base a0 a1 a2 a3 : Word} {w rw : EvmWord} :
+    expTwoMulIterExitPost iterCountNew bit sp evmSp base a0 a1 a2 a3 w rw =
+      (fun h =>
+        expTwoMulIterCondPost iterCountNew bit sp evmSp base a0 a1 a2 a3 rw
+          (iterCountNew = 0) h ∨
+        expTwoMulIterSkipPost iterCountNew bit sp evmSp base a0 a1 a2 a3 w
+          (iterCountNew = 0) h) := by
+  delta expTwoMulIterExitPost
+  rfl
+
 theorem exp_msb_saved_bit_two_mul_full_iter_owned_scratch_branch_named_posts_spec_within
     (e iterCount v18 sp evmSp vOld r0 r1 r2 r3 d0 d1 d2 d3
       e0 e1 e2 e3 a0 a1 a2 a3 mulTarget : Word)
@@ -243,6 +285,66 @@ theorem exp_msb_saved_bit_two_mul_full_iter_owned_scratch_branch_named_posts_spe
         simpa [expTwoMulIterSkipPost_unfold, expTwoMulIterSkipRest_unfold,
           expTwoMulIterBaseFrame_unfold] using hp)
     (exp_msb_saved_bit_two_mul_full_iter_owned_scratch_branch_spec_within
+      e iterCount v18 sp evmSp vOld r0 r1 r2 r3 d0 d1 d2 d3
+      e0 e1 e2 e3 a0 a1 a2 a3 mulTarget
+      squaringMulOff condMulOff skipOff backOff base loopTarget
+      hbase hsqmt hcondmt hd hskip hback)
+
+theorem exp_msb_saved_bit_two_mul_full_iter_owned_scratch_branch_named_loop_exit_spec_within
+    (e iterCount v18 sp evmSp vOld r0 r1 r2 r3 d0 d1 d2 d3
+      e0 e1 e2 e3 a0 a1 a2 a3 mulTarget : Word)
+    (squaringMulOff condMulOff : BitVec 21) (skipOff backOff : BitVec 13)
+    (base loopTarget : Word)
+    (hbase : base &&& 1 = 0)
+    (hsqmt : mulTarget = ((base + 44) + 64) + signExtend21 squaringMulOff)
+    (hcondmt : mulTarget = ((base + 152) + 64) + signExtend21 condMulOff)
+    (hd : CodeReq.Disjoint
+            (evmExpMsbSavedBitTwoMulCode
+              base squaringMulOff condMulOff skipOff backOff)
+            (mul_callable_code mulTarget))
+    (hskip : (base + 148 : Word) + signExtend13 skipOff = base + 256)
+    (hback : ((base + 256) + 4 : Word) + signExtend13 backOff = loopTarget) :
+    let bit := e >>> (63 : BitVec 6).toNat
+    let w := expResultWord r0 r1 r2 r3
+    let aw := expResultWord a0 a1 a2 a3
+    let rw := (w * w) * aw
+    let iterCountNew := iterCount + signExtend12 ((-1 : BitVec 12))
+    cpsBranchWithin
+      (((3 + 1 + (17 + 64 + 9) + 1) + 2) + ((17 + 64 + 9) + 2))
+      (base + 28)
+      (evmExpMsbSavedBitTwoMulWithMulCode
+        base mulTarget squaringMulOff condMulOff skipOff backOff)
+      (((.x5 ↦ᵣ e) ** regOwn .x6 ** regOwn .x10 ** (.x18 ↦ᵣ v18) **
+        (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) **
+        ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+        ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+        ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+        ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+        ((evmSp + signExtend12 (0 : BitVec 12)) ↦ₘ d0) **
+        ((evmSp + signExtend12 (8 : BitVec 12)) ↦ₘ d1) **
+        ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ d2) **
+        ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ d3) **
+        ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ e0) **
+        ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ e1) **
+        ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ e2) **
+        ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ e3) **
+        regOwn .x7 ** regOwn .x11 ** (.x1 ↦ᵣ vOld) **
+        (.x0 ↦ᵣ (0 : Word)) ** (.x9 ↦ᵣ iterCount)) **
+       expTwoMulIterBaseFrame evmSp a0 a1 a2 a3)
+      loopTarget
+        (expTwoMulIterLoopPost iterCountNew bit sp evmSp base a0 a1 a2 a3 w rw)
+      (base + 264)
+        (expTwoMulIterExitPost iterCountNew bit sp evmSp base a0 a1 a2 a3 w rw) := by
+  intro bit w aw rw iterCountNew
+  exact cpsBranchWithin_weaken
+    (fun _ hp => hp)
+    (fun _ hp => by
+      rw [expTwoMulIterLoopPost_unfold]
+      exact hp)
+    (fun _ hp => by
+      rw [expTwoMulIterExitPost_unfold]
+      exact hp)
+    (exp_msb_saved_bit_two_mul_full_iter_owned_scratch_branch_named_posts_spec_within
       e iterCount v18 sp evmSp vOld r0 r1 r2 r3 d0 d1 d2 d3
       e0 e1 e2 e3 a0 a1 a2 a3 mulTarget
       squaringMulOff condMulOff skipOff backOff base loopTarget


### PR DESCRIPTION
## Summary
- add named disjunctive loop and exit post assertions for the two-MUL saved-bit one-iteration theorem
- add a wrapper theorem exposing the owned-scratch branch spec with expTwoMulIterLoopPost and expTwoMulIterExitPost

## Verification
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitIterPosts
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/Compose/SavedBitIterPosts.lean (no matches)
- wc -l EvmAsm/Evm64/Exp/Compose/SavedBitIterPosts.lean
- scripts/check-file-size.sh EvmAsm/Evm64/Exp/Compose/SavedBitIterPosts.lean
- scripts/check-unimported.sh
- lake build