### PR TITLE
feat(exp): extend fixed code specs with mul

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedWithMul.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedWithMul.lean
@@ -67,6 +67,50 @@ theorem evmExpMsbSavedBitTwoMulFixedWithMulCode_mul_sub {base mulTarget : Word}
   unfold evmExpMsbSavedBitTwoMulFixedWithMulCode
   exact CodeReq.mono_union_right hd (fun _ _ h => h)
 
+/-- Lift a whole fixed-EXP triple spec into the fixed EXP+MUL code bundle. -/
+theorem cpsTripleWithin_extend_evmExpMsbSavedBitTwoMulFixedWithMulCode
+    {nSteps : Nat} {entry exit_ base mulTarget : Word}
+    {squaringMulOff condMulOff : BitVec 21} {skipOff backOff : BitVec 13}
+    {P Q : Assertion}
+    (h : cpsTripleWithin nSteps entry exit_
+      (expMsbSavedBitTwoMulFixedCode
+        base squaringMulOff condMulOff skipOff backOff) P Q) :
+    cpsTripleWithin nSteps entry exit_
+      (evmExpMsbSavedBitTwoMulFixedWithMulCode
+        base mulTarget squaringMulOff condMulOff skipOff backOff) P Q :=
+  cpsTripleWithin_extend_code
+    (hmono := evmExpMsbSavedBitTwoMulFixedWithMulCode_exp_sub) h
+
+/-- Lift a whole fixed-EXP branch spec into the fixed EXP+MUL code bundle. -/
+theorem cpsBranchWithin_extend_fixedCode_evmExpMsbSavedBitTwoMulFixedWithMulCode
+    {nSteps : Nat} {entry exit_t exit_f base mulTarget : Word}
+    {squaringMulOff condMulOff : BitVec 21} {skipOff backOff : BitVec 13}
+    {P Q_t Q_f : Assertion}
+    (h : cpsBranchWithin nSteps entry
+      (expMsbSavedBitTwoMulFixedCode
+        base squaringMulOff condMulOff skipOff backOff)
+      P exit_t Q_t exit_f Q_f) :
+    cpsBranchWithin nSteps entry
+      (evmExpMsbSavedBitTwoMulFixedWithMulCode
+        base mulTarget squaringMulOff condMulOff skipOff backOff)
+      P exit_t Q_t exit_f Q_f :=
+  cpsBranchWithin_extend_code
+    (hmono := evmExpMsbSavedBitTwoMulFixedWithMulCode_exp_sub) h
+
+/-- Lift a whole fixed-EXP N-branch spec into the fixed EXP+MUL code bundle. -/
+theorem cpsNBranchWithin_extend_evmExpMsbSavedBitTwoMulFixedWithMulCode
+    {nSteps : Nat} {entry base mulTarget : Word}
+    {squaringMulOff condMulOff : BitVec 21} {skipOff backOff : BitVec 13}
+    {P : Assertion} {exits : List (Word × Assertion)}
+    (h : cpsNBranchWithin nSteps entry
+      (expMsbSavedBitTwoMulFixedCode
+        base squaringMulOff condMulOff skipOff backOff) P exits) :
+    cpsNBranchWithin nSteps entry
+      (evmExpMsbSavedBitTwoMulFixedWithMulCode
+        base mulTarget squaringMulOff condMulOff skipOff backOff) P exits :=
+  cpsNBranchWithin_extend_code
+    (hmono := evmExpMsbSavedBitTwoMulFixedWithMulCode_exp_sub) h
+
 theorem evmExpMsbSavedBitTwoMulFixedWithMulCode_iter_body_union_mul_sub
     {base mulTarget : Word}
     {squaringMulOff condMulOff : BitVec 21} {skipOff backOff : BitVec 13}


### PR DESCRIPTION
## Summary
- add triple, branch, and N-branch extension helpers from fixed EXP code into fixed EXP+MUL code
- keep the fixed iteration-body+MUL branch lift separate for loop-body proofs
- prepare fixed prologue/epilogue boundary proofs to sequence with loop proofs under one code bundle

## Tests
- `lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedWithMul`
- `lake build EvmAsm.Evm64.Exp`
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `git diff --check`
- `lake build`