### PR TITLE
refactor(exp): centralize top next pc facts

### DIFF
--- a/EvmAsm/Evm64/Exp/AddrNorm.lean
+++ b/EvmAsm/Evm64/Exp/AddrNorm.lean
@@ -187,6 +187,38 @@ attribute [exp_addr]
     ((base + 268 : Word) + 36) = base + 304 := by
   bv_decide
 
+@[exp_addr, grind =] theorem expTopIterBitTestNextPc (base : Word) :
+    ((base + 28 : Word) + 12) = base + 40 := by
+  bv_decide
+
+@[exp_addr, grind =] theorem expTopSavedBitSaveNextPc (base : Word) :
+    ((base + 40 : Word) + 4) = base + 44 := by
+  bv_decide
+
+@[exp_addr, grind =] theorem expTopLoopBackNextPc (base : Word) :
+    ((base + 252 : Word) + 8) = base + 260 := by
+  bv_decide
+
+@[exp_addr, grind =] theorem expTopCondMulBeqNextPc (base : Word) :
+    ((base + 144 : Word) + 4) = base + 148 := by
+  bv_decide
+
+@[exp_addr, grind =] theorem expTopSavedBitCondMulBeqNextPc (base : Word) :
+    ((base + 148 : Word) + 4) = base + 152 := by
+  bv_decide
+
+@[exp_addr, grind =] theorem expTopCondMulMarshalPairNextPc (base : Word) :
+    ((base + 148 : Word) + 64) = base + 212 := by
+  bv_decide
+
+@[exp_addr, grind =] theorem expTopSquaringSquareReturnPc (base : Word) :
+    ((base + 104 : Word) + 4) = base + 108 := by
+  bv_decide
+
+@[exp_addr, grind =] theorem expTopCondMulSquareReturnPc (base : Word) :
+    ((base + 212 : Word) + 4) = base + 216 := by
+  bv_decide
+
 @[exp_addr, grind =] theorem expBaseAdd40Aligned
     (base : Word) (hbase : base &&& 1 = 0) :
     (base + 40 : Word) &&& 1 = 0 := by bv_decide

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFullLoopPrefix.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFullLoopPrefix.lean
@@ -41,7 +41,7 @@ theorem exp_msb_bit_test_evm_exp_msb_saved_bit_two_mul_with_mul_spec_within
        (.x6 ↦ᵣ (c + signExtend12 ((-1) : BitVec 12))) **
        (.x10 ↦ᵣ (expTwoMulIterBit e))) := by
   have h := EvmAsm.Evm64.exp_msb_bit_test_block_spec_within e c v10 (base + 28)
-  rw [expTopIterBitTestNextPc] at h
+  rw [EvmAsm.Evm64.Exp.AddrNorm.expTopIterBitTestNextPc] at h
   exact cpsTripleWithin_extend_code
     (h := h)
     (hmono := fun a i hi =>
@@ -73,7 +73,7 @@ theorem exp_save_bit_evm_exp_msb_saved_bit_two_mul_with_mul_spec_within
       ((.x10 ↦ᵣ bit) ** (.x18 ↦ᵣ v18))
       ((.x10 ↦ᵣ bit) ** (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12)))) := by
   have h := EvmAsm.Evm64.exp_save_bit_block_spec_within bit v18 (base + 40)
-  rw [expTopSavedBitSaveNextPc] at h
+  rw [EvmAsm.Evm64.Exp.AddrNorm.expTopSavedBitSaveNextPc] at h
   exact cpsTripleWithin_extend_code
     (h := h)
     (hmono := fun a i hi => by
@@ -181,7 +181,7 @@ theorem exp_cond_mul_saved_bit_beq_evm_exp_msb_saved_bit_two_mul_with_mul_spec_w
   have h := EvmAsm.Rv64.beq_spec_within .x18 .x0 skipOff v18 (0 : Word)
     (base + 148)
   rw [htarget] at h
-  rw [expTopSavedBitCondMulBeqNextPc] at h
+  rw [EvmAsm.Evm64.Exp.AddrNorm.expTopSavedBitCondMulBeqNextPc] at h
   exact cpsBranchWithin_extend_code
     (h := h)
     (hmono := fun a i hi => by

--- a/EvmAsm/Evm64/Exp/Compose/TopCallSubs.lean
+++ b/EvmAsm/Evm64/Exp/Compose/TopCallSubs.lean
@@ -161,16 +161,4 @@ theorem evmExpCode_cond_mul_beq_sub {base : Word}
     (EvmAsm.Evm64.exp_cond_mul_call_with_skip_block_code_beq_sub
       (base + 144) mulOff skipOff a i h)
 
-theorem expTopCondMulBeqNextPc (base : Word) :
-    ((base + 144 : Word) + 4) = base + 148 := by
-  bv_omega
-
-theorem expTopSavedBitCondMulBeqNextPc (base : Word) :
-    ((base + 148 : Word) + 4) = base + 152 := by
-  bv_omega
-
-theorem expTopCondMulMarshalPairNextPc (base : Word) :
-    ((base + 148 : Word) + 64) = base + 212 := by
-  bv_omega
-
 end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/TopCondMulMarshalBlocks.lean
+++ b/EvmAsm/Evm64/Exp/Compose/TopCondMulMarshalBlocks.lean
@@ -6,6 +6,7 @@
 -/
 
 import EvmAsm.Evm64.Exp.Compose.TopSquaringMarshalBlocks
+import EvmAsm.Evm64.Exp.AddrNorm
 
 namespace EvmAsm.Evm64.Exp.Compose
 
@@ -138,7 +139,7 @@ theorem exp_cond_mul_beq_evm_exp_spec_within
   have h := EvmAsm.Rv64.beq_spec_within .x10 .x0 skipOff v10 (0 : Word)
     (base + 144)
   rw [htarget] at h
-  rw [expTopCondMulBeqNextPc] at h
+  rw [EvmAsm.Evm64.Exp.AddrNorm.expTopCondMulBeqNextPc] at h
   exact cpsBranchWithin_extend_code (h := h)
     (hmono := evmExpCode_cond_mul_beq_sub)
 
@@ -158,7 +159,7 @@ theorem exp_cond_mul_saved_bit_beq_evm_exp_msb_saved_bit_spec_within
   have h := EvmAsm.Rv64.beq_spec_within .x18 .x0 skipOff v18 (0 : Word)
     (base + 148)
   rw [htarget] at h
-  rw [expTopSavedBitCondMulBeqNextPc] at h
+  rw [EvmAsm.Evm64.Exp.AddrNorm.expTopSavedBitCondMulBeqNextPc] at h
   exact cpsBranchWithin_extend_code (h := h)
     (hmono := evmExpMsbSavedBitCode_cond_mul_beq_sub)
 

--- a/EvmAsm/Evm64/Exp/Compose/TopIterSubs.lean
+++ b/EvmAsm/Evm64/Exp/Compose/TopIterSubs.lean
@@ -35,17 +35,6 @@ theorem expTopIterLoopBackAddr (base : Word) :
     (base + 252 : Word) = base + 28 + 224 := by
   bv_omega
 
-theorem expTopIterBitTestNextPc (base : Word) :
-    ((base + 28 : Word) + 12) = base + 40 := by
-  bv_omega
-
-theorem expTopSavedBitSaveNextPc (base : Word) :
-    ((base + 40 : Word) + 4) = base + 44 := by
-  bv_omega
-
-theorem expTopLoopBackNextPc (base : Word) :
-    ((base + 252 : Word) + 8) = base + 260 := by
-  bv_omega
 
 theorem expTopSavedBitLoopBackNextPc (base : Word) :
     ((base + 256 : Word) + 8) = base + 264 := by

--- a/EvmAsm/Evm64/Exp/Compose/TopJalBlocks.lean
+++ b/EvmAsm/Evm64/Exp/Compose/TopJalBlocks.lean
@@ -5,18 +5,11 @@
 -/
 
 import EvmAsm.Evm64.Exp.Compose.TopCallSubs
+import EvmAsm.Evm64.Exp.AddrNorm
 
 namespace EvmAsm.Evm64.Exp.Compose
 
 open EvmAsm.Rv64
-
-theorem expTopSquaringSquareReturnPc (base : Word) :
-    ((base + 104 : Word) + 4) = base + 108 := by
-  bv_omega
-
-theorem expTopCondMulSquareReturnPc (base : Word) :
-    ((base + 212 : Word) + 4) = base + 216 := by
-  bv_omega
 
 /-- Squaring-call JAL spec lifted to the top-level EXP code bundle. -/
 theorem exp_squaring_square_evm_exp_spec_within
@@ -29,7 +22,7 @@ theorem exp_squaring_square_evm_exp_spec_within
       (.x1 ↦ᵣ (base + 108)) := by
   have h := EvmAsm.Evm64.exp_square_block_spec_within mulOff vOld (base + 104)
   rw [hmul] at h
-  rw [expTopSquaringSquareReturnPc] at h
+  rw [EvmAsm.Evm64.Exp.AddrNorm.expTopSquaringSquareReturnPc] at h
   exact cpsTripleWithin_extend_code (h := h) (hmono := evmExpCode_squaring_square_sub)
 
 /-- Conditional-multiply JAL spec lifted to the top-level EXP code bundle. -/
@@ -43,7 +36,7 @@ theorem exp_cond_mul_square_evm_exp_spec_within
       (.x1 ↦ᵣ (base + 216)) := by
   have h := EvmAsm.Evm64.exp_square_block_spec_within mulOff vOld (base + 212)
   rw [hmul] at h
-  rw [expTopCondMulSquareReturnPc] at h
+  rw [EvmAsm.Evm64.Exp.AddrNorm.expTopCondMulSquareReturnPc] at h
   exact cpsTripleWithin_extend_code (h := h) (hmono := evmExpCode_cond_mul_square_sub)
 
 end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/TopLoopControl.lean
+++ b/EvmAsm/Evm64/Exp/Compose/TopLoopControl.lean
@@ -5,6 +5,7 @@
 -/
 
 import EvmAsm.Evm64.Exp.Compose.TopIterSubs
+import EvmAsm.Evm64.Exp.AddrNorm
 
 namespace EvmAsm.Evm64.Exp.Compose
 
@@ -21,7 +22,7 @@ theorem exp_bit_test_evm_exp_spec_within
        (.x6 ↦ᵣ (c + signExtend12 ((-1) : BitVec 12))) **
        (.x10 ↦ᵣ (e &&& signExtend12 (1 : BitVec 12)))) := by
   have h := EvmAsm.Evm64.exp_bit_test_block_spec_within e c v10 (base + 28)
-  rw [expTopIterBitTestNextPc] at h
+  rw [EvmAsm.Evm64.Exp.AddrNorm.expTopIterBitTestNextPc] at h
   exact cpsTripleWithin_extend_code (h := h) (hmono := evmExpCode_iter_bit_test_sub)
 
 /-- MSB bit-test block lifted to the corrected saved-bit top-level EXP code
@@ -36,7 +37,7 @@ theorem exp_msb_bit_test_evm_exp_msb_saved_bit_spec_within
        (.x6 ↦ᵣ (c + signExtend12 ((-1) : BitVec 12))) **
        (.x10 ↦ᵣ (expTwoMulIterBit e))) := by
   have h := EvmAsm.Evm64.exp_msb_bit_test_block_spec_within e c v10 (base + 28)
-  rw [expTopIterBitTestNextPc] at h
+  rw [EvmAsm.Evm64.Exp.AddrNorm.expTopIterBitTestNextPc] at h
   exact cpsTripleWithin_extend_code (h := h)
     (hmono := evmExpMsbSavedBitCode_iter_bit_test_sub)
 
@@ -50,7 +51,7 @@ theorem exp_save_bit_evm_exp_msb_saved_bit_spec_within
       ((.x10 ↦ᵣ bit) ** (.x18 ↦ᵣ v18))
       ((.x10 ↦ᵣ bit) ** (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12)))) := by
   have h := EvmAsm.Evm64.exp_save_bit_block_spec_within bit v18 (base + 40)
-  rw [expTopSavedBitSaveNextPc] at h
+  rw [EvmAsm.Evm64.Exp.AddrNorm.expTopSavedBitSaveNextPc] at h
   exact cpsTripleWithin_extend_code (h := h)
     (hmono := evmExpMsbSavedBitCode_iter_save_bit_sub)
 
@@ -67,7 +68,7 @@ theorem exp_loop_back_evm_exp_spec_within (c : Word)
       (base + 260)
         ((.x9 ↦ᵣ expIterCountNew c) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜expIterCountNew c = 0⌝) := by
   have h := EvmAsm.Evm64.exp_loop_back_spec_within c backOff (base + 252) target htarget
-  rw [expTopLoopBackNextPc] at h
+  rw [EvmAsm.Evm64.Exp.AddrNorm.expTopLoopBackNextPc] at h
   simpa [expIterCountNew] using
     (cpsBranchWithin_extend_code (h := h) (hmono := evmExpCode_iter_loop_back_sub))
 

--- a/EvmAsm/Evm64/Exp/Compose/TopPairBlocks.lean
+++ b/EvmAsm/Evm64/Exp/Compose/TopPairBlocks.lean
@@ -7,6 +7,7 @@
 import EvmAsm.Evm64.Exp.Compose.TopCondMulMarshalBlocks
 import EvmAsm.Evm64.Exp.CondMulMarshalPair
 import EvmAsm.Evm64.Exp.SquaringCallSeq
+import EvmAsm.Evm64.Exp.AddrNorm
 
 namespace EvmAsm.Evm64.Exp.Compose
 
@@ -108,7 +109,7 @@ theorem exp_cond_mul_marshal_pair_evm_exp_spec_within
        ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3)) := by
   have h := EvmAsm.Evm64.exp_loop_cond_mul_marshal_pair_spec_within
     sp evmSp tOld r0 r1 r2 r3 a0 a1 a2 a3 d0 d1 d2 d3 e0 e1 e2 e3 (base + 148)
-  rw [expTopCondMulMarshalPairNextPc] at h
+  rw [EvmAsm.Evm64.Exp.AddrNorm.expTopCondMulMarshalPairNextPc] at h
   have hmono :
       ∀ addr instr, EvmAsm.Evm64.exp_loop_cond_mul_marshal_pair_code
           (base + 148) addr = some instr →


### PR DESCRIPTION
## Summary
- add central EXP address-normalization facts for top-code next and return PCs
- remove the corresponding local wrappers from TopCodeSpecs

## Verification
- lake build EvmAsm.Evm64.Exp.AddrNorm EvmAsm.Evm64.Exp.Compose.TopCodeSpecs
- lake build EvmAsm.Evm64.Exp
- scripts/check-unimported.sh
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/AddrNorm.lean EvmAsm/Evm64/Exp/Compose/TopCodeSpecs.lean