### PR TITLE
refactor(sdiv): extract divcall pcfree basics

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/DivCallPostPcFree.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallPostPcFree.lean
@@ -5,118 +5,12 @@
   separate from `DivCallDispatch.lean`, which is at the Compose line cap.
 -/
 
-import EvmAsm.Evm64.SDiv.Compose.DivCallResultSignFix
+import EvmAsm.Evm64.SDiv.Compose.DivCallPostPcFreeBasics
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
 open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
-
-abbrev sdivAbsSign (top : Word) : Word :=
-  top >>> (63 : BitVec 6).toNat
-
-abbrev sdivAbsMask (top : Word) : Word :=
-  (0 : Word) - sdivAbsSign top
-
-abbrev sdivAbsSum0 (limb0 top : Word) : Word :=
-  (limb0 ^^^ sdivAbsMask top) + sdivAbsSign top
-
-abbrev sdivAbsCarry0 (limb0 top : Word) : Word :=
-  if BitVec.ult (sdivAbsSum0 limb0 top) (sdivAbsSign top) then (1 : Word) else 0
-
-abbrev sdivAbsSum1 (limb0 limb1 top : Word) : Word :=
-  (limb1 ^^^ sdivAbsMask top) + sdivAbsCarry0 limb0 top
-
-abbrev sdivAbsCarry1 (limb0 limb1 top : Word) : Word :=
-  if BitVec.ult (sdivAbsSum1 limb0 limb1 top) (sdivAbsCarry0 limb0 top) then
-    (1 : Word)
-  else
-    0
-
-abbrev sdivAbsSum2 (limb0 limb1 limb2 top : Word) : Word :=
-  (limb2 ^^^ sdivAbsMask top) + sdivAbsCarry1 limb0 limb1 top
-
-abbrev sdivAbsCarry2 (limb0 limb1 limb2 top : Word) : Word :=
-  if BitVec.ult (sdivAbsSum2 limb0 limb1 limb2 top)
-      (sdivAbsCarry1 limb0 limb1 top) then
-    (1 : Word)
-  else
-    0
-
-abbrev sdivAbsSum3 (limb0 limb1 limb2 top : Word) : Word :=
-  (top ^^^ sdivAbsMask top) + sdivAbsCarry2 limb0 limb1 limb2 top
-
-abbrev sdivAbsCarry3 (limb0 limb1 limb2 top : Word) : Word :=
-  if BitVec.ult (sdivAbsSum3 limb0 limb1 limb2 top)
-      (sdivAbsCarry2 limb0 limb1 limb2 top) then
-    (1 : Word)
-  else
-    0
-
-theorem sdivAbsDividendWord_eq_components
-    (limb0 limb1 limb2 top : Word) :
-    sdivAbsDividendWord limb0 limb1 limb2 top =
-      EvmWord.fromLimbs fun i : Fin 4 =>
-        match i with
-        | 0 => sdivAbsSum0 limb0 top
-        | 1 => sdivAbsSum1 limb0 limb1 top
-        | 2 => sdivAbsSum2 limb0 limb1 limb2 top
-        | 3 => sdivAbsSum3 limb0 limb1 limb2 top := by
-  rfl
-
-theorem sdivAbsDivisorWord_eq_components
-    (limb0 limb1 limb2 top : Word) :
-    sdivAbsDivisorWord limb0 limb1 limb2 top =
-      EvmWord.fromLimbs fun i : Fin 4 =>
-        match i with
-        | 0 => sdivAbsSum0 limb0 top
-        | 1 => sdivAbsSum1 limb0 limb1 top
-        | 2 => sdivAbsSum2 limb0 limb1 limb2 top
-        | 3 => sdivAbsSum3 limb0 limb1 limb2 top := by
-  rfl
-
-theorem divModStackDispatchPre_pcFree
-    {sp : Word} {a b : EvmWord}
-    {v1 v2 v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-      shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word} :
-    (EvmAsm.Evm64.divModStackDispatchPre sp a b
-      v1 v2 v5 v6 v7 v10 v11
-      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-      shiftMem nMem jMem retMem dMem dloMem scratchUn0).pcFree := by
-  rw [EvmAsm.Evm64.divModStackDispatchPre_unfold,
-    EvmAsm.Evm64.divScratchValuesCall_unfold]
-  pcFree
-
-instance pcFreeInst_divModStackDispatchPre
-    (sp : Word) (a b : EvmWord)
-    (v1 v2 v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-      shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word) :
-    Assertion.PCFree
-      (EvmAsm.Evm64.divModStackDispatchPre sp a b
-        v1 v2 v5 v6 v7 v10 v11
-        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-        shiftMem nMem jMem retMem dMem dloMem scratchUn0) :=
-  ⟨divModStackDispatchPre_pcFree⟩
-
-theorem divStackDispatchPostNoX1_pcFree {sp : Word} {a b : EvmWord} :
-    (EvmAsm.Evm64.divStackDispatchPostNoX1 sp a b).pcFree := by
-  rw [EvmAsm.Evm64.divStackDispatchPostNoX1_unfold,
-    EvmAsm.Evm64.divScratchOwnCall_unfold,
-    EvmAsm.Evm64.divScratchOwn_unfold]
-  pcFree
-
-instance pcFreeInst_divStackDispatchPostNoX1
-    (sp : Word) (a b : EvmWord) :
-    Assertion.PCFree (EvmAsm.Evm64.divStackDispatchPostNoX1 sp a b) :=
-  ⟨divStackDispatchPostNoX1_pcFree⟩
-
-abbrev saveRaDivCallSignFrame
-    (vRa resultSign divisorSign : Word) : Assertion :=
-  ((.x8 ↦ᵣ resultSign) ** (.x9 ↦ᵣ divisorSign) **
-    (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12))))
-
-abbrev sdivDivCallResultSign (dividendTop divisorTop : Word) : Word :=
-  sdivAbsSign dividendTop ^^^ sdivAbsSign divisorTop
 
 /-- Variant of the preserving-`x1` unsigned-DIV callable wrapper whose no-NOP
     body proof already has the exact caller return address in the dispatch

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallPostPcFreeBasics.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallPostPcFreeBasics.lean
@@ -1,0 +1,121 @@
+/-
+  EvmAsm.Evm64.SDiv.Compose.DivCallPostPcFreeBasics
+
+  Small helper abbreviations and core PC-free instances used by the SDIV
+  div-call postcondition sidecar proofs.
+-/
+
+import EvmAsm.Evm64.SDiv.Compose.DivCallResultSignFix
+
+namespace EvmAsm.Evm64.SDiv.Compose
+
+open EvmAsm.Rv64.Tactics
+open EvmAsm.Rv64
+
+abbrev sdivAbsSign (top : Word) : Word :=
+  top >>> (63 : BitVec 6).toNat
+
+abbrev sdivAbsMask (top : Word) : Word :=
+  (0 : Word) - sdivAbsSign top
+
+abbrev sdivAbsSum0 (limb0 top : Word) : Word :=
+  (limb0 ^^^ sdivAbsMask top) + sdivAbsSign top
+
+abbrev sdivAbsCarry0 (limb0 top : Word) : Word :=
+  if BitVec.ult (sdivAbsSum0 limb0 top) (sdivAbsSign top) then (1 : Word) else 0
+
+abbrev sdivAbsSum1 (limb0 limb1 top : Word) : Word :=
+  (limb1 ^^^ sdivAbsMask top) + sdivAbsCarry0 limb0 top
+
+abbrev sdivAbsCarry1 (limb0 limb1 top : Word) : Word :=
+  if BitVec.ult (sdivAbsSum1 limb0 limb1 top) (sdivAbsCarry0 limb0 top) then
+    (1 : Word)
+  else
+    0
+
+abbrev sdivAbsSum2 (limb0 limb1 limb2 top : Word) : Word :=
+  (limb2 ^^^ sdivAbsMask top) + sdivAbsCarry1 limb0 limb1 top
+
+abbrev sdivAbsCarry2 (limb0 limb1 limb2 top : Word) : Word :=
+  if BitVec.ult (sdivAbsSum2 limb0 limb1 limb2 top)
+      (sdivAbsCarry1 limb0 limb1 top) then
+    (1 : Word)
+  else
+    0
+
+abbrev sdivAbsSum3 (limb0 limb1 limb2 top : Word) : Word :=
+  (top ^^^ sdivAbsMask top) + sdivAbsCarry2 limb0 limb1 limb2 top
+
+abbrev sdivAbsCarry3 (limb0 limb1 limb2 top : Word) : Word :=
+  if BitVec.ult (sdivAbsSum3 limb0 limb1 limb2 top)
+      (sdivAbsCarry2 limb0 limb1 limb2 top) then
+    (1 : Word)
+  else
+    0
+
+theorem sdivAbsDividendWord_eq_components
+    (limb0 limb1 limb2 top : Word) :
+    sdivAbsDividendWord limb0 limb1 limb2 top =
+      EvmWord.fromLimbs fun i : Fin 4 =>
+        match i with
+        | 0 => sdivAbsSum0 limb0 top
+        | 1 => sdivAbsSum1 limb0 limb1 top
+        | 2 => sdivAbsSum2 limb0 limb1 limb2 top
+        | 3 => sdivAbsSum3 limb0 limb1 limb2 top := by
+  rfl
+
+theorem sdivAbsDivisorWord_eq_components
+    (limb0 limb1 limb2 top : Word) :
+    sdivAbsDivisorWord limb0 limb1 limb2 top =
+      EvmWord.fromLimbs fun i : Fin 4 =>
+        match i with
+        | 0 => sdivAbsSum0 limb0 top
+        | 1 => sdivAbsSum1 limb0 limb1 top
+        | 2 => sdivAbsSum2 limb0 limb1 limb2 top
+        | 3 => sdivAbsSum3 limb0 limb1 limb2 top := by
+  rfl
+
+theorem divModStackDispatchPre_pcFree
+    {sp : Word} {a b : EvmWord}
+    {v1 v2 v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word} :
+    (EvmAsm.Evm64.divModStackDispatchPre sp a b
+      v1 v2 v5 v6 v7 v10 v11
+      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0).pcFree := by
+  rw [EvmAsm.Evm64.divModStackDispatchPre_unfold,
+    EvmAsm.Evm64.divScratchValuesCall_unfold]
+  pcFree
+
+instance pcFreeInst_divModStackDispatchPre
+    (sp : Word) (a b : EvmWord)
+    (v1 v2 v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word) :
+    Assertion.PCFree
+      (EvmAsm.Evm64.divModStackDispatchPre sp a b
+        v1 v2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0) :=
+  ⟨divModStackDispatchPre_pcFree⟩
+
+theorem divStackDispatchPostNoX1_pcFree {sp : Word} {a b : EvmWord} :
+    (EvmAsm.Evm64.divStackDispatchPostNoX1 sp a b).pcFree := by
+  rw [EvmAsm.Evm64.divStackDispatchPostNoX1_unfold,
+    EvmAsm.Evm64.divScratchOwnCall_unfold,
+    EvmAsm.Evm64.divScratchOwn_unfold]
+  pcFree
+
+instance pcFreeInst_divStackDispatchPostNoX1
+    (sp : Word) (a b : EvmWord) :
+    Assertion.PCFree (EvmAsm.Evm64.divStackDispatchPostNoX1 sp a b) :=
+  ⟨divStackDispatchPostNoX1_pcFree⟩
+
+abbrev saveRaDivCallSignFrame
+    (vRa resultSign divisorSign : Word) : Assertion :=
+  ((.x8 ↦ᵣ resultSign) ** (.x9 ↦ᵣ divisorSign) **
+    (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12))))
+
+abbrev sdivDivCallResultSign (dividendTop divisorTop : Word) : Word :=
+  sdivAbsSign dividendTop ^^^ sdivAbsSign divisorTop
+
+end EvmAsm.Evm64.SDiv.Compose


### PR DESCRIPTION
## Summary
- extract SDIV div-call abs-word helpers, core DIV dispatch PCFree instances, and sign-frame/result-sign abbreviations into DivCallPostPcFreeBasics
- leave DivCallPostPcFree focused on callable handoff and postcondition composition theorems

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.DivCallPostPcFreeBasics
- lake build EvmAsm.Evm64.SDiv.Compose.DivCallPostPcFree EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/DivCallPostPcFree.lean EvmAsm/Evm64/SDiv/Compose/DivCallPostPcFreeBasics.lean
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build