### PR TITLE
refactor(exp): reuse boundary scratch in loop entry

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitLoopEntry.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitLoopEntry.lean
@@ -16,13 +16,12 @@ def expTwoMulBoundaryPre
     (sp evmSp cOld tOld m0 m1 m2 m3 vOld v18 : Word)
     (baseWord exponentWord : EvmWord) (rest : List EvmWord) : Assertion :=
   (((((.x2 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) ** (.x9 ↦ᵣ cOld) **
-      (.x5 ↦ᵣ tOld) ** ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ m0) **
-      ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ m1) **
-      ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ m2) **
-      ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ m3)) **
-     (.x12 ↦ᵣ evmSp)) ** evmStackIs evmSp (baseWord :: exponentWord :: rest)) **
-   (regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
-    (.x1 ↦ᵣ vOld) ** (.x18 ↦ᵣ v18)))
+        (.x5 ↦ᵣ tOld) ** ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ m0) **
+        ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ m1) **
+        ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ m2) **
+        ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ m3)) **
+       (.x12 ↦ᵣ evmSp)) ** evmStackIs evmSp (baseWord :: exponentWord :: rest)) **
+     expBoundaryScratchFrame vOld v18)
 
 theorem expTwoMulBoundaryPre_unfold
     {sp evmSp cOld tOld m0 m1 m2 m3 vOld v18 : Word}
@@ -30,15 +29,15 @@ theorem expTwoMulBoundaryPre_unfold
     expTwoMulBoundaryPre sp evmSp cOld tOld m0 m1 m2 m3 vOld v18
       baseWord exponentWord rest =
       (((((.x2 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) ** (.x9 ↦ᵣ cOld) **
-          (.x5 ↦ᵣ tOld) ** ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ m0) **
-          ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ m1) **
-          ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ m2) **
-          ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ m3)) **
-         (.x12 ↦ᵣ evmSp)) ** evmStackIs evmSp (baseWord :: exponentWord :: rest)) **
-       (regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
-        (.x1 ↦ᵣ vOld) ** (.x18 ↦ᵣ v18))) := by
-  delta expTwoMulBoundaryPre
-  rfl
+            (.x5 ↦ᵣ tOld) ** ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ m0) **
+            ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ m1) **
+            ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ m2) **
+            ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ m3)) **
+           (.x12 ↦ᵣ evmSp)) ** evmStackIs evmSp (baseWord :: exponentWord :: rest)) **
+         (regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
+          (.x1 ↦ᵣ vOld) ** (.x18 ↦ᵣ v18))) := by
+    delta expTwoMulBoundaryPre expBoundaryScratchFrame
+    rfl
 
 theorem expTwoMulBoundaryPre_pcFree
     {sp evmSp cOld tOld m0 m1 m2 m3 vOld v18 : Word}
@@ -61,26 +60,25 @@ def expTwoMulLoopEntryPost
     (sp evmSp vOld v18 : Word) (baseWord exponentWord : EvmWord)
     (rest : List EvmWord) : Assertion :=
   (((((.x2 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) **
-      (.x9 ↦ᵣ (256 : Word)) ** (.x5 ↦ᵣ (1 : Word)) **
-      evmWordIs sp (1 : EvmWord)) **
-     (.x12 ↦ᵣ (evmSp + 64))) **
-   evmStackIs evmSp (baseWord :: exponentWord :: rest)) **
-   (regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
-    (.x1 ↦ᵣ vOld) ** (.x18 ↦ᵣ v18)))
+        (.x9 ↦ᵣ (256 : Word)) ** (.x5 ↦ᵣ (1 : Word)) **
+        evmWordIs sp (1 : EvmWord)) **
+       (.x12 ↦ᵣ (evmSp + 64))) **
+     evmStackIs evmSp (baseWord :: exponentWord :: rest)) **
+     expBoundaryScratchFrame vOld v18)
 
 theorem expTwoMulLoopEntryPost_unfold
     {sp evmSp vOld v18 : Word} {baseWord exponentWord : EvmWord}
     {rest : List EvmWord} :
     expTwoMulLoopEntryPost sp evmSp vOld v18 baseWord exponentWord rest =
       (((((.x2 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) **
-          (.x9 ↦ᵣ (256 : Word)) ** (.x5 ↦ᵣ (1 : Word)) **
-          evmWordIs sp (1 : EvmWord)) **
-         (.x12 ↦ᵣ (evmSp + 64))) **
-        evmStackIs evmSp (baseWord :: exponentWord :: rest)) **
-       (regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
-        (.x1 ↦ᵣ vOld) ** (.x18 ↦ᵣ v18))) := by
-  delta expTwoMulLoopEntryPost
-  rfl
+            (.x9 ↦ᵣ (256 : Word)) ** (.x5 ↦ᵣ (1 : Word)) **
+            evmWordIs sp (1 : EvmWord)) **
+           (.x12 ↦ᵣ (evmSp + 64))) **
+          evmStackIs evmSp (baseWord :: exponentWord :: rest)) **
+         (regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
+          (.x1 ↦ᵣ vOld) ** (.x18 ↦ᵣ v18))) := by
+    delta expTwoMulLoopEntryPost expBoundaryScratchFrame
+    rfl
 
 theorem expTwoMulLoopEntryPost_pcFree
     {sp evmSp vOld v18 : Word} {baseWord exponentWord : EvmWord}
@@ -103,8 +101,7 @@ theorem exp_prologue_then_pointer_advance_evm_exp_msb_saved_bit_two_mul_canonica
     (baseWord exponentWord : EvmWord) (rest : List EvmWord)
     (base : Word) :
     let scratchFrame : Assertion :=
-      regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
-      (.x1 ↦ᵣ vOld) ** (.x18 ↦ᵣ v18)
+      expBoundaryScratchFrame vOld v18
     cpsTripleWithin (6 + 1) base (base + 28)
       (evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode base)
       (((((.x2 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) ** (.x9 ↦ᵣ cOld) **


### PR DESCRIPTION
## Summary
- use expBoundaryScratchFrame in the named loop-entry boundary pre/post definitions
- use the same scratch helper in the appended-MUL loop-entry theorem statement

## Validation
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitLoopEntry
- lake build EvmAsm.Evm64.Exp
- git diff --check
- rg -n "\b(sorry|admit)\b|set_option maxHeartbeats|set_option maxRecDepth|\t" EvmAsm/Evm64/Exp/Compose/SavedBitLoopEntry.lean (no matches)
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build