### PR TITLE
feat(sdiv): derive n2 uni hdivWord internally

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N2QuotientStackBridge.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2QuotientStackBridge.lean
@@ -1,0 +1,146 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N2QuotientStackBridge
+
+  Explicit-limb n=2 quotient bridge for Unified stack wrapper call sites.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.N2QuotientWord
+import EvmAsm.Evm64.EvmWordArith.DivN4Overestimate
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- n=2 quotient bridge specialized to the explicit limb variables used by the
+    unified-bound wrappers. -/
+theorem fullDivN2QuotientWord_eq_div_of_limbs_mulsub_overestimate
+    (bltu_2 bltu_1 bltu_0 : Bool) {a b : EvmWord}
+    {a0 a1 a2 a3 b0 b1 b2 b3 : Word}
+    (ha0 : a.getLimbN 0 = a0) (ha1 : a.getLimbN 1 = a1)
+    (ha2 : a.getLimbN 2 = a2) (ha3 : a.getLimbN 3 = a3)
+    (hb0 : b.getLimbN 0 = b0) (hb1 : b.getLimbN 1 = b1)
+    (hb2 : b.getLimbN 2 = b2) (hb3 : b.getLimbN 3 = b3)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hmulsub :
+      EvmWord.val256 a0 a1 a2 a3 =
+        (((fullDivN2R2 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).1).toNat * 2^128 +
+          ((fullDivN2R1 bltu_2 bltu_1
+              a0 a1 a2 a3 b0 b1 b2 b3).1).toNat * 2^64 +
+          ((fullDivN2R0 bltu_2 bltu_1 bltu_0
+              a0 a1 a2 a3 b0 b1 b2 b3).1).toNat) *
+          EvmWord.val256 b0 b1 b2 b3 +
+        EvmWord.val256
+          ((fullDivN2R0 bltu_2 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).2.1)
+          ((fullDivN2R0 bltu_2 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).2.2.1)
+          ((fullDivN2R0 bltu_2 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1)
+          ((fullDivN2R0 bltu_2 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1))
+    (hge :
+      EvmWord.val256 a0 a1 a2 a3 / EvmWord.val256 b0 b1 b2 b3 ≤
+        ((fullDivN2R2 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).1).toNat * 2^128 +
+          ((fullDivN2R1 bltu_2 bltu_1
+            a0 a1 a2 a3 b0 b1 b2 b3).1).toNat * 2^64 +
+          ((fullDivN2R0 bltu_2 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).1).toNat) :
+    fullDivN2QuotientWord bltu_2 bltu_1 bltu_0
+      a0 a1 a2 a3 b0 b1 b2 b3 = EvmWord.div a b := by
+  subst a0
+  subst a1
+  subst a2
+  subst a3
+  subst b0
+  subst b1
+  subst b2
+  subst b3
+  have hraw :=
+    fullDivN2QuotientWord_eq_div_of_mulsub_overestimate
+      bltu_2 bltu_1 bltu_0 hbnz hmulsub hge
+  change
+    fullDivN2QuotientWord bltu_2 bltu_1 bltu_0
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) =
+        EvmWord.div
+          (EvmWord.fromLimbs fun i : Fin 4 =>
+            match i with
+            | 0 => a.getLimbN 0
+            | 1 => a.getLimbN 1
+            | 2 => a.getLimbN 2
+            | 3 => a.getLimbN 3)
+          (EvmWord.fromLimbs fun i : Fin 4 =>
+            match i with
+            | 0 => b.getLimbN 0
+            | 1 => b.getLimbN 1
+            | 2 => b.getLimbN 2
+            | 3 => b.getLimbN 3) at hraw
+  exact hraw.trans (by
+    congr
+    · exact EvmWord.fromLimbs_match_getLimbN_id a
+    · exact EvmWord.fromLimbs_match_getLimbN_id b)
+
+/-- n=2 quotient bridge specialized to branch constructors that store
+    `a`/`b` as `EvmWord`s and refer to their limbs directly. -/
+theorem fullDivN2QuotientWord_eq_div_of_getLimbN_mulsub_overestimate
+    (bltu_2 bltu_1 bltu_0 : Bool) {a b : EvmWord}
+    (hbnz : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 ≠ 0)
+    (hmulsub :
+      EvmWord.val256 (a.getLimbN 0) (a.getLimbN 1)
+          (a.getLimbN 2) (a.getLimbN 3) =
+        (((fullDivN2R2 bltu_2
+              (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3)
+              (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).1).toNat * 2^128 +
+          ((fullDivN2R1 bltu_2 bltu_1
+              (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3)
+              (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).1).toNat * 2^64 +
+          ((fullDivN2R0 bltu_2 bltu_1 bltu_0
+              (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3)
+              (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).1).toNat) *
+          EvmWord.val256 (b.getLimbN 0) (b.getLimbN 1)
+            (b.getLimbN 2) (b.getLimbN 3) +
+        EvmWord.val256
+          ((fullDivN2R0 bltu_2 bltu_1 bltu_0
+            (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+            (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.1)
+          ((fullDivN2R0 bltu_2 bltu_1 bltu_0
+            (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+            (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1)
+          ((fullDivN2R0 bltu_2 bltu_1 bltu_0
+            (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+            (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2.1)
+          ((fullDivN2R0 bltu_2 bltu_1 bltu_0
+            (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+            (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2.2.1))
+    (hge :
+      EvmWord.val256 (a.getLimbN 0) (a.getLimbN 1)
+          (a.getLimbN 2) (a.getLimbN 3) /
+        EvmWord.val256 (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3) ≤
+        ((fullDivN2R2 bltu_2
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2)
+          (b.getLimbN 3)).1).toNat * 2^128 +
+          ((fullDivN2R1 bltu_2 bltu_1
+            (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+            (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2)
+            (b.getLimbN 3)).1).toNat * 2^64 +
+          ((fullDivN2R0 bltu_2 bltu_1 bltu_0
+            (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+            (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2)
+            (b.getLimbN 3)).1).toNat) :
+    fullDivN2QuotientWord bltu_2 bltu_1 bltu_0
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) =
+        EvmWord.div a b :=
+  fullDivN2QuotientWord_eq_div_of_limbs_mulsub_overestimate
+    bltu_2 bltu_1 bltu_0 rfl rfl rfl rfl rfl rfl rfl rfl
+    hbnz hmulsub hge
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/Unified.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/Unified.lean
@@ -30,6 +30,7 @@ import EvmAsm.Evm64.DivMod.Spec.UnifiedBzero
 import EvmAsm.Evm64.DivMod.Spec.N1QuotientWord
 import EvmAsm.Evm64.DivMod.Spec.N2DivStackSpec
 import EvmAsm.Evm64.DivMod.Spec.N2ModStackSpec
+import EvmAsm.Evm64.DivMod.Spec.N2QuotientStackBridge
 import EvmAsm.Evm64.DivMod.Spec.N3DivStackSpec
 import EvmAsm.Evm64.DivMod.Spec.N3ModBridge
 import EvmAsm.Evm64.DivMod.Spec.N3QuotientStackBridge
@@ -113,90 +114,6 @@ theorem fullDivN1QuotientWord_eq_div_of_getLimbN_mulsub_overestimate
       bltu_3 bltu_2 bltu_1 bltu_0 hbnz hmulsub hge
   change
     fullDivN1QuotientWord bltu_3 bltu_2 bltu_1 bltu_0
-      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) =
-        EvmWord.div
-          (EvmWord.fromLimbs fun i : Fin 4 =>
-            match i with
-            | 0 => a.getLimbN 0
-            | 1 => a.getLimbN 1
-            | 2 => a.getLimbN 2
-            | 3 => a.getLimbN 3)
-          (EvmWord.fromLimbs fun i : Fin 4 =>
-            match i with
-            | 0 => b.getLimbN 0
-            | 1 => b.getLimbN 1
-            | 2 => b.getLimbN 2
-            | 3 => b.getLimbN 3) at hraw
-  exact hraw.trans (by
-    congr
-    · exact EvmWord.fromLimbs_match_getLimbN_id a
-    · exact EvmWord.fromLimbs_match_getLimbN_id b)
-
-/-- n=2 quotient bridge specialized to branch constructors that store
-    `a`/`b` as `EvmWord`s and refer to their limbs directly. -/
-theorem fullDivN2QuotientWord_eq_div_of_getLimbN_mulsub_overestimate
-    (bltu_2 bltu_1 bltu_0 : Bool) {a b : EvmWord}
-    (hbnz : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 ≠ 0)
-    (hmulsub :
-      EvmWord.val256 (a.getLimbN 0) (a.getLimbN 1)
-          (a.getLimbN 2) (a.getLimbN 3) =
-        (((fullDivN2R2 bltu_2
-              (a.getLimbN 0) (a.getLimbN 1)
-              (a.getLimbN 2) (a.getLimbN 3)
-              (b.getLimbN 0) (b.getLimbN 1)
-              (b.getLimbN 2) (b.getLimbN 3)).1).toNat * 2^128 +
-          ((fullDivN2R1 bltu_2 bltu_1
-              (a.getLimbN 0) (a.getLimbN 1)
-              (a.getLimbN 2) (a.getLimbN 3)
-              (b.getLimbN 0) (b.getLimbN 1)
-              (b.getLimbN 2) (b.getLimbN 3)).1).toNat * 2^64 +
-          ((fullDivN2R0 bltu_2 bltu_1 bltu_0
-              (a.getLimbN 0) (a.getLimbN 1)
-              (a.getLimbN 2) (a.getLimbN 3)
-              (b.getLimbN 0) (b.getLimbN 1)
-              (b.getLimbN 2) (b.getLimbN 3)).1).toNat) *
-          EvmWord.val256 (b.getLimbN 0) (b.getLimbN 1)
-            (b.getLimbN 2) (b.getLimbN 3) +
-        EvmWord.val256
-          ((fullDivN2R0 bltu_2 bltu_1 bltu_0
-            (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-            (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.1)
-          ((fullDivN2R0 bltu_2 bltu_1 bltu_0
-            (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-            (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1)
-          ((fullDivN2R0 bltu_2 bltu_1 bltu_0
-            (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-            (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2.1)
-          ((fullDivN2R0 bltu_2 bltu_1 bltu_0
-            (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-            (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2.2.1))
-    (hge :
-      EvmWord.val256 (a.getLimbN 0) (a.getLimbN 1)
-          (a.getLimbN 2) (a.getLimbN 3) /
-        EvmWord.val256 (b.getLimbN 0) (b.getLimbN 1)
-          (b.getLimbN 2) (b.getLimbN 3) ≤
-        ((fullDivN2R2 bltu_2
-          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2)
-          (b.getLimbN 3)).1).toNat * 2^128 +
-          ((fullDivN2R1 bltu_2 bltu_1
-            (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-            (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2)
-            (b.getLimbN 3)).1).toNat * 2^64 +
-          ((fullDivN2R0 bltu_2 bltu_1 bltu_0
-            (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-            (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2)
-            (b.getLimbN 3)).1).toNat) :
-    fullDivN2QuotientWord bltu_2 bltu_1 bltu_0
-      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) =
-        EvmWord.div a b := by
-  have hraw :=
-    fullDivN2QuotientWord_eq_div_of_mulsub_overestimate
-      bltu_2 bltu_1 bltu_0 hbnz hmulsub hge
-  change
-    fullDivN2QuotientWord bltu_2 bltu_1 bltu_0
       (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
       (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) =
         EvmWord.div
@@ -438,8 +355,30 @@ theorem evm_div_n2_stack_spec_within_word_uni
       ((b1 <<< (((clzResult b1).1).toNat % 64)) ||| (b0 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b1).1).toNat % 64)))
       ((b2 <<< (((clzResult b1).1).toNat % 64)) ||| (b1 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b1).1).toNat % 64)))
       ((b3 <<< (((clzResult b1).1).toNat % 64)) ||| (b2 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b1).1).toNat % 64))))
-    (hdivWord : fullDivN2QuotientWord bltu_2 bltu_1 bltu_0
-      a0 a1 a2 a3 b0 b1 b2 b3 = EvmWord.div a b) :
+    (hmulsub :
+      EvmWord.val256 a0 a1 a2 a3 =
+        (((fullDivN2R2 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).1).toNat * 2^128 +
+          ((fullDivN2R1 bltu_2 bltu_1
+              a0 a1 a2 a3 b0 b1 b2 b3).1).toNat * 2^64 +
+          ((fullDivN2R0 bltu_2 bltu_1 bltu_0
+              a0 a1 a2 a3 b0 b1 b2 b3).1).toNat) *
+          EvmWord.val256 b0 b1 b2 b3 +
+        EvmWord.val256
+          ((fullDivN2R0 bltu_2 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).2.1)
+          ((fullDivN2R0 bltu_2 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).2.2.1)
+          ((fullDivN2R0 bltu_2 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1)
+          ((fullDivN2R0 bltu_2 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1))
+    (hge :
+      EvmWord.val256 a0 a1 a2 a3 / EvmWord.val256 b0 b1 b2 b3 ≤
+        ((fullDivN2R2 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).1).toNat * 2^128 +
+          ((fullDivN2R1 bltu_2 bltu_1
+            a0 a1 a2 a3 b0 b1 b2 b3).1).toNat * 2^64 +
+          ((fullDivN2R0 bltu_2 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).1).toNat) :
     cpsTripleWithin unifiedDivBound base (base + nopOff) (divCode base)
       (divModStackDispatchPre sp a b
         (signExtend12 (4 : BitVec 12) - (4 : Word))
@@ -447,8 +386,12 @@ theorem evm_div_n2_stack_spec_within_word_uni
         v5 v6 v7 v10 v11Old
         q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
         shiftMem nMem jMem retMem dMem dloMem scratch_un0)
-      (divStackDispatchPost sp a b) :=
-  cpsTripleWithin_mono_nSteps (by decide)
+      (divStackDispatchPost sp a b) := by
+  have hdivWord :=
+    fullDivN2QuotientWord_eq_div_of_limbs_mulsub_overestimate
+      bltu_2 bltu_1 bltu_0 ha0 ha1 ha2 ha3 hb0 hb1 hb2 hb3
+      hbnz hmulsub hge
+  exact cpsTripleWithin_mono_nSteps (by decide)
     (evm_div_n2_stack_spec_within_word bltu_2 bltu_1 bltu_0
       sp base a b a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old
       q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
@@ -479,8 +422,30 @@ theorem evm_div_n2_stack_spec_within_word_exact_x1_uni
       ((b1 <<< (((clzResult b1).1).toNat % 64)) ||| (b0 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b1).1).toNat % 64)))
       ((b2 <<< (((clzResult b1).1).toNat % 64)) ||| (b1 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b1).1).toNat % 64)))
       ((b3 <<< (((clzResult b1).1).toNat % 64)) ||| (b2 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b1).1).toNat % 64))))
-    (hdivWord : fullDivN2QuotientWord bltu_2 bltu_1 bltu_0
-      a0 a1 a2 a3 b0 b1 b2 b3 = EvmWord.div a b) :
+    (hmulsub :
+      EvmWord.val256 a0 a1 a2 a3 =
+        (((fullDivN2R2 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).1).toNat * 2^128 +
+          ((fullDivN2R1 bltu_2 bltu_1
+              a0 a1 a2 a3 b0 b1 b2 b3).1).toNat * 2^64 +
+          ((fullDivN2R0 bltu_2 bltu_1 bltu_0
+              a0 a1 a2 a3 b0 b1 b2 b3).1).toNat) *
+          EvmWord.val256 b0 b1 b2 b3 +
+        EvmWord.val256
+          ((fullDivN2R0 bltu_2 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).2.1)
+          ((fullDivN2R0 bltu_2 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).2.2.1)
+          ((fullDivN2R0 bltu_2 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1)
+          ((fullDivN2R0 bltu_2 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1))
+    (hge :
+      EvmWord.val256 a0 a1 a2 a3 / EvmWord.val256 b0 b1 b2 b3 ≤
+        ((fullDivN2R2 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).1).toNat * 2^128 +
+          ((fullDivN2R1 bltu_2 bltu_1
+            a0 a1 a2 a3 b0 b1 b2 b3).1).toNat * 2^64 +
+          ((fullDivN2R0 bltu_2 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).1).toNat) :
     cpsTripleWithin unifiedDivBound base (base + nopOff) (divCode base)
       (divModStackDispatchPre sp a b
         (signExtend12 (4 : BitVec 12) - (4 : Word))
@@ -489,8 +454,12 @@ theorem evm_div_n2_stack_spec_within_word_exact_x1_uni
         q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
         shiftMem nMem jMem retMem dMem dloMem scratch_un0)
       (divStackDispatchPostNoX1 sp a b **
-        (.x9 ↦ᵣ (signExtend12 4095 : Word))) :=
-  cpsTripleWithin_mono_nSteps (by decide)
+        (.x9 ↦ᵣ (signExtend12 4095 : Word))) := by
+  have hdivWord :=
+    fullDivN2QuotientWord_eq_div_of_limbs_mulsub_overestimate
+      bltu_2 bltu_1 bltu_0 ha0 ha1 ha2 ha3 hb0 hb1 hb2 hb3
+      hbnz hmulsub hge
+  exact cpsTripleWithin_mono_nSteps (by decide)
     (evm_div_n2_stack_spec_within_word_exact_x1 bltu_2 bltu_1 bltu_0
       sp base a b a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old
       q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
@@ -520,8 +489,30 @@ theorem evm_div_n2_stack_spec_within_word_noNop_uni
       ((b1 <<< (((clzResult b1).1).toNat % 64)) ||| (b0 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b1).1).toNat % 64)))
       ((b2 <<< (((clzResult b1).1).toNat % 64)) ||| (b1 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b1).1).toNat % 64)))
       ((b3 <<< (((clzResult b1).1).toNat % 64)) ||| (b2 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b1).1).toNat % 64))))
-    (hdivWord : fullDivN2QuotientWord bltu_2 bltu_1 bltu_0
-      a0 a1 a2 a3 b0 b1 b2 b3 = EvmWord.div a b) :
+    (hmulsub :
+      EvmWord.val256 a0 a1 a2 a3 =
+        (((fullDivN2R2 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).1).toNat * 2^128 +
+          ((fullDivN2R1 bltu_2 bltu_1
+              a0 a1 a2 a3 b0 b1 b2 b3).1).toNat * 2^64 +
+          ((fullDivN2R0 bltu_2 bltu_1 bltu_0
+              a0 a1 a2 a3 b0 b1 b2 b3).1).toNat) *
+          EvmWord.val256 b0 b1 b2 b3 +
+        EvmWord.val256
+          ((fullDivN2R0 bltu_2 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).2.1)
+          ((fullDivN2R0 bltu_2 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).2.2.1)
+          ((fullDivN2R0 bltu_2 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1)
+          ((fullDivN2R0 bltu_2 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1))
+    (hge :
+      EvmWord.val256 a0 a1 a2 a3 / EvmWord.val256 b0 b1 b2 b3 ≤
+        ((fullDivN2R2 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).1).toNat * 2^128 +
+          ((fullDivN2R1 bltu_2 bltu_1
+            a0 a1 a2 a3 b0 b1 b2 b3).1).toNat * 2^64 +
+          ((fullDivN2R0 bltu_2 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).1).toNat) :
     cpsTripleWithin unifiedDivBound base (base + nopOff) (divCode_noNop base)
       (divModStackDispatchPre sp a b
         (signExtend12 (4 : BitVec 12) - (4 : Word))
@@ -529,8 +520,12 @@ theorem evm_div_n2_stack_spec_within_word_noNop_uni
         v5 v6 v7 v10 v11Old
         q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
         shiftMem nMem jMem retMem dMem dloMem scratch_un0)
-      (divStackDispatchPost sp a b) :=
-  cpsTripleWithin_mono_nSteps (by decide)
+      (divStackDispatchPost sp a b) := by
+  have hdivWord :=
+    fullDivN2QuotientWord_eq_div_of_limbs_mulsub_overestimate
+      bltu_2 bltu_1 bltu_0 ha0 ha1 ha2 ha3 hb0 hb1 hb2 hb3
+      hbnz hmulsub hge
+  exact cpsTripleWithin_mono_nSteps (by decide)
     (evm_div_n2_stack_spec_within_word_noNop bltu_2 bltu_1 bltu_0
       sp base a b a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old
       q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
@@ -1036,9 +1031,6 @@ theorem evm_div_stack_spec (sp base : Word) (a b : EvmWord)
         hbltu_3 hbltu_2 hbltu_1 hbltu_0 hcarry2 hdivWord
   | n2Full bltu_2 bltu_1 bltu_0 hbnz hb3z hb2z hb1nz hshift_nz halign
       hbltu_2 hbltu_1 hbltu_0 hcarry2 hmulsub hge =>
-      have hdivWord :=
-        fullDivN2QuotientWord_eq_div_of_getLimbN_mulsub_overestimate
-          bltu_2 bltu_1 bltu_0 hbnz hmulsub hge
       exact evm_div_n2_stack_spec_within_word_uni
         bltu_2 bltu_1 bltu_0 sp base a b
         (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
@@ -1047,7 +1039,7 @@ theorem evm_div_stack_spec (sp base : Word) (a b : EvmWord)
         nMem shiftMem jMem retMem dMem dloMem scratch_un0
         rfl rfl rfl rfl rfl rfl rfl rfl
         hbnz hb3z hb2z hb1nz hshift_nz halign
-        hbltu_2 hbltu_1 hbltu_0 hcarry2 hdivWord
+        hbltu_2 hbltu_1 hbltu_0 hcarry2 hmulsub hge
   | n3Full bltu_1 bltu_0 hbnz hb3z hb2nz hshift_nz halign
       hbltu_1 hbltu_0 hcarry2 hmulsub hge =>
       exact evm_div_n3_stack_spec_within_word_uni
@@ -1097,9 +1089,6 @@ theorem evm_div_stack_spec_exact_x1 (sp base : Word) (a b : EvmWord)
         hbltu_3 hbltu_2 hbltu_1 hbltu_0 hcarry2 hdivWord
   | n2Full bltu_2 bltu_1 bltu_0 hbnz hb3z hb2z hb1nz hshift_nz halign
       hbltu_2 hbltu_1 hbltu_0 hcarry2 hmulsub hge =>
-      have hdivWord :=
-        fullDivN2QuotientWord_eq_div_of_getLimbN_mulsub_overestimate
-          bltu_2 bltu_1 bltu_0 hbnz hmulsub hge
       exact evm_div_n2_stack_spec_within_word_exact_x1_uni
         bltu_2 bltu_1 bltu_0 sp base a b
         (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
@@ -1108,7 +1097,7 @@ theorem evm_div_stack_spec_exact_x1 (sp base : Word) (a b : EvmWord)
         nMem shiftMem jMem retMem dMem dloMem scratch_un0
         rfl rfl rfl rfl rfl rfl rfl rfl
         hbnz hb3z hb2z hb1nz hshift_nz halign
-        hbltu_2 hbltu_1 hbltu_0 hcarry2 hdivWord
+        hbltu_2 hbltu_1 hbltu_0 hcarry2 hmulsub hge
   | n3Full bltu_1 bltu_0 hbnz hb3z hb2nz hshift_nz halign
       hbltu_1 hbltu_0 hcarry2 hmulsub hge =>
       exact evm_div_n3_stack_spec_within_word_exact_x1_uni
@@ -1155,9 +1144,6 @@ theorem evm_div_stack_spec_noNop (sp base : Word) (a b : EvmWord)
         hbltu_3 hbltu_2 hbltu_1 hbltu_0 hcarry2 hdivWord
   | n2Full bltu_2 bltu_1 bltu_0 hbnz hb3z hb2z hb1nz hshift_nz halign
       hbltu_2 hbltu_1 hbltu_0 hcarry2 hmulsub hge =>
-      have hdivWord :=
-        fullDivN2QuotientWord_eq_div_of_getLimbN_mulsub_overestimate
-          bltu_2 bltu_1 bltu_0 hbnz hmulsub hge
       exact evm_div_n2_stack_spec_within_word_noNop_uni
         bltu_2 bltu_1 bltu_0 sp base a b
         (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
@@ -1166,7 +1152,7 @@ theorem evm_div_stack_spec_noNop (sp base : Word) (a b : EvmWord)
         nMem shiftMem jMem retMem dMem dloMem scratch_un0
         rfl rfl rfl rfl rfl rfl rfl rfl
         hbnz hb3z hb2z hb1nz hshift_nz halign
-        hbltu_2 hbltu_1 hbltu_0 hcarry2 hdivWord
+        hbltu_2 hbltu_1 hbltu_0 hcarry2 hmulsub hge
   | n3Full bltu_1 bltu_0 hbnz hb3z hb2nz hshift_nz halign
       hbltu_1 hbltu_0 hcarry2 hmulsub hge =>
       exact evm_div_n3_stack_spec_within_word_noNop_uni


### PR DESCRIPTION
## Summary
- add N2QuotientStackBridge.lean for explicit-limb n2 quotient bridge call sites
- move the existing n2 getLimb bridge out of Unified.lean to keep the file below the size cap
- replace the n2 unified-bound wrapper hdivWord parameters with hmulsub+hge premises
- derive hdivWord internally before calling the existing n2 stack specs

## Checks
- lake build EvmAsm.Evm64.DivMod.Spec.N2QuotientStackBridge
- lake build EvmAsm.Evm64.DivMod.Spec.Unified
- lake build EvmAsm.Evm64.DivMod
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- lake build