### PR TITLE
fix(exp): specialize iter canonical branches

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitIterPosts.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitIterPosts.lean
@@ -504,4 +504,57 @@ theorem exp_msb_saved_bit_two_mul_full_iter_named_pre_loopback_spec_within
       squaringMulOff condMulOff skipOff backOff base (base + 28)
       hbase hsqmt hcondmt hd hskip hback
 
+theorem exp_msb_saved_bit_two_mul_full_iter_named_pre_canonical_branches_spec_within
+    (e iterCount v18 sp evmSp vOld r0 r1 r2 r3 d0 d1 d2 d3
+      e0 e1 e2 e3 a0 a1 a2 a3 mulTarget : Word)
+    (squaringMulOff condMulOff : BitVec 21)
+    (base : Word)
+    (hbase : base &&& 1 = 0)
+    (hsqmt : mulTarget = ((base + 44) + 64) + signExtend21 squaringMulOff)
+    (hcondmt : mulTarget = ((base + 152) + 64) + signExtend21 condMulOff)
+    (hd : CodeReq.Disjoint
+            (evmExpMsbSavedBitTwoMulCode
+              base squaringMulOff condMulOff
+              EvmAsm.Evm64.canonicalExpCondMulSkipOff
+              EvmAsm.Evm64.canonicalExpMsbSavedBitLoopBackOff)
+            (mul_callable_code mulTarget)) :
+    let bit := e >>> (63 : BitVec 6).toNat
+    let w := expResultWord r0 r1 r2 r3
+    let aw := expResultWord a0 a1 a2 a3
+    let rw := (w * w) * aw
+    let iterCountNew := iterCount + signExtend12 ((-1 : BitVec 12))
+    cpsBranchWithin
+      (((3 + 1 + (17 + 64 + 9) + 1) + 2) + ((17 + 64 + 9) + 2))
+      (base + 28)
+      (evmExpMsbSavedBitTwoMulWithMulCode
+        base mulTarget squaringMulOff condMulOff
+        EvmAsm.Evm64.canonicalExpCondMulSkipOff
+        EvmAsm.Evm64.canonicalExpMsbSavedBitLoopBackOff)
+      (expTwoMulIterPre e iterCount v18 sp evmSp vOld r0 r1 r2 r3 d0 d1 d2 d3
+        e0 e1 e2 e3 a0 a1 a2 a3)
+      (base + 28)
+        (expTwoMulIterLoopPost iterCountNew bit sp evmSp base a0 a1 a2 a3 w rw)
+      (base + 264)
+        (expTwoMulIterExitPost iterCountNew bit sp evmSp base a0 a1 a2 a3 w rw) := by
+  have hskip :
+      (base + 148 : Word) +
+        signExtend13 EvmAsm.Evm64.canonicalExpCondMulSkipOff = base + 256 := by
+    rw [EvmAsm.Evm64.canonicalExpCondMulSkipOff_eq]
+    unfold signExtend13
+    bv_decide
+  have hback :
+      ((base + 256) + 4 : Word) +
+        signExtend13 EvmAsm.Evm64.canonicalExpMsbSavedBitLoopBackOff = base + 28 := by
+    rw [EvmAsm.Evm64.canonicalExpMsbSavedBitLoopBackOff_eq]
+    unfold signExtend13
+    bv_decide
+  exact
+    exp_msb_saved_bit_two_mul_full_iter_named_pre_loopback_spec_within
+      e iterCount v18 sp evmSp vOld r0 r1 r2 r3 d0 d1 d2 d3
+      e0 e1 e2 e3 a0 a1 a2 a3 mulTarget
+      squaringMulOff condMulOff
+      EvmAsm.Evm64.canonicalExpCondMulSkipOff
+      EvmAsm.Evm64.canonicalExpMsbSavedBitLoopBackOff
+      base hbase hsqmt hcondmt hd hskip hback
+
 end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- add a two-MUL saved-bit iteration wrapper specialized to canonical EXP skip/back offsets
- discharge the canonical branch target equalities locally, leaving callers with only the MUL target and code-disjointness obligations

## Verification
- `lake build EvmAsm.Evm64.Exp.Compose.SavedBitIterPosts`
- `git diff --check`
- `rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/Compose/SavedBitIterPosts.lean`
- `wc -l EvmAsm/Evm64/Exp/Compose/SavedBitIterPosts.lean`
- `scripts/check-file-size.sh EvmAsm/Evm64/Exp/Compose/SavedBitIterPosts.lean`
- `scripts/check-unimported.sh`
- `lake build`
