### PR TITLE
chore(eq): add eqLimb0/eqOrLimb named specs (3/4→0 lets)

### DIFF
--- a/EvmAsm/Evm64/Eq/LimbSpec.lean
+++ b/EvmAsm/Evm64/Eq/LimbSpec.lean
@@ -55,5 +55,57 @@ theorem eq_or_limb_spec_within (offA offB : BitVec 12)
   have O := or_spec_gen_rd_eq_rs1_within .x7 .x6 acc (aLimb ^^^ bLimb) (base + 12) (by nofun)
   runBlock L0 L1 X O
 
+/-- Code requirement for `eq_limb0_spec_within`. -/
+abbrev eqLimb0Code (offA offB : BitVec 12) (base : Word) : CodeReq :=
+  CodeReq.union (CodeReq.singleton base (.LD .x7 .x12 offA))
+  (CodeReq.union (CodeReq.singleton (base + 4) (.LD .x6 .x12 offB))
+   (CodeReq.singleton (base + 8) (.XOR .x7 .x7 .x6)))
+
+/-- Named-postcondition wrapper for `eq_limb0_spec_within`. 0 statement lets.
+    Postcondition has no let-bound values; addresses are inlined directly. -/
+theorem eq_limb0_named_spec_within (offA offB : BitVec 12)
+    (sp aLimb bLimb v7 v6 : Word) (base : Word) :
+    cpsTripleWithin 3 base (base + 12) (eqLimb0Code offA offB base)
+      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7) ** (.x6 ↦ᵣ v6) **
+       ((sp + signExtend12 offA) ↦ₘ aLimb) ** ((sp + signExtend12 offB) ↦ₘ bLimb))
+      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ (aLimb ^^^ bLimb)) ** (.x6 ↦ᵣ bLimb) **
+       ((sp + signExtend12 offA) ↦ₘ aLimb) ** ((sp + signExtend12 offB) ↦ₘ bLimb)) :=
+  cpsTripleWithin_weaken
+    (fun _ hp => hp)
+    (fun _ hp => hp)
+    (eq_limb0_spec_within offA offB sp aLimb bLimb v7 v6 base)
+
+/-- Code requirement for `eq_or_limb_spec_within`. -/
+abbrev eqOrLimbCode (offA offB : BitVec 12) (base : Word) : CodeReq :=
+  CodeReq.union (CodeReq.singleton base (.LD .x6 .x12 offA))
+  (CodeReq.union (CodeReq.singleton (base + 4) (.LD .x5 .x12 offB))
+  (CodeReq.union (CodeReq.singleton (base + 8) (.XOR .x6 .x6 .x5))
+   (CodeReq.singleton (base + 12) (.OR .x7 .x7 .x6))))
+
+/-- Bundled postcondition for `eq_or_limb_spec_within`. Hides `xorK` let. -/
+@[irreducible]
+def eqOrLimbPost (sp : Word) (offA offB : BitVec 12) (aLimb bLimb acc : Word) : Assertion :=
+  let xorK := aLimb ^^^ bLimb
+  (.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ (acc ||| xorK)) ** (.x6 ↦ᵣ xorK) ** (.x5 ↦ᵣ bLimb) **
+  ((sp + signExtend12 offA) ↦ₘ aLimb) ** ((sp + signExtend12 offB) ↦ₘ bLimb)
+
+theorem eqOrLimbPost_unfold (sp : Word) (offA offB : BitVec 12) (aLimb bLimb acc : Word) :
+    eqOrLimbPost sp offA offB aLimb bLimb acc =
+      (let xorK := aLimb ^^^ bLimb
+       (.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ (acc ||| xorK)) ** (.x6 ↦ᵣ xorK) ** (.x5 ↦ᵣ bLimb) **
+       ((sp + signExtend12 offA) ↦ₘ aLimb) ** ((sp + signExtend12 offB) ↦ₘ bLimb)) := by
+  delta eqOrLimbPost; rfl
+
+/-- Named-postcondition wrapper for `eq_or_limb_spec_within`. 0 statement lets. -/
+theorem eq_or_limb_named_spec_within (offA offB : BitVec 12)
+    (sp aLimb bLimb v6 v5 acc : Word) (base : Word) :
+    cpsTripleWithin 4 base (base + 16) (eqOrLimbCode offA offB base)
+      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ acc) ** (.x6 ↦ᵣ v6) ** (.x5 ↦ᵣ v5) **
+       ((sp + signExtend12 offA) ↦ₘ aLimb) ** ((sp + signExtend12 offB) ↦ₘ bLimb))
+      (eqOrLimbPost sp offA offB aLimb bLimb acc) :=
+  cpsTripleWithin_weaken
+    (fun h hp => hp)
+    (fun h hp => by simp only [eqOrLimbPost_unfold]; exact hp)
+    (eq_or_limb_spec_within offA offB sp aLimb bLimb v6 v5 acc base)
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Add `eqLimb0Code` abbrev + `eq_limb0_named_spec_within` with **0** statement lets (down from 3) in `Eq/LimbSpec.lean` — postcondition has no let-bound values; addresses inlined directly
- Add `eqOrLimbCode` abbrev + `eqOrLimbPost` bundle + `eq_or_limb_named_spec_within` with **0** statement lets (down from 4) — bundle hides `xorK = aLimb ^^^ bLimb`

Callers in `Eq/Spec.lean` use `have Lx := ...` + `runBlock` without `intro_lets`.

Continues the let-chain reduction sweep from PRs #4530–#4565.

Refs #61. Bead: evm-asm-yz73p.

## Verification
- lake build EvmAsm.Evm64.Eq.LimbSpec
- scripts/check-file-size.sh
- lake build

Authored by @pirapira; implemented by Claude Code