### PR TITLE
chore(divmod): add 0-let named spec wrappers for ProdCheck1/Phase1

### DIFF
--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128PhaseEnd.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128PhaseEnd.lean
@@ -133,4 +133,32 @@ theorem divKDiv128Phase1Post_unfold (sp d uLo uHi retAddr : Word) :
        (sp + signExtend12 3944 ↦ₘ un0)) := by
   delta divKDiv128Phase1Post; rfl
 
+/-- 0-let named-postcondition wrapper for `divK_div128_phase1_spec_within`. -/
+theorem divK_div128_phase1_named_spec_within
+    (sp retAddr d uLo uHi v1Old v6Old v11Old
+     retMem dMem dloMem un0Mem : Word) (base : Word) :
+    cpsTripleWithin 10 base (base + 40)
+      (CodeReq.union (CodeReq.singleton base (.SD .x12 .x2 3968))
+      (CodeReq.union (CodeReq.singleton (base + 4) (.SD .x12 .x10 3960))
+      (CodeReq.union (CodeReq.singleton (base + 8) (.SRLI .x6 .x10 32))
+      (CodeReq.union (CodeReq.singleton (base + 12) (.SLLI .x1 .x10 32))
+      (CodeReq.union (CodeReq.singleton (base + 16) (.SRLI .x1 .x1 32))
+      (CodeReq.union (CodeReq.singleton (base + 20) (.SD .x12 .x1 3952))
+      (CodeReq.union (CodeReq.singleton (base + 24) (.SRLI .x11 .x5 32))
+      (CodeReq.union (CodeReq.singleton (base + 28) (.SLLI .x5 .x5 32))
+      (CodeReq.union (CodeReq.singleton (base + 32) (.SRLI .x5 .x5 32))
+       (CodeReq.singleton (base + 36) (.SD .x12 .x5 3944)))))))))))
+      ((.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ retAddr) ** (.x10 ↦ᵣ d) **
+       (.x6 ↦ᵣ v6Old) ** (.x1 ↦ᵣ v1Old) ** (.x5 ↦ᵣ uLo) **
+       (.x11 ↦ᵣ v11Old) ** (.x7 ↦ᵣ uHi) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
+       (sp + signExtend12 3944 ↦ₘ un0Mem))
+      (divKDiv128Phase1Post sp d uLo uHi retAddr) :=
+  EvmAsm.Rv64.cpsTripleWithin_weaken
+    (fun _ hp => hp)
+    (fun _ hp => by simp only [divKDiv128Phase1Post_unfold]; exact hp)
+    (divK_div128_phase1_spec_within sp retAddr d uLo uHi v1Old v6Old v11Old retMem dMem dloMem un0Mem base)
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck1.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck1.lean
@@ -194,4 +194,24 @@ theorem divKDiv128ProdCheck1Post_unfold (sp q1 rhat dHi un1 dlo : Word) :
        (sp + signExtend12 3952 ↦ₘ dlo)) := by
   delta divKDiv128ProdCheck1Post; rfl
 
+/-- 0-let named-postcondition wrapper for `divK_div128_prodcheck1_merged_spec_within`. -/
+theorem divK_div128_prodcheck1_merged_named_spec_within
+    (sp q1 rhat dHi un1 v1Old v5Old dlo : Word) (base : Word) :
+    cpsTripleWithin 8 base (base + 32) (CodeReq.union (CodeReq.singleton base (.LD .x1 .x12 3952))
+      (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x5 .x10 .x1))
+      (CodeReq.union (CodeReq.singleton (base + 8) (.SLLI .x1 .x7 32))
+      (CodeReq.union (CodeReq.singleton (base + 12) (.OR .x1 .x1 .x11))
+      (CodeReq.union (CodeReq.singleton (base + 16) (.BLTU .x1 .x5 8))
+      (CodeReq.union (CodeReq.singleton (base + 20) (.JAL .x0 12))
+      (CodeReq.union (CodeReq.singleton (base + 24) (.ADDI .x10 .x10 4095))
+       (CodeReq.singleton (base + 28) (.ADD .x7 .x7 .x6)))))))))
+      ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) ** (.x11 ↦ᵣ un1) **
+       (.x5 ↦ᵣ v5Old) ** (.x1 ↦ᵣ v1Old) ** (.x6 ↦ᵣ dHi) **
+       (sp + signExtend12 3952 ↦ₘ dlo))
+      (divKDiv128ProdCheck1Post sp q1 rhat dHi un1 dlo) :=
+  EvmAsm.Rv64.cpsTripleWithin_weaken
+    (fun _ hp => hp)
+    (fun _ hp => by simp only [divKDiv128ProdCheck1Post_unfold]; exact hp)
+    (divK_div128_prodcheck1_merged_spec_within sp q1 rhat dHi un1 v1Old v5Old dlo base)
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Add named-postcondition wrappers that use existing `@[irreducible]` bundles, eliminating 4 statement-level `let`s from each spec
- `divK_div128_prodcheck1_merged_named_spec_within` (Div128ProdCheck1.lean): uses `divKDiv128ProdCheck1Post`; 4 lets → 0 in statement
- `divK_div128_phase1_named_spec_within` (Div128PhaseEnd.lean): uses `divKDiv128Phase1Post`; 4 lets → 0 in statement

Both proofs use `cpsTripleWithin_weaken` with the respective `_unfold` theorem.

Refs #61. Bead: evm-asm-yz73p.

## Verification
- `lake build EvmAsm.Evm64.DivMod.LimbSpec.Div128ProdCheck1 EvmAsm.Evm64.DivMod.LimbSpec.Div128PhaseEnd`
- `scripts/check-file-size.sh`
- `rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" <files>`
- `lake build`

Authored by @pirapira; implemented by Claude Code