### PR TITLE
refactor(exp): move one-iteration disjointness facts

### DIFF
--- a/EvmAsm/Evm64/Exp/AddrNorm.lean
+++ b/EvmAsm/Evm64/Exp/AddrNorm.lean
@@ -364,6 +364,24 @@ theorem expIterBodyCode_square_cond_mul_disjoint_addr
       base + 16 + BitVec.ofNat 64 (4 * k2) := by
   bv_omega
 
+theorem expOneIterCode_bit_test_loop_back_disjoint_addr
+    (base : Word) {k1 k2 : Nat} (hk1 : k1 < 3) (hk2 : k2 < 2) :
+    base + BitVec.ofNat 64 (4 * k1) ≠
+      base + 24 + BitVec.ofNat 64 (4 * k2) := by
+  bv_omega
+
+theorem expOneIterCode_square_loop_back_disjoint_addr
+    (base : Word) {k1 k2 : Nat} (hk1 : k1 < 1) (hk2 : k2 < 2) :
+    base + 12 + BitVec.ofNat 64 (4 * k1) ≠
+      base + 24 + BitVec.ofNat 64 (4 * k2) := by
+  bv_omega
+
+theorem expOneIterCode_cond_mul_loop_back_disjoint_addr
+    (base : Word) {k1 k2 : Nat} (hk1 : k1 < 2) (hk2 : k2 < 2) :
+    base + 16 + BitVec.ofNat 64 (4 * k1) ≠
+      base + 24 + BitVec.ofNat 64 (4 * k2) := by
+  bv_omega
+
 @[exp_addr, grind =] theorem expSavedBitCondMulProgramAddr (base : Word) :
     (base + 120 : Word) = base + BitVec.ofNat 64 (4 * 30) := by
   bv_decide

--- a/EvmAsm/Evm64/Exp/Compose/Base.lean
+++ b/EvmAsm/Evm64/Exp/Compose/Base.lean
@@ -36,24 +36,6 @@ abbrev expOneIterCode (base : Word)
     CodeReq.ofProg (base + 24) (EvmAsm.Evm64.exp_loop_back backOff)
   ]
 
-theorem expOneIterCode_bit_test_loop_back_disjoint_addr
-    (base : Word) {k1 k2 : Nat} (hk1 : k1 < 3) (hk2 : k2 < 2) :
-    base + BitVec.ofNat 64 (4 * k1) ≠
-      base + 24 + BitVec.ofNat 64 (4 * k2) := by
-  bv_omega
-
-theorem expOneIterCode_square_loop_back_disjoint_addr
-    (base : Word) {k1 k2 : Nat} (hk1 : k1 < 1) (hk2 : k2 < 2) :
-    base + 12 + BitVec.ofNat 64 (4 * k1) ≠
-      base + 24 + BitVec.ofNat 64 (4 * k2) := by
-  bv_omega
-
-theorem expOneIterCode_cond_mul_loop_back_disjoint_addr
-    (base : Word) {k1 k2 : Nat} (hk1 : k1 < 2) (hk2 : k2 < 2) :
-    base + 16 + BitVec.ofNat 64 (4 * k1) ≠
-      base + 24 + BitVec.ofNat 64 (4 * k2) := by
-  bv_omega
-
 theorem expOneIterCode_bit_test_sub {base : Word}
     {mulOff : BitVec 21} {skipOff backOff : BitVec 13} :
     ∀ a i, (CodeReq.ofProg base EvmAsm.Evm64.exp_bit_test_block) a = some i →
@@ -105,15 +87,18 @@ theorem expOneIterCode_loop_back_sub {base : Word}
   apply CodeReq.mono_union_right
     (CodeReq.ofProg_disjoint_range (fun k1 k2 hk1 hk2 => by
       simp only [exp_bit_test_block_len, exp_loop_back_len] at hk1 hk2
-      exact expOneIterCode_bit_test_loop_back_disjoint_addr base hk1 hk2))
+      exact EvmAsm.Evm64.Exp.AddrNorm.expOneIterCode_bit_test_loop_back_disjoint_addr
+        base hk1 hk2))
   apply CodeReq.mono_union_right
     (CodeReq.ofProg_disjoint_range (fun k1 k2 hk1 hk2 => by
       simp only [exp_square_block_len, exp_loop_back_len] at hk1 hk2
-      exact expOneIterCode_square_loop_back_disjoint_addr base hk1 hk2))
+      exact EvmAsm.Evm64.Exp.AddrNorm.expOneIterCode_square_loop_back_disjoint_addr
+        base hk1 hk2))
   apply CodeReq.mono_union_right
     (CodeReq.ofProg_disjoint_range (fun k1 k2 hk1 hk2 => by
       simp only [exp_cond_mul_block_len, exp_loop_back_len] at hk1 hk2
-      exact expOneIterCode_cond_mul_loop_back_disjoint_addr base hk1 hk2))
+      exact EvmAsm.Evm64.Exp.AddrNorm.expOneIterCode_cond_mul_loop_back_disjoint_addr
+        base hk1 hk2))
   exact CodeReq.union_mono_left
 
 theorem expOneIterCode_block_subs {base : Word}


### PR DESCRIPTION
## Summary
- move EXP one-iteration loop-back disjointness facts into Exp.AddrNorm
- reuse the shared facts from the one-iteration CodeReq loop-back subsumption proof

## Verification
- lake build EvmAsm.Evm64.Exp.AddrNorm EvmAsm.Evm64.Exp.Compose.Base
- lake build EvmAsm.Evm64.Exp
- scripts/check-unimported.sh
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/AddrNorm.lean EvmAsm/Evm64/Exp/Compose/Base.lean