### PR TITLE
refactor(sdiv): clean bzero callable pcfree opens

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/BzeroCallablePCFree.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroCallablePCFree.lean
@@ -8,8 +8,6 @@ import EvmAsm.Evm64.SDiv.Compose.BzeroCallablePost
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64
-
 theorem saveRaDivCallBzeroCallablePost_pcFree
     {vRa sp base dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
       divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word} :
@@ -26,7 +24,7 @@ theorem saveRaDivCallBzeroCallablePost_pcFree
 instance pcFreeInst_saveRaDivCallBzeroCallablePost
     (vRa sp base dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
       divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word) :
-    Assertion.PCFree
+    EvmAsm.Rv64.Assertion.PCFree
       (saveRaDivCallBzeroCallablePost vRa sp base
         dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
         divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) :=


### PR DESCRIPTION
## Summary
- remove the broad Rv64 namespace open from SDiv Compose BzeroCallablePCFree
- qualify Assertion.PCFree locally in the instance declaration
- keep the pc-free proof behavior unchanged

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.BzeroCallablePCFree
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- forbidden proof-escape scan on EvmAsm/Evm64/SDiv/Compose/BzeroCallablePCFree.lean
- scripts/check-file-size.sh EvmAsm/Evm64/SDiv/Compose/BzeroCallablePCFree.lean
- scripts/check-unimported.sh
- lake build