### PR TITLE
chore(shift): add shrPhaseB/shlMergeInplace postcondition bundles (6→0 lets)

### DIFF
--- a/EvmAsm/Evm64/Shift/LimbSpec.lean
+++ b/EvmAsm/Evm64/Shift/LimbSpec.lean
@@ -1022,4 +1022,37 @@ theorem shr_merge_limb_named_spec_within (src_off next_off dst_off : BitVec 12)
     (fun _ hp => by simp only [shrMergeLimbPost_unfold]; exact hp)
     (shr_merge_limb_spec_within src_off next_off dst_off sp src next dstOld v5 v10 bit_shift antiShift mask base)
 
+/-- Bundled postcondition for `shr_phase_b_spec_within`. Hides 5 computation lets. -/
+@[irreducible]
+def shrPhaseBPost (sp shift0 : Word) : Assertion :=
+  let bit_shift := shift0 &&& signExtend12 63
+  let limb_shift := shift0 >>> (6 : BitVec 6).toNat
+  let cond := if BitVec.ult (0 : Word) bit_shift then (1 : Word) else 0
+  let mask := (0 : Word) - cond
+  let antiShift := (64 : Word) - bit_shift
+  (.x5 ↦ᵣ limb_shift) ** (.x6 ↦ᵣ bit_shift) ** (.x0 ↦ᵣ (0 : Word)) **
+  (.x11 ↦ᵣ mask) ** (.x7 ↦ᵣ antiShift) ** (.x12 ↦ᵣ (sp + signExtend12 32))
+
+theorem shrPhaseBPost_unfold (sp shift0 : Word) :
+    shrPhaseBPost sp shift0 =
+      (let bit_shift := shift0 &&& signExtend12 63
+       let limb_shift := shift0 >>> (6 : BitVec 6).toNat
+       let cond := if BitVec.ult (0 : Word) bit_shift then (1 : Word) else 0
+       let mask := (0 : Word) - cond
+       let antiShift := (64 : Word) - bit_shift
+       (.x5 ↦ᵣ limb_shift) ** (.x6 ↦ᵣ bit_shift) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x11 ↦ᵣ mask) ** (.x7 ↦ᵣ antiShift) ** (.x12 ↦ᵣ (sp + signExtend12 32))) := by
+  delta shrPhaseBPost; rfl
+
+/-- Named wrapper for `shr_phase_b_spec_within`. 0 statement lets. -/
+theorem shr_phase_b_named_spec_within (shift0 sp r6 r7 r11 : Word) (base : Word) :
+    cpsTripleWithin 7 base (base + 28) (shr_phase_b_code base)
+      ((.x5 ↦ᵣ shift0) ** (.x6 ↦ᵣ r6) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x11 ↦ᵣ r11) ** (.x7 ↦ᵣ r7) ** (.x12 ↦ᵣ sp))
+      (shrPhaseBPost sp shift0) :=
+  cpsTripleWithin_weaken
+    (fun _ hp => hp)
+    (fun _ hp => by simp only [shrPhaseBPost_unfold]; exact hp)
+    (shr_phase_b_spec_within shift0 sp r6 r7 r11 base)
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Shift/ShlSpec.lean
+++ b/EvmAsm/Evm64/Shift/ShlSpec.lean
@@ -322,4 +322,39 @@ theorem shl_first_limb_named_spec_within (dst_off : BitVec 12)
     (fun _ hp => hp) (fun _ hp => hp)
     (shl_first_limb_spec_within dst_off sp src dstOld v5 bit_shift base)
 
+/-- Bundled postcondition for `shl_merge_limb_inplace_spec_within`. -/
+@[irreducible]
+def shlMergeInplaceLimbPost (sp : Word) (off prev_off : BitVec 12)
+    (src prev bit_shift antiShift mask : Word) : Assertion :=
+  let shiftedSrc := src <<< (bit_shift.toNat % 64)
+  let shiftedPrev := (prev >>> (antiShift.toNat % 64)) &&& mask
+  let result := shiftedSrc ||| shiftedPrev
+  (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x6 ↦ᵣ bit_shift) **
+  (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ shiftedPrev) ** (.x11 ↦ᵣ mask) **
+  ((sp + signExtend12 off) ↦ₘ result) ** ((sp + signExtend12 prev_off) ↦ₘ prev)
+
+theorem shlMergeInplaceLimbPost_unfold (sp : Word) (off prev_off : BitVec 12)
+    (src prev bit_shift antiShift mask : Word) :
+    shlMergeInplaceLimbPost sp off prev_off src prev bit_shift antiShift mask =
+      (let shiftedSrc := src <<< (bit_shift.toNat % 64)
+       let shiftedPrev := (prev >>> (antiShift.toNat % 64)) &&& mask
+       let result := shiftedSrc ||| shiftedPrev
+       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x6 ↦ᵣ bit_shift) **
+       (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ shiftedPrev) ** (.x11 ↦ᵣ mask) **
+       ((sp + signExtend12 off) ↦ₘ result) ** ((sp + signExtend12 prev_off) ↦ₘ prev)) := by
+  delta shlMergeInplaceLimbPost; rfl
+
+/-- Named wrapper for `shl_merge_limb_inplace_spec_within`. 0 statement lets. -/
+theorem shl_merge_limb_inplace_named_spec_within (off prev_off : BitVec 12)
+    (sp src prev v5 v10 bit_shift antiShift mask : Word) (base : Word) :
+    cpsTripleWithin 7 base (base + 28) (shl_merge_limb_inplace_code base off prev_off)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ bit_shift) **
+       (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ mask) **
+       ((sp + signExtend12 off) ↦ₘ src) ** ((sp + signExtend12 prev_off) ↦ₘ prev))
+      (shlMergeInplaceLimbPost sp off prev_off src prev bit_shift antiShift mask) :=
+  cpsTripleWithin_weaken
+    (fun _ hp => hp)
+    (fun _ hp => by simp only [shlMergeInplaceLimbPost_unfold]; exact hp)
+    (shl_merge_limb_inplace_spec_within off prev_off sp src prev v5 v10 bit_shift antiShift mask base)
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Add `shrPhaseBPost` + `shr_phase_b_named_spec_within` with **0** statement lets (down from 6) in `Shift/LimbSpec.lean` — bundles `bit_shift`, `limb_shift`, `cond`, `mask`, `antiShift` computation
- Add `shlMergeInplaceLimbPost` + `shl_merge_limb_inplace_named_spec_within` with **0** statement lets (down from 6) in `Shift/ShlSpec.lean` — SHL inplace mirror of shr_merge_inplace

Callers in `Shift/Compose.lean`, `ShlCompose.lean`, `SarCompose.lean` use `have h := ...` without `intro_lets`.

Continues the let-chain reduction sweep from PRs #4530–#4574.

Refs #61. Bead: evm-asm-yz73p.

## Verification
- lake build EvmAsm.Evm64.Shift.LimbSpec EvmAsm.Evm64.Shift.ShlSpec
- scripts/check-file-size.sh
- lake build

Authored by @pirapira; implemented by Claude Code