### PR TITLE
refactor(sdiv): narrow final block imports

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/BaseFinalBlockSpecs.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BaseFinalBlockSpecs.lean
@@ -5,7 +5,7 @@
   the near DIV call, result-sign XOR, and saved-`ra` return.
 -/
 
-import EvmAsm.Evm64.SDiv.Compose.BaseResultSignFix
+import EvmAsm.Evm64.SDiv.Compose.BaseCode
 
 namespace EvmAsm.Evm64.SDiv.Compose
 


### PR DESCRIPTION
Summary:
- make `BaseFinalBlockSpecs` import `BaseCode` directly instead of the result sign-fix definition module
- keep final primitive block specs independent from result sign-fix pre/post definitions after the recent split

Validation:
- `lake build EvmAsm.Evm64.SDiv.Compose.BaseFinalBlockSpecs`
- `lake build EvmAsm.Evm64.SDiv.Compose.Base`
- `lake build EvmAsm.Evm64.SDiv`
- `git diff --check`
- forbidden scan for sorry/admit/heartbeat/recdepth options
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `lake build`