### PR TITLE
refactor(exp): move boundary disjointness fact

### DIFF
--- a/EvmAsm/Evm64/Exp/AddrNorm.lean
+++ b/EvmAsm/Evm64/Exp/AddrNorm.lean
@@ -382,6 +382,12 @@ theorem expOneIterCode_cond_mul_loop_back_disjoint_addr
       base + 24 + BitVec.ofNat 64 (4 * k2) := by
   bv_omega
 
+theorem expBoundaryCode_prologue_epilogue_disjoint_addr
+    (base : Word) {k1 k2 : Nat} (hk1 : k1 < 6) (hk2 : k2 < 9) :
+    base + BitVec.ofNat 64 (4 * k1) ≠
+      base + 24 + BitVec.ofNat 64 (4 * k2) := by
+  bv_omega
+
 @[exp_addr, grind =] theorem expSavedBitCondMulProgramAddr (base : Word) :
     (base + 120 : Word) = base + BitVec.ofNat 64 (4 * 30) := by
   bv_decide

--- a/EvmAsm/Evm64/Exp/Compose/BaseBoundary.lean
+++ b/EvmAsm/Evm64/Exp/Compose/BaseBoundary.lean
@@ -23,12 +23,6 @@ abbrev expBoundaryCode (base : Word) : CodeReq :=
     CodeReq.ofProg (base + 24) EvmAsm.Evm64.exp_epilogue
   ]
 
-theorem expBoundaryCode_prologue_epilogue_disjoint_addr
-    (base : Word) {k1 k2 : Nat} (hk1 : k1 < 6) (hk2 : k2 < 9) :
-    base + BitVec.ofNat 64 (4 * k1) ≠
-      base + 24 + BitVec.ofNat 64 (4 * k2) := by
-  bv_omega
-
 theorem expBoundaryCode_prologue_sub {base : Word} :
     ∀ a i, (CodeReq.ofProg base EvmAsm.Evm64.exp_prologue) a = some i →
       (expBoundaryCode base) a = some i := by
@@ -44,7 +38,8 @@ theorem expBoundaryCode_epilogue_sub {base : Word} :
   apply CodeReq.mono_union_right
     (CodeReq.ofProg_disjoint_range (fun k1 k2 hk1 hk2 => by
       simp only [exp_prologue_len, exp_epilogue_len] at hk1 hk2
-      exact expBoundaryCode_prologue_epilogue_disjoint_addr base hk1 hk2))
+      exact EvmAsm.Evm64.Exp.AddrNorm.expBoundaryCode_prologue_epilogue_disjoint_addr
+        base hk1 hk2))
   exact CodeReq.union_mono_left
 
 theorem expBoundaryCode_block_subs {base : Word} :


### PR DESCRIPTION
## Summary
- move the EXP boundary prologue/epilogue disjointness fact into Exp.AddrNorm
- reuse the shared fact from boundary CodeReq and boundary program composition proofs

## Verification
- lake build EvmAsm.Evm64.Exp.AddrNorm EvmAsm.Evm64.Exp.Compose.Base
- lake build EvmAsm.Evm64.Exp
- scripts/check-unimported.sh
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/AddrNorm.lean EvmAsm/Evm64/Exp/Compose/Base.lean
- rg -n "\(by bv_omega\)|bv_omega" EvmAsm/Evm64/Exp/Compose/Base.lean EvmAsm/Evm64/Exp/AddrNorm.lean