### PR TITLE
feat(exp): expose fixed entry scratch unfolds

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryLoopFixed.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryLoopFixed.lean
@@ -46,6 +46,23 @@ theorem expTwoMulBoundaryPreFixed_unfold
   delta expTwoMulBoundaryPreFixed
   rfl
 
+theorem expTwoMulBoundaryPreFixed_unfold_scratch
+    {sp evmSp cOld tOld c6Old c16Old c19Old m0 m1 m2 m3 vOld v18 : Word}
+    {baseWord exponentWord : EvmWord} {rest : List EvmWord} :
+    expTwoMulBoundaryPreFixed sp evmSp cOld tOld c6Old c16Old c19Old
+      m0 m1 m2 m3 vOld v18 baseWord exponentWord rest =
+      ((.x2 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) ** (.x9 ↦ᵣ cOld) **
+       (.x5 ↦ᵣ tOld) ** (.x12 ↦ᵣ evmSp) **
+       (.x6 ↦ᵣ c6Old) ** (.x16 ↦ᵣ c16Old) ** (.x19 ↦ᵣ c19Old) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ m0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ m1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ m2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ m3) **
+       (regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
+        (.x1 ↦ᵣ vOld) ** (.x18 ↦ᵣ v18)) **
+       evmStackIs evmSp (baseWord :: exponentWord :: rest)) := by
+  rw [expTwoMulBoundaryPreFixed_unfold, expTwoMulScratchFrame_unfold]
+
 theorem expTwoMulBoundaryPreFixed_pcFree
     {sp evmSp cOld tOld c6Old c16Old c19Old m0 m1 m2 m3 vOld v18 : Word}
     {baseWord exponentWord : EvmWord} {rest : List EvmWord} :

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryPrologueFixed.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryPrologueFixed.lean
@@ -61,6 +61,22 @@ theorem expTwoMulLoopEntryPostFixed_unfold
        expTwoMulScratchFrame vOld v18) := by
   delta expTwoMulLoopEntryPostFixed; rfl
 
+theorem expTwoMulLoopEntryPostFixed_unfold_scratch
+    {sp evmSp vOld v18 : Word} {baseWord exponentWord : EvmWord}
+    {rest : List EvmWord} :
+    expTwoMulLoopEntryPostFixed sp evmSp vOld v18 baseWord exponentWord rest =
+      (((((.x2 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) **
+          (.x9 ↦ᵣ (256 : Word)) ** (.x5 ↦ᵣ (1 : Word)) **
+          (.x6 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
+          (.x16 ↦ᵣ (evmSp + signExtend12 (56 : BitVec 12) + signExtend12 (-8 : BitVec 12))) **
+          (.x19 ↦ᵣ exponentWord.getLimbN 3) **
+          evmWordIs sp (1 : EvmWord)) **
+         (.x12 ↦ᵣ (evmSp + signExtend12 (64 : BitVec 12)))) **
+        evmStackIs evmSp (baseWord :: exponentWord :: rest)) **
+       (regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
+        (.x1 ↦ᵣ vOld) ** (.x18 ↦ᵣ v18))) := by
+  rw [expTwoMulLoopEntryPostFixed_unfold, expTwoMulScratchFrame_unfold]
+
 theorem expTwoMulLoopEntryPostFixed_pcFree
     {sp evmSp vOld v18 : Word} {baseWord exponentWord : EvmWord}
     {rest : List EvmWord} :


### PR DESCRIPTION
## Summary
- add expanded scratch-frame unfold lemma for expTwoMulLoopEntryPostFixed
- add expanded scratch-frame unfold lemma for expTwoMulBoundaryPreFixed
- expose x1/x7/x10/x11/x18 ownership for later fixed entry-to-iteration bridge proofs

## Tests
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryPrologueFixed
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryLoopFixed
- lake build EvmAsm.Evm64.Exp
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- lake build