### PR TITLE
feat(exp): bridge initial fixed loop run

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedLoopInvariant.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedLoopInvariant.lean
@@ -371,6 +371,18 @@ theorem expTwoMulFixedAccumulatorInvariant_full_of_run
   unfold expTwoMulFixedAccumulatorInvariant at hInv
   rw [hRun, expTwoMulFixedAccumulatorRun_eq_exp_of_start_zero hInv]
 
+theorem expTwoMulFixedAccumulatorRun_full_of_initial_one
+    {baseWord exponentWord : EvmWord}
+    {r0' r1' r2' r3' : Word}
+    (hRun :
+      expResultWord r0' r1' r2' r3' =
+        expTwoMulFixedAccumulatorRun baseWord exponentWord
+          (expResultWord 1 0 0 0) 0 256) :
+    expResultWord r0' r1' r2' r3' =
+      EvmWord.exp baseWord exponentWord :=
+  expTwoMulFixedAccumulatorInvariant_full_of_run
+    (expTwoMulFixedAccumulatorInvariant_zero_one baseWord exponentWord) hRun
+
 /-- Expected fixed-loop `x19` exponent cursor at the start of iteration `k`.
 
     The loop starts from limb 3, shifts the current limb left once per bit, and


### PR DESCRIPTION
## Summary
- combine the fixed-loop initial invariant with the 256-step run bridge
- expose a one-step helper from a machine-produced run starting at accumulator limbs 1,0,0,0 to EvmWord.exp base exponent

## Verification
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedLoopInvariant
- lake build EvmAsm.Evm64.Exp
- scripts/check-unimported.sh
- scripts/check-file-size.sh
- git diff --check
- lake build

Stacked on #4840. Refs evm-asm-w5mk.3.3 and evm-asm-6snn.1