### PR TITLE
chore(divmod): bundle normAFull postcondition, remove 5 lets from normA_full specs

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Base.lean
@@ -1000,6 +1000,41 @@ instance pcFreeInst_normBPost (sp nVal shift b0 b1 b2 b3 : Word) :
     Assertion.PCFree (normBPost sp nVal shift b0 b1 b2 b3) :=
   ⟨pcFree_normBPost⟩
 
+/-- Postcondition for the NormA block: the normalized `u[]`
+    sequence written to scratch slots, with `x5`/`x7`/`x10` holding the
+    top-of-the-shift intermediate values. Wrapped `@[irreducible]` so that
+    downstream proofs do not re-reduce the 15-atom sepConj. -/
+@[irreducible]
+def normAFullPost (sp a0 a1 a2 a3 shift antiShift : Word) : Assertion :=
+  let u4 := a3 >>> (antiShift.toNat % 64)
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
+  let u0 := a0 <<< (shift.toNat % 64)
+  (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ u1) ** (.x7 ↦ᵣ u0) ** (.x10 ↦ᵣ (a0 >>> (antiShift.toNat % 64))) **
+  (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
+  ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+  ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+  ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4032) ↦ₘ u3) **
+  ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4048) ↦ₘ u1) **
+  ((sp + signExtend12 4056) ↦ₘ u0)
+
+theorem normAFullPost_unfold {sp a0 a1 a2 a3 shift antiShift : Word} :
+    normAFullPost sp a0 a1 a2 a3 shift antiShift =
+      (let u4 := a3 >>> (antiShift.toNat % 64)
+       let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+       let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+       let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
+       let u0 := a0 <<< (shift.toNat % 64)
+       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ u1) ** (.x7 ↦ᵣ u0) ** (.x10 ↦ᵣ (a0 >>> (antiShift.toNat % 64))) **
+       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4032) ↦ₘ u3) **
+       ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4048) ↦ₘ u1) **
+       ((sp + signExtend12 4056) ↦ₘ u0)) := by
+  delta normAFullPost; rfl
+
 -- ============================================================================
 -- `se12_32`/`se12_40`/`se12_48`/`se12_56` were deleted by issue #493 / #494:
 -- they now live canonically in `Rv64/AddrNorm.lean` as part of the

--- a/EvmAsm/Evm64/DivMod/Compose/FullPath.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPath.lean
@@ -305,7 +305,7 @@ theorem evm_div_n4_to_loopSetup_spec (sp base : Word)
   have hNormA := divK_normA_full_spec_within sp a0 a1 a2 a3
     b0' (b0 >>> (antiShift.toNat % 64)) b3 shift antiShift
     u0Old u1Old u2Old u3Old u4Old base
-  intro_lets at hNormA
+  simp only [normAFullPost_unfold] at hNormA
   -- Frame NormA with x0, b[], scratch q/u5-7/n/shift
   have hNormAf := cpsTripleWithin_frameR
     ((.x0 ↦ᵣ (0 : Word)) **
@@ -400,8 +400,8 @@ theorem evm_div_n4_to_loopSetup_spec_noNop (sp base : Word)
   have hNormA := divK_normA_full_spec_within_noNop sp a0 a1 a2 a3
     b0' (b0 >>> (antiShift.toNat % 64)) b3 shift antiShift
     u0Old u1Old u2Old u3Old u4Old base
-  intro_lets at hNormA
-  rw [divKNormAFullPreNoNop_unfold, divKNormAFullPostNoNop_unfold] at hNormA
+  rw [divKNormAFullPreNoNop_unfold] at hNormA
+  simp only [normAFullPost_unfold] at hNormA
   have hNormAf := cpsTripleWithin_frameR
     ((.x0 ↦ᵣ (0 : Word)) **
      (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1.lean
@@ -171,7 +171,7 @@ theorem evm_div_n1_to_loopSetup_spec_within (sp base : Word)
   have hNormA := divK_normA_full_spec_within sp a0 a1 a2 a3
     b0' (b0 >>> (antiShift.toNat % 64)) b3 shift antiShift
     u0Old u1Old u2Old u3Old u4Old base
-  intro_lets at hNormA
+  simp only [normAFullPost_unfold] at hNormA
   have hNormAf := cpsTripleWithin_frameR
     ((.x0 ↦ᵣ (0 : Word)) **
      (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1NoNop.lean
@@ -271,8 +271,8 @@ theorem evm_div_n1_to_loopSetup_spec_within_noNop (sp base : Word)
   have hNormA := divK_normA_full_spec_within_noNop sp a0 a1 a2 a3
     b0' (b0 >>> (antiShift.toNat % 64)) b3 shift antiShift
     u0Old u1Old u2Old u3Old u4Old base
-  intro_lets at hNormA
-  rw [divKNormAFullPreNoNop_unfold, divKNormAFullPostNoNop_unfold] at hNormA
+  rw [divKNormAFullPreNoNop_unfold] at hNormA
+  simp only [normAFullPost_unfold] at hNormA
   have hNormAf := cpsTripleWithin_frameR
     ((.x0 ↦ᵣ (0 : Word)) **
      (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2.lean
@@ -244,8 +244,8 @@ theorem evm_div_n2_to_loopSetup_spec_within_noNop (sp base : Word)
   have hNormA := divK_normA_full_spec_within_noNop sp a0 a1 a2 a3
     b0' (b0 >>> (antiShift.toNat % 64)) b3 shift antiShift
     u0Old u1Old u2Old u3Old u4Old base
-  intro_lets at hNormA
-  rw [divKNormAFullPreNoNop_unfold, divKNormAFullPostNoNop_unfold] at hNormA
+  rw [divKNormAFullPreNoNop_unfold] at hNormA
+  simp only [normAFullPost_unfold] at hNormA
   have hNormAf := cpsTripleWithin_frameR
     ((.x0 ↦ᵣ (0 : Word)) **
      (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
@@ -381,7 +381,7 @@ theorem evm_div_n2_to_loopSetup_spec_within (sp base : Word)
   have hNormA := divK_normA_full_spec_within sp a0 a1 a2 a3
     b0' (b0 >>> (antiShift.toNat % 64)) b3 shift antiShift
     u0Old u1Old u2Old u3Old u4Old base
-  intro_lets at hNormA
+  simp only [normAFullPost_unfold] at hNormA
   have hNormAf := cpsTripleWithin_frameR
     ((.x0 ↦ᵣ (0 : Word)) **
      (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3.lean
@@ -244,8 +244,8 @@ theorem evm_div_n3_to_loopSetup_spec_within_noNop (sp base : Word)
   have hNormA := divK_normA_full_spec_within_noNop sp a0 a1 a2 a3
     b0' (b0 >>> (antiShift.toNat % 64)) b3 shift antiShift
     u0Old u1Old u2Old u3Old u4Old base
-  intro_lets at hNormA
-  rw [divKNormAFullPreNoNop_unfold, divKNormAFullPostNoNop_unfold] at hNormA
+  rw [divKNormAFullPreNoNop_unfold] at hNormA
+  simp only [normAFullPost_unfold] at hNormA
   have hNormAf := cpsTripleWithin_frameR
     ((.x0 ↦ᵣ (0 : Word)) **
      (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
@@ -381,7 +381,7 @@ theorem evm_div_n3_to_loopSetup_spec_within (sp base : Word)
   have hNormA := divK_normA_full_spec_within sp a0 a1 a2 a3
     b0' (b0 >>> (antiShift.toNat % 64)) b3 shift antiShift
     u0Old u1Old u2Old u3Old u4Old base
-  intro_lets at hNormA
+  simp only [normAFullPost_unfold] at hNormA
   have hNormAf := cpsTripleWithin_frameR
     ((.x0 ↦ᵣ (0 : Word)) **
      (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **

--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPath.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPath.lean
@@ -218,7 +218,7 @@ theorem evm_mod_n4_to_loopSetup_spec_within (sp base : Word)
   have hNormA := mod_normA_full_spec_within sp a0 a1 a2 a3
     b0' (b0 >>> (antiShift.toNat % 64)) b3 shift antiShift
     u0Old u1Old u2Old u3Old u4Old base
-  intro_lets at hNormA
+  simp only [normAFullPost_unfold] at hNormA
   have hNormAf := cpsTripleWithin_frameR
     ((.x0 ↦ᵣ (0 : Word)) **
      (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **

--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPathN1.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPathN1.lean
@@ -179,7 +179,7 @@ theorem evm_mod_n1_to_loopSetup_spec_within (sp base : Word)
   have hNormA := mod_normA_full_spec_within sp a0 a1 a2 a3
     b0' (b0 >>> (antiShift.toNat % 64)) b3 shift antiShift
     u0Old u1Old u2Old u3Old u4Old base
-  intro_lets at hNormA
+  simp only [normAFullPost_unfold] at hNormA
   have hNormAf := cpsTripleWithin_frameR
     ((.x0 ↦ᵣ (0 : Word)) **
      (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **

--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPathN2.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPathN2.lean
@@ -182,7 +182,7 @@ theorem evm_mod_n2_to_loopSetup_spec_within (sp base : Word)
   have hNormA := mod_normA_full_spec_within sp a0 a1 a2 a3
     b0' (b0 >>> (antiShift.toNat % 64)) b3 shift antiShift
     u0Old u1Old u2Old u3Old u4Old base
-  intro_lets at hNormA
+  simp only [normAFullPost_unfold] at hNormA
   have hNormAf := cpsTripleWithin_frameR
     ((.x0 ↦ᵣ (0 : Word)) **
      (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **

--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPathN3.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPathN3.lean
@@ -182,7 +182,7 @@ theorem evm_mod_n3_to_loopSetup_spec_within (sp base : Word)
   have hNormA := mod_normA_full_spec_within sp a0 a1 a2 a3
     b0' (b0 >>> (antiShift.toNat % 64)) b3 shift antiShift
     u0Old u1Old u2Old u3Old u4Old base
-  intro_lets at hNormA
+  simp only [normAFullPost_unfold] at hNormA
   have hNormAf := cpsTripleWithin_frameR
     ((.x0 ↦ᵣ (0 : Word)) **
      (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **

--- a/EvmAsm/Evm64/DivMod/Compose/ModNormA.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModNormA.lean
@@ -36,11 +36,6 @@ private theorem divK_normA_code_sub_modCode {base : Word} :
     MOD mirror of divK_normA_full_spec_within. -/
 theorem mod_normA_full_spec_within (sp a0 a1 a2 a3 v5 v7 v10 shift antiShift : Word)
     (u0Old u1Old u2Old u3Old u4Old : Word) (base : Word) :
-    let u4 := a3 >>> (antiShift.toNat % 64)
-    let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
-    let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
-    let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
-    let u0 := a0 <<< (shift.toNat % 64)
     cpsTripleWithin 21 (base + normAOff) (base + loopSetupOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) ** (.x10 ↦ᵣ v10) **
        (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
@@ -49,14 +44,13 @@ theorem mod_normA_full_spec_within (sp a0 a1 a2 a3 v5 v7 v10 shift antiShift : W
        ((sp + signExtend12 4024) ↦ₘ u4Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
        ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
        ((sp + signExtend12 4056) ↦ₘ u0Old))
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ u1) ** (.x7 ↦ᵣ u0) ** (.x10 ↦ᵣ (a0 >>> (antiShift.toNat % 64))) **
-       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
-       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
-       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
-       ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4032) ↦ₘ u3) **
-       ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4048) ↦ₘ u1) **
-       ((sp + signExtend12 4056) ↦ₘ u0)) := by
-  intro u4 u3 u2 u1 u0
+      (normAFullPost sp a0 a1 a2 a3 shift antiShift) := by
+  rw [normAFullPost_unfold]
+  let u4 := a3 >>> (antiShift.toNat % 64)
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
+  let u0 := a0 <<< (shift.toNat % 64)
   -- Top: LD a[3], SRL->u[4], SD u[4] (base+312 -> base+324)
   have htop := divK_normA_top_spec_within 24 4024 sp a3 v5 v7 antiShift u4Old (base + normAOff)
   simp only [signExtend12_24] at htop

--- a/EvmAsm/Evm64/DivMod/Compose/NormA.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/NormA.lean
@@ -43,11 +43,6 @@ open EvmAsm.Rv64.AddrNorm (bv64_4mul_3)
     u[4] = a[3]>>>antiShift, u[3..0] = merged shifted limbs. -/
 theorem divK_normA_full_spec_within (sp a0 a1 a2 a3 v5 v7 v10 shift antiShift : Word)
     (u0Old u1Old u2Old u3Old u4Old : Word) (base : Word) :
-    let u4 := a3 >>> (antiShift.toNat % 64)
-    let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
-    let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
-    let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
-    let u0 := a0 <<< (shift.toNat % 64)
     cpsTripleWithin 21 (base + normAOff) (base + loopSetupOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) ** (.x10 ↦ᵣ v10) **
        (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
@@ -56,14 +51,13 @@ theorem divK_normA_full_spec_within (sp a0 a1 a2 a3 v5 v7 v10 shift antiShift : 
        ((sp + signExtend12 4024) ↦ₘ u4Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
        ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
        ((sp + signExtend12 4056) ↦ₘ u0Old))
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ u1) ** (.x7 ↦ᵣ u0) ** (.x10 ↦ᵣ (a0 >>> (antiShift.toNat % 64))) **
-       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
-       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
-       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
-       ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4032) ↦ₘ u3) **
-       ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4048) ↦ₘ u1) **
-       ((sp + signExtend12 4056) ↦ₘ u0)) := by
-  intro u4 u3 u2 u1 u0
+      (normAFullPost sp a0 a1 a2 a3 shift antiShift) := by
+  rw [normAFullPost_unfold]
+  let u4 := a3 >>> (antiShift.toNat % 64)
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
+  let u0 := a0 <<< (shift.toNat % 64)
   -- Top: LD a[3], SRL→u[4], SD u[4] (base+312 → base+324)
   have htop := divK_normA_top_spec_within 24 4024 sp a3 v5 v7 antiShift u4Old (base + normAOff)
   simp only [se12_24] at htop
@@ -243,17 +237,16 @@ theorem divKNormAFullPostNoNop_unfold
 
 theorem divK_normA_full_spec_within_noNop (sp a0 a1 a2 a3 v5 v7 v10 shift antiShift : Word)
     (u0Old u1Old u2Old u3Old u4Old : Word) (base : Word) :
-    let u4 := a3 >>> (antiShift.toNat % 64)
-    let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
-    let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
-    let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
-    let u0 := a0 <<< (shift.toNat % 64)
     cpsTripleWithin 21 (base + normAOff) (base + loopSetupOff) (divCode_noNop base)
       (divKNormAFullPreNoNop sp v5 v7 v10 shift antiShift
         a0 a1 a2 a3 u0Old u1Old u2Old u3Old u4Old)
-      (divKNormAFullPostNoNop sp shift antiShift a0 a1 a2 a3 u0 u1 u2 u3 u4) := by
-  intro u4 u3 u2 u1 u0
-  rw [divKNormAFullPreNoNop_unfold, divKNormAFullPostNoNop_unfold]
+      (normAFullPost sp a0 a1 a2 a3 shift antiShift) := by
+  rw [divKNormAFullPreNoNop_unfold, normAFullPost_unfold]
+  let u4 := a3 >>> (antiShift.toNat % 64)
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
+  let u0 := a0 <<< (shift.toNat % 64)
   have htop := divK_normA_top_spec_within 24 4024 sp a3 v5 v7 antiShift u4Old (base + normAOff)
   simp only [se12_24] at htop
   have htope := cpsTripleWithin_extend_code (hmono := fun a i h =>


### PR DESCRIPTION
## Summary
- Adds `@[irreducible] def normAFullPost` to `Base.lean`, bundling the 5-let normA postcondition (u4, u3, u2, u1, u0)
- Removes 5 statement lets from `divK_normA_full_spec_within`, `divK_normA_full_spec_within_noNop` (`NormA.lean`), and `mod_normA_full_spec_within` (`ModNormA.lean`)
- Updates 12 callers across FullPath*, ModFullPath* to use `simp only [normAFullPost_unfold]` instead of `intro_lets`

Refs #35. Bead: evm-asm-yz73p.

## Verification
- `lake build EvmAsm.Evm64.DivMod.Compose.NormA`
- `lake build EvmAsm.Evm64.DivMod.Compose.ModNormA`
- `scripts/check-file-size.sh`
- `rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" ...` (no matches)
- `lake build` (1948 jobs, green)

Authored by @pirapira; implemented by Claude Code