### PR TITLE
feat(exp): add fixed iteration body bounds

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryLoopFixed.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryLoopFixed.lean
@@ -75,19 +75,10 @@ theorem expTwoMulFixedBoundaryLoopBound_eq (nSteps : Nat) :
     expTwoMulBoundarySuffixBound
   omega
 
-/-- Conservative bound for 256 fixed-x19 saved-bit two-MUL loop iterations,
-    using the reload-path bound for every iteration. -/
-abbrev expTwoMulFixedFullLoopBodyBound : Nat :=
-  256 * expTwoMulFixedReloadIterStepBound
-
 /-- Conservative bound for the fixed-x19 full boundary, including prologue and
     pointer-restore/epilogue. -/
 abbrev expTwoMulFixedFullLoopBoundaryBound : Nat :=
   expTwoMulFixedBoundaryLoopBound expTwoMulFixedFullLoopBodyBound
-
-theorem expTwoMulFixedFullLoopBodyBound_eq :
-    expTwoMulFixedFullLoopBodyBound = 49408 := by
-  norm_num [expTwoMulFixedFullLoopBodyBound, expTwoMulFixedReloadIterStepBound_eq]
 
 theorem expTwoMulFixedFullLoopBoundaryBound_eq :
     expTwoMulFixedFullLoopBoundaryBound = 49429 := by

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitLoopBounds.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitLoopBounds.lean
@@ -39,15 +39,30 @@ abbrev expTwoMulBoundaryLoopBound (nSteps : Nat) : Nat :=
 abbrev expTwoMulIterationsBodyBound (iterations : Nat) : Nat :=
   iterations * expTwoMulNamedIterStepBound
 
+/-- Conservative bound for `iterations` fixed-x19 saved-bit two-MUL loop
+    iterations, using the reload-path bound for every iteration. -/
+abbrev expTwoMulFixedIterationsBodyBound (iterations : Nat) : Nat :=
+  iterations * expTwoMulFixedReloadIterStepBound
+
 /-- Aggregate bound for 256 saved-bit two-MUL loop iterations, excluding the
     prologue/pointer-advance and pointer-restore/epilogue boundary. -/
 abbrev expTwoMulFullLoopBodyBound : Nat :=
   expTwoMulIterationsBodyBound 256
 
+/-- Conservative aggregate bound for 256 fixed-x19 saved-bit two-MUL loop
+    iterations. -/
+abbrev expTwoMulFixedFullLoopBodyBound : Nat :=
+  expTwoMulFixedIterationsBodyBound 256
+
 /-- Remaining body bound after peeling one iteration from the 256-iteration
     saved-bit two-MUL loop. -/
 abbrev expTwoMulFullLoopBodyTailBound : Nat :=
   expTwoMulIterationsBodyBound 255
+
+/-- Conservative remaining fixed-x19 body bound after peeling one iteration
+    from the 256-iteration saved-bit two-MUL loop. -/
+abbrev expTwoMulFixedFullLoopBodyTailBound : Nat :=
+  expTwoMulFixedIterationsBodyBound 255
 
 /-- Aggregate bound for the full saved-bit two-MUL loop including the
     prologue/pointer-advance and pointer-restore/epilogue boundary. -/
@@ -85,10 +100,25 @@ theorem expTwoMulIterationsBodyBound_eq (iterations : Nat) :
     expTwoMulIterationsBodyBound iterations = iterations * 189 := by
   rw [expTwoMulIterationsBodyBound, expTwoMulNamedIterStepBound_eq]
 
+theorem expTwoMulFixedIterationsBodyBound_zero :
+    expTwoMulFixedIterationsBodyBound 0 = 0 := by
+  rfl
+
+theorem expTwoMulFixedIterationsBodyBound_eq (iterations : Nat) :
+    expTwoMulFixedIterationsBodyBound iterations = iterations * 193 := by
+  rw [expTwoMulFixedIterationsBodyBound, expTwoMulFixedReloadIterStepBound_eq]
+
 theorem expTwoMulIterationsBodyBound_succ (iterations : Nat) :
     expTwoMulIterationsBodyBound (iterations + 1) =
       expTwoMulNamedIterStepBound + expTwoMulIterationsBodyBound iterations := by
   unfold expTwoMulIterationsBodyBound
+  rw [Nat.add_one, Nat.succ_mul, Nat.add_comm]
+
+theorem expTwoMulFixedIterationsBodyBound_succ (iterations : Nat) :
+    expTwoMulFixedIterationsBodyBound (iterations + 1) =
+      expTwoMulFixedReloadIterStepBound +
+        expTwoMulFixedIterationsBodyBound iterations := by
+  unfold expTwoMulFixedIterationsBodyBound
   rw [Nat.add_one, Nat.succ_mul, Nat.add_comm]
 
 theorem expTwoMulNamedIterStepBound_add_iterationsBodyBound_le_succ
@@ -96,6 +126,13 @@ theorem expTwoMulNamedIterStepBound_add_iterationsBodyBound_le_succ
     expTwoMulNamedIterStepBound + expTwoMulIterationsBodyBound iterations ≤
       expTwoMulIterationsBodyBound (iterations + 1) := by
   rw [expTwoMulIterationsBodyBound_succ]
+
+theorem expTwoMulFixedReloadIterStepBound_add_fixedIterationsBodyBound_le_succ
+    (iterations : Nat) :
+    expTwoMulFixedReloadIterStepBound +
+        expTwoMulFixedIterationsBodyBound iterations ≤
+      expTwoMulFixedIterationsBodyBound (iterations + 1) := by
+  rw [expTwoMulFixedIterationsBodyBound_succ]
 
 theorem expTwoMulNamedIterStepBound_add_max_iterationsBodyBound_le_succ
     (iterations : Nat) :
@@ -106,6 +143,17 @@ theorem expTwoMulNamedIterStepBound_add_max_iterationsBodyBound_le_succ
   rw [Nat.max_self]
   exact expTwoMulNamedIterStepBound_add_iterationsBodyBound_le_succ iterations
 
+theorem expTwoMulFixedReloadIterStepBound_add_max_fixedIterationsBodyBound_le_succ
+    (iterations : Nat) :
+    expTwoMulFixedReloadIterStepBound +
+        max (expTwoMulFixedIterationsBodyBound iterations)
+          (expTwoMulFixedIterationsBodyBound iterations) ≤
+      expTwoMulFixedIterationsBodyBound (iterations + 1) := by
+  rw [Nat.max_self]
+  exact
+    expTwoMulFixedReloadIterStepBound_add_fixedIterationsBodyBound_le_succ
+      iterations
+
 theorem expTwoMulNamedIterStepBound_add_max_iterationsBodyBound_zero_le_succ
     (iterations : Nat) :
     expTwoMulNamedIterStepBound +
@@ -114,6 +162,16 @@ theorem expTwoMulNamedIterStepBound_add_max_iterationsBodyBound_zero_le_succ
   rw [Nat.max_eq_left (Nat.zero_le _)]
   exact expTwoMulNamedIterStepBound_add_iterationsBodyBound_le_succ iterations
 
+theorem expTwoMulFixedReloadIterStepBound_add_max_fixedIterationsBodyBound_zero_le_succ
+    (iterations : Nat) :
+    expTwoMulFixedReloadIterStepBound +
+        max (expTwoMulFixedIterationsBodyBound iterations) 0 ≤
+      expTwoMulFixedIterationsBodyBound (iterations + 1) := by
+  rw [Nat.max_eq_left (Nat.zero_le _)]
+  exact
+    expTwoMulFixedReloadIterStepBound_add_fixedIterationsBodyBound_le_succ
+      iterations
+
 theorem expTwoMulIterationsBodyBound_mono {iterations iterations' : Nat}
     (h : iterations ≤ iterations') :
     expTwoMulIterationsBodyBound iterations ≤
@@ -121,15 +179,32 @@ theorem expTwoMulIterationsBodyBound_mono {iterations iterations' : Nat}
   unfold expTwoMulIterationsBodyBound
   exact Nat.mul_le_mul_right expTwoMulNamedIterStepBound h
 
+theorem expTwoMulFixedIterationsBodyBound_mono {iterations iterations' : Nat}
+    (h : iterations ≤ iterations') :
+    expTwoMulFixedIterationsBodyBound iterations ≤
+      expTwoMulFixedIterationsBodyBound iterations' := by
+  unfold expTwoMulFixedIterationsBodyBound
+  exact Nat.mul_le_mul_right expTwoMulFixedReloadIterStepBound h
+
 theorem expTwoMulFullLoopBodyBound_eq :
     expTwoMulFullLoopBodyBound = 48384 := by
   norm_num [expTwoMulFullLoopBodyBound, expTwoMulIterationsBodyBound,
     expTwoMulNamedIterStepBound_eq]
 
+theorem expTwoMulFixedFullLoopBodyBound_eq :
+    expTwoMulFixedFullLoopBodyBound = 49408 := by
+  norm_num [expTwoMulFixedFullLoopBodyBound, expTwoMulFixedIterationsBodyBound,
+    expTwoMulFixedReloadIterStepBound_eq]
+
 theorem expTwoMulFullLoopBodyTailBound_eq :
     expTwoMulFullLoopBodyTailBound = 48195 := by
   norm_num [expTwoMulFullLoopBodyTailBound, expTwoMulIterationsBodyBound,
     expTwoMulNamedIterStepBound_eq]
+
+theorem expTwoMulFixedFullLoopBodyTailBound_eq :
+    expTwoMulFixedFullLoopBodyTailBound = 49215 := by
+  norm_num [expTwoMulFixedFullLoopBodyTailBound,
+    expTwoMulFixedIterationsBodyBound, expTwoMulFixedReloadIterStepBound_eq]
 
 /-- Peel the first named iteration from the 256-iteration body bound. -/
 theorem expTwoMulFullLoopBodyBound_eq_iter_plus_tail :
@@ -138,6 +213,15 @@ theorem expTwoMulFullLoopBodyBound_eq_iter_plus_tail :
   norm_num [expTwoMulFullLoopBodyBound, expTwoMulFullLoopBodyTailBound,
     expTwoMulNamedIterStepBound_eq]
 
+/-- Peel the first fixed-x19 iteration from the conservative 256-iteration
+    body bound. -/
+theorem expTwoMulFixedFullLoopBodyBound_eq_iter_plus_tail :
+    expTwoMulFixedFullLoopBodyBound =
+      expTwoMulFixedReloadIterStepBound +
+        expTwoMulFixedFullLoopBodyTailBound := by
+  norm_num [expTwoMulFixedFullLoopBodyBound,
+    expTwoMulFixedFullLoopBodyTailBound, expTwoMulFixedReloadIterStepBound_eq]
+
 /-- View the 256-iteration full-body bound as one peeled iteration followed by
     the 255-iteration tail. -/
 theorem expTwoMulFullLoopBodyBound_eq_tail_succ :
@@ -145,12 +229,28 @@ theorem expTwoMulFullLoopBodyBound_eq_tail_succ :
   rw [expTwoMulFullLoopBodyBound_eq_iter_plus_tail,
     expTwoMulIterationsBodyBound_succ]
 
+/-- View the conservative fixed-x19 256-iteration full-body bound as one
+    peeled iteration followed by the 255-iteration tail. -/
+theorem expTwoMulFixedFullLoopBodyBound_eq_tail_succ :
+    expTwoMulFixedFullLoopBodyBound =
+      expTwoMulFixedIterationsBodyBound (255 + 1) := by
+  rw [expTwoMulFixedFullLoopBodyBound_eq_iter_plus_tail,
+    expTwoMulFixedIterationsBodyBound_succ]
+
 /-- The peeled named iteration plus the 255-iteration tail fits in the
     256-iteration full-body budget. -/
 theorem expTwoMulNamedIterStepBound_add_fullTail_le_full :
     expTwoMulNamedIterStepBound + expTwoMulFullLoopBodyTailBound ≤
       expTwoMulFullLoopBodyBound := by
   rw [← expTwoMulFullLoopBodyBound_eq_iter_plus_tail]
+
+/-- The peeled fixed-x19 iteration plus the 255-iteration tail fits in the
+    conservative 256-iteration full-body budget. -/
+theorem expTwoMulFixedReloadIterStepBound_add_fullTail_le_full :
+    expTwoMulFixedReloadIterStepBound +
+        expTwoMulFixedFullLoopBodyTailBound ≤
+      expTwoMulFixedFullLoopBodyBound := by
+  rw [← expTwoMulFixedFullLoopBodyBound_eq_iter_plus_tail]
 
 /-- Same budget fact with the duplicated tail bound shape produced by the
     continuation-composition rule. -/
@@ -160,6 +260,16 @@ theorem expTwoMulNamedIterStepBound_add_max_fullTail_le_full :
       expTwoMulFullLoopBodyBound := by
   rw [Nat.max_self]
   exact expTwoMulNamedIterStepBound_add_fullTail_le_full
+
+/-- Fixed-x19 version of the duplicated-tail budget fact produced by the
+    continuation-composition rule. -/
+theorem expTwoMulFixedReloadIterStepBound_add_max_fullTail_le_full :
+    expTwoMulFixedReloadIterStepBound +
+        max expTwoMulFixedFullLoopBodyTailBound
+          expTwoMulFixedFullLoopBodyTailBound ≤
+      expTwoMulFixedFullLoopBodyBound := by
+  rw [Nat.max_self]
+  exact expTwoMulFixedReloadIterStepBound_add_fullTail_le_full
 
 theorem expTwoMulFullLoopBoundaryBound_eq :
     expTwoMulFullLoopBoundaryBound = 48401 := by


### PR DESCRIPTION
## Summary
- add generic fixed-x19 iteration body bounds over an arbitrary iteration count
- add fixed tail, peel, duplicated-tail, zero, closed-form, and monotonicity lemmas for later fixed loop induction
- move the fixed 256-body bound name into the shared loop-bounds module and keep the boundary module consuming it

## Checks
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitLoopBounds
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryLoopFixed
- lake build EvmAsm.Evm64.Exp
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- lake build