### PR TITLE
fix(divmod): expose n4 call stack no-nop spec

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/CallAddbackNoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/CallAddbackNoNop.lean
@@ -125,4 +125,35 @@ theorem evm_div_n4_call_addback_beq_stack_spec_noNop (sp base : Word)
   rw [word_add_zero] at hq
   xperm_hyp hq
 
+/-- No-NOP variant of `evm_div_n4_call_stack_spec`. -/
+theorem evm_div_n4_call_stack_spec_noNop (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratch_un0 : Word)
+    (hbnz : b ≠ 0)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : isCallTrialN4Evm a b)
+    (hcarry2_nz_addback :
+      isAddbackBorrowN4CallEvm a b → isAddbackCarry2NzN4CallEvm a b)
+    (hsem_addback :
+      isAddbackBorrowN4CallEvm a b → n4CallAddbackBeqSemanticHolds a b) :
+    cpsTripleWithin 340 base (base + nopOff) (divCode_noNop base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratch_un0)
+      (divN4CallSkipStackPost sp a b) := by
+  rcases isSkipBorrowN4CallEvm_or_isAddbackBorrowN4CallEvm a b with hskip | haddback
+  · exact cpsTripleWithin_mono_nSteps (by decide) <|
+      evm_div_n4_call_skip_stack_spec_unconditional_noNop sp base a b
+      v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      nMem shiftMem jMem retMem dMem dloMem scratch_un0
+      hbnz hb3nz hshift_nz halign hbltu hskip
+  · exact evm_div_n4_call_addback_beq_stack_spec_noNop sp base a b
+      v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      nMem shiftMem jMem retMem dMem dloMem scratch_un0
+      hbnz hb3nz hshift_nz halign hbltu
+      (hcarry2_nz_addback haddback) haddback (hsem_addback haddback)
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add the no-NOP n=4 shift-nonzero DIV call dispatcher stack theorem
- dispatch between the existing no-NOP call-skip stack theorem and the no-NOP call+addback-BEQ theorem from the parent PR

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.CallAddbackNoNop
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- diff-only forbidden scan for sorry/admit/set_option maxHeartbeats/set_option maxRecDepth
- scripts/check-file-size.sh EvmAsm/Evm64/DivMod/Spec/CallAddbackNoNop.lean
- scripts/check-unimported.sh
- lake build