### PR TITLE
refactor(exp): centralize saved-bit addresses

### DIFF
--- a/EvmAsm/Evm64/Exp/AddrNorm.lean
+++ b/EvmAsm/Evm64/Exp/AddrNorm.lean
@@ -13,6 +13,7 @@
 
 import EvmAsm.Rv64.AddrNorm
 import EvmAsm.Evm64.Exp.AddrNormAttr
+import Std.Tactic.BVDecide
 
 namespace EvmAsm.Evm64.Exp.AddrNorm
 
@@ -37,6 +38,9 @@ namespace EvmAsm.Evm64.Exp.AddrNorm
 @[exp_addr, grind =] theorem exp_se12_neg32 :
     EvmAsm.Rv64.signExtend12 ((-32 : BitVec 12)) = (18446744073709551584 : Word) := by decide
 
+@[exp_addr, grind =] theorem exp_se12_256 :
+    EvmAsm.Rv64.signExtend12 (256 : BitVec 12) = (256 : Word) := by decide
+
 attribute [exp_addr]
   EvmAsm.Rv64.signExtend12_0 EvmAsm.Rv64.signExtend12_1
   EvmAsm.Rv64.signExtend12_8 EvmAsm.Rv64.signExtend12_16
@@ -54,5 +58,37 @@ attribute [exp_addr]
   EvmAsm.Rv64.signExtend12_3984 EvmAsm.Rv64.signExtend12_3976
   EvmAsm.Rv64.signExtend12_3968 EvmAsm.Rv64.signExtend12_3960
   EvmAsm.Rv64.signExtend12_3952 EvmAsm.Rv64.signExtend12_3944
+
+@[exp_addr, grind =] theorem expAddr0 (addr : Word) :
+    (addr + EvmAsm.Rv64.signExtend12 0#12 : Word) = addr := by
+  unfold EvmAsm.Rv64.signExtend12; bv_decide
+
+@[exp_addr, grind =] theorem expAddr8 (addr : Word) :
+    (addr + EvmAsm.Rv64.signExtend12 8#12 : Word) = addr + 8#64 := by
+  unfold EvmAsm.Rv64.signExtend12; bv_decide
+
+@[exp_addr, grind =] theorem expAddr16 (addr : Word) :
+    (addr + EvmAsm.Rv64.signExtend12 16#12 : Word) = addr + 16#64 := by
+  unfold EvmAsm.Rv64.signExtend12; bv_decide
+
+@[exp_addr, grind =] theorem expAddr24 (addr : Word) :
+    (addr + EvmAsm.Rv64.signExtend12 24#12 : Word) = addr + 24#64 := by
+  unfold EvmAsm.Rv64.signExtend12; bv_decide
+
+@[exp_addr, grind =] theorem expAddr32 (addr : Word) :
+    (addr + EvmAsm.Rv64.signExtend12 32#12 : Word) = addr + 32#64 := by
+  unfold EvmAsm.Rv64.signExtend12; bv_decide
+
+@[exp_addr, grind =] theorem expAddr40 (addr : Word) :
+    (addr + EvmAsm.Rv64.signExtend12 40#12 : Word) = addr + 40#64 := by
+  unfold EvmAsm.Rv64.signExtend12; bv_decide
+
+@[exp_addr, grind =] theorem expAddr48 (addr : Word) :
+    (addr + EvmAsm.Rv64.signExtend12 48#12 : Word) = addr + 48#64 := by
+  unfold EvmAsm.Rv64.signExtend12; bv_decide
+
+@[exp_addr, grind =] theorem expAddr56 (addr : Word) :
+    (addr + EvmAsm.Rv64.signExtend12 56#12 : Word) = addr + 56#64 := by
+  unfold EvmAsm.Rv64.signExtend12; bv_decide
 
 end EvmAsm.Evm64.Exp.AddrNorm

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryPrologue.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryPrologue.lean
@@ -6,6 +6,7 @@
 -/
 
 import EvmAsm.Evm64.Exp.Compose.SavedBitWithMul
+import EvmAsm.Evm64.Exp.AddrNorm
 import EvmAsm.Rv64.Tactics.XCancelStruct
 
 namespace EvmAsm.Evm64.Exp.Compose
@@ -63,7 +64,7 @@ instance pcFreeInst_expTwoMulOperandFrame
 
 theorem expTwoMulBoundaryCounterInitWord :
     ((0 : Word) + signExtend12 (256 : BitVec 12)) = (256 : Word) := by
-  unfold signExtend12
+  rw [EvmAsm.Evm64.Exp.AddrNorm.exp_se12_256]
   bv_decide
 
 theorem expTwoMulBoundaryAccumulatorInitWord :

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCondCall.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCondCall.lean
@@ -7,6 +7,7 @@
 
 import EvmAsm.Evm64.Exp.Compose.SavedBitCondMulCall
 import EvmAsm.Evm64.Exp.Compose.SavedBitTwoMulSkip
+import EvmAsm.Evm64.Exp.AddrNorm
 
 namespace EvmAsm.Evm64.Exp.Compose
 
@@ -30,36 +31,36 @@ theorem expTwoMulCondSourceAddr24 (evmSp : Word) :
   bv_omega
 
 theorem expTwoMulCondAddr0 (addr : Word) :
-    (addr + signExtend12 0#12 : Word) = addr := by
-  unfold signExtend12; bv_decide
+    (addr + signExtend12 0#12 : Word) = addr :=
+  EvmAsm.Evm64.Exp.AddrNorm.expAddr0 addr
 
 theorem expTwoMulCondAddr8 (addr : Word) :
-    (addr + signExtend12 8#12 : Word) = addr + 8#64 := by
-  unfold signExtend12; bv_decide
+    (addr + signExtend12 8#12 : Word) = addr + 8#64 :=
+  EvmAsm.Evm64.Exp.AddrNorm.expAddr8 addr
 
 theorem expTwoMulCondAddr16 (addr : Word) :
-    (addr + signExtend12 16#12 : Word) = addr + 16#64 := by
-  unfold signExtend12; bv_decide
+    (addr + signExtend12 16#12 : Word) = addr + 16#64 :=
+  EvmAsm.Evm64.Exp.AddrNorm.expAddr16 addr
 
 theorem expTwoMulCondAddr24 (addr : Word) :
-    (addr + signExtend12 24#12 : Word) = addr + 24#64 := by
-  unfold signExtend12; bv_decide
+    (addr + signExtend12 24#12 : Word) = addr + 24#64 :=
+  EvmAsm.Evm64.Exp.AddrNorm.expAddr24 addr
 
 theorem expTwoMulCondAddr32 (addr : Word) :
-    (addr + signExtend12 32#12 : Word) = addr + 32#64 := by
-  unfold signExtend12; bv_decide
+    (addr + signExtend12 32#12 : Word) = addr + 32#64 :=
+  EvmAsm.Evm64.Exp.AddrNorm.expAddr32 addr
 
 theorem expTwoMulCondAddr40 (addr : Word) :
-    (addr + signExtend12 40#12 : Word) = addr + 40#64 := by
-  unfold signExtend12; bv_decide
+    (addr + signExtend12 40#12 : Word) = addr + 40#64 :=
+  EvmAsm.Evm64.Exp.AddrNorm.expAddr40 addr
 
 theorem expTwoMulCondAddr48 (addr : Word) :
-    (addr + signExtend12 48#12 : Word) = addr + 48#64 := by
-  unfold signExtend12; bv_decide
+    (addr + signExtend12 48#12 : Word) = addr + 48#64 :=
+  EvmAsm.Evm64.Exp.AddrNorm.expAddr48 addr
 
 theorem expTwoMulCondAddr56 (addr : Word) :
-    (addr + signExtend12 56#12 : Word) = addr + 56#64 := by
-  unfold signExtend12; bv_decide
+    (addr + signExtend12 56#12 : Word) = addr + 56#64 :=
+  EvmAsm.Evm64.Exp.AddrNorm.expAddr56 addr
 
 @[irreducible]
 def expCondMulLoopRest


### PR DESCRIPTION
## Summary
- add shared EXP address-normalization lemmas for saved-bit stack slot offsets
- add an EXP-local signExtend12 256 fact for the loop counter initializer
- rewrite saved-bit two-MUL local address lemmas to use the centralized facts

## Verification
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitTwoMulCond EvmAsm.Evm64.Exp.Compose.SavedBitBoundarySeq
- lake build EvmAsm.Evm64.Exp
- scripts/check-unimported.sh
- git diff --check
- rg -n "\b(sorry|admit)\b|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/AddrNorm.lean EvmAsm/Evm64/Exp/Compose/SavedBitBoundarySeq.lean EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCond.lean