### PR TITLE
fix(divmod): expose n2 call-max loop no-nop spec

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopComposeN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopComposeN2.lean
@@ -1267,4 +1267,77 @@ theorem divK_loop_n2_call_max_spec_within
       exact hp)
     full
 
+/-- No-NOP variant of `divK_loop_n2_call_max_spec_within`. -/
+theorem divK_loop_n2_call_max_spec_within_noNop
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu_1 : BitVec.ult u2 v1)
+    (hbltu_0 : ¬BitVec.ult (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1 v1)
+    (hcarry2 : Carry2NzAll v0 v1 v2 v3) :
+    cpsTripleWithin 354 (base + loopBodyOff) (base + denormOff) (divCode_noNop base)
+      (loopN2Iter10PreWithScratch sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+        retMem dMem dloMem scratch_un0)
+      (loopN2CallMaxPost sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig) := by
+  delta loopN2Iter10PreWithScratch loopN2Iter10Pre; simp only []
+  let u_base_1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+  let u_base_0 := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+  let q_addr_1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+  let q_addr_0 := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
+  have J1 := divK_loop_body_n2_call_unified_j1_spec_within_noNop sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop q1Old retMem dMem dloMem scratch_un0 base
+    halign
+    hbltu_1
+    (hcarry2 (div128Quot u2 u1 v1) u0 u1 u2 u3 uTop : isAddbackCarry2NzN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+  intro_lets at J1
+  have J1f := cpsTripleWithin_frameR
+    (((u_base_0 + signExtend12 0) ↦ₘ u0Orig) ** (q_addr_0 ↦ₘ q0Old))
+    (by pcFree) J1
+  have J0 := divK_loop_body_n2_max_unified_j0_spec_within_noNop sp (1 : Word)
+    ((1 : Word) <<< (3 : BitVec 6).toNat) u_base_1 q_addr_1
+    ((mulsubN4 (div128Quot u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2)
+    ((iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).1)
+    ((iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1)
+    v0 v1 v2 v3
+    u0Orig
+    (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+    (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+    (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+    (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
+    q0Old base
+    hbltu_0
+    (hcarry2 (signExtend12 4095) u0Orig
+      (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1)
+  intro_lets at J0
+  have J0f := cpsTripleWithin_frameR
+    (((u_base_1 + signExtend12 4064) ↦ₘ (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.2) **
+     (q_addr_1 ↦ₘ (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).1) **
+     (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+     (sp + signExtend12 3960 ↦ₘ v1) **
+     (sp + signExtend12 3952 ↦ₘ div128DLo v1) **
+     (sp + signExtend12 3944 ↦ₘ div128Un0 u1))
+    (by pcFree) J0
+  have full := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by
+      delta loopIterPostN2Call loopExitPostN2 loopExitPost at hp
+      simp only [] at hp ⊢
+      have hj' := jpred_1
+      rw [hj', u_j1_0_eq_j0_4088, u_j1_4088_eq_j0_4080,
+          u_j1_4080_eq_j0_4072, u_j1_4072_eq_j0_4064] at hp
+      rw [sepConj_assoc'] at hp
+      xperm_hyp hp)
+    J1f J0f
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by
+      delta loopN2CallMaxPost
+      exact hp)
+    full
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- adds divK_loop_n2_call_max_spec_within_noNop over divCode_noNop
- composes the n=2 j=1 call-path and j=0 max-path no-NOP unified iteration wrappers
- completes the four branch-specific n=2 two-iteration no-NOP loop compositions

## Verification
- lake build EvmAsm.Evm64.DivMod.LoopComposeN2
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- diff-only forbidden scan for sorry/admit/set_option maxHeartbeats/set_option maxRecDepth
- scripts/check-file-size.sh EvmAsm/Evm64/DivMod/LoopComposeN2.lean
- scripts/check-unimported.sh
- lake build