### PR TITLE
refactor(sdiv): narrow div-call callable imports

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/DispatchPrefix.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DispatchPrefix.lean
@@ -4,6 +4,7 @@
   Generic SDIV prefix sequencing into the unsigned DIV callable handoff shape.
 -/
 
+import EvmAsm.Evm64.SDiv.Compose.Base
 import EvmAsm.Evm64.SDiv.Compose.DivCall
 import EvmAsm.Evm64.SDiv.Compose.Bridges
 import EvmAsm.Evm64.SDiv.Compose.DispatchReadyPost

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallCallable.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallCallable.lean
@@ -5,7 +5,8 @@
   the full SDIV code region.
 -/
 
-import EvmAsm.Evm64.SDiv.Compose.Base
+import EvmAsm.Evm64.DivMod.Callable
+import EvmAsm.Evm64.SDiv.Compose.BaseCode
 
 namespace EvmAsm.Evm64.SDiv.Compose
 


### PR DESCRIPTION
## Summary
- replace DivCallCallable's broad SDIV compose base import with direct DivMod callable and SDIV BaseCode dependencies
- make DispatchPrefix's target-PC lemma dependency explicit after removing the accidental re-export path

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.DivCallCallable EvmAsm.Evm64.SDiv.Compose.DispatchPrefix EvmAsm.Evm64.SDiv
- git diff --check
- rg -n '\b(sorry|admit)\b|set_option max(Heartbeats|RecDepth)' EvmAsm/Evm64/SDiv/Compose/DivCallCallable.lean EvmAsm/Evm64/SDiv/Compose/DispatchPrefix.lean
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build