### PR TITLE
refactor(exp): name boundary prologue scratch frame

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryPrologue.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryPrologue.lean
@@ -13,6 +13,10 @@ namespace EvmAsm.Evm64.Exp.Compose
 open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
+def expBoundaryScratchFrame (vOld v18 : Word) : Assertion :=
+  regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
+  (.x1 ↦ᵣ vOld) ** (.x18 ↦ᵣ v18)
+
 /-- EXP prologue followed by the pointer-advance block, lifted to the
     two-MUL saved-bit EXP+MUL code bundle. This lands at the iteration-body
     entry with the EVM stack pointer advanced by one operand window. -/
@@ -114,8 +118,7 @@ theorem exp_prologue_then_pointer_advance_evm_exp_msb_saved_bit_two_mul_with_mul
     (squaringMulOff condMulOff : BitVec 21) (skipOff backOff : BitVec 13)
     (base mulTarget : Word) :
     let scratchFrame : Assertion :=
-      regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
-      (.x1 ↦ᵣ vOld) ** (.x18 ↦ᵣ v18)
+      expBoundaryScratchFrame vOld v18
     cpsTripleWithin (6 + 1) base (base + 28)
       (evmExpMsbSavedBitTwoMulWithMulCode
         base mulTarget squaringMulOff condMulOff skipOff backOff)
@@ -145,13 +148,13 @@ theorem exp_prologue_then_pointer_advance_evm_exp_msb_saved_bit_two_mul_with_mul
     pcFree_evmStackIs hBase
   exact cpsTripleWithin_weaken
     (fun _ hp => by
-      dsimp [scratchFrame, operandFrame] at hp ⊢
+      dsimp [scratchFrame, operandFrame, expBoundaryScratchFrame] at hp ⊢
       rw [evmStackIs_cons, evmStackIs_cons] at hp
       rw [show evmSp + 32 + 32 = evmSp + 64#64 from by bv_addr] at hp
       rw [show evmSp + 32#64 = evmSp + (32 : Word) from rfl]
       xperm_hyp hp)
     (fun _ hp => by
-      dsimp [scratchFrame, operandFrame] at hp ⊢
+      dsimp [scratchFrame, operandFrame, expBoundaryScratchFrame] at hp ⊢
       rw [evmStackIs_cons, evmStackIs_cons]
       rw [show evmSp + 32#64 = evmSp + (32 : Word) from rfl] at hp
       rw [show evmSp + 64#64 = evmSp + 32 + 32 from by bv_addr] at hp
@@ -167,8 +170,7 @@ theorem exp_prologue_then_pointer_advance_evm_exp_msb_saved_bit_two_mul_with_mul
     (squaringMulOff condMulOff : BitVec 21) (skipOff backOff : BitVec 13)
     (base mulTarget : Word) :
     let scratchFrame : Assertion :=
-      regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
-      (.x1 ↦ᵣ vOld) ** (.x18 ↦ᵣ v18)
+      expBoundaryScratchFrame vOld v18
     cpsTripleWithin (6 + 1) base (base + 28)
       (evmExpMsbSavedBitTwoMulWithMulCode
         base mulTarget squaringMulOff condMulOff skipOff backOff)
@@ -211,8 +213,7 @@ theorem exp_prologue_then_pointer_advance_evm_exp_msb_saved_bit_two_mul_canonica
     (squaringMulOff condMulOff : BitVec 21)
     (base mulTarget : Word) :
     let scratchFrame : Assertion :=
-      regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
-      (.x1 ↦ᵣ vOld) ** (.x18 ↦ᵣ v18)
+      expBoundaryScratchFrame vOld v18
     cpsTripleWithin (6 + 1) base (base + 28)
       (evmExpMsbSavedBitTwoMulCanonicalWithMulCode
         base mulTarget squaringMulOff condMulOff)
@@ -244,8 +245,7 @@ theorem exp_prologue_then_pointer_advance_evm_exp_msb_saved_bit_two_mul_canonica
     (baseWord exponentWord : EvmWord) (rest : List EvmWord)
     (base : Word) :
     let scratchFrame : Assertion :=
-      regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
-      (.x1 ↦ᵣ vOld) ** (.x18 ↦ᵣ v18)
+      expBoundaryScratchFrame vOld v18
     cpsTripleWithin (6 + 1) base (base + 28)
       (evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode base)
       (((((.x2 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) ** (.x9 ↦ᵣ cOld) **


### PR DESCRIPTION
## Summary
- add expBoundaryScratchFrame for the repeated prologue scratch ownership frame
- replace repeated statement-level scratchFrame let bodies in SavedBitBoundaryPrologue with the named helper

## Validation
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryPrologue
- lake build EvmAsm.Evm64.Exp
- git diff --check
- rg -n "\b(sorry|admit)\b|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryPrologue.lean (no matches)
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build