### PR TITLE
refactor(sdiv): clean code handles namespace opens

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/CodeHandles.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/CodeHandles.lean
@@ -10,62 +10,60 @@ import EvmAsm.Evm64.SDiv.Compose.BaseOffsets
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64
-
 /-- Full SDIV code region handle: wrapper followed by `evm_div_callable`. -/
-abbrev sdivCode (base : Word) : CodeReq :=
-  CodeReq.ofProg base EvmAsm.Evm64.evm_sdiv
+abbrev sdivCode (base : Word) : EvmAsm.Rv64.CodeReq :=
+  EvmAsm.Rv64.CodeReq.ofProg base EvmAsm.Evm64.evm_sdiv
 
 /-- Code handle for the saved-`ra` prologue block. -/
-abbrev saveRaCode (base : Word) : CodeReq :=
-  CodeReq.ofProg (base + saveRaOff) (EvmAsm.Evm64.evm_sdiv_save_ra_block .x18)
+abbrev saveRaCode (base : Word) : EvmAsm.Rv64.CodeReq :=
+  EvmAsm.Rv64.CodeReq.ofProg (base + saveRaOff) (EvmAsm.Evm64.evm_sdiv_save_ra_block .x18)
 
 /-- Code handle for the dividend sign-bit probe. -/
-abbrev dividendSignCode (base : Word) : CodeReq :=
-  CodeReq.ofProg (base + dividendSignOff)
+abbrev dividendSignCode (base : Word) : EvmAsm.Rv64.CodeReq :=
+  EvmAsm.Rv64.CodeReq.ofProg (base + dividendSignOff)
     (EvmAsm.Evm64.evm_sdiv_sign_bit_block .x12 .x8
       EvmAsm.Evm64.evm_sdivDividendTopLimbOff)
 
 /-- Code handle for the divisor sign-bit probe. -/
-abbrev divisorSignCode (base : Word) : CodeReq :=
-  CodeReq.ofProg (base + divisorSignOff)
+abbrev divisorSignCode (base : Word) : EvmAsm.Rv64.CodeReq :=
+  EvmAsm.Rv64.CodeReq.ofProg (base + divisorSignOff)
     (EvmAsm.Evm64.evm_sdiv_sign_bit_block .x12 .x9
       EvmAsm.Evm64.evm_sdivDivisorTopLimbOff)
 
 /-- Code handle for the in-place dividend absolute-value block. -/
-abbrev dividendAbsCode (base : Word) : CodeReq :=
-  CodeReq.ofProg (base + dividendAbsOff)
+abbrev dividendAbsCode (base : Word) : EvmAsm.Rv64.CodeReq :=
+  EvmAsm.Rv64.CodeReq.ofProg (base + dividendAbsOff)
     (EvmAsm.Evm64.evm_sdiv_cond_negate_256_block .x12 .x8 .x10 .x7 .x11
       0 8 16 24)
 
 /-- Code handle for the in-place divisor absolute-value block. -/
-abbrev divisorAbsCode (base : Word) : CodeReq :=
-  CodeReq.ofProg (base + divisorAbsOff)
+abbrev divisorAbsCode (base : Word) : EvmAsm.Rv64.CodeReq :=
+  EvmAsm.Rv64.CodeReq.ofProg (base + divisorAbsOff)
     (EvmAsm.Evm64.evm_sdiv_cond_negate_256_block .x12 .x9 .x10 .x7 .x11
       32 40 48 56)
 
 /-- Code handle for the sign-xor instruction selecting result negation. -/
-abbrev signXorCode (base : Word) : CodeReq :=
-  CodeReq.ofProg (base + signXorOff) (EvmAsm.Rv64.XOR' .x8 .x8 .x9)
+abbrev signXorCode (base : Word) : EvmAsm.Rv64.CodeReq :=
+  EvmAsm.Rv64.CodeReq.ofProg (base + signXorOff) (EvmAsm.Rv64.XOR' .x8 .x8 .x9)
 
 /-- Code handle for the near call into `evm_div_callable`. -/
-abbrev divCallCode (base : Word) : CodeReq :=
-  CodeReq.ofProg (base + divCallOff)
+abbrev divCallCode (base : Word) : EvmAsm.Rv64.CodeReq :=
+  EvmAsm.Rv64.CodeReq.ofProg (base + divCallOff)
     (EvmAsm.Evm64.evm_sdiv_div_call_block EvmAsm.Evm64.evm_sdivCallOff)
 
 /-- Code handle for the in-place quotient sign-fixup block. -/
-abbrev resultSignFixCode (base : Word) : CodeReq :=
-  CodeReq.ofProg (base + resultSignFixOff)
+abbrev resultSignFixCode (base : Word) : EvmAsm.Rv64.CodeReq :=
+  EvmAsm.Rv64.CodeReq.ofProg (base + resultSignFixOff)
     (EvmAsm.Evm64.evm_sdiv_cond_negate_256_block .x12 .x8 .x10 .x7 .x11
       0 8 16 24)
 
 /-- Code handle for the saved-`ra` return instruction. -/
-abbrev savedRaRetCode (base : Word) : CodeReq :=
-  CodeReq.ofProg (base + savedRaRetOff)
+abbrev savedRaRetCode (base : Word) : EvmAsm.Rv64.CodeReq :=
+  EvmAsm.Rv64.CodeReq.ofProg (base + savedRaRetOff)
     (EvmAsm.Evm64.evm_sdiv_saved_ra_ret_block .x18)
 
 /-- Code handle for the appended unsigned divider callable. -/
-abbrev divCallableCode (base : Word) : CodeReq :=
-  CodeReq.ofProg (base + wrapperEndOff) EvmAsm.Evm64.evm_div_callable
+abbrev divCallableCode (base : Word) : EvmAsm.Rv64.CodeReq :=
+  EvmAsm.Rv64.CodeReq.ofProg (base + wrapperEndOff) EvmAsm.Evm64.evm_div_callable
 
 end EvmAsm.Evm64.SDiv.Compose


### PR DESCRIPTION
## Summary
- remove the broad Rv64 namespace open from SDiv Compose CodeHandles
- qualify the CodeReq type and constructors at each local use
- leave the SDIV code handle definitions behaviorally unchanged

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.CodeHandles
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- forbidden proof-escape scan on EvmAsm/Evm64/SDiv/Compose/CodeHandles.lean
- scripts/check-file-size.sh EvmAsm/Evm64/SDiv/Compose/CodeHandles.lean
- scripts/check-unimported.sh
- lake build