### PR TITLE
refactor(exp): name saved-bit cond product from limbs

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBase.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBase.lean
@@ -25,6 +25,10 @@ abbrev expTwoMulIterAw (a0 a1 a2 a3 : Word) : EvmWord :=
 abbrev expTwoMulCondRw (r : EvmWord) (a0 a1 a2 a3 : Word) : EvmWord :=
   r * expTwoMulIterAw a0 a1 a2 a3
 
+abbrev expTwoMulCondRwFromLimbs
+    (r0 r1 r2 r3 a0 a1 a2 a3 : Word) : EvmWord :=
+  expTwoMulCondRw (expTwoMulIterW r0 r1 r2 r3) a0 a1 a2 a3
+
 abbrev expTwoMulIterRw
     (r0 r1 r2 r3 a0 a1 a2 a3 : Word) : EvmWord :=
   (expTwoMulIterW r0 r1 r2 r3 * expTwoMulIterW r0 r1 r2 r3) *

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitIterMerge.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitIterMerge.lean
@@ -103,11 +103,6 @@ theorem exp_two_mul_named_iter_with_continuations_bounded_spec_within
     (hbase : base &&& 1 = 0)
     (hBound :
       expTwoMulNamedIterStepBound + max nLoop nExit ≤ nBound) :
-    let bit := e >>> (63 : BitVec 6).toNat
-    let w := expResultWord r0 r1 r2 r3
-    let aw := expResultWord a0 a1 a2 a3
-    let rw := (w * w) * aw
-    let iterCountNew := iterCount + signExtend12 ((-1 : BitVec 12))
     (cpsTripleWithin nLoop (base + 28) exit_
       (evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode base)
       (expTwoMulIterLoopPost (expTwoMulIterCountNew iterCount)

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitIterMerge.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitIterMerge.lean
@@ -103,6 +103,11 @@ theorem exp_two_mul_named_iter_with_continuations_bounded_spec_within
     (hbase : base &&& 1 = 0)
     (hBound :
       expTwoMulNamedIterStepBound + max nLoop nExit ≤ nBound) :
+    let bit := e >>> (63 : BitVec 6).toNat
+    let w := expResultWord r0 r1 r2 r3
+    let aw := expResultWord a0 a1 a2 a3
+    let rw := (w * w) * aw
+    let iterCountNew := iterCount + signExtend12 ((-1 : BitVec 12))
     (cpsTripleWithin nLoop (base + 28) exit_
       (evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode base)
       (expTwoMulIterLoopPost (expTwoMulIterCountNew iterCount)

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCond.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCond.lean
@@ -26,8 +26,7 @@ theorem exp_cond_mul_call_then_loop_back_evm_exp_msb_saved_bit_two_mul_with_mul_
               base squaringMulOff condMulOff skipOff backOff)
             (mul_callable_code mulTarget))
     (hback : ((base + 256) + 4 : Word) + signExtend13 backOff = loopTarget) :
-    let r := expResultWord r0 r1 r2 r3
-    let rw := expTwoMulCondRw r a0 a1 a2 a3
+    let rw := expTwoMulCondRwFromLimbs r0 r1 r2 r3 a0 a1 a2 a3
     let rest : Assertion :=
       (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) **
       (.x5 ↦ᵣ rw.getLimbN 3) **
@@ -69,7 +68,7 @@ theorem exp_cond_mul_call_then_loop_back_evm_exp_msb_saved_bit_two_mul_with_mul_
         (base + 264,
           (((.x9 ↦ᵣ expTwoMulIterCountNew iterCount) ** (.x0 ↦ᵣ (0 : Word)) **
            ⌜expTwoMulIterCountNew iterCount = 0⌝) ** rest))] := by
-  intro r rw rest
+  intro rw rest
   have hCond :=
     exp_cond_mul_call_block_evm_exp_msb_saved_bit_two_mul_with_mul_spec_within
       sp evmSp tOld vOld r0 r1 r2 r3 a0 a1 a2 a3 d0 d1 d2 d3 e0 e1 e2 e3
@@ -93,7 +92,7 @@ theorem exp_cond_mul_call_then_loop_back_evm_exp_msb_saved_bit_two_mul_with_mul_
         _ loopTarget _ (base + 264) _ :=
     cpsTripleWithin_seq_cpsBranchWithin_perm_same_cr
       (fun _ hp => by
-        dsimp [rest, r, rw] at hp ⊢
+        dsimp [rest, rw] at hp ⊢
         xperm_hyp hp)
       hCondFramed hLoopFramed
   have hSeqN := cpsBranchWithin_as_cpsNBranchWithin hSeq
@@ -116,8 +115,7 @@ theorem exp_cond_mul_call_then_loop_back_evm_exp_msb_saved_bit_two_mul_with_mul_
               base squaringMulOff condMulOff skipOff backOff)
             (mul_callable_code mulTarget))
     (hback : ((base + 256) + 4 : Word) + signExtend13 backOff = loopTarget) :
-    let r := expResultWord r0 r1 r2 r3
-    let rw := expTwoMulCondRw r a0 a1 a2 a3
+    let rw := expTwoMulCondRwFromLimbs r0 r1 r2 r3 a0 a1 a2 a3
     let rest : Assertion :=
       (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) **
       (.x5 ↦ᵣ rw.getLimbN 3) **
@@ -158,7 +156,7 @@ theorem exp_cond_mul_call_then_loop_back_evm_exp_msb_saved_bit_two_mul_with_mul_
         (base + 264,
           (((.x9 ↦ᵣ expTwoMulIterCountNew iterCount) ** (.x0 ↦ᵣ (0 : Word)) **
            ⌜expTwoMulIterCountNew iterCount = 0⌝) ** rest))] := by
-  intro r rw rest preCore
+  intro rw rest preCore
   refine cpsNBranchWithin_of_forall_regIs_to_regOwn_perm
     (r := .x6)
     (P := preCore ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
@@ -406,7 +404,8 @@ theorem exp_cond_mul_call_then_loop_back_evm_exp_msb_saved_bit_two_mul_with_mul_
             (((.x9 ↦ᵣ expTwoMulIterCountNew iterCount) ** (.x0 ↦ᵣ (0 : Word)) **
              ⌜expTwoMulIterCountNew iterCount = 0⌝) ** rest))] := by
     dsimp [concretePre, baseFrame, rest]
-    simpa [expResultWord_getLimbN_self r] using
+    simpa [expTwoMulCondRwFromLimbs, expTwoMulIterW,
+      expResultWord_getLimbN_self r] using
     exp_cond_mul_call_then_loop_back_evm_exp_msb_saved_bit_two_mul_with_mul_call_scratch_owned_spec_within
       iterCount sp evmSp (r.getLimbN 3) vOld
       (r.getLimbN 0) (r.getLimbN 1) (r.getLimbN 2) (r.getLimbN 3)

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCondCanonical.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCondCanonical.lean
@@ -22,8 +22,7 @@ theorem exp_cond_mul_call_then_loop_back_evm_exp_msb_saved_bit_two_mul_canonical
             (evmExpMsbSavedBitTwoMulCanonicalCode
               base squaringMulOff condMulOff)
             (mul_callable_code mulTarget)) :
-    let r := expResultWord r0 r1 r2 r3
-    let rw := expTwoMulCondRw r a0 a1 a2 a3
+    let rw := expTwoMulCondRwFromLimbs r0 r1 r2 r3 a0 a1 a2 a3
     let rest : Assertion :=
       (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) **
       (.x5 ↦ᵣ rw.getLimbN 3) **
@@ -85,8 +84,7 @@ theorem exp_cond_mul_call_then_loop_back_evm_exp_msb_saved_bit_two_mul_canonical
       e0 e1 e2 e3 v6 v7 v10 v11 : Word)
     (base : Word)
     (hbase : base &&& 1 = 0) :
-    let r := expResultWord r0 r1 r2 r3
-    let rw := expTwoMulCondRw r a0 a1 a2 a3
+    let rw := expTwoMulCondRwFromLimbs r0 r1 r2 r3 a0 a1 a2 a3
     let rest : Assertion :=
       (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) **
       (.x5 ↦ᵣ rw.getLimbN 3) **


### PR DESCRIPTION
Summary:
- add expTwoMulCondRwFromLimbs beside the saved-bit conditional product helper
- use it in concrete-limb saved-bit conditional multiply theorem surfaces
- leave folded-word variants on expTwoMulCondRw because they already receive an EvmWord

Validation:
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitTwoMulCondCanonical
- git diff --check
- forbidden scan for sorry/admit/set_option in edited EXP files
- wc -l edited EXP files
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build