### PR TITLE
refactor(sdiv): name sign-fixed return post

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/DivCallCallableReturnPost.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallCallableReturnPost.lean
@@ -70,12 +70,44 @@ instance pcFreeInst_saveRaDivCallCallableReturnPost
         divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) :=
   ⟨saveRaDivCallCallableReturnPost_pcFree⟩
 
-/-- Exact-callable return postcondition view with the result slot folded as the
-    named sign-fixed SDIV word. -/
-theorem saveRaDivCallCallableReturnPost_evmWordIs
+/-- Callable-return postcondition after SDIV result-sign fixup, with the
+    produced result slot folded as a named sign-fixed quotient word. -/
+@[irreducible]
+def saveRaDivCallCallableReturnSignFixedWordPost
     (vRa sp base dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word) :
-    saveRaDivCallCallableReturnPost vRa sp base
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word) : EvmAsm.Rv64.Assertion :=
+  let dividendAbsWord :=
+    sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+  let divisorAbsWord :=
+    sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+  let quotientWord := EvmWord.div dividendAbsWord divisorAbsWord
+  let resultSign :=
+    (dividendTop >>> (63 : BitVec 6).toNat) ^^^
+      (divisorTop >>> (63 : BitVec 6).toNat)
+  let divisorSign := divisorTop >>> (63 : BitVec 6).toNat
+  let resultWord :=
+    sdivSignFixedWord resultSign
+      (quotientWord.getLimbN 0) (quotientWord.getLimbN 1)
+      (quotientWord.getLimbN 2) (quotientWord.getLimbN 3)
+  let mask := (0 : Word) - resultSign
+  let sum0 := (quotientWord.getLimbN 0 ^^^ mask) + resultSign
+  let carry0 := if BitVec.ult sum0 resultSign then (1 : Word) else 0
+  let sum1 := (quotientWord.getLimbN 1 ^^^ mask) + carry0
+  let carry1 := if BitVec.ult sum1 carry0 then (1 : Word) else 0
+  let sum2 := (quotientWord.getLimbN 2 ^^^ mask) + carry1
+  let carry2 := if BitVec.ult sum2 carry1 then (1 : Word) else 0
+  let sum3 := (quotientWord.getLimbN 3 ^^^ mask) + carry2
+  let carry3 := if BitVec.ult sum3 carry2 then (1 : Word) else 0
+  (.x18 ↦ᵣ vRa) **
+  (((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ (sp + 32)) ** (.x8 ↦ᵣ resultSign) **
+    (.x10 ↦ᵣ mask) ** (.x7 ↦ᵣ sum3) ** (.x11 ↦ᵣ carry3) **
+    evmWordIs (sp + 32) resultWord) **
+   saveRaDivCallBzeroSavedRaRetFrame sp base divisorSign dividendAbsWord)
+
+theorem saveRaDivCallCallableReturnSignFixedWordPost_unfold
+    {vRa sp base dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word} :
+    saveRaDivCallCallableReturnSignFixedWordPost vRa sp base
         dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
         divisorLimb0 divisorLimb1 divisorLimb2 divisorTop =
       (let dividendAbsWord :=
@@ -105,7 +137,22 @@ theorem saveRaDivCallCallableReturnPost_evmWordIs
          (.x10 ↦ᵣ mask) ** (.x7 ↦ᵣ sum3) ** (.x11 ↦ᵣ carry3) **
          evmWordIs (sp + 32) resultWord) **
         saveRaDivCallBzeroSavedRaRetFrame sp base divisorSign dividendAbsWord)) := by
-  rw [saveRaDivCallCallableReturnPost_unfold]
+  delta saveRaDivCallCallableReturnSignFixedWordPost
+  rfl
+
+/-- Exact-callable return postcondition view with the result slot folded as the
+    named sign-fixed SDIV word. -/
+theorem saveRaDivCallCallableReturnPost_evmWordIs
+    (vRa sp base dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word) :
+    saveRaDivCallCallableReturnPost vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop =
+      saveRaDivCallCallableReturnSignFixedWordPost vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop := by
+  rw [saveRaDivCallCallableReturnPost_unfold,
+    saveRaDivCallCallableReturnSignFixedWordPost_unfold]
   dsimp only
   rw [resultSignFixPost_evmWordIs]
 

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallExactReturnHandoff.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallExactReturnHandoff.lean
@@ -190,33 +190,9 @@ theorem saveRa_signs_abs_signXor_then_divCall_exact_then_return_sign_fixed_word_
        ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
         EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0))
-      (let dividendAbsWord :=
-         sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-       let divisorAbsWord :=
-         sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
-       let quotientWord := EvmWord.div dividendAbsWord divisorAbsWord
-       let resultSign :=
-         (dividendTop >>> (63 : BitVec 6).toNat) ^^^
-           (divisorTop >>> (63 : BitVec 6).toNat)
-       let divisorSign := divisorTop >>> (63 : BitVec 6).toNat
-       let resultWord :=
-         sdivSignFixedWord resultSign
-           (quotientWord.getLimbN 0) (quotientWord.getLimbN 1)
-           (quotientWord.getLimbN 2) (quotientWord.getLimbN 3)
-       let mask := (0 : Word) - resultSign
-       let sum0 := (quotientWord.getLimbN 0 ^^^ mask) + resultSign
-       let carry0 := if BitVec.ult sum0 resultSign then (1 : Word) else 0
-       let sum1 := (quotientWord.getLimbN 1 ^^^ mask) + carry0
-       let carry1 := if BitVec.ult sum1 carry0 then (1 : Word) else 0
-       let sum2 := (quotientWord.getLimbN 2 ^^^ mask) + carry1
-       let carry2 := if BitVec.ult sum2 carry1 then (1 : Word) else 0
-       let sum3 := (quotientWord.getLimbN 3 ^^^ mask) + carry2
-       let carry3 := if BitVec.ult sum3 carry2 then (1 : Word) else 0
-       (.x18 ↦ᵣ vRa) **
-       (((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ (sp + 32)) ** (.x8 ↦ᵣ resultSign) **
-         (.x10 ↦ᵣ mask) ** (.x7 ↦ᵣ sum3) ** (.x11 ↦ᵣ carry3) **
-         evmWordIs (sp + 32) resultWord) **
-        saveRaDivCallBzeroSavedRaRetFrame sp base divisorSign dividendAbsWord)) := by
+      (saveRaDivCallCallableReturnSignFixedWordPost vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) := by
   exact EvmAsm.Rv64.cpsTripleWithin_weaken (fun _ hp => hp) (fun _ hp => by
       rw [saveRaDivCallCallableReturnPost_evmWordIs] at hp
       exact hp)

--- a/EvmAsm/Evm64/SDiv/Spec.lean
+++ b/EvmAsm/Evm64/SDiv/Spec.lean
@@ -640,36 +640,11 @@ theorem evm_sdiv_exact_callable_return_sign_fixed_word_stack_spec_within
        ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
         EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0))
-      ((let dividendAbsWord :=
-          sdivAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
-            (dividend.getLimbN 2) (dividend.getLimbN 3)
-        let divisorAbsWord :=
-          sdivAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
-            (divisor.getLimbN 2) (divisor.getLimbN 3)
-        let quotientWord := EvmWord.div dividendAbsWord divisorAbsWord
-        let resultSign :=
-          (dividend.getLimbN 3 >>> (63 : BitVec 6).toNat) ^^^
-            (divisor.getLimbN 3 >>> (63 : BitVec 6).toNat)
-        let divisorSign := divisor.getLimbN 3 >>> (63 : BitVec 6).toNat
-        let resultWord :=
-          sdivSignFixedWord resultSign
-            (quotientWord.getLimbN 0) (quotientWord.getLimbN 1)
-            (quotientWord.getLimbN 2) (quotientWord.getLimbN 3)
-        let mask := (0 : Word) - resultSign
-        let sum0 := (quotientWord.getLimbN 0 ^^^ mask) + resultSign
-        let carry0 := if BitVec.ult sum0 resultSign then (1 : Word) else 0
-        let sum1 := (quotientWord.getLimbN 1 ^^^ mask) + carry0
-        let carry1 := if BitVec.ult sum1 carry0 then (1 : Word) else 0
-        let sum2 := (quotientWord.getLimbN 2 ^^^ mask) + carry1
-        let carry2 := if BitVec.ult sum2 carry1 then (1 : Word) else 0
-        let sum3 := (quotientWord.getLimbN 3 ^^^ mask) + carry2
-        let carry3 := if BitVec.ult sum3 carry2 then (1 : Word) else 0
-        (.x18 ↦ᵣ vRa) **
-        (((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ (sp + 32)) **
-          (.x8 ↦ᵣ resultSign) ** (.x10 ↦ᵣ mask) **
-          (.x7 ↦ᵣ sum3) ** (.x11 ↦ᵣ carry3) **
-          evmWordIs (sp + 32) resultWord) **
-         saveRaDivCallBzeroSavedRaRetFrame sp base divisorSign dividendAbsWord)) **
+      (saveRaDivCallCallableReturnSignFixedWordPost vRa sp base
+        (dividend.getLimbN 0) (dividend.getLimbN 1)
+        (dividend.getLimbN 2) (dividend.getLimbN 3)
+        (divisor.getLimbN 0) (divisor.getLimbN 1)
+        (divisor.getLimbN 2) (divisor.getLimbN 3) **
        evmStackIs (sp + 64) rest) := by
   exact EvmAsm.Rv64.cpsTripleWithin_weaken (fun _ hp => hp) (fun _ hp => by
       rw [saveRaDivCallCallableReturnPost_evmWordIs] at hp


### PR DESCRIPTION
## Summary
- add saveRaDivCallCallableReturnSignFixedWordPost as a bundled assertion for the exact SDIV return result view
- retarget the exact-return and stack-level adapters to the named postcondition instead of repeating the long let-chain

## Verification
- lake build EvmAsm.Evm64.SDiv.Compose.DivCallCallableReturnPost EvmAsm.Evm64.SDiv.Compose.DivCallExactReturnHandoff EvmAsm.Evm64.SDiv.Spec
- lake build EvmAsm.Evm64.SDiv
- scripts/check-unimported.sh
- git diff --check
- rg -n forbidden-pattern scan on edited files