### PR TITLE
chore(shift): add shrBody0Post/shlBody0Post postcondition bundles (5→0 lets)

### DIFF
--- a/EvmAsm/Evm64/Shift/LimbSpec.lean
+++ b/EvmAsm/Evm64/Shift/LimbSpec.lean
@@ -1090,4 +1090,26 @@ theorem shr_phase_b_named_spec_within (shift0 sp r6 r7 r11 : Word) (base : Word)
     (fun _ hp => by simp only [shrPhaseBPost_unfold]; exact hp)
     (shr_phase_b_spec_within shift0 sp r6 r7 r11 base)
 
+/-- Bundled postcondition for `shr_body_0_spec_within`. Hides result0-3. -/
+@[irreducible]
+def shrBody0Post (sp bit_shift antiShift mask v0 v1 v2 v3 : Word) : Assertion :=
+  let result0 := (v0 >>> (bit_shift.toNat % 64)) ||| ((v1 <<< (antiShift.toNat % 64)) &&& mask)
+  let result1 := (v1 >>> (bit_shift.toNat % 64)) ||| ((v2 <<< (antiShift.toNat % 64)) &&& mask)
+  let result2 := (v2 >>> (bit_shift.toNat % 64)) ||| ((v3 <<< (antiShift.toNat % 64)) &&& mask)
+  let result3 := v3 >>> (bit_shift.toNat % 64)
+  (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result3) ** (.x6 ↦ᵣ bit_shift) **
+  (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ ((v3 <<< (antiShift.toNat % 64)) &&& mask)) ** (.x11 ↦ᵣ mask) **
+  (sp ↦ₘ result0) ** ((sp + 8) ↦ₘ result1) ** ((sp + 16) ↦ₘ result2) ** ((sp + 24) ↦ₘ result3)
+
+theorem shrBody0Post_unfold (sp bit_shift antiShift mask v0 v1 v2 v3 : Word) :
+    shrBody0Post sp bit_shift antiShift mask v0 v1 v2 v3 =
+      (let result0 := (v0 >>> (bit_shift.toNat % 64)) ||| ((v1 <<< (antiShift.toNat % 64)) &&& mask)
+       let result1 := (v1 >>> (bit_shift.toNat % 64)) ||| ((v2 <<< (antiShift.toNat % 64)) &&& mask)
+       let result2 := (v2 >>> (bit_shift.toNat % 64)) ||| ((v3 <<< (antiShift.toNat % 64)) &&& mask)
+       let result3 := v3 >>> (bit_shift.toNat % 64)
+       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result3) ** (.x6 ↦ᵣ bit_shift) **
+       (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ ((v3 <<< (antiShift.toNat % 64)) &&& mask)) ** (.x11 ↦ᵣ mask) **
+       (sp ↦ₘ result0) ** ((sp + 8) ↦ₘ result1) ** ((sp + 16) ↦ₘ result2) ** ((sp + 24) ↦ₘ result3)) := by
+  delta shrBody0Post; rfl
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Shift/ShlSpec.lean
+++ b/EvmAsm/Evm64/Shift/ShlSpec.lean
@@ -394,4 +394,27 @@ theorem shl_merge_limb_inplace_named_spec_within (off prev_off : BitVec 12)
     (fun _ hp => hp)
     (fun _ hp => by simp only [shlMergeInplaceLimbPost_unfold]; exact hp)
     (shl_merge_limb_inplace_spec_within off prev_off sp src prev v5 v10 bit_shift antiShift mask base)
+
+/-- Bundled postcondition for `shl_body_0_spec_within`. Hides result0-3. -/
+@[irreducible]
+def shlBody0Post (sp bit_shift antiShift mask v0 v1 v2 v3 : Word) : Assertion :=
+  let result3 := (v3 <<< (bit_shift.toNat % 64)) ||| ((v2 >>> (antiShift.toNat % 64)) &&& mask)
+  let result2 := (v2 <<< (bit_shift.toNat % 64)) ||| ((v1 >>> (antiShift.toNat % 64)) &&& mask)
+  let result1 := (v1 <<< (bit_shift.toNat % 64)) ||| ((v0 >>> (antiShift.toNat % 64)) &&& mask)
+  let result0 := v0 <<< (bit_shift.toNat % 64)
+  (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result0) ** (.x6 ↦ᵣ bit_shift) **
+  (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ ((v0 >>> (antiShift.toNat % 64)) &&& mask)) ** (.x11 ↦ᵣ mask) **
+  (sp ↦ₘ result0) ** ((sp + 8) ↦ₘ result1) ** ((sp + 16) ↦ₘ result2) ** ((sp + 24) ↦ₘ result3)
+
+theorem shlBody0Post_unfold (sp bit_shift antiShift mask v0 v1 v2 v3 : Word) :
+    shlBody0Post sp bit_shift antiShift mask v0 v1 v2 v3 =
+      (let result3 := (v3 <<< (bit_shift.toNat % 64)) ||| ((v2 >>> (antiShift.toNat % 64)) &&& mask)
+       let result2 := (v2 <<< (bit_shift.toNat % 64)) ||| ((v1 >>> (antiShift.toNat % 64)) &&& mask)
+       let result1 := (v1 <<< (bit_shift.toNat % 64)) ||| ((v0 >>> (antiShift.toNat % 64)) &&& mask)
+       let result0 := v0 <<< (bit_shift.toNat % 64)
+       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result0) ** (.x6 ↦ᵣ bit_shift) **
+       (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ ((v0 >>> (antiShift.toNat % 64)) &&& mask)) ** (.x11 ↦ᵣ mask) **
+       (sp ↦ₘ result0) ** ((sp + 8) ↦ₘ result1) ** ((sp + 16) ↦ₘ result2) ** ((sp + 24) ↦ₘ result3)) := by
+  delta shlBody0Post; rfl
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Add `shrBody0Post` + `shrBody0Post_unfold` in `Shift/LimbSpec.lean` — bundles 4 result computations from `shr_body_0_spec_within` (25-instr body-0 spec)
- Add `shlBody0Post` + `shlBody0Post_unfold` in `Shift/ShlSpec.lean` — SHL mirror with top-down limb order

External callers in `Compose.lean` and `ShlCompose.lean` use `have h := ...` without `intro_lets`.

Continues the let-chain reduction sweep from PRs #4530–#4575.

Refs #61. Bead: evm-asm-yz73p.

## Verification
- lake build EvmAsm.Evm64.Shift.LimbSpec EvmAsm.Evm64.Shift.ShlSpec
- scripts/check-file-size.sh
- lake build

Authored by @pirapira; implemented by Claude Code