### PR TITLE
chore(divmod): add 0-let named spec wrappers for Denorm/ProdCheck2

### DIFF
--- a/EvmAsm/Evm64/DivMod/LimbSpec/Denorm.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Denorm.lean
@@ -120,4 +120,18 @@ theorem divKDenormMergePost_unfold (sp : Word) (curr_off next_off : BitVec 12)
        ((sp + signExtend12 next_off) ↦ₘ next)) := by
   delta divKDenormMergePost; rfl
 
+/-- 0-let named wrapper for `divK_denorm_merge_spec_within`. -/
+theorem divK_denorm_merge_named_spec_within (curr_off next_off : BitVec 12)
+    (sp curr next v5 v7 shift antiShift : Word) (base : Word) :
+    cpsTripleWithin 6 base (base + 24) (divK_denorm_merge_code curr_off next_off base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) **
+       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
+       ((sp + signExtend12 curr_off) ↦ₘ curr) **
+       ((sp + signExtend12 next_off) ↦ₘ next))
+      (divKDenormMergePost sp curr_off next_off curr next shift antiShift) :=
+  EvmAsm.Rv64.cpsTripleWithin_weaken
+    (fun _ hp => hp)
+    (fun _ hp => by simp only [divKDenormMergePost_unfold]; exact hp)
+    (divK_denorm_merge_spec_within curr_off next_off sp curr next v5 v7 shift antiShift base)
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck2.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck2.lean
@@ -296,4 +296,25 @@ theorem divKDiv128ProdCheck2MergedPost_unfold (sp q0 rhat2 dlo un0 : Word) :
        (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0)) := by
   delta divKDiv128ProdCheck2MergedPost; rfl
 
+/-- 0-let named wrapper for `divK_div128_prodcheck2_merged_spec_within`. -/
+theorem divK_div128_prodcheck2_merged_named_spec_within
+    (sp q0 rhat2 v1Old v7Old dlo un0 : Word) (base : Word) :
+    cpsTripleWithin 8 base (base + 32)
+      (CodeReq.union (CodeReq.singleton base (.LD .x1 .x12 3952))
+      (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x7 .x5 .x1))
+      (CodeReq.union (CodeReq.singleton (base + 8) (.SLLI .x1 .x11 32))
+      (CodeReq.union (CodeReq.singleton (base + 12) (.LD .x11 .x12 3944))
+      (CodeReq.union (CodeReq.singleton (base + 16) (.OR .x1 .x1 .x11))
+      (CodeReq.union (CodeReq.singleton (base + 20) (.BLTU .x1 .x7 8))
+      (CodeReq.union (CodeReq.singleton (base + 24) (.JAL .x0 8))
+       (CodeReq.singleton (base + 28) (.ADDI .x5 .x5 4095)))))))))
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ rhat2) **
+       (.x7 ↦ᵣ v7Old) ** (.x1 ↦ᵣ v1Old) **
+       (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0))
+      (divKDiv128ProdCheck2MergedPost sp q0 rhat2 dlo un0) :=
+  EvmAsm.Rv64.cpsTripleWithin_weaken
+    (fun _ hp => hp)
+    (fun _ hp => by simp only [divKDiv128ProdCheck2MergedPost_unfold]; exact hp)
+    (divK_div128_prodcheck2_merged_spec_within sp q0 rhat2 v1Old v7Old dlo un0 base)
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Add 0-let named-postcondition wrappers for 2 specs, using existing `@[irreducible]` bundles
- `divK_denorm_merge_named_spec_within` (Denorm.lean, 3 lets → 0): uses `divKDenormMergePost` + `divK_denorm_merge_code` abbrev
- `divK_div128_prodcheck2_merged_named_spec_within` (Div128ProdCheck2.lean, 3 lets → 0): uses `divKDiv128ProdCheck2MergedPost` with inline code literal

Both proofs use `cpsTripleWithin_weaken` with bundle `_unfold` simp.

Refs #61. Bead: evm-asm-yz73p.

## Verification
- `lake build EvmAsm.Evm64.DivMod.LimbSpec.Denorm EvmAsm.Evm64.DivMod.LimbSpec.Div128ProdCheck2`
- `scripts/check-file-size.sh`
- `rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" <files>`
- `lake build`

Authored by @pirapira; implemented by Claude Code