### PR TITLE
refactor(sdiv): clean prepost namespace opens

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/DivCallPostView.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallPostView.lean
@@ -9,7 +9,6 @@ import EvmAsm.Evm64.SDiv.Compose.DivCallPreView
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
 /-- Postcondition for the SDIV save-ra/signs/dividendAbs/divisorAbs/signXor

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallPreView.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallPreView.lean
@@ -10,7 +10,6 @@ import EvmAsm.Evm64.SDiv.Compose.SignXorSequence
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
 /-- Precondition for the SDIV save-ra/signs/dividendAbs/divisorAbs/signXor

--- a/EvmAsm/Evm64/SDiv/Compose/DivisorAbsPost.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivisorAbsPost.lean
@@ -8,7 +8,6 @@ import EvmAsm.Evm64.SDiv.Compose.DivisorAbsPre
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
 /-- Postcondition for the SDIV save-ra/signs/dividendAbs/divisorAbs block.

--- a/EvmAsm/Evm64/SDiv/Compose/SaveRaDividendAbsPost.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/SaveRaDividendAbsPost.lean
@@ -8,7 +8,6 @@ import EvmAsm.Evm64.SDiv.Compose.SaveRaDividendAbsPre
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
 /-- Postcondition for the SDIV save-ra/signs/dividendAbs prefix. Takes

--- a/EvmAsm/Evm64/SDiv/Compose/SaveRaDividendAbsPre.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/SaveRaDividendAbsPre.lean
@@ -8,7 +8,6 @@ import EvmAsm.Evm64.SDiv.Compose.DividendAbsPost
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
 /-- Precondition for the SDIV save-ra + dividend/divisor signs +

--- a/EvmAsm/Evm64/SDiv/Compose/SaveRaSignsPost.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/SaveRaSignsPost.lean
@@ -9,7 +9,6 @@ import EvmAsm.Evm64.SDiv.Compose.SaveRaSignsPre
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
 /-- Postcondition for the save-ra + dividend sign + divisor sign

--- a/EvmAsm/Evm64/SDiv/Compose/SaveRaSignsPre.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/SaveRaSignsPre.lean
@@ -9,7 +9,6 @@ import EvmAsm.Evm64.SDiv.Compose.BaseCode
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
 /-- Precondition for the SDIV save-ra + dividend sign + divisor sign


### PR DESCRIPTION
## Summary
- remove stale Rv64.Tactics namespace opens from SDIV named pre/post definition modules
- keep tactic namespace imports concentrated in modules that actually use proof automation

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.SaveRaSignsPre EvmAsm.Evm64.SDiv.Compose.SaveRaSignsPost EvmAsm.Evm64.SDiv.Compose.SaveRaDividendAbsPre EvmAsm.Evm64.SDiv.Compose.SaveRaDividendAbsPost EvmAsm.Evm64.SDiv.Compose.DivisorAbsPost EvmAsm.Evm64.SDiv.Compose.DivCallPreView EvmAsm.Evm64.SDiv.Compose.DivCallPostView EvmAsm.Evm64.SDiv
- git diff --check
- rg -n '\b(sorry|admit)\b|set_option max(Heartbeats|RecDepth)' <touched files>
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build