### PR TITLE
chore(divmod): add divK_div128_step2_branch_merged_named_spec_within

### DIFF
--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2.lean
@@ -661,4 +661,66 @@ theorem divK_div128_step2_thru_guard_named_spec_within
       xperm_hyp hp)
     h
 
+/-- Bundled postcondition for the guard-doesn't-fire + prodcheck2 leg of
+    `divK_div128_step2_branch_merged_spec_within`. Hides 8 computation lets. -/
+@[irreducible]
+def divKDiv128Step2ProdCheck2Post (sp un21 dHi dlo un0 : Word) : Assertion :=
+  let q0 := rv64_divu un21 dHi
+  let rhat2 := un21 - q0 * dHi
+  let hi := q0 >>> (32 : BitVec 6).toNat
+  let q0c := if hi = 0 then q0 else q0 + signExtend12 4095
+  let rhat2c := if hi = 0 then rhat2 else rhat2 + dHi
+  let q0Dlo := q0c * dlo
+  let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| un0
+  let q0'Unguarded := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
+  (.x7 ↦ᵣ q0Dlo) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0'Unguarded) **
+  (.x1 ↦ᵣ rhat2Un0) ** (.x11 ↦ᵣ un0) **
+  (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) **
+  (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0)
+
+theorem divKDiv128Step2ProdCheck2Post_unfold (sp un21 dHi dlo un0 : Word) :
+    divKDiv128Step2ProdCheck2Post sp un21 dHi dlo un0 =
+      (let q0 := rv64_divu un21 dHi
+       let rhat2 := un21 - q0 * dHi
+       let hi := q0 >>> (32 : BitVec 6).toNat
+       let q0c := if hi = 0 then q0 else q0 + signExtend12 4095
+       let rhat2c := if hi = 0 then rhat2 else rhat2 + dHi
+       let q0Dlo := q0c * dlo
+       let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| un0
+       let q0'Unguarded := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
+       (.x7 ↦ᵣ q0Dlo) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0'Unguarded) **
+       (.x1 ↦ᵣ rhat2Un0) ** (.x11 ↦ᵣ un0) **
+       (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) **
+       (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0)) := by
+  delta divKDiv128Step2ProdCheck2Post; rfl
+
+/-- Named cpsBranchWithin wrapper for `divK_div128_step2_branch_merged_spec_within`. 0 statement lets.
+    Branch 1 (guard fires) uses `divKDiv128Step2ThruGuardPost`.
+    Branch 2 (guard doesn't fire + prodcheck2) uses `divKDiv128Step2ProdCheck2Post`. -/
+theorem divK_div128_step2_branch_merged_named_spec_within
+    (sp un21 dHi v1Old v5Old v11Old dlo un0 : Word) (base : Word) :
+    cpsBranchWithin 17 base (divKDiv128Step2Code base)
+      ((.x7 ↦ᵣ un21) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ v5Old) **
+       (.x1 ↦ᵣ v1Old) ** (.x11 ↦ᵣ v11Old) **
+       (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) **
+       (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0))
+      (base + 68)
+        (divKDiv128Step2ThruGuardPost sp un21 dHi dlo un0 **
+         ⌜divKDiv128Step2ThruGuardRhat2cHi un21 dHi ≠ 0⌝)
+      (base + 68)
+        (divKDiv128Step2ProdCheck2Post sp un21 dHi dlo un0 **
+         ⌜divKDiv128Step2ThruGuardRhat2cHi un21 dHi = 0⌝) := by
+  have h := divK_div128_step2_branch_merged_spec_within
+    sp un21 dHi v1Old v5Old v11Old dlo un0 base
+  simp only [divKDiv128Step2Code]
+  exact cpsBranchWithin_weaken
+    (fun _ hp => hp)
+    (fun _ hp => by
+      simp (config := { zeta := true }) only [divKDiv128Step2ThruGuardPost_unfold]
+      xperm_hyp hp)
+    (fun _ hp => by
+      simp (config := { zeta := true }) only [divKDiv128Step2ProdCheck2Post_unfold]
+      xperm_hyp hp)
+    h
+
 end EvmAsm.Evm64


### PR DESCRIPTION
Adds named cpsBranchWithin wrapper removing 9 statement lets from branch_merged_spec. Introduces divKDiv128Step2ProdCheck2Post. Stacked on #4610. Bead: evm-asm-yz73p.

Authored by @pirapira; implemented by Claude Code