### PR TITLE
fix(exp): add appended prefix block specs

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFullLoopCanonical.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFullLoopCanonical.lean
@@ -29,6 +29,19 @@ theorem exp_msb_bit_test_evm_exp_msb_saved_bit_two_mul_canonical_with_mul_spec_w
     EvmAsm.Evm64.canonicalExpMsbSavedBitLoopBackOff
     base mulTarget
 
+/-- Appended-MUL canonical-code view of the saved-bit MSB bit-test block. -/
+theorem exp_msb_bit_test_evm_exp_msb_saved_bit_two_mul_canonical_appended_mul_spec_within
+    (e c v10 : Word) (base : Word) :
+    cpsTripleWithin 3 (base + 28) (base + 40)
+      (evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode base)
+      ((.x5 ↦ᵣ e) ** (.x6 ↦ᵣ c) ** (.x10 ↦ᵣ v10))
+      ((.x5 ↦ᵣ (e <<< (1 : BitVec 6).toNat)) **
+       (.x6 ↦ᵣ (c + signExtend12 ((-1) : BitVec 12))) **
+       (.x10 ↦ᵣ (e >>> (63 : BitVec 6).toNat))) :=
+  exp_msb_bit_test_evm_exp_msb_saved_bit_two_mul_canonical_with_mul_spec_within
+    e c v10 EvmAsm.Evm64.canonicalExpSquaringMulOff
+    EvmAsm.Evm64.canonicalExpCondMulOff base (base + 304)
+
 /-- Canonical-code view of the saved-bit copy block. -/
 theorem exp_save_bit_evm_exp_msb_saved_bit_two_mul_canonical_with_mul_spec_within
     (bit v18 : Word) (squaringMulOff condMulOff : BitVec 21)
@@ -43,6 +56,17 @@ theorem exp_save_bit_evm_exp_msb_saved_bit_two_mul_canonical_with_mul_spec_withi
     EvmAsm.Evm64.canonicalExpCondMulSkipOff
     EvmAsm.Evm64.canonicalExpMsbSavedBitLoopBackOff
     base mulTarget
+
+/-- Appended-MUL canonical-code view of the saved-bit copy block. -/
+theorem exp_save_bit_evm_exp_msb_saved_bit_two_mul_canonical_appended_mul_spec_within
+    (bit v18 : Word) (base : Word) :
+    cpsTripleWithin 1 (base + 40) (base + 44)
+      (evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode base)
+      ((.x10 ↦ᵣ bit) ** (.x18 ↦ᵣ v18))
+      ((.x10 ↦ᵣ bit) ** (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12)))) :=
+  exp_save_bit_evm_exp_msb_saved_bit_two_mul_canonical_with_mul_spec_within
+    bit v18 EvmAsm.Evm64.canonicalExpSquaringMulOff
+    EvmAsm.Evm64.canonicalExpCondMulOff base (base + 304)
 
 /-- Canonical-code view of the bit-test plus saved-bit prefix. -/
 theorem exp_msb_bit_test_then_save_bit_evm_exp_msb_saved_bit_two_mul_canonical_with_mul_spec_within
@@ -63,6 +87,21 @@ theorem exp_msb_bit_test_then_save_bit_evm_exp_msb_saved_bit_two_mul_canonical_w
     EvmAsm.Evm64.canonicalExpMsbSavedBitLoopBackOff
     base mulTarget
 
+/-- Appended-MUL canonical-code view of the bit-test plus saved-bit prefix. -/
+theorem exp_msb_bit_test_then_save_bit_evm_exp_msb_saved_bit_two_mul_canonical_appended_mul_spec_within
+    (e c v10 v18 : Word) (base : Word) :
+    let bit := e >>> (63 : BitVec 6).toNat
+    cpsTripleWithin (3 + 1) (base + 28) (base + 44)
+      (evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode base)
+      ((.x5 ↦ᵣ e) ** (.x6 ↦ᵣ c) ** (.x10 ↦ᵣ v10) ** (.x18 ↦ᵣ v18))
+      ((.x5 ↦ᵣ (e <<< (1 : BitVec 6).toNat)) **
+       (.x6 ↦ᵣ (c + signExtend12 ((-1) : BitVec 12))) **
+       (.x10 ↦ᵣ bit) **
+       (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12)))) :=
+  exp_msb_bit_test_then_save_bit_evm_exp_msb_saved_bit_two_mul_canonical_with_mul_spec_within
+    e c v10 v18 EvmAsm.Evm64.canonicalExpSquaringMulOff
+    EvmAsm.Evm64.canonicalExpCondMulOff base (base + 304)
+
 /-- Canonical-code view of the saved-bit conditional-multiply BEQ gate. -/
 theorem exp_cond_mul_saved_bit_beq_evm_exp_msb_saved_bit_two_mul_canonical_with_mul_spec_within
     (squaringMulOff condMulOff : BitVec 21) (v18 : Word)
@@ -82,6 +121,22 @@ theorem exp_cond_mul_saved_bit_beq_evm_exp_msb_saved_bit_two_mul_canonical_with_
     EvmAsm.Evm64.canonicalExpMsbSavedBitLoopBackOff
     v18 base mulTarget target htarget
 
+/-- Appended-MUL canonical-code view of the saved-bit conditional-multiply
+    BEQ gate. -/
+theorem exp_cond_mul_saved_bit_beq_evm_exp_msb_saved_bit_two_mul_canonical_appended_mul_spec_within
+    (v18 : Word) (base target : Word)
+    (htarget :
+      (base + 148 : Word) + signExtend13 EvmAsm.Evm64.canonicalExpCondMulSkipOff =
+        target) :
+    cpsBranchWithin 1 (base + 148)
+      (evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode base)
+      ((.x18 ↦ᵣ v18) ** (.x0 ↦ᵣ (0 : Word)))
+      target ((.x18 ↦ᵣ v18) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜v18 = 0⌝)
+      (base + 152) ((.x18 ↦ᵣ v18) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜v18 ≠ 0⌝) :=
+  exp_cond_mul_saved_bit_beq_evm_exp_msb_saved_bit_two_mul_canonical_with_mul_spec_within
+    EvmAsm.Evm64.canonicalExpSquaringMulOff
+    EvmAsm.Evm64.canonicalExpCondMulOff v18 base (base + 304) target htarget
+
 /-- Canonical-code view of the saved-bit conditional-multiply BEQ gate,
     specialized to the canonical skip target. -/
 theorem exp_cond_mul_saved_bit_beq_evm_exp_msb_saved_bit_two_mul_canonical_target_with_mul_spec_within
@@ -96,6 +151,18 @@ theorem exp_cond_mul_saved_bit_beq_evm_exp_msb_saved_bit_two_mul_canonical_targe
   exp_cond_mul_saved_bit_beq_evm_exp_msb_saved_bit_two_mul_canonical_with_mul_spec_within
     squaringMulOff condMulOff v18 base mulTarget (base + 256)
     (EvmAsm.Evm64.canonicalExpCondMulSkip_target base)
+
+/-- Appended-MUL canonical-code view of the saved-bit conditional-multiply
+    BEQ gate, specialized to the canonical skip target. -/
+theorem exp_cond_mul_saved_bit_beq_evm_exp_msb_saved_bit_two_mul_canonical_appended_mul_target_spec_within
+    (v18 : Word) (base : Word) :
+    cpsBranchWithin 1 (base + 148)
+      (evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode base)
+      ((.x18 ↦ᵣ v18) ** (.x0 ↦ᵣ (0 : Word)))
+      (base + 256) ((.x18 ↦ᵣ v18) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜v18 = 0⌝)
+      (base + 152) ((.x18 ↦ᵣ v18) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜v18 ≠ 0⌝) :=
+  exp_cond_mul_saved_bit_beq_evm_exp_msb_saved_bit_two_mul_canonical_appended_mul_spec_within
+    v18 base (base + 256) (EvmAsm.Evm64.canonicalExpCondMulSkip_target base)
 
 /-- Canonical-code view of the prefix plus squaring-call side of one saved-bit
     iteration. -/


### PR DESCRIPTION
## Summary

- add appended-MUL canonical-code wrappers for the saved-bit bit-test block
- add appended-MUL wrappers for save-bit, bit-test+save-bit, and the conditional-multiply BEQ gate
- specialize the BEQ wrapper to the canonical skip target over `evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode`

## Verification

- `lake build EvmAsm.Evm64.Exp.Compose.SavedBitFullLoopCanonical`
- `git diff --check`
- `rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/Compose/SavedBitFullLoopCanonical.lean`
- `wc -l EvmAsm/Evm64/Exp/Compose/SavedBitFullLoopCanonical.lean`
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `lake build`
