### PR TITLE
refactor(sdiv): clean dividend abs pre opens

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/DividendAbsPre.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DividendAbsPre.lean
@@ -8,21 +8,19 @@ import EvmAsm.Evm64.SDiv.Compose.BaseSignSequence
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64
-
 /-- Precondition for the SDIV dividend-abs (conditional 2's-complement
     negation) block. Wraps the register/memory entry shape as an
     `@[irreducible]` def so downstream proofs do not re-unfold the
     sepConj atoms at each use site. -/
 @[irreducible]
 def dividendAbsPre (sp sign maskOld valueOld carryOld
-    limb0 limb1 limb2 limb3 : Word) : Assertion :=
+    limb0 limb1 limb2 limb3 : Word) : EvmAsm.Rv64.Assertion :=
   (.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sign) **
   (.x10 ↦ᵣ maskOld) ** (.x7 ↦ᵣ valueOld) ** (.x11 ↦ᵣ carryOld) **
-  ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ limb0) **
-  ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ limb1) **
-  ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ limb2) **
-  ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ limb3)
+  ((sp + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)) ↦ₘ limb0) **
+  ((sp + EvmAsm.Rv64.signExtend12 (8 : BitVec 12)) ↦ₘ limb1) **
+  ((sp + EvmAsm.Rv64.signExtend12 (16 : BitVec 12)) ↦ₘ limb2) **
+  ((sp + EvmAsm.Rv64.signExtend12 (24 : BitVec 12)) ↦ₘ limb3)
 
 theorem dividendAbsPre_unfold
     {sp sign maskOld valueOld carryOld limb0 limb1 limb2 limb3 : Word} :
@@ -30,10 +28,10 @@ theorem dividendAbsPre_unfold
         limb0 limb1 limb2 limb3 =
       ((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sign) **
        (.x10 ↦ᵣ maskOld) ** (.x7 ↦ᵣ valueOld) ** (.x11 ↦ᵣ carryOld) **
-       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ limb0) **
-       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ limb1) **
-       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ limb2) **
-       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ limb3)) := by
+       ((sp + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)) ↦ₘ limb0) **
+       ((sp + EvmAsm.Rv64.signExtend12 (8 : BitVec 12)) ↦ₘ limb1) **
+       ((sp + EvmAsm.Rv64.signExtend12 (16 : BitVec 12)) ↦ₘ limb2) **
+       ((sp + EvmAsm.Rv64.signExtend12 (24 : BitVec 12)) ↦ₘ limb3)) := by
   delta dividendAbsPre
   rfl
 


### PR DESCRIPTION
## Summary
- remove the broad Rv64 open from the dividendAbs precondition file
- qualify Assertion and signExtend12 references explicitly

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.DividendAbsPre
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/DividendAbsPre.lean (no matches)
- scripts/check-file-size.sh EvmAsm/Evm64/SDiv/Compose/DividendAbsPre.lean
- scripts/check-unimported.sh
- lake build