### PR TITLE
chore(addmod): add evmAddModPhase1LimbPost bundle + 2 named wrappers (17→0 lets)

### DIFF
--- a/EvmAsm/Evm64/AddMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/AddMod/Compose/Base.lean
@@ -389,4 +389,89 @@ theorem evm_addmod_prologue_phase1_phase2_reduce_spec_within
   -- `(prologue_phase1_post) ** (.x1 ↦ᵣ v1)`).
   exact cpsTripleWithin_seq_same_cr h1f h2f
 
+/-- Named-postcondition wrapper for `evm_addmod_prologue_evm_addmod_spec_within`.
+    0 statement-level lets; reuses `evmAddModPrologueLimbPost` from LimbSpec. -/
+theorem evm_addmod_prologue_evm_addmod_named_spec_within
+    (sp : Word) (base : Word) (modOff : BitVec 21)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word) (v7 v6 v5 v11 : Word) :
+    cpsTripleWithin 30 base (base + 120) (evm_addmod_program_code base modOff)
+      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7) ** (.x6 ↦ᵣ v6) ** (.x5 ↦ᵣ v5) ** (.x11 ↦ᵣ v11) **
+       (sp ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3))
+      (evmAddModPrologueLimbPost sp a0 a1 a2 a3 b0 b1 b2 b3) :=
+  cpsTripleWithin_weaken
+    (fun h hp => hp)
+    (fun h hp => by simp only [evmAddModPrologueLimbPost_unfold]; exact hp)
+    (evm_addmod_prologue_evm_addmod_spec_within sp base modOff a0 a1 a2 a3 b0 b1 b2 b3 v7 v6 v5 v11)
+
+/-- Bundled postcondition for `evm_addmod_prologue_phase1_spec_within`.
+    Hides 17 carry-chain lets; `.x7` holds `carry3 + signExtend12 0`. -/
+@[irreducible]
+def evmAddModPhase1LimbPost (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
+  let sum0 := a0 + b0
+  let carry0 := if BitVec.ult sum0 b0 then (1 : Word) else 0
+  let psum1 := a1 + b1
+  let carry1a := if BitVec.ult psum1 b1 then (1 : Word) else 0
+  let result1 := psum1 + carry0
+  let carry1b := if BitVec.ult result1 carry0 then (1 : Word) else 0
+  let carry1 := carry1a ||| carry1b
+  let psum2 := a2 + b2
+  let carry2a := if BitVec.ult psum2 b2 then (1 : Word) else 0
+  let result2 := psum2 + carry1
+  let carry2b := if BitVec.ult result2 carry1 then (1 : Word) else 0
+  let carry2 := carry2a ||| carry2b
+  let psum3 := a3 + b3
+  let carry3a := if BitVec.ult psum3 b3 then (1 : Word) else 0
+  let result3 := psum3 + carry2
+  let carry3b := if BitVec.ult result3 carry2 then (1 : Word) else 0
+  let carry3 := carry3a ||| carry3b
+  (.x12 ↦ᵣ (sp + 32)) **
+  (.x7 ↦ᵣ (carry3 + signExtend12 (0 : BitVec 12))) **
+  (.x6 ↦ᵣ carry3b) ** (.x5 ↦ᵣ carry3) ** (.x11 ↦ᵣ carry3a) **
+  (sp ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+  ((sp + 32) ↦ₘ sum0) ** ((sp + 40) ↦ₘ result1) **
+  ((sp + 48) ↦ₘ result2) ** ((sp + 56) ↦ₘ result3)
+
+theorem evmAddModPhase1LimbPost_unfold (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    evmAddModPhase1LimbPost sp a0 a1 a2 a3 b0 b1 b2 b3 =
+      (let sum0 := a0 + b0
+       let carry0 := if BitVec.ult sum0 b0 then (1 : Word) else 0
+       let psum1 := a1 + b1
+       let carry1a := if BitVec.ult psum1 b1 then (1 : Word) else 0
+       let result1 := psum1 + carry0
+       let carry1b := if BitVec.ult result1 carry0 then (1 : Word) else 0
+       let carry1 := carry1a ||| carry1b
+       let psum2 := a2 + b2
+       let carry2a := if BitVec.ult psum2 b2 then (1 : Word) else 0
+       let result2 := psum2 + carry1
+       let carry2b := if BitVec.ult result2 carry1 then (1 : Word) else 0
+       let carry2 := carry2a ||| carry2b
+       let psum3 := a3 + b3
+       let carry3a := if BitVec.ult psum3 b3 then (1 : Word) else 0
+       let result3 := psum3 + carry2
+       let carry3b := if BitVec.ult result3 carry2 then (1 : Word) else 0
+       let carry3 := carry3a ||| carry3b
+       (.x12 ↦ᵣ (sp + 32)) **
+       (.x7 ↦ᵣ (carry3 + signExtend12 (0 : BitVec 12))) **
+       (.x6 ↦ᵣ carry3b) ** (.x5 ↦ᵣ carry3) ** (.x11 ↦ᵣ carry3a) **
+       (sp ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ sum0) ** ((sp + 40) ↦ₘ result1) **
+       ((sp + 48) ↦ₘ result2) ** ((sp + 56) ↦ₘ result3)) := by
+  delta evmAddModPhase1LimbPost; rfl
+
+/-- Named-postcondition wrapper for `evm_addmod_prologue_phase1_spec_within`.
+    0 statement-level lets; postcondition is opaque `evmAddModPhase1LimbPost`. -/
+theorem evm_addmod_prologue_phase1_named_spec_within
+    (sp : Word) (base : Word) (modOff : BitVec 21)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word) (v7 v6 v5 v11 : Word) :
+    cpsTripleWithin (30 + 1) base (base + 124) (evm_addmod_program_code base modOff)
+      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7) ** (.x6 ↦ᵣ v6) ** (.x5 ↦ᵣ v5) ** (.x11 ↦ᵣ v11) **
+       (sp ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3))
+      (evmAddModPhase1LimbPost sp a0 a1 a2 a3 b0 b1 b2 b3) :=
+  cpsTripleWithin_weaken
+    (fun h hp => hp)
+    (fun h hp => by simp only [evmAddModPhase1LimbPost_unfold]; exact hp)
+    (evm_addmod_prologue_phase1_spec_within sp base modOff a0 a1 a2 a3 b0 b1 b2 b3 v7 v6 v5 v11)
+
 end EvmAsm.Evm64.AddMod.Compose


### PR DESCRIPTION
## Summary
- Add `evm_addmod_prologue_evm_addmod_named_spec_within` with **0** statement lets (down from 17) reusing the existing `evmAddModPrologueLimbPost` bundle from `AddMod/LimbSpec.lean`
- Add `@[irreducible] def evmAddModPhase1LimbPost` bundling the 17 carry-chain lets from `evm_addmod_prologue_phase1_spec_within` (postcondition has `carry3 + signExtend12 0` in `.x7`)
- Add `evm_addmod_prologue_phase1_named_spec_within` with **0** statement lets using the new bundle

Continues the let-chain reduction sweep from PRs #4530–#4550.

Refs #61. Bead: evm-asm-yz73p.

## Verification
- lake build EvmAsm.Evm64.AddMod.Compose.Base
- scripts/check-file-size.sh
- lake build

Authored by @pirapira; implemented by Claude Code