### PR TITLE
fix(divmod): expose n2 j1 call unified no-nop spec

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopComposeN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopComposeN2.lean
@@ -555,6 +555,65 @@ theorem divK_loop_body_n2_call_unified_j1_spec_within
         rw [← loopIterPostN2Call_skip hb]; exact hp)
       J1
 
+/-- No-NOP variant of `divK_loop_body_n2_call_unified_j1_spec_within`. -/
+theorem divK_loop_body_n2_call_unified_j1_spec_within_noNop
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : BitVec.ult u2 v1)
+    (hcarry2_nz : isAddbackCarry2NzN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+    cpsTripleWithin 202 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop base)
+      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
+       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
+       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
+       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
+       (qAddr ↦ₘ qOld) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
+       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+      (loopIterPostN2Call sp base (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro uBase qAddr
+  by_cases hb : BitVec.ult uTop (mulsubN4_c3 (div128Quot u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3)
+  · have hborrow : isAddbackBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+      delta isAddbackBorrowN2Call; simp only []; rw [if_pos hb]; decide
+    have J1 := divK_loop_body_n2_call_addback_jgt0_beq_spec_within_noNop (1 : Word)
+      EvmAsm.Evm64.DivMod.AddrNorm.slt_jpos_1
+      sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 base
+      halign
+      hbltu hborrow
+      hcarry2_nz
+    intro_lets at J1
+    exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+      (fun h hp => hp)
+      (fun h hp => by
+        rw [← loopIterPostN2Call_addback hb]; exact hp)
+      J1
+  · have hborrow : isSkipBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := if_neg hb
+    have J1 := divK_loop_body_n2_call_skip_jgt0_spec_within_noNop (1 : Word)
+      EvmAsm.Evm64.DivMod.AddrNorm.slt_jpos_1
+      sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 base
+      halign
+      hbltu hborrow
+    intro_lets at J1
+    exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+      (fun h hp => hp)
+      (fun h hp => by
+        rw [← loopIterPostN2Call_skip hb]; exact hp)
+      J1
+
 /-- Unified  j=0 call-path spec: handles both skip and addback internally.
     Since j=0, the BGE loop-back is not taken, giving a cpsTripleWithin 202 to base+908. -/
 theorem divK_loop_body_n2_call_unified_j0_spec_within


### PR DESCRIPTION
## Summary
- adds divK_loop_body_n2_call_unified_j1_spec_within_noNop over divCode_noNop
- composes the existing n=2 j=1 no-NOP call skip/addback leaves into the unified call postcondition
- continues the n=2 call-path per-iteration no-NOP compose wrappers needed before the unified no-NOP loop wrapper

## Verification
- lake build EvmAsm.Evm64.DivMod.LoopComposeN2
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- diff-only forbidden scan for sorry/admit/set_option maxHeartbeats/set_option maxRecDepth
- scripts/check-file-size.sh EvmAsm/Evm64/DivMod/LoopComposeN2.lean
- scripts/check-unimported.sh
- lake build