### PR TITLE
refactor(sdiv): extract bzero callable pcfree

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/BzeroCallablePCFree.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroCallablePCFree.lean
@@ -1,0 +1,36 @@
+/-
+  EvmAsm.Evm64.SDiv.Compose.BzeroCallablePCFree
+
+  PC-free instance for the zero-divisor SDIV callable post bundle.
+-/
+
+import EvmAsm.Evm64.SDiv.Compose.BzeroFramePCFree
+
+namespace EvmAsm.Evm64.SDiv.Compose
+
+open EvmAsm.Rv64.Tactics
+open EvmAsm.Rv64
+
+theorem saveRaDivCallBzeroCallablePost_pcFree
+    {vRa sp base dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word} :
+    (saveRaDivCallBzeroCallablePost vRa sp base
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop).pcFree := by
+  rw [saveRaDivCallBzeroCallablePost_unfold]
+  dsimp
+  rw [EvmAsm.Evm64.divStackDispatchPostNoX1_unfold,
+    EvmAsm.Evm64.divScratchOwnCall_unfold,
+    EvmAsm.Evm64.divScratchOwn_unfold]
+  pcFree
+
+instance pcFreeInst_saveRaDivCallBzeroCallablePost
+    (vRa sp base dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word) :
+    Assertion.PCFree
+      (saveRaDivCallBzeroCallablePost vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) :=
+  ⟨saveRaDivCallBzeroCallablePost_pcFree⟩
+
+end EvmAsm.Evm64.SDiv.Compose

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallPostPcFree.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallPostPcFree.lean
@@ -5,33 +5,4 @@
   separate from `DivCallDispatch.lean`, which is at the Compose line cap.
 -/
 
-import EvmAsm.Evm64.SDiv.Compose.BzeroFramePCFree
-
-namespace EvmAsm.Evm64.SDiv.Compose
-
-open EvmAsm.Rv64.Tactics
-open EvmAsm.Rv64
-
-theorem saveRaDivCallBzeroCallablePost_pcFree
-    {vRa sp base dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word} :
-    (saveRaDivCallBzeroCallablePost vRa sp base
-      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop).pcFree := by
-  rw [saveRaDivCallBzeroCallablePost_unfold]
-  dsimp
-  rw [EvmAsm.Evm64.divStackDispatchPostNoX1_unfold,
-    EvmAsm.Evm64.divScratchOwnCall_unfold,
-    EvmAsm.Evm64.divScratchOwn_unfold]
-  pcFree
-
-instance pcFreeInst_saveRaDivCallBzeroCallablePost
-    (vRa sp base dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word) :
-    Assertion.PCFree
-      (saveRaDivCallBzeroCallablePost vRa sp base
-        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) :=
-  ⟨saveRaDivCallBzeroCallablePost_pcFree⟩
-
-end EvmAsm.Evm64.SDiv.Compose
+import EvmAsm.Evm64.SDiv.Compose.BzeroCallablePCFree


### PR DESCRIPTION
## Summary
- extract the zero-divisor callable-post PCFree lemma and instance into BzeroCallablePCFree
- reduce DivCallPostPcFree to a compatibility import surface

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.BzeroCallablePCFree
- lake build EvmAsm.Evm64.SDiv.Compose.DivCallPostPcFree
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/BzeroCallablePCFree.lean EvmAsm/Evm64/SDiv/Compose/DivCallPostPcFree.lean
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build