### PR TITLE
refactor(exp): share squaring call disjointness facts

### DIFF
--- a/EvmAsm/Evm64/Exp/AddrNorm.lean
+++ b/EvmAsm/Evm64/Exp/AddrNorm.lean
@@ -394,6 +394,50 @@ theorem evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode_disjoint_addr
       base + 304 + BitVec.ofNat 64 (4 * k2) := by
   bv_omega
 
+theorem expCallBlock_factor1_factor2_disjoint_addr
+    (base : Word) {k1 k2 : Nat} (hk1 : k1 < 8) (hk2 : k2 < 8) :
+    base + BitVec.ofNat 64 (4 * k1) ≠
+      base + 32 + BitVec.ofNat 64 (4 * k2) := by
+  bv_omega
+
+theorem expCallBlock_factor1_square_disjoint_addr
+    (base : Word) {k1 k2 : Nat} (hk1 : k1 < 8) (hk2 : k2 < 1) :
+    base + BitVec.ofNat 64 (4 * k1) ≠
+      base + 64 + BitVec.ofNat 64 (4 * k2) := by
+  bv_omega
+
+theorem expCallBlock_factor2_square_disjoint_addr
+    (base : Word) {k1 k2 : Nat} (hk1 : k1 < 8) (hk2 : k2 < 1) :
+    base + 32 + BitVec.ofNat 64 (4 * k1) ≠
+      base + 64 + BitVec.ofNat 64 (4 * k2) := by
+  bv_omega
+
+theorem expCallBlock_factor1_restore_disjoint_addr
+    (base : Word) {k1 k2 : Nat} (hk1 : k1 < 8) (hk2 : k2 < 9) :
+    base + BitVec.ofNat 64 (4 * k1) ≠
+      base + 68 + BitVec.ofNat 64 (4 * k2) := by
+  bv_omega
+
+theorem expCallBlock_factor2_restore_disjoint_addr
+    (base : Word) {k1 k2 : Nat} (hk1 : k1 < 8) (hk2 : k2 < 9) :
+    base + 32 + BitVec.ofNat 64 (4 * k1) ≠
+      base + 68 + BitVec.ofNat 64 (4 * k2) := by
+  bv_omega
+
+theorem expCallBlock_square_restore_disjoint_addr
+    (base : Word) {k1 k2 : Nat} (hk1 : k1 < 1) (hk2 : k2 < 9) :
+    base + 64 + BitVec.ofNat 64 (4 * k1) ≠
+      base + 68 + BitVec.ofNat 64 (4 * k2) := by
+  bv_omega
+
+theorem expCallBlock_factor2_end_addr (base : Word) :
+    (base + 32 : Word) + BitVec.ofNat 64 (4 * 8) = base + 64 := by
+  bv_omega
+
+theorem expCallBlock_square_end_addr (base : Word) :
+    (base + 64 : Word) + BitVec.ofNat 64 (4 * 1) = base + 68 := by
+  bv_omega
+
 @[exp_addr, grind =] theorem expSavedBitCondMulProgramAddr (base : Word) :
     (base + 120 : Word) = base + BitVec.ofNat 64 (4 * 30) := by
   bv_decide

--- a/EvmAsm/Evm64/Exp/SquaringCall.lean
+++ b/EvmAsm/Evm64/Exp/SquaringCall.lean
@@ -29,6 +29,7 @@
 -/
 
 import EvmAsm.Evm64.Exp.MarshalPair
+import EvmAsm.Evm64.Exp.AddrNorm
 import EvmAsm.Evm64.Stack
 import EvmAsm.Evm64.Exp.LimbSpec
 
@@ -69,11 +70,13 @@ theorem exp_squaring_call_block_code_eq_ofProg (base : Word) (mulOff : BitVec 21
   rw [show (base + 32) +
         BitVec.ofNat 64 (4 * exp_loop_marshal_result_to_factor2.length) =
         base + 64 by
-    rw [exp_loop_marshal_result_to_factor2_length]; bv_omega]
+    rw [exp_loop_marshal_result_to_factor2_length]
+    exact EvmAsm.Evm64.Exp.AddrNorm.expCallBlock_factor2_end_addr base]
   rw [CodeReq.ofProg_append]
   rw [show (base + 64) + BitVec.ofNat 64 (4 * (exp_square_block mulOff).length) =
         base + 68 by
-    rw [exp_square_block_length]; bv_omega]
+    rw [exp_square_block_length]
+    exact EvmAsm.Evm64.Exp.AddrNorm.expCallBlock_square_end_addr base]
 
 /-- factor1 sub-block ⊆ exp_squaring_call_block_code. -/
 theorem exp_squaring_call_block_code_marshal_factor1_sub
@@ -96,7 +99,8 @@ theorem exp_squaring_call_block_code_marshal_result_to_factor2_sub
     (CodeReq.ofProg_disjoint_range (fun k1 k2 hk1 hk2 => by
       simp only [exp_loop_marshal_factor1_length,
         exp_loop_marshal_result_to_factor2_length] at hk1 hk2
-      bv_omega))
+      exact EvmAsm.Evm64.Exp.AddrNorm.expCallBlock_factor1_factor2_disjoint_addr
+        base hk1 hk2))
   exact CodeReq.union_mono_left
 
 /-- square sub-block ⊆ exp_squaring_call_block_code. -/
@@ -110,12 +114,14 @@ theorem exp_squaring_call_block_code_square_sub
     (CodeReq.ofProg_disjoint_range (fun k1 k2 hk1 hk2 => by
       simp only [exp_loop_marshal_factor1_length,
         exp_square_block_length] at hk1 hk2
-      bv_omega))
+      exact EvmAsm.Evm64.Exp.AddrNorm.expCallBlock_factor1_square_disjoint_addr
+        base hk1 hk2))
   apply CodeReq.mono_union_right
     (CodeReq.ofProg_disjoint_range (fun k1 k2 hk1 hk2 => by
       simp only [exp_loop_marshal_result_to_factor2_length,
         exp_square_block_length] at hk1 hk2
-      bv_omega))
+      exact EvmAsm.Evm64.Exp.AddrNorm.expCallBlock_factor2_square_disjoint_addr
+        base hk1 hk2))
   exact CodeReq.union_mono_left
 
 /-- un_marshal_and_restore sub-block ⊆ exp_squaring_call_block_code. -/
@@ -129,17 +135,20 @@ theorem exp_squaring_call_block_code_un_marshal_and_restore_sub
     (CodeReq.ofProg_disjoint_range (fun k1 k2 hk1 hk2 => by
       simp only [exp_loop_marshal_factor1_length,
         exp_loop_un_marshal_and_restore_length] at hk1 hk2
-      bv_omega))
+      exact EvmAsm.Evm64.Exp.AddrNorm.expCallBlock_factor1_restore_disjoint_addr
+        base hk1 hk2))
   apply CodeReq.mono_union_right
     (CodeReq.ofProg_disjoint_range (fun k1 k2 hk1 hk2 => by
       simp only [exp_loop_marshal_result_to_factor2_length,
         exp_loop_un_marshal_and_restore_length] at hk1 hk2
-      bv_omega))
+      exact EvmAsm.Evm64.Exp.AddrNorm.expCallBlock_factor2_restore_disjoint_addr
+        base hk1 hk2))
   apply CodeReq.mono_union_right
     (CodeReq.ofProg_disjoint_range (fun k1 k2 hk1 hk2 => by
       simp only [exp_square_block_length,
         exp_loop_un_marshal_and_restore_length] at hk1 hk2
-      bv_omega))
+      exact EvmAsm.Evm64.Exp.AddrNorm.expCallBlock_square_restore_disjoint_addr
+        base hk1 hk2))
   exact CodeReq.union_mono_left
 
 /-- Bundled per-sub-block subsumption witnesses for


### PR DESCRIPTION
## Summary
- add shared EXP four-block call-layout address facts to Exp.AddrNorm
- reuse those facts in SquaringCall for CodeReq disjointness and append offset normalization
- leave CondMulCall to reuse the same facts in a follow-up slice

## Verification
- lake build EvmAsm.Evm64.Exp.AddrNorm EvmAsm.Evm64.Exp.SquaringCall
- lake build EvmAsm.Evm64.Exp
- scripts/check-unimported.sh
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/AddrNorm.lean EvmAsm/Evm64/Exp/SquaringCall.lean
- rg -n "bv_omega" EvmAsm/Evm64/Exp/SquaringCall.lean EvmAsm/Evm64/Exp/AddrNorm.lean