### PR TITLE
refactor(sdiv): extract bzero return

### DIFF
--- a/EvmAsm/Evm64/SDiv.lean
+++ b/EvmAsm/Evm64/SDiv.lean
@@ -32,6 +32,7 @@ import EvmAsm.Evm64.SDiv.Compose.DispatchReadyPost
 import EvmAsm.Evm64.SDiv.Compose.DispatchPrefix
 import EvmAsm.Evm64.SDiv.Compose.BzeroCallable
 import EvmAsm.Evm64.SDiv.Compose.BzeroResultSignFix
+import EvmAsm.Evm64.SDiv.Compose.BzeroReturn
 import EvmAsm.Evm64.SDiv.Compose.DivCallDispatch
 import EvmAsm.Evm64.SDiv.Compose.DivCallResultSignFix
 import EvmAsm.Evm64.SDiv.Compose.DivCallPostPcFree

--- a/EvmAsm/Evm64/SDiv/Compose/BzeroReturn.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroReturn.lean
@@ -1,0 +1,95 @@
+/-
+  EvmAsm.Evm64.SDiv.Compose.BzeroReturn
+
+  SDIV zero-divisor path through the saved-RA return instruction.
+-/
+
+import EvmAsm.Evm64.SDiv.Compose.BzeroResultSignFix
+
+namespace EvmAsm.Evm64.SDiv.Compose
+
+open EvmAsm.Rv64.Tactics
+open EvmAsm.Rv64
+
+/-- SDIV zero-divisor path through the saved-RA return instruction. -/
+theorem saveRa_signs_abs_signXor_then_divCall_bzero_then_return_spec_in_sdivCode
+    (vRa vSavedOld sp sDividendOld sDivisorOld
+      dividendMaskOld dividendValueOld dividendCarryOld
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+      v2 v5 v6 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (base : Word) (hbase : base &&& 1 = 0)
+    (hbz : sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop = 0) :
+    cpsTripleWithin (((49 + (EvmAsm.Evm64.unifiedDivBound + 1)) + 21) + 1)
+      base (((vRa + signExtend12 (0 : BitVec 12)) +
+        signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word)) (sdivCode base)
+      (saveRaSignsAbsSignXorThenDivCallPre vRa vSavedOld sp sDividendOld sDivisorOld
+        dividendMaskOld dividendValueOld dividendCarryOld
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
+       ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
+        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0))
+      (let dividendAbsWord :=
+         sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+       let resultSign :=
+         (dividendTop >>> (63 : BitVec 6).toNat) ^^^
+           (divisorTop >>> (63 : BitVec 6).toNat)
+       let divisorSign := divisorTop >>> (63 : BitVec 6).toNat
+       (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12))) **
+       (resultSignFixPost (sp + 32) resultSign 0 0 0 0 **
+        saveRaDivCallBzeroSavedRaRetFrame sp base divisorSign dividendAbsWord)) := by
+  let dividendAbsWord :=
+    sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+  let resultSign :=
+    (dividendTop >>> (63 : BitVec 6).toNat) ^^^
+      (divisorTop >>> (63 : BitVec 6).toNat)
+  let divisorSign := divisorTop >>> (63 : BitVec 6).toNat
+  have hPrefix :=
+    saveRa_signs_abs_signXor_then_divCall_bzero_then_resultSignFix_spec_in_sdivCode
+      vRa vSavedOld sp sDividendOld sDivisorOld
+      dividendMaskOld dividendValueOld dividendCarryOld
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+      v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 base hbase hbz
+  have hRetFramePc :
+      (resultSignFixPost (sp + 32) resultSign 0 0 0 0 **
+        saveRaDivCallBzeroSavedRaRetFrame sp base divisorSign dividendAbsWord).pcFree := by
+    rw [resultSignFixPost_unfold, saveRaDivCallBzeroSavedRaRetFrame_unfold,
+      EvmAsm.Evm64.divScratchOwnCall_unfold,
+      EvmAsm.Evm64.divScratchOwn_unfold]
+    pcFree
+  have hRetFramed :=
+    cpsTripleWithin_frameR
+      (resultSignFixPost (sp + 32) resultSign 0 0 0 0 **
+        saveRaDivCallBzeroSavedRaRetFrame sp base divisorSign dividendAbsWord)
+      hRetFramePc
+      (savedRaRet_spec_in_sdivCode
+        (vRa + signExtend12 (0 : BitVec 12)) base)
+  have hFall :
+      (base + resultSignFixOff) + 84 = base + savedRaRetOff := by
+    simp [resultSignFixOff, savedRaRetOff]
+    bv_addr
+  have hRetFramed' :
+      cpsTripleWithin 1 ((base + resultSignFixOff) + 84)
+        (((vRa + signExtend12 (0 : BitVec 12)) +
+          signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word))
+        (sdivCode base)
+        ((.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12))) **
+         (resultSignFixPost (sp + 32) resultSign 0 0 0 0 **
+          saveRaDivCallBzeroSavedRaRetFrame sp base divisorSign dividendAbsWord))
+        ((.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12))) **
+         (resultSignFixPost (sp + 32) resultSign 0 0 0 0 **
+          saveRaDivCallBzeroSavedRaRetFrame sp base divisorSign dividendAbsWord)) := by
+    rw [hFall]
+    exact hRetFramed
+  exact cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by
+      rw [saveRaDivCallBzeroResultSignFixFrame_to_savedRaRet] at hp
+      xperm_hyp hp)
+    hPrefix hRetFramed'
+
+end EvmAsm.Evm64.SDiv.Compose

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallDispatch.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallDispatch.lean
@@ -18,6 +18,7 @@ import EvmAsm.Evm64.SDiv.Compose.Bridges
 import EvmAsm.Evm64.SDiv.Compose.BzeroPost
 import EvmAsm.Evm64.SDiv.Compose.BzeroCallable
 import EvmAsm.Evm64.SDiv.Compose.BzeroResultSignFix
+import EvmAsm.Evm64.SDiv.Compose.BzeroReturn
 import EvmAsm.Evm64.SDiv.Compose.DispatchReadyPost
 import EvmAsm.Evm64.SDiv.Compose.DispatchPrefix
 import EvmAsm.Evm64.SDiv.Compose.DispatchViews
@@ -28,87 +29,6 @@ namespace EvmAsm.Evm64.SDiv.Compose
 
 open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
-
-/-- SDIV zero-divisor path through the saved-RA return instruction. -/
-theorem saveRa_signs_abs_signXor_then_divCall_bzero_then_return_spec_in_sdivCode
-    (vRa vSavedOld sp sDividendOld sDivisorOld
-      dividendMaskOld dividendValueOld dividendCarryOld
-      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
-      v2 v5 v6 : Word)
-    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-     shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
-    (base : Word) (hbase : base &&& 1 = 0)
-    (hbz : sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop = 0) :
-    cpsTripleWithin (((49 + (EvmAsm.Evm64.unifiedDivBound + 1)) + 21) + 1)
-      base (((vRa + signExtend12 (0 : BitVec 12)) +
-        signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word)) (sdivCode base)
-      (saveRaSignsAbsSignXorThenDivCallPre vRa vSavedOld sp sDividendOld sDivisorOld
-        dividendMaskOld dividendValueOld dividendCarryOld
-        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
-       ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
-        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-          shiftMem nMem jMem retMem dMem dloMem scratchUn0))
-      (let dividendAbsWord :=
-         sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-       let resultSign :=
-         (dividendTop >>> (63 : BitVec 6).toNat) ^^^
-           (divisorTop >>> (63 : BitVec 6).toNat)
-       let divisorSign := divisorTop >>> (63 : BitVec 6).toNat
-       (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12))) **
-       (resultSignFixPost (sp + 32) resultSign 0 0 0 0 **
-        saveRaDivCallBzeroSavedRaRetFrame sp base divisorSign dividendAbsWord)) := by
-  let dividendAbsWord :=
-    sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-  let resultSign :=
-    (dividendTop >>> (63 : BitVec 6).toNat) ^^^
-      (divisorTop >>> (63 : BitVec 6).toNat)
-  let divisorSign := divisorTop >>> (63 : BitVec 6).toNat
-  have hPrefix :=
-    saveRa_signs_abs_signXor_then_divCall_bzero_then_resultSignFix_spec_in_sdivCode
-      vRa vSavedOld sp sDividendOld sDivisorOld
-      dividendMaskOld dividendValueOld dividendCarryOld
-      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
-      v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-      shiftMem nMem jMem retMem dMem dloMem scratchUn0 base hbase hbz
-  have hRetFramePc :
-      (resultSignFixPost (sp + 32) resultSign 0 0 0 0 **
-        saveRaDivCallBzeroSavedRaRetFrame sp base divisorSign dividendAbsWord).pcFree := by
-    rw [resultSignFixPost_unfold, saveRaDivCallBzeroSavedRaRetFrame_unfold,
-      EvmAsm.Evm64.divScratchOwnCall_unfold,
-      EvmAsm.Evm64.divScratchOwn_unfold]
-    pcFree
-  have hRetFramed :=
-    cpsTripleWithin_frameR
-      (resultSignFixPost (sp + 32) resultSign 0 0 0 0 **
-        saveRaDivCallBzeroSavedRaRetFrame sp base divisorSign dividendAbsWord)
-      hRetFramePc
-      (savedRaRet_spec_in_sdivCode
-        (vRa + signExtend12 (0 : BitVec 12)) base)
-  have hFall :
-      (base + resultSignFixOff) + 84 = base + savedRaRetOff := by
-    simp [resultSignFixOff, savedRaRetOff]
-    bv_addr
-  have hRetFramed' :
-      cpsTripleWithin 1 ((base + resultSignFixOff) + 84)
-        (((vRa + signExtend12 (0 : BitVec 12)) +
-          signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word))
-        (sdivCode base)
-        ((.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12))) **
-         (resultSignFixPost (sp + 32) resultSign 0 0 0 0 **
-          saveRaDivCallBzeroSavedRaRetFrame sp base divisorSign dividendAbsWord))
-        ((.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12))) **
-         (resultSignFixPost (sp + 32) resultSign 0 0 0 0 **
-          saveRaDivCallBzeroSavedRaRetFrame sp base divisorSign dividendAbsWord)) := by
-    rw [hFall]
-    exact hRetFramed
-  exact cpsTripleWithin_seq_perm_same_cr
-    (fun _ hp => by
-      rw [saveRaDivCallBzeroResultSignFixFrame_to_savedRaRet] at hp
-      xperm_hyp hp)
-    hPrefix hRetFramed'
 
 /-- Normalized return-target view of the SDIV zero-divisor path. This hides
     the two `signExtend12 0` artifacts introduced by the saved-RA move and


### PR DESCRIPTION
## Summary
- add Compose.BzeroReturn for the zero-divisor path through the saved-RA return instruction
- import that helper from DivCallDispatch so the remaining file focuses on normalized/stack-entry views
- wire the new module through the SDIV umbrella imports

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.BzeroReturn
- lake build EvmAsm.Evm64.SDiv.Compose.DivCallDispatch
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/DivCallDispatch.lean EvmAsm/Evm64/SDiv/Compose/BzeroReturn.lean EvmAsm/Evm64/SDiv.lean (no matches)
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build