### PR TITLE
refactor(exp): centralize top marshal pc facts

### DIFF
--- a/EvmAsm/Evm64/Exp/AddrNorm.lean
+++ b/EvmAsm/Evm64/Exp/AddrNorm.lean
@@ -243,6 +243,14 @@ attribute [exp_addr]
     ((base + 216 : Word) + 36) = base + 252 := by
   bv_decide
 
+@[exp_addr, grind =] theorem expTopSquaringMarshalPairReturnPc (base : Word) :
+    ((base + 40 : Word) + 68) = base + 108 := by
+  bv_decide
+
+@[exp_addr, grind =] theorem expTopSquaringMarshalPairTargetPc (base : Word) :
+    ((base + 40 : Word) + 64) = base + 104 := by
+  bv_decide
+
 @[exp_addr, grind =] theorem expBaseAdd40Aligned
     (base : Word) (hbase : base &&& 1 = 0) :
     (base + 40 : Word) &&& 1 = 0 := by bv_decide

--- a/EvmAsm/Evm64/Exp/Compose/TopPairBlocks.lean
+++ b/EvmAsm/Evm64/Exp/Compose/TopPairBlocks.lean
@@ -13,14 +13,6 @@ namespace EvmAsm.Evm64.Exp.Compose
 
 open EvmAsm.Rv64
 
-theorem expTopSquaringMarshalPairReturnPc (base : Word) :
-    ((base + 40 : Word) + 68) = base + 108 := by
-  bv_omega
-
-theorem expTopSquaringMarshalPairTargetPc (base : Word) :
-    ((base + 40 : Word) + 64) = base + 104 := by
-  bv_omega
-
 /-- Squaring-call marshal prefix and JAL lifted to the top-level EXP code bundle. -/
 theorem exp_squaring_marshal_pair_then_square_evm_exp_spec_within
     (sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 : Word)
@@ -60,10 +52,10 @@ theorem exp_squaring_marshal_pair_then_square_evm_exp_spec_within
   have h := EvmAsm.Evm64.exp_loop_squaring_marshal_pair_then_square_spec_within
     sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 mulOff (base + 40)
   have htarget : (((base + 40) + 64 : Word) + signExtend21 mulOff) = mulTarget := by
-    rw [expTopSquaringMarshalPairTargetPc]
+    rw [EvmAsm.Evm64.Exp.AddrNorm.expTopSquaringMarshalPairTargetPc]
     exact hmul
   rw [htarget] at h
-  rw [expTopSquaringMarshalPairReturnPc] at h
+  rw [EvmAsm.Evm64.Exp.AddrNorm.expTopSquaringMarshalPairReturnPc] at h
   exact cpsTripleWithin_extend_code (h := h) (hmono := evmExpCode_iter_squaring_sub)
 
 /-- Conditional-multiply marshal pair lifted to the top-level EXP code bundle. -/


### PR DESCRIPTION
## Summary
- add central EXP address-normalization facts for top squaring marshal-pair target and return PCs
- remove the corresponding local wrappers from TopCodeSpecs

## Verification
- lake build EvmAsm.Evm64.Exp.AddrNorm EvmAsm.Evm64.Exp.Compose.TopCodeSpecs
- lake build EvmAsm.Evm64.Exp
- scripts/check-unimported.sh
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/AddrNorm.lean EvmAsm/Evm64/Exp/Compose/TopCodeSpecs.lean