### PR TITLE
refactor(sdiv): prove zero sign fixes quotient word

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/Words.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/Words.lean
@@ -289,4 +289,21 @@ def sdivSignFixedWord
     match i with
     | 0 => sum0 | 1 => sum1 | 2 => sum2 | 3 => sum3
 
+/-- If the SDIV result sign is zero, result-sign fixup leaves the quotient
+    word unchanged. -/
+theorem sdivSignFixedWord_zero_sign (word : EvmWord) :
+    sdivSignFixedWord 0
+      (word.getLimbN 0) (word.getLimbN 1) (word.getLimbN 2) (word.getLimbN 3) =
+      word := by
+  rw [EvmWord.eq_iff_limbs]
+  intro i
+  fin_cases i
+  · simp [sdivSignFixedWord, EvmWord.getLimb_fromLimbs, EvmWord.getLimbN]
+  · simp [sdivSignFixedWord, EvmWord.getLimb_fromLimbs, EvmWord.getLimbN]
+    bv_decide
+  · simp [sdivSignFixedWord, EvmWord.getLimb_fromLimbs, EvmWord.getLimbN]
+    bv_decide
+  · simp [sdivSignFixedWord, EvmWord.getLimb_fromLimbs, EvmWord.getLimbN]
+    bv_decide
+
 end EvmAsm.Evm64.SDiv.Compose

--- a/EvmAsm/Evm64/SDiv/Compose/Words.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/Words.lean
@@ -295,15 +295,13 @@ theorem sdivSignFixedWord_zero_sign (word : EvmWord) :
     sdivSignFixedWord 0
       (word.getLimbN 0) (word.getLimbN 1) (word.getLimbN 2) (word.getLimbN 3) =
       word := by
-  rw [EvmWord.eq_iff_limbs]
-  intro i
-  fin_cases i
-  · simp [sdivSignFixedWord, EvmWord.getLimb_fromLimbs, EvmWord.getLimbN]
-  · simp [sdivSignFixedWord, EvmWord.getLimb_fromLimbs, EvmWord.getLimbN]
-    bv_decide
-  · simp [sdivSignFixedWord, EvmWord.getLimb_fromLimbs, EvmWord.getLimbN]
-    bv_decide
-  · simp [sdivSignFixedWord, EvmWord.getLimb_fromLimbs, EvmWord.getLimbN]
-    bv_decide
+  have hzero : (0 : Word) - (0 : Word) = 0 := by decide
+  have hxor : ∀ x : Word, x ^^^ (0 : Word) = x := fun x => by bv_decide
+  have hult0 : ∀ x : Word, BitVec.ult x (0 : Word) = false := fun x => by bv_decide
+  have hbool : ¬(false = true) := by decide
+  have hadd0 : ∀ x : Word, x + 0 = x := fun x => by bv_decide
+  unfold sdivSignFixedWord
+  simp only [hzero, hxor, hult0, if_neg hbool, hadd0]
+  exact sdivWord_from_getLimbN word
 
 end EvmAsm.Evm64.SDiv.Compose


### PR DESCRIPTION
## Summary
- add sdivSignFixedWord_zero_sign, proving result-sign fixup is identity when the SDIV result sign is zero
- this gives later semantic postcondition views a direct rewrite for the same-sign quotient case

## Verification
- lake build EvmAsm.Evm64.SDiv.Compose.Words
- lake build EvmAsm.Evm64.SDiv
- scripts/check-unimported.sh
- git diff --check
- rg -n forbidden-pattern scan on edited file