### PR TITLE
docs(addmod): document N=0 case architecture and infrastructure in AddMod/Spec.lean

### DIFF
--- a/EvmAsm/Evm64/AddMod/Spec.lean
+++ b/EvmAsm/Evm64/AddMod/Spec.lean
@@ -5,12 +5,23 @@
   bridging the limb-level composition to a single `evmWordIs` pre/post
   pair.
 
-  Skeleton placeholder for GH #91 (beads slice evm-asm-w1s0). The
-  actual `evm_addmod_stack_spec_within` theorem lands in slice
+  The general `evm_addmod_stack_spec_within` theorem lands in slice
   evm-asm-sord and is composed from the verified shared bridge with
   the boundary blocks. The addmod-correctness lemma
   `EvmWord.addmod_correct` is added in an earlier slice (see
   parent task evm-asm-z7qm).
+
+  Architecture notes for N=0 case (bead evm-asm-a32mz):
+  - When N=0, the mod callable follows the zeroPath: stores zeros at
+    x12+32..x12+56 WITHOUT advancing x12.
+  - cc_ret preserves x1=(base+128) through the zeroPath.
+  - After cc_ret, the epilogue at base+128 advances x12 by 32.
+  - Net: x12 goes sp → sp+32 (prologue) → sp+32 (zeroPath) → sp+64 (epilogue).
+  - Result (zero) sits at sp+64 = final x12. Correct for ADDMOD pop-3-push-1.
+  - Infrastructure available: evm_mod_callable_bzero_preserving_x1_spec
+    (from DivMod/Callable.lean, PR #4616) enables the proof.
+  - Next step: write the dispatch-bridge connecting evmAddModPhase1Phase2LimbPost
+    to divModStackDispatchPre for the N=0 case.
 -/
 
 import EvmAsm.Evm64.AddMod.Compose.Base
@@ -22,5 +33,6 @@ open EvmAsm.Rv64
 open EvmAsm.Evm64.AddMod.Compose
 
 -- Placeholder: `evm_addmod_stack_spec_within` lands in slice evm-asm-sord.
+-- The N=0 partial case is tracked in bead evm-asm-a32mz.
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Updates `AddMod/Spec.lean` header to document the key architectural insight for the ADDMOD N=0 (zero modulus) case
- Records that `evm_mod_callable_bzero_preserving_x1_spec` (from PR #4616) is the enabling infrastructure
- Documents the x12 advance analysis: prologue (+32) → zeroPath (unchanged) → epilogue (+32) = net +64 (correct for pop-3-push-1)
- Points to the next step: a dispatch-bridge lemma connecting `evmAddModPhase1Phase2LimbPost` to `divModStackDispatchPre` for N=0

This is a documentation-only commit preparing for the N=0 partial proof (bead evm-asm-a32mz).

Bead: evm-asm-a32mz.

## Verification
- `lake build EvmAsm.Evm64.AddMod.Spec` ✓
- `scripts/check-file-size.sh` ✓
- `rg -n 'sorry|admit|...'` → 0 matches

Authored by @pirapira; implemented by Claude Code