### PR TITLE
feat(exp): compose fixed skip squaring prefix

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBaseTwoMulFixedIter.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBaseTwoMulFixedIter.lean
@@ -517,6 +517,91 @@ theorem exp_squaring_call_block_expIterBodyFullMsbSavedBitTwoMulFixedCode_spec_w
     (h := h)
     (hmono := CodeReq.union_sub h_square_sub_union h_mul_sub_union)
 
+/-- Fixed x19 no-reload prefix followed by the squaring-side MUL call. -/
+theorem exp_msb_bit_test_fixed_skip_save_then_squaring_expIterBodyFullMsbSavedBitTwoMulFixedCode_spec_within
+    (e c6 v10 v18 sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
+      e0 e1 e2 e3 v7 v11 mulTarget : Word)
+    (squaringMulOff condMulOff : BitVec 21) (skipOff backOff : BitVec 13)
+    (base : Word)
+    (hc6 : c6 + signExtend12 (-1 : BitVec 12) ≠ 0)
+    (hbase : base &&& 1 = 0)
+    (hmt : mulTarget = ((base + 32) + 64) + signExtend21 squaringMulOff)
+    (hd : CodeReq.Disjoint
+            (expIterBodyFullMsbSavedBitTwoMulFixedCode
+              base squaringMulOff condMulOff skipOff backOff)
+            (mul_callable_code mulTarget)) :
+    let bit := e >>> (63 : BitVec 6).toNat
+    let c6New := c6 + signExtend12 (-1 : BitVec 12)
+    let squareW := expSquaringCallSquareW r0 r1 r2 r3
+    cpsTripleWithin ((4 + 1) + (17 + 64 + 9)) base (base + 136)
+      ((expIterBodyFullMsbSavedBitTwoMulFixedCode
+        base squaringMulOff condMulOff skipOff backOff).union
+        (mul_callable_code mulTarget))
+      (((.x19 ↦ᵣ e) ** (.x6 ↦ᵣ c6) ** (.x10 ↦ᵣ v10) **
+        (.x18 ↦ᵣ v18) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
+        ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+        ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+        ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+        ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+        ((evmSp + signExtend12 (0 : BitVec 12)) ↦ₘ d0) **
+        ((evmSp + signExtend12 (8 : BitVec 12)) ↦ₘ d1) **
+        ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ d2) **
+        ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ d3) **
+        ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ e0) **
+        ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ e1) **
+        ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ e2) **
+        ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ e3) **
+        (.x7 ↦ᵣ v7) ** (.x11 ↦ᵣ v11) ** (.x1 ↦ᵣ vOld)))
+      (((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) **
+        (.x5 ↦ᵣ squareW.getLimbN 3) **
+        evmWordIs sp squareW ** evmWordIs (evmSp + 32) squareW **
+        regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
+        memOwn evmSp ** memOwn (evmSp + 8) **
+        memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
+        (.x1 ↦ᵣ ((base + 32) + 68)) **
+        (.x0 ↦ᵣ (0 : Word)) **
+        (.x19 ↦ᵣ (e <<< (1 : BitVec 6).toNat)) **
+        (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
+        ⌜c6New ≠ 0⌝)) := by
+  intro bit c6New squareW
+  have hPrefix :=
+    exp_msb_bit_test_fixed_skip_then_save_expIterBodyFullMsbSavedBitTwoMulFixedCode_union_mul_spec_within
+      e c6 v10 v18 mulTarget squaringMulOff condMulOff skipOff backOff base hc6
+  have hPrefixFramed := cpsTripleWithin_frameR
+    ((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
+     ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+     ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+     ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+     ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+     ((evmSp + signExtend12 (0 : BitVec 12)) ↦ₘ d0) **
+     ((evmSp + signExtend12 (8 : BitVec 12)) ↦ₘ d1) **
+     ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ d2) **
+     ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ d3) **
+     ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ e0) **
+     ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ e1) **
+     ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ e2) **
+     ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ e3) **
+     (.x7 ↦ᵣ v7) ** (.x11 ↦ᵣ v11) ** (.x1 ↦ᵣ vOld))
+    (by pcFree) hPrefix
+  have hSquare :=
+    exp_squaring_call_block_expIterBodyFullMsbSavedBitTwoMulFixedCode_spec_within
+      sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+      c6New v7 bit v11 mulTarget squaringMulOff condMulOff skipOff backOff
+      base hbase hmt hd
+  have hSquareFramed := cpsTripleWithin_frameR
+    ((.x0 ↦ᵣ (0 : Word)) **
+     (.x19 ↦ᵣ (e <<< (1 : BitVec 6).toNat)) **
+     (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
+     ⌜c6New ≠ 0⌝)
+    (by pcFree) hSquare
+  have hSeq := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by xperm_hyp hp) hPrefixFramed hSquareFramed
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by xperm_hyp hp)
+    (fun _ hp => by xperm_hyp hp)
+    hSeq
+
 /-- Conditional-multiply taken call block lifted to the decomposed fixed
     iteration body plus the external `mul_callable` code. The leading saved-bit
     BEQ remains part of the surrounding conditional path proof. -/


### PR DESCRIPTION
## Summary
- add the fixed no-reload prefix plus squaring-side MUL call composition theorem for `expIterBodyFullMsbSavedBitTwoMulFixedCode`
- preserve `x0` through the squaring frame so the prefix postcondition sequences cleanly into the call block

## Verification
- `lake build EvmAsm.Evm64.Exp.Compose.SavedBitBaseTwoMulFixedIter`
- `lake build EvmAsm.Evm64.Exp`
- `scripts/check-file-size.sh`
- `git diff --check`
- `lake build`
