### PR TITLE
fix(divmod): expose n2 unified no-nop spec

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopUnifiedN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopUnifiedN2.lean
@@ -532,4 +532,43 @@ theorem divK_loop_n2_unified_spec_within (bltu_2 bltu_1 bltu_0 : Bool)
 
       hbltu_2' hbltu_1 hbltu_0 hcarry2
 
+/-- No-NOP variant of `divK_loop_n2_unified_spec_within`. -/
+theorem divK_loop_n2_unified_spec_within_noNop (bltu_2 bltu_1 bltu_0 : Bool)
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop
+     u0_orig_1 u0_orig_0
+     q2Old q1Old q0Old : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu_2 : bltu_2 = BitVec.ult u2 v1)
+    (hbltu_1 : bltu_1 = BitVec.ult (iterN2 bltu_2 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1 v1)
+    (hbltu_0 : bltu_0 = BitVec.ult (iterN2 bltu_1 v0 v1 v2 v3 u0_orig_1
+      (iterN2 bltu_2 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterN2 bltu_2 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN2 bltu_2 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterN2 bltu_2 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.1 v1)
+    (hcarry2 : Carry2NzAll v0 v1 v2 v3) :
+    cpsTripleWithin 606 (base + loopBodyOff) (base + denormOff) (divCode_noNop base)
+      (loopN2PreWithScratch sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop
+        u0_orig_1 u0_orig_0 q2Old q1Old q0Old
+        retMem dMem dloMem scratch_un0)
+      (loopN2UnifiedPost bltu_2 bltu_1 bltu_0 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop
+        u0_orig_1 u0_orig_0 retMem dMem dloMem scratch_un0) := by
+  cases bltu_2 <;> simp only [iterN2_true, iterN2_false] at hbltu_1 hbltu_0
+  · have hbltu_2' : ¬BitVec.ult u2 v1 := by
+      rw [show BitVec.ult u2 v1 = false from hbltu_2.symm]; decide
+    exact cpsTripleWithin_mono_nSteps (by decide) <| divK_loop_n2_max_iter10_spec_within_noNop bltu_1 bltu_0
+      sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig_1 u0_orig_0 q2Old q1Old q0Old
+      retMem dMem dloMem scratch_un0 base halign
+      hbltu_2' hbltu_1 hbltu_0 hcarry2
+  · have hbltu_2' : BitVec.ult u2 v1 := hbltu_2.symm ▸ rfl
+    exact divK_loop_n2_call_iter10_spec_within_noNop bltu_1 bltu_0
+      sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig_1 u0_orig_0 q2Old q1Old q0Old
+      retMem dMem dloMem scratch_un0 base halign
+      hbltu_2' hbltu_1 hbltu_0 hcarry2
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- adds divK_loop_n2_unified_spec_within_noNop over divCode_noNop
- dispatches the final bltu_2 Bool case to the n=2 max/call iter10 no-NOP wrappers
- completes the n=2 LoopUnifiedN2 no-NOP wrapper stack needed by SDIV div-call composition

## Verification
- lake build EvmAsm.Evm64.DivMod.LoopUnifiedN2
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- diff-only forbidden scan for sorry/admit/set_option maxHeartbeats/set_option maxRecDepth
- scripts/check-file-size.sh EvmAsm/Evm64/DivMod/LoopUnifiedN2.lean
- scripts/check-unimported.sh
- lake build