### PR TITLE
feat(exp): add fixed boundary pren entry wrappers

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryLoopFixedEntryExists.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitBoundaryLoopFixedEntryExists.lean
@@ -913,6 +913,78 @@ theorem exp_two_mul_fixed_full_loop_boundary_of_entry_exists_body_general_closed
       r0 r1 r2 r3 d0 d1 d2 d3
       baseWord exponentWord dWord eWord rest exitCond base hBodyNamed
 
+/-- Fixed full-loop boundary wrapper whose loop body starts from the
+    invariant-carrying first-iteration `PreN` residual assertion. -/
+theorem exp_two_mul_fixed_full_loop_boundary_of_entry_pren_exists_body_general_spec_within
+    (sp evmSp cOld tOld c6Old c16Old c19Old
+      m0 m1 m2 m3 vOld v18 iterCountNew
+      r0 r1 r2 r3 d0 d1 d2 d3 : Word)
+    (baseWord exponentWord dWord eWord : EvmWord) (rest : List EvmWord)
+    (exitCond : Prop) (base : Word)
+    (hBody :
+      cpsTripleWithin expTwoMulFixedFullLoopBodyBound (base + 44) (base + 296)
+        (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+        (expTwoMulFixedFirstIterPreNWithResidual sp evmSp v18 vOld
+          baseWord exponentWord dWord eWord rest)
+        (expTwoMulLoopExitFullStackPreFrame sp evmSp iterCountNew tOld
+          r0 r1 r2 r3 d0 d1 d2 d3 baseWord (dWord :: eWord :: rest)
+          exitCond)) :
+    cpsTripleWithin expTwoMulFixedFullLoopBoundaryBound base (base + 336)
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulBoundaryPreFixed sp evmSp cOld tOld c6Old c16Old c19Old
+        m0 m1 m2 m3 vOld v18 baseWord exponentWord (dWord :: eWord :: rest))
+      (expTwoMulLoopExitPost sp evmSp iterCountNew r0 r1 r2 r3
+        baseWord (dWord :: eWord :: rest) exitCond) :=
+  exp_two_mul_fixed_full_loop_boundary_of_entry_body_general_spec_within
+    sp evmSp cOld tOld c6Old c16Old c19Old
+    m0 m1 m2 m3 vOld v18 iterCountNew
+    r0 r1 r2 r3 d0 d1 d2 d3
+    baseWord exponentWord (dWord :: eWord :: rest) exitCond base
+    (fun _ h =>
+      expTwoMulLoopEntryPostFixed_to_firstIterPreNWithResidual h)
+    hBody
+
+/-- Closed-bound variant of
+    `exp_two_mul_fixed_full_loop_boundary_of_entry_pren_exists_body_general_spec_within`. -/
+theorem exp_two_mul_fixed_full_loop_boundary_of_entry_pren_exists_body_general_closed_bound_spec_within
+    (sp evmSp cOld tOld c6Old c16Old c19Old
+      m0 m1 m2 m3 vOld v18 iterCountNew
+      r0 r1 r2 r3 d0 d1 d2 d3 : Word)
+    (baseWord exponentWord dWord eWord : EvmWord) (rest : List EvmWord)
+    (exitCond : Prop) (base : Word)
+    (hBody :
+      cpsTripleWithin 49408 (base + 44) (base + 296)
+        (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+        (expTwoMulFixedFirstIterPreNWithResidual sp evmSp v18 vOld
+          baseWord exponentWord dWord eWord rest)
+        (expTwoMulLoopExitFullStackPreFrame sp evmSp iterCountNew tOld
+          r0 r1 r2 r3 d0 d1 d2 d3 baseWord (dWord :: eWord :: rest)
+          exitCond)) :
+    cpsTripleWithin 49429 base (base + 336)
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulBoundaryPreFixed sp evmSp cOld tOld c6Old c16Old c19Old
+        m0 m1 m2 m3 vOld v18 baseWord exponentWord (dWord :: eWord :: rest))
+      (expTwoMulLoopExitPost sp evmSp iterCountNew r0 r1 r2 r3
+        baseWord (dWord :: eWord :: rest) exitCond) := by
+  have hBodyNamed :
+      cpsTripleWithin expTwoMulFixedFullLoopBodyBound
+        (base + 44) (base + 296)
+        (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+        (expTwoMulFixedFirstIterPreNWithResidual sp evmSp v18 vOld
+          baseWord exponentWord dWord eWord rest)
+        (expTwoMulLoopExitFullStackPreFrame sp evmSp iterCountNew tOld
+          r0 r1 r2 r3 d0 d1 d2 d3 baseWord (dWord :: eWord :: rest)
+          exitCond) := by
+    rw [expTwoMulFixedFullLoopBodyBound_eq]
+    exact hBody
+  rw [← expTwoMulFixedFullLoopBoundaryBound_eq]
+  exact
+    exp_two_mul_fixed_full_loop_boundary_of_entry_pren_exists_body_general_spec_within
+      sp evmSp cOld tOld c6Old c16Old c19Old
+      m0 m1 m2 m3 vOld v18 iterCountNew
+      r0 r1 r2 r3 d0 d1 d2 d3
+      baseWord exponentWord dWord eWord rest exitCond base hBodyNamed
+
 /-- Fixed full-loop boundary wrapper whose body proof is supplied for every
     concrete choice of the first-iteration scratch registers. -/
 theorem exp_two_mul_fixed_full_loop_boundary_of_entry_concrete_body_general_spec_within


### PR DESCRIPTION
## Summary
- add fixed full-loop boundary wrappers whose body proof starts from expTwoMulFixedFirstIterPreNWithResidual
- provide both named-bound and closed-bound variants for the invariant-carrying first-iteration entry shape

## Checks
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryLoopFixedEntryExists
- lake build EvmAsm.Evm64.Exp
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- lake build