### PR TITLE
refactor(sdiv): narrow bzero post imports

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/BzeroCallablePost.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroCallablePost.lean
@@ -5,7 +5,8 @@
   path after the unsigned DIV callable returns.
 -/
 
-import EvmAsm.Evm64.SDiv.Compose.DivCall
+import EvmAsm.Evm64.DivMod.Spec.Dispatcher
+import EvmAsm.Evm64.SDiv.Compose.BaseOffsets
 import EvmAsm.Evm64.SDiv.Compose.Words
 
 namespace EvmAsm.Evm64.SDiv.Compose

--- a/EvmAsm/Evm64/SDiv/Compose/BzeroFrames.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroFrames.lean
@@ -5,8 +5,9 @@
   returns.
 -/
 
-import EvmAsm.Evm64.SDiv.Compose.BzeroCallablePost
-import EvmAsm.Evm64.SDiv.Compose.ResultSignFixOwn
+import EvmAsm.Evm64.DivMod.Compose.Base
+import EvmAsm.Evm64.SDiv.Compose.BaseOffsets
+import EvmAsm.Evm64.Stack
 
 namespace EvmAsm.Evm64.SDiv.Compose
 

--- a/EvmAsm/Evm64/SDiv/Compose/BzeroPost.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroPost.lean
@@ -5,7 +5,9 @@
   div-call path.
 -/
 
+import EvmAsm.Evm64.SDiv.Compose.BzeroCallablePost
 import EvmAsm.Evm64.SDiv.Compose.BzeroFrames
+import EvmAsm.Evm64.SDiv.Compose.ResultSignFixOwnPre
 
 namespace EvmAsm.Evm64.SDiv.Compose
 

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallCallableReturnPost.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallCallableReturnPost.lean
@@ -1,4 +1,6 @@
+import EvmAsm.Evm64.EvmWordArith.Div
 import EvmAsm.Evm64.SDiv.Compose.BzeroFrames
+import EvmAsm.Evm64.SDiv.Compose.BaseResultSignFix
 import EvmAsm.Evm64.SDiv.Compose.Words
 
 namespace EvmAsm.Evm64.SDiv.Compose

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallResultSignFix.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallResultSignFix.lean
@@ -2,6 +2,7 @@ import EvmAsm.Evm64.SDiv.Compose.BzeroPost
 import EvmAsm.Evm64.SDiv.Compose.DivCallReturnPosts
 import EvmAsm.Evm64.SDiv.Compose.DispatchPrefix
 import EvmAsm.Evm64.SDiv.Compose.DispatchReadyPost
+import EvmAsm.Evm64.SDiv.Compose.ResultSignFixOwn
 
 namespace EvmAsm.Evm64.SDiv.Compose
 

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallResultSignFixPost.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallResultSignFixPost.lean
@@ -1,4 +1,6 @@
+import EvmAsm.Evm64.EvmWordArith.Div
 import EvmAsm.Evm64.SDiv.Compose.BzeroFrames
+import EvmAsm.Evm64.SDiv.Compose.BaseResultSignFix
 import EvmAsm.Evm64.SDiv.Compose.Words
 
 namespace EvmAsm.Evm64.SDiv.Compose

--- a/EvmAsm/Evm64/SDiv/Compose/Words.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/Words.lean
@@ -4,7 +4,7 @@
   Pure word-level helpers shared by SDIV div-call composition files.
 -/
 
-import EvmAsm.Evm64.SDiv.Compose.Base
+import EvmAsm.Evm64.Stack
 
 namespace EvmAsm.Evm64.SDiv.Compose
 


### PR DESCRIPTION
## Summary
- narrow SDIV pure word helpers away from the broad compose base import
- replace bzero post/frame transitive dependencies with direct imports
- add explicit downstream imports for EvmWord.div and result-sign-fix specs

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.Words EvmAsm.Evm64.SDiv.Compose.BzeroCallablePost EvmAsm.Evm64.SDiv.Compose.BzeroFrames EvmAsm.Evm64.SDiv.Compose.BzeroPost
- lake build EvmAsm.Evm64.SDiv.Compose.DivCallResultSignFix EvmAsm.Evm64.SDiv
- git diff --check
- rg -n '\b(sorry|admit)\b|set_option max(Heartbeats|RecDepth)' <touched files>
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build