### PR TITLE
refactor(exp): centralize saved-bit top offsets

### DIFF
--- a/EvmAsm/Evm64/Exp/AddrNorm.lean
+++ b/EvmAsm/Evm64/Exp/AddrNorm.lean
@@ -354,6 +354,10 @@ attribute [exp_addr]
     (base + 228 : Word) = base + BitVec.ofNat 64 (4 * 57) := by
   bv_decide
 
+@[exp_addr, grind =] theorem expSavedBitEpilogueProgramAddr (base : Word) :
+    (base + 268 : Word) = base + BitVec.ofNat 64 (4 * 67) := by
+  bv_decide
+
 @[exp_addr, grind =] theorem expBaseAdd40Aligned
     (base : Word) (hbase : base &&& 1 = 0) :
     (base + 40 : Word) &&& 1 = 0 := by bv_decide

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBaseTwoMulCode.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBaseTwoMulCode.lean
@@ -102,7 +102,7 @@ theorem evmExpMsbSavedBitTwoMulCode_iter_body_sub {base : Word}
       squaringMulOff condMulOff skipOff backOff)
     (EvmAsm.Evm64.exp_iter_body_full_msb_saved_bit_two_mul
       squaringMulOff condMulOff skipOff backOff) 7
-    (by bv_omega)
+    (EvmAsm.Evm64.Exp.AddrNorm.expTopIterBodyProgramAddr base)
     (by
       unfold EvmAsm.Evm64.evm_exp_msb_saved_bit_two_mul
       simp only [EvmAsm.Rv64.seq]
@@ -136,7 +136,7 @@ theorem evmExpMsbSavedBitTwoMulCode_pointer_advance_sub {base : Word}
     (EvmAsm.Evm64.evm_exp_msb_saved_bit_two_mul
       squaringMulOff condMulOff skipOff backOff)
     EvmAsm.Evm64.exp_loop_pointer_advance 6
-    (by bv_omega)
+    (EvmAsm.Evm64.Exp.AddrNorm.expTopPointerAdvanceProgramAddr base)
     (by
       unfold EvmAsm.Evm64.evm_exp_msb_saved_bit_two_mul
       simp only [EvmAsm.Rv64.seq]
@@ -160,7 +160,7 @@ theorem evmExpMsbSavedBitTwoMulCode_pointer_restore_sub {base : Word}
     (EvmAsm.Evm64.evm_exp_msb_saved_bit_two_mul
       squaringMulOff condMulOff skipOff backOff)
     EvmAsm.Evm64.exp_loop_pointer_restore 66
-    (by bv_omega)
+    (EvmAsm.Evm64.Exp.AddrNorm.expTopEpilogueProgramAddr base)
     (by
       unfold EvmAsm.Evm64.evm_exp_msb_saved_bit_two_mul
       simp only [EvmAsm.Rv64.seq]
@@ -184,7 +184,7 @@ theorem evmExpMsbSavedBitTwoMulCode_epilogue_sub {base : Word}
     (EvmAsm.Evm64.evm_exp_msb_saved_bit_two_mul
       squaringMulOff condMulOff skipOff backOff)
     EvmAsm.Evm64.exp_epilogue 67
-    (by bv_omega)
+    (EvmAsm.Evm64.Exp.AddrNorm.expSavedBitEpilogueProgramAddr base)
     (by
       unfold EvmAsm.Evm64.evm_exp_msb_saved_bit_two_mul
       simp only [EvmAsm.Rv64.seq]


### PR DESCRIPTION
## Summary
- add a central EXP address-normalization fact for the saved-bit top-level epilogue offset
- replace inline bv_omega witnesses for saved-bit top-level subprogram offsets with central facts

## Verification
- lake build EvmAsm.Evm64.Exp.AddrNorm EvmAsm.Evm64.Exp.Compose.SavedBitBase
- lake build EvmAsm.Evm64.Exp
- scripts/check-unimported.sh
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/AddrNorm.lean EvmAsm/Evm64/Exp/Compose/SavedBitBase.lean