### PR TITLE
refactor(exp): name call block alignment

### DIFF
--- a/EvmAsm/Evm64/Exp/AddrNorm.lean
+++ b/EvmAsm/Evm64/Exp/AddrNorm.lean
@@ -91,4 +91,20 @@ attribute [exp_addr]
     (addr + EvmAsm.Rv64.signExtend12 56#12 : Word) = addr + 56#64 := by
   unfold EvmAsm.Rv64.signExtend12; bv_decide
 
+@[exp_addr, grind =] theorem expBaseAdd40Aligned
+    (base : Word) (hbase : base &&& 1 = 0) :
+    (base + 40 : Word) &&& 1 = 0 := by bv_decide
+
+@[exp_addr, grind =] theorem expBaseAdd44Aligned
+    (base : Word) (hbase : base &&& 1 = 0) :
+    (base + 44 : Word) &&& 1 = 0 := by bv_decide
+
+@[exp_addr, grind =] theorem expBaseAdd148Aligned
+    (base : Word) (hbase : base &&& 1 = 0) :
+    (base + 148 : Word) &&& 1 = 0 := by bv_decide
+
+@[exp_addr, grind =] theorem expBaseAdd152Aligned
+    (base : Word) (hbase : base &&& 1 = 0) :
+    (base + 152 : Word) &&& 1 = 0 := by bv_decide
+
 end EvmAsm.Evm64.Exp.AddrNorm

--- a/EvmAsm/Evm64/Exp/Compose/CondMulCallBlock.lean
+++ b/EvmAsm/Evm64/Exp/Compose/CondMulCallBlock.lean
@@ -6,6 +6,7 @@
 -/
 
 import EvmAsm.Evm64.Exp.Compose.CondMulCallPath
+import EvmAsm.Evm64.Exp.AddrNorm
 
 namespace EvmAsm.Evm64.Exp.Compose
 
@@ -60,7 +61,8 @@ theorem exp_cond_mul_call_block_evm_exp_with_mul_spec_within
        memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
        (.x1 ↦ᵣ ((base + 148) + 68))) := by
   intro rw
-  have hbase' : (base + 148 : Word) &&& 1 = 0 := by bv_decide
+  have hbase' : (base + 148 : Word) &&& 1 = 0 :=
+    EvmAsm.Evm64.Exp.AddrNorm.expBaseAdd148Aligned base hbase
   have hCondSub : ∀ a i,
       exp_cond_mul_call_block_code (base + 148) mulOff a = some i →
       evmExpCode base mulOff skipOff backOff a = some i := by

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitCondMulCall.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitCondMulCall.lean
@@ -7,6 +7,7 @@
 -/
 
 import EvmAsm.Evm64.Exp.Compose.SavedBitFullLoop
+import EvmAsm.Evm64.Exp.AddrNorm
 
 namespace EvmAsm.Evm64.Exp.Compose
 
@@ -68,7 +69,8 @@ theorem exp_cond_mul_call_block_evm_exp_msb_saved_bit_with_mul_spec_within
        memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
        (.x1 ↦ᵣ ((base + 152) + 68))) := by
   intro r aw
-  have hbase' : (base + 152 : Word) &&& 1 = 0 := by bv_decide
+  have hbase' : (base + 152 : Word) &&& 1 = 0 :=
+    EvmAsm.Evm64.Exp.AddrNorm.expBaseAdd152Aligned base hbase
   have hCondSub : ∀ a i,
       exp_cond_mul_call_block_code (base + 152) mulOff a = some i →
       evmExpMsbSavedBitCode base mulOff skipOff backOff a = some i := by
@@ -148,7 +150,8 @@ theorem exp_cond_mul_call_block_evm_exp_msb_saved_bit_two_mul_with_mul_spec_with
        memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
        (.x1 ↦ᵣ ((base + 152) + 68))) := by
   intro r aw
-  have hbase' : (base + 152 : Word) &&& 1 = 0 := by bv_decide
+  have hbase' : (base + 152 : Word) &&& 1 = 0 :=
+    EvmAsm.Evm64.Exp.AddrNorm.expBaseAdd152Aligned base hbase
   have hCondSub : ∀ a i,
       exp_cond_mul_call_block_code (base + 152) condMulOff a = some i →
       evmExpMsbSavedBitTwoMulCode

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFullLoopSquaring.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFullLoopSquaring.lean
@@ -7,6 +7,7 @@
 -/
 
 import EvmAsm.Evm64.Exp.Compose.SavedBitFullLoopPrefix
+import EvmAsm.Evm64.Exp.AddrNorm
 
 namespace EvmAsm.Evm64.Exp.Compose
 
@@ -59,7 +60,8 @@ theorem exp_squaring_call_block_evm_exp_msb_saved_bit_with_mul_spec_within
        memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
        (.x1 ↦ᵣ ((base + 44) + 68))) := by
   intro squareW
-  have hbase' : (base + 44 : Word) &&& 1 = 0 := by bv_decide
+  have hbase' : (base + 44 : Word) &&& 1 = 0 :=
+    EvmAsm.Evm64.Exp.AddrNorm.expBaseAdd44Aligned base hbase
   have hd_inner : CodeReq.Disjoint
       (exp_squaring_call_block_code (base + 44) mulOff)
       (mul_callable_code mulTarget) := by
@@ -127,7 +129,8 @@ theorem exp_squaring_call_block_evm_exp_msb_saved_bit_two_mul_with_mul_spec_with
        memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
        (.x1 ↦ᵣ ((base + 44) + 68))) := by
   intro squareW
-  have hbase' : (base + 44 : Word) &&& 1 = 0 := by bv_decide
+  have hbase' : (base + 44 : Word) &&& 1 = 0 :=
+    EvmAsm.Evm64.Exp.AddrNorm.expBaseAdd44Aligned base hbase
   have hSquareSub : ∀ a i,
       exp_squaring_call_block_code (base + 44) squaringMulOff a = some i →
       evmExpMsbSavedBitTwoMulCode

--- a/EvmAsm/Evm64/Exp/Compose/SquaringCallBlock.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SquaringCallBlock.lean
@@ -5,6 +5,7 @@
 -/
 
 import EvmAsm.Evm64.Exp.Compose.SquaringCallPath
+import EvmAsm.Evm64.Exp.AddrNorm
 
 namespace EvmAsm.Evm64.Exp.Compose
 
@@ -50,7 +51,8 @@ theorem exp_squaring_call_block_evm_exp_with_mul_spec_within
        memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
        (.x1 ↦ᵣ ((base + 40) + 68))) := by
   intro rw
-  have hbase' : (base + 40 : Word) &&& 1 = 0 := by bv_decide
+  have hbase' : (base + 40 : Word) &&& 1 = 0 :=
+    EvmAsm.Evm64.Exp.AddrNorm.expBaseAdd40Aligned base hbase
   have hd_inner : CodeReq.Disjoint
       (exp_squaring_call_block_code (base + 40) mulOff)
       (mul_callable_code mulTarget) := by


### PR DESCRIPTION
## Summary
- add named EXP alignment facts for call-block offsets 40, 44, 148, and 152
- replace repeated local bv_decide alignment proofs in full-loop and saved-bit call lifts

## Verification
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitCondMulCall EvmAsm.Evm64.Exp.Compose.FullLoop EvmAsm.Evm64.Exp.Compose.SavedBitFullLoop
- lake build EvmAsm.Evm64.Exp
- scripts/check-unimported.sh
- git diff --check
- rg -n "\b(sorry|admit)\b|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/AddrNorm.lean EvmAsm/Evm64/Exp/Compose/SavedBitCondMulCall.lean EvmAsm/Evm64/Exp/Compose/FullLoop.lean EvmAsm/Evm64/Exp/Compose/SavedBitFullLoop.lean