### PR TITLE
refactor(exp): extract top jal blocks

### DIFF
--- a/EvmAsm/Evm64/Exp.lean
+++ b/EvmAsm/Evm64/Exp.lean
@@ -33,6 +33,7 @@ import EvmAsm.Evm64.Exp.Compose.TopBoundaryBlocks
 import EvmAsm.Evm64.Exp.Compose.TopIterSubs
 import EvmAsm.Evm64.Exp.Compose.TopLoopControl
 import EvmAsm.Evm64.Exp.Compose.TopCallSubs
+import EvmAsm.Evm64.Exp.Compose.TopJalBlocks
 import EvmAsm.Evm64.Exp.Compose.TopCodeSpecs
 import EvmAsm.Evm64.Exp.Compose.WithMulCode
 import EvmAsm.Evm64.Exp.Compose.LoopControlBlocks

--- a/EvmAsm/Evm64/Exp/Compose/TopCodeSpecs.lean
+++ b/EvmAsm/Evm64/Exp/Compose/TopCodeSpecs.lean
@@ -11,6 +11,7 @@ import EvmAsm.Evm64.Exp.Compose.TopBoundaryBlocks
 import EvmAsm.Evm64.Exp.Compose.TopIterSubs
 import EvmAsm.Evm64.Exp.Compose.TopLoopControl
 import EvmAsm.Evm64.Exp.Compose.TopCallSubs
+import EvmAsm.Evm64.Exp.Compose.TopJalBlocks
 import EvmAsm.Evm64.Exp.CondMulMarshalPair
 import EvmAsm.Evm64.Exp.SquaringCallSeq
 
@@ -18,36 +19,6 @@ namespace EvmAsm.Evm64.Exp.Compose
 
 open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
-
-/-- Squaring-call JAL spec lifted to the top-level EXP code bundle. -/
-theorem exp_squaring_square_evm_exp_spec_within
-    (mulOff : BitVec 21) (skipOff backOff : BitVec 13)
-    (vOld : Word) (base mulTarget : Word)
-    (hmul : ((base + 104) + signExtend21 mulOff : Word) = mulTarget) :
-    cpsTripleWithin 1 (base + 104) mulTarget
-      (evmExpCode base mulOff skipOff backOff)
-      (.x1 ↦ᵣ vOld)
-      (.x1 ↦ᵣ (base + 108)) := by
-  have h := EvmAsm.Evm64.exp_square_block_spec_within mulOff vOld (base + 104)
-  rw [hmul] at h
-  have hret : ((base + 104 : Word) + 4) = base + 108 := by bv_omega
-  rw [hret] at h
-  exact cpsTripleWithin_extend_code (h := h) (hmono := evmExpCode_squaring_square_sub)
-
-/-- Conditional-multiply JAL spec lifted to the top-level EXP code bundle. -/
-theorem exp_cond_mul_square_evm_exp_spec_within
-    (mulOff : BitVec 21) (skipOff backOff : BitVec 13)
-    (vOld : Word) (base mulTarget : Word)
-    (hmul : ((base + 212) + signExtend21 mulOff : Word) = mulTarget) :
-    cpsTripleWithin 1 (base + 212) mulTarget
-      (evmExpCode base mulOff skipOff backOff)
-      (.x1 ↦ᵣ vOld)
-      (.x1 ↦ᵣ (base + 216)) := by
-  have h := EvmAsm.Evm64.exp_square_block_spec_within mulOff vOld (base + 212)
-  rw [hmul] at h
-  have hret : ((base + 212 : Word) + 4) = base + 216 := by bv_omega
-  rw [hret] at h
-  exact cpsTripleWithin_extend_code (h := h) (hmono := evmExpCode_cond_mul_square_sub)
 
 /-- Squaring-call factor-1 marshal spec lifted to the top-level EXP code
     bundle: at offset `base + 40`, copies result limbs from scratch to

--- a/EvmAsm/Evm64/Exp/Compose/TopJalBlocks.lean
+++ b/EvmAsm/Evm64/Exp/Compose/TopJalBlocks.lean
@@ -1,0 +1,44 @@
+/-
+  EvmAsm.Evm64.Exp.Compose.TopJalBlocks
+
+  JAL specs lifted to the top-level EXP code bundle.
+-/
+
+import EvmAsm.Evm64.Exp.Compose.TopCallSubs
+
+namespace EvmAsm.Evm64.Exp.Compose
+
+open EvmAsm.Rv64.Tactics
+open EvmAsm.Rv64
+
+/-- Squaring-call JAL spec lifted to the top-level EXP code bundle. -/
+theorem exp_squaring_square_evm_exp_spec_within
+    (mulOff : BitVec 21) (skipOff backOff : BitVec 13)
+    (vOld : Word) (base mulTarget : Word)
+    (hmul : ((base + 104) + signExtend21 mulOff : Word) = mulTarget) :
+    cpsTripleWithin 1 (base + 104) mulTarget
+      (evmExpCode base mulOff skipOff backOff)
+      (.x1 ↦ᵣ vOld)
+      (.x1 ↦ᵣ (base + 108)) := by
+  have h := EvmAsm.Evm64.exp_square_block_spec_within mulOff vOld (base + 104)
+  rw [hmul] at h
+  have hret : ((base + 104 : Word) + 4) = base + 108 := by bv_omega
+  rw [hret] at h
+  exact cpsTripleWithin_extend_code (h := h) (hmono := evmExpCode_squaring_square_sub)
+
+/-- Conditional-multiply JAL spec lifted to the top-level EXP code bundle. -/
+theorem exp_cond_mul_square_evm_exp_spec_within
+    (mulOff : BitVec 21) (skipOff backOff : BitVec 13)
+    (vOld : Word) (base mulTarget : Word)
+    (hmul : ((base + 212) + signExtend21 mulOff : Word) = mulTarget) :
+    cpsTripleWithin 1 (base + 212) mulTarget
+      (evmExpCode base mulOff skipOff backOff)
+      (.x1 ↦ᵣ vOld)
+      (.x1 ↦ᵣ (base + 216)) := by
+  have h := EvmAsm.Evm64.exp_square_block_spec_within mulOff vOld (base + 212)
+  rw [hmul] at h
+  have hret : ((base + 212 : Word) + 4) = base + 216 := by bv_omega
+  rw [hret] at h
+  exact cpsTripleWithin_extend_code (h := h) (hmono := evmExpCode_cond_mul_square_sub)
+
+end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- move top-code squaring and conditional-multiply JAL lifted specs into `EvmAsm.Evm64.Exp.Compose.TopJalBlocks`
- keep `Compose.TopCodeSpecs` importing the new module so existing downstream imports still see the declarations
- import the new module from the EXP umbrella

## Validation
- `lake build EvmAsm.Evm64.Exp.Compose.TopJalBlocks`
- `lake build EvmAsm.Evm64.Exp.Compose.TopCodeSpecs`
- `git diff --check`
- `rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp.lean EvmAsm/Evm64/Exp/Compose/TopCodeSpecs.lean EvmAsm/Evm64/Exp/Compose/TopJalBlocks.lean` (no matches)
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `lake build`