### PR TITLE
refactor(sdiv): extract div-call precondition view

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/DivCallPreView.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallPreView.lean
@@ -1,0 +1,79 @@
+/-
+  EvmAsm.Evm64.SDiv.Compose.DivCallPreView
+
+  Named precondition bundle for the SDIV wrapper prefix through the near
+  call into `evm_div_callable`.
+-/
+
+import EvmAsm.Evm64.SDiv.Compose.DivCallCallable
+import EvmAsm.Evm64.SDiv.Compose.SignXorSequence
+
+namespace EvmAsm.Evm64.SDiv.Compose
+
+open EvmAsm.Rv64.Tactics
+open EvmAsm.Rv64
+
+/-- Precondition for the SDIV save-ra/signs/dividendAbs/divisorAbs/signXor
+    /divCall block: same entry shape as the divisor-abs and signXor
+    sequences. Wrapped `@[irreducible]` so downstream proofs do not
+    re-reduce the 18-atom sepConj at each use site. -/
+@[irreducible]
+def saveRaSignsAbsSignXorThenDivCallPre
+    (vRa vSavedOld sp sDividendOld sDivisorOld
+      dividendMaskOld dividendValueOld dividendCarryOld
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word) : Assertion :=
+  let dividendMem0 := sp + signExtend12 (0 : BitVec 12)
+  let dividendMem1 := sp + signExtend12 (8 : BitVec 12)
+  let dividendMem2 := sp + signExtend12 (16 : BitVec 12)
+  let dividendMem3 := sp + signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff
+  let divisorMem0 := sp + signExtend12 (32 : BitVec 12)
+  let divisorMem1 := sp + signExtend12 (40 : BitVec 12)
+  let divisorMem2 := sp + signExtend12 (48 : BitVec 12)
+  let divisorMem3 := sp + signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff
+  (((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ vSavedOld)) **
+      ((.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sDividendOld) **
+       (dividendMem3 ↦ₘ dividendTop))) **
+     ((.x9 ↦ᵣ sDivisorOld) ** (divisorMem3 ↦ₘ divisorTop))) **
+    (((.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ dividendMaskOld) **
+      (.x7 ↦ᵣ dividendValueOld) ** (.x11 ↦ᵣ dividendCarryOld)) **
+     ((dividendMem0 ↦ₘ dividendLimb0) **
+      (dividendMem1 ↦ₘ dividendLimb1) **
+      (dividendMem2 ↦ₘ dividendLimb2)))) **
+   ((divisorMem0 ↦ₘ divisorLimb0) **
+    (divisorMem1 ↦ₘ divisorLimb1) **
+    (divisorMem2 ↦ₘ divisorLimb2))
+
+theorem saveRaSignsAbsSignXorThenDivCallPre_unfold
+    {vRa vSavedOld sp sDividendOld sDivisorOld
+      dividendMaskOld dividendValueOld dividendCarryOld
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word} :
+    saveRaSignsAbsSignXorThenDivCallPre vRa vSavedOld sp sDividendOld sDivisorOld
+        dividendMaskOld dividendValueOld dividendCarryOld
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop =
+      (let dividendMem0 := sp + signExtend12 (0 : BitVec 12)
+       let dividendMem1 := sp + signExtend12 (8 : BitVec 12)
+       let dividendMem2 := sp + signExtend12 (16 : BitVec 12)
+       let dividendMem3 := sp + signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff
+       let divisorMem0 := sp + signExtend12 (32 : BitVec 12)
+       let divisorMem1 := sp + signExtend12 (40 : BitVec 12)
+       let divisorMem2 := sp + signExtend12 (48 : BitVec 12)
+       let divisorMem3 := sp + signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff
+       (((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ vSavedOld)) **
+           ((.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sDividendOld) **
+            (dividendMem3 ↦ₘ dividendTop))) **
+          ((.x9 ↦ᵣ sDivisorOld) ** (divisorMem3 ↦ₘ divisorTop))) **
+         (((.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ dividendMaskOld) **
+           (.x7 ↦ᵣ dividendValueOld) ** (.x11 ↦ᵣ dividendCarryOld)) **
+          ((dividendMem0 ↦ₘ dividendLimb0) **
+           (dividendMem1 ↦ₘ dividendLimb1) **
+           (dividendMem2 ↦ₘ dividendLimb2)))) **
+        ((divisorMem0 ↦ₘ divisorLimb0) **
+         (divisorMem1 ↦ₘ divisorLimb1) **
+         (divisorMem2 ↦ₘ divisorLimb2))) := by
+  delta saveRaSignsAbsSignXorThenDivCallPre
+  rfl
+
+end EvmAsm.Evm64.SDiv.Compose

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallViews.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallViews.lean
@@ -5,76 +5,12 @@
   near call into `evm_div_callable`.
 -/
 
-import EvmAsm.Evm64.SDiv.Compose.DivCallCallable
-import EvmAsm.Evm64.SDiv.Compose.SignXorSequence
+import EvmAsm.Evm64.SDiv.Compose.DivCallPreView
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
 open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
-
-/-- Precondition for the SDIV save-ra/signs/dividendAbs/divisorAbs/signXor
-    /divCall block: same entry shape as the divisor-abs and signXor
-    sequences. Wrapped `@[irreducible]` so downstream proofs do not
-    re-reduce the 18-atom sepConj at each use site. -/
-@[irreducible]
-def saveRaSignsAbsSignXorThenDivCallPre
-    (vRa vSavedOld sp sDividendOld sDivisorOld
-      dividendMaskOld dividendValueOld dividendCarryOld
-      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word) : Assertion :=
-  let dividendMem0 := sp + signExtend12 (0 : BitVec 12)
-  let dividendMem1 := sp + signExtend12 (8 : BitVec 12)
-  let dividendMem2 := sp + signExtend12 (16 : BitVec 12)
-  let dividendMem3 := sp + signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff
-  let divisorMem0 := sp + signExtend12 (32 : BitVec 12)
-  let divisorMem1 := sp + signExtend12 (40 : BitVec 12)
-  let divisorMem2 := sp + signExtend12 (48 : BitVec 12)
-  let divisorMem3 := sp + signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff
-  (((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ vSavedOld)) **
-      ((.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sDividendOld) **
-       (dividendMem3 ↦ₘ dividendTop))) **
-     ((.x9 ↦ᵣ sDivisorOld) ** (divisorMem3 ↦ₘ divisorTop))) **
-    (((.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ dividendMaskOld) **
-      (.x7 ↦ᵣ dividendValueOld) ** (.x11 ↦ᵣ dividendCarryOld)) **
-     ((dividendMem0 ↦ₘ dividendLimb0) **
-      (dividendMem1 ↦ₘ dividendLimb1) **
-      (dividendMem2 ↦ₘ dividendLimb2)))) **
-   ((divisorMem0 ↦ₘ divisorLimb0) **
-    (divisorMem1 ↦ₘ divisorLimb1) **
-    (divisorMem2 ↦ₘ divisorLimb2))
-
-theorem saveRaSignsAbsSignXorThenDivCallPre_unfold
-    {vRa vSavedOld sp sDividendOld sDivisorOld
-      dividendMaskOld dividendValueOld dividendCarryOld
-      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word} :
-    saveRaSignsAbsSignXorThenDivCallPre vRa vSavedOld sp sDividendOld sDivisorOld
-        dividendMaskOld dividendValueOld dividendCarryOld
-        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop =
-      (let dividendMem0 := sp + signExtend12 (0 : BitVec 12)
-       let dividendMem1 := sp + signExtend12 (8 : BitVec 12)
-       let dividendMem2 := sp + signExtend12 (16 : BitVec 12)
-       let dividendMem3 := sp + signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff
-       let divisorMem0 := sp + signExtend12 (32 : BitVec 12)
-       let divisorMem1 := sp + signExtend12 (40 : BitVec 12)
-       let divisorMem2 := sp + signExtend12 (48 : BitVec 12)
-       let divisorMem3 := sp + signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff
-       (((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ vSavedOld)) **
-           ((.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sDividendOld) **
-            (dividendMem3 ↦ₘ dividendTop))) **
-          ((.x9 ↦ᵣ sDivisorOld) ** (divisorMem3 ↦ₘ divisorTop))) **
-         (((.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ dividendMaskOld) **
-           (.x7 ↦ᵣ dividendValueOld) ** (.x11 ↦ᵣ dividendCarryOld)) **
-          ((dividendMem0 ↦ₘ dividendLimb0) **
-           (dividendMem1 ↦ₘ dividendLimb1) **
-           (dividendMem2 ↦ₘ dividendLimb2)))) **
-        ((divisorMem0 ↦ₘ divisorLimb0) **
-         (divisorMem1 ↦ₘ divisorLimb1) **
-         (divisorMem2 ↦ₘ divisorLimb2))) := by
-  delta saveRaSignsAbsSignXorThenDivCallPre
-  rfl
 
 /-- Postcondition for the SDIV save-ra/signs/dividendAbs/divisorAbs/signXor
     /divCall block: `x1` holds the post-JAL return PC (`base + divCallOff


### PR DESCRIPTION
## Summary
- extract saveRaSignsAbsSignXorThenDivCallPre and its unfold theorem into DivCallPreView
- leave DivCallViews focused on the matching div-call postcondition view

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.DivCallPreView
- lake build EvmAsm.Evm64.SDiv.Compose.DivCallViews
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/DivCallPreView.lean EvmAsm/Evm64/SDiv/Compose/DivCallViews.lean
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build EvmAsm.Evm64.SDiv
- lake build