### PR TITLE
refactor(sdiv): clean base sign sequence opens

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/BaseSignSequence.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BaseSignSequence.lean
@@ -10,75 +10,73 @@ import EvmAsm.Evm64.SDiv.Compose.SaveRaSignBlocks
 namespace EvmAsm.Evm64.SDiv.Compose
 
 open EvmAsm.Rv64.Tactics
-open EvmAsm.Rv64
-
 theorem saveRa_dividendSign_then_divisorSign_spec_in_sdivCode
     (vRa vSavedOld sp sDividendOld dividendTop sDivisorOld divisorTop : Word)
     (base : Word) :
-    cpsTripleWithin 5 base ((base + divisorSignOff) + 8) (sdivCode base)
+    EvmAsm.Rv64.cpsTripleWithin 5 base ((base + divisorSignOff) + 8) (sdivCode base)
       (saveRaDividendSignThenDivisorSignPre vRa vSavedOld sp sDividendOld
         dividendTop sDivisorOld divisorTop)
       (saveRaDividendSignThenDivisorSignPost vRa sp dividendTop divisorTop) := by
   rw [saveRaDividendSignThenDivisorSignPre_unfold,
       saveRaDividendSignThenDivisorSignPost_unfold]
-  let pre : Assertion :=
+  let pre : EvmAsm.Rv64.Assertion :=
     ((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ vSavedOld)) **
       ((.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sDividendOld) **
-       ((sp + signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ
+       ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ
          dividendTop))) **
      ((.x9 ↦ᵣ sDivisorOld) **
-      ((sp + signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff) ↦ₘ
+      ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff) ↦ₘ
         divisorTop)))
-  let mid : Assertion :=
-    ((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12)))) **
+  let mid : EvmAsm.Rv64.Assertion :=
+    ((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))) **
       ((.x12 ↦ᵣ sp) **
        (.x8 ↦ᵣ (dividendTop >>> (63 : BitVec 6).toNat)) **
-       ((sp + signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ
+       ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ
          dividendTop))) **
      ((.x9 ↦ᵣ sDivisorOld) **
-      ((sp + signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff) ↦ₘ
+      ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff) ↦ₘ
         divisorTop)))
-  let midDivisor : Assertion :=
-    ((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12)))) **
+  let midDivisor : EvmAsm.Rv64.Assertion :=
+    ((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))) **
       ((.x8 ↦ᵣ (dividendTop >>> (63 : BitVec 6).toNat)) **
-       ((sp + signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ
+       ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ
          dividendTop))) **
      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ sDivisorOld) **
-      ((sp + signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff) ↦ₘ
+      ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff) ↦ₘ
         divisorTop)))
-  let post : Assertion :=
-    ((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12)))) **
+  let post : EvmAsm.Rv64.Assertion :=
+    ((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))) **
       ((.x8 ↦ᵣ (dividendTop >>> (63 : BitVec 6).toNat)) **
-       ((sp + signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ
+       ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ
          dividendTop))) **
      ((.x12 ↦ᵣ sp) **
       (.x9 ↦ᵣ (divisorTop >>> (63 : BitVec 6).toNat)) **
-      ((sp + signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff) ↦ₘ
+      ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff) ↦ₘ
         divisorTop)))
-  have hPrefix : cpsTripleWithin 3 base (base + divisorSignOff)
+  have hPrefix : EvmAsm.Rv64.cpsTripleWithin 3 base (base + divisorSignOff)
       (sdivCode base) pre mid := by
     dsimp [pre, mid]
     simpa [dividendSignOff, divisorSignOff, BitVec.add_assoc] using
-      (cpsTripleWithin_frameR
+      (EvmAsm.Rv64.cpsTripleWithin_frameR
         ((.x9 ↦ᵣ sDivisorOld) **
-         ((sp + signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff) ↦ₘ
+         ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff) ↦ₘ
           divisorTop))
         (by pcFree)
         (saveRa_then_dividendSign_spec_in_sdivCode
           vRa vSavedOld sp sDividendOld dividendTop base))
-  have hDivisor : cpsTripleWithin 2 (base + divisorSignOff)
+  have hDivisor : EvmAsm.Rv64.cpsTripleWithin 2 (base + divisorSignOff)
       ((base + divisorSignOff) + 8) (sdivCode base) midDivisor post := by
     dsimp [midDivisor, post]
     exact
-      cpsTripleWithin_frameL
+      EvmAsm.Rv64.cpsTripleWithin_frameL
         (((.x1 ↦ᵣ vRa) **
-          (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12)))) **
+          (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))) **
          ((.x8 ↦ᵣ (dividendTop >>> (63 : BitVec 6).toNat)) **
-          ((sp + signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ
+          ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ
             dividendTop)))
         (by pcFree)
         (divisorSign_spec_in_sdivCode sp sDivisorOld divisorTop base)
-  have hSeq := cpsTripleWithin_seq_perm_same_cr
+  have hSeq := EvmAsm.Rv64.cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by
       dsimp [mid, midDivisor] at hp ⊢
       xperm_hyp hp) hPrefix hDivisor


### PR DESCRIPTION
## Summary
- remove the broad Rv64 open from the base sign sequence composition file
- qualify cpsTripleWithin helpers, Assertion, and signExtend12 explicitly while retaining the tactics open for pcFree/xperm_hyp

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.BaseSignSequence
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/BaseSignSequence.lean (no matches)
- scripts/check-file-size.sh EvmAsm/Evm64/SDiv/Compose/BaseSignSequence.lean
- scripts/check-unimported.sh
- lake build