### PR TITLE
fix(exp): expose two-mul canonical code spec

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBase.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBase.lean
@@ -556,6 +556,26 @@ theorem evmExpMsbSavedBitTwoMulCode_eq_ofProg (base : Word)
     (base + 28) squaringMulOff condMulOff skipOff backOff]
   simp only [CodeReq.unionAll_cons, CodeReq.unionAll_nil, CodeReq.union_empty_right]
 
+/-- CodeReq decomposition for the canonical two-MUL saved-bit EXP program.
+    The branch offsets are fixed by `evm_exp_msb_saved_bit_two_mul_canonical`;
+    the two external MUL call offsets remain caller supplied. -/
+abbrev evmExpMsbSavedBitTwoMulCanonicalCode (base : Word)
+    (squaringMulOff condMulOff : BitVec 21) : CodeReq :=
+  evmExpMsbSavedBitTwoMulCode base squaringMulOff condMulOff
+    EvmAsm.Evm64.canonicalExpCondMulSkipOff
+    EvmAsm.Evm64.canonicalExpMsbSavedBitLoopBackOff
+
+theorem evmExpMsbSavedBitTwoMulCanonicalCode_eq_ofProg (base : Word)
+    (squaringMulOff condMulOff : BitVec 21) :
+    evmExpMsbSavedBitTwoMulCanonicalCode base squaringMulOff condMulOff =
+      CodeReq.ofProg base
+        (EvmAsm.Evm64.evm_exp_msb_saved_bit_two_mul_canonical
+          squaringMulOff condMulOff) := by
+  rw [EvmAsm.Evm64.evm_exp_msb_saved_bit_two_mul_canonical_eq]
+  exact evmExpMsbSavedBitTwoMulCode_eq_ofProg base squaringMulOff condMulOff
+    EvmAsm.Evm64.canonicalExpCondMulSkipOff
+    EvmAsm.Evm64.canonicalExpMsbSavedBitLoopBackOff
+
 theorem evmExpMsbSavedBitTwoMulCode_iter_body_sub {base : Word}
     {squaringMulOff condMulOff : BitVec 21} {skipOff backOff : BitVec 13} :
     ∀ a i, (expIterBodyFullMsbSavedBitTwoMulCode

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitIterPosts.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitIterPosts.lean
@@ -557,4 +557,43 @@ theorem exp_msb_saved_bit_two_mul_full_iter_named_pre_canonical_branches_spec_wi
       EvmAsm.Evm64.canonicalExpMsbSavedBitLoopBackOff
       base hbase hsqmt hcondmt hd hskip hback
 
+/-- Canonical-code view of the named-pre two-MUL iteration spec. This packages
+    the canonical branch offsets behind `evmExpMsbSavedBitTwoMulCanonicalCode`,
+    leaving only the two external MUL-call offsets visible to callers. -/
+theorem exp_msb_saved_bit_two_mul_full_iter_named_pre_canonical_code_spec_within
+    (e iterCount v18 sp evmSp vOld r0 r1 r2 r3 d0 d1 d2 d3
+      e0 e1 e2 e3 a0 a1 a2 a3 mulTarget : Word)
+    (squaringMulOff condMulOff : BitVec 21)
+    (base : Word)
+    (hbase : base &&& 1 = 0)
+    (hsqmt : mulTarget = ((base + 44) + 64) + signExtend21 squaringMulOff)
+    (hcondmt : mulTarget = ((base + 152) + 64) + signExtend21 condMulOff)
+    (hd : CodeReq.Disjoint
+            (evmExpMsbSavedBitTwoMulCanonicalCode
+              base squaringMulOff condMulOff)
+            (mul_callable_code mulTarget)) :
+    let bit := e >>> (63 : BitVec 6).toNat
+    let w := expResultWord r0 r1 r2 r3
+    let aw := expResultWord a0 a1 a2 a3
+    let rw := (w * w) * aw
+    let iterCountNew := iterCount + signExtend12 ((-1 : BitVec 12))
+    cpsBranchWithin
+      (((3 + 1 + (17 + 64 + 9) + 1) + 2) + ((17 + 64 + 9) + 2))
+      (base + 28)
+      (evmExpMsbSavedBitTwoMulWithMulCode
+        base mulTarget squaringMulOff condMulOff
+        EvmAsm.Evm64.canonicalExpCondMulSkipOff
+        EvmAsm.Evm64.canonicalExpMsbSavedBitLoopBackOff)
+      (expTwoMulIterPre e iterCount v18 sp evmSp vOld r0 r1 r2 r3 d0 d1 d2 d3
+        e0 e1 e2 e3 a0 a1 a2 a3)
+      (base + 28)
+        (expTwoMulIterLoopPost iterCountNew bit sp evmSp base a0 a1 a2 a3 w rw)
+      (base + 264)
+        (expTwoMulIterExitPost iterCountNew bit sp evmSp base a0 a1 a2 a3 w rw) := by
+  exact
+    exp_msb_saved_bit_two_mul_full_iter_named_pre_canonical_branches_spec_within
+      e iterCount v18 sp evmSp vOld r0 r1 r2 r3 d0 d1 d2 d3
+      e0 e1 e2 e3 a0 a1 a2 a3 mulTarget
+      squaringMulOff condMulOff base hbase hsqmt hcondmt hd
+
 end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary

- add `evmExpMsbSavedBitTwoMulCanonicalCode` for the canonical two-MUL saved-bit EXP CodeReq
- prove its `CodeReq.ofProg` view against `evm_exp_msb_saved_bit_two_mul_canonical`
- expose the named-pre iteration branch spec over the canonical CodeReq name

## Verification

- `lake build EvmAsm.Evm64.Exp.Compose.SavedBitIterPosts`
- `git diff --check`
- `rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/Compose/SavedBitBase.lean EvmAsm/Evm64/Exp/Compose/SavedBitIterPosts.lean`
- `wc -l EvmAsm/Evm64/Exp/Compose/SavedBitBase.lean EvmAsm/Evm64/Exp/Compose/SavedBitIterPosts.lean`
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `lake build`
