### PR TITLE
refactor(exp): reuse boundary program offset

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/BaseBoundary.lean
+++ b/EvmAsm/Evm64/Exp/Compose/BaseBoundary.lean
@@ -94,7 +94,7 @@ theorem expBoundaryProgramCode_epilogue_sub {base : Word} :
   unfold expBoundaryProgramCode
   exact CodeReq.ofProg_mono_sub base (base + 24)
     expBoundaryProgram EvmAsm.Evm64.exp_epilogue 6
-    (by bv_omega)
+    (EvmAsm.Evm64.Exp.AddrNorm.expTopPointerAdvanceProgramAddr base)
     (by unfold expBoundaryProgram; simp only [EvmAsm.Rv64.seq]; rfl)
     (by
       rw [expBoundaryProgram_len, exp_epilogue_len])


### PR DESCRIPTION
## Summary
- reuse the central EXP address-normalization fact for the boundary-program epilogue offset
- remove the remaining nonzero inline bv_omega offset witness from the boundary-program subsumption lemmas

## Verification
- lake build EvmAsm.Evm64.Exp.Compose.Base
- lake build EvmAsm.Evm64.Exp
- scripts/check-unimported.sh
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/Compose/Base.lean