### PR TITLE
refactor(sdiv): clean words namespace opens

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/Words.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/Words.lean
@@ -8,8 +8,6 @@ import EvmAsm.Evm64.Stack
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64
-
 /-- Absolute-value word produced by the SDIV dividend sign/absolute-value
     prefix, packaged as a named expression so downstream callable-composition
     proofs do not duplicate the expanded `fromLimbs` term. -/


### PR DESCRIPTION
## Summary
- remove the unused broad Rv64 namespace open from SDiv Compose Words
- keep the word helper definitions and proofs unchanged

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.Words
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- forbidden proof-escape scan on EvmAsm/Evm64/SDiv/Compose/Words.lean
- scripts/check-file-size.sh EvmAsm/Evm64/SDiv/Compose/Words.lean
- scripts/check-unimported.sh
- lake build