### PR TITLE
chore(divmod): add Div128Step2 thru-guard postcondition bundle

### DIFF
--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2.lean
@@ -541,6 +541,36 @@ abbrev divKDiv128Step2UptoGuardCode (base : Word) : CodeReq :=
   (CodeReq.union (CodeReq.singleton (base + 20) (.ADDI .x5 .x5 4095))
    (CodeReq.singleton (base + 24) (.ADD .x11 .x11 .x6)))))))
 
+/-- Bundled base postcondition for `divK_div128_step2_thru_guard_spec_within`.
+    Hides 6 lets (q0, rhat2, hi, q0c, rhat2c, rhat2cHi). The pure fact
+    (`rhat2cHi ≠ 0` or `= 0`) is composed on top by the caller. -/
+@[irreducible]
+def divKDiv128Step2ThruGuardPost (sp un21 dHi dlo un0 : Word) : Assertion :=
+  let q0 := rv64_divu un21 dHi
+  let rhat2 := un21 - q0 * dHi
+  let hi := q0 >>> (32 : BitVec 6).toNat
+  let q0c := if hi = 0 then q0 else q0 + signExtend12 4095
+  let rhat2c := if hi = 0 then rhat2 else rhat2 + dHi
+  let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
+  (.x7 ↦ᵣ un21) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) **
+  (.x1 ↦ᵣ rhat2cHi) ** (.x11 ↦ᵣ rhat2c) **
+  (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) **
+  (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0)
+
+theorem divKDiv128Step2ThruGuardPost_unfold (sp un21 dHi dlo un0 : Word) :
+    divKDiv128Step2ThruGuardPost sp un21 dHi dlo un0 =
+      (let q0 := rv64_divu un21 dHi
+       let rhat2 := un21 - q0 * dHi
+       let hi := q0 >>> (32 : BitVec 6).toNat
+       let q0c := if hi = 0 then q0 else q0 + signExtend12 4095
+       let rhat2c := if hi = 0 then rhat2 else rhat2 + dHi
+       let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
+       (.x7 ↦ᵣ un21) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) **
+       (.x1 ↦ᵣ rhat2cHi) ** (.x11 ↦ᵣ rhat2c) **
+       (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) **
+       (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0)) := by
+  delta divKDiv128Step2ThruGuardPost; rfl
+
 /-- Bundled postcondition for `divK_div128_step2_upto_guard_spec_within`.
     Hides 5 computation lets (q0, rhat2, hi, q0c, rhat2c). -/
 @[irreducible]


### PR DESCRIPTION
## Summary
- Add `@[irreducible]` bundled base postcondition for `divK_div128_step2_thru_guard_spec_within`, reducing 6 statement-level `let`s to 0
- `divKDiv128Step2ThruGuardPost` (6 lets → 0): hides `q0`, `rhat2`, `hi`, `q0c`, `rhat2c`, `rhat2cHi` — the full Phase-2 clamp+guard chain; surface parameters are `sp/un21/dHi/dlo/un0`
- Pure fact (`rhat2cHi ≠ 0` or `= 0`) for each cpsBranch leg is composed on top by callers

Ships with `divKDiv128Step2ThruGuardPost_unfold` theorem (`delta xxx; rfl`).

Refs #61. Bead: evm-asm-yz73p.

## Verification
- `lake build EvmAsm.Evm64.DivMod.LimbSpec.Div128Step2`
- `scripts/check-file-size.sh`
- `rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2.lean`
- `lake build`

Authored by @pirapira; implemented by Claude Code