### PR TITLE
chore(divmod): move n4McaNamed880Post forward, use it in sharedDivModCode named_880 variant

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopBody/CorrectionAddbackBeq.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody/CorrectionAddbackBeq.lean
@@ -101,6 +101,7 @@ theorem divK_mulsub_correction_addback_beq_spec_within
     -- Use named 880 spec (→880 with addbackN4_carry in postcondition)
     have MCA_N := (divK_mulsub_correction_addback_named_880_spec_within sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
       v1Old v5Old v6Old v7Old v10Old v2Old base) hborrow
+    simp only [n4McaNamed880Post_unfold] at MCA_N
     -- Rewrite carry to 0
     rw [show addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3 = (0 : Word) from hcarry] at MCA_N
     -- Use named DA spec (880→884 with addbackN4 projections in postcondition)

--- a/EvmAsm/Evm64/DivMod/LoopBody/MulsubCorrectionAddback.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody/MulsubCorrectionAddback.lean
@@ -278,46 +278,8 @@ theorem divK_mulsub_correction_addback_880_spec_within_noNop
     MSCA
 
 
-/-- Mulsub + correction addback (→880), named postcondition variant.
-    Uses addbackN4/addbackN4_carry in postcondition for rewritability. -/
-theorem divK_mulsub_correction_addback_named_880_spec_within
-    (sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
-    (v1Old v5Old v6Old v7Old v10Old v2Old : Word)
-    (base : Word) :
-    let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
-    let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
-    let c3 := ms.2.2.2.2
-    let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
-    let qHat' := qHat + signExtend12 4095
-    -- Hypothesis: borrow ≠ 0
-    (if BitVec.ult uTop c3 then (1 : Word) else 0) ≠ (0 : Word) →
-    cpsTripleWithin 91 (base + div128CallRetOff) (base + addbackBeqOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
-       (.x1 ↦ᵣ v1Old) ** (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x2 ↦ᵣ v2Old) **
-       (.x0 ↦ᵣ 0) **
-       (sp + signExtend12 3976 ↦ₘ j) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-       ((uBase + signExtend12 4064) ↦ₘ uTop))
-      ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat') **
-       (.x1 ↦ᵣ j) ** (.x5 ↦ᵣ ab.2.2.2.2) ** (.x6 ↦ᵣ uBase) **
-       (.x7 ↦ᵣ addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ ab.2.2.2.1) **
-       (.x0 ↦ᵣ 0) **
-       (sp + signExtend12 3976 ↦ₘ j) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ ab.1) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ ab.2.1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ ab.2.2.1) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ ab.2.2.2.1) **
-       ((uBase + signExtend12 4064) ↦ₘ ab.2.2.2.2)) := by
-  intro uBase ms c3 ab qHat' hborrow
-  exact (divK_mulsub_correction_addback_880_spec_within sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    v1Old v5Old v6Old v7Old v10Old v2Old base) hborrow
-
-/-- Bundled postcondition for `divK_mulsub_correction_addback_named_880_spec_within_noNop`.
-    Hides `ms`, `c3`, `ab`, and `qHat'` so the spec statement keeps only one
+/-- Bundled postcondition for the named 880 correction addback variants.
+    Hides `ms`, `c3`, `ab`, and `qHat'` so spec statements keep only one
     let (`uBase`) for the precondition's address calculations. -/
 @[irreducible]
 def n4McaNamed880Post
@@ -359,6 +321,35 @@ theorem n4McaNamed880Post_unfold
        ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ ab.2.2.2.1) **
        ((uBase + signExtend12 4064) ↦ₘ ab.2.2.2.2)) := by
   delta n4McaNamed880Post; rfl
+
+/-- Mulsub + correction addback (→880), named postcondition variant.
+    Uses addbackN4/addbackN4_carry in postcondition for rewritability. -/
+theorem divK_mulsub_correction_addback_named_880_spec_within
+    (sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+    (v1Old v5Old v6Old v7Old v10Old v2Old : Word)
+    (base : Word) :
+    let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+    -- Hypothesis: borrow ≠ 0
+    (if BitVec.ult uTop (mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2 then (1 : Word) else 0) ≠
+      (0 : Word) →
+    cpsTripleWithin 91 (base + div128CallRetOff) (base + addbackBeqOff) (sharedDivModCode base)
+      ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+       (.x1 ↦ᵣ v1Old) ** (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x2 ↦ᵣ v2Old) **
+       (.x0 ↦ᵣ 0) **
+       (sp + signExtend12 3976 ↦ₘ j) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop))
+      (n4McaNamed880Post sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro uBase hborrow
+  exact cpsTripleWithin_weaken
+    (fun h hp => hp)
+    (fun h hp => by simp only [n4McaNamed880Post_unfold]; exact hp)
+    ((divK_mulsub_correction_addback_880_spec_within sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
+       v1Old v5Old v6Old v7Old v10Old v2Old base) hborrow)
 
 /-- No-NOP variant of `divK_mulsub_correction_addback_named_880_spec_within`.
     The statement keeps one let (`uBase`, needed for the precondition addresses);


### PR DESCRIPTION
## Summary
- Moves `n4McaNamed880Post` + `n4McaNamed880Post_unfold` before the `divK_mulsub_correction_addback_named_880_spec_within` theorem (it was defined after, causing forward-reference issues)
- Updates `divK_mulsub_correction_addback_named_880_spec_within` (sharedDivModCode variant) to use `n4McaNamed880Post` in its postcondition, reducing 5 statement-level lets to 1, matching the existing `noNop` variant pattern
- Adds `simp only [n4McaNamed880Post_unfold]` to the `CorrectionAddbackBeq.lean` caller to unfold the bundle before using `rw`

Bead: evm-asm-yz73p.

## Verification
- lake build EvmAsm.Evm64.DivMod.LoopBody.MulsubCorrectionAddback
- lake build EvmAsm.Evm64.DivMod.LoopBody.CorrectionAddbackBeq
- scripts/check-file-size.sh
- rg -n "sorry|admit" EvmAsm/Evm64/DivMod/LoopBody/MulsubCorrectionAddback.lean
- lake build

Authored by @pirapira; implemented by Claude Code