### PR TITLE
fix(exp): name two-mul loop entry post

### DIFF
--- a/EvmAsm/Evm64/Exp.lean
+++ b/EvmAsm/Evm64/Exp.lean
@@ -35,6 +35,7 @@ import EvmAsm.Evm64.Exp.Compose.SavedBitWithMul
 import EvmAsm.Evm64.Exp.Compose.SavedBitFullLoop
 import EvmAsm.Evm64.Exp.Compose.SavedBitFullLoopCanonical
 import EvmAsm.Evm64.Exp.Compose.SavedBitBoundarySeq
+import EvmAsm.Evm64.Exp.Compose.SavedBitLoopEntry
 import EvmAsm.Evm64.Exp.Compose.SavedBitTwoMulSkip
 import EvmAsm.Evm64.Exp.Compose.SavedBitTwoMulSkipCanonical
 import EvmAsm.Evm64.Exp.Compose.SavedBitTwoMulCond

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitLoopEntry.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitLoopEntry.lean
@@ -1,0 +1,79 @@
+/-
+  EvmAsm.Evm64.Exp.Compose.SavedBitLoopEntry
+
+  Named loop-entry postcondition for the two-MUL saved-bit EXP prologue
+  and pointer-advance boundary.
+-/
+
+import EvmAsm.Evm64.Exp.Compose.SavedBitBoundarySeq
+
+namespace EvmAsm.Evm64.Exp.Compose
+
+open EvmAsm.Rv64
+
+@[irreducible]
+def expTwoMulLoopEntryPost
+    (sp evmSp vOld v18 : Word) (baseWord exponentWord : EvmWord)
+    (rest : List EvmWord) : Assertion :=
+  (((((.x2 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x9 ↦ᵣ (256 : Word)) ** (.x5 ↦ᵣ (1 : Word)) **
+      evmWordIs sp (1 : EvmWord)) **
+     (.x12 ↦ᵣ (evmSp + 64))) **
+   evmStackIs evmSp (baseWord :: exponentWord :: rest)) **
+   (regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
+    (.x1 ↦ᵣ vOld) ** (.x18 ↦ᵣ v18)))
+
+theorem expTwoMulLoopEntryPost_unfold
+    {sp evmSp vOld v18 : Word} {baseWord exponentWord : EvmWord}
+    {rest : List EvmWord} :
+    expTwoMulLoopEntryPost sp evmSp vOld v18 baseWord exponentWord rest =
+      (((((.x2 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) **
+          (.x9 ↦ᵣ (256 : Word)) ** (.x5 ↦ᵣ (1 : Word)) **
+          evmWordIs sp (1 : EvmWord)) **
+         (.x12 ↦ᵣ (evmSp + 64))) **
+        evmStackIs evmSp (baseWord :: exponentWord :: rest)) **
+       (regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
+        (.x1 ↦ᵣ vOld) ** (.x18 ↦ᵣ v18))) := by
+  delta expTwoMulLoopEntryPost
+  rfl
+
+theorem expTwoMulLoopEntryPost_pcFree
+    {sp evmSp vOld v18 : Word} {baseWord exponentWord : EvmWord}
+    {rest : List EvmWord} :
+    (expTwoMulLoopEntryPost sp evmSp vOld v18 baseWord exponentWord rest).pcFree := by
+  rw [expTwoMulLoopEntryPost_unfold]
+  pcFree
+
+instance pcFreeInst_expTwoMulLoopEntryPost
+    (sp evmSp vOld v18 : Word) (baseWord exponentWord : EvmWord)
+    (rest : List EvmWord) :
+    Assertion.PCFree
+      (expTwoMulLoopEntryPost sp evmSp vOld v18 baseWord exponentWord rest) :=
+  ⟨expTwoMulLoopEntryPost_pcFree⟩
+
+/-- Appended-MUL canonical-code prologue/pointer boundary with a named
+    loop-entry postcondition. -/
+theorem exp_prologue_then_pointer_advance_evm_exp_msb_saved_bit_two_mul_canonical_appended_mul_named_loop_entry_spec_within
+    (sp evmSp cOld tOld m0 m1 m2 m3 vOld v18 : Word)
+    (baseWord exponentWord : EvmWord) (rest : List EvmWord)
+    (base : Word) :
+    let scratchFrame : Assertion :=
+      regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
+      (.x1 ↦ᵣ vOld) ** (.x18 ↦ᵣ v18)
+    cpsTripleWithin (6 + 1) base (base + 28)
+      (evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode base)
+      (((((.x2 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) ** (.x9 ↦ᵣ cOld) **
+          (.x5 ↦ᵣ tOld) ** ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ m0) **
+          ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ m1) **
+          ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ m2) **
+          ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ m3)) **
+         (.x12 ↦ᵣ evmSp)) ** evmStackIs evmSp (baseWord :: exponentWord :: rest)) **
+       scratchFrame)
+      (expTwoMulLoopEntryPost sp evmSp vOld v18 baseWord exponentWord rest) := by
+  intro scratchFrame
+  rw [expTwoMulLoopEntryPost_unfold]
+  exact
+    exp_prologue_then_pointer_advance_evm_exp_msb_saved_bit_two_mul_canonical_appended_mul_full_stack_clean_regs_spec_within
+      sp evmSp cOld tOld m0 m1 m2 m3 vOld v18 baseWord exponentWord rest base
+
+end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
Adds EvmAsm.Evm64.Exp.Compose.SavedBitLoopEntry with a named expTwoMulLoopEntryPost assertion for the canonical appended-MUL EXP prologue + pointer-advance boundary. The file includes an unfold lemma, PCFree theorem/instance, and a wrapper theorem exposing the existing canonical appended-MUL prologue boundary with the named postcondition.\n\nThis gives the later 256-iteration loop composition a stable boundary handoff surface without forcing the loop-entry shape to be the already-named iteration precondition.\n\nVerification:\n- lake build EvmAsm.Evm64.Exp.Compose.SavedBitLoopEntry\n- git diff --check\n- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/Compose/SavedBitLoopEntry.lean EvmAsm/Evm64/Exp.lean\n- wc -l EvmAsm/Evm64/Exp/Compose/SavedBitLoopEntry.lean EvmAsm/Evm64/Exp/Compose/SavedBitBoundarySeq.lean EvmAsm/Evm64/Exp.lean\n- scripts/check-file-size.sh\n- scripts/check-unimported.sh\n- lake build