### PR TITLE
feat(exp): split fixed loop iterpre cases

### DIFF
--- a/EvmAsm/Evm64/Exp.lean
+++ b/EvmAsm/Evm64/Exp.lean
@@ -71,6 +71,7 @@ import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePostTailBounds
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePostCases
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePostFramedCases
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterReloadPointerPures
+import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePostIterPreCases
 import EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryLoopFixed
 import EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryEpilogueBase
 import EvmAsm.Evm64.Exp.Compose.SavedBitBoundarySeq

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostIterPreCases.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostIterPreCases.lean
@@ -1,0 +1,88 @@
+/-
+  EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePostIterPreCases
+
+  Case splits that convert fixed x19 non-reload branches to iterPre while
+  leaving reload-pointer branches explicit.
+-/
+
+import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterReloadPointerPures
+
+namespace EvmAsm.Evm64.Exp.Compose
+
+open EvmAsm.Rv64
+
+theorem expTwoMulFixedIterCaseLoopPost_iterPre_or_reloadPointerFrame
+    {iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
+    {frame : Assertion} {ps : PartialState}
+    (h :
+      (expTwoMulFixedIterCaseLoopPost iterCount e c6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base **
+        frame) ps) :
+    (∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      let squareW := expSquaringCallSquareW r0 r1 r2 r3
+      let rw := expTwoMulCondRw squareW a0 a1 a2 a3
+      ((expTwoMulFixedIterPre
+        (e <<< (1 : BitVec 6).toNat)
+        v6
+        (expTwoMulIterCountNew iterCount)
+        v10
+        ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+        ptr nextLimb sp evmSp
+        (rw.getLimbN 3)
+        (((base + 44) + 140) + 68)
+        (rw.getLimbN 0) (rw.getLimbN 1) (rw.getLimbN 2) (rw.getLimbN 3)
+        d0 d1 d2 d3
+        (rw.getLimbN 0) (rw.getLimbN 1) (rw.getLimbN 2) (rw.getLimbN 3)
+        a0 a1 a2 a3 v7 v11) **
+        frame) ps) ∨
+    (∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      let squareW := expSquaringCallSquareW r0 r1 r2 r3
+      ((expTwoMulFixedIterPre
+        (e <<< (1 : BitVec 6).toNat)
+        v6
+        (expTwoMulIterCountNew iterCount)
+        v10
+        ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+        ptr nextLimb sp evmSp
+        (squareW.getLimbN 3)
+        (((base + 44) + 32) + 68)
+        (squareW.getLimbN 0) (squareW.getLimbN 1)
+        (squareW.getLimbN 2) (squareW.getLimbN 3)
+        d0 d1 d2 d3
+        (squareW.getLimbN 0) (squareW.getLimbN 1)
+        (squareW.getLimbN 2) (squareW.getLimbN 3)
+        a0 a1 a2 a3 v7 v11) **
+        frame) ps) ∨
+    (∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      ((expTwoMulFixedIterSkipCondCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3
+        (expTwoMulIterCountNew iterCount ≠ 0) **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        expTwoMulFixedIterReloadCondCountPostScratchSuffixFrame
+          e c6 ptr nextLimb base) **
+        frame) ps) ∨
+    (∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      ((expTwoMulFixedIterSkipCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3
+        (expTwoMulIterCountNew iterCount ≠ 0) **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        expTwoMulFixedIterReloadSkipCountPostScratchSuffixFrame
+          e c6 ptr nextLimb evmSp a0 a1 a2 a3 base) **
+        frame) ps) := by
+  rcases expTwoMulFixedIterCaseLoopPost_scratch_cases_reloadPointerFrame h with
+    hSkipCond | hRest
+  · rcases hSkipCond with ⟨v6, v7, v10, v11, d0, d1, d2, d3, hScratch⟩
+    exact Or.inl
+      ⟨v6, v7, v10, v11, d0, d1, d2, d3,
+        expTwoMulFixedIterSkipCondScratchFrame_to_iterPre_frame hScratch⟩
+  · rcases hRest with hSkip | hRest
+    · rcases hSkip with ⟨v6, v7, v10, v11, d0, d1, d2, d3, hScratch⟩
+      exact Or.inr (Or.inl
+        ⟨v6, v7, v10, v11, d0, d1, d2, d3,
+          expTwoMulFixedIterSkipScratchFrame_to_iterPre_frame hScratch⟩)
+    · rcases hRest with hReloadCond | hReloadSkip
+      · exact Or.inr (Or.inr (Or.inl hReloadCond))
+      · exact Or.inr (Or.inr (Or.inr hReloadSkip))
+
+end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- add SavedBitFixedIterCasePostIterPreCases as a split bridge module
- convert fixed loop non-reload scratch branches directly to expTwoMulFixedIterPre
- leave reload-cond/reload-skip branches in explicit expTwoMulFixedIterReloadPointerFrame form for the remaining pointer-shape bridge work

## Tests
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePostIterPreCases
- lake build EvmAsm.Evm64.Exp
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- lake build