### PR TITLE
refactor(sdiv): extract save-ra dividend-abs postcondition

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/BaseDividendAbsSequence.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BaseDividendAbsSequence.lean
@@ -4,7 +4,7 @@
   SDIV wrapper composition through the dividend absolute-value block.
 -/
 
-import EvmAsm.Evm64.SDiv.Compose.SaveRaDividendAbsPre
+import EvmAsm.Evm64.SDiv.Compose.SaveRaDividendAbsPost
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
@@ -38,64 +38,6 @@ theorem dividendAbs_spec_in_sdivCode
   rw [EvmAsm.Evm64.condNegate256BlockPre_unfold,
     EvmAsm.Evm64.condNegate256BlockPost_unfold] at hSpec
   exact cpsTripleWithin_extend_code hmono hSpec
-
-/-- Postcondition for the SDIV save-ra/signs/dividendAbs prefix. Takes
-    only the bare wrapper inputs; the sign/mask/sum/carry let-chain
-    (~12 derived values) is computed internally so the theorem signature
-    stays flat. Wrapped `@[irreducible]`. -/
-@[irreducible]
-def saveRaSignsThenDividendAbsPost
-    (vRa sp divisorTop limb0 limb1 limb2 dividendTop : Word) : Assertion :=
-  let sign := dividendTop >>> (63 : BitVec 6).toNat
-  let divisorSign := divisorTop >>> (63 : BitVec 6).toNat
-  let mem0 := sp + signExtend12 (0 : BitVec 12)
-  let mem1 := sp + signExtend12 (8 : BitVec 12)
-  let mem2 := sp + signExtend12 (16 : BitVec 12)
-  let mem3 := sp + signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff
-  let divisorMem3 := sp + signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff
-  let mask := (0 : Word) - sign
-  let sum0 := (limb0 ^^^ mask) + sign
-  let carry0 := if BitVec.ult sum0 sign then (1 : Word) else 0
-  let sum1 := (limb1 ^^^ mask) + carry0
-  let carry1 := if BitVec.ult sum1 carry0 then (1 : Word) else 0
-  let sum2 := (limb2 ^^^ mask) + carry1
-  let carry2 := if BitVec.ult sum2 carry1 then (1 : Word) else 0
-  let sum3 := (dividendTop ^^^ mask) + carry2
-  let carry3 := if BitVec.ult sum3 carry2 then (1 : Word) else 0
-  (((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12)))) **
-    ((.x9 ↦ᵣ divisorSign) ** (divisorMem3 ↦ₘ divisorTop))) **
-   ((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sign) **
-    (.x10 ↦ᵣ mask) ** (.x7 ↦ᵣ sum3) ** (.x11 ↦ᵣ carry3) **
-    (mem0 ↦ₘ sum0) ** (mem1 ↦ₘ sum1) **
-    (mem2 ↦ₘ sum2) ** (mem3 ↦ₘ sum3))
-
-theorem saveRaSignsThenDividendAbsPost_unfold
-    {vRa sp divisorTop limb0 limb1 limb2 dividendTop : Word} :
-    saveRaSignsThenDividendAbsPost vRa sp divisorTop limb0 limb1 limb2 dividendTop =
-      (let sign := dividendTop >>> (63 : BitVec 6).toNat
-       let divisorSign := divisorTop >>> (63 : BitVec 6).toNat
-       let mem0 := sp + signExtend12 (0 : BitVec 12)
-       let mem1 := sp + signExtend12 (8 : BitVec 12)
-       let mem2 := sp + signExtend12 (16 : BitVec 12)
-       let mem3 := sp + signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff
-       let divisorMem3 := sp + signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff
-       let mask := (0 : Word) - sign
-       let sum0 := (limb0 ^^^ mask) + sign
-       let carry0 := if BitVec.ult sum0 sign then (1 : Word) else 0
-       let sum1 := (limb1 ^^^ mask) + carry0
-       let carry1 := if BitVec.ult sum1 carry0 then (1 : Word) else 0
-       let sum2 := (limb2 ^^^ mask) + carry1
-       let carry2 := if BitVec.ult sum2 carry1 then (1 : Word) else 0
-       let sum3 := (dividendTop ^^^ mask) + carry2
-       let carry3 := if BitVec.ult sum3 carry2 then (1 : Word) else 0
-       (((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12)))) **
-         ((.x9 ↦ᵣ divisorSign) ** (divisorMem3 ↦ₘ divisorTop))) **
-        ((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sign) **
-         (.x10 ↦ᵣ mask) ** (.x7 ↦ᵣ sum3) ** (.x11 ↦ᵣ carry3) **
-         (mem0 ↦ₘ sum0) ** (mem1 ↦ₘ sum1) **
-         (mem2 ↦ₘ sum2) ** (mem3 ↦ₘ sum3))) := by
-  delta saveRaSignsThenDividendAbsPost
-  rfl
 
 theorem saveRa_signs_then_dividendAbs_spec_in_sdivCode
     (vRa vSavedOld sp sDividendOld sDivisorOld divisorTop

--- a/EvmAsm/Evm64/SDiv/Compose/SaveRaDividendAbsPost.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/SaveRaDividendAbsPost.lean
@@ -1,0 +1,72 @@
+/-
+  EvmAsm.Evm64.SDiv.Compose.SaveRaDividendAbsPost
+
+  Irreducible postcondition for the SDIV save-ra/signs/dividendAbs prefix.
+-/
+
+import EvmAsm.Evm64.SDiv.Compose.SaveRaDividendAbsPre
+
+namespace EvmAsm.Evm64.SDiv.Compose
+
+open EvmAsm.Rv64.Tactics
+open EvmAsm.Rv64
+
+/-- Postcondition for the SDIV save-ra/signs/dividendAbs prefix. Takes
+    only the bare wrapper inputs; the sign/mask/sum/carry let-chain
+    (~12 derived values) is computed internally so the theorem signature
+    stays flat. Wrapped `@[irreducible]`. -/
+@[irreducible]
+def saveRaSignsThenDividendAbsPost
+    (vRa sp divisorTop limb0 limb1 limb2 dividendTop : Word) : Assertion :=
+  let sign := dividendTop >>> (63 : BitVec 6).toNat
+  let divisorSign := divisorTop >>> (63 : BitVec 6).toNat
+  let mem0 := sp + signExtend12 (0 : BitVec 12)
+  let mem1 := sp + signExtend12 (8 : BitVec 12)
+  let mem2 := sp + signExtend12 (16 : BitVec 12)
+  let mem3 := sp + signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff
+  let divisorMem3 := sp + signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff
+  let mask := (0 : Word) - sign
+  let sum0 := (limb0 ^^^ mask) + sign
+  let carry0 := if BitVec.ult sum0 sign then (1 : Word) else 0
+  let sum1 := (limb1 ^^^ mask) + carry0
+  let carry1 := if BitVec.ult sum1 carry0 then (1 : Word) else 0
+  let sum2 := (limb2 ^^^ mask) + carry1
+  let carry2 := if BitVec.ult sum2 carry1 then (1 : Word) else 0
+  let sum3 := (dividendTop ^^^ mask) + carry2
+  let carry3 := if BitVec.ult sum3 carry2 then (1 : Word) else 0
+  (((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12)))) **
+    ((.x9 ↦ᵣ divisorSign) ** (divisorMem3 ↦ₘ divisorTop))) **
+   ((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sign) **
+    (.x10 ↦ᵣ mask) ** (.x7 ↦ᵣ sum3) ** (.x11 ↦ᵣ carry3) **
+    (mem0 ↦ₘ sum0) ** (mem1 ↦ₘ sum1) **
+    (mem2 ↦ₘ sum2) ** (mem3 ↦ₘ sum3))
+
+theorem saveRaSignsThenDividendAbsPost_unfold
+    {vRa sp divisorTop limb0 limb1 limb2 dividendTop : Word} :
+    saveRaSignsThenDividendAbsPost vRa sp divisorTop limb0 limb1 limb2 dividendTop =
+      (let sign := dividendTop >>> (63 : BitVec 6).toNat
+       let divisorSign := divisorTop >>> (63 : BitVec 6).toNat
+       let mem0 := sp + signExtend12 (0 : BitVec 12)
+       let mem1 := sp + signExtend12 (8 : BitVec 12)
+       let mem2 := sp + signExtend12 (16 : BitVec 12)
+       let mem3 := sp + signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff
+       let divisorMem3 := sp + signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff
+       let mask := (0 : Word) - sign
+       let sum0 := (limb0 ^^^ mask) + sign
+       let carry0 := if BitVec.ult sum0 sign then (1 : Word) else 0
+       let sum1 := (limb1 ^^^ mask) + carry0
+       let carry1 := if BitVec.ult sum1 carry0 then (1 : Word) else 0
+       let sum2 := (limb2 ^^^ mask) + carry1
+       let carry2 := if BitVec.ult sum2 carry1 then (1 : Word) else 0
+       let sum3 := (dividendTop ^^^ mask) + carry2
+       let carry3 := if BitVec.ult sum3 carry2 then (1 : Word) else 0
+       (((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12)))) **
+         ((.x9 ↦ᵣ divisorSign) ** (divisorMem3 ↦ₘ divisorTop))) **
+        ((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sign) **
+         (.x10 ↦ᵣ mask) ** (.x7 ↦ᵣ sum3) ** (.x11 ↦ᵣ carry3) **
+         (mem0 ↦ₘ sum0) ** (mem1 ↦ₘ sum1) **
+         (mem2 ↦ₘ sum2) ** (mem3 ↦ₘ sum3))) := by
+  delta saveRaSignsThenDividendAbsPost
+  rfl
+
+end EvmAsm.Evm64.SDiv.Compose


### PR DESCRIPTION
## Summary
- extract saveRaSignsThenDividendAbsPost and its unfold theorem into SaveRaDividendAbsPost
- leave BaseDividendAbsSequence focused on composition specs

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.SaveRaDividendAbsPost
- lake build EvmAsm.Evm64.SDiv.Compose.BaseDividendAbsSequence
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/SaveRaDividendAbsPost.lean EvmAsm/Evm64/SDiv/Compose/BaseDividendAbsSequence.lean
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build EvmAsm.Evm64.SDiv
- lake build