### PR TITLE
fix(sdiv): add composite signfix pcfree instances

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/DivCallPostPcFree.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallPostPcFree.lean
@@ -116,4 +116,36 @@ instance pcFreeInst_resultSignFixPreOwnScratch
     Assertion.PCFree (resultSignFixPreOwnScratch sp sign limb0 limb1 limb2 limb3) :=
   ⟨resultSignFixPreOwnScratch_pcFree⟩
 
+theorem resultSignFixPost_bzeroResultSignFixFrame_pcFree
+    {vRa sp base divisorSign sign limb0 limb1 limb2 limb3 : Word}
+    {dividendAbsWord : EvmWord} :
+    (resultSignFixPost (sp + 32) sign limb0 limb1 limb2 limb3 **
+      saveRaDivCallBzeroResultSignFixFrame
+        vRa sp base divisorSign dividendAbsWord).pcFree := by
+  pcFree
+
+instance pcFreeInst_resultSignFixPost_bzeroResultSignFixFrame
+    (vRa sp base divisorSign sign limb0 limb1 limb2 limb3 : Word)
+    (dividendAbsWord : EvmWord) :
+    Assertion.PCFree
+      (resultSignFixPost (sp + 32) sign limb0 limb1 limb2 limb3 **
+        saveRaDivCallBzeroResultSignFixFrame
+          vRa sp base divisorSign dividendAbsWord) :=
+  ⟨resultSignFixPost_bzeroResultSignFixFrame_pcFree⟩
+
+theorem resultSignFixPost_savedRaRetFrame_pcFree
+    {sp base divisorSign sign limb0 limb1 limb2 limb3 : Word}
+    {dividendAbsWord : EvmWord} :
+    (resultSignFixPost (sp + 32) sign limb0 limb1 limb2 limb3 **
+      saveRaDivCallBzeroSavedRaRetFrame sp base divisorSign dividendAbsWord).pcFree := by
+  pcFree
+
+instance pcFreeInst_resultSignFixPost_savedRaRetFrame
+    (sp base divisorSign sign limb0 limb1 limb2 limb3 : Word)
+    (dividendAbsWord : EvmWord) :
+    Assertion.PCFree
+      (resultSignFixPost (sp + 32) sign limb0 limb1 limb2 limb3 **
+        saveRaDivCallBzeroSavedRaRetFrame sp base divisorSign dividendAbsWord) :=
+  ⟨resultSignFixPost_savedRaRetFrame_pcFree⟩
+
 end EvmAsm.Evm64.SDiv.Compose


### PR DESCRIPTION
Stacked on #3812.

Adds reusable PCFree facts and instances for the composite SDIV result-sign-fix frames:
- `resultSignFixPost_bzeroResultSignFixFrame_pcFree`
- `pcFreeInst_resultSignFixPost_bzeroResultSignFixFrame`
- `resultSignFixPost_savedRaRetFrame_pcFree`
- `pcFreeInst_resultSignFixPost_savedRaRetFrame`

This keeps frame automation facts out of capped `DivCallDispatch.lean` and avoids re-proving the same composite frame PCFree shape in later callable/result-sign sequencing slices.

Verification:
- `lake build EvmAsm.Evm64.SDiv.Compose.DivCallPostPcFree`
- `git diff --check`
- forbidden marker scan over touched file
- `wc -l EvmAsm/Evm64/SDiv/Compose/DivCallPostPcFree.lean EvmAsm/Evm64/SDiv/Compose/DivCallDispatch.lean`
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `lake build` (passes; only existing LeanRV64D deprecation warning)