### PR TITLE
fix(sdiv): preserve callable return address in div loop

### DIFF
--- a/EvmAsm/Evm64/AddMod/Spec.lean
+++ b/EvmAsm/Evm64/AddMod/Spec.lean
@@ -36,7 +36,7 @@ open EvmAsm.Evm64.AddMod.Compose
 
 The bridge lemma connects the prologue postcondition
 `evmAddModPhase1Phase2LimbPost` (for b=N=0) to the mod callable
-precondition `divModStackDispatchPre`. This is the key step enabling
+    precondition `divModStackDispatchPreCallable`. This is the key step enabling
 the N=0 end-to-end proof (bead evm-asm-a32mz).
 
 Key simplification: when b=0 (the second ADDMOD operand = N = 0),
@@ -69,7 +69,7 @@ private theorem evmAddModPhase1Phase2LimbPost_b0_simp
     - Original a at sp..sp+24
 
     Combined with the frame (x2, x10, x0=0, N=0 at sp+64..sp+88, scratch),
-    this gives exactly `divModStackDispatchPre (sp+32) a 0 (base+128) ...`. -/
+      this gives exactly `divModStackDispatchPreCallable (sp+32) a 0 (base+128) ...`. -/
 private theorem evm_addmod_n0_dispatch_bridge
     (sp base : Word) (a : EvmWord)
     (a0 a1 a2 a3 v2 v10 : Word)
@@ -83,15 +83,15 @@ private theorem evm_addmod_n0_dispatch_bridge
        (.x2 ↦ᵣ v2) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        ((sp + 64) ↦ₘ (0 : Word)) ** ((sp + 72) ↦ₘ (0 : Word)) **
        ((sp + 80) ↦ₘ (0 : Word)) ** ((sp + 88) ↦ₘ (0 : Word)) **
-       divScratchValuesCall (sp + 32) q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-         shiftMem nMem jMem retMem dMem dloMem scratchUn0) s) :
-    (divModStackDispatchPre (sp + 32) a (0 : EvmWord) ((base + 124) + 4)
-       v2 0 0 0 v10 0
-       q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-       shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+         divScratchValuesCallNoX1 (sp + 32) q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+           shiftMem nMem jMem retMem dMem dloMem scratchUn0) s) :
+      (divModStackDispatchPreCallable (sp + 32) a (0 : EvmWord) ((base + 124) + 4)
+         v2 0 0 0 v10 0
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
      (sp ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
      ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3)) s := by
-  rw [divModStackDispatchPre_unfold]
+  rw [divModStackDispatchPreCallable_unfold]
   rw [evmAddModPhase1Phase2LimbPost_b0_simp] at hpre
   -- Expand evmWordIs (sp+32) a → atoms at sp+32..sp+56
   simp only [evmWordIs_sp32_limbs_eq sp a a0 a1 a2 a3 ha0 ha1 ha2 ha3]
@@ -194,15 +194,15 @@ theorem evm_addmod_b0_n0_spec_within
        (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) ** (.x0 ↦ᵣ (0 : Word)) **
        evmWordIs sp a ** evmWordIs (sp + 32) (0 : EvmWord) **
        evmWordIs (sp + 64) (0 : EvmWord) **
-       divScratchValuesCall (sp + 32) q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-         shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+         divScratchValuesCallNoX1 (sp + 32) q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+           shiftMem nMem jMem retMem dMem dloMem scratchUn0)
       ((.x12 ↦ᵣ (sp + 64)) **
        (.x1 ↦ᵣ ((base + 124) + 4)) **
        regOwn .x2 ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
        regOwn .x10 ** regOwn .x11 ** (.x0 ↦ᵣ (0 : Word)) **
        evmWordIs sp a ** evmWordIs (sp + 32) a **
        evmWordIs (sp + 64) (0 : EvmWord) **
-       divScratchOwnCall (sp + 32)) := by
+         divScratchOwnCallNoX1 (sp + 32)) := by
   subst hcallable
   -- Code-region monotonicity helpers
   have hmono_prog : ∀ ad i,
@@ -230,10 +230,10 @@ theorem evm_addmod_b0_n0_spec_within
        (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) ** (.x0 ↦ᵣ (0 : Word)) **
        evmWordIs sp a ** evmWordIs (sp + 32) (0 : EvmWord) **
        evmWordIs (sp + 64) (0 : EvmWord) **
-       divScratchValuesCall (sp + 32) q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-         shiftMem nMem jMem retMem dMem dloMem scratchUn0)
-      (divModStackDispatchPre (sp + 32) a (0 : EvmWord) ((base + 124) + 4)
-         v2 0 0 0 v10 0
+         divScratchValuesCallNoX1 (sp + 32) q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+           shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+        (divModStackDispatchPreCallable (sp + 32) a (0 : EvmWord) ((base + 124) + 4)
+           v2 0 0 0 v10 0
          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
          shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
        (sp ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
@@ -244,9 +244,9 @@ theorem evm_addmod_b0_n0_spec_within
           ((.x2 ↦ᵣ v2) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
            ((sp + 64) ↦ₘ (0 : Word)) ** ((sp + 72) ↦ₘ (0 : Word)) **
            ((sp + 80) ↦ₘ (0 : Word)) ** ((sp + 88) ↦ₘ (0 : Word)) **
-           divScratchValuesCall (sp + 32) q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-             shiftMem nMem jMem retMem dMem dloMem scratchUn0)
-          (by rw [divScratchValuesCall_unfold]; pcFree)
+             divScratchValuesCallNoX1 (sp + 32) q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+               shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+            (by rw [divScratchValuesCallNoX1_unfold]; pcFree)
           (evm_addmod_prologue_phase1_phase2_reduce_named_spec_within
             sp base modOff a0 a1 a2 a3 0 0 0 0 v7 v6 v5 v11 v1))))
     · -- PRE weaken: expand evmWordIs atoms to match framed prologue PRE
@@ -268,8 +268,8 @@ theorem evm_addmod_b0_n0_spec_within
   -- Step 2: Callable spec (N=0 bzero) framed with original-a atoms
   -- The callable exits at raVal &&& ~~~1 = (base+124+4) &&& ~~~1 = base+128.
   have hcall_raw :=
-    evm_mod_callable_bzero_preserving_x1_spec
-      (sp + 32) ((base + 124) + signExtend21 modOff) ((base + 124) + 4)
+      evm_mod_callable_bzero_preserving_x1_noX9_spec
+        (sp + 32) ((base + 124) + signExtend21 modOff) ((base + 124) + 4)
       a (0 : EvmWord) v2 0 0 0 v10 0
       q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
       nMem shiftMem jMem retMem dMem dloMem scratchUn0 rfl
@@ -285,10 +285,10 @@ theorem evm_addmod_b0_n0_spec_within
   exact cpsTripleWithin_weaken
     (fun _ hp => hp)
     (fun s hpost => by
-      rw [modStackDispatchPostNoX1_unfold, EvmWord.mod_zero_right] at hpost
-      rw [divScratchOwnCall_unfold, divScratchOwn_unfold] at hpost
+      rw [modStackDispatchPostCallable_unfold, EvmWord.mod_zero_right] at hpost
+      rw [divScratchOwnCallNoX1_unfold, divScratchOwn_unfold] at hpost
       rw [evmWordIs_sp_limbs_eq sp a a0 a1 a2 a3 ha0 ha1 ha2 ha3]
-      rw [divScratchOwnCall_unfold, divScratchOwn_unfold]
+      rw [divScratchOwnCallNoX1_unfold, divScratchOwn_unfold]
       simp only [BitVec.add_assoc] at hpost ⊢
       simp only [show (32 : Word) + 32 = 64 from by bv_omega,
         show (124 : Word) + 4 = 128 from by bv_omega] at hpost ⊢

--- a/EvmAsm/Evm64/DivMod/Callable.lean
+++ b/EvmAsm/Evm64/DivMod/Callable.lean
@@ -610,31 +610,47 @@ theorem evm_div_callable_spec_from_noNop_branch_return_x1_framed
         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
         nMem shiftMem jMem retMem dMem dloMem scratchUn0 branch hStack)
 
-/-- Zero-divisor DIV callable wrapper that preserves the exact incoming `x1`
-    return address. This is the callable-ready specialization needed by SDIV
-    when the absolute divisor is zero. -/
-theorem evm_div_callable_bzero_preserving_x1_spec (sp base raVal : Word)
+/-- Zero-divisor DIV callable wrapper that preserves exact `x1` for return and
+    exact `x9` as caller-framed state. This callable-only surface keeps `x1`
+    out of the scratch bundle. -/
+theorem evm_div_callable_bzero_preserving_x1_spec (sp base x9Val raVal : Word)
     (a b : EvmWord) (v2 v5 v6 v7 v10 v11 : Word)
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
      nMem shiftMem jMem retMem dMem dloMem scratchUn0 : Word)
     (hbz : b = 0) :
     cpsTripleWithin (unifiedDivBound + 1) base (raVal &&& ~~~1)
       (evm_div_callable_code base)
-      (divModStackDispatchPre sp a b
-        raVal v2 v5 v6 v7 v10 v11
+      (divModStackDispatchPreNoX1 sp a b
+        x9Val raVal v2 v5 v6 v7 v10 v11
         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
         shiftMem nMem jMem retMem dMem dloMem scratchUn0)
-      (divStackDispatchPostNoX1 sp a b ** (.x1 ↦ᵣ raVal)) := by
+      ((divStackDispatchPostCallable sp a b ** (.x1 ↦ᵣ raVal)) **
+        (.x9 ↦ᵣ x9Val)) := by
   have hStack :=
-    evm_div_bzero_stack_spec_within_dispatch_noNop_preserving_x1_uni
-      sp base a b raVal v2 v5 v6 v7 v10 v11
+    evm_div_bzero_stack_spec_within_dispatch_noNop_callable_uni
+      sp base a b x9Val raVal v2 v5 v6 v7 v10 v11
       q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
       nMem shiftMem jMem retMem dMem dloMem scratchUn0 hbz
-  exact evm_div_callable_spec_from_noNop_preserving_x1
-    sp base raVal a b v5 v6 v7 v10 v11
-    q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-    nMem shiftMem jMem retMem dMem dloMem scratchUn0
-    (DivStackSpecCase.bzero raVal v2 hbz) hStack
+  have hStackCall :=
+    cpsTripleWithin_extend_code (hmono := divCode_noNop_sub_div_callable_code) hStack
+  have hStackForRet :
+      cpsTripleWithin unifiedDivBound base (base + nopOff) (evm_div_callable_code base)
+        (divModStackDispatchPreNoX1 sp a b
+          x9Val raVal v2 v5 v6 v7 v10 v11
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+        ((divStackDispatchPostCallable sp a b ** (.x9 ↦ᵣ x9Val)) **
+          (.x1 ↦ᵣ raVal)) :=
+    cpsTripleWithin_weaken (fun _ hp => hp) (fun _ hp => by xperm_hyp hp) hStackCall
+  have hRet :=
+    cpsTripleWithin_extend_code (hmono := evm_div_callable_code_ret_sub (base := base))
+      (ret_spec_within' (base + nopOff) raVal)
+  have hRetFramed :=
+    cpsTripleWithin_frameL (divStackDispatchPostCallable sp a b ** (.x9 ↦ᵣ x9Val))
+      (by rw [divStackDispatchPostCallable_unfold, divScratchOwnCallNoX1_unfold,
+        divScratchOwn_unfold]; pcFree) hRet
+  exact cpsTripleWithin_weaken (fun _ hp => hp) (fun _ hp => by xperm_hyp hp)
+    (cpsTripleWithin_seq_same_cr hStackForRet hRetFramed)
 
 /-- MOD callable spec from a no-NOP body proof that preserves the exact incoming
     `x1` return address. Mirror of `evm_div_callable_spec_from_noNop_preserving_x1`
@@ -703,30 +719,73 @@ theorem evm_mod_callable_spec_from_noNop (sp base raVal : Word)
     cpsTripleWithin_frameL (modStackDispatchPost sp a b) hpcFreePost hRet
   exact cpsTripleWithin_seq_same_cr hStackFramed hRetFramed
 
-/-- Zero-divisor MOD callable wrapper that preserves the exact incoming `x1`
-    return address. Mirror of `evm_div_callable_bzero_preserving_x1_spec`
-    for the MOD callable. Used for ADDMOD/MULMOD N=0 callable handoff. -/
-theorem evm_mod_callable_bzero_preserving_x1_spec (sp base raVal : Word)
+/-- Zero-divisor MOD callable wrapper that preserves exact `x1` for return and
+    exact `x9` as caller-framed state. Mirror of the DIV bzero callable wrapper. -/
+theorem evm_mod_callable_bzero_preserving_x1_spec (sp base x9Val raVal : Word)
     (a b : EvmWord) (v2 v5 v6 v7 v10 v11 : Word)
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
      nMem shiftMem jMem retMem dMem dloMem scratchUn0 : Word)
     (hbz : b = 0) :
     cpsTripleWithin (unifiedDivBound + 1) base (raVal &&& ~~~1)
       (evm_mod_callable_code base)
-      (divModStackDispatchPre sp a b
+      (divModStackDispatchPreNoX1 sp a b
+        x9Val raVal v2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+      ((modStackDispatchPostCallable sp a b ** (.x1 ↦ᵣ raVal)) **
+        (.x9 ↦ᵣ x9Val)) := by
+  have hStack :=
+    evm_mod_bzero_stack_spec_within_dispatch_noNop_callable_uni
+      sp base a b x9Val raVal v2 v5 v6 v7 v10 v11
+      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      nMem shiftMem jMem retMem dMem dloMem scratchUn0 hbz
+  have hStackCall :=
+    cpsTripleWithin_extend_code (hmono := modCode_noNop_sub_mod_callable_code) hStack
+  have hStackForRet :
+      cpsTripleWithin unifiedDivBound base (base + nopOff) (evm_mod_callable_code base)
+        (divModStackDispatchPreNoX1 sp a b
+          x9Val raVal v2 v5 v6 v7 v10 v11
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+        ((modStackDispatchPostCallable sp a b ** (.x9 ↦ᵣ x9Val)) **
+          (.x1 ↦ᵣ raVal)) :=
+    cpsTripleWithin_weaken (fun _ hp => hp) (fun _ hp => by xperm_hyp hp) hStackCall
+  have hRet :=
+    cpsTripleWithin_extend_code (hmono := evm_mod_callable_code_ret_sub (base := base))
+      (ret_spec_within' (base + nopOff) raVal)
+  have hRetFramed :=
+    cpsTripleWithin_frameL (modStackDispatchPostCallable sp a b ** (.x9 ↦ᵣ x9Val))
+      (by rw [modStackDispatchPostCallable_unfold, divScratchOwnCallNoX1_unfold,
+        divScratchOwn_unfold]; pcFree) hRet
+  exact cpsTripleWithin_weaken (fun _ hp => hp) (fun _ hp => by xperm_hyp hp)
+    (cpsTripleWithin_seq_same_cr hStackForRet hRetFramed)
+
+/-- Zero-divisor MOD callable wrapper with exact `x1` and no `x9` frame. -/
+theorem evm_mod_callable_bzero_preserving_x1_noX9_spec (sp base raVal : Word)
+    (a b : EvmWord) (v2 v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (hbz : b = 0) :
+    cpsTripleWithin (unifiedDivBound + 1) base (raVal &&& ~~~1)
+      (evm_mod_callable_code base)
+      (divModStackDispatchPreCallable sp a b
         raVal v2 v5 v6 v7 v10 v11
         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
         shiftMem nMem jMem retMem dMem dloMem scratchUn0)
-      (modStackDispatchPostNoX1 sp a b ** (.x1 ↦ᵣ raVal)) := by
+      (modStackDispatchPostCallable sp a b ** (.x1 ↦ᵣ raVal)) := by
   have hStack :=
-    evm_mod_bzero_stack_spec_within_dispatch_noNop_preserving_x1_uni
+    evm_mod_bzero_stack_spec_within_dispatch_noNop_callable_x1_uni
       sp base a b raVal v2 v5 v6 v7 v10 v11
       q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
       nMem shiftMem jMem retMem dMem dloMem scratchUn0 hbz
-  exact evm_mod_callable_spec_from_noNop_preserving_x1
-    sp base raVal a b v5 v6 v7 v10 v11
-    q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-    nMem shiftMem jMem retMem dMem dloMem scratchUn0
-    (ModStackSpecCase.bzero raVal v2 hbz) hStack
+  have hStackCall :=
+    cpsTripleWithin_extend_code (hmono := modCode_noNop_sub_mod_callable_code) hStack
+  have hRet :=
+    cpsTripleWithin_extend_code (hmono := evm_mod_callable_code_ret_sub (base := base))
+      (ret_spec_within' (base + nopOff) raVal)
+  have hRetFramed :=
+    cpsTripleWithin_frameL (modStackDispatchPostCallable sp a b)
+      (modStackDispatchPostCallable_pcFree sp a b) hRet
+  exact cpsTripleWithin_seq_same_cr hStackCall hRetFramed
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Base.lean
@@ -665,7 +665,7 @@ def divScratchValuesCall (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
   ((sp + signExtend12 3968) ↦ₘ retMem) **
   ((sp + signExtend12 3960) ↦ₘ dMem) **
   ((sp + signExtend12 3952) ↦ₘ dloMem) **
-  ((sp + signExtend12 3944) ↦ₘ scratch_un0)
+  ((sp + signExtend12 3944) ↦ₘ scratch_un0) ** regOwn .x1
 
 /-- Named unfold for `divScratchValuesCall`. -/
 theorem divScratchValuesCall_unfold {sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
@@ -676,7 +676,7 @@ theorem divScratchValuesCall_unfold {sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
      ((sp + signExtend12 3968) ↦ₘ retMem) **
      ((sp + signExtend12 3960) ↦ₘ dMem) **
      ((sp + signExtend12 3952) ↦ₘ dloMem) **
-     ((sp + signExtend12 3944) ↦ₘ scratch_un0)) := by
+     ((sp + signExtend12 3944) ↦ₘ scratch_un0) ** regOwn .x1) := by
   delta divScratchValuesCall; rfl
 
 /-- Value-agnostic counterpart to `divScratchValues`: the same 15 cells but
@@ -739,7 +739,7 @@ def divScratchOwnCall (sp : Word) : Assertion :=
   memOwn (sp + signExtend12 3968) **
   memOwn (sp + signExtend12 3960) **
   memOwn (sp + signExtend12 3952) **
-  memOwn (sp + signExtend12 3944)
+  memOwn (sp + signExtend12 3944) ** regOwn .x1
 
 /-- Named unfold for `divScratchOwnCall`. Parallel to `divScratchOwn_unfold`
     and `divScratchValuesCall_unfold`. -/
@@ -749,12 +749,74 @@ theorem divScratchOwnCall_unfold {sp : Word} :
      memOwn (sp + signExtend12 3968) **
      memOwn (sp + signExtend12 3960) **
      memOwn (sp + signExtend12 3952) **
-     memOwn (sp + signExtend12 3944)) := by
+     memOwn (sp + signExtend12 3944) ** regOwn .x1) := by
   delta divScratchOwnCall; rfl
+
+/-- Callable-ready concrete call scratch bundle, with `x1` kept out of the
+    scratch ownership so wrappers can expose the exact return address as its
+    own atom. This is intentionally separate from `divScratchValuesCall`, whose
+    historical shape includes `regOwn .x1` for public dispatcher posts. -/
+@[irreducible]
+def divScratchValuesCallNoX1 (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    shiftMem nMem jMem retMem dMem dloMem scratch_un0 : Word) : Assertion :=
+  divScratchValues sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    shiftMem nMem jMem **
+  ((sp + signExtend12 3968) ↦ₘ retMem) **
+  ((sp + signExtend12 3960) ↦ₘ dMem) **
+  ((sp + signExtend12 3952) ↦ₘ dloMem) **
+  ((sp + signExtend12 3944) ↦ₘ scratch_un0)
+
+/-- Named unfold for `divScratchValuesCallNoX1`. -/
+theorem divScratchValuesCallNoX1_unfold {sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    shiftMem nMem jMem retMem dMem dloMem scratch_un0 : Word} :
+    divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0 =
+      (divScratchValues sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem **
+       ((sp + signExtend12 3968) ↦ₘ retMem) **
+       ((sp + signExtend12 3960) ↦ₘ dMem) **
+       ((sp + signExtend12 3952) ↦ₘ dloMem) **
+       ((sp + signExtend12 3944) ↦ₘ scratch_un0)) := by
+  delta divScratchValuesCallNoX1; rfl
+
+/-- Callable-ready ownership counterpart to `divScratchValuesCallNoX1`;
+    intentionally omits `regOwn .x1`. -/
+@[irreducible]
+def divScratchOwnCallNoX1 (sp : Word) : Assertion :=
+  divScratchOwn sp **
+  memOwn (sp + signExtend12 3968) **
+  memOwn (sp + signExtend12 3960) **
+  memOwn (sp + signExtend12 3952) **
+  memOwn (sp + signExtend12 3944)
+
+/-- Named unfold for `divScratchOwnCallNoX1`. -/
+theorem divScratchOwnCallNoX1_unfold {sp : Word} :
+    divScratchOwnCallNoX1 sp =
+    (divScratchOwn sp **
+     memOwn (sp + signExtend12 3968) **
+     memOwn (sp + signExtend12 3960) **
+     memOwn (sp + signExtend12 3952) **
+     memOwn (sp + signExtend12 3944)) := by
+  delta divScratchOwnCallNoX1; rfl
 
 instance pcFreeInst_divScratchOwn (sp : Word) :
     Assertion.PCFree (divScratchOwn sp) :=
   ⟨pcFree_divScratchOwn⟩
+
+instance pcFreeInst_divScratchValuesCallNoX1
+    (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem
+      retMem dMem dloMem scratch_un0 : Word) :
+    Assertion.PCFree (divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratch_un0) := by
+  constructor
+  rw [divScratchValuesCallNoX1_unfold]
+  pcFree
+
+instance pcFreeInst_divScratchOwnCallNoX1 (sp : Word) :
+    Assertion.PCFree (divScratchOwnCallNoX1 sp) := by
+  constructor
+  rw [divScratchOwnCallNoX1_unfold, divScratchOwn_unfold]
+  pcFree
 
 /-- Weakening: any concrete scratch state implies ownership of the same 15
     cells. This lets a stack spec hide the scratch values on exit. -/
@@ -782,7 +844,21 @@ theorem divScratchValuesCall_implies_divScratchOwnCall
   -- Head: divScratchValues → divScratchOwn via the 15-cell weakener.
   apply sepConj_mono (divScratchValues_implies_divScratchOwn
     sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem)
-  -- Tail: 4 memIs → memOwn, same pattern as the 15-cell weakener.
+  -- Tail: 4 memIs → memOwn, preserving the framed return register.
+  iterate 4 apply sepConj_mono memIs_implies_memOwn
+  exact fun _ hp => hp
+
+/-- Callable-ready call-path weakening, keeping `x1` outside the scratch
+    bundle so it can be tracked exactly by wrappers. -/
+theorem divScratchValuesCallNoX1_implies_divScratchOwnCallNoX1
+    (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem
+     retMem dMem dloMem scratch_un0 : Word) :
+    ∀ h, divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0 h →
+      divScratchOwnCallNoX1 sp h := by
+  unfold divScratchValuesCallNoX1 divScratchOwnCallNoX1
+  apply sepConj_mono (divScratchValues_implies_divScratchOwn
+    sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem)
   iterate 3 apply sepConj_mono memIs_implies_memOwn
   exact memIs_implies_memOwn
 
@@ -805,7 +881,7 @@ def loopSetupPost (sp nVal shift a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
   (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ nVal) ** (.x10 ↦ᵣ (a0 >>> (antiShift.toNat % 64))) **
   (.x0 ↦ᵣ (0 : Word)) **
   (.x6 ↦ᵣ shift) ** (.x7 ↦ᵣ u0) ** (.x2 ↦ᵣ antiShift) **
-  (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - nVal) **
+  (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - nVal) **
   ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
   ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
   ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
@@ -835,7 +911,7 @@ theorem loopSetupPost_unfold {sp nVal shift a0 a1 a2 a3 b0 b1 b2 b3 : Word} :
     (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ nVal) ** (.x10 ↦ᵣ (a0 >>> (antiShift.toNat % 64))) **
     (.x0 ↦ᵣ (0 : Word)) **
     (.x6 ↦ᵣ shift) ** (.x7 ↦ᵣ u0) ** (.x2 ↦ᵣ antiShift) **
-    (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - nVal) **
+    (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - nVal) **
     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
     ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **

--- a/EvmAsm/Evm64/DivMod/Compose/Div128.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Div128.lean
@@ -119,11 +119,11 @@ def div128SpecPost (sp retAddr d uLo uHi : Word) : Assertion :=
   let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
   let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo un0
   let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
-  let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
+  let x9Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
   let q := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   (.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ retAddr) ** (.x10 ↦ᵣ q1') **
   (.x5 ↦ᵣ q0') ** (.x7 ↦ᵣ x7Exit) **
-  (.x6 ↦ᵣ dHi) ** (.x1 ↦ᵣ x1Exit) ** (.x11 ↦ᵣ q) **
+  (.x6 ↦ᵣ dHi) ** (.x9 ↦ᵣ x9Exit) ** (.x11 ↦ᵣ q) **
   (.x0 ↦ᵣ (0 : Word)) **
   (sp + signExtend12 3968 ↦ₘ retAddr) **
   (sp + signExtend12 3960 ↦ₘ d) **
@@ -131,7 +131,7 @@ def div128SpecPost (sp retAddr d uLo uHi : Word) : Assertion :=
   (sp + signExtend12 3944 ↦ₘ un0)
 
 private theorem div128_spec_within_of_sub (sp retAddr d uLo uHi : Word) (base : Word)
-    (v1Old v6Old v11Old : Word)
+    (v9Old v6Old v11Old : Word)
     (retMem dMem dloMem un0Mem : Word)
     (halign : (retAddr + signExtend12 0) &&& ~~~1 = retAddr)
     (code : CodeReq)
@@ -144,7 +144,7 @@ private theorem div128_spec_within_of_sub (sp retAddr d uLo uHi : Word) (base : 
       (-- Precondition: caller registers + scratch memory
        (.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ retAddr) ** (.x10 ↦ᵣ d) **
        (.x5 ↦ᵣ uLo) ** (.x7 ↦ᵣ uHi) **
-       (.x6 ↦ᵣ v6Old) ** (.x1 ↦ᵣ v1Old) ** (.x11 ↦ᵣ v11Old) **
+       (.x6 ↦ᵣ v6Old) ** (.x9 ↦ᵣ v9Old) ** (.x11 ↦ᵣ v11Old) **
        (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
@@ -182,14 +182,14 @@ private theorem div128_spec_within_of_sub (sp retAddr d uLo uHi : Word) (base : 
   let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
   let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo un0
   let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
-  let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
+  let x9Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
   let x11Exit := if rhat2cHi = 0 then un0 else rhat2c
   let q := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   -- ================================================================
   -- Block 1: Phase 1 (base+1072 → base+1112)
   -- Saves ret/d, splits d and uLo into halves.
   -- ================================================================
-  have hph1 := divK_div128_phase1_spec_within sp retAddr d uLo uHi v1Old v6Old v11Old
+  have hph1 := divK_div128_phase1_spec_within sp retAddr d uLo uHi v9Old v6Old v11Old
     retMem dMem dloMem un0Mem (base + div128Off)
   -- Extend phase1 cr to sharedDivModCode
   have hph1e := cpsTripleWithin_extend_code (hmono := by
@@ -267,7 +267,7 @@ private theorem div128_spec_within_of_sub (sp retAddr d uLo uHi : Word) (base : 
   -- ================================================================
   -- Block 4: Step 2 (base+1192 → base+1260)
   -- Trial division q0, clamp, Phase 2b guard, product check.
-  -- Params: un21(x7), dHi(x6), v1Old=cu_q1_dlo(x1),
+  -- Params: un21(x7), dHi(x6), v9Old=cu_q1_dlo(x1),
   --         v5Old=cu_rhat_un1(x5), v11Old=un1(x11),
   --         dlo=dLo(mem[3952]), un0(mem[3944])
   -- NOTE: 17 instructions (was 15) — SRLI+BNE guard added between clamp
@@ -320,7 +320,7 @@ private theorem div128_spec_within_of_sub (sp retAddr d uLo uHi : Word) (base : 
     hend
   -- Frame end with x7, x6, x1, x0, mem[3960], mem[3952], mem[3944]
   have hendf := cpsTripleWithin_frameR
-    ((.x7 ↦ᵣ x7Exit) ** (.x6 ↦ᵣ dHi) ** (.x1 ↦ᵣ x1Exit) **
+    ((.x7 ↦ᵣ x7Exit) ** (.x6 ↦ᵣ dHi) ** (.x9 ↦ᵣ x9Exit) **
      (.x0 ↦ᵣ (0 : Word)) **
      (sp + signExtend12 3960 ↦ₘ d) ** (sp + signExtend12 3952 ↦ₘ dLo) **
      (sp + signExtend12 3944 ↦ₘ un0))
@@ -335,13 +335,13 @@ private theorem div128_spec_within_of_sub (sp retAddr d uLo uHi : Word) (base : 
     h12345
 
 theorem div128_spec_within (sp retAddr d uLo uHi : Word) (base : Word)
-    (v1Old v6Old v11Old : Word)
+    (v9Old v6Old v11Old : Word)
     (retMem dMem dloMem un0Mem : Word)
     (halign : (retAddr + signExtend12 0) &&& ~~~1 = retAddr) :
     cpsTripleWithin 51 (base + div128Off) retAddr (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ retAddr) ** (.x10 ↦ᵣ d) **
        (.x5 ↦ᵣ uLo) ** (.x7 ↦ᵣ uHi) **
-       (.x6 ↦ᵣ v6Old) ** (.x1 ↦ᵣ v1Old) ** (.x11 ↦ᵣ v11Old) **
+       (.x6 ↦ᵣ v6Old) ** (.x9 ↦ᵣ v9Old) ** (.x11 ↦ᵣ v11Old) **
        (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
@@ -349,19 +349,19 @@ theorem div128_spec_within (sp retAddr d uLo uHi : Word) (base : Word)
        (sp + signExtend12 3944 ↦ₘ un0Mem))
       (div128SpecPost sp retAddr d uLo uHi) :=
   div128_spec_within_of_sub sp retAddr d uLo uHi base
-    v1Old v6Old v11Old retMem dMem dloMem un0Mem halign
+    v9Old v6Old v11Old retMem dMem dloMem un0Mem halign
     (sharedDivModCode base) d128_sub
 
 /-- `div128_spec_within` replayed over the DIV no-NOP code surface. This is
     the subroutine certificate needed by the no-NOP trial-call composition. -/
 theorem div128_spec_within_noNop (sp retAddr d uLo uHi : Word) (base : Word)
-    (v1Old v6Old v11Old : Word)
+    (v9Old v6Old v11Old : Word)
     (retMem dMem dloMem un0Mem : Word)
     (halign : (retAddr + signExtend12 0) &&& ~~~1 = retAddr) :
     cpsTripleWithin 51 (base + div128Off) retAddr (divCode_noNop base)
       ((.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ retAddr) ** (.x10 ↦ᵣ d) **
        (.x5 ↦ᵣ uLo) ** (.x7 ↦ᵣ uHi) **
-       (.x6 ↦ᵣ v6Old) ** (.x1 ↦ᵣ v1Old) ** (.x11 ↦ᵣ v11Old) **
+       (.x6 ↦ᵣ v6Old) ** (.x9 ↦ᵣ v9Old) ** (.x11 ↦ᵣ v11Old) **
        (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
@@ -369,5 +369,5 @@ theorem div128_spec_within_noNop (sp retAddr d uLo uHi : Word) (base : Word)
        (sp + signExtend12 3944 ↦ₘ un0Mem))
       (div128SpecPost sp retAddr d uLo uHi) :=
   div128_spec_within_of_sub sp retAddr d uLo uHi base
-    v1Old v6Old v11Old retMem dMem dloMem un0Mem halign
+    v9Old v6Old v11Old retMem dMem dloMem un0Mem halign
     (divCode_noNop base) d128_sub_noNop

--- a/EvmAsm/Evm64/DivMod/Compose/Div128V4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Div128V4.lean
@@ -112,12 +112,12 @@ def div128V4SpecPost (sp retAddr d uLo uHi scratchMem : Word) : Assertion :=
   let x7Exit_step2 := if rhat2cHi ≠ 0 then un21
                       else if rhat2'Hi ≠ 0 then q0Dlo1
                       else q0Dlo2
-  let x1Exit_step2 := if rhat2cHi ≠ 0 then rhat2cHi
+  let x9Exit_step2 := if rhat2cHi ≠ 0 then rhat2cHi
                       else if rhat2'Hi ≠ 0 then rhat2'Hi
                       else rhat2'Un0
   (.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ retAddr) ** (.x10 ↦ᵣ q1'') **
   (.x5 ↦ᵣ q0'') ** (.x7 ↦ᵣ x7Exit_step2) **
-  (.x6 ↦ᵣ dHi) ** (.x1 ↦ᵣ x1Exit_step2) ** (.x11 ↦ᵣ q) **
+  (.x6 ↦ᵣ dHi) ** (.x9 ↦ᵣ x9Exit_step2) ** (.x11 ↦ᵣ q) **
   (.x0 ↦ᵣ (0 : Word)) **
   (sp + signExtend12 3968 ↦ₘ retAddr) **
   (sp + signExtend12 3960 ↦ₘ d) **
@@ -148,7 +148,7 @@ def div128V4SpecPost (sp retAddr d uLo uHi scratchMem : Word) : Assertion :=
 
     Estimated: ~700 LOC for the full proof (vs ~600 for v2). -/
 theorem div128_v4_spec (sp retAddr d uLo uHi : Word) (base : Word)
-    (v1Old v6Old v11Old : Word)
+    (v9Old v6Old v11Old : Word)
     (retMem dMem dloMem un0Mem scratchMem : Word)
     (_halign : (retAddr + signExtend12 0) &&& ~~~1 = retAddr) :
     cpsTripleWithin 73 (base + div128Off) retAddr
@@ -157,7 +157,7 @@ theorem div128_v4_spec (sp retAddr d uLo uHi : Word) (base : Word)
        -- 3936 (used to save rhat2c across the un0 LD clobber).
        (.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ retAddr) ** (.x10 ↦ᵣ d) **
        (.x5 ↦ᵣ uLo) ** (.x7 ↦ᵣ uHi) **
-       (.x6 ↦ᵣ v6Old) ** (.x1 ↦ᵣ v1Old) ** (.x11 ↦ᵣ v11Old) **
+       (.x6 ↦ᵣ v6Old) ** (.x9 ↦ᵣ v9Old) ** (.x11 ↦ᵣ v11Old) **
        (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
@@ -188,7 +188,7 @@ theorem div128_v4_spec (sp retAddr d uLo uHi : Word) (base : Word)
   let rhat'' := if rhatHi2 = 0 ∧ BitVec.ult rhatUn1' qDlo2
                 then rhat' + dHi else rhat'
   -- Block 1: Phase 1 (base+1072 → base+1112).
-  have hph1 := divK_div128_phase1_spec_within sp retAddr d uLo uHi v1Old v6Old v11Old
+  have hph1 := divK_div128_phase1_spec_within sp retAddr d uLo uHi v9Old v6Old v11Old
     retMem dMem dloMem un0Mem (base + div128Off)
   have hph1e := cpsTripleWithin_extend_code (hmono := by
     exact CodeReq.union_sub (d128_v4_sub 0 _ _ (by decide) (by bv_addr) (by decide))
@@ -245,8 +245,8 @@ theorem div128_v4_spec (sp retAddr d uLo uHi : Word) (base : Word)
     (fun h hp => by xperm_hyp hp) hph1f hst1f
   -- Block 3: compute_un21 (base+1212 → base+1232).
   let x5Exit_st1 := if rhatHi2 = 0 then qDlo2 else qDlo1
-  let x1Exit_st1 := if rhatHi2 = 0 then rhatUn1' else rhatHi2
-  have hcu := divK_div128_compute_un21_spec_within sp q1'' rhat'' un1 x1Exit_st1 x5Exit_st1 dLo
+  let x9Exit_st1 := if rhatHi2 = 0 then rhatUn1' else rhatHi2
+  have hcu := divK_div128_compute_un21_spec_within sp q1'' rhat'' un1 x9Exit_st1 x5Exit_st1 dLo
     (base + div128Off + 140)
   rw [show (base + div128Off + 140 : Word) + 20 = base + div128Off + 160 from by bv_addr] at hcu
   have hcue := cpsTripleWithin_extend_code (hmono := by
@@ -305,7 +305,7 @@ theorem div128_v4_spec (sp retAddr d uLo uHi : Word) (base : Word)
   let x7Exit_step2 := if rhat2cHi ≠ 0 then un21
                       else if rhat2'Hi ≠ 0 then q0Dlo1
                       else q0Dlo2
-  let x1Exit_step2 := if rhat2cHi ≠ 0 then rhat2cHi
+  let x9Exit_step2 := if rhat2cHi ≠ 0 then rhat2cHi
                       else if rhat2'Hi ≠ 0 then rhat2'Hi
                       else rhat2'Un0
   let x11Exit_step2 := if rhat2cHi ≠ 0 then rhat2c
@@ -321,7 +321,7 @@ theorem div128_v4_spec (sp retAddr d uLo uHi : Word) (base : Word)
       (d128_v4_sub 74 _ _ (by decide) (by bv_addr) (by decide)))))
     hend
   have hendf := cpsTripleWithin_frameR
-    ((.x7 ↦ᵣ x7Exit_step2) ** (.x6 ↦ᵣ dHi) ** (.x1 ↦ᵣ x1Exit_step2) **
+    ((.x7 ↦ᵣ x7Exit_step2) ** (.x6 ↦ᵣ dHi) ** (.x9 ↦ᵣ x9Exit_step2) **
      (.x0 ↦ᵣ (0 : Word)) **
      (sp + signExtend12 3960 ↦ₘ d) ** (sp + signExtend12 3952 ↦ₘ dLo) **
      (sp + signExtend12 3944 ↦ₘ un0) ** (sp + signExtend12 3936 ↦ₘ mem3936Exit))
@@ -340,13 +340,13 @@ theorem div128_v4_spec (sp retAddr d uLo uHi : Word) (base : Word)
     Future v4-migrated specs (loop body, full path) will use this
     lifted form. -/
 theorem div128_v4_spec_shared (sp retAddr d uLo uHi : Word) (base : Word)
-    (v1Old v6Old v11Old : Word)
+    (v9Old v6Old v11Old : Word)
     (retMem dMem dloMem un0Mem scratchMem : Word)
     (halign : (retAddr + signExtend12 0) &&& ~~~1 = retAddr) :
     cpsTripleWithin 73 (base + div128Off) retAddr (sharedDivModCode_v4 base)
       ((.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ retAddr) ** (.x10 ↦ᵣ d) **
        (.x5 ↦ᵣ uLo) ** (.x7 ↦ᵣ uHi) **
-       (.x6 ↦ᵣ v6Old) ** (.x1 ↦ᵣ v1Old) ** (.x11 ↦ᵣ v11Old) **
+       (.x6 ↦ᵣ v6Old) ** (.x9 ↦ᵣ v9Old) ** (.x11 ↦ᵣ v11Old) **
        (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
@@ -355,7 +355,7 @@ theorem div128_v4_spec_shared (sp retAddr d uLo uHi : Word) (base : Word)
        (sp + signExtend12 3936 ↦ₘ scratchMem))
       (div128V4SpecPost sp retAddr d uLo uHi scratchMem) :=
   cpsTripleWithin_extend_code (hmono := shared_b12_div128_v4_sub)
-    (div128_v4_spec sp retAddr d uLo uHi base v1Old v6Old v11Old
+    (div128_v4_spec sp retAddr d uLo uHi base v9Old v6Old v11Old
       retMem dMem dloMem un0Mem scratchMem halign)
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPath.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPath.lean
@@ -263,7 +263,7 @@ theorem evm_div_n4_to_loopSetup_spec (sp base : Word)
     cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4) base (base + loopBodyOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
@@ -294,7 +294,7 @@ theorem evm_div_n4_to_loopSetup_spec (sp base : Word)
 
   -- Frame NormB result with a[], u[] scratch, x1
   have hNormBf := cpsTripleWithin_frameR
-    ((.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+    ((.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
      ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
      ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
      ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
@@ -309,7 +309,7 @@ theorem evm_div_n4_to_loopSetup_spec (sp base : Word)
   -- Frame NormA with x0, b[], scratch q/u5-7/n/shift
   have hNormAf := cpsTripleWithin_frameR
     ((.x0 ↦ᵣ (0 : Word)) **
-     (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
      ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
      ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3') **
      ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
@@ -362,7 +362,7 @@ theorem evm_div_n4_to_loopSetup_spec_noNop (sp base : Word)
     cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4) base (base + loopBodyOff) (divCode_noNop base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
@@ -390,7 +390,7 @@ theorem evm_div_n4_to_loopSetup_spec_noNop (sp base : Word)
   have hNormB := evm_div_n4_to_normB_spec_noNop sp base b0 b1 b2 b3 v5 v6 v7 v10
     q0 q1 q2 q3 u5 u6 u7 nMem shiftMem hbnz hb3nz hshift_nz
   have hNormBf := cpsTripleWithin_frameR
-    ((.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+    ((.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
      ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
      ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
      ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
@@ -404,7 +404,7 @@ theorem evm_div_n4_to_loopSetup_spec_noNop (sp base : Word)
   simp only [normAFullPost_unfold] at hNormA
   have hNormAf := cpsTripleWithin_frameR
     ((.x0 ↦ᵣ (0 : Word)) **
-     (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
      ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
      ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3') **
      ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
@@ -460,7 +460,7 @@ theorem evm_div_n4_shift0_to_loopSetup_spec (sp base : Word)
     cpsTripleWithin (8 + 21 + 24 + 4 + 9 + 4) base (base + loopBodyOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
@@ -476,7 +476,7 @@ theorem evm_div_n4_shift0_to_loopSetup_spec (sp base : Word)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (4 : Word)) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ (clzResult b3).1) ** (.x7 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
        (.x2 ↦ᵣ signExtend12 (0 : BitVec 12) - (clzResult b3).1) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
@@ -495,7 +495,7 @@ theorem evm_div_n4_shift0_to_loopSetup_spec (sp base : Word)
   -- Frame AB+CLZ with x2, x1, a[], u[0..4], shiftMem
   have hABCLZf := cpsTripleWithin_frameR
     ((.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
-     (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
      ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
      ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
      ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
@@ -510,7 +510,7 @@ theorem evm_div_n4_shift0_to_loopSetup_spec (sp base : Word)
   have hC2f := cpsTripleWithin_frameR
     ((.x5 ↦ᵣ (clzResult b3).2) ** (.x10 ↦ᵣ b3) **
      (.x7 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
-     (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
      ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
      ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
      ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
@@ -538,7 +538,7 @@ theorem evm_div_n4_shift0_to_loopSetup_spec (sp base : Word)
      (.x2 ↦ᵣ signExtend12 (0 : BitVec 12) - (clzResult b3).1) **
      (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ b3) **
      (.x7 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
-     (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
      ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
      ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
      ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
@@ -592,7 +592,7 @@ theorem evm_div_n4_shift0_to_loopSetup_spec_noNop (sp base : Word)
     cpsTripleWithin (8 + 21 + 24 + 4 + 9 + 4) base (base + loopBodyOff) (divCode_noNop base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
@@ -608,7 +608,7 @@ theorem evm_div_n4_shift0_to_loopSetup_spec_noNop (sp base : Word)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (4 : Word)) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ (clzResult b3).1) ** (.x7 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
        (.x2 ↦ᵣ signExtend12 (0 : BitVec 12) - (clzResult b3).1) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
@@ -625,7 +625,7 @@ theorem evm_div_n4_shift0_to_loopSetup_spec_noNop (sp base : Word)
     q0 q1 q2 q3 u5 u6 u7 nMem hbnz hb3nz
   have hABCLZf := cpsTripleWithin_frameR
     ((.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
-     (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
      ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
      ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
      ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
@@ -638,7 +638,7 @@ theorem evm_div_n4_shift0_to_loopSetup_spec_noNop (sp base : Word)
   have hC2f := cpsTripleWithin_frameR
     ((.x5 ↦ᵣ (clzResult b3).2) ** (.x10 ↦ᵣ b3) **
      (.x7 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
-     (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
      ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
      ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
      ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
@@ -661,7 +661,7 @@ theorem evm_div_n4_shift0_to_loopSetup_spec_noNop (sp base : Word)
      (.x2 ↦ᵣ signExtend12 (0 : BitVec 12) - (clzResult b3).1) **
      (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ b3) **
      (.x7 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
-     (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
      ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
      ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
      ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1.lean
@@ -86,7 +86,7 @@ theorem evm_div_n1_to_loopSetup_spec_within (sp base : Word)
     cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4) base (base + loopBodyOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b0).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
@@ -117,7 +117,7 @@ theorem evm_div_n1_to_loopSetup_spec_within (sp base : Word)
 
   have hABCLZf := cpsTripleWithin_frameR
     ((.x2 ↦ᵣ (clzResult b0).2 >>> (63 : Nat)) **
-     (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
      ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
      ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
      ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
@@ -131,7 +131,7 @@ theorem evm_div_n1_to_loopSetup_spec_within (sp base : Word)
   have hC2f := cpsTripleWithin_frameR
     ((.x5 ↦ᵣ (clzResult b0).2) ** (.x10 ↦ᵣ b3) **
      (.x7 ↦ᵣ (clzResult b0).2 >>> (63 : Nat)) **
-     (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
      ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
      ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
      ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
@@ -153,7 +153,7 @@ theorem evm_div_n1_to_loopSetup_spec_within (sp base : Word)
   simp only [normBFullPost_unfold] at hNB
   have hNBf := cpsTripleWithin_frameR
     ((.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
-     (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
      ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
      ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
      ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
@@ -174,7 +174,7 @@ theorem evm_div_n1_to_loopSetup_spec_within (sp base : Word)
   simp only [normAFullPost_unfold] at hNormA
   have hNormAf := cpsTripleWithin_frameR
     ((.x0 ↦ᵣ (0 : Word)) **
-     (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
      ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
      ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3') **
      ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1Loop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1Loop.lean
@@ -81,7 +81,7 @@ theorem n1_qa3 {sp : Word} :
 theorem loopExitPostN1_j0_eq (sp q_f c3 un0F un1F un2F un3F u4F
     v0 v1 v2 v3 : Word) :
     loopExitPostN1 sp (0 : Word) q_f c3 un0F un1F un2F un3F u4F v0 v1 v2 v3 =
-    ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ signExtend12 4095) **
+    ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ signExtend12 4095) **
      (.x5 ↦ᵣ (0 : Word)) ** (.x6 ↦ᵣ sp + signExtend12 4056) **
      (.x7 ↦ᵣ sp + signExtend12 4088) ** (.x10 ↦ᵣ c3) ** (.x11 ↦ᵣ q_f) **
      (.x2 ↦ᵣ un3F) ** (.x0 ↦ᵣ (0 : Word)) **

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1LoopUnified.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1LoopUnified.lean
@@ -266,7 +266,7 @@ theorem evm_div_n1_preloop_loop_unified_spec
     cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 808) base (base + denormOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b0).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        (.x11 ↦ᵣ v11Old) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
@@ -284,7 +284,7 @@ theorem evm_div_n1_preloop_loop_unified_spec
        ((sp + signExtend12 3968) ↦ₘ retMem) **
        ((sp + signExtend12 3960) ↦ₘ dMem) **
        ((sp + signExtend12 3952) ↦ₘ dloMem) **
-       ((sp + signExtend12 3944) ↦ₘ scratch_un0))
+       ((sp + signExtend12 3944) ↦ₘ scratch_un0) ** regOwn .x1)
       (preloopN1UnifiedPost bltu_3 bltu_2 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
         retMem dMem dloMem scratch_un0) := by
   -- 1. Pre-loop: base → base+448
@@ -300,7 +300,7 @@ theorem evm_div_n1_preloop_loop_unified_spec
      (sp + signExtend12 3968 ↦ₘ retMem) **
      (sp + signExtend12 3960 ↦ₘ dMem) **
      (sp + signExtend12 3952 ↦ₘ dloMem) **
-     (sp + signExtend12 3944 ↦ₘ scratch_un0))
+     (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
     (by pcFree) hPre
   -- 2. Loop: base+448 → base+904 (unified da, with explicit normalized values)
   have hLoop := evm_div_n1_loop_unified_inst bltu_3 bltu_2 bltu_1 bltu_0 sp base
@@ -365,7 +365,7 @@ theorem evm_div_n1_noNop_preloop_loop_unified_spec
     cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 808) base (base + denormOff) (divCode_noNop base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b0).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        (.x11 ↦ᵣ v11Old) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
@@ -383,7 +383,7 @@ theorem evm_div_n1_noNop_preloop_loop_unified_spec
        ((sp + signExtend12 3968) ↦ₘ retMem) **
        ((sp + signExtend12 3960) ↦ₘ dMem) **
        ((sp + signExtend12 3952) ↦ₘ dloMem) **
-       ((sp + signExtend12 3944) ↦ₘ scratch_un0))
+       ((sp + signExtend12 3944) ↦ₘ scratch_un0) ** regOwn .x1)
       (preloopN1UnifiedPost bltu_3 bltu_2 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
         retMem dMem dloMem scratch_un0) := by
   -- 1. No-NOP pre-loop.
@@ -396,7 +396,7 @@ theorem evm_div_n1_noNop_preloop_loop_unified_spec
      (sp + signExtend12 3968 ↦ₘ retMem) **
      (sp + signExtend12 3960 ↦ₘ dMem) **
      (sp + signExtend12 3952 ↦ₘ dloMem) **
-     (sp + signExtend12 3944 ↦ₘ scratch_un0))
+     (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
     (by pcFree) hPreNoNop
   -- 2. No-NOP unified loop: base+448 → base+904.
   have hLoop := evm_div_n1_loop_unified_inst_noNop bltu_3 bltu_2 bltu_1 bltu_0 sp base
@@ -542,7 +542,7 @@ def fullDivN1Scratch (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
   (sp + signExtend12 3968 ↦ₘ (if bltu_0 then (base + div128CallRetOff) else scratch_ret1)) **
   (sp + signExtend12 3960 ↦ₘ (if bltu_0 then v.1 else scratch_d1)) **
   (sp + signExtend12 3952 ↦ₘ (if bltu_0 then div128DLo v.1 else scratch_dlo1)) **
-  (sp + signExtend12 3944 ↦ₘ (if bltu_0 then div128Un0 u.1 else scratch_un01))
+  (sp + signExtend12 3944 ↦ₘ (if bltu_0 then div128Un0 u.1 else scratch_un01)) ** regOwn .x1
 
 @[irreducible]
 def fullDivN1DenormPre (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
@@ -587,7 +587,7 @@ def fullDivN1Frame (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
   ((sp + signExtend12 4000) ↦ₘ r3.2.2.2.2.2) **
   (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
   (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-  (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ r0.1) **
+  (.x9 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ r0.1) **
   fullDivN1Scratch bltu_3 bltu_2 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
     retMem dMem dloMem scratch_un0
 
@@ -735,7 +735,7 @@ theorem evm_div_n1_full_unified_spec
     cpsTripleWithin 946 base (base + nopOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b0).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        (.x11 ↦ᵣ v11Old) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
@@ -753,7 +753,7 @@ theorem evm_div_n1_full_unified_spec
        ((sp + signExtend12 3968) ↦ₘ retMem) **
        ((sp + signExtend12 3960) ↦ₘ dMem) **
        ((sp + signExtend12 3952) ↦ₘ dloMem) **
-       ((sp + signExtend12 3944) ↦ₘ scratch_un0))
+       ((sp + signExtend12 3944) ↦ₘ scratch_un0) ** regOwn .x1)
       (fullDivN1UnifiedPost bltu_3 bltu_2 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
         retMem dMem dloMem scratch_un0) := by
   have hA := evm_div_n1_preloop_loop_unified_spec bltu_3 bltu_2 bltu_1 bltu_0 sp base
@@ -804,7 +804,7 @@ theorem evm_div_n1_noNop_full_unified_spec
     cpsTripleWithin 946 base (base + nopOff) (divCode_noNop base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b0).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        (.x11 ↦ᵣ v11Old) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
@@ -822,7 +822,7 @@ theorem evm_div_n1_noNop_full_unified_spec
        ((sp + signExtend12 3968) ↦ₘ retMem) **
        ((sp + signExtend12 3960) ↦ₘ dMem) **
        ((sp + signExtend12 3952) ↦ₘ dloMem) **
-       ((sp + signExtend12 3944) ↦ₘ scratch_un0))
+       ((sp + signExtend12 3944) ↦ₘ scratch_un0) ** regOwn .x1)
       (fullDivN1UnifiedPost bltu_3 bltu_2 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
         retMem dMem dloMem scratch_un0) := by
   have hA := evm_div_n1_noNop_preloop_loop_unified_spec bltu_3 bltu_2 bltu_1 bltu_0 sp base

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1NoNop.lean
@@ -260,7 +260,7 @@ theorem evm_div_n1_to_loopSetup_spec_within_noNop (sp base : Word)
     cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4) base (base + loopBodyOff) (divCode_noNop base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b0).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
@@ -291,7 +291,7 @@ theorem evm_div_n1_to_loopSetup_spec_within_noNop (sp base : Word)
   simp only [evmDivPhaseABN1ClzC2NormBPre_unfold,
       evmDivPhaseABN1ClzC2NormBFullPost_unfold] at hNB
   have hNBf := cpsTripleWithin_frameR
-    ((.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+    ((.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
      ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
      ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
      ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
@@ -305,7 +305,7 @@ theorem evm_div_n1_to_loopSetup_spec_within_noNop (sp base : Word)
   simp only [normAFullPost_unfold] at hNormA
   have hNormAf := cpsTripleWithin_frameR
     ((.x0 ↦ᵣ (0 : Word)) **
-     (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
      ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
      ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3') **
      ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2.lean
@@ -206,7 +206,7 @@ theorem evm_div_n2_to_loopSetup_spec_within_noNop (sp base : Word)
     cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4) base (base + loopBodyOff) (divCode_noNop base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
@@ -234,7 +234,7 @@ theorem evm_div_n2_to_loopSetup_spec_within_noNop (sp base : Word)
   have hNB := evm_div_n2_to_normB_spec_within_noNop sp base b0 b1 b2 b3 v5 v6 v7 v10
     q0 q1 q2 q3 u5 u6 u7 nMem shiftMem hbnz hb3z hb2z hb1nz hshift_nz
   have hNBf := cpsTripleWithin_frameR
-    ((.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+    ((.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
      ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
      ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
      ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
@@ -248,7 +248,7 @@ theorem evm_div_n2_to_loopSetup_spec_within_noNop (sp base : Word)
   simp only [normAFullPost_unfold] at hNormA
   have hNormAf := cpsTripleWithin_frameR
     ((.x0 ↦ᵣ (0 : Word)) **
-     (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
      ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
      ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3') **
      ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
@@ -296,7 +296,7 @@ theorem evm_div_n2_to_loopSetup_spec_within (sp base : Word)
     cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4) base (base + loopBodyOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
@@ -327,7 +327,7 @@ theorem evm_div_n2_to_loopSetup_spec_within (sp base : Word)
 
   have hABCLZf := cpsTripleWithin_frameR
     ((.x2 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
-     (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
      ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
      ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
      ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
@@ -341,7 +341,7 @@ theorem evm_div_n2_to_loopSetup_spec_within (sp base : Word)
   have hC2f := cpsTripleWithin_frameR
     ((.x5 ↦ᵣ (clzResult b1).2) ** (.x10 ↦ᵣ b3) **
      (.x7 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
-     (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
      ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
      ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
      ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
@@ -363,7 +363,7 @@ theorem evm_div_n2_to_loopSetup_spec_within (sp base : Word)
   simp only [normBFullPost_unfold] at hNB
   have hNBf := cpsTripleWithin_frameR
     ((.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
-     (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
      ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
      ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
      ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
@@ -384,7 +384,7 @@ theorem evm_div_n2_to_loopSetup_spec_within (sp base : Word)
   simp only [normAFullPost_unfold] at hNormA
   have hNormAf := cpsTripleWithin_frameR
     ((.x0 ↦ᵣ (0 : Word)) **
-     (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
      ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
      ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3') **
      ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle/Full.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle/Full.lean
@@ -93,7 +93,7 @@ theorem evm_div_n2_full_bundled_spec
     cpsTripleWithin 744 base (base + nopOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        (.x11 ↦ᵣ v11Old) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
@@ -111,7 +111,7 @@ theorem evm_div_n2_full_bundled_spec
        ((sp + signExtend12 3968) ↦ₘ retMem) **
        ((sp + signExtend12 3960) ↦ₘ dMem) **
        ((sp + signExtend12 3952) ↦ₘ dloMem) **
-       ((sp + signExtend12 3944) ↦ₘ scratch_un0))
+       ((sp + signExtend12 3944) ↦ₘ scratch_un0) ** regOwn .x1)
       (fullDivN2DenormPost bltu_2 bltu_1 bltu_0 sp a0 a1 a2 a3 b0 b1 b2 b3 **
        fullDivN2Frame bltu_2 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
          retMem dMem dloMem scratch_un0) := by
@@ -161,7 +161,7 @@ theorem evm_div_n2_full_bundled_spec_noNop
     cpsTripleWithin 744 base (base + nopOff) (divCode_noNop base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        (.x11 ↦ᵣ v11Old) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
@@ -179,7 +179,7 @@ theorem evm_div_n2_full_bundled_spec_noNop
        ((sp + signExtend12 3968) ↦ₘ retMem) **
        ((sp + signExtend12 3960) ↦ₘ dMem) **
        ((sp + signExtend12 3952) ↦ₘ dloMem) **
-       ((sp + signExtend12 3944) ↦ₘ scratch_un0))
+       ((sp + signExtend12 3944) ↦ₘ scratch_un0) ** regOwn .x1)
       (fullDivN2DenormPost bltu_2 bltu_1 bltu_0 sp a0 a1 a2 a3 b0 b1 b2 b3 **
        fullDivN2Frame bltu_2 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
          retMem dMem dloMem scratch_un0) := by

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle/State.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle/State.lean
@@ -76,11 +76,11 @@ def fullDivN2Frame (bltu_2 bltu_1 bltu_0 : Bool)
   ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
   (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
   (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-  (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ r0.1) **
+  (.x9 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ r0.1) **
   (sp + signExtend12 3968 ↦ₘ n2ScratchRet scratch) **
   (sp + signExtend12 3960 ↦ₘ n2ScratchD scratch) **
   (sp + signExtend12 3952 ↦ₘ n2ScratchDLo scratch) **
-  (sp + signExtend12 3944 ↦ₘ n2ScratchUn0 scratch)
+  (sp + signExtend12 3944 ↦ₘ n2ScratchUn0 scratch) ** regOwn .x1
 
 theorem fullDivN2ScratchFinal_unfold (bltu_2 bltu_1 bltu_0 : Bool)
     (base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 : Word) :
@@ -140,11 +140,11 @@ theorem fullDivN2Frame_unfold (bltu_2 bltu_1 bltu_0 : Bool)
     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
     (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
     (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-    (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ r0.1) **
+    (.x9 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ r0.1) **
     (sp + signExtend12 3968 ↦ₘ n2ScratchRet scratch) **
     (sp + signExtend12 3960 ↦ₘ n2ScratchD scratch) **
     (sp + signExtend12 3952 ↦ₘ n2ScratchDLo scratch) **
-    (sp + signExtend12 3944 ↦ₘ n2ScratchUn0 scratch) := by
+    (sp + signExtend12 3944 ↦ₘ n2ScratchUn0 scratch) ** regOwn .x1 := by
   delta fullDivN2Frame
   rfl
 

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2Loop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2Loop.lean
@@ -79,7 +79,7 @@ theorem n2_qa2 {sp : Word} :
 theorem loopExitPostN2_j0_eq (sp q_f c3 un0F un1F un2F un3F u4F
     v0 v1 v2 v3 : Word) :
     loopExitPostN2 sp (0 : Word) q_f c3 un0F un1F un2F un3F u4F v0 v1 v2 v3 =
-    ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ signExtend12 4095) **
+    ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ signExtend12 4095) **
      (.x5 ↦ᵣ (0 : Word)) ** (.x6 ↦ᵣ sp + signExtend12 4056) **
      (.x7 ↦ᵣ sp + signExtend12 4088) ** (.x10 ↦ᵣ c3) ** (.x11 ↦ᵣ q_f) **
      (.x2 ↦ᵣ un3F) ** (.x0 ↦ᵣ (0 : Word)) **

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2LoopUnified.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2LoopUnified.lean
@@ -202,7 +202,7 @@ theorem evm_div_n2_preloop_loop_unified_spec
     cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 606) base (base + denormOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        (.x11 ↦ᵣ v11Old) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
@@ -220,7 +220,7 @@ theorem evm_div_n2_preloop_loop_unified_spec
        ((sp + signExtend12 3968) ↦ₘ retMem) **
        ((sp + signExtend12 3960) ↦ₘ dMem) **
        ((sp + signExtend12 3952) ↦ₘ dloMem) **
-       ((sp + signExtend12 3944) ↦ₘ scratch_un0))
+       ((sp + signExtend12 3944) ↦ₘ scratch_un0) ** regOwn .x1)
       (preloopN2UnifiedPost bltu_2 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
         retMem dMem dloMem scratch_un0) := by
   -- 1. Pre-loop: base → base+448
@@ -236,7 +236,7 @@ theorem evm_div_n2_preloop_loop_unified_spec
      (sp + signExtend12 3968 ↦ₘ retMem) **
      (sp + signExtend12 3960 ↦ₘ dMem) **
      (sp + signExtend12 3952 ↦ₘ dloMem) **
-     (sp + signExtend12 3944 ↦ₘ scratch_un0))
+     (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
     (by pcFree) hPre
   -- 2. Loop: base+448 → base+904 (unified da, with explicit normalized values)
   have hLoop := evm_div_n2_loop_unified_inst bltu_2 bltu_1 bltu_0 sp base
@@ -303,7 +303,7 @@ theorem evm_div_n2_preloop_loop_unified_spec_noNop
     cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 606) base (base + denormOff) (divCode_noNop base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        (.x11 ↦ᵣ v11Old) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
@@ -321,7 +321,7 @@ theorem evm_div_n2_preloop_loop_unified_spec_noNop
        ((sp + signExtend12 3968) ↦ₘ retMem) **
        ((sp + signExtend12 3960) ↦ₘ dMem) **
        ((sp + signExtend12 3952) ↦ₘ dloMem) **
-       ((sp + signExtend12 3944) ↦ₘ scratch_un0))
+       ((sp + signExtend12 3944) ↦ₘ scratch_un0) ** regOwn .x1)
       (preloopN2UnifiedPost bltu_2 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
         retMem dMem dloMem scratch_un0) := by
   -- 1. Pre-loop: base → base+448
@@ -337,7 +337,7 @@ theorem evm_div_n2_preloop_loop_unified_spec_noNop
      (sp + signExtend12 3968 ↦ₘ retMem) **
      (sp + signExtend12 3960 ↦ₘ dMem) **
      (sp + signExtend12 3952 ↦ₘ dloMem) **
-     (sp + signExtend12 3944 ↦ₘ scratch_un0))
+     (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
     (by pcFree) hPre
   -- 2. Loop: base+448 → base+904 (unified da, with explicit normalized values)
   have hLoop := evm_div_n2_loop_unified_inst_noNop bltu_2 bltu_1 bltu_0 sp base

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3.lean
@@ -206,7 +206,7 @@ theorem evm_div_n3_to_loopSetup_spec_within_noNop (sp base : Word)
     cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4) base (base + loopBodyOff) (divCode_noNop base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
@@ -234,7 +234,7 @@ theorem evm_div_n3_to_loopSetup_spec_within_noNop (sp base : Word)
   have hNB := evm_div_n3_to_normB_spec_within_noNop sp base b0 b1 b2 b3 v5 v6 v7 v10
     q0 q1 q2 q3 u5 u6 u7 nMem shiftMem hbnz hb3z hb2nz hshift_nz
   have hNBf := cpsTripleWithin_frameR
-    ((.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+    ((.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
      ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
      ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
      ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
@@ -248,7 +248,7 @@ theorem evm_div_n3_to_loopSetup_spec_within_noNop (sp base : Word)
   simp only [normAFullPost_unfold] at hNormA
   have hNormAf := cpsTripleWithin_frameR
     ((.x0 ↦ᵣ (0 : Word)) **
-     (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
      ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
      ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3') **
      ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
@@ -296,7 +296,7 @@ theorem evm_div_n3_to_loopSetup_spec_within (sp base : Word)
     cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4) base (base + loopBodyOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
@@ -327,7 +327,7 @@ theorem evm_div_n3_to_loopSetup_spec_within (sp base : Word)
 
   have hABCLZf := cpsTripleWithin_frameR
     ((.x2 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
-     (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
      ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
      ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
      ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
@@ -341,7 +341,7 @@ theorem evm_div_n3_to_loopSetup_spec_within (sp base : Word)
   have hC2f := cpsTripleWithin_frameR
     ((.x5 ↦ᵣ (clzResult b2).2) ** (.x10 ↦ᵣ b3) **
      (.x7 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
-     (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
      ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
      ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
      ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
@@ -363,7 +363,7 @@ theorem evm_div_n3_to_loopSetup_spec_within (sp base : Word)
   simp only [normBFullPost_unfold] at hNB
   have hNBf := cpsTripleWithin_frameR
     ((.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
-     (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
      ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
      ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
      ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
@@ -384,7 +384,7 @@ theorem evm_div_n3_to_loopSetup_spec_within (sp base : Word)
   simp only [normAFullPost_unfold] at hNormA
   have hNormAf := cpsTripleWithin_frameR
     ((.x0 ↦ᵣ (0 : Word)) **
-     (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
      ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
      ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3') **
      ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3LoopUnified.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3LoopUnified.lean
@@ -159,7 +159,7 @@ theorem evm_div_n3_preloop_loop_unified_spec (bltu_1 bltu_0 : Bool) (sp base : W
     cpsTripleWithin 507 base (base + denormOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        (.x11 ↦ᵣ v11Old) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
@@ -177,7 +177,7 @@ theorem evm_div_n3_preloop_loop_unified_spec (bltu_1 bltu_0 : Bool) (sp base : W
        ((sp + signExtend12 3968) ↦ₘ retMem) **
        ((sp + signExtend12 3960) ↦ₘ dMem) **
        ((sp + signExtend12 3952) ↦ₘ dloMem) **
-       ((sp + signExtend12 3944) ↦ₘ scratch_un0))
+       ((sp + signExtend12 3944) ↦ₘ scratch_un0) ** regOwn .x1)
       (preloopN3UnifiedPost bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
         retMem dMem dloMem scratch_un0) := by
   -- 1. Pre-loop: base → base+448
@@ -191,7 +191,7 @@ theorem evm_div_n3_preloop_loop_unified_spec (bltu_1 bltu_0 : Bool) (sp base : W
      (sp + signExtend12 3968 ↦ₘ retMem) **
      (sp + signExtend12 3960 ↦ₘ dMem) **
      (sp + signExtend12 3952 ↦ₘ dloMem) **
-     (sp + signExtend12 3944 ↦ₘ scratch_un0))
+     (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
     (by pcFree) hPre
   -- 2. Loop: base+448 → base+908 (unified da, with explicit normalized values)
   have hLoop := evm_div_n3_loop_unified_inst bltu_1 bltu_0 sp base
@@ -254,7 +254,7 @@ theorem evm_div_n3_preloop_loop_unified_spec_noNop (bltu_1 bltu_0 : Bool) (sp ba
     cpsTripleWithin 507 base (base + denormOff) (divCode_noNop base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        (.x11 ↦ᵣ v11Old) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
@@ -272,7 +272,7 @@ theorem evm_div_n3_preloop_loop_unified_spec_noNop (bltu_1 bltu_0 : Bool) (sp ba
        ((sp + signExtend12 3968) ↦ₘ retMem) **
        ((sp + signExtend12 3960) ↦ₘ dMem) **
        ((sp + signExtend12 3952) ↦ₘ dloMem) **
-       ((sp + signExtend12 3944) ↦ₘ scratch_un0))
+       ((sp + signExtend12 3944) ↦ₘ scratch_un0) ** regOwn .x1)
       (preloopN3UnifiedPost bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
         retMem dMem dloMem scratch_un0) := by
   have hPre := evm_div_n3_to_loopSetup_spec_within_noNop sp base
@@ -284,7 +284,7 @@ theorem evm_div_n3_preloop_loop_unified_spec_noNop (bltu_1 bltu_0 : Bool) (sp ba
      (sp + signExtend12 3968 ↦ₘ retMem) **
      (sp + signExtend12 3960 ↦ₘ dMem) **
      (sp + signExtend12 3952 ↦ₘ dloMem) **
-     (sp + signExtend12 3944 ↦ₘ scratch_un0))
+     (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
     (by pcFree) hPre
   have hLoop := evm_div_n3_loop_unified_inst_noNop bltu_1 bltu_0 sp base
     (clzResult b2).1 (signExtend12 (0 : BitVec 12) - (clzResult b2).1)
@@ -335,7 +335,7 @@ theorem evm_div_n3_preloop_loop_unified_spec_noNop (bltu_1 bltu_0 : Bool) (sp ba
 theorem loopExitPostN3_j0_eq (sp q_f c3 un0F un1F un2F un3F u4F
     v0 v1 v2 v3 : Word) :
     loopExitPostN3 sp (0 : Word) q_f c3 un0F un1F un2F un3F u4F v0 v1 v2 v3 =
-    ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ signExtend12 4095) **
+    ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ signExtend12 4095) **
      (.x5 ↦ᵣ (0 : Word)) ** (.x6 ↦ᵣ sp + signExtend12 4056) **
      (.x7 ↦ᵣ sp + signExtend12 4088) ** (.x10 ↦ᵣ c3) ** (.x11 ↦ᵣ q_f) **
      (.x2 ↦ᵣ un3F) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -428,7 +428,7 @@ def fullDivN3Scratch (bltu_1 bltu_0 : Bool)
   (sp + signExtend12 3968 ↦ₘ (if bltu_0 then (base + div128CallRetOff) else scratch_ret1)) **
   (sp + signExtend12 3960 ↦ₘ (if bltu_0 then v.2.2.1 else scratch_d1)) **
   (sp + signExtend12 3952 ↦ₘ (if bltu_0 then div128DLo v.2.2.1 else scratch_dlo1)) **
-  (sp + signExtend12 3944 ↦ₘ (if bltu_0 then div128Un0 r1.2.2.1 else scratch_un01))
+  (sp + signExtend12 3944 ↦ₘ (if bltu_0 then div128Un0 r1.2.2.1 else scratch_un01)) ** regOwn .x1
 
 @[irreducible]
 def fullDivN3DenormPre (bltu_1 bltu_0 : Bool)
@@ -469,7 +469,7 @@ def fullDivN3Frame (bltu_1 bltu_0 : Bool)
   ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
   (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
   (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-  (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ r0.1) **
+  (.x9 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ r0.1) **
   fullDivN3Scratch bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
     retMem dMem dloMem scratch_un0
 
@@ -593,7 +593,7 @@ theorem fullDivN3Frame_unfold (bltu_1 bltu_0 : Bool)
     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
     (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
     (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-    (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ r0.1) **
+    (.x9 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ r0.1) **
     fullDivN3Scratch bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
       retMem dMem dloMem scratch_un0 := by
   delta fullDivN3Frame
@@ -628,7 +628,7 @@ theorem fullDivN3Scratch_false_true (sp base a0 a1 a2 a3 b0 b1 b2 b3
     ((sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
      (sp + signExtend12 3960 ↦ₘ v.2.2.1) **
      (sp + signExtend12 3952 ↦ₘ div128DLo v.2.2.1) **
-     (sp + signExtend12 3944 ↦ₘ div128Un0 r1.2.2.1)) := by
+     (sp + signExtend12 3944 ↦ₘ div128Un0 r1.2.2.1) ** regOwn .x1) := by
   delta fullDivN3Scratch
   rfl
 
@@ -641,7 +641,7 @@ theorem fullDivN3Scratch_true_false (sp base a0 a1 a2 a3 b0 b1 b2 b3
     ((sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
      (sp + signExtend12 3960 ↦ₘ v.2.2.1) **
      (sp + signExtend12 3952 ↦ₘ div128DLo v.2.2.1) **
-     (sp + signExtend12 3944 ↦ₘ div128Un0 u.2.2.2.1)) := by
+     (sp + signExtend12 3944 ↦ₘ div128Un0 u.2.2.2.1) ** regOwn .x1) := by
   delta fullDivN3Scratch
   rfl
 
@@ -654,7 +654,7 @@ theorem fullDivN3Scratch_true_true (sp base a0 a1 a2 a3 b0 b1 b2 b3
     ((sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
      (sp + signExtend12 3960 ↦ₘ v.2.2.1) **
      (sp + signExtend12 3952 ↦ₘ div128DLo v.2.2.1) **
-     (sp + signExtend12 3944 ↦ₘ div128Un0 r1.2.2.1)) := by
+     (sp + signExtend12 3944 ↦ₘ div128Un0 r1.2.2.1) ** regOwn .x1) := by
   delta fullDivN3Scratch
   rfl
 
@@ -883,7 +883,7 @@ theorem evm_div_n3_full_unified_spec (bltu_1 bltu_0 : Bool) (sp base : Word)
     cpsTripleWithin 542 base (base + nopOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        (.x11 ↦ᵣ v11Old) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
@@ -901,7 +901,7 @@ theorem evm_div_n3_full_unified_spec (bltu_1 bltu_0 : Bool) (sp base : Word)
        ((sp + signExtend12 3968) ↦ₘ retMem) **
        ((sp + signExtend12 3960) ↦ₘ dMem) **
        ((sp + signExtend12 3952) ↦ₘ dloMem) **
-       ((sp + signExtend12 3944) ↦ₘ scratch_un0))
+       ((sp + signExtend12 3944) ↦ₘ scratch_un0) ** regOwn .x1)
       (fullDivN3UnifiedPost bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
         retMem dMem dloMem scratch_un0) := by
   have hshift_nz' : fullDivN3Shift b2 ≠ 0 := by
@@ -954,7 +954,7 @@ theorem evm_div_n3_full_unified_spec_noNop (bltu_1 bltu_0 : Bool) (sp base : Wor
     cpsTripleWithin 542 base (base + nopOff) (divCode_noNop base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        (.x11 ↦ᵣ v11Old) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
@@ -972,7 +972,7 @@ theorem evm_div_n3_full_unified_spec_noNop (bltu_1 bltu_0 : Bool) (sp base : Wor
        ((sp + signExtend12 3968) ↦ₘ retMem) **
        ((sp + signExtend12 3960) ↦ₘ dMem) **
        ((sp + signExtend12 3952) ↦ₘ dloMem) **
-       ((sp + signExtend12 3944) ↦ₘ scratch_un0))
+       ((sp + signExtend12 3944) ↦ₘ scratch_un0) ** regOwn .x1)
       (fullDivN3UnifiedPost bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
         retMem dMem dloMem scratch_un0) := by
   have hshift_nz' : fullDivN3Shift b2 ≠ 0 := by

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4.lean
@@ -92,7 +92,7 @@ theorem divK_loop_body_n4_max_skip_j0_norm (sp base : Word)
     (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
      then (1 : Word) else 0) = (0 : Word) →
     cpsTripleWithin 76 (base + loopBodyOff) (base + denormOff) (divCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -122,7 +122,7 @@ theorem divK_loop_body_n4_max_skip_j0_norm_noNop (sp base : Word)
     (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
      then (1 : Word) else 0) = (0 : Word) →
     cpsTripleWithin 76 (base + loopBodyOff) (base + denormOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -160,7 +160,7 @@ theorem evm_div_n4_preloop_max_skip_spec (sp base : Word)
     cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 76) base (base + denormOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        (.x11 ↦ᵣ v11Old) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
@@ -239,7 +239,7 @@ theorem evm_div_n4_preloop_max_skip_spec_noNop (sp base : Word)
     cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 76) base (base + denormOff) (divCode_noNop base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        (.x11 ↦ᵣ v11Old) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
@@ -322,7 +322,7 @@ theorem preloopMaxSkipPostN4_unfold {sp a0 a1 a2 a3 b0 b1 b2 b3 : Word} :
     let u0 := a0 <<< (shift.toNat % 64)
     let qHat : Word := signExtend12 4095
     let ms := mulsubN4 qHat b0' b1' b2' b3' u0 u1 u2 u3
-    ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ signExtend12 4095) **
+    ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ signExtend12 4095) **
      (.x5 ↦ᵣ (0 : Word)) ** (.x6 ↦ᵣ sp + signExtend12 4056) **
      (.x7 ↦ᵣ sp + signExtend12 4088) ** (.x10 ↦ᵣ ms.2.2.2.2) ** (.x11 ↦ᵣ qHat) **
      (.x2 ↦ᵣ ms.2.2.2.1) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -376,7 +376,7 @@ def fullDivN4MaxSkipPost (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
   ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
   (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
   (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-  (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ qHat)
+  (.x9 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ qHat)
 
 /-- Named unfold for `fullDivN4MaxSkipPost`. Restores access to the
     underlying sepConj structure once the `@[irreducible]` attribute
@@ -406,7 +406,7 @@ theorem fullDivN4MaxSkipPost_unfold {sp a0 a1 a2 a3 b0 b1 b2 b3 : Word} :
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
      (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-     (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ qHat)) := by
+     (.x9 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ qHat)) := by
   delta fullDivN4MaxSkipPost; rfl
 
 /-- `fullDivN4MaxSkipPost` is pc-free: all its atoms (inside the
@@ -457,7 +457,7 @@ theorem evm_div_n4_max_skip_denorm_epilogue_spec_noNop (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
      (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-     (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ qHat))
+     (.x9 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ qHat))
     (by pcFree) hB
   exact cpsTripleWithin_weaken
     (fun h hp => by
@@ -510,7 +510,7 @@ def fullModN4MaxSkipPost (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
   ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
   (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
   (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-  (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ qHat)
+  (.x9 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ qHat)
 
 /-- `fullModN4MaxSkipPost` is pc-free. Mirror of
     `pcFree_fullDivN4MaxSkipPost`. -/
@@ -537,7 +537,7 @@ theorem evm_div_n4_full_max_skip_spec (sp base : Word)
     cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 76 + 2 + 23 + 10) base (base + nopOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        (.x11 ↦ᵣ v11Old) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
@@ -590,7 +590,7 @@ theorem evm_div_n4_full_max_skip_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
      (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-     (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ qHat))
+     (.x9 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ qHat))
     (by pcFree) hB
   -- 3. Compose A + B
   have hFull := cpsTripleWithin_seq_perm_same_cr
@@ -662,7 +662,7 @@ theorem divK_loop_body_n4_call_skip_j0_norm (sp base : Word)
                   (mulsubN4_c3 (div128Quot uTop u3 v3) v0 v1 v2 v3 u0 u1 u2 u3)
                 then (1 : Word) else 0) = (0 : Word)) :
     cpsTripleWithin 126 (base + loopBodyOff) (base + denormOff) (divCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -676,7 +676,7 @@ theorem divK_loop_body_n4_call_skip_j0_norm (sp base : Word)
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (loopBodyN4CallSkipJ0Post sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   have raw := divK_loop_body_n4_call_skip_j0_divCode_within sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 base halign hbltu hborrow
@@ -711,7 +711,7 @@ def preloopCallSkipPostN4 (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :
   (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
   (sp + signExtend12 3960 ↦ₘ b3') **
   (sp + signExtend12 3952 ↦ₘ dLo) **
-  (sp + signExtend12 3944 ↦ₘ div_un0) **
+  (sp + signExtend12 3944 ↦ₘ div_un0) ** regOwn .x1 **
   ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
   ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
   ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
@@ -740,7 +740,7 @@ theorem preloopCallSkipPostN4_unfold {sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word} :
     let dLo := (b3' <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     let div_un0 := (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     let ms := mulsubN4 qHat b0' b1' b2' b3' u0 u1 u2 u3
-    ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ signExtend12 4095) **
+    ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ signExtend12 4095) **
      (.x5 ↦ᵣ (0 : Word)) ** (.x6 ↦ᵣ sp + signExtend12 4056) **
      (.x7 ↦ᵣ sp + signExtend12 4088) ** (.x10 ↦ᵣ ms.2.2.2.2) ** (.x11 ↦ᵣ qHat) **
      (.x2 ↦ᵣ ms.2.2.2.1) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -754,7 +754,7 @@ theorem preloopCallSkipPostN4_unfold {sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word} :
     (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
     (sp + signExtend12 3960 ↦ₘ b3') **
     (sp + signExtend12 3952 ↦ₘ dLo) **
-    (sp + signExtend12 3944 ↦ₘ div_un0) **
+    (sp + signExtend12 3944 ↦ₘ div_un0) ** regOwn .x1 **
     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
     ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
@@ -781,7 +781,7 @@ theorem evm_div_n4_preloop_call_skip_spec (sp base : Word)
     cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 126) base (base + denormOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        (.x11 ↦ᵣ v11Old) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
@@ -797,7 +797,7 @@ theorem evm_div_n4_preloop_call_skip_spec (sp base : Word)
        ((sp + signExtend12 3992) ↦ₘ shiftMem) **
        ((sp + signExtend12 3976) ↦ₘ jMem) **
        (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
-       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (preloopCallSkipPostN4 sp base a0 a1 a2 a3 b0 b1 b2 b3) := by
   unfold isCallTrialN4 at hbltu
   unfold isSkipBorrowN4Call at hborrow
@@ -821,7 +821,7 @@ theorem evm_div_n4_preloop_call_skip_spec (sp base : Word)
   have hPreF := cpsTripleWithin_frameR
     ((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
      (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
-     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
     (by pcFree) hPre
   have hLoop := divK_loop_body_n4_call_skip_j0_norm sp base
     jMem (4 : Word) shift u0 (a0 >>> (antiShift.toNat % 64)) v11Old antiShift
@@ -881,11 +881,11 @@ def fullDivN4CallSkipPost (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :
   ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
   (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
   (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-  (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ qHat) **
+  (.x9 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ qHat) **
   (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
   (sp + signExtend12 3960 ↦ₘ b3') **
   (sp + signExtend12 3952 ↦ₘ dLo) **
-  (sp + signExtend12 3944 ↦ₘ div_un0)
+  (sp + signExtend12 3944 ↦ₘ div_un0) ** regOwn .x1
 
 /-- Named unfold for `fullDivN4CallSkipPost`. Restores access to the
     underlying sepConj structure once the `@[irreducible]` attribute
@@ -919,11 +919,11 @@ theorem fullDivN4CallSkipPost_unfold {sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word} :
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
      (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-     (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ qHat) **
+     (.x9 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ qHat) **
      (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
      (sp + signExtend12 3960 ↦ₘ b3') **
      (sp + signExtend12 3952 ↦ₘ dLo) **
-     (sp + signExtend12 3944 ↦ₘ div_un0)) := by
+     (sp + signExtend12 3944 ↦ₘ div_un0) ** regOwn .x1) := by
   delta fullDivN4CallSkipPost; rfl
 
 theorem evm_div_n4_call_skip_denorm_epilogue_spec_noNop (sp base : Word)
@@ -962,11 +962,11 @@ theorem evm_div_n4_call_skip_denorm_epilogue_spec_noNop (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
      (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-     (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ qHat) **
+     (.x9 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ qHat) **
      (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
      (sp + signExtend12 3960 ↦ₘ b3') **
      (sp + signExtend12 3952 ↦ₘ dLo) **
-     (sp + signExtend12 3944 ↦ₘ div_un0))
+     (sp + signExtend12 3944 ↦ₘ div_un0) ** regOwn .x1)
     (by pcFree) hB
   exact cpsTripleWithin_weaken
     (fun h hp => by
@@ -992,7 +992,7 @@ theorem evm_div_n4_full_call_skip_spec (sp base : Word)
     cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 126 + 2 + 23 + 10) base (base + nopOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        (.x11 ↦ᵣ v11Old) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
@@ -1010,7 +1010,7 @@ theorem evm_div_n4_full_call_skip_spec (sp base : Word)
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (fullDivN4CallSkipPost sp base a0 a1 a2 a3 b0 b1 b2 b3) := by
   let shift := (clzResult b3).1
   let antiShift := signExtend12 (0 : BitVec 12) - shift
@@ -1050,11 +1050,11 @@ theorem evm_div_n4_full_call_skip_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
      (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-     (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ qHat) **
+     (.x9 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ qHat) **
      (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
      (sp + signExtend12 3960 ↦ₘ b3') **
      (sp + signExtend12 3952 ↦ₘ dLo) **
-     (sp + signExtend12 3944 ↦ₘ div_un0))
+     (sp + signExtend12 3944 ↦ₘ div_un0) ** regOwn .x1)
     (by pcFree) hB
   -- 3. Compose
   have hFull := cpsTripleWithin_seq_perm_same_cr
@@ -1105,11 +1105,11 @@ def fullModN4CallSkipPost (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :
   ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
   (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
   (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-  (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ qHat) **
+  (.x9 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ qHat) **
   (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
   (sp + signExtend12 3960 ↦ₘ b3') **
   (sp + signExtend12 3952 ↦ₘ dLo) **
-  (sp + signExtend12 3944 ↦ₘ div_un0)
+  (sp + signExtend12 3944 ↦ₘ div_un0) ** regOwn .x1
 
 /-- Named unfold for `fullModN4CallSkipPost`. Restores access to the
     underlying sepConj structure once the `@[irreducible]` attribute on
@@ -1147,11 +1147,11 @@ theorem fullModN4CallSkipPost_unfold {sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word} :
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
      (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-     (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ qHat) **
+     (.x9 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ qHat) **
      (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
      (sp + signExtend12 3960 ↦ₘ b3') **
      (sp + signExtend12 3952 ↦ₘ dLo) **
-     (sp + signExtend12 3944 ↦ₘ div_un0)) := by
+     (sp + signExtend12 3944 ↦ₘ div_un0) ** regOwn .x1) := by
   delta fullModN4CallSkipPost; rfl
 
 /-- `fullModN4CallSkipPost` is pc-free. Mirror of `pcFree_fullDivN4CallSkipPost`. -/

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4Beq.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4Beq.lean
@@ -36,7 +36,7 @@ theorem divK_loop_body_n4_call_addback_j0_beq_norm (sp base : Word)
                   (mulsubN4_c3 (div128Quot uTop u3 v3) v0 v1 v2 v3 u0 u1 u2 u3)
                 then (1 : Word) else 0) ≠ (0 : Word)) :
     cpsTripleWithin 202 (base + loopBodyOff) (base + denormOff) (divCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -50,7 +50,7 @@ theorem divK_loop_body_n4_call_addback_j0_beq_norm (sp base : Word)
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (loopBodyN4CallAddbackBeqJ0Post sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   have raw := divK_loop_body_n4_call_addback_j0_beq_divCode_within sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 base halign hbltu hcarry2_nz hborrow
@@ -72,7 +72,7 @@ theorem divK_loop_body_n4_call_addback_j0_beq_norm_noNop (sp base : Word)
                   (mulsubN4_c3 (div128Quot uTop u3 v3) v0 v1 v2 v3 u0 u1 u2 u3)
                 then (1 : Word) else 0) ≠ (0 : Word)) :
     cpsTripleWithin 202 (base + loopBodyOff) (base + denormOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -86,7 +86,7 @@ theorem divK_loop_body_n4_call_addback_j0_beq_norm_noNop (sp base : Word)
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (loopBodyN4CallAddbackBeqJ0Post sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   exact cpsTripleWithin_weaken
     (fun _ hp => by
@@ -148,7 +148,7 @@ def preloopCallAddbackBeqPostN4 (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Asser
   (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
   (sp + signExtend12 3960 ↦ₘ b3') **
   (sp + signExtend12 3952 ↦ₘ dLo) **
-  (sp + signExtend12 3944 ↦ₘ div_un0) **
+  (sp + signExtend12 3944 ↦ₘ div_un0) ** regOwn .x1 **
   ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
   ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
   ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
@@ -195,7 +195,7 @@ theorem evm_div_n4_preloop_call_addback_beq_spec (sp base : Word)
     cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 202) base (base + denormOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) ** (.x11 ↦ᵣ v11Old) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) ** (.x11 ↦ᵣ v11Old) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
        ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
@@ -207,7 +207,7 @@ theorem evm_div_n4_preloop_call_addback_beq_spec (sp base : Word)
        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
        ((sp + signExtend12 3992) ↦ₘ shiftMem) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
        (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
-       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (preloopCallAddbackBeqPostN4 sp base a0 a1 a2 a3 b0 b1 b2 b3) := by
   unfold isCallTrialN4 at hbltu
   unfold isAddbackBorrowN4Call at hborrow
@@ -232,7 +232,7 @@ theorem evm_div_n4_preloop_call_addback_beq_spec (sp base : Word)
   have hPreF := cpsTripleWithin_frameR
     ((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
      (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
-     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
     (by pcFree) hPre
   have hLoop := divK_loop_body_n4_call_addback_j0_beq_norm sp base
     jMem (4 : Word) shift u0 (a0 >>> (antiShift.toNat % 64)) v11Old antiShift
@@ -273,7 +273,7 @@ theorem evm_div_n4_preloop_call_addback_beq_spec_noNop (sp base : Word)
     cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 202) base (base + denormOff) (divCode_noNop base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) ** (.x11 ↦ᵣ v11Old) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) ** (.x11 ↦ᵣ v11Old) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
        ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
@@ -285,7 +285,7 @@ theorem evm_div_n4_preloop_call_addback_beq_spec_noNop (sp base : Word)
        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
        ((sp + signExtend12 3992) ↦ₘ shiftMem) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
        (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
-       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (preloopCallAddbackBeqPostN4 sp base a0 a1 a2 a3 b0 b1 b2 b3) := by
   unfold isCallTrialN4 at hbltu
   unfold isAddbackBorrowN4Call at hborrow
@@ -308,7 +308,7 @@ theorem evm_div_n4_preloop_call_addback_beq_spec_noNop (sp base : Word)
   have hPreF := cpsTripleWithin_frameR
     ((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
      (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
-     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
     (by pcFree) hPre
   have hLoop := divK_loop_body_n4_call_addback_j0_beq_norm_noNop sp base
     jMem (4 : Word) shift u0 (a0 >>> (antiShift.toNat % 64)) v11Old antiShift
@@ -369,7 +369,7 @@ theorem preloopCallAddbackBeqPostN4_unfold {sp base a0 a1 a2 a3 b0 b1 b2 b3 : Wo
     let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
     let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
     let u4_out  := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
-    ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ signExtend12 4095) **
+    ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ signExtend12 4095) **
      (.x5 ↦ᵣ (0 : Word)) ** (.x6 ↦ᵣ sp + signExtend12 4056) **
      (.x7 ↦ᵣ sp + signExtend12 4088) ** (.x10 ↦ᵣ c3) ** (.x11 ↦ᵣ q_out) **
      (.x2 ↦ᵣ un3Out) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -383,7 +383,7 @@ theorem preloopCallAddbackBeqPostN4_unfold {sp base a0 a1 a2 a3 b0 b1 b2 b3 : Wo
     (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
     (sp + signExtend12 3960 ↦ₘ b3') **
     (sp + signExtend12 3952 ↦ₘ dLo) **
-    (sp + signExtend12 3944 ↦ₘ div_un0) **
+    (sp + signExtend12 3944 ↦ₘ div_un0) ** regOwn .x1 **
     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
     ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
@@ -436,11 +436,11 @@ def fullDivN4CallAddbackBeqPost (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Asser
   ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
   (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
   (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-  (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ q_out) **
+  (.x9 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ q_out) **
   (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
   (sp + signExtend12 3960 ↦ₘ b3') **
   (sp + signExtend12 3952 ↦ₘ dLo) **
-  (sp + signExtend12 3944 ↦ₘ div_un0)
+  (sp + signExtend12 3944 ↦ₘ div_un0) ** regOwn .x1
 
 /-- Full n=4 DIV path: base → base+1068 (shift ≠ 0, call+addback BEQ). -/
 theorem evm_div_n4_full_call_addback_beq_spec (sp base : Word)
@@ -456,7 +456,7 @@ theorem evm_div_n4_full_call_addback_beq_spec (sp base : Word)
     cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 202 + 2 + 23 + 10) base (base + nopOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) ** (.x11 ↦ᵣ v11Old) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) ** (.x11 ↦ᵣ v11Old) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
        ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
@@ -468,7 +468,7 @@ theorem evm_div_n4_full_call_addback_beq_spec (sp base : Word)
        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
        ((sp + signExtend12 3992) ↦ₘ shiftMem) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
        (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
-       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (fullDivN4CallAddbackBeqPost sp base a0 a1 a2 a3 b0 b1 b2 b3) := by
   let shift := (clzResult b3).1
   let antiShift := signExtend12 (0 : BitVec 12) - shift
@@ -516,9 +516,9 @@ theorem evm_div_n4_full_call_addback_beq_spec (sp base : Word)
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      (sp + signExtend12 3984 ↦ₘ (4 : Word)) ** (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-     (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ q_out) **
+     (.x9 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ q_out) **
      (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) ** (sp + signExtend12 3960 ↦ₘ b3') **
-     (sp + signExtend12 3952 ↦ₘ dLo) ** (sp + signExtend12 3944 ↦ₘ div_un0))
+     (sp + signExtend12 3952 ↦ₘ dLo) ** (sp + signExtend12 3944 ↦ₘ div_un0) ** regOwn .x1)
     (by pcFree) hB
   have hFull := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by simp only [preloopCallAddbackBeqPostN4_unfold] at hp; xperm_hyp hp) hA hBF
@@ -569,11 +569,11 @@ theorem fullDivN4CallAddbackBeqPost_unfold {sp base a0 a1 a2 a3 b0 b1 b2 b3 : Wo
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
      (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-     (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ q_out) **
+     (.x9 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ q_out) **
      (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
      (sp + signExtend12 3960 ↦ₘ b3') **
      (sp + signExtend12 3952 ↦ₘ dLo) **
-     (sp + signExtend12 3944 ↦ₘ div_un0)) := by
+     (sp + signExtend12 3944 ↦ₘ div_un0) ** regOwn .x1) := by
   delta fullDivN4CallAddbackBeqPost; rfl
 
 theorem evm_div_n4_call_addback_beq_denorm_epilogue_spec_noNop (sp base : Word)
@@ -621,9 +621,9 @@ theorem evm_div_n4_call_addback_beq_denorm_epilogue_spec_noNop (sp base : Word)
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      (sp + signExtend12 3984 ↦ₘ (4 : Word)) ** (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-     (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ q_out) **
+     (.x9 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ q_out) **
      (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) ** (sp + signExtend12 3960 ↦ₘ b3') **
-     (sp + signExtend12 3952 ↦ₘ dLo) ** (sp + signExtend12 3944 ↦ₘ div_un0))
+     (sp + signExtend12 3952 ↦ₘ dLo) ** (sp + signExtend12 3944 ↦ₘ div_un0) ** regOwn .x1)
     (by pcFree) hB
   exact cpsTripleWithin_weaken
     (fun h hp => by
@@ -650,7 +650,7 @@ theorem evm_div_n4_full_call_addback_beq_spec_noNop (sp base : Word)
       base (base + nopOff) (divCode_noNop base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) ** (.x11 ↦ᵣ v11Old) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) ** (.x11 ↦ᵣ v11Old) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
        ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
@@ -662,7 +662,7 @@ theorem evm_div_n4_full_call_addback_beq_spec_noNop (sp base : Word)
        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
        ((sp + signExtend12 3992) ↦ₘ shiftMem) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
        (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
-       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (fullDivN4CallAddbackBeqPost sp base a0 a1 a2 a3 b0 b1 b2 b3) := by
   have hA := evm_div_n4_preloop_call_addback_beq_spec_noNop sp base
     a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old
@@ -727,11 +727,11 @@ def fullModN4CallAddbackBeqPost (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Asser
   ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
   (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
   (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-  (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ q_out) **
+  (.x9 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ q_out) **
   (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
   (sp + signExtend12 3960 ↦ₘ b3') **
   (sp + signExtend12 3952 ↦ₘ dLo) **
-  (sp + signExtend12 3944 ↦ₘ div_un0)
+  (sp + signExtend12 3944 ↦ₘ div_un0) ** regOwn .x1
 
 /-- Named unfold for `fullModN4CallAddbackBeqPost`. Restores access to
     the underlying sepConj structure once the `@[irreducible]` attribute
@@ -781,11 +781,11 @@ theorem fullModN4CallAddbackBeqPost_unfold {sp base a0 a1 a2 a3 b0 b1 b2 b3 : Wo
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
      (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-     (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ q_out) **
+     (.x9 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ q_out) **
      (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
      (sp + signExtend12 3960 ↦ₘ b3') **
      (sp + signExtend12 3952 ↦ₘ dLo) **
-     (sp + signExtend12 3944 ↦ₘ div_un0)) := by
+     (sp + signExtend12 3944 ↦ₘ div_un0) ** regOwn .x1) := by
   delta fullModN4CallAddbackBeqPost; rfl
 
 /-- `fullModN4CallAddbackBeqPost` is pc-free. Mirror of

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4Loop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4Loop.lean
@@ -56,7 +56,7 @@ theorem q_addr_j0 {sp : Word} :
 theorem loopExitPostN4_j0_eq (sp q_f c3 un0F un1F un2F un3F u4F
     v0 v1 v2 v3 : Word) :
     loopExitPostN4 sp (0 : Word) q_f c3 un0F un1F un2F un3F u4F v0 v1 v2 v3 =
-    ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ signExtend12 4095) **
+    ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ signExtend12 4095) **
      (.x5 ↦ᵣ (0 : Word)) ** (.x6 ↦ᵣ sp + signExtend12 4056) **
      (.x7 ↦ᵣ sp + signExtend12 4088) ** (.x10 ↦ᵣ c3) ** (.x11 ↦ᵣ q_f) **
      (.x2 ↦ᵣ un3F) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -86,7 +86,7 @@ def loopBodyN4SkipJ0Pre
      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word) : Assertion :=
   let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
   let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
-  (.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+  (.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
   (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
   (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
   (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -106,7 +106,7 @@ theorem loopBodyN4SkipJ0Pre_unfold
       v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld =
     (let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
      let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
-     (.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+     (.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
      (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
      (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
      (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -214,7 +214,7 @@ theorem divK_loop_body_n4_max_skip_j0_norm_modCode_within (sp base : Word)
                   (mulsubN4_c3 (signExtend12 4095) v0 v1 v2 v3 u0 u1 u2 u3)
                 then (1 : Word) else 0) = (0 : Word)) :
     cpsTripleWithin 76 (base + loopBodyOff) (base + denormOff) (modCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -360,7 +360,7 @@ theorem divK_loop_body_n4_call_skip_j0_norm_modCode_within (sp base : Word)
                   (mulsubN4_c3 (div128Quot uTop u3 v3) v0 v1 v2 v3 u0 u1 u2 u3)
                 then (1 : Word) else 0) = (0 : Word)) :
     cpsTripleWithin 126 (base + loopBodyOff) (base + denormOff) (modCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -374,7 +374,7 @@ theorem divK_loop_body_n4_call_skip_j0_norm_modCode_within (sp base : Word)
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (loopBodyN4CallSkipJ0Post sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   have raw := divK_loop_body_n4_call_skip_j0_modCode_within sp jOld v5Old v6Old v7Old
     v10Old v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
@@ -434,7 +434,7 @@ theorem divK_loop_body_n4_call_addback_j0_beq_norm_modCode_within (sp base : Wor
                   (mulsubN4_c3 (div128Quot uTop u3 v3) v0 v1 v2 v3 u0 u1 u2 u3)
                 then (1 : Word) else 0) ≠ (0 : Word)) :
     cpsTripleWithin 202 (base + loopBodyOff) (base + denormOff) (modCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -448,7 +448,7 @@ theorem divK_loop_body_n4_call_addback_j0_beq_norm_modCode_within (sp base : Wor
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (loopBodyN4CallAddbackBeqJ0Post sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   have raw := divK_loop_body_n4_call_addback_j0_beq_modCode_within sp jOld
     v5Old v6Old v7Old v10Old v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4NoNop.lean
@@ -24,7 +24,7 @@ def n4CallSkipJ0NormPost (sp base v3 u3 uTop v0 v1 v2 u0 u1 u2 : Word) : Asserti
   (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
   (sp + signExtend12 3960 ↦ₘ v3) **
   (sp + signExtend12 3952 ↦ₘ (v3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat) **
-  (sp + signExtend12 3944 ↦ₘ (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat)
+  (sp + signExtend12 3944 ↦ₘ (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat) ** regOwn .x1
 
 theorem n4CallSkipJ0NormPost_unfold
     {sp base v3 u3 uTop v0 v1 v2 u0 u1 u2 : Word} :
@@ -34,7 +34,7 @@ theorem n4CallSkipJ0NormPost_unfold
        (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
        (sp + signExtend12 3960 ↦ₘ v3) **
        (sp + signExtend12 3952 ↦ₘ (v3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat) **
-       (sp + signExtend12 3944 ↦ₘ (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat)) := by
+       (sp + signExtend12 3944 ↦ₘ (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat) ** regOwn .x1) := by
   delta n4CallSkipJ0NormPost; rfl
 
 /-- Loop body n=4, call+skip, j=0 with sp-relative addresses over `divCode_noNop`. -/
@@ -48,7 +48,7 @@ theorem divK_loop_body_n4_call_skip_j0_norm_noNop (sp base : Word)
     (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3)
      then (1 : Word) else 0) = (0 : Word) →
     cpsTripleWithin 126 (base + loopBodyOff) (base + denormOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -62,7 +62,7 @@ theorem divK_loop_body_n4_call_skip_j0_norm_noNop (sp base : Word)
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (n4CallSkipJ0NormPost sp base v3 u3 uTop v0 v1 v2 u0 u1 u2) := by
   intro qHat hborrow
   have raw := divK_loop_body_n4_call_skip_j0_divCode_noNop_within sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
@@ -91,7 +91,7 @@ theorem evm_div_n4_preloop_call_skip_spec_noNop (sp base : Word)
     cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 126) base (base + denormOff) (divCode_noNop base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        (.x11 ↦ᵣ v11Old) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
@@ -107,7 +107,7 @@ theorem evm_div_n4_preloop_call_skip_spec_noNop (sp base : Word)
        ((sp + signExtend12 3992) ↦ₘ shiftMem) **
        ((sp + signExtend12 3976) ↦ₘ jMem) **
        (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
-       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (preloopCallSkipPostN4 sp base a0 a1 a2 a3 b0 b1 b2 b3) := by
   unfold isCallTrialN4 at hbltu
   unfold isSkipBorrowN4Call at hborrow
@@ -129,7 +129,7 @@ theorem evm_div_n4_preloop_call_skip_spec_noNop (sp base : Word)
   have hPreF := cpsTripleWithin_frameR
     ((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
      (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
-     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
     (by pcFree) hPre
   have hLoop := divK_loop_body_n4_call_skip_j0_norm_noNop sp base
     jMem (4 : Word) shift u0 (a0 >>> (antiShift.toNat % 64)) v11Old antiShift
@@ -176,7 +176,7 @@ theorem evm_div_n4_full_call_skip_spec_noNop (sp base : Word)
     cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 126 + 2 + 23 + 10) base (base + nopOff) (divCode_noNop base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        (.x11 ↦ᵣ v11Old) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
@@ -194,7 +194,7 @@ theorem evm_div_n4_full_call_skip_spec_noNop (sp base : Word)
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (fullDivN4CallSkipPost sp base a0 a1 a2 a3 b0 b1 b2 b3) := by
   have hA := evm_div_n4_preloop_call_skip_spec_noNop sp base
     a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old
@@ -221,7 +221,7 @@ theorem evm_div_n4_full_max_skip_spec_noNop (sp base : Word)
     cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 76 + 2 + 23 + 10) base (base + nopOff) (divCode_noNop base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        (.x11 ↦ᵣ v11Old) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4Shift0.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4Shift0.lean
@@ -54,7 +54,7 @@ def preloopShift0CallSkipPostN4 (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Asser
   (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
   (sp + signExtend12 3960 ↦ₘ b3) **
   (sp + signExtend12 3952 ↦ₘ dLo) **
-  (sp + signExtend12 3944 ↦ₘ div_un0) **
+  (sp + signExtend12 3944 ↦ₘ div_un0) ** regOwn .x1 **
   ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
   ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
   ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
@@ -83,7 +83,7 @@ theorem evm_div_n4_preloop_shift0_call_skip_spec (sp base : Word)
     cpsTripleWithin (8 + 21 + 24 + 4 + 9 + 4 + 126) base (base + denormOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        (.x11 ↦ᵣ v11Old) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
@@ -99,7 +99,7 @@ theorem evm_div_n4_preloop_shift0_call_skip_spec (sp base : Word)
        ((sp + signExtend12 3992) ↦ₘ shiftMem) **
        ((sp + signExtend12 3976) ↦ₘ jMem) **
        (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
-       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (preloopShift0CallSkipPostN4 sp base a0 a1 a2 a3 b0 b1 b2 b3) := by
   unfold isSkipBorrowN4Shift0 at hborrow
   -- Pre-loop: base → base+448 (shift=0)
@@ -113,7 +113,7 @@ theorem evm_div_n4_preloop_shift0_call_skip_spec (sp base : Word)
   have hPreF := cpsTripleWithin_frameR
     ((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
      (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
-     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
     (by pcFree) hPre
   -- Loop body: base+448 → base+904, call+skip with v=b, u=a, uTop=0
   have hbltu : BitVec.ult (0 : Word) b3 := ult_zero_of_ne hb3nz
@@ -162,7 +162,7 @@ theorem evm_div_n4_preloop_shift0_call_skip_spec_noNop (sp base : Word)
     cpsTripleWithin (8 + 21 + 24 + 4 + 9 + 4 + 126) base (base + denormOff) (divCode_noNop base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        (.x11 ↦ᵣ v11Old) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
@@ -178,7 +178,7 @@ theorem evm_div_n4_preloop_shift0_call_skip_spec_noNop (sp base : Word)
        ((sp + signExtend12 3992) ↦ₘ shiftMem) **
        ((sp + signExtend12 3976) ↦ₘ jMem) **
        (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
-       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (preloopShift0CallSkipPostN4 sp base a0 a1 a2 a3 b0 b1 b2 b3) := by
   unfold isSkipBorrowN4Shift0 at hborrow
   have hPre := evm_div_n4_shift0_to_loopSetup_spec_noNop sp base
@@ -188,7 +188,7 @@ theorem evm_div_n4_preloop_shift0_call_skip_spec_noNop (sp base : Word)
   have hPreF := cpsTripleWithin_frameR
     ((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
      (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
-     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
     (by pcFree) hPre
   have hbltu : BitVec.ult (0 : Word) b3 := ult_zero_of_ne hb3nz
   have hLoop := divK_loop_body_n4_call_skip_j0_norm_noNop sp base
@@ -232,7 +232,7 @@ theorem preloopShift0CallSkipPostN4_unfold {sp base a0 a1 a2 a3 b0 b1 b2 b3 : Wo
     let dLo := (b3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     let div_un0 := (a3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     let ms := mulsubN4 qHat b0 b1 b2 b3 a0 a1 a2 a3
-    ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ signExtend12 4095) **
+    ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ signExtend12 4095) **
      (.x5 ↦ᵣ (0 : Word)) ** (.x6 ↦ᵣ sp + signExtend12 4056) **
      (.x7 ↦ᵣ sp + signExtend12 4088) ** (.x10 ↦ᵣ ms.2.2.2.2) ** (.x11 ↦ᵣ qHat) **
      (.x2 ↦ᵣ ms.2.2.2.1) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -246,7 +246,7 @@ theorem preloopShift0CallSkipPostN4_unfold {sp base a0 a1 a2 a3 b0 b1 b2 b3 : Wo
     (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
     (sp + signExtend12 3960 ↦ₘ b3) **
     (sp + signExtend12 3952 ↦ₘ dLo) **
-    (sp + signExtend12 3944 ↦ₘ div_un0) **
+    (sp + signExtend12 3944 ↦ₘ div_un0) ** regOwn .x1 **
     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
     ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
@@ -289,11 +289,11 @@ def fullDivN4Shift0CallSkipPost (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Asser
   ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
   (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
   (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-  (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ qHat) **
+  (.x9 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ qHat) **
   (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
   (sp + signExtend12 3960 ↦ₘ b3) **
   (sp + signExtend12 3952 ↦ₘ (b3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat) **
-  (sp + signExtend12 3944 ↦ₘ (a3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat)
+  (sp + signExtend12 3944 ↦ₘ (a3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat) ** regOwn .x1
 
 -- ============================================================================
 -- Full n=4 DIV path (shift=0, call+skip): base → base+1068
@@ -313,7 +313,7 @@ theorem evm_div_n4_full_shift0_call_skip_spec (sp base : Word)
     cpsTripleWithin (8 + 21 + 24 + 4 + 9 + 4 + 126 + 12) base (base + nopOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) ** (.x11 ↦ᵣ v11Old) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) ** (.x11 ↦ᵣ v11Old) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
        ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
@@ -325,7 +325,7 @@ theorem evm_div_n4_full_shift0_call_skip_spec (sp base : Word)
        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
        ((sp + signExtend12 3992) ↦ₘ shiftMem) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
        (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
-       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (fullDivN4Shift0CallSkipPost sp base a0 a1 a2 a3 b0 b1 b2 b3) := by
   let qHat := div128Quot (0 : Word) a3 b3
   let ms := mulsubN4 qHat b0 b1 b2 b3 a0 a1 a2 a3
@@ -357,11 +357,11 @@ theorem evm_div_n4_full_shift0_call_skip_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
      (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-     (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ qHat) **
+     (.x9 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ qHat) **
      (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
      (sp + signExtend12 3960 ↦ₘ b3) **
      (sp + signExtend12 3952 ↦ₘ (b3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat) **
-     (sp + signExtend12 3944 ↦ₘ (a3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat))
+     (sp + signExtend12 3944 ↦ₘ (a3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat) ** regOwn .x1)
     (by pcFree) hB
   -- 3. Compose A + B
   have hFull := cpsTripleWithin_seq_perm_same_cr
@@ -386,7 +386,7 @@ theorem evm_div_n4_full_shift0_call_skip_spec_noNop (sp base : Word)
     cpsTripleWithin (8 + 21 + 24 + 4 + 9 + 4 + 126 + 12) base (base + nopOff) (divCode_noNop base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) ** (.x11 ↦ᵣ v11Old) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) ** (.x11 ↦ᵣ v11Old) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
        ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
@@ -398,7 +398,7 @@ theorem evm_div_n4_full_shift0_call_skip_spec_noNop (sp base : Word)
        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
        ((sp + signExtend12 3992) ↦ₘ shiftMem) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
        (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
-       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (fullDivN4Shift0CallSkipPost sp base a0 a1 a2 a3 b0 b1 b2 b3) := by
   let qHat := div128Quot (0 : Word) a3 b3
   let ms := mulsubN4 qHat b0 b1 b2 b3 a0 a1 a2 a3
@@ -427,11 +427,11 @@ theorem evm_div_n4_full_shift0_call_skip_spec_noNop (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
      (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-     (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ qHat) **
+     (.x9 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ qHat) **
      (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
      (sp + signExtend12 3960 ↦ₘ b3) **
      (sp + signExtend12 3952 ↦ₘ (b3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat) **
-     (sp + signExtend12 3944 ↦ₘ (a3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat))
+     (sp + signExtend12 3944 ↦ₘ (a3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat) ** regOwn .x1)
     (by pcFree) hB
   have hFull := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by
@@ -478,7 +478,7 @@ def preloopShift0CallAddbackBeqPostN4
   (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
   (sp + signExtend12 3960 ↦ₘ b3) **
   (sp + signExtend12 3952 ↦ₘ dLo) **
-  (sp + signExtend12 3944 ↦ₘ div_un0) **
+  (sp + signExtend12 3944 ↦ₘ div_un0) ** regOwn .x1 **
   ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
   ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
   ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
@@ -512,7 +512,7 @@ theorem evm_div_n4_preloop_shift0_call_addback_beq_spec (sp base : Word)
     cpsTripleWithin (8 + 21 + 24 + 4 + 9 + 4 + 202) base (base + denormOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        (.x11 ↦ᵣ v11Old) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
@@ -528,7 +528,7 @@ theorem evm_div_n4_preloop_shift0_call_addback_beq_spec (sp base : Word)
        ((sp + signExtend12 3992) ↦ₘ shiftMem) **
        ((sp + signExtend12 3976) ↦ₘ jMem) **
        (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
-       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (preloopShift0CallAddbackBeqPostN4 sp base a0 a1 a2 a3 b0 b1 b2 b3) := by
   unfold isAddbackBorrowN4Shift0 at hborrow
   unfold isAddbackCarry2NzN4Shift0 at hcarry2_nz
@@ -541,7 +541,7 @@ theorem evm_div_n4_preloop_shift0_call_addback_beq_spec (sp base : Word)
   have hPreF := cpsTripleWithin_frameR
     ((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
      (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
-     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
     (by pcFree) hPre
   -- Loop body: base+loopBodyOff → base+denormOff, call+addback BEQ with v=b, u=a, uTop=0
   have hbltu : BitVec.ult (0 : Word) b3 := ult_zero_of_ne hb3nz
@@ -591,7 +591,7 @@ theorem evm_div_n4_preloop_shift0_call_addback_beq_spec_noNop (sp base : Word)
     cpsTripleWithin (8 + 21 + 24 + 4 + 9 + 4 + 202) base (base + denormOff) (divCode_noNop base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        (.x11 ↦ᵣ v11Old) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
@@ -607,7 +607,7 @@ theorem evm_div_n4_preloop_shift0_call_addback_beq_spec_noNop (sp base : Word)
        ((sp + signExtend12 3992) ↦ₘ shiftMem) **
        ((sp + signExtend12 3976) ↦ₘ jMem) **
        (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
-       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (preloopShift0CallAddbackBeqPostN4 sp base a0 a1 a2 a3 b0 b1 b2 b3) := by
   unfold isAddbackBorrowN4Shift0 at hborrow
   unfold isAddbackCarry2NzN4Shift0 at hcarry2_nz
@@ -618,7 +618,7 @@ theorem evm_div_n4_preloop_shift0_call_addback_beq_spec_noNop (sp base : Word)
   have hPreF := cpsTripleWithin_frameR
     ((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
      (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
-     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
     (by pcFree) hPre
   have hbltu : BitVec.ult (0 : Word) b3 := ult_zero_of_ne hb3nz
   have hLoop := divK_loop_body_n4_call_addback_j0_beq_norm_noNop sp base
@@ -677,7 +677,7 @@ theorem preloopShift0CallAddbackBeqPostN4_unfold
     let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
     let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
     let u4_out  := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
-    ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ signExtend12 4095) **
+    ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ signExtend12 4095) **
      (.x5 ↦ᵣ (0 : Word)) ** (.x6 ↦ᵣ sp + signExtend12 4056) **
      (.x7 ↦ᵣ sp + signExtend12 4088) ** (.x10 ↦ᵣ c3) ** (.x11 ↦ᵣ q_out) **
      (.x2 ↦ᵣ un3Out) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -691,7 +691,7 @@ theorem preloopShift0CallAddbackBeqPostN4_unfold
     (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
     (sp + signExtend12 3960 ↦ₘ b3) **
     (sp + signExtend12 3952 ↦ₘ dLo) **
-    (sp + signExtend12 3944 ↦ₘ div_un0) **
+    (sp + signExtend12 3944 ↦ₘ div_un0) ** regOwn .x1 **
     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
     ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
@@ -748,11 +748,11 @@ def fullDivN4Shift0CallAddbackBeqPost
   ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
   (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
   (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-  (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ q_out) **
+  (.x9 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ q_out) **
   (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
   (sp + signExtend12 3960 ↦ₘ b3) **
   (sp + signExtend12 3952 ↦ₘ (b3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat) **
-  (sp + signExtend12 3944 ↦ₘ (a3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat)
+  (sp + signExtend12 3944 ↦ₘ (a3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat) ** regOwn .x1
 
 /-- `fullDivN4Shift0CallAddbackBeqPost` is pc-free. -/
 theorem pcFree_fullDivN4Shift0CallAddbackBeqPost
@@ -788,7 +788,7 @@ theorem evm_div_n4_full_shift0_call_addback_beq_spec (sp base : Word)
     cpsTripleWithin (8 + 21 + 24 + 4 + 9 + 4 + 202 + 12) base (base + nopOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) ** (.x11 ↦ᵣ v11Old) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) ** (.x11 ↦ᵣ v11Old) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
        ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
@@ -800,7 +800,7 @@ theorem evm_div_n4_full_shift0_call_addback_beq_spec (sp base : Word)
        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
        ((sp + signExtend12 3992) ↦ₘ shiftMem) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
        (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
-       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (fullDivN4Shift0CallAddbackBeqPost sp base a0 a1 a2 a3 b0 b1 b2 b3) := by
   let qHat := div128Quot (0 : Word) a3 b3
   let ms := mulsubN4 qHat b0 b1 b2 b3 a0 a1 a2 a3
@@ -844,11 +844,11 @@ theorem evm_div_n4_full_shift0_call_addback_beq_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
      (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-     (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ q_out) **
+     (.x9 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ q_out) **
      (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
      (sp + signExtend12 3960 ↦ₘ b3) **
      (sp + signExtend12 3952 ↦ₘ (b3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat) **
-     (sp + signExtend12 3944 ↦ₘ (a3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat))
+     (sp + signExtend12 3944 ↦ₘ (a3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat) ** regOwn .x1)
     (by pcFree) hB
   -- 3. Compose A + B
   have hFull := cpsTripleWithin_seq_perm_same_cr
@@ -874,7 +874,7 @@ theorem evm_div_n4_full_shift0_call_addback_beq_spec_noNop (sp base : Word)
     cpsTripleWithin (8 + 21 + 24 + 4 + 9 + 4 + 202 + 12) base (base + nopOff) (divCode_noNop base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) ** (.x11 ↦ᵣ v11Old) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) ** (.x11 ↦ᵣ v11Old) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
        ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
@@ -886,7 +886,7 @@ theorem evm_div_n4_full_shift0_call_addback_beq_spec_noNop (sp base : Word)
        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
        ((sp + signExtend12 3992) ↦ₘ shiftMem) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
        (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
-       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (fullDivN4Shift0CallAddbackBeqPost sp base a0 a1 a2 a3 b0 b1 b2 b3) := by
   let qHat := div128Quot (0 : Word) a3 b3
   let ms := mulsubN4 qHat b0 b1 b2 b3 a0 a1 a2 a3
@@ -926,11 +926,11 @@ theorem evm_div_n4_full_shift0_call_addback_beq_spec_noNop (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
      (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-     (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ q_out) **
+     (.x9 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ q_out) **
      (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
      (sp + signExtend12 3960 ↦ₘ b3) **
      (sp + signExtend12 3952 ↦ₘ (b3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat) **
-     (sp + signExtend12 3944 ↦ₘ (a3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat))
+     (sp + signExtend12 3944 ↦ₘ (a3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat) ** regOwn .x1)
     (by pcFree) hB
   have hFull := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by

--- a/EvmAsm/Evm64/DivMod/Compose/ModDiv128.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModDiv128.lean
@@ -53,14 +53,14 @@ private theorem d128_sub_mod {base : Word} (k : Nat) (addr : Word) (instr : Inst
 -- ============================================================================
 
 theorem mod_div128_spec_within (sp retAddr d uLo uHi : Word) (base : Word)
-    (v1Old v6Old v11Old : Word)
+    (v9Old v6Old v11Old : Word)
     (retMem dMem dloMem un0Mem : Word)
     (halign : (retAddr + signExtend12 0) &&& ~~~1 = retAddr) :
     cpsTripleWithin 51 (base + div128Off) retAddr (modCode base)
       (-- Precondition: caller registers + scratch memory
        (.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ retAddr) ** (.x10 ↦ᵣ d) **
        (.x5 ↦ᵣ uLo) ** (.x7 ↦ᵣ uHi) **
-       (.x6 ↦ᵣ v6Old) ** (.x1 ↦ᵣ v1Old) ** (.x11 ↦ᵣ v11Old) **
+       (.x6 ↦ᵣ v6Old) ** (.x9 ↦ᵣ v9Old) ** (.x11 ↦ᵣ v11Old) **
        (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
@@ -102,14 +102,14 @@ theorem mod_div128_spec_within (sp retAddr d uLo uHi : Word) (base : Word)
   let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
   let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo un0
   let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
-  let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
+  let x9Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
   let x11Exit := if rhat2cHi = 0 then un0 else rhat2c
   let q := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   -- ================================================================
   -- Block 1: Phase 1 (base+1072 → base+1112)
   -- Saves ret/d, splits d and uLo into halves.
   -- ================================================================
-  have hph1 := divK_div128_phase1_spec_within sp retAddr d uLo uHi v1Old v6Old v11Old
+  have hph1 := divK_div128_phase1_spec_within sp retAddr d uLo uHi v9Old v6Old v11Old
     retMem dMem dloMem un0Mem (base + div128Off)
   -- Extend phase1 cr to modCode
   have hph1e := cpsTripleWithin_extend_code (hmono := by
@@ -234,7 +234,7 @@ theorem mod_div128_spec_within (sp retAddr d uLo uHi : Word) (base : Word)
     hend
   -- Frame end with x7, x6, x1, x0, mem[3960], mem[3952], mem[3944]
   have hendf := cpsTripleWithin_frameR
-    ((.x7 ↦ᵣ x7Exit) ** (.x6 ↦ᵣ dHi) ** (.x1 ↦ᵣ x1Exit) **
+    ((.x7 ↦ᵣ x7Exit) ** (.x6 ↦ᵣ dHi) ** (.x9 ↦ᵣ x9Exit) **
      (.x0 ↦ᵣ (0 : Word)) **
      (sp + signExtend12 3960 ↦ₘ d) ** (sp + signExtend12 3952 ↦ₘ dLo) **
      (sp + signExtend12 3944 ↦ₘ un0))

--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPath.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPath.lean
@@ -177,7 +177,7 @@ theorem evm_mod_n4_to_loopSetup_spec_within (sp base : Word)
     cpsTripleWithin 103 base (base + loopBodyOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
@@ -207,7 +207,7 @@ theorem evm_mod_n4_to_loopSetup_spec_within (sp base : Word)
     q0 q1 q2 q3 u5 u6 u7 nMem shiftMem hbnz hb3nz hshift_nz
 
   have hNormBf := cpsTripleWithin_frameR
-    ((.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+    ((.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
      ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
      ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
      ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
@@ -221,7 +221,7 @@ theorem evm_mod_n4_to_loopSetup_spec_within (sp base : Word)
   simp only [normAFullPost_unfold] at hNormA
   have hNormAf := cpsTripleWithin_frameR
     ((.x0 ↦ᵣ (0 : Word)) **
-     (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
      ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
      ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3') **
      ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
@@ -268,7 +268,7 @@ theorem evm_mod_n4_shift0_to_loopSetup_spec_within (sp base : Word)
     cpsTripleWithin 70 base (base + loopBodyOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
@@ -284,7 +284,7 @@ theorem evm_mod_n4_shift0_to_loopSetup_spec_within (sp base : Word)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (4 : Word)) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ (clzResult b3).1) ** (.x7 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
        (.x2 ↦ᵣ signExtend12 (0 : BitVec 12) - (clzResult b3).1) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
@@ -302,7 +302,7 @@ theorem evm_mod_n4_shift0_to_loopSetup_spec_within (sp base : Word)
     q0 q1 q2 q3 u5 u6 u7 nMem hbnz hb3nz
   have hABCLZf := cpsTripleWithin_frameR
     ((.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
-     (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
      ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
      ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
      ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
@@ -316,7 +316,7 @@ theorem evm_mod_n4_shift0_to_loopSetup_spec_within (sp base : Word)
   have hC2f := cpsTripleWithin_frameR
     ((.x5 ↦ᵣ (clzResult b3).2) ** (.x10 ↦ᵣ b3) **
      (.x7 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
-     (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
      ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
      ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
      ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
@@ -341,7 +341,7 @@ theorem evm_mod_n4_shift0_to_loopSetup_spec_within (sp base : Word)
      (.x2 ↦ᵣ signExtend12 (0 : BitVec 12) - (clzResult b3).1) **
      (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ b3) **
      (.x7 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
-     (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
      ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
      ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
      ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **

--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPathN1.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPathN1.lean
@@ -94,7 +94,7 @@ theorem evm_mod_n1_to_loopSetup_spec_within (sp base : Word)
     cpsTripleWithin 103 base (base + loopBodyOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b0).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
@@ -125,7 +125,7 @@ theorem evm_mod_n1_to_loopSetup_spec_within (sp base : Word)
 
   have hABCLZf := cpsTripleWithin_frameR
     ((.x2 ↦ᵣ (clzResult b0).2 >>> (63 : Nat)) **
-     (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
      ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
      ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
      ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
@@ -139,7 +139,7 @@ theorem evm_mod_n1_to_loopSetup_spec_within (sp base : Word)
   have hC2f := cpsTripleWithin_frameR
     ((.x5 ↦ᵣ (clzResult b0).2) ** (.x10 ↦ᵣ b3) **
      (.x7 ↦ᵣ (clzResult b0).2 >>> (63 : Nat)) **
-     (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
      ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
      ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
      ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
@@ -161,7 +161,7 @@ theorem evm_mod_n1_to_loopSetup_spec_within (sp base : Word)
   simp only [normBFullPost_unfold] at hNB
   have hNBf := cpsTripleWithin_frameR
     ((.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
-     (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
      ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
      ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
      ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
@@ -182,7 +182,7 @@ theorem evm_mod_n1_to_loopSetup_spec_within (sp base : Word)
   simp only [normAFullPost_unfold] at hNormA
   have hNormAf := cpsTripleWithin_frameR
     ((.x0 ↦ᵣ (0 : Word)) **
-     (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
      ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
      ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3') **
      ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **

--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPathN1LoopUnified.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPathN1LoopUnified.lean
@@ -141,7 +141,7 @@ theorem evm_mod_n1_preloop_loop_unified_spec
     cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 808) base (base + denormOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b0).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        (.x11 ↦ᵣ v11Old) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
@@ -159,7 +159,7 @@ theorem evm_mod_n1_preloop_loop_unified_spec
        ((sp + signExtend12 3968) ↦ₘ retMem) **
        ((sp + signExtend12 3960) ↦ₘ dMem) **
        ((sp + signExtend12 3952) ↦ₘ dloMem) **
-       ((sp + signExtend12 3944) ↦ₘ scratch_un0))
+       ((sp + signExtend12 3944) ↦ₘ scratch_un0) ** regOwn .x1)
       (preloopN1UnifiedPost bltu_3 bltu_2 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
         retMem dMem dloMem scratch_un0) := by
   have hPre := evm_mod_n1_to_loopSetup_spec_within sp base
@@ -171,7 +171,7 @@ theorem evm_mod_n1_preloop_loop_unified_spec
      (sp + signExtend12 3968 ↦ₘ retMem) **
      (sp + signExtend12 3960 ↦ₘ dMem) **
      (sp + signExtend12 3952 ↦ₘ dloMem) **
-     (sp + signExtend12 3944 ↦ₘ scratch_un0))
+     (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
     (by pcFree) hPre
   have hLoop := evm_mod_n1_loop_unified_inst bltu_3 bltu_2 bltu_1 bltu_0 sp base
     (clzResult b0).1 (signExtend12 (0 : BitVec 12) - (clzResult b0).1)
@@ -303,7 +303,7 @@ theorem evm_mod_n1_full_unified_spec
     cpsTripleWithin 946 base (base + nopOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b0).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        (.x11 ↦ᵣ v11Old) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
@@ -321,7 +321,7 @@ theorem evm_mod_n1_full_unified_spec
        ((sp + signExtend12 3968) ↦ₘ retMem) **
        ((sp + signExtend12 3960) ↦ₘ dMem) **
        ((sp + signExtend12 3952) ↦ₘ dloMem) **
-       ((sp + signExtend12 3944) ↦ₘ scratch_un0))
+       ((sp + signExtend12 3944) ↦ₘ scratch_un0) ** regOwn .x1)
       (fullModN1UnifiedPost bltu_3 bltu_2 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
         retMem dMem dloMem scratch_un0) := by
   have hA := evm_mod_n1_preloop_loop_unified_spec bltu_3 bltu_2 bltu_1 bltu_0 sp base

--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPathN2.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPathN2.lean
@@ -97,7 +97,7 @@ theorem evm_mod_n2_to_loopSetup_spec_within (sp base : Word)
     cpsTripleWithin 103 base (base + loopBodyOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
@@ -128,7 +128,7 @@ theorem evm_mod_n2_to_loopSetup_spec_within (sp base : Word)
 
   have hABCLZf := cpsTripleWithin_frameR
     ((.x2 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
-     (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
      ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
      ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
      ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
@@ -142,7 +142,7 @@ theorem evm_mod_n2_to_loopSetup_spec_within (sp base : Word)
   have hC2f := cpsTripleWithin_frameR
     ((.x5 ↦ᵣ (clzResult b1).2) ** (.x10 ↦ᵣ b3) **
      (.x7 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
-     (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
      ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
      ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
      ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
@@ -164,7 +164,7 @@ theorem evm_mod_n2_to_loopSetup_spec_within (sp base : Word)
   simp only [normBFullPost_unfold] at hNB
   have hNBf := cpsTripleWithin_frameR
     ((.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
-     (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
      ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
      ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
      ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
@@ -185,7 +185,7 @@ theorem evm_mod_n2_to_loopSetup_spec_within (sp base : Word)
   simp only [normAFullPost_unfold] at hNormA
   have hNormAf := cpsTripleWithin_frameR
     ((.x0 ↦ᵣ (0 : Word)) **
-     (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
      ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
      ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3') **
      ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **

--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPathN2LoopUnified.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPathN2LoopUnified.lean
@@ -97,7 +97,7 @@ theorem evm_mod_n2_preloop_loop_unified_spec
     cpsTripleWithin 709 base (base + denormOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        (.x11 ↦ᵣ v11Old) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
@@ -115,7 +115,7 @@ theorem evm_mod_n2_preloop_loop_unified_spec
        ((sp + signExtend12 3968) ↦ₘ retMem) **
        ((sp + signExtend12 3960) ↦ₘ dMem) **
        ((sp + signExtend12 3952) ↦ₘ dloMem) **
-       ((sp + signExtend12 3944) ↦ₘ scratch_un0))
+       ((sp + signExtend12 3944) ↦ₘ scratch_un0) ** regOwn .x1)
       (preloopN2UnifiedPost bltu_2 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
         retMem dMem dloMem scratch_un0) := by
   have hPre := evm_mod_n2_to_loopSetup_spec_within sp base
@@ -127,7 +127,7 @@ theorem evm_mod_n2_preloop_loop_unified_spec
      (sp + signExtend12 3968 ↦ₘ retMem) **
      (sp + signExtend12 3960 ↦ₘ dMem) **
      (sp + signExtend12 3952 ↦ₘ dloMem) **
-     (sp + signExtend12 3944 ↦ₘ scratch_un0))
+     (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
     (by pcFree) hPre
   have hLoop := evm_mod_n2_loop_unified_inst bltu_2 bltu_1 bltu_0 sp base
     (clzResult b1).1 (signExtend12 (0 : BitVec 12) - (clzResult b1).1)
@@ -258,7 +258,7 @@ theorem evm_mod_n2_full_unified_spec
     cpsTripleWithin 744 base (base + nopOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        (.x11 ↦ᵣ v11Old) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
@@ -276,7 +276,7 @@ theorem evm_mod_n2_full_unified_spec
        ((sp + signExtend12 3968) ↦ₘ retMem) **
        ((sp + signExtend12 3960) ↦ₘ dMem) **
        ((sp + signExtend12 3952) ↦ₘ dloMem) **
-       ((sp + signExtend12 3944) ↦ₘ scratch_un0))
+       ((sp + signExtend12 3944) ↦ₘ scratch_un0) ** regOwn .x1)
       (fullModN2UnifiedPost bltu_2 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
         retMem dMem dloMem scratch_un0) := by
   have hA := evm_mod_n2_preloop_loop_unified_spec bltu_2 bltu_1 bltu_0 sp base

--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPathN3.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPathN3.lean
@@ -97,7 +97,7 @@ theorem evm_mod_n3_to_loopSetup_spec_within (sp base : Word)
     cpsTripleWithin 103 base (base + loopBodyOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
@@ -128,7 +128,7 @@ theorem evm_mod_n3_to_loopSetup_spec_within (sp base : Word)
 
   have hABCLZf := cpsTripleWithin_frameR
     ((.x2 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
-     (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
      ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
      ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
      ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
@@ -142,7 +142,7 @@ theorem evm_mod_n3_to_loopSetup_spec_within (sp base : Word)
   have hC2f := cpsTripleWithin_frameR
     ((.x5 ↦ᵣ (clzResult b2).2) ** (.x10 ↦ᵣ b3) **
      (.x7 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
-     (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
      ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
      ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
      ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
@@ -164,7 +164,7 @@ theorem evm_mod_n3_to_loopSetup_spec_within (sp base : Word)
   simp only [normBFullPost_unfold] at hNB
   have hNBf := cpsTripleWithin_frameR
     ((.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
-     (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
      ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
      ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
      ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
@@ -185,7 +185,7 @@ theorem evm_mod_n3_to_loopSetup_spec_within (sp base : Word)
   simp only [normAFullPost_unfold] at hNormA
   have hNormAf := cpsTripleWithin_frameR
     ((.x0 ↦ᵣ (0 : Word)) **
-     (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
      ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
      ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3') **
      ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **

--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPathN3LoopUnified.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPathN3LoopUnified.lean
@@ -79,7 +79,7 @@ theorem evm_mod_n3_preloop_loop_unified_spec (bltu_1 bltu_0 : Bool) (sp base : W
     cpsTripleWithin 507 base (base + denormOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        (.x11 ↦ᵣ v11Old) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
@@ -97,7 +97,7 @@ theorem evm_mod_n3_preloop_loop_unified_spec (bltu_1 bltu_0 : Bool) (sp base : W
        ((sp + signExtend12 3968) ↦ₘ retMem) **
        ((sp + signExtend12 3960) ↦ₘ dMem) **
        ((sp + signExtend12 3952) ↦ₘ dloMem) **
-       ((sp + signExtend12 3944) ↦ₘ scratch_un0))
+       ((sp + signExtend12 3944) ↦ₘ scratch_un0) ** regOwn .x1)
       (preloopN3UnifiedPost bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
         retMem dMem dloMem scratch_un0) := by
   have hPre := evm_mod_n3_to_loopSetup_spec_within sp base
@@ -109,7 +109,7 @@ theorem evm_mod_n3_preloop_loop_unified_spec (bltu_1 bltu_0 : Bool) (sp base : W
      (sp + signExtend12 3968 ↦ₘ retMem) **
      (sp + signExtend12 3960 ↦ₘ dMem) **
      (sp + signExtend12 3952 ↦ₘ dloMem) **
-     (sp + signExtend12 3944 ↦ₘ scratch_un0))
+     (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
     (by pcFree) hPre
   have hLoop := evm_mod_n3_loop_unified_inst bltu_1 bltu_0 sp base
     (clzResult b2).1 (signExtend12 (0 : BitVec 12) - (clzResult b2).1)
@@ -234,7 +234,7 @@ theorem evm_mod_n3_full_unified_spec (bltu_1 bltu_0 : Bool) (sp base : Word)
     cpsTripleWithin 542 base (base + nopOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        (.x11 ↦ᵣ v11Old) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
@@ -252,7 +252,7 @@ theorem evm_mod_n3_full_unified_spec (bltu_1 bltu_0 : Bool) (sp base : Word)
        ((sp + signExtend12 3968) ↦ₘ retMem) **
        ((sp + signExtend12 3960) ↦ₘ dMem) **
        ((sp + signExtend12 3952) ↦ₘ dloMem) **
-       ((sp + signExtend12 3944) ↦ₘ scratch_un0))
+       ((sp + signExtend12 3944) ↦ₘ scratch_un0) ** regOwn .x1)
       (fullModN3UnifiedPost bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
         retMem dMem dloMem scratch_un0) := by
   have hA := evm_mod_n3_preloop_loop_unified_spec bltu_1 bltu_0 sp base

--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPathN4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPathN4.lean
@@ -168,7 +168,7 @@ theorem evm_mod_n4_preloop_max_skip_spec_within (sp base : Word)
     cpsTripleWithin 179 base (base + denormOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        (.x11 ↦ᵣ v11Old) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
@@ -247,7 +247,7 @@ theorem evm_mod_n4_preloop_call_skip_spec_within (sp base : Word)
     cpsTripleWithin 229 base (base + denormOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        (.x11 ↦ᵣ v11Old) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
@@ -263,7 +263,7 @@ theorem evm_mod_n4_preloop_call_skip_spec_within (sp base : Word)
        ((sp + signExtend12 3992) ↦ₘ shiftMem) **
        ((sp + signExtend12 3976) ↦ₘ jMem) **
        (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
-       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (preloopCallSkipPostN4 sp base a0 a1 a2 a3 b0 b1 b2 b3) := by
   unfold isCallTrialN4 at hbltu
   unfold isSkipBorrowN4Call at hborrow
@@ -285,7 +285,7 @@ theorem evm_mod_n4_preloop_call_skip_spec_within (sp base : Word)
   have hPreF := cpsTripleWithin_frameR
     ((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
      (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
-     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
     (by pcFree) hPre
   have hLoop := divK_loop_body_n4_call_skip_j0_norm_modCode_within sp base
     jMem (4 : Word) shift u0 (a0 >>> (antiShift.toNat % 64)) v11Old antiShift
@@ -335,7 +335,7 @@ theorem evm_mod_n4_full_max_skip_spec_within (sp base : Word)
     cpsTripleWithin 214 base (base + nopOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        (.x11 ↦ᵣ v11Old) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
@@ -389,7 +389,7 @@ theorem evm_mod_n4_full_max_skip_spec_within (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
      (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-     (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ qHat))
+     (.x9 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ qHat))
     (by pcFree) hB
   -- 3. Compose A + B
   have hFull := cpsTripleWithin_seq_perm_same_cr
@@ -422,7 +422,7 @@ theorem evm_mod_n4_full_call_skip_spec_within (sp base : Word)
     cpsTripleWithin 264 base (base + nopOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        (.x11 ↦ᵣ v11Old) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
@@ -440,7 +440,7 @@ theorem evm_mod_n4_full_call_skip_spec_within (sp base : Word)
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (fullModN4CallSkipPost sp base a0 a1 a2 a3 b0 b1 b2 b3) := by
   let shift := (clzResult b3).1
   let antiShift := signExtend12 (0 : BitVec 12) - shift
@@ -484,11 +484,11 @@ theorem evm_mod_n4_full_call_skip_spec_within (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
      (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-     (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ qHat) **
+     (.x9 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ qHat) **
      (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
      (sp + signExtend12 3960 ↦ₘ b3') **
      (sp + signExtend12 3952 ↦ₘ dLo) **
-     (sp + signExtend12 3944 ↦ₘ div_un0))
+     (sp + signExtend12 3944 ↦ₘ div_un0) ** regOwn .x1)
     (by pcFree) hB
   -- 3. Compose A + B
   have hFull := cpsTripleWithin_seq_perm_same_cr
@@ -524,7 +524,7 @@ theorem evm_mod_n4_preloop_call_addback_beq_spec_within (sp base : Word)
     cpsTripleWithin 305 base (base + denormOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        (.x11 ↦ᵣ v11Old) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
@@ -540,7 +540,7 @@ theorem evm_mod_n4_preloop_call_addback_beq_spec_within (sp base : Word)
        ((sp + signExtend12 3992) ↦ₘ shiftMem) **
        ((sp + signExtend12 3976) ↦ₘ jMem) **
        (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
-       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (preloopCallAddbackBeqPostN4 sp base a0 a1 a2 a3 b0 b1 b2 b3) := by
   unfold isCallTrialN4 at hbltu
   unfold isAddbackBorrowN4Call at hborrow
@@ -563,7 +563,7 @@ theorem evm_mod_n4_preloop_call_addback_beq_spec_within (sp base : Word)
   have hPreF := cpsTripleWithin_frameR
     ((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
      (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
-     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
     (by pcFree) hPre
   have hLoop := divK_loop_body_n4_call_addback_j0_beq_norm_modCode_within sp base
     jMem (4 : Word) shift u0 (a0 >>> (antiShift.toNat % 64)) v11Old antiShift
@@ -612,7 +612,7 @@ theorem evm_mod_n4_full_call_addback_beq_spec_within (sp base : Word)
     cpsTripleWithin 340 base (base + nopOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) ** (.x11 ↦ᵣ v11Old) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) ** (.x11 ↦ᵣ v11Old) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
        ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
@@ -624,7 +624,7 @@ theorem evm_mod_n4_full_call_addback_beq_spec_within (sp base : Word)
        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
        ((sp + signExtend12 3992) ↦ₘ shiftMem) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
        (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
-       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (fullModN4CallAddbackBeqPost sp base a0 a1 a2 a3 b0 b1 b2 b3) := by
   let shift := (clzResult b3).1
   let antiShift := signExtend12 (0 : BitVec 12) - shift
@@ -681,11 +681,11 @@ theorem evm_mod_n4_full_call_addback_beq_spec_within (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
      (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-     (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ q_out) **
+     (.x9 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ q_out) **
      (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
      (sp + signExtend12 3960 ↦ₘ b3') **
      (sp + signExtend12 3952 ↦ₘ dLo) **
-     (sp + signExtend12 3944 ↦ₘ div_un0))
+     (sp + signExtend12 3944 ↦ₘ div_un0) ** regOwn .x1)
     (by pcFree) hB
   -- 3. Compose A + B
   have hFull := cpsTripleWithin_seq_perm_same_cr

--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPathN4Shift0.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPathN4Shift0.lean
@@ -42,7 +42,7 @@ theorem evm_mod_n4_preloop_shift0_call_skip_spec (sp base : Word)
     cpsTripleWithin (8 + 21 + 24 + 4 + 9 + 4 + 126) base (base + denormOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        (.x11 ↦ᵣ v11Old) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
@@ -58,7 +58,7 @@ theorem evm_mod_n4_preloop_shift0_call_skip_spec (sp base : Word)
        ((sp + signExtend12 3992) ↦ₘ shiftMem) **
        ((sp + signExtend12 3976) ↦ₘ jMem) **
        (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
-       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (preloopShift0CallSkipPostN4 sp base a0 a1 a2 a3 b0 b1 b2 b3) := by
   unfold isSkipBorrowN4Shift0 at hborrow
   -- Pre-loop: base → base+loopBodyOff (shift=0, MOD)
@@ -70,7 +70,7 @@ theorem evm_mod_n4_preloop_shift0_call_skip_spec (sp base : Word)
   have hPreF := cpsTripleWithin_frameR
     ((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
      (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
-     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
     (by pcFree) hPre
   -- Loop body: base+loopBodyOff → base+denormOff, call+skip with v=b, u=a, uTop=0
   have hbltu : BitVec.ult (0 : Word) b3 := ult_zero_of_ne hb3nz
@@ -138,11 +138,11 @@ def fullModN4Shift0CallSkipPost (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Asser
   ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
   (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
   (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-  (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ qHat) **
+  (.x9 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ qHat) **
   (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
   (sp + signExtend12 3960 ↦ₘ b3) **
   (sp + signExtend12 3952 ↦ₘ (b3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat) **
-  (sp + signExtend12 3944 ↦ₘ (a3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat)
+  (sp + signExtend12 3944 ↦ₘ (a3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat) ** regOwn .x1
 
 /-- `fullModN4Shift0CallSkipPost` is pc-free. -/
 theorem pcFree_fullModN4Shift0CallSkipPost
@@ -176,7 +176,7 @@ theorem evm_mod_n4_full_shift0_call_skip_spec (sp base : Word)
     cpsTripleWithin (8 + 21 + 24 + 4 + 9 + 4 + 126 + 12) base (base + nopOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) ** (.x11 ↦ᵣ v11Old) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) ** (.x11 ↦ᵣ v11Old) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
        ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
@@ -188,7 +188,7 @@ theorem evm_mod_n4_full_shift0_call_skip_spec (sp base : Word)
        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
        ((sp + signExtend12 3992) ↦ₘ shiftMem) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
        (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
-       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (fullModN4Shift0CallSkipPost sp base a0 a1 a2 a3 b0 b1 b2 b3) := by
   let qHat := div128Quot (0 : Word) a3 b3
   let ms := mulsubN4 qHat b0 b1 b2 b3 a0 a1 a2 a3
@@ -219,11 +219,11 @@ theorem evm_mod_n4_full_shift0_call_skip_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
      (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-     (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ qHat) **
+     (.x9 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ qHat) **
      (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
      (sp + signExtend12 3960 ↦ₘ b3) **
      (sp + signExtend12 3952 ↦ₘ (b3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat) **
-     (sp + signExtend12 3944 ↦ₘ (a3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat))
+     (sp + signExtend12 3944 ↦ₘ (a3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat) ** regOwn .x1)
     (by pcFree) hB
   -- 3. Compose A + B
   have hFull := cpsTripleWithin_seq_perm_same_cr
@@ -256,7 +256,7 @@ theorem evm_mod_n4_preloop_shift0_call_addback_beq_spec (sp base : Word)
     cpsTripleWithin (8 + 21 + 24 + 4 + 9 + 4 + 202) base (base + denormOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        (.x11 ↦ᵣ v11Old) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
@@ -272,7 +272,7 @@ theorem evm_mod_n4_preloop_shift0_call_addback_beq_spec (sp base : Word)
        ((sp + signExtend12 3992) ↦ₘ shiftMem) **
        ((sp + signExtend12 3976) ↦ₘ jMem) **
        (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
-       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (preloopShift0CallAddbackBeqPostN4 sp base a0 a1 a2 a3 b0 b1 b2 b3) := by
   unfold isAddbackBorrowN4Shift0 at hborrow
   unfold isAddbackCarry2NzN4Shift0 at hcarry2_nz
@@ -285,7 +285,7 @@ theorem evm_mod_n4_preloop_shift0_call_addback_beq_spec (sp base : Word)
   have hPreF := cpsTripleWithin_frameR
     ((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
      (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
-     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
     (by pcFree) hPre
   -- Loop body: base+loopBodyOff → base+denormOff, call+addback BEQ (modCode)
   have hbltu : BitVec.ult (0 : Word) b3 := ult_zero_of_ne hb3nz
@@ -366,11 +366,11 @@ def fullModN4Shift0CallAddbackBeqPost
   ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
   (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
   (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-  (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ q_out) **
+  (.x9 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ q_out) **
   (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
   (sp + signExtend12 3960 ↦ₘ b3) **
   (sp + signExtend12 3952 ↦ₘ (b3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat) **
-  (sp + signExtend12 3944 ↦ₘ (a3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat)
+  (sp + signExtend12 3944 ↦ₘ (a3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat) ** regOwn .x1
 
 /-- `fullModN4Shift0CallAddbackBeqPost` is pc-free. -/
 theorem pcFree_fullModN4Shift0CallAddbackBeqPost
@@ -405,7 +405,7 @@ theorem evm_mod_n4_full_shift0_call_addback_beq_spec (sp base : Word)
     cpsTripleWithin (8 + 21 + 24 + 4 + 9 + 4 + 202 + 12) base (base + nopOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) ** (.x11 ↦ᵣ v11Old) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) ** (.x11 ↦ᵣ v11Old) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
        ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
@@ -417,7 +417,7 @@ theorem evm_mod_n4_full_shift0_call_addback_beq_spec (sp base : Word)
        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
        ((sp + signExtend12 3992) ↦ₘ shiftMem) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
        (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
-       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (fullModN4Shift0CallAddbackBeqPost sp base a0 a1 a2 a3 b0 b1 b2 b3) := by
   let qHat := div128Quot (0 : Word) a3 b3
   let ms := mulsubN4 qHat b0 b1 b2 b3 a0 a1 a2 a3
@@ -459,11 +459,11 @@ theorem evm_mod_n4_full_shift0_call_addback_beq_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
      (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-     (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ q_out) **
+     (.x9 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ q_out) **
      (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
      (sp + signExtend12 3960 ↦ₘ b3) **
      (sp + signExtend12 3952 ↦ₘ (b3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat) **
-     (sp + signExtend12 3944 ↦ₘ (a3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat))
+     (sp + signExtend12 3944 ↦ₘ (a3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat) ** regOwn .x1)
     (by pcFree) hB
   have hFull := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by

--- a/EvmAsm/Evm64/DivMod/Compose/ModNormA.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModNormA.lean
@@ -216,7 +216,7 @@ private theorem divK_loopSetup_code_sub_modCode {base : Word} :
 
 /-- BLT singleton at base+loopSetupOff+12 (index 3 of loopSetup) is subsumed by modCode. -/
 private theorem blt_loopSetup_sub_modCode {base : Word} :
-    ∀ a i, (CodeReq.singleton (base + loopSetupOff + 12) (.BLT .x1 .x0 464)) a = some i →
+    ∀ a i, (CodeReq.singleton (base + loopSetupOff + 12) (.BLT .x9 .x0 464)) a = some i →
       (modCode base) a = some i := by
   intro a i h
   have hlookup := CodeReq.ofProg_lookup (base + loopSetupOff) (divK_loopSetup 464) 3
@@ -233,14 +233,14 @@ theorem mod_loopSetup_ntaken_spec_within (sp n v1 v5 : Word) (base : Word)
     (hm_ge : ¬BitVec.slt (signExtend12 (4 : BitVec 12) - n) (0 : Word)) :
     let m := signExtend12 (4 : BitVec 12) - n
     cpsTripleWithin 4 (base + loopSetupOff) (base + loopBodyOff) (modCode base)
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x1 ↦ᵣ v1) ** (.x0 ↦ᵣ (0 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x9 ↦ᵣ v1) ** (.x0 ↦ᵣ (0 : Word)) **
        ((sp + signExtend12 3984) ↦ₘ n))
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ n) ** (.x1 ↦ᵣ m) ** (.x0 ↦ᵣ (0 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ n) ** (.x9 ↦ᵣ m) ** (.x0 ↦ᵣ (0 : Word)) **
        ((sp + signExtend12 3984) ↦ₘ n)) := by
   intro m
   have hbody := divK_loopSetup_body_spec_within sp n v1 v5 464 (base + loopSetupOff)
   have hbodye := cpsTripleWithin_extend_code divK_loopSetup_code_sub_modCode hbody
-  have hblt_raw := blt_spec_gen_within .x1 .x0 464 m (0 : Word) (base + loopSetupOff + 12)
+  have hblt_raw := blt_spec_gen_within .x9 .x0 464 m (0 : Word) (base + loopSetupOff + 12)
   rw [show (base + loopSetupOff + 12 : Word) + signExtend13 464 = base + denormOff from by rv64_addr,
       show (base + loopSetupOff + 12 : Word) + 4 = base + loopBodyOff from by bv_addr] at hblt_raw
   have hblt_clean := cpsBranchWithin_ntakenStripPure2 hblt_raw

--- a/EvmAsm/Evm64/DivMod/Compose/NormA.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/NormA.lean
@@ -438,7 +438,7 @@ private theorem divK_loopSetup_code_sub_divCode_noNop {base : Word} :
 
 /-- BLT singleton at base+loopSetupOff+12 (index 3 of loopSetup) is subsumed by divCode. -/
 private theorem blt_loopSetup_sub_divCode {base : Word} :
-    ∀ a i, (CodeReq.singleton (base + loopSetupOff + 12) (.BLT .x1 .x0 464)) a = some i →
+    ∀ a i, (CodeReq.singleton (base + loopSetupOff + 12) (.BLT .x9 .x0 464)) a = some i →
       (divCode base) a = some i := by
   intro a i h
   have hlookup := CodeReq.ofProg_lookup (base + loopSetupOff) (divK_loopSetup 464) 3
@@ -449,7 +449,7 @@ private theorem blt_loopSetup_sub_divCode {base : Word} :
 
 /-- BLT singleton at base+loopSetupOff+12 is subsumed by divCode_noNop. -/
 private theorem blt_loopSetup_sub_divCode_noNop {base : Word} :
-    ∀ a i, (CodeReq.singleton (base + loopSetupOff + 12) (.BLT .x1 .x0 464)) a = some i →
+    ∀ a i, (CodeReq.singleton (base + loopSetupOff + 12) (.BLT .x9 .x0 464)) a = some i →
       (divCode_noNop base) a = some i := by
   intro a i h
   have hlookup := CodeReq.ofProg_lookup (base + loopSetupOff) (divK_loopSetup 464) 3
@@ -466,14 +466,14 @@ theorem divK_loopSetup_ntaken_spec_within (sp n v1 v5 : Word) (base : Word)
     (hm_ge : ¬BitVec.slt (signExtend12 (4 : BitVec 12) - n) (0 : Word)) :
     let m := signExtend12 (4 : BitVec 12) - n
     cpsTripleWithin 4 (base + loopSetupOff) (base + loopBodyOff) (divCode base)
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x1 ↦ᵣ v1) ** (.x0 ↦ᵣ (0 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x9 ↦ᵣ v1) ** (.x0 ↦ᵣ (0 : Word)) **
        ((sp + signExtend12 3984) ↦ₘ n))
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ n) ** (.x1 ↦ᵣ m) ** (.x0 ↦ᵣ (0 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ n) ** (.x9 ↦ᵣ m) ** (.x0 ↦ᵣ (0 : Word)) **
        ((sp + signExtend12 3984) ↦ₘ n)) := by
   intro m
   have hbody := divK_loopSetup_body_spec_within sp n v1 v5 464 (base + loopSetupOff)
   have hbodye := cpsTripleWithin_extend_code divK_loopSetup_code_sub_divCode hbody
-  have hblt_raw := blt_spec_gen_within .x1 .x0 464 m (0 : Word) (base + loopSetupOff + 12)
+  have hblt_raw := blt_spec_gen_within .x9 .x0 464 m (0 : Word) (base + loopSetupOff + 12)
   rw [show (base + loopSetupOff + 12 : Word) + signExtend13 464 = base + denormOff from by rv64_addr,
       show (base + loopSetupOff + 12 : Word) + 4 = base + loopBodyOff from by bv_addr] at hblt_raw
   have hblt_clean := cpsBranchWithin_ntakenStripPure2 hblt_raw
@@ -496,13 +496,13 @@ theorem divK_loopSetup_ntaken_spec_within (sp n v1 v5 : Word) (base : Word)
     downstream proofs see an opaque atom instead of the 5-atom sepConj. -/
 @[irreducible]
 def divKLoopSetupNtakenPreNoNop (sp v5 v1 n : Word) : Assertion :=
-  (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x1 ↦ᵣ v1) ** (.x0 ↦ᵣ (0 : Word)) **
+  (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x9 ↦ᵣ v1) ** (.x0 ↦ᵣ (0 : Word)) **
   ((sp + signExtend12 3984) ↦ₘ n)
 
 theorem divKLoopSetupNtakenPreNoNop_unfold
     {sp v5 v1 n : Word} :
     divKLoopSetupNtakenPreNoNop sp v5 v1 n =
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x1 ↦ᵣ v1) ** (.x0 ↦ᵣ (0 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x9 ↦ᵣ v1) ** (.x0 ↦ᵣ (0 : Word)) **
        ((sp + signExtend12 3984) ↦ₘ n)) := by
   delta divKLoopSetupNtakenPreNoNop
   rfl
@@ -511,13 +511,13 @@ theorem divKLoopSetupNtakenPreNoNop_unfold
     `x1 ← m = signExtend12 4 − n`. Wrapped `@[irreducible]`. -/
 @[irreducible]
 def divKLoopSetupNtakenPostNoNop (sp n m : Word) : Assertion :=
-  (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ n) ** (.x1 ↦ᵣ m) ** (.x0 ↦ᵣ (0 : Word)) **
+  (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ n) ** (.x9 ↦ᵣ m) ** (.x0 ↦ᵣ (0 : Word)) **
   ((sp + signExtend12 3984) ↦ₘ n)
 
 theorem divKLoopSetupNtakenPostNoNop_unfold
     {sp n m : Word} :
     divKLoopSetupNtakenPostNoNop sp n m =
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ n) ** (.x1 ↦ᵣ m) ** (.x0 ↦ᵣ (0 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ n) ** (.x9 ↦ᵣ m) ** (.x0 ↦ᵣ (0 : Word)) **
        ((sp + signExtend12 3984) ↦ₘ n)) := by
   delta divKLoopSetupNtakenPostNoNop
   rfl
@@ -532,7 +532,7 @@ theorem divK_loopSetup_ntaken_spec_within_noNop (sp n v1 v5 : Word) (base : Word
   rw [divKLoopSetupNtakenPreNoNop_unfold, divKLoopSetupNtakenPostNoNop_unfold]
   have hbody := divK_loopSetup_body_spec_within sp n v1 v5 464 (base + loopSetupOff)
   have hbodye := cpsTripleWithin_extend_code divK_loopSetup_code_sub_divCode_noNop hbody
-  have hblt_raw := blt_spec_gen_within .x1 .x0 464 m (0 : Word) (base + loopSetupOff + 12)
+  have hblt_raw := blt_spec_gen_within .x9 .x0 464 m (0 : Word) (base + loopSetupOff + 12)
   rw [show (base + loopSetupOff + 12 : Word) + signExtend13 464 = base + denormOff from by rv64_addr,
       show (base + loopSetupOff + 12 : Word) + 4 = base + loopBodyOff from by bv_addr] at hblt_raw
   have hblt_clean := cpsBranchWithin_ntakenStripPure2 hblt_raw

--- a/EvmAsm/Evm64/DivMod/LimbSpec/AddBackFinalLoopControl.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/AddBackFinalLoopControl.lean
@@ -55,29 +55,29 @@ theorem divK_loop_control_spec_within (j : Word) (loop_back_off : BitVec 13)
     (base : Word) :
     let j' := j + signExtend12 4095
     let cr :=
-      CodeReq.union (CodeReq.singleton base (.ADDI .x1 .x1 4095))
-       (CodeReq.singleton (base + 4) (.BGE .x1 .x0 loop_back_off))
+      CodeReq.union (CodeReq.singleton base (.ADDI .x9 .x9 4095))
+       (CodeReq.singleton (base + 4) (.BGE .x9 .x0 loop_back_off))
     cpsBranchWithin 2 base cr
-      ((.x1 ↦ᵣ j) ** (.x0 ↦ᵣ 0))
+      ((.x9 ↦ᵣ j) ** (.x0 ↦ᵣ 0))
       (base + 4 + signExtend13 loop_back_off)
-      ((.x1 ↦ᵣ j') ** (.x0 ↦ᵣ 0))
+      ((.x9 ↦ᵣ j') ** (.x0 ↦ᵣ 0))
       (base + 8)
-      ((.x1 ↦ᵣ j') ** (.x0 ↦ᵣ 0)) := by
+      ((.x9 ↦ᵣ j') ** (.x0 ↦ᵣ 0)) := by
   intro j' cr
   have hbody : cpsTripleWithin 1 base (base + 4) cr
-      ((.x1 ↦ᵣ j) ** (.x0 ↦ᵣ 0))
-      ((.x1 ↦ᵣ j') ** (.x0 ↦ᵣ 0)) := by
-    have I0 := addi_spec_gen_same_within .x1 j 4095 base (by nofun)
+      ((.x9 ↦ᵣ j) ** (.x0 ↦ᵣ 0))
+      ((.x9 ↦ᵣ j') ** (.x0 ↦ᵣ 0)) := by
+    have I0 := addi_spec_gen_same_within .x9 j 4095 base (by nofun)
     runBlock I0
-  have hbge_raw := bge_spec_gen_within .x1 .x0 loop_back_off j' 0 (base + 4)
+  have hbge_raw := bge_spec_gen_within .x9 .x0 loop_back_off j' 0 (base + 4)
   have ha1 : (base + 4 : Word) + 4 = base + 8 := by bv_addr
   rw [ha1] at hbge_raw
   have hbge : cpsBranchWithin 1 (base + 4) _
-      ((.x1 ↦ᵣ j') ** (.x0 ↦ᵣ 0))
+      ((.x9 ↦ᵣ j') ** (.x0 ↦ᵣ 0))
       ((base + 4) + signExtend13 loop_back_off)
-        ((.x1 ↦ᵣ j') ** (.x0 ↦ᵣ 0))
+        ((.x9 ↦ᵣ j') ** (.x0 ↦ᵣ 0))
       (base + 8)
-        ((.x1 ↦ᵣ j') ** (.x0 ↦ᵣ 0)) :=
+        ((.x9 ↦ᵣ j') ** (.x0 ↦ᵣ 0)) :=
     cpsBranchWithin_weaken
       (fun _ hp => hp)
       (fun h hp => sepConj_mono_right
@@ -86,13 +86,13 @@ theorem divK_loop_control_spec_within (j : Word) (loop_back_off : BitVec 13)
         (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hp)
       hbge_raw
   have hbge_ext : cpsBranchWithin 1 (base + 4) cr
-      ((.x1 ↦ᵣ j') ** (.x0 ↦ᵣ 0))
-      ((base + 4) + signExtend13 loop_back_off) ((.x1 ↦ᵣ j') ** (.x0 ↦ᵣ 0))
-      (base + 8) ((.x1 ↦ᵣ j') ** (.x0 ↦ᵣ 0)) :=
+      ((.x9 ↦ᵣ j') ** (.x0 ↦ᵣ 0))
+      ((base + 4) + signExtend13 loop_back_off) ((.x9 ↦ᵣ j') ** (.x0 ↦ᵣ 0))
+      (base + 8) ((.x9 ↦ᵣ j') ** (.x0 ↦ᵣ 0)) :=
     fun R hR s hcr hPR hpc =>
       hbge R hR s (CodeReq.singleton_satisfiedBy.mpr (hcr _ _ (by
-        show CodeReq.union (CodeReq.singleton base (.ADDI .x1 .x1 4095))
-          (CodeReq.singleton (base + 4) (.BGE .x1 .x0 loop_back_off)) (base + 4) = _
+        show CodeReq.union (CodeReq.singleton base (.ADDI .x9 .x9 4095))
+          (CodeReq.singleton (base + 4) (.BGE .x9 .x0 loop_back_off)) (base + 4) = _
         simp only [CodeReq.union, CodeReq.singleton]
         have h0 : ¬(base + 4 = base) := by bv_omega
         simp only [beq_iff_eq, h0, ↓reduceIte]))) hPR hpc

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Clamp.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Clamp.lean
@@ -116,29 +116,29 @@ theorem divK_div128_clamp_q1_merged_spec_within (q1 rhat dHi v5Old : Word) (base
 
 /-- div128 clamp q0: test q0 >= 2^32, conditionally decrement and adjust rhat2.
     Instrs [33]-[36]. Both BEQ paths merge at base+16. -/
-theorem divK_div128_clamp_q0_merged_spec_within (q0 rhat2 dHi v1Old : Word) (base : Word) :
+theorem divK_div128_clamp_q0_merged_spec_within (q0 rhat2 dHi v9Old : Word) (base : Word) :
     let hi := q0 >>> (32 : BitVec 6).toNat
     let q0' := if hi = 0 then q0 else q0 + signExtend12 4095
     let rhat2' := if hi = 0 then rhat2 else rhat2 + dHi
     let cr :=
-      CodeReq.union (CodeReq.singleton base (.SRLI .x1 .x5 32))
-      (CodeReq.union (CodeReq.singleton (base + 4) (.BEQ .x1 .x0 12))
+      CodeReq.union (CodeReq.singleton base (.SRLI .x9 .x5 32))
+      (CodeReq.union (CodeReq.singleton (base + 4) (.BEQ .x9 .x0 12))
       (CodeReq.union (CodeReq.singleton (base + 8) (.ADDI .x5 .x5 4095))
        (CodeReq.singleton (base + 12) (.ADD .x11 .x11 .x6))))
     cpsTripleWithin 4 base (base + 16) cr
       ((.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ rhat2) ** (.x6 ↦ᵣ dHi) **
-       (.x1 ↦ᵣ v1Old) ** (.x0 ↦ᵣ 0))
+       (.x9 ↦ᵣ v9Old) ** (.x0 ↦ᵣ 0))
       ((.x5 ↦ᵣ q0') ** (.x11 ↦ᵣ rhat2') ** (.x6 ↦ᵣ dHi) **
-       (.x1 ↦ᵣ hi) ** (.x0 ↦ᵣ 0)) := by
+       (.x9 ↦ᵣ hi) ** (.x0 ↦ᵣ 0)) := by
   intro hi q0' rhat2' cr
   have hbody : cpsTripleWithin 1 base (base + 4) cr
       ((.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ rhat2) ** (.x6 ↦ᵣ dHi) **
-       (.x1 ↦ᵣ v1Old) ** (.x0 ↦ᵣ 0))
+       (.x9 ↦ᵣ v9Old) ** (.x0 ↦ᵣ 0))
       ((.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ rhat2) ** (.x6 ↦ᵣ dHi) **
-       (.x1 ↦ᵣ hi) ** (.x0 ↦ᵣ 0)) := by
-    have I0 := srli_spec_gen_within .x1 .x5 v1Old q0 32 base (by nofun)
+       (.x9 ↦ᵣ hi) ** (.x0 ↦ᵣ 0)) := by
+    have I0 := srli_spec_gen_within .x9 .x5 v9Old q0 32 base (by nofun)
     runBlock I0
-  have hbeq_raw := beq_spec_gen_within .x1 .x0 (12 : BitVec 13) hi (0 : Word) (base + 4)
+  have hbeq_raw := beq_spec_gen_within .x9 .x0 (12 : BitVec 13) hi (0 : Word) (base + 4)
   have ha_t : (base + 4) + signExtend13 (12 : BitVec 13) = base + 16 := by rv64_addr
   have ha_f : (base + 4 : Word) + 4 = base + 8 := by bv_addr
   rw [ha_t, ha_f] at hbeq_raw
@@ -146,13 +146,13 @@ theorem divK_div128_clamp_q0_merged_spec_within (q0 rhat2 dHi v1Old : Word) (bas
     ((.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ rhat2) ** (.x6 ↦ᵣ dHi))
     (by pcFree) hbeq_raw
   have hbeq_ext : cpsBranchWithin 1 (base + 4) cr
-      (((.x1 ↦ᵣ hi) ** (.x0 ↦ᵣ (0 : Word))) **
+      (((.x9 ↦ᵣ hi) ** (.x0 ↦ᵣ (0 : Word))) **
        ((.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ rhat2) ** (.x6 ↦ᵣ dHi)))
       (base + 16)
-        (((.x1 ↦ᵣ hi) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜hi = 0⌝) **
+        (((.x9 ↦ᵣ hi) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜hi = 0⌝) **
          ((.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ rhat2) ** (.x6 ↦ᵣ dHi)))
       (base + 8)
-        (((.x1 ↦ᵣ hi) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜hi ≠ 0⌝) **
+        (((.x9 ↦ᵣ hi) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜hi ≠ 0⌝) **
          ((.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ rhat2) ** (.x6 ↦ᵣ dHi))) :=
     fun R hR s hcr hPR hpc =>
       hbeq_framed R hR s (CodeReq.singleton_satisfiedBy.mpr (hcr _ _ (by
@@ -189,7 +189,7 @@ theorem divK_div128_clamp_q0_merged_spec_within (q0 rhat2 dHi v1Old : Word) (bas
         ((.x5 ↦ᵣ (q0 + signExtend12 4095)) ** (.x11 ↦ᵣ (rhat2 + dHi)) ** (.x6 ↦ᵣ dHi)) := by
       runBlock I1 I2
     have hcorr_framed := cpsTripleWithin_frameR
-      ((.x1 ↦ᵣ hi) ** (.x0 ↦ᵣ (0 : Word)))
+      ((.x9 ↦ᵣ hi) ** (.x0 ↦ᵣ (0 : Word)))
       (by pcFree) hcorr
     have full := cpsTripleWithin_seq_perm_same_cr
       (fun h hp => by

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Phase1.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Phase1.lean
@@ -31,7 +31,7 @@ namespace EvmAsm.Evm64
 open EvmAsm.Rv64
 
 /-- div128 Phase 1a: save x2 (return addr) and x10 (d), compute dHi and dLo. -/
-theorem divK_div128_save_split_d_spec_within (sp retAddr d v1Old v6Old
+theorem divK_div128_save_split_d_spec_within (sp retAddr d v9Old v6Old
     retMem dMem dloMem : Word) (base : Word) :
     let dHi := d >>> (32 : BitVec 6).toNat
     let dLo := (d <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
@@ -39,17 +39,17 @@ theorem divK_div128_save_split_d_spec_within (sp retAddr d v1Old v6Old
       CodeReq.union (CodeReq.singleton base (.SD .x12 .x2 3968))
       (CodeReq.union (CodeReq.singleton (base + 4) (.SD .x12 .x10 3960))
       (CodeReq.union (CodeReq.singleton (base + 8) (.SRLI .x6 .x10 32))
-      (CodeReq.union (CodeReq.singleton (base + 12) (.SLLI .x1 .x10 32))
-      (CodeReq.union (CodeReq.singleton (base + 16) (.SRLI .x1 .x1 32))
-       (CodeReq.singleton (base + 20) (.SD .x12 .x1 3952))))))
+      (CodeReq.union (CodeReq.singleton (base + 12) (.SLLI .x9 .x10 32))
+      (CodeReq.union (CodeReq.singleton (base + 16) (.SRLI .x9 .x9 32))
+       (CodeReq.singleton (base + 20) (.SD .x12 .x9 3952))))))
     cpsTripleWithin 6 base (base + 24) cr
       ((.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ retAddr) ** (.x10 ↦ᵣ d) **
-       (.x6 ↦ᵣ v6Old) ** (.x1 ↦ᵣ v1Old) **
+       (.x6 ↦ᵣ v6Old) ** (.x9 ↦ᵣ v9Old) **
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem))
       ((.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ retAddr) ** (.x10 ↦ᵣ d) **
-       (.x6 ↦ᵣ dHi) ** (.x1 ↦ᵣ dLo) **
+       (.x6 ↦ᵣ dHi) ** (.x9 ↦ᵣ dLo) **
        (sp + signExtend12 3968 ↦ₘ retAddr) **
        (sp + signExtend12 3960 ↦ₘ d) **
        (sp + signExtend12 3952 ↦ₘ dLo)) := by
@@ -57,9 +57,9 @@ theorem divK_div128_save_split_d_spec_within (sp retAddr d v1Old v6Old
   have I0 := sd_spec_gen_within .x12 .x2 sp retAddr retMem 3968 base
   have I1 := sd_spec_gen_within .x12 .x10 sp d dMem 3960 (base + 4)
   have I2 := srli_spec_gen_within .x6 .x10 v6Old d 32 (base + 8) (by nofun)
-  have I3 := slli_spec_gen_within .x1 .x10 v1Old d 32 (base + 12) (by nofun)
-  have I4 := srli_spec_gen_same_within .x1 (d <<< (32 : BitVec 6).toNat) 32 (base + 16) (by nofun)
-  have I5 := sd_spec_gen_within .x12 .x1 sp dLo dloMem 3952 (base + 20)
+  have I3 := slli_spec_gen_within .x9 .x10 v9Old d 32 (base + 12) (by nofun)
+  have I4 := srli_spec_gen_same_within .x9 (d <<< (32 : BitVec 6).toNat) 32 (base + 16) (by nofun)
+  have I5 := sd_spec_gen_within .x12 .x9 sp dLo dloMem 3952 (base + 20)
   runBlock I0 I1 I2 I3 I4 I5
 
 /-- div128 Phase 1b: split uLo into un1 (x11) and un0 (x5), save un0. -/

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128PhaseEnd.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128PhaseEnd.lean
@@ -33,7 +33,7 @@ open EvmAsm.Rv64
     Input: x12=sp, x2=retAddr, x10=d, x5=uLo, x7=uHi.
     Output: x6=dHi, x11=un1, x5=un0 (saved), x7=uHi (unchanged). -/
 theorem divK_div128_phase1_spec_within
-    (sp retAddr d uLo uHi v1Old v6Old v11Old
+    (sp retAddr d uLo uHi v9Old v6Old v11Old
      retMem dMem dloMem un0Mem : Word) (base : Word) :
     let dHi := d >>> (32 : BitVec 6).toNat
     let dLo := (d <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
@@ -43,23 +43,23 @@ theorem divK_div128_phase1_spec_within
       CodeReq.union (CodeReq.singleton base (.SD .x12 .x2 3968))
       (CodeReq.union (CodeReq.singleton (base + 4) (.SD .x12 .x10 3960))
       (CodeReq.union (CodeReq.singleton (base + 8) (.SRLI .x6 .x10 32))
-      (CodeReq.union (CodeReq.singleton (base + 12) (.SLLI .x1 .x10 32))
-      (CodeReq.union (CodeReq.singleton (base + 16) (.SRLI .x1 .x1 32))
-      (CodeReq.union (CodeReq.singleton (base + 20) (.SD .x12 .x1 3952))
+      (CodeReq.union (CodeReq.singleton (base + 12) (.SLLI .x9 .x10 32))
+      (CodeReq.union (CodeReq.singleton (base + 16) (.SRLI .x9 .x9 32))
+      (CodeReq.union (CodeReq.singleton (base + 20) (.SD .x12 .x9 3952))
       (CodeReq.union (CodeReq.singleton (base + 24) (.SRLI .x11 .x5 32))
       (CodeReq.union (CodeReq.singleton (base + 28) (.SLLI .x5 .x5 32))
       (CodeReq.union (CodeReq.singleton (base + 32) (.SRLI .x5 .x5 32))
        (CodeReq.singleton (base + 36) (.SD .x12 .x5 3944))))))))))
     cpsTripleWithin 10 base (base + 40) cr
       ((.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ retAddr) ** (.x10 ↦ᵣ d) **
-       (.x6 ↦ᵣ v6Old) ** (.x1 ↦ᵣ v1Old) ** (.x5 ↦ᵣ uLo) **
+       (.x6 ↦ᵣ v6Old) ** (.x9 ↦ᵣ v9Old) ** (.x5 ↦ᵣ uLo) **
        (.x11 ↦ᵣ v11Old) ** (.x7 ↦ᵣ uHi) **
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ un0Mem))
       ((.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ retAddr) ** (.x10 ↦ᵣ d) **
-       (.x6 ↦ᵣ dHi) ** (.x1 ↦ᵣ dLo) ** (.x5 ↦ᵣ un0) **
+       (.x6 ↦ᵣ dHi) ** (.x9 ↦ᵣ dLo) ** (.x5 ↦ᵣ un0) **
        (.x11 ↦ᵣ un1) ** (.x7 ↦ᵣ uHi) **
        (sp + signExtend12 3968 ↦ₘ retAddr) **
        (sp + signExtend12 3960 ↦ₘ d) **
@@ -69,9 +69,9 @@ theorem divK_div128_phase1_spec_within
   have I0 := sd_spec_gen_within .x12 .x2 sp retAddr retMem 3968 base
   have I1 := sd_spec_gen_within .x12 .x10 sp d dMem 3960 (base + 4)
   have I2 := srli_spec_gen_within .x6 .x10 v6Old d 32 (base + 8) (by nofun)
-  have I3 := slli_spec_gen_within .x1 .x10 v1Old d 32 (base + 12) (by nofun)
-  have I4 := srli_spec_gen_same_within .x1 (d <<< (32 : BitVec 6).toNat) 32 (base + 16) (by nofun)
-  have I5 := sd_spec_gen_within .x12 .x1 sp dLo dloMem 3952 (base + 20)
+  have I3 := slli_spec_gen_within .x9 .x10 v9Old d 32 (base + 12) (by nofun)
+  have I4 := srli_spec_gen_same_within .x9 (d <<< (32 : BitVec 6).toNat) 32 (base + 16) (by nofun)
+  have I5 := sd_spec_gen_within .x12 .x9 sp dLo dloMem 3952 (base + 20)
   have I6 := srli_spec_gen_within .x11 .x5 v11Old uLo 32 (base + 24) (by nofun)
   have I7 := slli_spec_gen_same_within .x5 uLo 32 (base + 28) (by nofun)
   have I8 := srli_spec_gen_same_within .x5 (uLo <<< (32 : BitVec 6).toNat) 32 (base + 32) (by nofun)

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck1.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck1.lean
@@ -32,41 +32,41 @@ open EvmAsm.Rv64
 /-- div128 product check 1: compute q1*dLo vs rhat*2^32+un1, conditionally correct.
     Instrs [17]-[24]. Both BLTU paths merge at base+32. -/
 theorem divK_div128_prodcheck1_merged_spec_within
-    (sp q1 rhat dHi un1 v1Old v5Old dlo : Word) (base : Word) :
+    (sp q1 rhat dHi un1 v9Old v5Old dlo : Word) (base : Word) :
     let qDlo := q1 * dlo
     let rhatUn1 := (rhat <<< (32 : BitVec 6).toNat) ||| un1
     let q1' := if BitVec.ult rhatUn1 qDlo then q1 + signExtend12 4095 else q1
     let rhat' := if BitVec.ult rhatUn1 qDlo then rhat + dHi else rhat
     let cr :=
-      CodeReq.union (CodeReq.singleton base (.LD .x1 .x12 3952))
-      (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x5 .x10 .x1))
-      (CodeReq.union (CodeReq.singleton (base + 8) (.SLLI .x1 .x7 32))
-      (CodeReq.union (CodeReq.singleton (base + 12) (.OR .x1 .x1 .x11))
-      (CodeReq.union (CodeReq.singleton (base + 16) (.BLTU .x1 .x5 8))
+      CodeReq.union (CodeReq.singleton base (.LD .x9 .x12 3952))
+      (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x5 .x10 .x9))
+      (CodeReq.union (CodeReq.singleton (base + 8) (.SLLI .x9 .x7 32))
+      (CodeReq.union (CodeReq.singleton (base + 12) (.OR .x9 .x9 .x11))
+      (CodeReq.union (CodeReq.singleton (base + 16) (.BLTU .x9 .x5 8))
       (CodeReq.union (CodeReq.singleton (base + 20) (.JAL .x0 12))
       (CodeReq.union (CodeReq.singleton (base + 24) (.ADDI .x10 .x10 4095))
        (CodeReq.singleton (base + 28) (.ADD .x7 .x7 .x6))))))))
     cpsTripleWithin 8 base (base + 32) cr
       ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) ** (.x11 ↦ᵣ un1) **
-       (.x5 ↦ᵣ v5Old) ** (.x1 ↦ᵣ v1Old) ** (.x6 ↦ᵣ dHi) **
+       (.x5 ↦ᵣ v5Old) ** (.x9 ↦ᵣ v9Old) ** (.x6 ↦ᵣ dHi) **
        (sp + signExtend12 3952 ↦ₘ dlo))
       ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1') ** (.x7 ↦ᵣ rhat') ** (.x11 ↦ᵣ un1) **
-       (.x5 ↦ᵣ qDlo) ** (.x1 ↦ᵣ rhatUn1) ** (.x6 ↦ᵣ dHi) **
+       (.x5 ↦ᵣ qDlo) ** (.x9 ↦ᵣ rhatUn1) ** (.x6 ↦ᵣ dHi) **
        (sp + signExtend12 3952 ↦ₘ dlo)) := by
   intro qDlo rhatUn1 q1' rhat' cr
   have hbody : cpsTripleWithin 4 base (base + 16) cr
       ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) ** (.x11 ↦ᵣ un1) **
-       (.x5 ↦ᵣ v5Old) ** (.x1 ↦ᵣ v1Old) ** (.x6 ↦ᵣ dHi) **
+       (.x5 ↦ᵣ v5Old) ** (.x9 ↦ᵣ v9Old) ** (.x6 ↦ᵣ dHi) **
        (sp + signExtend12 3952 ↦ₘ dlo))
       ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) ** (.x11 ↦ᵣ un1) **
-       (.x5 ↦ᵣ qDlo) ** (.x1 ↦ᵣ rhatUn1) ** (.x6 ↦ᵣ dHi) **
+       (.x5 ↦ᵣ qDlo) ** (.x9 ↦ᵣ rhatUn1) ** (.x6 ↦ᵣ dHi) **
        (sp + signExtend12 3952 ↦ₘ dlo)) := by
-    have I0 := ld_spec_gen_within .x1 .x12 sp v1Old dlo 3952 base (by nofun)
-    have I1 := mul_spec_gen_within .x5 .x10 .x1 v5Old q1 dlo (base + 4) (by nofun)
-    have I2 := slli_spec_gen_within .x1 .x7 dlo rhat 32 (base + 8) (by nofun)
-    have I3 := or_spec_gen_rd_eq_rs1_within .x1 .x11 (rhat <<< (32 : BitVec 6).toNat) un1 (base + 12) (by nofun)
+    have I0 := ld_spec_gen_within .x9 .x12 sp v9Old dlo 3952 base (by nofun)
+    have I1 := mul_spec_gen_within .x5 .x10 .x9 v5Old q1 dlo (base + 4) (by nofun)
+    have I2 := slli_spec_gen_within .x9 .x7 dlo rhat 32 (base + 8) (by nofun)
+    have I3 := or_spec_gen_rd_eq_rs1_within .x9 .x11 (rhat <<< (32 : BitVec 6).toNat) un1 (base + 12) (by nofun)
     runBlock I0 I1 I2 I3
-  have hbltu_raw := bltu_spec_gen_within .x1 .x5 (8 : BitVec 13) rhatUn1 qDlo (base + 16)
+  have hbltu_raw := bltu_spec_gen_within .x9 .x5 (8 : BitVec 13) rhatUn1 qDlo (base + 16)
   have ha_t : (base + 16) + signExtend13 (8 : BitVec 13) = base + 24 := by rv64_addr
   have ha_f : (base + 16 : Word) + 4 = base + 20 := by bv_addr
   rw [ha_t, ha_f] at hbltu_raw
@@ -75,15 +75,15 @@ theorem divK_div128_prodcheck1_merged_spec_within
      (.x6 ↦ᵣ dHi) ** (sp + signExtend12 3952 ↦ₘ dlo))
     (by pcFree) hbltu_raw
   have hbltu_ext : cpsBranchWithin 1 (base + 16) cr
-      (((.x1 ↦ᵣ rhatUn1) ** (.x5 ↦ᵣ qDlo)) **
+      (((.x9 ↦ᵣ rhatUn1) ** (.x5 ↦ᵣ qDlo)) **
        ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) ** (.x11 ↦ᵣ un1) **
         (.x6 ↦ᵣ dHi) ** (sp + signExtend12 3952 ↦ₘ dlo)))
       (base + 24)
-        (((.x1 ↦ᵣ rhatUn1) ** (.x5 ↦ᵣ qDlo) ** ⌜BitVec.ult rhatUn1 qDlo⌝) **
+        (((.x9 ↦ᵣ rhatUn1) ** (.x5 ↦ᵣ qDlo) ** ⌜BitVec.ult rhatUn1 qDlo⌝) **
          ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) ** (.x11 ↦ᵣ un1) **
           (.x6 ↦ᵣ dHi) ** (sp + signExtend12 3952 ↦ₘ dlo)))
       (base + 20)
-        (((.x1 ↦ᵣ rhatUn1) ** (.x5 ↦ᵣ qDlo) ** ⌜¬BitVec.ult rhatUn1 qDlo⌝) **
+        (((.x9 ↦ᵣ rhatUn1) ** (.x5 ↦ᵣ qDlo) ** ⌜¬BitVec.ult rhatUn1 qDlo⌝) **
          ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) ** (.x11 ↦ᵣ un1) **
           (.x6 ↦ᵣ dHi) ** (sp + signExtend12 3952 ↦ₘ dlo))) :=
     fun R hR s hcr hPR hpc =>
@@ -111,7 +111,7 @@ theorem divK_div128_prodcheck1_merged_spec_within
         ((.x10 ↦ᵣ (q1 + signExtend12 4095)) ** (.x7 ↦ᵣ (rhat + dHi)) ** (.x6 ↦ᵣ dHi)) := by
       runBlock I4 I5
     have hcorr_framed := cpsTripleWithin_frameR
-      ((.x1 ↦ᵣ rhatUn1) ** (.x5 ↦ᵣ qDlo) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ un1) **
+      ((.x9 ↦ᵣ rhatUn1) ** (.x5 ↦ᵣ qDlo) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ un1) **
        (sp + signExtend12 3952 ↦ₘ dlo))
       (by pcFree) hcorr
     have full := cpsTripleWithin_seq_perm_same_cr
@@ -142,22 +142,22 @@ theorem divK_div128_prodcheck1_merged_spec_within
       · simp at h
     have I_jal_cr := cpsTripleWithin_extend_code hcr_jal I_jal
     have hjal_framed := cpsTripleWithin_frameR
-      ((.x1 ↦ᵣ rhatUn1) ** (.x5 ↦ᵣ qDlo) ** (.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1) **
+      ((.x9 ↦ᵣ rhatUn1) ** (.x5 ↦ᵣ qDlo) ** (.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1) **
        (.x7 ↦ᵣ rhat) ** (.x11 ↦ᵣ un1) ** (.x6 ↦ᵣ dHi) **
        (sp + signExtend12 3952 ↦ₘ dlo))
       (by pcFree) I_jal_cr
     simp only [sepConj_emp_left'] at hjal_framed
     have ntaken_clean : cpsTripleWithin 5 base (base + 20) cr
         ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) ** (.x11 ↦ᵣ un1) **
-         (.x5 ↦ᵣ v5Old) ** (.x1 ↦ᵣ v1Old) ** (.x6 ↦ᵣ dHi) **
+         (.x5 ↦ᵣ v5Old) ** (.x9 ↦ᵣ v9Old) ** (.x6 ↦ᵣ dHi) **
          (sp + signExtend12 3952 ↦ₘ dlo))
-        ((.x1 ↦ᵣ rhatUn1) ** (.x5 ↦ᵣ qDlo) **
+        ((.x9 ↦ᵣ rhatUn1) ** (.x5 ↦ᵣ qDlo) **
          (.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) ** (.x11 ↦ᵣ un1) **
          (.x6 ↦ᵣ dHi) ** (sp + signExtend12 3952 ↦ₘ dlo)) :=
       cpsTripleWithin_weaken
         (fun h hp => hp)
         (fun h hp => by
-          have hp' : (((.x1 ↦ᵣ rhatUn1) ** (.x5 ↦ᵣ qDlo)) **
+          have hp' : (((.x9 ↦ᵣ rhatUn1) ** (.x5 ↦ᵣ qDlo)) **
             ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) ** (.x11 ↦ᵣ un1) **
              (.x6 ↦ᵣ dHi) ** (sp + signExtend12 3952 ↦ₘ dlo))) h :=
             sepConj_mono_left (sepConj_mono_right

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck1b.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck1b.lean
@@ -18,7 +18,7 @@
   The merged spec is shaped as a `cpsBranchWithin` (mirroring
   `divK_div128_step2_branch_merged_spec_within`) where both legs converge at
   `base + 40` but carry different register postconditions for `.x5`
-  and `.x1` (the body's mul-check temporaries).
+  and `.x9` (the body's mul-check temporaries).
 
   Issue #1337's algorithm fix migration. Tracked in PR #1389.
 -/
@@ -40,24 +40,24 @@ open EvmAsm.Rv64
     - **Taken** (rhatHi ≠ 0): branches to `(base + 4) + signExtend13 guard_off`.
     - **Fall-through** (rhatHi = 0): continues to `base + 8`. -/
 theorem divK_div128_prodcheck1b_guard_spec_within
-    (sp rhat v1Old : Word) (base : Word) (guard_off : BitVec 13) :
+    (sp rhat v9Old : Word) (base : Word) (guard_off : BitVec 13) :
     let rhatHi := rhat >>> (32 : BitVec 6).toNat
     let cr :=
-      CodeReq.union (CodeReq.singleton base (.SRLI .x1 .x7 32))
-        (CodeReq.singleton (base + 4) (.BNE .x1 .x0 guard_off))
+      CodeReq.union (CodeReq.singleton base (.SRLI .x9 .x7 32))
+        (CodeReq.singleton (base + 4) (.BNE .x9 .x0 guard_off))
     cpsBranchWithin 2 base cr
-      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ rhat) ** (.x1 ↦ᵣ v1Old) ** (.x0 ↦ᵣ 0))
+      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ rhat) ** (.x9 ↦ᵣ v9Old) ** (.x0 ↦ᵣ 0))
       ((base + 4) + signExtend13 guard_off)
-        ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ rhat) ** (.x1 ↦ᵣ rhatHi) **
+        ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ rhat) ** (.x9 ↦ᵣ rhatHi) **
          (.x0 ↦ᵣ 0) ** ⌜rhatHi ≠ 0⌝)
       (base + 8)
-        ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ rhat) ** (.x1 ↦ᵣ rhatHi) **
+        ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ rhat) ** (.x9 ↦ᵣ rhatHi) **
          (.x0 ↦ᵣ 0) ** ⌜rhatHi = 0⌝) := by
   intro rhatHi cr
-  -- Step 1: SRLI .x1 .x7 32  (cpsTripleWithin base → base+4)
-  have hsrli_raw := srli_spec_gen_within .x1 .x7 v1Old rhat 32 base (by nofun)
+  -- Step 1: SRLI .x9 .x7 32  (cpsTripleWithin base → base+4)
+  have hsrli_raw := srli_spec_gen_within .x9 .x7 v9Old rhat 32 base (by nofun)
   have hcr_srli : ∀ a i,
-      CodeReq.singleton base (.SRLI .x1 .x7 32) a = some i → cr a = some i := by
+      CodeReq.singleton base (.SRLI .x9 .x7 32) a = some i → cr a = some i := by
     intro a i h
     simp only [cr, CodeReq.union, CodeReq.singleton] at h ⊢
     split at h
@@ -67,10 +67,10 @@ theorem divK_div128_prodcheck1b_guard_spec_within
   have hsrli_framed := cpsTripleWithin_frameR
     ((.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0))
     (by pcFree) hsrli
-  -- Step 2: BNE .x1 .x0 guard_off  (cpsBranchWithin base+4 → ...)
-  have hbne_raw := bne_spec_gen_within .x1 .x0 guard_off rhatHi (0 : Word) (base + 4)
+  -- Step 2: BNE .x9 .x0 guard_off  (cpsBranchWithin base+4 → ...)
+  have hbne_raw := bne_spec_gen_within .x9 .x0 guard_off rhatHi (0 : Word) (base + 4)
   have hcr_bne : ∀ a i,
-      CodeReq.singleton (base + 4) (.BNE .x1 .x0 guard_off) a = some i → cr a = some i := by
+      CodeReq.singleton (base + 4) (.BNE .x9 .x0 guard_off) a = some i → cr a = some i := by
     intro a i h
     simp only [cr, CodeReq.union, CodeReq.singleton] at h ⊢
     split at h
@@ -97,21 +97,21 @@ theorem divK_div128_prodcheck1b_guard_spec_within
     theorem signature. -/
 @[irreducible]
 def divKDiv128Prodcheck1bBodyCode (base : Word) : CodeReq :=
-  CodeReq.union (CodeReq.singleton base (.LD .x1 .x12 3952))
-  (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x5 .x10 .x1))
-  (CodeReq.union (CodeReq.singleton (base + 8) (.SLLI .x1 .x7 32))
-  (CodeReq.union (CodeReq.singleton (base + 12) (.OR .x1 .x1 .x11))
-  (CodeReq.union (CodeReq.singleton (base + 16) (.BLTU .x1 .x5 8))
+  CodeReq.union (CodeReq.singleton base (.LD .x9 .x12 3952))
+  (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x5 .x10 .x9))
+  (CodeReq.union (CodeReq.singleton (base + 8) (.SLLI .x9 .x7 32))
+  (CodeReq.union (CodeReq.singleton (base + 12) (.OR .x9 .x9 .x11))
+  (CodeReq.union (CodeReq.singleton (base + 16) (.BLTU .x9 .x5 8))
   (CodeReq.union (CodeReq.singleton (base + 20) (.JAL .x0 12))
   (CodeReq.union (CodeReq.singleton (base + 24) (.ADDI .x10 .x10 4095))
    (CodeReq.singleton (base + 28) (.ADD .x7 .x7 .x6))))))))
 
 /-- Bundled precondition for `divK_div128_prodcheck1b_body_spec_within`. -/
 @[irreducible]
-def divKDiv128Prodcheck1bBodyPre (sp q1c rhatc dHi un1 v1Old v5Old dlo : Word) :
+def divKDiv128Prodcheck1bBodyPre (sp q1c rhatc dHi un1 v9Old v5Old dlo : Word) :
     Assertion :=
   (.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1c) ** (.x7 ↦ᵣ rhatc) ** (.x11 ↦ᵣ un1) **
-  (.x5 ↦ᵣ v5Old) ** (.x1 ↦ᵣ v1Old) ** (.x6 ↦ᵣ dHi) **
+  (.x5 ↦ᵣ v5Old) ** (.x9 ↦ᵣ v9Old) ** (.x6 ↦ᵣ dHi) **
   (sp + signExtend12 3952 ↦ₘ dlo)
 
 /-- Bundled postcondition for `divK_div128_prodcheck1b_body_spec_within`. -/
@@ -122,7 +122,7 @@ def divKDiv128Prodcheck1bBodyPost (sp q1c rhatc dHi un1 dlo : Word) : Assertion 
   let q1' := if BitVec.ult rhatUn1' qDlo then q1c + signExtend12 4095 else q1c
   let rhat' := if BitVec.ult rhatUn1' qDlo then rhatc + dHi else rhatc
   (.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1') ** (.x7 ↦ᵣ rhat') ** (.x11 ↦ᵣ un1) **
-  (.x5 ↦ᵣ qDlo) ** (.x1 ↦ᵣ rhatUn1') ** (.x6 ↦ᵣ dHi) **
+  (.x5 ↦ᵣ qDlo) ** (.x9 ↦ᵣ rhatUn1') ** (.x6 ↦ᵣ dHi) **
   (sp + signExtend12 3952 ↦ₘ dlo)
 
 /-- **Sub-stub B — body portion**: `[27..34]` LD/MUL/SLLI/OR/BLTU/JAL/ADDI/ADD.
@@ -131,37 +131,37 @@ def divKDiv128Prodcheck1bBodyPost (sp q1c rhatc dHi un1 dlo : Word) : Assertion 
 
     Reachable only when the guard at [25..26] falls through (rhatc < 2^32). -/
 theorem divK_div128_prodcheck1b_body_spec_within
-    (sp q1c rhatc dHi un1 v1Old v5Old dlo : Word) (base : Word) :
+    (sp q1c rhatc dHi un1 v9Old v5Old dlo : Word) (base : Word) :
     cpsTripleWithin 8 base (base + 32) (divKDiv128Prodcheck1bBodyCode base)
-      (divKDiv128Prodcheck1bBodyPre sp q1c rhatc dHi un1 v1Old v5Old dlo)
+      (divKDiv128Prodcheck1bBodyPre sp q1c rhatc dHi un1 v9Old v5Old dlo)
       (divKDiv128Prodcheck1bBodyPost sp q1c rhatc dHi un1 dlo) := by
   unfold divKDiv128Prodcheck1bBodyCode divKDiv128Prodcheck1bBodyPre
     divKDiv128Prodcheck1bBodyPost
   exact divK_div128_prodcheck1_merged_spec_within
-    sp q1c rhatc dHi un1 v1Old v5Old dlo base
+    sp q1c rhatc dHi un1 v9Old v5Old dlo base
 
 /-- Bundled CodeReq for `divK_div128_prodcheck1b_merged_spec_within` (10 singletons,
     instrs [25..34]). `@[irreducible]` to keep let-bindings out of the
     theorem signature. -/
 @[irreducible]
 def divKDiv128Prodcheck1bMergedCode (base : Word) : CodeReq :=
-  CodeReq.union (CodeReq.singleton base (.SRLI .x1 .x7 32))
-  (CodeReq.union (CodeReq.singleton (base + 4) (.BNE .x1 .x0 36))
-  (CodeReq.union (CodeReq.singleton (base + 8) (.LD .x1 .x12 3952))
-  (CodeReq.union (CodeReq.singleton (base + 12) (.MUL .x5 .x10 .x1))
-  (CodeReq.union (CodeReq.singleton (base + 16) (.SLLI .x1 .x7 32))
-  (CodeReq.union (CodeReq.singleton (base + 20) (.OR .x1 .x1 .x11))
-  (CodeReq.union (CodeReq.singleton (base + 24) (.BLTU .x1 .x5 8))
+  CodeReq.union (CodeReq.singleton base (.SRLI .x9 .x7 32))
+  (CodeReq.union (CodeReq.singleton (base + 4) (.BNE .x9 .x0 36))
+  (CodeReq.union (CodeReq.singleton (base + 8) (.LD .x9 .x12 3952))
+  (CodeReq.union (CodeReq.singleton (base + 12) (.MUL .x5 .x10 .x9))
+  (CodeReq.union (CodeReq.singleton (base + 16) (.SLLI .x9 .x7 32))
+  (CodeReq.union (CodeReq.singleton (base + 20) (.OR .x9 .x9 .x11))
+  (CodeReq.union (CodeReq.singleton (base + 24) (.BLTU .x9 .x5 8))
   (CodeReq.union (CodeReq.singleton (base + 28) (.JAL .x0 12))
   (CodeReq.union (CodeReq.singleton (base + 32) (.ADDI .x10 .x10 4095))
    (CodeReq.singleton (base + 36) (.ADD .x7 .x7 .x6))))))))))
 
 /-- Bundled precondition for `divK_div128_prodcheck1b_merged_spec_within`. -/
 @[irreducible]
-def divKDiv128Prodcheck1bMergedPre (sp q1c rhatc dHi un1 v1Old v5Old dlo : Word) :
+def divKDiv128Prodcheck1bMergedPre (sp q1c rhatc dHi un1 v9Old v5Old dlo : Word) :
     Assertion :=
   (.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1c) ** (.x7 ↦ᵣ rhatc) ** (.x11 ↦ᵣ un1) **
-  (.x5 ↦ᵣ v5Old) ** (.x1 ↦ᵣ v1Old) ** (.x6 ↦ᵣ dHi) ** (.x0 ↦ᵣ 0) **
+  (.x5 ↦ᵣ v5Old) ** (.x9 ↦ᵣ v9Old) ** (.x6 ↦ᵣ dHi) ** (.x0 ↦ᵣ 0) **
   (sp + signExtend12 3952 ↦ₘ dlo)
 
 /-- Bundled taken-leg postcondition for `divK_div128_prodcheck1b_merged_spec_within`
@@ -171,7 +171,7 @@ def divKDiv128Prodcheck1bMergedTakenPost
     (sp q1c rhatc dHi un1 v5Old dlo : Word) : Assertion :=
   let rhatHi := rhatc >>> (32 : BitVec 6).toNat
   (.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1c) ** (.x7 ↦ᵣ rhatc) ** (.x11 ↦ᵣ un1) **
-  (.x5 ↦ᵣ v5Old) ** (.x1 ↦ᵣ rhatHi) ** (.x6 ↦ᵣ dHi) ** (.x0 ↦ᵣ 0) **
+  (.x5 ↦ᵣ v5Old) ** (.x9 ↦ᵣ rhatHi) ** (.x6 ↦ᵣ dHi) ** (.x0 ↦ᵣ 0) **
   ⌜rhatHi ≠ 0⌝ **
   (sp + signExtend12 3952 ↦ₘ dlo)
 
@@ -186,7 +186,7 @@ def divKDiv128Prodcheck1bMergedFTPost (sp q1c rhatc dHi un1 dlo : Word) :
   let q1'FT := if BitVec.ult rhatUn1' qDlo then q1c + signExtend12 4095 else q1c
   let rhat'FT := if BitVec.ult rhatUn1' qDlo then rhatc + dHi else rhatc
   (.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1'FT) ** (.x7 ↦ᵣ rhat'FT) ** (.x11 ↦ᵣ un1) **
-  (.x5 ↦ᵣ qDlo) ** (.x1 ↦ᵣ rhatUn1') ** (.x6 ↦ᵣ dHi) ** (.x0 ↦ᵣ 0) **
+  (.x5 ↦ᵣ qDlo) ** (.x9 ↦ᵣ rhatUn1') ** (.x6 ↦ᵣ dHi) ** (.x0 ↦ᵣ 0) **
   ⌜rhatHi = 0⌝ **
   (sp + signExtend12 3952 ↦ₘ dlo)
 
@@ -197,9 +197,9 @@ def divKDiv128Prodcheck1bMergedFTPost (sp q1c rhatc dHi un1 dlo : Word) :
     **Shape**: `cpsBranchWithin` — mirrors `divK_div128_step2_branch_merged_spec_within`'s
     pattern of "two paths converging at the same merge address but with
     different register postconditions". The taken leg (rhatHi ≠ 0) skips
-    the body, leaving `.x5 = v5Old` and `.x1 = rhatHi` (the SRLI result).
+    the body, leaving `.x5 = v5Old` and `.x9 = rhatHi` (the SRLI result).
     The fall-through leg (rhatHi = 0) executes the body, producing
-    `.x5 = qDlo` and `.x1 = rhatUn1'`. Both legs end at `base + 40`.
+    `.x5 = qDlo` and `.x9 = rhatUn1'`. Both legs end at `base + 40`.
 
     Composes:
     - Sub-stub A (`divK_div128_prodcheck1b_guard_spec_within`): [25..26] guard.
@@ -217,9 +217,9 @@ def divKDiv128Prodcheck1bMergedFTPost (sp q1c rhatc dHi un1 dlo : Word) :
 
     Issue #1337 algorithm fix migration. -/
 theorem divK_div128_prodcheck1b_merged_spec_within
-    (sp q1c rhatc dHi un1 v1Old v5Old dlo : Word) (base : Word) :
+    (sp q1c rhatc dHi un1 v9Old v5Old dlo : Word) (base : Word) :
     cpsBranchWithin 10 base (divKDiv128Prodcheck1bMergedCode base)
-      (divKDiv128Prodcheck1bMergedPre sp q1c rhatc dHi un1 v1Old v5Old dlo)
+      (divKDiv128Prodcheck1bMergedPre sp q1c rhatc dHi un1 v9Old v5Old dlo)
       (base + 40)
         (divKDiv128Prodcheck1bMergedTakenPost sp q1c rhatc dHi un1 v5Old dlo)
       (base + 40)
@@ -233,29 +233,29 @@ theorem divK_div128_prodcheck1b_merged_spec_within
   let rhatUn1' := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
   let rhatHi := rhatc >>> (32 : BitVec 6).toNat
   let cr :=
-    CodeReq.union (CodeReq.singleton base (.SRLI .x1 .x7 32))
-    (CodeReq.union (CodeReq.singleton (base + 4) (.BNE .x1 .x0 36))
-    (CodeReq.union (CodeReq.singleton (base + 8) (.LD .x1 .x12 3952))
-    (CodeReq.union (CodeReq.singleton (base + 12) (.MUL .x5 .x10 .x1))
-    (CodeReq.union (CodeReq.singleton (base + 16) (.SLLI .x1 .x7 32))
-    (CodeReq.union (CodeReq.singleton (base + 20) (.OR .x1 .x1 .x11))
-    (CodeReq.union (CodeReq.singleton (base + 24) (.BLTU .x1 .x5 8))
+    CodeReq.union (CodeReq.singleton base (.SRLI .x9 .x7 32))
+    (CodeReq.union (CodeReq.singleton (base + 4) (.BNE .x9 .x0 36))
+    (CodeReq.union (CodeReq.singleton (base + 8) (.LD .x9 .x12 3952))
+    (CodeReq.union (CodeReq.singleton (base + 12) (.MUL .x5 .x10 .x9))
+    (CodeReq.union (CodeReq.singleton (base + 16) (.SLLI .x9 .x7 32))
+    (CodeReq.union (CodeReq.singleton (base + 20) (.OR .x9 .x9 .x11))
+    (CodeReq.union (CodeReq.singleton (base + 24) (.BLTU .x9 .x5 8))
     (CodeReq.union (CodeReq.singleton (base + 28) (.JAL .x0 12))
     (CodeReq.union (CodeReq.singleton (base + 32) (.ADDI .x10 .x10 4095))
      (CodeReq.singleton (base + 36) (.ADD .x7 .x7 .x6))))))))))
   have hcr_eq : cr =
-      CodeReq.union (CodeReq.singleton base (.SRLI .x1 .x7 32))
-      (CodeReq.union (CodeReq.singleton (base + 4) (.BNE .x1 .x0 36))
-      (CodeReq.union (CodeReq.singleton (base + 8) (.LD .x1 .x12 3952))
-      (CodeReq.union (CodeReq.singleton (base + 12) (.MUL .x5 .x10 .x1))
-      (CodeReq.union (CodeReq.singleton (base + 16) (.SLLI .x1 .x7 32))
-      (CodeReq.union (CodeReq.singleton (base + 20) (.OR .x1 .x1 .x11))
-      (CodeReq.union (CodeReq.singleton (base + 24) (.BLTU .x1 .x5 8))
+      CodeReq.union (CodeReq.singleton base (.SRLI .x9 .x7 32))
+      (CodeReq.union (CodeReq.singleton (base + 4) (.BNE .x9 .x0 36))
+      (CodeReq.union (CodeReq.singleton (base + 8) (.LD .x9 .x12 3952))
+      (CodeReq.union (CodeReq.singleton (base + 12) (.MUL .x5 .x10 .x9))
+      (CodeReq.union (CodeReq.singleton (base + 16) (.SLLI .x9 .x7 32))
+      (CodeReq.union (CodeReq.singleton (base + 20) (.OR .x9 .x9 .x11))
+      (CodeReq.union (CodeReq.singleton (base + 24) (.BLTU .x9 .x5 8))
       (CodeReq.union (CodeReq.singleton (base + 28) (.JAL .x0 12))
       (CodeReq.union (CodeReq.singleton (base + 32) (.ADDI .x10 .x10 4095))
        (CodeReq.singleton (base + 36) (.ADD .x7 .x7 .x6)))))))))) := rfl
-  -- h1 = guard_spec sp rhatc v1Old base 36 (cpsBranchWithin base..base+40|base+8)
-  have h1_raw := divK_div128_prodcheck1b_guard_spec_within sp rhatc v1Old base (36 : BitVec 13)
+  -- h1 = guard_spec sp rhatc v9Old base 36 (cpsBranchWithin base..base+40|base+8)
+  have h1_raw := divK_div128_prodcheck1b_guard_spec_within sp rhatc v9Old base (36 : BitVec 13)
   have ha_t : (base + 4 : Word) + signExtend13 (36 : BitVec 13) = base + 40 := by rv64_addr
   rw [ha_t] at h1_raw
   -- Extend guard's 2-singleton cr to merged's 10-singleton cr
@@ -273,7 +273,7 @@ theorem divK_div128_prodcheck1b_merged_spec_within
     ((.x10 ↦ᵣ q1c) ** (.x11 ↦ᵣ un1) ** (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ dHi) **
      (sp + signExtend12 3952 ↦ₘ dlo))
     (by pcFree) h1
-  -- h2 = body_spec at base+8 — body's v1Old becomes the SRLI result rhatHi
+  -- h2 = body_spec at base+8 — body's v9Old becomes the SRLI result rhatHi
   have h2_raw := divK_div128_prodcheck1b_body_spec_within sp q1c rhatc dHi un1 rhatHi v5Old dlo
     (base + 8)
   -- Unfold the body's bundled forms so the rest of the proof works with the

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck2.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck2.lean
@@ -40,7 +40,7 @@ open EvmAsm.Rv64
     ≥ 2^64 > q0Dlo in that regime). The guard skips the decrement in
     that case.
 
-    Matches the assembly's `SRLI .x1 .x11 32 ;; BNE .x1 .x0 36` guard
+    Matches the assembly's `SRLI .x9 .x11 32 ;; BNE .x9 .x0 36` guard
     that precedes the Phase 2b mul-check. See counterexample at
     `/home/zksecurity/.claude/plans/dynamic-strolling-riddle.md`.
 
@@ -63,8 +63,8 @@ def div128Quot_phase2b_q0' (q0c rhat2c dLo div_un0 : Word) : Word :=
 
     Assembly:
     ```
-    [0] SRLI .x1 .x11 32       -- x1 = rhat2c >> 32
-    [4] BNE  .x1 .x0 guard_off -- if nonzero, branch past mul-check
+    [0] SRLI .x9 .x11 32       -- x1 = rhat2c >> 32
+    [4] BNE  .x9 .x0 guard_off -- if nonzero, branch past mul-check
     ```
 
     Branches:
@@ -76,25 +76,25 @@ def div128Quot_phase2b_q0' (q0c rhat2c dLo div_un0 : Word) : Word :=
     Used by `divK_div128_step2_guarded_spec_within` (future) to compose
     clamp_q0 + guard + prodcheck2 into a 17-instruction step2 block. -/
 theorem divK_div128_phase2b_guard_spec_within
-    (sp rhat2c v1Old : Word) (base : Word) (guard_off : BitVec 13) :
+    (sp rhat2c v9Old : Word) (base : Word) (guard_off : BitVec 13) :
     let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
     let cr :=
-      CodeReq.union (CodeReq.singleton base (.SRLI .x1 .x11 32))
-        (CodeReq.singleton (base + 4) (.BNE .x1 .x0 guard_off))
+      CodeReq.union (CodeReq.singleton base (.SRLI .x9 .x11 32))
+        (CodeReq.singleton (base + 4) (.BNE .x9 .x0 guard_off))
     cpsBranchWithin 2 base cr
-      ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ rhat2c) ** (.x1 ↦ᵣ v1Old) ** (.x0 ↦ᵣ 0))
+      ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ rhat2c) ** (.x9 ↦ᵣ v9Old) ** (.x0 ↦ᵣ 0))
       ((base + 4) + signExtend13 guard_off)
-        ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ rhat2c) ** (.x1 ↦ᵣ rhat2cHi) **
+        ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ rhat2c) ** (.x9 ↦ᵣ rhat2cHi) **
          (.x0 ↦ᵣ 0) ** ⌜rhat2cHi ≠ 0⌝)
       (base + 8)
-        ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ rhat2c) ** (.x1 ↦ᵣ rhat2cHi) **
+        ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ rhat2c) ** (.x9 ↦ᵣ rhat2cHi) **
          (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝) := by
   intro rhat2cHi cr
-  -- Step 1: SRLI .x1 .x11 32  (cpsTripleWithin base → base+4)
-  have hsrli_raw := srli_spec_gen_within .x1 .x11 v1Old rhat2c 32 base (by nofun)
+  -- Step 1: SRLI .x9 .x11 32  (cpsTripleWithin base → base+4)
+  have hsrli_raw := srli_spec_gen_within .x9 .x11 v9Old rhat2c 32 base (by nofun)
   -- Extend to the full cr (which includes the BNE).
   have hcr_srli : ∀ a i,
-      CodeReq.singleton base (.SRLI .x1 .x11 32) a = some i → cr a = some i := by
+      CodeReq.singleton base (.SRLI .x9 .x11 32) a = some i → cr a = some i := by
     intro a i h
     simp only [cr, CodeReq.union, CodeReq.singleton] at h ⊢
     split at h
@@ -104,10 +104,10 @@ theorem divK_div128_phase2b_guard_spec_within
   have hsrli_framed := cpsTripleWithin_frameR
     ((.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0))
     (by pcFree) hsrli
-  -- Step 2: BNE .x1 .x0 guard_off  (cpsBranchWithin base+4 → ...)
-  have hbne_raw := bne_spec_gen_within .x1 .x0 guard_off rhat2cHi (0 : Word) (base + 4)
+  -- Step 2: BNE .x9 .x0 guard_off  (cpsBranchWithin base+4 → ...)
+  have hbne_raw := bne_spec_gen_within .x9 .x0 guard_off rhat2cHi (0 : Word) (base + 4)
   have hcr_bne : ∀ a i,
-      CodeReq.singleton (base + 4) (.BNE .x1 .x0 guard_off) a = some i → cr a = some i := by
+      CodeReq.singleton (base + 4) (.BNE .x9 .x0 guard_off) a = some i → cr a = some i := by
     intro a i h
     simp only [cr, CodeReq.union, CodeReq.singleton] at h ⊢
     split at h
@@ -134,7 +134,7 @@ theorem divK_div128_phase2b_guard_spec_within
 /-- div128 product check 2: compute q0*dLo vs rhat2*2^32+un0, conditionally correct q0.
     Instrs [37]-[44]. Both BLTU paths merge at base+32. -/
 theorem divK_div128_prodcheck2_merged_spec_within
-    (sp q0 rhat2 v1Old v7Old dlo un0 : Word) (base : Word) :
+    (sp q0 rhat2 v9Old v7Old dlo un0 : Word) (base : Word) :
     let q0Dlo := q0 * dlo
     let rhat2Un0 := (rhat2 <<< (32 : BitVec 6).toNat) ||| un0
     -- NOTE: describes the UNGUARDED 8-instruction Phase 2b mul-check.
@@ -143,36 +143,36 @@ theorem divK_div128_prodcheck2_merged_spec_within
     -- gates this mul-check.
     let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0 + signExtend12 4095 else q0
     let cr :=
-      CodeReq.union (CodeReq.singleton base (.LD .x1 .x12 3952))
-      (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x7 .x5 .x1))
-      (CodeReq.union (CodeReq.singleton (base + 8) (.SLLI .x1 .x11 32))
+      CodeReq.union (CodeReq.singleton base (.LD .x9 .x12 3952))
+      (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x7 .x5 .x9))
+      (CodeReq.union (CodeReq.singleton (base + 8) (.SLLI .x9 .x11 32))
       (CodeReq.union (CodeReq.singleton (base + 12) (.LD .x11 .x12 3944))
-      (CodeReq.union (CodeReq.singleton (base + 16) (.OR .x1 .x1 .x11))
-      (CodeReq.union (CodeReq.singleton (base + 20) (.BLTU .x1 .x7 8))
+      (CodeReq.union (CodeReq.singleton (base + 16) (.OR .x9 .x9 .x11))
+      (CodeReq.union (CodeReq.singleton (base + 20) (.BLTU .x9 .x7 8))
       (CodeReq.union (CodeReq.singleton (base + 24) (.JAL .x0 8))
        (CodeReq.singleton (base + 28) (.ADDI .x5 .x5 4095))))))))
     cpsTripleWithin 8 base (base + 32) cr
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ rhat2) **
-       (.x7 ↦ᵣ v7Old) ** (.x1 ↦ᵣ v1Old) **
+       (.x7 ↦ᵣ v7Old) ** (.x9 ↦ᵣ v9Old) **
        (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ q0') ** (.x11 ↦ᵣ un0) **
-       (.x7 ↦ᵣ q0Dlo) ** (.x1 ↦ᵣ rhat2Un0) **
+       (.x7 ↦ᵣ q0Dlo) ** (.x9 ↦ᵣ rhat2Un0) **
        (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0)) := by
   intro q0Dlo rhat2Un0 q0' cr
   have hbody : cpsTripleWithin 5 base (base + 20) cr
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ rhat2) **
-       (.x7 ↦ᵣ v7Old) ** (.x1 ↦ᵣ v1Old) **
+       (.x7 ↦ᵣ v7Old) ** (.x9 ↦ᵣ v9Old) **
        (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ un0) **
-       (.x7 ↦ᵣ q0Dlo) ** (.x1 ↦ᵣ rhat2Un0) **
+       (.x7 ↦ᵣ q0Dlo) ** (.x9 ↦ᵣ rhat2Un0) **
        (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0)) := by
-    have I0 := ld_spec_gen_within .x1 .x12 sp v1Old dlo 3952 base (by nofun)
-    have I1 := mul_spec_gen_within .x7 .x5 .x1 v7Old q0 dlo (base + 4) (by nofun)
-    have I2 := slli_spec_gen_within .x1 .x11 dlo rhat2 32 (base + 8) (by nofun)
+    have I0 := ld_spec_gen_within .x9 .x12 sp v9Old dlo 3952 base (by nofun)
+    have I1 := mul_spec_gen_within .x7 .x5 .x9 v7Old q0 dlo (base + 4) (by nofun)
+    have I2 := slli_spec_gen_within .x9 .x11 dlo rhat2 32 (base + 8) (by nofun)
     have I3 := ld_spec_gen_within .x11 .x12 sp rhat2 un0 3944 (base + 12) (by nofun)
-    have I4 := or_spec_gen_rd_eq_rs1_within .x1 .x11 (rhat2 <<< (32 : BitVec 6).toNat) un0 (base + 16) (by nofun)
+    have I4 := or_spec_gen_rd_eq_rs1_within .x9 .x11 (rhat2 <<< (32 : BitVec 6).toNat) un0 (base + 16) (by nofun)
     runBlock I0 I1 I2 I3 I4
-  have hbltu_raw := bltu_spec_gen_within .x1 .x7 (8 : BitVec 13) rhat2Un0 q0Dlo (base + 20)
+  have hbltu_raw := bltu_spec_gen_within .x9 .x7 (8 : BitVec 13) rhat2Un0 q0Dlo (base + 20)
   have ha_t : (base + 20) + signExtend13 (8 : BitVec 13) = base + 28 := by rv64_addr
   have ha_f : (base + 20 : Word) + 4 = base + 24 := by bv_addr
   rw [ha_t, ha_f] at hbltu_raw
@@ -181,15 +181,15 @@ theorem divK_div128_prodcheck2_merged_spec_within
      (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0))
     (by pcFree) hbltu_raw
   have hbltu_ext : cpsBranchWithin 1 (base + 20) cr
-      (((.x1 ↦ᵣ rhat2Un0) ** (.x7 ↦ᵣ q0Dlo)) **
+      (((.x9 ↦ᵣ rhat2Un0) ** (.x7 ↦ᵣ q0Dlo)) **
        ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ un0) **
         (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0)))
       (base + 28)
-        (((.x1 ↦ᵣ rhat2Un0) ** (.x7 ↦ᵣ q0Dlo) ** ⌜BitVec.ult rhat2Un0 q0Dlo⌝) **
+        (((.x9 ↦ᵣ rhat2Un0) ** (.x7 ↦ᵣ q0Dlo) ** ⌜BitVec.ult rhat2Un0 q0Dlo⌝) **
          ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ un0) **
           (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0)))
       (base + 24)
-        (((.x1 ↦ᵣ rhat2Un0) ** (.x7 ↦ᵣ q0Dlo) ** ⌜¬BitVec.ult rhat2Un0 q0Dlo⌝) **
+        (((.x9 ↦ᵣ rhat2Un0) ** (.x7 ↦ᵣ q0Dlo) ** ⌜¬BitVec.ult rhat2Un0 q0Dlo⌝) **
          ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ un0) **
           (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0))) :=
     fun R hR s hcr hPR hpc =>
@@ -216,7 +216,7 @@ theorem divK_div128_prodcheck2_merged_spec_within
         (.x5 ↦ᵣ (q0 + signExtend12 4095)) := by
       runBlock I5
     have hcorr_framed := cpsTripleWithin_frameR
-      ((.x1 ↦ᵣ rhat2Un0) ** (.x7 ↦ᵣ q0Dlo) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ un0) **
+      ((.x9 ↦ᵣ rhat2Un0) ** (.x7 ↦ᵣ q0Dlo) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ un0) **
        (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0))
       (by pcFree) hcorr
     have full := cpsTripleWithin_seq_perm_same_cr
@@ -246,22 +246,22 @@ theorem divK_div128_prodcheck2_merged_spec_within
       · simp at h
     have I_jal_cr := cpsTripleWithin_extend_code hcr_jal I_jal
     have hjal_framed := cpsTripleWithin_frameR
-      ((.x1 ↦ᵣ rhat2Un0) ** (.x7 ↦ᵣ q0Dlo) ** (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ q0) **
+      ((.x9 ↦ᵣ rhat2Un0) ** (.x7 ↦ᵣ q0Dlo) ** (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ q0) **
        (.x11 ↦ᵣ un0) **
        (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0))
       (by pcFree) I_jal_cr
     simp only [sepConj_emp_left'] at hjal_framed
     have ntaken_clean : cpsTripleWithin 6 base (base + 24) cr
         ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ rhat2) **
-         (.x7 ↦ᵣ v7Old) ** (.x1 ↦ᵣ v1Old) **
+         (.x7 ↦ᵣ v7Old) ** (.x9 ↦ᵣ v9Old) **
          (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0))
-        ((.x1 ↦ᵣ rhat2Un0) ** (.x7 ↦ᵣ q0Dlo) **
+        ((.x9 ↦ᵣ rhat2Un0) ** (.x7 ↦ᵣ q0Dlo) **
          (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ un0) **
          (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0)) :=
       cpsTripleWithin_weaken
         (fun h hp => hp)
         (fun h hp => by
-          have hp' : (((.x1 ↦ᵣ rhat2Un0) ** (.x7 ↦ᵣ q0Dlo)) **
+          have hp' : (((.x9 ↦ᵣ rhat2Un0) ** (.x7 ↦ᵣ q0Dlo)) **
             ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ un0) **
              (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0))) h :=
             sepConj_mono_left (sepConj_mono_right

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step1.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step1.lean
@@ -28,7 +28,7 @@ open EvmAsm.Rv64
     Input: uHi in x7, dHi in x6, un1 in x11, dlo in memory.
     Output: refined q1 in x10, refined rhat in x7. -/
 theorem divK_div128_step1_spec_within
-    (sp uHi dHi un1 v1Old v5Old v10Old dlo : Word) (base : Word) :
+    (sp uHi dHi un1 v9Old v5Old v10Old dlo : Word) (base : Word) :
     let q1 := rv64_divu uHi dHi
     let rhat := uHi - q1 * dHi
     let hi := q1 >>> (32 : BitVec 6).toNat
@@ -46,20 +46,20 @@ theorem divK_div128_step1_spec_within
       (CodeReq.union (CodeReq.singleton (base + 16) (.BEQ .x5 .x0 12))
       (CodeReq.union (CodeReq.singleton (base + 20) (.ADDI .x10 .x10 4095))
       (CodeReq.union (CodeReq.singleton (base + 24) (.ADD .x7 .x7 .x6))
-      (CodeReq.union (CodeReq.singleton (base + 28) (.LD .x1 .x12 3952))
-      (CodeReq.union (CodeReq.singleton (base + 32) (.MUL .x5 .x10 .x1))
-      (CodeReq.union (CodeReq.singleton (base + 36) (.SLLI .x1 .x7 32))
-      (CodeReq.union (CodeReq.singleton (base + 40) (.OR .x1 .x1 .x11))
-      (CodeReq.union (CodeReq.singleton (base + 44) (.BLTU .x1 .x5 8))
+      (CodeReq.union (CodeReq.singleton (base + 28) (.LD .x9 .x12 3952))
+      (CodeReq.union (CodeReq.singleton (base + 32) (.MUL .x5 .x10 .x9))
+      (CodeReq.union (CodeReq.singleton (base + 36) (.SLLI .x9 .x7 32))
+      (CodeReq.union (CodeReq.singleton (base + 40) (.OR .x9 .x9 .x11))
+      (CodeReq.union (CodeReq.singleton (base + 44) (.BLTU .x9 .x5 8))
       (CodeReq.union (CodeReq.singleton (base + 48) (.JAL .x0 12))
       (CodeReq.union (CodeReq.singleton (base + 52) (.ADDI .x10 .x10 4095))
        (CodeReq.singleton (base + 56) (.ADD .x7 .x7 .x6)))))))))))))))
     cpsTripleWithin 15 base (base + 60) cr
       ((.x7 ↦ᵣ uHi) ** (.x6 ↦ᵣ dHi) ** (.x10 ↦ᵣ v10Old) **
-       (.x5 ↦ᵣ v5Old) ** (.x11 ↦ᵣ un1) ** (.x1 ↦ᵣ v1Old) **
+       (.x5 ↦ᵣ v5Old) ** (.x11 ↦ᵣ un1) ** (.x9 ↦ᵣ v9Old) **
        (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** (sp + signExtend12 3952 ↦ₘ dlo))
       ((.x7 ↦ᵣ rhat') ** (.x6 ↦ᵣ dHi) ** (.x10 ↦ᵣ q1') **
-       (.x5 ↦ᵣ qDlo) ** (.x11 ↦ᵣ un1) ** (.x1 ↦ᵣ rhatUn1) **
+       (.x5 ↦ᵣ qDlo) ** (.x11 ↦ᵣ un1) ** (.x9 ↦ᵣ rhatUn1) **
        (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** (sp + signExtend12 3952 ↦ₘ dlo)) := by
   intro q1 rhat hi q1c rhatc qDlo rhatUn1 q1' rhat' cr
   have hcr_eq : cr =
@@ -70,11 +70,11 @@ theorem divK_div128_step1_spec_within
       (CodeReq.union (CodeReq.singleton (base + 16) (.BEQ .x5 .x0 12))
       (CodeReq.union (CodeReq.singleton (base + 20) (.ADDI .x10 .x10 4095))
       (CodeReq.union (CodeReq.singleton (base + 24) (.ADD .x7 .x7 .x6))
-      (CodeReq.union (CodeReq.singleton (base + 28) (.LD .x1 .x12 3952))
-      (CodeReq.union (CodeReq.singleton (base + 32) (.MUL .x5 .x10 .x1))
-      (CodeReq.union (CodeReq.singleton (base + 36) (.SLLI .x1 .x7 32))
-      (CodeReq.union (CodeReq.singleton (base + 40) (.OR .x1 .x1 .x11))
-      (CodeReq.union (CodeReq.singleton (base + 44) (.BLTU .x1 .x5 8))
+      (CodeReq.union (CodeReq.singleton (base + 28) (.LD .x9 .x12 3952))
+      (CodeReq.union (CodeReq.singleton (base + 32) (.MUL .x5 .x10 .x9))
+      (CodeReq.union (CodeReq.singleton (base + 36) (.SLLI .x9 .x7 32))
+      (CodeReq.union (CodeReq.singleton (base + 40) (.OR .x9 .x9 .x11))
+      (CodeReq.union (CodeReq.singleton (base + 44) (.BLTU .x9 .x5 8))
       (CodeReq.union (CodeReq.singleton (base + 48) (.JAL .x0 12))
       (CodeReq.union (CodeReq.singleton (base + 52) (.ADDI .x10 .x10 4095))
        (CodeReq.singleton (base + 56) (.ADD .x7 .x7 .x6))))))))))))))) := rfl
@@ -94,7 +94,7 @@ theorem divK_div128_step1_spec_within
     cpsTripleWithin_extend_code (h := h1_raw) (hmono := by
       rw [hcr_eq]; exact CodeReq.union_mono_tail (CodeReq.union_mono_tail (CodeReq.union_mono_left)))
   have h1f := cpsTripleWithin_frameR
-    ((.x11 ↦ᵣ un1) ** (.x1 ↦ᵣ v1Old) ** (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
+    ((.x11 ↦ᵣ un1) ** (.x9 ↦ᵣ v9Old) ** (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
      (sp + signExtend12 3952 ↦ₘ dlo))
     (by pcFree) h1
   have h2_raw := divK_div128_clamp_q1_merged_spec_within q1 rhat dHi (q1 * dHi) (base + 12)
@@ -117,13 +117,13 @@ theorem divK_div128_step1_spec_within
             · next hab => rw [beq_iff_eq] at hab; subst hab; simp_all [CodeReq.beq_offset_self_left, CodeReq.beq_base_offset]
             · simp at h)
   have h2f := cpsTripleWithin_frameR
-    ((.x11 ↦ᵣ un1) ** (.x1 ↦ᵣ v1Old) ** (.x12 ↦ᵣ sp) **
+    ((.x11 ↦ᵣ un1) ** (.x9 ↦ᵣ v9Old) ** (.x12 ↦ᵣ sp) **
      (sp + signExtend12 3952 ↦ₘ dlo))
     (by pcFree) h2
   have h12 := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h1f h2f
   have h3_raw := divK_div128_prodcheck1_merged_spec_within sp q1c rhatc dHi un1
-    v1Old hi dlo (base + 28)
+    v9Old hi dlo (base + 28)
   have : (base + 28 : Word) + 4 = base + 32 := by bv_addr
   have : (base + 28 : Word) + 8 = base + 36 := by bv_addr
   have : (base + 28 : Word) + 12 = base + 40 := by bv_addr
@@ -174,11 +174,11 @@ def divKDiv128Step1Code (base : Word) : CodeReq :=
   (CodeReq.union (CodeReq.singleton (base + 16) (.BEQ .x5 .x0 12))
   (CodeReq.union (CodeReq.singleton (base + 20) (.ADDI .x10 .x10 4095))
   (CodeReq.union (CodeReq.singleton (base + 24) (.ADD .x7 .x7 .x6))
-  (CodeReq.union (CodeReq.singleton (base + 28) (.LD .x1 .x12 3952))
-  (CodeReq.union (CodeReq.singleton (base + 32) (.MUL .x5 .x10 .x1))
-  (CodeReq.union (CodeReq.singleton (base + 36) (.SLLI .x1 .x7 32))
-  (CodeReq.union (CodeReq.singleton (base + 40) (.OR .x1 .x1 .x11))
-  (CodeReq.union (CodeReq.singleton (base + 44) (.BLTU .x1 .x5 8))
+  (CodeReq.union (CodeReq.singleton (base + 28) (.LD .x9 .x12 3952))
+  (CodeReq.union (CodeReq.singleton (base + 32) (.MUL .x5 .x10 .x9))
+  (CodeReq.union (CodeReq.singleton (base + 36) (.SLLI .x9 .x7 32))
+  (CodeReq.union (CodeReq.singleton (base + 40) (.OR .x9 .x9 .x11))
+  (CodeReq.union (CodeReq.singleton (base + 44) (.BLTU .x9 .x5 8))
   (CodeReq.union (CodeReq.singleton (base + 48) (.JAL .x0 12))
   (CodeReq.union (CodeReq.singleton (base + 52) (.ADDI .x10 .x10 4095))
    (CodeReq.singleton (base + 56) (.ADD .x7 .x7 .x6)))))))))))))))

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step1v2.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step1v2.lean
@@ -41,21 +41,21 @@ def divKDiv128Step1V2Code (base : Word) : CodeReq :=
   (CodeReq.union (CodeReq.singleton (base + 16) (.BEQ .x5 .x0 12))
   (CodeReq.union (CodeReq.singleton (base + 20) (.ADDI .x10 .x10 4095))
   (CodeReq.union (CodeReq.singleton (base + 24) (.ADD .x7 .x7 .x6))
-  (CodeReq.union (CodeReq.singleton (base + 28) (.LD .x1 .x12 3952))
-  (CodeReq.union (CodeReq.singleton (base + 32) (.MUL .x5 .x10 .x1))
-  (CodeReq.union (CodeReq.singleton (base + 36) (.SLLI .x1 .x7 32))
-  (CodeReq.union (CodeReq.singleton (base + 40) (.OR .x1 .x1 .x11))
-  (CodeReq.union (CodeReq.singleton (base + 44) (.BLTU .x1 .x5 8))
+  (CodeReq.union (CodeReq.singleton (base + 28) (.LD .x9 .x12 3952))
+  (CodeReq.union (CodeReq.singleton (base + 32) (.MUL .x5 .x10 .x9))
+  (CodeReq.union (CodeReq.singleton (base + 36) (.SLLI .x9 .x7 32))
+  (CodeReq.union (CodeReq.singleton (base + 40) (.OR .x9 .x9 .x11))
+  (CodeReq.union (CodeReq.singleton (base + 44) (.BLTU .x9 .x5 8))
   (CodeReq.union (CodeReq.singleton (base + 48) (.JAL .x0 12))
   (CodeReq.union (CodeReq.singleton (base + 52) (.ADDI .x10 .x10 4095))
   (CodeReq.union (CodeReq.singleton (base + 56) (.ADD .x7 .x7 .x6))
-  (CodeReq.union (CodeReq.singleton (base + 60) (.SRLI .x1 .x7 32))
-  (CodeReq.union (CodeReq.singleton (base + 64) (.BNE .x1 .x0 36))
-  (CodeReq.union (CodeReq.singleton (base + 68) (.LD .x1 .x12 3952))
-  (CodeReq.union (CodeReq.singleton (base + 72) (.MUL .x5 .x10 .x1))
-  (CodeReq.union (CodeReq.singleton (base + 76) (.SLLI .x1 .x7 32))
-  (CodeReq.union (CodeReq.singleton (base + 80) (.OR .x1 .x1 .x11))
-  (CodeReq.union (CodeReq.singleton (base + 84) (.BLTU .x1 .x5 8))
+  (CodeReq.union (CodeReq.singleton (base + 60) (.SRLI .x9 .x7 32))
+  (CodeReq.union (CodeReq.singleton (base + 64) (.BNE .x9 .x0 36))
+  (CodeReq.union (CodeReq.singleton (base + 68) (.LD .x9 .x12 3952))
+  (CodeReq.union (CodeReq.singleton (base + 72) (.MUL .x5 .x10 .x9))
+  (CodeReq.union (CodeReq.singleton (base + 76) (.SLLI .x9 .x7 32))
+  (CodeReq.union (CodeReq.singleton (base + 80) (.OR .x9 .x9 .x11))
+  (CodeReq.union (CodeReq.singleton (base + 84) (.BLTU .x9 .x5 8))
   (CodeReq.union (CodeReq.singleton (base + 88) (.JAL .x0 12))
   (CodeReq.union (CodeReq.singleton (base + 92) (.ADDI .x10 .x10 4095))
    (CodeReq.singleton (base + 96) (.ADD .x7 .x7 .x6)))))))))))))))))))))))))
@@ -63,10 +63,10 @@ def divKDiv128Step1V2Code (base : Word) : CodeReq :=
 /-- Bundled precondition for `divK_div128_step1_v2_spec_within` and
     `divK_div128_step1_v2_branch_merged_spec_within`. -/
 @[irreducible]
-def divKDiv128Step1V2Pre (sp uHi dHi un1 v1Old v5Old v10Old dlo : Word) :
+def divKDiv128Step1V2Pre (sp uHi dHi un1 v9Old v5Old v10Old dlo : Word) :
     Assertion :=
   (.x7 ↦ᵣ uHi) ** (.x6 ↦ᵣ dHi) ** (.x10 ↦ᵣ v10Old) **
-  (.x5 ↦ᵣ v5Old) ** (.x11 ↦ᵣ un1) ** (.x1 ↦ᵣ v1Old) **
+  (.x5 ↦ᵣ v5Old) ** (.x11 ↦ᵣ un1) ** (.x9 ↦ᵣ v9Old) **
   (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** (sp + signExtend12 3952 ↦ₘ dlo)
 
 /-- Bundled taken-leg postcondition for `divK_div128_step1_v2_branch_merged_spec_within`
@@ -85,7 +85,7 @@ def divKDiv128Step1V2BranchMergedTakenPost
   let rhat' := if BitVec.ult rhatUn1 qDlo1 then rhatc + dHi else rhatc
   let rhatHi2 := rhat' >>> (32 : BitVec 6).toNat
   (.x7 ↦ᵣ rhat') ** (.x6 ↦ᵣ dHi) ** (.x10 ↦ᵣ q1') **
-  (.x5 ↦ᵣ qDlo1) ** (.x11 ↦ᵣ un1) ** (.x1 ↦ᵣ rhatHi2) **
+  (.x5 ↦ᵣ qDlo1) ** (.x11 ↦ᵣ un1) ** (.x9 ↦ᵣ rhatHi2) **
   (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhatHi2 ≠ 0⌝ **
   (sp + signExtend12 3952 ↦ₘ dlo)
 
@@ -109,13 +109,13 @@ def divKDiv128Step1V2BranchMergedFTPost
   let q1'FT := if BitVec.ult rhatUn1' qDlo2 then q1' + signExtend12 4095 else q1'
   let rhat'FT := if BitVec.ult rhatUn1' qDlo2 then rhat' + dHi else rhat'
   (.x7 ↦ᵣ rhat'FT) ** (.x6 ↦ᵣ dHi) ** (.x10 ↦ᵣ q1'FT) **
-  (.x5 ↦ᵣ qDlo2) ** (.x11 ↦ᵣ un1) ** (.x1 ↦ᵣ rhatUn1') **
+  (.x5 ↦ᵣ qDlo2) ** (.x11 ↦ᵣ un1) ** (.x9 ↦ᵣ rhatUn1') **
   (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhatHi2 = 0⌝ **
   (sp + signExtend12 3952 ↦ₘ dlo)
 
 /-- Bundled postcondition for `divK_div128_step1_v2_spec_within` (top-level cpsTripleWithin).
     Output q1''/rhat'' match `div128Quot_v2`'s Phase 1 output exactly. The
-    `.x5 / .x1` register postconditions are conditional on `rhatHi2 = 0`. -/
+    `.x5 / .x9` register postconditions are conditional on `rhatHi2 = 0`. -/
 @[irreducible]
 def divKDiv128Step1V2Post (sp uHi dHi un1 dlo : Word) : Assertion :=
   let q1 := rv64_divu uHi dHi
@@ -135,9 +135,9 @@ def divKDiv128Step1V2Post (sp uHi dHi un1 dlo : Word) : Assertion :=
   let rhat'' := if rhatHi2 = 0 ∧ BitVec.ult rhatUn1' qDlo2
                 then rhat' + dHi else rhat'
   let x5Exit := if rhatHi2 = 0 then qDlo2 else qDlo1
-  let x1Exit := if rhatHi2 = 0 then rhatUn1' else rhatHi2
+  let x9Exit := if rhatHi2 = 0 then rhatUn1' else rhatHi2
   (.x7 ↦ᵣ rhat'') ** (.x6 ↦ᵣ dHi) ** (.x10 ↦ᵣ q1'') **
-  (.x5 ↦ᵣ x5Exit) ** (.x11 ↦ᵣ un1) ** (.x1 ↦ᵣ x1Exit) **
+  (.x5 ↦ᵣ x5Exit) ** (.x11 ↦ᵣ un1) ** (.x9 ↦ᵣ x9Exit) **
   (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** (sp + signExtend12 3952 ↦ₘ dlo)
 
 /-- Helper: prodcheck1b's 10-singleton cr at offset (base+60) is included in
@@ -197,9 +197,9 @@ private theorem step1_v2_pc1b_cr_subsumed (base : Word) :
 
     Issue #1337 algorithm fix migration. -/
 theorem divK_div128_step1_v2_branch_merged_spec_within
-    (sp uHi dHi un1 v1Old v5Old v10Old dlo : Word) (base : Word) :
+    (sp uHi dHi un1 v9Old v5Old v10Old dlo : Word) (base : Word) :
     cpsBranchWithin 25 base (divKDiv128Step1V2Code base)
-      (divKDiv128Step1V2Pre sp uHi dHi un1 v1Old v5Old v10Old dlo)
+      (divKDiv128Step1V2Pre sp uHi dHi un1 v9Old v5Old v10Old dlo)
       (base + 100)
         (divKDiv128Step1V2BranchMergedTakenPost sp uHi dHi un1 dlo)
       (base + 100)
@@ -224,21 +224,21 @@ theorem divK_div128_step1_v2_branch_merged_spec_within
     (CodeReq.union (CodeReq.singleton (base + 16) (.BEQ .x5 .x0 12))
     (CodeReq.union (CodeReq.singleton (base + 20) (.ADDI .x10 .x10 4095))
     (CodeReq.union (CodeReq.singleton (base + 24) (.ADD .x7 .x7 .x6))
-    (CodeReq.union (CodeReq.singleton (base + 28) (.LD .x1 .x12 3952))
-    (CodeReq.union (CodeReq.singleton (base + 32) (.MUL .x5 .x10 .x1))
-    (CodeReq.union (CodeReq.singleton (base + 36) (.SLLI .x1 .x7 32))
-    (CodeReq.union (CodeReq.singleton (base + 40) (.OR .x1 .x1 .x11))
-    (CodeReq.union (CodeReq.singleton (base + 44) (.BLTU .x1 .x5 8))
+    (CodeReq.union (CodeReq.singleton (base + 28) (.LD .x9 .x12 3952))
+    (CodeReq.union (CodeReq.singleton (base + 32) (.MUL .x5 .x10 .x9))
+    (CodeReq.union (CodeReq.singleton (base + 36) (.SLLI .x9 .x7 32))
+    (CodeReq.union (CodeReq.singleton (base + 40) (.OR .x9 .x9 .x11))
+    (CodeReq.union (CodeReq.singleton (base + 44) (.BLTU .x9 .x5 8))
     (CodeReq.union (CodeReq.singleton (base + 48) (.JAL .x0 12))
     (CodeReq.union (CodeReq.singleton (base + 52) (.ADDI .x10 .x10 4095))
     (CodeReq.union (CodeReq.singleton (base + 56) (.ADD .x7 .x7 .x6))
-    (CodeReq.union (CodeReq.singleton (base + 60) (.SRLI .x1 .x7 32))
-    (CodeReq.union (CodeReq.singleton (base + 64) (.BNE .x1 .x0 36))
-    (CodeReq.union (CodeReq.singleton (base + 68) (.LD .x1 .x12 3952))
-    (CodeReq.union (CodeReq.singleton (base + 72) (.MUL .x5 .x10 .x1))
-    (CodeReq.union (CodeReq.singleton (base + 76) (.SLLI .x1 .x7 32))
-    (CodeReq.union (CodeReq.singleton (base + 80) (.OR .x1 .x1 .x11))
-    (CodeReq.union (CodeReq.singleton (base + 84) (.BLTU .x1 .x5 8))
+    (CodeReq.union (CodeReq.singleton (base + 60) (.SRLI .x9 .x7 32))
+    (CodeReq.union (CodeReq.singleton (base + 64) (.BNE .x9 .x0 36))
+    (CodeReq.union (CodeReq.singleton (base + 68) (.LD .x9 .x12 3952))
+    (CodeReq.union (CodeReq.singleton (base + 72) (.MUL .x5 .x10 .x9))
+    (CodeReq.union (CodeReq.singleton (base + 76) (.SLLI .x9 .x7 32))
+    (CodeReq.union (CodeReq.singleton (base + 80) (.OR .x9 .x9 .x11))
+    (CodeReq.union (CodeReq.singleton (base + 84) (.BLTU .x9 .x5 8))
     (CodeReq.union (CodeReq.singleton (base + 88) (.JAL .x0 12))
     (CodeReq.union (CodeReq.singleton (base + 92) (.ADDI .x10 .x10 4095))
      (CodeReq.singleton (base + 96) (.ADD .x7 .x7 .x6)))))))))))))))))))))))))
@@ -250,26 +250,26 @@ theorem divK_div128_step1_v2_branch_merged_spec_within
       (CodeReq.union (CodeReq.singleton (base + 16) (.BEQ .x5 .x0 12))
       (CodeReq.union (CodeReq.singleton (base + 20) (.ADDI .x10 .x10 4095))
       (CodeReq.union (CodeReq.singleton (base + 24) (.ADD .x7 .x7 .x6))
-      (CodeReq.union (CodeReq.singleton (base + 28) (.LD .x1 .x12 3952))
-      (CodeReq.union (CodeReq.singleton (base + 32) (.MUL .x5 .x10 .x1))
-      (CodeReq.union (CodeReq.singleton (base + 36) (.SLLI .x1 .x7 32))
-      (CodeReq.union (CodeReq.singleton (base + 40) (.OR .x1 .x1 .x11))
-      (CodeReq.union (CodeReq.singleton (base + 44) (.BLTU .x1 .x5 8))
+      (CodeReq.union (CodeReq.singleton (base + 28) (.LD .x9 .x12 3952))
+      (CodeReq.union (CodeReq.singleton (base + 32) (.MUL .x5 .x10 .x9))
+      (CodeReq.union (CodeReq.singleton (base + 36) (.SLLI .x9 .x7 32))
+      (CodeReq.union (CodeReq.singleton (base + 40) (.OR .x9 .x9 .x11))
+      (CodeReq.union (CodeReq.singleton (base + 44) (.BLTU .x9 .x5 8))
       (CodeReq.union (CodeReq.singleton (base + 48) (.JAL .x0 12))
       (CodeReq.union (CodeReq.singleton (base + 52) (.ADDI .x10 .x10 4095))
       (CodeReq.union (CodeReq.singleton (base + 56) (.ADD .x7 .x7 .x6))
-      (CodeReq.union (CodeReq.singleton (base + 60) (.SRLI .x1 .x7 32))
-      (CodeReq.union (CodeReq.singleton (base + 64) (.BNE .x1 .x0 36))
-      (CodeReq.union (CodeReq.singleton (base + 68) (.LD .x1 .x12 3952))
-      (CodeReq.union (CodeReq.singleton (base + 72) (.MUL .x5 .x10 .x1))
-      (CodeReq.union (CodeReq.singleton (base + 76) (.SLLI .x1 .x7 32))
-      (CodeReq.union (CodeReq.singleton (base + 80) (.OR .x1 .x1 .x11))
-      (CodeReq.union (CodeReq.singleton (base + 84) (.BLTU .x1 .x5 8))
+      (CodeReq.union (CodeReq.singleton (base + 60) (.SRLI .x9 .x7 32))
+      (CodeReq.union (CodeReq.singleton (base + 64) (.BNE .x9 .x0 36))
+      (CodeReq.union (CodeReq.singleton (base + 68) (.LD .x9 .x12 3952))
+      (CodeReq.union (CodeReq.singleton (base + 72) (.MUL .x5 .x10 .x9))
+      (CodeReq.union (CodeReq.singleton (base + 76) (.SLLI .x9 .x7 32))
+      (CodeReq.union (CodeReq.singleton (base + 80) (.OR .x9 .x9 .x11))
+      (CodeReq.union (CodeReq.singleton (base + 84) (.BLTU .x9 .x5 8))
       (CodeReq.union (CodeReq.singleton (base + 88) (.JAL .x0 12))
       (CodeReq.union (CodeReq.singleton (base + 92) (.ADDI .x10 .x10 4095))
        (CodeReq.singleton (base + 96) (.ADD .x7 .x7 .x6))))))))))))))))))))))))) := rfl
   -- h1: step1_spec's cr is the 15-prefix of merged_cr.
-  have h1_raw := divK_div128_step1_spec_within sp uHi dHi un1 v1Old v5Old v10Old dlo base
+  have h1_raw := divK_div128_step1_spec_within sp uHi dHi un1 v9Old v5Old v10Old dlo base
   have h1 : cpsTripleWithin 15 base (base + 60) cr _ _ :=
     cpsTripleWithin_extend_code (h := h1_raw) (hmono := by
       rw [hcr_eq]
@@ -319,15 +319,15 @@ theorem divK_div128_step1_v2_branch_merged_spec_within
     Output: refined q1 in x10, refined rhat in x7 — matching
     `div128Quot_v2`'s Phase 1 output (post-both-D3-iterations).
 
-    The `.x5` / `.x1` postconditions diverge between the 2nd D3 guard's
+    The `.x5` / `.x9` postconditions diverge between the 2nd D3 guard's
     fall-through and taken legs; expressed via conditionals on
     `rhatHi2 := rhat' >> 32` (the 2nd guard's input).
 
     Issue #1337 algorithm fix migration. -/
 theorem divK_div128_step1_v2_spec_within
-    (sp uHi dHi un1 v1Old v5Old v10Old dlo : Word) (base : Word) :
+    (sp uHi dHi un1 v9Old v5Old v10Old dlo : Word) (base : Word) :
     cpsTripleWithin 25 base (base + 100) (divKDiv128Step1V2Code base)
-      (divKDiv128Step1V2Pre sp uHi dHi un1 v1Old v5Old v10Old dlo)
+      (divKDiv128Step1V2Pre sp uHi dHi un1 v9Old v5Old v10Old dlo)
       (divKDiv128Step1V2Post sp uHi dHi un1 dlo) := by
   unfold divKDiv128Step1V2Code divKDiv128Step1V2Pre divKDiv128Step1V2Post
   -- Reintroduce the locals the proof body uses.
@@ -348,7 +348,7 @@ theorem divK_div128_step1_v2_spec_within
   let rhat'' := if rhatHi2 = 0 ∧ BitVec.ult rhatUn1' qDlo2
                 then rhat' + dHi else rhat'
   let x5Exit := if rhatHi2 = 0 then qDlo2 else qDlo1
-  let x1Exit := if rhatHi2 = 0 then rhatUn1' else rhatHi2
+  let x9Exit := if rhatHi2 = 0 then rhatUn1' else rhatHi2
   let cr :=
     CodeReq.union (CodeReq.singleton base (.DIVU .x10 .x7 .x6))
     (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x5 .x10 .x6))
@@ -357,25 +357,25 @@ theorem divK_div128_step1_v2_spec_within
     (CodeReq.union (CodeReq.singleton (base + 16) (.BEQ .x5 .x0 12))
     (CodeReq.union (CodeReq.singleton (base + 20) (.ADDI .x10 .x10 4095))
     (CodeReq.union (CodeReq.singleton (base + 24) (.ADD .x7 .x7 .x6))
-    (CodeReq.union (CodeReq.singleton (base + 28) (.LD .x1 .x12 3952))
-    (CodeReq.union (CodeReq.singleton (base + 32) (.MUL .x5 .x10 .x1))
-    (CodeReq.union (CodeReq.singleton (base + 36) (.SLLI .x1 .x7 32))
-    (CodeReq.union (CodeReq.singleton (base + 40) (.OR .x1 .x1 .x11))
-    (CodeReq.union (CodeReq.singleton (base + 44) (.BLTU .x1 .x5 8))
+    (CodeReq.union (CodeReq.singleton (base + 28) (.LD .x9 .x12 3952))
+    (CodeReq.union (CodeReq.singleton (base + 32) (.MUL .x5 .x10 .x9))
+    (CodeReq.union (CodeReq.singleton (base + 36) (.SLLI .x9 .x7 32))
+    (CodeReq.union (CodeReq.singleton (base + 40) (.OR .x9 .x9 .x11))
+    (CodeReq.union (CodeReq.singleton (base + 44) (.BLTU .x9 .x5 8))
     (CodeReq.union (CodeReq.singleton (base + 48) (.JAL .x0 12))
     (CodeReq.union (CodeReq.singleton (base + 52) (.ADDI .x10 .x10 4095))
     (CodeReq.union (CodeReq.singleton (base + 56) (.ADD .x7 .x7 .x6))
-    (CodeReq.union (CodeReq.singleton (base + 60) (.SRLI .x1 .x7 32))
-    (CodeReq.union (CodeReq.singleton (base + 64) (.BNE .x1 .x0 36))
-    (CodeReq.union (CodeReq.singleton (base + 68) (.LD .x1 .x12 3952))
-    (CodeReq.union (CodeReq.singleton (base + 72) (.MUL .x5 .x10 .x1))
-    (CodeReq.union (CodeReq.singleton (base + 76) (.SLLI .x1 .x7 32))
-    (CodeReq.union (CodeReq.singleton (base + 80) (.OR .x1 .x1 .x11))
-    (CodeReq.union (CodeReq.singleton (base + 84) (.BLTU .x1 .x5 8))
+    (CodeReq.union (CodeReq.singleton (base + 60) (.SRLI .x9 .x7 32))
+    (CodeReq.union (CodeReq.singleton (base + 64) (.BNE .x9 .x0 36))
+    (CodeReq.union (CodeReq.singleton (base + 68) (.LD .x9 .x12 3952))
+    (CodeReq.union (CodeReq.singleton (base + 72) (.MUL .x5 .x10 .x9))
+    (CodeReq.union (CodeReq.singleton (base + 76) (.SLLI .x9 .x7 32))
+    (CodeReq.union (CodeReq.singleton (base + 80) (.OR .x9 .x9 .x11))
+    (CodeReq.union (CodeReq.singleton (base + 84) (.BLTU .x9 .x5 8))
     (CodeReq.union (CodeReq.singleton (base + 88) (.JAL .x0 12))
     (CodeReq.union (CodeReq.singleton (base + 92) (.ADDI .x10 .x10 4095))
      (CodeReq.singleton (base + 96) (.ADD .x7 .x7 .x6)))))))))))))))))))))))))
-  have hbr := divK_div128_step1_v2_branch_merged_spec_within sp uHi dHi un1 v1Old v5Old
+  have hbr := divK_div128_step1_v2_branch_merged_spec_within sp uHi dHi un1 v9Old v5Old
     v10Old dlo base
   -- Unfold the bundled defs in hbr so the merge bridges below see the
   -- explicit pre/post structure.
@@ -383,16 +383,16 @@ theorem divK_div128_step1_v2_spec_within
     divKDiv128Step1V2BranchMergedTakenPost divKDiv128Step1V2BranchMergedFTPost at hbr
   let tgtPost : Assertion :=
     (.x7 ↦ᵣ rhat'') ** (.x6 ↦ᵣ dHi) ** (.x10 ↦ᵣ q1'') **
-    (.x5 ↦ᵣ x5Exit) ** (.x11 ↦ᵣ un1) ** (.x1 ↦ᵣ x1Exit) **
+    (.x5 ↦ᵣ x5Exit) ** (.x11 ↦ᵣ un1) ** (.x9 ↦ᵣ x9Exit) **
     (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** (sp + signExtend12 3952 ↦ₘ dlo)
   have refl_of {P : Assertion} (h : ∀ hp, P hp → tgtPost hp) :
       cpsTripleWithin 0 (base + 100) (base + 100) cr P tgtPost :=
     cpsTripleWithin_extend_code (fun _ _ h => by simp [CodeReq.empty] at h)
       (cpsTripleWithin_refl h)
-  -- Taken bridge: rhatHi2 ≠ 0 ⟹ q1'' = q1', rhat'' = rhat', x5Exit = qDlo1, x1Exit = rhatHi2
+  -- Taken bridge: rhatHi2 ≠ 0 ⟹ q1'' = q1', rhat'' = rhat', x5Exit = qDlo1, x9Exit = rhatHi2
   have h_t : cpsTripleWithin 0 (base + 100) (base + 100) cr _ tgtPost := refl_of (P :=
     (.x7 ↦ᵣ rhat') ** (.x6 ↦ᵣ dHi) ** (.x10 ↦ᵣ q1') **
-    (.x5 ↦ᵣ qDlo1) ** (.x11 ↦ᵣ un1) ** (.x1 ↦ᵣ rhatHi2) **
+    (.x5 ↦ᵣ qDlo1) ** (.x11 ↦ᵣ un1) ** (.x9 ↦ᵣ rhatHi2) **
     (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhatHi2 ≠ 0⌝ **
     (sp + signExtend12 3952 ↦ₘ dlo)) (by
     intro hp hP
@@ -412,22 +412,22 @@ theorem divK_div128_step1_v2_spec_within
     have hq1'' : q1'' = q1' := if_neg h_and_false
     have hrhat'' : rhat'' = rhat' := if_neg h_and_false
     have hx5 : x5Exit = qDlo1 := if_neg h_hi_ne
-    have hx1 : x1Exit = rhatHi2 := if_neg h_hi_ne
+    have hx1 : x9Exit = rhatHi2 := if_neg h_hi_ne
     show tgtPost hp
     show ((.x7 ↦ᵣ rhat'') ** (.x6 ↦ᵣ dHi) ** (.x10 ↦ᵣ q1'') **
-         (.x5 ↦ᵣ x5Exit) ** (.x11 ↦ᵣ un1) ** (.x1 ↦ᵣ x1Exit) **
+         (.x5 ↦ᵣ x5Exit) ** (.x11 ↦ᵣ un1) ** (.x9 ↦ᵣ x9Exit) **
          (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** (sp + signExtend12 3952 ↦ₘ dlo)) hp
     rw [hq1'', hrhat'', hx5, hx1]
     -- drop_pure (#1435): strip ⌜rhatHi2 ≠ 0⌝ from hP via ac_rfl-based rebind,
     -- then xperm_hyp closes. Replaces a 9-line sepConj_mono_right ladder.
     drop_pure hP
     xperm_hyp hP)
-  -- Fall-through bridge: rhatHi2 = 0 ⟹ q1'' = q1'FT, rhat'' = rhat'FT, x5Exit = qDlo2, x1Exit = rhatUn1'
+  -- Fall-through bridge: rhatHi2 = 0 ⟹ q1'' = q1'FT, rhat'' = rhat'FT, x5Exit = qDlo2, x9Exit = rhatUn1'
   have h_f : cpsTripleWithin 0 (base + 100) (base + 100) cr _ tgtPost := refl_of (P :=
     (.x7 ↦ᵣ (if BitVec.ult rhatUn1' qDlo2 then rhat' + dHi else rhat')) **
     (.x6 ↦ᵣ dHi) **
     (.x10 ↦ᵣ (if BitVec.ult rhatUn1' qDlo2 then q1' + signExtend12 4095 else q1')) **
-    (.x5 ↦ᵣ qDlo2) ** (.x11 ↦ᵣ un1) ** (.x1 ↦ᵣ rhatUn1') **
+    (.x5 ↦ᵣ qDlo2) ** (.x11 ↦ᵣ un1) ** (.x9 ↦ᵣ rhatUn1') **
     (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhatHi2 = 0⌝ **
     (sp + signExtend12 3952 ↦ₘ dlo)) (by
     intro hp hP
@@ -453,9 +453,9 @@ theorem divK_div128_step1_v2_spec_within
       · rw [if_pos ⟨h_hi_eq, hult⟩, if_pos hult]
       · rw [if_neg (fun ⟨_, h⟩ => hult h), if_neg hult]
     have hx5 : x5Exit = qDlo2 := if_pos h_hi_eq
-    have hx1 : x1Exit = rhatUn1' := if_pos h_hi_eq
+    have hx1 : x9Exit = rhatUn1' := if_pos h_hi_eq
     show ((.x7 ↦ᵣ rhat'') ** (.x6 ↦ᵣ dHi) ** (.x10 ↦ᵣ q1'') **
-         (.x5 ↦ᵣ x5Exit) ** (.x11 ↦ᵣ un1) ** (.x1 ↦ᵣ x1Exit) **
+         (.x5 ↦ᵣ x5Exit) ** (.x11 ↦ᵣ un1) ** (.x9 ↦ᵣ x9Exit) **
          (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** (sp + signExtend12 3952 ↦ₘ dlo)) hp
     rw [hq1'', hrhat'', hx5, hx1]
     -- drop_pure (#1435): strip ⌜rhatHi2 = 0⌝ from hP via ac_rfl-based rebind,

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2.lean
@@ -35,7 +35,7 @@ open EvmAsm.Rv64
     can compose it with the new `phase2b_guard_spec` + `prodcheck2_merged_spec`
     without re-stating the init/clamp code subsumption every time. -/
 theorem divK_div128_step2_upto_guard_spec_within
-    (sp un21 dHi v1Old v5Old v11Old dlo un0 : Word) (base : Word) :
+    (sp un21 dHi v9Old v5Old v11Old dlo un0 : Word) (base : Word) :
     let q0 := rv64_divu un21 dHi
     let rhat2 := un21 - q0 * dHi
     let hi := q0 >>> (32 : BitVec 6).toNat
@@ -43,31 +43,31 @@ theorem divK_div128_step2_upto_guard_spec_within
     let rhat2c := if hi = 0 then rhat2 else rhat2 + dHi
     let cr :=
       CodeReq.union (CodeReq.singleton base (.DIVU .x5 .x7 .x6))
-      (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x1 .x5 .x6))
-      (CodeReq.union (CodeReq.singleton (base + 8) (.SUB .x11 .x7 .x1))
-      (CodeReq.union (CodeReq.singleton (base + 12) (.SRLI .x1 .x5 32))
-      (CodeReq.union (CodeReq.singleton (base + 16) (.BEQ .x1 .x0 12))
+      (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x9 .x5 .x6))
+      (CodeReq.union (CodeReq.singleton (base + 8) (.SUB .x11 .x7 .x9))
+      (CodeReq.union (CodeReq.singleton (base + 12) (.SRLI .x9 .x5 32))
+      (CodeReq.union (CodeReq.singleton (base + 16) (.BEQ .x9 .x0 12))
       (CodeReq.union (CodeReq.singleton (base + 20) (.ADDI .x5 .x5 4095))
        (CodeReq.singleton (base + 24) (.ADD .x11 .x11 .x6)))))))
     cpsTripleWithin 7 base (base + 28) cr
       ((.x7 ↦ᵣ un21) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ v5Old) **
-       (.x1 ↦ᵣ v1Old) ** (.x11 ↦ᵣ v11Old) **
+       (.x9 ↦ᵣ v9Old) ** (.x11 ↦ᵣ v11Old) **
        (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0))
       ((.x7 ↦ᵣ un21) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) **
-       (.x1 ↦ᵣ hi) ** (.x11 ↦ᵣ rhat2c) **
+       (.x9 ↦ᵣ hi) ** (.x11 ↦ᵣ rhat2c) **
        (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0)) := by
   intro q0 rhat2 hi q0c rhat2c cr
   have hcr_eq : cr =
       CodeReq.union (CodeReq.singleton base (.DIVU .x5 .x7 .x6))
-      (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x1 .x5 .x6))
-      (CodeReq.union (CodeReq.singleton (base + 8) (.SUB .x11 .x7 .x1))
-      (CodeReq.union (CodeReq.singleton (base + 12) (.SRLI .x1 .x5 32))
-      (CodeReq.union (CodeReq.singleton (base + 16) (.BEQ .x1 .x0 12))
+      (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x9 .x5 .x6))
+      (CodeReq.union (CodeReq.singleton (base + 8) (.SUB .x11 .x7 .x9))
+      (CodeReq.union (CodeReq.singleton (base + 12) (.SRLI .x9 .x5 32))
+      (CodeReq.union (CodeReq.singleton (base + 16) (.BEQ .x9 .x0 12))
       (CodeReq.union (CodeReq.singleton (base + 20) (.ADDI .x5 .x5 4095))
        (CodeReq.singleton (base + 24) (.ADD .x11 .x11 .x6))))))) := rfl
-  have h1_raw := divK_div128_step2_init_spec_within un21 dHi v1Old v5Old v11Old base
+  have h1_raw := divK_div128_step2_init_spec_within un21 dHi v9Old v5Old v11Old base
   have h1 : cpsTripleWithin 3 base (base + 12) cr _ _ :=
     cpsTripleWithin_extend_code (h := h1_raw) (hmono := by
       rw [hcr_eq]; exact CodeReq.union_mono_tail (CodeReq.union_mono_tail
@@ -111,7 +111,7 @@ theorem divK_div128_step2_upto_guard_spec_within
     the taken path to base+68 (skipping mul-check when rhat2cHi ≠ 0) or
     falls through to base+36 (rhat2cHi = 0) where mul-check will run. -/
 theorem divK_div128_step2_thru_guard_spec_within
-    (sp un21 dHi v1Old v5Old v11Old dlo un0 : Word) (base : Word) :
+    (sp un21 dHi v9Old v5Old v11Old dlo un0 : Word) (base : Word) :
     let q0 := rv64_divu un21 dHi
     let rhat2 := un21 - q0 * dHi
     let hi := q0 >>> (32 : BitVec 6).toNat
@@ -120,46 +120,46 @@ theorem divK_div128_step2_thru_guard_spec_within
     let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
     let cr :=
       CodeReq.union (CodeReq.singleton base (.DIVU .x5 .x7 .x6))
-      (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x1 .x5 .x6))
-      (CodeReq.union (CodeReq.singleton (base + 8) (.SUB .x11 .x7 .x1))
-      (CodeReq.union (CodeReq.singleton (base + 12) (.SRLI .x1 .x5 32))
-      (CodeReq.union (CodeReq.singleton (base + 16) (.BEQ .x1 .x0 12))
+      (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x9 .x5 .x6))
+      (CodeReq.union (CodeReq.singleton (base + 8) (.SUB .x11 .x7 .x9))
+      (CodeReq.union (CodeReq.singleton (base + 12) (.SRLI .x9 .x5 32))
+      (CodeReq.union (CodeReq.singleton (base + 16) (.BEQ .x9 .x0 12))
       (CodeReq.union (CodeReq.singleton (base + 20) (.ADDI .x5 .x5 4095))
       (CodeReq.union (CodeReq.singleton (base + 24) (.ADD .x11 .x11 .x6))
-      (CodeReq.union (CodeReq.singleton (base + 28) (.SRLI .x1 .x11 32))
-       (CodeReq.singleton (base + 32) (.BNE .x1 .x0 36)))))))))
+      (CodeReq.union (CodeReq.singleton (base + 28) (.SRLI .x9 .x11 32))
+       (CodeReq.singleton (base + 32) (.BNE .x9 .x0 36)))))))))
     cpsBranchWithin 9 base cr
       ((.x7 ↦ᵣ un21) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ v5Old) **
-       (.x1 ↦ᵣ v1Old) ** (.x11 ↦ᵣ v11Old) **
+       (.x9 ↦ᵣ v9Old) ** (.x11 ↦ᵣ v11Old) **
        (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0))
       (base + 68)
         ((.x7 ↦ᵣ un21) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) **
-         (.x1 ↦ᵣ rhat2cHi) ** (.x11 ↦ᵣ rhat2c) **
+         (.x9 ↦ᵣ rhat2cHi) ** (.x11 ↦ᵣ rhat2c) **
          (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi ≠ 0⌝ **
          (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0))
       (base + 36)
         ((.x7 ↦ᵣ un21) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) **
-         (.x1 ↦ᵣ rhat2cHi) ** (.x11 ↦ᵣ rhat2c) **
+         (.x9 ↦ᵣ rhat2cHi) ** (.x11 ↦ᵣ rhat2c) **
          (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
          (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0)) := by
   intro q0 rhat2 hi q0c rhat2c rhat2cHi cr
   have hcr_eq : cr =
       CodeReq.union (CodeReq.singleton base (.DIVU .x5 .x7 .x6))
-      (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x1 .x5 .x6))
-      (CodeReq.union (CodeReq.singleton (base + 8) (.SUB .x11 .x7 .x1))
-      (CodeReq.union (CodeReq.singleton (base + 12) (.SRLI .x1 .x5 32))
-      (CodeReq.union (CodeReq.singleton (base + 16) (.BEQ .x1 .x0 12))
+      (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x9 .x5 .x6))
+      (CodeReq.union (CodeReq.singleton (base + 8) (.SUB .x11 .x7 .x9))
+      (CodeReq.union (CodeReq.singleton (base + 12) (.SRLI .x9 .x5 32))
+      (CodeReq.union (CodeReq.singleton (base + 16) (.BEQ .x9 .x0 12))
       (CodeReq.union (CodeReq.singleton (base + 20) (.ADDI .x5 .x5 4095))
       (CodeReq.union (CodeReq.singleton (base + 24) (.ADD .x11 .x11 .x6))
-      (CodeReq.union (CodeReq.singleton (base + 28) (.SRLI .x1 .x11 32))
-       (CodeReq.singleton (base + 32) (.BNE .x1 .x0 36))))))))) := rfl
+      (CodeReq.union (CodeReq.singleton (base + 28) (.SRLI .x9 .x11 32))
+       (CodeReq.singleton (base + 32) (.BNE .x9 .x0 36))))))))) := rfl
   -- h1 = step2_upto_guard_spec (cpsTripleWithin base..base+28, 7-singleton cr).
   -- Its cr is a STRUCTURAL PREFIX of thru_guard's cr: same 7 singletons,
   -- ending in `singleton (base+24) ADD` vs thru_guard's `union (sing 24 ADD)
   -- (union (sing 28 SRLI) (sing 32 BNE))`. So 6 union_mono_tails + 1
   -- union_mono_left (peeling sing 24 ADD from the head).
-  have h1_raw := divK_div128_step2_upto_guard_spec_within sp un21 dHi v1Old v5Old v11Old
+  have h1_raw := divK_div128_step2_upto_guard_spec_within sp un21 dHi v9Old v5Old v11Old
     dlo un0 base
   have h1 : cpsTripleWithin 7 base (base + 28) cr _ _ :=
     cpsTripleWithin_extend_code (h := h1_raw) (hmono := by
@@ -200,7 +200,7 @@ theorem divK_div128_step2_thru_guard_spec_within
     a cpsBranchWithin where BOTH legs end at base+68 (guard-fires skips directly;
     guard-doesn't-fire runs the mul-check). -/
 theorem divK_div128_step2_branch_merged_spec_within
-    (sp un21 dHi v1Old v5Old v11Old dlo un0 : Word) (base : Word) :
+    (sp un21 dHi v9Old v5Old v11Old dlo un0 : Word) (base : Word) :
     let q0 := rv64_divu un21 dHi
     let rhat2 := un21 - q0 * dHi
     let hi := q0 >>> (32 : BitVec 6).toNat
@@ -212,61 +212,61 @@ theorem divK_div128_step2_branch_merged_spec_within
     let q0'Unguarded := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
     let cr :=
       CodeReq.union (CodeReq.singleton base (.DIVU .x5 .x7 .x6))
-      (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x1 .x5 .x6))
-      (CodeReq.union (CodeReq.singleton (base + 8) (.SUB .x11 .x7 .x1))
-      (CodeReq.union (CodeReq.singleton (base + 12) (.SRLI .x1 .x5 32))
-      (CodeReq.union (CodeReq.singleton (base + 16) (.BEQ .x1 .x0 12))
+      (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x9 .x5 .x6))
+      (CodeReq.union (CodeReq.singleton (base + 8) (.SUB .x11 .x7 .x9))
+      (CodeReq.union (CodeReq.singleton (base + 12) (.SRLI .x9 .x5 32))
+      (CodeReq.union (CodeReq.singleton (base + 16) (.BEQ .x9 .x0 12))
       (CodeReq.union (CodeReq.singleton (base + 20) (.ADDI .x5 .x5 4095))
       (CodeReq.union (CodeReq.singleton (base + 24) (.ADD .x11 .x11 .x6))
-      (CodeReq.union (CodeReq.singleton (base + 28) (.SRLI .x1 .x11 32))
-      (CodeReq.union (CodeReq.singleton (base + 32) (.BNE .x1 .x0 36))
-      (CodeReq.union (CodeReq.singleton (base + 36) (.LD .x1 .x12 3952))
-      (CodeReq.union (CodeReq.singleton (base + 40) (.MUL .x7 .x5 .x1))
-      (CodeReq.union (CodeReq.singleton (base + 44) (.SLLI .x1 .x11 32))
+      (CodeReq.union (CodeReq.singleton (base + 28) (.SRLI .x9 .x11 32))
+      (CodeReq.union (CodeReq.singleton (base + 32) (.BNE .x9 .x0 36))
+      (CodeReq.union (CodeReq.singleton (base + 36) (.LD .x9 .x12 3952))
+      (CodeReq.union (CodeReq.singleton (base + 40) (.MUL .x7 .x5 .x9))
+      (CodeReq.union (CodeReq.singleton (base + 44) (.SLLI .x9 .x11 32))
       (CodeReq.union (CodeReq.singleton (base + 48) (.LD .x11 .x12 3944))
-      (CodeReq.union (CodeReq.singleton (base + 52) (.OR .x1 .x1 .x11))
-      (CodeReq.union (CodeReq.singleton (base + 56) (.BLTU .x1 .x7 8))
+      (CodeReq.union (CodeReq.singleton (base + 52) (.OR .x9 .x9 .x11))
+      (CodeReq.union (CodeReq.singleton (base + 56) (.BLTU .x9 .x7 8))
       (CodeReq.union (CodeReq.singleton (base + 60) (.JAL .x0 8))
        (CodeReq.singleton (base + 64) (.ADDI .x5 .x5 4095)))))))))))))))))
     cpsBranchWithin 17 base cr
       ((.x7 ↦ᵣ un21) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ v5Old) **
-       (.x1 ↦ᵣ v1Old) ** (.x11 ↦ᵣ v11Old) **
+       (.x9 ↦ᵣ v9Old) ** (.x11 ↦ᵣ v11Old) **
        (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0))
       (base + 68)  -- guard-fires path
         ((.x7 ↦ᵣ un21) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) **
-         (.x1 ↦ᵣ rhat2cHi) ** (.x11 ↦ᵣ rhat2c) **
+         (.x9 ↦ᵣ rhat2cHi) ** (.x11 ↦ᵣ rhat2c) **
          (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi ≠ 0⌝ **
          (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0))
       (base + 68)  -- guard-doesn't-fire + prodcheck2 (carries ⌜rhat2cHi = 0⌝)
         ((.x7 ↦ᵣ q0Dlo) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0'Unguarded) **
-         (.x1 ↦ᵣ rhat2Un0) ** (.x11 ↦ᵣ un0) **
+         (.x9 ↦ᵣ rhat2Un0) ** (.x11 ↦ᵣ un0) **
          (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
          (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0)) := by
   intro q0 rhat2 hi q0c rhat2c q0Dlo rhat2Un0 rhat2cHi q0'Unguarded cr
   have hcr_eq : cr =
       CodeReq.union (CodeReq.singleton base (.DIVU .x5 .x7 .x6))
-      (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x1 .x5 .x6))
-      (CodeReq.union (CodeReq.singleton (base + 8) (.SUB .x11 .x7 .x1))
-      (CodeReq.union (CodeReq.singleton (base + 12) (.SRLI .x1 .x5 32))
-      (CodeReq.union (CodeReq.singleton (base + 16) (.BEQ .x1 .x0 12))
+      (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x9 .x5 .x6))
+      (CodeReq.union (CodeReq.singleton (base + 8) (.SUB .x11 .x7 .x9))
+      (CodeReq.union (CodeReq.singleton (base + 12) (.SRLI .x9 .x5 32))
+      (CodeReq.union (CodeReq.singleton (base + 16) (.BEQ .x9 .x0 12))
       (CodeReq.union (CodeReq.singleton (base + 20) (.ADDI .x5 .x5 4095))
       (CodeReq.union (CodeReq.singleton (base + 24) (.ADD .x11 .x11 .x6))
-      (CodeReq.union (CodeReq.singleton (base + 28) (.SRLI .x1 .x11 32))
-      (CodeReq.union (CodeReq.singleton (base + 32) (.BNE .x1 .x0 36))
-      (CodeReq.union (CodeReq.singleton (base + 36) (.LD .x1 .x12 3952))
-      (CodeReq.union (CodeReq.singleton (base + 40) (.MUL .x7 .x5 .x1))
-      (CodeReq.union (CodeReq.singleton (base + 44) (.SLLI .x1 .x11 32))
+      (CodeReq.union (CodeReq.singleton (base + 28) (.SRLI .x9 .x11 32))
+      (CodeReq.union (CodeReq.singleton (base + 32) (.BNE .x9 .x0 36))
+      (CodeReq.union (CodeReq.singleton (base + 36) (.LD .x9 .x12 3952))
+      (CodeReq.union (CodeReq.singleton (base + 40) (.MUL .x7 .x5 .x9))
+      (CodeReq.union (CodeReq.singleton (base + 44) (.SLLI .x9 .x11 32))
       (CodeReq.union (CodeReq.singleton (base + 48) (.LD .x11 .x12 3944))
-      (CodeReq.union (CodeReq.singleton (base + 52) (.OR .x1 .x1 .x11))
-      (CodeReq.union (CodeReq.singleton (base + 56) (.BLTU .x1 .x7 8))
+      (CodeReq.union (CodeReq.singleton (base + 52) (.OR .x9 .x9 .x11))
+      (CodeReq.union (CodeReq.singleton (base + 56) (.BLTU .x9 .x7 8))
       (CodeReq.union (CodeReq.singleton (base + 60) (.JAL .x0 8))
        (CodeReq.singleton (base + 64) (.ADDI .x5 .x5 4095))))))))))))))))) := rfl
   -- h1 = thru_guard_spec (cpsBranchWithin base..base+68|base+36, 9-singleton cr).
   -- Its cr is a STRUCTURAL PREFIX of branch_merged's 17-cr: same 8 outer unions,
   -- innermost differs (thru_guard = sing 32 BNE, branch_merged = union (sing 32 BNE) REST).
   -- So 8 union_mono_tails + 1 union_mono_left.
-  have h1_raw := divK_div128_step2_thru_guard_spec_within sp un21 dHi v1Old v5Old v11Old
+  have h1_raw := divK_div128_step2_thru_guard_spec_within sp un21 dHi v9Old v5Old v11Old
     dlo un0 base
   have h1 : cpsBranchWithin 9 base cr _ _ _ _ _ :=
     cpsBranchWithin_extend_code (h := h1_raw) (hmono := by
@@ -348,10 +348,10 @@ def divKDiv128Step2Post (sp un21 dHi dlo un0 : Word) : Assertion :=
   let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
   let q0' := div128Quot_phase2b_q0' q0c rhat2c dlo un0
   let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
-  let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
+  let x9Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
   let x11Exit := if rhat2cHi = 0 then un0 else rhat2c
   (.x7 ↦ᵣ x7Exit) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0') **
-  (.x1 ↦ᵣ x1Exit) ** (.x11 ↦ᵣ x11Exit) **
+  (.x9 ↦ᵣ x9Exit) ** (.x11 ↦ᵣ x11Exit) **
   (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
   (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0)
 
@@ -360,20 +360,20 @@ def divKDiv128Step2Post (sp un21 dHi dlo un0 : Word) : Assertion :=
 @[irreducible]
 def divKDiv128Step2Code (base : Word) : CodeReq :=
   CodeReq.union (CodeReq.singleton base (.DIVU .x5 .x7 .x6))
-  (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x1 .x5 .x6))
-  (CodeReq.union (CodeReq.singleton (base + 8) (.SUB .x11 .x7 .x1))
-  (CodeReq.union (CodeReq.singleton (base + 12) (.SRLI .x1 .x5 32))
-  (CodeReq.union (CodeReq.singleton (base + 16) (.BEQ .x1 .x0 12))
+  (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x9 .x5 .x6))
+  (CodeReq.union (CodeReq.singleton (base + 8) (.SUB .x11 .x7 .x9))
+  (CodeReq.union (CodeReq.singleton (base + 12) (.SRLI .x9 .x5 32))
+  (CodeReq.union (CodeReq.singleton (base + 16) (.BEQ .x9 .x0 12))
   (CodeReq.union (CodeReq.singleton (base + 20) (.ADDI .x5 .x5 4095))
   (CodeReq.union (CodeReq.singleton (base + 24) (.ADD .x11 .x11 .x6))
-  (CodeReq.union (CodeReq.singleton (base + 28) (.SRLI .x1 .x11 32))
-  (CodeReq.union (CodeReq.singleton (base + 32) (.BNE .x1 .x0 36))
-  (CodeReq.union (CodeReq.singleton (base + 36) (.LD .x1 .x12 3952))
-  (CodeReq.union (CodeReq.singleton (base + 40) (.MUL .x7 .x5 .x1))
-  (CodeReq.union (CodeReq.singleton (base + 44) (.SLLI .x1 .x11 32))
+  (CodeReq.union (CodeReq.singleton (base + 28) (.SRLI .x9 .x11 32))
+  (CodeReq.union (CodeReq.singleton (base + 32) (.BNE .x9 .x0 36))
+  (CodeReq.union (CodeReq.singleton (base + 36) (.LD .x9 .x12 3952))
+  (CodeReq.union (CodeReq.singleton (base + 40) (.MUL .x7 .x5 .x9))
+  (CodeReq.union (CodeReq.singleton (base + 44) (.SLLI .x9 .x11 32))
   (CodeReq.union (CodeReq.singleton (base + 48) (.LD .x11 .x12 3944))
-  (CodeReq.union (CodeReq.singleton (base + 52) (.OR .x1 .x1 .x11))
-  (CodeReq.union (CodeReq.singleton (base + 56) (.BLTU .x1 .x7 8))
+  (CodeReq.union (CodeReq.singleton (base + 52) (.OR .x9 .x9 .x11))
+  (CodeReq.union (CodeReq.singleton (base + 56) (.BLTU .x9 .x7 8))
   (CodeReq.union (CodeReq.singleton (base + 60) (.JAL .x0 8))
    (CodeReq.singleton (base + 64) (.ADDI .x5 .x5 4095)))))))))))))))))
 
@@ -389,10 +389,10 @@ def divKDiv128Step2Code (base : Word) : CodeReq :=
     breakdown is in that def's body. Bundling addresses the "many lets
     before cpsTripleWithin" elaboration anti-pattern (#1139). -/
 theorem divK_div128_step2_spec_within
-    (sp un21 dHi v1Old v5Old v11Old dlo un0 : Word) (base : Word) :
+    (sp un21 dHi v9Old v5Old v11Old dlo un0 : Word) (base : Word) :
     cpsTripleWithin 17 base (base + 68) (divKDiv128Step2Code base)
       ((.x7 ↦ᵣ un21) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ v5Old) **
-       (.x1 ↦ᵣ v1Old) ** (.x11 ↦ᵣ v11Old) **
+       (.x9 ↦ᵣ v9Old) ** (.x11 ↦ᵣ v11Old) **
        (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0))
       (divKDiv128Step2Post sp un21 dHi dlo un0) := by
@@ -407,33 +407,33 @@ theorem divK_div128_step2_spec_within
   let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
   let q0' := div128Quot_phase2b_q0' q0c rhat2c dlo un0
   let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
-  let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
+  let x9Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
   let x11Exit := if rhat2cHi = 0 then un0 else rhat2c
   let cr :=
     CodeReq.union (CodeReq.singleton base (.DIVU .x5 .x7 .x6))
-    (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x1 .x5 .x6))
-    (CodeReq.union (CodeReq.singleton (base + 8) (.SUB .x11 .x7 .x1))
-    (CodeReq.union (CodeReq.singleton (base + 12) (.SRLI .x1 .x5 32))
-    (CodeReq.union (CodeReq.singleton (base + 16) (.BEQ .x1 .x0 12))
+    (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x9 .x5 .x6))
+    (CodeReq.union (CodeReq.singleton (base + 8) (.SUB .x11 .x7 .x9))
+    (CodeReq.union (CodeReq.singleton (base + 12) (.SRLI .x9 .x5 32))
+    (CodeReq.union (CodeReq.singleton (base + 16) (.BEQ .x9 .x0 12))
     (CodeReq.union (CodeReq.singleton (base + 20) (.ADDI .x5 .x5 4095))
     (CodeReq.union (CodeReq.singleton (base + 24) (.ADD .x11 .x11 .x6))
-    (CodeReq.union (CodeReq.singleton (base + 28) (.SRLI .x1 .x11 32))
-    (CodeReq.union (CodeReq.singleton (base + 32) (.BNE .x1 .x0 36))
-    (CodeReq.union (CodeReq.singleton (base + 36) (.LD .x1 .x12 3952))
-    (CodeReq.union (CodeReq.singleton (base + 40) (.MUL .x7 .x5 .x1))
-    (CodeReq.union (CodeReq.singleton (base + 44) (.SLLI .x1 .x11 32))
+    (CodeReq.union (CodeReq.singleton (base + 28) (.SRLI .x9 .x11 32))
+    (CodeReq.union (CodeReq.singleton (base + 32) (.BNE .x9 .x0 36))
+    (CodeReq.union (CodeReq.singleton (base + 36) (.LD .x9 .x12 3952))
+    (CodeReq.union (CodeReq.singleton (base + 40) (.MUL .x7 .x5 .x9))
+    (CodeReq.union (CodeReq.singleton (base + 44) (.SLLI .x9 .x11 32))
     (CodeReq.union (CodeReq.singleton (base + 48) (.LD .x11 .x12 3944))
-    (CodeReq.union (CodeReq.singleton (base + 52) (.OR .x1 .x1 .x11))
-    (CodeReq.union (CodeReq.singleton (base + 56) (.BLTU .x1 .x7 8))
+    (CodeReq.union (CodeReq.singleton (base + 52) (.OR .x9 .x9 .x11))
+    (CodeReq.union (CodeReq.singleton (base + 56) (.BLTU .x9 .x7 8))
     (CodeReq.union (CodeReq.singleton (base + 60) (.JAL .x0 8))
      (CodeReq.singleton (base + 64) (.ADDI .x5 .x5 4095)))))))))))))))))
   -- Apply branch_merged to get a cpsBranchWithin with both legs at base+68.
-  have hbr := divK_div128_step2_branch_merged_spec_within sp un21 dHi v1Old v5Old v11Old
+  have hbr := divK_div128_step2_branch_merged_spec_within sp un21 dHi v9Old v5Old v11Old
     dlo un0 base
   -- Target post as a local assertion.
   let tgtPost : Assertion :=
     (.x7 ↦ᵣ x7Exit) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0') **
-    (.x1 ↦ᵣ x1Exit) ** (.x11 ↦ᵣ x11Exit) **
+    (.x9 ↦ᵣ x9Exit) ** (.x11 ↦ᵣ x11Exit) **
     (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
     (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0)
   -- Helper: cpsTripleWithin_refl at base+68 is a zero-step identity triple; we
@@ -446,7 +446,7 @@ theorem divK_div128_step2_spec_within
   -- exits to un21/rhat2cHi/rhat2c, rewrite q0' to q0c via helper unfolding.
   have h_t : cpsTripleWithin 0 (base + 68) (base + 68) cr _ tgtPost := refl_of (P :=
     (.x7 ↦ᵣ un21) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) **
-    (.x1 ↦ᵣ rhat2cHi) ** (.x11 ↦ᵣ rhat2c) **
+    (.x9 ↦ᵣ rhat2cHi) ** (.x11 ↦ᵣ rhat2c) **
     (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi ≠ 0⌝ **
     (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0)) (by
     intro hp hP
@@ -466,18 +466,18 @@ theorem divK_div128_step2_spec_within
       unfold div128Quot_phase2b_q0'
       exact if_neg h_hi_ne
     have hx7 : x7Exit = un21 := if_neg h_hi_ne
-    have hx1 : x1Exit = rhat2cHi := if_neg h_hi_ne
+    have hx1 : x9Exit = rhat2cHi := if_neg h_hi_ne
     have hx11 : x11Exit = rhat2c := if_neg h_hi_ne
     show tgtPost hp
     show ((.x7 ↦ᵣ x7Exit) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0') **
-         (.x1 ↦ᵣ x1Exit) ** (.x11 ↦ᵣ x11Exit) **
+         (.x9 ↦ᵣ x9Exit) ** (.x11 ↦ᵣ x11Exit) **
          (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
          (sp + signExtend12 3952 ↦ₘ dlo) **
          (sp + signExtend12 3944 ↦ₘ un0)) hp
     rw [hq0', hx7, hx1, hx11]
     -- Strip the pure fact and permute.
     have hP' : ((.x7 ↦ᵣ un21) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) **
-                (.x1 ↦ᵣ rhat2cHi) ** (.x11 ↦ᵣ rhat2c) **
+                (.x9 ↦ᵣ rhat2cHi) ** (.x11 ↦ᵣ rhat2c) **
                 (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
                 (sp + signExtend12 3952 ↦ₘ dlo) **
                 (sp + signExtend12 3944 ↦ₘ un0)) hp :=
@@ -490,7 +490,7 @@ theorem divK_div128_step2_spec_within
   have h_f : cpsTripleWithin 0 (base + 68) (base + 68) cr _ tgtPost := refl_of (P :=
     (.x7 ↦ᵣ q0Dlo) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ
       (if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c)) **
-    (.x1 ↦ᵣ rhat2Un0) ** (.x11 ↦ᵣ un0) **
+    (.x9 ↦ᵣ rhat2Un0) ** (.x11 ↦ᵣ un0) **
     (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
     (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0)) (by
     intro hp hP
@@ -510,10 +510,10 @@ theorem divK_div128_step2_spec_within
       unfold div128Quot_phase2b_q0'
       rw [if_pos h_hi_eq]
     have hx7 : x7Exit = q0Dlo := if_pos h_hi_eq
-    have hx1 : x1Exit = rhat2Un0 := if_pos h_hi_eq
+    have hx1 : x9Exit = rhat2Un0 := if_pos h_hi_eq
     have hx11 : x11Exit = un0 := if_pos h_hi_eq
     show ((.x7 ↦ᵣ x7Exit) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0') **
-         (.x1 ↦ᵣ x1Exit) ** (.x11 ↦ᵣ x11Exit) **
+         (.x9 ↦ᵣ x9Exit) ** (.x11 ↦ᵣ x11Exit) **
          (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
          (sp + signExtend12 3952 ↦ₘ dlo) **
          (sp + signExtend12 3944 ↦ₘ un0)) hp
@@ -521,7 +521,7 @@ theorem divK_div128_step2_spec_within
     -- Strip the pure fact and permute remaining atoms.
     have hP' : ((.x7 ↦ᵣ q0Dlo) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ
                 (if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c)) **
-                (.x1 ↦ᵣ rhat2Un0) ** (.x11 ↦ᵣ un0) **
+                (.x9 ↦ᵣ rhat2Un0) ** (.x11 ↦ᵣ un0) **
                 (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
                 (sp + signExtend12 3952 ↦ₘ dlo) **
                 (sp + signExtend12 3944 ↦ₘ un0)) hp :=
@@ -534,10 +534,10 @@ theorem divK_div128_step2_spec_within
 /-- Code requirement for `divK_div128_step2_upto_guard_spec_within`. -/
 abbrev divKDiv128Step2UptoGuardCode (base : Word) : CodeReq :=
   CodeReq.union (CodeReq.singleton base (.DIVU .x5 .x7 .x6))
-  (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x1 .x5 .x6))
-  (CodeReq.union (CodeReq.singleton (base + 8) (.SUB .x11 .x7 .x1))
-  (CodeReq.union (CodeReq.singleton (base + 12) (.SRLI .x1 .x5 32))
-  (CodeReq.union (CodeReq.singleton (base + 16) (.BEQ .x1 .x0 12))
+  (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x9 .x5 .x6))
+  (CodeReq.union (CodeReq.singleton (base + 8) (.SUB .x11 .x7 .x9))
+  (CodeReq.union (CodeReq.singleton (base + 12) (.SRLI .x9 .x5 32))
+  (CodeReq.union (CodeReq.singleton (base + 16) (.BEQ .x9 .x0 12))
   (CodeReq.union (CodeReq.singleton (base + 20) (.ADDI .x5 .x5 4095))
    (CodeReq.singleton (base + 24) (.ADD .x11 .x11 .x6)))))))
 
@@ -545,14 +545,14 @@ abbrev divKDiv128Step2UptoGuardCode (base : Word) : CodeReq :=
 @[irreducible]
 def divKDiv128Step2ThruGuardCode (base : Word) : CodeReq :=
   CodeReq.union (CodeReq.singleton base (.DIVU .x5 .x7 .x6))
-  (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x1 .x5 .x6))
-  (CodeReq.union (CodeReq.singleton (base + 8) (.SUB .x11 .x7 .x1))
-  (CodeReq.union (CodeReq.singleton (base + 12) (.SRLI .x1 .x5 32))
-  (CodeReq.union (CodeReq.singleton (base + 16) (.BEQ .x1 .x0 12))
+  (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x9 .x5 .x6))
+  (CodeReq.union (CodeReq.singleton (base + 8) (.SUB .x11 .x7 .x9))
+  (CodeReq.union (CodeReq.singleton (base + 12) (.SRLI .x9 .x5 32))
+  (CodeReq.union (CodeReq.singleton (base + 16) (.BEQ .x9 .x0 12))
   (CodeReq.union (CodeReq.singleton (base + 20) (.ADDI .x5 .x5 4095))
   (CodeReq.union (CodeReq.singleton (base + 24) (.ADD .x11 .x11 .x6))
-  (CodeReq.union (CodeReq.singleton (base + 28) (.SRLI .x1 .x11 32))
-   (CodeReq.singleton (base + 32) (.BNE .x1 .x0 36)))))))))
+  (CodeReq.union (CodeReq.singleton (base + 28) (.SRLI .x9 .x11 32))
+   (CodeReq.singleton (base + 32) (.BNE .x9 .x0 36)))))))))
 
 /-- The rhat2cHi value computed in `divK_div128_step2_thru_guard_spec_within`. -/
 abbrev divKDiv128Step2ThruGuardRhat2cHi (un21 dHi : Word) : Word :=

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2v4.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2v4.lean
@@ -40,16 +40,16 @@ open EvmAsm.Rv64
     `divK_div128_v4`), as a plain `List Instr` so `step2v4_sub` can use
     `CodeReq.ofProg_lookup` — the same mechanism as `d128_v4_sub`. -/
 def divKDiv128Step2V4Instrs : List Instr :=
-  [.DIVU .x5 .x7 .x6,   .MUL .x1 .x5 .x6,   .SUB .x11 .x7 .x1,   -- [0..2]
-   .SRLI .x1 .x5 32,     .BEQ .x1 .x0 12,     .ADDI .x5 .x5 4095,   -- [3..5]
-   .ADD .x11 .x11 .x6,   .SRLI .x1 .x11 32,   .BNE .x1 .x0 92,      -- [6..8]
-   .LD .x1 .x12 3952,    .MUL .x7 .x5 .x1,    .SLLI .x1 .x11 32,    -- [9..11]
-   .SD .x12 .x11 3936,   .LD .x11 .x12 3944,  .OR .x1 .x1 .x11,     -- [12..14]
-   .BLTU .x1 .x7 12,     .LD .x11 .x12 3936,  .JAL .x0 16,           -- [15..17]
+  [.DIVU .x5 .x7 .x6,   .MUL .x9 .x5 .x6,   .SUB .x11 .x7 .x9,   -- [0..2]
+   .SRLI .x9 .x5 32,     .BEQ .x9 .x0 12,     .ADDI .x5 .x5 4095,   -- [3..5]
+   .ADD .x11 .x11 .x6,   .SRLI .x9 .x11 32,   .BNE .x9 .x0 92,      -- [6..8]
+   .LD .x9 .x12 3952,    .MUL .x7 .x5 .x9,    .SLLI .x9 .x11 32,    -- [9..11]
+   .SD .x12 .x11 3936,   .LD .x11 .x12 3944,  .OR .x9 .x9 .x11,     -- [12..14]
+   .BLTU .x9 .x7 12,     .LD .x11 .x12 3936,  .JAL .x0 16,           -- [15..17]
    .ADDI .x5 .x5 4095,   .LD .x11 .x12 3936,  .ADD .x11 .x11 .x6,   -- [18..20]
-   .SRLI .x1 .x11 32,    .BNE .x1 .x0 36,     .LD .x1 .x12 3952,    -- [21..23]
-   .MUL .x7 .x5 .x1,    .SLLI .x1 .x11 32,   .LD .x11 .x12 3944,   -- [24..26]
-   .OR .x1 .x1 .x11,    .BLTU .x1 .x7 8,     .JAL .x0 8,            -- [27..29]
+   .SRLI .x9 .x11 32,    .BNE .x9 .x0 36,     .LD .x9 .x12 3952,    -- [21..23]
+   .MUL .x7 .x5 .x9,    .SLLI .x9 .x11 32,   .LD .x11 .x12 3944,   -- [24..26]
+   .OR .x9 .x9 .x11,    .BLTU .x9 .x7 8,     .JAL .x0 8,            -- [27..29]
    .ADDI .x5 .x5 4095]                                                  -- [30]
 
 /-- Bundled CodeReq for `divK_div128_step2_v4_spec`. Expressed as
@@ -84,17 +84,17 @@ private theorem step2v4_sub {base : Word} (k : Nat) (addr : Word) (instr : Instr
 private theorem divK_div128_step2_v4_phase_D_bltu_spec
     (rhat2Un0 q0Dlo1 : Word) (base : Word) :
     cpsBranchWithin 1 (base + 60) (divKDiv128Step2V4Code base)
-      ((.x1 ↦ᵣ rhat2Un0) ** (.x7 ↦ᵣ q0Dlo1))
+      ((.x9 ↦ᵣ rhat2Un0) ** (.x7 ↦ᵣ q0Dlo1))
       (base + 72)
-        ((.x1 ↦ᵣ rhat2Un0) ** (.x7 ↦ᵣ q0Dlo1) ** ⌜BitVec.ult rhat2Un0 q0Dlo1⌝)
+        ((.x9 ↦ᵣ rhat2Un0) ** (.x7 ↦ᵣ q0Dlo1) ** ⌜BitVec.ult rhat2Un0 q0Dlo1⌝)
       (base + 64)
-        ((.x1 ↦ᵣ rhat2Un0) ** (.x7 ↦ᵣ q0Dlo1) ** ⌜¬BitVec.ult rhat2Un0 q0Dlo1⌝) := by
-  have hbltu_raw := bltu_spec_gen_within .x1 .x7 (12 : BitVec 13) rhat2Un0 q0Dlo1 (base + 60)
+        ((.x9 ↦ᵣ rhat2Un0) ** (.x7 ↦ᵣ q0Dlo1) ** ⌜¬BitVec.ult rhat2Un0 q0Dlo1⌝) := by
+  have hbltu_raw := bltu_spec_gen_within .x9 .x7 (12 : BitVec 13) rhat2Un0 q0Dlo1 (base + 60)
   have ha_t : (base + 60) + signExtend13 (12 : BitVec 13) = base + 72 := by rv64_addr
   have ha_f : (base + 60 : Word) + 4 = base + 64 := by bv_addr
   rw [ha_t, ha_f] at hbltu_raw
   exact cpsBranchWithin_extend_code (h := hbltu_raw) (hmono := by
-    exact step2v4_sub 15 (base+60) (.BLTU .x1 .x7 12)
+    exact step2v4_sub 15 (base+60) (.BLTU .x9 .x7 12)
       (by omega) (by bv_omega) (by decide))
 
 /-- Phase D BLTU taken body: correction path [18..20]. -/
@@ -137,7 +137,7 @@ private theorem divK_div128_step2_v4_phase_D_fallthrough_body_spec
 
 private def phaseDTakenBranchPost
     (sp dHi q0c rhat2c dlo un0 rhat2cHi q0Dlo1 rhat2Un0 : Word) : Assertion :=
-  (((.x1 ↦ᵣ rhat2Un0) ** (.x7 ↦ᵣ q0Dlo1) ** ⌜BitVec.ult rhat2Un0 q0Dlo1⌝) **
+  (((.x9 ↦ᵣ rhat2Un0) ** (.x7 ↦ᵣ q0Dlo1) ** ⌜BitVec.ult rhat2Un0 q0Dlo1⌝) **
     (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) ** (.x11 ↦ᵣ un0) **
     (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
     (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
@@ -147,7 +147,7 @@ private def phaseDTakenBodyPre
     (sp dHi q0c rhat2c dlo un0 rhat2cHi q0Dlo1 rhat2Un0 : Word) : Assertion :=
   (((.x5 ↦ᵣ q0c) ** (.x11 ↦ᵣ un0) ** (.x12 ↦ᵣ sp) **
     (sp + signExtend12 3936 ↦ₘ rhat2c) ** (.x6 ↦ᵣ dHi)) **
-    (.x1 ↦ᵣ rhat2Un0) ** (.x7 ↦ᵣ q0Dlo1) ** (.x0 ↦ᵣ 0) **
+    (.x9 ↦ᵣ rhat2Un0) ** (.x7 ↦ᵣ q0Dlo1) ** (.x0 ↦ᵣ 0) **
     ⌜rhat2cHi = 0⌝ ** (sp + signExtend12 3952 ↦ₘ dlo) **
     (sp + signExtend12 3944 ↦ₘ un0))
 
@@ -158,7 +158,7 @@ private theorem divK_div128_step2_v4_phase_D_taken_body_pre
       phaseDTakenBodyPre sp dHi q0c rhat2c dlo un0 rhat2cHi q0Dlo1 rhat2Un0 h := by
   dsimp only [phaseDTakenBranchPost, phaseDTakenBodyPre] at hp ⊢
   have hp' :
-      ((((.x1 ↦ᵣ rhat2Un0) ** (.x7 ↦ᵣ q0Dlo1)) **
+      ((((.x9 ↦ᵣ rhat2Un0) ** (.x7 ↦ᵣ q0Dlo1)) **
         (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) ** (.x11 ↦ᵣ un0) **
         (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
         (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
@@ -169,7 +169,7 @@ private theorem divK_div128_step2_v4_phase_D_taken_body_pre
 
 private def phaseDFallthroughBranchPost
     (sp dHi q0c rhat2c dlo un0 rhat2cHi q0Dlo1 rhat2Un0 : Word) : Assertion :=
-  (((.x1 ↦ᵣ rhat2Un0) ** (.x7 ↦ᵣ q0Dlo1) ** ⌜¬BitVec.ult rhat2Un0 q0Dlo1⌝) **
+  (((.x9 ↦ᵣ rhat2Un0) ** (.x7 ↦ᵣ q0Dlo1) ** ⌜¬BitVec.ult rhat2Un0 q0Dlo1⌝) **
     (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) ** (.x11 ↦ᵣ un0) **
     (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
     (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
@@ -178,7 +178,7 @@ private def phaseDFallthroughBranchPost
 private def phaseDFallthroughBodyPre
     (sp dHi q0c rhat2c dlo un0 rhat2cHi q0Dlo1 rhat2Un0 : Word) : Assertion :=
   (((.x11 ↦ᵣ un0) ** (.x12 ↦ᵣ sp) ** (sp + signExtend12 3936 ↦ₘ rhat2c)) **
-    (.x1 ↦ᵣ rhat2Un0) ** (.x7 ↦ᵣ q0Dlo1) ** (.x6 ↦ᵣ dHi) **
+    (.x9 ↦ᵣ rhat2Un0) ** (.x7 ↦ᵣ q0Dlo1) ** (.x6 ↦ᵣ dHi) **
     (.x5 ↦ᵣ q0c) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
     (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0))
 
@@ -189,7 +189,7 @@ private theorem divK_div128_step2_v4_phase_D_fallthrough_body_pre
       phaseDFallthroughBodyPre sp dHi q0c rhat2c dlo un0 rhat2cHi q0Dlo1 rhat2Un0 h := by
   dsimp only [phaseDFallthroughBranchPost, phaseDFallthroughBodyPre] at hp ⊢
   have hp' :
-      ((((.x1 ↦ᵣ rhat2Un0) ** (.x7 ↦ᵣ q0Dlo1)) **
+      ((((.x9 ↦ᵣ rhat2Un0) ** (.x7 ↦ᵣ q0Dlo1)) **
         (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) ** (.x11 ↦ᵣ un0) **
         (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
         (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
@@ -201,7 +201,7 @@ private theorem divK_div128_step2_v4_phase_D_fallthrough_body_pre
 private def phaseDMergedPre
     (sp dHi q0c rhat2c dlo un0 rhat2cHi q0Dlo1 rhat2Un0 : Word) : Assertion :=
   (.x7 ↦ᵣ q0Dlo1) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) **
-  (.x11 ↦ᵣ un0) ** (.x1 ↦ᵣ rhat2Un0) **
+  (.x11 ↦ᵣ un0) ** (.x9 ↦ᵣ rhat2Un0) **
   (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
   (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
   (sp + signExtend12 3936 ↦ₘ rhat2c)
@@ -214,7 +214,7 @@ private theorem divK_div128_step2_v4_phase_D_pre_zero
   dsimp only [phaseDMergedPre] at hp
   have hp' :
       (((.x7 ↦ᵣ q0Dlo1) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) **
-        (.x11 ↦ᵣ un0) ** (.x1 ↦ᵣ rhat2Un0) **
+        (.x11 ↦ᵣ un0) ** (.x9 ↦ᵣ rhat2Un0) **
         (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0)) ** ⌜rhat2cHi = 0⌝ **
         (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
         (sp + signExtend12 3936 ↦ₘ rhat2c)) h := by
@@ -230,19 +230,19 @@ private theorem divK_div128_step2_v4_phase_E_guard_spec
     let rhat2'Hi := rhat2' >>> (32 : BitVec 6).toNat
     cpsBranchWithin 2 (base + 84) (divKDiv128Step2V4Code base)
       ((.x7 ↦ᵣ q0Dlo1) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0') **
-       (.x11 ↦ᵣ rhat2') ** (.x1 ↦ᵣ rhat2Un0) **
+       (.x11 ↦ᵣ rhat2') ** (.x9 ↦ᵣ rhat2Un0) **
        (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
        (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
        (sp + signExtend12 3936 ↦ₘ rhat2c))
       (base + 124)
         ((.x7 ↦ᵣ q0Dlo1) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0') **
-         (.x11 ↦ᵣ rhat2') ** (.x1 ↦ᵣ rhat2'Hi) **
+         (.x11 ↦ᵣ rhat2') ** (.x9 ↦ᵣ rhat2'Hi) **
          (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ ** ⌜rhat2'Hi ≠ 0⌝ **
          (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
          (sp + signExtend12 3936 ↦ₘ rhat2c))
       (base + 92)
         ((.x7 ↦ᵣ q0Dlo1) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0') **
-         (.x11 ↦ᵣ rhat2') ** (.x1 ↦ᵣ rhat2'Hi) **
+         (.x11 ↦ᵣ rhat2') ** (.x9 ↦ᵣ rhat2'Hi) **
          (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ ** ⌜rhat2'Hi = 0⌝ **
          (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
          (sp + signExtend12 3936 ↦ₘ rhat2c)) := by
@@ -255,8 +255,8 @@ private theorem divK_div128_step2_v4_phase_E_guard_spec
   have hguard : cpsBranchWithin 2 (base + 84) (divKDiv128Step2V4Code base) _ _ _ _ _ :=
     cpsBranchWithin_extend_code (h := hraw) (hmono := by
       exact CodeReq.union_sub
-        (step2v4_sub 21 (base+84) (.SRLI .x1 .x11 32) (by omega) (by bv_omega) (by decide))
-        (step2v4_sub 22 (base+88) (.BNE .x1 .x0 36) (by omega) (by bv_omega) (by decide)))
+        (step2v4_sub 21 (base+84) (.SRLI .x9 .x11 32) (by omega) (by bv_omega) (by decide))
+        (step2v4_sub 22 (base+88) (.BNE .x9 .x0 36) (by omega) (by bv_omega) (by decide)))
   have hframed := cpsBranchWithin_frameR
     ((.x7 ↦ᵣ q0Dlo1) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0') **
      ⌜rhat2cHi = 0⌝ **
@@ -278,12 +278,12 @@ private theorem divK_div128_step2_v4_phase_E_fallthrough_body_spec
     let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
     cpsTripleWithin 8 (base + 92) (base + 124) (divKDiv128Step2V4Code base)
       ((.x7 ↦ᵣ q0Dlo1) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0') **
-       (.x11 ↦ᵣ rhat2') ** (.x1 ↦ᵣ rhat2'Hi) **
+       (.x11 ↦ᵣ rhat2') ** (.x9 ↦ᵣ rhat2'Hi) **
        (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ ** ⌜rhat2'Hi = 0⌝ **
        (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
        (sp + signExtend12 3936 ↦ₘ rhat2c))
       ((.x5 ↦ᵣ q0'Unguarded) ** (.x6 ↦ᵣ dHi) ** (.x7 ↦ᵣ q0Dlo2) **
-       (.x1 ↦ᵣ rhat2'Un0) ** (.x11 ↦ᵣ un0) **
+       (.x9 ↦ᵣ rhat2'Un0) ** (.x11 ↦ᵣ un0) **
        (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ ** ⌜rhat2'Hi = 0⌝ **
        (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
        (sp + signExtend12 3936 ↦ₘ rhat2c)) := by
@@ -300,17 +300,17 @@ private theorem divK_div128_step2_v4_phase_E_fallthrough_body_spec
   have hext : cpsTripleWithin 8 (base + 92) (base + 124) (divKDiv128Step2V4Code base) _ _ :=
     cpsTripleWithin_extend_code (h := hraw) (hmono := by
       exact CodeReq.union_sub
-        (step2v4_sub 23 (base+92) (.LD .x1 .x12 3952) (by omega) (by bv_omega) (by decide))
+        (step2v4_sub 23 (base+92) (.LD .x9 .x12 3952) (by omega) (by bv_omega) (by decide))
         (CodeReq.union_sub
-        (step2v4_sub 24 (base+96) (.MUL .x7 .x5 .x1) (by omega) (by bv_omega) (by decide))
+        (step2v4_sub 24 (base+96) (.MUL .x7 .x5 .x9) (by omega) (by bv_omega) (by decide))
         (CodeReq.union_sub
-        (step2v4_sub 25 (base+100) (.SLLI .x1 .x11 32) (by omega) (by bv_omega) (by decide))
+        (step2v4_sub 25 (base+100) (.SLLI .x9 .x11 32) (by omega) (by bv_omega) (by decide))
         (CodeReq.union_sub
         (step2v4_sub 26 (base+104) (.LD .x11 .x12 3944) (by omega) (by bv_omega) (by decide))
         (CodeReq.union_sub
-        (step2v4_sub 27 (base+108) (.OR .x1 .x1 .x11) (by omega) (by bv_omega) (by decide))
+        (step2v4_sub 27 (base+108) (.OR .x9 .x9 .x11) (by omega) (by bv_omega) (by decide))
         (CodeReq.union_sub
-        (step2v4_sub 28 (base+112) (.BLTU .x1 .x7 8) (by omega) (by bv_omega) (by decide))
+        (step2v4_sub 28 (base+112) (.BLTU .x9 .x7 8) (by omega) (by bv_omega) (by decide))
         (CodeReq.union_sub
         (step2v4_sub 29 (base+116) (.JAL .x0 8) (by omega) (by bv_omega) (by decide))
         (step2v4_sub 30 (base+120) (.ADDI .x5 .x5 4095) (by omega) (by bv_omega) (by decide)))))))))
@@ -327,7 +327,7 @@ private def phaseETakenBranchPost
     (sp dHi q0' rhat2' rhat2cHi rhat2'Hi q0Dlo1 dlo un0 rhat2c : Word) :
     Assertion :=
   (.x7 ↦ᵣ q0Dlo1) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0') **
-  (.x11 ↦ᵣ rhat2') ** (.x1 ↦ᵣ rhat2'Hi) **
+  (.x11 ↦ᵣ rhat2') ** (.x9 ↦ᵣ rhat2'Hi) **
   (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ ** ⌜rhat2'Hi ≠ 0⌝ **
   (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
   (sp + signExtend12 3936 ↦ₘ rhat2c)
@@ -336,7 +336,7 @@ private def phaseEFallthroughBranchPost
     (sp dHi q0' rhat2' rhat2cHi rhat2'Hi q0Dlo1 dlo un0 rhat2c : Word) :
     Assertion :=
   (.x7 ↦ᵣ q0Dlo1) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0') **
-  (.x11 ↦ᵣ rhat2') ** (.x1 ↦ᵣ rhat2'Hi) **
+  (.x11 ↦ᵣ rhat2') ** (.x9 ↦ᵣ rhat2'Hi) **
   (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ ** ⌜rhat2'Hi = 0⌝ **
   (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
   (sp + signExtend12 3936 ↦ₘ rhat2c)
@@ -349,7 +349,7 @@ private theorem phaseE_taken_post_ne
   dsimp only [phaseETakenBranchPost] at hp
   have hp' :
       (((.x7 ↦ᵣ q0Dlo1) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0') **
-        (.x11 ↦ᵣ rhat2') ** (.x1 ↦ᵣ rhat2'Hi) **
+        (.x11 ↦ᵣ rhat2') ** (.x9 ↦ᵣ rhat2'Hi) **
         (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝) **
         ⌜rhat2'Hi ≠ 0⌝ **
         (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
@@ -366,7 +366,7 @@ private theorem phaseE_fallthrough_post_zero
   dsimp only [phaseEFallthroughBranchPost] at hp
   have hp' :
       (((.x7 ↦ᵣ q0Dlo1) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0') **
-        (.x11 ↦ᵣ rhat2') ** (.x1 ↦ᵣ rhat2'Hi) **
+        (.x11 ↦ᵣ rhat2') ** (.x9 ↦ᵣ rhat2'Hi) **
         (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝) **
         ⌜rhat2'Hi = 0⌝ **
         (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
@@ -412,7 +412,7 @@ def divKDiv128Step2V4Post (sp un21 dHi dlo un0 vScratchOld : Word) : Assertion :
                 else if rhat2'Hi ≠ 0 then q0Dlo1
                 else q0Dlo2
   -- x1: rhat2cHi (outer BNE) | rhat2'Hi (2nd BNE) | rhat2'*2^32|un0 (2nd D3 ran).
-  let x1Exit := if rhat2cHi ≠ 0 then rhat2cHi
+  let x9Exit := if rhat2cHi ≠ 0 then rhat2cHi
                 else if rhat2'Hi ≠ 0 then rhat2'Hi
                 else rhat2'Un0
   -- x11: rhat2c (outer BNE) | rhat2' (2nd BNE) | un0 (2nd D3 ran).
@@ -423,7 +423,7 @@ def divKDiv128Step2V4Post (sp un21 dHi dlo un0 vScratchOld : Word) : Assertion :
   --          else rhat2c (saved at [52]).
   let mem3936Exit := if rhat2cHi ≠ 0 then vScratchOld else rhat2c
   (.x5 ↦ᵣ q0'') ** (.x6 ↦ᵣ dHi) ** (.x7 ↦ᵣ x7Exit) **
-  (.x1 ↦ᵣ x1Exit) ** (.x11 ↦ᵣ x11Exit) **
+  (.x9 ↦ᵣ x9Exit) ** (.x11 ↦ᵣ x11Exit) **
   (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
   (sp + signExtend12 3952 ↦ₘ dlo) **
   (sp + signExtend12 3944 ↦ₘ un0) **
@@ -450,12 +450,12 @@ theorem divK_div128_step2_v4_phase_D_merged_spec
                     else rhat2c
     cpsTripleWithin 4 (base + 60) (base + 84) (divKDiv128Step2V4Code base)
       ((.x7 ↦ᵣ q0Dlo1) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) **
-       (.x11 ↦ᵣ un0) ** (.x1 ↦ᵣ rhat2Un0) **
+       (.x11 ↦ᵣ un0) ** (.x9 ↦ᵣ rhat2Un0) **
        (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
        (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
        (sp + signExtend12 3936 ↦ₘ rhat2c))
       ((.x7 ↦ᵣ q0Dlo1) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0') **
-       (.x11 ↦ᵣ rhat2') ** (.x1 ↦ᵣ rhat2Un0) **
+       (.x11 ↦ᵣ rhat2') ** (.x9 ↦ᵣ rhat2Un0) **
        (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
        (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
        (sp + signExtend12 3936 ↦ₘ rhat2c)) := by
@@ -479,7 +479,7 @@ theorem divK_div128_step2_v4_phase_D_merged_spec
         exact ((sepConj_pure_right _).1 hpure).2 hcond)
       have taken' : cpsTripleWithin 1 (base + 60) (base + 72) (divKDiv128Step2V4Code base)
           ((.x7 ↦ᵣ q0Dlo1) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) **
-           (.x11 ↦ᵣ un0) ** (.x1 ↦ᵣ rhat2Un0) **
+           (.x11 ↦ᵣ un0) ** (.x9 ↦ᵣ rhat2Un0) **
            (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
            (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
            (sp + signExtend12 3936 ↦ₘ rhat2c))
@@ -500,7 +500,7 @@ theorem divK_div128_step2_v4_phase_D_merged_spec
       rw [hq0', hrhat2']
       have hpath := divK_div128_step2_v4_phase_D_taken_body_spec sp q0c rhat2c dHi un0 base
       have hpath_f := cpsTripleWithin_frameR
-        ((.x1 ↦ᵣ rhat2Un0) ** (.x7 ↦ᵣ q0Dlo1) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
+        ((.x9 ↦ᵣ rhat2Un0) ** (.x7 ↦ᵣ q0Dlo1) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
          (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0))
         (by pcFree) hpath
       exact cpsTripleWithin_weaken
@@ -515,7 +515,7 @@ theorem divK_div128_step2_v4_phase_D_merged_spec
         exact absurd ((sepConj_pure_right _).1 hpure).2 hcond)
       have ntaken' : cpsTripleWithin 1 (base + 60) (base + 64) (divKDiv128Step2V4Code base)
           ((.x7 ↦ᵣ q0Dlo1) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) **
-           (.x11 ↦ᵣ un0) ** (.x1 ↦ᵣ rhat2Un0) **
+           (.x11 ↦ᵣ un0) ** (.x9 ↦ᵣ rhat2Un0) **
            (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
            (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
            (sp + signExtend12 3936 ↦ₘ rhat2c))
@@ -536,7 +536,7 @@ theorem divK_div128_step2_v4_phase_D_merged_spec
       rw [hq0', hrhat2']
       have hpath := divK_div128_step2_v4_phase_D_fallthrough_body_spec sp rhat2c un0 base
       have hpath_f := cpsTripleWithin_frameR
-        ((.x1 ↦ᵣ rhat2Un0) ** (.x7 ↦ᵣ q0Dlo1) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) **
+        ((.x9 ↦ᵣ rhat2Un0) ** (.x7 ↦ᵣ q0Dlo1) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) **
          (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
          (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0))
         (by pcFree) hpath
@@ -572,25 +572,25 @@ theorem divK_div128_step2_v4_phase_E_merged_spec
     let rhat2'Un0 := (rhat2' <<< (32 : BitVec 6).toNat) ||| un0
     let q0''     := div128Quot_phase2b_q0' q0' rhat2' dlo un0
     let x7Exit   := if rhat2'Hi ≠ 0 then q0Dlo1 else q0Dlo2
-    let x1Exit   := if rhat2'Hi ≠ 0 then rhat2'Hi else rhat2'Un0
+    let x9Exit   := if rhat2'Hi ≠ 0 then rhat2'Hi else rhat2'Un0
     let x11Exit  := if rhat2'Hi ≠ 0 then rhat2' else un0
     cpsTripleWithin 10 (base + 84) (base + 124) (divKDiv128Step2V4Code base)
       ((.x7 ↦ᵣ q0Dlo1) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0') **
-       (.x11 ↦ᵣ rhat2') ** (.x1 ↦ᵣ rhat2Un0) **
+       (.x11 ↦ᵣ rhat2') ** (.x9 ↦ᵣ rhat2Un0) **
        (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
        (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
        (sp + signExtend12 3936 ↦ₘ rhat2c))
         ((.x5 ↦ᵣ q0'') ** (.x6 ↦ᵣ dHi) ** (.x7 ↦ᵣ x7Exit) **
-         (.x1 ↦ᵣ x1Exit) ** (.x11 ↦ᵣ x11Exit) **
+         (.x9 ↦ᵣ x9Exit) ** (.x11 ↦ᵣ x11Exit) **
          (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
          (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
          (sp + signExtend12 3936 ↦ₘ rhat2c)) := by
-    intro rhat2cHi rhat2'Hi q0Dlo2 rhat2'Un0 q0'' x7Exit x1Exit x11Exit
+    intro rhat2cHi rhat2'Hi q0Dlo2 rhat2'Un0 q0'' x7Exit x9Exit x11Exit
     have hguard := divK_div128_step2_v4_phase_E_guard_spec
       sp dHi q0' rhat2' rhat2Un0 q0Dlo1 dlo un0 rhat2c base
     have hguard' : cpsBranchWithin 2 (base + 84) (divKDiv128Step2V4Code base)
         ((.x7 ↦ᵣ q0Dlo1) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0') **
-         (.x11 ↦ᵣ rhat2') ** (.x1 ↦ᵣ rhat2Un0) **
+         (.x11 ↦ᵣ rhat2') ** (.x9 ↦ᵣ rhat2Un0) **
          (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
          (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
          (sp + signExtend12 3936 ↦ₘ rhat2c))
@@ -620,8 +620,8 @@ theorem divK_div128_step2_v4_phase_E_merged_spec
       have hx7 : x7Exit = q0Dlo1 := by
         unfold x7Exit
         exact if_pos hhi
-      have hx1 : x1Exit = rhat2'Hi := by
-        unfold x1Exit
+      have hx1 : x9Exit = rhat2'Hi := by
+        unfold x9Exit
         exact if_pos hhi
       have hx11 : x11Exit = rhat2' := by
         unfold x11Exit
@@ -629,7 +629,7 @@ theorem divK_div128_step2_v4_phase_E_merged_spec
       have hzero : cpsTripleWithin 0 (base + 124) (base + 124) (divKDiv128Step2V4Code base)
           (phaseETakenBranchPost sp dHi q0' rhat2' rhat2cHi rhat2'Hi q0Dlo1 dlo un0 rhat2c)
           ((.x5 ↦ᵣ q0'') ** (.x6 ↦ᵣ dHi) ** (.x7 ↦ᵣ x7Exit) **
-           (.x1 ↦ᵣ x1Exit) ** (.x11 ↦ᵣ x11Exit) **
+           (.x9 ↦ᵣ x9Exit) ** (.x11 ↦ᵣ x11Exit) **
            (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
            (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
            (sp + signExtend12 3936 ↦ₘ rhat2c)) := refl_of (by
@@ -638,13 +638,13 @@ theorem divK_div128_step2_v4_phase_E_merged_spec
         rw [hq0'', hx7, hx1, hx11]
         have hp' :
             ((.x7 ↦ᵣ q0Dlo1) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0') **
-             (.x11 ↦ᵣ rhat2') ** (.x1 ↦ᵣ rhat2'Hi) **
+             (.x11 ↦ᵣ rhat2') ** (.x9 ↦ᵣ rhat2'Hi) **
              (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
              (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
              (sp + signExtend12 3936 ↦ₘ rhat2c)) h := by
           have hp0 :
               (((.x7 ↦ᵣ q0Dlo1) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0') **
-                (.x11 ↦ᵣ rhat2') ** (.x1 ↦ᵣ rhat2'Hi) **
+                (.x11 ↦ᵣ rhat2') ** (.x9 ↦ᵣ rhat2'Hi) **
                 (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
                 (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
                 (sp + signExtend12 3936 ↦ₘ rhat2c)) ** ⌜rhat2'Hi ≠ 0⌝) h := by
@@ -670,8 +670,8 @@ theorem divK_div128_step2_v4_phase_E_merged_spec
       have hx7 : x7Exit = q0Dlo2 := by
         unfold x7Exit
         exact if_neg hhi
-      have hx1 : x1Exit = rhat2'Un0 := by
-        unfold x1Exit
+      have hx1 : x9Exit = rhat2'Un0 := by
+        unfold x9Exit
         exact if_neg hhi
       have hx11 : x11Exit = un0 := by
         unfold x11Exit
@@ -683,7 +683,7 @@ theorem divK_div128_step2_v4_phase_E_merged_spec
           have hp0 :
               (((.x5 ↦ᵣ (if BitVec.ult rhat2'Un0 q0Dlo2 then q0' + signExtend12 4095 else q0')) **
                 (.x6 ↦ᵣ dHi) ** (.x7 ↦ᵣ q0Dlo2) **
-                (.x1 ↦ᵣ rhat2'Un0) ** (.x11 ↦ᵣ un0) **
+                (.x9 ↦ᵣ rhat2'Un0) ** (.x11 ↦ᵣ un0) **
                 (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
                 (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
                 (sp + signExtend12 3936 ↦ₘ rhat2c)) ** ⌜rhat2'Hi = 0⌝) h := by
@@ -705,10 +705,10 @@ theorem divK_div128_step2_v4_phase_E_merged_spec
       Block 4 [60..84] (hD): BLTU+paths via `phase_D_merged_spec`.
       Block 5 [84..124](hE): 2nd D3 guard+prodcheck via `phase_E_merged_spec`. -/
 theorem divK_div128_step2_v4_spec
-    (sp un21 dHi v1Old v5Old v11Old dlo un0 vScratchOld : Word) (base : Word) :
+    (sp un21 dHi v9Old v5Old v11Old dlo un0 vScratchOld : Word) (base : Word) :
     cpsTripleWithin 29 base (base + 124) (divKDiv128Step2V4Code base)
       ((.x7 ↦ᵣ un21) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ v5Old) **
-       (.x1 ↦ᵣ v1Old) ** (.x11 ↦ᵣ v11Old) **
+       (.x9 ↦ᵣ v9Old) ** (.x11 ↦ᵣ v11Old) **
        (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3952 ↦ₘ dlo) **
        (sp + signExtend12 3944 ↦ₘ un0) **
@@ -734,26 +734,26 @@ theorem divK_div128_step2_v4_spec
   let q0'' := div128Quot_phase2b_q0' q0' rhat2' dlo un0
   let x7Exit := if rhat2cHi ≠ 0 then un21
                 else if rhat2'Hi ≠ 0 then q0Dlo1 else q0Dlo2
-  let x1Exit := if rhat2cHi ≠ 0 then rhat2cHi
+  let x9Exit := if rhat2cHi ≠ 0 then rhat2cHi
                 else if rhat2'Hi ≠ 0 then rhat2'Hi else rhat2'Un0
   let x11Exit := if rhat2cHi ≠ 0 then rhat2c
                  else if rhat2'Hi ≠ 0 then rhat2' else un0
   let mem3936Exit := if rhat2cHi ≠ 0 then vScratchOld else rhat2c
   -- Phase A: init+clamp [0..28] — cpsTripleWithin base (base+28).
   -- Reuse divK_div128_step2_upto_guard_spec_within, extend via step2v4_sub 0..6.
-  have hA_raw := divK_div128_step2_upto_guard_spec_within sp un21 dHi v1Old v5Old v11Old dlo un0 base
+  have hA_raw := divK_div128_step2_upto_guard_spec_within sp un21 dHi v9Old v5Old v11Old dlo un0 base
   have hA : cpsTripleWithin 7 base (base + 28) (divKDiv128Step2V4Code base) _ _ :=
     cpsTripleWithin_extend_code (hmono := by
       exact CodeReq.union_sub
         (step2v4_sub 0 base (.DIVU .x5 .x7 .x6) (by omega) (by bv_omega) (by decide))
        (CodeReq.union_sub
-        (step2v4_sub 1 (base+4) (.MUL .x1 .x5 .x6) (by omega) (by bv_omega) (by decide))
+        (step2v4_sub 1 (base+4) (.MUL .x9 .x5 .x6) (by omega) (by bv_omega) (by decide))
        (CodeReq.union_sub
-        (step2v4_sub 2 (base+8) (.SUB .x11 .x7 .x1) (by omega) (by bv_omega) (by decide))
+        (step2v4_sub 2 (base+8) (.SUB .x11 .x7 .x9) (by omega) (by bv_omega) (by decide))
        (CodeReq.union_sub
-        (step2v4_sub 3 (base+12) (.SRLI .x1 .x5 32) (by omega) (by bv_omega) (by decide))
+        (step2v4_sub 3 (base+12) (.SRLI .x9 .x5 32) (by omega) (by bv_omega) (by decide))
        (CodeReq.union_sub
-        (step2v4_sub 4 (base+16) (.BEQ .x1 .x0 12) (by omega) (by bv_omega) (by decide))
+        (step2v4_sub 4 (base+16) (.BEQ .x9 .x0 12) (by omega) (by bv_omega) (by decide))
        (CodeReq.union_sub
         (step2v4_sub 5 (base+20) (.ADDI .x5 .x5 4095) (by omega) (by bv_omega) (by decide))
         (step2v4_sub 6 (base+24) (.ADD .x11 .x11 .x6) (by omega) (by bv_omega) (by decide))))))))
@@ -770,8 +770,8 @@ theorem divK_div128_step2_v4_spec
   have hB : cpsBranchWithin 2 (base + 28) (divKDiv128Step2V4Code base) _ _ _ _ _ :=
     cpsBranchWithin_extend_code (hmono := by
       exact CodeReq.union_sub
-        (step2v4_sub 7 (base+28) (.SRLI .x1 .x11 32) (by omega) (by bv_omega) (by decide))
-        (step2v4_sub 8 (base+32) (.BNE .x1 .x0 92) (by omega) (by bv_omega) (by decide))) hB_raw
+        (step2v4_sub 7 (base+28) (.SRLI .x9 .x11 32) (by omega) (by bv_omega) (by decide))
+        (step2v4_sub 8 (base+32) (.BNE .x9 .x0 92) (by omega) (by bv_omega) (by decide))) hB_raw
   have hBf := cpsBranchWithin_frameR
     ((.x7 ↦ᵣ un21) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) **
      (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
@@ -782,7 +782,7 @@ theorem divK_div128_step2_v4_spec
   -- finalPost (merged post at base+124 for both legs).
   let finalPost : Assertion :=
     (.x5 ↦ᵣ q0'') ** (.x6 ↦ᵣ dHi) ** (.x7 ↦ᵣ x7Exit) **
-    (.x1 ↦ᵣ x1Exit) ** (.x11 ↦ᵣ x11Exit) **
+    (.x9 ↦ᵣ x9Exit) ** (.x11 ↦ᵣ x11Exit) **
     (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
     (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
     (sp + signExtend12 3936 ↦ₘ mem3936Exit)
@@ -790,7 +790,7 @@ theorem divK_div128_step2_v4_spec
   -- q0'' = q0c (both D3 guards fire), x7=un21, x1=rhat2cHi, x11=rhat2c, mem3936=vScratchOld.
   -- The taken postcondition of composed_AB:
   let takenPost : Assertion :=
-    ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ rhat2c) ** (.x1 ↦ᵣ rhat2cHi) **
+    ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ rhat2c) ** (.x9 ↦ᵣ rhat2cHi) **
      (.x0 ↦ᵣ 0) ** ⌜rhat2cHi ≠ 0⌝) **
     (.x7 ↦ᵣ un21) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) **
     (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
@@ -802,12 +802,12 @@ theorem divK_div128_step2_v4_spec
     (cpsTripleWithin_refl (by
       intro hp htp
       -- Extract ⌜rhat2cHi ≠ 0⌝ from takenPost (inside a have so htp survives).
-      -- takenPost = (.x12 ** .x11 ** .x1 ** .x0 ** ⌜rhat2cHi ≠ 0⌝) ** rest.
+      -- takenPost = (.x12 ** .x11 ** .x9 ** .x0 ** ⌜rhat2cHi ≠ 0⌝) ** rest.
       have h_ne : rhat2cHi ≠ 0 := by
         obtain ⟨_, _, _, _, hleft, _⟩ := htp
         obtain ⟨_, _, _, _, _, h1⟩ := hleft  -- peel .x12
         obtain ⟨_, _, _, _, _, h2⟩ := h1     -- peel .x11
-        obtain ⟨_, _, _, _, _, h3⟩ := h2     -- peel .x1
+        obtain ⟨_, _, _, _, _, h3⟩ := h2     -- peel .x9
         obtain ⟨_, _, _, _, _, h4⟩ := h3     -- peel .x0
         obtain ⟨_, hpure⟩ := h4             -- ⌜rhat2cHi ≠ 0⌝
         exact hpure
@@ -823,13 +823,13 @@ theorem divK_div128_step2_v4_spec
         rw [hq0', hrhat2']
         simp only [div128Quot_phase2b_q0']; exact if_neg h_ne
       have hx7 : x7Exit = un21   := by show (if rhat2cHi ≠ 0 then un21 else _) = un21; exact if_pos h_ne
-      have hx1 : x1Exit = rhat2cHi := by show (if rhat2cHi ≠ 0 then rhat2cHi else _) = rhat2cHi; exact if_pos h_ne
+      have hx1 : x9Exit = rhat2cHi := by show (if rhat2cHi ≠ 0 then rhat2cHi else _) = rhat2cHi; exact if_pos h_ne
       have hx11 : x11Exit = rhat2c  := by show (if rhat2cHi ≠ 0 then rhat2c else _) = rhat2c; exact if_pos h_ne
       have hmem : mem3936Exit = vScratchOld := by show (if rhat2cHi ≠ 0 then vScratchOld else _) = vScratchOld; exact if_pos h_ne
       -- Strip ⌜rhat2cHi ≠ 0⌝ from htp for xperm_hyp.
-      -- takenPost = (.x12 ** .x11 ** .x1 ** .x0 ** ⌜...⌝) ** rest.
+      -- takenPost = (.x12 ** .x11 ** .x9 ** .x0 ** ⌜...⌝) ** rest.
       -- Strip: 3x sepConj_mono_right to reach .x0 ** ⌜...⌝, then strip.
-      have htp' : (((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ rhat2c) ** (.x1 ↦ᵣ rhat2cHi) ** (.x0 ↦ᵣ 0)) **
+      have htp' : (((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ rhat2c) ** (.x9 ↦ᵣ rhat2cHi) ** (.x0 ↦ᵣ 0)) **
           (.x7 ↦ᵣ un21) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) **
           (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
           (sp + signExtend12 3936 ↦ₘ vScratchOld)) hp :=
@@ -838,7 +838,7 @@ theorem divK_div128_step2_v4_spec
       -- Rewrite finalPost to explicit form, then xperm_hyp htp'.
       show finalPost hp
       rw [show finalPost = ((.x5 ↦ᵣ q0c) ** (.x6 ↦ᵣ dHi) ** (.x7 ↦ᵣ un21) **
-          (.x1 ↦ᵣ rhat2cHi) ** (.x11 ↦ᵣ rhat2c) **
+          (.x9 ↦ᵣ rhat2cHi) ** (.x11 ↦ᵣ rhat2c) **
           (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
           (sp + signExtend12 3952 ↦ₘ dlo) **
           (sp + signExtend12 3944 ↦ₘ un0) **
@@ -847,7 +847,7 @@ theorem divK_div128_step2_v4_spec
       xperm_hyp htp'))
   -- The not-taken postcondition of composed_AB:
   let notTakenPost : Assertion :=
-    ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ rhat2c) ** (.x1 ↦ᵣ rhat2cHi) **
+    ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ rhat2c) ** (.x9 ↦ᵣ rhat2cHi) **
      (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝) **
     (.x7 ↦ᵣ un21) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) **
     (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
@@ -858,25 +858,25 @@ theorem divK_div128_step2_v4_spec
     -- Phase C: pre-BLTU setup [9..14] = LD+MUL+SLLI+SD+LD+OR.
     let midC : Assertion :=
       (.x7 ↦ᵣ q0Dlo1) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) **
-      (.x11 ↦ᵣ un0) ** (.x1 ↦ᵣ rhat2Un0) **
+      (.x11 ↦ᵣ un0) ** (.x9 ↦ᵣ rhat2Un0) **
       (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
       (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
       (sp + signExtend12 3936 ↦ₘ rhat2c)
     have hC : cpsTripleWithin 6 (base+36) (base+60) (divKDiv128Step2V4Code base)
         notTakenPost midC := by
       apply cpsTripleWithin_extend_code (hmono := by
-        exact CodeReq.union_sub (step2v4_sub 9 (base+36) (.LD .x1 .x12 3952) (by omega) (by bv_omega) (by decide))
-         (CodeReq.union_sub (step2v4_sub 10 (base+40) (.MUL .x7 .x5 .x1) (by omega) (by bv_omega) (by decide))
-         (CodeReq.union_sub (step2v4_sub 11 (base+44) (.SLLI .x1 .x11 32) (by omega) (by bv_omega) (by decide))
+        exact CodeReq.union_sub (step2v4_sub 9 (base+36) (.LD .x9 .x12 3952) (by omega) (by bv_omega) (by decide))
+         (CodeReq.union_sub (step2v4_sub 10 (base+40) (.MUL .x7 .x5 .x9) (by omega) (by bv_omega) (by decide))
+         (CodeReq.union_sub (step2v4_sub 11 (base+44) (.SLLI .x9 .x11 32) (by omega) (by bv_omega) (by decide))
          (CodeReq.union_sub (step2v4_sub 12 (base+48) (.SD .x12 .x11 3936) (by omega) (by bv_omega) (by decide))
          (CodeReq.union_sub (step2v4_sub 13 (base+52) (.LD .x11 .x12 3944) (by omega) (by bv_omega) (by decide))
-          (step2v4_sub 14 (base+56) (.OR .x1 .x1 .x11) (by omega) (by bv_omega) (by decide)))))))
-      have I0 := ld_spec_gen_within .x1 .x12 sp rhat2cHi dlo 3952 (base+36) (by nofun)
-      have I1 := mul_spec_gen_within .x7 .x5 .x1 un21 q0c dlo (base+40) (by nofun)
-      have I2 := slli_spec_gen_within .x1 .x11 dlo rhat2c 32 (base+44) (by nofun)
+          (step2v4_sub 14 (base+56) (.OR .x9 .x9 .x11) (by omega) (by bv_omega) (by decide)))))))
+      have I0 := ld_spec_gen_within .x9 .x12 sp rhat2cHi dlo 3952 (base+36) (by nofun)
+      have I1 := mul_spec_gen_within .x7 .x5 .x9 un21 q0c dlo (base+40) (by nofun)
+      have I2 := slli_spec_gen_within .x9 .x11 dlo rhat2c 32 (base+44) (by nofun)
       have I3 := sd_spec_gen_within .x12 .x11 sp rhat2c vScratchOld 3936 (base+48)
       have I4 := ld_spec_gen_within .x11 .x12 sp rhat2c un0 3944 (base+52) (by nofun)
-      have I5 := or_spec_gen_rd_eq_rs1_within .x1 .x11
+      have I5 := or_spec_gen_rd_eq_rs1_within .x9 .x11
             (rhat2c <<< (32 : BitVec 6).toNat) un0 (base+56) (by nofun)
       simp only [show (base+36:Word)+4 = base+40 from by bv_omega,
                  show (base+40:Word)+4 = base+44 from by bv_omega,
@@ -888,7 +888,7 @@ theorem divK_div128_step2_v4_spec
     -- Phase D: BLTU+paths [15..20] via `divK_div128_step2_v4_phase_D_merged_spec`.
     let midD : Assertion :=
       (.x7 ↦ᵣ q0Dlo1) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0') **
-      (.x11 ↦ᵣ rhat2') ** (.x1 ↦ᵣ rhat2Un0) **
+      (.x11 ↦ᵣ rhat2') ** (.x9 ↦ᵣ rhat2Un0) **
       (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
       (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
       (sp + signExtend12 3936 ↦ₘ rhat2c)
@@ -909,7 +909,7 @@ theorem divK_div128_step2_v4_spec
               have hp0 :
                   ((.x5 ↦ᵣ q0'') ** (.x6 ↦ᵣ dHi) **
                    (.x7 ↦ᵣ (if rhat2'Hi ≠ 0 then q0Dlo1 else q0Dlo2)) **
-                   (.x1 ↦ᵣ (if rhat2'Hi ≠ 0 then rhat2'Hi else rhat2'Un0)) **
+                   (.x9 ↦ᵣ (if rhat2'Hi ≠ 0 then rhat2'Hi else rhat2'Un0)) **
                    (.x11 ↦ᵣ (if rhat2'Hi ≠ 0 then rhat2' else un0)) **
                    (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
                    (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
@@ -927,8 +927,8 @@ theorem divK_div128_step2_v4_spec
             have hx7 : x7Exit = (if rhat2'Hi ≠ 0 then q0Dlo1 else q0Dlo2) := by
               unfold x7Exit
               exact if_neg hne
-            have hx1 : x1Exit = (if rhat2'Hi ≠ 0 then rhat2'Hi else rhat2'Un0) := by
-              unfold x1Exit
+            have hx1 : x9Exit = (if rhat2'Hi ≠ 0 then rhat2'Hi else rhat2'Un0) := by
+              unfold x9Exit
               exact if_neg hne
             have hx11 : x11Exit = (if rhat2'Hi ≠ 0 then rhat2' else un0) := by
               unfold x11Exit
@@ -939,7 +939,7 @@ theorem divK_div128_step2_v4_spec
             let noPure : Assertion :=
               (.x5 ↦ᵣ q0'') ** (.x6 ↦ᵣ dHi) **
               (.x7 ↦ᵣ (if rhat2'Hi ≠ 0 then q0Dlo1 else q0Dlo2)) **
-              (.x1 ↦ᵣ (if rhat2'Hi ≠ 0 then rhat2'Hi else rhat2'Un0)) **
+              (.x9 ↦ᵣ (if rhat2'Hi ≠ 0 then rhat2'Hi else rhat2'Un0)) **
               (.x11 ↦ᵣ (if rhat2'Hi ≠ 0 then rhat2' else un0)) **
               (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
               (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Tail.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Tail.lean
@@ -48,60 +48,60 @@ theorem divK_div128_clamp_test_q1_spec_within (q1 v5Old : Word) (base : Word) :
   runBlock I0
 
 /-- div128 q0 clamp test: x1 = q0 >>> 32. -/
-theorem divK_div128_clamp_test_q0_spec_within (q0 v1Old : Word) (base : Word) :
+theorem divK_div128_clamp_test_q0_spec_within (q0 v9Old : Word) (base : Word) :
     let hi := q0 >>> (32 : BitVec 6).toNat
-    let cr := CodeReq.singleton base (.SRLI .x1 .x5 32)
+    let cr := CodeReq.singleton base (.SRLI .x9 .x5 32)
     cpsTripleWithin 1 base (base + 4) cr
-      ((.x5 ↦ᵣ q0) ** (.x1 ↦ᵣ v1Old))
-      ((.x5 ↦ᵣ q0) ** (.x1 ↦ᵣ hi)) := by
+      ((.x5 ↦ᵣ q0) ** (.x9 ↦ᵣ v9Old))
+      ((.x5 ↦ᵣ q0) ** (.x9 ↦ᵣ hi)) := by
   intro hi cr
-  have I0 := srli_spec_gen_within .x1 .x5 v1Old q0 32 base (by nofun)
+  have I0 := srli_spec_gen_within .x9 .x5 v9Old q0 32 base (by nofun)
   runBlock I0
 
 /-- div128 Step 2: q0 = DIVU(un21, dHi), rhat2 = un21 - q0 * dHi. -/
-theorem divK_div128_step2_init_spec_within (un21 dHi v1Old v5Old v11Old : Word) (base : Word) :
+theorem divK_div128_step2_init_spec_within (un21 dHi v9Old v5Old v11Old : Word) (base : Word) :
     let q0 := rv64_divu un21 dHi
     let rhat2 := un21 - q0 * dHi
     let cr :=
       CodeReq.union (CodeReq.singleton base (.DIVU .x5 .x7 .x6))
-      (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x1 .x5 .x6))
-       (CodeReq.singleton (base + 8) (.SUB .x11 .x7 .x1)))
+      (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x9 .x5 .x6))
+       (CodeReq.singleton (base + 8) (.SUB .x11 .x7 .x9)))
     cpsTripleWithin 3 base (base + 12) cr
       ((.x7 ↦ᵣ un21) ** (.x6 ↦ᵣ dHi) **
-       (.x5 ↦ᵣ v5Old) ** (.x1 ↦ᵣ v1Old) ** (.x11 ↦ᵣ v11Old))
+       (.x5 ↦ᵣ v5Old) ** (.x9 ↦ᵣ v9Old) ** (.x11 ↦ᵣ v11Old))
       ((.x7 ↦ᵣ un21) ** (.x6 ↦ᵣ dHi) **
-       (.x5 ↦ᵣ q0) ** (.x1 ↦ᵣ q0 * dHi) ** (.x11 ↦ᵣ rhat2)) := by
+       (.x5 ↦ᵣ q0) ** (.x9 ↦ᵣ q0 * dHi) ** (.x11 ↦ᵣ rhat2)) := by
   intro q0 rhat2 cr
   have I0 := divu_spec_gen_within .x5 .x7 .x6 v5Old un21 dHi base (by nofun)
-  have I1 := mul_spec_gen_within .x1 .x5 .x6 v1Old q0 dHi (base + 4) (by nofun)
-  have I2 := sub_spec_gen_within .x11 .x7 .x1 un21 (q0 * dHi) v11Old (base + 8) (by nofun)
+  have I1 := mul_spec_gen_within .x9 .x5 .x6 v9Old q0 dHi (base + 4) (by nofun)
+  have I2 := sub_spec_gen_within .x11 .x7 .x9 un21 (q0 * dHi) v11Old (base + 8) (by nofun)
   runBlock I0 I1 I2
 
 /-- div128 product check 2: compute q0*dLo and rhat2*2^32+un0 for comparison. -/
-theorem divK_div128_prodcheck2_body_spec_within (sp q0 rhat2 v1Old v7Old dlo un0 : Word)
+theorem divK_div128_prodcheck2_body_spec_within (sp q0 rhat2 v9Old v7Old dlo un0 : Word)
     (base : Word) :
     let q0Dlo := q0 * dlo
     let rhat2_hi := rhat2 <<< (32 : BitVec 6).toNat
     let rhat2Un0 := rhat2_hi ||| un0
     let cr :=
-      CodeReq.union (CodeReq.singleton base (.LD .x1 .x12 3952))
-      (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x7 .x5 .x1))
-      (CodeReq.union (CodeReq.singleton (base + 8) (.SLLI .x1 .x11 32))
+      CodeReq.union (CodeReq.singleton base (.LD .x9 .x12 3952))
+      (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x7 .x5 .x9))
+      (CodeReq.union (CodeReq.singleton (base + 8) (.SLLI .x9 .x11 32))
       (CodeReq.union (CodeReq.singleton (base + 12) (.LD .x11 .x12 3944))
-       (CodeReq.singleton (base + 16) (.OR .x1 .x1 .x11)))))
+       (CodeReq.singleton (base + 16) (.OR .x9 .x9 .x11)))))
     cpsTripleWithin 5 base (base + 20) cr
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ rhat2) **
-       (.x7 ↦ᵣ v7Old) ** (.x1 ↦ᵣ v1Old) **
+       (.x7 ↦ᵣ v7Old) ** (.x9 ↦ᵣ v9Old) **
        (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ un0) **
-       (.x7 ↦ᵣ q0Dlo) ** (.x1 ↦ᵣ rhat2Un0) **
+       (.x7 ↦ᵣ q0Dlo) ** (.x9 ↦ᵣ rhat2Un0) **
        (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0)) := by
   intro q0Dlo rhat2_hi rhat2Un0 cr
-  have I0 := ld_spec_gen_within .x1 .x12 sp v1Old dlo 3952 base (by nofun)
-  have I1 := mul_spec_gen_within .x7 .x5 .x1 v7Old q0 dlo (base + 4) (by nofun)
-  have I2 := slli_spec_gen_within .x1 .x11 dlo rhat2 32 (base + 8) (by nofun)
+  have I0 := ld_spec_gen_within .x9 .x12 sp v9Old dlo 3952 base (by nofun)
+  have I1 := mul_spec_gen_within .x7 .x5 .x9 v7Old q0 dlo (base + 4) (by nofun)
+  have I2 := slli_spec_gen_within .x9 .x11 dlo rhat2 32 (base + 8) (by nofun)
   have I3 := ld_spec_gen_within .x11 .x12 sp rhat2 un0 3944 (base + 12) (by nofun)
-  have I4 := or_spec_gen_rd_eq_rs1_within .x1 .x11 rhat2_hi un0 (base + 16) (by nofun)
+  have I4 := or_spec_gen_rd_eq_rs1_within .x9 .x11 rhat2_hi un0 (base + 16) (by nofun)
   runBlock I0 I1 I2 I3 I4
 
 /-- div128 product check 2 correction: q0--. -/

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128UnProdCheck.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128UnProdCheck.lean
@@ -33,52 +33,52 @@ open EvmAsm.Rv64
 
 /-- div128 un21 = rhat*2^32 + un1 - q1*dLo.
     Loads dLo from scratch memory. -/
-theorem divK_div128_compute_un21_spec_within (sp q1 rhat un1 v1Old v5Old dloMem : Word) (base : Word) :
+theorem divK_div128_compute_un21_spec_within (sp q1 rhat un1 v9Old v5Old dloMem : Word) (base : Word) :
     let rhatHi := rhat <<< (32 : BitVec 6).toNat
     let rhatUn1 := rhatHi ||| un1
     let q1Dlo := q1 * dloMem
     let un21 := rhatUn1 - q1Dlo
     let cr :=
-      CodeReq.union (CodeReq.singleton base (.LD .x1 .x12 3952))
+      CodeReq.union (CodeReq.singleton base (.LD .x9 .x12 3952))
       (CodeReq.union (CodeReq.singleton (base + 4) (.SLLI .x5 .x7 32))
       (CodeReq.union (CodeReq.singleton (base + 8) (.OR .x5 .x5 .x11))
-      (CodeReq.union (CodeReq.singleton (base + 12) (.MUL .x1 .x10 .x1))
-       (CodeReq.singleton (base + 16) (.SUB .x7 .x5 .x1)))))
+      (CodeReq.union (CodeReq.singleton (base + 12) (.MUL .x9 .x10 .x9))
+       (CodeReq.singleton (base + 16) (.SUB .x7 .x5 .x9)))))
     cpsTripleWithin 5 base (base + 20) cr
       ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) **
-       (.x11 ↦ᵣ un1) ** (.x5 ↦ᵣ v5Old) ** (.x1 ↦ᵣ v1Old) **
+       (.x11 ↦ᵣ un1) ** (.x5 ↦ᵣ v5Old) ** (.x9 ↦ᵣ v9Old) **
        (sp + signExtend12 3952 ↦ₘ dloMem))
       ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ un21) **
-       (.x11 ↦ᵣ un1) ** (.x5 ↦ᵣ rhatUn1) ** (.x1 ↦ᵣ q1Dlo) **
+       (.x11 ↦ᵣ un1) ** (.x5 ↦ᵣ rhatUn1) ** (.x9 ↦ᵣ q1Dlo) **
        (sp + signExtend12 3952 ↦ₘ dloMem)) := by
   intro rhatHi rhatUn1 q1Dlo un21 cr
-  have I0 := ld_spec_gen_within .x1 .x12 sp v1Old dloMem 3952 base (by nofun)
+  have I0 := ld_spec_gen_within .x9 .x12 sp v9Old dloMem 3952 base (by nofun)
   have I1 := slli_spec_gen_within .x5 .x7 v5Old rhat 32 (base + 4) (by nofun)
   have I2 := or_spec_gen_rd_eq_rs1_within .x5 .x11 rhatHi un1 (base + 8) (by nofun)
-  have I3 := mul_spec_gen_rd_eq_rs2_within .x1 .x10 q1 dloMem (base + 12) (by nofun)
-  have I4 := sub_spec_gen_within .x7 .x5 .x1 rhatUn1 q1Dlo rhat (base + 16) (by nofun)
+  have I3 := mul_spec_gen_rd_eq_rs2_within .x9 .x10 q1 dloMem (base + 12) (by nofun)
+  have I4 := sub_spec_gen_within .x7 .x5 .x9 rhatUn1 q1Dlo rhat (base + 16) (by nofun)
   runBlock I0 I1 I2 I3 I4
 
 /-- div128 product check body: compute q*dLo and rhat*2^32+un1 for comparison. -/
-theorem divK_div128_prodcheck_body_spec_within (sp q rhat un1 v1Old v5Old dlo : Word) (base : Word) :
+theorem divK_div128_prodcheck_body_spec_within (sp q rhat un1 v9Old v5Old dlo : Word) (base : Word) :
     let qDlo := q * dlo
     let rhatHi := rhat <<< (32 : BitVec 6).toNat
     let rhatUn1 := rhatHi ||| un1
     let cr :=
-      CodeReq.union (CodeReq.singleton base (.LD .x1 .x12 3952))
-      (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x5 .x10 .x1))
-      (CodeReq.union (CodeReq.singleton (base + 8) (.SLLI .x1 .x7 32))
-       (CodeReq.singleton (base + 12) (.OR .x1 .x1 .x11))))
+      CodeReq.union (CodeReq.singleton base (.LD .x9 .x12 3952))
+      (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x5 .x10 .x9))
+      (CodeReq.union (CodeReq.singleton (base + 8) (.SLLI .x9 .x7 32))
+       (CodeReq.singleton (base + 12) (.OR .x9 .x9 .x11))))
     cpsTripleWithin 4 base (base + 16) cr
       ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q) ** (.x7 ↦ᵣ rhat) ** (.x11 ↦ᵣ un1) **
-       (.x5 ↦ᵣ v5Old) ** (.x1 ↦ᵣ v1Old) ** (sp + signExtend12 3952 ↦ₘ dlo))
+       (.x5 ↦ᵣ v5Old) ** (.x9 ↦ᵣ v9Old) ** (sp + signExtend12 3952 ↦ₘ dlo))
       ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q) ** (.x7 ↦ᵣ rhat) ** (.x11 ↦ᵣ un1) **
-       (.x5 ↦ᵣ qDlo) ** (.x1 ↦ᵣ rhatUn1) ** (sp + signExtend12 3952 ↦ₘ dlo)) := by
+       (.x5 ↦ᵣ qDlo) ** (.x9 ↦ᵣ rhatUn1) ** (sp + signExtend12 3952 ↦ₘ dlo)) := by
   intro qDlo rhatHi rhatUn1 cr
-  have I0 := ld_spec_gen_within .x1 .x12 sp v1Old dlo 3952 base (by nofun)
-  have I1 := mul_spec_gen_within .x5 .x10 .x1 v5Old q dlo (base + 4) (by nofun)
-  have I2 := slli_spec_gen_within .x1 .x7 dlo rhat 32 (base + 8) (by nofun)
-  have I3 := or_spec_gen_rd_eq_rs1_within .x1 .x11 (rhat <<< (32 : BitVec 6).toNat) un1 (base + 12) (by nofun)
+  have I0 := ld_spec_gen_within .x9 .x12 sp v9Old dlo 3952 base (by nofun)
+  have I1 := mul_spec_gen_within .x5 .x10 .x9 v5Old q dlo (base + 4) (by nofun)
+  have I2 := slli_spec_gen_within .x9 .x7 dlo rhat 32 (base + 8) (by nofun)
+  have I3 := or_spec_gen_rd_eq_rs1_within .x9 .x11 (rhat <<< (32 : BitVec 6).toNat) un1 (base + 12) (by nofun)
   runBlock I0 I1 I2 I3
 
 /-- div128 correction: q-- and rhat += dHi. Generic for q1 (x10) or q0 (x5). -/

--- a/EvmAsm/Evm64/DivMod/LimbSpec/LoopSetup.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/LoopSetup.lean
@@ -36,16 +36,16 @@ theorem divK_loopSetup_body_spec_within (sp n v1 v5 : Word)
     let cr := divK_loopSetup_code bltOff base
     cpsTripleWithin 3 base (base + 12) cr
       (
-       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x1 ↦ᵣ v1) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x9 ↦ᵣ v1) ** (.x0 ↦ᵣ (0 : Word)) **
        ((sp + signExtend12 3984) ↦ₘ n))
       (
        (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ n) **
-       (.x1 ↦ᵣ (signExtend12 (4 : BitVec 12) - n)) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x9 ↦ᵣ (signExtend12 (4 : BitVec 12) - n)) ** (.x0 ↦ᵣ (0 : Word)) **
        ((sp + signExtend12 3984) ↦ₘ n)) := by
   intro cr
   have I0 := ld_spec_gen_within .x5 .x12 sp v5 n 3984 base (by nofun)
-  have I1 := addi_x0_spec_gen_within .x1 v1 4 (base + 4) (by nofun)
-  have I2 := sub_spec_gen_rd_eq_rs1_within .x1 .x5
+  have I1 := addi_x0_spec_gen_within .x9 v1 4 (base + 4) (by nofun)
+  have I2 := sub_spec_gen_rd_eq_rs1_within .x9 .x5
     (signExtend12 (4 : BitVec 12)) n (base + 8) (by nofun)
   runBlock I0 I1 I2
 
@@ -57,11 +57,11 @@ theorem divK_loopSetup_spec_within (sp n v1 v5 : Word)
     let m := signExtend12 (4 : BitVec 12) - n
     let cr := divK_loopSetup_code bltOff base
     let post :=
-      (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ n) ** (.x1 ↦ᵣ m) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ n) ** (.x9 ↦ᵣ m) ** (.x0 ↦ᵣ (0 : Word)) **
       ((sp + signExtend12 3984) ↦ₘ n)
     cpsBranchWithin 4 base cr
       (
-       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x1 ↦ᵣ v1) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x9 ↦ᵣ v1) ** (.x0 ↦ᵣ (0 : Word)) **
        ((sp + signExtend12 3984) ↦ₘ n))
       -- Taken: m < 0 (signed)
       ((base + 12) + signExtend13 bltOff) post
@@ -69,15 +69,15 @@ theorem divK_loopSetup_spec_within (sp n v1 v5 : Word)
       (base + 16) post := by
   intro m cr post
   have hbody := divK_loopSetup_body_spec_within sp n v1 v5 bltOff base
-  have hblt_raw := blt_spec_gen_within .x1 .x0 bltOff m (0 : Word) (base + 12)
+  have hblt_raw := blt_spec_gen_within .x9 .x0 bltOff m (0 : Word) (base + 12)
   have ha1 : (base + 12 : Word) + 4 = base + 16 := by bv_addr
   rw [ha1] at hblt_raw
   have hblt : cpsBranchWithin 1 (base + 12) _
-      ((.x1 ↦ᵣ m) ** (.x0 ↦ᵣ (0 : Word)))
+      ((.x9 ↦ᵣ m) ** (.x0 ↦ᵣ (0 : Word)))
       ((base + 12) + signExtend13 bltOff)
-        ((.x1 ↦ᵣ m) ** (.x0 ↦ᵣ (0 : Word)))
+        ((.x9 ↦ᵣ m) ** (.x0 ↦ᵣ (0 : Word)))
       (base + 16)
-        ((.x1 ↦ᵣ m) ** (.x0 ↦ᵣ (0 : Word))) :=
+        ((.x9 ↦ᵣ m) ** (.x0 ↦ᵣ (0 : Word))) :=
     cpsBranchWithin_weaken
       (fun _ hp => hp)
       (fun h hp => sepConj_mono_right

--- a/EvmAsm/Evm64/DivMod/LimbSpec/MulSubSetup.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/MulSubSetup.lean
@@ -28,29 +28,29 @@ namespace EvmAsm.Evm64
 open EvmAsm.Rv64
 
 /-- Mul-sub setup: restore j from scratch, compute uBase, zero carry. -/
-theorem divK_mulsub_setup_spec_within (sp qHat j v1Old v5Old v6Old v10Old : Word)
+theorem divK_mulsub_setup_spec_within (sp qHat j v9Old v5Old v6Old v10Old : Word)
     (base : Word) :
     let jX8 := j <<< (3 : BitVec 6).toNat
     let sp_m40 := sp + signExtend12 4056
     let uBase := sp_m40 - jX8
     let cr :=
-      CodeReq.union (CodeReq.singleton base (.LD .x1 .x12 3976))
-      (CodeReq.union (CodeReq.singleton (base + 4) (.SLLI .x5 .x1 3))
+      CodeReq.union (CodeReq.singleton base (.LD .x9 .x12 3976))
+      (CodeReq.union (CodeReq.singleton (base + 4) (.SLLI .x5 .x9 3))
       (CodeReq.union (CodeReq.singleton (base + 8) (.ADDI .x6 .x12 4056))
       (CodeReq.union (CodeReq.singleton (base + 12) (.SUB .x6 .x6 .x5))
        (CodeReq.singleton (base + 16) (.ADDI .x10 .x0 0)))))
     cpsTripleWithin 5 base (base + 20) cr
       ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
-       (.x1 ↦ᵣ v1Old) ** (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+       (.x9 ↦ᵣ v9Old) ** (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x10 ↦ᵣ v10Old) ** (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3976 ↦ₘ j))
       ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
-       (.x1 ↦ᵣ j) ** (.x5 ↦ᵣ jX8) ** (.x6 ↦ᵣ uBase) **
+       (.x9 ↦ᵣ j) ** (.x5 ↦ᵣ jX8) ** (.x6 ↦ᵣ uBase) **
        (.x10 ↦ᵣ signExtend12 0) ** (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3976 ↦ₘ j)) := by
   intro jX8 sp_m40 uBase cr
-  have I0 := ld_spec_gen_within .x1 .x12 sp v1Old j 3976 base (by nofun)
-  have I1 := slli_spec_gen_within .x5 .x1 v5Old j 3 (base + 4) (by nofun)
+  have I0 := ld_spec_gen_within .x9 .x12 sp v9Old j 3976 base (by nofun)
+  have I1 := slli_spec_gen_within .x5 .x9 v5Old j 3 (base + 4) (by nofun)
   have I2 := addi_spec_gen_within .x6 .x12 v6Old sp 4056 (base + 8) (by nofun)
   have I3 := sub_spec_gen_rd_eq_rs1_within .x6 .x5 sp_m40 jX8 (base + 12) (by nofun)
   have I4 := addi_x0_spec_gen_within .x10 v10Old 0 (base + 16) (by nofun)
@@ -58,12 +58,12 @@ theorem divK_mulsub_setup_spec_within (sp qHat j v1Old v5Old v6Old v10Old : Word
 
 /-- Save j to scratch memory. -/
 theorem divK_save_j_spec_within (sp j jOld : Word) (base : Word) :
-    let cr := CodeReq.singleton base (.SD .x12 .x1 3976)
+    let cr := CodeReq.singleton base (.SD .x12 .x9 3976)
     cpsTripleWithin 1 base (base + 4) cr
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) ** (sp + signExtend12 3976 ↦ₘ jOld))
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) ** (sp + signExtend12 3976 ↦ₘ j)) := by
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) ** (sp + signExtend12 3976 ↦ₘ jOld))
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) ** (sp + signExtend12 3976 ↦ₘ j)) := by
   intro cr
-  have I0 := sd_spec_gen_within .x12 .x1 sp j jOld 3976 base
+  have I0 := sd_spec_gen_within .x12 .x9 sp j jOld 3976 base
   runBlock I0
 
 /-- Initialize add-back carry to 0. -/

--- a/EvmAsm/Evm64/DivMod/LimbSpec/TrialStoreComposed.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/TrialStoreComposed.lean
@@ -38,7 +38,7 @@ theorem divK_trial_load_spec_within
     let vtopBase := sp + (n + signExtend12 4095) <<< (3 : BitVec 6).toNat
     let cr :=
       CodeReq.union (CodeReq.singleton base (.LD .x5 .x12 3984))
-      (CodeReq.union (CodeReq.singleton (base + 4) (.ADD .x7 .x1 .x5))
+      (CodeReq.union (CodeReq.singleton (base + 4) (.ADD .x7 .x9 .x5))
       (CodeReq.union (CodeReq.singleton (base + 8) (.SLLI .x7 .x7 3))
       (CodeReq.union (CodeReq.singleton (base + 12) (.ADDI .x5 .x12 4056))
       (CodeReq.union (CodeReq.singleton (base + 16) (.SUB .x5 .x5 .x7))
@@ -50,13 +50,13 @@ theorem divK_trial_load_spec_within
       (CodeReq.union (CodeReq.singleton (base + 40) (.ADD .x6 .x12 .x6))
        (CodeReq.singleton (base + 44) (.LD .x10 .x6 32))))))))))))
     cpsTripleWithin 12 base (base + 48) cr
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) **
        (sp + signExtend12 3984 ↦ₘ n) **
        (uAddr ↦ₘ uHi) ** ((uAddr + 8) ↦ₘ uLo) **
        (vtopBase + signExtend12 32 ↦ₘ vTop))
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
        (.x5 ↦ᵣ uLo) ** (.x6 ↦ᵣ vtopBase) **
        (.x7 ↦ᵣ uHi) ** (.x10 ↦ᵣ vTop) **
        (sp + signExtend12 3984 ↦ₘ n) **
@@ -68,7 +68,7 @@ theorem divK_trial_load_spec_within
   let u0_base := sp + signExtend12 4056
   have haddr0 : uAddr + signExtend12 (0 : BitVec 12) = uAddr := by rv64_addr
   have I0 := ld_spec_gen_within .x5 .x12 sp v5Old n 3984 base (by nofun)
-  have I1 := add_spec_gen_within .x7 .x1 .x5 j n v7Old (base + 4) (by nofun)
+  have I1 := add_spec_gen_within .x7 .x9 .x5 j n v7Old (base + 4) (by nofun)
   have I2 := slli_spec_gen_same_within .x7 jpn 3 (base + 8) (by nofun)
   have I3 := addi_spec_gen_within .x5 .x12 n sp 4056 (base + 12) (by nofun)
   have I4 := sub_spec_gen_rd_eq_rs1_within .x5 .x7 u0_base jpnX8 (base + 16) (by nofun)
@@ -91,19 +91,19 @@ theorem divK_store_qj_spec_within (sp j qHat v5Old v7Old qOld : Word)
     let jX8 := j <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - jX8
     let cr :=
-      CodeReq.union (CodeReq.singleton base (.SLLI .x5 .x1 3))
+      CodeReq.union (CodeReq.singleton base (.SLLI .x5 .x9 3))
       (CodeReq.union (CodeReq.singleton (base + 4) (.ADDI .x7 .x12 4088))
       (CodeReq.union (CodeReq.singleton (base + 8) (.SUB .x7 .x7 .x5))
        (CodeReq.singleton (base + 12) (.SD .x7 .x11 0))))
     cpsTripleWithin 4 base (base + 16) cr
-      ((.x1 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+      ((.x9 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
        (.x5 ↦ᵣ v5Old) ** (.x7 ↦ᵣ v7Old) **
        (qAddr ↦ₘ qOld))
-      ((.x1 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+      ((.x9 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
        (.x5 ↦ᵣ jX8) ** (.x7 ↦ᵣ qAddr) **
        (qAddr ↦ₘ qHat)) := by
   intro jX8 qAddr cr
-  have I0 := slli_spec_gen_within .x5 .x1 v5Old j 3 base (by nofun)
+  have I0 := slli_spec_gen_within .x5 .x9 v5Old j 3 base (by nofun)
   have I1 := addi_spec_gen_within .x7 .x12 v7Old sp 4088 (base + 4) (by nofun)
   have I2 := sub_spec_gen_rd_eq_rs1_within .x7 .x5 (sp + signExtend12 4088) jX8 (base + 8) (by nofun)
   have haddr : qAddr + signExtend12 (0 : BitVec 12) = qAddr := by rv64_addr

--- a/EvmAsm/Evm64/DivMod/LoopBody.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody.lean
@@ -618,7 +618,7 @@ set_option maxRecDepth 4096 in
     Entry: base+516, Exit: base+728, CodeReq: sharedDivModCode base. -/
 private theorem divK_mulsub_full_spec_within_of_sub
     (sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
-    (v1Old v5Old v6Old v7Old v10Old v2Old : Word)
+    (v9Old v5Old v6Old v7Old v10Old v2Old : Word)
     (base : Word)
     (code : CodeReq)
     (hsub : ∀ (k : Nat) (addr : Word) (instr : Instr)
@@ -665,7 +665,7 @@ private theorem divK_mulsub_full_spec_within_of_sub
     let u4_new := uTop - c3
     cpsTripleWithin 53 (base + div128CallRetOff) (base + correctionSkipBeqOff) code
       ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
-       (.x1 ↦ᵣ v1Old) ** (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+       (.x9 ↦ᵣ v9Old) ** (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x2 ↦ᵣ v2Old) **
        (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3976 ↦ₘ j) **
@@ -675,7 +675,7 @@ private theorem divK_mulsub_full_spec_within_of_sub
        ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
        ((uBase + signExtend12 4064) ↦ₘ uTop))
       ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
-       (.x1 ↦ᵣ j) ** (.x5 ↦ᵣ u4_new) ** (.x6 ↦ᵣ uBase) **
+       (.x9 ↦ᵣ j) ** (.x5 ↦ᵣ u4_new) ** (.x6 ↦ᵣ uBase) **
        (.x7 ↦ᵣ borrow) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
        (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3976 ↦ₘ j) **
@@ -691,7 +691,7 @@ private theorem divK_mulsub_full_spec_within_of_sub
         p3_lo p3_hi fs3 ba3 pc3 bs3 un3 c3
         borrow u4_new
   -- 1. Mulsub setup: instrs [17]-[21] at base+516
-  have S := divK_mulsub_setup_spec_within sp qHat j v1Old v5Old v6Old v10Old (base + div128CallRetOff)
+  have S := divK_mulsub_setup_spec_within sp qHat j v9Old v5Old v6Old v10Old (base + div128CallRetOff)
   rw [lb_ms_setup] at S
   have Se := cpsTripleWithin_extend_code (hmono := by
     exact CodeReq.union_sub (hsub 17 _ _ (by decide) (by bv_addr) (by decide))
@@ -732,7 +732,7 @@ private theorem divK_mulsub_full_spec_within_of_sub
 
 theorem divK_mulsub_full_spec_within
     (sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
-    (v1Old v5Old v6Old v7Old v10Old v2Old : Word)
+    (v9Old v5Old v6Old v7Old v10Old v2Old : Word)
     (base : Word) :
     let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
     let p0_lo := qHat * v0
@@ -771,7 +771,7 @@ theorem divK_mulsub_full_spec_within
     let u4_new := uTop - c3
     cpsTripleWithin 53 (base + div128CallRetOff) (base + correctionSkipBeqOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
-       (.x1 ↦ᵣ v1Old) ** (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+       (.x9 ↦ᵣ v9Old) ** (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x2 ↦ᵣ v2Old) **
        (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3976 ↦ₘ j) **
@@ -781,7 +781,7 @@ theorem divK_mulsub_full_spec_within
        ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
        ((uBase + signExtend12 4064) ↦ₘ uTop))
       ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
-       (.x1 ↦ᵣ j) ** (.x5 ↦ᵣ u4_new) ** (.x6 ↦ᵣ uBase) **
+       (.x9 ↦ᵣ j) ** (.x5 ↦ᵣ u4_new) ** (.x6 ↦ᵣ uBase) **
        (.x7 ↦ᵣ borrow) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
        (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3976 ↦ₘ j) **
@@ -791,12 +791,12 @@ theorem divK_mulsub_full_spec_within
        ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3) **
        ((uBase + signExtend12 4064) ↦ₘ u4_new)) :=
   divK_mulsub_full_spec_within_of_sub sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    v1Old v5Old v6Old v7Old v10Old v2Old base (sharedDivModCode base) lb_sub
+    v9Old v5Old v6Old v7Old v10Old v2Old base (sharedDivModCode base) lb_sub
 
 /-- `divK_mulsub_full_spec_within` replayed over the DIV no-NOP code surface. -/
 theorem divK_mulsub_full_spec_within_noNop
     (sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
-    (v1Old v5Old v6Old v7Old v10Old v2Old : Word)
+    (v9Old v5Old v6Old v7Old v10Old v2Old : Word)
     (base : Word) :
     let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
     let p0_lo := qHat * v0
@@ -835,7 +835,7 @@ theorem divK_mulsub_full_spec_within_noNop
     let u4_new := uTop - c3
     cpsTripleWithin 53 (base + div128CallRetOff) (base + correctionSkipBeqOff) (divCode_noNop base)
       ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
-       (.x1 ↦ᵣ v1Old) ** (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+       (.x9 ↦ᵣ v9Old) ** (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x2 ↦ᵣ v2Old) **
        (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3976 ↦ₘ j) **
@@ -845,7 +845,7 @@ theorem divK_mulsub_full_spec_within_noNop
        ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
        ((uBase + signExtend12 4064) ↦ₘ uTop))
       ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
-       (.x1 ↦ᵣ j) ** (.x5 ↦ᵣ u4_new) ** (.x6 ↦ᵣ uBase) **
+       (.x9 ↦ᵣ j) ** (.x5 ↦ᵣ u4_new) ** (.x6 ↦ᵣ uBase) **
        (.x7 ↦ᵣ borrow) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
        (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3976 ↦ₘ j) **
@@ -855,7 +855,7 @@ theorem divK_mulsub_full_spec_within_noNop
        ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3) **
        ((uBase + signExtend12 4064) ↦ₘ u4_new)) :=
   divK_mulsub_full_spec_within_of_sub sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    v1Old v5Old v6Old v7Old v10Old v2Old base (divCode_noNop base) lb_sub_noNop
+    v9Old v5Old v6Old v7Old v10Old v2Old base (divCode_noNop base) lb_sub_noNop
 
 theorem lb_beq_taken {base : Word} : (base + correctionSkipBeqOff : Word) + signExtend13 (156 : BitVec 13) = base + storeLoopOff := by
   rv64_addr
@@ -1041,14 +1041,14 @@ theorem divK_save_trial_load_spec_within
     let uAddr := sp + signExtend12 4056 - (j + n) <<< (3 : BitVec 6).toNat
     let vtopBase := sp + (n + signExtend12 4095) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 13 (base + loopBodyOff) (base + trialCallOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) **
        (sp + signExtend12 3976 ↦ₘ jOld) **
        (sp + signExtend12 3984 ↦ₘ n) **
        (uAddr ↦ₘ uHi) ** ((uAddr + 8) ↦ₘ uLo) **
        (vtopBase + signExtend12 32 ↦ₘ vTop))
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
        (.x5 ↦ᵣ uLo) ** (.x6 ↦ᵣ vtopBase) **
        (.x7 ↦ᵣ uHi) ** (.x10 ↦ᵣ vTop) **
        (sp + signExtend12 3976 ↦ₘ j) **
@@ -1103,14 +1103,14 @@ theorem divK_save_trial_load_spec_within_noNop
     let uAddr := sp + signExtend12 4056 - (j + n) <<< (3 : BitVec 6).toNat
     let vtopBase := sp + (n + signExtend12 4095) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 13 (base + loopBodyOff) (base + trialCallOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) **
        (sp + signExtend12 3976 ↦ₘ jOld) **
        (sp + signExtend12 3984 ↦ₘ n) **
        (uAddr ↦ₘ uHi) ** ((uAddr + 8) ↦ₘ uLo) **
        (vtopBase + signExtend12 32 ↦ₘ vTop))
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
        (.x5 ↦ᵣ uLo) ** (.x6 ↦ᵣ vtopBase) **
        (.x7 ↦ᵣ uHi) ** (.x10 ↦ᵣ vTop) **
        (sp + signExtend12 3976 ↦ₘ j) **

--- a/EvmAsm/Evm64/DivMod/LoopBody/CorrectionAddbackBeq.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody/CorrectionAddbackBeq.lean
@@ -60,7 +60,7 @@ theorem divK_mulsub_correction_addback_beq_spec_within
     (if BitVec.ult uTop c3 then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTripleWithin 130 (base + div128CallRetOff) (base + storeLoopOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
-       (.x1 ↦ᵣ v1Old) ** (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+       (.x9 ↦ᵣ v1Old) ** (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x2 ↦ᵣ v2Old) **
        (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3976 ↦ₘ j) **
@@ -70,7 +70,7 @@ theorem divK_mulsub_correction_addback_beq_spec_within
        ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
        ((uBase + signExtend12 4064) ↦ₘ uTop))
       ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_out) **
-       (.x1 ↦ᵣ j) ** (.x5 ↦ᵣ u4_out) ** (.x6 ↦ᵣ uBase) **
+       (.x9 ↦ᵣ j) ** (.x5 ↦ᵣ u4_out) ** (.x6 ↦ᵣ uBase) **
        (.x7 ↦ᵣ carryOut) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
        (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3976 ↦ₘ j) **
@@ -114,7 +114,7 @@ theorem divK_mulsub_correction_addback_beq_spec_within
     simp only [n4DoubleAddbackNamedPost_unfold] at DA
     -- Frame DA with extra atoms from MCA_N postcondition
     have DAf := cpsTripleWithin_frameR
-      ((.x1 ↦ᵣ j) ** (.x10 ↦ᵣ c3) **
+      ((.x9 ↦ᵣ j) ** (.x10 ↦ᵣ c3) **
        (sp + signExtend12 3976 ↦ₘ j))
       (by pcFree) DA
     -- Compose MCA_N(→880) with DAf(880→884)
@@ -165,7 +165,7 @@ theorem divK_mulsub_correction_addback_beq_spec_within_noNop
     (if BitVec.ult uTop c3 then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTripleWithin 130 (base + div128CallRetOff) (base + storeLoopOff) (divCode_noNop base)
       ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
-       (.x1 ↦ᵣ v1Old) ** (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+       (.x9 ↦ᵣ v1Old) ** (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x2 ↦ᵣ v2Old) **
        (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3976 ↦ₘ j) **
@@ -175,7 +175,7 @@ theorem divK_mulsub_correction_addback_beq_spec_within_noNop
        ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
        ((uBase + signExtend12 4064) ↦ₘ uTop))
       ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_out) **
-       (.x1 ↦ᵣ j) ** (.x5 ↦ᵣ u4_out) ** (.x6 ↦ᵣ uBase) **
+       (.x9 ↦ᵣ j) ** (.x5 ↦ᵣ u4_out) ** (.x6 ↦ᵣ uBase) **
        (.x7 ↦ᵣ carryOut) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
        (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3976 ↦ₘ j) **
@@ -219,7 +219,7 @@ theorem divK_mulsub_correction_addback_beq_spec_within_noNop
     rw [n4DoubleAddbackNamedPost_unfold] at DA
     -- Frame DA with extra atoms from MCA_N postcondition
     have DAf := cpsTripleWithin_frameR
-      ((.x1 ↦ᵣ j) ** (.x10 ↦ᵣ c3) **
+      ((.x9 ↦ᵣ j) ** (.x10 ↦ᵣ c3) **
        (sp + signExtend12 3976 ↦ₘ j))
       (by pcFree) DA
     -- Compose MCA_N(->880) with DAf(880->884)

--- a/EvmAsm/Evm64/DivMod/LoopBody/CorrectionAddbackBeqNamed.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody/CorrectionAddbackBeqNamed.lean
@@ -32,7 +32,7 @@ def n4McaBeqPost (sp uBase qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
   let carryOut := if carry = 0 then addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
                   else carry
   (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_out) **
-  (.x1 ↦ᵣ j) ** (.x5 ↦ᵣ u4_out) ** (.x6 ↦ᵣ uBase) **
+  (.x9 ↦ᵣ j) ** (.x5 ↦ᵣ u4_out) ** (.x6 ↦ᵣ uBase) **
   (.x7 ↦ᵣ carryOut) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
   (.x0 ↦ᵣ 0) **
   (sp + signExtend12 3976 ↦ₘ j) **
@@ -59,7 +59,7 @@ theorem n4McaBeqPost_unfold {sp uBase qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word
        let carryOut := if carry = 0 then addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
                        else carry
        (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_out) **
-       (.x1 ↦ᵣ j) ** (.x5 ↦ᵣ u4_out) ** (.x6 ↦ᵣ uBase) **
+       (.x9 ↦ᵣ j) ** (.x5 ↦ᵣ u4_out) ** (.x6 ↦ᵣ uBase) **
        (.x7 ↦ᵣ carryOut) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
        (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3976 ↦ₘ j) **
@@ -86,7 +86,7 @@ theorem divK_mulsub_correction_addback_beq_named_spec_within
     (if BitVec.ult uTop c3 then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTripleWithin 130 (base + div128CallRetOff) (base + storeLoopOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
-       (.x1 ↦ᵣ v1Old) ** (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+       (.x9 ↦ᵣ v1Old) ** (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x2 ↦ᵣ v2Old) **
        (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3976 ↦ₘ j) **
@@ -117,7 +117,7 @@ theorem divK_mulsub_correction_addback_beq_named_spec_within_noNop
     (if BitVec.ult uTop c3 then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTripleWithin 130 (base + div128CallRetOff) (base + storeLoopOff) (divCode_noNop base)
       ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
-       (.x1 ↦ᵣ v1Old) ** (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+       (.x9 ↦ᵣ v1Old) ** (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x2 ↦ᵣ v2Old) **
        (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3976 ↦ₘ j) **

--- a/EvmAsm/Evm64/DivMod/LoopBody/MulsubCorrectionAddback.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody/MulsubCorrectionAddback.lean
@@ -129,7 +129,7 @@ private theorem divK_mulsub_correction_addback_880_spec_within
     (if BitVec.ult uTop c3 then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTripleWithin 91 (base + div128CallRetOff) (base + addbackBeqOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
-       (.x1 ↦ᵣ v1Old) ** (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+       (.x9 ↦ᵣ v1Old) ** (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x2 ↦ᵣ v2Old) **
        (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3976 ↦ₘ j) **
@@ -139,7 +139,7 @@ private theorem divK_mulsub_correction_addback_880_spec_within
        ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
        ((uBase + signExtend12 4064) ↦ₘ uTop))
       ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat') **
-       (.x1 ↦ᵣ j) ** (.x5 ↦ᵣ aun4) ** (.x6 ↦ᵣ uBase) **
+       (.x9 ↦ᵣ j) ** (.x5 ↦ᵣ aun4) ** (.x6 ↦ᵣ uBase) **
        (.x7 ↦ᵣ aco3) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ aun3) **
        (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3976 ↦ₘ j) **
@@ -233,7 +233,7 @@ private theorem divK_mulsub_correction_addback_880_spec_within_noNop
     (if BitVec.ult uTop c3 then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTripleWithin 91 (base + div128CallRetOff) (base + addbackBeqOff) (divCode_noNop base)
       ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
-       (.x1 ↦ᵣ v1Old) ** (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+       (.x9 ↦ᵣ v1Old) ** (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x2 ↦ᵣ v2Old) **
        (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3976 ↦ₘ j) **
@@ -243,7 +243,7 @@ private theorem divK_mulsub_correction_addback_880_spec_within_noNop
        ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
        ((uBase + signExtend12 4064) ↦ₘ uTop))
       ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat') **
-       (.x1 ↦ᵣ j) ** (.x5 ↦ᵣ aun4) ** (.x6 ↦ᵣ uBase) **
+       (.x9 ↦ᵣ j) ** (.x5 ↦ᵣ aun4) ** (.x6 ↦ᵣ uBase) **
        (.x7 ↦ᵣ aco3) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ aun3) **
        (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3976 ↦ₘ j) **
@@ -291,7 +291,7 @@ def n4McaNamed880Post
   let ab    := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
   let qHat' := qHat + signExtend12 4095
   (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat') **
-  (.x1 ↦ᵣ j) ** (.x5 ↦ᵣ ab.2.2.2.2) ** (.x6 ↦ᵣ uBase) **
+  (.x9 ↦ᵣ j) ** (.x5 ↦ᵣ ab.2.2.2.2) ** (.x6 ↦ᵣ uBase) **
   (.x7 ↦ᵣ addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3) **
   (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ ab.2.2.2.1) **
   (.x0 ↦ᵣ 0) **
@@ -311,7 +311,7 @@ theorem n4McaNamed880Post_unfold
        let ab    := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
        let qHat' := qHat + signExtend12 4095
        (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat') **
-       (.x1 ↦ᵣ j) ** (.x5 ↦ᵣ ab.2.2.2.2) ** (.x6 ↦ᵣ uBase) **
+       (.x9 ↦ᵣ j) ** (.x5 ↦ᵣ ab.2.2.2.2) ** (.x6 ↦ᵣ uBase) **
        (.x7 ↦ᵣ addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3) **
        (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ ab.2.2.2.1) **
        (.x0 ↦ᵣ 0) **
@@ -335,7 +335,7 @@ theorem divK_mulsub_correction_addback_named_880_spec_within
       (0 : Word) →
     cpsTripleWithin 91 (base + div128CallRetOff) (base + addbackBeqOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
-       (.x1 ↦ᵣ v1Old) ** (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+       (.x9 ↦ᵣ v1Old) ** (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x2 ↦ᵣ v2Old) **
        (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3976 ↦ₘ j) **
@@ -365,7 +365,7 @@ theorem divK_mulsub_correction_addback_named_880_spec_within_noNop
       (0 : Word) →
     cpsTripleWithin 91 (base + div128CallRetOff) (base + addbackBeqOff) (divCode_noNop base)
       ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
-       (.x1 ↦ᵣ v1Old) ** (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+       (.x9 ↦ᵣ v1Old) ** (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x2 ↦ᵣ v2Old) **
        (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3976 ↦ₘ j) **
@@ -445,7 +445,7 @@ theorem divK_mulsub_correction_addback_spec_within
     aco3 ≠ 0 →
     cpsTripleWithin 92 (base + div128CallRetOff) (base + storeLoopOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
-       (.x1 ↦ᵣ v1Old) ** (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+       (.x9 ↦ᵣ v1Old) ** (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x2 ↦ᵣ v2Old) **
        (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3976 ↦ₘ j) **
@@ -455,7 +455,7 @@ theorem divK_mulsub_correction_addback_spec_within
        ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
        ((uBase + signExtend12 4064) ↦ₘ uTop))
       ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat') **
-       (.x1 ↦ᵣ j) ** (.x5 ↦ᵣ aun4) ** (.x6 ↦ᵣ uBase) **
+       (.x9 ↦ᵣ j) ** (.x5 ↦ᵣ aun4) ** (.x6 ↦ᵣ uBase) **
        (.x7 ↦ᵣ aco3) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ aun3) **
        (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3976 ↦ₘ j) **
@@ -481,7 +481,7 @@ theorem divK_mulsub_correction_addback_spec_within
   -- 2. Frame BEQ with remaining atoms and compose (880→884)
   have BEQf := cpsTripleWithin_frameR
     ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat') **
-     (.x1 ↦ᵣ j) ** (.x5 ↦ᵣ aun4) ** (.x6 ↦ᵣ uBase) **
+     (.x9 ↦ᵣ j) ** (.x5 ↦ᵣ aun4) ** (.x6 ↦ᵣ uBase) **
      (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ aun3) **
      (sp + signExtend12 3976 ↦ₘ j) **
      ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ aun0) **
@@ -558,7 +558,7 @@ theorem divK_mulsub_correction_addback_spec_within_noNop
     aco3 ≠ 0 →
     cpsTripleWithin 92 (base + div128CallRetOff) (base + storeLoopOff) (divCode_noNop base)
       ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
-       (.x1 ↦ᵣ v1Old) ** (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+       (.x9 ↦ᵣ v1Old) ** (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x2 ↦ᵣ v2Old) **
        (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3976 ↦ₘ j) **
@@ -568,7 +568,7 @@ theorem divK_mulsub_correction_addback_spec_within_noNop
        ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
        ((uBase + signExtend12 4064) ↦ₘ uTop))
       ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat') **
-       (.x1 ↦ᵣ j) ** (.x5 ↦ᵣ aun4) ** (.x6 ↦ᵣ uBase) **
+       (.x9 ↦ᵣ j) ** (.x5 ↦ᵣ aun4) ** (.x6 ↦ᵣ uBase) **
        (.x7 ↦ᵣ aco3) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ aun3) **
        (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3976 ↦ₘ j) **
@@ -594,7 +594,7 @@ theorem divK_mulsub_correction_addback_spec_within_noNop
   -- 2. Frame BEQ with remaining atoms and compose (880→884)
   have BEQf := cpsTripleWithin_frameR
     ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat') **
-     (.x1 ↦ᵣ j) ** (.x5 ↦ᵣ aun4) ** (.x6 ↦ᵣ uBase) **
+     (.x9 ↦ᵣ j) ** (.x5 ↦ᵣ aun4) ** (.x6 ↦ᵣ uBase) **
      (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ aun3) **
      (sp + signExtend12 3976 ↦ₘ j) **
      ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ aun0) **

--- a/EvmAsm/Evm64/DivMod/LoopBody/MulsubCorrectionSkip.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody/MulsubCorrectionSkip.lean
@@ -58,7 +58,7 @@ theorem divK_mulsub_correction_skip_spec_within
     (if BitVec.ult uTop c3 then (1 : Word) else 0) = (0 : Word) →
     cpsTripleWithin 54 (base + div128CallRetOff) (base + storeLoopOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
-       (.x1 ↦ᵣ v1Old) ** (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+       (.x9 ↦ᵣ v1Old) ** (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x2 ↦ᵣ v2Old) **
        (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3976 ↦ₘ j) **
@@ -68,7 +68,7 @@ theorem divK_mulsub_correction_skip_spec_within
        ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
        ((uBase + signExtend12 4064) ↦ₘ uTop))
       ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
-       (.x1 ↦ᵣ j) ** (.x5 ↦ᵣ u4_new) ** (.x6 ↦ᵣ uBase) **
+       (.x9 ↦ᵣ j) ** (.x5 ↦ᵣ u4_new) ** (.x6 ↦ᵣ uBase) **
        (.x7 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
        (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3976 ↦ₘ j) **
@@ -138,7 +138,7 @@ theorem divK_mulsub_correction_skip_spec_within_noNop
     (if BitVec.ult uTop c3 then (1 : Word) else 0) = (0 : Word) →
     cpsTripleWithin 54 (base + div128CallRetOff) (base + storeLoopOff) (divCode_noNop base)
       ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
-       (.x1 ↦ᵣ v1Old) ** (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+       (.x9 ↦ᵣ v1Old) ** (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x2 ↦ᵣ v2Old) **
        (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3976 ↦ₘ j) **
@@ -148,7 +148,7 @@ theorem divK_mulsub_correction_skip_spec_within_noNop
        ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
        ((uBase + signExtend12 4064) ↦ₘ uTop))
       ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
-       (.x1 ↦ᵣ j) ** (.x5 ↦ᵣ u4_new) ** (.x6 ↦ᵣ uBase) **
+       (.x9 ↦ᵣ j) ** (.x5 ↦ᵣ u4_new) ** (.x6 ↦ᵣ uBase) **
        (.x7 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
        (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3976 ↦ₘ j) **
@@ -186,7 +186,7 @@ def n4McaNamedSkipPost
   let c3    := ms.2.2.2.2
   let u4_new := uTop - c3
   (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
-  (.x1 ↦ᵣ j) ** (.x5 ↦ᵣ u4_new) ** (.x6 ↦ᵣ uBase) **
+  (.x9 ↦ᵣ j) ** (.x5 ↦ᵣ u4_new) ** (.x6 ↦ᵣ uBase) **
   (.x7 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ ms.2.2.2.1) **
   (.x0 ↦ᵣ 0) **
   (sp + signExtend12 3976 ↦ₘ j) **
@@ -204,7 +204,7 @@ theorem n4McaNamedSkipPost_unfold
        let c3    := ms.2.2.2.2
        let u4_new := uTop - c3
        (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
-       (.x1 ↦ᵣ j) ** (.x5 ↦ᵣ u4_new) ** (.x6 ↦ᵣ uBase) **
+       (.x9 ↦ᵣ j) ** (.x5 ↦ᵣ u4_new) ** (.x6 ↦ᵣ uBase) **
        (.x7 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ ms.2.2.2.1) **
        (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3976 ↦ₘ j) **
@@ -229,7 +229,7 @@ theorem divK_mulsub_correction_skip_named_spec_within_noNop
     (if BitVec.ult uTop c3 then (1 : Word) else 0) = (0 : Word) →
     cpsTripleWithin 54 (base + div128CallRetOff) (base + storeLoopOff) (divCode_noNop base)
       ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
-       (.x1 ↦ᵣ v1Old) ** (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+       (.x9 ↦ᵣ v1Old) ** (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x2 ↦ᵣ v2Old) **
        (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3976 ↦ₘ j) **

--- a/EvmAsm/Evm64/DivMod/LoopBody/MulsubFull.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody/MulsubFull.lean
@@ -38,7 +38,7 @@ def mulsubFullPost (sp uBase qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
   let borrow := if BitVec.ult uTop c3 then (1 : Word) else 0
   let u4_new := uTop - c3
   (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
-  (.x1 ↦ᵣ j) ** (.x5 ↦ᵣ u4_new) ** (.x6 ↦ᵣ uBase) **
+  (.x9 ↦ᵣ j) ** (.x5 ↦ᵣ u4_new) ** (.x6 ↦ᵣ uBase) **
   (.x7 ↦ᵣ borrow) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
   (.x0 ↦ᵣ (0 : Word)) **
   (sp + signExtend12 3976 ↦ₘ j) **

--- a/EvmAsm/Evm64/DivMod/LoopBody/StoreLoop.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody/StoreLoop.lean
@@ -37,10 +37,10 @@ theorem divK_store_loop_j0_spec_within
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     let j' := (0 : Word) + signExtend12 4095
     cpsTripleWithin 6 (base + storeLoopOff) (base + denormOff) (sharedDivModCode base)
-      ((.x1 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+      ((.x9 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
        (.x5 ↦ᵣ v5Old) ** (.x7 ↦ᵣ v7Old) ** (.x0 ↦ᵣ (0 : Word)) **
        (qAddr ↦ₘ qOld))
-      ((.x1 ↦ᵣ j') ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+      ((.x9 ↦ᵣ j') ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
        (.x5 ↦ᵣ (0 : Word) <<< (3 : BitVec 6).toNat) ** (.x7 ↦ᵣ qAddr) ** (.x0 ↦ᵣ (0 : Word)) **
        (qAddr ↦ₘ qHat)) := by
   intro qAddr j'
@@ -54,12 +54,12 @@ theorem divK_store_loop_j0_spec_within
      (CodeReq.union_sub (lb_sub 111 _ _ (by decide) (by bv_addr) (by decide))
       (lb_sub 112 _ _ (by decide) (by bv_addr) (by decide))))) SQ
   -- 2. ADDI x1 x1 4095 at base+900 (instr [113])
-  have haddi := addi_spec_gen_same_within .x1 (0 : Word) 4095 (base + loopControlOff) (by nofun)
+  have haddi := addi_spec_gen_same_within .x9 (0 : Word) 4095 (base + loopControlOff) (by nofun)
   rw [show (base + loopControlOff : Word) + 4 = base + loopBackBgeOff from by bv_addr] at haddi
   have haddi_e := cpsTripleWithin_extend_code (hmono := by
     exact lb_sub 113 _ _ (by decide) (by bv_addr) (by decide)) haddi
   -- 3. BGE x1 x0 7736 at base+904 (instr [114])
-  have hbge_raw := bge_spec_gen_within .x1 .x0 (7736 : BitVec 13) j' (0 : Word) (base + loopBackBgeOff)
+  have hbge_raw := bge_spec_gen_within .x9 .x0 (7736 : BitVec 13) j' (0 : Word) (base + loopBackBgeOff)
   rw [show (base + loopBackBgeOff : Word) + signExtend13 (7736 : BitVec 13) = base + loopBodyOff from by rv64_addr,
       show (base + loopBackBgeOff : Word) + 4 = base + denormOff from by bv_addr] at hbge_raw
   have hbge_ext := cpsBranchWithin_extend_code (hmono := by
@@ -77,9 +77,9 @@ theorem divK_store_loop_j0_spec_within
     hbge_exit_raw
   -- 5. Build store_qj + x0 frame → base+900
   have SQx0 : cpsTripleWithin 4 (base + storeLoopOff) (base + loopControlOff) (sharedDivModCode base)
-      ((.x1 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+      ((.x9 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
        (.x5 ↦ᵣ v5Old) ** (.x7 ↦ᵣ v7Old) ** (.x0 ↦ᵣ (0 : Word)) ** (qAddr ↦ₘ qOld))
-      ((.x1 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+      ((.x9 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
        (.x5 ↦ᵣ (0 : Word) <<< (3 : BitVec 6).toNat) ** (.x7 ↦ᵣ qAddr) **
        (.x0 ↦ᵣ (0 : Word)) ** (qAddr ↦ₘ qHat)) :=
     cpsTripleWithin_weaken
@@ -114,10 +114,10 @@ theorem divK_store_loop_j0_spec_within_noNop
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     let j' := (0 : Word) + signExtend12 4095
     cpsTripleWithin 6 (base + storeLoopOff) (base + denormOff) (divCode_noNop base)
-      ((.x1 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+      ((.x9 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
        (.x5 ↦ᵣ v5Old) ** (.x7 ↦ᵣ v7Old) ** (.x0 ↦ᵣ (0 : Word)) **
        (qAddr ↦ₘ qOld))
-      ((.x1 ↦ᵣ j') ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+      ((.x9 ↦ᵣ j') ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
        (.x5 ↦ᵣ (0 : Word) <<< (3 : BitVec 6).toNat) ** (.x7 ↦ᵣ qAddr) ** (.x0 ↦ᵣ (0 : Word)) **
        (qAddr ↦ₘ qHat)) := by
   intro qAddr j'
@@ -131,12 +131,12 @@ theorem divK_store_loop_j0_spec_within_noNop
      (CodeReq.union_sub (lb_sub_noNop 111 _ _ (by decide) (by bv_addr) (by decide))
       (lb_sub_noNop 112 _ _ (by decide) (by bv_addr) (by decide))))) SQ
   -- 2. ADDI x1 x1 4095 at base+900 (instr [113])
-  have haddi := addi_spec_gen_same_within .x1 (0 : Word) 4095 (base + loopControlOff) (by nofun)
+  have haddi := addi_spec_gen_same_within .x9 (0 : Word) 4095 (base + loopControlOff) (by nofun)
   rw [show (base + loopControlOff : Word) + 4 = base + loopBackBgeOff from by bv_addr] at haddi
   have haddi_e := cpsTripleWithin_extend_code (hmono := by
     exact lb_sub_noNop 113 _ _ (by decide) (by bv_addr) (by decide)) haddi
   -- 3. BGE x1 x0 7736 at base+904 (instr [114])
-  have hbge_raw := bge_spec_gen_within .x1 .x0 (7736 : BitVec 13) j' (0 : Word) (base + loopBackBgeOff)
+  have hbge_raw := bge_spec_gen_within .x9 .x0 (7736 : BitVec 13) j' (0 : Word) (base + loopBackBgeOff)
   rw [show (base + loopBackBgeOff : Word) + signExtend13 (7736 : BitVec 13) = base + loopBodyOff from by rv64_addr,
       show (base + loopBackBgeOff : Word) + 4 = base + denormOff from by bv_addr] at hbge_raw
   have hbge_ext := cpsBranchWithin_extend_code (hmono := by
@@ -154,9 +154,9 @@ theorem divK_store_loop_j0_spec_within_noNop
     hbge_exit_raw
   -- 5. Build store_qj + x0 frame → base+900
   have SQx0 : cpsTripleWithin 4 (base + storeLoopOff) (base + loopControlOff) (divCode_noNop base)
-      ((.x1 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+      ((.x9 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
        (.x5 ↦ᵣ v5Old) ** (.x7 ↦ᵣ v7Old) ** (.x0 ↦ᵣ (0 : Word)) ** (qAddr ↦ₘ qOld))
-      ((.x1 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+      ((.x9 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
        (.x5 ↦ᵣ (0 : Word) <<< (3 : BitVec 6).toNat) ** (.x7 ↦ᵣ qAddr) **
        (.x0 ↦ᵣ (0 : Word)) ** (qAddr ↦ₘ qHat)) :=
     cpsTripleWithin_weaken
@@ -192,10 +192,10 @@ theorem divK_store_loop_jgt0_spec_within
     let qAddr := sp + signExtend12 4088 - jX8
     let j' := j + signExtend12 4095
     cpsTripleWithin 6 (base + storeLoopOff) (base + loopBodyOff) (sharedDivModCode base)
-      ((.x1 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+      ((.x9 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
        (.x5 ↦ᵣ v5Old) ** (.x7 ↦ᵣ v7Old) ** (.x0 ↦ᵣ (0 : Word)) **
        (qAddr ↦ₘ qOld))
-      ((.x1 ↦ᵣ j') ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+      ((.x9 ↦ᵣ j') ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
        (.x5 ↦ᵣ jX8) ** (.x7 ↦ᵣ qAddr) ** (.x0 ↦ᵣ (0 : Word)) **
        (qAddr ↦ₘ qHat)) := by
   intro jX8 qAddr j'
@@ -209,12 +209,12 @@ theorem divK_store_loop_jgt0_spec_within
      (CodeReq.union_sub (lb_sub 111 _ _ (by decide) (by bv_addr) (by decide))
       (lb_sub 112 _ _ (by decide) (by bv_addr) (by decide))))) SQ
   -- 2. ADDI x1 x1 4095 at base+900 (instr [113])
-  have haddi := addi_spec_gen_same_within .x1 j 4095 (base + loopControlOff) (by nofun)
+  have haddi := addi_spec_gen_same_within .x9 j 4095 (base + loopControlOff) (by nofun)
   rw [show (base + loopControlOff : Word) + 4 = base + loopBackBgeOff from by bv_addr] at haddi
   have haddi_e := cpsTripleWithin_extend_code (hmono := by
     exact lb_sub 113 _ _ (by decide) (by bv_addr) (by decide)) haddi
   -- 3. BGE x1 x0 7736 at base+904 (instr [114])
-  have hbge_raw := bge_spec_gen_within .x1 .x0 (7736 : BitVec 13) j' (0 : Word) (base + loopBackBgeOff)
+  have hbge_raw := bge_spec_gen_within .x9 .x0 (7736 : BitVec 13) j' (0 : Word) (base + loopBackBgeOff)
   rw [show (base + loopBackBgeOff : Word) + signExtend13 (7736 : BitVec 13) = base + loopBodyOff from by rv64_addr,
       show (base + loopBackBgeOff : Word) + 4 = base + denormOff from by bv_addr] at hbge_raw
   have hbge_ext := cpsBranchWithin_extend_code (hmono := by
@@ -232,9 +232,9 @@ theorem divK_store_loop_jgt0_spec_within
     hbge_exit_raw
   -- 5. Build store_qj + x0 frame → base+900
   have SQx0 : cpsTripleWithin 4 (base + storeLoopOff) (base + loopControlOff) (sharedDivModCode base)
-      ((.x1 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+      ((.x9 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
        (.x5 ↦ᵣ v5Old) ** (.x7 ↦ᵣ v7Old) ** (.x0 ↦ᵣ (0 : Word)) ** (qAddr ↦ₘ qOld))
-      ((.x1 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+      ((.x9 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
        (.x5 ↦ᵣ jX8) ** (.x7 ↦ᵣ qAddr) ** (.x0 ↦ᵣ (0 : Word)) ** (qAddr ↦ₘ qHat)) :=
     cpsTripleWithin_weaken
       (fun h hp => by xperm_hyp hp)
@@ -270,10 +270,10 @@ theorem divK_store_loop_jgt0_spec_within_noNop
     let qAddr := sp + signExtend12 4088 - jX8
     let j' := j + signExtend12 4095
     cpsTripleWithin 6 (base + storeLoopOff) (base + loopBodyOff) (divCode_noNop base)
-      ((.x1 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+      ((.x9 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
        (.x5 ↦ᵣ v5Old) ** (.x7 ↦ᵣ v7Old) ** (.x0 ↦ᵣ (0 : Word)) **
        (qAddr ↦ₘ qOld))
-      ((.x1 ↦ᵣ j') ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+      ((.x9 ↦ᵣ j') ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
        (.x5 ↦ᵣ jX8) ** (.x7 ↦ᵣ qAddr) ** (.x0 ↦ᵣ (0 : Word)) **
        (qAddr ↦ₘ qHat)) := by
   intro jX8 qAddr j'
@@ -287,12 +287,12 @@ theorem divK_store_loop_jgt0_spec_within_noNop
      (CodeReq.union_sub (lb_sub_noNop 111 _ _ (by decide) (by bv_addr) (by decide))
       (lb_sub_noNop 112 _ _ (by decide) (by bv_addr) (by decide))))) SQ
   -- 2. ADDI x1 x1 4095 at base+900 (instr [113])
-  have haddi := addi_spec_gen_same_within .x1 j 4095 (base + loopControlOff) (by nofun)
+  have haddi := addi_spec_gen_same_within .x9 j 4095 (base + loopControlOff) (by nofun)
   rw [show (base + loopControlOff : Word) + 4 = base + loopBackBgeOff from by bv_addr] at haddi
   have haddi_e := cpsTripleWithin_extend_code (hmono := by
     exact lb_sub_noNop 113 _ _ (by decide) (by bv_addr) (by decide)) haddi
   -- 3. BGE x1 x0 7736 at base+904 (instr [114])
-  have hbge_raw := bge_spec_gen_within .x1 .x0 (7736 : BitVec 13) j' (0 : Word) (base + loopBackBgeOff)
+  have hbge_raw := bge_spec_gen_within .x9 .x0 (7736 : BitVec 13) j' (0 : Word) (base + loopBackBgeOff)
   rw [show (base + loopBackBgeOff : Word) + signExtend13 (7736 : BitVec 13) = base + loopBodyOff from by rv64_addr,
       show (base + loopBackBgeOff : Word) + 4 = base + denormOff from by bv_addr] at hbge_raw
   have hbge_ext := cpsBranchWithin_extend_code (hmono := by
@@ -310,9 +310,9 @@ theorem divK_store_loop_jgt0_spec_within_noNop
     hbge_exit_raw
   -- 5. Build store_qj + x0 frame → base+900
   have SQx0 : cpsTripleWithin 4 (base + storeLoopOff) (base + loopControlOff) (divCode_noNop base)
-      ((.x1 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+      ((.x9 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
        (.x5 ↦ᵣ v5Old) ** (.x7 ↦ᵣ v7Old) ** (.x0 ↦ᵣ (0 : Word)) ** (qAddr ↦ₘ qOld))
-      ((.x1 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+      ((.x9 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
        (.x5 ↦ᵣ jX8) ** (.x7 ↦ᵣ qAddr) ** (.x0 ↦ᵣ (0 : Word)) ** (qAddr ↦ₘ qHat)) :=
     cpsTripleWithin_weaken
       (fun h hp => by xperm_hyp hp)

--- a/EvmAsm/Evm64/DivMod/LoopBody/TrialCall.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody/TrialCall.lean
@@ -68,9 +68,9 @@ def divKTrialCallFullPost (sp j n uHi uLo vTop base : Word) : Assertion :=
   let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
   let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo un0Div
   let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
-  let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
+  let x9Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
   let q := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
-  (.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ x1Exit) **
+  (.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ x9Exit) ** regOwn .x1 **
   (.x5 ↦ᵣ q0') ** (.x6 ↦ᵣ dHi) **
   (.x7 ↦ᵣ x7Exit) ** (.x10 ↦ᵣ q1') ** (.x11 ↦ᵣ q) **
   (.x2 ↦ᵣ (base + div128CallRetOff)) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -94,7 +94,7 @@ theorem divK_trial_call_full_spec_within
     let uAddr := sp + signExtend12 4056 - (j + n) <<< (3 : BitVec 6).toNat
     let vtopBase := sp + (n + signExtend12 4095) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 66 (base + loopBodyOff) (base + div128CallRetOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
+      (((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -104,9 +104,11 @@ theorem divK_trial_call_full_spec_within
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ un0Mem))
+       (sp + signExtend12 3944 ↦ₘ un0Mem)) ** regOwn .x1)
       (divKTrialCallFullPost sp j n uHi uLo vTop base) := by
   intro uAddr vtopBase
+  apply cpsTripleWithin_of_forall_regIs_to_regOwn
+  intro v1Old
   -- Define the same lets locally so the proof body (unchanged from before
   -- bundling) can still reference q0', x1Exit, x7Exit, etc. by name. The
   -- goal's post stays `divKTrialCallFullPost ...` (opaque) throughout the
@@ -159,20 +161,20 @@ theorem divK_trial_call_full_spec_within
     (fun h hp => sepConj_mono_right
       (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hp) taken
   -- 3. Trial call path (base+512 → base+516)
-  have TCP := divK_trial_call_path_spec_within sp j uLo uHi vTop vtopBase base
-    v2Old v11Old retMem dMem dloMem un0Mem
+  have TCP := divK_trial_call_path_spec_within_exact_x1 sp j uLo uHi vTop vtopBase base
+    v1Old v2Old v11Old retMem dMem dloMem un0Mem
     halign
   unfold div128SpecPost at TCP
-  -- 4. Frame save_trial_load with x2, x11, x0, scratch memory
+  -- 4. Frame save_trial_load with x1 (v1Old), x2, x11, x0, scratch memory
   have STLf := cpsTripleWithin_frameR
-    ((.x11 ↦ᵣ v11Old) ** (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
+    ((.x1 ↦ᵣ v1Old) ** (.x11 ↦ᵣ v11Old) ** (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
      (sp + signExtend12 3968 ↦ₘ retMem) **
      (sp + signExtend12 3960 ↦ₘ dMem) **
      (sp + signExtend12 3952 ↦ₘ dloMem) **
      (sp + signExtend12 3944 ↦ₘ un0Mem))
     (by pcFree) STL
   have taken_framed := cpsTripleWithin_frameR
-    ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
+    ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) ** (.x1 ↦ᵣ v1Old) **
      (.x5 ↦ᵣ uLo) ** (.x6 ↦ᵣ vtopBase) **
      (.x11 ↦ᵣ v11Old) ** (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
      (sp + signExtend12 3976 ↦ₘ j) **
@@ -214,7 +216,7 @@ theorem divK_trial_call_full_spec_within_noNop
     let uAddr := sp + signExtend12 4056 - (j + n) <<< (3 : BitVec 6).toNat
     let vtopBase := sp + (n + signExtend12 4095) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 66 (base + loopBodyOff) (base + div128CallRetOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
+      (((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -224,9 +226,11 @@ theorem divK_trial_call_full_spec_within_noNop
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ un0Mem))
+       (sp + signExtend12 3944 ↦ₘ un0Mem)) ** regOwn .x1)
       (divKTrialCallFullPost sp j n uHi uLo vTop base) := by
   intro uAddr vtopBase
+  apply cpsTripleWithin_of_forall_regIs_to_regOwn
+  intro v1Old
   let dHi := vTop >>> (32 : BitVec 6).toNat
   let dLo := (vTop <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   let un1 := uLo >>> (32 : BitVec 6).toNat
@@ -269,19 +273,19 @@ theorem divK_trial_call_full_spec_within_noNop
     (fun h hp => hp)
     (fun h hp => sepConj_mono_right
       (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hp) taken
-  have TCP := divK_trial_call_path_spec_within_noNop sp j uLo uHi vTop vtopBase base
-    v2Old v11Old retMem dMem dloMem un0Mem
+  have TCP := divK_trial_call_path_spec_within_noNop_exact_x1 sp j uLo uHi vTop vtopBase base
+    v1Old v2Old v11Old retMem dMem dloMem un0Mem
     halign
   unfold div128SpecPost at TCP
   have STLf := cpsTripleWithin_frameR
-    ((.x11 ↦ᵣ v11Old) ** (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
+    ((.x1 ↦ᵣ v1Old) ** (.x11 ↦ᵣ v11Old) ** (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
      (sp + signExtend12 3968 ↦ₘ retMem) **
      (sp + signExtend12 3960 ↦ₘ dMem) **
      (sp + signExtend12 3952 ↦ₘ dloMem) **
      (sp + signExtend12 3944 ↦ₘ un0Mem))
     (by pcFree) STL
   have taken_framed := cpsTripleWithin_frameR
-    ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
+    ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) ** (.x1 ↦ᵣ v1Old) **
      (.x5 ↦ᵣ uLo) ** (.x6 ↦ᵣ vtopBase) **
      (.x11 ↦ᵣ v11Old) ** (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
      (sp + signExtend12 3976 ↦ₘ j) **

--- a/EvmAsm/Evm64/DivMod/LoopBody/TrialCallPath.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody/TrialCallPath.lean
@@ -30,21 +30,21 @@ private theorem lb_jal_ret {base : Word} : (base + trialJalOff : Word) + 4 = bas
 /-- Trial call path: JAL x2 560 (instr [16]) + div128 subroutine.
     Entry: base+512, Exit: base+516, CodeReq: sharedDivModCode base.
     Computes qHat = div128(uHi, uLo, vTop). -/
-theorem divK_trial_call_path_spec_within
+theorem divK_trial_call_path_spec_within_exact_x1
     (sp j uLo uHi vTop vtopBase : Word) (base : Word)
-    (v2Old v11Old : Word)
+    (v1Old v2Old v11Old : Word)
     (retMem dMem dloMem un0Mem : Word)
     (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff) :
     cpsTripleWithin 52 (base + trialJalOff) (base + div128CallRetOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
+      (((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
        (.x5 ↦ᵣ uLo) ** (.x6 ↦ᵣ vtopBase) **
        (.x7 ↦ᵣ uHi) ** (.x10 ↦ᵣ vTop) **
        (.x2 ↦ᵣ v2Old) ** (.x11 ↦ᵣ v11Old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ un0Mem))
-      (div128SpecPost sp (base + div128CallRetOff) vTop uLo uHi) := by
+       (sp + signExtend12 3944 ↦ₘ un0Mem)) ** (.x1 ↦ᵣ v1Old))
+      (div128SpecPost sp (base + div128CallRetOff) vTop uLo uHi ** regOwn .x1) := by
   -- Reuse the bundled `div128SpecPost` from `Compose/Div128.lean`. The
   -- post atoms here are identical to div128's (with retAddr ↦ base+516,
   -- d ↦ vTop) — just a permutation that the final `xperm_hyp` handles.
@@ -77,7 +77,7 @@ theorem divK_trial_call_path_spec_within
   let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
   let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo un0
   let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
-  let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
+  let x9Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
   let q := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   -- 1. JAL x2 560 at base+512: x2 ← base+516, PC → base+1072
   have J := jal_spec_within .x2 v2Old (560 : BitVec 21) (base + trialJalOff) (by nofun)
@@ -89,9 +89,11 @@ theorem divK_trial_call_path_spec_within
     j vtopBase v11Old retMem dMem dloMem un0Mem
     halign
   unfold div128SpecPost at D
+  -- 2b. Frame div128 with x1; div128 uses x9 as its scratch register.
+  have Df := cpsTripleWithin_frameR (.x1 ↦ᵣ v1Old) (by pcFree) D
   -- 3. Frame JAL with all registers/memory for div128
   have Jf := cpsTripleWithin_frameR
-    ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
+    ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) ** (.x1 ↦ᵣ v1Old) **
      (.x5 ↦ᵣ uLo) ** (.x6 ↦ᵣ vtopBase) **
      (.x7 ↦ᵣ uHi) ** (.x10 ↦ᵣ vTop) **
      (.x11 ↦ᵣ v11Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -100,32 +102,57 @@ theorem divK_trial_call_path_spec_within
      (sp + signExtend12 3952 ↦ₘ dloMem) **
      (sp + signExtend12 3944 ↦ₘ un0Mem))
     (by pcFree) Je
-  -- 4. Compose JAL + div128
+  -- 4. Compose JAL + div128.
   have full := cpsTripleWithin_seq_perm_same_cr
-    (fun h hp => by xperm_hyp hp) Jf D
+    (fun h hp => by xperm_hyp hp) Jf Df
   -- 5. Final permutation
   exact cpsTripleWithin_weaken
     (fun h hp => by xperm_hyp hp)
-    (fun h hq => by xperm_hyp hq)
+    (fun h hq => by
+      apply sepConj_mono_right (regIs_implies_regOwn .x1) h
+      xperm_hyp hq)
     full
 
-/-- Trial call path over `divCode_noNop`: JAL x2 560 (instr [16]) + div128
-    subroutine. -/
-theorem divK_trial_call_path_spec_within_noNop
+/-- Trial call path: JAL x2 560 (instr [16]) + div128 subroutine.
+    Entry: base+512, Exit: base+516, CodeReq: sharedDivModCode base.
+    Computes qHat = div128(uHi, uLo, vTop), with `x1` existentially owned. -/
+theorem divK_trial_call_path_spec_within
     (sp j uLo uHi vTop vtopBase : Word) (base : Word)
     (v2Old v11Old : Word)
     (retMem dMem dloMem un0Mem : Word)
     (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff) :
-    cpsTripleWithin 52 (base + trialJalOff) (base + div128CallRetOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
+    cpsTripleWithin 52 (base + trialJalOff) (base + div128CallRetOff) (sharedDivModCode base)
+      (((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
        (.x5 ↦ᵣ uLo) ** (.x6 ↦ᵣ vtopBase) **
        (.x7 ↦ᵣ uHi) ** (.x10 ↦ᵣ vTop) **
        (.x2 ↦ᵣ v2Old) ** (.x11 ↦ᵣ v11Old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ un0Mem))
-      (div128SpecPost sp (base + div128CallRetOff) vTop uLo uHi) := by
+       (sp + signExtend12 3944 ↦ₘ un0Mem)) ** regOwn .x1)
+      (div128SpecPost sp (base + div128CallRetOff) vTop uLo uHi ** regOwn .x1) := by
+  apply cpsTripleWithin_of_forall_regIs_to_regOwn
+  intro v1Old
+  exact divK_trial_call_path_spec_within_exact_x1 sp j uLo uHi vTop vtopBase base
+    v1Old v2Old v11Old retMem dMem dloMem un0Mem halign
+
+/-- Trial call path over `divCode_noNop`: JAL x2 560 (instr [16]) + div128
+    subroutine. -/
+theorem divK_trial_call_path_spec_within_noNop_exact_x1
+    (sp j uLo uHi vTop vtopBase : Word) (base : Word)
+    (v1Old v2Old v11Old : Word)
+    (retMem dMem dloMem un0Mem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff) :
+    cpsTripleWithin 52 (base + trialJalOff) (base + div128CallRetOff) (divCode_noNop base)
+      (((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
+       (.x5 ↦ᵣ uLo) ** (.x6 ↦ᵣ vtopBase) **
+       (.x7 ↦ᵣ uHi) ** (.x10 ↦ᵣ vTop) **
+       (.x2 ↦ᵣ v2Old) ** (.x11 ↦ᵣ v11Old) ** (.x0 ↦ᵣ (0 : Word)) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
+       (sp + signExtend12 3944 ↦ₘ un0Mem)) ** (.x1 ↦ᵣ v1Old))
+      (div128SpecPost sp (base + div128CallRetOff) vTop uLo uHi ** regOwn .x1) := by
   unfold div128SpecPost
   let dHi := vTop >>> (32 : BitVec 6).toNat
   let dLo := (vTop <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
@@ -153,7 +180,7 @@ theorem divK_trial_call_path_spec_within_noNop
   let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
   let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo un0
   let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
-  let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
+  let x9Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
   let q := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   have J := jal_spec_within .x2 v2Old (560 : BitVec 21) (base + trialJalOff) (by nofun)
   rw [lb_jal_target, lb_jal_ret] at J
@@ -163,8 +190,9 @@ theorem divK_trial_call_path_spec_within_noNop
     j vtopBase v11Old retMem dMem dloMem un0Mem
     halign
   unfold div128SpecPost at D
+  have Df := cpsTripleWithin_frameR (.x1 ↦ᵣ v1Old) (by pcFree) D
   have Jf := cpsTripleWithin_frameR
-    ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
+    ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) ** (.x1 ↦ᵣ v1Old) **
      (.x5 ↦ᵣ uLo) ** (.x6 ↦ᵣ vtopBase) **
      (.x7 ↦ᵣ uHi) ** (.x10 ↦ᵣ vTop) **
      (.x11 ↦ᵣ v11Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -173,11 +201,36 @@ theorem divK_trial_call_path_spec_within_noNop
      (sp + signExtend12 3952 ↦ₘ dloMem) **
      (sp + signExtend12 3944 ↦ₘ un0Mem))
     (by pcFree) Je
+
   have full := cpsTripleWithin_seq_perm_same_cr
-    (fun h hp => by xperm_hyp hp) Jf D
+    (fun h hp => by xperm_hyp hp) Jf Df
   exact cpsTripleWithin_weaken
     (fun h hp => by xperm_hyp hp)
-    (fun h hq => by xperm_hyp hq)
+    (fun h hq => by
+      apply sepConj_mono_right (regIs_implies_regOwn .x1) h
+      xperm_hyp hq)
     full
+
+/-- Trial call path over `divCode_noNop`: JAL x2 560 (instr [16]) + div128
+    subroutine, with `x1` existentially owned. -/
+theorem divK_trial_call_path_spec_within_noNop
+    (sp j uLo uHi vTop vtopBase : Word) (base : Word)
+    (v2Old v11Old : Word)
+    (retMem dMem dloMem un0Mem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff) :
+    cpsTripleWithin 52 (base + trialJalOff) (base + div128CallRetOff) (divCode_noNop base)
+      (((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
+       (.x5 ↦ᵣ uLo) ** (.x6 ↦ᵣ vtopBase) **
+       (.x7 ↦ᵣ uHi) ** (.x10 ↦ᵣ vTop) **
+       (.x2 ↦ᵣ v2Old) ** (.x11 ↦ᵣ v11Old) ** (.x0 ↦ᵣ (0 : Word)) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
+       (sp + signExtend12 3944 ↦ₘ un0Mem)) ** regOwn .x1)
+      (div128SpecPost sp (base + div128CallRetOff) vTop uLo uHi ** regOwn .x1) := by
+  apply cpsTripleWithin_of_forall_regIs_to_regOwn
+  intro v1Old
+  exact divK_trial_call_path_spec_within_noNop_exact_x1 sp j uLo uHi vTop vtopBase base
+    v1Old v2Old v11Old retMem dMem dloMem un0Mem halign
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LoopBody/TrialMax.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody/TrialMax.lean
@@ -73,14 +73,14 @@ theorem divK_trial_max_full_spec_within
     let uAddr := sp + signExtend12 4056 - (j + n) <<< (3 : BitVec 6).toNat
     let vtopBase := sp + (n + signExtend12 4095) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 16 (base + loopBodyOff) (base + div128CallRetOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ n) **
        (uAddr ↦ₘ uHi) ** ((uAddr + 8) ↦ₘ uLo) **
        (vtopBase + signExtend12 32 ↦ₘ vTop))
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
        (.x5 ↦ᵣ uLo) ** (.x6 ↦ᵣ vtopBase) **
        (.x7 ↦ᵣ uHi) ** (.x10 ↦ᵣ vTop) ** (.x11 ↦ᵣ signExtend12 4095) **
        (.x0 ↦ᵣ (0 : Word)) **
@@ -112,7 +112,7 @@ theorem divK_trial_max_full_spec_within
   have STLf := cpsTripleWithin_frameR
     ((.x11 ↦ᵣ v11Old) ** (.x0 ↦ᵣ (0 : Word))) (by pcFree) STL
   have ntaken_framed := cpsTripleWithin_frameR
-    ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
+    ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
      (.x5 ↦ᵣ uLo) ** (.x6 ↦ᵣ vtopBase) **
      (.x11 ↦ᵣ v11Old) ** (.x0 ↦ᵣ (0 : Word)) **
      (sp + signExtend12 3976 ↦ₘ j) ** (sp + signExtend12 3984 ↦ₘ n) **
@@ -123,7 +123,7 @@ theorem divK_trial_max_full_spec_within
     (fun h hp => by xperm_hyp hp) STLf ntaken_framed
   -- 5. Frame BLTU ntaken result with x0 + memory, compose with trial_max
   have TMf := cpsTripleWithin_frameR
-    ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
+    ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
      (.x5 ↦ᵣ uLo) ** (.x6 ↦ᵣ vtopBase) **
      (.x7 ↦ᵣ uHi) ** (.x10 ↦ᵣ vTop) **
      (sp + signExtend12 3976 ↦ₘ j) ** (sp + signExtend12 3984 ↦ₘ n) **
@@ -147,14 +147,14 @@ theorem divK_trial_max_full_spec_within_noNop
     let uAddr := sp + signExtend12 4056 - (j + n) <<< (3 : BitVec 6).toNat
     let vtopBase := sp + (n + signExtend12 4095) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 16 (base + loopBodyOff) (base + div128CallRetOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ n) **
        (uAddr ↦ₘ uHi) ** ((uAddr + 8) ↦ₘ uLo) **
        (vtopBase + signExtend12 32 ↦ₘ vTop))
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
        (.x5 ↦ᵣ uLo) ** (.x6 ↦ᵣ vtopBase) **
        (.x7 ↦ᵣ uHi) ** (.x10 ↦ᵣ vTop) ** (.x11 ↦ᵣ signExtend12 4095) **
        (.x0 ↦ᵣ (0 : Word)) **
@@ -186,7 +186,7 @@ theorem divK_trial_max_full_spec_within_noNop
   have STLf := cpsTripleWithin_frameR
     ((.x11 ↦ᵣ v11Old) ** (.x0 ↦ᵣ (0 : Word))) (by pcFree) STL
   have ntaken_framed := cpsTripleWithin_frameR
-    ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
+    ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
      (.x5 ↦ᵣ uLo) ** (.x6 ↦ᵣ vtopBase) **
      (.x11 ↦ᵣ v11Old) ** (.x0 ↦ᵣ (0 : Word)) **
      (sp + signExtend12 3976 ↦ₘ j) ** (sp + signExtend12 3984 ↦ₘ n) **
@@ -197,7 +197,7 @@ theorem divK_trial_max_full_spec_within_noNop
     (fun h hp => by xperm_hyp hp) STLf ntaken_framed
   -- 5. Frame BLTU ntaken result with x0 + memory, compose with trial_max
   have TMf := cpsTripleWithin_frameR
-    ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
+    ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
      (.x5 ↦ᵣ uLo) ** (.x6 ↦ᵣ vtopBase) **
      (.x7 ↦ᵣ uHi) ** (.x10 ↦ᵣ vTop) **
      (sp + signExtend12 3976 ↦ₘ j) ** (sp + signExtend12 3984 ↦ₘ n) **

--- a/EvmAsm/Evm64/DivMod/LoopComposeN1.lean
+++ b/EvmAsm/Evm64/DivMod/LoopComposeN1.lean
@@ -138,7 +138,7 @@ theorem divK_loop_body_n1_max_unified_j3_spec_within
     let uBase := sp + signExtend12 4056 - (3 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (3 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 152 (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (3 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (3 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -190,7 +190,7 @@ theorem divK_loop_body_n1_max_unified_j2_spec_within
     let uBase := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 152 (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (2 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (2 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -242,7 +242,7 @@ theorem divK_loop_body_n1_max_unified_j1_spec_within
     let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 152 (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (1 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -297,7 +297,7 @@ theorem divK_loop_body_n1_max_unified_j0_spec_within
     let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 152 (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -346,7 +346,7 @@ theorem divK_loop_body_n1_max_unified_j3_spec_within_noNop
     let uBase := sp + signExtend12 4056 - (3 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (3 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 152 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (3 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (3 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -398,7 +398,7 @@ theorem divK_loop_body_n1_max_unified_j2_spec_within_noNop
     let uBase := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 152 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (2 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (2 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -450,7 +450,7 @@ theorem divK_loop_body_n1_max_unified_j1_spec_within_noNop
     let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 152 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (1 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -505,7 +505,7 @@ theorem divK_loop_body_n1_max_unified_j0_spec_within_noNop
     let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 152 (base + loopBodyOff) (base + denormOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -561,7 +561,7 @@ theorem divK_loop_body_n1_call_unified_j3_spec_within
     let uBase := sp + signExtend12 4056 - (3 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (3 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 202 (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (3 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (3 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -575,7 +575,7 @@ theorem divK_loop_body_n1_call_unified_j3_spec_within
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (loopIterPostN1Call sp base (3 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro uBase qAddr
   by_cases hb : BitVec.ult uTop (mulsubN4_c3 (div128Quot u1 u0 v0) v0 v1 v2 v3 u0 u1 u2 u3)
@@ -622,7 +622,7 @@ theorem divK_loop_body_n1_call_unified_j2_spec_within
     let uBase := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 202 (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (2 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (2 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -636,7 +636,7 @@ theorem divK_loop_body_n1_call_unified_j2_spec_within
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (loopIterPostN1Call sp base (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro uBase qAddr
   by_cases hb : BitVec.ult uTop (mulsubN4_c3 (div128Quot u1 u0 v0) v0 v1 v2 v3 u0 u1 u2 u3)
@@ -683,7 +683,7 @@ theorem divK_loop_body_n1_call_unified_j1_spec_within
     let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 202 (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (1 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -697,7 +697,7 @@ theorem divK_loop_body_n1_call_unified_j1_spec_within
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (loopIterPostN1Call sp base (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro uBase qAddr
   by_cases hb : BitVec.ult uTop (mulsubN4_c3 (div128Quot u1 u0 v0) v0 v1 v2 v3 u0 u1 u2 u3)
@@ -745,7 +745,7 @@ theorem divK_loop_body_n1_call_unified_j0_spec_within
     let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 202 (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -759,7 +759,7 @@ theorem divK_loop_body_n1_call_unified_j0_spec_within
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (loopIterPostN1Call sp base (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro uBase qAddr
   by_cases hb : BitVec.ult uTop (mulsubN4_c3 (div128Quot u1 u0 v0) v0 v1 v2 v3 u0 u1 u2 u3)
@@ -801,7 +801,7 @@ theorem divK_loop_body_n1_call_unified_j3_spec_within_noNop
     let uBase := sp + signExtend12 4056 - (3 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (3 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 202 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (3 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (3 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -815,7 +815,7 @@ theorem divK_loop_body_n1_call_unified_j3_spec_within_noNop
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (loopIterPostN1Call sp base (3 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro uBase qAddr
   by_cases hb : BitVec.ult uTop (mulsubN4_c3 (div128Quot u1 u0 v0) v0 v1 v2 v3 u0 u1 u2 u3)
@@ -862,7 +862,7 @@ theorem divK_loop_body_n1_call_unified_j2_spec_within_noNop
     let uBase := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 202 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (2 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (2 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -876,7 +876,7 @@ theorem divK_loop_body_n1_call_unified_j2_spec_within_noNop
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (loopIterPostN1Call sp base (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro uBase qAddr
   by_cases hb : BitVec.ult uTop (mulsubN4_c3 (div128Quot u1 u0 v0) v0 v1 v2 v3 u0 u1 u2 u3)
@@ -923,7 +923,7 @@ theorem divK_loop_body_n1_call_unified_j1_spec_within_noNop
     let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 202 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (1 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -937,7 +937,7 @@ theorem divK_loop_body_n1_call_unified_j1_spec_within_noNop
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (loopIterPostN1Call sp base (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro uBase qAddr
   by_cases hb : BitVec.ult uTop (mulsubN4_c3 (div128Quot u1 u0 v0) v0 v1 v2 v3 u0 u1 u2 u3)
@@ -985,7 +985,7 @@ theorem divK_loop_body_n1_call_unified_j0_spec_within_noNop
     let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 202 (base + loopBodyOff) (base + denormOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -999,7 +999,7 @@ theorem divK_loop_body_n1_call_unified_j0_spec_within_noNop
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (loopIterPostN1Call sp base (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro uBase qAddr
   by_cases hb : BitVec.ult uTop (mulsubN4_c3 (div128Quot u1 u0 v0) v0 v1 v2 v3 u0 u1 u2 u3)

--- a/EvmAsm/Evm64/DivMod/LoopComposeN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopComposeN2.lean
@@ -73,7 +73,7 @@ theorem divK_loop_body_n2_max_unified_j2_spec_within
     let uBase := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 152 (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (2 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (2 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -125,7 +125,7 @@ theorem divK_loop_body_n2_max_unified_j2_spec_within_noNop
     let uBase := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 152 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (2 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (2 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -176,7 +176,7 @@ theorem divK_loop_body_n2_max_unified_j1_spec_within
     let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 152 (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (1 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -229,7 +229,7 @@ theorem divK_loop_body_n2_max_unified_j1_spec_within_noNop
     let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 152 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (1 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -281,7 +281,7 @@ theorem divK_loop_body_n2_max_unified_j0_spec_within
     let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 152 (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -331,7 +331,7 @@ theorem divK_loop_body_n2_max_unified_j0_spec_within_noNop
     let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 152 (base + loopBodyOff) (base + denormOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -386,7 +386,7 @@ theorem divK_loop_body_n2_call_unified_j2_spec_within
     let uBase := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 202 (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (2 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (2 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -400,7 +400,7 @@ theorem divK_loop_body_n2_call_unified_j2_spec_within
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (loopIterPostN2Call sp base (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro uBase qAddr
   by_cases hb : BitVec.ult uTop (mulsubN4_c3 (div128Quot u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3)
@@ -447,7 +447,7 @@ theorem divK_loop_body_n2_call_unified_j2_spec_within_noNop
     let uBase := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 202 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (2 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (2 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -461,7 +461,7 @@ theorem divK_loop_body_n2_call_unified_j2_spec_within_noNop
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (loopIterPostN2Call sp base (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro uBase qAddr
   by_cases hb : BitVec.ult uTop (mulsubN4_c3 (div128Quot u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3)
@@ -506,7 +506,7 @@ theorem divK_loop_body_n2_call_unified_j1_spec_within
     let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 202 (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (1 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -520,7 +520,7 @@ theorem divK_loop_body_n2_call_unified_j1_spec_within
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (loopIterPostN2Call sp base (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro uBase qAddr
   by_cases hb : BitVec.ult uTop (mulsubN4_c3 (div128Quot u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3)
@@ -567,7 +567,7 @@ theorem divK_loop_body_n2_call_unified_j1_spec_within_noNop
     let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 202 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (1 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -581,7 +581,7 @@ theorem divK_loop_body_n2_call_unified_j1_spec_within_noNop
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (loopIterPostN2Call sp base (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro uBase qAddr
   by_cases hb : BitVec.ult uTop (mulsubN4_c3 (div128Quot u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3)
@@ -627,7 +627,7 @@ theorem divK_loop_body_n2_call_unified_j0_spec_within
     let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 202 (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -641,7 +641,7 @@ theorem divK_loop_body_n2_call_unified_j0_spec_within
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (loopIterPostN2Call sp base (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro uBase qAddr
   by_cases hb : BitVec.ult uTop (mulsubN4_c3 (div128Quot u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3)
@@ -683,7 +683,7 @@ theorem divK_loop_body_n2_call_unified_j0_spec_within_noNop
     let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 202 (base + loopBodyOff) (base + denormOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -697,7 +697,7 @@ theorem divK_loop_body_n2_call_unified_j0_spec_within_noNop
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (loopIterPostN2Call sp base (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro uBase qAddr
   by_cases hb : BitVec.ult uTop (mulsubN4_c3 (div128Quot u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3)
@@ -1054,7 +1054,7 @@ theorem divK_loop_n2_max_call_spec_within
   have J1f := cpsTripleWithin_frameR
     (((u_base_0 + signExtend12 0) ↦ₘ u0Orig) ** (q_addr_0 ↦ₘ q0Old) **
      (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
-     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
     (by pcFree) J1
   -- 3. j=0 call  spec (inputs from j=1 via iterN2Max, scratch from frame)
   have J0 := divK_loop_body_n2_call_unified_j0_spec_within sp (1 : Word)
@@ -1134,7 +1134,7 @@ theorem divK_loop_n2_max_call_spec_within_noNop
   have J1f := cpsTripleWithin_frameR
     (((u_base_0 + signExtend12 0) ↦ₘ u0Orig) ** (q_addr_0 ↦ₘ q0Old) **
      (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
-     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
     (by pcFree) J1
   have J0 := divK_loop_body_n2_call_unified_j0_spec_within_noNop sp (1 : Word)
     ((1 : Word) <<< (3 : BitVec 6).toNat) u_base_1 q_addr_1
@@ -1246,7 +1246,7 @@ theorem divK_loop_n2_call_max_spec_within
      (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
      (sp + signExtend12 3960 ↦ₘ v1) **
      (sp + signExtend12 3952 ↦ₘ div128DLo v1) **
-     (sp + signExtend12 3944 ↦ₘ div128Un0 u1))
+     (sp + signExtend12 3944 ↦ₘ div128Un0 u1) ** regOwn .x1)
     (by pcFree) J0
   -- 4. Compose: rewrite j=1 call  postcondition → j=0 precondition
   have full := cpsTripleWithin_seq_perm_same_cr
@@ -1321,7 +1321,7 @@ theorem divK_loop_n2_call_max_spec_within_noNop
      (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
      (sp + signExtend12 3960 ↦ₘ v1) **
      (sp + signExtend12 3952 ↦ₘ div128DLo v1) **
-     (sp + signExtend12 3944 ↦ₘ div128Un0 u1))
+     (sp + signExtend12 3944 ↦ₘ div128Un0 u1) ** regOwn .x1)
     (by pcFree) J0
   have full := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by

--- a/EvmAsm/Evm64/DivMod/LoopComposeN3.lean
+++ b/EvmAsm/Evm64/DivMod/LoopComposeN3.lean
@@ -65,7 +65,7 @@ theorem divK_loop_body_n3_max_unified_j1_spec_within
     let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 152 (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (1 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -112,7 +112,7 @@ theorem divK_loop_body_n3_max_unified_j1_spec_within_noNop
     let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 152 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (1 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -161,7 +161,7 @@ theorem divK_loop_body_n3_max_unified_j0_spec_within
     let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 152 (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -208,7 +208,7 @@ theorem divK_loop_body_n3_max_unified_j0_spec_within_noNop
     let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 152 (base + loopBodyOff) (base + denormOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -259,7 +259,7 @@ theorem divK_loop_body_n3_call_unified_j1_spec_within
     let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 202 (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (1 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -273,7 +273,7 @@ theorem divK_loop_body_n3_call_unified_j1_spec_within
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (loopIterPostN3Call sp base (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro uBase qAddr
   by_cases hb : BitVec.ult uTop (mulsubN4_c3 (div128Quot u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3)
@@ -313,7 +313,7 @@ theorem divK_loop_body_n3_call_unified_j1_spec_within_noNop
     let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 202 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (1 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -327,7 +327,7 @@ theorem divK_loop_body_n3_call_unified_j1_spec_within_noNop
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (loopIterPostN3Call sp base (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro uBase qAddr
   by_cases hb : BitVec.ult uTop (mulsubN4_c3 (div128Quot u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3)
@@ -369,7 +369,7 @@ theorem divK_loop_body_n3_call_unified_j0_spec_within
     let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 202 (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -383,7 +383,7 @@ theorem divK_loop_body_n3_call_unified_j0_spec_within
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (loopIterPostN3Call sp base (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro uBase qAddr
   by_cases hb : BitVec.ult uTop (mulsubN4_c3 (div128Quot u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3)
@@ -429,7 +429,7 @@ theorem divK_loop_body_n3_call_unified_j0_spec_within_noNop
     let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 202 (base + loopBodyOff) (base + denormOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -443,7 +443,7 @@ theorem divK_loop_body_n3_call_unified_j0_spec_within_noNop
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (loopIterPostN3Call sp base (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro uBase qAddr
   by_cases hb : BitVec.ult uTop (mulsubN4_c3 (div128Quot u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3)
@@ -815,7 +815,7 @@ theorem divK_loop_n3_max_call_spec_within
   have J1f := cpsTripleWithin_frameR
     (((u_base_0 + signExtend12 0) ↦ₘ u0Orig) ** (q_addr_0 ↦ₘ q0Old) **
      (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
-     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
     (by pcFree) J1
   -- 3. j=0 call  spec (inputs from j=1 via iterN3Max, scratch from frame)
   have J0 := divK_loop_body_n3_call_unified_j0_spec_within sp (1 : Word)
@@ -895,7 +895,7 @@ theorem divK_loop_n3_max_call_spec_within_noNop
   have J1f := cpsTripleWithin_frameR
     (((u_base_0 + signExtend12 0) ↦ₘ u0Orig) ** (q_addr_0 ↦ₘ q0Old) **
      (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
-     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
     (by pcFree) J1
   have J0 := divK_loop_body_n3_call_unified_j0_spec_within_noNop sp (1 : Word)
     ((1 : Word) <<< (3 : BitVec 6).toNat) u_base_1 q_addr_1
@@ -1006,7 +1006,7 @@ theorem divK_loop_n3_call_max_spec_within
      (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
      (sp + signExtend12 3960 ↦ₘ v2) **
      (sp + signExtend12 3952 ↦ₘ div128DLo v2) **
-     (sp + signExtend12 3944 ↦ₘ div128Un0 u2))
+     (sp + signExtend12 3944 ↦ₘ div128Un0 u2) ** regOwn .x1)
     (by pcFree) J0
   -- 4. Compose: rewrite j=1 call  postcondition → j=0 precondition
   have full := cpsTripleWithin_seq_perm_same_cr
@@ -1080,7 +1080,7 @@ theorem divK_loop_n3_call_max_spec_within_noNop
      (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
      (sp + signExtend12 3960 ↦ₘ v2) **
      (sp + signExtend12 3952 ↦ₘ div128DLo v2) **
-     (sp + signExtend12 3944 ↦ₘ div128Un0 u2))
+     (sp + signExtend12 3944 ↦ₘ div128Un0 u2) ** regOwn .x1)
     (by pcFree) J0
   have full := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by

--- a/EvmAsm/Evm64/DivMod/LoopDefs/Bundle.lean
+++ b/EvmAsm/Evm64/DivMod/LoopDefs/Bundle.lean
@@ -35,7 +35,7 @@ def loopN3Pre (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
   let u_base_0 := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
   let q_addr_1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
   let q_addr_0 := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
-  (.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
+  (.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (1 : Word)) **
   (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
   (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
   (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -65,7 +65,7 @@ def loopN3PreWithScratch (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
   (sp + signExtend12 3968 ↦ₘ retMem) **
   (sp + signExtend12 3960 ↦ₘ dMem) **
   (sp + signExtend12 3952 ↦ₘ dloMem) **
-  (sp + signExtend12 3944 ↦ₘ scratch_un0)
+  (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1
 
 
 -- ============================================================================
@@ -86,7 +86,7 @@ def loopN2Pre (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
   let q_addr_2 := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
   let q_addr_1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
   let q_addr_0 := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
-  (.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (2 : Word)) **
+  (.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (2 : Word)) **
   (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
   (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
   (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -116,7 +116,7 @@ def loopN2PreWithScratch (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
   (sp + signExtend12 3968 ↦ₘ retMem) **
   (sp + signExtend12 3960 ↦ₘ dMem) **
   (sp + signExtend12 3952 ↦ₘ dloMem) **
-  (sp + signExtend12 3944 ↦ₘ scratch_un0)
+  (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1
 
 
 -- ============================================================================
@@ -132,7 +132,7 @@ def loopN2Iter10Pre (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
   let u_base_0 := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
   let q_addr_1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
   let q_addr_0 := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
-  (.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
+  (.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (1 : Word)) **
   (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
   (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
   (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -156,7 +156,7 @@ def loopN2Iter10PreWithScratch (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
   (sp + signExtend12 3968 ↦ₘ retMem) **
   (sp + signExtend12 3960 ↦ₘ dMem) **
   (sp + signExtend12 3952 ↦ₘ dloMem) **
-  (sp + signExtend12 3944 ↦ₘ scratch_un0)
+  (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1
 
 
 -- ============================================================================
@@ -179,7 +179,7 @@ def loopN1Pre (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
   let q_addr_2 := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
   let q_addr_1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
   let q_addr_0 := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
-  (.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (3 : Word)) **
+  (.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (3 : Word)) **
   (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
   (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
   (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -211,7 +211,7 @@ def loopN1PreWithScratch (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
   (sp + signExtend12 3968 ↦ₘ retMem) **
   (sp + signExtend12 3960 ↦ₘ dMem) **
   (sp + signExtend12 3952 ↦ₘ dloMem) **
-  (sp + signExtend12 3944 ↦ₘ scratch_un0)
+  (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1
 
 
 -- ============================================================================
@@ -227,7 +227,7 @@ def loopN1Iter10Pre (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
   let u_base_0 := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
   let q_addr_1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
   let q_addr_0 := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
-  (.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
+  (.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (1 : Word)) **
   (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
   (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
   (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -251,7 +251,7 @@ def loopN1Iter10PreWithScratch (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
   (sp + signExtend12 3968 ↦ₘ retMem) **
   (sp + signExtend12 3960 ↦ₘ dMem) **
   (sp + signExtend12 3952 ↦ₘ dloMem) **
-  (sp + signExtend12 3944 ↦ₘ scratch_un0)
+  (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1
 
 
 -- ============================================================================
@@ -271,7 +271,7 @@ def loopN1Iter210Pre (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
   let q_addr_2 := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
   let q_addr_1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
   let q_addr_0 := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
-  (.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (2 : Word)) **
+  (.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (2 : Word)) **
   (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
   (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
   (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -300,7 +300,7 @@ def loopN1Iter210PreWithScratch (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
   (sp + signExtend12 3968 ↦ₘ retMem) **
   (sp + signExtend12 3960 ↦ₘ dMem) **
   (sp + signExtend12 3952 ↦ₘ dloMem) **
-  (sp + signExtend12 3944 ↦ₘ scratch_un0)
+  (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1
 
 -- (Removed dead defs `loopBodyPre` and `loopBodyPreWithScratch`: shared
 -- one-iteration loop-body preconditions parametric on the stored divisor

--- a/EvmAsm/Evm64/DivMod/LoopDefs/Post.lean
+++ b/EvmAsm/Evm64/DivMod/LoopDefs/Post.lean
@@ -35,7 +35,7 @@ def loopExitPost (n : Word) (sp j q_f c3 un0F un1F un2F un3F u4F
   let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
   let j' := j + signExtend12 4095
   let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
-  (.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j') **
+  (.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j') **
   (.x5 ↦ᵣ j <<< (3 : BitVec 6).toNat) ** (.x6 ↦ᵣ uBase) **
   (.x7 ↦ᵣ qAddr) ** (.x10 ↦ᵣ c3) ** (.x11 ↦ᵣ q_f) **
   (.x2 ↦ᵣ un3F) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -53,7 +53,7 @@ theorem loopExitPost_unfold {n: Word} {sp j q_f c3 un0F un1F un2F un3F u4F
     let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
     let j' := j + signExtend12 4095
     let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
-    (.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j') **
+    (.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j') **
     (.x5 ↦ᵣ j <<< (3 : BitVec 6).toNat) ** (.x6 ↦ᵣ uBase) **
     (.x7 ↦ᵣ qAddr) ** (.x10 ↦ᵣ c3) ** (.x11 ↦ᵣ q_f) **
     (.x2 ↦ᵣ un3F) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -127,7 +127,7 @@ def loopBodyN3CallSkipPost (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Asser
   (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
   (sp + signExtend12 3960 ↦ₘ v2) **
   (sp + signExtend12 3952 ↦ₘ div128DLo v2) **
-  (sp + signExtend12 3944 ↦ₘ div128Un0 u2)
+  (sp + signExtend12 3944 ↦ₘ div128Un0 u2) ** regOwn .x1
 
 /-- Borrow condition for n=3 call+skip: mulsub doesn't overflow. -/
 def isSkipBorrowN3Call (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Prop :=
@@ -152,7 +152,7 @@ def loopBodyN3CallSkipPostJ (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : As
   (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
   (sp + signExtend12 3960 ↦ₘ v2) **
   (sp + signExtend12 3952 ↦ₘ div128DLo v2) **
-  (sp + signExtend12 3944 ↦ₘ div128Un0 u2)
+  (sp + signExtend12 3944 ↦ₘ div128Un0 u2) ** regOwn .x1
 
 /-- Call+addback BEQ postcondition for n=3 at j=0, with double-addback handling. -/
 @[irreducible]
@@ -162,7 +162,7 @@ def loopBodyN3CallAddbackBeqPost (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
   (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
   (sp + signExtend12 3960 ↦ₘ v2) **
   (sp + signExtend12 3952 ↦ₘ div128DLo v2) **
-  (sp + signExtend12 3944 ↦ₘ div128Un0 u2)
+  (sp + signExtend12 3944 ↦ₘ div128Un0 u2) ** regOwn .x1
 
 /-- Call+addback BEQ postcondition for n=3, generic j, with double-addback handling. -/
 @[irreducible]
@@ -172,7 +172,7 @@ def loopBodyN3CallAddbackBeqPostJ (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word
   (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
   (sp + signExtend12 3960 ↦ₘ v2) **
   (sp + signExtend12 3952 ↦ₘ div128DLo v2) **
-  (sp + signExtend12 3944 ↦ₘ div128Un0 u2)
+  (sp + signExtend12 3944 ↦ₘ div128Un0 u2) ** regOwn .x1
 
 /-- Bridge: j=0 specific call addback beq = generic-j at j=0. -/
 theorem loopBodyN3CallAddbackBeqPost_eq_J {sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word} :
@@ -195,7 +195,7 @@ def loopBodyN1CallSkipPostJ (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : As
   (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
   (sp + signExtend12 3960 ↦ₘ v0) **
   (sp + signExtend12 3952 ↦ₘ div128DLo v0) **
-  (sp + signExtend12 3944 ↦ₘ div128Un0 u0)
+  (sp + signExtend12 3944 ↦ₘ div128Un0 u0) ** regOwn .x1
 
 /-- Call+addback BEQ postcondition for n=1, generic j, with double-addback handling. -/
 @[irreducible]
@@ -205,7 +205,7 @@ def loopBodyN1CallAddbackBeqPostJ (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word
   (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
   (sp + signExtend12 3960 ↦ₘ v0) **
   (sp + signExtend12 3952 ↦ₘ div128DLo v0) **
-  (sp + signExtend12 3944 ↦ₘ div128Un0 u0)
+  (sp + signExtend12 3944 ↦ₘ div128Un0 u0) ** regOwn .x1
 
 -- ============================================================================
 -- Generic j versions of n=2 call path postconditions
@@ -221,7 +221,7 @@ def loopBodyN2CallSkipPostJ (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : As
   (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
   (sp + signExtend12 3960 ↦ₘ v1) **
   (sp + signExtend12 3952 ↦ₘ div128DLo v1) **
-  (sp + signExtend12 3944 ↦ₘ div128Un0 u1)
+  (sp + signExtend12 3944 ↦ₘ div128Un0 u1) ** regOwn .x1
 
 /-- Call+addback BEQ postcondition for n=2, generic j, with double-addback handling. -/
 @[irreducible]
@@ -231,7 +231,7 @@ def loopBodyN2CallAddbackBeqPostJ (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word
   (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
   (sp + signExtend12 3960 ↦ₘ v1) **
   (sp + signExtend12 3952 ↦ₘ div128DLo v1) **
-  (sp + signExtend12 3944 ↦ₘ div128Un0 u1)
+  (sp + signExtend12 3944 ↦ₘ div128Un0 u1) ** regOwn .x1
 
 -- ============================================================================
 -- Double-addback iteration postconditions
@@ -266,7 +266,7 @@ theorem loopIterPostN1Max_skip {sp j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word}
   (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
   (sp + signExtend12 3960 ↦ₘ v0) **
   (sp + signExtend12 3952 ↦ₘ div128DLo v0) **
-  (sp + signExtend12 3944 ↦ₘ div128Un0 u0)
+  (sp + signExtend12 3944 ↦ₘ div128Un0 u0) ** regOwn .x1
 
 theorem loopIterPostN1Call_addback {sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word}
     (hb : BitVec.ult uTop (mulsubN4_c3 (div128Quot u1 u0 v0) v0 v1 v2 v3 u0 u1 u2 u3)) :
@@ -318,7 +318,7 @@ theorem loopIterPostN2Max_skip {sp j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word}
   (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
   (sp + signExtend12 3960 ↦ₘ v1) **
   (sp + signExtend12 3952 ↦ₘ div128DLo v1) **
-  (sp + signExtend12 3944 ↦ₘ div128Un0 u1)
+  (sp + signExtend12 3944 ↦ₘ div128Un0 u1) ** regOwn .x1
 
 theorem loopIterPostN2Call_addback {sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word}
     (hb : BitVec.ult uTop (mulsubN4_c3 (div128Quot u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3)) :
@@ -367,7 +367,7 @@ theorem loopIterPostN3Max_skip {sp j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word}
   (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
   (sp + signExtend12 3960 ↦ₘ v2) **
   (sp + signExtend12 3952 ↦ₘ div128DLo v2) **
-  (sp + signExtend12 3944 ↦ₘ div128Un0 u2)
+  (sp + signExtend12 3944 ↦ₘ div128Un0 u2) ** regOwn .x1
 
 /-- Producer equation: call addback beq postcondition equals loopIterPostN3Call when borrow holds. -/
 theorem loopIterPostN3Call_addback {sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word}
@@ -436,7 +436,7 @@ def loopN3CallMaxPost (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig : Word) : Ass
   (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
   (sp + signExtend12 3960 ↦ₘ v2) **
   (sp + signExtend12 3952 ↦ₘ div128DLo v2) **
-  (sp + signExtend12 3944 ↦ₘ div128Un0 u2)
+  (sp + signExtend12 3944 ↦ₘ div128Un0 u2) ** regOwn .x1
 
 /-- Unified n=3 two-iteration postcondition with double addback. -/
 def loopN3UnifiedPost (bltu_1 bltu_0 : Bool)
@@ -448,7 +448,7 @@ def loopN3UnifiedPost (bltu_1 bltu_0 : Bool)
     (sp + signExtend12 3968 ↦ₘ retMem) **
     (sp + signExtend12 3960 ↦ₘ dMem) **
     (sp + signExtend12 3952 ↦ₘ dloMem) **
-    (sp + signExtend12 3944 ↦ₘ scratch_un0)
+    (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1
   | true,  true  => loopN3CallCallPost sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig
   | false, true  => loopN3MaxCallPost sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig
   | true,  false => loopN3CallMaxPost sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig
@@ -499,7 +499,7 @@ def loopN2CallMaxPost (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig : Word) : Ass
   (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
   (sp + signExtend12 3960 ↦ₘ v1) **
   (sp + signExtend12 3952 ↦ₘ div128DLo v1) **
-  (sp + signExtend12 3944 ↦ₘ div128Un0 u1)
+  (sp + signExtend12 3944 ↦ₘ div128Un0 u1) ** regOwn .x1
 
 /-- Unified n=2 two-iteration postcondition with double addback. -/
 def loopN2Iter10Post (bltu_1 bltu_0 : Bool)
@@ -511,7 +511,7 @@ def loopN2Iter10Post (bltu_1 bltu_0 : Bool)
     (sp + signExtend12 3968 ↦ₘ retMem) **
     (sp + signExtend12 3960 ↦ₘ dMem) **
     (sp + signExtend12 3952 ↦ₘ dloMem) **
-    (sp + signExtend12 3944 ↦ₘ scratch_un0)
+    (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1
   | true,  true  => loopN2CallCallPost sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig
   | false, true  => loopN2MaxCallPost sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig
   | true,  false => loopN2CallMaxPost sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig
@@ -560,13 +560,13 @@ def loopN1Iter10Post (bltu_1 bltu_0 : Bool)
     (sp + signExtend12 3968 ↦ₘ retMem) **
     (sp + signExtend12 3960 ↦ₘ dMem) **
     (sp + signExtend12 3952 ↦ₘ dloMem) **
-    (sp + signExtend12 3944 ↦ₘ scratch_un0)
+    (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1
   | false, true  => empAssertion
   | true,  false =>
     (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
     (sp + signExtend12 3960 ↦ₘ v0) **
     (sp + signExtend12 3952 ↦ₘ div128DLo v0) **
-    (sp + signExtend12 3944 ↦ₘ div128Un0 u0)
+    (sp + signExtend12 3944 ↦ₘ div128Un0 u0) ** regOwn .x1
   | true,  true  => empAssertion
 
 /-- Postcondition for n=1 three-iteration loop (j=2, j=1, j=0) with double addback.

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/Call.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/Call.lean
@@ -31,7 +31,7 @@ theorem divK_loop_body_n1_call_skip_j0_spec_within
     let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 126 (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -45,7 +45,7 @@ theorem divK_loop_body_n1_call_skip_j0_spec_within
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (loopBodyN1CallSkipPostJ sp base (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro uBase qAddr
   let dHi := v0 >>> (32 : BitVec 6).toNat
@@ -89,6 +89,7 @@ theorem divK_loop_body_n1_call_skip_j0_spec_within
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
+  have MCS0f := cpsTripleWithin_frameR (regOwn .x1) (by pcFree) MCS0
   let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
   let fs0 := p0_lo + (signExtend12 0 : Word)
   let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
@@ -115,7 +116,7 @@ theorem divK_loop_body_n1_call_skip_j0_spec_within
      ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
      (qAddr ↦ₘ qOld))
     (by pcFree) TF
-  seqFrame TFf MCS0
+  seqFrame TFf MCS0f
   have SLf := cpsTripleWithin_frameR
     ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
      (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
@@ -128,10 +129,10 @@ theorem divK_loop_body_n1_call_skip_j0_spec_within
      (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
      (sp + signExtend12 3960 ↦ₘ v0) **
      (sp + signExtend12 3952 ↦ₘ dLo) **
-     (sp + signExtend12 3944 ↦ₘ div_un0))
+     (sp + signExtend12 3944 ↦ₘ div_un0) ** regOwn .x1)
     (by pcFree) SL
   have full := cpsTripleWithin_seq_perm_same_cr
-    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
+    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0f SLf
   exact cpsTripleWithin_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
@@ -152,7 +153,7 @@ theorem divK_loop_body_n1_call_skip_jgt0_spec_within (j : Word)
     let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     cpsTripleWithin 126 (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -166,7 +167,7 @@ theorem divK_loop_body_n1_call_skip_jgt0_spec_within (j : Word)
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (loopBodyN1CallSkipPostJ sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro uBase qAddr
   let dHi := v0 >>> (32 : BitVec 6).toNat
@@ -210,6 +211,7 @@ theorem divK_loop_body_n1_call_skip_jgt0_spec_within (j : Word)
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
+  have MCS0f := cpsTripleWithin_frameR (regOwn .x1) (by pcFree) MCS0
   let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
   let fs0 := p0_lo + (signExtend12 0 : Word)
   let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
@@ -236,7 +238,7 @@ theorem divK_loop_body_n1_call_skip_jgt0_spec_within (j : Word)
      ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
      (qAddr ↦ₘ qOld))
     (by pcFree) TF
-  seqFrame TFf MCS0
+  seqFrame TFf MCS0f
   have SLf := cpsTripleWithin_frameR
     ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
      (sp + signExtend12 3976 ↦ₘ j) **
@@ -249,10 +251,10 @@ theorem divK_loop_body_n1_call_skip_jgt0_spec_within (j : Word)
      (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
      (sp + signExtend12 3960 ↦ₘ v0) **
      (sp + signExtend12 3952 ↦ₘ dLo) **
-     (sp + signExtend12 3944 ↦ₘ div_un0))
+     (sp + signExtend12 3944 ↦ₘ div_un0) ** regOwn .x1)
     (by pcFree) SL
   have full := cpsTripleWithin_seq_perm_same_cr
-    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
+    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0f SLf
   exact cpsTripleWithin_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
@@ -273,7 +275,7 @@ theorem divK_loop_body_n1_call_skip_j0_spec_within_noNop
     let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 126 (base + loopBodyOff) (base + denormOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -287,7 +289,7 @@ theorem divK_loop_body_n1_call_skip_j0_spec_within_noNop
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (loopBodyN1CallSkipPostJ sp base (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro uBase qAddr
   let dHi := v0 >>> (32 : BitVec 6).toNat
@@ -331,6 +333,7 @@ theorem divK_loop_body_n1_call_skip_j0_spec_within_noNop
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
+  have MCS0f := cpsTripleWithin_frameR (regOwn .x1) (by pcFree) MCS0
   let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
   let fs0 := p0_lo + (signExtend12 0 : Word)
   let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
@@ -357,7 +360,7 @@ theorem divK_loop_body_n1_call_skip_j0_spec_within_noNop
      ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
      (qAddr ↦ₘ qOld))
     (by pcFree) TF
-  seqFrame TFf MCS0
+  seqFrame TFf MCS0f
   have SLf := cpsTripleWithin_frameR
     ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
      (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
@@ -370,10 +373,10 @@ theorem divK_loop_body_n1_call_skip_j0_spec_within_noNop
      (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
      (sp + signExtend12 3960 ↦ₘ v0) **
      (sp + signExtend12 3952 ↦ₘ dLo) **
-     (sp + signExtend12 3944 ↦ₘ div_un0))
+     (sp + signExtend12 3944 ↦ₘ div_un0) ** regOwn .x1)
     (by pcFree) SL
   have full := cpsTripleWithin_seq_perm_same_cr
-    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
+    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0f SLf
   exact cpsTripleWithin_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
@@ -394,7 +397,7 @@ theorem divK_loop_body_n1_call_skip_jgt0_spec_within_noNop (j : Word)
     let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     cpsTripleWithin 126 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -408,7 +411,7 @@ theorem divK_loop_body_n1_call_skip_jgt0_spec_within_noNop (j : Word)
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (loopBodyN1CallSkipPostJ sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro uBase qAddr
   let dHi := v0 >>> (32 : BitVec 6).toNat
@@ -452,6 +455,7 @@ theorem divK_loop_body_n1_call_skip_jgt0_spec_within_noNop (j : Word)
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
+  have MCS0f := cpsTripleWithin_frameR (regOwn .x1) (by pcFree) MCS0
   let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
   let fs0 := p0_lo + (signExtend12 0 : Word)
   let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
@@ -478,7 +482,7 @@ theorem divK_loop_body_n1_call_skip_jgt0_spec_within_noNop (j : Word)
      ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
      (qAddr ↦ₘ qOld))
     (by pcFree) TF
-  seqFrame TFf MCS0
+  seqFrame TFf MCS0f
   have SLf := cpsTripleWithin_frameR
     ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
      (sp + signExtend12 3976 ↦ₘ j) **
@@ -491,10 +495,10 @@ theorem divK_loop_body_n1_call_skip_jgt0_spec_within_noNop (j : Word)
      (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
      (sp + signExtend12 3960 ↦ₘ v0) **
      (sp + signExtend12 3952 ↦ₘ dLo) **
-     (sp + signExtend12 3944 ↦ₘ div_un0))
+     (sp + signExtend12 3944 ↦ₘ div_un0) ** regOwn .x1)
     (by pcFree) SL
   have full := cpsTripleWithin_seq_perm_same_cr
-    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
+    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0f SLf
   exact cpsTripleWithin_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/CallBeq.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/CallBeq.lean
@@ -32,7 +32,7 @@ theorem divK_loop_body_n1_call_addback_j0_beq_spec_within
     let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 202 (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -46,7 +46,7 @@ theorem divK_loop_body_n1_call_addback_j0_beq_spec_within
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (loopBodyN1CallAddbackBeqPostJ sp base (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro uBase qAddr
   let dHi := v0 >>> (32 : BitVec 6).toNat
@@ -106,6 +106,7 @@ theorem divK_loop_body_n1_call_addback_j0_beq_spec_within
   intro_lets at MCA
   unfold isAddbackCarry2NzN1Call isAddbackCarry2Nz div128Quot at hcarry2_nz
   have MCA0 := MCA hcarry2_nz hborrow
+  have MCA0f := cpsTripleWithin_frameR (regOwn .x1) (by pcFree) MCA0
   have SL := divK_store_loop_j0_spec_within sp q_out u4_out carryOut qOld base
   intro_lets at SL
   have TFf := cpsTripleWithin_frameR
@@ -114,7 +115,7 @@ theorem divK_loop_body_n1_call_addback_j0_beq_spec_within
      ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
      (qAddr ↦ₘ qOld))
     (by pcFree) TF
-  seqFrame TFf MCA0
+  seqFrame TFf MCA0f
   have SLf := cpsTripleWithin_frameR
     ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
      (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
@@ -127,10 +128,10 @@ theorem divK_loop_body_n1_call_addback_j0_beq_spec_within
      (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
      (sp + signExtend12 3960 ↦ₘ v0) **
      (sp + signExtend12 3952 ↦ₘ dLo) **
-     (sp + signExtend12 3944 ↦ₘ div_un0))
+     (sp + signExtend12 3944 ↦ₘ div_un0) ** regOwn .x1)
     (by pcFree) SL
   have full := cpsTripleWithin_seq_perm_same_cr
-    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
+    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0f SLf
   exact cpsTripleWithin_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
@@ -152,7 +153,7 @@ theorem divK_loop_body_n1_call_addback_jgt0_beq_spec_within (j : Word)
     let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     cpsTripleWithin 202 (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -166,7 +167,7 @@ theorem divK_loop_body_n1_call_addback_jgt0_beq_spec_within (j : Word)
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (loopBodyN1CallAddbackBeqPostJ sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro uBase qAddr
   let dHi := v0 >>> (32 : BitVec 6).toNat
@@ -226,6 +227,7 @@ theorem divK_loop_body_n1_call_addback_jgt0_beq_spec_within (j : Word)
   intro_lets at MCA
   unfold isAddbackCarry2NzN1Call isAddbackCarry2Nz div128Quot at hcarry2_nz
   have MCA0 := MCA hcarry2_nz hborrow
+  have MCA0f := cpsTripleWithin_frameR (regOwn .x1) (by pcFree) MCA0
   have SL := divK_store_loop_jgt0_spec_within sp j q_out u4_out carryOut qOld base hpos
   intro_lets at SL
   have TFf := cpsTripleWithin_frameR
@@ -234,7 +236,7 @@ theorem divK_loop_body_n1_call_addback_jgt0_beq_spec_within (j : Word)
      ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
      (qAddr ↦ₘ qOld))
     (by pcFree) TF
-  seqFrame TFf MCA0
+  seqFrame TFf MCA0f
   have SLf := cpsTripleWithin_frameR
     ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
      (sp + signExtend12 3976 ↦ₘ j) **
@@ -247,10 +249,10 @@ theorem divK_loop_body_n1_call_addback_jgt0_beq_spec_within (j : Word)
      (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
      (sp + signExtend12 3960 ↦ₘ v0) **
      (sp + signExtend12 3952 ↦ₘ dLo) **
-     (sp + signExtend12 3944 ↦ₘ div_un0))
+     (sp + signExtend12 3944 ↦ₘ div_un0) ** regOwn .x1)
     (by pcFree) SL
   have full := cpsTripleWithin_seq_perm_same_cr
-    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
+    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0f SLf
   exact cpsTripleWithin_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
@@ -271,7 +273,7 @@ theorem divK_loop_body_n1_call_addback_j0_beq_spec_within_noNop
     let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 202 (base + loopBodyOff) (base + denormOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -285,7 +287,7 @@ theorem divK_loop_body_n1_call_addback_j0_beq_spec_within_noNop
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (loopBodyN1CallAddbackBeqPostJ sp base (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro uBase qAddr
   let dHi := v0 >>> (32 : BitVec 6).toNat
@@ -345,6 +347,7 @@ theorem divK_loop_body_n1_call_addback_j0_beq_spec_within_noNop
   intro_lets at MCA
   unfold isAddbackCarry2NzN1Call isAddbackCarry2Nz div128Quot at hcarry2_nz
   have MCA0 := MCA hcarry2_nz hborrow
+  have MCA0f := cpsTripleWithin_frameR (regOwn .x1) (by pcFree) MCA0
   have SL := divK_store_loop_j0_spec_within_noNop sp q_out u4_out carryOut qOld base
   intro_lets at SL
   have TFf := cpsTripleWithin_frameR
@@ -353,7 +356,7 @@ theorem divK_loop_body_n1_call_addback_j0_beq_spec_within_noNop
      ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
      (qAddr ↦ₘ qOld))
     (by pcFree) TF
-  seqFrame TFf MCA0
+  seqFrame TFf MCA0f
   have SLf := cpsTripleWithin_frameR
     ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
      (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
@@ -366,10 +369,10 @@ theorem divK_loop_body_n1_call_addback_j0_beq_spec_within_noNop
      (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
      (sp + signExtend12 3960 ↦ₘ v0) **
      (sp + signExtend12 3952 ↦ₘ dLo) **
-     (sp + signExtend12 3944 ↦ₘ div_un0))
+     (sp + signExtend12 3944 ↦ₘ div_un0) ** regOwn .x1)
     (by pcFree) SL
   have full := cpsTripleWithin_seq_perm_same_cr
-    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
+    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0f SLf
   exact cpsTripleWithin_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
@@ -391,7 +394,7 @@ theorem divK_loop_body_n1_call_addback_jgt0_beq_spec_within_noNop (j : Word)
     let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     cpsTripleWithin 202 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -405,7 +408,7 @@ theorem divK_loop_body_n1_call_addback_jgt0_beq_spec_within_noNop (j : Word)
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (loopBodyN1CallAddbackBeqPostJ sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro uBase qAddr
   let dHi := v0 >>> (32 : BitVec 6).toNat
@@ -465,6 +468,7 @@ theorem divK_loop_body_n1_call_addback_jgt0_beq_spec_within_noNop (j : Word)
   intro_lets at MCA
   unfold isAddbackCarry2NzN1Call isAddbackCarry2Nz div128Quot at hcarry2_nz
   have MCA0 := MCA hcarry2_nz hborrow
+  have MCA0f := cpsTripleWithin_frameR (regOwn .x1) (by pcFree) MCA0
   have SL := divK_store_loop_jgt0_spec_within_noNop sp j q_out u4_out carryOut qOld base hpos
   intro_lets at SL
   have TFf := cpsTripleWithin_frameR
@@ -473,7 +477,7 @@ theorem divK_loop_body_n1_call_addback_jgt0_beq_spec_within_noNop (j : Word)
      ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
      (qAddr ↦ₘ qOld))
     (by pcFree) TF
-  seqFrame TFf MCA0
+  seqFrame TFf MCA0f
   have SLf := cpsTripleWithin_frameR
     ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
      (sp + signExtend12 3976 ↦ₘ j) **
@@ -486,10 +490,10 @@ theorem divK_loop_body_n1_call_addback_jgt0_beq_spec_within_noNop (j : Word)
      (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
      (sp + signExtend12 3960 ↦ₘ v0) **
      (sp + signExtend12 3952 ↦ₘ dLo) **
-     (sp + signExtend12 3944 ↦ₘ div_un0))
+     (sp + signExtend12 3944 ↦ₘ div_un0) ** regOwn .x1)
     (by pcFree) SL
   have full := cpsTripleWithin_seq_perm_same_cr
-    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
+    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0f SLf
   exact cpsTripleWithin_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/Max.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/Max.lean
@@ -30,7 +30,7 @@ theorem divK_loop_body_n1_max_skip_j0_spec_within
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsTripleWithin 76 (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -128,7 +128,7 @@ theorem divK_loop_body_n1_max_skip_jgt0_spec_within (j : Word)
     let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsTripleWithin 76 (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -211,7 +211,7 @@ theorem divK_loop_body_n1_max_skip_j0_spec_within_noNop
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsTripleWithin 76 (base + loopBodyOff) (base + denormOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -304,7 +304,7 @@ theorem divK_loop_body_n1_max_skip_jgt0_spec_within_noNop (j : Word)
     let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsTripleWithin 76 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/MaxBeq.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/MaxBeq.lean
@@ -31,7 +31,7 @@ theorem divK_loop_body_n1_max_addback_j0_beq_spec_within
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTripleWithin 152 (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -112,7 +112,7 @@ theorem divK_loop_body_n1_max_addback_jgt0_beq_spec_within (j : Word)
     let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTripleWithin 152 (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -192,7 +192,7 @@ theorem divK_loop_body_n1_max_addback_j0_beq_spec_within_noNop
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTripleWithin 152 (base + loopBodyOff) (base + denormOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -273,7 +273,7 @@ theorem divK_loop_body_n1_max_addback_jgt0_beq_spec_within_noNop (j : Word)
     let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTripleWithin 152 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **

--- a/EvmAsm/Evm64/DivMod/LoopIterN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN2.lean
@@ -40,7 +40,7 @@ theorem divK_loop_body_n2_max_skip_j0_spec_within
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsTripleWithin 76 (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -138,7 +138,7 @@ theorem divK_loop_body_n2_max_skip_j0_spec_within_noNop
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsTripleWithin 76 (base + loopBodyOff) (base + denormOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -234,7 +234,7 @@ theorem divK_loop_body_n2_call_skip_j0_spec_within
     let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 126 (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -248,7 +248,7 @@ theorem divK_loop_body_n2_call_skip_j0_spec_within
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (loopBodyN2CallSkipPostJ sp base (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro uBase qAddr
   -- Reconstruct div128 intermediates for n=2: vTop=v1, uHi=u2, uLo=u1
@@ -296,6 +296,7 @@ theorem divK_loop_body_n2_call_skip_j0_spec_within
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
+  have MCS0f := cpsTripleWithin_frameR (regOwn .x1) (by pcFree) MCS0
   -- Mulsub intermediates for store spec
   let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
   let fs0 := p0_lo + (signExtend12 0 : Word)
@@ -326,7 +327,7 @@ theorem divK_loop_body_n2_call_skip_j0_spec_within
      (qAddr ↦ₘ qOld))
     (by pcFree) TF
   -- 5. Compose TF + MCS0
-  seqFrame TFf MCS0
+  seqFrame TFf MCS0f
   -- 6. Frame store_loop_j0
   have SLf := cpsTripleWithin_frameR
     ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
@@ -340,11 +341,11 @@ theorem divK_loop_body_n2_call_skip_j0_spec_within
      (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
      (sp + signExtend12 3960 ↦ₘ v1) **
      (sp + signExtend12 3952 ↦ₘ dLo) **
-     (sp + signExtend12 3944 ↦ₘ div_un0))
+     (sp + signExtend12 3944 ↦ₘ div_un0) ** regOwn .x1)
     (by pcFree) SL
   -- 7. Compose
   have full := cpsTripleWithin_seq_perm_same_cr
-    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
+    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0f SLf
   exact cpsTripleWithin_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
@@ -365,7 +366,7 @@ theorem divK_loop_body_n2_call_skip_j0_spec_within_noNop
     let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 126 (base + loopBodyOff) (base + denormOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -379,7 +380,7 @@ theorem divK_loop_body_n2_call_skip_j0_spec_within_noNop
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (loopBodyN2CallSkipPostJ sp base (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro uBase qAddr
   let dHi := v1 >>> (32 : BitVec 6).toNat
@@ -422,6 +423,7 @@ theorem divK_loop_body_n2_call_skip_j0_spec_within_noNop
     x1Exit q0' dHi x7Exit q1' (base + div128CallRetOff) base
   intro_lets at MCS
   have MCS0 := MCS hborrow
+  have MCS0f := cpsTripleWithin_frameR (regOwn .x1) (by pcFree) MCS0
   let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
   let fs0 := p0_lo + (signExtend12 0 : Word)
   let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
@@ -448,7 +450,7 @@ theorem divK_loop_body_n2_call_skip_j0_spec_within_noNop
      ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
      (qAddr ↦ₘ qOld))
     (by pcFree) TF
-  seqFrame TFf MCS0
+  seqFrame TFf MCS0f
   have SLf := cpsTripleWithin_frameR
     ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
      (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
@@ -461,10 +463,10 @@ theorem divK_loop_body_n2_call_skip_j0_spec_within_noNop
      (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
      (sp + signExtend12 3960 ↦ₘ v1) **
      (sp + signExtend12 3952 ↦ₘ dLo) **
-     (sp + signExtend12 3944 ↦ₘ div_un0))
+     (sp + signExtend12 3944 ↦ₘ div_un0) ** regOwn .x1)
     (by pcFree) SL
   have full := cpsTripleWithin_seq_perm_same_cr
-    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
+    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0f SLf
   exact cpsTripleWithin_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
@@ -491,7 +493,7 @@ theorem divK_loop_body_n2_max_skip_jgt0_spec_within (j : Word)
     let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsTripleWithin 76 (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -575,7 +577,7 @@ theorem divK_loop_body_n2_max_skip_jgt0_spec_within_noNop (j : Word)
     let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsTripleWithin 76 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -665,7 +667,7 @@ theorem divK_loop_body_n2_call_skip_jgt0_spec_within (j : Word)
     let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     cpsTripleWithin 126 (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -679,7 +681,7 @@ theorem divK_loop_body_n2_call_skip_jgt0_spec_within (j : Word)
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (loopBodyN2CallSkipPostJ sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro uBase qAddr
   let dHi := v1 >>> (32 : BitVec 6).toNat
@@ -723,6 +725,7 @@ theorem divK_loop_body_n2_call_skip_jgt0_spec_within (j : Word)
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
+  have MCS0f := cpsTripleWithin_frameR (regOwn .x1) (by pcFree) MCS0
   let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
   let fs0 := p0_lo + (signExtend12 0 : Word)
   let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
@@ -749,7 +752,7 @@ theorem divK_loop_body_n2_call_skip_jgt0_spec_within (j : Word)
      ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
      (qAddr ↦ₘ qOld))
     (by pcFree) TF
-  seqFrame TFf MCS0
+  seqFrame TFf MCS0f
   have SLf := cpsTripleWithin_frameR
     ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
      (sp + signExtend12 3976 ↦ₘ j) **
@@ -762,10 +765,10 @@ theorem divK_loop_body_n2_call_skip_jgt0_spec_within (j : Word)
      (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
      (sp + signExtend12 3960 ↦ₘ v1) **
      (sp + signExtend12 3952 ↦ₘ dLo) **
-     (sp + signExtend12 3944 ↦ₘ div_un0))
+     (sp + signExtend12 3944 ↦ₘ div_un0) ** regOwn .x1)
     (by pcFree) SL
   have full := cpsTripleWithin_seq_perm_same_cr
-    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
+    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0f SLf
   exact cpsTripleWithin_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
@@ -787,7 +790,7 @@ theorem divK_loop_body_n2_call_skip_jgt0_spec_within_noNop (j : Word)
     let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     cpsTripleWithin 126 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -801,7 +804,7 @@ theorem divK_loop_body_n2_call_skip_jgt0_spec_within_noNop (j : Word)
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (loopBodyN2CallSkipPostJ sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro uBase qAddr
   let dHi := v1 >>> (32 : BitVec 6).toNat
@@ -844,6 +847,7 @@ theorem divK_loop_body_n2_call_skip_jgt0_spec_within_noNop (j : Word)
     x1Exit q0' dHi x7Exit q1' (base + div128CallRetOff) base
   intro_lets at MCS
   have MCS0 := MCS hborrow
+  have MCS0f := cpsTripleWithin_frameR (regOwn .x1) (by pcFree) MCS0
   let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
   let fs0 := p0_lo + (signExtend12 0 : Word)
   let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
@@ -870,7 +874,7 @@ theorem divK_loop_body_n2_call_skip_jgt0_spec_within_noNop (j : Word)
      ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
      (qAddr ↦ₘ qOld))
     (by pcFree) TF
-  seqFrame TFf MCS0
+  seqFrame TFf MCS0f
   have SLf := cpsTripleWithin_frameR
     ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
      (sp + signExtend12 3976 ↦ₘ j) **
@@ -883,10 +887,10 @@ theorem divK_loop_body_n2_call_skip_jgt0_spec_within_noNop (j : Word)
      (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
      (sp + signExtend12 3960 ↦ₘ v1) **
      (sp + signExtend12 3952 ↦ₘ dLo) **
-     (sp + signExtend12 3944 ↦ₘ div_un0))
+     (sp + signExtend12 3944 ↦ₘ div_un0) ** regOwn .x1)
     (by pcFree) SL
   have full := cpsTripleWithin_seq_perm_same_cr
-    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
+    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0f SLf
   exact cpsTripleWithin_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
@@ -918,7 +922,7 @@ theorem divK_loop_body_n2_max_addback_j0_beq_spec_within
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTripleWithin 152 (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -999,7 +1003,7 @@ theorem divK_loop_body_n2_max_addback_j0_beq_spec_within_noNop
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTripleWithin 152 (base + loopBodyOff) (base + denormOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -1084,7 +1088,7 @@ theorem divK_loop_body_n2_call_addback_j0_beq_spec_within
     let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 202 (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -1098,7 +1102,7 @@ theorem divK_loop_body_n2_call_addback_j0_beq_spec_within
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (loopBodyN2CallAddbackBeqPostJ sp base (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro uBase qAddr
   -- Reconstruct div128 intermediates for n=2
@@ -1162,6 +1166,7 @@ theorem divK_loop_body_n2_call_addback_j0_beq_spec_within
   intro_lets at MCA
   unfold isAddbackCarry2NzN2Call isAddbackCarry2Nz div128Quot at hcarry2_nz
   have MCA0 := MCA hcarry2_nz hborrow
+  have MCA0f := cpsTripleWithin_frameR (regOwn .x1) (by pcFree) MCA0
   -- 3. Store + loop exit j=0 (cpsTripleWithin base+884 → base+908)
   have SL := divK_store_loop_j0_spec_within sp q_out u4_out carryOut qOld base
   intro_lets at SL
@@ -1173,7 +1178,7 @@ theorem divK_loop_body_n2_call_addback_j0_beq_spec_within
      (qAddr ↦ₘ qOld))
     (by pcFree) TF
   -- 5. Compose TF + MCA0
-  seqFrame TFf MCA0
+  seqFrame TFf MCA0f
   -- 6. Frame store_loop_j0
   have SLf := cpsTripleWithin_frameR
     ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
@@ -1187,11 +1192,11 @@ theorem divK_loop_body_n2_call_addback_j0_beq_spec_within
      (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
      (sp + signExtend12 3960 ↦ₘ v1) **
      (sp + signExtend12 3952 ↦ₘ dLo) **
-     (sp + signExtend12 3944 ↦ₘ div_un0))
+     (sp + signExtend12 3944 ↦ₘ div_un0) ** regOwn .x1)
     (by pcFree) SL
   -- 7. Compose
   have full := cpsTripleWithin_seq_perm_same_cr
-    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
+    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0f SLf
   exact cpsTripleWithin_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
@@ -1218,7 +1223,7 @@ theorem divK_loop_body_n2_max_addback_jgt0_beq_spec_within (j : Word)
     let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTripleWithin 152 (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -1306,7 +1311,7 @@ theorem divK_loop_body_n2_call_addback_jgt0_beq_spec_within (j : Word)
     let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     cpsTripleWithin 202 (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -1320,7 +1325,7 @@ theorem divK_loop_body_n2_call_addback_jgt0_beq_spec_within (j : Word)
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (loopBodyN2CallAddbackBeqPostJ sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro uBase qAddr
   let dHi := v1 >>> (32 : BitVec 6).toNat
@@ -1380,6 +1385,7 @@ theorem divK_loop_body_n2_call_addback_jgt0_beq_spec_within (j : Word)
   intro_lets at MCA
   unfold isAddbackCarry2NzN2Call isAddbackCarry2Nz div128Quot at hcarry2_nz
   have MCA0 := MCA hcarry2_nz hborrow
+  have MCA0f := cpsTripleWithin_frameR (regOwn .x1) (by pcFree) MCA0
   have SL := divK_store_loop_jgt0_spec_within sp j q_out u4_out carryOut qOld base hpos
   intro_lets at SL
   have TFf := cpsTripleWithin_frameR
@@ -1388,7 +1394,7 @@ theorem divK_loop_body_n2_call_addback_jgt0_beq_spec_within (j : Word)
      ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
      (qAddr ↦ₘ qOld))
     (by pcFree) TF
-  seqFrame TFf MCA0
+  seqFrame TFf MCA0f
   have SLf := cpsTripleWithin_frameR
     ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
      (sp + signExtend12 3976 ↦ₘ j) **
@@ -1401,10 +1407,10 @@ theorem divK_loop_body_n2_call_addback_jgt0_beq_spec_within (j : Word)
      (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
      (sp + signExtend12 3960 ↦ₘ v1) **
      (sp + signExtend12 3952 ↦ₘ dLo) **
-     (sp + signExtend12 3944 ↦ₘ div_un0))
+     (sp + signExtend12 3944 ↦ₘ div_un0) ** regOwn .x1)
     (by pcFree) SL
   have full := cpsTripleWithin_seq_perm_same_cr
-    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
+    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0f SLf
   exact cpsTripleWithin_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by

--- a/EvmAsm/Evm64/DivMod/LoopIterN2NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN2NoNop.lean
@@ -19,7 +19,7 @@ theorem divK_loop_body_n2_call_addback_j0_beq_spec_within_noNop
     let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 202 (base + loopBodyOff) (base + denormOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -33,7 +33,7 @@ theorem divK_loop_body_n2_call_addback_j0_beq_spec_within_noNop
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (loopBodyN2CallAddbackBeqPostJ sp base (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro uBase qAddr
   let dHi := v1 >>> (32 : BitVec 6).toNat
@@ -91,6 +91,7 @@ theorem divK_loop_body_n2_call_addback_j0_beq_spec_within_noNop
   intro_lets at MCA
   unfold isAddbackCarry2NzN2Call isAddbackCarry2Nz div128Quot at hcarry2_nz
   have MCA0 := MCA hcarry2_nz hborrow
+  have MCA0f := cpsTripleWithin_frameR (regOwn .x1) (by pcFree) MCA0
   have SL := divK_store_loop_j0_spec_within_noNop sp q_out u4_out carryOut qOld base
   intro_lets at SL
   have TFf := cpsTripleWithin_frameR
@@ -99,7 +100,7 @@ theorem divK_loop_body_n2_call_addback_j0_beq_spec_within_noNop
      ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
      (qAddr ↦ₘ qOld))
     (by pcFree) TF
-  seqFrame TFf MCA0
+  seqFrame TFf MCA0f
   have SLf := cpsTripleWithin_frameR
     ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
      (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
@@ -112,10 +113,10 @@ theorem divK_loop_body_n2_call_addback_j0_beq_spec_within_noNop
      (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
      (sp + signExtend12 3960 ↦ₘ v1) **
      (sp + signExtend12 3952 ↦ₘ dLo) **
-     (sp + signExtend12 3944 ↦ₘ div_un0))
+     (sp + signExtend12 3944 ↦ₘ div_un0) ** regOwn .x1)
     (by pcFree) SL
   have full := cpsTripleWithin_seq_perm_same_cr
-    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
+    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0f SLf
   exact cpsTripleWithin_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
@@ -136,7 +137,7 @@ theorem divK_loop_body_n2_max_addback_jgt0_beq_spec_within_noNop (j : Word)
     let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTripleWithin 152 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -218,7 +219,7 @@ theorem divK_loop_body_n2_call_addback_jgt0_beq_spec_within_noNop (j : Word)
     let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     cpsTripleWithin 202 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -232,7 +233,7 @@ theorem divK_loop_body_n2_call_addback_jgt0_beq_spec_within_noNop (j : Word)
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (loopBodyN2CallAddbackBeqPostJ sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro uBase qAddr
   let dHi := v1 >>> (32 : BitVec 6).toNat
@@ -290,6 +291,7 @@ theorem divK_loop_body_n2_call_addback_jgt0_beq_spec_within_noNop (j : Word)
   intro_lets at MCA
   unfold isAddbackCarry2NzN2Call isAddbackCarry2Nz div128Quot at hcarry2_nz
   have MCA0 := MCA hcarry2_nz hborrow
+  have MCA0f := cpsTripleWithin_frameR (regOwn .x1) (by pcFree) MCA0
   have SL := divK_store_loop_jgt0_spec_within_noNop sp j q_out u4_out carryOut qOld base hpos
   intro_lets at SL
   have TFf := cpsTripleWithin_frameR
@@ -298,7 +300,7 @@ theorem divK_loop_body_n2_call_addback_jgt0_beq_spec_within_noNop (j : Word)
      ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
      (qAddr ↦ₘ qOld))
     (by pcFree) TF
-  seqFrame TFf MCA0
+  seqFrame TFf MCA0f
   have SLf := cpsTripleWithin_frameR
     ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
      (sp + signExtend12 3976 ↦ₘ j) **
@@ -311,10 +313,10 @@ theorem divK_loop_body_n2_call_addback_jgt0_beq_spec_within_noNop (j : Word)
      (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
      (sp + signExtend12 3960 ↦ₘ v1) **
      (sp + signExtend12 3952 ↦ₘ dLo) **
-     (sp + signExtend12 3944 ↦ₘ div_un0))
+     (sp + signExtend12 3944 ↦ₘ div_un0) ** regOwn .x1)
     (by pcFree) SL
   have full := cpsTripleWithin_seq_perm_same_cr
-    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
+    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0f SLf
   exact cpsTripleWithin_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by

--- a/EvmAsm/Evm64/DivMod/LoopIterN3.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN3.lean
@@ -36,7 +36,7 @@ theorem divK_loop_body_n3_max_skip_j0_spec_within
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsTripleWithin 76 (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -134,7 +134,7 @@ theorem divK_loop_body_n3_max_skip_j0_spec_within_noNop
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsTripleWithin 76 (base + loopBodyOff) (base + denormOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -230,7 +230,7 @@ theorem divK_loop_body_n3_call_skip_j0_spec_within
     let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 126 (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -244,7 +244,7 @@ theorem divK_loop_body_n3_call_skip_j0_spec_within
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (loopBodyN3CallSkipPost sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro uBase qAddr
   -- Reconstruct div128 intermediates as raw expressions (matching trial spec's internal let chain)
@@ -292,6 +292,7 @@ theorem divK_loop_body_n3_call_skip_j0_spec_within
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
+  have MCS0f := cpsTripleWithin_frameR (regOwn .x1) (by pcFree) MCS0
   -- Mulsub intermediates for store spec
   let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
   let fs0 := p0_lo + (signExtend12 0 : Word)
@@ -322,7 +323,7 @@ theorem divK_loop_body_n3_call_skip_j0_spec_within
      (qAddr ↦ₘ qOld))
     (by pcFree) TF
   -- 5. Compose TF + MCS0
-  seqFrame TFf MCS0
+  seqFrame TFf MCS0f
   -- 6. Frame store_loop_j0
   have SLf := cpsTripleWithin_frameR
     ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
@@ -336,11 +337,11 @@ theorem divK_loop_body_n3_call_skip_j0_spec_within
      (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
      (sp + signExtend12 3960 ↦ₘ v2) **
      (sp + signExtend12 3952 ↦ₘ dLo) **
-     (sp + signExtend12 3944 ↦ₘ div_un0))
+     (sp + signExtend12 3944 ↦ₘ div_un0) ** regOwn .x1)
     (by pcFree) SL
   -- 7. Compose
   have full := cpsTripleWithin_seq_perm_same_cr
-    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
+    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0f SLf
   exact cpsTripleWithin_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
@@ -361,7 +362,7 @@ theorem divK_loop_body_n3_call_skip_j0_spec_within_noNop
     let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 126 (base + loopBodyOff) (base + denormOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -375,7 +376,7 @@ theorem divK_loop_body_n3_call_skip_j0_spec_within_noNop
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (loopBodyN3CallSkipPost sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro uBase qAddr
   let dHi := v2 >>> (32 : BitVec 6).toNat
@@ -418,6 +419,7 @@ theorem divK_loop_body_n3_call_skip_j0_spec_within_noNop
     x1Exit q0' dHi x7Exit q1' (base + div128CallRetOff) base
   intro_lets at MCS
   have MCS0 := MCS hborrow
+  have MCS0f := cpsTripleWithin_frameR (regOwn .x1) (by pcFree) MCS0
   let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
   let fs0 := p0_lo + (signExtend12 0 : Word)
   let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
@@ -444,7 +446,7 @@ theorem divK_loop_body_n3_call_skip_j0_spec_within_noNop
      ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
      (qAddr ↦ₘ qOld))
     (by pcFree) TF
-  seqFrame TFf MCS0
+  seqFrame TFf MCS0f
   have SLf := cpsTripleWithin_frameR
     ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
      (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
@@ -457,10 +459,10 @@ theorem divK_loop_body_n3_call_skip_j0_spec_within_noNop
      (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
      (sp + signExtend12 3960 ↦ₘ v2) **
      (sp + signExtend12 3952 ↦ₘ dLo) **
-     (sp + signExtend12 3944 ↦ₘ div_un0))
+     (sp + signExtend12 3944 ↦ₘ div_un0) ** regOwn .x1)
     (by pcFree) SL
   have full := cpsTripleWithin_seq_perm_same_cr
-    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
+    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0f SLf
   exact cpsTripleWithin_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
@@ -486,7 +488,7 @@ theorem divK_loop_body_n3_max_skip_j1_spec_within
     let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
     (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsTripleWithin 76 (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (1 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -584,7 +586,7 @@ theorem divK_loop_body_n3_max_skip_j1_spec_within_noNop
     let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
     (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsTripleWithin 76 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (1 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -680,7 +682,7 @@ theorem divK_loop_body_n3_call_skip_j1_spec_within
     let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 126 (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (1 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -694,7 +696,7 @@ theorem divK_loop_body_n3_call_skip_j1_spec_within
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (loopBodyN3CallSkipPostJ sp base (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro uBase qAddr
   -- Reconstruct div128 intermediates as raw expressions
@@ -742,6 +744,7 @@ theorem divK_loop_body_n3_call_skip_j1_spec_within
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
+  have MCS0f := cpsTripleWithin_frameR (regOwn .x1) (by pcFree) MCS0
   -- Mulsub intermediates for store spec
   let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
   let fs0 := p0_lo + (signExtend12 0 : Word)
@@ -772,7 +775,7 @@ theorem divK_loop_body_n3_call_skip_j1_spec_within
      (qAddr ↦ₘ qOld))
     (by pcFree) TF
   -- 5. Compose TF + MCS0
-  seqFrame TFf MCS0
+  seqFrame TFf MCS0f
   -- 6. Frame store_loop_jgt0
   have SLf := cpsTripleWithin_frameR
     ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
@@ -786,11 +789,11 @@ theorem divK_loop_body_n3_call_skip_j1_spec_within
      (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
      (sp + signExtend12 3960 ↦ₘ v2) **
      (sp + signExtend12 3952 ↦ₘ dLo) **
-     (sp + signExtend12 3944 ↦ₘ div_un0))
+     (sp + signExtend12 3944 ↦ₘ div_un0) ** regOwn .x1)
     (by pcFree) SL
   -- 7. Compose
   have full := cpsTripleWithin_seq_perm_same_cr
-    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
+    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0f SLf
   exact cpsTripleWithin_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
@@ -811,7 +814,7 @@ theorem divK_loop_body_n3_call_skip_j1_spec_within_noNop
     let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 126 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (1 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -825,7 +828,7 @@ theorem divK_loop_body_n3_call_skip_j1_spec_within_noNop
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (loopBodyN3CallSkipPostJ sp base (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro uBase qAddr
   let dHi := v2 >>> (32 : BitVec 6).toNat
@@ -868,6 +871,7 @@ theorem divK_loop_body_n3_call_skip_j1_spec_within_noNop
     x1Exit q0' dHi x7Exit q1' (base + div128CallRetOff) base
   intro_lets at MCS
   have MCS0 := MCS hborrow
+  have MCS0f := cpsTripleWithin_frameR (regOwn .x1) (by pcFree) MCS0
   let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
   let fs0 := p0_lo + (signExtend12 0 : Word)
   let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
@@ -894,7 +898,7 @@ theorem divK_loop_body_n3_call_skip_j1_spec_within_noNop
      ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
      (qAddr ↦ₘ qOld))
     (by pcFree) TF
-  seqFrame TFf MCS0
+  seqFrame TFf MCS0f
   have SLf := cpsTripleWithin_frameR
     ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
      (sp + signExtend12 3976 ↦ₘ (1 : Word)) **
@@ -907,10 +911,10 @@ theorem divK_loop_body_n3_call_skip_j1_spec_within_noNop
      (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
      (sp + signExtend12 3960 ↦ₘ v2) **
      (sp + signExtend12 3952 ↦ₘ dLo) **
-     (sp + signExtend12 3944 ↦ₘ div_un0))
+     (sp + signExtend12 3944 ↦ₘ div_un0) ** regOwn .x1)
     (by pcFree) SL
   have full := cpsTripleWithin_seq_perm_same_cr
-    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
+    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0f SLf
   exact cpsTripleWithin_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
@@ -937,7 +941,7 @@ theorem divK_loop_body_n3_max_addback_beq_j0_spec_within
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTripleWithin 152 (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -1022,7 +1026,7 @@ theorem divK_loop_body_n3_max_addback_beq_j0_spec_within_noNop
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTripleWithin 152 (base + loopBodyOff) (base + denormOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -1109,7 +1113,7 @@ theorem divK_loop_body_n3_call_addback_beq_j0_spec_within
     let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 202 (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -1123,7 +1127,7 @@ theorem divK_loop_body_n3_call_addback_beq_j0_spec_within
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (loopBodyN3CallAddbackBeqPost sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro uBase qAddr
   -- Reconstruct div128 intermediates as raw expressions (matching trial spec's internal let chain)
@@ -1188,6 +1192,7 @@ theorem divK_loop_body_n3_call_addback_beq_j0_spec_within
   intro_lets at MCA
   unfold isAddbackCarry2NzN3Call isAddbackCarry2Nz div128Quot at hcarry2_nz
   have MCA0 := MCA hcarry2_nz hborrow
+  have MCA0f := cpsTripleWithin_frameR (regOwn .x1) (by pcFree) MCA0
   -- 3. Store + loop exit j=0 (cpsTripleWithin base+884 → base+908)
   have SL := divK_store_loop_j0_spec_within sp q_out u4_out carryOut qOld base
   intro_lets at SL
@@ -1199,7 +1204,7 @@ theorem divK_loop_body_n3_call_addback_beq_j0_spec_within
      (qAddr ↦ₘ qOld))
     (by pcFree) TF
   -- 5. Compose TF + MCA0
-  seqFrame TFf MCA0
+  seqFrame TFf MCA0f
   -- 6. Frame store_loop_j0
   have SLf := cpsTripleWithin_frameR
     ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
@@ -1213,11 +1218,11 @@ theorem divK_loop_body_n3_call_addback_beq_j0_spec_within
      (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
      (sp + signExtend12 3960 ↦ₘ v2) **
      (sp + signExtend12 3952 ↦ₘ dLo) **
-     (sp + signExtend12 3944 ↦ₘ div_un0))
+     (sp + signExtend12 3944 ↦ₘ div_un0) ** regOwn .x1)
     (by pcFree) SL
   -- 7. Compose
   have full := cpsTripleWithin_seq_perm_same_cr
-    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
+    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0f SLf
   exact cpsTripleWithin_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
@@ -1244,7 +1249,7 @@ theorem divK_loop_body_n3_max_addback_beq_j1_spec_within
     let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
     (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTripleWithin 152 (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (1 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -1336,7 +1341,7 @@ theorem divK_loop_body_n3_call_addback_beq_j1_spec_within
     let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 202 (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (1 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -1350,7 +1355,7 @@ theorem divK_loop_body_n3_call_addback_beq_j1_spec_within
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (loopBodyN3CallAddbackBeqPostJ sp base (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro uBase qAddr
   -- Reconstruct div128 intermediates as raw expressions
@@ -1415,6 +1420,7 @@ theorem divK_loop_body_n3_call_addback_beq_j1_spec_within
   intro_lets at MCA
   unfold isAddbackCarry2NzN3Call isAddbackCarry2Nz div128Quot at hcarry2_nz
   have MCA0 := MCA hcarry2_nz hborrow
+  have MCA0f := cpsTripleWithin_frameR (regOwn .x1) (by pcFree) MCA0
   -- 3. Store + loop back j=1 (cpsTripleWithin base+884 → base+448)
   have SL := divK_store_loop_jgt0_spec_within sp (1 : Word) q_out u4_out carryOut qOld base slt_jpos_1
   intro_lets at SL
@@ -1426,7 +1432,7 @@ theorem divK_loop_body_n3_call_addback_beq_j1_spec_within
      (qAddr ↦ₘ qOld))
     (by pcFree) TF
   -- 5. Compose TF + MCA0
-  seqFrame TFf MCA0
+  seqFrame TFf MCA0f
   -- 6. Frame store_loop_jgt0
   have SLf := cpsTripleWithin_frameR
     ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
@@ -1440,11 +1446,11 @@ theorem divK_loop_body_n3_call_addback_beq_j1_spec_within
      (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
      (sp + signExtend12 3960 ↦ₘ v2) **
      (sp + signExtend12 3952 ↦ₘ dLo) **
-     (sp + signExtend12 3944 ↦ₘ div_un0))
+     (sp + signExtend12 3944 ↦ₘ div_un0) ** regOwn .x1)
     (by pcFree) SL
   -- 7. Compose
   have full := cpsTripleWithin_seq_perm_same_cr
-    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
+    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0f SLf
   exact cpsTripleWithin_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by

--- a/EvmAsm/Evm64/DivMod/LoopIterN3NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN3NoNop.lean
@@ -18,7 +18,7 @@ theorem divK_loop_body_n3_max_addback_beq_j1_spec_within_noNop
     let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
     (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTripleWithin 152 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (1 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -99,7 +99,7 @@ theorem divK_loop_body_n3_call_addback_beq_j0_spec_within_noNop
     let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 202 (base + loopBodyOff) (base + denormOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -113,7 +113,7 @@ theorem divK_loop_body_n3_call_addback_beq_j0_spec_within_noNop
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (loopBodyN3CallAddbackBeqPost sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro uBase qAddr
   let dHi := v2 >>> (32 : BitVec 6).toNat
@@ -171,6 +171,7 @@ theorem divK_loop_body_n3_call_addback_beq_j0_spec_within_noNop
   intro_lets at MCA
   unfold isAddbackCarry2NzN3Call isAddbackCarry2Nz div128Quot at hcarry2_nz
   have MCA0 := MCA hcarry2_nz hborrow
+  have MCA0f := cpsTripleWithin_frameR (regOwn .x1) (by pcFree) MCA0
   have SL := divK_store_loop_j0_spec_within_noNop sp q_out u4_out carryOut qOld base
   intro_lets at SL
   have TFf := cpsTripleWithin_frameR
@@ -179,7 +180,7 @@ theorem divK_loop_body_n3_call_addback_beq_j0_spec_within_noNop
      ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
      (qAddr ↦ₘ qOld))
     (by pcFree) TF
-  seqFrame TFf MCA0
+  seqFrame TFf MCA0f
   have SLf := cpsTripleWithin_frameR
     ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
      (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
@@ -192,10 +193,10 @@ theorem divK_loop_body_n3_call_addback_beq_j0_spec_within_noNop
      (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
      (sp + signExtend12 3960 ↦ₘ v2) **
      (sp + signExtend12 3952 ↦ₘ dLo) **
-     (sp + signExtend12 3944 ↦ₘ div_un0))
+     (sp + signExtend12 3944 ↦ₘ div_un0) ** regOwn .x1)
     (by pcFree) SL
   have full := cpsTripleWithin_seq_perm_same_cr
-    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
+    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0f SLf
   exact cpsTripleWithin_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
@@ -217,7 +218,7 @@ theorem divK_loop_body_n3_call_addback_beq_j1_spec_within_noNop
     let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 202 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (1 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -231,7 +232,7 @@ theorem divK_loop_body_n3_call_addback_beq_j1_spec_within_noNop
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (loopBodyN3CallAddbackBeqPostJ sp base (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro uBase qAddr
   let dHi := v2 >>> (32 : BitVec 6).toNat
@@ -289,6 +290,7 @@ theorem divK_loop_body_n3_call_addback_beq_j1_spec_within_noNop
   intro_lets at MCA
   unfold isAddbackCarry2NzN3Call isAddbackCarry2Nz div128Quot at hcarry2_nz
   have MCA0 := MCA hcarry2_nz hborrow
+  have MCA0f := cpsTripleWithin_frameR (regOwn .x1) (by pcFree) MCA0
   have SL := divK_store_loop_jgt0_spec_within_noNop sp (1 : Word) q_out u4_out carryOut qOld base slt_jpos_1
   intro_lets at SL
   have TFf := cpsTripleWithin_frameR
@@ -297,7 +299,7 @@ theorem divK_loop_body_n3_call_addback_beq_j1_spec_within_noNop
      ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
      (qAddr ↦ₘ qOld))
     (by pcFree) TF
-  seqFrame TFf MCA0
+  seqFrame TFf MCA0f
   have SLf := cpsTripleWithin_frameR
     ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
      (sp + signExtend12 3976 ↦ₘ (1 : Word)) **
@@ -310,10 +312,10 @@ theorem divK_loop_body_n3_call_addback_beq_j1_spec_within_noNop
      (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
      (sp + signExtend12 3960 ↦ₘ v2) **
      (sp + signExtend12 3952 ↦ₘ dLo) **
-     (sp + signExtend12 3944 ↦ₘ div_un0))
+     (sp + signExtend12 3944 ↦ₘ div_un0) ** regOwn .x1)
     (by pcFree) SL
   have full := cpsTripleWithin_seq_perm_same_cr
-    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
+    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0f SLf
   exact cpsTripleWithin_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by

--- a/EvmAsm/Evm64/DivMod/LoopIterN4.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN4.lean
@@ -32,7 +32,7 @@ theorem divK_loop_body_n4_max_skip_j0_spec_within
     -- Hypothesis: borrow = 0
     (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsTripleWithin 76 (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -130,7 +130,7 @@ theorem divK_loop_body_n4_max_skip_j0_spec_within_noNop
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsTripleWithin 76 (base + loopBodyOff) (base + denormOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -250,7 +250,7 @@ private theorem divK_loop_body_n4_call_skip_j0_spec_within
     -- Hypothesis: borrow = 0
     (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsTripleWithin 126 (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -264,12 +264,12 @@ private theorem divK_loop_body_n4_call_skip_j0_spec_within
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (loopBodyN4SkipPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
        (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
        (sp + signExtend12 3960 ↦ₘ v3) **
        (sp + signExtend12 3952 ↦ₘ dLo) **
-       (sp + signExtend12 3944 ↦ₘ div_un0)) := by
+       (sp + signExtend12 3944 ↦ₘ div_un0) ** regOwn .x1) := by
   intro uBase
         dHi dLo div_un1 div_un0 q1 rhat hi1 q1c rhatc qDlo rhatUn1 q1' rhat'
         cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0' qHat
@@ -315,6 +315,7 @@ private theorem divK_loop_body_n4_call_skip_j0_spec_within
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
+  have MCS0f := cpsTripleWithin_frameR (regOwn .x1) (by pcFree) MCS0
   -- 3. Store + loop exit j=0 (cpsTripleWithin base+880 → base+904)
   have SL := divK_store_loop_j0_spec_within sp qHat u4_new (0 : Word) qOld base
   intro_lets at SL
@@ -326,7 +327,7 @@ private theorem divK_loop_body_n4_call_skip_j0_spec_within
      (qAddr ↦ₘ qOld))
     (by pcFree) TF
   -- 5. Compose TF + MCS0
-  seqFrame TFf MCS0
+  seqFrame TFf MCS0f
   -- 6. Frame store_loop_j0
   have SLf := cpsTripleWithin_frameR
     ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
@@ -340,11 +341,11 @@ private theorem divK_loop_body_n4_call_skip_j0_spec_within
      (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
      (sp + signExtend12 3960 ↦ₘ v3) **
      (sp + signExtend12 3952 ↦ₘ dLo) **
-     (sp + signExtend12 3944 ↦ₘ div_un0))
+     (sp + signExtend12 3944 ↦ₘ div_un0) ** regOwn .x1)
     (by pcFree) SL
   -- 7. Compose
   have full := cpsTripleWithin_seq_perm_same_cr
-    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
+    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0f SLf
   exact cpsTripleWithin_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by delta loopBodyN4SkipPost loopBodySkipPost mulsubN4 loopExitPostN4 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
@@ -385,7 +386,7 @@ private theorem divK_loop_body_n4_call_skip_j0_spec_within_noNop
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsTripleWithin 126 (base + loopBodyOff) (base + denormOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -399,12 +400,12 @@ private theorem divK_loop_body_n4_call_skip_j0_spec_within_noNop
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (loopBodyN4SkipPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
        (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
        (sp + signExtend12 3960 ↦ₘ v3) **
        (sp + signExtend12 3952 ↦ₘ dLo) **
-       (sp + signExtend12 3944 ↦ₘ div_un0)) := by
+       (sp + signExtend12 3944 ↦ₘ div_un0) ** regOwn .x1) := by
   intro uBase
         dHi dLo div_un1 div_un0 q1 rhat hi1 q1c rhatc qDlo rhatUn1 q1' rhat'
         cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0' qHat
@@ -448,6 +449,7 @@ private theorem divK_loop_body_n4_call_skip_j0_spec_within_noNop
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
+  have MCS0f := cpsTripleWithin_frameR (regOwn .x1) (by pcFree) MCS0
   have SL := divK_store_loop_j0_spec_within_noNop sp qHat u4_new (0 : Word) qOld base
   intro_lets at SL
   have TFf := cpsTripleWithin_frameR
@@ -456,7 +458,7 @@ private theorem divK_loop_body_n4_call_skip_j0_spec_within_noNop
      ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
      (qAddr ↦ₘ qOld))
     (by pcFree) TF
-  seqFrame TFf MCS0
+  seqFrame TFf MCS0f
   have SLf := cpsTripleWithin_frameR
     ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
      (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
@@ -469,10 +471,10 @@ private theorem divK_loop_body_n4_call_skip_j0_spec_within_noNop
      (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
      (sp + signExtend12 3960 ↦ₘ v3) **
      (sp + signExtend12 3952 ↦ₘ dLo) **
-     (sp + signExtend12 3944 ↦ₘ div_un0))
+     (sp + signExtend12 3944 ↦ₘ div_un0) ** regOwn .x1)
     (by pcFree) SL
   have full := cpsTripleWithin_seq_perm_same_cr
-    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
+    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0f SLf
   exact cpsTripleWithin_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by delta loopBodyN4SkipPost loopBodySkipPost mulsubN4 loopExitPostN4 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
@@ -524,7 +526,7 @@ private theorem divK_loop_body_n4_call_addback_j0_beq_spec_within
     -- Hypothesis: borrow ≠ 0
     (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTripleWithin 202 (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -538,12 +540,12 @@ private theorem divK_loop_body_n4_call_addback_j0_beq_spec_within
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (loopBodyN4AddbackBeqPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
        (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
        (sp + signExtend12 3960 ↦ₘ v3) **
        (sp + signExtend12 3952 ↦ₘ dLo) **
-       (sp + signExtend12 3944 ↦ₘ div_un0)) := by
+       (sp + signExtend12 3944 ↦ₘ div_un0) ** regOwn .x1) := by
   intro uBase
         dHi dLo div_un1 div_un0 q1 rhat hi1 q1c rhatc qDlo rhatUn1 q1' rhat'
         cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0' qHat
@@ -586,6 +588,7 @@ private theorem divK_loop_body_n4_call_addback_j0_beq_spec_within
   intro_lets at MCA
   unfold isAddbackCarry2NzN4Call isAddbackCarry2Nz div128Quot at hcarry2_nz
   have MCA0 := MCA hcarry2_nz hborrow
+  have MCA0f := cpsTripleWithin_frameR (regOwn .x1) (by pcFree) MCA0
   -- 3. Store loop (use q_out, u4_out, carryOut)
   have SL := divK_store_loop_j0_spec_within sp q_out u4_out carryOut qOld base
   intro_lets at SL
@@ -597,7 +600,7 @@ private theorem divK_loop_body_n4_call_addback_j0_beq_spec_within
      (qAddr ↦ₘ qOld))
     (by pcFree) TF
   -- 5. Compose TF + MCA0
-  seqFrame TFf MCA0
+  seqFrame TFf MCA0f
   -- 6. Frame store_loop_j0
   have SLf := cpsTripleWithin_frameR
     ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
@@ -611,11 +614,11 @@ private theorem divK_loop_body_n4_call_addback_j0_beq_spec_within
      (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
      (sp + signExtend12 3960 ↦ₘ v3) **
      (sp + signExtend12 3952 ↦ₘ dLo) **
-     (sp + signExtend12 3944 ↦ₘ div_un0))
+     (sp + signExtend12 3944 ↦ₘ div_un0) ** regOwn .x1)
     (by pcFree) SL
   -- 7. Compose
   have full := cpsTripleWithin_seq_perm_same_cr
-    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
+    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0f SLf
   exact cpsTripleWithin_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by delta loopBodyN4AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN4 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
@@ -657,7 +660,7 @@ private theorem divK_loop_body_n4_call_addback_j0_beq_spec_within_noNop
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTripleWithin 202 (base + loopBodyOff) (base + denormOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -671,12 +674,12 @@ private theorem divK_loop_body_n4_call_addback_j0_beq_spec_within_noNop
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (loopBodyN4AddbackBeqPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
        (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
        (sp + signExtend12 3960 ↦ₘ v3) **
        (sp + signExtend12 3952 ↦ₘ dLo) **
-       (sp + signExtend12 3944 ↦ₘ div_un0)) := by
+       (sp + signExtend12 3944 ↦ₘ div_un0) ** regOwn .x1) := by
   intro uBase
         dHi dLo div_un1 div_un0 q1 rhat hi1 q1c rhatc qDlo rhatUn1 q1' rhat'
         cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0' qHat
@@ -715,6 +718,7 @@ private theorem divK_loop_body_n4_call_addback_j0_beq_spec_within_noNop
   intro_lets at MCA
   unfold isAddbackCarry2NzN4Call isAddbackCarry2Nz div128Quot at hcarry2_nz
   have MCA0 := MCA hcarry2_nz hborrow
+  have MCA0f := cpsTripleWithin_frameR (regOwn .x1) (by pcFree) MCA0
   have SL := divK_store_loop_j0_spec_within_noNop sp q_out u4_out carryOut qOld base
   intro_lets at SL
   have TFf := cpsTripleWithin_frameR
@@ -723,7 +727,7 @@ private theorem divK_loop_body_n4_call_addback_j0_beq_spec_within_noNop
      ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
      (qAddr ↦ₘ qOld))
     (by pcFree) TF
-  seqFrame TFf MCA0
+  seqFrame TFf MCA0f
   have SLf := cpsTripleWithin_frameR
     ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
      (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
@@ -736,10 +740,10 @@ private theorem divK_loop_body_n4_call_addback_j0_beq_spec_within_noNop
      (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
      (sp + signExtend12 3960 ↦ₘ v3) **
      (sp + signExtend12 3952 ↦ₘ dLo) **
-     (sp + signExtend12 3944 ↦ₘ div_un0))
+     (sp + signExtend12 3944 ↦ₘ div_un0) ** regOwn .x1)
     (by pcFree) SL
   have full := cpsTripleWithin_seq_perm_same_cr
-    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
+    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0f SLf
   exact cpsTripleWithin_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by delta loopBodyN4AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN4 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
@@ -762,7 +766,7 @@ def loopBodyN4CallSkipJ0Pre
      retMem dMem dloMem scratch_un0 : Word) : Assertion :=
   let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
   let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
-  (.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+  (.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
   (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
   (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
   (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -776,7 +780,7 @@ def loopBodyN4CallSkipJ0Pre
   (sp + signExtend12 3968 ↦ₘ retMem) **
   (sp + signExtend12 3960 ↦ₘ dMem) **
   (sp + signExtend12 3952 ↦ₘ dloMem) **
-  (sp + signExtend12 3944 ↦ₘ scratch_un0)
+  (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1
 
 /-- Named unfold for `loopBodyN4CallSkipJ0Pre`. -/
 theorem loopBodyN4CallSkipJ0Pre_unfold
@@ -787,7 +791,7 @@ theorem loopBodyN4CallSkipJ0Pre_unfold
       v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 =
     (let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
      let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
-     (.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+     (.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
      (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
      (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
      (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -801,7 +805,7 @@ theorem loopBodyN4CallSkipJ0Pre_unfold
      (sp + signExtend12 3968 ↦ₘ retMem) **
      (sp + signExtend12 3960 ↦ₘ dMem) **
      (sp + signExtend12 3952 ↦ₘ dloMem) **
-     (sp + signExtend12 3944 ↦ₘ scratch_un0)) := by
+     (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1) := by
   delta loopBodyN4CallSkipJ0Pre; rfl
 
 /-- Bundled postcondition for the call_skip j=0 loop body. -/
@@ -815,7 +819,7 @@ def loopBodyN4CallSkipJ0Post (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
   (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
   (sp + signExtend12 3960 ↦ₘ v3) **
   (sp + signExtend12 3952 ↦ₘ dLo) **
-  (sp + signExtend12 3944 ↦ₘ div_un0)
+  (sp + signExtend12 3944 ↦ₘ div_un0) ** regOwn .x1
 
 /-- Named unfold for `loopBodyN4CallSkipJ0Post`. -/
 theorem loopBodyN4CallSkipJ0Post_unfold
@@ -828,7 +832,7 @@ theorem loopBodyN4CallSkipJ0Post_unfold
      (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
      (sp + signExtend12 3960 ↦ₘ v3) **
      (sp + signExtend12 3952 ↦ₘ dLo) **
-     (sp + signExtend12 3944 ↦ₘ div_un0)) := by
+     (sp + signExtend12 3944 ↦ₘ div_un0) ** regOwn .x1) := by
   delta loopBodyN4CallSkipJ0Post; rfl
 
 /-- Bundled postcondition for the call_addback (BEQ) j=0 loop body. -/
@@ -842,7 +846,7 @@ def loopBodyN4CallAddbackBeqJ0Post
   (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
   (sp + signExtend12 3960 ↦ₘ v3) **
   (sp + signExtend12 3952 ↦ₘ dLo) **
-  (sp + signExtend12 3944 ↦ₘ div_un0)
+  (sp + signExtend12 3944 ↦ₘ div_un0) ** regOwn .x1
 
 /-- Named unfold for `loopBodyN4CallAddbackBeqJ0Post`. -/
 theorem loopBodyN4CallAddbackBeqJ0Post_unfold
@@ -855,7 +859,7 @@ theorem loopBodyN4CallAddbackBeqJ0Post_unfold
      (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
      (sp + signExtend12 3960 ↦ₘ v3) **
      (sp + signExtend12 3952 ↦ₘ dLo) **
-     (sp + signExtend12 3944 ↦ₘ div_un0)) := by
+     (sp + signExtend12 3944 ↦ₘ div_un0) ** regOwn .x1) := by
   delta loopBodyN4CallAddbackBeqJ0Post; rfl
 
 -- ============================================================================

--- a/EvmAsm/Evm64/DivMod/LoopUnifiedN1.lean
+++ b/EvmAsm/Evm64/DivMod/LoopUnifiedN1.lean
@@ -76,7 +76,7 @@ theorem divK_loop_n1_iter10_unified_spec_within (bltu_1 bltu_0 : Bool)
     have J1f := cpsTripleWithin_frameR
       (((u_base_0 + signExtend12 0) ↦ₘ u0Orig) ** (q_addr_0 ↦ₘ q0Old) **
        (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
-       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (by pcFree) J1
     -- Derive j=0 validity via j=1->j=0 address linking
     -- j=0 max  spec (inputs from j=1 via iterN1Max)
@@ -105,7 +105,7 @@ theorem divK_loop_n1_iter10_unified_spec_within (bltu_1 bltu_0 : Bool)
       (((u_base_1 + signExtend12 4064) ↦ₘ (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.2) **
        (q_addr_1 ↦ₘ (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).1) **
        (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
-       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (by pcFree) J0
     -- Compose j=1 and j=0 via address rewriting
     have full := cpsTripleWithin_seq_perm_same_cr
@@ -146,7 +146,7 @@ theorem divK_loop_n1_iter10_unified_spec_within (bltu_1 bltu_0 : Bool)
     have J1f := cpsTripleWithin_frameR
       (((u_base_0 + signExtend12 0) ↦ₘ u0Orig) ** (q_addr_0 ↦ₘ q0Old) **
        (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
-       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (by pcFree) J1
     -- j=0 call  spec (includes scratch in pre/post)
     have J0 := divK_loop_body_n1_call_unified_j0_spec_within sp (1 : Word)
@@ -241,7 +241,7 @@ theorem divK_loop_n1_iter10_unified_spec_within (bltu_1 bltu_0 : Bool)
        (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
        (sp + signExtend12 3960 ↦ₘ v0) **
        (sp + signExtend12 3952 ↦ₘ div128DLo v0) **
-       (sp + signExtend12 3944 ↦ₘ div128Un0 u0))
+       (sp + signExtend12 3944 ↦ₘ div128Un0 u0) ** regOwn .x1)
       (by pcFree) J0
     have full := cpsTripleWithin_seq_perm_same_cr
       (fun h hp => by
@@ -367,7 +367,7 @@ theorem divK_loop_n1_iter10_unified_spec_within_noNop (bltu_1 bltu_0 : Bool)
     have J1f := cpsTripleWithin_frameR
       (((u_base_0 + signExtend12 0) ↦ₘ u0Orig) ** (q_addr_0 ↦ₘ q0Old) **
        (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
-       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (by pcFree) J1
     -- Derive j=0 validity via j=1->j=0 address linking
     -- j=0 max  spec (inputs from j=1 via iterN1Max)
@@ -396,7 +396,7 @@ theorem divK_loop_n1_iter10_unified_spec_within_noNop (bltu_1 bltu_0 : Bool)
       (((u_base_1 + signExtend12 4064) ↦ₘ (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.2) **
        (q_addr_1 ↦ₘ (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).1) **
        (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
-       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (by pcFree) J0
     -- Compose j=1 and j=0 via address rewriting
     have full := cpsTripleWithin_seq_perm_same_cr
@@ -437,7 +437,7 @@ theorem divK_loop_n1_iter10_unified_spec_within_noNop (bltu_1 bltu_0 : Bool)
     have J1f := cpsTripleWithin_frameR
       (((u_base_0 + signExtend12 0) ↦ₘ u0Orig) ** (q_addr_0 ↦ₘ q0Old) **
        (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
-       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (by pcFree) J1
     -- j=0 call  spec (includes scratch in pre/post)
     have J0 := divK_loop_body_n1_call_unified_j0_spec_within_noNop sp (1 : Word)
@@ -532,7 +532,7 @@ theorem divK_loop_n1_iter10_unified_spec_within_noNop (bltu_1 bltu_0 : Bool)
        (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
        (sp + signExtend12 3960 ↦ₘ v0) **
        (sp + signExtend12 3952 ↦ₘ div128DLo v0) **
-       (sp + signExtend12 3944 ↦ₘ div128Un0 u0))
+       (sp + signExtend12 3944 ↦ₘ div128Un0 u0) ** regOwn .x1)
       (by pcFree) J0
     have full := cpsTripleWithin_seq_perm_same_cr
       (fun h hp => by
@@ -667,7 +667,7 @@ theorem divK_loop_n1_max_iter10_spec_within (bltu_1 bltu_0 : Bool)
     (((u_base_1 + signExtend12 0) ↦ₘ u0_orig_1) ** (q_addr_1 ↦ₘ q1Old) **
      ((u_base_0 + signExtend12 0) ↦ₘ u0_orig_0) ** (q_addr_0 ↦ₘ q0Old) **
      (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
-     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
     (by pcFree) J2
   -- iter10  unified spec (inputs from j=2 max  output)
   have H10 := divK_loop_n1_iter10_unified_spec_within bltu_1 bltu_0
@@ -747,7 +747,7 @@ theorem divK_loop_n1_max_iter10_spec_within_noNop (bltu_1 bltu_0 : Bool)
     (((u_base_1 + signExtend12 0) ↦ₘ u0_orig_1) ** (q_addr_1 ↦ₘ q1Old) **
      ((u_base_0 + signExtend12 0) ↦ₘ u0_orig_0) ** (q_addr_0 ↦ₘ q0Old) **
      (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
-     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
     (by pcFree) J2
   -- iter10  unified spec (inputs from j=2 max  output)
   have H10 := divK_loop_n1_iter10_unified_spec_within_noNop bltu_1 bltu_0
@@ -1113,7 +1113,7 @@ theorem divK_loop_n1_max_iter210_spec_within (bltu_2 bltu_1 bltu_0 : Bool)
      ((u_base_1 + signExtend12 0) ↦ₘ u0_orig_1) ** (q_addr_1 ↦ₘ q1Old) **
      ((u_base_0 + signExtend12 0) ↦ₘ u0_orig_0) ** (q_addr_0 ↦ₘ q0Old) **
      (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
-     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
     (by pcFree) J3
   -- iter210  unified spec (inputs from j=3 max  output)
   have H210 := divK_loop_n1_iter210_unified_spec_within bltu_2 bltu_1 bltu_0
@@ -1221,7 +1221,7 @@ theorem divK_loop_n1_max_iter210_spec_within_noNop (bltu_2 bltu_1 bltu_0 : Bool)
      ((u_base_1 + signExtend12 0) ↦ₘ u0_orig_1) ** (q_addr_1 ↦ₘ q1Old) **
      ((u_base_0 + signExtend12 0) ↦ₘ u0_orig_0) ** (q_addr_0 ↦ₘ q0Old) **
      (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
-     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
     (by pcFree) J3
   -- iter210  unified spec (inputs from j=3 max  output)
   have H210 := divK_loop_n1_iter210_unified_spec_within_noNop bltu_2 bltu_1 bltu_0

--- a/EvmAsm/Evm64/DivMod/LoopUnifiedN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopUnifiedN2.lean
@@ -58,10 +58,10 @@ theorem divK_loop_n2_iter10_unified_spec_within (bltu_1 bltu_0 : Bool)
       v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old base
       hbltu_1' hbltu_0' hcarry2
     have hMMF := cpsTripleWithin_frameR
-      ((sp + signExtend12 3968 ↦ₘ retMem) **
-       (sp + signExtend12 3960 ↦ₘ dMem) **
-       (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+     ((sp + signExtend12 3968 ↦ₘ retMem) **
+      (sp + signExtend12 3960 ↦ₘ dMem) **
+      (sp + signExtend12 3952 ↦ₘ dloMem) **
+      (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (by pcFree) hMM
     exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
       (fun h hp => by delta loopN2Iter10PreWithScratch at hp; xperm_hyp hp)
@@ -136,10 +136,10 @@ theorem divK_loop_n2_iter10_unified_spec_within_noNop (bltu_1 bltu_0 : Bool)
       v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old base
       hbltu_1' hbltu_0' hcarry2
     have hMMF := cpsTripleWithin_frameR
-      ((sp + signExtend12 3968 ↦ₘ retMem) **
-       (sp + signExtend12 3960 ↦ₘ dMem) **
-       (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+     ((sp + signExtend12 3968 ↦ₘ retMem) **
+      (sp + signExtend12 3960 ↦ₘ dMem) **
+      (sp + signExtend12 3952 ↦ₘ dloMem) **
+      (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (by pcFree) hMM
     exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
       (fun h hp => by delta loopN2Iter10PreWithScratch at hp; xperm_hyp hp)
@@ -227,7 +227,7 @@ theorem divK_loop_n2_max_iter10_spec_within (bltu_1 bltu_0 : Bool)
     (((u_base_1 + signExtend12 0) ↦ₘ u0_orig_1) ** (q_addr_1 ↦ₘ q1Old) **
      ((u_base_0 + signExtend12 0) ↦ₘ u0_orig_0) ** (q_addr_0 ↦ₘ q0Old) **
      (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
-     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
     (by pcFree) J2
   have H10 := divK_loop_n2_iter10_unified_spec_within bltu_1 bltu_0
     sp (2 : Word) ((2 : Word) <<< (3 : BitVec 6).toNat) u_base_2 q_addr_2
@@ -302,7 +302,7 @@ theorem divK_loop_n2_max_iter10_spec_within_noNop (bltu_1 bltu_0 : Bool)
     (((u_base_1 + signExtend12 0) ↦ₘ u0_orig_1) ** (q_addr_1 ↦ₘ q1Old) **
      ((u_base_0 + signExtend12 0) ↦ₘ u0_orig_0) ** (q_addr_0 ↦ₘ q0Old) **
      (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
-     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
     (by pcFree) J2
   have H10 := divK_loop_n2_iter10_unified_spec_within_noNop bltu_1 bltu_0
     sp (2 : Word) ((2 : Word) <<< (3 : BitVec 6).toNat) u_base_2 q_addr_2

--- a/EvmAsm/Evm64/DivMod/LoopUnifiedN3.lean
+++ b/EvmAsm/Evm64/DivMod/LoopUnifiedN3.lean
@@ -59,7 +59,7 @@ theorem divK_loop_n3_unified_spec_within (bltu_1 bltu_0 : Bool)
       ((sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (by pcFree) hMM
     exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
       (fun h hp => by delta loopN3PreWithScratch at hp; xperm_hyp hp)
@@ -131,7 +131,7 @@ theorem divK_loop_n3_unified_spec_within_noNop (bltu_1 bltu_0 : Bool)
       ((sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
       (by pcFree) hMM
     exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
       (fun h hp => by delta loopN3PreWithScratch at hp; xperm_hyp hp)

--- a/EvmAsm/Evm64/DivMod/N4StackSpec.lean
+++ b/EvmAsm/Evm64/DivMod/N4StackSpec.lean
@@ -86,7 +86,7 @@ theorem evm_div_n4_stack_spec_exact_x1 (sp base : Word)
          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
          shiftMem nMem jMem retMem dMem dloMem scratch_un0)
       (divN4CallSkipStackPostNoX1 sp a b **
-        (.x1 ↦ᵣ signExtend12 (4095 : BitVec 12))) := by
+        (.x9 ↦ᵣ signExtend12 (4095 : BitVec 12))) := by
   by_cases hshift : (clzResult (b.getLimbN 3)).1 = 0
   · exact cpsTripleWithin_mono_nSteps (by decide) <|
       evm_div_n4_shift0_stack_spec_exact_x1 sp base a b

--- a/EvmAsm/Evm64/DivMod/N4StackSpecWithin.lean
+++ b/EvmAsm/Evm64/DivMod/N4StackSpecWithin.lean
@@ -38,8 +38,8 @@ theorem divN4CallSkipStackPostNoX1_eq_divStackDispatchPostNoX1
 theorem divN4CallSkipStackPostNoX1_to_divStackDispatchPostNoX1_frame
     (sp : Word) (a b : EvmWord) {v1 : Word} :
     ∀ h,
-      (divN4CallSkipStackPostNoX1 sp a b ** (.x1 ↦ᵣ v1)) h →
-      (divStackDispatchPostNoX1 sp a b ** (.x1 ↦ᵣ v1)) h := by
+      (divN4CallSkipStackPostNoX1 sp a b ** (.x9 ↦ᵣ v1)) h →
+      (divStackDispatchPostNoX1 sp a b ** (.x9 ↦ᵣ v1)) h := by
   intro h hp
   rw [← divN4CallSkipStackPostNoX1_eq_divStackDispatchPostNoX1]
   exact hp
@@ -107,7 +107,7 @@ theorem evm_div_n4_stack_spec_within_dispatch_exact_x1 (sp base : Word)
         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
         shiftMem nMem jMem retMem dMem dloMem scratch_un0)
       (divStackDispatchPostNoX1 sp a b **
-        (.x1 ↦ᵣ signExtend12 (4095 : BitVec 12))) := by
+        (.x9 ↦ᵣ signExtend12 (4095 : BitVec 12))) := by
   have hN4 := evm_div_n4_stack_spec_exact_x1 sp base a b
     v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
     nMem shiftMem jMem retMem dMem dloMem scratch_un0

--- a/EvmAsm/Evm64/DivMod/Program.lean
+++ b/EvmAsm/Evm64/DivMod/Program.lean
@@ -29,7 +29,8 @@
 
   Register allocation:
     x12 = EVM stack pointer (preserved)
-    x1  = loop counter j / temp
+    x9  = loop counter j
+    x1  = temp (used inside div128 subroutine)
     x2  = antiShift / subroutine return addr
     x5  = general temp
     x6  = general temp / uBase in mul-sub
@@ -52,7 +53,7 @@ open EvmAsm.Rv64
     Called via JAL x2, offset. Returns via JALR x0, x2, 0.
     Input: x7 = uHi (< d), x5 = uLo, x10 = d (normalized, >= 2^63)
     Output: x11 = floor((uHi * 2^64 + uLo) / d)
-    Clobbers: x1, x5, x6, x7, x10, x11. Preserves: x2, x12.
+    Clobbers: .x9, x5, x6, x7, x10, x11. Preserves: x2, x12.
     Uses scratch memory at 3992, 3984, 3976, 3968 (offsets from x12). -/
 def divK_div128 : Program :=
   -- Save return addr and d
@@ -60,8 +61,8 @@ def divK_div128 : Program :=
   SD .x12 .x10 3960 ;;                        -- [1]  save d
   -- Split d: dHi = d >> 32, dLo = (d << 32) >> 32
   SRLI .x6 .x10 32 ;;                         -- [2]  x6 = dHi (>= 2^31)
-  SLLI .x1 .x10 32 ;; SRLI .x1 .x1 32 ;;     -- [3,4] x1 = dLo
-  SD .x12 .x1 3952 ;;                         -- [5]  save dLo
+  SLLI .x9 .x10 32 ;; SRLI .x9 .x9 32 ;;     -- [3,4] x9 = dLo
+  SD .x12 .x9 3952 ;;                         -- [5]  save dLo
   -- Split uLo: un1 = uLo >> 32, un0 = (uLo << 32) >> 32
   SRLI .x11 .x5 32 ;;                         -- [6]  x11 = un1
   SLLI .x5 .x5 32 ;; SRLI .x5 .x5 32 ;;      -- [7,8] x5 = un0
@@ -77,42 +78,42 @@ def divK_div128 : Program :=
   ADDI .x10 .x10 4095 ;;                      -- [15] q1--
   single (.ADD .x7 .x7 .x6) ;;               -- [16] rhat += dHi
   -- [17] Product check: q1*dLo > rhat*2^32 + un1?
-  LD .x1 .x12 3952 ;;                         -- [17] x1 = dLo
-  single (.MUL .x5 .x10 .x1) ;;              -- [18] x5 = q1 * dLo
-  SLLI .x1 .x7 32 ;;                          -- [19] x1 = rhat << 32
-  single (.OR .x1 .x1 .x11) ;;               -- [20] x1 = rhat*2^32 + un1
-  single (.BLTU .x1 .x5 8) ;;                -- [21] if rhs < lhs → correct [23]
+  LD .x9 .x12 3952 ;;                         -- [17] x9 = dLo
+  single (.MUL .x5 .x10 .x9) ;;              -- [18] x5 = q1 * dLo
+  SLLI .x9 .x7 32 ;;                          -- [19] x9 = rhat << 32
+  single (.OR .x9 .x9 .x11) ;;               -- [20] x9 = rhat*2^32 + un1
+  single (.BLTU .x9 .x5 8) ;;                -- [21] if rhs < lhs → correct [23]
   JAL .x0 12 ;;                                -- [22] skip → [25]
   ADDI .x10 .x10 4095 ;;                      -- [23] q1--
   single (.ADD .x7 .x7 .x6) ;;               -- [24] rhat += dHi
   -- Compute un21 = rhat*2^32 + un1 - q1*dLo
-  LD .x1 .x12 3952 ;;                         -- [25] dLo
+  LD .x9 .x12 3952 ;;                         -- [25] dLo
   SLLI .x5 .x7 32 ;;                          -- [26] rhat << 32
   single (.OR .x5 .x5 .x11) ;;               -- [27] x5 = rhat*2^32 + un1
-  single (.MUL .x1 .x10 .x1) ;;              -- [28] x1 = q1 * dLo
-  single (.SUB .x7 .x5 .x1) ;;               -- [29] x7 = un21
+  single (.MUL .x9 .x10 .x9) ;;              -- [28] x9 = q1 * dLo
+  single (.SUB .x7 .x5 .x9) ;;               -- [29] x7 = un21
   -- Step 2: q0 = DIVU(un21, dHi), rhat2 = un21 - q0*dHi
   single (.DIVU .x5 .x7 .x6) ;;              -- [30] x5 = q0
-  single (.MUL .x1 .x5 .x6) ;;               -- [31]
-  single (.SUB .x11 .x7 .x1) ;;              -- [32] x11 = rhat2
+  single (.MUL .x9 .x5 .x6) ;;               -- [31]
+  single (.SUB .x11 .x7 .x9) ;;              -- [32] x11 = rhat2
   -- Refine q0: clamp
-  SRLI .x1 .x5 32 ;;                          -- [33]
-  single (.BEQ .x1 .x0 12) ;;                -- [34] skip if q0 < 2^32 → [37]
+  SRLI .x9 .x5 32 ;;                          -- [33]
+  single (.BEQ .x9 .x0 12) ;;                -- [34] skip if q0 < 2^32 → [37]
   ADDI .x5 .x5 4095 ;;                        -- [35] q0--
   single (.ADD .x11 .x11 .x6) ;;             -- [36] rhat2 += dHi
   -- [37] Phase 2b guard (Knuth TAOCP §4.3.1 Step D3): skip mul-check
   --      when rhat2c ≥ 2^32 to avoid Word `<< 32` truncation causing
   --      the BLTU to false-positive fire. See counterexample at
   --      `/home/zksecurity/.claude/plans/dynamic-strolling-riddle.md`.
-  SRLI .x1 .x11 32 ;;                         -- [37] x1 = rhat2c >> 32
-  single (.BNE .x1 .x0 36) ;;                -- [38] if nonzero → skip to [47]
+  SRLI .x9 .x11 32 ;;                         -- [37] x9 = rhat2c >> 32
+  single (.BNE .x9 .x0 36) ;;                -- [38] if nonzero → skip to [47]
   -- [39] Product check for q0 (only reached when rhat2c < 2^32)
-  LD .x1 .x12 3952 ;;                         -- [39] dLo
-  single (.MUL .x7 .x5 .x1) ;;               -- [40] x7 = q0 * dLo
-  SLLI .x1 .x11 32 ;;                         -- [41] rhat2 << 32
+  LD .x9 .x12 3952 ;;                         -- [39] dLo
+  single (.MUL .x7 .x5 .x9) ;;               -- [40] x7 = q0 * dLo
+  SLLI .x9 .x11 32 ;;                         -- [41] rhat2 << 32
   LD .x11 .x12 3944 ;;                        -- [42] un0
-  single (.OR .x1 .x1 .x11) ;;               -- [43] x1 = rhat2*2^32 + un0
-  single (.BLTU .x1 .x7 8) ;;                -- [44] if rhs < lhs → correct [46]
+  single (.OR .x9 .x9 .x11) ;;               -- [43] x9 = rhat2*2^32 + un0
+  single (.BLTU .x9 .x7 8) ;;                -- [44] if rhs < lhs → correct [46]
   JAL .x0 8 ;;                                 -- [45] skip → [47]
   ADDI .x5 .x5 4095 ;;                        -- [46] q0--
   -- Combine: q = q1*2^32 + q0
@@ -151,8 +152,8 @@ def divK_div128_v2 : Program :=
   SD .x12 .x10 3960 ;;                        -- [1]  save d
   -- Split d: dHi = d >> 32, dLo = (d << 32) >> 32
   SRLI .x6 .x10 32 ;;                         -- [2]  x6 = dHi (>= 2^31)
-  SLLI .x1 .x10 32 ;; SRLI .x1 .x1 32 ;;     -- [3,4] x1 = dLo
-  SD .x12 .x1 3952 ;;                         -- [5]  save dLo
+  SLLI .x9 .x10 32 ;; SRLI .x9 .x9 32 ;;     -- [3,4] x9 = dLo
+  SD .x12 .x9 3952 ;;                         -- [5]  save dLo
   -- Split uLo: un1 = uLo >> 32, un0 = (uLo << 32) >> 32
   SRLI .x11 .x5 32 ;;                         -- [6]  x11 = un1
   SLLI .x5 .x5 32 ;; SRLI .x5 .x5 32 ;;      -- [7,8] x5 = un0
@@ -167,11 +168,11 @@ def divK_div128_v2 : Program :=
   ADDI .x10 .x10 4095 ;;                      -- [15] q1--
   single (.ADD .x7 .x7 .x6) ;;               -- [16] rhat += dHi
   -- [17] Phase 1b 1st D3 correction: q1*dLo > rhat*2^32 + un1?
-  LD .x1 .x12 3952 ;;                         -- [17] x1 = dLo
-  single (.MUL .x5 .x10 .x1) ;;              -- [18] x5 = q1 * dLo
-  SLLI .x1 .x7 32 ;;                          -- [19] x1 = rhat << 32
-  single (.OR .x1 .x1 .x11) ;;               -- [20] x1 = rhat*2^32 + un1
-  single (.BLTU .x1 .x5 8) ;;                -- [21] if rhs < lhs → correct [23]
+  LD .x9 .x12 3952 ;;                         -- [17] x9 = dLo
+  single (.MUL .x5 .x10 .x9) ;;              -- [18] x5 = q1 * dLo
+  SLLI .x9 .x7 32 ;;                          -- [19] x9 = rhat << 32
+  single (.OR .x9 .x9 .x11) ;;               -- [20] x9 = rhat*2^32 + un1
+  single (.BLTU .x9 .x5 8) ;;                -- [21] if rhs < lhs → correct [23]
   JAL .x0 12 ;;                                -- [22] skip → [25]
   ADDI .x10 .x10 4095 ;;                      -- [23] q1--
   single (.ADD .x7 .x7 .x6) ;;               -- [24] rhat += dHi
@@ -179,42 +180,42 @@ def divK_div128_v2 : Program :=
   --      Guard: skip mul-check when rhat ≥ 2^32 (matches Phase 2b's guard
   --      at [47..48] below). Without this, BLTU would false-positive fire
   --      due to `<< 32` truncation. Mirrors Phase 2b structure.
-  SRLI .x1 .x7 32 ;;                          -- [25] x1 = rhat >> 32
-  single (.BNE .x1 .x0 36) ;;                -- [26] if nonzero → skip to [35]
+  SRLI .x9 .x7 32 ;;                          -- [25] x9 = rhat >> 32
+  single (.BNE .x9 .x0 36) ;;                -- [26] if nonzero → skip to [35]
   -- [27] 2nd D3 product check (only when rhat < 2^32)
-  LD .x1 .x12 3952 ;;                         -- [27] dLo
-  single (.MUL .x5 .x10 .x1) ;;              -- [28] x5 = q1 * dLo
-  SLLI .x1 .x7 32 ;;                          -- [29] x1 = rhat << 32
-  single (.OR .x1 .x1 .x11) ;;               -- [30] x1 = rhat*2^32 + un1
-  single (.BLTU .x1 .x5 8) ;;                -- [31] if rhs < lhs → correct [33]
+  LD .x9 .x12 3952 ;;                         -- [27] dLo
+  single (.MUL .x5 .x10 .x9) ;;              -- [28] x5 = q1 * dLo
+  SLLI .x9 .x7 32 ;;                          -- [29] x9 = rhat << 32
+  single (.OR .x9 .x9 .x11) ;;               -- [30] x9 = rhat*2^32 + un1
+  single (.BLTU .x9 .x5 8) ;;                -- [31] if rhs < lhs → correct [33]
   JAL .x0 12 ;;                                -- [32] skip → [35]
   ADDI .x10 .x10 4095 ;;                      -- [33] q1--
   single (.ADD .x7 .x7 .x6) ;;               -- [34] rhat += dHi
   -- [35] Compute un21 = rhat*2^32 + un1 - q1*dLo
-  LD .x1 .x12 3952 ;;                         -- [35] dLo
+  LD .x9 .x12 3952 ;;                         -- [35] dLo
   SLLI .x5 .x7 32 ;;                          -- [36] rhat << 32
   single (.OR .x5 .x5 .x11) ;;               -- [37] x5 = rhat*2^32 + un1
-  single (.MUL .x1 .x10 .x1) ;;              -- [38] x1 = q1 * dLo
-  single (.SUB .x7 .x5 .x1) ;;               -- [39] x7 = un21
+  single (.MUL .x9 .x10 .x9) ;;              -- [38] x9 = q1 * dLo
+  single (.SUB .x7 .x5 .x9) ;;               -- [39] x7 = un21
   -- Step 2: q0 = DIVU(un21, dHi), rhat2 = un21 - q0*dHi
   single (.DIVU .x5 .x7 .x6) ;;              -- [40] x5 = q0
-  single (.MUL .x1 .x5 .x6) ;;               -- [41]
-  single (.SUB .x11 .x7 .x1) ;;              -- [42] x11 = rhat2
+  single (.MUL .x9 .x5 .x6) ;;               -- [41]
+  single (.SUB .x11 .x7 .x9) ;;              -- [42] x11 = rhat2
   -- Refine q0: clamp
-  SRLI .x1 .x5 32 ;;                          -- [43]
-  single (.BEQ .x1 .x0 12) ;;                -- [44] skip if q0 < 2^32 → [47]
+  SRLI .x9 .x5 32 ;;                          -- [43]
+  single (.BEQ .x9 .x0 12) ;;                -- [44] skip if q0 < 2^32 → [47]
   ADDI .x5 .x5 4095 ;;                        -- [45] q0--
   single (.ADD .x11 .x11 .x6) ;;             -- [46] rhat2 += dHi
   -- [47] Phase 2b guard (rhat2c ≥ 2^32 ⟹ skip mul-check)
-  SRLI .x1 .x11 32 ;;                         -- [47] x1 = rhat2c >> 32
-  single (.BNE .x1 .x0 36) ;;                -- [48] if nonzero → skip to [57]
+  SRLI .x9 .x11 32 ;;                         -- [47] x9 = rhat2c >> 32
+  single (.BNE .x9 .x0 36) ;;                -- [48] if nonzero → skip to [57]
   -- [49] Product check for q0
-  LD .x1 .x12 3952 ;;                         -- [49] dLo
-  single (.MUL .x7 .x5 .x1) ;;               -- [50] x7 = q0 * dLo
-  SLLI .x1 .x11 32 ;;                         -- [51] rhat2 << 32
+  LD .x9 .x12 3952 ;;                         -- [49] dLo
+  single (.MUL .x7 .x5 .x9) ;;               -- [50] x7 = q0 * dLo
+  SLLI .x9 .x11 32 ;;                         -- [51] rhat2 << 32
   LD .x11 .x12 3944 ;;                        -- [52] un0
-  single (.OR .x1 .x1 .x11) ;;               -- [53] x1 = rhat2*2^32 + un0
-  single (.BLTU .x1 .x7 8) ;;                -- [54] if rhs < lhs → correct [56]
+  single (.OR .x9 .x9 .x11) ;;               -- [53] x9 = rhat2*2^32 + un0
+  single (.BLTU .x9 .x7 8) ;;                -- [54] if rhs < lhs → correct [56]
   JAL .x0 8 ;;                                 -- [55] skip → [57]
   ADDI .x5 .x5 4095 ;;                        -- [56] q0--
   -- Combine: q = q1*2^32 + q0
@@ -255,8 +256,8 @@ def divK_div128_v4 : Program :=
   SD .x12 .x10 3960 ;;                        -- [1]  save d
   -- Split d: dHi = d >> 32, dLo = (d << 32) >> 32
   SRLI .x6 .x10 32 ;;                         -- [2]  x6 = dHi (>= 2^31)
-  SLLI .x1 .x10 32 ;; SRLI .x1 .x1 32 ;;     -- [3,4] x1 = dLo
-  SD .x12 .x1 3952 ;;                         -- [5]  save dLo
+  SLLI .x9 .x10 32 ;; SRLI .x9 .x9 32 ;;     -- [3,4] x9 = dLo
+  SD .x12 .x9 3952 ;;                         -- [5]  save dLo
   -- Split uLo: un1 = uLo >> 32, un0 = (uLo << 32) >> 32
   SRLI .x11 .x5 32 ;;                         -- [6]  x11 = un1
   SLLI .x5 .x5 32 ;; SRLI .x5 .x5 32 ;;      -- [7,8] x5 = un0
@@ -271,51 +272,51 @@ def divK_div128_v4 : Program :=
   ADDI .x10 .x10 4095 ;;                      -- [15] q1--
   single (.ADD .x7 .x7 .x6) ;;               -- [16] rhat += dHi
   -- [17] Phase 1b 1st D3 correction
-  LD .x1 .x12 3952 ;;                         -- [17] x1 = dLo
-  single (.MUL .x5 .x10 .x1) ;;              -- [18] x5 = q1 * dLo
-  SLLI .x1 .x7 32 ;;                          -- [19] x1 = rhat << 32
-  single (.OR .x1 .x1 .x11) ;;               -- [20] x1 = rhat*2^32 + un1
-  single (.BLTU .x1 .x5 8) ;;                -- [21] if rhs < lhs → correct [23]
+  LD .x9 .x12 3952 ;;                         -- [17] x9 = dLo
+  single (.MUL .x5 .x10 .x9) ;;              -- [18] x5 = q1 * dLo
+  SLLI .x9 .x7 32 ;;                          -- [19] x9 = rhat << 32
+  single (.OR .x9 .x9 .x11) ;;               -- [20] x9 = rhat*2^32 + un1
+  single (.BLTU .x9 .x5 8) ;;                -- [21] if rhs < lhs → correct [23]
   JAL .x0 12 ;;                                -- [22] skip → [25]
   ADDI .x10 .x10 4095 ;;                      -- [23] q1--
   single (.ADD .x7 .x7 .x6) ;;               -- [24] rhat += dHi
   -- [25] Phase 1b 2nd D3 correction
-  SRLI .x1 .x7 32 ;;                          -- [25] x1 = rhat >> 32
-  single (.BNE .x1 .x0 36) ;;                -- [26] if nonzero → skip to [35]
-  LD .x1 .x12 3952 ;;                         -- [27] dLo
-  single (.MUL .x5 .x10 .x1) ;;              -- [28] x5 = q1 * dLo
-  SLLI .x1 .x7 32 ;;                          -- [29] x1 = rhat << 32
-  single (.OR .x1 .x1 .x11) ;;               -- [30] x1 = rhat*2^32 + un1
-  single (.BLTU .x1 .x5 8) ;;                -- [31] if rhs < lhs → correct [33]
+  SRLI .x9 .x7 32 ;;                          -- [25] x9 = rhat >> 32
+  single (.BNE .x9 .x0 36) ;;                -- [26] if nonzero → skip to [35]
+  LD .x9 .x12 3952 ;;                         -- [27] dLo
+  single (.MUL .x5 .x10 .x9) ;;              -- [28] x5 = q1 * dLo
+  SLLI .x9 .x7 32 ;;                          -- [29] x9 = rhat << 32
+  single (.OR .x9 .x9 .x11) ;;               -- [30] x9 = rhat*2^32 + un1
+  single (.BLTU .x9 .x5 8) ;;                -- [31] if rhs < lhs → correct [33]
   JAL .x0 12 ;;                                -- [32] skip → [35]
   ADDI .x10 .x10 4095 ;;                      -- [33] q1--
   single (.ADD .x7 .x7 .x6) ;;               -- [34] rhat += dHi
   -- [35] Compute un21 = rhat*2^32 + un1 - q1*dLo
-  LD .x1 .x12 3952 ;;                         -- [35] dLo
+  LD .x9 .x12 3952 ;;                         -- [35] dLo
   SLLI .x5 .x7 32 ;;                          -- [36] rhat << 32
   single (.OR .x5 .x5 .x11) ;;               -- [37] x5 = rhat*2^32 + un1
-  single (.MUL .x1 .x10 .x1) ;;              -- [38] x1 = q1 * dLo
-  single (.SUB .x7 .x5 .x1) ;;               -- [39] x7 = un21
+  single (.MUL .x9 .x10 .x9) ;;              -- [38] x9 = q1 * dLo
+  single (.SUB .x7 .x5 .x9) ;;               -- [39] x7 = un21
   -- Step 2: q0 = DIVU(un21, dHi), rhat2 = un21 - q0*dHi
   single (.DIVU .x5 .x7 .x6) ;;              -- [40] x5 = q0
-  single (.MUL .x1 .x5 .x6) ;;               -- [41]
-  single (.SUB .x11 .x7 .x1) ;;              -- [42] x11 = rhat2
+  single (.MUL .x9 .x5 .x6) ;;               -- [41]
+  single (.SUB .x11 .x7 .x9) ;;              -- [42] x11 = rhat2
   -- Refine q0: clamp
-  SRLI .x1 .x5 32 ;;                          -- [43]
-  single (.BEQ .x1 .x0 12) ;;                -- [44] skip if q0 < 2^32 → [47]
+  SRLI .x9 .x5 32 ;;                          -- [43]
+  single (.BEQ .x9 .x0 12) ;;                -- [44] skip if q0 < 2^32 → [47]
   ADDI .x5 .x5 4095 ;;                        -- [45] q0--
   single (.ADD .x11 .x11 .x6) ;;             -- [46] rhat2 += dHi
   -- [47] Phase 2b guard (rhat2c ≥ 2^32 ⟹ skip BOTH 1st and 2nd D3)
-  SRLI .x1 .x11 32 ;;                         -- [47] x1 = rhat2c >> 32
-  single (.BNE .x1 .x0 92) ;;                -- [48] if nonzero → skip to [71] (combine)
+  SRLI .x9 .x11 32 ;;                         -- [47] x9 = rhat2c >> 32
+  single (.BNE .x9 .x0 92) ;;                -- [48] if nonzero → skip to [71] (combine)
   -- [49] Phase 2b 1st D3 mul-check
-  LD .x1 .x12 3952 ;;                         -- [49] dLo
-  single (.MUL .x7 .x5 .x1) ;;               -- [50] x7 = q0 * dLo
-  SLLI .x1 .x11 32 ;;                         -- [51] rhat2c << 32
+  LD .x9 .x12 3952 ;;                         -- [49] dLo
+  single (.MUL .x7 .x5 .x9) ;;               -- [50] x7 = q0 * dLo
+  SLLI .x9 .x11 32 ;;                         -- [51] rhat2c << 32
   SD .x12 .x11 3936 ;;                        -- [52] save rhat2c (NEW in v4)
   LD .x11 .x12 3944 ;;                        -- [53] x11 = un0 (clobbers rhat2c)
-  single (.OR .x1 .x1 .x11) ;;               -- [54] x1 = rhat2c*2^32 + un0
-  single (.BLTU .x1 .x7 12) ;;               -- [55] if BLTU fires → correction [58]
+  single (.OR .x9 .x9 .x11) ;;               -- [54] x9 = rhat2c*2^32 + un0
+  single (.BLTU .x9 .x7 12) ;;               -- [55] if BLTU fires → correction [58]
   -- [56] No-correction path
   LD .x11 .x12 3936 ;;                        -- [56] restore rhat2c (unchanged)
   JAL .x0 16 ;;                                -- [57] skip correction → [61] (2nd D3 entry)
@@ -324,14 +325,14 @@ def divK_div128_v4 : Program :=
   LD .x11 .x12 3936 ;;                        -- [59] restore rhat2c
   single (.ADD .x11 .x11 .x6) ;;             -- [60] rhat2c += dHi
   -- [61] Phase 2b 2nd D3 guarded mul-check (NEW in v4 vs v2)
-  SRLI .x1 .x11 32 ;;                         -- [61] x1 = rhat2c >> 32 (post-1st-correction)
-  single (.BNE .x1 .x0 36) ;;                -- [62] if nonzero → skip to [71] (combine)
-  LD .x1 .x12 3952 ;;                         -- [63] dLo
-  single (.MUL .x7 .x5 .x1) ;;               -- [64] x7 = q0 * dLo
-  SLLI .x1 .x11 32 ;;                         -- [65] rhat2c << 32
+  SRLI .x9 .x11 32 ;;                         -- [61] x9 = rhat2c >> 32 (post-1st-correction)
+  single (.BNE .x9 .x0 36) ;;                -- [62] if nonzero → skip to [71] (combine)
+  LD .x9 .x12 3952 ;;                         -- [63] dLo
+  single (.MUL .x7 .x5 .x9) ;;               -- [64] x7 = q0 * dLo
+  SLLI .x9 .x11 32 ;;                         -- [65] rhat2c << 32
   LD .x11 .x12 3944 ;;                        -- [66] x11 = un0 (last use of rhat2c, no save needed)
-  single (.OR .x1 .x1 .x11) ;;               -- [67] x1 = rhat2c*2^32 + un0
-  single (.BLTU .x1 .x7 8) ;;                -- [68] if BLTU fires → 2nd correction [70]
+  single (.OR .x9 .x9 .x11) ;;               -- [67] x9 = rhat2c*2^32 + un0
+  single (.BLTU .x9 .x7 8) ;;                -- [68] if BLTU fires → 2nd correction [70]
   JAL .x0 8 ;;                                 -- [69] skip → [71]
   ADDI .x5 .x5 4095 ;;                        -- [70] 2nd correction: q0--
   -- [71] Combine: q = q1*2^32 + q0
@@ -443,8 +444,8 @@ def divK_copyAU : Program :=
     4 instructions. BLT if j < 0 (signed). -/
 def divK_loopSetup (bltOff : BitVec 13) : Program :=
   LD .x5 .x12 3984 ;;
-  ADDI .x1 .x0 4 ;; single (.SUB .x1 .x1 .x5) ;;
-  single (.BLT .x1 .x0 bltOff)
+  ADDI .x9 .x0 4 ;; single (.SUB .x9 .x9 .x5) ;;
+  single (.BLT .x9 .x0 bltOff)
 
 /-- Loop body: trial quotient + multiply-subtract + correction + store q[j].
     Starts at loop_start. Includes save/restore of j.
@@ -464,11 +465,11 @@ def divK_loopSetup (bltOff : BitVec 13) : Program :=
     110 instructions per loop body. -/
 def divK_loopBody (subr_off : BitVec 21) (loop_back_off : BitVec 13) : Program :=
   -- Save j
-  SD .x12 .x1 3976 ;;                         -- [0]
+  SD .x12 .x9 3976 ;;                         -- [0]
 
   -- Load u[j+n] and u[j+n-1]
   LD .x5 .x12 3984 ;;                         -- [1] n
-  single (.ADD .x7 .x1 .x5) ;;               -- [2] x7 = j+n
+  single (.ADD .x7 .x9 .x5) ;;               -- [2] x7 = j+n
   SLLI .x7 .x7 3 ;;                           -- [3] (j+n)*8
   ADDI .x5 .x12 4056 ;;                       -- [4] sp-40 = &u[0]
   single (.SUB .x5 .x5 .x7) ;;               -- [5] &u[j+n]
@@ -489,8 +490,8 @@ def divK_loopBody (subr_off : BitVec 21) (loop_back_off : BitVec 13) : Program :
   JAL .x2 subr_off ;;                          -- [16] call 128/64 subroutine
 
   -- Restore j, compute uBase
-  LD .x1 .x12 3976 ;;                         -- [17] restore j
-  SLLI .x5 .x1 3 ;;                           -- [18] j*8
+  LD .x9 .x12 3976 ;;                         -- [17] restore j
+  SLLI .x5 .x9 3 ;;                           -- [18] j*8
   ADDI .x6 .x12 4056 ;;                       -- [19] sp-40
   single (.SUB .x6 .x6 .x5) ;;               -- [20] x6 = uBase = &u[j]
 
@@ -605,14 +606,14 @@ def divK_loopBody (subr_off : BitVec 21) (loop_back_off : BitVec 13) : Program :
   single (.BEQ .x7 .x0 8044) ;;              -- [108] if carry=0 → [71]
 
   -- STORE q[j]: q[j] at sp - 8 - j*8 = sp + (4088 - j*8)
-  SLLI .x5 .x1 3 ;;                           -- [109] j*8
+  SLLI .x5 .x9 3 ;;                           -- [109] j*8
   ADDI .x7 .x12 4088 ;;                       -- [110] sp-8
   single (.SUB .x7 .x7 .x5) ;;               -- [111] &q[j]
   SD .x7 .x11 0 ;;                            -- [112] q[j] = qHat
 
   -- LOOP CONTROL
-  ADDI .x1 .x1 4095 ;;                        -- [113] j--
-  single (.BGE .x1 .x0 loop_back_off)         -- [114] if j >= 0 → loop
+  ADDI .x9 .x9 4095 ;;                        -- [113] j--
+  single (.BGE .x9 .x0 loop_back_off)         -- [114] if j >= 0 → loop
 
 /-- Phase E: De-normalize remainder. Right-shift u[0..3] by shift amount.
     25 instructions. -/

--- a/EvmAsm/Evm64/DivMod/Shift0Dispatcher.lean
+++ b/EvmAsm/Evm64/DivMod/Shift0Dispatcher.lean
@@ -79,7 +79,7 @@ theorem evm_div_n4_shift0_stack_spec (sp base : Word)
 
 /-- Exact-`x1` variant of `evm_div_n4_shift0_stack_spec`. Both shift=0
     branches leave the same concrete return marker in `x1`, so callers can
-    retain it instead of receiving only `regOwn .x1`. -/
+    retain it instead of receiving only `regOwn .x9`. -/
 theorem evm_div_n4_shift0_stack_spec_exact_x1 (sp base : Word)
     (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
@@ -94,7 +94,7 @@ theorem evm_div_n4_shift0_stack_spec_exact_x1 (sp base : Word)
          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
          shiftMem nMem jMem retMem dMem dloMem scratch_un0)
       (divN4CallSkipStackPostNoX1 sp a b **
-        (.x1 ↦ᵣ signExtend12 (4095 : BitVec 12))) := by
+        (.x9 ↦ᵣ signExtend12 (4095 : BitVec 12))) := by
   by_cases h_skip : isSkipBorrowN4Shift0Evm a b
   · exact cpsTripleWithin_mono_nSteps (by decide) <|
       evm_div_n4_shift0_call_skip_stack_spec_exact_x1 sp base a b

--- a/EvmAsm/Evm64/DivMod/Spec/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/Base.lean
@@ -96,7 +96,7 @@ def n4MaxSkipSemanticHolds (a b : EvmWord) : Prop :=
     semantic bridge + `divScratchValues_implies_divScratchOwn` weakener. -/
 @[irreducible]
 def divN4MaxSkipStackPost (sp : Word) (a b : EvmWord) : Assertion :=
-  (.x12 ↦ᵣ (sp + 32)) ** regOwn .x1 ** regOwn .x2 **
+  (.x12 ↦ᵣ (sp + 32)) ** regOwn .x9 ** regOwn .x2 **
   regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
   regOwn .x10 ** regOwn .x11 ** (.x0 ↦ᵣ (0 : Word)) **
   evmWordIs sp a ** evmWordIs (sp + 32) (EvmWord.div a b) **
@@ -119,7 +119,7 @@ def divN4StackPre (sp : Word) (a b : EvmWord)
   (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
   (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
   (.x2 ↦ᵣ (clzResult (b.getLimbN 3)).2 >>> (63 : Nat)) **
-  (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+  (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
   (.x11 ↦ᵣ v11) **
   evmWordIs sp a ** evmWordIs (sp + 32) b **
   divScratchValues sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
@@ -149,7 +149,7 @@ theorem divN4StackPre_unfold {sp : Word} {a b : EvmWord}
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
      (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
      (.x2 ↦ᵣ (clzResult (b.getLimbN 3)).2 >>> (63 : Nat)) **
-     (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
      (.x11 ↦ᵣ v11) **
      evmWordIs sp a ** evmWordIs (sp + 32) b **
      divScratchValues sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
@@ -171,7 +171,7 @@ def divN4StackPreCall (sp : Word) (a b : EvmWord)
   (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
   (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
   (.x2 ↦ᵣ (clzResult (b.getLimbN 3)).2 >>> (63 : Nat)) **
-  (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+  (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
   (.x11 ↦ᵣ v11) **
   evmWordIs sp a ** evmWordIs (sp + 32) b **
   divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
@@ -207,7 +207,7 @@ theorem divN4StackPreCall_unfold {sp : Word} {a b : EvmWord}
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
      (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
      (.x2 ↦ᵣ (clzResult (b.getLimbN 3)).2 >>> (63 : Nat)) **
-     (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
      (.x11 ↦ᵣ v11) **
      evmWordIs sp a ** evmWordIs (sp + 32) b **
      divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
@@ -226,7 +226,7 @@ def modN4StackPre (sp : Word) (a b : EvmWord)
   (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
   (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
   (.x2 ↦ᵣ (clzResult (b.getLimbN 3)).2 >>> (63 : Nat)) **
-  (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+  (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
   (.x11 ↦ᵣ v11) **
   evmWordIs sp a ** evmWordIs (sp + 32) b **
   divScratchValues sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
@@ -253,7 +253,7 @@ instance (sp : Word) (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
     `delta` the only way in at call sites. -/
 theorem divN4MaxSkipStackPost_unfold {sp : Word} {a b : EvmWord} :
     divN4MaxSkipStackPost sp a b =
-    ((.x12 ↦ᵣ (sp + 32)) ** regOwn .x1 ** regOwn .x2 **
+    ((.x12 ↦ᵣ (sp + 32)) ** regOwn .x9 ** regOwn .x2 **
      regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
      regOwn .x10 ** regOwn .x11 ** (.x0 ↦ᵣ (0 : Word)) **
      evmWordIs sp a ** evmWordIs (sp + 32) (EvmWord.div a b) **
@@ -281,7 +281,7 @@ theorem div_n4_max_skip_stack_weaken
      shift_p n_p j_p : Word} :
     ∀ h,
       ((.x12 ↦ᵣ (sp + 32)) **
-       (.x1 ↦ᵣ v1_p) ** (.x2 ↦ᵣ v2_p) **
+       (.x9 ↦ᵣ v1_p) ** (.x2 ↦ᵣ v2_p) **
        (.x5 ↦ᵣ v5_p) ** (.x6 ↦ᵣ v6_p) ** (.x7 ↦ᵣ v7_p) **
        (.x10 ↦ᵣ v10_p) ** (.x11 ↦ᵣ v11_p) **
        (.x0 ↦ᵣ (0 : Word)) **
@@ -321,7 +321,7 @@ theorem evm_div_n4_full_max_skip_stack_pre_spec (sp base : Word)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
        (.x2 ↦ᵣ (clzResult (b.getLimbN 3)).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        (.x11 ↦ᵣ v11Old) **
        evmWordIs sp a ** evmWordIs (sp + 32) b **
        divScratchValues sp q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old

--- a/EvmAsm/Evm64/DivMod/Spec/CallAddback.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/CallAddback.lean
@@ -286,7 +286,7 @@ theorem evm_div_n4_call_addback_beq_stack_spec_exact_x1 (sp base : Word)
          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
          shiftMem nMem jMem retMem dMem dloMem scratch_un0)
       (divN4CallSkipStackPostNoX1 sp a b **
-        (.x1 ↦ᵣ signExtend12 (4095 : BitVec 12))) := by
+        (.x9 ↦ᵣ signExtend12 (4095 : BitVec 12))) := by
   have h_pre := evm_div_n4_full_call_addback_beq_stack_pre_spec_bundled sp base a b
     v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
     nMem shiftMem jMem retMem dMem dloMem scratch_un0

--- a/EvmAsm/Evm64/DivMod/Spec/CallAddbackMod.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/CallAddbackMod.lean
@@ -441,7 +441,7 @@ theorem evm_div_n4_call_stack_spec_exact_x1 (sp base : Word)
          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
          shiftMem nMem jMem retMem dMem dloMem scratch_un0)
       (divN4CallSkipStackPostNoX1 sp a b **
-        (.x1 ↦ᵣ signExtend12 (4095 : BitVec 12))) := by
+        (.x9 ↦ᵣ signExtend12 (4095 : BitVec 12))) := by
   rcases isSkipBorrowN4CallEvm_or_isAddbackBorrowN4CallEvm a b with hskip | haddback
   · exact cpsTripleWithin_mono_nSteps (by decide) <|
       evm_div_n4_call_skip_stack_spec_unconditional_exact_x1 sp base a b

--- a/EvmAsm/Evm64/DivMod/Spec/CallAddbackNoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/CallAddbackNoNop.lean
@@ -30,7 +30,7 @@ theorem evm_div_n4_full_call_addback_beq_stack_pre_spec_noNop (sp base : Word)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
        (.x2 ↦ᵣ (clzResult (b.getLimbN 3)).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        (.x11 ↦ᵣ v11Old) **
        evmWordIs sp a ** evmWordIs (sp + 32) b **
        divScratchValuesCall sp q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old

--- a/EvmAsm/Evm64/DivMod/Spec/CallSkip.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/CallSkip.lean
@@ -42,7 +42,7 @@ def modN4StackPreCall (sp : Word) (a b : EvmWord)
   (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
   (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
   (.x2 ↦ᵣ (clzResult (b.getLimbN 3)).2 >>> (63 : Nat)) **
-  (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+  (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
   (.x11 ↦ᵣ v11) **
   evmWordIs sp a ** evmWordIs (sp + 32) b **
   divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
@@ -78,7 +78,7 @@ theorem modN4StackPreCall_unfold {sp : Word} {a b : EvmWord}
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
      (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
      (.x2 ↦ᵣ (clzResult (b.getLimbN 3)).2 >>> (63 : Nat)) **
-     (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
      (.x11 ↦ᵣ v11) **
      evmWordIs sp a ** evmWordIs (sp + 32) b **
      divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
@@ -94,7 +94,7 @@ theorem modN4StackPreCall_unfold {sp : Word} {a b : EvmWord}
     `evm_div_n4_call_skip_stack_spec`. -/
 @[irreducible]
 def divN4CallSkipStackPost (sp : Word) (a b : EvmWord) : Assertion :=
-  (.x12 ↦ᵣ (sp + 32)) ** regOwn .x1 ** regOwn .x2 **
+  (.x12 ↦ᵣ (sp + 32)) ** regOwn .x9 ** regOwn .x2 **
   regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
   regOwn .x10 ** regOwn .x11 ** (.x0 ↦ᵣ (0 : Word)) **
   evmWordIs sp a ** evmWordIs (sp + 32) (EvmWord.div a b) **
@@ -104,7 +104,7 @@ def divN4CallSkipStackPost (sp : Word) (a b : EvmWord) : Assertion :=
     `divN4MaxSkipStackPost_unfold` but with `divScratchOwnCall`. -/
 theorem divN4CallSkipStackPost_unfold {sp : Word} {a b : EvmWord} :
     divN4CallSkipStackPost sp a b =
-    ((.x12 ↦ᵣ (sp + 32)) ** regOwn .x1 ** regOwn .x2 **
+    ((.x12 ↦ᵣ (sp + 32)) ** regOwn .x9 ** regOwn .x2 **
      regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
      regOwn .x10 ** regOwn .x11 ** (.x0 ↦ᵣ (0 : Word)) **
      evmWordIs sp a ** evmWordIs (sp + 32) (EvmWord.div a b) **
@@ -158,7 +158,7 @@ instance (sp : Word) (a b : EvmWord) :
     `evm_mod_n4_call_skip_stack_spec_within`. -/
 @[irreducible]
 def modN4CallSkipStackPost (sp : Word) (a b : EvmWord) : Assertion :=
-  (.x12 ↦ᵣ (sp + 32)) ** regOwn .x1 ** regOwn .x2 **
+  (.x12 ↦ᵣ (sp + 32)) ** regOwn .x9 ** regOwn .x2 **
   regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
   regOwn .x10 ** regOwn .x11 ** (.x0 ↦ᵣ (0 : Word)) **
   evmWordIs sp a ** evmWordIs (sp + 32) (EvmWord.mod a b) **
@@ -167,7 +167,7 @@ def modN4CallSkipStackPost (sp : Word) (a b : EvmWord) : Assertion :=
 /-- Named unfold for `modN4CallSkipStackPost`. -/
 theorem modN4CallSkipStackPost_unfold {sp : Word} {a b : EvmWord} :
     modN4CallSkipStackPost sp a b =
-    ((.x12 ↦ᵣ (sp + 32)) ** regOwn .x1 ** regOwn .x2 **
+    ((.x12 ↦ᵣ (sp + 32)) ** regOwn .x9 ** regOwn .x2 **
      regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
      regOwn .x10 ** regOwn .x11 ** (.x0 ↦ᵣ (0 : Word)) **
      evmWordIs sp a ** evmWordIs (sp + 32) (EvmWord.mod a b) **
@@ -201,7 +201,7 @@ theorem div_n4_call_skip_stack_weaken
      shift_p n_p j_p retMem_p dMem_p dloMem_p scratch_un0_p : Word} :
     ∀ h,
       ((.x12 ↦ᵣ (sp + 32)) **
-       (.x1 ↦ᵣ v1_p) ** (.x2 ↦ᵣ v2_p) **
+       (.x9 ↦ᵣ v1_p) ** (.x2 ↦ᵣ v2_p) **
        (.x5 ↦ᵣ v5_p) ** (.x6 ↦ᵣ v6_p) ** (.x7 ↦ᵣ v7_p) **
        (.x10 ↦ᵣ v10_p) ** (.x11 ↦ᵣ v11_p) **
        (.x0 ↦ᵣ (0 : Word)) **
@@ -233,8 +233,8 @@ theorem div_n4_call_skip_stack_weaken_noX1_frame
         evmWordIs sp a ** evmWordIs (sp + 32) (EvmWord.div a b) **
         divScratchValuesCall sp q0P q1P q2_p q3_p u0P u1P u2P u3P u4_p
           u5_p u6_p u7_p shift_p n_p j_p retMem_p dMem_p dloMem_p scratch_un0_p) **
-       (.x1 ↦ᵣ v1_p)) h →
-      (divN4CallSkipStackPostNoX1 sp a b ** (.x1 ↦ᵣ v1_p)) h := by
+       (.x9 ↦ᵣ v1_p)) h →
+      (divN4CallSkipStackPostNoX1 sp a b ** (.x9 ↦ᵣ v1_p)) h := by
   intro h hp
   rw [divN4CallSkipStackPostNoX1_unfold]
   apply sepConj_mono_left _ h hp
@@ -261,14 +261,14 @@ theorem div_n4_call_skip_stack_weaken_noX1
      shift_p n_p j_p retMem_p dMem_p dloMem_p scratch_un0_p : Word} :
     ∀ h,
       ((.x12 ↦ᵣ (sp + 32)) **
-       (.x1 ↦ᵣ v1_p) ** (.x2 ↦ᵣ v2_p) **
+       (.x9 ↦ᵣ v1_p) ** (.x2 ↦ᵣ v2_p) **
        (.x5 ↦ᵣ v5_p) ** (.x6 ↦ᵣ v6_p) ** (.x7 ↦ᵣ v7_p) **
        (.x10 ↦ᵣ v10_p) ** (.x11 ↦ᵣ v11_p) **
        (.x0 ↦ᵣ (0 : Word)) **
        evmWordIs sp a ** evmWordIs (sp + 32) (EvmWord.div a b) **
        divScratchValuesCall sp q0P q1P q2_p q3_p u0P u1P u2P u3P u4_p
          u5_p u6_p u7_p shift_p n_p j_p retMem_p dMem_p dloMem_p scratch_un0_p) h →
-      (divN4CallSkipStackPostNoX1 sp a b ** (.x1 ↦ᵣ v1_p)) h := by
+      (divN4CallSkipStackPostNoX1 sp a b ** (.x9 ↦ᵣ v1_p)) h := by
   intro h hp
   exact div_n4_call_skip_stack_weaken_noX1_frame
     (sp := sp) (a := a) (b := b) h (by xperm_hyp hp)
@@ -283,7 +283,7 @@ theorem mod_n4_call_skip_stack_weaken
      shift_p n_p j_p retMem_p dMem_p dloMem_p scratch_un0_p : Word} :
     ∀ h,
       ((.x12 ↦ᵣ (sp + 32)) **
-       (.x1 ↦ᵣ v1_p) ** (.x2 ↦ᵣ v2_p) **
+       (.x9 ↦ᵣ v1_p) ** (.x2 ↦ᵣ v2_p) **
        (.x5 ↦ᵣ v5_p) ** (.x6 ↦ᵣ v6_p) ** (.x7 ↦ᵣ v7_p) **
        (.x10 ↦ᵣ v10_p) ** (.x11 ↦ᵣ v11_p) **
        (.x0 ↦ᵣ (0 : Word)) **
@@ -335,7 +335,7 @@ theorem evm_div_n4_full_call_skip_stack_pre_spec (sp base : Word)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
        (.x2 ↦ᵣ (clzResult (b.getLimbN 3)).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        (.x11 ↦ᵣ v11Old) **
        evmWordIs sp a ** evmWordIs (sp + 32) b **
        divScratchValuesCall sp q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old
@@ -408,7 +408,7 @@ theorem evm_div_n4_full_call_skip_stack_pre_spec_noNop (sp base : Word)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
        (.x2 ↦ᵣ (clzResult (b.getLimbN 3)).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        (.x11 ↦ᵣ v11Old) **
        evmWordIs sp a ** evmWordIs (sp + 32) b **
        divScratchValuesCall sp q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old
@@ -482,7 +482,7 @@ theorem evm_mod_n4_full_call_skip_stack_pre_spec_within (sp base : Word)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
        (.x2 ↦ᵣ (clzResult (b.getLimbN 3)).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        (.x11 ↦ᵣ v11Old) **
        evmWordIs sp a ** evmWordIs (sp + 32) b **
        divScratchValuesCall sp q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old
@@ -568,7 +568,7 @@ theorem evm_div_n4_full_call_addback_beq_stack_pre_spec (sp base : Word)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
        (.x2 ↦ᵣ (clzResult (b.getLimbN 3)).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        (.x11 ↦ᵣ v11Old) **
        evmWordIs sp a ** evmWordIs (sp + 32) b **
        divScratchValuesCall sp q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old
@@ -651,7 +651,7 @@ theorem evm_mod_n4_full_call_addback_beq_stack_pre_spec_within (sp base : Word)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
        (.x2 ↦ᵣ (clzResult (b.getLimbN 3)).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        (.x11 ↦ᵣ v11Old) **
        evmWordIs sp a ** evmWordIs (sp + 32) b **
        divScratchValuesCall sp q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old
@@ -747,7 +747,7 @@ theorem evm_div_n4_full_shift0_call_skip_stack_pre_spec (sp base : Word)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
        (.x2 ↦ᵣ (clzResult (b.getLimbN 3)).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        (.x11 ↦ᵣ v11Old) **
        evmWordIs sp a ** evmWordIs (sp + 32) b **
        divScratchValuesCall sp q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old
@@ -820,7 +820,7 @@ theorem evm_mod_n4_full_shift0_call_skip_stack_pre_spec (sp base : Word)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
        (.x2 ↦ᵣ (clzResult (b.getLimbN 3)).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        (.x11 ↦ᵣ v11Old) **
        evmWordIs sp a ** evmWordIs (sp + 32) b **
        divScratchValuesCall sp q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old
@@ -917,7 +917,7 @@ theorem evm_div_n4_full_shift0_call_addback_beq_stack_pre_spec (sp base : Word)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
        (.x2 ↦ᵣ (clzResult (b.getLimbN 3)).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        (.x11 ↦ᵣ v11Old) **
        evmWordIs sp a ** evmWordIs (sp + 32) b **
        divScratchValuesCall sp q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old
@@ -988,7 +988,7 @@ theorem evm_mod_n4_full_shift0_call_addback_beq_stack_pre_spec (sp base : Word)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
        (.x2 ↦ᵣ (clzResult (b.getLimbN 3)).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        (.x11 ↦ᵣ v11Old) **
        evmWordIs sp a ** evmWordIs (sp + 32) b **
        divScratchValuesCall sp q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old

--- a/EvmAsm/Evm64/DivMod/Spec/CallSkipExactX1.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/CallSkipExactX1.lean
@@ -37,7 +37,7 @@ theorem evm_div_n4_call_skip_stack_spec_exact_x1 (sp base : Word)
          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
          shiftMem nMem jMem retMem dMem dloMem scratch_un0)
       (divN4CallSkipStackPostNoX1 sp a b **
-        (.x1 ↦ᵣ signExtend12 (4095 : BitVec 12))) := by
+        (.x9 ↦ᵣ signExtend12 (4095 : BitVec 12))) := by
   have h_pre := evm_div_n4_full_call_skip_stack_pre_spec_bundled sp base a b
     v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
     nMem shiftMem jMem retMem dMem dloMem scratch_un0

--- a/EvmAsm/Evm64/DivMod/Spec/CallSkipNoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/CallSkipNoNop.lean
@@ -28,7 +28,7 @@ theorem evm_div_n4_full_shift0_call_skip_stack_pre_spec_noNop (sp base : Word)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
        (.x2 ↦ᵣ (clzResult (b.getLimbN 3)).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        (.x11 ↦ᵣ v11Old) **
        evmWordIs sp a ** evmWordIs (sp + 32) b **
        divScratchValuesCall sp q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old
@@ -98,7 +98,7 @@ theorem evm_div_n4_full_shift0_call_addback_beq_stack_pre_spec_noNop (sp base : 
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
        (.x2 ↦ᵣ (clzResult (b.getLimbN 3)).2 >>> (63 : Nat)) **
-       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
        (.x11 ↦ᵣ v11Old) **
        evmWordIs sp a ** evmWordIs (sp + 32) b **
        divScratchValuesCall sp q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old

--- a/EvmAsm/Evm64/DivMod/Spec/CallSkipUnconditional.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/CallSkipUnconditional.lean
@@ -132,7 +132,7 @@ theorem evm_div_n4_call_skip_stack_spec_unconditional_exact_x1 (sp base : Word)
          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
          shiftMem nMem jMem retMem dMem dloMem scratch_un0)
       (divN4CallSkipStackPostNoX1 sp a b **
-        (.x1 ↦ᵣ signExtend12 (4095 : BitVec 12))) :=
+        (.x9 ↦ᵣ signExtend12 (4095 : BitVec 12))) :=
   evm_div_n4_call_skip_stack_spec_exact_x1 sp base a b v5 v6 v7 v10 v11
     q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
     nMem shiftMem jMem retMem dMem dloMem scratch_un0

--- a/EvmAsm/Evm64/DivMod/Spec/Dispatcher.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/Dispatcher.lean
@@ -25,7 +25,7 @@ def divModStackDispatchPre (sp : Word) (a b : EvmWord)
     (v1 v2 v5 v6 v7 v10 v11 : Word)
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
      shiftMem nMem jMem retMem dMem dloMem scratch_un0 : Word) : Assertion :=
-  (.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ v1) ** (.x2 ↦ᵣ v2) **
+  (.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ v1) ** (.x2 ↦ᵣ v2) **
   (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
   (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) ** (.x0 ↦ᵣ (0 : Word)) **
   evmWordIs sp a ** evmWordIs (sp + 32) b **
@@ -39,7 +39,7 @@ theorem divModStackDispatchPre_unfold {sp : Word} {a b : EvmWord}
     divModStackDispatchPre sp a b v1 v2 v5 v6 v7 v10 v11
       q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem
       retMem dMem dloMem scratch_un0 =
-    ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ v1) ** (.x2 ↦ᵣ v2) **
+    ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ v1) ** (.x2 ↦ᵣ v2) **
      (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
      (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) ** (.x0 ↦ᵣ (0 : Word)) **
      evmWordIs sp a ** evmWordIs (sp + 32) b **
@@ -48,10 +48,74 @@ theorem divModStackDispatchPre_unfold {sp : Word} {a b : EvmWord}
   delta divModStackDispatchPre
   rfl
 
+/-- Callable-ready dispatch precondition shared by DIV and MOD.
+
+Unlike `divModStackDispatchPre`, this keeps `x1` as an exact register atom
+instead of hiding it inside the scratch bundle. `x9` is also explicit so
+callers that carry wrapper-private state in `x9` across the bzero path can
+frame it directly. -/
+@[irreducible]
+def divModStackDispatchPreNoX1 (sp : Word) (a b : EvmWord)
+    (x9Val x1Val v2 v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratch_un0 : Word) : Assertion :=
+  (.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ x9Val) ** (.x1 ↦ᵣ x1Val) ** (.x2 ↦ᵣ v2) **
+  (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+  (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) ** (.x0 ↦ᵣ (0 : Word)) **
+  evmWordIs sp a ** evmWordIs (sp + 32) b **
+  divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    shiftMem nMem jMem retMem dMem dloMem scratch_un0
+
+theorem divModStackDispatchPreNoX1_unfold {sp : Word} {a b : EvmWord}
+    {x9Val x1Val v2 v5 v6 v7 v10 v11 : Word}
+    {q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem
+     retMem dMem dloMem scratch_un0 : Word} :
+    divModStackDispatchPreNoX1 sp a b x9Val x1Val v2 v5 v6 v7 v10 v11
+      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem
+      retMem dMem dloMem scratch_un0 =
+    ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ x9Val) ** (.x1 ↦ᵣ x1Val) ** (.x2 ↦ᵣ v2) **
+     (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+     (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) ** (.x0 ↦ᵣ (0 : Word)) **
+     evmWordIs sp a ** evmWordIs (sp + 32) b **
+     divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+       shiftMem nMem jMem retMem dMem dloMem scratch_un0) := by
+  delta divModStackDispatchPreNoX1
+  rfl
+
+/-- Callable-ready dispatch precondition for callers that need exact `x1` but
+    do not carry any `x9` state across the bzero path. -/
+@[irreducible]
+def divModStackDispatchPreCallable (sp : Word) (a b : EvmWord)
+    (x1Val v2 v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratch_un0 : Word) : Assertion :=
+  (.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ x1Val) ** (.x2 ↦ᵣ v2) **
+  (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+  (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) ** (.x0 ↦ᵣ (0 : Word)) **
+  evmWordIs sp a ** evmWordIs (sp + 32) b **
+  divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    shiftMem nMem jMem retMem dMem dloMem scratch_un0
+
+theorem divModStackDispatchPreCallable_unfold {sp : Word} {a b : EvmWord}
+    {x1Val v2 v5 v6 v7 v10 v11 : Word}
+    {q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem
+     retMem dMem dloMem scratch_un0 : Word} :
+    divModStackDispatchPreCallable sp a b x1Val v2 v5 v6 v7 v10 v11
+      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem
+      retMem dMem dloMem scratch_un0 =
+    ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ x1Val) ** (.x2 ↦ᵣ v2) **
+     (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+     (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) ** (.x0 ↦ᵣ (0 : Word)) **
+     evmWordIs sp a ** evmWordIs (sp + 32) b **
+     divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+       shiftMem nMem jMem retMem dMem dloMem scratch_un0) := by
+  delta divModStackDispatchPreCallable
+  rfl
+
 /-- Final DIV stack-dispatch postcondition. -/
 @[irreducible]
 def divStackDispatchPost (sp : Word) (a b : EvmWord) : Assertion :=
-  (.x12 ↦ᵣ (sp + 32)) ** regOwn .x1 ** regOwn .x2 **
+  (.x12 ↦ᵣ (sp + 32)) ** regOwn .x9 ** regOwn .x2 **
   regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
   regOwn .x10 ** regOwn .x11 ** (.x0 ↦ᵣ (0 : Word)) **
   evmWordIs sp a ** evmWordIs (sp + 32) (EvmWord.div a b) **
@@ -59,7 +123,7 @@ def divStackDispatchPost (sp : Word) (a b : EvmWord) : Assertion :=
 
 theorem divStackDispatchPost_unfold {sp : Word} {a b : EvmWord} :
     divStackDispatchPost sp a b =
-    ((.x12 ↦ᵣ (sp + 32)) ** regOwn .x1 ** regOwn .x2 **
+    ((.x12 ↦ᵣ (sp + 32)) ** regOwn .x9 ** regOwn .x2 **
      regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
      regOwn .x10 ** regOwn .x11 ** (.x0 ↦ᵣ (0 : Word)) **
      evmWordIs sp a ** evmWordIs (sp + 32) (EvmWord.div a b) **
@@ -88,6 +152,33 @@ theorem divStackDispatchPostNoX1_unfold {sp : Word} {a b : EvmWord} :
   delta divStackDispatchPostNoX1
   rfl
 
+/-- Callable-ready DIV postcondition that omits both exact `x1` and exact `x9`.
+    Callers frame those registers explicitly around the no-NOP body and return
+    instruction. -/
+@[irreducible]
+def divStackDispatchPostCallable (sp : Word) (a b : EvmWord) : Assertion :=
+  (.x12 ↦ᵣ (sp + 32)) ** regOwn .x2 **
+  regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+  regOwn .x10 ** regOwn .x11 ** (.x0 ↦ᵣ (0 : Word)) **
+  evmWordIs sp a ** evmWordIs (sp + 32) (EvmWord.div a b) **
+  divScratchOwnCallNoX1 sp
+
+theorem divStackDispatchPostCallable_unfold {sp : Word} {a b : EvmWord} :
+    divStackDispatchPostCallable sp a b =
+    ((.x12 ↦ᵣ (sp + 32)) ** regOwn .x2 **
+     regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+     regOwn .x10 ** regOwn .x11 ** (.x0 ↦ᵣ (0 : Word)) **
+     evmWordIs sp a ** evmWordIs (sp + 32) (EvmWord.div a b) **
+     divScratchOwnCallNoX1 sp) := by
+  delta divStackDispatchPostCallable
+  rfl
+
+theorem divStackDispatchPostCallable_pcFree (sp : Word) (a b : EvmWord) :
+    (divStackDispatchPostCallable sp a b).pcFree := by
+  rw [divStackDispatchPostCallable_unfold, divScratchOwnCallNoX1_unfold,
+    divScratchOwn_unfold]
+  pcFree
+
 theorem divStackDispatchPost_weaken
     (sp : Word) (a b : EvmWord)
     {v1 v2 v5 v6 v7 v10 v11 : Word}
@@ -95,7 +186,7 @@ theorem divStackDispatchPost_weaken
      shiftMem nMem jMem retMem dMem dloMem scratch_un0 : Word} :
     ∀ h,
       ((.x12 ↦ᵣ (sp + 32)) **
-       (.x1 ↦ᵣ v1) ** (.x2 ↦ᵣ v2) **
+       (.x9 ↦ᵣ v1) ** (.x2 ↦ᵣ v2) **
        (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
        (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) **
        (.x0 ↦ᵣ (0 : Word)) **
@@ -127,8 +218,8 @@ theorem divStackDispatchPostNoX1_weaken_frame
         evmWordIs sp a ** evmWordIs (sp + 32) (EvmWord.div a b) **
         divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratch_un0) **
-       (.x1 ↦ᵣ v1)) h →
-      (divStackDispatchPostNoX1 sp a b ** (.x1 ↦ᵣ v1)) h := by
+       (.x9 ↦ᵣ v1)) h →
+      (divStackDispatchPostNoX1 sp a b ** (.x9 ↦ᵣ v1)) h := by
   intro h hp
   rw [divStackDispatchPostNoX1_unfold]
   apply sepConj_mono_left _ h hp
@@ -155,13 +246,13 @@ theorem divStackDispatchPostNoX1_weaken
      shiftMem nMem jMem retMem dMem dloMem scratch_un0 : Word} :
     ∀ h,
       ((.x12 ↦ᵣ (sp + 32)) **
-       (.x1 ↦ᵣ v1) ** (.x2 ↦ᵣ v2) **
+       (.x9 ↦ᵣ v1) ** (.x2 ↦ᵣ v2) **
        (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
        (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) ** (.x0 ↦ᵣ (0 : Word)) **
        evmWordIs sp a ** evmWordIs (sp + 32) (EvmWord.div a b) **
        divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
          shiftMem nMem jMem retMem dMem dloMem scratch_un0) h →
-      (divStackDispatchPostNoX1 sp a b ** (.x1 ↦ᵣ v1)) h := by
+      (divStackDispatchPostNoX1 sp a b ** (.x9 ↦ᵣ v1)) h := by
   intro h hp
   exact divStackDispatchPostNoX1_weaken_frame (sp := sp) (a := a) (b := b) h
     (by xperm_hyp hp)
@@ -169,7 +260,7 @@ theorem divStackDispatchPostNoX1_weaken
 /-- Final MOD stack-dispatch postcondition. -/
 @[irreducible]
 def modStackDispatchPost (sp : Word) (a b : EvmWord) : Assertion :=
-  (.x12 ↦ᵣ (sp + 32)) ** regOwn .x1 ** regOwn .x2 **
+  (.x12 ↦ᵣ (sp + 32)) ** regOwn .x9 ** regOwn .x2 **
   regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
   regOwn .x10 ** regOwn .x11 ** (.x0 ↦ᵣ (0 : Word)) **
   evmWordIs sp a ** evmWordIs (sp + 32) (EvmWord.mod a b) **
@@ -177,7 +268,7 @@ def modStackDispatchPost (sp : Word) (a b : EvmWord) : Assertion :=
 
 theorem modStackDispatchPost_unfold {sp : Word} {a b : EvmWord} :
     modStackDispatchPost sp a b =
-    ((.x12 ↦ᵣ (sp + 32)) ** regOwn .x1 ** regOwn .x2 **
+    ((.x12 ↦ᵣ (sp + 32)) ** regOwn .x9 ** regOwn .x2 **
      regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
      regOwn .x10 ** regOwn .x11 ** (.x0 ↦ᵣ (0 : Word)) **
      evmWordIs sp a ** evmWordIs (sp + 32) (EvmWord.mod a b) **
@@ -206,6 +297,31 @@ theorem modStackDispatchPostNoX1_unfold {sp : Word} {a b : EvmWord} :
   delta modStackDispatchPostNoX1
   rfl
 
+/-- Callable-ready MOD postcondition that omits both exact `x1` and exact `x9`. -/
+@[irreducible]
+def modStackDispatchPostCallable (sp : Word) (a b : EvmWord) : Assertion :=
+  (.x12 ↦ᵣ (sp + 32)) ** regOwn .x2 **
+  regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+  regOwn .x10 ** regOwn .x11 ** (.x0 ↦ᵣ (0 : Word)) **
+  evmWordIs sp a ** evmWordIs (sp + 32) (EvmWord.mod a b) **
+  divScratchOwnCallNoX1 sp
+
+theorem modStackDispatchPostCallable_unfold {sp : Word} {a b : EvmWord} :
+    modStackDispatchPostCallable sp a b =
+    ((.x12 ↦ᵣ (sp + 32)) ** regOwn .x2 **
+     regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+     regOwn .x10 ** regOwn .x11 ** (.x0 ↦ᵣ (0 : Word)) **
+     evmWordIs sp a ** evmWordIs (sp + 32) (EvmWord.mod a b) **
+     divScratchOwnCallNoX1 sp) := by
+  delta modStackDispatchPostCallable
+  rfl
+
+theorem modStackDispatchPostCallable_pcFree (sp : Word) (a b : EvmWord) :
+    (modStackDispatchPostCallable sp a b).pcFree := by
+  rw [modStackDispatchPostCallable_unfold, divScratchOwnCallNoX1_unfold,
+    divScratchOwn_unfold]
+  pcFree
+
 theorem modStackDispatchPostNoX1_pcFree (sp : Word) (a b : EvmWord) :
     (modStackDispatchPostNoX1 sp a b).pcFree := by
   rw [modStackDispatchPostNoX1_unfold]
@@ -219,7 +335,7 @@ theorem modStackDispatchPost_weaken
      shiftMem nMem jMem retMem dMem dloMem scratch_un0 : Word} :
     ∀ h,
       ((.x12 ↦ᵣ (sp + 32)) **
-       (.x1 ↦ᵣ v1) ** (.x2 ↦ᵣ v2) **
+       (.x9 ↦ᵣ v1) ** (.x2 ↦ᵣ v2) **
        (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
        (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) **
        (.x0 ↦ᵣ (0 : Word)) **
@@ -334,7 +450,7 @@ theorem fullDivN1UnifiedPost_to_divStackDispatchPostNoX1
       fullDivN1UnifiedPost bltu_3 bltu_2 bltu_1 bltu_0 sp base
         a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 h →
       (divStackDispatchPostNoX1 sp a b **
-        (.x1 ↦ᵣ (signExtend12 4095 : Word))) h := by
+        (.x9 ↦ᵣ (signExtend12 4095 : Word))) h := by
   intro h hq
   let shift := fullDivN1Shift b0
   let antiShift := signExtend12 (0 : BitVec 12) - shift
@@ -715,7 +831,7 @@ theorem evm_div_n1_stack_spec_within_word_exact_x1
         q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
         shiftMem nMem jMem retMem dMem dloMem scratch_un0)
       (divStackDispatchPostNoX1 sp a b **
-        (.x1 ↦ᵣ (signExtend12 4095 : Word))) := by
+        (.x9 ↦ᵣ (signExtend12 4095 : Word))) := by
   obtain ⟨hdiv0, hdiv1, hdiv2, hdiv3⟩ :=
     fullDivN1_hdivs_of_word_eq bltu_3 bltu_2 bltu_1 bltu_0
       a b a0 a1 a2 a3 b0 b1 b2 b3 hdivWord
@@ -1123,7 +1239,7 @@ theorem fullDivN3UnifiedPost_to_divStackDispatchPostNoX1
       fullDivN3UnifiedPost bltu_1 bltu_0 sp base
         a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 h →
       (divStackDispatchPostNoX1 sp a b **
-        (.x1 ↦ᵣ (signExtend12 4095 : Word))) h := by
+        (.x9 ↦ᵣ (signExtend12 4095 : Word))) h := by
   intro h hq
   let shift := fullDivN3Shift b2
   let antiShift := signExtend12 (0 : BitVec 12) - shift
@@ -1286,8 +1402,8 @@ theorem evm_div_n3_stack_spec_within_noNop
 
 /-- Weaken the framed bzero-MOD postcondition to `modStackDispatchPostNoX1`.
     Mirrors `modStackDispatchPost_weaken_bzero_frame` but uses the NoX1 variant,
-    keeping `.x1 ↦ᵣ v1` as an explicit post atom instead of absorbing it into
-    `regOwn .x1`. -/
+    keeping `.x9 ↦ᵣ v1` as an explicit post atom instead of absorbing it into
+    `regOwn .x9`. -/
 theorem modStackDispatchPostNoX1_weaken_bzero_frame
     (sp : Word) (a b : EvmWord)
     {v2 v6 v7 v11 : Word}
@@ -1331,7 +1447,7 @@ def modBzeroDispatchPostPreservingX1Frame (sp : Word) (a b : EvmWord)
      shiftMem nMem jMem retMem dMem dloMem scratch_un0 : Word) : Assertion :=
   ((.x12 ↦ᵣ (sp + 32)) ** regOwn .x5 ** regOwn .x10 **
     (.x0 ↦ᵣ (0 : Word)) ** evmWordIs (sp + 32) (EvmWord.mod a b)) **
-  ((.x1 ↦ᵣ v1) ** (.x2 ↦ᵣ v2) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+  ((.x9 ↦ᵣ v1) ** (.x2 ↦ᵣ v2) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
     (.x11 ↦ᵣ v11) ** evmWordIs sp a **
     divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
       shiftMem nMem jMem retMem dMem dloMem scratch_un0)
@@ -1345,7 +1461,7 @@ theorem modBzeroDispatchPostPreservingX1Frame_unfold
         shiftMem nMem jMem retMem dMem dloMem scratch_un0 =
       (((.x12 ↦ᵣ (sp + 32)) ** regOwn .x5 ** regOwn .x10 **
         (.x0 ↦ᵣ (0 : Word)) ** evmWordIs (sp + 32) (EvmWord.mod a b)) **
-       ((.x1 ↦ᵣ v1) ** (.x2 ↦ᵣ v2) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+       ((.x9 ↦ᵣ v1) ** (.x2 ↦ᵣ v2) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
         (.x11 ↦ᵣ v11) ** evmWordIs sp a **
         divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratch_un0)) := by
@@ -1353,7 +1469,7 @@ theorem modBzeroDispatchPostPreservingX1Frame_unfold
   rfl
 
 /-- Weaken `modBzeroDispatchPostPreservingX1Frame` to
-    `modStackDispatchPostNoX1 ** (.x1 ↦ᵣ v1)`. This is the MOD-side analog of
+    `modStackDispatchPostNoX1 ** (.x9 ↦ᵣ v1)`. This is the MOD-side analog of
     `divBzeroDispatchPostPreservingX1Frame_weaken_noX1`. -/
 theorem modBzeroDispatchPostPreservingX1Frame_weaken_noX1
     (sp : Word) (a b : EvmWord)
@@ -1364,7 +1480,7 @@ theorem modBzeroDispatchPostPreservingX1Frame_weaken_noX1
     modBzeroDispatchPostPreservingX1Frame sp a b v1 v2 v6 v7 v11
         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
         shiftMem nMem jMem retMem dMem dloMem scratch_un0 h →
-    (modStackDispatchPostNoX1 sp a b ** (.x1 ↦ᵣ v1)) h := by
+    (modStackDispatchPostNoX1 sp a b ** (.x9 ↦ᵣ v1)) h := by
   intro h hp
   rw [modBzeroDispatchPostPreservingX1Frame_unfold] at hp
   simp only [sepConj_assoc', sepConj_comm', sepConj_left_comm'] at hp ⊢

--- a/EvmAsm/Evm64/DivMod/Spec/ModBzeroNoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/ModBzeroNoNop.lean
@@ -3,8 +3,8 @@
 
   Dispatch-level zero-divisor MOD spec over `modCode_noNop`, mirroring
   the div-side `evm_div_bzero_stack_spec_within_dispatch_noNop_preserving_x1_uni`
-  in `Spec/Unified.lean`. Placed in a separate file because `Spec/Unified.lean`
-  is at the file-size cap.
+  in `Spec/UnifiedBzero.lean`. Placed in a separate file because the unified
+  stack spec surface is near the file-size cap.
 -/
 
 import EvmAsm.Evm64.DivMod.Spec.Base
@@ -32,9 +32,9 @@ theorem evm_mod_bzero_stack_spec_within_dispatch_noNop_preserving_x1_uni
         v1 v2 v5 v6 v7 v10 v11
         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
         shiftMem nMem jMem retMem dMem dloMem scratch_un0)
-      (modStackDispatchPostNoX1 sp a b ** (.x1 ↦ᵣ v1)) := by
+      (modStackDispatchPostNoX1 sp a b ** (.x9 ↦ᵣ v1)) := by
   let frame : Assertion :=
-    (.x1 ↦ᵣ v1) ** (.x2 ↦ᵣ v2) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+    (.x9 ↦ᵣ v1) ** (.x2 ↦ᵣ v2) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
     (.x11 ↦ᵣ v11) ** evmWordIs sp a **
     divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
       shiftMem nMem jMem retMem dMem dloMem scratch_un0
@@ -53,6 +53,136 @@ theorem evm_mod_bzero_stack_spec_within_dispatch_noNop_preserving_x1_uni
         -- The POST is exactly the framed form, so weaken is trivial.
         exact modBzeroDispatchPostPreservingX1Frame_weaken_noX1 sp a b h
           (by rw [modBzeroDispatchPostPreservingX1Frame_unfold]; xperm_hyp hq))
+      hFramed
+
+/-- Zero-divisor MOD dispatcher over `modCode_noNop` in the callable-only
+    surface: exact `x1` is preserved for `cc_ret`, and exact `x9` is framed
+    separately from the DIV/MOD loop-counter ownership surface. -/
+theorem evm_mod_bzero_stack_spec_within_dispatch_noNop_callable_uni
+    (sp base : Word)
+    (a b : EvmWord) (x9Val raVal v2 v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratch_un0 : Word)
+    (hbz : b = 0) :
+    cpsTripleWithin unifiedDivBound base (base + nopOff) (modCode_noNop base)
+      (divModStackDispatchPreNoX1 sp a b
+        x9Val raVal v2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0)
+      ((modStackDispatchPostCallable sp a b ** (.x1 ↦ᵣ raVal)) **
+        (.x9 ↦ᵣ x9Val)) := by
+  let frame : Assertion :=
+    (.x9 ↦ᵣ x9Val) ** (.x1 ↦ᵣ raVal) ** (.x2 ↦ᵣ v2) **
+    (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x11 ↦ᵣ v11) **
+    evmWordIs sp a **
+    divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratch_un0
+  have hBzero := evm_mod_bzero_stack_spec_within_noNop sp base a b v5 v10 hbz
+  have hFramed :
+      cpsTripleWithin (8 + 5) base (base + nopOff) (modCode_noNop base)
+        (((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) **
+          (.x0 ↦ᵣ (0 : Word)) ** evmWordIs (sp + 32) b) ** frame)
+        ((((.x12 ↦ᵣ (sp + 32)) ** regOwn .x5 ** regOwn .x10 **
+          (.x0 ↦ᵣ (0 : Word)) ** evmWordIs (sp + 32) (EvmWord.mod a b)) ** frame)) :=
+    cpsTripleWithin_frameR frame (by
+      dsimp [frame]
+      rw [divScratchValuesCallNoX1_unfold]
+      pcFree) hBzero
+  exact cpsTripleWithin_mono_nSteps (by decide) <|
+    cpsTripleWithin_weaken
+      (fun _ hp => by
+        rw [divModStackDispatchPreNoX1_unfold] at hp
+        dsimp [frame]
+        simp only [sepConj_comm', sepConj_left_comm'] at hp ⊢
+        exact hp)
+      (fun h hq => by
+        dsimp [frame] at hq
+        rw [modStackDispatchPostCallable_unfold]
+        simp only [sepConj_assoc', sepConj_comm', sepConj_left_comm'] at hq ⊢
+        have hqOwn :
+            (divScratchOwnCallNoX1 sp ** evmWordIs sp a ** (.x0 ↦ᵣ (0 : Word)) **
+              (.x1 ↦ᵣ raVal) ** regOwn .x11 ** (.x12 ↦ᵣ (sp + 32)) **
+              regOwn .x2 ** regOwn .x6 ** regOwn .x7 ** (.x9 ↦ᵣ x9Val) **
+              regOwn .x10 ** regOwn .x5 ** evmWordIs (sp + 32) (EvmWord.mod a b)) h := by
+          refine sepConj_mono ?_ ?_ h hq
+          · intro hLeft hpLeft
+            exact divScratchValuesCallNoX1_implies_divScratchOwnCallNoX1
+              sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem
+                retMem dMem dloMem scratch_un0 hLeft hpLeft
+          · apply sepConj_mono_right
+            apply sepConj_mono_right
+            apply sepConj_mono_right
+            apply sepConj_mono (regIs_implies_regOwn .x11 (v := v11))
+            apply sepConj_mono_right
+            apply sepConj_mono (regIs_implies_regOwn .x2 (v := v2))
+            apply sepConj_mono (regIs_implies_regOwn .x6 (v := v6))
+            apply sepConj_mono (regIs_implies_regOwn .x7 (v := v7))
+            exact fun _ hp => hp
+        exact by xperm_hyp hqOwn)
+      hFramed
+
+/-- Zero-divisor MOD dispatcher over `modCode_noNop` with exact `x1` and no
+    `x9` frame. Used by callers whose bzero handoff does not carry `x9` state. -/
+theorem evm_mod_bzero_stack_spec_within_dispatch_noNop_callable_x1_uni
+    (sp base : Word)
+    (a b : EvmWord) (raVal v2 v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratch_un0 : Word)
+    (hbz : b = 0) :
+    cpsTripleWithin unifiedDivBound base (base + nopOff) (modCode_noNop base)
+      (divModStackDispatchPreCallable sp a b
+        raVal v2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0)
+      (modStackDispatchPostCallable sp a b ** (.x1 ↦ᵣ raVal)) := by
+  let frame : Assertion :=
+    (.x1 ↦ᵣ raVal) ** (.x2 ↦ᵣ v2) **
+    (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x11 ↦ᵣ v11) **
+    evmWordIs sp a **
+    divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratch_un0
+  have hBzero := evm_mod_bzero_stack_spec_within_noNop sp base a b v5 v10 hbz
+  have hFramed :
+      cpsTripleWithin (8 + 5) base (base + nopOff) (modCode_noNop base)
+        (((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) **
+          (.x0 ↦ᵣ (0 : Word)) ** evmWordIs (sp + 32) b) ** frame)
+        ((((.x12 ↦ᵣ (sp + 32)) ** regOwn .x5 ** regOwn .x10 **
+          (.x0 ↦ᵣ (0 : Word)) ** evmWordIs (sp + 32) (EvmWord.mod a b)) ** frame)) :=
+    cpsTripleWithin_frameR frame (by
+      dsimp [frame]
+      rw [divScratchValuesCallNoX1_unfold]
+      pcFree) hBzero
+  exact cpsTripleWithin_mono_nSteps (by decide) <|
+    cpsTripleWithin_weaken
+      (fun _ hp => by
+        rw [divModStackDispatchPreCallable_unfold] at hp
+        dsimp [frame]
+        simp only [sepConj_comm', sepConj_left_comm'] at hp ⊢
+        exact hp)
+      (fun h hq => by
+        dsimp [frame] at hq
+        rw [modStackDispatchPostCallable_unfold]
+        simp only [sepConj_assoc', sepConj_comm', sepConj_left_comm'] at hq ⊢
+        have hqOwn :
+            (divScratchOwnCallNoX1 sp ** evmWordIs sp a ** (.x0 ↦ᵣ (0 : Word)) **
+              (.x1 ↦ᵣ raVal) ** regOwn .x11 ** (.x12 ↦ᵣ (sp + 32)) **
+              regOwn .x2 ** regOwn .x6 ** regOwn .x7 **
+              regOwn .x10 ** regOwn .x5 ** evmWordIs (sp + 32) (EvmWord.mod a b)) h := by
+          refine sepConj_mono ?_ ?_ h hq
+          · intro hLeft hpLeft
+            exact divScratchValuesCallNoX1_implies_divScratchOwnCallNoX1
+              sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem
+                retMem dMem dloMem scratch_un0 hLeft hpLeft
+          · apply sepConj_mono_right
+            apply sepConj_mono_right
+            apply sepConj_mono_right
+            apply sepConj_mono (regIs_implies_regOwn .x11 (v := v11))
+            apply sepConj_mono_right
+            apply sepConj_mono (regIs_implies_regOwn .x2 (v := v2))
+            apply sepConj_mono (regIs_implies_regOwn .x6 (v := v6))
+            apply sepConj_mono (regIs_implies_regOwn .x7 (v := v7))
+            exact fun _ hp => hp
+        exact by xperm_hyp hqOwn)
       hFramed
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N2DivStackSpec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2DivStackSpec.lean
@@ -114,7 +114,7 @@ theorem fullDivN2DenormPost_fullDivN2Frame_to_divStackDispatchPostNoX1
        fullDivN2Frame bltu_2 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
          retMem dMem dloMem scratch_un0) h →
       (divStackDispatchPostNoX1 sp a b **
-        (.x1 ↦ᵣ (signExtend12 4095 : Word))) h := by
+        (.x9 ↦ᵣ (signExtend12 4095 : Word))) h := by
   intro h hq
   let shift := fullDivN2Shift b1
   let antiShift := signExtend12 (0 : BitVec 12) - shift
@@ -360,7 +360,7 @@ theorem evm_div_n2_stack_spec_within_word_exact_x1
         q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
         shiftMem nMem jMem retMem dMem dloMem scratch_un0)
       (divStackDispatchPostNoX1 sp a b **
-        (.x1 ↦ᵣ (signExtend12 4095 : Word))) := by
+        (.x9 ↦ᵣ (signExtend12 4095 : Word))) := by
   obtain ⟨hdiv0, hdiv1, hdiv2, hdiv3⟩ :=
     fullDivN2_hdivs_of_word_eq bltu_2 bltu_1 bltu_0
       a b a0 a1 a2 a3 b0 b1 b2 b3 hdivWord

--- a/EvmAsm/Evm64/DivMod/Spec/N3DivStackSpec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3DivStackSpec.lean
@@ -100,7 +100,7 @@ theorem evm_div_n3_stack_spec_within_word_exact_x1
         q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
         shiftMem nMem jMem retMem dMem dloMem scratch_un0)
       (divStackDispatchPostNoX1 sp a b **
-        (.x1 ↦ᵣ (signExtend12 4095 : Word))) := by
+        (.x9 ↦ᵣ (signExtend12 4095 : Word))) := by
   obtain ⟨hdiv0, hdiv1, hdiv2, hdiv3⟩ :=
     fullDivN3_hdivs_of_word_eq bltu_1 bltu_0
       a b a0 a1 a2 a3 b0 b1 b2 b3 hdivWord

--- a/EvmAsm/Evm64/DivMod/Spec/Unified.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/Unified.lean
@@ -8,9 +8,10 @@
   parent #61) via case-split, all four need a shared bound — otherwise the
   case-split branches produce triples with incompatible `nSteps`.
 
-  This file introduces `unifiedDivBound : Nat := 946` (the maximum across n=1..4)
-  and `_uni` wrappers for each per-`n` dispatcher-surface spec that lift the
-  existing bound to `unifiedDivBound` via `cpsTripleWithin_mono_nSteps`.
+  This file imports `unifiedDivBound : Nat := 946` (the maximum across n=1..4)
+  from `UnifiedBzero` and defines `_uni` wrappers for each per-`n`
+  dispatcher-surface spec that lift the existing bound to `unifiedDivBound`
+  via `cpsTripleWithin_mono_nSteps`.
 
   Pre/post are unchanged; the proof is a single `cpsTripleWithin_mono_nSteps`
   application with `by decide` for the bound inequality.
@@ -22,6 +23,7 @@
 -/
 
 import EvmAsm.Evm64.DivMod.Spec.Dispatcher
+import EvmAsm.Evm64.DivMod.Spec.UnifiedBzero
 import EvmAsm.Evm64.DivMod.Spec.N2DivStackSpec
 import EvmAsm.Evm64.DivMod.Spec.N2ModStackSpec
 import EvmAsm.Evm64.DivMod.Spec.N3DivStackSpec
@@ -31,378 +33,6 @@ import EvmAsm.Evm64.DivMod.N4StackSpecWithin
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
-
-/-- Unified `cpsTripleWithin` step bound for the dispatcher-surface DIV/MOD
-specs across n ∈ {1,2,3,4}. The maximum of the per-`n` bounds:
-n=1 = 946, n=2 = 744, n=3 = 542, n=4 = 340. The `_uni` wrappers below lift
-each per-`n` spec to this bound via `cpsTripleWithin_mono_nSteps`, so a future
-`evm_div_stack_spec` / `evm_mod_stack_spec` can case-split on `n` without
-incompatible `nSteps` between branches. -/
-def unifiedDivBound : Nat := 946
-
-theorem divStackDispatchPost_weaken_bzero_frame
-    (sp : Word) (a b : EvmWord)
-    {v1 v2 v6 v7 v11 : Word}
-    {q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-     shiftMem nMem jMem retMem dMem dloMem scratch_un0 : Word} :
-    ∀ h,
-      ((.x12 ↦ᵣ (sp + 32)) **
-       (.x1 ↦ᵣ v1) ** (.x2 ↦ᵣ v2) **
-       regOwn .x5 ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
-       regOwn .x10 ** (.x11 ↦ᵣ v11) **
-       (.x0 ↦ᵣ (0 : Word)) **
-       evmWordIs sp a ** evmWordIs (sp + 32) (EvmWord.div a b) **
-       divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-         shiftMem nMem jMem retMem dMem dloMem scratch_un0) h →
-      divStackDispatchPost sp a b h := by
-  intro h hp
-  delta divStackDispatchPost
-  apply sepConj_mono_right
-  apply sepConj_mono (regIs_implies_regOwn .x1 (v := v1))
-  apply sepConj_mono (regIs_implies_regOwn .x2 (v := v2))
-  apply sepConj_mono_right
-  apply sepConj_mono (regIs_implies_regOwn .x6 (v := v6))
-  apply sepConj_mono (regIs_implies_regOwn .x7 (v := v7))
-  apply sepConj_mono_right
-  apply sepConj_mono (regIs_implies_regOwn .x11 (v := v11))
-  apply sepConj_mono_right
-  apply sepConj_mono_right
-  apply sepConj_mono_right
-  exact divScratchValuesCall_implies_divScratchOwnCall
-    sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem
-      retMem dMem dloMem scratch_un0
-  exact hp
-
-theorem evm_div_bzero_stack_spec_within_dispatch_uni (sp base : Word)
-    (a b : EvmWord) (v1 v2 v5 v6 v7 v10 v11 : Word)
-    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-     nMem shiftMem jMem retMem dMem dloMem scratch_un0 : Word)
-    (hbz : b = 0) :
-    cpsTripleWithin unifiedDivBound base (base + nopOff) (divCode base)
-      (divModStackDispatchPre sp a b
-        v1 v2 v5 v6 v7 v10 v11
-        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-        shiftMem nMem jMem retMem dMem dloMem scratch_un0)
-      (divStackDispatchPost sp a b) := by
-  let frame : Assertion :=
-    (.x1 ↦ᵣ v1) ** (.x2 ↦ᵣ v2) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
-    (.x11 ↦ᵣ v11) ** evmWordIs sp a **
-    divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-      shiftMem nMem jMem retMem dMem dloMem scratch_un0
-  have hBzero :=
-    evm_div_bzero_stack_spec_within sp base a b v5 v10 hbz
-  have hFramed :
-      cpsTripleWithin (8 + 5) base (base + nopOff) (divCode base)
-        (((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) **
-          (.x0 ↦ᵣ (0 : Word)) ** evmWordIs (sp + 32) b) ** frame)
-        ((((.x12 ↦ᵣ (sp + 32)) ** regOwn .x5 ** regOwn .x10 **
-          (.x0 ↦ᵣ (0 : Word)) ** evmWordIs (sp + 32) (EvmWord.div a b)) ** frame)) :=
-    cpsTripleWithin_frameR frame (by
-      dsimp [frame]
-      rw [divScratchValuesCall_unfold]
-      pcFree) hBzero
-  exact cpsTripleWithin_mono_nSteps (by decide) <|
-    cpsTripleWithin_weaken
-      (fun _ hp => by
-        rw [divModStackDispatchPre_unfold] at hp
-        dsimp [frame]
-        simp only [sepConj_comm', sepConj_left_comm'] at hp ⊢
-        exact hp)
-      (fun _ hq => by
-        dsimp [frame] at hq
-        refine divStackDispatchPost_weaken_bzero_frame (sp := sp) (a := a) (b := b)
-          (v1 := v1) (v2 := v2) (v6 := v6) (v7 := v7) (v11 := v11)
-          (q0 := q0) (q1 := q1) (q2 := q2) (q3 := q3)
-          (u0 := u0) (u1 := u1) (u2 := u2) (u3 := u3)
-          (u4 := u4) (u5 := u5) (u6 := u6) (u7 := u7)
-          (shiftMem := shiftMem) (nMem := nMem) (jMem := jMem)
-          (retMem := retMem) (dMem := dMem) (dloMem := dloMem)
-          (scratch_un0 := scratch_un0) _ ?_
-        simp only [sepConj_assoc', sepConj_comm', sepConj_left_comm'] at hq ⊢
-        exact hq)
-      hFramed
-
-theorem evm_div_bzero_stack_spec_within_dispatch_noNop_uni (sp base : Word)
-    (a b : EvmWord) (v1 v2 v5 v6 v7 v10 v11 : Word)
-    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-     nMem shiftMem jMem retMem dMem dloMem scratch_un0 : Word)
-    (hbz : b = 0) :
-    cpsTripleWithin unifiedDivBound base (base + nopOff) (divCode_noNop base)
-      (divModStackDispatchPre sp a b
-        v1 v2 v5 v6 v7 v10 v11
-        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-        shiftMem nMem jMem retMem dMem dloMem scratch_un0)
-      (divStackDispatchPost sp a b) := by
-  let frame : Assertion :=
-    (.x1 ↦ᵣ v1) ** (.x2 ↦ᵣ v2) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
-    (.x11 ↦ᵣ v11) ** evmWordIs sp a **
-    divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-      shiftMem nMem jMem retMem dMem dloMem scratch_un0
-  have hBzero :=
-    evm_div_bzero_stack_spec_within_noNop sp base a b v5 v10 hbz
-  have hFramed :
-      cpsTripleWithin (8 + 5) base (base + nopOff) (divCode_noNop base)
-        (((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) **
-          (.x0 ↦ᵣ (0 : Word)) ** evmWordIs (sp + 32) b) ** frame)
-        ((((.x12 ↦ᵣ (sp + 32)) ** regOwn .x5 ** regOwn .x10 **
-          (.x0 ↦ᵣ (0 : Word)) ** evmWordIs (sp + 32) (EvmWord.div a b)) ** frame)) :=
-    cpsTripleWithin_frameR frame (by
-      dsimp [frame]
-      rw [divScratchValuesCall_unfold]
-      pcFree) hBzero
-  exact cpsTripleWithin_mono_nSteps (by decide) <|
-    cpsTripleWithin_weaken
-      (fun _ hp => by
-        rw [divModStackDispatchPre_unfold] at hp
-        dsimp [frame]
-        simp only [sepConj_comm', sepConj_left_comm'] at hp ⊢
-        exact hp)
-      (fun _ hq => by
-        dsimp [frame] at hq
-        refine divStackDispatchPost_weaken_bzero_frame (sp := sp) (a := a) (b := b)
-          (v1 := v1) (v2 := v2) (v6 := v6) (v7 := v7) (v11 := v11)
-          (q0 := q0) (q1 := q1) (q2 := q2) (q3 := q3)
-          (u0 := u0) (u1 := u1) (u2 := u2) (u3 := u3)
-          (u4 := u4) (u5 := u5) (u6 := u6) (u7 := u7)
-          (shiftMem := shiftMem) (nMem := nMem) (jMem := jMem)
-          (retMem := retMem) (dMem := dMem) (dloMem := dloMem)
-          (scratch_un0 := scratch_un0) _ ?_
-        simp only [sepConj_assoc', sepConj_comm', sepConj_left_comm'] at hq ⊢
-        exact hq)
-      hFramed
-
-/-- Framed zero-divisor DIV dispatcher post over `divCode_noNop`, before the
-    usual weakening to `divStackDispatchPost`. This keeps the incoming `x1`
-    value concrete for callable wrappers that need the following `ret` address
-    to remain visible. -/
-@[irreducible]
-def divBzeroDispatchPostPreservingX1Frame (sp : Word) (a b : EvmWord)
-    (v1 v2 v6 v7 v11 : Word)
-    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-     shiftMem nMem jMem retMem dMem dloMem scratch_un0 : Word) : Assertion :=
-  ((.x12 ↦ᵣ (sp + 32)) ** regOwn .x5 ** regOwn .x10 **
-    (.x0 ↦ᵣ (0 : Word)) ** evmWordIs (sp + 32) (EvmWord.div a b)) **
-  ((.x1 ↦ᵣ v1) ** (.x2 ↦ᵣ v2) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
-    (.x11 ↦ᵣ v11) ** evmWordIs sp a **
-    divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-      shiftMem nMem jMem retMem dMem dloMem scratch_un0)
-
-theorem divBzeroDispatchPostPreservingX1Frame_unfold
-    {sp : Word} {a b : EvmWord} {v1 v2 v6 v7 v11 : Word}
-    {q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-     shiftMem nMem jMem retMem dMem dloMem scratch_un0 : Word} :
-    divBzeroDispatchPostPreservingX1Frame sp a b v1 v2 v6 v7 v11
-        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-        shiftMem nMem jMem retMem dMem dloMem scratch_un0 =
-      (((.x12 ↦ᵣ (sp + 32)) ** regOwn .x5 ** regOwn .x10 **
-        (.x0 ↦ᵣ (0 : Word)) ** evmWordIs (sp + 32) (EvmWord.div a b)) **
-       ((.x1 ↦ᵣ v1) ** (.x2 ↦ᵣ v2) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
-        (.x11 ↦ᵣ v11) ** evmWordIs sp a **
-        divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-          shiftMem nMem jMem retMem dMem dloMem scratch_un0)) := by
-  delta divBzeroDispatchPostPreservingX1Frame
-  rfl
-
-theorem divStackDispatchPostNoX1_weaken_bzero_frame
-    (sp : Word) (a b : EvmWord)
-    {v1 v2 v6 v7 v11 : Word}
-    {q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-     shiftMem nMem jMem retMem dMem dloMem scratch_un0 : Word} :
-    ∀ h,
-      (((.x12 ↦ᵣ (sp + 32)) **
-        (.x2 ↦ᵣ v2) ** regOwn .x5 ** (.x6 ↦ᵣ v6) **
-        (.x7 ↦ᵣ v7) ** regOwn .x10 ** (.x11 ↦ᵣ v11) **
-        (.x0 ↦ᵣ (0 : Word)) **
-        evmWordIs sp a ** evmWordIs (sp + 32) (EvmWord.div a b) **
-        divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-          shiftMem nMem jMem retMem dMem dloMem scratch_un0) **
-       (.x1 ↦ᵣ v1)) h →
-      (divStackDispatchPostNoX1 sp a b ** (.x1 ↦ᵣ v1)) h := by
-  intro h hp
-  rw [divStackDispatchPostNoX1_unfold]
-  apply sepConj_mono_left _ h hp
-  intro hLeft hpLeft
-  apply sepConj_mono_right
-  apply sepConj_mono (regIs_implies_regOwn .x2 (v := v2))
-  apply sepConj_mono_right
-  apply sepConj_mono (regIs_implies_regOwn .x6 (v := v6))
-  apply sepConj_mono (regIs_implies_regOwn .x7 (v := v7))
-  apply sepConj_mono_right
-  apply sepConj_mono (regIs_implies_regOwn .x11 (v := v11))
-  apply sepConj_mono_right
-  apply sepConj_mono_right
-  apply sepConj_mono_right
-  exact divScratchValuesCall_implies_divScratchOwnCall
-    sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem
-      retMem dMem dloMem scratch_un0
-  exact hpLeft
-
-theorem divBzeroDispatchPostPreservingX1Frame_weaken_noX1
-    (sp : Word) (a b : EvmWord)
-    {v1 v2 v6 v7 v11 : Word}
-    {q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-     shiftMem nMem jMem retMem dMem dloMem scratch_un0 : Word} :
-    ∀ h,
-      divBzeroDispatchPostPreservingX1Frame sp a b v1 v2 v6 v7 v11
-        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-        shiftMem nMem jMem retMem dMem dloMem scratch_un0 h →
-      (divStackDispatchPostNoX1 sp a b ** (.x1 ↦ᵣ v1)) h := by
-  intro h hp
-  rw [divBzeroDispatchPostPreservingX1Frame_unfold] at hp
-  simp only [sepConj_assoc', sepConj_comm', sepConj_left_comm'] at hp ⊢
-  exact divStackDispatchPostNoX1_weaken_bzero_frame
-    (sp := sp) (a := a) (b := b) h (by xperm_hyp hp)
-
-/-- Zero-divisor DIV dispatcher over `divCode_noNop`, preserving the exact
-    incoming `x1` value in a named framed postcondition. -/
-theorem evm_div_bzero_stack_spec_within_dispatch_noNop_preserving_x1_frame_uni
-    (sp base : Word)
-    (a b : EvmWord) (v1 v2 v5 v6 v7 v10 v11 : Word)
-    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-     nMem shiftMem jMem retMem dMem dloMem scratch_un0 : Word)
-    (hbz : b = 0) :
-    cpsTripleWithin unifiedDivBound base (base + nopOff) (divCode_noNop base)
-      (divModStackDispatchPre sp a b
-        v1 v2 v5 v6 v7 v10 v11
-        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-        shiftMem nMem jMem retMem dMem dloMem scratch_un0)
-      (divBzeroDispatchPostPreservingX1Frame sp a b v1 v2 v6 v7 v11
-        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-        shiftMem nMem jMem retMem dMem dloMem scratch_un0) := by
-  let frame : Assertion :=
-    (.x1 ↦ᵣ v1) ** (.x2 ↦ᵣ v2) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
-    (.x11 ↦ᵣ v11) ** evmWordIs sp a **
-    divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-      shiftMem nMem jMem retMem dMem dloMem scratch_un0
-  have hBzero :=
-    evm_div_bzero_stack_spec_within_noNop sp base a b v5 v10 hbz
-  have hFramed :
-      cpsTripleWithin (8 + 5) base (base + nopOff) (divCode_noNop base)
-        (((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) **
-          (.x0 ↦ᵣ (0 : Word)) ** evmWordIs (sp + 32) b) ** frame)
-        ((((.x12 ↦ᵣ (sp + 32)) ** regOwn .x5 ** regOwn .x10 **
-          (.x0 ↦ᵣ (0 : Word)) ** evmWordIs (sp + 32) (EvmWord.div a b)) ** frame)) :=
-    cpsTripleWithin_frameR frame (by
-      dsimp [frame]
-      rw [divScratchValuesCall_unfold]
-      pcFree) hBzero
-  exact cpsTripleWithin_mono_nSteps (by decide) <|
-    cpsTripleWithin_weaken
-      (fun _ hp => by
-        rw [divModStackDispatchPre_unfold] at hp
-        dsimp [frame]
-        simp only [sepConj_comm', sepConj_left_comm'] at hp ⊢
-        exact hp)
-      (fun h hq => by
-        dsimp [frame] at hq
-        rw [divBzeroDispatchPostPreservingX1Frame_unfold]
-        simp only [sepConj_assoc', sepConj_comm', sepConj_left_comm'] at hq ⊢
-        exact hq)
-      hFramed
-
-/-- Zero-divisor DIV dispatcher over `divCode_noNop`, preserving the exact
-    incoming `x1` value in the callable-ready post shape. -/
-theorem evm_div_bzero_stack_spec_within_dispatch_noNop_preserving_x1_uni
-    (sp base : Word)
-    (a b : EvmWord) (v1 v2 v5 v6 v7 v10 v11 : Word)
-    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-     nMem shiftMem jMem retMem dMem dloMem scratch_un0 : Word)
-    (hbz : b = 0) :
-    cpsTripleWithin unifiedDivBound base (base + nopOff) (divCode_noNop base)
-      (divModStackDispatchPre sp a b
-        v1 v2 v5 v6 v7 v10 v11
-        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-        shiftMem nMem jMem retMem dMem dloMem scratch_un0)
-      (divStackDispatchPostNoX1 sp a b ** (.x1 ↦ᵣ v1)) := by
-  exact cpsTripleWithin_weaken (fun _ hp => hp) (fun h hp =>
-    divBzeroDispatchPostPreservingX1Frame_weaken_noX1
-      (sp := sp) (a := a) (b := b) h hp)
-    (evm_div_bzero_stack_spec_within_dispatch_noNop_preserving_x1_frame_uni
-      sp base a b v1 v2 v5 v6 v7 v10 v11
-      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-      nMem shiftMem jMem retMem dMem dloMem scratch_un0 hbz)
-
-theorem modStackDispatchPost_weaken_bzero_frame
-    (sp : Word) (a b : EvmWord)
-    {v1 v2 v6 v7 v11 : Word}
-    {q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-     shiftMem nMem jMem retMem dMem dloMem scratch_un0 : Word} :
-    ∀ h,
-      ((.x12 ↦ᵣ (sp + 32)) **
-       (.x1 ↦ᵣ v1) ** (.x2 ↦ᵣ v2) **
-       regOwn .x5 ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
-       regOwn .x10 ** (.x11 ↦ᵣ v11) **
-       (.x0 ↦ᵣ (0 : Word)) **
-       evmWordIs sp a ** evmWordIs (sp + 32) (EvmWord.mod a b) **
-       divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-         shiftMem nMem jMem retMem dMem dloMem scratch_un0) h →
-      modStackDispatchPost sp a b h := by
-  intro h hp
-  delta modStackDispatchPost
-  apply sepConj_mono_right
-  apply sepConj_mono (regIs_implies_regOwn .x1 (v := v1))
-  apply sepConj_mono (regIs_implies_regOwn .x2 (v := v2))
-  apply sepConj_mono_right
-  apply sepConj_mono (regIs_implies_regOwn .x6 (v := v6))
-  apply sepConj_mono (regIs_implies_regOwn .x7 (v := v7))
-  apply sepConj_mono_right
-  apply sepConj_mono (regIs_implies_regOwn .x11 (v := v11))
-  apply sepConj_mono_right
-  apply sepConj_mono_right
-  apply sepConj_mono_right
-  exact divScratchValuesCall_implies_divScratchOwnCall
-    sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem
-      retMem dMem dloMem scratch_un0
-  exact hp
-
-theorem evm_mod_bzero_stack_spec_within_dispatch_uni (sp base : Word)
-    (a b : EvmWord) (v1 v2 v5 v6 v7 v10 v11 : Word)
-    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-     nMem shiftMem jMem retMem dMem dloMem scratch_un0 : Word)
-    (hbz : b = 0) :
-    cpsTripleWithin unifiedDivBound base (base + nopOff) (modCode base)
-      (divModStackDispatchPre sp a b
-        v1 v2 v5 v6 v7 v10 v11
-        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-        shiftMem nMem jMem retMem dMem dloMem scratch_un0)
-      (modStackDispatchPost sp a b) := by
-  let frame : Assertion :=
-    (.x1 ↦ᵣ v1) ** (.x2 ↦ᵣ v2) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
-    (.x11 ↦ᵣ v11) ** evmWordIs sp a **
-    divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-      shiftMem nMem jMem retMem dMem dloMem scratch_un0
-  have hBzero :=
-    evm_mod_bzero_stack_spec_within sp base a b v5 v10 hbz
-  have hFramed :
-      cpsTripleWithin 13 base (base + nopOff) (modCode base)
-        (((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) **
-          (.x0 ↦ᵣ (0 : Word)) ** evmWordIs (sp + 32) b) ** frame)
-        ((((.x12 ↦ᵣ (sp + 32)) ** regOwn .x5 ** regOwn .x10 **
-          (.x0 ↦ᵣ (0 : Word)) ** evmWordIs (sp + 32) (EvmWord.mod a b)) ** frame)) :=
-    cpsTripleWithin_frameR frame (by
-      dsimp [frame]
-      rw [divScratchValuesCall_unfold]
-      pcFree) hBzero
-  exact cpsTripleWithin_mono_nSteps (by decide) <|
-    cpsTripleWithin_weaken
-      (fun _ hp => by
-        rw [divModStackDispatchPre_unfold] at hp
-        dsimp [frame]
-        simp only [sepConj_comm', sepConj_left_comm'] at hp ⊢
-        exact hp)
-      (fun _ hq => by
-        dsimp [frame] at hq
-        refine modStackDispatchPost_weaken_bzero_frame (sp := sp) (a := a) (b := b)
-          (v1 := v1) (v2 := v2) (v6 := v6) (v7 := v7) (v11 := v11)
-          (q0 := q0) (q1 := q1) (q2 := q2) (q3 := q3)
-          (u0 := u0) (u1 := u1) (u2 := u2) (u3 := u3)
-          (u4 := u4) (u5 := u5) (u6 := u6) (u7 := u7)
-          (shiftMem := shiftMem) (nMem := nMem) (jMem := jMem)
-          (retMem := retMem) (dMem := dMem) (dloMem := dloMem)
-          (scratch_un0 := scratch_un0) _ ?_
-        simp only [sepConj_assoc', sepConj_comm', sepConj_left_comm'] at hq ⊢
-        exact hq)
-      hFramed
 
 /-! ### DIV `_uni` wrappers -/
 
@@ -481,7 +111,7 @@ theorem evm_div_n1_stack_spec_within_word_exact_x1_uni
         q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
         shiftMem nMem jMem retMem dMem dloMem scratch_un0)
       (divStackDispatchPostNoX1 sp a b **
-        (.x1 ↦ᵣ (signExtend12 4095 : Word))) :=
+        (.x9 ↦ᵣ (signExtend12 4095 : Word))) :=
   cpsTripleWithin_mono_nSteps (by decide)
     (evm_div_n1_stack_spec_within_word_exact_x1 bltu_3 bltu_2 bltu_1 bltu_0
       sp base a b a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old
@@ -604,7 +234,7 @@ theorem evm_div_n2_stack_spec_within_word_exact_x1_uni
         q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
         shiftMem nMem jMem retMem dMem dloMem scratch_un0)
       (divStackDispatchPostNoX1 sp a b **
-        (.x1 ↦ᵣ (signExtend12 4095 : Word))) :=
+        (.x9 ↦ᵣ (signExtend12 4095 : Word))) :=
   cpsTripleWithin_mono_nSteps (by decide)
     (evm_div_n2_stack_spec_within_word_exact_x1 bltu_2 bltu_1 bltu_0
       sp base a b a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old
@@ -724,7 +354,7 @@ theorem evm_div_n3_stack_spec_within_word_exact_x1_uni
         q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
         shiftMem nMem jMem retMem dMem dloMem scratch_un0)
       (divStackDispatchPostNoX1 sp a b **
-        (.x1 ↦ᵣ (signExtend12 4095 : Word))) :=
+        (.x9 ↦ᵣ (signExtend12 4095 : Word))) :=
   cpsTripleWithin_mono_nSteps (by decide)
     (evm_div_n3_stack_spec_within_word_exact_x1 bltu_1 bltu_0
       sp base a b a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old
@@ -821,7 +451,7 @@ theorem evm_div_n4_stack_spec_within_dispatch_exact_x1_uni (sp base : Word)
         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
         shiftMem nMem jMem retMem dMem dloMem scratch_un0)
       (divStackDispatchPostNoX1 sp a b **
-        (.x1 ↦ᵣ signExtend12 (4095 : BitVec 12))) :=
+        (.x9 ↦ᵣ signExtend12 (4095 : BitVec 12))) :=
   cpsTripleWithin_mono_nSteps (by decide)
     (evm_div_n4_stack_spec_within_dispatch_exact_x1 sp base a b v5 v6 v7 v10 v11
       q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
@@ -971,6 +601,9 @@ def x1 {base : Word} {a b : EvmWord} : DivStackSpecCase base a b → Word
   | .bzero v1 _ _ => v1
   | _ => signExtend12 (4 : BitVec 12) - (4 : Word)
 
+/-- x9 is the loop-counter register (renamed from x1 post-fix). -/
+def x9 {base : Word} {a b : EvmWord} : DivStackSpecCase base a b → Word := x1
+
 def x2 {base : Word} {a b : EvmWord} : DivStackSpecCase base a b → Word
   | .bzero _ v2 _ => v2
   | .n1Full .. => (clzResult (b.getLimbN 0)).2 >>> (63 : Nat)
@@ -982,6 +615,9 @@ def returnX1 {base : Word} {a b : EvmWord} : DivStackSpecCase base a b → Word
   | .bzero v1 _ _ => v1
   | _ => signExtend12 (4095 : BitVec 12)
 
+/-- returnX9 is the final loop-counter value (renamed from returnX1 post-fix). -/
+def returnX9 {base : Word} {a b : EvmWord} : DivStackSpecCase base a b → Word := returnX1
+
 end DivStackSpecCase
 
 /-- Single named DIV stack spec over the dispatcher branch certificate. -/
@@ -992,7 +628,7 @@ theorem evm_div_stack_spec (sp base : Word) (a b : EvmWord)
     (branch : DivStackSpecCase base a b) :
     cpsTripleWithin unifiedDivBound base (base + nopOff) (divCode base)
       (divModStackDispatchPre sp a b
-        branch.x1 branch.x2 v5 v6 v7 v10 v11
+        branch.x9 branch.x2 v5 v6 v7 v10 v11
         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
         shiftMem nMem jMem retMem dMem dloMem scratch_un0)
       (divStackDispatchPost sp a b) := by
@@ -1050,10 +686,10 @@ theorem evm_div_stack_spec_exact_x1 (sp base : Word) (a b : EvmWord)
     (branch : DivStackSpecCase base a b) :
     cpsTripleWithin unifiedDivBound base (base + nopOff) (divCode base)
       (divModStackDispatchPre sp a b
-        branch.x1 branch.x2 v5 v6 v7 v10 v11
+        branch.x9 branch.x2 v5 v6 v7 v10 v11
         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
         shiftMem nMem jMem retMem dMem dloMem scratch_un0)
-      (divStackDispatchPostNoX1 sp a b ** (.x1 ↦ᵣ branch.returnX1)) := by
+      (divStackDispatchPostNoX1 sp a b ** (.x9 ↦ᵣ branch.returnX1)) := by
   cases branch with
   | bzero v1 v2 hbz =>
       have hStack :=
@@ -1109,7 +745,7 @@ theorem evm_div_stack_spec_noNop (sp base : Word) (a b : EvmWord)
     (branch : DivStackSpecCase base a b) :
     cpsTripleWithin unifiedDivBound base (base + nopOff) (divCode_noNop base)
       (divModStackDispatchPre sp a b
-        branch.x1 branch.x2 v5 v6 v7 v10 v11
+        branch.x9 branch.x2 v5 v6 v7 v10 v11
         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
         shiftMem nMem jMem retMem dMem dloMem scratch_un0)
       (divStackDispatchPost sp a b) := by
@@ -1423,6 +1059,9 @@ def x1 {base : Word} {a b : EvmWord} : ModStackSpecCase base a b → Word
   | .bzero v1 _ _ => v1
   | _ => signExtend12 (4 : BitVec 12) - (4 : Word)
 
+/-- x9 is the loop-counter register (renamed from x1 post-fix). -/
+def x9 {base : Word} {a b : EvmWord} : ModStackSpecCase base a b → Word := x1
+
 def x2 {base : Word} {a b : EvmWord} : ModStackSpecCase base a b → Word
   | .bzero _ v2 _ => v2
   | .n1Full .. => (clzResult (b.getLimbN 0)).2 >>> (63 : Nat)
@@ -1440,7 +1079,7 @@ theorem evm_mod_stack_spec (sp base : Word) (a b : EvmWord)
     (branch : ModStackSpecCase base a b) :
     cpsTripleWithin unifiedDivBound base (base + nopOff) (modCode base)
       (divModStackDispatchPre sp a b
-        branch.x1 branch.x2 v5 v6 v7 v10 v11
+        branch.x9 branch.x2 v5 v6 v7 v10 v11
         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
         shiftMem nMem jMem retMem dMem dloMem scratch_un0)
       (modStackDispatchPost sp a b) := by

--- a/EvmAsm/Evm64/DivMod/Spec/UnifiedBzero.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/UnifiedBzero.lean
@@ -1,0 +1,473 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.UnifiedBzero
+
+  Unified-bound zero-divisor DIV/MOD dispatcher wrappers. The four per-`n` dispatcher-surface
+  specs (n=1, n=2, n=3, n=4) all have different `cpsTripleWithin` step bounds
+  (n=1: 946, n=2: 744, n=3: 542, n=4: 340). Before they can be combined into a
+  single `evm_div_stack_spec` / `evm_mod_stack_spec` (slice 4keh / 3muq under
+  parent #61) via case-split, all four need a shared bound — otherwise the
+  case-split branches produce triples with incompatible `nSteps`.
+
+  This file owns `unifiedDivBound : Nat := 946` and the zero-divisor dispatcher wrappers shared by the unified stack specs.
+
+  Pre/post are unchanged; the proof is a single `cpsTripleWithin_mono_nSteps`
+  application with `by decide` for the bound inequality.
+
+  Authored by @pirapira; implemented by Hermes-bot (evm-hermes).
+
+  Refs: GH #61, beads `evm-asm-unta` (parent `evm-asm-4keh`, grandparent
+  `evm-asm-pb40`).
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.Dispatcher
+import EvmAsm.Evm64.DivMod.Spec.N2DivStackSpec
+import EvmAsm.Evm64.DivMod.Spec.N2ModStackSpec
+import EvmAsm.Evm64.DivMod.Spec.N3DivStackSpec
+import EvmAsm.Evm64.DivMod.Spec.N3ModBridge
+import EvmAsm.Evm64.DivMod.N4StackSpecWithin
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Unified `cpsTripleWithin` step bound for the dispatcher-surface DIV/MOD
+specs across n ∈ {1,2,3,4}. The maximum of the per-`n` bounds:
+n=1 = 946, n=2 = 744, n=3 = 542, n=4 = 340. The `_uni` wrappers below lift
+each per-`n` spec to this bound via `cpsTripleWithin_mono_nSteps`, so a future
+`evm_div_stack_spec` / `evm_mod_stack_spec` can case-split on `n` without
+incompatible `nSteps` between branches. -/
+def unifiedDivBound : Nat := 946
+
+theorem divStackDispatchPost_weaken_bzero_frame
+    (sp : Word) (a b : EvmWord)
+    {v1 v2 v6 v7 v11 : Word}
+    {q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratch_un0 : Word} :
+    ∀ h,
+      ((.x12 ↦ᵣ (sp + 32)) **
+       (.x9 ↦ᵣ v1) ** (.x2 ↦ᵣ v2) **
+       regOwn .x5 ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+       regOwn .x10 ** (.x11 ↦ᵣ v11) **
+       (.x0 ↦ᵣ (0 : Word)) **
+       evmWordIs sp a ** evmWordIs (sp + 32) (EvmWord.div a b) **
+       divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratch_un0) h →
+      divStackDispatchPost sp a b h := by
+  intro h hp
+  delta divStackDispatchPost
+  apply sepConj_mono_right
+  apply sepConj_mono (regIs_implies_regOwn .x9 (v := v1))
+  apply sepConj_mono (regIs_implies_regOwn .x2 (v := v2))
+  apply sepConj_mono_right
+  apply sepConj_mono (regIs_implies_regOwn .x6 (v := v6))
+  apply sepConj_mono (regIs_implies_regOwn .x7 (v := v7))
+  apply sepConj_mono_right
+  apply sepConj_mono (regIs_implies_regOwn .x11 (v := v11))
+  apply sepConj_mono_right
+  apply sepConj_mono_right
+  apply sepConj_mono_right
+  exact divScratchValuesCall_implies_divScratchOwnCall
+    sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem
+      retMem dMem dloMem scratch_un0
+  exact hp
+
+theorem evm_div_bzero_stack_spec_within_dispatch_uni (sp base : Word)
+    (a b : EvmWord) (v1 v2 v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratch_un0 : Word)
+    (hbz : b = 0) :
+    cpsTripleWithin unifiedDivBound base (base + nopOff) (divCode base)
+      (divModStackDispatchPre sp a b
+        v1 v2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0)
+      (divStackDispatchPost sp a b) := by
+  let frame : Assertion :=
+    (.x9 ↦ᵣ v1) ** (.x2 ↦ᵣ v2) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+    (.x11 ↦ᵣ v11) ** evmWordIs sp a **
+    divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratch_un0
+  have hBzero :=
+    evm_div_bzero_stack_spec_within sp base a b v5 v10 hbz
+  have hFramed :
+      cpsTripleWithin (8 + 5) base (base + nopOff) (divCode base)
+        (((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) **
+          (.x0 ↦ᵣ (0 : Word)) ** evmWordIs (sp + 32) b) ** frame)
+        ((((.x12 ↦ᵣ (sp + 32)) ** regOwn .x5 ** regOwn .x10 **
+          (.x0 ↦ᵣ (0 : Word)) ** evmWordIs (sp + 32) (EvmWord.div a b)) ** frame)) :=
+    cpsTripleWithin_frameR frame (by
+      dsimp [frame]
+      rw [divScratchValuesCall_unfold]
+      pcFree) hBzero
+  exact cpsTripleWithin_mono_nSteps (by decide) <|
+    cpsTripleWithin_weaken
+      (fun _ hp => by
+        rw [divModStackDispatchPre_unfold] at hp
+        dsimp [frame]
+        simp only [sepConj_comm', sepConj_left_comm'] at hp ⊢
+        exact hp)
+      (fun _ hq => by
+        dsimp [frame] at hq
+        refine divStackDispatchPost_weaken_bzero_frame (sp := sp) (a := a) (b := b)
+          (v1 := v1) (v2 := v2) (v6 := v6) (v7 := v7) (v11 := v11)
+          (q0 := q0) (q1 := q1) (q2 := q2) (q3 := q3)
+          (u0 := u0) (u1 := u1) (u2 := u2) (u3 := u3)
+          (u4 := u4) (u5 := u5) (u6 := u6) (u7 := u7)
+          (shiftMem := shiftMem) (nMem := nMem) (jMem := jMem)
+          (retMem := retMem) (dMem := dMem) (dloMem := dloMem)
+          (scratch_un0 := scratch_un0) _ ?_
+        simp only [sepConj_assoc', sepConj_comm', sepConj_left_comm'] at hq ⊢
+        exact hq)
+      hFramed
+
+theorem evm_div_bzero_stack_spec_within_dispatch_noNop_uni (sp base : Word)
+    (a b : EvmWord) (v1 v2 v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratch_un0 : Word)
+    (hbz : b = 0) :
+    cpsTripleWithin unifiedDivBound base (base + nopOff) (divCode_noNop base)
+      (divModStackDispatchPre sp a b
+        v1 v2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0)
+      (divStackDispatchPost sp a b) := by
+  let frame : Assertion :=
+    (.x9 ↦ᵣ v1) ** (.x2 ↦ᵣ v2) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+    (.x11 ↦ᵣ v11) ** evmWordIs sp a **
+    divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratch_un0
+  have hBzero :=
+    evm_div_bzero_stack_spec_within_noNop sp base a b v5 v10 hbz
+  have hFramed :
+      cpsTripleWithin (8 + 5) base (base + nopOff) (divCode_noNop base)
+        (((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) **
+          (.x0 ↦ᵣ (0 : Word)) ** evmWordIs (sp + 32) b) ** frame)
+        ((((.x12 ↦ᵣ (sp + 32)) ** regOwn .x5 ** regOwn .x10 **
+          (.x0 ↦ᵣ (0 : Word)) ** evmWordIs (sp + 32) (EvmWord.div a b)) ** frame)) :=
+    cpsTripleWithin_frameR frame (by
+      dsimp [frame]
+      rw [divScratchValuesCall_unfold]
+      pcFree) hBzero
+  exact cpsTripleWithin_mono_nSteps (by decide) <|
+    cpsTripleWithin_weaken
+      (fun _ hp => by
+        rw [divModStackDispatchPre_unfold] at hp
+        dsimp [frame]
+        simp only [sepConj_comm', sepConj_left_comm'] at hp ⊢
+        exact hp)
+      (fun _ hq => by
+        dsimp [frame] at hq
+        refine divStackDispatchPost_weaken_bzero_frame (sp := sp) (a := a) (b := b)
+          (v1 := v1) (v2 := v2) (v6 := v6) (v7 := v7) (v11 := v11)
+          (q0 := q0) (q1 := q1) (q2 := q2) (q3 := q3)
+          (u0 := u0) (u1 := u1) (u2 := u2) (u3 := u3)
+          (u4 := u4) (u5 := u5) (u6 := u6) (u7 := u7)
+          (shiftMem := shiftMem) (nMem := nMem) (jMem := jMem)
+          (retMem := retMem) (dMem := dMem) (dloMem := dloMem)
+          (scratch_un0 := scratch_un0) _ ?_
+        simp only [sepConj_assoc', sepConj_comm', sepConj_left_comm'] at hq ⊢
+        exact hq)
+      hFramed
+
+/-- Framed zero-divisor DIV dispatcher post over `divCode_noNop`, before the
+    usual weakening to `divStackDispatchPost`. This keeps the incoming `x1`
+    value concrete for callable wrappers that need the following `ret` address
+    to remain visible. -/
+@[irreducible]
+def divBzeroDispatchPostPreservingX1Frame (sp : Word) (a b : EvmWord)
+    (v1 v2 v6 v7 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratch_un0 : Word) : Assertion :=
+  ((.x12 ↦ᵣ (sp + 32)) ** regOwn .x5 ** regOwn .x10 **
+    (.x0 ↦ᵣ (0 : Word)) ** evmWordIs (sp + 32) (EvmWord.div a b)) **
+  ((.x9 ↦ᵣ v1) ** (.x2 ↦ᵣ v2) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+    (.x11 ↦ᵣ v11) ** evmWordIs sp a **
+    divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratch_un0)
+
+theorem divBzeroDispatchPostPreservingX1Frame_unfold
+    {sp : Word} {a b : EvmWord} {v1 v2 v6 v7 v11 : Word}
+    {q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratch_un0 : Word} :
+    divBzeroDispatchPostPreservingX1Frame sp a b v1 v2 v6 v7 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0 =
+      (((.x12 ↦ᵣ (sp + 32)) ** regOwn .x5 ** regOwn .x10 **
+        (.x0 ↦ᵣ (0 : Word)) ** evmWordIs (sp + 32) (EvmWord.div a b)) **
+       ((.x9 ↦ᵣ v1) ** (.x2 ↦ᵣ v2) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+        (.x11 ↦ᵣ v11) ** evmWordIs sp a **
+        divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratch_un0)) := by
+  delta divBzeroDispatchPostPreservingX1Frame
+  rfl
+
+theorem divStackDispatchPostNoX1_weaken_bzero_frame
+    (sp : Word) (a b : EvmWord)
+    {v1 v2 v6 v7 v11 : Word}
+    {q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratch_un0 : Word} :
+    ∀ h,
+      (((.x12 ↦ᵣ (sp + 32)) **
+        (.x2 ↦ᵣ v2) ** regOwn .x5 ** (.x6 ↦ᵣ v6) **
+        (.x7 ↦ᵣ v7) ** regOwn .x10 ** (.x11 ↦ᵣ v11) **
+        (.x0 ↦ᵣ (0 : Word)) **
+        evmWordIs sp a ** evmWordIs (sp + 32) (EvmWord.div a b) **
+        divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratch_un0) **
+       (.x9 ↦ᵣ v1)) h →
+      (divStackDispatchPostNoX1 sp a b ** (.x9 ↦ᵣ v1)) h := by
+  intro h hp
+  rw [divStackDispatchPostNoX1_unfold]
+  apply sepConj_mono_left _ h hp
+  intro hLeft hpLeft
+  apply sepConj_mono_right
+  apply sepConj_mono (regIs_implies_regOwn .x2 (v := v2))
+  apply sepConj_mono_right
+  apply sepConj_mono (regIs_implies_regOwn .x6 (v := v6))
+  apply sepConj_mono (regIs_implies_regOwn .x7 (v := v7))
+  apply sepConj_mono_right
+  apply sepConj_mono (regIs_implies_regOwn .x11 (v := v11))
+  apply sepConj_mono_right
+  apply sepConj_mono_right
+  apply sepConj_mono_right
+  exact divScratchValuesCall_implies_divScratchOwnCall
+    sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem
+      retMem dMem dloMem scratch_un0
+  exact hpLeft
+
+theorem divBzeroDispatchPostPreservingX1Frame_weaken_noX1
+    (sp : Word) (a b : EvmWord)
+    {v1 v2 v6 v7 v11 : Word}
+    {q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratch_un0 : Word} :
+    ∀ h,
+      divBzeroDispatchPostPreservingX1Frame sp a b v1 v2 v6 v7 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0 h →
+      (divStackDispatchPostNoX1 sp a b ** (.x9 ↦ᵣ v1)) h := by
+  intro h hp
+  rw [divBzeroDispatchPostPreservingX1Frame_unfold] at hp
+  simp only [sepConj_assoc', sepConj_comm', sepConj_left_comm'] at hp ⊢
+  exact divStackDispatchPostNoX1_weaken_bzero_frame
+    (sp := sp) (a := a) (b := b) h (by xperm_hyp hp)
+
+/-- Zero-divisor DIV dispatcher over `divCode_noNop`, preserving the exact
+    incoming `x1` value in a named framed postcondition. -/
+theorem evm_div_bzero_stack_spec_within_dispatch_noNop_preserving_x1_frame_uni
+    (sp base : Word)
+    (a b : EvmWord) (v1 v2 v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratch_un0 : Word)
+    (hbz : b = 0) :
+    cpsTripleWithin unifiedDivBound base (base + nopOff) (divCode_noNop base)
+      (divModStackDispatchPre sp a b
+        v1 v2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0)
+      (divBzeroDispatchPostPreservingX1Frame sp a b v1 v2 v6 v7 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0) := by
+  let frame : Assertion :=
+    (.x9 ↦ᵣ v1) ** (.x2 ↦ᵣ v2) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+    (.x11 ↦ᵣ v11) ** evmWordIs sp a **
+    divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratch_un0
+  have hBzero :=
+    evm_div_bzero_stack_spec_within_noNop sp base a b v5 v10 hbz
+  have hFramed :
+      cpsTripleWithin (8 + 5) base (base + nopOff) (divCode_noNop base)
+        (((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) **
+          (.x0 ↦ᵣ (0 : Word)) ** evmWordIs (sp + 32) b) ** frame)
+        ((((.x12 ↦ᵣ (sp + 32)) ** regOwn .x5 ** regOwn .x10 **
+          (.x0 ↦ᵣ (0 : Word)) ** evmWordIs (sp + 32) (EvmWord.div a b)) ** frame)) :=
+    cpsTripleWithin_frameR frame (by
+      dsimp [frame]
+      rw [divScratchValuesCall_unfold]
+      pcFree) hBzero
+  exact cpsTripleWithin_mono_nSteps (by decide) <|
+    cpsTripleWithin_weaken
+      (fun _ hp => by
+        rw [divModStackDispatchPre_unfold] at hp
+        dsimp [frame]
+        simp only [sepConj_comm', sepConj_left_comm'] at hp ⊢
+        exact hp)
+      (fun h hq => by
+        dsimp [frame] at hq
+        rw [divBzeroDispatchPostPreservingX1Frame_unfold]
+        simp only [sepConj_assoc', sepConj_comm', sepConj_left_comm'] at hq ⊢
+        exact hq)
+      hFramed
+
+/-- Zero-divisor DIV dispatcher over `divCode_noNop`, preserving the exact
+    incoming `x1` value in the callable-ready post shape. -/
+theorem evm_div_bzero_stack_spec_within_dispatch_noNop_preserving_x1_uni
+    (sp base : Word)
+    (a b : EvmWord) (v1 v2 v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratch_un0 : Word)
+    (hbz : b = 0) :
+    cpsTripleWithin unifiedDivBound base (base + nopOff) (divCode_noNop base)
+      (divModStackDispatchPre sp a b
+        v1 v2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0)
+      (divStackDispatchPostNoX1 sp a b ** (.x9 ↦ᵣ v1)) := by
+  exact cpsTripleWithin_weaken (fun _ hp => hp) (fun h hp =>
+    divBzeroDispatchPostPreservingX1Frame_weaken_noX1
+      (sp := sp) (a := a) (b := b) h hp)
+    (evm_div_bzero_stack_spec_within_dispatch_noNop_preserving_x1_frame_uni
+      sp base a b v1 v2 v5 v6 v7 v10 v11
+      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      nMem shiftMem jMem retMem dMem dloMem scratch_un0 hbz)
+
+/-- Zero-divisor DIV dispatcher over `divCode_noNop` in the callable-only
+    surface: exact `x1` is preserved for `cc_ret`, and exact `x9` is framed
+    separately from the DIV loop-counter ownership surface. -/
+theorem evm_div_bzero_stack_spec_within_dispatch_noNop_callable_uni
+    (sp base : Word)
+    (a b : EvmWord) (x9Val raVal v2 v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratch_un0 : Word)
+    (hbz : b = 0) :
+    cpsTripleWithin unifiedDivBound base (base + nopOff) (divCode_noNop base)
+      (divModStackDispatchPreNoX1 sp a b
+        x9Val raVal v2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0)
+      ((divStackDispatchPostCallable sp a b ** (.x1 ↦ᵣ raVal)) **
+        (.x9 ↦ᵣ x9Val)) := by
+  let frame : Assertion :=
+    (.x9 ↦ᵣ x9Val) ** (.x1 ↦ᵣ raVal) ** (.x2 ↦ᵣ v2) **
+    (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x11 ↦ᵣ v11) **
+    evmWordIs sp a **
+    divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratch_un0
+  have hBzero :=
+    evm_div_bzero_stack_spec_within_noNop sp base a b v5 v10 hbz
+  have hFramed :
+      cpsTripleWithin (8 + 5) base (base + nopOff) (divCode_noNop base)
+        (((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) **
+          (.x0 ↦ᵣ (0 : Word)) ** evmWordIs (sp + 32) b) ** frame)
+        ((((.x12 ↦ᵣ (sp + 32)) ** regOwn .x5 ** regOwn .x10 **
+          (.x0 ↦ᵣ (0 : Word)) ** evmWordIs (sp + 32) (EvmWord.div a b)) ** frame)) :=
+    cpsTripleWithin_frameR frame (by
+      dsimp [frame]
+      rw [divScratchValuesCallNoX1_unfold]
+      pcFree) hBzero
+  exact cpsTripleWithin_mono_nSteps (by decide) <|
+    cpsTripleWithin_weaken
+      (fun _ hp => by
+        rw [divModStackDispatchPreNoX1_unfold] at hp
+        dsimp [frame]
+        simp only [sepConj_comm', sepConj_left_comm'] at hp ⊢
+        exact hp)
+      (fun h hq => by
+        dsimp [frame] at hq
+        rw [divStackDispatchPostCallable_unfold]
+        simp only [sepConj_assoc', sepConj_comm', sepConj_left_comm'] at hq ⊢
+        have hqOwn :
+            (divScratchOwnCallNoX1 sp ** evmWordIs sp a ** (.x0 ↦ᵣ (0 : Word)) **
+              (.x1 ↦ᵣ raVal) ** regOwn .x11 ** (.x12 ↦ᵣ (sp + 32)) **
+              regOwn .x2 ** regOwn .x6 ** regOwn .x7 ** (.x9 ↦ᵣ x9Val) **
+              regOwn .x10 ** regOwn .x5 ** evmWordIs (sp + 32) (EvmWord.div a b)) h := by
+          refine sepConj_mono ?_ ?_ h hq
+          · intro hLeft hpLeft
+            exact divScratchValuesCallNoX1_implies_divScratchOwnCallNoX1
+              sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem
+                retMem dMem dloMem scratch_un0 hLeft hpLeft
+          · apply sepConj_mono_right
+            apply sepConj_mono_right
+            apply sepConj_mono_right
+            apply sepConj_mono (regIs_implies_regOwn .x11 (v := v11))
+            apply sepConj_mono_right
+            apply sepConj_mono (regIs_implies_regOwn .x2 (v := v2))
+            apply sepConj_mono (regIs_implies_regOwn .x6 (v := v6))
+            apply sepConj_mono (regIs_implies_regOwn .x7 (v := v7))
+            exact fun _ hp => hp
+        exact by xperm_hyp hqOwn)
+      hFramed
+
+theorem modStackDispatchPost_weaken_bzero_frame
+    (sp : Word) (a b : EvmWord)
+    {v1 v2 v6 v7 v11 : Word}
+    {q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratch_un0 : Word} :
+    ∀ h,
+      ((.x12 ↦ᵣ (sp + 32)) **
+       (.x9 ↦ᵣ v1) ** (.x2 ↦ᵣ v2) **
+       regOwn .x5 ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+       regOwn .x10 ** (.x11 ↦ᵣ v11) **
+       (.x0 ↦ᵣ (0 : Word)) **
+       evmWordIs sp a ** evmWordIs (sp + 32) (EvmWord.mod a b) **
+       divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratch_un0) h →
+      modStackDispatchPost sp a b h := by
+  intro h hp
+  delta modStackDispatchPost
+  apply sepConj_mono_right
+  apply sepConj_mono (regIs_implies_regOwn .x9 (v := v1))
+  apply sepConj_mono (regIs_implies_regOwn .x2 (v := v2))
+  apply sepConj_mono_right
+  apply sepConj_mono (regIs_implies_regOwn .x6 (v := v6))
+  apply sepConj_mono (regIs_implies_regOwn .x7 (v := v7))
+  apply sepConj_mono_right
+  apply sepConj_mono (regIs_implies_regOwn .x11 (v := v11))
+  apply sepConj_mono_right
+  apply sepConj_mono_right
+  apply sepConj_mono_right
+  exact divScratchValuesCall_implies_divScratchOwnCall
+    sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem
+      retMem dMem dloMem scratch_un0
+  exact hp
+
+theorem evm_mod_bzero_stack_spec_within_dispatch_uni (sp base : Word)
+    (a b : EvmWord) (v1 v2 v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratch_un0 : Word)
+    (hbz : b = 0) :
+    cpsTripleWithin unifiedDivBound base (base + nopOff) (modCode base)
+      (divModStackDispatchPre sp a b
+        v1 v2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0)
+      (modStackDispatchPost sp a b) := by
+  let frame : Assertion :=
+    (.x9 ↦ᵣ v1) ** (.x2 ↦ᵣ v2) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+    (.x11 ↦ᵣ v11) ** evmWordIs sp a **
+    divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratch_un0
+  have hBzero :=
+    evm_mod_bzero_stack_spec_within sp base a b v5 v10 hbz
+  have hFramed :
+      cpsTripleWithin 13 base (base + nopOff) (modCode base)
+        (((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) **
+          (.x0 ↦ᵣ (0 : Word)) ** evmWordIs (sp + 32) b) ** frame)
+        ((((.x12 ↦ᵣ (sp + 32)) ** regOwn .x5 ** regOwn .x10 **
+          (.x0 ↦ᵣ (0 : Word)) ** evmWordIs (sp + 32) (EvmWord.mod a b)) ** frame)) :=
+    cpsTripleWithin_frameR frame (by
+      dsimp [frame]
+      rw [divScratchValuesCall_unfold]
+      pcFree) hBzero
+  exact cpsTripleWithin_mono_nSteps (by decide) <|
+    cpsTripleWithin_weaken
+      (fun _ hp => by
+        rw [divModStackDispatchPre_unfold] at hp
+        dsimp [frame]
+        simp only [sepConj_comm', sepConj_left_comm'] at hp ⊢
+        exact hp)
+      (fun _ hq => by
+        dsimp [frame] at hq
+        refine modStackDispatchPost_weaken_bzero_frame (sp := sp) (a := a) (b := b)
+          (v1 := v1) (v2 := v2) (v6 := v6) (v7 := v7) (v11 := v11)
+          (q0 := q0) (q1 := q1) (q2 := q2) (q3 := q3)
+          (u0 := u0) (u1 := u1) (u2 := u2) (u3 := u3)
+          (u4 := u4) (u5 := u5) (u6 := u6) (u7 := u7)
+          (shiftMem := shiftMem) (nMem := nMem) (jMem := jMem)
+          (retMem := retMem) (dMem := dMem) (dloMem := dloMem)
+          (scratch_un0 := scratch_un0) _ ?_
+        simp only [sepConj_assoc', sepConj_comm', sepConj_left_comm'] at hq ⊢
+        exact hq)
+      hFramed
+
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/SpecCallShift0.lean
+++ b/EvmAsm/Evm64/DivMod/SpecCallShift0.lean
@@ -220,7 +220,7 @@ theorem evm_div_n4_shift0_call_skip_stack_spec_exact_x1 (sp base : Word)
          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
          shiftMem nMem jMem retMem dMem dloMem scratch_un0)
       (divN4CallSkipStackPostNoX1 sp a b **
-        (.x1 ↦ᵣ signExtend12 (4095 : BitVec 12))) := by
+        (.x9 ↦ᵣ signExtend12 (4095 : BitVec 12))) := by
   have h_pre := evm_div_n4_full_shift0_call_skip_stack_pre_spec_bundled sp base a b
     v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
     nMem shiftMem jMem retMem dMem dloMem scratch_un0
@@ -648,7 +648,7 @@ theorem evm_div_n4_shift0_call_addback_beq_stack_spec_exact_x1 (sp base : Word)
          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
          shiftMem nMem jMem retMem dMem dloMem scratch_un0)
       (divN4CallSkipStackPostNoX1 sp a b **
-        (.x1 ↦ᵣ signExtend12 (4095 : BitVec 12))) := by
+        (.x9 ↦ᵣ signExtend12 (4095 : BitVec 12))) := by
   have h_pre := evm_div_n4_full_shift0_call_addback_beq_stack_pre_spec_bundled
     sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
     nMem shiftMem jMem retMem dMem dloMem scratch_un0

--- a/EvmAsm/Evm64/SDiv/Compose/Bridges.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/Bridges.lean
@@ -33,14 +33,14 @@ theorem divModStackDispatchPre_unfold_explicit
     EvmAsm.Evm64.divModStackDispatchPre sp a b v1 v2 v5 v6 v7 v10 v11
       q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem
       retMem dMem dloMem scratch_un0 =
-    ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ v1) ** (.x2 ↦ᵣ v2) **
+    ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ v1) ** (.x2 ↦ᵣ v2) **
      (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
      (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) ** (.x0 ↦ᵣ (0 : Word)) **
      ((sp ↦ₘ a.getLimbN 0) ** ((sp + 8) ↦ₘ a.getLimbN 1) **
       ((sp + 16) ↦ₘ a.getLimbN 2) ** ((sp + 24) ↦ₘ a.getLimbN 3)) **
      (((sp + 32) ↦ₘ b.getLimbN 0) ** ((sp + 40) ↦ₘ b.getLimbN 1) **
       ((sp + 48) ↦ₘ b.getLimbN 2) ** ((sp + 56) ↦ₘ b.getLimbN 3)) **
-     EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+       EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
        shiftMem nMem jMem retMem dMem dloMem scratch_un0) := by
   rw [EvmAsm.Evm64.divModStackDispatchPre_unfold,
       evmWordIs_sp_unfold, evmWordIs_sp32_unfold]
@@ -57,7 +57,7 @@ theorem divModStackDispatchPre_unfold_explicit_sdiv
     EvmAsm.Evm64.divModStackDispatchPre sp a b v1 v2 v5 v6 v7 v10 v11
       q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem
       retMem dMem dloMem scratch_un0 =
-    ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ v1) ** (.x2 ↦ᵣ v2) **
+    ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ v1) ** (.x2 ↦ᵣ v2) **
      (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
      (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) ** (.x0 ↦ᵣ (0 : Word)) **
      (((sp + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)) ↦ₘ a.getLimbN 0) **
@@ -73,6 +73,77 @@ theorem divModStackDispatchPre_unfold_explicit_sdiv
     EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
        shiftMem nMem jMem retMem dMem dloMem scratch_un0) := by
   rw [divModStackDispatchPre_unfold_explicit]
+  rw [EvmAsm.Evm64.SDiv.AddrNorm.stackSlot0 sp,
+    EvmAsm.Evm64.SDiv.AddrNorm.stackSlot8 sp,
+    EvmAsm.Evm64.SDiv.AddrNorm.stackSlot16 sp,
+    EvmAsm.Evm64.SDiv.AddrNorm.dividendTopSlot sp,
+    EvmAsm.Evm64.SDiv.AddrNorm.stackSlot32 sp,
+    EvmAsm.Evm64.SDiv.AddrNorm.stackSlot40 sp,
+    EvmAsm.Evm64.SDiv.AddrNorm.stackSlot48 sp,
+    EvmAsm.Evm64.SDiv.AddrNorm.divisorTopSlot sp]
+
+/-- SDIV-offset-shaped expansion for the callable-only dispatch precondition
+    that keeps exact `x1` separate and leaves `x9` to the SDIV sign frame. -/
+theorem divModStackDispatchPreCallable_unfold_explicit_sdiv
+    {sp : Word} {a b : EvmWord}
+    {v1 v2 v5 v6 v7 v10 v11 : Word}
+    {q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem
+     retMem dMem dloMem scratch_un0 : Word} :
+    EvmAsm.Evm64.divModStackDispatchPreCallable sp a b v1 v2 v5 v6 v7 v10 v11
+      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem
+      retMem dMem dloMem scratch_un0 =
+    ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ v1) ** (.x2 ↦ᵣ v2) **
+     (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+     (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) ** (.x0 ↦ᵣ (0 : Word)) **
+     (((sp + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)) ↦ₘ a.getLimbN 0) **
+      ((sp + EvmAsm.Rv64.signExtend12 (8 : BitVec 12)) ↦ₘ a.getLimbN 1) **
+      ((sp + EvmAsm.Rv64.signExtend12 (16 : BitVec 12)) ↦ₘ a.getLimbN 2) **
+      ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ
+        a.getLimbN 3)) **
+     (((sp + EvmAsm.Rv64.signExtend12 (32 : BitVec 12)) ↦ₘ b.getLimbN 0) **
+      ((sp + EvmAsm.Rv64.signExtend12 (40 : BitVec 12)) ↦ₘ b.getLimbN 1) **
+      ((sp + EvmAsm.Rv64.signExtend12 (48 : BitVec 12)) ↦ₘ b.getLimbN 2) **
+      ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff) ↦ₘ
+        b.getLimbN 3)) **
+    EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+       shiftMem nMem jMem retMem dMem dloMem scratch_un0) := by
+  rw [EvmAsm.Evm64.divModStackDispatchPreCallable_unfold,
+    evmWordIs_sp_unfold, evmWordIs_sp32_unfold]
+  rw [EvmAsm.Evm64.SDiv.AddrNorm.stackSlot0 sp,
+    EvmAsm.Evm64.SDiv.AddrNorm.stackSlot8 sp,
+    EvmAsm.Evm64.SDiv.AddrNorm.stackSlot16 sp,
+    EvmAsm.Evm64.SDiv.AddrNorm.dividendTopSlot sp,
+    EvmAsm.Evm64.SDiv.AddrNorm.stackSlot32 sp,
+    EvmAsm.Evm64.SDiv.AddrNorm.stackSlot40 sp,
+    EvmAsm.Evm64.SDiv.AddrNorm.stackSlot48 sp,
+    EvmAsm.Evm64.SDiv.AddrNorm.divisorTopSlot sp]
+
+/-- SDIV-offset-shaped expansion for `divModStackDispatchPreNoX1`. -/
+theorem divModStackDispatchPreNoX1_unfold_explicit_sdiv
+    {sp : Word} {a b : EvmWord}
+    {x9Val v1 v2 v5 v6 v7 v10 v11 : Word}
+    {q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem
+     retMem dMem dloMem scratch_un0 : Word} :
+    EvmAsm.Evm64.divModStackDispatchPreNoX1 sp a b x9Val v1 v2 v5 v6 v7 v10 v11
+      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem
+      retMem dMem dloMem scratch_un0 =
+    ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ x9Val) ** (.x1 ↦ᵣ v1) ** (.x2 ↦ᵣ v2) **
+     (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+     (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) ** (.x0 ↦ᵣ (0 : Word)) **
+     (((sp + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)) ↦ₘ a.getLimbN 0) **
+      ((sp + EvmAsm.Rv64.signExtend12 (8 : BitVec 12)) ↦ₘ a.getLimbN 1) **
+      ((sp + EvmAsm.Rv64.signExtend12 (16 : BitVec 12)) ↦ₘ a.getLimbN 2) **
+      ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ
+        a.getLimbN 3)) **
+     (((sp + EvmAsm.Rv64.signExtend12 (32 : BitVec 12)) ↦ₘ b.getLimbN 0) **
+      ((sp + EvmAsm.Rv64.signExtend12 (40 : BitVec 12)) ↦ₘ b.getLimbN 1) **
+      ((sp + EvmAsm.Rv64.signExtend12 (48 : BitVec 12)) ↦ₘ b.getLimbN 2) **
+      ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff) ↦ₘ
+        b.getLimbN 3)) **
+    EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+       shiftMem nMem jMem retMem dMem dloMem scratch_un0) := by
+  rw [EvmAsm.Evm64.divModStackDispatchPreNoX1_unfold,
+    evmWordIs_sp_unfold, evmWordIs_sp32_unfold]
   rw [EvmAsm.Evm64.SDiv.AddrNorm.stackSlot0 sp,
     EvmAsm.Evm64.SDiv.AddrNorm.stackSlot8 sp,
     EvmAsm.Evm64.SDiv.AddrNorm.stackSlot16 sp,

--- a/EvmAsm/Evm64/SDiv/Compose/BzeroCallable.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroCallable.lean
@@ -9,6 +9,7 @@ import EvmAsm.Evm64.SDiv.Compose.DispatchPrefix
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
+open EvmAsm.Rv64
 open EvmAsm.Rv64.Tactics
 /-- SDIV wrapper prefix followed by the zero-divisor branch of the unsigned DIV
     callable, stopping at the result-sign-fixup entry. The hypothesis `hbz`
@@ -31,11 +32,11 @@ theorem saveRa_signs_abs_signXor_then_divCall_bzero_callable_spec_in_sdivCode
         dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
         divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
        ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
-        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0))
-      ((EvmAsm.Evm64.divStackDispatchPostNoX1 sp
-          (sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
-          (sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) **
+        ((EvmAsm.Evm64.divStackDispatchPostCallable sp
+            (sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+            (sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) **
         (.x1 ↦ᵣ ((base + divCallOff) + 4))) **
        ((.x8 ↦ᵣ ((dividendTop >>> (63 : BitVec 6).toNat) ^^^
           (divisorTop >>> (63 : BitVec 6).toNat))) **
@@ -60,9 +61,12 @@ theorem saveRa_signs_abs_signXor_then_divCall_bzero_callable_spec_in_sdivCode
   let signFrame : EvmAsm.Rv64.Assertion :=
     ((.x8 ↦ᵣ resultSign) ** (.x9 ↦ᵣ divisorSign) **
       (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12))))
+  let signFrameNoX9 : EvmAsm.Rv64.Assertion :=
+    ((.x8 ↦ᵣ resultSign) **
+      (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12))))
   have hCallableRaw :=
     EvmAsm.Evm64.evm_div_callable_bzero_preserving_x1_spec
-      sp (base + wrapperEndOff) ((base + divCallOff) + 4)
+      sp (base + wrapperEndOff) divisorSign ((base + divCallOff) + 4)
       dividendAbsWord divisorAbsWord v2 v5 v6 divisorSum3 divisorMask divisorCarry3
       q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
       nMem shiftMem jMem retMem dMem dloMem scratchUn0
@@ -71,20 +75,28 @@ theorem saveRa_signs_abs_signXor_then_divCall_bzero_callable_spec_in_sdivCode
     EvmAsm.Rv64.cpsTripleWithin_extend_code
       (hmono := evm_div_callable_code_sub_sdivCode (base := base)) hCallableRaw
   have hCallableFramed :=
-    EvmAsm.Rv64.cpsTripleWithin_frameR signFrame (by
-      dsimp [signFrame]
+    EvmAsm.Rv64.cpsTripleWithin_frameR signFrameNoX9 (by
+      dsimp [signFrameNoX9]
       pcFree) hCallableCode
   have hCallableFramedExit :
       EvmAsm.Rv64.cpsTripleWithin (EvmAsm.Evm64.unifiedDivBound + 1)
         (base + wrapperEndOff) (base + resultSignFixOff) (sdivCode base)
-        (EvmAsm.Evm64.divModStackDispatchPre sp dividendAbsWord divisorAbsWord
-          ((base + divCallOff) + 4) v2 v5 v6 divisorSum3 divisorMask divisorCarry3
-          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-          shiftMem nMem jMem retMem dMem dloMem scratchUn0 ** signFrame)
-        ((EvmAsm.Evm64.divStackDispatchPostNoX1 sp dividendAbsWord divisorAbsWord **
+        (saveRaDivCallDispatchReadyPost vRa sp base
+          dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+          divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+          v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+        ((EvmAsm.Evm64.divStackDispatchPostCallable sp dividendAbsWord divisorAbsWord **
           (.x1 ↦ᵣ ((base + divCallOff) + 4))) ** signFrame) := by
     rw [← divCall_return_andn_one_eq_resultSignFixOff base hbase]
-    exact hCallableFramed
+    exact EvmAsm.Rv64.cpsTripleWithin_weaken (fun _ hp => by
+      rw [saveRaDivCallDispatchReadyPost_unfold] at hp
+      dsimp [dividendAbsWord, divisorAbsWord, divisorSign, divisorMask, divisorSum0,
+        divisorCarry0, divisorSum1, divisorCarry1, divisorSum2, divisorCarry2,
+        divisorSum3, divisorCarry3, resultSign, signFrame, signFrameNoX9] at hp ⊢
+      exact hp) (fun _ hp => by
+      dsimp [signFrame, signFrameNoX9] at hp ⊢
+      xperm_hyp hp) hCallableFramed
   have hCallable :
       EvmAsm.Rv64.cpsTripleWithin (EvmAsm.Evm64.unifiedDivBound + 1)
         (base + wrapperEndOff) (base + resultSignFixOff) (sdivCode base)
@@ -93,17 +105,9 @@ theorem saveRa_signs_abs_signXor_then_divCall_bzero_callable_spec_in_sdivCode
           divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
           v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0)
-        ((EvmAsm.Evm64.divStackDispatchPostNoX1 sp dividendAbsWord divisorAbsWord **
-          (.x1 ↦ᵣ ((base + divCallOff) + 4))) ** signFrame) := by
-    exact EvmAsm.Rv64.cpsTripleWithin_weaken (fun h hp => by
-      rw [saveRaDivCallDispatchReadyPost_unfold] at hp
-      dsimp [dividendAbsWord, divisorAbsWord, divisorSign, divisorMask, divisorSum0,
-        divisorCarry0, divisorSum1, divisorCarry1, divisorSum2, divisorCarry2,
-        divisorSum3, divisorCarry3, resultSign, signFrame] at hp ⊢
-      rw [sdivDivCallSignFrame_unfold] at hp
-      exact hp) (fun h hp => by
-      dsimp [signFrame] at hp ⊢
-      exact hp) hCallableFramedExit
+          ((EvmAsm.Evm64.divStackDispatchPostCallable sp dividendAbsWord divisorAbsWord **
+            (.x1 ↦ᵣ ((base + divCallOff) + 4))) ** signFrame) := by
+    exact hCallableFramedExit
   have hSeq :=
     saveRa_signs_abs_signXor_then_divCall_then_exact_callable_spec_in_sdivCode
       vRa vSavedOld sp sDividendOld sDivisorOld

--- a/EvmAsm/Evm64/SDiv/Compose/BzeroCallableNamedPost.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroCallableNamedPost.lean
@@ -27,7 +27,7 @@ theorem saveRa_signs_abs_signXor_then_divCall_bzero_callable_named_post_spec_in_
         dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
         divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
        ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
-        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0))
       (saveRaDivCallBzeroCallablePost vRa sp base
         dividendLimb0 dividendLimb1 dividendLimb2 dividendTop

--- a/EvmAsm/Evm64/SDiv/Compose/BzeroCallablePCFree.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroCallablePCFree.lean
@@ -16,8 +16,8 @@ theorem saveRaDivCallBzeroCallablePost_pcFree
       divisorLimb0 divisorLimb1 divisorLimb2 divisorTop).pcFree := by
   rw [saveRaDivCallBzeroCallablePost_unfold]
   dsimp
-  rw [EvmAsm.Evm64.divStackDispatchPostNoX1_unfold,
-    EvmAsm.Evm64.divScratchOwnCall_unfold,
+  rw [EvmAsm.Evm64.divStackDispatchPostCallable_unfold,
+    EvmAsm.Evm64.divScratchOwnCallNoX1_unfold,
     EvmAsm.Evm64.divScratchOwn_unfold]
   pcFree
 

--- a/EvmAsm/Evm64/SDiv/Compose/BzeroCallablePost.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroCallablePost.lean
@@ -23,7 +23,7 @@ def saveRaDivCallBzeroCallablePost
     (dividendTop >>> (63 : BitVec 6).toNat) ^^^
       (divisorTop >>> (63 : BitVec 6).toNat)
   let divisorSign := divisorTop >>> (63 : BitVec 6).toNat
-  ((EvmAsm.Evm64.divStackDispatchPostNoX1 sp
+  ((EvmAsm.Evm64.divStackDispatchPostCallable sp
       (sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
       (sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) **
     (.x1 ↦ᵣ ((base + divCallOff) + 4))) **
@@ -37,17 +37,54 @@ theorem saveRaDivCallBzeroCallablePost_unfold
     saveRaDivCallBzeroCallablePost vRa sp base
         dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
         divisorLimb0 divisorLimb1 divisorLimb2 divisorTop =
-      (let resultSign :=
+       (let resultSign :=
          (dividendTop >>> (63 : BitVec 6).toNat) ^^^
            (divisorTop >>> (63 : BitVec 6).toNat)
        let divisorSign := divisorTop >>> (63 : BitVec 6).toNat
-       ((EvmAsm.Evm64.divStackDispatchPostNoX1 sp
+       ((EvmAsm.Evm64.divStackDispatchPostCallable sp
            (sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
            (sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) **
          (.x1 ↦ᵣ ((base + divCallOff) + 4))) **
         ((.x8 ↦ᵣ resultSign) ** (.x9 ↦ᵣ divisorSign) **
          (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))))) := by
   delta saveRaDivCallBzeroCallablePost
+  rfl
+
+/-- Callable postcondition for exact SDIV paths. Unlike the zero-divisor path,
+    this does not claim that `x9` still holds the divisor sign; unsigned DIV uses
+    `x9` as its loop counter on nonzero paths. -/
+@[irreducible]
+def saveRaDivCallCallablePostNoX9
+    (vRa sp base : Word)
+    (dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word) : EvmAsm.Rv64.Assertion :=
+  let resultSign :=
+    (dividendTop >>> (63 : BitVec 6).toNat) ^^^
+      (divisorTop >>> (63 : BitVec 6).toNat)
+  ((EvmAsm.Evm64.divStackDispatchPostCallable sp
+      (sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+      (sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) **
+    (.x1 ↦ᵣ ((base + divCallOff) + 4))) **
+   ((.x8 ↦ᵣ resultSign) **
+    (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))))
+
+theorem saveRaDivCallCallablePostNoX9_unfold
+    {vRa sp base : Word}
+    {dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word} :
+    saveRaDivCallCallablePostNoX9 vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop =
+      (let resultSign :=
+         (dividendTop >>> (63 : BitVec 6).toNat) ^^^
+           (divisorTop >>> (63 : BitVec 6).toNat)
+       ((EvmAsm.Evm64.divStackDispatchPostCallable sp
+           (sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+           (sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) **
+         (.x1 ↦ᵣ ((base + divCallOff) + 4))) **
+        ((.x8 ↦ᵣ resultSign) **
+         (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))))) := by
+  delta saveRaDivCallCallablePostNoX9
   rfl
 
 /-- Zero-divisor view of `saveRaDivCallBzeroCallablePost`: the unsigned DIV
@@ -70,12 +107,12 @@ theorem saveRaDivCallBzeroCallablePost_unfold_zero_quotient
          EvmAsm.Rv64.regOwn .x5 ** EvmAsm.Rv64.regOwn .x6 ** EvmAsm.Rv64.regOwn .x7 **
          EvmAsm.Rv64.regOwn .x10 ** EvmAsm.Rv64.regOwn .x11 ** (.x0 ↦ᵣ (0 : Word)) **
          evmWordIs sp dividendAbsWord ** evmWordIs (sp + 32) (0 : EvmWord) **
-         EvmAsm.Evm64.divScratchOwnCall sp) **
+           EvmAsm.Evm64.divScratchOwnCallNoX1 sp) **
         (.x1 ↦ᵣ ((base + divCallOff) + 4))) **
        ((.x8 ↦ᵣ resultSign) ** (.x9 ↦ᵣ divisorSign) **
         (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12))))) := by
   rw [saveRaDivCallBzeroCallablePost_unfold,
-    EvmAsm.Evm64.divStackDispatchPostNoX1_unfold]
+      EvmAsm.Evm64.divStackDispatchPostCallable_unfold]
   dsimp only
   rw [hbz, EvmWord.div_zero_right]
 

--- a/EvmAsm/Evm64/SDiv/Compose/BzeroFramePCFree.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroFramePCFree.lean
@@ -14,7 +14,7 @@ theorem saveRaDivCallBzeroResultSignFixFrame_pcFree
     (saveRaDivCallBzeroResultSignFixFrame
       vRa sp base divisorSign dividendAbsWord).pcFree := by
   rw [saveRaDivCallBzeroResultSignFixFrame_unfold,
-    EvmAsm.Evm64.divScratchOwnCall_unfold,
+    EvmAsm.Evm64.divScratchOwnCallNoX1_unfold,
     EvmAsm.Evm64.divScratchOwn_unfold]
   pcFree
 
@@ -30,7 +30,7 @@ theorem saveRaDivCallBzeroSavedRaRetFrame_pcFree
     (saveRaDivCallBzeroSavedRaRetFrame
       sp base divisorSign dividendAbsWord).pcFree := by
   rw [saveRaDivCallBzeroSavedRaRetFrame_unfold,
-    EvmAsm.Evm64.divScratchOwnCall_unfold,
+    EvmAsm.Evm64.divScratchOwnCallNoX1_unfold,
     EvmAsm.Evm64.divScratchOwn_unfold]
   pcFree
 

--- a/EvmAsm/Evm64/SDiv/Compose/BzeroFrames.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroFrames.lean
@@ -19,7 +19,7 @@ open EvmAsm.Rv64.Tactics
 def saveRaDivCallBzeroResultSignFixFrame
     (vRa sp base divisorSign : Word) (dividendAbsWord : EvmWord) : EvmAsm.Rv64.Assertion :=
   EvmAsm.Rv64.regOwn .x2 ** EvmAsm.Rv64.regOwn .x5 ** EvmAsm.Rv64.regOwn .x6 **
-  evmWordIs sp dividendAbsWord ** EvmAsm.Evm64.divScratchOwnCall sp **
+  evmWordIs sp dividendAbsWord ** EvmAsm.Evm64.divScratchOwnCallNoX1 sp **
   (.x1 ↦ᵣ ((base + divCallOff) + 4)) **
   (.x9 ↦ᵣ divisorSign) **
   (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))
@@ -28,7 +28,7 @@ theorem saveRaDivCallBzeroResultSignFixFrame_unfold
     {vRa sp base divisorSign : Word} {dividendAbsWord : EvmWord} :
     saveRaDivCallBzeroResultSignFixFrame vRa sp base divisorSign dividendAbsWord =
       (EvmAsm.Rv64.regOwn .x2 ** EvmAsm.Rv64.regOwn .x5 ** EvmAsm.Rv64.regOwn .x6 **
-       evmWordIs sp dividendAbsWord ** EvmAsm.Evm64.divScratchOwnCall sp **
+       evmWordIs sp dividendAbsWord ** EvmAsm.Evm64.divScratchOwnCallNoX1 sp **
        (.x1 ↦ᵣ ((base + divCallOff) + 4)) **
        (.x9 ↦ᵣ divisorSign) **
        (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))) := by
@@ -40,7 +40,7 @@ theorem saveRaDivCallBzeroResultSignFixFrame_unfold
 def saveRaDivCallBzeroSavedRaRetFrame
     (sp base divisorSign : Word) (dividendAbsWord : EvmWord) : EvmAsm.Rv64.Assertion :=
   EvmAsm.Rv64.regOwn .x2 ** EvmAsm.Rv64.regOwn .x5 ** EvmAsm.Rv64.regOwn .x6 **
-  evmWordIs sp dividendAbsWord ** EvmAsm.Evm64.divScratchOwnCall sp **
+  evmWordIs sp dividendAbsWord ** EvmAsm.Evm64.divScratchOwnCallNoX1 sp **
   (.x1 ↦ᵣ ((base + divCallOff) + 4)) **
   (.x9 ↦ᵣ divisorSign)
 
@@ -48,7 +48,7 @@ theorem saveRaDivCallBzeroSavedRaRetFrame_unfold
     {sp base divisorSign : Word} {dividendAbsWord : EvmWord} :
     saveRaDivCallBzeroSavedRaRetFrame sp base divisorSign dividendAbsWord =
       (EvmAsm.Rv64.regOwn .x2 ** EvmAsm.Rv64.regOwn .x5 ** EvmAsm.Rv64.regOwn .x6 **
-       evmWordIs sp dividendAbsWord ** EvmAsm.Evm64.divScratchOwnCall sp **
+       evmWordIs sp dividendAbsWord ** EvmAsm.Evm64.divScratchOwnCallNoX1 sp **
        (.x1 ↦ᵣ ((base + divCallOff) + 4)) **
        (.x9 ↦ᵣ divisorSign)) := by
   delta saveRaDivCallBzeroSavedRaRetFrame
@@ -63,6 +63,54 @@ theorem saveRaDivCallBzeroResultSignFixFrame_to_savedRaRet
        saveRaDivCallBzeroSavedRaRetFrame sp base divisorSign dividendAbsWord) := by
   rw [saveRaDivCallBzeroResultSignFixFrame_unfold,
     saveRaDivCallBzeroSavedRaRetFrame_unfold]
+  xperm
+
+/-- Exact-path result-sign-fix frame. It intentionally omits `x9`: nonzero
+    unsigned DIV uses `x9` as its loop counter, so SDIV cannot retain the
+    divisor sign there across the callable. -/
+@[irreducible]
+def saveRaDivCallResultSignFixFrameNoX9
+    (vRa sp base : Word) (dividendAbsWord : EvmWord) : EvmAsm.Rv64.Assertion :=
+  EvmAsm.Rv64.regOwn .x2 ** EvmAsm.Rv64.regOwn .x5 ** EvmAsm.Rv64.regOwn .x6 **
+  evmWordIs sp dividendAbsWord ** EvmAsm.Evm64.divScratchOwnCallNoX1 sp **
+  (.x1 ↦ᵣ ((base + divCallOff) + 4)) **
+  (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))
+
+theorem saveRaDivCallResultSignFixFrameNoX9_unfold
+    {vRa sp base : Word} {dividendAbsWord : EvmWord} :
+    saveRaDivCallResultSignFixFrameNoX9 vRa sp base dividendAbsWord =
+      (EvmAsm.Rv64.regOwn .x2 ** EvmAsm.Rv64.regOwn .x5 ** EvmAsm.Rv64.regOwn .x6 **
+       evmWordIs sp dividendAbsWord ** EvmAsm.Evm64.divScratchOwnCallNoX1 sp **
+       (.x1 ↦ᵣ ((base + divCallOff) + 4)) **
+       (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))) := by
+  delta saveRaDivCallResultSignFixFrameNoX9
+  rfl
+
+/-- Exact-path saved-RA return frame after exposing `x18`; intentionally omits
+    `x9` for the same reason as `saveRaDivCallResultSignFixFrameNoX9`. -/
+@[irreducible]
+def saveRaDivCallSavedRaRetFrameNoX9
+    (sp base : Word) (dividendAbsWord : EvmWord) : EvmAsm.Rv64.Assertion :=
+  EvmAsm.Rv64.regOwn .x2 ** EvmAsm.Rv64.regOwn .x5 ** EvmAsm.Rv64.regOwn .x6 **
+  evmWordIs sp dividendAbsWord ** EvmAsm.Evm64.divScratchOwnCallNoX1 sp **
+  (.x1 ↦ᵣ ((base + divCallOff) + 4))
+
+theorem saveRaDivCallSavedRaRetFrameNoX9_unfold
+    {sp base : Word} {dividendAbsWord : EvmWord} :
+    saveRaDivCallSavedRaRetFrameNoX9 sp base dividendAbsWord =
+      (EvmAsm.Rv64.regOwn .x2 ** EvmAsm.Rv64.regOwn .x5 ** EvmAsm.Rv64.regOwn .x6 **
+       evmWordIs sp dividendAbsWord ** EvmAsm.Evm64.divScratchOwnCallNoX1 sp **
+       (.x1 ↦ᵣ ((base + divCallOff) + 4))) := by
+  delta saveRaDivCallSavedRaRetFrameNoX9
+  rfl
+
+theorem saveRaDivCallResultSignFixFrameNoX9_to_savedRaRet
+    {vRa sp base : Word} {dividendAbsWord : EvmWord} :
+    saveRaDivCallResultSignFixFrameNoX9 vRa sp base dividendAbsWord =
+      ((.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12))) **
+       saveRaDivCallSavedRaRetFrameNoX9 sp base dividendAbsWord) := by
+  rw [saveRaDivCallResultSignFixFrameNoX9_unfold,
+    saveRaDivCallSavedRaRetFrameNoX9_unfold]
   xperm
 
 end EvmAsm.Evm64.SDiv.Compose

--- a/EvmAsm/Evm64/SDiv/Compose/BzeroPost.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroPost.lean
@@ -65,10 +65,40 @@ theorem saveRaDivCallBzeroCallablePost_resultSignFixPreOwnScratch_quotient
          (quotientWord.getLimbN 2) (quotientWord.getLimbN 3) **
        saveRaDivCallBzeroResultSignFixFrame vRa sp base divisorSign dividendAbsWord) := by
   rw [saveRaDivCallBzeroCallablePost_unfold,
-    EvmAsm.Evm64.divStackDispatchPostNoX1_unfold]
+    EvmAsm.Evm64.divStackDispatchPostCallable_unfold]
   dsimp only
   rw [resultSignFixPreOwnScratch_unfold,
     saveRaDivCallBzeroResultSignFixFrame_unfold, evmWordIs_sp32_unfold]
+  rw [show (sp + 32 + EvmAsm.Rv64.signExtend12 (0 : BitVec 12) : Word) = sp + 32 by bv_addr]
+  rw [show (sp + 32 + EvmAsm.Rv64.signExtend12 (8 : BitVec 12) : Word) = sp + 40 by bv_addr]
+  rw [show (sp + 32 + EvmAsm.Rv64.signExtend12 (16 : BitVec 12) : Word) = sp + 48 by bv_addr]
+  rw [show (sp + 32 + EvmAsm.Rv64.signExtend12 (24 : BitVec 12) : Word) = sp + 56 by bv_addr]
+  xperm
+
+theorem saveRaDivCallCallablePostNoX9_resultSignFixPreOwnScratch_quotient
+    {vRa sp base : Word}
+    {dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word} :
+    saveRaDivCallCallablePostNoX9 vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop =
+      (let dividendAbsWord :=
+         sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+       let divisorAbsWord :=
+         sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+       let quotientWord := EvmWord.div dividendAbsWord divisorAbsWord
+       let resultSign :=
+         (dividendTop >>> (63 : BitVec 6).toNat) ^^^
+           (divisorTop >>> (63 : BitVec 6).toNat)
+       resultSignFixPreOwnScratch (sp + 32) resultSign
+         (quotientWord.getLimbN 0) (quotientWord.getLimbN 1)
+         (quotientWord.getLimbN 2) (quotientWord.getLimbN 3) **
+       saveRaDivCallResultSignFixFrameNoX9 vRa sp base dividendAbsWord) := by
+  rw [saveRaDivCallCallablePostNoX9_unfold,
+    EvmAsm.Evm64.divStackDispatchPostCallable_unfold]
+  dsimp only
+  rw [resultSignFixPreOwnScratch_unfold,
+    saveRaDivCallResultSignFixFrameNoX9_unfold, evmWordIs_sp32_unfold]
   rw [show (sp + 32 + EvmAsm.Rv64.signExtend12 (0 : BitVec 12) : Word) = sp + 32 by bv_addr]
   rw [show (sp + 32 + EvmAsm.Rv64.signExtend12 (8 : BitVec 12) : Word) = sp + 40 by bv_addr]
   rw [show (sp + 32 + EvmAsm.Rv64.signExtend12 (16 : BitVec 12) : Word) = sp + 48 by bv_addr]

--- a/EvmAsm/Evm64/SDiv/Compose/BzeroResultSignFix.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroResultSignFix.lean
@@ -31,7 +31,7 @@ theorem saveRa_signs_abs_signXor_then_divCall_bzero_then_resultSignFix_spec_in_s
         dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
         divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
        ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
-        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0))
       (let dividendAbsWord :=
          sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
@@ -59,7 +59,7 @@ theorem saveRa_signs_abs_signXor_then_divCall_bzero_then_resultSignFix_spec_in_s
       (saveRaDivCallBzeroResultSignFixFrame
         vRa sp base divisorSign dividendAbsWord).pcFree := by
     rw [saveRaDivCallBzeroResultSignFixFrame_unfold,
-      EvmAsm.Evm64.divScratchOwnCall_unfold,
+      EvmAsm.Evm64.divScratchOwnCallNoX1_unfold,
       EvmAsm.Evm64.divScratchOwn_unfold]
     pcFree
   have hFix :=
@@ -70,7 +70,9 @@ theorem saveRa_signs_abs_signXor_then_divCall_bzero_then_resultSignFix_spec_in_s
       (resultSignFix_regOwn_scratch_spec_in_sdivCode
         (sp + 32) resultSign 0 0 0 0 base)
   exact EvmAsm.Rv64.cpsTripleWithin_seq_perm_same_cr
-    (fun _ hp => by
+    (fun h (hp : (saveRaDivCallBzeroCallablePost vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) h) => by
       rw [saveRaDivCallBzeroCallablePost_resultSignFixPreOwnScratch hbz] at hp
       exact hp)
     hPrefix hFix

--- a/EvmAsm/Evm64/SDiv/Compose/BzeroReturn.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroReturn.lean
@@ -28,7 +28,7 @@ theorem saveRa_signs_abs_signXor_then_divCall_bzero_then_return_spec_in_sdivCode
         dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
         divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
        ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
-        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0))
       (let dividendAbsWord :=
          sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
@@ -57,7 +57,7 @@ theorem saveRa_signs_abs_signXor_then_divCall_bzero_then_return_spec_in_sdivCode
       (resultSignFixPost (sp + 32) resultSign 0 0 0 0 **
         saveRaDivCallBzeroSavedRaRetFrame sp base divisorSign dividendAbsWord).pcFree := by
     rw [resultSignFixPost_unfold, saveRaDivCallBzeroSavedRaRetFrame_unfold,
-      EvmAsm.Evm64.divScratchOwnCall_unfold,
+      EvmAsm.Evm64.divScratchOwnCallNoX1_unfold,
       EvmAsm.Evm64.divScratchOwn_unfold]
     pcFree
   have hRetFramed :=

--- a/EvmAsm/Evm64/SDiv/Compose/BzeroReturnNormalizedView.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroReturnNormalizedView.lean
@@ -30,7 +30,7 @@ theorem saveRa_signs_abs_signXor_then_divCall_bzero_then_return_normalized_spec_
         dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
         divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
        ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
-        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0))
       (let dividendAbsWord :=
          sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop

--- a/EvmAsm/Evm64/SDiv/Compose/BzeroReturnStackZeroView.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroReturnStackZeroView.lean
@@ -30,7 +30,7 @@ theorem saveRa_signs_abs_signXor_then_divCall_bzero_then_return_stack_zero_spec_
           dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
           divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
         ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
-         EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
            shiftMem nMem jMem retMem dMem dloMem scratchUn0)) **
        evmStackIs (sp + 64) rest)
       (let dividendAbsWord :=

--- a/EvmAsm/Evm64/SDiv/Compose/BzeroReturnZeroWordRestView.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroReturnZeroWordRestView.lean
@@ -28,7 +28,7 @@ theorem saveRa_signs_abs_signXor_then_divCall_bzero_then_return_zero_word_rest_s
           dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
           divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
         ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
-         EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
            shiftMem nMem jMem retMem dMem dloMem scratchUn0)) **
        evmStackIs (sp + 64) rest)
       ((let dividendAbsWord :=

--- a/EvmAsm/Evm64/SDiv/Compose/BzeroReturnZeroWordView.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroReturnZeroWordView.lean
@@ -27,7 +27,7 @@ theorem saveRa_signs_abs_signXor_then_divCall_bzero_then_return_zero_word_spec_i
         dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
         divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
        ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
-        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0))
       (let dividendAbsWord :=
          sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop

--- a/EvmAsm/Evm64/SDiv/Compose/BzeroSemanticConcreteRunStackView.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroSemanticConcreteRunStackView.lean
@@ -28,7 +28,7 @@ theorem saveRa_signs_abs_signXor_then_divCall_bzero_stack_entry_zero_divisor_run
          (.x7 ↦ᵣ dividendValueOld) ** (.x11 ↦ᵣ dividendCarryOld)) **
         evmStackIs sp (dividend :: (0 : EvmWord) :: rest)) **
        ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
-        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0))
       (let out : EvmAsm.Evm64.SDivStackExecutionBridge.SDivStackResult :=
          { effects := { stackWords := [0] }, stack := rest }

--- a/EvmAsm/Evm64/SDiv/Compose/BzeroSemanticHandlerView.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroSemanticHandlerView.lean
@@ -29,7 +29,7 @@ theorem saveRa_signs_abs_signXor_then_divCall_bzero_stack_entry_zero_divisor_han
          (.x7 ↦ᵣ dividendValueOld) ** (.x11 ↦ᵣ dividendCarryOld)) **
         evmStackIs sp (dividend :: (0 : EvmWord) :: rest)) **
        ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
-        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0))
       (let dividendAbsWord :=
          sdivAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)

--- a/EvmAsm/Evm64/SDiv/Compose/BzeroSemanticResultView.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroSemanticResultView.lean
@@ -32,7 +32,7 @@ theorem saveRa_signs_abs_signXor_then_divCall_bzero_stack_entry_zero_divisor_res
          (.x7 ↦ᵣ dividendValueOld) ** (.x11 ↦ᵣ dividendCarryOld)) **
         evmStackIs sp (dividend :: (0 : EvmWord) :: rest)) **
        ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
-        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0))
       (let result := EvmAsm.Evm64.SDivArgs.sdivResultFromArgs
           (EvmAsm.Evm64.SDivArgs.sdivArgs dividend 0)

--- a/EvmAsm/Evm64/SDiv/Compose/BzeroSemanticRunStackView.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroSemanticRunStackView.lean
@@ -33,7 +33,7 @@ theorem saveRa_signs_abs_signXor_then_divCall_bzero_stack_entry_zero_divisor_run
          (.x7 ↦ᵣ dividendValueOld) ** (.x11 ↦ᵣ dividendCarryOld)) **
         evmStackIs sp (dividend :: (0 : EvmWord) :: rest)) **
        ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
-        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0))
       (let dividendAbsWord :=
          sdivAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)

--- a/EvmAsm/Evm64/SDiv/Compose/BzeroSemanticStackAfterView.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroSemanticStackAfterView.lean
@@ -27,7 +27,7 @@ theorem saveRa_signs_abs_signXor_then_divCall_bzero_stack_entry_zero_divisor_sta
          (.x7 ↦ᵣ dividendValueOld) ** (.x11 ↦ᵣ dividendCarryOld)) **
         evmStackIs sp (dividend :: (0 : EvmWord) :: rest)) **
        ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
-        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0))
       (let args := EvmAsm.Evm64.SDivArgs.sdivArgs dividend 0
        let dividendAbsWord :=

--- a/EvmAsm/Evm64/SDiv/Compose/BzeroStackEntryViews.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroStackEntryViews.lean
@@ -31,7 +31,7 @@ theorem saveRa_signs_abs_signXor_then_divCall_bzero_stack_entry_zero_spec_in_sdi
          (.x7 ↦ᵣ dividendValueOld) ** (.x11 ↦ᵣ dividendCarryOld)) **
         evmStackIs sp (dividend :: divisor :: rest)) **
        ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
-        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0))
       (let dividendAbsWord :=
          sdivAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
@@ -57,7 +57,7 @@ theorem saveRa_signs_abs_signXor_then_divCall_bzero_stack_entry_zero_spec_in_sdi
   exact EvmAsm.Rv64.cpsTripleWithin_weaken (fun h hp => by
       let scratchFrame : EvmAsm.Rv64.Assertion :=
         ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
-         EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
            shiftMem nMem jMem retMem dMem dloMem scratchUn0)
       have h_old :
           ((saveRaSignsAbsSignXorThenDivCallPre

--- a/EvmAsm/Evm64/SDiv/Compose/BzeroStackZeroDivisorView.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroStackZeroDivisorView.lean
@@ -28,7 +28,7 @@ theorem saveRa_signs_abs_signXor_then_divCall_bzero_stack_entry_zero_divisor_spe
          (.x7 ↦ᵣ dividendValueOld) ** (.x11 ↦ᵣ dividendCarryOld)) **
         evmStackIs sp (dividend :: (0 : EvmWord) :: rest)) **
        ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
-        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0))
       (let dividendAbsWord :=
          sdivAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)

--- a/EvmAsm/Evm64/SDiv/Compose/DispatchPrefix.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DispatchPrefix.lean
@@ -31,7 +31,7 @@ theorem saveRa_signs_abs_signXor_then_divCall_dispatchReady_spec_in_sdivCode
         dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
         divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
        ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
-        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0))
       (saveRaDivCallDispatchReadyPost vRa sp base
         dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
@@ -50,8 +50,7 @@ theorem saveRa_signs_abs_signXor_then_divCall_dispatchReady_spec_in_sdivCode
     rw [saveRaSignsAbsSignXorThenDivCallPost_unfold] at hq
     rw [saveRaDivCallDispatchReadyPost_unfold]
     dsimp only at hq ⊢
-    rw [sdivDivCallSignFrame_unfold]
-    rw [divModStackDispatchPre_unfold_explicit_sdiv]
+    rw [divModStackDispatchPreNoX1_unfold_explicit_sdiv]
     simp [sdivAbsDividendWord, sdivAbsDivisorWord, EvmWord.getLimbN,
       EvmWord.getLimb_fromLimbs] at hq ⊢
     xperm_hyp hq) hPrefix
@@ -84,7 +83,7 @@ theorem saveRa_signs_abs_signXor_then_divCall_then_exact_callable_spec_in_sdivCo
         dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
         divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
        ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
-        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0))
       callPost := by
   have hPrefixRaw :=
@@ -101,7 +100,7 @@ theorem saveRa_signs_abs_signXor_then_divCall_then_exact_callable_spec_in_sdivCo
         dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
         divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
        ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
-        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0))
       (saveRaDivCallDispatchReadyPost vRa sp base
         dividendLimb0 dividendLimb1 dividendLimb2 dividendTop

--- a/EvmAsm/Evm64/SDiv/Compose/DispatchReadyPost.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DispatchReadyPost.lean
@@ -43,11 +43,11 @@ def saveRaDivCallDispatchReadyPost
     sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
   let divisorAbsWord : EvmWord :=
     sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
-  EvmAsm.Evm64.divModStackDispatchPre sp dividendAbsWord divisorAbsWord
-      ((base + divCallOff) + 4) v2 v5 v6 divisorSum3 divisorMask divisorCarry3
+  EvmAsm.Evm64.divModStackDispatchPreNoX1 sp dividendAbsWord divisorAbsWord
+      divisorSign ((base + divCallOff) + 4) v2 v5 v6 divisorSum3 divisorMask divisorCarry3
       q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
       shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
-    sdivDivCallSignFrame vRa resultSign divisorSign
+    ((.x8 ↦ᵣ resultSign) ** (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12))))
 
 theorem saveRaDivCallDispatchReadyPost_unfold
     {vRa sp base : Word}
@@ -77,11 +77,11 @@ theorem saveRaDivCallDispatchReadyPost_unfold
          sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
        let divisorAbsWord : EvmWord :=
          sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
-       EvmAsm.Evm64.divModStackDispatchPre sp dividendAbsWord divisorAbsWord
-           ((base + divCallOff) + 4) v2 v5 v6 divisorSum3 divisorMask divisorCarry3
+       EvmAsm.Evm64.divModStackDispatchPreNoX1 sp dividendAbsWord divisorAbsWord
+           divisorSign ((base + divCallOff) + 4) v2 v5 v6 divisorSum3 divisorMask divisorCarry3
            q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
            shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
-         sdivDivCallSignFrame vRa resultSign divisorSign) := by
+         ((.x8 ↦ᵣ resultSign) ** (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12))))) := by
   delta saveRaDivCallDispatchReadyPost
   rfl
 
@@ -97,9 +97,8 @@ theorem saveRaDivCallDispatchReadyPost_pcFree
       shiftMem nMem jMem retMem dMem dloMem scratchUn0).pcFree := by
   rw [saveRaDivCallDispatchReadyPost_unfold]
   dsimp
-  rw [EvmAsm.Evm64.divModStackDispatchPre_unfold,
-    EvmAsm.Evm64.divScratchValuesCall_unfold,
-    sdivDivCallSignFrame_unfold]
+  rw [EvmAsm.Evm64.divModStackDispatchPreNoX1_unfold,
+    EvmAsm.Evm64.divScratchValuesCallNoX1_unfold]
   pcFree
 
 instance pcFreeInst_saveRaDivCallDispatchReadyPost

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallBzeroCallableHandoff.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallBzeroCallableHandoff.lean
@@ -29,7 +29,7 @@ theorem saveRa_signs_abs_signXor_then_divCall_bzero_callable_named_post_from_han
         dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
         divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
        ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
-        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0))
       (saveRaDivCallBzeroCallablePost vRa sp base
         dividendLimb0 dividendLimb1 dividendLimb2 dividendTop

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallBzeroHandoff.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallBzeroHandoff.lean
@@ -49,38 +49,34 @@ theorem saveRaDivCallDispatchReadyPost_bzero_callable_spec_in_sdivCode
   let divisorSum3 := sdivAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
   let divisorCarry3 := sdivAbsCarry3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
   let resultSign := sdivDivCallResultSign dividendTop divisorTop
-  have hStack :=
-    EvmAsm.Evm64.evm_div_bzero_stack_spec_within_dispatch_noNop_preserving_x1_uni
-      sp (base + wrapperEndOff) dividendAbsWord divisorAbsWord
-      ((base + divCallOff) + 4) v2 v5 v6 divisorSum3 divisorMask divisorCarry3
+  let signFrameNoX9 : EvmAsm.Rv64.Assertion :=
+    ((.x8 ↦ᵣ resultSign) **
+      (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12))))
+  have hCallableRaw :=
+    EvmAsm.Evm64.evm_div_callable_bzero_preserving_x1_spec
+      sp (base + wrapperEndOff) divisorSign ((base + divCallOff) + 4)
+      dividendAbsWord divisorAbsWord v2 v5 v6 divisorSum3 divisorMask divisorCarry3
       q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
       nMem shiftMem jMem retMem dMem dloMem scratchUn0
       (by simpa [divisorAbsWord] using hbz)
-  let branch : EvmAsm.Evm64.DivStackSpecCase (base + wrapperEndOff)
-      dividendAbsWord divisorAbsWord :=
-    EvmAsm.Evm64.DivStackSpecCase.bzero ((base + divCallOff) + 4) v2
-      (by simpa [divisorAbsWord] using hbz)
+  have hCallableCode :=
+    EvmAsm.Rv64.cpsTripleWithin_extend_code
+      (hmono := evm_div_callable_code_sub_sdivCode (base := base)) hCallableRaw
   have hCallableFramed :=
-    evm_div_callable_preserving_branch_return_x1_framed_spec_in_sdivCode
-      (F := saveRaDivCallSignFrame vRa resultSign divisorSign)
-      sp base dividendAbsWord divisorAbsWord v5 v6 divisorSum3 divisorMask divisorCarry3
-      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-      nMem shiftMem jMem retMem dMem dloMem scratchUn0
-      branch
-      (by
-        dsimp [branch]
-        exact hStack)
+    EvmAsm.Rv64.cpsTripleWithin_frameR signFrameNoX9 (by
+      dsimp [signFrameNoX9]
+      pcFree) hCallableCode
   have hCallableExit :
       EvmAsm.Rv64.cpsTripleWithin (EvmAsm.Evm64.unifiedDivBound + 1)
         (base + wrapperEndOff) (base + resultSignFixOff) (sdivCode base)
-        (EvmAsm.Evm64.divModStackDispatchPre sp dividendAbsWord divisorAbsWord
-          ((base + divCallOff) + 4) v2 v5 v6 divisorSum3 divisorMask divisorCarry3
+        (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp dividendAbsWord divisorAbsWord
+          divisorSign ((base + divCallOff) + 4) v2 v5 v6 divisorSum3 divisorMask divisorCarry3
           q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
-          saveRaDivCallSignFrame vRa resultSign divisorSign)
-        ((EvmAsm.Evm64.divStackDispatchPostNoX1 sp dividendAbsWord divisorAbsWord **
+          signFrameNoX9)
+        (((EvmAsm.Evm64.divStackDispatchPostCallable sp dividendAbsWord divisorAbsWord **
           (.x1 ↦ᵣ ((base + divCallOff) + 4))) **
-          saveRaDivCallSignFrame vRa resultSign divisorSign) := by
+          (.x9 ↦ᵣ divisorSign)) ** signFrameNoX9) := by
     rw [← divCall_return_andn_one_eq_resultSignFixOff base hbase]
     exact hCallableFramed
   exact EvmAsm.Rv64.cpsTripleWithin_weaken (fun h hp => by
@@ -91,10 +87,12 @@ theorem saveRaDivCallDispatchReadyPost_bzero_callable_spec_in_sdivCode
       sdivDivCallResultSign, sdivAbsSign, sdivAbsMask, sdivAbsSum0, sdivAbsCarry0,
       sdivAbsSum1, sdivAbsCarry1, sdivAbsSum2, sdivAbsCarry2, sdivAbsSum3,
       sdivAbsCarry3] at hp ⊢
+    dsimp [signFrameNoX9] at hp ⊢
     exact hp) (fun h hp => by
     rw [saveRaDivCallBzeroCallablePost_unfold]
-    dsimp [dividendAbsWord, divisorAbsWord, divisorSign, resultSign,
+    dsimp [dividendAbsWord, divisorAbsWord, divisorSign, resultSign, signFrameNoX9,
       saveRaDivCallSignFrame, sdivDivCallResultSign, sdivAbsSign] at hp ⊢
-    exact hp) hCallableExit
+    simpa only [EvmAsm.Rv64.sepConj_assoc', EvmAsm.Rv64.sepConj_comm',
+      EvmAsm.Rv64.sepConj_left_comm'] using hp) hCallableExit
 
 end EvmAsm.Evm64.SDiv.Compose

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallBzeroResultSignFixHandoff.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallBzeroResultSignFixHandoff.lean
@@ -28,7 +28,7 @@ theorem saveRa_signs_abs_signXor_then_divCall_bzero_then_resultSignFix_named_pos
         dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
         divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
        ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
-        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0))
       (saveRaDivCallResultSignFixPost vRa sp base
         dividendLimb0 dividendLimb1 dividendLimb2 dividendTop

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallBzeroReturnHandoff.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallBzeroReturnHandoff.lean
@@ -28,7 +28,7 @@ theorem saveRa_signs_abs_signXor_then_divCall_bzero_then_return_normalized_named
         dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
         divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
        ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
-        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0))
       (saveRaDivCallCallableReturnPost vRa sp base
         dividendLimb0 dividendLimb1 dividendLimb2 dividendTop

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallCallableReturnPost.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallCallableReturnPost.lean
@@ -57,7 +57,7 @@ theorem saveRaDivCallCallableReturnPost_pcFree
   rw [saveRaDivCallCallableReturnPost_unfold]
   dsimp
   rw [resultSignFixPost_unfold, saveRaDivCallBzeroSavedRaRetFrame_unfold,
-    EvmAsm.Evm64.divScratchOwnCall_unfold,
+    EvmAsm.Evm64.divScratchOwnCallNoX1_unfold,
     EvmAsm.Evm64.divScratchOwn_unfold]
   pcFree
 
@@ -69,6 +69,59 @@ instance pcFreeInst_saveRaDivCallCallableReturnPost
         dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
         divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) :=
   ⟨saveRaDivCallCallableReturnPost_pcFree⟩
+
+@[irreducible]
+def saveRaDivCallCallableReturnPostNoX9
+    (vRa sp base dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word) : EvmAsm.Rv64.Assertion :=
+  let dividendAbsWord :=
+    sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+  let divisorAbsWord :=
+    sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+  let quotientWord := EvmWord.div dividendAbsWord divisorAbsWord
+  let resultSign :=
+    (dividendTop >>> (63 : BitVec 6).toNat) ^^^
+      (divisorTop >>> (63 : BitVec 6).toNat)
+  (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12))) **
+  (resultSignFixPost (sp + 32) resultSign
+    (quotientWord.getLimbN 0) (quotientWord.getLimbN 1)
+    (quotientWord.getLimbN 2) (quotientWord.getLimbN 3) **
+   saveRaDivCallSavedRaRetFrameNoX9 sp base dividendAbsWord)
+
+theorem saveRaDivCallCallableReturnPostNoX9_unfold
+    {vRa sp base dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word} :
+    saveRaDivCallCallableReturnPostNoX9 vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop =
+      (let dividendAbsWord :=
+         sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+       let divisorAbsWord :=
+         sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+       let quotientWord := EvmWord.div dividendAbsWord divisorAbsWord
+       let resultSign :=
+         (dividendTop >>> (63 : BitVec 6).toNat) ^^^
+           (divisorTop >>> (63 : BitVec 6).toNat)
+       (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12))) **
+       (resultSignFixPost (sp + 32) resultSign
+         (quotientWord.getLimbN 0) (quotientWord.getLimbN 1)
+         (quotientWord.getLimbN 2) (quotientWord.getLimbN 3) **
+        saveRaDivCallSavedRaRetFrameNoX9 sp base dividendAbsWord)) := by
+  delta saveRaDivCallCallableReturnPostNoX9
+  rfl
+
+theorem saveRaDivCallCallableReturnPostNoX9_pcFree
+    {vRa sp base dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word} :
+    (saveRaDivCallCallableReturnPostNoX9 vRa sp base
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop).pcFree := by
+  rw [saveRaDivCallCallableReturnPostNoX9_unfold]
+  dsimp
+  rw [resultSignFixPost_unfold, saveRaDivCallSavedRaRetFrameNoX9_unfold,
+    EvmAsm.Evm64.divScratchOwnCallNoX1_unfold,
+    EvmAsm.Evm64.divScratchOwn_unfold]
+  pcFree
 
 /-- Callable-return postcondition after SDIV result-sign fixup, with the
     produced result slot folded as a named sign-fixed quotient word. -/
@@ -149,7 +202,7 @@ theorem saveRaDivCallCallableReturnSignFixedWordPost_pcFree
   rw [saveRaDivCallCallableReturnSignFixedWordPost_unfold]
   dsimp
   rw [saveRaDivCallBzeroSavedRaRetFrame_unfold,
-    EvmAsm.Evm64.divScratchOwnCall_unfold,
+    EvmAsm.Evm64.divScratchOwnCallNoX1_unfold,
     EvmAsm.Evm64.divScratchOwn_unfold]
   pcFree
 
@@ -175,6 +228,86 @@ theorem saveRaDivCallCallableReturnPost_evmWordIs
         divisorLimb0 divisorLimb1 divisorLimb2 divisorTop := by
   rw [saveRaDivCallCallableReturnPost_unfold,
     saveRaDivCallCallableReturnSignFixedWordPost_unfold]
+  dsimp only
+  rw [resultSignFixPost_evmWordIs]
+
+@[irreducible]
+def saveRaDivCallCallableReturnSignFixedWordPostNoX9
+    (vRa sp base dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word) : EvmAsm.Rv64.Assertion :=
+  let dividendAbsWord :=
+    sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+  let divisorAbsWord :=
+    sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+  let quotientWord := EvmWord.div dividendAbsWord divisorAbsWord
+  let resultSign :=
+    (dividendTop >>> (63 : BitVec 6).toNat) ^^^
+      (divisorTop >>> (63 : BitVec 6).toNat)
+  let resultWord :=
+    sdivSignFixedWord resultSign
+      (quotientWord.getLimbN 0) (quotientWord.getLimbN 1)
+      (quotientWord.getLimbN 2) (quotientWord.getLimbN 3)
+  let mask := (0 : Word) - resultSign
+  let sum0 := (quotientWord.getLimbN 0 ^^^ mask) + resultSign
+  let carry0 := if BitVec.ult sum0 resultSign then (1 : Word) else 0
+  let sum1 := (quotientWord.getLimbN 1 ^^^ mask) + carry0
+  let carry1 := if BitVec.ult sum1 carry0 then (1 : Word) else 0
+  let sum2 := (quotientWord.getLimbN 2 ^^^ mask) + carry1
+  let carry2 := if BitVec.ult sum2 carry1 then (1 : Word) else 0
+  let sum3 := (quotientWord.getLimbN 3 ^^^ mask) + carry2
+  let carry3 := if BitVec.ult sum3 carry2 then (1 : Word) else 0
+  (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12))) **
+  (((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ (sp + 32)) ** (.x8 ↦ᵣ resultSign) **
+    (.x10 ↦ᵣ mask) ** (.x7 ↦ᵣ sum3) ** (.x11 ↦ᵣ carry3) **
+    evmWordIs (sp + 32) resultWord) **
+   saveRaDivCallSavedRaRetFrameNoX9 sp base dividendAbsWord)
+
+theorem saveRaDivCallCallableReturnSignFixedWordPostNoX9_unfold
+    {vRa sp base dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word} :
+    saveRaDivCallCallableReturnSignFixedWordPostNoX9 vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop =
+      (let dividendAbsWord :=
+         sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+       let divisorAbsWord :=
+         sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+       let quotientWord := EvmWord.div dividendAbsWord divisorAbsWord
+       let resultSign :=
+         (dividendTop >>> (63 : BitVec 6).toNat) ^^^
+           (divisorTop >>> (63 : BitVec 6).toNat)
+       let resultWord :=
+         sdivSignFixedWord resultSign
+           (quotientWord.getLimbN 0) (quotientWord.getLimbN 1)
+           (quotientWord.getLimbN 2) (quotientWord.getLimbN 3)
+       let mask := (0 : Word) - resultSign
+       let sum0 := (quotientWord.getLimbN 0 ^^^ mask) + resultSign
+       let carry0 := if BitVec.ult sum0 resultSign then (1 : Word) else 0
+       let sum1 := (quotientWord.getLimbN 1 ^^^ mask) + carry0
+       let carry1 := if BitVec.ult sum1 carry0 then (1 : Word) else 0
+       let sum2 := (quotientWord.getLimbN 2 ^^^ mask) + carry1
+       let carry2 := if BitVec.ult sum2 carry1 then (1 : Word) else 0
+       let sum3 := (quotientWord.getLimbN 3 ^^^ mask) + carry2
+       let carry3 := if BitVec.ult sum3 carry2 then (1 : Word) else 0
+       (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12))) **
+       (((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ (sp + 32)) ** (.x8 ↦ᵣ resultSign) **
+         (.x10 ↦ᵣ mask) ** (.x7 ↦ᵣ sum3) ** (.x11 ↦ᵣ carry3) **
+         evmWordIs (sp + 32) resultWord) **
+        saveRaDivCallSavedRaRetFrameNoX9 sp base dividendAbsWord)) := by
+  delta saveRaDivCallCallableReturnSignFixedWordPostNoX9
+  rfl
+
+theorem saveRaDivCallCallableReturnPostNoX9_evmWordIs
+    (vRa sp base dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word) :
+    saveRaDivCallCallableReturnPostNoX9 vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop =
+      saveRaDivCallCallableReturnSignFixedWordPostNoX9 vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop := by
+  rw [saveRaDivCallCallableReturnPostNoX9_unfold,
+    saveRaDivCallCallableReturnSignFixedWordPostNoX9_unfold]
   dsimp only
   rw [resultSignFixPost_evmWordIs]
 

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallDispatchFrame.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallDispatchFrame.lean
@@ -11,7 +11,7 @@ namespace EvmAsm.Evm64.SDiv.Compose
 open EvmAsm.Rv64.Tactics
 
 /-- Frame the dispatcher-pre slots — `(.x2 ↦ᵣ v2)`, `(.x5 ↦ᵣ v5)`,
-    `(.x6 ↦ᵣ v6)`, and `divScratchValuesCall` — through
+    `(.x6 ↦ᵣ v6)`, and `divScratchValuesCallNoX1` — through
     `saveRa_signs_abs_signXor_then_divCall_spec_in_sdivCode`. None of those
     slots is touched by the SDIV wrapper prefix (the wrapper only mutates
     `x0/x1/x7..x12/x18` and `sp[0..56]`), so the frame extension is
@@ -36,19 +36,19 @@ theorem saveRa_signs_abs_signXor_then_divCall_framed_for_dispatch_spec_in_sdivCo
         dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
         divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
        ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
-        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0))
       (saveRaSignsAbsSignXorThenDivCallPost vRa sp base
         dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
         divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
        ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
-        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0)) := by
   have hFramePcFree :
       ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
-       EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+       EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
          shiftMem nMem jMem retMem dMem dloMem scratchUn0).pcFree := by
-    rw [EvmAsm.Evm64.divScratchValuesCall_unfold]
+    rw [EvmAsm.Evm64.divScratchValuesCallNoX1_unfold]
     unfold EvmAsm.Evm64.divScratchValues
     pcFree
   exact EvmAsm.Rv64.cpsTripleWithin_frameR _ hFramePcFree

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallExactCallable.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallExactCallable.lean
@@ -17,7 +17,7 @@ open EvmAsm.Rv64.Tactics
     `DivStackSpecCase.x1`, whose nonzero constructors use the dispatcher-local
     scratch value `0` instead of the wrapper return address. -/
 theorem evm_div_callable_preserving_x1_exact_pre_spec_in_sdivCode
-    (sp base raVal : Word) (a b : EvmWord) (v2 v5 v6 v7 v10 v11 : Word)
+    (sp base x9Val raVal : Word) (a b : EvmWord) (v2 v5 v6 v7 v10 v11 : Word)
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
      nMem shiftMem jMem retMem dMem dloMem scratchUn0 : Word)
     (hStack :
@@ -25,18 +25,18 @@ theorem evm_div_callable_preserving_x1_exact_pre_spec_in_sdivCode
         (base + wrapperEndOff)
         ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
         (EvmAsm.Evm64.divCode_noNop (base + wrapperEndOff))
-        (EvmAsm.Evm64.divModStackDispatchPre sp a b
-          raVal v2 v5 v6 v7 v10 v11
+        (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp a b
+          x9Val raVal v2 v5 v6 v7 v10 v11
           q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0)
-        (EvmAsm.Evm64.divStackDispatchPostNoX1 sp a b ** (.x1 ↦ᵣ raVal))) :
+        (EvmAsm.Evm64.divStackDispatchPostCallable sp a b ** (.x1 ↦ᵣ raVal))) :
     EvmAsm.Rv64.cpsTripleWithin (EvmAsm.Evm64.unifiedDivBound + 1)
       (base + wrapperEndOff) (raVal &&& ~~~1) (sdivCode base)
-      (EvmAsm.Evm64.divModStackDispatchPre sp a b
-        raVal v2 v5 v6 v7 v10 v11
+      (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp a b
+        x9Val raVal v2 v5 v6 v7 v10 v11
         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
         shiftMem nMem jMem retMem dMem dloMem scratchUn0)
-      (EvmAsm.Evm64.divStackDispatchPostNoX1 sp a b ** (.x1 ↦ᵣ raVal)) := by
+      (EvmAsm.Evm64.divStackDispatchPostCallable sp a b ** (.x1 ↦ᵣ raVal)) := by
   have hStackCallDiv :=
     EvmAsm.Rv64.cpsTripleWithin_extend_code
       (hmono := EvmAsm.Evm64.divCode_noNop_sub_div_callable_code)
@@ -56,8 +56,8 @@ theorem evm_div_callable_preserving_x1_exact_pre_spec_in_sdivCode
       hRetDiv
   have hRetFramed :=
     EvmAsm.Rv64.cpsTripleWithin_frameL
-      (EvmAsm.Evm64.divStackDispatchPostNoX1 sp a b)
-      (divStackDispatchPostNoX1_pcFree (sp := sp) (a := a) (b := b))
+      (EvmAsm.Evm64.divStackDispatchPostCallable sp a b)
+      (EvmAsm.Evm64.divStackDispatchPostCallable_pcFree sp a b)
       hRet
   exact EvmAsm.Rv64.cpsTripleWithin_seq_same_cr hStackCall hRetFramed
 
@@ -138,7 +138,7 @@ theorem evm_div_callable_preserving_branch_return_x1_framed_spec_in_sdivCode
     frame. -/
 theorem evm_div_callable_preserving_x1_exact_pre_framed_spec_in_sdivCode
     {F : EvmAsm.Rv64.Assertion} [EvmAsm.Rv64.Assertion.PCFree F]
-    (sp base raVal : Word) (a b : EvmWord) (v2 v5 v6 v7 v10 v11 : Word)
+    (sp base x9Val raVal : Word) (a b : EvmWord) (v2 v5 v6 v7 v10 v11 : Word)
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
      nMem shiftMem jMem retMem dMem dloMem scratchUn0 : Word)
     (hStack :
@@ -146,22 +146,22 @@ theorem evm_div_callable_preserving_x1_exact_pre_framed_spec_in_sdivCode
         (base + wrapperEndOff)
         ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
         (EvmAsm.Evm64.divCode_noNop (base + wrapperEndOff))
-        (EvmAsm.Evm64.divModStackDispatchPre sp a b
-          raVal v2 v5 v6 v7 v10 v11
+        (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp a b
+          x9Val raVal v2 v5 v6 v7 v10 v11
           q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0)
-        (EvmAsm.Evm64.divStackDispatchPostNoX1 sp a b ** (.x1 ↦ᵣ raVal))) :
+        (EvmAsm.Evm64.divStackDispatchPostCallable sp a b ** (.x1 ↦ᵣ raVal))) :
     EvmAsm.Rv64.cpsTripleWithin (EvmAsm.Evm64.unifiedDivBound + 1)
       (base + wrapperEndOff) (raVal &&& ~~~1) (sdivCode base)
-      (EvmAsm.Evm64.divModStackDispatchPre sp a b
-        raVal v2 v5 v6 v7 v10 v11
+      (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp a b
+        x9Val raVal v2 v5 v6 v7 v10 v11
         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
         shiftMem nMem jMem retMem dMem dloMem scratchUn0 ** F)
-      ((EvmAsm.Evm64.divStackDispatchPostNoX1 sp a b ** (.x1 ↦ᵣ raVal)) ** F) := by
+      ((EvmAsm.Evm64.divStackDispatchPostCallable sp a b ** (.x1 ↦ᵣ raVal)) ** F) := by
   exact
     EvmAsm.Rv64.cpsTripleWithin_frameR F (by pcFree)
       (evm_div_callable_preserving_x1_exact_pre_spec_in_sdivCode
-        sp base raVal a b v2 v5 v6 v7 v10 v11
+        sp base x9Val raVal a b v2 v5 v6 v7 v10 v11
         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
         nMem shiftMem jMem retMem dMem dloMem scratchUn0 hStack)
 

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallExactHandoff.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallExactHandoff.lean
@@ -25,16 +25,16 @@ theorem saveRaDivCallDispatchReadyPost_exact_callable_spec_in_sdivCode
         (base + wrapperEndOff)
         ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
         (EvmAsm.Evm64.divCode_noNop (base + wrapperEndOff))
-        (EvmAsm.Evm64.divModStackDispatchPre sp
+        (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp
           (sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
           (sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
-          ((base + divCallOff) + 4) v2 v5 v6
+          (sdivAbsSign divisorTop) ((base + divCallOff) + 4) v2 v5 v6
           (sdivAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
           (sdivAbsMask divisorTop)
           (sdivAbsCarry3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
           q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0)
-        (EvmAsm.Evm64.divStackDispatchPostNoX1 sp
+        (EvmAsm.Evm64.divStackDispatchPostCallable sp
           (sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
           (sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) **
           (.x1 ↦ᵣ ((base + divCallOff) + 4)))) :
@@ -45,7 +45,7 @@ theorem saveRaDivCallDispatchReadyPost_exact_callable_spec_in_sdivCode
         divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
         v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
         shiftMem nMem jMem retMem dMem dloMem scratchUn0)
-      (saveRaDivCallBzeroCallablePost vRa sp base
+      (saveRaDivCallCallablePostNoX9 vRa sp base
         dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
         divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) := by
   let dividendAbsWord :=
@@ -63,10 +63,12 @@ theorem saveRaDivCallDispatchReadyPost_exact_callable_spec_in_sdivCode
   let divisorSum3 := sdivAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
   let divisorCarry3 := sdivAbsCarry3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
   let resultSign := sdivDivCallResultSign dividendTop divisorTop
+  let signFrameNoX9 : EvmAsm.Rv64.Assertion :=
+    (.x8 ↦ᵣ resultSign) ** (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))
   have hCallableFramed :=
     evm_div_callable_preserving_x1_exact_pre_framed_spec_in_sdivCode
-      (F := saveRaDivCallSignFrame vRa resultSign divisorSign)
-      sp base ((base + divCallOff) + 4)
+      (F := signFrameNoX9)
+      sp base divisorSign ((base + divCallOff) + 4)
       dividendAbsWord divisorAbsWord v2 v5 v6 divisorSum3 divisorMask divisorCarry3
       q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
       nMem shiftMem jMem retMem dMem dloMem scratchUn0
@@ -77,14 +79,14 @@ theorem saveRaDivCallDispatchReadyPost_exact_callable_spec_in_sdivCode
   have hCallableExit :
       EvmAsm.Rv64.cpsTripleWithin (EvmAsm.Evm64.unifiedDivBound + 1)
         (base + wrapperEndOff) (base + resultSignFixOff) (sdivCode base)
-        (EvmAsm.Evm64.divModStackDispatchPre sp dividendAbsWord divisorAbsWord
-          ((base + divCallOff) + 4) v2 v5 v6 divisorSum3 divisorMask divisorCarry3
+        (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp dividendAbsWord divisorAbsWord
+          divisorSign ((base + divCallOff) + 4) v2 v5 v6 divisorSum3 divisorMask divisorCarry3
           q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
-          saveRaDivCallSignFrame vRa resultSign divisorSign)
-        ((EvmAsm.Evm64.divStackDispatchPostNoX1 sp dividendAbsWord divisorAbsWord **
+          signFrameNoX9)
+        ((EvmAsm.Evm64.divStackDispatchPostCallable sp dividendAbsWord divisorAbsWord **
           (.x1 ↦ᵣ ((base + divCallOff) + 4))) **
-          saveRaDivCallSignFrame vRa resultSign divisorSign) := by
+          signFrameNoX9) := by
     rw [← divCall_return_andn_one_eq_resultSignFixOff base hbase]
     exact hCallableFramed
   exact EvmAsm.Rv64.cpsTripleWithin_weaken (fun h hp => by
@@ -94,11 +96,11 @@ theorem saveRaDivCallDispatchReadyPost_exact_callable_spec_in_sdivCode
       divisorSum3, divisorCarry3, resultSign, saveRaDivCallSignFrame,
       sdivDivCallResultSign, sdivAbsSign, sdivAbsMask, sdivAbsSum0, sdivAbsCarry0,
       sdivAbsSum1, sdivAbsCarry1, sdivAbsSum2, sdivAbsCarry2, sdivAbsSum3,
-      sdivAbsCarry3] at hp ⊢
+      sdivAbsCarry3, signFrameNoX9] at hp ⊢
     exact hp) (fun h hp => by
-    rw [saveRaDivCallBzeroCallablePost_unfold]
+    rw [saveRaDivCallCallablePostNoX9_unfold]
     dsimp [dividendAbsWord, divisorAbsWord, divisorSign, resultSign,
-      saveRaDivCallSignFrame, sdivDivCallResultSign, sdivAbsSign] at hp ⊢
+      signFrameNoX9, sdivDivCallResultSign, sdivAbsSign] at hp ⊢
     exact hp) hCallableExit
 
 end EvmAsm.Evm64.SDiv.Compose

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallExactResultSignFixHandoff.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallExactResultSignFixHandoff.lean
@@ -25,16 +25,16 @@ theorem saveRa_signs_abs_signXor_then_divCall_exact_then_resultSignFix_named_pos
         (base + wrapperEndOff)
         ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
         (EvmAsm.Evm64.divCode_noNop (base + wrapperEndOff))
-        (EvmAsm.Evm64.divModStackDispatchPre sp
+        (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp
           (sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
           (sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
-          ((base + divCallOff) + 4) v2 v5 v6
+          (sdivAbsSign divisorTop) ((base + divCallOff) + 4) v2 v5 v6
           (sdivAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
           (sdivAbsMask divisorTop)
           (sdivAbsCarry3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
           q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0)
-        (EvmAsm.Evm64.divStackDispatchPostNoX1 sp
+        (EvmAsm.Evm64.divStackDispatchPostCallable sp
           (sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
           (sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) **
           (.x1 ↦ᵣ ((base + divCallOff) + 4)))) :
@@ -45,13 +45,13 @@ theorem saveRa_signs_abs_signXor_then_divCall_exact_then_resultSignFix_named_pos
         dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
         divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
        ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
-        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0))
-      (saveRaDivCallResultSignFixPost vRa sp base
+      (saveRaDivCallResultSignFixPostNoX9 vRa sp base
         dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
         divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) := by
   exact
-    saveRa_signs_abs_signXor_then_divCall_then_resultSignFix_named_post_of_callable_post_spec_in_sdivCode
+    saveRa_signs_abs_signXor_then_divCall_then_resultSignFix_named_post_of_callable_post_noX9_spec_in_sdivCode
       vRa vSavedOld sp sDividendOld sDivisorOld
       dividendMaskOld dividendValueOld dividendCarryOld
       dividendLimb0 dividendLimb1 dividendLimb2 dividendTop

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallExactReturnHandoff.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallExactReturnHandoff.lean
@@ -27,16 +27,16 @@ theorem saveRa_signs_abs_signXor_then_divCall_exact_then_return_normalized_named
         (base + wrapperEndOff)
         ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
         (EvmAsm.Evm64.divCode_noNop (base + wrapperEndOff))
-        (EvmAsm.Evm64.divModStackDispatchPre sp
+        (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp
           (sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
           (sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
-          ((base + divCallOff) + 4) v2 v5 v6
+          (sdivAbsSign divisorTop) ((base + divCallOff) + 4) v2 v5 v6
           (sdivAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
           (sdivAbsMask divisorTop)
           (sdivAbsCarry3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
           q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0)
-        (EvmAsm.Evm64.divStackDispatchPostNoX1 sp
+        (EvmAsm.Evm64.divStackDispatchPostCallable sp
           (sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
           (sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) **
           (.x1 ↦ᵣ ((base + divCallOff) + 4)))) :
@@ -47,13 +47,20 @@ theorem saveRa_signs_abs_signXor_then_divCall_exact_then_return_normalized_named
         dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
         divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
        ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
-        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0))
-      (saveRaDivCallCallableReturnPost vRa sp base
+      (saveRaDivCallCallableReturnPostNoX9 vRa sp base
         dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
         divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) := by
+  have hExit :
+      (((vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)) +
+        EvmAsm.Rv64.signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word)) =
+        (vRa &&& ~~~(1 : Word)) := by
+    rw [EvmAsm.Rv64.signExtend12_0]
+    bv_decide
+  rw [← hExit]
   exact
-    saveRa_signs_abs_signXor_then_divCall_then_return_normalized_named_post_of_callable_post_spec_in_sdivCode
+    saveRa_signs_abs_signXor_then_divCall_then_return_of_callable_post_noX9_spec_in_sdivCode
       vRa vSavedOld sp sDividendOld sDivisorOld
       dividendMaskOld dividendValueOld dividendCarryOld
       dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
@@ -84,12 +91,12 @@ theorem saveRa_signs_abs_signXor_then_divCall_exact_then_return_stack_tail_from_
         (base + wrapperEndOff)
         ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
         (EvmAsm.Evm64.divCode_noNop (base + wrapperEndOff))
-        (EvmAsm.Evm64.divModStackDispatchPre sp
+        (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp
           (sdivAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
             (dividend.getLimbN 2) (dividend.getLimbN 3))
           (sdivAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
             (divisor.getLimbN 2) (divisor.getLimbN 3))
-          ((base + divCallOff) + 4) v2 v5 v6
+          (sdivAbsSign (divisor.getLimbN 3)) ((base + divCallOff) + 4) v2 v5 v6
           (sdivAbsSum3 (divisor.getLimbN 0) (divisor.getLimbN 1)
             (divisor.getLimbN 2) (divisor.getLimbN 3))
           (sdivAbsMask (divisor.getLimbN 3))
@@ -97,7 +104,7 @@ theorem saveRa_signs_abs_signXor_then_divCall_exact_then_return_stack_tail_from_
             (divisor.getLimbN 2) (divisor.getLimbN 3))
           q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0)
-        (EvmAsm.Evm64.divStackDispatchPostNoX1 sp
+        (EvmAsm.Evm64.divStackDispatchPostCallable sp
           (sdivAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
             (dividend.getLimbN 2) (dividend.getLimbN 3))
           (sdivAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
@@ -111,9 +118,9 @@ theorem saveRa_signs_abs_signXor_then_divCall_exact_then_return_stack_tail_from_
          (.x7 ↦ᵣ dividendValueOld) ** (.x11 ↦ᵣ dividendCarryOld)) **
         evmStackIs sp (dividend :: divisor :: rest)) **
        ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
-        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0))
-      (saveRaDivCallCallableReturnPost vRa sp base
+      (saveRaDivCallCallableReturnPostNoX9 vRa sp base
         (dividend.getLimbN 0) (dividend.getLimbN 1)
         (dividend.getLimbN 2) (dividend.getLimbN 3)
         (divisor.getLimbN 0) (divisor.getLimbN 1)
@@ -121,7 +128,7 @@ theorem saveRa_signs_abs_signXor_then_divCall_exact_then_return_stack_tail_from_
        evmStackIs (sp + 64) rest) := by
   let scratchFrame : EvmAsm.Rv64.Assertion :=
     ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
-     EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
        shiftMem nMem jMem retMem dMem dloMem scratchUn0)
   have hBase :=
     saveRa_signs_abs_signXor_then_divCall_exact_then_return_normalized_named_post_from_handoff_spec_in_sdivCode
@@ -168,16 +175,16 @@ theorem saveRa_signs_abs_signXor_then_divCall_exact_then_return_sign_fixed_word_
         (base + wrapperEndOff)
         ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
         (EvmAsm.Evm64.divCode_noNop (base + wrapperEndOff))
-        (EvmAsm.Evm64.divModStackDispatchPre sp
+        (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp
           (sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
           (sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
-          ((base + divCallOff) + 4) v2 v5 v6
+          (sdivAbsSign divisorTop) ((base + divCallOff) + 4) v2 v5 v6
           (sdivAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
           (sdivAbsMask divisorTop)
           (sdivAbsCarry3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
           q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0)
-        (EvmAsm.Evm64.divStackDispatchPostNoX1 sp
+        (EvmAsm.Evm64.divStackDispatchPostCallable sp
           (sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
           (sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) **
           (.x1 ↦ᵣ ((base + divCallOff) + 4)))) :
@@ -188,13 +195,13 @@ theorem saveRa_signs_abs_signXor_then_divCall_exact_then_return_sign_fixed_word_
         dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
         divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
        ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
-        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0))
-      (saveRaDivCallCallableReturnSignFixedWordPost vRa sp base
+      (saveRaDivCallCallableReturnSignFixedWordPostNoX9 vRa sp base
         dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
         divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) := by
   exact EvmAsm.Rv64.cpsTripleWithin_weaken (fun _ hp => hp) (fun _ hp => by
-      rw [saveRaDivCallCallableReturnPost_evmWordIs] at hp
+      rw [saveRaDivCallCallableReturnPostNoX9_evmWordIs] at hp
       exact hp)
     (saveRa_signs_abs_signXor_then_divCall_exact_then_return_normalized_named_post_from_handoff_spec_in_sdivCode
       vRa vSavedOld sp sDividendOld sDivisorOld

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallResultSignFix.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallResultSignFix.lean
@@ -37,7 +37,7 @@ theorem saveRa_signs_abs_signXor_then_divCall_then_resultSignFix_of_callable_pos
         dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
         divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
        ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
-        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0))
       (let dividendAbsWord :=
          sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
@@ -74,7 +74,7 @@ theorem saveRa_signs_abs_signXor_then_divCall_then_resultSignFix_of_callable_pos
       (saveRaDivCallBzeroResultSignFixFrame
         vRa sp base divisorSign dividendAbsWord).pcFree := by
     rw [saveRaDivCallBzeroResultSignFixFrame_unfold,
-      EvmAsm.Evm64.divScratchOwnCall_unfold,
+      EvmAsm.Evm64.divScratchOwnCallNoX1_unfold,
       EvmAsm.Evm64.divScratchOwn_unfold]
     pcFree
   have hFix :=
@@ -87,8 +87,92 @@ theorem saveRa_signs_abs_signXor_then_divCall_then_resultSignFix_of_callable_pos
         (quotientWord.getLimbN 0) (quotientWord.getLimbN 1)
         (quotientWord.getLimbN 2) (quotientWord.getLimbN 3) base)
   exact EvmAsm.Rv64.cpsTripleWithin_seq_perm_same_cr
-    (fun _ hp => by
+    (fun h (hp : (saveRaDivCallBzeroCallablePost vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) h) => by
       rw [saveRaDivCallBzeroCallablePost_resultSignFixPreOwnScratch_quotient] at hp
+      exact hp)
+    hPrefix hFix
+
+theorem saveRa_signs_abs_signXor_then_divCall_then_resultSignFix_of_callable_post_noX9_spec_in_sdivCode
+    {nSteps : Nat}
+    (vRa vSavedOld sp sDividendOld sDivisorOld
+      dividendMaskOld dividendValueOld dividendCarryOld
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+      v2 v5 v6 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (base : Word)
+    (hCallable :
+      EvmAsm.Rv64.cpsTripleWithin nSteps (base + wrapperEndOff) (base + resultSignFixOff) (sdivCode base)
+        (saveRaDivCallDispatchReadyPost vRa sp base
+          dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+          divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+          v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+        (saveRaDivCallCallablePostNoX9 vRa sp base
+          dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+          divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)) :
+    EvmAsm.Rv64.cpsTripleWithin ((49 + nSteps) + 21)
+      base ((base + resultSignFixOff) + 84) (sdivCode base)
+      (saveRaSignsAbsSignXorThenDivCallPre vRa vSavedOld sp sDividendOld sDivisorOld
+        dividendMaskOld dividendValueOld dividendCarryOld
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
+       ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
+        EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0))
+      (let dividendAbsWord :=
+         sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+       let divisorAbsWord :=
+         sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+       let quotientWord := EvmWord.div dividendAbsWord divisorAbsWord
+       let resultSign :=
+         (dividendTop >>> (63 : BitVec 6).toNat) ^^^
+           (divisorTop >>> (63 : BitVec 6).toNat)
+       resultSignFixPost (sp + 32) resultSign
+         (quotientWord.getLimbN 0) (quotientWord.getLimbN 1)
+         (quotientWord.getLimbN 2) (quotientWord.getLimbN 3) **
+       saveRaDivCallResultSignFixFrameNoX9 vRa sp base dividendAbsWord) := by
+  let dividendAbsWord :=
+    sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+  let divisorAbsWord :=
+    sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+  let quotientWord := EvmWord.div dividendAbsWord divisorAbsWord
+  let resultSign :=
+    (dividendTop >>> (63 : BitVec 6).toNat) ^^^
+      (divisorTop >>> (63 : BitVec 6).toNat)
+  have hPrefix :=
+    saveRa_signs_abs_signXor_then_divCall_then_exact_callable_spec_in_sdivCode
+      vRa vSavedOld sp sDividendOld sDivisorOld
+      dividendMaskOld dividendValueOld dividendCarryOld
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+      v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0
+      base (base + resultSignFixOff) hCallable
+  have hFramePc :
+      (saveRaDivCallResultSignFixFrameNoX9
+        vRa sp base dividendAbsWord).pcFree := by
+    rw [saveRaDivCallResultSignFixFrameNoX9_unfold,
+      EvmAsm.Evm64.divScratchOwnCallNoX1_unfold,
+      EvmAsm.Evm64.divScratchOwn_unfold]
+    pcFree
+  have hFix :=
+    EvmAsm.Rv64.cpsTripleWithin_frameR
+      (saveRaDivCallResultSignFixFrameNoX9
+        vRa sp base dividendAbsWord)
+      hFramePc
+      (resultSignFix_regOwn_scratch_spec_in_sdivCode
+        (sp + 32) resultSign
+        (quotientWord.getLimbN 0) (quotientWord.getLimbN 1)
+        (quotientWord.getLimbN 2) (quotientWord.getLimbN 3) base)
+  exact EvmAsm.Rv64.cpsTripleWithin_seq_perm_same_cr
+    (fun h (hp : (saveRaDivCallCallablePostNoX9 vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) h) => by
+      rw [saveRaDivCallCallablePostNoX9_resultSignFixPreOwnScratch_quotient] at hp
       exact hp)
     hPrefix hFix
 

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallResultSignFixNamedPost.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallResultSignFixNamedPost.lean
@@ -32,7 +32,7 @@ theorem saveRa_signs_abs_signXor_then_divCall_then_resultSignFix_named_post_of_c
         dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
         divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
        ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
-        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0))
       (saveRaDivCallResultSignFixPost vRa sp base
         dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
@@ -40,6 +40,49 @@ theorem saveRa_signs_abs_signXor_then_divCall_then_resultSignFix_named_post_of_c
   rw [saveRaDivCallResultSignFixPost_unfold]
   exact
     saveRa_signs_abs_signXor_then_divCall_then_resultSignFix_of_callable_post_spec_in_sdivCode
+      vRa vSavedOld sp sDividendOld sDivisorOld
+      dividendMaskOld dividendValueOld dividendCarryOld
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+      v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 base hCallable
+
+theorem saveRa_signs_abs_signXor_then_divCall_then_resultSignFix_named_post_of_callable_post_noX9_spec_in_sdivCode
+    {nSteps : Nat}
+    (vRa vSavedOld sp sDividendOld sDivisorOld
+      dividendMaskOld dividendValueOld dividendCarryOld
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+      v2 v5 v6 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (base : Word)
+    (hCallable :
+      EvmAsm.Rv64.cpsTripleWithin nSteps
+        (base + wrapperEndOff) (base + resultSignFixOff) (sdivCode base)
+        (saveRaDivCallDispatchReadyPost vRa sp base
+          dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+          divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+          v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+        (saveRaDivCallCallablePostNoX9 vRa sp base
+          dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+          divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)) :
+    EvmAsm.Rv64.cpsTripleWithin ((49 + nSteps) + 21)
+      base ((base + resultSignFixOff) + 84) (sdivCode base)
+      (saveRaSignsAbsSignXorThenDivCallPre vRa vSavedOld sp sDividendOld sDivisorOld
+        dividendMaskOld dividendValueOld dividendCarryOld
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
+       ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
+        EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0))
+      (saveRaDivCallResultSignFixPostNoX9 vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) := by
+  rw [saveRaDivCallResultSignFixPostNoX9_unfold]
+  exact
+    saveRa_signs_abs_signXor_then_divCall_then_resultSignFix_of_callable_post_noX9_spec_in_sdivCode
       vRa vSavedOld sp sDividendOld sDivisorOld
       dividendMaskOld dividendValueOld dividendCarryOld
       dividendLimb0 dividendLimb1 dividendLimb2 dividendTop

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallResultSignFixPost.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallResultSignFixPost.lean
@@ -54,7 +54,7 @@ theorem saveRaDivCallResultSignFixPost_pcFree
   rw [saveRaDivCallResultSignFixPost_unfold]
   dsimp
   rw [resultSignFixPost_unfold, saveRaDivCallBzeroResultSignFixFrame_unfold,
-    EvmAsm.Evm64.divScratchOwnCall_unfold,
+    EvmAsm.Evm64.divScratchOwnCallNoX1_unfold,
     EvmAsm.Evm64.divScratchOwn_unfold]
   pcFree
 
@@ -66,5 +66,56 @@ instance pcFreeInst_saveRaDivCallResultSignFixPost
         dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
         divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) :=
   ⟨saveRaDivCallResultSignFixPost_pcFree⟩
+
+@[irreducible]
+def saveRaDivCallResultSignFixPostNoX9
+    (vRa sp base dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word) : EvmAsm.Rv64.Assertion :=
+  let dividendAbsWord :=
+    sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+  let divisorAbsWord :=
+    sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+  let quotientWord := EvmWord.div dividendAbsWord divisorAbsWord
+  let resultSign :=
+    (dividendTop >>> (63 : BitVec 6).toNat) ^^^
+      (divisorTop >>> (63 : BitVec 6).toNat)
+  resultSignFixPost (sp + 32) resultSign
+    (quotientWord.getLimbN 0) (quotientWord.getLimbN 1)
+    (quotientWord.getLimbN 2) (quotientWord.getLimbN 3) **
+  saveRaDivCallResultSignFixFrameNoX9 vRa sp base dividendAbsWord
+
+theorem saveRaDivCallResultSignFixPostNoX9_unfold
+    {vRa sp base dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word} :
+    saveRaDivCallResultSignFixPostNoX9 vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop =
+      (let dividendAbsWord :=
+         sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+       let divisorAbsWord :=
+         sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+       let quotientWord := EvmWord.div dividendAbsWord divisorAbsWord
+       let resultSign :=
+         (dividendTop >>> (63 : BitVec 6).toNat) ^^^
+           (divisorTop >>> (63 : BitVec 6).toNat)
+       resultSignFixPost (sp + 32) resultSign
+         (quotientWord.getLimbN 0) (quotientWord.getLimbN 1)
+         (quotientWord.getLimbN 2) (quotientWord.getLimbN 3) **
+       saveRaDivCallResultSignFixFrameNoX9 vRa sp base dividendAbsWord) := by
+  delta saveRaDivCallResultSignFixPostNoX9
+  rfl
+
+theorem saveRaDivCallResultSignFixPostNoX9_pcFree
+    {vRa sp base dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word} :
+    (saveRaDivCallResultSignFixPostNoX9 vRa sp base
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop).pcFree := by
+  rw [saveRaDivCallResultSignFixPostNoX9_unfold]
+  dsimp
+  rw [resultSignFixPost_unfold, saveRaDivCallResultSignFixFrameNoX9_unfold,
+    EvmAsm.Evm64.divScratchOwnCallNoX1_unfold,
+    EvmAsm.Evm64.divScratchOwn_unfold]
+  pcFree
 
 end EvmAsm.Evm64.SDiv.Compose

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallReturnComposition.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallReturnComposition.lean
@@ -31,7 +31,7 @@ theorem saveRa_signs_abs_signXor_then_divCall_then_return_normalized_named_post_
         dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
         divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
        ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
-        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0))
       (saveRaDivCallCallableReturnPost vRa sp base
         dividendLimb0 dividendLimb1 dividendLimb2 dividendTop

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallReturnGeneric.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallReturnGeneric.lean
@@ -34,7 +34,7 @@ theorem saveRa_signs_abs_signXor_then_divCall_then_return_of_callable_post_spec_
         dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
         divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
        ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
-        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0))
       (let dividendAbsWord :=
          sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
@@ -74,7 +74,7 @@ theorem saveRa_signs_abs_signXor_then_divCall_then_return_of_callable_post_spec_
         (quotientWord.getLimbN 2) (quotientWord.getLimbN 3) **
         saveRaDivCallBzeroSavedRaRetFrame sp base divisorSign dividendAbsWord).pcFree := by
     rw [resultSignFixPost_unfold, saveRaDivCallBzeroSavedRaRetFrame_unfold,
-      EvmAsm.Evm64.divScratchOwnCall_unfold,
+      EvmAsm.Evm64.divScratchOwnCallNoX1_unfold,
       EvmAsm.Evm64.divScratchOwn_unfold]
     pcFree
   have hRetFramed :=
@@ -110,6 +110,102 @@ theorem saveRa_signs_abs_signXor_then_divCall_then_return_of_callable_post_spec_
   exact EvmAsm.Rv64.cpsTripleWithin_seq_perm_same_cr
     (fun _ hp => by
       rw [saveRaDivCallBzeroResultSignFixFrame_to_savedRaRet] at hp
+      xperm_hyp hp)
+    hPrefix hRetFramed'
+
+theorem saveRa_signs_abs_signXor_then_divCall_then_return_of_callable_post_noX9_spec_in_sdivCode
+    {nSteps : Nat}
+    (vRa vSavedOld sp sDividendOld sDivisorOld
+      dividendMaskOld dividendValueOld dividendCarryOld
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+      v2 v5 v6 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (base : Word)
+    (hCallable :
+      EvmAsm.Rv64.cpsTripleWithin nSteps (base + wrapperEndOff) (base + resultSignFixOff) (sdivCode base)
+        (saveRaDivCallDispatchReadyPost vRa sp base
+          dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+          divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+          v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+        (saveRaDivCallCallablePostNoX9 vRa sp base
+          dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+          divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)) :
+    EvmAsm.Rv64.cpsTripleWithin (((49 + nSteps) + 21) + 1)
+      base (((vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)) +
+        EvmAsm.Rv64.signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word)) (sdivCode base)
+      (saveRaSignsAbsSignXorThenDivCallPre vRa vSavedOld sp sDividendOld sDivisorOld
+        dividendMaskOld dividendValueOld dividendCarryOld
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
+       ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
+        EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0))
+      (saveRaDivCallCallableReturnPostNoX9 vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) := by
+  rw [saveRaDivCallCallableReturnPostNoX9_unfold]
+  let dividendAbsWord :=
+    sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+  let divisorAbsWord :=
+    sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+  let quotientWord := EvmWord.div dividendAbsWord divisorAbsWord
+  let resultSign :=
+    (dividendTop >>> (63 : BitVec 6).toNat) ^^^
+      (divisorTop >>> (63 : BitVec 6).toNat)
+  have hPrefix :=
+    saveRa_signs_abs_signXor_then_divCall_then_resultSignFix_named_post_of_callable_post_noX9_spec_in_sdivCode
+      vRa vSavedOld sp sDividendOld sDivisorOld
+      dividendMaskOld dividendValueOld dividendCarryOld
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+      v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 base hCallable
+  rw [saveRaDivCallResultSignFixPostNoX9_unfold] at hPrefix
+  have hRetFramePc :
+      (resultSignFixPost (sp + 32) resultSign
+        (quotientWord.getLimbN 0) (quotientWord.getLimbN 1)
+        (quotientWord.getLimbN 2) (quotientWord.getLimbN 3) **
+        saveRaDivCallSavedRaRetFrameNoX9 sp base dividendAbsWord).pcFree := by
+    rw [resultSignFixPost_unfold, saveRaDivCallSavedRaRetFrameNoX9_unfold,
+      EvmAsm.Evm64.divScratchOwnCallNoX1_unfold,
+      EvmAsm.Evm64.divScratchOwn_unfold]
+    pcFree
+  have hRetFramed :=
+    EvmAsm.Rv64.cpsTripleWithin_frameR
+      (resultSignFixPost (sp + 32) resultSign
+        (quotientWord.getLimbN 0) (quotientWord.getLimbN 1)
+        (quotientWord.getLimbN 2) (quotientWord.getLimbN 3) **
+        saveRaDivCallSavedRaRetFrameNoX9 sp base dividendAbsWord)
+      hRetFramePc
+      (savedRaRet_spec_in_sdivCode
+        (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)) base)
+  have hFall :
+      (base + resultSignFixOff) + 84 = base + savedRaRetOff := by
+    simp [resultSignFixOff, savedRaRetOff]
+    bv_addr
+  have hRetFramed' :
+      EvmAsm.Rv64.cpsTripleWithin 1 ((base + resultSignFixOff) + 84)
+        (((vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)) +
+          EvmAsm.Rv64.signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word))
+        (sdivCode base)
+        ((.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12))) **
+         (resultSignFixPost (sp + 32) resultSign
+          (quotientWord.getLimbN 0) (quotientWord.getLimbN 1)
+          (quotientWord.getLimbN 2) (quotientWord.getLimbN 3) **
+          saveRaDivCallSavedRaRetFrameNoX9 sp base dividendAbsWord))
+        ((.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12))) **
+         (resultSignFixPost (sp + 32) resultSign
+          (quotientWord.getLimbN 0) (quotientWord.getLimbN 1)
+          (quotientWord.getLimbN 2) (quotientWord.getLimbN 3) **
+          saveRaDivCallSavedRaRetFrameNoX9 sp base dividendAbsWord)) := by
+    rw [hFall]
+    exact hRetFramed
+  exact EvmAsm.Rv64.cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by
+      rw [saveRaDivCallResultSignFixFrameNoX9_to_savedRaRet] at hp
       xperm_hyp hp)
     hPrefix hRetFramed'
 

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallReturnNormalized.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallReturnNormalized.lean
@@ -32,7 +32,7 @@ theorem saveRa_signs_abs_signXor_then_divCall_then_return_normalized_of_callable
         dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
         divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
        ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
-        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0))
       (let dividendAbsWord :=
          sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop

--- a/EvmAsm/Evm64/SDiv/Spec.lean
+++ b/EvmAsm/Evm64/SDiv/Spec.lean
@@ -257,7 +257,6 @@ def sdivExactHandlerPost (sp vRa base : Word) (dividend divisor : EvmWord)
   let resultSign :=
     (dividend.getLimbN 3 >>> (63 : BitVec 6).toNat) ^^^
       (divisor.getLimbN 3 >>> (63 : BitVec 6).toNat)
-  let divisorSign := divisor.getLimbN 3 >>> (63 : BitVec 6).toNat
   let mask := (0 : Word) - resultSign
   let divisorAbsWord :=
     sdivAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
@@ -271,11 +270,18 @@ def sdivExactHandlerPost (sp vRa base : Word) (dividend divisor : EvmWord)
   let carry2 := if BitVec.ult sum2 carry1 then (1 : Word) else 0
   let sum3 := ((quotientWord.getLimbN 3) ^^^ mask) + carry2
   let carry3 := if BitVec.ult sum3 carry2 then (1 : Word) else 0
-  (.x18 ↦ᵣ vRa) **
-  (((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ (sp + 32)) ** (.x8 ↦ᵣ resultSign) **
-    (.x10 ↦ᵣ mask) ** (.x7 ↦ᵣ sum3) ** (.x11 ↦ᵣ carry3) **
-    evmStackIs (sp + 32) stackResult) **
-   saveRaDivCallBzeroSavedRaRetFrame sp base divisorSign dividendAbsWord)
+  let divisorSign := divisor.getLimbN 3 >>> (63 : BitVec 6).toNat
+  fun h =>
+    (((.x18 ↦ᵣ vRa) **
+     (((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ (sp + 32)) ** (.x8 ↦ᵣ resultSign) **
+       (.x10 ↦ᵣ mask) ** (.x7 ↦ᵣ sum3) ** (.x11 ↦ᵣ carry3) **
+       evmStackIs (sp + 32) stackResult) **
+      saveRaDivCallBzeroSavedRaRetFrame sp base divisorSign dividendAbsWord)) h) ∨
+    (((.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12))) **
+     (((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ (sp + 32)) ** (.x8 ↦ᵣ resultSign) **
+       (.x10 ↦ᵣ mask) ** (.x7 ↦ᵣ sum3) ** (.x11 ↦ᵣ carry3) **
+       evmStackIs (sp + 32) stackResult) **
+      saveRaDivCallSavedRaRetFrameNoX9 sp base dividendAbsWord)) h)
 
 theorem sdivExactHandlerPost_unfold {sp vRa base : Word} {dividend divisor : EvmWord}
     {stackResult : List EvmWord} :
@@ -286,7 +292,6 @@ theorem sdivExactHandlerPost_unfold {sp vRa base : Word} {dividend divisor : Evm
        let resultSign :=
          (dividend.getLimbN 3 >>> (63 : BitVec 6).toNat) ^^^
            (divisor.getLimbN 3 >>> (63 : BitVec 6).toNat)
-       let divisorSign := divisor.getLimbN 3 >>> (63 : BitVec 6).toNat
        let mask := (0 : Word) - resultSign
        let divisorAbsWord :=
          sdivAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
@@ -300,11 +305,18 @@ theorem sdivExactHandlerPost_unfold {sp vRa base : Word} {dividend divisor : Evm
        let carry2 := if BitVec.ult sum2 carry1 then (1 : Word) else 0
        let sum3 := ((quotientWord.getLimbN 3) ^^^ mask) + carry2
        let carry3 := if BitVec.ult sum3 carry2 then (1 : Word) else 0
-       (.x18 ↦ᵣ vRa) **
-       (((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ (sp + 32)) ** (.x8 ↦ᵣ resultSign) **
-         (.x10 ↦ᵣ mask) ** (.x7 ↦ᵣ sum3) ** (.x11 ↦ᵣ carry3) **
-         evmStackIs (sp + 32) stackResult) **
-        saveRaDivCallBzeroSavedRaRetFrame sp base divisorSign dividendAbsWord)) := by
+       let divisorSign := divisor.getLimbN 3 >>> (63 : BitVec 6).toNat
+       fun h =>
+        (((.x18 ↦ᵣ vRa) **
+         (((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ (sp + 32)) ** (.x8 ↦ᵣ resultSign) **
+           (.x10 ↦ᵣ mask) ** (.x7 ↦ᵣ sum3) ** (.x11 ↦ᵣ carry3) **
+           evmStackIs (sp + 32) stackResult) **
+          saveRaDivCallBzeroSavedRaRetFrame sp base divisorSign dividendAbsWord)) h) ∨
+        (((.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12))) **
+         (((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ (sp + 32)) ** (.x8 ↦ᵣ resultSign) **
+           (.x10 ↦ᵣ mask) ** (.x7 ↦ᵣ sum3) ** (.x11 ↦ᵣ carry3) **
+           evmStackIs (sp + 32) stackResult) **
+          saveRaDivCallSavedRaRetFrameNoX9 sp base dividendAbsWord)) h)) := by
   delta sdivExactHandlerPost; rfl
 
 /-- Postcondition bundle for zero-divisor SDIV handler path.
@@ -382,7 +394,7 @@ theorem evm_sdiv_zero_divisor_result_stack_spec_within
          (.x7 ↦ᵣ dividendValueOld) ** (.x11 ↦ᵣ dividendCarryOld)) **
         evmStackIs sp (dividend :: (0 : EvmWord) :: rest)) **
        ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
-        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0))
       (sdivZeroDivisorPost sp vRa base dividend ((0 : EvmWord) :: rest)) := by
   rw [sdivZeroDivisorPost_unfold]
@@ -417,7 +429,7 @@ theorem evm_sdiv_zero_divisor_handler_stack_spec_within
          (.x7 ↦ᵣ dividendValueOld) ** (.x11 ↦ᵣ dividendCarryOld)) **
         evmStackIs sp (dividend :: (0 : EvmWord) :: rest)) **
        ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
-        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0))
       (sdivZeroDivisorPost sp vRa base dividend
         (ArithmeticHandlers.sdivHandler
@@ -452,7 +464,7 @@ theorem evm_sdiv_zero_divisor_handler_stack_of_eq_spec_within
          (.x7 ↦ᵣ dividendValueOld) ** (.x11 ↦ᵣ dividendCarryOld)) **
         evmStackIs sp (dividend :: divisor :: rest)) **
        ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
-        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0))
       (sdivZeroDivisorPost sp vRa base dividend
         (ArithmeticHandlers.sdivHandler
@@ -488,7 +500,7 @@ theorem evm_sdiv_zero_divisor_handler_stack_exact_post_of_eq_spec_within
          (.x7 ↦ᵣ dividendValueOld) ** (.x11 ↦ᵣ dividendCarryOld)) **
         evmStackIs sp (dividend :: divisor :: rest)) **
        ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
-        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0))
       (sdivExactHandlerPost sp vRa base dividend divisor
         (ArithmeticHandlers.sdivHandler
@@ -506,7 +518,7 @@ theorem evm_sdiv_zero_divisor_handler_stack_exact_post_of_eq_spec_within
       have hSum3 := sdivResultSign_fixZeroWordLimb3 (dividend.getLimbN 3) (0 : Word)
       simp only [EvmWord.getLimbN_zero] at hSum3
       rw [hSum3] at hp ⊢
-      simpa using hp)
+      exact Or.inl (by simpa using hp))
     (evm_sdiv_zero_divisor_handler_stack_spec_within
       vRa vSavedOld sp sDividendOld sDivisorOld
       dividendMaskOld dividendValueOld dividendCarryOld
@@ -534,12 +546,12 @@ theorem evm_sdiv_exact_callable_return_stack_spec_within
         (base + wrapperEndOff)
         ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
         (EvmAsm.Evm64.divCode_noNop (base + wrapperEndOff))
-        (EvmAsm.Evm64.divModStackDispatchPre sp
+        (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp
           (sdivAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
             (dividend.getLimbN 2) (dividend.getLimbN 3))
           (sdivAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
             (divisor.getLimbN 2) (divisor.getLimbN 3))
-          ((base + divCallOff) + 4) v2 v5 v6
+          (sdivAbsSign (divisor.getLimbN 3)) ((base + divCallOff) + 4) v2 v5 v6
           (sdivAbsSum3 (divisor.getLimbN 0) (divisor.getLimbN 1)
             (divisor.getLimbN 2) (divisor.getLimbN 3))
           (sdivAbsMask (divisor.getLimbN 3))
@@ -547,7 +559,7 @@ theorem evm_sdiv_exact_callable_return_stack_spec_within
             (divisor.getLimbN 2) (divisor.getLimbN 3))
           q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0)
-        (EvmAsm.Evm64.divStackDispatchPostNoX1 sp
+        (EvmAsm.Evm64.divStackDispatchPostCallable sp
           (sdivAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
             (dividend.getLimbN 2) (dividend.getLimbN 3))
           (sdivAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
@@ -561,9 +573,9 @@ theorem evm_sdiv_exact_callable_return_stack_spec_within
          (.x7 ↦ᵣ dividendValueOld) ** (.x11 ↦ᵣ dividendCarryOld)) **
         evmStackIs sp (dividend :: divisor :: rest)) **
        ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
-        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0))
-      (saveRaDivCallCallableReturnPost vRa sp base
+      (saveRaDivCallCallableReturnPostNoX9 vRa sp base
         (dividend.getLimbN 0) (dividend.getLimbN 1)
         (dividend.getLimbN 2) (dividend.getLimbN 3)
         (divisor.getLimbN 0) (divisor.getLimbN 1)
@@ -585,7 +597,7 @@ theorem evm_sdiv_exact_callable_return_stack_spec_within
   exact EvmAsm.Rv64.cpsTripleWithin_weaken (fun h hp => by
       let scratchFrame : EvmAsm.Rv64.Assertion :=
         ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
-         EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
            shiftMem nMem jMem retMem dMem dloMem scratchUn0)
       have h_old :
           ((saveRaSignsAbsSignXorThenDivCallPre
@@ -617,12 +629,12 @@ theorem evm_sdiv_exact_callable_return_sign_fixed_word_stack_spec_within
         (base + wrapperEndOff)
         ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
         (EvmAsm.Evm64.divCode_noNop (base + wrapperEndOff))
-        (EvmAsm.Evm64.divModStackDispatchPre sp
+        (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp
           (sdivAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
             (dividend.getLimbN 2) (dividend.getLimbN 3))
           (sdivAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
             (divisor.getLimbN 2) (divisor.getLimbN 3))
-          ((base + divCallOff) + 4) v2 v5 v6
+          (sdivAbsSign (divisor.getLimbN 3)) ((base + divCallOff) + 4) v2 v5 v6
           (sdivAbsSum3 (divisor.getLimbN 0) (divisor.getLimbN 1)
             (divisor.getLimbN 2) (divisor.getLimbN 3))
           (sdivAbsMask (divisor.getLimbN 3))
@@ -630,7 +642,7 @@ theorem evm_sdiv_exact_callable_return_sign_fixed_word_stack_spec_within
             (divisor.getLimbN 2) (divisor.getLimbN 3))
           q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0)
-        (EvmAsm.Evm64.divStackDispatchPostNoX1 sp
+        (EvmAsm.Evm64.divStackDispatchPostCallable sp
           (sdivAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
             (dividend.getLimbN 2) (dividend.getLimbN 3))
           (sdivAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
@@ -644,16 +656,16 @@ theorem evm_sdiv_exact_callable_return_sign_fixed_word_stack_spec_within
          (.x7 ↦ᵣ dividendValueOld) ** (.x11 ↦ᵣ dividendCarryOld)) **
         evmStackIs sp (dividend :: divisor :: rest)) **
        ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
-        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0))
-      (saveRaDivCallCallableReturnSignFixedWordPost vRa sp base
+      (saveRaDivCallCallableReturnSignFixedWordPostNoX9 vRa sp base
         (dividend.getLimbN 0) (dividend.getLimbN 1)
         (dividend.getLimbN 2) (dividend.getLimbN 3)
         (divisor.getLimbN 0) (divisor.getLimbN 1)
         (divisor.getLimbN 2) (divisor.getLimbN 3) **
        evmStackIs (sp + 64) rest) := by
   exact EvmAsm.Rv64.cpsTripleWithin_weaken (fun _ hp => hp) (fun _ hp => by
-      rw [saveRaDivCallCallableReturnPost_evmWordIs] at hp
+      rw [saveRaDivCallCallableReturnPostNoX9_evmWordIs] at hp
       exact hp)
     (evm_sdiv_exact_callable_return_stack_spec_within
       vRa vSavedOld sp sDividendOld sDivisorOld
@@ -682,12 +694,12 @@ theorem evm_sdiv_exact_return_stack_tail_spec_within
         (base + wrapperEndOff)
         ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
         (EvmAsm.Evm64.divCode_noNop (base + wrapperEndOff))
-        (EvmAsm.Evm64.divModStackDispatchPre sp
+        (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp
           (sdivAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
             (dividend.getLimbN 2) (dividend.getLimbN 3))
           (sdivAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
             (divisor.getLimbN 2) (divisor.getLimbN 3))
-          ((base + divCallOff) + 4) v2 v5 v6
+          (sdivAbsSign (divisor.getLimbN 3)) ((base + divCallOff) + 4) v2 v5 v6
           (sdivAbsSum3 (divisor.getLimbN 0) (divisor.getLimbN 1)
             (divisor.getLimbN 2) (divisor.getLimbN 3))
           (sdivAbsMask (divisor.getLimbN 3))
@@ -695,7 +707,7 @@ theorem evm_sdiv_exact_return_stack_tail_spec_within
             (divisor.getLimbN 2) (divisor.getLimbN 3))
           q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0)
-        (EvmAsm.Evm64.divStackDispatchPostNoX1 sp
+        (EvmAsm.Evm64.divStackDispatchPostCallable sp
           (sdivAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
             (dividend.getLimbN 2) (dividend.getLimbN 3))
           (sdivAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
@@ -709,9 +721,9 @@ theorem evm_sdiv_exact_return_stack_tail_spec_within
          (.x7 ↦ᵣ dividendValueOld) ** (.x11 ↦ᵣ dividendCarryOld)) **
         evmStackIs sp (dividend :: divisor :: rest)) **
        ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
-        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0))
-      (saveRaDivCallCallableReturnPost vRa sp base
+      (saveRaDivCallCallableReturnPostNoX9 vRa sp base
         (dividend.getLimbN 0) (dividend.getLimbN 1)
         (dividend.getLimbN 2) (dividend.getLimbN 3)
         (divisor.getLimbN 0) (divisor.getLimbN 1)
@@ -743,12 +755,12 @@ theorem evm_sdiv_exact_return_result_stack_spec_within
         (base + wrapperEndOff)
         ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
         (EvmAsm.Evm64.divCode_noNop (base + wrapperEndOff))
-        (EvmAsm.Evm64.divModStackDispatchPre sp
+        (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp
           (sdivAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
             (dividend.getLimbN 2) (dividend.getLimbN 3))
           (sdivAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
             (divisor.getLimbN 2) (divisor.getLimbN 3))
-          ((base + divCallOff) + 4) v2 v5 v6
+          (sdivAbsSign (divisor.getLimbN 3)) ((base + divCallOff) + 4) v2 v5 v6
           (sdivAbsSum3 (divisor.getLimbN 0) (divisor.getLimbN 1)
             (divisor.getLimbN 2) (divisor.getLimbN 3))
           (sdivAbsMask (divisor.getLimbN 3))
@@ -756,7 +768,7 @@ theorem evm_sdiv_exact_return_result_stack_spec_within
             (divisor.getLimbN 2) (divisor.getLimbN 3))
           q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0)
-        (EvmAsm.Evm64.divStackDispatchPostNoX1 sp
+        (EvmAsm.Evm64.divStackDispatchPostCallable sp
           (sdivAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
             (dividend.getLimbN 2) (dividend.getLimbN 3))
           (sdivAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
@@ -770,7 +782,7 @@ theorem evm_sdiv_exact_return_result_stack_spec_within
          (.x7 ↦ᵣ dividendValueOld) ** (.x11 ↦ᵣ dividendCarryOld)) **
         evmStackIs sp (dividend :: divisor :: rest)) **
        ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
-        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0))
       (let dividendAbsWord :=
          sdivAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
@@ -786,7 +798,6 @@ theorem evm_sdiv_exact_return_result_stack_spec_within
        let resultSign :=
          (dividend.getLimbN 3 >>> (63 : BitVec 6).toNat) ^^^
            (divisor.getLimbN 3 >>> (63 : BitVec 6).toNat)
-       let divisorSign := divisor.getLimbN 3 >>> (63 : BitVec 6).toNat
        let mask := (0 : Word) - resultSign
        let sum0 := ((quotientWord.getLimbN 0) ^^^ mask) + resultSign
        let carry0 := if BitVec.ult sum0 resultSign then (1 : Word) else 0
@@ -796,13 +807,13 @@ theorem evm_sdiv_exact_return_result_stack_spec_within
        let carry2 := if BitVec.ult sum2 carry1 then (1 : Word) else 0
        let sum3 := ((quotientWord.getLimbN 3) ^^^ mask) + carry2
        let carry3 := if BitVec.ult sum3 carry2 then (1 : Word) else 0
-       (.x18 ↦ᵣ vRa) **
+       (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12))) **
        (((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ (sp + 32)) ** (.x8 ↦ᵣ resultSign) **
          (.x10 ↦ᵣ mask) ** (.x7 ↦ᵣ sum3) ** (.x11 ↦ᵣ carry3) **
          evmStackIs (sp + 32) (resultWord :: rest)) **
-        saveRaDivCallBzeroSavedRaRetFrame sp base divisorSign dividendAbsWord)) := by
+        saveRaDivCallSavedRaRetFrameNoX9 sp base dividendAbsWord)) := by
   exact EvmAsm.Rv64.cpsTripleWithin_weaken (fun _ hp => hp) (fun h hp => by
-      rw [saveRaDivCallCallableReturnPost_unfold] at hp
+      rw [saveRaDivCallCallableReturnPostNoX9_unfold] at hp
       dsimp only at hp ⊢
       rw [resultSignFixPost_sdivResultSign_word
         (sp + 32) (dividend.getLimbN 3) (divisor.getLimbN 3)
@@ -855,12 +866,12 @@ theorem evm_sdiv_exact_return_handler_stack_of_result_eq_spec_within
         (base + wrapperEndOff)
         ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
         (EvmAsm.Evm64.divCode_noNop (base + wrapperEndOff))
-        (EvmAsm.Evm64.divModStackDispatchPre sp
+        (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp
           (sdivAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
             (dividend.getLimbN 2) (dividend.getLimbN 3))
           (sdivAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
             (divisor.getLimbN 2) (divisor.getLimbN 3))
-          ((base + divCallOff) + 4) v2 v5 v6
+          (sdivAbsSign (divisor.getLimbN 3)) ((base + divCallOff) + 4) v2 v5 v6
           (sdivAbsSum3 (divisor.getLimbN 0) (divisor.getLimbN 1)
             (divisor.getLimbN 2) (divisor.getLimbN 3))
           (sdivAbsMask (divisor.getLimbN 3))
@@ -868,7 +879,7 @@ theorem evm_sdiv_exact_return_handler_stack_of_result_eq_spec_within
             (divisor.getLimbN 2) (divisor.getLimbN 3))
           q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0)
-        (EvmAsm.Evm64.divStackDispatchPostNoX1 sp
+        (EvmAsm.Evm64.divStackDispatchPostCallable sp
           (sdivAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
             (dividend.getLimbN 2) (dividend.getLimbN 3))
           (sdivAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
@@ -894,7 +905,7 @@ theorem evm_sdiv_exact_return_handler_stack_of_result_eq_spec_within
          (.x7 ↦ᵣ dividendValueOld) ** (.x11 ↦ᵣ dividendCarryOld)) **
         evmStackIs sp (dividend :: divisor :: rest)) **
        ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
-        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0))
       (sdivExactHandlerPost sp vRa base dividend divisor
         (ArithmeticHandlers.sdivHandler
@@ -902,7 +913,7 @@ theorem evm_sdiv_exact_return_handler_stack_of_result_eq_spec_within
   exact EvmAsm.Rv64.cpsTripleWithin_weaken (fun _ hp => hp) (fun _ hp => by
       rw [hResult] at hp
       rw [sdivExactHandlerPost_unfold]
-      simpa using hp)
+      exact Or.inr (by simpa using hp))
     (evm_sdiv_exact_return_result_stack_spec_within
       vRa vSavedOld sp sDividendOld sDivisorOld
       dividendMaskOld dividendValueOld dividendCarryOld
@@ -925,12 +936,12 @@ theorem evm_sdiv_exact_return_handler_stack_spec_within
         (base + wrapperEndOff)
         ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
         (EvmAsm.Evm64.divCode_noNop (base + wrapperEndOff))
-        (EvmAsm.Evm64.divModStackDispatchPre sp
+        (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp
           (sdivAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
             (dividend.getLimbN 2) (dividend.getLimbN 3))
           (sdivAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
             (divisor.getLimbN 2) (divisor.getLimbN 3))
-          ((base + divCallOff) + 4) v2 v5 v6
+          (sdivAbsSign (divisor.getLimbN 3)) ((base + divCallOff) + 4) v2 v5 v6
           (sdivAbsSum3 (divisor.getLimbN 0) (divisor.getLimbN 1)
             (divisor.getLimbN 2) (divisor.getLimbN 3))
           (sdivAbsMask (divisor.getLimbN 3))
@@ -938,7 +949,7 @@ theorem evm_sdiv_exact_return_handler_stack_spec_within
             (divisor.getLimbN 2) (divisor.getLimbN 3))
           q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0)
-        (EvmAsm.Evm64.divStackDispatchPostNoX1 sp
+        (EvmAsm.Evm64.divStackDispatchPostCallable sp
           (sdivAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
             (dividend.getLimbN 2) (dividend.getLimbN 3))
           (sdivAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
@@ -952,7 +963,7 @@ theorem evm_sdiv_exact_return_handler_stack_spec_within
          (.x7 ↦ᵣ dividendValueOld) ** (.x11 ↦ᵣ dividendCarryOld)) **
         evmStackIs sp (dividend :: divisor :: rest)) **
        ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
-        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0))
       (sdivExactHandlerPost sp vRa base dividend divisor
         (ArithmeticHandlers.sdivHandler
@@ -983,12 +994,12 @@ theorem evm_sdiv_handler_stack_spec_within
         (base + wrapperEndOff)
         ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
         (EvmAsm.Evm64.divCode_noNop (base + wrapperEndOff))
-        (EvmAsm.Evm64.divModStackDispatchPre sp
+        (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp
           (sdivAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
             (dividend.getLimbN 2) (dividend.getLimbN 3))
           (sdivAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
             (divisor.getLimbN 2) (divisor.getLimbN 3))
-          ((base + divCallOff) + 4) v2 v5 v6
+          (sdivAbsSign (divisor.getLimbN 3)) ((base + divCallOff) + 4) v2 v5 v6
           (sdivAbsSum3 (divisor.getLimbN 0) (divisor.getLimbN 1)
             (divisor.getLimbN 2) (divisor.getLimbN 3))
           (sdivAbsMask (divisor.getLimbN 3))
@@ -996,7 +1007,7 @@ theorem evm_sdiv_handler_stack_spec_within
             (divisor.getLimbN 2) (divisor.getLimbN 3))
           q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0)
-        (EvmAsm.Evm64.divStackDispatchPostNoX1 sp
+        (EvmAsm.Evm64.divStackDispatchPostCallable sp
           (sdivAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
             (dividend.getLimbN 2) (dividend.getLimbN 3))
           (sdivAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
@@ -1010,7 +1021,7 @@ theorem evm_sdiv_handler_stack_spec_within
          (.x7 ↦ᵣ dividendValueOld) ** (.x11 ↦ᵣ dividendCarryOld)) **
         evmStackIs sp (dividend :: divisor :: rest)) **
        ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
-        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0))
       (sdivExactHandlerPost sp vRa base dividend divisor
         (ArithmeticHandlers.sdivHandler
@@ -1065,12 +1076,12 @@ theorem evm_sdiv_exact_callable_return_result_stack_spec_within
         (base + wrapperEndOff)
         ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
         (EvmAsm.Evm64.divCode_noNop (base + wrapperEndOff))
-        (EvmAsm.Evm64.divModStackDispatchPre sp
+        (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp
           (sdivAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
             (dividend.getLimbN 2) (dividend.getLimbN 3))
           (sdivAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
             (divisor.getLimbN 2) (divisor.getLimbN 3))
-          ((base + divCallOff) + 4) v2 v5 v6
+          (sdivAbsSign (divisor.getLimbN 3)) ((base + divCallOff) + 4) v2 v5 v6
           (sdivAbsSum3 (divisor.getLimbN 0) (divisor.getLimbN 1)
             (divisor.getLimbN 2) (divisor.getLimbN 3))
           (sdivAbsMask (divisor.getLimbN 3))
@@ -1078,7 +1089,7 @@ theorem evm_sdiv_exact_callable_return_result_stack_spec_within
             (divisor.getLimbN 2) (divisor.getLimbN 3))
           q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0)
-        (EvmAsm.Evm64.divStackDispatchPostNoX1 sp
+        (EvmAsm.Evm64.divStackDispatchPostCallable sp
           (sdivAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
             (dividend.getLimbN 2) (dividend.getLimbN 3))
           (sdivAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
@@ -1092,7 +1103,7 @@ theorem evm_sdiv_exact_callable_return_result_stack_spec_within
          (.x7 ↦ᵣ dividendValueOld) ** (.x11 ↦ᵣ dividendCarryOld)) **
         evmStackIs sp (dividend :: divisor :: rest)) **
        ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
-        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0))
       (let dividendAbsWord :=
          sdivAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
@@ -1104,7 +1115,6 @@ theorem evm_sdiv_exact_callable_return_result_stack_spec_within
        let resultSign :=
          (dividend.getLimbN 3 >>> (63 : BitVec 6).toNat) ^^^
            (divisor.getLimbN 3 >>> (63 : BitVec 6).toNat)
-       let divisorSign := divisor.getLimbN 3 >>> (63 : BitVec 6).toNat
        let resultWord :=
          sdivSignFixedWord resultSign
            (quotientWord.getLimbN 0) (quotientWord.getLimbN 1)
@@ -1118,13 +1128,13 @@ theorem evm_sdiv_exact_callable_return_result_stack_spec_within
        let carry2 := if BitVec.ult sum2 carry1 then (1 : Word) else 0
        let sum3 := (quotientWord.getLimbN 3 ^^^ mask) + carry2
        let carry3 := if BitVec.ult sum3 carry2 then (1 : Word) else 0
-       (.x18 ↦ᵣ vRa) **
+       (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12))) **
        (((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ (sp + 32)) ** (.x8 ↦ᵣ resultSign) **
          (.x10 ↦ᵣ mask) ** (.x7 ↦ᵣ sum3) ** (.x11 ↦ᵣ carry3) **
          evmStackIs (sp + 32) (resultWord :: rest)) **
-        saveRaDivCallBzeroSavedRaRetFrame sp base divisorSign dividendAbsWord)) := by
+        saveRaDivCallSavedRaRetFrameNoX9 sp base dividendAbsWord)) := by
   exact EvmAsm.Rv64.cpsTripleWithin_weaken (fun _ hp => hp) (fun _ hp => by
-      rw [saveRaDivCallCallableReturnSignFixedWordPost_unfold] at hp
+      rw [saveRaDivCallCallableReturnSignFixedWordPostNoX9_unfold] at hp
       dsimp only at hp ⊢
       rw [evmStackIs_cons]
       rw [show (sp + 32 + 32 : Word) = sp + 64 by bv_addr]
@@ -1151,12 +1161,12 @@ theorem evm_sdiv_exact_callable_return_result_sign_branch_stack_spec_within
         (base + wrapperEndOff)
         ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
         (EvmAsm.Evm64.divCode_noNop (base + wrapperEndOff))
-        (EvmAsm.Evm64.divModStackDispatchPre sp
+        (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp
           (sdivAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
             (dividend.getLimbN 2) (dividend.getLimbN 3))
           (sdivAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
             (divisor.getLimbN 2) (divisor.getLimbN 3))
-          ((base + divCallOff) + 4) v2 v5 v6
+          (sdivAbsSign (divisor.getLimbN 3)) ((base + divCallOff) + 4) v2 v5 v6
           (sdivAbsSum3 (divisor.getLimbN 0) (divisor.getLimbN 1)
             (divisor.getLimbN 2) (divisor.getLimbN 3))
           (sdivAbsMask (divisor.getLimbN 3))
@@ -1164,7 +1174,7 @@ theorem evm_sdiv_exact_callable_return_result_sign_branch_stack_spec_within
             (divisor.getLimbN 2) (divisor.getLimbN 3))
           q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0)
-        (EvmAsm.Evm64.divStackDispatchPostNoX1 sp
+        (EvmAsm.Evm64.divStackDispatchPostCallable sp
           (sdivAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
             (dividend.getLimbN 2) (dividend.getLimbN 3))
           (sdivAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
@@ -1178,7 +1188,7 @@ theorem evm_sdiv_exact_callable_return_result_sign_branch_stack_spec_within
          (.x7 ↦ᵣ dividendValueOld) ** (.x11 ↦ᵣ dividendCarryOld)) **
         evmStackIs sp (dividend :: divisor :: rest)) **
        ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
-        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0))
       (let dividendAbsWord :=
          sdivAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
@@ -1190,7 +1200,6 @@ theorem evm_sdiv_exact_callable_return_result_sign_branch_stack_spec_within
        let resultSign :=
          (dividend.getLimbN 3 >>> (63 : BitVec 6).toNat) ^^^
            (divisor.getLimbN 3 >>> (63 : BitVec 6).toNat)
-       let divisorSign := divisor.getLimbN 3 >>> (63 : BitVec 6).toNat
        let resultWord :=
          if resultSign = 0 then quotientWord else ~~~quotientWord + 1
        let mask := (0 : Word) - resultSign
@@ -1202,11 +1211,11 @@ theorem evm_sdiv_exact_callable_return_result_sign_branch_stack_spec_within
        let carry2 := if BitVec.ult sum2 carry1 then (1 : Word) else 0
        let sum3 := (quotientWord.getLimbN 3 ^^^ mask) + carry2
        let carry3 := if BitVec.ult sum3 carry2 then (1 : Word) else 0
-       (.x18 ↦ᵣ vRa) **
+       (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12))) **
        (((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ (sp + 32)) ** (.x8 ↦ᵣ resultSign) **
          (.x10 ↦ᵣ mask) ** (.x7 ↦ᵣ sum3) ** (.x11 ↦ᵣ carry3) **
          evmStackIs (sp + 32) (resultWord :: rest)) **
-        saveRaDivCallBzeroSavedRaRetFrame sp base divisorSign dividendAbsWord)) := by
+        saveRaDivCallSavedRaRetFrameNoX9 sp base dividendAbsWord)) := by
   exact EvmAsm.Rv64.cpsTripleWithin_weaken (fun _ hp => hp) (fun _ hp => by
       rw [EvmAsm.Evm64.SDiv.Compose.sdivSignFixedWord_result_sign (dividend.getLimbN 3)
         (divisor.getLimbN 3)] at hp
@@ -1233,12 +1242,12 @@ theorem evm_sdiv_exact_callable_return_sign_bit_branch_stack_spec_within
         (base + wrapperEndOff)
         ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
         (EvmAsm.Evm64.divCode_noNop (base + wrapperEndOff))
-        (EvmAsm.Evm64.divModStackDispatchPre sp
+        (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp
           (sdivAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
             (dividend.getLimbN 2) (dividend.getLimbN 3))
           (sdivAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
             (divisor.getLimbN 2) (divisor.getLimbN 3))
-          ((base + divCallOff) + 4) v2 v5 v6
+          (sdivAbsSign (divisor.getLimbN 3)) ((base + divCallOff) + 4) v2 v5 v6
           (sdivAbsSum3 (divisor.getLimbN 0) (divisor.getLimbN 1)
             (divisor.getLimbN 2) (divisor.getLimbN 3))
           (sdivAbsMask (divisor.getLimbN 3))
@@ -1246,7 +1255,7 @@ theorem evm_sdiv_exact_callable_return_sign_bit_branch_stack_spec_within
             (divisor.getLimbN 2) (divisor.getLimbN 3))
           q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0)
-        (EvmAsm.Evm64.divStackDispatchPostNoX1 sp
+        (EvmAsm.Evm64.divStackDispatchPostCallable sp
           (sdivAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
             (dividend.getLimbN 2) (dividend.getLimbN 3))
           (sdivAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
@@ -1260,7 +1269,7 @@ theorem evm_sdiv_exact_callable_return_sign_bit_branch_stack_spec_within
          (.x7 ↦ᵣ dividendValueOld) ** (.x11 ↦ᵣ dividendCarryOld)) **
         evmStackIs sp (dividend :: divisor :: rest)) **
        ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
-        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0))
       (let dividendAbsWord :=
          sdivAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
@@ -1272,7 +1281,6 @@ theorem evm_sdiv_exact_callable_return_sign_bit_branch_stack_spec_within
        let resultSign :=
          (dividend.getLimbN 3 >>> (63 : BitVec 6).toNat) ^^^
            (divisor.getLimbN 3 >>> (63 : BitVec 6).toNat)
-       let divisorSign := divisor.getLimbN 3 >>> (63 : BitVec 6).toNat
        let resultWord :=
          if dividend.getLimbN 3 >>> (63 : BitVec 6).toNat =
              divisor.getLimbN 3 >>> (63 : BitVec 6).toNat then
@@ -1288,11 +1296,11 @@ theorem evm_sdiv_exact_callable_return_sign_bit_branch_stack_spec_within
        let carry2 := if BitVec.ult sum2 carry1 then (1 : Word) else 0
        let sum3 := (quotientWord.getLimbN 3 ^^^ mask) + carry2
        let carry3 := if BitVec.ult sum3 carry2 then (1 : Word) else 0
-       (.x18 ↦ᵣ vRa) **
+       (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12))) **
        (((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ (sp + 32)) ** (.x8 ↦ᵣ resultSign) **
          (.x10 ↦ᵣ mask) ** (.x7 ↦ᵣ sum3) ** (.x11 ↦ᵣ carry3) **
          evmStackIs (sp + 32) (resultWord :: rest)) **
-        saveRaDivCallBzeroSavedRaRetFrame sp base divisorSign dividendAbsWord)) := by
+        saveRaDivCallSavedRaRetFrameNoX9 sp base dividendAbsWord)) := by
   exact EvmAsm.Rv64.cpsTripleWithin_weaken (fun _ hp => hp) (fun _ hp => by
       by_cases h_sign :
           dividend.getLimbN 3 >>> (63 : BitVec 6).toNat =
@@ -1326,12 +1334,12 @@ theorem evm_sdiv_exact_callable_return_result_sign_zero_stack_spec_within
         (base + wrapperEndOff)
         ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
         (EvmAsm.Evm64.divCode_noNop (base + wrapperEndOff))
-        (EvmAsm.Evm64.divModStackDispatchPre sp
+        (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp
           (sdivAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
             (dividend.getLimbN 2) (dividend.getLimbN 3))
           (sdivAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
             (divisor.getLimbN 2) (divisor.getLimbN 3))
-          ((base + divCallOff) + 4) v2 v5 v6
+          (sdivAbsSign (divisor.getLimbN 3)) ((base + divCallOff) + 4) v2 v5 v6
           (sdivAbsSum3 (divisor.getLimbN 0) (divisor.getLimbN 1)
             (divisor.getLimbN 2) (divisor.getLimbN 3))
           (sdivAbsMask (divisor.getLimbN 3))
@@ -1339,7 +1347,7 @@ theorem evm_sdiv_exact_callable_return_result_sign_zero_stack_spec_within
             (divisor.getLimbN 2) (divisor.getLimbN 3))
           q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0)
-        (EvmAsm.Evm64.divStackDispatchPostNoX1 sp
+        (EvmAsm.Evm64.divStackDispatchPostCallable sp
           (sdivAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
             (dividend.getLimbN 2) (dividend.getLimbN 3))
           (sdivAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
@@ -1353,7 +1361,7 @@ theorem evm_sdiv_exact_callable_return_result_sign_zero_stack_spec_within
          (.x7 ↦ᵣ dividendValueOld) ** (.x11 ↦ᵣ dividendCarryOld)) **
         evmStackIs sp (dividend :: divisor :: rest)) **
        ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
-        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0))
       (let dividendAbsWord :=
          sdivAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
@@ -1365,7 +1373,6 @@ theorem evm_sdiv_exact_callable_return_result_sign_zero_stack_spec_within
        let resultSign :=
          (dividend.getLimbN 3 >>> (63 : BitVec 6).toNat) ^^^
            (divisor.getLimbN 3 >>> (63 : BitVec 6).toNat)
-       let divisorSign := divisor.getLimbN 3 >>> (63 : BitVec 6).toNat
        let mask := (0 : Word) - resultSign
        let sum0 := (quotientWord.getLimbN 0 ^^^ mask) + resultSign
        let carry0 := if BitVec.ult sum0 resultSign then (1 : Word) else 0
@@ -1375,11 +1382,11 @@ theorem evm_sdiv_exact_callable_return_result_sign_zero_stack_spec_within
        let carry2 := if BitVec.ult sum2 carry1 then (1 : Word) else 0
        let sum3 := (quotientWord.getLimbN 3 ^^^ mask) + carry2
        let carry3 := if BitVec.ult sum3 carry2 then (1 : Word) else 0
-       (.x18 ↦ᵣ vRa) **
+       (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12))) **
        (((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ (sp + 32)) ** (.x8 ↦ᵣ resultSign) **
          (.x10 ↦ᵣ mask) ** (.x7 ↦ᵣ sum3) ** (.x11 ↦ᵣ carry3) **
          evmStackIs (sp + 32) (quotientWord :: rest)) **
-        saveRaDivCallBzeroSavedRaRetFrame sp base divisorSign dividendAbsWord)) := by
+        saveRaDivCallSavedRaRetFrameNoX9 sp base dividendAbsWord)) := by
   exact EvmAsm.Rv64.cpsTripleWithin_weaken (fun _ hp => hp) (fun _ hp => by
       rw [hResultSign] at hp ⊢
       simp at hp ⊢
@@ -1409,12 +1416,12 @@ theorem evm_sdiv_exact_callable_return_same_sign_stack_spec_within
         (base + wrapperEndOff)
         ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
         (EvmAsm.Evm64.divCode_noNop (base + wrapperEndOff))
-        (EvmAsm.Evm64.divModStackDispatchPre sp
+        (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp
           (sdivAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
             (dividend.getLimbN 2) (dividend.getLimbN 3))
           (sdivAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
             (divisor.getLimbN 2) (divisor.getLimbN 3))
-          ((base + divCallOff) + 4) v2 v5 v6
+          (sdivAbsSign (divisor.getLimbN 3)) ((base + divCallOff) + 4) v2 v5 v6
           (sdivAbsSum3 (divisor.getLimbN 0) (divisor.getLimbN 1)
             (divisor.getLimbN 2) (divisor.getLimbN 3))
           (sdivAbsMask (divisor.getLimbN 3))
@@ -1422,7 +1429,7 @@ theorem evm_sdiv_exact_callable_return_same_sign_stack_spec_within
             (divisor.getLimbN 2) (divisor.getLimbN 3))
           q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0)
-        (EvmAsm.Evm64.divStackDispatchPostNoX1 sp
+        (EvmAsm.Evm64.divStackDispatchPostCallable sp
           (sdivAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
             (dividend.getLimbN 2) (dividend.getLimbN 3))
           (sdivAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
@@ -1436,7 +1443,7 @@ theorem evm_sdiv_exact_callable_return_same_sign_stack_spec_within
          (.x7 ↦ᵣ dividendValueOld) ** (.x11 ↦ᵣ dividendCarryOld)) **
         evmStackIs sp (dividend :: divisor :: rest)) **
        ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
-        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0))
       (let dividendAbsWord :=
          sdivAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
@@ -1448,7 +1455,6 @@ theorem evm_sdiv_exact_callable_return_same_sign_stack_spec_within
        let resultSign :=
          (dividend.getLimbN 3 >>> (63 : BitVec 6).toNat) ^^^
            (divisor.getLimbN 3 >>> (63 : BitVec 6).toNat)
-       let divisorSign := divisor.getLimbN 3 >>> (63 : BitVec 6).toNat
        let mask := (0 : Word) - resultSign
        let sum0 := (quotientWord.getLimbN 0 ^^^ mask) + resultSign
        let carry0 := if BitVec.ult sum0 resultSign then (1 : Word) else 0
@@ -1458,11 +1464,11 @@ theorem evm_sdiv_exact_callable_return_same_sign_stack_spec_within
        let carry2 := if BitVec.ult sum2 carry1 then (1 : Word) else 0
        let sum3 := (quotientWord.getLimbN 3 ^^^ mask) + carry2
        let carry3 := if BitVec.ult sum3 carry2 then (1 : Word) else 0
-       (.x18 ↦ᵣ vRa) **
+       (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12))) **
        (((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ (sp + 32)) ** (.x8 ↦ᵣ resultSign) **
          (.x10 ↦ᵣ mask) ** (.x7 ↦ᵣ sum3) ** (.x11 ↦ᵣ carry3) **
          evmStackIs (sp + 32) (quotientWord :: rest)) **
-        saveRaDivCallBzeroSavedRaRetFrame sp base divisorSign dividendAbsWord)) :=
+        saveRaDivCallSavedRaRetFrameNoX9 sp base dividendAbsWord)) :=
   evm_sdiv_exact_callable_return_result_sign_zero_stack_spec_within
     vRa vSavedOld sp sDividendOld sDivisorOld
     dividendMaskOld dividendValueOld dividendCarryOld
@@ -1489,12 +1495,12 @@ theorem evm_sdiv_exact_callable_return_result_sign_one_stack_spec_within
         (base + wrapperEndOff)
         ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
         (EvmAsm.Evm64.divCode_noNop (base + wrapperEndOff))
-        (EvmAsm.Evm64.divModStackDispatchPre sp
+        (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp
           (sdivAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
             (dividend.getLimbN 2) (dividend.getLimbN 3))
           (sdivAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
             (divisor.getLimbN 2) (divisor.getLimbN 3))
-          ((base + divCallOff) + 4) v2 v5 v6
+          (sdivAbsSign (divisor.getLimbN 3)) ((base + divCallOff) + 4) v2 v5 v6
           (sdivAbsSum3 (divisor.getLimbN 0) (divisor.getLimbN 1)
             (divisor.getLimbN 2) (divisor.getLimbN 3))
           (sdivAbsMask (divisor.getLimbN 3))
@@ -1502,7 +1508,7 @@ theorem evm_sdiv_exact_callable_return_result_sign_one_stack_spec_within
             (divisor.getLimbN 2) (divisor.getLimbN 3))
           q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0)
-        (EvmAsm.Evm64.divStackDispatchPostNoX1 sp
+        (EvmAsm.Evm64.divStackDispatchPostCallable sp
           (sdivAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
             (dividend.getLimbN 2) (dividend.getLimbN 3))
           (sdivAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
@@ -1516,7 +1522,7 @@ theorem evm_sdiv_exact_callable_return_result_sign_one_stack_spec_within
          (.x7 ↦ᵣ dividendValueOld) ** (.x11 ↦ᵣ dividendCarryOld)) **
         evmStackIs sp (dividend :: divisor :: rest)) **
        ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
-        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0))
       (let dividendAbsWord :=
          sdivAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
@@ -1528,7 +1534,6 @@ theorem evm_sdiv_exact_callable_return_result_sign_one_stack_spec_within
        let resultSign :=
          (dividend.getLimbN 3 >>> (63 : BitVec 6).toNat) ^^^
            (divisor.getLimbN 3 >>> (63 : BitVec 6).toNat)
-       let divisorSign := divisor.getLimbN 3 >>> (63 : BitVec 6).toNat
        let mask := (0 : Word) - resultSign
        let sum0 := (quotientWord.getLimbN 0 ^^^ mask) + resultSign
        let carry0 := if BitVec.ult sum0 resultSign then (1 : Word) else 0
@@ -1538,11 +1543,11 @@ theorem evm_sdiv_exact_callable_return_result_sign_one_stack_spec_within
        let carry2 := if BitVec.ult sum2 carry1 then (1 : Word) else 0
        let sum3 := (quotientWord.getLimbN 3 ^^^ mask) + carry2
        let carry3 := if BitVec.ult sum3 carry2 then (1 : Word) else 0
-       (.x18 ↦ᵣ vRa) **
+       (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12))) **
        (((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ (sp + 32)) ** (.x8 ↦ᵣ resultSign) **
          (.x10 ↦ᵣ mask) ** (.x7 ↦ᵣ sum3) ** (.x11 ↦ᵣ carry3) **
          evmStackIs (sp + 32) ((~~~quotientWord + 1) :: rest)) **
-        saveRaDivCallBzeroSavedRaRetFrame sp base divisorSign dividendAbsWord)) := by
+        saveRaDivCallSavedRaRetFrameNoX9 sp base dividendAbsWord)) := by
   exact EvmAsm.Rv64.cpsTripleWithin_weaken (fun _ hp => hp) (fun _ hp => by
       rw [hResultSign] at hp ⊢
       simp at hp ⊢
@@ -1572,12 +1577,12 @@ theorem evm_sdiv_exact_callable_return_opposite_sign_stack_spec_within
         (base + wrapperEndOff)
         ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
         (EvmAsm.Evm64.divCode_noNop (base + wrapperEndOff))
-        (EvmAsm.Evm64.divModStackDispatchPre sp
+        (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp
           (sdivAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
             (dividend.getLimbN 2) (dividend.getLimbN 3))
           (sdivAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
             (divisor.getLimbN 2) (divisor.getLimbN 3))
-          ((base + divCallOff) + 4) v2 v5 v6
+          (sdivAbsSign (divisor.getLimbN 3)) ((base + divCallOff) + 4) v2 v5 v6
           (sdivAbsSum3 (divisor.getLimbN 0) (divisor.getLimbN 1)
             (divisor.getLimbN 2) (divisor.getLimbN 3))
           (sdivAbsMask (divisor.getLimbN 3))
@@ -1585,7 +1590,7 @@ theorem evm_sdiv_exact_callable_return_opposite_sign_stack_spec_within
             (divisor.getLimbN 2) (divisor.getLimbN 3))
           q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0)
-        (EvmAsm.Evm64.divStackDispatchPostNoX1 sp
+        (EvmAsm.Evm64.divStackDispatchPostCallable sp
           (sdivAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
             (dividend.getLimbN 2) (dividend.getLimbN 3))
           (sdivAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
@@ -1599,7 +1604,7 @@ theorem evm_sdiv_exact_callable_return_opposite_sign_stack_spec_within
          (.x7 ↦ᵣ dividendValueOld) ** (.x11 ↦ᵣ dividendCarryOld)) **
         evmStackIs sp (dividend :: divisor :: rest)) **
        ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
-        EvmAsm.Evm64.divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0))
       (let dividendAbsWord :=
          sdivAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
@@ -1611,7 +1616,6 @@ theorem evm_sdiv_exact_callable_return_opposite_sign_stack_spec_within
        let resultSign :=
          (dividend.getLimbN 3 >>> (63 : BitVec 6).toNat) ^^^
            (divisor.getLimbN 3 >>> (63 : BitVec 6).toNat)
-       let divisorSign := divisor.getLimbN 3 >>> (63 : BitVec 6).toNat
        let mask := (0 : Word) - resultSign
        let sum0 := (quotientWord.getLimbN 0 ^^^ mask) + resultSign
        let carry0 := if BitVec.ult sum0 resultSign then (1 : Word) else 0
@@ -1621,11 +1625,11 @@ theorem evm_sdiv_exact_callable_return_opposite_sign_stack_spec_within
        let carry2 := if BitVec.ult sum2 carry1 then (1 : Word) else 0
        let sum3 := (quotientWord.getLimbN 3 ^^^ mask) + carry2
        let carry3 := if BitVec.ult sum3 carry2 then (1 : Word) else 0
-       (.x18 ↦ᵣ vRa) **
+       (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12))) **
        (((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ (sp + 32)) ** (.x8 ↦ᵣ resultSign) **
          (.x10 ↦ᵣ mask) ** (.x7 ↦ᵣ sum3) ** (.x11 ↦ᵣ carry3) **
          evmStackIs (sp + 32) ((~~~quotientWord + 1) :: rest)) **
-        saveRaDivCallBzeroSavedRaRetFrame sp base divisorSign dividendAbsWord)) :=
+        saveRaDivCallSavedRaRetFrameNoX9 sp base dividendAbsWord)) :=
   evm_sdiv_exact_callable_return_result_sign_one_stack_spec_within
     vRa vSavedOld sp sDividendOld sDivisorOld
     dividendMaskOld dividendValueOld dividendCarryOld


### PR DESCRIPTION
## Summary
- rename the DIV loop counter away from x1 to x9 through DivMod programs and proofs
- add callable NoX1 scratch/pre/post surfaces so SDIV can call DIV without clobbering the return address
- thread no-x9 exact return/result-sign-fix postconditions through SDIV while keeping the public return PC normalized

## Verification
- lake build EvmAsm.Evm64.SDiv.Spec
- lake build

Bead: evm-asm-01uh.1