### PR TITLE
refactor(sdiv): extract bzero resultsignfix

### DIFF
--- a/EvmAsm/Evm64/SDiv.lean
+++ b/EvmAsm/Evm64/SDiv.lean
@@ -31,6 +31,7 @@ import EvmAsm.Evm64.SDiv.Compose.BzeroPost
 import EvmAsm.Evm64.SDiv.Compose.DispatchReadyPost
 import EvmAsm.Evm64.SDiv.Compose.DispatchPrefix
 import EvmAsm.Evm64.SDiv.Compose.BzeroCallable
+import EvmAsm.Evm64.SDiv.Compose.BzeroResultSignFix
 import EvmAsm.Evm64.SDiv.Compose.DivCallDispatch
 import EvmAsm.Evm64.SDiv.Compose.DivCallResultSignFix
 import EvmAsm.Evm64.SDiv.Compose.DivCallPostPcFree

--- a/EvmAsm/Evm64/SDiv/Compose/BzeroResultSignFix.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroResultSignFix.lean
@@ -1,0 +1,80 @@
+/-
+  EvmAsm.Evm64.SDiv.Compose.BzeroResultSignFix
+
+  SDIV zero-divisor path through result-sign fixup.
+-/
+
+import EvmAsm.Evm64.SDiv.Compose.BzeroCallable
+import EvmAsm.Evm64.SDiv.Compose.ResultSignFixOwn
+
+namespace EvmAsm.Evm64.SDiv.Compose
+
+open EvmAsm.Rv64.Tactics
+open EvmAsm.Rv64
+
+/-- SDIV zero-divisor path through the final result sign-fix block. The
+    unsigned DIV callable has already produced a zero quotient at the current
+    stack top, so this composes the named callable post with
+    `resultSignFix_regOwn_scratch_spec_in_sdivCode`. -/
+theorem saveRa_signs_abs_signXor_then_divCall_bzero_then_resultSignFix_spec_in_sdivCode
+    (vRa vSavedOld sp sDividendOld sDivisorOld
+      dividendMaskOld dividendValueOld dividendCarryOld
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+      v2 v5 v6 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (base : Word) (hbase : base &&& 1 = 0)
+    (hbz : sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop = 0) :
+    cpsTripleWithin ((49 + (EvmAsm.Evm64.unifiedDivBound + 1)) + 21)
+      base ((base + resultSignFixOff) + 84) (sdivCode base)
+      (saveRaSignsAbsSignXorThenDivCallPre vRa vSavedOld sp sDividendOld sDivisorOld
+        dividendMaskOld dividendValueOld dividendCarryOld
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
+       ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
+        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0))
+      (let dividendAbsWord :=
+         sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+       let resultSign :=
+         (dividendTop >>> (63 : BitVec 6).toNat) ^^^
+           (divisorTop >>> (63 : BitVec 6).toNat)
+       let divisorSign := divisorTop >>> (63 : BitVec 6).toNat
+       resultSignFixPost (sp + 32) resultSign 0 0 0 0 **
+       saveRaDivCallBzeroResultSignFixFrame vRa sp base divisorSign dividendAbsWord) := by
+  let dividendAbsWord :=
+    sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+  let resultSign :=
+    (dividendTop >>> (63 : BitVec 6).toNat) ^^^
+      (divisorTop >>> (63 : BitVec 6).toNat)
+  let divisorSign := divisorTop >>> (63 : BitVec 6).toNat
+  have hPrefix :=
+    saveRa_signs_abs_signXor_then_divCall_bzero_callable_named_post_spec_in_sdivCode
+      vRa vSavedOld sp sDividendOld sDivisorOld
+      dividendMaskOld dividendValueOld dividendCarryOld
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+      v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 base hbase hbz
+  have hFramePc :
+      (saveRaDivCallBzeroResultSignFixFrame
+        vRa sp base divisorSign dividendAbsWord).pcFree := by
+    rw [saveRaDivCallBzeroResultSignFixFrame_unfold,
+      EvmAsm.Evm64.divScratchOwnCall_unfold,
+      EvmAsm.Evm64.divScratchOwn_unfold]
+    pcFree
+  have hFix :=
+    cpsTripleWithin_frameR
+      (saveRaDivCallBzeroResultSignFixFrame
+        vRa sp base divisorSign dividendAbsWord)
+      hFramePc
+      (resultSignFix_regOwn_scratch_spec_in_sdivCode
+        (sp + 32) resultSign 0 0 0 0 base)
+  exact cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by
+      rw [saveRaDivCallBzeroCallablePost_resultSignFixPreOwnScratch hbz] at hp
+      exact hp)
+    hPrefix hFix
+
+end EvmAsm.Evm64.SDiv.Compose

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallDispatch.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallDispatch.lean
@@ -17,6 +17,7 @@ import EvmAsm.Evm64.SDiv.Compose.DivCall
 import EvmAsm.Evm64.SDiv.Compose.Bridges
 import EvmAsm.Evm64.SDiv.Compose.BzeroPost
 import EvmAsm.Evm64.SDiv.Compose.BzeroCallable
+import EvmAsm.Evm64.SDiv.Compose.BzeroResultSignFix
 import EvmAsm.Evm64.SDiv.Compose.DispatchReadyPost
 import EvmAsm.Evm64.SDiv.Compose.DispatchPrefix
 import EvmAsm.Evm64.SDiv.Compose.DispatchViews
@@ -27,71 +28,6 @@ namespace EvmAsm.Evm64.SDiv.Compose
 
 open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
-
-/-- SDIV zero-divisor path through the final result sign-fix block. The
-    unsigned DIV callable has already produced a zero quotient at the current
-    stack top, so this composes the named callable post with
-    `resultSignFix_regOwn_scratch_spec_in_sdivCode`. -/
-theorem saveRa_signs_abs_signXor_then_divCall_bzero_then_resultSignFix_spec_in_sdivCode
-    (vRa vSavedOld sp sDividendOld sDivisorOld
-      dividendMaskOld dividendValueOld dividendCarryOld
-      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
-      v2 v5 v6 : Word)
-    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-     shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
-    (base : Word) (hbase : base &&& 1 = 0)
-    (hbz : sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop = 0) :
-    cpsTripleWithin ((49 + (EvmAsm.Evm64.unifiedDivBound + 1)) + 21)
-      base ((base + resultSignFixOff) + 84) (sdivCode base)
-      (saveRaSignsAbsSignXorThenDivCallPre vRa vSavedOld sp sDividendOld sDivisorOld
-        dividendMaskOld dividendValueOld dividendCarryOld
-        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
-       ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
-        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-          shiftMem nMem jMem retMem dMem dloMem scratchUn0))
-      (let dividendAbsWord :=
-         sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-       let resultSign :=
-         (dividendTop >>> (63 : BitVec 6).toNat) ^^^
-           (divisorTop >>> (63 : BitVec 6).toNat)
-       let divisorSign := divisorTop >>> (63 : BitVec 6).toNat
-       resultSignFixPost (sp + 32) resultSign 0 0 0 0 **
-       saveRaDivCallBzeroResultSignFixFrame vRa sp base divisorSign dividendAbsWord) := by
-  let dividendAbsWord :=
-    sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-  let resultSign :=
-    (dividendTop >>> (63 : BitVec 6).toNat) ^^^
-      (divisorTop >>> (63 : BitVec 6).toNat)
-  let divisorSign := divisorTop >>> (63 : BitVec 6).toNat
-  have hPrefix :=
-    saveRa_signs_abs_signXor_then_divCall_bzero_callable_named_post_spec_in_sdivCode
-      vRa vSavedOld sp sDividendOld sDivisorOld
-      dividendMaskOld dividendValueOld dividendCarryOld
-      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
-      v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-      shiftMem nMem jMem retMem dMem dloMem scratchUn0 base hbase hbz
-  have hFramePc :
-      (saveRaDivCallBzeroResultSignFixFrame
-        vRa sp base divisorSign dividendAbsWord).pcFree := by
-    rw [saveRaDivCallBzeroResultSignFixFrame_unfold,
-      EvmAsm.Evm64.divScratchOwnCall_unfold,
-      EvmAsm.Evm64.divScratchOwn_unfold]
-    pcFree
-  have hFix :=
-    cpsTripleWithin_frameR
-      (saveRaDivCallBzeroResultSignFixFrame
-        vRa sp base divisorSign dividendAbsWord)
-      hFramePc
-      (resultSignFix_regOwn_scratch_spec_in_sdivCode
-        (sp + 32) resultSign 0 0 0 0 base)
-  exact cpsTripleWithin_seq_perm_same_cr
-    (fun _ hp => by
-      rw [saveRaDivCallBzeroCallablePost_resultSignFixPreOwnScratch hbz] at hp
-      exact hp)
-    hPrefix hFix
 
 /-- SDIV zero-divisor path through the saved-RA return instruction. -/
 theorem saveRa_signs_abs_signXor_then_divCall_bzero_then_return_spec_in_sdivCode


### PR DESCRIPTION
## Summary
- add Compose.BzeroResultSignFix for the zero-divisor path through result-sign fixup
- import that helper from DivCallDispatch so the remaining file focuses on return/stack-entry views
- wire the new module through the SDIV umbrella imports

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.BzeroResultSignFix
- lake build EvmAsm.Evm64.SDiv.Compose.DivCallDispatch
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/DivCallDispatch.lean EvmAsm/Evm64/SDiv/Compose/BzeroResultSignFix.lean EvmAsm/Evm64/SDiv.lean (no matches)
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build