### PR TITLE
refactor(sdiv): clean bzero semantic handler view opens

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/BzeroSemanticHandlerView.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroSemanticHandlerView.lean
@@ -9,8 +9,6 @@ import EvmAsm.Evm64.SDiv.HandlerBridge
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64
-
 /-- Zero-divisor SDIV bzero path with the post stack named by the pure
     `sdivHandler` stack result. This connects the assembly zero-divisor path
     to the executable handler view for states whose visible stack starts with
@@ -23,7 +21,7 @@ theorem saveRa_signs_abs_signXor_then_divCall_bzero_stack_entry_zero_divisor_han
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
      shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
     (base : Word) (hbase : base &&& 1 = 0) :
-    cpsTripleWithin (((49 + (EvmAsm.Evm64.unifiedDivBound + 1)) + 21) + 1)
+    EvmAsm.Rv64.cpsTripleWithin (((49 + (EvmAsm.Evm64.unifiedDivBound + 1)) + 21) + 1)
       base (vRa &&& ~~~(1 : Word)) (sdivCode base)
       ((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ vSavedOld) ** (.x12 ↦ᵣ sp) **
          (.x8 ↦ᵣ sDividendOld) ** (.x9 ↦ᵣ sDivisorOld) **
@@ -55,7 +53,7 @@ theorem saveRa_signs_abs_signXor_then_divCall_bzero_stack_entry_zero_divisor_han
           ((ArithmeticHandlers.sdivHandler
             { state with stack := dividend :: (0 : EvmWord) :: rest }).stack)) **
         saveRaDivCallBzeroSavedRaRetFrame sp base divisorSign dividendAbsWord)) := by
-  exact cpsTripleWithin_weaken
+  exact EvmAsm.Rv64.cpsTripleWithin_weaken
     (fun _ hp => hp)
     (fun _ hp => by
       rw [EvmAsm.Evm64.SDivStackExecutionBridge.sdivHandler_stack_zero_divisor


### PR DESCRIPTION
## Summary
- remove the broad Rv64 open from the bzero semantic handler adapter
- qualify cpsTripleWithin and cpsTripleWithin_weaken explicitly

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.BzeroSemanticHandlerView
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/BzeroSemanticHandlerView.lean (no matches)
- scripts/check-file-size.sh EvmAsm/Evm64/SDiv/Compose/BzeroSemanticHandlerView.lean
- scripts/check-unimported.sh
- lake build