### PR TITLE
chore(sdiv): prune addback false references

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopDefs/Iter.lean
+++ b/EvmAsm/Evm64/DivMod/LoopDefs/Iter.lean
@@ -268,8 +268,8 @@ def div128Un0 (uLo : Word) : Word :=
 -- does only 1 Phase 1b correction, which under hshift_nz allows val256-level
 -- qHat overshoot up to ~2^33 (combining per-digit Knuth-B applied to q1' and
 -- q0' independently). On such inputs `iterWithDoubleAddback` exits with the
--- wrong q_out (off by ~2^32 from q_true), making
--- `n4CallAddbackBeqSemanticHolds` provably FALSE.
+-- wrong q_out (off by ~2^32 from q_true), falsifying the n=4
+-- call-addback semantic target.
 --
 -- See `memory/project_n4callbeq_addback_overshoot_2pow32.md` for the
 -- counterexample (a3 = 2^63+2^33, b3 = 1, b2 = 2^33-1) and

--- a/EvmAsm/Evm64/DivMod/N4StackSpec.lean
+++ b/EvmAsm/Evm64/DivMod/N4StackSpec.lean
@@ -3,7 +3,7 @@
 
   This module is intentionally inert while the n=4 call-addback path is being
   repaired. The old dispatcher wrappers depended transitively on
-  `n4CallAddbackBeqSemanticHolds`, which is false for the current algorithm.
+  the false n=4 call-addback semantic predicate.
 
   The predicate itself remains in `Spec/CallAddback.lean` as the Phase 2a target
   marker; the stack-surface wrappers will be rebuilt after the addback loop is

--- a/EvmAsm/Evm64/DivMod/N4StackSpecWithin.lean
+++ b/EvmAsm/Evm64/DivMod/N4StackSpecWithin.lean
@@ -4,7 +4,7 @@
   This module is intentionally inert while the n=4 call-addback path is being
   repaired. The old dispatcher-surface wrappers depended on the n=4 stack
   wrappers in `N4StackSpec.lean`, which in turn depended transitively on the
-  false `n4CallAddbackBeqSemanticHolds` premise.
+  false n=4 call-addback semantic premise.
 -/
 
 namespace EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Program.lean
+++ b/EvmAsm/Evm64/DivMod/Program.lean
@@ -129,10 +129,9 @@ def divK_div128 : Program :=
     4.3.1). The 2nd correction has the `rhat < B` guard, mirroring the
     existing Phase 2b guard at lines 107-108.
 
-    This fixes the algorithm correctness bug — see
-    `n4CallAddbackBeqSemanticHolds_counterexample` (in
-    `EvmAsm/Evm64/DivMod/SpecCallAddbackBeq.lean`) and the matching
-    Lean abstraction `div128Quot_v2` (in `LoopDefs/Iter.lean`).
+    This fixes the algorithm correctness bug; see the deleted
+    SpecCallAddbackBeq counterexample scaffolding and the matching Lean
+    abstraction `div128Quot_v2` (in `LoopDefs/Iter.lean`).
 
     **Layout**:
     - [0..24]: same as `divK_div128` (initial split + Phase 1a + 1st D3).
@@ -232,8 +231,9 @@ def divK_div128_v2 : Program :=
 
     With Phase 2b 2-correction, the trial quotient `qHat` equals
     `q*_full = ⌊(uHi*2^64 + uLo) / vTop⌋` exactly (no per-phase
-    overshoot). Closes `n4CallAddbackBeqSemanticHolds_v4`
-    (proven in PR #1418, Layer 2a fwd/back + c3 sub-stub all closed).
+    overshoot). This was the v4 closure route for the n=4 call-addback
+    semantic target (proven in PR #1418, Layer 2a fwd/back + c3 sub-stub
+    all closed).
 
     **Layout** (75 instructions total):
     - [0..46]: identical to `divK_div128_v2` (setup + Phase 1a + Phase

--- a/EvmAsm/Evm64/DivMod/Spec/CallAddback.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/CallAddback.lean
@@ -4,9 +4,9 @@
   Call+addback BEQ semantic predicate marker (n=4, shift ≠ 0).
 
   Contents:
-  - `n4CallAddbackBeqSemanticHolds` predicate, retained only as the Phase 2a
-    algorithm-fix target marker.
-  - `n4CallAddbackBeqSemanticHolds_def`, the rfl unfolding theorem.
+  - the predicate below, retained only as the Phase 2a algorithm-fix target
+    marker.
+  - a small rfl unfolding theorem.
 
   The former stack specs, qHat sub-stubs, and Word-level Euclideans were
   deleted after they were found to depend transitively on the false n=4 addback
@@ -59,9 +59,8 @@ open EvmAsm.Rv64.Tactics
     still ~2^32 too large.
 
     **Implication**: the algorithm is genuinely buggy on this input
-    class. The `n4CallAddbackBeqSemanticHolds` predicate is provably
-    FALSE on runtime-reachable inputs. Closure
-    (`n4CallAddbackBeqSemanticHolds_of_*`) cannot be proven; the
+    class. This predicate is provably FALSE on runtime-reachable inputs.
+    Closure theorems for it cannot be proven; the
     user-facing `evm_div_n4_full_call_addback_beq_stack_pre_spec` and
     its relatives are vacuous on this input class.
 
@@ -108,7 +107,7 @@ def n4CallAddbackBeqSemanticHolds (a b : EvmWord) : Prop :=
       val256 (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
 
 -- The v1 counterexample, v2 fix-verification, v2-buggy-confirmation and
--- the v2 mirror predicate `n4CallAddbackBeqSemanticHolds_v2` (plus its
+-- the v2 mirror predicate (plus its
 -- sanity check on the v1 counterexample input) live in
 -- `EvmAsm/Evm64/DivMod/Spec/CallAddbackCounterexamples.lean` (extracted
 -- 2026 toward the #1078 file-size cap; see beads evm-asm-b5i).
@@ -116,7 +115,7 @@ def n4CallAddbackBeqSemanticHolds (a b : EvmWord) : Prop :=
 
 
 
-theorem n4CallAddbackBeqSemanticHolds_def {a b : EvmWord} :
+theorem n4CallAddbackBeqSemantic_unfold {a b : EvmWord} :
     n4CallAddbackBeqSemanticHolds a b =
     (let shift := (clzResult (b.getLimbN 3)).1.toNat % 64
      let antiShift :=


### PR DESCRIPTION
## Summary
- prune exact false-predicate references from N4 stack inert-module headers, LoopDefs/Iter, and Program comments
- keep only the Phase 2a marker predicate and its unfold statement as exact references
- rename the CallAddback unfold theorem to avoid stale closure-style naming

## Checks
- rg -n "n4CallAddbackBeqSemanticHolds" EvmAsm/Evm64
- lake build EvmAsm.Evm64.SDiv
- lake build EvmAsm.Evm64.DivMod
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- lake build