### PR TITLE
refactor(sdiv): extract save-ra signs precondition

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/BaseSignSequence.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BaseSignSequence.lean
@@ -5,7 +5,7 @@
   dividend and divisor sign-bit probes.
 -/
 
-import EvmAsm.Evm64.SDiv.Compose.BaseCode
+import EvmAsm.Evm64.SDiv.Compose.SaveRaSignsPre
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
@@ -105,37 +105,6 @@ theorem divisorSign_spec_in_sdivCode
     (EvmAsm.Evm64.evm_sdiv_sign_bit_block_spec_within .x12 .x9
       EvmAsm.Evm64.evm_sdivDivisorTopLimbOff sp sOld divisorTop
       (base + divisorSignOff) (by decide))
-
-/-- Precondition for the SDIV save-ra + dividend sign + divisor sign
-    composition: standard entry frame with the dividend and divisor top
-    limbs accessible in memory and both sign-register slots holding
-    their pre-call scratch. Wrapped `@[irreducible]` so downstream proofs
-    do not re-reduce the 7-atom sepConj at each use site. -/
-@[irreducible]
-def saveRaDividendSignThenDivisorSignPre
-    (vRa vSavedOld sp sDividendOld dividendTop sDivisorOld divisorTop : Word) :
-    Assertion :=
-  (((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ vSavedOld)) **
-    ((.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sDividendOld) **
-     ((sp + signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ
-       dividendTop))) **
-   ((.x9 ↦ᵣ sDivisorOld) **
-    ((sp + signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff) ↦ₘ
-      divisorTop))
-
-theorem saveRaDividendSignThenDivisorSignPre_unfold
-    {vRa vSavedOld sp sDividendOld dividendTop sDivisorOld divisorTop : Word} :
-    saveRaDividendSignThenDivisorSignPre vRa vSavedOld sp sDividendOld
-        dividendTop sDivisorOld divisorTop =
-      ((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ vSavedOld)) **
-        ((.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sDividendOld) **
-         ((sp + signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ
-           dividendTop))) **
-       ((.x9 ↦ᵣ sDivisorOld) **
-        ((sp + signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff) ↦ₘ
-          divisorTop))) := by
-  delta saveRaDividendSignThenDivisorSignPre
-  rfl
 
 /-- Postcondition for the same composition: `ra` saved to the spill
     slot (x18 ← vRa + 0), `x8` and `x9` hold the dividend/divisor sign

--- a/EvmAsm/Evm64/SDiv/Compose/SaveRaSignsPre.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/SaveRaSignsPre.lean
@@ -1,0 +1,46 @@
+/-
+  EvmAsm.Evm64.SDiv.Compose.SaveRaSignsPre
+
+  Irreducible precondition for the SDIV save-ra/dividend-sign/divisor-sign
+  prefix.
+-/
+
+import EvmAsm.Evm64.SDiv.Compose.BaseCode
+
+namespace EvmAsm.Evm64.SDiv.Compose
+
+open EvmAsm.Rv64.Tactics
+open EvmAsm.Rv64
+
+/-- Precondition for the SDIV save-ra + dividend sign + divisor sign
+    composition: standard entry frame with the dividend and divisor top
+    limbs accessible in memory and both sign-register slots holding
+    their pre-call scratch. Wrapped `@[irreducible]` so downstream proofs
+    do not re-reduce the 7-atom sepConj at each use site. -/
+@[irreducible]
+def saveRaDividendSignThenDivisorSignPre
+    (vRa vSavedOld sp sDividendOld dividendTop sDivisorOld divisorTop : Word) :
+    Assertion :=
+  (((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ vSavedOld)) **
+    ((.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sDividendOld) **
+     ((sp + signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ
+       dividendTop))) **
+   ((.x9 ↦ᵣ sDivisorOld) **
+    ((sp + signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff) ↦ₘ
+      divisorTop))
+
+theorem saveRaDividendSignThenDivisorSignPre_unfold
+    {vRa vSavedOld sp sDividendOld dividendTop sDivisorOld divisorTop : Word} :
+    saveRaDividendSignThenDivisorSignPre vRa vSavedOld sp sDividendOld
+        dividendTop sDivisorOld divisorTop =
+      ((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ vSavedOld)) **
+        ((.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sDividendOld) **
+         ((sp + signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ
+           dividendTop))) **
+       ((.x9 ↦ᵣ sDivisorOld) **
+        ((sp + signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff) ↦ₘ
+          divisorTop))) := by
+  delta saveRaDividendSignThenDivisorSignPre
+  rfl
+
+end EvmAsm.Evm64.SDiv.Compose


### PR DESCRIPTION
## Summary
- extract saveRaDividendSignThenDivisorSignPre and its unfold theorem into SaveRaSignsPre
- leave BaseSignSequence focused on the save-ra/dividend-sign/divisor-sign composition proof

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.SaveRaSignsPre
- lake build EvmAsm.Evm64.SDiv.Compose.BaseSignSequence
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/SaveRaSignsPre.lean EvmAsm/Evm64/SDiv/Compose/BaseSignSequence.lean
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build EvmAsm.Evm64.SDiv
- lake build