### PR TITLE
refactor(divmod): add framed branch return x1 callable helper

### DIFF
--- a/EvmAsm/Evm64/DivMod/Callable.lean
+++ b/EvmAsm/Evm64/DivMod/Callable.lean
@@ -703,6 +703,34 @@ theorem evm_div_callable_spec_from_noNop_branch_return_x1 (sp base : Word)
     cpsTripleWithin_frameL (divStackDispatchPostNoX1 sp a b) hpcFreePost hRet
   exact cpsTripleWithin_seq_same_cr hStackCall hRetFramed
 
+/-- Framed variant of `evm_div_callable_spec_from_noNop_branch_return_x1`. -/
+theorem evm_div_callable_spec_from_noNop_branch_return_x1_framed
+    {F : Assertion} [Assertion.PCFree F] (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (branch : DivStackSpecCase base a b)
+    (hStack :
+      cpsTripleWithin unifiedDivBound base (base + nopOff) (divCode_noNop base)
+        (divModStackDispatchPre sp a b
+          branch.returnX1 branch.x2 v5 v6 v7 v10 v11
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+        (divStackDispatchPostNoX1 sp a b ** (.x1 ↦ᵣ branch.returnX1))) :
+    cpsTripleWithin (unifiedDivBound + 1) base (branch.returnX1 &&& ~~~1)
+      (evm_div_callable_code base)
+      (divModStackDispatchPre sp a b
+        branch.returnX1 branch.x2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 ** F)
+      ((divStackDispatchPostNoX1 sp a b ** (.x1 ↦ᵣ branch.returnX1)) ** F) := by
+  exact
+    cpsTripleWithin_frameR F (by pcFree)
+      (evm_div_callable_spec_from_noNop_branch_return_x1
+        sp base a b v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        nMem shiftMem jMem retMem dMem dloMem scratchUn0 branch hStack)
+
 /-- Zero-divisor DIV callable wrapper that preserves the exact incoming `x1`
     return address. This is the callable-ready specialization needed by SDIV
     when the absolute divisor is zero. -/


### PR DESCRIPTION
## Summary
- Adds `evm_div_callable_spec_from_noNop_branch_return_x1_framed`, a frame-lifting wrapper around `evm_div_callable_spec_from_noNop_branch_return_x1`
- Enables SDIV composition proofs that need to carry an extra assertion frame F through the callable round-trip
- Proof is a one-liner via `cpsTripleWithin_frameR`

Refs #90. Bead: evm-asm-48gpp.

## Verification
- lake build EvmAsm.Evm64.DivMod.Callable
- rg clean (no sorry/admit/heartbeat/recdepth)
- 794 lines

Authored by @pirapira; implemented by Claude Code