### PR TITLE
refactor(sdiv): clean save-ra sign blockspec opens

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/SaveRaSignBlockSpecs.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/SaveRaSignBlockSpecs.lean
@@ -9,13 +9,11 @@ import EvmAsm.Evm64.SDiv.Compose.BaseCode
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64
-
 theorem saveRa_spec_in_sdivCode
     (vRa vSavedOld : Word) (base : Word) :
-    cpsTripleWithin 1 base (base + 4) (sdivCode base)
+    EvmAsm.Rv64.cpsTripleWithin 1 base (base + 4) (sdivCode base)
       ((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ vSavedOld))
-      ((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12)))) := by
+      ((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))) := by
   have hmono :
       ∀ a i, (EvmAsm.Evm64.evm_sdiv_save_ra_block_code .x18 base) a = some i →
         (sdivCode base) a = some i := by
@@ -23,20 +21,20 @@ theorem saveRa_spec_in_sdivCode
     exact sdivCode_saveRa_sub (base := base) a i
       (by simpa [saveRaCode, saveRaOff,
         EvmAsm.Evm64.evm_sdiv_save_ra_block_code] using h)
-  exact cpsTripleWithin_extend_code hmono
+  exact EvmAsm.Rv64.cpsTripleWithin_extend_code hmono
     (EvmAsm.Evm64.evm_sdiv_save_ra_block_spec_within .x18
       vRa vSavedOld base (by decide))
 
 theorem dividendSign_spec_in_sdivCode
     (sp sOld dividendTop : Word) (base : Word) :
-    cpsTripleWithin 2 (base + dividendSignOff) ((base + dividendSignOff) + 8)
+    EvmAsm.Rv64.cpsTripleWithin 2 (base + dividendSignOff) ((base + dividendSignOff) + 8)
       (sdivCode base)
       ((.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sOld) **
-       ((sp + signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ
+       ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ
          dividendTop))
       ((.x12 ↦ᵣ sp) **
        (.x8 ↦ᵣ (dividendTop >>> (63 : BitVec 6).toNat)) **
-       ((sp + signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ
+       ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ
          dividendTop)) := by
   have hmono :
       ∀ a i,
@@ -48,21 +46,21 @@ theorem dividendSign_spec_in_sdivCode
     exact sdivCode_dividendSign_sub (base := base) a i
       (by simpa [dividendSignCode,
         EvmAsm.Evm64.evm_sdiv_sign_bit_block_code] using h)
-  exact cpsTripleWithin_extend_code hmono
+  exact EvmAsm.Rv64.cpsTripleWithin_extend_code hmono
     (EvmAsm.Evm64.evm_sdiv_sign_bit_block_spec_within .x12 .x8
       EvmAsm.Evm64.evm_sdivDividendTopLimbOff sp sOld dividendTop
       (base + dividendSignOff) (by decide))
 
 theorem divisorSign_spec_in_sdivCode
     (sp sOld divisorTop : Word) (base : Word) :
-    cpsTripleWithin 2 (base + divisorSignOff) ((base + divisorSignOff) + 8)
+    EvmAsm.Rv64.cpsTripleWithin 2 (base + divisorSignOff) ((base + divisorSignOff) + 8)
       (sdivCode base)
       ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ sOld) **
-       ((sp + signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff) ↦ₘ
+       ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff) ↦ₘ
          divisorTop))
       ((.x12 ↦ᵣ sp) **
        (.x9 ↦ᵣ (divisorTop >>> (63 : BitVec 6).toNat)) **
-       ((sp + signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff) ↦ₘ
+       ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff) ↦ₘ
          divisorTop)) := by
   have hmono :
       ∀ a i,
@@ -74,7 +72,7 @@ theorem divisorSign_spec_in_sdivCode
     exact sdivCode_divisorSign_sub (base := base) a i
       (by simpa [divisorSignCode,
         EvmAsm.Evm64.evm_sdiv_sign_bit_block_code] using h)
-  exact cpsTripleWithin_extend_code hmono
+  exact EvmAsm.Rv64.cpsTripleWithin_extend_code hmono
     (EvmAsm.Evm64.evm_sdiv_sign_bit_block_spec_within .x12 .x9
       EvmAsm.Evm64.evm_sdivDivisorTopLimbOff sp sOld divisorTop
       (base + divisorSignOff) (by decide))


### PR DESCRIPTION
## Summary
- remove the broad Rv64 open from the save-ra/sign primitive block specs
- qualify cpsTripleWithin, cpsTripleWithin_extend_code, and signExtend12 explicitly

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.SaveRaSignBlockSpecs
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/SaveRaSignBlockSpecs.lean (no matches)
- scripts/check-file-size.sh EvmAsm/Evm64/SDiv/Compose/SaveRaSignBlockSpecs.lean
- scripts/check-unimported.sh
- lake build