### PR TITLE
fix(sdiv): add divcall post pcfree instances

### DIFF
--- a/EvmAsm/Evm64/SDiv.lean
+++ b/EvmAsm/Evm64/SDiv.lean
@@ -26,6 +26,7 @@ import EvmAsm.Evm64.SDiv.Compose.SignXorSequence
 import EvmAsm.Evm64.SDiv.Compose.DivCall
 import EvmAsm.Evm64.SDiv.Compose.DivCallDispatch
 import EvmAsm.Evm64.SDiv.Compose.DivCallResultSignFix
+import EvmAsm.Evm64.SDiv.Compose.DivCallPostPcFree
 import EvmAsm.Evm64.SDiv.Compose.DivCallDispatchZeroDivisor
 import EvmAsm.Evm64.SDiv.Compose.ResultSignFixOwn
 import EvmAsm.Evm64.SDiv.Spec

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallPostPcFree.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallPostPcFree.lean
@@ -1,0 +1,37 @@
+/-
+  EvmAsm.Evm64.SDiv.Compose.DivCallPostPcFree
+
+  PC-free instances for named SDIV div-call postcondition bundles.  Kept
+  separate from `DivCallDispatch.lean`, which is at the Compose line cap.
+-/
+
+import EvmAsm.Evm64.SDiv.Compose.DivCallResultSignFix
+
+namespace EvmAsm.Evm64.SDiv.Compose
+
+open EvmAsm.Rv64.Tactics
+open EvmAsm.Rv64
+
+theorem saveRaDivCallBzeroCallablePost_pcFree
+    {vRa sp base dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word} :
+    (saveRaDivCallBzeroCallablePost vRa sp base
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop).pcFree := by
+  rw [saveRaDivCallBzeroCallablePost_unfold]
+  dsimp
+  rw [EvmAsm.Evm64.divStackDispatchPostNoX1_unfold,
+    EvmAsm.Evm64.divScratchOwnCall_unfold,
+    EvmAsm.Evm64.divScratchOwn_unfold]
+  pcFree
+
+instance pcFreeInst_saveRaDivCallBzeroCallablePost
+    (vRa sp base dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word) :
+    Assertion.PCFree
+      (saveRaDivCallBzeroCallablePost vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) :=
+  ⟨saveRaDivCallBzeroCallablePost_pcFree⟩
+
+end EvmAsm.Evm64.SDiv.Compose


### PR DESCRIPTION
## Summary

- add `DivCallPostPcFree.lean` for named SDIV div-call postcondition frame facts
- prove and register `saveRaDivCallBzeroCallablePost_pcFree`
- import the new helper through the SDIV umbrella while keeping `DivCallDispatch.lean` at 1199 lines

## Verification

- `lake build EvmAsm.Evm64.SDiv.Compose.DivCallPostPcFree`
- `git diff --check`
- `rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/DivCallPostPcFree.lean EvmAsm/Evm64/SDiv.lean`
- `wc -l EvmAsm/Evm64/SDiv/Compose/DivCallPostPcFree.lean EvmAsm/Evm64/SDiv/Compose/DivCallDispatch.lean`
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `lake build`
