### PR TITLE
refactor(exp): name iter-post square

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBase.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBase.lean
@@ -22,6 +22,10 @@ abbrev expTwoMulIterW (r0 r1 r2 r3 : Word) : EvmWord :=
 abbrev expTwoMulIterAw (a0 a1 a2 a3 : Word) : EvmWord :=
   expResultWord a0 a1 a2 a3
 
+abbrev expTwoMulSquareW (r0 r1 r2 r3 : Word) : EvmWord :=
+  let w := expTwoMulIterW r0 r1 r2 r3
+  w * w
+
 abbrev expTwoMulCondRw (r : EvmWord) (a0 a1 a2 a3 : Word) : EvmWord :=
   r * expTwoMulIterAw a0 a1 a2 a3
 
@@ -31,7 +35,7 @@ abbrev expTwoMulCondRwFromLimbs
 
 abbrev expTwoMulIterRw
     (r0 r1 r2 r3 a0 a1 a2 a3 : Word) : EvmWord :=
-  (expTwoMulIterW r0 r1 r2 r3 * expTwoMulIterW r0 r1 r2 r3) *
+  expTwoMulSquareW r0 r1 r2 r3 *
     expTwoMulIterAw a0 a1 a2 a3
 
 abbrev expTwoMulIterCountNew (iterCount : Word) : Word :=

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitIterMerge.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitIterMerge.lean
@@ -24,14 +24,14 @@ theorem exp_two_mul_named_iter_with_continuations_spec_within
       (evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode base)
       (expTwoMulIterLoopPost (expTwoMulIterCountNew iterCount)
         (expTwoMulIterBit e) sp evmSp base a0 a1 a2 a3
-        (expTwoMulIterW r0 r1 r2 r3)
+        (expTwoMulSquareW r0 r1 r2 r3)
         (expTwoMulIterRw r0 r1 r2 r3 a0 a1 a2 a3))
       R) →
     (cpsTripleWithin nCont (base + 264) exit_
       (evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode base)
       (expTwoMulIterExitPost (expTwoMulIterCountNew iterCount)
         (expTwoMulIterBit e) sp evmSp base a0 a1 a2 a3
-        (expTwoMulIterW r0 r1 r2 r3)
+        (expTwoMulSquareW r0 r1 r2 r3)
         (expTwoMulIterRw r0 r1 r2 r3 a0 a1 a2 a3))
       R) →
     cpsTripleWithin
@@ -65,14 +65,14 @@ theorem exp_two_mul_named_iter_with_continuations_max_spec_within
       (evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode base)
       (expTwoMulIterLoopPost (expTwoMulIterCountNew iterCount)
         (expTwoMulIterBit e) sp evmSp base a0 a1 a2 a3
-        (expTwoMulIterW r0 r1 r2 r3)
+        (expTwoMulSquareW r0 r1 r2 r3)
         (expTwoMulIterRw r0 r1 r2 r3 a0 a1 a2 a3))
       R) →
     (cpsTripleWithin nExit (base + 264) exit_
       (evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode base)
       (expTwoMulIterExitPost (expTwoMulIterCountNew iterCount)
         (expTwoMulIterBit e) sp evmSp base a0 a1 a2 a3
-        (expTwoMulIterW r0 r1 r2 r3)
+        (expTwoMulSquareW r0 r1 r2 r3)
         (expTwoMulIterRw r0 r1 r2 r3 a0 a1 a2 a3))
       R) →
     cpsTripleWithin
@@ -107,14 +107,14 @@ theorem exp_two_mul_named_iter_with_continuations_bounded_spec_within
       (evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode base)
       (expTwoMulIterLoopPost (expTwoMulIterCountNew iterCount)
         (expTwoMulIterBit e) sp evmSp base a0 a1 a2 a3
-        (expTwoMulIterW r0 r1 r2 r3)
+        (expTwoMulSquareW r0 r1 r2 r3)
         (expTwoMulIterRw r0 r1 r2 r3 a0 a1 a2 a3))
       R) →
     (cpsTripleWithin nExit (base + 264) exit_
       (evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode base)
       (expTwoMulIterExitPost (expTwoMulIterCountNew iterCount)
         (expTwoMulIterBit e) sp evmSp base a0 a1 a2 a3
-        (expTwoMulIterW r0 r1 r2 r3)
+        (expTwoMulSquareW r0 r1 r2 r3)
         (expTwoMulIterRw r0 r1 r2 r3 a0 a1 a2 a3))
       R) →
     cpsTripleWithin nBound
@@ -145,14 +145,14 @@ theorem exp_two_mul_named_iter_with_continuations_closed_bound_spec_within
       (evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode base)
       (expTwoMulIterLoopPost (expTwoMulIterCountNew iterCount)
         (expTwoMulIterBit e) sp evmSp base a0 a1 a2 a3
-        (expTwoMulIterW r0 r1 r2 r3)
+        (expTwoMulSquareW r0 r1 r2 r3)
         (expTwoMulIterRw r0 r1 r2 r3 a0 a1 a2 a3))
       R) →
     (cpsTripleWithin nExit (base + 264) exit_
       (evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode base)
       (expTwoMulIterExitPost (expTwoMulIterCountNew iterCount)
         (expTwoMulIterBit e) sp evmSp base a0 a1 a2 a3
-        (expTwoMulIterW r0 r1 r2 r3)
+        (expTwoMulSquareW r0 r1 r2 r3)
         (expTwoMulIterRw r0 r1 r2 r3 a0 a1 a2 a3))
       R) →
     cpsTripleWithin nBound
@@ -182,14 +182,14 @@ theorem exp_two_mul_named_iter_with_continuations_exact_closed_bound_spec_within
       (evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode base)
       (expTwoMulIterLoopPost (expTwoMulIterCountNew iterCount)
         (expTwoMulIterBit e) sp evmSp base a0 a1 a2 a3
-        (expTwoMulIterW r0 r1 r2 r3)
+        (expTwoMulSquareW r0 r1 r2 r3)
         (expTwoMulIterRw r0 r1 r2 r3 a0 a1 a2 a3))
       R) →
     (cpsTripleWithin nExit (base + 264) exit_
       (evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode base)
       (expTwoMulIterExitPost (expTwoMulIterCountNew iterCount)
         (expTwoMulIterBit e) sp evmSp base a0 a1 a2 a3
-        (expTwoMulIterW r0 r1 r2 r3)
+        (expTwoMulSquareW r0 r1 r2 r3)
         (expTwoMulIterRw r0 r1 r2 r3 a0 a1 a2 a3))
       R) →
     cpsTripleWithin (189 + max nLoop nExit)

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitIterPosts.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitIterPosts.lean
@@ -29,24 +29,25 @@ theorem expTwoMulIterBaseFrame_pcFree
 
 @[irreducible]
 def expTwoMulIterSkipRest
-    (bit sp evmSp base : Word) (w : EvmWord) : Assertion :=
+    (bit sp evmSp base : Word) (squareW : EvmWord) : Assertion :=
   (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
   ⌜bit + signExtend12 (0 : BitVec 12) = 0⌝ **
   (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) **
-  (.x5 ↦ᵣ (w * w).getLimbN 3) **
-  evmWordIs sp (w * w) ** evmWordIs (evmSp + 32) (w * w) **
+  (.x5 ↦ᵣ squareW.getLimbN 3) **
+  evmWordIs sp squareW ** evmWordIs (evmSp + 32) squareW **
   regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
   memOwn evmSp ** memOwn (evmSp + 8) **
   memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
   (.x1 ↦ᵣ ((base + 44) + 68))
 
-theorem expTwoMulIterSkipRest_unfold {bit sp evmSp base : Word} {w : EvmWord} :
-    expTwoMulIterSkipRest bit sp evmSp base w =
+theorem expTwoMulIterSkipRest_unfold
+    {bit sp evmSp base : Word} {squareW : EvmWord} :
+    expTwoMulIterSkipRest bit sp evmSp base squareW =
       ((.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
        ⌜bit + signExtend12 (0 : BitVec 12) = 0⌝ **
        (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) **
-       (.x5 ↦ᵣ (w * w).getLimbN 3) **
-       evmWordIs sp (w * w) ** evmWordIs (evmSp + 32) (w * w) **
+       (.x5 ↦ᵣ squareW.getLimbN 3) **
+       evmWordIs sp squareW ** evmWordIs (evmSp + 32) squareW **
        regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
        memOwn evmSp ** memOwn (evmSp + 8) **
        memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
@@ -55,8 +56,8 @@ theorem expTwoMulIterSkipRest_unfold {bit sp evmSp base : Word} {w : EvmWord} :
   rfl
 
 theorem expTwoMulIterSkipRest_pcFree
-    {bit sp evmSp base : Word} {w : EvmWord} :
-    (expTwoMulIterSkipRest bit sp evmSp base w).pcFree := by
+    {bit sp evmSp base : Word} {squareW : EvmWord} :
+    (expTwoMulIterSkipRest bit sp evmSp base squareW).pcFree := by
   rw [expTwoMulIterSkipRest_unfold, evmWordIs_sp_unfold, evmWordIs_sp32_unfold]
   pcFree
 
@@ -144,26 +145,26 @@ theorem expTwoMulIterCondPost_pcFree
 
 @[irreducible]
 def expTwoMulIterSkipPost
-    (iterCountNew bit sp evmSp base a0 a1 a2 a3 : Word) (w : EvmWord)
+    (iterCountNew bit sp evmSp base a0 a1 a2 a3 : Word) (squareW : EvmWord)
     (exitCond : Prop) : Assertion :=
   (((.x9 ↦ᵣ iterCountNew) ** (.x0 ↦ᵣ (0 : Word)) **
-   ⌜exitCond⌝) ** expTwoMulIterSkipRest bit sp evmSp base w) **
+   ⌜exitCond⌝) ** expTwoMulIterSkipRest bit sp evmSp base squareW) **
   expTwoMulIterBaseFrame evmSp a0 a1 a2 a3
 
 theorem expTwoMulIterSkipPost_unfold
-    {iterCountNew bit sp evmSp base a0 a1 a2 a3 : Word} {w : EvmWord}
+    {iterCountNew bit sp evmSp base a0 a1 a2 a3 : Word} {squareW : EvmWord}
     {exitCond : Prop} :
-    expTwoMulIterSkipPost iterCountNew bit sp evmSp base a0 a1 a2 a3 w exitCond =
+    expTwoMulIterSkipPost iterCountNew bit sp evmSp base a0 a1 a2 a3 squareW exitCond =
       ((((.x9 ↦ᵣ iterCountNew) ** (.x0 ↦ᵣ (0 : Word)) **
-        ⌜exitCond⌝) ** expTwoMulIterSkipRest bit sp evmSp base w) **
+        ⌜exitCond⌝) ** expTwoMulIterSkipRest bit sp evmSp base squareW) **
        expTwoMulIterBaseFrame evmSp a0 a1 a2 a3) := by
   delta expTwoMulIterSkipPost
   rfl
 
 theorem expTwoMulIterSkipPost_pcFree
-    {iterCountNew bit sp evmSp base a0 a1 a2 a3 : Word} {w : EvmWord}
+    {iterCountNew bit sp evmSp base a0 a1 a2 a3 : Word} {squareW : EvmWord}
     {exitCond : Prop} :
-    (expTwoMulIterSkipPost iterCountNew bit sp evmSp base a0 a1 a2 a3 w
+    (expTwoMulIterSkipPost iterCountNew bit sp evmSp base a0 a1 a2 a3 squareW
       exitCond).pcFree := by
   rw [expTwoMulIterSkipPost_unfold, expTwoMulIterSkipRest_unfold,
     expTwoMulIterBaseFrame_unfold, evmWordIs_sp_unfold, evmWordIs_sp32_unfold]
@@ -172,27 +173,27 @@ theorem expTwoMulIterSkipPost_pcFree
 @[irreducible]
 def expTwoMulIterLoopPost
     (iterCountNew bit sp evmSp base a0 a1 a2 a3 : Word)
-    (w rw : EvmWord) : Assertion :=
+    (squareW rw : EvmWord) : Assertion :=
   fun h =>
     expTwoMulIterCondPost iterCountNew bit sp evmSp base a0 a1 a2 a3 rw
       (iterCountNew ≠ 0) h ∨
-    expTwoMulIterSkipPost iterCountNew bit sp evmSp base a0 a1 a2 a3 w
+    expTwoMulIterSkipPost iterCountNew bit sp evmSp base a0 a1 a2 a3 squareW
       (iterCountNew ≠ 0) h
 
 theorem expTwoMulIterLoopPost_unfold
-    {iterCountNew bit sp evmSp base a0 a1 a2 a3 : Word} {w rw : EvmWord} :
-    expTwoMulIterLoopPost iterCountNew bit sp evmSp base a0 a1 a2 a3 w rw =
+    {iterCountNew bit sp evmSp base a0 a1 a2 a3 : Word} {squareW rw : EvmWord} :
+    expTwoMulIterLoopPost iterCountNew bit sp evmSp base a0 a1 a2 a3 squareW rw =
       (fun h =>
         expTwoMulIterCondPost iterCountNew bit sp evmSp base a0 a1 a2 a3 rw
           (iterCountNew ≠ 0) h ∨
-        expTwoMulIterSkipPost iterCountNew bit sp evmSp base a0 a1 a2 a3 w
+        expTwoMulIterSkipPost iterCountNew bit sp evmSp base a0 a1 a2 a3 squareW
           (iterCountNew ≠ 0) h) := by
   delta expTwoMulIterLoopPost
   rfl
 
 theorem expTwoMulIterLoopPost_pcFree
-    {iterCountNew bit sp evmSp base a0 a1 a2 a3 : Word} {w rw : EvmWord} :
-    (expTwoMulIterLoopPost iterCountNew bit sp evmSp base a0 a1 a2 a3 w rw).pcFree := by
+    {iterCountNew bit sp evmSp base a0 a1 a2 a3 : Word} {squareW rw : EvmWord} :
+    (expTwoMulIterLoopPost iterCountNew bit sp evmSp base a0 a1 a2 a3 squareW rw).pcFree := by
   rw [expTwoMulIterLoopPost_unfold]
   intro h hp
   rcases hp with hp | hp
@@ -202,27 +203,27 @@ theorem expTwoMulIterLoopPost_pcFree
 @[irreducible]
 def expTwoMulIterExitPost
     (iterCountNew bit sp evmSp base a0 a1 a2 a3 : Word)
-    (w rw : EvmWord) : Assertion :=
+    (squareW rw : EvmWord) : Assertion :=
   fun h =>
     expTwoMulIterCondPost iterCountNew bit sp evmSp base a0 a1 a2 a3 rw
       (iterCountNew = 0) h ∨
-    expTwoMulIterSkipPost iterCountNew bit sp evmSp base a0 a1 a2 a3 w
+    expTwoMulIterSkipPost iterCountNew bit sp evmSp base a0 a1 a2 a3 squareW
       (iterCountNew = 0) h
 
 theorem expTwoMulIterExitPost_unfold
-    {iterCountNew bit sp evmSp base a0 a1 a2 a3 : Word} {w rw : EvmWord} :
-    expTwoMulIterExitPost iterCountNew bit sp evmSp base a0 a1 a2 a3 w rw =
+    {iterCountNew bit sp evmSp base a0 a1 a2 a3 : Word} {squareW rw : EvmWord} :
+    expTwoMulIterExitPost iterCountNew bit sp evmSp base a0 a1 a2 a3 squareW rw =
       (fun h =>
         expTwoMulIterCondPost iterCountNew bit sp evmSp base a0 a1 a2 a3 rw
           (iterCountNew = 0) h ∨
-        expTwoMulIterSkipPost iterCountNew bit sp evmSp base a0 a1 a2 a3 w
+        expTwoMulIterSkipPost iterCountNew bit sp evmSp base a0 a1 a2 a3 squareW
           (iterCountNew = 0) h) := by
   delta expTwoMulIterExitPost
   rfl
 
 theorem expTwoMulIterExitPost_pcFree
-    {iterCountNew bit sp evmSp base a0 a1 a2 a3 : Word} {w rw : EvmWord} :
-    (expTwoMulIterExitPost iterCountNew bit sp evmSp base a0 a1 a2 a3 w rw).pcFree := by
+    {iterCountNew bit sp evmSp base a0 a1 a2 a3 : Word} {squareW rw : EvmWord} :
+    (expTwoMulIterExitPost iterCountNew bit sp evmSp base a0 a1 a2 a3 squareW rw).pcFree := by
   rw [expTwoMulIterExitPost_unfold]
   intro h hp
   rcases hp with hp | hp
@@ -299,7 +300,7 @@ theorem exp_msb_saved_bit_two_mul_full_iter_owned_scratch_branch_named_posts_spe
     (hskip : (base + 148 : Word) + signExtend13 skipOff = base + 256)
     (hback : ((base + 256) + 4 : Word) + signExtend13 backOff = loopTarget) :
     let bit := expTwoMulIterBit e
-    let w := expTwoMulIterW r0 r1 r2 r3
+    let squareW := expTwoMulSquareW r0 r1 r2 r3
     let rw := expTwoMulIterRw r0 r1 r2 r3 a0 a1 a2 a3
     cpsBranchWithin
       (((3 + 1 + (17 + 64 + 9) + 1) + 2) + ((17 + 64 + 9) + 2))
@@ -328,14 +329,14 @@ theorem exp_msb_saved_bit_two_mul_full_iter_owned_scratch_branch_named_posts_spe
           expTwoMulIterCondPost (expTwoMulIterCountNew iterCount) bit sp evmSp
             base a0 a1 a2 a3 rw (expTwoMulIterCountNew iterCount ≠ 0) h ∨
           expTwoMulIterSkipPost (expTwoMulIterCountNew iterCount) bit sp evmSp
-            base a0 a1 a2 a3 w (expTwoMulIterCountNew iterCount ≠ 0) h)
+            base a0 a1 a2 a3 squareW (expTwoMulIterCountNew iterCount ≠ 0) h)
       (base + 264)
         (fun h =>
           expTwoMulIterCondPost (expTwoMulIterCountNew iterCount) bit sp evmSp
             base a0 a1 a2 a3 rw (expTwoMulIterCountNew iterCount = 0) h ∨
           expTwoMulIterSkipPost (expTwoMulIterCountNew iterCount) bit sp evmSp
-            base a0 a1 a2 a3 w (expTwoMulIterCountNew iterCount = 0) h) := by
-  intro bit w rw
+            base a0 a1 a2 a3 squareW (expTwoMulIterCountNew iterCount = 0) h) := by
+  intro bit squareW rw
   rw [expTwoMulIterBaseFrame_unfold]
   exact cpsBranchWithin_weaken
     (fun _ hp => hp)
@@ -400,12 +401,12 @@ theorem exp_msb_saved_bit_two_mul_full_iter_owned_scratch_branch_named_loop_exit
       loopTarget
         (expTwoMulIterLoopPost (expTwoMulIterCountNew iterCount)
           (expTwoMulIterBit e) sp evmSp base a0 a1 a2 a3
-          (expTwoMulIterW r0 r1 r2 r3)
+          (expTwoMulSquareW r0 r1 r2 r3)
           (expTwoMulIterRw r0 r1 r2 r3 a0 a1 a2 a3))
       (base + 264)
         (expTwoMulIterExitPost (expTwoMulIterCountNew iterCount)
           (expTwoMulIterBit e) sp evmSp base a0 a1 a2 a3
-          (expTwoMulIterW r0 r1 r2 r3)
+          (expTwoMulSquareW r0 r1 r2 r3)
           (expTwoMulIterRw r0 r1 r2 r3 a0 a1 a2 a3)) := by
   exact cpsBranchWithin_weaken
     (fun _ hp => hp)
@@ -448,12 +449,12 @@ theorem exp_msb_saved_bit_two_mul_full_iter_named_pre_loop_exit_spec_within
       loopTarget
         (expTwoMulIterLoopPost (expTwoMulIterCountNew iterCount)
           (expTwoMulIterBit e) sp evmSp base a0 a1 a2 a3
-          (expTwoMulIterW r0 r1 r2 r3)
+          (expTwoMulSquareW r0 r1 r2 r3)
           (expTwoMulIterRw r0 r1 r2 r3 a0 a1 a2 a3))
       (base + 264)
         (expTwoMulIterExitPost (expTwoMulIterCountNew iterCount)
           (expTwoMulIterBit e) sp evmSp base a0 a1 a2 a3
-          (expTwoMulIterW r0 r1 r2 r3)
+          (expTwoMulSquareW r0 r1 r2 r3)
           (expTwoMulIterRw r0 r1 r2 r3 a0 a1 a2 a3)) := by
   exact cpsBranchWithin_weaken
     (fun _ hp => by
@@ -491,12 +492,12 @@ theorem exp_msb_saved_bit_two_mul_full_iter_named_pre_loopback_spec_within
       (base + 28)
         (expTwoMulIterLoopPost (expTwoMulIterCountNew iterCount)
           (expTwoMulIterBit e) sp evmSp base a0 a1 a2 a3
-          (expTwoMulIterW r0 r1 r2 r3)
+          (expTwoMulSquareW r0 r1 r2 r3)
           (expTwoMulIterRw r0 r1 r2 r3 a0 a1 a2 a3))
       (base + 264)
         (expTwoMulIterExitPost (expTwoMulIterCountNew iterCount)
           (expTwoMulIterBit e) sp evmSp base a0 a1 a2 a3
-          (expTwoMulIterW r0 r1 r2 r3)
+          (expTwoMulSquareW r0 r1 r2 r3)
           (expTwoMulIterRw r0 r1 r2 r3 a0 a1 a2 a3)) := by
   exact
     exp_msb_saved_bit_two_mul_full_iter_named_pre_loop_exit_spec_within
@@ -531,12 +532,12 @@ theorem exp_msb_saved_bit_two_mul_full_iter_named_pre_canonical_branches_spec_wi
       (base + 28)
         (expTwoMulIterLoopPost (expTwoMulIterCountNew iterCount)
           (expTwoMulIterBit e) sp evmSp base a0 a1 a2 a3
-          (expTwoMulIterW r0 r1 r2 r3)
+          (expTwoMulSquareW r0 r1 r2 r3)
           (expTwoMulIterRw r0 r1 r2 r3 a0 a1 a2 a3))
       (base + 264)
         (expTwoMulIterExitPost (expTwoMulIterCountNew iterCount)
           (expTwoMulIterBit e) sp evmSp base a0 a1 a2 a3
-          (expTwoMulIterW r0 r1 r2 r3)
+          (expTwoMulSquareW r0 r1 r2 r3)
           (expTwoMulIterRw r0 r1 r2 r3 a0 a1 a2 a3)) := by
   have hskip :
       (base + 148 : Word) +
@@ -582,12 +583,12 @@ theorem exp_msb_saved_bit_two_mul_full_iter_named_pre_canonical_code_spec_within
       (base + 28)
         (expTwoMulIterLoopPost (expTwoMulIterCountNew iterCount)
           (expTwoMulIterBit e) sp evmSp base a0 a1 a2 a3
-          (expTwoMulIterW r0 r1 r2 r3)
+          (expTwoMulSquareW r0 r1 r2 r3)
           (expTwoMulIterRw r0 r1 r2 r3 a0 a1 a2 a3))
       (base + 264)
         (expTwoMulIterExitPost (expTwoMulIterCountNew iterCount)
           (expTwoMulIterBit e) sp evmSp base a0 a1 a2 a3
-          (expTwoMulIterW r0 r1 r2 r3)
+          (expTwoMulSquareW r0 r1 r2 r3)
           (expTwoMulIterRw r0 r1 r2 r3 a0 a1 a2 a3)) := by
   exact
     exp_msb_saved_bit_two_mul_full_iter_named_pre_canonical_branches_spec_within
@@ -620,12 +621,12 @@ theorem exp_msb_saved_bit_two_mul_full_iter_named_pre_canonical_with_mul_spec_wi
       (base + 28)
         (expTwoMulIterLoopPost (expTwoMulIterCountNew iterCount)
           (expTwoMulIterBit e) sp evmSp base a0 a1 a2 a3
-          (expTwoMulIterW r0 r1 r2 r3)
+          (expTwoMulSquareW r0 r1 r2 r3)
           (expTwoMulIterRw r0 r1 r2 r3 a0 a1 a2 a3))
       (base + 264)
         (expTwoMulIterExitPost (expTwoMulIterCountNew iterCount)
           (expTwoMulIterBit e) sp evmSp base a0 a1 a2 a3
-          (expTwoMulIterW r0 r1 r2 r3)
+          (expTwoMulSquareW r0 r1 r2 r3)
           (expTwoMulIterRw r0 r1 r2 r3 a0 a1 a2 a3)) := by
   exact
     exp_msb_saved_bit_two_mul_full_iter_named_pre_canonical_code_spec_within
@@ -649,12 +650,12 @@ theorem exp_msb_saved_bit_two_mul_full_iter_named_pre_canonical_appended_mul_spe
       (base + 28)
         (expTwoMulIterLoopPost (expTwoMulIterCountNew iterCount)
           (expTwoMulIterBit e) sp evmSp base a0 a1 a2 a3
-          (expTwoMulIterW r0 r1 r2 r3)
+          (expTwoMulSquareW r0 r1 r2 r3)
           (expTwoMulIterRw r0 r1 r2 r3 a0 a1 a2 a3))
       (base + 264)
         (expTwoMulIterExitPost (expTwoMulIterCountNew iterCount)
           (expTwoMulIterBit e) sp evmSp base a0 a1 a2 a3
-          (expTwoMulIterW r0 r1 r2 r3)
+          (expTwoMulSquareW r0 r1 r2 r3)
           (expTwoMulIterRw r0 r1 r2 r3 a0 a1 a2 a3)) := by
   exact
     exp_msb_saved_bit_two_mul_full_iter_named_pre_canonical_with_mul_spec_within

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulSkip.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulSkip.lean
@@ -56,13 +56,13 @@ theorem exp_msb_saved_bit_prefix_squaring_beq_skip_then_loop_back_evm_exp_msb_sa
     (hskip : (base + 148 : Word) + signExtend13 skipOff = base + 256)
     (hback : ((base + 256) + 4 : Word) + signExtend13 backOff = loopTarget) :
     let bit := expTwoMulIterBit e
-    let w := expTwoMulIterW r0 r1 r2 r3
+    let squareW := expTwoMulSquareW r0 r1 r2 r3
     let rest : Assertion :=
       (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
       ⌜bit + signExtend12 (0 : BitVec 12) = 0⌝ **
       (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) **
-      (.x5 ↦ᵣ (w * w).getLimbN 3) **
-      evmWordIs sp (w * w) ** evmWordIs (evmSp + 32) (w * w) **
+      (.x5 ↦ᵣ squareW.getLimbN 3) **
+      evmWordIs sp squareW ** evmWordIs (evmSp + 32) squareW **
       regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
       memOwn evmSp ** memOwn (evmSp + 8) **
       memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
@@ -90,8 +90,8 @@ theorem exp_msb_saved_bit_prefix_squaring_beq_skip_then_loop_back_evm_exp_msb_sa
           ((.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
            (.x0 ↦ᵣ (0 : Word)) ** ⌜bit + signExtend12 (0 : BitVec 12) ≠ 0⌝ **
            (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) **
-           (.x5 ↦ᵣ (w * w).getLimbN 3) **
-           evmWordIs sp (w * w) ** evmWordIs (evmSp + 32) (w * w) **
+           (.x5 ↦ᵣ squareW.getLimbN 3) **
+           evmWordIs sp squareW ** evmWordIs (evmSp + 32) squareW **
            regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
            memOwn evmSp ** memOwn (evmSp + 8) **
            memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
@@ -102,7 +102,7 @@ theorem exp_msb_saved_bit_prefix_squaring_beq_skip_then_loop_back_evm_exp_msb_sa
         (base + 264,
           (((.x9 ↦ᵣ expTwoMulIterCountNew iterCount) ** (.x0 ↦ᵣ (0 : Word)) **
            ⌜expTwoMulIterCountNew iterCount = 0⌝) ** rest))] := by
-  intro bit w rest
+  intro bit squareW rest
   have hBranch :=
     exp_msb_saved_bit_prefix_squaring_then_beq_evm_exp_msb_saved_bit_two_mul_with_mul_spec_within
       e c v10 v18 sp evmSp vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
@@ -125,7 +125,7 @@ theorem exp_msb_saved_bit_prefix_squaring_beq_skip_then_loop_back_evm_exp_msb_sa
         _ _ :=
     cpsBranchWithin_cons_cpsNBranchWithin_with_perm_same_cr
       (fun _ hp => by
-        dsimp [rest, bit] at hp ⊢
+        dsimp [rest, bit, squareW, expTwoMulSquareW] at hp ⊢
         xperm_hyp hp)
       hBranchSwapped hLoopN
   have hSeqPre :
@@ -170,7 +170,7 @@ theorem exp_msb_saved_bit_prefix_squaring_beq_skip_then_loop_back_with_base_fram
     (hskip : (base + 148 : Word) + signExtend13 skipOff = base + 256)
     (hback : ((base + 256) + 4 : Word) + signExtend13 backOff = loopTarget) :
     let bit := expTwoMulIterBit e
-    let w := expTwoMulIterW r0 r1 r2 r3
+    let squareW := expTwoMulSquareW r0 r1 r2 r3
     let baseFrame : Assertion :=
       ((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
       ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **
@@ -180,8 +180,8 @@ theorem exp_msb_saved_bit_prefix_squaring_beq_skip_then_loop_back_with_base_fram
       (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
       ⌜bit + signExtend12 (0 : BitVec 12) = 0⌝ **
       (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) **
-      (.x5 ↦ᵣ (w * w).getLimbN 3) **
-      evmWordIs sp (w * w) ** evmWordIs (evmSp + 32) (w * w) **
+      (.x5 ↦ᵣ squareW.getLimbN 3) **
+      evmWordIs sp squareW ** evmWordIs (evmSp + 32) squareW **
       regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
       memOwn evmSp ** memOwn (evmSp + 8) **
       memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
@@ -209,8 +209,8 @@ theorem exp_msb_saved_bit_prefix_squaring_beq_skip_then_loop_back_with_base_fram
           (((.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
            (.x0 ↦ᵣ (0 : Word)) ** ⌜bit + signExtend12 (0 : BitVec 12) ≠ 0⌝ **
            (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) **
-           (.x5 ↦ᵣ (w * w).getLimbN 3) **
-           evmWordIs sp (w * w) ** evmWordIs (evmSp + 32) (w * w) **
+           (.x5 ↦ᵣ squareW.getLimbN 3) **
+           evmWordIs sp squareW ** evmWordIs (evmSp + 32) squareW **
            regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
            memOwn evmSp ** memOwn (evmSp + 8) **
            memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
@@ -221,7 +221,7 @@ theorem exp_msb_saved_bit_prefix_squaring_beq_skip_then_loop_back_with_base_fram
         (base + 264,
           ((((.x9 ↦ᵣ expTwoMulIterCountNew iterCount) ** (.x0 ↦ᵣ (0 : Word)) **
            ⌜expTwoMulIterCountNew iterCount = 0⌝) ** rest) ** baseFrame))] := by
-  intro bit w baseFrame rest
+  intro bit squareW baseFrame rest
   have h :=
     exp_msb_saved_bit_prefix_squaring_beq_skip_then_loop_back_evm_exp_msb_saved_bit_two_mul_with_mul_spec_within
       e c iterCount v10 v18 sp evmSp vOld r0 r1 r2 r3 d0 d1 d2 d3

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulSkipCanonical.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulSkipCanonical.lean
@@ -65,13 +65,13 @@ theorem exp_msb_saved_bit_prefix_squaring_beq_skip_then_loop_back_evm_exp_msb_sa
               base squaringMulOff condMulOff)
             (mul_callable_code mulTarget)) :
     let bit := expTwoMulIterBit e
-    let w := expTwoMulIterW r0 r1 r2 r3
+    let squareW := expTwoMulSquareW r0 r1 r2 r3
     let rest : Assertion :=
       (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
       ⌜bit + signExtend12 (0 : BitVec 12) = 0⌝ **
       (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) **
-      (.x5 ↦ᵣ (w * w).getLimbN 3) **
-      evmWordIs sp (w * w) ** evmWordIs (evmSp + 32) (w * w) **
+      (.x5 ↦ᵣ squareW.getLimbN 3) **
+      evmWordIs sp squareW ** evmWordIs (evmSp + 32) squareW **
       regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
       memOwn evmSp ** memOwn (evmSp + 8) **
       memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
@@ -99,8 +99,8 @@ theorem exp_msb_saved_bit_prefix_squaring_beq_skip_then_loop_back_evm_exp_msb_sa
           ((.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
            (.x0 ↦ᵣ (0 : Word)) ** ⌜bit + signExtend12 (0 : BitVec 12) ≠ 0⌝ **
            (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) **
-           (.x5 ↦ᵣ (w * w).getLimbN 3) **
-           evmWordIs sp (w * w) ** evmWordIs (evmSp + 32) (w * w) **
+           (.x5 ↦ᵣ squareW.getLimbN 3) **
+           evmWordIs sp squareW ** evmWordIs (evmSp + 32) squareW **
            regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
            memOwn evmSp ** memOwn (evmSp + 8) **
            memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
@@ -136,13 +136,13 @@ theorem exp_msb_saved_bit_prefix_squaring_beq_skip_then_loop_back_evm_exp_msb_sa
     (base : Word)
     (hbase : base &&& 1 = 0) :
     let bit := expTwoMulIterBit e
-    let w := expTwoMulIterW r0 r1 r2 r3
+    let squareW := expTwoMulSquareW r0 r1 r2 r3
     let rest : Assertion :=
       (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
       ⌜bit + signExtend12 (0 : BitVec 12) = 0⌝ **
       (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) **
-      (.x5 ↦ᵣ (w * w).getLimbN 3) **
-      evmWordIs sp (w * w) ** evmWordIs (evmSp + 32) (w * w) **
+      (.x5 ↦ᵣ squareW.getLimbN 3) **
+      evmWordIs sp squareW ** evmWordIs (evmSp + 32) squareW **
       regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
       memOwn evmSp ** memOwn (evmSp + 8) **
       memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
@@ -169,8 +169,8 @@ theorem exp_msb_saved_bit_prefix_squaring_beq_skip_then_loop_back_evm_exp_msb_sa
           ((.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
            (.x0 ↦ᵣ (0 : Word)) ** ⌜bit + signExtend12 (0 : BitVec 12) ≠ 0⌝ **
            (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) **
-           (.x5 ↦ᵣ (w * w).getLimbN 3) **
-           evmWordIs sp (w * w) ** evmWordIs (evmSp + 32) (w * w) **
+           (.x5 ↦ᵣ squareW.getLimbN 3) **
+           evmWordIs sp squareW ** evmWordIs (evmSp + 32) squareW **
            regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
            memOwn evmSp ** memOwn (evmSp + 8) **
            memOwn (evmSp + 16) ** memOwn (evmSp + 24) **


### PR DESCRIPTION
## Summary
- make the saved-bit iter skip post carry the named squared word directly
- route iter-post and merge continuation surfaces through expTwoMulSquareW

## Validation
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitIterMerge
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitFullLoopCanonical
- git diff --check
- rg -n "set_option maxHeartbeats|set_option maxRecDepth|sorry|admit" EvmAsm/Evm64/Exp/Compose/SavedBitIterPosts.lean EvmAsm/Evm64/Exp/Compose/SavedBitIterMerge.lean
- wc -l EvmAsm/Evm64/Exp/Compose/SavedBitIterPosts.lean EvmAsm/Evm64/Exp/Compose/SavedBitIterMerge.lean
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build