### PR TITLE
fix(exp): name full body successor bound

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitIterMerge.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitIterMerge.lean
@@ -676,10 +676,7 @@ theorem exp_two_mul_full_loop_body_peel_tail_with_exit_cases_spec_within
       (expTwoMulLoopExitPre sp evmSp iterCountFinal tOld out0 out1 out2 out3
         baseWord rest exitCond) := by
   intro hLoop
-  rw [show expTwoMulFullLoopBodyBound =
-        expTwoMulIterationsBodyBound (255 + 1) by
-      rw [expTwoMulFullLoopBodyBound_eq_iter_plus_tail,
-        expTwoMulIterationsBodyBound_succ]]
+  rw [expTwoMulFullLoopBodyBound_eq_tail_succ]
   exact
     exp_two_mul_iterations_body_peel_with_exit_cases_spec_within
       255

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitLoopBounds.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitLoopBounds.lean
@@ -94,6 +94,13 @@ theorem expTwoMulFullLoopBodyBound_eq_iter_plus_tail :
   norm_num [expTwoMulFullLoopBodyBound, expTwoMulFullLoopBodyTailBound,
     expTwoMulNamedIterStepBound_eq]
 
+/-- View the 256-iteration full-body bound as one peeled iteration followed by
+    the 255-iteration tail. -/
+theorem expTwoMulFullLoopBodyBound_eq_tail_succ :
+    expTwoMulFullLoopBodyBound = expTwoMulIterationsBodyBound (255 + 1) := by
+  rw [expTwoMulFullLoopBodyBound_eq_iter_plus_tail,
+    expTwoMulIterationsBodyBound_succ]
+
 theorem expTwoMulFullLoopBoundaryBound_eq :
     expTwoMulFullLoopBoundaryBound = 48401 := by
   rw [expTwoMulFullLoopBoundaryBound, expTwoMulBoundaryLoopBound_eq,


### PR DESCRIPTION
## Summary
- add expTwoMulFullLoopBodyBound_eq_tail_succ to expose the 256-body bound as the peeled 255+1 iteration bound
- use the named bound lemma in the full-loop body peel-with-exit-cases wrapper

## Verification
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitLoopBounds
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitIterMerge
- lake build EvmAsm.Evm64.Exp
- git diff --check
- rg -n '^\+.*(sorry|admit|set_option maxHeartbeats|set_option maxRecDepth)' --no-heading
- scripts/check-file-size.sh EvmAsm/Evm64/Exp/Compose/SavedBitLoopBounds.lean EvmAsm/Evm64/Exp/Compose/SavedBitIterMerge.lean
- scripts/check-unimported.sh
- lake build