### PR TITLE
refactor(sdiv): clean definition namespace opens

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/DividendAbsPost.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DividendAbsPost.lean
@@ -8,7 +8,6 @@ import EvmAsm.Evm64.SDiv.Compose.DividendAbsPre
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
 /-- Postcondition for the SDIV dividend-abs block: each limb is XORed

--- a/EvmAsm/Evm64/SDiv/Compose/DividendAbsPre.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DividendAbsPre.lean
@@ -8,7 +8,6 @@ import EvmAsm.Evm64.SDiv.Compose.BaseSignSequence
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
 /-- Precondition for the SDIV dividend-abs (conditional 2's-complement

--- a/EvmAsm/Evm64/SDiv/Compose/DivisorAbsPre.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivisorAbsPre.lean
@@ -9,7 +9,6 @@ import EvmAsm.Rv64.SepLogic
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
 /-- Precondition for the SDIV save-ra/signs/dividendAbs/divisorAbs block

--- a/EvmAsm/Evm64/SDiv/Compose/SignXorPost.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/SignXorPost.lean
@@ -8,7 +8,6 @@ import EvmAsm.Evm64.SDiv.Compose.SignXorPre
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
 /-- Postcondition for the SDIV save-ra/signs/dividendAbs/divisorAbs/signXor

--- a/EvmAsm/Evm64/SDiv/Compose/SignXorPre.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/SignXorPre.lean
@@ -8,7 +8,6 @@ import EvmAsm.Evm64.SDiv.Compose.DivisorAbsSequence
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
 /-- Precondition for the SDIV save-ra/signs/dividendAbs/divisorAbs/signXor

--- a/EvmAsm/Evm64/SDiv/Compose/Words.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/Words.lean
@@ -8,7 +8,6 @@ import EvmAsm.Evm64.Stack
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
 /-- Absolute-value word produced by the SDIV dividend sign/absolute-value


### PR DESCRIPTION
## Summary
- remove stale Rv64.Tactics namespace opens from SDIV definition/algebra modules
- keep the modules focused on Rv64 data/assertion names without importing tactic namespace state

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.Words EvmAsm.Evm64.SDiv.Compose.DivisorAbsPre EvmAsm.Evm64.SDiv.Compose.DividendAbsPre EvmAsm.Evm64.SDiv.Compose.DividendAbsPost EvmAsm.Evm64.SDiv.Compose.SignXorPre EvmAsm.Evm64.SDiv.Compose.SignXorPost EvmAsm.Evm64.SDiv
- git diff --check
- rg -n '\b(sorry|admit)\b|set_option max(Heartbeats|RecDepth)' <touched files>
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build