### PR TITLE
refactor(sdiv): extract result sign-fix block spec

### DIFF
--- a/EvmAsm/Evm64/SDiv.lean
+++ b/EvmAsm/Evm64/SDiv.lean
@@ -23,6 +23,7 @@ import EvmAsm.Evm64.SDiv.Compose.Base
 import EvmAsm.Evm64.SDiv.Compose.Bridges
 import EvmAsm.Evm64.SDiv.Compose.BaseDividendAbsBlockSpec
 import EvmAsm.Evm64.SDiv.Compose.BaseDivisorAbsBlockSpec
+import EvmAsm.Evm64.SDiv.Compose.BaseResultSignFixBlockSpec
 import EvmAsm.Evm64.SDiv.Compose.DivisorAbsSequence
 import EvmAsm.Evm64.SDiv.Compose.SignXorSequence
 import EvmAsm.Evm64.SDiv.Compose.DivCall

--- a/EvmAsm/Evm64/SDiv/Compose/Base.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/Base.lean
@@ -19,6 +19,7 @@ import EvmAsm.Evm64.SDiv.Compose.BaseSignSequence
 import EvmAsm.Evm64.SDiv.Compose.BaseDividendAbsSequence
 import EvmAsm.Evm64.SDiv.Compose.BaseDivisorAbsSequence
 import EvmAsm.Evm64.SDiv.Compose.BaseResultSignFix
+import EvmAsm.Evm64.SDiv.Compose.BaseResultSignFixBlockSpec
 import EvmAsm.Evm64.SDiv.Compose.BaseFinalBlockSpecs
 
 namespace EvmAsm.Evm64.SDiv.Compose

--- a/EvmAsm/Evm64/SDiv/Compose/BaseResultSignFix.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BaseResultSignFix.lean
@@ -81,32 +81,4 @@ theorem resultSignFixPost_unfold
   delta resultSignFixPost
   rfl
 
-theorem resultSignFix_spec_in_sdivCode
-    (sp sign maskOld valueOld carryOld limb0 limb1 limb2 limb3 : Word)
-    (base : Word) :
-    cpsTripleWithin 21 (base + resultSignFixOff)
-      ((base + resultSignFixOff) + 84) (sdivCode base)
-      (resultSignFixPre sp sign maskOld valueOld carryOld
-        limb0 limb1 limb2 limb3)
-      (resultSignFixPost sp sign limb0 limb1 limb2 limb3) := by
-  rw [resultSignFixPre_unfold, resultSignFixPost_unfold]
-  have hmono :
-      ∀ a i,
-        (EvmAsm.Evm64.evm_sdiv_cond_negate_256_block_code
-          .x12 .x8 .x10 .x7 .x11 0 8 16 24
-          (base + resultSignFixOff)) a = some i →
-        (sdivCode base) a = some i := by
-    intro a i h
-    exact sdivCode_resultSignFix_sub (base := base) a i
-      (by simpa [resultSignFixCode,
-        EvmAsm.Evm64.evm_sdiv_cond_negate_256_block_code] using h)
-  have hSpec :=
-    EvmAsm.Evm64.evm_sdiv_cond_negate_256_block_spec_within
-      .x12 .x8 .x10 .x7 .x11 0 8 16 24
-      sp sign maskOld valueOld carryOld limb0 limb1 limb2 limb3
-      (base + resultSignFixOff) (by decide) (by decide) (by decide)
-  rw [EvmAsm.Evm64.condNegate256BlockPre_unfold,
-    EvmAsm.Evm64.condNegate256BlockPost_unfold] at hSpec
-  exact cpsTripleWithin_extend_code hmono hSpec
-
 end EvmAsm.Evm64.SDiv.Compose

--- a/EvmAsm/Evm64/SDiv/Compose/BaseResultSignFixBlockSpec.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BaseResultSignFixBlockSpec.lean
@@ -1,0 +1,42 @@
+/-
+  EvmAsm.Evm64.SDiv.Compose.BaseResultSignFixBlockSpec
+
+  SDIV wrapper base spec for the result sign-fixup block.
+-/
+
+import EvmAsm.Evm64.SDiv.Compose.BaseResultSignFix
+
+namespace EvmAsm.Evm64.SDiv.Compose
+
+open EvmAsm.Rv64.Tactics
+open EvmAsm.Rv64
+
+theorem resultSignFix_spec_in_sdivCode
+    (sp sign maskOld valueOld carryOld limb0 limb1 limb2 limb3 : Word)
+    (base : Word) :
+    cpsTripleWithin 21 (base + resultSignFixOff)
+      ((base + resultSignFixOff) + 84) (sdivCode base)
+      (resultSignFixPre sp sign maskOld valueOld carryOld
+        limb0 limb1 limb2 limb3)
+      (resultSignFixPost sp sign limb0 limb1 limb2 limb3) := by
+  rw [resultSignFixPre_unfold, resultSignFixPost_unfold]
+  have hmono :
+      ∀ a i,
+        (EvmAsm.Evm64.evm_sdiv_cond_negate_256_block_code
+          .x12 .x8 .x10 .x7 .x11 0 8 16 24
+          (base + resultSignFixOff)) a = some i →
+        (sdivCode base) a = some i := by
+    intro a i h
+    exact sdivCode_resultSignFix_sub (base := base) a i
+      (by simpa [resultSignFixCode,
+        EvmAsm.Evm64.evm_sdiv_cond_negate_256_block_code] using h)
+  have hSpec :=
+    EvmAsm.Evm64.evm_sdiv_cond_negate_256_block_spec_within
+      .x12 .x8 .x10 .x7 .x11 0 8 16 24
+      sp sign maskOld valueOld carryOld limb0 limb1 limb2 limb3
+      (base + resultSignFixOff) (by decide) (by decide) (by decide)
+  rw [EvmAsm.Evm64.condNegate256BlockPre_unfold,
+    EvmAsm.Evm64.condNegate256BlockPost_unfold] at hSpec
+  exact cpsTripleWithin_extend_code hmono hSpec
+
+end EvmAsm.Evm64.SDiv.Compose


### PR DESCRIPTION
Summary:
- extract `resultSignFix_spec_in_sdivCode` into `BaseResultSignFixBlockSpec`
- keep `BaseResultSignFix` focused on result sign-fix pre/post definitions
- update SDIV base and umbrella imports for the new block-spec module

Validation:
- `lake build EvmAsm.Evm64.SDiv.Compose.BaseResultSignFixBlockSpec`
- `lake build EvmAsm.Evm64.SDiv.Compose.BaseResultSignFix`
- `lake build EvmAsm.Evm64.SDiv.Compose.ResultSignFixOwn`
- `lake build EvmAsm.Evm64.SDiv`
- `git diff --check`
- forbidden scan for sorry/admit/heartbeat/recdepth options
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `lake build`