### PR TITLE
refactor(sdiv): narrow pcfree imports

### DIFF
--- a/EvmAsm/Evm64/SDiv.lean
+++ b/EvmAsm/Evm64/SDiv.lean
@@ -63,6 +63,8 @@ import EvmAsm.Evm64.SDiv.Compose.DivCallExactResultSignFixHandoff
 import EvmAsm.Evm64.SDiv.Compose.DivCallBzeroResultSignFixHandoff
 import EvmAsm.Evm64.SDiv.Compose.DivCallExactReturnHandoff
 import EvmAsm.Evm64.SDiv.Compose.DivCallBzeroReturnHandoff
+import EvmAsm.Evm64.SDiv.Compose.ResultSignFixPCFree
+import EvmAsm.Evm64.SDiv.Compose.BzeroFramePCFree
 import EvmAsm.Evm64.SDiv.Compose.DivCallPostPcFree
 import EvmAsm.Evm64.SDiv.Compose.BzeroSemanticViews
 import EvmAsm.Evm64.SDiv.Compose.DivCallDispatchZeroDivisor

--- a/EvmAsm/Evm64/SDiv/Compose/BzeroCallablePCFree.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroCallablePCFree.lean
@@ -4,7 +4,7 @@
   PC-free instance for the zero-divisor SDIV callable post bundle.
 -/
 
-import EvmAsm.Evm64.SDiv.Compose.BzeroFramePCFree
+import EvmAsm.Evm64.SDiv.Compose.BzeroCallablePost
 
 namespace EvmAsm.Evm64.SDiv.Compose
 

--- a/EvmAsm/Evm64/SDiv/Compose/BzeroFramePCFree.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroFramePCFree.lean
@@ -4,6 +4,7 @@
   PC-free instances for zero-divisor SDIV result-sign-fix/return frames.
 -/
 
+import EvmAsm.Evm64.SDiv.Compose.BzeroFrames
 import EvmAsm.Evm64.SDiv.Compose.ResultSignFixPCFree
 
 namespace EvmAsm.Evm64.SDiv.Compose

--- a/EvmAsm/Evm64/SDiv/Compose/ResultSignFixPCFree.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/ResultSignFixPCFree.lean
@@ -4,7 +4,7 @@
   PC-free instances for standalone SDIV result-sign-fix bundles.
 -/
 
-import EvmAsm.Evm64.SDiv.Compose.DivCallBzeroReturnHandoff
+import EvmAsm.Evm64.SDiv.Compose.ResultSignFixOwnPre
 
 namespace EvmAsm.Evm64.SDiv.Compose
 


### PR DESCRIPTION
Summary:
- narrow result-sign-fix and bzero PC-free modules to the definitions they actually use
- wire the PC-free sidecar modules through the SDIV umbrella after import narrowing

Validation:
- `lake build EvmAsm.Evm64.SDiv.Compose.ResultSignFixPCFree`
- `lake build EvmAsm.Evm64.SDiv.Compose.BzeroFramePCFree`
- `lake build EvmAsm.Evm64.SDiv.Compose.BzeroCallablePCFree`
- `lake build EvmAsm.Evm64.SDiv`
- `git diff --check`
- forbidden scan for sorry/admit/heartbeat/recdepth options
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `lake build`