### PR TITLE
refactor(sdiv): clean dispatch frame opens

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/DivCallDispatchFrame.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallDispatchFrame.lean
@@ -9,7 +9,6 @@ import EvmAsm.Evm64.SDiv.Compose.DivCallPrefix
 namespace EvmAsm.Evm64.SDiv.Compose
 
 open EvmAsm.Rv64.Tactics
-open EvmAsm.Rv64
 
 /-- Frame the dispatcher-pre slots — `(.x2 ↦ᵣ v2)`, `(.x5 ↦ᵣ v5)`,
     `(.x6 ↦ᵣ v6)`, and `divScratchValuesCall` — through
@@ -29,8 +28,8 @@ theorem saveRa_signs_abs_signXor_then_divCall_framed_for_dispatch_spec_in_sdivCo
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
      shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
     (base : Word) :
-    cpsTripleWithin 49 base
-      ((base + divCallOff) + signExtend21 EvmAsm.Evm64.evm_sdivCallOff)
+    EvmAsm.Rv64.cpsTripleWithin 49 base
+      ((base + divCallOff) + EvmAsm.Rv64.signExtend21 EvmAsm.Evm64.evm_sdivCallOff)
       (sdivCode base)
       (saveRaSignsAbsSignXorThenDivCallPre vRa vSavedOld sp sDividendOld sDivisorOld
         dividendMaskOld dividendValueOld dividendCarryOld
@@ -52,7 +51,7 @@ theorem saveRa_signs_abs_signXor_then_divCall_framed_for_dispatch_spec_in_sdivCo
     rw [EvmAsm.Evm64.divScratchValuesCall_unfold]
     unfold EvmAsm.Evm64.divScratchValues
     pcFree
-  exact cpsTripleWithin_frameR _ hFramePcFree
+  exact EvmAsm.Rv64.cpsTripleWithin_frameR _ hFramePcFree
     (saveRa_signs_abs_signXor_then_divCall_spec_in_sdivCode
       vRa vSavedOld sp sDividendOld sDivisorOld
       dividendMaskOld dividendValueOld dividendCarryOld


### PR DESCRIPTION
## Summary
- remove the broad Rv64 namespace open from DivCallDispatchFrame
- qualify the Rv64 CPS triple, offset sign extension, and frame rule references directly
- keep the tactics open needed for pcFree automation

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.DivCallDispatchFrame
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/DivCallDispatchFrame.lean (no matches)
- scripts/check-file-size.sh EvmAsm/Evm64/SDiv/Compose/DivCallDispatchFrame.lean
- scripts/check-unimported.sh
- lake build