### PR TITLE
fix(divmod): expose n2 jgt0 call skip no-nop spec

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopIterN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN2.lean
@@ -770,6 +770,127 @@ theorem divK_loop_body_n2_call_skip_jgt0_spec_within (j : Word)
       rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full
 
+/-- No-NOP variant of `divK_loop_body_n2_call_skip_jgt0_spec_within`. -/
+theorem divK_loop_body_n2_call_skip_jgt0_spec_within_noNop (j : Word)
+    (hpos : BitVec.slt (j + signExtend12 4095) 0 = false)
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : BitVec.ult u2 v1)
+    (hborrow : isSkipBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+    let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
+    cpsTripleWithin 126 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop base)
+      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
+       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
+       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
+       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
+       (qAddr ↦ₘ qOld) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
+       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+      (loopBodyN2CallSkipPostJ sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro uBase qAddr
+  let dHi := v1 >>> (32 : BitVec 6).toNat
+  let dLo := (v1 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  let div_un1 := u1 >>> (32 : BitVec 6).toNat
+  let div_un0 := (u1 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  let q1 := rv64_divu u2 dHi; let rhat := u2 - q1 * dHi
+  let hi1 := q1 >>> (32 : BitVec 6).toNat
+  let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
+  let rhatc := if hi1 = 0 then rhat else rhat + dHi
+  let qDlo := q1c * dLo
+  let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
+  let q1' := if BitVec.ult rhatUn1 qDlo then q1c + signExtend12 4095 else q1c
+  let rhat' := if BitVec.ult rhatUn1 qDlo then rhatc + dHi else rhatc
+  let cu_rhat_un1 := (rhat' <<< (32 : BitVec 6).toNat) ||| div_un1
+  let cu_q1_dlo := q1' * dLo
+  let un21 := cu_rhat_un1 - cu_q1_dlo
+  let q0 := rv64_divu un21 dHi; let rhat2 := un21 - q0 * dHi
+  let hi2 := q0 >>> (32 : BitVec 6).toNat
+  let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
+  let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
+  let q0Dlo := q0c * dLo
+  let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
+  let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
+  let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
+  let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
+  let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
+  let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
+  unfold isSkipBorrowN2Call div128Quot at hborrow
+  let vtopBase := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  have TF := divK_trial_call_full_spec_within_noNop sp j (2 : Word) jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    u2 u1 v1 retMem dMem dloMem scratch_un0 base
+    halign hbltu
+  unfold divKTrialCallFullPost at TF
+  dsimp only [] at TF
+  rw [u_addr_eq_n2] at TF
+  rw [u_addr8_eq_n2] at TF
+  rw [vtop_eq_v1_n2] at TF
+  have MCS := divK_mulsub_correction_skip_spec_within_noNop sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    x1Exit q0' dHi x7Exit q1' (base + div128CallRetOff) base
+  intro_lets at MCS
+  have MCS0 := MCS hborrow
+  let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
+  let fs0 := p0_lo + (signExtend12 0 : Word)
+  let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
+  let pc0 := ba0 + p0_hi; let bs0 := if BitVec.ult u0 fs0 then (1 : Word) else 0
+  let un0 := u0 - fs0; let c0 := pc0 + bs0
+  let p1_lo := qHat * v1; let p1_hi := rv64_mulhu qHat v1
+  let fs1 := p1_lo + c0; let ba1 := if BitVec.ult fs1 c0 then (1 : Word) else 0
+  let pc1 := ba1 + p1_hi; let bs1 := if BitVec.ult u1 fs1 then (1 : Word) else 0
+  let un1 := u1 - fs1; let c1 := pc1 + bs1
+  let p2_lo := qHat * v2; let p2_hi := rv64_mulhu qHat v2
+  let fs2 := p2_lo + c1; let ba2 := if BitVec.ult fs2 c1 then (1 : Word) else 0
+  let pc2 := ba2 + p2_hi; let bs2 := if BitVec.ult u2 fs2 then (1 : Word) else 0
+  let un2 := u2 - fs2; let c2 := pc2 + bs2
+  let p3_lo := qHat * v3; let p3_hi := rv64_mulhu qHat v3
+  let fs3 := p3_lo + c2; let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
+  let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
+  let un3 := u3 - fs3; let c3 := pc3 + bs3
+  let u4_new := uTop - c3
+  have SL := divK_store_loop_jgt0_spec_within_noNop sp j qHat u4_new (0 : Word) qOld base hpos
+  intro_lets at SL
+  have TFf := cpsTripleWithin_frameR
+    (((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
+     (qAddr ↦ₘ qOld))
+    (by pcFree) TF
+  seqFrame TFf MCS0
+  have SLf := cpsTripleWithin_frameR
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
+     (sp + signExtend12 3976 ↦ₘ j) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_new) **
+     (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
+     (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+     (sp + signExtend12 3960 ↦ₘ v1) **
+     (sp + signExtend12 3952 ↦ₘ dLo) **
+     (sp + signExtend12 3944 ↦ₘ div_un0))
+    (by pcFree) SL
+  have full := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
+  exact cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by
+      delta loopBodyN2CallSkipPostJ div128Quot div128DLo div128Un0
+            loopBodyN2SkipPost loopBodySkipPost mulsubN4 loopExitPostN2 loopExitPost
+      rw [sepConj_assoc'] at hp; xperm_hyp hp)
+    full
+
 
 -- ============================================================================
 -- BEQ variants: double-addback handling (no sorry)


### PR DESCRIPTION
## Summary
- adds divK_loop_body_n2_call_skip_jgt0_spec_within_noNop
- mirrors the existing parametric n=2 j>0 call-skip proof over divCode_noNop
- continues filling n=2 loop no-NOP leaf specs needed before the unified no-NOP loop wrapper

## Verification
- lake build EvmAsm.Evm64.DivMod.LoopIterN2
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- diff-only forbidden scan for sorry/admit/set_option maxHeartbeats/set_option maxRecDepth
- scripts/check-file-size.sh EvmAsm/Evm64/DivMod/LoopIterN2.lean
- scripts/check-unimported.sh
- lake build