### PR TITLE
refactor(exp): clean saved-bit base open

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBase.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBase.lean
@@ -11,7 +11,7 @@ import EvmAsm.Evm64.Exp.Compose.Base
 namespace EvmAsm.Evm64.Exp.Compose
 
 open EvmAsm.Rv64.Tactics
-open EvmAsm.Rv64
+open EvmAsm.Rv64 (CodeReq Program seq)
 
 theorem exp_msb_bit_test_block_len :
     (EvmAsm.Evm64.exp_msb_bit_test_block).length = 3 := by


### PR DESCRIPTION
## Summary
- replace the broad Rv64 namespace open in Exp/Compose/SavedBitBase.lean with an explicit import list
- keep the existing Rv64.Tactics open for proof tactics
- leave code decomposition/proofs unchanged

## Validation
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitBase
- lake build EvmAsm.Evm64.Exp
- git diff --check
- rg -n "^open EvmAsm\.Rv64$|sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/Compose/SavedBitBase.lean
- scripts/check-file-size.sh EvmAsm/Evm64/Exp/Compose/SavedBitBase.lean
- scripts/check-unimported.sh
- lake build

Full build has only the known LeanRV64D/RiscvExtras.lean extension.toCtorIdx deprecation warning.