### PR TITLE
chore(Evm64): delete 28 dead rfl theorems in Gas.lean + 1 in SquaringCall.lean

### DIFF
--- a/EvmAsm/Evm64/Exp/SquaringCall.lean
+++ b/EvmAsm/Evm64/Exp/SquaringCall.lean
@@ -170,16 +170,4 @@ theorem exp_squaring_call_block_code_block_subs
     exp_squaring_call_block_code_square_sub base mulOff,
     exp_squaring_call_block_code_un_marshal_and_restore_sub base mulOff⟩
 
-/-- The two-block squaring marshal-pair prefix is contained in the full
-    squaring call block code. -/
-theorem exp_squaring_call_block_code_marshal_pair_sub
-    (base : Word) (mulOff : BitVec 21) :
-    ∀ a i, (exp_loop_squaring_marshal_pair_code base) a = some i →
-      (exp_squaring_call_block_code base mulOff) a = some i := by
-  intro a i h
-  exact CodeReq.union_sub
-    (exp_squaring_call_block_code_marshal_factor1_sub base mulOff)
-    (exp_squaring_call_block_code_marshal_result_to_factor2_sub base mulOff)
-    a i h
-
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Gas.lean
+++ b/EvmAsm/Evm64/Gas.lean
@@ -281,30 +281,8 @@ theorem byte?_SWAP_of_valid {n : Nat} (h : validSwapIndex n = true) :
     byte? (SWAP n) = some (0x8f + n) := by
   simp [byte?, h]
 
-theorem byte?_PUSH0 : byte? PUSH0 = some 0x5f := rfl
-
-theorem byte?_STOP : byte? STOP = some 0x00 := rfl
-
-theorem byte?_RETURN : byte? RETURN = some 0xf3 := rfl
-
-theorem byte?_REVERT : byte? REVERT = some 0xfd := rfl
-
-theorem byte?_SELFDESTRUCT : byte? SELFDESTRUCT = some 0xff := rfl
-
-theorem byte?_INVALID : byte? INVALID = some 0xfe := rfl
-
-theorem byte?_ADDRESS : byte? ADDRESS = some 0x30 := rfl
-
-theorem byte?_BASEFEE : byte? BASEFEE = some 0x48 := rfl
-
-theorem byte?_KECCAK256 : byte? KECCAK256 = some 0x20 := rfl
-
 theorem byte?_LOG (kind : LogArgs.Kind) :
     byte? (LOG kind) = some (0xa0 + LogArgs.topicCount kind) := rfl
-
-theorem byte?_LOG0 : byte? (LOG .log0) = some 0xa0 := rfl
-
-theorem byte?_LOG4 : byte? (LOG .log4) = some 0xa4 := rfl
 
 def ofCallKind : CallArgs.Kind → EvmOpcode
   | .call => CALL
@@ -414,18 +392,6 @@ theorem byte?_ofBlockBlobKind (kind : BlockBlobKind) :
       | .blobbasefee => some 0x4a := by
   cases kind <;> rfl
 
-theorem staticGasCost_stop : staticGasCost STOP = 0 := rfl
-
-theorem staticGasCost_push0 : staticGasCost PUSH0 = 2 := rfl
-
-theorem staticGasCost_msize : staticGasCost MSIZE = 2 := rfl
-
-theorem staticGasCost_calldataLoad : staticGasCost CALLDATALOAD = 3 := rfl
-
-theorem staticGasCost_calldataSize : staticGasCost CALLDATASIZE = 2 := rfl
-
-theorem staticGasCost_calldataCopyBase : staticGasCost CALLDATACOPY = 3 := rfl
-
 theorem staticGasCost_ofControlFlowKind (kind : ControlFlowKind) :
     staticGasCost (ofControlFlowKind kind) =
       match kind with
@@ -452,18 +418,8 @@ theorem staticGasCost_ofCopyLikeKind (kind : CopyLikeKind) :
     staticGasCost (ofCopyLikeKind kind) = 3 := by
   cases kind <;> rfl
 
-theorem staticGasCost_address : staticGasCost ADDRESS = 2 := rfl
-
-theorem staticGasCost_basefee : staticGasCost BASEFEE = 2 := rfl
-
-theorem staticGasCost_selfbalance : staticGasCost SELFBALANCE = 5 := rfl
-
 theorem staticGasCost_LOG (kind : LogArgs.Kind) :
     staticGasCost (LOG kind) = 375 := rfl
-
-theorem staticGasCost_log0Base : staticGasCost (LOG .log0) = 375 := rfl
-
-theorem staticGasCost_log4Base : staticGasCost (LOG .log4) = 375 := rfl
 
 theorem staticGasCost_ofCallKind (kind : CallArgs.Kind) :
     staticGasCost (ofCallKind kind) = 700 := by
@@ -472,18 +428,6 @@ theorem staticGasCost_ofCallKind (kind : CallArgs.Kind) :
 theorem staticGasCost_ofCreateKind (kind : CreateKind) :
     staticGasCost (ofCreateKind kind) = 32000 := by
   cases kind <;> rfl
-
-theorem staticGasCost_returnBase : staticGasCost RETURN = 0 := rfl
-
-theorem staticGasCost_revertBase : staticGasCost REVERT = 0 := rfl
-
-theorem staticGasCost_selfdestructBase : staticGasCost SELFDESTRUCT = 5000 := rfl
-
-theorem staticGasCost_invalidBase : staticGasCost INVALID = 0 := rfl
-
-theorem staticGasCost_expBase : staticGasCost EXP = 10 := rfl
-
-theorem staticGasCost_keccak256Base : staticGasCost KECCAK256 = 30 := rfl
 
 end EvmOpcode
 


### PR DESCRIPTION
## Summary
- Delete 28 dead single-line `rfl` theorems from `Evm64/Gas.lean` (zero callers): `byte?_*` instances for PUSH0/STOP/RETURN/REVERT/SELFDESTRUCT/INVALID/ADDRESS/BASEFEE/KECCAK256/LOG0/LOG4, and `staticGasCost_*` instances for stop/push0/msize/calldataLoad/calldataSize/calldataCopyBase/address/basefee/selfbalance/log0Base/log4Base/returnBase/revertBase/selfdestructBase/invalidBase/expBase/keccak256Base
- Delete 1 dead helper `exp_squaring_call_block_code_marshal_pair_sub` from `Exp/SquaringCall.lean` (zero callers)
- 68 lines removed across 2 files

Refs #61. Bead: evm-asm-sboz.4. Parent: evm-asm-sboz.

## Verification
- `lake build EvmAsm.Evm64.Gas EvmAsm.Evm64.Exp.SquaringCall` ✓ (887 jobs)
- `scripts/check-file-size.sh` ✓ (631 files, all within cap)
- `lake build` (CI)

Authored by @pirapira; implemented by Claude Code