### PR TITLE
fix(exp): name canonical mul call targets

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitIterPosts.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitIterPosts.lean
@@ -629,4 +629,45 @@ theorem exp_msb_saved_bit_two_mul_full_iter_named_pre_canonical_with_mul_spec_wi
       e0 e1 e2 e3 a0 a1 a2 a3 mulTarget
       squaringMulOff condMulOff base hbase hsqmt hcondmt hd
 
+/-- Canonical combined-code view of the named-pre two-MUL iteration spec with
+    `mul_callable` appended immediately after the 304-byte EXP wrapper. -/
+theorem exp_msb_saved_bit_two_mul_full_iter_named_pre_canonical_appended_mul_spec_within
+    (e iterCount v18 sp evmSp vOld r0 r1 r2 r3 d0 d1 d2 d3
+      e0 e1 e2 e3 a0 a1 a2 a3 : Word)
+    (base : Word)
+    (hbase : base &&& 1 = 0)
+    (hd : CodeReq.Disjoint
+            (evmExpMsbSavedBitTwoMulCanonicalCode
+              base EvmAsm.Evm64.canonicalExpSquaringMulOff
+                EvmAsm.Evm64.canonicalExpCondMulOff)
+            (mul_callable_code (base + 304))) :
+    let bit := e >>> (63 : BitVec 6).toNat
+    let w := expResultWord r0 r1 r2 r3
+    let aw := expResultWord a0 a1 a2 a3
+    let rw := (w * w) * aw
+    let iterCountNew := iterCount + signExtend12 ((-1 : BitVec 12))
+    cpsBranchWithin
+      (((3 + 1 + (17 + 64 + 9) + 1) + 2) + ((17 + 64 + 9) + 2))
+      (base + 28)
+      (evmExpMsbSavedBitTwoMulCanonicalWithMulCode
+        base (base + 304)
+        EvmAsm.Evm64.canonicalExpSquaringMulOff
+        EvmAsm.Evm64.canonicalExpCondMulOff)
+      (expTwoMulIterPre e iterCount v18 sp evmSp vOld r0 r1 r2 r3 d0 d1 d2 d3
+        e0 e1 e2 e3 a0 a1 a2 a3)
+      (base + 28)
+        (expTwoMulIterLoopPost iterCountNew bit sp evmSp base a0 a1 a2 a3 w rw)
+      (base + 264)
+        (expTwoMulIterExitPost iterCountNew bit sp evmSp base a0 a1 a2 a3 w rw) := by
+  exact
+    exp_msb_saved_bit_two_mul_full_iter_named_pre_canonical_with_mul_spec_within
+      e iterCount v18 sp evmSp vOld r0 r1 r2 r3 d0 d1 d2 d3
+      e0 e1 e2 e3 a0 a1 a2 a3 (base + 304)
+      EvmAsm.Evm64.canonicalExpSquaringMulOff
+      EvmAsm.Evm64.canonicalExpCondMulOff
+      base hbase
+      (EvmAsm.Evm64.canonicalExpSquaringMul_target base).symm
+      (EvmAsm.Evm64.canonicalExpCondMul_target base).symm
+      hd
+
 end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Program.lean
+++ b/EvmAsm/Evm64/Exp/Program.lean
@@ -1031,6 +1031,14 @@ def canonicalExpLoopBackOff : BitVec 13 := -228
 /-- Canonical BNE back-edge for the corrected MSB-first saved-bit layout. -/
 def canonicalExpMsbSavedBitLoopBackOff : BitVec 13 := -232
 
+/-- Canonical JAL offset from the saved-bit squaring call site to an appended
+    `mul_callable` body immediately after the 304-byte EXP wrapper. -/
+def canonicalExpSquaringMulOff : BitVec 21 := 196
+
+/-- Canonical JAL offset from the saved-bit conditional-multiply call site to an
+    appended `mul_callable` body immediately after the 304-byte EXP wrapper. -/
+def canonicalExpCondMulOff : BitVec 21 := 88
+
 /-- EXP program with the internal branch offsets pinned by the canonical layout.
     The MUL call offset remains external because it depends on the caller's
     placement of `mul_callable`. -/
@@ -1059,6 +1067,12 @@ theorem canonicalExpLoopBackOff_eq :
 theorem canonicalExpMsbSavedBitLoopBackOff_eq :
     canonicalExpMsbSavedBitLoopBackOff = -232 := rfl
 
+theorem canonicalExpSquaringMulOff_eq :
+    canonicalExpSquaringMulOff = 196 := rfl
+
+theorem canonicalExpCondMulOff_eq :
+    canonicalExpCondMulOff = 88 := rfl
+
 theorem canonicalExpCondMulSkip_target (base : Word) :
     (base + 148 : Word) + signExtend13 canonicalExpCondMulSkipOff =
       base + 256 := by
@@ -1072,6 +1086,20 @@ theorem canonicalExpMsbSavedBitLoopBack_target (base : Word) :
       base + 28 := by
   rw [canonicalExpMsbSavedBitLoopBackOff_eq]
   unfold signExtend13
+  bv_decide
+
+theorem canonicalExpSquaringMul_target (base : Word) :
+    ((base + 44) + 64 : Word) + signExtend21 canonicalExpSquaringMulOff =
+      base + 304 := by
+  rw [canonicalExpSquaringMulOff_eq]
+  unfold signExtend21
+  bv_decide
+
+theorem canonicalExpCondMul_target (base : Word) :
+    ((base + 152) + 64 : Word) + signExtend21 canonicalExpCondMulOff =
+      base + 304 := by
+  rw [canonicalExpCondMulOff_eq]
+  unfold signExtend21
   bv_decide
 
 theorem evm_exp_canonical_eq (mulOff : BitVec 21) :


### PR DESCRIPTION
## Summary

- add canonical two-MUL saved-bit EXP JAL offsets for an appended `mul_callable` body at `base + 304`
- prove the squaring and conditional-multiply JAL target equalities for that appended layout
- expose a named-pre one-iteration wrapper over `evmExpMsbSavedBitTwoMulCanonicalWithMulCode` using the canonical appended-MUL offsets

## Verification

- `lake build EvmAsm.Evm64.Exp.Program`
- `lake build EvmAsm.Evm64.Exp.Compose.SavedBitIterPosts`
- `git diff --check`
- `rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/Program.lean EvmAsm/Evm64/Exp/Compose/SavedBitIterPosts.lean`
- `wc -l EvmAsm/Evm64/Exp/Program.lean EvmAsm/Evm64/Exp/Compose/SavedBitIterPosts.lean`
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `lake build`
