### PR TITLE
chore(shift): add shrMergeInplace/shlMerge postcondition bundles (6/7→0 lets)

### DIFF
--- a/EvmAsm/Evm64/Shift/LimbSpec.lean
+++ b/EvmAsm/Evm64/Shift/LimbSpec.lean
@@ -1022,4 +1022,39 @@ theorem shr_merge_limb_named_spec_within (src_off next_off dst_off : BitVec 12)
     (fun _ hp => by simp only [shrMergeLimbPost_unfold]; exact hp)
     (shr_merge_limb_spec_within src_off next_off dst_off sp src next dstOld v5 v10 bit_shift antiShift mask base)
 
+/-- Bundled postcondition for `shr_merge_limb_inplace_spec_within`. -/
+@[irreducible]
+def shrMergeInplaceLimbPost (sp : Word) (off next_off : BitVec 12)
+    (src next bit_shift antiShift mask : Word) : Assertion :=
+  let shiftedSrc := src >>> (bit_shift.toNat % 64)
+  let shiftedNext := (next <<< (antiShift.toNat % 64)) &&& mask
+  let result := shiftedSrc ||| shiftedNext
+  (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x6 ↦ᵣ bit_shift) **
+  (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ shiftedNext) ** (.x11 ↦ᵣ mask) **
+  ((sp + signExtend12 off) ↦ₘ result) ** ((sp + signExtend12 next_off) ↦ₘ next)
+
+theorem shrMergeInplaceLimbPost_unfold (sp : Word) (off next_off : BitVec 12)
+    (src next bit_shift antiShift mask : Word) :
+    shrMergeInplaceLimbPost sp off next_off src next bit_shift antiShift mask =
+      (let shiftedSrc := src >>> (bit_shift.toNat % 64)
+       let shiftedNext := (next <<< (antiShift.toNat % 64)) &&& mask
+       let result := shiftedSrc ||| shiftedNext
+       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x6 ↦ᵣ bit_shift) **
+       (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ shiftedNext) ** (.x11 ↦ᵣ mask) **
+       ((sp + signExtend12 off) ↦ₘ result) ** ((sp + signExtend12 next_off) ↦ₘ next)) := by
+  delta shrMergeInplaceLimbPost; rfl
+
+/-- Named wrapper for `shr_merge_limb_inplace_spec_within`. 0 statement lets. -/
+theorem shr_merge_limb_inplace_named_spec_within (off next_off : BitVec 12)
+    (sp src next v5 v10 bit_shift antiShift mask : Word) (base : Word) :
+    cpsTripleWithin 7 base (base + 28) (shr_merge_limb_inplace_code off next_off base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ bit_shift) **
+       (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ mask) **
+       ((sp + signExtend12 off) ↦ₘ src) ** ((sp + signExtend12 next_off) ↦ₘ next))
+      (shrMergeInplaceLimbPost sp off next_off src next bit_shift antiShift mask) :=
+  cpsTripleWithin_weaken
+    (fun _ hp => hp)
+    (fun _ hp => by simp only [shrMergeInplaceLimbPost_unfold]; exact hp)
+    (shr_merge_limb_inplace_spec_within off next_off sp src next v5 v10 bit_shift antiShift mask base)
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Shift/ShlSpec.lean
+++ b/EvmAsm/Evm64/Shift/ShlSpec.lean
@@ -322,4 +322,42 @@ theorem shl_first_limb_named_spec_within (dst_off : BitVec 12)
     (fun _ hp => hp) (fun _ hp => hp)
     (shl_first_limb_spec_within dst_off sp src dstOld v5 bit_shift base)
 
+/-- Bundled postcondition for `shl_merge_limb_spec_within`. Hides shiftedSrc/Prev/result. -/
+@[irreducible]
+def shlMergeLimbPost (sp : Word) (src_off prev_off dst_off : BitVec 12)
+    (src prev bit_shift antiShift mask : Word) : Assertion :=
+  let shiftedSrc := src <<< (bit_shift.toNat % 64)
+  let shiftedPrev := (prev >>> (antiShift.toNat % 64)) &&& mask
+  let result := shiftedSrc ||| shiftedPrev
+  (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x6 ↦ᵣ bit_shift) **
+  (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ shiftedPrev) ** (.x11 ↦ᵣ mask) **
+  ((sp + signExtend12 src_off) ↦ₘ src) ** ((sp + signExtend12 prev_off) ↦ₘ prev) **
+  ((sp + signExtend12 dst_off) ↦ₘ result)
+
+theorem shlMergeLimbPost_unfold (sp : Word) (src_off prev_off dst_off : BitVec 12)
+    (src prev bit_shift antiShift mask : Word) :
+    shlMergeLimbPost sp src_off prev_off dst_off src prev bit_shift antiShift mask =
+      (let shiftedSrc := src <<< (bit_shift.toNat % 64)
+       let shiftedPrev := (prev >>> (antiShift.toNat % 64)) &&& mask
+       let result := shiftedSrc ||| shiftedPrev
+       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x6 ↦ᵣ bit_shift) **
+       (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ shiftedPrev) ** (.x11 ↦ᵣ mask) **
+       ((sp + signExtend12 src_off) ↦ₘ src) ** ((sp + signExtend12 prev_off) ↦ₘ prev) **
+       ((sp + signExtend12 dst_off) ↦ₘ result)) := by
+  delta shlMergeLimbPost; rfl
+
+/-- Named wrapper for `shl_merge_limb_spec_within`. 0 statement lets. -/
+theorem shl_merge_limb_named_spec_within (src_off prev_off dst_off : BitVec 12)
+    (sp src prev dstOld v5 v10 bit_shift antiShift mask : Word) (base : Word) :
+    cpsTripleWithin 7 base (base + 28) (shl_merge_limb_code base src_off prev_off dst_off)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ bit_shift) **
+       (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ mask) **
+       ((sp + signExtend12 src_off) ↦ₘ src) ** ((sp + signExtend12 prev_off) ↦ₘ prev) **
+       ((sp + signExtend12 dst_off) ↦ₘ dstOld))
+      (shlMergeLimbPost sp src_off prev_off dst_off src prev bit_shift antiShift mask) :=
+  cpsTripleWithin_weaken
+    (fun _ hp => hp)
+    (fun _ hp => by simp only [shlMergeLimbPost_unfold]; exact hp)
+    (shl_merge_limb_spec_within src_off prev_off dst_off sp src prev dstOld v5 v10 bit_shift antiShift mask base)
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Add `shrMergeInplaceLimbPost` + `shr_merge_limb_inplace_named_spec_within` with **0** statement lets (down from 6) in `Shift/LimbSpec.lean`
- Add `shlMergeLimbPost` + `shl_merge_limb_named_spec_within` with **0** statement lets (down from 7) in `Shift/ShlSpec.lean`

Both are merge-pattern variants (SHR inplace and SHL); callers in `SarSpec.lean` and `ShlSpec.lean` use `have MM := ...` + `runBlock` without `intro_lets`.

Continues the let-chain reduction sweep from PRs #4530–#4573.

Refs #61. Bead: evm-asm-yz73p.

## Verification
- lake build EvmAsm.Evm64.Shift.LimbSpec EvmAsm.Evm64.Shift.ShlSpec
- scripts/check-file-size.sh
- lake build

Authored by @pirapira; implemented by Claude Code