### PR TITLE
chore(exp): document saved-bit full-loop size exception

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFullLoop.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFullLoop.lean
@@ -7,6 +7,8 @@
   tested bit live in `x18` across the unconditional squaring call.
 -/
 
+-- file-size-exception: legacy saved-bit EXP bundle on this stack branch; descendant stack splits these helpers.
+
 import EvmAsm.Evm64.Exp.Compose.FullLoop
 
 namespace EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary

- add the documented `file-size-exception` required by the guardrail for PR #3727
- note that this is the legacy saved-bit EXP bundle on this stack branch; descendant EXP stack work splits these helpers

## Verification

- `lake build EvmAsm.Evm64.Exp.Compose.SavedBitFullLoop`
- `scripts/check-file-size.sh --report`
- `git diff --check`
- `rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/Compose/SavedBitFullLoop.lean`
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `wc -l EvmAsm/Evm64/Exp/Compose/SavedBitFullLoop.lean`
- `lake build`
