### PR TITLE
refactor(exp): name negative frame offset

### DIFF
--- a/EvmAsm/Evm64/Exp/AddrNorm.lean
+++ b/EvmAsm/Evm64/Exp/AddrNorm.lean
@@ -22,6 +22,9 @@ namespace EvmAsm.Evm64.Exp.AddrNorm
 @[exp_addr, grind =] theorem exp_se13_neg228 :
     EvmAsm.Rv64.signExtend13 ((-228 : BitVec 13)) = (18446744073709551388 : Word) := by decide
 
+@[exp_addr, grind =] theorem exp_se12_neg64 :
+    EvmAsm.Rv64.signExtend12 ((-64 : BitVec 12)) = (18446744073709551552 : Word) := by decide
+
 attribute [exp_addr]
   EvmAsm.Rv64.signExtend12_0 EvmAsm.Rv64.signExtend12_1
   EvmAsm.Rv64.signExtend12_8 EvmAsm.Rv64.signExtend12_16

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryEpilogueBase.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryEpilogueBase.lean
@@ -6,6 +6,7 @@
 -/
 
 import EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryPrologue
+import EvmAsm.Evm64.Exp.AddrNorm
 import EvmAsm.Rv64.Tactics.XCancelStruct
 
 namespace EvmAsm.Evm64.Exp.Compose
@@ -57,10 +58,7 @@ theorem exp_pointer_restore_then_epilogue_evm_exp_msb_saved_bit_two_mul_with_mul
     pcFree) hRestore
   have hPtr : (evmSp + signExtend12 (64 : BitVec 12)) +
       signExtend12 ((-64) : BitVec 12) = evmSp := by
-    have hNeg64 :
-        signExtend12 ((-64) : BitVec 12) =
-          (18446744073709551552 : Word) := by decide
-    rw [signExtend12_64, hNeg64]
+    rw [signExtend12_64, EvmAsm.Evm64.Exp.AddrNorm.exp_se12_neg64]
     bv_decide
   have hRestoreFramed' :
       cpsTripleWithin 1 (base + 264) (base + 268)


### PR DESCRIPTION
## Summary
- add EXP-local exp_addr normalization for signExtend12 (-64)
- consume the named offset in the two-MUL boundary pointer-restore proof
- update the EXP AddrNorm header now that it carries concrete local facts

## Verification
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitBoundarySeq
- lake build EvmAsm.Evm64.Exp
- scripts/check-unimported.sh
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/AddrNorm.lean EvmAsm/Evm64/Exp/Compose/SavedBitBoundarySeq.lean