### PR TITLE
refactor(exp): clean spec open

### DIFF
--- a/EvmAsm/Evm64/Exp/Spec.lean
+++ b/EvmAsm/Evm64/Exp/Spec.lean
@@ -18,7 +18,9 @@ import EvmAsm.Rv64.Tactics.XSimp
 
 namespace EvmAsm.Evm64
 
-open EvmAsm.Rv64
+open EvmAsm.Rv64 (Assertion cpsTripleWithin cpsTripleWithin_frameR
+  cpsTripleWithin_weaken signExtend12 signExtend12_1 signExtend12_32
+  signExtend12_40 signExtend12_48 signExtend12_56)
 open EvmAsm.Evm64.Exp.Compose
 
 /-- Stack-shaped bridge for the current EXP boundary mini-program.


### PR DESCRIPTION
## Summary
- replace the broad Rv64 namespace open in Exp/Spec.lean with an explicit import list
- leave boundary stack specs/proofs unchanged

## Validation
- lake build EvmAsm.Evm64.Exp.Spec
- lake build EvmAsm.Evm64.Exp
- git diff --check
- rg -n "^open EvmAsm\.Rv64$|sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/Spec.lean
- scripts/check-file-size.sh EvmAsm/Evm64/Exp/Spec.lean
- scripts/check-unimported.sh
- lake build

Full build has only the known LeanRV64D/RiscvExtras.lean extension.toCtorIdx deprecation warning.