### PR TITLE
refactor(sdiv): clean base dividend abs blockspec opens

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/BaseDividendAbsBlockSpec.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BaseDividendAbsBlockSpec.lean
@@ -8,12 +8,10 @@ import EvmAsm.Evm64.SDiv.Compose.SaveRaDividendAbsPost
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64
-
 theorem dividendAbs_spec_in_sdivCode
     (sp sign maskOld valueOld carryOld limb0 limb1 limb2 limb3 : Word)
     (base : Word) :
-    cpsTripleWithin 21 (base + dividendAbsOff) ((base + dividendAbsOff) + 84)
+    EvmAsm.Rv64.cpsTripleWithin 21 (base + dividendAbsOff) ((base + dividendAbsOff) + 84)
       (sdivCode base)
       (dividendAbsPre sp sign maskOld valueOld carryOld
         limb0 limb1 limb2 limb3)
@@ -36,6 +34,6 @@ theorem dividendAbs_spec_in_sdivCode
       (base + dividendAbsOff) (by decide) (by decide) (by decide)
   rw [EvmAsm.Evm64.condNegate256BlockPre_unfold,
     EvmAsm.Evm64.condNegate256BlockPost_unfold] at hSpec
-  exact cpsTripleWithin_extend_code hmono hSpec
+  exact EvmAsm.Rv64.cpsTripleWithin_extend_code hmono hSpec
 
 end EvmAsm.Evm64.SDiv.Compose


### PR DESCRIPTION
## Summary
- remove the broad Rv64 open from the base dividend-abs block spec
- qualify cpsTripleWithin and cpsTripleWithin_extend_code explicitly

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.BaseDividendAbsBlockSpec
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/BaseDividendAbsBlockSpec.lean (no matches)
- scripts/check-file-size.sh EvmAsm/Evm64/SDiv/Compose/BaseDividendAbsBlockSpec.lean
- scripts/check-unimported.sh
- lake build