### PR TITLE
chore(divmod): bundle double-addback BEQ spec into n4DoubleAddbackNamedPost

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopBody.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody.lean
@@ -1304,7 +1304,7 @@ private theorem lb_beq_back_taken {base : Word} :
     then falls through to base+884.
     Entry: base+880 (after first addback), x7 = 0.
     Exit: base+884 (store entry), with double-addback results. -/
-theorem divK_double_addback_beq_spec_within
+private theorem divK_double_addback_beq_spec_within
     (sp uBase qHat' v0 v1 v2 v3 aun0 aun1 aun2 aun3 aun4 : Word)
     (base : Word)
     (hcarry2_nz : addbackN4_carry aun0 aun1 aun2 aun3 v0 v1 v2 v3 ≠ 0) :
@@ -1406,12 +1406,43 @@ theorem divK_double_addback_beq_spec_within
     (fun h hp => by xperm_hyp hp)
     full
 
+/-- Bundled postcondition for `divK_double_addback_beq_named_spec_within`.
+    Hides `ab'` and `qHat''` so the spec statement is flat. -/
+@[irreducible]
+def n4DoubleAddbackNamedPost
+    (sp uBase qHat' v0 v1 v2 v3 aun0 aun1 aun2 aun3 aun4 : Word) : Assertion :=
+  let ab'   := addbackN4 aun0 aun1 aun2 aun3 aun4 v0 v1 v2 v3
+  let qHat'' := qHat' + signExtend12 4095
+  (.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ uBase) **
+  (.x7 ↦ᵣ addbackN4_carry aun0 aun1 aun2 aun3 v0 v1 v2 v3) **
+  (.x11 ↦ᵣ qHat'') ** (.x5 ↦ᵣ ab'.2.2.2.2) ** (.x2 ↦ᵣ ab'.2.2.2.1) **
+  (.x0 ↦ᵣ (0 : Word)) **
+  ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ ab'.1) **
+  ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ ab'.2.1) **
+  ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ ab'.2.2.1) **
+  ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ ab'.2.2.2.1) **
+  ((uBase + signExtend12 4064) ↦ₘ ab'.2.2.2.2)
+
+theorem n4DoubleAddbackNamedPost_unfold
+    {sp uBase qHat' v0 v1 v2 v3 aun0 aun1 aun2 aun3 aun4 : Word} :
+    n4DoubleAddbackNamedPost sp uBase qHat' v0 v1 v2 v3 aun0 aun1 aun2 aun3 aun4 =
+      (let ab'   := addbackN4 aun0 aun1 aun2 aun3 aun4 v0 v1 v2 v3
+       let qHat'' := qHat' + signExtend12 4095
+       (.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ uBase) **
+       (.x7 ↦ᵣ addbackN4_carry aun0 aun1 aun2 aun3 v0 v1 v2 v3) **
+       (.x11 ↦ᵣ qHat'') ** (.x5 ↦ᵣ ab'.2.2.2.2) ** (.x2 ↦ᵣ ab'.2.2.2.1) **
+       (.x0 ↦ᵣ (0 : Word)) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ ab'.1) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ ab'.2.1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ ab'.2.2.1) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ ab'.2.2.2.1) **
+       ((uBase + signExtend12 4064) ↦ₘ ab'.2.2.2.2)) := by
+  delta n4DoubleAddbackNamedPost; rfl
+
 theorem divK_double_addback_beq_named_spec_within
     (sp uBase qHat' v0 v1 v2 v3 aun0 aun1 aun2 aun3 aun4 : Word)
     (base : Word)
     (hcarry2_nz : addbackN4_carry aun0 aun1 aun2 aun3 v0 v1 v2 v3 ≠ 0) :
-    let ab' := addbackN4 aun0 aun1 aun2 aun3 aun4 v0 v1 v2 v3
-    let qHat'' := qHat' + signExtend12 4095
     cpsTripleWithin 39 (base + addbackBeqOff) (base + storeLoopOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ uBase) ** (.x7 ↦ᵣ (0 : Word)) **
        (.x11 ↦ᵣ qHat') ** (.x5 ↦ᵣ aun4) ** (.x2 ↦ᵣ aun3) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -1420,16 +1451,11 @@ theorem divK_double_addback_beq_named_spec_within
        ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ aun2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ aun3) **
        ((uBase + signExtend12 4064) ↦ₘ aun4))
-      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ uBase) **
-       (.x7 ↦ᵣ addbackN4_carry aun0 aun1 aun2 aun3 v0 v1 v2 v3) **
-       (.x11 ↦ᵣ qHat'') ** (.x5 ↦ᵣ ab'.2.2.2.2) ** (.x2 ↦ᵣ ab'.2.2.2.1) ** (.x0 ↦ᵣ (0 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ ab'.1) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ ab'.2.1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ ab'.2.2.1) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ ab'.2.2.2.1) **
-       ((uBase + signExtend12 4064) ↦ₘ ab'.2.2.2.2)) := by
-  intro ab' qHat''
-  exact divK_double_addback_beq_spec_within sp uBase qHat' v0 v1 v2 v3 aun0 aun1 aun2 aun3 aun4
-    base hcarry2_nz
+      (n4DoubleAddbackNamedPost sp uBase qHat' v0 v1 v2 v3 aun0 aun1 aun2 aun3 aun4) := by
+  exact cpsTripleWithin_weaken
+    (fun h hp => hp)
+    (fun h hp => by simp only [n4DoubleAddbackNamedPost_unfold]; exact hp)
+    (divK_double_addback_beq_spec_within sp uBase qHat' v0 v1 v2 v3 aun0 aun1 aun2 aun3 aun4
+      base hcarry2_nz)
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LoopBody/CorrectionAddbackBeq.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody/CorrectionAddbackBeq.lean
@@ -111,6 +111,7 @@ theorem divK_mulsub_correction_addback_beq_spec_within
       (qHat + signExtend12 4095) v0 v1 v2 v3
       ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2
       base hcarry2
+    simp only [n4DoubleAddbackNamedPost_unfold] at DA
     -- Frame DA with extra atoms from MCA_N postcondition
     have DAf := cpsTripleWithin_frameR
       ((.x1 ↦ᵣ j) ** (.x10 ↦ᵣ c3) **

--- a/EvmAsm/Evm64/DivMod/LoopBody/DoubleAddbackBeq.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody/DoubleAddbackBeq.lean
@@ -14,7 +14,7 @@ private theorem lb_double_addback_beq_taken {base : Word} :
   rv64_addr
 
 /-- No-NOP variant of `divK_double_addback_beq_spec_within`. -/
-theorem divK_double_addback_beq_spec_within_noNop
+private theorem divK_double_addback_beq_spec_within_noNop
     (sp uBase qHat' v0 v1 v2 v3 aun0 aun1 aun2 aun3 aun4 : Word)
     (base : Word)
     (hcarry2_nz : addbackN4_carry aun0 aun1 aun2 aun3 v0 v1 v2 v3 ≠ 0) :
@@ -116,39 +116,8 @@ theorem divK_double_addback_beq_spec_within_noNop
     (fun h hp => by xperm_hyp hp)
     full
 
-/-- Bundled postcondition for the no-NOP named double-addback BEQ spec.
-    Hides `ab'` (the `addbackN4` result tuple) and `qHat''` (the bumped
-    trial quotient) so the spec statement is flat. -/
-@[irreducible]
-def n4DoubleAddbackNamedPost
-    (sp uBase qHat' v0 v1 v2 v3 aun0 aun1 aun2 aun3 aun4 : Word) : Assertion :=
-  let ab'   := addbackN4 aun0 aun1 aun2 aun3 aun4 v0 v1 v2 v3
-  let qHat'' := qHat' + signExtend12 4095
-  (.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ uBase) **
-  (.x7 ↦ᵣ addbackN4_carry aun0 aun1 aun2 aun3 v0 v1 v2 v3) **
-  (.x11 ↦ᵣ qHat'') ** (.x5 ↦ᵣ ab'.2.2.2.2) ** (.x2 ↦ᵣ ab'.2.2.2.1) **
-  (.x0 ↦ᵣ (0 : Word)) **
-  ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ ab'.1) **
-  ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ ab'.2.1) **
-  ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ ab'.2.2.1) **
-  ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ ab'.2.2.2.1) **
-  ((uBase + signExtend12 4064) ↦ₘ ab'.2.2.2.2)
-
-theorem n4DoubleAddbackNamedPost_unfold
-    {sp uBase qHat' v0 v1 v2 v3 aun0 aun1 aun2 aun3 aun4 : Word} :
-    n4DoubleAddbackNamedPost sp uBase qHat' v0 v1 v2 v3 aun0 aun1 aun2 aun3 aun4 =
-      (let ab'   := addbackN4 aun0 aun1 aun2 aun3 aun4 v0 v1 v2 v3
-       let qHat'' := qHat' + signExtend12 4095
-       (.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ uBase) **
-       (.x7 ↦ᵣ addbackN4_carry aun0 aun1 aun2 aun3 v0 v1 v2 v3) **
-       (.x11 ↦ᵣ qHat'') ** (.x5 ↦ᵣ ab'.2.2.2.2) ** (.x2 ↦ᵣ ab'.2.2.2.1) **
-       (.x0 ↦ᵣ (0 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ ab'.1) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ ab'.2.1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ ab'.2.2.1) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ ab'.2.2.2.1) **
-       ((uBase + signExtend12 4064) ↦ₘ ab'.2.2.2.2)) := by
-  delta n4DoubleAddbackNamedPost; rfl
+-- n4DoubleAddbackNamedPost and n4DoubleAddbackNamedPost_unfold are now in
+-- EvmAsm.Evm64.DivMod.LoopBody (the parent module) and visible here via import.
 
 /-- Named-postcondition no-NOP wrapper for `divK_double_addback_beq_spec_within_noNop`.
     The statement is flat: `ab'` and `qHat''` are hidden in `n4DoubleAddbackNamedPost`. -/


### PR DESCRIPTION
## Summary
- Moves `n4DoubleAddbackNamedPost`/`_unfold` from `DoubleAddbackBeq.lean` to `LoopBody.lean` so both sharedDivModCode and noNop variants can use it
- Updates `divK_double_addback_beq_named_spec_within` (sharedDivModCode) to use `n4DoubleAddbackNamedPost`, reducing 2 statement-level `let` bindings to 0 (matching the existing noNop pattern)
- Makes the 22-let `_spec_within` (sharedDivModCode, in `LoopBody.lean`) and `_spec_within_noNop` (in `DoubleAddbackBeq.lean`) private since they are only internal implementation details with no external callers
- Adds `simp only [n4DoubleAddbackNamedPost_unfold] at DA` in `CorrectionAddbackBeq.lean` sharedDivModCode path to match the existing noNop path pattern (PR #4535 established this pattern)

Bead: evm-asm-yz73p.

## Verification
- lake build EvmAsm.Evm64.DivMod.LoopBody
- lake build EvmAsm.Evm64.DivMod.LoopBody.DoubleAddbackBeq
- lake build EvmAsm.Evm64.DivMod.LoopBody.CorrectionAddbackBeq
- scripts/check-file-size.sh
- lake build

Authored by @pirapira; implemented by Claude Code