### PR TITLE
refactor(sdiv): clean base divisor abs sequence opens

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/BaseDivisorAbsSequence.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BaseDivisorAbsSequence.lean
@@ -8,8 +8,6 @@ import EvmAsm.Evm64.SDiv.Compose.BaseDividendAbsSequence
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64
-
 /-- Precondition for the SDIV divisor-abs (conditional 2's-complement
     negation) block. Mirrors `dividendAbsPre` but with the sign in `x9`
     and limb memory cells at the `+32 … +56` divisor slots. Wrapped
@@ -17,13 +15,13 @@ open EvmAsm.Rv64
     atoms at each use site. -/
 @[irreducible]
 def divisorAbsPre (sp sign maskOld valueOld carryOld
-    limb0 limb1 limb2 limb3 : Word) : Assertion :=
+    limb0 limb1 limb2 limb3 : Word) : EvmAsm.Rv64.Assertion :=
   (.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ sign) **
   (.x10 ↦ᵣ maskOld) ** (.x7 ↦ᵣ valueOld) ** (.x11 ↦ᵣ carryOld) **
-  ((sp + signExtend12 (32 : BitVec 12)) ↦ₘ limb0) **
-  ((sp + signExtend12 (40 : BitVec 12)) ↦ₘ limb1) **
-  ((sp + signExtend12 (48 : BitVec 12)) ↦ₘ limb2) **
-  ((sp + signExtend12 (56 : BitVec 12)) ↦ₘ limb3)
+  ((sp + EvmAsm.Rv64.signExtend12 (32 : BitVec 12)) ↦ₘ limb0) **
+  ((sp + EvmAsm.Rv64.signExtend12 (40 : BitVec 12)) ↦ₘ limb1) **
+  ((sp + EvmAsm.Rv64.signExtend12 (48 : BitVec 12)) ↦ₘ limb2) **
+  ((sp + EvmAsm.Rv64.signExtend12 (56 : BitVec 12)) ↦ₘ limb3)
 
 theorem divisorAbsPre_unfold
     {sp sign maskOld valueOld carryOld limb0 limb1 limb2 limb3 : Word} :
@@ -31,10 +29,10 @@ theorem divisorAbsPre_unfold
         limb0 limb1 limb2 limb3 =
       ((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ sign) **
        (.x10 ↦ᵣ maskOld) ** (.x7 ↦ᵣ valueOld) ** (.x11 ↦ᵣ carryOld) **
-       ((sp + signExtend12 (32 : BitVec 12)) ↦ₘ limb0) **
-       ((sp + signExtend12 (40 : BitVec 12)) ↦ₘ limb1) **
-       ((sp + signExtend12 (48 : BitVec 12)) ↦ₘ limb2) **
-       ((sp + signExtend12 (56 : BitVec 12)) ↦ₘ limb3)) := by
+       ((sp + EvmAsm.Rv64.signExtend12 (32 : BitVec 12)) ↦ₘ limb0) **
+       ((sp + EvmAsm.Rv64.signExtend12 (40 : BitVec 12)) ↦ₘ limb1) **
+       ((sp + EvmAsm.Rv64.signExtend12 (48 : BitVec 12)) ↦ₘ limb2) **
+       ((sp + EvmAsm.Rv64.signExtend12 (56 : BitVec 12)) ↦ₘ limb3)) := by
   delta divisorAbsPre
   rfl
 
@@ -43,7 +41,7 @@ theorem divisorAbsPre_unfold
     memory slots `+32 … +56`. Wrapped `@[irreducible]` to hide the let
     chain from downstream proofs. -/
 @[irreducible]
-def divisorAbsPost (sp sign limb0 limb1 limb2 limb3 : Word) : Assertion :=
+def divisorAbsPost (sp sign limb0 limb1 limb2 limb3 : Word) : EvmAsm.Rv64.Assertion :=
   let mask := (0 : Word) - sign
   let sum0 := (limb0 ^^^ mask) + sign
   let carry0 := if BitVec.ult sum0 sign then (1 : Word) else 0
@@ -55,10 +53,10 @@ def divisorAbsPost (sp sign limb0 limb1 limb2 limb3 : Word) : Assertion :=
   let carry3 := if BitVec.ult sum3 carry2 then (1 : Word) else 0
   (.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ sign) **
   (.x10 ↦ᵣ mask) ** (.x7 ↦ᵣ sum3) ** (.x11 ↦ᵣ carry3) **
-  ((sp + signExtend12 (32 : BitVec 12)) ↦ₘ sum0) **
-  ((sp + signExtend12 (40 : BitVec 12)) ↦ₘ sum1) **
-  ((sp + signExtend12 (48 : BitVec 12)) ↦ₘ sum2) **
-  ((sp + signExtend12 (56 : BitVec 12)) ↦ₘ sum3)
+  ((sp + EvmAsm.Rv64.signExtend12 (32 : BitVec 12)) ↦ₘ sum0) **
+  ((sp + EvmAsm.Rv64.signExtend12 (40 : BitVec 12)) ↦ₘ sum1) **
+  ((sp + EvmAsm.Rv64.signExtend12 (48 : BitVec 12)) ↦ₘ sum2) **
+  ((sp + EvmAsm.Rv64.signExtend12 (56 : BitVec 12)) ↦ₘ sum3)
 
 theorem divisorAbsPost_unfold
     {sp sign limb0 limb1 limb2 limb3 : Word} :
@@ -74,10 +72,10 @@ theorem divisorAbsPost_unfold
        let carry3 := if BitVec.ult sum3 carry2 then (1 : Word) else 0
        (.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ sign) **
        (.x10 ↦ᵣ mask) ** (.x7 ↦ᵣ sum3) ** (.x11 ↦ᵣ carry3) **
-       ((sp + signExtend12 (32 : BitVec 12)) ↦ₘ sum0) **
-       ((sp + signExtend12 (40 : BitVec 12)) ↦ₘ sum1) **
-       ((sp + signExtend12 (48 : BitVec 12)) ↦ₘ sum2) **
-       ((sp + signExtend12 (56 : BitVec 12)) ↦ₘ sum3)) := by
+       ((sp + EvmAsm.Rv64.signExtend12 (32 : BitVec 12)) ↦ₘ sum0) **
+       ((sp + EvmAsm.Rv64.signExtend12 (40 : BitVec 12)) ↦ₘ sum1) **
+       ((sp + EvmAsm.Rv64.signExtend12 (48 : BitVec 12)) ↦ₘ sum2) **
+       ((sp + EvmAsm.Rv64.signExtend12 (56 : BitVec 12)) ↦ₘ sum3)) := by
   delta divisorAbsPost
   rfl
 


### PR DESCRIPTION
## Summary
- remove the broad Rv64 namespace open from the base divisor-abs sequence definitions
- qualify Assertion and signExtend12 explicitly in the pre/post definitions and unfold lemmas

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.BaseDivisorAbsSequence
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/BaseDivisorAbsSequence.lean
- scripts/check-file-size.sh EvmAsm/Evm64/SDiv/Compose/BaseDivisorAbsSequence.lean
- scripts/check-unimported.sh
- lake build