### PR TITLE
fix(sdiv): discharge nonnegative negative exact result word

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/Words.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/Words.lean
@@ -208,6 +208,22 @@ theorem sdivResultSignFixedWord_eq_word_of_result_sign_zero
   rw [sdivResultSignFixedWord_of_result_sign_zero _ _ _ _ _ _ hSign]
   exact sdivWord_from_getLimbN quotient
 
+/-- If the SDIV result sign is one, the result-sign-fix helper returns the
+    two's-complement negation of the quotient word. -/
+theorem sdivResultSignFixedWord_eq_neg_word_of_result_sign_one
+    (dividendTop divisorTop : Word) (quotient : EvmWord)
+    (hSign :
+      (dividendTop >>> (63 : BitVec 6).toNat) ^^^
+        (divisorTop >>> (63 : BitVec 6).toNat) = (1 : Word)) :
+    sdivResultSignFixedWord dividendTop divisorTop
+      (quotient.getLimbN 0) (quotient.getLimbN 1)
+      (quotient.getLimbN 2) (quotient.getLimbN 3) = -quotient := by
+  unfold sdivResultSignFixedWord EvmWord.fromLimbs
+  rw [hSign]
+  unfold EvmWord.getLimbN EvmWord.getLimb
+  simp only [Neg.neg]
+  bv_decide
+
 /-- The SDIV divisor absolute-value word is zero when all divisor limbs are
     zero. This discharges the internal bzero-branch hypothesis for the
     caller-visible zero-divisor stack case. -/

--- a/EvmAsm/Evm64/SDiv/Spec.lean
+++ b/EvmAsm/Evm64/SDiv/Spec.lean
@@ -111,6 +111,51 @@ theorem sdivResultSignFixedWord_eq_sdiv_of_negative
   · simp [hZero]
   · rw [if_neg hZero]
 
+/-- Nonnegative/negative exact-path SDIV result bridge.
+
+    When only the divisor is negative, the assembly divisor absolute-value
+    helper produces `-divisor` and result-sign-fix negates the unsigned
+    quotient. This is the `false,true` branch of `BitVec.sdiv_eq`. -/
+theorem sdivResultSignFixedWord_eq_sdiv_of_nonnegative_negative
+    (dividend divisor : EvmWord)
+    (hDividendSign :
+      dividend.getLimbN 3 >>> (63 : BitVec 6).toNat = (0 : Word))
+    (hDivisorSign :
+      divisor.getLimbN 3 >>> (63 : BitVec 6).toNat = (1 : Word)) :
+    let dividendAbsWord :=
+      sdivAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
+        (dividend.getLimbN 2) (dividend.getLimbN 3)
+    let divisorAbsWord :=
+      sdivAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
+        (divisor.getLimbN 2) (divisor.getLimbN 3)
+    let quotientWord := EvmWord.div dividendAbsWord divisorAbsWord
+    sdivResultSignFixedWord (dividend.getLimbN 3) (divisor.getLimbN 3)
+      (quotientWord.getLimbN 0) (quotientWord.getLimbN 1)
+      (quotientWord.getLimbN 2) (quotientWord.getLimbN 3) =
+      EvmWord.sdiv dividend divisor := by
+  dsimp
+  rw [sdivAbsDividendWord_eq_word_of_sign_zero dividend hDividendSign]
+  rw [sdivAbsDivisorWord_eq_neg_word_of_sign_one divisor hDivisorSign]
+  have hResultSign :
+      (dividend.getLimbN 3 >>> (63 : BitVec 6).toNat) ^^^
+        (divisor.getLimbN 3 >>> (63 : BitVec 6).toNat) = (1 : Word) := by
+    rw [hDividendSign, hDivisorSign]
+    bv_decide
+  rw [sdivResultSignFixedWord_eq_neg_word_of_result_sign_one _ _ _ hResultSign]
+  have hDividendMsb : BitVec.msb dividend = false := by
+    unfold EvmWord.getLimbN EvmWord.getLimb at hDividendSign
+    simp at hDividendSign
+    bv_decide
+  have hDivisorMsb : BitVec.msb divisor = true := by
+    unfold EvmWord.getLimbN EvmWord.getLimb at hDivisorSign
+    simp at hDivisorSign
+    bv_decide
+  unfold EvmWord.div EvmWord.sdiv
+  rw [BitVec.sdiv_eq, hDividendMsb, hDivisorMsb]
+  by_cases hZero : -divisor = 0
+  · simp [hZero]
+  · rw [if_neg hZero]
+
 /-- Top-level zero-divisor SDIV stack bridge with the concrete semantic
     zero-result stack shape.
 


### PR DESCRIPTION
## Summary
- add result-sign-one word view for the SDIV result-sign-fix helper
- add sdivResultSignFixedWord_eq_sdiv_of_nonnegative_negative for the exact path when the dividend is nonnegative and divisor is negative
- reduce the remaining exact-path hResult work by another opposite-sign semantic subcase

## Verification
- lake build EvmAsm.Evm64.SDiv.Spec
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/Words.lean EvmAsm/Evm64/SDiv/Spec.lean
- scripts/check-file-size.sh EvmAsm/Evm64/SDiv/Compose/Words.lean EvmAsm/Evm64/SDiv/Spec.lean
- scripts/check-unimported.sh
- lake build