### PR TITLE
chore(DivMod/LimbSpec): delete 36 dead Post bundle defs (follow-on from PRs #4648+#4651)

### DIFF
--- a/EvmAsm/Evm64/DivMod/LimbSpec/AddBackFinalLoopControl.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/AddBackFinalLoopControl.lean
@@ -98,13 +98,4 @@ theorem divK_loop_control_spec_within (j : Word) (loop_back_off : BitVec 13)
         simp only [beq_iff_eq, h0, ↓reduceIte]))) hPR hpc
   exact cpsTripleWithin_seq_cpsBranchWithin_same_cr hbody hbge_ext
 
-/-- Bundled postcondition for `divK_addback_final_spec_within`.
-    Hides `uNew` and `qHat'` add-back intermediates. -/
-@[irreducible]
-def divKAddbackFinalPost (uBase carry qHat uTop : Word) (u_off : BitVec 12) : Assertion :=
-  let uNew := uTop + carry
-  let qHat' := qHat + signExtend12 4095
-  (.x6 ↦ᵣ uBase) ** (.x7 ↦ᵣ carry) ** (.x11 ↦ᵣ qHat') **
-  (.x5 ↦ᵣ uNew) ** (uBase + signExtend12 u_off ↦ₘ uNew)
-
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Denorm.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Denorm.lean
@@ -95,17 +95,4 @@ theorem divK_denorm_last_spec_within (off : BitVec 12)
   have I2 := sd_spec_gen_within .x12 .x5 sp result val off (base + 8)
   runBlock I0 I1 I2
 
-/-- Bundled postcondition for `divK_denorm_merge_spec_within`.
-    Hides `shiftedCurr`, `shiftedNext`, and `result`; x5 holds the result. -/
-@[irreducible]
-def divKDenormMergePost (sp : Word) (curr_off next_off : BitVec 12)
-    (curr next shift antiShift : Word) : Assertion :=
-  let shiftedCurr := curr >>> (shift.toNat % 64)
-  let shiftedNext := next <<< (antiShift.toNat % 64)
-  let result := shiftedCurr ||| shiftedNext
-  (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x7 ↦ᵣ shiftedNext) **
-  (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
-  ((sp + signExtend12 curr_off) ↦ₘ result) **
-  ((sp + signExtend12 next_off) ↦ₘ next)
-
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Clamp.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Clamp.lean
@@ -209,14 +209,4 @@ def divKDiv128ClampQ1Post (q1 rhat dHi : Word) : Assertion :=
   (.x10 ↦ᵣ q1') ** (.x7 ↦ᵣ rhat') ** (.x6 ↦ᵣ dHi) **
   (.x5 ↦ᵣ hi) ** (.x0 ↦ᵣ (0 : Word))
 
-/-- Bundled postcondition for `divK_div128_clamp_q0_merged_spec_within`.
-    Mirrors `divKDiv128ClampQ1Post` but for `q0` on x5/x11/x1. -/
-@[irreducible]
-def divKDiv128ClampQ0Post (q0 rhat2 dHi : Word) : Assertion :=
-  let hi := q0 >>> (32 : BitVec 6).toNat
-  let q0' := if hi = 0 then q0 else q0 + signExtend12 4095
-  let rhat2' := if hi = 0 then rhat2 else rhat2 + dHi
-  (.x5 ↦ᵣ q0') ** (.x11 ↦ᵣ rhat2') ** (.x6 ↦ᵣ dHi) **
-  (.x1 ↦ᵣ hi) ** (.x0 ↦ᵣ (0 : Word))
-
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Phase1.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Phase1.lean
@@ -102,34 +102,4 @@ theorem divK_div128_step1_init_spec_within (uHi dHi v5Old v10Old : Word) (base :
   have I2 := sub_spec_gen_rd_eq_rs1_within .x7 .x5 uHi (q1 * dHi) (base + 8) (by nofun)
   runBlock I0 I1 I2
 
-/-- Bundled postcondition for `divK_div128_save_split_d_spec_within`.
-    Hides `dHi` and `dLo` split intermediates. -/
-@[irreducible]
-def divKDiv128SaveSplitDPost (sp retAddr d : Word) : Assertion :=
-  let dHi := d >>> (32 : BitVec 6).toNat
-  let dLo := (d <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-  (.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ retAddr) ** (.x10 ↦ᵣ d) **
-  (.x6 ↦ᵣ dHi) ** (.x1 ↦ᵣ dLo) **
-  (sp + signExtend12 3968 ↦ₘ retAddr) **
-  (sp + signExtend12 3960 ↦ₘ d) **
-  (sp + signExtend12 3952 ↦ₘ dLo)
-
-/-- Bundled postcondition for `divK_div128_split_ulo_spec_within`.
-    Hides `un1` and `un0` split intermediates. -/
-@[irreducible]
-def divKDiv128SplitUloPost (sp uLo : Word) : Assertion :=
-  let un1 := uLo >>> (32 : BitVec 6).toNat
-  let un0 := (uLo <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-  (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ un0) ** (.x11 ↦ᵣ un1) **
-  (sp + signExtend12 3944 ↦ₘ un0)
-
-/-- Bundled postcondition for `divK_div128_step1_init_spec_within`.
-    Hides `q1` and `rhat` DIVU/SUB intermediates. -/
-@[irreducible]
-def divKDiv128Step1InitPost (uHi dHi : Word) : Assertion :=
-  let q1 := rv64_divu uHi dHi
-  let rhat := uHi - q1 * dHi
-  (.x7 ↦ᵣ rhat) ** (.x6 ↦ᵣ dHi) **
-  (.x10 ↦ᵣ q1) ** (.x5 ↦ᵣ q1 * dHi)
-
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128PhaseEnd.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128PhaseEnd.lean
@@ -103,19 +103,4 @@ theorem divK_div128_end_spec_within
   rw [halign] at I3
   runBlock I0 I1 I2 I3
 
-/-- Bundled postcondition for `divK_div128_phase1_spec_within`. Hides 4 computation lets. -/
-@[irreducible]
-def divKDiv128Phase1Post (sp d uLo uHi retAddr : Word) : Assertion :=
-  let dHi := d >>> (32 : BitVec 6).toNat
-  let dLo := (d <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-  let un1 := uLo >>> (32 : BitVec 6).toNat
-  let un0 := (uLo <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-  (.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ retAddr) ** (.x10 ↦ᵣ d) **
-  (.x6 ↦ᵣ dHi) ** (.x1 ↦ᵣ dLo) ** (.x5 ↦ᵣ un0) **
-  (.x11 ↦ᵣ un1) ** (.x7 ↦ᵣ uHi) **
-  (sp + signExtend12 3968 ↦ₘ retAddr) **
-  (sp + signExtend12 3960 ↦ₘ d) **
-  (sp + signExtend12 3952 ↦ₘ dLo) **
-  (sp + signExtend12 3944 ↦ₘ un0)
-
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck1.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck1.lean
@@ -171,16 +171,4 @@ theorem divK_div128_prodcheck1_merged_spec_within
         (fun _ hp => hp)
         ntaken_clean hjal_framed)
 
-/-- Bundled postcondition for `divK_div128_prodcheck1_merged_spec_within`.
-    Hides qDlo, rhatUn1, q1', rhat' lets. -/
-@[irreducible]
-def divKDiv128ProdCheck1Post (sp q1 rhat dHi un1 dlo : Word) : Assertion :=
-  let qDlo := q1 * dlo
-  let rhatUn1 := (rhat <<< (32 : BitVec 6).toNat) ||| un1
-  let q1' := if BitVec.ult rhatUn1 qDlo then q1 + signExtend12 4095 else q1
-  let rhat' := if BitVec.ult rhatUn1 qDlo then rhat + dHi else rhat
-  (.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1') ** (.x7 ↦ᵣ rhat') ** (.x11 ↦ᵣ un1) **
-  (.x5 ↦ᵣ qDlo) ** (.x1 ↦ᵣ rhatUn1) ** (.x6 ↦ᵣ dHi) **
-  (sp + signExtend12 3952 ↦ₘ dlo)
-
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck2.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck2.lean
@@ -275,15 +275,4 @@ theorem divK_div128_prodcheck2_merged_spec_within
         (fun _ hp => hp)
         ntaken_clean hjal_framed)
 
-/-- Bundled postcondition for `divK_div128_prodcheck2_merged_spec_within`.
-    Hides `q0Dlo`, `rhat2Un0`, and `q0'` product-check-2 intermediates. -/
-@[irreducible]
-def divKDiv128ProdCheck2MergedPost (sp q0 rhat2 dlo un0 : Word) : Assertion :=
-  let q0Dlo := q0 * dlo
-  let rhat2Un0 := (rhat2 <<< (32 : BitVec 6).toNat) ||| un0
-  let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0 + signExtend12 4095 else q0
-  (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ q0') ** (.x11 ↦ᵣ un0) **
-  (.x7 ↦ᵣ q0Dlo) ** (.x1 ↦ᵣ rhat2Un0) **
-  (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0)
-
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step1.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step1.lean
@@ -164,24 +164,6 @@ theorem divK_div128_step1_spec_within
     (fun h hp => by xperm_hyp hp)
     h123
 
-/-- Bundled postcondition for `divK_div128_step1_spec_within`.
-    Hides all 10 let-intermediates (q1, rhat, hi, q1c, rhatc, qDlo,
-    rhatUn1, q1', rhat') leaving only the input parameters visible. -/
-@[irreducible]
-def divKDiv128Step1Post (sp uHi dHi dlo un1 : Word) : Assertion :=
-  let q1 := rv64_divu uHi dHi
-  let rhat := uHi - q1 * dHi
-  let hi := q1 >>> (32 : BitVec 6).toNat
-  let q1c := if hi = 0 then q1 else q1 + signExtend12 4095
-  let rhatc := if hi = 0 then rhat else rhat + dHi
-  let qDlo := q1c * dlo
-  let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
-  let q1' := if BitVec.ult rhatUn1 qDlo then q1c + signExtend12 4095 else q1c
-  let rhat' := if BitVec.ult rhatUn1 qDlo then rhatc + dHi else rhatc
-  (.x7 ↦ᵣ rhat') ** (.x6 ↦ᵣ dHi) ** (.x10 ↦ᵣ q1') **
-  (.x5 ↦ᵣ qDlo) ** (.x11 ↦ᵣ un1) ** (.x1 ↦ᵣ rhatUn1) **
-  (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** (sp + signExtend12 3952 ↦ₘ dlo)
-
 /-- Bundled CodeReq for `divK_div128_step1_spec_within` (instrs [10]-[24], 15 singletons). -/
 @[irreducible]
 def divKDiv128Step1Code (base : Word) : CodeReq :=

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2.lean
@@ -541,36 +541,6 @@ abbrev divKDiv128Step2UptoGuardCode (base : Word) : CodeReq :=
   (CodeReq.union (CodeReq.singleton (base + 20) (.ADDI .x5 .x5 4095))
    (CodeReq.singleton (base + 24) (.ADD .x11 .x11 .x6)))))))
 
-/-- Bundled base postcondition for `divK_div128_step2_thru_guard_spec_within`.
-    Hides 6 lets (q0, rhat2, hi, q0c, rhat2c, rhat2cHi). The pure fact
-    (`rhat2cHi ≠ 0` or `= 0`) is composed on top by the caller. -/
-@[irreducible]
-def divKDiv128Step2ThruGuardPost (sp un21 dHi dlo un0 : Word) : Assertion :=
-  let q0 := rv64_divu un21 dHi
-  let rhat2 := un21 - q0 * dHi
-  let hi := q0 >>> (32 : BitVec 6).toNat
-  let q0c := if hi = 0 then q0 else q0 + signExtend12 4095
-  let rhat2c := if hi = 0 then rhat2 else rhat2 + dHi
-  let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
-  (.x7 ↦ᵣ un21) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) **
-  (.x1 ↦ᵣ rhat2cHi) ** (.x11 ↦ᵣ rhat2c) **
-  (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) **
-  (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0)
-
-/-- Bundled postcondition for `divK_div128_step2_upto_guard_spec_within`.
-    Hides 5 computation lets (q0, rhat2, hi, q0c, rhat2c). -/
-@[irreducible]
-def divKDiv128Step2UptoGuardPost (sp un21 dHi dlo un0 : Word) : Assertion :=
-  let q0 := rv64_divu un21 dHi
-  let rhat2 := un21 - q0 * dHi
-  let hi := q0 >>> (32 : BitVec 6).toNat
-  let q0c := if hi = 0 then q0 else q0 + signExtend12 4095
-  let rhat2c := if hi = 0 then rhat2 else rhat2 + dHi
-  (.x7 ↦ᵣ un21) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) **
-  (.x1 ↦ᵣ hi) ** (.x11 ↦ᵣ rhat2c) **
-  (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) **
-  (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0)
-
 /-- Bundled 9-instruction code for `divK_div128_step2_thru_guard_spec_within`. -/
 @[irreducible]
 def divKDiv128Step2ThruGuardCode (base : Word) : CodeReq :=
@@ -592,21 +562,5 @@ abbrev divKDiv128Step2ThruGuardRhat2cHi (un21 dHi : Word) : Word :=
   let rhat2c := if hi = 0 then rhat2 else rhat2 + dHi
   rhat2c >>> (32 : BitVec 6).toNat
 
-/-- Bundled postcondition for the guard-doesn't-fire + prodcheck2 leg of
-    `divK_div128_step2_branch_merged_spec_within`. Hides 8 computation lets. -/
-@[irreducible]
-def divKDiv128Step2ProdCheck2Post (sp un21 dHi dlo un0 : Word) : Assertion :=
-  let q0 := rv64_divu un21 dHi
-  let rhat2 := un21 - q0 * dHi
-  let hi := q0 >>> (32 : BitVec 6).toNat
-  let q0c := if hi = 0 then q0 else q0 + signExtend12 4095
-  let rhat2c := if hi = 0 then rhat2 else rhat2 + dHi
-  let q0Dlo := q0c * dlo
-  let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| un0
-  let q0'Unguarded := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
-  (.x7 ↦ᵣ q0Dlo) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0'Unguarded) **
-  (.x1 ↦ᵣ rhat2Un0) ** (.x11 ↦ᵣ un0) **
-  (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) **
-  (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0)
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2v4.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2v4.lean
@@ -962,44 +962,4 @@ theorem divK_div128_step2_v4_spec
     (fun h hq => by xperm_hyp hq)
     (cpsBranchWithin_merge_same_cr composed_AB h_taken h_notTaken)
 
-/-- Bundled postcondition for `divK_div128_step2_v4_phase_E_merged_spec`.
-    Hides 7 lets (rhat2cHi, rhat2'Hi, q0Dlo2, rhat2'Un0, q0'', x7Exit, x1Exit, x11Exit).
-    The pure fact `⌜rhat2cHi = 0⌝` is baked in since `rhat2cHi` is derived from `rhat2c`.
-    Note: `rhat2Un0` (Phase-D output) does not appear in the postcondition. -/
-@[irreducible]
-def divKDiv128Step2V4PhaseEPost
-    (sp dHi q0' rhat2' q0Dlo1 dlo un0 rhat2c : Word) : Assertion :=
-  let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
-  let rhat2'Hi := rhat2' >>> (32 : BitVec 6).toNat
-  let q0Dlo2 := q0' * dlo
-  let rhat2'Un0 := (rhat2' <<< (32 : BitVec 6).toNat) ||| un0
-  let q0'' := div128Quot_phase2b_q0' q0' rhat2' dlo un0
-  let x7Exit := if rhat2'Hi ≠ 0 then q0Dlo1 else q0Dlo2
-  let x1Exit := if rhat2'Hi ≠ 0 then rhat2'Hi else rhat2'Un0
-  let x11Exit := if rhat2'Hi ≠ 0 then rhat2' else un0
-  (.x5 ↦ᵣ q0'') ** (.x6 ↦ᵣ dHi) ** (.x7 ↦ᵣ x7Exit) **
-  (.x1 ↦ᵣ x1Exit) ** (.x11 ↦ᵣ x11Exit) **
-  (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
-  (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
-  (sp + signExtend12 3936 ↦ₘ rhat2c)
-
-/-- Bundled postcondition for `divK_div128_step2_v4_phase_D_merged_spec`.
-    Hides 5 lets: rhat2cHi, q0Dlo1, rhat2Un0, q0', rhat2'.
-    Bakes in `⌜rhat2cHi = 0⌝` (derived from rhat2c). -/
-@[irreducible]
-def divKDiv128Step2V4PhaseDPost
-    (sp dHi q0c rhat2c dlo un0 : Word) : Assertion :=
-  let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
-  let q0Dlo1 := q0c * dlo
-  let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| un0
-  let q0' := div128Quot_phase2b_q0' q0c rhat2c dlo un0
-  let rhat2' := if rhat2cHi = 0 then
-                  if BitVec.ult rhat2Un0 q0Dlo1 then rhat2c + dHi else rhat2c
-                else rhat2c
-  (.x7 ↦ᵣ q0Dlo1) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0') **
-  (.x11 ↦ᵣ rhat2') ** (.x1 ↦ᵣ rhat2Un0) **
-  (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
-  (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
-  (sp + signExtend12 3936 ↦ₘ rhat2c)
-
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Tail.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Tail.lean
@@ -145,28 +145,3 @@ theorem divK_div128_restore_return_spec_within (sp v2Old retAddr : Word) (base :
   rw [halign] at I1
   runBlock I0 I1
 
-/-- Bundled postcondition for `divK_div128_prodcheck2_body_spec_within`. -/
-@[irreducible]
-def divKDiv128ProdCheck2BodyPost (sp q0 rhat2 dlo un0 : Word) : Assertion :=
-  let q0Dlo := q0 * dlo
-  let rhat2_hi := rhat2 <<< (32 : BitVec 6).toNat
-  let rhat2Un0 := rhat2_hi ||| un0
-  (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ un0) **
-  (.x7 ↦ᵣ q0Dlo) ** (.x1 ↦ᵣ rhat2Un0) **
-  (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0)
-
-/-- Bundled postcondition for `divK_div128_step2_init_spec_within`.
-    Hides `q0` and `rhat2` DIVU/MUL/SUB step-2-init intermediates. -/
-@[irreducible]
-def divKDiv128Step2InitPost (un21 dHi : Word) : Assertion :=
-  let q0 := rv64_divu un21 dHi
-  let rhat2 := un21 - q0 * dHi
-  (.x7 ↦ᵣ un21) ** (.x6 ↦ᵣ dHi) **
-  (.x5 ↦ᵣ q0) ** (.x1 ↦ᵣ q0 * dHi) ** (.x11 ↦ᵣ rhat2)
-
-/-- Bundled postcondition for `divK_div128_combine_q_spec_within`.
-    Hides `q1Hi` and `q = q1Hi ||| q0` intermediates. -/
-@[irreducible]
-def divKDiv128CombineQPost (q1 q0 : Word) : Assertion :=
-  let q := (q1 <<< (32 : BitVec 6).toNat) ||| q0
-  (.x10 ↦ᵣ q1) ** (.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ q)

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128UnProdCheck.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128UnProdCheck.lean
@@ -111,42 +111,4 @@ theorem divK_div128_correct_q0_spec_within (q0 rhat2 dHi : Word) (base : Word) :
   have I1 := add_spec_gen_rd_eq_rs1_within .x11 .x6 rhat2 dHi (base + 4) (by nofun)
   runBlock I0 I1
 
-/-- Bundled postcondition for `divK_div128_compute_un21_spec_within`.
-    Hides rhatHi, rhatUn1, q1Dlo, un21 lets. -/
-@[irreducible]
-def divKDiv128ComputeUn21Post (sp q1 rhat un1 dloMem : Word) : Assertion :=
-  let rhatHi := rhat <<< (32 : BitVec 6).toNat
-  let rhatUn1 := rhatHi ||| un1
-  let q1Dlo := q1 * dloMem
-  let un21 := rhatUn1 - q1Dlo
-  (.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ un21) **
-  (.x11 ↦ᵣ un1) ** (.x5 ↦ᵣ rhatUn1) ** (.x1 ↦ᵣ q1Dlo) **
-  (sp + signExtend12 3952 ↦ₘ dloMem)
-
-/-- Bundled postcondition for `divK_div128_prodcheck_body_spec_within`.
-    Hides `qDlo`, `rhatHi`, `rhatUn1` lets. -/
-@[irreducible]
-def divKDiv128ProdCheckBodyPost (sp q rhat un1 dlo : Word) : Assertion :=
-  let qDlo := q * dlo
-  let rhatHi := rhat <<< (32 : BitVec 6).toNat
-  let rhatUn1 := rhatHi ||| un1
-  (.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q) ** (.x7 ↦ᵣ rhat) ** (.x11 ↦ᵣ un1) **
-  (.x5 ↦ᵣ qDlo) ** (.x1 ↦ᵣ rhatUn1) ** (sp + signExtend12 3952 ↦ₘ dlo)
-
-/-- Bundled postcondition for `divK_div128_correct_q1_spec_within`.
-    Hides `q'` and `rhat'` correction intermediates (x10/x7 pair). -/
-@[irreducible]
-def divKDiv128CorrectQ1Post (q rhat dHi : Word) : Assertion :=
-  let q' := q + signExtend12 4095
-  let rhat' := rhat + dHi
-  (.x10 ↦ᵣ q') ** (.x7 ↦ᵣ rhat') ** (.x6 ↦ᵣ dHi)
-
-/-- Bundled postcondition for `divK_div128_correct_q0_spec_within`.
-    Hides `q0'` and `rhat2'` correction intermediates (x5/x11 pair). -/
-@[irreducible]
-def divKDiv128CorrectQ0Post (q0 rhat2 dHi : Word) : Assertion :=
-  let q0' := q0 + signExtend12 4095
-  let rhat2' := rhat2 + dHi
-  (.x5 ↦ᵣ q0') ** (.x11 ↦ᵣ rhat2') ** (.x6 ↦ᵣ dHi)
-
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LimbSpec/MulSub.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/MulSub.lean
@@ -98,18 +98,6 @@ abbrev divKMulsubPartACode (v_off : BitVec 12) (base : Word) : CodeReq :=
   (CodeReq.union (CodeReq.singleton (base + 16) (.SLTU .x10 .x7 .x10))
    (CodeReq.singleton (base + 20) (.ADD .x10 .x10 .x5))))))
 
-/-- Bundled postcondition for `divK_mulsub_partA_spec_within`. Hides 5 computation lets. -/
-@[irreducible]
-def divKMulsubPartAPost (sp qHat carryIn v_i : Word) (v_off : BitVec 12) : Assertion :=
-  let prodLo := qHat * v_i
-  let prodHi := rv64_mulhu qHat v_i
-  let fullSub := prodLo + carryIn
-  let borrowAdd := if BitVec.ult fullSub carryIn then (1 : Word) else 0
-  let partialCarry := borrowAdd + prodHi
-  (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) ** (.x10 ↦ᵣ partialCarry) **
-  (.x5 ↦ᵣ prodHi) ** (.x7 ↦ᵣ fullSub) **
-  ((sp + signExtend12 v_off) ↦ₘ v_i)
-
 /-- Code requirement for `divK_mulsub_partB_spec_within`. -/
 abbrev divKMulsubPartBCode (u_off : BitVec 12) (base : Word) : CodeReq :=
   CodeReq.union (CodeReq.singleton base (.LD .x2 .x6 u_off))
@@ -117,16 +105,5 @@ abbrev divKMulsubPartBCode (u_off : BitVec 12) (base : Word) : CodeReq :=
   (CodeReq.union (CodeReq.singleton (base + 8) (.SUB .x2 .x2 .x7))
   (CodeReq.union (CodeReq.singleton (base + 12) (.ADD .x10 .x10 .x5))
    (CodeReq.singleton (base + 16) (.SD .x6 .x2 u_off)))))
-
-/-- Bundled postcondition for `divK_mulsub_partB_spec_within`. Hides 3 computation lets.
-    `prodHi` is not in the postcondition so it's not a bundle parameter. -/
-@[irreducible]
-def divKMulsubPartBPost (uBase partialCarry fullSub u_i : Word) (u_off : BitVec 12) : Assertion :=
-  let borrowSub := if BitVec.ult u_i fullSub then (1 : Word) else 0
-  let uNew := u_i - fullSub
-  let carryOut := partialCarry + borrowSub
-  (.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ carryOut) **
-  (.x5 ↦ᵣ borrowSub) ** (.x7 ↦ᵣ fullSub) ** (.x2 ↦ᵣ uNew) **
-  ((uBase + signExtend12 u_off) ↦ₘ uNew)
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LimbSpec/MulSubLimb.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/MulSubLimb.lean
@@ -133,23 +133,6 @@ abbrev divKMulsubLimbCode (v_off u_off : BitVec 12) (base : Word) : CodeReq :=
   (CodeReq.union (CodeReq.singleton (base + 36) (.ADD .x10 .x10 .x5))
    (CodeReq.singleton (base + 40) (.SD .x6 .x2 u_off)))))))))))
 
-/-- Bundled postcondition for `divK_mulsub_limb_spec_within`. Hides 8 computation lets. -/
-@[irreducible]
-def divKMulsubLimbPost (sp qHat carryIn uBase v_i u_i : Word) (v_off u_off : BitVec 12) : Assertion :=
-  let prodLo := qHat * v_i
-  let prodHi := rv64_mulhu qHat v_i
-  let fullSub := prodLo + carryIn
-  let borrowAdd := if BitVec.ult fullSub carryIn then (1 : Word) else 0
-  let partialCarry := borrowAdd + prodHi
-  let borrowSub := if BitVec.ult u_i fullSub then (1 : Word) else 0
-  let uNew := u_i - fullSub
-  let carryOut := partialCarry + borrowSub
-  (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) ** (.x10 ↦ᵣ carryOut) **
-  (.x6 ↦ᵣ uBase) ** (.x5 ↦ᵣ borrowSub) ** (.x7 ↦ᵣ fullSub) **
-  (.x2 ↦ᵣ uNew) **
-  ((sp + signExtend12 v_off) ↦ₘ v_i) **
-  ((uBase + signExtend12 u_off) ↦ₘ uNew)
-
 /-- Code requirement for `divK_addback_limb_spec_within`. -/
 abbrev divKAddbackLimbCode (v_off u_off : BitVec 12) (base : Word) : CodeReq :=
   CodeReq.union (CodeReq.singleton base (.LD .x5 .x12 v_off))
@@ -160,18 +143,5 @@ abbrev divKAddbackLimbCode (v_off u_off : BitVec 12) (base : Word) : CodeReq :=
   (CodeReq.union (CodeReq.singleton (base + 20) (.SLTU .x5 .x2 .x5))
   (CodeReq.union (CodeReq.singleton (base + 24) (.OR .x7 .x7 .x5))
    (CodeReq.singleton (base + 28) (.SD .x6 .x2 u_off))))))))
-
-/-- Bundled postcondition for `divK_addback_limb_spec_within`. Hides 5 computation lets. -/
-@[irreducible]
-def divKAddbackLimbPost (sp uBase carryIn v_i u_i : Word) (v_off u_off : BitVec 12) : Assertion :=
-  let uPlusCarry := u_i + carryIn
-  let carry1 := if BitVec.ult uPlusCarry carryIn then (1 : Word) else 0
-  let uNew := uPlusCarry + v_i
-  let carry2 := if BitVec.ult uNew v_i then (1 : Word) else 0
-  let carryOut := carry1 ||| carry2
-  (.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ uBase) ** (.x7 ↦ᵣ carryOut) **
-  (.x5 ↦ᵣ carry2) ** (.x2 ↦ᵣ uNew) **
-  ((sp + signExtend12 v_off) ↦ₘ v_i) **
-  ((uBase + signExtend12 u_off) ↦ₘ uNew)
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LimbSpec/MulSubSetup.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/MulSubSetup.lean
@@ -75,13 +75,3 @@ theorem divK_addback_init_spec_within (v7Old : Word) (base : Word) :
   intro cr
   have I0 := addi_x0_spec_gen_within .x7 v7Old 0 base (by nofun)
   runBlock I0
-
-/-- Bundled postcondition for `divK_mulsub_setup_spec_within`. -/
-@[irreducible]
-def divKMulsubSetupPost (sp j qHat : Word) : Assertion :=
-  let jX8 := j <<< (3 : BitVec 6).toNat
-  let uBase := sp + signExtend12 4056 - jX8
-  (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
-  (.x1 ↦ᵣ j) ** (.x5 ↦ᵣ jX8) ** (.x6 ↦ᵣ uBase) **
-  (.x10 ↦ᵣ signExtend12 (0 : BitVec 12)) ** (.x0 ↦ᵣ (0 : Word)) **
-  (sp + signExtend12 3976 ↦ₘ j)

--- a/EvmAsm/Evm64/DivMod/LimbSpec/NormA.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/NormA.lean
@@ -158,30 +158,4 @@ theorem divK_normA_last_spec_within (dst_off : BitVec 12)
   have I1 := sd_spec_gen_within .x12 .x7 sp result dstOld dst_off (base + 4)
   runBlock I0 I1
 
-/-- Bundled postcondition for `divK_normA_mergeA_spec_within`.
-    Hides `shiftedCurr`, `shiftedNext`, and `result`; x5 holds the result. -/
-@[irreducible]
-def divKNormAMergeAPost (sp : Word) (next_off dst_off : BitVec 12)
-    (current next shift antiShift : Word) : Assertion :=
-  let shiftedCurr := current <<< (shift.toNat % 64)
-  let shiftedNext := next >>> (antiShift.toNat % 64)
-  let result := shiftedCurr ||| shiftedNext
-  (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x7 ↦ᵣ next) ** (.x10 ↦ᵣ shiftedNext) **
-  (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
-  ((sp + signExtend12 next_off) ↦ₘ next) **
-  ((sp + signExtend12 dst_off) ↦ₘ result)
-
-/-- Bundled postcondition for `divK_normA_mergeB_spec_within`.
-    Hides `shiftedCurr`, `shiftedNext`, and `result`; x7 holds the result. -/
-@[irreducible]
-def divKNormAMergeBPost (sp : Word) (next_off dst_off : BitVec 12)
-    (current next shift antiShift : Word) : Assertion :=
-  let shiftedCurr := current <<< (shift.toNat % 64)
-  let shiftedNext := next >>> (antiShift.toNat % 64)
-  let result := shiftedCurr ||| shiftedNext
-  (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ next) ** (.x7 ↦ᵣ result) ** (.x10 ↦ᵣ shiftedNext) **
-  (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
-  ((sp + signExtend12 next_off) ↦ₘ next) **
-  ((sp + signExtend12 dst_off) ↦ₘ result)
-
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LimbSpec/NormB.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/NormB.lean
@@ -95,16 +95,4 @@ theorem divK_normB_last_spec_within (off : BitVec 12)
   have I2 := sd_spec_gen_within .x12 .x5 sp result val off (base + 8)
   runBlock I0 I1 I2
 
-/-- Bundled postcondition for `divK_normB_merge_spec_within`. -/
-@[irreducible]
-def divKNormBMergePost (sp : Word) (high_off low_off : BitVec 12)
-    (high low shift antiShift : Word) : Assertion :=
-  let shiftedHigh := high <<< (shift.toNat % 64)
-  let shiftedLow := low >>> (antiShift.toNat % 64)
-  let result := shiftedHigh ||| shiftedLow
-  (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x7 ↦ᵣ shiftedLow) **
-  (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
-  ((sp + signExtend12 high_off) ↦ₘ result) **
-  ((sp + signExtend12 low_off) ↦ₘ low)
-
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LimbSpec/SubCarryStoreQj.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/SubCarryStoreQj.lean
@@ -89,23 +89,4 @@ theorem divK_store_qj_write_spec_within (qAddr qHat qOld : Word) (base : Word) :
   rw [haddr] at I0
   runBlock I0
 
-/-- Bundled postcondition for `divK_sub_carry_spec_within`.
-    Hides the `borrow` and `uNew` let-intermediates. -/
-@[irreducible]
-def divKSubCarryPost (uBase carryIn uTop : Word) (u_off : BitVec 12) : Assertion :=
-  let borrow := if BitVec.ult uTop carryIn then (1 : Word) else 0
-  let uNew := uTop - carryIn
-  (.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ carryIn) **
-  (.x5 ↦ᵣ uNew) ** (.x7 ↦ᵣ borrow) **
-  ((uBase + signExtend12 u_off) ↦ₘ uNew)
-
-/-- Bundled postcondition for `divK_store_qj_addr_spec_within`.
-    Hides `jX8`, `sp_m8`, and `qAddr` address intermediates. -/
-@[irreducible]
-def divKStoreQjAddrPost (sp j : Word) : Assertion :=
-  let jX8 := j <<< (3 : BitVec 6).toNat
-  let qAddr := sp + signExtend12 4088 - jX8
-  (.x1 ↦ᵣ j) ** (.x12 ↦ᵣ sp) **
-  (.x5 ↦ᵣ jX8) ** (.x7 ↦ᵣ qAddr)
-
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LimbSpec/TrialQuotient.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/TrialQuotient.lean
@@ -133,23 +133,4 @@ theorem divK_trial_max_spec_within (v11Old : Word) (base : Word) :
   rw [ha] at I1
   runBlock I0 I1
 
-/-- Bundled postcondition for `divK_trial_load_u_spec_within`.
-    Hides the intermediate `jpn`, `jpnX8`, `u0_base`, and `uAddr` address
-    computations so callers can reason about the postcondition opaquely. -/
-@[irreducible]
-def divKTrialLoadUPost (sp j n uHi uLo : Word) : Assertion :=
-  let uAddr := sp + signExtend12 4056 - ((j + n) <<< (3 : BitVec 6).toNat)
-  (.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
-  (.x5 ↦ᵣ uLo) ** (.x7 ↦ᵣ uHi) **
-  (sp + signExtend12 3984 ↦ₘ n) **
-  (uAddr ↦ₘ uHi) ** ((uAddr + 8) ↦ₘ uLo)
-
-/-- Bundled postcondition for `divK_trial_load_vtop_spec_within`.
-    Hides the `nm1`, `nm1X8`, and `vtopBase` address intermediates. -/
-@[irreducible]
-def divKTrialLoadVTopPost (sp n vTop : Word) : Assertion :=
-  let vtopBase := sp + ((n + signExtend12 4095) <<< (3 : BitVec 6).toNat)
-  (.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ vtopBase) ** (.x10 ↦ᵣ vTop) **
-  (sp + signExtend12 3984 ↦ₘ n) ** (vtopBase + signExtend12 32 ↦ₘ vTop)
-
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LimbSpec/TrialStoreComposed.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/TrialStoreComposed.lean
@@ -111,27 +111,4 @@ theorem divK_store_qj_spec_within (sp j qHat v5Old v7Old qOld : Word)
   rw [haddr] at I3
   runBlock I0 I1 I2 I3
 
-/-- Bundled postcondition for `divK_trial_load_spec_within`.
-    Hides `uAddr` and `vtopBase` address computations. -/
-@[irreducible]
-def divKTrialLoadPost (sp j n uHi uLo vTop : Word) : Assertion :=
-  let uAddr := sp + signExtend12 4056 - (j + n) <<< (3 : BitVec 6).toNat
-  let vtopBase := sp + (n + signExtend12 4095) <<< (3 : BitVec 6).toNat
-  (.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
-  (.x5 ↦ᵣ uLo) ** (.x6 ↦ᵣ vtopBase) **
-  (.x7 ↦ᵣ uHi) ** (.x10 ↦ᵣ vTop) **
-  (sp + signExtend12 3984 ↦ₘ n) **
-  (uAddr ↦ₘ uHi) ** ((uAddr + 8) ↦ₘ uLo) **
-  (vtopBase + signExtend12 32 ↦ₘ vTop)
-
-/-- Bundled postcondition for `divK_store_qj_spec_within`.
-    Hides `jX8` and `qAddr` address intermediates. -/
-@[irreducible]
-def divKStoreQjPost (sp j qHat : Word) : Assertion :=
-  let jX8 := j <<< (3 : BitVec 6).toNat
-  let qAddr := sp + signExtend12 4088 - jX8
-  (.x1 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
-  (.x5 ↦ᵣ jX8) ** (.x7 ↦ᵣ qAddr) **
-  (qAddr ↦ₘ qHat)
-
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Delete 36 dead named-postcondition bundle `def`/`abbrev` declarations (429 lines) across 20 `DivMod/LimbSpec/` files
- These became orphaned after PR #4648 deleted `_named_spec_within` wrappers and PR #4651 deleted `_Post_unfold` simp lemmas — their last callers
- All have total=1 (definition only, zero callers)

Refs #61. Bead: evm-asm-sboz.7. Parent: evm-asm-sboz.

## Verification
- `lake build EvmAsm.Evm64.DivMod.LimbSpec` ✓ (912 jobs)
- `scripts/check-file-size.sh` ✓ (632 files, all within cap)
- No `sorry/admit/maxHeartbeats/maxRecDepth`
- `lake build` (CI)

Authored by @pirapira; implemented by Claude Code