### PR TITLE
refactor(sdiv): remove unused addr norm open

### DIFF
--- a/EvmAsm/Evm64/SDiv/AddrNorm.lean
+++ b/EvmAsm/Evm64/SDiv/AddrNorm.lean
@@ -16,6 +16,4 @@ import EvmAsm.Evm64.SDiv.AddrNormAttr
 
 namespace EvmAsm.Evm64.SDiv.AddrNorm
 
-open EvmAsm.Rv64
-
 end EvmAsm.Evm64.SDiv.AddrNorm


### PR DESCRIPTION
## Summary
- remove the unused broad Rv64 namespace open from the SDIV address-normalization placeholder

## Validation
- lake build EvmAsm.Evm64.SDiv.AddrNorm
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "^open EvmAsm\.Rv64$|sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/AddrNorm.lean
- scripts/check-file-size.sh EvmAsm/Evm64/SDiv/AddrNorm.lean
- scripts/check-unimported.sh
- lake build