### PR TITLE
feat(exp): choose framed fixed skip count scratch witnesses

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostCases.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostCases.lean
@@ -380,6 +380,66 @@ theorem expTwoMulFixedIterReloadSkipCountPost_choose_scratch
     sep_perm h
   exact expTwoMulFixedIterScratchOwn_choose_two_frame hDecomp
 
+theorem expTwoMulFixedIterSkipCondCountPost_choose_scratch_frame
+    {iterCount e c6 sp evmSp r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
+    {exitCond : Prop} {frame : Assertion} {ps : PartialState}
+    (h :
+      (expTwoMulFixedIterSkipCondCountPost iterCount e c6 sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base exitCond **
+        frame) ps) :
+    ∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      (expTwoMulFixedIterSkipCondCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 exitCond **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        (expTwoMulFixedIterSkipCondCountPostScratchSuffix e c6 base **
+          frame)) ps := by
+  have hDecomp :
+      (expTwoMulFixedIterSkipCondCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 exitCond **
+        expTwoMulFixedIterScratchOwn evmSp **
+        (expTwoMulFixedIterSkipCondCountPostScratchSuffix e c6 base **
+          frame)) ps := by
+    unfold expTwoMulFixedIterSkipCondCountPost
+      expTwoMulFixedIterSkipCondRest
+      expTwoMulFixedIterSkipCondCountPostScratchPrefix
+      expTwoMulFixedIterSkipCondRestScratchPrefix
+      expTwoMulFixedIterScratchOwn
+      expTwoMulFixedIterSkipCondCountPostScratchSuffix
+      expTwoMulFixedIterSkipCondRestScratchSuffix at *
+    sep_perm h
+  exact expTwoMulFixedIterScratchOwn_choose_two_frame hDecomp
+
+theorem expTwoMulFixedIterSkipCountPost_choose_scratch_frame
+    {iterCount e c6 sp evmSp r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
+    {exitCond : Prop} {frame : Assertion} {ps : PartialState}
+    (h :
+      (expTwoMulFixedIterSkipCountPost iterCount e c6 sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base exitCond **
+        frame) ps) :
+    ∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      (expTwoMulFixedIterSkipCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3 exitCond **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        (expTwoMulFixedIterSkipCountPostScratchSuffix e c6 evmSp
+          a0 a1 a2 a3 base **
+          frame)) ps := by
+  have hDecomp :
+      (expTwoMulFixedIterSkipCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3 exitCond **
+        expTwoMulFixedIterScratchOwn evmSp **
+        (expTwoMulFixedIterSkipCountPostScratchSuffix e c6 evmSp
+          a0 a1 a2 a3 base **
+          frame)) ps := by
+    unfold expTwoMulFixedIterSkipCountPost
+      expTwoMulFixedIterSkipRest
+      expTwoMulFixedIterSkipCountPostScratchPrefix
+      expTwoMulFixedIterSkipRestScratchPrefix
+      expTwoMulFixedIterScratchOwn
+      expTwoMulFixedIterSkipCountPostScratchSuffix
+      expTwoMulFixedIterSkipRestScratchSuffix at *
+    sep_perm h
+  exact expTwoMulFixedIterScratchOwn_choose_two_frame hDecomp
+
 theorem expTwoMulFixedIterCaseLoopPost_iff
     {iterCount e c6 ptr nextLimb sp evmSp
       r0 r1 r2 r3 a0 a1 a2 a3 base : Word} {ps : PartialState} :


### PR DESCRIPTION
## Summary
- add framed scratch chooser variants for fixed skip-cond and skip count posts
- preserve an arbitrary trailing frame, including the pointer post frame used by case-post split helpers
- prepare higher-level case-post scratch case helpers to extract concrete scratch witnesses from skip branches

## Tests
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePostCases
- lake build EvmAsm.Evm64.Exp
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- lake build