### PR TITLE
refactor(divmod): expose n4 shift0 dispatch exact x1

### DIFF
--- a/EvmAsm/Evm64/DivMod/Shift0Dispatcher.lean
+++ b/EvmAsm/Evm64/DivMod/Shift0Dispatcher.lean
@@ -77,6 +77,43 @@ theorem evm_div_n4_shift0_stack_spec (sp base : Word)
       nMem shiftMem jMem retMem dMem dloMem scratch_un0
       hbnz hb3nz hshift_z halign h_carry2_nz h_addback
 
+/-- Exact-`x1` variant of `evm_div_n4_shift0_stack_spec`. Both shift=0
+    branches leave the same concrete return marker in `x1`, so callers can
+    retain it instead of receiving only `regOwn .x1`. -/
+theorem evm_div_n4_shift0_stack_spec_exact_x1 (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratch_un0 : Word)
+    (hbnz : b ≠ 0)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_z : (clzResult (b.getLimbN 3)).1 = 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 9 + 4 + 202 + 12)
+      base (base + nopOff) (divCode base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratch_un0)
+      (divN4CallSkipStackPostNoX1 sp a b **
+        (.x1 ↦ᵣ signExtend12 (4095 : BitVec 12))) := by
+  by_cases h_skip : isSkipBorrowN4Shift0Evm a b
+  · exact cpsTripleWithin_mono_nSteps (by decide) <|
+      evm_div_n4_shift0_call_skip_stack_spec_exact_x1 sp base a b
+      v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      nMem shiftMem jMem retMem dMem dloMem scratch_un0
+      hbnz hb3nz hshift_z halign h_skip
+  · have h_addback : isAddbackBorrowN4Shift0Evm a b := by
+      rw [isAddbackBorrowN4Shift0Evm_def]
+      rw [isSkipBorrowN4Shift0Evm_def] at h_skip
+      unfold isSkipBorrowN4Shift0 at h_skip
+      unfold isAddbackBorrowN4Shift0
+      simp only [] at h_skip ⊢
+      exact h_skip
+    have h_carry2_nz := n4_shift0_addback_carry2_nz_of_borrow a b hbnz hshift_z h_addback
+    exact evm_div_n4_shift0_call_addback_beq_stack_spec_exact_x1 sp base a b
+      v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      nMem shiftMem jMem retMem dMem dloMem scratch_un0
+      hbnz hb3nz hshift_z halign h_carry2_nz h_addback
+
 /-- No-NOP variant of `evm_div_n4_shift0_stack_spec`. -/
 theorem evm_div_n4_shift0_stack_spec_noNop (sp base : Word)
     (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)


### PR DESCRIPTION
Summary:
- add an exact-x1 variant of the N4 DIV shift0 dispatcher
- route the skip and addback-BEQ branches through their exact-x1 stack specs
- keep the existing branch split and derived addback carry proof unchanged

Verification:
- lake build EvmAsm.Evm64.DivMod.Shift0Dispatcher
- lake build EvmAsm.Evm64.SDiv
- scripts/check-unimported.sh
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|bv_omega" EvmAsm/Evm64/DivMod/Shift0Dispatcher.lean