### PR TITLE
refactor(divmod): add exact x1 div stack spec

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/Unified.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/Unified.lean
@@ -978,6 +978,10 @@ def x2 {base : Word} {a b : EvmWord} : DivStackSpecCase base a b → Word
   | .n3Full .. => (clzResult (b.getLimbN 2)).2 >>> (63 : Nat)
   | .n4Full .. => (clzResult (b.getLimbN 3)).2 >>> (63 : Nat)
 
+def returnX1 {base : Word} {a b : EvmWord} : DivStackSpecCase base a b → Word
+  | .bzero v1 _ _ => v1
+  | _ => signExtend12 (4095 : BitVec 12)
+
 end DivStackSpecCase
 
 /-- Single named DIV stack spec over the dispatcher branch certificate. -/
@@ -1033,6 +1037,66 @@ theorem evm_div_stack_spec (sp base : Word) (a b : EvmWord)
         hbltu_1 hbltu_0 hcarry2 hdivWord
   | n4Full hbnz hb3nz halign hbltu hcarry2_nz_addback hsem_addback =>
       exact evm_div_n4_stack_spec_within_dispatch_uni sp base a b
+        v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        nMem shiftMem jMem retMem dMem dloMem scratch_un0
+        hbnz hb3nz halign hbltu hcarry2_nz_addback hsem_addback
+
+/-- Single named DIV stack spec that preserves the caller-owned `x1` atom
+    through the dispatcher surface. -/
+theorem evm_div_stack_spec_exact_x1 (sp base : Word) (a b : EvmWord)
+    (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratch_un0 : Word)
+    (branch : DivStackSpecCase base a b) :
+    cpsTripleWithin unifiedDivBound base (base + nopOff) (divCode base)
+      (divModStackDispatchPre sp a b
+        branch.x1 branch.x2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0)
+      (divStackDispatchPostNoX1 sp a b ** (.x1 ↦ᵣ branch.returnX1)) := by
+  cases branch with
+  | bzero v1 v2 hbz =>
+      have hStack :=
+        evm_div_bzero_stack_spec_within_dispatch_noNop_preserving_x1_uni
+        sp base a b v1 v2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        nMem shiftMem jMem retMem dMem dloMem scratch_un0 hbz
+      exact cpsTripleWithin_extend_code (hmono := divCode_noNop_sub_divCode) hStack
+  | n1Full bltu_3 bltu_2 bltu_1 bltu_0 hbnz hb3z hb2z hb1z hshift_nz halign
+      hbltu_3 hbltu_2 hbltu_1 hbltu_0 hcarry2 hdivWord =>
+      exact evm_div_n1_stack_spec_within_word_exact_x1_uni
+        bltu_3 bltu_2 bltu_1 bltu_0 sp base a b
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+        v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        nMem shiftMem jMem retMem dMem dloMem scratch_un0
+        rfl rfl rfl rfl rfl rfl rfl rfl
+        hbnz hb3z hb2z hb1z hshift_nz halign
+        hbltu_3 hbltu_2 hbltu_1 hbltu_0 hcarry2 hdivWord
+  | n2Full bltu_2 bltu_1 bltu_0 hbnz hb3z hb2z hb1nz hshift_nz halign
+      hbltu_2 hbltu_1 hbltu_0 hcarry2 hdivWord =>
+      exact evm_div_n2_stack_spec_within_word_exact_x1_uni
+        bltu_2 bltu_1 bltu_0 sp base a b
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+        v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        nMem shiftMem jMem retMem dMem dloMem scratch_un0
+        rfl rfl rfl rfl rfl rfl rfl rfl
+        hbnz hb3z hb2z hb1nz hshift_nz halign
+        hbltu_2 hbltu_1 hbltu_0 hcarry2 hdivWord
+  | n3Full bltu_1 bltu_0 hbnz hb3z hb2nz hshift_nz halign
+      hbltu_1 hbltu_0 hcarry2 hdivWord =>
+      exact evm_div_n3_stack_spec_within_word_exact_x1_uni
+        bltu_1 bltu_0 sp base a b
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+        v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        nMem shiftMem jMem retMem dMem dloMem scratch_un0
+        rfl rfl rfl rfl rfl rfl rfl rfl
+        hbnz hb3z hb2nz hshift_nz halign
+        hbltu_1 hbltu_0 hcarry2 hdivWord
+  | n4Full hbnz hb3nz halign hbltu hcarry2_nz_addback hsem_addback =>
+      exact evm_div_n4_stack_spec_within_dispatch_exact_x1_uni sp base a b
         v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
         nMem shiftMem jMem retMem dMem dloMem scratch_un0
         hbnz hb3nz halign hbltu hcarry2_nz_addback hsem_addback


### PR DESCRIPTION
Summary:
- add DivStackSpecCase.returnX1 to describe the caller-owned x1 value at the exact-x1 dispatcher surface
- add evm_div_stack_spec_exact_x1, a single branch-certificate DIV dispatcher theorem returning divStackDispatchPostNoX1 plus the preserved x1 atom
- lift the bzero no-NOP preserving-x1 path into divCode and reuse the exact-x1 N1-N4 wrappers

Verification:
- lake build EvmAsm.Evm64.DivMod.Spec.Unified
- lake build EvmAsm.Evm64.SDiv
- scripts/check-unimported.sh
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|bv_omega" EvmAsm/Evm64/DivMod/Spec/Unified.lean