### PR TITLE
chore(shift): add shr/shl/sar last/first limb named specs (4→0 lets)

### DIFF
--- a/EvmAsm/Evm64/Shift/LimbSpec.lean
+++ b/EvmAsm/Evm64/Shift/LimbSpec.lean
@@ -970,5 +970,18 @@ theorem shr_phase_a_spec_within (sp r5 r10 : Word)
       combined
   exact result
 
+/-- Named-postcondition wrapper for `shr_last_limb_spec_within`. 0 statement lets.
+    Inlines memSrc = sp+24, memDst = sp+dst_off, result = src >>> (bit_shift % 64). -/
+theorem shr_last_limb_named_spec_within (dst_off : BitVec 12)
+    (sp src dstOld v5 bit_shift : Word) (base : Word) :
+    cpsTripleWithin 3 base (base + 12) (shr_last_limb_code dst_off base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ bit_shift) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ src) ** ((sp + signExtend12 dst_off) ↦ₘ dstOld))
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ src >>> (bit_shift.toNat % 64)) ** (.x6 ↦ᵣ bit_shift) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ src) **
+       ((sp + signExtend12 dst_off) ↦ₘ src >>> (bit_shift.toNat % 64))) :=
+  cpsTripleWithin_weaken
+    (fun _ hp => hp) (fun _ hp => hp)
+    (shr_last_limb_spec_within dst_off sp src dstOld v5 bit_shift base)
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Shift/SarSpec.lean
+++ b/EvmAsm/Evm64/Shift/SarSpec.lean
@@ -279,5 +279,18 @@ theorem sar_sign_fill_path_spec_within (sp : Word)
   have S3 := sd_spec_gen_within .x12 .x5 (sp + 32) (BitVec.sshiftRight v3 63) v3 24 (base + 24)
   runBlock LD0 SR AD S0 S1 S2 S3
 
+/-- Named-postcondition wrapper for `sar_last_limb_spec_within`. 0 statement lets.
+    Inlines memSrc = sp+24, memDst = sp+dst_off, result = sshiftRight src (bit_shift % 64). -/
+theorem sar_last_limb_named_spec_within (dst_off : BitVec 12)
+    (sp src dstOld v5 bit_shift : Word) (base : Word) :
+    cpsTripleWithin 3 base (base + 12) (sar_last_limb_code base dst_off)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ bit_shift) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ src) ** ((sp + signExtend12 dst_off) ↦ₘ dstOld))
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ BitVec.sshiftRight src (bit_shift.toNat % 64)) ** (.x6 ↦ᵣ bit_shift) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ src) **
+       ((sp + signExtend12 dst_off) ↦ₘ BitVec.sshiftRight src (bit_shift.toNat % 64))) :=
+  cpsTripleWithin_weaken
+    (fun _ hp => hp) (fun _ hp => hp)
+    (sar_last_limb_spec_within dst_off sp src dstOld v5 bit_shift base)
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Shift/ShlSpec.lean
+++ b/EvmAsm/Evm64/Shift/ShlSpec.lean
@@ -308,5 +308,18 @@ theorem shl_body_0_spec_within (sp : Word)
   rw [hexit] at JL
   runBlock MM1 MM2 MM3 FL JL
 
+/-- Named-postcondition wrapper for `shl_first_limb_spec_within`. 0 statement lets.
+    Inlines memSrc = sp+0, memDst = sp+dst_off, result = src <<< (bit_shift % 64). -/
+theorem shl_first_limb_named_spec_within (dst_off : BitVec 12)
+    (sp src dstOld v5 bit_shift : Word) (base : Word) :
+    cpsTripleWithin 3 base (base + 12) (shl_first_limb_code base dst_off)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ bit_shift) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ src) ** ((sp + signExtend12 dst_off) ↦ₘ dstOld))
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ src <<< (bit_shift.toNat % 64)) ** (.x6 ↦ᵣ bit_shift) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ src) **
+       ((sp + signExtend12 dst_off) ↦ₘ src <<< (bit_shift.toNat % 64))) :=
+  cpsTripleWithin_weaken
+    (fun _ hp => hp) (fun _ hp => hp)
+    (shl_first_limb_spec_within dst_off sp src dstOld v5 bit_shift base)
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Add `shr_last_limb_named_spec_within` with **0** statement lets (down from 4) in `Shift/LimbSpec.lean` — `result = src >>> (bit_shift % 64)`, `memSrc = sp+24` inlined
- Add `shl_first_limb_named_spec_within` with **0** statement lets in `Shift/ShlSpec.lean` — `result = src <<< (bit_shift % 64)`, `memSrc = sp+0`
- Add `sar_last_limb_named_spec_within` with **0** statement lets in `Shift/SarSpec.lean` — `result = sshiftRight src (bit_shift % 64)`, `memSrc = sp+24`

All three follow the same approach: inline addresses and result directly into the theorem statement. All callers use `runBlock` without `intro_lets`.

Continues the let-chain reduction sweep from PRs #4530–#4566.

Refs #61. Bead: evm-asm-yz73p.

## Verification
- lake build EvmAsm.Evm64.Shift.LimbSpec EvmAsm.Evm64.Shift.ShlSpec EvmAsm.Evm64.Shift.SarSpec
- scripts/check-file-size.sh
- lake build

Authored by @pirapira; implemented by Claude Code