### PR TITLE
feat(exp): compose fixed reload full iteration

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBaseTwoMulFixedIterLoop.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBaseTwoMulFixedIterLoop.lean
@@ -788,4 +788,150 @@ theorem exp_msb_bit_test_fixed_skip_full_iter_four_exit_expIterBodyFullMsbSavedB
       xperm_hyp hp)
     hFull
 
+/-- Fixed x19 reload full-iteration slice. This mirrors the no-reload slice
+    while carrying the reloaded exponent limb and pointer state through the
+    conditional-multiply continuation. -/
+theorem exp_msb_bit_test_fixed_reload_full_iter_four_exit_expIterBodyFullMsbSavedBitTwoMulFixedCode_spec_within
+    (e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 mulTarget loopTarget : Word)
+    (squaringMulOff condMulOff : BitVec 21) (skipOff backOff : BitVec 13)
+    (base : Word)
+    (hc6 : c6 + signExtend12 (-1 : BitVec 12) = 0)
+    (hbase : base &&& 1 = 0)
+    (hsqmt : mulTarget = ((base + 32) + 64) + signExtend21 squaringMulOff)
+    (hcondmt : mulTarget = ((base + 140) + 64) + signExtend21 condMulOff)
+    (hskip : (base + 136 : Word) + signExtend13 skipOff = base + 244)
+    (hback : ((base + 244) + 4 : Word) + signExtend13 backOff = loopTarget)
+    (hd : CodeReq.Disjoint
+            (expIterBodyFullMsbSavedBitTwoMulFixedCode
+              base squaringMulOff condMulOff skipOff backOff)
+            (mul_callable_code mulTarget)) :
+    let bit := e >>> (63 : BitVec 6).toNat
+    let squareW := expSquaringCallSquareW r0 r1 r2 r3
+    let rw := expTwoMulCondRw squareW a0 a1 a2 a3
+    let baseFrame : Assertion :=
+      ((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
+      ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **
+      ((evmSp + signExtend12 ((-48) : BitVec 12)) ↦ₘ a2) **
+      ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3)
+    let condFrame : Assertion :=
+      (.x19 ↦ᵣ nextLimb) **
+      (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
+      ⌜c6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
+      (.x16 ↦ᵣ (ptr + signExtend12 (-8 : BitVec 12))) **
+      ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
+      ⌜bit + signExtend12 (0 : BitVec 12) ≠ 0⌝
+    let skipRest : Assertion :=
+      (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) **
+      (.x5 ↦ᵣ squareW.getLimbN 3) **
+      evmWordIs sp squareW ** evmWordIs (evmSp + 32) squareW **
+      regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
+      memOwn evmSp ** memOwn (evmSp + 8) **
+      memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
+      (.x1 ↦ᵣ ((base + 32) + 68)) **
+      (.x19 ↦ᵣ nextLimb) **
+      (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
+      ⌜c6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
+      (.x16 ↦ᵣ (ptr + signExtend12 (-8 : BitVec 12))) **
+      ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
+      ⌜bit + signExtend12 (0 : BitVec 12) = 0⌝
+    let condRest : Assertion :=
+      (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) **
+      (.x5 ↦ᵣ rw.getLimbN 3) **
+      ((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
+      ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **
+      ((evmSp + signExtend12 ((-48) : BitVec 12)) ↦ₘ a2) **
+      ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3) **
+      evmWordIs sp rw ** evmWordIs (evmSp + 32) rw **
+      regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
+      memOwn evmSp ** memOwn (evmSp + 8) **
+      memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
+      (.x1 ↦ᵣ ((base + 140) + 68))
+    cpsNBranchWithin
+      (((((7 + 1) + (17 + 64 + 9)) + 1) + 2) + ((17 + 64 + 9) + 2))
+      base
+      ((expIterBodyFullMsbSavedBitTwoMulFixedCode
+        base squaringMulOff condMulOff skipOff backOff).union
+        (mul_callable_code mulTarget))
+      (((((.x19 ↦ᵣ e) ** (.x6 ↦ᵣ c6) ** (.x10 ↦ᵣ v10) **
+        (.x18 ↦ᵣ v18) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x16 ↦ᵣ ptr) ** ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
+        (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
+        ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+        ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+        ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+        ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+        ((evmSp + signExtend12 (0 : BitVec 12)) ↦ₘ d0) **
+        ((evmSp + signExtend12 (8 : BitVec 12)) ↦ₘ d1) **
+        ((evmSp + signExtend12 (16 : BitVec 12)) ↦ₘ d2) **
+        ((evmSp + signExtend12 (24 : BitVec 12)) ↦ₘ d3) **
+        ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ e0) **
+        ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ e1) **
+        ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ e2) **
+        ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ e3) **
+        (.x7 ↦ᵣ v7) ** (.x11 ↦ᵣ v11) ** (.x1 ↦ᵣ vOld)) **
+        (.x9 ↦ᵣ iterCount)) ** baseFrame))
+      [(loopTarget,
+          (((.x9 ↦ᵣ expTwoMulIterCountNew iterCount) ** (.x0 ↦ᵣ (0 : Word)) **
+            ⌜expTwoMulIterCountNew iterCount ≠ 0⌝) ** condRest) ** condFrame),
+        (base + 252,
+          (((.x9 ↦ᵣ expTwoMulIterCountNew iterCount) ** (.x0 ↦ᵣ (0 : Word)) **
+            ⌜expTwoMulIterCountNew iterCount = 0⌝) ** condRest) ** condFrame),
+        (loopTarget,
+          (((.x9 ↦ᵣ expTwoMulIterCountNew iterCount) ** (.x0 ↦ᵣ (0 : Word)) **
+            ⌜expTwoMulIterCountNew iterCount ≠ 0⌝) ** skipRest) ** baseFrame),
+        (base + 252,
+          (((.x9 ↦ᵣ expTwoMulIterCountNew iterCount) ** (.x0 ↦ᵣ (0 : Word)) **
+            ⌜expTwoMulIterCountNew iterCount = 0⌝) ** skipRest) ** baseFrame)] := by
+  intro bit squareW rw baseFrame condFrame skipRest condRest
+  have hReloadRaw :=
+    exp_msb_bit_test_fixed_reload_save_squaring_beq_skip_then_loop_back_expIterBodyFullMsbSavedBitTwoMulFixedCode_spec_within
+      e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 v7 v11 mulTarget loopTarget
+      squaringMulOff condMulOff skipOff backOff base hc6 hbase hsqmt hskip hback hd
+  have hReload := cpsNBranchWithin_frameR (F := baseFrame) (by
+    dsimp [baseFrame]
+    pcFree) hReloadRaw
+  have hCondRaw :=
+    exp_cond_mul_call_then_loop_back_expIterBodyFullMsbSavedBitTwoMulFixedCode_folded_owned_spec_within
+      iterCount sp evmSp ((base + 32) + 68) a0 a1 a2 a3 mulTarget loopTarget
+      squareW squaringMulOff condMulOff skipOff backOff base hbase hcondmt hback hd
+  have hCondFramed := cpsNBranchWithin_frameR (F := condFrame) (by
+    dsimp [condFrame]
+    pcFree) hCondRaw
+  have hCondHead :
+      cpsNBranchWithin ((17 + 64 + 9) + 2) (base + 140)
+        ((expIterBodyFullMsbSavedBitTwoMulFixedCode
+          base squaringMulOff condMulOff skipOff backOff).union
+          (mul_callable_code mulTarget))
+        ((((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) **
+          (.x5 ↦ᵣ squareW.getLimbN 3) **
+          evmWordIs sp squareW ** evmWordIs (evmSp + 32) squareW **
+          regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
+          memOwn evmSp ** memOwn (evmSp + 8) **
+          memOwn (evmSp + 16) ** memOwn (evmSp + 24) **
+          (.x1 ↦ᵣ ((base + 32) + 68)) **
+          (.x0 ↦ᵣ (0 : Word)) ** condFrame) **
+          (.x9 ↦ᵣ iterCount)) ** baseFrame)
+        [(loopTarget,
+            (((.x9 ↦ᵣ expTwoMulIterCountNew iterCount) ** (.x0 ↦ᵣ (0 : Word)) **
+              ⌜expTwoMulIterCountNew iterCount ≠ 0⌝) ** condRest) ** condFrame),
+          (base + 252,
+            (((.x9 ↦ᵣ expTwoMulIterCountNew iterCount) ** (.x0 ↦ᵣ (0 : Word)) **
+              ⌜expTwoMulIterCountNew iterCount = 0⌝) ** condRest) ** condFrame)] := by
+    exact cpsNBranchWithin_weaken_pre
+      (fun _ hp => by
+        simp only [expCondMulFoldedPre_unfold] at hp ⊢
+        dsimp [baseFrame, condFrame, condRest, rw] at hp ⊢
+        xperm_hyp hp)
+      hCondFramed
+  have hFull :=
+    cpsNBranchWithin_extend_head_nbranch hReload hCondHead
+  exact cpsNBranchWithin_weaken_pre
+    (fun _ hp => by
+      dsimp [baseFrame] at hp ⊢
+      xperm_hyp hp)
+    hFull
+
 end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- compose the fixed x19 reload prefix/squaring/BEQ path with the folded conditional-multiply continuation
- expose a four-exit fixed reload iteration slice: conditional loop/done exits plus zero-bit skip loop/done exits
- carry the reloaded x19 limb, x16 pointer update, and consumed exponent-limb memory cell through the continuation

## Verification
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitBaseTwoMulFixedIterLoop
- lake build EvmAsm.Evm64.Exp
- scripts/check-file-size.sh
- git diff --check
- lake build