### PR TITLE
feat(exp): name fixed skip target

### DIFF
--- a/EvmAsm/Evm64/Exp/Program.lean
+++ b/EvmAsm/Evm64/Exp/Program.lean
@@ -1118,6 +1118,14 @@ theorem canonicalExpFixedSquaringMul_target (base : Word) :
   have h : signExtend21 (196 : BitVec 21) = (196 : Word) := by decide
   simp only [h]; bv_omega
 
+theorem canonicalExpFixedCondMulSkip_target (base : Word) :
+    ((base + 44) + 136 : Word) +
+        signExtend13 canonicalExpCondMulSkipOff =
+      (base + 44) + 244 := by
+  rw [canonicalExpCondMulSkipOff_eq]
+  have h : signExtend13 (108 : BitVec 13) = (108 : Word) := by decide
+  simp only [h]; bv_omega
+
 theorem canonicalExpCondMul_target (base : Word) :
     ((base + 152) + 64 : Word) + signExtend21 canonicalExpCondMulOff =
       base + 304 := by


### PR DESCRIPTION
## Summary
- add `canonicalExpFixedCondMulSkip_target` for the fixed x19 saved-bit iteration layout
- pin the fixed BEQ skip edge from `(base + 44) + 136` to `(base + 44) + 244`
- align the fixed target lemma set with the existing fixed MUL and loop-back target facts

## Tests
- `lake build EvmAsm.Evm64.Exp.Program`
- `lake build EvmAsm.Evm64.Exp`
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `git diff --check`
- `lake build`