### PR TITLE
feat(exp): bound fixed full boundary

### DIFF
--- a/EvmAsm/Evm64/Exp.lean
+++ b/EvmAsm/Evm64/Exp.lean
@@ -67,6 +67,7 @@ import EvmAsm.Evm64.Exp.Compose.SavedBitFixedWithMul
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePosts
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterExits
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePostBridge
+import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePostTailBounds
 import EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryLoopFixed
 import EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryEpilogueBase
 import EvmAsm.Evm64.Exp.Compose.SavedBitBoundarySeq

--- a/EvmAsm/Evm64/Exp.lean
+++ b/EvmAsm/Evm64/Exp.lean
@@ -68,6 +68,7 @@ import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePosts
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterExits
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePostBridge
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePostTailBounds
+import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePostCases
 import EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryLoopFixed
 import EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryEpilogueBase
 import EvmAsm.Evm64.Exp.Compose.SavedBitBoundarySeq

--- a/EvmAsm/Evm64/Exp.lean
+++ b/EvmAsm/Evm64/Exp.lean
@@ -71,6 +71,7 @@ import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePostTailBounds
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePostCases
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePostFramedCases
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterReloadPointerPures
+import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePostIterPreCases
 import EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryLoopFixed
 import EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryEpilogueBase
 import EvmAsm.Evm64.Exp.Compose.SavedBitBoundarySeq

--- a/EvmAsm/Evm64/Exp.lean
+++ b/EvmAsm/Evm64/Exp.lean
@@ -70,6 +70,7 @@ import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePostBridge
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePostTailBounds
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePostCases
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePostFramedCases
+import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterReloadPointerPures
 import EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryLoopFixed
 import EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryEpilogueBase
 import EvmAsm.Evm64.Exp.Compose.SavedBitBoundarySeq

--- a/EvmAsm/Evm64/Exp.lean
+++ b/EvmAsm/Evm64/Exp.lean
@@ -69,6 +69,7 @@ import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterExits
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePostBridge
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePostTailBounds
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePostCases
+import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePostFramedCases
 import EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryLoopFixed
 import EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryEpilogueBase
 import EvmAsm.Evm64.Exp.Compose.SavedBitBoundarySeq

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryLoopFixed.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryLoopFixed.lean
@@ -277,6 +277,35 @@ theorem exp_two_mul_fixed_full_loop_boundary_of_body_general_spec_within
     iterCountNew r0 r1 r2 r3 d0 d1 d2 d3 baseWord exponentWord rest
     exitCond base hLoop
 
+/-- Bounded fixed full-loop boundary wrapper over a caller-supplied
+    256-iteration loop proof. -/
+theorem exp_two_mul_fixed_full_loop_boundary_of_body_general_bounded_spec_within
+    {nBound : Nat}
+    (sp evmSp cOld tOld c6Old c16Old c19Old
+      m0 m1 m2 m3 vOld v18 iterCountNew
+      r0 r1 r2 r3 d0 d1 d2 d3 : Word)
+    (baseWord exponentWord : EvmWord) (rest : List EvmWord)
+    (exitCond : Prop) (base : Word)
+    (hBound : expTwoMulFixedFullLoopBoundaryBound ≤ nBound)
+    (hLoop :
+      cpsTripleWithin expTwoMulFixedFullLoopBodyBound (base + 44) (base + 296)
+        (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+        (expTwoMulLoopEntryPostFixed sp evmSp vOld v18
+          baseWord exponentWord rest)
+        (expTwoMulLoopExitFullStackPreFrame sp evmSp iterCountNew tOld
+          r0 r1 r2 r3 d0 d1 d2 d3 baseWord rest exitCond)) :
+    cpsTripleWithin nBound base (base + 336)
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulBoundaryPreFixed sp evmSp cOld tOld c6Old c16Old c19Old
+        m0 m1 m2 m3 vOld v18 baseWord exponentWord rest)
+      (expTwoMulLoopExitPost sp evmSp iterCountNew r0 r1 r2 r3
+        baseWord rest exitCond) :=
+  cpsTripleWithin_mono_nSteps hBound
+    (exp_two_mul_fixed_full_loop_boundary_of_body_general_spec_within
+      sp evmSp cOld tOld c6Old c16Old c19Old m0 m1 m2 m3 vOld v18
+      iterCountNew r0 r1 r2 r3 d0 d1 d2 d3 baseWord exponentWord rest
+      exitCond base hLoop)
+
 /-- Closed-form fixed full-loop boundary wrapper for a 49408-step loop proof. -/
 theorem exp_two_mul_fixed_full_loop_boundary_of_body_general_closed_bound_spec_within
     (sp evmSp cOld tOld c6Old c16Old c19Old
@@ -311,5 +340,34 @@ theorem exp_two_mul_fixed_full_loop_boundary_of_body_general_closed_bound_spec_w
       sp evmSp cOld tOld c6Old c16Old c19Old m0 m1 m2 m3 vOld v18
       iterCountNew r0 r1 r2 r3 d0 d1 d2 d3 baseWord exponentWord rest
       exitCond base hLoopNamed
+
+/-- Bounded closed-form fixed full-loop boundary wrapper for a 49408-step
+    loop proof. -/
+theorem exp_two_mul_fixed_full_loop_boundary_of_body_general_closed_bounded_spec_within
+    {nBound : Nat}
+    (sp evmSp cOld tOld c6Old c16Old c19Old
+      m0 m1 m2 m3 vOld v18 iterCountNew
+      r0 r1 r2 r3 d0 d1 d2 d3 : Word)
+    (baseWord exponentWord : EvmWord) (rest : List EvmWord)
+    (exitCond : Prop) (base : Word)
+    (hBound : 49429 ≤ nBound)
+    (hLoop :
+      cpsTripleWithin 49408 (base + 44) (base + 296)
+        (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+        (expTwoMulLoopEntryPostFixed sp evmSp vOld v18
+          baseWord exponentWord rest)
+        (expTwoMulLoopExitFullStackPreFrame sp evmSp iterCountNew tOld
+          r0 r1 r2 r3 d0 d1 d2 d3 baseWord rest exitCond)) :
+    cpsTripleWithin nBound base (base + 336)
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulBoundaryPreFixed sp evmSp cOld tOld c6Old c16Old c19Old
+        m0 m1 m2 m3 vOld v18 baseWord exponentWord rest)
+      (expTwoMulLoopExitPost sp evmSp iterCountNew r0 r1 r2 r3
+        baseWord rest exitCond) :=
+  cpsTripleWithin_mono_nSteps hBound
+    (exp_two_mul_fixed_full_loop_boundary_of_body_general_closed_bound_spec_within
+      sp evmSp cOld tOld c6Old c16Old c19Old m0 m1 m2 m3 vOld v18
+      iterCountNew r0 r1 r2 r3 d0 d1 d2 d3 baseWord exponentWord rest
+      exitCond base hLoop)
 
 end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostBridge.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostBridge.lean
@@ -425,6 +425,80 @@ theorem exp_fixed_iter_case_loop_zero_step_vacuous
   exact exp_fixed_iter_merged_loop_zero_step_vacuous hzero
 
 /-- Peel one fixed x19 iteration from the conservative 256-iteration body
+    using named case-post continuations for both branch targets. -/
+theorem exp_two_mul_fixed_full_loop_body_peel_tail_with_case_continuations_spec_within
+    (e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word)
+    (base exit_ : Word) (R : Assertion)
+    (hbase : (base + 44 : Word) &&& 1 = 0) :
+    (cpsTripleWithin expTwoMulFixedFullLoopBodyTailBound
+      (base + 44) exit_
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterCaseLoopPost iterCount e c6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base)
+      R) →
+    (cpsTripleWithin expTwoMulFixedFullLoopBodyTailBound
+      (base + 296) exit_
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterCaseExitPost iterCount e c6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base)
+      R) →
+    cpsTripleWithin expTwoMulFixedFullLoopBodyBound
+      (base + 44)
+      exit_
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterPre e c6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+        v7 v11)
+      R := by
+  intro hLoop hExit
+  rw [← expTwoMulFixedIterMergedLoopPost_eq_caseLoopPost] at hLoop
+  rw [← expTwoMulFixedIterMergedExitPost_eq_caseExitPost] at hExit
+  exact
+    exp_two_mul_fixed_full_loop_body_peel_tail_with_continuations_spec_within
+      e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 base exit_ R hbase hLoop hExit
+
+/-- Closed-form variant of
+    `exp_two_mul_fixed_full_loop_body_peel_tail_with_case_continuations_spec_within`. -/
+theorem exp_two_mul_fixed_full_loop_body_peel_tail_with_case_continuations_closed_bound_spec_within
+    (e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word)
+    (base exit_ : Word) (R : Assertion)
+    (hbase : (base + 44 : Word) &&& 1 = 0) :
+    (cpsTripleWithin 49215
+      (base + 44) exit_
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterCaseLoopPost iterCount e c6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base)
+      R) →
+    (cpsTripleWithin 49215
+      (base + 296) exit_
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterCaseExitPost iterCount e c6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base)
+      R) →
+    cpsTripleWithin 49408
+      (base + 44)
+      exit_
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterPre e c6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+        v7 v11)
+      R := by
+  intro hLoop hExit
+  rw [← expTwoMulFixedFullLoopBodyTailBound_eq] at hLoop hExit
+  rw [← expTwoMulFixedFullLoopBodyBound_eq]
+  exact
+    exp_two_mul_fixed_full_loop_body_peel_tail_with_case_continuations_spec_within
+      e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 base exit_ R hbase hLoop hExit
+
+/-- Peel one fixed x19 iteration from the conservative 256-iteration body
     using named case-post assertions and an explicit exit bridge. -/
 theorem exp_two_mul_fixed_full_loop_body_peel_tail_with_case_exit_imp_spec_within
     (e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostBridge.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostBridge.lean
@@ -498,6 +498,71 @@ theorem exp_two_mul_fixed_full_loop_body_peel_tail_with_case_continuations_close
       r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
       v7 v11 base exit_ R hbase hLoop hExit
 
+/-- Final-count full-tail peel using named case-post assertions: the loop
+    branch is impossible, so only the exit continuation is needed. -/
+theorem exp_two_mul_fixed_full_loop_body_peel_tail_case_final_spec_within
+    (e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word)
+    (base exit_ : Word) (R : Assertion)
+    (hbase : (base + 44 : Word) &&& 1 = 0)
+    (hzero : expTwoMulIterCountNew iterCount = 0) :
+    (cpsTripleWithin expTwoMulFixedFullLoopBodyTailBound
+      (base + 296) exit_
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterCaseExitPost iterCount e c6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base)
+      R) →
+    cpsTripleWithin expTwoMulFixedFullLoopBodyBound
+      (base + 44)
+      exit_
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterPre e c6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+        v7 v11)
+      R := by
+  intro hExit
+  exact
+    exp_two_mul_fixed_full_loop_body_peel_tail_with_case_continuations_spec_within
+      e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 base exit_ R hbase
+      (cpsTripleWithin_mono_nSteps (Nat.zero_le _)
+        (exp_fixed_iter_case_loop_zero_step_vacuous hzero))
+      hExit
+
+/-- Closed-form variant of
+    `exp_two_mul_fixed_full_loop_body_peel_tail_case_final_spec_within`. -/
+theorem exp_two_mul_fixed_full_loop_body_peel_tail_case_final_closed_bound_spec_within
+    (e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word)
+    (base exit_ : Word) (R : Assertion)
+    (hbase : (base + 44 : Word) &&& 1 = 0)
+    (hzero : expTwoMulIterCountNew iterCount = 0) :
+    (cpsTripleWithin 49215
+      (base + 296) exit_
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterCaseExitPost iterCount e c6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base)
+      R) →
+    cpsTripleWithin 49408
+      (base + 44)
+      exit_
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterPre e c6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+        v7 v11)
+      R := by
+  intro hExit
+  rw [← expTwoMulFixedFullLoopBodyTailBound_eq] at hExit
+  rw [← expTwoMulFixedFullLoopBodyBound_eq]
+  exact
+    exp_two_mul_fixed_full_loop_body_peel_tail_case_final_spec_within
+      e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 base exit_ R hbase hzero hExit
+
 /-- Peel one fixed x19 iteration from the conservative 256-iteration body
     using named case-post assertions and an explicit exit bridge. -/
 theorem exp_two_mul_fixed_full_loop_body_peel_tail_with_case_exit_imp_spec_within

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostBridge.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostBridge.lean
@@ -563,6 +563,68 @@ theorem exp_two_mul_fixed_full_loop_body_peel_tail_case_final_closed_bound_spec_
       r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
       v7 v11 base exit_ R hbase hzero hExit
 
+/-- Final-count full-tail peel with an immediate exit implication over named
+    case-post assertions. -/
+theorem exp_two_mul_fixed_full_loop_body_peel_tail_case_final_exit_imp_spec_within
+    (e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word)
+    (base : Word) (R : Assertion)
+    (hbase : (base + 44 : Word) &&& 1 = 0)
+    (hzero : expTwoMulIterCountNew iterCount = 0)
+    (hExit :
+      ∀ ps,
+        expTwoMulFixedIterCaseExitPost iterCount e c6 ptr nextLimb sp evmSp
+          r0 r1 r2 r3 a0 a1 a2 a3 base ps →
+        R ps) :
+    cpsTripleWithin expTwoMulFixedFullLoopBodyBound
+      (base + 44)
+      (base + 296)
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterPre e c6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+        v7 v11)
+      R :=
+  exp_two_mul_fixed_full_loop_body_peel_tail_case_final_spec_within
+    e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+    r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+    v7 v11 base (base + 296) R hbase hzero
+    (cpsTripleWithin_mono_nSteps (Nat.zero_le _)
+      (cpsTripleWithin_extend_code
+        (hmono := by
+          intro a i h
+          cases h)
+        (cpsTripleWithin_refl hExit)))
+
+/-- Closed-form variant of
+    `exp_two_mul_fixed_full_loop_body_peel_tail_case_final_exit_imp_spec_within`. -/
+theorem exp_two_mul_fixed_full_loop_body_peel_tail_case_final_exit_imp_closed_bound_spec_within
+    (e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word)
+    (base : Word) (R : Assertion)
+    (hbase : (base + 44 : Word) &&& 1 = 0)
+    (hzero : expTwoMulIterCountNew iterCount = 0)
+    (hExit :
+      ∀ ps,
+        expTwoMulFixedIterCaseExitPost iterCount e c6 ptr nextLimb sp evmSp
+          r0 r1 r2 r3 a0 a1 a2 a3 base ps →
+        R ps) :
+    cpsTripleWithin 49408
+      (base + 44)
+      (base + 296)
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterPre e c6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+        v7 v11)
+      R := by
+  rw [← expTwoMulFixedFullLoopBodyBound_eq]
+  exact
+    exp_two_mul_fixed_full_loop_body_peel_tail_case_final_exit_imp_spec_within
+      e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 base R hbase hzero hExit
+
 /-- Peel one fixed x19 iteration from the conservative 256-iteration body
     using named case-post assertions and an explicit exit bridge. -/
 theorem exp_two_mul_fixed_full_loop_body_peel_tail_with_case_exit_imp_spec_within

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostCases.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostCases.lean
@@ -138,6 +138,36 @@ theorem expTwoMulFixedIterSkipCondRest_scratch_decomp
     expTwoMulFixedIterSkipCondRestScratchSuffix at *
   sep_perm h
 
+abbrev expTwoMulFixedIterSkipRestScratchPrefix
+    (sp evmSp r0 r1 r2 r3 : Word) : Assertion :=
+  let squareW := expSquaringCallSquareW r0 r1 r2 r3
+  (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) **
+  (.x5 ↦ᵣ squareW.getLimbN 3) **
+  evmWordIs sp squareW ** evmWordIs (evmSp + 32) squareW
+
+abbrev expTwoMulFixedIterSkipRestScratchSuffix
+    (e c6 base : Word) : Assertion :=
+  let bit := e >>> (63 : BitVec 6).toNat
+  let c6New := c6 + signExtend12 (-1 : BitVec 12)
+  (.x1 ↦ᵣ (((base + 44) + 32) + 68)) **
+  (.x19 ↦ᵣ (e <<< (1 : BitVec 6).toNat)) **
+  (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
+  ⌜c6New ≠ 0⌝ ** ⌜bit + signExtend12 (0 : BitVec 12) = 0⌝
+
+theorem expTwoMulFixedIterSkipRest_scratch_decomp
+    {e c6 sp evmSp r0 r1 r2 r3 base : Word} {ps : PartialState}
+    (h :
+      expTwoMulFixedIterSkipRest e c6 sp evmSp
+        r0 r1 r2 r3 base ps) :
+    (expTwoMulFixedIterSkipRestScratchPrefix sp evmSp r0 r1 r2 r3 **
+      expTwoMulFixedIterScratchOwn evmSp **
+      expTwoMulFixedIterSkipRestScratchSuffix e c6 base) ps := by
+  unfold expTwoMulFixedIterSkipRest
+    expTwoMulFixedIterSkipRestScratchPrefix
+    expTwoMulFixedIterScratchOwn
+    expTwoMulFixedIterSkipRestScratchSuffix at *
+  sep_perm h
+
 theorem expTwoMulFixedIterCaseLoopPost_iff
     {iterCount e c6 ptr nextLimb sp evmSp
       r0 r1 r2 r3 a0 a1 a2 a3 base : Word} {ps : PartialState} :

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostCases.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostCases.lean
@@ -204,4 +204,26 @@ theorem expTwoMulFixedIterCaseExitPost_count_cases
     · exact Or.inr (Or.inr (Or.inl hCond))
     · exact Or.inr (Or.inr (Or.inr hSkipCount))
 
+theorem expTwoMulFixedIterSkipCondCountPost_pures
+    {iterCount e c6 sp evmSp r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
+    {exitCond : Prop} {ps : PartialState}
+    (h :
+      expTwoMulFixedIterSkipCondCountPost iterCount e c6 sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base exitCond ps) :
+    exitCond ∧
+    c6 + signExtend12 (-1 : BitVec 12) ≠ 0 ∧
+    (e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12) ≠ 0 := by
+  unfold expTwoMulFixedIterSkipCondCountPost
+    expTwoMulFixedIterSkipCondFrame at h
+  obtain ⟨_, _, _, _, hMain, hFrame⟩ := h
+  obtain ⟨_, _, _, _, hCount, _⟩ := hMain
+  obtain ⟨_, _, _, _, _, hCountTail⟩ := hCount
+  have hExit : exitCond := ((sepConj_pure_right _).1 hCountTail).2
+  obtain ⟨_, _, _, _, _, hFrameTail⟩ := hFrame
+  obtain ⟨_, _, _, _, _, hPureTail⟩ := hFrameTail
+  have hC6 : c6 + signExtend12 (-1 : BitVec 12) ≠ 0 :=
+    ((sepConj_pure_left _).1 hPureTail).1
+  obtain ⟨_, hBit⟩ := ((sepConj_pure_left _).1 hPureTail).2
+  exact ⟨hExit, hC6, hBit⟩
+
 end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostCases.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostCases.lean
@@ -220,6 +220,19 @@ theorem expTwoMulFixedIterSkipRest_choose_scratch
   have hDecomp := expTwoMulFixedIterSkipRest_scratch_decomp h
   exact expTwoMulFixedIterScratchOwn_choose_two_frame hDecomp
 
+theorem expTwoMulFixedIterReloadSkipRest_choose_scratch
+    {e c6 ptr nextLimb sp evmSp r0 r1 r2 r3 base : Word}
+    {ps : PartialState}
+    (h :
+      expTwoMulFixedIterReloadSkipRest e c6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 base ps) :
+    ∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      (expTwoMulFixedIterSkipRestScratchPrefix sp evmSp r0 r1 r2 r3 **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        expTwoMulFixedIterReloadSkipRestScratchSuffix e c6 ptr nextLimb base) ps := by
+  have hDecomp := expTwoMulFixedIterReloadSkipRest_scratch_decomp h
+  exact expTwoMulFixedIterScratchOwn_choose_two_frame hDecomp
+
 theorem expTwoMulFixedIterCaseLoopPost_iff
     {iterCount e c6 ptr nextLimb sp evmSp
       r0 r1 r2 r3 a0 a1 a2 a3 base : Word} {ps : PartialState} :

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostCases.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostCases.lean
@@ -312,6 +312,40 @@ theorem expTwoMulFixedIterSkipCountPost_choose_scratch
     sep_perm h
   exact expTwoMulFixedIterScratchOwn_choose_two_frame hDecomp
 
+abbrev expTwoMulFixedIterReloadCondCountPostScratchSuffix
+    (e c6 ptr nextLimb base : Word) : Assertion :=
+  expTwoMulFixedIterSkipCondRestScratchSuffix base **
+    expTwoMulFixedIterReloadCondFrame e c6 ptr nextLimb
+
+theorem expTwoMulFixedIterReloadCondCountPost_choose_scratch
+    {iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
+    {exitCond : Prop} {ps : PartialState}
+    (h :
+      expTwoMulFixedIterReloadCondCountPost iterCount e c6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base exitCond ps) :
+    ∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      (expTwoMulFixedIterSkipCondCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 exitCond **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        expTwoMulFixedIterReloadCondCountPostScratchSuffix
+          e c6 ptr nextLimb base) ps := by
+  have hDecomp :
+      (expTwoMulFixedIterSkipCondCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 exitCond **
+        expTwoMulFixedIterScratchOwn evmSp **
+        expTwoMulFixedIterReloadCondCountPostScratchSuffix
+          e c6 ptr nextLimb base) ps := by
+    unfold expTwoMulFixedIterReloadCondCountPost
+      expTwoMulFixedIterSkipCondRest
+      expTwoMulFixedIterSkipCondCountPostScratchPrefix
+      expTwoMulFixedIterSkipCondRestScratchPrefix
+      expTwoMulFixedIterScratchOwn
+      expTwoMulFixedIterReloadCondCountPostScratchSuffix
+      expTwoMulFixedIterSkipCondRestScratchSuffix at *
+    sep_perm h
+  exact expTwoMulFixedIterScratchOwn_choose_two_frame hDecomp
+
 theorem expTwoMulFixedIterCaseLoopPost_iff
     {iterCount e c6 ptr nextLimb sp evmSp
       r0 r1 r2 r3 a0 a1 a2 a3 base : Word} {ps : PartialState} :

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostCases.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostCases.lean
@@ -168,6 +168,33 @@ theorem expTwoMulFixedIterSkipRest_scratch_decomp
     expTwoMulFixedIterSkipRestScratchSuffix at *
   sep_perm h
 
+abbrev expTwoMulFixedIterReloadSkipRestScratchSuffix
+    (e c6 ptr nextLimb base : Word) : Assertion :=
+  let bit := e >>> (63 : BitVec 6).toNat
+  let c6New := c6 + signExtend12 (-1 : BitVec 12)
+  (.x1 ↦ᵣ (((base + 44) + 32) + 68)) **
+  (.x19 ↦ᵣ nextLimb) **
+  (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
+  ⌜c6New = 0⌝ **
+  (.x16 ↦ᵣ (ptr + signExtend12 (-8 : BitVec 12))) **
+  ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
+  ⌜bit + signExtend12 (0 : BitVec 12) = 0⌝
+
+theorem expTwoMulFixedIterReloadSkipRest_scratch_decomp
+    {e c6 ptr nextLimb sp evmSp r0 r1 r2 r3 base : Word}
+    {ps : PartialState}
+    (h :
+      expTwoMulFixedIterReloadSkipRest e c6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 base ps) :
+    (expTwoMulFixedIterSkipRestScratchPrefix sp evmSp r0 r1 r2 r3 **
+      expTwoMulFixedIterScratchOwn evmSp **
+      expTwoMulFixedIterReloadSkipRestScratchSuffix e c6 ptr nextLimb base) ps := by
+  unfold expTwoMulFixedIterReloadSkipRest
+    expTwoMulFixedIterSkipRestScratchPrefix
+    expTwoMulFixedIterScratchOwn
+    expTwoMulFixedIterReloadSkipRestScratchSuffix at *
+  sep_perm h
+
 theorem expTwoMulFixedIterCaseLoopPost_iff
     {iterCount e c6 ptr nextLimb sp evmSp
       r0 r1 r2 r3 a0 a1 a2 a3 base : Word} {ps : PartialState} :

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostCases.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostCases.lean
@@ -262,4 +262,30 @@ theorem expTwoMulFixedIterSkipCountPost_pures
   obtain ⟨_, hBit⟩ := ((sepConj_pure_left _).1 hPureTail).2
   exact ⟨hExit, hC6, hBit⟩
 
+theorem expTwoMulFixedIterReloadCondCountPost_pures
+    {iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
+    {exitCond : Prop} {ps : PartialState}
+    (h :
+      expTwoMulFixedIterReloadCondCountPost iterCount e c6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base exitCond ps) :
+    exitCond ∧
+    c6 + signExtend12 (-1 : BitVec 12) = 0 ∧
+    (e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12) ≠ 0 := by
+  unfold expTwoMulFixedIterReloadCondCountPost
+    expTwoMulFixedIterReloadCondFrame at h
+  obtain ⟨_, _, _, _, hMain, hFrame⟩ := h
+  obtain ⟨_, _, _, _, hCount, _⟩ := hMain
+  obtain ⟨_, _, _, _, _, hCountTail⟩ := hCount
+  have hExit : exitCond := ((sepConj_pure_right _).1 hCountTail).2
+  obtain ⟨_, _, _, _, _, hFrame1⟩ := hFrame
+  obtain ⟨_, _, _, _, _, hFrame2⟩ := hFrame1
+  have hC6 : c6 + signExtend12 (-1 : BitVec 12) = 0 :=
+    ((sepConj_pure_left _).1 hFrame2).1
+  have hAfterC6 := ((sepConj_pure_left _).1 hFrame2).2
+  obtain ⟨_, _, _, _, _, hFrame3⟩ := hAfterC6
+  obtain ⟨_, _, _, _, _, hBitPure⟩ := hFrame3
+  obtain ⟨_, hBit⟩ := hBitPure
+  exact ⟨hExit, hC6, hBit⟩
+
 end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostCases.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostCases.lean
@@ -195,6 +195,19 @@ theorem expTwoMulFixedIterReloadSkipRest_scratch_decomp
     expTwoMulFixedIterReloadSkipRestScratchSuffix at *
   sep_perm h
 
+theorem expTwoMulFixedIterSkipCondRest_choose_scratch
+    {sp evmSp r0 r1 r2 r3 a0 a1 a2 a3 base : Word} {ps : PartialState}
+    (h :
+      expTwoMulFixedIterSkipCondRest sp evmSp r0 r1 r2 r3
+        a0 a1 a2 a3 base ps) :
+    ∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      (expTwoMulFixedIterSkipCondRestScratchPrefix sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        expTwoMulFixedIterSkipCondRestScratchSuffix base) ps := by
+  have hDecomp := expTwoMulFixedIterSkipCondRest_scratch_decomp h
+  exact expTwoMulFixedIterScratchOwn_choose_two_frame hDecomp
+
 theorem expTwoMulFixedIterCaseLoopPost_iff
     {iterCount e c6 ptr nextLimb sp evmSp
       r0 r1 r2 r3 a0 a1 a2 a3 base : Word} {ps : PartialState} :

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostCases.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostCases.lean
@@ -95,6 +95,19 @@ theorem expTwoMulFixedIterScratchOwn_choose_frame
   exact ⟨v6, v7, v10, v11, d0, d1, d2, d3,
     psScratch, psRest, h_disjoint, h_union, hScratchIs, hRest⟩
 
+theorem expTwoMulFixedIterScratchOwn_choose_two_frame
+    {evmSp : Word} {A B : Assertion} {ps : PartialState}
+    (h : (A ** expTwoMulFixedIterScratchOwn evmSp ** B) ps) :
+    ∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      (A ** expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 ** B) ps := by
+  have hFront :
+      (expTwoMulFixedIterScratchOwn evmSp ** (A ** B)) ps := by
+    sep_perm h
+  obtain ⟨v6, v7, v10, v11, d0, d1, d2, d3, hChosen⟩ :=
+    expTwoMulFixedIterScratchOwn_choose_frame hFront
+  refine ⟨v6, v7, v10, v11, d0, d1, d2, d3, ?_⟩
+  sep_perm hChosen
+
 theorem expTwoMulFixedIterCaseLoopPost_iff
     {iterCount e c6 ptr nextLimb sp evmSp
       r0 r1 r2 r3 a0 a1 a2 a3 base : Word} {ps : PartialState} :

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostCases.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostCases.lean
@@ -681,6 +681,53 @@ theorem expTwoMulFixedIterCaseLoopPost_scratch_cases
       · exact Or.inr (Or.inr (Or.inr
           (expTwoMulFixedIterReloadSkipCountPost_choose_scratch hReloadSkip)))
 
+theorem expTwoMulFixedIterCaseExitPost_scratch_cases
+    {iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word} {ps : PartialState}
+    (h :
+      expTwoMulFixedIterCaseExitPost iterCount e c6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base ps) :
+    (∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      (expTwoMulFixedIterSkipCondCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3
+        (expTwoMulIterCountNew iterCount = 0) **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        (expTwoMulFixedIterSkipCondCountPostScratchSuffix e c6 base **
+          expTwoMulFixedIterPointerPost ptr nextLimb)) ps) ∨
+    (∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      (expTwoMulFixedIterSkipCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3
+        (expTwoMulIterCountNew iterCount = 0) **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        (expTwoMulFixedIterSkipCountPostScratchSuffix e c6 evmSp
+          a0 a1 a2 a3 base **
+          expTwoMulFixedIterPointerPost ptr nextLimb)) ps) ∨
+    (∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      (expTwoMulFixedIterSkipCondCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3
+        (expTwoMulIterCountNew iterCount = 0) **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        expTwoMulFixedIterReloadCondCountPostScratchSuffix
+          e c6 ptr nextLimb base) ps) ∨
+    (∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      (expTwoMulFixedIterSkipCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3
+        (expTwoMulIterCountNew iterCount = 0) **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        expTwoMulFixedIterReloadSkipCountPostScratchSuffix
+          e c6 ptr nextLimb evmSp a0 a1 a2 a3 base) ps) := by
+  rcases expTwoMulFixedIterCaseExitPost_count_cases h with hSkipCond | hRest
+  · exact Or.inl
+      (expTwoMulFixedIterSkipCondCountPost_choose_scratch_frame hSkipCond)
+  · rcases hRest with hSkip | hRest
+    · exact Or.inr (Or.inl
+        (expTwoMulFixedIterSkipCountPost_choose_scratch_frame hSkip))
+    · rcases hRest with hReloadCond | hReloadSkip
+      · exact Or.inr (Or.inr (Or.inl
+          (expTwoMulFixedIterReloadCondCountPost_choose_scratch hReloadCond)))
+      · exact Or.inr (Or.inr (Or.inr
+          (expTwoMulFixedIterReloadSkipCountPost_choose_scratch hReloadSkip)))
+
 theorem expTwoMulFixedIterSkipCondCountPost_pures
     {iterCount e c6 sp evmSp r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
     {exitCond : Prop} {ps : PartialState}

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostCases.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostCases.lean
@@ -110,4 +110,42 @@ theorem expTwoMulFixedIterReloadExitPost_cases
       (expTwoMulIterCountNew iterCount = 0) ps :=
   expTwoMulFixedIterReloadExitPost_iff.mp h
 
+theorem expTwoMulFixedIterSkipLoopPost_cases
+    {iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word} {ps : PartialState}
+    (h :
+      expTwoMulFixedIterSkipLoopPost iterCount e c6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base ps) :
+    (expTwoMulFixedIterSkipCondCountPost iterCount e c6 sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base
+      (expTwoMulIterCountNew iterCount ≠ 0) **
+      expTwoMulFixedIterPointerPost ptr nextLimb) ps ∨
+    (expTwoMulFixedIterSkipCountPost iterCount e c6 sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base
+      (expTwoMulIterCountNew iterCount ≠ 0) **
+      expTwoMulFixedIterPointerPost ptr nextLimb) ps := by
+  obtain ⟨psLeft, psRight, hDisjoint, hUnion, hCases, hPtr⟩ := h
+  rcases hCases with hCond | hSkip
+  · exact Or.inl ⟨psLeft, psRight, hDisjoint, hUnion, hCond, hPtr⟩
+  · exact Or.inr ⟨psLeft, psRight, hDisjoint, hUnion, hSkip, hPtr⟩
+
+theorem expTwoMulFixedIterSkipExitPost_cases
+    {iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word} {ps : PartialState}
+    (h :
+      expTwoMulFixedIterSkipExitPost iterCount e c6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base ps) :
+    (expTwoMulFixedIterSkipCondCountPost iterCount e c6 sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base
+      (expTwoMulIterCountNew iterCount = 0) **
+      expTwoMulFixedIterPointerPost ptr nextLimb) ps ∨
+    (expTwoMulFixedIterSkipCountPost iterCount e c6 sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base
+      (expTwoMulIterCountNew iterCount = 0) **
+      expTwoMulFixedIterPointerPost ptr nextLimb) ps := by
+  obtain ⟨psLeft, psRight, hDisjoint, hUnion, hCases, hPtr⟩ := h
+  rcases hCases with hCond | hSkip
+  · exact Or.inl ⟨psLeft, psRight, hDisjoint, hUnion, hCond, hPtr⟩
+  · exact Or.inr ⟨psLeft, psRight, hDisjoint, hUnion, hSkip, hPtr⟩
+
 end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostCases.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostCases.lean
@@ -288,4 +288,45 @@ theorem expTwoMulFixedIterReloadCondCountPost_pures
   obtain ⟨_, hBit⟩ := hBitPure
   exact ⟨hExit, hC6, hBit⟩
 
+theorem expTwoMulFixedIterReloadSkipCountPost_pures
+    {iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
+    {exitCond : Prop} {ps : PartialState}
+    (h :
+      expTwoMulFixedIterReloadSkipCountPost iterCount e c6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base exitCond ps) :
+    exitCond ∧
+    c6 + signExtend12 (-1 : BitVec 12) = 0 ∧
+    (e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12) = 0 := by
+  unfold expTwoMulFixedIterReloadSkipCountPost
+    expTwoMulFixedIterReloadSkipRest at h
+  obtain ⟨_, _, _, _, hMain, _hBaseFrame⟩ := h
+  obtain ⟨_, _, _, _, hCount, hRest⟩ := hMain
+  obtain ⟨_, _, _, _, _, hCountTail⟩ := hCount
+  have hExit : exitCond := ((sepConj_pure_right _).1 hCountTail).2
+  obtain ⟨_, _, _, _, _, hRest1⟩ := hRest
+  obtain ⟨_, _, _, _, _, hRest2⟩ := hRest1
+  obtain ⟨_, _, _, _, _, hRest3⟩ := hRest2
+  obtain ⟨_, _, _, _, _, hRest4⟩ := hRest3
+  obtain ⟨_, _, _, _, _, hRest5⟩ := hRest4
+  obtain ⟨_, _, _, _, _, hRest6⟩ := hRest5
+  obtain ⟨_, _, _, _, _, hRest7⟩ := hRest6
+  obtain ⟨_, _, _, _, _, hRest8⟩ := hRest7
+  obtain ⟨_, _, _, _, _, hRest9⟩ := hRest8
+  obtain ⟨_, _, _, _, _, hRest10⟩ := hRest9
+  obtain ⟨_, _, _, _, _, hRest11⟩ := hRest10
+  obtain ⟨_, _, _, _, _, hRest12⟩ := hRest11
+  obtain ⟨_, _, _, _, _, hRest13⟩ := hRest12
+  obtain ⟨_, _, _, _, _, hRest14⟩ := hRest13
+  obtain ⟨_, _, _, _, _, hRest15⟩ := hRest14
+  obtain ⟨_, _, _, _, _, hRest16⟩ := hRest15
+  have hC6 : c6 + signExtend12 (-1 : BitVec 12) = 0 :=
+    ((sepConj_pure_left _).1 hRest16).1
+  have hAfterC6 := ((sepConj_pure_left _).1 hRest16).2
+  obtain ⟨_, _, _, _, _, hRest17⟩ := hAfterC6
+  have hBit :
+      (e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12) = 0 :=
+    ((sepConj_pure_right _).1 hRest17).2
+  exact ⟨hExit, hC6, hBit⟩
+
 end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostCases.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostCases.lean
@@ -272,6 +272,46 @@ theorem expTwoMulFixedIterSkipCondCountPost_choose_scratch
     sep_perm h
   exact expTwoMulFixedIterScratchOwn_choose_two_frame hDecomp
 
+abbrev expTwoMulFixedIterSkipCountPostScratchPrefix
+    (iterCount sp evmSp r0 r1 r2 r3 : Word)
+    (exitCond : Prop) : Assertion :=
+  ((.x9 ↦ᵣ expTwoMulIterCountNew iterCount) ** (.x0 ↦ᵣ (0 : Word)) **
+    ⌜exitCond⌝) **
+    expTwoMulFixedIterSkipRestScratchPrefix sp evmSp r0 r1 r2 r3
+
+abbrev expTwoMulFixedIterSkipCountPostScratchSuffix
+    (e c6 evmSp a0 a1 a2 a3 base : Word) : Assertion :=
+  expTwoMulFixedIterSkipRestScratchSuffix e c6 base **
+    expTwoMulFixedIterBaseFrame evmSp a0 a1 a2 a3
+
+theorem expTwoMulFixedIterSkipCountPost_choose_scratch
+    {iterCount e c6 sp evmSp r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
+    {exitCond : Prop} {ps : PartialState}
+    (h :
+      expTwoMulFixedIterSkipCountPost iterCount e c6 sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base exitCond ps) :
+    ∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      (expTwoMulFixedIterSkipCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3 exitCond **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        expTwoMulFixedIterSkipCountPostScratchSuffix e c6 evmSp
+          a0 a1 a2 a3 base) ps := by
+  have hDecomp :
+      (expTwoMulFixedIterSkipCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3 exitCond **
+        expTwoMulFixedIterScratchOwn evmSp **
+        expTwoMulFixedIterSkipCountPostScratchSuffix e c6 evmSp
+          a0 a1 a2 a3 base) ps := by
+    unfold expTwoMulFixedIterSkipCountPost
+      expTwoMulFixedIterSkipRest
+      expTwoMulFixedIterSkipCountPostScratchPrefix
+      expTwoMulFixedIterSkipRestScratchPrefix
+      expTwoMulFixedIterScratchOwn
+      expTwoMulFixedIterSkipCountPostScratchSuffix
+      expTwoMulFixedIterSkipRestScratchSuffix at *
+    sep_perm h
+  exact expTwoMulFixedIterScratchOwn_choose_two_frame hDecomp
+
 theorem expTwoMulFixedIterCaseLoopPost_iff
     {iterCount e c6 ptr nextLimb sp evmSp
       r0 r1 r2 r3 a0 a1 a2 a3 base : Word} {ps : PartialState} :

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostCases.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostCases.lean
@@ -233,6 +233,45 @@ theorem expTwoMulFixedIterReloadSkipRest_choose_scratch
   have hDecomp := expTwoMulFixedIterReloadSkipRest_scratch_decomp h
   exact expTwoMulFixedIterScratchOwn_choose_two_frame hDecomp
 
+abbrev expTwoMulFixedIterSkipCondCountPostScratchPrefix
+    (iterCount sp evmSp r0 r1 r2 r3 a0 a1 a2 a3 : Word)
+    (exitCond : Prop) : Assertion :=
+  ((.x9 ↦ᵣ expTwoMulIterCountNew iterCount) ** (.x0 ↦ᵣ (0 : Word)) **
+    ⌜exitCond⌝) **
+    expTwoMulFixedIterSkipCondRestScratchPrefix sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3
+
+abbrev expTwoMulFixedIterSkipCondCountPostScratchSuffix
+    (e c6 base : Word) : Assertion :=
+  expTwoMulFixedIterSkipCondRestScratchSuffix base **
+    expTwoMulFixedIterSkipCondFrame e c6
+
+theorem expTwoMulFixedIterSkipCondCountPost_choose_scratch
+    {iterCount e c6 sp evmSp r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
+    {exitCond : Prop} {ps : PartialState}
+    (h :
+      expTwoMulFixedIterSkipCondCountPost iterCount e c6 sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base exitCond ps) :
+    ∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      (expTwoMulFixedIterSkipCondCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 exitCond **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        expTwoMulFixedIterSkipCondCountPostScratchSuffix e c6 base) ps := by
+  have hDecomp :
+      (expTwoMulFixedIterSkipCondCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 exitCond **
+        expTwoMulFixedIterScratchOwn evmSp **
+        expTwoMulFixedIterSkipCondCountPostScratchSuffix e c6 base) ps := by
+    unfold expTwoMulFixedIterSkipCondCountPost
+      expTwoMulFixedIterSkipCondRest
+      expTwoMulFixedIterSkipCondCountPostScratchPrefix
+      expTwoMulFixedIterSkipCondRestScratchPrefix
+      expTwoMulFixedIterScratchOwn
+      expTwoMulFixedIterSkipCondCountPostScratchSuffix
+      expTwoMulFixedIterSkipCondRestScratchSuffix at *
+    sep_perm h
+  exact expTwoMulFixedIterScratchOwn_choose_two_frame hDecomp
+
 theorem expTwoMulFixedIterCaseLoopPost_iff
     {iterCount e c6 ptr nextLimb sp evmSp
       r0 r1 r2 r3 a0 a1 a2 a3 base : Word} {ps : PartialState} :

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostCases.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostCases.lean
@@ -148,4 +148,60 @@ theorem expTwoMulFixedIterSkipExitPost_cases
   · exact Or.inl ⟨psLeft, psRight, hDisjoint, hUnion, hCond, hPtr⟩
   · exact Or.inr ⟨psLeft, psRight, hDisjoint, hUnion, hSkip, hPtr⟩
 
+theorem expTwoMulFixedIterCaseLoopPost_count_cases
+    {iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word} {ps : PartialState}
+    (h :
+      expTwoMulFixedIterCaseLoopPost iterCount e c6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base ps) :
+    (expTwoMulFixedIterSkipCondCountPost iterCount e c6 sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base
+      (expTwoMulIterCountNew iterCount ≠ 0) **
+      expTwoMulFixedIterPointerPost ptr nextLimb) ps ∨
+    (expTwoMulFixedIterSkipCountPost iterCount e c6 sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base
+      (expTwoMulIterCountNew iterCount ≠ 0) **
+      expTwoMulFixedIterPointerPost ptr nextLimb) ps ∨
+    expTwoMulFixedIterReloadCondCountPost iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base
+      (expTwoMulIterCountNew iterCount ≠ 0) ps ∨
+    expTwoMulFixedIterReloadSkipCountPost iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base
+      (expTwoMulIterCountNew iterCount ≠ 0) ps := by
+  rcases expTwoMulFixedIterCaseLoopPost_cases h with hSkip | hReload
+  · rcases expTwoMulFixedIterSkipLoopPost_cases hSkip with hCond | hSkipCount
+    · exact Or.inl hCond
+    · exact Or.inr (Or.inl hSkipCount)
+  · rcases expTwoMulFixedIterReloadLoopPost_cases hReload with hCond | hSkipCount
+    · exact Or.inr (Or.inr (Or.inl hCond))
+    · exact Or.inr (Or.inr (Or.inr hSkipCount))
+
+theorem expTwoMulFixedIterCaseExitPost_count_cases
+    {iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word} {ps : PartialState}
+    (h :
+      expTwoMulFixedIterCaseExitPost iterCount e c6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base ps) :
+    (expTwoMulFixedIterSkipCondCountPost iterCount e c6 sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base
+      (expTwoMulIterCountNew iterCount = 0) **
+      expTwoMulFixedIterPointerPost ptr nextLimb) ps ∨
+    (expTwoMulFixedIterSkipCountPost iterCount e c6 sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base
+      (expTwoMulIterCountNew iterCount = 0) **
+      expTwoMulFixedIterPointerPost ptr nextLimb) ps ∨
+    expTwoMulFixedIterReloadCondCountPost iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base
+      (expTwoMulIterCountNew iterCount = 0) ps ∨
+    expTwoMulFixedIterReloadSkipCountPost iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base
+      (expTwoMulIterCountNew iterCount = 0) ps := by
+  rcases expTwoMulFixedIterCaseExitPost_cases h with hSkip | hReload
+  · rcases expTwoMulFixedIterSkipExitPost_cases hSkip with hCond | hSkipCount
+    · exact Or.inl hCond
+    · exact Or.inr (Or.inl hSkipCount)
+  · rcases expTwoMulFixedIterReloadExitPost_cases hReload with hCond | hSkipCount
+    · exact Or.inr (Or.inr (Or.inl hCond))
+    · exact Or.inr (Or.inr (Or.inr hSkipCount))
+
 end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostCases.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostCases.lean
@@ -84,6 +84,17 @@ theorem expTwoMulFixedIterScratchOwn_choose
   refine ⟨ps_d2, ps_rest7, h_disjoint_d2, h_union_d2, h_d2, ?_⟩
   exact h_d3
 
+theorem expTwoMulFixedIterScratchOwn_choose_frame
+    {evmSp : Word} {B : Assertion} {ps : PartialState}
+    (h : (expTwoMulFixedIterScratchOwn evmSp ** B) ps) :
+    ∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      (expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 ** B) ps := by
+  obtain ⟨psScratch, psRest, h_disjoint, h_union, hScratch, hRest⟩ := h
+  obtain ⟨v6, v7, v10, v11, d0, d1, d2, d3, hScratchIs⟩ :=
+    expTwoMulFixedIterScratchOwn_choose hScratch
+  exact ⟨v6, v7, v10, v11, d0, d1, d2, d3,
+    psScratch, psRest, h_disjoint, h_union, hScratchIs, hRest⟩
+
 theorem expTwoMulFixedIterCaseLoopPost_iff
     {iterCount e c6 ptr nextLimb sp evmSp
       r0 r1 r2 r3 a0 a1 a2 a3 base : Word} {ps : PartialState} :

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostCases.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostCases.lean
@@ -108,6 +108,36 @@ theorem expTwoMulFixedIterScratchOwn_choose_two_frame
   refine ⟨v6, v7, v10, v11, d0, d1, d2, d3, ?_⟩
   sep_perm hChosen
 
+abbrev expTwoMulFixedIterSkipCondRestScratchPrefix
+    (sp evmSp r0 r1 r2 r3 a0 a1 a2 a3 : Word) : Assertion :=
+  let squareW := expSquaringCallSquareW r0 r1 r2 r3
+  let rw := expTwoMulCondRw squareW a0 a1 a2 a3
+  (.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) **
+  (.x5 ↦ᵣ rw.getLimbN 3) **
+  ((evmSp + signExtend12 ((-64) : BitVec 12)) ↦ₘ a0) **
+  ((evmSp + signExtend12 ((-56) : BitVec 12)) ↦ₘ a1) **
+  ((evmSp + signExtend12 ((-48) : BitVec 12)) ↦ₘ a2) **
+  ((evmSp + signExtend12 ((-40) : BitVec 12)) ↦ₘ a3) **
+  evmWordIs sp rw ** evmWordIs (evmSp + 32) rw
+
+abbrev expTwoMulFixedIterSkipCondRestScratchSuffix (base : Word) : Assertion :=
+  (.x1 ↦ᵣ (((base + 44) + 140) + 68))
+
+theorem expTwoMulFixedIterSkipCondRest_scratch_decomp
+    {sp evmSp r0 r1 r2 r3 a0 a1 a2 a3 base : Word} {ps : PartialState}
+    (h :
+      expTwoMulFixedIterSkipCondRest sp evmSp r0 r1 r2 r3
+        a0 a1 a2 a3 base ps) :
+    (expTwoMulFixedIterSkipCondRestScratchPrefix sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 **
+      expTwoMulFixedIterScratchOwn evmSp **
+      expTwoMulFixedIterSkipCondRestScratchSuffix base) ps := by
+  unfold expTwoMulFixedIterSkipCondRest
+    expTwoMulFixedIterSkipCondRestScratchPrefix
+    expTwoMulFixedIterScratchOwn
+    expTwoMulFixedIterSkipCondRestScratchSuffix at *
+  sep_perm h
+
 theorem expTwoMulFixedIterCaseLoopPost_iff
     {iterCount e c6 ptr nextLimb sp evmSp
       r0 r1 r2 r3 a0 a1 a2 a3 base : Word} {ps : PartialState} :

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostCases.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostCases.lean
@@ -45,6 +45,45 @@ instance pcFreeInst_expTwoMulFixedIterScratchIs
         d0 d1 d2 d3) :=
   ⟨expTwoMulFixedIterScratchIs_pcFree⟩
 
+theorem expTwoMulFixedIterScratchOwn_choose
+    {evmSp : Word} {ps : PartialState}
+    (h : expTwoMulFixedIterScratchOwn evmSp ps) :
+    ∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 ps := by
+  unfold expTwoMulFixedIterScratchOwn at h
+  obtain ⟨v6, h_v6_chain⟩ := sepConj_choose_regOwn h
+  obtain ⟨ps_v6, ps_rest1, h_disjoint_v6, h_union_v6, h_v6, h_rest1⟩ :=
+    h_v6_chain
+  obtain ⟨v7, h_v7_chain⟩ := sepConj_choose_regOwn h_rest1
+  obtain ⟨ps_v7, ps_rest2, h_disjoint_v7, h_union_v7, h_v7, h_rest2⟩ :=
+    h_v7_chain
+  obtain ⟨v10, h_v10_chain⟩ := sepConj_choose_regOwn h_rest2
+  obtain ⟨ps_v10, ps_rest3, h_disjoint_v10, h_union_v10, h_v10, h_rest3⟩ :=
+    h_v10_chain
+  obtain ⟨v11, h_v11_chain⟩ := sepConj_choose_regOwn h_rest3
+  obtain ⟨ps_v11, ps_rest4, h_disjoint_v11, h_union_v11, h_v11, h_rest4⟩ :=
+    h_v11_chain
+  obtain ⟨d0, h_d0_chain⟩ := sepConj_choose_memOwn h_rest4
+  obtain ⟨ps_d0, ps_rest5, h_disjoint_d0, h_union_d0, h_d0, h_rest5⟩ :=
+    h_d0_chain
+  obtain ⟨d1, h_d1_chain⟩ := sepConj_choose_memOwn h_rest5
+  obtain ⟨ps_d1, ps_rest6, h_disjoint_d1, h_union_d1, h_d1, h_rest6⟩ :=
+    h_d1_chain
+  obtain ⟨d2, h_d2_chain⟩ := sepConj_choose_memOwn h_rest6
+  obtain ⟨ps_d2, ps_rest7, h_disjoint_d2, h_union_d2, h_d2, h_rest7⟩ :=
+    h_d2_chain
+  obtain ⟨d3, h_d3⟩ := h_rest7
+  refine ⟨v6, v7, v10, v11, d0, d1, d2, d3, ?_⟩
+  unfold expTwoMulFixedIterScratchIs
+  refine ⟨ps_v6, ps_rest1, h_disjoint_v6, h_union_v6, h_v6, ?_⟩
+  refine ⟨ps_v7, ps_rest2, h_disjoint_v7, h_union_v7, h_v7, ?_⟩
+  refine ⟨ps_v10, ps_rest3, h_disjoint_v10, h_union_v10, h_v10, ?_⟩
+  refine ⟨ps_v11, ps_rest4, h_disjoint_v11, h_union_v11, h_v11, ?_⟩
+  refine ⟨ps_d0, ps_rest5, h_disjoint_d0, h_union_d0, h_d0, ?_⟩
+  refine ⟨ps_d1, ps_rest6, h_disjoint_d1, h_union_d1, h_d1, ?_⟩
+  refine ⟨ps_d2, ps_rest7, h_disjoint_d2, h_union_d2, h_d2, ?_⟩
+  exact h_d3
+
 theorem expTwoMulFixedIterCaseLoopPost_iff
     {iterCount e c6 ptr nextLimb sp evmSp
       r0 r1 r2 r3 a0 a1 a2 a3 base : Word} {ps : PartialState} :

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostCases.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostCases.lean
@@ -10,6 +10,41 @@ namespace EvmAsm.Evm64.Exp.Compose
 
 open EvmAsm.Rv64
 
+abbrev expTwoMulFixedIterScratchOwn (evmSp : Word) : Assertion :=
+  regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
+  memOwn evmSp ** memOwn (evmSp + 8) **
+  memOwn (evmSp + 16) ** memOwn (evmSp + 24)
+
+abbrev expTwoMulFixedIterScratchIs
+    (evmSp v6 v7 v10 v11 d0 d1 d2 d3 : Word) : Assertion :=
+  (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+  (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) **
+  (evmSp ↦ₘ d0) ** (evmSp + 8 ↦ₘ d1) **
+  (evmSp + 16 ↦ₘ d2) ** (evmSp + 24 ↦ₘ d3)
+
+theorem expTwoMulFixedIterScratchOwn_pcFree {evmSp : Word} :
+    (expTwoMulFixedIterScratchOwn evmSp).pcFree := by
+  unfold expTwoMulFixedIterScratchOwn
+  pcFree
+
+theorem expTwoMulFixedIterScratchIs_pcFree
+    {evmSp v6 v7 v10 v11 d0 d1 d2 d3 : Word} :
+    (expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11
+      d0 d1 d2 d3).pcFree := by
+  unfold expTwoMulFixedIterScratchIs
+  pcFree
+
+instance pcFreeInst_expTwoMulFixedIterScratchOwn (evmSp : Word) :
+    Assertion.PCFree (expTwoMulFixedIterScratchOwn evmSp) :=
+  ⟨expTwoMulFixedIterScratchOwn_pcFree⟩
+
+instance pcFreeInst_expTwoMulFixedIterScratchIs
+    (evmSp v6 v7 v10 v11 d0 d1 d2 d3 : Word) :
+    Assertion.PCFree
+      (expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11
+        d0 d1 d2 d3) :=
+  ⟨expTwoMulFixedIterScratchIs_pcFree⟩
+
 theorem expTwoMulFixedIterCaseLoopPost_iff
     {iterCount e c6 ptr nextLimb sp evmSp
       r0 r1 r2 r3 a0 a1 a2 a3 base : Word} {ps : PartialState} :

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostCases.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostCases.lean
@@ -1,0 +1,113 @@
+/-
+  EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePostCases
+
+  Case-splitting lemmas for fixed x19 named case-post assertions.
+-/
+
+import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePostBridge
+
+namespace EvmAsm.Evm64.Exp.Compose
+
+open EvmAsm.Rv64
+
+theorem expTwoMulFixedIterCaseLoopPost_iff
+    {iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word} {ps : PartialState} :
+    expTwoMulFixedIterCaseLoopPost iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base ps ↔
+    expTwoMulFixedIterSkipLoopPost iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base ps ∨
+    expTwoMulFixedIterReloadLoopPost iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base ps := by
+  rfl
+
+theorem expTwoMulFixedIterCaseExitPost_iff
+    {iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word} {ps : PartialState} :
+    expTwoMulFixedIterCaseExitPost iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base ps ↔
+    expTwoMulFixedIterSkipExitPost iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base ps ∨
+    expTwoMulFixedIterReloadExitPost iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base ps := by
+  rfl
+
+theorem expTwoMulFixedIterReloadLoopPost_iff
+    {iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word} {ps : PartialState} :
+    expTwoMulFixedIterReloadLoopPost iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base ps ↔
+    expTwoMulFixedIterReloadCondCountPost iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base
+      (expTwoMulIterCountNew iterCount ≠ 0) ps ∨
+    expTwoMulFixedIterReloadSkipCountPost iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base
+      (expTwoMulIterCountNew iterCount ≠ 0) ps := by
+  rfl
+
+theorem expTwoMulFixedIterReloadExitPost_iff
+    {iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word} {ps : PartialState} :
+    expTwoMulFixedIterReloadExitPost iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base ps ↔
+    expTwoMulFixedIterReloadCondCountPost iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base
+      (expTwoMulIterCountNew iterCount = 0) ps ∨
+    expTwoMulFixedIterReloadSkipCountPost iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base
+      (expTwoMulIterCountNew iterCount = 0) ps := by
+  rfl
+
+theorem expTwoMulFixedIterCaseLoopPost_cases
+    {iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word} {ps : PartialState}
+    (h :
+      expTwoMulFixedIterCaseLoopPost iterCount e c6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base ps) :
+    expTwoMulFixedIterSkipLoopPost iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base ps ∨
+    expTwoMulFixedIterReloadLoopPost iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base ps :=
+  expTwoMulFixedIterCaseLoopPost_iff.mp h
+
+theorem expTwoMulFixedIterCaseExitPost_cases
+    {iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word} {ps : PartialState}
+    (h :
+      expTwoMulFixedIterCaseExitPost iterCount e c6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base ps) :
+    expTwoMulFixedIterSkipExitPost iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base ps ∨
+    expTwoMulFixedIterReloadExitPost iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base ps :=
+  expTwoMulFixedIterCaseExitPost_iff.mp h
+
+theorem expTwoMulFixedIterReloadLoopPost_cases
+    {iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word} {ps : PartialState}
+    (h :
+      expTwoMulFixedIterReloadLoopPost iterCount e c6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base ps) :
+    expTwoMulFixedIterReloadCondCountPost iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base
+      (expTwoMulIterCountNew iterCount ≠ 0) ps ∨
+    expTwoMulFixedIterReloadSkipCountPost iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base
+      (expTwoMulIterCountNew iterCount ≠ 0) ps :=
+  expTwoMulFixedIterReloadLoopPost_iff.mp h
+
+theorem expTwoMulFixedIterReloadExitPost_cases
+    {iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word} {ps : PartialState}
+    (h :
+      expTwoMulFixedIterReloadExitPost iterCount e c6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base ps) :
+    expTwoMulFixedIterReloadCondCountPost iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base
+      (expTwoMulIterCountNew iterCount = 0) ps ∨
+    expTwoMulFixedIterReloadSkipCountPost iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base
+      (expTwoMulIterCountNew iterCount = 0) ps :=
+  expTwoMulFixedIterReloadExitPost_iff.mp h
+
+end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostCases.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostCases.lean
@@ -346,6 +346,40 @@ theorem expTwoMulFixedIterReloadCondCountPost_choose_scratch
     sep_perm h
   exact expTwoMulFixedIterScratchOwn_choose_two_frame hDecomp
 
+abbrev expTwoMulFixedIterReloadSkipCountPostScratchSuffix
+    (e c6 ptr nextLimb evmSp a0 a1 a2 a3 base : Word) : Assertion :=
+  expTwoMulFixedIterReloadSkipRestScratchSuffix e c6 ptr nextLimb base **
+    expTwoMulFixedIterBaseFrame evmSp a0 a1 a2 a3
+
+theorem expTwoMulFixedIterReloadSkipCountPost_choose_scratch
+    {iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
+    {exitCond : Prop} {ps : PartialState}
+    (h :
+      expTwoMulFixedIterReloadSkipCountPost iterCount e c6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base exitCond ps) :
+    ∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      (expTwoMulFixedIterSkipCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3 exitCond **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        expTwoMulFixedIterReloadSkipCountPostScratchSuffix
+          e c6 ptr nextLimb evmSp a0 a1 a2 a3 base) ps := by
+  have hDecomp :
+      (expTwoMulFixedIterSkipCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3 exitCond **
+        expTwoMulFixedIterScratchOwn evmSp **
+        expTwoMulFixedIterReloadSkipCountPostScratchSuffix
+          e c6 ptr nextLimb evmSp a0 a1 a2 a3 base) ps := by
+    unfold expTwoMulFixedIterReloadSkipCountPost
+      expTwoMulFixedIterReloadSkipRest
+      expTwoMulFixedIterSkipCountPostScratchPrefix
+      expTwoMulFixedIterSkipRestScratchPrefix
+      expTwoMulFixedIterScratchOwn
+      expTwoMulFixedIterReloadSkipCountPostScratchSuffix
+      expTwoMulFixedIterReloadSkipRestScratchSuffix at *
+    sep_perm h
+  exact expTwoMulFixedIterScratchOwn_choose_two_frame hDecomp
+
 theorem expTwoMulFixedIterCaseLoopPost_iff
     {iterCount e c6 ptr nextLimb sp evmSp
       r0 r1 r2 r3 a0 a1 a2 a3 base : Word} {ps : PartialState} :

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostCases.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostCases.lean
@@ -728,6 +728,70 @@ theorem expTwoMulFixedIterCaseExitPost_scratch_cases
       · exact Or.inr (Or.inr (Or.inr
           (expTwoMulFixedIterReloadSkipCountPost_choose_scratch hReloadSkip)))
 
+theorem expTwoMulFixedIterCaseLoopPost_scratch_cases_frame
+    {iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
+    {frame : Assertion} {ps : PartialState}
+    (h :
+      (expTwoMulFixedIterCaseLoopPost iterCount e c6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base **
+        frame) ps) :
+    (∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      ((expTwoMulFixedIterSkipCondCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3
+        (expTwoMulIterCountNew iterCount ≠ 0) **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        (expTwoMulFixedIterSkipCondCountPostScratchSuffix e c6 base **
+          expTwoMulFixedIterPointerPost ptr nextLimb)) **
+        frame) ps) ∨
+    (∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      ((expTwoMulFixedIterSkipCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3
+        (expTwoMulIterCountNew iterCount ≠ 0) **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        (expTwoMulFixedIterSkipCountPostScratchSuffix e c6 evmSp
+          a0 a1 a2 a3 base **
+          expTwoMulFixedIterPointerPost ptr nextLimb)) **
+        frame) ps) ∨
+    (∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      ((expTwoMulFixedIterSkipCondCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3
+        (expTwoMulIterCountNew iterCount ≠ 0) **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        expTwoMulFixedIterReloadCondCountPostScratchSuffix
+          e c6 ptr nextLimb base) **
+        frame) ps) ∨
+    (∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      ((expTwoMulFixedIterSkipCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3
+        (expTwoMulIterCountNew iterCount ≠ 0) **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        expTwoMulFixedIterReloadSkipCountPostScratchSuffix
+          e c6 ptr nextLimb evmSp a0 a1 a2 a3 base) **
+        frame) ps) := by
+  obtain ⟨psCase, psFrame, hDisjoint, hUnion, hCase, hFrame⟩ := h
+  rcases expTwoMulFixedIterCaseLoopPost_scratch_cases hCase with hSkipCond | hRest
+  · rcases hSkipCond with ⟨v6, v7, v10, v11, d0, d1, d2, d3, hScratch⟩
+    exact Or.inl
+      ⟨v6, v7, v10, v11, d0, d1, d2, d3,
+        psCase, psFrame, hDisjoint, hUnion, hScratch, hFrame⟩
+  · rcases hRest with hSkip | hRest
+    · rcases hSkip with ⟨v6, v7, v10, v11, d0, d1, d2, d3, hScratch⟩
+      exact Or.inr (Or.inl
+        ⟨v6, v7, v10, v11, d0, d1, d2, d3,
+          psCase, psFrame, hDisjoint, hUnion, hScratch, hFrame⟩)
+    · rcases hRest with hReloadCond | hReloadSkip
+      · rcases hReloadCond with
+          ⟨v6, v7, v10, v11, d0, d1, d2, d3, hScratch⟩
+        exact Or.inr (Or.inr (Or.inl
+          ⟨v6, v7, v10, v11, d0, d1, d2, d3,
+            psCase, psFrame, hDisjoint, hUnion, hScratch, hFrame⟩))
+      · rcases hReloadSkip with
+          ⟨v6, v7, v10, v11, d0, d1, d2, d3, hScratch⟩
+        exact Or.inr (Or.inr (Or.inr
+          ⟨v6, v7, v10, v11, d0, d1, d2, d3,
+            psCase, psFrame, hDisjoint, hUnion, hScratch, hFrame⟩))
+
 theorem expTwoMulFixedIterSkipCondCountPost_pures
     {iterCount e c6 sp evmSp r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
     {exitCond : Prop} {ps : PartialState}

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostCases.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostCases.lean
@@ -634,6 +634,53 @@ theorem expTwoMulFixedIterCaseExitPost_count_cases
     · exact Or.inr (Or.inr (Or.inl hCond))
     · exact Or.inr (Or.inr (Or.inr hSkipCount))
 
+theorem expTwoMulFixedIterCaseLoopPost_scratch_cases
+    {iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word} {ps : PartialState}
+    (h :
+      expTwoMulFixedIterCaseLoopPost iterCount e c6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base ps) :
+    (∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      (expTwoMulFixedIterSkipCondCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3
+        (expTwoMulIterCountNew iterCount ≠ 0) **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        (expTwoMulFixedIterSkipCondCountPostScratchSuffix e c6 base **
+          expTwoMulFixedIterPointerPost ptr nextLimb)) ps) ∨
+    (∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      (expTwoMulFixedIterSkipCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3
+        (expTwoMulIterCountNew iterCount ≠ 0) **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        (expTwoMulFixedIterSkipCountPostScratchSuffix e c6 evmSp
+          a0 a1 a2 a3 base **
+          expTwoMulFixedIterPointerPost ptr nextLimb)) ps) ∨
+    (∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      (expTwoMulFixedIterSkipCondCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3
+        (expTwoMulIterCountNew iterCount ≠ 0) **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        expTwoMulFixedIterReloadCondCountPostScratchSuffix
+          e c6 ptr nextLimb base) ps) ∨
+    (∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      (expTwoMulFixedIterSkipCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3
+        (expTwoMulIterCountNew iterCount ≠ 0) **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        expTwoMulFixedIterReloadSkipCountPostScratchSuffix
+          e c6 ptr nextLimb evmSp a0 a1 a2 a3 base) ps) := by
+  rcases expTwoMulFixedIterCaseLoopPost_count_cases h with hSkipCond | hRest
+  · exact Or.inl
+      (expTwoMulFixedIterSkipCondCountPost_choose_scratch_frame hSkipCond)
+  · rcases hRest with hSkip | hRest
+    · exact Or.inr (Or.inl
+        (expTwoMulFixedIterSkipCountPost_choose_scratch_frame hSkip))
+    · rcases hRest with hReloadCond | hReloadSkip
+      · exact Or.inr (Or.inr (Or.inl
+          (expTwoMulFixedIterReloadCondCountPost_choose_scratch hReloadCond)))
+      · exact Or.inr (Or.inr (Or.inr
+          (expTwoMulFixedIterReloadSkipCountPost_choose_scratch hReloadSkip)))
+
 theorem expTwoMulFixedIterSkipCondCountPost_pures
     {iterCount e c6 sp evmSp r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
     {exitCond : Prop} {ps : PartialState}

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostCases.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostCases.lean
@@ -380,6 +380,66 @@ theorem expTwoMulFixedIterReloadSkipCountPost_choose_scratch
     sep_perm h
   exact expTwoMulFixedIterScratchOwn_choose_two_frame hDecomp
 
+theorem expTwoMulFixedIterSkipCondCountPost_choose_scratch_frame
+    {iterCount e c6 sp evmSp r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
+    {exitCond : Prop} {frame : Assertion} {ps : PartialState}
+    (h :
+      (expTwoMulFixedIterSkipCondCountPost iterCount e c6 sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base exitCond **
+        frame) ps) :
+    ∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      (expTwoMulFixedIterSkipCondCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 exitCond **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        (expTwoMulFixedIterSkipCondCountPostScratchSuffix e c6 base **
+          frame)) ps := by
+  have hDecomp :
+      (expTwoMulFixedIterSkipCondCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 exitCond **
+        expTwoMulFixedIterScratchOwn evmSp **
+        (expTwoMulFixedIterSkipCondCountPostScratchSuffix e c6 base **
+          frame)) ps := by
+    unfold expTwoMulFixedIterSkipCondCountPost
+      expTwoMulFixedIterSkipCondRest
+      expTwoMulFixedIterSkipCondCountPostScratchPrefix
+      expTwoMulFixedIterSkipCondRestScratchPrefix
+      expTwoMulFixedIterScratchOwn
+      expTwoMulFixedIterSkipCondCountPostScratchSuffix
+      expTwoMulFixedIterSkipCondRestScratchSuffix at *
+    sep_perm h
+  exact expTwoMulFixedIterScratchOwn_choose_two_frame hDecomp
+
+theorem expTwoMulFixedIterSkipCountPost_choose_scratch_frame
+    {iterCount e c6 sp evmSp r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
+    {exitCond : Prop} {frame : Assertion} {ps : PartialState}
+    (h :
+      (expTwoMulFixedIterSkipCountPost iterCount e c6 sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base exitCond **
+        frame) ps) :
+    ∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      (expTwoMulFixedIterSkipCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3 exitCond **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        (expTwoMulFixedIterSkipCountPostScratchSuffix e c6 evmSp
+          a0 a1 a2 a3 base **
+          frame)) ps := by
+  have hDecomp :
+      (expTwoMulFixedIterSkipCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3 exitCond **
+        expTwoMulFixedIterScratchOwn evmSp **
+        (expTwoMulFixedIterSkipCountPostScratchSuffix e c6 evmSp
+          a0 a1 a2 a3 base **
+          frame)) ps := by
+    unfold expTwoMulFixedIterSkipCountPost
+      expTwoMulFixedIterSkipRest
+      expTwoMulFixedIterSkipCountPostScratchPrefix
+      expTwoMulFixedIterSkipRestScratchPrefix
+      expTwoMulFixedIterScratchOwn
+      expTwoMulFixedIterSkipCountPostScratchSuffix
+      expTwoMulFixedIterSkipRestScratchSuffix at *
+    sep_perm h
+  exact expTwoMulFixedIterScratchOwn_choose_two_frame hDecomp
+
 theorem expTwoMulFixedIterCaseLoopPost_iff
     {iterCount e c6 ptr nextLimb sp evmSp
       r0 r1 r2 r3 a0 a1 a2 a3 base : Word} {ps : PartialState} :

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostCases.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostCases.lean
@@ -226,4 +226,40 @@ theorem expTwoMulFixedIterSkipCondCountPost_pures
   obtain ⟨_, hBit⟩ := ((sepConj_pure_left _).1 hPureTail).2
   exact ⟨hExit, hC6, hBit⟩
 
+theorem expTwoMulFixedIterSkipCountPost_pures
+    {iterCount e c6 sp evmSp r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
+    {exitCond : Prop} {ps : PartialState}
+    (h :
+      expTwoMulFixedIterSkipCountPost iterCount e c6 sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base exitCond ps) :
+    exitCond ∧
+    c6 + signExtend12 (-1 : BitVec 12) ≠ 0 ∧
+    (e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12) = 0 := by
+  unfold expTwoMulFixedIterSkipCountPost
+    expTwoMulFixedIterSkipRest at h
+  obtain ⟨_, _, _, _, hMain, _hBaseFrame⟩ := h
+  obtain ⟨_, _, _, _, hCount, hRest⟩ := hMain
+  obtain ⟨_, _, _, _, _, hCountTail⟩ := hCount
+  have hExit : exitCond := ((sepConj_pure_right _).1 hCountTail).2
+  obtain ⟨_, _, _, _, _, hRest1⟩ := hRest
+  obtain ⟨_, _, _, _, _, hRest2⟩ := hRest1
+  obtain ⟨_, _, _, _, _, hRest3⟩ := hRest2
+  obtain ⟨_, _, _, _, _, hRest4⟩ := hRest3
+  obtain ⟨_, _, _, _, _, hRest5⟩ := hRest4
+  obtain ⟨_, _, _, _, _, hRest6⟩ := hRest5
+  obtain ⟨_, _, _, _, _, hRest7⟩ := hRest6
+  obtain ⟨_, _, _, _, _, hRest8⟩ := hRest7
+  obtain ⟨_, _, _, _, _, hRest9⟩ := hRest8
+  obtain ⟨_, _, _, _, _, hRest10⟩ := hRest9
+  obtain ⟨_, _, _, _, _, hRest11⟩ := hRest10
+  obtain ⟨_, _, _, _, _, hRest12⟩ := hRest11
+  obtain ⟨_, _, _, _, _, hRest13⟩ := hRest12
+  obtain ⟨_, _, _, _, _, hRest14⟩ := hRest13
+  obtain ⟨_, _, _, _, _, hRest15⟩ := hRest14
+  obtain ⟨_, _, _, _, _, hPureTail⟩ := hRest15
+  have hC6 : c6 + signExtend12 (-1 : BitVec 12) ≠ 0 :=
+    ((sepConj_pure_left _).1 hPureTail).1
+  obtain ⟨_, hBit⟩ := ((sepConj_pure_left _).1 hPureTail).2
+  exact ⟨hExit, hC6, hBit⟩
+
 end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostCases.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostCases.lean
@@ -329,4 +329,76 @@ theorem expTwoMulFixedIterReloadSkipCountPost_pures
     ((sepConj_pure_right _).1 hRest17).2
   exact ⟨hExit, hC6, hBit⟩
 
+theorem expTwoMulFixedIterCaseLoopPost_pure_cases
+    {iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word} {ps : PartialState}
+    (h :
+      expTwoMulFixedIterCaseLoopPost iterCount e c6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base ps) :
+    (expTwoMulIterCountNew iterCount ≠ 0 ∧
+      c6 + signExtend12 (-1 : BitVec 12) ≠ 0 ∧
+      (e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12) ≠ 0) ∨
+    (expTwoMulIterCountNew iterCount ≠ 0 ∧
+      c6 + signExtend12 (-1 : BitVec 12) ≠ 0 ∧
+      (e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12) = 0) ∨
+    (expTwoMulIterCountNew iterCount ≠ 0 ∧
+      c6 + signExtend12 (-1 : BitVec 12) = 0 ∧
+      (e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12) ≠ 0) ∨
+    (expTwoMulIterCountNew iterCount ≠ 0 ∧
+      c6 + signExtend12 (-1 : BitVec 12) = 0 ∧
+      (e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12) = 0) := by
+  rcases expTwoMulFixedIterCaseLoopPost_count_cases h with hSkipCond | hRest
+  · obtain ⟨_, _, _, _, hSkipCondPost, _⟩ := hSkipCond
+    obtain ⟨hExit, hC6, hBit⟩ :=
+      expTwoMulFixedIterSkipCondCountPost_pures hSkipCondPost
+    exact Or.inl ⟨hExit, hC6, hBit⟩
+  · rcases hRest with hSkip | hRest
+    · obtain ⟨_, _, _, _, hSkipPost, _⟩ := hSkip
+      obtain ⟨hExit, hC6, hBit⟩ :=
+        expTwoMulFixedIterSkipCountPost_pures hSkipPost
+      exact Or.inr (Or.inl ⟨hExit, hC6, hBit⟩)
+    · rcases hRest with hReloadCond | hReloadSkip
+      · obtain ⟨hExit, hC6, hBit⟩ :=
+          expTwoMulFixedIterReloadCondCountPost_pures hReloadCond
+        exact Or.inr (Or.inr (Or.inl ⟨hExit, hC6, hBit⟩))
+      · obtain ⟨hExit, hC6, hBit⟩ :=
+          expTwoMulFixedIterReloadSkipCountPost_pures hReloadSkip
+        exact Or.inr (Or.inr (Or.inr ⟨hExit, hC6, hBit⟩))
+
+theorem expTwoMulFixedIterCaseExitPost_pure_cases
+    {iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word} {ps : PartialState}
+    (h :
+      expTwoMulFixedIterCaseExitPost iterCount e c6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base ps) :
+    (expTwoMulIterCountNew iterCount = 0 ∧
+      c6 + signExtend12 (-1 : BitVec 12) ≠ 0 ∧
+      (e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12) ≠ 0) ∨
+    (expTwoMulIterCountNew iterCount = 0 ∧
+      c6 + signExtend12 (-1 : BitVec 12) ≠ 0 ∧
+      (e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12) = 0) ∨
+    (expTwoMulIterCountNew iterCount = 0 ∧
+      c6 + signExtend12 (-1 : BitVec 12) = 0 ∧
+      (e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12) ≠ 0) ∨
+    (expTwoMulIterCountNew iterCount = 0 ∧
+      c6 + signExtend12 (-1 : BitVec 12) = 0 ∧
+      (e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12) = 0) := by
+  rcases expTwoMulFixedIterCaseExitPost_count_cases h with hSkipCond | hRest
+  · obtain ⟨_, _, _, _, hSkipCondPost, _⟩ := hSkipCond
+    obtain ⟨hExit, hC6, hBit⟩ :=
+      expTwoMulFixedIterSkipCondCountPost_pures hSkipCondPost
+    exact Or.inl ⟨hExit, hC6, hBit⟩
+  · rcases hRest with hSkip | hRest
+    · obtain ⟨_, _, _, _, hSkipPost, _⟩ := hSkip
+      obtain ⟨hExit, hC6, hBit⟩ :=
+        expTwoMulFixedIterSkipCountPost_pures hSkipPost
+      exact Or.inr (Or.inl ⟨hExit, hC6, hBit⟩)
+    · rcases hRest with hReloadCond | hReloadSkip
+      · obtain ⟨hExit, hC6, hBit⟩ :=
+          expTwoMulFixedIterReloadCondCountPost_pures hReloadCond
+        exact Or.inr (Or.inr (Or.inl ⟨hExit, hC6, hBit⟩))
+      · obtain ⟨hExit, hC6, hBit⟩ :=
+          expTwoMulFixedIterReloadSkipCountPost_pures hReloadSkip
+        exact Or.inr (Or.inr (Or.inr ⟨hExit, hC6, hBit⟩))
+
 end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostCases.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostCases.lean
@@ -208,6 +208,18 @@ theorem expTwoMulFixedIterSkipCondRest_choose_scratch
   have hDecomp := expTwoMulFixedIterSkipCondRest_scratch_decomp h
   exact expTwoMulFixedIterScratchOwn_choose_two_frame hDecomp
 
+theorem expTwoMulFixedIterSkipRest_choose_scratch
+    {e c6 sp evmSp r0 r1 r2 r3 base : Word} {ps : PartialState}
+    (h :
+      expTwoMulFixedIterSkipRest e c6 sp evmSp
+        r0 r1 r2 r3 base ps) :
+    ∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      (expTwoMulFixedIterSkipRestScratchPrefix sp evmSp r0 r1 r2 r3 **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        expTwoMulFixedIterSkipRestScratchSuffix e c6 base) ps := by
+  have hDecomp := expTwoMulFixedIterSkipRest_scratch_decomp h
+  exact expTwoMulFixedIterScratchOwn_choose_two_frame hDecomp
+
 theorem expTwoMulFixedIterCaseLoopPost_iff
     {iterCount e c6 ptr nextLimb sp evmSp
       r0 r1 r2 r3 a0 a1 a2 a3 base : Word} {ps : PartialState} :

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostFramedCases.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostFramedCases.lean
@@ -10,6 +10,12 @@ namespace EvmAsm.Evm64.Exp.Compose
 
 open EvmAsm.Rv64
 
+theorem expTwoMulFixedIterPointerPost_eq_pointerFrame
+    {ptr nextLimb : Word} :
+    expTwoMulFixedIterPointerPost ptr nextLimb =
+      expTwoMulFixedIterPointerFrame ptr nextLimb := by
+  rw [expTwoMulFixedIterPointerFrame_unfold]
+
 theorem expTwoMulFixedIterCaseExitPost_scratch_cases_frame
     {iterCount e c6 ptr nextLimb sp evmSp
       r0 r1 r2 r3 a0 a1 a2 a3 base : Word}

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostFramedCases.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostFramedCases.lean
@@ -16,6 +16,79 @@ theorem expTwoMulFixedIterPointerPost_eq_pointerFrame
       expTwoMulFixedIterPointerFrame ptr nextLimb := by
   rw [expTwoMulFixedIterPointerFrame_unfold]
 
+@[irreducible]
+def expTwoMulFixedIterReloadPointerFrame
+    (ptr nextLimb : Word) : Assertion :=
+  (.x16 ↦ᵣ (ptr + signExtend12 (-8 : BitVec 12))) **
+  ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb)
+
+theorem expTwoMulFixedIterReloadPointerFrame_unfold {ptr nextLimb : Word} :
+    expTwoMulFixedIterReloadPointerFrame ptr nextLimb =
+      ((.x16 ↦ᵣ (ptr + signExtend12 (-8 : BitVec 12))) **
+       ((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb)) := by
+  delta expTwoMulFixedIterReloadPointerFrame
+  rfl
+
+theorem expTwoMulFixedIterReloadPointerFrame_pcFree {ptr nextLimb : Word} :
+    (expTwoMulFixedIterReloadPointerFrame ptr nextLimb).pcFree := by
+  rw [expTwoMulFixedIterReloadPointerFrame_unfold]
+  pcFree
+
+instance pcFreeInst_expTwoMulFixedIterReloadPointerFrame
+    (ptr nextLimb : Word) :
+    Assertion.PCFree (expTwoMulFixedIterReloadPointerFrame ptr nextLimb) :=
+  ⟨expTwoMulFixedIterReloadPointerFrame_pcFree⟩
+
+abbrev expTwoMulFixedIterReloadCondCountPostScratchSuffixFrame
+    (e c6 ptr nextLimb base : Word) : Assertion :=
+  let bit := e >>> (63 : BitVec 6).toNat
+  let c6New := c6 + signExtend12 (-1 : BitVec 12)
+  expTwoMulFixedIterSkipCondRestScratchSuffix base **
+  (.x19 ↦ᵣ nextLimb) **
+  (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
+  ⌜c6New = 0⌝ **
+  expTwoMulFixedIterReloadPointerFrame ptr nextLimb **
+  ⌜bit + signExtend12 (0 : BitVec 12) ≠ 0⌝
+
+theorem expTwoMulFixedIterReloadCondCountPostScratchSuffix_frame
+    {e c6 ptr nextLimb base : Word} {ps : PartialState}
+    (h :
+      expTwoMulFixedIterReloadCondCountPostScratchSuffix
+        e c6 ptr nextLimb base ps) :
+    expTwoMulFixedIterReloadCondCountPostScratchSuffixFrame
+      e c6 ptr nextLimb base ps := by
+  unfold expTwoMulFixedIterReloadCondCountPostScratchSuffix
+    expTwoMulFixedIterReloadCondFrame at h
+  unfold expTwoMulFixedIterReloadCondCountPostScratchSuffixFrame
+  rw [expTwoMulFixedIterReloadPointerFrame_unfold]
+  sep_perm h
+
+abbrev expTwoMulFixedIterReloadSkipCountPostScratchSuffixFrame
+    (e c6 ptr nextLimb evmSp a0 a1 a2 a3 base : Word) : Assertion :=
+  let bit := e >>> (63 : BitVec 6).toNat
+  let c6New := c6 + signExtend12 (-1 : BitVec 12)
+  (.x1 ↦ᵣ (((base + 44) + 32) + 68)) **
+  (.x19 ↦ᵣ nextLimb) **
+  (.x18 ↦ᵣ (bit + signExtend12 (0 : BitVec 12))) **
+  ⌜c6New = 0⌝ **
+  expTwoMulFixedIterReloadPointerFrame ptr nextLimb **
+  ⌜bit + signExtend12 (0 : BitVec 12) = 0⌝ **
+  expTwoMulFixedIterBaseFrame evmSp a0 a1 a2 a3
+
+theorem expTwoMulFixedIterReloadSkipCountPostScratchSuffix_frame
+    {e c6 ptr nextLimb evmSp a0 a1 a2 a3 base : Word}
+    {ps : PartialState}
+    (h :
+      expTwoMulFixedIterReloadSkipCountPostScratchSuffix
+        e c6 ptr nextLimb evmSp a0 a1 a2 a3 base ps) :
+    expTwoMulFixedIterReloadSkipCountPostScratchSuffixFrame
+      e c6 ptr nextLimb evmSp a0 a1 a2 a3 base ps := by
+  unfold expTwoMulFixedIterReloadSkipCountPostScratchSuffix
+    expTwoMulFixedIterReloadSkipRestScratchSuffix at h
+  unfold expTwoMulFixedIterReloadSkipCountPostScratchSuffixFrame
+  rw [expTwoMulFixedIterReloadPointerFrame_unfold]
+  sep_perm h
+
 theorem expTwoMulFixedIterCaseLoopPost_scratch_cases_pointerFrame
     {iterCount e c6 ptr nextLimb sp evmSp
       r0 r1 r2 r3 a0 a1 a2 a3 base : Word}

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostFramedCases.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostFramedCases.lean
@@ -208,4 +208,176 @@ theorem expTwoMulFixedIterCaseExitPost_scratch_cases_pointerFrame
         exact Or.inr (Or.inr (Or.inr
           ⟨v6, v7, v10, v11, d0, d1, d2, d3, hScratch⟩))
 
+theorem expTwoMulFixedIterSkipCondScratchFrame_pures
+    {iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
+    {exitCond : Prop} {v6 v7 v10 v11 d0 d1 d2 d3 : Word}
+    {frame : Assertion} {ps : PartialState}
+    (h :
+      ((expTwoMulFixedIterSkipCondCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 exitCond **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        (expTwoMulFixedIterSkipCondCountPostScratchSuffix e c6 base **
+          expTwoMulFixedIterPointerFrame ptr nextLimb)) **
+        frame) ps) :
+    exitCond ∧
+    c6 + signExtend12 (-1 : BitVec 12) ≠ 0 ∧
+    (e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12) ≠ 0 := by
+  unfold expTwoMulFixedIterSkipCondCountPostScratchPrefix
+    expTwoMulFixedIterSkipCondCountPostScratchSuffix
+    expTwoMulFixedIterSkipCondFrame at h
+  obtain ⟨psMain, _psFrame, _hDisjoint, _hUnion, hMain, _hFrame⟩ := h
+  obtain ⟨psPrefix, _psTail, _hDisjointPrefix, _hUnionPrefix, hPrefix, hTail⟩ :=
+    hMain
+  obtain ⟨psCount, _psRest, _hDisjointCount, _hUnionCount, hCount, _hRest⟩ :=
+    hPrefix
+  obtain ⟨_psX9, _psX0Exit, _hDisjointX9, _hUnionX9, _hX9, hX0Exit⟩ :=
+    hCount
+  obtain ⟨_psX0, _psExit, _hDisjointX0, _hUnionX0, _hX0, hExit⟩ :=
+    hX0Exit
+  have h_exit : exitCond := hExit.2
+  obtain ⟨_psScratch, _psSuffixPtr, _hDisjointScratch, _hUnionScratch,
+    _hScratch, hSuffixPtr⟩ := hTail
+  obtain ⟨_psSuffix, _psPtr, _hDisjointSuffix, _hUnionSuffix,
+    hSuffix, _hPtr⟩ := hSuffixPtr
+  obtain ⟨_psRet, _psSkipCondFrame, _hDisjointRet, _hUnionRet,
+    _hRet, hSkipCondFrame⟩ := hSuffix
+  obtain ⟨_, _, _, _, _, hFrameTail⟩ := hSkipCondFrame
+  obtain ⟨_, _, _, _, _, hPureTail⟩ := hFrameTail
+  have h_c6 : c6 + signExtend12 (-1 : BitVec 12) ≠ 0 :=
+    ((sepConj_pure_left _).1 hPureTail).1
+  obtain ⟨_, h_bit⟩ := ((sepConj_pure_left _).1 hPureTail).2
+  exact ⟨h_exit, h_c6, h_bit⟩
+
+theorem expTwoMulFixedIterSkipScratchFrame_pures
+    {iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
+    {exitCond : Prop} {v6 v7 v10 v11 d0 d1 d2 d3 : Word}
+    {frame : Assertion} {ps : PartialState}
+    (h :
+      ((expTwoMulFixedIterSkipCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3 exitCond **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        (expTwoMulFixedIterSkipCountPostScratchSuffix e c6 evmSp
+          a0 a1 a2 a3 base **
+          expTwoMulFixedIterPointerFrame ptr nextLimb)) **
+        frame) ps) :
+    exitCond ∧
+    c6 + signExtend12 (-1 : BitVec 12) ≠ 0 ∧
+    (e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12) = 0 := by
+  unfold expTwoMulFixedIterSkipCountPostScratchPrefix
+    expTwoMulFixedIterSkipCountPostScratchSuffix
+    expTwoMulFixedIterSkipRestScratchSuffix at h
+  obtain ⟨psMain, _psFrame, _hDisjoint, _hUnion, hMain, _hFrame⟩ := h
+  obtain ⟨psPrefix, _psTail, _hDisjointPrefix, _hUnionPrefix, hPrefix, hTail⟩ :=
+    hMain
+  obtain ⟨psCount, _psRest, _hDisjointCount, _hUnionCount, hCount, _hRest⟩ :=
+    hPrefix
+  obtain ⟨_psX9, _psX0Exit, _hDisjointX9, _hUnionX9, _hX9, hX0Exit⟩ :=
+    hCount
+  obtain ⟨_psX0, _psExit, _hDisjointX0, _hUnionX0, _hX0, hExit⟩ :=
+    hX0Exit
+  have h_exit : exitCond := hExit.2
+  obtain ⟨_psScratch, _psSuffixPtr, _hDisjointScratch, _hUnionScratch,
+    _hScratch, hSuffixPtr⟩ := hTail
+  obtain ⟨_psSuffix, _psPtr, _hDisjointSuffix, _hUnionSuffix,
+    hSuffix, _hPtr⟩ := hSuffixPtr
+  obtain ⟨_psSkipRest, _psBaseFrame, _hDisjointSkipRest, _hUnionSkipRest,
+    hSkipRest, _hBaseFrame⟩ := hSuffix
+  obtain ⟨_, _, _, _, _, hSkipRestTail⟩ := hSkipRest
+  obtain ⟨_, _, _, _, _, hX18Tail⟩ := hSkipRestTail
+  obtain ⟨_, _, _, _, _, hPureTail⟩ := hX18Tail
+  have h_c6 : c6 + signExtend12 (-1 : BitVec 12) ≠ 0 :=
+    ((sepConj_pure_left _).1 hPureTail).1
+  obtain ⟨_, h_bit⟩ := ((sepConj_pure_left _).1 hPureTail).2
+  exact ⟨h_exit, h_c6, h_bit⟩
+
+theorem expTwoMulFixedIterReloadCondScratchFrame_pures
+    {iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
+    {exitCond : Prop} {v6 v7 v10 v11 d0 d1 d2 d3 : Word}
+    {frame : Assertion} {ps : PartialState}
+    (h :
+      ((expTwoMulFixedIterSkipCondCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 exitCond **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        expTwoMulFixedIterReloadCondCountPostScratchSuffix
+          e c6 ptr nextLimb base) **
+        frame) ps) :
+    exitCond ∧
+    c6 + signExtend12 (-1 : BitVec 12) = 0 ∧
+    (e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12) ≠ 0 := by
+  unfold expTwoMulFixedIterSkipCondCountPostScratchPrefix
+    expTwoMulFixedIterReloadCondCountPostScratchSuffix
+    expTwoMulFixedIterReloadCondFrame at h
+  obtain ⟨psMain, _psFrame, _hDisjoint, _hUnion, hMain, _hFrame⟩ := h
+  obtain ⟨psPrefix, _psTail, _hDisjointPrefix, _hUnionPrefix, hPrefix, hTail⟩ :=
+    hMain
+  obtain ⟨psCount, _psRest, _hDisjointCount, _hUnionCount, hCount, _hRest⟩ :=
+    hPrefix
+  obtain ⟨_psX9, _psX0Exit, _hDisjointX9, _hUnionX9, _hX9, hX0Exit⟩ :=
+    hCount
+  obtain ⟨_psX0, _psExit, _hDisjointX0, _hUnionX0, _hX0, hExit⟩ :=
+    hX0Exit
+  have h_exit : exitCond := hExit.2
+  obtain ⟨_psScratch, _psSuffix, _hDisjointScratch, _hUnionScratch,
+    _hScratch, hSuffix⟩ := hTail
+  obtain ⟨_psRet, _psReloadCondFrame, _hDisjointRet, _hUnionRet,
+    _hRet, hReloadCondFrame⟩ := hSuffix
+  obtain ⟨_, _, _, _, _, hReloadCondTail⟩ := hReloadCondFrame
+  obtain ⟨_, _, _, _, _, hPureTail⟩ := hReloadCondTail
+  have hC6Tail := ((sepConj_pure_left _).1 hPureTail)
+  have h_c6 : c6 + signExtend12 (-1 : BitVec 12) = 0 := hC6Tail.1
+  obtain ⟨_, _, _, _, _, hMemBit⟩ := hC6Tail.2
+  obtain ⟨_, _, _, _, _, hBitPure⟩ := hMemBit
+  have h_bit :
+      (e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12) ≠ 0 :=
+    hBitPure.2
+  exact ⟨h_exit, h_c6, h_bit⟩
+
+theorem expTwoMulFixedIterReloadSkipScratchFrame_pures
+    {iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
+    {exitCond : Prop} {v6 v7 v10 v11 d0 d1 d2 d3 : Word}
+    {frame : Assertion} {ps : PartialState}
+    (h :
+      ((expTwoMulFixedIterSkipCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3 exitCond **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        expTwoMulFixedIterReloadSkipCountPostScratchSuffix
+          e c6 ptr nextLimb evmSp a0 a1 a2 a3 base) **
+        frame) ps) :
+    exitCond ∧
+    c6 + signExtend12 (-1 : BitVec 12) = 0 ∧
+    (e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12) = 0 := by
+  unfold expTwoMulFixedIterSkipCountPostScratchPrefix
+    expTwoMulFixedIterReloadSkipCountPostScratchSuffix
+    expTwoMulFixedIterReloadSkipRestScratchSuffix at h
+  obtain ⟨psMain, _psFrame, _hDisjoint, _hUnion, hMain, _hFrame⟩ := h
+  obtain ⟨psPrefix, _psTail, _hDisjointPrefix, _hUnionPrefix, hPrefix, hTail⟩ :=
+    hMain
+  obtain ⟨psCount, _psRest, _hDisjointCount, _hUnionCount, hCount, _hRest⟩ :=
+    hPrefix
+  obtain ⟨_psX9, _psX0Exit, _hDisjointX9, _hUnionX9, _hX9, hX0Exit⟩ :=
+    hCount
+  obtain ⟨_psX0, _psExit, _hDisjointX0, _hUnionX0, _hX0, hExit⟩ :=
+    hX0Exit
+  have h_exit : exitCond := hExit.2
+  obtain ⟨_psScratch, _psSuffix, _hDisjointScratch, _hUnionScratch,
+    _hScratch, hSuffix⟩ := hTail
+  obtain ⟨_psReloadSkip, _psBaseFrame, _hDisjointReloadSkip, _hUnionReloadSkip,
+    hReloadSkip, _hBaseFrame⟩ := hSuffix
+  obtain ⟨_, _, _, _, _, hReloadSkipTail1⟩ := hReloadSkip
+  obtain ⟨_, _, _, _, _, hReloadSkipTail2⟩ := hReloadSkipTail1
+  obtain ⟨_, _, _, _, _, hReloadSkipTail3⟩ := hReloadSkipTail2
+  obtain ⟨_, _, _, _, hC6Pure, hPtrMemBit⟩ := hReloadSkipTail3
+  have h_c6 : c6 + signExtend12 (-1 : BitVec 12) = 0 :=
+    hC6Pure.2
+  obtain ⟨_, _, _, _, _, hMemBit⟩ := hPtrMemBit
+  obtain ⟨_, _, _, _, _, hBitPure⟩ := hMemBit
+  have h_bit :
+      (e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12) = 0 :=
+    hBitPure.2
+  exact ⟨h_exit, h_c6, h_bit⟩
+
 end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostFramedCases.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostFramedCases.lean
@@ -153,6 +153,99 @@ theorem expTwoMulFixedIterCaseLoopPost_scratch_cases_pointerFrame
         exact Or.inr (Or.inr (Or.inr
           ⟨v6, v7, v10, v11, d0, d1, d2, d3, hScratch⟩))
 
+theorem expTwoMulFixedIterCaseLoopPost_scratch_cases_reloadPointerFrame
+    {iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
+    {frame : Assertion} {ps : PartialState}
+    (h :
+      (expTwoMulFixedIterCaseLoopPost iterCount e c6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base **
+        frame) ps) :
+    (∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      ((expTwoMulFixedIterSkipCondCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3
+        (expTwoMulIterCountNew iterCount ≠ 0) **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        (expTwoMulFixedIterSkipCondCountPostScratchSuffix e c6 base **
+          expTwoMulFixedIterPointerFrame ptr nextLimb)) **
+        frame) ps) ∨
+    (∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      ((expTwoMulFixedIterSkipCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3
+        (expTwoMulIterCountNew iterCount ≠ 0) **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        (expTwoMulFixedIterSkipCountPostScratchSuffix e c6 evmSp
+          a0 a1 a2 a3 base **
+          expTwoMulFixedIterPointerFrame ptr nextLimb)) **
+        frame) ps) ∨
+    (∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      ((expTwoMulFixedIterSkipCondCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3
+        (expTwoMulIterCountNew iterCount ≠ 0) **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        expTwoMulFixedIterReloadCondCountPostScratchSuffixFrame
+          e c6 ptr nextLimb base) **
+        frame) ps) ∨
+    (∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      ((expTwoMulFixedIterSkipCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3
+        (expTwoMulIterCountNew iterCount ≠ 0) **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        expTwoMulFixedIterReloadSkipCountPostScratchSuffixFrame
+          e c6 ptr nextLimb evmSp a0 a1 a2 a3 base) **
+        frame) ps) := by
+  rcases expTwoMulFixedIterCaseLoopPost_scratch_cases_pointerFrame h with
+    hSkipCond | hRest
+  · exact Or.inl hSkipCond
+  · rcases hRest with hSkip | hRest
+    · exact Or.inr (Or.inl hSkip)
+    · rcases hRest with hReloadCond | hReloadSkip
+      · rcases hReloadCond with
+          ⟨v6, v7, v10, v11, d0, d1, d2, d3, hScratch⟩
+        obtain ⟨psMain, psFrame, hDisjoint, hUnion, hMain, hFrame⟩ :=
+          hScratch
+        obtain ⟨psPrefix, psTail, hDisjointPrefix, hUnionPrefix,
+          hPrefix, hTail⟩ := hMain
+        obtain ⟨psScratch, psSuffix, hDisjointScratch, hUnionScratch,
+          hScratchIs, hSuffix⟩ := hTail
+        have hSuffixFrame :=
+          expTwoMulFixedIterReloadCondCountPostScratchSuffix_frame hSuffix
+        have hMainFrame :
+            (expTwoMulFixedIterSkipCondCountPostScratchPrefix iterCount sp evmSp
+              r0 r1 r2 r3 a0 a1 a2 a3
+              (expTwoMulIterCountNew iterCount ≠ 0) **
+              expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+              expTwoMulFixedIterReloadCondCountPostScratchSuffixFrame
+                e c6 ptr nextLimb base) psMain :=
+          ⟨psPrefix, psTail, hDisjointPrefix, hUnionPrefix, hPrefix,
+            psScratch, psSuffix, hDisjointScratch, hUnionScratch,
+            hScratchIs, hSuffixFrame⟩
+        exact Or.inr (Or.inr (Or.inl
+          ⟨v6, v7, v10, v11, d0, d1, d2, d3,
+            psMain, psFrame, hDisjoint, hUnion, hMainFrame, hFrame⟩))
+      · rcases hReloadSkip with
+          ⟨v6, v7, v10, v11, d0, d1, d2, d3, hScratch⟩
+        obtain ⟨psMain, psFrame, hDisjoint, hUnion, hMain, hFrame⟩ :=
+          hScratch
+        obtain ⟨psPrefix, psTail, hDisjointPrefix, hUnionPrefix,
+          hPrefix, hTail⟩ := hMain
+        obtain ⟨psScratch, psSuffix, hDisjointScratch, hUnionScratch,
+          hScratchIs, hSuffix⟩ := hTail
+        have hSuffixFrame :=
+          expTwoMulFixedIterReloadSkipCountPostScratchSuffix_frame hSuffix
+        have hMainFrame :
+            (expTwoMulFixedIterSkipCountPostScratchPrefix iterCount sp evmSp
+              r0 r1 r2 r3 (expTwoMulIterCountNew iterCount ≠ 0) **
+              expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+              expTwoMulFixedIterReloadSkipCountPostScratchSuffixFrame
+                e c6 ptr nextLimb evmSp a0 a1 a2 a3 base) psMain :=
+          ⟨psPrefix, psTail, hDisjointPrefix, hUnionPrefix, hPrefix,
+            psScratch, psSuffix, hDisjointScratch, hUnionScratch,
+            hScratchIs, hSuffixFrame⟩
+        exact Or.inr (Or.inr (Or.inr
+          ⟨v6, v7, v10, v11, d0, d1, d2, d3,
+            psMain, psFrame, hDisjoint, hUnion, hMainFrame, hFrame⟩))
+
 theorem expTwoMulFixedIterCaseExitPost_scratch_cases_frame
     {iterCount e c6 ptr nextLimb sp evmSp
       r0 r1 r2 r3 a0 a1 a2 a3 base : Word}

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostFramedCases.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostFramedCases.lean
@@ -1,0 +1,77 @@
+/-
+  EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePostFramedCases
+
+  Framed scratch case splits for fixed x19 case-post assertions.
+-/
+
+import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePostCases
+
+namespace EvmAsm.Evm64.Exp.Compose
+
+open EvmAsm.Rv64
+
+theorem expTwoMulFixedIterCaseExitPost_scratch_cases_frame
+    {iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
+    {frame : Assertion} {ps : PartialState}
+    (h :
+      (expTwoMulFixedIterCaseExitPost iterCount e c6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base **
+        frame) ps) :
+    (∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      ((expTwoMulFixedIterSkipCondCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3
+        (expTwoMulIterCountNew iterCount = 0) **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        (expTwoMulFixedIterSkipCondCountPostScratchSuffix e c6 base **
+          expTwoMulFixedIterPointerPost ptr nextLimb)) **
+        frame) ps) ∨
+    (∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      ((expTwoMulFixedIterSkipCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3
+        (expTwoMulIterCountNew iterCount = 0) **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        (expTwoMulFixedIterSkipCountPostScratchSuffix e c6 evmSp
+          a0 a1 a2 a3 base **
+          expTwoMulFixedIterPointerPost ptr nextLimb)) **
+        frame) ps) ∨
+    (∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      ((expTwoMulFixedIterSkipCondCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3
+        (expTwoMulIterCountNew iterCount = 0) **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        expTwoMulFixedIterReloadCondCountPostScratchSuffix
+          e c6 ptr nextLimb base) **
+        frame) ps) ∨
+    (∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      ((expTwoMulFixedIterSkipCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3
+        (expTwoMulIterCountNew iterCount = 0) **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        expTwoMulFixedIterReloadSkipCountPostScratchSuffix
+          e c6 ptr nextLimb evmSp a0 a1 a2 a3 base) **
+        frame) ps) := by
+  obtain ⟨psCase, psFrame, hDisjoint, hUnion, hCase, hFrame⟩ := h
+  rcases expTwoMulFixedIterCaseExitPost_scratch_cases hCase with hSkipCond | hRest
+  · rcases hSkipCond with ⟨v6, v7, v10, v11, d0, d1, d2, d3, hScratch⟩
+    exact Or.inl
+      ⟨v6, v7, v10, v11, d0, d1, d2, d3,
+        psCase, psFrame, hDisjoint, hUnion, hScratch, hFrame⟩
+  · rcases hRest with hSkip | hRest
+    · rcases hSkip with ⟨v6, v7, v10, v11, d0, d1, d2, d3, hScratch⟩
+      exact Or.inr (Or.inl
+        ⟨v6, v7, v10, v11, d0, d1, d2, d3,
+          psCase, psFrame, hDisjoint, hUnion, hScratch, hFrame⟩)
+    · rcases hRest with hReloadCond | hReloadSkip
+      · rcases hReloadCond with
+          ⟨v6, v7, v10, v11, d0, d1, d2, d3, hScratch⟩
+        exact Or.inr (Or.inr (Or.inl
+          ⟨v6, v7, v10, v11, d0, d1, d2, d3,
+            psCase, psFrame, hDisjoint, hUnion, hScratch, hFrame⟩))
+      · rcases hReloadSkip with
+          ⟨v6, v7, v10, v11, d0, d1, d2, d3, hScratch⟩
+        exact Or.inr (Or.inr (Or.inr
+          ⟨v6, v7, v10, v11, d0, d1, d2, d3,
+            psCase, psFrame, hDisjoint, hUnion, hScratch, hFrame⟩))
+
+end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostFramedCases.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostFramedCases.lean
@@ -374,6 +374,99 @@ theorem expTwoMulFixedIterCaseExitPost_scratch_cases_pointerFrame
         exact Or.inr (Or.inr (Or.inr
           ⟨v6, v7, v10, v11, d0, d1, d2, d3, hScratch⟩))
 
+theorem expTwoMulFixedIterCaseExitPost_scratch_cases_reloadPointerFrame
+    {iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
+    {frame : Assertion} {ps : PartialState}
+    (h :
+      (expTwoMulFixedIterCaseExitPost iterCount e c6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base **
+        frame) ps) :
+    (∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      ((expTwoMulFixedIterSkipCondCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3
+        (expTwoMulIterCountNew iterCount = 0) **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        (expTwoMulFixedIterSkipCondCountPostScratchSuffix e c6 base **
+          expTwoMulFixedIterPointerFrame ptr nextLimb)) **
+        frame) ps) ∨
+    (∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      ((expTwoMulFixedIterSkipCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3
+        (expTwoMulIterCountNew iterCount = 0) **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        (expTwoMulFixedIterSkipCountPostScratchSuffix e c6 evmSp
+          a0 a1 a2 a3 base **
+          expTwoMulFixedIterPointerFrame ptr nextLimb)) **
+        frame) ps) ∨
+    (∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      ((expTwoMulFixedIterSkipCondCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3
+        (expTwoMulIterCountNew iterCount = 0) **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        expTwoMulFixedIterReloadCondCountPostScratchSuffixFrame
+          e c6 ptr nextLimb base) **
+        frame) ps) ∨
+    (∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      ((expTwoMulFixedIterSkipCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3
+        (expTwoMulIterCountNew iterCount = 0) **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        expTwoMulFixedIterReloadSkipCountPostScratchSuffixFrame
+          e c6 ptr nextLimb evmSp a0 a1 a2 a3 base) **
+        frame) ps) := by
+  rcases expTwoMulFixedIterCaseExitPost_scratch_cases_pointerFrame h with
+    hSkipCond | hRest
+  · exact Or.inl hSkipCond
+  · rcases hRest with hSkip | hRest
+    · exact Or.inr (Or.inl hSkip)
+    · rcases hRest with hReloadCond | hReloadSkip
+      · rcases hReloadCond with
+          ⟨v6, v7, v10, v11, d0, d1, d2, d3, hScratch⟩
+        obtain ⟨psMain, psFrame, hDisjoint, hUnion, hMain, hFrame⟩ :=
+          hScratch
+        obtain ⟨psPrefix, psTail, hDisjointPrefix, hUnionPrefix,
+          hPrefix, hTail⟩ := hMain
+        obtain ⟨psScratch, psSuffix, hDisjointScratch, hUnionScratch,
+          hScratchIs, hSuffix⟩ := hTail
+        have hSuffixFrame :=
+          expTwoMulFixedIterReloadCondCountPostScratchSuffix_frame hSuffix
+        have hMainFrame :
+            (expTwoMulFixedIterSkipCondCountPostScratchPrefix iterCount sp evmSp
+              r0 r1 r2 r3 a0 a1 a2 a3
+              (expTwoMulIterCountNew iterCount = 0) **
+              expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+              expTwoMulFixedIterReloadCondCountPostScratchSuffixFrame
+                e c6 ptr nextLimb base) psMain :=
+          ⟨psPrefix, psTail, hDisjointPrefix, hUnionPrefix, hPrefix,
+            psScratch, psSuffix, hDisjointScratch, hUnionScratch,
+            hScratchIs, hSuffixFrame⟩
+        exact Or.inr (Or.inr (Or.inl
+          ⟨v6, v7, v10, v11, d0, d1, d2, d3,
+            psMain, psFrame, hDisjoint, hUnion, hMainFrame, hFrame⟩))
+      · rcases hReloadSkip with
+          ⟨v6, v7, v10, v11, d0, d1, d2, d3, hScratch⟩
+        obtain ⟨psMain, psFrame, hDisjoint, hUnion, hMain, hFrame⟩ :=
+          hScratch
+        obtain ⟨psPrefix, psTail, hDisjointPrefix, hUnionPrefix,
+          hPrefix, hTail⟩ := hMain
+        obtain ⟨psScratch, psSuffix, hDisjointScratch, hUnionScratch,
+          hScratchIs, hSuffix⟩ := hTail
+        have hSuffixFrame :=
+          expTwoMulFixedIterReloadSkipCountPostScratchSuffix_frame hSuffix
+        have hMainFrame :
+            (expTwoMulFixedIterSkipCountPostScratchPrefix iterCount sp evmSp
+              r0 r1 r2 r3 (expTwoMulIterCountNew iterCount = 0) **
+              expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+              expTwoMulFixedIterReloadSkipCountPostScratchSuffixFrame
+                e c6 ptr nextLimb evmSp a0 a1 a2 a3 base) psMain :=
+          ⟨psPrefix, psTail, hDisjointPrefix, hUnionPrefix, hPrefix,
+            psScratch, psSuffix, hDisjointScratch, hUnionScratch,
+            hScratchIs, hSuffixFrame⟩
+        exact Or.inr (Or.inr (Or.inr
+          ⟨v6, v7, v10, v11, d0, d1, d2, d3,
+            psMain, psFrame, hDisjoint, hUnion, hMainFrame, hFrame⟩))
+
 theorem expTwoMulFixedIterSkipCondScratchFrame_pures
     {iterCount e c6 ptr nextLimb sp evmSp
       r0 r1 r2 r3 a0 a1 a2 a3 base : Word}

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostFramedCases.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostFramedCases.lean
@@ -446,4 +446,72 @@ theorem expTwoMulFixedIterSkipCondScratchFrame_to_iterPre_frame
     BitVec.add_assoc] at h ⊢
   sep_perm h
 
+theorem expTwoMulFixedIterSkipScratchFrame_to_iterPre_frame
+    {iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
+    {exitCond : Prop} {v6 v7 v10 v11 d0 d1 d2 d3 : Word}
+    {frame : Assertion} {ps : PartialState}
+    (h :
+      ((expTwoMulFixedIterSkipCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3 exitCond **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        (expTwoMulFixedIterSkipCountPostScratchSuffix e c6 evmSp
+          a0 a1 a2 a3 base **
+          expTwoMulFixedIterPointerFrame ptr nextLimb)) **
+        frame) ps) :
+    let squareW := expSquaringCallSquareW r0 r1 r2 r3
+    ((expTwoMulFixedIterPre
+      (e <<< (1 : BitVec 6).toNat)
+      v6
+      (expTwoMulIterCountNew iterCount)
+      v10
+      ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+      ptr nextLimb sp evmSp
+      (squareW.getLimbN 3)
+      (((base + 44) + 32) + 68)
+      (squareW.getLimbN 0) (squareW.getLimbN 1)
+      (squareW.getLimbN 2) (squareW.getLimbN 3)
+      d0 d1 d2 d3
+      (squareW.getLimbN 0) (squareW.getLimbN 1)
+      (squareW.getLimbN 2) (squareW.getLimbN 3)
+      a0 a1 a2 a3 v7 v11) **
+      frame) ps := by
+  intro squareW
+  have h_pures := expTwoMulFixedIterSkipScratchFrame_pures h
+  rcases h_pures with ⟨h_exit, h_c6, h_bit⟩
+  unfold expTwoMulFixedIterSkipCountPostScratchPrefix
+    expTwoMulFixedIterSkipRestScratchPrefix
+    expTwoMulFixedIterScratchIs
+    expTwoMulFixedIterSkipCountPostScratchSuffix
+    expTwoMulFixedIterSkipRestScratchSuffix
+    expTwoMulFixedIterBaseFrame at h
+  rw [show (⌜exitCond⌝ : Assertion) = empAssertion from
+      funext fun ps' => propext ⟨fun h' => h'.1, fun h' => ⟨h', h_exit⟩⟩] at h
+  simp only [sepConj_emp_right'] at h
+  rw [show (⌜c6 + signExtend12 (-1 : BitVec 12) ≠ 0⌝ : Assertion) =
+      empAssertion from
+      funext fun ps' => propext ⟨fun h' => h'.1, fun h' => ⟨h', h_c6⟩⟩] at h
+  rw [show
+      (⌜(e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12) = 0⌝ :
+        Assertion) =
+      empAssertion from
+      funext fun ps' => propext ⟨fun h' => h'.1, fun h' => ⟨h', h_bit⟩⟩] at h
+  simp only [sepConj_emp_right'] at h
+  rw [expTwoMulFixedIterPointerFrame_unfold] at h
+  rw [expTwoMulFixedIterPre_unfold, expTwoMulIterBaseFrame_unfold,
+    expTwoMulFixedIterPointerFrame_unfold]
+  simp only [evmWordIs, signExtend12_0, signExtend12_8, signExtend12_16,
+    signExtend12_24, signExtend12_32, signExtend12_40, signExtend12_48,
+    signExtend12_56,
+    EvmAsm.Evm64.Exp.AddrNorm.exp_se12_neg64,
+    EvmAsm.Evm64.Exp.AddrNorm.exp_se12_neg56,
+    EvmAsm.Evm64.Exp.AddrNorm.exp_se12_neg48,
+    EvmAsm.Evm64.Exp.AddrNorm.exp_se12_neg40,
+    EvmAsm.Rv64.AddrNorm.word_add_zero,
+    show (32 : Word) + 8 = 40 from by decide,
+    show (32 : Word) + 16 = 48 from by decide,
+    show (32 : Word) + 24 = 56 from by decide,
+    BitVec.add_assoc] at h ⊢
+  sep_perm h
+
 end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostFramedCases.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostFramedCases.lean
@@ -16,6 +16,70 @@ theorem expTwoMulFixedIterPointerPost_eq_pointerFrame
       expTwoMulFixedIterPointerFrame ptr nextLimb := by
   rw [expTwoMulFixedIterPointerFrame_unfold]
 
+theorem expTwoMulFixedIterCaseLoopPost_scratch_cases_pointerFrame
+    {iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
+    {frame : Assertion} {ps : PartialState}
+    (h :
+      (expTwoMulFixedIterCaseLoopPost iterCount e c6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base **
+        frame) ps) :
+    (∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      ((expTwoMulFixedIterSkipCondCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3
+        (expTwoMulIterCountNew iterCount ≠ 0) **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        (expTwoMulFixedIterSkipCondCountPostScratchSuffix e c6 base **
+          expTwoMulFixedIterPointerFrame ptr nextLimb)) **
+        frame) ps) ∨
+    (∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      ((expTwoMulFixedIterSkipCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3
+        (expTwoMulIterCountNew iterCount ≠ 0) **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        (expTwoMulFixedIterSkipCountPostScratchSuffix e c6 evmSp
+          a0 a1 a2 a3 base **
+          expTwoMulFixedIterPointerFrame ptr nextLimb)) **
+        frame) ps) ∨
+    (∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      ((expTwoMulFixedIterSkipCondCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3
+        (expTwoMulIterCountNew iterCount ≠ 0) **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        expTwoMulFixedIterReloadCondCountPostScratchSuffix
+          e c6 ptr nextLimb base) **
+        frame) ps) ∨
+    (∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      ((expTwoMulFixedIterSkipCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3
+        (expTwoMulIterCountNew iterCount ≠ 0) **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        expTwoMulFixedIterReloadSkipCountPostScratchSuffix
+          e c6 ptr nextLimb evmSp a0 a1 a2 a3 base) **
+        frame) ps) := by
+  rcases expTwoMulFixedIterCaseLoopPost_scratch_cases_frame h with
+    hSkipCond | hRest
+  · rcases hSkipCond with ⟨v6, v7, v10, v11, d0, d1, d2, d3, hScratch⟩
+    exact Or.inl
+      ⟨v6, v7, v10, v11, d0, d1, d2, d3,
+        by
+          simpa [expTwoMulFixedIterPointerPost_eq_pointerFrame] using hScratch⟩
+  · rcases hRest with hSkip | hRest
+    · rcases hSkip with ⟨v6, v7, v10, v11, d0, d1, d2, d3, hScratch⟩
+      exact Or.inr (Or.inl
+        ⟨v6, v7, v10, v11, d0, d1, d2, d3,
+          by
+            simpa [expTwoMulFixedIterPointerPost_eq_pointerFrame] using hScratch⟩)
+    · rcases hRest with hReloadCond | hReloadSkip
+      · rcases hReloadCond with
+          ⟨v6, v7, v10, v11, d0, d1, d2, d3, hScratch⟩
+        exact Or.inr (Or.inr (Or.inl
+          ⟨v6, v7, v10, v11, d0, d1, d2, d3, hScratch⟩))
+      · rcases hReloadSkip with
+          ⟨v6, v7, v10, v11, d0, d1, d2, d3, hScratch⟩
+        exact Or.inr (Or.inr (Or.inr
+          ⟨v6, v7, v10, v11, d0, d1, d2, d3, hScratch⟩))
+
 theorem expTwoMulFixedIterCaseExitPost_scratch_cases_frame
     {iterCount e c6 ptr nextLimb sp evmSp
       r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
@@ -79,5 +143,69 @@ theorem expTwoMulFixedIterCaseExitPost_scratch_cases_frame
         exact Or.inr (Or.inr (Or.inr
           ⟨v6, v7, v10, v11, d0, d1, d2, d3,
             psCase, psFrame, hDisjoint, hUnion, hScratch, hFrame⟩))
+
+theorem expTwoMulFixedIterCaseExitPost_scratch_cases_pointerFrame
+    {iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
+    {frame : Assertion} {ps : PartialState}
+    (h :
+      (expTwoMulFixedIterCaseExitPost iterCount e c6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base **
+        frame) ps) :
+    (∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      ((expTwoMulFixedIterSkipCondCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3
+        (expTwoMulIterCountNew iterCount = 0) **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        (expTwoMulFixedIterSkipCondCountPostScratchSuffix e c6 base **
+          expTwoMulFixedIterPointerFrame ptr nextLimb)) **
+        frame) ps) ∨
+    (∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      ((expTwoMulFixedIterSkipCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3
+        (expTwoMulIterCountNew iterCount = 0) **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        (expTwoMulFixedIterSkipCountPostScratchSuffix e c6 evmSp
+          a0 a1 a2 a3 base **
+          expTwoMulFixedIterPointerFrame ptr nextLimb)) **
+        frame) ps) ∨
+    (∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      ((expTwoMulFixedIterSkipCondCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3
+        (expTwoMulIterCountNew iterCount = 0) **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        expTwoMulFixedIterReloadCondCountPostScratchSuffix
+          e c6 ptr nextLimb base) **
+        frame) ps) ∨
+    (∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      ((expTwoMulFixedIterSkipCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3
+        (expTwoMulIterCountNew iterCount = 0) **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        expTwoMulFixedIterReloadSkipCountPostScratchSuffix
+          e c6 ptr nextLimb evmSp a0 a1 a2 a3 base) **
+        frame) ps) := by
+  rcases expTwoMulFixedIterCaseExitPost_scratch_cases_frame h with
+    hSkipCond | hRest
+  · rcases hSkipCond with ⟨v6, v7, v10, v11, d0, d1, d2, d3, hScratch⟩
+    exact Or.inl
+      ⟨v6, v7, v10, v11, d0, d1, d2, d3,
+        by
+          simpa [expTwoMulFixedIterPointerPost_eq_pointerFrame] using hScratch⟩
+  · rcases hRest with hSkip | hRest
+    · rcases hSkip with ⟨v6, v7, v10, v11, d0, d1, d2, d3, hScratch⟩
+      exact Or.inr (Or.inl
+        ⟨v6, v7, v10, v11, d0, d1, d2, d3,
+          by
+            simpa [expTwoMulFixedIterPointerPost_eq_pointerFrame] using hScratch⟩)
+    · rcases hRest with hReloadCond | hReloadSkip
+      · rcases hReloadCond with
+          ⟨v6, v7, v10, v11, d0, d1, d2, d3, hScratch⟩
+        exact Or.inr (Or.inr (Or.inl
+          ⟨v6, v7, v10, v11, d0, d1, d2, d3, hScratch⟩))
+      · rcases hReloadSkip with
+          ⟨v6, v7, v10, v11, d0, d1, d2, d3, hScratch⟩
+        exact Or.inr (Or.inr (Or.inr
+          ⟨v6, v7, v10, v11, d0, d1, d2, d3, hScratch⟩))
 
 end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostFramedCases.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostFramedCases.lean
@@ -380,4 +380,70 @@ theorem expTwoMulFixedIterReloadSkipScratchFrame_pures
     hBitPure.2
   exact ⟨h_exit, h_c6, h_bit⟩
 
+theorem expTwoMulFixedIterSkipCondScratchFrame_to_iterPre_frame
+    {iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
+    {exitCond : Prop} {v6 v7 v10 v11 d0 d1 d2 d3 : Word}
+    {frame : Assertion} {ps : PartialState}
+    (h :
+      ((expTwoMulFixedIterSkipCondCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 exitCond **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        (expTwoMulFixedIterSkipCondCountPostScratchSuffix e c6 base **
+          expTwoMulFixedIterPointerFrame ptr nextLimb)) **
+        frame) ps) :
+    let squareW := expSquaringCallSquareW r0 r1 r2 r3
+    let rw := expTwoMulCondRw squareW a0 a1 a2 a3
+    ((expTwoMulFixedIterPre
+      (e <<< (1 : BitVec 6).toNat)
+      v6
+      (expTwoMulIterCountNew iterCount)
+      v10
+      ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+      ptr nextLimb sp evmSp
+      (rw.getLimbN 3)
+      (((base + 44) + 140) + 68)
+      (rw.getLimbN 0) (rw.getLimbN 1) (rw.getLimbN 2) (rw.getLimbN 3)
+      d0 d1 d2 d3
+      (rw.getLimbN 0) (rw.getLimbN 1) (rw.getLimbN 2) (rw.getLimbN 3)
+      a0 a1 a2 a3 v7 v11) **
+      frame) ps := by
+  intro squareW rw
+  have h_pures := expTwoMulFixedIterSkipCondScratchFrame_pures h
+  rcases h_pures with ⟨h_exit, h_c6, h_bit⟩
+  unfold expTwoMulFixedIterSkipCondCountPostScratchPrefix
+    expTwoMulFixedIterSkipCondRestScratchPrefix
+    expTwoMulFixedIterScratchIs
+    expTwoMulFixedIterSkipCondCountPostScratchSuffix
+    expTwoMulFixedIterSkipCondRestScratchSuffix
+    expTwoMulFixedIterSkipCondFrame at h
+  rw [show (⌜exitCond⌝ : Assertion) = empAssertion from
+      funext fun ps' => propext ⟨fun h' => h'.1, fun h' => ⟨h', h_exit⟩⟩] at h
+  simp only [sepConj_emp_right'] at h
+  rw [show (⌜c6 + signExtend12 (-1 : BitVec 12) ≠ 0⌝ : Assertion) =
+      empAssertion from
+      funext fun ps' => propext ⟨fun h' => h'.1, fun h' => ⟨h', h_c6⟩⟩] at h
+  rw [show
+      (⌜(e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12) ≠ 0⌝ :
+        Assertion) =
+      empAssertion from
+      funext fun ps' => propext ⟨fun h' => h'.1, fun h' => ⟨h', h_bit⟩⟩] at h
+  simp only [sepConj_emp_right'] at h
+  rw [expTwoMulFixedIterPointerFrame_unfold] at h
+  rw [expTwoMulFixedIterPre_unfold, expTwoMulIterBaseFrame_unfold,
+    expTwoMulFixedIterPointerFrame_unfold]
+  simp only [evmWordIs, signExtend12_0, signExtend12_8, signExtend12_16,
+    signExtend12_24, signExtend12_32, signExtend12_40, signExtend12_48,
+    signExtend12_56,
+    EvmAsm.Evm64.Exp.AddrNorm.exp_se12_neg64,
+    EvmAsm.Evm64.Exp.AddrNorm.exp_se12_neg56,
+    EvmAsm.Evm64.Exp.AddrNorm.exp_se12_neg48,
+    EvmAsm.Evm64.Exp.AddrNorm.exp_se12_neg40,
+    EvmAsm.Rv64.AddrNorm.word_add_zero,
+    show (32 : Word) + 8 = 40 from by decide,
+    show (32 : Word) + 16 = 48 from by decide,
+    show (32 : Word) + 24 = 56 from by decide,
+    BitVec.add_assoc] at h ⊢
+  sep_perm h
+
 end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostIterPreCases.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostIterPreCases.lean
@@ -1,0 +1,88 @@
+/-
+  EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePostIterPreCases
+
+  Case splits that convert fixed x19 non-reload branches to iterPre while
+  leaving reload-pointer branches explicit.
+-/
+
+import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterReloadPointerPures
+
+namespace EvmAsm.Evm64.Exp.Compose
+
+open EvmAsm.Rv64
+
+theorem expTwoMulFixedIterCaseLoopPost_iterPre_or_reloadPointerFrame
+    {iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
+    {frame : Assertion} {ps : PartialState}
+    (h :
+      (expTwoMulFixedIterCaseLoopPost iterCount e c6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base **
+        frame) ps) :
+    (∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      let squareW := expSquaringCallSquareW r0 r1 r2 r3
+      let rw := expTwoMulCondRw squareW a0 a1 a2 a3
+      ((expTwoMulFixedIterPre
+        (e <<< (1 : BitVec 6).toNat)
+        v6
+        (expTwoMulIterCountNew iterCount)
+        v10
+        ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+        ptr nextLimb sp evmSp
+        (rw.getLimbN 3)
+        (((base + 44) + 140) + 68)
+        (rw.getLimbN 0) (rw.getLimbN 1) (rw.getLimbN 2) (rw.getLimbN 3)
+        d0 d1 d2 d3
+        (rw.getLimbN 0) (rw.getLimbN 1) (rw.getLimbN 2) (rw.getLimbN 3)
+        a0 a1 a2 a3 v7 v11) **
+        frame) ps) ∨
+    (∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      let squareW := expSquaringCallSquareW r0 r1 r2 r3
+      ((expTwoMulFixedIterPre
+        (e <<< (1 : BitVec 6).toNat)
+        v6
+        (expTwoMulIterCountNew iterCount)
+        v10
+        ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+        ptr nextLimb sp evmSp
+        (squareW.getLimbN 3)
+        (((base + 44) + 32) + 68)
+        (squareW.getLimbN 0) (squareW.getLimbN 1)
+        (squareW.getLimbN 2) (squareW.getLimbN 3)
+        d0 d1 d2 d3
+        (squareW.getLimbN 0) (squareW.getLimbN 1)
+        (squareW.getLimbN 2) (squareW.getLimbN 3)
+        a0 a1 a2 a3 v7 v11) **
+        frame) ps) ∨
+    (∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      ((expTwoMulFixedIterSkipCondCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3
+        (expTwoMulIterCountNew iterCount ≠ 0) **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        expTwoMulFixedIterReloadCondCountPostScratchSuffixFrame
+          e c6 ptr nextLimb base) **
+        frame) ps) ∨
+    (∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      ((expTwoMulFixedIterSkipCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3
+        (expTwoMulIterCountNew iterCount ≠ 0) **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        expTwoMulFixedIterReloadSkipCountPostScratchSuffixFrame
+          e c6 ptr nextLimb evmSp a0 a1 a2 a3 base) **
+        frame) ps) := by
+  rcases expTwoMulFixedIterCaseLoopPost_scratch_cases_reloadPointerFrame h with
+    hSkipCond | hRest
+  · rcases hSkipCond with ⟨v6, v7, v10, v11, d0, d1, d2, d3, hScratch⟩
+    exact Or.inl
+      ⟨v6, v7, v10, v11, d0, d1, d2, d3,
+        expTwoMulFixedIterSkipCondScratchFrame_to_iterPre_frame hScratch⟩
+  · rcases hRest with hSkip | hRest
+    · rcases hSkip with ⟨v6, v7, v10, v11, d0, d1, d2, d3, hScratch⟩
+      exact Or.inr (Or.inl
+        ⟨v6, v7, v10, v11, d0, d1, d2, d3,
+          expTwoMulFixedIterSkipScratchFrame_to_iterPre_frame hScratch⟩)
+    · rcases hRest with hReloadCond | hReloadSkip
+      · exact Or.inr (Or.inr (Or.inl hReloadCond))
+      · exact Or.inr (Or.inr (Or.inr hReloadSkip))
+
+end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostIterPreCases.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostIterPreCases.lean
@@ -85,4 +85,78 @@ theorem expTwoMulFixedIterCaseLoopPost_iterPre_or_reloadPointerFrame
       · exact Or.inr (Or.inr (Or.inl hReloadCond))
       · exact Or.inr (Or.inr (Or.inr hReloadSkip))
 
+theorem expTwoMulFixedIterCaseExitPost_iterPre_or_reloadPointerFrame
+    {iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
+    {frame : Assertion} {ps : PartialState}
+    (h :
+      (expTwoMulFixedIterCaseExitPost iterCount e c6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base **
+        frame) ps) :
+    (∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      let squareW := expSquaringCallSquareW r0 r1 r2 r3
+      let rw := expTwoMulCondRw squareW a0 a1 a2 a3
+      ((expTwoMulFixedIterPre
+        (e <<< (1 : BitVec 6).toNat)
+        v6
+        (expTwoMulIterCountNew iterCount)
+        v10
+        ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+        ptr nextLimb sp evmSp
+        (rw.getLimbN 3)
+        (((base + 44) + 140) + 68)
+        (rw.getLimbN 0) (rw.getLimbN 1) (rw.getLimbN 2) (rw.getLimbN 3)
+        d0 d1 d2 d3
+        (rw.getLimbN 0) (rw.getLimbN 1) (rw.getLimbN 2) (rw.getLimbN 3)
+        a0 a1 a2 a3 v7 v11) **
+        frame) ps) ∨
+    (∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      let squareW := expSquaringCallSquareW r0 r1 r2 r3
+      ((expTwoMulFixedIterPre
+        (e <<< (1 : BitVec 6).toNat)
+        v6
+        (expTwoMulIterCountNew iterCount)
+        v10
+        ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+        ptr nextLimb sp evmSp
+        (squareW.getLimbN 3)
+        (((base + 44) + 32) + 68)
+        (squareW.getLimbN 0) (squareW.getLimbN 1)
+        (squareW.getLimbN 2) (squareW.getLimbN 3)
+        d0 d1 d2 d3
+        (squareW.getLimbN 0) (squareW.getLimbN 1)
+        (squareW.getLimbN 2) (squareW.getLimbN 3)
+        a0 a1 a2 a3 v7 v11) **
+        frame) ps) ∨
+    (∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      ((expTwoMulFixedIterSkipCondCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3
+        (expTwoMulIterCountNew iterCount = 0) **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        expTwoMulFixedIterReloadCondCountPostScratchSuffixFrame
+          e c6 ptr nextLimb base) **
+        frame) ps) ∨
+    (∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      ((expTwoMulFixedIterSkipCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3
+        (expTwoMulIterCountNew iterCount = 0) **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        expTwoMulFixedIterReloadSkipCountPostScratchSuffixFrame
+          e c6 ptr nextLimb evmSp a0 a1 a2 a3 base) **
+        frame) ps) := by
+  rcases expTwoMulFixedIterCaseExitPost_scratch_cases_reloadPointerFrame h with
+    hSkipCond | hRest
+  · rcases hSkipCond with ⟨v6, v7, v10, v11, d0, d1, d2, d3, hScratch⟩
+    exact Or.inl
+      ⟨v6, v7, v10, v11, d0, d1, d2, d3,
+        expTwoMulFixedIterSkipCondScratchFrame_to_iterPre_frame hScratch⟩
+  · rcases hRest with hSkip | hRest
+    · rcases hSkip with ⟨v6, v7, v10, v11, d0, d1, d2, d3, hScratch⟩
+      exact Or.inr (Or.inl
+        ⟨v6, v7, v10, v11, d0, d1, d2, d3,
+          expTwoMulFixedIterSkipScratchFrame_to_iterPre_frame hScratch⟩)
+    · rcases hRest with hReloadCond | hReloadSkip
+      · exact Or.inr (Or.inr (Or.inl hReloadCond))
+      · exact Or.inr (Or.inr (Or.inr hReloadSkip))
+
 end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostTailBounds.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostTailBounds.lean
@@ -10,6 +10,171 @@ namespace EvmAsm.Evm64.Exp.Compose
 
 open EvmAsm.Rv64
 
+/-- Symbolic bounded full-tail peel using named case-post continuations for
+    both branch targets. -/
+theorem exp_two_mul_fixed_full_loop_body_peel_tail_with_case_continuations_symbolic_bounded_spec_within
+    (nBound : Nat)
+    (e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word)
+    (base exit_ : Word) (R : Assertion)
+    (hbase : (base + 44 : Word) &&& 1 = 0)
+    (hBound : expTwoMulFixedFullLoopBodyBound ≤ nBound) :
+    (cpsTripleWithin expTwoMulFixedFullLoopBodyTailBound
+      (base + 44) exit_
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterCaseLoopPost iterCount e c6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base)
+      R) →
+    (cpsTripleWithin expTwoMulFixedFullLoopBodyTailBound
+      (base + 296) exit_
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterCaseExitPost iterCount e c6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base)
+      R) →
+    cpsTripleWithin nBound
+      (base + 44)
+      exit_
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterPre e c6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+        v7 v11)
+      R :=
+  fun hLoop hExit =>
+    cpsTripleWithin_mono_nSteps hBound
+      (exp_two_mul_fixed_full_loop_body_peel_tail_with_case_continuations_spec_within
+        e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+        r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+        v7 v11 base exit_ R hbase hLoop hExit)
+
+/-- Symbolic bounded full-tail peel using a named case-post exit implication. -/
+theorem exp_two_mul_fixed_full_loop_body_peel_tail_with_case_exit_imp_symbolic_bounded_spec_within
+    (nBound : Nat)
+    (e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word)
+    (base : Word) (R : Assertion)
+    (hbase : (base + 44 : Word) &&& 1 = 0)
+    (hBound : expTwoMulFixedFullLoopBodyBound ≤ nBound)
+    (hExit :
+      ∀ ps,
+        expTwoMulFixedIterCaseExitPost iterCount e c6 ptr nextLimb sp evmSp
+          r0 r1 r2 r3 a0 a1 a2 a3 base ps →
+        R ps) :
+    (cpsTripleWithin expTwoMulFixedFullLoopBodyTailBound
+      (base + 44) (base + 296)
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterCaseLoopPost iterCount e c6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base)
+      R) →
+    cpsTripleWithin nBound
+      (base + 44)
+      (base + 296)
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterPre e c6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+        v7 v11)
+      R :=
+  fun hLoop =>
+    cpsTripleWithin_mono_nSteps hBound
+      (exp_two_mul_fixed_full_loop_body_peel_tail_with_case_exit_imp_spec_within
+        e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+        r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+        v7 v11 base R hbase hExit hLoop)
+
+/-- Symbolic bounded non-final full-tail peel using named case-post assertions. -/
+theorem exp_two_mul_fixed_full_loop_body_peel_tail_case_nonfinal_symbolic_bounded_spec_within
+    (nBound : Nat)
+    (e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word)
+    (base : Word) (R : Assertion)
+    (hbase : (base + 44 : Word) &&& 1 = 0)
+    (hne : expTwoMulIterCountNew iterCount ≠ 0)
+    (hBound : expTwoMulFixedFullLoopBodyBound ≤ nBound) :
+    (cpsTripleWithin expTwoMulFixedFullLoopBodyTailBound
+      (base + 44) (base + 296)
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterCaseLoopPost iterCount e c6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base)
+      R) →
+    cpsTripleWithin nBound
+      (base + 44)
+      (base + 296)
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterPre e c6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+        v7 v11)
+      R :=
+  fun hLoop =>
+    cpsTripleWithin_mono_nSteps hBound
+      (exp_two_mul_fixed_full_loop_body_peel_tail_case_nonfinal_spec_within
+        e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+        r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+        v7 v11 base R hbase hne hLoop)
+
+/-- Symbolic bounded final full-tail peel using a named case-post exit
+    continuation. -/
+theorem exp_two_mul_fixed_full_loop_body_peel_tail_case_final_symbolic_bounded_spec_within
+    (nBound : Nat)
+    (e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word)
+    (base exit_ : Word) (R : Assertion)
+    (hbase : (base + 44 : Word) &&& 1 = 0)
+    (hzero : expTwoMulIterCountNew iterCount = 0)
+    (hBound : expTwoMulFixedFullLoopBodyBound ≤ nBound) :
+    (cpsTripleWithin expTwoMulFixedFullLoopBodyTailBound
+      (base + 296) exit_
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterCaseExitPost iterCount e c6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base)
+      R) →
+    cpsTripleWithin nBound
+      (base + 44)
+      exit_
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterPre e c6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+        v7 v11)
+      R :=
+  fun hExit =>
+    cpsTripleWithin_mono_nSteps hBound
+      (exp_two_mul_fixed_full_loop_body_peel_tail_case_final_spec_within
+        e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+        r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+        v7 v11 base exit_ R hbase hzero hExit)
+
+/-- Symbolic bounded final full-tail peel using a named case-post exit
+    implication. -/
+theorem exp_two_mul_fixed_full_loop_body_peel_tail_case_final_exit_imp_symbolic_bounded_spec_within
+    (nBound : Nat)
+    (e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word)
+    (base : Word) (R : Assertion)
+    (hbase : (base + 44 : Word) &&& 1 = 0)
+    (hzero : expTwoMulIterCountNew iterCount = 0)
+    (hBound : expTwoMulFixedFullLoopBodyBound ≤ nBound)
+    (hExit :
+      ∀ ps,
+        expTwoMulFixedIterCaseExitPost iterCount e c6 ptr nextLimb sp evmSp
+          r0 r1 r2 r3 a0 a1 a2 a3 base ps →
+        R ps) :
+    cpsTripleWithin nBound
+      (base + 44)
+      (base + 296)
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterPre e c6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+        v7 v11)
+      R :=
+  cpsTripleWithin_mono_nSteps hBound
+    (exp_two_mul_fixed_full_loop_body_peel_tail_case_final_exit_imp_spec_within
+      e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 base R hbase hzero hExit)
+
 /-- Bounded full-tail peel using named case-post continuations for both branch
     targets. -/
 theorem exp_two_mul_fixed_full_loop_body_peel_tail_with_case_continuations_bounded_spec_within

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostTailBounds.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostTailBounds.lean
@@ -1,0 +1,176 @@
+/-
+  EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePostTailBounds
+
+  Bounded variants for fixed x19 case-post full-tail wrappers.
+-/
+
+import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePostBridge
+
+namespace EvmAsm.Evm64.Exp.Compose
+
+open EvmAsm.Rv64
+
+/-- Bounded full-tail peel using named case-post continuations for both branch
+    targets. -/
+theorem exp_two_mul_fixed_full_loop_body_peel_tail_with_case_continuations_bounded_spec_within
+    (nBound : Nat)
+    (e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word)
+    (base exit_ : Word) (R : Assertion)
+    (hbase : (base + 44 : Word) &&& 1 = 0)
+    (hBound : 49408 ≤ nBound) :
+    (cpsTripleWithin 49215
+      (base + 44) exit_
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterCaseLoopPost iterCount e c6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base)
+      R) →
+    (cpsTripleWithin 49215
+      (base + 296) exit_
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterCaseExitPost iterCount e c6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base)
+      R) →
+    cpsTripleWithin nBound
+      (base + 44)
+      exit_
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterPre e c6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+        v7 v11)
+      R :=
+  fun hLoop hExit =>
+    cpsTripleWithin_mono_nSteps hBound
+      (exp_two_mul_fixed_full_loop_body_peel_tail_with_case_continuations_closed_bound_spec_within
+        e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+        r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+        v7 v11 base exit_ R hbase hLoop hExit)
+
+/-- Bounded full-tail peel using a named case-post exit implication. -/
+theorem exp_two_mul_fixed_full_loop_body_peel_tail_with_case_exit_imp_bounded_spec_within
+    (nBound : Nat)
+    (e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word)
+    (base : Word) (R : Assertion)
+    (hbase : (base + 44 : Word) &&& 1 = 0)
+    (hBound : 49408 ≤ nBound)
+    (hExit :
+      ∀ ps,
+        expTwoMulFixedIterCaseExitPost iterCount e c6 ptr nextLimb sp evmSp
+          r0 r1 r2 r3 a0 a1 a2 a3 base ps →
+        R ps) :
+    (cpsTripleWithin 49215
+      (base + 44) (base + 296)
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterCaseLoopPost iterCount e c6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base)
+      R) →
+    cpsTripleWithin nBound
+      (base + 44)
+      (base + 296)
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterPre e c6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+        v7 v11)
+      R :=
+  fun hLoop =>
+    cpsTripleWithin_mono_nSteps hBound
+      (exp_two_mul_fixed_full_loop_body_peel_tail_with_case_exit_imp_closed_bound_spec_within
+        e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+        r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+        v7 v11 base R hbase hExit hLoop)
+
+/-- Bounded non-final full-tail peel using named case-post assertions. -/
+theorem exp_two_mul_fixed_full_loop_body_peel_tail_case_nonfinal_bounded_spec_within
+    (nBound : Nat)
+    (e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word)
+    (base : Word) (R : Assertion)
+    (hbase : (base + 44 : Word) &&& 1 = 0)
+    (hne : expTwoMulIterCountNew iterCount ≠ 0)
+    (hBound : 49408 ≤ nBound) :
+    (cpsTripleWithin 49215
+      (base + 44) (base + 296)
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterCaseLoopPost iterCount e c6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base)
+      R) →
+    cpsTripleWithin nBound
+      (base + 44)
+      (base + 296)
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterPre e c6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+        v7 v11)
+      R :=
+  fun hLoop =>
+    cpsTripleWithin_mono_nSteps hBound
+      (exp_two_mul_fixed_full_loop_body_peel_tail_case_nonfinal_closed_bound_spec_within
+        e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+        r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+        v7 v11 base R hbase hne hLoop)
+
+/-- Bounded final full-tail peel using a named case-post exit continuation. -/
+theorem exp_two_mul_fixed_full_loop_body_peel_tail_case_final_bounded_spec_within
+    (nBound : Nat)
+    (e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word)
+    (base exit_ : Word) (R : Assertion)
+    (hbase : (base + 44 : Word) &&& 1 = 0)
+    (hzero : expTwoMulIterCountNew iterCount = 0)
+    (hBound : 49408 ≤ nBound) :
+    (cpsTripleWithin 49215
+      (base + 296) exit_
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterCaseExitPost iterCount e c6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base)
+      R) →
+    cpsTripleWithin nBound
+      (base + 44)
+      exit_
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterPre e c6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+        v7 v11)
+      R :=
+  fun hExit =>
+    cpsTripleWithin_mono_nSteps hBound
+      (exp_two_mul_fixed_full_loop_body_peel_tail_case_final_closed_bound_spec_within
+        e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+        r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+        v7 v11 base exit_ R hbase hzero hExit)
+
+/-- Bounded final full-tail peel using a named case-post exit implication. -/
+theorem exp_two_mul_fixed_full_loop_body_peel_tail_case_final_exit_imp_bounded_spec_within
+    (nBound : Nat)
+    (e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word)
+    (base : Word) (R : Assertion)
+    (hbase : (base + 44 : Word) &&& 1 = 0)
+    (hzero : expTwoMulIterCountNew iterCount = 0)
+    (hBound : 49408 ≤ nBound)
+    (hExit :
+      ∀ ps,
+        expTwoMulFixedIterCaseExitPost iterCount e c6 ptr nextLimb sp evmSp
+          r0 r1 r2 r3 a0 a1 a2 a3 base ps →
+        R ps) :
+    cpsTripleWithin nBound
+      (base + 44)
+      (base + 296)
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterPre e c6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+        v7 v11)
+      R :=
+  cpsTripleWithin_mono_nSteps hBound
+    (exp_two_mul_fixed_full_loop_body_peel_tail_case_final_exit_imp_closed_bound_spec_within
+      e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 base R hbase hzero hExit)
+
+end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterReloadPointerPures.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterReloadPointerPures.lean
@@ -1,0 +1,113 @@
+/-
+  EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterReloadPointerPures
+
+  Pure extractors for fixed x19 reload-pointer framed case splits.
+-/
+
+import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePostFramedCases
+
+namespace EvmAsm.Evm64.Exp.Compose
+
+open EvmAsm.Rv64
+
+theorem expTwoMulFixedIterReloadCondPointerScratchFrame_pures
+    {iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
+    {exitCond : Prop} {v6 v7 v10 v11 d0 d1 d2 d3 : Word}
+    {frame : Assertion} {ps : PartialState}
+    (h :
+      ((expTwoMulFixedIterSkipCondCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 exitCond **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        expTwoMulFixedIterReloadCondCountPostScratchSuffixFrame
+          e c6 ptr nextLimb base) **
+        frame) ps) :
+    exitCond ∧
+    c6 + signExtend12 (-1 : BitVec 12) = 0 ∧
+    (e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12) ≠ 0 := by
+  unfold expTwoMulFixedIterSkipCondCountPostScratchPrefix
+    expTwoMulFixedIterSkipCondRestScratchPrefix
+    expTwoMulFixedIterScratchIs
+    expTwoMulFixedIterReloadCondCountPostScratchSuffixFrame
+    expTwoMulFixedIterSkipCondRestScratchSuffix
+    expTwoMulFixedIterReloadPointerFrame at h
+  obtain ⟨psMain, _psFrame, _hDisjoint, _hUnion, hMain, _hFrame⟩ := h
+  obtain ⟨psPrefix, _psTail, _hDisjointPrefix, _hUnionPrefix, hPrefix, hTail⟩ :=
+    hMain
+  obtain ⟨psCount, _psRest, _hDisjointCount, _hUnionCount, hCount, _hRest⟩ :=
+    hPrefix
+  obtain ⟨_psX9, _psX0Exit, _hDisjointX9, _hUnionX9, _hX9, hX0Exit⟩ :=
+    hCount
+  obtain ⟨_psX0, _psExit, _hDisjointX0, _hUnionX0, _hX0, hExit⟩ :=
+    hX0Exit
+  have h_exit : exitCond := hExit.2
+  obtain ⟨_psScratch, _psSuffix, _hDisjointScratch, _hUnionScratch,
+    _hScratch, hSuffix⟩ := hTail
+  obtain ⟨_psRet, _psX19Tail, _hDisjointRet, _hUnionRet,
+    _hRet, hX19Tail⟩ := hSuffix
+  obtain ⟨_psX19, _psX18Tail, _hDisjointX19, _hUnionX19,
+    _hX19, hX18Tail⟩ := hX19Tail
+  obtain ⟨_psX18, _psC6Tail, _hDisjointX18, _hUnionX18,
+    _hX18, hC6Tail⟩ := hX18Tail
+  obtain ⟨_psC6, _psPtrTail, _hDisjointC6, _hUnionC6,
+    hC6Pure, hPtrTail⟩ := hC6Tail
+  have h_c6 : c6 + signExtend12 (-1 : BitVec 12) = 0 := hC6Pure.2
+  obtain ⟨_psPtr, _psBit, _hDisjointPtr, _hUnionPtr,
+    _hPtr, hBitPure⟩ := hPtrTail
+  have h_bit :
+      (e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12) ≠ 0 :=
+    hBitPure.2
+  exact ⟨h_exit, h_c6, h_bit⟩
+
+theorem expTwoMulFixedIterReloadSkipPointerScratchFrame_pures
+    {iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
+    {exitCond : Prop} {v6 v7 v10 v11 d0 d1 d2 d3 : Word}
+    {frame : Assertion} {ps : PartialState}
+    (h :
+      ((expTwoMulFixedIterSkipCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3 exitCond **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        expTwoMulFixedIterReloadSkipCountPostScratchSuffixFrame
+          e c6 ptr nextLimb evmSp a0 a1 a2 a3 base) **
+        frame) ps) :
+    exitCond ∧
+    c6 + signExtend12 (-1 : BitVec 12) = 0 ∧
+    (e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12) = 0 := by
+  unfold expTwoMulFixedIterSkipCountPostScratchPrefix
+    expTwoMulFixedIterSkipRestScratchPrefix
+    expTwoMulFixedIterScratchIs
+    expTwoMulFixedIterReloadSkipCountPostScratchSuffixFrame
+    expTwoMulFixedIterBaseFrame
+    expTwoMulFixedIterReloadPointerFrame at h
+  obtain ⟨psMain, _psFrame, _hDisjoint, _hUnion, hMain, _hFrame⟩ := h
+  obtain ⟨psPrefix, _psTail, _hDisjointPrefix, _hUnionPrefix, hPrefix, hTail⟩ :=
+    hMain
+  obtain ⟨psCount, _psRest, _hDisjointCount, _hUnionCount, hCount, _hRest⟩ :=
+    hPrefix
+  obtain ⟨_psX9, _psX0Exit, _hDisjointX9, _hUnionX9, _hX9, hX0Exit⟩ :=
+    hCount
+  obtain ⟨_psX0, _psExit, _hDisjointX0, _hUnionX0, _hX0, hExit⟩ :=
+    hX0Exit
+  have h_exit : exitCond := hExit.2
+  obtain ⟨_psScratch, _psSuffix, _hDisjointScratch, _hUnionScratch,
+    _hScratch, hSuffix⟩ := hTail
+  obtain ⟨_psRet, _psX19Tail, _hDisjointRet, _hUnionRet,
+    _hRet, hX19Tail⟩ := hSuffix
+  obtain ⟨_psX19, _psX18Tail, _hDisjointX19, _hUnionX19,
+    _hX19, hX18Tail⟩ := hX19Tail
+  obtain ⟨_psX18, _psC6Tail, _hDisjointX18, _hUnionX18,
+    _hX18, hC6Tail⟩ := hX18Tail
+  obtain ⟨_psC6, _psPtrTail, _hDisjointC6, _hUnionC6,
+    hC6Pure, hPtrTail⟩ := hC6Tail
+  have h_c6 : c6 + signExtend12 (-1 : BitVec 12) = 0 := hC6Pure.2
+  obtain ⟨_psPtr, _psBitBase, _hDisjointPtr, _hUnionPtr,
+    _hPtr, hBitBase⟩ := hPtrTail
+  obtain ⟨_psBit, _psBase, _hDisjointBit, _hUnionBit,
+    hBitPure, _hBase⟩ := hBitBase
+  have h_bit :
+      (e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12) = 0 :=
+    hBitPure.2
+  exact ⟨h_exit, h_c6, h_bit⟩
+
+end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- add exp_two_mul_fixed_full_loop_boundary_of_body_general_bounded_spec_within
- add closed-form bounded wrapper for 49408-step fixed full-loop body proofs
- keep the existing exact 49429-step boundary theorem unchanged for direct consumers

## Tests
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryLoopFixed
- lake build EvmAsm.Evm64.Exp
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- lake build