### PR TITLE
refactor(sdiv): clean divcall bzero callable handoff opens

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/DivCallBzeroCallableHandoff.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallBzeroCallableHandoff.lean
@@ -8,8 +8,6 @@ import EvmAsm.Evm64.SDiv.Compose.DivCallBzeroHandoff
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64
-
 /-- SDIV wrapper prefix followed by the zero-divisor unsigned-DIV callable,
     using the sidecar dispatch-ready handoff above. This mirrors the named
     callable-post theorem in `DivCallDispatch.lean` without adding proof bulk
@@ -24,7 +22,7 @@ theorem saveRa_signs_abs_signXor_then_divCall_bzero_callable_named_post_from_han
      shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
     (base : Word) (hbase : base &&& 1 = 0)
     (hbz : sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop = 0) :
-    cpsTripleWithin (49 + (EvmAsm.Evm64.unifiedDivBound + 1))
+    EvmAsm.Rv64.cpsTripleWithin (49 + (EvmAsm.Evm64.unifiedDivBound + 1))
       base (base + resultSignFixOff) (sdivCode base)
       (saveRaSignsAbsSignXorThenDivCallPre vRa vSavedOld sp sDividendOld sDivisorOld
         dividendMaskOld dividendValueOld dividendCarryOld


### PR DESCRIPTION
## Summary
- remove the broad Rv64 namespace open from DivCallBzeroCallableHandoff
- qualify the CPS triple declaration directly in the zero-divisor callable handoff wrapper

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.DivCallBzeroCallableHandoff
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/DivCallBzeroCallableHandoff.lean (no matches)
- scripts/check-file-size.sh EvmAsm/Evm64/SDiv/Compose/DivCallBzeroCallableHandoff.lean
- scripts/check-unimported.sh
- lake build