### PR TITLE
refactor(divmod): expose n4 call dispatch exact x1

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/CallAddbackMod.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/CallAddbackMod.lean
@@ -420,6 +420,39 @@ theorem evm_div_n4_call_stack_spec (sp base : Word)
       hbnz hb3nz hshift_nz halign hbltu
       (hcarry2_nz_addback haddback) haddback (hsem_addback haddback)
 
+/-- Exact-`x1` variant of `evm_div_n4_call_stack_spec`. Both nonzero-shift
+    call-trial branches leave the same concrete return marker in `x1`. -/
+theorem evm_div_n4_call_stack_spec_exact_x1 (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratch_un0 : Word)
+    (hbnz : b ≠ 0)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : isCallTrialN4Evm a b)
+    (hcarry2_nz_addback :
+      isAddbackBorrowN4CallEvm a b → isAddbackCarry2NzN4CallEvm a b)
+    (hsem_addback :
+      isAddbackBorrowN4CallEvm a b → n4CallAddbackBeqSemanticHolds a b) :
+    cpsTripleWithin 340 base (base + nopOff) (divCode base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratch_un0)
+      (divN4CallSkipStackPostNoX1 sp a b **
+        (.x1 ↦ᵣ signExtend12 (4095 : BitVec 12))) := by
+  rcases isSkipBorrowN4CallEvm_or_isAddbackBorrowN4CallEvm a b with hskip | haddback
+  · exact cpsTripleWithin_mono_nSteps (by decide) <|
+      evm_div_n4_call_skip_stack_spec_unconditional_exact_x1 sp base a b
+      v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      nMem shiftMem jMem retMem dMem dloMem scratch_un0
+      hbnz hb3nz hshift_nz halign hbltu hskip
+  · exact evm_div_n4_call_addback_beq_stack_spec_exact_x1 sp base a b
+      v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      nMem shiftMem jMem retMem dMem dloMem scratch_un0
+      hbnz hb3nz hshift_nz halign hbltu
+      (hcarry2_nz_addback haddback) haddback (hsem_addback haddback)
+
 /-- **n=4 shift_nz MOD top-level dispatcher** — mirror of
     `evm_div_n4_call_stack_spec` for MOD. Routes between
     call+skip (auto-discharged) and call+addback BEQ paths.


### PR DESCRIPTION
Summary:
- add an exact-x1 variant of the N4 DIV nonzero-shift call dispatcher
- route skip and addback-BEQ branches through their exact-x1 stack specs
- keep the existing borrow split and addback side-condition plumbing unchanged

Verification:
- lake build EvmAsm.Evm64.DivMod.Spec.CallAddbackMod
- lake build EvmAsm.Evm64.SDiv
- scripts/check-unimported.sh
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|bv_omega" EvmAsm/Evm64/DivMod/Spec/CallAddbackMod.lean