### PR TITLE
feat(exp): bridge full fixed loop invariant

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedLoopInvariant.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedLoopInvariant.lean
@@ -135,6 +135,15 @@ theorem expTwoMulFixedAccumulatorInvariant_zero_one
   rw [expResultWord_one_zero_zero_zero,
     expTwoMulFixedAccumulatorTarget_zero]
 
+theorem expTwoMulFixedAccumulatorInvariant_full
+    {baseWord exponentWord : EvmWord} {r0 r1 r2 r3 : Word}
+    (hInv :
+      expTwoMulFixedAccumulatorInvariant baseWord exponentWord 256
+        r0 r1 r2 r3) :
+    expResultWord r0 r1 r2 r3 = EvmWord.exp baseWord exponentWord := by
+  unfold expTwoMulFixedAccumulatorInvariant at hInv
+  rw [hInv, expTwoMulFixedAccumulatorTarget_full]
+
 @[irreducible]
 def expTwoMulFixedSemanticInvariant
     (baseWord exponentWord : EvmWord) (k : Nat)


### PR DESCRIPTION
## Summary
- add `expTwoMulFixedAccumulatorInvariant_full`
- bridge the fixed-loop accumulator invariant at k=256 directly to `EvmWord.exp baseWord exponentWord`
- keep the final `evm_exp_stack_spec_within` placeholder untouched until the CPS loop post exposes this invariant

## Verification
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedLoopInvariant
- lake build EvmAsm.Evm64.Exp
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- lake build

Bead: evm-asm-6snn.1