### PR TITLE
chore(divmod): privatize addback-full specs, add named bundled wrappers (22→0 lets)

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopBody.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody.lean
@@ -407,7 +407,7 @@ set_option maxRecDepth 4096 in
 /-- Full add-back correction: init carry + 4 limb corrections + final u[j+4] adjust + qHat--.
     37 instructions, loop body indices [71]-[107].
     Entry: base+732, Exit: base+880, CodeReq: sharedDivModCode base. -/
-theorem divK_addback_full_spec_within
+private theorem divK_addback_full_spec_within
     (sp uBase qHat v0 v1 v2 v3 u0 u1 u2 u3 u4 : Word)
     (v7_init v5_init v2_init : Word)
     (base : Word) :
@@ -551,7 +551,7 @@ theorem divK_addback_full_spec_within
     IfA0eA1eA2eA3eAFe
 
 /-- `divK_addback_full_spec_within` replayed over the DIV no-NOP code surface. -/
-theorem divK_addback_full_spec_within_noNop
+private theorem divK_addback_full_spec_within_noNop
     (sp uBase qHat v0 v1 v2 v3 u0 u1 u2 u3 u4 : Word)
     (v7_init v5_init v2_init : Word)
     (base : Word) :
@@ -694,6 +694,45 @@ theorem divK_addback_full_spec_within_noNop
     (fun h hq => by xperm_hyp hq)
     IfA0eA1eA2eA3eAFe
 
+/-- Named-postcondition wrapper for `divK_addback_full_spec_within`.
+    Bundles the 22-let result into `addbackFullPost`; 0 statement lets. -/
+theorem divK_addback_full_named_spec_within
+    (sp uBase qHat v0 v1 v2 v3 u0 u1 u2 u3 u4 : Word)
+    (v7_init v5_init v2_init : Word)
+    (base : Word) :
+    cpsTripleWithin 37 (base + addbackInitOff) (base + addbackBeqOff) (sharedDivModCode base)
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ uBase) ** (.x7 ↦ᵣ v7_init) **
+       (.x11 ↦ᵣ qHat) ** (.x5 ↦ᵣ v5_init) ** (.x2 ↦ᵣ v2_init) ** (.x0 ↦ᵣ (0 : Word)) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ u4))
+      (addbackFullPost sp uBase qHat v0 v1 v2 v3 u0 u1 u2 u3 u4) :=
+  cpsTripleWithin_weaken
+    (fun h hp => hp)
+    (fun h hp => by simp only [addbackFullPost_unfold]; exact hp)
+    (divK_addback_full_spec_within sp uBase qHat v0 v1 v2 v3 u0 u1 u2 u3 u4 v7_init v5_init v2_init base)
+
+/-- Named-postcondition no-NOP wrapper for `divK_addback_full_spec_within_noNop`.
+    Bundles the 22-let result into `addbackFullPost`; 0 statement lets. -/
+theorem divK_addback_full_named_spec_within_noNop
+    (sp uBase qHat v0 v1 v2 v3 u0 u1 u2 u3 u4 : Word)
+    (v7_init v5_init v2_init : Word)
+    (base : Word) :
+    cpsTripleWithin 37 (base + addbackInitOff) (base + addbackBeqOff) (divCode_noNop base)
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ uBase) ** (.x7 ↦ᵣ v7_init) **
+       (.x11 ↦ᵣ qHat) ** (.x5 ↦ᵣ v5_init) ** (.x2 ↦ᵣ v2_init) ** (.x0 ↦ᵣ (0 : Word)) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ u4))
+      (addbackFullPost sp uBase qHat v0 v1 v2 v3 u0 u1 u2 u3 u4) :=
+  cpsTripleWithin_weaken
+    (fun h hp => hp)
+    (fun h hp => by simp only [addbackFullPost_unfold]; exact hp)
+    (divK_addback_full_spec_within_noNop sp uBase qHat v0 v1 v2 v3 u0 u1 u2 u3 u4 v7_init v5_init v2_init base)
 
 private theorem lb_ms_setup {base : Word} : (base + div128CallRetOff : Word) + 20 = base + mulsubOff := by bv_addr
 

--- a/EvmAsm/Evm64/DivMod/LoopBody/DoubleAddbackBeq.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody/DoubleAddbackBeq.lean
@@ -74,10 +74,9 @@ private theorem divK_double_addback_beq_spec_within_noNop
       (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hp)
     beq_taken
   -- 2. Second addback (base+732 -> base+880)
-  have AB2 := divK_addback_full_spec_within_noNop sp uBase qHat' v0 v1 v2 v3 aun0 aun1 aun2 aun3 aun4
+  have AB2 := divK_addback_full_named_spec_within_noNop sp uBase qHat' v0 v1 v2 v3 aun0 aun1 aun2 aun3 aun4
     (0 : Word) aun4 aun3 base
-
-  intro_lets at AB2
+  simp only [addbackFullPost_unfold] at AB2
   -- 3. BEQ at [108] not taken (carry2 != 0) -> base+884
   have haco3_nz : aco3' ≠ 0 := by
     unfold addbackN4_carry at hcarry2_nz


### PR DESCRIPTION
## Summary
- Makes `divK_addback_full_spec_within` and `divK_addback_full_spec_within_noNop` private (22 statement-level lets each, no longer part of public API)
- Adds 0-let named wrappers `divK_addback_full_named_spec_within` and `divK_addback_full_named_spec_within_noNop` using `addbackFullPost` bundle (from PR #4534)
- Updates `DoubleAddbackBeq.lean` caller to use the named noNop wrapper + `simp only [addbackFullPost_unfold]`, matching the established pattern from PR #4537

The `_spec_within` variants had no external callers; the `_spec_within_noNop` had one caller (`DoubleAddbackBeq.lean`) which is updated here.

Bead: evm-asm-yz73p.

## Verification
- lake build EvmAsm.Evm64.DivMod.LoopBody
- lake build EvmAsm.Evm64.DivMod.LoopBody.DoubleAddbackBeq
- scripts/check-file-size.sh
- lake build

Authored by @pirapira; implemented by Claude Code