### PR TITLE
refactor(sdiv): extract result sign-fix owned preconditions

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/ResultSignFixOwn.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/ResultSignFixOwn.lean
@@ -7,35 +7,12 @@
   shape one register at a time.
 -/
 
-import EvmAsm.Evm64.SDiv.Compose.Base
+import EvmAsm.Evm64.SDiv.Compose.ResultSignFixOwnPre
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
 open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
-
-/-- Result sign-fix precondition with `x10` hidden behind ownership. -/
-@[irreducible]
-def resultSignFixPreOwnX10 (sp sign valueOld carryOld
-    limb0 limb1 limb2 limb3 : Word) : Assertion :=
-  (((((((((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp)) ** (.x8 ↦ᵣ sign)) **
-    (.x7 ↦ᵣ valueOld)) ** (.x11 ↦ᵣ carryOld)) **
-    ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ limb0)) **
-    ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ limb1)) **
-    ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ limb2)) **
-    ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ limb3)) ** regOwn .x10
-
-theorem resultSignFixPreOwnX10_unfold
-    {sp sign valueOld carryOld limb0 limb1 limb2 limb3 : Word} :
-    resultSignFixPreOwnX10 sp sign valueOld carryOld limb0 limb1 limb2 limb3 =
-      ((((((((((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp)) ** (.x8 ↦ᵣ sign)) **
-        (.x7 ↦ᵣ valueOld)) ** (.x11 ↦ᵣ carryOld)) **
-        ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ limb0)) **
-        ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ limb1)) **
-        ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ limb2)) **
-        ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ limb3)) ** regOwn .x10) := by
-  delta resultSignFixPreOwnX10
-  rfl
 
 /-- SDIV result sign-fix spec that consumes owned `x10` instead of requiring
     a concrete old mask value. -/
@@ -56,31 +33,6 @@ theorem resultSignFix_regOwn_x10_spec_in_sdivCode
     (resultSignFix_spec_in_sdivCode sp sign maskOld valueOld carryOld
       limb0 limb1 limb2 limb3 base)
 
-/-- Result sign-fix precondition with `x10` and `x7` hidden behind ownership. -/
-@[irreducible]
-def resultSignFixPreOwnX10X7 (sp sign carryOld
-    limb0 limb1 limb2 limb3 : Word) : Assertion :=
-  (((((((((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp)) ** (.x8 ↦ᵣ sign)) **
-    (.x11 ↦ᵣ carryOld)) **
-    ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ limb0)) **
-    ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ limb1)) **
-    ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ limb2)) **
-    ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ limb3)) **
-    regOwn .x10) ** regOwn .x7
-
-theorem resultSignFixPreOwnX10X7_unfold
-    {sp sign carryOld limb0 limb1 limb2 limb3 : Word} :
-    resultSignFixPreOwnX10X7 sp sign carryOld limb0 limb1 limb2 limb3 =
-      ((((((((((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp)) ** (.x8 ↦ᵣ sign)) **
-        (.x11 ↦ᵣ carryOld)) **
-        ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ limb0)) **
-        ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ limb1)) **
-        ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ limb2)) **
-        ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ limb3)) **
-        regOwn .x10) ** regOwn .x7) := by
-  delta resultSignFixPreOwnX10X7
-  rfl
-
 /-- SDIV result sign-fix spec that consumes owned `x10` and `x7`, leaving
     only the old `x11` carry value concrete. -/
 theorem resultSignFix_regOwn_x10_x7_spec_in_sdivCode
@@ -99,29 +51,6 @@ theorem resultSignFix_regOwn_x10_x7_spec_in_sdivCode
     (fun _ hq => hq)
     (resultSignFix_regOwn_x10_spec_in_sdivCode sp sign valueOld carryOld
       limb0 limb1 limb2 limb3 base)
-
-/-- Result sign-fix precondition with all scratch registers hidden behind
-    ownership. -/
-@[irreducible]
-def resultSignFixPreOwnScratch (sp sign limb0 limb1 limb2 limb3 : Word) : Assertion :=
-  (((((((((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp)) ** (.x8 ↦ᵣ sign)) **
-    ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ limb0)) **
-    ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ limb1)) **
-    ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ limb2)) **
-    ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ limb3)) **
-    regOwn .x10) ** regOwn .x7) ** regOwn .x11
-
-theorem resultSignFixPreOwnScratch_unfold
-    {sp sign limb0 limb1 limb2 limb3 : Word} :
-    resultSignFixPreOwnScratch sp sign limb0 limb1 limb2 limb3 =
-      ((((((((((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp)) ** (.x8 ↦ᵣ sign)) **
-        ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ limb0)) **
-        ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ limb1)) **
-        ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ limb2)) **
-        ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ limb3)) **
-        regOwn .x10) ** regOwn .x7) ** regOwn .x11) := by
-  delta resultSignFixPreOwnScratch
-  rfl
 
 /-- SDIV result sign-fix spec that consumes owned `x10`, `x7`, and `x11`. -/
 theorem resultSignFix_regOwn_scratch_spec_in_sdivCode

--- a/EvmAsm/Evm64/SDiv/Compose/ResultSignFixOwnPre.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/ResultSignFixOwnPre.lean
@@ -1,0 +1,86 @@
+/-
+  EvmAsm.Evm64.SDiv.Compose.ResultSignFixOwnPre
+
+  Named preconditions for result sign-fix specs that hide scratch registers
+  behind ownership.
+-/
+
+import EvmAsm.Evm64.SDiv.Compose.Base
+
+namespace EvmAsm.Evm64.SDiv.Compose
+
+open EvmAsm.Rv64.Tactics
+open EvmAsm.Rv64
+
+/-- Result sign-fix precondition with `x10` hidden behind ownership. -/
+@[irreducible]
+def resultSignFixPreOwnX10 (sp sign valueOld carryOld
+    limb0 limb1 limb2 limb3 : Word) : Assertion :=
+  (((((((((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp)) ** (.x8 ↦ᵣ sign)) **
+    (.x7 ↦ᵣ valueOld)) ** (.x11 ↦ᵣ carryOld)) **
+    ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ limb0)) **
+    ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ limb1)) **
+    ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ limb2)) **
+    ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ limb3)) ** regOwn .x10
+
+theorem resultSignFixPreOwnX10_unfold
+    {sp sign valueOld carryOld limb0 limb1 limb2 limb3 : Word} :
+    resultSignFixPreOwnX10 sp sign valueOld carryOld limb0 limb1 limb2 limb3 =
+      ((((((((((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp)) ** (.x8 ↦ᵣ sign)) **
+        (.x7 ↦ᵣ valueOld)) ** (.x11 ↦ᵣ carryOld)) **
+        ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ limb0)) **
+        ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ limb1)) **
+        ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ limb2)) **
+        ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ limb3)) ** regOwn .x10) := by
+  delta resultSignFixPreOwnX10
+  rfl
+
+/-- Result sign-fix precondition with `x10` and `x7` hidden behind ownership. -/
+@[irreducible]
+def resultSignFixPreOwnX10X7 (sp sign carryOld
+    limb0 limb1 limb2 limb3 : Word) : Assertion :=
+  (((((((((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp)) ** (.x8 ↦ᵣ sign)) **
+    (.x11 ↦ᵣ carryOld)) **
+    ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ limb0)) **
+    ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ limb1)) **
+    ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ limb2)) **
+    ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ limb3)) **
+    regOwn .x10) ** regOwn .x7
+
+theorem resultSignFixPreOwnX10X7_unfold
+    {sp sign carryOld limb0 limb1 limb2 limb3 : Word} :
+    resultSignFixPreOwnX10X7 sp sign carryOld limb0 limb1 limb2 limb3 =
+      ((((((((((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp)) ** (.x8 ↦ᵣ sign)) **
+        (.x11 ↦ᵣ carryOld)) **
+        ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ limb0)) **
+        ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ limb1)) **
+        ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ limb2)) **
+        ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ limb3)) **
+        regOwn .x10) ** regOwn .x7) := by
+  delta resultSignFixPreOwnX10X7
+  rfl
+
+/-- Result sign-fix precondition with all scratch registers hidden behind
+    ownership. -/
+@[irreducible]
+def resultSignFixPreOwnScratch (sp sign limb0 limb1 limb2 limb3 : Word) : Assertion :=
+  (((((((((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp)) ** (.x8 ↦ᵣ sign)) **
+    ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ limb0)) **
+    ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ limb1)) **
+    ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ limb2)) **
+    ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ limb3)) **
+    regOwn .x10) ** regOwn .x7) ** regOwn .x11
+
+theorem resultSignFixPreOwnScratch_unfold
+    {sp sign limb0 limb1 limb2 limb3 : Word} :
+    resultSignFixPreOwnScratch sp sign limb0 limb1 limb2 limb3 =
+      ((((((((((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp)) ** (.x8 ↦ᵣ sign)) **
+        ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ limb0)) **
+        ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ limb1)) **
+        ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ limb2)) **
+        ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ limb3)) **
+        regOwn .x10) ** regOwn .x7) ** regOwn .x11) := by
+  delta resultSignFixPreOwnScratch
+  rfl
+
+end EvmAsm.Evm64.SDiv.Compose


### PR DESCRIPTION
## Summary
- extract resultSignFixPreOwnX10, resultSignFixPreOwnX10X7, resultSignFixPreOwnScratch and their unfold lemmas into ResultSignFixOwnPre
- leave ResultSignFixOwn focused on the wrapper specs that consume the owned-register preconditions

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.ResultSignFixOwnPre
- lake build EvmAsm.Evm64.SDiv.Compose.ResultSignFixOwn
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/ResultSignFixOwnPre.lean EvmAsm/Evm64/SDiv/Compose/ResultSignFixOwn.lean
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build EvmAsm.Evm64.SDiv
- lake build