### PR TITLE
chore(sub,add): add phase1/phase2 postcondition bundles for carry-limb specs

### DIFF
--- a/EvmAsm/Evm64/Add/LimbSpec.lean
+++ b/EvmAsm/Evm64/Add/LimbSpec.lean
@@ -206,4 +206,38 @@ theorem add_limb_carry_named_spec_within (offA offB : BitVec 12)
     (fun h hp => by simp only [addLimbCarryPost_unfold]; exact hp)
     (add_limb_carry_spec_within offA offB sp aLimb bLimb v7 v6 carryIn v11 base)
 
+/-- Bundled postcondition for `add_limb_carry_spec_phase1_within`. -/
+@[irreducible]
+def addLimbCarryPhase1Post (sp : Word) (offA offB : BitVec 12) (aLimb bLimb : Word) : Assertion :=
+  let psum := aLimb + bLimb
+  let carry1 := if BitVec.ult psum bLimb then (1 : Word) else 0
+  (.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ psum) ** (.x6 ↦ᵣ bLimb) ** (.x11 ↦ᵣ carry1) **
+  ((sp + signExtend12 offA) ↦ₘ aLimb) ** ((sp + signExtend12 offB) ↦ₘ bLimb)
+
+theorem addLimbCarryPhase1Post_unfold (sp : Word) (offA offB : BitVec 12) (aLimb bLimb : Word) :
+    addLimbCarryPhase1Post sp offA offB aLimb bLimb =
+      (let psum := aLimb + bLimb
+       let carry1 := if BitVec.ult psum bLimb then (1 : Word) else 0
+       (.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ psum) ** (.x6 ↦ᵣ bLimb) ** (.x11 ↦ᵣ carry1) **
+       ((sp + signExtend12 offA) ↦ₘ aLimb) ** ((sp + signExtend12 offB) ↦ₘ bLimb)) := by
+  delta addLimbCarryPhase1Post; rfl
+
+/-- Bundled postcondition for `add_limb_carry_spec_phase2_within`. -/
+@[irreducible]
+def addLimbCarryPhase2Post (sp : Word) (offB : BitVec 12) (psum carryIn carry1 aLimb : Word) (memA : Word) : Assertion :=
+  let result := psum + carryIn
+  let carry2 := if BitVec.ult result carryIn then (1 : Word) else 0
+  let carryOut := carry1 ||| carry2
+  (.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ result) ** (.x6 ↦ᵣ carry2) ** (.x5 ↦ᵣ carryOut) ** (.x11 ↦ᵣ carry1) **
+  (memA ↦ₘ aLimb) ** ((sp + signExtend12 offB) ↦ₘ result)
+
+theorem addLimbCarryPhase2Post_unfold (sp : Word) (offB : BitVec 12) (psum carryIn carry1 aLimb : Word) (memA : Word) :
+    addLimbCarryPhase2Post sp offB psum carryIn carry1 aLimb memA =
+      (let result := psum + carryIn
+       let carry2 := if BitVec.ult result carryIn then (1 : Word) else 0
+       let carryOut := carry1 ||| carry2
+       (.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ result) ** (.x6 ↦ᵣ carry2) ** (.x5 ↦ᵣ carryOut) ** (.x11 ↦ᵣ carry1) **
+       (memA ↦ₘ aLimb) ** ((sp + signExtend12 offB) ↦ₘ result)) := by
+  delta addLimbCarryPhase2Post; rfl
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Sub/LimbSpec.lean
+++ b/EvmAsm/Evm64/Sub/LimbSpec.lean
@@ -206,4 +206,38 @@ theorem sub_limb_carry_named_spec_within (offA offB : BitVec 12)
     (fun h hp => by simp only [subLimbCarryPost_unfold]; exact hp)
     (sub_limb_carry_spec_within offA offB sp aLimb bLimb v7 v6 borrowIn v11 base)
 
+/-- Bundled postcondition for `sub_limb_carry_spec_phase1_within`. -/
+@[irreducible]
+def subLimbCarryPhase1Post (sp : Word) (offA offB : BitVec 12) (aLimb bLimb : Word) : Assertion :=
+  let borrow1 := if BitVec.ult aLimb bLimb then (1 : Word) else 0
+  let temp := aLimb - bLimb
+  (.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ temp) ** (.x6 ↦ᵣ bLimb) ** (.x11 ↦ᵣ borrow1) **
+  ((sp + signExtend12 offA) ↦ₘ aLimb) ** ((sp + signExtend12 offB) ↦ₘ bLimb)
+
+theorem subLimbCarryPhase1Post_unfold (sp : Word) (offA offB : BitVec 12) (aLimb bLimb : Word) :
+    subLimbCarryPhase1Post sp offA offB aLimb bLimb =
+      (let borrow1 := if BitVec.ult aLimb bLimb then (1 : Word) else 0
+       let temp := aLimb - bLimb
+       (.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ temp) ** (.x6 ↦ᵣ bLimb) ** (.x11 ↦ᵣ borrow1) **
+       ((sp + signExtend12 offA) ↦ₘ aLimb) ** ((sp + signExtend12 offB) ↦ₘ bLimb)) := by
+  delta subLimbCarryPhase1Post; rfl
+
+/-- Bundled postcondition for `sub_limb_carry_spec_phase2_within`. -/
+@[irreducible]
+def subLimbCarryPhase2Post (sp : Word) (offB : BitVec 12) (temp borrowIn borrow1 aLimb : Word) (memA : Word) : Assertion :=
+  let borrow2 := if BitVec.ult temp borrowIn then (1 : Word) else 0
+  let result := temp - borrowIn
+  let borrowOut := borrow1 ||| borrow2
+  (.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ result) ** (.x6 ↦ᵣ borrow2) ** (.x5 ↦ᵣ borrowOut) ** (.x11 ↦ᵣ borrow1) **
+  (memA ↦ₘ aLimb) ** ((sp + signExtend12 offB) ↦ₘ result)
+
+theorem subLimbCarryPhase2Post_unfold (sp : Word) (offB : BitVec 12) (temp borrowIn borrow1 aLimb : Word) (memA : Word) :
+    subLimbCarryPhase2Post sp offB temp borrowIn borrow1 aLimb memA =
+      (let borrow2 := if BitVec.ult temp borrowIn then (1 : Word) else 0
+       let result := temp - borrowIn
+       let borrowOut := borrow1 ||| borrow2
+       (.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ result) ** (.x6 ↦ᵣ borrow2) ** (.x5 ↦ᵣ borrowOut) ** (.x11 ↦ᵣ borrow1) **
+       (memA ↦ₘ aLimb) ** ((sp + signExtend12 offB) ↦ₘ result)) := by
+  delta subLimbCarryPhase2Post; rfl
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Add `subLimbCarryPhase1Post` and `subLimbCarryPhase2Post` bundles in `Sub/LimbSpec.lean` — postcondition bundles for the 4-instruction phase sub-specs used internally by `sub_limb_carry_spec_within`
- Add `addLimbCarryPhase1Post` and `addLimbCarryPhase2Post` bundles in `Add/LimbSpec.lean` — mirror pattern for Add

Both phase2 bundles correctly exclude `bLimb` (precondition-only parameter not needed in the postcondition).

Continues the let-chain reduction sweep from PRs #4530–#4560.

Refs #61. Bead: evm-asm-yz73p.

## Verification
- lake build EvmAsm.Evm64.Sub.LimbSpec EvmAsm.Evm64.Add.LimbSpec
- scripts/check-file-size.sh
- lake build

Authored by @pirapira; implemented by Claude Code