### PR TITLE
refactor(exp): centralize top program offsets

### DIFF
--- a/EvmAsm/Evm64/Exp/AddrNorm.lean
+++ b/EvmAsm/Evm64/Exp/AddrNorm.lean
@@ -318,6 +318,22 @@ attribute [exp_addr]
   rw [EvmAsm.Evm64.exp_prologue_length]
   bv_decide
 
+@[exp_addr, grind =] theorem expTopPointerAdvanceProgramAddr (base : Word) :
+    (base + 24 : Word) = base + BitVec.ofNat 64 (4 * 6) := by
+  bv_decide
+
+@[exp_addr, grind =] theorem expTopIterBodyProgramAddr (base : Word) :
+    (base + 28 : Word) = base + BitVec.ofNat 64 (4 * 7) := by
+  bv_decide
+
+@[exp_addr, grind =] theorem expTopPointerRestoreProgramAddr (base : Word) :
+    (base + 260 : Word) = base + BitVec.ofNat 64 (4 * 65) := by
+  bv_decide
+
+@[exp_addr, grind =] theorem expTopEpilogueProgramAddr (base : Word) :
+    (base + 264 : Word) = base + BitVec.ofNat 64 (4 * 66) := by
+  bv_decide
+
 @[exp_addr, grind =] theorem expBaseAdd40Aligned
     (base : Word) (hbase : base &&& 1 = 0) :
     (base + 40 : Word) &&& 1 = 0 := by bv_decide

--- a/EvmAsm/Evm64/Exp/Compose/EvmExpCode.lean
+++ b/EvmAsm/Evm64/Exp/Compose/EvmExpCode.lean
@@ -86,7 +86,7 @@ theorem evmExpCode_pointer_advance_sub {base : Word}
   exact CodeReq.ofProg_mono_sub base (base + 24)
     (EvmAsm.Evm64.evm_exp mulOff skipOff backOff)
     EvmAsm.Evm64.exp_loop_pointer_advance 6
-    (by bv_omega)
+    (EvmAsm.Evm64.Exp.AddrNorm.expTopPointerAdvanceProgramAddr base)
     (by
       unfold EvmAsm.Evm64.evm_exp
       simp only [EvmAsm.Rv64.seq]
@@ -107,7 +107,7 @@ theorem evmExpCode_iter_body_sub {base : Word}
   exact CodeReq.ofProg_mono_sub base (base + 28)
     (EvmAsm.Evm64.evm_exp mulOff skipOff backOff)
     (EvmAsm.Evm64.exp_iter_body_full mulOff skipOff backOff) 7
-    (by bv_omega)
+    (EvmAsm.Evm64.Exp.AddrNorm.expTopIterBodyProgramAddr base)
     (by
       unfold EvmAsm.Evm64.evm_exp
       simp only [EvmAsm.Rv64.seq]
@@ -129,7 +129,7 @@ theorem evmExpCode_pointer_restore_sub {base : Word}
   exact CodeReq.ofProg_mono_sub base (base + 260)
     (EvmAsm.Evm64.evm_exp mulOff skipOff backOff)
     EvmAsm.Evm64.exp_loop_pointer_restore 65
-    (by bv_omega)
+    (EvmAsm.Evm64.Exp.AddrNorm.expTopPointerRestoreProgramAddr base)
     (by
       unfold EvmAsm.Evm64.evm_exp
       simp only [EvmAsm.Rv64.seq]

--- a/EvmAsm/Evm64/Exp/Compose/TopCodeSubs.lean
+++ b/EvmAsm/Evm64/Exp/Compose/TopCodeSubs.lean
@@ -21,7 +21,7 @@ theorem evmExpCode_epilogue_sub {base : Word}
   exact CodeReq.ofProg_mono_sub base (base + 264)
     (EvmAsm.Evm64.evm_exp mulOff skipOff backOff)
     EvmAsm.Evm64.exp_epilogue 66
-    (by bv_omega)
+    (EvmAsm.Evm64.Exp.AddrNorm.expTopEpilogueProgramAddr base)
     (by
       unfold EvmAsm.Evm64.evm_exp
       simp only [EvmAsm.Rv64.seq]


### PR DESCRIPTION
## Summary
- add central EXP address-normalization facts for top-level evm_exp subprogram offsets
- replace inline bv_omega offset witnesses in EvmExpCode and TopCodeSubs

## Verification
- lake build EvmAsm.Evm64.Exp.AddrNorm EvmAsm.Evm64.Exp.Compose.EvmExpCode EvmAsm.Evm64.Exp.Compose.TopCodeSubs
- lake build EvmAsm.Evm64.Exp
- scripts/check-unimported.sh
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/AddrNorm.lean EvmAsm/Evm64/Exp/Compose/EvmExpCode.lean EvmAsm/Evm64/Exp/Compose/TopCodeSubs.lean