### PR TITLE
fix(divmod): expose store loop jgt0 no-nop spec

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopBody/StoreLoop.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody/StoreLoop.lean
@@ -260,4 +260,80 @@ theorem divK_store_loop_jgt0_spec_within
     (fun h hp => by xperm_hyp hp)
     full
 
+/-- Store q[j] + loop back at j>0 over `divCode_noNop`. Since j' = j-1 ≥ 0,
+    BGE is taken, so this returns to the loop body. -/
+theorem divK_store_loop_jgt0_spec_within_noNop
+    (sp j qHat v5Old v7Old qOld : Word)
+    (base : Word)
+    (hj_pos : BitVec.slt (j + signExtend12 4095) 0 = false) :
+    let jX8 := j <<< (3 : BitVec 6).toNat
+    let qAddr := sp + signExtend12 4088 - jX8
+    let j' := j + signExtend12 4095
+    cpsTripleWithin 6 (base + storeLoopOff) (base + loopBodyOff) (divCode_noNop base)
+      ((.x1 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+       (.x5 ↦ᵣ v5Old) ** (.x7 ↦ᵣ v7Old) ** (.x0 ↦ᵣ (0 : Word)) **
+       (qAddr ↦ₘ qOld))
+      ((.x1 ↦ᵣ j') ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+       (.x5 ↦ᵣ jX8) ** (.x7 ↦ᵣ qAddr) ** (.x0 ↦ᵣ (0 : Word)) **
+       (qAddr ↦ₘ qHat)) := by
+  intro jX8 qAddr j'
+  -- 1. Store q[j]: instrs [109]-[112] at base+884
+  have SQ := divK_store_qj_spec_within sp j qHat v5Old v7Old qOld (base + storeLoopOff)
+  dsimp only [] at SQ
+  rw [lb_sqj] at SQ
+  have SQe := cpsTripleWithin_extend_code (hmono := by
+    exact CodeReq.union_sub (lb_sub_noNop 109 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub_noNop 110 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub_noNop 111 _ _ (by decide) (by bv_addr) (by decide))
+      (lb_sub_noNop 112 _ _ (by decide) (by bv_addr) (by decide))))) SQ
+  -- 2. ADDI x1 x1 4095 at base+900 (instr [113])
+  have haddi := addi_spec_gen_same_within .x1 j 4095 (base + loopControlOff) (by nofun)
+  rw [show (base + loopControlOff : Word) + 4 = base + loopBackBgeOff from by bv_addr] at haddi
+  have haddi_e := cpsTripleWithin_extend_code (hmono := by
+    exact lb_sub_noNop 113 _ _ (by decide) (by bv_addr) (by decide)) haddi
+  -- 3. BGE x1 x0 7736 at base+904 (instr [114])
+  have hbge_raw := bge_spec_gen_within .x1 .x0 (7736 : BitVec 13) j' (0 : Word) (base + loopBackBgeOff)
+  rw [show (base + loopBackBgeOff : Word) + signExtend13 (7736 : BitVec 13) = base + loopBodyOff from by rv64_addr,
+      show (base + loopBackBgeOff : Word) + 4 = base + denormOff from by bv_addr] at hbge_raw
+  have hbge_ext := cpsBranchWithin_extend_code (hmono := by
+    exact lb_sub_noNop 114 _ _ (by decide) (by bv_addr) (by decide)) hbge_raw
+  -- 4. Eliminate not-taken branch: j' = j-1 ≥ 0, so BGE is taken
+  have hbge_exit_raw := cpsBranchWithin_takenPath hbge_ext
+    (fun hp hQf => by
+      obtain ⟨_, _, _, _, _, ⟨_, _, _, _, _, ⟨_, hpure⟩⟩⟩ := hQf
+      exact absurd hpure (by rw [hj_pos]; exact Bool.false_ne_true))
+  -- Strip pure fact from taken postcondition
+  have hbge_exit := cpsTripleWithin_weaken
+    (fun h hp => hp)
+    (fun h hp => sepConj_mono_right
+      (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hp)
+    hbge_exit_raw
+  -- 5. Build store_qj + x0 frame → base+900
+  have SQx0 : cpsTripleWithin 4 (base + storeLoopOff) (base + loopControlOff) (divCode_noNop base)
+      ((.x1 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+       (.x5 ↦ᵣ v5Old) ** (.x7 ↦ᵣ v7Old) ** (.x0 ↦ᵣ (0 : Word)) ** (qAddr ↦ₘ qOld))
+      ((.x1 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+       (.x5 ↦ᵣ jX8) ** (.x7 ↦ᵣ qAddr) ** (.x0 ↦ᵣ (0 : Word)) ** (qAddr ↦ₘ qHat)) :=
+    cpsTripleWithin_weaken
+      (fun h hp => by xperm_hyp hp)
+      (fun h hp => by xperm_hyp hp)
+      (cpsTripleWithin_frameR (.x0 ↦ᵣ (0 : Word)) (by pcFree) SQe)
+  -- 6. Frame ADDI with x0, then frame both with remaining atoms
+  have haddi_x0 := cpsTripleWithin_frameR
+      (.x0 ↦ᵣ (0 : Word)) (by pcFree) haddi_e
+  have addi_bge := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) haddi_x0 hbge_exit
+  have addi_bge_framed := cpsTripleWithin_frameR
+      ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+       (.x5 ↦ᵣ jX8) ** (.x7 ↦ᵣ qAddr) **
+       (qAddr ↦ₘ qHat))
+      (by pcFree) addi_bge
+  -- 7. Compose: store_qj → (ADDI → BGE exit)
+  have full := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) SQx0 addi_bge_framed
+  exact cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by xperm_hyp hp)
+    full
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add divK_store_loop_jgt0_spec_within_noNop over divCode_noNop
- reuse lb_sub_noNop for the store, ADDI, and BGE loop-back instructions
- pair with the j=0 no-NOP StoreLoop theorem from the parent PR

## Verification
- lake build EvmAsm.Evm64.DivMod.LoopBody.StoreLoop
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats" EvmAsm/Evm64/DivMod/LoopBody/StoreLoop.lean
- scripts/check-file-size.sh EvmAsm/Evm64/DivMod/LoopBody/StoreLoop.lean
- scripts/check-unimported.sh
- lake build