### PR TITLE
fix(divmod): expose n2 j2 max unified no-nop spec

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopComposeN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopComposeN2.lean
@@ -15,6 +15,7 @@
 -/
 
 import EvmAsm.Evm64.DivMod.LoopIterN2
+import EvmAsm.Evm64.DivMod.LoopIterN2NoNop
 import EvmAsm.Evm64.DivMod.LoopComposeN3
 
 open EvmAsm.Rv64.Tactics
@@ -104,6 +105,56 @@ theorem divK_loop_body_n2_max_unified_j2_spec_within
     have hborrow : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
                     then (1 : Word) else 0) = (0 : Word) := if_neg hb
     have J2 := divK_loop_body_n2_max_skip_jgt0_spec_within (2 : Word)
+      EvmAsm.Evm64.DivMod.AddrNorm.slt_jpos_2
+      sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base hbltu
+    intro_lets at J2
+    exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+      (fun h hp => hp)
+      (fun h hp => by
+        rw [← loopIterPostN2Max_skip hb]; exact hp)
+      (J2 hborrow)
+
+/-- No-NOP variant of `divK_loop_body_n2_max_unified_j2_spec_within`. -/
+theorem divK_loop_body_n2_max_unified_j2_spec_within_noNop
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (base : Word)
+    (hbltu : ¬BitVec.ult u2 v1)
+    (hcarry2_nz : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    let uBase := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
+    cpsTripleWithin 152 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop base)
+      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (2 : Word)) **
+       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
+       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
+       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
+       (qAddr ↦ₘ qOld))
+      (loopIterPostN2Max sp (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro uBase qAddr
+  by_cases hb : BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+  · have hborrow : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+                    then (1 : Word) else 0) ≠ (0 : Word) := by rw [if_pos hb]; decide
+    have J2 := divK_loop_body_n2_max_addback_jgt0_beq_spec_within_noNop (2 : Word)
+      EvmAsm.Evm64.DivMod.AddrNorm.slt_jpos_2
+      sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base hbltu
+      hcarry2_nz
+    intro_lets at J2
+    exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+      (fun h hp => hp)
+      (fun h hp => by
+        rw [← loopIterPostN2Max_addback hb]; exact hp)
+      (J2 hborrow)
+  · have hborrow : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+                    then (1 : Word) else 0) = (0 : Word) := if_neg hb
+    have J2 := divK_loop_body_n2_max_skip_jgt0_spec_within_noNop (2 : Word)
       EvmAsm.Evm64.DivMod.AddrNorm.slt_jpos_2
       sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base hbltu


### PR DESCRIPTION
## Summary
- imports LoopIterN2NoNop into LoopComposeN2
- adds divK_loop_body_n2_max_unified_j2_spec_within_noNop over divCode_noNop
- starts the n=2 compose-level no-NOP unified wrappers after completing the n=2 leaf wrappers

## Verification
- lake build EvmAsm.Evm64.DivMod.LoopComposeN2
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- diff-only forbidden scan for sorry/admit/set_option maxHeartbeats/set_option maxRecDepth
- scripts/check-file-size.sh EvmAsm/Evm64/DivMod/LoopComposeN2.lean
- scripts/check-unimported.sh
- lake build