### PR TITLE
docs(exp): document loopPost→iterPre bridge gap for 256-iter induction

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitIterMerge.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitIterMerge.lean
@@ -954,4 +954,26 @@ theorem exp_loop_body_succ_step
     e0 e1 e2 e3 a0 a1 a2 a3 iterCountFinal tOld out0 out1 out2 out3
     base baseWord rest exitCond hbase hExit hLoop
 
+-- Key insight for the 256-iteration loop body proof: the `loopPost` assertion
+-- embeds ALL the atoms needed by the NEXT iteration's `iterPre`, except for
+-- `d0..d3` which come from `memOwn` atoms (algorithmically irrelevant scratch).
+--
+-- For the SKIP path (bit = 0):
+--   x5' = squareW.getLimbN 3  (next exponent cursor, from skipRest)
+--   r0'..r3' = squareW.getLimbN 0..3  (from evmWordIs sp squareW)
+--   e0'..e3' = squareW.getLimbN 0..3  (from evmWordIs (evmSp+32) squareW)
+--   v18' = bit + signExtend12 0  (from skipRest's x18)
+--   vOld' = (base+44)+68  (from skipRest's x1)
+--   d0'..d3' = WHATEVER is at evmSp..evmSp+24  (from memOwn atoms)
+--
+-- For the COND path (bit = 1):
+--   x5' = rw.getLimbN 3,  r0'..r3' = rw.getLimbN 0..3
+--   e0'..e3' = rw.getLimbN 0..3 (from evmWordIs (evmSp+32) rw)
+--   v18' = bit+signExtend12 0, vOld' = (base+152)+68
+--   d0'..d3' = WHATEVER is at evmSp..evmSp+24 (from memOwn atoms)
+--
+-- Proving this existential bridge (expTwoMulIterLoopPost_to_iterPre_exists)
+-- requires extracting d0..d3 from memOwn via Classical.choose and reassembling
+-- the sepConj — see bead evm-asm-w5mk notes for the proof sketch.
+
 end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- Documents the exact proof sketch for `expTwoMulIterLoopPost_to_iterPre_exists` — the existential bridge needed to chain the peel theorem 256 times in the full loop body proof
- Identifies the concrete next-state values for both SKIP (bit=0) and COND (bit=1) paths: `e'`, `r0'..r3'`, `v18'`, `vOld'`, `e0'..e3'` all computed from `squareW`/`rw` atoms
- Pinpoints the last open step: extracting `d0..d3` from `memOwn` atoms via `Classical.choose` and reassembling the `sepConj`

This analysis unblocks the 256-iteration loop body proof (the core remaining piece of `evm-asm-w5mk`). The infrastructure is complete (PRs #4632 and #4633 are merged): base case, vacuous exit bridge, inductive step wrapper are all available.

Refs #92. Bead: evm-asm-w5mk.

## Verification
- `lake build EvmAsm.Evm64.Exp.Compose.SavedBitIterMerge`
- `scripts/check-file-size.sh`
- `rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/Compose/SavedBitIterMerge.lean`
- `lake build`

Authored by @pirapira; implemented by Claude Code