### PR TITLE
fix(divmod): expose n3 loop divcode no-nop spec

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3Loop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3Loop.lean
@@ -87,3 +87,26 @@ theorem divK_loop_n3_unified_divCode (bltu_1 bltu_0 : Bool)
       v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
       retMem dMem dloMem scratch_un0 base halign
       hbltu_1 hbltu_0 hcarry2)
+
+/-- No-NOP variant of `divK_loop_n3_unified_divCode`. -/
+theorem divK_loop_n3_unified_divCode_noNop (bltu_1 bltu_0 : Bool)
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu_1 : bltu_1 = BitVec.ult u3 v2)
+    (hbltu_0 : bltu_0 = BitVec.ult (iterN3 bltu_1 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1 v2)
+    (hcarry2 : Carry2NzAll v0 v1 v2 v3) :
+    cpsTripleWithin 404 (base + loopBodyOff) (base + denormOff) (divCode_noNop base)
+      (loopN3PreWithScratch sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+        retMem dMem dloMem scratch_un0)
+      (loopN3UnifiedPost bltu_1 bltu_0 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig
+        retMem dMem dloMem scratch_un0) :=
+  cpsTripleWithin_mono_nSteps (by decide) <|
+    divK_loop_n3_unified_spec_within_noNop bltu_1 bltu_0
+      sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+      retMem dMem dloMem scratch_un0 base halign
+      hbltu_1 hbltu_0 hcarry2


### PR DESCRIPTION
## Summary
- adds divK_loop_n3_unified_divCode_noNop
- bridges the Bool-parameterized n=3 loop proof to divCode_noNop using the no-NOP unified loop theorem
- prepares the full n=3 preloop+loop no-NOP composition to call a divCode_noNop loop spec directly

## Verification
- lake build EvmAsm.Evm64.DivMod.Compose.FullPathN3Loop
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- diff-only forbidden scan for sorry/admit/set_option maxHeartbeats/set_option maxRecDepth
- scripts/check-file-size.sh EvmAsm/Evm64/DivMod/Compose/FullPathN3Loop.lean
- scripts/check-unimported.sh
- lake build