### PR TITLE
feat(exp): specialize fixed loop run to full exponent

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedLoopInvariant.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedLoopInvariant.lean
@@ -323,6 +323,30 @@ theorem expTwoMulFixedAccumulatorInvariant_of_run
   rw [hRun, expTwoMulFixedAccumulatorRun_eq_target_add
     hBound hInv]
 
+theorem expTwoMulFixedAccumulatorRun_eq_exp_of_start_zero
+    {baseWord exponentWord accWord : EvmWord}
+    (hStart :
+      accWord = expTwoMulFixedAccumulatorTarget baseWord exponentWord 0) :
+    expTwoMulFixedAccumulatorRun baseWord exponentWord accWord 0 256 =
+      EvmWord.exp baseWord exponentWord := by
+  rw [expTwoMulFixedAccumulatorRun_eq_target_add (hBound := by decide) hStart]
+  exact expTwoMulFixedAccumulatorTarget_full baseWord exponentWord
+
+theorem expTwoMulFixedAccumulatorInvariant_full_of_run
+    {baseWord exponentWord : EvmWord}
+    {r0 r1 r2 r3 r0' r1' r2' r3' : Word}
+    (hInv :
+      expTwoMulFixedAccumulatorInvariant baseWord exponentWord 0
+        r0 r1 r2 r3)
+    (hRun :
+      expResultWord r0' r1' r2' r3' =
+        expTwoMulFixedAccumulatorRun baseWord exponentWord
+          (expResultWord r0 r1 r2 r3) 0 256) :
+    expResultWord r0' r1' r2' r3' =
+      EvmWord.exp baseWord exponentWord := by
+  unfold expTwoMulFixedAccumulatorInvariant at hInv
+  rw [hRun, expTwoMulFixedAccumulatorRun_eq_exp_of_start_zero hInv]
+
 /-- Expected fixed-loop `x19` exponent cursor at the start of iteration `k`.
 
     The loop starts from limb 3, shifts the current limb left once per bit, and


### PR DESCRIPTION
## Summary
- specialize the generic fixed-loop accumulator run to the 256-iteration case
- bridge a zero-iteration start target through the full run to EvmWord.exp base exponent
- expose a direct invariant helper for later CPS proofs that produce the 256-step run

## Verification
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedLoopInvariant
- lake build EvmAsm.Evm64.Exp
- scripts/check-unimported.sh
- scripts/check-file-size.sh
- git diff --check
- lake build

Stacked on #4838. Refs evm-asm-w5mk.3.3 and evm-asm-6snn.1