### PR TITLE
refactor(exp): clean addr norm open

### DIFF
--- a/EvmAsm/Evm64/Exp/AddrNorm.lean
+++ b/EvmAsm/Evm64/Exp/AddrNorm.lean
@@ -16,23 +16,28 @@ import EvmAsm.Evm64.Exp.AddrNormAttr
 
 namespace EvmAsm.Evm64.Exp.AddrNorm
 
-open EvmAsm.Rv64
-
 @[exp_addr, grind =] theorem exp_se13_108 :
-    signExtend13 (108 : BitVec 13) = (108 : Word) := by decide
+    EvmAsm.Rv64.signExtend13 (108 : BitVec 13) = (108 : Word) := by decide
 
 @[exp_addr, grind =] theorem exp_se13_neg228 :
-    signExtend13 ((-228 : BitVec 13)) = (18446744073709551388 : Word) := by decide
+    EvmAsm.Rv64.signExtend13 ((-228 : BitVec 13)) = (18446744073709551388 : Word) := by decide
 
 attribute [exp_addr]
-  signExtend12_0 signExtend12_1 signExtend12_8 signExtend12_16
-  signExtend12_24 signExtend12_32 signExtend12_40 signExtend12_48
-  signExtend12_56 signExtend12_64
-  signExtend12_neg16
-  signExtend12_4095 signExtend12_4088 signExtend12_4080 signExtend12_4072
-  signExtend12_4064 signExtend12_4056 signExtend12_4048 signExtend12_4040
-  signExtend12_4032 signExtend12_4024 signExtend12_4016 signExtend12_4008
-  signExtend12_4000 signExtend12_3992 signExtend12_3984 signExtend12_3976
-  signExtend12_3968 signExtend12_3960 signExtend12_3952 signExtend12_3944
+  EvmAsm.Rv64.signExtend12_0 EvmAsm.Rv64.signExtend12_1
+  EvmAsm.Rv64.signExtend12_8 EvmAsm.Rv64.signExtend12_16
+  EvmAsm.Rv64.signExtend12_24 EvmAsm.Rv64.signExtend12_32
+  EvmAsm.Rv64.signExtend12_40 EvmAsm.Rv64.signExtend12_48
+  EvmAsm.Rv64.signExtend12_56 EvmAsm.Rv64.signExtend12_64
+  EvmAsm.Rv64.signExtend12_neg16
+  EvmAsm.Rv64.signExtend12_4095 EvmAsm.Rv64.signExtend12_4088
+  EvmAsm.Rv64.signExtend12_4080 EvmAsm.Rv64.signExtend12_4072
+  EvmAsm.Rv64.signExtend12_4064 EvmAsm.Rv64.signExtend12_4056
+  EvmAsm.Rv64.signExtend12_4048 EvmAsm.Rv64.signExtend12_4040
+  EvmAsm.Rv64.signExtend12_4032 EvmAsm.Rv64.signExtend12_4024
+  EvmAsm.Rv64.signExtend12_4016 EvmAsm.Rv64.signExtend12_4008
+  EvmAsm.Rv64.signExtend12_4000 EvmAsm.Rv64.signExtend12_3992
+  EvmAsm.Rv64.signExtend12_3984 EvmAsm.Rv64.signExtend12_3976
+  EvmAsm.Rv64.signExtend12_3968 EvmAsm.Rv64.signExtend12_3960
+  EvmAsm.Rv64.signExtend12_3952 EvmAsm.Rv64.signExtend12_3944
 
 end EvmAsm.Evm64.Exp.AddrNorm


### PR DESCRIPTION
## Summary
- remove the broad Rv64 namespace open from the EXP address-normalization file
- qualify signExtend13 and signExtend12 simp declarations explicitly in the EXP addr simp set

## Validation
- lake build EvmAsm.Evm64.Exp.AddrNorm
- lake build EvmAsm.Evm64.Exp
- git diff --check
- rg -n "^open EvmAsm\.Rv64$|sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/AddrNorm.lean
- scripts/check-file-size.sh EvmAsm/Evm64/Exp/AddrNorm.lean
- scripts/check-unimported.sh
- lake build