### PR TITLE
fix(sdiv): name abs components

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/DivCallPostPcFree.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallPostPcFree.lean
@@ -12,6 +12,69 @@ namespace EvmAsm.Evm64.SDiv.Compose
 open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
+abbrev sdivAbsSign (top : Word) : Word :=
+  top >>> (63 : BitVec 6).toNat
+
+abbrev sdivAbsMask (top : Word) : Word :=
+  (0 : Word) - sdivAbsSign top
+
+abbrev sdivAbsSum0 (limb0 top : Word) : Word :=
+  (limb0 ^^^ sdivAbsMask top) + sdivAbsSign top
+
+abbrev sdivAbsCarry0 (limb0 top : Word) : Word :=
+  if BitVec.ult (sdivAbsSum0 limb0 top) (sdivAbsSign top) then (1 : Word) else 0
+
+abbrev sdivAbsSum1 (limb0 limb1 top : Word) : Word :=
+  (limb1 ^^^ sdivAbsMask top) + sdivAbsCarry0 limb0 top
+
+abbrev sdivAbsCarry1 (limb0 limb1 top : Word) : Word :=
+  if BitVec.ult (sdivAbsSum1 limb0 limb1 top) (sdivAbsCarry0 limb0 top) then
+    (1 : Word)
+  else
+    0
+
+abbrev sdivAbsSum2 (limb0 limb1 limb2 top : Word) : Word :=
+  (limb2 ^^^ sdivAbsMask top) + sdivAbsCarry1 limb0 limb1 top
+
+abbrev sdivAbsCarry2 (limb0 limb1 limb2 top : Word) : Word :=
+  if BitVec.ult (sdivAbsSum2 limb0 limb1 limb2 top)
+      (sdivAbsCarry1 limb0 limb1 top) then
+    (1 : Word)
+  else
+    0
+
+abbrev sdivAbsSum3 (limb0 limb1 limb2 top : Word) : Word :=
+  (top ^^^ sdivAbsMask top) + sdivAbsCarry2 limb0 limb1 limb2 top
+
+abbrev sdivAbsCarry3 (limb0 limb1 limb2 top : Word) : Word :=
+  if BitVec.ult (sdivAbsSum3 limb0 limb1 limb2 top)
+      (sdivAbsCarry2 limb0 limb1 limb2 top) then
+    (1 : Word)
+  else
+    0
+
+theorem sdivAbsDividendWord_eq_components
+    (limb0 limb1 limb2 top : Word) :
+    sdivAbsDividendWord limb0 limb1 limb2 top =
+      EvmWord.fromLimbs fun i : Fin 4 =>
+        match i with
+        | 0 => sdivAbsSum0 limb0 top
+        | 1 => sdivAbsSum1 limb0 limb1 top
+        | 2 => sdivAbsSum2 limb0 limb1 limb2 top
+        | 3 => sdivAbsSum3 limb0 limb1 limb2 top := by
+  rfl
+
+theorem sdivAbsDivisorWord_eq_components
+    (limb0 limb1 limb2 top : Word) :
+    sdivAbsDivisorWord limb0 limb1 limb2 top =
+      EvmWord.fromLimbs fun i : Fin 4 =>
+        match i with
+        | 0 => sdivAbsSum0 limb0 top
+        | 1 => sdivAbsSum1 limb0 limb1 top
+        | 2 => sdivAbsSum2 limb0 limb1 limb2 top
+        | 3 => sdivAbsSum3 limb0 limb1 limb2 top := by
+  rfl
+
 theorem divModStackDispatchPre_pcFree
     {sp : Word} {a b : EvmWord}
     {v1 v2 v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7


### PR DESCRIPTION
Summary:
- add named SDIV absolute-value sign, mask, sum, and carry component helpers in the div-call sidecar
- add unfold lemmas for sdivAbsDividendWord and sdivAbsDivisorWord in terms of those helpers
- prepare exact nonzero callable handoff statements without expanding the carry chain inline

Validation:
- lake build EvmAsm.Evm64.SDiv.Compose.DivCallPostPcFree
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/DivCallPostPcFree.lean (no matches)
- wc -l EvmAsm/Evm64/SDiv/Compose/DivCallPostPcFree.lean EvmAsm/Evm64/SDiv/Compose/DivCallDispatch.lean
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build (passes; existing LeanRV64D/RiscvExtras.lean extension.toCtorIdx deprecation warning)