### PR TITLE
refactor(exp): name full-loop cond product

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/FullLoop.lean
+++ b/EvmAsm/Evm64/Exp/Compose/FullLoop.lean
@@ -37,6 +37,9 @@ theorem evmExpWithMulCode_mul_sub {base mulTarget : Word}
   unfold evmExpWithMulCode
   exact CodeReq.mono_union_right hd (fun _ _ h => h)
 
+abbrev expCondMulRw (r : EvmWord) (a0 a1 a2 a3 : Word) : EvmWord :=
+  r * expResultWord a0 a1 a2 a3
+
 /-- Lift a top-level EXP-body spec into the combined EXP+MUL code bundle. -/
 theorem cpsTripleWithin_extend_evmExpWithMulCode {nSteps : Nat}
     {entry exit_ base mulTarget : Word}
@@ -517,7 +520,7 @@ theorem exp_cond_mul_call_block_evm_exp_with_mul_spec_within
             (evmExpCode base mulOff skipOff backOff)
             (mul_callable_code mulTarget)) :
     let r := expResultWord r0 r1 r2 r3
-    let aw := expResultWord a0 a1 a2 a3
+    let rw := expCondMulRw r a0 a1 a2 a3
     cpsTripleWithin (17 + 64 + 9) (base + 148) ((base + 148) + 104)
       (evmExpWithMulCode base mulTarget mulOff skipOff backOff)
       ((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
@@ -540,17 +543,17 @@ theorem exp_cond_mul_call_block_evm_exp_with_mul_spec_within
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) **
        (.x1 ↦ᵣ vOld))
       ((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) **
-       (.x5 ↦ᵣ (r * aw).getLimbN 3) **
+       (.x5 ↦ᵣ rw.getLimbN 3) **
        ((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
        ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **
        ((evmSp + signExtend12 ((-48) : BitVec 12)) ↦ₘ a2) **
        ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3) **
-       evmWordIs sp (r * aw) ** evmWordIs (evmSp + 32) (r * aw) **
+       evmWordIs sp rw ** evmWordIs (evmSp + 32) rw **
        regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
        memOwn evmSp ** memOwn (evmSp + 8) **
        memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
        (.x1 ↦ᵣ ((base + 148) + 68))) := by
-  intro r aw
+  intro r rw
   have hbase' : (base + 148 : Word) &&& 1 = 0 := by bv_decide
   -- Sub-sub: exp_cond_mul_call_block_code (base+148) ⊆ evmExpCode base
   -- via the with-skip block at base+144.

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBase.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBase.lean
@@ -22,6 +22,9 @@ abbrev expTwoMulIterW (r0 r1 r2 r3 : Word) : EvmWord :=
 abbrev expTwoMulIterAw (a0 a1 a2 a3 : Word) : EvmWord :=
   expResultWord a0 a1 a2 a3
 
+abbrev expTwoMulCondRw (r : EvmWord) (a0 a1 a2 a3 : Word) : EvmWord :=
+  r * expTwoMulIterAw a0 a1 a2 a3
+
 abbrev expTwoMulIterRw
     (r0 r1 r2 r3 a0 a1 a2 a3 : Word) : EvmWord :=
   (expTwoMulIterW r0 r1 r2 r3 * expTwoMulIterW r0 r1 r2 r3) *

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFullLoopCanonical.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFullLoopCanonical.lean
@@ -177,7 +177,7 @@ theorem exp_msb_saved_bit_prefix_then_squaring_call_evm_exp_msb_saved_bit_two_mu
               base squaringMulOff condMulOff)
             (mul_callable_code mulTarget)) :
     let bit := expTwoMulIterBit e
-    let w := expResultWord r0 r1 r2 r3
+    let w := expTwoMulIterW r0 r1 r2 r3
     cpsTripleWithin (3 + 1 + (17 + 64 + 9)) (base + 28) (base + 148)
       (evmExpMsbSavedBitTwoMulCanonicalWithMulCode
         base mulTarget squaringMulOff condMulOff)
@@ -218,7 +218,7 @@ theorem exp_msb_saved_bit_prefix_then_squaring_call_evm_exp_msb_saved_bit_two_mu
     (base : Word)
     (hbase : base &&& 1 = 0) :
     let bit := expTwoMulIterBit e
-    let w := expResultWord r0 r1 r2 r3
+    let w := expTwoMulIterW r0 r1 r2 r3
     cpsTripleWithin (3 + 1 + (17 + 64 + 9)) (base + 28) (base + 148)
       (evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode base)
       ((.x5 ↦ᵣ e) ** (.x6 ↦ᵣ c) ** (.x10 ↦ᵣ v10) ** (.x18 ↦ᵣ v18) **
@@ -269,7 +269,7 @@ theorem exp_msb_saved_bit_prefix_squaring_then_beq_evm_exp_msb_saved_bit_two_mul
       (base + 148 : Word) + signExtend13 EvmAsm.Evm64.canonicalExpCondMulSkipOff =
         target) :
     let bit := expTwoMulIterBit e
-    let w := expResultWord r0 r1 r2 r3
+    let w := expTwoMulIterW r0 r1 r2 r3
     cpsBranchWithin (3 + 1 + (17 + 64 + 9) + 1) (base + 28)
       (evmExpMsbSavedBitTwoMulCanonicalWithMulCode
         base mulTarget squaringMulOff condMulOff)
@@ -329,7 +329,7 @@ theorem exp_msb_saved_bit_prefix_squaring_then_beq_evm_exp_msb_saved_bit_two_mul
               base squaringMulOff condMulOff)
             (mul_callable_code mulTarget)) :
     let bit := expTwoMulIterBit e
-    let w := expResultWord r0 r1 r2 r3
+    let w := expTwoMulIterW r0 r1 r2 r3
     cpsBranchWithin (3 + 1 + (17 + 64 + 9) + 1) (base + 28)
       (evmExpMsbSavedBitTwoMulCanonicalWithMulCode
         base mulTarget squaringMulOff condMulOff)
@@ -385,7 +385,7 @@ theorem exp_msb_saved_bit_prefix_squaring_then_beq_evm_exp_msb_saved_bit_two_mul
       (base + 148 : Word) + signExtend13 EvmAsm.Evm64.canonicalExpCondMulSkipOff =
         target) :
     let bit := expTwoMulIterBit e
-    let w := expResultWord r0 r1 r2 r3
+    let w := expTwoMulIterW r0 r1 r2 r3
     cpsBranchWithin (3 + 1 + (17 + 64 + 9) + 1) (base + 28)
       (evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode base)
       ((.x5 ↦ᵣ e) ** (.x6 ↦ᵣ c) ** (.x10 ↦ᵣ v10) ** (.x18 ↦ᵣ v18) **
@@ -442,7 +442,7 @@ theorem exp_msb_saved_bit_prefix_squaring_then_beq_evm_exp_msb_saved_bit_two_mul
     (base : Word)
     (hbase : base &&& 1 = 0) :
     let bit := expTwoMulIterBit e
-    let w := expResultWord r0 r1 r2 r3
+    let w := expTwoMulIterW r0 r1 r2 r3
     cpsBranchWithin (3 + 1 + (17 + 64 + 9) + 1) (base + 28)
       (evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode base)
       ((.x5 ↦ᵣ e) ** (.x6 ↦ᵣ c) ** (.x10 ↦ᵣ v10) ** (.x18 ↦ᵣ v18) **

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitIterPosts.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitIterPosts.lean
@@ -299,9 +299,8 @@ theorem exp_msb_saved_bit_two_mul_full_iter_owned_scratch_branch_named_posts_spe
     (hskip : (base + 148 : Word) + signExtend13 skipOff = base + 256)
     (hback : ((base + 256) + 4 : Word) + signExtend13 backOff = loopTarget) :
     let bit := expTwoMulIterBit e
-    let w := expResultWord r0 r1 r2 r3
-    let aw := expResultWord a0 a1 a2 a3
-    let rw := (w * w) * aw
+    let w := expTwoMulIterW r0 r1 r2 r3
+    let rw := expTwoMulIterRw r0 r1 r2 r3 a0 a1 a2 a3
     cpsBranchWithin
       (((3 + 1 + (17 + 64 + 9) + 1) + 2) + ((17 + 64 + 9) + 2))
       (base + 28)
@@ -336,7 +335,7 @@ theorem exp_msb_saved_bit_two_mul_full_iter_owned_scratch_branch_named_posts_spe
             base a0 a1 a2 a3 rw (expTwoMulIterCountNew iterCount = 0) h ∨
           expTwoMulIterSkipPost (expTwoMulIterCountNew iterCount) bit sp evmSp
             base a0 a1 a2 a3 w (expTwoMulIterCountNew iterCount = 0) h) := by
-  intro bit w aw rw
+  intro bit w rw
   rw [expTwoMulIterBaseFrame_unfold]
   exact cpsBranchWithin_weaken
     (fun _ hp => hp)

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCond.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCond.lean
@@ -27,8 +27,7 @@ theorem exp_cond_mul_call_then_loop_back_evm_exp_msb_saved_bit_two_mul_with_mul_
             (mul_callable_code mulTarget))
     (hback : ((base + 256) + 4 : Word) + signExtend13 backOff = loopTarget) :
     let r := expResultWord r0 r1 r2 r3
-    let aw := expTwoMulIterAw a0 a1 a2 a3
-    let rw := r * aw
+    let rw := expTwoMulCondRw r a0 a1 a2 a3
     let rest : Assertion :=
       (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) **
       (.x5 ↦ᵣ rw.getLimbN 3) **
@@ -70,7 +69,7 @@ theorem exp_cond_mul_call_then_loop_back_evm_exp_msb_saved_bit_two_mul_with_mul_
         (base + 264,
           (((.x9 ↦ᵣ expTwoMulIterCountNew iterCount) ** (.x0 ↦ᵣ (0 : Word)) **
            ⌜expTwoMulIterCountNew iterCount = 0⌝) ** rest))] := by
-  intro r aw rw rest
+  intro r rw rest
   have hCond :=
     exp_cond_mul_call_block_evm_exp_msb_saved_bit_two_mul_with_mul_spec_within
       sp evmSp tOld vOld r0 r1 r2 r3 a0 a1 a2 a3 d0 d1 d2 d3 e0 e1 e2 e3
@@ -94,7 +93,7 @@ theorem exp_cond_mul_call_then_loop_back_evm_exp_msb_saved_bit_two_mul_with_mul_
         _ loopTarget _ (base + 264) _ :=
     cpsTripleWithin_seq_cpsBranchWithin_perm_same_cr
       (fun _ hp => by
-        dsimp [rest, r, aw, rw] at hp ⊢
+        dsimp [rest, r, rw] at hp ⊢
         xperm_hyp hp)
       hCondFramed hLoopFramed
   have hSeqN := cpsBranchWithin_as_cpsNBranchWithin hSeq
@@ -118,8 +117,7 @@ theorem exp_cond_mul_call_then_loop_back_evm_exp_msb_saved_bit_two_mul_with_mul_
             (mul_callable_code mulTarget))
     (hback : ((base + 256) + 4 : Word) + signExtend13 backOff = loopTarget) :
     let r := expResultWord r0 r1 r2 r3
-    let aw := expTwoMulIterAw a0 a1 a2 a3
-    let rw := r * aw
+    let rw := expTwoMulCondRw r a0 a1 a2 a3
     let rest : Assertion :=
       (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) **
       (.x5 ↦ᵣ rw.getLimbN 3) **
@@ -160,7 +158,7 @@ theorem exp_cond_mul_call_then_loop_back_evm_exp_msb_saved_bit_two_mul_with_mul_
         (base + 264,
           (((.x9 ↦ᵣ expTwoMulIterCountNew iterCount) ** (.x0 ↦ᵣ (0 : Word)) **
            ⌜expTwoMulIterCountNew iterCount = 0⌝) ** rest))] := by
-  intro r aw rw rest preCore
+  intro r rw rest preCore
   refine cpsNBranchWithin_of_forall_regIs_to_regOwn_perm
     (r := .x6)
     (P := preCore ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
@@ -338,8 +336,7 @@ theorem exp_cond_mul_call_then_loop_back_evm_exp_msb_saved_bit_two_mul_with_mul_
               base squaringMulOff condMulOff skipOff backOff)
             (mul_callable_code mulTarget))
     (hback : ((base + 256) + 4 : Word) + signExtend13 backOff = loopTarget) :
-    let aw := expTwoMulIterAw a0 a1 a2 a3
-    let rw := r * aw
+    let rw := expTwoMulCondRw r a0 a1 a2 a3
     let baseFrame : Assertion :=
       ((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
       ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **
@@ -375,7 +372,7 @@ theorem exp_cond_mul_call_then_loop_back_evm_exp_msb_saved_bit_two_mul_with_mul_
         (base + 264,
           (((.x9 ↦ᵣ expTwoMulIterCountNew iterCount) ** (.x0 ↦ᵣ (0 : Word)) **
            ⌜expTwoMulIterCountNew iterCount = 0⌝) ** rest))] := by
-  intro aw rw baseFrame rest foldedPre
+  intro rw baseFrame rest foldedPre
   let concretePre : Assertion :=
     let preCore : Assertion :=
       (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ r.getLimbN 3) **

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCondCanonical.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCondCanonical.lean
@@ -23,8 +23,7 @@ theorem exp_cond_mul_call_then_loop_back_evm_exp_msb_saved_bit_two_mul_canonical
               base squaringMulOff condMulOff)
             (mul_callable_code mulTarget)) :
     let r := expResultWord r0 r1 r2 r3
-    let aw := expTwoMulIterAw a0 a1 a2 a3
-    let rw := r * aw
+    let rw := expTwoMulCondRw r a0 a1 a2 a3
     let rest : Assertion :=
       (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) **
       (.x5 ↦ᵣ rw.getLimbN 3) **
@@ -87,8 +86,7 @@ theorem exp_cond_mul_call_then_loop_back_evm_exp_msb_saved_bit_two_mul_canonical
     (base : Word)
     (hbase : base &&& 1 = 0) :
     let r := expResultWord r0 r1 r2 r3
-    let aw := expTwoMulIterAw a0 a1 a2 a3
-    let rw := r * aw
+    let rw := expTwoMulCondRw r a0 a1 a2 a3
     let rest : Assertion :=
       (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) **
       (.x5 ↦ᵣ rw.getLimbN 3) **
@@ -148,8 +146,7 @@ theorem exp_cond_mul_call_then_loop_back_evm_exp_msb_saved_bit_two_mul_canonical
             (evmExpMsbSavedBitTwoMulCanonicalCode
               base squaringMulOff condMulOff)
             (mul_callable_code mulTarget)) :
-    let aw := expTwoMulIterAw a0 a1 a2 a3
-    let rw := r * aw
+    let rw := expTwoMulCondRw r a0 a1 a2 a3
     let baseFrame : Assertion :=
       ((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
       ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **
@@ -204,8 +201,7 @@ theorem exp_cond_mul_call_then_loop_back_evm_exp_msb_saved_bit_two_mul_canonical
     (iterCount sp evmSp vOld a0 a1 a2 a3 : Word) (r : EvmWord)
     (base : Word)
     (hbase : base &&& 1 = 0) :
-    let aw := expTwoMulIterAw a0 a1 a2 a3
-    let rw := r * aw
+    let rw := expTwoMulCondRw r a0 a1 a2 a3
     let baseFrame : Assertion :=
       ((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
       ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulSkip.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulSkip.lean
@@ -56,7 +56,7 @@ theorem exp_msb_saved_bit_prefix_squaring_beq_skip_then_loop_back_evm_exp_msb_sa
     (hskip : (base + 148 : Word) + signExtend13 skipOff = base + 256)
     (hback : ((base + 256) + 4 : Word) + signExtend13 backOff = loopTarget) :
     let bit := expTwoMulIterBit e
-    let w := expResultWord r0 r1 r2 r3
+    let w := expTwoMulIterW r0 r1 r2 r3
     let rest : Assertion :=
       (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
       ⌜bit + signExtend12 (0 : BitVec 12) = 0⌝ **
@@ -170,7 +170,7 @@ theorem exp_msb_saved_bit_prefix_squaring_beq_skip_then_loop_back_with_base_fram
     (hskip : (base + 148 : Word) + signExtend13 skipOff = base + 256)
     (hback : ((base + 256) + 4 : Word) + signExtend13 backOff = loopTarget) :
     let bit := expTwoMulIterBit e
-    let w := expResultWord r0 r1 r2 r3
+    let w := expTwoMulIterW r0 r1 r2 r3
     let baseFrame : Assertion :=
       ((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
       ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulSkipCanonical.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulSkipCanonical.lean
@@ -65,7 +65,7 @@ theorem exp_msb_saved_bit_prefix_squaring_beq_skip_then_loop_back_evm_exp_msb_sa
               base squaringMulOff condMulOff)
             (mul_callable_code mulTarget)) :
     let bit := expTwoMulIterBit e
-    let w := expResultWord r0 r1 r2 r3
+    let w := expTwoMulIterW r0 r1 r2 r3
     let rest : Assertion :=
       (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
       ⌜bit + signExtend12 (0 : BitVec 12) = 0⌝ **
@@ -136,7 +136,7 @@ theorem exp_msb_saved_bit_prefix_squaring_beq_skip_then_loop_back_evm_exp_msb_sa
     (base : Word)
     (hbase : base &&& 1 = 0) :
     let bit := expTwoMulIterBit e
-    let w := expResultWord r0 r1 r2 r3
+    let w := expTwoMulIterW r0 r1 r2 r3
     let rest : Assertion :=
       (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
       ⌜bit + signExtend12 (0 : BitVec 12) = 0⌝ **


### PR DESCRIPTION
## Summary
- add expCondMulRw for the generic full-loop conditional multiply product
- use it in exp_cond_mul_call_block_evm_exp_with_mul_spec_within
- remove the redundant aw let and repeated r * aw postcondition terms

## Validation
- lake build EvmAsm.Evm64.Exp.Compose.FullLoop
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/Compose/FullLoop.lean
- wc -l EvmAsm/Evm64/Exp/Compose/FullLoop.lean
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build