### PR TITLE
chore(divmod): bundle modCode norm posts, remove 3 lets from skip/addback modCode norms

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4Loop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4Loop.lean
@@ -478,12 +478,10 @@ theorem divK_loop_body_n4_call_skip_j0_norm_modCode_within (sp base : Word)
     (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
     (retMem dMem dloMem scratch_un0 : Word)
     (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
-    (hbltu : BitVec.ult uTop v3) :
-    let qHat := div128Quot uTop u3 v3
-    let dLo := (v3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    let div_un0 := (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3)
-     then (1 : Word) else 0) = (0 : Word) →
+    (hbltu : BitVec.ult uTop v3)
+    (hborrow : (if BitVec.ult uTop
+                  (mulsubN4_c3 (div128Quot uTop u3 v3) v0 v1 v2 v3 u0 u1 u2 u3)
+                then (1 : Word) else 0) = (0 : Word)) :
     cpsTripleWithin 126 (base + loopBodyOff) (base + denormOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
@@ -500,12 +498,7 @@ theorem divK_loop_body_n4_call_skip_j0_norm_modCode_within (sp base : Word)
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopBodyN4SkipPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
-       (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
-       (sp + signExtend12 3960 ↦ₘ v3) **
-       (sp + signExtend12 3952 ↦ₘ dLo) **
-       (sp + signExtend12 3944 ↦ₘ div_un0)) := by
-  intro qHat dLo div_un0 hborrow
+      (loopBodyN4CallSkipJ0Post sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   have raw := divK_loop_body_n4_call_skip_j0_modCode_within sp jOld v5Old v6Old v7Old
     v10Old v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
     retMem dMem dloMem scratch_un0 base halign hbltu hborrow
@@ -517,7 +510,6 @@ theorem divK_loop_body_n4_call_skip_j0_norm_modCode_within (sp base : Word)
                u_base_off4072_j0, u_base_off4064_j0, q_addr_j0]
     exact hp
   · intro _ hq
-    rw [loopBodyN4CallSkipJ0Post_unfold] at hq
     exact hq
 
 -- ============================================================================
@@ -567,12 +559,10 @@ theorem divK_loop_body_n4_call_addback_j0_beq_norm_modCode_within (sp base : Wor
     (retMem dMem dloMem scratch_un0 : Word)
     (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
     (hbltu : BitVec.ult uTop v3)
-    (hcarry2_nz : isAddbackCarry2NzN4Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let qHat := div128Quot uTop u3 v3
-    let dLo := (v3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    let div_un0 := (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3)
-     then (1 : Word) else 0) ≠ (0 : Word) →
+    (hcarry2_nz : isAddbackCarry2NzN4Call v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hborrow : (if BitVec.ult uTop
+                  (mulsubN4_c3 (div128Quot uTop u3 v3) v0 v1 v2 v3 u0 u1 u2 u3)
+                then (1 : Word) else 0) ≠ (0 : Word)) :
     cpsTripleWithin 202 (base + loopBodyOff) (base + denormOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
@@ -589,12 +579,7 @@ theorem divK_loop_body_n4_call_addback_j0_beq_norm_modCode_within (sp base : Wor
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopBodyN4AddbackBeqPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
-       (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
-       (sp + signExtend12 3960 ↦ₘ v3) **
-       (sp + signExtend12 3952 ↦ₘ dLo) **
-       (sp + signExtend12 3944 ↦ₘ div_un0)) := by
-  intro qHat dLo div_un0 hborrow
+      (loopBodyN4CallAddbackBeqJ0Post sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   have raw := divK_loop_body_n4_call_addback_j0_beq_modCode_within sp jOld
     v5Old v6Old v7Old v10Old v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop
     qOld retMem dMem dloMem scratch_un0 base halign hbltu hcarry2_nz hborrow
@@ -606,7 +591,6 @@ theorem divK_loop_body_n4_call_addback_j0_beq_norm_modCode_within (sp base : Wor
                u_base_off4072_j0, u_base_off4064_j0, q_addr_j0]
     exact hp
   · intro _ hq
-    rw [loopBodyN4CallAddbackBeqJ0Post_unfold] at hq
     exact hq
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPathN4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPathN4.lean
@@ -291,9 +291,7 @@ theorem evm_mod_n4_preloop_call_skip_spec_within (sp base : Word)
     jMem (4 : Word) shift u0 (a0 >>> (antiShift.toNat % 64)) v11Old antiShift
     b0' b1' b2' b3' u0 u1 u2 u3 u4 (0 : Word)
     retMem dMem dloMem scratch_un0 halign
-    hbltu
-  intro_lets at hLoop
-  have hLoop' := hLoop hborrow
+    hbltu hborrow
   have hLoopF := cpsTripleWithin_frameR
     (((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
      ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
@@ -304,7 +302,7 @@ theorem evm_mod_n4_preloop_call_skip_spec_within (sp base : Word)
      ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3992) ↦ₘ shift))
-    (by pcFree) hLoop'
+    (by pcFree) hLoop
   have hFull := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by
       delta loopSetupPost at hp
@@ -312,7 +310,10 @@ theorem evm_mod_n4_preloop_call_skip_spec_within (sp base : Word)
       xperm_hyp hp) hPreF hLoopF
   exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
     (fun h hp => by xperm_hyp hp)
-    (fun h hq => by delta preloopCallSkipPostN4; xperm_hyp hq)
+    (fun h hq => by
+      simp only [loopBodyN4CallSkipJ0Post_unfold] at hq
+      delta preloopCallSkipPostN4
+      xperm_hyp hq)
     hFull
 
 -- ============================================================================
@@ -568,16 +569,14 @@ theorem evm_mod_n4_preloop_call_addback_beq_spec_within (sp base : Word)
     jMem (4 : Word) shift u0 (a0 >>> (antiShift.toNat % 64)) v11Old antiShift
     b0' b1' b2' b3' u0 u1 u2 u3 u4 (0 : Word)
     retMem dMem dloMem scratch_un0
-    halign hbltu hcarry2_nz
-  intro_lets at hLoop
-  have hLoop' := hLoop hborrow
+    halign hbltu hcarry2_nz hborrow
   have hLoopF := cpsTripleWithin_frameR
     (((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
      ((sp + signExtend12 4080) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4072) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4064) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4016) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4008) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3992) ↦ₘ shift))
-    (by pcFree) hLoop'
+    (by pcFree) hLoop
   have hFull := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by
       delta loopSetupPost at hp
@@ -585,7 +584,10 @@ theorem evm_mod_n4_preloop_call_addback_beq_spec_within (sp base : Word)
       xperm_hyp hp) hPreF hLoopF
   exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
     (fun h hp => by xperm_hyp hp)
-    (fun h hq => by delta preloopCallAddbackBeqPostN4; xperm_hyp hq)
+    (fun h hq => by
+      simp only [loopBodyN4CallAddbackBeqJ0Post_unfold] at hq
+      delta preloopCallAddbackBeqPostN4
+      xperm_hyp hq)
     hFull
 
 -- ============================================================================

--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPathN4Shift0.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPathN4Shift0.lean
@@ -79,9 +79,7 @@ theorem evm_mod_n4_preloop_shift0_call_skip_spec (sp base : Word)
     v11Old (signExtend12 (0 : BitVec 12) - (clzResult b3).1)
     b0 b1 b2 b3 a0 a1 a2 a3 (0 : Word) (0 : Word)
     retMem dMem dloMem scratch_un0 halign
-    hbltu
-  intro_lets at hLoop
-  have hLoop' := hLoop hborrow
+    hbltu hborrow
   -- Frame loop body with a[], q[1-3]=0, padding, shift=0
   have hLoopF := cpsTripleWithin_frameR
     (((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
@@ -93,7 +91,7 @@ theorem evm_mod_n4_preloop_shift0_call_skip_spec (sp base : Word)
      ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3992) ↦ₘ (clzResult b3).1))
-    (by pcFree) hLoop'
+    (by pcFree) hLoop
   -- Compose preloop → loop body
   have hFull := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by
@@ -101,7 +99,11 @@ theorem evm_mod_n4_preloop_shift0_call_skip_spec (sp base : Word)
       xperm_hyp hp) hPreF hLoopF
   exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
     (fun h hp => by xperm_hyp hp)
-    (fun h hq => by delta preloopShift0CallSkipPostN4; simp only [hshift_z] at hq; xperm_hyp hq)
+    (fun h hq => by
+      simp only [loopBodyN4CallSkipJ0Post_unfold] at hq
+      delta preloopShift0CallSkipPostN4
+      simp only [hshift_z] at hq
+      xperm_hyp hq)
     hFull
 
 -- ============================================================================
@@ -292,9 +294,7 @@ theorem evm_mod_n4_preloop_shift0_call_addback_beq_spec (sp base : Word)
     v11Old (signExtend12 (0 : BitVec 12) - (clzResult b3).1)
     b0 b1 b2 b3 a0 a1 a2 a3 (0 : Word) (0 : Word)
     retMem dMem dloMem scratch_un0 halign
-    hbltu hcarry2_nz
-  intro_lets at hLoop
-  have hLoop' := hLoop hborrow
+    hbltu hcarry2_nz hborrow
   -- Frame loop body with a[], q[1-3]=0, padding, shift=0
   have hLoopF := cpsTripleWithin_frameR
     (((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
@@ -306,7 +306,7 @@ theorem evm_mod_n4_preloop_shift0_call_addback_beq_spec (sp base : Word)
      ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3992) ↦ₘ (clzResult b3).1))
-    (by pcFree) hLoop'
+    (by pcFree) hLoop
   -- Compose preloop → loop body
   have hFull := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by
@@ -315,6 +315,7 @@ theorem evm_mod_n4_preloop_shift0_call_addback_beq_spec (sp base : Word)
   exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hq => by
+      simp only [loopBodyN4CallAddbackBeqJ0Post_unfold] at hq
       delta preloopShift0CallAddbackBeqPostN4
       simp only [hshift_z] at hq
       xperm_hyp hq)


### PR DESCRIPTION
## Summary
- Uses `loopBodyN4CallSkipJ0Post` in `divK_loop_body_n4_call_skip_j0_norm_modCode_within`, removing 3 statement lets → 0
- Uses `loopBodyN4CallAddbackBeqJ0Post` in `divK_loop_body_n4_call_addback_j0_beq_norm_modCode_within`, removing 3 statement lets → 0
- Updates 4 callers in `ModFullPathN4.lean` and `ModFullPathN4Shift0.lean`

Refs #35. Bead: evm-asm-yz73p.

## Verification
- `lake build EvmAsm.Evm64.DivMod.Compose.FullPathN4Loop`
- `lake build EvmAsm.Evm64.DivMod.Compose.ModFullPathN4`
- `lake build EvmAsm.Evm64.DivMod.Compose.ModFullPathN4Shift0`
- `scripts/check-file-size.sh`
- `rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" ...` (no matches)
- `lake build` (1948 jobs, green)

Authored by @pirapira; implemented by Claude Code