### PR TITLE
refactor(exp): name saved-bit cond words

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCond.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCond.lean
@@ -27,7 +27,7 @@ theorem exp_cond_mul_call_then_loop_back_evm_exp_msb_saved_bit_two_mul_with_mul_
             (mul_callable_code mulTarget))
     (hback : ((base + 256) + 4 : Word) + signExtend13 backOff = loopTarget) :
     let r := expResultWord r0 r1 r2 r3
-    let aw := expResultWord a0 a1 a2 a3
+    let aw := expTwoMulIterAw a0 a1 a2 a3
     let rw := r * aw
     let rest : Assertion :=
       (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) **
@@ -118,7 +118,7 @@ theorem exp_cond_mul_call_then_loop_back_evm_exp_msb_saved_bit_two_mul_with_mul_
             (mul_callable_code mulTarget))
     (hback : ((base + 256) + 4 : Word) + signExtend13 backOff = loopTarget) :
     let r := expResultWord r0 r1 r2 r3
-    let aw := expResultWord a0 a1 a2 a3
+    let aw := expTwoMulIterAw a0 a1 a2 a3
     let rw := r * aw
     let rest : Assertion :=
       (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) **
@@ -338,7 +338,7 @@ theorem exp_cond_mul_call_then_loop_back_evm_exp_msb_saved_bit_two_mul_with_mul_
               base squaringMulOff condMulOff skipOff backOff)
             (mul_callable_code mulTarget))
     (hback : ((base + 256) + 4 : Word) + signExtend13 backOff = loopTarget) :
-    let aw := expResultWord a0 a1 a2 a3
+    let aw := expTwoMulIterAw a0 a1 a2 a3
     let rw := r * aw
     let baseFrame : Assertion :=
       ((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
@@ -444,9 +444,8 @@ theorem exp_msb_saved_bit_two_mul_full_iter_four_exit_spec_within
     (hskip : (base + 148 : Word) + signExtend13 skipOff = base + 256)
     (hback : ((base + 256) + 4 : Word) + signExtend13 backOff = loopTarget) :
     let bit := expTwoMulIterBit e
-    let w := expResultWord r0 r1 r2 r3
-    let aw := expResultWord a0 a1 a2 a3
-    let rw := (w * w) * aw
+    let w := expTwoMulIterW r0 r1 r2 r3
+    let rw := expTwoMulIterRw r0 r1 r2 r3 a0 a1 a2 a3
     let baseFrame : Assertion :=
       ((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
       ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **
@@ -510,7 +509,7 @@ theorem exp_msb_saved_bit_two_mul_full_iter_four_exit_spec_within
         (base + 264,
           ((((.x9 ↦ᵣ expTwoMulIterCountNew iterCount) ** (.x0 ↦ᵣ (0 : Word)) **
            ⌜expTwoMulIterCountNew iterCount = 0⌝) ** skipRest) ** baseFrame))] := by
-  intro bit w aw rw baseFrame skipRest condRest condFrame
+  intro bit w rw baseFrame skipRest condRest condFrame
   have hSkip :=
     exp_msb_saved_bit_prefix_squaring_beq_skip_then_loop_back_with_base_frame_evm_exp_msb_saved_bit_two_mul_with_mul_spec_within
       e c iterCount v10 v18 sp evmSp vOld r0 r1 r2 r3 d0 d1 d2 d3
@@ -572,9 +571,8 @@ theorem exp_msb_saved_bit_two_mul_full_iter_merged_exit_spec_within
     (hskip : (base + 148 : Word) + signExtend13 skipOff = base + 256)
     (hback : ((base + 256) + 4 : Word) + signExtend13 backOff = loopTarget) :
     let bit := expTwoMulIterBit e
-    let w := expResultWord r0 r1 r2 r3
-    let aw := expResultWord a0 a1 a2 a3
-    let rw := (w * w) * aw
+    let w := expTwoMulIterW r0 r1 r2 r3
+    let rw := expTwoMulIterRw r0 r1 r2 r3 a0 a1 a2 a3
     let baseFrame : Assertion :=
       ((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
       ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **
@@ -640,7 +638,7 @@ theorem exp_msb_saved_bit_two_mul_full_iter_merged_exit_spec_within
         (.x0 ↦ᵣ (0 : Word)) ** (.x9 ↦ᵣ iterCount)) ** baseFrame)
       [(loopTarget, fun h => condLoop h ∨ skipLoop h),
         (base + 264, fun h => condExit h ∨ skipExit h)] := by
-  intro bit w aw rw baseFrame skipRest condRest condFrame
+  intro bit w rw baseFrame skipRest condRest condFrame
     condLoop condExit skipLoop skipExit
   have hFour :=
     exp_msb_saved_bit_two_mul_full_iter_four_exit_spec_within
@@ -696,9 +694,8 @@ theorem exp_msb_saved_bit_two_mul_full_iter_branch_spec_within
     (hskip : (base + 148 : Word) + signExtend13 skipOff = base + 256)
     (hback : ((base + 256) + 4 : Word) + signExtend13 backOff = loopTarget) :
     let bit := expTwoMulIterBit e
-    let w := expResultWord r0 r1 r2 r3
-    let aw := expResultWord a0 a1 a2 a3
-    let rw := (w * w) * aw
+    let w := expTwoMulIterW r0 r1 r2 r3
+    let rw := expTwoMulIterRw r0 r1 r2 r3 a0 a1 a2 a3
     let baseFrame : Assertion :=
       ((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
       ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **
@@ -764,7 +761,7 @@ theorem exp_msb_saved_bit_two_mul_full_iter_branch_spec_within
         (.x0 ↦ᵣ (0 : Word)) ** (.x9 ↦ᵣ iterCount)) ** baseFrame)
       loopTarget (fun h => condLoop h ∨ skipLoop h)
       (base + 264) (fun h => condExit h ∨ skipExit h) := by
-  intro bit w aw rw baseFrame skipRest condRest condFrame
+  intro bit w rw baseFrame skipRest condRest condFrame
     condLoop condExit skipLoop skipExit
   exact cpsNBranchWithin_as_cpsBranchWithin
     (exp_msb_saved_bit_two_mul_full_iter_merged_exit_spec_within
@@ -792,9 +789,8 @@ theorem exp_msb_saved_bit_two_mul_full_iter_branch_owned_scratch_spec_within
     (hskip : (base + 148 : Word) + signExtend13 skipOff = base + 256)
     (hback : ((base + 256) + 4 : Word) + signExtend13 backOff = loopTarget) :
     let bit := expTwoMulIterBit e
-    let w := expResultWord r0 r1 r2 r3
-    let aw := expResultWord a0 a1 a2 a3
-    let rw := (w * w) * aw
+    let w := expTwoMulIterW r0 r1 r2 r3
+    let rw := expTwoMulIterRw r0 r1 r2 r3 a0 a1 a2 a3
     let baseFrame : Assertion :=
       ((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
       ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **
@@ -860,7 +856,7 @@ theorem exp_msb_saved_bit_two_mul_full_iter_branch_owned_scratch_spec_within
         (.x0 ↦ᵣ (0 : Word)) ** (.x9 ↦ᵣ iterCount)) ** baseFrame)
       [(loopTarget, fun h => condLoop h ∨ skipLoop h),
        (base + 264, fun h => condExit h ∨ skipExit h)] := by
-  intro bit w aw rw baseFrame skipRest condRest condFrame
+  intro bit w rw baseFrame skipRest condRest condFrame
     condLoop condExit skipLoop skipExit
   refine cpsNBranchWithin_of_forall_regIs_to_regOwn_perm
     (r := .x6)
@@ -984,9 +980,8 @@ theorem exp_msb_saved_bit_two_mul_full_iter_owned_scratch_branch_spec_within
     (hskip : (base + 148 : Word) + signExtend13 skipOff = base + 256)
     (hback : ((base + 256) + 4 : Word) + signExtend13 backOff = loopTarget) :
     let bit := expTwoMulIterBit e
-    let w := expResultWord r0 r1 r2 r3
-    let aw := expResultWord a0 a1 a2 a3
-    let rw := (w * w) * aw
+    let w := expTwoMulIterW r0 r1 r2 r3
+    let rw := expTwoMulIterRw r0 r1 r2 r3 a0 a1 a2 a3
     let baseFrame : Assertion :=
       ((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
       ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **
@@ -1052,7 +1047,7 @@ theorem exp_msb_saved_bit_two_mul_full_iter_owned_scratch_branch_spec_within
         (.x0 ↦ᵣ (0 : Word)) ** (.x9 ↦ᵣ iterCount)) ** baseFrame)
       loopTarget (fun h => condLoop h ∨ skipLoop h)
       (base + 264) (fun h => condExit h ∨ skipExit h) := by
-  intro bit w aw rw baseFrame skipRest condRest condFrame
+  intro bit w rw baseFrame skipRest condRest condFrame
     condLoop condExit skipLoop skipExit
   exact cpsNBranchWithin_as_cpsBranchWithin
     (exp_msb_saved_bit_two_mul_full_iter_branch_owned_scratch_spec_within


### PR DESCRIPTION
Summary:
- use expTwoMulIterAw/W/Rw helpers in SavedBitTwoMulCond theorem surfaces
- remove redundant aw lets where expTwoMulIterRw now names the full conditional multiply result
- keep the two-MUL conditional path aligned with the saved-bit helper vocabulary

Validation:
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitTwoMulCond
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCond.lean (no matches)
- wc -l EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCond.lean
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build (passes; existing LeanRV64D/RiscvExtras.lean extension.toCtorIdx deprecation warning)