### PR TITLE
chore(divmod): add 0-let named spec wrappers for Div128UnProdCheck/Clamp

### DIFF
--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Clamp.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Clamp.lean
@@ -237,4 +237,36 @@ theorem divKDiv128ClampQ0Post_unfold (q0 rhat2 dHi : Word) :
        (.x1 ↦ᵣ hi) ** (.x0 ↦ᵣ (0 : Word))) := by
   delta divKDiv128ClampQ0Post; rfl
 
+/-- 0-let named wrapper for `divK_div128_clamp_q1_merged_spec_within`. -/
+theorem divK_div128_clamp_q1_merged_named_spec_within
+    (q1 rhat dHi v5Old : Word) (base : Word) :
+    cpsTripleWithin 4 base (base + 16)
+      (CodeReq.union (CodeReq.singleton base (.SRLI .x5 .x10 32))
+      (CodeReq.union (CodeReq.singleton (base + 4) (.BEQ .x5 .x0 12))
+      (CodeReq.union (CodeReq.singleton (base + 8) (.ADDI .x10 .x10 4095))
+       (CodeReq.singleton (base + 12) (.ADD .x7 .x7 .x6)))))
+      ((.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) ** (.x6 ↦ᵣ dHi) **
+       (.x5 ↦ᵣ v5Old) ** (.x0 ↦ᵣ 0))
+      (divKDiv128ClampQ1Post q1 rhat dHi) :=
+  EvmAsm.Rv64.cpsTripleWithin_weaken
+    (fun _ hp => hp)
+    (fun _ hp => by simp only [divKDiv128ClampQ1Post_unfold]; exact hp)
+    (divK_div128_clamp_q1_merged_spec_within q1 rhat dHi v5Old base)
+
+/-- 0-let named wrapper for `divK_div128_clamp_q0_merged_spec_within`. -/
+theorem divK_div128_clamp_q0_merged_named_spec_within
+    (q0 rhat2 dHi v1Old : Word) (base : Word) :
+    cpsTripleWithin 4 base (base + 16)
+      (CodeReq.union (CodeReq.singleton base (.SRLI .x1 .x5 32))
+      (CodeReq.union (CodeReq.singleton (base + 4) (.BEQ .x1 .x0 12))
+      (CodeReq.union (CodeReq.singleton (base + 8) (.ADDI .x5 .x5 4095))
+       (CodeReq.singleton (base + 12) (.ADD .x11 .x11 .x6)))))
+      ((.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ rhat2) ** (.x6 ↦ᵣ dHi) **
+       (.x1 ↦ᵣ v1Old) ** (.x0 ↦ᵣ 0))
+      (divKDiv128ClampQ0Post q0 rhat2 dHi) :=
+  EvmAsm.Rv64.cpsTripleWithin_weaken
+    (fun _ hp => hp)
+    (fun _ hp => by simp only [divKDiv128ClampQ0Post_unfold]; exact hp)
+    (divK_div128_clamp_q0_merged_spec_within q0 rhat2 dHi v1Old base)
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128UnProdCheck.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128UnProdCheck.lean
@@ -183,4 +183,62 @@ theorem divKDiv128CorrectQ0Post_unfold (q0 rhat2 dHi : Word) :
        (.x5 ↦ᵣ q0') ** (.x11 ↦ᵣ rhat2') ** (.x6 ↦ᵣ dHi)) := by
   delta divKDiv128CorrectQ0Post; rfl
 
+/-- 0-let named wrapper for `divK_div128_compute_un21_spec_within`. -/
+theorem divK_div128_compute_un21_named_spec_within
+    (sp q1 rhat un1 v1Old v5Old dloMem : Word) (base : Word) :
+    cpsTripleWithin 5 base (base + 20)
+      (CodeReq.union (CodeReq.singleton base (.LD .x1 .x12 3952))
+      (CodeReq.union (CodeReq.singleton (base + 4) (.SLLI .x5 .x7 32))
+      (CodeReq.union (CodeReq.singleton (base + 8) (.OR .x5 .x5 .x11))
+      (CodeReq.union (CodeReq.singleton (base + 12) (.MUL .x1 .x10 .x1))
+       (CodeReq.singleton (base + 16) (.SUB .x7 .x5 .x1))))))
+      ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) **
+       (.x11 ↦ᵣ un1) ** (.x5 ↦ᵣ v5Old) ** (.x1 ↦ᵣ v1Old) **
+       (sp + signExtend12 3952 ↦ₘ dloMem))
+      (divKDiv128ComputeUn21Post sp q1 rhat un1 dloMem) :=
+  EvmAsm.Rv64.cpsTripleWithin_weaken
+    (fun _ hp => hp)
+    (fun _ hp => by simp only [divKDiv128ComputeUn21Post_unfold]; exact hp)
+    (divK_div128_compute_un21_spec_within sp q1 rhat un1 v1Old v5Old dloMem base)
+
+/-- 0-let named wrapper for `divK_div128_prodcheck_body_spec_within`. -/
+theorem divK_div128_prodcheck_body_named_spec_within
+    (sp q rhat un1 v1Old v5Old dlo : Word) (base : Word) :
+    cpsTripleWithin 4 base (base + 16)
+      (CodeReq.union (CodeReq.singleton base (.LD .x1 .x12 3952))
+      (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x5 .x10 .x1))
+      (CodeReq.union (CodeReq.singleton (base + 8) (.SLLI .x1 .x7 32))
+       (CodeReq.singleton (base + 12) (.OR .x1 .x1 .x11)))))
+      ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q) ** (.x7 ↦ᵣ rhat) ** (.x11 ↦ᵣ un1) **
+       (.x5 ↦ᵣ v5Old) ** (.x1 ↦ᵣ v1Old) ** (sp + signExtend12 3952 ↦ₘ dlo))
+      (divKDiv128ProdCheckBodyPost sp q rhat un1 dlo) :=
+  EvmAsm.Rv64.cpsTripleWithin_weaken
+    (fun _ hp => hp)
+    (fun _ hp => by simp only [divKDiv128ProdCheckBodyPost_unfold]; exact hp)
+    (divK_div128_prodcheck_body_spec_within sp q rhat un1 v1Old v5Old dlo base)
+
+/-- 0-let named wrapper for `divK_div128_correct_q1_spec_within`. -/
+theorem divK_div128_correct_q1_named_spec_within (q rhat dHi : Word) (base : Word) :
+    cpsTripleWithin 2 base (base + 8)
+      (CodeReq.union (CodeReq.singleton base (.ADDI .x10 .x10 4095))
+       (CodeReq.singleton (base + 4) (.ADD .x7 .x7 .x6)))
+      ((.x10 ↦ᵣ q) ** (.x7 ↦ᵣ rhat) ** (.x6 ↦ᵣ dHi))
+      (divKDiv128CorrectQ1Post q rhat dHi) :=
+  EvmAsm.Rv64.cpsTripleWithin_weaken
+    (fun _ hp => hp)
+    (fun _ hp => by simp only [divKDiv128CorrectQ1Post_unfold]; exact hp)
+    (divK_div128_correct_q1_spec_within q rhat dHi base)
+
+/-- 0-let named wrapper for `divK_div128_correct_q0_spec_within`. -/
+theorem divK_div128_correct_q0_named_spec_within (q0 rhat2 dHi : Word) (base : Word) :
+    cpsTripleWithin 2 base (base + 8)
+      (CodeReq.union (CodeReq.singleton base (.ADDI .x5 .x5 4095))
+       (CodeReq.singleton (base + 4) (.ADD .x11 .x11 .x6)))
+      ((.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ rhat2) ** (.x6 ↦ᵣ dHi))
+      (divKDiv128CorrectQ0Post q0 rhat2 dHi) :=
+  EvmAsm.Rv64.cpsTripleWithin_weaken
+    (fun _ hp => hp)
+    (fun _ hp => by simp only [divKDiv128CorrectQ0Post_unfold]; exact hp)
+    (divK_div128_correct_q0_spec_within q0 rhat2 dHi base)
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Add 0-let named-postcondition wrappers for 6 specs across 2 files, using existing `@[irreducible]` bundles
- `divK_div128_compute_un21_named_spec_within` (4 lets → 0): uses `divKDiv128ComputeUn21Post`
- `divK_div128_prodcheck_body_named_spec_within` (3 lets → 0): uses `divKDiv128ProdCheckBodyPost`
- `divK_div128_correct_q1_named_spec_within` (2 lets → 0): uses `divKDiv128CorrectQ1Post`
- `divK_div128_correct_q0_named_spec_within` (2 lets → 0): uses `divKDiv128CorrectQ0Post`
- `divK_div128_clamp_q1_merged_named_spec_within` (3 lets → 0): uses `divKDiv128ClampQ1Post`
- `divK_div128_clamp_q0_merged_named_spec_within` (3 lets → 0): uses `divKDiv128ClampQ0Post`

All proofs use `cpsTripleWithin_weaken` with bundle `_unfold` simp.

Refs #61. Bead: evm-asm-yz73p.

## Verification
- `lake build EvmAsm.Evm64.DivMod.LimbSpec.Div128UnProdCheck EvmAsm.Evm64.DivMod.LimbSpec.Div128Clamp`
- `scripts/check-file-size.sh`
- `rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" <files>`
- `lake build`

Authored by @pirapira; implemented by Claude Code