### PR TITLE
refactor(sdiv): clean divcall exact resultsignfix handoff opens

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/DivCallExactResultSignFixHandoff.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallExactResultSignFixHandoff.lean
@@ -9,8 +9,6 @@ import EvmAsm.Evm64.SDiv.Compose.DivCallResultSignFixNamedPost
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64
-
 /-- Exact SDIV path through result-sign-fix, specialized from the sidecar
     exact callable handoff and stopping before the saved-RA return. -/
 theorem saveRa_signs_abs_signXor_then_divCall_exact_then_resultSignFix_named_post_from_handoff_spec_in_sdivCode
@@ -23,7 +21,7 @@ theorem saveRa_signs_abs_signXor_then_divCall_exact_then_resultSignFix_named_pos
      shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
     (base : Word) (hbase : base &&& 1 = 0)
     (hStack :
-      cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
+      EvmAsm.Rv64.cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
         (base + wrapperEndOff)
         ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
         (EvmAsm.Evm64.divCode_noNop (base + wrapperEndOff))
@@ -40,7 +38,7 @@ theorem saveRa_signs_abs_signXor_then_divCall_exact_then_resultSignFix_named_pos
           (sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
           (sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) **
           (.x1 ↦ᵣ ((base + divCallOff) + 4)))) :
-    cpsTripleWithin ((49 + (EvmAsm.Evm64.unifiedDivBound + 1)) + 21)
+    EvmAsm.Rv64.cpsTripleWithin ((49 + (EvmAsm.Evm64.unifiedDivBound + 1)) + 21)
       base ((base + resultSignFixOff) + 84) (sdivCode base)
       (saveRaSignsAbsSignXorThenDivCallPre vRa vSavedOld sp sDividendOld sDivisorOld
         dividendMaskOld dividendValueOld dividendCarryOld


### PR DESCRIPTION
## Summary
- remove the broad Rv64 namespace open from DivCallExactResultSignFixHandoff
- qualify the CPS triple declarations directly in the exact result-sign-fix handoff wrapper

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.DivCallExactResultSignFixHandoff
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/DivCallExactResultSignFixHandoff.lean (no matches)
- scripts/check-file-size.sh EvmAsm/Evm64/SDiv/Compose/DivCallExactResultSignFixHandoff.lean
- scripts/check-unimported.sh
- lake build