### PR TITLE
refactor(sdiv): clean bzero post opens

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/BzeroPost.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroPost.lean
@@ -12,7 +12,6 @@ import EvmAsm.Evm64.SDiv.Compose.ResultSignFixOwnPre
 namespace EvmAsm.Evm64.SDiv.Compose
 
 open EvmAsm.Rv64.Tactics
-open EvmAsm.Rv64
 
 /-- Zero-divisor callable post reshaped as the result-sign-fix precondition
     over the current quotient cell plus an explicit frame. -/
@@ -36,10 +35,10 @@ theorem saveRaDivCallBzeroCallablePost_resultSignFixPreOwnScratch
   dsimp only
   rw [resultSignFixPreOwnScratch_unfold,
     saveRaDivCallBzeroResultSignFixFrame_unfold, evmWordIs_zero]
-  rw [show (sp + 32 + signExtend12 (0 : BitVec 12) : Word) = sp + 32 by bv_addr]
-  rw [show (sp + 32 + signExtend12 (8 : BitVec 12) : Word) = (sp + 32) + 8 by bv_addr]
-  rw [show (sp + 32 + signExtend12 (16 : BitVec 12) : Word) = (sp + 32) + 16 by bv_addr]
-  rw [show (sp + 32 + signExtend12 (24 : BitVec 12) : Word) = (sp + 32) + 24 by bv_addr]
+  rw [show (sp + 32 + EvmAsm.Rv64.signExtend12 (0 : BitVec 12) : Word) = sp + 32 by bv_addr]
+  rw [show (sp + 32 + EvmAsm.Rv64.signExtend12 (8 : BitVec 12) : Word) = (sp + 32) + 8 by bv_addr]
+  rw [show (sp + 32 + EvmAsm.Rv64.signExtend12 (16 : BitVec 12) : Word) = (sp + 32) + 16 by bv_addr]
+  rw [show (sp + 32 + EvmAsm.Rv64.signExtend12 (24 : BitVec 12) : Word) = (sp + 32) + 24 by bv_addr]
   xperm
 
 /-- Callable post reshaped as the result-sign-fix precondition over the
@@ -70,10 +69,10 @@ theorem saveRaDivCallBzeroCallablePost_resultSignFixPreOwnScratch_quotient
   dsimp only
   rw [resultSignFixPreOwnScratch_unfold,
     saveRaDivCallBzeroResultSignFixFrame_unfold, evmWordIs_sp32_unfold]
-  rw [show (sp + 32 + signExtend12 (0 : BitVec 12) : Word) = sp + 32 by bv_addr]
-  rw [show (sp + 32 + signExtend12 (8 : BitVec 12) : Word) = sp + 40 by bv_addr]
-  rw [show (sp + 32 + signExtend12 (16 : BitVec 12) : Word) = sp + 48 by bv_addr]
-  rw [show (sp + 32 + signExtend12 (24 : BitVec 12) : Word) = sp + 56 by bv_addr]
+  rw [show (sp + 32 + EvmAsm.Rv64.signExtend12 (0 : BitVec 12) : Word) = sp + 32 by bv_addr]
+  rw [show (sp + 32 + EvmAsm.Rv64.signExtend12 (8 : BitVec 12) : Word) = sp + 40 by bv_addr]
+  rw [show (sp + 32 + EvmAsm.Rv64.signExtend12 (16 : BitVec 12) : Word) = sp + 48 by bv_addr]
+  rw [show (sp + 32 + EvmAsm.Rv64.signExtend12 (24 : BitVec 12) : Word) = sp + 56 by bv_addr]
   xperm
 
 end EvmAsm.Evm64.SDiv.Compose


### PR DESCRIPTION
## Summary
- remove the broad Rv64 namespace open from BzeroPost
- qualify signExtend12 references directly in zero-divisor postcondition reshaping proofs
- keep only the tactics open needed for xperm/bv_addr

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.BzeroPost
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/BzeroPost.lean (no matches)
- scripts/check-file-size.sh EvmAsm/Evm64/SDiv/Compose/BzeroPost.lean
- scripts/check-unimported.sh
- lake build