### PR TITLE
refactor(exp): extract squaring call block

### DIFF
--- a/EvmAsm/Evm64/Exp.lean
+++ b/EvmAsm/Evm64/Exp.lean
@@ -34,6 +34,7 @@ import EvmAsm.Evm64.Exp.Compose.TopCodeSpecs
 import EvmAsm.Evm64.Exp.Compose.WithMulCode
 import EvmAsm.Evm64.Exp.Compose.SquaringCallPath
 import EvmAsm.Evm64.Exp.Compose.CondMulCallPath
+import EvmAsm.Evm64.Exp.Compose.SquaringCallBlock
 import EvmAsm.Evm64.Exp.Compose.FullLoop
 import EvmAsm.Evm64.Exp.Compose.SavedBitWithMul
 import EvmAsm.Evm64.Exp.Compose.SavedBitFullLoop

--- a/EvmAsm/Evm64/Exp/Compose/FullLoop.lean
+++ b/EvmAsm/Evm64/Exp/Compose/FullLoop.lean
@@ -9,6 +9,7 @@
 import EvmAsm.Evm64.Exp.Compose.WithMulCode
 import EvmAsm.Evm64.Exp.Compose.SquaringCallPath
 import EvmAsm.Evm64.Exp.Compose.CondMulCallPath
+import EvmAsm.Evm64.Exp.Compose.SquaringCallBlock
 import EvmAsm.Evm64.Exp.SquaringPairThenMulCall
 import EvmAsm.Evm64.Exp.CondMulPairThenMulCall
 import EvmAsm.Evm64.Multiply.Callable
@@ -267,72 +268,6 @@ theorem exp_cond_mul_beq_evm_exp_with_mul_spec_within
   cpsBranchWithin_extend_evmExpWithMulCode
     (exp_cond_mul_beq_evm_exp_spec_within
       mulOff skipOff backOff v10 base target htarget)
-
-/-- Squaring-side full call-block (`marshal_pair + JAL + mul_callable +
-    un_marshal_and_restore`, 90 instrs) lifted from the disjoint-union
-    code into the full-loop `evmExpWithMulCode` bundle. Instantiates
-    `EvmAsm.Evm64.exp_squaring_call_block_spec_within` at offset `base + 40`
-    (the squaring-call sub-block entry inside the iteration body). -/
-theorem exp_squaring_call_block_evm_exp_with_mul_spec_within
-    (sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
-      v6 v7 v10 v11 mulTarget : Word)
-    (mulOff : BitVec 21) (skipOff backOff : BitVec 13) (base : Word)
-    (hbase : base &&& 1 = 0)
-    (hmt : mulTarget = ((base + 40) + 64) + signExtend21 mulOff)
-    (hd : CodeReq.Disjoint
-            (evmExpCode base mulOff skipOff backOff)
-            (mul_callable_code mulTarget)) :
-    let rw := expSquareRw r0 r1 r2 r3
-    cpsTripleWithin (17 + 64 + 9) (base + 40) ((base + 40) + 104)
-      (evmExpWithMulCode base mulTarget mulOff skipOff backOff)
-      ((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
-       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
-       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
-       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
-       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
-       ((evmSp + signExtend12 (0 : BitVec 12)) ↦ₘ d0) **
-       ((evmSp + signExtend12 (8 : BitVec 12)) ↦ₘ d1) **
-       ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ d2) **
-       ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ d3) **
-       ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ e0) **
-       ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ e1) **
-       ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ e2) **
-       ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ e3) **
-       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) **
-       (.x1 ↦ᵣ vOld))
-      ((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) **
-       (.x5 ↦ᵣ rw.getLimbN 3) **
-       evmWordIs sp rw ** evmWordIs (evmSp + 32) rw **
-       regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
-       memOwn evmSp ** memOwn (evmSp + 8) **
-       memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
-       (.x1 ↦ᵣ ((base + 40) + 68))) := by
-  intro rw
-  have hbase' : (base + 40 : Word) &&& 1 = 0 := by bv_decide
-  have hd_inner : CodeReq.Disjoint
-      (exp_squaring_call_block_code (base + 40) mulOff)
-      (mul_callable_code mulTarget) := by
-    intro a
-    rcases hd a with hExp | hMul
-    · left
-      cases hsub : exp_squaring_call_block_code (base + 40) mulOff a with
-      | none => rfl
-      | some i =>
-        have hev := evmExpCode_iter_squaring_sub
-          (base := base) (mulOff := mulOff)
-          (skipOff := skipOff) (backOff := backOff) a i hsub
-        exact absurd (hev.symm.trans hExp) (by simp)
-    · right; exact hMul
-  have hbase_spec := EvmAsm.Evm64.exp_squaring_call_block_spec_within
-    sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
-    v6 v7 v10 v11 mulTarget mulOff (base + 40) hbase' hmt hd_inner
-  exact cpsTripleWithin_extend_code
-    (hmono := CodeReq.union_sub
-      (fun a i h => evmExpWithMulCode_exp_sub a i
-        (evmExpCode_iter_squaring_sub
-          (base := base) (mulOff := mulOff)
-          (skipOff := skipOff) (backOff := backOff) a i h))
-      (fun a i h => evmExpWithMulCode_mul_sub hd a i h)) hbase_spec
 
 /-- Cond-mul-side full call-block (`marshal_pair + JAL + mul_callable +
     un_marshal_and_restore`, 90 instrs) lifted from the disjoint-union

--- a/EvmAsm/Evm64/Exp/Compose/SquaringCallBlock.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SquaringCallBlock.lean
@@ -1,0 +1,80 @@
+/-
+  EvmAsm.Evm64.Exp.Compose.SquaringCallBlock
+
+  Lift the complete squaring call block into the full-loop EXP+MUL code bundle.
+-/
+
+import EvmAsm.Evm64.Exp.Compose.SquaringCallPath
+
+namespace EvmAsm.Evm64.Exp.Compose
+
+open EvmAsm.Rv64
+
+/-- Squaring-side full call-block (`marshal_pair + JAL + mul_callable +
+    un_marshal_and_restore`, 90 instrs) lifted from the disjoint-union
+    code into the full-loop `evmExpWithMulCode` bundle. Instantiates
+    `EvmAsm.Evm64.exp_squaring_call_block_spec_within` at offset `base + 40`
+    (the squaring-call sub-block entry inside the iteration body). -/
+theorem exp_squaring_call_block_evm_exp_with_mul_spec_within
+    (sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+      v6 v7 v10 v11 mulTarget : Word)
+    (mulOff : BitVec 21) (skipOff backOff : BitVec 13) (base : Word)
+    (hbase : base &&& 1 = 0)
+    (hmt : mulTarget = ((base + 40) + 64) + signExtend21 mulOff)
+    (hd : CodeReq.Disjoint
+            (evmExpCode base mulOff skipOff backOff)
+            (mul_callable_code mulTarget)) :
+    let rw := expSquareRw r0 r1 r2 r3
+    cpsTripleWithin (17 + 64 + 9) (base + 40) ((base + 40) + 104)
+      (evmExpWithMulCode base mulTarget mulOff skipOff backOff)
+      ((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+       ((evmSp + signExtend12 (0 : BitVec 12)) ↦ₘ d0) **
+       ((evmSp + signExtend12 (8 : BitVec 12)) ↦ₘ d1) **
+       ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ d2) **
+       ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ d3) **
+       ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ e0) **
+       ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ e1) **
+       ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ e2) **
+       ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ e3) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) **
+       (.x1 ↦ᵣ vOld))
+      ((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) **
+       (.x5 ↦ᵣ rw.getLimbN 3) **
+       evmWordIs sp rw ** evmWordIs (evmSp + 32) rw **
+       regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
+       memOwn evmSp ** memOwn (evmSp + 8) **
+       memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
+       (.x1 ↦ᵣ ((base + 40) + 68))) := by
+  intro rw
+  have hbase' : (base + 40 : Word) &&& 1 = 0 := by bv_decide
+  have hd_inner : CodeReq.Disjoint
+      (exp_squaring_call_block_code (base + 40) mulOff)
+      (mul_callable_code mulTarget) := by
+    intro a
+    rcases hd a with hExp | hMul
+    · left
+      cases hsub : exp_squaring_call_block_code (base + 40) mulOff a with
+      | none => rfl
+      | some i =>
+        have hev := evmExpCode_iter_squaring_sub
+          (base := base) (mulOff := mulOff)
+          (skipOff := skipOff) (backOff := backOff) a i hsub
+        exact absurd (hev.symm.trans hExp) (by simp)
+    · right
+      exact hMul
+  have hbase_spec := EvmAsm.Evm64.exp_squaring_call_block_spec_within
+    sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+    v6 v7 v10 v11 mulTarget mulOff (base + 40) hbase' hmt hd_inner
+  exact cpsTripleWithin_extend_code
+    (hmono := CodeReq.union_sub
+      (fun a i h => evmExpWithMulCode_exp_sub a i
+        (evmExpCode_iter_squaring_sub
+          (base := base) (mulOff := mulOff)
+          (skipOff := skipOff) (backOff := backOff) a i h))
+      (fun a i h => evmExpWithMulCode_mul_sub hd a i h)) hbase_spec
+
+end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- add Compose.SquaringCallBlock for the squaring full call-block theorem
- import that helper from Compose.FullLoop so the remaining file focuses on cond-mul call-block and loop composition
- wire the new module through the EXP umbrella imports

## Validation
- lake build EvmAsm.Evm64.Exp.Compose.SquaringCallBlock
- lake build EvmAsm.Evm64.Exp.Compose.FullLoop
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/Compose/FullLoop.lean EvmAsm/Evm64/Exp/Compose/SquaringCallBlock.lean EvmAsm/Evm64/Exp.lean (no matches)
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build