### PR TITLE
fix(sdiv): frame preserving x1 callable

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/DivCallPostPcFree.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallPostPcFree.lean
@@ -47,6 +47,39 @@ instance pcFreeInst_divStackDispatchPostNoX1
     Assertion.PCFree (EvmAsm.Evm64.divStackDispatchPostNoX1 sp a b) :=
   ⟨divStackDispatchPostNoX1_pcFree⟩
 
+/-- Frame the preserving-`x1` unsigned-DIV callable wrapper by an arbitrary
+    PC-free assertion. SDIV uses this for the private sign frame carried across
+    the exact callable handoff. -/
+theorem evm_div_callable_preserving_x1_framed_spec_in_sdivCode
+    {F : Assertion} [Assertion.PCFree F]
+    (sp base raVal : Word) (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (branch : EvmAsm.Evm64.DivStackSpecCase (base + wrapperEndOff) a b)
+    (hStack :
+      cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
+        (base + wrapperEndOff)
+        ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
+        (EvmAsm.Evm64.divCode_noNop (base + wrapperEndOff))
+        (EvmAsm.Evm64.divModStackDispatchPre sp a b
+          branch.x1 branch.x2 v5 v6 v7 v10 v11
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+        (EvmAsm.Evm64.divStackDispatchPostNoX1 sp a b ** (.x1 ↦ᵣ raVal))) :
+    cpsTripleWithin (EvmAsm.Evm64.unifiedDivBound + 1)
+      (base + wrapperEndOff) (raVal &&& ~~~1) (sdivCode base)
+      (EvmAsm.Evm64.divModStackDispatchPre sp a b
+        branch.x1 branch.x2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 ** F)
+      ((EvmAsm.Evm64.divStackDispatchPostNoX1 sp a b ** (.x1 ↦ᵣ raVal)) ** F) := by
+  exact
+    cpsTripleWithin_frameR F (by pcFree)
+      (evm_div_callable_preserving_x1_spec_in_sdivCode
+        sp base raVal a b v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        nMem shiftMem jMem retMem dMem dloMem scratchUn0 branch hStack)
+
 theorem saveRaDivCallBzeroCallablePost_pcFree
     {vRa sp base dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
       divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word} :


### PR DESCRIPTION
Stacked on #3821.

Adds `evm_div_callable_preserving_x1_framed_spec_in_sdivCode`, a generic framed version of the SDIV unsigned-DIV callable wrapper that preserves the incoming `x1` return address. The helper carries any PC-free frame across the callable, which is the shape needed for the SDIV-private sign frame during exact callable handoff composition.

Verification:
- `lake build EvmAsm.Evm64.SDiv.Compose.DivCallPostPcFree`
- `git diff --check`
- forbidden marker scan over touched file
- `wc -l EvmAsm/Evm64/SDiv/Compose/DivCallPostPcFree.lean EvmAsm/Evm64/SDiv/Compose/DivCallDispatch.lean`
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `lake build` (passes; only existing LeanRV64D deprecation warning)