### PR TITLE
refactor(sdiv): clean leaf spec namespace opens

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/BaseCode.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BaseCode.lean
@@ -8,7 +8,6 @@ import EvmAsm.Evm64.SDiv.Compose.CodeHandles
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
 theorem sdivCode_saveRa_sub {base : Word} :

--- a/EvmAsm/Evm64/SDiv/Compose/BaseDividendAbsBlockSpec.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BaseDividendAbsBlockSpec.lean
@@ -8,7 +8,6 @@ import EvmAsm.Evm64.SDiv.Compose.SaveRaDividendAbsPost
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
 theorem dividendAbs_spec_in_sdivCode

--- a/EvmAsm/Evm64/SDiv/Compose/BaseDivisorAbsBlockSpec.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BaseDivisorAbsBlockSpec.lean
@@ -8,7 +8,6 @@ import EvmAsm.Evm64.SDiv.Compose.BaseDivisorAbsSequence
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
 theorem divisorAbs_spec_in_sdivCode

--- a/EvmAsm/Evm64/SDiv/Compose/BaseFinalBlockSpecs.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BaseFinalBlockSpecs.lean
@@ -9,7 +9,6 @@ import EvmAsm.Evm64.SDiv.Compose.BaseCode
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
 theorem divCall_spec_in_sdivCode

--- a/EvmAsm/Evm64/SDiv/Compose/BaseResultSignFixBlockSpec.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BaseResultSignFixBlockSpec.lean
@@ -9,7 +9,6 @@ import EvmAsm.Evm64.SDiv.Compose.BaseResultSignFix
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
 theorem resultSignFix_spec_in_sdivCode

--- a/EvmAsm/Evm64/SDiv/Compose/CodeHandles.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/CodeHandles.lean
@@ -10,7 +10,6 @@ import EvmAsm.Evm64.SDiv.Compose.BaseOffsets
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
 /-- Full SDIV code region handle: wrapper followed by `evm_div_callable`. -/

--- a/EvmAsm/Evm64/SDiv/Compose/SaveRaSignBlockSpecs.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/SaveRaSignBlockSpecs.lean
@@ -9,7 +9,6 @@ import EvmAsm.Evm64.SDiv.Compose.BaseCode
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
 theorem saveRa_spec_in_sdivCode


### PR DESCRIPTION
## Summary
- remove unused Rv64.Tactics namespace opens from SDIV code-handle and leaf block-spec modules
- leave proof terms and imports otherwise unchanged

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.CodeHandles EvmAsm.Evm64.SDiv.Compose.BaseCode EvmAsm.Evm64.SDiv.Compose.BaseFinalBlockSpecs EvmAsm.Evm64.SDiv.Compose.BaseDividendAbsBlockSpec EvmAsm.Evm64.SDiv.Compose.BaseDivisorAbsBlockSpec EvmAsm.Evm64.SDiv.Compose.BaseResultSignFixBlockSpec EvmAsm.Evm64.SDiv.Compose.SaveRaSignBlockSpecs EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "set_option max(Heartbeats|RecDepth)|\b(sorry|admit)\b" EvmAsm/Evm64/SDiv/Compose/CodeHandles.lean EvmAsm/Evm64/SDiv/Compose/BaseCode.lean EvmAsm/Evm64/SDiv/Compose/BaseFinalBlockSpecs.lean EvmAsm/Evm64/SDiv/Compose/BaseDividendAbsBlockSpec.lean EvmAsm/Evm64/SDiv/Compose/BaseDivisorAbsBlockSpec.lean EvmAsm/Evm64/SDiv/Compose/BaseResultSignFixBlockSpec.lean EvmAsm/Evm64/SDiv/Compose/SaveRaSignBlockSpecs.lean
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build