### PR TITLE
feat(exp): lift fixed epilogue blocks into mul code

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedWithMul.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedWithMul.lean
@@ -113,6 +113,59 @@ theorem exp_prologue_fixed_then_pointer_advance_full_stack_evmExpMsbSavedBitTwoM
       sp evmSp cOld tOld c6Old c16Old c19Old m0 m1 m2 m3 vOld v18
       baseWord exponentWord rest squaringMulOff condMulOff skipOff backOff base)
 
+/-- Fixed pointer restore lifted to the fixed EXP+MUL code bundle. -/
+theorem exp_loop_pointer_restore_evm_exp_msb_saved_bit_two_mul_fixed_with_mul_spec_within
+    (vOld : Word) (squaringMulOff condMulOff : BitVec 21)
+    (skipOff backOff : BitVec 13) (base mulTarget : Word) :
+    cpsTripleWithin 1 (base + 296) (base + 300)
+      (evmExpMsbSavedBitTwoMulFixedWithMulCode
+        base mulTarget squaringMulOff condMulOff skipOff backOff)
+      (.x12 ↦ᵣ vOld)
+      (.x12 ↦ᵣ (vOld + signExtend12 ((-64) : BitVec 12))) := by
+  have h := EvmAsm.Evm64.exp_loop_pointer_restore_spec_within vOld (base + 296)
+  have haddr : (base + 296 : Word) + 4 = base + 300 := by bv_addr
+  rw [haddr] at h
+  exact cpsTripleWithin_extend_code
+    (h := h)
+    (hmono := fun a i h =>
+      evmExpMsbSavedBitTwoMulFixedWithMulCode_exp_sub a i
+        (expMsbSavedBitTwoMulFixedCode_pointer_restore_sub a i h))
+
+/-- Fixed EXP epilogue lifted to the fixed EXP+MUL code bundle. -/
+theorem exp_epilogue_evm_exp_msb_saved_bit_two_mul_fixed_with_mul_spec_within
+    (sp evmSp tOld r0 r1 r2 r3 d0 d1 d2 d3 : Word)
+    (squaringMulOff condMulOff : BitVec 21) (skipOff backOff : BitVec 13)
+    (base mulTarget : Word) :
+    cpsTripleWithin 9 (base + 300) (base + 336)
+      (evmExpMsbSavedBitTwoMulFixedWithMulCode
+        base mulTarget squaringMulOff condMulOff skipOff backOff)
+      ((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+       ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ d0) **
+       ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ d1) **
+       ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ d2) **
+       ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ d3))
+      ((.x2 ↦ᵣ sp) **
+       (.x12 ↦ᵣ (evmSp + signExtend12 (32 : BitVec 12))) **
+       (.x5 ↦ᵣ r3) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+       evmWordIs (evmSp + 32) (expResultWord r0 r1 r2 r3)) := by
+  have h := EvmAsm.Evm64.exp_epilogue_word_spec_within
+    sp evmSp tOld r0 r1 r2 r3 d0 d1 d2 d3 (base + 300)
+  have haddr : (base + 300 : Word) + 36 = base + 336 := by bv_addr
+  rw [haddr] at h
+  exact cpsTripleWithin_extend_code
+    (h := h)
+    (hmono := fun a i h =>
+      evmExpMsbSavedBitTwoMulFixedWithMulCode_exp_sub a i
+        (expMsbSavedBitTwoMulFixedCode_epilogue_sub a i h))
+
 theorem evmExpMsbSavedBitTwoMulFixedWithMulCode_iter_body_union_mul_sub
     {base mulTarget : Word}
     {squaringMulOff condMulOff : BitVec 21} {skipOff backOff : BitVec 13}


### PR DESCRIPTION
## Summary
- add fixed-code sub lemmas for pointer restore at `base + 296` and epilogue at `base + 300`
- lift fixed pointer-restore and EXP epilogue specs into `evmExpMsbSavedBitTwoMulFixedWithMulCode`
- prepare the fixed loop-exit boundary sequence under the same EXP+MUL code bundle as the loop body

## Tests
- `lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedWithMul`
- `lake build EvmAsm.Evm64.Exp`
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `git diff --check`
- `lake build`