### PR TITLE
fix(exp): compose named boundary loop

### DIFF
--- a/EvmAsm/Evm64/Exp.lean
+++ b/EvmAsm/Evm64/Exp.lean
@@ -37,6 +37,7 @@ import EvmAsm.Evm64.Exp.Compose.SavedBitFullLoopCanonical
 import EvmAsm.Evm64.Exp.Compose.SavedBitBoundarySeq
 import EvmAsm.Evm64.Exp.Compose.SavedBitLoopEntry
 import EvmAsm.Evm64.Exp.Compose.SavedBitLoopExit
+import EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryLoop
 import EvmAsm.Evm64.Exp.Compose.SavedBitTwoMulSkip
 import EvmAsm.Evm64.Exp.Compose.SavedBitTwoMulSkipCanonical
 import EvmAsm.Evm64.Exp.Compose.SavedBitTwoMulCond

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryLoop.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryLoop.lean
@@ -1,0 +1,46 @@
+/-
+  EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryLoop
+
+  Generic composition scaffold for the two-MUL saved-bit EXP boundary:
+  prologue/pointer-advance, an externally supplied loop proof, and
+  pointer-restore/epilogue.
+-/
+
+import EvmAsm.Evm64.Exp.Compose.SavedBitLoopExit
+
+namespace EvmAsm.Evm64.Exp.Compose
+
+open EvmAsm.Rv64
+
+/-- Compose the named prologue boundary, any loop proof over the named
+    loop-entry/loop-exit surface, and the named epilogue boundary. The future
+    256-iteration proof can instantiate `hLoop`. -/
+theorem exp_two_mul_boundary_loop_epilogue_of_loop_spec_within
+    {nSteps : Nat}
+    (sp evmSp cOld tOld m0 m1 m2 m3 vOld v18 iterCountNew
+      r0 r1 r2 r3 : Word)
+    (baseWord exponentWord : EvmWord) (rest : List EvmWord)
+    (exitCond : Prop) (base : Word)
+    (hLoop :
+      cpsTripleWithin nSteps (base + 28) (base + 264)
+        (evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode base)
+        (expTwoMulLoopEntryPost sp evmSp vOld v18 baseWord exponentWord rest)
+        (expTwoMulLoopExitPre sp evmSp iterCountNew tOld r0 r1 r2 r3
+          baseWord rest exitCond)) :
+    cpsTripleWithin (((6 + 1) + nSteps) + (1 + 9)) base (base + 304)
+      (evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode base)
+      (expTwoMulBoundaryPre sp evmSp cOld tOld m0 m1 m2 m3 vOld v18
+        baseWord exponentWord rest)
+      (expTwoMulLoopExitPost sp evmSp iterCountNew r0 r1 r2 r3
+        baseWord rest exitCond) := by
+  have hBoundary :=
+    exp_prologue_then_pointer_advance_evm_exp_msb_saved_bit_two_mul_canonical_appended_mul_named_boundary_spec_within
+      sp evmSp cOld tOld m0 m1 m2 m3 vOld v18 baseWord exponentWord rest base
+  have hPrefix :=
+    cpsTripleWithin_seq_same_cr hBoundary hLoop
+  exact
+    cpsTripleWithin_seq_same_cr hPrefix
+      (exp_pointer_restore_then_epilogue_evm_exp_msb_saved_bit_two_mul_canonical_appended_mul_named_loop_exit_spec_within
+        sp evmSp iterCountNew tOld r0 r1 r2 r3 baseWord rest exitCond base)
+
+end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
Adds EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryLoop with exp_two_mul_boundary_loop_epilogue_of_loop_spec_within. The theorem composes the named prologue/pointer boundary, any externally supplied loop proof from expTwoMulLoopEntryPost to expTwoMulLoopExitPre, and the named pointer-restore/epilogue boundary into a full boundary-to-epilogue cpsTriple.\n\nThis gives the future 256-iteration EXP loop theorem a direct sequencing target without reopening the boundary proof internals.\n\nVerification:\n- lake build EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryLoop\n- git diff --check\n- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryLoop.lean EvmAsm/Evm64/Exp.lean\n- wc -l EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryLoop.lean EvmAsm/Evm64/Exp/Compose/SavedBitLoopEntry.lean EvmAsm/Evm64/Exp/Compose/SavedBitLoopExit.lean EvmAsm/Evm64/Exp.lean\n- scripts/check-file-size.sh\n- scripts/check-unimported.sh\n- lake build