### PR TITLE
fix(exp): add saved-bit loop bound lemmas

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitLoopBounds.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitLoopBounds.lean
@@ -5,6 +5,8 @@
   composition helpers.
 -/
 
+import EvmAsm.Evm64.Exp.Compose.Base
+
 namespace EvmAsm.Evm64.Exp.Compose
 
 /-- Instruction bound for one named saved-bit two-MUL iteration, excluding
@@ -24,5 +26,15 @@ abbrev expTwoMulBoundarySuffixBound : Nat := 1 + 9
     proof with `nSteps`. -/
 abbrev expTwoMulBoundaryLoopBound (nSteps : Nat) : Nat :=
   (expTwoMulBoundaryPrefixBound + nSteps) + expTwoMulBoundarySuffixBound
+
+theorem expTwoMulNamedIterStepBound_eq :
+    expTwoMulNamedIterStepBound = 189 := by
+  norm_num [expTwoMulNamedIterStepBound]
+
+theorem expTwoMulBoundaryLoopBound_eq (nSteps : Nat) :
+    expTwoMulBoundaryLoopBound nSteps = nSteps + 17 := by
+  unfold expTwoMulBoundaryLoopBound expTwoMulBoundaryPrefixBound
+    expTwoMulBoundarySuffixBound
+  omega
 
 end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- add `expTwoMulNamedIterStepBound_eq`
- add `expTwoMulBoundaryLoopBound_eq`
- provide closed-form rewrites for the named saved-bit EXP loop bounds used by the recent bounded composition helpers

## Verification
- `lake build EvmAsm.Evm64.Exp.Compose.SavedBitLoopBounds`
- `lake build EvmAsm.Evm64.Exp.Compose.SavedBitIterMerge`
- `lake build EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryLoop`
- `git diff --check`
- `rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/Compose/SavedBitLoopBounds.lean` (no matches)
- `wc -l EvmAsm/Evm64/Exp/Compose/SavedBitLoopBounds.lean` => 40 lines
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `lake build`