### PR TITLE
refactor(sdiv): clean program open

### DIFF
--- a/EvmAsm/Evm64/SDiv/Program.lean
+++ b/EvmAsm/Evm64/SDiv/Program.lean
@@ -29,8 +29,6 @@ import EvmAsm.Evm64.DivMod.Callable
 
 namespace EvmAsm.Evm64
 
-open EvmAsm.Rv64
-
 /-- Load the top limb of a 256-bit word and extract its sign bit.
 
     On entry, `addrReg + topLimbOff` points at limb 3 of the word.
@@ -41,18 +39,20 @@ open EvmAsm.Rv64
 
     2 instructions: `LD; SRLI 63`. -/
 def evm_sdiv_sign_bit_block
-    (addrReg signReg : Reg) (topLimbOff : BitVec 12) : Program :=
-  LD signReg addrReg topLimbOff ;;
-  SRLI signReg signReg 63
+    (addrReg signReg : EvmAsm.Rv64.Reg) (topLimbOff : BitVec 12) :
+    EvmAsm.Rv64.Program :=
+  EvmAsm.Rv64.LD signReg addrReg topLimbOff ;;
+  EvmAsm.Rv64.SRLI signReg signReg 63
 
 theorem evm_sdiv_sign_bit_block_length
-    (addrReg signReg : Reg) (topLimbOff : BitVec 12) :
+    (addrReg signReg : EvmAsm.Rv64.Reg) (topLimbOff : BitVec 12) :
     (evm_sdiv_sign_bit_block addrReg signReg topLimbOff).length = 2 := by
-  unfold evm_sdiv_sign_bit_block LD SRLI single seq Program
+  unfold evm_sdiv_sign_bit_block EvmAsm.Rv64.LD EvmAsm.Rv64.SRLI
+    EvmAsm.Rv64.single EvmAsm.Rv64.seq EvmAsm.Rv64.Program
   rfl
 
 theorem evm_sdiv_sign_bit_block_byte_length
-    (addrReg signReg : Reg) (topLimbOff : BitVec 12) :
+    (addrReg signReg : EvmAsm.Rv64.Reg) (topLimbOff : BitVec 12) :
     4 * (evm_sdiv_sign_bit_block addrReg signReg topLimbOff).length = 8 := by
   rw [evm_sdiv_sign_bit_block_length]
 
@@ -66,20 +66,22 @@ theorem evm_sdiv_sign_bit_block_byte_length
 
     5 instructions: `LD; XOR; ADD; SLTU; SD`. -/
 def evm_sdiv_cond_negate_limb_step
-    (addrReg carryInReg maskReg valueReg carryReg : Reg)
-    (limbOff : BitVec 12) : Program :=
-  LD valueReg addrReg limbOff ;;
-  XOR' valueReg valueReg maskReg ;;
-  ADD valueReg valueReg carryInReg ;;
-  SLTU carryReg valueReg carryInReg ;;
-  SD addrReg valueReg limbOff
+    (addrReg carryInReg maskReg valueReg carryReg : EvmAsm.Rv64.Reg)
+    (limbOff : BitVec 12) : EvmAsm.Rv64.Program :=
+  EvmAsm.Rv64.LD valueReg addrReg limbOff ;;
+  EvmAsm.Rv64.XOR' valueReg valueReg maskReg ;;
+  EvmAsm.Rv64.ADD valueReg valueReg carryInReg ;;
+  EvmAsm.Rv64.SLTU carryReg valueReg carryInReg ;;
+  EvmAsm.Rv64.SD addrReg valueReg limbOff
 
 theorem evm_sdiv_cond_negate_limb_step_length
-    (addrReg carryInReg maskReg valueReg carryReg : Reg)
+    (addrReg carryInReg maskReg valueReg carryReg : EvmAsm.Rv64.Reg)
     (limbOff : BitVec 12) :
     (evm_sdiv_cond_negate_limb_step addrReg carryInReg maskReg valueReg carryReg
       limbOff).length = 5 := by
-  unfold evm_sdiv_cond_negate_limb_step LD XOR' ADD SLTU SD single seq Program
+  unfold evm_sdiv_cond_negate_limb_step EvmAsm.Rv64.LD EvmAsm.Rv64.XOR'
+    EvmAsm.Rv64.ADD EvmAsm.Rv64.SLTU EvmAsm.Rv64.SD EvmAsm.Rv64.single
+    EvmAsm.Rv64.seq EvmAsm.Rv64.Program
   rfl
 
 /-- Conditionally negate a 256-bit word in place.
@@ -97,25 +99,27 @@ theorem evm_sdiv_cond_negate_limb_step_length
     21 instructions: one `SUB` mask setup plus four 5-instruction limb
     steps (`LD; XOR; ADD; SLTU; SD`). -/
 def evm_sdiv_cond_negate_256_block
-    (addrReg signReg maskReg valueReg carryReg : Reg)
-    (limb0Off limb1Off limb2Off limb3Off : BitVec 12) : Program :=
-  SUB maskReg .x0 signReg ;;
+    (addrReg signReg maskReg valueReg carryReg : EvmAsm.Rv64.Reg)
+    (limb0Off limb1Off limb2Off limb3Off : BitVec 12) : EvmAsm.Rv64.Program :=
+  EvmAsm.Rv64.SUB maskReg .x0 signReg ;;
   evm_sdiv_cond_negate_limb_step addrReg signReg maskReg valueReg carryReg limb0Off ;;
   evm_sdiv_cond_negate_limb_step addrReg carryReg maskReg valueReg carryReg limb1Off ;;
   evm_sdiv_cond_negate_limb_step addrReg carryReg maskReg valueReg carryReg limb2Off ;;
   evm_sdiv_cond_negate_limb_step addrReg carryReg maskReg valueReg carryReg limb3Off
 
 theorem evm_sdiv_cond_negate_256_block_length
-    (addrReg signReg maskReg valueReg carryReg : Reg)
+    (addrReg signReg maskReg valueReg carryReg : EvmAsm.Rv64.Reg)
     (limb0Off limb1Off limb2Off limb3Off : BitVec 12) :
     (evm_sdiv_cond_negate_256_block addrReg signReg maskReg valueReg carryReg
       limb0Off limb1Off limb2Off limb3Off).length = 21 := by
   unfold evm_sdiv_cond_negate_256_block evm_sdiv_cond_negate_limb_step
-    SUB LD XOR' ADD SLTU SD single seq Program
+    EvmAsm.Rv64.SUB EvmAsm.Rv64.LD EvmAsm.Rv64.XOR' EvmAsm.Rv64.ADD
+    EvmAsm.Rv64.SLTU EvmAsm.Rv64.SD EvmAsm.Rv64.single EvmAsm.Rv64.seq
+    EvmAsm.Rv64.Program
   rfl
 
 theorem evm_sdiv_cond_negate_256_block_byte_length
-    (addrReg signReg maskReg valueReg carryReg : Reg)
+    (addrReg signReg maskReg valueReg carryReg : EvmAsm.Rv64.Reg)
     (limb0Off limb1Off limb2Off limb3Off : BitVec 12) :
     4 * (evm_sdiv_cond_negate_256_block addrReg signReg maskReg valueReg carryReg
       limb0Off limb1Off limb2Off limb3Off).length = 84 := by
@@ -124,8 +128,8 @@ theorem evm_sdiv_cond_negate_256_block_byte_length
 /-- Near-call block from SDIV into the unsigned `evm_div_callable` body.
     The concrete signed 21-bit offset is pinned by the eventual top-level
     `evm_sdiv` layout. -/
-def evm_sdiv_div_call_block (divOff : BitVec 21) : Program :=
-  JAL .x1 divOff
+def evm_sdiv_div_call_block (divOff : BitVec 21) : EvmAsm.Rv64.Program :=
+  EvmAsm.Rv64.JAL .x1 divOff
 
 theorem evm_sdiv_div_call_block_length (divOff : BitVec 21) :
     (evm_sdiv_div_call_block divOff).length = 1 := rfl
@@ -137,24 +141,24 @@ theorem evm_sdiv_div_call_block_byte_length (divOff : BitVec 21) :
 /-- Copy the current return address to a preserved scratch register. SDIV
     cannot use `cc_prologue` / `cc_epilogue` around `evm_div_callable`
     because the divider body owns `x2` as a scratch/link register. -/
-def evm_sdiv_save_ra_block (savedRaReg : Reg) : Program :=
-  ADDI savedRaReg .x1 0
+def evm_sdiv_save_ra_block (savedRaReg : EvmAsm.Rv64.Reg) : EvmAsm.Rv64.Program :=
+  EvmAsm.Rv64.ADDI savedRaReg .x1 0
 
-theorem evm_sdiv_save_ra_block_length (savedRaReg : Reg) :
+theorem evm_sdiv_save_ra_block_length (savedRaReg : EvmAsm.Rv64.Reg) :
     (evm_sdiv_save_ra_block savedRaReg).length = 1 := rfl
 
-theorem evm_sdiv_save_ra_block_byte_length (savedRaReg : Reg) :
+theorem evm_sdiv_save_ra_block_byte_length (savedRaReg : EvmAsm.Rv64.Reg) :
     4 * (evm_sdiv_save_ra_block savedRaReg).length = 4 := by
   rw [evm_sdiv_save_ra_block_length]
 
 /-- Return to the address saved before the nested DIV call. -/
-def evm_sdiv_saved_ra_ret_block (savedRaReg : Reg) : Program :=
-  JALR .x0 savedRaReg 0
+def evm_sdiv_saved_ra_ret_block (savedRaReg : EvmAsm.Rv64.Reg) : EvmAsm.Rv64.Program :=
+  EvmAsm.Rv64.JALR .x0 savedRaReg 0
 
-theorem evm_sdiv_saved_ra_ret_block_length (savedRaReg : Reg) :
+theorem evm_sdiv_saved_ra_ret_block_length (savedRaReg : EvmAsm.Rv64.Reg) :
     (evm_sdiv_saved_ra_ret_block savedRaReg).length = 1 := rfl
 
-theorem evm_sdiv_saved_ra_ret_block_byte_length (savedRaReg : Reg) :
+theorem evm_sdiv_saved_ra_ret_block_byte_length (savedRaReg : EvmAsm.Rv64.Reg) :
     4 * (evm_sdiv_saved_ra_ret_block savedRaReg).length = 4 := by
   rw [evm_sdiv_saved_ra_ret_block_length]
 
@@ -172,13 +176,13 @@ def evm_sdivCallOff : BitVec 21 := 92
 
     Memory layout matches `evm_div_callable`: dividend at `sp + 0..24`,
     divisor at `sp + 32..56`, quotient result at `sp + 32..56`. -/
-def evm_sdiv_wrapper : Program :=
+def evm_sdiv_wrapper : EvmAsm.Rv64.Program :=
   evm_sdiv_save_ra_block .x18 ;;
   evm_sdiv_sign_bit_block .x12 .x8 evm_sdivDividendTopLimbOff ;;
   evm_sdiv_sign_bit_block .x12 .x9 evm_sdivDivisorTopLimbOff ;;
   evm_sdiv_cond_negate_256_block .x12 .x8 .x10 .x7 .x11 0 8 16 24 ;;
   evm_sdiv_cond_negate_256_block .x12 .x9 .x10 .x7 .x11 32 40 48 56 ;;
-  XOR' .x8 .x8 .x9 ;;
+  EvmAsm.Rv64.XOR' .x8 .x8 .x9 ;;
   evm_sdiv_div_call_block evm_sdivCallOff ;;
   evm_sdiv_cond_negate_256_block .x12 .x8 .x10 .x7 .x11 0 8 16 24 ;;
   evm_sdiv_saved_ra_ret_block .x18
@@ -197,14 +201,14 @@ theorem evm_sdiv_call_target_byte_offset :
        (evm_sdiv_sign_bit_block .x12 .x9 evm_sdivDivisorTopLimbOff).length +
        (evm_sdiv_cond_negate_256_block .x12 .x8 .x10 .x7 .x11 0 8 16 24).length +
        (evm_sdiv_cond_negate_256_block .x12 .x9 .x10 .x7 .x11 32 40 48 56).length +
-       (XOR' .x8 .x8 .x9).length) +
-      signExtend21 evm_sdivCallOff =
+       (EvmAsm.Rv64.XOR' .x8 .x8 .x9).length) +
+      EvmAsm.Rv64.signExtend21 evm_sdivCallOff =
     4 * evm_sdiv_wrapper.length := by
   native_decide
 
 /-- Full SDIV code region. The wrapper returns via `x18`; the appended
     `evm_div_callable` block is reached only by the wrapper's near call. -/
-def evm_sdiv : Program :=
+def evm_sdiv : EvmAsm.Rv64.Program :=
   evm_sdiv_wrapper ;; evm_div_callable
 
 theorem evm_sdiv_length : evm_sdiv.length = 390 := by


### PR DESCRIPTION
## Summary
- remove the broad Rv64 namespace open from the SDIV program layout
- qualify Rv64 program types, instruction constructors, and length-proof helpers explicitly

## Validation
- lake build EvmAsm.Evm64.SDiv.Program
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "^open EvmAsm\.Rv64$|sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Program.lean
- scripts/check-file-size.sh EvmAsm/Evm64/SDiv/Program.lean
- scripts/check-unimported.sh
- lake build