### PR TITLE
refactor(sdiv): extract bzero callable named post

### DIFF
--- a/EvmAsm/Evm64/SDiv.lean
+++ b/EvmAsm/Evm64/SDiv.lean
@@ -31,6 +31,7 @@ import EvmAsm.Evm64.SDiv.Compose.BzeroPost
 import EvmAsm.Evm64.SDiv.Compose.DispatchReadyPost
 import EvmAsm.Evm64.SDiv.Compose.DispatchPrefix
 import EvmAsm.Evm64.SDiv.Compose.BzeroCallable
+import EvmAsm.Evm64.SDiv.Compose.BzeroCallableNamedPost
 import EvmAsm.Evm64.SDiv.Compose.BzeroResultSignFix
 import EvmAsm.Evm64.SDiv.Compose.BzeroReturn
 import EvmAsm.Evm64.SDiv.Compose.BzeroStackViews

--- a/EvmAsm/Evm64/SDiv/Compose/BzeroCallable.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroCallable.lean
@@ -117,39 +117,4 @@ theorem saveRa_signs_abs_signXor_then_divCall_bzero_callable_spec_in_sdivCode
       base (base + resultSignFixOff) hCallable
   simpa [dividendAbsWord, divisorAbsWord, divisorSign, resultSign, signFrame] using hSeq
 
-/-- SDIV wrapper prefix followed by the zero-divisor unsigned-DIV callable,
-    using the named postcondition consumed by later composition slices. -/
-theorem saveRa_signs_abs_signXor_then_divCall_bzero_callable_named_post_spec_in_sdivCode
-    (vRa vSavedOld sp sDividendOld sDivisorOld
-      dividendMaskOld dividendValueOld dividendCarryOld
-      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
-      v2 v5 v6 : Word)
-    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-     shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
-    (base : Word) (hbase : base &&& 1 = 0)
-    (hbz : sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop = 0) :
-    cpsTripleWithin (49 + (EvmAsm.Evm64.unifiedDivBound + 1))
-      base (base + resultSignFixOff) (sdivCode base)
-      (saveRaSignsAbsSignXorThenDivCallPre vRa vSavedOld sp sDividendOld sDivisorOld
-        dividendMaskOld dividendValueOld dividendCarryOld
-        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
-       ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
-        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-          shiftMem nMem jMem retMem dMem dloMem scratchUn0))
-      (saveRaDivCallBzeroCallablePost vRa sp base
-        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) := by
-  have h :=
-    saveRa_signs_abs_signXor_then_divCall_bzero_callable_spec_in_sdivCode
-      vRa vSavedOld sp sDividendOld sDivisorOld
-      dividendMaskOld dividendValueOld dividendCarryOld
-      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
-      v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-      shiftMem nMem jMem retMem dMem dloMem scratchUn0 base hbase hbz
-  rw [saveRaDivCallBzeroCallablePost_unfold]
-  exact h
-
 end EvmAsm.Evm64.SDiv.Compose

--- a/EvmAsm/Evm64/SDiv/Compose/BzeroCallableNamedPost.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroCallableNamedPost.lean
@@ -1,0 +1,49 @@
+/-
+  EvmAsm.Evm64.SDiv.Compose.BzeroCallableNamedPost
+
+  Named-post wrapper for the SDIV zero-divisor callable handoff.
+-/
+
+import EvmAsm.Evm64.SDiv.Compose.BzeroCallable
+
+namespace EvmAsm.Evm64.SDiv.Compose
+
+open EvmAsm.Rv64.Tactics
+open EvmAsm.Rv64
+
+/-- SDIV wrapper prefix followed by the zero-divisor unsigned-DIV callable,
+    using the named postcondition consumed by later composition slices. -/
+theorem saveRa_signs_abs_signXor_then_divCall_bzero_callable_named_post_spec_in_sdivCode
+    (vRa vSavedOld sp sDividendOld sDivisorOld
+      dividendMaskOld dividendValueOld dividendCarryOld
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+      v2 v5 v6 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (base : Word) (hbase : base &&& 1 = 0)
+    (hbz : sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop = 0) :
+    cpsTripleWithin (49 + (EvmAsm.Evm64.unifiedDivBound + 1))
+      base (base + resultSignFixOff) (sdivCode base)
+      (saveRaSignsAbsSignXorThenDivCallPre vRa vSavedOld sp sDividendOld sDivisorOld
+        dividendMaskOld dividendValueOld dividendCarryOld
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
+       ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
+        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0))
+      (saveRaDivCallBzeroCallablePost vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) := by
+  have h :=
+    saveRa_signs_abs_signXor_then_divCall_bzero_callable_spec_in_sdivCode
+      vRa vSavedOld sp sDividendOld sDivisorOld
+      dividendMaskOld dividendValueOld dividendCarryOld
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+      v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 base hbase hbz
+  rw [saveRaDivCallBzeroCallablePost_unfold]
+  exact h
+
+end EvmAsm.Evm64.SDiv.Compose

--- a/EvmAsm/Evm64/SDiv/Compose/BzeroResultSignFix.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroResultSignFix.lean
@@ -4,7 +4,7 @@
   SDIV zero-divisor path through result-sign fixup.
 -/
 
-import EvmAsm.Evm64.SDiv.Compose.BzeroCallable
+import EvmAsm.Evm64.SDiv.Compose.BzeroCallableNamedPost
 import EvmAsm.Evm64.SDiv.Compose.ResultSignFixOwn
 
 namespace EvmAsm.Evm64.SDiv.Compose


### PR DESCRIPTION
## Summary
- extract saveRa_signs_abs_signXor_then_divCall_bzero_callable_named_post_spec_in_sdivCode into BzeroCallableNamedPost
- leave BzeroCallable focused on the generic zero-divisor callable handoff theorem
- update BzeroResultSignFix and the SDIV umbrella import to use the new module

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.BzeroCallableNamedPost
- lake build EvmAsm.Evm64.SDiv.Compose.BzeroResultSignFix
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/BzeroCallableNamedPost.lean EvmAsm/Evm64/SDiv/Compose/BzeroCallable.lean EvmAsm/Evm64/SDiv/Compose/BzeroResultSignFix.lean EvmAsm/Evm64/SDiv.lean
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build