### PR TITLE
refactor(sdiv): clean quad mem bridge opens

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/QuadMemBridges.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/QuadMemBridges.lean
@@ -10,25 +10,23 @@ import EvmAsm.Evm64.Stack
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-open EvmAsm.Rv64
-
 /-- Bridge lemma: four `↦ₘ`-memory atoms at `sp + signExtend12 (0/8/16/24)`
     fold into a single `evmWordIs sp` atom holding `EvmWord.fromLimbs` of the
     four limbs. -/
 theorem evmWordIs_eq_quadMem (sp : Word) (limbs : Fin 4 → Word) :
-    (((sp + signExtend12 (0 : BitVec 12)) ↦ₘ limbs 0) **
-     ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ limbs 1) **
-     ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ limbs 2) **
-     ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ limbs 3)) =
+    (((sp + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)) ↦ₘ limbs 0) **
+     ((sp + EvmAsm.Rv64.signExtend12 (8 : BitVec 12)) ↦ₘ limbs 1) **
+     ((sp + EvmAsm.Rv64.signExtend12 (16 : BitVec 12)) ↦ₘ limbs 2) **
+     ((sp + EvmAsm.Rv64.signExtend12 (24 : BitVec 12)) ↦ₘ limbs 3)) =
     evmWordIs sp (EvmWord.fromLimbs limbs) := by
-  have h0 : (sp + signExtend12 (0 : BitVec 12) : Word) = sp := by
-    unfold signExtend12; bv_decide
-  have h8 : (sp + signExtend12 (8 : BitVec 12) : Word) = sp + 8 := by
-    unfold signExtend12; bv_decide
-  have h16 : (sp + signExtend12 (16 : BitVec 12) : Word) = sp + 16 := by
-    unfold signExtend12; bv_decide
-  have h24 : (sp + signExtend12 (24 : BitVec 12) : Word) = sp + 24 := by
-    unfold signExtend12; bv_decide
+  have h0 : (sp + EvmAsm.Rv64.signExtend12 (0 : BitVec 12) : Word) = sp := by
+    unfold EvmAsm.Rv64.signExtend12; bv_decide
+  have h8 : (sp + EvmAsm.Rv64.signExtend12 (8 : BitVec 12) : Word) = sp + 8 := by
+    unfold EvmAsm.Rv64.signExtend12; bv_decide
+  have h16 : (sp + EvmAsm.Rv64.signExtend12 (16 : BitVec 12) : Word) = sp + 16 := by
+    unfold EvmAsm.Rv64.signExtend12; bv_decide
+  have h24 : (sp + EvmAsm.Rv64.signExtend12 (24 : BitVec 12) : Word) = sp + 24 := by
+    unfold EvmAsm.Rv64.signExtend12; bv_decide
   rw [h0, h8, h16, h24]
   exact (evmWordIs_fromLimbs (addr := sp) limbs).symm
 
@@ -36,28 +34,28 @@ theorem evmWordIs_eq_quadMem (sp : Word) (limbs : Fin 4 → Word) :
     at `sp + signExtend12 (32/40/48/56)` fold into a single
     `evmWordIs (sp + 32)` atom. -/
 theorem evmWordIs_eq_quadMem_sp32 (sp : Word) (limbs : Fin 4 → Word) :
-    (((sp + signExtend12 (32 : BitVec 12)) ↦ₘ limbs 0) **
-     ((sp + signExtend12 (40 : BitVec 12)) ↦ₘ limbs 1) **
-     ((sp + signExtend12 (48 : BitVec 12)) ↦ₘ limbs 2) **
-     ((sp + signExtend12 (56 : BitVec 12)) ↦ₘ limbs 3)) =
+    (((sp + EvmAsm.Rv64.signExtend12 (32 : BitVec 12)) ↦ₘ limbs 0) **
+     ((sp + EvmAsm.Rv64.signExtend12 (40 : BitVec 12)) ↦ₘ limbs 1) **
+     ((sp + EvmAsm.Rv64.signExtend12 (48 : BitVec 12)) ↦ₘ limbs 2) **
+     ((sp + EvmAsm.Rv64.signExtend12 (56 : BitVec 12)) ↦ₘ limbs 3)) =
     evmWordIs (sp + 32) (EvmWord.fromLimbs limbs) := by
-  have h32 : (sp + signExtend12 (32 : BitVec 12) : Word) = sp + 32 := by
-    unfold signExtend12; bv_decide
-  have h40 : (sp + signExtend12 (40 : BitVec 12) : Word) = (sp + 32) + 8 := by
-    unfold signExtend12; bv_decide
-  have h48 : (sp + signExtend12 (48 : BitVec 12) : Word) = (sp + 32) + 16 := by
-    unfold signExtend12; bv_decide
-  have h56 : (sp + signExtend12 (56 : BitVec 12) : Word) = (sp + 32) + 24 := by
-    unfold signExtend12; bv_decide
+  have h32 : (sp + EvmAsm.Rv64.signExtend12 (32 : BitVec 12) : Word) = sp + 32 := by
+    unfold EvmAsm.Rv64.signExtend12; bv_decide
+  have h40 : (sp + EvmAsm.Rv64.signExtend12 (40 : BitVec 12) : Word) = (sp + 32) + 8 := by
+    unfold EvmAsm.Rv64.signExtend12; bv_decide
+  have h48 : (sp + EvmAsm.Rv64.signExtend12 (48 : BitVec 12) : Word) = (sp + 32) + 16 := by
+    unfold EvmAsm.Rv64.signExtend12; bv_decide
+  have h56 : (sp + EvmAsm.Rv64.signExtend12 (56 : BitVec 12) : Word) = (sp + 32) + 24 := by
+    unfold EvmAsm.Rv64.signExtend12; bv_decide
   rw [h32, h40, h48, h56]
   exact (evmWordIs_fromLimbs (addr := sp + 32) limbs).symm
 
 /-- Named-arguments specialization of `evmWordIs_eq_quadMem`. -/
 theorem evmWordIs_eq_quadMem_named (sp s0 s1 s2 s3 : Word) :
-    (((sp + signExtend12 (0 : BitVec 12)) ↦ₘ s0) **
-     ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ s1) **
-     ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ s2) **
-     ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ s3)) =
+    (((sp + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)) ↦ₘ s0) **
+     ((sp + EvmAsm.Rv64.signExtend12 (8 : BitVec 12)) ↦ₘ s1) **
+     ((sp + EvmAsm.Rv64.signExtend12 (16 : BitVec 12)) ↦ₘ s2) **
+     ((sp + EvmAsm.Rv64.signExtend12 (24 : BitVec 12)) ↦ₘ s3)) =
     evmWordIs sp (EvmWord.fromLimbs fun i : Fin 4 =>
       match i with | 0 => s0 | 1 => s1 | 2 => s2 | 3 => s3) := by
   rw [← evmWordIs_eq_quadMem sp
@@ -65,10 +63,10 @@ theorem evmWordIs_eq_quadMem_named (sp s0 s1 s2 s3 : Word) :
 
 /-- Named-arguments specialization of `evmWordIs_eq_quadMem_sp32`. -/
 theorem evmWordIs_eq_quadMem_sp32_named (sp s0 s1 s2 s3 : Word) :
-    (((sp + signExtend12 (32 : BitVec 12)) ↦ₘ s0) **
-     ((sp + signExtend12 (40 : BitVec 12)) ↦ₘ s1) **
-     ((sp + signExtend12 (48 : BitVec 12)) ↦ₘ s2) **
-     ((sp + signExtend12 (56 : BitVec 12)) ↦ₘ s3)) =
+    (((sp + EvmAsm.Rv64.signExtend12 (32 : BitVec 12)) ↦ₘ s0) **
+     ((sp + EvmAsm.Rv64.signExtend12 (40 : BitVec 12)) ↦ₘ s1) **
+     ((sp + EvmAsm.Rv64.signExtend12 (48 : BitVec 12)) ↦ₘ s2) **
+     ((sp + EvmAsm.Rv64.signExtend12 (56 : BitVec 12)) ↦ₘ s3)) =
     evmWordIs (sp + 32) (EvmWord.fromLimbs fun i : Fin 4 =>
       match i with | 0 => s0 | 1 => s1 | 2 => s2 | 3 => s3) := by
   rw [← evmWordIs_eq_quadMem_sp32 sp
@@ -77,10 +75,10 @@ theorem evmWordIs_eq_quadMem_sp32_named (sp s0 s1 s2 s3 : Word) :
 /-- SDIV-Post-shaped variant of `evmWordIs_eq_quadMem_named`: same dividend
     bridge but slot 3's offset is `signExtend12 evm_sdivDividendTopLimbOff`. -/
 theorem evmWordIs_eq_quadMem_sdivDividend (sp s0 s1 s2 s3 : Word) :
-    (((sp + signExtend12 (0 : BitVec 12)) ↦ₘ s0) **
-     ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ s1) **
-     ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ s2) **
-     ((sp + signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ s3)) =
+    (((sp + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)) ↦ₘ s0) **
+     ((sp + EvmAsm.Rv64.signExtend12 (8 : BitVec 12)) ↦ₘ s1) **
+     ((sp + EvmAsm.Rv64.signExtend12 (16 : BitVec 12)) ↦ₘ s2) **
+     ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ s3)) =
     evmWordIs sp (EvmWord.fromLimbs fun i : Fin 4 =>
       match i with | 0 => s0 | 1 => s1 | 2 => s2 | 3 => s3) := by
   unfold EvmAsm.Evm64.evm_sdivDividendTopLimbOff
@@ -88,10 +86,10 @@ theorem evmWordIs_eq_quadMem_sdivDividend (sp s0 s1 s2 s3 : Word) :
 
 /-- SDIV-Post-shaped variant of `evmWordIs_eq_quadMem_sp32_named`. -/
 theorem evmWordIs_eq_quadMem_sdivDivisor (sp s0 s1 s2 s3 : Word) :
-    (((sp + signExtend12 (32 : BitVec 12)) ↦ₘ s0) **
-     ((sp + signExtend12 (40 : BitVec 12)) ↦ₘ s1) **
-     ((sp + signExtend12 (48 : BitVec 12)) ↦ₘ s2) **
-     ((sp + signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff) ↦ₘ s3)) =
+    (((sp + EvmAsm.Rv64.signExtend12 (32 : BitVec 12)) ↦ₘ s0) **
+     ((sp + EvmAsm.Rv64.signExtend12 (40 : BitVec 12)) ↦ₘ s1) **
+     ((sp + EvmAsm.Rv64.signExtend12 (48 : BitVec 12)) ↦ₘ s2) **
+     ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff) ↦ₘ s3)) =
     evmWordIs (sp + 32) (EvmWord.fromLimbs fun i : Fin 4 =>
       match i with | 0 => s0 | 1 => s1 | 2 => s2 | 3 => s3) := by
   unfold EvmAsm.Evm64.evm_sdivDivisorTopLimbOff
@@ -101,28 +99,32 @@ theorem evmWordIs_eq_quadMem_sdivDivisor (sp s0 s1 s2 s3 : Word) :
     remainder `Q` so callers can fold four dividend sum-memIs atoms into
     a single `evmWordIs sp` atom inside a longer sepConj chain. -/
 theorem evmWordIs_eq_quadMem_sdivDividend_right
-    (sp s0 s1 s2 s3 : Word) (Q : Assertion) :
-    (((sp + signExtend12 (0 : BitVec 12)) ↦ₘ s0) **
-     ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ s1) **
-     ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ s2) **
-     ((sp + signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ s3) **
+    (sp s0 s1 s2 s3 : Word) (Q : EvmAsm.Rv64.Assertion) :
+    (((sp + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)) ↦ₘ s0) **
+     ((sp + EvmAsm.Rv64.signExtend12 (8 : BitVec 12)) ↦ₘ s1) **
+     ((sp + EvmAsm.Rv64.signExtend12 (16 : BitVec 12)) ↦ₘ s2) **
+     ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ
+       s3) **
      Q) =
     ((evmWordIs sp (EvmWord.fromLimbs fun i : Fin 4 =>
         match i with | 0 => s0 | 1 => s1 | 2 => s2 | 3 => s3)) ** Q) := by
   rw [← evmWordIs_eq_quadMem_sdivDividend sp s0 s1 s2 s3]
-  rw [sepConj_assoc', sepConj_assoc', sepConj_assoc']
+  rw [EvmAsm.Rv64.sepConj_assoc', EvmAsm.Rv64.sepConj_assoc',
+    EvmAsm.Rv64.sepConj_assoc']
 
 /-- Mid-tree variant of `evmWordIs_eq_quadMem_sdivDivisor`. -/
 theorem evmWordIs_eq_quadMem_sdivDivisor_right
-    (sp s0 s1 s2 s3 : Word) (Q : Assertion) :
-    (((sp + signExtend12 (32 : BitVec 12)) ↦ₘ s0) **
-     ((sp + signExtend12 (40 : BitVec 12)) ↦ₘ s1) **
-     ((sp + signExtend12 (48 : BitVec 12)) ↦ₘ s2) **
-     ((sp + signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff) ↦ₘ s3) **
+    (sp s0 s1 s2 s3 : Word) (Q : EvmAsm.Rv64.Assertion) :
+    (((sp + EvmAsm.Rv64.signExtend12 (32 : BitVec 12)) ↦ₘ s0) **
+     ((sp + EvmAsm.Rv64.signExtend12 (40 : BitVec 12)) ↦ₘ s1) **
+     ((sp + EvmAsm.Rv64.signExtend12 (48 : BitVec 12)) ↦ₘ s2) **
+     ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff) ↦ₘ
+       s3) **
      Q) =
     ((evmWordIs (sp + 32) (EvmWord.fromLimbs fun i : Fin 4 =>
         match i with | 0 => s0 | 1 => s1 | 2 => s2 | 3 => s3)) ** Q) := by
   rw [← evmWordIs_eq_quadMem_sdivDivisor sp s0 s1 s2 s3]
-  rw [sepConj_assoc', sepConj_assoc', sepConj_assoc']
+  rw [EvmAsm.Rv64.sepConj_assoc', EvmAsm.Rv64.sepConj_assoc',
+    EvmAsm.Rv64.sepConj_assoc']
 
 end EvmAsm.Evm64.SDiv.Compose


### PR DESCRIPTION
## Summary
- remove the broad Rv64 namespace open from the SDIV quad memory bridge lemmas
- qualify signExtend12, Assertion, and sepConj_assoc' explicitly

## Validation
- lake build EvmAsm.Evm64.SDiv.Compose.QuadMemBridges
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/QuadMemBridges.lean
- scripts/check-file-size.sh EvmAsm/Evm64/SDiv/Compose/QuadMemBridges.lean
- scripts/check-unimported.sh
- lake build