### PR TITLE
refactor(exp): name loop exit stack tail frame

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryEpilogueBase.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryEpilogueBase.lean
@@ -151,7 +151,7 @@ theorem exp_pointer_restore_then_epilogue_stack_tail_evm_exp_msb_saved_bit_two_m
     let exitControl : Assertion :=
       (.x9 ↦ᵣ iterCountNew) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜exitCond⌝
     let stackTail : Assertion :=
-      evmWordIs evmSp baseWord ** evmStackIs (evmSp + 64) rest
+      expTwoMulLoopExitStackTailFrame evmSp baseWord rest
     cpsTripleWithin (1 + 9) (base + 264) (base + 304)
       (evmExpMsbSavedBitTwoMulWithMulCode
         base mulTarget squaringMulOff condMulOff skipOff backOff)
@@ -182,17 +182,17 @@ theorem exp_pointer_restore_then_epilogue_stack_tail_evm_exp_msb_saved_bit_two_m
     exp_pointer_restore_then_epilogue_exit_control_evm_exp_msb_saved_bit_two_mul_with_mul_spec_within
       sp evmSp iterCountNew tOld r0 r1 r2 r3 d0 d1 d2 d3 exitCond
       squaringMulOff condMulOff skipOff backOff base mulTarget
-  have hFramed := cpsTripleWithin_frameR stackTail (by
-    dsimp [stackTail]
-    pcFree) hBase
+  have hFramed := cpsTripleWithin_frameR stackTail (by pcFree) hBase
   exact cpsTripleWithin_weaken
     (fun _ hp => by
       dsimp [exitControl, stackTail] at hp ⊢
+      rw [expTwoMulLoopExitStackTailFrame_unfold] at hp ⊢
       xperm_hyp hp)
     (fun _ hp => by
       dsimp [exitControl, stackTail] at hp ⊢
+      rw [expTwoMulLoopExitStackTailFrame_unfold] at hp
       rw [evmStackIs_cons]
-      rw [show evmSp + 64#64 = evmSp + 32#64 + 32#64 from by bv_addr] at hp
+      rw [show evmSp + 64 = evmSp + 32#64 + 32#64 from by bv_addr] at hp
       xperm_hyp hp)
     hFramed
 

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryPrologue.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryPrologue.lean
@@ -84,6 +84,31 @@ theorem expTwoMulPointerRestoreBackToEvmSp (evmSp : Word) :
   rw [signExtend12_64, hNeg64]
   bv_decide
 
+@[irreducible]
+def expTwoMulLoopExitStackTailFrame
+    (evmSp : Word) (baseWord : EvmWord) (rest : List EvmWord) :
+    Assertion :=
+  evmWordIs evmSp baseWord ** evmStackIs (evmSp + 64) rest
+
+theorem expTwoMulLoopExitStackTailFrame_unfold
+    {evmSp : Word} {baseWord : EvmWord} {rest : List EvmWord} :
+    expTwoMulLoopExitStackTailFrame evmSp baseWord rest =
+      (evmWordIs evmSp baseWord ** evmStackIs (evmSp + 64) rest) := by
+  delta expTwoMulLoopExitStackTailFrame
+  rfl
+
+theorem expTwoMulLoopExitStackTailFrame_pcFree
+    {evmSp : Word} {baseWord : EvmWord} {rest : List EvmWord} :
+    (expTwoMulLoopExitStackTailFrame evmSp baseWord rest).pcFree := by
+  rw [expTwoMulLoopExitStackTailFrame_unfold]
+  pcFree
+
+instance pcFreeInst_expTwoMulLoopExitStackTailFrame
+    (evmSp : Word) (baseWord : EvmWord) (rest : List EvmWord) :
+    Assertion.PCFree
+      (expTwoMulLoopExitStackTailFrame evmSp baseWord rest) :=
+  ⟨expTwoMulLoopExitStackTailFrame_pcFree⟩
+
 /-- EXP prologue followed by the pointer-advance block, lifted to the
     two-MUL saved-bit EXP+MUL code bundle. This lands at the iteration-body
     entry with the EVM stack pointer advanced by one operand window. -/

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBoundarySeq.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBoundarySeq.lean
@@ -538,7 +538,6 @@ theorem exp_pointer_restore_then_epilogue_full_stack_evm_exp_msb_saved_bit_two_m
       rw [← exp_epilogue_result_word_right evmSp d0 d1 d2 d3
         (evmStackIs (evmSp + 32 + 32) rest)] at hp
       rw [show evmSp + 32 + 32 = evmSp + 64 from by bv_addr] at hp
-      rw [expTwoMulPointerRestoreEpiloguePreFrame_unfold]
       rw [expTwoMulLoopExitStackTailFrame_unfold]
       xcancel_struct hp)
     (fun _ hp => by

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBoundarySeq.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBoundarySeq.lean
@@ -214,6 +214,31 @@ instance pcFreeInst_expTwoMulLoopExitFullStackPostFrame
         sp evmSp iterCountNew r0 r1 r2 r3 baseWord rest exitCond) :=
   ⟨expTwoMulLoopExitFullStackPostFrame_pcFree⟩
 
+@[irreducible]
+def expTwoMulLoopExitStackTailFrame
+    (evmSp : Word) (baseWord : EvmWord) (rest : List EvmWord) :
+    Assertion :=
+  evmWordIs evmSp baseWord ** evmStackIs (evmSp + 64) rest
+
+theorem expTwoMulLoopExitStackTailFrame_unfold
+    {evmSp : Word} {baseWord : EvmWord} {rest : List EvmWord} :
+    expTwoMulLoopExitStackTailFrame evmSp baseWord rest =
+      (evmWordIs evmSp baseWord ** evmStackIs (evmSp + 64) rest) := by
+  delta expTwoMulLoopExitStackTailFrame
+  rfl
+
+theorem expTwoMulLoopExitStackTailFrame_pcFree
+    {evmSp : Word} {baseWord : EvmWord} {rest : List EvmWord} :
+    (expTwoMulLoopExitStackTailFrame evmSp baseWord rest).pcFree := by
+  rw [expTwoMulLoopExitStackTailFrame_unfold]
+  pcFree
+
+instance pcFreeInst_expTwoMulLoopExitStackTailFrame
+    (evmSp : Word) (baseWord : EvmWord) (rest : List EvmWord) :
+    Assertion.PCFree
+      (expTwoMulLoopExitStackTailFrame evmSp baseWord rest) :=
+  ⟨expTwoMulLoopExitStackTailFrame_pcFree⟩
+
 /-- Pointer-restore followed by the EXP epilogue in the two-MUL saved-bit
     EXP+MUL code bundle. This packages the loop-exit boundary from
     `base + 264` through the final stack-facing writeback at `base + 304`. -/
@@ -349,7 +374,7 @@ theorem exp_pointer_restore_then_epilogue_stack_tail_evm_exp_msb_saved_bit_two_m
     let exitControl : Assertion :=
       (.x9 ↦ᵣ iterCountNew) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜exitCond⌝
     let stackTail : Assertion :=
-      evmWordIs evmSp baseWord ** evmStackIs (evmSp + 64) rest
+      expTwoMulLoopExitStackTailFrame evmSp baseWord rest
     cpsTripleWithin (1 + 9) (base + 264) (base + 304)
       (evmExpMsbSavedBitTwoMulWithMulCode
         base mulTarget squaringMulOff condMulOff skipOff backOff)
@@ -380,17 +405,17 @@ theorem exp_pointer_restore_then_epilogue_stack_tail_evm_exp_msb_saved_bit_two_m
     exp_pointer_restore_then_epilogue_exit_control_evm_exp_msb_saved_bit_two_mul_with_mul_spec_within
       sp evmSp iterCountNew tOld r0 r1 r2 r3 d0 d1 d2 d3 exitCond
       squaringMulOff condMulOff skipOff backOff base mulTarget
-  have hFramed := cpsTripleWithin_frameR stackTail (by
-    dsimp [stackTail]
-    pcFree) hBase
+  have hFramed := cpsTripleWithin_frameR stackTail (by pcFree) hBase
   exact cpsTripleWithin_weaken
     (fun _ hp => by
       dsimp [exitControl, stackTail] at hp ⊢
+      rw [expTwoMulLoopExitStackTailFrame_unfold] at hp ⊢
       xperm_hyp hp)
     (fun _ hp => by
       dsimp [exitControl, stackTail] at hp ⊢
+      rw [expTwoMulLoopExitStackTailFrame_unfold] at hp
       rw [evmStackIs_cons]
-      rw [show evmSp + 64#64 = evmSp + 32#64 + 32#64 from by bv_addr] at hp
+      rw [show evmSp + 64 = evmSp + 32#64 + 32#64 from by bv_addr] at hp
       xcancel_struct hp)
     hFramed
 
@@ -406,7 +431,7 @@ theorem exp_pointer_restore_then_epilogue_full_post_stack_evm_exp_msb_saved_bit_
     let exitControl : Assertion :=
       (.x9 ↦ᵣ iterCountNew) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜exitCond⌝
     let stackTail : Assertion :=
-      evmWordIs evmSp baseWord ** evmStackIs (evmSp + 64) rest
+      expTwoMulLoopExitStackTailFrame evmSp baseWord rest
     cpsTripleWithin (1 + 9) (base + 264) (base + 304)
       (evmExpMsbSavedBitTwoMulWithMulCode
         base mulTarget squaringMulOff condMulOff skipOff backOff)
@@ -433,9 +458,11 @@ theorem exp_pointer_restore_then_epilogue_full_post_stack_evm_exp_msb_saved_bit_
         evmStackIs evmSp (baseWord :: expResultWord r0 r1 r2 r3 :: rest))) := by
   intro exitControl stackTail
   exact cpsTripleWithin_weaken
-    (fun _ hp => hp)
     (fun _ hp => by
-      dsimp [exitControl] at hp ⊢
+      dsimp [exitControl, stackTail] at hp ⊢
+      exact hp)
+    (fun _ hp => by
+      dsimp [exitControl, stackTail] at hp ⊢
       rw [evmStackIs_cons]
       xperm_hyp hp)
     (exp_pointer_restore_then_epilogue_stack_tail_evm_exp_msb_saved_bit_two_mul_with_mul_spec_within
@@ -453,7 +480,7 @@ theorem exp_pointer_restore_then_epilogue_full_post_stack_clean_pointer_evm_exp_
     let exitControl : Assertion :=
       (.x9 ↦ᵣ iterCountNew) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜exitCond⌝
     let stackTail : Assertion :=
-      evmWordIs evmSp baseWord ** evmStackIs (evmSp + 64) rest
+      expTwoMulLoopExitStackTailFrame evmSp baseWord rest
     cpsTripleWithin (1 + 9) (base + 264) (base + 304)
       (evmExpMsbSavedBitTwoMulWithMulCode
         base mulTarget squaringMulOff condMulOff skipOff backOff)
@@ -511,6 +538,8 @@ theorem exp_pointer_restore_then_epilogue_full_stack_evm_exp_msb_saved_bit_two_m
       rw [← exp_epilogue_result_word_right evmSp d0 d1 d2 d3
         (evmStackIs (evmSp + 32 + 32) rest)] at hp
       rw [show evmSp + 32 + 32 = evmSp + 64 from by bv_addr] at hp
+      rw [expTwoMulPointerRestoreEpiloguePreFrame_unfold]
+      rw [expTwoMulLoopExitStackTailFrame_unfold]
       xcancel_struct hp)
     (fun _ hp => by
       rw [expTwoMulLoopExitFullStackPostFrame_unfold]

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBoundarySeq.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBoundarySeq.lean
@@ -214,31 +214,6 @@ instance pcFreeInst_expTwoMulLoopExitFullStackPostFrame
         sp evmSp iterCountNew r0 r1 r2 r3 baseWord rest exitCond) :=
   ⟨expTwoMulLoopExitFullStackPostFrame_pcFree⟩
 
-@[irreducible]
-def expTwoMulLoopExitStackTailFrame
-    (evmSp : Word) (baseWord : EvmWord) (rest : List EvmWord) :
-    Assertion :=
-  evmWordIs evmSp baseWord ** evmStackIs (evmSp + 64) rest
-
-theorem expTwoMulLoopExitStackTailFrame_unfold
-    {evmSp : Word} {baseWord : EvmWord} {rest : List EvmWord} :
-    expTwoMulLoopExitStackTailFrame evmSp baseWord rest =
-      (evmWordIs evmSp baseWord ** evmStackIs (evmSp + 64) rest) := by
-  delta expTwoMulLoopExitStackTailFrame
-  rfl
-
-theorem expTwoMulLoopExitStackTailFrame_pcFree
-    {evmSp : Word} {baseWord : EvmWord} {rest : List EvmWord} :
-    (expTwoMulLoopExitStackTailFrame evmSp baseWord rest).pcFree := by
-  rw [expTwoMulLoopExitStackTailFrame_unfold]
-  pcFree
-
-instance pcFreeInst_expTwoMulLoopExitStackTailFrame
-    (evmSp : Word) (baseWord : EvmWord) (rest : List EvmWord) :
-    Assertion.PCFree
-      (expTwoMulLoopExitStackTailFrame evmSp baseWord rest) :=
-  ⟨expTwoMulLoopExitStackTailFrame_pcFree⟩
-
 /-- Pointer-restore followed by the EXP epilogue in the two-MUL saved-bit
     EXP+MUL code bundle. This packages the loop-exit boundary from
     `base + 264` through the final stack-facing writeback at `base + 304`. -/


### PR DESCRIPTION
## Summary
- add a named expTwoMulLoopExitStackTailFrame for the preserved base operand and caller tail at loop exit
- use the named frame in the pointer-restore/epilogue stack-tail wrappers

## Verification
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitBoundarySeq
- lake build EvmAsm.Evm64.Exp
- git diff --check
- scripts/check-unimported.sh
- lake build