### PR TITLE
feat(rv64): add read_input ECALL handler and gen-spec (zkvm-standards t0=0xF2)

### DIFF
--- a/EvmAsm/Evm64/Accelerators/SyscallIds.lean
+++ b/EvmAsm/Evm64/Accelerators/SyscallIds.lean
@@ -110,11 +110,14 @@ def halt : Nat := 0x00
 /-- Host `write_output(ptr, size)` framing selector. -/
 def commit : Nat := 0x10
 
-/-- HINT_LEN framing selector (matches `Rv64.HintSpecs`). -/
+/-- HINT_LEN framing selector (matches `Rv64.HintSpecs`). Deprecated: use `readInput` (0xF2) instead. -/
 def hintLen : Nat := 0xF0
 
-/-- HINT_READ framing selector (matches `Rv64.RLP.Phase4HintRead`). -/
+/-- HINT_READ framing selector (matches `Rv64.RLP.Phase4HintRead`). Deprecated. -/
 def hintRead : Nat := 0xF1
+
+/-- `read_input` framing selector (zkvm-standards C ABI, matches `Rv64.HintSpecs.ecall_read_input_spec_gen_within`). -/
+def readInput : Nat := 0xF2
 
 /-! ## Sanity properties
 

--- a/EvmAsm/Rv64/Execution.lean
+++ b/EvmAsm/Rv64/Execution.lean
@@ -420,6 +420,17 @@ def step (s : MachineState) : Option MachineState :=
         some ((s'.writeBytesAsWords addr bytes).setPC (s.pc + 4))
       else
         none  -- trap: not enough input (SP1: panic)
+    else if t0 == (0xF2 : Word) then  -- read_input syscall (zkvm-standards C ABI)
+      -- Idempotent: writes (inputBufBase, privateInput.length) to the
+      -- two out-pointers supplied in a0/a1. Does not mutate input state.
+      -- a0 = &buf_ptr  →  [a0] := s.inputBufBase
+      -- a1 = &buf_size →  [a1] := s.privateInput.length (as 64-bit Word)
+      if isValidDwordAccess (s.getReg .x10) && isValidDwordAccess (s.getReg .x11) then
+        let s' := s.setMem (s.getReg .x10) s.inputBufBase
+        let s'' := s'.setMem (s.getReg .x11) (BitVec.ofNat 64 s.privateInput.length)
+        some (s''.setPC (s.pc + 4))
+      else
+        none  -- trap: out-pointer is not a valid dword address
     else some (execInstrBr s .ECALL)  -- other ecalls continue
   | some i => some (execInstrBr s i)
 
@@ -623,9 +634,10 @@ theorem step_ecall_continue {s : MachineState}
     (ht0_nw : s.getReg .x5 ≠ (0x02 : Word))
     (ht0_nwo : s.getReg .x5 ≠ (0x10 : Word))
     (ht0_nhl : s.getReg .x5 ≠ (0xF0 : Word))
-    (ht0_nhr : s.getReg .x5 ≠ (0xF1 : Word)) :
+    (ht0_nhr : s.getReg .x5 ≠ (0xF1 : Word))
+    (ht0_nri : s.getReg .x5 ≠ (0xF2 : Word)) :
     step s = some (execInstrBr s .ECALL) := by
-  simp only [step, hfetch, beq_iff_eq, ht0, ht0_nw, ht0_nwo, ht0_nhl, ht0_nhr, ↓reduceIte]
+  simp only [step, hfetch, beq_iff_eq, ht0, ht0_nw, ht0_nwo, ht0_nhl, ht0_nhr, ht0_nri, ↓reduceIte]
 
 /-- `write_output` syscall (t0 = 0x10) appends a1 bytes from memory at a0. -/
 theorem step_ecall_write_output {s : MachineState}
@@ -688,6 +700,30 @@ theorem step_ecall_hint_read_trap {s : MachineState}
     (hinsuff : ¬ ((s.getReg .x11).toNat ≤ s.privateInput.length)) :
     step s = none := by
   simp [step, hfetch, ht0, hinsuff]
+
+/-- `read_input` syscall (zkvm-standards C ABI, t0 = 0xF2): idempotently writes
+    (inputBufBase, privateInput.length) to the out-pointers in a0/a1. -/
+theorem step_ecall_read_input {s : MachineState}
+    (hfetch : s.code s.pc = some .ECALL)
+    (ht0 : s.getReg .x5 = BitVec.ofNat 64 0xF2)
+    (hvalid_a0 : isValidDwordAccess (s.getReg .x10) = true)
+    (hvalid_a1 : isValidDwordAccess (s.getReg .x11) = true) :
+    let s' := s.setMem (s.getReg .x10) s.inputBufBase
+    let s'' := s'.setMem (s.getReg .x11) (BitVec.ofNat 64 s.privateInput.length)
+    step s = some (s''.setPC (s.pc + 4)) := by
+  simp [step, hfetch, ht0, isValidDwordAccess, isValidMemAddr, isAligned8,
+    MEM_START, MEM_END] at hvalid_a0 hvalid_a1 ⊢
+  omega
+
+/-- `read_input` syscall traps when the first out-pointer is not a valid dword address. -/
+theorem step_ecall_read_input_trap_a0 {s : MachineState}
+    (hfetch : s.code s.pc = some .ECALL)
+    (ht0 : s.getReg .x5 = BitVec.ofNat 64 0xF2)
+    (hinvalid : isValidDwordAccess (s.getReg .x10) = false) :
+    step s = none := by
+  simp [step, hfetch, ht0, isValidDwordAccess, isValidMemAddr, isAligned8,
+    MEM_START, MEM_END] at hinvalid ⊢
+  omega
 
 /-- Multi-step execution (n steps). -/
 def stepN : Nat → MachineState → Option MachineState
@@ -761,7 +797,10 @@ theorem code_step {s s' : MachineState} (h : step s = some s') :
                         | (simp at h; done)
                         | (split at h <;> first
                             | (simp only [Option.some.injEq] at h; rw [← h]; simp)
-                            | (simp at h; done))))))))
+                            | (simp at h; done)
+                            | (split at h <;> first
+                                | (simp only [Option.some.injEq] at h; rw [← h]; simp)
+                                | (simp at h; done)))))))))
 
 /-- stepN preserves code memory. -/
 theorem code_stepN {k : Nat} {s s' : MachineState} (h : stepN k s = some s') :

--- a/EvmAsm/Rv64/HintSpecs.lean
+++ b/EvmAsm/Rv64/HintSpecs.lean
@@ -274,4 +274,109 @@ theorem ecall_hint_read_whole_one_word_spec_gen_within
   simpa [h_toNat, List.take_of_length_le (Nat.le_refl input.length),
     List.drop_eq_nil_of_le (Nat.le_refl input.length)] using hread
 
+-- ============================================================================
+-- read_input ECALL spec (zkvm-standards C ABI: t0 = 0xF2)
+-- ============================================================================
+
+/-- `read_input` (zkvm-standards C ABI, t0 = 0xF2) idempotently writes the
+    input-buffer base pointer to memory at `a0` and the input length to
+    memory at `a1`.  Does not consume or mutate the private input.
+
+    Pre:  x5 = 0xF2; x10 = ptr_a0 (valid dword addr); x11 = ptr_a1 (valid dword addr);
+          mem[ptr_a0] = old_ptr; mem[ptr_a1] = old_size;
+          inputBufBaseIs buf_base; privateInputIs input
+    Post: mem[ptr_a0] = buf_base; mem[ptr_a1] = input.length;
+          inputBufBaseIs buf_base; privateInputIs input (unchanged)
+
+    Shape mirrors `ecall_hint_len_spec_gen_within`. -/
+theorem ecall_read_input_spec_gen_within
+    (buf_base old_ptr old_size ptr_a0 ptr_a1 : Word)
+    (input : List (BitVec 8)) (addr : Word)
+    (hvalid_a0 : isValidDwordAccess ptr_a0 = true)
+    (hvalid_a1 : isValidDwordAccess ptr_a1 = true) :
+    cpsTripleWithin 1 addr (addr + 4) (CodeReq.singleton addr .ECALL)
+      ((addr ↦ᵢ .ECALL) **
+        (.x5 ↦ᵣ (BitVec.ofNat 64 0xF2)) **
+        (.x10 ↦ᵣ ptr_a0) ** (.x11 ↦ᵣ ptr_a1) **
+        (ptr_a0 ↦ₘ old_ptr) ** (ptr_a1 ↦ₘ old_size) **
+        inputBufBaseIs buf_base ** privateInputIs input)
+      ((addr ↦ᵢ .ECALL) **
+        (.x5 ↦ᵣ (BitVec.ofNat 64 0xF2)) **
+        (.x10 ↦ᵣ ptr_a0) ** (.x11 ↦ᵣ ptr_a1) **
+        (ptr_a0 ↦ₘ buf_base) ** (ptr_a1 ↦ₘ (BitVec.ofNat 64 input.length)) **
+        inputBufBaseIs buf_base ** privateInputIs input) := by
+  intro R hR s hcr hPR hpc; subst hpc
+  have hfetch : s.code s.pc = some .ECALL :=
+    CodeReq.singleton_satisfiedBy.mp hcr
+  -- Extract the big precondition (left of ** R), then split it
+  have hBIG := holdsFor_sepConj_elim_left hPR
+  -- hBIG : (addr ↦ᵢ ** x5 ** x10 ** x11 ** a0 ** a1 ** base ** priv).holdsFor s
+  have hP_rest1 := holdsFor_sepConj_elim_right hBIG
+  have hx5 : s.getReg .x5 = BitVec.ofNat 64 0xF2 :=
+    holdsFor_regIs.mp (holdsFor_sepConj_elim_left hP_rest1)
+  have hP_rest2 := holdsFor_sepConj_elim_right hP_rest1
+  have hx10 : s.getReg .x10 = ptr_a0 :=
+    holdsFor_regIs.mp (holdsFor_sepConj_elim_left hP_rest2)
+  have hP_rest3 := holdsFor_sepConj_elim_right hP_rest2
+  have hx11 : s.getReg .x11 = ptr_a1 :=
+    holdsFor_regIs.mp (holdsFor_sepConj_elim_left hP_rest3)
+  -- Extract inputBufBase and privateInput
+  have hP_rest4 := holdsFor_sepConj_elim_right hP_rest3  -- ptr_a0 ↦ₘ old_ptr
+  have hP_rest5 := holdsFor_sepConj_elim_right hP_rest4  -- ptr_a1 ↦ₘ old_size
+  have hP_rest6 := holdsFor_sepConj_elim_right hP_rest5  -- inputBufBaseIs buf_base
+  have hbase : s.inputBufBase = buf_base :=
+    holdsFor_inputBufBaseIs.mp (holdsFor_sepConj_elim_left hP_rest6)
+  have hpi : s.privateInput = input :=
+    holdsFor_privateInputIs.mp (holdsFor_sepConj_elim_right hP_rest6)
+  -- Execute step
+  rw [← hx10] at hvalid_a0; rw [← hx11] at hvalid_a1
+  have hstep := step_ecall_read_input hfetch hx5 hvalid_a0 hvalid_a1
+  rw [hbase, hpi] at hstep
+  let s1 := s.setMem ptr_a0 buf_base
+  let s2 := s1.setMem ptr_a1 (BitVec.ofNat 64 input.length)
+  refine ⟨1, Nat.le_refl 1, s2.setPC (s.pc + 4),
+    ?_, by simp [MachineState.setPC, s2, s1], ?_⟩
+  · show (step s).bind (stepN 0) = some _
+    simp only [hstep, s1, s2, hx10, hx11, hbase, hpi, stepN, Option.bind_some]
+  · -- POST: build using two successive setMem updates then setPC.
+    -- Permute PRE to have (a0 ↦ₘ old_ptr) first
+    have hPR' : ((ptr_a0 ↦ₘ old_ptr) **
+          ((ptr_a1 ↦ₘ old_size) **
+           ((s.pc ↦ᵢ .ECALL) **
+            (.x5 ↦ᵣ BitVec.ofNat 64 0xF2) **
+            (.x10 ↦ᵣ ptr_a0) ** (.x11 ↦ᵣ ptr_a1) **
+            inputBufBaseIs buf_base ** privateInputIs input ** R))).holdsFor s := by
+      simpa only [sepConj_assoc', sepConj_comm', sepConj_left_comm'] using hPR
+    -- Update a0 ↦ₘ old_ptr → a0 ↦ₘ buf_base
+    have h1 : ((ptr_a0 ↦ₘ buf_base) **
+          ((ptr_a1 ↦ₘ old_size) **
+           ((s.pc ↦ᵢ .ECALL) **
+            (.x5 ↦ᵣ BitVec.ofNat 64 0xF2) **
+            (.x10 ↦ᵣ ptr_a0) ** (.x11 ↦ᵣ ptr_a1) **
+            inputBufBaseIs buf_base ** privateInputIs input ** R))).holdsFor s1 :=
+      holdsFor_sepConj_memIs_setMem hPR'
+    -- Update a1 ↦ₘ old_size → a1 ↦ₘ len (permute first, then apply)
+    have hPR1' : ((ptr_a1 ↦ₘ old_size) **
+          ((ptr_a0 ↦ₘ buf_base) **
+           ((s.pc ↦ᵢ .ECALL) **
+            (.x5 ↦ᵣ BitVec.ofNat 64 0xF2) **
+            (.x10 ↦ᵣ ptr_a0) ** (.x11 ↦ᵣ ptr_a1) **
+            inputBufBaseIs buf_base ** privateInputIs input ** R))).holdsFor s1 := by
+      simpa only [sepConj_assoc', sepConj_comm', sepConj_left_comm'] using h1
+    have h2 : ((ptr_a1 ↦ₘ (BitVec.ofNat 64 input.length)) **
+          ((ptr_a0 ↦ₘ buf_base) **
+           ((s.pc ↦ᵢ .ECALL) **
+            (.x5 ↦ᵣ BitVec.ofNat 64 0xF2) **
+            (.x10 ↦ᵣ ptr_a0) ** (.x11 ↦ᵣ ptr_a1) **
+            inputBufBaseIs buf_base ** privateInputIs input ** R))).holdsFor s2 :=
+      holdsFor_sepConj_memIs_setMem hPR1'
+    -- Apply setPC
+    have hPC : (((s.pc ↦ᵢ .ECALL) **
+          (.x5 ↦ᵣ BitVec.ofNat 64 0xF2) **
+          (.x10 ↦ᵣ ptr_a0) ** (.x11 ↦ᵣ ptr_a1) **
+          (ptr_a0 ↦ₘ buf_base) ** (ptr_a1 ↦ₘ (BitVec.ofNat 64 input.length)) **
+          inputBufBaseIs buf_base ** privateInputIs input) ** R).holdsFor s2 := by
+      simpa only [sepConj_assoc', sepConj_comm', sepConj_left_comm'] using h2
+    exact holdsFor_pcFree_setPC (pcFree_sepConj (by pcFree) hR) hPC
+
 end EvmAsm.Rv64

--- a/EvmAsm/Rv64/HintSpecs.lean
+++ b/EvmAsm/Rv64/HintSpecs.lean
@@ -337,7 +337,7 @@ theorem ecall_read_input_spec_gen_within
   refine ⟨1, Nat.le_refl 1, s2.setPC (s.pc + 4),
     ?_, by simp [MachineState.setPC, s2, s1], ?_⟩
   · show (step s).bind (stepN 0) = some _
-    simp only [hstep, s1, s2, hx10, hx11, hbase, hpi, stepN, Option.bind_some]
+    simp only [hstep, s1, s2, hx10, hx11, stepN, Option.bind_some]
   · -- POST: build using two successive setMem updates then setPC.
     -- Permute PRE to have (a0 ↦ₘ old_ptr) first
     have hPR' : ((ptr_a0 ↦ₘ old_ptr) **


### PR DESCRIPTION
## Summary
- Adds `read_input` ECALL handler at `t0 = 0xF2` implementing the zkvm-standards C ABI
- Handler writes `inputBufBase` to memory at `a0` and `privateInput.length` to memory at `a1` (idempotent, no input consumed)
- Keeps legacy `HINT_LEN` (0xF0) and `HINT_READ` (0xF1) in place (deprecated; slice 3/4 will retire)
- Adds `step_ecall_read_input` and `step_ecall_read_input_trap_a0` step theorems in `Execution.lean`
- Adds `ecall_read_input_spec_gen_within` Hoare triple in `HintSpecs.lean`
- Adds `readInput` selector constant (`0xF2`) in `SyscallIds.lean`

Refs #114. Bead: evm-asm-oqbz9.

## Verification
- lake build EvmAsm.Rv64.Execution ✓
- lake build EvmAsm.Rv64.HintSpecs ✓
- lake build EvmAsm.Evm64.Accelerators.SyscallIds ✓
- scripts/check-file-size.sh ✓
- rg clean (no sorry/admit/heartbeat/recdepth) ✓
- lake build ✓

Authored by @pirapira; implemented by Claude Code