### PR TITLE
chore(divmod): add Div128Tail step2Init/combineQ postcondition bundles

### DIFF
--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Tail.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Tail.lean
@@ -164,3 +164,33 @@ theorem divKDiv128ProdCheck2BodyPost_unfold (sp q0 rhat2 dlo un0 : Word) :
        (.x7 ↦ᵣ q0Dlo) ** (.x1 ↦ᵣ rhat2Un0) **
        (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0)) := by
   delta divKDiv128ProdCheck2BodyPost; rfl
+
+/-- Bundled postcondition for `divK_div128_step2_init_spec_within`.
+    Hides `q0` and `rhat2` DIVU/MUL/SUB step-2-init intermediates. -/
+@[irreducible]
+def divKDiv128Step2InitPost (un21 dHi : Word) : Assertion :=
+  let q0 := rv64_divu un21 dHi
+  let rhat2 := un21 - q0 * dHi
+  (.x7 ↦ᵣ un21) ** (.x6 ↦ᵣ dHi) **
+  (.x5 ↦ᵣ q0) ** (.x1 ↦ᵣ q0 * dHi) ** (.x11 ↦ᵣ rhat2)
+
+theorem divKDiv128Step2InitPost_unfold (un21 dHi : Word) :
+    divKDiv128Step2InitPost un21 dHi =
+      (let q0 := rv64_divu un21 dHi
+       let rhat2 := un21 - q0 * dHi
+       (.x7 ↦ᵣ un21) ** (.x6 ↦ᵣ dHi) **
+       (.x5 ↦ᵣ q0) ** (.x1 ↦ᵣ q0 * dHi) ** (.x11 ↦ᵣ rhat2)) := by
+  delta divKDiv128Step2InitPost; rfl
+
+/-- Bundled postcondition for `divK_div128_combine_q_spec_within`.
+    Hides `q1Hi` and `q = q1Hi ||| q0` intermediates. -/
+@[irreducible]
+def divKDiv128CombineQPost (q1 q0 : Word) : Assertion :=
+  let q := (q1 <<< (32 : BitVec 6).toNat) ||| q0
+  (.x10 ↦ᵣ q1) ** (.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ q)
+
+theorem divKDiv128CombineQPost_unfold (q1 q0 : Word) :
+    divKDiv128CombineQPost q1 q0 =
+      (let q := (q1 <<< (32 : BitVec 6).toNat) ||| q0
+       (.x10 ↦ᵣ q1) ** (.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ q)) := by
+  delta divKDiv128CombineQPost; rfl


### PR DESCRIPTION
## Summary
- Add `@[irreducible]` bundled postconditions for 2 Div128Tail LimbSpec specs, reducing 2 statement-level `let`s to 0 each
- `divKDiv128Step2InitPost` (2 lets → 0): hides `q0` and `rhat2` DIVU/MUL/SUB step-2-init results; parameters: `un21/dHi`
- `divKDiv128CombineQPost` (2 lets → 0): hides `q1Hi` and `q = q1<<32|q0` combine intermediates; parameters: `q1/q0`

Ships with `_unfold` theorems (`delta xxx; rfl`).

Refs #61. Bead: evm-asm-yz73p.

## Verification
- `lake build EvmAsm.Evm64.DivMod.LimbSpec.Div128Tail`
- `scripts/check-file-size.sh`
- `rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/LimbSpec/Div128Tail.lean`
- `lake build`

Authored by @pirapira; implemented by Claude Code