### PR TITLE
refactor(exp): centralize saved-bit iteration offsets

### DIFF
--- a/EvmAsm/Evm64/Exp/AddrNorm.lean
+++ b/EvmAsm/Evm64/Exp/AddrNorm.lean
@@ -346,6 +346,14 @@ attribute [exp_addr]
     (base + 24 : Word) = base + BitVec.ofNat 64 (4 * 6) := by
   bv_decide
 
+@[exp_addr, grind =] theorem expSavedBitCondMulProgramAddr (base : Word) :
+    (base + 120 : Word) = base + BitVec.ofNat 64 (4 * 30) := by
+  bv_decide
+
+@[exp_addr, grind =] theorem expSavedBitLoopBackProgramAddr (base : Word) :
+    (base + 228 : Word) = base + BitVec.ofNat 64 (4 * 57) := by
+  bv_decide
+
 @[exp_addr, grind =] theorem expBaseAdd40Aligned
     (base : Word) (hbase : base &&& 1 = 0) :
     (base + 40 : Word) &&& 1 = 0 := by bv_decide

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBaseIter.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBaseIter.lean
@@ -103,7 +103,7 @@ theorem expIterBodyFullMsbSavedBitCode_save_bit_sub {base : Word}
   exact CodeReq.ofProg_mono_sub base (base + 12)
     (EvmAsm.Evm64.exp_iter_body_full_msb_saved_bit mulOff skipOff backOff)
     EvmAsm.Evm64.exp_save_bit_block 3
-    (by bv_omega)
+    (EvmAsm.Evm64.Exp.AddrNorm.expLoopSquareProgramAddr base)
     (by
       unfold EvmAsm.Evm64.exp_iter_body_full_msb_saved_bit
       simp only [EvmAsm.Rv64.seq]
@@ -126,7 +126,7 @@ theorem expIterBodyFullMsbSavedBitCode_squaring_sub {base : Word}
   exact CodeReq.ofProg_mono_sub base (base + 16)
     (EvmAsm.Evm64.exp_iter_body_full_msb_saved_bit mulOff skipOff backOff)
     (EvmAsm.Evm64.exp_squaring_call_block mulOff) 4
-    (by bv_omega)
+    (EvmAsm.Evm64.Exp.AddrNorm.expLoopCondMulProgramAddr base)
     (by
       unfold EvmAsm.Evm64.exp_iter_body_full_msb_saved_bit
       simp only [EvmAsm.Rv64.seq]
@@ -150,7 +150,7 @@ theorem expIterBodyFullMsbSavedBitCode_cond_mul_sub {base : Word}
   exact CodeReq.ofProg_mono_sub base (base + 120)
     (EvmAsm.Evm64.exp_iter_body_full_msb_saved_bit mulOff skipOff backOff)
     (EvmAsm.Evm64.exp_cond_mul_call_with_saved_bit_skip_block mulOff skipOff) 30
-    (by bv_omega)
+    (EvmAsm.Evm64.Exp.AddrNorm.expSavedBitCondMulProgramAddr base)
     (by
       unfold EvmAsm.Evm64.exp_iter_body_full_msb_saved_bit
       simp only [EvmAsm.Rv64.seq]
@@ -174,7 +174,7 @@ theorem expIterBodyFullMsbSavedBitCode_loop_back_sub {base : Word}
   exact CodeReq.ofProg_mono_sub base (base + 228)
     (EvmAsm.Evm64.exp_iter_body_full_msb_saved_bit mulOff skipOff backOff)
     (EvmAsm.Evm64.exp_loop_back backOff) 57
-    (by bv_omega)
+    (EvmAsm.Evm64.Exp.AddrNorm.expSavedBitLoopBackProgramAddr base)
     (by
       unfold EvmAsm.Evm64.exp_iter_body_full_msb_saved_bit
       simp only [EvmAsm.Rv64.seq]


### PR DESCRIPTION
## Summary
- add central EXP address-normalization facts for saved-bit iteration cond-mul and loop-back offsets
- replace inline bv_omega offset witnesses in SavedBitBase with central facts

## Verification
- lake build EvmAsm.Evm64.Exp.AddrNorm EvmAsm.Evm64.Exp.Compose.SavedBitBase
- lake build EvmAsm.Evm64.Exp
- scripts/check-unimported.sh
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/AddrNorm.lean EvmAsm/Evm64/Exp/Compose/SavedBitBase.lean