### PR TITLE
chore(divmod): add sharedDivModCode named correction-skip spec (26→2 lets)

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopBody/MulsubCorrectionSkip.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody/MulsubCorrectionSkip.lean
@@ -246,4 +246,34 @@ theorem divK_mulsub_correction_skip_named_spec_within_noNop
     (divK_mulsub_correction_skip_spec_within_noNop sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
       v1Old v5Old v6Old v7Old v10Old v2Old base hborrow)
 
+/-- Named-postcondition sharedDivModCode wrapper for `divK_mulsub_correction_skip_spec_within`.
+    The statement keeps two lets (`uBase`, `c3`); mulsub intermediates are hidden
+    inside `n4McaNamedSkipPost`. Mirror of `divK_mulsub_correction_skip_named_spec_within_noNop`. -/
+theorem divK_mulsub_correction_skip_named_spec_within
+    (sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+    (v1Old v5Old v6Old v7Old v10Old v2Old : Word)
+    (base : Word) :
+    let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+    let c3 := (mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2
+    -- Hypothesis: mulsub borrow = 0
+    (if BitVec.ult uTop c3 then (1 : Word) else 0) = (0 : Word) →
+    cpsTripleWithin 54 (base + div128CallRetOff) (base + storeLoopOff) (sharedDivModCode base)
+      ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+       (.x1 ↦ᵣ v1Old) ** (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x2 ↦ᵣ v2Old) **
+       (.x0 ↦ᵣ 0) **
+       (sp + signExtend12 3976 ↦ₘ j) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop))
+      (n4McaNamedSkipPost sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro uBase c3 hborrow
+  exact cpsTripleWithin_weaken
+    (fun h hp => hp)
+    (fun h hp => by simp only [n4McaNamedSkipPost_unfold]; exact hp)
+    (divK_mulsub_correction_skip_spec_within sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      v1Old v5Old v6Old v7Old v10Old v2Old base hborrow)
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Adds `divK_mulsub_correction_skip_named_spec_within` for the `sharedDivModCode` code surface, mirroring the existing `divK_mulsub_correction_skip_named_spec_within_noNop`
- Reduces 26 statement-level `let` bindings to 2 (`uBase`, `c3`) by using the `n4McaNamedSkipPost` bundle
- Follows the same pattern as PR #4535 (which added the `named_880` sharedDivModCode variant)

The naming asymmetry between noNop (has named variant) and sharedDivModCode (previously had none) is now resolved.

Bead: evm-asm-yz73p.

## Verification
- lake build EvmAsm.Evm64.DivMod.LoopBody.MulsubCorrectionSkip
- scripts/check-file-size.sh
- lake build

Authored by @pirapira; implemented by Claude Code