### PR TITLE
refactor(divmod): add branch return x1 callable helper

### DIFF
--- a/EvmAsm/Evm64/DivMod/Callable.lean
+++ b/EvmAsm/Evm64/DivMod/Callable.lean
@@ -669,6 +669,40 @@ theorem evm_div_callable_spec_from_noNop_preserving_x1 (sp base raVal : Word)
     cpsTripleWithin_frameL (divStackDispatchPostNoX1 sp a b) hpcFreePost hRet
   exact cpsTripleWithin_seq_same_cr hStackCall hRetFramed
 
+/-- Callable wrapper whose no-NOP body proof uses the exact return address
+    selected by the branch certificate in the dispatch precondition. -/
+theorem evm_div_callable_spec_from_noNop_branch_return_x1 (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (branch : DivStackSpecCase base a b)
+    (hStack :
+      cpsTripleWithin unifiedDivBound base (base + nopOff) (divCode_noNop base)
+        (divModStackDispatchPre sp a b
+          branch.returnX1 branch.x2 v5 v6 v7 v10 v11
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+        (divStackDispatchPostNoX1 sp a b ** (.x1 ↦ᵣ branch.returnX1))) :
+    cpsTripleWithin (unifiedDivBound + 1) base (branch.returnX1 &&& ~~~1)
+      (evm_div_callable_code base)
+      (divModStackDispatchPre sp a b
+        branch.returnX1 branch.x2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+      (divStackDispatchPostNoX1 sp a b ** (.x1 ↦ᵣ branch.returnX1)) := by
+  have hpcFreePost : (divStackDispatchPostNoX1 sp a b).pcFree := by
+    rw [divStackDispatchPostNoX1_unfold]
+    rw [divScratchOwnCall_unfold, divScratchOwn_unfold]
+    pcFree
+  have hStackCall :=
+    cpsTripleWithin_extend_code (hmono := divCode_noNop_sub_div_callable_code) hStack
+  have hRet :=
+    cpsTripleWithin_extend_code (hmono := evm_div_callable_code_ret_sub (base := base))
+      (ret_spec_within' (base + nopOff) branch.returnX1)
+  have hRetFramed :=
+    cpsTripleWithin_frameL (divStackDispatchPostNoX1 sp a b) hpcFreePost hRet
+  exact cpsTripleWithin_seq_same_cr hStackCall hRetFramed
+
 /-- Zero-divisor DIV callable wrapper that preserves the exact incoming `x1`
     return address. This is the callable-ready specialization needed by SDIV
     when the absolute divisor is zero. -/


### PR DESCRIPTION
Summary:
- add evm_div_callable_spec_from_noNop_branch_return_x1
- support no-NOP DIV body proofs whose dispatch precondition uses DivStackSpecCase.returnX1 and branch.x2
- keep the callable return post as divStackDispatchPostNoX1 plus the preserved branch return x1 atom

Verification:
- lake build EvmAsm.Evm64.DivMod.Callable
- lake build EvmAsm.Evm64.SDiv
- scripts/check-unimported.sh
- git diff --check
- git diff -U0 -- EvmAsm/Evm64/DivMod/Callable.lean | rg -n '^\+.*(sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|bv_omega)'

Note: the whole Callable.lean file has pre-existing bv_omega uses outside this diff, so the forbidden-token check was run on added lines.