### PR TITLE
chore(divmod): bundle skip norm post, remove 3 lets from skip j0 norm

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4.lean
@@ -657,12 +657,10 @@ theorem divK_loop_body_n4_call_skip_j0_norm (sp base : Word)
     (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
     (retMem dMem dloMem scratch_un0 : Word)
     (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
-    (hbltu : BitVec.ult uTop v3) :
-    let qHat := div128Quot uTop u3 v3
-    let dLo := (v3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    let div_un0 := (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3)
-     then (1 : Word) else 0) = (0 : Word) →
+    (hbltu : BitVec.ult uTop v3)
+    (hborrow : (if BitVec.ult uTop
+                  (mulsubN4_c3 (div128Quot uTop u3 v3) v0 v1 v2 v3 u0 u1 u2 u3)
+                then (1 : Word) else 0) = (0 : Word)) :
     cpsTripleWithin 126 (base + loopBodyOff) (base + denormOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
@@ -679,15 +677,10 @@ theorem divK_loop_body_n4_call_skip_j0_norm (sp base : Word)
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopBodyN4SkipPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
-       (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
-       (sp + signExtend12 3960 ↦ₘ v3) **
-       (sp + signExtend12 3952 ↦ₘ dLo) **
-       (sp + signExtend12 3944 ↦ₘ div_un0)) := by
-  intro qHat dLo div_un0 hborrow
+      (loopBodyN4CallSkipJ0Post sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   have raw := divK_loop_body_n4_call_skip_j0_divCode_within sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 base halign hbltu hborrow
-  simp only [loopBodyN4CallSkipJ0Pre_unfold, loopBodyN4CallSkipJ0Post_unfold,
+  simp only [loopBodyN4CallSkipJ0Pre_unfold,
              se12_32, se12_40, se12_48, se12_56,
              u_base_off0_j0, u_base_off4088_j0, u_base_off4080_j0,
              u_base_off4072_j0, u_base_off4064_j0, q_addr_j0] at raw
@@ -834,10 +827,7 @@ theorem evm_div_n4_preloop_call_skip_spec (sp base : Word)
     jMem (4 : Word) shift u0 (a0 >>> (antiShift.toNat % 64)) v11Old antiShift
     b0' b1' b2' b3' u0 u1 u2 u3 u4 (0 : Word)
     retMem dMem dloMem scratch_un0 halign
-
-    hbltu
-  intro_lets at hLoop
-  have hLoop' := hLoop hborrow
+    hbltu hborrow
   have hLoopF := cpsTripleWithin_frameR
     (((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
      ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
@@ -848,7 +838,7 @@ theorem evm_div_n4_preloop_call_skip_spec (sp base : Word)
      ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3992) ↦ₘ shift))
-    (by pcFree) hLoop'
+    (by pcFree) hLoop
   have hFull := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by
       delta loopSetupPost at hp
@@ -856,7 +846,10 @@ theorem evm_div_n4_preloop_call_skip_spec (sp base : Word)
       xperm_hyp hp) hPreF hLoopF
   exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
     (fun h hp => by xperm_hyp hp)
-    (fun h hq => by delta preloopCallSkipPostN4; xperm_hyp hq)
+    (fun h hq => by
+      simp only [loopBodyN4CallSkipJ0Post_unfold] at hq
+      delta preloopCallSkipPostN4
+      xperm_hyp hq)
     hFull
 
 /-- Full path postcondition for n=4 DIV (shift ≠ 0, call+skip).

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4Shift0.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4Shift0.lean
@@ -122,10 +122,7 @@ theorem evm_div_n4_preloop_shift0_call_skip_spec (sp base : Word)
     v11Old (signExtend12 (0 : BitVec 12) - (clzResult b3).1)
     b0 b1 b2 b3 a0 a1 a2 a3 (0 : Word) (0 : Word)
     retMem dMem dloMem scratch_un0 halign
-
-    hbltu
-  intro_lets at hLoop
-  have hLoop' := hLoop hborrow
+    hbltu hborrow
   -- Frame loop body with a[], q[1-3]=0, padding, shift=0
   have hLoopF := cpsTripleWithin_frameR
     (((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
@@ -137,7 +134,7 @@ theorem evm_div_n4_preloop_shift0_call_skip_spec (sp base : Word)
      ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3992) ↦ₘ (clzResult b3).1))
-    (by pcFree) hLoop'
+    (by pcFree) hLoop
   -- Compose preloop → loop body
   have hFull := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by
@@ -145,7 +142,11 @@ theorem evm_div_n4_preloop_shift0_call_skip_spec (sp base : Word)
       xperm_hyp hp) hPreF hLoopF
   exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
     (fun h hp => by xperm_hyp hp)
-    (fun h hq => by delta preloopShift0CallSkipPostN4; simp only [hshift_z] at hq; xperm_hyp hq)
+    (fun h hq => by
+      simp only [loopBodyN4CallSkipJ0Post_unfold] at hq
+      delta preloopShift0CallSkipPostN4
+      simp only [hshift_z] at hq
+      xperm_hyp hq)
     hFull
 
 /-- No-NOP variant of `evm_div_n4_preloop_shift0_call_skip_spec`. -/


### PR DESCRIPTION
## Summary
- Uses `loopBodyN4CallSkipJ0Post` in `divK_loop_body_n4_call_skip_j0_norm`, removing 3 statement lets (qHat, dLo, div_un0) → 0 lets
- Updates callers in `evm_div_n4_preloop_call_skip_spec` (`FullPathN4.lean`) and `evm_div_n4_preloop_shift0_call_skip_spec` (`FullPathN4Shift0.lean`) to pass `hborrow` directly and bridge via `loopBodyN4CallSkipJ0Post_unfold`

Refs #35. Bead: evm-asm-yz73p.

## Verification
- `lake build EvmAsm.Evm64.DivMod.Compose.FullPathN4`
- `lake build EvmAsm.Evm64.DivMod.Compose.FullPathN4Shift0`
- `scripts/check-file-size.sh`
- `rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" ...` (no matches)
- `lake build` (1948 jobs, green)

Authored by @pirapira; implemented by Claude Code