### PR TITLE
refactor(exp): extract top pair blocks

### DIFF
--- a/EvmAsm/Evm64/Exp.lean
+++ b/EvmAsm/Evm64/Exp.lean
@@ -36,6 +36,7 @@ import EvmAsm.Evm64.Exp.Compose.TopCallSubs
 import EvmAsm.Evm64.Exp.Compose.TopJalBlocks
 import EvmAsm.Evm64.Exp.Compose.TopSquaringMarshalBlocks
 import EvmAsm.Evm64.Exp.Compose.TopCondMulMarshalBlocks
+import EvmAsm.Evm64.Exp.Compose.TopPairBlocks
 import EvmAsm.Evm64.Exp.Compose.TopCodeSpecs
 import EvmAsm.Evm64.Exp.Compose.WithMulCode
 import EvmAsm.Evm64.Exp.Compose.LoopControlBlocks

--- a/EvmAsm/Evm64/Exp/Compose/TopCodeSpecs.lean
+++ b/EvmAsm/Evm64/Exp/Compose/TopCodeSpecs.lean
@@ -14,6 +14,7 @@ import EvmAsm.Evm64.Exp.Compose.TopCallSubs
 import EvmAsm.Evm64.Exp.Compose.TopJalBlocks
 import EvmAsm.Evm64.Exp.Compose.TopSquaringMarshalBlocks
 import EvmAsm.Evm64.Exp.Compose.TopCondMulMarshalBlocks
+import EvmAsm.Evm64.Exp.Compose.TopPairBlocks
 import EvmAsm.Evm64.Exp.CondMulMarshalPair
 import EvmAsm.Evm64.Exp.SquaringCallSeq
 
@@ -21,113 +22,5 @@ namespace EvmAsm.Evm64.Exp.Compose
 
 open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
-/-- Squaring-call marshal prefix and JAL lifted to the top-level EXP code bundle. -/
-theorem exp_squaring_marshal_pair_then_square_evm_exp_spec_within
-    (sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 : Word)
-    (mulOff : BitVec 21) (skipOff backOff : BitVec 13)
-    (base mulTarget : Word)
-    (hmul : ((base + 104) + signExtend21 mulOff : Word) = mulTarget) :
-    cpsTripleWithin 17 (base + 40) mulTarget
-      (evmExpCode base mulOff skipOff backOff)
-      ((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
-       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
-       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
-       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
-       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
-       ((evmSp + signExtend12 (0 : BitVec 12)) ↦ₘ d0) **
-       ((evmSp + signExtend12 (8 : BitVec 12)) ↦ₘ d1) **
-       ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ d2) **
-       ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ d3) **
-       ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ e0) **
-       ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ e1) **
-       ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ e2) **
-       ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ e3) **
-       (.x1 ↦ᵣ vOld))
-      ((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ r3) **
-       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
-       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
-       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
-       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
-       ((evmSp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
-       ((evmSp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
-       ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
-       ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
-       ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ r0) **
-       ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ r1) **
-       ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ r2) **
-       ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ r3) **
-       (.x1 ↦ᵣ (base + 108))) := by
-  have h := EvmAsm.Evm64.exp_loop_squaring_marshal_pair_then_square_spec_within
-    sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 mulOff (base + 40)
-  have htarget : (((base + 40) + 64 : Word) + signExtend21 mulOff) = mulTarget := by
-    rw [show ((base + 40 : Word) + 64) = base + 104 by bv_omega]
-    exact hmul
-  rw [htarget] at h
-  have hret : ((base + 40 : Word) + 68) = base + 108 := by bv_omega
-  rw [hret] at h
-  exact cpsTripleWithin_extend_code (h := h) (hmono := evmExpCode_iter_squaring_sub)
-
-/-- Conditional-multiply marshal pair lifted to the top-level EXP code bundle. -/
-theorem exp_cond_mul_marshal_pair_evm_exp_spec_within
-    (sp evmSp tOld r0 r1 r2 r3 a0 a1 a2 a3 d0 d1 d2 d3 e0 e1 e2 e3 : Word)
-    (mulOff : BitVec 21) (skipOff backOff : BitVec 13)
-    (base : Word) :
-    cpsTripleWithin 16 (base + 148) (base + 212)
-      (evmExpCode base mulOff skipOff backOff)
-      ((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
-       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
-       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
-       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
-       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
-       ((evmSp + signExtend12 (0 : BitVec 12)) ↦ₘ d0) **
-       ((evmSp + signExtend12 (8 : BitVec 12)) ↦ₘ d1) **
-       ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ d2) **
-       ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ d3) **
-       ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ e0) **
-       ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ e1) **
-       ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ e2) **
-       ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ e3) **
-       ((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
-       ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **
-       ((evmSp + signExtend12 ((-48) : BitVec 12)) ↦ₘ a2) **
-       ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3))
-      ((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ a3) **
-       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
-       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
-       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
-       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
-       ((evmSp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
-       ((evmSp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
-       ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
-       ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
-       ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ a0) **
-       ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ a1) **
-       ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ a2) **
-       ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ a3) **
-       ((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
-       ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **
-       ((evmSp + signExtend12 ((-48) : BitVec 12)) ↦ₘ a2) **
-       ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3)) := by
-  have h := EvmAsm.Evm64.exp_loop_cond_mul_marshal_pair_spec_within
-    sp evmSp tOld r0 r1 r2 r3 a0 a1 a2 a3 d0 d1 d2 d3 e0 e1 e2 e3 (base + 148)
-  have hnext : ((base + 148 : Word) + 64) = base + 212 := by bv_omega
-  rw [hnext] at h
-  have hmono :
-      ∀ addr instr, EvmAsm.Evm64.exp_loop_cond_mul_marshal_pair_code
-          (base + 148) addr = some instr →
-        (evmExpCode base mulOff skipOff backOff) addr = some instr := by
-    intro addr instr hcode
-    unfold EvmAsm.Evm64.exp_loop_cond_mul_marshal_pair_code at hcode
-    exact CodeReq.union_sub
-      (evmExpCode_cond_mul_marshal_factor1_sub (base := base)
-        (mulOff := mulOff) (skipOff := skipOff) (backOff := backOff))
-      (fun a i hfactor2 => by
-        have haddr : ((base + 148 : Word) + 32) = base + 180 := by bv_omega
-        rw [haddr] at hfactor2
-        exact evmExpCode_cond_mul_marshal_a_to_factor2_sub
-          (base := base) (mulOff := mulOff) (skipOff := skipOff)
-          (backOff := backOff) a i hfactor2)
-      addr instr hcode
-  exact cpsTripleWithin_extend_code (h := h) (hmono := hmono)
 
 end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/TopPairBlocks.lean
+++ b/EvmAsm/Evm64/Exp/Compose/TopPairBlocks.lean
@@ -1,0 +1,125 @@
+/-
+  EvmAsm.Evm64.Exp.Compose.TopPairBlocks
+
+  Pair-composition specs lifted to the top-level EXP code bundle.
+-/
+
+import EvmAsm.Evm64.Exp.Compose.TopCondMulMarshalBlocks
+import EvmAsm.Evm64.Exp.CondMulMarshalPair
+import EvmAsm.Evm64.Exp.SquaringCallSeq
+
+namespace EvmAsm.Evm64.Exp.Compose
+
+open EvmAsm.Rv64.Tactics
+open EvmAsm.Rv64
+
+/-- Squaring-call marshal prefix and JAL lifted to the top-level EXP code bundle. -/
+theorem exp_squaring_marshal_pair_then_square_evm_exp_spec_within
+    (sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 : Word)
+    (mulOff : BitVec 21) (skipOff backOff : BitVec 13)
+    (base mulTarget : Word)
+    (hmul : ((base + 104) + signExtend21 mulOff : Word) = mulTarget) :
+    cpsTripleWithin 17 (base + 40) mulTarget
+      (evmExpCode base mulOff skipOff backOff)
+      ((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+       ((evmSp + signExtend12 (0 : BitVec 12)) ↦ₘ d0) **
+       ((evmSp + signExtend12 (8 : BitVec 12)) ↦ₘ d1) **
+       ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ d2) **
+       ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ d3) **
+       ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ e0) **
+       ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ e1) **
+       ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ e2) **
+       ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ e3) **
+       (.x1 ↦ᵣ vOld))
+      ((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ r3) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+       ((evmSp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+       ((evmSp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+       ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+       ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+       ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ r0) **
+       ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ r1) **
+       ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ r2) **
+       ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ r3) **
+       (.x1 ↦ᵣ (base + 108))) := by
+  have h := EvmAsm.Evm64.exp_loop_squaring_marshal_pair_then_square_spec_within
+    sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 mulOff (base + 40)
+  have htarget : (((base + 40) + 64 : Word) + signExtend21 mulOff) = mulTarget := by
+    rw [show ((base + 40 : Word) + 64) = base + 104 by bv_omega]
+    exact hmul
+  rw [htarget] at h
+  have hret : ((base + 40 : Word) + 68) = base + 108 := by bv_omega
+  rw [hret] at h
+  exact cpsTripleWithin_extend_code (h := h) (hmono := evmExpCode_iter_squaring_sub)
+
+/-- Conditional-multiply marshal pair lifted to the top-level EXP code bundle. -/
+theorem exp_cond_mul_marshal_pair_evm_exp_spec_within
+    (sp evmSp tOld r0 r1 r2 r3 a0 a1 a2 a3 d0 d1 d2 d3 e0 e1 e2 e3 : Word)
+    (mulOff : BitVec 21) (skipOff backOff : BitVec 13)
+    (base : Word) :
+    cpsTripleWithin 16 (base + 148) (base + 212)
+      (evmExpCode base mulOff skipOff backOff)
+      ((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+       ((evmSp + signExtend12 (0 : BitVec 12)) ↦ₘ d0) **
+       ((evmSp + signExtend12 (8 : BitVec 12)) ↦ₘ d1) **
+       ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ d2) **
+       ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ d3) **
+       ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ e0) **
+       ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ e1) **
+       ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ e2) **
+       ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ e3) **
+       ((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
+       ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **
+       ((evmSp + signExtend12 ((-48) : BitVec 12)) ↦ₘ a2) **
+       ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3))
+      ((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ a3) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+       ((evmSp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+       ((evmSp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+       ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+       ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+       ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ a0) **
+       ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ a1) **
+       ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ a2) **
+       ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ a3) **
+       ((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
+       ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **
+       ((evmSp + signExtend12 ((-48) : BitVec 12)) ↦ₘ a2) **
+       ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3)) := by
+  have h := EvmAsm.Evm64.exp_loop_cond_mul_marshal_pair_spec_within
+    sp evmSp tOld r0 r1 r2 r3 a0 a1 a2 a3 d0 d1 d2 d3 e0 e1 e2 e3 (base + 148)
+  have hnext : ((base + 148 : Word) + 64) = base + 212 := by bv_omega
+  rw [hnext] at h
+  have hmono :
+      ∀ addr instr, EvmAsm.Evm64.exp_loop_cond_mul_marshal_pair_code
+          (base + 148) addr = some instr →
+        (evmExpCode base mulOff skipOff backOff) addr = some instr := by
+    intro addr instr hcode
+    unfold EvmAsm.Evm64.exp_loop_cond_mul_marshal_pair_code at hcode
+    exact CodeReq.union_sub
+      (evmExpCode_cond_mul_marshal_factor1_sub (base := base)
+        (mulOff := mulOff) (skipOff := skipOff) (backOff := backOff))
+      (fun a i hfactor2 => by
+        have haddr : ((base + 148 : Word) + 32) = base + 180 := by bv_omega
+        rw [haddr] at hfactor2
+        exact evmExpCode_cond_mul_marshal_a_to_factor2_sub
+          (base := base) (mulOff := mulOff) (skipOff := skipOff)
+          (backOff := backOff) a i hfactor2)
+      addr instr hcode
+  exact cpsTripleWithin_extend_code (h := h) (hmono := hmono)
+
+end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- move the remaining top-code pair-composition specs into `EvmAsm.Evm64.Exp.Compose.TopPairBlocks`
- leave `Compose.TopCodeSpecs` as a small grouping module over the split top-code spec modules
- import the new module from the EXP umbrella

## Validation
- `lake build EvmAsm.Evm64.Exp.Compose.TopPairBlocks`
- `lake build EvmAsm.Evm64.Exp.Compose.TopCodeSpecs`
- `git diff --check`
- `rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp.lean EvmAsm/Evm64/Exp/Compose/TopCodeSpecs.lean EvmAsm/Evm64/Exp/Compose/TopPairBlocks.lean` (no matches)
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `lake build`