### PR TITLE
fix(exp): bound boundary loop composition

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryLoop.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryLoop.lean
@@ -43,4 +43,33 @@ theorem exp_two_mul_boundary_loop_epilogue_of_loop_spec_within
       (exp_pointer_restore_then_epilogue_evm_exp_msb_saved_bit_two_mul_canonical_appended_mul_named_loop_exit_spec_within
         sp evmSp iterCountNew tOld r0 r1 r2 r3 baseWord rest exitCond base)
 
+/-- Bounded variant of
+    `exp_two_mul_boundary_loop_epilogue_of_loop_spec_within`. This packages
+    the prologue/loop/epilogue boundary into a caller-chosen closed-form bound
+    for the later full-loop theorem. -/
+theorem exp_two_mul_boundary_loop_epilogue_of_loop_bounded_spec_within
+    {nSteps nBound : Nat}
+    (sp evmSp cOld tOld m0 m1 m2 m3 vOld v18 iterCountNew
+      r0 r1 r2 r3 : Word)
+    (baseWord exponentWord : EvmWord) (rest : List EvmWord)
+    (exitCond : Prop) (base : Word)
+    (hBound : (((6 + 1) + nSteps) + (1 + 9)) ≤ nBound)
+    (hLoop :
+      cpsTripleWithin nSteps (base + 28) (base + 264)
+        (evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode base)
+        (expTwoMulLoopEntryPost sp evmSp vOld v18 baseWord exponentWord rest)
+        (expTwoMulLoopExitPre sp evmSp iterCountNew tOld r0 r1 r2 r3
+          baseWord rest exitCond)) :
+    cpsTripleWithin nBound base (base + 304)
+      (evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode base)
+      (expTwoMulBoundaryPre sp evmSp cOld tOld m0 m1 m2 m3 vOld v18
+        baseWord exponentWord rest)
+      (expTwoMulLoopExitPost sp evmSp iterCountNew r0 r1 r2 r3
+        baseWord rest exitCond) := by
+  exact
+    cpsTripleWithin_mono_nSteps hBound
+      (exp_two_mul_boundary_loop_epilogue_of_loop_spec_within
+        sp evmSp cOld tOld m0 m1 m2 m3 vOld v18 iterCountNew
+        r0 r1 r2 r3 baseWord exponentWord rest exitCond base hLoop)
+
 end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- add `exp_two_mul_boundary_loop_epilogue_of_loop_bounded_spec_within`
- lift the named EXP prologue/loop/epilogue composition into an arbitrary caller-provided closed-form bound
- keep the exact boundary-loop theorem available while preparing the later full-loop proof to use a uniform bound

## Verification
- `lake build EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryLoop`
- `git diff --check`
- `rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryLoop.lean` (no matches)
- `wc -l EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryLoop.lean` => 75 lines
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `lake build`