### PR TITLE
fix(sdiv): add result sign post pcfree instance

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/DivCallPostPcFree.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallPostPcFree.lean
@@ -66,4 +66,16 @@ instance pcFreeInst_saveRaDivCallBzeroSavedRaRetFrame
         sp base divisorSign dividendAbsWord) :=
   ⟨saveRaDivCallBzeroSavedRaRetFrame_pcFree⟩
 
+theorem resultSignFixPost_pcFree
+    {sp sign limb0 limb1 limb2 limb3 : Word} :
+    (resultSignFixPost sp sign limb0 limb1 limb2 limb3).pcFree := by
+  rw [resultSignFixPost_unfold]
+  dsimp
+  pcFree
+
+instance pcFreeInst_resultSignFixPost
+    (sp sign limb0 limb1 limb2 limb3 : Word) :
+    Assertion.PCFree (resultSignFixPost sp sign limb0 limb1 limb2 limb3) :=
+  ⟨resultSignFixPost_pcFree⟩
+
 end EvmAsm.Evm64.SDiv.Compose


### PR DESCRIPTION
## Summary

- add `resultSignFixPost_pcFree`
- register `pcFreeInst_resultSignFixPost`
- keep the helper in `DivCallPostPcFree.lean`, leaving capped `DivCallDispatch.lean` untouched

## Verification

- `lake build EvmAsm.Evm64.SDiv.Compose.DivCallPostPcFree`
- `git diff --check`
- `rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/DivCallPostPcFree.lean`
- `wc -l EvmAsm/Evm64/SDiv/Compose/DivCallPostPcFree.lean EvmAsm/Evm64/SDiv/Compose/DivCallDispatch.lean`
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `lake build`
