### PR TITLE
feat(exp): frame fixed epilogue exit control

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedWithMul.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedWithMul.lean
@@ -239,6 +239,54 @@ theorem exp_pointer_restore_then_epilogue_evm_exp_msb_saved_bit_two_mul_fixed_wi
     (fun _ hp => hp)
     hSeq
 
+/-- Exit-control framed view of the fixed pointer-restore/epilogue sequence. -/
+theorem exp_pointer_restore_then_epilogue_exit_control_evm_exp_msb_saved_bit_two_mul_fixed_with_mul_spec_within
+    (sp evmSp iterCountNew tOld r0 r1 r2 r3 d0 d1 d2 d3 : Word)
+    (exitCond : Prop)
+    (squaringMulOff condMulOff : BitVec 21) (skipOff backOff : BitVec 13)
+    (base mulTarget : Word) :
+    let exitControl : Assertion :=
+      (.x9 ↦ᵣ iterCountNew) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜exitCond⌝
+    cpsTripleWithin (1 + 9) (base + 296) (base + 336)
+      (evmExpMsbSavedBitTwoMulFixedWithMulCode
+        base mulTarget squaringMulOff condMulOff skipOff backOff)
+      (exitControl **
+       ((.x12 ↦ᵣ (evmSp + signExtend12 (64 : BitVec 12))) **
+        ((.x2 ↦ᵣ sp) ** (.x5 ↦ᵣ tOld) **
+         ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+         ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+         ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+         ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+         ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ d0) **
+         ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ d1) **
+         ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ d2) **
+         ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ d3))))
+      (exitControl **
+       ((.x2 ↦ᵣ sp) **
+        (.x12 ↦ᵣ (evmSp + signExtend12 (32 : BitVec 12))) **
+        (.x5 ↦ᵣ r3) **
+        ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+        ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+        ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+        ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+        evmWordIs (evmSp + 32) (expResultWord r0 r1 r2 r3))) := by
+  intro exitControl
+  have hBase :=
+    exp_pointer_restore_then_epilogue_evm_exp_msb_saved_bit_two_mul_fixed_with_mul_spec_within
+      sp evmSp tOld r0 r1 r2 r3 d0 d1 d2 d3
+      squaringMulOff condMulOff skipOff backOff base mulTarget
+  have hFramed := cpsTripleWithin_frameL exitControl (by
+    dsimp [exitControl]
+    pcFree) hBase
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by
+      dsimp [exitControl] at hp ⊢
+      xperm_hyp hp)
+    (fun _ hp => by
+      dsimp [exitControl] at hp ⊢
+      xperm_hyp hp)
+    hFramed
+
 theorem evmExpMsbSavedBitTwoMulFixedWithMulCode_iter_body_union_mul_sub
     {base mulTarget : Word}
     {squaringMulOff condMulOff : BitVec 21} {skipOff backOff : BitVec 13}


### PR DESCRIPTION
## Summary
- add the exit-control framed view of the fixed pointer-restore/epilogue sequence
- preserve `x9`, `x0`, and the pure exit condition through final EXP writeback
- prepare fixed loop-exit branch posts for final boundary composition under `evmExpMsbSavedBitTwoMulFixedWithMulCode`

## Tests
- `lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedWithMul`
- `lake build EvmAsm.Evm64.Exp`
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `git diff --check`
- `lake build`