### PR TITLE
feat(rv64): add sepConj_choose_memOwn helper for loopPost→iterPre bridge

### DIFF
--- a/EvmAsm/Rv64/SepLogic.lean
+++ b/EvmAsm/Rv64/SepLogic.lean
@@ -1466,6 +1466,15 @@ theorem sepConj_extract_pure_end3 {A B C : Assertion} {P : Prop} :
     obtain ⟨_, _, _, _, _, h3⟩ := h2
     exact ((sepConj_pure_right _).1 h3).2
 
+/-- Choose a concrete value from `memOwn` in a leading `memOwn ** B` chain.
+    This is the key building block for the `loopPost → iterPre` bridge:
+    each `memOwn a` atom embeds an existential `∃ v, memIs a v`, so peeling
+    it yields a concrete `memIs a v` together with the rest of the chain. -/
+theorem sepConj_choose_memOwn {a : Word} {B : Assertion} {ps : PartialState}
+    (h : (memOwn a ** B) ps) : ∃ v, (memIs a v ** B) ps := by
+  obtain ⟨ps1, ps2, hd, hu, ⟨v, hv⟩, hB⟩ := h
+  exact ⟨v, ps1, ps2, hd, hu, hv, hB⟩
+
 /-- Push the outer atom of a 4-chain left-associated `(3-chain) ** D`
     into the right-associated 4-chain — the inverse of the tree shape
     `cpsBranch_frameR` produces when framing a 3-atom pre with a


### PR DESCRIPTION
## Summary
- Adds `sepConj_choose_memOwn` to `SepLogic.lean`: given `(memOwn a ** B) ps`, extract a concrete `v` such that `(memIs a v ** B) ps`.
- This is the key building block for the `expTwoMulIterLoopPost → iterPre` bridge needed to close the EXP 256-iteration loop body proof.

The bridge proof pattern (4 applications):
```
obtain ⟨d0, h'⟩ := sepConj_choose_memOwn h_with_d0_position
obtain ⟨d1, h''⟩ := ...
obtain ⟨d2, h'''⟩ := ...
obtain ⟨d3, h''''⟩ := ...
sep_perm h''''  -- ac_rfl closes via Std.Commutative/Std.Associative for **
```

Refs #92. Bead: evm-asm-w5mk.

## Verification
- `lake build EvmAsm.Rv64.SepLogic`
- `scripts/check-file-size.sh`
- `rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Rv64/SepLogic.lean`
- `lake build`

Authored by @pirapira; implemented by Claude Code