### PR TITLE
fix(divmod): expose n2 iter10 unified no-nop spec

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopUnifiedN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopUnifiedN2.lean
@@ -111,6 +111,75 @@ theorem divK_loop_n2_iter10_unified_spec_within (bltu_1 bltu_0 : Bool)
       (fun h hp => by delta loopN2Iter10Post; exact hp)
       hCC
 
+/-- No-NOP variant of `divK_loop_n2_iter10_unified_spec_within`. -/
+theorem divK_loop_n2_iter10_unified_spec_within_noNop (bltu_1 bltu_0 : Bool)
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu_1 : bltu_1 = BitVec.ult u2 v1)
+    (hbltu_0 : bltu_0 = BitVec.ult (iterN2 bltu_1 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1 v1)
+    (hcarry2 : Carry2NzAll v0 v1 v2 v3) :
+    cpsTripleWithin 404 (base + loopBodyOff) (base + denormOff) (divCode_noNop base)
+      (loopN2Iter10PreWithScratch sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+        retMem dMem dloMem scratch_un0)
+      (loopN2Iter10Post bltu_1 bltu_0 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig
+        retMem dMem dloMem scratch_un0) := by
+  cases bltu_1 <;> cases bltu_0 <;> simp only [iterN2_true, iterN2_false] at hbltu_0
+  · have hbltu_1' : ¬BitVec.ult u2 v1 := by
+      rw [show BitVec.ult u2 v1 = false from hbltu_1.symm]; decide
+    have hbltu_0' : ¬BitVec.ult (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1 v1 := by
+      rw [show BitVec.ult _ v1 = false from hbltu_0.symm]; decide
+    have hMM := divK_loop_n2_max_max_spec_within_noNop sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old base
+      hbltu_1' hbltu_0' hcarry2
+    have hMMF := cpsTripleWithin_frameR
+      ((sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
+       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+      (by pcFree) hMM
+    exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+      (fun h hp => by delta loopN2Iter10PreWithScratch at hp; xperm_hyp hp)
+      (fun h hp => by delta loopN2Iter10Post; xperm_hyp hp)
+      hMMF
+  · have hbltu_1' : ¬BitVec.ult u2 v1 := by
+      rw [show BitVec.ult u2 v1 = false from hbltu_1.symm]; decide
+    have hbltu_0' : BitVec.ult (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1 v1 :=
+      hbltu_0.symm ▸ rfl
+    have hMC := divK_loop_n2_max_call_spec_within_noNop sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+      retMem dMem dloMem scratch_un0 base halign
+      hbltu_1' hbltu_0' hcarry2
+    exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+      (fun h hp => hp)
+      (fun h hp => by delta loopN2Iter10Post; exact hp)
+      hMC
+  · have hbltu_1' : BitVec.ult u2 v1 := hbltu_1.symm ▸ rfl
+    have hbltu_0' : ¬BitVec.ult (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1 v1 := by
+      rw [show BitVec.ult _ v1 = false from hbltu_0.symm]; decide
+    have hCM := divK_loop_n2_call_max_spec_within_noNop sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+      retMem dMem dloMem scratch_un0 base halign
+      hbltu_1' hbltu_0' hcarry2
+    exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+      (fun h hp => hp)
+      (fun h hp => by delta loopN2Iter10Post; exact hp)
+      hCM
+  · have hbltu_1' : BitVec.ult u2 v1 := hbltu_1.symm ▸ rfl
+    have hbltu_0' : BitVec.ult (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1 v1 :=
+      hbltu_0.symm ▸ rfl
+    have hCC := divK_loop_n2_call_call_spec_within_noNop sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+      retMem dMem dloMem scratch_un0 base halign
+      hbltu_1' hbltu_0' hcarry2
+    exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+      (fun h hp => hp)
+      (fun h hp => by delta loopN2Iter10Post; exact hp)
+      hCC
+
 -- ============================================================================
 -- Full three-iteration : compose j=2 with iter10
 -- Postcondition uses @[irreducible] loopN2UnifiedPost


### PR DESCRIPTION
## Summary
- adds divK_loop_n2_iter10_unified_spec_within_noNop over divCode_noNop
- dispatches the j=1/j=0 unified Bool cases to the four no-NOP branch-specific loop compositions
- prepares the remaining full n=2 no-NOP loop wrappers for the j=2 max/call prefixes

## Verification
- lake build EvmAsm.Evm64.DivMod.LoopUnifiedN2
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- diff-only forbidden scan for sorry/admit/set_option maxHeartbeats/set_option maxRecDepth
- scripts/check-file-size.sh EvmAsm/Evm64/DivMod/LoopUnifiedN2.lean
- scripts/check-unimported.sh
- lake build