### PR TITLE
refactor(sdiv): split bzero return views

### DIFF
--- a/EvmAsm/Evm64/SDiv.lean
+++ b/EvmAsm/Evm64/SDiv.lean
@@ -34,6 +34,8 @@ import EvmAsm.Evm64.SDiv.Compose.BzeroCallable
 import EvmAsm.Evm64.SDiv.Compose.BzeroCallableNamedPost
 import EvmAsm.Evm64.SDiv.Compose.BzeroResultSignFix
 import EvmAsm.Evm64.SDiv.Compose.BzeroReturn
+import EvmAsm.Evm64.SDiv.Compose.BzeroReturnNormalizedView
+import EvmAsm.Evm64.SDiv.Compose.BzeroReturnZeroWordView
 import EvmAsm.Evm64.SDiv.Compose.BzeroStackViews
 import EvmAsm.Evm64.SDiv.Compose.DivCallDispatch
 import EvmAsm.Evm64.SDiv.Compose.DivCallCallableReturnPost

--- a/EvmAsm/Evm64/SDiv/Compose/BzeroReturnNormalizedView.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroReturnNormalizedView.lean
@@ -1,0 +1,67 @@
+/-
+  EvmAsm.Evm64.SDiv.Compose.BzeroReturnNormalizedView
+
+  Normalized return-target view of the SDIV zero-divisor path.
+-/
+
+import EvmAsm.Evm64.SDiv.Compose.BzeroReturn
+import EvmAsm.Evm64.SDiv.Compose.DispatchViews
+
+namespace EvmAsm.Evm64.SDiv.Compose
+
+open EvmAsm.Rv64.Tactics
+open EvmAsm.Rv64
+
+/-- Normalized return-target view of the SDIV zero-divisor path. This hides
+    the two `signExtend12 0` artifacts introduced by the saved-RA move and
+    the final `JALR`, leaving downstream callers with the ordinary masked
+    saved return address. -/
+theorem saveRa_signs_abs_signXor_then_divCall_bzero_then_return_normalized_spec_in_sdivCode
+    (vRa vSavedOld sp sDividendOld sDivisorOld
+      dividendMaskOld dividendValueOld dividendCarryOld
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+      v2 v5 v6 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (base : Word) (hbase : base &&& 1 = 0)
+    (hbz : sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop = 0) :
+    cpsTripleWithin (((49 + (EvmAsm.Evm64.unifiedDivBound + 1)) + 21) + 1)
+      base (vRa &&& ~~~(1 : Word)) (sdivCode base)
+      (saveRaSignsAbsSignXorThenDivCallPre vRa vSavedOld sp sDividendOld sDivisorOld
+        dividendMaskOld dividendValueOld dividendCarryOld
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
+       ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
+        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0))
+      (let dividendAbsWord :=
+         sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+       let resultSign :=
+         (dividendTop >>> (63 : BitVec 6).toNat) ^^^
+           (divisorTop >>> (63 : BitVec 6).toNat)
+       let divisorSign := divisorTop >>> (63 : BitVec 6).toNat
+       (.x18 ↦ᵣ vRa) **
+       (resultSignFixPost (sp + 32) resultSign 0 0 0 0 **
+        saveRaDivCallBzeroSavedRaRetFrame sp base divisorSign dividendAbsWord)) := by
+  have hExit :
+      (((vRa + signExtend12 (0 : BitVec 12)) +
+        signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word)) =
+        (vRa &&& ~~~(1 : Word)) := by
+    rw [signExtend12_0]
+    bv_decide
+  rw [← hExit]
+  exact cpsTripleWithin_weaken (fun _ hp => hp) (fun _ hp => by
+      simp only [signExtend12_0] at hp ⊢
+      have hRa : (vRa + (0 : Word)) = vRa := by bv_decide
+      rw [hRa] at hp
+      exact hp)
+    (saveRa_signs_abs_signXor_then_divCall_bzero_then_return_spec_in_sdivCode
+      vRa vSavedOld sp sDividendOld sDivisorOld
+      dividendMaskOld dividendValueOld dividendCarryOld
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+      v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 base hbase hbz)
+
+end EvmAsm.Evm64.SDiv.Compose

--- a/EvmAsm/Evm64/SDiv/Compose/BzeroReturnViews.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroReturnViews.lean
@@ -1,119 +1,13 @@
 /-
   EvmAsm.Evm64.SDiv.Compose.BzeroReturnViews
 
-  Base return-shaped views of the SDIV zero-divisor path.
+  Compatibility module for base return-shaped views of the SDIV zero-divisor
+  path.
 -/
 
-import EvmAsm.Evm64.SDiv.Compose.BzeroReturn
-import EvmAsm.Evm64.SDiv.Compose.DispatchViews
+import EvmAsm.Evm64.SDiv.Compose.BzeroReturnNormalizedView
+import EvmAsm.Evm64.SDiv.Compose.BzeroReturnZeroWordView
 
 namespace EvmAsm.Evm64.SDiv.Compose
-
-open EvmAsm.Rv64.Tactics
-open EvmAsm.Rv64
-
-/-- Normalized return-target view of the SDIV zero-divisor path. This hides
-    the two `signExtend12 0` artifacts introduced by the saved-RA move and
-    the final `JALR`, leaving downstream callers with the ordinary masked
-    saved return address. -/
-theorem saveRa_signs_abs_signXor_then_divCall_bzero_then_return_normalized_spec_in_sdivCode
-    (vRa vSavedOld sp sDividendOld sDivisorOld
-      dividendMaskOld dividendValueOld dividendCarryOld
-      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
-      v2 v5 v6 : Word)
-    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-     shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
-    (base : Word) (hbase : base &&& 1 = 0)
-    (hbz : sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop = 0) :
-    cpsTripleWithin (((49 + (EvmAsm.Evm64.unifiedDivBound + 1)) + 21) + 1)
-      base (vRa &&& ~~~(1 : Word)) (sdivCode base)
-      (saveRaSignsAbsSignXorThenDivCallPre vRa vSavedOld sp sDividendOld sDivisorOld
-        dividendMaskOld dividendValueOld dividendCarryOld
-        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
-       ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
-        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-          shiftMem nMem jMem retMem dMem dloMem scratchUn0))
-      (let dividendAbsWord :=
-         sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-       let resultSign :=
-         (dividendTop >>> (63 : BitVec 6).toNat) ^^^
-           (divisorTop >>> (63 : BitVec 6).toNat)
-       let divisorSign := divisorTop >>> (63 : BitVec 6).toNat
-       (.x18 ↦ᵣ vRa) **
-       (resultSignFixPost (sp + 32) resultSign 0 0 0 0 **
-        saveRaDivCallBzeroSavedRaRetFrame sp base divisorSign dividendAbsWord)) := by
-  have hExit :
-      (((vRa + signExtend12 (0 : BitVec 12)) +
-        signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word)) =
-        (vRa &&& ~~~(1 : Word)) := by
-    rw [signExtend12_0]
-    bv_decide
-  rw [← hExit]
-  exact cpsTripleWithin_weaken (fun _ hp => hp) (fun _ hp => by
-      simp only [signExtend12_0] at hp ⊢
-      have hRa : (vRa + (0 : Word)) = vRa := by bv_decide
-      rw [hRa] at hp
-      exact hp)
-    (saveRa_signs_abs_signXor_then_divCall_bzero_then_return_spec_in_sdivCode
-      vRa vSavedOld sp sDividendOld sDivisorOld
-      dividendMaskOld dividendValueOld dividendCarryOld
-      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
-      v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-      shiftMem nMem jMem retMem dMem dloMem scratchUn0 base hbase hbz)
-
-/-- Zero-divisor SDIV path through return, with the result stack word exposed
-    as the concrete zero EVM word after result-sign fixup. -/
-theorem saveRa_signs_abs_signXor_then_divCall_bzero_then_return_zero_word_spec_in_sdivCode
-    (vRa vSavedOld sp sDividendOld sDivisorOld
-      dividendMaskOld dividendValueOld dividendCarryOld
-      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
-      v2 v5 v6 : Word)
-    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-     shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
-    (base : Word) (hbase : base &&& 1 = 0)
-    (hbz : sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop = 0) :
-    cpsTripleWithin (((49 + (EvmAsm.Evm64.unifiedDivBound + 1)) + 21) + 1)
-      base (vRa &&& ~~~(1 : Word)) (sdivCode base)
-      (saveRaSignsAbsSignXorThenDivCallPre vRa vSavedOld sp sDividendOld sDivisorOld
-        dividendMaskOld dividendValueOld dividendCarryOld
-        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
-       ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
-        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-          shiftMem nMem jMem retMem dMem dloMem scratchUn0))
-      (let dividendAbsWord :=
-         sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-       let resultSign :=
-         (dividendTop >>> (63 : BitVec 6).toNat) ^^^
-           (divisorTop >>> (63 : BitVec 6).toNat)
-       let divisorSign := divisorTop >>> (63 : BitVec 6).toNat
-       let mask := (0 : Word) - resultSign
-       let sum0 := ((0 : Word) ^^^ mask) + resultSign
-       let carry0 := if BitVec.ult sum0 resultSign then (1 : Word) else 0
-       let sum1 := ((0 : Word) ^^^ mask) + carry0
-       let carry1 := if BitVec.ult sum1 carry0 then (1 : Word) else 0
-       let sum2 := ((0 : Word) ^^^ mask) + carry1
-       let carry2 := if BitVec.ult sum2 carry1 then (1 : Word) else 0
-       let sum3 := ((0 : Word) ^^^ mask) + carry2
-       let carry3 := if BitVec.ult sum3 carry2 then (1 : Word) else 0
-       (.x18 ↦ᵣ vRa) **
-       (((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ (sp + 32)) ** (.x8 ↦ᵣ resultSign) **
-         (.x10 ↦ᵣ mask) ** (.x7 ↦ᵣ (0 : Word)) ** (.x11 ↦ᵣ carry3) **
-         evmWordIs (sp + 32) (0 : EvmWord)) **
-        saveRaDivCallBzeroSavedRaRetFrame sp base divisorSign dividendAbsWord)) := by
-  exact cpsTripleWithin_weaken (fun _ hp => hp) (fun _ hp => by
-      rw [resultSignFixPost_sdivResultSign_zero_word (sp + 32) dividendTop divisorTop] at hp
-      exact hp)
-    (saveRa_signs_abs_signXor_then_divCall_bzero_then_return_normalized_spec_in_sdivCode
-      vRa vSavedOld sp sDividendOld sDivisorOld
-      dividendMaskOld dividendValueOld dividendCarryOld
-      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
-      v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-      shiftMem nMem jMem retMem dMem dloMem scratchUn0 base hbase hbz)
 
 end EvmAsm.Evm64.SDiv.Compose

--- a/EvmAsm/Evm64/SDiv/Compose/BzeroReturnZeroWordView.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroReturnZeroWordView.lean
@@ -1,0 +1,66 @@
+/-
+  EvmAsm.Evm64.SDiv.Compose.BzeroReturnZeroWordView
+
+  Zero-word return view of the SDIV zero-divisor path.
+-/
+
+import EvmAsm.Evm64.SDiv.Compose.BzeroReturnNormalizedView
+
+namespace EvmAsm.Evm64.SDiv.Compose
+
+open EvmAsm.Rv64.Tactics
+open EvmAsm.Rv64
+
+/-- Zero-divisor SDIV path through return, with the result stack word exposed
+    as the concrete zero EVM word after result-sign fixup. -/
+theorem saveRa_signs_abs_signXor_then_divCall_bzero_then_return_zero_word_spec_in_sdivCode
+    (vRa vSavedOld sp sDividendOld sDivisorOld
+      dividendMaskOld dividendValueOld dividendCarryOld
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+      v2 v5 v6 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (base : Word) (hbase : base &&& 1 = 0)
+    (hbz : sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop = 0) :
+    cpsTripleWithin (((49 + (EvmAsm.Evm64.unifiedDivBound + 1)) + 21) + 1)
+      base (vRa &&& ~~~(1 : Word)) (sdivCode base)
+      (saveRaSignsAbsSignXorThenDivCallPre vRa vSavedOld sp sDividendOld sDivisorOld
+        dividendMaskOld dividendValueOld dividendCarryOld
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
+       ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
+        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0))
+      (let dividendAbsWord :=
+         sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+       let resultSign :=
+         (dividendTop >>> (63 : BitVec 6).toNat) ^^^
+           (divisorTop >>> (63 : BitVec 6).toNat)
+       let divisorSign := divisorTop >>> (63 : BitVec 6).toNat
+       let mask := (0 : Word) - resultSign
+       let sum0 := ((0 : Word) ^^^ mask) + resultSign
+       let carry0 := if BitVec.ult sum0 resultSign then (1 : Word) else 0
+       let sum1 := ((0 : Word) ^^^ mask) + carry0
+       let carry1 := if BitVec.ult sum1 carry0 then (1 : Word) else 0
+       let sum2 := ((0 : Word) ^^^ mask) + carry1
+       let carry2 := if BitVec.ult sum2 carry1 then (1 : Word) else 0
+       let sum3 := ((0 : Word) ^^^ mask) + carry2
+       let carry3 := if BitVec.ult sum3 carry2 then (1 : Word) else 0
+       (.x18 ↦ᵣ vRa) **
+       (((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ (sp + 32)) ** (.x8 ↦ᵣ resultSign) **
+         (.x10 ↦ᵣ mask) ** (.x7 ↦ᵣ (0 : Word)) ** (.x11 ↦ᵣ carry3) **
+         evmWordIs (sp + 32) (0 : EvmWord)) **
+        saveRaDivCallBzeroSavedRaRetFrame sp base divisorSign dividendAbsWord)) := by
+  exact cpsTripleWithin_weaken (fun _ hp => hp) (fun _ hp => by
+      rw [resultSignFixPost_sdivResultSign_zero_word (sp + 32) dividendTop divisorTop] at hp
+      exact hp)
+    (saveRa_signs_abs_signXor_then_divCall_bzero_then_return_normalized_spec_in_sdivCode
+      vRa vSavedOld sp sDividendOld sDivisorOld
+      dividendMaskOld dividendValueOld dividendCarryOld
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+      v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 base hbase hbz)
+
+end EvmAsm.Evm64.SDiv.Compose


### PR DESCRIPTION
Summary:
- split the normalized zero-divisor return view into BzeroReturnNormalizedView
- split the zero-word return view into BzeroReturnZeroWordView
- keep BzeroReturnViews as a compatibility importer and register the new modules in the SDIV umbrella

Validation:
- lake build EvmAsm.Evm64.SDiv.Compose.BzeroReturnNormalizedView
- lake build EvmAsm.Evm64.SDiv.Compose.BzeroReturnZeroWordView
- lake build EvmAsm.Evm64.SDiv.Compose.BzeroReturnViews
- lake build EvmAsm.Evm64.SDiv.Compose.BzeroStackTailViews
- lake build EvmAsm.Evm64.SDiv.Compose.BzeroStackViews
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" <touched files> (no matches)
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build