### PR TITLE
chore(divmod): remove 3-let chains from n4 max-skip-j0 divCode specs

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4.lean
@@ -109,6 +109,7 @@ theorem divK_loop_body_n4_max_skip_j0_norm (sp base : Word)
     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base
 
     hbltu hborrow
+  rw [loopBodyN4SkipJ0Pre_unfold] at raw
   simp only [se12_32, se12_40, se12_48, se12_56,
              u_base_off0_j0, u_base_off4088_j0, u_base_off4080_j0,
              u_base_off4072_j0, u_base_off4064_j0, q_addr_j0] at raw
@@ -137,6 +138,7 @@ theorem divK_loop_body_n4_max_skip_j0_norm_noNop (sp base : Word)
   have raw := divK_loop_body_n4_max_skip_j0_divCode_noNop_within sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base
     hbltu hborrow
+  rw [loopBodyN4SkipJ0Pre_unfold] at raw
   simp only [se12_32, se12_40, se12_48, se12_56,
              u_base_off0_j0, u_base_off4088_j0, u_base_off4080_j0,
              u_base_off4072_j0, u_base_off4064_j0, q_addr_j0] at raw

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4Loop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4Loop.lean
@@ -73,69 +73,12 @@ theorem loopExitPostN4_j0_eq (sp q_f c3 un0F un1F un2F un3F u4F
   simp only [divmod_addr]
 
 -- ============================================================================
--- Loop body j=0 extended to divCode (from sharedDivModCode)
+-- Bundled precondition (defined here so divCode/noNop theorems can use it)
 -- ============================================================================
 
-/-- Extend max_skip j=0 loop body from sharedDivModCode to divCode. -/
-theorem divK_loop_body_n4_max_skip_j0_divCode_within
-    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
-     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
-    (base : Word)
-    (hbltu : ¬BitVec.ult uTop v3) :
-    let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
-    let qHat : Word := signExtend12 4095
-    let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
-    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
-    cpsTripleWithin 76 (base + loopBodyOff) (base + denormOff) (divCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
-       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-       ((uBase + signExtend12 4064) ↦ₘ uTop) **
-       (qAddr ↦ₘ qOld))
-      (loopBodyN4SkipPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro uBase qHat qAddr hborrow
-  exact cpsTripleWithin_extend_code (hmono := sharedDivModCode_sub_divCode)
-    (cpsTripleWithin_mono_nSteps (by decide) (divK_loop_body_n4_max_skip_j0_spec_within sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base hbltu hborrow))
-
-/-- Extend max_skip j=0 loop body to `divCode_noNop`. -/
-theorem divK_loop_body_n4_max_skip_j0_divCode_noNop_within
-    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
-     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
-    (base : Word)
-    (hbltu : ¬BitVec.ult uTop v3) :
-    let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
-    let qHat : Word := signExtend12 4095
-    let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
-    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
-    cpsTripleWithin 76 (base + loopBodyOff) (base + denormOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
-       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-       ((uBase + signExtend12 4064) ↦ₘ uTop) **
-       (qAddr ↦ₘ qOld))
-      (loopBodyN4SkipPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro uBase qHat qAddr hborrow
-  exact cpsTripleWithin_mono_nSteps (by decide)
-    (divK_loop_body_n4_max_skip_j0_spec_within_noNop sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base hbltu hborrow)
-
-/-- Bundled precondition for the `divK_loop_body_n4_max_skip_j0_modCode_within` /
-    `_divCode` code-extended loop-body specs. Wraps the 21-atom sepConj
-    chain that the `let uBase / qAddr` bindings make awkward in the
-    raw statement. Marked `@[irreducible]` so the `let`-bound offsets
+/-- Bundled precondition for the `divK_loop_body_n4_max_skip_j0_{divCode,noNop,modCode}_within`
+    specs. Wraps the 21-atom sepConj chain that the `let uBase / qAddr` bindings make awkward
+    in the raw statement. Marked `@[irreducible]` so the `let`-bound offsets
     don't pollute callers' types. -/
 @[irreducible]
 def loopBodyN4SkipJ0Pre
@@ -175,6 +118,62 @@ theorem loopBodyN4SkipJ0Pre_unfold
      ((uBase + signExtend12 4064) ↦ₘ uTop) **
      (qAddr ↦ₘ qOld)) := by
   delta loopBodyN4SkipJ0Pre; rfl
+
+-- ============================================================================
+-- Loop body j=0 extended to divCode / divCode_noNop (from sharedDivModCode)
+-- Uses loopBodyN4SkipJ0Pre so no let-bindings appear in the statement.
+-- ============================================================================
+
+/-- Extend max_skip j=0 loop body from sharedDivModCode to divCode.
+    Uses `loopBodyN4SkipJ0Pre` so no `let`-bindings appear in the statement. -/
+theorem divK_loop_body_n4_max_skip_j0_divCode_within
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (base : Word)
+    (hbltu : ¬BitVec.ult uTop v3)
+    (hborrow : (if BitVec.ult uTop
+                  (mulsubN4_c3 (signExtend12 4095) v0 v1 v2 v3 u0 u1 u2 u3)
+                then (1 : Word) else 0) = (0 : Word)) :
+    cpsTripleWithin 76 (base + loopBodyOff) (base + denormOff) (divCode base)
+      (loopBodyN4SkipJ0Pre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld)
+      (loopBodyN4SkipPost sp (0 : Word) (signExtend12 4095)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  have h := cpsTripleWithin_extend_code (hmono := sharedDivModCode_sub_divCode)
+    (divK_loop_body_n4_max_skip_j0_spec_within sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base hbltu hborrow)
+  refine cpsTripleWithin_weaken ?_ (fun _ hq => hq) h
+  intro _ hp
+  rw [loopBodyN4SkipJ0Pre_unfold] at hp
+  exact hp
+
+/-- Extend max_skip j=0 loop body to `divCode_noNop`.
+    Uses `loopBodyN4SkipJ0Pre` so no `let`-bindings appear in the statement. -/
+theorem divK_loop_body_n4_max_skip_j0_divCode_noNop_within
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (base : Word)
+    (hbltu : ¬BitVec.ult uTop v3)
+    (hborrow : (if BitVec.ult uTop
+                  (mulsubN4_c3 (signExtend12 4095) v0 v1 v2 v3 u0 u1 u2 u3)
+                then (1 : Word) else 0) = (0 : Word)) :
+    cpsTripleWithin 76 (base + loopBodyOff) (base + denormOff) (divCode_noNop base)
+      (loopBodyN4SkipJ0Pre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld)
+      (loopBodyN4SkipPost sp (0 : Word) (signExtend12 4095)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  have h : cpsTripleWithin 76 (base + loopBodyOff) (base + denormOff) (divCode_noNop base)
+      (loopBodyN4SkipJ0Pre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld)
+      (loopBodyN4SkipPost sp (0 : Word) (signExtend12 4095)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+    have raw := divK_loop_body_n4_max_skip_j0_spec_within_noNop sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base hbltu hborrow
+    refine cpsTripleWithin_weaken ?_ (fun _ hq => hq) (cpsTripleWithin_mono_nSteps (by decide) raw)
+    intro _ hp
+    rw [loopBodyN4SkipJ0Pre_unfold] at hp
+    exact hp
+  exact h
 
 /-- Extend max_skip j=0 loop body from sharedDivModCode to modCode.
     Mirror of `divK_loop_body_n4_max_skip_j0_divCode_within` — same proof,


### PR DESCRIPTION
## Summary
- Removes the 3 statement-level lets (`uBase`, `qHat`, `qAddr`) from `divK_loop_body_n4_max_skip_j0_divCode_within` and `divK_loop_body_n4_max_skip_j0_divCode_noNop_within` in `FullPathN4Loop.lean`
- Moves `loopBodyN4SkipJ0Pre` before the divCode theorems so they can reference it
- divCode variant: mirrors the existing modCode proof (uses `cpsTripleWithin_extend_code` directly without `mono_nSteps`)
- noNop variant: uses inner `have h : ... := by` block with explicit type annotation to separate step-count adjustment from precondition bridging
- `FullPathN4.lean` callers: add `rw [loopBodyN4SkipJ0Pre_unfold] at raw` before the `simp` normalization step

Bead: evm-asm-yz73p.

## Verification
- lake build EvmAsm.Evm64.DivMod.Compose.FullPathN4Loop
- lake build EvmAsm.Evm64.DivMod.Compose.FullPathN4
- rg clean (no sorry/admit/heartbeat/recdepth)
- lake build (full, green)

Authored by @pirapira; implemented by Claude Code