### PR TITLE
chore(Evm64): delete 9 dead _code_block_subs theorems across Exp/Multiply/AddMod

### DIFF
--- a/EvmAsm/Evm64/AddMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/AddMod/Compose/Base.lean
@@ -118,25 +118,6 @@ theorem evm_addmod_program_code_epilogue_sub
   · rw [evm_addmod_length, evm_addmod_epilogue_length]
   · rw [evm_addmod_length]; decide
 
-/-- Bundled per-block subsumptions for `evm_addmod_program_code`, used by
-    slice 3d (`evm-asm-s7v49`) when wiring per-block cpsTriple specs into
-    the full `evm_addmod_stack_spec_within` composition. -/
-theorem evm_addmod_program_code_block_subs
-    {base : Word} {modOff : BitVec 21} :
-    (∀ a i, (CodeReq.ofProg base evm_addmod_prologue) a = some i →
-      (evm_addmod_program_code base modOff) a = some i) ∧
-    (∀ a i, (CodeReq.ofProg (base + 120) evm_addmod_phase1_carry) a = some i →
-      (evm_addmod_program_code base modOff) a = some i) ∧
-    (∀ a i, (CodeReq.ofProg (base + 124)
-        (evm_addmod_phase2_reduce modOff)) a = some i →
-      (evm_addmod_program_code base modOff) a = some i) ∧
-    (∀ a i, (CodeReq.ofProg (base + 128) evm_addmod_epilogue) a = some i →
-      (evm_addmod_program_code base modOff) a = some i) :=
-  ⟨evm_addmod_program_code_prologue_sub,
-    evm_addmod_program_code_phase1_carry_sub,
-    evm_addmod_program_code_phase2_reduce_sub,
-    evm_addmod_program_code_epilogue_sub⟩
-
 -- ============================================================================
 -- Per-block leaf specs lifted onto `evm_addmod_program_code`
 -- ============================================================================

--- a/EvmAsm/Evm64/Exp/Compose/BaseSquaringCallCode.lean
+++ b/EvmAsm/Evm64/Exp/Compose/BaseSquaringCallCode.lean
@@ -146,22 +146,4 @@ theorem exp_squaring_call_block_code_un_marshal_and_restore_sub {base : Word}
       simp only [exp_squaring_call_block_len]
       norm_num)
 
-theorem exp_squaring_call_block_code_block_subs {base : Word}
-    {mulOff : BitVec 21} :
-    (∀ a i, (CodeReq.ofProg base EvmAsm.Evm64.exp_loop_marshal_factor1) a = some i →
-      (exp_squaring_call_block_code base mulOff) a = some i) ∧
-    (∀ a i, (CodeReq.ofProg (base + 32)
-      EvmAsm.Evm64.exp_loop_marshal_result_to_factor2) a = some i →
-      (exp_squaring_call_block_code base mulOff) a = some i) ∧
-    (∀ a i, (CodeReq.ofProg (base + 64)
-      (EvmAsm.Evm64.exp_square_block mulOff)) a = some i →
-      (exp_squaring_call_block_code base mulOff) a = some i) ∧
-    (∀ a i, (CodeReq.ofProg (base + 68)
-      EvmAsm.Evm64.exp_loop_un_marshal_and_restore) a = some i →
-      (exp_squaring_call_block_code base mulOff) a = some i) := by
-  exact ⟨exp_squaring_call_block_code_marshal_factor1_sub,
-    exp_squaring_call_block_code_marshal_result_to_factor2_sub,
-    exp_squaring_call_block_code_square_sub,
-    exp_squaring_call_block_code_un_marshal_and_restore_sub⟩
-
 end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/CondMulCall.lean
+++ b/EvmAsm/Evm64/Exp/CondMulCall.lean
@@ -125,22 +125,6 @@ theorem exp_cond_mul_call_block_code_un_marshal_and_restore_sub
         base hk1 hk2))
   exact CodeReq.union_mono_left
 
-theorem exp_cond_mul_call_block_code_block_subs
-    (base : Word) (mulOff : BitVec 21) :
-    (∀ a i, (CodeReq.ofProg base exp_loop_marshal_factor1) a = some i →
-      (exp_cond_mul_call_block_code base mulOff) a = some i) ∧
-    (∀ a i, (CodeReq.ofProg (base + 32)
-      exp_loop_marshal_a_to_factor2) a = some i →
-      (exp_cond_mul_call_block_code base mulOff) a = some i) ∧
-    (∀ a i, (CodeReq.ofProg (base + 64) (exp_square_block mulOff)) a = some i →
-      (exp_cond_mul_call_block_code base mulOff) a = some i) ∧
-    (∀ a i, (CodeReq.ofProg (base + 68) exp_loop_un_marshal_and_restore) a = some i →
-      (exp_cond_mul_call_block_code base mulOff) a = some i) := by
-  exact ⟨exp_cond_mul_call_block_code_marshal_factor1_sub base mulOff,
-    exp_cond_mul_call_block_code_marshal_a_to_factor2_sub base mulOff,
-    exp_cond_mul_call_block_code_square_sub base mulOff,
-    exp_cond_mul_call_block_code_un_marshal_and_restore_sub base mulOff⟩
-
 /-- The two-block cond-mul marshal-pair prefix is contained in the full
     conditional-multiply call block code. -/
 theorem exp_cond_mul_call_block_code_marshal_pair_sub
@@ -212,15 +196,6 @@ theorem exp_cond_mul_call_with_skip_block_code_call_sub
       simp only [exp_cond_mul_call_with_skip_block_length]
       norm_num)
 
-theorem exp_cond_mul_call_with_skip_block_code_block_subs
-    (base : Word) (mulOff : BitVec 21) (skipOff : BitVec 13) :
-    (∀ a i, (CodeReq.singleton base (.BEQ .x10 .x0 skipOff)) a = some i →
-      (exp_cond_mul_call_with_skip_block_code base mulOff skipOff) a = some i) ∧
-    (∀ a i, (exp_cond_mul_call_block_code (base + 4) mulOff) a = some i →
-      (exp_cond_mul_call_with_skip_block_code base mulOff skipOff) a = some i) := by
-  exact ⟨exp_cond_mul_call_with_skip_block_code_beq_sub base mulOff skipOff,
-    exp_cond_mul_call_with_skip_block_code_call_sub base mulOff skipOff⟩
-
 /-- CodeReq decomposition for the conditional-multiply step with its leading
     BEQ skip gate, branching on the saved bit in `x18`. The BEQ lives at
     `base`; the taken call block starts at `base + 4` and is skipped when
@@ -283,18 +258,5 @@ theorem exp_cond_mul_call_with_saved_bit_skip_block_code_call_sub
     (by
       simp only [exp_cond_mul_call_with_saved_bit_skip_block_length]
       norm_num)
-
-theorem exp_cond_mul_call_with_saved_bit_skip_block_code_block_subs
-    (base : Word) (mulOff : BitVec 21) (skipOff : BitVec 13) :
-    (∀ a i, (CodeReq.singleton base (.BEQ .x18 .x0 skipOff)) a = some i →
-      (exp_cond_mul_call_with_saved_bit_skip_block_code base mulOff skipOff)
-        a = some i) ∧
-    (∀ a i, (exp_cond_mul_call_block_code (base + 4) mulOff) a = some i →
-      (exp_cond_mul_call_with_saved_bit_skip_block_code base mulOff skipOff)
-        a = some i) := by
-  exact ⟨exp_cond_mul_call_with_saved_bit_skip_block_code_beq_sub
-      base mulOff skipOff,
-    exp_cond_mul_call_with_saved_bit_skip_block_code_call_sub
-      base mulOff skipOff⟩
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Exp/CondMulMarshalPair.lean
+++ b/EvmAsm/Evm64/Exp/CondMulMarshalPair.lean
@@ -72,17 +72,6 @@ theorem exp_loop_cond_mul_marshal_pair_code_a_to_factor2_sub
   intro a i h
   exact h
 
-/-- Bundled per-sub-block subsumption witnesses for the cond-mul marshal-pair
-    code prefix. -/
-theorem exp_loop_cond_mul_marshal_pair_code_block_subs
-    (base : Word) :
-    (∀ a i, (CodeReq.ofProg base exp_loop_marshal_factor1) a = some i →
-      (exp_loop_cond_mul_marshal_pair_code base) a = some i) ∧
-    (∀ a i, (CodeReq.ofProg (base + 32) exp_loop_marshal_a_to_factor2) a = some i →
-      (exp_loop_cond_mul_marshal_pair_code base) a = some i) := by
-  exact ⟨exp_loop_cond_mul_marshal_pair_code_factor1_sub base,
-    exp_loop_cond_mul_marshal_pair_code_a_to_factor2_sub base⟩
-
 /-- Composition of `exp_loop_marshal_factor1` followed by
     `exp_loop_marshal_a_to_factor2`. The first block copies the running
     accumulator `r0..r3` from `sp[0..24]` into the LP64 factor-1 slot

--- a/EvmAsm/Evm64/Exp/MarshalPair.lean
+++ b/EvmAsm/Evm64/Exp/MarshalPair.lean
@@ -67,18 +67,6 @@ theorem exp_loop_squaring_marshal_pair_code_result_to_factor2_sub
   intro a i h
   exact h
 
-/-- Bundled per-sub-block subsumption witnesses for the squaring marshal-pair
-    code prefix. -/
-theorem exp_loop_squaring_marshal_pair_code_block_subs
-    (base : Word) :
-    (∀ a i, (CodeReq.ofProg base exp_loop_marshal_factor1) a = some i →
-      (exp_loop_squaring_marshal_pair_code base) a = some i) ∧
-    (∀ a i, (CodeReq.ofProg (base + 32)
-      exp_loop_marshal_result_to_factor2) a = some i →
-      (exp_loop_squaring_marshal_pair_code base) a = some i) := by
-  exact ⟨exp_loop_squaring_marshal_pair_code_factor1_sub base,
-    exp_loop_squaring_marshal_pair_code_result_to_factor2_sub base⟩
-
 /-- Composition of `exp_loop_marshal_factor1` followed by
     `exp_loop_marshal_result_to_factor2`. Both blocks read the four limbs
     of the accumulator from `sp[0..24]`; `factor1` writes them into

--- a/EvmAsm/Evm64/Exp/SquaringPairThenMulCall.lean
+++ b/EvmAsm/Evm64/Exp/SquaringPairThenMulCall.lean
@@ -64,39 +64,6 @@ theorem exp_squaring_call_with_mul_code_mul_callable_sub
   unfold exp_squaring_call_with_mul_code
   exact CodeReq.mono_union_right hd (fun _ _ h => h)
 
-/-- Bundled sub-block witnesses for the squaring-call block plus the external
-    `mul_callable` body. This packages the code facts needed by the final
-    `exp_squaring_call_block_spec_within` composition. -/
-theorem exp_squaring_call_with_mul_code_block_subs
-    (base mulTarget : Word) (mulOff : BitVec 21)
-    (hd : CodeReq.Disjoint
-            (exp_squaring_call_block_code base mulOff)
-            (mul_callable_code mulTarget)) :
-    (∀ a i, (CodeReq.ofProg base exp_loop_marshal_factor1) a = some i →
-      (exp_squaring_call_with_mul_code base mulTarget mulOff) a = some i) ∧
-    (∀ a i, (CodeReq.ofProg (base + 32)
-      exp_loop_marshal_result_to_factor2) a = some i →
-      (exp_squaring_call_with_mul_code base mulTarget mulOff) a = some i) ∧
-    (∀ a i, (CodeReq.ofProg (base + 64) (exp_square_block mulOff)) a = some i →
-      (exp_squaring_call_with_mul_code base mulTarget mulOff) a = some i) ∧
-    (∀ a i, (CodeReq.ofProg (base + 68) exp_loop_un_marshal_and_restore) a = some i →
-      (exp_squaring_call_with_mul_code base mulTarget mulOff) a = some i) ∧
-    (∀ a i, (mul_callable_code mulTarget) a = some i →
-      (exp_squaring_call_with_mul_code base mulTarget mulOff) a = some i) := by
-  rcases exp_squaring_call_block_code_block_subs base mulOff with
-    ⟨h_factor1, h_resultToFactor2, h_square, h_unmarshal⟩
-  exact
-    ⟨fun a i h => exp_squaring_call_with_mul_code_block_sub
-        base mulTarget mulOff a i (h_factor1 a i h),
-     fun a i h => exp_squaring_call_with_mul_code_block_sub
-        base mulTarget mulOff a i (h_resultToFactor2 a i h),
-     fun a i h => exp_squaring_call_with_mul_code_block_sub
-        base mulTarget mulOff a i (h_square a i h),
-     fun a i h => exp_squaring_call_with_mul_code_block_sub
-        base mulTarget mulOff a i (h_unmarshal a i h),
-     exp_squaring_call_with_mul_code_mul_callable_sub
-        base mulTarget mulOff hd⟩
-
 /-- Bridge the post-call MUL result word at `evmSp + 32` into the
     unmarshal/restore block, producing the same word in the local EXP scratch
     frame at `sp`. -/

--- a/EvmAsm/Evm64/Multiply/Callable.lean
+++ b/EvmAsm/Evm64/Multiply/Callable.lean
@@ -100,13 +100,6 @@ theorem mul_callable_code_ret_sub (base : Word) :
   intro a i h
   exact h
 
-theorem mul_callable_code_block_subs (base : Word) :
-    (∀ a i, (evm_mul_code base) a = some i →
-      (mul_callable_code base) a = some i) ∧
-    (∀ a i, (cc_ret_code (base + 252)) a = some i →
-      (mul_callable_code base) a = some i) := by
-  exact ⟨mul_callable_code_mul_sub base, mul_callable_code_ret_sub base⟩
-
 -- ============================================================================
 -- Callable spec
 -- ============================================================================


### PR DESCRIPTION
## Summary
- Delete 9 zero-caller `_code_block_subs` theorem blocks (138 lines) across 7 files in `Evm64/`
- Each theorem bundled per-sub-block `CodeReq` subsumption witnesses but was never consumed by any downstream proof
- Files: Exp/CondMulCall.lean (3), Exp/SquaringPairThenMulCall.lean (1), Exp/Compose/BaseSquaringCallCode.lean (1, duplicate), Exp/CondMulMarshalPair.lean (1), Exp/MarshalPair.lean (1), Multiply/Callable.lean (1), AddMod/Compose/Base.lean (1)

Refs #61. Bead: evm-asm-sboz.2. Parent: evm-asm-sboz.

## Verification
- `lake build EvmAsm.Evm64.Exp.SquaringPairThenMulCall EvmAsm.Evm64.Multiply.Callable EvmAsm.Evm64.AddMod.Compose.Base ...` ✓ (978 jobs)
- `scripts/check-file-size.sh` ✓ (631 files, all within cap)
- `rg 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth' <files>` ✓ (no matches)
- `lake build` (CI)

Authored by @pirapira; implemented by Claude Code