### PR TITLE
refactor(sdiv): narrow result sign base imports

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/BaseResultSignFix.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BaseResultSignFix.lean
@@ -4,11 +4,10 @@
   SDIV wrapper base spec for the result sign-fixup block.
 -/
 
-import EvmAsm.Evm64.SDiv.Compose.BaseDivisorAbsSequence
+import EvmAsm.Rv64.SepLogic
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
 /-- Precondition for the SDIV result sign-fixup (conditional 2's-complement

--- a/EvmAsm/Evm64/SDiv/Compose/BaseResultSignFixBlockSpec.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BaseResultSignFixBlockSpec.lean
@@ -4,6 +4,7 @@
   SDIV wrapper base spec for the result sign-fixup block.
 -/
 
+import EvmAsm.Evm64.SDiv.Compose.BaseCode
 import EvmAsm.Evm64.SDiv.Compose.BaseResultSignFix
 
 namespace EvmAsm.Evm64.SDiv.Compose


### PR DESCRIPTION
## Summary
- narrow BaseResultSignFix to the separation-logic layer instead of importing the divisor-abs sequence
- add the direct BaseCode dependency to the result-sign-fix block spec that uses sdivCode/resultSignFixCode subsumption

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.BaseResultSignFix EvmAsm.Evm64.SDiv.Compose.BaseResultSignFixBlockSpec EvmAsm.Evm64.SDiv
- git diff --check
- rg -n '\b(sorry|admit)\b|set_option max(Heartbeats|RecDepth)' EvmAsm/Evm64/SDiv/Compose/BaseResultSignFix.lean EvmAsm/Evm64/SDiv/Compose/BaseResultSignFixBlockSpec.lean
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build