### PR TITLE
refactor(exp): move iter base frame upstream

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitIterPostDefs.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitIterPostDefs.lean
@@ -5,29 +5,6 @@ namespace EvmAsm.Evm64.Exp.Compose
 open EvmAsm.Rv64
 
 @[irreducible]
-def expTwoMulIterBaseFrame
-    (evmSp a0 a1 a2 a3 : Word) : Assertion :=
-  ((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
-  ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **
-  ((evmSp + signExtend12 ((-48) : BitVec 12)) ↦ₘ a2) **
-  ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3)
-
-theorem expTwoMulIterBaseFrame_unfold {evmSp a0 a1 a2 a3 : Word} :
-    expTwoMulIterBaseFrame evmSp a0 a1 a2 a3 =
-      (((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
-       ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **
-       ((evmSp + signExtend12 ((-48) : BitVec 12)) ↦ₘ a2) **
-       ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3)) := by
-  delta expTwoMulIterBaseFrame
-  rfl
-
-theorem expTwoMulIterBaseFrame_pcFree
-    {evmSp a0 a1 a2 a3 : Word} :
-    (expTwoMulIterBaseFrame evmSp a0 a1 a2 a3).pcFree := by
-  rw [expTwoMulIterBaseFrame_unfold]
-  pcFree
-
-@[irreducible]
 def expTwoMulIterSkipRest
     (bit sp evmSp base : Word) (squareW : EvmWord) : Assertion :=
   expTwoMulSkipLoopRest bit sp evmSp base squareW

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCondCanonical.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCondCanonical.lean
@@ -5,7 +5,6 @@
 -/
 
 import EvmAsm.Evm64.Exp.Compose.SavedBitTwoMulCond
-import EvmAsm.Evm64.Exp.Compose.SavedBitIterPostDefs
 
 namespace EvmAsm.Evm64.Exp.Compose
 

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulSkip.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulSkip.lean
@@ -12,6 +12,29 @@ namespace EvmAsm.Evm64.Exp.Compose
 open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
+@[irreducible]
+def expTwoMulIterBaseFrame
+    (evmSp a0 a1 a2 a3 : Word) : Assertion :=
+  ((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
+  ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **
+  ((evmSp + signExtend12 ((-48) : BitVec 12)) ↦ₘ a2) **
+  ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3)
+
+theorem expTwoMulIterBaseFrame_unfold {evmSp a0 a1 a2 a3 : Word} :
+    expTwoMulIterBaseFrame evmSp a0 a1 a2 a3 =
+      (((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
+       ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **
+       ((evmSp + signExtend12 ((-48) : BitVec 12)) ↦ₘ a2) **
+       ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3)) := by
+  delta expTwoMulIterBaseFrame
+  rfl
+
+theorem expTwoMulIterBaseFrame_pcFree
+    {evmSp a0 a1 a2 a3 : Word} :
+    (expTwoMulIterBaseFrame evmSp a0 a1 a2 a3).pcFree := by
+  rw [expTwoMulIterBaseFrame_unfold]
+  pcFree
+
 /-- Saved-bit loop-back block lifted to the two-MUL-offset EXP+MUL code
     bundle. -/
 theorem exp_loop_back_evm_exp_msb_saved_bit_two_mul_with_mul_spec_within


### PR DESCRIPTION
## Summary
- move expTwoMulIterBaseFrame and its unfold/pcFree lemmas from SavedBitIterPostDefs to SavedBitTwoMulSkip
- remove the temporary canonical-file import now that the helper is visible through the two-mul import chain

## Validation
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitTwoMulSkip EvmAsm.Evm64.Exp.Compose.SavedBitIterPostDefs EvmAsm.Evm64.Exp.Compose.SavedBitTwoMulCondCanonical
- lake build EvmAsm.Evm64.Exp
- git diff --check
- rg -n "\b(sorry|admit)\b|set_option maxHeartbeats|set_option maxRecDepth|\t" EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulSkip.lean EvmAsm/Evm64/Exp/Compose/SavedBitIterPostDefs.lean EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCondCanonical.lean
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build