### PR TITLE
refactor(exp): clean full loop open

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/FullLoop.lean
+++ b/EvmAsm/Evm64/Exp/Compose/FullLoop.lean
@@ -13,7 +13,9 @@ import EvmAsm.Evm64.Multiply.Callable
 
 namespace EvmAsm.Evm64.Exp.Compose
 
-open EvmAsm.Rv64
+open EvmAsm.Rv64 (Assertion CodeReq cpsBranchWithin
+  cpsBranchWithin_extend_code cpsTripleWithin cpsTripleWithin_extend_code
+  memOwn regOwn signExtend12 signExtend13 signExtend21)
 
 /-- Code required by the top-level EXP program plus the external
     `mul_callable` body reached by both JALs in one loop iteration. -/


### PR DESCRIPTION
## Summary
- narrow the `EvmAsm.Rv64` open in `Exp/Compose/FullLoop.lean` to the assertion, code, CPS, ownership, and sign-extension names used by the full-loop helpers
- leave the EXP+MUL code-bundle proofs otherwise unchanged

## Validation
- `lake build EvmAsm.Evm64.Exp.Compose.FullLoop`
- `lake build EvmAsm.Evm64.Exp`
- `git diff --check`
- `rg -n "^open EvmAsm\\.Rv64$|sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/Compose/FullLoop.lean`
- `scripts/check-file-size.sh EvmAsm/Evm64/Exp/Compose/FullLoop.lean`
- `scripts/check-unimported.sh`
- `lake build`
