### PR TITLE
feat(exp): add fixed case-post tail bounds

### DIFF
--- a/EvmAsm/Evm64/Exp.lean
+++ b/EvmAsm/Evm64/Exp.lean
@@ -67,6 +67,7 @@ import EvmAsm.Evm64.Exp.Compose.SavedBitFixedWithMul
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePosts
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterExits
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePostBridge
+import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePostTailBounds
 import EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryLoopFixed
 import EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryEpilogueBase
 import EvmAsm.Evm64.Exp.Compose.SavedBitBoundarySeq

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostTailBounds.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostTailBounds.lean
@@ -1,0 +1,176 @@
+/-
+  EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePostTailBounds
+
+  Bounded variants for fixed x19 case-post full-tail wrappers.
+-/
+
+import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePostBridge
+
+namespace EvmAsm.Evm64.Exp.Compose
+
+open EvmAsm.Rv64
+
+/-- Bounded full-tail peel using named case-post continuations for both branch
+    targets. -/
+theorem exp_two_mul_fixed_full_loop_body_peel_tail_with_case_continuations_bounded_spec_within
+    (nBound : Nat)
+    (e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word)
+    (base exit_ : Word) (R : Assertion)
+    (hbase : (base + 44 : Word) &&& 1 = 0)
+    (hBound : 49408 ≤ nBound) :
+    (cpsTripleWithin 49215
+      (base + 44) exit_
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterCaseLoopPost iterCount e c6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base)
+      R) →
+    (cpsTripleWithin 49215
+      (base + 296) exit_
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterCaseExitPost iterCount e c6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base)
+      R) →
+    cpsTripleWithin nBound
+      (base + 44)
+      exit_
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterPre e c6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+        v7 v11)
+      R :=
+  fun hLoop hExit =>
+    cpsTripleWithin_mono_nSteps hBound
+      (exp_two_mul_fixed_full_loop_body_peel_tail_with_case_continuations_closed_bound_spec_within
+        e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+        r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+        v7 v11 base exit_ R hbase hLoop hExit)
+
+/-- Bounded full-tail peel using a named case-post exit implication. -/
+theorem exp_two_mul_fixed_full_loop_body_peel_tail_with_case_exit_imp_bounded_spec_within
+    (nBound : Nat)
+    (e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word)
+    (base : Word) (R : Assertion)
+    (hbase : (base + 44 : Word) &&& 1 = 0)
+    (hBound : 49408 ≤ nBound)
+    (hExit :
+      ∀ ps,
+        expTwoMulFixedIterCaseExitPost iterCount e c6 ptr nextLimb sp evmSp
+          r0 r1 r2 r3 a0 a1 a2 a3 base ps →
+        R ps) :
+    (cpsTripleWithin 49215
+      (base + 44) (base + 296)
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterCaseLoopPost iterCount e c6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base)
+      R) →
+    cpsTripleWithin nBound
+      (base + 44)
+      (base + 296)
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterPre e c6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+        v7 v11)
+      R :=
+  fun hLoop =>
+    cpsTripleWithin_mono_nSteps hBound
+      (exp_two_mul_fixed_full_loop_body_peel_tail_with_case_exit_imp_closed_bound_spec_within
+        e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+        r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+        v7 v11 base R hbase hExit hLoop)
+
+/-- Bounded non-final full-tail peel using named case-post assertions. -/
+theorem exp_two_mul_fixed_full_loop_body_peel_tail_case_nonfinal_bounded_spec_within
+    (nBound : Nat)
+    (e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word)
+    (base : Word) (R : Assertion)
+    (hbase : (base + 44 : Word) &&& 1 = 0)
+    (hne : expTwoMulIterCountNew iterCount ≠ 0)
+    (hBound : 49408 ≤ nBound) :
+    (cpsTripleWithin 49215
+      (base + 44) (base + 296)
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterCaseLoopPost iterCount e c6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base)
+      R) →
+    cpsTripleWithin nBound
+      (base + 44)
+      (base + 296)
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterPre e c6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+        v7 v11)
+      R :=
+  fun hLoop =>
+    cpsTripleWithin_mono_nSteps hBound
+      (exp_two_mul_fixed_full_loop_body_peel_tail_case_nonfinal_closed_bound_spec_within
+        e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+        r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+        v7 v11 base R hbase hne hLoop)
+
+/-- Bounded final full-tail peel using a named case-post exit continuation. -/
+theorem exp_two_mul_fixed_full_loop_body_peel_tail_case_final_bounded_spec_within
+    (nBound : Nat)
+    (e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word)
+    (base exit_ : Word) (R : Assertion)
+    (hbase : (base + 44 : Word) &&& 1 = 0)
+    (hzero : expTwoMulIterCountNew iterCount = 0)
+    (hBound : 49408 ≤ nBound) :
+    (cpsTripleWithin 49215
+      (base + 296) exit_
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterCaseExitPost iterCount e c6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base)
+      R) →
+    cpsTripleWithin nBound
+      (base + 44)
+      exit_
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterPre e c6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+        v7 v11)
+      R :=
+  fun hExit =>
+    cpsTripleWithin_mono_nSteps hBound
+      (exp_two_mul_fixed_full_loop_body_peel_tail_case_final_closed_bound_spec_within
+        e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+        r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+        v7 v11 base exit_ R hbase hzero hExit)
+
+/-- Bounded final full-tail peel using a named case-post exit implication. -/
+theorem exp_two_mul_fixed_full_loop_body_peel_tail_case_final_exit_imp_bounded_spec_within
+    (nBound : Nat)
+    (e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word)
+    (base : Word) (R : Assertion)
+    (hbase : (base + 44 : Word) &&& 1 = 0)
+    (hzero : expTwoMulIterCountNew iterCount = 0)
+    (hBound : 49408 ≤ nBound)
+    (hExit :
+      ∀ ps,
+        expTwoMulFixedIterCaseExitPost iterCount e c6 ptr nextLimb sp evmSp
+          r0 r1 r2 r3 a0 a1 a2 a3 base ps →
+        R ps) :
+    cpsTripleWithin nBound
+      (base + 44)
+      (base + 296)
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterPre e c6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+        v7 v11)
+      R :=
+  cpsTripleWithin_mono_nSteps hBound
+    (exp_two_mul_fixed_full_loop_body_peel_tail_case_final_exit_imp_closed_bound_spec_within
+      e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 base R hbase hzero hExit)
+
+end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- add a new SavedBitFixedIterCasePostTailBounds module to keep the near-cap bridge file stable
- add bounded variants for case-post full-tail continuations, exit-imp, non-final, final, and final-exit wrappers
- wire the new module into the EXP umbrella import list

## Tests
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePostTailBounds
- lake build EvmAsm.Evm64.Exp
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- lake build