### PR TITLE
refactor(exp): name pointer restore normalization

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryPrologue.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryPrologue.lean
@@ -75,6 +75,15 @@ theorem expTwoMulBoundaryAdvancedEvmSpWord (evmSp : Word) :
     evmSp + signExtend12 (64 : BitVec 12) = evmSp + 64 := by
   rw [signExtend12_64]
 
+theorem expTwoMulPointerRestoreBackToEvmSp (evmSp : Word) :
+    (evmSp + signExtend12 (64 : BitVec 12)) +
+      signExtend12 ((-64) : BitVec 12) = evmSp := by
+  have hNeg64 :
+      signExtend12 ((-64) : BitVec 12) =
+        (18446744073709551552 : Word) := by decide
+  rw [signExtend12_64, hNeg64]
+  bv_decide
+
 /-- EXP prologue followed by the pointer-advance block, lifted to the
     two-MUL saved-bit EXP+MUL code bundle. This lands at the iteration-body
     entry with the EVM stack pointer advanced by one operand window. -/

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBoundarySeq.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBoundarySeq.lean
@@ -259,13 +259,7 @@ theorem exp_pointer_restore_then_epilogue_evm_exp_msb_saved_bit_two_mul_with_mul
   have hRestoreFramed := cpsTripleWithin_frameR epilogueFrame (by
     dsimp [epilogueFrame]
     pcFree) hRestore
-  have hPtr : (evmSp + signExtend12 (64 : BitVec 12)) +
-      signExtend12 ((-64) : BitVec 12) = evmSp := by
-    have hNeg64 :
-        signExtend12 ((-64) : BitVec 12) =
-          (18446744073709551552 : Word) := by decide
-    rw [signExtend12_64, hNeg64]
-    bv_decide
+  have hPtr := expTwoMulPointerRestoreBackToEvmSp evmSp
   have hRestoreFramed' :
       cpsTripleWithin 1 (base + 264) (base + 268)
         (evmExpMsbSavedBitTwoMulWithMulCode


### PR DESCRIPTION
## Summary
- add a named word-normalization lemma for restoring the EXP EVM stack pointer after the +64/-64 pointer step
- replace the local pointer arithmetic proof in the pointer-restore/epilogue boundary composition

## Verification
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitBoundarySeq
- lake build EvmAsm.Evm64.Exp
- git diff --check
- scripts/check-unimported.sh
- lake build