### PR TITLE
refactor(sdiv): clean resultsign pcfree opens

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/ResultSignFixPCFree.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/ResultSignFixPCFree.lean
@@ -9,8 +9,6 @@ import EvmAsm.Evm64.SDiv.Compose.ResultSignFixOwnPre
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64
-
 theorem resultSignFixPost_pcFree
     {sp sign limb0 limb1 limb2 limb3 : Word} :
     (resultSignFixPost sp sign limb0 limb1 limb2 limb3).pcFree := by
@@ -20,7 +18,7 @@ theorem resultSignFixPost_pcFree
 
 instance pcFreeInst_resultSignFixPost
     (sp sign limb0 limb1 limb2 limb3 : Word) :
-    Assertion.PCFree (resultSignFixPost sp sign limb0 limb1 limb2 limb3) :=
+    EvmAsm.Rv64.Assertion.PCFree (resultSignFixPost sp sign limb0 limb1 limb2 limb3) :=
   ⟨resultSignFixPost_pcFree⟩
 
 theorem resultSignFixPreOwnX10_pcFree
@@ -32,7 +30,7 @@ theorem resultSignFixPreOwnX10_pcFree
 
 instance pcFreeInst_resultSignFixPreOwnX10
     (sp sign valueOld carryOld limb0 limb1 limb2 limb3 : Word) :
-    Assertion.PCFree
+    EvmAsm.Rv64.Assertion.PCFree
       (resultSignFixPreOwnX10
         sp sign valueOld carryOld limb0 limb1 limb2 limb3) :=
   ⟨resultSignFixPreOwnX10_pcFree⟩
@@ -46,7 +44,7 @@ theorem resultSignFixPreOwnX10X7_pcFree
 
 instance pcFreeInst_resultSignFixPreOwnX10X7
     (sp sign carryOld limb0 limb1 limb2 limb3 : Word) :
-    Assertion.PCFree
+    EvmAsm.Rv64.Assertion.PCFree
       (resultSignFixPreOwnX10X7 sp sign carryOld limb0 limb1 limb2 limb3) :=
   ⟨resultSignFixPreOwnX10X7_pcFree⟩
 
@@ -58,7 +56,7 @@ theorem resultSignFixPreOwnScratch_pcFree
 
 instance pcFreeInst_resultSignFixPreOwnScratch
     (sp sign limb0 limb1 limb2 limb3 : Word) :
-    Assertion.PCFree (resultSignFixPreOwnScratch sp sign limb0 limb1 limb2 limb3) :=
+    EvmAsm.Rv64.Assertion.PCFree (resultSignFixPreOwnScratch sp sign limb0 limb1 limb2 limb3) :=
   ⟨resultSignFixPreOwnScratch_pcFree⟩
 
 end EvmAsm.Evm64.SDiv.Compose


### PR DESCRIPTION
## Summary
- remove the broad Rv64 namespace open from SDiv Compose ResultSignFixPCFree
- qualify Assertion.PCFree locally in the four instance declarations
- keep the pc-free proofs behaviorally unchanged

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.ResultSignFixPCFree
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- forbidden proof-escape scan on EvmAsm/Evm64/SDiv/Compose/ResultSignFixPCFree.lean
- scripts/check-file-size.sh EvmAsm/Evm64/SDiv/Compose/ResultSignFixPCFree.lean
- scripts/check-unimported.sh
- lake build