### PR TITLE
refactor(exp): name generic count update

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/Base.lean
+++ b/EvmAsm/Evm64/Exp/Compose/Base.lean
@@ -19,6 +19,9 @@ namespace EvmAsm.Evm64.Exp.Compose
 open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
+abbrev expIterCountNew (iterCount : Word) : Word :=
+  iterCount + signExtend12 ((-1 : BitVec 12))
+
 /-- Length of the EXP prologue block, restated in the composition namespace so
     future `skipBlock`-style subsumption proofs can use a compact simp set. -/
 theorem exp_prologue_len : (EvmAsm.Evm64.exp_prologue).length = 6 := by


### PR DESCRIPTION
Summary:
- add neutral expIterCountNew helper in EXP compose base
- prepare older non-two-MUL loop-back wrappers to use a generic count-update name
- keep Base.lean under the file-size guardrail

Validation:
- lake build EvmAsm.Evm64.Exp.Compose.Base
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/Compose/Base.lean (no matches)
- wc -l EvmAsm/Evm64/Exp/Compose/Base.lean
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build (passes; existing LeanRV64D/RiscvExtras.lean extension.toCtorIdx deprecation warning)