### PR TITLE
fix(sdiv): name bzero callable handoff

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/DivCallPostPcFree.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallPostPcFree.lean
@@ -80,6 +80,84 @@ theorem evm_div_callable_preserving_x1_framed_spec_in_sdivCode
         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
         nMem shiftMem jMem retMem dMem dloMem scratchUn0 branch hStack)
 
+/-- The named zero-divisor callable handoff from the SDIV dispatch-ready
+    bundle to the zero-divisor callable post. This isolates the callable
+    proof currently needed by the larger result-sign-fix composition. -/
+theorem saveRaDivCallDispatchReadyPost_bzero_callable_spec_in_sdivCode
+    (vRa sp base
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+      v2 v5 v6 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (hbase : base &&& 1 = 0)
+    (hbz : sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop = 0) :
+    cpsTripleWithin (EvmAsm.Evm64.unifiedDivBound + 1)
+      (base + wrapperEndOff) (base + resultSignFixOff) (sdivCode base)
+      (saveRaDivCallDispatchReadyPost vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+        v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+      (saveRaDivCallBzeroCallablePost vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) := by
+  let dividendAbsWord :=
+    sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+  let divisorAbsWord :=
+    sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+  let divisorSign := divisorTop >>> (63 : BitVec 6).toNat
+  let divisorMask := (0 : Word) - divisorSign
+  let divisorSum0 := (divisorLimb0 ^^^ divisorMask) + divisorSign
+  let divisorCarry0 := if BitVec.ult divisorSum0 divisorSign then (1 : Word) else 0
+  let divisorSum1 := (divisorLimb1 ^^^ divisorMask) + divisorCarry0
+  let divisorCarry1 := if BitVec.ult divisorSum1 divisorCarry0 then (1 : Word) else 0
+  let divisorSum2 := (divisorLimb2 ^^^ divisorMask) + divisorCarry1
+  let divisorCarry2 := if BitVec.ult divisorSum2 divisorCarry1 then (1 : Word) else 0
+  let divisorSum3 := (divisorTop ^^^ divisorMask) + divisorCarry2
+  let divisorCarry3 := if BitVec.ult divisorSum3 divisorCarry2 then (1 : Word) else 0
+  let resultSign :=
+    (dividendTop >>> (63 : BitVec 6).toNat) ^^^ divisorSign
+  let signFrame : Assertion :=
+    ((.x8 ↦ᵣ resultSign) ** (.x9 ↦ᵣ divisorSign) **
+      (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12))))
+  have hStack :=
+    EvmAsm.Evm64.evm_div_bzero_stack_spec_within_dispatch_noNop_preserving_x1_uni
+      sp (base + wrapperEndOff) dividendAbsWord divisorAbsWord
+      ((base + divCallOff) + 4) v2 v5 v6 divisorSum3 divisorMask divisorCarry3
+      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      nMem shiftMem jMem retMem dMem dloMem scratchUn0
+      (by simpa [divisorAbsWord] using hbz)
+  have hCallableFramed :=
+    evm_div_callable_preserving_x1_framed_spec_in_sdivCode
+      (F := signFrame) sp base ((base + divCallOff) + 4)
+      dividendAbsWord divisorAbsWord v5 v6 divisorSum3 divisorMask divisorCarry3
+      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      nMem shiftMem jMem retMem dMem dloMem scratchUn0
+      (EvmAsm.Evm64.DivStackSpecCase.bzero ((base + divCallOff) + 4) v2
+        (by simpa [divisorAbsWord] using hbz))
+      hStack
+  have hCallableExit :
+      cpsTripleWithin (EvmAsm.Evm64.unifiedDivBound + 1)
+        (base + wrapperEndOff) (base + resultSignFixOff) (sdivCode base)
+        (EvmAsm.Evm64.divModStackDispatchPre sp dividendAbsWord divisorAbsWord
+          ((base + divCallOff) + 4) v2 v5 v6 divisorSum3 divisorMask divisorCarry3
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0 ** signFrame)
+        ((EvmAsm.Evm64.divStackDispatchPostNoX1 sp dividendAbsWord divisorAbsWord **
+          (.x1 ↦ᵣ ((base + divCallOff) + 4))) ** signFrame) := by
+    rw [← divCall_return_andn_one_eq_resultSignFixOff base hbase]
+    exact hCallableFramed
+  exact cpsTripleWithin_weaken (fun h hp => by
+    rw [saveRaDivCallDispatchReadyPost_unfold] at hp
+    dsimp [dividendAbsWord, divisorAbsWord, divisorSign, divisorMask, divisorSum0,
+      divisorCarry0, divisorSum1, divisorCarry1, divisorSum2, divisorCarry2,
+      divisorSum3, divisorCarry3, resultSign, signFrame] at hp ⊢
+    exact hp) (fun h hp => by
+    rw [saveRaDivCallBzeroCallablePost_unfold]
+    dsimp [dividendAbsWord, divisorAbsWord, divisorSign, resultSign, signFrame] at hp ⊢
+    exact hp) hCallableExit
+
 theorem saveRaDivCallBzeroCallablePost_pcFree
     {vRa sp base dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
       divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word} :


### PR DESCRIPTION
## Summary
- add `saveRaDivCallDispatchReadyPost_bzero_callable_spec_in_sdivCode` as a named sidecar theorem
- package the SDIV zero-divisor dispatch-ready callable step into `saveRaDivCallBzeroCallablePost`
- reuse the framed preserving-x1 callable helper from the parent stack, without growing `DivCallDispatch.lean`

## Verification
- `lake build EvmAsm.Evm64.SDiv.Compose.DivCallPostPcFree`
- `git diff --check`
- `rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/DivCallPostPcFree.lean` (no matches)
- `wc -l EvmAsm/Evm64/SDiv/Compose/DivCallPostPcFree.lean EvmAsm/Evm64/SDiv/Compose/DivCallDispatch.lean` => 297 / 1199 lines
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `lake build`