### PR TITLE
feat(divmod): add evm_mod_callable_bzero_preserving_x1_spec

### DIFF
--- a/EvmAsm/Evm64/DivMod/Callable.lean
+++ b/EvmAsm/Evm64/DivMod/Callable.lean
@@ -32,6 +32,7 @@
 import EvmAsm.Evm64.DivMod.Program
 import EvmAsm.Evm64.DivMod.Compose.Base
 import EvmAsm.Evm64.DivMod.Spec.Unified
+import EvmAsm.Evm64.DivMod.Spec.ModBzeroNoNop
 import EvmAsm.Evm64.CallingConvention
 
 namespace EvmAsm.Evm64
@@ -823,5 +824,31 @@ theorem evm_mod_callable_spec_from_noNop (sp base raVal : Word)
   have hRetFramed :=
     cpsTripleWithin_frameL (modStackDispatchPost sp a b) hpcFreePost hRet
   exact cpsTripleWithin_seq_same_cr hStackFramed hRetFramed
+
+/-- Zero-divisor MOD callable wrapper that preserves the exact incoming `x1`
+    return address. Mirror of `evm_div_callable_bzero_preserving_x1_spec`
+    for the MOD callable. Used for ADDMOD/MULMOD N=0 callable handoff. -/
+theorem evm_mod_callable_bzero_preserving_x1_spec (sp base raVal : Word)
+    (a b : EvmWord) (v2 v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (hbz : b = 0) :
+    cpsTripleWithin (unifiedDivBound + 1) base (raVal &&& ~~~1)
+      (evm_mod_callable_code base)
+      (divModStackDispatchPre sp a b
+        raVal v2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+      (modStackDispatchPostNoX1 sp a b ** (.x1 ↦ᵣ raVal)) := by
+  have hStack :=
+    evm_mod_bzero_stack_spec_within_dispatch_noNop_preserving_x1_uni
+      sp base a b raVal v2 v5 v6 v7 v10 v11
+      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      nMem shiftMem jMem retMem dMem dloMem scratchUn0 hbz
+  exact evm_mod_callable_spec_from_noNop_preserving_x1
+    sp base raVal a b v5 v6 v7 v10 v11
+    q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0
+    (ModStackSpecCase.bzero raVal v2 hbz) hStack
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/Dispatcher.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/Dispatcher.lean
@@ -1319,4 +1319,63 @@ theorem modStackDispatchPostNoX1_weaken_bzero_frame
       retMem dMem dloMem scratch_un0
   xperm_hyp hp
 
+/-- Post-bundle for the MOD zero-divisor bzero path that preserves the
+    exact incoming `x1` return address. Mirrors `divBzeroDispatchPostPreservingX1Frame`
+    for the MOD callable. The bundle is the direct framing of
+    `evm_mod_bzero_stack_spec_within_noNop`'s output with the extra register
+    and scratch frame atoms, making the POST-weaken step in
+    `ModBzeroNoNop.lean` trivial. -/
+def modBzeroDispatchPostPreservingX1Frame (sp : Word) (a b : EvmWord)
+    (v1 v2 v6 v7 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratch_un0 : Word) : Assertion :=
+  ((.x12 ↦ᵣ (sp + 32)) ** regOwn .x5 ** regOwn .x10 **
+    (.x0 ↦ᵣ (0 : Word)) ** evmWordIs (sp + 32) (EvmWord.mod a b)) **
+  ((.x1 ↦ᵣ v1) ** (.x2 ↦ᵣ v2) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+    (.x11 ↦ᵣ v11) ** evmWordIs sp a **
+    divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratch_un0)
+
+theorem modBzeroDispatchPostPreservingX1Frame_unfold
+    {sp : Word} {a b : EvmWord} {v1 v2 v6 v7 v11 : Word}
+    {q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratch_un0 : Word} :
+    modBzeroDispatchPostPreservingX1Frame sp a b v1 v2 v6 v7 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0 =
+      (((.x12 ↦ᵣ (sp + 32)) ** regOwn .x5 ** regOwn .x10 **
+        (.x0 ↦ᵣ (0 : Word)) ** evmWordIs (sp + 32) (EvmWord.mod a b)) **
+       ((.x1 ↦ᵣ v1) ** (.x2 ↦ᵣ v2) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+        (.x11 ↦ᵣ v11) ** evmWordIs sp a **
+        divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratch_un0)) := by
+  delta modBzeroDispatchPostPreservingX1Frame
+  rfl
+
+/-- Weaken `modBzeroDispatchPostPreservingX1Frame` to
+    `modStackDispatchPostNoX1 ** (.x1 ↦ᵣ v1)`. This is the MOD-side analog of
+    `divBzeroDispatchPostPreservingX1Frame_weaken_noX1`. -/
+theorem modBzeroDispatchPostPreservingX1Frame_weaken_noX1
+    (sp : Word) (a b : EvmWord)
+    {v1 v2 v6 v7 v11 : Word}
+    {q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratch_un0 : Word} :
+    ∀ h,
+    modBzeroDispatchPostPreservingX1Frame sp a b v1 v2 v6 v7 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0 h →
+    (modStackDispatchPostNoX1 sp a b ** (.x1 ↦ᵣ v1)) h := by
+  intro h hp
+  rw [modBzeroDispatchPostPreservingX1Frame_unfold] at hp
+  simp only [sepConj_assoc', sepConj_comm', sepConj_left_comm'] at hp ⊢
+  exact sepConj_mono_left
+    (modStackDispatchPostNoX1_weaken_bzero_frame
+      (v2 := v2) (v6 := v6) (v7 := v7) (v11 := v11)
+      (q0 := q0) (q1 := q1) (q2 := q2) (q3 := q3)
+      (u0 := u0) (u1 := u1) (u2 := u2) (u3 := u3) (u4 := u4)
+      (u5 := u5) (u6 := u6) (u7 := u7) (shiftMem := shiftMem)
+      (nMem := nMem) (jMem := jMem) (retMem := retMem) (dMem := dMem)
+      (dloMem := dloMem) (scratch_un0 := scratch_un0) sp a b)
+    h (by xperm_hyp hp)
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/ModBzeroNoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/ModBzeroNoNop.lean
@@ -1,0 +1,58 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.ModBzeroNoNop
+
+  Dispatch-level zero-divisor MOD spec over `modCode_noNop`, mirroring
+  the div-side `evm_div_bzero_stack_spec_within_dispatch_noNop_preserving_x1_uni`
+  in `Spec/Unified.lean`. Placed in a separate file because `Spec/Unified.lean`
+  is at the file-size cap.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.Base
+import EvmAsm.Evm64.DivMod.Spec.Dispatcher
+import EvmAsm.Evm64.DivMod.Spec.Unified
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Zero-divisor MOD dispatcher over `modCode_noNop`, preserving the exact
+    incoming `x1` value. Mirror of
+    `evm_div_bzero_stack_spec_within_dispatch_noNop_preserving_x1_uni`
+    for the MOD callable. -/
+theorem evm_mod_bzero_stack_spec_within_dispatch_noNop_preserving_x1_uni
+    (sp base : Word)
+    (a b : EvmWord) (v1 v2 v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratch_un0 : Word)
+    (hbz : b = 0) :
+    cpsTripleWithin unifiedDivBound base (base + nopOff) (modCode_noNop base)
+      (divModStackDispatchPre sp a b
+        v1 v2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0)
+      (modStackDispatchPostNoX1 sp a b ** (.x1 ↦ᵣ v1)) := by
+  let frame : Assertion :=
+    (.x1 ↦ᵣ v1) ** (.x2 ↦ᵣ v2) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+    (.x11 ↦ᵣ v11) ** evmWordIs sp a **
+    divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratch_un0
+  have hBzero := evm_mod_bzero_stack_spec_within_noNop sp base a b v5 v10 hbz
+  have hFramed :=
+    cpsTripleWithin_frameR frame (by dsimp [frame]; rw [divScratchValuesCall_unfold]; pcFree) hBzero
+  exact cpsTripleWithin_mono_nSteps (by decide) <|
+    cpsTripleWithin_weaken
+      (fun _ hp => by
+        rw [divModStackDispatchPre_unfold] at hp
+        dsimp [frame]
+        simp only [sepConj_comm', sepConj_left_comm'] at hp ⊢
+        exact hp)
+      (fun h hq => by
+        -- Use the modBzeroDispatchPostPreservingX1Frame bundle approach:
+        -- The POST is exactly the framed form, so weaken is trivial.
+        exact modBzeroDispatchPostPreservingX1Frame_weaken_noX1 sp a b h
+          (by rw [modBzeroDispatchPostPreservingX1Frame_unfold]; xperm_hyp hq))
+      hFramed
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Adds `modBzeroDispatchPostPreservingX1Frame` bundle + `_unfold` + `_weaken_noX1` to `Spec/Dispatcher.lean` (mirrors `divBzeroDispatchPostPreservingX1Frame`)
- Adds `EvmAsm/Evm64/DivMod/Spec/ModBzeroNoNop.lean` (new file): `evm_mod_bzero_stack_spec_within_dispatch_noNop_preserving_x1_uni`
- Adds `evm_mod_callable_bzero_preserving_x1_spec` to `Callable.lean` — the final zero-divisor MOD callable wrapper that preserves the exact return address

Stacked on PR #4615 (`feat/mod-callable-bzero-preserving-x1`). Completes bead evm-asm-vipod.

Bead: evm-asm-vipod.

## Verification
- `lake build EvmAsm.Evm64.DivMod.Callable` ✓
- `scripts/check-file-size.sh` ✓ (627 files, all within cap)
- `rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth' <files>` → 0 matches
- `lake build` ✓

Authored by @pirapira; implemented by Claude Code