### PR TITLE
refactor(sdiv): clean divcall framed callable opens

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/DivCallFramedCallable.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallFramedCallable.lean
@@ -10,19 +10,18 @@ import EvmAsm.Evm64.SDiv.Compose.DivCallCallable
 namespace EvmAsm.Evm64.SDiv.Compose
 
 open EvmAsm.Rv64.Tactics
-open EvmAsm.Rv64
 
 /-- Frame the preserving-`x1` unsigned-DIV callable wrapper by an arbitrary
     PC-free assertion. SDIV uses this for the private sign frame carried across
     the exact callable handoff. -/
 theorem evm_div_callable_preserving_x1_framed_spec_in_sdivCode
-    {F : Assertion} [Assertion.PCFree F]
+    {F : EvmAsm.Rv64.Assertion} [EvmAsm.Rv64.Assertion.PCFree F]
     (sp base raVal : Word) (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
      nMem shiftMem jMem retMem dMem dloMem scratchUn0 : Word)
     (branch : EvmAsm.Evm64.DivStackSpecCase (base + wrapperEndOff) a b)
     (hStack :
-      cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
+      EvmAsm.Rv64.cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
         (base + wrapperEndOff)
         ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
         (EvmAsm.Evm64.divCode_noNop (base + wrapperEndOff))
@@ -31,7 +30,7 @@ theorem evm_div_callable_preserving_x1_framed_spec_in_sdivCode
           q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0)
         (EvmAsm.Evm64.divStackDispatchPostNoX1 sp a b ** (.x1 ↦ᵣ raVal))) :
-    cpsTripleWithin (EvmAsm.Evm64.unifiedDivBound + 1)
+    EvmAsm.Rv64.cpsTripleWithin (EvmAsm.Evm64.unifiedDivBound + 1)
       (base + wrapperEndOff) (raVal &&& ~~~1) (sdivCode base)
       (EvmAsm.Evm64.divModStackDispatchPre sp a b
         branch.x1 branch.x2 v5 v6 v7 v10 v11
@@ -39,7 +38,7 @@ theorem evm_div_callable_preserving_x1_framed_spec_in_sdivCode
         shiftMem nMem jMem retMem dMem dloMem scratchUn0 ** F)
       ((EvmAsm.Evm64.divStackDispatchPostNoX1 sp a b ** (.x1 ↦ᵣ raVal)) ** F) := by
   exact
-    cpsTripleWithin_frameR F (by pcFree)
+    EvmAsm.Rv64.cpsTripleWithin_frameR F (by pcFree)
       (evm_div_callable_preserving_x1_spec_in_sdivCode
         sp base raVal a b v5 v6 v7 v10 v11
         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7


### PR DESCRIPTION
## Summary
- remove the broad Rv64 namespace open from DivCallFramedCallable
- qualify the framed Assertion/PCFree surface, CPS triple annotations, and frame rule directly
- keep only the tactics open needed for pcFree

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.DivCallFramedCallable
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/DivCallFramedCallable.lean (no matches)
- scripts/check-file-size.sh EvmAsm/Evm64/SDiv/Compose/DivCallFramedCallable.lean
- scripts/check-unimported.sh
- lake build