### PR TITLE
feat(exp): add fixed loop semantic step

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/Exp.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Exp.lean
@@ -101,6 +101,45 @@ theorem exp_succ_right_of_toNat_lt (base exponent : EvmWord)
   rw [Nat.mul_mod]
   rw [Nat.mod_eq_of_lt base.isLt]
 
+/-- Squaring recurrence for EXP when the next exponent is twice the previous
+    exponent. -/
+theorem exp_double_right_of_toNat_eq (base exponent nextExponent : EvmWord)
+    (hNext : nextExponent.toNat = 2 * exponent.toNat) :
+    exp base nextExponent = exp base exponent * exp base exponent := by
+  apply BitVec.eq_of_toNat_eq
+  rw [exp_correct, BitVec.toNat_mul, exp_correct, hNext]
+  rw [show base.toNat ^ (2 * exponent.toNat) =
+      base.toNat ^ exponent.toNat * base.toNat ^ exponent.toNat by
+    rw [show 2 * exponent.toNat = exponent.toNat + exponent.toNat by omega]
+    rw [Nat.pow_add]]
+  rw [← Nat.mul_mod]
+
+/-- Square-and-multiply recurrence for EXP when the next exponent is twice the
+    previous exponent plus one. -/
+theorem exp_double_add_one_right_of_toNat_eq
+    (base exponent nextExponent : EvmWord)
+    (hNext : nextExponent.toNat = 2 * exponent.toNat + 1) :
+    exp base nextExponent = base * (exp base exponent * exp base exponent) := by
+  apply BitVec.eq_of_toNat_eq
+  rw [exp_correct, BitVec.toNat_mul, BitVec.toNat_mul, exp_correct, hNext]
+  rw [show base.toNat ^ (2 * exponent.toNat + 1) =
+      base.toNat * (base.toNat ^ exponent.toNat * base.toNat ^ exponent.toNat) by
+    rw [show 2 * exponent.toNat + 1 =
+        (exponent.toNat + exponent.toNat) + 1 by omega]
+    rw [Nat.pow_succ, Nat.pow_add]
+    rw [Nat.mul_comm
+      (base.toNat ^ exponent.toNat * base.toNat ^ exponent.toNat) base.toNat]]
+  rw [← Nat.mul_mod
+    (base.toNat ^ exponent.toNat) (base.toNat ^ exponent.toNat) (2^256)]
+  rw [Nat.mul_mod
+    (base.toNat) (base.toNat ^ exponent.toNat * base.toNat ^ exponent.toNat)
+    (2^256)]
+  rw [Nat.mul_mod
+    (base.toNat)
+    ((base.toNat ^ exponent.toNat * base.toNat ^ exponent.toNat) % 2^256)
+    (2^256)]
+  rw [Nat.mod_mod]
+
 /-- The GH #92 cross-limb boundary case `EXP(2, 64)`. -/
 theorem exp_two_64 : exp (2 : EvmWord) (64 : EvmWord) =
     BitVec.ofNat 256 (2^64) := by

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedLoopInvariant.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedLoopInvariant.lean
@@ -102,6 +102,30 @@ theorem expTwoMulFixedAccumulatorInvariant_succ_of_step
   unfold expTwoMulFixedAccumulatorInvariant at *
   rw [hStep, hInv, hSemanticStep]
 
+theorem expTwoMulFixedAccumulatorStep_eq_target_of_processedExponent_succ
+    {baseWord exponentWord : EvmWord} {k : Nat} {bit : Bool}
+    (hNext :
+      (expTwoMulFixedProcessedExponent exponentWord (k + 1)).toNat =
+        2 * (expTwoMulFixedProcessedExponent exponentWord k).toNat +
+          if bit then 1 else 0) :
+    expTwoMulFixedAccumulatorStep baseWord
+        (expTwoMulFixedAccumulatorTarget baseWord exponentWord k) bit =
+      expTwoMulFixedAccumulatorTarget baseWord exponentWord (k + 1) := by
+  unfold expTwoMulFixedAccumulatorStep expTwoMulFixedAccumulatorTarget
+  by_cases hbit : bit
+  · simp [hbit] at hNext ⊢
+    exact (EvmWord.exp_double_add_one_right_of_toNat_eq
+      baseWord
+      (expTwoMulFixedProcessedExponent exponentWord k)
+      (expTwoMulFixedProcessedExponent exponentWord (k + 1))
+      hNext).symm
+  · simp [hbit] at hNext ⊢
+    exact (EvmWord.exp_double_right_of_toNat_eq
+      baseWord
+      (expTwoMulFixedProcessedExponent exponentWord k)
+      (expTwoMulFixedProcessedExponent exponentWord (k + 1))
+      hNext).symm
+
 /-- The fixed iteration precondition indexed by the semantic iteration count.
 
     This is the precondition family future fixed-loop induction should recurse


### PR DESCRIPTION
## Summary
- add EvmWord.exp double and double-plus-one recurrence lemmas
- use them to prove the fixed-loop accumulator target step from the processed-exponent recurrence
- keep the actual bit-window recurrence as the remaining obligation for the CPS loop step

## Tests
- lake build EvmAsm.Evm64.EvmWordArith.Exp
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedLoopInvariant
- lake build EvmAsm.Evm64.Exp
- scripts/check-unimported.sh
- scripts/check-file-size.sh
- git diff --check
- lake build