### PR TITLE
refactor(sdiv): split sign-fixed word on result sign

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/Words.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/Words.lean
@@ -337,4 +337,19 @@ theorem sdivSignFixedWord_bool_sign
   · rw [h_one, sdivSignFixedWord_one_sign]
     simp
 
+/-- Specialized boolean-sign split for the SDIV result sign derived from the
+    operand top limbs. -/
+theorem sdivSignFixedWord_result_sign
+    (dividendTop divisorTop : Word) (word : EvmWord) :
+    let resultSign :=
+      (dividendTop >>> (63 : BitVec 6).toNat) ^^^
+        (divisorTop >>> (63 : BitVec 6).toNat)
+    sdivSignFixedWord resultSign
+      (word.getLimbN 0) (word.getLimbN 1) (word.getLimbN 2) (word.getLimbN 3) =
+      if resultSign = 0 then word else ~~~word + 1 := by
+  dsimp
+  exact sdivSignFixedWord_bool_sign
+    ((dividendTop >>> 63) ^^^ (divisorTop >>> 63))
+    (sdivResultSign_bool dividendTop divisorTop) word
+
 end EvmAsm.Evm64.SDiv.Compose


### PR DESCRIPTION
## Summary
- add sdivSignFixedWord_result_sign, specializing the boolean-sign rewrite to the SDIV result sign derived from operand top limbs
- later semantic views can now rewrite result-sign fixup without manually threading sdivResultSign_bool

## Verification
- lake build EvmAsm.Evm64.SDiv.Compose.Words
- lake build EvmAsm.Evm64.SDiv
- scripts/check-unimported.sh
- git diff --check
- rg -n forbidden-pattern scan on edited file