### PR TITLE
refactor(sdiv): clean dispatch pcfree basics opens

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/DivCallDispatchPcFreeBasics.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallDispatchPcFreeBasics.lean
@@ -9,8 +9,6 @@ import EvmAsm.Evm64.SDiv.Compose.DivCallResultSignFix
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64
-
 theorem divModStackDispatchPre_pcFree
     {sp : Word} {a b : EvmWord}
     {v1 v2 v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
@@ -27,7 +25,7 @@ instance pcFreeInst_divModStackDispatchPre
     (sp : Word) (a b : EvmWord)
     (v1 v2 v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
       shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word) :
-    Assertion.PCFree
+    EvmAsm.Rv64.Assertion.PCFree
       (EvmAsm.Evm64.divModStackDispatchPre sp a b
         v1 v2 v5 v6 v7 v10 v11
         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
@@ -43,7 +41,7 @@ theorem divStackDispatchPostNoX1_pcFree {sp : Word} {a b : EvmWord} :
 
 instance pcFreeInst_divStackDispatchPostNoX1
     (sp : Word) (a b : EvmWord) :
-    Assertion.PCFree (EvmAsm.Evm64.divStackDispatchPostNoX1 sp a b) :=
+    EvmAsm.Rv64.Assertion.PCFree (EvmAsm.Evm64.divStackDispatchPostNoX1 sp a b) :=
   ⟨divStackDispatchPostNoX1_pcFree⟩
 
 end EvmAsm.Evm64.SDiv.Compose


### PR DESCRIPTION
## Summary
- remove the broad Rv64 namespace open from SDiv Compose DivCallDispatchPcFreeBasics
- qualify Assertion.PCFree locally in the two instance declarations
- keep the pc-free proofs behaviorally unchanged

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.DivCallDispatchPcFreeBasics
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- forbidden proof-escape scan on EvmAsm/Evm64/SDiv/Compose/DivCallDispatchPcFreeBasics.lean
- scripts/check-file-size.sh EvmAsm/Evm64/SDiv/Compose/DivCallDispatchPcFreeBasics.lean
- scripts/check-unimported.sh
- lake build