### PR TITLE
refactor(sdiv): use branch return x1 callable helper

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/DivCallExactCallable.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallExactCallable.lean
@@ -91,10 +91,12 @@ theorem evm_div_callable_preserving_branch_return_x1_spec_in_sdivCode
         shiftMem nMem jMem retMem dMem dloMem scratchUn0)
       (EvmAsm.Evm64.divStackDispatchPostNoX1 sp a b **
         (.x1 ↦ᵣ branch.returnX1)) := by
-  exact evm_div_callable_preserving_x1_exact_pre_spec_in_sdivCode
-    sp base branch.returnX1 a b branch.x2 v5 v6 v7 v10 v11
-    q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-    nMem shiftMem jMem retMem dMem dloMem scratchUn0 hStack
+  exact cpsTripleWithin_extend_code
+    (hmono := evm_div_callable_code_sub_sdivCode (base := base))
+    (EvmAsm.Evm64.evm_div_callable_spec_from_noNop_branch_return_x1
+      sp (base + wrapperEndOff) a b v5 v6 v7 v10 v11
+      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      nMem shiftMem jMem retMem dMem dloMem scratchUn0 branch hStack)
 
 /-- Framed variant of
     `evm_div_callable_preserving_branch_return_x1_spec_in_sdivCode`. -/

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallExactCallable.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallExactCallable.lean
@@ -91,7 +91,7 @@ theorem evm_div_callable_preserving_branch_return_x1_spec_in_sdivCode
         shiftMem nMem jMem retMem dMem dloMem scratchUn0)
       (EvmAsm.Evm64.divStackDispatchPostNoX1 sp a b **
         (.x1 ↦ᵣ branch.returnX1)) := by
-  exact cpsTripleWithin_extend_code
+  exact EvmAsm.Rv64.cpsTripleWithin_extend_code
     (hmono := evm_div_callable_code_sub_sdivCode (base := base))
     (EvmAsm.Evm64.evm_div_callable_spec_from_noNop_branch_return_x1
       sp (base + wrapperEndOff) a b v5 v6 v7 v10 v11


### PR DESCRIPTION
Summary:
- refactor the SDiv branch-return exact callable wrapper to reuse the generic DivMod callable helper
- keep the theorem surface unchanged while delegating the no-NOP callable composition to evm_div_callable_spec_from_noNop_branch_return_x1
- leave only the SDiv code-region lift in the SDiv-specific proof

Verification:
- lake build EvmAsm.Evm64.SDiv.Compose.DivCallExactCallable
- lake build EvmAsm.Evm64.SDiv
- scripts/check-unimported.sh
- git diff --check
- git diff -U0 -- EvmAsm/Evm64/SDiv/Compose/DivCallExactCallable.lean | rg -n '^\+.*(sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|bv_omega)'