### PR TITLE
feat(exp): add fixed step post constructors

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStepPost.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStepPost.lean
@@ -167,6 +167,92 @@ instance pcFreeInst_expTwoMulFixedIterStepPostNWithControlFrame
         r0 r1 r2 r3 a0 a1 a2 a3 base frame) :=
   ⟨expTwoMulFixedIterStepPostNWithControlFrame_pcFree⟩
 
+theorem expTwoMulFixedIterStepPostNWithControlFrame_branch
+    {baseWord exponentWord : EvmWord} {k : Nat}
+    {iterCount e c6 ptr nextLimb nextNextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
+    {frame : Assertion} {ps : PartialState}
+    (bit : Bool) {v6 v7 v10 v11 d0 d1 d2 d3 : Word}
+    (h :
+      let outW := expTwoMulFixedBranchResult bit
+        a0 a1 a2 a3 r0 r1 r2 r3
+      expTwoMulFixedIterPreNWithControlFrame (k + 1) baseWord exponentWord
+        (c6 + signExtend12 (-1 : BitVec 12))
+        (e <<< (1 : BitVec 6).toNat)
+        v6
+        (expTwoMulIterCountNew iterCount)
+        v10
+        ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+        ptr nextLimb sp evmSp
+        (outW.getLimbN 3)
+        (expTwoMulFixedBranchReturnPc bit base)
+        (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
+        (outW.getLimbN 3)
+        d0 d1 d2 d3
+        (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
+        (outW.getLimbN 3)
+        a0 a1 a2 a3 v7 v11
+        frame ps) :
+    expTwoMulFixedIterStepPostNWithControlFrame k baseWord exponentWord
+      iterCount e c6 ptr nextLimb nextNextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base frame ps := by
+  rw [expTwoMulFixedIterStepPostNWithControlFrame_unfold]
+  exact Or.inl ⟨bit, v6, v7, v10, v11, d0, d1, d2, d3, h⟩
+
+theorem expTwoMulFixedIterStepPostNWithControlFrame_reload
+    {baseWord exponentWord : EvmWord} {k : Nat}
+    {iterCount e c6 ptr nextLimb nextNextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
+    {frame : Assertion} {ps : PartialState}
+    (bit : Bool) {v6 v7 v10 v11 d0 d1 d2 d3 : Word}
+    (h :
+      expTwoMulFixedReloadBranchResidualWithControlFrame bit (k := k)
+        baseWord exponentWord iterCount e c6 ptr nextLimb nextNextLimb
+        sp evmSp r0 r1 r2 r3 a0 a1 a2 a3 base
+        v6 v7 v10 v11 d0 d1 d2 d3 frame ps) :
+    expTwoMulFixedIterStepPostNWithControlFrame k baseWord exponentWord
+      iterCount e c6 ptr nextLimb nextNextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base frame ps := by
+  rw [expTwoMulFixedIterStepPostNWithControlFrame_unfold]
+  exact Or.inr ⟨bit, v6, v7, v10, v11, d0, d1, d2, d3, h⟩
+
+theorem expTwoMulFixedIterStepPostNWithControlFrame_cases
+    {baseWord exponentWord : EvmWord} {k : Nat}
+    {iterCount e c6 ptr nextLimb nextNextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
+    {frame : Assertion} {ps : PartialState}
+    (h :
+      expTwoMulFixedIterStepPostNWithControlFrame k baseWord exponentWord
+        iterCount e c6 ptr nextLimb nextNextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base frame ps) :
+    (∃ bit v6 v7 v10 v11 d0 d1 d2 d3,
+      let outW := expTwoMulFixedBranchResult bit
+        a0 a1 a2 a3 r0 r1 r2 r3
+      expTwoMulFixedIterPreNWithControlFrame (k + 1) baseWord exponentWord
+        (c6 + signExtend12 (-1 : BitVec 12))
+        (e <<< (1 : BitVec 6).toNat)
+        v6
+        (expTwoMulIterCountNew iterCount)
+        v10
+        ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+        ptr nextLimb sp evmSp
+        (outW.getLimbN 3)
+        (expTwoMulFixedBranchReturnPc bit base)
+        (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
+        (outW.getLimbN 3)
+        d0 d1 d2 d3
+        (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
+        (outW.getLimbN 3)
+        a0 a1 a2 a3 v7 v11
+        frame ps) ∨
+    (∃ bit v6 v7 v10 v11 d0 d1 d2 d3,
+      expTwoMulFixedReloadBranchResidualWithControlFrame bit (k := k)
+        baseWord exponentWord iterCount e c6 ptr nextLimb nextNextLimb
+        sp evmSp r0 r1 r2 r3 a0 a1 a2 a3 base
+        v6 v7 v10 v11 d0 d1 d2 d3 frame ps) := by
+  rw [expTwoMulFixedIterStepPostNWithControlFrame_unfold] at h
+  exact h
+
 theorem expTwoMulFixedIterCaseLoopPost_to_stepPostNWithControlFrame
     {baseWord exponentWord : EvmWord} {k : Nat}
     {iterCount e c6 ptr nextLimb nextNextLimb sp evmSp


### PR DESCRIPTION
## Summary
- add constructor lemmas for the Bool-indexed branch and reload alternatives of expTwoMulFixedIterStepPostNWithControlFrame
- add a cases theorem so downstream induction proofs can consume the named step-post target without unfolding the large assertion manually

## Checks
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterStepPost
- lake build EvmAsm.Evm64.Exp
- scripts/check-unimported.sh
- scripts/check-file-size.sh
- git diff --check
- lake build

Rebased onto main after #4892 merged.