### PR TITLE
refactor(sdiv): clean sign frame opens

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/SignFrame.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/SignFrame.lean
@@ -9,18 +9,16 @@ import EvmAsm.Rv64.SepLogic
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64
-
 /-- SDIV wrapper-private sign frame preserved across the unsigned DIV callable. -/
-def sdivDivCallSignFrame (vRa resultSign divisorSign : Word) : Assertion :=
+def sdivDivCallSignFrame (vRa resultSign divisorSign : Word) : EvmAsm.Rv64.Assertion :=
   (.x8 ↦ᵣ resultSign) ** (.x9 ↦ᵣ divisorSign) **
-  (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12)))
+  (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))
 
 theorem sdivDivCallSignFrame_unfold
     {vRa resultSign divisorSign : Word} :
     sdivDivCallSignFrame vRa resultSign divisorSign =
       ((.x8 ↦ᵣ resultSign) ** (.x9 ↦ᵣ divisorSign) **
-       (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12)))) := by
+       (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))) := by
   rfl
 
 end EvmAsm.Evm64.SDiv.Compose


### PR DESCRIPTION
## Summary
- remove the broad Rv64 open from the SDIV sign-frame helper
- qualify Assertion and signExtend12 references explicitly

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.SignFrame
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/SignFrame.lean (no matches)
- scripts/check-file-size.sh EvmAsm/Evm64/SDiv/Compose/SignFrame.lean
- scripts/check-unimported.sh
- lake build