### PR TITLE
feat(exp): add fixed second iter cps

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryLoopFixedEntryExists.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryLoopFixedEntryExists.lean
@@ -531,6 +531,120 @@ theorem expTwoMulFixedFirstCase_to_secondIterPreWithResidual
   rw [expTwoMulFixedSecondIterPreWithResidual]
   exact expTwoMulFixedFirstIterCaseLoopPostWithResidual_no_reload_norm h
 
+theorem expTwoMulFixedSecondIterPreWithResidual_pcFree
+    {sp evmSp : Word}
+    {baseWord exponentWord : EvmWord} {rest : List EvmWord}
+    {base : Word} :
+    (expTwoMulFixedSecondIterPreWithResidual
+      sp evmSp baseWord exponentWord rest base).pcFree := by
+  intro hpc h_pre
+  rw [expTwoMulFixedSecondIterPreWithResidual] at h_pre
+  rcases h_pre with hCond | hSkip
+  · rcases hCond with
+      ⟨v6, v7, v10, v11, d0, d1, d2, d3, h_concrete_pre⟩
+    exact
+      pcFree_sepConj expTwoMulFixedIterPre_pcFree
+        expTwoMulFixedFirstIterEntryResidual_pcFree hpc h_concrete_pre
+  · rcases hSkip with
+      ⟨v6, v7, v10, v11, d0, d1, d2, d3, h_concrete_pre⟩
+    exact
+      pcFree_sepConj expTwoMulFixedIterPre_pcFree
+        expTwoMulFixedFirstIterEntryResidual_pcFree hpc h_concrete_pre
+
+instance pcFreeInst_expTwoMulFixedSecondIterPreWithResidual
+    (sp evmSp : Word)
+    (baseWord exponentWord : EvmWord) (rest : List EvmWord)
+    (base : Word) :
+    Assertion.PCFree
+      (expTwoMulFixedSecondIterPreWithResidual
+        sp evmSp baseWord exponentWord rest base) :=
+  ⟨expTwoMulFixedSecondIterPreWithResidual_pcFree⟩
+
+theorem cpsTripleWithin_expTwoMulFixedSecondIterPreWithResidual
+    {nSteps : Nat} {entry exit_ : Word} {cr : CodeReq} {Q : Assertion}
+    {sp evmSp : Word}
+    {baseWord exponentWord : EvmWord} {rest : List EvmWord}
+    {base : Word}
+    (hCond :
+      ∀ v6 v7 v10 v11 d0 d1 d2 d3,
+        let squareW :=
+          expSquaringCallSquareW
+            ((1 : EvmWord).getLimbN 0)
+            ((1 : EvmWord).getLimbN 1)
+            ((1 : EvmWord).getLimbN 2)
+            ((1 : EvmWord).getLimbN 3)
+        let rw := expTwoMulCondRw squareW
+          (baseWord.getLimbN 0) (baseWord.getLimbN 1)
+          (baseWord.getLimbN 2) (baseWord.getLimbN 3)
+        cpsTripleWithin nSteps entry exit_ cr
+          (expTwoMulFixedIterPre
+            (exponentWord.getLimbN 3 <<< (1 : BitVec 6).toNat)
+            v6
+            (255 : Word)
+            v10
+            ((exponentWord.getLimbN 3 >>> (63 : BitVec 6).toNat) +
+              signExtend12 (0 : BitVec 12))
+            (evmSp + 48)
+            (exponentWord.getLimbN 2)
+            sp (evmSp + signExtend12 (64 : BitVec 12))
+            (rw.getLimbN 3)
+            (((base + 44) + 140) + 68)
+            (rw.getLimbN 0) (rw.getLimbN 1) (rw.getLimbN 2)
+            (rw.getLimbN 3)
+            d0 d1 d2 d3
+            (rw.getLimbN 0) (rw.getLimbN 1) (rw.getLimbN 2)
+            (rw.getLimbN 3)
+            (baseWord.getLimbN 0) (baseWord.getLimbN 1)
+            (baseWord.getLimbN 2) (baseWord.getLimbN 3) v7 v11 **
+           expTwoMulFixedFirstIterEntryResidual evmSp exponentWord rest)
+          Q)
+    (hSkip :
+      ∀ v6 v7 v10 v11 d0 d1 d2 d3,
+        let squareW :=
+          expSquaringCallSquareW
+            ((1 : EvmWord).getLimbN 0)
+            ((1 : EvmWord).getLimbN 1)
+            ((1 : EvmWord).getLimbN 2)
+            ((1 : EvmWord).getLimbN 3)
+        cpsTripleWithin nSteps entry exit_ cr
+          (expTwoMulFixedIterPre
+            (exponentWord.getLimbN 3 <<< (1 : BitVec 6).toNat)
+            v6
+            (255 : Word)
+            v10
+            ((exponentWord.getLimbN 3 >>> (63 : BitVec 6).toNat) +
+              signExtend12 (0 : BitVec 12))
+            (evmSp + 48)
+            (exponentWord.getLimbN 2)
+            sp (evmSp + signExtend12 (64 : BitVec 12))
+            (squareW.getLimbN 3)
+            (((base + 44) + 32) + 68)
+            (squareW.getLimbN 0) (squareW.getLimbN 1)
+            (squareW.getLimbN 2) (squareW.getLimbN 3)
+            d0 d1 d2 d3
+            (squareW.getLimbN 0) (squareW.getLimbN 1)
+            (squareW.getLimbN 2) (squareW.getLimbN 3)
+            (baseWord.getLimbN 0) (baseWord.getLimbN 1)
+            (baseWord.getLimbN 2) (baseWord.getLimbN 3) v7 v11 **
+           expTwoMulFixedFirstIterEntryResidual evmSp exponentWord rest)
+          Q) :
+    cpsTripleWithin nSteps entry exit_ cr
+      (expTwoMulFixedSecondIterPreWithResidual
+        sp evmSp baseWord exponentWord rest base)
+      Q := by
+  intro R hR s hcr h_pre_R hpc
+  obtain ⟨hp, hcompat, psPre, psR, hdisj, hunion, h_pre, hRps⟩ := h_pre_R
+  rw [expTwoMulFixedSecondIterPreWithResidual] at h_pre
+  rcases h_pre with hCondPre | hSkipPre
+  · rcases hCondPre with
+      ⟨v6, v7, v10, v11, d0, d1, d2, d3, h_concrete_pre⟩
+    exact hCond v6 v7 v10 v11 d0 d1 d2 d3 R hR s hcr
+      ⟨hp, hcompat, psPre, psR, hdisj, hunion, h_concrete_pre, hRps⟩ hpc
+  · rcases hSkipPre with
+      ⟨v6, v7, v10, v11, d0, d1, d2, d3, h_concrete_pre⟩
+    exact hSkip v6 v7 v10 v11 d0 d1 d2 d3 R hR s hcr
+      ⟨hp, hcompat, psPre, psR, hdisj, hunion, h_concrete_pre, hRps⟩ hpc
+
 /-- Fixed full-loop boundary wrapper whose loop body starts from the named
     existential first-iteration precondition produced by the fixed loop entry
     post. This is the surface needed before destructing the chosen


### PR DESCRIPTION
Stacked on #4824.

Adds PCFree plumbing and cpsTripleWithin_expTwoMulFixedSecondIterPreWithResidual for the named second-iteration precondition, exposing the conditional-multiply and skip branches as concrete CPS premises while preserving the first-entry residual frame.

Local checks:
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryLoopFixedEntryExists
- lake build EvmAsm.Evm64.Exp
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- lake build