### PR TITLE
fix(exp): name full tail step bound

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitIterMerge.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitIterMerge.lean
@@ -570,9 +570,7 @@ theorem exp_two_mul_full_loop_body_peel_tail_with_continuations_spec_within
       e iterCount v18 sp evmSp vOld r0 r1 r2 r3 d0 d1 d2 d3
       e0 e1 e2 e3 a0 a1 a2 a3 iterCountFinal tOld out0 out1 out2 out3
       base baseWord rest exitCond hbase
-      (by
-        rw [Nat.max_self]
-        rw [← expTwoMulFullLoopBodyBound_eq_iter_plus_tail])
+      expTwoMulNamedIterStepBound_add_max_fullTail_le_full
 
 /-- Closed-form variant of
     `exp_two_mul_full_loop_body_peel_tail_with_continuations_spec_within`,

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitLoopBounds.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitLoopBounds.lean
@@ -101,6 +101,22 @@ theorem expTwoMulFullLoopBodyBound_eq_tail_succ :
   rw [expTwoMulFullLoopBodyBound_eq_iter_plus_tail,
     expTwoMulIterationsBodyBound_succ]
 
+/-- The peeled named iteration plus the 255-iteration tail fits in the
+    256-iteration full-body budget. -/
+theorem expTwoMulNamedIterStepBound_add_fullTail_le_full :
+    expTwoMulNamedIterStepBound + expTwoMulFullLoopBodyTailBound ≤
+      expTwoMulFullLoopBodyBound := by
+  rw [← expTwoMulFullLoopBodyBound_eq_iter_plus_tail]
+
+/-- Same budget fact with the duplicated tail bound shape produced by the
+    continuation-composition rule. -/
+theorem expTwoMulNamedIterStepBound_add_max_fullTail_le_full :
+    expTwoMulNamedIterStepBound +
+        max expTwoMulFullLoopBodyTailBound expTwoMulFullLoopBodyTailBound ≤
+      expTwoMulFullLoopBodyBound := by
+  rw [Nat.max_self]
+  exact expTwoMulNamedIterStepBound_add_fullTail_le_full
+
 theorem expTwoMulFullLoopBoundaryBound_eq :
     expTwoMulFullLoopBoundaryBound = 48401 := by
   rw [expTwoMulFullLoopBoundaryBound, expTwoMulBoundaryLoopBound_eq,


### PR DESCRIPTION
## Summary
- add named EXP full-tail step budget lemmas in SavedBitLoopBounds
- replace the local max-tail arithmetic proof in SavedBitIterMerge with the named lemma

## Verification
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitLoopBounds
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitIterMerge
- lake build EvmAsm.Evm64.Exp
- git diff --check
- scripts/check-unimported.sh
- lake build