### PR TITLE
feat(exp): generalize fixed boundary case stack

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryLoopFixed.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryLoopFixed.lean
@@ -508,6 +508,67 @@ theorem exp_two_mul_fixed_full_loop_boundary_of_entry_tail_case_posts_closed_bou
       v7 v11 iterCountNew baseWord exponentWord rest exitCond base hbase
       hEntry hExit hTailNamed
 
+/-- Boundary-level wrapper for the first fixed full-loop body iteration with
+    the iteration stack pointer separated from the boundary stack pointer. This
+    is the shape needed after the fixed prologue advances `x12`. -/
+theorem exp_two_mul_fixed_full_loop_boundary_of_entry_tail_case_posts_iter_sp_spec_within
+    (sp evmSp iterSp cOld tOld c6Old c16Old c19Old
+      m0 m1 m2 m3 vOld v18
+      e c6 iterCount v10 ptr nextLimb
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 iterCountNew : Word)
+    (baseWord exponentWord : EvmWord) (rest : List EvmWord)
+    (exitCond : Prop) (base : Word)
+    (hbase : (base + 44 : Word) &&& 1 = 0)
+    (hEntry :
+      ∀ hp,
+        expTwoMulLoopEntryPostFixed sp evmSp vOld v18
+          baseWord exponentWord rest hp →
+        expTwoMulFixedIterPre e c6 iterCount v10 v18 ptr nextLimb sp iterSp
+          tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+          v7 v11 hp)
+    (hExit :
+      ∀ hp,
+        expTwoMulFixedIterCaseExitPost iterCount e c6 ptr nextLimb sp iterSp
+          r0 r1 r2 r3 a0 a1 a2 a3 base hp →
+        expTwoMulLoopExitFullStackPreFrame sp evmSp iterCountNew tOld
+          r0 r1 r2 r3 d0 d1 d2 d3 baseWord rest exitCond hp)
+    (hTail :
+      cpsTripleWithin expTwoMulFixedFullLoopBodyTailBound
+        (base + 44) (base + 296)
+        (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+        (expTwoMulFixedIterCaseLoopPost iterCount e c6 ptr nextLimb sp iterSp
+          r0 r1 r2 r3 a0 a1 a2 a3 base)
+        (expTwoMulLoopExitFullStackPreFrame sp evmSp iterCountNew tOld
+          r0 r1 r2 r3 d0 d1 d2 d3 baseWord rest exitCond)) :
+    cpsTripleWithin expTwoMulFixedFullLoopBoundaryBound base (base + 336)
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulBoundaryPreFixed sp evmSp cOld tOld c6Old c16Old c19Old
+        m0 m1 m2 m3 vOld v18 baseWord exponentWord rest)
+      (expTwoMulLoopExitPost sp evmSp iterCountNew r0 r1 r2 r3
+        baseWord rest exitCond) := by
+  have hBody :
+      cpsTripleWithin expTwoMulFixedFullLoopBodyBound
+        (base + 44) (base + 296)
+        (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+        (expTwoMulFixedIterPre e c6 iterCount v10 v18 ptr nextLimb sp iterSp
+          tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+          v7 v11)
+        (expTwoMulLoopExitFullStackPreFrame sp evmSp iterCountNew tOld
+          r0 r1 r2 r3 d0 d1 d2 d3 baseWord rest exitCond) :=
+    exp_two_mul_fixed_full_loop_body_peel_tail_with_case_exit_imp_spec_within
+      e c6 iterCount v10 v18 ptr nextLimb sp iterSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 base
+      (expTwoMulLoopExitFullStackPreFrame sp evmSp iterCountNew tOld
+        r0 r1 r2 r3 d0 d1 d2 d3 baseWord rest exitCond)
+      hbase hExit hTail
+  exact
+    exp_two_mul_fixed_full_loop_boundary_of_entry_body_general_spec_within
+      sp evmSp cOld tOld c6Old c16Old c19Old m0 m1 m2 m3 vOld v18
+      iterCountNew r0 r1 r2 r3 d0 d1 d2 d3 baseWord exponentWord rest
+      exitCond base hEntry hBody
+
 /-- Non-final fixed boundary-level wrapper for the first full-loop body
     iteration. The current case-post exit edge is impossible, so callers only
     supply the loop-back case-post tail continuation. -/


### PR DESCRIPTION
## Summary
- add a fixed boundary case-tail wrapper with a separate iteration stack-pointer parameter
- keep the boundary pre/post stack pointer distinct from the iteration body's x12 value
- prepare the wrapper shape needed after fixed prologue pointer advancement

## Tests
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryLoopFixed
- lake build EvmAsm.Evm64.Exp
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- lake build