### PR TITLE
refactor(sdiv): narrow dispatch prefix imports

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/DispatchPrefix.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DispatchPrefix.lean
@@ -5,8 +5,8 @@
 -/
 
 import EvmAsm.Evm64.SDiv.Compose.Base
-import EvmAsm.Evm64.SDiv.Compose.DivCall
 import EvmAsm.Evm64.SDiv.Compose.Bridges
+import EvmAsm.Evm64.SDiv.Compose.DivCallDispatchFrame
 import EvmAsm.Evm64.SDiv.Compose.DispatchReadyPost
 
 namespace EvmAsm.Evm64.SDiv.Compose


### PR DESCRIPTION
## Summary
- replace DispatchPrefix's broad DivCall import with the exact DivCallDispatchFrame dependency it uses
- leave the target-PC helper dependency explicit through the existing base import

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.DispatchPrefix EvmAsm.Evm64.SDiv
- git diff --check
- rg -n '\b(sorry|admit)\b|set_option max(Heartbeats|RecDepth)' EvmAsm/Evm64/SDiv/Compose/DispatchPrefix.lean
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build