### PR TITLE
feat(exp): compose fixed reload-save prefix

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBaseTwoMulFixedIter.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBaseTwoMulFixedIter.lean
@@ -335,6 +335,50 @@ theorem exp_msb_bit_test_fixed_skip_then_save_expIterBodyFullMsbSavedBitTwoMulFi
     (fun _ hp => by xperm_hyp hp)
     hSeq
 
+/-- Fixed x19 reload bit-test path followed by the saved-bit store. -/
+theorem exp_msb_bit_test_fixed_reload_then_save_expIterBodyFullMsbSavedBitTwoMulFixedCode_spec_within
+    (e c6 v10 v18 ptr nextLimb : Word)
+    (squaringMulOff condMulOff : BitVec 21) (skipOff backOff : BitVec 13)
+    (base : Word)
+    (hc6 : c6 + signExtend12 (-1 : BitVec 12) = 0) :
+    let bit := e >>> (63 : BitVec 6).toNat
+    cpsTripleWithin (7 + 1) base (base + 32)
+      (expIterBodyFullMsbSavedBitTwoMulFixedCode
+        base squaringMulOff condMulOff skipOff backOff)
+      ((.x19 ↦ᵣ e) ** (.x6 ↦ᵣ c6) ** (.x10 ↦ᵣ v10) **
+       (.x18 ↦ᵣ v18) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x16 ↦ᵣ ptr) ** ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb))
+      ((.x19 ↦ᵣ nextLimb) **
+       (.x6 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
+       (.x10 ↦ᵣ bit) ** (.x0 ↦ᵣ (0 : Word)) **
+       ⌜c6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
+       (.x16 ↦ᵣ (ptr + signExtend12 (-8 : BitVec 12))) **
+       ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
+       (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12)))) := by
+  intro bit
+  have hBit :=
+    exp_msb_bit_test_block_fixed_reload_expIterBodyFullMsbSavedBitTwoMulFixedCode_spec_within
+      e c6 v10 ptr nextLimb squaringMulOff condMulOff skipOff backOff base hc6
+  have hBitFramed :=
+    cpsTripleWithin_frameR (.x18 ↦ᵣ v18) (by pcFree) hBit
+  have hSave :=
+    exp_save_bit_expIterBodyFullMsbSavedBitTwoMulFixedCode_spec_within
+      bit v18 squaringMulOff condMulOff skipOff backOff base
+  have hSaveFramed := cpsTripleWithin_frameL
+    ((.x19 ↦ᵣ nextLimb) **
+     (.x6 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
+     (.x0 ↦ᵣ (0 : Word)) **
+     ⌜c6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
+     (.x16 ↦ᵣ (ptr + signExtend12 (-8 : BitVec 12))) **
+     ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb))
+    (by pcFree) hSave
+  have hSeq := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by xperm_hyp hp) hBitFramed hSaveFramed
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by xperm_hyp hp)
+    (fun _ hp => by xperm_hyp hp)
+    hSeq
+
 /-- Squaring-side call block lifted to the decomposed fixed iteration body
     plus the external `mul_callable` code. -/
 theorem exp_squaring_call_block_expIterBodyFullMsbSavedBitTwoMulFixedCode_spec_within


### PR DESCRIPTION
## Summary
- stack on #4667
- add `exp_msb_bit_test_fixed_reload_then_save_expIterBodyFullMsbSavedBitTwoMulFixedCode_spec_within`
- compose the fixed x19 reload bit-test path with `exp_save_bit`, carrying the x16 pointer and reloaded limb memory atom

## Verification
- `lake build EvmAsm.Evm64.Exp.Compose.SavedBitBaseTwoMulFixedIter`
- `lake build EvmAsm.Evm64.Exp`
- `scripts/check-file-size.sh`
- `git diff --check`
- `lake build`
