### PR TITLE
refactor(sdiv): extract dividend abs block spec

### DIFF
--- a/EvmAsm/Evm64/SDiv.lean
+++ b/EvmAsm/Evm64/SDiv.lean
@@ -21,6 +21,7 @@ import EvmAsm.Evm64.SDiv.LimbSpec
 import EvmAsm.Evm64.SDiv.AddrNorm
 import EvmAsm.Evm64.SDiv.Compose.Base
 import EvmAsm.Evm64.SDiv.Compose.Bridges
+import EvmAsm.Evm64.SDiv.Compose.BaseDividendAbsBlockSpec
 import EvmAsm.Evm64.SDiv.Compose.DivisorAbsSequence
 import EvmAsm.Evm64.SDiv.Compose.SignXorSequence
 import EvmAsm.Evm64.SDiv.Compose.DivCall

--- a/EvmAsm/Evm64/SDiv/Compose/BaseDividendAbsBlockSpec.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BaseDividendAbsBlockSpec.lean
@@ -1,0 +1,42 @@
+/-
+  EvmAsm.Evm64.SDiv.Compose.BaseDividendAbsBlockSpec
+
+  Leaf SDIV wrapper spec for the dividend absolute-value block.
+-/
+
+import EvmAsm.Evm64.SDiv.Compose.SaveRaDividendAbsPost
+
+namespace EvmAsm.Evm64.SDiv.Compose
+
+open EvmAsm.Rv64.Tactics
+open EvmAsm.Rv64
+
+theorem dividendAbs_spec_in_sdivCode
+    (sp sign maskOld valueOld carryOld limb0 limb1 limb2 limb3 : Word)
+    (base : Word) :
+    cpsTripleWithin 21 (base + dividendAbsOff) ((base + dividendAbsOff) + 84)
+      (sdivCode base)
+      (dividendAbsPre sp sign maskOld valueOld carryOld
+        limb0 limb1 limb2 limb3)
+      (dividendAbsPost sp sign limb0 limb1 limb2 limb3) := by
+  rw [dividendAbsPre_unfold, dividendAbsPost_unfold]
+  have hmono :
+      ∀ a i,
+        (EvmAsm.Evm64.evm_sdiv_cond_negate_256_block_code
+          .x12 .x8 .x10 .x7 .x11 0 8 16 24
+          (base + dividendAbsOff)) a = some i →
+        (sdivCode base) a = some i := by
+    intro a i h
+    exact sdivCode_dividendAbs_sub (base := base) a i
+      (by simpa [dividendAbsCode,
+        EvmAsm.Evm64.evm_sdiv_cond_negate_256_block_code] using h)
+  have hSpec :=
+    EvmAsm.Evm64.evm_sdiv_cond_negate_256_block_spec_within
+      .x12 .x8 .x10 .x7 .x11 0 8 16 24
+      sp sign maskOld valueOld carryOld limb0 limb1 limb2 limb3
+      (base + dividendAbsOff) (by decide) (by decide) (by decide)
+  rw [EvmAsm.Evm64.condNegate256BlockPre_unfold,
+    EvmAsm.Evm64.condNegate256BlockPost_unfold] at hSpec
+  exact cpsTripleWithin_extend_code hmono hSpec
+
+end EvmAsm.Evm64.SDiv.Compose

--- a/EvmAsm/Evm64/SDiv/Compose/BaseDividendAbsSequence.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BaseDividendAbsSequence.lean
@@ -4,40 +4,12 @@
   SDIV wrapper composition through the dividend absolute-value block.
 -/
 
-import EvmAsm.Evm64.SDiv.Compose.SaveRaDividendAbsPost
+import EvmAsm.Evm64.SDiv.Compose.BaseDividendAbsBlockSpec
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
 open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
-
-theorem dividendAbs_spec_in_sdivCode
-    (sp sign maskOld valueOld carryOld limb0 limb1 limb2 limb3 : Word)
-    (base : Word) :
-    cpsTripleWithin 21 (base + dividendAbsOff) ((base + dividendAbsOff) + 84)
-      (sdivCode base)
-      (dividendAbsPre sp sign maskOld valueOld carryOld
-        limb0 limb1 limb2 limb3)
-      (dividendAbsPost sp sign limb0 limb1 limb2 limb3) := by
-  rw [dividendAbsPre_unfold, dividendAbsPost_unfold]
-  have hmono :
-      ∀ a i,
-        (EvmAsm.Evm64.evm_sdiv_cond_negate_256_block_code
-          .x12 .x8 .x10 .x7 .x11 0 8 16 24
-          (base + dividendAbsOff)) a = some i →
-        (sdivCode base) a = some i := by
-    intro a i h
-    exact sdivCode_dividendAbs_sub (base := base) a i
-      (by simpa [dividendAbsCode,
-        EvmAsm.Evm64.evm_sdiv_cond_negate_256_block_code] using h)
-  have hSpec :=
-    EvmAsm.Evm64.evm_sdiv_cond_negate_256_block_spec_within
-      .x12 .x8 .x10 .x7 .x11 0 8 16 24
-      sp sign maskOld valueOld carryOld limb0 limb1 limb2 limb3
-      (base + dividendAbsOff) (by decide) (by decide) (by decide)
-  rw [EvmAsm.Evm64.condNegate256BlockPre_unfold,
-    EvmAsm.Evm64.condNegate256BlockPost_unfold] at hSpec
-  exact cpsTripleWithin_extend_code hmono hSpec
 
 theorem saveRa_signs_then_dividendAbs_spec_in_sdivCode
     (vRa vSavedOld sp sDividendOld sDivisorOld divisorTop


### PR DESCRIPTION
Summary:
- extract dividendAbs_spec_in_sdivCode into BaseDividendAbsBlockSpec
- leave BaseDividendAbsSequence focused on the save-ra/signs through dividend-abs sequencing proof
- register the new module in the SDIV umbrella

Validation:
- lake build EvmAsm.Evm64.SDiv.Compose.BaseDividendAbsBlockSpec
- lake build EvmAsm.Evm64.SDiv.Compose.BaseDividendAbsSequence
- lake build EvmAsm.Evm64.SDiv.Compose.BaseDivisorAbsSequence
- lake build EvmAsm.Evm64.SDiv.Compose.DivisorAbsSequence
- lake build EvmAsm.Evm64.SDiv.Compose.SignXorSequence
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" <touched files> (no matches)
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build