### PR TITLE
refactor(sdiv): clean callable return post opens

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/DivCallCallableReturnPost.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallCallableReturnPost.lean
@@ -5,12 +5,10 @@ import EvmAsm.Evm64.SDiv.Compose.Words
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64
-
 @[irreducible]
 def saveRaDivCallCallableReturnPost
     (vRa sp base dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word) : Assertion :=
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word) : EvmAsm.Rv64.Assertion :=
   let dividendAbsWord :=
     sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
   let divisorAbsWord :=
@@ -65,7 +63,7 @@ theorem saveRaDivCallCallableReturnPost_pcFree
 instance pcFreeInst_saveRaDivCallCallableReturnPost
     (vRa sp base dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
       divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word) :
-    Assertion.PCFree
+    EvmAsm.Rv64.Assertion.PCFree
       (saveRaDivCallCallableReturnPost vRa sp base
         dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
         divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) :=


### PR DESCRIPTION
## Summary
- remove the broad Rv64 namespace open from SDiv Compose DivCallCallableReturnPost
- qualify the Assertion return type and PCFree instance target locally
- keep the callable-return postcondition and proof behavior unchanged

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.DivCallCallableReturnPost
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- forbidden proof-escape scan on EvmAsm/Evm64/SDiv/Compose/DivCallCallableReturnPost.lean
- scripts/check-file-size.sh EvmAsm/Evm64/SDiv/Compose/DivCallCallableReturnPost.lean
- scripts/check-unimported.sh
- lake build