### PR TITLE
refactor(sdiv): extract resultsignfix pcfree

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/DivCallPostPcFree.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallPostPcFree.lean
@@ -5,7 +5,7 @@
   separate from `DivCallDispatch.lean`, which is at the Compose line cap.
 -/
 
-import EvmAsm.Evm64.SDiv.Compose.DivCallBzeroReturnHandoff
+import EvmAsm.Evm64.SDiv.Compose.ResultSignFixPCFree
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
@@ -65,56 +65,6 @@ instance pcFreeInst_saveRaDivCallBzeroSavedRaRetFrame
       (saveRaDivCallBzeroSavedRaRetFrame
         sp base divisorSign dividendAbsWord) :=
   ⟨saveRaDivCallBzeroSavedRaRetFrame_pcFree⟩
-
-theorem resultSignFixPost_pcFree
-    {sp sign limb0 limb1 limb2 limb3 : Word} :
-    (resultSignFixPost sp sign limb0 limb1 limb2 limb3).pcFree := by
-  rw [resultSignFixPost_unfold]
-  dsimp
-  pcFree
-
-instance pcFreeInst_resultSignFixPost
-    (sp sign limb0 limb1 limb2 limb3 : Word) :
-    Assertion.PCFree (resultSignFixPost sp sign limb0 limb1 limb2 limb3) :=
-  ⟨resultSignFixPost_pcFree⟩
-
-theorem resultSignFixPreOwnX10_pcFree
-    {sp sign valueOld carryOld limb0 limb1 limb2 limb3 : Word} :
-    (resultSignFixPreOwnX10
-      sp sign valueOld carryOld limb0 limb1 limb2 limb3).pcFree := by
-  rw [resultSignFixPreOwnX10_unfold]
-  pcFree
-
-instance pcFreeInst_resultSignFixPreOwnX10
-    (sp sign valueOld carryOld limb0 limb1 limb2 limb3 : Word) :
-    Assertion.PCFree
-      (resultSignFixPreOwnX10
-        sp sign valueOld carryOld limb0 limb1 limb2 limb3) :=
-  ⟨resultSignFixPreOwnX10_pcFree⟩
-
-theorem resultSignFixPreOwnX10X7_pcFree
-    {sp sign carryOld limb0 limb1 limb2 limb3 : Word} :
-    (resultSignFixPreOwnX10X7
-      sp sign carryOld limb0 limb1 limb2 limb3).pcFree := by
-  rw [resultSignFixPreOwnX10X7_unfold]
-  pcFree
-
-instance pcFreeInst_resultSignFixPreOwnX10X7
-    (sp sign carryOld limb0 limb1 limb2 limb3 : Word) :
-    Assertion.PCFree
-      (resultSignFixPreOwnX10X7 sp sign carryOld limb0 limb1 limb2 limb3) :=
-  ⟨resultSignFixPreOwnX10X7_pcFree⟩
-
-theorem resultSignFixPreOwnScratch_pcFree
-    {sp sign limb0 limb1 limb2 limb3 : Word} :
-    (resultSignFixPreOwnScratch sp sign limb0 limb1 limb2 limb3).pcFree := by
-  rw [resultSignFixPreOwnScratch_unfold]
-  pcFree
-
-instance pcFreeInst_resultSignFixPreOwnScratch
-    (sp sign limb0 limb1 limb2 limb3 : Word) :
-    Assertion.PCFree (resultSignFixPreOwnScratch sp sign limb0 limb1 limb2 limb3) :=
-  ⟨resultSignFixPreOwnScratch_pcFree⟩
 
 theorem resultSignFixPost_bzeroResultSignFixFrame_pcFree
     {vRa sp base divisorSign sign limb0 limb1 limb2 limb3 : Word}

--- a/EvmAsm/Evm64/SDiv/Compose/ResultSignFixPCFree.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/ResultSignFixPCFree.lean
@@ -1,0 +1,64 @@
+/-
+  EvmAsm.Evm64.SDiv.Compose.ResultSignFixPCFree
+
+  PC-free instances for standalone SDIV result-sign-fix bundles.
+-/
+
+import EvmAsm.Evm64.SDiv.Compose.DivCallBzeroReturnHandoff
+
+namespace EvmAsm.Evm64.SDiv.Compose
+
+open EvmAsm.Rv64.Tactics
+open EvmAsm.Rv64
+
+theorem resultSignFixPost_pcFree
+    {sp sign limb0 limb1 limb2 limb3 : Word} :
+    (resultSignFixPost sp sign limb0 limb1 limb2 limb3).pcFree := by
+  rw [resultSignFixPost_unfold]
+  dsimp
+  pcFree
+
+instance pcFreeInst_resultSignFixPost
+    (sp sign limb0 limb1 limb2 limb3 : Word) :
+    Assertion.PCFree (resultSignFixPost sp sign limb0 limb1 limb2 limb3) :=
+  ⟨resultSignFixPost_pcFree⟩
+
+theorem resultSignFixPreOwnX10_pcFree
+    {sp sign valueOld carryOld limb0 limb1 limb2 limb3 : Word} :
+    (resultSignFixPreOwnX10
+      sp sign valueOld carryOld limb0 limb1 limb2 limb3).pcFree := by
+  rw [resultSignFixPreOwnX10_unfold]
+  pcFree
+
+instance pcFreeInst_resultSignFixPreOwnX10
+    (sp sign valueOld carryOld limb0 limb1 limb2 limb3 : Word) :
+    Assertion.PCFree
+      (resultSignFixPreOwnX10
+        sp sign valueOld carryOld limb0 limb1 limb2 limb3) :=
+  ⟨resultSignFixPreOwnX10_pcFree⟩
+
+theorem resultSignFixPreOwnX10X7_pcFree
+    {sp sign carryOld limb0 limb1 limb2 limb3 : Word} :
+    (resultSignFixPreOwnX10X7
+      sp sign carryOld limb0 limb1 limb2 limb3).pcFree := by
+  rw [resultSignFixPreOwnX10X7_unfold]
+  pcFree
+
+instance pcFreeInst_resultSignFixPreOwnX10X7
+    (sp sign carryOld limb0 limb1 limb2 limb3 : Word) :
+    Assertion.PCFree
+      (resultSignFixPreOwnX10X7 sp sign carryOld limb0 limb1 limb2 limb3) :=
+  ⟨resultSignFixPreOwnX10X7_pcFree⟩
+
+theorem resultSignFixPreOwnScratch_pcFree
+    {sp sign limb0 limb1 limb2 limb3 : Word} :
+    (resultSignFixPreOwnScratch sp sign limb0 limb1 limb2 limb3).pcFree := by
+  rw [resultSignFixPreOwnScratch_unfold]
+  pcFree
+
+instance pcFreeInst_resultSignFixPreOwnScratch
+    (sp sign limb0 limb1 limb2 limb3 : Word) :
+    Assertion.PCFree (resultSignFixPreOwnScratch sp sign limb0 limb1 limb2 limb3) :=
+  ⟨resultSignFixPreOwnScratch_pcFree⟩
+
+end EvmAsm.Evm64.SDiv.Compose


### PR DESCRIPTION
## Summary
- extract standalone result-sign-fix PCFree lemmas and instances into ResultSignFixPCFree
- keep DivCallPostPcFree focused on SDIV div-call/bzero-frame PCFree bundles

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.ResultSignFixPCFree
- lake build EvmAsm.Evm64.SDiv.Compose.DivCallPostPcFree
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/ResultSignFixPCFree.lean EvmAsm/Evm64/SDiv/Compose/DivCallPostPcFree.lean
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build