### PR TITLE
docs(exp): document 256-iter induction gap; merge origin/main

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitIterBridges.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitIterBridges.lean
@@ -319,4 +319,21 @@ theorem expTwoMulIterLoopPost_to_iterPre
            squareW.getLimbN 0, squareW.getLimbN 1, squareW.getLimbN 2, squareW.getLimbN 3,
            hpre⟩
 
+-- The abstract n-step loop-body spec from loopPost(n) is blocked by Lean 4 elaboration
+-- depth when using exp_two_mul_iterations_body_peel_with_exit_imp_closed_bound_spec_within
+-- directly in a Nat.rec induction (the peel theorem + succ_step combination produces a term
+-- too large for the elaborator at the final `exact` step).
+--
+-- PROOF SKETCH (see bead evm-asm-w5mk notes):
+-- By Nat.rec on n:
+--   Base (n=0): exp_loop_body_zero_step_vacuous (vacuous, loopPost(0)=False)
+--   Step (k+1): apply expTwoMulIterLoopPost_to_iterPre bridge → iterPre,
+--               then apply exp_two_mul_iterations_body_peel_with_exit_imp_closed_bound_spec_within
+--               with hExit = vacuous (k≠0) or hExitFinal (k=0), hLoop = IH instantiated at
+--               the post-iteration state values (expTwoMulIterBit e', squarW', rwW').
+--
+-- This would give: cpsTripleWithin (n * 189) ... (loopPost n ...) loopExitPre
+-- Combined with hEntry (loopEntryPost → iterPre) and exp_two_mul_full_loop_boundary_of_entry_body_spec_within,
+-- this closes the full 256-iteration loop body spec.
+
 end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitIterMerge.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitIterMerge.lean
@@ -954,4 +954,5 @@ theorem exp_loop_body_succ_step
     e0 e1 e2 e3 a0 a1 a2 a3 iterCountFinal tOld out0 out1 out2 out3
     base baseWord rest exitCond hbase hExit hLoop
 
+
 end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- Merges origin/main to resolve the conflict between the old comment stub (from main) and the actual proved bridge theorems (from our branch stack)
- Adds a comment documenting the remaining gap: the abstract n-step induction from loopPost(n) triggers Lean 4 maximum elaboration depth at the final `exact exp_two_mul_iterations_body_peel_with_exit_imp_closed_bound_spec_within ...` call. All component infrastructure is proved; only the final assembly step is pending.

The component infrastructure that IS complete (all zero-sorry):
- `expTwoMulIterLoopPost_to_iterPre` (both skip+cond paths)
- `expTwoMulIterLoopPost_zero_count_false` + `exp_loop_body_zero_step_vacuous`
- `expTwoMulIterExitPost_nonzero_count_false` + `exp_loop_exit_vacuous_bridge`
- `exp_loop_body_succ_step`

Refs #92. Bead: evm-asm-w5mk.

## Verification
- `lake build EvmAsm.Evm64.Exp.Compose.SavedBitIterMerge`
- `scripts/check-file-size.sh`
- `rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/Exp/Compose/SavedBitIterMerge.lean`
- `lake build`

Authored by @pirapira; implemented by Claude Code