### PR TITLE
refactor(sdiv): narrow sign result imports

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/DivisorAbsPre.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivisorAbsPre.lean
@@ -4,7 +4,8 @@
   Irreducible precondition for the SDIV prefix through divisor absolute value.
 -/
 
-import EvmAsm.Evm64.SDiv.Compose.Base
+import EvmAsm.Evm64.SDiv.Program
+import EvmAsm.Rv64.SepLogic
 
 namespace EvmAsm.Evm64.SDiv.Compose
 

--- a/EvmAsm/Evm64/SDiv/Compose/QuadMemBridges.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/QuadMemBridges.lean
@@ -5,7 +5,8 @@
   bridges from `Compose/Base.lean`.
 -/
 
-import EvmAsm.Evm64.SDiv.Compose.Base
+import EvmAsm.Evm64.SDiv.Program
+import EvmAsm.Evm64.Stack
 
 namespace EvmAsm.Evm64.SDiv.Compose
 

--- a/EvmAsm/Evm64/SDiv/Compose/ResultSignFixOwn.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/ResultSignFixOwn.lean
@@ -7,7 +7,9 @@
   shape one register at a time.
 -/
 
+import EvmAsm.Evm64.SDiv.Compose.BaseResultSignFixBlockSpec
 import EvmAsm.Evm64.SDiv.Compose.ResultSignFixOwnPre
+import EvmAsm.Rv64.Tactics.XSimp
 
 namespace EvmAsm.Evm64.SDiv.Compose
 

--- a/EvmAsm/Evm64/SDiv/Compose/ResultSignFixOwnPre.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/ResultSignFixOwnPre.lean
@@ -5,11 +5,10 @@
   behind ownership.
 -/
 
-import EvmAsm.Evm64.SDiv.Compose.Base
+import EvmAsm.Rv64.SepLogic
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
 /-- Result sign-fix precondition with `x10` hidden behind ownership. -/

--- a/EvmAsm/Evm64/SDiv/Compose/ResultSignFixPCFree.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/ResultSignFixPCFree.lean
@@ -4,11 +4,11 @@
   PC-free instances for standalone SDIV result-sign-fix bundles.
 -/
 
+import EvmAsm.Evm64.SDiv.Compose.BaseResultSignFix
 import EvmAsm.Evm64.SDiv.Compose.ResultSignFixOwnPre
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
 theorem resultSignFixPost_pcFree

--- a/EvmAsm/Evm64/SDiv/Compose/SignFrame.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/SignFrame.lean
@@ -5,7 +5,7 @@
   across the unsigned DIV callable.
 -/
 
-import EvmAsm.Evm64.SDiv.Compose.Base
+import EvmAsm.Rv64.SepLogic
 
 namespace EvmAsm.Evm64.SDiv.Compose
 

--- a/EvmAsm/Evm64/SDiv/Compose/SignXorSequence.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/SignXorSequence.lean
@@ -8,6 +8,7 @@
   per-file line cap on Compose files.
 -/
 
+import EvmAsm.Evm64.SDiv.Compose.BaseFinalBlockSpecs
 import EvmAsm.Evm64.SDiv.Compose.SignXorPost
 
 namespace EvmAsm.Evm64.SDiv.Compose


### PR DESCRIPTION
## Summary
- narrow lightweight SDIV sign/result helper modules away from the broad compose base import
- add direct imports for result-sign-fix specs and pc-free dependencies exposed by the narrowing
- add an explicit final-block spec import where sign-xor composition used it transitively

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.ResultSignFixOwnPre EvmAsm.Evm64.SDiv.Compose.ResultSignFixOwn EvmAsm.Evm64.SDiv.Compose.ResultSignFixPCFree EvmAsm.Evm64.SDiv.Compose.DivisorAbsPre EvmAsm.Evm64.SDiv.Compose.QuadMemBridges EvmAsm.Evm64.SDiv.Compose.SignFrame EvmAsm.Evm64.SDiv
- lake build EvmAsm.Evm64.SDiv.Compose.SignXorSequence EvmAsm.Evm64.SDiv
- git diff --check
- rg -n '\b(sorry|admit)\b|set_option max(Heartbeats|RecDepth)' <touched files>
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build