### PR TITLE
feat(exp): compose fixed skip beq loopback

### DIFF
--- a/EvmAsm/Evm64/Exp.lean
+++ b/EvmAsm/Evm64/Exp.lean
@@ -61,6 +61,7 @@ import EvmAsm.Evm64.Exp.Compose.SavedBitLoopBounds
 import EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryPrologue
 import EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryPrologueFixed
 import EvmAsm.Evm64.Exp.Compose.SavedBitBaseTwoMulFixedIter
+import EvmAsm.Evm64.Exp.Compose.SavedBitBaseTwoMulFixedIterLoop
 import EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryEpilogueBase
 import EvmAsm.Evm64.Exp.Compose.SavedBitBoundarySeq
 import EvmAsm.Evm64.Exp.Compose.SavedBitLoopEntry

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBaseTwoMulFixedIterLoop.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBaseTwoMulFixedIterLoop.lean
@@ -1,0 +1,115 @@
+/-
+  EvmAsm.Evm64.Exp.Compose.SavedBitBaseTwoMulFixedIterLoop
+
+  Continuation compositions for the fixed x19 two-MUL saved-bit EXP iteration.
+  This file extends `SavedBitBaseTwoMulFixedIter` without pushing that module
+  over the Compose file-size cap.
+-/
+
+import EvmAsm.Evm64.Exp.Compose.SavedBitBaseTwoMulFixedIter
+
+namespace EvmAsm.Evm64.Exp.Compose
+
+open EvmAsm.Rv64.Tactics
+open EvmAsm.Rv64
+
+/-- Fixed x19 no-reload path through the saved-bit BEQ zero branch, followed by
+    the loop-back counter update. The nonzero conditional-multiply path remains
+    the first exit. -/
+theorem exp_msb_bit_test_fixed_skip_save_squaring_beq_skip_then_loop_back_expIterBodyFullMsbSavedBitTwoMulFixedCode_spec_within
+    (e c6 iterCount v10 v18 sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
+      e0 e1 e2 e3 v7 v11 mulTarget loopTarget : Word)
+    (squaringMulOff condMulOff : BitVec 21) (skipOff backOff : BitVec 13)
+    (base : Word)
+    (hc6 : c6 + signExtend12 (-1 : BitVec 12) ≠ 0)
+    (hbase : base &&& 1 = 0)
+    (hmt : mulTarget = ((base + 32) + 64) + signExtend21 squaringMulOff)
+    (hskip : (base + 136 : Word) + signExtend13 skipOff = base + 244)
+    (hback : ((base + 244) + 4 : Word) + signExtend13 backOff = loopTarget)
+    (hd : CodeReq.Disjoint
+            (expIterBodyFullMsbSavedBitTwoMulFixedCode
+              base squaringMulOff condMulOff skipOff backOff)
+            (mul_callable_code mulTarget)) :
+    let bit := e >>> (63 : BitVec 6).toNat
+    let c6New := c6 + signExtend12 (-1 : BitVec 12)
+    let squareW := expSquaringCallSquareW r0 r1 r2 r3
+    let skipRest : Assertion :=
+      (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) **
+      (.x5 ↦ᵣ squareW.getLimbN 3) **
+      evmWordIs sp squareW ** evmWordIs (evmSp + 32) squareW **
+      regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
+      memOwn evmSp ** memOwn (evmSp + 8) **
+      memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
+      (.x1 ↦ᵣ ((base + 32) + 68)) **
+      (.x19 ↦ᵣ (e <<< (1 : BitVec 6).toNat)) **
+      (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
+      ⌜c6New ≠ 0⌝ ** ⌜bit + signExtend12 (0 : BitVec 12) = 0⌝
+    cpsNBranchWithin ((((4 + 1) + (17 + 64 + 9)) + 1) + 2) base
+      ((expIterBodyFullMsbSavedBitTwoMulFixedCode
+        base squaringMulOff condMulOff skipOff backOff).union
+        (mul_callable_code mulTarget))
+      ((((.x19 ↦ᵣ e) ** (.x6 ↦ᵣ c6) ** (.x10 ↦ᵣ v10) **
+        (.x18 ↦ᵣ v18) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
+        ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+        ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+        ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+        ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+        ((evmSp + signExtend12 (0 : BitVec 12)) ↦ₘ d0) **
+        ((evmSp + signExtend12 (8 : BitVec 12)) ↦ₘ d1) **
+        ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ d2) **
+        ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ d3) **
+        ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ e0) **
+        ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ e1) **
+        ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ e2) **
+        ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ e3) **
+        (.x7 ↦ᵣ v7) ** (.x11 ↦ᵣ v11) ** (.x1 ↦ᵣ vOld)) **
+        (.x9 ↦ᵣ iterCount)))
+      [(base + 140,
+          (((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) **
+            (.x5 ↦ᵣ squareW.getLimbN 3) **
+            evmWordIs sp squareW ** evmWordIs (evmSp + 32) squareW **
+            regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
+            memOwn evmSp ** memOwn (evmSp + 8) **
+            memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
+            (.x1 ↦ᵣ ((base + 32) + 68)) **
+            (.x0 ↦ᵣ (0 : Word)) **
+            (.x19 ↦ᵣ (e <<< (1 : BitVec 6).toNat)) **
+            (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
+            ⌜c6New ≠ 0⌝ ** ⌜bit + signExtend12 (0 : BitVec 12) ≠ 0⌝) **
+            (.x9 ↦ᵣ iterCount))),
+        (loopTarget,
+          ((.x9 ↦ᵣ expTwoMulIterCountNew iterCount) ** (.x0 ↦ᵣ (0 : Word)) **
+            ⌜expTwoMulIterCountNew iterCount ≠ 0⌝) ** skipRest),
+        (base + 252,
+          ((.x9 ↦ᵣ expTwoMulIterCountNew iterCount) ** (.x0 ↦ᵣ (0 : Word)) **
+            ⌜expTwoMulIterCountNew iterCount = 0⌝) ** skipRest)] := by
+  intro bit c6New squareW skipRest
+  have hBranch :=
+    exp_msb_bit_test_fixed_skip_save_squaring_then_cond_mul_beq_expIterBodyFullMsbSavedBitTwoMulFixedCode_spec_within
+      e c6 v10 v18 sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
+      e0 e1 e2 e3 v7 v11 mulTarget (base + 244) squaringMulOff condMulOff
+      skipOff backOff base hc6 hbase hmt hskip hd
+  have hBranchFramed := cpsBranchWithin_frameR (.x9 ↦ᵣ iterCount) (by pcFree) hBranch
+  have hBranchSwapped := cpsBranchWithin_swap hBranchFramed
+  have hLoop := exp_loop_back_expIterBodyFullMsbSavedBitTwoMulFixedCode_union_mul_spec_within
+    iterCount squaringMulOff condMulOff skipOff backOff base loopTarget mulTarget hback
+  have hLoopFramed := cpsBranchWithin_frameR skipRest (by
+    dsimp [skipRest]
+    pcFree) hLoop
+  have hLoopN := cpsBranchWithin_as_cpsNBranchWithin hLoopFramed
+  have hSeq :
+      cpsNBranchWithin ((((4 + 1) + (17 + 64 + 9)) + 1) + 2) base
+        ((expIterBodyFullMsbSavedBitTwoMulFixedCode
+          base squaringMulOff condMulOff skipOff backOff).union
+          (mul_callable_code mulTarget))
+        _ _ :=
+    cpsBranchWithin_cons_cpsNBranchWithin_with_perm_same_cr
+      (fun _ hp => by
+        dsimp [skipRest, bit, c6New] at hp ⊢
+        xperm_hyp hp)
+      hBranchSwapped hLoopN
+  exact cpsNBranchWithin_weaken_pre
+    (fun _ hp => by xperm_hyp hp) hSeq
+
+end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- add `SavedBitBaseTwoMulFixedIterLoop` as a split continuation module for fixed x19 iteration composition
- compose the fixed no-reload BEQ zero branch into the loop-back counter update, leaving the nonzero conditional-multiply path as the first exit
- wire the new module into `EvmAsm.Evm64.Exp`

## Verification
- `lake build EvmAsm.Evm64.Exp.Compose.SavedBitBaseTwoMulFixedIterLoop`
- `lake build EvmAsm.Evm64.Exp`
- `scripts/check-file-size.sh`
- `git diff --check`
- `lake build`
