### PR TITLE
fix(exp): name full loop bounds

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitLoopBounds.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitLoopBounds.lean
@@ -27,6 +27,16 @@ abbrev expTwoMulBoundarySuffixBound : Nat := 1 + 9
 abbrev expTwoMulBoundaryLoopBound (nSteps : Nat) : Nat :=
   (expTwoMulBoundaryPrefixBound + nSteps) + expTwoMulBoundarySuffixBound
 
+/-- Aggregate bound for 256 saved-bit two-MUL loop iterations, excluding the
+    prologue/pointer-advance and pointer-restore/epilogue boundary. -/
+abbrev expTwoMulFullLoopBodyBound : Nat :=
+  256 * expTwoMulNamedIterStepBound
+
+/-- Aggregate bound for the full saved-bit two-MUL loop including the
+    prologue/pointer-advance and pointer-restore/epilogue boundary. -/
+abbrev expTwoMulFullLoopBoundaryBound : Nat :=
+  expTwoMulBoundaryLoopBound expTwoMulFullLoopBodyBound
+
 theorem expTwoMulNamedIterStepBound_eq :
     expTwoMulNamedIterStepBound = 189 := by
   norm_num [expTwoMulNamedIterStepBound]
@@ -36,5 +46,14 @@ theorem expTwoMulBoundaryLoopBound_eq (nSteps : Nat) :
   unfold expTwoMulBoundaryLoopBound expTwoMulBoundaryPrefixBound
     expTwoMulBoundarySuffixBound
   omega
+
+theorem expTwoMulFullLoopBodyBound_eq :
+    expTwoMulFullLoopBodyBound = 48384 := by
+  norm_num [expTwoMulFullLoopBodyBound, expTwoMulNamedIterStepBound_eq]
+
+theorem expTwoMulFullLoopBoundaryBound_eq :
+    expTwoMulFullLoopBoundaryBound = 48401 := by
+  rw [expTwoMulFullLoopBoundaryBound, expTwoMulBoundaryLoopBound_eq,
+    expTwoMulFullLoopBodyBound_eq]
 
 end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- add `expTwoMulFullLoopBodyBound` and `expTwoMulFullLoopBoundaryBound`
- prove their closed forms: `48384` for 256 iterations and `48401` including the boundary
- prepare later full-loop statements to use named aggregate bounds instead of recomputing arithmetic

## Verification
- `lake build EvmAsm.Evm64.Exp.Compose.SavedBitLoopBounds`
- `lake build EvmAsm.Evm64.Exp`
- `git diff --check`
- `rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/Compose/SavedBitLoopBounds.lean` (no matches)
- `wc -l EvmAsm/Evm64/Exp/Compose/SavedBitLoopBounds.lean` => 59 lines
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `lake build`