### PR TITLE
chore(mul): add mul-col2/col1-partA/col1-partB named specs (6-8→0 lets)

### DIFF
--- a/EvmAsm/Evm64/Multiply/LimbSpec.lean
+++ b/EvmAsm/Evm64/Multiply/LimbSpec.lean
@@ -610,8 +610,124 @@ theorem evm_mul_named_spec_within (sp base : Word)
     (fun h hp => by simp only [evmMulLimbPost_unfold]; exact hp)
     (evm_mul_spec_within sp base a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11)
 
+/-- Bundled postcondition for `mul_col2_spec_within`. Hides 6 computation lets. -/
+@[irreducible]
+def mulCol2Post (sp a0 a1 b2 r2_in r3p : Word) : Assertion :=
+  let lo_a0b2 := a0 * b2
+  let hi_a0b2 := rv64_mulhu a0 b2
+  let r2_out := r2_in + lo_a0b2
+  let carry02 := if BitVec.ult r2_out lo_a0b2 then (1 : Word) else 0
+  let r3_contrib := hi_a0b2 + carry02 + a1 * b2
+  let r3_out := r3p + r3_contrib
+  (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b2) ** (.x6 ↦ᵣ r3_contrib) ** (.x7 ↦ᵣ a1 * b2) **
+  (.x10 ↦ᵣ r3_out) ** (.x11 ↦ᵣ r2_out) **
+  (sp ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ r3p) ** ((sp + 48) ↦ₘ r2_out)
 
+theorem mulCol2Post_unfold (sp a0 a1 b2 r2_in r3p : Word) :
+    mulCol2Post sp a0 a1 b2 r2_in r3p =
+      (let lo_a0b2 := a0 * b2
+       let hi_a0b2 := rv64_mulhu a0 b2
+       let r2_out := r2_in + lo_a0b2
+       let carry02 := if BitVec.ult r2_out lo_a0b2 then (1 : Word) else 0
+       let r3_contrib := hi_a0b2 + carry02 + a1 * b2
+       let r3_out := r3p + r3_contrib
+       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b2) ** (.x6 ↦ᵣ r3_contrib) ** (.x7 ↦ᵣ a1 * b2) **
+       (.x10 ↦ᵣ r3_out) ** (.x11 ↦ᵣ r2_out) **
+       (sp ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ r3p) ** ((sp + 48) ↦ₘ r2_out)) := by
+  delta mulCol2Post; rfl
 
+/-- Named-postcondition wrapper for `mul_col2_spec_within`. 0 statement lets. -/
+theorem mul_col2_named_spec_within (sp base : Word)
+    (a0 a1 b2 r2_in r3p v5 v6 v7 v10 : Word) :
+    cpsTripleWithin 13 base (base + 52) (mul_col2_code base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+       (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ r2_in) **
+       (sp ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ r3p) ** ((sp + 48) ↦ₘ b2))
+      (mulCol2Post sp a0 a1 b2 r2_in r3p) :=
+  cpsTripleWithin_weaken
+    (fun h hp => hp)
+    (fun h hp => by simp only [mulCol2Post_unfold]; exact hp)
+    (mul_col2_spec_within sp base a0 a1 b2 r2_in r3p v5 v6 v7 v10)
+
+/-- Bundled postcondition for `mul_col1_partA_spec_within`. Hides 7 computation lets. -/
+@[irreducible]
+def mulCol1PartAPost (sp a0 b1 r1_in r2_in : Word) : Assertion :=
+  let lo_a0b1 := a0 * b1
+  let hi_a0b1 := rv64_mulhu a0 b1
+  let r1_out := r1_in + lo_a0b1
+  let carry01 := if BitVec.ult r1_out lo_a0b1 then (1 : Word) else 0
+  let r2_contrib1 := hi_a0b1 + carry01
+  let r2_acc1 := r2_in + r2_contrib1
+  let carry_r2_1 := if BitVec.ult r2_acc1 r2_contrib1 then (1 : Word) else 0
+  (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b1) ** (.x6 ↦ᵣ r2_contrib1) ** (.x7 ↦ᵣ carry01) **
+  (.x10 ↦ᵣ carry_r2_1) ** (.x11 ↦ᵣ r2_acc1) **
+  (sp ↦ₘ a0) ** ((sp + 40) ↦ₘ r1_out)
+
+theorem mulCol1PartAPost_unfold (sp a0 b1 r1_in r2_in : Word) :
+    mulCol1PartAPost sp a0 b1 r1_in r2_in =
+      (let lo_a0b1 := a0 * b1
+       let hi_a0b1 := rv64_mulhu a0 b1
+       let r1_out := r1_in + lo_a0b1
+       let carry01 := if BitVec.ult r1_out lo_a0b1 then (1 : Word) else 0
+       let r2_contrib1 := hi_a0b1 + carry01
+       let r2_acc1 := r2_in + r2_contrib1
+       let carry_r2_1 := if BitVec.ult r2_acc1 r2_contrib1 then (1 : Word) else 0
+       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b1) ** (.x6 ↦ᵣ r2_contrib1) ** (.x7 ↦ᵣ carry01) **
+       (.x10 ↦ᵣ carry_r2_1) ** (.x11 ↦ᵣ r2_acc1) **
+       (sp ↦ₘ a0) ** ((sp + 40) ↦ₘ r1_out)) := by
+  delta mulCol1PartAPost; rfl
+
+/-- Named-postcondition wrapper for `mul_col1_partA_spec_within`. 0 statement lets. -/
+theorem mul_col1_partA_named_spec_within (sp base : Word)
+    (a0 b1 r1_in r2_in v5 v6 v7 : Word) :
+    cpsTripleWithin 10 base (base + 40) (mul_col1_partA_code base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+       (.x10 ↦ᵣ r1_in) ** (.x11 ↦ᵣ r2_in) **
+       (sp ↦ₘ a0) ** ((sp + 40) ↦ₘ b1))
+      (mulCol1PartAPost sp a0 b1 r1_in r2_in) :=
+  cpsTripleWithin_weaken
+    (fun h hp => hp)
+    (fun h hp => by simp only [mulCol1PartAPost_unfold]; exact hp)
+    (mul_col1_partA_spec_within sp base a0 b1 r1_in r2_in v5 v6 v7)
+
+/-- Bundled postcondition for `mul_col1_partB_spec_within`. Hides 6 computation lets. -/
+@[irreducible]
+def mulCol1PartBPost (sp a1 a2 b1 r3p0 carry_r2_1 r2_acc1 : Word) : Assertion :=
+  let lo_a1b1 := a1 * b1
+  let hi_a1b1 := rv64_mulhu a1 b1
+  let r2_out := r2_acc1 + lo_a1b1
+  let carry_r2_2 := if BitVec.ult r2_out lo_a1b1 then (1 : Word) else 0
+  let r3_contrib1 := hi_a1b1 + carry_r2_2
+  let r3_spill := carry_r2_1 + r3_contrib1 + a2 * b1 + r3p0
+  (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b1) ** (.x6 ↦ᵣ r3p0) ** (.x7 ↦ᵣ carry_r2_2) **
+  (.x10 ↦ᵣ r3_spill) ** (.x11 ↦ᵣ r2_out) **
+  ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ r3_spill) ** ((sp + 24) ↦ₘ r3p0)
+
+theorem mulCol1PartBPost_unfold (sp a1 a2 b1 r3p0 carry_r2_1 r2_acc1 : Word) :
+    mulCol1PartBPost sp a1 a2 b1 r3p0 carry_r2_1 r2_acc1 =
+      (let lo_a1b1 := a1 * b1
+       let hi_a1b1 := rv64_mulhu a1 b1
+       let r2_out := r2_acc1 + lo_a1b1
+       let carry_r2_2 := if BitVec.ult r2_out lo_a1b1 then (1 : Word) else 0
+       let r3_contrib1 := hi_a1b1 + carry_r2_2
+       let r3_spill := carry_r2_1 + r3_contrib1 + a2 * b1 + r3p0
+       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b1) ** (.x6 ↦ᵣ r3p0) ** (.x7 ↦ᵣ carry_r2_2) **
+       (.x10 ↦ᵣ r3_spill) ** (.x11 ↦ᵣ r2_out) **
+       ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ r3_spill) ** ((sp + 24) ↦ₘ r3p0)) := by
+  delta mulCol1PartBPost; rfl
+
+/-- Named-postcondition wrapper for `mul_col1_partB_spec_within`. 0 statement lets. -/
+theorem mul_col1_partB_named_spec_within (sp base : Word)
+    (a1 a2 b1 r3p0 v6 v7 carry_r2_1 r2_acc1 : Word) :
+    cpsTripleWithin 13 (base + 40) (base + 92) (mul_col1_partB_code base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b1) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+       (.x10 ↦ᵣ carry_r2_1) ** (.x11 ↦ᵣ r2_acc1) **
+       ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ r3p0))
+      (mulCol1PartBPost sp a1 a2 b1 r3p0 carry_r2_1 r2_acc1) :=
+  cpsTripleWithin_weaken
+    (fun h hp => hp)
+    (fun h hp => by simp only [mulCol1PartBPost_unfold]; exact hp)
+    (mul_col1_partB_spec_within sp base a1 a2 b1 r3p0 v6 v7 carry_r2_1 r2_acc1)
 
 
 


### PR DESCRIPTION
## Summary
- Add `mulCol2Post` + `mul_col2_named_spec_within` with **0** statement lets (down from 7) — col-2 multiply spec in `Multiply/LimbSpec.lean`
- Add `mulCol1PartAPost` + `mul_col1_partA_named_spec_within` with **0** statement lets (down from 8) — col-1 part A
- Add `mulCol1PartBPost` + `mul_col1_partB_named_spec_within` with **0** statement lets (down from 7) — col-1 part B

All three are internal-only specs (no external callers); adding named wrappers is purely additive.

Continues the let-chain reduction sweep from PRs #4530–#4558.

Refs #61. Bead: evm-asm-yz73p.

## Verification
- lake build EvmAsm.Evm64.Multiply.LimbSpec
- scripts/check-file-size.sh
- lake build

Authored by @pirapira; implemented by Claude Code