### PR TITLE
refactor(sdiv): add branch return x1 div callable wrapper

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/DivCallExactCallable.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallExactCallable.lean
@@ -73,7 +73,7 @@ theorem evm_div_callable_preserving_branch_return_x1_spec_in_sdivCode
      nMem shiftMem jMem retMem dMem dloMem scratchUn0 : Word)
     (branch : EvmAsm.Evm64.DivStackSpecCase (base + wrapperEndOff) a b)
     (hStack :
-      cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
+      EvmAsm.Rv64.cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
         (base + wrapperEndOff)
         ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
         (EvmAsm.Evm64.divCode_noNop (base + wrapperEndOff))
@@ -83,7 +83,7 @@ theorem evm_div_callable_preserving_branch_return_x1_spec_in_sdivCode
           shiftMem nMem jMem retMem dMem dloMem scratchUn0)
         (EvmAsm.Evm64.divStackDispatchPostNoX1 sp a b **
           (.x1 ↦ᵣ branch.returnX1))) :
-    cpsTripleWithin (EvmAsm.Evm64.unifiedDivBound + 1)
+    EvmAsm.Rv64.cpsTripleWithin (EvmAsm.Evm64.unifiedDivBound + 1)
       (base + wrapperEndOff) (branch.returnX1 &&& ~~~1) (sdivCode base)
       (EvmAsm.Evm64.divModStackDispatchPre sp a b
         branch.returnX1 branch.x2 v5 v6 v7 v10 v11

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallExactCallable.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallExactCallable.lean
@@ -61,6 +61,41 @@ theorem evm_div_callable_preserving_x1_exact_pre_spec_in_sdivCode
       hRet
   exact EvmAsm.Rv64.cpsTripleWithin_seq_same_cr hStackCall hRetFramed
 
+/-- Branch-certificate specialization of
+    `evm_div_callable_preserving_x1_exact_pre_spec_in_sdivCode`.
+
+    The dispatcher precondition uses the exact return value described by
+    `DivStackSpecCase.returnX1`, while the CLZ/shift register comes from the
+    branch certificate's `x2` selector. -/
+theorem evm_div_callable_preserving_branch_return_x1_spec_in_sdivCode
+    (sp base : Word) (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (branch : EvmAsm.Evm64.DivStackSpecCase (base + wrapperEndOff) a b)
+    (hStack :
+      cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
+        (base + wrapperEndOff)
+        ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
+        (EvmAsm.Evm64.divCode_noNop (base + wrapperEndOff))
+        (EvmAsm.Evm64.divModStackDispatchPre sp a b
+          branch.returnX1 branch.x2 v5 v6 v7 v10 v11
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+        (EvmAsm.Evm64.divStackDispatchPostNoX1 sp a b **
+          (.x1 ↦ᵣ branch.returnX1))) :
+    cpsTripleWithin (EvmAsm.Evm64.unifiedDivBound + 1)
+      (base + wrapperEndOff) (branch.returnX1 &&& ~~~1) (sdivCode base)
+      (EvmAsm.Evm64.divModStackDispatchPre sp a b
+        branch.returnX1 branch.x2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+      (EvmAsm.Evm64.divStackDispatchPostNoX1 sp a b **
+        (.x1 ↦ᵣ branch.returnX1)) := by
+  exact evm_div_callable_preserving_x1_exact_pre_spec_in_sdivCode
+    sp base branch.returnX1 a b branch.x2 v5 v6 v7 v10 v11
+    q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 hStack
+
 /-- Frame the exact-pre preserving-`x1` unsigned-DIV callable wrapper by an
     arbitrary PC-free assertion. This is the shape needed once SDIV has a
     no-NOP proof for the exact dispatch-ready post, including the private sign


### PR DESCRIPTION
Summary:
- add an SDiv exact-pre callable wrapper specialized to DivStackSpecCase.returnX1
- use branch.x2 for the dispatcher shift/CLZ register and preserve branch.returnX1 through the callable return
- provide a smaller handoff surface for future exact dispatch-ready no-NOP proofs

Verification:
- lake build EvmAsm.Evm64.SDiv.Compose.DivCallExactCallable
- lake build EvmAsm.Evm64.SDiv
- scripts/check-unimported.sh
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|bv_omega" EvmAsm/Evm64/SDiv/Compose/DivCallExactCallable.lean