### PR TITLE
refactor(exp): share limb address facts

### DIFF
--- a/EvmAsm/Evm64/Exp/AddrNorm.lean
+++ b/EvmAsm/Evm64/Exp/AddrNorm.lean
@@ -462,6 +462,13 @@ theorem expCallBlock_square_end_addr (base : Word) :
     (base + 4 : Word) = base + BitVec.ofNat 64 (4 * 1) := by
   bv_decide
 
+@[exp_addr, grind =] theorem expSingleInstrNextPc (base : Word) :
+    ((base + 4 : Word) + 4) = base + 8 := by
+  bv_decide
+
+theorem expBase_ne_add4 (base : Word) : base ≠ base + 4 := by
+  bv_omega
+
 @[exp_addr, grind =] theorem expSquaringCallFactor2ProgramAddr (base : Word) :
     (base + 32 : Word) = base + BitVec.ofNat 64 (4 * 8) := by
   bv_decide

--- a/EvmAsm/Evm64/Exp/LimbSpec.lean
+++ b/EvmAsm/Evm64/Exp/LimbSpec.lean
@@ -12,6 +12,7 @@
 
 import EvmAsm.Evm64.Stack
 import EvmAsm.Evm64.Exp.Program
+import EvmAsm.Evm64.Exp.AddrNorm
 import EvmAsm.Rv64.SyscallSpecs
 import EvmAsm.Rv64.Tactics.XSimp
 import EvmAsm.Rv64.Tactics.RunBlock
@@ -185,7 +186,8 @@ theorem exp_cond_mul_block_spec_within
   have hjal_framed := cpsTripleWithin_frameR
     ((.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜v10 ≠ (0 : Word)⌝)
     (by pcFree) hjal_raw
-  have hb4 : (base + 4 : Word) + 4 = base + 8 := by bv_omega
+  have hb4 : (base + 4 : Word) + 4 = base + 8 :=
+    EvmAsm.Evm64.Exp.AddrNorm.expSingleInstrNextPc base
   rw [hb4] at hjal_framed
   have hjal_ext : cpsTripleWithin 1 (base + 4)
       ((base + 4) + signExtend21 mulOff)
@@ -252,11 +254,12 @@ theorem exp_loop_back_spec_within (c : Word) (backOff : BitVec 13)
         (ADDI .x9 .x9 (-1) ;; single (.BNE .x9 .x0 backOff)) = _
     show CodeReq.ofProg base [.ADDI .x9 .x9 (-1), .BNE .x9 .x0 backOff] = _
     exact CodeReq.ofProg_pair]
-  have ha1 : (base + 4 : Word) + 4 = base + 8 := by bv_omega
+  have ha1 : (base + 4 : Word) + 4 = base + 8 :=
+    EvmAsm.Evm64.Exp.AddrNorm.expSingleInstrNextPc base
   have hd : CodeReq.Disjoint
       (CodeReq.singleton base (.ADDI .x9 .x9 (-1)))
       (CodeReq.singleton (base + 4) (.BNE .x9 .x0 backOff)) :=
-    CodeReq.Disjoint.singleton (by bv_omega)
+    CodeReq.Disjoint.singleton (EvmAsm.Evm64.Exp.AddrNorm.expBase_ne_add4 base)
   -- Step 1: ADDI x9 x9 -1 — frame x0 across.
   have s1_raw := addi_spec_gen_same_within .x9 c (-1) base (by nofun)
   have s1 : cpsTripleWithin 1 base (base + 4)


### PR DESCRIPTION
## Summary
- add shared EXP single-instruction next-PC and singleton-disjoint address facts to Exp.AddrNorm
- reuse those facts in conditional-multiply and loop-back limb specs
- remove local bv_omega address witnesses from LimbSpec

## Verification
- lake build EvmAsm.Evm64.Exp.AddrNorm EvmAsm.Evm64.Exp.LimbSpec
- lake build EvmAsm.Evm64.Exp
- scripts/check-unimported.sh
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/AddrNorm.lean EvmAsm/Evm64/Exp/LimbSpec.lean
- rg -n "bv_omega" EvmAsm/Evm64/Exp/LimbSpec.lean