### PR TITLE
feat(exp): expose fixed entry rest stack

### DIFF
--- a/EvmAsm/Evm64/Exp.lean
+++ b/EvmAsm/Evm64/Exp.lean
@@ -64,6 +64,7 @@ import EvmAsm.Evm64.Exp.Compose.SavedBitBaseTwoMulFixedIter
 import EvmAsm.Evm64.Exp.Compose.SavedBitBaseTwoMulFixedIterLoop
 import EvmAsm.Evm64.Exp.Compose.SavedBitBaseTwoMulFixedIterMerged
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedWithMul
+import EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryEntryFixedIterPre
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePosts
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterExits
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePostBridge

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryEntryFixedIterPre.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryEntryFixedIterPre.lean
@@ -1,0 +1,87 @@
+/-
+  EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryEntryFixedIterPre
+
+  Named first-iteration precondition for the fixed saved-bit EXP loop entry.
+  The fixed prologue advances x12 past the two EXP operands, so the first
+  iteration sees the first two `rest` words at the advanced stack pointer.
+-/
+
+import EvmAsm.Evm64.Exp.Compose.SavedBitFixedWithMul
+
+namespace EvmAsm.Evm64.Exp.Compose
+
+open EvmAsm.Rv64
+
+/-- Canonical fixed-loop first-iteration precondition after the prologue.
+    The first two words below the EXP operands become the `d`/`e` limb groups
+    at the advanced iteration stack pointer `evmSp + 64`. -/
+@[irreducible]
+def expTwoMulFixedFirstIterPre
+    (sp evmSp v10 v18 vOld v7 v11 : Word)
+    (baseWord exponentWord dWord eWord : EvmWord) : Assertion :=
+  expTwoMulFixedIterPre
+    (exponentWord.getLimbN 3)
+    ((0 : Word) + signExtend12 (64 : BitVec 12))
+    (256 : Word)
+    v10 v18
+    (evmSp + signExtend12 (56 : BitVec 12) + signExtend12 (-8 : BitVec 12))
+    (exponentWord.getLimbN 2)
+    sp (evmSp + signExtend12 (64 : BitVec 12))
+    (1 : Word) vOld
+    ((1 : EvmWord).getLimbN 0)
+    ((1 : EvmWord).getLimbN 1)
+    ((1 : EvmWord).getLimbN 2)
+    ((1 : EvmWord).getLimbN 3)
+    (dWord.getLimbN 0) (dWord.getLimbN 1)
+    (dWord.getLimbN 2) (dWord.getLimbN 3)
+    (eWord.getLimbN 0) (eWord.getLimbN 1)
+    (eWord.getLimbN 2) (eWord.getLimbN 3)
+    (baseWord.getLimbN 0) (baseWord.getLimbN 1)
+    (baseWord.getLimbN 2) (baseWord.getLimbN 3)
+    v7 v11
+
+theorem expTwoMulFixedFirstIterPre_unfold
+    {sp evmSp v10 v18 vOld v7 v11 : Word}
+    {baseWord exponentWord dWord eWord : EvmWord} :
+    expTwoMulFixedFirstIterPre sp evmSp v10 v18 vOld v7 v11
+        baseWord exponentWord dWord eWord =
+      expTwoMulFixedIterPre
+        (exponentWord.getLimbN 3)
+        ((0 : Word) + signExtend12 (64 : BitVec 12))
+        (256 : Word)
+        v10 v18
+        (evmSp + signExtend12 (56 : BitVec 12) + signExtend12 (-8 : BitVec 12))
+        (exponentWord.getLimbN 2)
+        sp (evmSp + signExtend12 (64 : BitVec 12))
+        (1 : Word) vOld
+        ((1 : EvmWord).getLimbN 0)
+        ((1 : EvmWord).getLimbN 1)
+        ((1 : EvmWord).getLimbN 2)
+        ((1 : EvmWord).getLimbN 3)
+        (dWord.getLimbN 0) (dWord.getLimbN 1)
+        (dWord.getLimbN 2) (dWord.getLimbN 3)
+        (eWord.getLimbN 0) (eWord.getLimbN 1)
+        (eWord.getLimbN 2) (eWord.getLimbN 3)
+        (baseWord.getLimbN 0) (baseWord.getLimbN 1)
+        (baseWord.getLimbN 2) (baseWord.getLimbN 3)
+        v7 v11 := by
+  delta expTwoMulFixedFirstIterPre
+  rfl
+
+theorem expTwoMulFixedFirstIterPre_pcFree
+    {sp evmSp v10 v18 vOld v7 v11 : Word}
+    {baseWord exponentWord dWord eWord : EvmWord} :
+    (expTwoMulFixedFirstIterPre sp evmSp v10 v18 vOld v7 v11
+      baseWord exponentWord dWord eWord).pcFree := by
+  rw [expTwoMulFixedFirstIterPre_unfold]
+  exact expTwoMulFixedIterPre_pcFree
+
+instance pcFreeInst_expTwoMulFixedFirstIterPre
+    (sp evmSp v10 v18 vOld v7 v11 : Word)
+    (baseWord exponentWord dWord eWord : EvmWord) :
+    Assertion.PCFree
+      (expTwoMulFixedFirstIterPre sp evmSp v10 v18 vOld v7 v11
+        baseWord exponentWord dWord eWord) :=
+  ⟨expTwoMulFixedFirstIterPre_pcFree⟩
+
+end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryPrologueFixed.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryPrologueFixed.lean
@@ -77,6 +77,59 @@ theorem expTwoMulLoopEntryPostFixed_unfold_scratch
         (.x1 ↦ᵣ vOld) ** (.x18 ↦ᵣ v18))) := by
   rw [expTwoMulLoopEntryPostFixed_unfold, expTwoMulScratchFrame_unfold]
 
+/-- Fixed entry-post unfold that exposes the first two words below the EXP
+    operands. This is the stack shape needed by the fixed iteration precondition
+    after the prologue advances `x12` to `evmSp + 64`. -/
+theorem expTwoMulLoopEntryPostFixed_unfold_rest2
+    {sp evmSp vOld v18 : Word} {baseWord exponentWord dWord eWord : EvmWord}
+    {rest : List EvmWord} :
+    expTwoMulLoopEntryPostFixed sp evmSp vOld v18
+        baseWord exponentWord (dWord :: eWord :: rest) =
+      (((((.x2 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) **
+          (.x9 ↦ᵣ (256 : Word)) ** (.x5 ↦ᵣ (1 : Word)) **
+          (.x6 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
+          (.x16 ↦ᵣ (evmSp + signExtend12 (56 : BitVec 12) + signExtend12 (-8 : BitVec 12))) **
+          (.x19 ↦ᵣ exponentWord.getLimbN 3) **
+          evmWordIs sp (1 : EvmWord)) **
+         (.x12 ↦ᵣ (evmSp + signExtend12 (64 : BitVec 12)))) **
+        (evmWordIs evmSp baseWord **
+         evmWordIs (evmSp + 32) exponentWord **
+         evmWordIs (evmSp + 32 + 32) dWord **
+         evmWordIs (evmSp + 32 + 32 + 32) eWord **
+         evmStackIs (evmSp + 32 + 32 + 32 + 32) rest)) **
+       (regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
+        (.x1 ↦ᵣ vOld) ** (.x18 ↦ᵣ v18))) := by
+  rw [expTwoMulLoopEntryPostFixed_unfold_scratch]
+  rfl
+
+/-- Normalized-offset variant of `expTwoMulLoopEntryPostFixed_unfold_rest2`.
+    The first rest word starts exactly at the advanced iteration stack pointer
+    `evmSp + 64`. -/
+theorem expTwoMulLoopEntryPostFixed_unfold_rest2_offsets
+    {sp evmSp vOld v18 : Word} {baseWord exponentWord dWord eWord : EvmWord}
+    {rest : List EvmWord} :
+    expTwoMulLoopEntryPostFixed sp evmSp vOld v18
+        baseWord exponentWord (dWord :: eWord :: rest) =
+      (((((.x2 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) **
+          (.x9 ↦ᵣ (256 : Word)) ** (.x5 ↦ᵣ (1 : Word)) **
+          (.x6 ↦ᵣ ((0 : Word) + signExtend12 (64 : BitVec 12))) **
+          (.x16 ↦ᵣ (evmSp + signExtend12 (56 : BitVec 12) + signExtend12 (-8 : BitVec 12))) **
+          (.x19 ↦ᵣ exponentWord.getLimbN 3) **
+          evmWordIs sp (1 : EvmWord)) **
+         (.x12 ↦ᵣ (evmSp + signExtend12 (64 : BitVec 12)))) **
+        (evmWordIs evmSp baseWord **
+         evmWordIs (evmSp + 32) exponentWord **
+         evmWordIs (evmSp + 64) dWord **
+         evmWordIs (evmSp + 96) eWord **
+         evmStackIs (evmSp + 128) rest)) **
+       (regOwn .x6 ** regOwn .x7 ** regOwn .x10 ** regOwn .x11 **
+        (.x1 ↦ᵣ vOld) ** (.x18 ↦ᵣ v18))) := by
+  rw [expTwoMulLoopEntryPostFixed_unfold_rest2]
+  simp only [BitVec.add_assoc,
+    show (32 : Word) + 32 = 64 from by decide,
+    show (64 : Word) + 32 = 96 from by decide,
+    show (96 : Word) + 32 = 128 from by decide]
+
 theorem expTwoMulLoopEntryPostFixed_pcFree
     {sp evmSp vOld v18 : Word} {baseWord exponentWord : EvmWord}
     {rest : List EvmWord} :


### PR DESCRIPTION
## Summary
- add fixed loop-entry unfold lemmas for the rest stack with two explicit words below EXP operands
- add a normalized-offset variant exposing the first rest word at evmSp + 64 for the upcoming fixed entry-to-iter-pre bridge
- add expTwoMulFixedFirstIterPre as the named canonical first fixed-iteration precondition over those two rest words, with PCFree support

## Checks
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryPrologueFixed
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryEntryFixedIterPre
- lake build EvmAsm.Evm64.Exp
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- lake build