### PR TITLE
chore(evm64): delete dead zero-external-ref theorems in LogGas/CodeRegion/LogArgsStackDecode

### DIFF
--- a/EvmAsm/Evm64/CodeRegion.lean
+++ b/EvmAsm/Evm64/CodeRegion.lean
@@ -202,34 +202,4 @@ theorem evmCodeIs_split_at (base : Word) (bytes : List (BitVec 8)) (dw : Nat)
       rw [List.drop_take, harith3]
 
 -- ============================================================================
--- Alignment bridge lemma
--- ============================================================================
-
-/-- Aligned base: low 3 bits are zero. -/
-abbrev IsAligned8 (addr : Word) : Prop := addr &&& 7#64 = 0#64
-
-/-- An aligned address is unchanged by alignToDword. -/
-theorem alignToDword_of_aligned (base : Word) (h : IsAligned8 base) :
-    alignToDword base = base := by
-  unfold alignToDword
-  have : base &&& ~~~7#64 = base ^^^ (base &&& 7#64) := by bv_decide
-  rw [this, h]; simp [BitVec.xor_zero]
-
--- ============================================================================
--- Byte extraction bridge
--- ============================================================================
-
-/-- Reading byte `k` from the code region: the byte at global index `k` can be
-    extracted from the containing doubleword's `packBytes` using byte offset `k % 8`. -/
-theorem extractByte_codeRegion_at (bytes : List (BitVec 8)) (k : Nat)
-    (hk : k < bytes.length) :
-    extractByte (packBytes ((bytes.drop (k / 8 * 8)).take 8)) (k % 8) = bytes[k] := by
-  have hmod : k % 8 < 8 := Nat.mod_lt k (by omega)
-  have hchunkLen : k % 8 < ((bytes.drop (k / 8 * 8)).take 8).length := by
-    simp; omega
-  rw [extractByte_packBytes _ (k % 8) hmod (by simp; omega)]
-  show ((bytes.drop (k / 8 * 8)).take 8)[k % 8]'hchunkLen = bytes[k]
-  rw [List.getElem_take, List.getElem_drop]
-  congr 1; omega
-
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/LogArgsStackDecode.lean
+++ b/EvmAsm/Evm64/LogArgsStackDecode.lean
@@ -15,21 +15,6 @@ open LogArgs
 def mkArgs (offset size : EvmWord) (topics : List EvmWord) : Args :=
   { data := { offset := offset, size := size }, topics := topics }
 
-theorem mkArgs_dataRange (offset size : EvmWord) (topics : List EvmWord) :
-    dataRange (mkArgs offset size topics) = { offset := offset, size := size } := rfl
-
-theorem mkArgs_data_offset (offset size : EvmWord) (topics : List EvmWord) :
-    (dataRange (mkArgs offset size topics)).offset = offset := rfl
-
-theorem mkArgs_data_size (offset size : EvmWord) (topics : List EvmWord) :
-    (dataRange (mkArgs offset size topics)).size = size := rfl
-
-theorem mkArgs_topics (offset size : EvmWord) (topics : List EvmWord) :
-    (mkArgs offset size topics).topics = topics := rfl
-
-theorem mkArgs_topics_length (offset size : EvmWord) (topics : List EvmWord) :
-    (mkArgs offset size topics).topics.length = topics.length := rfl
-
 /--
 Decode LOG-family stack arguments from the top-of-stack list order:
 `offset, size, topic0, topic1, ...`.

--- a/EvmAsm/Evm64/LogGas.lean
+++ b/EvmAsm/Evm64/LogGas.lean
@@ -37,19 +37,9 @@ def logDynamicCost
 @[simp] theorem logTopicDynamicCost_log0 :
     logTopicDynamicCost .log0 = 0 := rfl
 
-theorem logTopicDynamicCost_log4 :
-    logTopicDynamicCost .log4 = 1500 := rfl
-
 @[simp] theorem logDataDynamicCost_zero :
     logDataDynamicCost 0 = 0 := by
   simp [logDataDynamicCost, logGasPerDataByte]
-
-theorem logDynamicCost_eq
-    (kind : LogArgs.Kind) (sizeBytes offset length : Nat) :
-    logDynamicCost kind sizeBytes offset length =
-      logTopicDynamicCost kind + logDataDynamicCost length +
-        MemoryGas.memoryExpansionCost sizeBytes
-          (evmMemExpand sizeBytes offset length) := rfl
 
 theorem logDynamicCost_eq_charges_of_no_growth
     {kind : LogArgs.Kind} {sizeBytes offset length : Nat}


### PR DESCRIPTION
## Summary
- Delete `logTopicDynamicCost_log4` + `logDynamicCost_eq` from LogGas.lean (2 rfl theorems, 10 lines)
- Delete `IsAligned8` abbrev + `alignToDword_of_aligned` + `extractByte_codeRegion_at` from CodeRegion.lean (30 lines)
- Delete 5 `mkArgs_*` rfl theorems from LogArgsStackDecode.lean (15 lines)

All 10 declarations have zero external references (verified with `rg`). 55 lines total removed.

Refs evm-asm-sboz. Bead: evm-asm-iatyp.

## Verification
- lake build EvmAsm.Evm64.LogGas EvmAsm.Evm64.CodeRegion EvmAsm.Evm64.LogArgsStackDecode
- scripts/check-file-size.sh
- rg -n "sorry|admit" EvmAsm/Evm64/{LogGas,CodeRegion,LogArgsStackDecode}.lean
- lake build

Authored by @pirapira; implemented by Claude Code