### PR TITLE
chore(signext): add signextBody0/2 postcondition bundles (3 lets each)

### DIFF
--- a/EvmAsm/Evm64/SignExtend/LimbSpec.lean
+++ b/EvmAsm/Evm64/SignExtend/LimbSpec.lean
@@ -822,5 +822,36 @@ theorem signext_phase_c_spec_pure_within (v5 v10 : Word) (base : Word)
       · exact ⟨_, List.Mem.tail _ (List.Mem.tail _ (List.Mem.head _)), rfl, fun h hp => by xperm_hyp hp⟩
       · exact ⟨_, List.Mem.tail _ (List.Mem.tail _ (List.Mem.tail _ (List.Mem.head _))), he3.symm, fun h hp => by xperm_hyp hp⟩)
 
+/-- Bundled postcondition for `signext_body_2_spec_within`. Hides `result` and `signFill`. -/
+@[irreducible]
+def signextBody2Post (sp shiftAmount v2 : Word) : Assertion :=
+  let result := BitVec.sshiftRight (v2 <<< (shiftAmount.toNat % 64)) (shiftAmount.toNat % 64)
+  let signFill := BitVec.sshiftRight result 63
+  (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x6 ↦ᵣ shiftAmount) ** (.x10 ↦ᵣ signFill) **
+  ((sp + 48) ↦ₘ result) ** ((sp + 56) ↦ₘ signFill)
+
+theorem signextBody2Post_unfold (sp shiftAmount v2 : Word) :
+    signextBody2Post sp shiftAmount v2 =
+      (let result := BitVec.sshiftRight (v2 <<< (shiftAmount.toNat % 64)) (shiftAmount.toNat % 64)
+       let signFill := BitVec.sshiftRight result 63
+       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x6 ↦ᵣ shiftAmount) ** (.x10 ↦ᵣ signFill) **
+       ((sp + 48) ↦ₘ result) ** ((sp + 56) ↦ₘ signFill)) := by
+  delta signextBody2Post; rfl
+
+/-- Bundled postcondition for `signext_body_0_spec_within`. Hides `result` and `signFill`. -/
+@[irreducible]
+def signextBody0Post (sp shiftAmount v0 : Word) : Assertion :=
+  let result := BitVec.sshiftRight (v0 <<< (shiftAmount.toNat % 64)) (shiftAmount.toNat % 64)
+  let signFill := BitVec.sshiftRight result 63
+  (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x6 ↦ᵣ shiftAmount) ** (.x10 ↦ᵣ signFill) **
+  ((sp + 32) ↦ₘ result) ** ((sp + 40) ↦ₘ signFill) ** ((sp + 48) ↦ₘ signFill) ** ((sp + 56) ↦ₘ signFill)
+
+theorem signextBody0Post_unfold (sp shiftAmount v0 : Word) :
+    signextBody0Post sp shiftAmount v0 =
+      (let result := BitVec.sshiftRight (v0 <<< (shiftAmount.toNat % 64)) (shiftAmount.toNat % 64)
+       let signFill := BitVec.sshiftRight result 63
+       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x6 ↦ᵣ shiftAmount) ** (.x10 ↦ᵣ signFill) **
+       ((sp + 32) ↦ₘ result) ** ((sp + 40) ↦ₘ signFill) ** ((sp + 48) ↦ₘ signFill) ** ((sp + 56) ↦ₘ signFill)) := by
+  delta signextBody0Post; rfl
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Add `@[irreducible] def signextBody2Post` + `signextBody2Post_unfold` in `SignExtend/LimbSpec.lean` — bundles `result = sshiftRight(v2 <<< shift, shift)` and `signFill = sshiftRight(result, 63)` for body-2
- Add `@[irreducible] def signextBody0Post` + `signextBody0Post_unfold` — bundles same computation for body-0

Both hide the 2 computation lets; callers in `SignExtend/Compose.lean` use direct theorem calls without `intro_lets`.

Continues the let-chain reduction sweep from PRs #4530–#4569.

Refs #61. Bead: evm-asm-yz73p.

## Verification
- lake build EvmAsm.Evm64.SignExtend.LimbSpec
- scripts/check-file-size.sh
- lake build

Authored by @pirapira; implemented by Claude Code