### PR TITLE
refactor(exp): centralize top iteration addresses

### DIFF
--- a/EvmAsm/Evm64/Exp/AddrNorm.lean
+++ b/EvmAsm/Evm64/Exp/AddrNorm.lean
@@ -251,6 +251,30 @@ attribute [exp_addr]
     ((base + 40 : Word) + 64) = base + 104 := by
   bv_decide
 
+@[exp_addr, grind =] theorem expTopIterSquaringAddr (base : Word) :
+    (base + 40 : Word) = base + 28 + 12 := by
+  bv_decide
+
+@[exp_addr, grind =] theorem expTopIterCondMulAddr (base : Word) :
+    (base + 144 : Word) = base + 28 + 116 := by
+  bv_decide
+
+@[exp_addr, grind =] theorem expTopIterSavedBitSquaringAddr (base : Word) :
+    (base + 44 : Word) = base + 28 + 16 := by
+  bv_decide
+
+@[exp_addr, grind =] theorem expTopIterSavedBitCondMulAddr (base : Word) :
+    (base + 148 : Word) = base + 28 + 120 := by
+  bv_decide
+
+@[exp_addr, grind =] theorem expTopIterSavedBitLoopBackAddr (base : Word) :
+    (base + 256 : Word) = base + 28 + 228 := by
+  bv_decide
+
+@[exp_addr, grind =] theorem expTopIterLoopBackAddr (base : Word) :
+    (base + 252 : Word) = base + 28 + 224 := by
+  bv_decide
+
 @[exp_addr, grind =] theorem expBaseAdd40Aligned
     (base : Word) (hbase : base &&& 1 = 0) :
     (base + 40 : Word) &&& 1 = 0 := by bv_decide

--- a/EvmAsm/Evm64/Exp/Compose/TopIterSubs.lean
+++ b/EvmAsm/Evm64/Exp/Compose/TopIterSubs.lean
@@ -6,35 +6,11 @@
 
 import EvmAsm.Evm64.Exp.Compose.SavedBitBase
 import EvmAsm.Evm64.Exp.Compose.EvmExpCode
+import EvmAsm.Evm64.Exp.AddrNorm
 
 namespace EvmAsm.Evm64.Exp.Compose
 
 open EvmAsm.Rv64
-
-theorem expTopIterSquaringAddr (base : Word) :
-    (base + 40 : Word) = base + 28 + 12 := by
-  bv_omega
-
-theorem expTopIterCondMulAddr (base : Word) :
-    (base + 144 : Word) = base + 28 + 116 := by
-  bv_omega
-
-theorem expTopIterSavedBitSquaringAddr (base : Word) :
-    (base + 44 : Word) = base + 28 + 16 := by
-  bv_omega
-
-theorem expTopIterSavedBitCondMulAddr (base : Word) :
-    (base + 148 : Word) = base + 28 + 120 := by
-  bv_omega
-
-theorem expTopIterSavedBitLoopBackAddr (base : Word) :
-    (base + 256 : Word) = base + 28 + 228 := by
-  bv_omega
-
-theorem expTopIterLoopBackAddr (base : Word) :
-    (base + 252 : Word) = base + 28 + 224 := by
-  bv_omega
-
 
 theorem expTopSavedBitLoopBackNextPc (base : Word) :
     ((base + 256 : Word) + 8) = base + 264 := by
@@ -54,7 +30,7 @@ theorem evmExpCode_iter_squaring_sub {base : Word}
     ∀ a i, (exp_squaring_call_block_code (base + 40) mulOff) a = some i →
       (evmExpCode base mulOff skipOff backOff) a = some i := by
   intro a i h
-  rw [expTopIterSquaringAddr] at h
+  rw [EvmAsm.Evm64.Exp.AddrNorm.expTopIterSquaringAddr] at h
   exact evmExpCode_iter_body_sub a i (expIterBodyFullCode_squaring_sub a i h)
 
 /-- Conditional-multiply sub-block directly included in the top-level EXP code
@@ -65,7 +41,7 @@ theorem evmExpCode_iter_cond_mul_sub {base : Word}
       (base + 144) mulOff skipOff) a = some i →
       (evmExpCode base mulOff skipOff backOff) a = some i := by
   intro a i h
-  rw [expTopIterCondMulAddr] at h
+  rw [EvmAsm.Evm64.Exp.AddrNorm.expTopIterCondMulAddr] at h
   exact evmExpCode_iter_body_sub a i (expIterBodyFullCode_cond_mul_sub a i h)
 
 /-- MSB bit-test sub-block directly included in the corrected saved-bit
@@ -87,7 +63,7 @@ theorem evmExpMsbSavedBitCode_iter_save_bit_sub {base : Word}
       a = some i →
       (evmExpMsbSavedBitCode base mulOff skipOff backOff) a = some i := by
   intro a i h
-  rw [expTopIterSquaringAddr] at h
+  rw [EvmAsm.Evm64.Exp.AddrNorm.expTopIterSquaringAddr] at h
   exact evmExpMsbSavedBitCode_iter_body_sub a i
     (expIterBodyFullMsbSavedBitCode_save_bit_sub a i h)
 
@@ -98,7 +74,7 @@ theorem evmExpMsbSavedBitCode_iter_squaring_sub {base : Word}
     ∀ a i, (exp_squaring_call_block_code (base + 44) mulOff) a = some i →
       (evmExpMsbSavedBitCode base mulOff skipOff backOff) a = some i := by
   intro a i h
-  rw [expTopIterSavedBitSquaringAddr] at h
+  rw [EvmAsm.Evm64.Exp.AddrNorm.expTopIterSavedBitSquaringAddr] at h
   exact evmExpMsbSavedBitCode_iter_body_sub a i
     (expIterBodyFullMsbSavedBitCode_squaring_sub a i h)
 
@@ -110,7 +86,7 @@ theorem evmExpMsbSavedBitCode_iter_cond_mul_sub {base : Word}
       (base + 148) mulOff skipOff) a = some i →
       (evmExpMsbSavedBitCode base mulOff skipOff backOff) a = some i := by
   intro a i h
-  rw [expTopIterSavedBitCondMulAddr] at h
+  rw [EvmAsm.Evm64.Exp.AddrNorm.expTopIterSavedBitCondMulAddr] at h
   exact evmExpMsbSavedBitCode_iter_body_sub a i
     (expIterBodyFullMsbSavedBitCode_cond_mul_sub a i h)
 
@@ -122,7 +98,7 @@ theorem evmExpMsbSavedBitCode_iter_loop_back_sub {base : Word}
       (EvmAsm.Evm64.exp_loop_back backOff)) a = some i →
       (evmExpMsbSavedBitCode base mulOff skipOff backOff) a = some i := by
   intro a i h
-  rw [expTopIterSavedBitLoopBackAddr] at h
+  rw [EvmAsm.Evm64.Exp.AddrNorm.expTopIterSavedBitLoopBackAddr] at h
   exact evmExpMsbSavedBitCode_iter_body_sub a i
     (expIterBodyFullMsbSavedBitCode_loop_back_sub a i h)
 
@@ -133,7 +109,7 @@ theorem evmExpMsbSavedBitTwoMulCode_iter_loop_back_sub {base : Word}
       (evmExpMsbSavedBitTwoMulCode
         base squaringMulOff condMulOff skipOff backOff) a = some i := by
   intro a i h
-  rw [expTopIterSavedBitLoopBackAddr] at h
+  rw [EvmAsm.Evm64.Exp.AddrNorm.expTopIterSavedBitLoopBackAddr] at h
   exact evmExpMsbSavedBitTwoMulCode_iter_body_sub a i
     (expIterBodyFullMsbSavedBitTwoMulCode_loop_back_sub a i h)
 
@@ -156,7 +132,7 @@ theorem evmExpCode_iter_loop_back_sub {base : Word}
       (EvmAsm.Evm64.exp_loop_back backOff)) a = some i →
       (evmExpCode base mulOff skipOff backOff) a = some i := by
   intro a i h
-  rw [expTopIterLoopBackAddr] at h
+  rw [EvmAsm.Evm64.Exp.AddrNorm.expTopIterLoopBackAddr] at h
   exact evmExpCode_iter_body_sub a i (expIterBodyFullCode_loop_back_sub a i h)
 
 end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- add central EXP address-normalization facts for top-code iteration sub-block addresses
- remove the corresponding local wrappers from TopCodeSpecs

## Verification
- lake build EvmAsm.Evm64.Exp.AddrNorm EvmAsm.Evm64.Exp.Compose.TopCodeSpecs
- lake build EvmAsm.Evm64.Exp
- scripts/check-unimported.sh
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/AddrNorm.lean EvmAsm/Evm64/Exp/Compose/TopCodeSpecs.lean