### PR TITLE
refactor(sdiv): clean post helper namespace opens

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/BzeroCallablePost.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroCallablePost.lean
@@ -11,7 +11,6 @@ import EvmAsm.Evm64.SDiv.Compose.Words
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
 /-- Named postcondition after the SDIV prefix has called the unsigned DIV

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallAbsComponents.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallAbsComponents.lean
@@ -9,7 +9,6 @@ import EvmAsm.Evm64.SDiv.Compose.DivCallResultSignFix
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
 abbrev sdivAbsSign (top : Word) : Word :=

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallCallableReturnPost.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallCallableReturnPost.lean
@@ -5,7 +5,6 @@ import EvmAsm.Evm64.SDiv.Compose.Words
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
 @[irreducible]

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallResultSignFixPost.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallResultSignFixPost.lean
@@ -5,7 +5,6 @@ import EvmAsm.Evm64.SDiv.Compose.Words
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
 @[irreducible]


### PR DESCRIPTION
## Summary
- remove unused Rv64.Tactics namespace opens from SDIV post/helper modules
- keep tactic-bearing frame modules untouched

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.BzeroCallablePost EvmAsm.Evm64.SDiv.Compose.DivCallAbsComponents EvmAsm.Evm64.SDiv.Compose.DivCallCallableReturnPost EvmAsm.Evm64.SDiv.Compose.DivCallResultSignFixPost EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "set_option max(Heartbeats|RecDepth)|\b(sorry|admit)\b" EvmAsm/Evm64/SDiv/Compose/BzeroCallablePost.lean EvmAsm/Evm64/SDiv/Compose/DivCallAbsComponents.lean EvmAsm/Evm64/SDiv/Compose/DivCallCallableReturnPost.lean EvmAsm/Evm64/SDiv/Compose/DivCallResultSignFixPost.lean
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build