### PR TITLE
refactor(exp): alias iter cond frame

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitIterPostDefs.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitIterPostDefs.lean
@@ -72,20 +72,21 @@ theorem expTwoMulIterCondRest_pcFree
 
 @[irreducible]
 def expTwoMulIterCondFrame (bit : Word) : Assertion :=
-  (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
-  ⌜bit + signExtend12 (0 : BitVec 12) ≠ 0⌝
+  expTwoMulCondFrame bit
 
 theorem expTwoMulIterCondFrame_unfold {bit : Word} :
     expTwoMulIterCondFrame bit =
       ((.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
        ⌜bit + signExtend12 (0 : BitVec 12) ≠ 0⌝) := by
   delta expTwoMulIterCondFrame
-  rfl
+  exact expTwoMulCondFrame_unfold
 
 theorem expTwoMulIterCondFrame_pcFree {bit : Word} :
     (expTwoMulIterCondFrame bit).pcFree := by
-  rw [expTwoMulIterCondFrame_unfold]
-  pcFree
+  rw [show expTwoMulIterCondFrame bit = expTwoMulCondFrame bit by
+    delta expTwoMulIterCondFrame
+    rfl]
+  exact expTwoMulCondFrame_pcFree
 
 @[irreducible]
 def expTwoMulIterCondPost


### PR DESCRIPTION
## Summary
- make expTwoMulIterCondFrame a thin alias of the upstream expTwoMulCondFrame
- reuse the upstream unfold and pcFree proofs for the iteration post definitions
- avoid keeping two expanded definitions for the same nonzero-bit x18 frame

## Verification
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitIterPostDefs
- lake build EvmAsm.Evm64.Exp
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/Compose/SavedBitIterPostDefs.lean (no matches)
- scripts/check-file-size.sh EvmAsm/Evm64/Exp/Compose/SavedBitIterPostDefs.lean
- scripts/check-unimported.sh
- lake build