### PR TITLE
refactor(sdiv): extract bzero callable post

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/BzeroCallablePost.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroCallablePost.lean
@@ -1,0 +1,84 @@
+/-
+  EvmAsm.Evm64.SDiv.Compose.BzeroCallablePost
+
+  Named postcondition and unfold views for the SDIV zero-divisor div-call
+  path after the unsigned DIV callable returns.
+-/
+
+import EvmAsm.Evm64.SDiv.Compose.DivCall
+import EvmAsm.Evm64.SDiv.Compose.Words
+
+namespace EvmAsm.Evm64.SDiv.Compose
+
+open EvmAsm.Rv64.Tactics
+open EvmAsm.Rv64
+
+/-- Named postcondition after the SDIV prefix has called the unsigned DIV
+    callable along the zero-divisor branch. This keeps the sign frame and the
+    concrete return address bundled for the following result-sign-fix step. -/
+@[irreducible]
+def saveRaDivCallBzeroCallablePost
+    (vRa sp base : Word)
+    (dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word) : Assertion :=
+  let resultSign :=
+    (dividendTop >>> (63 : BitVec 6).toNat) ^^^
+      (divisorTop >>> (63 : BitVec 6).toNat)
+  let divisorSign := divisorTop >>> (63 : BitVec 6).toNat
+  ((EvmAsm.Evm64.divStackDispatchPostNoX1 sp
+      (sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+      (sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) **
+    (.x1 ↦ᵣ ((base + divCallOff) + 4))) **
+   ((.x8 ↦ᵣ resultSign) ** (.x9 ↦ᵣ divisorSign) **
+    (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12)))))
+
+theorem saveRaDivCallBzeroCallablePost_unfold
+    {vRa sp base : Word}
+    {dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word} :
+    saveRaDivCallBzeroCallablePost vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop =
+      (let resultSign :=
+         (dividendTop >>> (63 : BitVec 6).toNat) ^^^
+           (divisorTop >>> (63 : BitVec 6).toNat)
+       let divisorSign := divisorTop >>> (63 : BitVec 6).toNat
+       ((EvmAsm.Evm64.divStackDispatchPostNoX1 sp
+           (sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+           (sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) **
+         (.x1 ↦ᵣ ((base + divCallOff) + 4))) **
+        ((.x8 ↦ᵣ resultSign) ** (.x9 ↦ᵣ divisorSign) **
+         (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12)))))) := by
+  delta saveRaDivCallBzeroCallablePost
+  rfl
+
+/-- Zero-divisor view of `saveRaDivCallBzeroCallablePost`: the unsigned DIV
+    callable's quotient word in the EVM stack result slot is concretely zero. -/
+theorem saveRaDivCallBzeroCallablePost_unfold_zero_quotient
+    {vRa sp base : Word}
+    {dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word}
+    (hbz : sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop = 0) :
+    saveRaDivCallBzeroCallablePost vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop =
+      (let dividendAbsWord :=
+         sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+       let resultSign :=
+         (dividendTop >>> (63 : BitVec 6).toNat) ^^^
+           (divisorTop >>> (63 : BitVec 6).toNat)
+       let divisorSign := divisorTop >>> (63 : BitVec 6).toNat
+       (((.x12 ↦ᵣ (sp + 32)) ** regOwn .x2 **
+         regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+         regOwn .x10 ** regOwn .x11 ** (.x0 ↦ᵣ (0 : Word)) **
+         evmWordIs sp dividendAbsWord ** evmWordIs (sp + 32) (0 : EvmWord) **
+         EvmAsm.Evm64.divScratchOwnCall sp) **
+        (.x1 ↦ᵣ ((base + divCallOff) + 4))) **
+       ((.x8 ↦ᵣ resultSign) ** (.x9 ↦ᵣ divisorSign) **
+        (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12))))) := by
+  rw [saveRaDivCallBzeroCallablePost_unfold,
+    EvmAsm.Evm64.divStackDispatchPostNoX1_unfold]
+  dsimp only
+  rw [hbz, EvmWord.div_zero_right]
+
+end EvmAsm.Evm64.SDiv.Compose

--- a/EvmAsm/Evm64/SDiv/Compose/BzeroPost.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroPost.lean
@@ -5,82 +5,13 @@
   div-call path.
 -/
 
-import EvmAsm.Evm64.SDiv.Compose.DivCall
+import EvmAsm.Evm64.SDiv.Compose.BzeroCallablePost
 import EvmAsm.Evm64.SDiv.Compose.ResultSignFixOwn
-import EvmAsm.Evm64.SDiv.Compose.Words
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
 open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
-
-/-- Named postcondition after the SDIV prefix has called the unsigned DIV
-    callable along the zero-divisor branch. This keeps the sign frame and the
-    concrete return address bundled for the following result-sign-fix step. -/
-@[irreducible]
-def saveRaDivCallBzeroCallablePost
-    (vRa sp base : Word)
-    (dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word) : Assertion :=
-  let resultSign :=
-    (dividendTop >>> (63 : BitVec 6).toNat) ^^^
-      (divisorTop >>> (63 : BitVec 6).toNat)
-  let divisorSign := divisorTop >>> (63 : BitVec 6).toNat
-  ((EvmAsm.Evm64.divStackDispatchPostNoX1 sp
-      (sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
-      (sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) **
-    (.x1 ↦ᵣ ((base + divCallOff) + 4))) **
-   ((.x8 ↦ᵣ resultSign) ** (.x9 ↦ᵣ divisorSign) **
-    (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12)))))
-
-theorem saveRaDivCallBzeroCallablePost_unfold
-    {vRa sp base : Word}
-    {dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word} :
-    saveRaDivCallBzeroCallablePost vRa sp base
-        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop =
-      (let resultSign :=
-         (dividendTop >>> (63 : BitVec 6).toNat) ^^^
-           (divisorTop >>> (63 : BitVec 6).toNat)
-       let divisorSign := divisorTop >>> (63 : BitVec 6).toNat
-       ((EvmAsm.Evm64.divStackDispatchPostNoX1 sp
-           (sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
-           (sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) **
-         (.x1 ↦ᵣ ((base + divCallOff) + 4))) **
-        ((.x8 ↦ᵣ resultSign) ** (.x9 ↦ᵣ divisorSign) **
-         (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12)))))) := by
-  delta saveRaDivCallBzeroCallablePost
-  rfl
-
-/-- Zero-divisor view of `saveRaDivCallBzeroCallablePost`: the unsigned DIV
-    callable's quotient word in the EVM stack result slot is concretely zero. -/
-theorem saveRaDivCallBzeroCallablePost_unfold_zero_quotient
-    {vRa sp base : Word}
-    {dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word}
-    (hbz : sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop = 0) :
-    saveRaDivCallBzeroCallablePost vRa sp base
-        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop =
-      (let dividendAbsWord :=
-         sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-       let resultSign :=
-         (dividendTop >>> (63 : BitVec 6).toNat) ^^^
-           (divisorTop >>> (63 : BitVec 6).toNat)
-       let divisorSign := divisorTop >>> (63 : BitVec 6).toNat
-       (((.x12 ↦ᵣ (sp + 32)) ** regOwn .x2 **
-         regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
-         regOwn .x10 ** regOwn .x11 ** (.x0 ↦ᵣ (0 : Word)) **
-         evmWordIs sp dividendAbsWord ** evmWordIs (sp + 32) (0 : EvmWord) **
-         EvmAsm.Evm64.divScratchOwnCall sp) **
-        (.x1 ↦ᵣ ((base + divCallOff) + 4))) **
-       ((.x8 ↦ᵣ resultSign) ** (.x9 ↦ᵣ divisorSign) **
-        (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12))))) := by
-  rw [saveRaDivCallBzeroCallablePost_unfold,
-    EvmAsm.Evm64.divStackDispatchPostNoX1_unfold]
-  dsimp only
-  rw [hbz, EvmWord.div_zero_right]
 
 /-- Frame left around the result-sign-fix precondition after the SDIV prefix
     and zero-divisor unsigned-DIV callable have run. -/


### PR DESCRIPTION
## Summary
- extract saveRaDivCallBzeroCallablePost and its unfold views into BzeroCallablePost
- leave BzeroPost focused on result-sign-fix frame reshaping lemmas

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.BzeroCallablePost
- lake build EvmAsm.Evm64.SDiv.Compose.BzeroPost
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/BzeroCallablePost.lean EvmAsm/Evm64/SDiv/Compose/BzeroPost.lean
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build EvmAsm.Evm64.SDiv
- lake build