### PR TITLE
refactor(exp): centralize two-mul source addresses

### DIFF
--- a/EvmAsm/Evm64/Exp/AddrNorm.lean
+++ b/EvmAsm/Evm64/Exp/AddrNorm.lean
@@ -91,6 +91,18 @@ attribute [exp_addr]
     (addr + EvmAsm.Rv64.signExtend12 56#12 : Word) = addr + 56#64 := by
   unfold EvmAsm.Rv64.signExtend12; bv_decide
 
+@[exp_addr, grind =] theorem expAdd32Add8 (addr : Word) :
+    (addr + 32#64 + 8 : Word) = addr + 40#64 := by
+  bv_decide
+
+@[exp_addr, grind =] theorem expAdd32Add16 (addr : Word) :
+    (addr + 32#64 + 16 : Word) = addr + 48#64 := by
+  bv_decide
+
+@[exp_addr, grind =] theorem expAdd32Add24 (addr : Word) :
+    (addr + 32#64 + 24 : Word) = addr + 56#64 := by
+  bv_decide
+
 @[exp_addr, grind =] theorem expBaseAdd40Aligned
     (base : Word) (hbase : base &&& 1 = 0) :
     (base + 40 : Word) &&& 1 = 0 := by bv_decide

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCondCall.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCondCall.lean
@@ -18,18 +18,6 @@ theorem expTwoMulCondMulCallExitPc (base : Word) :
     ((base + 152 : Word) + 104) = base + 256 := by
   bv_omega
 
-theorem expTwoMulCondSourceAddr8 (evmSp : Word) :
-    (evmSp + 32#64 + 8 : Word) = evmSp + 40#64 := by
-  bv_omega
-
-theorem expTwoMulCondSourceAddr16 (evmSp : Word) :
-    (evmSp + 32#64 + 16 : Word) = evmSp + 48#64 := by
-  bv_omega
-
-theorem expTwoMulCondSourceAddr24 (evmSp : Word) :
-    (evmSp + 32#64 + 24 : Word) = evmSp + 56#64 := by
-  bv_omega
-
 
 @[irreducible]
 def expCondMulLoopRest
@@ -321,7 +309,9 @@ theorem exp_cond_mul_folded_pre_to_call_scratch_owned_pre
   intro baseFrame foldedPre concretePre h hp
   dsimp [foldedPre, concretePre, baseFrame] at hp ⊢
   unfold evmWordIs at hp
-  rw [expTwoMulCondSourceAddr8, expTwoMulCondSourceAddr16, expTwoMulCondSourceAddr24] at hp
+  rw [EvmAsm.Evm64.Exp.AddrNorm.expAdd32Add8,
+    EvmAsm.Evm64.Exp.AddrNorm.expAdd32Add16,
+    EvmAsm.Evm64.Exp.AddrNorm.expAdd32Add24] at hp
   have hSp0 : (sp + signExtend12 0#12 : Word) = sp := EvmAsm.Evm64.Exp.AddrNorm.expAddr0 sp
   have hSp8 : (sp + signExtend12 8#12 : Word) = sp + 8 := EvmAsm.Evm64.Exp.AddrNorm.expAddr8 sp
   have hSp16 : (sp + signExtend12 16#12 : Word) = sp + 16 := EvmAsm.Evm64.Exp.AddrNorm.expAddr16 sp


### PR DESCRIPTION
## Summary
- add central EXP address-normalization facts for addr + 32 + {8,16,24}
- remove the SavedBitTwoMulCond-local source-address wrappers and use the central facts

## Verification
- lake build EvmAsm.Evm64.Exp.AddrNorm EvmAsm.Evm64.Exp.Compose.SavedBitTwoMulCond
- lake build EvmAsm.Evm64.Exp
- scripts/check-unimported.sh
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/AddrNorm.lean EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCond.lean