### PR TITLE
fix(divmod): expose n2 max iter10 no-nop spec

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopUnifiedN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopUnifiedN2.lean
@@ -262,6 +262,79 @@ theorem divK_loop_n2_max_iter10_spec_within (bltu_1 bltu_0 : Bool)
       cases bltu_1 <;> cases bltu_0 <;> xperm_hyp hp)
     full
 
+/-- No-NOP variant of `divK_loop_n2_max_iter10_spec_within`. -/
+theorem divK_loop_n2_max_iter10_spec_within_noNop (bltu_1 bltu_0 : Bool)
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop
+     u0_orig_1 u0_orig_0
+     q2Old q1Old q0Old : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu_2 : ¬BitVec.ult u2 v1)
+    (hbltu_1 : bltu_1 = BitVec.ult (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1 v1)
+    (hbltu_0 : bltu_0 = BitVec.ult (iterN2 bltu_1 v0 v1 v2 v3 u0_orig_1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.1 v1)
+    (hcarry2 : Carry2NzAll v0 v1 v2 v3) :
+    cpsTripleWithin 556 (base + loopBodyOff) (base + denormOff) (divCode_noNop base)
+      (loopN2PreWithScratch sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop
+        u0_orig_1 u0_orig_0 q2Old q1Old q0Old
+        retMem dMem dloMem scratch_un0)
+      (loopN2UnifiedPost false bltu_1 bltu_0 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop
+        u0_orig_1 u0_orig_0 retMem dMem dloMem scratch_un0) := by
+  let r2 := iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  let u_base_2 := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
+  let u_base_1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+  let q_addr_2 := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
+  let q_addr_1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+  let u_base_0 := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+  let q_addr_0 := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
+  have J2 := divK_loop_body_n2_max_unified_j2_spec_within_noNop sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop q2Old base
+    hbltu_2
+    (hcarry2 (signExtend12 4095) u0 u1 u2 u3 uTop : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+  intro_lets at J2
+  have J2f := cpsTripleWithin_frameR
+    (((u_base_1 + signExtend12 0) ↦ₘ u0_orig_1) ** (q_addr_1 ↦ₘ q1Old) **
+     ((u_base_0 + signExtend12 0) ↦ₘ u0_orig_0) ** (q_addr_0 ↦ₘ q0Old) **
+     (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
+     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+    (by pcFree) J2
+  have H10 := divK_loop_n2_iter10_unified_spec_within_noNop bltu_1 bltu_0
+    sp (2 : Word) ((2 : Word) <<< (3 : BitVec 6).toNat) u_base_2 q_addr_2
+    ((mulsubN4 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2)
+    r2.1 r2.2.2.2.2.1
+    v0 v1 v2 v3
+    u0_orig_1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
+    u0_orig_0 q1Old q0Old
+    retMem dMem dloMem scratch_un0 base halign
+    hbltu_1 hbltu_0 hcarry2
+  have H10f := cpsTripleWithin_frameR
+    (((u_base_2 + signExtend12 4064) ↦ₘ r2.2.2.2.2.2) ** (q_addr_2 ↦ₘ r2.1))
+    (by pcFree) H10
+  have full := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by
+      delta loopIterPostN2Max loopExitPostN2 loopExitPost at hp
+      delta loopN2Iter10PreWithScratch loopN2Iter10Pre at ⊢
+      simp only [] at hp ⊢
+      have hj' := jpred_2
+      rw [hj', u_j2_0_eq_j1_4088, u_j2_4088_eq_j1_4080,
+          u_j2_4080_eq_j1_4072, u_j2_4072_eq_j1_4064] at hp
+      rw [sepConj_assoc'] at hp
+      xperm_hyp hp)
+    J2f H10f
+  exact cpsTripleWithin_weaken
+    (fun h hp => by delta loopN2PreWithScratch loopN2Pre at hp; xperm_hyp hp)
+    (fun h hp => by
+      delta loopN2UnifiedPost loopN2Iter10Post at hp ⊢
+      simp only [iterN2_false, Bool.false_eq_true, ↓reduceIte] at hp ⊢
+      cases bltu_1 <;> cases bltu_0 <;> xperm_hyp hp)
+    full
+
 /-- Three-iteration  composition when j=2 is call (bltu_2 = true).
     Composes j=2  call spec with the 2-iteration iter10 unified  spec. -/
 theorem divK_loop_n2_call_iter10_spec_within (bltu_1 bltu_0 : Bool)


### PR DESCRIPTION
## Summary
- adds divK_loop_n2_max_iter10_spec_within_noNop over divCode_noNop
- composes the j=2 max no-NOP body wrapper with the iter10 unified no-NOP theorem from #4325
- leaves the j=2 call prefix and final n=2 unified no-NOP theorem as the remaining loop wrapper slices

## Verification
- lake build EvmAsm.Evm64.DivMod.LoopUnifiedN2
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- diff-only forbidden scan for sorry/admit/set_option maxHeartbeats/set_option maxRecDepth
- scripts/check-file-size.sh EvmAsm/Evm64/DivMod/LoopUnifiedN2.lean
- scripts/check-unimported.sh
- lake build