### PR TITLE
chore(divmod): add Div128Phase1 postcondition bundles

### DIFF
--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Phase1.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Phase1.lean
@@ -102,4 +102,61 @@ theorem divK_div128_step1_init_spec_within (uHi dHi v5Old v10Old : Word) (base :
   have I2 := sub_spec_gen_rd_eq_rs1_within .x7 .x5 uHi (q1 * dHi) (base + 8) (by nofun)
   runBlock I0 I1 I2
 
+/-- Bundled postcondition for `divK_div128_save_split_d_spec_within`.
+    Hides `dHi` and `dLo` split intermediates. -/
+@[irreducible]
+def divKDiv128SaveSplitDPost (sp retAddr d : Word) : Assertion :=
+  let dHi := d >>> (32 : BitVec 6).toNat
+  let dLo := (d <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  (.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ retAddr) ** (.x10 ↦ᵣ d) **
+  (.x6 ↦ᵣ dHi) ** (.x1 ↦ᵣ dLo) **
+  (sp + signExtend12 3968 ↦ₘ retAddr) **
+  (sp + signExtend12 3960 ↦ₘ d) **
+  (sp + signExtend12 3952 ↦ₘ dLo)
+
+theorem divKDiv128SaveSplitDPost_unfold (sp retAddr d : Word) :
+    divKDiv128SaveSplitDPost sp retAddr d =
+      (let dHi := d >>> (32 : BitVec 6).toNat
+       let dLo := (d <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+       (.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ retAddr) ** (.x10 ↦ᵣ d) **
+       (.x6 ↦ᵣ dHi) ** (.x1 ↦ᵣ dLo) **
+       (sp + signExtend12 3968 ↦ₘ retAddr) **
+       (sp + signExtend12 3960 ↦ₘ d) **
+       (sp + signExtend12 3952 ↦ₘ dLo)) := by
+  delta divKDiv128SaveSplitDPost; rfl
+
+/-- Bundled postcondition for `divK_div128_split_ulo_spec_within`.
+    Hides `un1` and `un0` split intermediates. -/
+@[irreducible]
+def divKDiv128SplitUloPost (sp uLo : Word) : Assertion :=
+  let un1 := uLo >>> (32 : BitVec 6).toNat
+  let un0 := (uLo <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ un0) ** (.x11 ↦ᵣ un1) **
+  (sp + signExtend12 3944 ↦ₘ un0)
+
+theorem divKDiv128SplitUloPost_unfold (sp uLo : Word) :
+    divKDiv128SplitUloPost sp uLo =
+      (let un1 := uLo >>> (32 : BitVec 6).toNat
+       let un0 := (uLo <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ un0) ** (.x11 ↦ᵣ un1) **
+       (sp + signExtend12 3944 ↦ₘ un0)) := by
+  delta divKDiv128SplitUloPost; rfl
+
+/-- Bundled postcondition for `divK_div128_step1_init_spec_within`.
+    Hides `q1` and `rhat` DIVU/SUB intermediates. -/
+@[irreducible]
+def divKDiv128Step1InitPost (uHi dHi : Word) : Assertion :=
+  let q1 := rv64_divu uHi dHi
+  let rhat := uHi - q1 * dHi
+  (.x7 ↦ᵣ rhat) ** (.x6 ↦ᵣ dHi) **
+  (.x10 ↦ᵣ q1) ** (.x5 ↦ᵣ q1 * dHi)
+
+theorem divKDiv128Step1InitPost_unfold (uHi dHi : Word) :
+    divKDiv128Step1InitPost uHi dHi =
+      (let q1 := rv64_divu uHi dHi
+       let rhat := uHi - q1 * dHi
+       (.x7 ↦ᵣ rhat) ** (.x6 ↦ᵣ dHi) **
+       (.x10 ↦ᵣ q1) ** (.x5 ↦ᵣ q1 * dHi)) := by
+  delta divKDiv128Step1InitPost; rfl
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Add `@[irreducible]` bundled postconditions for 3 div128 Phase-1 LimbSpec specs, each reducing 2 statement-level `let`s to 0
- `divKDiv128SaveSplitDPost` (2 lets → 0): hides `dHi`, `dLo` divisor split intermediates
- `divKDiv128SplitUloPost` (2 lets → 0): hides `un1`, `un0` dividend-low split intermediates
- `divKDiv128Step1InitPost` (2 lets → 0): hides `q1`, `rhat` DIVU/MUL/SUB step-1 init results

Each bundle ships with a `_unfold` theorem (`delta xxx; rfl`).

Refs #61. Bead: evm-asm-yz73p.

## Verification
- `lake build EvmAsm.Evm64.DivMod.LimbSpec.Div128Phase1`
- `scripts/check-file-size.sh`
- `rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/LimbSpec/Div128Phase1.lean`
- `lake build`

Authored by @pirapira; implemented by Claude Code