### PR TITLE
feat(sdiv): expose exact callable stack entry

### DIFF
--- a/EvmAsm/Evm64/SDiv/Spec.lean
+++ b/EvmAsm/Evm64/SDiv/Spec.lean
@@ -508,6 +508,94 @@ theorem evm_sdiv_zero_divisor_handler_stack_exact_post_of_eq_spec_within
       q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
       shiftMem nMem jMem retMem dMem dloMem scratchUn0 base hbase)
 
+/-- Top-level exact-callable SDIV stack bridge.
+
+    This exposes the nonzero/all-case composition surface from a caller-visible
+    two-word stack precondition while keeping the unsigned-DIV stack proof as an
+    explicit parameter. The final all-case `evm_sdiv_stack_spec_within` can
+    instantiate `hStack` with the dispatcher branch proof that matches the
+    absolute divisor. -/
+theorem evm_sdiv_exact_callable_return_stack_spec_within
+    (vRa vSavedOld sp sDividendOld sDivisorOld
+      dividendMaskOld dividendValueOld dividendCarryOld
+      v2 v5 v6 : Word)
+    (dividend divisor : EvmWord) (rest : List EvmWord)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (base : Word) (hbase : base &&& 1 = 0)
+    (hStack :
+      EvmAsm.Rv64.cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
+        (base + wrapperEndOff)
+        ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
+        (EvmAsm.Evm64.divCode_noNop (base + wrapperEndOff))
+        (EvmAsm.Evm64.divModStackDispatchPre sp
+          (sdivAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
+            (dividend.getLimbN 2) (dividend.getLimbN 3))
+          (sdivAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
+            (divisor.getLimbN 2) (divisor.getLimbN 3))
+          ((base + divCallOff) + 4) v2 v5 v6
+          (sdivAbsSum3 (divisor.getLimbN 0) (divisor.getLimbN 1)
+            (divisor.getLimbN 2) (divisor.getLimbN 3))
+          (sdivAbsMask (divisor.getLimbN 3))
+          (sdivAbsCarry3 (divisor.getLimbN 0) (divisor.getLimbN 1)
+            (divisor.getLimbN 2) (divisor.getLimbN 3))
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+        (EvmAsm.Evm64.divStackDispatchPostNoX1 sp
+          (sdivAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
+            (dividend.getLimbN 2) (dividend.getLimbN 3))
+          (sdivAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
+            (divisor.getLimbN 2) (divisor.getLimbN 3)) **
+          (.x1 ↦ᵣ ((base + divCallOff) + 4)))) :
+    EvmAsm.Rv64.cpsTripleWithin (((49 + (EvmAsm.Evm64.unifiedDivBound + 1)) + 21) + 1)
+      base (vRa &&& ~~~(1 : Word)) (sdivCode base)
+      ((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ vSavedOld) ** (.x12 ↦ᵣ sp) **
+         (.x8 ↦ᵣ sDividendOld) ** (.x9 ↦ᵣ sDivisorOld) **
+         (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ dividendMaskOld) **
+         (.x7 ↦ᵣ dividendValueOld) ** (.x11 ↦ᵣ dividendCarryOld)) **
+        evmStackIs sp (dividend :: divisor :: rest)) **
+       ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
+        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0))
+      (saveRaDivCallCallableReturnPost vRa sp base
+        (dividend.getLimbN 0) (dividend.getLimbN 1)
+        (dividend.getLimbN 2) (dividend.getLimbN 3)
+        (divisor.getLimbN 0) (divisor.getLimbN 1)
+        (divisor.getLimbN 2) (divisor.getLimbN 3) **
+       evmStackIs (sp + 64) rest) := by
+  have hExact :=
+    saveRa_signs_abs_signXor_then_divCall_exact_then_return_normalized_named_post_from_handoff_spec_in_sdivCode
+      vRa vSavedOld sp sDividendOld sDivisorOld
+      dividendMaskOld dividendValueOld dividendCarryOld
+      (dividend.getLimbN 0) (dividend.getLimbN 1)
+      (dividend.getLimbN 2) (dividend.getLimbN 3)
+      (divisor.getLimbN 0) (divisor.getLimbN 1)
+      (divisor.getLimbN 2) (divisor.getLimbN 3)
+      v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 base hbase hStack
+  have hExactFramed :=
+    EvmAsm.Rv64.cpsTripleWithin_frameR
+      (evmStackIs (sp + 64) rest) pcFree_evmStackIs hExact
+  exact EvmAsm.Rv64.cpsTripleWithin_weaken (fun h hp => by
+      let scratchFrame : EvmAsm.Rv64.Assertion :=
+        ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
+         EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+           shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+      have h_old :
+          ((saveRaSignsAbsSignXorThenDivCallPre
+              vRa vSavedOld sp sDividendOld sDivisorOld
+              dividendMaskOld dividendValueOld dividendCarryOld
+              (dividend.getLimbN 0) (dividend.getLimbN 1)
+              (dividend.getLimbN 2) (dividend.getLimbN 3)
+              (divisor.getLimbN 0) (divisor.getLimbN 1)
+              (divisor.getLimbN 2) (divisor.getLimbN 3) **
+            evmStackIs (sp + 64) rest) ** scratchFrame) h := by
+        rw [saveRaSignsAbsSignXorThenDivCallPre_stack_pair_rest]
+        dsimp [scratchFrame]
+        exact hp
+      dsimp [scratchFrame] at h_old
+      xperm_hyp h_old) (fun _ hp => hp) hExactFramed
+
 /-- Top-level exact-callable SDIV stack-tail bridge.
 
     This is the caller-visible exact path through `sdivCode`, parameterized


### PR DESCRIPTION
## Summary
- import the exact SDIV div-call return handoff into the top-level SDIV spec
- add evm_sdiv_exact_callable_return_stack_spec_within, exposing the exact callable path from a caller-visible dividend :: divisor :: rest stack precondition
- preserve the untouched tail stack as a frame while leaving the unsigned-DIV dispatcher proof explicit for the final all-case spec

## Verification
- lake build EvmAsm.Evm64.SDiv.Spec
- lake build EvmAsm.Evm64.SDiv
- scripts/check-unimported.sh
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|bv_omega" EvmAsm/Evm64/SDiv/Spec.lean