### PR TITLE
fix(exp): expose canonical cond loopback

### DIFF
--- a/EvmAsm/Evm64/Exp.lean
+++ b/EvmAsm/Evm64/Exp.lean
@@ -38,6 +38,7 @@ import EvmAsm.Evm64.Exp.Compose.SavedBitBoundarySeq
 import EvmAsm.Evm64.Exp.Compose.SavedBitTwoMulSkip
 import EvmAsm.Evm64.Exp.Compose.SavedBitTwoMulSkipCanonical
 import EvmAsm.Evm64.Exp.Compose.SavedBitTwoMulCond
+import EvmAsm.Evm64.Exp.Compose.SavedBitTwoMulCondCanonical
 import EvmAsm.Evm64.Exp.Compose.SavedBitIterPosts
 import EvmAsm.Evm64.Exp.Layout
 import EvmAsm.Evm64.Exp.Spec

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCondCanonical.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCondCanonical.lean
@@ -1,0 +1,85 @@
+/-
+  EvmAsm.Evm64.Exp.Compose.SavedBitTwoMulCondCanonical
+
+  Canonical-code views of the saved-bit two-MUL conditional-multiply path.
+-/
+
+import EvmAsm.Evm64.Exp.Compose.SavedBitTwoMulCond
+
+namespace EvmAsm.Evm64.Exp.Compose
+
+open EvmAsm.Rv64
+
+/-- Canonical-code view of the taken conditional-multiply block followed by
+    the loop-back counter update. The loop branch returns to `base + 28`. -/
+theorem exp_cond_mul_call_then_loop_back_evm_exp_msb_saved_bit_two_mul_canonical_with_mul_spec_within
+    (iterCount sp evmSp tOld vOld r0 r1 r2 r3 a0 a1 a2 a3 d0 d1 d2 d3
+      e0 e1 e2 e3 v6 v7 v10 v11 mulTarget : Word)
+    (squaringMulOff condMulOff : BitVec 21) (base : Word)
+    (hbase : base &&& 1 = 0)
+    (hmt : mulTarget = ((base + 152) + 64) + signExtend21 condMulOff)
+    (hd : CodeReq.Disjoint
+            (evmExpMsbSavedBitTwoMulCanonicalCode
+              base squaringMulOff condMulOff)
+            (mul_callable_code mulTarget)) :
+    let r := expResultWord r0 r1 r2 r3
+    let aw := expResultWord a0 a1 a2 a3
+    let rw := r * aw
+    let iterCountNew := iterCount + signExtend12 ((-1 : BitVec 12))
+    let rest : Assertion :=
+      (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) **
+      (.x5 ↦ᵣ rw.getLimbN 3) **
+      ((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
+      ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **
+      ((evmSp + signExtend12 ((-48) : BitVec 12)) ↦ₘ a2) **
+      ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3) **
+      evmWordIs sp rw ** evmWordIs (evmSp + 32) rw **
+      regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
+      memOwn evmSp ** memOwn (evmSp + 8) **
+      memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
+      (.x1 ↦ᵣ ((base + 152) + 68))
+    cpsNBranchWithin ((17 + 64 + 9) + 2) (base + 152)
+      (evmExpMsbSavedBitTwoMulCanonicalWithMulCode
+        base mulTarget squaringMulOff condMulOff)
+      (((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
+        ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+        ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+        ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+        ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+        ((evmSp + signExtend12 (0 : BitVec 12)) ↦ₘ d0) **
+        ((evmSp + signExtend12 (8 : BitVec 12)) ↦ₘ d1) **
+        ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ d2) **
+        ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ d3) **
+        ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ e0) **
+        ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ e1) **
+        ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ e2) **
+        ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ e3) **
+        ((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
+        ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **
+        ((evmSp + signExtend12 ((-48) : BitVec 12)) ↦ₘ a2) **
+        ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3) **
+        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x10 ↦ᵣ v10) **
+        (.x11 ↦ᵣ v11) ** (.x1 ↦ᵣ vOld)) **
+       (.x9 ↦ᵣ iterCount) ** (.x0 ↦ᵣ (0 : Word)))
+      [(base + 28,
+          (((.x9 ↦ᵣ iterCountNew) ** (.x0 ↦ᵣ (0 : Word)) **
+           ⌜iterCountNew ≠ 0⌝) ** rest)),
+        (base + 264,
+          (((.x9 ↦ᵣ iterCountNew) ** (.x0 ↦ᵣ (0 : Word)) **
+           ⌜iterCountNew = 0⌝) ** rest))] := by
+  have hback :
+      ((base + 256) + 4 : Word) +
+          signExtend13 EvmAsm.Evm64.canonicalExpMsbSavedBitLoopBackOff =
+        base + 28 := by
+    rw [EvmAsm.Evm64.canonicalExpMsbSavedBitLoopBackOff_eq]
+    unfold signExtend13
+    bv_decide
+  exact
+    exp_cond_mul_call_then_loop_back_evm_exp_msb_saved_bit_two_mul_with_mul_spec_within
+      iterCount sp evmSp tOld vOld r0 r1 r2 r3 a0 a1 a2 a3 d0 d1 d2 d3
+      e0 e1 e2 e3 v6 v7 v10 v11 mulTarget squaringMulOff condMulOff
+      EvmAsm.Evm64.canonicalExpCondMulSkipOff
+      EvmAsm.Evm64.canonicalExpMsbSavedBitLoopBackOff
+      base (base + 28) hbase hmt hd hback
+
+end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary

- add `SavedBitTwoMulCondCanonical` for canonical-code views of the two-MUL conditional-multiply path
- expose the taken conditional-multiply path followed by canonical loop-back to `base + 28`
- import the new module from the EXP umbrella

## Verification

- `lake build EvmAsm.Evm64.Exp.Compose.SavedBitTwoMulCondCanonical`
- `git diff --check`
- `rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCondCanonical.lean EvmAsm/Evm64/Exp.lean`
- `wc -l EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCondCanonical.lean EvmAsm/Evm64/Exp.lean`
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `lake build`
