### PR TITLE
refactor(exp): name boundary disjointness

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/BaseBoundary.lean
+++ b/EvmAsm/Evm64/Exp/Compose/BaseBoundary.lean
@@ -23,6 +23,12 @@ abbrev expBoundaryCode (base : Word) : CodeReq :=
     CodeReq.ofProg (base + 24) EvmAsm.Evm64.exp_epilogue
   ]
 
+theorem expBoundaryCode_prologue_epilogue_disjoint_addr
+    (base : Word) {k1 k2 : Nat} (hk1 : k1 < 6) (hk2 : k2 < 9) :
+    base + BitVec.ofNat 64 (4 * k1) ≠
+      base + 24 + BitVec.ofNat 64 (4 * k2) := by
+  bv_omega
+
 theorem expBoundaryCode_prologue_sub {base : Word} :
     ∀ a i, (CodeReq.ofProg base EvmAsm.Evm64.exp_prologue) a = some i →
       (expBoundaryCode base) a = some i := by
@@ -38,7 +44,7 @@ theorem expBoundaryCode_epilogue_sub {base : Word} :
   apply CodeReq.mono_union_right
     (CodeReq.ofProg_disjoint_range (fun k1 k2 hk1 hk2 => by
       simp only [exp_prologue_len, exp_epilogue_len] at hk1 hk2
-      bv_omega))
+      exact expBoundaryCode_prologue_epilogue_disjoint_addr base hk1 hk2))
   exact CodeReq.union_mono_left
 
 theorem expBoundaryCode_block_subs {base : Word} :


### PR DESCRIPTION
## Summary
- extract EXP boundary prologue/epilogue disjointness arithmetic into a named local theorem
- reuse the named fact in both boundary CodeReq disjointness proofs

## Verification
- lake build EvmAsm.Evm64.Exp.Compose.Base
- lake build EvmAsm.Evm64.Exp
- scripts/check-unimported.sh
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/Compose/Base.lean