### PR TITLE
refactor(exp): centralize two-mul pc facts

### DIFF
--- a/EvmAsm/Evm64/Exp/AddrNorm.lean
+++ b/EvmAsm/Evm64/Exp/AddrNorm.lean
@@ -111,6 +111,14 @@ attribute [exp_addr]
     (base + 152 : Word) = (base + 28) + 120 + 4 := by
   bv_decide
 
+@[exp_addr, grind =] theorem expTwoMulSkipLoopBackNextPc (base : Word) :
+    ((base + 256 : Word) + 8) = base + 264 := by
+  bv_decide
+
+@[exp_addr, grind =] theorem expTwoMulCondMulCallExitPc (base : Word) :
+    ((base + 152 : Word) + 104) = base + 256 := by
+  bv_decide
+
 @[exp_addr, grind =] theorem expBaseAdd40Aligned
     (base : Word) (hbase : base &&& 1 = 0) :
     (base + 40 : Word) &&& 1 = 0 := by bv_decide

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCondCall.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCondCall.lean
@@ -14,11 +14,6 @@ namespace EvmAsm.Evm64.Exp.Compose
 open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
-theorem expTwoMulCondMulCallExitPc (base : Word) :
-    ((base + 152 : Word) + 104) = base + 256 := by
-  bv_omega
-
-
 @[irreducible]
 def expCondMulLoopRest
     (sp evmSp base a0 a1 a2 a3 : Word) (rw : EvmWord) : Assertion :=
@@ -112,7 +107,7 @@ theorem exp_cond_mul_call_then_loop_back_evm_exp_msb_saved_bit_two_mul_with_mul_
   have hCondFramed :=
     cpsTripleWithin_frameR
       ((.x9 ↦ᵣ iterCount) ** (.x0 ↦ᵣ (0 : Word))) (by pcFree) hCond
-  rw [expTwoMulCondMulCallExitPc] at hCondFramed
+  rw [EvmAsm.Evm64.Exp.AddrNorm.expTwoMulCondMulCallExitPc] at hCondFramed
   have hLoop := exp_loop_back_evm_exp_msb_saved_bit_two_mul_with_mul_spec_within
     iterCount squaringMulOff condMulOff skipOff backOff base mulTarget
     loopTarget hback

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulSkip.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulSkip.lean
@@ -6,15 +6,12 @@
 -/
 
 import EvmAsm.Evm64.Exp.Compose.SavedBitFullLoop
+import EvmAsm.Evm64.Exp.AddrNorm
 
 namespace EvmAsm.Evm64.Exp.Compose
 
 open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
-
-theorem expTwoMulSkipLoopBackNextPc (base : Word) :
-    ((base + 256 : Word) + 8) = base + 264 := by
-  bv_omega
 
 /-- Saved-bit loop-back block lifted to the two-MUL-offset EXP+MUL code
     bundle. -/
@@ -35,7 +32,7 @@ theorem exp_loop_back_evm_exp_msb_saved_bit_two_mul_with_mul_spec_within
           ⌜expTwoMulIterCountNew c = 0⌝) := by
   have h := EvmAsm.Evm64.exp_loop_back_spec_within c backOff (base + 256)
     target htarget
-  rw [expTwoMulSkipLoopBackNextPc] at h
+  rw [EvmAsm.Evm64.Exp.AddrNorm.expTwoMulSkipLoopBackNextPc] at h
   simpa [expTwoMulIterCountNew] using
     (cpsBranchWithin_extend_code (h := h)
       (hmono := fun a i hi =>


### PR DESCRIPTION
## Summary
- add central EXP address-normalization facts for two-mul skip and cond-mul exit PCs
- remove the corresponding local wrappers from SavedBitTwoMulSkip and SavedBitTwoMulCond

## Verification
- lake build EvmAsm.Evm64.Exp.AddrNorm EvmAsm.Evm64.Exp.Compose.SavedBitTwoMulSkip EvmAsm.Evm64.Exp.Compose.SavedBitTwoMulCond
- lake build EvmAsm.Evm64.Exp
- scripts/check-unimported.sh
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/AddrNorm.lean EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulSkip.lean EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCond.lean