### PR TITLE
refactor(exp): clean compose base open

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/Base.lean
+++ b/EvmAsm/Evm64/Exp/Compose/Base.lean
@@ -17,7 +17,9 @@ import EvmAsm.Evm64.Exp.LimbSpec
 namespace EvmAsm.Evm64.Exp.Compose
 
 open EvmAsm.Rv64.Tactics
-open EvmAsm.Rv64
+open EvmAsm.Rv64 (CodeReq Program cpsTripleWithin cpsTripleWithin_extend_code
+  cpsTripleWithin_frameR cpsTripleWithin_seq cpsTripleWithin_weaken seq
+  signExtend12)
 
 /-- Length of the EXP prologue block, restated in the composition namespace so
     future `skipBlock`-style subsumption proofs can use a compact simp set. -/


### PR DESCRIPTION
## Summary
- narrow the `EvmAsm.Rv64` open in `Exp/Compose/Base.lean` to the code, program, CPS triple, sequencing, and sign-extension names used by the base composition helpers
- keep the tactics namespace open for existing `bv_omega`, `xperm_hyp`, and `pcFree` proof steps

## Validation
- `lake build EvmAsm.Evm64.Exp.Compose.Base`
- `lake build EvmAsm.Evm64.Exp`
- `git diff --check`
- `rg -n "^open EvmAsm\\.Rv64$|sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/Compose/Base.lean`
- `scripts/check-file-size.sh EvmAsm/Evm64/Exp/Compose/Base.lean`
- `scripts/check-unimported.sh`
- `lake build`
