### PR TITLE
refactor(sdiv): narrow dispatch ready imports

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/DispatchReadyPost.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DispatchReadyPost.lean
@@ -5,13 +5,13 @@
   prefix has normalized signs and absolute values.
 -/
 
-import EvmAsm.Evm64.SDiv.Compose.Base
+import EvmAsm.Evm64.DivMod.Spec.Dispatcher
+import EvmAsm.Evm64.SDiv.Compose.BaseOffsets
 import EvmAsm.Evm64.SDiv.Compose.SignFrame
 import EvmAsm.Evm64.SDiv.Compose.Words
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
 /-- Post-shape consumed by `evm_div_callable_spec_in_sdivCode`: the


### PR DESCRIPTION
## Summary
- replace the broad SDIV compose base import in DispatchReadyPost with direct dispatcher and offset dependencies
- drop the stale Rv64.Tactics namespace open from the pc-free-only module

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.DispatchReadyPost EvmAsm.Evm64.SDiv
- git diff --check
- rg -n '\b(sorry|admit)\b|set_option max(Heartbeats|RecDepth)' EvmAsm/Evm64/SDiv/Compose/DispatchReadyPost.lean
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build