### PR TITLE
refactor(sdiv): clean bzero frame pcfree opens

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/BzeroFramePCFree.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroFramePCFree.lean
@@ -9,8 +9,6 @@ import EvmAsm.Evm64.SDiv.Compose.ResultSignFixPCFree
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64
-
 theorem saveRaDivCallBzeroResultSignFixFrame_pcFree
     {vRa sp base divisorSign : Word} {dividendAbsWord : EvmWord} :
     (saveRaDivCallBzeroResultSignFixFrame
@@ -22,7 +20,7 @@ theorem saveRaDivCallBzeroResultSignFixFrame_pcFree
 
 instance pcFreeInst_saveRaDivCallBzeroResultSignFixFrame
     (vRa sp base divisorSign : Word) (dividendAbsWord : EvmWord) :
-    Assertion.PCFree
+    EvmAsm.Rv64.Assertion.PCFree
       (saveRaDivCallBzeroResultSignFixFrame
         vRa sp base divisorSign dividendAbsWord) :=
   ⟨saveRaDivCallBzeroResultSignFixFrame_pcFree⟩
@@ -38,7 +36,7 @@ theorem saveRaDivCallBzeroSavedRaRetFrame_pcFree
 
 instance pcFreeInst_saveRaDivCallBzeroSavedRaRetFrame
     (sp base divisorSign : Word) (dividendAbsWord : EvmWord) :
-    Assertion.PCFree
+    EvmAsm.Rv64.Assertion.PCFree
       (saveRaDivCallBzeroSavedRaRetFrame
         sp base divisorSign dividendAbsWord) :=
   ⟨saveRaDivCallBzeroSavedRaRetFrame_pcFree⟩
@@ -54,7 +52,7 @@ theorem resultSignFixPost_bzeroResultSignFixFrame_pcFree
 instance pcFreeInst_resultSignFixPost_bzeroResultSignFixFrame
     (vRa sp base divisorSign sign limb0 limb1 limb2 limb3 : Word)
     (dividendAbsWord : EvmWord) :
-    Assertion.PCFree
+    EvmAsm.Rv64.Assertion.PCFree
       (resultSignFixPost (sp + 32) sign limb0 limb1 limb2 limb3 **
         saveRaDivCallBzeroResultSignFixFrame
           vRa sp base divisorSign dividendAbsWord) :=
@@ -70,7 +68,7 @@ theorem resultSignFixPost_savedRaRetFrame_pcFree
 instance pcFreeInst_resultSignFixPost_savedRaRetFrame
     (sp base divisorSign sign limb0 limb1 limb2 limb3 : Word)
     (dividendAbsWord : EvmWord) :
-    Assertion.PCFree
+    EvmAsm.Rv64.Assertion.PCFree
       (resultSignFixPost (sp + 32) sign limb0 limb1 limb2 limb3 **
         saveRaDivCallBzeroSavedRaRetFrame sp base divisorSign dividendAbsWord) :=
   ⟨resultSignFixPost_savedRaRetFrame_pcFree⟩


### PR DESCRIPTION
## Summary
- remove the broad Rv64 namespace open from SDiv Compose BzeroFramePCFree
- qualify Assertion.PCFree locally in the four instance declarations
- keep the pc-free proofs behaviorally unchanged

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.BzeroFramePCFree
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- forbidden proof-escape scan on EvmAsm/Evm64/SDiv/Compose/BzeroFramePCFree.lean
- scripts/check-file-size.sh EvmAsm/Evm64/SDiv/Compose/BzeroFramePCFree.lean
- scripts/check-unimported.sh
- lake build