### PR TITLE
refactor(sdiv): clean bzero view namespace opens

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/BzeroCallableNamedPost.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroCallableNamedPost.lean
@@ -8,7 +8,6 @@ import EvmAsm.Evm64.SDiv.Compose.BzeroCallable
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
 /-- SDIV wrapper prefix followed by the zero-divisor unsigned-DIV callable,

--- a/EvmAsm/Evm64/SDiv/Compose/BzeroReturnNormalizedView.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroReturnNormalizedView.lean
@@ -9,7 +9,6 @@ import EvmAsm.Evm64.SDiv.Compose.DispatchViews
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
 /-- Normalized return-target view of the SDIV zero-divisor path. This hides

--- a/EvmAsm/Evm64/SDiv/Compose/BzeroReturnZeroWordRestView.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroReturnZeroWordRestView.lean
@@ -8,7 +8,6 @@ import EvmAsm.Evm64.SDiv.Compose.BzeroReturnViews
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
 /-- Framed variant of the SDIV zero-divisor return path that preserves the

--- a/EvmAsm/Evm64/SDiv/Compose/BzeroReturnZeroWordView.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroReturnZeroWordView.lean
@@ -8,7 +8,6 @@ import EvmAsm.Evm64.SDiv.Compose.BzeroReturnNormalizedView
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
 /-- Zero-divisor SDIV path through return, with the result stack word exposed

--- a/EvmAsm/Evm64/SDiv/Compose/BzeroStackZeroDivisorView.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroStackZeroDivisorView.lean
@@ -8,7 +8,6 @@ import EvmAsm.Evm64.SDiv.Compose.BzeroStackEntryViews
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
 /-- Caller-visible zero-divisor specialization of the SDIV bzero stack-entry


### PR DESCRIPTION
## Summary
- remove unused Rv64.Tactics namespace opens from SDIV zero-divisor view wrapper modules
- keep proofs and imports otherwise unchanged

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.BzeroCallableNamedPost EvmAsm.Evm64.SDiv.Compose.BzeroReturnNormalizedView EvmAsm.Evm64.SDiv.Compose.BzeroReturnZeroWordView EvmAsm.Evm64.SDiv.Compose.BzeroReturnZeroWordRestView EvmAsm.Evm64.SDiv.Compose.BzeroStackZeroDivisorView EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "set_option max(Heartbeats|RecDepth)|\b(sorry|admit)\b" EvmAsm/Evm64/SDiv/Compose/BzeroCallableNamedPost.lean EvmAsm/Evm64/SDiv/Compose/BzeroReturnNormalizedView.lean EvmAsm/Evm64/SDiv/Compose/BzeroReturnZeroWordView.lean EvmAsm/Evm64/SDiv/Compose/BzeroReturnZeroWordRestView.lean EvmAsm/Evm64/SDiv/Compose/BzeroStackZeroDivisorView.lean
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build