### PR TITLE
refactor(exp): name full-loop cond-mul call address

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/CondMulCallBlock.lean
+++ b/EvmAsm/Evm64/Exp/Compose/CondMulCallBlock.lean
@@ -65,8 +65,7 @@ theorem exp_cond_mul_call_block_evm_exp_with_mul_spec_within
       exp_cond_mul_call_block_code (base + 148) mulOff a = some i →
       evmExpCode base mulOff skipOff backOff a = some i := by
     intro a i h
-    have hskip : (base + 148 : Word) = base + 144 + 4 := by bv_omega
-    rw [hskip] at h
+    rw [expFullLoopCondMulCallAddr] at h
     exact evmExpCode_iter_cond_mul_sub a i
       (EvmAsm.Evm64.exp_cond_mul_call_with_skip_block_code_call_sub
         (base + 144) mulOff skipOff a i h)

--- a/EvmAsm/Evm64/Exp/Compose/CondMulCallPath.lean
+++ b/EvmAsm/Evm64/Exp/Compose/CondMulCallPath.lean
@@ -12,6 +12,10 @@ namespace EvmAsm.Evm64.Exp.Compose
 
 open EvmAsm.Rv64
 
+theorem expFullLoopCondMulCallAddr (base : Word) :
+    (base + 148 : Word) = base + 144 + 4 := by
+  bv_omega
+
 /-- Cond-mul-side marshal-pair + JAL + `mul_callable` round-trip lifted from
     the disjoint-union code `exp_cond_mul_call_block_code.union mul_callable_code`
     into the combined `evmExpWithMulCode` bundle. Sibling of
@@ -64,8 +68,7 @@ theorem exp_cond_mul_marshal_pair_then_mul_call_evm_exp_with_mul_spec_within
       exp_cond_mul_call_block_code (base + 148) mulOff a = some i →
       evmExpCode base mulOff skipOff backOff a = some i := by
     intro a i h
-    have hskip : (base + 148 : Word) = base + 144 + 4 := by bv_omega
-    rw [hskip] at h
+    rw [expFullLoopCondMulCallAddr] at h
     exact evmExpCode_iter_cond_mul_sub a i
       (EvmAsm.Evm64.exp_cond_mul_call_with_skip_block_code_call_sub
         (base + 144) mulOff skipOff a i h)


### PR DESCRIPTION
## Summary
- add a named full-loop conditional-multiply call-entry address normalizer
- replace duplicate inline hskip rewrites in FullLoop

## Verification
- lake build EvmAsm.Evm64.Exp.Compose.FullLoop
- lake build EvmAsm.Evm64.Exp
- scripts/check-unimported.sh
- lake build