### PR TITLE
chore(add,sub,addmod): add stack-level postcondition bundles (22→0 lets)

### DIFF
--- a/EvmAsm/Evm64/Add/Spec.lean
+++ b/EvmAsm/Evm64/Add/Spec.lean
@@ -188,4 +188,74 @@ theorem evm_add_named_spec_within (sp base : Word)
     (fun h hp => by simp only [evmAddLimbPost_unfold]; exact hp)
     (evm_add_spec_within sp base a0 a1 a2 a3 b0 b1 b2 b3 v7 v6 v5 v11)
 
+/-- Bundled postcondition for `evm_add_stack_spec_within` (EvmWord level).
+    Hides all 22 limb-extraction and carry-chain lets. -/
+@[irreducible]
+def evmAddStackPost (sp : Word) (a b : EvmWord) : Assertion :=
+  let a0 := a.getLimbN 0; let b0 := b.getLimbN 0
+  let a1 := a.getLimbN 1; let b1 := b.getLimbN 1
+  let a2 := a.getLimbN 2; let b2 := b.getLimbN 2
+  let a3 := a.getLimbN 3; let b3 := b.getLimbN 3
+  let sum0 := a0 + b0
+  let carry0 := if BitVec.ult sum0 b0 then (1 : Word) else 0
+  let psum1 := a1 + b1
+  let carry1a := if BitVec.ult psum1 b1 then (1 : Word) else 0
+  let result1 := psum1 + carry0
+  let carry1b := if BitVec.ult result1 carry0 then (1 : Word) else 0
+  let carry1 := carry1a ||| carry1b
+  let psum2 := a2 + b2
+  let carry2a := if BitVec.ult psum2 b2 then (1 : Word) else 0
+  let result2 := psum2 + carry1
+  let carry2b := if BitVec.ult result2 carry1 then (1 : Word) else 0
+  let carry2 := carry2a ||| carry2b
+  let psum3 := a3 + b3
+  let carry3a := if BitVec.ult psum3 b3 then (1 : Word) else 0
+  let result3 := psum3 + carry2
+  let carry3b := if BitVec.ult result3 carry2 then (1 : Word) else 0
+  let carry3 := carry3a ||| carry3b
+  (.x12 ↦ᵣ (sp + 32)) ** (.x7 ↦ᵣ result3) ** (.x6 ↦ᵣ carry3b) **
+  (.x5 ↦ᵣ carry3) ** (.x11 ↦ᵣ carry3a) **
+  evmWordIs sp a ** evmWordIs (sp + 32) (a + b)
+
+theorem evmAddStackPost_unfold (sp : Word) (a b : EvmWord) :
+    evmAddStackPost sp a b =
+      (let a0 := a.getLimbN 0; let b0 := b.getLimbN 0
+       let a1 := a.getLimbN 1; let b1 := b.getLimbN 1
+       let a2 := a.getLimbN 2; let b2 := b.getLimbN 2
+       let a3 := a.getLimbN 3; let b3 := b.getLimbN 3
+       let sum0 := a0 + b0
+       let carry0 := if BitVec.ult sum0 b0 then (1 : Word) else 0
+       let psum1 := a1 + b1
+       let carry1a := if BitVec.ult psum1 b1 then (1 : Word) else 0
+       let result1 := psum1 + carry0
+       let carry1b := if BitVec.ult result1 carry0 then (1 : Word) else 0
+       let carry1 := carry1a ||| carry1b
+       let psum2 := a2 + b2
+       let carry2a := if BitVec.ult psum2 b2 then (1 : Word) else 0
+       let result2 := psum2 + carry1
+       let carry2b := if BitVec.ult result2 carry1 then (1 : Word) else 0
+       let carry2 := carry2a ||| carry2b
+       let psum3 := a3 + b3
+       let carry3a := if BitVec.ult psum3 b3 then (1 : Word) else 0
+       let result3 := psum3 + carry2
+       let carry3b := if BitVec.ult result3 carry2 then (1 : Word) else 0
+       let carry3 := carry3a ||| carry3b
+       (.x12 ↦ᵣ (sp + 32)) ** (.x7 ↦ᵣ result3) ** (.x6 ↦ᵣ carry3b) **
+       (.x5 ↦ᵣ carry3) ** (.x11 ↦ᵣ carry3a) **
+       evmWordIs sp a ** evmWordIs (sp + 32) (a + b)) := by
+  delta evmAddStackPost; rfl
+
+/-- Named-postcondition wrapper for `evm_add_stack_spec_within`.
+    0 statement-level lets; postcondition is opaque `evmAddStackPost`. -/
+theorem evm_add_stack_named_spec_within (sp base : Word)
+    (a b : EvmWord) (v7 v6 v5 v11 : Word) :
+    cpsTripleWithin 30 base (base + 120) (evm_add_code base)
+      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7) ** (.x6 ↦ᵣ v6) ** (.x5 ↦ᵣ v5) ** (.x11 ↦ᵣ v11) **
+       evmWordIs sp a ** evmWordIs (sp + 32) b)
+      (evmAddStackPost sp a b) :=
+  cpsTripleWithin_weaken
+    (fun h hp => hp)
+    (fun h hp => by simp only [evmAddStackPost_unfold]; exact hp)
+    (evm_add_stack_spec_within sp base a b v7 v6 v5 v11)
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/AddMod/LimbSpec.lean
+++ b/EvmAsm/Evm64/AddMod/LimbSpec.lean
@@ -104,6 +104,76 @@ theorem evm_addmod_prologue_stack_spec_within (sp base : Word)
   show cpsTripleWithin 30 base (base + 120) (evm_add_code base) _ _
   exact evm_add_stack_spec_within sp base a b v7 v6 v5 v11
 
+/-- Bundled postcondition for `evm_addmod_prologue_stack_spec_within`.
+    Hides all 22 limb-extraction and carry-chain lets. -/
+@[irreducible]
+def evmAddModPrologueStackPost (sp : Word) (a b : EvmWord) : Assertion :=
+  let a0 := a.getLimbN 0; let b0 := b.getLimbN 0
+  let a1 := a.getLimbN 1; let b1 := b.getLimbN 1
+  let a2 := a.getLimbN 2; let b2 := b.getLimbN 2
+  let a3 := a.getLimbN 3; let b3 := b.getLimbN 3
+  let sum0 := a0 + b0
+  let carry0 := if BitVec.ult sum0 b0 then (1 : Word) else 0
+  let psum1 := a1 + b1
+  let carry1a := if BitVec.ult psum1 b1 then (1 : Word) else 0
+  let result1 := psum1 + carry0
+  let carry1b := if BitVec.ult result1 carry0 then (1 : Word) else 0
+  let carry1 := carry1a ||| carry1b
+  let psum2 := a2 + b2
+  let carry2a := if BitVec.ult psum2 b2 then (1 : Word) else 0
+  let result2 := psum2 + carry1
+  let carry2b := if BitVec.ult result2 carry1 then (1 : Word) else 0
+  let carry2 := carry2a ||| carry2b
+  let psum3 := a3 + b3
+  let carry3a := if BitVec.ult psum3 b3 then (1 : Word) else 0
+  let result3 := psum3 + carry2
+  let carry3b := if BitVec.ult result3 carry2 then (1 : Word) else 0
+  let carry3 := carry3a ||| carry3b
+  (.x12 ↦ᵣ (sp + 32)) ** (.x7 ↦ᵣ result3) ** (.x6 ↦ᵣ carry3b) **
+  (.x5 ↦ᵣ carry3) ** (.x11 ↦ᵣ carry3a) **
+  evmWordIs sp a ** evmWordIs (sp + 32) (a + b)
+
+theorem evmAddModPrologueStackPost_unfold (sp : Word) (a b : EvmWord) :
+    evmAddModPrologueStackPost sp a b =
+      (let a0 := a.getLimbN 0; let b0 := b.getLimbN 0
+       let a1 := a.getLimbN 1; let b1 := b.getLimbN 1
+       let a2 := a.getLimbN 2; let b2 := b.getLimbN 2
+       let a3 := a.getLimbN 3; let b3 := b.getLimbN 3
+       let sum0 := a0 + b0
+       let carry0 := if BitVec.ult sum0 b0 then (1 : Word) else 0
+       let psum1 := a1 + b1
+       let carry1a := if BitVec.ult psum1 b1 then (1 : Word) else 0
+       let result1 := psum1 + carry0
+       let carry1b := if BitVec.ult result1 carry0 then (1 : Word) else 0
+       let carry1 := carry1a ||| carry1b
+       let psum2 := a2 + b2
+       let carry2a := if BitVec.ult psum2 b2 then (1 : Word) else 0
+       let result2 := psum2 + carry1
+       let carry2b := if BitVec.ult result2 carry1 then (1 : Word) else 0
+       let carry2 := carry2a ||| carry2b
+       let psum3 := a3 + b3
+       let carry3a := if BitVec.ult psum3 b3 then (1 : Word) else 0
+       let result3 := psum3 + carry2
+       let carry3b := if BitVec.ult result3 carry2 then (1 : Word) else 0
+       let carry3 := carry3a ||| carry3b
+       (.x12 ↦ᵣ (sp + 32)) ** (.x7 ↦ᵣ result3) ** (.x6 ↦ᵣ carry3b) **
+       (.x5 ↦ᵣ carry3) ** (.x11 ↦ᵣ carry3a) **
+       evmWordIs sp a ** evmWordIs (sp + 32) (a + b)) := by
+  delta evmAddModPrologueStackPost; rfl
+
+/-- Named-postcondition wrapper for `evm_addmod_prologue_stack_spec_within`.
+    0 statement-level lets; postcondition is opaque `evmAddModPrologueStackPost`. -/
+theorem evm_addmod_prologue_stack_named_spec_within (sp base : Word)
+    (a b : EvmWord) (v7 v6 v5 v11 : Word) :
+    cpsTripleWithin 30 base (base + 120) (evm_addmod_prologue_code base)
+      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7) ** (.x6 ↦ᵣ v6) ** (.x5 ↦ᵣ v5) ** (.x11 ↦ᵣ v11) **
+       evmWordIs sp a ** evmWordIs (sp + 32) b)
+      (evmAddModPrologueStackPost sp a b) :=
+  cpsTripleWithin_weaken
+    (fun h hp => hp)
+    (fun h hp => by simp only [evmAddModPrologueStackPost_unfold]; exact hp)
+    (evm_addmod_prologue_stack_spec_within sp base a b v7 v6 v5 v11)
+
 -- ============================================================================
 -- evm_addmod_epilogue (1 instruction, slice evm-asm-hsybl toward evm-asm-s7v49)
 -- ============================================================================

--- a/EvmAsm/Evm64/Sub/Spec.lean
+++ b/EvmAsm/Evm64/Sub/Spec.lean
@@ -188,4 +188,74 @@ theorem evm_sub_named_spec_within (sp base : Word)
     (fun h hp => by simp only [evmSubLimbPost_unfold]; exact hp)
     (evm_sub_spec_within sp base a0 a1 a2 a3 b0 b1 b2 b3 v7 v6 v5 v11)
 
+/-- Bundled postcondition for `evm_sub_stack_spec_within` (EvmWord level).
+    Hides all 22 limb-extraction and borrow-chain lets. -/
+@[irreducible]
+def evmSubStackPost (sp : Word) (a b : EvmWord) : Assertion :=
+  let a0 := a.getLimbN 0; let b0 := b.getLimbN 0
+  let a1 := a.getLimbN 1; let b1 := b.getLimbN 1
+  let a2 := a.getLimbN 2; let b2 := b.getLimbN 2
+  let a3 := a.getLimbN 3; let b3 := b.getLimbN 3
+  let borrow0 := if BitVec.ult a0 b0 then (1 : Word) else 0
+  let _diff0 := a0 - b0
+  let borrow1a := if BitVec.ult a1 b1 then (1 : Word) else 0
+  let temp1 := a1 - b1
+  let borrow1b := if BitVec.ult temp1 borrow0 then (1 : Word) else 0
+  let _result1 := temp1 - borrow0
+  let borrow1 := borrow1a ||| borrow1b
+  let borrow2a := if BitVec.ult a2 b2 then (1 : Word) else 0
+  let temp2 := a2 - b2
+  let borrow2b := if BitVec.ult temp2 borrow1 then (1 : Word) else 0
+  let _result2 := temp2 - borrow1
+  let borrow2 := borrow2a ||| borrow2b
+  let borrow3a := if BitVec.ult a3 b3 then (1 : Word) else 0
+  let temp3 := a3 - b3
+  let borrow3b := if BitVec.ult temp3 borrow2 then (1 : Word) else 0
+  let result3 := temp3 - borrow2
+  let borrow3 := borrow3a ||| borrow3b
+  (.x12 ↦ᵣ (sp + 32)) ** (.x7 ↦ᵣ result3) ** (.x6 ↦ᵣ borrow3b) **
+  (.x5 ↦ᵣ borrow3) ** (.x11 ↦ᵣ borrow3a) **
+  evmWordIs sp a ** evmWordIs (sp + 32) (a - b)
+
+theorem evmSubStackPost_unfold (sp : Word) (a b : EvmWord) :
+    evmSubStackPost sp a b =
+      (let a0 := a.getLimbN 0; let b0 := b.getLimbN 0
+       let a1 := a.getLimbN 1; let b1 := b.getLimbN 1
+       let a2 := a.getLimbN 2; let b2 := b.getLimbN 2
+       let a3 := a.getLimbN 3; let b3 := b.getLimbN 3
+       let borrow0 := if BitVec.ult a0 b0 then (1 : Word) else 0
+       let _diff0 := a0 - b0
+       let borrow1a := if BitVec.ult a1 b1 then (1 : Word) else 0
+       let temp1 := a1 - b1
+       let borrow1b := if BitVec.ult temp1 borrow0 then (1 : Word) else 0
+       let _result1 := temp1 - borrow0
+       let borrow1 := borrow1a ||| borrow1b
+       let borrow2a := if BitVec.ult a2 b2 then (1 : Word) else 0
+       let temp2 := a2 - b2
+       let borrow2b := if BitVec.ult temp2 borrow1 then (1 : Word) else 0
+       let _result2 := temp2 - borrow1
+       let borrow2 := borrow2a ||| borrow2b
+       let borrow3a := if BitVec.ult a3 b3 then (1 : Word) else 0
+       let temp3 := a3 - b3
+       let borrow3b := if BitVec.ult temp3 borrow2 then (1 : Word) else 0
+       let result3 := temp3 - borrow2
+       let borrow3 := borrow3a ||| borrow3b
+       (.x12 ↦ᵣ (sp + 32)) ** (.x7 ↦ᵣ result3) ** (.x6 ↦ᵣ borrow3b) **
+       (.x5 ↦ᵣ borrow3) ** (.x11 ↦ᵣ borrow3a) **
+       evmWordIs sp a ** evmWordIs (sp + 32) (a - b)) := by
+  delta evmSubStackPost; rfl
+
+/-- Named-postcondition wrapper for `evm_sub_stack_spec_within`.
+    0 statement-level lets; postcondition is opaque `evmSubStackPost`. -/
+theorem evm_sub_stack_named_spec_within (sp base : Word)
+    (a b : EvmWord) (v7 v6 v5 v11 : Word) :
+    cpsTripleWithin 30 base (base + 120) (evm_sub_code base)
+      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7) ** (.x6 ↦ᵣ v6) ** (.x5 ↦ᵣ v5) ** (.x11 ↦ᵣ v11) **
+       evmWordIs sp a ** evmWordIs (sp + 32) b)
+      (evmSubStackPost sp a b) :=
+  cpsTripleWithin_weaken
+    (fun h hp => hp)
+    (fun h hp => by simp only [evmSubStackPost_unfold]; exact hp)
+    (evm_sub_stack_spec_within sp base a b v7 v6 v5 v11)
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Add `evmAddStackPost` + `evm_add_stack_named_spec_within` with **0** statement lets (down from 22) in `Add/Spec.lean`
- Add `evmSubStackPost` + `evm_sub_stack_named_spec_within` with **0** statement lets (down from 22) in `Sub/Spec.lean`
- Add `evmAddModPrologueStackPost` + `evm_addmod_prologue_stack_named_spec_within` with **0** statement lets (down from 22) in `AddMod/LimbSpec.lean`

All three follow the `@[irreducible] def` + `delta/rfl` unfold + `cpsTripleWithin_weaken` pattern established in PRs #4530–#4545. These are the EvmWord-level stack specs; the corresponding raw limb-level specs got bundles in PRs #4544–#4545.

Refs #61. Bead: evm-asm-yz73p.

## Verification
- lake build EvmAsm.Evm64.Add.Spec EvmAsm.Evm64.Sub.Spec EvmAsm.Evm64.AddMod.LimbSpec
- scripts/check-file-size.sh
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Add/Spec.lean EvmAsm/Evm64/Sub/Spec.lean EvmAsm/Evm64/AddMod/LimbSpec.lean
- lake build

Authored by @pirapira; implemented by Claude Code