### PR TITLE
chore(exp): bundle skip rest in two-mul skip specs (3→2 statement lets)

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulSkip.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulSkip.lean
@@ -12,6 +12,21 @@ namespace EvmAsm.Evm64.Exp.Compose
 open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64
 
+/-- Bundles `expTwoMulSkipLoopRest` with the `bit` and `squareW` computations
+    so the skip specs need only two statement lets instead of three. -/
+@[irreducible]
+def expTwoMulSkipIterRest
+    (e sp evmSp base r0 r1 r2 r3 : Word) : Assertion :=
+  expTwoMulSkipLoopRest
+    (expTwoMulIterBit e) sp evmSp base (expTwoMulSquareW r0 r1 r2 r3)
+
+theorem expTwoMulSkipIterRest_unfold
+    {e sp evmSp base r0 r1 r2 r3 : Word} :
+    expTwoMulSkipIterRest e sp evmSp base r0 r1 r2 r3 =
+      expTwoMulSkipLoopRest
+        (expTwoMulIterBit e) sp evmSp base (expTwoMulSquareW r0 r1 r2 r3) := by
+  delta expTwoMulSkipIterRest; rfl
+
 /-- Saved-bit loop-back block lifted to the two-MUL-offset EXP+MUL code
     bundle. -/
 theorem exp_loop_back_evm_exp_msb_saved_bit_two_mul_with_mul_spec_within
@@ -57,8 +72,6 @@ theorem exp_msb_saved_bit_prefix_squaring_beq_skip_then_loop_back_evm_exp_msb_sa
     (hback : ((base + 256) + 4 : Word) + signExtend13 backOff = loopTarget) :
     let bit := expTwoMulIterBit e
     let squareW := expTwoMulSquareW r0 r1 r2 r3
-    let rest : Assertion :=
-      expTwoMulSkipLoopRest bit sp evmSp base squareW
     cpsNBranchWithin ((3 + 1 + (17 + 64 + 9) + 1) + 2) (base + 28)
       (evmExpMsbSavedBitTwoMulWithMulCode
         base mulTarget squaringMulOff condMulOff skipOff backOff)
@@ -90,11 +103,13 @@ theorem exp_msb_saved_bit_prefix_squaring_beq_skip_then_loop_back_evm_exp_msb_sa
            (.x1 ↦ᵣ ((base + 44) + 68))) ** (.x9 ↦ᵣ iterCount)),
         (loopTarget,
           (((.x9 ↦ᵣ expTwoMulIterCountNew iterCount) ** (.x0 ↦ᵣ (0 : Word)) **
-           ⌜expTwoMulIterCountNew iterCount ≠ 0⌝) ** rest)),
+           ⌜expTwoMulIterCountNew iterCount ≠ 0⌝) **
+            expTwoMulSkipIterRest e sp evmSp base r0 r1 r2 r3)),
         (base + 264,
           (((.x9 ↦ᵣ expTwoMulIterCountNew iterCount) ** (.x0 ↦ᵣ (0 : Word)) **
-           ⌜expTwoMulIterCountNew iterCount = 0⌝) ** rest))] := by
-  intro bit squareW rest
+           ⌜expTwoMulIterCountNew iterCount = 0⌝) **
+            expTwoMulSkipIterRest e sp evmSp base r0 r1 r2 r3))] := by
+  intro bit squareW
   have hBranch :=
     exp_msb_saved_bit_prefix_squaring_then_beq_evm_exp_msb_saved_bit_two_mul_with_mul_spec_within
       e c v10 v18 sp evmSp vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
@@ -106,9 +121,10 @@ theorem exp_msb_saved_bit_prefix_squaring_beq_skip_then_loop_back_evm_exp_msb_sa
   have hLoop := exp_loop_back_evm_exp_msb_saved_bit_two_mul_with_mul_spec_within
     iterCount squaringMulOff condMulOff skipOff backOff base mulTarget
     loopTarget hback
-  have hLoopFramed := cpsBranchWithin_frameR rest (by
-    dsimp [rest]
-    exact expTwoMulSkipLoopRest_pcFree) hLoop
+  have hLoopFramed := cpsBranchWithin_frameR
+    (expTwoMulSkipIterRest e sp evmSp base r0 r1 r2 r3) (by
+      rw [expTwoMulSkipIterRest_unfold]
+      exact expTwoMulSkipLoopRest_pcFree) hLoop
   have hLoopN := cpsBranchWithin_as_cpsNBranchWithin hLoopFramed
   have hSeq :
       cpsNBranchWithin ((3 + 1 + (17 + 64 + 9) + 1) + 2) (base + 28)
@@ -117,8 +133,7 @@ theorem exp_msb_saved_bit_prefix_squaring_beq_skip_then_loop_back_evm_exp_msb_sa
         _ _ :=
     cpsBranchWithin_cons_cpsNBranchWithin_with_perm_same_cr
       (fun _ hp => by
-        simp [rest, expTwoMulSkipLoopRest_unfold, bit,
-          squareW, expTwoMulSquareW] at hp ⊢
+        simp [expTwoMulSkipIterRest_unfold, expTwoMulSkipLoopRest_unfold] at hp ⊢
         xperm_hyp hp)
       hBranchSwapped hLoopN
   have hSeqPre :
@@ -218,7 +233,7 @@ theorem exp_msb_saved_bit_prefix_squaring_beq_skip_then_loop_back_with_base_fram
       (pcFree_sepConj pcFree_memIs
         (pcFree_sepConj pcFree_memIs pcFree_memIs))
   have hf := cpsNBranchWithin_frameR hBaseFramePcFree h
-  simpa [rest, expTwoMulSkipLoopRest_unfold] using
+  simpa [rest, expTwoMulSkipLoopRest_unfold, expTwoMulSkipIterRest_unfold] using
     (cpsNBranchWithin_weaken_pre
       (fun _ hp => by simpa using hp) hf)
 

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulSkipCanonical.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitTwoMulSkipCanonical.lean
@@ -10,21 +10,6 @@ namespace EvmAsm.Evm64.Exp.Compose
 
 open EvmAsm.Rv64
 
-/-- Bundles `expTwoMulSkipLoopRest` with the `bit` and `squareW` computations
-    so the skip canonical specs need only one let instead of three. -/
-@[irreducible]
-def expTwoMulSkipIterRest
-    (e sp evmSp base r0 r1 r2 r3 : Word) : Assertion :=
-  expTwoMulSkipLoopRest
-    (expTwoMulIterBit e) sp evmSp base (expTwoMulSquareW r0 r1 r2 r3)
-
-theorem expTwoMulSkipIterRest_unfold
-    {e sp evmSp base r0 r1 r2 r3 : Word} :
-    expTwoMulSkipIterRest e sp evmSp base r0 r1 r2 r3 =
-      expTwoMulSkipLoopRest
-        (expTwoMulIterBit e) sp evmSp base (expTwoMulSquareW r0 r1 r2 r3) := by
-  delta expTwoMulSkipIterRest; rfl
-
 /-- Canonical-code view of the saved-bit loop-back block. -/
 theorem exp_loop_back_evm_exp_msb_saved_bit_two_mul_canonical_with_mul_spec_within
     (c : Word) (squaringMulOff condMulOff : BitVec 21)


### PR DESCRIPTION
## Summary
- Moves `expTwoMulSkipIterRest` and `expTwoMulSkipIterRest_unfold` from `SavedBitTwoMulSkipCanonical.lean` to `SavedBitTwoMulSkip.lean` (where the 3-let theorem lives)
- Reduces `exp_msb_saved_bit_prefix_squaring_beq_skip_then_loop_back_..._spec_within` from 3 statement lets (`bit`, `squareW`, `rest`) to 2 (`bit`, `squareW`)
- Proof: removes `intro ... rest`, uses `expTwoMulSkipIterRest` directly in branches, adds `expTwoMulSkipIterRest_unfold` to `simp`
- The 4-let theorem (with `baseFrame`) also needs `expTwoMulSkipIterRest_unfold` since it calls the 3-let theorem as its inner spec

Bead: evm-asm-yz73p.

## Verification
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitTwoMulSkip
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitTwoMulSkipCanonical
- rg clean (no sorry/admit/heartbeat/recdepth)
- lake build (full, green)

Authored by @pirapira; implemented by Claude Code