### PR TITLE
refactor(sdiv): narrow dispatch stack imports

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/DispatchStackViews.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DispatchStackViews.lean
@@ -4,8 +4,9 @@
   Stack-entry folding lemmas for the SDIV div-call dispatch composition.
 -/
 
-import EvmAsm.Evm64.SDiv.Compose.DivCall
-import EvmAsm.Evm64.SDiv.Compose.Words
+import EvmAsm.Evm64.SDiv.Compose.DivCallPreView
+import EvmAsm.Evm64.Stack
+import EvmAsm.Rv64.Tactics.XSimp
 
 namespace EvmAsm.Evm64.SDiv.Compose
 


### PR DESCRIPTION
## Summary
- replace the broad DivCall import in DispatchStackViews with the div-call precondition view, stack helpers, and xperm tactic imports
- keep the stack folding lemmas independent of later div-call continuation files

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.DispatchStackViews EvmAsm.Evm64.SDiv
- git diff --check
- rg -n '\b(sorry|admit)\b|set_option max(Heartbeats|RecDepth)' EvmAsm/Evm64/SDiv/Compose/DispatchStackViews.lean
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build