### PR TITLE
chore(divmod): bundle LoopIterN4 call-skip/addback-beq j0 specs (25→0 lets)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4Beq.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4Beq.lean
@@ -88,17 +88,18 @@ theorem divK_loop_body_n4_call_addback_j0_beq_norm_noNop (sp base : Word)
        (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (loopBodyN4CallAddbackBeqJ0Post sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  have raw := divK_loop_body_n4_call_addback_j0_beq_spec_within_noNop
-    sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
-    v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0
-    base halign hbltu hcarry2_nz
-  have raw' := raw hborrow
-  simp only [se12_32, se12_40, se12_48, se12_56,
-             u_base_off0_j0, u_base_off4088_j0, u_base_off4080_j0,
-             u_base_off4072_j0, u_base_off4064_j0, q_addr_j0] at raw'
-  exact cpsTripleWithin_weaken (fun _ hp => hp)
-    (fun _ hq => by rw [loopBodyN4CallAddbackBeqJ0Post_unfold]; exact hq)
-    (cpsTripleWithin_mono_nSteps (by decide) raw')
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by
+      rw [loopBodyN4CallSkipJ0Pre_unfold]
+      simp only [se12_32, se12_40, se12_48, se12_56,
+                 u_base_off0_j0, u_base_off4088_j0, u_base_off4080_j0,
+                 u_base_off4072_j0, u_base_off4064_j0, q_addr_j0]
+      exact hp)
+    (fun _ hq => hq)
+    (cpsTripleWithin_mono_nSteps (by decide)
+      (divK_loop_body_n4_call_addback_j0_beq_spec_within_noNop_bundled sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0
+        base halign hbltu hcarry2_nz hborrow))
 
 /-- Addback condition at n=4 with max trial quotient: borrow ≠ 0. Complement
     of `isSkipBorrowN4Max` — the mulsub underflowed so the algorithm needs

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4Loop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4Loop.lean
@@ -239,87 +239,9 @@ theorem divK_loop_body_n4_max_skip_j0_norm_modCode_within (sp base : Word)
 
 -- ============================================================================
 -- Call path: bundled pre/post for j=0 extended to divCode/modCode.
--- ============================================================================
-
-/-- Bundled precondition for the call_skip j=0 loop body.
-    Wraps the 25-atom sepConj chain (registers + scratch memory cells) plus
-    the `let`-bound `uBase` and `qAddr` offsets. Marked `@[irreducible]` so
-    the offsets don't pollute callers' types. -/
-@[irreducible]
-def loopBodyN4CallSkipJ0Pre
-    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
-     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
-     retMem dMem dloMem scratch_un0 : Word) : Assertion :=
-  let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
-  let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
-  (.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
-  (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-  (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-  (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-  (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
-  ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-  ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
-  ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-  ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-  ((uBase + signExtend12 4064) ↦ₘ uTop) **
-  (qAddr ↦ₘ qOld) **
-  (sp + signExtend12 3968 ↦ₘ retMem) **
-  (sp + signExtend12 3960 ↦ₘ dMem) **
-  (sp + signExtend12 3952 ↦ₘ dloMem) **
-  (sp + signExtend12 3944 ↦ₘ scratch_un0)
-
-/-- Named unfold for `loopBodyN4CallSkipJ0Pre`. -/
-theorem loopBodyN4CallSkipJ0Pre_unfold
-    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
-     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
-     retMem dMem dloMem scratch_un0 : Word) :
-    loopBodyN4CallSkipJ0Pre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 =
-    (let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
-     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
-     (.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
-     (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-     (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-     (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-     (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-     ((uBase + signExtend12 4064) ↦ₘ uTop) **
-     (qAddr ↦ₘ qOld) **
-     (sp + signExtend12 3968 ↦ₘ retMem) **
-     (sp + signExtend12 3960 ↦ₘ dMem) **
-     (sp + signExtend12 3952 ↦ₘ dloMem) **
-     (sp + signExtend12 3944 ↦ₘ scratch_un0)) := by
-  delta loopBodyN4CallSkipJ0Pre; rfl
-
-/-- Bundled postcondition for the call_skip j=0 loop body. -/
-@[irreducible]
-def loopBodyN4CallSkipJ0Post (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
-    Assertion :=
-  let qHat := div128Quot uTop u3 v3
-  let dLo := (v3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-  let div_un0 := (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-  loopBodyN4SkipPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
-  (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
-  (sp + signExtend12 3960 ↦ₘ v3) **
-  (sp + signExtend12 3952 ↦ₘ dLo) **
-  (sp + signExtend12 3944 ↦ₘ div_un0)
-
-/-- Named unfold for `loopBodyN4CallSkipJ0Post`. -/
-theorem loopBodyN4CallSkipJ0Post_unfold
-    (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
-    loopBodyN4CallSkipJ0Post sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop =
-    (let qHat := div128Quot uTop u3 v3
-     let dLo := (v3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-     let div_un0 := (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-     loopBodyN4SkipPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
-     (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
-     (sp + signExtend12 3960 ↦ₘ v3) **
-     (sp + signExtend12 3952 ↦ₘ dLo) **
-     (sp + signExtend12 3944 ↦ₘ div_un0)) := by
-  delta loopBodyN4CallSkipJ0Post; rfl
+-- (loopBodyN4CallSkipJ0Pre, loopBodyN4CallSkipJ0Post, and
+--  loopBodyN4CallAddbackBeqJ0Post are defined in LoopIterN4, available
+--  here via the import.)
 
 -- ============================================================================
 -- Call path: Loop body j=0 extended to divCode (from sharedDivModCode)
@@ -341,14 +263,11 @@ theorem divK_loop_body_n4_call_skip_j0_divCode_within
       (loopBodyN4CallSkipJ0Pre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
         v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0)
       (loopBodyN4CallSkipJ0Post sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop) :=
-  cpsTripleWithin_weaken
-    (fun _ hp => by rw [loopBodyN4CallSkipJ0Pre_unfold] at hp; exact hp)
-    (fun _ hq => by rw [loopBodyN4CallSkipJ0Post_unfold]; exact hq)
-    (cpsTripleWithin_extend_code (hmono := sharedDivModCode_sub_divCode)
-      (cpsTripleWithin_mono_nSteps (by decide)
-        (divK_loop_body_n4_call_skip_j0_spec_within sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
-          v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 base
-          halign hbltu hborrow)))
+  cpsTripleWithin_extend_code (hmono := sharedDivModCode_sub_divCode)
+    (cpsTripleWithin_mono_nSteps (by decide)
+      (divK_loop_body_n4_call_skip_j0_spec_within_bundled sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 base
+        halign hbltu hborrow))
 
 /-- Extend call_skip j=0 loop body to `divCode_noNop`.
     Pre/post bundled via `loopBodyN4CallSkipJ0Pre`/`Post`; 0 statement lets. -/
@@ -366,44 +285,14 @@ theorem divK_loop_body_n4_call_skip_j0_divCode_noNop_within
       (loopBodyN4CallSkipJ0Pre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
         v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0)
       (loopBodyN4CallSkipJ0Post sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop) :=
-  cpsTripleWithin_weaken
-    (fun _ hp => by rw [loopBodyN4CallSkipJ0Pre_unfold] at hp; exact hp)
-    (fun _ hq => by rw [loopBodyN4CallSkipJ0Post_unfold]; exact hq)
-    (cpsTripleWithin_mono_nSteps (by decide)
-      (divK_loop_body_n4_call_skip_j0_spec_within_noNop sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
-        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 base
-        halign hbltu hborrow))
+  cpsTripleWithin_mono_nSteps (by decide)
+    (divK_loop_body_n4_call_skip_j0_spec_within_noNop_bundled sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 base
+      halign hbltu hborrow)
 
 -- ============================================================================
 -- _da (double-addback) variants: lift _beq_spec to divCode
 -- ============================================================================
-
-/-- Bundled postcondition for the call_addback (BEQ) j=0 loop body. -/
-@[irreducible]
-def loopBodyN4CallAddbackBeqJ0Post
-    (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Assertion :=
-  let qHat := div128Quot uTop u3 v3
-  let dLo := (v3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-  let div_un0 := (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-  loopBodyN4AddbackBeqPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
-  (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
-  (sp + signExtend12 3960 ↦ₘ v3) **
-  (sp + signExtend12 3952 ↦ₘ dLo) **
-  (sp + signExtend12 3944 ↦ₘ div_un0)
-
-/-- Named unfold for `loopBodyN4CallAddbackBeqJ0Post`. -/
-theorem loopBodyN4CallAddbackBeqJ0Post_unfold
-    (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
-    loopBodyN4CallAddbackBeqJ0Post sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop =
-    (let qHat := div128Quot uTop u3 v3
-     let dLo := (v3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-     let div_un0 := (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-     loopBodyN4AddbackBeqPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
-     (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
-     (sp + signExtend12 3960 ↦ₘ v3) **
-     (sp + signExtend12 3952 ↦ₘ dLo) **
-     (sp + signExtend12 3944 ↦ₘ div_un0)) := by
-  delta loopBodyN4CallAddbackBeqJ0Post; rfl
 
 /-- Extend call_addback (BEQ double-addback) j=0 loop body from sharedDivModCode to divCode.
     Pre/post bundled; 0 statement lets. -/
@@ -422,14 +311,11 @@ theorem divK_loop_body_n4_call_addback_j0_beq_divCode_within
       (loopBodyN4CallSkipJ0Pre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
         v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0)
       (loopBodyN4CallAddbackBeqJ0Post sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop) :=
-  cpsTripleWithin_weaken
-    (fun _ hp => by rw [loopBodyN4CallSkipJ0Pre_unfold] at hp; exact hp)
-    (fun _ hq => by rw [loopBodyN4CallAddbackBeqJ0Post_unfold]; exact hq)
-    (cpsTripleWithin_extend_code (hmono := sharedDivModCode_sub_divCode)
-      (cpsTripleWithin_mono_nSteps (by decide)
-        (divK_loop_body_n4_call_addback_j0_beq_spec_within sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
-          v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 base
-          halign hbltu hcarry2_nz hborrow)))
+  cpsTripleWithin_extend_code (hmono := sharedDivModCode_sub_divCode)
+    (cpsTripleWithin_mono_nSteps (by decide)
+      (divK_loop_body_n4_call_addback_j0_beq_spec_within_bundled sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 base
+        halign hbltu hcarry2_nz hborrow))
 
 -- ============================================================================
 -- Call path: Loop body j=0 extended to modCode (from sharedDivModCode)
@@ -455,20 +341,11 @@ theorem divK_loop_body_n4_call_skip_j0_modCode_within
     cpsTripleWithin 126 (base + loopBodyOff) (base + denormOff) (modCode base)
       (loopBodyN4CallSkipJ0Pre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
         v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0)
-      (loopBodyN4CallSkipJ0Post sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  -- Apply the underlying spec (which has the algorithm's let-chain unfolded)
-  have h := cpsTripleWithin_extend_code (hmono := sharedDivModCode_sub_modCode)
-    (divK_loop_body_n4_call_skip_j0_spec_within sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      (loopBodyN4CallSkipJ0Post sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop) :=
+  cpsTripleWithin_extend_code (hmono := sharedDivModCode_sub_modCode)
+    (divK_loop_body_n4_call_skip_j0_spec_within_bundled sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 base
       halign hbltu hborrow)
-  -- Bridge bundled pre/post to the underlying unbundled forms
-  refine cpsTripleWithin_weaken ?_ ?_ h
-  · intro _ hp
-    rw [loopBodyN4CallSkipJ0Pre_unfold] at hp
-    exact hp
-  · intro _ hq
-    rw [loopBodyN4CallSkipJ0Post_unfold]
-    exact hq
 
 /-- Call_skip j=0 loop body against modCode with sp-relative addresses
     in the precondition. Mirror of `divK_loop_body_n4_call_skip_j0_norm`
@@ -538,18 +415,11 @@ theorem divK_loop_body_n4_call_addback_j0_beq_modCode_within
     cpsTripleWithin 202 (base + loopBodyOff) (base + denormOff) (modCode base)
       (loopBodyN4CallSkipJ0Pre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
         v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0)
-      (loopBodyN4CallAddbackBeqJ0Post sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  have h := cpsTripleWithin_extend_code (hmono := sharedDivModCode_sub_modCode)
-    (divK_loop_body_n4_call_addback_j0_beq_spec_within sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      (loopBodyN4CallAddbackBeqJ0Post sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop) :=
+  cpsTripleWithin_extend_code (hmono := sharedDivModCode_sub_modCode)
+    (divK_loop_body_n4_call_addback_j0_beq_spec_within_bundled sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 base
       halign hbltu hcarry2_nz hborrow)
-  refine cpsTripleWithin_weaken ?_ ?_ h
-  · intro _ hp
-    rw [loopBodyN4CallSkipJ0Pre_unfold] at hp
-    exact hp
-  · intro _ hq
-    rw [loopBodyN4CallAddbackBeqJ0Post_unfold]
-    exact hq
 
 /-- Call_addback (BEQ) j=0 loop body against modCode with sp-relative
     addresses in the precondition. -/

--- a/EvmAsm/Evm64/DivMod/LoopIterN4.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN4.lean
@@ -214,7 +214,7 @@ theorem divK_loop_body_n4_max_skip_j0_spec_within_noNop
 set_option maxRecDepth 4096 in
 /-- Loop body cpsTripleWithin for n=4, call+skip, j=0.
     Since j=0, the BGE loop-back is not taken, giving a cpsTripleWithin to base+904. -/
-theorem divK_loop_body_n4_call_skip_j0_spec_within
+private theorem divK_loop_body_n4_call_skip_j0_spec_within
     (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
     (retMem dMem dloMem scratch_un0 : Word)
@@ -351,7 +351,7 @@ theorem divK_loop_body_n4_call_skip_j0_spec_within
     full
 
 /-- No-NOP variant of `divK_loop_body_n4_call_skip_j0_spec_within`. -/
-theorem divK_loop_body_n4_call_skip_j0_spec_within_noNop
+private theorem divK_loop_body_n4_call_skip_j0_spec_within_noNop
     (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
     (retMem dMem dloMem scratch_un0 : Word)
@@ -487,7 +487,7 @@ set_option maxRecDepth 4096 in
 /-- Loop body cpsTripleWithin for n=4, call+addback (beq variant), j=0.
     Uses the beq_spec which handles both carry=0 and carry≠0 internally,
     eliminating the sorry for aco3 ≠ 0. -/
-theorem divK_loop_body_n4_call_addback_j0_beq_spec_within
+private theorem divK_loop_body_n4_call_addback_j0_beq_spec_within
     (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
     (retMem dMem dloMem scratch_un0 : Word)
@@ -622,7 +622,7 @@ theorem divK_loop_body_n4_call_addback_j0_beq_spec_within
     full
 
 /-- No-NOP variant of `divK_loop_body_n4_call_addback_j0_beq_spec_within`. -/
-theorem divK_loop_body_n4_call_addback_j0_beq_spec_within_noNop
+private theorem divK_loop_body_n4_call_addback_j0_beq_spec_within_noNop
     (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
     (retMem dMem dloMem scratch_un0 : Word)
@@ -745,5 +745,220 @@ theorem divK_loop_body_n4_call_addback_j0_beq_spec_within_noNop
     (fun h hp => by delta loopBodyN4AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN4 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full
 
+
+-- ============================================================================
+-- Bundled pre/post for call-path j=0 specs
+-- (Defined here so public wrappers below and FullPathN4Loop can share them.)
+-- ============================================================================
+
+/-- Bundled precondition for the call_skip / call_addback j=0 loop body.
+    Wraps the 25-atom sepConj chain (registers + scratch memory cells) plus
+    the `let`-bound `uBase` and `qAddr` offsets. Marked `@[irreducible]` so
+    the offsets don't pollute callers' types. -/
+@[irreducible]
+def loopBodyN4CallSkipJ0Pre
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
+     retMem dMem dloMem scratch_un0 : Word) : Assertion :=
+  let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
+  (.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+  (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+  (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
+  (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
+  (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
+  ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+  ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+  ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+  ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+  ((uBase + signExtend12 4064) ↦ₘ uTop) **
+  (qAddr ↦ₘ qOld) **
+  (sp + signExtend12 3968 ↦ₘ retMem) **
+  (sp + signExtend12 3960 ↦ₘ dMem) **
+  (sp + signExtend12 3952 ↦ₘ dloMem) **
+  (sp + signExtend12 3944 ↦ₘ scratch_un0)
+
+/-- Named unfold for `loopBodyN4CallSkipJ0Pre`. -/
+theorem loopBodyN4CallSkipJ0Pre_unfold
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
+     retMem dMem dloMem scratch_un0 : Word) :
+    loopBodyN4CallSkipJ0Pre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 =
+    (let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
+     (.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+     (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+     (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
+     (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
+     (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((uBase + signExtend12 4064) ↦ₘ uTop) **
+     (qAddr ↦ₘ qOld) **
+     (sp + signExtend12 3968 ↦ₘ retMem) **
+     (sp + signExtend12 3960 ↦ₘ dMem) **
+     (sp + signExtend12 3952 ↦ₘ dloMem) **
+     (sp + signExtend12 3944 ↦ₘ scratch_un0)) := by
+  delta loopBodyN4CallSkipJ0Pre; rfl
+
+/-- Bundled postcondition for the call_skip j=0 loop body. -/
+@[irreducible]
+def loopBodyN4CallSkipJ0Post (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
+    Assertion :=
+  let qHat := div128Quot uTop u3 v3
+  let dLo := (v3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  let div_un0 := (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  loopBodyN4SkipPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+  (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+  (sp + signExtend12 3960 ↦ₘ v3) **
+  (sp + signExtend12 3952 ↦ₘ dLo) **
+  (sp + signExtend12 3944 ↦ₘ div_un0)
+
+/-- Named unfold for `loopBodyN4CallSkipJ0Post`. -/
+theorem loopBodyN4CallSkipJ0Post_unfold
+    (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
+    loopBodyN4CallSkipJ0Post sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop =
+    (let qHat := div128Quot uTop u3 v3
+     let dLo := (v3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+     let div_un0 := (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+     loopBodyN4SkipPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+     (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+     (sp + signExtend12 3960 ↦ₘ v3) **
+     (sp + signExtend12 3952 ↦ₘ dLo) **
+     (sp + signExtend12 3944 ↦ₘ div_un0)) := by
+  delta loopBodyN4CallSkipJ0Post; rfl
+
+/-- Bundled postcondition for the call_addback (BEQ) j=0 loop body. -/
+@[irreducible]
+def loopBodyN4CallAddbackBeqJ0Post
+    (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Assertion :=
+  let qHat := div128Quot uTop u3 v3
+  let dLo := (v3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  let div_un0 := (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  loopBodyN4AddbackBeqPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+  (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+  (sp + signExtend12 3960 ↦ₘ v3) **
+  (sp + signExtend12 3952 ↦ₘ dLo) **
+  (sp + signExtend12 3944 ↦ₘ div_un0)
+
+/-- Named unfold for `loopBodyN4CallAddbackBeqJ0Post`. -/
+theorem loopBodyN4CallAddbackBeqJ0Post_unfold
+    (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
+    loopBodyN4CallAddbackBeqJ0Post sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop =
+    (let qHat := div128Quot uTop u3 v3
+     let dLo := (v3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+     let div_un0 := (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+     loopBodyN4AddbackBeqPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+     (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+     (sp + signExtend12 3960 ↦ₘ v3) **
+     (sp + signExtend12 3952 ↦ₘ dLo) **
+     (sp + signExtend12 3944 ↦ₘ div_un0)) := by
+  delta loopBodyN4CallAddbackBeqJ0Post; rfl
+
+-- ============================================================================
+-- Public bundle-using wrappers for the 4 call-path j=0 specs
+-- These have 0 statement-level let bindings.
+-- ============================================================================
+
+set_option maxRecDepth 4096 in
+/-- Bundled-pre/post version of `divK_loop_body_n4_call_skip_j0_spec_within`.
+    0 statement-level let bindings. -/
+theorem divK_loop_body_n4_call_skip_j0_spec_within_bundled
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : BitVec.ult uTop v3)
+    (hborrow : (if BitVec.ult uTop
+                  (mulsubN4_c3 (div128Quot uTop u3 v3) v0 v1 v2 v3 u0 u1 u2 u3)
+                then (1 : Word) else 0) = (0 : Word)) :
+    cpsTripleWithin 126 (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
+      (loopBodyN4CallSkipJ0Pre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0)
+      (loopBodyN4CallSkipJ0Post sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop) :=
+  cpsTripleWithin_weaken
+    (fun _ hp => by rw [loopBodyN4CallSkipJ0Pre_unfold] at hp; exact hp)
+    (fun _ hq => by rw [loopBodyN4CallSkipJ0Post_unfold]; exact hq)
+    (divK_loop_body_n4_call_skip_j0_spec_within sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 base
+      halign hbltu hborrow)
+
+set_option maxRecDepth 4096 in
+/-- Bundled-pre/post version of `divK_loop_body_n4_call_skip_j0_spec_within_noNop`.
+    0 statement-level let bindings. -/
+theorem divK_loop_body_n4_call_skip_j0_spec_within_noNop_bundled
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : BitVec.ult uTop v3)
+    (hborrow : (if BitVec.ult uTop
+                  (mulsubN4_c3 (div128Quot uTop u3 v3) v0 v1 v2 v3 u0 u1 u2 u3)
+                then (1 : Word) else 0) = (0 : Word)) :
+    cpsTripleWithin 126 (base + loopBodyOff) (base + denormOff) (divCode_noNop base)
+      (loopBodyN4CallSkipJ0Pre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0)
+      (loopBodyN4CallSkipJ0Post sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop) :=
+  cpsTripleWithin_weaken
+    (fun _ hp => by rw [loopBodyN4CallSkipJ0Pre_unfold] at hp; exact hp)
+    (fun _ hq => by rw [loopBodyN4CallSkipJ0Post_unfold]; exact hq)
+    (divK_loop_body_n4_call_skip_j0_spec_within_noNop sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 base
+      halign hbltu hborrow)
+
+set_option maxRecDepth 4096 in
+/-- Bundled-pre/post version of `divK_loop_body_n4_call_addback_j0_beq_spec_within`.
+    0 statement-level let bindings. -/
+theorem divK_loop_body_n4_call_addback_j0_beq_spec_within_bundled
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : BitVec.ult uTop v3)
+    (hcarry2_nz : isAddbackCarry2NzN4Call v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hborrow : (if BitVec.ult uTop
+                  (mulsubN4_c3 (div128Quot uTop u3 v3) v0 v1 v2 v3 u0 u1 u2 u3)
+                then (1 : Word) else 0) ≠ (0 : Word)) :
+    cpsTripleWithin 202 (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
+      (loopBodyN4CallSkipJ0Pre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0)
+      (loopBodyN4CallAddbackBeqJ0Post sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop) :=
+  cpsTripleWithin_weaken
+    (fun _ hp => by rw [loopBodyN4CallSkipJ0Pre_unfold] at hp; exact hp)
+    (fun _ hq => by rw [loopBodyN4CallAddbackBeqJ0Post_unfold]; exact hq)
+    (divK_loop_body_n4_call_addback_j0_beq_spec_within sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 base
+      halign hbltu hcarry2_nz hborrow)
+
+set_option maxRecDepth 4096 in
+/-- Bundled-pre/post version of `divK_loop_body_n4_call_addback_j0_beq_spec_within_noNop`.
+    0 statement-level let bindings. -/
+theorem divK_loop_body_n4_call_addback_j0_beq_spec_within_noNop_bundled
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : BitVec.ult uTop v3)
+    (hcarry2_nz : isAddbackCarry2NzN4Call v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hborrow : (if BitVec.ult uTop
+                  (mulsubN4_c3 (div128Quot uTop u3 v3) v0 v1 v2 v3 u0 u1 u2 u3)
+                then (1 : Word) else 0) ≠ (0 : Word)) :
+    cpsTripleWithin 202 (base + loopBodyOff) (base + denormOff) (divCode_noNop base)
+      (loopBodyN4CallSkipJ0Pre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0)
+      (loopBodyN4CallAddbackBeqJ0Post sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop) :=
+  cpsTripleWithin_weaken
+    (fun _ hp => by rw [loopBodyN4CallSkipJ0Pre_unfold] at hp; exact hp)
+    (fun _ hq => by rw [loopBodyN4CallAddbackBeqJ0Post_unfold]; exact hq)
+    (divK_loop_body_n4_call_addback_j0_beq_spec_within_noNop sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 base
+      halign hbltu hcarry2_nz hborrow)
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Moves bundle defs (`loopBodyN4CallSkipJ0Pre/Post`, `loopBodyN4CallAddbackBeqJ0Post`) from `FullPathN4Loop.lean` into `LoopIterN4.lean` (earlier in the import chain)
- Adds 4 bundled 0-let public wrapper theorems with `_bundled` suffix, delegating to the private 25-let implementations via `cpsTripleWithin_weaken`
- Makes the original 25-let theorems `private` (they were the only 25-let specs in the file, reducing public API exposure)
- Updates callers in `FullPathN4Loop.lean` (4 wrappers) and `FullPathN4Beq.lean` (1 caller) to use the bundled variants

Before: `LoopIterN4.lean` had 4 public theorems × 25 statement-level `let` bindings = 100 lets  
After: 0 statement-level lets in the public interface

Bead: evm-asm-yz73p.

## Verification
- lake build EvmAsm.Evm64.DivMod.LoopIterN4
- lake build EvmAsm.Evm64.DivMod.Compose.FullPathN4Loop
- scripts/check-file-size.sh
- rg -n "sorry|admit" EvmAsm/Evm64/DivMod/LoopIterN4.lean
- lake build

Authored by @pirapira; implemented by Claude Code