### PR TITLE
feat(exp): expose fixed named iteration branch

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterExits.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterExits.lean
@@ -202,4 +202,33 @@ theorem exp_msb_bit_test_fixed_full_iter_merged_named_exits_evmExpMsbSavedBitTwo
         r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
         v7 v11 base hbase
 
+/-- Branch view of the canonical-appended whole-code fixed x19 merged
+    full-iteration spec with named loop/exit postconditions. -/
+theorem exp_msb_bit_test_fixed_full_iter_merged_named_branch_evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode_spec_within
+    (e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word)
+    (base : Word)
+    (hbase : (base + 44 : Word) &&& 1 = 0) :
+    cpsBranchWithin
+      expTwoMulFixedReloadIterStepBound
+      (base + 44)
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterPre e c6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+        v7 v11)
+      (base + 44)
+      (expTwoMulFixedIterMergedLoopPost e c6 iterCount ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base)
+      (base + 296)
+      (expTwoMulFixedIterMergedExitPost e c6 iterCount ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base) := by
+  simpa [expTwoMulFixedIterMergedExits]
+    using
+      cpsNBranchWithin_as_cpsBranchWithin
+        (exp_msb_bit_test_fixed_full_iter_merged_named_exits_evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode_spec_within
+          e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+          r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+          v7 v11 base hbase)
+
 end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- add a cpsBranchWithin view over the named fixed merged-iteration loop/exit postconditions
- derive it from the named-exit-list NBranch wrapper via cpsNBranchWithin_as_cpsBranchWithin

## Tests
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterExits
- lake build EvmAsm.Evm64.Exp
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- lake build