### PR TITLE
feat(exp): normalize fixed branch results

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedBoolStep.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedBoolStep.lean
@@ -33,6 +33,38 @@ theorem expTwoMulFixedBranchResult_true
         a0 a1 a2 a3 := by
   rfl
 
+theorem expTwoMulFixedBranchResult_decide_highBit_eq_squareW_of_zero
+    {e a0 a1 a2 a3 r0 r1 r2 r3 : Word}
+    (hBitZero : (e >>> (63 : BitVec 6).toNat) +
+        signExtend12 (0 : BitVec 12) = 0) :
+    expTwoMulFixedBranchResult
+        (decide ((e >>> (63 : BitVec 6).toNat) +
+          signExtend12 (0 : BitVec 12) ≠ 0))
+        a0 a1 a2 a3 r0 r1 r2 r3 =
+      expSquaringCallSquareW r0 r1 r2 r3 := by
+  have hDecide :
+      decide ((e >>> (63 : BitVec 6).toNat) +
+        signExtend12 (0 : BitVec 12) ≠ 0) = false := by
+    rw [hBitZero]
+    decide
+  rw [hDecide, expTwoMulFixedBranchResult_false]
+
+theorem expTwoMulFixedBranchResult_decide_highBit_eq_condRw_of_ne_zero
+    {e a0 a1 a2 a3 r0 r1 r2 r3 : Word}
+    (hBitNe : (e >>> (63 : BitVec 6).toNat) +
+        signExtend12 (0 : BitVec 12) ≠ 0) :
+    expTwoMulFixedBranchResult
+        (decide ((e >>> (63 : BitVec 6).toNat) +
+          signExtend12 (0 : BitVec 12) ≠ 0))
+        a0 a1 a2 a3 r0 r1 r2 r3 =
+      expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3)
+        a0 a1 a2 a3 := by
+  have hDecide :
+      decide ((e >>> (63 : BitVec 6).toNat) +
+        signExtend12 (0 : BitVec 12) ≠ 0) = true := by
+    exact decide_eq_true hBitNe
+  rw [hDecide, expTwoMulFixedBranchResult_true]
+
 theorem expTwoMulFixedAccumulatorStep_eq_branchResult
     {baseWord : EvmWord} {bit : Bool}
     {a0 a1 a2 a3 r0 r1 r2 r3 : Word}


### PR DESCRIPTION
## Summary
- add branch-result normalization lemmas for the machine high-bit condition
- connect zero-bit posts to expTwoMulFixedBranchResult false / square output
- connect nonzero-bit posts to expTwoMulFixedBranchResult true / conditional multiply output

## Checks
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedBoolStep
- lake build EvmAsm.Evm64.Exp
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- lake build

Full build has only the pre-existing LeanRV64D/RiscvExtras deprecation warning.