### PR TITLE
refactor(exp): clean squaring mul-call open

### DIFF
--- a/EvmAsm/Evm64/Exp/CondMulCallSeq.lean
+++ b/EvmAsm/Evm64/Exp/CondMulCallSeq.lean
@@ -27,7 +27,9 @@ open EvmAsm.Rv64.Tactics
 
 namespace EvmAsm.Evm64
 
-open EvmAsm.Rv64
+open EvmAsm.Rv64 (cpsTripleWithin cpsTripleWithin_extend_code cpsTripleWithin_frameL
+  cpsTripleWithin_frameR cpsTripleWithin_seq_perm_same_cr cpsTripleWithin_weaken
+  signExtend12 signExtend21)
 
 /-- Compose the cond-mul marshal pair (16 instr, `base..(base+64)`) with
     its trailing JAL into `mul_callable` (1 instr at `base+64`).

--- a/EvmAsm/Evm64/Exp/Spec.lean
+++ b/EvmAsm/Evm64/Exp/Spec.lean
@@ -18,7 +18,9 @@ import EvmAsm.Rv64.Tactics.XSimp
 
 namespace EvmAsm.Evm64
 
-open EvmAsm.Rv64
+open EvmAsm.Rv64 (Assertion cpsTripleWithin cpsTripleWithin_frameR
+  cpsTripleWithin_weaken signExtend12 signExtend12_1 signExtend12_32
+  signExtend12_40 signExtend12_48 signExtend12_56)
 open EvmAsm.Evm64.Exp.Compose
 
 /-- Stack-shaped bridge for the current EXP boundary mini-program.

--- a/EvmAsm/Evm64/Exp/SquaringCallSeq.lean
+++ b/EvmAsm/Evm64/Exp/SquaringCallSeq.lean
@@ -25,7 +25,9 @@ open EvmAsm.Rv64.Tactics
 
 namespace EvmAsm.Evm64
 
-open EvmAsm.Rv64
+open EvmAsm.Rv64 (Assertion CodeReq cpsTripleWithin cpsTripleWithin_extend_code
+  cpsTripleWithin_frameL cpsTripleWithin_frameR cpsTripleWithin_seq_perm_same_cr
+  cpsTripleWithin_weaken signExtend12 signExtend21)
 
 /-- Composition of the squaring marshal pair (factor1 ;; result_to_factor2,
     16 instr at offsets 0..32..64) and the squaring JAL (1 instr at offset 64),

--- a/EvmAsm/Evm64/Exp/SquaringPairThenMulCall.lean
+++ b/EvmAsm/Evm64/Exp/SquaringPairThenMulCall.lean
@@ -31,7 +31,10 @@ open EvmAsm.Rv64.Tactics
 
 namespace EvmAsm.Evm64
 
-open EvmAsm.Rv64
+open EvmAsm.Rv64 (Assertion CodeReq cpsTripleWithin cpsTripleWithin_extend_code
+  cpsTripleWithin_frameL cpsTripleWithin_frameR cpsTripleWithin_of_forall_regIs_to_regOwn
+  cpsTripleWithin_seq cpsTripleWithin_seq_perm_same_cr cpsTripleWithin_weaken
+  memOwn regOwn signExtend12 signExtend21)
 
 /-- Code required by the squaring-call block plus the out-of-line
     `mul_callable` body reached by the JAL inside the block. -/


### PR DESCRIPTION
## Summary
- replace the broad Rv64 namespace open in Exp/SquaringPairThenMulCall.lean with an explicit import list
- keep the existing Rv64.Tactics open for proof tactics
- leave proof structure unchanged

## Validation
- lake build EvmAsm.Evm64.Exp.SquaringPairThenMulCall
- lake build EvmAsm.Evm64.Exp
- git diff --check
- rg -n "^open EvmAsm\.Rv64$|sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/SquaringPairThenMulCall.lean
- scripts/check-file-size.sh EvmAsm/Evm64/Exp/SquaringPairThenMulCall.lean
- scripts/check-unimported.sh
- lake build

Full build has only the known LeanRV64D/RiscvExtras.lean extension.toCtorIdx deprecation warning.