### PR TITLE
refactor(sdiv): clean divcall wrapper opens

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/DivCall.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCall.lean
@@ -9,6 +9,4 @@ import EvmAsm.Evm64.SDiv.Compose.DivCallDispatchFrame
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64
-
 end EvmAsm.Evm64.SDiv.Compose


### PR DESCRIPTION
## Summary
- remove the unused broad Rv64 namespace open from the DivCall import wrapper

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.DivCall
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/DivCall.lean (no matches)
- scripts/check-file-size.sh EvmAsm/Evm64/SDiv/Compose/DivCall.lean
- scripts/check-unimported.sh
- lake build