### PR TITLE
refactor(sdiv): clean dispatch ready post opens

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/DispatchReadyPost.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DispatchReadyPost.lean
@@ -12,8 +12,6 @@ import EvmAsm.Evm64.SDiv.Compose.Words
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64
-
 /-- Post-shape consumed by `evm_div_callable_spec_in_sdivCode`: the
     `divModStackDispatchPre` bundle (the dispatcher's pre, which the
     callable consumes) paired with the SDIV-wrapper-private sign frame
@@ -28,7 +26,7 @@ def saveRaDivCallDispatchReadyPost
       divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word)
     (v2 v5 v6 : Word)
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-     shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word) : Assertion :=
+     shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word) : EvmAsm.Rv64.Assertion :=
   let dividendSign := dividendTop >>> (63 : BitVec 6).toNat
   let divisorSign := divisorTop >>> (63 : BitVec 6).toNat
   let resultSign := dividendSign ^^^ divisorSign
@@ -108,7 +106,7 @@ instance pcFreeInst_saveRaDivCallDispatchReadyPost
     (vRa sp base dividendLimb0 dividendLimb1 dividendLimb2 dividendTop divisorLimb0
       divisorLimb1 divisorLimb2 divisorTop v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5
       u6 u7 shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word) :
-    Assertion.PCFree (saveRaDivCallDispatchReadyPost vRa sp base dividendLimb0 dividendLimb1 dividendLimb2 dividendTop divisorLimb0 divisorLimb1 divisorLimb2 divisorTop v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem retMem dMem dloMem scratchUn0) :=
+    EvmAsm.Rv64.Assertion.PCFree (saveRaDivCallDispatchReadyPost vRa sp base dividendLimb0 dividendLimb1 dividendLimb2 dividendTop divisorLimb0 divisorLimb1 divisorLimb2 divisorTop v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem retMem dMem dloMem scratchUn0) :=
   ⟨saveRaDivCallDispatchReadyPost_pcFree⟩
 
 end EvmAsm.Evm64.SDiv.Compose


### PR DESCRIPTION
## Summary
- remove the broad Rv64 open from the dispatch-ready postcondition file
- qualify Assertion and its PCFree instance explicitly

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.DispatchReadyPost
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/DispatchReadyPost.lean (no matches)
- scripts/check-file-size.sh EvmAsm/Evm64/SDiv/Compose/DispatchReadyPost.lean
- scripts/check-unimported.sh
- lake build