### PR TITLE
refactor(exp): name topcode next pcs

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFullLoopPrefix.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFullLoopPrefix.lean
@@ -40,8 +40,7 @@ theorem exp_msb_bit_test_evm_exp_msb_saved_bit_two_mul_with_mul_spec_within
        (.x6 ↦ᵣ (c + signExtend12 ((-1) : BitVec 12))) **
        (.x10 ↦ᵣ (expTwoMulIterBit e))) := by
   have h := EvmAsm.Evm64.exp_msb_bit_test_block_spec_within e c v10 (base + 28)
-  have hnext : ((base + 28 : Word) + 12) = base + 40 := by bv_omega
-  rw [hnext] at h
+  rw [expTopIterBitTestNextPc] at h
   exact cpsTripleWithin_extend_code
     (h := h)
     (hmono := fun a i hi =>
@@ -73,8 +72,7 @@ theorem exp_save_bit_evm_exp_msb_saved_bit_two_mul_with_mul_spec_within
       ((.x10 ↦ᵣ bit) ** (.x18 ↦ᵣ v18))
       ((.x10 ↦ᵣ bit) ** (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12)))) := by
   have h := EvmAsm.Evm64.exp_save_bit_block_spec_within bit v18 (base + 40)
-  have hnext : ((base + 40 : Word) + 4) = base + 44 := by bv_omega
-  rw [hnext] at h
+  rw [expTopSavedBitSaveNextPc] at h
   exact cpsTripleWithin_extend_code
     (h := h)
     (hmono := fun a i hi => by
@@ -183,8 +181,7 @@ theorem exp_cond_mul_saved_bit_beq_evm_exp_msb_saved_bit_two_mul_with_mul_spec_w
   have h := EvmAsm.Rv64.beq_spec_within .x18 .x0 skipOff v18 (0 : Word)
     (base + 148)
   rw [htarget] at h
-  have hnext : ((base + 148 : Word) + 4) = base + 152 := by bv_omega
-  rw [hnext] at h
+  rw [expTopSavedBitCondMulBeqNextPc] at h
   exact cpsBranchWithin_extend_code
     (h := h)
     (hmono := fun a i hi => by
@@ -213,8 +210,7 @@ theorem exp_loop_back_evm_exp_msb_saved_bit_with_mul_spec_within (c : Word)
         ((.x9 ↦ᵣ expIterCountNew c) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜expIterCountNew c = 0⌝) := by
   have h := EvmAsm.Evm64.exp_loop_back_spec_within c backOff (base + 256)
     target htarget
-  have hnext : ((base + 256 : Word) + 8) = base + 264 := by bv_omega
-  rw [hnext] at h
+  rw [expTopSavedBitLoopBackNextPc] at h
   simpa [expIterCountNew] using
     (cpsBranchWithin_extend_code (h := h)
       (hmono := fun a i hi =>

--- a/EvmAsm/Evm64/Exp/Compose/TopBoundaryBlocks.lean
+++ b/EvmAsm/Evm64/Exp/Compose/TopBoundaryBlocks.lean
@@ -11,6 +11,26 @@ namespace EvmAsm.Evm64.Exp.Compose
 
 open EvmAsm.Rv64
 
+theorem expTopPointerAdvanceNextPc (base : Word) :
+    ((base + 24 : Word) + 4) = base + 28 := by
+  bv_omega
+
+theorem expTopPointerRestoreNextPc (base : Word) :
+    ((base + 260 : Word) + 4) = base + 264 := by
+  bv_omega
+
+theorem expTopEpilogueNextPc (base : Word) :
+    ((base + 264 : Word) + 36) = base + 300 := by
+  bv_omega
+
+theorem expTopSavedBitEpilogueEntryNextPc (base : Word) :
+    ((base + 264 : Word) + 4) = base + 268 := by
+  bv_omega
+
+theorem expTopSavedBitEpilogueNextPc (base : Word) :
+    ((base + 268 : Word) + 36) = base + 304 := by
+  bv_omega
+
 /-- Pointer advance lifted to the top-level EXP code bundle. -/
 theorem exp_loop_pointer_advance_evm_exp_spec_within
     (vOld : Word) (mulOff : BitVec 21) (skipOff backOff : BitVec 13)
@@ -20,8 +40,7 @@ theorem exp_loop_pointer_advance_evm_exp_spec_within
       (.x12 ↦ᵣ vOld)
       (.x12 ↦ᵣ (vOld + signExtend12 (64 : BitVec 12))) := by
   have h := EvmAsm.Evm64.exp_loop_pointer_advance_spec_within vOld (base + 24)
-  have hnext : ((base + 24 : Word) + 4) = base + 28 := by bv_omega
-  rw [hnext] at h
+  rw [expTopPointerAdvanceNextPc] at h
   exact cpsTripleWithin_extend_code (h := h) (hmono := evmExpCode_pointer_advance_sub)
 
 /-- Pointer restore lifted to the top-level EXP code bundle. -/
@@ -33,8 +52,7 @@ theorem exp_loop_pointer_restore_evm_exp_spec_within
       (.x12 ↦ᵣ vOld)
       (.x12 ↦ᵣ (vOld + signExtend12 ((-64) : BitVec 12))) := by
   have h := EvmAsm.Evm64.exp_loop_pointer_restore_spec_within vOld (base + 260)
-  have hnext : ((base + 260 : Word) + 4) = base + 264 := by bv_omega
-  rw [hnext] at h
+  rw [expTopPointerRestoreNextPc] at h
   exact cpsTripleWithin_extend_code (h := h) (hmono := evmExpCode_pointer_restore_sub)
 
 /-- EXP prologue lifted to the top-level EXP code bundle. -/
@@ -83,8 +101,7 @@ theorem exp_epilogue_evm_exp_spec_within
        evmWordIs (evmSp + 32) (expResultWord r0 r1 r2 r3)) := by
   have h := EvmAsm.Evm64.exp_epilogue_word_spec_within
     sp evmSp tOld r0 r1 r2 r3 d0 d1 d2 d3 (base + 264)
-  have hnext : ((base + 264 : Word) + 36) = base + 300 := by bv_omega
-  rw [hnext] at h
+  rw [expTopEpilogueNextPc] at h
   exact cpsTripleWithin_extend_code (h := h) (hmono := evmExpCode_epilogue_sub)
 
 /-- Pointer advance lifted to the two-MUL saved-bit top-level EXP code
@@ -98,8 +115,7 @@ theorem exp_loop_pointer_advance_evm_exp_msb_saved_bit_two_mul_spec_within
       (.x12 ↦ᵣ vOld)
       (.x12 ↦ᵣ (vOld + signExtend12 (64 : BitVec 12))) := by
   have h := EvmAsm.Evm64.exp_loop_pointer_advance_spec_within vOld (base + 24)
-  have hnext : ((base + 24 : Word) + 4) = base + 28 := by bv_omega
-  rw [hnext] at h
+  rw [expTopPointerAdvanceNextPc] at h
   exact cpsTripleWithin_extend_code
     (h := h)
     (hmono := evmExpMsbSavedBitTwoMulCode_pointer_advance_sub)
@@ -115,8 +131,7 @@ theorem exp_loop_pointer_restore_evm_exp_msb_saved_bit_two_mul_spec_within
       (.x12 ↦ᵣ vOld)
       (.x12 ↦ᵣ (vOld + signExtend12 ((-64) : BitVec 12))) := by
   have h := EvmAsm.Evm64.exp_loop_pointer_restore_spec_within vOld (base + 264)
-  have hnext : ((base + 264 : Word) + 4) = base + 268 := by bv_omega
-  rw [hnext] at h
+  rw [expTopSavedBitEpilogueEntryNextPc] at h
   exact cpsTripleWithin_extend_code
     (h := h)
     (hmono := evmExpMsbSavedBitTwoMulCode_pointer_restore_sub)
@@ -171,8 +186,7 @@ theorem exp_epilogue_evm_exp_msb_saved_bit_two_mul_spec_within
        evmWordIs (evmSp + 32) (expResultWord r0 r1 r2 r3)) := by
   have h := EvmAsm.Evm64.exp_epilogue_word_spec_within
     sp evmSp tOld r0 r1 r2 r3 d0 d1 d2 d3 (base + 268)
-  have hnext : ((base + 268 : Word) + 36) = base + 304 := by bv_omega
-  rw [hnext] at h
+  rw [expTopSavedBitEpilogueNextPc] at h
   exact cpsTripleWithin_extend_code
     (h := h)
     (hmono := evmExpMsbSavedBitTwoMulCode_epilogue_sub)

--- a/EvmAsm/Evm64/Exp/Compose/TopCallSubs.lean
+++ b/EvmAsm/Evm64/Exp/Compose/TopCallSubs.lean
@@ -161,4 +161,16 @@ theorem evmExpCode_cond_mul_beq_sub {base : Word}
     (EvmAsm.Evm64.exp_cond_mul_call_with_skip_block_code_beq_sub
       (base + 144) mulOff skipOff a i h)
 
+theorem expTopCondMulBeqNextPc (base : Word) :
+    ((base + 144 : Word) + 4) = base + 148 := by
+  bv_omega
+
+theorem expTopSavedBitCondMulBeqNextPc (base : Word) :
+    ((base + 148 : Word) + 4) = base + 152 := by
+  bv_omega
+
+theorem expTopCondMulMarshalPairNextPc (base : Word) :
+    ((base + 148 : Word) + 64) = base + 212 := by
+  bv_omega
+
 end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/TopCondMulMarshalBlocks.lean
+++ b/EvmAsm/Evm64/Exp/Compose/TopCondMulMarshalBlocks.lean
@@ -128,8 +128,7 @@ theorem exp_cond_mul_beq_evm_exp_spec_within
   have h := EvmAsm.Rv64.beq_spec_within .x10 .x0 skipOff v10 (0 : Word)
     (base + 144)
   rw [htarget] at h
-  have hnext : ((base + 144 : Word) + 4) = base + 148 := by bv_omega
-  rw [hnext] at h
+  rw [expTopCondMulBeqNextPc] at h
   exact cpsBranchWithin_extend_code (h := h)
     (hmono := evmExpCode_cond_mul_beq_sub)
 
@@ -149,8 +148,7 @@ theorem exp_cond_mul_saved_bit_beq_evm_exp_msb_saved_bit_spec_within
   have h := EvmAsm.Rv64.beq_spec_within .x18 .x0 skipOff v18 (0 : Word)
     (base + 148)
   rw [htarget] at h
-  have hnext : ((base + 148 : Word) + 4) = base + 152 := by bv_omega
-  rw [hnext] at h
+  rw [expTopSavedBitCondMulBeqNextPc] at h
   exact cpsBranchWithin_extend_code (h := h)
     (hmono := evmExpMsbSavedBitCode_cond_mul_beq_sub)
 

--- a/EvmAsm/Evm64/Exp/Compose/TopIterSubs.lean
+++ b/EvmAsm/Evm64/Exp/Compose/TopIterSubs.lean
@@ -35,6 +35,22 @@ theorem expTopIterLoopBackAddr (base : Word) :
     (base + 252 : Word) = base + 28 + 224 := by
   bv_omega
 
+theorem expTopIterBitTestNextPc (base : Word) :
+    ((base + 28 : Word) + 12) = base + 40 := by
+  bv_omega
+
+theorem expTopSavedBitSaveNextPc (base : Word) :
+    ((base + 40 : Word) + 4) = base + 44 := by
+  bv_omega
+
+theorem expTopLoopBackNextPc (base : Word) :
+    ((base + 252 : Word) + 8) = base + 260 := by
+  bv_omega
+
+theorem expTopSavedBitLoopBackNextPc (base : Word) :
+    ((base + 256 : Word) + 8) = base + 264 := by
+  bv_omega
+
 /-- Bit-test sub-block directly included in the top-level EXP code bundle. -/
 theorem evmExpCode_iter_bit_test_sub {base : Word}
     {mulOff : BitVec 21} {skipOff backOff : BitVec 13} :

--- a/EvmAsm/Evm64/Exp/Compose/TopLoopControl.lean
+++ b/EvmAsm/Evm64/Exp/Compose/TopLoopControl.lean
@@ -21,8 +21,7 @@ theorem exp_bit_test_evm_exp_spec_within
        (.x6 ↦ᵣ (c + signExtend12 ((-1) : BitVec 12))) **
        (.x10 ↦ᵣ (e &&& signExtend12 (1 : BitVec 12)))) := by
   have h := EvmAsm.Evm64.exp_bit_test_block_spec_within e c v10 (base + 28)
-  have hnext : ((base + 28 : Word) + 12) = base + 40 := by bv_omega
-  rw [hnext] at h
+  rw [expTopIterBitTestNextPc] at h
   exact cpsTripleWithin_extend_code (h := h) (hmono := evmExpCode_iter_bit_test_sub)
 
 /-- MSB bit-test block lifted to the corrected saved-bit top-level EXP code
@@ -37,8 +36,7 @@ theorem exp_msb_bit_test_evm_exp_msb_saved_bit_spec_within
        (.x6 ↦ᵣ (c + signExtend12 ((-1) : BitVec 12))) **
        (.x10 ↦ᵣ (expTwoMulIterBit e))) := by
   have h := EvmAsm.Evm64.exp_msb_bit_test_block_spec_within e c v10 (base + 28)
-  have hnext : ((base + 28 : Word) + 12) = base + 40 := by bv_omega
-  rw [hnext] at h
+  rw [expTopIterBitTestNextPc] at h
   exact cpsTripleWithin_extend_code (h := h)
     (hmono := evmExpMsbSavedBitCode_iter_bit_test_sub)
 
@@ -52,8 +50,7 @@ theorem exp_save_bit_evm_exp_msb_saved_bit_spec_within
       ((.x10 ↦ᵣ bit) ** (.x18 ↦ᵣ v18))
       ((.x10 ↦ᵣ bit) ** (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12)))) := by
   have h := EvmAsm.Evm64.exp_save_bit_block_spec_within bit v18 (base + 40)
-  have hnext : ((base + 40 : Word) + 4) = base + 44 := by bv_omega
-  rw [hnext] at h
+  rw [expTopSavedBitSaveNextPc] at h
   exact cpsTripleWithin_extend_code (h := h)
     (hmono := evmExpMsbSavedBitCode_iter_save_bit_sub)
 
@@ -70,8 +67,7 @@ theorem exp_loop_back_evm_exp_spec_within (c : Word)
       (base + 260)
         ((.x9 ↦ᵣ expIterCountNew c) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜expIterCountNew c = 0⌝) := by
   have h := EvmAsm.Evm64.exp_loop_back_spec_within c backOff (base + 252) target htarget
-  have hnext : ((base + 252 : Word) + 8) = base + 260 := by bv_omega
-  rw [hnext] at h
+  rw [expTopLoopBackNextPc] at h
   simpa [expIterCountNew] using
     (cpsBranchWithin_extend_code (h := h) (hmono := evmExpCode_iter_loop_back_sub))
 

--- a/EvmAsm/Evm64/Exp/Compose/TopPairBlocks.lean
+++ b/EvmAsm/Evm64/Exp/Compose/TopPairBlocks.lean
@@ -101,8 +101,7 @@ theorem exp_cond_mul_marshal_pair_evm_exp_spec_within
        ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3)) := by
   have h := EvmAsm.Evm64.exp_loop_cond_mul_marshal_pair_spec_within
     sp evmSp tOld r0 r1 r2 r3 a0 a1 a2 a3 d0 d1 d2 d3 e0 e1 e2 e3 (base + 148)
-  have hnext : ((base + 148 : Word) + 64) = base + 212 := by bv_omega
-  rw [hnext] at h
+  rw [expTopCondMulMarshalPairNextPc] at h
   have hmono :
       ∀ addr instr, EvmAsm.Evm64.exp_loop_cond_mul_marshal_pair_code
           (base + 148) addr = some instr →


### PR DESCRIPTION
## Summary
- add named EXP top-code next-PC normalizers
- replace repeated inline hnext proofs in lifted top-code specs

## Verification
- lake build EvmAsm.Evm64.Exp.Compose.TopCodeSpecs
- lake build EvmAsm.Evm64.Exp
- scripts/check-unimported.sh
- lake build