### PR TITLE
fix(exp): prove appended mul disjoint

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitIterPosts.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitIterPosts.lean
@@ -635,12 +635,7 @@ theorem exp_msb_saved_bit_two_mul_full_iter_named_pre_canonical_appended_mul_spe
     (e iterCount v18 sp evmSp vOld r0 r1 r2 r3 d0 d1 d2 d3
       e0 e1 e2 e3 a0 a1 a2 a3 : Word)
     (base : Word)
-    (hbase : base &&& 1 = 0)
-    (hd : CodeReq.Disjoint
-            (evmExpMsbSavedBitTwoMulCanonicalCode
-              base EvmAsm.Evm64.canonicalExpSquaringMulOff
-                EvmAsm.Evm64.canonicalExpCondMulOff)
-            (mul_callable_code (base + 304))) :
+    (hbase : base &&& 1 = 0) :
     let bit := e >>> (63 : BitVec 6).toNat
     let w := expResultWord r0 r1 r2 r3
     let aw := expResultWord a0 a1 a2 a3
@@ -668,6 +663,6 @@ theorem exp_msb_saved_bit_two_mul_full_iter_named_pre_canonical_appended_mul_spe
       base hbase
       (EvmAsm.Evm64.canonicalExpSquaringMul_target base).symm
       (EvmAsm.Evm64.canonicalExpCondMul_target base).symm
-      hd
+      (evmExpMsbSavedBitTwoMulCanonicalCode_disjoint_appended_mul base)
 
 end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitWithMul.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitWithMul.lean
@@ -100,6 +100,33 @@ theorem evmExpMsbSavedBitTwoMulCanonicalWithMulCode_mul_sub
   unfold evmExpMsbSavedBitTwoMulCanonicalWithMulCode
   exact CodeReq.mono_union_right hd (fun _ _ h => h)
 
+/-- The canonical two-MUL saved-bit EXP wrapper is disjoint from a
+    `mul_callable` body appended immediately after the 304-byte wrapper. -/
+theorem evmExpMsbSavedBitTwoMulCanonicalCode_disjoint_appended_mul
+    (base : Word) :
+    CodeReq.Disjoint
+      (evmExpMsbSavedBitTwoMulCanonicalCode
+        base EvmAsm.Evm64.canonicalExpSquaringMulOff
+          EvmAsm.Evm64.canonicalExpCondMulOff)
+      (mul_callable_code (base + 304)) := by
+  rw [evmExpMsbSavedBitTwoMulCanonicalCode_eq_ofProg,
+    mul_callable_code_eq_ofProg]
+  exact CodeReq.ofProg_disjoint_range_len
+    base
+    (EvmAsm.Evm64.evm_exp_msb_saved_bit_two_mul_canonical
+      EvmAsm.Evm64.canonicalExpSquaringMulOff
+      EvmAsm.Evm64.canonicalExpCondMulOff)
+    76
+    (base + 304)
+    EvmAsm.Evm64.mul_callable
+    64
+    (EvmAsm.Evm64.evm_exp_msb_saved_bit_two_mul_canonical_length
+      EvmAsm.Evm64.canonicalExpSquaringMulOff
+      EvmAsm.Evm64.canonicalExpCondMulOff)
+    EvmAsm.Evm64.mul_callable_length
+    (fun k1 k2 hk1 hk2 => by
+      bv_omega)
+
 /-- Lift a corrected saved-bit top-level EXP spec into the combined EXP+MUL
     code bundle. -/
 theorem cpsTripleWithin_extend_evmExpMsbSavedBitWithMulCode {nSteps : Nat}


### PR DESCRIPTION
## Summary

- prove the canonical two-MUL saved-bit EXP wrapper is disjoint from `mul_callable` appended at `base + 304`
- use that disjointness proof in the canonical appended-MUL one-iteration wrapper
- remove the explicit disjointness argument from that wrapper's caller-facing API

## Verification

- `lake build EvmAsm.Evm64.Exp.Compose.SavedBitWithMul`
- `lake build EvmAsm.Evm64.Exp.Compose.SavedBitIterPosts`
- `git diff --check`
- `rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/Compose/SavedBitWithMul.lean EvmAsm/Evm64/Exp/Compose/SavedBitIterPosts.lean`
- `wc -l EvmAsm/Evm64/Exp/Compose/SavedBitWithMul.lean EvmAsm/Evm64/Exp/Compose/SavedBitIterPosts.lean`
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `lake build`
