### PR TITLE
feat(exp): expose fixed merged case posts

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePosts.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePosts.lean
@@ -171,4 +171,22 @@ abbrev expTwoMulFixedIterReloadExitPost
       r0 r1 r2 r3 a0 a1 a2 a3 base
       (expTwoMulIterCountNew iterCount = 0) ps
 
+abbrev expTwoMulFixedIterCaseLoopPost
+    (iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word) : Assertion :=
+  fun ps =>
+    expTwoMulFixedIterSkipLoopPost iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base ps ∨
+    expTwoMulFixedIterReloadLoopPost iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base ps
+
+abbrev expTwoMulFixedIterCaseExitPost
+    (iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word) : Assertion :=
+  fun ps =>
+    expTwoMulFixedIterSkipExitPost iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base ps ∨
+    expTwoMulFixedIterReloadExitPost iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base ps
+
 end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- add expTwoMulFixedIterCaseLoopPost as the named disjunction of fixed skip/reload loop cases
- add expTwoMulFixedIterCaseExitPost as the named disjunction of fixed skip/reload exit cases

## Verification
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePosts
- lake build EvmAsm.Evm64.Exp
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- lake build