### PR TITLE
feat(exp): add fixed loop cursor reload successor

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedLoopInvariant.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedLoopInvariant.lean
@@ -575,6 +575,18 @@ theorem expTwoMulFixedCursorInvariant_succ_no_reload
     exponentWord.getLimbN (3 - k / 64) <<< (k % 64 + 1)
   exact word_shiftLeft_succ _ _
 
+theorem expTwoMulFixedCursorInvariant_succ_reload
+    {exponentWord : EvmWord} {k : Nat} {nextLimb : Word}
+    (hMod : k % 64 = 63)
+    (hNext : nextLimb = exponentWord.getLimbN (3 - (k + 1) / 64)) :
+    expTwoMulFixedCursorInvariant exponentWord (k + 1) nextLimb := by
+  unfold expTwoMulFixedCursorInvariant expTwoMulFixedCursorWord
+  rw [hNext]
+  have hmod : (k + 1) % 64 = 0 := by
+    omega
+  rw [hmod]
+  simp
+
 private theorem expTwoMulFixedCursorWord_highBit_eq_processedBitWord_aux
     (exponentWord : EvmWord) (q r : Nat)
     (hq : q < 4) (hr : r < 64) :


### PR DESCRIPTION
## Summary
- add expTwoMulFixedCursorInvariant_succ_reload for fixed-loop limb reload boundaries
- package the k % 64 = 63 cursor transition as a reusable pure lemma for the induction path

## Checks
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedLoopInvariant
- lake build EvmAsm.Evm64.Exp
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- lake build