### PR TITLE
refactor(exp): share pair mul address facts

### DIFF
--- a/EvmAsm/Evm64/Exp/AddrNorm.lean
+++ b/EvmAsm/Evm64/Exp/AddrNorm.lean
@@ -450,6 +450,10 @@ theorem expCallBlock_square_end_addr (base : Word) :
     (base + 268 : Word) = base + BitVec.ofNat 64 (4 * 67) := by
   bv_decide
 
+@[exp_addr, grind =] theorem expCallBlockRestoreExitPc (base : Word) :
+    ((base + 68 : Word) + 36) = base + 104 := by
+  bv_decide
+
 @[exp_addr, grind =] theorem expCondMulCallSkipCallProgramAddr (base : Word) :
     (base + 4 : Word) = base + BitVec.ofNat 64 (4 * 1) := by
   bv_decide

--- a/EvmAsm/Evm64/Exp/CondMulPairThenMulCall.lean
+++ b/EvmAsm/Evm64/Exp/CondMulPairThenMulCall.lean
@@ -279,7 +279,8 @@ theorem exp_cond_mul_call_block_spec_within
        memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
        (.x1 ↦ᵣ (base + 68)))
       (by pcFree) h2_lifted
-  have hexit : (base + 68 : Word) + 36 = base + 104 := by bv_omega
+  have hexit : (base + 68 : Word) + 36 = base + 104 :=
+    EvmAsm.Evm64.Exp.AddrNorm.expCallBlockRestoreExitPc base
   rw [hexit] at h2_framed
   -- (4) Compose with mid-point permutation.
   have hseq : cpsTripleWithin (17 + 64 + 9) base (base + 104)

--- a/EvmAsm/Evm64/Exp/SquaringPairThenMulCall.lean
+++ b/EvmAsm/Evm64/Exp/SquaringPairThenMulCall.lean
@@ -131,9 +131,12 @@ theorem exp_loop_un_marshal_and_restore_word_spec_within
         unfold signExtend12; bv_decide
       rw [h0, h8, h16, h24]
       unfold evmWordIs at hp
-      have hSrc8 : ((evmSp + 32) + 8 : Word) = evmSp + 40 := by bv_omega
-      have hSrc16 : ((evmSp + 32) + 16 : Word) = evmSp + 48 := by bv_omega
-      have hSrc24 : ((evmSp + 32) + 24 : Word) = evmSp + 56 := by bv_omega
+      have hSrc8 : ((evmSp + 32) + 8 : Word) = evmSp + 40 :=
+        EvmAsm.Evm64.Exp.AddrNorm.expAdd32Add8 evmSp
+      have hSrc16 : ((evmSp + 32) + 16 : Word) = evmSp + 48 :=
+        EvmAsm.Evm64.Exp.AddrNorm.expAdd32Add16 evmSp
+      have hSrc24 : ((evmSp + 32) + 24 : Word) = evmSp + 56 :=
+        EvmAsm.Evm64.Exp.AddrNorm.expAdd32Add24 evmSp
       rw [hSrc8, hSrc16, hSrc24] at hp
       xperm_hyp hp)
     (fun _ hp => by
@@ -161,9 +164,12 @@ theorem exp_loop_un_marshal_and_restore_word_spec_within
         unfold signExtend12; bv_decide
       have hSp24 : (sp + signExtend12 (24 : BitVec 12) : Word) = sp + 24 := by
         unfold signExtend12; bv_decide
-      have hSrc8 : ((evmSp + 32) + 8 : Word) = evmSp + 40 := by bv_omega
-      have hSrc16 : ((evmSp + 32) + 16 : Word) = evmSp + 48 := by bv_omega
-      have hSrc24 : ((evmSp + 32) + 24 : Word) = evmSp + 56 := by bv_omega
+      have hSrc8 : ((evmSp + 32) + 8 : Word) = evmSp + 40 :=
+        EvmAsm.Evm64.Exp.AddrNorm.expAdd32Add8 evmSp
+      have hSrc16 : ((evmSp + 32) + 16 : Word) = evmSp + 48 :=
+        EvmAsm.Evm64.Exp.AddrNorm.expAdd32Add16 evmSp
+      have hSrc24 : ((evmSp + 32) + 24 : Word) = evmSp + 56 :=
+        EvmAsm.Evm64.Exp.AddrNorm.expAdd32Add24 evmSp
       rw [hSp0, hSp8, hSp16, hSp24] at hp
       unfold evmWordIs
       rw [hSrc8, hSrc16, hSrc24]
@@ -412,7 +418,8 @@ theorem exp_squaring_call_block_spec_within
        (.x1 ↦ᵣ (base + 68)))
       (by pcFree) h2_lifted
   -- Exit pcs: (base+68) + 36 = base + 104.
-  have hexit : (base + 68 : Word) + 36 = base + 104 := by bv_omega
+  have hexit : (base + 68 : Word) + 36 = base + 104 :=
+    EvmAsm.Evm64.Exp.AddrNorm.expCallBlockRestoreExitPc base
   rw [hexit] at h2_framed
   -- (4) Compose with mid-point permutation: align h1's post with
   -- h2_framed's pre.


### PR DESCRIPTION
## Summary
- add the shared EXP call-block restore exit PC fact to Exp.AddrNorm
- reuse existing Exp.AddrNorm slot-offset facts in the squaring unmarshal bridge
- remove local bv_omega address witnesses from squaring and conditional-multiply pair-then-mul-call proofs

## Verification
- lake build EvmAsm.Evm64.Exp.AddrNorm EvmAsm.Evm64.Exp.SquaringPairThenMulCall EvmAsm.Evm64.Exp.CondMulPairThenMulCall
- lake build EvmAsm.Evm64.Exp
- scripts/check-unimported.sh
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/AddrNorm.lean EvmAsm/Evm64/Exp/SquaringPairThenMulCall.lean EvmAsm/Evm64/Exp/CondMulPairThenMulCall.lean
- rg -n "bv_omega" EvmAsm/Evm64/Exp/SquaringPairThenMulCall.lean EvmAsm/Evm64/Exp/CondMulPairThenMulCall.lean