### PR TITLE
chore(signext): add signextBody1Post bundle (3 lets)

### DIFF
--- a/EvmAsm/Evm64/SignExtend/LimbSpec.lean
+++ b/EvmAsm/Evm64/SignExtend/LimbSpec.lean
@@ -822,5 +822,20 @@ theorem signext_phase_c_spec_pure_within (v5 v10 : Word) (base : Word)
       · exact ⟨_, List.Mem.tail _ (List.Mem.tail _ (List.Mem.head _)), rfl, fun h hp => by xperm_hyp hp⟩
       · exact ⟨_, List.Mem.tail _ (List.Mem.tail _ (List.Mem.tail _ (List.Mem.head _))), he3.symm, fun h hp => by xperm_hyp hp⟩)
 
+/-- Bundled postcondition for `signext_body_1_spec_within`. Hides `result` and `signFill`. -/
+@[irreducible]
+def signextBody1Post (sp shiftAmount v1 : Word) : Assertion :=
+  let result := BitVec.sshiftRight (v1 <<< (shiftAmount.toNat % 64)) (shiftAmount.toNat % 64)
+  let signFill := BitVec.sshiftRight result 63
+  (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x6 ↦ᵣ shiftAmount) ** (.x10 ↦ᵣ signFill) **
+  ((sp + 40) ↦ₘ result) ** ((sp + 48) ↦ₘ signFill) ** ((sp + 56) ↦ₘ signFill)
+
+theorem signextBody1Post_unfold (sp shiftAmount v1 : Word) :
+    signextBody1Post sp shiftAmount v1 =
+      (let result := BitVec.sshiftRight (v1 <<< (shiftAmount.toNat % 64)) (shiftAmount.toNat % 64)
+       let signFill := BitVec.sshiftRight result 63
+       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x6 ↦ᵣ shiftAmount) ** (.x10 ↦ᵣ signFill) **
+       ((sp + 40) ↦ₘ result) ** ((sp + 48) ↦ₘ signFill) ** ((sp + 56) ↦ₘ signFill)) := by
+  delta signextBody1Post; rfl
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Add `@[irreducible] def signextBody1Post` + `signextBody1Post_unfold` in `SignExtend/LimbSpec.lean` — bundles `result = sshiftRight(v1 <<< shift, shift)` and `signFill = sshiftRight(result, 63)` for body-1 (sp+40..56 memory pattern)

Completes the signext body bundle set alongside PR #4570 (body_0/body_2 bundles). Callers in `SignExtend/Compose.lean` use direct calls without `intro_lets`.

Continues the let-chain reduction sweep from PRs #4530–#4570.

Refs #61. Bead: evm-asm-yz73p.

## Verification
- lake build EvmAsm.Evm64.SignExtend.LimbSpec
- scripts/check-file-size.sh
- lake build

Authored by @pirapira; implemented by Claude Code