### PR TITLE
refactor(exp): reuse squaring-call square helper

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/FullLoop.lean
+++ b/EvmAsm/Evm64/Exp/Compose/FullLoop.lean
@@ -45,8 +45,7 @@ abbrev expCondMulRwFromLimbs
   expCondMulRw (expResultWord r0 r1 r2 r3) a0 a1 a2 a3
 
 abbrev expSquareRw (r0 r1 r2 r3 : Word) : EvmWord :=
-  let w := expResultWord r0 r1 r2 r3
-  w * w
+  expSquaringCallSquareW r0 r1 r2 r3
 
 /-- Lift a top-level EXP-body spec into the combined EXP+MUL code bundle. -/
 theorem cpsTripleWithin_extend_evmExpWithMulCode {nSteps : Nat}


### PR DESCRIPTION
## Summary
- route Compose.FullLoop's expSquareRw through expSquaringCallSquareW
- keep the public compose helper name stable while removing the duplicate square body

## Validation
- lake build EvmAsm.Evm64.Exp.Compose.FullLoop EvmAsm.Evm64.Exp.Compose.SavedBitFullLoop
- git diff --check
- rg -n "set_option maxHeartbeats|set_option maxRecDepth|sorry|admit" EvmAsm/Evm64/Exp/Compose/FullLoop.lean
- wc -l EvmAsm/Evm64/Exp/Compose/FullLoop.lean
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build