### PR TITLE
chore(clz): add CLZ/ModCLZ stage-combined postcondition bundles (3 lets each)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/CLZ.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/CLZ.lean
@@ -347,3 +347,17 @@ theorem divK_clz_spec_within_noNop (val v6Old v7Old : Word) (base : Word) :
     (fun h hp => by xperm_hyp hp)
     (fun h hq => by xperm_hyp hq)
     IefS0eS1eS2eS3eS4eS5e
+
+/-- Bundled postcondition for `divK_clz_stage_combined_within`. Hides `val'` and `count'` lets. -/
+@[irreducible]
+private def divKClzStageCombinedPost (K M_s : BitVec 6) (M_a : BitVec 12) (val count : Word) : Assertion :=
+  let val' := if val >>> K.toNat ≠ 0 then val else val <<< M_s.toNat
+  let count' := if val >>> K.toNat ≠ 0 then count else count + signExtend12 M_a
+  (.x5 ↦ᵣ val') ** (.x6 ↦ᵣ count') ** (.x7 ↦ᵣ (val >>> K.toNat)) ** (.x0 ↦ᵣ (0 : Word))
+
+private theorem divKClzStageCombinedPost_unfold (K M_s : BitVec 6) (M_a : BitVec 12) (val count : Word) :
+    divKClzStageCombinedPost K M_s M_a val count =
+      (let val' := if val >>> K.toNat ≠ 0 then val else val <<< M_s.toNat
+       let count' := if val >>> K.toNat ≠ 0 then count else count + signExtend12 M_a
+       (.x5 ↦ᵣ val') ** (.x6 ↦ᵣ count') ** (.x7 ↦ᵣ (val >>> K.toNat)) ** (.x0 ↦ᵣ (0 : Word))) := by
+  delta divKClzStageCombinedPost; rfl

--- a/EvmAsm/Evm64/DivMod/Compose/ModCLZ.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModCLZ.lean
@@ -199,3 +199,17 @@ theorem mod_clz_spec_within (val v6Old v7Old : Word) (base : Word) :
     (fun h hq => by xperm_hyp hq)
     IefS0eS1eS2eS3eS4eS5e
 
+
+/-- Bundled postcondition for `mod_clz_stage_combined`. Hides `val'` and `count'` lets. -/
+@[irreducible]
+private def modClzStageCombinedPost (K M_s : BitVec 6) (M_a : BitVec 12) (val count : Word) : Assertion :=
+  let val' := if val >>> K.toNat ≠ 0 then val else val <<< M_s.toNat
+  let count' := if val >>> K.toNat ≠ 0 then count else count + signExtend12 M_a
+  (.x5 ↦ᵣ val') ** (.x6 ↦ᵣ count') ** (.x7 ↦ᵣ (val >>> K.toNat)) ** (.x0 ↦ᵣ (0 : Word))
+
+private theorem modClzStageCombinedPost_unfold (K M_s : BitVec 6) (M_a : BitVec 12) (val count : Word) :
+    modClzStageCombinedPost K M_s M_a val count =
+      (let val' := if val >>> K.toNat ≠ 0 then val else val <<< M_s.toNat
+       let count' := if val >>> K.toNat ≠ 0 then count else count + signExtend12 M_a
+       (.x5 ↦ᵣ val') ** (.x6 ↦ᵣ count') ** (.x7 ↦ᵣ (val >>> K.toNat)) ** (.x0 ↦ᵣ (0 : Word))) := by
+  delta modClzStageCombinedPost; rfl


### PR DESCRIPTION
## Summary
- Add `@[irreducible] private def divKClzStageCombinedPost` + `divKClzStageCombinedPost_unfold` in `DivMod/Compose/CLZ.lean` — bundles `val'` and `count'` conditional expressions from `divK_clz_stage_combined_within`
- Add `@[irreducible] private def modClzStageCombinedPost` + `modClzStageCombinedPost_unfold` in `DivMod/Compose/ModCLZ.lean` — same pattern for the mod variant

Both are private (used only within their respective files). This exhausts the 3-let targets visible in the scan outside the already-handled files.

Continues the let-chain reduction sweep from PRs #4530–#4571.

Refs #61. Bead: evm-asm-yz73p.

## Verification
- lake build EvmAsm.Evm64.DivMod.Compose.CLZ EvmAsm.Evm64.DivMod.Compose.ModCLZ
- scripts/check-file-size.sh
- lake build

Authored by @pirapira; implemented by Claude Code