### PR TITLE
refactor(exp): centralize squaring call offsets

### DIFF
--- a/EvmAsm/Evm64/Exp/AddrNorm.lean
+++ b/EvmAsm/Evm64/Exp/AddrNorm.lean
@@ -358,6 +358,18 @@ attribute [exp_addr]
     (base + 268 : Word) = base + BitVec.ofNat 64 (4 * 67) := by
   bv_decide
 
+@[exp_addr, grind =] theorem expSquaringCallFactor2ProgramAddr (base : Word) :
+    (base + 32 : Word) = base + BitVec.ofNat 64 (4 * 8) := by
+  bv_decide
+
+@[exp_addr, grind =] theorem expSquaringCallSquareProgramAddr (base : Word) :
+    (base + 64 : Word) = base + BitVec.ofNat 64 (4 * 16) := by
+  bv_decide
+
+@[exp_addr, grind =] theorem expSquaringCallRestoreProgramAddr (base : Word) :
+    (base + 68 : Word) = base + BitVec.ofNat 64 (4 * 17) := by
+  bv_decide
+
 @[exp_addr, grind =] theorem expBaseAdd40Aligned
     (base : Word) (hbase : base &&& 1 = 0) :
     (base + 40 : Word) &&& 1 = 0 := by bv_decide

--- a/EvmAsm/Evm64/Exp/Compose/BaseSquaringCallCode.lean
+++ b/EvmAsm/Evm64/Exp/Compose/BaseSquaringCallCode.lean
@@ -5,6 +5,7 @@
 -/
 
 import EvmAsm.Evm64.Exp.Compose.BaseLengths
+import EvmAsm.Evm64.Exp.AddrNorm
 
 namespace EvmAsm.Evm64.Exp.Compose
 
@@ -86,7 +87,7 @@ theorem exp_squaring_call_block_code_marshal_result_to_factor2_sub {base : Word}
   exact CodeReq.ofProg_mono_sub base (base + 32)
     (EvmAsm.Evm64.exp_squaring_call_block mulOff)
     EvmAsm.Evm64.exp_loop_marshal_result_to_factor2 8
-    (by bv_omega)
+    (EvmAsm.Evm64.Exp.AddrNorm.expSquaringCallFactor2ProgramAddr base)
     (by
       unfold EvmAsm.Evm64.exp_squaring_call_block
       simp only [EvmAsm.Rv64.seq]
@@ -109,7 +110,7 @@ theorem exp_squaring_call_block_code_square_sub {base : Word}
   exact CodeReq.ofProg_mono_sub base (base + 64)
     (EvmAsm.Evm64.exp_squaring_call_block mulOff)
     (EvmAsm.Evm64.exp_square_block mulOff) 16
-    (by bv_omega)
+    (EvmAsm.Evm64.Exp.AddrNorm.expSquaringCallSquareProgramAddr base)
     (by
       unfold EvmAsm.Evm64.exp_squaring_call_block
       simp only [EvmAsm.Rv64.seq]
@@ -131,7 +132,7 @@ theorem exp_squaring_call_block_code_un_marshal_and_restore_sub {base : Word}
   exact CodeReq.ofProg_mono_sub base (base + 68)
     (EvmAsm.Evm64.exp_squaring_call_block mulOff)
     EvmAsm.Evm64.exp_loop_un_marshal_and_restore 17
-    (by bv_omega)
+    (EvmAsm.Evm64.Exp.AddrNorm.expSquaringCallRestoreProgramAddr base)
     (by
       unfold EvmAsm.Evm64.exp_squaring_call_block
       simp only [EvmAsm.Rv64.seq]


### PR DESCRIPTION
## Summary
- add central EXP address-normalization facts for nonzero squaring-call subprogram offsets
- replace inline bv_omega witnesses in the squaring-call subsumption lemmas

## Verification
- lake build EvmAsm.Evm64.Exp.AddrNorm EvmAsm.Evm64.Exp.Compose.Base
- lake build EvmAsm.Evm64.Exp
- scripts/check-unimported.sh
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/AddrNorm.lean EvmAsm/Evm64/Exp/Compose/Base.lean