### PR TITLE
chore(sub): add subLimb0Post/subLimbCarryPost bundles + named specs (5/8→0 lets)

### DIFF
--- a/EvmAsm/Evm64/Sub/LimbSpec.lean
+++ b/EvmAsm/Evm64/Sub/LimbSpec.lean
@@ -125,5 +125,85 @@ theorem sub_limb_carry_spec_within (offA offB : BitVec 12)
     aLimb (sp + signExtend12 offA) (base + 16)
   runBlock p1 p2
 
+/-- Code requirement for `sub_limb0_spec_within`. -/
+abbrev subLimb0Code (offA offB : BitVec 12) (base : Word) : CodeReq :=
+  CodeReq.union (CodeReq.singleton base (.LD .x7 .x12 offA))
+  (CodeReq.union (CodeReq.singleton (base + 4) (.LD .x6 .x12 offB))
+  (CodeReq.union (CodeReq.singleton (base + 8) (.SLTU .x5 .x7 .x6))
+  (CodeReq.union (CodeReq.singleton (base + 12) (.SUB .x7 .x7 .x6))
+   (CodeReq.singleton (base + 16) (.SD .x12 .x7 offB)))))
+
+/-- Bundled postcondition for `sub_limb0_spec_within`. Hides `borrow` and `diff` lets. -/
+@[irreducible]
+def subLimb0Post (sp : Word) (offA offB : BitVec 12) (aLimb bLimb : Word) : Assertion :=
+  let borrow := if BitVec.ult aLimb bLimb then (1 : Word) else 0
+  let diff := aLimb - bLimb
+  (.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ diff) ** (.x6 ↦ᵣ bLimb) ** (.x5 ↦ᵣ borrow) **
+  ((sp + signExtend12 offA) ↦ₘ aLimb) ** ((sp + signExtend12 offB) ↦ₘ diff)
+
+theorem subLimb0Post_unfold (sp : Word) (offA offB : BitVec 12) (aLimb bLimb : Word) :
+    subLimb0Post sp offA offB aLimb bLimb =
+      (let borrow := if BitVec.ult aLimb bLimb then (1 : Word) else 0
+       let diff := aLimb - bLimb
+       (.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ diff) ** (.x6 ↦ᵣ bLimb) ** (.x5 ↦ᵣ borrow) **
+       ((sp + signExtend12 offA) ↦ₘ aLimb) ** ((sp + signExtend12 offB) ↦ₘ diff)) := by
+  delta subLimb0Post; rfl
+
+/-- Named-postcondition wrapper for `sub_limb0_spec_within`. 0 statement lets. -/
+theorem sub_limb0_named_spec_within (offA offB : BitVec 12)
+    (sp aLimb bLimb v7 v6 v5 : Word) (base : Word) :
+    cpsTripleWithin 5 base (base + 20) (subLimb0Code offA offB base)
+      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7) ** (.x6 ↦ᵣ v6) ** (.x5 ↦ᵣ v5) **
+       ((sp + signExtend12 offA) ↦ₘ aLimb) ** ((sp + signExtend12 offB) ↦ₘ bLimb))
+      (subLimb0Post sp offA offB aLimb bLimb) :=
+  cpsTripleWithin_weaken
+    (fun h hp => hp)
+    (fun h hp => by simp only [subLimb0Post_unfold]; exact hp)
+    (sub_limb0_spec_within offA offB sp aLimb bLimb v7 v6 v5 base)
+
+/-- Code requirement for `sub_limb_carry_spec_within`. -/
+abbrev subLimbCarryCode (offA offB : BitVec 12) (base : Word) : CodeReq :=
+  CodeReq.union (CodeReq.singleton base (.LD .x7 .x12 offA))
+  (CodeReq.union (CodeReq.singleton (base + 4) (.LD .x6 .x12 offB))
+  (CodeReq.union (CodeReq.singleton (base + 8) (.SLTU .x11 .x7 .x6))
+  (CodeReq.union (CodeReq.singleton (base + 12) (.SUB .x7 .x7 .x6))
+  (CodeReq.union (CodeReq.singleton (base + 16) (.SLTU .x6 .x7 .x5))
+  (CodeReq.union (CodeReq.singleton (base + 20) (.SUB .x7 .x7 .x5))
+  (CodeReq.union (CodeReq.singleton (base + 24) (.OR .x5 .x11 .x6))
+   (CodeReq.singleton (base + 28) (.SD .x12 .x7 offB))))))))
+
+/-- Bundled postcondition for `sub_limb_carry_spec_within`. Hides 7 computation lets. -/
+@[irreducible]
+def subLimbCarryPost (sp : Word) (offA offB : BitVec 12) (aLimb bLimb borrowIn : Word) : Assertion :=
+  let borrow1 := if BitVec.ult aLimb bLimb then (1 : Word) else 0
+  let temp := aLimb - bLimb
+  let borrow2 := if BitVec.ult temp borrowIn then (1 : Word) else 0
+  let result := temp - borrowIn
+  let borrowOut := borrow1 ||| borrow2
+  (.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ result) ** (.x6 ↦ᵣ borrow2) ** (.x5 ↦ᵣ borrowOut) ** (.x11 ↦ᵣ borrow1) **
+  ((sp + signExtend12 offA) ↦ₘ aLimb) ** ((sp + signExtend12 offB) ↦ₘ result)
+
+theorem subLimbCarryPost_unfold (sp : Word) (offA offB : BitVec 12) (aLimb bLimb borrowIn : Word) :
+    subLimbCarryPost sp offA offB aLimb bLimb borrowIn =
+      (let borrow1 := if BitVec.ult aLimb bLimb then (1 : Word) else 0
+       let temp := aLimb - bLimb
+       let borrow2 := if BitVec.ult temp borrowIn then (1 : Word) else 0
+       let result := temp - borrowIn
+       let borrowOut := borrow1 ||| borrow2
+       (.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ result) ** (.x6 ↦ᵣ borrow2) ** (.x5 ↦ᵣ borrowOut) ** (.x11 ↦ᵣ borrow1) **
+       ((sp + signExtend12 offA) ↦ₘ aLimb) ** ((sp + signExtend12 offB) ↦ₘ result)) := by
+  delta subLimbCarryPost; rfl
+
+/-- Named-postcondition wrapper for `sub_limb_carry_spec_within`. 0 statement lets. -/
+theorem sub_limb_carry_named_spec_within (offA offB : BitVec 12)
+    (sp aLimb bLimb v7 v6 borrowIn v11 : Word) (base : Word) :
+    cpsTripleWithin 8 base (base + 32) (subLimbCarryCode offA offB base)
+      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7) ** (.x6 ↦ᵣ v6) ** (.x5 ↦ᵣ borrowIn) ** (.x11 ↦ᵣ v11) **
+       ((sp + signExtend12 offA) ↦ₘ aLimb) ** ((sp + signExtend12 offB) ↦ₘ bLimb))
+      (subLimbCarryPost sp offA offB aLimb bLimb borrowIn) :=
+  cpsTripleWithin_weaken
+    (fun h hp => hp)
+    (fun h hp => by simp only [subLimbCarryPost_unfold]; exact hp)
+    (sub_limb_carry_spec_within offA offB sp aLimb bLimb v7 v6 borrowIn v11 base)
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Add `subLimb0Code` + `subLimb0Post` + `sub_limb0_named_spec_within` with **0** statement lets (down from 5) — 5-instruction SUB limb 0 spec in `Sub/LimbSpec.lean`
- Add `subLimbCarryCode` + `subLimbCarryPost` + `sub_limb_carry_named_spec_within` with **0** statement lets (down from 8) — 8-instruction SUB carry-limb spec

Named wrappers inline `memA`/`memB` addresses as `sp + signExtend12 offA/offB` directly, avoiding statement-level `let` bindings for the address computation. `sub_limb_carry_spec_within` callers in `Sub/Spec.lean` use `have L := ...` + `runBlock` without `intro_lets`, so adding named wrappers is purely additive.

Continues the let-chain reduction sweep from PRs #4530–#4555.

Refs #61. Bead: evm-asm-yz73p.

## Verification
- lake build EvmAsm.Evm64.Sub.LimbSpec
- scripts/check-file-size.sh
- lake build

Authored by @pirapira; implemented by Claude Code