### PR TITLE
fix(sdiv): discharge nonnegative exact result word

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/Words.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/Words.lean
@@ -111,6 +111,25 @@ theorem sdivAbsDividendWord_of_sign_zero
   rw [hSign]
   bv_decide
 
+/-- Four concrete `getLimbN` projections assemble back to their source word. -/
+theorem sdivWord_from_getLimbN (v : EvmWord) :
+    EvmWord.fromLimbs (fun i : Fin 4 =>
+      match i with
+      | 0 => v.getLimbN 0 | 1 => v.getLimbN 1 | 2 => v.getLimbN 2 | 3 => v.getLimbN 3) =
+      v := by
+  unfold EvmWord.fromLimbs EvmWord.getLimbN EvmWord.getLimb
+  bv_decide
+
+/-- Word-shaped variant of `sdivAbsDividendWord_of_sign_zero`: if the dividend
+    sign bit is zero, the SDIV absolute-value helper returns the dividend word. -/
+theorem sdivAbsDividendWord_eq_word_of_sign_zero
+    (dividend : EvmWord)
+    (hSign : dividend.getLimbN 3 >>> (63 : BitVec 6).toNat = (0 : Word)) :
+    sdivAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
+      (dividend.getLimbN 2) (dividend.getLimbN 3) = dividend := by
+  rw [sdivAbsDividendWord_of_sign_zero _ _ _ _ hSign]
+  exact sdivWord_from_getLimbN dividend
+
 /-- If the divisor sign bit is zero, the divisor absolute-value word is just the
     original four-limb word. -/
 theorem sdivAbsDivisorWord_of_sign_zero
@@ -123,6 +142,16 @@ theorem sdivAbsDivisorWord_of_sign_zero
   unfold sdivAbsDivisorWord EvmWord.fromLimbs
   rw [hSign]
   bv_decide
+
+/-- Word-shaped variant of `sdivAbsDivisorWord_of_sign_zero`: if the divisor
+    sign bit is zero, the SDIV absolute-value helper returns the divisor word. -/
+theorem sdivAbsDivisorWord_eq_word_of_sign_zero
+    (divisor : EvmWord)
+    (hSign : divisor.getLimbN 3 >>> (63 : BitVec 6).toNat = (0 : Word)) :
+    sdivAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
+      (divisor.getLimbN 2) (divisor.getLimbN 3) = divisor := by
+  rw [sdivAbsDivisorWord_of_sign_zero _ _ _ _ hSign]
+  exact sdivWord_from_getLimbN divisor
 
 /-- If the SDIV result sign is zero, the result-sign-fix word is just the
     unsigned quotient word assembled from its four limbs. -/
@@ -138,6 +167,20 @@ theorem sdivResultSignFixedWord_of_result_sign_zero
   unfold sdivResultSignFixedWord EvmWord.fromLimbs
   rw [hSign]
   bv_decide
+
+/-- Word-shaped variant of `sdivResultSignFixedWord_of_result_sign_zero`: if
+    the result sign is zero, the result-sign-fix helper leaves the quotient word
+    unchanged. -/
+theorem sdivResultSignFixedWord_eq_word_of_result_sign_zero
+    (dividendTop divisorTop : Word) (quotient : EvmWord)
+    (hSign :
+      (dividendTop >>> (63 : BitVec 6).toNat) ^^^
+        (divisorTop >>> (63 : BitVec 6).toNat) = (0 : Word)) :
+    sdivResultSignFixedWord dividendTop divisorTop
+      (quotient.getLimbN 0) (quotient.getLimbN 1)
+      (quotient.getLimbN 2) (quotient.getLimbN 3) = quotient := by
+  rw [sdivResultSignFixedWord_of_result_sign_zero _ _ _ _ _ _ hSign]
+  exact sdivWord_from_getLimbN quotient
 
 /-- The SDIV divisor absolute-value word is zero when all divisor limbs are
     zero. This discharges the internal bzero-branch hypothesis for the

--- a/EvmAsm/Evm64/SDiv/Spec.lean
+++ b/EvmAsm/Evm64/SDiv/Spec.lean
@@ -20,6 +20,51 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Evm64.SDiv.Compose
 
+/-- Nonnegative/nonnegative exact-path SDIV result bridge.
+
+    When both input signs are zero, the assembly absolute-value helpers leave
+    both operands unchanged and the result-sign-fix helper leaves the unsigned
+    quotient unchanged. In that case `EvmWord.div` and `EvmWord.sdiv` agree. -/
+theorem sdivResultSignFixedWord_eq_sdiv_of_nonnegative
+    (dividend divisor : EvmWord)
+    (hDividendSign :
+      dividend.getLimbN 3 >>> (63 : BitVec 6).toNat = (0 : Word))
+    (hDivisorSign :
+      divisor.getLimbN 3 >>> (63 : BitVec 6).toNat = (0 : Word)) :
+    let dividendAbsWord :=
+      sdivAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
+        (dividend.getLimbN 2) (dividend.getLimbN 3)
+    let divisorAbsWord :=
+      sdivAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
+        (divisor.getLimbN 2) (divisor.getLimbN 3)
+    let quotientWord := EvmWord.div dividendAbsWord divisorAbsWord
+    sdivResultSignFixedWord (dividend.getLimbN 3) (divisor.getLimbN 3)
+      (quotientWord.getLimbN 0) (quotientWord.getLimbN 1)
+      (quotientWord.getLimbN 2) (quotientWord.getLimbN 3) =
+      EvmWord.sdiv dividend divisor := by
+  dsimp
+  rw [sdivAbsDividendWord_eq_word_of_sign_zero dividend hDividendSign]
+  rw [sdivAbsDivisorWord_eq_word_of_sign_zero divisor hDivisorSign]
+  have hResultSign :
+      (dividend.getLimbN 3 >>> (63 : BitVec 6).toNat) ^^^
+        (divisor.getLimbN 3 >>> (63 : BitVec 6).toNat) = (0 : Word) := by
+    rw [hDividendSign, hDivisorSign]
+    bv_decide
+  rw [sdivResultSignFixedWord_eq_word_of_result_sign_zero _ _ _ hResultSign]
+  have hDividendMsb : BitVec.msb dividend = false := by
+    unfold EvmWord.getLimbN EvmWord.getLimb at hDividendSign
+    simp at hDividendSign
+    bv_decide
+  have hDivisorMsb : BitVec.msb divisor = false := by
+    unfold EvmWord.getLimbN EvmWord.getLimb at hDivisorSign
+    simp at hDivisorSign
+    bv_decide
+  unfold EvmWord.div EvmWord.sdiv
+  rw [BitVec.sdiv_eq, hDividendMsb, hDivisorMsb]
+  by_cases hZero : divisor = 0
+  · simp [hZero]
+  · rw [if_neg hZero]
+
 /-- Top-level zero-divisor SDIV stack bridge with the concrete semantic
     zero-result stack shape.
 


### PR DESCRIPTION
## Summary
- add word-shaped sign-zero views for SDIV abs/result-sign-fix helpers
- add sdivResultSignFixedWord_eq_sdiv_of_nonnegative for the exact path when both operands are nonnegative
- reduce the remaining exact-path hResult work by one concrete semantic subcase

## Verification
- lake build EvmAsm.Evm64.SDiv.Compose.Words
- lake build EvmAsm.Evm64.SDiv.Spec
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/Words.lean EvmAsm/Evm64/SDiv/Spec.lean
- scripts/check-file-size.sh EvmAsm/Evm64/SDiv/Compose/Words.lean EvmAsm/Evm64/SDiv/Spec.lean
- scripts/check-unimported.sh
- lake build