### PR TITLE
chore(sdiv): prune unified addback reference

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/Unified.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/Unified.lean
@@ -8,8 +8,8 @@
   case-split branches produce triples with incompatible `nSteps`.
 
   The n=4 stack-surface path is intentionally absent while the call-addback
-  algorithm is being repaired; the old n=4 wrappers depended on the false
-  `n4CallAddbackBeqSemanticHolds` premise.
+  algorithm is being repaired; the old n=4 wrappers depended on a false
+  semantic premise.
 
   This file imports `unifiedDivBound : Nat := 946` (the maximum across n=1..4)
   from `UnifiedBzero` and defines `_uni` wrappers for each per-`n`


### PR DESCRIPTION
## Summary
- remove the last Unified.lean mention of the false n=4 addback semantic predicate
- leave the n=4 stack-surface path absent while Phase 2a repairs the addback algorithm

## Verification
- rg -n "n4CallAddbackBeqSemanticHolds|n4Full|evm_div_n4_call_addback_beq" EvmAsm/Evm64/DivMod/Spec/Unified.lean (no matches)
- lake build EvmAsm.Evm64.DivMod.Spec.Unified
- git diff --check

Bead: evm-asm-9iqmw.1.5