### PR TITLE
feat(exp): expose fixed boundary nonfinal tail

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryLoopFixed.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryLoopFixed.lean
@@ -491,6 +491,91 @@ theorem exp_two_mul_fixed_full_loop_boundary_of_entry_tail_case_posts_closed_bou
       v7 v11 iterCountNew baseWord exponentWord rest exitCond base hbase
       hEntry hExit hTailNamed
 
+/-- Non-final fixed boundary-level wrapper for the first full-loop body
+    iteration. The current case-post exit edge is impossible, so callers only
+    supply the loop-back case-post tail continuation. -/
+theorem exp_two_mul_fixed_full_loop_boundary_of_entry_tail_case_nonfinal_spec_within
+    (sp evmSp cOld tOld c6Old c16Old c19Old
+      m0 m1 m2 m3 vOld v18
+      e c6 iterCount v10 ptr nextLimb
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 iterCountNew : Word)
+    (baseWord exponentWord : EvmWord) (rest : List EvmWord)
+    (exitCond : Prop) (base : Word)
+    (hbase : (base + 44 : Word) &&& 1 = 0)
+    (hne : expTwoMulIterCountNew iterCount ≠ 0)
+    (hEntry :
+      ∀ hp,
+        expTwoMulLoopEntryPostFixed sp evmSp vOld v18
+          baseWord exponentWord rest hp →
+        expTwoMulFixedIterPre e c6 iterCount v10 v18 ptr nextLimb sp evmSp
+          tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+          v7 v11 hp)
+    (hTail :
+      cpsTripleWithin expTwoMulFixedFullLoopBodyTailBound
+        (base + 44) (base + 296)
+        (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+        (expTwoMulFixedIterCaseLoopPost iterCount e c6 ptr nextLimb sp evmSp
+          r0 r1 r2 r3 a0 a1 a2 a3 base)
+        (expTwoMulLoopExitFullStackPreFrame sp evmSp iterCountNew tOld
+          r0 r1 r2 r3 d0 d1 d2 d3 baseWord rest exitCond)) :
+    cpsTripleWithin expTwoMulFixedFullLoopBoundaryBound base (base + 336)
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulBoundaryPreFixed sp evmSp cOld tOld c6Old c16Old c19Old
+        m0 m1 m2 m3 vOld v18 baseWord exponentWord rest)
+      (expTwoMulLoopExitPost sp evmSp iterCountNew r0 r1 r2 r3
+        baseWord rest exitCond) :=
+  exp_two_mul_fixed_full_loop_boundary_of_entry_tail_case_posts_spec_within
+    sp evmSp cOld tOld c6Old c16Old c19Old m0 m1 m2 m3 vOld v18
+    e c6 iterCount v10 ptr nextLimb
+    r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+    v7 v11 iterCountNew baseWord exponentWord rest exitCond base hbase
+    hEntry
+    (exp_fixed_iter_case_exit_vacuous_bridge hne)
+    hTail
+
+/-- Closed-form variant of
+    `exp_two_mul_fixed_full_loop_boundary_of_entry_tail_case_nonfinal_spec_within`. -/
+theorem exp_two_mul_fixed_full_loop_boundary_of_entry_tail_case_nonfinal_closed_bound_spec_within
+    (sp evmSp cOld tOld c6Old c16Old c19Old
+      m0 m1 m2 m3 vOld v18
+      e c6 iterCount v10 ptr nextLimb
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 iterCountNew : Word)
+    (baseWord exponentWord : EvmWord) (rest : List EvmWord)
+    (exitCond : Prop) (base : Word)
+    (hbase : (base + 44 : Word) &&& 1 = 0)
+    (hne : expTwoMulIterCountNew iterCount ≠ 0)
+    (hEntry :
+      ∀ hp,
+        expTwoMulLoopEntryPostFixed sp evmSp vOld v18
+          baseWord exponentWord rest hp →
+        expTwoMulFixedIterPre e c6 iterCount v10 v18 ptr nextLimb sp evmSp
+          tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+          v7 v11 hp)
+    (hTail :
+      cpsTripleWithin 49215
+        (base + 44) (base + 296)
+        (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+        (expTwoMulFixedIterCaseLoopPost iterCount e c6 ptr nextLimb sp evmSp
+          r0 r1 r2 r3 a0 a1 a2 a3 base)
+        (expTwoMulLoopExitFullStackPreFrame sp evmSp iterCountNew tOld
+          r0 r1 r2 r3 d0 d1 d2 d3 baseWord rest exitCond)) :
+    cpsTripleWithin 49429 base (base + 336)
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulBoundaryPreFixed sp evmSp cOld tOld c6Old c16Old c19Old
+        m0 m1 m2 m3 vOld v18 baseWord exponentWord rest)
+      (expTwoMulLoopExitPost sp evmSp iterCountNew r0 r1 r2 r3
+        baseWord rest exitCond) :=
+  exp_two_mul_fixed_full_loop_boundary_of_entry_tail_case_posts_closed_bound_spec_within
+    sp evmSp cOld tOld c6Old c16Old c19Old m0 m1 m2 m3 vOld v18
+    e c6 iterCount v10 ptr nextLimb
+    r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+    v7 v11 iterCountNew baseWord exponentWord rest exitCond base hbase
+    hEntry
+    (exp_fixed_iter_case_exit_vacuous_bridge hne)
+    hTail
+
 /-- Fixed boundary wrapper that accepts any body proof bounded by the named
     conservative fixed full-loop body bound. -/
 theorem exp_two_mul_fixed_full_loop_boundary_of_bounded_body_general_spec_within


### PR DESCRIPTION
## Summary
- add a non-final fixed boundary wrapper over the case-post tail theorem
- discharge the current case-post exit branch with the existing vacuous exit bridge when expTwoMulIterCountNew iterCount != 0
- add a closed-bound 49215/49429 variant

## Tests
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryLoopFixed
- lake build EvmAsm.Evm64.Exp
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- lake build