### PR TITLE
feat(exp): close fixed iter stack bound

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryLoopFixed.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryLoopFixed.lean
@@ -569,6 +569,63 @@ theorem exp_two_mul_fixed_full_loop_boundary_of_entry_tail_case_posts_iter_sp_sp
       iterCountNew r0 r1 r2 r3 d0 d1 d2 d3 baseWord exponentWord rest
       exitCond base hEntry hBody
 
+/-- Closed-form variant of
+    `exp_two_mul_fixed_full_loop_boundary_of_entry_tail_case_posts_iter_sp_spec_within`. -/
+theorem exp_two_mul_fixed_full_loop_boundary_of_entry_tail_case_posts_iter_sp_closed_bound_spec_within
+    (sp evmSp iterSp cOld tOld c6Old c16Old c19Old
+      m0 m1 m2 m3 vOld v18
+      e c6 iterCount v10 ptr nextLimb
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 iterCountNew : Word)
+    (baseWord exponentWord : EvmWord) (rest : List EvmWord)
+    (exitCond : Prop) (base : Word)
+    (hbase : (base + 44 : Word) &&& 1 = 0)
+    (hEntry :
+      ∀ hp,
+        expTwoMulLoopEntryPostFixed sp evmSp vOld v18
+          baseWord exponentWord rest hp →
+        expTwoMulFixedIterPre e c6 iterCount v10 v18 ptr nextLimb sp iterSp
+          tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+          v7 v11 hp)
+    (hExit :
+      ∀ hp,
+        expTwoMulFixedIterCaseExitPost iterCount e c6 ptr nextLimb sp iterSp
+          r0 r1 r2 r3 a0 a1 a2 a3 base hp →
+        expTwoMulLoopExitFullStackPreFrame sp evmSp iterCountNew tOld
+          r0 r1 r2 r3 d0 d1 d2 d3 baseWord rest exitCond hp)
+    (hTail :
+      cpsTripleWithin 49215
+        (base + 44) (base + 296)
+        (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+        (expTwoMulFixedIterCaseLoopPost iterCount e c6 ptr nextLimb sp iterSp
+          r0 r1 r2 r3 a0 a1 a2 a3 base)
+        (expTwoMulLoopExitFullStackPreFrame sp evmSp iterCountNew tOld
+          r0 r1 r2 r3 d0 d1 d2 d3 baseWord rest exitCond)) :
+    cpsTripleWithin 49429 base (base + 336)
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulBoundaryPreFixed sp evmSp cOld tOld c6Old c16Old c19Old
+        m0 m1 m2 m3 vOld v18 baseWord exponentWord rest)
+      (expTwoMulLoopExitPost sp evmSp iterCountNew r0 r1 r2 r3
+        baseWord rest exitCond) := by
+  have hTailNamed :
+      cpsTripleWithin expTwoMulFixedFullLoopBodyTailBound
+        (base + 44) (base + 296)
+        (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+        (expTwoMulFixedIterCaseLoopPost iterCount e c6 ptr nextLimb sp iterSp
+          r0 r1 r2 r3 a0 a1 a2 a3 base)
+        (expTwoMulLoopExitFullStackPreFrame sp evmSp iterCountNew tOld
+          r0 r1 r2 r3 d0 d1 d2 d3 baseWord rest exitCond) := by
+    rw [expTwoMulFixedFullLoopBodyTailBound_eq]
+    exact hTail
+  rw [← expTwoMulFixedFullLoopBoundaryBound_eq]
+  exact
+    exp_two_mul_fixed_full_loop_boundary_of_entry_tail_case_posts_iter_sp_spec_within
+      sp evmSp iterSp cOld tOld c6Old c16Old c19Old
+      m0 m1 m2 m3 vOld v18 e c6 iterCount v10 ptr nextLimb
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 iterCountNew baseWord exponentWord rest exitCond base hbase
+      hEntry hExit hTailNamed
+
 /-- Non-final fixed boundary-level wrapper for the first full-loop body
     iteration. The current case-post exit edge is impossible, so callers only
     supply the loop-back case-post tail continuation. -/


### PR DESCRIPTION
## Summary
- add a closed-bound variant for the generalized fixed boundary case-tail wrapper
- expose the 49215-step tail and 49429-step boundary constants with separate boundary and iteration stack pointers

## Tests
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryLoopFixed
- lake build EvmAsm.Evm64.Exp
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- lake build