### PR TITLE
refactor(sdiv): clean bzero normalized view opens

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/BzeroReturnNormalizedView.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroReturnNormalizedView.lean
@@ -9,8 +9,6 @@ import EvmAsm.Evm64.SDiv.Compose.DispatchViews
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64
-
 /-- Normalized return-target view of the SDIV zero-divisor path. This hides
     the two `signExtend12 0` artifacts introduced by the saved-RA move and
     the final `JALR`, leaving downstream callers with the ordinary masked
@@ -25,7 +23,7 @@ theorem saveRa_signs_abs_signXor_then_divCall_bzero_then_return_normalized_spec_
      shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
     (base : Word) (hbase : base &&& 1 = 0)
     (hbz : sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop = 0) :
-    cpsTripleWithin (((49 + (EvmAsm.Evm64.unifiedDivBound + 1)) + 21) + 1)
+    EvmAsm.Rv64.cpsTripleWithin (((49 + (EvmAsm.Evm64.unifiedDivBound + 1)) + 21) + 1)
       base (vRa &&& ~~~(1 : Word)) (sdivCode base)
       (saveRaSignsAbsSignXorThenDivCallPre vRa vSavedOld sp sDividendOld sDivisorOld
         dividendMaskOld dividendValueOld dividendCarryOld
@@ -44,14 +42,14 @@ theorem saveRa_signs_abs_signXor_then_divCall_bzero_then_return_normalized_spec_
        (resultSignFixPost (sp + 32) resultSign 0 0 0 0 **
         saveRaDivCallBzeroSavedRaRetFrame sp base divisorSign dividendAbsWord)) := by
   have hExit :
-      (((vRa + signExtend12 (0 : BitVec 12)) +
-        signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word)) =
+      (((vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)) +
+        EvmAsm.Rv64.signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word)) =
         (vRa &&& ~~~(1 : Word)) := by
-    rw [signExtend12_0]
+    rw [EvmAsm.Rv64.signExtend12_0]
     bv_decide
   rw [← hExit]
-  exact cpsTripleWithin_weaken (fun _ hp => hp) (fun _ hp => by
-      simp only [signExtend12_0] at hp ⊢
+  exact EvmAsm.Rv64.cpsTripleWithin_weaken (fun _ hp => hp) (fun _ hp => by
+      simp only [EvmAsm.Rv64.signExtend12_0] at hp ⊢
       have hRa : (vRa + (0 : Word)) = vRa := by bv_decide
       rw [hRa] at hp
       exact hp)


### PR DESCRIPTION
## Summary
- remove the broad Rv64 namespace open from SDiv Compose BzeroReturnNormalizedView
- qualify cpsTripleWithin, cpsTripleWithin_weaken, signExtend12, and signExtend12_0 locally
- keep the normalized return-target proof behavior unchanged

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.BzeroReturnNormalizedView
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- forbidden proof-escape scan on EvmAsm/Evm64/SDiv/Compose/BzeroReturnNormalizedView.lean
- scripts/check-file-size.sh EvmAsm/Evm64/SDiv/Compose/BzeroReturnNormalizedView.lean
- scripts/check-unimported.sh
- lake build