### PR TITLE
refactor(exp): centralize zero program offsets

### DIFF
--- a/EvmAsm/Evm64/Exp/AddrNorm.lean
+++ b/EvmAsm/Evm64/Exp/AddrNorm.lean
@@ -378,6 +378,10 @@ attribute [exp_addr]
     (base + 224 : Word) = base + BitVec.ofNat 64 (4 * 56) := by
   bv_decide
 
+@[exp_addr] theorem expProgramStartAddr (base : Word) :
+    base = base + BitVec.ofNat 64 (4 * (0 : Nat)) := by
+  bv_decide
+
 @[exp_addr, grind =] theorem expBaseAdd40Aligned
     (base : Word) (hbase : base &&& 1 = 0) :
     (base + 40 : Word) &&& 1 = 0 := by bv_decide

--- a/EvmAsm/Evm64/Exp/Compose/Base.lean
+++ b/EvmAsm/Evm64/Exp/Compose/Base.lean
@@ -124,7 +124,7 @@ theorem expLoopCode_bit_test_sub {base : Word}
   exact CodeReq.ofProg_mono_sub base base
     (EvmAsm.Evm64.exp_loop mulOff skipOff backOff)
     EvmAsm.Evm64.exp_bit_test_block 0
-    (by bv_omega)
+    (EvmAsm.Evm64.Exp.AddrNorm.expProgramStartAddr base)
     (by
       unfold EvmAsm.Evm64.exp_loop EvmAsm.Evm64.exp_iter_body
       unfold EvmAsm.Evm64.exp_bit_test_block EvmAsm.Evm64.exp_square_block

--- a/EvmAsm/Evm64/Exp/Compose/BaseBoundary.lean
+++ b/EvmAsm/Evm64/Exp/Compose/BaseBoundary.lean
@@ -79,7 +79,7 @@ theorem expBoundaryProgramCode_prologue_sub {base : Word} :
       (expBoundaryProgramCode base) a = some i := by
   unfold expBoundaryProgramCode
   exact CodeReq.ofProg_mono_sub base base expBoundaryProgram EvmAsm.Evm64.exp_prologue 0
-    (by bv_omega)
+    (EvmAsm.Evm64.Exp.AddrNorm.expProgramStartAddr base)
     (by unfold expBoundaryProgram; simp only [EvmAsm.Rv64.seq]; rfl)
     (by
       rw [expBoundaryProgram_len, exp_prologue_len]

--- a/EvmAsm/Evm64/Exp/Compose/BaseSquaringCallCode.lean
+++ b/EvmAsm/Evm64/Exp/Compose/BaseSquaringCallCode.lean
@@ -64,7 +64,7 @@ theorem exp_squaring_call_block_code_marshal_factor1_sub {base : Word}
   exact CodeReq.ofProg_mono_sub base base
     (EvmAsm.Evm64.exp_squaring_call_block mulOff)
     EvmAsm.Evm64.exp_loop_marshal_factor1 0
-    (by bv_omega)
+    (EvmAsm.Evm64.Exp.AddrNorm.expProgramStartAddr base)
     (by
       unfold EvmAsm.Evm64.exp_squaring_call_block
       simp only [EvmAsm.Rv64.seq]

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBaseIter.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBaseIter.lean
@@ -80,7 +80,7 @@ theorem expIterBodyFullMsbSavedBitCode_bit_test_sub {base : Word}
   exact CodeReq.ofProg_mono_sub base base
     (EvmAsm.Evm64.exp_iter_body_full_msb_saved_bit mulOff skipOff backOff)
     EvmAsm.Evm64.exp_msb_bit_test_block 0
-    (by bv_omega)
+    (EvmAsm.Evm64.Exp.AddrNorm.expProgramStartAddr base)
     (by
       unfold EvmAsm.Evm64.exp_iter_body_full_msb_saved_bit
       simp only [EvmAsm.Rv64.seq]

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBaseTwoMulIter.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBaseTwoMulIter.lean
@@ -82,7 +82,7 @@ theorem expIterBodyFullMsbSavedBitTwoMulCode_bit_test_sub {base : Word}
     (EvmAsm.Evm64.exp_iter_body_full_msb_saved_bit_two_mul
       squaringMulOff condMulOff skipOff backOff)
     EvmAsm.Evm64.exp_msb_bit_test_block 0
-    (by bv_omega)
+    (EvmAsm.Evm64.Exp.AddrNorm.expProgramStartAddr base)
     (by
       unfold EvmAsm.Evm64.exp_iter_body_full_msb_saved_bit_two_mul
       simp only [EvmAsm.Rv64.seq]


### PR DESCRIPTION
## Summary
- add a central EXP address-normalization fact for zero subprogram offsets
- replace zero-offset inline bv_omega witnesses in Base and SavedBitBase subsumption lemmas

## Verification
- lake build EvmAsm.Evm64.Exp.AddrNorm EvmAsm.Evm64.Exp.Compose.Base EvmAsm.Evm64.Exp.Compose.SavedBitBase
- lake build EvmAsm.Evm64.Exp
- scripts/check-unimported.sh
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/AddrNorm.lean EvmAsm/Evm64/Exp/Compose/Base.lean EvmAsm/Evm64/Exp/Compose/SavedBitBase.lean