### PR TITLE
refactor(sdiv): clean named result post opens

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/DivCallResultSignFixNamedPost.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallResultSignFixNamedPost.lean
@@ -2,8 +2,6 @@ import EvmAsm.Evm64.SDiv.Compose.DivCallResultSignFix
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64
-
 /-- Named-post wrapper for the generic SDIV callable composition through
     result-sign-fix, before the saved-RA return. -/
 theorem saveRa_signs_abs_signXor_then_divCall_then_resultSignFix_named_post_of_callable_post_spec_in_sdivCode
@@ -17,7 +15,8 @@ theorem saveRa_signs_abs_signXor_then_divCall_then_resultSignFix_named_post_of_c
      shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
     (base : Word)
     (hCallable :
-      cpsTripleWithin nSteps (base + wrapperEndOff) (base + resultSignFixOff) (sdivCode base)
+      EvmAsm.Rv64.cpsTripleWithin nSteps
+        (base + wrapperEndOff) (base + resultSignFixOff) (sdivCode base)
         (saveRaDivCallDispatchReadyPost vRa sp base
           dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
           divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
@@ -26,7 +25,7 @@ theorem saveRa_signs_abs_signXor_then_divCall_then_resultSignFix_named_post_of_c
         (saveRaDivCallBzeroCallablePost vRa sp base
           dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
           divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)) :
-    cpsTripleWithin ((49 + nSteps) + 21)
+    EvmAsm.Rv64.cpsTripleWithin ((49 + nSteps) + 21)
       base ((base + resultSignFixOff) + 84) (sdivCode base)
       (saveRaSignsAbsSignXorThenDivCallPre vRa vSavedOld sp sDividendOld sDivisorOld
         dividendMaskOld dividendValueOld dividendCarryOld


### PR DESCRIPTION
## Summary
- remove the broad Rv64 namespace open from SDiv Compose DivCallResultSignFixNamedPost
- qualify cpsTripleWithin locally in the theorem hypothesis and conclusion
- keep the named-post wrapper proof behavior unchanged

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.DivCallResultSignFixNamedPost
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- forbidden proof-escape scan on EvmAsm/Evm64/SDiv/Compose/DivCallResultSignFixNamedPost.lean
- scripts/check-file-size.sh EvmAsm/Evm64/SDiv/Compose/DivCallResultSignFixNamedPost.lean
- scripts/check-unimported.sh
- lake build