### PR TITLE
feat(sdiv): add n2 quotient semantic bridge

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N2QuotientWord.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2QuotientWord.lean
@@ -17,10 +17,12 @@
 -/
 
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.Base
+import EvmAsm.Evm64.EvmWordArith.DivAccumulate
 
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
+open EvmWord
 
 /-- Pack the four per-limb DIV results from the n=2 path into a single
     `EvmWord`. The top limb is `0` because n=2 means `b2 = b3 = 0` and so
@@ -63,5 +65,71 @@ theorem fullDivN2_hdivs_of_word_eq
   · rw [← hdiv]
     delta fullDivN2QuotientWord
     exact EvmWord.getLimbN_fromLimbs_3
+
+/-- Semantic bridge for the n=2 quotient word once the loop proof supplies the
+    accumulated mulsub equation and quotient-overestimate bound. -/
+theorem fullDivN2QuotientWord_eq_div_of_mulsub_overestimate
+    (bltu_2 bltu_1 bltu_0 : Bool)
+    {a0 a1 a2 a3 b0 b1 b2 b3 : Word}
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hmulsub :
+      val256 a0 a1 a2 a3 =
+        (((fullDivN2R2 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).1).toNat *
+            2^128 +
+          ((fullDivN2R1 bltu_2 bltu_1
+            a0 a1 a2 a3 b0 b1 b2 b3).1).toNat * 2^64 +
+          ((fullDivN2R0 bltu_2 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).1).toNat) *
+          val256 b0 b1 b2 b3 +
+        val256
+          ((fullDivN2R0 bltu_2 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).2.1)
+          ((fullDivN2R0 bltu_2 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).2.2.1)
+          ((fullDivN2R0 bltu_2 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1)
+          ((fullDivN2R0 bltu_2 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1))
+    (hge :
+      val256 a0 a1 a2 a3 / val256 b0 b1 b2 b3 ≤
+        ((fullDivN2R2 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).1).toNat *
+            2^128 +
+          ((fullDivN2R1 bltu_2 bltu_1
+            a0 a1 a2 a3 b0 b1 b2 b3).1).toNat * 2^64 +
+          ((fullDivN2R0 bltu_2 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).1).toNat) :
+    fullDivN2QuotientWord bltu_2 bltu_1 bltu_0
+        a0 a1 a2 a3 b0 b1 b2 b3 =
+      EvmWord.div
+        (EvmWord.fromLimbs fun i : Fin 4 =>
+          match i with | 0 => a0 | 1 => a1 | 2 => a2 | 3 => a3)
+        (EvmWord.fromLimbs fun i : Fin 4 =>
+          match i with | 0 => b0 | 1 => b1 | 2 => b2 | 3 => b3) := by
+  let q0 := (fullDivN2R0 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).1
+  let q1 := (fullDivN2R1 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1
+  let q2 := (fullDivN2R2 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).1
+  let r0 := (fullDivN2R0 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.1
+  let r1 := (fullDivN2R0 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1
+  let r2 := (fullDivN2R0 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1
+  let r3 := (fullDivN2R0 bltu_2 bltu_1 bltu_0
+    a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1
+  have h_correct := div_correct_n2_no_shift
+    (a0 := a0) (a1 := a1) (a2 := a2) (a3 := a3)
+    (b0 := b0) (b1 := b1) (b2 := b2) (b3 := b3)
+    (q0 := q0) (q1 := q1) (q2 := q2)
+    (r0 := r0) (r1 := r1) (r2 := r2) (r3 := r3)
+    hbnz (by simpa [q0, q1, q2, r0, r1, r2, r3] using hmulsub)
+    (by simpa [q0, q1, q2] using hge)
+  delta fullDivN2QuotientWord
+  change
+    EvmWord.fromLimbs (fun i : Fin 4 =>
+      match i with
+      | 0 => q0 | 1 => q1 | 2 => q2 | 3 => (0 : Word)) =
+      EvmWord.div
+        (EvmWord.fromLimbs fun i : Fin 4 =>
+          match i with | 0 => a0 | 1 => a1 | 2 => a2 | 3 => a3)
+        (EvmWord.fromLimbs fun i : Fin 4 =>
+          match i with | 0 => b0 | 1 => b1 | 2 => b2 | 3 => b3)
+  exact h_correct.1
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add fullDivN2QuotientWord_eq_div_of_mulsub_overestimate
- package div_correct_n2_no_shift for the N2 quotient-word shape once the loop proof supplies the accumulated mulsub equation and overestimate bound

## Checks
- lake build EvmAsm.Evm64.DivMod.Spec.N2QuotientWord
- lake build EvmAsm.Evm64.DivMod
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- lake build