### PR TITLE
feat(exp): bridge fixed loop word step

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedLoopInvariant.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedLoopInvariant.lean
@@ -229,6 +229,24 @@ theorem expTwoMulFixedAccumulatorStep_eq_target_succ
   expTwoMulFixedAccumulatorStep_eq_target_of_processedExponent_succ
     (expTwoMulFixedProcessedExponent_succ_toNat exponentWord hk)
 
+theorem expTwoMulFixedAccumulatorStep_false_eq_squareW
+    (baseWord : EvmWord) (r0 r1 r2 r3 : Word) :
+    expTwoMulFixedAccumulatorStep baseWord
+        (expResultWord r0 r1 r2 r3) false =
+      expSquaringCallSquareW r0 r1 r2 r3 := by
+  rfl
+
+theorem expTwoMulFixedAccumulatorStep_true_eq_condRw
+    {baseWord : EvmWord} {a0 a1 a2 a3 r0 r1 r2 r3 : Word}
+    (hBase : baseWord = expResultWord a0 a1 a2 a3) :
+    expTwoMulFixedAccumulatorStep baseWord
+        (expResultWord r0 r1 r2 r3) true =
+      expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3) a0 a1 a2 a3 := by
+  subst hBase
+  simp [expTwoMulFixedAccumulatorStep, expTwoMulCondRw,
+    expSquaringCallSquareW, expTwoMulIterAw]
+  ac_rfl
+
 /-- Semantic accumulator obtained by running `n` generic fixed-loop updates
     starting from the target at iteration `k`.
 


### PR DESCRIPTION
## Summary
- add `expTwoMulFixedAccumulatorStep_false_eq_squareW`
- add `expTwoMulFixedAccumulatorStep_true_eq_condRw`
- normalize the machine word updates used by the fixed iteration posts to the semantic accumulator-step function

## Verification
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedLoopInvariant
- lake build EvmAsm.Evm64.Exp
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- lake build

Bead: evm-asm-6snn.1