### PR TITLE
refactor(exp): centralize loop-code pc facts

### DIFF
--- a/EvmAsm/Evm64/Exp/AddrNorm.lean
+++ b/EvmAsm/Evm64/Exp/AddrNorm.lean
@@ -123,6 +123,18 @@ attribute [exp_addr]
     ((base + 152 : Word) + 104) = base + 256 := by
   bv_decide
 
+@[exp_addr, grind =] theorem expLoopBackNextPc (base : Word) :
+    ((base + 24 : Word) + 8) = base + 32 := by
+  bv_decide
+
+@[exp_addr, grind =] theorem expLoopSquareReturnPc (base : Word) :
+    ((base + 12 : Word) + 4) = base + 16 := by
+  bv_decide
+
+@[exp_addr, grind =] theorem expLoopCondMulReturnPc (base : Word) :
+    ((base + 16 : Word) + 8) = base + 24 := by
+  bv_decide
+
 @[exp_addr, grind =] theorem expBaseAdd40Aligned
     (base : Word) (hbase : base &&& 1 = 0) :
     (base + 40 : Word) &&& 1 = 0 := by bv_decide

--- a/EvmAsm/Evm64/Exp/Compose/LoopCodeSpecs.lean
+++ b/EvmAsm/Evm64/Exp/Compose/LoopCodeSpecs.lean
@@ -6,24 +6,13 @@
 -/
 
 import EvmAsm.Evm64.Exp.Compose.Base
+import EvmAsm.Evm64.Exp.AddrNorm
 
 namespace EvmAsm.Evm64.Exp.Compose
 
 open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64 (cpsBranchWithin cpsBranchWithin_extend_code cpsTripleWithin
   cpsTripleWithin_extend_code signExtend12 signExtend13 signExtend21)
-
-theorem expLoopBackNextPc (base : Word) :
-    ((base + 24 : Word) + 8) = base + 32 := by
-  bv_omega
-
-theorem expLoopSquareReturnPc (base : Word) :
-    ((base + 12 : Word) + 4) = base + 16 := by
-  bv_omega
-
-theorem expLoopCondMulReturnPc (base : Word) :
-    ((base + 16 : Word) + 8) = base + 24 := by
-  bv_omega
 
 theorem exp_loop_back_loop_spec_within (c : Word)
     (mulOff : BitVec 21) (skipOff backOff : BitVec 13)
@@ -37,7 +26,7 @@ theorem exp_loop_back_loop_spec_within (c : Word)
       (base + 32)
         ((.x9 ↦ᵣ expIterCountNew c) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜expIterCountNew c = 0⌝) := by
   have h := EvmAsm.Evm64.exp_loop_back_spec_within c backOff (base + 24) target htarget
-  rw [expLoopBackNextPc] at h
+  rw [EvmAsm.Evm64.Exp.AddrNorm.expLoopBackNextPc] at h
   simpa [expIterCountNew] using
     (cpsBranchWithin_extend_code (h := h) (hmono := expLoopCode_loop_back_sub))
 
@@ -62,7 +51,7 @@ theorem exp_square_loop_spec_within
       (.x1 ↦ᵣ (base + 16)) := by
   have h := EvmAsm.Evm64.exp_square_block_spec_within mulOff vOld (base + 12)
   rw [hmul] at h
-  rw [expLoopSquareReturnPc] at h
+  rw [EvmAsm.Evm64.Exp.AddrNorm.expLoopSquareReturnPc] at h
   exact cpsTripleWithin_extend_code (h := h) (hmono := expLoopCode_square_sub)
 
 theorem exp_cond_mul_loop_spec_within
@@ -81,7 +70,7 @@ theorem exp_cond_mul_loop_spec_within
   have h := EvmAsm.Evm64.exp_cond_mul_block_spec_within
     mulOff skipOff v10 vOld (base + 16)
   rw [hskip, hmul] at h
-  rw [expLoopCondMulReturnPc] at h
+  rw [EvmAsm.Evm64.Exp.AddrNorm.expLoopCondMulReturnPc] at h
   exact cpsBranchWithin_extend_code (h := h) (hmono := expLoopCode_cond_mul_sub)
 
 end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- add central EXP address-normalization facts for loop-code return and fallthrough PCs
- remove the local LoopCodeSpecs wrappers and use the central facts

## Verification
- lake build EvmAsm.Evm64.Exp.AddrNorm EvmAsm.Evm64.Exp.Compose.LoopCodeSpecs
- lake build EvmAsm.Evm64.Exp
- scripts/check-unimported.sh
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/AddrNorm.lean EvmAsm/Evm64/Exp/Compose/LoopCodeSpecs.lean