### PR TITLE
refactor(exp): extract top squaring marshal blocks

### DIFF
--- a/EvmAsm/Evm64/Exp.lean
+++ b/EvmAsm/Evm64/Exp.lean
@@ -34,6 +34,7 @@ import EvmAsm.Evm64.Exp.Compose.TopIterSubs
 import EvmAsm.Evm64.Exp.Compose.TopLoopControl
 import EvmAsm.Evm64.Exp.Compose.TopCallSubs
 import EvmAsm.Evm64.Exp.Compose.TopJalBlocks
+import EvmAsm.Evm64.Exp.Compose.TopSquaringMarshalBlocks
 import EvmAsm.Evm64.Exp.Compose.TopCodeSpecs
 import EvmAsm.Evm64.Exp.Compose.WithMulCode
 import EvmAsm.Evm64.Exp.Compose.LoopControlBlocks

--- a/EvmAsm/Evm64/Exp/Compose/TopCodeSpecs.lean
+++ b/EvmAsm/Evm64/Exp/Compose/TopCodeSpecs.lean
@@ -12,6 +12,7 @@ import EvmAsm.Evm64.Exp.Compose.TopIterSubs
 import EvmAsm.Evm64.Exp.Compose.TopLoopControl
 import EvmAsm.Evm64.Exp.Compose.TopCallSubs
 import EvmAsm.Evm64.Exp.Compose.TopJalBlocks
+import EvmAsm.Evm64.Exp.Compose.TopSquaringMarshalBlocks
 import EvmAsm.Evm64.Exp.CondMulMarshalPair
 import EvmAsm.Evm64.Exp.SquaringCallSeq
 
@@ -19,107 +20,6 @@ namespace EvmAsm.Evm64.Exp.Compose
 
 open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
-
-/-- Squaring-call factor-1 marshal spec lifted to the top-level EXP code
-    bundle: at offset `base + 40`, copies result limbs from scratch to
-    factor1, exits at `base + 72`. -/
-theorem exp_squaring_marshal_factor1_evm_exp_spec_within
-    (mulOff : BitVec 21) (skipOff backOff : BitVec 13)
-    (sp evmSp tOld r0 r1 r2 r3 d0 d1 d2 d3 : Word) (base : Word) :
-    cpsTripleWithin 8 (base + 40) (base + 72)
-      (evmExpCode base mulOff skipOff backOff)
-      ((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
-       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
-       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
-       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
-       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
-       ((evmSp + signExtend12 (0 : BitVec 12)) ↦ₘ d0) **
-       ((evmSp + signExtend12 (8 : BitVec 12)) ↦ₘ d1) **
-       ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ d2) **
-       ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ d3))
-      ((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ r3) **
-       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
-       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
-       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
-       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
-       ((evmSp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
-       ((evmSp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
-       ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
-       ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ r3)) := by
-  have h := EvmAsm.Evm64.exp_loop_marshal_factor1_ofProg_spec_within
-    sp evmSp tOld r0 r1 r2 r3 d0 d1 d2 d3 (base + 40)
-  have hexit : ((base + 40 : Word) + 32) = base + 72 := by bv_omega
-  rw [hexit] at h
-  exact cpsTripleWithin_extend_code (h := h)
-    (hmono := evmExpCode_squaring_marshal_factor1_sub)
-
-/-- Squaring-call factor-2 marshal spec lifted to the top-level EXP code
-    bundle: at offset `base + 72`, copies result limbs from scratch to the
-    factor2 slot, exits at `base + 104`. -/
-theorem exp_squaring_marshal_result_to_factor2_evm_exp_spec_within
-    (mulOff : BitVec 21) (skipOff backOff : BitVec 13)
-    (sp evmSp tOld r0 r1 r2 r3 d0 d1 d2 d3 : Word) (base : Word) :
-    cpsTripleWithin 8 (base + 72) (base + 104)
-      (evmExpCode base mulOff skipOff backOff)
-      ((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
-       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
-       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
-       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
-       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
-       ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ d0) **
-       ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ d1) **
-       ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ d2) **
-       ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ d3))
-      ((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ r3) **
-       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
-       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
-       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
-       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
-       ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ r0) **
-       ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ r1) **
-       ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ r2) **
-       ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ r3)) := by
-  have h := EvmAsm.Evm64.exp_loop_marshal_result_to_factor2_ofProg_spec_within
-    sp evmSp tOld r0 r1 r2 r3 d0 d1 d2 d3 (base + 72)
-  have hexit : ((base + 72 : Word) + 32) = base + 104 := by bv_omega
-  rw [hexit] at h
-  exact cpsTripleWithin_extend_code (h := h)
-    (hmono := evmExpCode_squaring_marshal_result_to_factor2_sub)
-
-/-- Squaring-call un-marshal-and-restore spec lifted to the top-level EXP
-    code bundle: at offset `base + 108`, copies factor1 limbs back to scratch
-    and decrements `x12` by 32, exits at `base + 144`. -/
-theorem exp_squaring_un_marshal_and_restore_evm_exp_spec_within
-    (mulOff : BitVec 21) (skipOff backOff : BitVec 13)
-    (sp evmSp tOld r0 r1 r2 r3 d0 d1 d2 d3 : Word) (base : Word) :
-    cpsTripleWithin 9 (base + 108) (base + 144)
-      (evmExpCode base mulOff skipOff backOff)
-      ((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
-       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
-       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
-       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
-       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
-       ((evmSp + signExtend12 (0 : BitVec 12)) ↦ₘ d0) **
-       ((evmSp + signExtend12 (8 : BitVec 12)) ↦ₘ d1) **
-       ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ d2) **
-       ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ d3))
-      ((.x2 ↦ᵣ sp) **
-       (.x12 ↦ᵣ (evmSp + signExtend12 (-32 : BitVec 12))) **
-       (.x5 ↦ᵣ d3) **
-       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ d0) **
-       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ d1) **
-       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ d2) **
-       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ d3) **
-       ((evmSp + signExtend12 (0 : BitVec 12)) ↦ₘ d0) **
-       ((evmSp + signExtend12 (8 : BitVec 12)) ↦ₘ d1) **
-       ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ d2) **
-       ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ d3)) := by
-  have h := EvmAsm.Evm64.exp_loop_un_marshal_and_restore_ofProg_spec_within
-    sp evmSp tOld r0 r1 r2 r3 d0 d1 d2 d3 (base + 108)
-  have hexit : ((base + 108 : Word) + 36) = base + 144 := by bv_omega
-  rw [hexit] at h
-  exact cpsTripleWithin_extend_code (h := h)
-    (hmono := evmExpCode_squaring_un_marshal_and_restore_sub)
 
 /-- Conditional-multiply factor-1 marshal spec lifted to the top-level EXP
     code bundle: at offset `base + 148`, copies result limbs from scratch to

--- a/EvmAsm/Evm64/Exp/Compose/TopSquaringMarshalBlocks.lean
+++ b/EvmAsm/Evm64/Exp/Compose/TopSquaringMarshalBlocks.lean
@@ -1,0 +1,116 @@
+/-
+  EvmAsm.Evm64.Exp.Compose.TopSquaringMarshalBlocks
+
+  Squaring marshal/unmarshal block specs lifted to the top-level EXP code
+  bundle.
+-/
+
+import EvmAsm.Evm64.Exp.Compose.TopJalBlocks
+
+namespace EvmAsm.Evm64.Exp.Compose
+
+open EvmAsm.Rv64.Tactics
+open EvmAsm.Rv64
+
+/-- Squaring-call factor-1 marshal spec lifted to the top-level EXP code
+    bundle: at offset `base + 40`, copies result limbs from scratch to
+    factor1, exits at `base + 72`. -/
+theorem exp_squaring_marshal_factor1_evm_exp_spec_within
+    (mulOff : BitVec 21) (skipOff backOff : BitVec 13)
+    (sp evmSp tOld r0 r1 r2 r3 d0 d1 d2 d3 : Word) (base : Word) :
+    cpsTripleWithin 8 (base + 40) (base + 72)
+      (evmExpCode base mulOff skipOff backOff)
+      ((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+       ((evmSp + signExtend12 (0 : BitVec 12)) ↦ₘ d0) **
+       ((evmSp + signExtend12 (8 : BitVec 12)) ↦ₘ d1) **
+       ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ d2) **
+       ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ d3))
+      ((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ r3) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+       ((evmSp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+       ((evmSp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+       ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+       ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ r3)) := by
+  have h := EvmAsm.Evm64.exp_loop_marshal_factor1_ofProg_spec_within
+    sp evmSp tOld r0 r1 r2 r3 d0 d1 d2 d3 (base + 40)
+  have hexit : ((base + 40 : Word) + 32) = base + 72 := by bv_omega
+  rw [hexit] at h
+  exact cpsTripleWithin_extend_code (h := h)
+    (hmono := evmExpCode_squaring_marshal_factor1_sub)
+
+/-- Squaring-call factor-2 marshal spec lifted to the top-level EXP code
+    bundle: at offset `base + 72`, copies result limbs from scratch to the
+    factor2 slot, exits at `base + 104`. -/
+theorem exp_squaring_marshal_result_to_factor2_evm_exp_spec_within
+    (mulOff : BitVec 21) (skipOff backOff : BitVec 13)
+    (sp evmSp tOld r0 r1 r2 r3 d0 d1 d2 d3 : Word) (base : Word) :
+    cpsTripleWithin 8 (base + 72) (base + 104)
+      (evmExpCode base mulOff skipOff backOff)
+      ((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+       ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ d0) **
+       ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ d1) **
+       ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ d2) **
+       ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ d3))
+      ((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ r3) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+       ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ r0) **
+       ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ r1) **
+       ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ r2) **
+       ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ r3)) := by
+  have h := EvmAsm.Evm64.exp_loop_marshal_result_to_factor2_ofProg_spec_within
+    sp evmSp tOld r0 r1 r2 r3 d0 d1 d2 d3 (base + 72)
+  have hexit : ((base + 72 : Word) + 32) = base + 104 := by bv_omega
+  rw [hexit] at h
+  exact cpsTripleWithin_extend_code (h := h)
+    (hmono := evmExpCode_squaring_marshal_result_to_factor2_sub)
+
+/-- Squaring-call un-marshal-and-restore spec lifted to the top-level EXP
+    code bundle: at offset `base + 108`, copies factor1 limbs back to scratch
+    and decrements `x12` by 32, exits at `base + 144`. -/
+theorem exp_squaring_un_marshal_and_restore_evm_exp_spec_within
+    (mulOff : BitVec 21) (skipOff backOff : BitVec 13)
+    (sp evmSp tOld r0 r1 r2 r3 d0 d1 d2 d3 : Word) (base : Word) :
+    cpsTripleWithin 9 (base + 108) (base + 144)
+      (evmExpCode base mulOff skipOff backOff)
+      ((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+       ((evmSp + signExtend12 (0 : BitVec 12)) ↦ₘ d0) **
+       ((evmSp + signExtend12 (8 : BitVec 12)) ↦ₘ d1) **
+       ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ d2) **
+       ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ d3))
+      ((.x2 ↦ᵣ sp) **
+       (.x12 ↦ᵣ (evmSp + signExtend12 (-32 : BitVec 12))) **
+       (.x5 ↦ᵣ d3) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ d0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ d1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ d2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ d3) **
+       ((evmSp + signExtend12 (0 : BitVec 12)) ↦ₘ d0) **
+       ((evmSp + signExtend12 (8 : BitVec 12)) ↦ₘ d1) **
+       ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ d2) **
+       ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ d3)) := by
+  have h := EvmAsm.Evm64.exp_loop_un_marshal_and_restore_ofProg_spec_within
+    sp evmSp tOld r0 r1 r2 r3 d0 d1 d2 d3 (base + 108)
+  have hexit : ((base + 108 : Word) + 36) = base + 144 := by bv_omega
+  rw [hexit] at h
+  exact cpsTripleWithin_extend_code (h := h)
+    (hmono := evmExpCode_squaring_un_marshal_and_restore_sub)
+
+end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- move top-code squaring marshal/unmarshal lifted specs into `EvmAsm.Evm64.Exp.Compose.TopSquaringMarshalBlocks`
- keep `Compose.TopCodeSpecs` importing the new module so existing downstream imports still see the declarations
- import the new module from the EXP umbrella

## Validation
- `lake build EvmAsm.Evm64.Exp.Compose.TopSquaringMarshalBlocks`
- `lake build EvmAsm.Evm64.Exp.Compose.TopCodeSpecs`
- `git diff --check`
- `rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp.lean EvmAsm/Evm64/Exp/Compose/TopCodeSpecs.lean EvmAsm/Evm64/Exp/Compose/TopSquaringMarshalBlocks.lean` (no matches)
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `lake build`