### PR TITLE
refactor(sdiv): clean bzero named post opens

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/BzeroCallableNamedPost.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroCallableNamedPost.lean
@@ -8,8 +8,6 @@ import EvmAsm.Evm64.SDiv.Compose.BzeroCallable
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64
-
 /-- SDIV wrapper prefix followed by the zero-divisor unsigned-DIV callable,
     using the named postcondition consumed by later composition slices. -/
 theorem saveRa_signs_abs_signXor_then_divCall_bzero_callable_named_post_spec_in_sdivCode
@@ -22,7 +20,7 @@ theorem saveRa_signs_abs_signXor_then_divCall_bzero_callable_named_post_spec_in_
      shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
     (base : Word) (hbase : base &&& 1 = 0)
     (hbz : sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop = 0) :
-    cpsTripleWithin (49 + (EvmAsm.Evm64.unifiedDivBound + 1))
+    EvmAsm.Rv64.cpsTripleWithin (49 + (EvmAsm.Evm64.unifiedDivBound + 1))
       base (base + resultSignFixOff) (sdivCode base)
       (saveRaSignsAbsSignXorThenDivCallPre vRa vSavedOld sp sDividendOld sDivisorOld
         dividendMaskOld dividendValueOld dividendCarryOld


### PR DESCRIPTION
## Summary
- remove the broad Rv64 namespace open from SDiv Compose BzeroCallableNamedPost
- qualify cpsTripleWithin locally in the theorem conclusion
- keep the zero-divisor named-post wrapper proof behavior unchanged

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.BzeroCallableNamedPost
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- forbidden proof-escape scan on EvmAsm/Evm64/SDiv/Compose/BzeroCallableNamedPost.lean
- scripts/check-file-size.sh EvmAsm/Evm64/SDiv/Compose/BzeroCallableNamedPost.lean
- scripts/check-unimported.sh
- lake build