### PR TITLE
chore(divmod): add AddbackFinal/Div128Step1 postcondition bundles

### DIFF
--- a/EvmAsm/Evm64/DivMod/LimbSpec/AddBackFinalLoopControl.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/AddBackFinalLoopControl.lean
@@ -98,4 +98,21 @@ theorem divK_loop_control_spec_within (j : Word) (loop_back_off : BitVec 13)
         simp only [beq_iff_eq, h0, ↓reduceIte]))) hPR hpc
   exact cpsTripleWithin_seq_cpsBranchWithin_same_cr hbody hbge_ext
 
+/-- Bundled postcondition for `divK_addback_final_spec_within`.
+    Hides `uNew` and `qHat'` add-back intermediates. -/
+@[irreducible]
+def divKAddbackFinalPost (uBase carry qHat uTop : Word) (u_off : BitVec 12) : Assertion :=
+  let uNew := uTop + carry
+  let qHat' := qHat + signExtend12 4095
+  (.x6 ↦ᵣ uBase) ** (.x7 ↦ᵣ carry) ** (.x11 ↦ᵣ qHat') **
+  (.x5 ↦ᵣ uNew) ** (uBase + signExtend12 u_off ↦ₘ uNew)
+
+theorem divKAddbackFinalPost_unfold (uBase carry qHat uTop : Word) (u_off : BitVec 12) :
+    divKAddbackFinalPost uBase carry qHat uTop u_off =
+      (let uNew := uTop + carry
+       let qHat' := qHat + signExtend12 4095
+       (.x6 ↦ᵣ uBase) ** (.x7 ↦ᵣ carry) ** (.x11 ↦ᵣ qHat') **
+       (.x5 ↦ᵣ uNew) ** (uBase + signExtend12 u_off ↦ₘ uNew)) := by
+  delta divKAddbackFinalPost; rfl
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step1.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step1.lean
@@ -164,4 +164,38 @@ theorem divK_div128_step1_spec_within
     (fun h hp => by xperm_hyp hp)
     h123
 
+/-- Bundled postcondition for `divK_div128_step1_spec_within`.
+    Hides all 10 let-intermediates (q1, rhat, hi, q1c, rhatc, qDlo,
+    rhatUn1, q1', rhat') leaving only the input parameters visible. -/
+@[irreducible]
+def divKDiv128Step1Post (sp uHi dHi dlo un1 : Word) : Assertion :=
+  let q1 := rv64_divu uHi dHi
+  let rhat := uHi - q1 * dHi
+  let hi := q1 >>> (32 : BitVec 6).toNat
+  let q1c := if hi = 0 then q1 else q1 + signExtend12 4095
+  let rhatc := if hi = 0 then rhat else rhat + dHi
+  let qDlo := q1c * dlo
+  let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
+  let q1' := if BitVec.ult rhatUn1 qDlo then q1c + signExtend12 4095 else q1c
+  let rhat' := if BitVec.ult rhatUn1 qDlo then rhatc + dHi else rhatc
+  (.x7 ↦ᵣ rhat') ** (.x6 ↦ᵣ dHi) ** (.x10 ↦ᵣ q1') **
+  (.x5 ↦ᵣ qDlo) ** (.x11 ↦ᵣ un1) ** (.x1 ↦ᵣ rhatUn1) **
+  (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** (sp + signExtend12 3952 ↦ₘ dlo)
+
+theorem divKDiv128Step1Post_unfold (sp uHi dHi dlo un1 : Word) :
+    divKDiv128Step1Post sp uHi dHi dlo un1 =
+      (let q1 := rv64_divu uHi dHi
+       let rhat := uHi - q1 * dHi
+       let hi := q1 >>> (32 : BitVec 6).toNat
+       let q1c := if hi = 0 then q1 else q1 + signExtend12 4095
+       let rhatc := if hi = 0 then rhat else rhat + dHi
+       let qDlo := q1c * dlo
+       let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
+       let q1' := if BitVec.ult rhatUn1 qDlo then q1c + signExtend12 4095 else q1c
+       let rhat' := if BitVec.ult rhatUn1 qDlo then rhatc + dHi else rhatc
+       (.x7 ↦ᵣ rhat') ** (.x6 ↦ᵣ dHi) ** (.x10 ↦ᵣ q1') **
+       (.x5 ↦ᵣ qDlo) ** (.x11 ↦ᵣ un1) ** (.x1 ↦ᵣ rhatUn1) **
+       (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** (sp + signExtend12 3952 ↦ₘ dlo)) := by
+  delta divKDiv128Step1Post; rfl
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Add `@[irreducible]` bundled postconditions for 2 DivMod LimbSpec specs, eliminating statement-level `let` chains
- `divKAddbackFinalPost` (AddBackFinalLoopControl.lean, 2 lets → 0): hides `uNew`, `qHat'` add-back intermediates
- `divKDiv128Step1Post` (Div128Step1.lean, 10 lets → 0): hides the full Phase-1 div128 derivation chain (`q1`, `rhat`, `hi`, `q1c`, `rhatc`, `qDlo`, `rhatUn1`, `q1'`, `rhat'`); surface parameters are `sp/uHi/dHi/dlo/un1`

Each bundle ships with a `_unfold` theorem (`delta xxx; rfl`).

Refs #61. Bead: evm-asm-yz73p.

## Verification
- `lake build EvmAsm.Evm64.DivMod.LimbSpec.AddBackFinalLoopControl EvmAsm.Evm64.DivMod.LimbSpec.Div128Step1`
- `scripts/check-file-size.sh`
- `rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/LimbSpec/AddBackFinalLoopControl.lean EvmAsm/Evm64/DivMod/LimbSpec/Div128Step1.lean`
- `lake build`

Authored by @pirapira; implemented by Claude Code