### PR TITLE
refactor(sdiv): clean divcall return composition opens

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/DivCallReturnComposition.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallReturnComposition.lean
@@ -2,8 +2,6 @@ import EvmAsm.Evm64.SDiv.Compose.DivCallReturnNormalized
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64
-
 /-- Named-post wrapper for the normalized generic SDIV callable composition.
     This is the stable handoff surface for later exact-callable proofs. -/
 theorem saveRa_signs_abs_signXor_then_divCall_then_return_normalized_named_post_of_callable_post_spec_in_sdivCode
@@ -17,7 +15,7 @@ theorem saveRa_signs_abs_signXor_then_divCall_then_return_normalized_named_post_
      shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
     (base : Word)
     (hCallable :
-      cpsTripleWithin nSteps (base + wrapperEndOff) (base + resultSignFixOff) (sdivCode base)
+      EvmAsm.Rv64.cpsTripleWithin nSteps (base + wrapperEndOff) (base + resultSignFixOff) (sdivCode base)
         (saveRaDivCallDispatchReadyPost vRa sp base
           dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
           divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
@@ -26,7 +24,7 @@ theorem saveRa_signs_abs_signXor_then_divCall_then_return_normalized_named_post_
         (saveRaDivCallBzeroCallablePost vRa sp base
           dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
           divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)) :
-    cpsTripleWithin (((49 + nSteps) + 21) + 1)
+    EvmAsm.Rv64.cpsTripleWithin (((49 + nSteps) + 21) + 1)
       base (vRa &&& ~~~(1 : Word)) (sdivCode base)
       (saveRaSignsAbsSignXorThenDivCallPre vRa vSavedOld sp sDividendOld sDivisorOld
         dividendMaskOld dividendValueOld dividendCarryOld


### PR DESCRIPTION
## Summary
- remove the broad Rv64 namespace open from DivCallReturnComposition
- qualify the CPS triple declarations directly in the named-post wrapper

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.DivCallReturnComposition
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/DivCallReturnComposition.lean (no matches)
- scripts/check-file-size.sh EvmAsm/Evm64/SDiv/Compose/DivCallReturnComposition.lean
- scripts/check-unimported.sh
- lake build