### PR TITLE
refactor(sdiv): extract bzero frames

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/BzeroFrames.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroFrames.lean
@@ -1,0 +1,68 @@
+/-
+  EvmAsm.Evm64.SDiv.Compose.BzeroFrames
+
+  Named frames used after the SDIV zero-divisor unsigned-DIV callable
+  returns.
+-/
+
+import EvmAsm.Evm64.SDiv.Compose.BzeroCallablePost
+import EvmAsm.Evm64.SDiv.Compose.ResultSignFixOwn
+
+namespace EvmAsm.Evm64.SDiv.Compose
+
+open EvmAsm.Rv64.Tactics
+open EvmAsm.Rv64
+
+/-- Frame left around the result-sign-fix precondition after the SDIV prefix
+    and zero-divisor unsigned-DIV callable have run. -/
+@[irreducible]
+def saveRaDivCallBzeroResultSignFixFrame
+    (vRa sp base divisorSign : Word) (dividendAbsWord : EvmWord) : Assertion :=
+  regOwn .x2 ** regOwn .x5 ** regOwn .x6 **
+  evmWordIs sp dividendAbsWord ** EvmAsm.Evm64.divScratchOwnCall sp **
+  (.x1 ↦ᵣ ((base + divCallOff) + 4)) **
+  (.x9 ↦ᵣ divisorSign) **
+  (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12)))
+
+theorem saveRaDivCallBzeroResultSignFixFrame_unfold
+    {vRa sp base divisorSign : Word} {dividendAbsWord : EvmWord} :
+    saveRaDivCallBzeroResultSignFixFrame vRa sp base divisorSign dividendAbsWord =
+      (regOwn .x2 ** regOwn .x5 ** regOwn .x6 **
+       evmWordIs sp dividendAbsWord ** EvmAsm.Evm64.divScratchOwnCall sp **
+       (.x1 ↦ᵣ ((base + divCallOff) + 4)) **
+       (.x9 ↦ᵣ divisorSign) **
+       (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12)))) := by
+  delta saveRaDivCallBzeroResultSignFixFrame
+  rfl
+
+/-- Frame remaining after exposing `x18` for the saved-RA return. -/
+@[irreducible]
+def saveRaDivCallBzeroSavedRaRetFrame
+    (sp base divisorSign : Word) (dividendAbsWord : EvmWord) : Assertion :=
+  regOwn .x2 ** regOwn .x5 ** regOwn .x6 **
+  evmWordIs sp dividendAbsWord ** EvmAsm.Evm64.divScratchOwnCall sp **
+  (.x1 ↦ᵣ ((base + divCallOff) + 4)) **
+  (.x9 ↦ᵣ divisorSign)
+
+theorem saveRaDivCallBzeroSavedRaRetFrame_unfold
+    {sp base divisorSign : Word} {dividendAbsWord : EvmWord} :
+    saveRaDivCallBzeroSavedRaRetFrame sp base divisorSign dividendAbsWord =
+      (regOwn .x2 ** regOwn .x5 ** regOwn .x6 **
+       evmWordIs sp dividendAbsWord ** EvmAsm.Evm64.divScratchOwnCall sp **
+       (.x1 ↦ᵣ ((base + divCallOff) + 4)) **
+       (.x9 ↦ᵣ divisorSign)) := by
+  delta saveRaDivCallBzeroSavedRaRetFrame
+  rfl
+
+/-- Expose the saved return address atom from the bzero result-sign-fix
+    frame, leaving the rest as an explicit return frame. -/
+theorem saveRaDivCallBzeroResultSignFixFrame_to_savedRaRet
+    {vRa sp base divisorSign : Word} {dividendAbsWord : EvmWord} :
+    saveRaDivCallBzeroResultSignFixFrame vRa sp base divisorSign dividendAbsWord =
+      ((.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12))) **
+       saveRaDivCallBzeroSavedRaRetFrame sp base divisorSign dividendAbsWord) := by
+  rw [saveRaDivCallBzeroResultSignFixFrame_unfold,
+    saveRaDivCallBzeroSavedRaRetFrame_unfold]
+  xperm
+
+end EvmAsm.Evm64.SDiv.Compose

--- a/EvmAsm/Evm64/SDiv/Compose/BzeroPost.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroPost.lean
@@ -5,65 +5,12 @@
   div-call path.
 -/
 
-import EvmAsm.Evm64.SDiv.Compose.BzeroCallablePost
-import EvmAsm.Evm64.SDiv.Compose.ResultSignFixOwn
+import EvmAsm.Evm64.SDiv.Compose.BzeroFrames
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
 open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
-
-/-- Frame left around the result-sign-fix precondition after the SDIV prefix
-    and zero-divisor unsigned-DIV callable have run. -/
-@[irreducible]
-def saveRaDivCallBzeroResultSignFixFrame
-    (vRa sp base divisorSign : Word) (dividendAbsWord : EvmWord) : Assertion :=
-  regOwn .x2 ** regOwn .x5 ** regOwn .x6 **
-  evmWordIs sp dividendAbsWord ** EvmAsm.Evm64.divScratchOwnCall sp **
-  (.x1 ↦ᵣ ((base + divCallOff) + 4)) **
-  (.x9 ↦ᵣ divisorSign) **
-  (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12)))
-
-theorem saveRaDivCallBzeroResultSignFixFrame_unfold
-    {vRa sp base divisorSign : Word} {dividendAbsWord : EvmWord} :
-    saveRaDivCallBzeroResultSignFixFrame vRa sp base divisorSign dividendAbsWord =
-      (regOwn .x2 ** regOwn .x5 ** regOwn .x6 **
-       evmWordIs sp dividendAbsWord ** EvmAsm.Evm64.divScratchOwnCall sp **
-       (.x1 ↦ᵣ ((base + divCallOff) + 4)) **
-       (.x9 ↦ᵣ divisorSign) **
-       (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12)))) := by
-  delta saveRaDivCallBzeroResultSignFixFrame
-  rfl
-
-/-- Frame remaining after exposing `x18` for the saved-RA return. -/
-@[irreducible]
-def saveRaDivCallBzeroSavedRaRetFrame
-    (sp base divisorSign : Word) (dividendAbsWord : EvmWord) : Assertion :=
-  regOwn .x2 ** regOwn .x5 ** regOwn .x6 **
-  evmWordIs sp dividendAbsWord ** EvmAsm.Evm64.divScratchOwnCall sp **
-  (.x1 ↦ᵣ ((base + divCallOff) + 4)) **
-  (.x9 ↦ᵣ divisorSign)
-
-theorem saveRaDivCallBzeroSavedRaRetFrame_unfold
-    {sp base divisorSign : Word} {dividendAbsWord : EvmWord} :
-    saveRaDivCallBzeroSavedRaRetFrame sp base divisorSign dividendAbsWord =
-      (regOwn .x2 ** regOwn .x5 ** regOwn .x6 **
-       evmWordIs sp dividendAbsWord ** EvmAsm.Evm64.divScratchOwnCall sp **
-       (.x1 ↦ᵣ ((base + divCallOff) + 4)) **
-       (.x9 ↦ᵣ divisorSign)) := by
-  delta saveRaDivCallBzeroSavedRaRetFrame
-  rfl
-
-/-- Expose the saved return address atom from the bzero result-sign-fix
-    frame, leaving the rest as an explicit return frame. -/
-theorem saveRaDivCallBzeroResultSignFixFrame_to_savedRaRet
-    {vRa sp base divisorSign : Word} {dividendAbsWord : EvmWord} :
-    saveRaDivCallBzeroResultSignFixFrame vRa sp base divisorSign dividendAbsWord =
-      ((.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12))) **
-       saveRaDivCallBzeroSavedRaRetFrame sp base divisorSign dividendAbsWord) := by
-  rw [saveRaDivCallBzeroResultSignFixFrame_unfold,
-    saveRaDivCallBzeroSavedRaRetFrame_unfold]
-  xperm
 
 /-- Zero-divisor callable post reshaped as the result-sign-fix precondition
     over the current quotient cell plus an explicit frame. -/


### PR DESCRIPTION
## Summary
- extract the bzero result-sign-fix and saved-RA return frames into BzeroFrames
- leave BzeroPost focused on callable-post to result-sign-fix reshaping lemmas

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.BzeroFrames
- lake build EvmAsm.Evm64.SDiv.Compose.BzeroPost
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/BzeroFrames.lean EvmAsm/Evm64/SDiv/Compose/BzeroPost.lean
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build EvmAsm.Evm64.SDiv
- lake build