### PR TITLE
fix(exp): allow iter merge max bounds

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitIterMerge.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitIterMerge.lean
@@ -50,4 +50,44 @@ theorem exp_two_mul_named_iter_with_continuations_spec_within
         e0 e1 e2 e3 a0 a1 a2 a3 base hbase)
       hLoop hExit
 
+/-- Variant of `exp_two_mul_named_iter_with_continuations_spec_within` that
+    permits different bounds for the loop-back and loop-exit continuations. -/
+theorem exp_two_mul_named_iter_with_continuations_max_spec_within
+    {nLoop nExit : Nat} {exit_ : Word} {R : Assertion}
+    (e iterCount v18 sp evmSp vOld r0 r1 r2 r3 d0 d1 d2 d3
+      e0 e1 e2 e3 a0 a1 a2 a3 : Word)
+    (base : Word)
+    (hbase : base &&& 1 = 0) :
+    let bit := e >>> (63 : BitVec 6).toNat
+    let w := expResultWord r0 r1 r2 r3
+    let aw := expResultWord a0 a1 a2 a3
+    let rw := (w * w) * aw
+    let iterCountNew := iterCount + signExtend12 ((-1 : BitVec 12))
+    (cpsTripleWithin nLoop (base + 28) exit_
+      (evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode base)
+      (expTwoMulIterLoopPost iterCountNew bit sp evmSp base
+        a0 a1 a2 a3 w rw)
+      R) →
+    (cpsTripleWithin nExit (base + 264) exit_
+      (evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode base)
+      (expTwoMulIterExitPost iterCountNew bit sp evmSp base
+        a0 a1 a2 a3 w rw)
+      R) →
+    cpsTripleWithin
+      ((((3 + 1 + (17 + 64 + 9) + 1) + 2) + ((17 + 64 + 9) + 2)) +
+        max nLoop nExit)
+      (base + 28)
+      exit_
+      (evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode base)
+      (expTwoMulIterPre e iterCount v18 sp evmSp vOld r0 r1 r2 r3
+        d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3)
+      R := by
+  intro bit w aw rw iterCountNew hLoop hExit
+  exact
+    exp_two_mul_named_iter_with_continuations_spec_within
+      e iterCount v18 sp evmSp vOld r0 r1 r2 r3 d0 d1 d2 d3
+      e0 e1 e2 e3 a0 a1 a2 a3 base hbase
+      (cpsTripleWithin_mono_nSteps (Nat.le_max_left nLoop nExit) hLoop)
+      (cpsTripleWithin_mono_nSteps (Nat.le_max_right nLoop nExit) hExit)
+
 end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
Stacked on #3818.

Adds `exp_two_mul_named_iter_with_continuations_max_spec_within`, a variant of the named EXP iteration merge helper that allows different step bounds for the loop-back and loop-exit continuations. It lifts both continuations to `max nLoop nExit` with `cpsTripleWithin_mono_nSteps` and reuses the same branch-elimination helper.

Verification:
- `lake build EvmAsm.Evm64.Exp.Compose.SavedBitIterMerge`
- `git diff --check`
- forbidden marker scan over touched file
- `wc -l EvmAsm/Evm64/Exp/Compose/SavedBitIterMerge.lean EvmAsm/Evm64/Exp/Compose/SavedBitFullLoop.lean`
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `lake build` (passes; only existing LeanRV64D deprecation warning)