### PR TITLE
feat(exp): bridge fixed case posts

### DIFF
--- a/EvmAsm/Evm64/Exp.lean
+++ b/EvmAsm/Evm64/Exp.lean
@@ -66,6 +66,7 @@ import EvmAsm.Evm64.Exp.Compose.SavedBitBaseTwoMulFixedIterMerged
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedWithMul
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePosts
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterExits
+import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePostBridge
 import EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryLoopFixed
 import EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryEpilogueBase
 import EvmAsm.Evm64.Exp.Compose.SavedBitBoundarySeq

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostBridge.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostBridge.lean
@@ -1,0 +1,33 @@
+/-
+  EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePostBridge
+
+  Bridges between the historical fixed merged postconditions and the named
+  case-post presentation used by fixed loop-back bridge proofs.
+-/
+
+import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePosts
+import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterExits
+
+namespace EvmAsm.Evm64.Exp.Compose
+
+open EvmAsm.Rv64
+
+theorem expTwoMulFixedIterMergedLoopPost_eq_caseLoopPost
+    {e c6 iterCount ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word} :
+    expTwoMulFixedIterMergedLoopPost e c6 iterCount ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base =
+    expTwoMulFixedIterCaseLoopPost iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base := by
+  rfl
+
+theorem expTwoMulFixedIterMergedExitPost_eq_caseExitPost
+    {e c6 iterCount ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word} :
+    expTwoMulFixedIterMergedExitPost e c6 iterCount ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base =
+    expTwoMulFixedIterCaseExitPost iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base := by
+  rfl
+
+end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- add SavedBitFixedIterCasePostBridge
- prove the historical fixed merged loop post is definitionally equal to expTwoMulFixedIterCaseLoopPost
- prove the historical fixed merged exit post is definitionally equal to expTwoMulFixedIterCaseExitPost
- wire the bridge module into the EXP umbrella

## Verification
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePostBridge
- lake build EvmAsm.Evm64.Exp
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- lake build