### PR TITLE
chore(divmod): add 0-let named spec wrapper for Div128Step2v4 phase E

### DIFF
--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2v4.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2v4.lean
@@ -1037,4 +1037,20 @@ theorem divKDiv128Step2V4PhaseEPost_unfold
        (sp + signExtend12 3936 ↦ₘ rhat2c)) := by
   delta divKDiv128Step2V4PhaseEPost; rfl
 
+/-- 0-let named wrapper for `divK_div128_step2_v4_phase_D_merged_spec`.
+    Inlines rhat2cHi, q0Dlo1, rhat2Un0 in precondition. -/
+theorem divK_div128_step2_v4_phase_D_named_spec
+    (sp dHi q0c rhat2c dlo un0 : Word) (base : Word) :
+    cpsTripleWithin 4 (base + 60) (base + 84) (divKDiv128Step2V4Code base)
+      ((.x7 ↦ᵣ q0c * dlo) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) **
+       (.x11 ↦ᵣ un0) ** (.x1 ↦ᵣ (rhat2c <<< (32 : BitVec 6).toNat) ||| un0) **
+       (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2c >>> (32 : BitVec 6).toNat = 0⌝ **
+       (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
+       (sp + signExtend12 3936 ↦ₘ rhat2c))
+      (divKDiv128Step2V4PhaseDPost sp dHi q0c rhat2c dlo un0) :=
+  EvmAsm.Rv64.cpsTripleWithin_weaken
+    (fun _ hp => hp)
+    (fun _ hp => by simp only [divKDiv128Step2V4PhaseDPost_unfold]; exact hp)
+    (divK_div128_step2_v4_phase_D_merged_spec sp dHi q0c rhat2c dlo un0 base)
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2v4.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2v4.lean
@@ -1037,4 +1037,21 @@ theorem divKDiv128Step2V4PhaseEPost_unfold
        (sp + signExtend12 3936 ↦ₘ rhat2c)) := by
   delta divKDiv128Step2V4PhaseEPost; rfl
 
+/-- 0-let named wrapper for `divK_div128_step2_v4_phase_E_merged_spec`.
+    Inlines rhat2cHi in the precondition pure fact. -/
+theorem divK_div128_step2_v4_phase_E_named_spec
+    (sp dHi q0' rhat2' rhat2Un0 q0Dlo1 dlo un0 rhat2c : Word) (base : Word) :
+    cpsTripleWithin 10 (base + 84) (base + 124) (divKDiv128Step2V4Code base)
+      ((.x7 ↦ᵣ q0Dlo1) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0') **
+       (.x11 ↦ᵣ rhat2') ** (.x1 ↦ᵣ rhat2Un0) **
+       (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2c >>> (32 : BitVec 6).toNat = 0⌝ **
+       (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
+       (sp + signExtend12 3936 ↦ₘ rhat2c))
+      (divKDiv128Step2V4PhaseEPost sp dHi q0' rhat2' q0Dlo1 dlo un0 rhat2c) :=
+  EvmAsm.Rv64.cpsTripleWithin_weaken
+    (fun _ hp => hp)
+    (fun _ hp => by simp only [divKDiv128Step2V4PhaseEPost_unfold]; exact hp)
+    (divK_div128_step2_v4_phase_E_merged_spec
+      sp dHi q0' rhat2' rhat2Un0 q0Dlo1 dlo un0 rhat2c base)
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Tail.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Tail.lean
@@ -165,6 +165,24 @@ theorem divKDiv128ProdCheck2BodyPost_unfold (sp q0 rhat2 dlo un0 : Word) :
        (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0)) := by
   delta divKDiv128ProdCheck2BodyPost; rfl
 
+/-- 0-let named wrapper for `divK_div128_prodcheck2_body_spec_within`. -/
+theorem divK_div128_prodcheck2_body_named_spec_within
+    (sp q0 rhat2 v1Old v7Old dlo un0 : Word) (base : Word) :
+    cpsTripleWithin 5 base (base + 20)
+      (CodeReq.union (CodeReq.singleton base (.LD .x1 .x12 3952))
+      (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x7 .x5 .x1))
+      (CodeReq.union (CodeReq.singleton (base + 8) (.SLLI .x1 .x11 32))
+      (CodeReq.union (CodeReq.singleton (base + 12) (.LD .x11 .x12 3944))
+       (CodeReq.singleton (base + 16) (.OR .x1 .x1 .x11))))))
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ rhat2) **
+       (.x7 ↦ᵣ v7Old) ** (.x1 ↦ᵣ v1Old) **
+       (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0))
+      (divKDiv128ProdCheck2BodyPost sp q0 rhat2 dlo un0) :=
+  EvmAsm.Rv64.cpsTripleWithin_weaken
+    (fun _ hp => hp)
+    (fun _ hp => by simp only [divKDiv128ProdCheck2BodyPost_unfold]; exact hp)
+    (divK_div128_prodcheck2_body_spec_within sp q0 rhat2 v1Old v7Old dlo un0 base)
+
 /-- Bundled postcondition for `divK_div128_step2_init_spec_within`.
     Hides `q0` and `rhat2` DIVU/MUL/SUB step-2-init intermediates. -/
 @[irreducible]


### PR DESCRIPTION
## Summary
- Add `divK_div128_step2_v4_phase_E_named_spec`: 7 statement lets → 0 via `divKDiv128Step2V4PhaseEPost`
- Inlines `rhat2cHi = rhat2c >>> 32` directly in the precondition pure fact
- Term-mode proof: `cpsTripleWithin_weaken` + `divKDiv128Step2V4PhaseEPost_unfold`

With this PR and PR #4607 together, all phase D and E specs in Div128Step2v4.lean have 0-let named wrappers.

Refs #61. Bead: evm-asm-yz73p.

## Verification
- `lake build EvmAsm.Evm64.DivMod.LimbSpec.Div128Step2v4` (no warnings)
- `scripts/check-file-size.sh`
- `rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2v4.lean`
- `lake build`

Authored by @pirapira; implemented by Claude Code