### PR TITLE
feat(exp): compose fixed cond call loopback

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBaseTwoMulFixedIterLoop.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBaseTwoMulFixedIterLoop.lean
@@ -217,4 +217,95 @@ theorem exp_msb_bit_test_fixed_reload_save_squaring_beq_skip_then_loop_back_expI
   exact cpsNBranchWithin_weaken_pre
     (fun _ hp => by xperm_hyp hp) hSeq
 
+/-- Fixed conditional-multiply call block followed by the loop-back counter
+    update. This is the concrete-limb continuation for the saved-bit nonzero
+    branch before later owned-scratch adapters. -/
+theorem exp_cond_mul_call_then_loop_back_expIterBodyFullMsbSavedBitTwoMulFixedCode_spec_within
+    (iterCount sp evmSp tOld vOld r0 r1 r2 r3 a0 a1 a2 a3 d0 d1 d2 d3
+      e0 e1 e2 e3 v6 v7 v10 v11 mulTarget loopTarget : Word)
+    (squaringMulOff condMulOff : BitVec 21) (skipOff backOff : BitVec 13)
+    (base : Word)
+    (hbase : base &&& 1 = 0)
+    (hmt : mulTarget = ((base + 140) + 64) + signExtend21 condMulOff)
+    (hback : ((base + 244) + 4 : Word) + signExtend13 backOff = loopTarget)
+    (hd : CodeReq.Disjoint
+            (expIterBodyFullMsbSavedBitTwoMulFixedCode
+              base squaringMulOff condMulOff skipOff backOff)
+            (mul_callable_code mulTarget)) :
+    let r := expResultWord r0 r1 r2 r3
+    let aw := expResultWord a0 a1 a2 a3
+    let rw := r * aw
+    let rest : Assertion :=
+      (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) **
+      (.x5 ↦ᵣ rw.getLimbN 3) **
+      ((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
+      ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **
+      ((evmSp + signExtend12 ((-48) : BitVec 12)) ↦ₘ a2) **
+      ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3) **
+      evmWordIs sp rw ** evmWordIs (evmSp + 32) rw **
+      regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
+      memOwn evmSp ** memOwn (evmSp + 8) **
+      memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
+      (.x1 ↦ᵣ ((base + 140) + 68))
+    let exitLoop : Assertion :=
+      ((.x9 ↦ᵣ expTwoMulIterCountNew iterCount) ** (.x0 ↦ᵣ (0 : Word)) **
+        ⌜expTwoMulIterCountNew iterCount ≠ 0⌝) ** rest
+    let exitDone : Assertion :=
+      ((.x9 ↦ᵣ expTwoMulIterCountNew iterCount) ** (.x0 ↦ᵣ (0 : Word)) **
+        ⌜expTwoMulIterCountNew iterCount = 0⌝) ** rest
+    let exits : List (Word × Assertion) :=
+      [(loopTarget, exitLoop), (base + 252, exitDone)]
+    (cpsNBranchWithin ((17 + 64 + 9) + 2) (base + 140)
+      ((expIterBodyFullMsbSavedBitTwoMulFixedCode
+        base squaringMulOff condMulOff skipOff backOff).union
+        (mul_callable_code mulTarget))
+      ((((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
+        ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+        ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+        ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+        ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+        ((evmSp + signExtend12 (0 : BitVec 12)) ↦ₘ d0) **
+        ((evmSp + signExtend12 (8 : BitVec 12)) ↦ₘ d1) **
+        ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ d2) **
+        ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ d3) **
+        ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ e0) **
+        ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ e1) **
+        ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ e2) **
+        ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ e3) **
+        ((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
+        ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **
+        ((evmSp + signExtend12 ((-48) : BitVec 12)) ↦ₘ a2) **
+        ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3) **
+        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) **
+        (.x1 ↦ᵣ vOld)) ** (.x9 ↦ᵣ iterCount) ** (.x0 ↦ᵣ (0 : Word))))
+      exits) := by
+  intro r aw rw rest exitLoop exitDone exits
+  have hCond :=
+    exp_cond_mul_call_block_expIterBodyFullMsbSavedBitTwoMulFixedCode_spec_within
+      sp evmSp tOld vOld r0 r1 r2 r3 a0 a1 a2 a3 d0 d1 d2 d3 e0 e1 e2 e3
+      v6 v7 v10 v11 mulTarget squaringMulOff condMulOff skipOff backOff
+      base hbase hmt hd
+  have hCondFramed :=
+    cpsTripleWithin_frameR
+      ((.x9 ↦ᵣ iterCount) ** (.x0 ↦ᵣ (0 : Word))) (by pcFree) hCond
+  have hLoop := exp_loop_back_expIterBodyFullMsbSavedBitTwoMulFixedCode_union_mul_spec_within
+    iterCount squaringMulOff condMulOff skipOff backOff base loopTarget mulTarget hback
+  have hLoopFramed := cpsBranchWithin_frameR rest (by
+    dsimp [rest]
+    pcFree) hLoop
+  have hSeq :
+      cpsBranchWithin ((17 + 64 + 9) + 2) (base + 140)
+        ((expIterBodyFullMsbSavedBitTwoMulFixedCode
+          base squaringMulOff condMulOff skipOff backOff).union
+          (mul_callable_code mulTarget))
+        _ loopTarget _ (base + 252) _ :=
+    cpsTripleWithin_seq_cpsBranchWithin_perm_same_cr
+      (fun _ hp => by
+        dsimp [rest, rw] at hp ⊢
+        xperm_hyp hp)
+      hCondFramed hLoopFramed
+  have hSeqN := cpsBranchWithin_as_cpsNBranchWithin hSeq
+  exact cpsNBranchWithin_weaken_pre
+    (fun _ hp => by xperm_hyp hp) hSeqN
+
 end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- compose the fixed conditional-multiply call block into the loop-back counter update
- keep the theorem in the split `SavedBitBaseTwoMulFixedIterLoop` continuation module
- expose the concrete-limb nonzero-branch continuation before later owned-scratch adapters

## Verification
- `lake build EvmAsm.Evm64.Exp.Compose.SavedBitBaseTwoMulFixedIterLoop`
- `lake build EvmAsm.Evm64.Exp`
- `scripts/check-file-size.sh`
- `git diff --check`
- `lake build`
