### PR TITLE
feat(exp): choose fixed skip-rest scratch witnesses

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostCases.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostCases.lean
@@ -208,6 +208,18 @@ theorem expTwoMulFixedIterSkipCondRest_choose_scratch
   have hDecomp := expTwoMulFixedIterSkipCondRest_scratch_decomp h
   exact expTwoMulFixedIterScratchOwn_choose_two_frame hDecomp
 
+theorem expTwoMulFixedIterSkipRest_choose_scratch
+    {e c6 sp evmSp r0 r1 r2 r3 base : Word} {ps : PartialState}
+    (h :
+      expTwoMulFixedIterSkipRest e c6 sp evmSp
+        r0 r1 r2 r3 base ps) :
+    ∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      (expTwoMulFixedIterSkipRestScratchPrefix sp evmSp r0 r1 r2 r3 **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        expTwoMulFixedIterSkipRestScratchSuffix e c6 base) ps := by
+  have hDecomp := expTwoMulFixedIterSkipRest_scratch_decomp h
+  exact expTwoMulFixedIterScratchOwn_choose_two_frame hDecomp
+
 theorem expTwoMulFixedIterCaseLoopPost_iff
     {iterCount e c6 ptr nextLimb sp evmSp
       r0 r1 r2 r3 a0 a1 a2 a3 base : Word} {ps : PartialState} :


### PR DESCRIPTION
## Summary
- add expTwoMulFixedIterSkipRest_choose_scratch
- compose the skip-rest scratch decomp with two-sided scratch witness extraction
- prepare the no-conditional-multiply bridge branch to recover concrete scratch witnesses while preserving skip-rest pures

## Tests
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePostCases
- lake build EvmAsm.Evm64.Exp
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- lake build