### PR TITLE
fix(sdiv): expose exact handler stack with result hypothesis

### DIFF
--- a/EvmAsm/Evm64/SDiv/Spec.lean
+++ b/EvmAsm/Evm64/SDiv/Spec.lean
@@ -301,6 +301,103 @@ theorem evm_sdiv_exact_return_result_stack_spec_within
       q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
       shiftMem nMem jMem retMem dMem dloMem scratchUn0 base hbase hStack)
 
+/-- Exact-callable SDIV handler-stack bridge, parameterized by the remaining
+    pure result-word equality.
+
+    The assembly side has already produced the named sign-fixed quotient
+    word. This theorem isolates the final semantic obligation as
+    `hResult`, then exposes the executable `sdivHandler` stack view. -/
+theorem evm_sdiv_exact_return_handler_stack_of_result_eq_spec_within
+    (vRa vSavedOld sp sDividendOld sDivisorOld
+      dividendMaskOld dividendValueOld dividendCarryOld
+      v2 v5 v6 : Word)
+    (state : EvmState) (dividend divisor : EvmWord) (rest : List EvmWord)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (base : Word) (hbase : base &&& 1 = 0)
+    (hStack :
+      EvmAsm.Rv64.cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
+        (base + wrapperEndOff)
+        ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
+        (EvmAsm.Evm64.divCode_noNop (base + wrapperEndOff))
+        (EvmAsm.Evm64.divModStackDispatchPre sp
+          (sdivAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
+            (dividend.getLimbN 2) (dividend.getLimbN 3))
+          (sdivAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
+            (divisor.getLimbN 2) (divisor.getLimbN 3))
+          ((base + divCallOff) + 4) v2 v5 v6
+          (sdivAbsSum3 (divisor.getLimbN 0) (divisor.getLimbN 1)
+            (divisor.getLimbN 2) (divisor.getLimbN 3))
+          (sdivAbsMask (divisor.getLimbN 3))
+          (sdivAbsCarry3 (divisor.getLimbN 0) (divisor.getLimbN 1)
+            (divisor.getLimbN 2) (divisor.getLimbN 3))
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+        (EvmAsm.Evm64.divStackDispatchPostNoX1 sp
+          (sdivAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
+            (dividend.getLimbN 2) (dividend.getLimbN 3))
+          (sdivAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
+            (divisor.getLimbN 2) (divisor.getLimbN 3)) **
+          (.x1 ↦ᵣ ((base + divCallOff) + 4))))
+    (hResult :
+      let dividendAbsWord :=
+        sdivAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
+          (dividend.getLimbN 2) (dividend.getLimbN 3)
+      let divisorAbsWord :=
+        sdivAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
+          (divisor.getLimbN 2) (divisor.getLimbN 3)
+      let quotientWord := EvmWord.div dividendAbsWord divisorAbsWord
+      sdivResultSignFixedWord (dividend.getLimbN 3) (divisor.getLimbN 3)
+        (quotientWord.getLimbN 0) (quotientWord.getLimbN 1)
+        (quotientWord.getLimbN 2) (quotientWord.getLimbN 3) =
+        EvmWord.sdiv dividend divisor) :
+    EvmAsm.Rv64.cpsTripleWithin (((49 + (EvmAsm.Evm64.unifiedDivBound + 1)) + 21) + 1)
+      base (vRa &&& ~~~(1 : Word)) (sdivCode base)
+      ((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ vSavedOld) ** (.x12 ↦ᵣ sp) **
+         (.x8 ↦ᵣ sDividendOld) ** (.x9 ↦ᵣ sDivisorOld) **
+         (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ dividendMaskOld) **
+         (.x7 ↦ᵣ dividendValueOld) ** (.x11 ↦ᵣ dividendCarryOld)) **
+        evmStackIs sp (dividend :: divisor :: rest)) **
+       ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
+        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0))
+      (let dividendAbsWord :=
+         sdivAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
+           (dividend.getLimbN 2) (dividend.getLimbN 3)
+       let resultSign :=
+         (dividend.getLimbN 3 >>> (63 : BitVec 6).toNat) ^^^
+           (divisor.getLimbN 3 >>> (63 : BitVec 6).toNat)
+       let divisorSign := divisor.getLimbN 3 >>> (63 : BitVec 6).toNat
+       let mask := (0 : Word) - resultSign
+       let divisorAbsWord :=
+         sdivAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
+           (divisor.getLimbN 2) (divisor.getLimbN 3)
+       let quotientWord := EvmWord.div dividendAbsWord divisorAbsWord
+       let sum0 := ((quotientWord.getLimbN 0) ^^^ mask) + resultSign
+       let carry0 := if BitVec.ult sum0 resultSign then (1 : Word) else 0
+       let sum1 := ((quotientWord.getLimbN 1) ^^^ mask) + carry0
+       let carry1 := if BitVec.ult sum1 carry0 then (1 : Word) else 0
+       let sum2 := ((quotientWord.getLimbN 2) ^^^ mask) + carry1
+       let carry2 := if BitVec.ult sum2 carry1 then (1 : Word) else 0
+       let sum3 := ((quotientWord.getLimbN 3) ^^^ mask) + carry2
+       let carry3 := if BitVec.ult sum3 carry2 then (1 : Word) else 0
+       (.x18 ↦ᵣ vRa) **
+       (((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ (sp + 32)) ** (.x8 ↦ᵣ resultSign) **
+         (.x10 ↦ᵣ mask) ** (.x7 ↦ᵣ sum3) ** (.x11 ↦ᵣ carry3) **
+         evmStackIs (sp + 32)
+          ((ArithmeticHandlers.sdivHandler
+            { state with stack := dividend :: divisor :: rest }).stack)) **
+        saveRaDivCallBzeroSavedRaRetFrame sp base divisorSign dividendAbsWord)) := by
+  exact EvmAsm.Rv64.cpsTripleWithin_weaken (fun _ hp => hp) (fun _ hp => by
+      rw [hResult] at hp
+      simpa using hp)
+    (evm_sdiv_exact_return_result_stack_spec_within
+      vRa vSavedOld sp sDividendOld sDivisorOld
+      dividendMaskOld dividendValueOld dividendCarryOld
+      v2 v5 v6 dividend divisor rest
+      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 base hbase hStack)
+
 -- Placeholder: full all-case `evm_sdiv_stack_spec_within` lands in slice 4
 -- (evm-asm-01uh). The signed-division correctness lemma
 -- `EvmWord.sdiv_correct` is added in slice 3 (evm-asm-kvs4).


### PR DESCRIPTION
## Summary
- add evm_sdiv_exact_return_handler_stack_of_result_eq_spec_within
- expose the executable sdivHandler stack view for the exact path under a single pure result-word equality
- keep the remaining semantic obligation isolated as hResult

## Verification
- lake build EvmAsm.Evm64.SDiv.Spec
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Spec.lean
- scripts/check-file-size.sh EvmAsm/Evm64/SDiv/Spec.lean
- scripts/check-unimported.sh
- lake build