### PR TITLE
refactor(sdiv): extract bzero callable handoff

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/DivCallBzeroCallableHandoff.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallBzeroCallableHandoff.lean
@@ -1,0 +1,56 @@
+/-
+  EvmAsm.Evm64.SDiv.Compose.DivCallBzeroCallableHandoff
+
+  Prefix-to-zero-divisor-callable SDIV handoff wrapper.
+-/
+
+import EvmAsm.Evm64.SDiv.Compose.DivCallBzeroHandoff
+
+namespace EvmAsm.Evm64.SDiv.Compose
+
+open EvmAsm.Rv64.Tactics
+open EvmAsm.Rv64
+
+/-- SDIV wrapper prefix followed by the zero-divisor unsigned-DIV callable,
+    using the sidecar dispatch-ready handoff above. This mirrors the named
+    callable-post theorem in `DivCallDispatch.lean` without adding proof bulk
+    to that capped file. -/
+theorem saveRa_signs_abs_signXor_then_divCall_bzero_callable_named_post_from_handoff_spec_in_sdivCode
+    (vRa vSavedOld sp sDividendOld sDivisorOld
+      dividendMaskOld dividendValueOld dividendCarryOld
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+      v2 v5 v6 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (base : Word) (hbase : base &&& 1 = 0)
+    (hbz : sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop = 0) :
+    cpsTripleWithin (49 + (EvmAsm.Evm64.unifiedDivBound + 1))
+      base (base + resultSignFixOff) (sdivCode base)
+      (saveRaSignsAbsSignXorThenDivCallPre vRa vSavedOld sp sDividendOld sDivisorOld
+        dividendMaskOld dividendValueOld dividendCarryOld
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
+       ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
+        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0))
+      (saveRaDivCallBzeroCallablePost vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) := by
+  exact
+    saveRa_signs_abs_signXor_then_divCall_then_exact_callable_spec_in_sdivCode
+      vRa vSavedOld sp sDividendOld sDivisorOld
+      dividendMaskOld dividendValueOld dividendCarryOld
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+      v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0
+      base (base + resultSignFixOff)
+      (saveRaDivCallDispatchReadyPost_bzero_callable_spec_in_sdivCode
+        vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+        v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 hbase hbz)
+
+end EvmAsm.Evm64.SDiv.Compose

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallPostPcFree.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallPostPcFree.lean
@@ -5,54 +5,12 @@
   separate from `DivCallDispatch.lean`, which is at the Compose line cap.
 -/
 
-import EvmAsm.Evm64.SDiv.Compose.DivCallBzeroHandoff
+import EvmAsm.Evm64.SDiv.Compose.DivCallBzeroCallableHandoff
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
 open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
-
-/-- SDIV wrapper prefix followed by the zero-divisor unsigned-DIV callable,
-    using the sidecar dispatch-ready handoff above. This mirrors the named
-    callable-post theorem in `DivCallDispatch.lean` without adding proof bulk
-    to that capped file. -/
-theorem saveRa_signs_abs_signXor_then_divCall_bzero_callable_named_post_from_handoff_spec_in_sdivCode
-    (vRa vSavedOld sp sDividendOld sDivisorOld
-      dividendMaskOld dividendValueOld dividendCarryOld
-      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
-      v2 v5 v6 : Word)
-    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-     shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
-    (base : Word) (hbase : base &&& 1 = 0)
-    (hbz : sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop = 0) :
-    cpsTripleWithin (49 + (EvmAsm.Evm64.unifiedDivBound + 1))
-      base (base + resultSignFixOff) (sdivCode base)
-      (saveRaSignsAbsSignXorThenDivCallPre vRa vSavedOld sp sDividendOld sDivisorOld
-        dividendMaskOld dividendValueOld dividendCarryOld
-        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
-       ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
-        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-          shiftMem nMem jMem retMem dMem dloMem scratchUn0))
-      (saveRaDivCallBzeroCallablePost vRa sp base
-        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) := by
-  exact
-    saveRa_signs_abs_signXor_then_divCall_then_exact_callable_spec_in_sdivCode
-      vRa vSavedOld sp sDividendOld sDivisorOld
-      dividendMaskOld dividendValueOld dividendCarryOld
-      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
-      v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-      shiftMem nMem jMem retMem dMem dloMem scratchUn0
-      base (base + resultSignFixOff)
-      (saveRaDivCallDispatchReadyPost_bzero_callable_spec_in_sdivCode
-        vRa sp base
-        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
-        v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-        shiftMem nMem jMem retMem dMem dloMem scratchUn0 hbase hbz)
 
 /-- Exact SDIV path through result-sign-fix, specialized from the sidecar
     exact callable handoff and stopping before the saved-RA return. -/


### PR DESCRIPTION
## Summary
- extract the prefix-to-bzero-callable handoff wrapper into DivCallBzeroCallableHandoff
- keep DivCallPostPcFree focused on result-sign-fix/return compositions and PCFree instances

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.DivCallBzeroCallableHandoff
- lake build EvmAsm.Evm64.SDiv.Compose.DivCallPostPcFree
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/DivCallBzeroCallableHandoff.lean EvmAsm/Evm64/SDiv/Compose/DivCallPostPcFree.lean
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build