### PR TITLE
fix(divmod): expose n2 stack no-nop unified wrapper

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/Unified.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/Unified.lean
@@ -528,6 +528,46 @@ theorem evm_div_n2_stack_spec_within_word_uni
       ha0 ha1 ha2 ha3 hb0 hb1 hb2 hb3 hbnz hb3z hb2z hb1nz
       hshift_nz halign hbltu_2 hbltu_1 hbltu_0 hcarry2 hdivWord)
 
+/-- Unified-bound wrapper for `evm_div_n2_stack_spec_within_word_noNop`. -/
+theorem evm_div_n2_stack_spec_within_word_noNop_uni
+    (bltu_2 bltu_1 bltu_0 : Bool) (sp base : Word)
+    (a b : EvmWord)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratch_un0 : Word)
+    (ha0 : a.getLimbN 0 = a0) (ha1 : a.getLimbN 1 = a1)
+    (ha2 : a.getLimbN 2 = a2) (ha3 : a.getLimbN 3 = a3)
+    (hb0 : b.getLimbN 0 = b0) (hb1 : b.getLimbN 1 = b1)
+    (hb2 : b.getLimbN 2 = b2) (hb3 : b.getLimbN 3 = b3)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0)
+    (hshift_nz : (clzResult b1).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu_2 : isTrialN2_j2 bltu_2 a3 b0 b1)
+    (hbltu_1 : isTrialN2_j1 bltu_2 bltu_1 a1 a2 a3 b0 b1 b2 b3)
+    (hbltu_0 : isTrialN2_j0 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3)
+    (hcarry2 : Carry2NzAll (b0 <<< (((clzResult b1).1).toNat % 64))
+      ((b1 <<< (((clzResult b1).1).toNat % 64)) ||| (b0 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b1).1).toNat % 64)))
+      ((b2 <<< (((clzResult b1).1).toNat % 64)) ||| (b1 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b1).1).toNat % 64)))
+      ((b3 <<< (((clzResult b1).1).toNat % 64)) ||| (b2 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b1).1).toNat % 64))))
+    (hdivWord : fullDivN2QuotientWord bltu_2 bltu_1 bltu_0
+      a0 a1 a2 a3 b0 b1 b2 b3 = EvmWord.div a b) :
+    cpsTripleWithin unifiedDivBound base (base + nopOff) (divCode_noNop base)
+      (divModStackDispatchPre sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word))
+        ((clzResult b1).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0)
+      (divStackDispatchPost sp a b) :=
+  cpsTripleWithin_mono_nSteps (by decide)
+    (evm_div_n2_stack_spec_within_word_noNop bltu_2 bltu_1 bltu_0
+      sp base a b a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old
+      q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+      nMem shiftMem jMem retMem dMem dloMem scratch_un0
+      ha0 ha1 ha2 ha3 hb0 hb1 hb2 hb3 hbnz hb3z hb2z hb1nz
+      hshift_nz halign hbltu_2 hbltu_1 hbltu_0 hcarry2 hdivWord)
+
 /-- Unified-bound wrapper for `evm_div_n3_stack_spec_within_word`. -/
 theorem evm_div_n3_stack_spec_within_word_uni
     (bltu_1 bltu_0 : Bool) (sp base : Word)


### PR DESCRIPTION
## Summary
- add evm_div_n2_stack_spec_within_word_noNop_uni over divCode_noNop
- lift the n=2 no-NOP stack word spec to unifiedDivBound
- match the existing n=1 and n=3 no-NOP unified wrapper shape

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.Unified
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- git diff -U0 -- EvmAsm/Evm64/DivMod/Spec/Unified.lean | rg -n '^\+.*(sorry|admit|set_option maxHeartbeats|set_option maxRecDepth)'
- scripts/check-file-size.sh EvmAsm/Evm64/DivMod/Spec/Unified.lean
- scripts/check-unimported.sh
- lake build