### PR TITLE
chore(divmod): add divKDiv128Phase1Post postcondition bundle (5→0 lets)

### DIFF
--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128PhaseEnd.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128PhaseEnd.lean
@@ -103,4 +103,34 @@ theorem divK_div128_end_spec_within
   rw [halign] at I3
   runBlock I0 I1 I2 I3
 
+/-- Bundled postcondition for `divK_div128_phase1_spec_within`. Hides 4 computation lets. -/
+@[irreducible]
+def divKDiv128Phase1Post (sp d uLo uHi retAddr : Word) : Assertion :=
+  let dHi := d >>> (32 : BitVec 6).toNat
+  let dLo := (d <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  let un1 := uLo >>> (32 : BitVec 6).toNat
+  let un0 := (uLo <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  (.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ retAddr) ** (.x10 ↦ᵣ d) **
+  (.x6 ↦ᵣ dHi) ** (.x1 ↦ᵣ dLo) ** (.x5 ↦ᵣ un0) **
+  (.x11 ↦ᵣ un1) ** (.x7 ↦ᵣ uHi) **
+  (sp + signExtend12 3968 ↦ₘ retAddr) **
+  (sp + signExtend12 3960 ↦ₘ d) **
+  (sp + signExtend12 3952 ↦ₘ dLo) **
+  (sp + signExtend12 3944 ↦ₘ un0)
+
+theorem divKDiv128Phase1Post_unfold (sp d uLo uHi retAddr : Word) :
+    divKDiv128Phase1Post sp d uLo uHi retAddr =
+      (let dHi := d >>> (32 : BitVec 6).toNat
+       let dLo := (d <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+       let un1 := uLo >>> (32 : BitVec 6).toNat
+       let un0 := (uLo <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+       (.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ retAddr) ** (.x10 ↦ᵣ d) **
+       (.x6 ↦ᵣ dHi) ** (.x1 ↦ᵣ dLo) ** (.x5 ↦ᵣ un0) **
+       (.x11 ↦ᵣ un1) ** (.x7 ↦ᵣ uHi) **
+       (sp + signExtend12 3968 ↦ₘ retAddr) **
+       (sp + signExtend12 3960 ↦ₘ d) **
+       (sp + signExtend12 3952 ↦ₘ dLo) **
+       (sp + signExtend12 3944 ↦ₘ un0)) := by
+  delta divKDiv128Phase1Post; rfl
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Add `@[irreducible] def divKDiv128Phase1Post` bundling 4 computation lets (`dHi`, `dLo`, `un1`, `un0`) from `divK_div128_phase1_spec_within` in `DivMod/LimbSpec/Div128PhaseEnd.lean`
- Add `divKDiv128Phase1Post_unfold` (delta/rfl)

Callers in `Compose/Div128.lean`, `Div128V4.lean`, `ModDiv128.lean` use `have hph1 := ...` without `intro_lets`.

Continues the let-chain reduction sweep from PRs #4530–#4581.

Refs #61. Bead: evm-asm-yz73p.

## Verification
- lake build EvmAsm.Evm64.DivMod.LimbSpec.Div128PhaseEnd
- scripts/check-file-size.sh
- lake build

Authored by @pirapira; implemented by Claude Code