### PR TITLE
feat(sdiv): derive n3 uni hdivWord internally

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N3QuotientStackBridge.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3QuotientStackBridge.lean
@@ -1,0 +1,81 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N3QuotientStackBridge
+
+  Explicit-limb n=3 quotient bridge for Unified stack wrapper call sites.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.N3QuotientWord
+import EvmAsm.Evm64.EvmWordArith.DivN4Overestimate
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- n=3 quotient bridge specialized to the explicit limb variables used by the
+    unified-bound wrappers. -/
+theorem fullDivN3QuotientWord_eq_div_of_limbs_mulsub_overestimate
+    (bltu_1 bltu_0 : Bool) {a b : EvmWord}
+    {a0 a1 a2 a3 b0 b1 b2 b3 : Word}
+    (ha0 : a.getLimbN 0 = a0) (ha1 : a.getLimbN 1 = a1)
+    (ha2 : a.getLimbN 2 = a2) (ha3 : a.getLimbN 3 = a3)
+    (hb0 : b.getLimbN 0 = b0) (hb1 : b.getLimbN 1 = b1)
+    (hb2 : b.getLimbN 2 = b2) (hb3 : b.getLimbN 3 = b3)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hmulsub :
+      EvmWord.val256 a0 a1 a2 a3 =
+        (((fullDivN3R1 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1).toNat *
+            2^64 +
+          ((fullDivN3R0 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).1).toNat) *
+          EvmWord.val256 b0 b1 b2 b3 +
+        EvmWord.val256
+          ((fullDivN3R0 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).2.1)
+          ((fullDivN3R0 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).2.2.1)
+          ((fullDivN3R0 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1)
+          ((fullDivN3R0 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1))
+    (hge :
+      EvmWord.val256 a0 a1 a2 a3 / EvmWord.val256 b0 b1 b2 b3 ≤
+        ((fullDivN3R1 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1).toNat *
+            2^64 +
+          ((fullDivN3R0 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).1).toNat) :
+    fullDivN3QuotientWord bltu_1 bltu_0
+      a0 a1 a2 a3 b0 b1 b2 b3 = EvmWord.div a b := by
+  subst a0
+  subst a1
+  subst a2
+  subst a3
+  subst b0
+  subst b1
+  subst b2
+  subst b3
+  have hraw :=
+    fullDivN3QuotientWord_eq_div_of_mulsub_overestimate
+      bltu_1 bltu_0 hbnz hmulsub hge
+  change
+    fullDivN3QuotientWord bltu_1 bltu_0
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) =
+        EvmWord.div
+          (EvmWord.fromLimbs fun i : Fin 4 =>
+            match i with
+            | 0 => a.getLimbN 0
+            | 1 => a.getLimbN 1
+            | 2 => a.getLimbN 2
+            | 3 => a.getLimbN 3)
+          (EvmWord.fromLimbs fun i : Fin 4 =>
+            match i with
+            | 0 => b.getLimbN 0
+            | 1 => b.getLimbN 1
+            | 2 => b.getLimbN 2
+            | 3 => b.getLimbN 3) at hraw
+  exact hraw.trans (by
+    congr
+    · exact EvmWord.fromLimbs_match_getLimbN_id a
+    · exact EvmWord.fromLimbs_match_getLimbN_id b)
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/Unified.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/Unified.lean
@@ -32,6 +32,7 @@ import EvmAsm.Evm64.DivMod.Spec.N2DivStackSpec
 import EvmAsm.Evm64.DivMod.Spec.N2ModStackSpec
 import EvmAsm.Evm64.DivMod.Spec.N3DivStackSpec
 import EvmAsm.Evm64.DivMod.Spec.N3ModBridge
+import EvmAsm.Evm64.DivMod.Spec.N3QuotientStackBridge
 
 namespace EvmAsm.Evm64
 
@@ -558,8 +559,28 @@ theorem evm_div_n3_stack_spec_within_word_uni
       ((b1 <<< (((clzResult b2).1).toNat % 64)) ||| (b0 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b2).1).toNat % 64)))
       ((b2 <<< (((clzResult b2).1).toNat % 64)) ||| (b1 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b2).1).toNat % 64)))
       ((b3 <<< (((clzResult b2).1).toNat % 64)) ||| (b2 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b2).1).toNat % 64))))
-    (hdivWord : fullDivN3QuotientWord bltu_1 bltu_0
-      a0 a1 a2 a3 b0 b1 b2 b3 = EvmWord.div a b) :
+    (hmulsub :
+      EvmWord.val256 a0 a1 a2 a3 =
+        (((fullDivN3R1 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1).toNat *
+            2^64 +
+          ((fullDivN3R0 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).1).toNat) *
+          EvmWord.val256 b0 b1 b2 b3 +
+        EvmWord.val256
+          ((fullDivN3R0 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).2.1)
+          ((fullDivN3R0 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).2.2.1)
+          ((fullDivN3R0 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1)
+          ((fullDivN3R0 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1))
+    (hge :
+      EvmWord.val256 a0 a1 a2 a3 / EvmWord.val256 b0 b1 b2 b3 ≤
+        ((fullDivN3R1 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1).toNat *
+            2^64 +
+          ((fullDivN3R0 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).1).toNat) :
     cpsTripleWithin unifiedDivBound base (base + nopOff) (divCode base)
       (divModStackDispatchPre sp a b
         (signExtend12 (4 : BitVec 12) - (4 : Word))
@@ -567,7 +588,11 @@ theorem evm_div_n3_stack_spec_within_word_uni
         v5 v6 v7 v10 v11Old
         q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
         shiftMem nMem jMem retMem dMem dloMem scratch_un0)
-      (divStackDispatchPost sp a b) :=
+      (divStackDispatchPost sp a b) := by
+  have hdivWord :=
+    fullDivN3QuotientWord_eq_div_of_limbs_mulsub_overestimate
+      bltu_1 bltu_0 ha0 ha1 ha2 ha3 hb0 hb1 hb2 hb3 hbnz hmulsub hge
+  exact
   cpsTripleWithin_mono_nSteps (by decide)
     (evm_div_n3_stack_spec_within_word bltu_1 bltu_0
       sp base a b a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old
@@ -598,8 +623,28 @@ theorem evm_div_n3_stack_spec_within_word_exact_x1_uni
       ((b1 <<< (((clzResult b2).1).toNat % 64)) ||| (b0 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b2).1).toNat % 64)))
       ((b2 <<< (((clzResult b2).1).toNat % 64)) ||| (b1 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b2).1).toNat % 64)))
       ((b3 <<< (((clzResult b2).1).toNat % 64)) ||| (b2 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b2).1).toNat % 64))))
-    (hdivWord : fullDivN3QuotientWord bltu_1 bltu_0
-      a0 a1 a2 a3 b0 b1 b2 b3 = EvmWord.div a b) :
+    (hmulsub :
+      EvmWord.val256 a0 a1 a2 a3 =
+        (((fullDivN3R1 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1).toNat *
+            2^64 +
+          ((fullDivN3R0 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).1).toNat) *
+          EvmWord.val256 b0 b1 b2 b3 +
+        EvmWord.val256
+          ((fullDivN3R0 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).2.1)
+          ((fullDivN3R0 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).2.2.1)
+          ((fullDivN3R0 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1)
+          ((fullDivN3R0 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1))
+    (hge :
+      EvmWord.val256 a0 a1 a2 a3 / EvmWord.val256 b0 b1 b2 b3 ≤
+        ((fullDivN3R1 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1).toNat *
+            2^64 +
+          ((fullDivN3R0 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).1).toNat) :
     cpsTripleWithin unifiedDivBound base (base + nopOff) (divCode base)
       (divModStackDispatchPre sp a b
         (signExtend12 (4 : BitVec 12) - (4 : Word))
@@ -608,7 +653,11 @@ theorem evm_div_n3_stack_spec_within_word_exact_x1_uni
         q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
         shiftMem nMem jMem retMem dMem dloMem scratch_un0)
       (divStackDispatchPostNoX1 sp a b **
-        (.x9 ↦ᵣ (signExtend12 4095 : Word))) :=
+        (.x9 ↦ᵣ (signExtend12 4095 : Word))) := by
+  have hdivWord :=
+    fullDivN3QuotientWord_eq_div_of_limbs_mulsub_overestimate
+      bltu_1 bltu_0 ha0 ha1 ha2 ha3 hb0 hb1 hb2 hb3 hbnz hmulsub hge
+  exact
   cpsTripleWithin_mono_nSteps (by decide)
     (evm_div_n3_stack_spec_within_word_exact_x1 bltu_1 bltu_0
       sp base a b a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old
@@ -638,8 +687,28 @@ theorem evm_div_n3_stack_spec_within_word_noNop_uni
       ((b1 <<< (((clzResult b2).1).toNat % 64)) ||| (b0 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b2).1).toNat % 64)))
       ((b2 <<< (((clzResult b2).1).toNat % 64)) ||| (b1 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b2).1).toNat % 64)))
       ((b3 <<< (((clzResult b2).1).toNat % 64)) ||| (b2 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b2).1).toNat % 64))))
-    (hdivWord : fullDivN3QuotientWord bltu_1 bltu_0
-      a0 a1 a2 a3 b0 b1 b2 b3 = EvmWord.div a b) :
+    (hmulsub :
+      EvmWord.val256 a0 a1 a2 a3 =
+        (((fullDivN3R1 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1).toNat *
+            2^64 +
+          ((fullDivN3R0 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).1).toNat) *
+          EvmWord.val256 b0 b1 b2 b3 +
+        EvmWord.val256
+          ((fullDivN3R0 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).2.1)
+          ((fullDivN3R0 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).2.2.1)
+          ((fullDivN3R0 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1)
+          ((fullDivN3R0 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1))
+    (hge :
+      EvmWord.val256 a0 a1 a2 a3 / EvmWord.val256 b0 b1 b2 b3 ≤
+        ((fullDivN3R1 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1).toNat *
+            2^64 +
+          ((fullDivN3R0 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).1).toNat) :
     cpsTripleWithin unifiedDivBound base (base + nopOff) (divCode_noNop base)
       (divModStackDispatchPre sp a b
         (signExtend12 (4 : BitVec 12) - (4 : Word))
@@ -647,7 +716,11 @@ theorem evm_div_n3_stack_spec_within_word_noNop_uni
         v5 v6 v7 v10 v11Old
         q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
         shiftMem nMem jMem retMem dMem dloMem scratch_un0)
-      (divStackDispatchPost sp a b) :=
+      (divStackDispatchPost sp a b) := by
+  have hdivWord :=
+    fullDivN3QuotientWord_eq_div_of_limbs_mulsub_overestimate
+      bltu_1 bltu_0 ha0 ha1 ha2 ha3 hb0 hb1 hb2 hb3 hbnz hmulsub hge
+  exact
   cpsTripleWithin_mono_nSteps (by decide)
     (evm_div_n3_stack_spec_within_word_noNop bltu_1 bltu_0
       sp base a b a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old
@@ -977,9 +1050,6 @@ theorem evm_div_stack_spec (sp base : Word) (a b : EvmWord)
         hbltu_2 hbltu_1 hbltu_0 hcarry2 hdivWord
   | n3Full bltu_1 bltu_0 hbnz hb3z hb2nz hshift_nz halign
       hbltu_1 hbltu_0 hcarry2 hmulsub hge =>
-      have hdivWord :=
-        fullDivN3QuotientWord_eq_div_of_getLimbN_mulsub_overestimate
-          bltu_1 bltu_0 hbnz hmulsub hge
       exact evm_div_n3_stack_spec_within_word_uni
         bltu_1 bltu_0 sp base a b
         (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
@@ -988,7 +1058,7 @@ theorem evm_div_stack_spec (sp base : Word) (a b : EvmWord)
         nMem shiftMem jMem retMem dMem dloMem scratch_un0
         rfl rfl rfl rfl rfl rfl rfl rfl
         hbnz hb3z hb2nz hshift_nz halign
-        hbltu_1 hbltu_0 hcarry2 hdivWord
+        hbltu_1 hbltu_0 hcarry2 hmulsub hge
 
 /-- Single named DIV stack spec that preserves the caller-owned `x1` atom
     through the dispatcher surface. -/
@@ -1041,9 +1111,6 @@ theorem evm_div_stack_spec_exact_x1 (sp base : Word) (a b : EvmWord)
         hbltu_2 hbltu_1 hbltu_0 hcarry2 hdivWord
   | n3Full bltu_1 bltu_0 hbnz hb3z hb2nz hshift_nz halign
       hbltu_1 hbltu_0 hcarry2 hmulsub hge =>
-      have hdivWord :=
-        fullDivN3QuotientWord_eq_div_of_getLimbN_mulsub_overestimate
-          bltu_1 bltu_0 hbnz hmulsub hge
       exact evm_div_n3_stack_spec_within_word_exact_x1_uni
         bltu_1 bltu_0 sp base a b
         (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
@@ -1052,7 +1119,7 @@ theorem evm_div_stack_spec_exact_x1 (sp base : Word) (a b : EvmWord)
         nMem shiftMem jMem retMem dMem dloMem scratch_un0
         rfl rfl rfl rfl rfl rfl rfl rfl
         hbnz hb3z hb2nz hshift_nz halign
-        hbltu_1 hbltu_0 hcarry2 hdivWord
+        hbltu_1 hbltu_0 hcarry2 hmulsub hge
 
 /-- Single named DIV stack spec over `divCode_noNop`. -/
 theorem evm_div_stack_spec_noNop (sp base : Word) (a b : EvmWord)
@@ -1102,9 +1169,6 @@ theorem evm_div_stack_spec_noNop (sp base : Word) (a b : EvmWord)
         hbltu_2 hbltu_1 hbltu_0 hcarry2 hdivWord
   | n3Full bltu_1 bltu_0 hbnz hb3z hb2nz hshift_nz halign
       hbltu_1 hbltu_0 hcarry2 hmulsub hge =>
-      have hdivWord :=
-        fullDivN3QuotientWord_eq_div_of_getLimbN_mulsub_overestimate
-          bltu_1 bltu_0 hbnz hmulsub hge
       exact evm_div_n3_stack_spec_within_word_noNop_uni
         bltu_1 bltu_0 sp base a b
         (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
@@ -1113,7 +1177,7 @@ theorem evm_div_stack_spec_noNop (sp base : Word) (a b : EvmWord)
         nMem shiftMem jMem retMem dMem dloMem scratch_un0
         rfl rfl rfl rfl rfl rfl rfl rfl
         hbnz hb3z hb2nz hshift_nz halign
-        hbltu_1 hbltu_0 hcarry2 hdivWord
+        hbltu_1 hbltu_0 hcarry2 hmulsub hge
 
 /-! ### MOD `_uni` wrappers -/
 


### PR DESCRIPTION
## Summary
- add N3QuotientStackBridge.lean for explicit-limb n3 quotient bridge call sites
- replace the n3 unified-bound wrapper hdivWord parameters with hmulsub+hge premises
- derive hdivWord internally before calling the existing n3 stack specs

## Checks
- lake build EvmAsm.Evm64.DivMod.Spec.N3QuotientStackBridge
- lake build EvmAsm.Evm64.DivMod.Spec.Unified
- lake build EvmAsm.Evm64.DivMod
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- lake build