### PR TITLE
refactor(exp): clean marshal pair open

### DIFF
--- a/EvmAsm/Evm64/Exp/MarshalPair.lean
+++ b/EvmAsm/Evm64/Exp/MarshalPair.lean
@@ -26,7 +26,8 @@ open EvmAsm.Rv64.Tactics
 
 namespace EvmAsm.Evm64
 
-open EvmAsm.Rv64
+open EvmAsm.Rv64 (CodeReq cpsTripleWithin cpsTripleWithin_frameL cpsTripleWithin_frameR
+  cpsTripleWithin_seq_with_perm cpsTripleWithin_weaken signExtend12)
 
 /-- Code requirement for the two-block squaring marshal prefix: the union
     of `factor1` at `base..(base+32)` and `result_to_factor2` at


### PR DESCRIPTION
## Summary
- replace the broad Rv64 namespace open in Exp/MarshalPair.lean with an explicit import list
- keep the existing Rv64.Tactics open for proof tactics
- leave proof structure unchanged

## Validation
- lake build EvmAsm.Evm64.Exp.MarshalPair
- lake build EvmAsm.Evm64.Exp
- git diff --check
- rg -n "^open EvmAsm\.Rv64$|sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/MarshalPair.lean
- scripts/check-file-size.sh EvmAsm/Evm64/Exp/MarshalPair.lean
- scripts/check-unimported.sh
- lake build

Full build has only the known LeanRV64D/RiscvExtras.lean extension.toCtorIdx deprecation warning.