### PR TITLE
refactor(sdiv): clean base handoff namespace opens

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/Base.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/Base.lean
@@ -24,7 +24,6 @@ import EvmAsm.Evm64.SDiv.Compose.BaseFinalBlockSpecs
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
 /-- Wrapper sub-region inside `sdivCode`. -/

--- a/EvmAsm/Evm64/SDiv/Compose/BaseDivisorAbsSequence.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BaseDivisorAbsSequence.lean
@@ -8,7 +8,6 @@ import EvmAsm.Evm64.SDiv.Compose.BaseDividendAbsSequence
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
 /-- Precondition for the SDIV divisor-abs (conditional 2's-complement

--- a/EvmAsm/Evm64/SDiv/Compose/DivCall.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCall.lean
@@ -9,7 +9,6 @@ import EvmAsm.Evm64.SDiv.Compose.DivCallDispatchFrame
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
 end EvmAsm.Evm64.SDiv.Compose

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallBzeroHandoff.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallBzeroHandoff.lean
@@ -11,7 +11,6 @@ import EvmAsm.Evm64.SDiv.Compose.DivCallFramedCallable
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
 /-- The named zero-divisor callable handoff from the SDIV dispatch-ready

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallCallable.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallCallable.lean
@@ -10,7 +10,6 @@ import EvmAsm.Evm64.SDiv.Compose.BaseCode
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
 theorem evm_div_callable_code_sub_sdivCode {base : Word} :

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallExactHandoff.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallExactHandoff.lean
@@ -9,7 +9,6 @@ import EvmAsm.Evm64.SDiv.Compose.DivCallFramedCallable
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
 /-- Generic exact-`x1` callable handoff from the SDIV dispatch-ready bundle.


### PR DESCRIPTION
## Summary
- remove unused Rv64.Tactics namespace opens from SDIV base and handoff modules
- leave proof terms and imports otherwise unchanged

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.Base EvmAsm.Evm64.SDiv.Compose.BaseDivisorAbsSequence EvmAsm.Evm64.SDiv.Compose.DivCall EvmAsm.Evm64.SDiv.Compose.DivCallCallable EvmAsm.Evm64.SDiv.Compose.DivCallBzeroHandoff EvmAsm.Evm64.SDiv.Compose.DivCallExactHandoff EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "set_option max(Heartbeats|RecDepth)|\b(sorry|admit)\b" EvmAsm/Evm64/SDiv/Compose/Base.lean EvmAsm/Evm64/SDiv/Compose/BaseDivisorAbsSequence.lean EvmAsm/Evm64/SDiv/Compose/DivCall.lean EvmAsm/Evm64/SDiv/Compose/DivCallCallable.lean EvmAsm/Evm64/SDiv/Compose/DivCallBzeroHandoff.lean EvmAsm/Evm64/SDiv/Compose/DivCallExactHandoff.lean
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build