### PR TITLE
refactor(exp): reuse iter base frame in two-mul cond

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitIterPosts.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitIterPosts.lean
@@ -56,7 +56,6 @@ theorem exp_msb_saved_bit_two_mul_full_iter_owned_scratch_branch_named_posts_spe
           expTwoMulIterSkipPost (expTwoMulIterCountNew iterCount) bit sp evmSp
             base a0 a1 a2 a3 squareW (expTwoMulIterCountNew iterCount = 0) h) := by
   intro bit squareW rw
-  rw [expTwoMulIterBaseFrame_unfold]
   exact cpsBranchWithin_weaken
     (fun _ hp => hp)
     (fun _ hp => by

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCond.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCond.lean
@@ -34,10 +34,7 @@ theorem exp_msb_saved_bit_two_mul_full_iter_four_exit_spec_within
     let squareW := expTwoMulSquareW r0 r1 r2 r3
     let rw := expTwoMulIterRw r0 r1 r2 r3 a0 a1 a2 a3
     let baseFrame : Assertion :=
-      ((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
-      ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **
-      ((evmSp + signExtend12 ((-48) : BitVec 12)) ↦ₘ a2) **
-      ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3)
+      expTwoMulIterBaseFrame evmSp a0 a1 a2 a3
     let skipRest : Assertion :=
       expTwoMulSkipLoopRest bit sp evmSp base squareW
     let condFrame : Assertion :=
@@ -116,7 +113,7 @@ theorem exp_msb_saved_bit_two_mul_full_iter_four_exit_spec_within
               expCondMulLoopRest sp evmSp base a0 a1 a2 a3 rw) ** condFrame)] := by
     exact cpsNBranchWithin_weaken_pre
       (fun _ hp => by
-        dsimp [condFrame, baseFrame] at hp ⊢
+        simp [condFrame, baseFrame, expTwoMulIterBaseFrame_unfold] at hp ⊢
         xperm_hyp hp) hCondFramed
   have hFull :=
     cpsNBranchWithin_extend_head_nbranch hSkip hCondHead
@@ -145,10 +142,7 @@ theorem exp_msb_saved_bit_two_mul_full_iter_merged_exit_spec_within
     let squareW := expTwoMulSquareW r0 r1 r2 r3
     let rw := expTwoMulIterRw r0 r1 r2 r3 a0 a1 a2 a3
     let baseFrame : Assertion :=
-      ((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
-      ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **
-      ((evmSp + signExtend12 ((-48) : BitVec 12)) ↦ₘ a2) **
-      ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3)
+      expTwoMulIterBaseFrame evmSp a0 a1 a2 a3
     let skipRest : Assertion :=
       expTwoMulSkipLoopRest bit sp evmSp base squareW
     let condFrame : Assertion :=
@@ -250,10 +244,7 @@ theorem exp_msb_saved_bit_two_mul_full_iter_branch_spec_within
     let squareW := expTwoMulSquareW r0 r1 r2 r3
     let rw := expTwoMulIterRw r0 r1 r2 r3 a0 a1 a2 a3
     let baseFrame : Assertion :=
-      ((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
-      ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **
-      ((evmSp + signExtend12 ((-48) : BitVec 12)) ↦ₘ a2) **
-      ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3)
+      expTwoMulIterBaseFrame evmSp a0 a1 a2 a3
     let skipRest : Assertion :=
       expTwoMulSkipLoopRest bit sp evmSp base squareW
     let condFrame : Assertion :=
@@ -327,10 +318,7 @@ theorem exp_msb_saved_bit_two_mul_full_iter_branch_owned_scratch_spec_within
     let squareW := expTwoMulSquareW r0 r1 r2 r3
     let rw := expTwoMulIterRw r0 r1 r2 r3 a0 a1 a2 a3
     let baseFrame : Assertion :=
-      ((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
-      ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **
-      ((evmSp + signExtend12 ((-48) : BitVec 12)) ↦ₘ a2) **
-      ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3)
+      expTwoMulIterBaseFrame evmSp a0 a1 a2 a3
     let skipRest : Assertion :=
       expTwoMulSkipLoopRest bit sp evmSp base squareW
     let condFrame : Assertion :=
@@ -500,10 +488,7 @@ theorem exp_msb_saved_bit_two_mul_full_iter_owned_scratch_branch_spec_within
     let squareW := expTwoMulSquareW r0 r1 r2 r3
     let rw := expTwoMulIterRw r0 r1 r2 r3 a0 a1 a2 a3
     let baseFrame : Assertion :=
-      ((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
-      ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **
-      ((evmSp + signExtend12 ((-48) : BitVec 12)) ↦ₘ a2) **
-      ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3)
+      expTwoMulIterBaseFrame evmSp a0 a1 a2 a3
     let skipRest : Assertion :=
       expTwoMulSkipLoopRest bit sp evmSp base squareW
     let condFrame : Assertion :=

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulSkip.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulSkip.lean
@@ -188,10 +188,7 @@ theorem exp_msb_saved_bit_prefix_squaring_beq_skip_then_loop_back_with_base_fram
     let bit := expTwoMulIterBit e
     let squareW := expTwoMulSquareW r0 r1 r2 r3
     let baseFrame : Assertion :=
-      ((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
-      ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **
-      ((evmSp + signExtend12 ((-48) : BitVec 12)) ↦ₘ a2) **
-      ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3)
+      expTwoMulIterBaseFrame evmSp a0 a1 a2 a3
     let rest : Assertion :=
       expTwoMulSkipLoopRest bit sp evmSp base squareW
     cpsNBranchWithin ((3 + 1 + (17 + 64 + 9) + 1) + 2) (base + 28)
@@ -237,9 +234,7 @@ theorem exp_msb_saved_bit_prefix_squaring_beq_skip_then_loop_back_with_base_fram
       backOff base loopTarget hbase hmt hd hskip hback
   have hBaseFramePcFree : baseFrame.pcFree := by
     dsimp only [baseFrame]
-    exact pcFree_sepConj pcFree_memIs
-      (pcFree_sepConj pcFree_memIs
-        (pcFree_sepConj pcFree_memIs pcFree_memIs))
+    exact expTwoMulIterBaseFrame_pcFree
   have hf := cpsNBranchWithin_frameR hBaseFramePcFree h
   simpa [rest, expTwoMulSkipLoopRest_unfold] using
     (cpsNBranchWithin_weaken_pre


### PR DESCRIPTION
## Summary
- reuse expTwoMulIterBaseFrame in two-mul skip and conditional composition statements
- keep the named frame through the iter-post adapter instead of immediately unfolding it
- unfold the helper only inside the one permutation proof that must match expanded callee output

## Validation
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitTwoMulSkip EvmAsm.Evm64.Exp.Compose.SavedBitTwoMulCond
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitIterPosts EvmAsm.Evm64.Exp
- git diff --check
- rg -n "\b(sorry|admit)\b|set_option maxHeartbeats|set_option maxRecDepth|\t" EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulSkip.lean EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCond.lean EvmAsm/Evm64/Exp/Compose/SavedBitIterPosts.lean
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build