### PR TITLE
chore(divmod): inline constant qHat in n2/n3 noNop max-addback-beq specs

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopIterN2NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN2NoNop.lean
@@ -133,9 +133,8 @@ theorem divK_loop_body_n2_max_addback_jgt0_beq_spec_within_noNop (j : Word)
     (hbltu : ¬BitVec.ult u2 v1)
     (hcarry2_nz : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
     let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
-    let qHat : Word := signExtend12 4095
     let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
-    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTripleWithin 152 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
@@ -148,8 +147,9 @@ theorem divK_loop_body_n2_max_addback_jgt0_beq_spec_within_noNop (j : Word)
        ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
        ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ qOld))
-      (loopBodyN2AddbackBeqPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro uBase qHat qAddr hborrow
+      (loopBodyN2AddbackBeqPost sp j (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro uBase qAddr hborrow
+  let qHat : Word := signExtend12 4095
   let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
   let c3 := ms.2.2.2.2
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3

--- a/EvmAsm/Evm64/DivMod/LoopIterN3NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN3NoNop.lean
@@ -15,9 +15,8 @@ theorem divK_loop_body_n3_max_addback_beq_j1_spec_within_noNop
     (hbltu : ¬BitVec.ult u3 v2)
     (hcarry2_nz : isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
     let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
-    let qHat : Word := signExtend12 4095
     let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
-    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTripleWithin 152 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
@@ -30,8 +29,9 @@ theorem divK_loop_body_n3_max_addback_beq_j1_spec_within_noNop
        ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
        ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ qOld))
-      (loopBodyN3AddbackBeqPost sp (1 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro uBase qHat qAddr hborrow
+      (loopBodyN3AddbackBeqPost sp (1 : Word) (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro uBase qAddr hborrow
+  let qHat : Word := signExtend12 4095
   unfold isAddbackCarry2NzN3Max isAddbackCarry2Nz at hcarry2_nz
   let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
   let c3 := ms.2.2.2.2


### PR DESCRIPTION
## Summary
- Removes the statement-level `let qHat : Word := signExtend12 4095` from `divK_loop_body_n2_max_addback_jgt0_beq_spec_within_noNop` and `divK_loop_body_n3_max_addback_beq_j1_spec_within_noNop`
- Replaces `qHat` with the literal `signExtend12 4095` in the borrow hypothesis and postcondition (both use the bundled post `loopBody{N2,N3}AddbackBeqPost`)
- Reduces each statement from 3 lets to 2 (`uBase`, `qAddr`); the `qHat` binding moves to the proof body

Bead: evm-asm-yz73p.

## Verification
- lake build EvmAsm.Evm64.DivMod.LoopIterN2NoNop
- lake build EvmAsm.Evm64.DivMod.LoopIterN3NoNop
- rg clean (no sorry/admit/heartbeat/recdepth)
- lake build (full, green)

Authored by @pirapira; implemented by Claude Code