### PR TITLE
refactor(sdiv): clean divisor abs pre opens

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/DivisorAbsPre.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivisorAbsPre.lean
@@ -9,8 +9,6 @@ import EvmAsm.Rv64.SepLogic
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64
-
 /-- Precondition for the SDIV save-ra/signs/dividendAbs/divisorAbs block
     (entry to the wrapper, just after the saved-`ra` slot is materialized
     in `x1`). Takes only the bare wrapper inputs; the `sp`-relative
@@ -22,15 +20,15 @@ def saveRaSignsAbsThenDivisorAbsPre
     (vRa vSavedOld sp sDividendOld sDivisorOld
       dividendMaskOld dividendValueOld dividendCarryOld
       dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word) : Assertion :=
-  let dividendMem0 := sp + signExtend12 (0 : BitVec 12)
-  let dividendMem1 := sp + signExtend12 (8 : BitVec 12)
-  let dividendMem2 := sp + signExtend12 (16 : BitVec 12)
-  let dividendMem3 := sp + signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff
-  let divisorMem0 := sp + signExtend12 (32 : BitVec 12)
-  let divisorMem1 := sp + signExtend12 (40 : BitVec 12)
-  let divisorMem2 := sp + signExtend12 (48 : BitVec 12)
-  let divisorMem3 := sp + signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word) : EvmAsm.Rv64.Assertion :=
+  let dividendMem0 := sp + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)
+  let dividendMem1 := sp + EvmAsm.Rv64.signExtend12 (8 : BitVec 12)
+  let dividendMem2 := sp + EvmAsm.Rv64.signExtend12 (16 : BitVec 12)
+  let dividendMem3 := sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff
+  let divisorMem0 := sp + EvmAsm.Rv64.signExtend12 (32 : BitVec 12)
+  let divisorMem1 := sp + EvmAsm.Rv64.signExtend12 (40 : BitVec 12)
+  let divisorMem2 := sp + EvmAsm.Rv64.signExtend12 (48 : BitVec 12)
+  let divisorMem3 := sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff
   ((((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ vSavedOld)) **
       ((.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sDividendOld) **
        (dividendMem3 ↦ₘ dividendTop))) **
@@ -53,14 +51,14 @@ theorem saveRaSignsAbsThenDivisorAbsPre_unfold
         dividendMaskOld dividendValueOld dividendCarryOld
         dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
         divisorLimb0 divisorLimb1 divisorLimb2 divisorTop =
-      (let dividendMem0 := sp + signExtend12 (0 : BitVec 12)
-       let dividendMem1 := sp + signExtend12 (8 : BitVec 12)
-       let dividendMem2 := sp + signExtend12 (16 : BitVec 12)
-       let dividendMem3 := sp + signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff
-       let divisorMem0 := sp + signExtend12 (32 : BitVec 12)
-       let divisorMem1 := sp + signExtend12 (40 : BitVec 12)
-       let divisorMem2 := sp + signExtend12 (48 : BitVec 12)
-       let divisorMem3 := sp + signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff
+      (let dividendMem0 := sp + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)
+       let dividendMem1 := sp + EvmAsm.Rv64.signExtend12 (8 : BitVec 12)
+       let dividendMem2 := sp + EvmAsm.Rv64.signExtend12 (16 : BitVec 12)
+       let dividendMem3 := sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff
+       let divisorMem0 := sp + EvmAsm.Rv64.signExtend12 (32 : BitVec 12)
+       let divisorMem1 := sp + EvmAsm.Rv64.signExtend12 (40 : BitVec 12)
+       let divisorMem2 := sp + EvmAsm.Rv64.signExtend12 (48 : BitVec 12)
+       let divisorMem3 := sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff
        ((((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ vSavedOld)) **
            ((.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sDividendOld) **
             (dividendMem3 ↦ₘ dividendTop))) **


### PR DESCRIPTION
## Summary
- remove the broad Rv64 open from the divisorAbs precondition file
- qualify Assertion and signExtend12 references explicitly

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.DivisorAbsPre
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/DivisorAbsPre.lean (no matches)
- scripts/check-file-size.sh EvmAsm/Evm64/SDiv/Compose/DivisorAbsPre.lean
- scripts/check-unimported.sh
- lake build