### PR TITLE
refactor(exp): name cond call base pre

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCondCall.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCondCall.lean
@@ -152,24 +152,37 @@ theorem expCondMulCallScratchPre_unfold
   delta expCondMulCallScratchPre
   rfl
 
-/-- Taken conditional-multiply block followed by the loop-back counter update
-    under the two-MUL-offset saved-bit EXP+MUL code bundle. -/
-theorem exp_cond_mul_call_then_loop_back_evm_exp_msb_saved_bit_two_mul_with_mul_spec_within
-    (iterCount sp evmSp tOld vOld r0 r1 r2 r3 a0 a1 a2 a3 d0 d1 d2 d3
-      e0 e1 e2 e3 v6 v7 v10 v11 mulTarget : Word)
-    (squaringMulOff condMulOff : BitVec 21) (skipOff backOff : BitVec 13)
-    (base loopTarget : Word)
-    (hbase : base &&& 1 = 0)
-    (hmt : mulTarget = ((base + 152) + 64) + signExtend21 condMulOff)
-    (hd : CodeReq.Disjoint
-            (evmExpMsbSavedBitTwoMulCode
-              base squaringMulOff condMulOff skipOff backOff)
-            (mul_callable_code mulTarget))
-    (hback : ((base + 256) + 4 : Word) + signExtend13 backOff = loopTarget) :
-    let rw := expTwoMulCondRwFromLimbs r0 r1 r2 r3 a0 a1 a2 a3
-    cpsNBranchWithin ((17 + 64 + 9) + 2) (base + 152)
-      (evmExpMsbSavedBitTwoMulWithMulCode
-        base mulTarget squaringMulOff condMulOff skipOff backOff)
+@[irreducible]
+def expCondMulCallConcretePre
+    (iterCount sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
+      e0 e1 e2 e3 a0 a1 a2 a3 v6 v7 v10 v11 : Word) : Assertion :=
+  (((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
+    ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+    ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+    ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+    ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+    ((evmSp + signExtend12 (0 : BitVec 12)) ↦ₘ d0) **
+    ((evmSp + signExtend12 (8 : BitVec 12)) ↦ₘ d1) **
+    ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ d2) **
+    ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ d3) **
+    ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ e0) **
+    ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ e1) **
+    ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ e2) **
+    ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ e3) **
+    ((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
+    ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **
+    ((evmSp + signExtend12 ((-48) : BitVec 12)) ↦ₘ a2) **
+    ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3) **
+    (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x10 ↦ᵣ v10) **
+    (.x11 ↦ᵣ v11) ** (.x1 ↦ᵣ vOld)) **
+   (.x9 ↦ᵣ iterCount) ** (.x0 ↦ᵣ (0 : Word)))
+
+theorem expCondMulCallConcretePre_unfold
+    {iterCount sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
+      e0 e1 e2 e3 a0 a1 a2 a3 v6 v7 v10 v11 : Word} :
+    expCondMulCallConcretePre
+      iterCount sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
+      e0 e1 e2 e3 a0 a1 a2 a3 v6 v7 v10 v11 =
       (((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
         ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
         ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
@@ -189,7 +202,31 @@ theorem exp_cond_mul_call_then_loop_back_evm_exp_msb_saved_bit_two_mul_with_mul_
         ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3) **
         (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x10 ↦ᵣ v10) **
         (.x11 ↦ᵣ v11) ** (.x1 ↦ᵣ vOld)) **
-       (.x9 ↦ᵣ iterCount) ** (.x0 ↦ᵣ (0 : Word)))
+       (.x9 ↦ᵣ iterCount) ** (.x0 ↦ᵣ (0 : Word))) := by
+  delta expCondMulCallConcretePre
+  rfl
+
+/-- Taken conditional-multiply block followed by the loop-back counter update
+    under the two-MUL-offset saved-bit EXP+MUL code bundle. -/
+theorem exp_cond_mul_call_then_loop_back_evm_exp_msb_saved_bit_two_mul_with_mul_spec_within
+    (iterCount sp evmSp tOld vOld r0 r1 r2 r3 a0 a1 a2 a3 d0 d1 d2 d3
+      e0 e1 e2 e3 v6 v7 v10 v11 mulTarget : Word)
+    (squaringMulOff condMulOff : BitVec 21) (skipOff backOff : BitVec 13)
+    (base loopTarget : Word)
+    (hbase : base &&& 1 = 0)
+    (hmt : mulTarget = ((base + 152) + 64) + signExtend21 condMulOff)
+    (hd : CodeReq.Disjoint
+            (evmExpMsbSavedBitTwoMulCode
+              base squaringMulOff condMulOff skipOff backOff)
+            (mul_callable_code mulTarget))
+    (hback : ((base + 256) + 4 : Word) + signExtend13 backOff = loopTarget) :
+    let rw := expTwoMulCondRwFromLimbs r0 r1 r2 r3 a0 a1 a2 a3
+    cpsNBranchWithin ((17 + 64 + 9) + 2) (base + 152)
+      (evmExpMsbSavedBitTwoMulWithMulCode
+        base mulTarget squaringMulOff condMulOff skipOff backOff)
+      (expCondMulCallConcretePre
+        iterCount sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
+        e0 e1 e2 e3 a0 a1 a2 a3 v6 v7 v10 v11)
       [(loopTarget,
           (((.x9 ↦ᵣ expTwoMulIterCountNew iterCount) ** (.x0 ↦ᵣ (0 : Word)) **
            ⌜expTwoMulIterCountNew iterCount ≠ 0⌝) **
@@ -229,7 +266,9 @@ theorem exp_cond_mul_call_then_loop_back_evm_exp_msb_saved_bit_two_mul_with_mul_
       hCondFramed hLoopFramed
   have hSeqN := cpsBranchWithin_as_cpsNBranchWithin hSeq
   exact cpsNBranchWithin_weaken_pre
-    (fun _ hp => by xperm_hyp hp) hSeqN
+    (fun _ hp => by
+      rw [expCondMulCallConcretePre_unfold] at hp
+      xperm_hyp hp) hSeqN
 
 /-- Variant of the conditional-multiply path that consumes owned caller-saved
     call scratch in the precondition. The data words stay in the concrete
@@ -331,6 +370,7 @@ theorem exp_cond_mul_call_then_loop_back_evm_exp_msb_saved_bit_two_mul_with_mul_
       base loopTarget hbase hmt hd hback
   exact cpsNBranchWithin_weaken_pre
     (fun _ hp => by
+      rw [expCondMulCallConcretePre_unfold]
       simp [preCore, expCondMulCallScratchPre_unfold,
         expTwoMulIterBaseFrame_unfold] at hp ⊢
       have hSp0 : (sp + signExtend12 0#12 : Word) = sp := by

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCondCanonical.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCondCanonical.lean
@@ -26,26 +26,9 @@ theorem exp_cond_mul_call_then_loop_back_evm_exp_msb_saved_bit_two_mul_canonical
     cpsNBranchWithin ((17 + 64 + 9) + 2) (base + 152)
       (evmExpMsbSavedBitTwoMulCanonicalWithMulCode
         base mulTarget squaringMulOff condMulOff)
-      (((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
-        ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
-        ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
-        ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
-        ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
-        ((evmSp + signExtend12 (0 : BitVec 12)) ↦ₘ d0) **
-        ((evmSp + signExtend12 (8 : BitVec 12)) ↦ₘ d1) **
-        ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ d2) **
-        ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ d3) **
-        ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ e0) **
-        ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ e1) **
-        ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ e2) **
-        ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ e3) **
-        ((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
-        ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **
-        ((evmSp + signExtend12 ((-48) : BitVec 12)) ↦ₘ a2) **
-        ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3) **
-        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x10 ↦ᵣ v10) **
-        (.x11 ↦ᵣ v11) ** (.x1 ↦ᵣ vOld)) **
-       (.x9 ↦ᵣ iterCount) ** (.x0 ↦ᵣ (0 : Word)))
+      (expCondMulCallConcretePre
+        iterCount sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
+        e0 e1 e2 e3 a0 a1 a2 a3 v6 v7 v10 v11)
       [(base + 28,
           (((.x9 ↦ᵣ expTwoMulIterCountNew iterCount) ** (.x0 ↦ᵣ (0 : Word)) **
            ⌜expTwoMulIterCountNew iterCount ≠ 0⌝) **
@@ -77,26 +60,9 @@ theorem exp_cond_mul_call_then_loop_back_evm_exp_msb_saved_bit_two_mul_canonical
     let rw := expTwoMulCondRwFromLimbs r0 r1 r2 r3 a0 a1 a2 a3
     cpsNBranchWithin ((17 + 64 + 9) + 2) (base + 152)
       (evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode base)
-      (((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
-        ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
-        ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
-        ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
-        ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
-        ((evmSp + signExtend12 (0 : BitVec 12)) ↦ₘ d0) **
-        ((evmSp + signExtend12 (8 : BitVec 12)) ↦ₘ d1) **
-        ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ d2) **
-        ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ d3) **
-        ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ e0) **
-        ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ e1) **
-        ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ e2) **
-        ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ e3) **
-        ((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
-        ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **
-        ((evmSp + signExtend12 ((-48) : BitVec 12)) ↦ₘ a2) **
-        ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3) **
-        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x10 ↦ᵣ v10) **
-        (.x11 ↦ᵣ v11) ** (.x1 ↦ᵣ vOld)) **
-       (.x9 ↦ᵣ iterCount) ** (.x0 ↦ᵣ (0 : Word)))
+      (expCondMulCallConcretePre
+        iterCount sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
+        e0 e1 e2 e3 a0 a1 a2 a3 v6 v7 v10 v11)
       [(base + 28,
           (((.x9 ↦ᵣ expTwoMulIterCountNew iterCount) ** (.x0 ↦ᵣ (0 : Word)) **
            ⌜expTwoMulIterCountNew iterCount ≠ 0⌝) **


### PR DESCRIPTION
## Summary
- extract the base saved-bit cond-mul concrete precondition into expCondMulCallConcretePre
- update canonical cond-mul views to consume the named precondition
- keep the theorem behavior unchanged while removing duplicated inline assertion chains

## Verification
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitTwoMulCondCall
- lake build EvmAsm.Evm64.Exp
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCondCall.lean EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCondCanonical.lean (no matches)
- scripts/check-file-size.sh EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCondCall.lean EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCondCanonical.lean
- scripts/check-unimported.sh
- lake build