### PR TITLE
refactor(sdiv): clean save-ra signs post opens

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/SaveRaSignsPost.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/SaveRaSignsPost.lean
@@ -9,34 +9,32 @@ import EvmAsm.Evm64.SDiv.Compose.SaveRaSignsPre
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64
-
 /-- Postcondition for the save-ra + dividend sign + divisor sign
     composition: `ra` is saved to the spill slot, `x8` and `x9` hold
     the dividend/divisor sign bits, and the top-limb memory cells are
     unchanged. Wrapped `@[irreducible]`. -/
 @[irreducible]
 def saveRaDividendSignThenDivisorSignPost
-    (vRa sp dividendTop divisorTop : Word) : Assertion :=
-  (((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12)))) **
+    (vRa sp dividendTop divisorTop : Word) : EvmAsm.Rv64.Assertion :=
+  (((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))) **
     ((.x8 ↦ᵣ (dividendTop >>> (63 : BitVec 6).toNat)) **
-     ((sp + signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ
+     ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ
        dividendTop))) **
    ((.x12 ↦ᵣ sp) **
     (.x9 ↦ᵣ (divisorTop >>> (63 : BitVec 6).toNat)) **
-    ((sp + signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff) ↦ₘ
+    ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff) ↦ₘ
       divisorTop))
 
 theorem saveRaDividendSignThenDivisorSignPost_unfold
     {vRa sp dividendTop divisorTop : Word} :
     saveRaDividendSignThenDivisorSignPost vRa sp dividendTop divisorTop =
-      ((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12)))) **
+      ((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))) **
         ((.x8 ↦ᵣ (dividendTop >>> (63 : BitVec 6).toNat)) **
-         ((sp + signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ
+         ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ
            dividendTop))) **
        ((.x12 ↦ᵣ sp) **
         (.x9 ↦ᵣ (divisorTop >>> (63 : BitVec 6).toNat)) **
-        ((sp + signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff) ↦ₘ
+        ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff) ↦ₘ
           divisorTop))) := by
   delta saveRaDividendSignThenDivisorSignPost
   rfl


### PR DESCRIPTION
## Summary
- remove the broad Rv64 open from the save-ra/signs postcondition file
- qualify Assertion and signExtend12 references explicitly

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.SaveRaSignsPost
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/SaveRaSignsPost.lean (no matches)
- scripts/check-file-size.sh EvmAsm/Evm64/SDiv/Compose/SaveRaSignsPost.lean
- scripts/check-unimported.sh
- lake build