### PR TITLE
refactor(exp): name two-mul skip loopback pc

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulSkip.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulSkip.lean
@@ -12,6 +12,10 @@ namespace EvmAsm.Evm64.Exp.Compose
 open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
+theorem expTwoMulSkipLoopBackNextPc (base : Word) :
+    ((base + 256 : Word) + 8) = base + 264 := by
+  bv_omega
+
 /-- Saved-bit loop-back block lifted to the two-MUL-offset EXP+MUL code
     bundle. -/
 theorem exp_loop_back_evm_exp_msb_saved_bit_two_mul_with_mul_spec_within
@@ -31,7 +35,7 @@ theorem exp_loop_back_evm_exp_msb_saved_bit_two_mul_with_mul_spec_within
           ⌜expTwoMulIterCountNew c = 0⌝) := by
   have h := EvmAsm.Evm64.exp_loop_back_spec_within c backOff (base + 256)
     target htarget
-  rw [expSavedBitLoopBackNextPc] at h
+  rw [expTwoMulSkipLoopBackNextPc] at h
   simpa [expTwoMulIterCountNew] using
     (cpsBranchWithin_extend_code (h := h)
       (hmono := fun a i hi =>


### PR DESCRIPTION
## Summary
- add a named two-MUL skip loop-back next-PC normalizer
- replace the inline hnext rewrite in SavedBitTwoMulSkip

## Verification
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitTwoMulSkip
- lake build EvmAsm.Evm64.Exp
- scripts/check-unimported.sh
- lake build