### PR TITLE
feat(exp): bound fixed boundary loop

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryLoopFixed.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryLoopFixed.lean
@@ -61,6 +61,20 @@ instance pcFreeInst_expTwoMulBoundaryPreFixed
         m0 m1 m2 m3 vOld v18 baseWord exponentWord rest) :=
   ⟨expTwoMulBoundaryPreFixed_pcFree⟩
 
+/-- Bound for the fixed-x19 prologue/pointer-advance boundary. -/
+abbrev expTwoMulFixedBoundaryPrefixBound : Nat := 10 + 1
+
+/-- Bound for the fixed-x19 boundary composition around a loop proof with
+    `nSteps`. -/
+abbrev expTwoMulFixedBoundaryLoopBound (nSteps : Nat) : Nat :=
+  (expTwoMulFixedBoundaryPrefixBound + nSteps) + expTwoMulBoundarySuffixBound
+
+theorem expTwoMulFixedBoundaryLoopBound_eq (nSteps : Nat) :
+    expTwoMulFixedBoundaryLoopBound nSteps = nSteps + 21 := by
+  unfold expTwoMulFixedBoundaryLoopBound expTwoMulFixedBoundaryPrefixBound
+    expTwoMulBoundarySuffixBound
+  omega
+
 /-- Fixed-code analogue of the general boundary composition: fixed prologue,
     caller-supplied loop proof, and fixed pointer-restore/epilogue. -/
 theorem exp_two_mul_fixed_boundary_loop_epilogue_of_loop_general_spec_within
@@ -114,5 +128,117 @@ theorem exp_two_mul_fixed_boundary_loop_epilogue_of_loop_general_spec_within
         sp evmSp iterCountNew tOld r0 r1 r2 r3 d0 d1 d2 d3
         baseWord rest exitCond base
   exact cpsTripleWithin_seq_same_cr hPrefix hEpilogue
+
+/-- Named-bound variant of
+    `exp_two_mul_fixed_boundary_loop_epilogue_of_loop_general_spec_within`. -/
+theorem exp_two_mul_fixed_boundary_loop_epilogue_of_loop_general_named_bound_spec_within
+    {nSteps : Nat}
+    (sp evmSp cOld tOld c6Old c16Old c19Old
+      m0 m1 m2 m3 vOld v18 iterCountNew
+      r0 r1 r2 r3 d0 d1 d2 d3 : Word)
+    (baseWord exponentWord : EvmWord) (rest : List EvmWord)
+    (exitCond : Prop) (base : Word)
+    (hLoop :
+      cpsTripleWithin nSteps (base + 44) (base + 296)
+        (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+        (expTwoMulLoopEntryPostFixed sp evmSp vOld v18
+          baseWord exponentWord rest)
+        (expTwoMulLoopExitFullStackPreFrame sp evmSp iterCountNew tOld
+          r0 r1 r2 r3 d0 d1 d2 d3 baseWord rest exitCond)) :
+    cpsTripleWithin (expTwoMulFixedBoundaryLoopBound nSteps) base (base + 336)
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulBoundaryPreFixed sp evmSp cOld tOld c6Old c16Old c19Old
+        m0 m1 m2 m3 vOld v18 baseWord exponentWord rest)
+      (expTwoMulLoopExitPost sp evmSp iterCountNew r0 r1 r2 r3
+        baseWord rest exitCond) := by
+  simpa [expTwoMulFixedBoundaryLoopBound_eq, Nat.add_assoc, Nat.add_comm,
+    Nat.add_left_comm] using
+    exp_two_mul_fixed_boundary_loop_epilogue_of_loop_general_spec_within
+      sp evmSp cOld tOld c6Old c16Old c19Old m0 m1 m2 m3 vOld v18
+      iterCountNew r0 r1 r2 r3 d0 d1 d2 d3 baseWord exponentWord rest
+      exitCond base hLoop
+
+/-- Caller-chosen bound variant of the fixed boundary composition. -/
+theorem exp_two_mul_fixed_boundary_loop_epilogue_of_loop_general_bounded_spec_within
+    {nSteps nBound : Nat}
+    (sp evmSp cOld tOld c6Old c16Old c19Old
+      m0 m1 m2 m3 vOld v18 iterCountNew
+      r0 r1 r2 r3 d0 d1 d2 d3 : Word)
+    (baseWord exponentWord : EvmWord) (rest : List EvmWord)
+    (exitCond : Prop) (base : Word)
+    (hBound : expTwoMulFixedBoundaryLoopBound nSteps ≤ nBound)
+    (hLoop :
+      cpsTripleWithin nSteps (base + 44) (base + 296)
+        (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+        (expTwoMulLoopEntryPostFixed sp evmSp vOld v18
+          baseWord exponentWord rest)
+        (expTwoMulLoopExitFullStackPreFrame sp evmSp iterCountNew tOld
+          r0 r1 r2 r3 d0 d1 d2 d3 baseWord rest exitCond)) :
+    cpsTripleWithin nBound base (base + 336)
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulBoundaryPreFixed sp evmSp cOld tOld c6Old c16Old c19Old
+        m0 m1 m2 m3 vOld v18 baseWord exponentWord rest)
+      (expTwoMulLoopExitPost sp evmSp iterCountNew r0 r1 r2 r3
+        baseWord rest exitCond) :=
+  cpsTripleWithin_mono_nSteps hBound
+    (exp_two_mul_fixed_boundary_loop_epilogue_of_loop_general_named_bound_spec_within
+      sp evmSp cOld tOld c6Old c16Old c19Old m0 m1 m2 m3 vOld v18
+      iterCountNew r0 r1 r2 r3 d0 d1 d2 d3 baseWord exponentWord rest
+      exitCond base hLoop)
+
+/-- Closed-form bound variant of the fixed boundary composition. -/
+theorem exp_two_mul_fixed_boundary_loop_epilogue_of_loop_general_closed_bound_spec_within
+    {nSteps nBound : Nat}
+    (sp evmSp cOld tOld c6Old c16Old c19Old
+      m0 m1 m2 m3 vOld v18 iterCountNew
+      r0 r1 r2 r3 d0 d1 d2 d3 : Word)
+    (baseWord exponentWord : EvmWord) (rest : List EvmWord)
+    (exitCond : Prop) (base : Word)
+    (hBound : nSteps + 21 ≤ nBound)
+    (hLoop :
+      cpsTripleWithin nSteps (base + 44) (base + 296)
+        (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+        (expTwoMulLoopEntryPostFixed sp evmSp vOld v18
+          baseWord exponentWord rest)
+        (expTwoMulLoopExitFullStackPreFrame sp evmSp iterCountNew tOld
+          r0 r1 r2 r3 d0 d1 d2 d3 baseWord rest exitCond)) :
+    cpsTripleWithin nBound base (base + 336)
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulBoundaryPreFixed sp evmSp cOld tOld c6Old c16Old c19Old
+        m0 m1 m2 m3 vOld v18 baseWord exponentWord rest)
+      (expTwoMulLoopExitPost sp evmSp iterCountNew r0 r1 r2 r3
+        baseWord rest exitCond) :=
+  exp_two_mul_fixed_boundary_loop_epilogue_of_loop_general_bounded_spec_within
+    sp evmSp cOld tOld c6Old c16Old c19Old m0 m1 m2 m3 vOld v18
+    iterCountNew r0 r1 r2 r3 d0 d1 d2 d3 baseWord exponentWord rest
+    exitCond base
+    (by simpa [expTwoMulFixedBoundaryLoopBound_eq] using hBound)
+    hLoop
+
+/-- Exact closed-form bound variant of the fixed boundary composition. -/
+theorem exp_two_mul_fixed_boundary_loop_epilogue_of_loop_general_exact_closed_bound_spec_within
+    {nSteps : Nat}
+    (sp evmSp cOld tOld c6Old c16Old c19Old
+      m0 m1 m2 m3 vOld v18 iterCountNew
+      r0 r1 r2 r3 d0 d1 d2 d3 : Word)
+    (baseWord exponentWord : EvmWord) (rest : List EvmWord)
+    (exitCond : Prop) (base : Word)
+    (hLoop :
+      cpsTripleWithin nSteps (base + 44) (base + 296)
+        (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+        (expTwoMulLoopEntryPostFixed sp evmSp vOld v18
+          baseWord exponentWord rest)
+        (expTwoMulLoopExitFullStackPreFrame sp evmSp iterCountNew tOld
+          r0 r1 r2 r3 d0 d1 d2 d3 baseWord rest exitCond)) :
+    cpsTripleWithin (nSteps + 21) base (base + 336)
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulBoundaryPreFixed sp evmSp cOld tOld c6Old c16Old c19Old
+        m0 m1 m2 m3 vOld v18 baseWord exponentWord rest)
+      (expTwoMulLoopExitPost sp evmSp iterCountNew r0 r1 r2 r3
+        baseWord rest exitCond) :=
+  exp_two_mul_fixed_boundary_loop_epilogue_of_loop_general_closed_bound_spec_within
+    sp evmSp cOld tOld c6Old c16Old c19Old m0 m1 m2 m3 vOld v18
+    iterCountNew r0 r1 r2 r3 d0 d1 d2 d3 baseWord exponentWord rest
+    exitCond base (by rfl) hLoop
 
 end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- name the fixed-x19 boundary loop bound as prologue + loop + epilogue
- prove the closed form `nSteps + 21`
- add named, bounded, closed-bound, and exact closed-bound wrappers for the fixed boundary composition

## Tests
- `lake build EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryLoopFixed`
- `lake build EvmAsm.Evm64.Exp`
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `git diff --check`
- `lake build`