### PR TITLE
chore(divmod): bundle normBFull postcondition, remove 4 lets from normB_full specs

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Base.lean
@@ -1001,6 +1001,37 @@ instance pcFreeInst_normBPost (sp nVal shift b0 b1 b2 b3 : Word) :
   ⟨pcFree_normBPost⟩
 
 -- ============================================================================
+-- Postcondition bundle for normB full spec (without extra normBPost atoms).
+-- Used by divK_normB_full_spec_within, divK_normB_full_spec_within_noNop, and
+-- mod_normB_full_spec_within to avoid statement let-chains in callers.
+-- ============================================================================
+
+/-- Postcondition after the NormB block (21 instructions): shift, antiShift,
+    and the four normalized limbs b'[0..3] written to memory. -/
+@[irreducible]
+def normBFullPost (sp b0 b1 b2 b3 shift antiShift : Word) : Assertion :=
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+  let b0' := b0 <<< (shift.toNat % 64)
+  (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b0') ** (.x7 ↦ᵣ (b0 >>> (antiShift.toNat % 64))) **
+  (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
+  ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
+  ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3')
+
+theorem normBFullPost_unfold {sp b0 b1 b2 b3 shift antiShift : Word} :
+    normBFullPost sp b0 b1 b2 b3 shift antiShift =
+      (let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+       let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+       let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+       let b0' := b0 <<< (shift.toNat % 64)
+       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b0') ** (.x7 ↦ᵣ (b0 >>> (antiShift.toNat % 64))) **
+       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
+       ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
+       ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3')) := by
+  delta normBFullPost; rfl
+
+-- ============================================================================
 -- `se12_32`/`se12_40`/`se12_48`/`se12_56` were deleted by issue #493 / #494:
 -- they now live canonically in `Rv64/AddrNorm.lean` as part of the
 -- `rv64_addr` grindset. Consumers should `open EvmAsm.Rv64.AddrNorm

--- a/EvmAsm/Evm64/DivMod/Compose/FullPath.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPath.lean
@@ -169,7 +169,7 @@ theorem evm_div_n4_to_normB_spec (sp base : Word)
   have hNB := divK_normB_full_spec_within sp b0 b1 b2 b3
     (clzResult b3).2 ((clzResult b3).2 >>> (63 : Nat))
     shift antiShift base
-  intro_lets at hNB
+  simp only [normBFullPost_unfold] at hNB
   -- Frame NormB with x10, x0, and non-b[] memory
   have hNBf := cpsTripleWithin_frameR
     ((.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -231,7 +231,7 @@ theorem evm_div_n4_to_normB_spec_noNop (sp base : Word)
   have hNB := divK_normB_full_spec_within_noNop sp b0 b1 b2 b3
     (clzResult b3).2 ((clzResult b3).2 >>> (63 : Nat))
     shift antiShift base
-  intro_lets at hNB
+  simp only [normBFullPost_unfold] at hNB
   have hNBf := cpsTripleWithin_frameR
     ((.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
      ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1.lean
@@ -150,7 +150,7 @@ theorem evm_div_n1_to_loopSetup_spec_within (sp base : Word)
   have hNB := divK_normB_full_spec_within sp b0 b1 b2 b3
     (clzResult b0).2 ((clzResult b0).2 >>> (63 : Nat))
     shift antiShift base
-  intro_lets at hNB
+  simp only [normBFullPost_unfold] at hNB
   have hNBf := cpsTripleWithin_frameR
     ((.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
      (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1NoNop.lean
@@ -205,7 +205,7 @@ theorem evm_div_phaseAB_n1_clz_c2_normB_spec_within_noNop (sp base : Word)
   have hNB := divK_normB_full_spec_within_noNop sp b0 b1 b2 b3
     (clzResult b0).2 ((clzResult b0).2 >>> (63 : Nat))
     shift antiShift base
-  intro_lets at hNB
+  simp only [normBFullPost_unfold] at hNB
   have hNBf := cpsTripleWithin_frameR
     ((.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
      ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2.lean
@@ -181,7 +181,7 @@ theorem evm_div_n2_to_normB_spec_within_noNop (sp base : Word)
   have hNB := divK_normB_full_spec_within_noNop sp b0 b1 b2 b3
     (clzResult b1).2 ((clzResult b1).2 >>> (63 : Nat))
     shift antiShift base
-  intro_lets at hNB
+  simp only [normBFullPost_unfold] at hNB
   have hNBf := cpsTripleWithin_frameR
     ((.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
      ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
@@ -360,7 +360,7 @@ theorem evm_div_n2_to_loopSetup_spec_within (sp base : Word)
   have hNB := divK_normB_full_spec_within sp b0 b1 b2 b3
     (clzResult b1).2 ((clzResult b1).2 >>> (63 : Nat))
     shift antiShift base
-  intro_lets at hNB
+  simp only [normBFullPost_unfold] at hNB
   have hNBf := cpsTripleWithin_frameR
     ((.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
      (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3.lean
@@ -181,7 +181,7 @@ theorem evm_div_n3_to_normB_spec_within_noNop (sp base : Word)
   have hNB := divK_normB_full_spec_within_noNop sp b0 b1 b2 b3
     (clzResult b2).2 ((clzResult b2).2 >>> (63 : Nat))
     shift antiShift base
-  intro_lets at hNB
+  simp only [normBFullPost_unfold] at hNB
   have hNBf := cpsTripleWithin_frameR
     ((.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
      ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
@@ -360,7 +360,7 @@ theorem evm_div_n3_to_loopSetup_spec_within (sp base : Word)
   have hNB := divK_normB_full_spec_within sp b0 b1 b2 b3
     (clzResult b2).2 ((clzResult b2).2 >>> (63 : Nat))
     shift antiShift base
-  intro_lets at hNB
+  simp only [normBFullPost_unfold] at hNB
   have hNBf := cpsTripleWithin_frameR
     ((.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
      (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **

--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPath.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPath.lean
@@ -152,7 +152,7 @@ theorem evm_mod_n4_to_normB_spec_within (sp base : Word)
   have hNB := mod_normB_full_spec_within sp b0 b1 b2 b3
     (clzResult b3).2 ((clzResult b3).2 >>> (63 : Nat))
     shift antiShift base
-  intro_lets at hNB
+  simp only [normBFullPost_unfold] at hNB
   have hNBf := cpsTripleWithin_frameR
     ((.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
      ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **

--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPathN1.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPathN1.lean
@@ -158,7 +158,7 @@ theorem evm_mod_n1_to_loopSetup_spec_within (sp base : Word)
   have hNB := mod_normB_full_spec_within sp b0 b1 b2 b3
     (clzResult b0).2 ((clzResult b0).2 >>> (63 : Nat))
     shift antiShift base
-  intro_lets at hNB
+  simp only [normBFullPost_unfold] at hNB
   have hNBf := cpsTripleWithin_frameR
     ((.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
      (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **

--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPathN2.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPathN2.lean
@@ -161,7 +161,7 @@ theorem evm_mod_n2_to_loopSetup_spec_within (sp base : Word)
   have hNB := mod_normB_full_spec_within sp b0 b1 b2 b3
     (clzResult b1).2 ((clzResult b1).2 >>> (63 : Nat))
     shift antiShift base
-  intro_lets at hNB
+  simp only [normBFullPost_unfold] at hNB
   have hNBf := cpsTripleWithin_frameR
     ((.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
      (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **

--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPathN3.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPathN3.lean
@@ -161,7 +161,7 @@ theorem evm_mod_n3_to_loopSetup_spec_within (sp base : Word)
   have hNB := mod_normB_full_spec_within sp b0 b1 b2 b3
     (clzResult b2).2 ((clzResult b2).2 >>> (63 : Nat))
     shift antiShift base
-  intro_lets at hNB
+  simp only [normBFullPost_unfold] at hNB
   have hNBf := cpsTripleWithin_frameR
     ((.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
      (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **

--- a/EvmAsm/Evm64/DivMod/Compose/ModNorm.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModNorm.lean
@@ -220,20 +220,17 @@ private theorem mod_normB_half2 (sp b0 b1 b2' b3' shift antiShift : Word) (base 
     base+228 -> base+312 (21 instructions).
     MOD mirror of divK_normB_full_spec_within. -/
 theorem mod_normB_full_spec_within (sp b0 b1 b2 b3 v5 v7 shift antiShift : Word) (base : Word) :
-    let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
-    let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
-    let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
-    let b0' := b0 <<< (shift.toNat % 64)
     cpsTripleWithin 21 (base + normBOff) (base + normAOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) **
        (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
        ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3))
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b0') ** (.x7 ↦ᵣ (b0 >>> (antiShift.toNat % 64))) **
-       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
-       ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
-       ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3')) := by
-  intro b3' b2' b1' b0'
+      (normBFullPost sp b0 b1 b2 b3 shift antiShift) := by
+  rw [normBFullPost_unfold]
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+  let b0' := b0 <<< (shift.toNat % 64)
   have h1 := mod_normB_half1 sp b0 b1 b2 b3 v5 v7 shift antiShift base
   have h2 := mod_normB_half2 sp b0 b1 b2' b3' shift antiShift base
   exact cpsTripleWithin_weaken

--- a/EvmAsm/Evm64/DivMod/Compose/Norm.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Norm.lean
@@ -299,20 +299,17 @@ private theorem divK_normB_half2_within (sp b0 b1 b2' b3' shift antiShift : Word
     h34
 
 theorem divK_normB_full_spec_within (sp b0 b1 b2 b3 v5 v7 shift antiShift : Word) (base : Word) :
-    let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
-    let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
-    let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
-    let b0' := b0 <<< (shift.toNat % 64)
     cpsTripleWithin 21 (base + normBOff) (base + normAOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) **
        (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
        ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3))
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b0') ** (.x7 ↦ᵣ (b0 >>> (antiShift.toNat % 64))) **
-       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
-       ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
-       ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3')) := by
-  intro b3' b2' b1' b0'
+      (normBFullPost sp b0 b1 b2 b3 shift antiShift) := by
+  rw [normBFullPost_unfold]
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+  let b0' := b0 <<< (shift.toNat % 64)
   have h1 := divK_normB_half1_within sp b0 b1 b2 b3 v5 v7 shift antiShift base
   have h2 := divK_normB_half2_within sp b0 b1 b2' b3' shift antiShift base
   exact cpsTripleWithin_weaken
@@ -411,20 +408,17 @@ private theorem divK_normB_half2_within_noNop
 
 theorem divK_normB_full_spec_within_noNop
     (sp b0 b1 b2 b3 v5 v7 shift antiShift : Word) (base : Word) :
-    let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
-    let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
-    let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
-    let b0' := b0 <<< (shift.toNat % 64)
     cpsTripleWithin 21 (base + normBOff) (base + normAOff) (divCode_noNop base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) **
        (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
        ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3))
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b0') ** (.x7 ↦ᵣ (b0 >>> (antiShift.toNat % 64))) **
-       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
-       ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
-       ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3')) := by
-  intro b3' b2' b1' b0'
+      (normBFullPost sp b0 b1 b2 b3 shift antiShift) := by
+  rw [normBFullPost_unfold]
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+  let b0' := b0 <<< (shift.toNat % 64)
   have h1 := divK_normB_half1_within_noNop sp b0 b1 b2 b3 v5 v7 shift antiShift base
   have h2 := divK_normB_half2_within_noNop sp b0 b1 b2' b3' shift antiShift base
   exact cpsTripleWithin_weaken


### PR DESCRIPTION
## Summary
- Adds `@[irreducible] def normBFullPost` to `Base.lean`, bundling the 4-let normB postcondition (b3', b2', b1', b0')
- Removes 4 statement lets from `divK_normB_full_spec_within`, `divK_normB_full_spec_within_noNop` (`Norm.lean`), and `mod_normB_full_spec_within` (`ModNorm.lean`)
- Updates 12 callers across FullPath*, ModFullPath* to use `simp only [normBFullPost_unfold]` instead of `intro_lets`

Refs #35. Bead: evm-asm-yz73p.

## Verification
- `lake build EvmAsm.Evm64.DivMod.Compose.Norm`
- `lake build EvmAsm.Evm64.DivMod.Compose.ModNorm`
- `scripts/check-file-size.sh`
- `rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" ...` (no matches)
- `lake build` (1948 jobs, green)

Authored by @pirapira; implemented by Claude Code