### PR TITLE
feat(exp): expose fixed iteration bounded wrappers

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterExits.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterExits.lean
@@ -226,6 +226,30 @@ theorem exp_msb_bit_test_fixed_full_iter_merged_named_exits_closed_bound_evmExpM
       r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
       v7 v11 base hbase
 
+/-- Bounded variant of the named-exit-list fixed x19 merged full-iteration
+    spec. -/
+theorem exp_msb_bit_test_fixed_full_iter_merged_named_exits_bounded_evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode_spec_within
+    (e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word)
+    (base : Word)
+    (hbase : (base + 44 : Word) &&& 1 = 0)
+    {nBound : Nat} (hBound : 193 ≤ nBound) :
+    cpsNBranchWithin
+      nBound
+      (base + 44)
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterPre e c6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+        v7 v11)
+      (expTwoMulFixedIterMergedExits e c6 iterCount ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base) :=
+  cpsNBranchWithin_mono_nSteps hBound
+    (exp_msb_bit_test_fixed_full_iter_merged_named_exits_closed_bound_evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode_spec_within
+      e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 base hbase)
+
 /-- Branch view of the canonical-appended whole-code fixed x19 merged
     full-iteration spec with named loop/exit postconditions. -/
 theorem exp_msb_bit_test_fixed_full_iter_merged_named_branch_evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode_spec_within
@@ -282,5 +306,32 @@ theorem exp_msb_bit_test_fixed_full_iter_merged_named_branch_closed_bound_evmExp
       e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
       r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
       v7 v11 base hbase
+
+/-- Bounded variant of the named fixed x19 merged full-iteration branch. -/
+theorem exp_msb_bit_test_fixed_full_iter_merged_named_branch_bounded_evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode_spec_within
+    (e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word)
+    (base : Word)
+    (hbase : (base + 44 : Word) &&& 1 = 0)
+    {nBound : Nat} (hBound : 193 ≤ nBound) :
+    cpsBranchWithin
+      nBound
+      (base + 44)
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterPre e c6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+        v7 v11)
+      (base + 44)
+      (expTwoMulFixedIterMergedLoopPost e c6 iterCount ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base)
+      (base + 296)
+      (expTwoMulFixedIterMergedExitPost e c6 iterCount ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base) :=
+  cpsBranchWithin_mono_nSteps hBound
+    (exp_msb_bit_test_fixed_full_iter_merged_named_branch_closed_bound_evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode_spec_within
+      e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 base hbase)
 
 end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- add bounded nBound wrappers for the named fixed merged iteration NBranch and Branch specs
- derive them from the 193-step closed-bound wrappers via cpsNBranchWithin_mono_nSteps / cpsBranchWithin_mono_nSteps

## Tests
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterExits
- lake build EvmAsm.Evm64.Exp
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- lake build