### PR TITLE
chore(shift): add shr/shl/sar inplace last-limb named specs (3→0 lets)

### DIFF
--- a/EvmAsm/Evm64/Shift/LimbSpec.lean
+++ b/EvmAsm/Evm64/Shift/LimbSpec.lean
@@ -1150,4 +1150,17 @@ theorem shrBody1Post_unfold (sp bit_shift antiShift mask v1 v2 v3 : Word) :
        (sp ↦ₘ result0) ** ((sp + 8) ↦ₘ result1) ** ((sp + 16) ↦ₘ result2) ** ((sp + 24) ↦ₘ 0)) := by
   delta shrBody1Post; rfl
 
+/-- Named wrapper for `shr_last_limb_inplace_spec_within`. 0 statement lets.
+    Inlines mem = sp+24, result = src >>> (bit_shift % 64). -/
+theorem shr_last_limb_inplace_named_spec_within
+    (sp src v5 bit_shift : Word) (base : Word) :
+    cpsTripleWithin 3 base (base + 12) (shr_last_limb_inplace_code base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ bit_shift) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ src))
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ src >>> (bit_shift.toNat % 64)) ** (.x6 ↦ᵣ bit_shift) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ src >>> (bit_shift.toNat % 64))) :=
+  cpsTripleWithin_weaken
+    (fun _ hp => hp) (fun _ hp => hp)
+    (shr_last_limb_inplace_spec_within sp src v5 bit_shift base)
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Shift/SarSpec.lean
+++ b/EvmAsm/Evm64/Shift/SarSpec.lean
@@ -375,4 +375,17 @@ theorem sarBody3Post_unfold (sp bit_shift antiShift mask v3 : Word) :
        (sp ↦ₘ result0) ** ((sp + 8) ↦ₘ signExt) ** ((sp + 16) ↦ₘ signExt) ** ((sp + 24) ↦ₘ signExt)) := by
   delta sarBody3Post; rfl
 
+/-- Named wrapper for `sar_last_limb_inplace_spec_within`. 0 statement lets.
+    Inlines mem = sp+24, result = sshiftRight src (bit_shift % 64). -/
+theorem sar_last_limb_inplace_named_spec_within
+    (sp src v5 bit_shift : Word) (base : Word) :
+    cpsTripleWithin 3 base (base + 12) (sar_last_limb_inplace_code base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ bit_shift) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ src))
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ BitVec.sshiftRight src (bit_shift.toNat % 64)) ** (.x6 ↦ᵣ bit_shift) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ BitVec.sshiftRight src (bit_shift.toNat % 64))) :=
+  cpsTripleWithin_weaken
+    (fun _ hp => hp) (fun _ hp => hp)
+    (sar_last_limb_inplace_spec_within sp src v5 bit_shift base)
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Shift/ShlSpec.lean
+++ b/EvmAsm/Evm64/Shift/ShlSpec.lean
@@ -455,4 +455,17 @@ theorem shlBody1Post_unfold (sp bit_shift antiShift mask v0 v1 v2 : Word) :
        (sp ↦ₘ 0) ** ((sp + 8) ↦ₘ result1) ** ((sp + 16) ↦ₘ result2) ** ((sp + 24) ↦ₘ result3)) := by
   delta shlBody1Post; rfl
 
+/-- Named wrapper for `shl_first_limb_inplace_spec_within`. 0 statement lets.
+    Inlines mem = sp+0, result = src <<< (bit_shift % 64). -/
+theorem shl_first_limb_inplace_named_spec_within
+    (sp src v5 bit_shift : Word) (base : Word) :
+    cpsTripleWithin 3 base (base + 12) (shl_first_limb_inplace_code base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ bit_shift) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ src))
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ src <<< (bit_shift.toNat % 64)) ** (.x6 ↦ᵣ bit_shift) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ src <<< (bit_shift.toNat % 64))) :=
+  cpsTripleWithin_weaken
+    (fun _ hp => hp) (fun _ hp => hp)
+    (shl_first_limb_inplace_spec_within sp src v5 bit_shift base)
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Add `shr_last_limb_inplace_named_spec_within` with **0** statement lets (down from 3) in `Shift/LimbSpec.lean` — `mem = sp+24`, `result = src >>> (bit_shift % 64)` inlined
- Add `shl_first_limb_inplace_named_spec_within` with **0** statement lets in `Shift/ShlSpec.lean` — `mem = sp+0`, `result = src <<< (bit_shift % 64)`
- Add `sar_last_limb_inplace_named_spec_within` with **0** statement lets in `Shift/SarSpec.lean` — `mem = sp+24`, `result = sshiftRight src (bit_shift % 64)`

All three are internal specs (called only within their own files via `runBlock`).

Continues the let-chain reduction sweep from PRs #4530–#4580.

Refs #61. Bead: evm-asm-yz73p.

## Verification
- lake build EvmAsm.Evm64.Shift.LimbSpec EvmAsm.Evm64.Shift.ShlSpec EvmAsm.Evm64.Shift.SarSpec
- scripts/check-file-size.sh
- lake build

Authored by @pirapira; implemented by Claude Code