### PR TITLE
refactor(exp): name top loop count

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/TopCodeSpecs.lean
+++ b/EvmAsm/Evm64/Exp/Compose/TopCodeSpecs.lean
@@ -360,16 +360,18 @@ theorem exp_loop_back_evm_exp_spec_within (c : Word)
     (mulOff : BitVec 21) (skipOff backOff : BitVec 13)
     (base target : Word)
     (htarget : ((base + 252) + 4 : Word) + signExtend13 backOff = target) :
-    let cNew := c + signExtend12 ((-1 : BitVec 12))
     cpsBranchWithin 2 (base + 252)
       (evmExpCode base mulOff skipOff backOff)
       ((.x9 ↦ᵣ c) ** (.x0 ↦ᵣ (0 : Word)))
-      target ((.x9 ↦ᵣ cNew) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜cNew ≠ 0⌝)
-      (base + 260) ((.x9 ↦ᵣ cNew) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜cNew = 0⌝) := by
+      target
+        ((.x9 ↦ᵣ expIterCountNew c) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜expIterCountNew c ≠ 0⌝)
+      (base + 260)
+        ((.x9 ↦ᵣ expIterCountNew c) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜expIterCountNew c = 0⌝) := by
   have h := EvmAsm.Evm64.exp_loop_back_spec_within c backOff (base + 252) target htarget
   have hnext : ((base + 252 : Word) + 8) = base + 260 := by bv_omega
   rw [hnext] at h
-  exact cpsBranchWithin_extend_code (h := h) (hmono := evmExpCode_iter_loop_back_sub)
+  simpa [expIterCountNew] using
+    (cpsBranchWithin_extend_code (h := h) (hmono := evmExpCode_iter_loop_back_sub))
 
 /-- Squaring-call factor-1 marshal sub-block directly included in the
     top-level EXP code bundle. -/


### PR DESCRIPTION
Summary:
- use expIterCountNew in exp_loop_back_evm_exp_spec_within
- remove the local cNew let from TopCodeSpecs.lean
- keep the top-level loop-back proof as a direct block-spec lift

Validation:
- lake build EvmAsm.Evm64.Exp.Compose.TopCodeSpecs
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/Compose/TopCodeSpecs.lean (no matches)
- wc -l EvmAsm/Evm64/Exp/Compose/TopCodeSpecs.lean
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build (passes; existing LeanRV64D/RiscvExtras.lean extension.toCtorIdx deprecation warning)