### PR TITLE
chore(divmod): add mulsubFullPost bundle and named mulsub_full wrappers (35→1 lets)

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -21,6 +21,7 @@ import EvmAsm.Evm64.DivMod.Shift0Dispatcher
 import EvmAsm.Evm64.DivMod.N4StackSpec
 import EvmAsm.Evm64.DivMod.N4StackSpecWithin
 import EvmAsm.Evm64.DivMod.LoopBody.DoubleAddbackBeq
+import EvmAsm.Evm64.DivMod.LoopBody.MulsubFull
 import EvmAsm.Evm64.DivMod.Compose.SharedLoopPost
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1LoopUnified
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN1LoopUnified

--- a/EvmAsm/Evm64/DivMod/LoopBody/MulsubFull.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody/MulsubFull.lean
@@ -1,0 +1,135 @@
+/-
+  EvmAsm.Evm64.DivMod.LoopBody.MulsubFull
+
+  Named-postcondition wrappers for `divK_mulsub_full_spec_within` and
+  `divK_mulsub_full_spec_within_noNop`. These expose the mulsub full
+  spec with 1 statement let (`uBase`) instead of 35, via `mulsubFullPost`.
+-/
+
+import EvmAsm.Evm64.DivMod.LoopBody
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Bundled postcondition for `divK_mulsub_full_spec_within`.
+    Hides the 34 mulsub intermediates plus borrow/u4_new; leaves `uBase`
+    for address calculations in callers. -/
+@[irreducible]
+def mulsubFullPost (sp uBase qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
+    Assertion :=
+  let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
+  let fs0 := p0_lo + (signExtend12 0 : Word)
+  let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
+  let pc0 := ba0 + p0_hi; let bs0 := if BitVec.ult u0 fs0 then (1 : Word) else 0
+  let un0 := u0 - fs0; let c0 := pc0 + bs0
+  let p1_lo := qHat * v1; let p1_hi := rv64_mulhu qHat v1
+  let fs1 := p1_lo + c0; let ba1 := if BitVec.ult fs1 c0 then (1 : Word) else 0
+  let pc1 := ba1 + p1_hi; let bs1 := if BitVec.ult u1 fs1 then (1 : Word) else 0
+  let un1 := u1 - fs1; let c1 := pc1 + bs1
+  let p2_lo := qHat * v2; let p2_hi := rv64_mulhu qHat v2
+  let fs2 := p2_lo + c1; let ba2 := if BitVec.ult fs2 c1 then (1 : Word) else 0
+  let pc2 := ba2 + p2_hi; let bs2 := if BitVec.ult u2 fs2 then (1 : Word) else 0
+  let un2 := u2 - fs2; let c2 := pc2 + bs2
+  let p3_lo := qHat * v3; let p3_hi := rv64_mulhu qHat v3
+  let fs3 := p3_lo + c2; let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
+  let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
+  let un3 := u3 - fs3; let c3 := pc3 + bs3
+  let borrow := if BitVec.ult uTop c3 then (1 : Word) else 0
+  let u4_new := uTop - c3
+  (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+  (.x1 ↦ᵣ j) ** (.x5 ↦ᵣ u4_new) ** (.x6 ↦ᵣ uBase) **
+  (.x7 ↦ᵣ borrow) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
+  (.x0 ↦ᵣ (0 : Word)) **
+  (sp + signExtend12 3976 ↦ₘ j) **
+  ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0) **
+  ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1) **
+  ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2) **
+  ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3) **
+  ((uBase + signExtend12 4064) ↦ₘ u4_new)
+
+theorem mulsubFullPost_unfold {sp uBase qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word} :
+    mulsubFullPost sp uBase qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop =
+      (let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
+       let fs0 := p0_lo + (signExtend12 0 : Word)
+       let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
+       let pc0 := ba0 + p0_hi; let bs0 := if BitVec.ult u0 fs0 then (1 : Word) else 0
+       let un0 := u0 - fs0; let c0 := pc0 + bs0
+       let p1_lo := qHat * v1; let p1_hi := rv64_mulhu qHat v1
+       let fs1 := p1_lo + c0; let ba1 := if BitVec.ult fs1 c0 then (1 : Word) else 0
+       let pc1 := ba1 + p1_hi; let bs1 := if BitVec.ult u1 fs1 then (1 : Word) else 0
+       let un1 := u1 - fs1; let c1 := pc1 + bs1
+       let p2_lo := qHat * v2; let p2_hi := rv64_mulhu qHat v2
+       let fs2 := p2_lo + c1; let ba2 := if BitVec.ult fs2 c1 then (1 : Word) else 0
+       let pc2 := ba2 + p2_hi; let bs2 := if BitVec.ult u2 fs2 then (1 : Word) else 0
+       let un2 := u2 - fs2; let c2 := pc2 + bs2
+       let p3_lo := qHat * v3; let p3_hi := rv64_mulhu qHat v3
+       let fs3 := p3_lo + c2; let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
+       let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
+       let un3 := u3 - fs3; let c3 := pc3 + bs3
+       let borrow := if BitVec.ult uTop c3 then (1 : Word) else 0
+       let u4_new := uTop - c3
+       (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+       (.x1 ↦ᵣ j) ** (.x5 ↦ᵣ u4_new) ** (.x6 ↦ᵣ uBase) **
+       (.x7 ↦ᵣ borrow) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
+       (.x0 ↦ᵣ (0 : Word)) **
+       (sp + signExtend12 3976 ↦ₘ j) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3) **
+       ((uBase + signExtend12 4064) ↦ₘ u4_new)) := by
+  delta mulsubFullPost; rfl
+
+/-- Named-postcondition wrapper for `divK_mulsub_full_spec_within`.
+    1 statement let (`uBase`); 34 mulsub lets are in `mulsubFullPost`. -/
+theorem divK_mulsub_full_named_spec_within
+    (sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+    (v1Old v5Old v6Old v7Old v10Old v2Old : Word)
+    (base : Word) :
+    let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+    cpsTripleWithin 53 (base + div128CallRetOff) (base + correctionSkipBeqOff) (sharedDivModCode base)
+      ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+       (.x1 ↦ᵣ v1Old) ** (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x2 ↦ᵣ v2Old) **
+       (.x0 ↦ᵣ 0) **
+       (sp + signExtend12 3976 ↦ₘ j) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop))
+      (mulsubFullPost sp uBase qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro uBase
+  exact cpsTripleWithin_weaken
+    (fun h hp => hp)
+    (fun h hp => by simp only [mulsubFullPost_unfold]; exact hp)
+    (divK_mulsub_full_spec_within sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      v1Old v5Old v6Old v7Old v10Old v2Old base)
+
+/-- Named-postcondition no-NOP wrapper for `divK_mulsub_full_spec_within_noNop`. -/
+theorem divK_mulsub_full_named_spec_within_noNop
+    (sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+    (v1Old v5Old v6Old v7Old v10Old v2Old : Word)
+    (base : Word) :
+    let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+    cpsTripleWithin 53 (base + div128CallRetOff) (base + correctionSkipBeqOff) (divCode_noNop base)
+      ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+       (.x1 ↦ᵣ v1Old) ** (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x2 ↦ᵣ v2Old) **
+       (.x0 ↦ᵣ 0) **
+       (sp + signExtend12 3976 ↦ₘ j) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop))
+      (mulsubFullPost sp uBase qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro uBase
+  exact cpsTripleWithin_weaken
+    (fun h hp => hp)
+    (fun h hp => by simp only [mulsubFullPost_unfold]; exact hp)
+    (divK_mulsub_full_spec_within_noNop sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      v1Old v5Old v6Old v7Old v10Old v2Old base)
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Adds `EvmAsm/Evm64/DivMod/LoopBody/MulsubFull.lean` with:
  - `mulsubFullPost` `@[irreducible]` bundle + unfold theorem (bundles the 35-let mulsub chain including borrow/u4_new computation)
  - `divK_mulsub_full_named_spec_within` (1 let, sharedDivModCode)
  - `divK_mulsub_full_named_spec_within_noNop` (1 let, divCode_noNop)
- Both wrappers reduce from 35 public statement-level `let` bindings to 1 (`uBase`)
- Created as a separate file to respect the 1500-line cap on `LoopBody.lean`
- Mirrors the pattern established by PRs #4535/#4537/#4540 for other named spec variants

Bead: evm-asm-yz73p.

## Verification
- lake build EvmAsm.Evm64.DivMod.LoopBody.MulsubFull
- scripts/check-file-size.sh
- lake build

Authored by @pirapira; implemented by Claude Code