### PR TITLE
refactor(exp): move saved-bit mul disjointness fact

### DIFF
--- a/EvmAsm/Evm64/Exp/AddrNorm.lean
+++ b/EvmAsm/Evm64/Exp/AddrNorm.lean
@@ -388,6 +388,12 @@ theorem expBoundaryCode_prologue_epilogue_disjoint_addr
       base + 24 + BitVec.ofNat 64 (4 * k2) := by
   bv_omega
 
+theorem evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode_disjoint_addr
+    (base : Word) {k1 k2 : Nat} (hk1 : k1 < 76) (hk2 : k2 < 64) :
+    base + BitVec.ofNat 64 (4 * k1) ≠
+      base + 304 + BitVec.ofNat 64 (4 * k2) := by
+  bv_omega
+
 @[exp_addr, grind =] theorem expSavedBitCondMulProgramAddr (base : Word) :
     (base + 120 : Word) = base + BitVec.ofNat 64 (4 * 30) := by
   bv_decide

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitWithMul.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitWithMul.lean
@@ -126,12 +126,6 @@ theorem evmExpMsbSavedBitTwoMulCanonicalWithMulCode_mul_sub
   unfold evmExpMsbSavedBitTwoMulCanonicalWithMulCode
   exact CodeReq.mono_union_right hd (fun _ _ h => h)
 
-theorem evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode_disjoint_addr
-    (base : Word) {k1 k2 : Nat} (hk1 : k1 < 76) (hk2 : k2 < 64) :
-    base + BitVec.ofNat 64 (4 * k1) ≠
-      base + 304 + BitVec.ofNat 64 (4 * k2) := by
-  bv_omega
-
 /-- The canonical two-MUL saved-bit EXP wrapper is disjoint from a
     `mul_callable` body appended immediately after the 304-byte wrapper. -/
 theorem evmExpMsbSavedBitTwoMulCanonicalCode_disjoint_appended_mul
@@ -157,7 +151,7 @@ theorem evmExpMsbSavedBitTwoMulCanonicalCode_disjoint_appended_mul
       EvmAsm.Evm64.canonicalExpCondMulOff)
     EvmAsm.Evm64.mul_callable_length
     (fun k1 k2 hk1 hk2 =>
-      evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode_disjoint_addr
+      EvmAsm.Evm64.Exp.AddrNorm.evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode_disjoint_addr
         base hk1 hk2)
 
 theorem evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode_mul_sub


### PR DESCRIPTION
## Summary
- move the saved-bit canonical appended-MUL disjointness fact into Exp.AddrNorm
- reuse the shared fact from the appended mul CodeReq disjointness proof

## Verification
- lake build EvmAsm.Evm64.Exp.AddrNorm EvmAsm.Evm64.Exp.Compose.SavedBitWithMul
- lake build EvmAsm.Evm64.Exp
- scripts/check-unimported.sh
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/AddrNorm.lean EvmAsm/Evm64/Exp/Compose/SavedBitWithMul.lean
- rg -n "\(by bv_omega\)|bv_omega" EvmAsm/Evm64/Exp/Compose/Base.lean EvmAsm/Evm64/Exp/Compose/SavedBitBase.lean EvmAsm/Evm64/Exp/Compose/SavedBitWithMul.lean