### PR TITLE
fix(divmod): expose correction skip no-nop spec

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopBody/CorrectionSkip.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody/CorrectionSkip.lean
@@ -72,4 +72,53 @@ theorem divK_correction_skip_spec_within
     (fun h hp => by xperm_hyp hp)
     skip_framed
 
+/-- Correction skip over `divCode_noNop`: when borrow=0, BEQ taken → jump
+    to base+884. No addback. -/
+theorem divK_correction_skip_spec_within_noNop
+    (sp uBase qHat v0 v1 v2 v3 u0 u1 u2 u3 u4 : Word)
+    (v5Old v2Old : Word) (base : Word) :
+    cpsTripleWithin 1 (base + correctionSkipBeqOff) (base + storeLoopOff) (divCode_noNop base)
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ uBase) ** (.x7 ↦ᵣ (0 : Word)) **
+       (.x11 ↦ᵣ qHat) ** (.x5 ↦ᵣ v5Old) ** (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ u4))
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ uBase) ** (.x7 ↦ᵣ (0 : Word)) **
+       (.x11 ↦ᵣ qHat) ** (.x5 ↦ᵣ v5Old) ** (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ u4)) := by
+  have hbeq := beq_spec_gen_within .x7 .x0 (156 : BitVec 13) (0 : Word) 0 (base + correctionSkipBeqOff)
+  rw [lb_beq_taken, lb_beq_ntaken] at hbeq
+  have hbeq_ext := cpsBranchWithin_extend_code (hmono :=
+    lb_sub_noNop 70 _ _ (by decide) (by bv_addr) (by decide)) hbeq
+  have skip := cpsBranchWithin_takenPath hbeq_ext (fun hp hQf => by
+    obtain ⟨_, _, _, _, _, ⟨_, _, _, _, _, ⟨_, hpure⟩⟩⟩ := hQf
+    exact hpure rfl)
+  have skip_clean : cpsTripleWithin 1 (base + correctionSkipBeqOff) (base + storeLoopOff) (divCode_noNop base)
+      ((.x7 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)))
+      ((.x7 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word))) :=
+    cpsTripleWithin_weaken
+      (fun h hp => hp)
+      (fun h hp => sepConj_mono_right
+        (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hp)
+      skip
+  have skip_framed := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ uBase) **
+     (.x11 ↦ᵣ qHat) ** (.x5 ↦ᵣ v5Old) ** (.x2 ↦ᵣ v2Old) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((uBase + signExtend12 4064) ↦ₘ u4))
+    (by pcFree) skip_clean
+  exact cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by xperm_hyp hp)
+    skip_framed
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add divK_correction_skip_spec_within_noNop over divCode_noNop
- reuse the existing BEQ taken proof with the no-NOP loop-body singleton inclusion
- prepare mulsub-correction-skip and N=1 loop-branch no-NOP compositions

## Verification
- lake build EvmAsm.Evm64.DivMod.LoopBody.CorrectionSkip
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/LoopBody/CorrectionSkip.lean
- scripts/check-file-size.sh EvmAsm/Evm64/DivMod/LoopBody/CorrectionSkip.lean
- scripts/check-unimported.sh
- lake build