### PR TITLE
refactor(sdiv): extract bzero frame pcfree

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/BzeroFramePCFree.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroFramePCFree.lean
@@ -1,0 +1,78 @@
+/-
+  EvmAsm.Evm64.SDiv.Compose.BzeroFramePCFree
+
+  PC-free instances for zero-divisor SDIV result-sign-fix/return frames.
+-/
+
+import EvmAsm.Evm64.SDiv.Compose.ResultSignFixPCFree
+
+namespace EvmAsm.Evm64.SDiv.Compose
+
+open EvmAsm.Rv64.Tactics
+open EvmAsm.Rv64
+
+theorem saveRaDivCallBzeroResultSignFixFrame_pcFree
+    {vRa sp base divisorSign : Word} {dividendAbsWord : EvmWord} :
+    (saveRaDivCallBzeroResultSignFixFrame
+      vRa sp base divisorSign dividendAbsWord).pcFree := by
+  rw [saveRaDivCallBzeroResultSignFixFrame_unfold,
+    EvmAsm.Evm64.divScratchOwnCall_unfold,
+    EvmAsm.Evm64.divScratchOwn_unfold]
+  pcFree
+
+instance pcFreeInst_saveRaDivCallBzeroResultSignFixFrame
+    (vRa sp base divisorSign : Word) (dividendAbsWord : EvmWord) :
+    Assertion.PCFree
+      (saveRaDivCallBzeroResultSignFixFrame
+        vRa sp base divisorSign dividendAbsWord) :=
+  ⟨saveRaDivCallBzeroResultSignFixFrame_pcFree⟩
+
+theorem saveRaDivCallBzeroSavedRaRetFrame_pcFree
+    {sp base divisorSign : Word} {dividendAbsWord : EvmWord} :
+    (saveRaDivCallBzeroSavedRaRetFrame
+      sp base divisorSign dividendAbsWord).pcFree := by
+  rw [saveRaDivCallBzeroSavedRaRetFrame_unfold,
+    EvmAsm.Evm64.divScratchOwnCall_unfold,
+    EvmAsm.Evm64.divScratchOwn_unfold]
+  pcFree
+
+instance pcFreeInst_saveRaDivCallBzeroSavedRaRetFrame
+    (sp base divisorSign : Word) (dividendAbsWord : EvmWord) :
+    Assertion.PCFree
+      (saveRaDivCallBzeroSavedRaRetFrame
+        sp base divisorSign dividendAbsWord) :=
+  ⟨saveRaDivCallBzeroSavedRaRetFrame_pcFree⟩
+
+theorem resultSignFixPost_bzeroResultSignFixFrame_pcFree
+    {vRa sp base divisorSign sign limb0 limb1 limb2 limb3 : Word}
+    {dividendAbsWord : EvmWord} :
+    (resultSignFixPost (sp + 32) sign limb0 limb1 limb2 limb3 **
+      saveRaDivCallBzeroResultSignFixFrame
+        vRa sp base divisorSign dividendAbsWord).pcFree := by
+  pcFree
+
+instance pcFreeInst_resultSignFixPost_bzeroResultSignFixFrame
+    (vRa sp base divisorSign sign limb0 limb1 limb2 limb3 : Word)
+    (dividendAbsWord : EvmWord) :
+    Assertion.PCFree
+      (resultSignFixPost (sp + 32) sign limb0 limb1 limb2 limb3 **
+        saveRaDivCallBzeroResultSignFixFrame
+          vRa sp base divisorSign dividendAbsWord) :=
+  ⟨resultSignFixPost_bzeroResultSignFixFrame_pcFree⟩
+
+theorem resultSignFixPost_savedRaRetFrame_pcFree
+    {sp base divisorSign sign limb0 limb1 limb2 limb3 : Word}
+    {dividendAbsWord : EvmWord} :
+    (resultSignFixPost (sp + 32) sign limb0 limb1 limb2 limb3 **
+      saveRaDivCallBzeroSavedRaRetFrame sp base divisorSign dividendAbsWord).pcFree := by
+  pcFree
+
+instance pcFreeInst_resultSignFixPost_savedRaRetFrame
+    (sp base divisorSign sign limb0 limb1 limb2 limb3 : Word)
+    (dividendAbsWord : EvmWord) :
+    Assertion.PCFree
+      (resultSignFixPost (sp + 32) sign limb0 limb1 limb2 limb3 **
+        saveRaDivCallBzeroSavedRaRetFrame sp base divisorSign dividendAbsWord) :=
+  ⟨resultSignFixPost_savedRaRetFrame_pcFree⟩
+
+end EvmAsm.Evm64.SDiv.Compose

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallPostPcFree.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallPostPcFree.lean
@@ -5,7 +5,7 @@
   separate from `DivCallDispatch.lean`, which is at the Compose line cap.
 -/
 
-import EvmAsm.Evm64.SDiv.Compose.ResultSignFixPCFree
+import EvmAsm.Evm64.SDiv.Compose.BzeroFramePCFree
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
@@ -33,69 +33,5 @@ instance pcFreeInst_saveRaDivCallBzeroCallablePost
         dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
         divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) :=
   ⟨saveRaDivCallBzeroCallablePost_pcFree⟩
-
-theorem saveRaDivCallBzeroResultSignFixFrame_pcFree
-    {vRa sp base divisorSign : Word} {dividendAbsWord : EvmWord} :
-    (saveRaDivCallBzeroResultSignFixFrame
-      vRa sp base divisorSign dividendAbsWord).pcFree := by
-  rw [saveRaDivCallBzeroResultSignFixFrame_unfold,
-    EvmAsm.Evm64.divScratchOwnCall_unfold,
-    EvmAsm.Evm64.divScratchOwn_unfold]
-  pcFree
-
-instance pcFreeInst_saveRaDivCallBzeroResultSignFixFrame
-    (vRa sp base divisorSign : Word) (dividendAbsWord : EvmWord) :
-    Assertion.PCFree
-      (saveRaDivCallBzeroResultSignFixFrame
-        vRa sp base divisorSign dividendAbsWord) :=
-  ⟨saveRaDivCallBzeroResultSignFixFrame_pcFree⟩
-
-theorem saveRaDivCallBzeroSavedRaRetFrame_pcFree
-    {sp base divisorSign : Word} {dividendAbsWord : EvmWord} :
-    (saveRaDivCallBzeroSavedRaRetFrame
-      sp base divisorSign dividendAbsWord).pcFree := by
-  rw [saveRaDivCallBzeroSavedRaRetFrame_unfold,
-    EvmAsm.Evm64.divScratchOwnCall_unfold,
-    EvmAsm.Evm64.divScratchOwn_unfold]
-  pcFree
-
-instance pcFreeInst_saveRaDivCallBzeroSavedRaRetFrame
-    (sp base divisorSign : Word) (dividendAbsWord : EvmWord) :
-    Assertion.PCFree
-      (saveRaDivCallBzeroSavedRaRetFrame
-        sp base divisorSign dividendAbsWord) :=
-  ⟨saveRaDivCallBzeroSavedRaRetFrame_pcFree⟩
-
-theorem resultSignFixPost_bzeroResultSignFixFrame_pcFree
-    {vRa sp base divisorSign sign limb0 limb1 limb2 limb3 : Word}
-    {dividendAbsWord : EvmWord} :
-    (resultSignFixPost (sp + 32) sign limb0 limb1 limb2 limb3 **
-      saveRaDivCallBzeroResultSignFixFrame
-        vRa sp base divisorSign dividendAbsWord).pcFree := by
-  pcFree
-
-instance pcFreeInst_resultSignFixPost_bzeroResultSignFixFrame
-    (vRa sp base divisorSign sign limb0 limb1 limb2 limb3 : Word)
-    (dividendAbsWord : EvmWord) :
-    Assertion.PCFree
-      (resultSignFixPost (sp + 32) sign limb0 limb1 limb2 limb3 **
-        saveRaDivCallBzeroResultSignFixFrame
-          vRa sp base divisorSign dividendAbsWord) :=
-  ⟨resultSignFixPost_bzeroResultSignFixFrame_pcFree⟩
-
-theorem resultSignFixPost_savedRaRetFrame_pcFree
-    {sp base divisorSign sign limb0 limb1 limb2 limb3 : Word}
-    {dividendAbsWord : EvmWord} :
-    (resultSignFixPost (sp + 32) sign limb0 limb1 limb2 limb3 **
-      saveRaDivCallBzeroSavedRaRetFrame sp base divisorSign dividendAbsWord).pcFree := by
-  pcFree
-
-instance pcFreeInst_resultSignFixPost_savedRaRetFrame
-    (sp base divisorSign sign limb0 limb1 limb2 limb3 : Word)
-    (dividendAbsWord : EvmWord) :
-    Assertion.PCFree
-      (resultSignFixPost (sp + 32) sign limb0 limb1 limb2 limb3 **
-        saveRaDivCallBzeroSavedRaRetFrame sp base divisorSign dividendAbsWord) :=
-  ⟨resultSignFixPost_savedRaRetFrame_pcFree⟩
 
 end EvmAsm.Evm64.SDiv.Compose


### PR DESCRIPTION
## Summary
- extract zero-divisor result-sign-fix/return frame PCFree lemmas and instances into BzeroFramePCFree
- leave DivCallPostPcFree focused on the bzero callable post PCFree instance

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.BzeroFramePCFree
- lake build EvmAsm.Evm64.SDiv.Compose.DivCallPostPcFree
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/BzeroFramePCFree.lean EvmAsm/Evm64/SDiv/Compose/DivCallPostPcFree.lean
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build