### PR TITLE
feat(exp): fold fixed epilogue post stack

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedWithMul.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedWithMul.lean
@@ -342,6 +342,96 @@ theorem exp_pointer_restore_then_epilogue_stack_tail_evm_exp_msb_saved_bit_two_m
       xperm_hyp hp)
     hFramed
 
+/-- Fixed pointer-restore/epilogue view with the visible post stack folded. -/
+theorem exp_pointer_restore_then_epilogue_full_post_stack_evm_exp_msb_saved_bit_two_mul_fixed_with_mul_spec_within
+    (sp evmSp iterCountNew tOld r0 r1 r2 r3 d0 d1 d2 d3 : Word)
+    (baseWord : EvmWord) (rest : List EvmWord)
+    (exitCond : Prop)
+    (squaringMulOff condMulOff : BitVec 21) (skipOff backOff : BitVec 13)
+    (base mulTarget : Word) :
+    let exitControl : Assertion :=
+      (.x9 ↦ᵣ iterCountNew) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜exitCond⌝
+    let stackTail : Assertion :=
+      expTwoMulLoopExitStackTailFrame evmSp baseWord rest
+    cpsTripleWithin (1 + 9) (base + 296) (base + 336)
+      (evmExpMsbSavedBitTwoMulFixedWithMulCode
+        base mulTarget squaringMulOff condMulOff skipOff backOff)
+      ((exitControl **
+        ((.x12 ↦ᵣ (evmSp + signExtend12 (64 : BitVec 12))) **
+         ((.x2 ↦ᵣ sp) ** (.x5 ↦ᵣ tOld) **
+          ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+          ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+          ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+          ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+          ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ d0) **
+          ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ d1) **
+          ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ d2) **
+          ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ d3)))) **
+       stackTail)
+      (exitControl **
+       ((.x2 ↦ᵣ sp) **
+        (.x12 ↦ᵣ (evmSp + signExtend12 (32 : BitVec 12))) **
+        (.x5 ↦ᵣ r3) **
+        ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+        ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+        ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+        ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+        evmStackIs evmSp (baseWord :: expResultWord r0 r1 r2 r3 :: rest))) := by
+  intro exitControl stackTail
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by
+      dsimp [exitControl, stackTail] at hp ⊢
+      exact hp)
+    (fun _ hp => by
+      dsimp [exitControl, stackTail] at hp ⊢
+      rw [evmStackIs_cons]
+      xperm_hyp hp)
+    (exp_pointer_restore_then_epilogue_stack_tail_evm_exp_msb_saved_bit_two_mul_fixed_with_mul_spec_within
+      sp evmSp iterCountNew tOld r0 r1 r2 r3 d0 d1 d2 d3 baseWord rest exitCond
+      squaringMulOff condMulOff skipOff backOff base mulTarget)
+
+/-- Fixed full visible-post-stack view with the final EVM stack pointer exposed
+    in plain consumer-facing form. -/
+theorem exp_pointer_restore_then_epilogue_full_post_stack_clean_pointer_evm_exp_msb_saved_bit_two_mul_fixed_with_mul_spec_within
+    (sp evmSp iterCountNew tOld r0 r1 r2 r3 d0 d1 d2 d3 : Word)
+    (baseWord : EvmWord) (rest : List EvmWord)
+    (exitCond : Prop)
+    (squaringMulOff condMulOff : BitVec 21) (skipOff backOff : BitVec 13)
+    (base mulTarget : Word) :
+    let exitControl : Assertion :=
+      (.x9 ↦ᵣ iterCountNew) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜exitCond⌝
+    let stackTail : Assertion :=
+      expTwoMulLoopExitStackTailFrame evmSp baseWord rest
+    cpsTripleWithin (1 + 9) (base + 296) (base + 336)
+      (evmExpMsbSavedBitTwoMulFixedWithMulCode
+        base mulTarget squaringMulOff condMulOff skipOff backOff)
+      ((exitControl **
+        ((.x12 ↦ᵣ (evmSp + signExtend12 (64 : BitVec 12))) **
+         ((.x2 ↦ᵣ sp) ** (.x5 ↦ᵣ tOld) **
+          ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+          ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+          ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+          ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+          ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ d0) **
+          ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ d1) **
+          ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ d2) **
+          ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ d3)))) **
+       stackTail)
+      (exitControl **
+       ((.x2 ↦ᵣ sp) **
+        (.x12 ↦ᵣ (evmSp + 32)) **
+        (.x5 ↦ᵣ r3) **
+        ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+        ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+        ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+        ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+        evmStackIs evmSp (baseWord :: expResultWord r0 r1 r2 r3 :: rest))) := by
+  intro exitControl stackTail
+  rw [← expTwoMulBoundaryResultEvmSpWord]
+  exact exp_pointer_restore_then_epilogue_full_post_stack_evm_exp_msb_saved_bit_two_mul_fixed_with_mul_spec_within
+    sp evmSp iterCountNew tOld r0 r1 r2 r3 d0 d1 d2 d3 baseWord rest exitCond
+    squaringMulOff condMulOff skipOff backOff base mulTarget
+
 theorem evmExpMsbSavedBitTwoMulFixedWithMulCode_iter_body_union_mul_sub
     {base mulTarget : Word}
     {squaringMulOff condMulOff : BitVec 21} {skipOff backOff : BitVec 13}


### PR DESCRIPTION
## Summary
- add fixed full-post-stack wrapper for pointer-restore/epilogue over `evmExpMsbSavedBitTwoMulFixedWithMulCode`
- fold the base operand and EXP result into one visible `evmStackIs` post
- add a clean-pointer variant exposing the final EVM stack pointer as `evmSp + 32`

## Tests
- `lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedWithMul`
- `lake build EvmAsm.Evm64.Exp`
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `git diff --check`
- `lake build`