### PR TITLE
refactor(sdiv): prove abs divisor zero iff

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/Words.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/Words.lean
@@ -298,6 +298,18 @@ theorem sdivAbsDivisorWord_zero :
   unfold sdivAbsDivisorWord EvmWord.fromLimbs
   bv_decide
 
+/-- The SDIV divisor absolute-value word is zero exactly for the zero
+    divisor. This lets stack-level branch proofs switch between the
+    caller-visible divisor and the unsigned-DIV dispatch divisor. -/
+theorem sdivAbsDivisorWord_eq_zero_iff
+    (divisor : EvmWord) :
+    sdivAbsDivisorWord
+        (divisor.getLimbN 0) (divisor.getLimbN 1)
+        (divisor.getLimbN 2) (divisor.getLimbN 3) = 0 ↔
+      divisor = 0 := by
+  unfold sdivAbsDivisorWord EvmWord.fromLimbs EvmWord.getLimbN EvmWord.getLimb
+  bv_decide
+
 /-- Word produced by conditionally negating four quotient limbs with the SDIV
     result sign. This names the post-result-sign-fix `fromLimbs` term so
     stack-level views can fold the four memory atoms into one `evmWordIs`. -/


### PR DESCRIPTION
## Summary
- add sdivAbsDivisorWord_eq_zero_iff
- relate the caller-visible divisor zero case to the unsigned-DIV dispatch divisor
- provide the branch-selection bridge needed by the final SDIV stack spec

## Verification
- lake build EvmAsm.Evm64.SDiv.Compose.Words
- lake build EvmAsm.Evm64.SDiv
- scripts/check-unimported.sh
- git diff --check
- rg -n forbidden-pattern scan on edited file