### PR TITLE
fix(exp): add closed-form bound helpers

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryLoop.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryLoop.lean
@@ -73,4 +73,33 @@ theorem exp_two_mul_boundary_loop_epilogue_of_loop_bounded_spec_within
         sp evmSp cOld tOld m0 m1 m2 m3 vOld v18 iterCountNew
         r0 r1 r2 r3 baseWord exponentWord rest exitCond base hLoop)
 
+/-- Closed-form bound variant of
+    `exp_two_mul_boundary_loop_epilogue_of_loop_bounded_spec_within`, using
+    the normalized boundary cost `nSteps + 17`. -/
+theorem exp_two_mul_boundary_loop_epilogue_of_loop_closed_bound_spec_within
+    {nSteps nBound : Nat}
+    (sp evmSp cOld tOld m0 m1 m2 m3 vOld v18 iterCountNew
+      r0 r1 r2 r3 : Word)
+    (baseWord exponentWord : EvmWord) (rest : List EvmWord)
+    (exitCond : Prop) (base : Word)
+    (hBound : nSteps + 17 ≤ nBound)
+    (hLoop :
+      cpsTripleWithin nSteps (base + 28) (base + 264)
+        (evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode base)
+        (expTwoMulLoopEntryPost sp evmSp vOld v18 baseWord exponentWord rest)
+        (expTwoMulLoopExitPre sp evmSp iterCountNew tOld r0 r1 r2 r3
+          baseWord rest exitCond)) :
+    cpsTripleWithin nBound base (base + 304)
+      (evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode base)
+      (expTwoMulBoundaryPre sp evmSp cOld tOld m0 m1 m2 m3 vOld v18
+        baseWord exponentWord rest)
+      (expTwoMulLoopExitPost sp evmSp iterCountNew r0 r1 r2 r3
+        baseWord rest exitCond) := by
+  exact
+    exp_two_mul_boundary_loop_epilogue_of_loop_bounded_spec_within
+      sp evmSp cOld tOld m0 m1 m2 m3 vOld v18 iterCountNew
+      r0 r1 r2 r3 baseWord exponentWord rest exitCond base
+      (by simpa [expTwoMulBoundaryLoopBound_eq] using hBound)
+      hLoop
+
 end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitIterMerge.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitIterMerge.lean
@@ -131,4 +131,44 @@ theorem exp_two_mul_named_iter_with_continuations_bounded_spec_within
         e iterCount v18 sp evmSp vOld r0 r1 r2 r3 d0 d1 d2 d3
         e0 e1 e2 e3 a0 a1 a2 a3 base hbase hLoop hExit)
 
+/-- Closed-form bound variant of
+    `exp_two_mul_named_iter_with_continuations_bounded_spec_within`, using the
+    normalized one-iteration cost `189`. -/
+theorem exp_two_mul_named_iter_with_continuations_closed_bound_spec_within
+    {nLoop nExit nBound : Nat} {exit_ : Word} {R : Assertion}
+    (e iterCount v18 sp evmSp vOld r0 r1 r2 r3 d0 d1 d2 d3
+      e0 e1 e2 e3 a0 a1 a2 a3 : Word)
+    (base : Word)
+    (hbase : base &&& 1 = 0)
+    (hBound : 189 + max nLoop nExit ≤ nBound) :
+    let bit := e >>> (63 : BitVec 6).toNat
+    let w := expResultWord r0 r1 r2 r3
+    let aw := expResultWord a0 a1 a2 a3
+    let rw := (w * w) * aw
+    let iterCountNew := iterCount + signExtend12 ((-1 : BitVec 12))
+    (cpsTripleWithin nLoop (base + 28) exit_
+      (evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode base)
+      (expTwoMulIterLoopPost iterCountNew bit sp evmSp base
+        a0 a1 a2 a3 w rw)
+      R) →
+    (cpsTripleWithin nExit (base + 264) exit_
+      (evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode base)
+      (expTwoMulIterExitPost iterCountNew bit sp evmSp base
+        a0 a1 a2 a3 w rw)
+      R) →
+    cpsTripleWithin nBound
+      (base + 28)
+      exit_
+      (evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode base)
+      (expTwoMulIterPre e iterCount v18 sp evmSp vOld r0 r1 r2 r3
+        d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3)
+      R := by
+  intro bit w aw rw iterCountNew hLoop hExit
+  exact
+    exp_two_mul_named_iter_with_continuations_bounded_spec_within
+      e iterCount v18 sp evmSp vOld r0 r1 r2 r3 d0 d1 d2 d3
+      e0 e1 e2 e3 a0 a1 a2 a3 base hbase
+      (by simpa [expTwoMulNamedIterStepBound_eq] using hBound)
+      hLoop hExit
+
 end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitLoopBounds.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitLoopBounds.lean
@@ -5,6 +5,8 @@
   composition helpers.
 -/
 
+import EvmAsm.Evm64.Exp.Compose.Base
+
 namespace EvmAsm.Evm64.Exp.Compose
 
 /-- Instruction bound for one named saved-bit two-MUL iteration, excluding
@@ -24,5 +26,15 @@ abbrev expTwoMulBoundarySuffixBound : Nat := 1 + 9
     proof with `nSteps`. -/
 abbrev expTwoMulBoundaryLoopBound (nSteps : Nat) : Nat :=
   (expTwoMulBoundaryPrefixBound + nSteps) + expTwoMulBoundarySuffixBound
+
+theorem expTwoMulNamedIterStepBound_eq :
+    expTwoMulNamedIterStepBound = 189 := by
+  norm_num [expTwoMulNamedIterStepBound]
+
+theorem expTwoMulBoundaryLoopBound_eq (nSteps : Nat) :
+    expTwoMulBoundaryLoopBound nSteps = nSteps + 17 := by
+  unfold expTwoMulBoundaryLoopBound expTwoMulBoundaryPrefixBound
+    expTwoMulBoundarySuffixBound
+  omega
 
 end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- add `exp_two_mul_named_iter_with_continuations_closed_bound_spec_within`
- add `exp_two_mul_boundary_loop_epilogue_of_loop_closed_bound_spec_within`
- let later full-loop proofs use closed-form bounds `189 + max nLoop nExit` and `nSteps + 17` directly

## Verification
- `lake build EvmAsm.Evm64.Exp.Compose.SavedBitIterMerge`
- `lake build EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryLoop`
- `git diff --check`
- `rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/Compose/SavedBitIterMerge.lean EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryLoop.lean` (no matches)
- `wc -l EvmAsm/Evm64/Exp/Compose/SavedBitIterMerge.lean EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryLoop.lean` => 174 / 105 lines
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `lake build`