### PR TITLE
fix(exp): name canonical branch targets

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitIterPosts.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitIterPosts.lean
@@ -539,15 +539,11 @@ theorem exp_msb_saved_bit_two_mul_full_iter_named_pre_canonical_branches_spec_wi
   have hskip :
       (base + 148 : Word) +
         signExtend13 EvmAsm.Evm64.canonicalExpCondMulSkipOff = base + 256 := by
-    rw [EvmAsm.Evm64.canonicalExpCondMulSkipOff_eq]
-    unfold signExtend13
-    bv_decide
+    exact EvmAsm.Evm64.canonicalExpCondMulSkip_target base
   have hback :
       ((base + 256) + 4 : Word) +
         signExtend13 EvmAsm.Evm64.canonicalExpMsbSavedBitLoopBackOff = base + 28 := by
-    rw [EvmAsm.Evm64.canonicalExpMsbSavedBitLoopBackOff_eq]
-    unfold signExtend13
-    bv_decide
+    exact EvmAsm.Evm64.canonicalExpMsbSavedBitLoopBack_target base
   exact
     exp_msb_saved_bit_two_mul_full_iter_named_pre_loopback_spec_within
       e iterCount v18 sp evmSp vOld r0 r1 r2 r3 d0 d1 d2 d3

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCondCanonical.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCondCanonical.lean
@@ -71,9 +71,7 @@ theorem exp_cond_mul_call_then_loop_back_evm_exp_msb_saved_bit_two_mul_canonical
       ((base + 256) + 4 : Word) +
           signExtend13 EvmAsm.Evm64.canonicalExpMsbSavedBitLoopBackOff =
         base + 28 := by
-    rw [EvmAsm.Evm64.canonicalExpMsbSavedBitLoopBackOff_eq]
-    unfold signExtend13
-    bv_decide
+    exact EvmAsm.Evm64.canonicalExpMsbSavedBitLoopBack_target base
   exact
     exp_cond_mul_call_then_loop_back_evm_exp_msb_saved_bit_two_mul_with_mul_spec_within
       iterCount sp evmSp tOld vOld r0 r1 r2 r3 a0 a1 a2 a3 d0 d1 d2 d3
@@ -135,9 +133,7 @@ theorem exp_cond_mul_call_then_loop_back_evm_exp_msb_saved_bit_two_mul_canonical
       ((base + 256) + 4 : Word) +
           signExtend13 EvmAsm.Evm64.canonicalExpMsbSavedBitLoopBackOff =
         base + 28 := by
-    rw [EvmAsm.Evm64.canonicalExpMsbSavedBitLoopBackOff_eq]
-    unfold signExtend13
-    bv_decide
+    exact EvmAsm.Evm64.canonicalExpMsbSavedBitLoopBack_target base
   exact
     exp_cond_mul_call_then_loop_back_evm_exp_msb_saved_bit_two_mul_with_mul_folded_owned_spec_within
       iterCount sp evmSp vOld a0 a1 a2 a3 mulTarget r

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulSkipCanonical.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulSkipCanonical.lean
@@ -25,9 +25,7 @@ theorem exp_loop_back_evm_exp_msb_saved_bit_two_mul_canonical_with_mul_spec_with
       ((base + 256) + 4 : Word) +
           signExtend13 EvmAsm.Evm64.canonicalExpMsbSavedBitLoopBackOff =
         base + 28 := by
-    rw [EvmAsm.Evm64.canonicalExpMsbSavedBitLoopBackOff_eq]
-    unfold signExtend13
-    bv_decide
+    exact EvmAsm.Evm64.canonicalExpMsbSavedBitLoopBack_target base
   exact exp_loop_back_evm_exp_msb_saved_bit_two_mul_with_mul_spec_within
     c squaringMulOff condMulOff EvmAsm.Evm64.canonicalExpCondMulSkipOff
     EvmAsm.Evm64.canonicalExpMsbSavedBitLoopBackOff
@@ -97,16 +95,12 @@ theorem exp_msb_saved_bit_prefix_squaring_beq_skip_then_loop_back_evm_exp_msb_sa
   have hskip :
       (base + 148 : Word) + signExtend13 EvmAsm.Evm64.canonicalExpCondMulSkipOff =
         base + 256 := by
-    rw [EvmAsm.Evm64.canonicalExpCondMulSkipOff_eq]
-    unfold signExtend13
-    bv_decide
+    exact EvmAsm.Evm64.canonicalExpCondMulSkip_target base
   have hback :
       ((base + 256) + 4 : Word) +
           signExtend13 EvmAsm.Evm64.canonicalExpMsbSavedBitLoopBackOff =
         base + 28 := by
-    rw [EvmAsm.Evm64.canonicalExpMsbSavedBitLoopBackOff_eq]
-    unfold signExtend13
-    bv_decide
+    exact EvmAsm.Evm64.canonicalExpMsbSavedBitLoopBack_target base
   exact
     exp_msb_saved_bit_prefix_squaring_beq_skip_then_loop_back_evm_exp_msb_saved_bit_two_mul_with_mul_spec_within
       e c iterCount v10 v18 sp evmSp vOld r0 r1 r2 r3 d0 d1 d2 d3

--- a/EvmAsm/Evm64/Exp/Program.lean
+++ b/EvmAsm/Evm64/Exp/Program.lean
@@ -12,6 +12,7 @@
 -/
 
 import EvmAsm.Rv64.Program
+import Std.Tactic.BVDecide
 
 namespace EvmAsm.Evm64
 
@@ -1057,6 +1058,21 @@ theorem canonicalExpLoopBackOff_eq :
 
 theorem canonicalExpMsbSavedBitLoopBackOff_eq :
     canonicalExpMsbSavedBitLoopBackOff = -232 := rfl
+
+theorem canonicalExpCondMulSkip_target (base : Word) :
+    (base + 148 : Word) + signExtend13 canonicalExpCondMulSkipOff =
+      base + 256 := by
+  rw [canonicalExpCondMulSkipOff_eq]
+  unfold signExtend13
+  bv_decide
+
+theorem canonicalExpMsbSavedBitLoopBack_target (base : Word) :
+    ((base + 256) + 4 : Word) +
+        signExtend13 canonicalExpMsbSavedBitLoopBackOff =
+      base + 28 := by
+  rw [canonicalExpMsbSavedBitLoopBackOff_eq]
+  unfold signExtend13
+  bv_decide
 
 theorem evm_exp_canonical_eq (mulOff : BitVec 21) :
     evm_exp_canonical mulOff =


### PR DESCRIPTION
## Summary

- add named canonical EXP branch-target equalities for the conditional-multiply skip and saved-bit loop-back branches
- reuse those equalities in the canonical skip/cond/folded wrappers and saved-bit iteration wrapper
- make `Exp.Program` explicitly import `Std.Tactic.BVDecide` now that it owns the `bv_decide` proofs

## Verification

- `lake build EvmAsm.Evm64.Exp.Program`
- `lake build EvmAsm.Evm64.Exp.Compose.SavedBitTwoMulSkipCanonical`
- `lake build EvmAsm.Evm64.Exp.Compose.SavedBitTwoMulCondCanonical`
- `lake build EvmAsm.Evm64.Exp.Compose.SavedBitIterPosts`
- `git diff --check`
- `rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/Program.lean EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulSkipCanonical.lean EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCondCanonical.lean EvmAsm/Evm64/Exp/Compose/SavedBitIterPosts.lean`
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `lake build`
