### PR TITLE
refactor(sdiv): clean divisor abs sequence opens

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/DivisorAbsSequence.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivisorAbsSequence.lean
@@ -14,15 +14,13 @@ import EvmAsm.Evm64.SDiv.Compose.DivisorAbsPost
 namespace EvmAsm.Evm64.SDiv.Compose
 
 open EvmAsm.Rv64.Tactics
-open EvmAsm.Rv64
-
 theorem saveRa_signs_abs_then_divisorAbs_spec_in_sdivCode
     (vRa vSavedOld sp sDividendOld sDivisorOld
       dividendMaskOld dividendValueOld dividendCarryOld
       dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
       divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word)
     (base : Word) :
-    cpsTripleWithin 47 base ((base + divisorAbsOff) + 84) (sdivCode base)
+    EvmAsm.Rv64.cpsTripleWithin 47 base ((base + divisorAbsOff) + 84) (sdivCode base)
       (saveRaSignsAbsThenDivisorAbsPre vRa vSavedOld sp sDividendOld sDivisorOld
         dividendMaskOld dividendValueOld dividendCarryOld
         dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
@@ -36,14 +34,14 @@ theorem saveRa_signs_abs_then_divisorAbs_spec_in_sdivCode
   -- (which references these derived names) keeps working unchanged.
   let dividendSign := dividendTop >>> (63 : BitVec 6).toNat
   let divisorSign := divisorTop >>> (63 : BitVec 6).toNat
-  let dividendMem0 := sp + signExtend12 (0 : BitVec 12)
-  let dividendMem1 := sp + signExtend12 (8 : BitVec 12)
-  let dividendMem2 := sp + signExtend12 (16 : BitVec 12)
-  let dividendMem3 := sp + signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff
-  let divisorMem0 := sp + signExtend12 (32 : BitVec 12)
-  let divisorMem1 := sp + signExtend12 (40 : BitVec 12)
-  let divisorMem2 := sp + signExtend12 (48 : BitVec 12)
-  let divisorMem3 := sp + signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff
+  let dividendMem0 := sp + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)
+  let dividendMem1 := sp + EvmAsm.Rv64.signExtend12 (8 : BitVec 12)
+  let dividendMem2 := sp + EvmAsm.Rv64.signExtend12 (16 : BitVec 12)
+  let dividendMem3 := sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff
+  let divisorMem0 := sp + EvmAsm.Rv64.signExtend12 (32 : BitVec 12)
+  let divisorMem1 := sp + EvmAsm.Rv64.signExtend12 (40 : BitVec 12)
+  let divisorMem2 := sp + EvmAsm.Rv64.signExtend12 (48 : BitVec 12)
+  let divisorMem3 := sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff
   let dividendMask := (0 : Word) - dividendSign
   let dividendXored0 := dividendLimb0 ^^^ dividendMask
   let dividendSum0 := dividendXored0 + dividendSign
@@ -70,10 +68,10 @@ theorem saveRa_signs_abs_then_divisorAbs_spec_in_sdivCode
   let divisorSum3 := divisorXored3 + divisorCarry2
   let divisorCarry3 := if BitVec.ult divisorSum3 divisorCarry2 then (1 : Word) else 0
   let dividendCarry3 := if BitVec.ult dividendSum3 dividendCarry2 then (1 : Word) else 0
-  let divisorLower : Assertion :=
+  let divisorLower : EvmAsm.Rv64.Assertion :=
     ((divisorMem0 ↦ₘ divisorLimb0) ** (divisorMem1 ↦ₘ divisorLimb1) **
      (divisorMem2 ↦ₘ divisorLimb2))
-  let pre : Assertion :=
+  let pre : EvmAsm.Rv64.Assertion :=
     ((((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ vSavedOld)) **
         ((.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sDividendOld) **
          (dividendMem3 ↦ₘ dividendTop))) **
@@ -84,8 +82,8 @@ theorem saveRa_signs_abs_then_divisorAbs_spec_in_sdivCode
         (dividendMem1 ↦ₘ dividendLimb1) **
         (dividendMem2 ↦ₘ dividendLimb2)))) **
      divisorLower)
-  let mid : Assertion :=
-    (((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12)))) **
+  let mid : EvmAsm.Rv64.Assertion :=
+    (((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))) **
        ((.x9 ↦ᵣ divisorSign) ** (divisorMem3 ↦ₘ divisorTop))) **
       ((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ dividendSign) **
        (.x10 ↦ᵣ dividendMask) ** (.x7 ↦ᵣ dividendSum3) **
@@ -95,8 +93,8 @@ theorem saveRa_signs_abs_then_divisorAbs_spec_in_sdivCode
        (dividendMem2 ↦ₘ dividendSum2) **
        (dividendMem3 ↦ₘ dividendSum3))) **
      divisorLower)
-  let absPre : Assertion :=
-    ((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12)))) **
+  let absPre : EvmAsm.Rv64.Assertion :=
+    ((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))) **
       ((.x8 ↦ᵣ dividendSign) **
        (dividendMem0 ↦ₘ dividendSum0) **
        (dividendMem1 ↦ₘ dividendSum1) **
@@ -109,8 +107,8 @@ theorem saveRa_signs_abs_then_divisorAbs_spec_in_sdivCode
       (divisorMem1 ↦ₘ divisorLimb1) **
       (divisorMem2 ↦ₘ divisorLimb2) **
       (divisorMem3 ↦ₘ divisorTop)))
-  let post : Assertion :=
-    ((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12)))) **
+  let post : EvmAsm.Rv64.Assertion :=
+    ((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))) **
       ((.x8 ↦ᵣ dividendSign) **
        (dividendMem0 ↦ₘ dividendSum0) **
        (dividendMem1 ↦ₘ dividendSum1) **
@@ -121,7 +119,7 @@ theorem saveRa_signs_abs_then_divisorAbs_spec_in_sdivCode
       (.x11 ↦ᵣ divisorCarry3) **
       (divisorMem0 ↦ₘ divisorSum0) ** (divisorMem1 ↦ₘ divisorSum1) **
       (divisorMem2 ↦ₘ divisorSum2) ** (divisorMem3 ↦ₘ divisorSum3)))
-  have hPrefix : cpsTripleWithin 26 base (base + divisorAbsOff)
+  have hPrefix : EvmAsm.Rv64.cpsTripleWithin 26 base (base + divisorAbsOff)
       (sdivCode base) pre mid := by
     dsimp [pre, mid, divisorLower, dividendSign, divisorSign, dividendMem0,
       dividendMem1, dividendMem2, dividendMem3, divisorMem3,
@@ -133,7 +131,7 @@ theorem saveRa_signs_abs_then_divisorAbs_spec_in_sdivCode
     simpa [dividendAbsOff, divisorAbsOff, BitVec.add_assoc,
       saveRaSignsThenDividendAbsPre_unfold,
       saveRaSignsThenDividendAbsPost_unfold] using
-      (cpsTripleWithin_frameR
+      (EvmAsm.Rv64.cpsTripleWithin_frameR
         ((divisorMem0 ↦ₘ divisorLimb0) **
          (divisorMem1 ↦ₘ divisorLimb1) **
          (divisorMem2 ↦ₘ divisorLimb2))
@@ -142,16 +140,16 @@ theorem saveRa_signs_abs_then_divisorAbs_spec_in_sdivCode
           vRa vSavedOld sp sDividendOld sDivisorOld divisorTop
           dividendMaskOld dividendValueOld dividendCarryOld
           dividendLimb0 dividendLimb1 dividendLimb2 dividendTop base))
-  have hAbs : cpsTripleWithin 21 (base + divisorAbsOff)
+  have hAbs : EvmAsm.Rv64.cpsTripleWithin 21 (base + divisorAbsOff)
       ((base + divisorAbsOff) + 84) (sdivCode base) absPre post := by
     simpa [absPre, post, divisorMem0, divisorMem1, divisorMem2, divisorMem3,
       EvmAsm.Evm64.evm_sdivDivisorTopLimbOff, divisorMask, divisorXored0,
       divisorSum0, divisorCarry0, divisorXored1, divisorSum1, divisorCarry1,
       divisorXored2, divisorSum2, divisorCarry2, divisorXored3, divisorSum3,
       divisorCarry3, divisorAbsPre_unfold, divisorAbsPost_unfold] using
-      cpsTripleWithin_frameL
+      EvmAsm.Rv64.cpsTripleWithin_frameL
         ((((.x1 ↦ᵣ vRa) **
-          (.x18 ↦ᵣ (vRa + signExtend12 (0 : BitVec 12)))) **
+          (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))) **
           ((.x8 ↦ᵣ dividendSign) **
            (dividendMem0 ↦ₘ dividendSum0) **
            (dividendMem1 ↦ₘ dividendSum1) **
@@ -161,7 +159,7 @@ theorem saveRa_signs_abs_then_divisorAbs_spec_in_sdivCode
         (divisorAbs_spec_in_sdivCode
           sp divisorSign dividendMask dividendSum3 dividendCarry3
           divisorLimb0 divisorLimb1 divisorLimb2 divisorTop base)
-  have hSeq := cpsTripleWithin_seq_perm_same_cr
+  have hSeq := EvmAsm.Rv64.cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by
       dsimp [mid, absPre, divisorLower] at hp ⊢
       xperm_hyp hp) hPrefix hAbs


### PR DESCRIPTION
## Summary
- remove the broad Rv64 namespace open from the divisor-abs sequence composition proof
- qualify cpsTripleWithin helpers, Assertion, and signExtend12 explicitly while keeping the tactics open for pcFree/xperm_hyp

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.DivisorAbsSequence
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/DivisorAbsSequence.lean
- scripts/check-file-size.sh EvmAsm/Evm64/SDiv/Compose/DivisorAbsSequence.lean
- scripts/check-unimported.sh
- lake build