### PR TITLE
refactor(sdiv): clean base compose opens

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/Base.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/Base.lean
@@ -24,16 +24,14 @@ import EvmAsm.Evm64.SDiv.Compose.BaseFinalBlockSpecs
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64
-
 /-- Wrapper sub-region inside `sdivCode`. -/
 theorem sdivCode_wrapper_sub {base : Word} :
-    ∀ a i, (CodeReq.ofProg base evm_sdiv_wrapper) a = some i →
+    ∀ a i, (EvmAsm.Rv64.CodeReq.ofProg base evm_sdiv_wrapper) a = some i →
       (sdivCode base) a = some i := by
   unfold sdivCode
-  exact CodeReq.ofProg_mono_sub base base evm_sdiv evm_sdiv_wrapper 0
+  exact EvmAsm.Rv64.CodeReq.ofProg_mono_sub base base evm_sdiv evm_sdiv_wrapper 0
     (by bv_omega)
-    (by unfold evm_sdiv; simp only [seq, Program]; rfl)
+    (by unfold evm_sdiv; simp only [EvmAsm.Rv64.seq, EvmAsm.Rv64.Program]; rfl)
     (by
       rw [evm_sdiv_length, evm_sdiv_wrapper_length]
       norm_num)
@@ -48,12 +46,12 @@ theorem sdivCode_div_callable_sub {base : Word} :
   intro a i h
   rw [evm_div_callable_code_eq_ofProg (base + 284)] at h
   unfold sdivCode
-  exact CodeReq.ofProg_mono_sub base (base + 284)
+  exact EvmAsm.Rv64.CodeReq.ofProg_mono_sub base (base + 284)
     evm_sdiv evm_div_callable 71
     (by
       bv_omega)
     (by
-      unfold evm_sdiv seq
+      unfold evm_sdiv EvmAsm.Rv64.seq
       rw [← evm_sdiv_wrapper_length]
       have h_drop :
           List.drop evm_sdiv_wrapper.length
@@ -71,7 +69,7 @@ theorem sdivCode_div_callable_sub {base : Word} :
 /-- Bundled top-level SDIV code subsumptions for the wrapper and appended
     unsigned DIV callable. -/
 theorem sdivCode_top_level_subs {base : Word} :
-    (∀ a i, (CodeReq.ofProg base evm_sdiv_wrapper) a = some i →
+    (∀ a i, (EvmAsm.Rv64.CodeReq.ofProg base evm_sdiv_wrapper) a = some i →
       (sdivCode base) a = some i) ∧
     (∀ a i, (evm_div_callable_code (base + 284)) a = some i →
       (sdivCode base) a = some i) := by
@@ -82,7 +80,7 @@ theorem sdivCode_top_level_subs {base : Word} :
     the entry-PC alignment fact needed to sequence the wrapper prefix with the
     callable DIV stack dispatcher. -/
 theorem divCall_target_eq_wrapperEndOff (base : Word) :
-    (base + divCallOff) + signExtend21 EvmAsm.Evm64.evm_sdivCallOff =
+    (base + divCallOff) + EvmAsm.Rv64.signExtend21 EvmAsm.Evm64.evm_sdivCallOff =
       base + wrapperEndOff := by
   show (base + (192 : Word)) + (92 : Word) = base + (284 : Word)
   bv_decide


### PR DESCRIPTION
## Summary
- remove the broad Rv64 namespace open from the SDIV compose base file
- qualify CodeReq, Program, seq, and signExtend21 explicitly

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.Base
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/Base.lean
- scripts/check-file-size.sh EvmAsm/Evm64/SDiv/Compose/Base.lean
- scripts/check-unimported.sh
- lake build