### PR TITLE
chore(exp): bundle baseFrame/foldedPre in cond-mul canonical specs

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCondCall.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCondCall.lean
@@ -434,4 +434,41 @@ theorem exp_cond_mul_call_then_loop_back_evm_exp_msb_saved_bit_two_mul_with_mul_
       sp evmSp iterCount vOld a0 a1 a2 a3 r h hp
 
 
+/-- Bundled precondition shared by the folded-word conditional-multiply
+    adapters in both `SavedBitTwoMulCondCall` and `SavedBitTwoMulCondCanonical`.
+    Hides `baseFrame` (the exponent-limb frame) and the full `foldedPre`
+    assertion so spec statements can reduce to a single `let rw` binding. -/
+@[irreducible]
+def expCondMulFoldedPre
+    (sp evmSp iterCount vOld a0 a1 a2 a3 : Word) (r : EvmWord) : Assertion :=
+  let baseFrame : Assertion :=
+    ((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
+    ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **
+    ((evmSp + signExtend12 ((-48) : BitVec 12)) ↦ₘ a2) **
+    ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3)
+  (((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ r.getLimbN 3) **
+    evmWordIs sp r ** evmWordIs (evmSp + 32) r **
+    baseFrame ** (.x1 ↦ᵣ vOld) ** (.x9 ↦ᵣ iterCount) **
+    (.x0 ↦ᵣ (0 : Word))) **
+   regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
+   memOwn evmSp ** memOwn (evmSp + 8) **
+   memOwn (evmSp + 16) ** memOwn (evmSp + 24))
+
+theorem expCondMulFoldedPre_unfold
+    {sp evmSp iterCount vOld a0 a1 a2 a3 : Word} {r : EvmWord} :
+    expCondMulFoldedPre sp evmSp iterCount vOld a0 a1 a2 a3 r =
+      (let baseFrame : Assertion :=
+         ((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
+         ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **
+         ((evmSp + signExtend12 ((-48) : BitVec 12)) ↦ₘ a2) **
+         ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3)
+       (((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ r.getLimbN 3) **
+         evmWordIs sp r ** evmWordIs (evmSp + 32) r **
+         baseFrame ** (.x1 ↦ᵣ vOld) ** (.x9 ↦ᵣ iterCount) **
+         (.x0 ↦ᵣ (0 : Word))) **
+        regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
+        memOwn evmSp ** memOwn (evmSp + 8) **
+        memOwn (evmSp + 16) ** memOwn (evmSp + 24))) := by
+  delta expCondMulFoldedPre; rfl
+
 end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCondCanonical.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulCondCanonical.lean
@@ -125,23 +125,10 @@ theorem exp_cond_mul_call_then_loop_back_evm_exp_msb_saved_bit_two_mul_canonical
               base squaringMulOff condMulOff)
             (mul_callable_code mulTarget)) :
     let rw := expTwoMulCondRw r a0 a1 a2 a3
-    let baseFrame : Assertion :=
-      ((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
-      ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **
-      ((evmSp + signExtend12 ((-48) : BitVec 12)) ↦ₘ a2) **
-      ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3)
-    let foldedPre : Assertion :=
-      (((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ r.getLimbN 3) **
-        evmWordIs sp r ** evmWordIs (evmSp + 32) r **
-        baseFrame ** (.x1 ↦ᵣ vOld) ** (.x9 ↦ᵣ iterCount) **
-        (.x0 ↦ᵣ (0 : Word))) **
-       regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
-       memOwn evmSp ** memOwn (evmSp + 8) **
-       memOwn (evmSp + 16) ** memOwn (evmSp + 24))
     cpsNBranchWithin ((17 + 64 + 9) + 2) (base + 152)
       (evmExpMsbSavedBitTwoMulCanonicalWithMulCode
         base mulTarget squaringMulOff condMulOff)
-      foldedPre
+      (expCondMulFoldedPre sp evmSp iterCount vOld a0 a1 a2 a3 r)
       [(base + 28,
           (((.x9 ↦ᵣ expTwoMulIterCountNew iterCount) ** (.x0 ↦ᵣ (0 : Word)) **
            ⌜expTwoMulIterCountNew iterCount ≠ 0⌝) **
@@ -155,7 +142,7 @@ theorem exp_cond_mul_call_then_loop_back_evm_exp_msb_saved_bit_two_mul_canonical
           signExtend13 EvmAsm.Evm64.canonicalExpMsbSavedBitLoopBackOff =
         base + 28 := by
     exact EvmAsm.Evm64.canonicalExpMsbSavedBitLoopBack_target base
-  simpa [expCondMulLoopRest_unfold, expTwoMulIterCountNew] using
+  simpa [expCondMulLoopRest_unfold, expTwoMulIterCountNew, expCondMulFoldedPre_unfold] using
     (exp_cond_mul_call_then_loop_back_evm_exp_msb_saved_bit_two_mul_with_mul_folded_owned_spec_within
       iterCount sp evmSp vOld a0 a1 a2 a3 mulTarget r
       squaringMulOff condMulOff
@@ -170,22 +157,9 @@ theorem exp_cond_mul_call_then_loop_back_evm_exp_msb_saved_bit_two_mul_canonical
     (base : Word)
     (hbase : base &&& 1 = 0) :
     let rw := expTwoMulCondRw r a0 a1 a2 a3
-    let baseFrame : Assertion :=
-      ((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
-      ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **
-      ((evmSp + signExtend12 ((-48) : BitVec 12)) ↦ₘ a2) **
-      ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3)
-    let foldedPre : Assertion :=
-      (((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ r.getLimbN 3) **
-        evmWordIs sp r ** evmWordIs (evmSp + 32) r **
-        baseFrame ** (.x1 ↦ᵣ vOld) ** (.x9 ↦ᵣ iterCount) **
-        (.x0 ↦ᵣ (0 : Word))) **
-       regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
-       memOwn evmSp ** memOwn (evmSp + 8) **
-       memOwn (evmSp + 16) ** memOwn (evmSp + 24))
     cpsNBranchWithin ((17 + 64 + 9) + 2) (base + 152)
       (evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode base)
-      foldedPre
+      (expCondMulFoldedPre sp evmSp iterCount vOld a0 a1 a2 a3 r)
       [(base + 28,
           (((.x9 ↦ᵣ expTwoMulIterCountNew iterCount) ** (.x0 ↦ᵣ (0 : Word)) **
            ⌜expTwoMulIterCountNew iterCount ≠ 0⌝) **


### PR DESCRIPTION
## Summary
- Adds `@[irreducible] def expCondMulFoldedPre` to `SavedBitTwoMulCondCall.lean`, bundling the `baseFrame` and `foldedPre` assertion lets used by the folded-word conditional-multiply path
- Updates 2 theorems in `SavedBitTwoMulCondCanonical.lean`: reduces each statement from 3 lets (`rw`, `baseFrame`, `foldedPre`) to 1 (`rw`)
- Proofs add `expCondMulFoldedPre_unfold` to the `simpa` lemma list (works because the proofs use `simpa ... using inner_spec` not `intro rw baseFrame foldedPre`)

Bead: evm-asm-yz73p.

## Verification
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitTwoMulCondCall
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitTwoMulCondCanonical
- rg clean (no sorry/admit/heartbeat/recdepth)
- lake build (full, green)

Authored by @pirapira; implemented by Claude Code