### PR TITLE
feat(exp): expose fixed full-tail peel

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterExits.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterExits.lean
@@ -450,6 +450,81 @@ theorem exp_two_mul_fixed_iterations_body_peel_with_continuations_closed_bound_s
       r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
       v7 v11 base exit_ R hbase hLoop hExit
 
+/-- Peel one fixed x19 merged iteration from the conservative 256-iteration
+    body when both branch continuations are packaged under the named
+    255-iteration tail bound. -/
+theorem exp_two_mul_fixed_full_loop_body_peel_tail_with_continuations_spec_within
+    (e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word)
+    (base exit_ : Word) (R : Assertion)
+    (hbase : (base + 44 : Word) &&& 1 = 0) :
+    (cpsTripleWithin expTwoMulFixedFullLoopBodyTailBound
+      (base + 44) exit_
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterMergedLoopPost e c6 iterCount ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base)
+      R) →
+    (cpsTripleWithin expTwoMulFixedFullLoopBodyTailBound
+      (base + 296) exit_
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterMergedExitPost e c6 iterCount ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base)
+      R) →
+    cpsTripleWithin expTwoMulFixedFullLoopBodyBound
+      (base + 44)
+      exit_
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterPre e c6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+        v7 v11)
+      R := by
+  exact
+    exp_two_mul_fixed_iter_merged_with_continuations_bounded_spec_within
+      e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 base hbase
+      expTwoMulFixedReloadIterStepBound_add_max_fullTail_le_full
+
+/-- Closed-form variant of
+    `exp_two_mul_fixed_full_loop_body_peel_tail_with_continuations_spec_within`,
+    exposing the conservative 256-iteration body as `49408` steps and the
+    255-iteration tail as `49215` steps. -/
+theorem exp_two_mul_fixed_full_loop_body_peel_tail_with_continuations_closed_bound_spec_within
+    (e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word)
+    (base exit_ : Word) (R : Assertion)
+    (hbase : (base + 44 : Word) &&& 1 = 0) :
+    (cpsTripleWithin 49215
+      (base + 44) exit_
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterMergedLoopPost e c6 iterCount ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base)
+      R) →
+    (cpsTripleWithin 49215
+      (base + 296) exit_
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterMergedExitPost e c6 iterCount ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base)
+      R) →
+    cpsTripleWithin 49408
+      (base + 44)
+      exit_
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterPre e c6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+        v7 v11)
+      R := by
+  intro hLoop hExit
+  rw [← expTwoMulFixedFullLoopBodyTailBound_eq] at hLoop hExit
+  rw [← expTwoMulFixedFullLoopBodyBound_eq]
+  exact
+    exp_two_mul_fixed_full_loop_body_peel_tail_with_continuations_spec_within
+      e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 base exit_ R hbase hLoop hExit
+
 /-- Branch view of the canonical-appended whole-code fixed x19 merged
     full-iteration spec with named loop/exit postconditions. -/
 theorem exp_msb_bit_test_fixed_full_iter_merged_named_branch_evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode_spec_within


### PR DESCRIPTION
## Summary
- add fixed 256-body tail peel wrapper over the fixed continuation adapter
- add closed-bound form exposing the 49215-step tail and 49408-step body
- lets later fixed loop induction peel the first iteration without restating tail arithmetic

## Checks
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterExits
- lake build EvmAsm.Evm64.Exp
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- lake build