### PR TITLE
fix(exp): add exact bound wrappers

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryLoop.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryLoop.lean
@@ -102,6 +102,31 @@ theorem exp_two_mul_boundary_loop_epilogue_of_loop_closed_bound_spec_within
       (by simpa [expTwoMulBoundaryLoopBound_eq] using hBound)
       hLoop
 
+/-- Exact closed-form bound variant of
+    `exp_two_mul_boundary_loop_epilogue_of_loop_spec_within`. -/
+theorem exp_two_mul_boundary_loop_epilogue_of_loop_exact_closed_bound_spec_within
+    {nSteps : Nat}
+    (sp evmSp cOld tOld m0 m1 m2 m3 vOld v18 iterCountNew
+      r0 r1 r2 r3 : Word)
+    (baseWord exponentWord : EvmWord) (rest : List EvmWord)
+    (exitCond : Prop) (base : Word)
+    (hLoop :
+      cpsTripleWithin nSteps (base + 28) (base + 264)
+        (evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode base)
+        (expTwoMulLoopEntryPost sp evmSp vOld v18 baseWord exponentWord rest)
+        (expTwoMulLoopExitPre sp evmSp iterCountNew tOld r0 r1 r2 r3
+          baseWord rest exitCond)) :
+    cpsTripleWithin (nSteps + 17) base (base + 304)
+      (evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode base)
+      (expTwoMulBoundaryPre sp evmSp cOld tOld m0 m1 m2 m3 vOld v18
+        baseWord exponentWord rest)
+      (expTwoMulLoopExitPost sp evmSp iterCountNew r0 r1 r2 r3
+        baseWord rest exitCond) := by
+  exact
+    exp_two_mul_boundary_loop_epilogue_of_loop_closed_bound_spec_within
+      sp evmSp cOld tOld m0 m1 m2 m3 vOld v18 iterCountNew
+      r0 r1 r2 r3 baseWord exponentWord rest exitCond base (by rfl) hLoop
+
 /-- Specialization of the named boundary composition to the 256-iteration
     saved-bit two-MUL loop body bound. This is the outer shell expected by the
     eventual full-loop proof once the loop proof itself is available. -/

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitIterMerge.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitIterMerge.lean
@@ -171,4 +171,39 @@ theorem exp_two_mul_named_iter_with_continuations_closed_bound_spec_within
       (by simpa [expTwoMulNamedIterStepBound_eq] using hBound)
       hLoop hExit
 
+/-- Exact closed-form bound variant of
+    `exp_two_mul_named_iter_with_continuations_max_spec_within`. -/
+theorem exp_two_mul_named_iter_with_continuations_exact_closed_bound_spec_within
+    {nLoop nExit : Nat} {exit_ : Word} {R : Assertion}
+    (e iterCount v18 sp evmSp vOld r0 r1 r2 r3 d0 d1 d2 d3
+      e0 e1 e2 e3 a0 a1 a2 a3 : Word)
+    (base : Word)
+    (hbase : base &&& 1 = 0) :
+    let bit := e >>> (63 : BitVec 6).toNat
+    let w := expResultWord r0 r1 r2 r3
+    let aw := expResultWord a0 a1 a2 a3
+    let rw := (w * w) * aw
+    let iterCountNew := iterCount + signExtend12 ((-1 : BitVec 12))
+    (cpsTripleWithin nLoop (base + 28) exit_
+      (evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode base)
+      (expTwoMulIterLoopPost iterCountNew bit sp evmSp base
+        a0 a1 a2 a3 w rw)
+      R) →
+    (cpsTripleWithin nExit (base + 264) exit_
+      (evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode base)
+      (expTwoMulIterExitPost iterCountNew bit sp evmSp base
+        a0 a1 a2 a3 w rw)
+      R) →
+    cpsTripleWithin (189 + max nLoop nExit)
+      (base + 28)
+      exit_
+      (evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode base)
+      (expTwoMulIterPre e iterCount v18 sp evmSp vOld r0 r1 r2 r3
+        d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3)
+      R := by
+  exact
+    exp_two_mul_named_iter_with_continuations_closed_bound_spec_within
+      e iterCount v18 sp evmSp vOld r0 r1 r2 r3 d0 d1 d2 d3
+      e0 e1 e2 e3 a0 a1 a2 a3 base hbase (by rfl)
+
 end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- add `exp_two_mul_named_iter_with_continuations_exact_closed_bound_spec_within`
- add `exp_two_mul_boundary_loop_epilogue_of_loop_exact_closed_bound_spec_within`
- expose the natural closed bounds `189 + max nLoop nExit` and `nSteps + 17` without a separate bound proof argument

## Verification
- `lake build EvmAsm.Evm64.Exp.Compose.SavedBitIterMerge`
- `lake build EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryLoop`
- `git diff --check`
- `rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/Compose/SavedBitIterMerge.lean EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryLoop.lean` (no matches)
- `wc -l EvmAsm/Evm64/Exp/Compose/SavedBitIterMerge.lean EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryLoop.lean`
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `lake build`