### PR TITLE
refactor(sdiv): clean pcfree namespace opens

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/BzeroCallablePCFree.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroCallablePCFree.lean
@@ -8,7 +8,6 @@ import EvmAsm.Evm64.SDiv.Compose.BzeroCallablePost
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
 theorem saveRaDivCallBzeroCallablePost_pcFree

--- a/EvmAsm/Evm64/SDiv/Compose/BzeroFramePCFree.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroFramePCFree.lean
@@ -9,7 +9,6 @@ import EvmAsm.Evm64.SDiv.Compose.ResultSignFixPCFree
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
 theorem saveRaDivCallBzeroResultSignFixFrame_pcFree

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallDispatchPcFreeBasics.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallDispatchPcFreeBasics.lean
@@ -9,7 +9,6 @@ import EvmAsm.Evm64.SDiv.Compose.DivCallResultSignFix
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
 theorem divModStackDispatchPre_pcFree


### PR DESCRIPTION
## Summary
- remove stale Rv64.Tactics namespace opens from SDIV pc-free-only modules
- keep pc-free proofs relying on the SepLogic pcFree tactic already provided by their imports

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.BzeroCallablePCFree EvmAsm.Evm64.SDiv.Compose.BzeroFramePCFree EvmAsm.Evm64.SDiv.Compose.DivCallDispatchPcFreeBasics EvmAsm.Evm64.SDiv
- git diff --check
- rg -n '\b(sorry|admit)\b|set_option max(Heartbeats|RecDepth)' EvmAsm/Evm64/SDiv/Compose/BzeroCallablePCFree.lean EvmAsm/Evm64/SDiv/Compose/BzeroFramePCFree.lean EvmAsm/Evm64/SDiv/Compose/DivCallDispatchPcFreeBasics.lean
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build