### PR TITLE
feat(exp): separate fixed loop control counter

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterPreNPost.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterPreNPost.lean
@@ -7,6 +7,7 @@
 
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedBoolStep
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePostFramedCases
+import EvmAsm.Evm64.Exp.Compose.SavedBitFixedLoopInvariantWithControl
 
 namespace EvmAsm.Evm64.Exp.Compose
 
@@ -208,6 +209,198 @@ theorem expTwoMulFixedIterSkipScratchFrame_to_iterPreN_frame
       (expTwoMulFixedIterSkipScratchFrame_to_iterPre_frame h)
   rw [expTwoMulFixedIterPreNWithFrame_unfold,
     expTwoMulFixedIterPreN_unfold,
+    expTwoMulFixedSemanticInvariant_unfold,
+    expTwoMulFixedCursorAssertion_unfold,
+    expTwoMulFixedControlAssertion_unfold]
+  rw [pure_assertion_eq_emp_of_true h_acc,
+    pure_assertion_eq_emp_of_true h_cursor,
+    pure_assertion_eq_emp_of_true h_control]
+  simp only [sepConj_emp_right']
+  sep_perm hPre
+
+theorem expTwoMulFixedIterSkipCondScratchFrame_to_iterPreNWithControl_frame
+    {baseWord exponentWord : EvmWord} {k : Nat}
+    {iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
+    {exitCond : Prop} {v6 v7 v10 v11 d0 d1 d2 d3 : Word}
+    {frame : Assertion} {ps : PartialState}
+    (hk : k < 256)
+    (hBase : baseWord = expResultWord a0 a1 a2 a3)
+    (hCursor : expTwoMulFixedCursorInvariant exponentWord k e)
+    (hControl :
+      expTwoMulFixedControlInvariant exponentWord k c6 ptr nextLimb evmSp)
+    (hInv :
+      expTwoMulFixedAccumulatorInvariant baseWord exponentWord k
+        r0 r1 r2 r3)
+    (h :
+      ((expTwoMulFixedIterSkipCondCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 exitCond **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        (expTwoMulFixedIterSkipCondCountPostScratchSuffix e c6 base **
+          expTwoMulFixedIterPointerFrame ptr nextLimb)) **
+        frame) ps) :
+    let rw := expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3)
+      a0 a1 a2 a3
+    expTwoMulFixedIterPreNWithControlFrame (k + 1) baseWord exponentWord
+      (c6 + signExtend12 (-1 : BitVec 12))
+      (e <<< (1 : BitVec 6).toNat)
+      v6
+      (expTwoMulIterCountNew iterCount)
+      v10
+      ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+      ptr nextLimb sp evmSp
+      (rw.getLimbN 3)
+      (((base + 44) + 140) + 68)
+      (rw.getLimbN 0) (rw.getLimbN 1) (rw.getLimbN 2) (rw.getLimbN 3)
+      d0 d1 d2 d3
+      (rw.getLimbN 0) (rw.getLimbN 1) (rw.getLimbN 2) (rw.getLimbN 3)
+      a0 a1 a2 a3 v7 v11
+      frame ps := by
+  intro rw
+  obtain ⟨_hExit, hC6, hBitNe⟩ :=
+    expTwoMulFixedIterSkipCondScratchFrame_pures h
+  have hStep :=
+    expTwoMulFixedNoReloadInvariants_succ_of_decideBranchResult
+      hk hBase hCursor hControl hC6 hInv
+  have hBranchEq :
+      expTwoMulFixedBranchResult
+          (decide ((e >>> (63 : BitVec 6).toNat) +
+            signExtend12 (0 : BitVec 12) ≠ 0))
+          a0 a1 a2 a3 r0 r1 r2 r3 = rw := by
+    dsimp [rw]
+    exact expTwoMulFixedBranchResult_decide_highBit_eq_condRw_of_ne_zero
+      hBitNe
+  have h_acc :
+      expTwoMulFixedAccumulatorInvariant baseWord exponentWord (k + 1)
+        (rw.getLimbN 0) (rw.getLimbN 1) (rw.getLimbN 2)
+        (rw.getLimbN 3) := by
+    rw [← hBranchEq]
+    exact hStep.1
+  have h_cursor :
+      expTwoMulFixedCursorInvariant exponentWord (k + 1)
+        (e <<< (1 : BitVec 6).toNat) :=
+    hStep.2.1
+  have h_control :
+      expTwoMulFixedControlInvariant exponentWord (k + 1)
+        (c6 + signExtend12 (-1 : BitVec 12)) ptr nextLimb evmSp :=
+    hStep.2.2
+  have hPre :
+      ((expTwoMulFixedIterPre
+        (e <<< (1 : BitVec 6).toNat)
+        v6
+        (expTwoMulIterCountNew iterCount)
+        v10
+        ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+        ptr nextLimb sp evmSp
+        (rw.getLimbN 3)
+        (((base + 44) + 140) + 68)
+        (rw.getLimbN 0) (rw.getLimbN 1) (rw.getLimbN 2) (rw.getLimbN 3)
+        d0 d1 d2 d3
+        (rw.getLimbN 0) (rw.getLimbN 1) (rw.getLimbN 2) (rw.getLimbN 3)
+        a0 a1 a2 a3 v7 v11) **
+        frame) ps := by
+    simpa [rw] using
+      (expTwoMulFixedIterSkipCondScratchFrame_to_iterPre_frame h)
+  rw [expTwoMulFixedIterPreNWithControlFrame_unfold,
+    expTwoMulFixedIterPreNWithControl_unfold,
+    expTwoMulFixedSemanticInvariant_unfold,
+    expTwoMulFixedCursorAssertion_unfold,
+    expTwoMulFixedControlAssertion_unfold]
+  rw [pure_assertion_eq_emp_of_true h_acc,
+    pure_assertion_eq_emp_of_true h_cursor,
+    pure_assertion_eq_emp_of_true h_control]
+  simp only [sepConj_emp_right']
+  sep_perm hPre
+
+theorem expTwoMulFixedIterSkipScratchFrame_to_iterPreNWithControl_frame
+    {baseWord exponentWord : EvmWord} {k : Nat}
+    {iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
+    {exitCond : Prop} {v6 v7 v10 v11 d0 d1 d2 d3 : Word}
+    {frame : Assertion} {ps : PartialState}
+    (hk : k < 256)
+    (hBase : baseWord = expResultWord a0 a1 a2 a3)
+    (hCursor : expTwoMulFixedCursorInvariant exponentWord k e)
+    (hControl :
+      expTwoMulFixedControlInvariant exponentWord k c6 ptr nextLimb evmSp)
+    (hInv :
+      expTwoMulFixedAccumulatorInvariant baseWord exponentWord k
+        r0 r1 r2 r3)
+    (h :
+      ((expTwoMulFixedIterSkipCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3 exitCond **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        (expTwoMulFixedIterSkipCountPostScratchSuffix e c6 evmSp
+          a0 a1 a2 a3 base **
+          expTwoMulFixedIterPointerFrame ptr nextLimb)) **
+        frame) ps) :
+    let squareW := expSquaringCallSquareW r0 r1 r2 r3
+    expTwoMulFixedIterPreNWithControlFrame (k + 1) baseWord exponentWord
+      (c6 + signExtend12 (-1 : BitVec 12))
+      (e <<< (1 : BitVec 6).toNat)
+      v6
+      (expTwoMulIterCountNew iterCount)
+      v10
+      ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+      ptr nextLimb sp evmSp
+      (squareW.getLimbN 3)
+      (((base + 44) + 32) + 68)
+      (squareW.getLimbN 0) (squareW.getLimbN 1)
+      (squareW.getLimbN 2) (squareW.getLimbN 3)
+      d0 d1 d2 d3
+      (squareW.getLimbN 0) (squareW.getLimbN 1)
+      (squareW.getLimbN 2) (squareW.getLimbN 3)
+      a0 a1 a2 a3 v7 v11
+      frame ps := by
+  intro squareW
+  obtain ⟨_hExit, hC6, hBitZero⟩ :=
+    expTwoMulFixedIterSkipScratchFrame_pures h
+  have hStep :=
+    expTwoMulFixedNoReloadInvariants_succ_of_decideBranchResult
+      hk hBase hCursor hControl hC6 hInv
+  have hBranchEq :
+      expTwoMulFixedBranchResult
+          (decide ((e >>> (63 : BitVec 6).toNat) +
+            signExtend12 (0 : BitVec 12) ≠ 0))
+          a0 a1 a2 a3 r0 r1 r2 r3 = squareW := by
+    dsimp [squareW]
+    exact expTwoMulFixedBranchResult_decide_highBit_eq_squareW_of_zero
+      hBitZero
+  have h_acc :
+      expTwoMulFixedAccumulatorInvariant baseWord exponentWord (k + 1)
+        (squareW.getLimbN 0) (squareW.getLimbN 1)
+        (squareW.getLimbN 2) (squareW.getLimbN 3) := by
+    rw [← hBranchEq]
+    exact hStep.1
+  have h_cursor :
+      expTwoMulFixedCursorInvariant exponentWord (k + 1)
+        (e <<< (1 : BitVec 6).toNat) :=
+    hStep.2.1
+  have h_control :
+      expTwoMulFixedControlInvariant exponentWord (k + 1)
+        (c6 + signExtend12 (-1 : BitVec 12)) ptr nextLimb evmSp :=
+    hStep.2.2
+  have hPre :
+      ((expTwoMulFixedIterPre
+        (e <<< (1 : BitVec 6).toNat)
+        v6
+        (expTwoMulIterCountNew iterCount)
+        v10
+        ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+        ptr nextLimb sp evmSp
+        (squareW.getLimbN 3)
+        (((base + 44) + 32) + 68)
+        (squareW.getLimbN 0) (squareW.getLimbN 1)
+        (squareW.getLimbN 2) (squareW.getLimbN 3)
+        d0 d1 d2 d3
+        (squareW.getLimbN 0) (squareW.getLimbN 1)
+        (squareW.getLimbN 2) (squareW.getLimbN 3)
+        a0 a1 a2 a3 v7 v11) **
+        frame) ps := by
+    simpa [squareW] using
+      (expTwoMulFixedIterSkipScratchFrame_to_iterPre_frame h)
+  rw [expTwoMulFixedIterPreNWithControlFrame_unfold,
+    expTwoMulFixedIterPreNWithControl_unfold,
     expTwoMulFixedSemanticInvariant_unfold,
     expTwoMulFixedCursorAssertion_unfold,
     expTwoMulFixedControlAssertion_unfold]

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedLoopInvariantWithControl.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedLoopInvariantWithControl.lean
@@ -1,0 +1,132 @@
+/-
+  EvmAsm.Evm64.Exp.Compose.SavedBitFixedLoopInvariantWithControl
+
+  Relaxed fixed-loop invariant preconditions that separate the semantic
+  control counter from the machine x6 scratch register.
+-/
+
+import EvmAsm.Evm64.Exp.Compose.SavedBitFixedLoopInvariant
+
+namespace EvmAsm.Evm64.Exp.Compose
+
+open EvmAsm.Rv64
+
+/-- Fixed iteration precondition indexed by the semantic iteration count, with
+    the semantic control counter separated from the machine `x6` value.
+
+The fixed EXP iteration calls the shared MUL routine, whose public contract
+leaves `x6` as scratch ownership. Induction over the loop still needs to carry
+the semantic bit-counter value, so this variant keeps that counter in the pure
+control assertion instead of requiring it to be the current machine `x6`
+register value. -/
+@[irreducible]
+def expTwoMulFixedIterPreNWithControl
+    (k : Nat) (baseWord exponentWord : EvmWord)
+    (controlC6 : Word)
+    (e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word) : Assertion :=
+  expTwoMulFixedIterPre e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp
+    tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3 v7 v11 **
+  expTwoMulFixedSemanticInvariant baseWord exponentWord k r0 r1 r2 r3 **
+  expTwoMulFixedCursorAssertion exponentWord k e **
+  expTwoMulFixedControlAssertion exponentWord k controlC6 ptr nextLimb evmSp
+
+theorem expTwoMulFixedIterPreNWithControl_unfold
+    {k : Nat} {baseWord exponentWord : EvmWord} {controlC6 : Word}
+    {e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word} :
+    expTwoMulFixedIterPreNWithControl k baseWord exponentWord controlC6
+      e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3 v7 v11 =
+      (expTwoMulFixedIterPre e machineC6 iterCount v10 v18 ptr nextLimb sp
+        evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+        v7 v11 **
+      expTwoMulFixedSemanticInvariant baseWord exponentWord k r0 r1 r2 r3 **
+      expTwoMulFixedCursorAssertion exponentWord k e **
+      expTwoMulFixedControlAssertion exponentWord k controlC6 ptr nextLimb
+        evmSp) := by
+  delta expTwoMulFixedIterPreNWithControl
+  rfl
+
+theorem expTwoMulFixedIterPreNWithControl_pcFree
+    {k : Nat} {baseWord exponentWord : EvmWord} {controlC6 : Word}
+    {e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word} :
+    (expTwoMulFixedIterPreNWithControl k baseWord exponentWord controlC6
+      e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3 v7 v11).pcFree := by
+  rw [expTwoMulFixedIterPreNWithControl_unfold]
+  pcFree
+
+instance pcFreeInst_expTwoMulFixedIterPreNWithControl
+    (k : Nat) (baseWord exponentWord : EvmWord) (controlC6 : Word)
+    (e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word) :
+    Assertion.PCFree
+      (expTwoMulFixedIterPreNWithControl k baseWord exponentWord controlC6
+        e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+        r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3 v7 v11) :=
+  ⟨expTwoMulFixedIterPreNWithControl_pcFree⟩
+
+/-- Framed version of `expTwoMulFixedIterPreNWithControl`. -/
+@[irreducible]
+def expTwoMulFixedIterPreNWithControlFrame
+    (k : Nat) (baseWord exponentWord : EvmWord)
+    (controlC6 : Word)
+    (e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word)
+    (frame : Assertion) : Assertion :=
+  expTwoMulFixedIterPreNWithControl k baseWord exponentWord controlC6
+    e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+    r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3 v7 v11 **
+  frame
+
+theorem expTwoMulFixedIterPreNWithControlFrame_unfold
+    {k : Nat} {baseWord exponentWord : EvmWord} {controlC6 : Word}
+    {e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word}
+    {frame : Assertion} :
+    expTwoMulFixedIterPreNWithControlFrame k baseWord exponentWord controlC6
+      e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3 v7 v11
+      frame =
+      (expTwoMulFixedIterPreNWithControl k baseWord exponentWord controlC6
+        e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+        r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3 v7 v11 **
+       frame) := by
+  delta expTwoMulFixedIterPreNWithControlFrame
+  rfl
+
+theorem expTwoMulFixedIterPreNWithControlFrame_pcFree
+    {k : Nat} {baseWord exponentWord : EvmWord} {controlC6 : Word}
+    {e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word}
+    {frame : Assertion} [Assertion.PCFree frame] :
+    (expTwoMulFixedIterPreNWithControlFrame k baseWord exponentWord controlC6
+      e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3 v7 v11
+      frame).pcFree := by
+  rw [expTwoMulFixedIterPreNWithControlFrame_unfold]
+  pcFree
+
+instance pcFreeInst_expTwoMulFixedIterPreNWithControlFrame
+    (k : Nat) (baseWord exponentWord : EvmWord) (controlC6 : Word)
+    (e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word)
+    (frame : Assertion) [Assertion.PCFree frame] :
+    Assertion.PCFree
+      (expTwoMulFixedIterPreNWithControlFrame k baseWord exponentWord controlC6
+        e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+        r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3 v7 v11
+        frame) :=
+  ⟨expTwoMulFixedIterPreNWithControlFrame_pcFree⟩
+
+end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- add a relaxed fixed-loop precondition family that separates the semantic control counter from the machine x6 scratch register
- add no-reload post adapters for both fixed branch outcomes targeting the relaxed induction precondition
- split the relaxed invariant family into a small Compose module to keep file-size hygiene green

## Verification
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedLoopInvariant
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterPreNPost
- lake build EvmAsm.Evm64.Exp
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- lake build