### PR TITLE
refactor(exp): name saved-bit loop count

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFullLoop.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFullLoop.lean
@@ -204,20 +204,22 @@ theorem exp_loop_back_evm_exp_msb_saved_bit_with_mul_spec_within (c : Word)
     (mulOff : BitVec 21) (skipOff backOff : BitVec 13)
     (base mulTarget target : Word)
     (htarget : ((base + 256) + 4 : Word) + signExtend13 backOff = target) :
-    let cNew := c + signExtend12 ((-1 : BitVec 12))
     cpsBranchWithin 2 (base + 256)
       (evmExpMsbSavedBitWithMulCode base mulTarget mulOff skipOff backOff)
       ((.x9 ↦ᵣ c) ** (.x0 ↦ᵣ (0 : Word)))
-      target ((.x9 ↦ᵣ cNew) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜cNew ≠ 0⌝)
-      (base + 264) ((.x9 ↦ᵣ cNew) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜cNew = 0⌝) := by
+      target
+        ((.x9 ↦ᵣ expIterCountNew c) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜expIterCountNew c ≠ 0⌝)
+      (base + 264)
+        ((.x9 ↦ᵣ expIterCountNew c) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜expIterCountNew c = 0⌝) := by
   have h := EvmAsm.Evm64.exp_loop_back_spec_within c backOff (base + 256)
     target htarget
   have hnext : ((base + 256 : Word) + 8) = base + 264 := by bv_omega
   rw [hnext] at h
-  exact cpsBranchWithin_extend_code (h := h)
-    (hmono := fun a i hi =>
-      evmExpMsbSavedBitWithMulCode_exp_sub a i
-        (evmExpMsbSavedBitCode_iter_loop_back_sub a i hi))
+  simpa [expIterCountNew] using
+    (cpsBranchWithin_extend_code (h := h)
+      (hmono := fun a i hi =>
+        evmExpMsbSavedBitWithMulCode_exp_sub a i
+          (evmExpMsbSavedBitCode_iter_loop_back_sub a i hi)))
 
 /-- Squaring-side full call-block lifted to the corrected saved-bit EXP+MUL
     code bundle.  The block starts after the saved-bit instruction, at


### PR DESCRIPTION
Summary:
- use expIterCountNew in exp_loop_back_evm_exp_msb_saved_bit_with_mul_spec_within
- remove the local cNew let from the saved-bit loop-back wrapper
- keep the wrapper proof as a direct block-spec lift with the helper unfolded

Validation:
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitFullLoop
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/Compose/SavedBitFullLoop.lean (no matches)
- wc -l EvmAsm/Evm64/Exp/Compose/SavedBitFullLoop.lean
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build (passes; existing LeanRV64D/RiscvExtras.lean extension.toCtorIdx deprecation warning)