### PR TITLE
refactor(exp): centralize full iteration offsets

### DIFF
--- a/EvmAsm/Evm64/Exp/AddrNorm.lean
+++ b/EvmAsm/Evm64/Exp/AddrNorm.lean
@@ -370,6 +370,14 @@ attribute [exp_addr]
     (base + 68 : Word) = base + BitVec.ofNat 64 (4 * 17) := by
   bv_decide
 
+@[exp_addr, grind =] theorem expFullIterCondMulProgramAddr (base : Word) :
+    (base + 116 : Word) = base + BitVec.ofNat 64 (4 * 29) := by
+  bv_decide
+
+@[exp_addr, grind =] theorem expFullIterLoopBackProgramAddr (base : Word) :
+    (base + 224 : Word) = base + BitVec.ofNat 64 (4 * 56) := by
+  bv_decide
+
 @[exp_addr, grind =] theorem expBaseAdd40Aligned
     (base : Word) (hbase : base &&& 1 = 0) :
     (base + 40 : Word) &&& 1 = 0 := by bv_decide

--- a/EvmAsm/Evm64/Exp/Compose/Base.lean
+++ b/EvmAsm/Evm64/Exp/Compose/Base.lean
@@ -353,7 +353,7 @@ theorem expIterBodyFullCode_squaring_sub {base : Word}
   exact CodeReq.ofProg_mono_sub base (base + 12)
     (EvmAsm.Evm64.exp_iter_body_full mulOff skipOff backOff)
     (EvmAsm.Evm64.exp_squaring_call_block mulOff) 3
-    (by bv_omega)
+    (EvmAsm.Evm64.Exp.AddrNorm.expLoopSquareProgramAddr base)
     (by
       unfold EvmAsm.Evm64.exp_iter_body_full
       simp only [EvmAsm.Rv64.seq]
@@ -376,7 +376,7 @@ theorem expIterBodyFullCode_cond_mul_sub {base : Word}
   exact CodeReq.ofProg_mono_sub base (base + 116)
     (EvmAsm.Evm64.exp_iter_body_full mulOff skipOff backOff)
     (EvmAsm.Evm64.exp_cond_mul_call_with_skip_block mulOff skipOff) 29
-    (by bv_omega)
+    (EvmAsm.Evm64.Exp.AddrNorm.expFullIterCondMulProgramAddr base)
     (by
       unfold EvmAsm.Evm64.exp_iter_body_full
       simp only [EvmAsm.Rv64.seq]
@@ -398,7 +398,7 @@ theorem expIterBodyFullCode_loop_back_sub {base : Word}
   exact CodeReq.ofProg_mono_sub base (base + 224)
     (EvmAsm.Evm64.exp_iter_body_full mulOff skipOff backOff)
     (EvmAsm.Evm64.exp_loop_back backOff) 56
-    (by bv_omega)
+    (EvmAsm.Evm64.Exp.AddrNorm.expFullIterLoopBackProgramAddr base)
     (by
       unfold EvmAsm.Evm64.exp_iter_body_full
       simp only [EvmAsm.Rv64.seq]


### PR DESCRIPTION
## Summary
- add central EXP address-normalization facts for full-iteration cond-mul and loop-back offsets
- replace inline bv_omega offset witnesses in full-iteration subsumption lemmas

## Verification
- lake build EvmAsm.Evm64.Exp.AddrNorm EvmAsm.Evm64.Exp.Compose.Base
- lake build EvmAsm.Evm64.Exp
- scripts/check-unimported.sh
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/AddrNorm.lean EvmAsm/Evm64/Exp/Compose/Base.lean