### PR TITLE
refactor(sdiv): extract divisor abs block spec

### DIFF
--- a/EvmAsm/Evm64/SDiv.lean
+++ b/EvmAsm/Evm64/SDiv.lean
@@ -22,6 +22,7 @@ import EvmAsm.Evm64.SDiv.AddrNorm
 import EvmAsm.Evm64.SDiv.Compose.Base
 import EvmAsm.Evm64.SDiv.Compose.Bridges
 import EvmAsm.Evm64.SDiv.Compose.BaseDividendAbsBlockSpec
+import EvmAsm.Evm64.SDiv.Compose.BaseDivisorAbsBlockSpec
 import EvmAsm.Evm64.SDiv.Compose.DivisorAbsSequence
 import EvmAsm.Evm64.SDiv.Compose.SignXorSequence
 import EvmAsm.Evm64.SDiv.Compose.DivCall

--- a/EvmAsm/Evm64/SDiv/Compose/BaseDivisorAbsBlockSpec.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BaseDivisorAbsBlockSpec.lean
@@ -1,0 +1,42 @@
+/-
+  EvmAsm.Evm64.SDiv.Compose.BaseDivisorAbsBlockSpec
+
+  Leaf SDIV wrapper spec for the divisor absolute-value block.
+-/
+
+import EvmAsm.Evm64.SDiv.Compose.BaseDivisorAbsSequence
+
+namespace EvmAsm.Evm64.SDiv.Compose
+
+open EvmAsm.Rv64.Tactics
+open EvmAsm.Rv64
+
+theorem divisorAbs_spec_in_sdivCode
+    (sp sign maskOld valueOld carryOld limb0 limb1 limb2 limb3 : Word)
+    (base : Word) :
+    cpsTripleWithin 21 (base + divisorAbsOff) ((base + divisorAbsOff) + 84)
+      (sdivCode base)
+      (divisorAbsPre sp sign maskOld valueOld carryOld
+        limb0 limb1 limb2 limb3)
+      (divisorAbsPost sp sign limb0 limb1 limb2 limb3) := by
+  rw [divisorAbsPre_unfold, divisorAbsPost_unfold]
+  have hmono :
+      ∀ a i,
+        (EvmAsm.Evm64.evm_sdiv_cond_negate_256_block_code
+          .x12 .x9 .x10 .x7 .x11 32 40 48 56
+          (base + divisorAbsOff)) a = some i →
+        (sdivCode base) a = some i := by
+    intro a i h
+    exact sdivCode_divisorAbs_sub (base := base) a i
+      (by simpa [divisorAbsCode,
+        EvmAsm.Evm64.evm_sdiv_cond_negate_256_block_code] using h)
+  have hSpec :=
+    EvmAsm.Evm64.evm_sdiv_cond_negate_256_block_spec_within
+      .x12 .x9 .x10 .x7 .x11 32 40 48 56
+      sp sign maskOld valueOld carryOld limb0 limb1 limb2 limb3
+      (base + divisorAbsOff) (by decide) (by decide) (by decide)
+  rw [EvmAsm.Evm64.condNegate256BlockPre_unfold,
+    EvmAsm.Evm64.condNegate256BlockPost_unfold] at hSpec
+  exact cpsTripleWithin_extend_code hmono hSpec
+
+end EvmAsm.Evm64.SDiv.Compose

--- a/EvmAsm/Evm64/SDiv/Compose/BaseDivisorAbsSequence.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BaseDivisorAbsSequence.lean
@@ -82,32 +82,4 @@ theorem divisorAbsPost_unfold
   delta divisorAbsPost
   rfl
 
-theorem divisorAbs_spec_in_sdivCode
-    (sp sign maskOld valueOld carryOld limb0 limb1 limb2 limb3 : Word)
-    (base : Word) :
-    cpsTripleWithin 21 (base + divisorAbsOff) ((base + divisorAbsOff) + 84)
-      (sdivCode base)
-      (divisorAbsPre sp sign maskOld valueOld carryOld
-        limb0 limb1 limb2 limb3)
-      (divisorAbsPost sp sign limb0 limb1 limb2 limb3) := by
-  rw [divisorAbsPre_unfold, divisorAbsPost_unfold]
-  have hmono :
-      ∀ a i,
-        (EvmAsm.Evm64.evm_sdiv_cond_negate_256_block_code
-          .x12 .x9 .x10 .x7 .x11 32 40 48 56
-          (base + divisorAbsOff)) a = some i →
-        (sdivCode base) a = some i := by
-    intro a i h
-    exact sdivCode_divisorAbs_sub (base := base) a i
-      (by simpa [divisorAbsCode,
-        EvmAsm.Evm64.evm_sdiv_cond_negate_256_block_code] using h)
-  have hSpec :=
-    EvmAsm.Evm64.evm_sdiv_cond_negate_256_block_spec_within
-      .x12 .x9 .x10 .x7 .x11 32 40 48 56
-      sp sign maskOld valueOld carryOld limb0 limb1 limb2 limb3
-      (base + divisorAbsOff) (by decide) (by decide) (by decide)
-  rw [EvmAsm.Evm64.condNegate256BlockPre_unfold,
-    EvmAsm.Evm64.condNegate256BlockPost_unfold] at hSpec
-  exact cpsTripleWithin_extend_code hmono hSpec
-
 end EvmAsm.Evm64.SDiv.Compose

--- a/EvmAsm/Evm64/SDiv/Compose/DivisorAbsSequence.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivisorAbsSequence.lean
@@ -8,6 +8,7 @@
   `Compose/Base.lean` to respect the per-file line cap on Compose files.
 -/
 
+import EvmAsm.Evm64.SDiv.Compose.BaseDivisorAbsBlockSpec
 import EvmAsm.Evm64.SDiv.Compose.DivisorAbsPost
 
 namespace EvmAsm.Evm64.SDiv.Compose


### PR DESCRIPTION
Summary:
- extract `divisorAbs_spec_in_sdivCode` into `BaseDivisorAbsBlockSpec`
- leave `BaseDivisorAbsSequence` focused on divisor abs pre/post definitions
- update `DivisorAbsSequence` and SDIV umbrella imports

Validation:
- `lake build EvmAsm.Evm64.SDiv.Compose.BaseDivisorAbsBlockSpec`
- `lake build EvmAsm.Evm64.SDiv.Compose.BaseDivisorAbsSequence`
- `lake build EvmAsm.Evm64.SDiv.Compose.DivisorAbsSequence`
- `lake build EvmAsm.Evm64.SDiv`
- `git diff --check`
- forbidden scan for sorry/admit/heartbeat/recdepth options
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `lake build`