### PR TITLE
fix(sdiv): discharge negative exact result word

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/Words.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/Words.lean
@@ -130,6 +130,19 @@ theorem sdivAbsDividendWord_eq_word_of_sign_zero
   rw [sdivAbsDividendWord_of_sign_zero _ _ _ _ hSign]
   exact sdivWord_from_getLimbN dividend
 
+/-- If the dividend sign bit is one, the SDIV absolute-value helper returns the
+    two's-complement negation of the dividend word. -/
+theorem sdivAbsDividendWord_eq_neg_word_of_sign_one
+    (dividend : EvmWord)
+    (hSign : dividend.getLimbN 3 >>> (63 : BitVec 6).toNat = (1 : Word)) :
+    sdivAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
+      (dividend.getLimbN 2) (dividend.getLimbN 3) = -dividend := by
+  unfold sdivAbsDividendWord EvmWord.fromLimbs
+  rw [hSign]
+  unfold EvmWord.getLimbN EvmWord.getLimb at hSign ⊢
+  simp only [Neg.neg]
+  bv_decide
+
 /-- If the divisor sign bit is zero, the divisor absolute-value word is just the
     original four-limb word. -/
 theorem sdivAbsDivisorWord_of_sign_zero
@@ -152,6 +165,19 @@ theorem sdivAbsDivisorWord_eq_word_of_sign_zero
       (divisor.getLimbN 2) (divisor.getLimbN 3) = divisor := by
   rw [sdivAbsDivisorWord_of_sign_zero _ _ _ _ hSign]
   exact sdivWord_from_getLimbN divisor
+
+/-- If the divisor sign bit is one, the SDIV absolute-value helper returns the
+    two's-complement negation of the divisor word. -/
+theorem sdivAbsDivisorWord_eq_neg_word_of_sign_one
+    (divisor : EvmWord)
+    (hSign : divisor.getLimbN 3 >>> (63 : BitVec 6).toNat = (1 : Word)) :
+    sdivAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
+      (divisor.getLimbN 2) (divisor.getLimbN 3) = -divisor := by
+  unfold sdivAbsDivisorWord EvmWord.fromLimbs
+  rw [hSign]
+  unfold EvmWord.getLimbN EvmWord.getLimb at hSign ⊢
+  simp only [Neg.neg]
+  bv_decide
 
 /-- If the SDIV result sign is zero, the result-sign-fix word is just the
     unsigned quotient word assembled from its four limbs. -/

--- a/EvmAsm/Evm64/SDiv/Spec.lean
+++ b/EvmAsm/Evm64/SDiv/Spec.lean
@@ -65,6 +65,52 @@ theorem sdivResultSignFixedWord_eq_sdiv_of_nonnegative
   · simp [hZero]
   · rw [if_neg hZero]
 
+/-- Negative/negative exact-path SDIV result bridge.
+
+    When both input signs are one, the assembly absolute-value helpers produce
+    `-dividend` and `-divisor`; the result sign is zero, so the result-sign-fix
+    helper leaves the unsigned quotient unchanged. This is the `true,true`
+    branch of `BitVec.sdiv_eq`. -/
+theorem sdivResultSignFixedWord_eq_sdiv_of_negative
+    (dividend divisor : EvmWord)
+    (hDividendSign :
+      dividend.getLimbN 3 >>> (63 : BitVec 6).toNat = (1 : Word))
+    (hDivisorSign :
+      divisor.getLimbN 3 >>> (63 : BitVec 6).toNat = (1 : Word)) :
+    let dividendAbsWord :=
+      sdivAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
+        (dividend.getLimbN 2) (dividend.getLimbN 3)
+    let divisorAbsWord :=
+      sdivAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
+        (divisor.getLimbN 2) (divisor.getLimbN 3)
+    let quotientWord := EvmWord.div dividendAbsWord divisorAbsWord
+    sdivResultSignFixedWord (dividend.getLimbN 3) (divisor.getLimbN 3)
+      (quotientWord.getLimbN 0) (quotientWord.getLimbN 1)
+      (quotientWord.getLimbN 2) (quotientWord.getLimbN 3) =
+      EvmWord.sdiv dividend divisor := by
+  dsimp
+  rw [sdivAbsDividendWord_eq_neg_word_of_sign_one dividend hDividendSign]
+  rw [sdivAbsDivisorWord_eq_neg_word_of_sign_one divisor hDivisorSign]
+  have hResultSign :
+      (dividend.getLimbN 3 >>> (63 : BitVec 6).toNat) ^^^
+        (divisor.getLimbN 3 >>> (63 : BitVec 6).toNat) = (0 : Word) := by
+    rw [hDividendSign, hDivisorSign]
+    bv_decide
+  rw [sdivResultSignFixedWord_eq_word_of_result_sign_zero _ _ _ hResultSign]
+  have hDividendMsb : BitVec.msb dividend = true := by
+    unfold EvmWord.getLimbN EvmWord.getLimb at hDividendSign
+    simp at hDividendSign
+    bv_decide
+  have hDivisorMsb : BitVec.msb divisor = true := by
+    unfold EvmWord.getLimbN EvmWord.getLimb at hDivisorSign
+    simp at hDivisorSign
+    bv_decide
+  unfold EvmWord.div EvmWord.sdiv
+  rw [BitVec.sdiv_eq, hDividendMsb, hDivisorMsb]
+  by_cases hZero : -divisor = 0
+  · simp [hZero]
+  · rw [if_neg hZero]
+
 /-- Top-level zero-divisor SDIV stack bridge with the concrete semantic
     zero-result stack shape.
 


### PR DESCRIPTION
## Summary
- add sign-one word views for SDIV dividend/divisor absolute-value helpers
- add sdivResultSignFixedWord_eq_sdiv_of_negative for the exact path when both operands are negative
- reduce the remaining exact-path hResult work by the same-sign negative semantic subcase

## Verification
- lake build EvmAsm.Evm64.SDiv.Spec
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/Words.lean EvmAsm/Evm64/SDiv/Spec.lean
- scripts/check-file-size.sh EvmAsm/Evm64/SDiv/Compose/Words.lean EvmAsm/Evm64/SDiv/Spec.lean
- scripts/check-unimported.sh
- lake build