### PR TITLE
refactor(sdiv): clean bzero zero-divisor view opens

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/BzeroStackZeroDivisorView.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroStackZeroDivisorView.lean
@@ -8,8 +8,6 @@ import EvmAsm.Evm64.SDiv.Compose.BzeroStackEntryViews
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64
-
 /-- Caller-visible zero-divisor specialization of the SDIV bzero stack-entry
     path. The internal absolute-divisor-zero proof is discharged from
     `(0 : EvmWord).getLimbN k = 0`, leaving the precondition in ordinary
@@ -22,7 +20,7 @@ theorem saveRa_signs_abs_signXor_then_divCall_bzero_stack_entry_zero_divisor_spe
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
      shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
     (base : Word) (hbase : base &&& 1 = 0) :
-    cpsTripleWithin (((49 + (EvmAsm.Evm64.unifiedDivBound + 1)) + 21) + 1)
+    EvmAsm.Rv64.cpsTripleWithin (((49 + (EvmAsm.Evm64.unifiedDivBound + 1)) + 21) + 1)
       base (vRa &&& ~~~(1 : Word)) (sdivCode base)
       ((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ vSavedOld) ** (.x12 ↦ᵣ sp) **
          (.x8 ↦ᵣ sDividendOld) ** (.x9 ↦ᵣ sDivisorOld) **


### PR DESCRIPTION
## Summary
- remove the broad Rv64 namespace open from SDiv Compose BzeroStackZeroDivisorView
- qualify cpsTripleWithin locally in the theorem conclusion
- keep the zero-divisor stack-entry proof behavior unchanged

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.BzeroStackZeroDivisorView
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- forbidden proof-escape scan on EvmAsm/Evm64/SDiv/Compose/BzeroStackZeroDivisorView.lean
- scripts/check-file-size.sh EvmAsm/Evm64/SDiv/Compose/BzeroStackZeroDivisorView.lean
- scripts/check-unimported.sh
- lake build