### PR TITLE
chore(addmod): add evmAddModPhase1Phase2LimbPost bundle (17→0 lets)

### DIFF
--- a/EvmAsm/Evm64/AddMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/AddMod/Compose/Base.lean
@@ -474,4 +474,78 @@ theorem evm_addmod_prologue_phase1_named_spec_within
     (fun h hp => by simp only [evmAddModPhase1LimbPost_unfold]; exact hp)
     (evm_addmod_prologue_phase1_spec_within sp base modOff a0 a1 a2 a3 b0 b1 b2 b3 v7 v6 v5 v11)
 
+@[irreducible]
+def evmAddModPhase1Phase2LimbPost (base sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
+  let sum0 := a0 + b0
+  let carry0 := if BitVec.ult sum0 b0 then (1 : Word) else 0
+  let psum1 := a1 + b1
+  let carry1a := if BitVec.ult psum1 b1 then (1 : Word) else 0
+  let result1 := psum1 + carry0
+  let carry1b := if BitVec.ult result1 carry0 then (1 : Word) else 0
+  let carry1 := carry1a ||| carry1b
+  let psum2 := a2 + b2
+  let carry2a := if BitVec.ult psum2 b2 then (1 : Word) else 0
+  let result2 := psum2 + carry1
+  let carry2b := if BitVec.ult result2 carry1 then (1 : Word) else 0
+  let carry2 := carry2a ||| carry2b
+  let psum3 := a3 + b3
+  let carry3a := if BitVec.ult psum3 b3 then (1 : Word) else 0
+  let result3 := psum3 + carry2
+  let carry3b := if BitVec.ult result3 carry2 then (1 : Word) else 0
+  let carry3 := carry3a ||| carry3b
+  ((.x12 ↦ᵣ (sp + 32)) **
+   (.x7 ↦ᵣ (carry3 + signExtend12 (0 : BitVec 12))) **
+   (.x6 ↦ᵣ carry3b) ** (.x5 ↦ᵣ carry3) ** (.x11 ↦ᵣ carry3a) **
+   (sp ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+   ((sp + 32) ↦ₘ sum0) ** ((sp + 40) ↦ₘ result1) **
+   ((sp + 48) ↦ₘ result2) ** ((sp + 56) ↦ₘ result3))
+  ** (.x1 ↦ᵣ ((base + 124) + 4))
+
+theorem evmAddModPhase1Phase2LimbPost_unfold (base sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    evmAddModPhase1Phase2LimbPost base sp a0 a1 a2 a3 b0 b1 b2 b3 =
+      (let sum0 := a0 + b0
+       let carry0 := if BitVec.ult sum0 b0 then (1 : Word) else 0
+       let psum1 := a1 + b1
+       let carry1a := if BitVec.ult psum1 b1 then (1 : Word) else 0
+       let result1 := psum1 + carry0
+       let carry1b := if BitVec.ult result1 carry0 then (1 : Word) else 0
+       let carry1 := carry1a ||| carry1b
+       let psum2 := a2 + b2
+       let carry2a := if BitVec.ult psum2 b2 then (1 : Word) else 0
+       let result2 := psum2 + carry1
+       let carry2b := if BitVec.ult result2 carry1 then (1 : Word) else 0
+       let carry2 := carry2a ||| carry2b
+       let psum3 := a3 + b3
+       let carry3a := if BitVec.ult psum3 b3 then (1 : Word) else 0
+       let result3 := psum3 + carry2
+       let carry3b := if BitVec.ult result3 carry2 then (1 : Word) else 0
+       let carry3 := carry3a ||| carry3b
+       ((.x12 ↦ᵣ (sp + 32)) **
+        (.x7 ↦ᵣ (carry3 + signExtend12 (0 : BitVec 12))) **
+        (.x6 ↦ᵣ carry3b) ** (.x5 ↦ᵣ carry3) ** (.x11 ↦ᵣ carry3a) **
+        (sp ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+        ((sp + 32) ↦ₘ sum0) ** ((sp + 40) ↦ₘ result1) **
+        ((sp + 48) ↦ₘ result2) ** ((sp + 56) ↦ₘ result3))
+       ** (.x1 ↦ᵣ ((base + 124) + 4))) := by
+  delta evmAddModPhase1Phase2LimbPost; rfl
+
+/-- Named-postcondition wrapper for `evm_addmod_prologue_phase1_phase2_reduce_spec_within`.
+    0 statement-level lets; postcondition is opaque `evmAddModPhase1Phase2LimbPost`. -/
+theorem evm_addmod_prologue_phase1_phase2_reduce_named_spec_within
+    (sp : Word) (base : Word) (modOff : BitVec 21)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word) (v7 v6 v5 v11 v1 : Word) :
+    cpsTripleWithin (31 + 1) base ((base + 124) + signExtend21 modOff)
+      (evm_addmod_program_code base modOff)
+      (((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7) ** (.x6 ↦ᵣ v6) ** (.x5 ↦ᵣ v5) ** (.x11 ↦ᵣ v11) **
+        (sp ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) **
+        ((sp + 56) ↦ₘ b3))
+       ** (.x1 ↦ᵣ v1))
+      (evmAddModPhase1Phase2LimbPost base sp a0 a1 a2 a3 b0 b1 b2 b3) :=
+  cpsTripleWithin_weaken
+    (fun h hp => hp)
+    (fun h hp => by simp only [evmAddModPhase1Phase2LimbPost_unfold]; exact hp)
+    (evm_addmod_prologue_phase1_phase2_reduce_spec_within sp base modOff
+      a0 a1 a2 a3 b0 b1 b2 b3 v7 v6 v5 v11 v1)
+
 end EvmAsm.Evm64.AddMod.Compose


### PR DESCRIPTION
## Summary
- Add `@[irreducible] def evmAddModPhase1Phase2LimbPost` bundling the 17 carry-chain lets from `evm_addmod_prologue_phase1_phase2_reduce_spec_within`; includes `base : Word` parameter for the `.x1 ↦ᵣ (base+124)+4` return-address postcondition atom
- Add `evm_addmod_prologue_phase1_phase2_reduce_named_spec_within` with **0** statement-level lets using the bundle

Standalone PR (no dependency on #4551's `evmAddModPhase1LimbPost`). Completes the AddMod Compose/Base.lean let-chain sweep.

Continues the let-chain reduction sweep from PRs #4530–#4551.

Refs #61. Bead: evm-asm-yz73p.

## Verification
- lake build EvmAsm.Evm64.AddMod.Compose.Base
- scripts/check-file-size.sh
- lake build

Authored by @pirapira; implemented by Claude Code