### PR TITLE
refactor(exp): centralize full-loop cond-mul address

### DIFF
--- a/EvmAsm/Evm64/Exp/AddrNorm.lean
+++ b/EvmAsm/Evm64/Exp/AddrNorm.lean
@@ -103,6 +103,10 @@ attribute [exp_addr]
     (addr + 32#64 + 24 : Word) = addr + 56#64 := by
   bv_decide
 
+@[exp_addr, grind =] theorem expFullLoopCondMulCallAddr (base : Word) :
+    (base + 148 : Word) = base + 144 + 4 := by
+  bv_decide
+
 @[exp_addr, grind =] theorem expSavedBitCondMulTakenAddr (base : Word) :
     (base + 152 : Word) = base + 148 + 4 := by
   bv_decide

--- a/EvmAsm/Evm64/Exp/Compose/CondMulCallBlock.lean
+++ b/EvmAsm/Evm64/Exp/Compose/CondMulCallBlock.lean
@@ -67,7 +67,7 @@ theorem exp_cond_mul_call_block_evm_exp_with_mul_spec_within
       exp_cond_mul_call_block_code (base + 148) mulOff a = some i →
       evmExpCode base mulOff skipOff backOff a = some i := by
     intro a i h
-    rw [expFullLoopCondMulCallAddr] at h
+    rw [EvmAsm.Evm64.Exp.AddrNorm.expFullLoopCondMulCallAddr] at h
     exact evmExpCode_iter_cond_mul_sub a i
       (EvmAsm.Evm64.exp_cond_mul_call_with_skip_block_code_call_sub
         (base + 144) mulOff skipOff a i h)

--- a/EvmAsm/Evm64/Exp/Compose/CondMulCallPath.lean
+++ b/EvmAsm/Evm64/Exp/Compose/CondMulCallPath.lean
@@ -7,14 +7,11 @@
 
 import EvmAsm.Evm64.Exp.Compose.WithMulCode
 import EvmAsm.Evm64.Exp.CondMulPairThenMulCall
+import EvmAsm.Evm64.Exp.AddrNorm
 
 namespace EvmAsm.Evm64.Exp.Compose
 
 open EvmAsm.Rv64
-
-theorem expFullLoopCondMulCallAddr (base : Word) :
-    (base + 148 : Word) = base + 144 + 4 := by
-  bv_omega
 
 /-- Cond-mul-side marshal-pair + JAL + `mul_callable` round-trip lifted from
     the disjoint-union code `exp_cond_mul_call_block_code.union mul_callable_code`
@@ -68,7 +65,7 @@ theorem exp_cond_mul_marshal_pair_then_mul_call_evm_exp_with_mul_spec_within
       exp_cond_mul_call_block_code (base + 148) mulOff a = some i →
       evmExpCode base mulOff skipOff backOff a = some i := by
     intro a i h
-    rw [expFullLoopCondMulCallAddr] at h
+    rw [EvmAsm.Evm64.Exp.AddrNorm.expFullLoopCondMulCallAddr] at h
     exact evmExpCode_iter_cond_mul_sub a i
       (EvmAsm.Evm64.exp_cond_mul_call_with_skip_block_code_call_sub
         (base + 144) mulOff skipOff a i h)


### PR DESCRIPTION
## Summary
- add a central EXP address-normalization fact for the full-loop cond-mul call block address
- remove the local FullLoop wrapper and use the central fact at both code-subsumption sites

## Verification
- lake build EvmAsm.Evm64.Exp.AddrNorm EvmAsm.Evm64.Exp.Compose.FullLoop
- lake build EvmAsm.Evm64.Exp
- scripts/check-unimported.sh
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/AddrNorm.lean EvmAsm/Evm64/Exp/Compose/FullLoop.lean