### PR TITLE
refactor(sdiv): name sign-fixed word view

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/DispatchViews.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DispatchViews.lean
@@ -6,8 +6,56 @@
 -/
 
 import EvmAsm.Evm64.SDiv.Compose.DispatchStackViews
+import EvmAsm.Evm64.SDiv.Compose.QuadMemBridges
 import EvmAsm.Evm64.SDiv.Compose.ResultSignFixZeroWordView
 
 namespace EvmAsm.Evm64.SDiv.Compose
+
+/-- General postcondition view for SDIV result-sign fixup: the four memory
+    result limbs fold into a single `evmWordIs` for the named sign-fixed word,
+    with scratch registers still exposed. -/
+theorem resultSignFixPost_evmWordIs
+    (sp sign limb0 limb1 limb2 limb3 : Word) :
+    resultSignFixPost sp sign limb0 limb1 limb2 limb3 =
+      (let mask := (0 : Word) - sign
+       let sum0 := (limb0 ^^^ mask) + sign
+       let carry0 := if BitVec.ult sum0 sign then (1 : Word) else 0
+       let sum1 := (limb1 ^^^ mask) + carry0
+       let carry1 := if BitVec.ult sum1 carry0 then (1 : Word) else 0
+       let sum2 := (limb2 ^^^ mask) + carry1
+       let carry2 := if BitVec.ult sum2 carry1 then (1 : Word) else 0
+       let sum3 := (limb3 ^^^ mask) + carry2
+       let carry3 := if BitVec.ult sum3 carry2 then (1 : Word) else 0
+       ((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sign) **
+        (.x10 ↦ᵣ mask) ** (.x7 ↦ᵣ sum3) ** (.x11 ↦ᵣ carry3) **
+        evmWordIs sp (sdivSignFixedWord sign limb0 limb1 limb2 limb3))) := by
+  rw [resultSignFixPost_unfold]
+  dsimp only [sdivSignFixedWord]
+  let mask := (0 : Word) - sign
+  let sum0 := (limb0 ^^^ mask) + sign
+  let carry0 := if BitVec.ult sum0 sign then (1 : Word) else 0
+  let sum1 := (limb1 ^^^ mask) + carry0
+  let carry1 := if BitVec.ult sum1 carry0 then (1 : Word) else 0
+  let sum2 := (limb2 ^^^ mask) + carry1
+  let carry2 := if BitVec.ult sum2 carry1 then (1 : Word) else 0
+  let sum3 := (limb3 ^^^ mask) + carry2
+  let carry3 := if BitVec.ult sum3 carry2 then (1 : Word) else 0
+  change
+    (((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sign) **
+      (.x10 ↦ᵣ mask) ** (.x7 ↦ᵣ sum3) ** (.x11 ↦ᵣ carry3) **
+      (((sp + signExtend12 (0 : BitVec 12)) ↦ₘ sum0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ sum1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ sum2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ sum3))) =
+     ((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sign) **
+      (.x10 ↦ᵣ mask) ** (.x7 ↦ᵣ sum3) ** (.x11 ↦ᵣ carry3) **
+      evmWordIs sp (EvmWord.fromLimbs fun i : Fin 4 =>
+        match i with
+        | 0 => sum0
+        | 1 => sum1
+        | 2 => sum2
+        | 3 => sum3)))
+  rw [evmWordIs_eq_quadMem_named]
+  rfl
 
 end EvmAsm.Evm64.SDiv.Compose

--- a/EvmAsm/Evm64/SDiv/Compose/DispatchViews.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DispatchViews.lean
@@ -43,10 +43,10 @@ theorem resultSignFixPost_evmWordIs
   change
     (((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sign) **
       (.x10 ↦ᵣ mask) ** (.x7 ↦ᵣ sum3) ** (.x11 ↦ᵣ carry3) **
-      (((sp + signExtend12 (0 : BitVec 12)) ↦ₘ sum0) **
-       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ sum1) **
-       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ sum2) **
-       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ sum3))) =
+      (((sp + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)) ↦ₘ sum0) **
+       ((sp + EvmAsm.Rv64.signExtend12 (8 : BitVec 12)) ↦ₘ sum1) **
+       ((sp + EvmAsm.Rv64.signExtend12 (16 : BitVec 12)) ↦ₘ sum2) **
+       ((sp + EvmAsm.Rv64.signExtend12 (24 : BitVec 12)) ↦ₘ sum3))) =
      ((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sign) **
       (.x10 ↦ᵣ mask) ** (.x7 ↦ᵣ sum3) ** (.x11 ↦ᵣ carry3) **
       evmWordIs sp (EvmWord.fromLimbs fun i : Fin 4 =>

--- a/EvmAsm/Evm64/SDiv/Compose/Words.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/Words.lean
@@ -272,4 +272,21 @@ theorem sdivAbsDivisorWord_zero :
   unfold sdivAbsDivisorWord EvmWord.fromLimbs
   bv_decide
 
+/-- Word produced by conditionally negating four quotient limbs with the SDIV
+    result sign. This names the post-result-sign-fix `fromLimbs` term so
+    stack-level views can fold the four memory atoms into one `evmWordIs`. -/
+def sdivSignFixedWord
+    (sign limb0 limb1 limb2 limb3 : Word) : EvmWord :=
+  let mask := (0 : Word) - sign
+  let sum0 := (limb0 ^^^ mask) + sign
+  let carry0 := if BitVec.ult sum0 sign then (1 : Word) else 0
+  let sum1 := (limb1 ^^^ mask) + carry0
+  let carry1 := if BitVec.ult sum1 carry0 then (1 : Word) else 0
+  let sum2 := (limb2 ^^^ mask) + carry1
+  let carry2 := if BitVec.ult sum2 carry1 then (1 : Word) else 0
+  let sum3 := (limb3 ^^^ mask) + carry2
+  EvmWord.fromLimbs fun i : Fin 4 =>
+    match i with
+    | 0 => sum0 | 1 => sum1 | 2 => sum2 | 3 => sum3
+
 end EvmAsm.Evm64.SDiv.Compose


### PR DESCRIPTION
## Summary
- add sdivSignFixedWord for the post-result-sign-fix quotient limbs
- add resultSignFixPost_evmWordIs to fold the four result memory cells into one word assertion

## Verification
- lake build EvmAsm.Evm64.SDiv.Compose.Words EvmAsm.Evm64.SDiv.Compose.DispatchViews
- lake build EvmAsm.Evm64.SDiv
- scripts/check-unimported.sh
- git diff --check
- rg -n forbidden-pattern scan on edited files