### PR TITLE
chore(lt,addmod): add evmLtStackPost and evmAddModPrologueLimbPost bundles (18→0 lets)

### DIFF
--- a/EvmAsm/Evm64/AddMod/LimbSpec.lean
+++ b/EvmAsm/Evm64/AddMod/LimbSpec.lean
@@ -69,6 +69,73 @@ theorem evm_addmod_prologue_spec_within (sp : Word) (base : Word)
   show cpsTripleWithin 30 base (base + 120) (evm_add_code base) _ _
   exact evm_add_spec_within sp base a0 a1 a2 a3 b0 b1 b2 b3 v7 v6 v5 v11
 
+/-- Bundled postcondition for `evm_addmod_prologue_spec_within` (register/memory level).
+    Hides 18 carry-chain let-bindings. -/
+@[irreducible]
+def evmAddModPrologueLimbPost (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
+  let sum0 := a0 + b0
+  let carry0 := if BitVec.ult sum0 b0 then (1 : Word) else 0
+  let psum1 := a1 + b1
+  let carry1a := if BitVec.ult psum1 b1 then (1 : Word) else 0
+  let result1 := psum1 + carry0
+  let carry1b := if BitVec.ult result1 carry0 then (1 : Word) else 0
+  let carry1 := carry1a ||| carry1b
+  let psum2 := a2 + b2
+  let carry2a := if BitVec.ult psum2 b2 then (1 : Word) else 0
+  let result2 := psum2 + carry1
+  let carry2b := if BitVec.ult result2 carry1 then (1 : Word) else 0
+  let carry2 := carry2a ||| carry2b
+  let psum3 := a3 + b3
+  let carry3a := if BitVec.ult psum3 b3 then (1 : Word) else 0
+  let result3 := psum3 + carry2
+  let carry3b := if BitVec.ult result3 carry2 then (1 : Word) else 0
+  let carry3 := carry3a ||| carry3b
+  (.x12 ↦ᵣ (sp + 32)) ** (.x7 ↦ᵣ result3) ** (.x6 ↦ᵣ carry3b) **
+  (.x5 ↦ᵣ carry3) ** (.x11 ↦ᵣ carry3a) **
+  (sp ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+  ((sp + 32) ↦ₘ sum0) ** ((sp + 40) ↦ₘ result1) ** ((sp + 48) ↦ₘ result2) **
+  ((sp + 56) ↦ₘ result3)
+
+theorem evmAddModPrologueLimbPost_unfold (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    evmAddModPrologueLimbPost sp a0 a1 a2 a3 b0 b1 b2 b3 =
+      (let sum0 := a0 + b0
+       let carry0 := if BitVec.ult sum0 b0 then (1 : Word) else 0
+       let psum1 := a1 + b1
+       let carry1a := if BitVec.ult psum1 b1 then (1 : Word) else 0
+       let result1 := psum1 + carry0
+       let carry1b := if BitVec.ult result1 carry0 then (1 : Word) else 0
+       let carry1 := carry1a ||| carry1b
+       let psum2 := a2 + b2
+       let carry2a := if BitVec.ult psum2 b2 then (1 : Word) else 0
+       let result2 := psum2 + carry1
+       let carry2b := if BitVec.ult result2 carry1 then (1 : Word) else 0
+       let carry2 := carry2a ||| carry2b
+       let psum3 := a3 + b3
+       let carry3a := if BitVec.ult psum3 b3 then (1 : Word) else 0
+       let result3 := psum3 + carry2
+       let carry3b := if BitVec.ult result3 carry2 then (1 : Word) else 0
+       let carry3 := carry3a ||| carry3b
+       (.x12 ↦ᵣ (sp + 32)) ** (.x7 ↦ᵣ result3) ** (.x6 ↦ᵣ carry3b) **
+       (.x5 ↦ᵣ carry3) ** (.x11 ↦ᵣ carry3a) **
+       (sp ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ sum0) ** ((sp + 40) ↦ₘ result1) ** ((sp + 48) ↦ₘ result2) **
+       ((sp + 56) ↦ₘ result3)) := by
+  delta evmAddModPrologueLimbPost; rfl
+
+/-- Named-postcondition wrapper for `evm_addmod_prologue_spec_within`.
+    0 statement-level lets; postcondition is opaque `evmAddModPrologueLimbPost`. -/
+theorem evm_addmod_prologue_named_spec_within (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word) (v7 v6 v5 v11 : Word) :
+    cpsTripleWithin 30 base (base + 120) (evm_addmod_prologue_code base)
+      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7) ** (.x6 ↦ᵣ v6) ** (.x5 ↦ᵣ v5) ** (.x11 ↦ᵣ v11) **
+       (sp ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3))
+      (evmAddModPrologueLimbPost sp a0 a1 a2 a3 b0 b1 b2 b3) :=
+  cpsTripleWithin_weaken
+    (fun h hp => hp)
+    (fun h hp => by simp only [evmAddModPrologueLimbPost_unfold]; exact hp)
+    (evm_addmod_prologue_spec_within sp base a0 a1 a2 a3 b0 b1 b2 b3 v7 v6 v5 v11)
+
 /-- Stack-level prologue spec on `evmWordIs` surface: thin lift of
     `evm_add_stack_spec_within`. -/
 theorem evm_addmod_prologue_stack_spec_within (sp base : Word)

--- a/EvmAsm/Evm64/Lt/Spec.lean
+++ b/EvmAsm/Evm64/Lt/Spec.lean
@@ -127,5 +127,66 @@ theorem evm_lt_stack_spec_within (sp base : Word)
       xperm_hyp hq)
     h_main
 
+/-- Bundled postcondition for `evm_lt_stack_spec_within` (EvmWord level).
+    Hides all 18 limb-extraction and borrow-chain lets. -/
+@[irreducible]
+def evmLtStackPost (sp : Word) (a b : EvmWord) : Assertion :=
+  let a0 := a.getLimbN 0; let b0 := b.getLimbN 0
+  let a1 := a.getLimbN 1; let b1 := b.getLimbN 1
+  let a2 := a.getLimbN 2; let b2 := b.getLimbN 2
+  let a3 := a.getLimbN 3; let b3 := b.getLimbN 3
+  let borrow0 := if BitVec.ult a0 b0 then (1 : Word) else 0
+  let borrow1a := if BitVec.ult a1 b1 then (1 : Word) else 0
+  let temp1 := a1 - b1
+  let borrow1b := if BitVec.ult temp1 borrow0 then (1 : Word) else 0
+  let borrow1 := borrow1a ||| borrow1b
+  let borrow2a := if BitVec.ult a2 b2 then (1 : Word) else 0
+  let temp2 := a2 - b2
+  let borrow2b := if BitVec.ult temp2 borrow1 then (1 : Word) else 0
+  let borrow2 := borrow2a ||| borrow2b
+  let borrow3a := if BitVec.ult a3 b3 then (1 : Word) else 0
+  let temp3 := a3 - b3
+  let borrow3b := if BitVec.ult temp3 borrow2 then (1 : Word) else 0
+  let borrow3 := borrow3a ||| borrow3b
+  (.x12 ↦ᵣ (sp + 32)) ** (.x7 ↦ᵣ temp3) ** (.x6 ↦ᵣ borrow3b) **
+  (.x5 ↦ᵣ borrow3) ** (.x11 ↦ᵣ borrow3a) **
+  evmWordIs sp a ** evmWordIs (sp + 32) (if BitVec.ult a b then 1 else 0)
+
+theorem evmLtStackPost_unfold (sp : Word) (a b : EvmWord) :
+    evmLtStackPost sp a b =
+      (let a0 := a.getLimbN 0; let b0 := b.getLimbN 0
+       let a1 := a.getLimbN 1; let b1 := b.getLimbN 1
+       let a2 := a.getLimbN 2; let b2 := b.getLimbN 2
+       let a3 := a.getLimbN 3; let b3 := b.getLimbN 3
+       let borrow0 := if BitVec.ult a0 b0 then (1 : Word) else 0
+       let borrow1a := if BitVec.ult a1 b1 then (1 : Word) else 0
+       let temp1 := a1 - b1
+       let borrow1b := if BitVec.ult temp1 borrow0 then (1 : Word) else 0
+       let borrow1 := borrow1a ||| borrow1b
+       let borrow2a := if BitVec.ult a2 b2 then (1 : Word) else 0
+       let temp2 := a2 - b2
+       let borrow2b := if BitVec.ult temp2 borrow1 then (1 : Word) else 0
+       let borrow2 := borrow2a ||| borrow2b
+       let borrow3a := if BitVec.ult a3 b3 then (1 : Word) else 0
+       let temp3 := a3 - b3
+       let borrow3b := if BitVec.ult temp3 borrow2 then (1 : Word) else 0
+       let borrow3 := borrow3a ||| borrow3b
+       (.x12 ↦ᵣ (sp + 32)) ** (.x7 ↦ᵣ temp3) ** (.x6 ↦ᵣ borrow3b) **
+       (.x5 ↦ᵣ borrow3) ** (.x11 ↦ᵣ borrow3a) **
+       evmWordIs sp a ** evmWordIs (sp + 32) (if BitVec.ult a b then 1 else 0)) := by
+  delta evmLtStackPost; rfl
+
+/-- Named-postcondition wrapper for `evm_lt_stack_spec_within`.
+    0 statement-level lets; postcondition is opaque `evmLtStackPost`. -/
+theorem evm_lt_stack_named_spec_within (sp base : Word)
+    (a b : EvmWord) (v7 v6 v5 v11 : Word) :
+    cpsTripleWithin 26 base (base + 104) (evm_lt_code base)
+      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7) ** (.x6 ↦ᵣ v6) ** (.x5 ↦ᵣ v5) ** (.x11 ↦ᵣ v11) **
+       evmWordIs sp a ** evmWordIs (sp + 32) b)
+      (evmLtStackPost sp a b) :=
+  cpsTripleWithin_weaken
+    (fun h hp => hp)
+    (fun h hp => by simp only [evmLtStackPost_unfold]; exact hp)
+    (evm_lt_stack_spec_within sp base a b v7 v6 v5 v11)
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Add `evmLtStackPost` bundle + `evm_lt_stack_named_spec_within` with **0** statement lets (down from 18) in `Lt/Spec.lean`
- Add `evmAddModPrologueLimbPost` bundle + `evm_addmod_prologue_named_spec_within` with **0** statement lets (down from 18) in `AddMod/LimbSpec.lean`

Both follow the `@[irreducible] def` + `delta/rfl` + `cpsTripleWithin_weaken` pattern from PRs #4530–#4546.

Refs #61. Bead: evm-asm-yz73p.

## Verification
- lake build EvmAsm.Evm64.Lt.Spec EvmAsm.Evm64.AddMod.LimbSpec
- scripts/check-file-size.sh
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Lt/Spec.lean EvmAsm/Evm64/AddMod/LimbSpec.lean
- lake build

Authored by @pirapira; implemented by Claude Code