### PR TITLE
fix(sdiv): add bzero frame pcfree instances

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/DivCallPostPcFree.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallPostPcFree.lean
@@ -34,4 +34,36 @@ instance pcFreeInst_saveRaDivCallBzeroCallablePost
         divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) :=
   ⟨saveRaDivCallBzeroCallablePost_pcFree⟩
 
+theorem saveRaDivCallBzeroResultSignFixFrame_pcFree
+    {vRa sp base divisorSign : Word} {dividendAbsWord : EvmWord} :
+    (saveRaDivCallBzeroResultSignFixFrame
+      vRa sp base divisorSign dividendAbsWord).pcFree := by
+  rw [saveRaDivCallBzeroResultSignFixFrame_unfold,
+    EvmAsm.Evm64.divScratchOwnCall_unfold,
+    EvmAsm.Evm64.divScratchOwn_unfold]
+  pcFree
+
+instance pcFreeInst_saveRaDivCallBzeroResultSignFixFrame
+    (vRa sp base divisorSign : Word) (dividendAbsWord : EvmWord) :
+    Assertion.PCFree
+      (saveRaDivCallBzeroResultSignFixFrame
+        vRa sp base divisorSign dividendAbsWord) :=
+  ⟨saveRaDivCallBzeroResultSignFixFrame_pcFree⟩
+
+theorem saveRaDivCallBzeroSavedRaRetFrame_pcFree
+    {sp base divisorSign : Word} {dividendAbsWord : EvmWord} :
+    (saveRaDivCallBzeroSavedRaRetFrame
+      sp base divisorSign dividendAbsWord).pcFree := by
+  rw [saveRaDivCallBzeroSavedRaRetFrame_unfold,
+    EvmAsm.Evm64.divScratchOwnCall_unfold,
+    EvmAsm.Evm64.divScratchOwn_unfold]
+  pcFree
+
+instance pcFreeInst_saveRaDivCallBzeroSavedRaRetFrame
+    (sp base divisorSign : Word) (dividendAbsWord : EvmWord) :
+    Assertion.PCFree
+      (saveRaDivCallBzeroSavedRaRetFrame
+        sp base divisorSign dividendAbsWord) :=
+  ⟨saveRaDivCallBzeroSavedRaRetFrame_pcFree⟩
+
 end EvmAsm.Evm64.SDiv.Compose


### PR DESCRIPTION
## Summary

- add reusable `PCFree` facts for `saveRaDivCallBzeroResultSignFixFrame`
- add reusable `PCFree` facts for `saveRaDivCallBzeroSavedRaRetFrame`
- keep these frame facts in `DivCallPostPcFree.lean`, leaving capped `DivCallDispatch.lean` untouched

## Verification

- `lake build EvmAsm.Evm64.SDiv.Compose.DivCallPostPcFree`
- `git diff --check`
- `rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/DivCallPostPcFree.lean`
- `wc -l EvmAsm/Evm64/SDiv/Compose/DivCallPostPcFree.lean EvmAsm/Evm64/SDiv/Compose/DivCallDispatch.lean`
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `lake build`
