### PR TITLE
refactor(exp): use named scratch for loop entry pcfree

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitLoopEntry.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitLoopEntry.lean
@@ -59,7 +59,7 @@ theorem expTwoMulBoundaryPre_pcFree
     {baseWord exponentWord : EvmWord} {rest : List EvmWord} :
     (expTwoMulBoundaryPre sp evmSp cOld tOld m0 m1 m2 m3 vOld v18
       baseWord exponentWord rest).pcFree := by
-  rw [expTwoMulBoundaryPre_unfold]
+  rw [expTwoMulBoundaryPre_unfold_namedScratch]
   pcFree
 
 instance pcFreeInst_expTwoMulBoundaryPre
@@ -112,7 +112,7 @@ theorem expTwoMulLoopEntryPost_pcFree
     {sp evmSp vOld v18 : Word} {baseWord exponentWord : EvmWord}
     {rest : List EvmWord} :
     (expTwoMulLoopEntryPost sp evmSp vOld v18 baseWord exponentWord rest).pcFree := by
-  rw [expTwoMulLoopEntryPost_unfold]
+  rw [expTwoMulLoopEntryPost_unfold_namedScratch]
   pcFree
 
 instance pcFreeInst_expTwoMulLoopEntryPost


### PR DESCRIPTION
## Summary
- make expTwoMulBoundaryPre_pcFree and expTwoMulLoopEntryPost_pcFree use the named-scratch unfold lemmas
- keep the fully expanded unfold lemmas unchanged for compatibility

## Verification
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitLoopEntry
- lake build EvmAsm.Evm64.Exp
- git diff --check
- scripts/check-unimported.sh
- lake build