### PR TITLE
refactor(exp): centralize top exit pc facts

### DIFF
--- a/EvmAsm/Evm64/Exp/AddrNorm.lean
+++ b/EvmAsm/Evm64/Exp/AddrNorm.lean
@@ -219,6 +219,30 @@ attribute [exp_addr]
     ((base + 212 : Word) + 4) = base + 216 := by
   bv_decide
 
+@[exp_addr, grind =] theorem expTopSquaringFactor1ExitPc (base : Word) :
+    ((base + 40 : Word) + 32) = base + 72 := by
+  bv_decide
+
+@[exp_addr, grind =] theorem expTopSquaringFactor2ExitPc (base : Word) :
+    ((base + 72 : Word) + 32) = base + 104 := by
+  bv_decide
+
+@[exp_addr, grind =] theorem expTopSquaringRestoreExitPc (base : Word) :
+    ((base + 108 : Word) + 36) = base + 144 := by
+  bv_decide
+
+@[exp_addr, grind =] theorem expTopCondMulFactor1ExitPc (base : Word) :
+    ((base + 148 : Word) + 32) = base + 180 := by
+  bv_decide
+
+@[exp_addr, grind =] theorem expTopCondMulFactor2ExitPc (base : Word) :
+    ((base + 180 : Word) + 32) = base + 212 := by
+  bv_decide
+
+@[exp_addr, grind =] theorem expTopCondMulRestoreExitPc (base : Word) :
+    ((base + 216 : Word) + 36) = base + 252 := by
+  bv_decide
+
 @[exp_addr, grind =] theorem expBaseAdd40Aligned
     (base : Word) (hbase : base &&& 1 = 0) :
     (base + 40 : Word) &&& 1 = 0 := by bv_decide

--- a/EvmAsm/Evm64/Exp/Compose/TopCondMulMarshalBlocks.lean
+++ b/EvmAsm/Evm64/Exp/Compose/TopCondMulMarshalBlocks.lean
@@ -12,18 +12,6 @@ namespace EvmAsm.Evm64.Exp.Compose
 
 open EvmAsm.Rv64
 
-theorem expTopCondMulFactor1ExitPc (base : Word) :
-    ((base + 148 : Word) + 32) = base + 180 := by
-  bv_omega
-
-theorem expTopCondMulFactor2ExitPc (base : Word) :
-    ((base + 180 : Word) + 32) = base + 212 := by
-  bv_omega
-
-theorem expTopCondMulRestoreExitPc (base : Word) :
-    ((base + 216 : Word) + 36) = base + 252 := by
-  bv_omega
-
 /-- Conditional-multiply factor-1 marshal spec lifted to the top-level EXP
     code bundle: at offset `base + 148`, copies result limbs from scratch to
     factor1, exits at `base + 180`. -/
@@ -85,7 +73,7 @@ theorem exp_cond_mul_marshal_a_to_factor2_evm_exp_spec_within
        ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ a3)) := by
   have h := EvmAsm.Evm64.exp_loop_marshal_a_to_factor2_ofProg_spec_within
     evmSp tOld a0 a1 a2 a3 d0 d1 d2 d3 (base + 180)
-  rw [expTopCondMulFactor2ExitPc] at h
+  rw [EvmAsm.Evm64.Exp.AddrNorm.expTopCondMulFactor2ExitPc] at h
   exact cpsTripleWithin_extend_code (h := h)
     (hmono := evmExpCode_cond_mul_marshal_a_to_factor2_sub)
 
@@ -119,7 +107,7 @@ theorem exp_cond_mul_un_marshal_and_restore_evm_exp_spec_within
        ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ d3)) := by
   have h := EvmAsm.Evm64.exp_loop_un_marshal_and_restore_ofProg_spec_within
     sp evmSp tOld r0 r1 r2 r3 d0 d1 d2 d3 (base + 216)
-  rw [expTopCondMulRestoreExitPc] at h
+  rw [EvmAsm.Evm64.Exp.AddrNorm.expTopCondMulRestoreExitPc] at h
   exact cpsTripleWithin_extend_code (h := h)
     (hmono := evmExpCode_cond_mul_un_marshal_and_restore_sub)
 

--- a/EvmAsm/Evm64/Exp/Compose/TopSquaringMarshalBlocks.lean
+++ b/EvmAsm/Evm64/Exp/Compose/TopSquaringMarshalBlocks.lean
@@ -6,22 +6,11 @@
 -/
 
 import EvmAsm.Evm64.Exp.Compose.TopJalBlocks
+import EvmAsm.Evm64.Exp.AddrNorm
 
 namespace EvmAsm.Evm64.Exp.Compose
 
 open EvmAsm.Rv64
-
-theorem expTopSquaringFactor1ExitPc (base : Word) :
-    ((base + 40 : Word) + 32) = base + 72 := by
-  bv_omega
-
-theorem expTopSquaringFactor2ExitPc (base : Word) :
-    ((base + 72 : Word) + 32) = base + 104 := by
-  bv_omega
-
-theorem expTopSquaringRestoreExitPc (base : Word) :
-    ((base + 108 : Word) + 36) = base + 144 := by
-  bv_omega
 
 /-- Squaring-call factor-1 marshal spec lifted to the top-level EXP code
     bundle: at offset `base + 40`, copies result limbs from scratch to
@@ -51,7 +40,7 @@ theorem exp_squaring_marshal_factor1_evm_exp_spec_within
        ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ r3)) := by
   have h := EvmAsm.Evm64.exp_loop_marshal_factor1_ofProg_spec_within
     sp evmSp tOld r0 r1 r2 r3 d0 d1 d2 d3 (base + 40)
-  rw [expTopSquaringFactor1ExitPc] at h
+  rw [EvmAsm.Evm64.Exp.AddrNorm.expTopSquaringFactor1ExitPc] at h
   exact cpsTripleWithin_extend_code (h := h)
     (hmono := evmExpCode_squaring_marshal_factor1_sub)
 
@@ -83,7 +72,7 @@ theorem exp_squaring_marshal_result_to_factor2_evm_exp_spec_within
        ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ r3)) := by
   have h := EvmAsm.Evm64.exp_loop_marshal_result_to_factor2_ofProg_spec_within
     sp evmSp tOld r0 r1 r2 r3 d0 d1 d2 d3 (base + 72)
-  rw [expTopSquaringFactor2ExitPc] at h
+  rw [EvmAsm.Evm64.Exp.AddrNorm.expTopSquaringFactor2ExitPc] at h
   exact cpsTripleWithin_extend_code (h := h)
     (hmono := evmExpCode_squaring_marshal_result_to_factor2_sub)
 
@@ -117,7 +106,7 @@ theorem exp_squaring_un_marshal_and_restore_evm_exp_spec_within
        ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ d3)) := by
   have h := EvmAsm.Evm64.exp_loop_un_marshal_and_restore_ofProg_spec_within
     sp evmSp tOld r0 r1 r2 r3 d0 d1 d2 d3 (base + 108)
-  rw [expTopSquaringRestoreExitPc] at h
+  rw [EvmAsm.Evm64.Exp.AddrNorm.expTopSquaringRestoreExitPc] at h
   exact cpsTripleWithin_extend_code (h := h)
     (hmono := evmExpCode_squaring_un_marshal_and_restore_sub)
 


### PR DESCRIPTION
## Summary
- add central EXP address-normalization facts for top-code squaring and cond-mul exit PCs
- remove the corresponding local wrappers from TopCodeSpecs

## Verification
- lake build EvmAsm.Evm64.Exp.AddrNorm EvmAsm.Evm64.Exp.Compose.TopCodeSpecs
- lake build EvmAsm.Evm64.Exp
- scripts/check-unimported.sh
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/AddrNorm.lean EvmAsm/Evm64/Exp/Compose/TopCodeSpecs.lean