### PR TITLE
feat(sdiv): derive n2 stack hdivWord internally

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/Unified.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/Unified.lean
@@ -631,10 +631,60 @@ inductive DivStackSpecCase (base : Word) (a b : EvmWord) where
         ((b.getLimbN 3 <<< (((clzResult (b.getLimbN 1)).1).toNat % 64)) |||
           (b.getLimbN 2 >>> ((signExtend12 (0 : BitVec 12) -
             (clzResult (b.getLimbN 1)).1).toNat % 64))))
-      (hdivWord : fullDivN2QuotientWord bltu_2 bltu_1 bltu_0
-        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) =
-          EvmWord.div a b)
+      (hmulsub :
+        EvmWord.val256 (a.getLimbN 0) (a.getLimbN 1)
+            (a.getLimbN 2) (a.getLimbN 3) =
+          (((fullDivN2R2 bltu_2
+                (a.getLimbN 0) (a.getLimbN 1)
+                (a.getLimbN 2) (a.getLimbN 3)
+                (b.getLimbN 0) (b.getLimbN 1)
+                (b.getLimbN 2) (b.getLimbN 3)).1).toNat * 2^128 +
+            ((fullDivN2R1 bltu_2 bltu_1
+                (a.getLimbN 0) (a.getLimbN 1)
+                (a.getLimbN 2) (a.getLimbN 3)
+                (b.getLimbN 0) (b.getLimbN 1)
+                (b.getLimbN 2) (b.getLimbN 3)).1).toNat * 2^64 +
+            ((fullDivN2R0 bltu_2 bltu_1 bltu_0
+                (a.getLimbN 0) (a.getLimbN 1)
+                (a.getLimbN 2) (a.getLimbN 3)
+                (b.getLimbN 0) (b.getLimbN 1)
+                (b.getLimbN 2) (b.getLimbN 3)).1).toNat) *
+            EvmWord.val256 (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3) +
+          EvmWord.val256
+            ((fullDivN2R0 bltu_2 bltu_1 bltu_0
+              (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+              (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2)
+              (b.getLimbN 3)).2.1)
+            ((fullDivN2R0 bltu_2 bltu_1 bltu_0
+              (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+              (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2)
+              (b.getLimbN 3)).2.2.1)
+            ((fullDivN2R0 bltu_2 bltu_1 bltu_0
+              (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+              (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2)
+              (b.getLimbN 3)).2.2.2.1)
+            ((fullDivN2R0 bltu_2 bltu_1 bltu_0
+              (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+              (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2)
+              (b.getLimbN 3)).2.2.2.2.1))
+      (hge :
+        EvmWord.val256 (a.getLimbN 0) (a.getLimbN 1)
+            (a.getLimbN 2) (a.getLimbN 3) /
+          EvmWord.val256 (b.getLimbN 0) (b.getLimbN 1)
+            (b.getLimbN 2) (b.getLimbN 3) ≤
+          ((fullDivN2R2 bltu_2
+            (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+            (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2)
+            (b.getLimbN 3)).1).toNat * 2^128 +
+            ((fullDivN2R1 bltu_2 bltu_1
+              (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+              (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2)
+              (b.getLimbN 3)).1).toNat * 2^64 +
+            ((fullDivN2R0 bltu_2 bltu_1 bltu_0
+              (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+              (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2)
+              (b.getLimbN 3)).1).toNat)
   | n3Full (bltu_1 bltu_0 : Bool)
       (hbnz : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 ≠ 0)
       (hb3z : b.getLimbN 3 = 0) (hb2nz : b.getLimbN 2 ≠ 0)
@@ -756,7 +806,10 @@ theorem evm_div_stack_spec (sp base : Word) (a b : EvmWord)
         hbnz hb3z hb2z hb1z hshift_nz halign
         hbltu_3 hbltu_2 hbltu_1 hbltu_0 hcarry2 hdivWord
   | n2Full bltu_2 bltu_1 bltu_0 hbnz hb3z hb2z hb1nz hshift_nz halign
-      hbltu_2 hbltu_1 hbltu_0 hcarry2 hdivWord =>
+      hbltu_2 hbltu_1 hbltu_0 hcarry2 hmulsub hge =>
+      have hdivWord :=
+        fullDivN2QuotientWord_eq_div_of_getLimbN_mulsub_overestimate
+          bltu_2 bltu_1 bltu_0 hbnz hmulsub hge
       exact evm_div_n2_stack_spec_within_word_uni
         bltu_2 bltu_1 bltu_0 sp base a b
         (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
@@ -814,7 +867,10 @@ theorem evm_div_stack_spec_exact_x1 (sp base : Word) (a b : EvmWord)
         hbnz hb3z hb2z hb1z hshift_nz halign
         hbltu_3 hbltu_2 hbltu_1 hbltu_0 hcarry2 hdivWord
   | n2Full bltu_2 bltu_1 bltu_0 hbnz hb3z hb2z hb1nz hshift_nz halign
-      hbltu_2 hbltu_1 hbltu_0 hcarry2 hdivWord =>
+      hbltu_2 hbltu_1 hbltu_0 hcarry2 hmulsub hge =>
+      have hdivWord :=
+        fullDivN2QuotientWord_eq_div_of_getLimbN_mulsub_overestimate
+          bltu_2 bltu_1 bltu_0 hbnz hmulsub hge
       exact evm_div_n2_stack_spec_within_word_exact_x1_uni
         bltu_2 bltu_1 bltu_0 sp base a b
         (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
@@ -869,7 +925,10 @@ theorem evm_div_stack_spec_noNop (sp base : Word) (a b : EvmWord)
         hbnz hb3z hb2z hb1z hshift_nz halign
         hbltu_3 hbltu_2 hbltu_1 hbltu_0 hcarry2 hdivWord
   | n2Full bltu_2 bltu_1 bltu_0 hbnz hb3z hb2z hb1nz hshift_nz halign
-      hbltu_2 hbltu_1 hbltu_0 hcarry2 hdivWord =>
+      hbltu_2 hbltu_1 hbltu_0 hcarry2 hmulsub hge =>
+      have hdivWord :=
+        fullDivN2QuotientWord_eq_div_of_getLimbN_mulsub_overestimate
+          bltu_2 bltu_1 bltu_0 hbnz hmulsub hge
       exact evm_div_n2_stack_spec_within_word_noNop_uni
         bltu_2 bltu_1 bltu_0 sp base a b
         (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)


### PR DESCRIPTION
## Summary
- replace the n2Full DivStackSpecCase direct hdivWord field with the mulsub equation and quotient-overestimate premises
- derive the n2 hdivWord locally in evm_div_stack_spec, evm_div_stack_spec_exact_x1, and evm_div_stack_spec_noNop using the stack-case bridge from the parent PR

## Checks
- lake build EvmAsm.Evm64.DivMod.Spec.Unified
- lake build EvmAsm.Evm64.DivMod
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- lake build