### PR TITLE
refactor(sdiv): clean divcall bzero resultsignfix handoff opens

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/DivCallBzeroResultSignFixHandoff.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallBzeroResultSignFixHandoff.lean
@@ -9,8 +9,6 @@ import EvmAsm.Evm64.SDiv.Compose.DivCallResultSignFixNamedPost
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64
-
 /-- Zero-divisor SDIV path through result-sign-fix, specialized from the
     sidecar bzero callable handoff and stopping before the saved-RA return. -/
 theorem saveRa_signs_abs_signXor_then_divCall_bzero_then_resultSignFix_named_post_from_handoff_spec_in_sdivCode
@@ -23,7 +21,7 @@ theorem saveRa_signs_abs_signXor_then_divCall_bzero_then_resultSignFix_named_pos
      shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
     (base : Word) (hbase : base &&& 1 = 0)
     (hbz : sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop = 0) :
-    cpsTripleWithin ((49 + (EvmAsm.Evm64.unifiedDivBound + 1)) + 21)
+    EvmAsm.Rv64.cpsTripleWithin ((49 + (EvmAsm.Evm64.unifiedDivBound + 1)) + 21)
       base ((base + resultSignFixOff) + 84) (sdivCode base)
       (saveRaSignsAbsSignXorThenDivCallPre vRa vSavedOld sp sDividendOld sDivisorOld
         dividendMaskOld dividendValueOld dividendCarryOld


### PR DESCRIPTION
## Summary
- remove the broad Rv64 namespace open from DivCallBzeroResultSignFixHandoff
- qualify the CPS triple declaration directly in the zero-divisor result-sign-fix handoff wrapper

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.DivCallBzeroResultSignFixHandoff
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/DivCallBzeroResultSignFixHandoff.lean (no matches)
- scripts/check-file-size.sh EvmAsm/Evm64/SDiv/Compose/DivCallBzeroResultSignFixHandoff.lean
- scripts/check-unimported.sh
- lake build