### PR TITLE
chore(sar): add sarBody3Post/sarBody2Post postcondition bundles (3/4→0 lets)

### DIFF
--- a/EvmAsm/Evm64/Shift/SarSpec.lean
+++ b/EvmAsm/Evm64/Shift/SarSpec.lean
@@ -337,4 +337,42 @@ theorem sarBody0Post_unfold (sp bit_shift antiShift mask v0 v1 v2 v3 : Word) :
        (sp ↦ₘ result0) ** ((sp + 8) ↦ₘ result1) ** ((sp + 16) ↦ₘ result2) ** ((sp + 24) ↦ₘ result3)) := by
   delta sarBody0Post; rfl
 
+/-- Bundled postcondition for `sar_body_2_spec_within`. Hides result0/result1/signExt. -/
+@[irreducible]
+def sarBody2Post (sp bit_shift antiShift mask v2 v3 : Word) : Assertion :=
+  let result0 := (v2 >>> (bit_shift.toNat % 64)) ||| ((v3 <<< (antiShift.toNat % 64)) &&& mask)
+  let result1 := BitVec.sshiftRight v3 (bit_shift.toNat % 64)
+  let signExt := BitVec.sshiftRight result1 63
+  (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result1) ** (.x6 ↦ᵣ bit_shift) **
+  (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ signExt) ** (.x11 ↦ᵣ mask) **
+  (sp ↦ₘ result0) ** ((sp + 8) ↦ₘ result1) ** ((sp + 16) ↦ₘ signExt) ** ((sp + 24) ↦ₘ signExt)
+
+theorem sarBody2Post_unfold (sp bit_shift antiShift mask v2 v3 : Word) :
+    sarBody2Post sp bit_shift antiShift mask v2 v3 =
+      (let result0 := (v2 >>> (bit_shift.toNat % 64)) ||| ((v3 <<< (antiShift.toNat % 64)) &&& mask)
+       let result1 := BitVec.sshiftRight v3 (bit_shift.toNat % 64)
+       let signExt := BitVec.sshiftRight result1 63
+       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result1) ** (.x6 ↦ᵣ bit_shift) **
+       (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ signExt) ** (.x11 ↦ᵣ mask) **
+       (sp ↦ₘ result0) ** ((sp + 8) ↦ₘ result1) ** ((sp + 16) ↦ₘ signExt) ** ((sp + 24) ↦ₘ signExt)) := by
+  delta sarBody2Post; rfl
+
+/-- Bundled postcondition for `sar_body_3_spec_within`. Hides result0/signExt. -/
+@[irreducible]
+def sarBody3Post (sp bit_shift antiShift mask v3 : Word) : Assertion :=
+  let result0 := BitVec.sshiftRight v3 (bit_shift.toNat % 64)
+  let signExt := BitVec.sshiftRight result0 63
+  (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result0) ** (.x6 ↦ᵣ bit_shift) **
+  (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ signExt) ** (.x11 ↦ᵣ mask) **
+  (sp ↦ₘ result0) ** ((sp + 8) ↦ₘ signExt) ** ((sp + 16) ↦ₘ signExt) ** ((sp + 24) ↦ₘ signExt)
+
+theorem sarBody3Post_unfold (sp bit_shift antiShift mask v3 : Word) :
+    sarBody3Post sp bit_shift antiShift mask v3 =
+      (let result0 := BitVec.sshiftRight v3 (bit_shift.toNat % 64)
+       let signExt := BitVec.sshiftRight result0 63
+       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result0) ** (.x6 ↦ᵣ bit_shift) **
+       (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ signExt) ** (.x11 ↦ᵣ mask) **
+       (sp ↦ₘ result0) ** ((sp + 8) ↦ₘ signExt) ** ((sp + 16) ↦ₘ signExt) ** ((sp + 24) ↦ₘ signExt)) := by
+  delta sarBody3Post; rfl
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Add `sarBody3Post` + `sarBody3Post_unfold` in `Shift/SarSpec.lean` — bundles `result0 = sshiftRight(v3, bs)` and `signExt = sshiftRight(result0, 63)` for `sar_body_3_spec_within`
- Add `sarBody2Post` + `sarBody2Post_unfold` — bundles `result0` (merge), `result1` (SRA), `signExt` for `sar_body_2_spec_within`

Callers in `SarCompose.lean` use `have h := ...` without `intro_lets`.

Continues the let-chain reduction sweep from PRs #4530–#4579.

Refs #61. Bead: evm-asm-yz73p.

## Verification
- lake build EvmAsm.Evm64.Shift.SarSpec
- scripts/check-file-size.sh
- lake build

Authored by @pirapira; implemented by Claude Code