### PR TITLE
fix(exp): add appended loopback cond specs

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCondCanonical.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCondCanonical.lean
@@ -80,6 +80,65 @@ theorem exp_cond_mul_call_then_loop_back_evm_exp_msb_saved_bit_two_mul_canonical
       EvmAsm.Evm64.canonicalExpMsbSavedBitLoopBackOff
       base (base + 28) hbase hmt hd hback
 
+/-- Appended-MUL canonical-code view of the taken conditional-multiply block
+    followed by the loop-back counter update. -/
+theorem exp_cond_mul_call_then_loop_back_evm_exp_msb_saved_bit_two_mul_canonical_appended_mul_spec_within
+    (iterCount sp evmSp tOld vOld r0 r1 r2 r3 a0 a1 a2 a3 d0 d1 d2 d3
+      e0 e1 e2 e3 v6 v7 v10 v11 : Word)
+    (base : Word)
+    (hbase : base &&& 1 = 0) :
+    let r := expResultWord r0 r1 r2 r3
+    let aw := expResultWord a0 a1 a2 a3
+    let rw := r * aw
+    let iterCountNew := iterCount + signExtend12 ((-1 : BitVec 12))
+    let rest : Assertion :=
+      (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) **
+      (.x5 ↦ᵣ rw.getLimbN 3) **
+      ((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
+      ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **
+      ((evmSp + signExtend12 ((-48) : BitVec 12)) ↦ₘ a2) **
+      ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3) **
+      evmWordIs sp rw ** evmWordIs (evmSp + 32) rw **
+      regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
+      memOwn evmSp ** memOwn (evmSp + 8) **
+      memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
+      (.x1 ↦ᵣ ((base + 152) + 68))
+    cpsNBranchWithin ((17 + 64 + 9) + 2) (base + 152)
+      (evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode base)
+      (((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
+        ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+        ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+        ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+        ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+        ((evmSp + signExtend12 (0 : BitVec 12)) ↦ₘ d0) **
+        ((evmSp + signExtend12 (8 : BitVec 12)) ↦ₘ d1) **
+        ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ d2) **
+        ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ d3) **
+        ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ e0) **
+        ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ e1) **
+        ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ e2) **
+        ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ e3) **
+        ((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
+        ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **
+        ((evmSp + signExtend12 ((-48) : BitVec 12)) ↦ₘ a2) **
+        ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3) **
+        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x10 ↦ᵣ v10) **
+        (.x11 ↦ᵣ v11) ** (.x1 ↦ᵣ vOld)) **
+       (.x9 ↦ᵣ iterCount) ** (.x0 ↦ᵣ (0 : Word)))
+      [(base + 28,
+          (((.x9 ↦ᵣ iterCountNew) ** (.x0 ↦ᵣ (0 : Word)) **
+           ⌜iterCountNew ≠ 0⌝) ** rest)),
+        (base + 264,
+          (((.x9 ↦ᵣ iterCountNew) ** (.x0 ↦ᵣ (0 : Word)) **
+           ⌜iterCountNew = 0⌝) ** rest))] :=
+  exp_cond_mul_call_then_loop_back_evm_exp_msb_saved_bit_two_mul_canonical_with_mul_spec_within
+    iterCount sp evmSp tOld vOld r0 r1 r2 r3 a0 a1 a2 a3 d0 d1 d2 d3
+    e0 e1 e2 e3 v6 v7 v10 v11 (base + 304)
+    EvmAsm.Evm64.canonicalExpSquaringMulOff
+    EvmAsm.Evm64.canonicalExpCondMulOff
+    base hbase (EvmAsm.Evm64.canonicalExpCondMul_target base).symm
+    (evmExpMsbSavedBitTwoMulCanonicalCode_disjoint_appended_mul base)
+
 /-- Canonical-code view of the folded-word conditional-multiply path followed
     by loop-back to the saved-bit iteration entry. -/
 theorem exp_cond_mul_call_then_loop_back_evm_exp_msb_saved_bit_two_mul_canonical_with_mul_folded_owned_spec_within

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulSkipCanonical.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulSkipCanonical.lean
@@ -31,6 +31,19 @@ theorem exp_loop_back_evm_exp_msb_saved_bit_two_mul_canonical_with_mul_spec_with
     EvmAsm.Evm64.canonicalExpMsbSavedBitLoopBackOff
     base mulTarget (base + 28) htarget
 
+/-- Appended-MUL canonical-code view of the saved-bit loop-back block. -/
+theorem exp_loop_back_evm_exp_msb_saved_bit_two_mul_canonical_appended_mul_spec_within
+    (c : Word) (base : Word) :
+    let cNew := c + signExtend12 ((-1 : BitVec 12))
+    cpsBranchWithin 2 (base + 256)
+      (evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode base)
+      ((.x9 ↦ᵣ c) ** (.x0 ↦ᵣ (0 : Word)))
+      (base + 28) ((.x9 ↦ᵣ cNew) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜cNew ≠ 0⌝)
+      (base + 264) ((.x9 ↦ᵣ cNew) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜cNew = 0⌝) :=
+  exp_loop_back_evm_exp_msb_saved_bit_two_mul_canonical_with_mul_spec_within
+    c EvmAsm.Evm64.canonicalExpSquaringMulOff
+    EvmAsm.Evm64.canonicalExpCondMulOff base (base + 304)
+
 /-- Canonical-code view of the zero-bit path through the saved-bit BEQ and
     loop-back update. The nonzero branch remains the conditional-multiply
     handoff at `base + 152`; the loop branch returns to `base + 28`. -/


### PR DESCRIPTION
## Summary

- add an appended-MUL canonical-code wrapper for the saved-bit loop-back block
- add an appended-MUL wrapper for the non-folded conditional-multiply path through loop-back

## Verification

- `lake build EvmAsm.Evm64.Exp.Compose.SavedBitTwoMulSkipCanonical`
- `lake build EvmAsm.Evm64.Exp.Compose.SavedBitTwoMulCondCanonical`
- `git diff --check`
- `rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulSkipCanonical.lean EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCondCanonical.lean`
- `wc -l EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulSkipCanonical.lean EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCondCanonical.lean`
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `lake build`
