### PR TITLE
feat(exp): expose fixed iter disjoint

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedWithMul.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedWithMul.lean
@@ -724,4 +724,19 @@ theorem cpsNBranchWithin_extend_iter_body_union_evmExpMsbSavedBitTwoMulFixedCano
     (expMsbSavedBitTwoMulFixedCanonicalCode_disjoint_appended_mul base)
     h
 
+/-- The fixed canonical iteration body inside the 336-byte wrapper is disjoint
+    from the appended `mul_callable` body. -/
+theorem expIterBodyFullMsbSavedBitTwoMulFixedCanonicalCode_disjoint_appended_mul
+    (base : Word) :
+    CodeReq.Disjoint
+      (expIterBodyFullMsbSavedBitTwoMulFixedCode
+        (base + 44)
+        EvmAsm.Evm64.canonicalExpSquaringMulOff
+        EvmAsm.Evm64.canonicalExpCondMulOff
+        EvmAsm.Evm64.canonicalExpCondMulSkipOff
+        EvmAsm.Evm64.canonicalExpMsbSavedBitFixedLoopBackOff)
+      (mul_callable_code (base + 336)) :=
+  expIterBodyFullMsbSavedBitTwoMulFixedCode_disjoint_mul_of_fixed_disjoint
+    (expMsbSavedBitTwoMulFixedCanonicalCode_disjoint_appended_mul base)
+
 end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- add `expIterBodyFullMsbSavedBitTwoMulFixedCanonicalCode_disjoint_appended_mul`
- derive fixed iteration-body/appended-MUL disjointness from the whole fixed wrapper disjointness lemma
- prepare canonical fixed iteration wrappers to instantiate existing merged-iteration proofs without an explicit disjointness argument

## Tests
- `lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedWithMul`
- `lake build EvmAsm.Evm64.Exp`
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `git diff --check`
- `lake build`