### PR TITLE
feat(exp): expose unframed exit reload pures

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostIterPreCases.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostIterPreCases.lean
@@ -403,4 +403,72 @@ theorem expTwoMulFixedIterCaseExitPost_iterPre_or_reloadPointerFrame_pures
           ⟨v6, v7, v10, v11, d0, d1, d2, d3,
             hScratch, h_exit, h_c6, h_bit⟩))
 
+theorem expTwoMulFixedIterCaseExitPost_iterPre_or_reloadPointerFrame_pures_unframed
+    {iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
+    {ps : PartialState}
+    (h :
+      expTwoMulFixedIterCaseExitPost iterCount e c6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base ps) :
+    (∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      let squareW := expSquaringCallSquareW r0 r1 r2 r3
+      let rw := expTwoMulCondRw squareW a0 a1 a2 a3
+      (expTwoMulFixedIterPre
+        (e <<< (1 : BitVec 6).toNat)
+        v6
+        (expTwoMulIterCountNew iterCount)
+        v10
+        ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+        ptr nextLimb sp evmSp
+        (rw.getLimbN 3)
+        (((base + 44) + 140) + 68)
+        (rw.getLimbN 0) (rw.getLimbN 1) (rw.getLimbN 2) (rw.getLimbN 3)
+        d0 d1 d2 d3
+        (rw.getLimbN 0) (rw.getLimbN 1) (rw.getLimbN 2) (rw.getLimbN 3)
+        a0 a1 a2 a3 v7 v11) ps) ∨
+    (∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      let squareW := expSquaringCallSquareW r0 r1 r2 r3
+      (expTwoMulFixedIterPre
+        (e <<< (1 : BitVec 6).toNat)
+        v6
+        (expTwoMulIterCountNew iterCount)
+        v10
+        ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+        ptr nextLimb sp evmSp
+        (squareW.getLimbN 3)
+        (((base + 44) + 32) + 68)
+        (squareW.getLimbN 0) (squareW.getLimbN 1)
+        (squareW.getLimbN 2) (squareW.getLimbN 3)
+        d0 d1 d2 d3
+        (squareW.getLimbN 0) (squareW.getLimbN 1)
+        (squareW.getLimbN 2) (squareW.getLimbN 3)
+        a0 a1 a2 a3 v7 v11) ps) ∨
+    (∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      (expTwoMulFixedIterSkipCondCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3
+        (expTwoMulIterCountNew iterCount = 0) **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        expTwoMulFixedIterReloadCondCountPostScratchSuffixFrame
+          e c6 ptr nextLimb base) ps ∧
+      expTwoMulIterCountNew iterCount = 0 ∧
+      c6 + signExtend12 (-1 : BitVec 12) = 0 ∧
+      (e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12) ≠ 0) ∨
+    (∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      (expTwoMulFixedIterSkipCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3
+        (expTwoMulIterCountNew iterCount = 0) **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        expTwoMulFixedIterReloadSkipCountPostScratchSuffixFrame
+          e c6 ptr nextLimb evmSp a0 a1 a2 a3 base) ps ∧
+      expTwoMulIterCountNew iterCount = 0 ∧
+      c6 + signExtend12 (-1 : BitVec 12) = 0 ∧
+      (e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12) = 0) := by
+  have hFrame :
+      (expTwoMulFixedIterCaseExitPost iterCount e c6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base ** empAssertion) ps := by
+    simpa [sepConj_emp_right'] using h
+  simpa [sepConj_emp_right'] using
+    (expTwoMulFixedIterCaseExitPost_iterPre_or_reloadPointerFrame_pures
+      (frame := empAssertion) hFrame)
+
 end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- add expTwoMulFixedIterCaseExitPost_iterPre_or_reloadPointerFrame_pures_unframed
- reuse the framed pure-case split with an empty frame
- expose bare exit case-post consumers to the same iterPre-or-reload split and reload pure facts

## Tests
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePostIterPreCases
- lake build EvmAsm.Evm64.Exp
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- lake build