### PR TITLE
fix(exp): add fullloop nbranch extend helper

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/FullLoop.lean
+++ b/EvmAsm/Evm64/Exp/Compose/FullLoop.lean
@@ -63,6 +63,18 @@ theorem cpsBranchWithin_extend_evmExpWithMulCode {nSteps : Nat}
       P exit_t Q_t exit_f Q_f :=
   cpsBranchWithin_extend_code (hmono := evmExpWithMulCode_exp_sub) h
 
+/-- Lift a top-level EXP-body N-branch spec into the combined EXP+MUL code
+    bundle. -/
+theorem cpsNBranchWithin_extend_evmExpWithMulCode {nSteps : Nat}
+    {entry base mulTarget : Word}
+    {mulOff : BitVec 21} {skipOff backOff : BitVec 13}
+    {P : Assertion} {exits : List (Word × Assertion)}
+    (h : cpsNBranchWithin nSteps entry
+      (evmExpCode base mulOff skipOff backOff) P exits) :
+    cpsNBranchWithin nSteps entry
+      (evmExpWithMulCode base mulTarget mulOff skipOff backOff) P exits :=
+  cpsNBranchWithin_extend_code (hmono := evmExpWithMulCode_exp_sub) h
+
 /-- Lift a multiply-callable spec into the combined EXP+MUL code bundle. -/
 theorem cpsTripleWithin_extend_mulCallable_evmExpWithMulCode {nSteps : Nat}
     {entry exit_ base mulTarget : Word}


### PR DESCRIPTION
## Summary

- add `cpsNBranchWithin_extend_evmExpWithMulCode` for the original EXP full-loop code bundle
- align `FullLoop.lean` helper coverage with the saved-bit EXP+MUL helper files

## Verification

- `lake build EvmAsm.Evm64.Exp.Compose.FullLoop`
- `git diff --check`
- `rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/Compose/FullLoop.lean`
- `wc -l EvmAsm/Evm64/Exp/Compose/FullLoop.lean`
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `lake build`
