### PR TITLE
refactor(exp): name full-loop count

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/FullLoop.lean
+++ b/EvmAsm/Evm64/Exp/Compose/FullLoop.lean
@@ -137,12 +137,13 @@ theorem exp_loop_back_evm_exp_with_mul_spec_within (c : Word)
     (mulOff : BitVec 21) (skipOff backOff : BitVec 13)
     (base mulTarget target : Word)
     (htarget : ((base + 252) + 4 : Word) + signExtend13 backOff = target) :
-    let cNew := c + signExtend12 ((-1 : BitVec 12))
     cpsBranchWithin 2 (base + 252)
       (evmExpWithMulCode base mulTarget mulOff skipOff backOff)
       ((.x9 ↦ᵣ c) ** (.x0 ↦ᵣ (0 : Word)))
-      target ((.x9 ↦ᵣ cNew) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜cNew ≠ 0⌝)
-      (base + 260) ((.x9 ↦ᵣ cNew) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜cNew = 0⌝) :=
+      target
+        ((.x9 ↦ᵣ expIterCountNew c) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜expIterCountNew c ≠ 0⌝)
+      (base + 260)
+        ((.x9 ↦ᵣ expIterCountNew c) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜expIterCountNew c = 0⌝) :=
   cpsBranchWithin_extend_evmExpWithMulCode
     (exp_loop_back_evm_exp_spec_within c mulOff skipOff backOff base target htarget)
 


### PR DESCRIPTION
Summary:
- use expIterCountNew in exp_loop_back_evm_exp_with_mul_spec_within
- remove the local cNew let from FullLoop.lean
- keep the full-loop wrapper as a direct extension of the top-code spec

Validation:
- lake build EvmAsm.Evm64.Exp.Compose.FullLoop
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/Compose/FullLoop.lean (no matches)
- wc -l EvmAsm/Evm64/Exp/Compose/FullLoop.lean
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build (passes; existing LeanRV64D/RiscvExtras.lean extension.toCtorIdx deprecation warning)