### PR TITLE
feat(divmod): add evm_mod bzero noNop chain + modStackDispatchPostNoX1

### DIFF
--- a/EvmAsm/Evm64/DivMod/Callable.lean
+++ b/EvmAsm/Evm64/DivMod/Callable.lean
@@ -757,6 +757,39 @@ theorem evm_div_callable_bzero_preserving_x1_spec (sp base raVal : Word)
     nMem shiftMem jMem retMem dMem dloMem scratchUn0
     (DivStackSpecCase.bzero raVal v2 hbz) hStack
 
+/-- MOD callable spec from a no-NOP body proof that preserves the exact incoming
+    `x1` return address. Mirror of `evm_div_callable_spec_from_noNop_preserving_x1`
+    for the MOD callable. -/
+theorem evm_mod_callable_spec_from_noNop_preserving_x1 (sp base raVal : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (branch : ModStackSpecCase base a b)
+    (hStack :
+      cpsTripleWithin unifiedDivBound base (base + nopOff) (modCode_noNop base)
+        (divModStackDispatchPre sp a b
+          branch.x1 branch.x2 v5 v6 v7 v10 v11
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+        (modStackDispatchPostNoX1 sp a b ** (.x1 ↦ᵣ raVal))) :
+    cpsTripleWithin (unifiedDivBound + 1) base (raVal &&& ~~~1)
+      (evm_mod_callable_code base)
+      (divModStackDispatchPre sp a b
+        branch.x1 branch.x2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+      (modStackDispatchPostNoX1 sp a b ** (.x1 ↦ᵣ raVal)) := by
+  have hpcFreePost : (modStackDispatchPostNoX1 sp a b).pcFree :=
+    modStackDispatchPostNoX1_pcFree sp a b
+  have hStackCall :=
+    cpsTripleWithin_extend_code (hmono := modCode_noNop_sub_mod_callable_code) hStack
+  have hRet :=
+    cpsTripleWithin_extend_code (hmono := evm_mod_callable_code_ret_sub (base := base))
+      (ret_spec_within' (base + nopOff) raVal)
+  have hRetFramed :=
+    cpsTripleWithin_frameL (modStackDispatchPostNoX1 sp a b) hpcFreePost hRet
+  exact cpsTripleWithin_seq_same_cr hStackCall hRetFramed
+
 theorem evm_mod_callable_spec_from_noNop (sp base raVal : Word)
     (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7

--- a/EvmAsm/Evm64/DivMod/Compose/Epilogue.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Epilogue.lean
@@ -469,6 +469,77 @@ theorem evm_mod_phaseA_ntaken_spec_within (sp base : Word)
     hAB
 
 -- ============================================================================
+-- Section 13b: MOD zero path over `modCode_noNop`
+-- Mirror of Section 13 (`evm_mod_bzero_spec_within`) with `modCode_noNop`
+-- instead of `modCode`. Needed by `evm_mod_callable_bzero_preserving_x1_spec`
+-- in `DivMod/Callable.lean`.
+-- ============================================================================
+
+private theorem divK_phaseA_code_sub_modCode_noNop {base : Word} :
+    ∀ a i, (divK_phaseA_code base) a = some i → (modCode_noNop base) a = some i := by
+  unfold modCode_noNop divK_phaseA_code; simp only [CodeReq.unionAll_cons]
+  exact CodeReq.union_mono_left
+
+private theorem divK_zeroPath_code_sub_modCode_noNop {base : Word} :
+    ∀ a i, (divK_zeroPath_code (base + zeroPathOff)) a = some i → (modCode_noNop base) a = some i := by
+  unfold modCode_noNop divK_zeroPath_code; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
+  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
+  exact CodeReq.union_mono_left
+
+private theorem beq_singleton_sub_modCode_noNop {base : Word} :
+    ∀ a i, (CodeReq.singleton (base + phaseABeqOff) (.BEQ .x5 .x0 1020)) a = some i →
+      (modCode_noNop base) a = some i := by
+  unfold modCode_noNop; simp only [CodeReq.unionAll_cons]
+  intro a i h
+  exact CodeReq.union_mono_left a i
+    (CodeReq.singleton_mono (CodeReq.ofProg_lookup base (divK_phaseA 1020) 7
+      (by decide) (by decide)) a i h)
+
+/-- MOD zero-divisor path over `modCode_noNop`. Mirror of
+    `evm_mod_bzero_spec_within` with `modCode_noNop` instead of `modCode`.
+    Used by `evm_mod_callable_bzero_preserving_x1_spec` in Callable.lean. -/
+theorem evm_mod_bzero_spec_within_noNop (sp base : Word)
+    (b0 b1 b2 b3 v5 v10 : Word)
+    (hbz : b0 ||| b1 ||| b2 ||| b3 = 0) :
+    cpsTripleWithin 13 base (base + nopOff) (modCode_noNop base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3))
+      ((.x12 ↦ᵣ (sp + 32)) ** (.x5 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
+       ((sp + 32) ↦ₘ (0 : Word)) ** ((sp + 40) ↦ₘ (0 : Word)) **
+       ((sp + 48) ↦ₘ (0 : Word)) ** ((sp + 56) ↦ₘ (0 : Word))) := by
+  have hbody := cpsTripleWithin_extend_code divK_phaseA_code_sub_modCode_noNop
+    (divK_phaseA_body_spec_within sp base b0 b1 b2 b3 v5 v10)
+  have hbeq_raw := beq_spec_gen_within .x5 .x0 1020 (b0 ||| b1 ||| b2 ||| b3) (0 : Word) (base + phaseABeqOff)
+  rw [show (base + phaseABeqOff : Word) + signExtend13 1020 = base + zeroPathOff from by rv64_addr,
+      show (base + phaseABeqOff : Word) + 4 = base + phaseBOff from by bv_addr] at hbeq_raw
+  have hbeq_clean := cpsBranchWithin_takenStripPure2 hbeq_raw
+    (fun hp hQf => by
+      obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
+      exact absurd hbz ((sepConj_pure_right _).mp h_rest).2)
+  have hbeq := cpsTripleWithin_extend_code beq_singleton_sub_modCode_noNop hbeq_clean
+  have hbeq_framed := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ b3) **
+     ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+     ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3))
+    (by pcFree) hbeq
+  have hAB := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hbody hbeq_framed
+  have hzp := cpsTripleWithin_extend_code divK_zeroPath_code_sub_modCode_noNop
+    (divK_zeroPath_spec_within sp (base + zeroPathOff) b0 b1 b2 b3)
+  rw [show (base + zeroPathOff : Word) + 20 = base + nopOff from by bv_addr] at hzp
+  have hzp_framed := cpsTripleWithin_frameR
+    ((.x5 ↦ᵣ (b0 ||| b1 ||| b2 ||| b3)) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)))
+    (by pcFree) hzp
+  have hABZ := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hAB hzp_framed
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by rw [hbz] at hq; xperm_hyp hq)
+    hABZ
+
+-- ============================================================================
 -- Section 14: MOD epilogue composition (load u[0..3], store to output)
 -- Mirrors DIV epilogue but reads from u[] offsets (4056/4048/4040/4032).
 -- ============================================================================

--- a/EvmAsm/Evm64/DivMod/Spec/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/Base.lean
@@ -601,6 +601,55 @@ theorem evm_mod_bzero_stack_spec_within (sp base : Word)
         from by xperm) h).mp w1)
     h_raw
 
+/-- Stack-level MOD bzero spec over `modCode_noNop`. Mirror of
+    `evm_mod_bzero_stack_spec_within` with `modCode_noNop` instead of `modCode`.
+    Used by `evm_mod_bzero_stack_spec_within_dispatch_noNop_preserving_x1_uni`
+    in `DivMod/Spec/Unified.lean`. -/
+theorem evm_mod_bzero_stack_spec_within_noNop (sp base : Word)
+    (a b : EvmWord) (v5 v10 : Word)
+    (hbz : b = 0) :
+    cpsTripleWithin 13 base (base + nopOff) (modCode_noNop base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       evmWordIs (sp + 32) b)
+      ((.x12 ↦ᵣ (sp + 32)) ** (regOwn .x5) ** (regOwn .x10) ** (.x0 ↦ᵣ (0 : Word)) **
+       evmWordIs (sp + 32) (EvmWord.mod a b)) := by
+  subst hbz
+  have hg0 := EvmWord.getLimbN_zero 0
+  have hg1 := EvmWord.getLimbN_zero 1
+  have hg2 := EvmWord.getLimbN_zero 2
+  have hg3 := EvmWord.getLimbN_zero 3
+  have hlimbs_or : (0 : EvmWord).getLimbN 0 ||| (0 : EvmWord).getLimbN 1 |||
+      (0 : EvmWord).getLimbN 2 ||| (0 : EvmWord).getLimbN 3 = (0 : Word) := by decide
+  have h_raw := evm_mod_bzero_spec_within_noNop sp base
+    ((0 : EvmWord).getLimbN 0) ((0 : EvmWord).getLimbN 1)
+    ((0 : EvmWord).getLimbN 2) ((0 : EvmWord).getLimbN 3)
+    v5 v10 hlimbs_or
+  simp only [hg0, hg1, hg2, hg3] at h_raw
+  have hr0 := EvmWord.mod_getLimbN_zero_right a 0
+  have hr1 := EvmWord.mod_getLimbN_zero_right a 1
+  have hr2 := EvmWord.mod_getLimbN_zero_right a 2
+  have hr3 := EvmWord.mod_getLimbN_zero_right a 3
+  exact cpsTripleWithin_weaken
+    (fun h hp => by
+      rw [evmWordIs_sp32_limbs_eq sp 0 0 0 0 0 hg0 hg1 hg2 hg3] at hp
+      xperm_hyp hp)
+    (fun h hq => by
+      rw [evmWordIs_sp32_limbs_eq sp _ 0 0 0 0 hr0 hr1 hr2 hr3]
+      have w0 := sepConj_mono_left (regIs_implies_regOwn .x5) h
+        ((congrFun (show _ =
+          ((.x5 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ (0 : Word)) **
+           (.x12 ↦ᵣ (sp + 32)) ** (.x0 ↦ᵣ (0 : Word)) **
+           ((sp + 32) ↦ₘ (0 : Word)) ** ((sp + 40) ↦ₘ (0 : Word)) **
+           ((sp + 48) ↦ₘ (0 : Word)) ** ((sp + 56) ↦ₘ (0 : Word)))
+          from by xperm) h).mp hq)
+      have w1 := sepConj_mono_right (sepConj_mono_left (regIs_implies_regOwn .x10)) h w0
+      exact (congrFun (show _ =
+        ((.x12 ↦ᵣ (sp + 32)) ** (regOwn .x5) ** (regOwn .x10) ** (.x0 ↦ᵣ (0 : Word)) **
+         ((sp + 32) ↦ₘ (0 : Word)) ** ((sp + 40) ↦ₘ (0 : Word)) **
+         ((sp + 48) ↦ₘ (0 : Word)) ** ((sp + 56) ↦ₘ (0 : Word)))
+        from by xperm) h).mp w1)
+    h_raw
+
 -- ============================================================================
 -- Sublemmas towards evm_div_n4_max_skip_stack_spec (reshape plan)
 -- ============================================================================

--- a/EvmAsm/Evm64/DivMod/Spec/Dispatcher.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/Dispatcher.lean
@@ -185,6 +185,33 @@ theorem modStackDispatchPost_unfold {sp : Word} {a b : EvmWord} :
   delta modStackDispatchPost
   rfl
 
+/-- Final MOD stack-dispatch postcondition with `x1` omitted from the generic
+    owned-register frame. Callable wrappers use this shape when they need to
+    preserve the exact return address for the following `cc_ret`. -/
+@[irreducible]
+def modStackDispatchPostNoX1 (sp : Word) (a b : EvmWord) : Assertion :=
+  (.x12 ↦ᵣ (sp + 32)) ** regOwn .x2 **
+  regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+  regOwn .x10 ** regOwn .x11 ** (.x0 ↦ᵣ (0 : Word)) **
+  evmWordIs sp a ** evmWordIs (sp + 32) (EvmWord.mod a b) **
+  divScratchOwnCall sp
+
+theorem modStackDispatchPostNoX1_unfold {sp : Word} {a b : EvmWord} :
+    modStackDispatchPostNoX1 sp a b =
+    ((.x12 ↦ᵣ (sp + 32)) ** regOwn .x2 **
+     regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+     regOwn .x10 ** regOwn .x11 ** (.x0 ↦ᵣ (0 : Word)) **
+     evmWordIs sp a ** evmWordIs (sp + 32) (EvmWord.mod a b) **
+     divScratchOwnCall sp) := by
+  delta modStackDispatchPostNoX1
+  rfl
+
+theorem modStackDispatchPostNoX1_pcFree (sp : Word) (a b : EvmWord) :
+    (modStackDispatchPostNoX1 sp a b).pcFree := by
+  rw [modStackDispatchPostNoX1_unfold]
+  rw [divScratchOwnCall_unfold, divScratchOwn_unfold]
+  pcFree
+
 theorem modStackDispatchPost_weaken
     (sp : Word) (a b : EvmWord)
     {v1 v2 v5 v6 v7 v10 v11 : Word}
@@ -1256,5 +1283,40 @@ theorem evm_div_n3_stack_spec_within_noNop
         a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0
         ha0 ha1 ha2 ha3 hdiv0 hdiv1 hdiv2 hdiv3 h hq)
     hFull
+
+/-- Weaken the framed bzero-MOD postcondition to `modStackDispatchPostNoX1`.
+    Mirrors `modStackDispatchPost_weaken_bzero_frame` but uses the NoX1 variant,
+    keeping `.x1 ↦ᵣ v1` as an explicit post atom instead of absorbing it into
+    `regOwn .x1`. -/
+theorem modStackDispatchPostNoX1_weaken_bzero_frame
+    (sp : Word) (a b : EvmWord)
+    {v2 v6 v7 v11 : Word}
+    {q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratch_un0 : Word} :
+    ∀ h,
+      ((.x12 ↦ᵣ (sp + 32)) **
+       (.x2 ↦ᵣ v2) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x11 ↦ᵣ v11) **
+       regOwn .x5 ** regOwn .x10 **
+       (.x0 ↦ᵣ (0 : Word)) **
+       evmWordIs sp a ** evmWordIs (sp + 32) (EvmWord.mod a b) **
+       divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratch_un0) h →
+      modStackDispatchPostNoX1 sp a b h := by
+  intro h hp
+  rw [modStackDispatchPostNoX1_unfold]
+  apply sepConj_mono_right
+  apply sepConj_mono (regIs_implies_regOwn .x2 (v := v2))
+  apply sepConj_mono_right
+  apply sepConj_mono (regIs_implies_regOwn .x6 (v := v6))
+  apply sepConj_mono (regIs_implies_regOwn .x7 (v := v7))
+  apply sepConj_mono_right
+  apply sepConj_mono (regIs_implies_regOwn .x11 (v := v11))
+  apply sepConj_mono_right
+  apply sepConj_mono_right
+  apply sepConj_mono_right
+  exact divScratchValuesCall_implies_divScratchOwnCall
+    sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem
+      retMem dMem dloMem scratch_un0
+  xperm_hyp hp
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Adds `evm_mod_bzero_spec_within_noNop` in `Compose/Epilogue.lean` — MOD bzero spec over `modCode_noNop` (mirrors the existing `evm_div_bzero_spec_within_noNop`)
- Adds `evm_mod_bzero_stack_spec_within_noNop` in `Spec/Base.lean` — stack-level wrapper (mirrors `evm_div_bzero_stack_spec_within_noNop`)
- Adds `modStackDispatchPostNoX1` (+ unfold + pcFree + `weaken_bzero_frame`) in `Spec/Dispatcher.lean` — NoX1 postcondition for the MOD callable, mirroring `divStackDispatchPostNoX1`
- Adds `evm_mod_callable_spec_from_noNop_preserving_x1` in `Callable.lean` — MOD callable composition with x1 preserved, mirroring the DIV analog

These form the infrastructure for the ADDMOD/MULMOD N=0 callable handoff. The bzero path (N=0 case) in the MOD callable does not corrupt x1 (zeroPath stores zeros to output without touching x1), so the callable can correctly return to the ADDMOD caller's return address in the N=0 case.

Bead: evm-asm-vipod.

## Verification
- `lake build EvmAsm.Evm64.DivMod.Callable` ✓
- `scripts/check-file-size.sh` ✓ (626 files, all within cap)
- `rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth' <files>` → 0 matches
- `lake build` ✓

Authored by @pirapira; implemented by Claude Code