### PR TITLE
refactor(exp): name saved-bit full-loop pcs

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFullLoop.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFullLoop.lean
@@ -10,4 +10,22 @@ import EvmAsm.Evm64.Exp.Compose.SavedBitFullLoopBranch
 
 namespace EvmAsm.Evm64.Exp.Compose
 
+open EvmAsm.Rv64
+
+theorem expSavedBitBitTestNextPc (base : Word) :
+    ((base + 28 : Word) + 12) = base + 40 := by
+  bv_omega
+
+theorem expSavedBitSaveNextPc (base : Word) :
+    ((base + 40 : Word) + 4) = base + 44 := by
+  bv_omega
+
+theorem expSavedBitCondMulBeqNextPc (base : Word) :
+    ((base + 148 : Word) + 4) = base + 152 := by
+  bv_omega
+
+theorem expSavedBitLoopBackNextPc (base : Word) :
+    ((base + 256 : Word) + 8) = base + 264 := by
+  bv_omega
+
 end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulSkip.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulSkip.lean
@@ -31,8 +31,7 @@ theorem exp_loop_back_evm_exp_msb_saved_bit_two_mul_with_mul_spec_within
           ⌜expTwoMulIterCountNew c = 0⌝) := by
   have h := EvmAsm.Evm64.exp_loop_back_spec_within c backOff (base + 256)
     target htarget
-  have hnext : ((base + 256 : Word) + 8) = base + 264 := by bv_omega
-  rw [hnext] at h
+  rw [expSavedBitLoopBackNextPc] at h
   simpa [expTwoMulIterCountNew] using
     (cpsBranchWithin_extend_code (h := h)
       (hmono := fun a i hi =>


### PR DESCRIPTION
## Summary
- add named saved-bit full-loop next-PC normalizers
- replace inline hnext rewrites in the two-MUL saved-bit lifts

## Verification
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitFullLoop
- lake build EvmAsm.Evm64.Exp
- scripts/check-unimported.sh
- lake build