### PR TITLE
fix(divmod): expose store loop j0 no-nop spec

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopBody/StoreLoop.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody/StoreLoop.lean
@@ -106,6 +106,81 @@ theorem divK_store_loop_j0_spec_within
     (fun h hp => by xperm_hyp hp)
     full
 
+/-- Store q[0] + loop exit at j=0 over `divCode_noNop`. Since j' = -1 < 0,
+    BGE is not taken, so this exits to base+908. -/
+theorem divK_store_loop_j0_spec_within_noNop
+    (sp qHat v5Old v7Old qOld : Word)
+    (base : Word) :
+    let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
+    let j' := (0 : Word) + signExtend12 4095
+    cpsTripleWithin 6 (base + storeLoopOff) (base + denormOff) (divCode_noNop base)
+      ((.x1 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+       (.x5 ↦ᵣ v5Old) ** (.x7 ↦ᵣ v7Old) ** (.x0 ↦ᵣ (0 : Word)) **
+       (qAddr ↦ₘ qOld))
+      ((.x1 ↦ᵣ j') ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+       (.x5 ↦ᵣ (0 : Word) <<< (3 : BitVec 6).toNat) ** (.x7 ↦ᵣ qAddr) ** (.x0 ↦ᵣ (0 : Word)) **
+       (qAddr ↦ₘ qHat)) := by
+  intro qAddr j'
+  -- 1. Store q[j]: instrs [109]-[112] at base+884
+  have SQ := divK_store_qj_spec_within sp (0 : Word) qHat v5Old v7Old qOld (base + storeLoopOff)
+  dsimp only [] at SQ
+  rw [lb_sqj] at SQ
+  have SQe := cpsTripleWithin_extend_code (hmono := by
+    exact CodeReq.union_sub (lb_sub_noNop 109 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub_noNop 110 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub_noNop 111 _ _ (by decide) (by bv_addr) (by decide))
+      (lb_sub_noNop 112 _ _ (by decide) (by bv_addr) (by decide))))) SQ
+  -- 2. ADDI x1 x1 4095 at base+900 (instr [113])
+  have haddi := addi_spec_gen_same_within .x1 (0 : Word) 4095 (base + loopControlOff) (by nofun)
+  rw [show (base + loopControlOff : Word) + 4 = base + loopBackBgeOff from by bv_addr] at haddi
+  have haddi_e := cpsTripleWithin_extend_code (hmono := by
+    exact lb_sub_noNop 113 _ _ (by decide) (by bv_addr) (by decide)) haddi
+  -- 3. BGE x1 x0 7736 at base+904 (instr [114])
+  have hbge_raw := bge_spec_gen_within .x1 .x0 (7736 : BitVec 13) j' (0 : Word) (base + loopBackBgeOff)
+  rw [show (base + loopBackBgeOff : Word) + signExtend13 (7736 : BitVec 13) = base + loopBodyOff from by rv64_addr,
+      show (base + loopBackBgeOff : Word) + 4 = base + denormOff from by bv_addr] at hbge_raw
+  have hbge_ext := cpsBranchWithin_extend_code (hmono := by
+    exact lb_sub_noNop 114 _ _ (by decide) (by bv_addr) (by decide)) hbge_raw
+  -- 4. Eliminate taken branch: j' = -1 < 0, so BGE is not taken
+  have hbge_exit_raw := cpsBranchWithin_ntakenPath hbge_ext
+    (fun hp hQt => by
+      obtain ⟨_, _, _, _, _, ⟨_, _, _, _, _, ⟨_, hpure⟩⟩⟩ := hQt
+      exact hpure j0_slt_zero)
+  -- Strip pure fact from not-taken postcondition
+  have hbge_exit := cpsTripleWithin_weaken
+    (fun h hp => hp)
+    (fun h hp => sepConj_mono_right
+      (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hp)
+    hbge_exit_raw
+  -- 5. Build store_qj + x0 frame → base+900
+  have SQx0 : cpsTripleWithin 4 (base + storeLoopOff) (base + loopControlOff) (divCode_noNop base)
+      ((.x1 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+       (.x5 ↦ᵣ v5Old) ** (.x7 ↦ᵣ v7Old) ** (.x0 ↦ᵣ (0 : Word)) ** (qAddr ↦ₘ qOld))
+      ((.x1 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+       (.x5 ↦ᵣ (0 : Word) <<< (3 : BitVec 6).toNat) ** (.x7 ↦ᵣ qAddr) **
+       (.x0 ↦ᵣ (0 : Word)) ** (qAddr ↦ₘ qHat)) :=
+    cpsTripleWithin_weaken
+      (fun h hp => by xperm_hyp hp)
+      (fun h hp => by xperm_hyp hp)
+      (cpsTripleWithin_frameR (.x0 ↦ᵣ (0 : Word)) (by pcFree) SQe)
+  -- 6. Frame ADDI with x0 (BGE needs x0), then frame both with remaining atoms
+  have haddi_x0 := cpsTripleWithin_frameR
+      (.x0 ↦ᵣ (0 : Word)) (by pcFree) haddi_e
+  have addi_bge := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) haddi_x0 hbge_exit
+  have addi_bge_framed := cpsTripleWithin_frameR
+      ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+       (.x5 ↦ᵣ (0 : Word) <<< (3 : BitVec 6).toNat) ** (.x7 ↦ᵣ qAddr) **
+       (qAddr ↦ₘ qHat))
+      (by pcFree) addi_bge
+  -- 7. Compose: store_qj → (ADDI → BGE exit)
+  have full := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) SQx0 addi_bge_framed
+  exact cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by xperm_hyp hp)
+    full
+
 /-- Store q[0] + loop exit at j=0. Since j' = -1 < 0, BGE is not taken,
     so this is a cpsTripleWithin (not cpsBranchWithin) to base+908. -/
 


### PR DESCRIPTION
## Summary
- add divK_store_loop_j0_spec_within_noNop over divCode_noNop
- reuse lb_sub_noNop for the store, ADDI, and BGE loop-exit instructions
- keep the existing shared-code theorem unchanged

## Verification
- lake build EvmAsm.Evm64.DivMod.LoopBody.StoreLoop
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats" EvmAsm/Evm64/DivMod/LoopBody/StoreLoop.lean
- scripts/check-file-size.sh EvmAsm/Evm64/DivMod/LoopBody/StoreLoop.lean
- scripts/check-unimported.sh
- lake build