### PR TITLE
refactor(exp): extract squaring-call square helper

### DIFF
--- a/EvmAsm/Evm64/Exp/SquaringPairThenMulCall.lean
+++ b/EvmAsm/Evm64/Exp/SquaringPairThenMulCall.lean
@@ -36,6 +36,10 @@ open EvmAsm.Rv64 (Assertion CodeReq cpsTripleWithin cpsTripleWithin_extend_code
   cpsTripleWithin_seq cpsTripleWithin_seq_perm_same_cr cpsTripleWithin_weaken
   memOwn regOwn signExtend12 signExtend21)
 
+abbrev expSquaringCallSquareW (r0 r1 r2 r3 : Word) : EvmWord :=
+  let w := expResultWord r0 r1 r2 r3
+  w * w
+
 /-- Code required by the squaring-call block plus the out-of-line
     `mul_callable` body reached by the JAL inside the block. -/
 abbrev exp_squaring_call_with_mul_code
@@ -212,7 +216,7 @@ theorem exp_loop_un_marshal_and_restore_word_spec_within_regOwn5
       `w := expResultWord r0 r1 r2 r3` (squaring of the limb-packed
       result word): `(.x12 ↦ᵣ evmSp + 32)`, `regOwn` on the
       caller-saved scratch registers, `memOwn` on the four bytes
-      below the new LP64 sp, and `evmWordIs (evmSp + 32) (w * w)`.
+      below the new LP64 sp, and `evmWordIs (evmSp + 32) squareW`.
     * `(.x1 ↦ᵣ (base + 68))` — `mul_callable` preserves `.x1`. -/
 theorem exp_squaring_marshal_pair_then_mul_call_spec_within
     (sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
@@ -355,9 +359,7 @@ theorem exp_squaring_call_block_spec_within
     (hd : CodeReq.Disjoint
             (exp_squaring_call_block_code base mulOff)
             (mul_callable_code mul_target)) :
-    let squareW :=
-      let w := expResultWord r0 r1 r2 r3
-      w * w
+    let squareW := expSquaringCallSquareW r0 r1 r2 r3
     cpsTripleWithin (17 + 64 + 9) base (base + 104)
       ((exp_squaring_call_block_code base mulOff).union
         (mul_callable_code mul_target))


### PR DESCRIPTION
## Summary
- add expSquaringCallSquareW for the lower-level EXP squaring-call result
- use the helper in exp_squaring_call_block_spec_within so the theorem no longer carries a nested square let

## Validation
- lake build EvmAsm.Evm64.Exp.SquaringPairThenMulCall EvmAsm.Evm64.Exp.Compose.SavedBitFullLoop EvmAsm.Evm64.Exp.Compose.FullLoop
- git diff --check
- rg -n "set_option maxHeartbeats|set_option maxRecDepth|sorry|admit" EvmAsm/Evm64/Exp/SquaringPairThenMulCall.lean
- wc -l EvmAsm/Evm64/Exp/SquaringPairThenMulCall.lean
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build