### PR TITLE
fix(divmod): expose n3 call addback j1 no-nop spec

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopIterN3NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN3NoNop.lean
@@ -204,4 +204,122 @@ theorem divK_loop_body_n3_call_addback_beq_j0_spec_within_noNop
       rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full
 
+/-- No-NOP variant of `divK_loop_body_n3_call_addback_beq_j1_spec_within`. -/
+theorem divK_loop_body_n3_call_addback_beq_j1_spec_within_noNop
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : BitVec.ult u3 v2)
+    (hborrow : isAddbackBorrowN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hcarry2_nz : isAddbackCarry2NzN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+    cpsTripleWithin 202 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop base)
+      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
+       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
+       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
+       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
+       (qAddr ↦ₘ qOld) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
+       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+      (loopBodyN3CallAddbackBeqPostJ sp base (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro uBase qAddr
+  let dHi := v2 >>> (32 : BitVec 6).toNat
+  let dLo := (v2 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  let div_un1 := u2 >>> (32 : BitVec 6).toNat
+  let div_un0 := (u2 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  let q1 := rv64_divu u3 dHi; let rhat := u3 - q1 * dHi
+  let hi1 := q1 >>> (32 : BitVec 6).toNat
+  let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
+  let rhatc := if hi1 = 0 then rhat else rhat + dHi
+  let qDlo := q1c * dLo
+  let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
+  let q1' := if BitVec.ult rhatUn1 qDlo then q1c + signExtend12 4095 else q1c
+  let rhat' := if BitVec.ult rhatUn1 qDlo then rhatc + dHi else rhatc
+  let cu_rhat_un1 := (rhat' <<< (32 : BitVec 6).toNat) ||| div_un1
+  let cu_q1_dlo := q1' * dLo
+  let un21 := cu_rhat_un1 - cu_q1_dlo
+  let q0 := rv64_divu un21 dHi; let rhat2 := un21 - q0 * dHi
+  let hi2 := q0 >>> (32 : BitVec 6).toNat
+  let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
+  let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
+  let q0Dlo := q0c * dLo
+  let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
+  let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
+  let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
+  let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
+  let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
+  let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
+  unfold isAddbackBorrowN3Call div128Quot at hborrow
+  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+  let c3 := ms.2.2.2.2
+  let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
+  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
+  let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
+  let q_out := if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
+               else qHat + signExtend12 4095
+  let un0Out := if carry = 0 then ab'.1 else ab.1
+  let un1Out := if carry = 0 then ab'.2.1 else ab.2.1
+  let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
+  let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
+  let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
+  let carryOut := if carry = 0 then
+      addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
+    else carry
+  have TF := divK_trial_call_full_spec_within_noNop sp (1 : Word) (3 : Word) jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    u3 u2 v2 retMem dMem dloMem scratch_un0 base
+    halign hbltu
+  unfold divKTrialCallFullPost at TF
+  dsimp only [] at TF
+  rw [u_addr_eq_n3] at TF
+  rw [u_addr8_eq_n3] at TF
+  rw [vtop_eq_v2_n3] at TF
+  have MCA := divK_mulsub_correction_addback_beq_spec_within_noNop sp qHat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    x1Exit q0' dHi x7Exit q1' (base + div128CallRetOff) base
+  intro_lets at MCA
+  unfold isAddbackCarry2NzN3Call isAddbackCarry2Nz div128Quot at hcarry2_nz
+  have MCA0 := MCA hcarry2_nz hborrow
+  have SL := divK_store_loop_jgt0_spec_within_noNop sp (1 : Word) q_out u4_out carryOut qOld base slt_jpos_1
+  intro_lets at SL
+  have TFf := cpsTripleWithin_frameR
+    (((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
+     (qAddr ↦ₘ qOld))
+    (by pcFree) TF
+  seqFrame TFf MCA0
+  have SLf := cpsTripleWithin_frameR
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
+     (sp + signExtend12 3976 ↦ₘ (1 : Word)) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0Out) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1Out) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2Out) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3Out) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_out) **
+     (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
+     (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+     (sp + signExtend12 3960 ↦ₘ v2) **
+     (sp + signExtend12 3952 ↦ₘ dLo) **
+     (sp + signExtend12 3944 ↦ₘ div_un0))
+    (by pcFree) SL
+  have full := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
+  exact cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by
+      delta loopBodyN3CallAddbackBeqPostJ div128Quot div128DLo div128Un0
+            loopBodyN3AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN3 loopExitPost
+      rw [sepConj_assoc'] at hp; xperm_hyp hp)
+    full
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- adds the no-NOP theorem for the n=3 call addback+BEQ j=1 loop-body path
- composes no-NOP trial-call, mulsub correction addback+BEQ, and store-loop j>0 specs
- extends the existing LoopIterN3NoNop split module without touching the oversized LoopIterN3 file

## Verification
- lake build EvmAsm.Evm64.DivMod.LoopIterN3NoNop
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- diff-only forbidden scan for sorry/admit/set_option maxHeartbeats/set_option maxRecDepth
- scripts/check-file-size.sh EvmAsm/Evm64/DivMod/LoopIterN3NoNop.lean
- scripts/check-unimported.sh
- lake build