### PR TITLE
fix(sdiv): add callable return post pcfree instance

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/DivCallResultSignFix.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallResultSignFix.lean
@@ -60,6 +60,15 @@ theorem saveRaDivCallCallableReturnPost_pcFree
     EvmAsm.Evm64.divScratchOwn_unfold]
   pcFree
 
+instance pcFreeInst_saveRaDivCallCallableReturnPost
+    (vRa sp base dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word) :
+    Assertion.PCFree
+      (saveRaDivCallCallableReturnPost vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) :=
+  ⟨saveRaDivCallCallableReturnPost_pcFree⟩
+
 /-- SDIV wrapper prefix followed by any exact unsigned-DIV callable proof,
     then through result-sign-fix over the produced quotient word. -/
 theorem saveRa_signs_abs_signXor_then_divCall_then_resultSignFix_of_callable_post_spec_in_sdivCode


### PR DESCRIPTION
## Summary

- add `pcFreeInst_saveRaDivCallCallableReturnPost`
- let later SDIV callable-return composition frame the named post by instance search

## Verification

- `lake build EvmAsm.Evm64.SDiv.Compose.DivCallResultSignFix`
- `git diff --check`
- `rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/DivCallResultSignFix.lean`
- `wc -l EvmAsm/Evm64/SDiv/Compose/DivCallResultSignFix.lean EvmAsm/Evm64/SDiv/Compose/DivCallDispatch.lean`
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `lake build`
