### PR TITLE
refactor(exp): centralize loop program offsets

### DIFF
--- a/EvmAsm/Evm64/Exp/AddrNorm.lean
+++ b/EvmAsm/Evm64/Exp/AddrNorm.lean
@@ -334,6 +334,18 @@ attribute [exp_addr]
     (base + 264 : Word) = base + BitVec.ofNat 64 (4 * 66) := by
   bv_decide
 
+@[exp_addr, grind =] theorem expLoopSquareProgramAddr (base : Word) :
+    (base + 12 : Word) = base + BitVec.ofNat 64 (4 * 3) := by
+  bv_decide
+
+@[exp_addr, grind =] theorem expLoopCondMulProgramAddr (base : Word) :
+    (base + 16 : Word) = base + BitVec.ofNat 64 (4 * 4) := by
+  bv_decide
+
+@[exp_addr, grind =] theorem expLoopBackProgramAddr (base : Word) :
+    (base + 24 : Word) = base + BitVec.ofNat 64 (4 * 6) := by
+  bv_decide
+
 @[exp_addr, grind =] theorem expBaseAdd40Aligned
     (base : Word) (hbase : base &&& 1 = 0) :
     (base + 40 : Word) &&& 1 = 0 := by bv_decide

--- a/EvmAsm/Evm64/Exp/Compose/Base.lean
+++ b/EvmAsm/Evm64/Exp/Compose/Base.lean
@@ -148,7 +148,7 @@ theorem expLoopCode_square_sub {base : Word}
   exact CodeReq.ofProg_mono_sub base (base + 12)
     (EvmAsm.Evm64.exp_loop mulOff skipOff backOff)
     (EvmAsm.Evm64.exp_square_block mulOff) 3
-    (by bv_omega)
+    (EvmAsm.Evm64.Exp.AddrNorm.expLoopSquareProgramAddr base)
     (by
       unfold EvmAsm.Evm64.exp_loop EvmAsm.Evm64.exp_iter_body
       unfold EvmAsm.Evm64.exp_bit_test_block EvmAsm.Evm64.exp_square_block
@@ -172,7 +172,7 @@ theorem expLoopCode_cond_mul_sub {base : Word}
   exact CodeReq.ofProg_mono_sub base (base + 16)
     (EvmAsm.Evm64.exp_loop mulOff skipOff backOff)
     (EvmAsm.Evm64.exp_cond_mul_block mulOff skipOff) 4
-    (by bv_omega)
+    (EvmAsm.Evm64.Exp.AddrNorm.expLoopCondMulProgramAddr base)
     (by
       unfold EvmAsm.Evm64.exp_loop EvmAsm.Evm64.exp_iter_body
       unfold EvmAsm.Evm64.exp_bit_test_block EvmAsm.Evm64.exp_square_block
@@ -196,7 +196,7 @@ theorem expLoopCode_loop_back_sub {base : Word}
   exact CodeReq.ofProg_mono_sub base (base + 24)
     (EvmAsm.Evm64.exp_loop mulOff skipOff backOff)
     (EvmAsm.Evm64.exp_loop_back backOff) 6
-    (by bv_omega)
+    (EvmAsm.Evm64.Exp.AddrNorm.expLoopBackProgramAddr base)
     (by
       unfold EvmAsm.Evm64.exp_loop EvmAsm.Evm64.exp_iter_body
       unfold EvmAsm.Evm64.exp_bit_test_block EvmAsm.Evm64.exp_square_block


### PR DESCRIPTION
## Summary
- add central EXP address-normalization facts for nonzero exp_loop subprogram offsets
- replace inline bv_omega offset witnesses in Compose/Base loop subsumption lemmas

## Verification
- lake build EvmAsm.Evm64.Exp.AddrNorm EvmAsm.Evm64.Exp.Compose.Base
- lake build EvmAsm.Evm64.Exp
- scripts/check-unimported.sh
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/AddrNorm.lean EvmAsm/Evm64/Exp/Compose/Base.lean