### PR TITLE
refactor(exp): name loop entry scratch unfolds

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitLoopEntry.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitLoopEntry.lean
@@ -23,6 +23,21 @@ def expTwoMulBoundaryPre
      (.x12 ↦ᵣ evmSp)) ** evmStackIs evmSp (baseWord :: exponentWord :: rest)) **
    expTwoMulScratchFrame vOld v18)
 
+theorem expTwoMulBoundaryPre_unfold_namedScratch
+    {sp evmSp cOld tOld m0 m1 m2 m3 vOld v18 : Word}
+    {baseWord exponentWord : EvmWord} {rest : List EvmWord} :
+    expTwoMulBoundaryPre sp evmSp cOld tOld m0 m1 m2 m3 vOld v18
+      baseWord exponentWord rest =
+      (((((.x2 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) ** (.x9 ↦ᵣ cOld) **
+          (.x5 ↦ᵣ tOld) ** ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ m0) **
+          ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ m1) **
+          ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ m2) **
+          ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ m3)) **
+         (.x12 ↦ᵣ evmSp)) ** evmStackIs evmSp (baseWord :: exponentWord :: rest)) **
+       expTwoMulScratchFrame vOld v18) := by
+  delta expTwoMulBoundaryPre
+  rfl
+
 theorem expTwoMulBoundaryPre_unfold
     {sp evmSp cOld tOld m0 m1 m2 m3 vOld v18 : Word}
     {baseWord exponentWord : EvmWord} {rest : List EvmWord} :
@@ -36,7 +51,7 @@ theorem expTwoMulBoundaryPre_unfold
          (.x12 ↦ᵣ evmSp)) ** evmStackIs evmSp (baseWord :: exponentWord :: rest)) **
        (regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
         (.x1 ↦ᵣ vOld) ** (.x18 ↦ᵣ v18))) := by
-  delta expTwoMulBoundaryPre
+  rw [expTwoMulBoundaryPre_unfold_namedScratch]
   rw [expTwoMulScratchFrame_unfold]
 
 theorem expTwoMulBoundaryPre_pcFree
@@ -66,6 +81,19 @@ def expTwoMulLoopEntryPost
    evmStackIs evmSp (baseWord :: exponentWord :: rest)) **
    expTwoMulScratchFrame vOld v18)
 
+theorem expTwoMulLoopEntryPost_unfold_namedScratch
+    {sp evmSp vOld v18 : Word} {baseWord exponentWord : EvmWord}
+    {rest : List EvmWord} :
+    expTwoMulLoopEntryPost sp evmSp vOld v18 baseWord exponentWord rest =
+      (((((.x2 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) **
+          (.x9 ↦ᵣ (256 : Word)) ** (.x5 ↦ᵣ (1 : Word)) **
+          evmWordIs sp (1 : EvmWord)) **
+         (.x12 ↦ᵣ (evmSp + 64))) **
+        evmStackIs evmSp (baseWord :: exponentWord :: rest)) **
+       expTwoMulScratchFrame vOld v18) := by
+  delta expTwoMulLoopEntryPost
+  rfl
+
 theorem expTwoMulLoopEntryPost_unfold
     {sp evmSp vOld v18 : Word} {baseWord exponentWord : EvmWord}
     {rest : List EvmWord} :
@@ -77,7 +105,7 @@ theorem expTwoMulLoopEntryPost_unfold
         evmStackIs evmSp (baseWord :: exponentWord :: rest)) **
        (regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
         (.x1 ↦ᵣ vOld) ** (.x18 ↦ᵣ v18))) := by
-  delta expTwoMulLoopEntryPost
+  rw [expTwoMulLoopEntryPost_unfold_namedScratch]
   rw [expTwoMulScratchFrame_unfold]
 
 theorem expTwoMulLoopEntryPost_pcFree
@@ -126,8 +154,8 @@ theorem exp_prologue_then_pointer_advance_evm_exp_msb_saved_bit_two_mul_canonica
       (expTwoMulBoundaryPre sp evmSp cOld tOld m0 m1 m2 m3 vOld v18
         baseWord exponentWord rest)
       (expTwoMulLoopEntryPost sp evmSp vOld v18 baseWord exponentWord rest) := by
-  rw [expTwoMulBoundaryPre_unfold]
-  simpa [expTwoMulScratchFrame_unfold] using
+  rw [expTwoMulBoundaryPre_unfold_namedScratch]
+  exact
     exp_prologue_then_pointer_advance_evm_exp_msb_saved_bit_two_mul_canonical_appended_mul_named_loop_entry_spec_within
       sp evmSp cOld tOld m0 m1 m2 m3 vOld v18 baseWord exponentWord rest base
 


### PR DESCRIPTION
## Summary
- add named-scratch unfold lemmas for expTwoMulBoundaryPre and expTwoMulLoopEntryPost
- use the named-scratch boundary pre unfold in the prologue/pointer boundary adapter

## Verification
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitLoopEntry
- lake build EvmAsm.Evm64.Exp
- git diff --check
- scripts/check-unimported.sh
- lake build