### PR TITLE
chore(gt,slt,sgt): add evmGtStackPost/evmSltStackPost/evmSgtStackPost bundles

### DIFF
--- a/EvmAsm/Evm64/Gt/Spec.lean
+++ b/EvmAsm/Evm64/Gt/Spec.lean
@@ -127,5 +127,58 @@ theorem evm_gt_stack_spec_within (sp base : Word)
       xperm_hyp hq)
     h_main
 
+/-- Bundled postcondition for `evm_gt_stack_spec_within` (EvmWord level).
+    Hides all 14 limb-extraction and borrow-chain lets. -/
+@[irreducible]
+def evmGtStackPost (sp : Word) (a b : EvmWord) : Assertion :=
+  let borrow0 := if BitVec.ult (b.getLimbN 0) (a.getLimbN 0) then (1 : Word) else 0
+  let borrow1a := if BitVec.ult (b.getLimbN 1) (a.getLimbN 1) then (1 : Word) else 0
+  let temp1 := b.getLimbN 1 - a.getLimbN 1
+  let borrow1b := if BitVec.ult temp1 borrow0 then (1 : Word) else 0
+  let borrow1 := borrow1a ||| borrow1b
+  let borrow2a := if BitVec.ult (b.getLimbN 2) (a.getLimbN 2) then (1 : Word) else 0
+  let temp2 := b.getLimbN 2 - a.getLimbN 2
+  let borrow2b := if BitVec.ult temp2 borrow1 then (1 : Word) else 0
+  let borrow2 := borrow2a ||| borrow2b
+  let borrow3a := if BitVec.ult (b.getLimbN 3) (a.getLimbN 3) then (1 : Word) else 0
+  let temp3 := b.getLimbN 3 - a.getLimbN 3
+  let borrow3b := if BitVec.ult temp3 borrow2 then (1 : Word) else 0
+  let borrow3 := borrow3a ||| borrow3b
+  (.x12 ↦ᵣ (sp + 32)) ** (.x7 ↦ᵣ temp3) ** (.x6 ↦ᵣ borrow3b) **
+  (.x5 ↦ᵣ borrow3) ** (.x11 ↦ᵣ borrow3a) **
+  evmWordIs sp a ** evmWordIs (sp + 32) (if BitVec.ult b a then 1 else 0)
+
+theorem evmGtStackPost_unfold (sp : Word) (a b : EvmWord) :
+    evmGtStackPost sp a b =
+      (let borrow0 := if BitVec.ult (b.getLimbN 0) (a.getLimbN 0) then (1 : Word) else 0
+       let borrow1a := if BitVec.ult (b.getLimbN 1) (a.getLimbN 1) then (1 : Word) else 0
+       let temp1 := b.getLimbN 1 - a.getLimbN 1
+       let borrow1b := if BitVec.ult temp1 borrow0 then (1 : Word) else 0
+       let borrow1 := borrow1a ||| borrow1b
+       let borrow2a := if BitVec.ult (b.getLimbN 2) (a.getLimbN 2) then (1 : Word) else 0
+       let temp2 := b.getLimbN 2 - a.getLimbN 2
+       let borrow2b := if BitVec.ult temp2 borrow1 then (1 : Word) else 0
+       let borrow2 := borrow2a ||| borrow2b
+       let borrow3a := if BitVec.ult (b.getLimbN 3) (a.getLimbN 3) then (1 : Word) else 0
+       let temp3 := b.getLimbN 3 - a.getLimbN 3
+       let borrow3b := if BitVec.ult temp3 borrow2 then (1 : Word) else 0
+       let borrow3 := borrow3a ||| borrow3b
+       (.x12 ↦ᵣ (sp + 32)) ** (.x7 ↦ᵣ temp3) ** (.x6 ↦ᵣ borrow3b) **
+       (.x5 ↦ᵣ borrow3) ** (.x11 ↦ᵣ borrow3a) **
+       evmWordIs sp a ** evmWordIs (sp + 32) (if BitVec.ult b a then 1 else 0)) := by
+  delta evmGtStackPost; rfl
+
+/-- Named-postcondition wrapper for `evm_gt_stack_spec_within`.
+    0 statement-level lets; postcondition is opaque `evmGtStackPost`. -/
+theorem evm_gt_stack_named_spec_within (sp base : Word)
+    (a b : EvmWord) (v7 v6 v5 v11 : Word) :
+    cpsTripleWithin 26 base (base + 104) (evm_gt_code base)
+      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7) ** (.x6 ↦ᵣ v6) ** (.x5 ↦ᵣ v5) ** (.x11 ↦ᵣ v11) **
+       evmWordIs sp a ** evmWordIs (sp + 32) b)
+      (evmGtStackPost sp a b) :=
+  cpsTripleWithin_weaken
+    (fun h hp => hp)
+    (fun h hp => by simp only [evmGtStackPost_unfold]; exact hp)
+    (evm_gt_stack_spec_within sp base a b v7 v6 v5 v11)
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Sgt/Spec.lean
+++ b/EvmAsm/Evm64/Sgt/Spec.lean
@@ -167,5 +167,60 @@ theorem evm_sgt_stack_spec_within (sp base : Word)
       xperm_hyp hq)
     h_main
 
+/-- Bundled postcondition for `evm_sgt_stack_spec_within`.
+    Hides 12 borrow-chain and signed-compare lets. -/
+@[irreducible]
+def evmSgtStackPost (sp v11 : Word) (a b : EvmWord) : Assertion :=
+  let borrow0 := if BitVec.ult (b.getLimbN 0) (a.getLimbN 0) then (1 : Word) else 0
+  let borrow1a := if BitVec.ult (b.getLimbN 1) (a.getLimbN 1) then (1 : Word) else 0
+  let temp1 := b.getLimbN 1 - a.getLimbN 1
+  let borrow1b := if BitVec.ult temp1 borrow0 then (1 : Word) else 0
+  let borrow1 := borrow1a ||| borrow1b
+  let borrow2a := if BitVec.ult (b.getLimbN 2) (a.getLimbN 2) then (1 : Word) else 0
+  let temp2 := b.getLimbN 2 - a.getLimbN 2
+  let borrow2b := if BitVec.ult temp2 borrow1 then (1 : Word) else 0
+  let borrow2 := borrow2a ||| borrow2b
+  let sgtMsb := if BitVec.slt (b.getLimbN 3) (a.getLimbN 3) then (1 : Word) else 0
+  let result := if b.getLimbN 3 = a.getLimbN 3 then borrow2 else sgtMsb
+  (.x12 ↦ᵣ (sp + 32)) **
+  (.x7 ↦ᵣ (if b.getLimbN 3 = a.getLimbN 3 then temp2 else b.getLimbN 3)) **
+  (.x6 ↦ᵣ (if b.getLimbN 3 = a.getLimbN 3 then borrow2b else a.getLimbN 3)) **
+  (.x5 ↦ᵣ result) **
+  (.x11 ↦ᵣ (if b.getLimbN 3 = a.getLimbN 3 then borrow2a else v11)) **
+  evmWordIs sp a ** evmWordIs (sp + 32) (if BitVec.slt b a then 1 else 0)
+
+theorem evmSgtStackPost_unfold (sp v11 : Word) (a b : EvmWord) :
+    evmSgtStackPost sp v11 a b =
+      (let borrow0 := if BitVec.ult (b.getLimbN 0) (a.getLimbN 0) then (1 : Word) else 0
+       let borrow1a := if BitVec.ult (b.getLimbN 1) (a.getLimbN 1) then (1 : Word) else 0
+       let temp1 := b.getLimbN 1 - a.getLimbN 1
+       let borrow1b := if BitVec.ult temp1 borrow0 then (1 : Word) else 0
+       let borrow1 := borrow1a ||| borrow1b
+       let borrow2a := if BitVec.ult (b.getLimbN 2) (a.getLimbN 2) then (1 : Word) else 0
+       let temp2 := b.getLimbN 2 - a.getLimbN 2
+       let borrow2b := if BitVec.ult temp2 borrow1 then (1 : Word) else 0
+       let borrow2 := borrow2a ||| borrow2b
+       let sgtMsb := if BitVec.slt (b.getLimbN 3) (a.getLimbN 3) then (1 : Word) else 0
+       let result := if b.getLimbN 3 = a.getLimbN 3 then borrow2 else sgtMsb
+       (.x12 ↦ᵣ (sp + 32)) **
+       (.x7 ↦ᵣ (if b.getLimbN 3 = a.getLimbN 3 then temp2 else b.getLimbN 3)) **
+       (.x6 ↦ᵣ (if b.getLimbN 3 = a.getLimbN 3 then borrow2b else a.getLimbN 3)) **
+       (.x5 ↦ᵣ result) **
+       (.x11 ↦ᵣ (if b.getLimbN 3 = a.getLimbN 3 then borrow2a else v11)) **
+       evmWordIs sp a ** evmWordIs (sp + 32) (if BitVec.slt b a then 1 else 0)) := by
+  delta evmSgtStackPost; rfl
+
+/-- Named-postcondition wrapper for `evm_sgt_stack_spec_within`.
+    0 statement-level lets; postcondition is opaque `evmSgtStackPost`. -/
+theorem evm_sgt_stack_named_spec_within (sp base : Word)
+    (a b : EvmWord) (v7 v6 v5 v11 : Word) :
+    cpsTripleWithin 25 base (base + 100) (evm_sgt_code base)
+      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7) ** (.x6 ↦ᵣ v6) ** (.x5 ↦ᵣ v5) ** (.x11 ↦ᵣ v11) **
+       evmWordIs sp a ** evmWordIs (sp + 32) b)
+      (evmSgtStackPost sp v11 a b) :=
+  cpsTripleWithin_weaken
+    (fun h hp => hp)
+    (fun h hp => by simp only [evmSgtStackPost_unfold]; exact hp)
+    (evm_sgt_stack_spec_within sp base a b v7 v6 v5 v11)
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Slt/Spec.lean
+++ b/EvmAsm/Evm64/Slt/Spec.lean
@@ -165,5 +165,60 @@ theorem evm_slt_stack_spec_within (sp base : Word)
       xperm_hyp hq)
     h_main
 
+/-- Bundled postcondition for `evm_slt_stack_spec_within`.
+    Hides 12 borrow-chain and signed-compare lets. -/
+@[irreducible]
+def evmSltStackPost (sp v11 : Word) (a b : EvmWord) : Assertion :=
+  let borrow0 := if BitVec.ult (a.getLimbN 0) (b.getLimbN 0) then (1 : Word) else 0
+  let borrow1a := if BitVec.ult (a.getLimbN 1) (b.getLimbN 1) then (1 : Word) else 0
+  let temp1 := a.getLimbN 1 - b.getLimbN 1
+  let borrow1b := if BitVec.ult temp1 borrow0 then (1 : Word) else 0
+  let borrow1 := borrow1a ||| borrow1b
+  let borrow2a := if BitVec.ult (a.getLimbN 2) (b.getLimbN 2) then (1 : Word) else 0
+  let temp2 := a.getLimbN 2 - b.getLimbN 2
+  let borrow2b := if BitVec.ult temp2 borrow1 then (1 : Word) else 0
+  let borrow2 := borrow2a ||| borrow2b
+  let sltMsb := if BitVec.slt (a.getLimbN 3) (b.getLimbN 3) then (1 : Word) else 0
+  let result := if a.getLimbN 3 = b.getLimbN 3 then borrow2 else sltMsb
+  (.x12 ↦ᵣ (sp + 32)) **
+  (.x7 ↦ᵣ (if a.getLimbN 3 = b.getLimbN 3 then temp2 else a.getLimbN 3)) **
+  (.x6 ↦ᵣ (if a.getLimbN 3 = b.getLimbN 3 then borrow2b else b.getLimbN 3)) **
+  (.x5 ↦ᵣ result) **
+  (.x11 ↦ᵣ (if a.getLimbN 3 = b.getLimbN 3 then borrow2a else v11)) **
+  evmWordIs sp a ** evmWordIs (sp + 32) (if BitVec.slt a b then 1 else 0)
+
+theorem evmSltStackPost_unfold (sp v11 : Word) (a b : EvmWord) :
+    evmSltStackPost sp v11 a b =
+      (let borrow0 := if BitVec.ult (a.getLimbN 0) (b.getLimbN 0) then (1 : Word) else 0
+       let borrow1a := if BitVec.ult (a.getLimbN 1) (b.getLimbN 1) then (1 : Word) else 0
+       let temp1 := a.getLimbN 1 - b.getLimbN 1
+       let borrow1b := if BitVec.ult temp1 borrow0 then (1 : Word) else 0
+       let borrow1 := borrow1a ||| borrow1b
+       let borrow2a := if BitVec.ult (a.getLimbN 2) (b.getLimbN 2) then (1 : Word) else 0
+       let temp2 := a.getLimbN 2 - b.getLimbN 2
+       let borrow2b := if BitVec.ult temp2 borrow1 then (1 : Word) else 0
+       let borrow2 := borrow2a ||| borrow2b
+       let sltMsb := if BitVec.slt (a.getLimbN 3) (b.getLimbN 3) then (1 : Word) else 0
+       let result := if a.getLimbN 3 = b.getLimbN 3 then borrow2 else sltMsb
+       (.x12 ↦ᵣ (sp + 32)) **
+       (.x7 ↦ᵣ (if a.getLimbN 3 = b.getLimbN 3 then temp2 else a.getLimbN 3)) **
+       (.x6 ↦ᵣ (if a.getLimbN 3 = b.getLimbN 3 then borrow2b else b.getLimbN 3)) **
+       (.x5 ↦ᵣ result) **
+       (.x11 ↦ᵣ (if a.getLimbN 3 = b.getLimbN 3 then borrow2a else v11)) **
+       evmWordIs sp a ** evmWordIs (sp + 32) (if BitVec.slt a b then 1 else 0)) := by
+  delta evmSltStackPost; rfl
+
+/-- Named-postcondition wrapper for `evm_slt_stack_spec_within`.
+    0 statement-level lets; postcondition is opaque `evmSltStackPost`. -/
+theorem evm_slt_stack_named_spec_within (sp base : Word)
+    (a b : EvmWord) (v7 v6 v5 v11 : Word) :
+    cpsTripleWithin 25 base (base + 100) (evm_slt_code base)
+      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7) ** (.x6 ↦ᵣ v6) ** (.x5 ↦ᵣ v5) ** (.x11 ↦ᵣ v11) **
+       evmWordIs sp a ** evmWordIs (sp + 32) b)
+      (evmSltStackPost sp v11 a b) :=
+  cpsTripleWithin_weaken
+    (fun h hp => hp)
+    (fun h hp => by simp only [evmSltStackPost_unfold]; exact hp)
+    (evm_slt_stack_spec_within sp base a b v7 v6 v5 v11)
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Add `evmGtStackPost` + `evm_gt_stack_named_spec_within` with **0** lets (down from 14) in `Gt/Spec.lean`
- Add `evmSltStackPost` + `evm_slt_stack_named_spec_within` with **0** lets (down from 12) in `Slt/Spec.lean`
- Add `evmSgtStackPost` + `evm_sgt_stack_named_spec_within` with **0** lets (down from 12) in `Sgt/Spec.lean`

`evmSltStackPost`/`evmSgtStackPost` take `v11 : Word` as a parameter because the conditional `.x11` postcondition register value depends on it.

Continues the let-chain reduction sweep from PRs #4530–#4547.

Refs #61. Bead: evm-asm-yz73p.

## Verification
- lake build EvmAsm.Evm64.Gt.Spec EvmAsm.Evm64.Slt.Spec EvmAsm.Evm64.Sgt.Spec
- scripts/check-file-size.sh
- lake build

Authored by @pirapira; implemented by Claude Code