### PR TITLE
fix(exp): name saved-bit loop bounds

### DIFF
--- a/EvmAsm/Evm64/Exp.lean
+++ b/EvmAsm/Evm64/Exp.lean
@@ -36,6 +36,7 @@ import EvmAsm.Evm64.Exp.Compose.SavedBitWithMul
 import EvmAsm.Evm64.Exp.Compose.SavedBitFullLoop
 import EvmAsm.Evm64.Exp.Compose.SavedBitFullLoopCanonical
 import EvmAsm.Evm64.Exp.Compose.SavedBitCondMulCall
+import EvmAsm.Evm64.Exp.Compose.SavedBitLoopBounds
 import EvmAsm.Evm64.Exp.Compose.SavedBitBoundarySeq
 import EvmAsm.Evm64.Exp.Compose.SavedBitLoopEntry
 import EvmAsm.Evm64.Exp.Compose.SavedBitLoopExit

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryLoop.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryLoop.lean
@@ -7,6 +7,7 @@
 -/
 
 import EvmAsm.Evm64.Exp.Compose.SavedBitLoopExit
+import EvmAsm.Evm64.Exp.Compose.SavedBitLoopBounds
 
 namespace EvmAsm.Evm64.Exp.Compose
 
@@ -27,7 +28,7 @@ theorem exp_two_mul_boundary_loop_epilogue_of_loop_spec_within
         (expTwoMulLoopEntryPost sp evmSp vOld v18 baseWord exponentWord rest)
         (expTwoMulLoopExitPre sp evmSp iterCountNew tOld r0 r1 r2 r3
           baseWord rest exitCond)) :
-    cpsTripleWithin (((6 + 1) + nSteps) + (1 + 9)) base (base + 304)
+    cpsTripleWithin (expTwoMulBoundaryLoopBound nSteps) base (base + 304)
       (evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode base)
       (expTwoMulBoundaryPre sp evmSp cOld tOld m0 m1 m2 m3 vOld v18
         baseWord exponentWord rest)
@@ -53,7 +54,7 @@ theorem exp_two_mul_boundary_loop_epilogue_of_loop_bounded_spec_within
       r0 r1 r2 r3 : Word)
     (baseWord exponentWord : EvmWord) (rest : List EvmWord)
     (exitCond : Prop) (base : Word)
-    (hBound : (((6 + 1) + nSteps) + (1 + 9)) ≤ nBound)
+    (hBound : expTwoMulBoundaryLoopBound nSteps ≤ nBound)
     (hLoop :
       cpsTripleWithin nSteps (base + 28) (base + 264)
         (evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode base)

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitIterMerge.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitIterMerge.lean
@@ -5,6 +5,7 @@
 -/
 
 import EvmAsm.Evm64.Exp.Compose.SavedBitIterPosts
+import EvmAsm.Evm64.Exp.Compose.SavedBitLoopBounds
 
 namespace EvmAsm.Evm64.Exp.Compose
 
@@ -35,7 +36,7 @@ theorem exp_two_mul_named_iter_with_continuations_spec_within
         a0 a1 a2 a3 w rw)
       R) →
     cpsTripleWithin
-      ((((3 + 1 + (17 + 64 + 9) + 1) + 2) + ((17 + 64 + 9) + 2)) + nCont)
+      (expTwoMulNamedIterStepBound + nCont)
       (base + 28)
       exit_
       (evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode base)
@@ -74,8 +75,7 @@ theorem exp_two_mul_named_iter_with_continuations_max_spec_within
         a0 a1 a2 a3 w rw)
       R) →
     cpsTripleWithin
-      ((((3 + 1 + (17 + 64 + 9) + 1) + 2) + ((17 + 64 + 9) + 2)) +
-        max nLoop nExit)
+      (expTwoMulNamedIterStepBound + max nLoop nExit)
       (base + 28)
       exit_
       (evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode base)
@@ -101,8 +101,7 @@ theorem exp_two_mul_named_iter_with_continuations_bounded_spec_within
     (base : Word)
     (hbase : base &&& 1 = 0)
     (hBound :
-      ((((3 + 1 + (17 + 64 + 9) + 1) + 2) + ((17 + 64 + 9) + 2)) +
-        max nLoop nExit) ≤ nBound) :
+      expTwoMulNamedIterStepBound + max nLoop nExit ≤ nBound) :
     let bit := e >>> (63 : BitVec 6).toNat
     let w := expResultWord r0 r1 r2 r3
     let aw := expResultWord a0 a1 a2 a3

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitLoopBounds.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitLoopBounds.lean
@@ -1,0 +1,28 @@
+/-
+  EvmAsm.Evm64.Exp.Compose.SavedBitLoopBounds
+
+  Named step-count expressions for the two-MUL saved-bit EXP loop
+  composition helpers.
+-/
+
+namespace EvmAsm.Evm64.Exp.Compose
+
+/-- Instruction bound for one named saved-bit two-MUL iteration, excluding
+    externally supplied loop-back and loop-exit continuations. -/
+abbrev expTwoMulNamedIterStepBound : Nat :=
+  (((3 + 1 + (17 + 64 + 9) + 1) + 2) + ((17 + 64 + 9) + 2))
+
+/-- Bound for the prologue/pointer-advance boundary before the saved-bit
+    two-MUL loop. -/
+abbrev expTwoMulBoundaryPrefixBound : Nat := 6 + 1
+
+/-- Bound for the pointer-restore/epilogue boundary after the saved-bit
+    two-MUL loop exits. -/
+abbrev expTwoMulBoundarySuffixBound : Nat := 1 + 9
+
+/-- Bound for the named saved-bit two-MUL boundary composition around a loop
+    proof with `nSteps`. -/
+abbrev expTwoMulBoundaryLoopBound (nSteps : Nat) : Nat :=
+  (expTwoMulBoundaryPrefixBound + nSteps) + expTwoMulBoundarySuffixBound
+
+end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- add `SavedBitLoopBounds.lean` with named bounds for saved-bit two-MUL iteration and boundary composition
- use `expTwoMulNamedIterStepBound` in the iteration merge helpers
- use `expTwoMulBoundaryLoopBound` in the boundary-loop helpers

## Verification
- `lake build EvmAsm.Evm64.Exp.Compose.SavedBitIterMerge`
- `lake build EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryLoop`
- `lake build EvmAsm.Evm64.Exp`
- `git diff --check`
- `rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/Compose/SavedBitLoopBounds.lean EvmAsm/Evm64/Exp/Compose/SavedBitIterMerge.lean EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryLoop.lean EvmAsm/Evm64/Exp.lean` (no matches)
- `wc -l EvmAsm/Evm64/Exp/Compose/SavedBitLoopBounds.lean EvmAsm/Evm64/Exp/Compose/SavedBitIterMerge.lean EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryLoop.lean` => 28 / 134 / 76 lines
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `lake build`