### PR TITLE
fix(exp): use appended mul code name

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBoundarySeq.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBoundarySeq.lean
@@ -247,10 +247,7 @@ theorem exp_prologue_then_pointer_advance_evm_exp_msb_saved_bit_two_mul_canonica
       regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
       (.x1 ↦ᵣ vOld) ** (.x18 ↦ᵣ v18)
     cpsTripleWithin (6 + 1) base (base + 28)
-      (evmExpMsbSavedBitTwoMulCanonicalWithMulCode
-        base (base + 304)
-        EvmAsm.Evm64.canonicalExpSquaringMulOff
-        EvmAsm.Evm64.canonicalExpCondMulOff)
+      (evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode base)
       (((((.x2 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) ** (.x9 ↦ᵣ cOld) **
           (.x5 ↦ᵣ tOld) ** ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ m0) **
           ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ m1) **
@@ -641,10 +638,7 @@ theorem exp_pointer_restore_then_epilogue_full_stack_evm_exp_msb_saved_bit_two_m
     let exitControl : Assertion :=
       (.x9 ↦ᵣ iterCountNew) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜exitCond⌝
     cpsTripleWithin (1 + 9) (base + 264) (base + 304)
-      (evmExpMsbSavedBitTwoMulCanonicalWithMulCode
-        base (base + 304)
-        EvmAsm.Evm64.canonicalExpSquaringMulOff
-        EvmAsm.Evm64.canonicalExpCondMulOff)
+      (evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode base)
       (exitControl **
        ((.x12 ↦ᵣ (evmSp + signExtend12 (64 : BitVec 12))) **
         ((.x2 ↦ᵣ sp) ** (.x5 ↦ᵣ tOld) **

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFullLoopCanonical.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFullLoopCanonical.lean
@@ -153,10 +153,7 @@ theorem exp_msb_saved_bit_prefix_then_squaring_call_evm_exp_msb_saved_bit_two_mu
     let bit := e >>> (63 : BitVec 6).toNat
     let w := expResultWord r0 r1 r2 r3
     cpsTripleWithin (3 + 1 + (17 + 64 + 9)) (base + 28) (base + 148)
-      (evmExpMsbSavedBitTwoMulCanonicalWithMulCode
-        base (base + 304)
-        EvmAsm.Evm64.canonicalExpSquaringMulOff
-        EvmAsm.Evm64.canonicalExpCondMulOff)
+      (evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode base)
       ((.x5 ↦ᵣ e) ** (.x6 ↦ᵣ c) ** (.x10 ↦ᵣ v10) ** (.x18 ↦ᵣ v18) **
        (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) **
        ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
@@ -320,10 +317,7 @@ theorem exp_msb_saved_bit_prefix_squaring_then_beq_evm_exp_msb_saved_bit_two_mul
     let bit := e >>> (63 : BitVec 6).toNat
     let w := expResultWord r0 r1 r2 r3
     cpsBranchWithin (3 + 1 + (17 + 64 + 9) + 1) (base + 28)
-      (evmExpMsbSavedBitTwoMulCanonicalWithMulCode
-        base (base + 304)
-        EvmAsm.Evm64.canonicalExpSquaringMulOff
-        EvmAsm.Evm64.canonicalExpCondMulOff)
+      (evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode base)
       ((.x5 ↦ᵣ e) ** (.x6 ↦ᵣ c) ** (.x10 ↦ᵣ v10) ** (.x18 ↦ᵣ v18) **
        (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) **
        ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitIterPosts.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitIterPosts.lean
@@ -644,10 +644,7 @@ theorem exp_msb_saved_bit_two_mul_full_iter_named_pre_canonical_appended_mul_spe
     cpsBranchWithin
       (((3 + 1 + (17 + 64 + 9) + 1) + 2) + ((17 + 64 + 9) + 2))
       (base + 28)
-      (evmExpMsbSavedBitTwoMulCanonicalWithMulCode
-        base (base + 304)
-        EvmAsm.Evm64.canonicalExpSquaringMulOff
-        EvmAsm.Evm64.canonicalExpCondMulOff)
+      (evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode base)
       (expTwoMulIterPre e iterCount v18 sp evmSp vOld r0 r1 r2 r3 d0 d1 d2 d3
         e0 e1 e2 e3 a0 a1 a2 a3)
       (base + 28)

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCondCanonical.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCondCanonical.lean
@@ -177,10 +177,7 @@ theorem exp_cond_mul_call_then_loop_back_evm_exp_msb_saved_bit_two_mul_canonical
        memOwn evmSp ** memOwn (evmSp + 8) **
        memOwn (evmSp + 16) ** memOwn (evmSp + 24))
     cpsNBranchWithin ((17 + 64 + 9) + 2) (base + 152)
-      (evmExpMsbSavedBitTwoMulCanonicalWithMulCode
-        base (base + 304)
-        EvmAsm.Evm64.canonicalExpSquaringMulOff
-        EvmAsm.Evm64.canonicalExpCondMulOff)
+      (evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode base)
       foldedPre
       [(base + 28,
           (((.x9 ↦ᵣ iterCountNew) ** (.x0 ↦ᵣ (0 : Word)) **

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulSkipCanonical.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulSkipCanonical.lean
@@ -130,10 +130,7 @@ theorem exp_msb_saved_bit_prefix_squaring_beq_skip_then_loop_back_evm_exp_msb_sa
       memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
       (.x1 ↦ᵣ ((base + 44) + 68))
     cpsNBranchWithin ((3 + 1 + (17 + 64 + 9) + 1) + 2) (base + 28)
-      (evmExpMsbSavedBitTwoMulCanonicalWithMulCode
-        base (base + 304)
-        EvmAsm.Evm64.canonicalExpSquaringMulOff
-        EvmAsm.Evm64.canonicalExpCondMulOff)
+      (evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode base)
       ((.x5 ↦ᵣ e) ** (.x6 ↦ᵣ c) ** (.x10 ↦ᵣ v10) ** (.x18 ↦ᵣ v18) **
        (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) **
        ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **


### PR DESCRIPTION
## Summary

- replace expanded appended-MUL code expressions in EXP wrapper statements with `evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode`
- keep existing proof calls to the parametric wrappers unchanged

## Verification

- `lake build EvmAsm.Evm64.Exp.Compose.SavedBitIterPosts`
- `lake build EvmAsm.Evm64.Exp.Compose.SavedBitTwoMulSkipCanonical`
- `lake build EvmAsm.Evm64.Exp.Compose.SavedBitFullLoopCanonical`
- `lake build EvmAsm.Evm64.Exp.Compose.SavedBitTwoMulCondCanonical`
- `lake build EvmAsm.Evm64.Exp.Compose.SavedBitBoundarySeq`
- `git diff --check`
- `rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/Compose/SavedBitIterPosts.lean EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulSkipCanonical.lean EvmAsm/Evm64/Exp/Compose/SavedBitFullLoopCanonical.lean EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCondCanonical.lean EvmAsm/Evm64/Exp/Compose/SavedBitBoundarySeq.lean`
- `wc -l EvmAsm/Evm64/Exp/Compose/SavedBitIterPosts.lean EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulSkipCanonical.lean EvmAsm/Evm64/Exp/Compose/SavedBitFullLoopCanonical.lean EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCondCanonical.lean EvmAsm/Evm64/Exp/Compose/SavedBitBoundarySeq.lean`
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `lake build`
