### PR TITLE
refactor(exp): share call sequence link address

### DIFF
--- a/EvmAsm/Evm64/Exp/CondMulCallSeq.lean
+++ b/EvmAsm/Evm64/Exp/CondMulCallSeq.lean
@@ -103,7 +103,8 @@ theorem exp_loop_cond_mul_marshal_pair_then_call_spec_within
     (exp_cond_mul_call_block_code_marshal_pair_sub base mulOff) hpairFramed
   -- (2) JAL: 1 instr at base+64, exit (base+64)+signExtend21 mulOff.
   have hjalRaw := exp_square_block_spec_within mulOff vOld (base + 64)
-  have hb : (base + 64 : Word) + 4 = base + 68 := by bv_omega
+  have hb : (base + 64 : Word) + 4 = base + 68 := by
+    exact EvmAsm.Evm64.Exp.AddrNorm.expCallBlock_square_end_addr base
   rw [hb] at hjalRaw
   -- Frame the entire pair-post (every slot but `.x1`) on the left of the JAL.
   have hjalFramed :=

--- a/EvmAsm/Evm64/Exp/SquaringCallSeq.lean
+++ b/EvmAsm/Evm64/Exp/SquaringCallSeq.lean
@@ -93,7 +93,8 @@ theorem exp_loop_squaring_marshal_pair_then_square_spec_within
   --     code = exp_square_block_code (base+64) mulOff.
   have hjalRaw := exp_square_block_spec_within mulOff vOld (base + 64)
   -- Normalize the link-address: (base+64) + 4 = base + 68.
-  have hb : (base + 64 : Word) + 4 = base + 68 := by bv_omega
+  have hb : (base + 64 : Word) + 4 = base + 68 := by
+    exact EvmAsm.Evm64.Exp.AddrNorm.expCallBlock_square_end_addr base
   rw [hb] at hjalRaw
   -- Frame the entire pair-post (every slot but `.x1`) on the left of the JAL.
   -- The pair-post is exactly the assertion below, in the same right-leaning shape.


### PR DESCRIPTION
## Summary
- reuse the shared EXP call-block link-address fact in squaring and conditional-multiply call sequence proofs
- remove the remaining local bv_omega address normalization from both call-sequence files

## Verification
- lake build EvmAsm.Evm64.Exp.SquaringCallSeq EvmAsm.Evm64.Exp.CondMulCallSeq
- lake build EvmAsm.Evm64.Exp
- scripts/check-unimported.sh
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/SquaringCallSeq.lean EvmAsm/Evm64/Exp/CondMulCallSeq.lean
- rg -n "bv_omega" EvmAsm/Evm64/Exp/SquaringCallSeq.lean EvmAsm/Evm64/Exp/CondMulCallSeq.lean