### PR TITLE
chore(divmod): add TrialQuotient/NormA postcondition bundles

### DIFF
--- a/EvmAsm/Evm64/DivMod/LimbSpec/NormA.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/NormA.lean
@@ -158,4 +158,54 @@ theorem divK_normA_last_spec_within (dst_off : BitVec 12)
   have I1 := sd_spec_gen_within .x12 .x7 sp result dstOld dst_off (base + 4)
   runBlock I0 I1
 
+/-- Bundled postcondition for `divK_normA_mergeA_spec_within`.
+    Hides `shiftedCurr`, `shiftedNext`, and `result`; x5 holds the result. -/
+@[irreducible]
+def divKNormAMergeAPost (sp : Word) (next_off dst_off : BitVec 12)
+    (current next shift antiShift : Word) : Assertion :=
+  let shiftedCurr := current <<< (shift.toNat % 64)
+  let shiftedNext := next >>> (antiShift.toNat % 64)
+  let result := shiftedCurr ||| shiftedNext
+  (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x7 ↦ᵣ next) ** (.x10 ↦ᵣ shiftedNext) **
+  (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
+  ((sp + signExtend12 next_off) ↦ₘ next) **
+  ((sp + signExtend12 dst_off) ↦ₘ result)
+
+theorem divKNormAMergeAPost_unfold (sp : Word) (next_off dst_off : BitVec 12)
+    (current next shift antiShift : Word) :
+    divKNormAMergeAPost sp next_off dst_off current next shift antiShift =
+      (let shiftedCurr := current <<< (shift.toNat % 64)
+       let shiftedNext := next >>> (antiShift.toNat % 64)
+       let result := shiftedCurr ||| shiftedNext
+       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x7 ↦ᵣ next) ** (.x10 ↦ᵣ shiftedNext) **
+       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
+       ((sp + signExtend12 next_off) ↦ₘ next) **
+       ((sp + signExtend12 dst_off) ↦ₘ result)) := by
+  delta divKNormAMergeAPost; rfl
+
+/-- Bundled postcondition for `divK_normA_mergeB_spec_within`.
+    Hides `shiftedCurr`, `shiftedNext`, and `result`; x7 holds the result. -/
+@[irreducible]
+def divKNormAMergeBPost (sp : Word) (next_off dst_off : BitVec 12)
+    (current next shift antiShift : Word) : Assertion :=
+  let shiftedCurr := current <<< (shift.toNat % 64)
+  let shiftedNext := next >>> (antiShift.toNat % 64)
+  let result := shiftedCurr ||| shiftedNext
+  (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ next) ** (.x7 ↦ᵣ result) ** (.x10 ↦ᵣ shiftedNext) **
+  (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
+  ((sp + signExtend12 next_off) ↦ₘ next) **
+  ((sp + signExtend12 dst_off) ↦ₘ result)
+
+theorem divKNormAMergeBPost_unfold (sp : Word) (next_off dst_off : BitVec 12)
+    (current next shift antiShift : Word) :
+    divKNormAMergeBPost sp next_off dst_off current next shift antiShift =
+      (let shiftedCurr := current <<< (shift.toNat % 64)
+       let shiftedNext := next >>> (antiShift.toNat % 64)
+       let result := shiftedCurr ||| shiftedNext
+       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ next) ** (.x7 ↦ᵣ result) ** (.x10 ↦ᵣ shiftedNext) **
+       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
+       ((sp + signExtend12 next_off) ↦ₘ next) **
+       ((sp + signExtend12 dst_off) ↦ₘ result)) := by
+  delta divKNormAMergeBPost; rfl
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LimbSpec/TrialQuotient.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/TrialQuotient.lean
@@ -133,4 +133,39 @@ theorem divK_trial_max_spec_within (v11Old : Word) (base : Word) :
   rw [ha] at I1
   runBlock I0 I1
 
+/-- Bundled postcondition for `divK_trial_load_u_spec_within`.
+    Hides the intermediate `jpn`, `jpnX8`, `u0_base`, and `uAddr` address
+    computations so callers can reason about the postcondition opaquely. -/
+@[irreducible]
+def divKTrialLoadUPost (sp j n uHi uLo : Word) : Assertion :=
+  let uAddr := sp + signExtend12 4056 - ((j + n) <<< (3 : BitVec 6).toNat)
+  (.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
+  (.x5 ↦ᵣ uLo) ** (.x7 ↦ᵣ uHi) **
+  (sp + signExtend12 3984 ↦ₘ n) **
+  (uAddr ↦ₘ uHi) ** ((uAddr + 8) ↦ₘ uLo)
+
+theorem divKTrialLoadUPost_unfold (sp j n uHi uLo : Word) :
+    divKTrialLoadUPost sp j n uHi uLo =
+      (let uAddr := sp + signExtend12 4056 - ((j + n) <<< (3 : BitVec 6).toNat)
+       (.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
+       (.x5 ↦ᵣ uLo) ** (.x7 ↦ᵣ uHi) **
+       (sp + signExtend12 3984 ↦ₘ n) **
+       (uAddr ↦ₘ uHi) ** ((uAddr + 8) ↦ₘ uLo)) := by
+  delta divKTrialLoadUPost; rfl
+
+/-- Bundled postcondition for `divK_trial_load_vtop_spec_within`.
+    Hides the `nm1`, `nm1X8`, and `vtopBase` address intermediates. -/
+@[irreducible]
+def divKTrialLoadVTopPost (sp n vTop : Word) : Assertion :=
+  let vtopBase := sp + ((n + signExtend12 4095) <<< (3 : BitVec 6).toNat)
+  (.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ vtopBase) ** (.x10 ↦ᵣ vTop) **
+  (sp + signExtend12 3984 ↦ₘ n) ** (vtopBase + signExtend12 32 ↦ₘ vTop)
+
+theorem divKTrialLoadVTopPost_unfold (sp n vTop : Word) :
+    divKTrialLoadVTopPost sp n vTop =
+      (let vtopBase := sp + ((n + signExtend12 4095) <<< (3 : BitVec 6).toNat)
+       (.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ vtopBase) ** (.x10 ↦ᵣ vTop) **
+       (sp + signExtend12 3984 ↦ₘ n) ** (vtopBase + signExtend12 32 ↦ₘ vTop)) := by
+  delta divKTrialLoadVTopPost; rfl
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Add `@[irreducible]` bundled postconditions for 4 DivMod LimbSpec specs, reducing statement-level `let` chains to 0
- `divKTrialLoadUPost` (TrialQuotient.lean, 4 lets → 0): hides `jpn`, `jpnX8`, `u0_base`, `uAddr` address intermediates
- `divKTrialLoadVTopPost` (TrialQuotient.lean, 3 lets → 0): hides `nm1`, `nm1X8`, `vtopBase`
- `divKNormAMergeAPost` (NormA.lean, 3 lets → 0): hides `shiftedCurr`, `shiftedNext`, `result` (x5-holds-result)
- `divKNormAMergeBPost` (NormA.lean, 3 lets → 0): hides `shiftedCurr`, `shiftedNext`, `result` (x7-holds-result)

Each bundle ships with a `_unfold` theorem (`delta xxx; rfl`) for callers that need to peek inside.

Refs #61. Bead: evm-asm-yz73p.

## Verification
- `lake build EvmAsm.Evm64.DivMod.LimbSpec.TrialQuotient EvmAsm.Evm64.DivMod.LimbSpec.NormA`
- `scripts/check-file-size.sh`
- `rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/LimbSpec/TrialQuotient.lean EvmAsm/Evm64/DivMod/LimbSpec/NormA.lean`
- `lake build`

Authored by @pirapira; implemented by Claude Code