### PR TITLE
fix(sdiv): normalize callable return target

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/DivCallResultSignFix.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallResultSignFix.lean
@@ -197,4 +197,70 @@ theorem saveRa_signs_abs_signXor_then_divCall_then_return_of_callable_post_spec_
       xperm_hyp hp)
     hPrefix hRetFramed'
 
+/-- Normalized return-target view of the generic SDIV callable composition.
+    This hides the two `signExtend12 0` artifacts from the saved-RA move and
+    final `JALR`, leaving callers with the ordinary masked return address. -/
+theorem saveRa_signs_abs_signXor_then_divCall_then_return_normalized_of_callable_post_spec_in_sdivCode
+    {nSteps : Nat}
+    (vRa vSavedOld sp sDividendOld sDivisorOld
+      dividendMaskOld dividendValueOld dividendCarryOld
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+      v2 v5 v6 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (base : Word)
+    (hCallable :
+      cpsTripleWithin nSteps (base + wrapperEndOff) (base + resultSignFixOff) (sdivCode base)
+        (saveRaDivCallDispatchReadyPost vRa sp base
+          dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+          divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+          v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+        (saveRaDivCallBzeroCallablePost vRa sp base
+          dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+          divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)) :
+    cpsTripleWithin (((49 + nSteps) + 21) + 1)
+      base (vRa &&& ~~~(1 : Word)) (sdivCode base)
+      (saveRaSignsAbsSignXorThenDivCallPre vRa vSavedOld sp sDividendOld sDivisorOld
+        dividendMaskOld dividendValueOld dividendCarryOld
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
+       ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
+        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0))
+      (let dividendAbsWord :=
+         sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+       let divisorAbsWord :=
+         sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+       let quotientWord := EvmWord.div dividendAbsWord divisorAbsWord
+       let resultSign :=
+         (dividendTop >>> (63 : BitVec 6).toNat) ^^^
+           (divisorTop >>> (63 : BitVec 6).toNat)
+       let divisorSign := divisorTop >>> (63 : BitVec 6).toNat
+       (.x18 ↦ᵣ vRa) **
+       (resultSignFixPost (sp + 32) resultSign
+         (quotientWord.getLimbN 0) (quotientWord.getLimbN 1)
+         (quotientWord.getLimbN 2) (quotientWord.getLimbN 3) **
+        saveRaDivCallBzeroSavedRaRetFrame sp base divisorSign dividendAbsWord)) := by
+  have hExit :
+      (((vRa + signExtend12 (0 : BitVec 12)) +
+        signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word)) =
+        (vRa &&& ~~~(1 : Word)) := by
+    rw [signExtend12_0]
+    bv_decide
+  rw [← hExit]
+  exact cpsTripleWithin_weaken (fun _ hp => hp) (fun _ hp => by
+      simp only [signExtend12_0] at hp ⊢
+      have h_ra : (vRa + (0 : Word)) = vRa := by bv_decide
+      rw [h_ra] at hp
+      exact hp)
+    (saveRa_signs_abs_signXor_then_divCall_then_return_of_callable_post_spec_in_sdivCode
+      vRa vSavedOld sp sDividendOld sDivisorOld
+      dividendMaskOld dividendValueOld dividendCarryOld
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+      v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 base hCallable)
+
 end EvmAsm.Evm64.SDiv.Compose


### PR DESCRIPTION
## Summary
- add a normalized return-target wrapper for the generic SDIV callable composition
- expose the final target as `vRa &&& ~~~1` and normalize the preserved `x18` atom to `vRa`

## Verification
- `lake build EvmAsm.Evm64.SDiv.Compose.DivCallResultSignFix`
- `git diff --check`
- `rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/DivCallResultSignFix.lean`
- `wc -l EvmAsm/Evm64/SDiv/Compose/DivCallResultSignFix.lean`
- `scripts/check-file-size.sh EvmAsm/Evm64/SDiv/Compose/DivCallResultSignFix.lean`
- `scripts/check-unimported.sh`
- `lake build`
