### PR TITLE
refactor(sdiv): clean base resultsignfix blockspec opens

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/BaseResultSignFixBlockSpec.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BaseResultSignFixBlockSpec.lean
@@ -9,12 +9,10 @@ import EvmAsm.Evm64.SDiv.Compose.BaseResultSignFix
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64
-
 theorem resultSignFix_spec_in_sdivCode
     (sp sign maskOld valueOld carryOld limb0 limb1 limb2 limb3 : Word)
     (base : Word) :
-    cpsTripleWithin 21 (base + resultSignFixOff)
+    EvmAsm.Rv64.cpsTripleWithin 21 (base + resultSignFixOff)
       ((base + resultSignFixOff) + 84) (sdivCode base)
       (resultSignFixPre sp sign maskOld valueOld carryOld
         limb0 limb1 limb2 limb3)
@@ -37,6 +35,6 @@ theorem resultSignFix_spec_in_sdivCode
       (base + resultSignFixOff) (by decide) (by decide) (by decide)
   rw [EvmAsm.Evm64.condNegate256BlockPre_unfold,
     EvmAsm.Evm64.condNegate256BlockPost_unfold] at hSpec
-  exact cpsTripleWithin_extend_code hmono hSpec
+  exact EvmAsm.Rv64.cpsTripleWithin_extend_code hmono hSpec
 
 end EvmAsm.Evm64.SDiv.Compose


### PR DESCRIPTION
## Summary
- remove the broad Rv64 namespace open from BaseResultSignFixBlockSpec
- qualify the CPS triple and code-extension combinator directly

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.BaseResultSignFixBlockSpec
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/BaseResultSignFixBlockSpec.lean (no matches)
- scripts/check-file-size.sh EvmAsm/Evm64/SDiv/Compose/BaseResultSignFixBlockSpec.lean
- scripts/check-unimported.sh
- lake build