### PR TITLE
chore(divmod): add ClampQ0/CorrectQ1/CorrectQ0 postcondition bundles

### DIFF
--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Clamp.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Clamp.lean
@@ -218,4 +218,23 @@ theorem divKDiv128ClampQ1Post_unfold (q1 rhat dHi : Word) :
        (.x5 ↦ᵣ hi) ** (.x0 ↦ᵣ (0 : Word))) := by
   delta divKDiv128ClampQ1Post; rfl
 
+/-- Bundled postcondition for `divK_div128_clamp_q0_merged_spec_within`.
+    Mirrors `divKDiv128ClampQ1Post` but for `q0` on x5/x11/x1. -/
+@[irreducible]
+def divKDiv128ClampQ0Post (q0 rhat2 dHi : Word) : Assertion :=
+  let hi := q0 >>> (32 : BitVec 6).toNat
+  let q0' := if hi = 0 then q0 else q0 + signExtend12 4095
+  let rhat2' := if hi = 0 then rhat2 else rhat2 + dHi
+  (.x5 ↦ᵣ q0') ** (.x11 ↦ᵣ rhat2') ** (.x6 ↦ᵣ dHi) **
+  (.x1 ↦ᵣ hi) ** (.x0 ↦ᵣ (0 : Word))
+
+theorem divKDiv128ClampQ0Post_unfold (q0 rhat2 dHi : Word) :
+    divKDiv128ClampQ0Post q0 rhat2 dHi =
+      (let hi := q0 >>> (32 : BitVec 6).toNat
+       let q0' := if hi = 0 then q0 else q0 + signExtend12 4095
+       let rhat2' := if hi = 0 then rhat2 else rhat2 + dHi
+       (.x5 ↦ᵣ q0') ** (.x11 ↦ᵣ rhat2') ** (.x6 ↦ᵣ dHi) **
+       (.x1 ↦ᵣ hi) ** (.x0 ↦ᵣ (0 : Word))) := by
+  delta divKDiv128ClampQ0Post; rfl
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128UnProdCheck.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128UnProdCheck.lean
@@ -153,4 +153,34 @@ theorem divKDiv128ProdCheckBodyPost_unfold (sp q rhat un1 dlo : Word) :
        (.x5 ↦ᵣ qDlo) ** (.x1 ↦ᵣ rhatUn1) ** (sp + signExtend12 3952 ↦ₘ dlo)) := by
   delta divKDiv128ProdCheckBodyPost; rfl
 
+/-- Bundled postcondition for `divK_div128_correct_q1_spec_within`.
+    Hides `q'` and `rhat'` correction intermediates (x10/x7 pair). -/
+@[irreducible]
+def divKDiv128CorrectQ1Post (q rhat dHi : Word) : Assertion :=
+  let q' := q + signExtend12 4095
+  let rhat' := rhat + dHi
+  (.x10 ↦ᵣ q') ** (.x7 ↦ᵣ rhat') ** (.x6 ↦ᵣ dHi)
+
+theorem divKDiv128CorrectQ1Post_unfold (q rhat dHi : Word) :
+    divKDiv128CorrectQ1Post q rhat dHi =
+      (let q' := q + signExtend12 4095
+       let rhat' := rhat + dHi
+       (.x10 ↦ᵣ q') ** (.x7 ↦ᵣ rhat') ** (.x6 ↦ᵣ dHi)) := by
+  delta divKDiv128CorrectQ1Post; rfl
+
+/-- Bundled postcondition for `divK_div128_correct_q0_spec_within`.
+    Hides `q0'` and `rhat2'` correction intermediates (x5/x11 pair). -/
+@[irreducible]
+def divKDiv128CorrectQ0Post (q0 rhat2 dHi : Word) : Assertion :=
+  let q0' := q0 + signExtend12 4095
+  let rhat2' := rhat2 + dHi
+  (.x5 ↦ᵣ q0') ** (.x11 ↦ᵣ rhat2') ** (.x6 ↦ᵣ dHi)
+
+theorem divKDiv128CorrectQ0Post_unfold (q0 rhat2 dHi : Word) :
+    divKDiv128CorrectQ0Post q0 rhat2 dHi =
+      (let q0' := q0 + signExtend12 4095
+       let rhat2' := rhat2 + dHi
+       (.x5 ↦ᵣ q0') ** (.x11 ↦ᵣ rhat2') ** (.x6 ↦ᵣ dHi)) := by
+  delta divKDiv128CorrectQ0Post; rfl
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Add `@[irreducible]` bundled postconditions for 3 div128 LimbSpec specs, reducing 2–3 statement-level `let`s to 0
- `divKDiv128ClampQ0Post` (Div128Clamp.lean, 3 lets → 0): mirrors `divKDiv128ClampQ1Post`; hides `hi`, `q0'`, `rhat2'` for the x5/x11/x1 clamp
- `divKDiv128CorrectQ1Post` (Div128UnProdCheck.lean, 2 lets → 0): hides `q'`, `rhat'` correction intermediates (x10/x7 pair)
- `divKDiv128CorrectQ0Post` (Div128UnProdCheck.lean, 2 lets → 0): hides `q0'`, `rhat2'` correction intermediates (x5/x11 pair)

Ships with `_unfold` theorems (`delta xxx; rfl`).

Refs #61. Bead: evm-asm-yz73p.

## Verification
- `lake build EvmAsm.Evm64.DivMod.LimbSpec.Div128Clamp EvmAsm.Evm64.DivMod.LimbSpec.Div128UnProdCheck`
- `scripts/check-file-size.sh`
- `rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" <files>`
- `lake build`

Authored by @pirapira; implemented by Claude Code