### PR TITLE
refactor(sdiv): prove result sign bit cases

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/Words.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/Words.lean
@@ -352,4 +352,30 @@ theorem sdivSignFixedWord_result_sign
     ((dividendTop >>> 63) ^^^ (divisorTop >>> 63))
     (sdivResultSign_bool dividendTop divisorTop) word
 
+/-- Equal SDIV operand sign bits make the result sign zero. -/
+theorem sdivResultSign_zero_of_eq
+    {dividendTop divisorTop : Word}
+    (h_sign :
+      dividendTop >>> (63 : BitVec 6).toNat =
+        divisorTop >>> (63 : BitVec 6).toNat) :
+    let resultSign :=
+      (dividendTop >>> (63 : BitVec 6).toNat) ^^^
+        (divisorTop >>> (63 : BitVec 6).toNat)
+    resultSign = 0 := by
+  dsimp
+  bv_decide
+
+/-- Distinct SDIV operand sign bits make the result sign one. -/
+theorem sdivResultSign_one_of_ne
+    {dividendTop divisorTop : Word}
+    (h_sign :
+      dividendTop >>> (63 : BitVec 6).toNat ≠
+        divisorTop >>> (63 : BitVec 6).toNat) :
+    let resultSign :=
+      (dividendTop >>> (63 : BitVec 6).toNat) ^^^
+        (divisorTop >>> (63 : BitVec 6).toNat)
+    resultSign = 1 := by
+  dsimp
+  bv_decide
+
 end EvmAsm.Evm64.SDiv.Compose


### PR DESCRIPTION
## Summary
- add sdivResultSign_zero_of_eq for equal operand sign bits
- add sdivResultSign_one_of_ne for distinct operand sign bits
- these helpers make the exact result-sign zero/one stack adapters easier to instantiate from operand sign relations

## Verification
- lake build EvmAsm.Evm64.SDiv.Compose.Words
- lake build EvmAsm.Evm64.SDiv
- scripts/check-unimported.sh
- git diff --check
- rg -n forbidden-pattern scan on edited file