### PR TITLE
refactor(sdiv): name stack slot addresses

### DIFF
--- a/EvmAsm/Evm64/SDiv/AddrNorm.lean
+++ b/EvmAsm/Evm64/SDiv/AddrNorm.lean
@@ -3,17 +3,89 @@
 
   Address-normalization simp set for SDIV composition proofs.
 
-  Skeleton placeholder for GH #90 (beads slice evm-asm-kyp6). The
-  `@[sdiv_addr, grind =]`-tagged atomic facts will be added once the
-  Compose layer (`SDiv/Compose/...`) starts emitting concrete address
-  arithmetic. For now this file just imports the shared `Rv64.AddrNorm`
-  base and the attribute declaration so downstream files can already
-  open the namespace.
+  The base `signExtend12` literals live in `Rv64.AddrNorm`; this module
+  re-tags the SDIV stack-slot subset and records the composed address
+  equalities that recur in the SDIV bridge layer.
 -/
 
 import EvmAsm.Rv64.AddrNorm
 import EvmAsm.Evm64.SDiv.AddrNormAttr
+import EvmAsm.Evm64.SDiv.Program
 
 namespace EvmAsm.Evm64.SDiv.AddrNorm
+
+attribute [sdiv_addr]
+  EvmAsm.Rv64.AddrNorm.se12_0
+  EvmAsm.Rv64.AddrNorm.se12_8
+  EvmAsm.Rv64.AddrNorm.se12_16
+  EvmAsm.Rv64.AddrNorm.se12_24
+  EvmAsm.Rv64.AddrNorm.se12_32
+  EvmAsm.Rv64.AddrNorm.se12_40
+  EvmAsm.Rv64.AddrNorm.se12_48
+  EvmAsm.Rv64.AddrNorm.se12_56
+
+@[sdiv_addr, grind =] theorem stackSlot0 (sp : Word) :
+    (sp + EvmAsm.Rv64.signExtend12 (0 : BitVec 12) : Word) = sp := by
+  rw [EvmAsm.Rv64.AddrNorm.se12_0]
+  simp
+
+@[sdiv_addr, grind =] theorem stackSlot8 (sp : Word) :
+    (sp + EvmAsm.Rv64.signExtend12 (8 : BitVec 12) : Word) = sp + 8 := by
+  rw [EvmAsm.Rv64.AddrNorm.se12_8]
+
+@[sdiv_addr, grind =] theorem stackSlot16 (sp : Word) :
+    (sp + EvmAsm.Rv64.signExtend12 (16 : BitVec 12) : Word) = sp + 16 := by
+  rw [EvmAsm.Rv64.AddrNorm.se12_16]
+
+@[sdiv_addr, grind =] theorem stackSlot24 (sp : Word) :
+    (sp + EvmAsm.Rv64.signExtend12 (24 : BitVec 12) : Word) = sp + 24 := by
+  rw [EvmAsm.Rv64.AddrNorm.se12_24]
+
+@[sdiv_addr, grind =] theorem stackSlot32 (sp : Word) :
+    (sp + EvmAsm.Rv64.signExtend12 (32 : BitVec 12) : Word) = sp + 32 := by
+  rw [EvmAsm.Rv64.AddrNorm.se12_32]
+
+@[sdiv_addr, grind =] theorem stackSlot40 (sp : Word) :
+    (sp + EvmAsm.Rv64.signExtend12 (40 : BitVec 12) : Word) = sp + 40 := by
+  rw [EvmAsm.Rv64.AddrNorm.se12_40]
+
+@[sdiv_addr, grind =] theorem stackSlot48 (sp : Word) :
+    (sp + EvmAsm.Rv64.signExtend12 (48 : BitVec 12) : Word) = sp + 48 := by
+  rw [EvmAsm.Rv64.AddrNorm.se12_48]
+
+@[sdiv_addr, grind =] theorem stackSlot56 (sp : Word) :
+    (sp + EvmAsm.Rv64.signExtend12 (56 : BitVec 12) : Word) = sp + 56 := by
+  rw [EvmAsm.Rv64.AddrNorm.se12_56]
+
+@[sdiv_addr, grind =] theorem divisorBaseSlot0 (sp : Word) :
+    (sp + EvmAsm.Rv64.signExtend12 (32 : BitVec 12) : Word) = sp + 32 := by
+  exact stackSlot32 sp
+
+@[sdiv_addr, grind =] theorem divisorBaseSlot8 (sp : Word) :
+    (sp + EvmAsm.Rv64.signExtend12 (40 : BitVec 12) : Word) = (sp + 32) + 8 := by
+  rw [EvmAsm.Rv64.AddrNorm.se12_40]
+  bv_decide
+
+@[sdiv_addr, grind =] theorem divisorBaseSlot16 (sp : Word) :
+    (sp + EvmAsm.Rv64.signExtend12 (48 : BitVec 12) : Word) = (sp + 32) + 16 := by
+  rw [EvmAsm.Rv64.AddrNorm.se12_48]
+  bv_decide
+
+@[sdiv_addr, grind =] theorem divisorBaseSlot24 (sp : Word) :
+    (sp + EvmAsm.Rv64.signExtend12 (56 : BitVec 12) : Word) = (sp + 32) + 24 := by
+  rw [EvmAsm.Rv64.AddrNorm.se12_56]
+  bv_decide
+
+@[sdiv_addr, grind =] theorem dividendTopSlot (sp : Word) :
+    (sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff : Word) =
+      sp + 24 := by
+  unfold EvmAsm.Evm64.evm_sdivDividendTopLimbOff
+  exact stackSlot24 sp
+
+@[sdiv_addr, grind =] theorem divisorTopSlot (sp : Word) :
+    (sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff : Word) =
+      sp + 56 := by
+  unfold EvmAsm.Evm64.evm_sdivDivisorTopLimbOff
+  exact stackSlot56 sp
 
 end EvmAsm.Evm64.SDiv.AddrNorm

--- a/EvmAsm/Evm64/SDiv/Compose/Bridges.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/Bridges.lean
@@ -73,26 +73,13 @@ theorem divModStackDispatchPre_unfold_explicit_sdiv
     EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
        shiftMem nMem jMem retMem dMem dloMem scratch_un0) := by
   rw [divModStackDispatchPre_unfold_explicit]
-  rw [show (sp + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)) = sp by
-    rw [show EvmAsm.Rv64.signExtend12 (0 : BitVec 12) = (0 : Word) by decide]
-    simp]
-  rw [show (sp + EvmAsm.Rv64.signExtend12 (8 : BitVec 12)) = sp + 8 by
-    rw [show EvmAsm.Rv64.signExtend12 (8 : BitVec 12) = (8 : Word) by decide]]
-  rw [show (sp + EvmAsm.Rv64.signExtend12 (16 : BitVec 12)) = sp + 16 by
-    rw [show EvmAsm.Rv64.signExtend12 (16 : BitVec 12) = (16 : Word) by decide]]
-  rw [show (sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) =
-      sp + 24 by
-    unfold EvmAsm.Evm64.evm_sdivDividendTopLimbOff
-    rw [show EvmAsm.Rv64.signExtend12 (24 : BitVec 12) = (24 : Word) by decide]]
-  rw [show (sp + EvmAsm.Rv64.signExtend12 (32 : BitVec 12)) = sp + 32 by
-    rw [show EvmAsm.Rv64.signExtend12 (32 : BitVec 12) = (32 : Word) by decide]]
-  rw [show (sp + EvmAsm.Rv64.signExtend12 (40 : BitVec 12)) = sp + 40 by
-    rw [show EvmAsm.Rv64.signExtend12 (40 : BitVec 12) = (40 : Word) by decide]]
-  rw [show (sp + EvmAsm.Rv64.signExtend12 (48 : BitVec 12)) = sp + 48 by
-    rw [show EvmAsm.Rv64.signExtend12 (48 : BitVec 12) = (48 : Word) by decide]]
-  rw [show (sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff) =
-      sp + 56 by
-    unfold EvmAsm.Evm64.evm_sdivDivisorTopLimbOff
-    rw [show EvmAsm.Rv64.signExtend12 (56 : BitVec 12) = (56 : Word) by decide]]
+  rw [EvmAsm.Evm64.SDiv.AddrNorm.stackSlot0 sp,
+    EvmAsm.Evm64.SDiv.AddrNorm.stackSlot8 sp,
+    EvmAsm.Evm64.SDiv.AddrNorm.stackSlot16 sp,
+    EvmAsm.Evm64.SDiv.AddrNorm.dividendTopSlot sp,
+    EvmAsm.Evm64.SDiv.AddrNorm.stackSlot32 sp,
+    EvmAsm.Evm64.SDiv.AddrNorm.stackSlot40 sp,
+    EvmAsm.Evm64.SDiv.AddrNorm.stackSlot48 sp,
+    EvmAsm.Evm64.SDiv.AddrNorm.divisorTopSlot sp]
 
 end EvmAsm.Evm64.SDiv.Compose

--- a/EvmAsm/Evm64/SDiv/Compose/QuadMemBridges.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/QuadMemBridges.lean
@@ -5,7 +5,7 @@
   bridges from `Compose/Base.lean`.
 -/
 
-import EvmAsm.Evm64.SDiv.Program
+import EvmAsm.Evm64.SDiv.AddrNorm
 import EvmAsm.Evm64.Stack
 
 namespace EvmAsm.Evm64.SDiv.Compose
@@ -19,15 +19,10 @@ theorem evmWordIs_eq_quadMem (sp : Word) (limbs : Fin 4 → Word) :
      ((sp + EvmAsm.Rv64.signExtend12 (16 : BitVec 12)) ↦ₘ limbs 2) **
      ((sp + EvmAsm.Rv64.signExtend12 (24 : BitVec 12)) ↦ₘ limbs 3)) =
     evmWordIs sp (EvmWord.fromLimbs limbs) := by
-  have h0 : (sp + EvmAsm.Rv64.signExtend12 (0 : BitVec 12) : Word) = sp := by
-    unfold EvmAsm.Rv64.signExtend12; bv_decide
-  have h8 : (sp + EvmAsm.Rv64.signExtend12 (8 : BitVec 12) : Word) = sp + 8 := by
-    unfold EvmAsm.Rv64.signExtend12; bv_decide
-  have h16 : (sp + EvmAsm.Rv64.signExtend12 (16 : BitVec 12) : Word) = sp + 16 := by
-    unfold EvmAsm.Rv64.signExtend12; bv_decide
-  have h24 : (sp + EvmAsm.Rv64.signExtend12 (24 : BitVec 12) : Word) = sp + 24 := by
-    unfold EvmAsm.Rv64.signExtend12; bv_decide
-  rw [h0, h8, h16, h24]
+  rw [EvmAsm.Evm64.SDiv.AddrNorm.stackSlot0 sp,
+    EvmAsm.Evm64.SDiv.AddrNorm.stackSlot8 sp,
+    EvmAsm.Evm64.SDiv.AddrNorm.stackSlot16 sp,
+    EvmAsm.Evm64.SDiv.AddrNorm.stackSlot24 sp]
   exact (evmWordIs_fromLimbs (addr := sp) limbs).symm
 
 /-- Divisor-slot companion to `evmWordIs_eq_quadMem`: four `↦ₘ`-memory atoms
@@ -39,15 +34,10 @@ theorem evmWordIs_eq_quadMem_sp32 (sp : Word) (limbs : Fin 4 → Word) :
      ((sp + EvmAsm.Rv64.signExtend12 (48 : BitVec 12)) ↦ₘ limbs 2) **
      ((sp + EvmAsm.Rv64.signExtend12 (56 : BitVec 12)) ↦ₘ limbs 3)) =
     evmWordIs (sp + 32) (EvmWord.fromLimbs limbs) := by
-  have h32 : (sp + EvmAsm.Rv64.signExtend12 (32 : BitVec 12) : Word) = sp + 32 := by
-    unfold EvmAsm.Rv64.signExtend12; bv_decide
-  have h40 : (sp + EvmAsm.Rv64.signExtend12 (40 : BitVec 12) : Word) = (sp + 32) + 8 := by
-    unfold EvmAsm.Rv64.signExtend12; bv_decide
-  have h48 : (sp + EvmAsm.Rv64.signExtend12 (48 : BitVec 12) : Word) = (sp + 32) + 16 := by
-    unfold EvmAsm.Rv64.signExtend12; bv_decide
-  have h56 : (sp + EvmAsm.Rv64.signExtend12 (56 : BitVec 12) : Word) = (sp + 32) + 24 := by
-    unfold EvmAsm.Rv64.signExtend12; bv_decide
-  rw [h32, h40, h48, h56]
+  rw [EvmAsm.Evm64.SDiv.AddrNorm.divisorBaseSlot0 sp,
+    EvmAsm.Evm64.SDiv.AddrNorm.divisorBaseSlot8 sp,
+    EvmAsm.Evm64.SDiv.AddrNorm.divisorBaseSlot16 sp,
+    EvmAsm.Evm64.SDiv.AddrNorm.divisorBaseSlot24 sp]
   exact (evmWordIs_fromLimbs (addr := sp + 32) limbs).symm
 
 /-- Named-arguments specialization of `evmWordIs_eq_quadMem`. -/


### PR DESCRIPTION
## Summary
- add SDIV address-normalization lemmas for dividend/divisor stack slots
- re-tag the relevant shared signExtend12 facts in the SDIV simp set
- replace inline signExtend12 proof blocks in SDIV bridge rewrites with named lemmas

## Verification
- lake build EvmAsm.Evm64.SDiv.Compose.Bridges
- lake build EvmAsm.Evm64.SDiv
- scripts/check-unimported.sh
- git diff --check
- rg -n "\b(sorry|admit)\b|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/AddrNorm.lean EvmAsm/Evm64/SDiv/Compose/QuadMemBridges.lean EvmAsm/Evm64/SDiv/Compose/Bridges.lean