### PR TITLE
fix(sdiv): add exact x1 callable bridge

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/DivCallPostPcFree.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallPostPcFree.lean
@@ -47,6 +47,89 @@ instance pcFreeInst_divStackDispatchPostNoX1
     Assertion.PCFree (EvmAsm.Evm64.divStackDispatchPostNoX1 sp a b) :=
   ⟨divStackDispatchPostNoX1_pcFree⟩
 
+/-- Variant of the preserving-`x1` unsigned-DIV callable wrapper whose no-NOP
+    body proof already has the exact caller return address in the dispatch
+    precondition. This avoids tying SDIV's exact handoff to
+    `DivStackSpecCase.x1`, whose nonzero constructors use the dispatcher-local
+    scratch value `0` instead of the wrapper return address. -/
+theorem evm_div_callable_preserving_x1_exact_pre_spec_in_sdivCode
+    (sp base raVal : Word) (a b : EvmWord) (v2 v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (hStack :
+      cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
+        (base + wrapperEndOff)
+        ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
+        (EvmAsm.Evm64.divCode_noNop (base + wrapperEndOff))
+        (EvmAsm.Evm64.divModStackDispatchPre sp a b
+          raVal v2 v5 v6 v7 v10 v11
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+        (EvmAsm.Evm64.divStackDispatchPostNoX1 sp a b ** (.x1 ↦ᵣ raVal))) :
+    cpsTripleWithin (EvmAsm.Evm64.unifiedDivBound + 1)
+      (base + wrapperEndOff) (raVal &&& ~~~1) (sdivCode base)
+      (EvmAsm.Evm64.divModStackDispatchPre sp a b
+        raVal v2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+      (EvmAsm.Evm64.divStackDispatchPostNoX1 sp a b ** (.x1 ↦ᵣ raVal)) := by
+  have hStackCallDiv :=
+    cpsTripleWithin_extend_code
+      (hmono := EvmAsm.Evm64.divCode_noNop_sub_div_callable_code)
+      hStack
+  have hStackCall :=
+    cpsTripleWithin_extend_code
+      (hmono := evm_div_callable_code_sub_sdivCode (base := base))
+      hStackCallDiv
+  have hRetDiv :=
+    cpsTripleWithin_extend_code
+      (hmono := EvmAsm.Evm64.evm_div_callable_code_ret_sub
+        (base := base + wrapperEndOff))
+      (ret_spec_within' ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff) raVal)
+  have hRet :=
+    cpsTripleWithin_extend_code
+      (hmono := evm_div_callable_code_sub_sdivCode (base := base))
+      hRetDiv
+  have hRetFramed :=
+    cpsTripleWithin_frameL
+      (EvmAsm.Evm64.divStackDispatchPostNoX1 sp a b)
+      (divStackDispatchPostNoX1_pcFree (sp := sp) (a := a) (b := b))
+      hRet
+  exact cpsTripleWithin_seq_same_cr hStackCall hRetFramed
+
+/-- Frame the exact-pre preserving-`x1` unsigned-DIV callable wrapper by an
+    arbitrary PC-free assertion. This is the shape needed once SDIV has a
+    no-NOP proof for the exact dispatch-ready post, including the private sign
+    frame. -/
+theorem evm_div_callable_preserving_x1_exact_pre_framed_spec_in_sdivCode
+    {F : Assertion} [Assertion.PCFree F]
+    (sp base raVal : Word) (a b : EvmWord) (v2 v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (hStack :
+      cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
+        (base + wrapperEndOff)
+        ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
+        (EvmAsm.Evm64.divCode_noNop (base + wrapperEndOff))
+        (EvmAsm.Evm64.divModStackDispatchPre sp a b
+          raVal v2 v5 v6 v7 v10 v11
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+        (EvmAsm.Evm64.divStackDispatchPostNoX1 sp a b ** (.x1 ↦ᵣ raVal))) :
+    cpsTripleWithin (EvmAsm.Evm64.unifiedDivBound + 1)
+      (base + wrapperEndOff) (raVal &&& ~~~1) (sdivCode base)
+      (EvmAsm.Evm64.divModStackDispatchPre sp a b
+        raVal v2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 ** F)
+      ((EvmAsm.Evm64.divStackDispatchPostNoX1 sp a b ** (.x1 ↦ᵣ raVal)) ** F) := by
+  exact
+    cpsTripleWithin_frameR F (by pcFree)
+      (evm_div_callable_preserving_x1_exact_pre_spec_in_sdivCode
+        sp base raVal a b v2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        nMem shiftMem jMem retMem dMem dloMem scratchUn0 hStack)
+
 /-- Frame the preserving-`x1` unsigned-DIV callable wrapper by an arbitrary
     PC-free assertion. SDIV uses this for the private sign frame carried across
     the exact callable handoff. -/


### PR DESCRIPTION
## Summary
- add an SDIV callable wrapper that accepts a no-NOP DIV proof whose dispatch precondition already carries the exact return address in x1
- add a framed version for the private SDIV sign frame
- avoid tying future nonzero handoff work to DivStackSpecCase.x1, whose nonzero constructors use the dispatcher-local scratch value 0

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.DivCallPostPcFree
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/DivCallPostPcFree.lean (no matches)
- wc -l EvmAsm/Evm64/SDiv/Compose/DivCallPostPcFree.lean EvmAsm/Evm64/SDiv/Compose/DivCallDispatch.lean
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build