### PR TITLE
refactor(sdiv): clean handoff wrapper namespace opens

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/DivCallBzeroCallableHandoff.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallBzeroCallableHandoff.lean
@@ -8,7 +8,6 @@ import EvmAsm.Evm64.SDiv.Compose.DivCallBzeroHandoff
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
 /-- SDIV wrapper prefix followed by the zero-divisor unsigned-DIV callable,

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallBzeroResultSignFixHandoff.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallBzeroResultSignFixHandoff.lean
@@ -9,7 +9,6 @@ import EvmAsm.Evm64.SDiv.Compose.DivCallResultSignFixNamedPost
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
 /-- Zero-divisor SDIV path through result-sign-fix, specialized from the

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallBzeroReturnHandoff.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallBzeroReturnHandoff.lean
@@ -9,7 +9,6 @@ import EvmAsm.Evm64.SDiv.Compose.DivCallReturnComposition
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
 /-- Zero-divisor SDIV path through result-sign-fix and the saved-RA return,

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallExactResultSignFixHandoff.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallExactResultSignFixHandoff.lean
@@ -9,7 +9,6 @@ import EvmAsm.Evm64.SDiv.Compose.DivCallResultSignFixNamedPost
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
 /-- Exact SDIV path through result-sign-fix, specialized from the sidecar

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallExactReturnHandoff.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallExactReturnHandoff.lean
@@ -9,7 +9,6 @@ import EvmAsm.Evm64.SDiv.Compose.DivCallReturnComposition
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
 /-- Exact SDIV path through result-sign-fix and the saved-RA return,

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallResultSignFixNamedPost.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallResultSignFixNamedPost.lean
@@ -2,7 +2,6 @@ import EvmAsm.Evm64.SDiv.Compose.DivCallResultSignFix
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
 /-- Named-post wrapper for the generic SDIV callable composition through

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallReturnComposition.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallReturnComposition.lean
@@ -2,7 +2,6 @@ import EvmAsm.Evm64.SDiv.Compose.DivCallReturnNormalized
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
 /-- Named-post wrapper for the normalized generic SDIV callable composition.

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallReturnNormalized.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallReturnNormalized.lean
@@ -2,7 +2,6 @@ import EvmAsm.Evm64.SDiv.Compose.DivCallReturnGeneric
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
 /-- Normalized return-target view of the generic SDIV callable composition.


### PR DESCRIPTION
## Summary
- remove unused Rv64.Tactics namespace opens from SDIV handoff/return wrapper modules
- leave proof terms and imports otherwise unchanged

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.DivCallBzeroReturnHandoff EvmAsm.Evm64.SDiv.Compose.DivCallBzeroCallableHandoff EvmAsm.Evm64.SDiv.Compose.DivCallBzeroResultSignFixHandoff EvmAsm.Evm64.SDiv.Compose.DivCallExactReturnHandoff EvmAsm.Evm64.SDiv.Compose.DivCallExactResultSignFixHandoff EvmAsm.Evm64.SDiv.Compose.DivCallReturnComposition EvmAsm.Evm64.SDiv.Compose.DivCallResultSignFixNamedPost EvmAsm.Evm64.SDiv.Compose.DivCallReturnNormalized EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "set_option max(Heartbeats|RecDepth)|\b(sorry|admit)\b" EvmAsm/Evm64/SDiv/Compose/DivCallBzeroReturnHandoff.lean EvmAsm/Evm64/SDiv/Compose/DivCallBzeroCallableHandoff.lean EvmAsm/Evm64/SDiv/Compose/DivCallBzeroResultSignFixHandoff.lean EvmAsm/Evm64/SDiv/Compose/DivCallExactReturnHandoff.lean EvmAsm/Evm64/SDiv/Compose/DivCallExactResultSignFixHandoff.lean EvmAsm/Evm64/SDiv/Compose/DivCallReturnComposition.lean EvmAsm/Evm64/SDiv/Compose/DivCallResultSignFixNamedPost.lean EvmAsm/Evm64/SDiv/Compose/DivCallReturnNormalized.lean
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build