### PR TITLE
feat(exp): add bounded fixed case-post succ steps

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostBridge.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostBridge.lean
@@ -206,4 +206,86 @@ theorem exp_fixed_loop_body_final_succ_step_case_posts
         rw [← expTwoMulFixedIterMergedExitPost_eq_caseExitPost]
         exact h))
 
+/-- Bounded non-final fixed loop-body succ step using named case-post
+    assertions. -/
+theorem exp_fixed_loop_body_nonfinal_succ_step_case_posts_bounded
+    (n nBound : Nat)
+    (e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word)
+    (base : Word) (R : Assertion)
+    (hbase : (base + 44 : Word) &&& 1 = 0)
+    (hne : expTwoMulIterCountNew iterCount ≠ 0)
+    (hBound : (n + 1) * 193 ≤ nBound)
+    (hLoop :
+      cpsTripleWithin (n * 193) (base + 44) (base + 296)
+        (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+        (expTwoMulFixedIterCaseLoopPost iterCount e c6 ptr nextLimb sp evmSp
+          r0 r1 r2 r3 a0 a1 a2 a3 base)
+        R) :
+    cpsTripleWithin nBound (base + 44) (base + 296)
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterPre e c6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+        v7 v11)
+      R :=
+  cpsTripleWithin_mono_nSteps hBound
+    (exp_fixed_loop_body_nonfinal_succ_step_case_posts n
+      e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 base R hbase hne hLoop)
+
+/-- Closed 193-step final fixed loop-body succ step using named case-post
+    assertions. -/
+theorem exp_fixed_loop_body_final_succ_step_case_posts_closed_bound
+    (e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word)
+    (base : Word) (R : Assertion)
+    (hbase : (base + 44 : Word) &&& 1 = 0)
+    (hzero : expTwoMulIterCountNew iterCount = 0)
+    (hExit :
+      ∀ ps,
+        expTwoMulFixedIterCaseExitPost iterCount e c6 ptr nextLimb sp evmSp
+          r0 r1 r2 r3 a0 a1 a2 a3 base ps →
+        R ps) :
+    cpsTripleWithin 193 (base + 44) (base + 296)
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterPre e c6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+        v7 v11)
+      R := by
+  simpa using
+    exp_fixed_loop_body_final_succ_step_case_posts
+      e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 base R hbase hzero hExit
+
+/-- Bounded final fixed loop-body succ step using named case-post assertions. -/
+theorem exp_fixed_loop_body_final_succ_step_case_posts_bounded
+    (nBound : Nat)
+    (e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word)
+    (base : Word) (R : Assertion)
+    (hbase : (base + 44 : Word) &&& 1 = 0)
+    (hzero : expTwoMulIterCountNew iterCount = 0)
+    (hBound : 193 ≤ nBound)
+    (hExit :
+      ∀ ps,
+        expTwoMulFixedIterCaseExitPost iterCount e c6 ptr nextLimb sp evmSp
+          r0 r1 r2 r3 a0 a1 a2 a3 base ps →
+        R ps) :
+    cpsTripleWithin nBound (base + 44) (base + 296)
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterPre e c6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+        v7 v11)
+      R :=
+  cpsTripleWithin_mono_nSteps hBound
+    (exp_fixed_loop_body_final_succ_step_case_posts_closed_bound
+      e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 base R hbase hzero hExit)
+
 end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- add bounded non-final fixed loop-body succ-step wrapper over named case posts
- add closed-bound and bounded final fixed loop-body succ-step wrappers over named case posts
- keep later fixed loop induction callers on the case-post presentation without restating bound coercions

## Tests
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePostBridge
- lake build EvmAsm.Evm64.Exp
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- lake build