### PR TITLE
fix(sdiv): name result sign-fix word

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/ResultSignFixZeroWordView.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/ResultSignFixZeroWordView.lean
@@ -9,6 +9,38 @@ import EvmAsm.Evm64.SDiv.Compose.Words
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
+/-- Postcondition view for a general SDIV result-sign-fix output: the four
+    result memory cells fold into the named result-sign-fixed EVM word, while
+    the scratch registers remain exposed explicitly. -/
+theorem resultSignFixPost_sdivResultSign_word
+    (sp dividendTop divisorTop limb0 limb1 limb2 limb3 : Word) :
+    let resultSign :=
+      (dividendTop >>> (63 : BitVec 6).toNat) ^^^
+        (divisorTop >>> (63 : BitVec 6).toNat)
+    let mask := (0 : Word) - resultSign
+    let sum0 := (limb0 ^^^ mask) + resultSign
+    let carry0 := if BitVec.ult sum0 resultSign then (1 : Word) else 0
+    let sum1 := (limb1 ^^^ mask) + carry0
+    let carry1 := if BitVec.ult sum1 carry0 then (1 : Word) else 0
+    let sum2 := (limb2 ^^^ mask) + carry1
+    let carry2 := if BitVec.ult sum2 carry1 then (1 : Word) else 0
+    let sum3 := (limb3 ^^^ mask) + carry2
+    let carry3 := if BitVec.ult sum3 carry2 then (1 : Word) else 0
+    resultSignFixPost sp resultSign limb0 limb1 limb2 limb3 =
+      ((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ resultSign) **
+       (.x10 ↦ᵣ mask) ** (.x7 ↦ᵣ sum3) ** (.x11 ↦ᵣ carry3) **
+       evmWordIs sp
+        (sdivResultSignFixedWord dividendTop divisorTop limb0 limb1 limb2 limb3)) := by
+  dsimp only
+  rw [resultSignFixPost_unfold, evmWordIs_sp_unfold]
+  unfold sdivResultSignFixedWord
+  dsimp only
+  simp only [EvmAsm.Rv64.signExtend12_0, EvmAsm.Rv64.signExtend12_8,
+    EvmAsm.Rv64.signExtend12_16, EvmAsm.Rv64.signExtend12_24,
+    EvmWord.getLimbN_fromLimbs_gen_0, EvmWord.getLimbN_fromLimbs_gen_1,
+    EvmWord.getLimbN_fromLimbs_gen_2, EvmWord.getLimbN_fromLimbs_gen_3]
+  rw [show (sp + 0 : Word) = sp by bv_decide]
+
 /-- Postcondition view for the SDIV zero-divisor branch after result-sign
     fixup: conditional negation of the zero quotient is still the zero EVM
     word, with the sign-fix scratch registers exposed explicitly. -/

--- a/EvmAsm/Evm64/SDiv/Compose/Words.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/Words.lean
@@ -47,6 +47,26 @@ def sdivAbsDivisorWord
     match i with
     | 0 => divisorSum0 | 1 => divisorSum1 | 2 => divisorSum2 | 3 => divisorSum3
 
+/-- Word produced by conditionally negating the unsigned quotient limbs by the
+    SDIV result sign. This names the memory-result word of the result-sign
+    fixup block before connecting it to the semantic `EvmWord.sdiv` result. -/
+def sdivResultSignFixedWord
+    (dividendTop divisorTop limb0 limb1 limb2 limb3 : Word) : EvmWord :=
+  let resultSign :=
+    (dividendTop >>> (63 : BitVec 6).toNat) ^^^
+      (divisorTop >>> (63 : BitVec 6).toNat)
+  let mask := (0 : Word) - resultSign
+  let sum0 := (limb0 ^^^ mask) + resultSign
+  let carry0 := if BitVec.ult sum0 resultSign then (1 : Word) else 0
+  let sum1 := (limb1 ^^^ mask) + carry0
+  let carry1 := if BitVec.ult sum1 carry0 then (1 : Word) else 0
+  let sum2 := (limb2 ^^^ mask) + carry1
+  let carry2 := if BitVec.ult sum2 carry1 then (1 : Word) else 0
+  let sum3 := (limb3 ^^^ mask) + carry2
+  EvmWord.fromLimbs fun i : Fin 4 =>
+    match i with
+    | 0 => sum0 | 1 => sum1 | 2 => sum2 | 3 => sum3
+
 /-- The SDIV result sign is the XOR of two top-bit extractions, hence it is a
     Boolean word. This keeps later result-sign-fix zero-quotient rewrites from
     reasoning about arbitrary 64-bit masks. -/


### PR DESCRIPTION
## Summary
- add sdivResultSignFixedWord for the word produced by conditional quotient sign-fix
- add resultSignFixPost_sdivResultSign_word to fold the four result-sign-fix memory cells into evmWordIs
- keep this as an assertion-shape bridge, not the final EvmWord.sdiv semantic equivalence

## Verification
- lake build EvmAsm.Evm64.SDiv.Compose.ResultSignFixZeroWordView
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/Words.lean EvmAsm/Evm64/SDiv/Compose/ResultSignFixZeroWordView.lean
- scripts/check-file-size.sh EvmAsm/Evm64/SDiv/Compose/Words.lean EvmAsm/Evm64/SDiv/Compose/ResultSignFixZeroWordView.lean
- scripts/check-unimported.sh
- lake build