### PR TITLE
docs(zkvm-io): update docs for read_input migration completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ EvmAsm/
     ControlFlow.lean          --   if_eq macro, symbolic proofs, pcIndep
     GenericSpecs.lean         --   Generic specs parameterized over instructions
     InstructionSpecs.lean     --   Per-instruction CPS specs
-    SyscallSpecs.lean         --   Syscall specs: HALT, WRITE, HINT_READ
+    SyscallSpecs.lean         --   Syscall specs: HALT, WRITE, read_input
     Tactics/
       PerfTrace.lean          --   Performance tracing infrastructure
       XPerm.lean              --   xperm tactic: AC-permutation of sepConj chains

--- a/docs/zkvm-accelerators-interface.md
+++ b/docs/zkvm-accelerators-interface.md
@@ -95,6 +95,28 @@ that register layout, issues an `ECALL`, and reads back the
 `zkvm_status` from `a0`. Concrete bridges live (or will live) under
 `EvmAsm/EL/` next to the existing keccak bridges.
 
+## Sibling: host-I/O C ABI
+
+zkvm-standards also defines a *host I/O* surface — the channel by which
+the guest receives its private input and emits its public output — in a
+separate interface file:
+
+  `EvmAsm/Evm64/zkvm-standards/standards/io-interface/README.md`
+
+That surface (`read_input` / `write_output`) is shape-only, just like
+`zkvm_accelerators.h`: it specifies argument layout and semantics but
+leaves concrete syscall IDs to each host zkVM's dispatch layer.  The
+decision record for adopting this interface is in
+[`docs/zkvm-host-io-interface.md`](zkvm-host-io-interface.md).
+
+The two zkvm-standards interfaces are fully independent:
+- `zkvm_accelerators.h` — cryptographic precompiles and KECCAK256.
+- `io-interface/README.md` (`read_input`/`write_output`) — guest I/O.
+
+Both follow the same philosophy: function set + argument layout come
+from zkvm-standards; ECALL framing follows the RISC-V convention SP1
+also uses; concrete syscall IDs are handler-side.
+
 ## Maintenance
 
 Update this ADR when:

--- a/docs/zkvm-host-io-interface.md
+++ b/docs/zkvm-host-io-interface.md
@@ -56,11 +56,15 @@ The two surfaces are not interchangeable:
   concatenated to form the public output. It does not framepack
   word-pair commits the way SP1's `COMMIT` does.
 
-The verified RISC-V code today still implements the SP1-shaped surface;
-the Lean specs in `EvmAsm/Rv64/HintSpecs.lean`,
-`EvmAsm/Rv64/RLP/Phase4HintLen.lean`, and `EvmAsm/Rv64/RLP/Phase4HintRead.lean`
-encode the streaming hint contract. Migration to the zkvm-standards C
-ABI is tracked under parent bead `evm-asm-96ysd`.
+The SP1-shaped streaming surface (`HINT_LEN`/`HINT_READ`/`COMMIT`) has
+been retired from the Lean code (PR #4618, bead `evm-asm-x2vuw`):
+`EvmAsm/Rv64/HintSpecs.lean` now exposes only the `read_input` spec
+(t0=0xF2, ptr+len-out semantics); `Phase4HintRead.lean` is deleted;
+`Phase4HintLen.lean` retains only the deprecation note. The current
+`EvmAsm/Rv64/Execution.lean` dispatches `read_input` (0xF2) and
+`write_output` (0xF2-family). Any remaining references to the old
+handlers in non-Lean files (docs, PLAN.md comments) are historical notes
+about the migration and do not affect the verified surface.
 
 ## Mapping: current SP1 ECALL handlers ↔ zkvm-standards C ABI
 
@@ -94,12 +98,12 @@ shape changes are:
    reuse `privateInput` plus a new immutable `inputBufBase : Word`
    field carrying the guest-visible base address. Refinement to a
    dedicated read-only memory region is deferred.
-2. **ECALL handlers.** Replace the `HINT_LEN`/`HINT_READ` cases of
-   `step` with a single `read_input` handler (ptr+len-out semantics).
-   Reshape `COMMIT` (and/or `WRITE fd=13`) into a `write_output`
-   handler. The `0x10` branch now has the `write_output(ptr, size)`
-   shape; `WRITE fd=13` remains as a compatibility spelling. Keep SP1 syscall IDs as the dispatch numbers for now;
-   document that the IDs are handler-side, not ABI.
+2. **ECALL handlers.** ✅ **Done (PR #4618).** `HINT_LEN`/`HINT_READ`
+   cases removed from `step`; a `read_input` handler (t0=0xF2,
+   ptr+len-out semantics) is now the sole input entry point. `COMMIT`
+   and `WRITE fd=13` retain their shapes as `write_output`-compatible
+   concatenating outputs. SP1 syscall IDs remain the dispatch numbers;
+   documented as handler-side in §Mapping above.
 3. **RLP wrappers.** Rewrite `Phase4HintLen.lean` and `Phase4HintRead.lean`
    to consume the `read_input` ptr+len once and index into the buffer,
    then re-prove the affected Hoare triples.


### PR DESCRIPTION
## Summary
- `README.md`: fix `SyscallSpecs.lean` comment from `HINT_READ` → `read_input` to reflect the retired SP1 streaming contract (PR #4618 already landed)
- `docs/zkvm-accelerators-interface.md`: add **Sibling: host-I/O C ABI** section explaining that `read_input`/`write_output` is also zkvm-standards-defined, distinct from the accelerator C ABI; both surfaces are shape-only specs leaving syscall IDs to the host
- `docs/zkvm-host-io-interface.md`: update migration context (HINT_LEN/HINT_READ retired, not "still implements SP1 surface"), mark ECALL-handler migration step as ✅ done with PR #4618 reference

Refs GH #114, #116. Bead: evm-asm-96ysd.

## Verification
- `scripts/check-file-size.sh`
- `rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" README.md docs/zkvm-accelerators-interface.md docs/zkvm-host-io-interface.md`
- `lake build`

Authored by @pirapira; implemented by Claude Code