### PR TITLE
fix(exp): name iteration successor bounds

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitIterMerge.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitIterMerge.lean
@@ -290,8 +290,8 @@ theorem exp_two_mul_iterations_body_peel_with_continuations_spec_within
     exp_two_mul_named_iter_with_continuations_bounded_spec_within
       e iterCount v18 sp evmSp vOld r0 r1 r2 r3 d0 d1 d2 d3
       e0 e1 e2 e3 a0 a1 a2 a3 base hbase
-      (by
-        rw [Nat.max_self, expTwoMulIterationsBodyBound_succ])
+      (expTwoMulNamedIterStepBound_add_max_iterationsBodyBound_le_succ
+        iterations)
 
 /-- Closed-form variant of
     `exp_two_mul_iterations_body_peel_with_continuations_spec_within`,
@@ -377,8 +377,8 @@ theorem exp_two_mul_iterations_body_peel_with_exit_imp_spec_within
     exp_two_mul_named_iter_with_continuations_bounded_spec_within
       e iterCount v18 sp evmSp vOld r0 r1 r2 r3 d0 d1 d2 d3
       e0 e1 e2 e3 a0 a1 a2 a3 base hbase
-      (by
-        rw [Nat.max_eq_left (Nat.zero_le _), expTwoMulIterationsBodyBound_succ])
+      (expTwoMulNamedIterStepBound_add_max_iterationsBodyBound_zero_le_succ
+        iterations)
       hLoop
       (cpsTripleWithin_extend_code
         (hmono := by

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitLoopBounds.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitLoopBounds.lean
@@ -70,6 +70,29 @@ theorem expTwoMulIterationsBodyBound_succ (iterations : Nat) :
   unfold expTwoMulIterationsBodyBound
   rw [Nat.add_one, Nat.succ_mul, Nat.add_comm]
 
+theorem expTwoMulNamedIterStepBound_add_iterationsBodyBound_le_succ
+    (iterations : Nat) :
+    expTwoMulNamedIterStepBound + expTwoMulIterationsBodyBound iterations ≤
+      expTwoMulIterationsBodyBound (iterations + 1) := by
+  rw [expTwoMulIterationsBodyBound_succ]
+
+theorem expTwoMulNamedIterStepBound_add_max_iterationsBodyBound_le_succ
+    (iterations : Nat) :
+    expTwoMulNamedIterStepBound +
+        max (expTwoMulIterationsBodyBound iterations)
+          (expTwoMulIterationsBodyBound iterations) ≤
+      expTwoMulIterationsBodyBound (iterations + 1) := by
+  rw [Nat.max_self]
+  exact expTwoMulNamedIterStepBound_add_iterationsBodyBound_le_succ iterations
+
+theorem expTwoMulNamedIterStepBound_add_max_iterationsBodyBound_zero_le_succ
+    (iterations : Nat) :
+    expTwoMulNamedIterStepBound +
+        max (expTwoMulIterationsBodyBound iterations) 0 ≤
+      expTwoMulIterationsBodyBound (iterations + 1) := by
+  rw [Nat.max_eq_left (Nat.zero_le _)]
+  exact expTwoMulNamedIterStepBound_add_iterationsBodyBound_le_succ iterations
+
 theorem expTwoMulIterationsBodyBound_mono {iterations iterations' : Nat}
     (h : iterations ≤ iterations') :
     expTwoMulIterationsBodyBound iterations ≤


### PR DESCRIPTION
## Summary
- add generic named EXP successor-bound lemmas for one saved-bit iteration plus loop/exit continuations
- replace two remaining local successor arithmetic proofs in SavedBitIterMerge

## Verification
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitLoopBounds
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitIterMerge
- lake build EvmAsm.Evm64.Exp
- git diff --check
- scripts/check-unimported.sh
- lake build