### PR TITLE
chore(eq): add evmEqLimbPost/evmEqStackPost bundles (6→0 lets)

### DIFF
--- a/EvmAsm/Evm64/Eq/Spec.lean
+++ b/EvmAsm/Evm64/Eq/Spec.lean
@@ -117,5 +117,85 @@ theorem evm_eq_stack_spec_within (sp base : Word)
       xperm_hyp hq)
     h_main
 
+/-- Bundled postcondition for `evm_eq_spec_within` (register/memory level).
+    Hides 5 XOR-OR accumulation lets; `v11` param preserves unchanged .x11. -/
+@[irreducible]
+def evmEqLimbPost (sp v11 a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
+  let acc0 := a0 ^^^ b0
+  let acc1 := acc0 ||| (a1 ^^^ b1)
+  let acc2 := acc1 ||| (a2 ^^^ b2)
+  let acc3 := acc2 ||| (a3 ^^^ b3)
+  let eqResult := if BitVec.ult acc3 (1 : Word) then (1 : Word) else 0
+  (.x12 ↦ᵣ (sp + 32)) **
+  (.x7 ↦ᵣ eqResult) ** (.x6 ↦ᵣ (a3 ^^^ b3)) ** (.x5 ↦ᵣ b3) ** (.x11 ↦ᵣ v11) **
+  (sp ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+  ((sp + 32) ↦ₘ eqResult) ** ((sp + 40) ↦ₘ 0) ** ((sp + 48) ↦ₘ 0) ** ((sp + 56) ↦ₘ 0)
+
+theorem evmEqLimbPost_unfold (sp v11 a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    evmEqLimbPost sp v11 a0 a1 a2 a3 b0 b1 b2 b3 =
+      (let acc0 := a0 ^^^ b0
+       let acc1 := acc0 ||| (a1 ^^^ b1)
+       let acc2 := acc1 ||| (a2 ^^^ b2)
+       let acc3 := acc2 ||| (a3 ^^^ b3)
+       let eqResult := if BitVec.ult acc3 (1 : Word) then (1 : Word) else 0
+       (.x12 ↦ᵣ (sp + 32)) **
+       (.x7 ↦ᵣ eqResult) ** (.x6 ↦ᵣ (a3 ^^^ b3)) ** (.x5 ↦ᵣ b3) ** (.x11 ↦ᵣ v11) **
+       (sp ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ eqResult) ** ((sp + 40) ↦ₘ 0) ** ((sp + 48) ↦ₘ 0) ** ((sp + 56) ↦ₘ 0)) := by
+  delta evmEqLimbPost; rfl
+
+/-- Named-postcondition wrapper for `evm_eq_spec_within`.
+    0 statement-level lets; postcondition is opaque `evmEqLimbPost`. -/
+theorem evm_eq_named_spec_within (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word) (v7 v6 v5 v11 : Word) :
+    cpsTripleWithin 21 base (base + 84) (evm_eq_code base)
+      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7) ** (.x6 ↦ᵣ v6) ** (.x5 ↦ᵣ v5) ** (.x11 ↦ᵣ v11) **
+       (sp ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3))
+      (evmEqLimbPost sp v11 a0 a1 a2 a3 b0 b1 b2 b3) :=
+  cpsTripleWithin_weaken
+    (fun h hp => hp)
+    (fun h hp => by simp only [evmEqLimbPost_unfold]; exact hp)
+    (evm_eq_spec_within sp base a0 a1 a2 a3 b0 b1 b2 b3 v7 v6 v5 v11)
+
+/-- Bundled postcondition for `evm_eq_stack_spec_within` (EvmWord level).
+    Hides 5 XOR-OR accumulation lets; `v11` param preserves unchanged .x11. -/
+@[irreducible]
+def evmEqStackPost (sp v11 : Word) (a b : EvmWord) : Assertion :=
+  let acc0 := a.getLimbN 0 ^^^ b.getLimbN 0
+  let acc1 := acc0 ||| (a.getLimbN 1 ^^^ b.getLimbN 1)
+  let acc2 := acc1 ||| (a.getLimbN 2 ^^^ b.getLimbN 2)
+  let acc3 := acc2 ||| (a.getLimbN 3 ^^^ b.getLimbN 3)
+  let eqResult := if BitVec.ult acc3 (1 : Word) then (1 : Word) else 0
+  (.x12 ↦ᵣ (sp + 32)) **
+  (.x7 ↦ᵣ eqResult) ** (.x6 ↦ᵣ (a.getLimbN 3 ^^^ b.getLimbN 3)) **
+  (.x5 ↦ᵣ b.getLimbN 3) ** (.x11 ↦ᵣ v11) **
+  evmWordIs sp a ** evmWordIs (sp + 32) (if a = b then 1 else 0)
+
+theorem evmEqStackPost_unfold (sp v11 : Word) (a b : EvmWord) :
+    evmEqStackPost sp v11 a b =
+      (let acc0 := a.getLimbN 0 ^^^ b.getLimbN 0
+       let acc1 := acc0 ||| (a.getLimbN 1 ^^^ b.getLimbN 1)
+       let acc2 := acc1 ||| (a.getLimbN 2 ^^^ b.getLimbN 2)
+       let acc3 := acc2 ||| (a.getLimbN 3 ^^^ b.getLimbN 3)
+       let eqResult := if BitVec.ult acc3 (1 : Word) then (1 : Word) else 0
+       (.x12 ↦ᵣ (sp + 32)) **
+       (.x7 ↦ᵣ eqResult) ** (.x6 ↦ᵣ (a.getLimbN 3 ^^^ b.getLimbN 3)) **
+       (.x5 ↦ᵣ b.getLimbN 3) ** (.x11 ↦ᵣ v11) **
+       evmWordIs sp a ** evmWordIs (sp + 32) (if a = b then 1 else 0)) := by
+  delta evmEqStackPost; rfl
+
+/-- Named-postcondition wrapper for `evm_eq_stack_spec_within`.
+    0 statement-level lets; postcondition is opaque `evmEqStackPost`. -/
+theorem evm_eq_stack_named_spec_within (sp base : Word)
+    (a b : EvmWord) (v7 v6 v5 v11 : Word) :
+    cpsTripleWithin 21 base (base + 84) (evm_eq_code base)
+      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7) ** (.x6 ↦ᵣ v6) ** (.x5 ↦ᵣ v5) ** (.x11 ↦ᵣ v11) **
+       evmWordIs sp a ** evmWordIs (sp + 32) b)
+      (evmEqStackPost sp v11 a b) :=
+  cpsTripleWithin_weaken
+    (fun h hp => hp)
+    (fun h hp => by simp only [evmEqStackPost_unfold]; exact hp)
+    (evm_eq_stack_spec_within sp base a b v7 v6 v5 v11)
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Add `evmEqLimbPost` + `evm_eq_named_spec_within` with **0** statement lets (down from 6) in `Eq/Spec.lean` — raw register/memory level; `v11 : Word` param preserves the unchanged `.x11` scratch register
- Add `evmEqStackPost` + `evm_eq_stack_named_spec_within` with **0** statement lets (down from 6) — EvmWord stack level; also takes `v11` parameter

Continues the let-chain reduction sweep from PRs #4530–#4552.

Refs #61. Bead: evm-asm-yz73p.

## Verification
- lake build EvmAsm.Evm64.Eq.Spec
- scripts/check-file-size.sh
- lake build

Authored by @pirapira; implemented by Claude Code