### PR TITLE
chore(divmod): add 0-let named spec wrappers for NormA/NormB/MulSubSetup

### DIFF
--- a/EvmAsm/Evm64/DivMod/LimbSpec/MulSubSetup.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/MulSubSetup.lean
@@ -95,3 +95,22 @@ theorem divKMulsubSetupPost_unfold (sp j qHat : Word) :
        (.x10 ↦ᵣ signExtend12 (0 : BitVec 12)) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j)) := by
   delta divKMulsubSetupPost; rfl
+
+/-- 0-let named wrapper for `divK_mulsub_setup_spec_within`. -/
+theorem divK_mulsub_setup_named_spec_within (sp qHat j v1Old v5Old v6Old v10Old : Word)
+    (base : Word) :
+    cpsTripleWithin 5 base (base + 20)
+      (CodeReq.union (CodeReq.singleton base (.LD .x1 .x12 3976))
+      (CodeReq.union (CodeReq.singleton (base + 4) (.SLLI .x5 .x1 3))
+      (CodeReq.union (CodeReq.singleton (base + 8) (.ADDI .x6 .x12 4056))
+      (CodeReq.union (CodeReq.singleton (base + 12) (.SUB .x6 .x6 .x5))
+       (CodeReq.singleton (base + 16) (.ADDI .x10 .x0 0))))))
+      ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+       (.x1 ↦ᵣ v1Old) ** (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+       (.x10 ↦ᵣ v10Old) ** (.x0 ↦ᵣ 0) **
+       (sp + signExtend12 3976 ↦ₘ j))
+      (divKMulsubSetupPost sp j qHat) :=
+  EvmAsm.Rv64.cpsTripleWithin_weaken
+    (fun _ hp => hp)
+    (fun _ hp => by simp only [divKMulsubSetupPost_unfold]; exact hp)
+    (divK_mulsub_setup_spec_within sp qHat j v1Old v5Old v6Old v10Old base)

--- a/EvmAsm/Evm64/DivMod/LimbSpec/NormA.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/NormA.lean
@@ -208,4 +208,32 @@ theorem divKNormAMergeBPost_unfold (sp : Word) (next_off dst_off : BitVec 12)
        ((sp + signExtend12 dst_off) ↦ₘ result)) := by
   delta divKNormAMergeBPost; rfl
 
+/-- 0-let named wrapper for `divK_normA_mergeA_spec_within`. -/
+theorem divK_normA_mergeA_named_spec_within (next_off dst_off : BitVec 12)
+    (sp current next v7 v10 shift antiShift dstOld : Word) (base : Word) :
+    cpsTripleWithin 5 base (base + 20) (divK_normA_mergeA_code next_off dst_off base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ current) ** (.x7 ↦ᵣ v7) ** (.x10 ↦ᵣ v10) **
+       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
+       ((sp + signExtend12 next_off) ↦ₘ next) **
+       ((sp + signExtend12 dst_off) ↦ₘ dstOld))
+      (divKNormAMergeAPost sp next_off dst_off current next shift antiShift) :=
+  EvmAsm.Rv64.cpsTripleWithin_weaken
+    (fun _ hp => hp)
+    (fun _ hp => by simp only [divKNormAMergeAPost_unfold]; exact hp)
+    (divK_normA_mergeA_spec_within next_off dst_off sp current next v7 v10 shift antiShift dstOld base)
+
+/-- 0-let named wrapper for `divK_normA_mergeB_spec_within`. -/
+theorem divK_normA_mergeB_named_spec_within (next_off dst_off : BitVec 12)
+    (sp current next v5 v10 shift antiShift dstOld : Word) (base : Word) :
+    cpsTripleWithin 5 base (base + 20) (divK_normA_mergeB_code next_off dst_off base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ current) ** (.x10 ↦ᵣ v10) **
+       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
+       ((sp + signExtend12 next_off) ↦ₘ next) **
+       ((sp + signExtend12 dst_off) ↦ₘ dstOld))
+      (divKNormAMergeBPost sp next_off dst_off current next shift antiShift) :=
+  EvmAsm.Rv64.cpsTripleWithin_weaken
+    (fun _ hp => hp)
+    (fun _ hp => by simp only [divKNormAMergeBPost_unfold]; exact hp)
+    (divK_normA_mergeB_spec_within next_off dst_off sp current next v5 v10 shift antiShift dstOld base)
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LimbSpec/NormB.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/NormB.lean
@@ -119,4 +119,18 @@ theorem divKNormBMergePost_unfold (sp : Word) (high_off low_off : BitVec 12)
        ((sp + signExtend12 low_off) ↦ₘ low)) := by
   delta divKNormBMergePost; rfl
 
+/-- 0-let named wrapper for `divK_normB_merge_spec_within`. -/
+theorem divK_normB_merge_named_spec_within (high_off low_off : BitVec 12)
+    (sp high low v5 v7 shift antiShift : Word) (base : Word) :
+    cpsTripleWithin 6 base (base + 24) (divK_normB_merge_code high_off low_off base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) **
+       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
+       ((sp + signExtend12 high_off) ↦ₘ high) **
+       ((sp + signExtend12 low_off) ↦ₘ low))
+      (divKNormBMergePost sp high_off low_off high low shift antiShift) :=
+  EvmAsm.Rv64.cpsTripleWithin_weaken
+    (fun _ hp => hp)
+    (fun _ hp => by simp only [divKNormBMergePost_unfold]; exact hp)
+    (divK_normB_merge_spec_within high_off low_off sp high low v5 v7 shift antiShift base)
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Add 0-let named-postcondition wrappers for 4 specs, using existing `@[irreducible]` postcondition bundles
- `divK_normA_mergeA_named_spec_within` (NormA.lean, 3 lets → 0): uses `divKNormAMergeAPost`
- `divK_normA_mergeB_named_spec_within` (NormA.lean, 3 lets → 0): uses `divKNormAMergeBPost`
- `divK_normB_merge_named_spec_within` (NormB.lean, 3 lets → 0): uses `divKNormBMergePost`
- `divK_mulsub_setup_named_spec_within` (MulSubSetup.lean, 3 lets → 0): uses `divKMulsubSetupPost`

All proofs use `cpsTripleWithin_weaken` with bundle `_unfold` simp.

Refs #61. Bead: evm-asm-yz73p.

## Verification
- `lake build EvmAsm.Evm64.DivMod.LimbSpec.NormA EvmAsm.Evm64.DivMod.LimbSpec.NormB EvmAsm.Evm64.DivMod.LimbSpec.MulSubSetup`
- `scripts/check-file-size.sh`
- `rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" <files>`
- `lake build`

Authored by @pirapira; implemented by Claude Code