### PR TITLE
chore(divmod): add Denorm/TrialLoad/StoreQj postcondition bundles

### DIFF
--- a/EvmAsm/Evm64/DivMod/LimbSpec/Denorm.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Denorm.lean
@@ -95,4 +95,29 @@ theorem divK_denorm_last_spec_within (off : BitVec 12)
   have I2 := sd_spec_gen_within .x12 .x5 sp result val off (base + 8)
   runBlock I0 I1 I2
 
+/-- Bundled postcondition for `divK_denorm_merge_spec_within`.
+    Hides `shiftedCurr`, `shiftedNext`, and `result`; x5 holds the result. -/
+@[irreducible]
+def divKDenormMergePost (sp : Word) (curr_off next_off : BitVec 12)
+    (curr next shift antiShift : Word) : Assertion :=
+  let shiftedCurr := curr >>> (shift.toNat % 64)
+  let shiftedNext := next <<< (antiShift.toNat % 64)
+  let result := shiftedCurr ||| shiftedNext
+  (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x7 ↦ᵣ shiftedNext) **
+  (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
+  ((sp + signExtend12 curr_off) ↦ₘ result) **
+  ((sp + signExtend12 next_off) ↦ₘ next)
+
+theorem divKDenormMergePost_unfold (sp : Word) (curr_off next_off : BitVec 12)
+    (curr next shift antiShift : Word) :
+    divKDenormMergePost sp curr_off next_off curr next shift antiShift =
+      (let shiftedCurr := curr >>> (shift.toNat % 64)
+       let shiftedNext := next <<< (antiShift.toNat % 64)
+       let result := shiftedCurr ||| shiftedNext
+       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x7 ↦ᵣ shiftedNext) **
+       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
+       ((sp + signExtend12 curr_off) ↦ₘ result) **
+       ((sp + signExtend12 next_off) ↦ₘ next)) := by
+  delta divKDenormMergePost; rfl
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LimbSpec/TrialStoreComposed.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/TrialStoreComposed.lean
@@ -111,4 +111,48 @@ theorem divK_store_qj_spec_within (sp j qHat v5Old v7Old qOld : Word)
   rw [haddr] at I3
   runBlock I0 I1 I2 I3
 
+/-- Bundled postcondition for `divK_trial_load_spec_within`.
+    Hides `uAddr` and `vtopBase` address computations. -/
+@[irreducible]
+def divKTrialLoadPost (sp j n uHi uLo vTop : Word) : Assertion :=
+  let uAddr := sp + signExtend12 4056 - (j + n) <<< (3 : BitVec 6).toNat
+  let vtopBase := sp + (n + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  (.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
+  (.x5 ↦ᵣ uLo) ** (.x6 ↦ᵣ vtopBase) **
+  (.x7 ↦ᵣ uHi) ** (.x10 ↦ᵣ vTop) **
+  (sp + signExtend12 3984 ↦ₘ n) **
+  (uAddr ↦ₘ uHi) ** ((uAddr + 8) ↦ₘ uLo) **
+  (vtopBase + signExtend12 32 ↦ₘ vTop)
+
+theorem divKTrialLoadPost_unfold (sp j n uHi uLo vTop : Word) :
+    divKTrialLoadPost sp j n uHi uLo vTop =
+      (let uAddr := sp + signExtend12 4056 - (j + n) <<< (3 : BitVec 6).toNat
+       let vtopBase := sp + (n + signExtend12 4095) <<< (3 : BitVec 6).toNat
+       (.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
+       (.x5 ↦ᵣ uLo) ** (.x6 ↦ᵣ vtopBase) **
+       (.x7 ↦ᵣ uHi) ** (.x10 ↦ᵣ vTop) **
+       (sp + signExtend12 3984 ↦ₘ n) **
+       (uAddr ↦ₘ uHi) ** ((uAddr + 8) ↦ₘ uLo) **
+       (vtopBase + signExtend12 32 ↦ₘ vTop)) := by
+  delta divKTrialLoadPost; rfl
+
+/-- Bundled postcondition for `divK_store_qj_spec_within`.
+    Hides `jX8` and `qAddr` address intermediates. -/
+@[irreducible]
+def divKStoreQjPost (sp j qHat : Word) : Assertion :=
+  let jX8 := j <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - jX8
+  (.x1 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+  (.x5 ↦ᵣ jX8) ** (.x7 ↦ᵣ qAddr) **
+  (qAddr ↦ₘ qHat)
+
+theorem divKStoreQjPost_unfold (sp j qHat : Word) :
+    divKStoreQjPost sp j qHat =
+      (let jX8 := j <<< (3 : BitVec 6).toNat
+       let qAddr := sp + signExtend12 4088 - jX8
+       (.x1 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+       (.x5 ↦ᵣ jX8) ** (.x7 ↦ᵣ qAddr) **
+       (qAddr ↦ₘ qHat)) := by
+  delta divKStoreQjPost; rfl
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Add `@[irreducible]` bundled postconditions for 3 DivMod LimbSpec specs, reducing statement-level `let` chains to 0
- `divKDenormMergePost` (Denorm.lean, 3 lets → 0): hides `shiftedCurr`, `shiftedNext`, `result` (SRL-shift mirror of NormB merge)
- `divKTrialLoadPost` (TrialStoreComposed.lean, 2 lets → 0): hides `uAddr`, `vtopBase` for the combined 12-instruction u+vTop load
- `divKStoreQjPost` (TrialStoreComposed.lean, 2 lets → 0): hides `jX8`, `qAddr` address computation

Each bundle ships with a `_unfold` theorem (`delta xxx; rfl`).

Refs #61. Bead: evm-asm-yz73p.

## Verification
- `lake build EvmAsm.Evm64.DivMod.LimbSpec.Denorm EvmAsm.Evm64.DivMod.LimbSpec.TrialStoreComposed`
- `scripts/check-file-size.sh`
- `rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/LimbSpec/Denorm.lean EvmAsm/Evm64/DivMod/LimbSpec/TrialStoreComposed.lean`
- `lake build`

Authored by @pirapira; implemented by Claude Code