### PR TITLE
refactor(sdiv): extract dividend-abs precondition

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/BaseDividendAbsSequence.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BaseDividendAbsSequence.lean
@@ -4,39 +4,12 @@
   SDIV wrapper composition through the dividend absolute-value block.
 -/
 
-import EvmAsm.Evm64.SDiv.Compose.BaseSignSequence
+import EvmAsm.Evm64.SDiv.Compose.DividendAbsPre
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
 open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
-
-/-- Precondition for the SDIV dividend-abs (conditional 2's-complement
-    negation) block. Wraps the register/memory entry shape as an
-    `@[irreducible]` def so downstream proofs do not re-unfold the
-    sepConj atoms at each use site. -/
-@[irreducible]
-def dividendAbsPre (sp sign maskOld valueOld carryOld
-    limb0 limb1 limb2 limb3 : Word) : Assertion :=
-  (.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sign) **
-  (.x10 ↦ᵣ maskOld) ** (.x7 ↦ᵣ valueOld) ** (.x11 ↦ᵣ carryOld) **
-  ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ limb0) **
-  ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ limb1) **
-  ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ limb2) **
-  ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ limb3)
-
-theorem dividendAbsPre_unfold
-    {sp sign maskOld valueOld carryOld limb0 limb1 limb2 limb3 : Word} :
-    dividendAbsPre sp sign maskOld valueOld carryOld
-        limb0 limb1 limb2 limb3 =
-      ((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sign) **
-       (.x10 ↦ᵣ maskOld) ** (.x7 ↦ᵣ valueOld) ** (.x11 ↦ᵣ carryOld) **
-       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ limb0) **
-       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ limb1) **
-       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ limb2) **
-       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ limb3)) := by
-  delta dividendAbsPre
-  rfl
 
 /-- Postcondition for the SDIV dividend-abs block: each limb is XORed
     with `mask = -sign` and the ripple-carry add of `sign` is propagated

--- a/EvmAsm/Evm64/SDiv/Compose/DividendAbsPre.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DividendAbsPre.lean
@@ -1,0 +1,41 @@
+/-
+  EvmAsm.Evm64.SDiv.Compose.DividendAbsPre
+
+  Irreducible precondition for the SDIV dividend absolute-value block.
+-/
+
+import EvmAsm.Evm64.SDiv.Compose.BaseSignSequence
+
+namespace EvmAsm.Evm64.SDiv.Compose
+
+open EvmAsm.Rv64.Tactics
+open EvmAsm.Rv64
+
+/-- Precondition for the SDIV dividend-abs (conditional 2's-complement
+    negation) block. Wraps the register/memory entry shape as an
+    `@[irreducible]` def so downstream proofs do not re-unfold the
+    sepConj atoms at each use site. -/
+@[irreducible]
+def dividendAbsPre (sp sign maskOld valueOld carryOld
+    limb0 limb1 limb2 limb3 : Word) : Assertion :=
+  (.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sign) **
+  (.x10 ↦ᵣ maskOld) ** (.x7 ↦ᵣ valueOld) ** (.x11 ↦ᵣ carryOld) **
+  ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ limb0) **
+  ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ limb1) **
+  ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ limb2) **
+  ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ limb3)
+
+theorem dividendAbsPre_unfold
+    {sp sign maskOld valueOld carryOld limb0 limb1 limb2 limb3 : Word} :
+    dividendAbsPre sp sign maskOld valueOld carryOld
+        limb0 limb1 limb2 limb3 =
+      ((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sign) **
+       (.x10 ↦ᵣ maskOld) ** (.x7 ↦ᵣ valueOld) ** (.x11 ↦ᵣ carryOld) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ limb0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ limb1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ limb2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ limb3)) := by
+  delta dividendAbsPre
+  rfl
+
+end EvmAsm.Evm64.SDiv.Compose


### PR DESCRIPTION
## Summary
- extract dividendAbsPre and its unfold theorem into DividendAbsPre
- keep BaseDividendAbsSequence focused on postconditions and composition proofs

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.DividendAbsPre
- lake build EvmAsm.Evm64.SDiv.Compose.BaseDividendAbsSequence
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/DividendAbsPre.lean EvmAsm/Evm64/SDiv/Compose/BaseDividendAbsSequence.lean
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build EvmAsm.Evm64.SDiv
- lake build