### PR TITLE
refactor(sdiv): clean semantic view namespace opens

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/BzeroSemanticConcreteRunStackView.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroSemanticConcreteRunStackView.lean
@@ -8,7 +8,6 @@ import EvmAsm.Evm64.SDiv.Compose.BzeroSemanticRunStackView
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
 /-- Zero-divisor SDIV bzero path with the concrete successful `runSDivStack?`

--- a/EvmAsm/Evm64/SDiv/Compose/BzeroSemanticHandlerView.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroSemanticHandlerView.lean
@@ -9,7 +9,6 @@ import EvmAsm.Evm64.SDiv.HandlerBridge
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
 /-- Zero-divisor SDIV bzero path with the post stack named by the pure

--- a/EvmAsm/Evm64/SDiv/Compose/BzeroSemanticResultView.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroSemanticResultView.lean
@@ -9,7 +9,6 @@ import EvmAsm.Evm64.SDiv.Compose.DivCallDispatch
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
 /-- Caller-visible zero-divisor SDIV path with the produced stack word named

--- a/EvmAsm/Evm64/SDiv/Compose/BzeroSemanticRunStackView.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroSemanticRunStackView.lean
@@ -9,7 +9,6 @@ import EvmAsm.Evm64.SDiv.StackExecutionBridge
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
 /-- Zero-divisor SDIV bzero path with the post stack named by a concrete

--- a/EvmAsm/Evm64/SDiv/Compose/BzeroSemanticStackAfterView.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroSemanticStackAfterView.lean
@@ -8,7 +8,6 @@ import EvmAsm.Evm64.SDiv.Compose.BzeroSemanticResultView
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
 /-- Caller-visible zero-divisor SDIV path with the post stack named through


### PR DESCRIPTION
## Summary
- remove unused Rv64.Tactics namespace opens from SDIV bzero semantic view adapters
- keep proofs and imports otherwise unchanged

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.BzeroSemanticResultView EvmAsm.Evm64.SDiv.Compose.BzeroSemanticStackAfterView EvmAsm.Evm64.SDiv.Compose.BzeroSemanticRunStackView EvmAsm.Evm64.SDiv.Compose.BzeroSemanticConcreteRunStackView EvmAsm.Evm64.SDiv.Compose.BzeroSemanticHandlerView EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "set_option max(Heartbeats|RecDepth)|\b(sorry|admit)\b" EvmAsm/Evm64/SDiv/Compose/BzeroSemanticResultView.lean EvmAsm/Evm64/SDiv/Compose/BzeroSemanticStackAfterView.lean EvmAsm/Evm64/SDiv/Compose/BzeroSemanticRunStackView.lean EvmAsm/Evm64/SDiv/Compose/BzeroSemanticConcreteRunStackView.lean EvmAsm/Evm64/SDiv/Compose/BzeroSemanticHandlerView.lean
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build