### PR TITLE
feat(exp): relate fixed pointer post and frame

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostFramedCases.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostFramedCases.lean
@@ -10,6 +10,12 @@ namespace EvmAsm.Evm64.Exp.Compose
 
 open EvmAsm.Rv64
 
+theorem expTwoMulFixedIterPointerPost_eq_pointerFrame
+    {ptr nextLimb : Word} :
+    expTwoMulFixedIterPointerPost ptr nextLimb =
+      expTwoMulFixedIterPointerFrame ptr nextLimb := by
+  rw [expTwoMulFixedIterPointerFrame_unfold]
+
 theorem expTwoMulFixedIterCaseExitPost_scratch_cases_frame
     {iterCount e c6 ptr nextLimb sp evmSp
       r0 r1 r2 r3 a0 a1 a2 a3 base : Word}


### PR DESCRIPTION
## Summary
- add expTwoMulFixedIterPointerPost_eq_pointerFrame
- make the named case-post pointer assertion interchangeable with the fixed iter pre pointer frame
- prepare scratch-case-to-iterPre bridge helpers without growing the near-cap case helper module

## Tests
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePostFramedCases
- lake build EvmAsm.Evm64.Exp
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- lake build