### PR TITLE
feat(exp): bool-index fixed reload handoff

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterPreNPost.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterPreNPost.lean
@@ -36,6 +36,101 @@ theorem expTwoMulFixedBranchReturnPc_true (base : Word) :
     expTwoMulFixedBranchReturnPc true base = (((base + 44) + 140) + 68) := by
   rfl
 
+@[irreducible]
+def expTwoMulFixedReloadBranchResidualWithControlFrame
+    (bit : Bool) (k : Nat) (baseWord exponentWord : EvmWord)
+    (iterCount e c6 ptr nextLimb nextNextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base
+      v6 v7 v10 v11 d0 d1 d2 d3 : Word)
+    (frame : Assertion) : Assertion :=
+  if bit then
+    let outW := expTwoMulFixedBranchResult true
+      a0 a1 a2 a3 r0 r1 r2 r3
+    (((((expTwoMulFixedIterSkipCondCountPostScratchPrefix iterCount sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3
+      (expTwoMulIterCountNew iterCount ≠ 0) **
+      expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+      expTwoMulFixedIterReloadCondCountPostScratchSuffixFrame
+        e c6 ptr nextLimb base) **
+      expTwoMulFixedSemanticInvariant baseWord exponentWord (k + 1)
+        (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
+        (outW.getLimbN 3)) **
+      expTwoMulFixedCursorAssertion exponentWord (k + 1) nextLimb) **
+      expTwoMulFixedControlAssertion exponentWord (k + 1)
+        64 (ptr + signExtend12 (-8 : BitVec 12)) nextNextLimb evmSp) **
+      frame)
+  else
+    let outW := expTwoMulFixedBranchResult false
+      a0 a1 a2 a3 r0 r1 r2 r3
+    (((((expTwoMulFixedIterSkipCountPostScratchPrefix iterCount sp evmSp
+      r0 r1 r2 r3
+      (expTwoMulIterCountNew iterCount ≠ 0) **
+      expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+      expTwoMulFixedIterReloadSkipCountPostScratchSuffixFrame
+        e c6 ptr nextLimb evmSp a0 a1 a2 a3 base) **
+      expTwoMulFixedSemanticInvariant baseWord exponentWord (k + 1)
+        (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
+        (outW.getLimbN 3)) **
+      expTwoMulFixedCursorAssertion exponentWord (k + 1) nextLimb) **
+      expTwoMulFixedControlAssertion exponentWord (k + 1)
+        64 (ptr + signExtend12 (-8 : BitVec 12)) nextNextLimb evmSp) **
+      frame)
+
+theorem expTwoMulFixedReloadBranchResidualWithControlFrame_false
+    {k : Nat} {baseWord exponentWord : EvmWord}
+    {iterCount e c6 ptr nextLimb nextNextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base
+      v6 v7 v10 v11 d0 d1 d2 d3 : Word}
+    {frame : Assertion} :
+    expTwoMulFixedReloadBranchResidualWithControlFrame false k
+      baseWord exponentWord iterCount e c6 ptr nextLimb nextNextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base v6 v7 v10 v11 d0 d1 d2 d3
+      frame =
+      (let squareW := expSquaringCallSquareW r0 r1 r2 r3
+      (((((expTwoMulFixedIterSkipCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3
+        (expTwoMulIterCountNew iterCount ≠ 0) **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        expTwoMulFixedIterReloadSkipCountPostScratchSuffixFrame
+          e c6 ptr nextLimb evmSp a0 a1 a2 a3 base) **
+        expTwoMulFixedSemanticInvariant baseWord exponentWord (k + 1)
+          (squareW.getLimbN 0) (squareW.getLimbN 1)
+          (squareW.getLimbN 2) (squareW.getLimbN 3)) **
+        expTwoMulFixedCursorAssertion exponentWord (k + 1) nextLimb) **
+        expTwoMulFixedControlAssertion exponentWord (k + 1)
+          64 (ptr + signExtend12 (-8 : BitVec 12)) nextNextLimb evmSp) **
+        frame)) := by
+  rw [expTwoMulFixedReloadBranchResidualWithControlFrame]
+  rfl
+
+theorem expTwoMulFixedReloadBranchResidualWithControlFrame_true
+    {k : Nat} {baseWord exponentWord : EvmWord}
+    {iterCount e c6 ptr nextLimb nextNextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base
+      v6 v7 v10 v11 d0 d1 d2 d3 : Word}
+    {frame : Assertion} :
+    expTwoMulFixedReloadBranchResidualWithControlFrame true k
+      baseWord exponentWord iterCount e c6 ptr nextLimb nextNextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base v6 v7 v10 v11 d0 d1 d2 d3
+      frame =
+      (let rw := expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3)
+        a0 a1 a2 a3
+      (((((expTwoMulFixedIterSkipCondCountPostScratchPrefix iterCount sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3
+        (expTwoMulIterCountNew iterCount ≠ 0) **
+        expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+        expTwoMulFixedIterReloadCondCountPostScratchSuffixFrame
+          e c6 ptr nextLimb base) **
+        expTwoMulFixedSemanticInvariant baseWord exponentWord (k + 1)
+          (rw.getLimbN 0) (rw.getLimbN 1) (rw.getLimbN 2)
+          (rw.getLimbN 3)) **
+        expTwoMulFixedCursorAssertion exponentWord (k + 1) nextLimb) **
+        expTwoMulFixedControlAssertion exponentWord (k + 1)
+          64 (ptr + signExtend12 (-8 : BitVec 12)) nextNextLimb evmSp) **
+        frame)) := by
+  rw [expTwoMulFixedReloadBranchResidualWithControlFrame]
+  rfl
+
 theorem expTwoMulFixedIterSkipCondScratchFrame_to_iterPreN_frame
     {baseWord exponentWord : EvmWord} {k : Nat}
     {iterCount e c6 ptr nextLimb sp evmSp
@@ -835,5 +930,68 @@ theorem expTwoMulFixedIterCaseLoopPost_branchPreNWithControl_or_reloadWithContro
           simpa [expTwoMulFixedBranchResult_false,
             expTwoMulFixedBranchReturnPc_false] using hPre⟩
     · exact Or.inr hRest
+
+theorem expTwoMulFixedIterCaseLoopPost_branchPreNWithControl_or_branchReloadWithControlFrame
+    {baseWord exponentWord : EvmWord} {k : Nat}
+    {iterCount e c6 ptr nextLimb nextNextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
+    {frame : Assertion} {ps : PartialState}
+    (hk : k < 256)
+    (hBase : baseWord = expResultWord a0 a1 a2 a3)
+    (hCursor : expTwoMulFixedCursorInvariant exponentWord k e)
+    (hControl :
+      expTwoMulFixedControlInvariant exponentWord k c6 ptr nextLimb evmSp)
+    (hNextNext :
+      nextNextLimb = exponentWord.getLimbN (2 - (k + 1) / 64))
+    (hInv :
+      expTwoMulFixedAccumulatorInvariant baseWord exponentWord k
+        r0 r1 r2 r3)
+    (h :
+      (expTwoMulFixedIterCaseLoopPost iterCount e c6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base **
+        frame) ps) :
+    (∃ bit v6 v7 v10 v11 d0 d1 d2 d3,
+      let outW := expTwoMulFixedBranchResult bit
+        a0 a1 a2 a3 r0 r1 r2 r3
+      expTwoMulFixedIterPreNWithControlFrame (k + 1) baseWord exponentWord
+        (c6 + signExtend12 (-1 : BitVec 12))
+        (e <<< (1 : BitVec 6).toNat)
+        v6
+        (expTwoMulIterCountNew iterCount)
+        v10
+        ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+        ptr nextLimb sp evmSp
+        (outW.getLimbN 3)
+        (expTwoMulFixedBranchReturnPc bit base)
+        (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
+        (outW.getLimbN 3)
+        d0 d1 d2 d3
+        (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
+        (outW.getLimbN 3)
+        a0 a1 a2 a3 v7 v11
+        frame ps) ∨
+    (∃ bit v6 v7 v10 v11 d0 d1 d2 d3,
+      expTwoMulFixedReloadBranchResidualWithControlFrame bit (k := k)
+        baseWord exponentWord iterCount e c6 ptr nextLimb nextNextLimb
+        sp evmSp r0 r1 r2 r3 a0 a1 a2 a3 base
+        v6 v7 v10 v11 d0 d1 d2 d3 frame ps) := by
+  rcases
+      expTwoMulFixedIterCaseLoopPost_branchPreNWithControl_or_reloadWithControlFrame
+        hk hBase hCursor hControl hNextNext hInv h with
+    hPre | hReload
+  · exact Or.inl hPre
+  · rcases hReload with hReloadCond | hReloadSkip
+    · rcases hReloadCond with
+        ⟨v6, v7, v10, v11, d0, d1, d2, d3, hResidual⟩
+      exact Or.inr
+        ⟨true, v6, v7, v10, v11, d0, d1, d2, d3, by
+          simpa [expTwoMulFixedReloadBranchResidualWithControlFrame_true]
+            using hResidual⟩
+    · rcases hReloadSkip with
+        ⟨v6, v7, v10, v11, d0, d1, d2, d3, hResidual⟩
+      exact Or.inr
+        ⟨false, v6, v7, v10, v11, d0, d1, d2, d3, by
+          simpa [expTwoMulFixedReloadBranchResidualWithControlFrame_false]
+            using hResidual⟩
 
 end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- add a Bool-indexed assertion for fixed-loop reload residuals carrying k+1 semantic/cursor/control invariants
- add unfold lemmas for the true/false reload residual shapes
- add a handoff theorem that collapses reload cond/skip alternatives into one bit-indexed residual, complementing the Bool-indexed non-reload handoff from #4887

## Checks
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterPreNPost
- lake build EvmAsm.Evm64.Exp
- scripts/check-unimported.sh
- scripts/check-file-size.sh
- git diff --check
- lake build

Stacked on #4887.