### PR TITLE
refactor(sdiv): clean resultsignfix own opens

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/ResultSignFixOwn.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/ResultSignFixOwn.lean
@@ -14,20 +14,19 @@ import EvmAsm.Rv64.Tactics.XSimp
 namespace EvmAsm.Evm64.SDiv.Compose
 
 open EvmAsm.Rv64.Tactics
-open EvmAsm.Rv64
 
 /-- SDIV result sign-fix spec that consumes owned `x10` instead of requiring
     a concrete old mask value. -/
 theorem resultSignFix_regOwn_x10_spec_in_sdivCode
     (sp sign valueOld carryOld limb0 limb1 limb2 limb3 : Word) (base : Word) :
-    cpsTripleWithin 21 (base + resultSignFixOff)
+    EvmAsm.Rv64.cpsTripleWithin 21 (base + resultSignFixOff)
       ((base + resultSignFixOff) + 84) (sdivCode base)
       (resultSignFixPreOwnX10 sp sign valueOld carryOld limb0 limb1 limb2 limb3)
       (resultSignFixPost sp sign limb0 limb1 limb2 limb3) := by
   rw [resultSignFixPreOwnX10_unfold]
-  apply cpsTripleWithin_of_forall_regIs_to_regOwn
+  apply EvmAsm.Rv64.cpsTripleWithin_of_forall_regIs_to_regOwn
   intro maskOld
-  exact cpsTripleWithin_weaken
+  exact EvmAsm.Rv64.cpsTripleWithin_weaken
     (fun _ hp => by
       rw [resultSignFixPre_unfold]
       xperm_hyp hp)
@@ -39,14 +38,14 @@ theorem resultSignFix_regOwn_x10_spec_in_sdivCode
     only the old `x11` carry value concrete. -/
 theorem resultSignFix_regOwn_x10_x7_spec_in_sdivCode
     (sp sign carryOld limb0 limb1 limb2 limb3 : Word) (base : Word) :
-    cpsTripleWithin 21 (base + resultSignFixOff)
+    EvmAsm.Rv64.cpsTripleWithin 21 (base + resultSignFixOff)
       ((base + resultSignFixOff) + 84) (sdivCode base)
       (resultSignFixPreOwnX10X7 sp sign carryOld limb0 limb1 limb2 limb3)
       (resultSignFixPost sp sign limb0 limb1 limb2 limb3) := by
   rw [resultSignFixPreOwnX10X7_unfold]
-  apply cpsTripleWithin_of_forall_regIs_to_regOwn
+  apply EvmAsm.Rv64.cpsTripleWithin_of_forall_regIs_to_regOwn
   intro valueOld
-  exact cpsTripleWithin_weaken
+  exact EvmAsm.Rv64.cpsTripleWithin_weaken
     (fun _ hp => by
       rw [resultSignFixPreOwnX10_unfold]
       xperm_hyp hp)
@@ -57,14 +56,14 @@ theorem resultSignFix_regOwn_x10_x7_spec_in_sdivCode
 /-- SDIV result sign-fix spec that consumes owned `x10`, `x7`, and `x11`. -/
 theorem resultSignFix_regOwn_scratch_spec_in_sdivCode
     (sp sign limb0 limb1 limb2 limb3 : Word) (base : Word) :
-    cpsTripleWithin 21 (base + resultSignFixOff)
+    EvmAsm.Rv64.cpsTripleWithin 21 (base + resultSignFixOff)
       ((base + resultSignFixOff) + 84) (sdivCode base)
       (resultSignFixPreOwnScratch sp sign limb0 limb1 limb2 limb3)
       (resultSignFixPost sp sign limb0 limb1 limb2 limb3) := by
   rw [resultSignFixPreOwnScratch_unfold]
-  apply cpsTripleWithin_of_forall_regIs_to_regOwn
+  apply EvmAsm.Rv64.cpsTripleWithin_of_forall_regIs_to_regOwn
   intro carryOld
-  exact cpsTripleWithin_weaken
+  exact EvmAsm.Rv64.cpsTripleWithin_weaken
     (fun _ hp => by
       rw [resultSignFixPreOwnX10X7_unfold]
       xperm_hyp hp)


### PR DESCRIPTION
## Summary
- remove the broad Rv64 namespace open from ResultSignFixOwn
- qualify CPS triple, register-ownership conversion, and weakening combinators directly
- keep only the tactics open needed for xperm_hyp

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.ResultSignFixOwn
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/ResultSignFixOwn.lean (no matches)
- scripts/check-file-size.sh EvmAsm/Evm64/SDiv/Compose/ResultSignFixOwn.lean
- scripts/check-unimported.sh
- lake build