### PR TITLE
refactor(exp): name topcode call addresses

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/TopCallSubs.lean
+++ b/EvmAsm/Evm64/Exp/Compose/TopCallSubs.lean
@@ -11,6 +11,38 @@ namespace EvmAsm.Evm64.Exp.Compose
 
 open EvmAsm.Rv64
 
+theorem expTopSquaringFactor2Addr (base : Word) :
+    (base + 72 : Word) = base + 40 + 32 := by
+  bv_omega
+
+theorem expTopSquaringSquareAddr (base : Word) :
+    (base + 104 : Word) = base + 40 + 64 := by
+  bv_omega
+
+theorem expTopSquaringRestoreAddr (base : Word) :
+    (base + 108 : Word) = base + 40 + 68 := by
+  bv_omega
+
+theorem expTopCondMulCallStartAddr (base : Word) :
+    (base + 148 : Word) = base + 144 + 4 := by
+  bv_omega
+
+theorem expTopCondMulFactor2Addr (base : Word) :
+    (base + 180 : Word) = base + 148 + 32 := by
+  bv_omega
+
+theorem expTopCondMulFactor2Addr_symm (base : Word) :
+    ((base + 148 : Word) + 32) = base + 180 := by
+  bv_omega
+
+theorem expTopCondMulSquareAddr (base : Word) :
+    (base + 212 : Word) = base + 148 + 64 := by
+  bv_omega
+
+theorem expTopCondMulRestoreAddr (base : Word) :
+    (base + 216 : Word) = base + 148 + 68 := by
+  bv_omega
+
 /-- Squaring-call factor-1 marshal sub-block directly included in the
     top-level EXP code bundle. -/
 theorem evmExpCode_squaring_marshal_factor1_sub {base : Word}
@@ -29,8 +61,7 @@ theorem evmExpCode_squaring_marshal_result_to_factor2_sub {base : Word}
       EvmAsm.Evm64.exp_loop_marshal_result_to_factor2) a = some i →
       (evmExpCode base mulOff skipOff backOff) a = some i := by
   intro a i h
-  have haddr : (base + 72 : Word) = base + 40 + 32 := by bv_omega
-  rw [haddr] at h
+  rw [expTopSquaringFactor2Addr] at h
   exact evmExpCode_iter_squaring_sub a i
     (exp_squaring_call_block_code_marshal_result_to_factor2_sub a i h)
 
@@ -42,8 +73,7 @@ theorem evmExpCode_squaring_square_sub {base : Word}
       (EvmAsm.Evm64.exp_square_block mulOff)) a = some i →
       (evmExpCode base mulOff skipOff backOff) a = some i := by
   intro a i h
-  have haddr : (base + 104 : Word) = base + 40 + 64 := by bv_omega
-  rw [haddr] at h
+  rw [expTopSquaringSquareAddr] at h
   exact evmExpCode_iter_squaring_sub a i
     (exp_squaring_call_block_code_square_sub a i h)
 
@@ -55,8 +85,7 @@ theorem evmExpCode_squaring_un_marshal_and_restore_sub {base : Word}
       EvmAsm.Evm64.exp_loop_un_marshal_and_restore) a = some i →
       (evmExpCode base mulOff skipOff backOff) a = some i := by
   intro a i h
-  have haddr : (base + 108 : Word) = base + 40 + 68 := by bv_omega
-  rw [haddr] at h
+  rw [expTopSquaringRestoreAddr] at h
   exact evmExpCode_iter_squaring_sub a i
     (exp_squaring_call_block_code_un_marshal_and_restore_sub a i h)
 
@@ -69,8 +98,7 @@ theorem evmExpCode_cond_mul_marshal_factor1_sub {base : Word}
   intro a i h
   have hcall := exp_cond_mul_call_block_code_marshal_factor1_sub
     (base + 148) mulOff a i h
-  have hskip : (base + 148 : Word) = base + 144 + 4 := by bv_omega
-  rw [hskip] at hcall
+  rw [expTopCondMulCallStartAddr] at hcall
   exact evmExpCode_iter_cond_mul_sub a i
     (EvmAsm.Evm64.exp_cond_mul_call_with_skip_block_code_call_sub
       (base + 144) mulOff skipOff a i hcall)
@@ -83,12 +111,10 @@ theorem evmExpCode_cond_mul_marshal_a_to_factor2_sub {base : Word}
       EvmAsm.Evm64.exp_loop_marshal_a_to_factor2) a = some i →
       (evmExpCode base mulOff skipOff backOff) a = some i := by
   intro a i h
-  have haddr : (base + 180 : Word) = base + 148 + 32 := by bv_omega
-  rw [haddr] at h
+  rw [expTopCondMulFactor2Addr] at h
   have hcall := exp_cond_mul_call_block_code_marshal_a_to_factor2_sub
     (base + 148) mulOff a i h
-  have hskip : (base + 148 : Word) = base + 144 + 4 := by bv_omega
-  rw [hskip] at hcall
+  rw [expTopCondMulCallStartAddr] at hcall
   exact evmExpCode_iter_cond_mul_sub a i
     (EvmAsm.Evm64.exp_cond_mul_call_with_skip_block_code_call_sub
       (base + 144) mulOff skipOff a i hcall)
@@ -101,11 +127,9 @@ theorem evmExpCode_cond_mul_square_sub {base : Word}
       (EvmAsm.Evm64.exp_square_block mulOff)) a = some i →
       (evmExpCode base mulOff skipOff backOff) a = some i := by
   intro a i h
-  have haddr : (base + 212 : Word) = base + 148 + 64 := by bv_omega
-  rw [haddr] at h
+  rw [expTopCondMulSquareAddr] at h
   have hcall := exp_cond_mul_call_block_code_square_sub (base + 148) mulOff a i h
-  have hskip : (base + 148 : Word) = base + 144 + 4 := by bv_omega
-  rw [hskip] at hcall
+  rw [expTopCondMulCallStartAddr] at hcall
   exact evmExpCode_iter_cond_mul_sub a i
     (EvmAsm.Evm64.exp_cond_mul_call_with_skip_block_code_call_sub
       (base + 144) mulOff skipOff a i hcall)
@@ -118,12 +142,10 @@ theorem evmExpCode_cond_mul_un_marshal_and_restore_sub {base : Word}
       EvmAsm.Evm64.exp_loop_un_marshal_and_restore) a = some i →
       (evmExpCode base mulOff skipOff backOff) a = some i := by
   intro a i h
-  have haddr : (base + 216 : Word) = base + 148 + 68 := by bv_omega
-  rw [haddr] at h
+  rw [expTopCondMulRestoreAddr] at h
   have hcall := exp_cond_mul_call_block_code_un_marshal_and_restore_sub
     (base + 148) mulOff a i h
-  have hskip : (base + 148 : Word) = base + 144 + 4 := by bv_omega
-  rw [hskip] at hcall
+  rw [expTopCondMulCallStartAddr] at hcall
   exact evmExpCode_iter_cond_mul_sub a i
     (EvmAsm.Evm64.exp_cond_mul_call_with_skip_block_code_call_sub
       (base + 144) mulOff skipOff a i hcall)

--- a/EvmAsm/Evm64/Exp/Compose/TopCondMulMarshalBlocks.lean
+++ b/EvmAsm/Evm64/Exp/Compose/TopCondMulMarshalBlocks.lean
@@ -39,8 +39,7 @@ theorem exp_cond_mul_marshal_factor1_evm_exp_spec_within
        ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ r3)) := by
   have h := EvmAsm.Evm64.exp_loop_marshal_factor1_ofProg_spec_within
     sp evmSp tOld r0 r1 r2 r3 d0 d1 d2 d3 (base + 148)
-  have hexit : ((base + 148 : Word) + 32) = base + 180 := by bv_omega
-  rw [hexit] at h
+  rw [expTopCondMulFactor2Addr_symm] at h
   exact cpsTripleWithin_extend_code (h := h)
     (hmono := evmExpCode_cond_mul_marshal_factor1_sub)
 

--- a/EvmAsm/Evm64/Exp/Compose/TopPairBlocks.lean
+++ b/EvmAsm/Evm64/Exp/Compose/TopPairBlocks.lean
@@ -113,8 +113,7 @@ theorem exp_cond_mul_marshal_pair_evm_exp_spec_within
       (evmExpCode_cond_mul_marshal_factor1_sub (base := base)
         (mulOff := mulOff) (skipOff := skipOff) (backOff := backOff))
       (fun a i hfactor2 => by
-        have haddr : ((base + 148 : Word) + 32) = base + 180 := by bv_omega
-        rw [haddr] at hfactor2
+        rw [expTopCondMulFactor2Addr_symm] at hfactor2
         exact evmExpCode_cond_mul_marshal_a_to_factor2_sub
           (base := base) (mulOff := mulOff) (skipOff := skipOff)
           (backOff := backOff) a i hfactor2)


### PR DESCRIPTION
## Summary
- add named EXP top-code address normalizers for squaring-call sub-blocks
- add named conditional-multiply call address normalizers and reuse them at call-subsumption sites

## Verification
- lake build EvmAsm.Evm64.Exp.Compose.TopCodeSpecs
- lake build EvmAsm.Evm64.Exp
- scripts/check-unimported.sh
- lake build