### PR TITLE
refactor(sdiv): clean save-ra signs pre opens

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/SaveRaSignsPre.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/SaveRaSignsPre.lean
@@ -9,8 +9,6 @@ import EvmAsm.Evm64.SDiv.Compose.BaseCode
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64
-
 /-- Precondition for the SDIV save-ra + dividend sign + divisor sign
     composition: standard entry frame with the dividend and divisor top
     limbs accessible in memory and both sign-register slots holding
@@ -19,13 +17,13 @@ open EvmAsm.Rv64
 @[irreducible]
 def saveRaDividendSignThenDivisorSignPre
     (vRa vSavedOld sp sDividendOld dividendTop sDivisorOld divisorTop : Word) :
-    Assertion :=
+    EvmAsm.Rv64.Assertion :=
   (((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ vSavedOld)) **
     ((.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sDividendOld) **
-     ((sp + signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ
+     ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ
        dividendTop))) **
    ((.x9 ↦ᵣ sDivisorOld) **
-    ((sp + signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff) ↦ₘ
+    ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff) ↦ₘ
       divisorTop))
 
 theorem saveRaDividendSignThenDivisorSignPre_unfold
@@ -34,10 +32,10 @@ theorem saveRaDividendSignThenDivisorSignPre_unfold
         dividendTop sDivisorOld divisorTop =
       ((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ vSavedOld)) **
         ((.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sDividendOld) **
-         ((sp + signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ
+         ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ
            dividendTop))) **
        ((.x9 ↦ᵣ sDivisorOld) **
-        ((sp + signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff) ↦ₘ
+        ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff) ↦ₘ
           divisorTop))) := by
   delta saveRaDividendSignThenDivisorSignPre
   rfl


### PR DESCRIPTION
## Summary
- remove the broad Rv64 open from the save-ra/signs precondition file
- qualify Assertion and signExtend12 references explicitly

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.SaveRaSignsPre
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/SaveRaSignsPre.lean (no matches)
- scripts/check-file-size.sh EvmAsm/Evm64/SDiv/Compose/SaveRaSignsPre.lean
- scripts/check-unimported.sh
- lake build