### PR TITLE
refactor(exp): name topcode exit pcs

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/TopCondMulMarshalBlocks.lean
+++ b/EvmAsm/Evm64/Exp/Compose/TopCondMulMarshalBlocks.lean
@@ -11,6 +11,18 @@ namespace EvmAsm.Evm64.Exp.Compose
 
 open EvmAsm.Rv64
 
+theorem expTopCondMulFactor1ExitPc (base : Word) :
+    ((base + 148 : Word) + 32) = base + 180 := by
+  bv_omega
+
+theorem expTopCondMulFactor2ExitPc (base : Word) :
+    ((base + 180 : Word) + 32) = base + 212 := by
+  bv_omega
+
+theorem expTopCondMulRestoreExitPc (base : Word) :
+    ((base + 216 : Word) + 36) = base + 252 := by
+  bv_omega
+
 /-- Conditional-multiply factor-1 marshal spec lifted to the top-level EXP
     code bundle: at offset `base + 148`, copies result limbs from scratch to
     factor1, exits at `base + 180`. -/
@@ -72,8 +84,7 @@ theorem exp_cond_mul_marshal_a_to_factor2_evm_exp_spec_within
        ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ a3)) := by
   have h := EvmAsm.Evm64.exp_loop_marshal_a_to_factor2_ofProg_spec_within
     evmSp tOld a0 a1 a2 a3 d0 d1 d2 d3 (base + 180)
-  have hexit : ((base + 180 : Word) + 32) = base + 212 := by bv_omega
-  rw [hexit] at h
+  rw [expTopCondMulFactor2ExitPc] at h
   exact cpsTripleWithin_extend_code (h := h)
     (hmono := evmExpCode_cond_mul_marshal_a_to_factor2_sub)
 
@@ -107,8 +118,7 @@ theorem exp_cond_mul_un_marshal_and_restore_evm_exp_spec_within
        ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ d3)) := by
   have h := EvmAsm.Evm64.exp_loop_un_marshal_and_restore_ofProg_spec_within
     sp evmSp tOld r0 r1 r2 r3 d0 d1 d2 d3 (base + 216)
-  have hexit : ((base + 216 : Word) + 36) = base + 252 := by bv_omega
-  rw [hexit] at h
+  rw [expTopCondMulRestoreExitPc] at h
   exact cpsTripleWithin_extend_code (h := h)
     (hmono := evmExpCode_cond_mul_un_marshal_and_restore_sub)
 

--- a/EvmAsm/Evm64/Exp/Compose/TopJalBlocks.lean
+++ b/EvmAsm/Evm64/Exp/Compose/TopJalBlocks.lean
@@ -10,6 +10,14 @@ namespace EvmAsm.Evm64.Exp.Compose
 
 open EvmAsm.Rv64
 
+theorem expTopSquaringSquareReturnPc (base : Word) :
+    ((base + 104 : Word) + 4) = base + 108 := by
+  bv_omega
+
+theorem expTopCondMulSquareReturnPc (base : Word) :
+    ((base + 212 : Word) + 4) = base + 216 := by
+  bv_omega
+
 /-- Squaring-call JAL spec lifted to the top-level EXP code bundle. -/
 theorem exp_squaring_square_evm_exp_spec_within
     (mulOff : BitVec 21) (skipOff backOff : BitVec 13)
@@ -21,8 +29,7 @@ theorem exp_squaring_square_evm_exp_spec_within
       (.x1 ↦ᵣ (base + 108)) := by
   have h := EvmAsm.Evm64.exp_square_block_spec_within mulOff vOld (base + 104)
   rw [hmul] at h
-  have hret : ((base + 104 : Word) + 4) = base + 108 := by bv_omega
-  rw [hret] at h
+  rw [expTopSquaringSquareReturnPc] at h
   exact cpsTripleWithin_extend_code (h := h) (hmono := evmExpCode_squaring_square_sub)
 
 /-- Conditional-multiply JAL spec lifted to the top-level EXP code bundle. -/
@@ -36,8 +43,7 @@ theorem exp_cond_mul_square_evm_exp_spec_within
       (.x1 ↦ᵣ (base + 216)) := by
   have h := EvmAsm.Evm64.exp_square_block_spec_within mulOff vOld (base + 212)
   rw [hmul] at h
-  have hret : ((base + 212 : Word) + 4) = base + 216 := by bv_omega
-  rw [hret] at h
+  rw [expTopCondMulSquareReturnPc] at h
   exact cpsTripleWithin_extend_code (h := h) (hmono := evmExpCode_cond_mul_square_sub)
 
 end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/TopPairBlocks.lean
+++ b/EvmAsm/Evm64/Exp/Compose/TopPairBlocks.lean
@@ -12,6 +12,10 @@ namespace EvmAsm.Evm64.Exp.Compose
 
 open EvmAsm.Rv64
 
+theorem expTopSquaringMarshalPairReturnPc (base : Word) :
+    ((base + 40 : Word) + 68) = base + 108 := by
+  bv_omega
+
 /-- Squaring-call marshal prefix and JAL lifted to the top-level EXP code bundle. -/
 theorem exp_squaring_marshal_pair_then_square_evm_exp_spec_within
     (sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 : Word)
@@ -54,8 +58,7 @@ theorem exp_squaring_marshal_pair_then_square_evm_exp_spec_within
     rw [show ((base + 40 : Word) + 64) = base + 104 by bv_omega]
     exact hmul
   rw [htarget] at h
-  have hret : ((base + 40 : Word) + 68) = base + 108 := by bv_omega
-  rw [hret] at h
+  rw [expTopSquaringMarshalPairReturnPc] at h
   exact cpsTripleWithin_extend_code (h := h) (hmono := evmExpCode_iter_squaring_sub)
 
 /-- Conditional-multiply marshal pair lifted to the top-level EXP code bundle. -/

--- a/EvmAsm/Evm64/Exp/Compose/TopSquaringMarshalBlocks.lean
+++ b/EvmAsm/Evm64/Exp/Compose/TopSquaringMarshalBlocks.lean
@@ -11,6 +11,18 @@ namespace EvmAsm.Evm64.Exp.Compose
 
 open EvmAsm.Rv64
 
+theorem expTopSquaringFactor1ExitPc (base : Word) :
+    ((base + 40 : Word) + 32) = base + 72 := by
+  bv_omega
+
+theorem expTopSquaringFactor2ExitPc (base : Word) :
+    ((base + 72 : Word) + 32) = base + 104 := by
+  bv_omega
+
+theorem expTopSquaringRestoreExitPc (base : Word) :
+    ((base + 108 : Word) + 36) = base + 144 := by
+  bv_omega
+
 /-- Squaring-call factor-1 marshal spec lifted to the top-level EXP code
     bundle: at offset `base + 40`, copies result limbs from scratch to
     factor1, exits at `base + 72`. -/
@@ -39,8 +51,7 @@ theorem exp_squaring_marshal_factor1_evm_exp_spec_within
        ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ r3)) := by
   have h := EvmAsm.Evm64.exp_loop_marshal_factor1_ofProg_spec_within
     sp evmSp tOld r0 r1 r2 r3 d0 d1 d2 d3 (base + 40)
-  have hexit : ((base + 40 : Word) + 32) = base + 72 := by bv_omega
-  rw [hexit] at h
+  rw [expTopSquaringFactor1ExitPc] at h
   exact cpsTripleWithin_extend_code (h := h)
     (hmono := evmExpCode_squaring_marshal_factor1_sub)
 
@@ -72,8 +83,7 @@ theorem exp_squaring_marshal_result_to_factor2_evm_exp_spec_within
        ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ r3)) := by
   have h := EvmAsm.Evm64.exp_loop_marshal_result_to_factor2_ofProg_spec_within
     sp evmSp tOld r0 r1 r2 r3 d0 d1 d2 d3 (base + 72)
-  have hexit : ((base + 72 : Word) + 32) = base + 104 := by bv_omega
-  rw [hexit] at h
+  rw [expTopSquaringFactor2ExitPc] at h
   exact cpsTripleWithin_extend_code (h := h)
     (hmono := evmExpCode_squaring_marshal_result_to_factor2_sub)
 
@@ -107,8 +117,7 @@ theorem exp_squaring_un_marshal_and_restore_evm_exp_spec_within
        ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ d3)) := by
   have h := EvmAsm.Evm64.exp_loop_un_marshal_and_restore_ofProg_spec_within
     sp evmSp tOld r0 r1 r2 r3 d0 d1 d2 d3 (base + 108)
-  have hexit : ((base + 108 : Word) + 36) = base + 144 := by bv_omega
-  rw [hexit] at h
+  rw [expTopSquaringRestoreExitPc] at h
   exact cpsTripleWithin_extend_code (h := h)
     (hmono := evmExpCode_squaring_un_marshal_and_restore_sub)
 


### PR DESCRIPTION
## Summary
- add named EXP top-code return and exit PC normalizers
- replace repeated inline hret/hexit proofs in lifted top-code specs

## Verification
- lake build EvmAsm.Evm64.Exp.Compose.TopCodeSpecs
- lake build EvmAsm.Evm64.Exp
- scripts/check-unimported.sh
- lake build