### PR TITLE
refactor(sdiv): bridge abs components to evmWordIs

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/DivCallAbsComponents.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallAbsComponents.lean
@@ -86,6 +86,7 @@ theorem sdivAbsDividendWord_evmWordIs_sp_components
     EvmWord.getLimbN_fromLimbs_2
     EvmWord.getLimbN_fromLimbs_3
 
+open EvmAsm.Rv64 in
 theorem sdivAbsDividendWord_evmWordIs_sp_components_right
     (sp limb0 limb1 limb2 top : Word) (Q : Assertion) :
     ((sp ↦ₘ sdivAbsSum0 limb0 top) **
@@ -110,6 +111,7 @@ theorem sdivAbsDivisorWord_evmWordIs_sp32_components
     EvmWord.getLimbN_fromLimbs_2
     EvmWord.getLimbN_fromLimbs_3
 
+open EvmAsm.Rv64 in
 theorem sdivAbsDivisorWord_evmWordIs_sp32_components_right
     (sp limb0 limb1 limb2 top : Word) (Q : Assertion) :
     (((sp + 32) ↦ₘ sdivAbsSum0 limb0 top) **

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallAbsComponents.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallAbsComponents.lean
@@ -72,6 +72,54 @@ theorem sdivAbsDivisorWord_eq_components
         | 3 => sdivAbsSum3 limb0 limb1 limb2 top := by
   rfl
 
+theorem sdivAbsDividendWord_evmWordIs_sp_components
+    (sp limb0 limb1 limb2 top : Word) :
+    evmWordIs sp (sdivAbsDividendWord limb0 limb1 limb2 top) =
+      ((sp ↦ₘ sdivAbsSum0 limb0 top) **
+       ((sp + 8) ↦ₘ sdivAbsSum1 limb0 limb1 top) **
+       ((sp + 16) ↦ₘ sdivAbsSum2 limb0 limb1 limb2 top) **
+       ((sp + 24) ↦ₘ sdivAbsSum3 limb0 limb1 limb2 top)) := by
+  rw [sdivAbsDividendWord_eq_components]
+  exact evmWordIs_sp_limbs_eq sp _ _ _ _ _
+    EvmWord.getLimbN_fromLimbs_0
+    EvmWord.getLimbN_fromLimbs_1
+    EvmWord.getLimbN_fromLimbs_2
+    EvmWord.getLimbN_fromLimbs_3
+
+theorem sdivAbsDividendWord_evmWordIs_sp_components_right
+    (sp limb0 limb1 limb2 top : Word) (Q : Assertion) :
+    ((sp ↦ₘ sdivAbsSum0 limb0 top) **
+     ((sp + 8) ↦ₘ sdivAbsSum1 limb0 limb1 top) **
+     ((sp + 16) ↦ₘ sdivAbsSum2 limb0 limb1 limb2 top) **
+     ((sp + 24) ↦ₘ sdivAbsSum3 limb0 limb1 limb2 top) ** Q) =
+      (evmWordIs sp (sdivAbsDividendWord limb0 limb1 limb2 top) ** Q) := by
+  rw [sdivAbsDividendWord_evmWordIs_sp_components]
+  rw [sepConj_assoc', sepConj_assoc', sepConj_assoc']
+
+theorem sdivAbsDivisorWord_evmWordIs_sp32_components
+    (sp limb0 limb1 limb2 top : Word) :
+    evmWordIs (sp + 32) (sdivAbsDivisorWord limb0 limb1 limb2 top) =
+      (((sp + 32) ↦ₘ sdivAbsSum0 limb0 top) **
+       ((sp + 40) ↦ₘ sdivAbsSum1 limb0 limb1 top) **
+       ((sp + 48) ↦ₘ sdivAbsSum2 limb0 limb1 limb2 top) **
+       ((sp + 56) ↦ₘ sdivAbsSum3 limb0 limb1 limb2 top)) := by
+  rw [sdivAbsDivisorWord_eq_components]
+  exact evmWordIs_sp32_limbs_eq sp _ _ _ _ _
+    EvmWord.getLimbN_fromLimbs_0
+    EvmWord.getLimbN_fromLimbs_1
+    EvmWord.getLimbN_fromLimbs_2
+    EvmWord.getLimbN_fromLimbs_3
+
+theorem sdivAbsDivisorWord_evmWordIs_sp32_components_right
+    (sp limb0 limb1 limb2 top : Word) (Q : Assertion) :
+    (((sp + 32) ↦ₘ sdivAbsSum0 limb0 top) **
+     ((sp + 40) ↦ₘ sdivAbsSum1 limb0 limb1 top) **
+     ((sp + 48) ↦ₘ sdivAbsSum2 limb0 limb1 limb2 top) **
+     ((sp + 56) ↦ₘ sdivAbsSum3 limb0 limb1 limb2 top) ** Q) =
+      (evmWordIs (sp + 32) (sdivAbsDivisorWord limb0 limb1 limb2 top) ** Q) := by
+  rw [sdivAbsDivisorWord_evmWordIs_sp32_components]
+  rw [sepConj_assoc', sepConj_assoc', sepConj_assoc']
+
 abbrev saveRaDivCallSignFrame
     (vRa resultSign divisorSign : Word) : EvmAsm.Rv64.Assertion :=
   ((.x8 ↦ᵣ resultSign) ** (.x9 ↦ᵣ divisorSign) **


### PR DESCRIPTION
## Summary
- add dividend absolute-value component-to-evmWordIs bridge at sp
- add divisor absolute-value component-to-evmWordIs bridge at sp+32
- add right-threaded variants for folding inside larger sepConj posts

## Verification
- lake build EvmAsm.Evm64.SDiv.Compose.DivCallAbsComponents
- lake build EvmAsm.Evm64.SDiv
- scripts/check-unimported.sh
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|bv_omega" EvmAsm/Evm64/SDiv/Compose/DivCallAbsComponents.lean