### PR TITLE
refactor(exp): reuse boundary tail normalizers

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryPrologue.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryPrologue.lean
@@ -241,14 +241,14 @@ theorem exp_prologue_then_pointer_advance_evm_exp_msb_saved_bit_two_mul_with_mul
       rw [expTwoMulOperandFrame_unfold]
       rw [expTwoMulScratchFrame_unfold] at hp ⊢
       rw [evmStackIs_cons, evmStackIs_cons] at hp
-      rw [show evmSp + 32 + 32 = evmSp + 64#64 from by bv_addr] at hp
+      rw [expTwoMulBoundaryResultTailWord] at hp
       xperm_hyp hp)
     (fun _ hp => by
       dsimp [scratchFrame, operandFrame] at hp ⊢
       rw [expTwoMulOperandFrame_unfold] at hp
       rw [expTwoMulScratchFrame_unfold] at hp ⊢
       rw [evmStackIs_cons, evmStackIs_cons]
-      rw [show evmSp + 64#64 = evmSp + 32 + 32 from by bv_addr] at hp
+      rw [expTwoMulBoundaryResultTailWord_symm_word] at hp
       xperm_hyp hp)
     hFramed
 

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryPrologue.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryPrologue.lean
@@ -84,6 +84,22 @@ theorem expTwoMulPointerRestoreBackToEvmSp (evmSp : Word) :
   rw [signExtend12_64, hNeg64]
   bv_decide
 
+theorem expTwoMulBoundaryResultEvmSpWord (evmSp : Word) :
+    evmSp + signExtend12 (32 : BitVec 12) = evmSp + 32 := by
+  rw [signExtend12_32]
+
+theorem expTwoMulBoundaryResultTailWord (evmSp : Word) :
+    evmSp + 32 + 32 = evmSp + 64#64 := by
+  bv_addr
+
+theorem expTwoMulBoundaryResultTailWord_symm (evmSp : Word) :
+    evmSp + 64 = evmSp + 32#64 + 32#64 := by
+  bv_addr
+
+theorem expTwoMulBoundaryResultTailWord_symm_word (evmSp : Word) :
+    evmSp + 64#64 = evmSp + 32 + 32 := by
+  bv_addr
+
 @[irreducible]
 def expTwoMulLoopExitStackTailFrame
     (evmSp : Word) (baseWord : EvmWord) (rest : List EvmWord) :

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBoundarySeq.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBoundarySeq.lean
@@ -13,22 +13,6 @@ namespace EvmAsm.Evm64.Exp.Compose
 open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
-theorem expTwoMulBoundaryResultEvmSpWord (evmSp : Word) :
-    evmSp + signExtend12 (32 : BitVec 12) = evmSp + 32 := by
-  rw [signExtend12_32]
-
-theorem expTwoMulBoundaryResultTailWord (evmSp : Word) :
-    evmSp + 32 + 32 = evmSp + 64#64 := by
-  bv_addr
-
-theorem expTwoMulBoundaryResultTailWord_symm (evmSp : Word) :
-    evmSp + 64 = evmSp + 32#64 + 32#64 := by
-  bv_addr
-
-theorem expTwoMulBoundaryResultTailWord_symm_word (evmSp : Word) :
-    evmSp + 64#64 = evmSp + 32 + 32 := by
-  bv_addr
-
 @[irreducible]
 def expTwoMulLoopExitControl (iterCountNew : Word) (exitCond : Prop) : Assertion :=
   (.x9 ↦ᵣ iterCountNew) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜exitCond⌝

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBoundarySeq.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBoundarySeq.lean
@@ -25,6 +25,10 @@ theorem expTwoMulBoundaryResultTailWord_symm (evmSp : Word) :
     evmSp + 64 = evmSp + 32#64 + 32#64 := by
   bv_addr
 
+theorem expTwoMulBoundaryResultTailWord_symm_word (evmSp : Word) :
+    evmSp + 64#64 = evmSp + 32 + 32 := by
+  bv_addr
+
 @[irreducible]
 def expTwoMulLoopExitControl (iterCountNew : Word) (exitCond : Prop) : Assertion :=
   (.x9 ↦ᵣ iterCountNew) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜exitCond⌝


### PR DESCRIPTION
## Summary
- add a named boundary tail normalizer for the prologue full-stack postcondition shape
- replace two inline bv_addr rewrites in the EXP saved-bit boundary composition proof

## Verification
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitBoundarySeq
- lake build EvmAsm.Evm64.Exp
- scripts/check-unimported.sh
- lake build