### PR TITLE
chore(Evm64): delete 57 dead Post_unfold simp lemmas (follow-on from PR #4649)

### DIFF
--- a/EvmAsm/Evm64/Add/LimbSpec.lean
+++ b/EvmAsm/Evm64/Add/LimbSpec.lean
@@ -141,14 +141,6 @@ def addLimb0Post (sp : Word) (offA offB : BitVec 12) (aLimb bLimb : Word) : Asse
   (.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ sum) ** (.x6 ↦ᵣ bLimb) ** (.x5 ↦ᵣ carry) **
   ((sp + signExtend12 offA) ↦ₘ aLimb) ** ((sp + signExtend12 offB) ↦ₘ sum)
 
-theorem addLimb0Post_unfold (sp : Word) (offA offB : BitVec 12) (aLimb bLimb : Word) :
-    addLimb0Post sp offA offB aLimb bLimb =
-      (let sum := aLimb + bLimb
-       let carry := if BitVec.ult sum bLimb then (1 : Word) else 0
-       (.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ sum) ** (.x6 ↦ᵣ bLimb) ** (.x5 ↦ᵣ carry) **
-       ((sp + signExtend12 offA) ↦ₘ aLimb) ** ((sp + signExtend12 offB) ↦ₘ sum)) := by
-  delta addLimb0Post; rfl
-
 /-- Code requirement for `add_limb_carry_spec_within`. -/
 abbrev addLimbCarryCode (offA offB : BitVec 12) (base : Word) : CodeReq :=
   CodeReq.union (CodeReq.singleton base (.LD .x7 .x12 offA))
@@ -171,17 +163,6 @@ def addLimbCarryPost (sp : Word) (offA offB : BitVec 12) (aLimb bLimb carryIn : 
   (.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ result) ** (.x6 ↦ᵣ carry2) ** (.x5 ↦ᵣ carryOut) ** (.x11 ↦ᵣ carry1) **
   ((sp + signExtend12 offA) ↦ₘ aLimb) ** ((sp + signExtend12 offB) ↦ₘ result)
 
-theorem addLimbCarryPost_unfold (sp : Word) (offA offB : BitVec 12) (aLimb bLimb carryIn : Word) :
-    addLimbCarryPost sp offA offB aLimb bLimb carryIn =
-      (let psum := aLimb + bLimb
-       let carry1 := if BitVec.ult psum bLimb then (1 : Word) else 0
-       let result := psum + carryIn
-       let carry2 := if BitVec.ult result carryIn then (1 : Word) else 0
-       let carryOut := carry1 ||| carry2
-       (.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ result) ** (.x6 ↦ᵣ carry2) ** (.x5 ↦ᵣ carryOut) ** (.x11 ↦ᵣ carry1) **
-       ((sp + signExtend12 offA) ↦ₘ aLimb) ** ((sp + signExtend12 offB) ↦ₘ result)) := by
-  delta addLimbCarryPost; rfl
-
 /-- Bundled postcondition for `add_limb_carry_spec_phase1_within`. -/
 @[irreducible]
 def addLimbCarryPhase1Post (sp : Word) (offA offB : BitVec 12) (aLimb bLimb : Word) : Assertion :=
@@ -189,14 +170,6 @@ def addLimbCarryPhase1Post (sp : Word) (offA offB : BitVec 12) (aLimb bLimb : Wo
   let carry1 := if BitVec.ult psum bLimb then (1 : Word) else 0
   (.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ psum) ** (.x6 ↦ᵣ bLimb) ** (.x11 ↦ᵣ carry1) **
   ((sp + signExtend12 offA) ↦ₘ aLimb) ** ((sp + signExtend12 offB) ↦ₘ bLimb)
-
-theorem addLimbCarryPhase1Post_unfold (sp : Word) (offA offB : BitVec 12) (aLimb bLimb : Word) :
-    addLimbCarryPhase1Post sp offA offB aLimb bLimb =
-      (let psum := aLimb + bLimb
-       let carry1 := if BitVec.ult psum bLimb then (1 : Word) else 0
-       (.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ psum) ** (.x6 ↦ᵣ bLimb) ** (.x11 ↦ᵣ carry1) **
-       ((sp + signExtend12 offA) ↦ₘ aLimb) ** ((sp + signExtend12 offB) ↦ₘ bLimb)) := by
-  delta addLimbCarryPhase1Post; rfl
 
 /-- Bundled postcondition for `add_limb_carry_spec_phase2_within`. -/
 @[irreducible]
@@ -206,14 +179,5 @@ def addLimbCarryPhase2Post (sp : Word) (offB : BitVec 12) (psum carryIn carry1 a
   let carryOut := carry1 ||| carry2
   (.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ result) ** (.x6 ↦ᵣ carry2) ** (.x5 ↦ᵣ carryOut) ** (.x11 ↦ᵣ carry1) **
   (memA ↦ₘ aLimb) ** ((sp + signExtend12 offB) ↦ₘ result)
-
-theorem addLimbCarryPhase2Post_unfold (sp : Word) (offB : BitVec 12) (psum carryIn carry1 aLimb : Word) (memA : Word) :
-    addLimbCarryPhase2Post sp offB psum carryIn carry1 aLimb memA =
-      (let result := psum + carryIn
-       let carry2 := if BitVec.ult result carryIn then (1 : Word) else 0
-       let carryOut := carry1 ||| carry2
-       (.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ result) ** (.x6 ↦ᵣ carry2) ** (.x5 ↦ᵣ carryOut) ** (.x11 ↦ᵣ carry1) **
-       (memA ↦ₘ aLimb) ** ((sp + signExtend12 offB) ↦ₘ result)) := by
-  delta addLimbCarryPhase2Post; rfl
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Add/Spec.lean
+++ b/EvmAsm/Evm64/Add/Spec.lean
@@ -149,30 +149,6 @@ def evmAddLimbPost (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
   (sp ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
   ((sp + 32) ↦ₘ sum0) ** ((sp + 40) ↦ₘ result1) ** ((sp + 48) ↦ₘ result2) ** ((sp + 56) ↦ₘ result3)
 
-theorem evmAddLimbPost_unfold (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
-    evmAddLimbPost sp a0 a1 a2 a3 b0 b1 b2 b3 =
-      (let sum0 := a0 + b0
-       let carry0 := if BitVec.ult sum0 b0 then (1 : Word) else 0
-       let psum1 := a1 + b1
-       let carry1a := if BitVec.ult psum1 b1 then (1 : Word) else 0
-       let result1 := psum1 + carry0
-       let carry1b := if BitVec.ult result1 carry0 then (1 : Word) else 0
-       let carry1 := carry1a ||| carry1b
-       let psum2 := a2 + b2
-       let carry2a := if BitVec.ult psum2 b2 then (1 : Word) else 0
-       let result2 := psum2 + carry1
-       let carry2b := if BitVec.ult result2 carry1 then (1 : Word) else 0
-       let carry2 := carry2a ||| carry2b
-       let psum3 := a3 + b3
-       let carry3a := if BitVec.ult psum3 b3 then (1 : Word) else 0
-       let result3 := psum3 + carry2
-       let carry3b := if BitVec.ult result3 carry2 then (1 : Word) else 0
-       let carry3 := carry3a ||| carry3b
-       (.x12 ↦ᵣ (sp + 32)) ** (.x7 ↦ᵣ result3) ** (.x6 ↦ᵣ carry3b) ** (.x5 ↦ᵣ carry3) ** (.x11 ↦ᵣ carry3a) **
-       (sp ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
-       ((sp + 32) ↦ₘ sum0) ** ((sp + 40) ↦ₘ result1) ** ((sp + 48) ↦ₘ result2) ** ((sp + 56) ↦ₘ result3)) := by
-  delta evmAddLimbPost; rfl
-
 /-- Bundled postcondition for `evm_add_stack_spec_within` (EvmWord level).
     Hides all 22 limb-extraction and carry-chain lets. -/
 @[irreducible]
@@ -201,33 +177,5 @@ def evmAddStackPost (sp : Word) (a b : EvmWord) : Assertion :=
   (.x12 ↦ᵣ (sp + 32)) ** (.x7 ↦ᵣ result3) ** (.x6 ↦ᵣ carry3b) **
   (.x5 ↦ᵣ carry3) ** (.x11 ↦ᵣ carry3a) **
   evmWordIs sp a ** evmWordIs (sp + 32) (a + b)
-
-theorem evmAddStackPost_unfold (sp : Word) (a b : EvmWord) :
-    evmAddStackPost sp a b =
-      (let a0 := a.getLimbN 0; let b0 := b.getLimbN 0
-       let a1 := a.getLimbN 1; let b1 := b.getLimbN 1
-       let a2 := a.getLimbN 2; let b2 := b.getLimbN 2
-       let a3 := a.getLimbN 3; let b3 := b.getLimbN 3
-       let sum0 := a0 + b0
-       let carry0 := if BitVec.ult sum0 b0 then (1 : Word) else 0
-       let psum1 := a1 + b1
-       let carry1a := if BitVec.ult psum1 b1 then (1 : Word) else 0
-       let result1 := psum1 + carry0
-       let carry1b := if BitVec.ult result1 carry0 then (1 : Word) else 0
-       let carry1 := carry1a ||| carry1b
-       let psum2 := a2 + b2
-       let carry2a := if BitVec.ult psum2 b2 then (1 : Word) else 0
-       let result2 := psum2 + carry1
-       let carry2b := if BitVec.ult result2 carry1 then (1 : Word) else 0
-       let carry2 := carry2a ||| carry2b
-       let psum3 := a3 + b3
-       let carry3a := if BitVec.ult psum3 b3 then (1 : Word) else 0
-       let result3 := psum3 + carry2
-       let carry3b := if BitVec.ult result3 carry2 then (1 : Word) else 0
-       let carry3 := carry3a ||| carry3b
-       (.x12 ↦ᵣ (sp + 32)) ** (.x7 ↦ᵣ result3) ** (.x6 ↦ᵣ carry3b) **
-       (.x5 ↦ᵣ carry3) ** (.x11 ↦ᵣ carry3a) **
-       evmWordIs sp a ** evmWordIs (sp + 32) (a + b)) := by
-  delta evmAddStackPost; rfl
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/AddMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/AddMod/Compose/Base.lean
@@ -417,33 +417,6 @@ def evmAddModPhase1LimbPost (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
   ((sp + 32) ↦ₘ sum0) ** ((sp + 40) ↦ₘ result1) **
   ((sp + 48) ↦ₘ result2) ** ((sp + 56) ↦ₘ result3)
 
-theorem evmAddModPhase1LimbPost_unfold (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
-    evmAddModPhase1LimbPost sp a0 a1 a2 a3 b0 b1 b2 b3 =
-      (let sum0 := a0 + b0
-       let carry0 := if BitVec.ult sum0 b0 then (1 : Word) else 0
-       let psum1 := a1 + b1
-       let carry1a := if BitVec.ult psum1 b1 then (1 : Word) else 0
-       let result1 := psum1 + carry0
-       let carry1b := if BitVec.ult result1 carry0 then (1 : Word) else 0
-       let carry1 := carry1a ||| carry1b
-       let psum2 := a2 + b2
-       let carry2a := if BitVec.ult psum2 b2 then (1 : Word) else 0
-       let result2 := psum2 + carry1
-       let carry2b := if BitVec.ult result2 carry1 then (1 : Word) else 0
-       let carry2 := carry2a ||| carry2b
-       let psum3 := a3 + b3
-       let carry3a := if BitVec.ult psum3 b3 then (1 : Word) else 0
-       let result3 := psum3 + carry2
-       let carry3b := if BitVec.ult result3 carry2 then (1 : Word) else 0
-       let carry3 := carry3a ||| carry3b
-       (.x12 ↦ᵣ (sp + 32)) **
-       (.x7 ↦ᵣ (carry3 + signExtend12 (0 : BitVec 12))) **
-       (.x6 ↦ᵣ carry3b) ** (.x5 ↦ᵣ carry3) ** (.x11 ↦ᵣ carry3a) **
-       (sp ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
-       ((sp + 32) ↦ₘ sum0) ** ((sp + 40) ↦ₘ result1) **
-       ((sp + 48) ↦ₘ result2) ** ((sp + 56) ↦ₘ result3)) := by
-  delta evmAddModPhase1LimbPost; rfl
-
 @[irreducible]
 def evmAddModPhase1Phase2LimbPost (base sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
   let sum0 := a0 + b0

--- a/EvmAsm/Evm64/AddMod/LimbSpec.lean
+++ b/EvmAsm/Evm64/AddMod/LimbSpec.lean
@@ -96,32 +96,6 @@ def evmAddModPrologueLimbPost (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
   ((sp + 32) ↦ₘ sum0) ** ((sp + 40) ↦ₘ result1) ** ((sp + 48) ↦ₘ result2) **
   ((sp + 56) ↦ₘ result3)
 
-theorem evmAddModPrologueLimbPost_unfold (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
-    evmAddModPrologueLimbPost sp a0 a1 a2 a3 b0 b1 b2 b3 =
-      (let sum0 := a0 + b0
-       let carry0 := if BitVec.ult sum0 b0 then (1 : Word) else 0
-       let psum1 := a1 + b1
-       let carry1a := if BitVec.ult psum1 b1 then (1 : Word) else 0
-       let result1 := psum1 + carry0
-       let carry1b := if BitVec.ult result1 carry0 then (1 : Word) else 0
-       let carry1 := carry1a ||| carry1b
-       let psum2 := a2 + b2
-       let carry2a := if BitVec.ult psum2 b2 then (1 : Word) else 0
-       let result2 := psum2 + carry1
-       let carry2b := if BitVec.ult result2 carry1 then (1 : Word) else 0
-       let carry2 := carry2a ||| carry2b
-       let psum3 := a3 + b3
-       let carry3a := if BitVec.ult psum3 b3 then (1 : Word) else 0
-       let result3 := psum3 + carry2
-       let carry3b := if BitVec.ult result3 carry2 then (1 : Word) else 0
-       let carry3 := carry3a ||| carry3b
-       (.x12 ↦ᵣ (sp + 32)) ** (.x7 ↦ᵣ result3) ** (.x6 ↦ᵣ carry3b) **
-       (.x5 ↦ᵣ carry3) ** (.x11 ↦ᵣ carry3a) **
-       (sp ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
-       ((sp + 32) ↦ₘ sum0) ** ((sp + 40) ↦ₘ result1) ** ((sp + 48) ↦ₘ result2) **
-       ((sp + 56) ↦ₘ result3)) := by
-  delta evmAddModPrologueLimbPost; rfl
-
 /-- Stack-level prologue spec on `evmWordIs` surface: thin lift of
     `evm_add_stack_spec_within`. -/
 theorem evm_addmod_prologue_stack_spec_within (sp base : Word)
@@ -185,34 +159,6 @@ def evmAddModPrologueStackPost (sp : Word) (a b : EvmWord) : Assertion :=
   (.x12 ↦ᵣ (sp + 32)) ** (.x7 ↦ᵣ result3) ** (.x6 ↦ᵣ carry3b) **
   (.x5 ↦ᵣ carry3) ** (.x11 ↦ᵣ carry3a) **
   evmWordIs sp a ** evmWordIs (sp + 32) (a + b)
-
-theorem evmAddModPrologueStackPost_unfold (sp : Word) (a b : EvmWord) :
-    evmAddModPrologueStackPost sp a b =
-      (let a0 := a.getLimbN 0; let b0 := b.getLimbN 0
-       let a1 := a.getLimbN 1; let b1 := b.getLimbN 1
-       let a2 := a.getLimbN 2; let b2 := b.getLimbN 2
-       let a3 := a.getLimbN 3; let b3 := b.getLimbN 3
-       let sum0 := a0 + b0
-       let carry0 := if BitVec.ult sum0 b0 then (1 : Word) else 0
-       let psum1 := a1 + b1
-       let carry1a := if BitVec.ult psum1 b1 then (1 : Word) else 0
-       let result1 := psum1 + carry0
-       let carry1b := if BitVec.ult result1 carry0 then (1 : Word) else 0
-       let carry1 := carry1a ||| carry1b
-       let psum2 := a2 + b2
-       let carry2a := if BitVec.ult psum2 b2 then (1 : Word) else 0
-       let result2 := psum2 + carry1
-       let carry2b := if BitVec.ult result2 carry1 then (1 : Word) else 0
-       let carry2 := carry2a ||| carry2b
-       let psum3 := a3 + b3
-       let carry3a := if BitVec.ult psum3 b3 then (1 : Word) else 0
-       let result3 := psum3 + carry2
-       let carry3b := if BitVec.ult result3 carry2 then (1 : Word) else 0
-       let carry3 := carry3a ||| carry3b
-       (.x12 ↦ᵣ (sp + 32)) ** (.x7 ↦ᵣ result3) ** (.x6 ↦ᵣ carry3b) **
-       (.x5 ↦ᵣ carry3) ** (.x11 ↦ᵣ carry3a) **
-       evmWordIs sp a ** evmWordIs (sp + 32) (a + b)) := by
-  delta evmAddModPrologueStackPost; rfl
 
 -- ============================================================================
 -- evm_addmod_epilogue (1 instruction, slice evm-asm-hsybl toward evm-asm-s7v49)

--- a/EvmAsm/Evm64/Compare/LimbSpec.lean
+++ b/EvmAsm/Evm64/Compare/LimbSpec.lean
@@ -167,13 +167,6 @@ def ltLimb0Post (sp : Word) (offA offB : BitVec 12) (aLimb bLimb : Word) : Asser
   (.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ aLimb) ** (.x6 ↦ᵣ bLimb) ** (.x5 ↦ᵣ borrow) **
   ((sp + signExtend12 offA) ↦ₘ aLimb) ** ((sp + signExtend12 offB) ↦ₘ bLimb)
 
-theorem ltLimb0Post_unfold (sp : Word) (offA offB : BitVec 12) (aLimb bLimb : Word) :
-    ltLimb0Post sp offA offB aLimb bLimb =
-      (let borrow := if BitVec.ult aLimb bLimb then (1 : Word) else 0
-       (.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ aLimb) ** (.x6 ↦ᵣ bLimb) ** (.x5 ↦ᵣ borrow) **
-       ((sp + signExtend12 offA) ↦ₘ aLimb) ** ((sp + signExtend12 offB) ↦ₘ bLimb)) := by
-  delta ltLimb0Post; rfl
-
 /-- Code requirement for `lt_limb_carry_spec_within`. -/
 abbrev ltLimbCarryCode (offA offB : BitVec 12) (base : Word) : CodeReq :=
   CodeReq.union (CodeReq.singleton base (.LD .x7 .x12 offA))
@@ -192,15 +185,5 @@ def ltLimbCarryPost (sp : Word) (offA offB : BitVec 12) (aLimb bLimb borrowIn : 
   let borrowOut := borrow1 ||| borrow2
   (.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ temp) ** (.x6 ↦ᵣ borrow2) ** (.x5 ↦ᵣ borrowOut) ** (.x11 ↦ᵣ borrow1) **
   ((sp + signExtend12 offA) ↦ₘ aLimb) ** ((sp + signExtend12 offB) ↦ₘ bLimb)
-
-theorem ltLimbCarryPost_unfold (sp : Word) (offA offB : BitVec 12) (aLimb bLimb borrowIn : Word) :
-    ltLimbCarryPost sp offA offB aLimb bLimb borrowIn =
-      (let borrow1 := if BitVec.ult aLimb bLimb then (1 : Word) else 0
-       let temp := aLimb - bLimb
-       let borrow2 := if BitVec.ult temp borrowIn then (1 : Word) else 0
-       let borrowOut := borrow1 ||| borrow2
-       (.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ temp) ** (.x6 ↦ᵣ borrow2) ** (.x5 ↦ᵣ borrowOut) ** (.x11 ↦ᵣ borrow1) **
-       ((sp + signExtend12 offA) ↦ₘ aLimb) ** ((sp + signExtend12 offB) ↦ₘ bLimb)) := by
-  delta ltLimbCarryPost; rfl
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LoopBody/MulsubFull.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody/MulsubFull.lean
@@ -48,37 +48,4 @@ def mulsubFullPost (sp uBase qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
   ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3) **
   ((uBase + signExtend12 4064) ↦ₘ u4_new)
 
-theorem mulsubFullPost_unfold {sp uBase qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word} :
-    mulsubFullPost sp uBase qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop =
-      (let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
-       let fs0 := p0_lo + (signExtend12 0 : Word)
-       let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
-       let pc0 := ba0 + p0_hi; let bs0 := if BitVec.ult u0 fs0 then (1 : Word) else 0
-       let un0 := u0 - fs0; let c0 := pc0 + bs0
-       let p1_lo := qHat * v1; let p1_hi := rv64_mulhu qHat v1
-       let fs1 := p1_lo + c0; let ba1 := if BitVec.ult fs1 c0 then (1 : Word) else 0
-       let pc1 := ba1 + p1_hi; let bs1 := if BitVec.ult u1 fs1 then (1 : Word) else 0
-       let un1 := u1 - fs1; let c1 := pc1 + bs1
-       let p2_lo := qHat * v2; let p2_hi := rv64_mulhu qHat v2
-       let fs2 := p2_lo + c1; let ba2 := if BitVec.ult fs2 c1 then (1 : Word) else 0
-       let pc2 := ba2 + p2_hi; let bs2 := if BitVec.ult u2 fs2 then (1 : Word) else 0
-       let un2 := u2 - fs2; let c2 := pc2 + bs2
-       let p3_lo := qHat * v3; let p3_hi := rv64_mulhu qHat v3
-       let fs3 := p3_lo + c2; let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
-       let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
-       let un3 := u3 - fs3; let c3 := pc3 + bs3
-       let borrow := if BitVec.ult uTop c3 then (1 : Word) else 0
-       let u4_new := uTop - c3
-       (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
-       (.x1 ↦ᵣ j) ** (.x5 ↦ᵣ u4_new) ** (.x6 ↦ᵣ uBase) **
-       (.x7 ↦ᵣ borrow) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
-       (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ j) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3) **
-       ((uBase + signExtend12 4064) ↦ₘ u4_new)) := by
-  delta mulsubFullPost; rfl
-
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Eq/LimbSpec.lean
+++ b/EvmAsm/Evm64/Eq/LimbSpec.lean
@@ -75,11 +75,4 @@ def eqOrLimbPost (sp : Word) (offA offB : BitVec 12) (aLimb bLimb acc : Word) : 
   (.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ (acc ||| xorK)) ** (.x6 ↦ᵣ xorK) ** (.x5 ↦ᵣ bLimb) **
   ((sp + signExtend12 offA) ↦ₘ aLimb) ** ((sp + signExtend12 offB) ↦ₘ bLimb)
 
-theorem eqOrLimbPost_unfold (sp : Word) (offA offB : BitVec 12) (aLimb bLimb acc : Word) :
-    eqOrLimbPost sp offA offB aLimb bLimb acc =
-      (let xorK := aLimb ^^^ bLimb
-       (.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ (acc ||| xorK)) ** (.x6 ↦ᵣ xorK) ** (.x5 ↦ᵣ bLimb) **
-       ((sp + signExtend12 offA) ↦ₘ aLimb) ** ((sp + signExtend12 offB) ↦ₘ bLimb)) := by
-  delta eqOrLimbPost; rfl
-
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Eq/Spec.lean
+++ b/EvmAsm/Evm64/Eq/Spec.lean
@@ -131,19 +131,6 @@ def evmEqLimbPost (sp v11 a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
   (sp ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
   ((sp + 32) ↦ₘ eqResult) ** ((sp + 40) ↦ₘ 0) ** ((sp + 48) ↦ₘ 0) ** ((sp + 56) ↦ₘ 0)
 
-theorem evmEqLimbPost_unfold (sp v11 a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
-    evmEqLimbPost sp v11 a0 a1 a2 a3 b0 b1 b2 b3 =
-      (let acc0 := a0 ^^^ b0
-       let acc1 := acc0 ||| (a1 ^^^ b1)
-       let acc2 := acc1 ||| (a2 ^^^ b2)
-       let acc3 := acc2 ||| (a3 ^^^ b3)
-       let eqResult := if BitVec.ult acc3 (1 : Word) then (1 : Word) else 0
-       (.x12 ↦ᵣ (sp + 32)) **
-       (.x7 ↦ᵣ eqResult) ** (.x6 ↦ᵣ (a3 ^^^ b3)) ** (.x5 ↦ᵣ b3) ** (.x11 ↦ᵣ v11) **
-       (sp ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
-       ((sp + 32) ↦ₘ eqResult) ** ((sp + 40) ↦ₘ 0) ** ((sp + 48) ↦ₘ 0) ** ((sp + 56) ↦ₘ 0)) := by
-  delta evmEqLimbPost; rfl
-
 /-- Bundled postcondition for `evm_eq_stack_spec_within` (EvmWord level).
     Hides 5 XOR-OR accumulation lets; `v11` param preserves unchanged .x11. -/
 @[irreducible]
@@ -157,18 +144,5 @@ def evmEqStackPost (sp v11 : Word) (a b : EvmWord) : Assertion :=
   (.x7 ↦ᵣ eqResult) ** (.x6 ↦ᵣ (a.getLimbN 3 ^^^ b.getLimbN 3)) **
   (.x5 ↦ᵣ b.getLimbN 3) ** (.x11 ↦ᵣ v11) **
   evmWordIs sp a ** evmWordIs (sp + 32) (if a = b then 1 else 0)
-
-theorem evmEqStackPost_unfold (sp v11 : Word) (a b : EvmWord) :
-    evmEqStackPost sp v11 a b =
-      (let acc0 := a.getLimbN 0 ^^^ b.getLimbN 0
-       let acc1 := acc0 ||| (a.getLimbN 1 ^^^ b.getLimbN 1)
-       let acc2 := acc1 ||| (a.getLimbN 2 ^^^ b.getLimbN 2)
-       let acc3 := acc2 ||| (a.getLimbN 3 ^^^ b.getLimbN 3)
-       let eqResult := if BitVec.ult acc3 (1 : Word) then (1 : Word) else 0
-       (.x12 ↦ᵣ (sp + 32)) **
-       (.x7 ↦ᵣ eqResult) ** (.x6 ↦ᵣ (a.getLimbN 3 ^^^ b.getLimbN 3)) **
-       (.x5 ↦ᵣ b.getLimbN 3) ** (.x11 ↦ᵣ v11) **
-       evmWordIs sp a ** evmWordIs (sp + 32) (if a = b then 1 else 0)) := by
-  delta evmEqStackPost; rfl
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Gt/Spec.lean
+++ b/EvmAsm/Evm64/Gt/Spec.lean
@@ -97,27 +97,6 @@ def evmGtLimbPost (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
   (sp ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
   ((sp + 32) ↦ₘ borrow3) ** ((sp + 40) ↦ₘ 0) ** ((sp + 48) ↦ₘ 0) ** ((sp + 56) ↦ₘ 0)
 
-theorem evmGtLimbPost_unfold (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
-    evmGtLimbPost sp a0 a1 a2 a3 b0 b1 b2 b3 =
-      (let borrow0 := if BitVec.ult b0 a0 then (1 : Word) else 0
-       let borrow1a := if BitVec.ult b1 a1 then (1 : Word) else 0
-       let temp1 := b1 - a1
-       let borrow1b := if BitVec.ult temp1 borrow0 then (1 : Word) else 0
-       let borrow1 := borrow1a ||| borrow1b
-       let borrow2a := if BitVec.ult b2 a2 then (1 : Word) else 0
-       let temp2 := b2 - a2
-       let borrow2b := if BitVec.ult temp2 borrow1 then (1 : Word) else 0
-       let borrow2 := borrow2a ||| borrow2b
-       let borrow3a := if BitVec.ult b3 a3 then (1 : Word) else 0
-       let temp3 := b3 - a3
-       let borrow3b := if BitVec.ult temp3 borrow2 then (1 : Word) else 0
-       let borrow3 := borrow3a ||| borrow3b
-       (.x12 ↦ᵣ (sp + 32)) ** (.x7 ↦ᵣ temp3) ** (.x6 ↦ᵣ borrow3b) **
-       (.x5 ↦ᵣ borrow3) ** (.x11 ↦ᵣ borrow3a) **
-       (sp ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
-       ((sp + 32) ↦ₘ borrow3) ** ((sp + 40) ↦ₘ 0) ** ((sp + 48) ↦ₘ 0) ** ((sp + 56) ↦ₘ 0)) := by
-  delta evmGtLimbPost; rfl
-
 -- ============================================================================
 
 /-- Stack-level 256-bit EVM GT: operates on two EvmWords via evmWordIs.
@@ -190,25 +169,5 @@ def evmGtStackPost (sp : Word) (a b : EvmWord) : Assertion :=
   (.x12 ↦ᵣ (sp + 32)) ** (.x7 ↦ᵣ temp3) ** (.x6 ↦ᵣ borrow3b) **
   (.x5 ↦ᵣ borrow3) ** (.x11 ↦ᵣ borrow3a) **
   evmWordIs sp a ** evmWordIs (sp + 32) (if BitVec.ult b a then 1 else 0)
-
-theorem evmGtStackPost_unfold (sp : Word) (a b : EvmWord) :
-    evmGtStackPost sp a b =
-      (let borrow0 := if BitVec.ult (b.getLimbN 0) (a.getLimbN 0) then (1 : Word) else 0
-       let borrow1a := if BitVec.ult (b.getLimbN 1) (a.getLimbN 1) then (1 : Word) else 0
-       let temp1 := b.getLimbN 1 - a.getLimbN 1
-       let borrow1b := if BitVec.ult temp1 borrow0 then (1 : Word) else 0
-       let borrow1 := borrow1a ||| borrow1b
-       let borrow2a := if BitVec.ult (b.getLimbN 2) (a.getLimbN 2) then (1 : Word) else 0
-       let temp2 := b.getLimbN 2 - a.getLimbN 2
-       let borrow2b := if BitVec.ult temp2 borrow1 then (1 : Word) else 0
-       let borrow2 := borrow2a ||| borrow2b
-       let borrow3a := if BitVec.ult (b.getLimbN 3) (a.getLimbN 3) then (1 : Word) else 0
-       let temp3 := b.getLimbN 3 - a.getLimbN 3
-       let borrow3b := if BitVec.ult temp3 borrow2 then (1 : Word) else 0
-       let borrow3 := borrow3a ||| borrow3b
-       (.x12 ↦ᵣ (sp + 32)) ** (.x7 ↦ᵣ temp3) ** (.x6 ↦ᵣ borrow3b) **
-       (.x5 ↦ᵣ borrow3) ** (.x11 ↦ᵣ borrow3a) **
-       evmWordIs sp a ** evmWordIs (sp + 32) (if BitVec.ult b a then 1 else 0)) := by
-  delta evmGtStackPost; rfl
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/IsZero/Spec.lean
+++ b/EvmAsm/Evm64/IsZero/Spec.lean
@@ -103,14 +103,6 @@ def evmIsZeroPost (sp a0 a1 a2 a3 : Word) : Assertion :=
   (.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ result) ** (.x6 ↦ᵣ a3) **
   (sp ↦ₘ result) ** ((sp + 8) ↦ₘ 0) ** ((sp + 16) ↦ₘ 0) ** ((sp + 24) ↦ₘ 0)
 
-theorem evmIsZeroPost_unfold (sp a0 a1 a2 a3 : Word) :
-    evmIsZeroPost sp a0 a1 a2 a3 =
-      (let orAll := a0 ||| a1 ||| a2 ||| a3
-       let result := if BitVec.ult orAll (1 : Word) then (1 : Word) else 0
-       (.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ result) ** (.x6 ↦ᵣ a3) **
-       (sp ↦ₘ result) ** ((sp + 8) ↦ₘ 0) ** ((sp + 16) ↦ₘ 0) ** ((sp + 24) ↦ₘ 0)) := by
-  delta evmIsZeroPost; rfl
-
 /-- Bundled postcondition for `evm_iszero_stack_spec_within` (EvmWord level). -/
 @[irreducible]
 def evmIsZeroStackPost (sp : Word) (a : EvmWord) : Assertion :=
@@ -118,13 +110,5 @@ def evmIsZeroStackPost (sp : Word) (a : EvmWord) : Assertion :=
   let result := if BitVec.ult orAll 1 then (1 : Word) else 0
   (.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ result) ** (.x6 ↦ᵣ a.getLimbN 3) **
   evmWordIs sp (if a = 0 then 1 else 0)
-
-theorem evmIsZeroStackPost_unfold (sp : Word) (a : EvmWord) :
-    evmIsZeroStackPost sp a =
-      (let orAll := a.getLimbN 0 ||| a.getLimbN 1 ||| a.getLimbN 2 ||| a.getLimbN 3
-       let result := if BitVec.ult orAll 1 then (1 : Word) else 0
-       (.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ result) ** (.x6 ↦ᵣ a.getLimbN 3) **
-       evmWordIs sp (if a = 0 then 1 else 0)) := by
-  delta evmIsZeroStackPost; rfl
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Lt/Spec.lean
+++ b/EvmAsm/Evm64/Lt/Spec.lean
@@ -149,27 +149,6 @@ def evmLtLimbPost (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
   (sp ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
   ((sp + 32) ↦ₘ borrow3) ** ((sp + 40) ↦ₘ 0) ** ((sp + 48) ↦ₘ 0) ** ((sp + 56) ↦ₘ 0)
 
-theorem evmLtLimbPost_unfold (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
-    evmLtLimbPost sp a0 a1 a2 a3 b0 b1 b2 b3 =
-      (let borrow0 := if BitVec.ult a0 b0 then (1 : Word) else 0
-       let borrow1a := if BitVec.ult a1 b1 then (1 : Word) else 0
-       let temp1 := a1 - b1
-       let borrow1b := if BitVec.ult temp1 borrow0 then (1 : Word) else 0
-       let borrow1 := borrow1a ||| borrow1b
-       let borrow2a := if BitVec.ult a2 b2 then (1 : Word) else 0
-       let temp2 := a2 - b2
-       let borrow2b := if BitVec.ult temp2 borrow1 then (1 : Word) else 0
-       let borrow2 := borrow2a ||| borrow2b
-       let borrow3a := if BitVec.ult a3 b3 then (1 : Word) else 0
-       let temp3 := a3 - b3
-       let borrow3b := if BitVec.ult temp3 borrow2 then (1 : Word) else 0
-       let borrow3 := borrow3a ||| borrow3b
-       (.x12 ↦ᵣ (sp + 32)) ** (.x7 ↦ᵣ temp3) ** (.x6 ↦ᵣ borrow3b) **
-       (.x5 ↦ᵣ borrow3) ** (.x11 ↦ᵣ borrow3a) **
-       (sp ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
-       ((sp + 32) ↦ₘ borrow3) ** ((sp + 40) ↦ₘ 0) ** ((sp + 48) ↦ₘ 0) ** ((sp + 56) ↦ₘ 0)) := by
-  delta evmLtLimbPost; rfl
-
 /-- Bundled postcondition for `evm_lt_stack_spec_within` (EvmWord level).
     Hides all 18 limb-extraction and borrow-chain lets. -/
 @[irreducible]
@@ -194,29 +173,5 @@ def evmLtStackPost (sp : Word) (a b : EvmWord) : Assertion :=
   (.x12 ↦ᵣ (sp + 32)) ** (.x7 ↦ᵣ temp3) ** (.x6 ↦ᵣ borrow3b) **
   (.x5 ↦ᵣ borrow3) ** (.x11 ↦ᵣ borrow3a) **
   evmWordIs sp a ** evmWordIs (sp + 32) (if BitVec.ult a b then 1 else 0)
-
-theorem evmLtStackPost_unfold (sp : Word) (a b : EvmWord) :
-    evmLtStackPost sp a b =
-      (let a0 := a.getLimbN 0; let b0 := b.getLimbN 0
-       let a1 := a.getLimbN 1; let b1 := b.getLimbN 1
-       let a2 := a.getLimbN 2; let b2 := b.getLimbN 2
-       let a3 := a.getLimbN 3; let b3 := b.getLimbN 3
-       let borrow0 := if BitVec.ult a0 b0 then (1 : Word) else 0
-       let borrow1a := if BitVec.ult a1 b1 then (1 : Word) else 0
-       let temp1 := a1 - b1
-       let borrow1b := if BitVec.ult temp1 borrow0 then (1 : Word) else 0
-       let borrow1 := borrow1a ||| borrow1b
-       let borrow2a := if BitVec.ult a2 b2 then (1 : Word) else 0
-       let temp2 := a2 - b2
-       let borrow2b := if BitVec.ult temp2 borrow1 then (1 : Word) else 0
-       let borrow2 := borrow2a ||| borrow2b
-       let borrow3a := if BitVec.ult a3 b3 then (1 : Word) else 0
-       let temp3 := a3 - b3
-       let borrow3b := if BitVec.ult temp3 borrow2 then (1 : Word) else 0
-       let borrow3 := borrow3a ||| borrow3b
-       (.x12 ↦ᵣ (sp + 32)) ** (.x7 ↦ᵣ temp3) ** (.x6 ↦ᵣ borrow3b) **
-       (.x5 ↦ᵣ borrow3) ** (.x11 ↦ᵣ borrow3a) **
-       evmWordIs sp a ** evmWordIs (sp + 32) (if BitVec.ult a b then 1 else 0)) := by
-  delta evmLtStackPost; rfl
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Multiply/LimbSpec.lean
+++ b/EvmAsm/Evm64/Multiply/LimbSpec.lean
@@ -555,45 +555,6 @@ def evmMulLimbPost (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
   (sp ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ c1_r3p) ** ((sp + 24) ↦ₘ c0_r3p) **
   ((sp + 32) ↦ₘ c0_r0) ** ((sp + 40) ↦ₘ c1_r1) ** ((sp + 48) ↦ₘ c2_r2) ** ((sp + 56) ↦ₘ r3_final)
 
-theorem evmMulLimbPost_unfold (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
-    evmMulLimbPost sp a0 a1 a2 a3 b0 b1 b2 b3 =
-      (let c0_r0 := a0 * b0
-       let c0_hi_a0b0 := rv64_mulhu a0 b0
-       let c0_lo_a1b0 := a1 * b0
-       let c0_hi_a1b0 := rv64_mulhu a1 b0
-       let c0_r1 := c0_hi_a0b0 + c0_lo_a1b0
-       let c0_c1 := if BitVec.ult c0_r1 c0_lo_a1b0 then (1 : Word) else 0
-       let c0_lo_a2b0 := a2 * b0
-       let c0_hi_a2b0 := rv64_mulhu a2 b0
-       let c0_r2 := c0_hi_a1b0 + c0_c1 + c0_lo_a2b0
-       let c0_c2 := if BitVec.ult c0_r2 c0_lo_a2b0 then (1 : Word) else 0
-       let c0_r3p := c0_hi_a2b0 + c0_c2 + a3 * b0
-       let c1_lo := a0 * b1
-       let c1_hi := rv64_mulhu a0 b1
-       let c1_r1 := c0_r1 + c1_lo
-       let c1_c1 := if BitVec.ult c1_r1 c1_lo then (1 : Word) else 0
-       let c1_rc := c1_hi + c1_c1
-       let c1_r2a := c0_r2 + c1_rc
-       let c1_cr1 := if BitVec.ult c1_r2a c1_rc then (1 : Word) else 0
-       let c1_lo2 := a1 * b1
-       let c1_hi2 := rv64_mulhu a1 b1
-       let c1_r2 := c1_r2a + c1_lo2
-       let c1_cr2 := if BitVec.ult c1_r2 c1_lo2 then (1 : Word) else 0
-       let c1_rc2 := c1_hi2 + c1_cr2
-       let c1_r3p := c1_cr1 + c1_rc2 + a2 * b1 + c0_r3p
-       let c2_lo := a0 * b2
-       let c2_hi := rv64_mulhu a0 b2
-       let c2_r2 := c1_r2 + c2_lo
-       let c2_c := if BitVec.ult c2_r2 c2_lo then (1 : Word) else 0
-       let c2_rc := c2_hi + c2_c + a1 * b2
-       let c2_r3 := c1_r3p + c2_rc
-       let r3_final := c2_r3 + a0 * b3
-       (.x12 ↦ᵣ (sp + 32)) ** (.x5 ↦ᵣ b3) ** (.x6 ↦ᵣ a0 * b3) ** (.x7 ↦ᵣ a1 * b2) **
-       (.x10 ↦ᵣ r3_final) ** (.x11 ↦ᵣ c2_r2) **
-       (sp ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ c1_r3p) ** ((sp + 24) ↦ₘ c0_r3p) **
-       ((sp + 32) ↦ₘ c0_r0) ** ((sp + 40) ↦ₘ c1_r1) ** ((sp + 48) ↦ₘ c2_r2) ** ((sp + 56) ↦ₘ r3_final)) := by
-  delta evmMulLimbPost; rfl
-
 /-- Bundled postcondition for `mul_col2_spec_within`. Hides 6 computation lets. -/
 @[irreducible]
 def mulCol2Post (sp a0 a1 b2 r2_in r3p : Word) : Assertion :=
@@ -606,19 +567,6 @@ def mulCol2Post (sp a0 a1 b2 r2_in r3p : Word) : Assertion :=
   (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b2) ** (.x6 ↦ᵣ r3_contrib) ** (.x7 ↦ᵣ a1 * b2) **
   (.x10 ↦ᵣ r3_out) ** (.x11 ↦ᵣ r2_out) **
   (sp ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ r3p) ** ((sp + 48) ↦ₘ r2_out)
-
-theorem mulCol2Post_unfold (sp a0 a1 b2 r2_in r3p : Word) :
-    mulCol2Post sp a0 a1 b2 r2_in r3p =
-      (let lo_a0b2 := a0 * b2
-       let hi_a0b2 := rv64_mulhu a0 b2
-       let r2_out := r2_in + lo_a0b2
-       let carry02 := if BitVec.ult r2_out lo_a0b2 then (1 : Word) else 0
-       let r3_contrib := hi_a0b2 + carry02 + a1 * b2
-       let r3_out := r3p + r3_contrib
-       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b2) ** (.x6 ↦ᵣ r3_contrib) ** (.x7 ↦ᵣ a1 * b2) **
-       (.x10 ↦ᵣ r3_out) ** (.x11 ↦ᵣ r2_out) **
-       (sp ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ r3p) ** ((sp + 48) ↦ₘ r2_out)) := by
-  delta mulCol2Post; rfl
 
 /-- Bundled postcondition for `mul_col1_partA_spec_within`. Hides 7 computation lets. -/
 @[irreducible]
@@ -634,20 +582,6 @@ def mulCol1PartAPost (sp a0 b1 r1_in r2_in : Word) : Assertion :=
   (.x10 ↦ᵣ carry_r2_1) ** (.x11 ↦ᵣ r2_acc1) **
   (sp ↦ₘ a0) ** ((sp + 40) ↦ₘ r1_out)
 
-theorem mulCol1PartAPost_unfold (sp a0 b1 r1_in r2_in : Word) :
-    mulCol1PartAPost sp a0 b1 r1_in r2_in =
-      (let lo_a0b1 := a0 * b1
-       let hi_a0b1 := rv64_mulhu a0 b1
-       let r1_out := r1_in + lo_a0b1
-       let carry01 := if BitVec.ult r1_out lo_a0b1 then (1 : Word) else 0
-       let r2_contrib1 := hi_a0b1 + carry01
-       let r2_acc1 := r2_in + r2_contrib1
-       let carry_r2_1 := if BitVec.ult r2_acc1 r2_contrib1 then (1 : Word) else 0
-       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b1) ** (.x6 ↦ᵣ r2_contrib1) ** (.x7 ↦ᵣ carry01) **
-       (.x10 ↦ᵣ carry_r2_1) ** (.x11 ↦ᵣ r2_acc1) **
-       (sp ↦ₘ a0) ** ((sp + 40) ↦ₘ r1_out)) := by
-  delta mulCol1PartAPost; rfl
-
 /-- Bundled postcondition for `mul_col1_partB_spec_within`. Hides 6 computation lets. -/
 @[irreducible]
 def mulCol1PartBPost (sp a1 a2 b1 r3p0 carry_r2_1 r2_acc1 : Word) : Assertion :=
@@ -660,19 +594,6 @@ def mulCol1PartBPost (sp a1 a2 b1 r3p0 carry_r2_1 r2_acc1 : Word) : Assertion :=
   (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b1) ** (.x6 ↦ᵣ r3p0) ** (.x7 ↦ᵣ carry_r2_2) **
   (.x10 ↦ᵣ r3_spill) ** (.x11 ↦ᵣ r2_out) **
   ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ r3_spill) ** ((sp + 24) ↦ₘ r3p0)
-
-theorem mulCol1PartBPost_unfold (sp a1 a2 b1 r3p0 carry_r2_1 r2_acc1 : Word) :
-    mulCol1PartBPost sp a1 a2 b1 r3p0 carry_r2_1 r2_acc1 =
-      (let lo_a1b1 := a1 * b1
-       let hi_a1b1 := rv64_mulhu a1 b1
-       let r2_out := r2_acc1 + lo_a1b1
-       let carry_r2_2 := if BitVec.ult r2_out lo_a1b1 then (1 : Word) else 0
-       let r3_contrib1 := hi_a1b1 + carry_r2_2
-       let r3_spill := carry_r2_1 + r3_contrib1 + a2 * b1 + r3p0
-       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b1) ** (.x6 ↦ᵣ r3p0) ** (.x7 ↦ᵣ carry_r2_2) **
-       (.x10 ↦ᵣ r3_spill) ** (.x11 ↦ᵣ r2_out) **
-       ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ r3_spill) ** ((sp + 24) ↦ₘ r3p0)) := by
-  delta mulCol1PartBPost; rfl
 
 /-- Bundled postcondition for `mul_col0_partA_spec_within`. Hides 6 computation lets. -/
 @[irreducible]
@@ -687,19 +608,6 @@ def mulCol0PartAPost (sp a0 a1 b0 : Word) : Assertion :=
   (.x10 ↦ᵣ r1_acc) ** (.x11 ↦ᵣ hi_a1b0 + carry_r1) **
   (sp ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 32) ↦ₘ r0)
 
-theorem mulCol0PartAPost_unfold (sp a0 a1 b0 : Word) :
-    mulCol0PartAPost sp a0 a1 b0 =
-      (let r0 := a0 * b0
-       let hi_a0b0 := rv64_mulhu a0 b0
-       let lo_a1b0 := a1 * b0
-       let hi_a1b0 := rv64_mulhu a1 b0
-       let r1_acc := hi_a0b0 + lo_a1b0
-       let carry_r1 := if BitVec.ult r1_acc lo_a1b0 then (1 : Word) else 0
-       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b0) ** (.x6 ↦ᵣ carry_r1) ** (.x7 ↦ᵣ lo_a1b0) **
-       (.x10 ↦ᵣ r1_acc) ** (.x11 ↦ᵣ hi_a1b0 + carry_r1) **
-       (sp ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 32) ↦ₘ r0)) := by
-  delta mulCol0PartAPost; rfl
-
 /-- Bundled postcondition for `mul_col0_partB_spec_within`. Hides 5 computation lets. -/
 @[irreducible]
 def mulCol0PartBPost (sp a2 a3 b0 r2_partial : Word) : Assertion :=
@@ -711,18 +619,6 @@ def mulCol0PartBPost (sp a2 a3 b0 r2_partial : Word) : Assertion :=
   (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b0) ** (.x6 ↦ᵣ r3p) ** (.x7 ↦ᵣ a3 * b0) **
   (.x11 ↦ᵣ r2_acc) **
   ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ r3p)
-
-theorem mulCol0PartBPost_unfold (sp a2 a3 b0 r2_partial : Word) :
-    mulCol0PartBPost sp a2 a3 b0 r2_partial =
-      (let lo_a2b0 := a2 * b0
-       let hi_a2b0 := rv64_mulhu a2 b0
-       let r2_acc := r2_partial + lo_a2b0
-       let carry_r2 := if BitVec.ult r2_acc lo_a2b0 then (1 : Word) else 0
-       let r3p := hi_a2b0 + carry_r2 + a3 * b0
-       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b0) ** (.x6 ↦ᵣ r3p) ** (.x7 ↦ᵣ a3 * b0) **
-       (.x11 ↦ᵣ r2_acc) **
-       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ r3p)) := by
-  delta mulCol0PartBPost; rfl
 
 /-- Bundled postcondition for `evm_mul_cols23ep_spec_within`. Hides 7 computation lets. -/
 @[irreducible]
@@ -738,21 +634,6 @@ def mulCols23epPost (sp a0 a1 b2 b3 r2_in r3p_in : Word) : Assertion :=
   (.x10 ↦ᵣ r3_final) ** (.x11 ↦ᵣ c2_r2) **
   (sp ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ r3p_in) **
   ((sp + 48) ↦ₘ c2_r2) ** ((sp + 56) ↦ₘ r3_final)
-
-theorem mulCols23epPost_unfold (sp a0 a1 b2 b3 r2_in r3p_in : Word) :
-    mulCols23epPost sp a0 a1 b2 b3 r2_in r3p_in =
-      (let c2_lo := a0 * b2
-       let c2_hi := rv64_mulhu a0 b2
-       let c2_r2 := r2_in + c2_lo
-       let c2_c := if BitVec.ult c2_r2 c2_lo then (1 : Word) else 0
-       let c2_rc := c2_hi + c2_c + a1 * b2
-       let c2_r3 := r3p_in + c2_rc
-       let r3_final := c2_r3 + a0 * b3
-       (.x12 ↦ᵣ (sp + 32)) ** (.x5 ↦ᵣ b3) ** (.x6 ↦ᵣ a0 * b3) ** (.x7 ↦ᵣ a1 * b2) **
-       (.x10 ↦ᵣ r3_final) ** (.x11 ↦ᵣ c2_r2) **
-       (sp ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ r3p_in) **
-       ((sp + 48) ↦ₘ c2_r2) ** ((sp + 56) ↦ₘ r3_final)) := by
-  delta mulCols23epPost; rfl
 
 /-- Bundled postcondition for `mul_col0_spec_within`. Hides 11 computation lets. -/
 @[irreducible]
@@ -772,25 +653,6 @@ def mulCol0Post (sp a0 a1 a2 a3 b0 : Word) : Assertion :=
   (.x10 ↦ᵣ r1_acc) ** (.x11 ↦ᵣ r2_acc) **
   (sp ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) **
   ((sp + 24) ↦ₘ r3p) ** ((sp + 32) ↦ₘ r0)
-
-theorem mulCol0Post_unfold (sp a0 a1 a2 a3 b0 : Word) :
-    mulCol0Post sp a0 a1 a2 a3 b0 =
-      (let r0 := a0 * b0
-       let hi_a0b0 := rv64_mulhu a0 b0
-       let lo_a1b0 := a1 * b0
-       let hi_a1b0 := rv64_mulhu a1 b0
-       let r1_acc := hi_a0b0 + lo_a1b0
-       let carry_r1 := if BitVec.ult r1_acc lo_a1b0 then (1 : Word) else 0
-       let lo_a2b0 := a2 * b0
-       let hi_a2b0 := rv64_mulhu a2 b0
-       let r2_acc := hi_a1b0 + carry_r1 + lo_a2b0
-       let carry_r2 := if BitVec.ult r2_acc lo_a2b0 then (1 : Word) else 0
-       let r3p := hi_a2b0 + carry_r2 + a3 * b0
-       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b0) ** (.x6 ↦ᵣ r3p) ** (.x7 ↦ᵣ a3 * b0) **
-       (.x10 ↦ᵣ r1_acc) ** (.x11 ↦ᵣ r2_acc) **
-       (sp ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) **
-       ((sp + 24) ↦ₘ r3p) ** ((sp + 32) ↦ₘ r0)) := by
-  delta mulCol0Post; rfl
 
 /-- Bundled postcondition for `evm_mul_cols01_spec_within`. Hides 24 computation lets. -/
 @[irreducible]
@@ -824,38 +686,6 @@ def mulCols01Post (sp a0 a1 a2 a3 b0 b1 : Word) : Assertion :=
   (sp ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ c1_r3p) **
   ((sp + 24) ↦ₘ c0_r3p) ** ((sp + 32) ↦ₘ c0_r0) ** ((sp + 40) ↦ₘ c1_r1)
 
-theorem mulCols01Post_unfold (sp a0 a1 a2 a3 b0 b1 : Word) :
-    mulCols01Post sp a0 a1 a2 a3 b0 b1 =
-      (let c0_r0 := a0 * b0
-       let c0_hi_a0b0 := rv64_mulhu a0 b0
-       let c0_lo_a1b0 := a1 * b0
-       let c0_hi_a1b0 := rv64_mulhu a1 b0
-       let c0_r1 := c0_hi_a0b0 + c0_lo_a1b0
-       let c0_c1 := if BitVec.ult c0_r1 c0_lo_a1b0 then (1 : Word) else 0
-       let c0_lo_a2b0 := a2 * b0
-       let c0_hi_a2b0 := rv64_mulhu a2 b0
-       let c0_r2 := c0_hi_a1b0 + c0_c1 + c0_lo_a2b0
-       let c0_c2 := if BitVec.ult c0_r2 c0_lo_a2b0 then (1 : Word) else 0
-       let c0_r3p := c0_hi_a2b0 + c0_c2 + a3 * b0
-       let c1_lo := a0 * b1
-       let c1_hi := rv64_mulhu a0 b1
-       let c1_r1 := c0_r1 + c1_lo
-       let c1_c1 := if BitVec.ult c1_r1 c1_lo then (1 : Word) else 0
-       let c1_rc := c1_hi + c1_c1
-       let c1_r2a := c0_r2 + c1_rc
-       let c1_cr1 := if BitVec.ult c1_r2a c1_rc then (1 : Word) else 0
-       let c1_lo2 := a1 * b1
-       let c1_hi2 := rv64_mulhu a1 b1
-       let c1_r2 := c1_r2a + c1_lo2
-       let c1_cr2 := if BitVec.ult c1_r2 c1_lo2 then (1 : Word) else 0
-       let c1_rc2 := c1_hi2 + c1_cr2
-       let c1_r3p := c1_cr1 + c1_rc2 + a2 * b1 + c0_r3p
-       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b1) ** (.x6 ↦ᵣ c0_r3p) ** (.x7 ↦ᵣ c1_cr2) **
-       (.x10 ↦ᵣ c1_r3p) ** (.x11 ↦ᵣ c1_r2) **
-       (sp ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ c1_r3p) **
-       ((sp + 24) ↦ₘ c0_r3p) ** ((sp + 32) ↦ₘ c0_r0) ** ((sp + 40) ↦ₘ c1_r1)) := by
-  delta mulCols01Post; rfl
-
 /-- Bundled postcondition for `mul_col1_spec_within`. Hides 13 computation lets. -/
 @[irreducible]
 def mulCol1Post (sp a0 a1 a2 b1 r1_in r2_in r3p0 : Word) : Assertion :=
@@ -876,26 +706,5 @@ def mulCol1Post (sp a0 a1 a2 b1 r1_in r2_in r3p0 : Word) : Assertion :=
   (.x10 ↦ᵣ r3_spill) ** (.x11 ↦ᵣ r2_out) **
   (sp ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ r3_spill) **
   ((sp + 24) ↦ₘ r3p0) ** ((sp + 40) ↦ₘ r1_out)
-
-theorem mulCol1Post_unfold (sp a0 a1 a2 b1 r1_in r2_in r3p0 : Word) :
-    mulCol1Post sp a0 a1 a2 b1 r1_in r2_in r3p0 =
-      (let lo_a0b1 := a0 * b1
-       let hi_a0b1 := rv64_mulhu a0 b1
-       let r1_out := r1_in + lo_a0b1
-       let carry01 := if BitVec.ult r1_out lo_a0b1 then (1 : Word) else 0
-       let r2_contrib1 := hi_a0b1 + carry01
-       let r2_acc1 := r2_in + r2_contrib1
-       let carry_r2_1 := if BitVec.ult r2_acc1 r2_contrib1 then (1 : Word) else 0
-       let lo_a1b1 := a1 * b1
-       let hi_a1b1 := rv64_mulhu a1 b1
-       let r2_out := r2_acc1 + lo_a1b1
-       let carry_r2_2 := if BitVec.ult r2_out lo_a1b1 then (1 : Word) else 0
-       let r3_contrib1 := hi_a1b1 + carry_r2_2
-       let r3_spill := carry_r2_1 + r3_contrib1 + a2 * b1 + r3p0
-       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b1) ** (.x6 ↦ᵣ r3p0) ** (.x7 ↦ᵣ carry_r2_2) **
-       (.x10 ↦ᵣ r3_spill) ** (.x11 ↦ᵣ r2_out) **
-       (sp ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ r3_spill) **
-       ((sp + 24) ↦ₘ r3p0) ** ((sp + 40) ↦ₘ r1_out)) := by
-  delta mulCol1Post; rfl
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Sgt/Spec.lean
+++ b/EvmAsm/Evm64/Sgt/Spec.lean
@@ -134,28 +134,6 @@ def evmSgtLimbPost (sp v11 a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
   (sp ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
   ((sp + 32) ↦ₘ result) ** ((sp + 40) ↦ₘ 0) ** ((sp + 48) ↦ₘ 0) ** ((sp + 56) ↦ₘ 0)
 
-theorem evmSgtLimbPost_unfold (sp v11 a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
-    evmSgtLimbPost sp v11 a0 a1 a2 a3 b0 b1 b2 b3 =
-      (let borrow0 := if BitVec.ult b0 a0 then (1 : Word) else 0
-       let borrow1a := if BitVec.ult b1 a1 then (1 : Word) else 0
-       let temp1 := b1 - a1
-       let borrow1b := if BitVec.ult temp1 borrow0 then (1 : Word) else 0
-       let borrow1 := borrow1a ||| borrow1b
-       let borrow2a := if BitVec.ult b2 a2 then (1 : Word) else 0
-       let temp2 := b2 - a2
-       let borrow2b := if BitVec.ult temp2 borrow1 then (1 : Word) else 0
-       let borrow2 := borrow2a ||| borrow2b
-       let sgtMsb := if BitVec.slt b3 a3 then (1 : Word) else 0
-       let result := if b3 = a3 then borrow2 else sgtMsb
-       (.x12 ↦ᵣ (sp + 32)) **
-       (.x7 ↦ᵣ (if b3 = a3 then temp2 else b3)) **
-       (.x6 ↦ᵣ (if b3 = a3 then borrow2b else a3)) **
-       (.x5 ↦ᵣ result) **
-       (.x11 ↦ᵣ (if b3 = a3 then borrow2a else v11)) **
-       (sp ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
-       ((sp + 32) ↦ₘ result) ** ((sp + 40) ↦ₘ 0) ** ((sp + 48) ↦ₘ 0) ** ((sp + 56) ↦ₘ 0)) := by
-  delta evmSgtLimbPost; rfl
-
 -- ============================================================================
 -- Stack-level SGT spec
 -- ============================================================================
@@ -233,26 +211,5 @@ def evmSgtStackPost (sp v11 : Word) (a b : EvmWord) : Assertion :=
   (.x5 ↦ᵣ result) **
   (.x11 ↦ᵣ (if b.getLimbN 3 = a.getLimbN 3 then borrow2a else v11)) **
   evmWordIs sp a ** evmWordIs (sp + 32) (if BitVec.slt b a then 1 else 0)
-
-theorem evmSgtStackPost_unfold (sp v11 : Word) (a b : EvmWord) :
-    evmSgtStackPost sp v11 a b =
-      (let borrow0 := if BitVec.ult (b.getLimbN 0) (a.getLimbN 0) then (1 : Word) else 0
-       let borrow1a := if BitVec.ult (b.getLimbN 1) (a.getLimbN 1) then (1 : Word) else 0
-       let temp1 := b.getLimbN 1 - a.getLimbN 1
-       let borrow1b := if BitVec.ult temp1 borrow0 then (1 : Word) else 0
-       let borrow1 := borrow1a ||| borrow1b
-       let borrow2a := if BitVec.ult (b.getLimbN 2) (a.getLimbN 2) then (1 : Word) else 0
-       let temp2 := b.getLimbN 2 - a.getLimbN 2
-       let borrow2b := if BitVec.ult temp2 borrow1 then (1 : Word) else 0
-       let borrow2 := borrow2a ||| borrow2b
-       let sgtMsb := if BitVec.slt (b.getLimbN 3) (a.getLimbN 3) then (1 : Word) else 0
-       let result := if b.getLimbN 3 = a.getLimbN 3 then borrow2 else sgtMsb
-       (.x12 ↦ᵣ (sp + 32)) **
-       (.x7 ↦ᵣ (if b.getLimbN 3 = a.getLimbN 3 then temp2 else b.getLimbN 3)) **
-       (.x6 ↦ᵣ (if b.getLimbN 3 = a.getLimbN 3 then borrow2b else a.getLimbN 3)) **
-       (.x5 ↦ᵣ result) **
-       (.x11 ↦ᵣ (if b.getLimbN 3 = a.getLimbN 3 then borrow2a else v11)) **
-       evmWordIs sp a ** evmWordIs (sp + 32) (if BitVec.slt b a then 1 else 0)) := by
-  delta evmSgtStackPost; rfl
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Shift/LimbSpec.lean
+++ b/EvmAsm/Evm64/Shift/LimbSpec.lean
@@ -982,18 +982,6 @@ def shrMergeLimbPost (sp : Word) (src_off next_off dst_off : BitVec 12)
   ((sp + signExtend12 src_off) ↦ₘ src) ** ((sp + signExtend12 next_off) ↦ₘ next) **
   ((sp + signExtend12 dst_off) ↦ₘ result)
 
-theorem shrMergeLimbPost_unfold (sp : Word) (src_off next_off dst_off : BitVec 12)
-    (src next bit_shift antiShift mask : Word) :
-    shrMergeLimbPost sp src_off next_off dst_off src next bit_shift antiShift mask =
-      (let shiftedSrc := src >>> (bit_shift.toNat % 64)
-       let shiftedNext := (next <<< (antiShift.toNat % 64)) &&& mask
-       let result := shiftedSrc ||| shiftedNext
-       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x6 ↦ᵣ bit_shift) **
-       (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ shiftedNext) ** (.x11 ↦ᵣ mask) **
-       ((sp + signExtend12 src_off) ↦ₘ src) ** ((sp + signExtend12 next_off) ↦ₘ next) **
-       ((sp + signExtend12 dst_off) ↦ₘ result)) := by
-  delta shrMergeLimbPost; rfl
-
 /-- Bundled postcondition for `shr_merge_limb_inplace_spec_within`. -/
 @[irreducible]
 def shrMergeInplaceLimbPost (sp : Word) (off next_off : BitVec 12)
@@ -1004,17 +992,6 @@ def shrMergeInplaceLimbPost (sp : Word) (off next_off : BitVec 12)
   (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x6 ↦ᵣ bit_shift) **
   (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ shiftedNext) ** (.x11 ↦ᵣ mask) **
   ((sp + signExtend12 off) ↦ₘ result) ** ((sp + signExtend12 next_off) ↦ₘ next)
-
-theorem shrMergeInplaceLimbPost_unfold (sp : Word) (off next_off : BitVec 12)
-    (src next bit_shift antiShift mask : Word) :
-    shrMergeInplaceLimbPost sp off next_off src next bit_shift antiShift mask =
-      (let shiftedSrc := src >>> (bit_shift.toNat % 64)
-       let shiftedNext := (next <<< (antiShift.toNat % 64)) &&& mask
-       let result := shiftedSrc ||| shiftedNext
-       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x6 ↦ᵣ bit_shift) **
-       (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ shiftedNext) ** (.x11 ↦ᵣ mask) **
-       ((sp + signExtend12 off) ↦ₘ result) ** ((sp + signExtend12 next_off) ↦ₘ next)) := by
-  delta shrMergeInplaceLimbPost; rfl
 
 /-- Bundled postcondition for `shr_phase_b_spec_within`. Hides 5 computation lets. -/
 @[irreducible]
@@ -1027,17 +1004,6 @@ def shrPhaseBPost (sp shift0 : Word) : Assertion :=
   (.x5 ↦ᵣ limb_shift) ** (.x6 ↦ᵣ bit_shift) ** (.x0 ↦ᵣ (0 : Word)) **
   (.x11 ↦ᵣ mask) ** (.x7 ↦ᵣ antiShift) ** (.x12 ↦ᵣ (sp + signExtend12 32))
 
-theorem shrPhaseBPost_unfold (sp shift0 : Word) :
-    shrPhaseBPost sp shift0 =
-      (let bit_shift := shift0 &&& signExtend12 63
-       let limb_shift := shift0 >>> (6 : BitVec 6).toNat
-       let cond := if BitVec.ult (0 : Word) bit_shift then (1 : Word) else 0
-       let mask := (0 : Word) - cond
-       let antiShift := (64 : Word) - bit_shift
-       (.x5 ↦ᵣ limb_shift) ** (.x6 ↦ᵣ bit_shift) ** (.x0 ↦ᵣ (0 : Word)) **
-       (.x11 ↦ᵣ mask) ** (.x7 ↦ᵣ antiShift) ** (.x12 ↦ᵣ (sp + signExtend12 32))) := by
-  delta shrPhaseBPost; rfl
-
 /-- Bundled postcondition for `shr_body_0_spec_within`. Hides result0-3. -/
 @[irreducible]
 def shrBody0Post (sp bit_shift antiShift mask v0 v1 v2 v3 : Word) : Assertion :=
@@ -1049,17 +1015,6 @@ def shrBody0Post (sp bit_shift antiShift mask v0 v1 v2 v3 : Word) : Assertion :=
   (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ ((v3 <<< (antiShift.toNat % 64)) &&& mask)) ** (.x11 ↦ᵣ mask) **
   (sp ↦ₘ result0) ** ((sp + 8) ↦ₘ result1) ** ((sp + 16) ↦ₘ result2) ** ((sp + 24) ↦ₘ result3)
 
-theorem shrBody0Post_unfold (sp bit_shift antiShift mask v0 v1 v2 v3 : Word) :
-    shrBody0Post sp bit_shift antiShift mask v0 v1 v2 v3 =
-      (let result0 := (v0 >>> (bit_shift.toNat % 64)) ||| ((v1 <<< (antiShift.toNat % 64)) &&& mask)
-       let result1 := (v1 >>> (bit_shift.toNat % 64)) ||| ((v2 <<< (antiShift.toNat % 64)) &&& mask)
-       let result2 := (v2 >>> (bit_shift.toNat % 64)) ||| ((v3 <<< (antiShift.toNat % 64)) &&& mask)
-       let result3 := v3 >>> (bit_shift.toNat % 64)
-       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result3) ** (.x6 ↦ᵣ bit_shift) **
-       (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ ((v3 <<< (antiShift.toNat % 64)) &&& mask)) ** (.x11 ↦ᵣ mask) **
-       (sp ↦ₘ result0) ** ((sp + 8) ↦ₘ result1) ** ((sp + 16) ↦ₘ result2) ** ((sp + 24) ↦ₘ result3)) := by
-  delta shrBody0Post; rfl
-
 /-- Bundled postcondition for `shr_body_2_spec_within`. -/
 @[irreducible]
 def shrBody2Post (sp bit_shift antiShift mask v2 v3 : Word) : Assertion :=
@@ -1068,15 +1023,6 @@ def shrBody2Post (sp bit_shift antiShift mask v2 v3 : Word) : Assertion :=
   (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result1) ** (.x6 ↦ᵣ bit_shift) **
   (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ ((v3 <<< (antiShift.toNat % 64)) &&& mask)) ** (.x11 ↦ᵣ mask) **
   (sp ↦ₘ result0) ** ((sp + 8) ↦ₘ result1) ** ((sp + 16) ↦ₘ 0) ** ((sp + 24) ↦ₘ 0)
-
-theorem shrBody2Post_unfold (sp bit_shift antiShift mask v2 v3 : Word) :
-    shrBody2Post sp bit_shift antiShift mask v2 v3 =
-      (let result0 := (v2 >>> (bit_shift.toNat % 64)) ||| ((v3 <<< (antiShift.toNat % 64)) &&& mask)
-       let result1 := v3 >>> (bit_shift.toNat % 64)
-       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result1) ** (.x6 ↦ᵣ bit_shift) **
-       (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ ((v3 <<< (antiShift.toNat % 64)) &&& mask)) ** (.x11 ↦ᵣ mask) **
-       (sp ↦ₘ result0) ** ((sp + 8) ↦ₘ result1) ** ((sp + 16) ↦ₘ 0) ** ((sp + 24) ↦ₘ 0)) := by
-  delta shrBody2Post; rfl
 
 /-- Bundled postcondition for `shr_body_1_spec_within`. -/
 @[irreducible]
@@ -1087,15 +1033,5 @@ def shrBody1Post (sp bit_shift antiShift mask v1 v2 v3 : Word) : Assertion :=
   (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result2) ** (.x6 ↦ᵣ bit_shift) **
   (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ ((v3 <<< (antiShift.toNat % 64)) &&& mask)) ** (.x11 ↦ᵣ mask) **
   (sp ↦ₘ result0) ** ((sp + 8) ↦ₘ result1) ** ((sp + 16) ↦ₘ result2) ** ((sp + 24) ↦ₘ 0)
-
-theorem shrBody1Post_unfold (sp bit_shift antiShift mask v1 v2 v3 : Word) :
-    shrBody1Post sp bit_shift antiShift mask v1 v2 v3 =
-      (let result0 := (v1 >>> (bit_shift.toNat % 64)) ||| ((v2 <<< (antiShift.toNat % 64)) &&& mask)
-       let result1 := (v2 >>> (bit_shift.toNat % 64)) ||| ((v3 <<< (antiShift.toNat % 64)) &&& mask)
-       let result2 := v3 >>> (bit_shift.toNat % 64)
-       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result2) ** (.x6 ↦ᵣ bit_shift) **
-       (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ ((v3 <<< (antiShift.toNat % 64)) &&& mask)) ** (.x11 ↦ᵣ mask) **
-       (sp ↦ₘ result0) ** ((sp + 8) ↦ₘ result1) ** ((sp + 16) ↦ₘ result2) ** ((sp + 24) ↦ₘ 0)) := by
-  delta shrBody1Post; rfl
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Shift/SarSpec.lean
+++ b/EvmAsm/Evm64/Shift/SarSpec.lean
@@ -290,17 +290,6 @@ def sarBody1Post (sp bit_shift antiShift mask v1 v2 v3 : Word) : Assertion :=
   (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ signExt) ** (.x11 ↦ᵣ mask) **
   (sp ↦ₘ result0) ** ((sp + 8) ↦ₘ result1) ** ((sp + 16) ↦ₘ result2) ** ((sp + 24) ↦ₘ signExt)
 
-theorem sarBody1Post_unfold (sp bit_shift antiShift mask v1 v2 v3 : Word) :
-    sarBody1Post sp bit_shift antiShift mask v1 v2 v3 =
-      (let result0 := (v1 >>> (bit_shift.toNat % 64)) ||| ((v2 <<< (antiShift.toNat % 64)) &&& mask)
-       let result1 := (v2 >>> (bit_shift.toNat % 64)) ||| ((v3 <<< (antiShift.toNat % 64)) &&& mask)
-       let result2 := BitVec.sshiftRight v3 (bit_shift.toNat % 64)
-       let signExt := BitVec.sshiftRight result2 63
-       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result2) ** (.x6 ↦ᵣ bit_shift) **
-       (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ signExt) ** (.x11 ↦ᵣ mask) **
-       (sp ↦ₘ result0) ** ((sp + 8) ↦ₘ result1) ** ((sp + 16) ↦ₘ result2) ** ((sp + 24) ↦ₘ signExt)) := by
-  delta sarBody1Post; rfl
-
 /-- Bundled postcondition for `sar_body_0_spec_within`. Hides result0-3. -/
 @[irreducible]
 def sarBody0Post (sp bit_shift antiShift mask v0 v1 v2 v3 : Word) : Assertion :=
@@ -312,17 +301,6 @@ def sarBody0Post (sp bit_shift antiShift mask v0 v1 v2 v3 : Word) : Assertion :=
   (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ ((v3 <<< (antiShift.toNat % 64)) &&& mask)) ** (.x11 ↦ᵣ mask) **
   (sp ↦ₘ result0) ** ((sp + 8) ↦ₘ result1) ** ((sp + 16) ↦ₘ result2) ** ((sp + 24) ↦ₘ result3)
 
-theorem sarBody0Post_unfold (sp bit_shift antiShift mask v0 v1 v2 v3 : Word) :
-    sarBody0Post sp bit_shift antiShift mask v0 v1 v2 v3 =
-      (let result0 := (v0 >>> (bit_shift.toNat % 64)) ||| ((v1 <<< (antiShift.toNat % 64)) &&& mask)
-       let result1 := (v1 >>> (bit_shift.toNat % 64)) ||| ((v2 <<< (antiShift.toNat % 64)) &&& mask)
-       let result2 := (v2 >>> (bit_shift.toNat % 64)) ||| ((v3 <<< (antiShift.toNat % 64)) &&& mask)
-       let result3 := BitVec.sshiftRight v3 (bit_shift.toNat % 64)
-       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result3) ** (.x6 ↦ᵣ bit_shift) **
-       (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ ((v3 <<< (antiShift.toNat % 64)) &&& mask)) ** (.x11 ↦ᵣ mask) **
-       (sp ↦ₘ result0) ** ((sp + 8) ↦ₘ result1) ** ((sp + 16) ↦ₘ result2) ** ((sp + 24) ↦ₘ result3)) := by
-  delta sarBody0Post; rfl
-
 /-- Bundled postcondition for `sar_body_2_spec_within`. Hides result0/result1/signExt. -/
 @[irreducible]
 def sarBody2Post (sp bit_shift antiShift mask v2 v3 : Word) : Assertion :=
@@ -333,16 +311,6 @@ def sarBody2Post (sp bit_shift antiShift mask v2 v3 : Word) : Assertion :=
   (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ signExt) ** (.x11 ↦ᵣ mask) **
   (sp ↦ₘ result0) ** ((sp + 8) ↦ₘ result1) ** ((sp + 16) ↦ₘ signExt) ** ((sp + 24) ↦ₘ signExt)
 
-theorem sarBody2Post_unfold (sp bit_shift antiShift mask v2 v3 : Word) :
-    sarBody2Post sp bit_shift antiShift mask v2 v3 =
-      (let result0 := (v2 >>> (bit_shift.toNat % 64)) ||| ((v3 <<< (antiShift.toNat % 64)) &&& mask)
-       let result1 := BitVec.sshiftRight v3 (bit_shift.toNat % 64)
-       let signExt := BitVec.sshiftRight result1 63
-       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result1) ** (.x6 ↦ᵣ bit_shift) **
-       (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ signExt) ** (.x11 ↦ᵣ mask) **
-       (sp ↦ₘ result0) ** ((sp + 8) ↦ₘ result1) ** ((sp + 16) ↦ₘ signExt) ** ((sp + 24) ↦ₘ signExt)) := by
-  delta sarBody2Post; rfl
-
 /-- Bundled postcondition for `sar_body_3_spec_within`. Hides result0/signExt. -/
 @[irreducible]
 def sarBody3Post (sp bit_shift antiShift mask v3 : Word) : Assertion :=
@@ -351,14 +319,5 @@ def sarBody3Post (sp bit_shift antiShift mask v3 : Word) : Assertion :=
   (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result0) ** (.x6 ↦ᵣ bit_shift) **
   (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ signExt) ** (.x11 ↦ᵣ mask) **
   (sp ↦ₘ result0) ** ((sp + 8) ↦ₘ signExt) ** ((sp + 16) ↦ₘ signExt) ** ((sp + 24) ↦ₘ signExt)
-
-theorem sarBody3Post_unfold (sp bit_shift antiShift mask v3 : Word) :
-    sarBody3Post sp bit_shift antiShift mask v3 =
-      (let result0 := BitVec.sshiftRight v3 (bit_shift.toNat % 64)
-       let signExt := BitVec.sshiftRight result0 63
-       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result0) ** (.x6 ↦ᵣ bit_shift) **
-       (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ signExt) ** (.x11 ↦ᵣ mask) **
-       (sp ↦ₘ result0) ** ((sp + 8) ↦ₘ signExt) ** ((sp + 16) ↦ₘ signExt) ** ((sp + 24) ↦ₘ signExt)) := by
-  delta sarBody3Post; rfl
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Shift/ShlSpec.lean
+++ b/EvmAsm/Evm64/Shift/ShlSpec.lean
@@ -320,18 +320,6 @@ def shlMergeLimbPost (sp : Word) (src_off prev_off dst_off : BitVec 12)
   ((sp + signExtend12 src_off) ↦ₘ src) ** ((sp + signExtend12 prev_off) ↦ₘ prev) **
   ((sp + signExtend12 dst_off) ↦ₘ result)
 
-theorem shlMergeLimbPost_unfold (sp : Word) (src_off prev_off dst_off : BitVec 12)
-    (src prev bit_shift antiShift mask : Word) :
-    shlMergeLimbPost sp src_off prev_off dst_off src prev bit_shift antiShift mask =
-      (let shiftedSrc := src <<< (bit_shift.toNat % 64)
-       let shiftedPrev := (prev >>> (antiShift.toNat % 64)) &&& mask
-       let result := shiftedSrc ||| shiftedPrev
-       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x6 ↦ᵣ bit_shift) **
-       (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ shiftedPrev) ** (.x11 ↦ᵣ mask) **
-       ((sp + signExtend12 src_off) ↦ₘ src) ** ((sp + signExtend12 prev_off) ↦ₘ prev) **
-       ((sp + signExtend12 dst_off) ↦ₘ result)) := by
-  delta shlMergeLimbPost; rfl
-
 /-- Bundled postcondition for `shl_merge_limb_inplace_spec_within`. -/
 @[irreducible]
 def shlMergeInplaceLimbPost (sp : Word) (off prev_off : BitVec 12)
@@ -342,17 +330,6 @@ def shlMergeInplaceLimbPost (sp : Word) (off prev_off : BitVec 12)
   (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x6 ↦ᵣ bit_shift) **
   (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ shiftedPrev) ** (.x11 ↦ᵣ mask) **
   ((sp + signExtend12 off) ↦ₘ result) ** ((sp + signExtend12 prev_off) ↦ₘ prev)
-
-theorem shlMergeInplaceLimbPost_unfold (sp : Word) (off prev_off : BitVec 12)
-    (src prev bit_shift antiShift mask : Word) :
-    shlMergeInplaceLimbPost sp off prev_off src prev bit_shift antiShift mask =
-      (let shiftedSrc := src <<< (bit_shift.toNat % 64)
-       let shiftedPrev := (prev >>> (antiShift.toNat % 64)) &&& mask
-       let result := shiftedSrc ||| shiftedPrev
-       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x6 ↦ᵣ bit_shift) **
-       (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ shiftedPrev) ** (.x11 ↦ᵣ mask) **
-       ((sp + signExtend12 off) ↦ₘ result) ** ((sp + signExtend12 prev_off) ↦ₘ prev)) := by
-  delta shlMergeInplaceLimbPost; rfl
 
 /-- Bundled postcondition for `shl_body_0_spec_within`. Hides result0-3. -/
 @[irreducible]
@@ -365,17 +342,6 @@ def shlBody0Post (sp bit_shift antiShift mask v0 v1 v2 v3 : Word) : Assertion :=
   (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ ((v0 >>> (antiShift.toNat % 64)) &&& mask)) ** (.x11 ↦ᵣ mask) **
   (sp ↦ₘ result0) ** ((sp + 8) ↦ₘ result1) ** ((sp + 16) ↦ₘ result2) ** ((sp + 24) ↦ₘ result3)
 
-theorem shlBody0Post_unfold (sp bit_shift antiShift mask v0 v1 v2 v3 : Word) :
-    shlBody0Post sp bit_shift antiShift mask v0 v1 v2 v3 =
-      (let result3 := (v3 <<< (bit_shift.toNat % 64)) ||| ((v2 >>> (antiShift.toNat % 64)) &&& mask)
-       let result2 := (v2 <<< (bit_shift.toNat % 64)) ||| ((v1 >>> (antiShift.toNat % 64)) &&& mask)
-       let result1 := (v1 <<< (bit_shift.toNat % 64)) ||| ((v0 >>> (antiShift.toNat % 64)) &&& mask)
-       let result0 := v0 <<< (bit_shift.toNat % 64)
-       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result0) ** (.x6 ↦ᵣ bit_shift) **
-       (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ ((v0 >>> (antiShift.toNat % 64)) &&& mask)) ** (.x11 ↦ᵣ mask) **
-       (sp ↦ₘ result0) ** ((sp + 8) ↦ₘ result1) ** ((sp + 16) ↦ₘ result2) ** ((sp + 24) ↦ₘ result3)) := by
-  delta shlBody0Post; rfl
-
 /-- Bundled postcondition for `shl_body_2_spec_within`. -/
 @[irreducible]
 def shlBody2Post (sp bit_shift antiShift mask v0 v1 : Word) : Assertion :=
@@ -384,15 +350,6 @@ def shlBody2Post (sp bit_shift antiShift mask v0 v1 : Word) : Assertion :=
   (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result2) ** (.x6 ↦ᵣ bit_shift) **
   (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ ((v0 >>> (antiShift.toNat % 64)) &&& mask)) ** (.x11 ↦ᵣ mask) **
   (sp ↦ₘ 0) ** ((sp + 8) ↦ₘ 0) ** ((sp + 16) ↦ₘ result2) ** ((sp + 24) ↦ₘ result3)
-
-theorem shlBody2Post_unfold (sp bit_shift antiShift mask v0 v1 : Word) :
-    shlBody2Post sp bit_shift antiShift mask v0 v1 =
-      (let result3 := (v1 <<< (bit_shift.toNat % 64)) ||| ((v0 >>> (antiShift.toNat % 64)) &&& mask)
-       let result2 := v0 <<< (bit_shift.toNat % 64)
-       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result2) ** (.x6 ↦ᵣ bit_shift) **
-       (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ ((v0 >>> (antiShift.toNat % 64)) &&& mask)) ** (.x11 ↦ᵣ mask) **
-       (sp ↦ₘ 0) ** ((sp + 8) ↦ₘ 0) ** ((sp + 16) ↦ₘ result2) ** ((sp + 24) ↦ₘ result3)) := by
-  delta shlBody2Post; rfl
 
 /-- Bundled postcondition for `shl_body_1_spec_within`. -/
 @[irreducible]
@@ -403,15 +360,5 @@ def shlBody1Post (sp bit_shift antiShift mask v0 v1 v2 : Word) : Assertion :=
   (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result1) ** (.x6 ↦ᵣ bit_shift) **
   (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ ((v0 >>> (antiShift.toNat % 64)) &&& mask)) ** (.x11 ↦ᵣ mask) **
   (sp ↦ₘ 0) ** ((sp + 8) ↦ₘ result1) ** ((sp + 16) ↦ₘ result2) ** ((sp + 24) ↦ₘ result3)
-
-theorem shlBody1Post_unfold (sp bit_shift antiShift mask v0 v1 v2 : Word) :
-    shlBody1Post sp bit_shift antiShift mask v0 v1 v2 =
-      (let result3 := (v2 <<< (bit_shift.toNat % 64)) ||| ((v1 >>> (antiShift.toNat % 64)) &&& mask)
-       let result2 := (v1 <<< (bit_shift.toNat % 64)) ||| ((v0 >>> (antiShift.toNat % 64)) &&& mask)
-       let result1 := v0 <<< (bit_shift.toNat % 64)
-       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result1) ** (.x6 ↦ᵣ bit_shift) **
-       (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ ((v0 >>> (antiShift.toNat % 64)) &&& mask)) ** (.x11 ↦ᵣ mask) **
-       (sp ↦ₘ 0) ** ((sp + 8) ↦ₘ result1) ** ((sp + 16) ↦ₘ result2) ** ((sp + 24) ↦ₘ result3)) := by
-  delta shlBody1Post; rfl
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Slt/Spec.lean
+++ b/EvmAsm/Evm64/Slt/Spec.lean
@@ -133,28 +133,6 @@ def evmSltLimbPost (sp v11 a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
   (sp ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
   ((sp + 32) ↦ₘ result) ** ((sp + 40) ↦ₘ 0) ** ((sp + 48) ↦ₘ 0) ** ((sp + 56) ↦ₘ 0)
 
-theorem evmSltLimbPost_unfold (sp v11 a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
-    evmSltLimbPost sp v11 a0 a1 a2 a3 b0 b1 b2 b3 =
-      (let borrow0 := if BitVec.ult a0 b0 then (1 : Word) else 0
-       let borrow1a := if BitVec.ult a1 b1 then (1 : Word) else 0
-       let temp1 := a1 - b1
-       let borrow1b := if BitVec.ult temp1 borrow0 then (1 : Word) else 0
-       let borrow1 := borrow1a ||| borrow1b
-       let borrow2a := if BitVec.ult a2 b2 then (1 : Word) else 0
-       let temp2 := a2 - b2
-       let borrow2b := if BitVec.ult temp2 borrow1 then (1 : Word) else 0
-       let borrow2 := borrow2a ||| borrow2b
-       let sltMsb := if BitVec.slt a3 b3 then (1 : Word) else 0
-       let result := if a3 = b3 then borrow2 else sltMsb
-       (.x12 ↦ᵣ (sp + 32)) **
-       (.x7 ↦ᵣ (if a3 = b3 then temp2 else a3)) **
-       (.x6 ↦ᵣ (if a3 = b3 then borrow2b else b3)) **
-       (.x5 ↦ᵣ result) **
-       (.x11 ↦ᵣ (if a3 = b3 then borrow2a else v11)) **
-       (sp ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
-       ((sp + 32) ↦ₘ result) ** ((sp + 40) ↦ₘ 0) ** ((sp + 48) ↦ₘ 0) ** ((sp + 56) ↦ₘ 0)) := by
-  delta evmSltLimbPost; rfl
-
 -- ============================================================================
 -- Stack-level SLT spec
 -- ============================================================================
@@ -231,26 +209,5 @@ def evmSltStackPost (sp v11 : Word) (a b : EvmWord) : Assertion :=
   (.x5 ↦ᵣ result) **
   (.x11 ↦ᵣ (if a.getLimbN 3 = b.getLimbN 3 then borrow2a else v11)) **
   evmWordIs sp a ** evmWordIs (sp + 32) (if BitVec.slt a b then 1 else 0)
-
-theorem evmSltStackPost_unfold (sp v11 : Word) (a b : EvmWord) :
-    evmSltStackPost sp v11 a b =
-      (let borrow0 := if BitVec.ult (a.getLimbN 0) (b.getLimbN 0) then (1 : Word) else 0
-       let borrow1a := if BitVec.ult (a.getLimbN 1) (b.getLimbN 1) then (1 : Word) else 0
-       let temp1 := a.getLimbN 1 - b.getLimbN 1
-       let borrow1b := if BitVec.ult temp1 borrow0 then (1 : Word) else 0
-       let borrow1 := borrow1a ||| borrow1b
-       let borrow2a := if BitVec.ult (a.getLimbN 2) (b.getLimbN 2) then (1 : Word) else 0
-       let temp2 := a.getLimbN 2 - b.getLimbN 2
-       let borrow2b := if BitVec.ult temp2 borrow1 then (1 : Word) else 0
-       let borrow2 := borrow2a ||| borrow2b
-       let sltMsb := if BitVec.slt (a.getLimbN 3) (b.getLimbN 3) then (1 : Word) else 0
-       let result := if a.getLimbN 3 = b.getLimbN 3 then borrow2 else sltMsb
-       (.x12 ↦ᵣ (sp + 32)) **
-       (.x7 ↦ᵣ (if a.getLimbN 3 = b.getLimbN 3 then temp2 else a.getLimbN 3)) **
-       (.x6 ↦ᵣ (if a.getLimbN 3 = b.getLimbN 3 then borrow2b else b.getLimbN 3)) **
-       (.x5 ↦ᵣ result) **
-       (.x11 ↦ᵣ (if a.getLimbN 3 = b.getLimbN 3 then borrow2a else v11)) **
-       evmWordIs sp a ** evmWordIs (sp + 32) (if BitVec.slt a b then 1 else 0)) := by
-  delta evmSltStackPost; rfl
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Sub/LimbSpec.lean
+++ b/EvmAsm/Evm64/Sub/LimbSpec.lean
@@ -141,14 +141,6 @@ def subLimb0Post (sp : Word) (offA offB : BitVec 12) (aLimb bLimb : Word) : Asse
   (.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ diff) ** (.x6 ↦ᵣ bLimb) ** (.x5 ↦ᵣ borrow) **
   ((sp + signExtend12 offA) ↦ₘ aLimb) ** ((sp + signExtend12 offB) ↦ₘ diff)
 
-theorem subLimb0Post_unfold (sp : Word) (offA offB : BitVec 12) (aLimb bLimb : Word) :
-    subLimb0Post sp offA offB aLimb bLimb =
-      (let borrow := if BitVec.ult aLimb bLimb then (1 : Word) else 0
-       let diff := aLimb - bLimb
-       (.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ diff) ** (.x6 ↦ᵣ bLimb) ** (.x5 ↦ᵣ borrow) **
-       ((sp + signExtend12 offA) ↦ₘ aLimb) ** ((sp + signExtend12 offB) ↦ₘ diff)) := by
-  delta subLimb0Post; rfl
-
 /-- Code requirement for `sub_limb_carry_spec_within`. -/
 abbrev subLimbCarryCode (offA offB : BitVec 12) (base : Word) : CodeReq :=
   CodeReq.union (CodeReq.singleton base (.LD .x7 .x12 offA))
@@ -171,17 +163,6 @@ def subLimbCarryPost (sp : Word) (offA offB : BitVec 12) (aLimb bLimb borrowIn :
   (.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ result) ** (.x6 ↦ᵣ borrow2) ** (.x5 ↦ᵣ borrowOut) ** (.x11 ↦ᵣ borrow1) **
   ((sp + signExtend12 offA) ↦ₘ aLimb) ** ((sp + signExtend12 offB) ↦ₘ result)
 
-theorem subLimbCarryPost_unfold (sp : Word) (offA offB : BitVec 12) (aLimb bLimb borrowIn : Word) :
-    subLimbCarryPost sp offA offB aLimb bLimb borrowIn =
-      (let borrow1 := if BitVec.ult aLimb bLimb then (1 : Word) else 0
-       let temp := aLimb - bLimb
-       let borrow2 := if BitVec.ult temp borrowIn then (1 : Word) else 0
-       let result := temp - borrowIn
-       let borrowOut := borrow1 ||| borrow2
-       (.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ result) ** (.x6 ↦ᵣ borrow2) ** (.x5 ↦ᵣ borrowOut) ** (.x11 ↦ᵣ borrow1) **
-       ((sp + signExtend12 offA) ↦ₘ aLimb) ** ((sp + signExtend12 offB) ↦ₘ result)) := by
-  delta subLimbCarryPost; rfl
-
 /-- Bundled postcondition for `sub_limb_carry_spec_phase1_within`. -/
 @[irreducible]
 def subLimbCarryPhase1Post (sp : Word) (offA offB : BitVec 12) (aLimb bLimb : Word) : Assertion :=
@@ -189,14 +170,6 @@ def subLimbCarryPhase1Post (sp : Word) (offA offB : BitVec 12) (aLimb bLimb : Wo
   let temp := aLimb - bLimb
   (.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ temp) ** (.x6 ↦ᵣ bLimb) ** (.x11 ↦ᵣ borrow1) **
   ((sp + signExtend12 offA) ↦ₘ aLimb) ** ((sp + signExtend12 offB) ↦ₘ bLimb)
-
-theorem subLimbCarryPhase1Post_unfold (sp : Word) (offA offB : BitVec 12) (aLimb bLimb : Word) :
-    subLimbCarryPhase1Post sp offA offB aLimb bLimb =
-      (let borrow1 := if BitVec.ult aLimb bLimb then (1 : Word) else 0
-       let temp := aLimb - bLimb
-       (.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ temp) ** (.x6 ↦ᵣ bLimb) ** (.x11 ↦ᵣ borrow1) **
-       ((sp + signExtend12 offA) ↦ₘ aLimb) ** ((sp + signExtend12 offB) ↦ₘ bLimb)) := by
-  delta subLimbCarryPhase1Post; rfl
 
 /-- Bundled postcondition for `sub_limb_carry_spec_phase2_within`. -/
 @[irreducible]
@@ -206,14 +179,5 @@ def subLimbCarryPhase2Post (sp : Word) (offB : BitVec 12) (temp borrowIn borrow1
   let borrowOut := borrow1 ||| borrow2
   (.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ result) ** (.x6 ↦ᵣ borrow2) ** (.x5 ↦ᵣ borrowOut) ** (.x11 ↦ᵣ borrow1) **
   (memA ↦ₘ aLimb) ** ((sp + signExtend12 offB) ↦ₘ result)
-
-theorem subLimbCarryPhase2Post_unfold (sp : Word) (offB : BitVec 12) (temp borrowIn borrow1 aLimb : Word) (memA : Word) :
-    subLimbCarryPhase2Post sp offB temp borrowIn borrow1 aLimb memA =
-      (let borrow2 := if BitVec.ult temp borrowIn then (1 : Word) else 0
-       let result := temp - borrowIn
-       let borrowOut := borrow1 ||| borrow2
-       (.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ result) ** (.x6 ↦ᵣ borrow2) ** (.x5 ↦ᵣ borrowOut) ** (.x11 ↦ᵣ borrow1) **
-       (memA ↦ₘ aLimb) ** ((sp + signExtend12 offB) ↦ₘ result)) := by
-  delta subLimbCarryPhase2Post; rfl
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Sub/Spec.lean
+++ b/EvmAsm/Evm64/Sub/Spec.lean
@@ -149,30 +149,6 @@ def evmSubLimbPost (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
   (sp ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
   ((sp + 32) ↦ₘ diff0) ** ((sp + 40) ↦ₘ result1) ** ((sp + 48) ↦ₘ result2) ** ((sp + 56) ↦ₘ result3)
 
-theorem evmSubLimbPost_unfold (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
-    evmSubLimbPost sp a0 a1 a2 a3 b0 b1 b2 b3 =
-      (let borrow0 := if BitVec.ult a0 b0 then (1 : Word) else 0
-       let diff0 := a0 - b0
-       let borrow1a := if BitVec.ult a1 b1 then (1 : Word) else 0
-       let temp1 := a1 - b1
-       let borrow1b := if BitVec.ult temp1 borrow0 then (1 : Word) else 0
-       let result1 := temp1 - borrow0
-       let borrow1 := borrow1a ||| borrow1b
-       let borrow2a := if BitVec.ult a2 b2 then (1 : Word) else 0
-       let temp2 := a2 - b2
-       let borrow2b := if BitVec.ult temp2 borrow1 then (1 : Word) else 0
-       let result2 := temp2 - borrow1
-       let borrow2 := borrow2a ||| borrow2b
-       let borrow3a := if BitVec.ult a3 b3 then (1 : Word) else 0
-       let temp3 := a3 - b3
-       let borrow3b := if BitVec.ult temp3 borrow2 then (1 : Word) else 0
-       let result3 := temp3 - borrow2
-       let borrow3 := borrow3a ||| borrow3b
-       (.x12 ↦ᵣ (sp + 32)) ** (.x7 ↦ᵣ result3) ** (.x6 ↦ᵣ borrow3b) ** (.x5 ↦ᵣ borrow3) ** (.x11 ↦ᵣ borrow3a) **
-       (sp ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
-       ((sp + 32) ↦ₘ diff0) ** ((sp + 40) ↦ₘ result1) ** ((sp + 48) ↦ₘ result2) ** ((sp + 56) ↦ₘ result3)) := by
-  delta evmSubLimbPost; rfl
-
 /-- Bundled postcondition for `evm_sub_stack_spec_within` (EvmWord level).
     Hides all 22 limb-extraction and borrow-chain lets. -/
 @[irreducible]
@@ -201,33 +177,5 @@ def evmSubStackPost (sp : Word) (a b : EvmWord) : Assertion :=
   (.x12 ↦ᵣ (sp + 32)) ** (.x7 ↦ᵣ result3) ** (.x6 ↦ᵣ borrow3b) **
   (.x5 ↦ᵣ borrow3) ** (.x11 ↦ᵣ borrow3a) **
   evmWordIs sp a ** evmWordIs (sp + 32) (a - b)
-
-theorem evmSubStackPost_unfold (sp : Word) (a b : EvmWord) :
-    evmSubStackPost sp a b =
-      (let a0 := a.getLimbN 0; let b0 := b.getLimbN 0
-       let a1 := a.getLimbN 1; let b1 := b.getLimbN 1
-       let a2 := a.getLimbN 2; let b2 := b.getLimbN 2
-       let a3 := a.getLimbN 3; let b3 := b.getLimbN 3
-       let borrow0 := if BitVec.ult a0 b0 then (1 : Word) else 0
-       let _diff0 := a0 - b0
-       let borrow1a := if BitVec.ult a1 b1 then (1 : Word) else 0
-       let temp1 := a1 - b1
-       let borrow1b := if BitVec.ult temp1 borrow0 then (1 : Word) else 0
-       let _result1 := temp1 - borrow0
-       let borrow1 := borrow1a ||| borrow1b
-       let borrow2a := if BitVec.ult a2 b2 then (1 : Word) else 0
-       let temp2 := a2 - b2
-       let borrow2b := if BitVec.ult temp2 borrow1 then (1 : Word) else 0
-       let _result2 := temp2 - borrow1
-       let borrow2 := borrow2a ||| borrow2b
-       let borrow3a := if BitVec.ult a3 b3 then (1 : Word) else 0
-       let temp3 := a3 - b3
-       let borrow3b := if BitVec.ult temp3 borrow2 then (1 : Word) else 0
-       let result3 := temp3 - borrow2
-       let borrow3 := borrow3a ||| borrow3b
-       (.x12 ↦ᵣ (sp + 32)) ** (.x7 ↦ᵣ result3) ** (.x6 ↦ᵣ borrow3b) **
-       (.x5 ↦ᵣ borrow3) ** (.x11 ↦ᵣ borrow3a) **
-       evmWordIs sp a ** evmWordIs (sp + 32) (a - b)) := by
-  delta evmSubStackPost; rfl
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Delete 57 dead `_Post_unfold` simp lemmas (877 lines) across 19 `Evm64/` opcode files, orphaned after PR #4649 removed their sole callers (`_named_spec_within` wrappers)
- Files: Add/{LimbSpec,Spec}, AddMod/{Compose/Base,LimbSpec}, Compare/LimbSpec, DivMod/LoopBody/MulsubFull, Eq/{LimbSpec,Spec}, Gt/Spec, IsZero/Spec, Lt/Spec, Multiply/LimbSpec, Sgt/Spec, Shift/{LimbSpec,SarSpec,ShlSpec}, Slt/Spec, Sub/{LimbSpec,Spec}

Refs #61. Bead: evm-asm-sboz.6. Parent: evm-asm-sboz.

## Verification
- `lake build EvmAsm.Evm64.Add EvmAsm.Evm64.Sub EvmAsm.Evm64.Multiply EvmAsm.Evm64.Shift EvmAsm.Evm64.AddMod ...` ✓ (1220 jobs)
- `scripts/check-file-size.sh` ✓ (631 files, all within cap)
- `lake build` (CI)

Authored by @pirapira; implemented by Claude Code