### PR TITLE
fix(divmod): expose n1 iter210 unified no-nop spec

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopUnifiedN1.lean
+++ b/EvmAsm/Evm64/DivMod/LoopUnifiedN1.lean
@@ -995,6 +995,51 @@ theorem divK_loop_n1_iter210_unified_spec_within (bltu_2 bltu_1 bltu_0 : Bool)
 
       hbltu_2' hbltu_1 hbltu_0 hcarry2
 
+theorem divK_loop_n1_iter210_unified_spec_within_noNop (bltu_2 bltu_1 bltu_0 : Bool)
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop
+     u0_orig_1 u0_orig_0
+     q2Old q1Old q0Old : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu_2 : bltu_2 = BitVec.ult u1 v0)
+    (hbltu_1 : bltu_1 = BitVec.ult (iterN1 bltu_2 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v0)
+    (hbltu_0 : bltu_0 = BitVec.ult (iterN1 bltu_1 v0 v1 v2 v3 u0_orig_1
+      (iterN1 bltu_2 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterN1 bltu_2 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN1 bltu_2 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterN1 bltu_2 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.1 v0)
+    (hcarry2 : Carry2NzAll v0 v1 v2 v3) :
+    cpsTripleWithin 606 (base + loopBodyOff) (base + denormOff) (divCode_noNop base)
+      (loopN1Iter210PreWithScratch sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop
+        u0_orig_1 u0_orig_0 q2Old q1Old q0Old
+        retMem dMem dloMem scratch_un0)
+      (loopN1Iter210Post bltu_2 bltu_1 bltu_0 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop
+        u0_orig_1 u0_orig_0 retMem dMem dloMem scratch_un0) := by
+  cases bltu_2 <;> simp only [iterN1_true, iterN1_false] at hbltu_1 hbltu_0
+  · -- bltu_2 = false -> max
+    have hbltu_2' : ¬BitVec.ult u1 v0 := by
+      rw [show BitVec.ult u1 v0 = false from hbltu_2.symm]; decide
+    exact cpsTripleWithin_mono_nSteps (by decide) <|
+      divK_loop_n1_max_iter10_spec_within_noNop bltu_1 bltu_0
+      sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig_1 u0_orig_0 q2Old q1Old q0Old
+      retMem dMem dloMem scratch_un0 base halign
+
+
+      hbltu_2' hbltu_1 hbltu_0 hcarry2
+  · -- bltu_2 = true -> call
+    have hbltu_2' : BitVec.ult u1 v0 := hbltu_2.symm ▸ rfl
+    exact divK_loop_n1_call_iter10_spec_within_noNop bltu_1 bltu_0
+      sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig_1 u0_orig_0 q2Old q1Old q0Old
+      retMem dMem dloMem scratch_un0 base halign
+
+
+      hbltu_2' hbltu_1 hbltu_0 hcarry2
+
 -- ============================================================================
 -- Full four-iteration : compose j=3 with iter210 -- separate lemmas per case
 -- Postcondition uses @[irreducible] loopN1UnifiedPost


### PR DESCRIPTION
## Summary
- add `divK_loop_n1_iter210_unified_spec_within_noNop`
- dispatch the three-iteration N=1 unified no-NOP composition through the max/call iter10 no-NOP specs
- keep this as the dispatch layer before the final four-iteration no-NOP wrappers

## Verification
- `lake build EvmAsm.Evm64.DivMod.LoopUnifiedN1`
- `lake build EvmAsm.Evm64.DivMod`
- `git diff --check`
- diff-only scan for new `sorry`/`admit`/`set_option maxHeartbeats`/`set_option maxRecDepth`
- `scripts/check-file-size.sh EvmAsm/Evm64/DivMod/LoopUnifiedN1.lean`
- `scripts/check-unimported.sh`
- `lake build`