### PR TITLE
chore(divmod): add 0-let named correction_addback spec wrappers (22→0 lets)

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -22,6 +22,7 @@ import EvmAsm.Evm64.DivMod.N4StackSpec
 import EvmAsm.Evm64.DivMod.N4StackSpecWithin
 import EvmAsm.Evm64.DivMod.LoopBody.DoubleAddbackBeq
 import EvmAsm.Evm64.DivMod.LoopBody.MulsubFull
+import EvmAsm.Evm64.DivMod.LoopBody.CorrectionAddback
 import EvmAsm.Evm64.DivMod.Compose.SharedLoopPost
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1LoopUnified
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN1LoopUnified

--- a/EvmAsm/Evm64/DivMod/LoopBody/CorrectionAddback.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody/CorrectionAddback.lean
@@ -1,0 +1,57 @@
+/-
+  EvmAsm.Evm64.DivMod.LoopBody.CorrectionAddback
+
+  Named-postcondition wrappers for `divK_correction_addback_spec_within` and
+  `divK_correction_addback_spec_within_noNop`. These expose the correction
+  addback spec with 0 statement lets via `addbackFullPost`.
+-/
+
+import EvmAsm.Evm64.DivMod.LoopBody.DoubleAddbackBeq
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Named-postcondition wrapper for `divK_correction_addback_spec_within`.
+    0 statement-level lets; all addback intermediates are in `addbackFullPost`. -/
+theorem divK_correction_addback_named_spec_within
+    (sp uBase borrow qHat v0 v1 v2 v3 u0 u1 u2 u3 u4 : Word)
+    (v5Old v2Old : Word) (base : Word)
+    (hb : borrow ≠ (0 : Word)) :
+    cpsTripleWithin 38 (base + correctionSkipBeqOff) (base + addbackBeqOff) (sharedDivModCode base)
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ uBase) ** (.x7 ↦ᵣ borrow) **
+       (.x11 ↦ᵣ qHat) ** (.x5 ↦ᵣ v5Old) ** (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ u4))
+      (addbackFullPost sp uBase qHat v0 v1 v2 v3 u0 u1 u2 u3 u4) :=
+  cpsTripleWithin_weaken
+    (fun h hp => hp)
+    (fun h hp => by simp only [addbackFullPost_unfold]; exact hp)
+    (divK_correction_addback_spec_within sp uBase borrow qHat v0 v1 v2 v3 u0 u1 u2 u3 u4
+       v5Old v2Old base hb)
+
+/-- Named-postcondition no-NOP wrapper for `divK_correction_addback_spec_within_noNop`.
+    0 statement-level lets; all addback intermediates are in `addbackFullPost`. -/
+theorem divK_correction_addback_named_spec_within_noNop
+    (sp uBase borrow qHat v0 v1 v2 v3 u0 u1 u2 u3 u4 : Word)
+    (v5Old v2Old : Word) (base : Word)
+    (hb : borrow ≠ (0 : Word)) :
+    cpsTripleWithin 38 (base + correctionSkipBeqOff) (base + addbackBeqOff) (divCode_noNop base)
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ uBase) ** (.x7 ↦ᵣ borrow) **
+       (.x11 ↦ᵣ qHat) ** (.x5 ↦ᵣ v5Old) ** (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ u4))
+      (addbackFullPost sp uBase qHat v0 v1 v2 v3 u0 u1 u2 u3 u4) :=
+  cpsTripleWithin_weaken
+    (fun h hp => hp)
+    (fun h hp => by simp only [addbackFullPost_unfold]; exact hp)
+    (divK_correction_addback_spec_within_noNop sp uBase borrow qHat v0 v1 v2 v3 u0 u1 u2 u3 u4
+       v5Old v2Old base hb)
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Adds `EvmAsm/Evm64/DivMod/LoopBody/CorrectionAddback.lean` with:
  - `divK_correction_addback_named_spec_within` (0 statement lets, sharedDivModCode)
  - `divK_correction_addback_named_spec_within_noNop` (0 statement lets, divCode_noNop)
- Both wrappers use `addbackFullPost` to bundle the 22 addback intermediate lets
- `uBase` is a theorem parameter (not a let binding), so the result is 0 statement-level lets
- Mirrors the pattern from PRs #4539 (`divK_addback_full_named_spec_within`) and #4541 (`divK_mulsub_full_named_spec_within`)

Bead: evm-asm-yz73p.

## Verification
- lake build EvmAsm.Evm64.DivMod.LoopBody.CorrectionAddback
- scripts/check-file-size.sh
- lake build

Authored by @pirapira; implemented by Claude Code