### PR TITLE
feat(exp): expose fixed first case pures

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryLoopFixedEntryExists.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryLoopFixedEntryExists.lean
@@ -187,6 +187,125 @@ theorem expTwoMulFixedFirstIterCaseLoopPostWithResidual_cases
   rw [expTwoMulFixedFirstIterCaseLoopPostWithResidual_unfold] at h
   exact expTwoMulFixedIterCaseLoopPost_iterPre_or_reloadPointerFrame h
 
+theorem expTwoMulFixedFirstIterCaseLoopPostWithResidual_pures
+    {sp evmSp : Word}
+    {baseWord exponentWord : EvmWord} {rest : List EvmWord}
+    {base : Word} {ps : PartialState}
+    (h : expTwoMulFixedFirstIterCaseLoopPostWithResidual
+      sp evmSp baseWord exponentWord rest base ps) :
+    (∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      let squareW :=
+        expSquaringCallSquareW
+          ((1 : EvmWord).getLimbN 0)
+          ((1 : EvmWord).getLimbN 1)
+          ((1 : EvmWord).getLimbN 2)
+          ((1 : EvmWord).getLimbN 3)
+      let rw := expTwoMulCondRw squareW
+        (baseWord.getLimbN 0) (baseWord.getLimbN 1)
+        (baseWord.getLimbN 2) (baseWord.getLimbN 3)
+      ((expTwoMulFixedIterPre
+        (exponentWord.getLimbN 3 <<< (1 : BitVec 6).toNat)
+        v6
+        (expTwoMulIterCountNew (256 : Word))
+        v10
+        ((exponentWord.getLimbN 3 >>> (63 : BitVec 6).toNat) +
+          signExtend12 (0 : BitVec 12))
+        (evmSp + signExtend12 (56 : BitVec 12) +
+          signExtend12 (-8 : BitVec 12))
+        (exponentWord.getLimbN 2)
+        sp (evmSp + signExtend12 (64 : BitVec 12))
+        (rw.getLimbN 3)
+        (((base + 44) + 140) + 68)
+        (rw.getLimbN 0) (rw.getLimbN 1) (rw.getLimbN 2) (rw.getLimbN 3)
+        d0 d1 d2 d3
+        (rw.getLimbN 0) (rw.getLimbN 1) (rw.getLimbN 2) (rw.getLimbN 3)
+        (baseWord.getLimbN 0) (baseWord.getLimbN 1)
+        (baseWord.getLimbN 2) (baseWord.getLimbN 3) v7 v11) **
+        expTwoMulFixedFirstIterEntryResidual evmSp exponentWord rest) ps) ∨
+    (∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      let squareW :=
+        expSquaringCallSquareW
+          ((1 : EvmWord).getLimbN 0)
+          ((1 : EvmWord).getLimbN 1)
+          ((1 : EvmWord).getLimbN 2)
+          ((1 : EvmWord).getLimbN 3)
+      ((expTwoMulFixedIterPre
+        (exponentWord.getLimbN 3 <<< (1 : BitVec 6).toNat)
+        v6
+        (expTwoMulIterCountNew (256 : Word))
+        v10
+        ((exponentWord.getLimbN 3 >>> (63 : BitVec 6).toNat) +
+          signExtend12 (0 : BitVec 12))
+        (evmSp + signExtend12 (56 : BitVec 12) +
+          signExtend12 (-8 : BitVec 12))
+        (exponentWord.getLimbN 2)
+        sp (evmSp + signExtend12 (64 : BitVec 12))
+        (squareW.getLimbN 3)
+        (((base + 44) + 32) + 68)
+        (squareW.getLimbN 0) (squareW.getLimbN 1)
+        (squareW.getLimbN 2) (squareW.getLimbN 3)
+        d0 d1 d2 d3
+        (squareW.getLimbN 0) (squareW.getLimbN 1)
+        (squareW.getLimbN 2) (squareW.getLimbN 3)
+        (baseWord.getLimbN 0) (baseWord.getLimbN 1)
+        (baseWord.getLimbN 2) (baseWord.getLimbN 3) v7 v11) **
+        expTwoMulFixedFirstIterEntryResidual evmSp exponentWord rest) ps) ∨
+    (∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      ((expTwoMulFixedIterSkipCondCountPostScratchPrefix
+        (256 : Word) sp (evmSp + signExtend12 (64 : BitVec 12))
+        ((1 : EvmWord).getLimbN 0)
+        ((1 : EvmWord).getLimbN 1)
+        ((1 : EvmWord).getLimbN 2)
+        ((1 : EvmWord).getLimbN 3)
+        (baseWord.getLimbN 0) (baseWord.getLimbN 1)
+        (baseWord.getLimbN 2) (baseWord.getLimbN 3)
+        (expTwoMulIterCountNew (256 : Word) ≠ 0) **
+        expTwoMulFixedIterScratchIs
+          (evmSp + signExtend12 (64 : BitVec 12))
+          v6 v7 v10 v11 d0 d1 d2 d3 **
+        expTwoMulFixedIterReloadCondCountPostScratchSuffixFrame
+          (exponentWord.getLimbN 3)
+          ((0 : Word) + signExtend12 (64 : BitVec 12))
+          (evmSp + signExtend12 (56 : BitVec 12) +
+            signExtend12 (-8 : BitVec 12))
+          (exponentWord.getLimbN 2)
+          base) **
+        expTwoMulFixedFirstIterEntryResidual evmSp exponentWord rest) ps ∧
+      expTwoMulIterCountNew (256 : Word) ≠ 0 ∧
+      ((0 : Word) + signExtend12 (64 : BitVec 12)) +
+        signExtend12 (-1 : BitVec 12) = 0 ∧
+      (exponentWord.getLimbN 3 >>> (63 : BitVec 6).toNat) +
+        signExtend12 (0 : BitVec 12) ≠ 0) ∨
+    (∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      ((expTwoMulFixedIterSkipCountPostScratchPrefix
+        (256 : Word) sp (evmSp + signExtend12 (64 : BitVec 12))
+        ((1 : EvmWord).getLimbN 0)
+        ((1 : EvmWord).getLimbN 1)
+        ((1 : EvmWord).getLimbN 2)
+        ((1 : EvmWord).getLimbN 3)
+        (expTwoMulIterCountNew (256 : Word) ≠ 0) **
+        expTwoMulFixedIterScratchIs
+          (evmSp + signExtend12 (64 : BitVec 12))
+          v6 v7 v10 v11 d0 d1 d2 d3 **
+        expTwoMulFixedIterReloadSkipCountPostScratchSuffixFrame
+          (exponentWord.getLimbN 3)
+          ((0 : Word) + signExtend12 (64 : BitVec 12))
+          (evmSp + signExtend12 (56 : BitVec 12) +
+            signExtend12 (-8 : BitVec 12))
+          (exponentWord.getLimbN 2)
+          (evmSp + signExtend12 (64 : BitVec 12))
+          (baseWord.getLimbN 0) (baseWord.getLimbN 1)
+          (baseWord.getLimbN 2) (baseWord.getLimbN 3)
+          base) **
+        expTwoMulFixedFirstIterEntryResidual evmSp exponentWord rest) ps ∧
+      expTwoMulIterCountNew (256 : Word) ≠ 0 ∧
+      ((0 : Word) + signExtend12 (64 : BitVec 12)) +
+        signExtend12 (-1 : BitVec 12) = 0 ∧
+      (exponentWord.getLimbN 3 >>> (63 : BitVec 6).toNat) +
+        signExtend12 (0 : BitVec 12) = 0) := by
+  rw [expTwoMulFixedFirstIterCaseLoopPostWithResidual_unfold] at h
+  exact expTwoMulFixedIterCaseLoopPost_iterPre_or_reloadPointerFrame_pures h
+
 /-- Fixed full-loop boundary wrapper whose loop body starts from the named
     existential first-iteration precondition produced by the fixed loop entry
     post. This is the surface needed before destructing the chosen


### PR DESCRIPTION
Stacked on #4820.\n\nAdds a pures-enriched split for expTwoMulFixedFirstIterCaseLoopPostWithResidual. Reload tail cases now carry the nonzero count, c6 rollover, and saved-bit facts directly while preserving expTwoMulFixedFirstIterEntryResidual.\n\nLocal checks:\n- lake build EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryLoopFixedEntryExists\n- lake build EvmAsm.Evm64.Exp\n- scripts/check-file-size.sh\n- scripts/check-unimported.sh\n- git diff --check\n- lake build