### PR TITLE
refactor(sdiv): prove result sign bit iff

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/Words.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/Words.lean
@@ -78,6 +78,32 @@ theorem sdivResultSign_bool (dividendTop divisorTop : Word) :
   dsimp
   bv_decide
 
+
+/-- The SDIV result sign is zero exactly when the operand sign bits match. -/
+theorem sdivResultSign_eq_zero_iff
+    (dividendTop divisorTop : Word) :
+    let resultSign :=
+      (dividendTop >>> (63 : BitVec 6).toNat) ^^^
+        (divisorTop >>> (63 : BitVec 6).toNat)
+    resultSign = 0 ↔
+      dividendTop >>> (63 : BitVec 6).toNat =
+        divisorTop >>> (63 : BitVec 6).toNat := by
+  dsimp
+  bv_decide
+
+/-- The SDIV result sign is one exactly when the operand sign bits differ. -/
+theorem sdivResultSign_eq_one_iff
+    (dividendTop divisorTop : Word) :
+    let resultSign :=
+      (dividendTop >>> (63 : BitVec 6).toNat) ^^^
+        (divisorTop >>> (63 : BitVec 6).toNat)
+    resultSign = 1 ↔
+      dividendTop >>> (63 : BitVec 6).toNat ≠
+        divisorTop >>> (63 : BitVec 6).toNat := by
+  dsimp
+  bv_decide
+
+
 /-- Conditional negation by the SDIV result sign leaves the zero quotient
     limbs equal to zero. The carries may be used internally by the sign-fix
     block, but the four memory-result limbs remain zero. -/


### PR DESCRIPTION
## Summary
- add sdivResultSign_eq_zero_iff, relating resultSign = 0 to equal operand sign bits
- add sdivResultSign_eq_one_iff, relating resultSign = 1 to distinct operand sign bits
- these helpers let later stack views rewrite result-sign branches into direct sign-bit branches

## Verification
- lake build EvmAsm.Evm64.SDiv.Compose.Words
- lake build EvmAsm.Evm64.SDiv
- scripts/check-unimported.sh
- git diff --check
- rg -n forbidden-pattern scan on edited file