### PR TITLE
refactor(exp): centralize saved-bit full-loop facts

### DIFF
--- a/EvmAsm/Evm64/Exp/AddrNorm.lean
+++ b/EvmAsm/Evm64/Exp/AddrNorm.lean
@@ -135,6 +135,38 @@ attribute [exp_addr]
     ((base + 16 : Word) + 8) = base + 24 := by
   bv_decide
 
+@[exp_addr, grind =] theorem expSavedBitSquaringPrefixExitPc (base : Word) :
+    ((base + 44 : Word) + 104) = base + 148 := by
+  bv_decide
+
+@[exp_addr, grind =] theorem expSavedBitBitTestNextPc (base : Word) :
+    ((base + 28 : Word) + 12) = base + 40 := by
+  bv_decide
+
+@[exp_addr, grind =] theorem expSavedBitSaveNextPc (base : Word) :
+    ((base + 40 : Word) + 4) = base + 44 := by
+  bv_decide
+
+@[exp_addr, grind =] theorem expSavedBitCondMulBeqNextPc (base : Word) :
+    ((base + 148 : Word) + 4) = base + 152 := by
+  bv_decide
+
+@[exp_addr, grind =] theorem expSavedBitLoopBackNextPc (base : Word) :
+    ((base + 256 : Word) + 8) = base + 264 := by
+  bv_decide
+
+@[exp_addr, grind =] theorem expSavedBitSaveEntryAddr (base : Word) :
+    (base + 40 : Word) = (base + 28) + 12 := by
+  bv_decide
+
+@[exp_addr, grind =] theorem expSavedBitCondMulBeqEntryAddr (base : Word) :
+    (base + 148 : Word) = (base + 28) + 120 := by
+  bv_decide
+
+@[exp_addr, grind =] theorem expSavedBitSquaringEntryAddr (base : Word) :
+    (base + 44 : Word) = (base + 28) + 16 := by
+  bv_decide
+
 @[exp_addr, grind =] theorem expBaseAdd40Aligned
     (base : Word) (hbase : base &&& 1 = 0) :
     (base + 40 : Word) &&& 1 = 0 := by bv_decide

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFullLoop.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFullLoop.lean
@@ -12,20 +12,4 @@ namespace EvmAsm.Evm64.Exp.Compose
 
 open EvmAsm.Rv64
 
-theorem expSavedBitBitTestNextPc (base : Word) :
-    ((base + 28 : Word) + 12) = base + 40 := by
-  bv_omega
-
-theorem expSavedBitSaveNextPc (base : Word) :
-    ((base + 40 : Word) + 4) = base + 44 := by
-  bv_omega
-
-theorem expSavedBitCondMulBeqNextPc (base : Word) :
-    ((base + 148 : Word) + 4) = base + 152 := by
-  bv_omega
-
-theorem expSavedBitLoopBackNextPc (base : Word) :
-    ((base + 256 : Word) + 8) = base + 264 := by
-  bv_omega
-
 end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFullLoopPrefix.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFullLoopPrefix.lean
@@ -8,19 +8,12 @@
 -/
 
 import EvmAsm.Evm64.Exp.Compose.SavedBitWithMul
+import EvmAsm.Evm64.Exp.AddrNorm
 
 namespace EvmAsm.Evm64.Exp.Compose
 
 open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
-
-theorem expSavedBitSaveEntryAddr (base : Word) :
-    (base + 40 : Word) = (base + 28) + 12 := by
-  bv_omega
-
-theorem expSavedBitCondMulBeqEntryAddr (base : Word) :
-    (base + 148 : Word) = (base + 28) + 120 := by
-  bv_omega
 
 /-- MSB bit-test block lifted to the corrected saved-bit EXP+MUL code bundle. -/
 theorem exp_msb_bit_test_evm_exp_msb_saved_bit_with_mul_spec_within
@@ -84,7 +77,7 @@ theorem exp_save_bit_evm_exp_msb_saved_bit_two_mul_with_mul_spec_within
   exact cpsTripleWithin_extend_code
     (h := h)
     (hmono := fun a i hi => by
-      rw [expSavedBitSaveEntryAddr] at hi
+      rw [EvmAsm.Evm64.Exp.AddrNorm.expSavedBitSaveEntryAddr] at hi
       exact evmExpMsbSavedBitTwoMulWithMulCode_exp_sub a i
         (evmExpMsbSavedBitTwoMulCode_iter_body_sub
           (base := base) (squaringMulOff := squaringMulOff)
@@ -192,7 +185,7 @@ theorem exp_cond_mul_saved_bit_beq_evm_exp_msb_saved_bit_two_mul_with_mul_spec_w
   exact cpsBranchWithin_extend_code
     (h := h)
     (hmono := fun a i hi => by
-      rw [expSavedBitCondMulBeqEntryAddr] at hi
+      rw [EvmAsm.Evm64.Exp.AddrNorm.expSavedBitCondMulBeqEntryAddr] at hi
       exact evmExpMsbSavedBitTwoMulWithMulCode_exp_sub a i
         (evmExpMsbSavedBitTwoMulCode_iter_body_sub
           (base := base) (squaringMulOff := squaringMulOff)

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFullLoopSquaring.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFullLoopSquaring.lean
@@ -14,14 +14,6 @@ namespace EvmAsm.Evm64.Exp.Compose
 open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
-theorem expSavedBitSquaringPrefixExitPc (base : Word) :
-    ((base + 44 : Word) + 104) = base + 148 := by
-  bv_omega
-
-theorem expSavedBitSquaringEntryAddr (base : Word) :
-    (base + 44 : Word) = (base + 28) + 16 := by
-  bv_omega
-
 /-- Squaring-side full call-block lifted to the corrected saved-bit EXP+MUL
     code bundle.  The block starts after the saved-bit instruction, at
     `base + 44`, and exits at the saved-bit BEQ site `base + 148`. -/
@@ -136,7 +128,7 @@ theorem exp_squaring_call_block_evm_exp_msb_saved_bit_two_mul_with_mul_spec_with
       evmExpMsbSavedBitTwoMulCode
         base squaringMulOff condMulOff skipOff backOff a = some i := by
     intro a i h
-    rw [expSavedBitSquaringEntryAddr] at h
+    rw [EvmAsm.Evm64.Exp.AddrNorm.expSavedBitSquaringEntryAddr] at h
     exact evmExpMsbSavedBitTwoMulCode_iter_body_sub
       (base := base) (squaringMulOff := squaringMulOff)
       (condMulOff := condMulOff) (skipOff := skipOff) (backOff := backOff)
@@ -240,7 +232,7 @@ theorem exp_msb_saved_bit_prefix_then_squaring_call_evm_exp_msb_saved_bit_with_m
         dsimp only [bit] at hp ⊢
         xperm_hyp hp)
       hPrefixFramed hSquareFramed
-  rw [expSavedBitSquaringPrefixExitPc] at hSeq
+  rw [EvmAsm.Evm64.Exp.AddrNorm.expSavedBitSquaringPrefixExitPc] at hSeq
   exact cpsTripleWithin_weaken
     (fun _ hp => by xperm_hyp hp)
     (fun _ hp => by xperm_hyp hp)
@@ -327,7 +319,7 @@ theorem exp_msb_saved_bit_prefix_then_squaring_call_evm_exp_msb_saved_bit_two_mu
         dsimp only [bit] at hp ⊢
         xperm_hyp hp)
       hPrefixFramed hSquareFramed
-  rw [expSavedBitSquaringPrefixExitPc] at hSeq
+  rw [EvmAsm.Evm64.Exp.AddrNorm.expSavedBitSquaringPrefixExitPc] at hSeq
   exact cpsTripleWithin_weaken
     (fun _ hp => by xperm_hyp hp)
     (fun _ hp => by xperm_hyp hp)


### PR DESCRIPTION
## Summary
- add central EXP address-normalization facts for saved-bit full-loop PCs and entry addresses
- remove the corresponding local wrappers from SavedBitFullLoop

## Verification
- lake build EvmAsm.Evm64.Exp.AddrNorm EvmAsm.Evm64.Exp.Compose.SavedBitFullLoop
- lake build EvmAsm.Evm64.Exp
- scripts/check-unimported.sh
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/AddrNorm.lean EvmAsm/Evm64/Exp/Compose/SavedBitFullLoop.lean