### PR TITLE
refactor(exp): clean cond-mul call open

### DIFF
--- a/EvmAsm/Evm64/Exp/CondMulCall.lean
+++ b/EvmAsm/Evm64/Exp/CondMulCall.lean
@@ -14,7 +14,7 @@ import EvmAsm.Evm64.Multiply.Callable
 
 namespace EvmAsm.Evm64
 
-open EvmAsm.Rv64
+open EvmAsm.Rv64 (CodeReq Instr Program seq single)
 
 /-- 4-block `unionAll` decomposition of `exp_cond_mul_call_block mulOff`.
     The block layout is:


### PR DESCRIPTION
## Summary
- replace the broad Rv64 namespace open in Exp/CondMulCall.lean with a selective import list
- keep the code decomposition/proofs unchanged

## Validation
- lake build EvmAsm.Evm64.Exp.CondMulCall
- lake build EvmAsm.Evm64.Exp
- git diff --check
- rg -n "^open EvmAsm\.Rv64$|sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/CondMulCall.lean
- scripts/check-file-size.sh EvmAsm/Evm64/Exp/CondMulCall.lean
- scripts/check-unimported.sh
- lake build

Full build has only the known LeanRV64D/RiscvExtras.lean extension.toCtorIdx deprecation warning.