### PR TITLE
refactor(sdiv): name base address facts

### DIFF
--- a/EvmAsm/Evm64/SDiv/AddrNorm.lean
+++ b/EvmAsm/Evm64/SDiv/AddrNorm.lean
@@ -88,4 +88,18 @@ attribute [sdiv_addr]
   unfold EvmAsm.Evm64.evm_sdivDivisorTopLimbOff
   exact stackSlot56 sp
 
+/-- The wrapper starts at the enclosing SDIV program base. -/
+@[sdiv_addr]
+theorem wrapperStart_addr (base : Word) :
+    base = base + BitVec.ofNat 64 (4 * 0) := by
+  bv_decide
+
+/-- The appended unsigned DIV callable starts after the 71-instruction wrapper,
+    at byte offset 284 from the enclosing SDIV program base. -/
+@[sdiv_addr]
+theorem divCallableStart_addr (base : Word) :
+    base + (284 : Word) =
+      base + BitVec.ofNat 64 (4 * 71) := by
+  bv_decide
+
 end EvmAsm.Evm64.SDiv.AddrNorm

--- a/EvmAsm/Evm64/SDiv/Compose/Base.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/Base.lean
@@ -30,7 +30,7 @@ theorem sdivCode_wrapper_sub {base : Word} :
       (sdivCode base) a = some i := by
   unfold sdivCode
   exact EvmAsm.Rv64.CodeReq.ofProg_mono_sub base base evm_sdiv evm_sdiv_wrapper 0
-    (by bv_omega)
+    (EvmAsm.Evm64.SDiv.AddrNorm.wrapperStart_addr base)
     (by unfold evm_sdiv; simp only [EvmAsm.Rv64.seq, EvmAsm.Rv64.Program]; rfl)
     (by
       rw [evm_sdiv_length, evm_sdiv_wrapper_length]
@@ -48,8 +48,7 @@ theorem sdivCode_div_callable_sub {base : Word} :
   unfold sdivCode
   exact EvmAsm.Rv64.CodeReq.ofProg_mono_sub base (base + 284)
     evm_sdiv evm_div_callable 71
-    (by
-      bv_omega)
+    (EvmAsm.Evm64.SDiv.AddrNorm.divCallableStart_addr base)
     (by
       unfold evm_sdiv EvmAsm.Rv64.seq
       rw [← evm_sdiv_wrapper_length]


### PR DESCRIPTION
## Summary
- add named SDIV address-normalization facts for wrapper start and appended DIV callable start
- use the named facts in top-level SDIV code subsumption proofs instead of local bv_omega goals

## Verification
- lake build EvmAsm.Evm64.SDiv.AddrNorm EvmAsm.Evm64.SDiv.Compose.Base
- lake build EvmAsm.Evm64.SDiv
- scripts/check-unimported.sh
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|bv_omega" EvmAsm/Evm64/SDiv/AddrNorm.lean EvmAsm/Evm64/SDiv/Compose/Base.lean