### PR TITLE
feat(exp): choose fixed reload-cond count scratch witnesses

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostCases.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostCases.lean
@@ -312,6 +312,40 @@ theorem expTwoMulFixedIterSkipCountPost_choose_scratch
     sep_perm h
   exact expTwoMulFixedIterScratchOwn_choose_two_frame hDecomp
 
+abbrev expTwoMulFixedIterReloadCondCountPostScratchSuffix
+    (e c6 ptr nextLimb base : Word) : Assertion :=
+  expTwoMulFixedIterSkipCondRestScratchSuffix base **
+    expTwoMulFixedIterReloadCondFrame e c6 ptr nextLimb
+
+theorem expTwoMulFixedIterReloadCondCountPost_choose_scratch
+    {iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
+    {exitCond : Prop} {ps : PartialState}
+    (h :
+      expTwoMulFixedIterReloadCondCountPost iterCount e c6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base exitCond ps) :
+    ∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      (expTwoMulFixedIterSkipCondCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 exitCond **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        expTwoMulFixedIterReloadCondCountPostScratchSuffix
+          e c6 ptr nextLimb base) ps := by
+  have hDecomp :
+      (expTwoMulFixedIterSkipCondCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 exitCond **
+        expTwoMulFixedIterScratchOwn evmSp **
+        expTwoMulFixedIterReloadCondCountPostScratchSuffix
+          e c6 ptr nextLimb base) ps := by
+    unfold expTwoMulFixedIterReloadCondCountPost
+      expTwoMulFixedIterSkipCondRest
+      expTwoMulFixedIterSkipCondCountPostScratchPrefix
+      expTwoMulFixedIterSkipCondRestScratchPrefix
+      expTwoMulFixedIterScratchOwn
+      expTwoMulFixedIterReloadCondCountPostScratchSuffix
+      expTwoMulFixedIterSkipCondRestScratchSuffix at *
+    sep_perm h
+  exact expTwoMulFixedIterScratchOwn_choose_two_frame hDecomp
+
 theorem expTwoMulFixedIterCaseLoopPost_iff
     {iterCount e c6 ptr nextLimb sp evmSp
       r0 r1 r2 r3 a0 a1 a2 a3 base : Word} {ps : PartialState} :


### PR DESCRIPTION
## Summary
- add expTwoMulFixedIterReloadCondCountPostScratchSuffix
- add expTwoMulFixedIterReloadCondCountPost_choose_scratch
- preserve the iteration counter, exit condition, skip-cond rest prefix, and reload-cond pointer frame while replacing owned scratch cells with concrete witnesses

## Tests
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePostCases
- lake build EvmAsm.Evm64.Exp
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- lake build