### PR TITLE
fix(exp): specialize appended mul skip cond

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCondCanonical.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCondCanonical.lean
@@ -142,4 +142,58 @@ theorem exp_cond_mul_call_then_loop_back_evm_exp_msb_saved_bit_two_mul_canonical
       EvmAsm.Evm64.canonicalExpMsbSavedBitLoopBackOff
       base (base + 28) hbase hmt hd hback
 
+/-- Appended-MUL canonical-code view of the folded-word conditional-multiply
+    path followed by loop-back to the saved-bit iteration entry. -/
+theorem exp_cond_mul_call_then_loop_back_evm_exp_msb_saved_bit_two_mul_canonical_appended_mul_folded_owned_spec_within
+    (iterCount sp evmSp vOld a0 a1 a2 a3 : Word) (r : EvmWord)
+    (base : Word)
+    (hbase : base &&& 1 = 0) :
+    let aw := expResultWord a0 a1 a2 a3
+    let rw := r * aw
+    let iterCountNew := iterCount + signExtend12 ((-1 : BitVec 12))
+    let baseFrame : Assertion :=
+      ((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
+      ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **
+      ((evmSp + signExtend12 ((-48) : BitVec 12)) ↦ₘ a2) **
+      ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3)
+    let rest : Assertion :=
+      (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) **
+      (.x5 ↦ᵣ rw.getLimbN 3) **
+      ((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
+      ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **
+      ((evmSp + signExtend12 ((-48) : BitVec 12)) ↦ₘ a2) **
+      ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3) **
+      evmWordIs sp rw ** evmWordIs (evmSp + 32) rw **
+      regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
+      memOwn evmSp ** memOwn (evmSp + 8) **
+      memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
+      (.x1 ↦ᵣ ((base + 152) + 68))
+    let foldedPre : Assertion :=
+      (((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ r.getLimbN 3) **
+        evmWordIs sp r ** evmWordIs (evmSp + 32) r **
+        baseFrame ** (.x1 ↦ᵣ vOld) ** (.x9 ↦ᵣ iterCount) **
+        (.x0 ↦ᵣ (0 : Word))) **
+       regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
+       memOwn evmSp ** memOwn (evmSp + 8) **
+       memOwn (evmSp + 16) ** memOwn (evmSp + 24))
+    cpsNBranchWithin ((17 + 64 + 9) + 2) (base + 152)
+      (evmExpMsbSavedBitTwoMulCanonicalWithMulCode
+        base (base + 304)
+        EvmAsm.Evm64.canonicalExpSquaringMulOff
+        EvmAsm.Evm64.canonicalExpCondMulOff)
+      foldedPre
+      [(base + 28,
+          (((.x9 ↦ᵣ iterCountNew) ** (.x0 ↦ᵣ (0 : Word)) **
+           ⌜iterCountNew ≠ 0⌝) ** rest)),
+        (base + 264,
+          (((.x9 ↦ᵣ iterCountNew) ** (.x0 ↦ᵣ (0 : Word)) **
+           ⌜iterCountNew = 0⌝) ** rest))] :=
+  exp_cond_mul_call_then_loop_back_evm_exp_msb_saved_bit_two_mul_canonical_with_mul_folded_owned_spec_within
+    iterCount sp evmSp vOld a0 a1 a2 a3 (base + 304) r
+    EvmAsm.Evm64.canonicalExpSquaringMulOff
+    EvmAsm.Evm64.canonicalExpCondMulOff
+    base hbase
+    (EvmAsm.Evm64.canonicalExpCondMul_target base).symm
+    (evmExpMsbSavedBitTwoMulCanonicalCode_disjoint_appended_mul base)
+
 end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulSkipCanonical.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulSkipCanonical.lean
@@ -109,4 +109,70 @@ theorem exp_msb_saved_bit_prefix_squaring_beq_skip_then_loop_back_evm_exp_msb_sa
       EvmAsm.Evm64.canonicalExpMsbSavedBitLoopBackOff
       base (base + 28) hbase hmt hd hskip hback
 
+/-- Appended-MUL canonical-code view of the zero-bit saved-bit path through
+    BEQ and loop-back. -/
+theorem exp_msb_saved_bit_prefix_squaring_beq_skip_then_loop_back_evm_exp_msb_saved_bit_two_mul_canonical_appended_mul_spec_within
+    (e c iterCount v10 v18 sp evmSp vOld r0 r1 r2 r3 d0 d1 d2 d3
+      e0 e1 e2 e3 v7 v11 : Word)
+    (base : Word)
+    (hbase : base &&& 1 = 0) :
+    let bit := e >>> (63 : BitVec 6).toNat
+    let w := expResultWord r0 r1 r2 r3
+    let iterCountNew := iterCount + signExtend12 ((-1 : BitVec 12))
+    let rest : Assertion :=
+      (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
+      ⌜bit + signExtend12 (0 : BitVec 12) = 0⌝ **
+      (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) **
+      (.x5 ↦ᵣ (w * w).getLimbN 3) **
+      evmWordIs sp (w * w) ** evmWordIs (evmSp + 32) (w * w) **
+      regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
+      memOwn evmSp ** memOwn (evmSp + 8) **
+      memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
+      (.x1 ↦ᵣ ((base + 44) + 68))
+    cpsNBranchWithin ((3 + 1 + (17 + 64 + 9) + 1) + 2) (base + 28)
+      (evmExpMsbSavedBitTwoMulCanonicalWithMulCode
+        base (base + 304)
+        EvmAsm.Evm64.canonicalExpSquaringMulOff
+        EvmAsm.Evm64.canonicalExpCondMulOff)
+      ((.x5 ↦ᵣ e) ** (.x6 ↦ᵣ c) ** (.x10 ↦ᵣ v10) ** (.x18 ↦ᵣ v18) **
+       (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+       ((evmSp + signExtend12 (0 : BitVec 12)) ↦ₘ d0) **
+       ((evmSp + signExtend12 (8 : BitVec 12)) ↦ₘ d1) **
+       ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ d2) **
+       ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ d3) **
+       ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ e0) **
+       ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ e1) **
+       ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ e2) **
+       ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ e3) **
+       (.x7 ↦ᵣ v7) ** (.x11 ↦ᵣ v11) ** (.x1 ↦ᵣ vOld) **
+       (.x0 ↦ᵣ (0 : Word)) ** (.x9 ↦ᵣ iterCount))
+      [((base + 152),
+          ((.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
+           (.x0 ↦ᵣ (0 : Word)) ** ⌜bit + signExtend12 (0 : BitVec 12) ≠ 0⌝ **
+           (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) **
+           (.x5 ↦ᵣ (w * w).getLimbN 3) **
+           evmWordIs sp (w * w) ** evmWordIs (evmSp + 32) (w * w) **
+           regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
+           memOwn evmSp ** memOwn (evmSp + 8) **
+           memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
+           (.x1 ↦ᵣ ((base + 44) + 68))) ** (.x9 ↦ᵣ iterCount)),
+        (base + 28,
+          (((.x9 ↦ᵣ iterCountNew) ** (.x0 ↦ᵣ (0 : Word)) **
+           ⌜iterCountNew ≠ 0⌝) ** rest)),
+        (base + 264,
+          (((.x9 ↦ᵣ iterCountNew) ** (.x0 ↦ᵣ (0 : Word)) **
+           ⌜iterCountNew = 0⌝) ** rest))] :=
+  exp_msb_saved_bit_prefix_squaring_beq_skip_then_loop_back_evm_exp_msb_saved_bit_two_mul_canonical_with_mul_spec_within
+    e c iterCount v10 v18 sp evmSp vOld r0 r1 r2 r3 d0 d1 d2 d3
+    e0 e1 e2 e3 v7 v11 (base + 304)
+    EvmAsm.Evm64.canonicalExpSquaringMulOff
+    EvmAsm.Evm64.canonicalExpCondMulOff
+    base hbase
+    (EvmAsm.Evm64.canonicalExpSquaringMul_target base).symm
+    (evmExpMsbSavedBitTwoMulCanonicalCode_disjoint_appended_mul base)
+
 end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary

- specialize the canonical zero-bit skip/loop-back path to the appended-MUL code layout
- specialize the folded conditional-multiply loop-back path to the appended-MUL code layout
- reuse the canonical appended-MUL target and disjointness lemmas from the parent stack

## Verification

- `lake build EvmAsm.Evm64.Exp.Compose.SavedBitTwoMulSkipCanonical`
- `lake build EvmAsm.Evm64.Exp.Compose.SavedBitTwoMulCondCanonical`
- `git diff --check`
- `rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulSkipCanonical.lean EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCondCanonical.lean`
- `wc -l EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulSkipCanonical.lean EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCondCanonical.lean`
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `lake build`
