### PR TITLE
fix(divmod): expose n4 stack-within no-nop spec

### DIFF
--- a/EvmAsm/Evm64/DivMod/N4StackSpecWithin.lean
+++ b/EvmAsm/Evm64/DivMod/N4StackSpecWithin.lean
@@ -68,6 +68,42 @@ theorem evm_div_n4_stack_spec_within_dispatch (sp base : Word)
       exact hq)
     hN4
 
+/-- No-NOP dispatcher-surface wrapper for the n=4 DIV path. -/
+theorem evm_div_n4_stack_spec_within_dispatch_noNop (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratch_un0 : Word)
+    (hbnz : b ≠ 0)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : isCallTrialN4Evm a b)
+    (hcarry2_nz_addback :
+      isAddbackBorrowN4CallEvm a b → isAddbackCarry2NzN4CallEvm a b)
+    (hsem_addback :
+      isAddbackBorrowN4CallEvm a b → n4CallAddbackBeqSemanticHolds a b) :
+    cpsTripleWithin 340 base (base + nopOff) (divCode_noNop base)
+      (divModStackDispatchPre sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word))
+        ((clzResult (b.getLimbN 3)).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0)
+      (divStackDispatchPost sp a b) := by
+  have hN4 := evm_div_n4_stack_spec_noNop sp base a b
+    v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratch_un0
+    hbnz hb3nz halign hbltu hcarry2_nz_addback hsem_addback
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by
+      delta divModStackDispatchPre at hp
+      rw [divN4StackPreCall_unfold]
+      xperm_hyp hp)
+    (fun _ hq => by
+      rw [divN4CallSkipStackPost_unfold] at hq
+      rw [divStackDispatchPost_unfold]
+      exact hq)
+    hN4
+
 /-- Dispatcher-surface wrapper for the n=4 MOD path. Mirror of
     `evm_div_n4_stack_spec_within`. -/
 theorem evm_mod_n4_stack_spec_within_dispatch (sp base : Word)


### PR DESCRIPTION
## Summary
- add evm_div_n4_stack_spec_within_dispatch_noNop over divCode_noNop
- bridge the new evm_div_n4_stack_spec_noNop into divModStackDispatchPre / divStackDispatchPost

## Verification
- lake build EvmAsm.Evm64.DivMod.N4StackSpecWithin
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- diff-only forbidden scan for sorry/admit/set_option maxHeartbeats/set_option maxRecDepth
- scripts/check-file-size.sh EvmAsm/Evm64/DivMod/N4StackSpecWithin.lean
- scripts/check-unimported.sh
- lake build