### PR TITLE
refactor(exp): clean squaring call open

### DIFF
--- a/EvmAsm/Evm64/Exp/SquaringCall.lean
+++ b/EvmAsm/Evm64/Exp/SquaringCall.lean
@@ -34,7 +34,7 @@ import EvmAsm.Evm64.Exp.LimbSpec
 
 namespace EvmAsm.Evm64
 
-open EvmAsm.Rv64
+open EvmAsm.Rv64 (CodeReq Program seq)
 
 /-- 4-block `unionAll` decomposition of `exp_squaring_call_block mulOff`. The
     four sub-blocks live at offsets 0 / 32 / 64 / 68 from `base` and total


### PR DESCRIPTION
## Summary
- replace the broad Rv64 namespace open in Exp/SquaringCall.lean with a selective import list
- keep the code decomposition/proofs unchanged

## Validation
- lake build EvmAsm.Evm64.Exp.SquaringCall
- lake build EvmAsm.Evm64.Exp
- git diff --check
- rg -n "^open EvmAsm\.Rv64$|sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/SquaringCall.lean
- scripts/check-file-size.sh EvmAsm/Evm64/Exp/SquaringCall.lean
- scripts/check-unimported.sh
- lake build

Full build has only the known LeanRV64D/RiscvExtras.lean extension.toCtorIdx deprecation warning.