### PR TITLE
refactor(exp): share marshal pair address facts

### DIFF
--- a/EvmAsm/Evm64/Exp/AddrNorm.lean
+++ b/EvmAsm/Evm64/Exp/AddrNorm.lean
@@ -434,6 +434,10 @@ theorem expCallBlock_factor2_end_addr (base : Word) :
     (base + 32 : Word) + BitVec.ofNat 64 (4 * 8) = base + 64 := by
   bv_omega
 
+@[exp_addr, grind =] theorem expMarshalPairExitPc (base : Word) :
+    ((base + 32 : Word) + 32) = base + 64 := by
+  bv_decide
+
 theorem expCallBlock_square_end_addr (base : Word) :
     (base + 64 : Word) + BitVec.ofNat 64 (4 * 1) = base + 68 := by
   bv_omega

--- a/EvmAsm/Evm64/Exp/CondMulMarshalPair.lean
+++ b/EvmAsm/Evm64/Exp/CondMulMarshalPair.lean
@@ -27,6 +27,7 @@
 -/
 
 import EvmAsm.Evm64.Exp.LimbSpec
+import EvmAsm.Evm64.Exp.AddrNorm
 
 open EvmAsm.Rv64.Tactics
 
@@ -49,7 +50,8 @@ private theorem exp_loop_cond_mul_marshal_pair_codes_disjoint (base : Word) :
   intro k1 k2 hk1 hk2
   simp only [exp_loop_marshal_factor1_length,
     exp_loop_marshal_a_to_factor2_length] at hk1 hk2
-  bv_omega
+  exact EvmAsm.Evm64.Exp.AddrNorm.expCallBlock_factor1_factor2_disjoint_addr
+    base hk1 hk2
 
 /-- factor1 sub-block ⊆ cond-mul marshal-pair code. -/
 theorem exp_loop_cond_mul_marshal_pair_code_factor1_sub
@@ -171,7 +173,8 @@ theorem exp_loop_cond_mul_marshal_pair_spec_within
   have hseq := cpsTripleWithin_seq_with_perm hd
     (fun _ hp => by xperm_hyp hp) h1Frame h2Frame
   -- Normalize the exit address (base + 32) + 32 → base + 64.
-  have hexit : (base + 32 : Word) + 32 = base + 64 := by bv_omega
+  have hexit : (base + 32 : Word) + 32 = base + 64 :=
+    EvmAsm.Evm64.Exp.AddrNorm.expMarshalPairExitPc base
   rw [hexit] at hseq
   -- Permute pre and post into the natural shape stated at the top.
   exact cpsTripleWithin_weaken

--- a/EvmAsm/Evm64/Exp/MarshalPair.lean
+++ b/EvmAsm/Evm64/Exp/MarshalPair.lean
@@ -21,6 +21,7 @@
 -/
 
 import EvmAsm.Evm64.Exp.LimbSpec
+import EvmAsm.Evm64.Exp.AddrNorm
 
 open EvmAsm.Rv64.Tactics
 
@@ -43,7 +44,8 @@ private theorem exp_loop_squaring_marshal_pair_codes_disjoint (base : Word) :
   intro k1 k2 hk1 hk2
   simp only [exp_loop_marshal_factor1_length,
     exp_loop_marshal_result_to_factor2_length] at hk1 hk2
-  bv_omega
+  exact EvmAsm.Evm64.Exp.AddrNorm.expCallBlock_factor1_factor2_disjoint_addr
+    base hk1 hk2
 
 /-- factor1 sub-block ⊆ squaring marshal-pair code. -/
 theorem exp_loop_squaring_marshal_pair_code_factor1_sub
@@ -148,7 +150,8 @@ theorem exp_loop_squaring_marshal_pair_spec_within
   have hseq := cpsTripleWithin_seq_with_perm hd
     (fun _ hp => by xperm_hyp hp) h1Frame h2Frame
   -- Normalize the exit address (base + 32) + 32 → base + 64.
-  have hexit : (base + 32 : Word) + 32 = base + 64 := by bv_omega
+  have hexit : (base + 32 : Word) + 32 = base + 64 :=
+    EvmAsm.Evm64.Exp.AddrNorm.expMarshalPairExitPc base
   rw [hexit] at hseq
   -- Permute pre and post into the natural shape.
   exact cpsTripleWithin_weaken


### PR DESCRIPTION
## Summary
- add the shared EXP marshal-pair exit PC fact to Exp.AddrNorm
- reuse shared call-layout disjointness in squaring and conditional-multiply marshal-pair CodeReq proofs
- remove local bv_omega address witnesses from both marshal-pair files

## Verification
- lake build EvmAsm.Evm64.Exp.AddrNorm EvmAsm.Evm64.Exp.MarshalPair EvmAsm.Evm64.Exp.CondMulMarshalPair
- lake build EvmAsm.Evm64.Exp
- scripts/check-unimported.sh
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/AddrNorm.lean EvmAsm/Evm64/Exp/MarshalPair.lean EvmAsm/Evm64/Exp/CondMulMarshalPair.lean
- rg -n "bv_omega" EvmAsm/Evm64/Exp/MarshalPair.lean EvmAsm/Evm64/Exp/CondMulMarshalPair.lean