### PR TITLE
refactor(sdiv): clean divcall post view opens

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/DivCallPostView.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallPostView.lean
@@ -9,8 +9,6 @@ import EvmAsm.Evm64.SDiv.Compose.DivCallPreView
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64
-
 /-- Postcondition for the SDIV save-ra/signs/dividendAbs/divisorAbs/signXor
     /divCall block: `x1` holds the post-JAL return PC (`base + divCallOff
     + 4`), `x8` holds the result sign, the rest matches the signXor
@@ -19,18 +17,18 @@ open EvmAsm.Rv64
 @[irreducible]
 def saveRaSignsAbsSignXorThenDivCallPost
     (vRa sp base dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word) : Assertion :=
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word) : EvmAsm.Rv64.Assertion :=
   let dividendSign := dividendTop >>> (63 : BitVec 6).toNat
   let divisorSign := divisorTop >>> (63 : BitVec 6).toNat
   let resultSign := dividendSign ^^^ divisorSign
-  let dividendMem0 := sp + signExtend12 (0 : BitVec 12)
-  let dividendMem1 := sp + signExtend12 (8 : BitVec 12)
-  let dividendMem2 := sp + signExtend12 (16 : BitVec 12)
-  let dividendMem3 := sp + signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff
-  let divisorMem0 := sp + signExtend12 (32 : BitVec 12)
-  let divisorMem1 := sp + signExtend12 (40 : BitVec 12)
-  let divisorMem2 := sp + signExtend12 (48 : BitVec 12)
-  let divisorMem3 := sp + signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff
+  let dividendMem0 := sp + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)
+  let dividendMem1 := sp + EvmAsm.Rv64.signExtend12 (8 : BitVec 12)
+  let dividendMem2 := sp + EvmAsm.Rv64.signExtend12 (16 : BitVec 12)
+  let dividendMem3 := sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff
+  let divisorMem0 := sp + EvmAsm.Rv64.signExtend12 (32 : BitVec 12)
+  let divisorMem1 := sp + EvmAsm.Rv64.signExtend12 (40 : BitVec 12)
+  let divisorMem2 := sp + EvmAsm.Rv64.signExtend12 (48 : BitVec 12)
+  let divisorMem3 := sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff
   let dividendMask := (0 : Word) - dividendSign
   let dividendSum0 := (dividendLimb0 ^^^ dividendMask) + dividendSign
   let dividendCarry0 := if BitVec.ult dividendSum0 dividendSign then (1 : Word) else 0
@@ -50,7 +48,7 @@ def saveRaSignsAbsSignXorThenDivCallPost
   let divisorCarry3 := if BitVec.ult divisorSum3 divisorCarry2 then (1 : Word) else 0
   ((.x1 ↦ᵣ ((base + divCallOff) + 4)) **
    (((.x8 ↦ᵣ resultSign) ** (.x9 ↦ᵣ divisorSign)) **
-    ((.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12))) **
+    ((.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12))) **
      ((dividendMem0 ↦ₘ dividendSum0) **
       (dividendMem1 ↦ₘ dividendSum1) **
       (dividendMem2 ↦ₘ dividendSum2) **
@@ -70,14 +68,14 @@ theorem saveRaSignsAbsSignXorThenDivCallPost_unfold
       (let dividendSign := dividendTop >>> (63 : BitVec 6).toNat
        let divisorSign := divisorTop >>> (63 : BitVec 6).toNat
        let resultSign := dividendSign ^^^ divisorSign
-       let dividendMem0 := sp + signExtend12 (0 : BitVec 12)
-       let dividendMem1 := sp + signExtend12 (8 : BitVec 12)
-       let dividendMem2 := sp + signExtend12 (16 : BitVec 12)
-       let dividendMem3 := sp + signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff
-       let divisorMem0 := sp + signExtend12 (32 : BitVec 12)
-       let divisorMem1 := sp + signExtend12 (40 : BitVec 12)
-       let divisorMem2 := sp + signExtend12 (48 : BitVec 12)
-       let divisorMem3 := sp + signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff
+       let dividendMem0 := sp + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)
+       let dividendMem1 := sp + EvmAsm.Rv64.signExtend12 (8 : BitVec 12)
+       let dividendMem2 := sp + EvmAsm.Rv64.signExtend12 (16 : BitVec 12)
+       let dividendMem3 := sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff
+       let divisorMem0 := sp + EvmAsm.Rv64.signExtend12 (32 : BitVec 12)
+       let divisorMem1 := sp + EvmAsm.Rv64.signExtend12 (40 : BitVec 12)
+       let divisorMem2 := sp + EvmAsm.Rv64.signExtend12 (48 : BitVec 12)
+       let divisorMem3 := sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff
        let dividendMask := (0 : Word) - dividendSign
        let dividendSum0 := (dividendLimb0 ^^^ dividendMask) + dividendSign
        let dividendCarry0 := if BitVec.ult dividendSum0 dividendSign then (1 : Word) else 0
@@ -97,7 +95,7 @@ theorem saveRaSignsAbsSignXorThenDivCallPost_unfold
        let divisorCarry3 := if BitVec.ult divisorSum3 divisorCarry2 then (1 : Word) else 0
        ((.x1 ↦ᵣ ((base + divCallOff) + 4)) **
         (((.x8 ↦ᵣ resultSign) ** (.x9 ↦ᵣ divisorSign)) **
-         ((.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12))) **
+         ((.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12))) **
           ((dividendMem0 ↦ₘ dividendSum0) **
            (dividendMem1 ↦ₘ dividendSum1) **
            (dividendMem2 ↦ₘ dividendSum2) **


### PR DESCRIPTION
## Summary
- remove the broad Rv64 namespace open from SDiv Compose DivCallPostView
- qualify Assertion and signExtend12 locally in the postcondition bundle
- keep the postcondition definition and unfold theorem behavior unchanged

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.DivCallPostView
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- forbidden proof-escape scan on EvmAsm/Evm64/SDiv/Compose/DivCallPostView.lean
- scripts/check-file-size.sh EvmAsm/Evm64/SDiv/Compose/DivCallPostView.lean
- scripts/check-unimported.sh
- lake build