### PR TITLE
refactor(sdiv): clean bzero callable post opens

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/BzeroCallablePost.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroCallablePost.lean
@@ -11,8 +11,6 @@ import EvmAsm.Evm64.SDiv.Compose.Words
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64
-
 /-- Named postcondition after the SDIV prefix has called the unsigned DIV
     callable along the zero-divisor branch. This keeps the sign frame and the
     concrete return address bundled for the following result-sign-fix step. -/
@@ -20,7 +18,7 @@ open EvmAsm.Rv64
 def saveRaDivCallBzeroCallablePost
     (vRa sp base : Word)
     (dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word) : Assertion :=
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word) : EvmAsm.Rv64.Assertion :=
   let resultSign :=
     (dividendTop >>> (63 : BitVec 6).toNat) ^^^
       (divisorTop >>> (63 : BitVec 6).toNat)
@@ -30,7 +28,7 @@ def saveRaDivCallBzeroCallablePost
       (sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) **
     (.x1 ↦ᵣ ((base + divCallOff) + 4))) **
    ((.x8 ↦ᵣ resultSign) ** (.x9 ↦ᵣ divisorSign) **
-    (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12)))))
+    (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))))
 
 theorem saveRaDivCallBzeroCallablePost_unfold
     {vRa sp base : Word}
@@ -48,7 +46,7 @@ theorem saveRaDivCallBzeroCallablePost_unfold
            (sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) **
          (.x1 ↦ᵣ ((base + divCallOff) + 4))) **
         ((.x8 ↦ᵣ resultSign) ** (.x9 ↦ᵣ divisorSign) **
-         (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12)))))) := by
+         (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))))) := by
   delta saveRaDivCallBzeroCallablePost
   rfl
 
@@ -68,14 +66,14 @@ theorem saveRaDivCallBzeroCallablePost_unfold_zero_quotient
          (dividendTop >>> (63 : BitVec 6).toNat) ^^^
            (divisorTop >>> (63 : BitVec 6).toNat)
        let divisorSign := divisorTop >>> (63 : BitVec 6).toNat
-       (((.x12 ↦ᵣ (sp + 32)) ** regOwn .x2 **
-         regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
-         regOwn .x10 ** regOwn .x11 ** (.x0 ↦ᵣ (0 : Word)) **
+       (((.x12 ↦ᵣ (sp + 32)) ** EvmAsm.Rv64.regOwn .x2 **
+         EvmAsm.Rv64.regOwn .x5 ** EvmAsm.Rv64.regOwn .x6 ** EvmAsm.Rv64.regOwn .x7 **
+         EvmAsm.Rv64.regOwn .x10 ** EvmAsm.Rv64.regOwn .x11 ** (.x0 ↦ᵣ (0 : Word)) **
          evmWordIs sp dividendAbsWord ** evmWordIs (sp + 32) (0 : EvmWord) **
          EvmAsm.Evm64.divScratchOwnCall sp) **
         (.x1 ↦ᵣ ((base + divCallOff) + 4))) **
        ((.x8 ↦ᵣ resultSign) ** (.x9 ↦ᵣ divisorSign) **
-        (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12))))) := by
+        (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12))))) := by
   rw [saveRaDivCallBzeroCallablePost_unfold,
     EvmAsm.Evm64.divStackDispatchPostNoX1_unfold]
   dsimp only


### PR DESCRIPTION
## Summary
- remove the broad Rv64 namespace open from BzeroCallablePost
- qualify Assertion, regOwn, and signExtend12 references directly in the zero-divisor callable post views

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.BzeroCallablePost
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/BzeroCallablePost.lean (no matches)
- scripts/check-file-size.sh EvmAsm/Evm64/SDiv/Compose/BzeroCallablePost.lean
- scripts/check-unimported.sh
- lake build