### PR TITLE
refactor(sdiv): clean bzero zero-word view opens

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/BzeroReturnZeroWordView.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroReturnZeroWordView.lean
@@ -8,8 +8,6 @@ import EvmAsm.Evm64.SDiv.Compose.BzeroReturnNormalizedView
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64
-
 /-- Zero-divisor SDIV path through return, with the result stack word exposed
     as the concrete zero EVM word after result-sign fixup. -/
 theorem saveRa_signs_abs_signXor_then_divCall_bzero_then_return_zero_word_spec_in_sdivCode
@@ -22,7 +20,7 @@ theorem saveRa_signs_abs_signXor_then_divCall_bzero_then_return_zero_word_spec_i
      shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
     (base : Word) (hbase : base &&& 1 = 0)
     (hbz : sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop = 0) :
-    cpsTripleWithin (((49 + (EvmAsm.Evm64.unifiedDivBound + 1)) + 21) + 1)
+    EvmAsm.Rv64.cpsTripleWithin (((49 + (EvmAsm.Evm64.unifiedDivBound + 1)) + 21) + 1)
       base (vRa &&& ~~~(1 : Word)) (sdivCode base)
       (saveRaSignsAbsSignXorThenDivCallPre vRa vSavedOld sp sDividendOld sDivisorOld
         dividendMaskOld dividendValueOld dividendCarryOld
@@ -51,7 +49,7 @@ theorem saveRa_signs_abs_signXor_then_divCall_bzero_then_return_zero_word_spec_i
          (.x10 ↦ᵣ mask) ** (.x7 ↦ᵣ (0 : Word)) ** (.x11 ↦ᵣ carry3) **
          evmWordIs (sp + 32) (0 : EvmWord)) **
         saveRaDivCallBzeroSavedRaRetFrame sp base divisorSign dividendAbsWord)) := by
-  exact cpsTripleWithin_weaken (fun _ hp => hp) (fun _ hp => by
+  exact EvmAsm.Rv64.cpsTripleWithin_weaken (fun _ hp => hp) (fun _ hp => by
       rw [resultSignFixPost_sdivResultSign_zero_word (sp + 32) dividendTop divisorTop] at hp
       exact hp)
     (saveRa_signs_abs_signXor_then_divCall_bzero_then_return_normalized_spec_in_sdivCode


### PR DESCRIPTION
## Summary
- remove the broad Rv64 namespace open from SDiv Compose BzeroReturnZeroWordView
- qualify cpsTripleWithin and cpsTripleWithin_weaken locally
- keep the zero-word return proof behavior unchanged

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.BzeroReturnZeroWordView
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- forbidden proof-escape scan on EvmAsm/Evm64/SDiv/Compose/BzeroReturnZeroWordView.lean
- scripts/check-file-size.sh EvmAsm/Evm64/SDiv/Compose/BzeroReturnZeroWordView.lean
- scripts/check-unimported.sh
- lake build