### PR TITLE
chore(xor,or,and): add xorLimb/orLimb/andLimb named specs (3→0 lets)

### DIFF
--- a/EvmAsm/Evm64/And/LimbSpec.lean
+++ b/EvmAsm/Evm64/And/LimbSpec.lean
@@ -35,5 +35,23 @@ theorem and_limb_spec_within (offA offB : BitVec 12)
   have S := sd_spec_gen_within .x12 .x7 sp (aLimb &&& bLimb) bLimb offB (base + 12)
   runBlock L0 L1 A S
 
+/-- Code requirement for `and_limb_spec_within`. -/
+abbrev andLimbCode (offA offB : BitVec 12) (base : Word) : CodeReq :=
+  CodeReq.union (CodeReq.singleton base (.LD .x7 .x12 offA))
+  (CodeReq.union (CodeReq.singleton (base + 4) (.LD .x6 .x12 offB))
+  (CodeReq.union (CodeReq.singleton (base + 8) (.AND .x7 .x7 .x6))
+   (CodeReq.singleton (base + 12) (.SD .x12 .x7 offB))))
+
+/-- Named-postcondition wrapper for `and_limb_spec_within`. 0 statement lets. -/
+theorem and_limb_named_spec_within (offA offB : BitVec 12)
+    (sp aLimb bLimb v7 v6 : Word) (base : Word) :
+    cpsTripleWithin 4 base (base + 16) (andLimbCode offA offB base)
+      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7) ** (.x6 ↦ᵣ v6) **
+       ((sp + signExtend12 offA) ↦ₘ aLimb) ** ((sp + signExtend12 offB) ↦ₘ bLimb))
+      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ (aLimb &&& bLimb)) ** (.x6 ↦ᵣ bLimb) **
+       ((sp + signExtend12 offA) ↦ₘ aLimb) ** ((sp + signExtend12 offB) ↦ₘ (aLimb &&& bLimb))) :=
+  cpsTripleWithin_weaken
+    (fun _ hp => hp) (fun _ hp => hp)
+    (and_limb_spec_within offA offB sp aLimb bLimb v7 v6 base)
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Or/LimbSpec.lean
+++ b/EvmAsm/Evm64/Or/LimbSpec.lean
@@ -34,5 +34,23 @@ theorem or_limb_spec_within (offA offB : BitVec 12)
   have S := sd_spec_gen_within .x12 .x7 sp (aLimb ||| bLimb) bLimb offB (base + 12)
   runBlock L0 L1 O S
 
+/-- Code requirement for `or_limb_spec_within`. -/
+abbrev orLimbCode (offA offB : BitVec 12) (base : Word) : CodeReq :=
+  CodeReq.union (CodeReq.singleton base (.LD .x7 .x12 offA))
+  (CodeReq.union (CodeReq.singleton (base + 4) (.LD .x6 .x12 offB))
+  (CodeReq.union (CodeReq.singleton (base + 8) (.OR .x7 .x7 .x6))
+   (CodeReq.singleton (base + 12) (.SD .x12 .x7 offB))))
+
+/-- Named-postcondition wrapper for `or_limb_spec_within`. 0 statement lets. -/
+theorem or_limb_named_spec_within (offA offB : BitVec 12)
+    (sp aLimb bLimb v7 v6 : Word) (base : Word) :
+    cpsTripleWithin 4 base (base + 16) (orLimbCode offA offB base)
+      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7) ** (.x6 ↦ᵣ v6) **
+       ((sp + signExtend12 offA) ↦ₘ aLimb) ** ((sp + signExtend12 offB) ↦ₘ bLimb))
+      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ (aLimb ||| bLimb)) ** (.x6 ↦ᵣ bLimb) **
+       ((sp + signExtend12 offA) ↦ₘ aLimb) ** ((sp + signExtend12 offB) ↦ₘ (aLimb ||| bLimb))) :=
+  cpsTripleWithin_weaken
+    (fun _ hp => hp) (fun _ hp => hp)
+    (or_limb_spec_within offA offB sp aLimb bLimb v7 v6 base)
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Xor/LimbSpec.lean
+++ b/EvmAsm/Evm64/Xor/LimbSpec.lean
@@ -34,5 +34,23 @@ theorem xor_limb_spec_within (offA offB : BitVec 12)
   have S := sd_spec_gen_within .x12 .x7 sp (aLimb ^^^ bLimb) bLimb offB (base + 12)
   runBlock L0 L1 X S
 
+/-- Code requirement for `xor_limb_spec_within`. -/
+abbrev xorLimbCode (offA offB : BitVec 12) (base : Word) : CodeReq :=
+  CodeReq.union (CodeReq.singleton base (.LD .x7 .x12 offA))
+  (CodeReq.union (CodeReq.singleton (base + 4) (.LD .x6 .x12 offB))
+  (CodeReq.union (CodeReq.singleton (base + 8) (.XOR .x7 .x7 .x6))
+   (CodeReq.singleton (base + 12) (.SD .x12 .x7 offB))))
+
+/-- Named-postcondition wrapper for `xor_limb_spec_within`. 0 statement lets. -/
+theorem xor_limb_named_spec_within (offA offB : BitVec 12)
+    (sp aLimb bLimb v7 v6 : Word) (base : Word) :
+    cpsTripleWithin 4 base (base + 16) (xorLimbCode offA offB base)
+      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7) ** (.x6 ↦ᵣ v6) **
+       ((sp + signExtend12 offA) ↦ₘ aLimb) ** ((sp + signExtend12 offB) ↦ₘ bLimb))
+      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ (aLimb ^^^ bLimb)) ** (.x6 ↦ᵣ bLimb) **
+       ((sp + signExtend12 offA) ↦ₘ aLimb) ** ((sp + signExtend12 offB) ↦ₘ (aLimb ^^^ bLimb))) :=
+  cpsTripleWithin_weaken
+    (fun _ hp => hp) (fun _ hp => hp)
+    (xor_limb_spec_within offA offB sp aLimb bLimb v7 v6 base)
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Add `xorLimbCode` abbrev + `xor_limb_named_spec_within` with **0** statement lets (down from 3) in `Xor/LimbSpec.lean`
- Add `orLimbCode` abbrev + `or_limb_named_spec_within` with **0** statement lets in `Or/LimbSpec.lean`
- Add `andLimbCode` abbrev + `and_limb_named_spec_within` with **0** statement lets in `And/LimbSpec.lean`

All three follow the same pattern as PR #4566 (`eq_limb0_named`): postcondition has no let-bound values, so `memA`/`memB` addresses are inlined directly into the named wrapper statement. Each uses `cpsTripleWithin_weaken (fun _ hp => hp) (fun _ hp => hp)`.

Refs #61. Bead: evm-asm-yz73p.

## Verification
- lake build EvmAsm.Evm64.Xor.LimbSpec EvmAsm.Evm64.Or.LimbSpec EvmAsm.Evm64.And.LimbSpec
- scripts/check-file-size.sh
- lake build

Authored by @pirapira; implemented by Claude Code