### PR TITLE
fix(sdiv): discharge negative nonnegative exact result word

### DIFF
--- a/EvmAsm/Evm64/SDiv/Spec.lean
+++ b/EvmAsm/Evm64/SDiv/Spec.lean
@@ -156,6 +156,51 @@ theorem sdivResultSignFixedWord_eq_sdiv_of_nonnegative_negative
   · simp [hZero]
   · rw [if_neg hZero]
 
+/-- Negative/nonnegative exact-path SDIV result bridge.
+
+    When only the dividend is negative, the assembly dividend absolute-value
+    helper produces `-dividend` and result-sign-fix negates the unsigned
+    quotient. This is the `true,false` branch of `BitVec.sdiv_eq`. -/
+theorem sdivResultSignFixedWord_eq_sdiv_of_negative_nonnegative
+    (dividend divisor : EvmWord)
+    (hDividendSign :
+      dividend.getLimbN 3 >>> (63 : BitVec 6).toNat = (1 : Word))
+    (hDivisorSign :
+      divisor.getLimbN 3 >>> (63 : BitVec 6).toNat = (0 : Word)) :
+    let dividendAbsWord :=
+      sdivAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
+        (dividend.getLimbN 2) (dividend.getLimbN 3)
+    let divisorAbsWord :=
+      sdivAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
+        (divisor.getLimbN 2) (divisor.getLimbN 3)
+    let quotientWord := EvmWord.div dividendAbsWord divisorAbsWord
+    sdivResultSignFixedWord (dividend.getLimbN 3) (divisor.getLimbN 3)
+      (quotientWord.getLimbN 0) (quotientWord.getLimbN 1)
+      (quotientWord.getLimbN 2) (quotientWord.getLimbN 3) =
+      EvmWord.sdiv dividend divisor := by
+  dsimp
+  rw [sdivAbsDividendWord_eq_neg_word_of_sign_one dividend hDividendSign]
+  rw [sdivAbsDivisorWord_eq_word_of_sign_zero divisor hDivisorSign]
+  have hResultSign :
+      (dividend.getLimbN 3 >>> (63 : BitVec 6).toNat) ^^^
+        (divisor.getLimbN 3 >>> (63 : BitVec 6).toNat) = (1 : Word) := by
+    rw [hDividendSign, hDivisorSign]
+    bv_decide
+  rw [sdivResultSignFixedWord_eq_neg_word_of_result_sign_one _ _ _ hResultSign]
+  have hDividendMsb : BitVec.msb dividend = true := by
+    unfold EvmWord.getLimbN EvmWord.getLimb at hDividendSign
+    simp at hDividendSign
+    bv_decide
+  have hDivisorMsb : BitVec.msb divisor = false := by
+    unfold EvmWord.getLimbN EvmWord.getLimb at hDivisorSign
+    simp at hDivisorSign
+    bv_decide
+  unfold EvmWord.div EvmWord.sdiv
+  rw [BitVec.sdiv_eq, hDividendMsb, hDivisorMsb]
+  by_cases hZero : divisor = 0
+  · simp [hZero]
+  · rw [if_neg hZero]
+
 /-- Top-level zero-divisor SDIV stack bridge with the concrete semantic
     zero-result stack shape.
 


### PR DESCRIPTION
## Summary
- add sdivResultSignFixedWord_eq_sdiv_of_negative_nonnegative for the exact path when the dividend is negative and the divisor is nonnegative
- finish the four sign-case semantic hResult split for the exact SDIV path
- reduce the remaining exact-path hResult work to wiring/case dispatch over operand signs

## Verification
- lake build EvmAsm.Evm64.SDiv.Spec
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/Words.lean EvmAsm/Evm64/SDiv/Spec.lean
- scripts/check-file-size.sh EvmAsm/Evm64/SDiv/Compose/Words.lean EvmAsm/Evm64/SDiv/Spec.lean
- scripts/check-unimported.sh
- lake build