### PR TITLE
feat(exp): add expTwoMulLoopEntryPostFixed + boundary prologue spec

### DIFF
--- a/EvmAsm/Evm64/Exp.lean
+++ b/EvmAsm/Evm64/Exp.lean
@@ -59,6 +59,7 @@ import EvmAsm.Evm64.Exp.Compose.SavedBitFullLoopCanonical
 import EvmAsm.Evm64.Exp.Compose.SavedBitCondMulCall
 import EvmAsm.Evm64.Exp.Compose.SavedBitLoopBounds
 import EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryPrologue
+import EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryPrologueFixed
 import EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryEpilogueBase
 import EvmAsm.Evm64.Exp.Compose.SavedBitBoundarySeq
 import EvmAsm.Evm64.Exp.Compose.SavedBitLoopEntry

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryPrologueFixed.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryPrologueFixed.lean
@@ -1,0 +1,224 @@
+/-
+  EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryPrologueFixed
+
+  Boundary-block prologue and pointer-advance helpers for the FIXED
+  two-MUL saved-bit EXP code bundle (`evm_exp_msb_saved_bit_two_mul_fixed`).
+
+  The fixed algorithm uses x19 as the callee-saved exponent cursor
+  (initialized to `exponentWord.getLimbN 3`), x16 as the limb pointer,
+  and x6 as the per-limb countdown counter, rather than leaving x5 = 1
+  and ignoring the exponent entirely.
+
+  GH #92, bead evm-asm-w5mk.
+-/
+
+import EvmAsm.Evm64.Exp.LimbSpec
+import EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryPrologue
+
+namespace EvmAsm.Evm64.Exp.Compose
+
+open EvmAsm.Rv64.Tactics
+open EvmAsm.Rv64
+
+-- ============================================================================
+-- Fixed loop entry state definition
+-- ============================================================================
+
+/-- The correct loop entry state for the fixed EXP algorithm, after
+    `exp_prologue_fixed ;; exp_loop_pointer_advance` executes.
+
+    Differences from `expTwoMulLoopEntryPost`:
+    - x6 = 64 (per-limb counter, counting down from 64 bits per limb)
+    - x16 = evmSp + 48 (limb pointer pre-advanced to second limb)
+    - x19 = exponentWord.getLimbN 3 (exponent cursor, MSB limb loaded)
+-/
+@[irreducible]
+def expTwoMulLoopEntryPostFixed
+    (sp evmSp vOld v18 : Word) (baseWord exponentWord : EvmWord)
+    (rest : List EvmWord) : Assertion :=
+  (((((.x2 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x9 ↦ᵣ (256 : Word)) ** (.x5 ↦ᵣ (1 : Word)) **
+      (.x6 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
+      (.x16 ↦ᵣ (evmSp + signExtend12 (56 : BitVec 12) + signExtend12 (-8 : BitVec 12))) **
+      (.x19 ↦ᵣ exponentWord.getLimbN 3) **
+      evmWordIs sp (1 : EvmWord)) **
+     (.x12 ↦ᵣ (evmSp + signExtend12 (64 : BitVec 12)))) **
+   evmStackIs evmSp (baseWord :: exponentWord :: rest)) **
+   expTwoMulScratchFrame vOld v18)
+
+theorem expTwoMulLoopEntryPostFixed_unfold
+    {sp evmSp vOld v18 : Word} {baseWord exponentWord : EvmWord}
+    {rest : List EvmWord} :
+    expTwoMulLoopEntryPostFixed sp evmSp vOld v18 baseWord exponentWord rest =
+      (((((.x2 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) **
+          (.x9 ↦ᵣ (256 : Word)) ** (.x5 ↦ᵣ (1 : Word)) **
+          (.x6 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
+          (.x16 ↦ᵣ (evmSp + signExtend12 (56 : BitVec 12) + signExtend12 (-8 : BitVec 12))) **
+          (.x19 ↦ᵣ exponentWord.getLimbN 3) **
+          evmWordIs sp (1 : EvmWord)) **
+         (.x12 ↦ᵣ (evmSp + signExtend12 (64 : BitVec 12)))) **
+        evmStackIs evmSp (baseWord :: exponentWord :: rest)) **
+       expTwoMulScratchFrame vOld v18) := by
+  delta expTwoMulLoopEntryPostFixed; rfl
+
+theorem expTwoMulLoopEntryPostFixed_pcFree
+    {sp evmSp vOld v18 : Word} {baseWord exponentWord : EvmWord}
+    {rest : List EvmWord} :
+    (expTwoMulLoopEntryPostFixed sp evmSp vOld v18 baseWord exponentWord rest).pcFree := by
+  rw [expTwoMulLoopEntryPostFixed_unfold]
+  pcFree
+
+instance pcFreeInst_expTwoMulLoopEntryPostFixed
+    (sp evmSp vOld v18 : Word) (baseWord exponentWord : EvmWord)
+    (rest : List EvmWord) :
+    Assertion.PCFree (expTwoMulLoopEntryPostFixed sp evmSp vOld v18 baseWord exponentWord rest) :=
+  ⟨expTwoMulLoopEntryPostFixed_pcFree⟩
+
+-- ============================================================================
+-- Code abbreviation for the fixed EXP program
+-- ============================================================================
+
+abbrev expMsbSavedBitTwoMulFixedCode (base : Word)
+    (squaringMulOff condMulOff : BitVec 21)
+    (skipOff backOff : BitVec 13) : CodeReq :=
+  CodeReq.ofProg base (EvmAsm.Evm64.evm_exp_msb_saved_bit_two_mul_fixed
+    squaringMulOff condMulOff skipOff backOff)
+
+-- ============================================================================
+-- Prologue + pointer-advance spec for the fixed code
+-- ============================================================================
+
+/-- The fixed prologue (10 instructions) lifted to the full fixed code,
+    against a PRE that includes the exponent's MSB limb at evmSp+56. -/
+private theorem exp_prologue_fixed_in_fixed_code_spec_within
+    (sp evmSp cOld tOld c6Old c16Old c19Old m0 m1 m2 m3 expLimb3 : Word)
+    (squaringMulOff condMulOff : BitVec 21) (skipOff backOff : BitVec 13)
+    (base : Word) :
+    cpsTripleWithin 10 base (base + 40)
+      (expMsbSavedBitTwoMulFixedCode base squaringMulOff condMulOff skipOff backOff)
+      ((.x2 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) ** (.x9 ↦ᵣ cOld) **
+       (.x5 ↦ᵣ tOld) ** (.x12 ↦ᵣ evmSp) **
+       (.x6 ↦ᵣ c6Old) ** (.x16 ↦ᵣ c16Old) ** (.x19 ↦ᵣ c19Old) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ m0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ m1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ m2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ m3) **
+       ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ expLimb3))
+      ((.x2 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x9 ↦ᵣ ((0 : Word) + signExtend12 (256 : BitVec 12))) **
+       (.x5 ↦ᵣ ((0 : Word) + signExtend12 (1 : BitVec 12))) **
+       (.x12 ↦ᵣ evmSp) **
+       (.x6 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
+       (.x16 ↦ᵣ evmSp + signExtend12 (56 : BitVec 12) + signExtend12 (-8 : BitVec 12)) **
+       (.x19 ↦ᵣ expLimb3) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ
+        ((0 : Word) + signExtend12 (1 : BitVec 12))) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ (0 : Word)) **
+       ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ expLimb3)) :=
+  cpsTripleWithin_extend_code
+    (h := EvmAsm.Evm64.exp_prologue_fixed_spec_within
+      sp evmSp cOld tOld c6Old c16Old c19Old m0 m1 m2 m3 expLimb3 base)
+    (hmono := CodeReq.ofProg_mono_sub base base
+      (EvmAsm.Evm64.evm_exp_msb_saved_bit_two_mul_fixed
+        squaringMulOff condMulOff skipOff backOff)
+      EvmAsm.Evm64.exp_prologue_fixed 0
+      (by bv_omega)
+      (by unfold EvmAsm.Evm64.evm_exp_msb_saved_bit_two_mul_fixed EvmAsm.Rv64.seq
+              EvmAsm.Evm64.exp_prologue_fixed EvmAsm.Rv64.ADDI
+              EvmAsm.Rv64.SD EvmAsm.Rv64.LD
+              EvmAsm.Rv64.single
+          rfl)
+      (by simp [EvmAsm.Evm64.evm_exp_msb_saved_bit_two_mul_fixed_length,
+                EvmAsm.Evm64.exp_prologue_fixed_length])
+      (by simp [EvmAsm.Evm64.evm_exp_msb_saved_bit_two_mul_fixed_length]))
+
+/-- The pointer-advance instruction lifted to the full fixed code. -/
+private theorem exp_pointer_advance_fixed_in_fixed_code_spec_within
+    (evmSp : Word)
+    (squaringMulOff condMulOff : BitVec 21) (skipOff backOff : BitVec 13)
+    (base : Word) :
+    cpsTripleWithin 1 (base + 40) (base + 44)
+      (expMsbSavedBitTwoMulFixedCode base squaringMulOff condMulOff skipOff backOff)
+      (.x12 ↦ᵣ evmSp)
+      (.x12 ↦ᵣ (evmSp + signExtend12 (64 : BitVec 12))) := by
+  have h := EvmAsm.Evm64.exp_loop_pointer_advance_spec_within evmSp (base + 40)
+  have haddr : (base + 40 : Word) + 4 = base + 44 := by bv_addr
+  rw [haddr] at h
+  exact cpsTripleWithin_extend_code (h := h)
+    (hmono := CodeReq.ofProg_mono_sub base (base + 40)
+      (EvmAsm.Evm64.evm_exp_msb_saved_bit_two_mul_fixed
+        squaringMulOff condMulOff skipOff backOff)
+      EvmAsm.Evm64.exp_loop_pointer_advance 10
+      (by bv_omega)
+      (by unfold EvmAsm.Evm64.evm_exp_msb_saved_bit_two_mul_fixed EvmAsm.Rv64.seq
+              EvmAsm.Evm64.exp_prologue_fixed EvmAsm.Evm64.exp_loop_pointer_advance
+              EvmAsm.Rv64.ADDI
+              EvmAsm.Rv64.SD EvmAsm.Rv64.LD
+              EvmAsm.Rv64.single
+          rfl)
+      (by simp [EvmAsm.Evm64.evm_exp_msb_saved_bit_two_mul_fixed_length,
+                EvmAsm.Evm64.exp_loop_pointer_advance_length])
+      (by simp [EvmAsm.Evm64.evm_exp_msb_saved_bit_two_mul_fixed_length]))
+
+/-- The fixed EXP prologue followed by the pointer advance:
+    proves that 11 instructions correctly initialize x19, x6, x16 for the
+    fixed MSB-first exponent cursor from a raw precondition.
+
+    The PRE includes the exponent's MSB limb explicitly at evmSp+56;
+    the POST is the raw (pre-folded) accumulation from the specs.
+    Callers wrap this in a further weaken to fold into `expTwoMulLoopEntryPostFixed`. -/
+theorem exp_prologue_fixed_then_pointer_advance_spec_within
+    (sp evmSp cOld tOld c6Old c16Old c19Old m0 m1 m2 m3 vOld v18 : Word)
+    (squaringMulOff condMulOff : BitVec 21) (skipOff backOff : BitVec 13)
+    (base expLimb3 : Word) :
+    cpsTripleWithin (10 + 1) base (base + 44)
+      (expMsbSavedBitTwoMulFixedCode base squaringMulOff condMulOff skipOff backOff)
+      ((.x2 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) ** (.x9 ↦ᵣ cOld) **
+       (.x5 ↦ᵣ tOld) ** (.x12 ↦ᵣ evmSp) **
+       (.x6 ↦ᵣ c6Old) ** (.x16 ↦ᵣ c16Old) ** (.x19 ↦ᵣ c19Old) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ m0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ m1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ m2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ m3) **
+       ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ expLimb3) **
+       expTwoMulScratchFrame vOld v18)
+      (((.x2 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x9 ↦ᵣ ((0 : Word) + signExtend12 (256 : BitVec 12))) **
+        (.x5 ↦ᵣ ((0 : Word) + signExtend12 (1 : BitVec 12))) **
+        (.x6 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
+        (.x16 ↦ᵣ evmSp + signExtend12 (56 : BitVec 12) + signExtend12 (-8 : BitVec 12)) **
+        (.x19 ↦ᵣ expLimb3) **
+        ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ ((0 : Word) + signExtend12 (1 : BitVec 12))) **
+        ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ (0 : Word)) **
+        ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ expLimb3)) **
+       (.x12 ↦ᵣ (evmSp + signExtend12 (64 : BitVec 12))) **
+       expTwoMulScratchFrame vOld v18) := by
+  have hPrologue := exp_prologue_fixed_in_fixed_code_spec_within
+    sp evmSp cOld tOld c6Old c16Old c19Old m0 m1 m2 m3 expLimb3
+    squaringMulOff condMulOff skipOff backOff base
+  have hPrologueF := cpsTripleWithin_frameR
+    (expTwoMulScratchFrame vOld v18)
+    (by pcFree) hPrologue
+  have hAdvance := exp_pointer_advance_fixed_in_fixed_code_spec_within
+    evmSp squaringMulOff condMulOff skipOff backOff base
+  have hAdvanceF := cpsTripleWithin_frameR
+    ((.x2 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
+     (.x9 ↦ᵣ 0 + signExtend12 256) ** (.x5 ↦ᵣ 0 + signExtend12 1) **
+     (.x6 ↦ᵣ 0 + signExtend12 64) **
+     (.x16 ↦ᵣ evmSp + signExtend12 56 + signExtend12 (-8:BitVec 12)) **
+     (.x19 ↦ᵣ expLimb3) **
+     ((sp + signExtend12 0) ↦ₘ 0 + signExtend12 1) **
+     ((sp + signExtend12 8) ↦ₘ 0) ** ((sp + signExtend12 16) ↦ₘ 0) **
+     ((sp + signExtend12 24) ↦ₘ 0) **
+     ((evmSp + signExtend12 56) ↦ₘ expLimb3) **
+     expTwoMulScratchFrame vOld v18)
+    (by pcFree) hAdvance
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by xperm_hyp hp) (fun _ hp => by xperm_hyp hp)
+    (cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hPrologueF hAdvanceF)
+
+end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- Defines `expTwoMulLoopEntryPostFixed`: the correct EXP loop entry state for the fixed algorithm, with x19=exponent.getLimbN 3, x6=64, x16=evmSp+48, x12=evmSp+64
- Proves `exp_prologue_fixed_then_pointer_advance_spec_within`: the combined 11-instruction fixed prologue + pointer-advance correctly initializes these new cursor registers from a raw precondition
- Adds `expMsbSavedBitTwoMulFixedCode` abbreviation for the full fixed program CodeReq
- Merges origin/main to include PR #4627 (prologue spec) and PRs #4628/#4629 (BNE specs)

Refs #92. Bead: evm-asm-w5mk.

## Verification
- `lake build EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryPrologueFixed`
- `scripts/check-file-size.sh`
- `rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryPrologueFixed.lean`
- `lake build`

Authored by @pirapira; implemented by Claude Code