### PR TITLE
refactor(sdiv): extract dividend-abs postcondition

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/BaseDividendAbsSequence.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BaseDividendAbsSequence.lean
@@ -4,55 +4,12 @@
   SDIV wrapper composition through the dividend absolute-value block.
 -/
 
-import EvmAsm.Evm64.SDiv.Compose.DividendAbsPre
+import EvmAsm.Evm64.SDiv.Compose.DividendAbsPost
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
 open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
-
-/-- Postcondition for the SDIV dividend-abs block: each limb is XORed
-    with `mask = -sign` and the ripple-carry add of `sign` is propagated
-    through the four limbs. Wrapped `@[irreducible]` to hide the let
-    chain from downstream proofs. -/
-@[irreducible]
-def dividendAbsPost (sp sign limb0 limb1 limb2 limb3 : Word) : Assertion :=
-  let mask := (0 : Word) - sign
-  let sum0 := (limb0 ^^^ mask) + sign
-  let carry0 := if BitVec.ult sum0 sign then (1 : Word) else 0
-  let sum1 := (limb1 ^^^ mask) + carry0
-  let carry1 := if BitVec.ult sum1 carry0 then (1 : Word) else 0
-  let sum2 := (limb2 ^^^ mask) + carry1
-  let carry2 := if BitVec.ult sum2 carry1 then (1 : Word) else 0
-  let sum3 := (limb3 ^^^ mask) + carry2
-  let carry3 := if BitVec.ult sum3 carry2 then (1 : Word) else 0
-  (.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sign) **
-  (.x10 ↦ᵣ mask) ** (.x7 ↦ᵣ sum3) ** (.x11 ↦ᵣ carry3) **
-  ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ sum0) **
-  ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ sum1) **
-  ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ sum2) **
-  ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ sum3)
-
-theorem dividendAbsPost_unfold
-    {sp sign limb0 limb1 limb2 limb3 : Word} :
-    dividendAbsPost sp sign limb0 limb1 limb2 limb3 =
-      (let mask := (0 : Word) - sign
-       let sum0 := (limb0 ^^^ mask) + sign
-       let carry0 := if BitVec.ult sum0 sign then (1 : Word) else 0
-       let sum1 := (limb1 ^^^ mask) + carry0
-       let carry1 := if BitVec.ult sum1 carry0 then (1 : Word) else 0
-       let sum2 := (limb2 ^^^ mask) + carry1
-       let carry2 := if BitVec.ult sum2 carry1 then (1 : Word) else 0
-       let sum3 := (limb3 ^^^ mask) + carry2
-       let carry3 := if BitVec.ult sum3 carry2 then (1 : Word) else 0
-       (.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sign) **
-       (.x10 ↦ᵣ mask) ** (.x7 ↦ᵣ sum3) ** (.x11 ↦ᵣ carry3) **
-       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ sum0) **
-       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ sum1) **
-       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ sum2) **
-       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ sum3)) := by
-  delta dividendAbsPost
-  rfl
 
 theorem dividendAbs_spec_in_sdivCode
     (sp sign maskOld valueOld carryOld limb0 limb1 limb2 limb3 : Word)

--- a/EvmAsm/Evm64/SDiv/Compose/DividendAbsPost.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DividendAbsPost.lean
@@ -1,0 +1,57 @@
+/-
+  EvmAsm.Evm64.SDiv.Compose.DividendAbsPost
+
+  Irreducible postcondition for the SDIV dividend absolute-value block.
+-/
+
+import EvmAsm.Evm64.SDiv.Compose.DividendAbsPre
+
+namespace EvmAsm.Evm64.SDiv.Compose
+
+open EvmAsm.Rv64.Tactics
+open EvmAsm.Rv64
+
+/-- Postcondition for the SDIV dividend-abs block: each limb is XORed
+    with `mask = -sign` and the ripple-carry add of `sign` is propagated
+    through the four limbs. Wrapped `@[irreducible]` to hide the let
+    chain from downstream proofs. -/
+@[irreducible]
+def dividendAbsPost (sp sign limb0 limb1 limb2 limb3 : Word) : Assertion :=
+  let mask := (0 : Word) - sign
+  let sum0 := (limb0 ^^^ mask) + sign
+  let carry0 := if BitVec.ult sum0 sign then (1 : Word) else 0
+  let sum1 := (limb1 ^^^ mask) + carry0
+  let carry1 := if BitVec.ult sum1 carry0 then (1 : Word) else 0
+  let sum2 := (limb2 ^^^ mask) + carry1
+  let carry2 := if BitVec.ult sum2 carry1 then (1 : Word) else 0
+  let sum3 := (limb3 ^^^ mask) + carry2
+  let carry3 := if BitVec.ult sum3 carry2 then (1 : Word) else 0
+  (.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sign) **
+  (.x10 ↦ᵣ mask) ** (.x7 ↦ᵣ sum3) ** (.x11 ↦ᵣ carry3) **
+  ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ sum0) **
+  ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ sum1) **
+  ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ sum2) **
+  ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ sum3)
+
+theorem dividendAbsPost_unfold
+    {sp sign limb0 limb1 limb2 limb3 : Word} :
+    dividendAbsPost sp sign limb0 limb1 limb2 limb3 =
+      (let mask := (0 : Word) - sign
+       let sum0 := (limb0 ^^^ mask) + sign
+       let carry0 := if BitVec.ult sum0 sign then (1 : Word) else 0
+       let sum1 := (limb1 ^^^ mask) + carry0
+       let carry1 := if BitVec.ult sum1 carry0 then (1 : Word) else 0
+       let sum2 := (limb2 ^^^ mask) + carry1
+       let carry2 := if BitVec.ult sum2 carry1 then (1 : Word) else 0
+       let sum3 := (limb3 ^^^ mask) + carry2
+       let carry3 := if BitVec.ult sum3 carry2 then (1 : Word) else 0
+       (.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sign) **
+       (.x10 ↦ᵣ mask) ** (.x7 ↦ᵣ sum3) ** (.x11 ↦ᵣ carry3) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ sum0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ sum1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ sum2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ sum3)) := by
+  delta dividendAbsPost
+  rfl
+
+end EvmAsm.Evm64.SDiv.Compose


### PR DESCRIPTION
## Summary
- extract dividendAbsPost and its unfold theorem into DividendAbsPost
- keep BaseDividendAbsSequence focused on composition proofs and larger wrapper pre/post definitions

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.DividendAbsPost
- lake build EvmAsm.Evm64.SDiv.Compose.BaseDividendAbsSequence
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/DividendAbsPost.lean EvmAsm/Evm64/SDiv/Compose/BaseDividendAbsSequence.lean
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build EvmAsm.Evm64.SDiv
- lake build