### PR TITLE
refactor(sdiv): narrow framed callable imports

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/DivCallExactHandoff.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallExactHandoff.lean
@@ -4,6 +4,7 @@
   Exact-`x1` callable handoff from the SDIV div-call dispatch-ready bundle.
 -/
 
+import EvmAsm.Evm64.SDiv.Compose.DivCallExactCallable
 import EvmAsm.Evm64.SDiv.Compose.DivCallFramedCallable
 
 namespace EvmAsm.Evm64.SDiv.Compose

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallFramedCallable.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallFramedCallable.lean
@@ -5,7 +5,7 @@
   SDIV div-call sidecar proofs.
 -/
 
-import EvmAsm.Evm64.SDiv.Compose.DivCallExactCallable
+import EvmAsm.Evm64.SDiv.Compose.DivCallCallable
 
 namespace EvmAsm.Evm64.SDiv.Compose
 


### PR DESCRIPTION
Summary:
- make `DivCallFramedCallable` depend on the generic callable wrapper instead of the exact-callable module
- import `DivCallExactCallable` directly from `DivCallExactHandoff`, where the exact-pre wrapper is used

Validation:
- `lake build EvmAsm.Evm64.SDiv.Compose.DivCallFramedCallable`
- `lake build EvmAsm.Evm64.SDiv.Compose.DivCallExactHandoff`
- `lake build EvmAsm.Evm64.SDiv.Compose.DivCallBzeroHandoff`
- `lake build EvmAsm.Evm64.SDiv`
- `git diff --check`
- forbidden scan for sorry/admit/heartbeat/recdepth options
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `lake build`