### PR TITLE
refactor(exp): drop obsolete cond-mul alias

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/FullLoop.lean
+++ b/EvmAsm/Evm64/Exp/Compose/FullLoop.lean
@@ -37,9 +37,6 @@ theorem evmExpWithMulCode_mul_sub {base mulTarget : Word}
   unfold evmExpWithMulCode
   exact CodeReq.mono_union_right hd (fun _ _ h => h)
 
-abbrev expCondMulRw (r : EvmWord) (a0 a1 a2 a3 : Word) : EvmWord :=
-  r * expResultWord a0 a1 a2 a3
-
 abbrev expCondMulRwFromLimbs
     (r0 r1 r2 r3 a0 a1 a2 a3 : Word) : EvmWord :=
   expCondMulRw (expResultWord r0 r1 r2 r3) a0 a1 a2 a3


### PR DESCRIPTION
## Summary
- remove the now-unused expCondMulRw alias from FullLoop
- keep expCondMulRwFromLimbs pointed at the shared expCondMulCallProductW helper

## Validation
- lake build EvmAsm.Evm64.Exp.Compose.FullLoop
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- lake build