### PR TITLE
chore(divmod): add Div128ProdCheck2 merged postcondition bundle

### DIFF
--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck2.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck2.lean
@@ -275,4 +275,25 @@ theorem divK_div128_prodcheck2_merged_spec_within
         (fun _ hp => hp)
         ntaken_clean hjal_framed)
 
+/-- Bundled postcondition for `divK_div128_prodcheck2_merged_spec_within`.
+    Hides `q0Dlo`, `rhat2Un0`, and `q0'` product-check-2 intermediates. -/
+@[irreducible]
+def divKDiv128ProdCheck2MergedPost (sp q0 rhat2 dlo un0 : Word) : Assertion :=
+  let q0Dlo := q0 * dlo
+  let rhat2Un0 := (rhat2 <<< (32 : BitVec 6).toNat) ||| un0
+  let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0 + signExtend12 4095 else q0
+  (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ q0') ** (.x11 ↦ᵣ un0) **
+  (.x7 ↦ᵣ q0Dlo) ** (.x1 ↦ᵣ rhat2Un0) **
+  (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0)
+
+theorem divKDiv128ProdCheck2MergedPost_unfold (sp q0 rhat2 dlo un0 : Word) :
+    divKDiv128ProdCheck2MergedPost sp q0 rhat2 dlo un0 =
+      (let q0Dlo := q0 * dlo
+       let rhat2Un0 := (rhat2 <<< (32 : BitVec 6).toNat) ||| un0
+       let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0 + signExtend12 4095 else q0
+       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ q0') ** (.x11 ↦ᵣ un0) **
+       (.x7 ↦ᵣ q0Dlo) ** (.x1 ↦ᵣ rhat2Un0) **
+       (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0)) := by
+  delta divKDiv128ProdCheck2MergedPost; rfl
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Add `@[irreducible]` bundled postcondition for `divK_div128_prodcheck2_merged_spec_within`, reducing 3 statement-level `let`s to 0
- `divKDiv128ProdCheck2MergedPost` (3 lets → 0): hides `q0Dlo`, `rhat2Un0`, and `q0'` product-check-2 intermediates; surface parameters are `sp/q0/rhat2/dlo/un0`

Ships with `divKDiv128ProdCheck2MergedPost_unfold` theorem (`delta xxx; rfl`).

Refs #61. Bead: evm-asm-yz73p.

## Verification
- `lake build EvmAsm.Evm64.DivMod.LimbSpec.Div128ProdCheck2`
- `scripts/check-file-size.sh`
- `rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck2.lean`
- `lake build`

Authored by @pirapira; implemented by Claude Code