### PR TITLE
refactor(sdiv): clean spec open

### DIFF
--- a/EvmAsm/Evm64/SDiv/Spec.lean
+++ b/EvmAsm/Evm64/SDiv/Spec.lean
@@ -16,7 +16,6 @@ import EvmAsm.Rv64.Tactics.XSimp
 
 namespace EvmAsm.Evm64
 
-open EvmAsm.Rv64
 open EvmAsm.Evm64.SDiv.Compose
 
 /-- Top-level zero-divisor SDIV stack bridge with the concrete semantic
@@ -34,7 +33,7 @@ theorem evm_sdiv_zero_divisor_result_stack_spec_within
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
      shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
     (base : Word) (hbase : base &&& 1 = 0) :
-    cpsTripleWithin (((49 + (EvmAsm.Evm64.unifiedDivBound + 1)) + 21) + 1)
+    EvmAsm.Rv64.cpsTripleWithin (((49 + (EvmAsm.Evm64.unifiedDivBound + 1)) + 21) + 1)
       base (vRa &&& ~~~(1 : Word)) (sdivCode base)
       ((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ vSavedOld) ** (.x12 ↦ᵣ sp) **
          (.x8 ↦ᵣ sDividendOld) ** (.x9 ↦ᵣ sDivisorOld) **
@@ -87,7 +86,7 @@ theorem evm_sdiv_zero_divisor_handler_stack_spec_within
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
      shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
     (base : Word) (hbase : base &&& 1 = 0) :
-    cpsTripleWithin (((49 + (EvmAsm.Evm64.unifiedDivBound + 1)) + 21) + 1)
+    EvmAsm.Rv64.cpsTripleWithin (((49 + (EvmAsm.Evm64.unifiedDivBound + 1)) + 21) + 1)
       base (vRa &&& ~~~(1 : Word)) (sdivCode base)
       ((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ vSavedOld) ** (.x12 ↦ᵣ sp) **
          (.x8 ↦ᵣ sDividendOld) ** (.x9 ↦ᵣ sDivisorOld) **


### PR DESCRIPTION
## Summary
- remove the broad Rv64 namespace open from the SDIV top-level spec file
- qualify cpsTripleWithin explicitly in the zero-divisor stack bridge theorems

## Validation
- lake build EvmAsm.Evm64.SDiv.Spec
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Spec.lean
- scripts/check-file-size.sh EvmAsm/Evm64/SDiv/Spec.lean
- scripts/check-unimported.sh
- lake build