### PR TITLE
refactor(exp): clean squaring marshal post open

### DIFF
--- a/EvmAsm/Evm64/Exp/SquaringMarshalPairPost.lean
+++ b/EvmAsm/Evm64/Exp/SquaringMarshalPairPost.lean
@@ -24,7 +24,9 @@ import EvmAsm.Evm64.Exp.LimbSpec
 
 namespace EvmAsm.Evm64
 
-open EvmAsm.Rv64
+private theorem sepConjAssocEq (P Q R : EvmAsm.Rv64.Assertion) :
+    ((P ** Q) ** R) = (P ** (Q ** R)) :=
+  EvmAsm.Rv64.sepConj_assoc' P Q R
 
 /-- Fold the 8-atom post-state of `exp_loop_squaring_marshal_pair_spec_within`
     (factor-1 slot at `evmSp[0..24]` and factor-2 slot at `evmSp[32..56]`,
@@ -32,33 +34,33 @@ open EvmAsm.Rv64
     `expResultWord r0 r1 r2 r3`. -/
 theorem exp_squaring_marshal_pair_post_evmWordIs
     (evmSp r0 r1 r2 r3 : Word) :
-    (((evmSp + signExtend12 (0  : BitVec 12)) ↦ₘ r0) **
-     ((evmSp + signExtend12 (8  : BitVec 12)) ↦ₘ r1) **
-     ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
-     ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
-     ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ r0) **
-     ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ r1) **
-     ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ r2) **
-     ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ r3)) =
+    (((evmSp + EvmAsm.Rv64.signExtend12 (0  : BitVec 12)) ↦ₘ r0) **
+     ((evmSp + EvmAsm.Rv64.signExtend12 (8  : BitVec 12)) ↦ₘ r1) **
+     ((evmSp + EvmAsm.Rv64.signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+     ((evmSp + EvmAsm.Rv64.signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+     ((evmSp + EvmAsm.Rv64.signExtend12 (32 : BitVec 12)) ↦ₘ r0) **
+     ((evmSp + EvmAsm.Rv64.signExtend12 (40 : BitVec 12)) ↦ₘ r1) **
+     ((evmSp + EvmAsm.Rv64.signExtend12 (48 : BitVec 12)) ↦ₘ r2) **
+     ((evmSp + EvmAsm.Rv64.signExtend12 (56 : BitVec 12)) ↦ₘ r3)) =
     (evmWordIs evmSp (expResultWord r0 r1 r2 r3) **
       evmWordIs (evmSp + 32) (expResultWord r0 r1 r2 r3)) := by
-  -- Canonicalize all signExtend12 offsets to their literal Word values.
-  have h0  : (evmSp + signExtend12 (0  : BitVec 12) : Word) = evmSp       := by
-    unfold signExtend12; bv_decide
-  have h8  : (evmSp + signExtend12 (8  : BitVec 12) : Word) = evmSp + 8   := by
-    unfold signExtend12; bv_decide
-  have h16 : (evmSp + signExtend12 (16 : BitVec 12) : Word) = evmSp + 16  := by
-    unfold signExtend12; bv_decide
-  have h24 : (evmSp + signExtend12 (24 : BitVec 12) : Word) = evmSp + 24  := by
-    unfold signExtend12; bv_decide
-  have h32 : (evmSp + signExtend12 (32 : BitVec 12) : Word) = evmSp + 32  := by
-    unfold signExtend12; bv_decide
-  have h40 : (evmSp + signExtend12 (40 : BitVec 12) : Word) = evmSp + 40  := by
-    unfold signExtend12; bv_decide
-  have h48 : (evmSp + signExtend12 (48 : BitVec 12) : Word) = evmSp + 48  := by
-    unfold signExtend12; bv_decide
-  have h56 : (evmSp + signExtend12 (56 : BitVec 12) : Word) = evmSp + 56  := by
-    unfold signExtend12; bv_decide
+  -- Canonicalize all immediate offsets to their literal Word values.
+  have h0  : (evmSp + EvmAsm.Rv64.signExtend12 (0  : BitVec 12) : Word) = evmSp       := by
+    unfold EvmAsm.Rv64.signExtend12; bv_decide
+  have h8  : (evmSp + EvmAsm.Rv64.signExtend12 (8  : BitVec 12) : Word) = evmSp + 8   := by
+    unfold EvmAsm.Rv64.signExtend12; bv_decide
+  have h16 : (evmSp + EvmAsm.Rv64.signExtend12 (16 : BitVec 12) : Word) = evmSp + 16  := by
+    unfold EvmAsm.Rv64.signExtend12; bv_decide
+  have h24 : (evmSp + EvmAsm.Rv64.signExtend12 (24 : BitVec 12) : Word) = evmSp + 24  := by
+    unfold EvmAsm.Rv64.signExtend12; bv_decide
+  have h32 : (evmSp + EvmAsm.Rv64.signExtend12 (32 : BitVec 12) : Word) = evmSp + 32  := by
+    unfold EvmAsm.Rv64.signExtend12; bv_decide
+  have h40 : (evmSp + EvmAsm.Rv64.signExtend12 (40 : BitVec 12) : Word) = evmSp + 40  := by
+    unfold EvmAsm.Rv64.signExtend12; bv_decide
+  have h48 : (evmSp + EvmAsm.Rv64.signExtend12 (48 : BitVec 12) : Word) = evmSp + 48  := by
+    unfold EvmAsm.Rv64.signExtend12; bv_decide
+  have h56 : (evmSp + EvmAsm.Rv64.signExtend12 (56 : BitVec 12) : Word) = evmSp + 56  := by
+    unfold EvmAsm.Rv64.signExtend12; bv_decide
   rw [h0, h8, h16, h24, h32, h40, h48, h56]
   -- Now the LHS is the eight literal-offset atoms. Re-associate so that the
   -- first four atoms (factor-1 slot) and the last four (factor-2 slot) form
@@ -76,7 +78,9 @@ theorem exp_squaring_marshal_pair_post_evmWordIs
         (expResultWord_getLimbN_3 r0 r1 r2 r3)]
   -- Re-associate the right-leaning 8-atom chain into two right-leaning
   -- 4-atom chains separated at the factor-1/factor-2 boundary.
-  rw [sepConj_assoc', sepConj_assoc', sepConj_assoc']
+  rw [sepConjAssocEq]
+  rw [sepConjAssocEq]
+  rw [sepConjAssocEq]
 
 /-- Mid-tree variant of `exp_squaring_marshal_pair_post_evmWordIs`: thread a
     remainder `Q` so callers (`evm-asm-ct3ti`, `evm-asm-nrfpf`) can fold the
@@ -84,53 +88,53 @@ theorem exp_squaring_marshal_pair_post_evmWordIs
     chain alongside frame slots like `(.x12 ↦ᵣ evmSp)`, `(.x1 ↦ᵣ ra_val)`,
     or the local-scratch `sp[0..24]` group. -/
 theorem exp_squaring_marshal_pair_post_evmWordIs_right
-    (evmSp r0 r1 r2 r3 : Word) (Q : Assertion) :
-    (((evmSp + signExtend12 (0  : BitVec 12)) ↦ₘ r0) **
-     ((evmSp + signExtend12 (8  : BitVec 12)) ↦ₘ r1) **
-     ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
-     ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
-     ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ r0) **
-     ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ r1) **
-     ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ r2) **
-     ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ r3) ** Q) =
+    (evmSp r0 r1 r2 r3 : Word) (Q : EvmAsm.Rv64.Assertion) :
+    (((evmSp + EvmAsm.Rv64.signExtend12 (0  : BitVec 12)) ↦ₘ r0) **
+     ((evmSp + EvmAsm.Rv64.signExtend12 (8  : BitVec 12)) ↦ₘ r1) **
+     ((evmSp + EvmAsm.Rv64.signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+     ((evmSp + EvmAsm.Rv64.signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+     ((evmSp + EvmAsm.Rv64.signExtend12 (32 : BitVec 12)) ↦ₘ r0) **
+     ((evmSp + EvmAsm.Rv64.signExtend12 (40 : BitVec 12)) ↦ₘ r1) **
+     ((evmSp + EvmAsm.Rv64.signExtend12 (48 : BitVec 12)) ↦ₘ r2) **
+     ((evmSp + EvmAsm.Rv64.signExtend12 (56 : BitVec 12)) ↦ₘ r3) ** Q) =
     (evmWordIs evmSp (expResultWord r0 r1 r2 r3) **
       evmWordIs (evmSp + 32) (expResultWord r0 r1 r2 r3) ** Q) := by
-  rw [show
-      (((evmSp + signExtend12 (0  : BitVec 12)) ↦ₘ r0) **
-       ((evmSp + signExtend12 (8  : BitVec 12)) ↦ₘ r1) **
-       ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
-       ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
-       ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ r0) **
-       ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ r1) **
-       ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ r2) **
-       ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ r3) ** Q) =
-      ((((evmSp + signExtend12 (0  : BitVec 12)) ↦ₘ r0) **
-        ((evmSp + signExtend12 (8  : BitVec 12)) ↦ₘ r1) **
-        ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
-        ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
-        ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ r0) **
-        ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ r1) **
-        ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ r2) **
-        ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ r3)) ** Q) from by
-      rw [sepConj_assoc', sepConj_assoc', sepConj_assoc', sepConj_assoc',
-          sepConj_assoc', sepConj_assoc', sepConj_assoc']]
+  have h_assoc :
+      (((evmSp + EvmAsm.Rv64.signExtend12 (0  : BitVec 12)) ↦ₘ r0) **
+       ((evmSp + EvmAsm.Rv64.signExtend12 (8  : BitVec 12)) ↦ₘ r1) **
+       ((evmSp + EvmAsm.Rv64.signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+       ((evmSp + EvmAsm.Rv64.signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+       ((evmSp + EvmAsm.Rv64.signExtend12 (32 : BitVec 12)) ↦ₘ r0) **
+       ((evmSp + EvmAsm.Rv64.signExtend12 (40 : BitVec 12)) ↦ₘ r1) **
+       ((evmSp + EvmAsm.Rv64.signExtend12 (48 : BitVec 12)) ↦ₘ r2) **
+       ((evmSp + EvmAsm.Rv64.signExtend12 (56 : BitVec 12)) ↦ₘ r3) ** Q) =
+      ((((evmSp + EvmAsm.Rv64.signExtend12 (0  : BitVec 12)) ↦ₘ r0) **
+        ((evmSp + EvmAsm.Rv64.signExtend12 (8  : BitVec 12)) ↦ₘ r1) **
+        ((evmSp + EvmAsm.Rv64.signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+        ((evmSp + EvmAsm.Rv64.signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+        ((evmSp + EvmAsm.Rv64.signExtend12 (32 : BitVec 12)) ↦ₘ r0) **
+        ((evmSp + EvmAsm.Rv64.signExtend12 (40 : BitVec 12)) ↦ₘ r1) **
+        ((evmSp + EvmAsm.Rv64.signExtend12 (48 : BitVec 12)) ↦ₘ r2) **
+        ((evmSp + EvmAsm.Rv64.signExtend12 (56 : BitVec 12)) ↦ₘ r3)) ** Q) := by
+    simp only [sepConjAssocEq]
+  rw [h_assoc]
   rw [exp_squaring_marshal_pair_post_evmWordIs]
-  rw [sepConj_assoc']
+  rw [sepConjAssocEq]
 
 /-- Left-framed variant of `exp_squaring_marshal_pair_post_evmWordIs`: thread a
     leading frame `P` so callers can fold the 8-limb sub-tree when it follows
     already-framed registers or scratch slots. -/
 theorem exp_squaring_marshal_pair_post_evmWordIs_left
-    (evmSp r0 r1 r2 r3 : Word) (P : Assertion) :
+    (evmSp r0 r1 r2 r3 : Word) (P : EvmAsm.Rv64.Assertion) :
     (P **
-     (((evmSp + signExtend12 (0  : BitVec 12)) ↦ₘ r0) **
-      ((evmSp + signExtend12 (8  : BitVec 12)) ↦ₘ r1) **
-      ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
-      ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
-      ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ r0) **
-      ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ r1) **
-      ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ r2) **
-      ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ r3))) =
+     (((evmSp + EvmAsm.Rv64.signExtend12 (0  : BitVec 12)) ↦ₘ r0) **
+      ((evmSp + EvmAsm.Rv64.signExtend12 (8  : BitVec 12)) ↦ₘ r1) **
+      ((evmSp + EvmAsm.Rv64.signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+      ((evmSp + EvmAsm.Rv64.signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+      ((evmSp + EvmAsm.Rv64.signExtend12 (32 : BitVec 12)) ↦ₘ r0) **
+      ((evmSp + EvmAsm.Rv64.signExtend12 (40 : BitVec 12)) ↦ₘ r1) **
+      ((evmSp + EvmAsm.Rv64.signExtend12 (48 : BitVec 12)) ↦ₘ r2) **
+      ((evmSp + EvmAsm.Rv64.signExtend12 (56 : BitVec 12)) ↦ₘ r3))) =
     (P **
       (evmWordIs evmSp (expResultWord r0 r1 r2 r3) **
         evmWordIs (evmSp + 32) (expResultWord r0 r1 r2 r3))) := by


### PR DESCRIPTION
## Summary
- remove the broad Rv64 namespace open from Exp/SquaringMarshalPairPost.lean
- qualify signExtend12 and Assertion references explicitly
- split the nested associativity rewrite into a local helper/have while preserving proof behavior

## Validation
- lake build EvmAsm.Evm64.Exp.SquaringMarshalPairPost
- lake build EvmAsm.Evm64.Exp
- git diff --check
- rg -n "^open EvmAsm\.Rv64$|sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|sepConjAssocEq.*flat|mul_callable.*sepConjAssocEq" EvmAsm/Evm64/Exp/SquaringMarshalPairPost.lean
- scripts/check-file-size.sh EvmAsm/Evm64/Exp/SquaringMarshalPairPost.lean
- scripts/check-unimported.sh
- lake build

Full build has only the known LeanRV64D/RiscvExtras.lean extension.toCtorIdx deprecation warning.