### PR TITLE
fix(divmod): expose n4 normb no-nop spec

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPath.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPath.lean
@@ -187,6 +187,66 @@ theorem evm_div_n4_to_normB_spec (sp base : Word)
     (fun h hq => by delta normBPost; xperm_hyp hq)
     hFull
 
+/-- PhaseAB(n=4) + CLZ + PhaseC2(shift≠0) + NormB over `divCode_noNop`.
+    base → base+312. b[0..3] normalized in-place. -/
+theorem evm_div_n4_to_normB_spec_noNop (sp base : Word)
+    (b0 b1 b2 b3 v5 v6 v7 v10 : Word)
+    (q0 q1 q2 q3 u5 u6 u7 nMem shiftMem : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3nz : b3 ≠ 0)
+    (hshift_nz : (clzResult b3).1 ≠ 0) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21) base (base + normAOff) (divCode_noNop base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
+      (normBPost sp (4 : Word) (clzResult b3).1 b0 b1 b2 b3) := by
+  let shift := (clzResult b3).1
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  have hABCLZ := evm_div_phaseAB_n4_clz_spec_noNop sp base b0 b1 b2 b3 v5 v6 v7 v10
+    q0 q1 q2 q3 u5 u6 u7 nMem hbnz hb3nz
+  have hABCLZf := cpsTripleWithin_frameR
+    ((.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
+     ((sp + signExtend12 3992) ↦ₘ shiftMem))
+    (by pcFree) hABCLZ
+  have hC2 := divK_phaseC2_ntaken_spec_within_noNop sp shift ((clzResult b3).2 >>> (63 : Nat))
+    shiftMem base hshift_nz
+  have hC2f := cpsTripleWithin_frameR
+    ((.x5 ↦ᵣ (clzResult b3).2) ** (.x10 ↦ᵣ b3) **
+     (.x7 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
+     ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+     ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (4 : Word)))
+    (by pcFree) hC2
+  have hABC2 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hABCLZf hC2f
+  have hNB := divK_normB_full_spec_within_noNop sp b0 b1 b2 b3
+    (clzResult b3).2 ((clzResult b3).2 >>> (63 : Nat))
+    shift antiShift base
+  intro_lets at hNB
+  have hNBf := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (4 : Word)) **
+     ((sp + signExtend12 3992) ↦ₘ shift))
+    (by pcFree) hNB
+  have hFull := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hABC2 hNBf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by delta normBPost; xperm_hyp hq)
+    hFull
+
 -- ============================================================================
 -- Full n=4 path to LoopSetup: base → base+448
 -- Composes: PhaseAB → CLZ → PhaseC2(ntaken) → NormB → NormA → LoopSetup(ntaken)


### PR DESCRIPTION
## Summary
- add evm_div_n4_to_normB_spec_noNop in FullPath
- compose the N=4 PhaseAB+CLZ no-NOP proof from #4240 with existing PhaseC2 and NormB no-NOP specs
- unblock a future N=4 to_loopSetup no-NOP prefix for full DIV no-NOP composition

## Verification
- lake build EvmAsm.Evm64.DivMod.Compose.FullPath
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- diff-only scan for sorry/admit/set_option additions
- scripts/check-file-size.sh EvmAsm/Evm64/DivMod/Compose/FullPath.lean
- scripts/check-unimported.sh
- lake build