### PR TITLE
refactor(sdiv): extract div-call result-sign-fix named post

### DIFF
--- a/EvmAsm/Evm64/SDiv.lean
+++ b/EvmAsm/Evm64/SDiv.lean
@@ -38,6 +38,7 @@ import EvmAsm.Evm64.SDiv.Compose.BzeroStackViews
 import EvmAsm.Evm64.SDiv.Compose.DivCallDispatch
 import EvmAsm.Evm64.SDiv.Compose.DivCallReturnPosts
 import EvmAsm.Evm64.SDiv.Compose.DivCallResultSignFix
+import EvmAsm.Evm64.SDiv.Compose.DivCallResultSignFixNamedPost
 import EvmAsm.Evm64.SDiv.Compose.DivCallPostPcFree
 import EvmAsm.Evm64.SDiv.Compose.BzeroSemanticViews
 import EvmAsm.Evm64.SDiv.Compose.DivCallDispatchZeroDivisor

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallExactResultSignFixHandoff.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallExactResultSignFixHandoff.lean
@@ -5,6 +5,7 @@
 -/
 
 import EvmAsm.Evm64.SDiv.Compose.DivCallBzeroCallableHandoff
+import EvmAsm.Evm64.SDiv.Compose.DivCallResultSignFixNamedPost
 
 namespace EvmAsm.Evm64.SDiv.Compose
 

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallResultSignFix.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallResultSignFix.lean
@@ -89,48 +89,4 @@ theorem saveRa_signs_abs_signXor_then_divCall_then_resultSignFix_of_callable_pos
       exact hp)
     hPrefix hFix
 
-/-- Named-post wrapper for the generic SDIV callable composition through
-    result-sign-fix, before the saved-RA return. -/
-theorem saveRa_signs_abs_signXor_then_divCall_then_resultSignFix_named_post_of_callable_post_spec_in_sdivCode
-    {nSteps : Nat}
-    (vRa vSavedOld sp sDividendOld sDivisorOld
-      dividendMaskOld dividendValueOld dividendCarryOld
-      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
-      v2 v5 v6 : Word)
-    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-     shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
-    (base : Word)
-    (hCallable :
-      cpsTripleWithin nSteps (base + wrapperEndOff) (base + resultSignFixOff) (sdivCode base)
-        (saveRaDivCallDispatchReadyPost vRa sp base
-          dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-          divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
-          v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
-        (saveRaDivCallBzeroCallablePost vRa sp base
-          dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-          divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)) :
-    cpsTripleWithin ((49 + nSteps) + 21)
-      base ((base + resultSignFixOff) + 84) (sdivCode base)
-      (saveRaSignsAbsSignXorThenDivCallPre vRa vSavedOld sp sDividendOld sDivisorOld
-        dividendMaskOld dividendValueOld dividendCarryOld
-        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
-       ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
-        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-          shiftMem nMem jMem retMem dMem dloMem scratchUn0))
-      (saveRaDivCallResultSignFixPost vRa sp base
-        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) := by
-  rw [saveRaDivCallResultSignFixPost_unfold]
-  exact
-    saveRa_signs_abs_signXor_then_divCall_then_resultSignFix_of_callable_post_spec_in_sdivCode
-      vRa vSavedOld sp sDividendOld sDivisorOld
-      dividendMaskOld dividendValueOld dividendCarryOld
-      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
-      v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-      shiftMem nMem jMem retMem dMem dloMem scratchUn0 base hCallable
-
 end EvmAsm.Evm64.SDiv.Compose

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallResultSignFixNamedPost.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallResultSignFixNamedPost.lean
@@ -1,20 +1,14 @@
-/-
-  EvmAsm.Evm64.SDiv.Compose.DivCallBzeroResultSignFixHandoff
-
-  Zero-divisor SDIV path handoff from the div-call prefix through result-sign-fix.
--/
-
-import EvmAsm.Evm64.SDiv.Compose.DivCallExactReturnHandoff
-import EvmAsm.Evm64.SDiv.Compose.DivCallResultSignFixNamedPost
+import EvmAsm.Evm64.SDiv.Compose.DivCallResultSignFix
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
 open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
-/-- Zero-divisor SDIV path through result-sign-fix, specialized from the
-    sidecar bzero callable handoff and stopping before the saved-RA return. -/
-theorem saveRa_signs_abs_signXor_then_divCall_bzero_then_resultSignFix_named_post_from_handoff_spec_in_sdivCode
+/-- Named-post wrapper for the generic SDIV callable composition through
+    result-sign-fix, before the saved-RA return. -/
+theorem saveRa_signs_abs_signXor_then_divCall_then_resultSignFix_named_post_of_callable_post_spec_in_sdivCode
+    {nSteps : Nat}
     (vRa vSavedOld sp sDividendOld sDivisorOld
       dividendMaskOld dividendValueOld dividendCarryOld
       dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
@@ -22,9 +16,18 @@ theorem saveRa_signs_abs_signXor_then_divCall_bzero_then_resultSignFix_named_pos
       v2 v5 v6 : Word)
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
      shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
-    (base : Word) (hbase : base &&& 1 = 0)
-    (hbz : sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop = 0) :
-    cpsTripleWithin ((49 + (EvmAsm.Evm64.unifiedDivBound + 1)) + 21)
+    (base : Word)
+    (hCallable :
+      cpsTripleWithin nSteps (base + wrapperEndOff) (base + resultSignFixOff) (sdivCode base)
+        (saveRaDivCallDispatchReadyPost vRa sp base
+          dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+          divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+          v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+        (saveRaDivCallBzeroCallablePost vRa sp base
+          dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+          divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)) :
+    cpsTripleWithin ((49 + nSteps) + 21)
       base ((base + resultSignFixOff) + 84) (sdivCode base)
       (saveRaSignsAbsSignXorThenDivCallPre vRa vSavedOld sp sDividendOld sDivisorOld
         dividendMaskOld dividendValueOld dividendCarryOld
@@ -36,19 +39,14 @@ theorem saveRa_signs_abs_signXor_then_divCall_bzero_then_resultSignFix_named_pos
       (saveRaDivCallResultSignFixPost vRa sp base
         dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
         divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) := by
+  rw [saveRaDivCallResultSignFixPost_unfold]
   exact
-    saveRa_signs_abs_signXor_then_divCall_then_resultSignFix_named_post_of_callable_post_spec_in_sdivCode
+    saveRa_signs_abs_signXor_then_divCall_then_resultSignFix_of_callable_post_spec_in_sdivCode
       vRa vSavedOld sp sDividendOld sDivisorOld
       dividendMaskOld dividendValueOld dividendCarryOld
       dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
       divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
       v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-      shiftMem nMem jMem retMem dMem dloMem scratchUn0 base
-      (saveRaDivCallDispatchReadyPost_bzero_callable_spec_in_sdivCode
-        vRa sp base
-        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
-        v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-        shiftMem nMem jMem retMem dMem dloMem scratchUn0 hbase hbz)
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 base hCallable
 
 end EvmAsm.Evm64.SDiv.Compose

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallReturnGeneric.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallReturnGeneric.lean
@@ -1,4 +1,4 @@
-import EvmAsm.Evm64.SDiv.Compose.DivCallResultSignFix
+import EvmAsm.Evm64.SDiv.Compose.DivCallResultSignFixNamedPost
 
 namespace EvmAsm.Evm64.SDiv.Compose
 


### PR DESCRIPTION
Summary:
- extract saveRa_signs_abs_signXor_then_divCall_then_resultSignFix_named_post_of_callable_post_spec_in_sdivCode into DivCallResultSignFixNamedPost
- leave DivCallResultSignFix focused on the generic result-sign-fix composition theorem
- update return/handoff consumers and SDIV umbrella imports

Validation:
- lake build EvmAsm.Evm64.SDiv.Compose.DivCallResultSignFixNamedPost
- lake build EvmAsm.Evm64.SDiv.Compose.DivCallResultSignFix
- lake build EvmAsm.Evm64.SDiv.Compose.DivCallReturnGeneric
- lake build EvmAsm.Evm64.SDiv.Compose.DivCallExactResultSignFixHandoff
- lake build EvmAsm.Evm64.SDiv.Compose.DivCallBzeroResultSignFixHandoff
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" <touched files> (no matches)
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build