### PR TITLE
chore(divmod): add div128 prodcheck/un21 postcondition bundles (5→0 lets)

### DIFF
--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck1.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck1.lean
@@ -171,4 +171,27 @@ theorem divK_div128_prodcheck1_merged_spec_within
         (fun _ hp => hp)
         ntaken_clean hjal_framed)
 
+/-- Bundled postcondition for `divK_div128_prodcheck1_merged_spec_within`.
+    Hides qDlo, rhatUn1, q1', rhat' lets. -/
+@[irreducible]
+def divKDiv128ProdCheck1Post (sp q1 rhat dHi un1 dlo : Word) : Assertion :=
+  let qDlo := q1 * dlo
+  let rhatUn1 := (rhat <<< (32 : BitVec 6).toNat) ||| un1
+  let q1' := if BitVec.ult rhatUn1 qDlo then q1 + signExtend12 4095 else q1
+  let rhat' := if BitVec.ult rhatUn1 qDlo then rhat + dHi else rhat
+  (.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1') ** (.x7 ↦ᵣ rhat') ** (.x11 ↦ᵣ un1) **
+  (.x5 ↦ᵣ qDlo) ** (.x1 ↦ᵣ rhatUn1) ** (.x6 ↦ᵣ dHi) **
+  (sp + signExtend12 3952 ↦ₘ dlo)
+
+theorem divKDiv128ProdCheck1Post_unfold (sp q1 rhat dHi un1 dlo : Word) :
+    divKDiv128ProdCheck1Post sp q1 rhat dHi un1 dlo =
+      (let qDlo := q1 * dlo
+       let rhatUn1 := (rhat <<< (32 : BitVec 6).toNat) ||| un1
+       let q1' := if BitVec.ult rhatUn1 qDlo then q1 + signExtend12 4095 else q1
+       let rhat' := if BitVec.ult rhatUn1 qDlo then rhat + dHi else rhat
+       (.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1') ** (.x7 ↦ᵣ rhat') ** (.x11 ↦ᵣ un1) **
+       (.x5 ↦ᵣ qDlo) ** (.x1 ↦ᵣ rhatUn1) ** (.x6 ↦ᵣ dHi) **
+       (sp + signExtend12 3952 ↦ₘ dlo)) := by
+  delta divKDiv128ProdCheck1Post; rfl
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128UnProdCheck.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128UnProdCheck.lean
@@ -111,4 +111,27 @@ theorem divK_div128_correct_q0_spec_within (q0 rhat2 dHi : Word) (base : Word) :
   have I1 := add_spec_gen_rd_eq_rs1_within .x11 .x6 rhat2 dHi (base + 4) (by nofun)
   runBlock I0 I1
 
+/-- Bundled postcondition for `divK_div128_compute_un21_spec_within`.
+    Hides rhatHi, rhatUn1, q1Dlo, un21 lets. -/
+@[irreducible]
+def divKDiv128ComputeUn21Post (sp q1 rhat un1 dloMem : Word) : Assertion :=
+  let rhatHi := rhat <<< (32 : BitVec 6).toNat
+  let rhatUn1 := rhatHi ||| un1
+  let q1Dlo := q1 * dloMem
+  let un21 := rhatUn1 - q1Dlo
+  (.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ un21) **
+  (.x11 ↦ᵣ un1) ** (.x5 ↦ᵣ rhatUn1) ** (.x1 ↦ᵣ q1Dlo) **
+  (sp + signExtend12 3952 ↦ₘ dloMem)
+
+theorem divKDiv128ComputeUn21Post_unfold (sp q1 rhat un1 dloMem : Word) :
+    divKDiv128ComputeUn21Post sp q1 rhat un1 dloMem =
+      (let rhatHi := rhat <<< (32 : BitVec 6).toNat
+       let rhatUn1 := rhatHi ||| un1
+       let q1Dlo := q1 * dloMem
+       let un21 := rhatUn1 - q1Dlo
+       (.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ un21) **
+       (.x11 ↦ᵣ un1) ** (.x5 ↦ᵣ rhatUn1) ** (.x1 ↦ᵣ q1Dlo) **
+       (sp + signExtend12 3952 ↦ₘ dloMem)) := by
+  delta divKDiv128ComputeUn21Post; rfl
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Add `divKDiv128ProdCheck1Post` + `divKDiv128ProdCheck1Post_unfold` in `DivMod/LimbSpec/Div128ProdCheck1.lean` — bundles `qDlo`, `rhatUn1`, `q1'`, `rhat'` conditional computation from `divK_div128_prodcheck1_merged_spec_within`
- Add `divKDiv128ComputeUn21Post` + `divKDiv128ComputeUn21Post_unfold` in `DivMod/LimbSpec/Div128UnProdCheck.lean` — bundles `rhatHi`, `rhatUn1`, `q1Dlo`, `un21` computation from `divK_div128_compute_un21_spec_within`

Callers in `Compose/ModDiv128.lean`, `Div128V4.lean`, `Div128Step1.lean` use direct calls without `intro_lets`.

Continues the let-chain reduction sweep from PRs #4530–#4582.

Refs #61. Bead: evm-asm-yz73p.

## Verification
- lake build EvmAsm.Evm64.DivMod.LimbSpec.Div128ProdCheck1 EvmAsm.Evm64.DivMod.LimbSpec.Div128UnProdCheck
- scripts/check-file-size.sh
- lake build

Authored by @pirapira; implemented by Claude Code