### PR TITLE
refactor(sdiv): wire handoff sidecars

### DIFF
--- a/EvmAsm/Evm64/SDiv.lean
+++ b/EvmAsm/Evm64/SDiv.lean
@@ -53,6 +53,16 @@ import EvmAsm.Evm64.SDiv.Compose.DivCallResultSignFix
 import EvmAsm.Evm64.SDiv.Compose.DivCallResultSignFixNamedPost
 import EvmAsm.Evm64.SDiv.Compose.DivCallAbsComponents
 import EvmAsm.Evm64.SDiv.Compose.DivCallDispatchPcFreeBasics
+import EvmAsm.Evm64.SDiv.Compose.DivCallPostPcFreeBasics
+import EvmAsm.Evm64.SDiv.Compose.DivCallExactCallable
+import EvmAsm.Evm64.SDiv.Compose.DivCallFramedCallable
+import EvmAsm.Evm64.SDiv.Compose.DivCallExactHandoff
+import EvmAsm.Evm64.SDiv.Compose.DivCallBzeroHandoff
+import EvmAsm.Evm64.SDiv.Compose.DivCallBzeroCallableHandoff
+import EvmAsm.Evm64.SDiv.Compose.DivCallExactResultSignFixHandoff
+import EvmAsm.Evm64.SDiv.Compose.DivCallBzeroResultSignFixHandoff
+import EvmAsm.Evm64.SDiv.Compose.DivCallExactReturnHandoff
+import EvmAsm.Evm64.SDiv.Compose.DivCallBzeroReturnHandoff
 import EvmAsm.Evm64.SDiv.Compose.DivCallPostPcFree
 import EvmAsm.Evm64.SDiv.Compose.BzeroSemanticViews
 import EvmAsm.Evm64.SDiv.Compose.DivCallDispatchZeroDivisor

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallBzeroResultSignFixHandoff.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallBzeroResultSignFixHandoff.lean
@@ -4,7 +4,7 @@
   Zero-divisor SDIV path handoff from the div-call prefix through result-sign-fix.
 -/
 
-import EvmAsm.Evm64.SDiv.Compose.DivCallExactReturnHandoff
+import EvmAsm.Evm64.SDiv.Compose.DivCallBzeroHandoff
 import EvmAsm.Evm64.SDiv.Compose.DivCallResultSignFixNamedPost
 
 namespace EvmAsm.Evm64.SDiv.Compose

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallBzeroReturnHandoff.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallBzeroReturnHandoff.lean
@@ -4,7 +4,7 @@
   Zero-divisor SDIV path handoff through result-sign-fix and saved-RA return.
 -/
 
-import EvmAsm.Evm64.SDiv.Compose.DivCallBzeroResultSignFixHandoff
+import EvmAsm.Evm64.SDiv.Compose.DivCallBzeroHandoff
 import EvmAsm.Evm64.SDiv.Compose.DivCallReturnComposition
 
 namespace EvmAsm.Evm64.SDiv.Compose


### PR DESCRIPTION
Summary:
- make bzero result-sign-fix and return handoff modules import the bzero handoff directly instead of broader exact/return modules
- explicitly wire SDIV callable handoff sidecar modules through the SDIV umbrella so they stay reachable after import narrowing

Validation:
- `lake build EvmAsm.Evm64.SDiv.Compose.DivCallBzeroResultSignFixHandoff`
- `lake build EvmAsm.Evm64.SDiv.Compose.DivCallBzeroReturnHandoff`
- `lake build EvmAsm.Evm64.SDiv.Compose.BzeroResultSignFix`
- `lake build EvmAsm.Evm64.SDiv`
- `git diff --check`
- forbidden scan for sorry/admit/heartbeat/recdepth options
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `lake build`