### PR TITLE
refactor(sdiv): narrow div-call post imports

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/DivCallCallableReturnPost.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallCallableReturnPost.lean
@@ -1,4 +1,5 @@
-import EvmAsm.Evm64.SDiv.Compose.DivCallDispatch
+import EvmAsm.Evm64.SDiv.Compose.BzeroFrames
+import EvmAsm.Evm64.SDiv.Compose.Words
 
 namespace EvmAsm.Evm64.SDiv.Compose
 

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallResultSignFix.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallResultSignFix.lean
@@ -1,4 +1,7 @@
+import EvmAsm.Evm64.SDiv.Compose.BzeroPost
 import EvmAsm.Evm64.SDiv.Compose.DivCallReturnPosts
+import EvmAsm.Evm64.SDiv.Compose.DispatchPrefix
+import EvmAsm.Evm64.SDiv.Compose.DispatchReadyPost
 
 namespace EvmAsm.Evm64.SDiv.Compose
 

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallResultSignFixPost.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallResultSignFixPost.lean
@@ -1,4 +1,5 @@
-import EvmAsm.Evm64.SDiv.Compose.DivCallDispatch
+import EvmAsm.Evm64.SDiv.Compose.BzeroFrames
+import EvmAsm.Evm64.SDiv.Compose.Words
 
 namespace EvmAsm.Evm64.SDiv.Compose
 


### PR DESCRIPTION
Summary:
- make div-call callable/result-sign-fix post modules import only the word/frame definitions they use
- add explicit dependencies to `DivCallResultSignFix` for dispatch-prefix, dispatch-ready, and bzero-post reshaping helpers after narrowing the post modules

Validation:
- `lake build EvmAsm.Evm64.SDiv.Compose.DivCallCallableReturnPost`
- `lake build EvmAsm.Evm64.SDiv.Compose.DivCallResultSignFixPost`
- `lake build EvmAsm.Evm64.SDiv.Compose.DivCallReturnPosts`
- `lake build EvmAsm.Evm64.SDiv.Compose.DivCallResultSignFix`
- `lake build EvmAsm.Evm64.SDiv.Compose.DivCallResultSignFixNamedPost`
- `lake build EvmAsm.Evm64.SDiv`
- `git diff --check`
- forbidden scan for sorry/admit/heartbeat/recdepth options
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `lake build`