### PR TITLE
feat(exp): bridge machine step invariant

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedLoopInvariant.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedLoopInvariant.lean
@@ -247,6 +247,57 @@ theorem expTwoMulFixedAccumulatorStep_true_eq_condRw
     expSquaringCallSquareW, expTwoMulIterAw]
   ac_rfl
 
+theorem expTwoMulFixedAccumulatorInvariant_succ_of_squareW_false
+    {baseWord exponentWord : EvmWord} {k : Nat}
+    {r0 r1 r2 r3 : Word}
+    (hInv :
+      expTwoMulFixedAccumulatorInvariant baseWord exponentWord k
+        r0 r1 r2 r3)
+    (hSemanticStep :
+      expTwoMulFixedAccumulatorStep baseWord
+        (expTwoMulFixedAccumulatorTarget baseWord exponentWord k) false =
+        expTwoMulFixedAccumulatorTarget baseWord exponentWord (k + 1)) :
+    expTwoMulFixedAccumulatorInvariant baseWord exponentWord (k + 1)
+      ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 0)
+      ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 1)
+      ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 2)
+      ((expSquaringCallSquareW r0 r1 r2 r3).getLimbN 3) := by
+  exact
+    expTwoMulFixedAccumulatorInvariant_succ_of_step
+      hInv
+      (by
+        rw [expResultWord_getLimbN_self,
+          expTwoMulFixedAccumulatorStep_false_eq_squareW])
+      hSemanticStep
+
+theorem expTwoMulFixedAccumulatorInvariant_succ_of_condRw_true
+    {baseWord exponentWord : EvmWord} {k : Nat}
+    {a0 a1 a2 a3 r0 r1 r2 r3 : Word}
+    (hBase : baseWord = expResultWord a0 a1 a2 a3)
+    (hInv :
+      expTwoMulFixedAccumulatorInvariant baseWord exponentWord k
+        r0 r1 r2 r3)
+    (hSemanticStep :
+      expTwoMulFixedAccumulatorStep baseWord
+        (expTwoMulFixedAccumulatorTarget baseWord exponentWord k) true =
+        expTwoMulFixedAccumulatorTarget baseWord exponentWord (k + 1)) :
+    expTwoMulFixedAccumulatorInvariant baseWord exponentWord (k + 1)
+      ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3)
+        a0 a1 a2 a3).getLimbN 0)
+      ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3)
+        a0 a1 a2 a3).getLimbN 1)
+      ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3)
+        a0 a1 a2 a3).getLimbN 2)
+      ((expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3)
+        a0 a1 a2 a3).getLimbN 3) := by
+  exact
+    expTwoMulFixedAccumulatorInvariant_succ_of_step
+      hInv
+      (by
+        rw [expResultWord_getLimbN_self,
+          expTwoMulFixedAccumulatorStep_true_eq_condRw hBase])
+      hSemanticStep
+
 /-- Semantic accumulator obtained by running `n` generic fixed-loop updates
     starting from the target at iteration `k`.
 


### PR DESCRIPTION
## Summary
- add fixed-loop invariant successor lemmas for the machine square path
- add fixed-loop invariant successor lemmas for the machine conditional-multiply path
- package the word-step bridges with `expResultWord_getLimbN_self` so CPS post-case bridges can consume machine result limbs directly

## Verification
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedLoopInvariant
- lake build EvmAsm.Evm64.Exp
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- lake build

Bead: evm-asm-6snn.1