### PR TITLE
feat(exp): lift fixed loop case posts to relaxed pren

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterPreNPost.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterPreNPost.lean
@@ -410,4 +410,93 @@ theorem expTwoMulFixedIterSkipScratchFrame_to_iterPreNWithControl_frame
   simp only [sepConj_emp_right']
   sep_perm hPre
 
+theorem expTwoMulFixedIterCaseLoopPost_iterPreNWithControl_or_reloadPointerFrame
+    {baseWord exponentWord : EvmWord} {k : Nat}
+    {iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
+    {frame : Assertion} {ps : PartialState}
+    (hk : k < 256)
+    (hBase : baseWord = expResultWord a0 a1 a2 a3)
+    (hCursor : expTwoMulFixedCursorInvariant exponentWord k e)
+    (hControl :
+      expTwoMulFixedControlInvariant exponentWord k c6 ptr nextLimb evmSp)
+    (hInv :
+      expTwoMulFixedAccumulatorInvariant baseWord exponentWord k
+        r0 r1 r2 r3)
+    (h :
+      (expTwoMulFixedIterCaseLoopPost iterCount e c6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base **
+        frame) ps) :
+    (∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      let rw := expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3)
+        a0 a1 a2 a3
+      expTwoMulFixedIterPreNWithControlFrame (k + 1) baseWord exponentWord
+        (c6 + signExtend12 (-1 : BitVec 12))
+        (e <<< (1 : BitVec 6).toNat)
+        v6
+        (expTwoMulIterCountNew iterCount)
+        v10
+        ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+        ptr nextLimb sp evmSp
+        (rw.getLimbN 3)
+        (((base + 44) + 140) + 68)
+        (rw.getLimbN 0) (rw.getLimbN 1) (rw.getLimbN 2)
+        (rw.getLimbN 3)
+        d0 d1 d2 d3
+        (rw.getLimbN 0) (rw.getLimbN 1) (rw.getLimbN 2)
+        (rw.getLimbN 3)
+        a0 a1 a2 a3 v7 v11
+        frame ps) ∨
+    (∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      let squareW := expSquaringCallSquareW r0 r1 r2 r3
+      expTwoMulFixedIterPreNWithControlFrame (k + 1) baseWord exponentWord
+        (c6 + signExtend12 (-1 : BitVec 12))
+        (e <<< (1 : BitVec 6).toNat)
+        v6
+        (expTwoMulIterCountNew iterCount)
+        v10
+        ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+        ptr nextLimb sp evmSp
+        (squareW.getLimbN 3)
+        (((base + 44) + 32) + 68)
+        (squareW.getLimbN 0) (squareW.getLimbN 1)
+        (squareW.getLimbN 2) (squareW.getLimbN 3)
+        d0 d1 d2 d3
+        (squareW.getLimbN 0) (squareW.getLimbN 1)
+        (squareW.getLimbN 2) (squareW.getLimbN 3)
+        a0 a1 a2 a3 v7 v11
+        frame ps) ∨
+    (∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      ((expTwoMulFixedIterSkipCondCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3
+        (expTwoMulIterCountNew iterCount ≠ 0) **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        expTwoMulFixedIterReloadCondCountPostScratchSuffixFrame
+          e c6 ptr nextLimb base) **
+        frame) ps) ∨
+    (∃ v6 v7 v10 v11 d0 d1 d2 d3,
+      ((expTwoMulFixedIterSkipCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3
+        (expTwoMulIterCountNew iterCount ≠ 0) **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        expTwoMulFixedIterReloadSkipCountPostScratchSuffixFrame
+          e c6 ptr nextLimb evmSp a0 a1 a2 a3 base) **
+        frame) ps) := by
+  rcases expTwoMulFixedIterCaseLoopPost_scratch_cases_reloadPointerFrame h with
+    hSkipCond | hRest
+  · rcases hSkipCond with ⟨v6, v7, v10, v11, d0, d1, d2, d3, hScratch⟩
+    exact Or.inl
+      ⟨v6, v7, v10, v11, d0, d1, d2, d3,
+        expTwoMulFixedIterSkipCondScratchFrame_to_iterPreNWithControl_frame
+          hk hBase hCursor hControl hInv hScratch⟩
+  · rcases hRest with hSkip | hRest
+    · rcases hSkip with ⟨v6, v7, v10, v11, d0, d1, d2, d3, hScratch⟩
+      exact Or.inr (Or.inl
+        ⟨v6, v7, v10, v11, d0, d1, d2, d3,
+          expTwoMulFixedIterSkipScratchFrame_to_iterPreNWithControl_frame
+            hk hBase hCursor hControl hInv hScratch⟩)
+    · rcases hRest with hReloadCond | hReloadSkip
+      · exact Or.inr (Or.inr (Or.inl hReloadCond))
+      · exact Or.inr (Or.inr (Or.inr hReloadSkip))
+
 end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- add a loop-post case adapter that advances non-reload fixed EXP cases into expTwoMulFixedIterPreNWithControlFrame
- keep reload-pointer cases explicit for the next reload induction slice
- reuse the Bool/semantic invariant bridge and relaxed control counter from the existing no-reload adapters

## Verification
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterPreNPost
- lake build EvmAsm.Evm64.Exp
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build