### PR TITLE
feat(exp): expose fixed reload residual pures

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStep.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStep.lean
@@ -134,4 +134,72 @@ theorem cpsTripleWithin_expTwoMulFixedIterPre_seq_stepPostNWithControl
       hNextNext hInv)
     hStepPost
 
+theorem cpsTripleWithin_expTwoMulFixedIterPre_stepPostNWithControl_elim
+    {baseWord exponentWord : EvmWord} {k : Nat}
+    {nSteps : Nat} {exit : Word} {Q : Assertion}
+    (e c6 iterCount v10 v18 ptr nextLimb nextNextLimb sp evmSp
+      tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+      a0 a1 a2 a3 v7 v11 : Word)
+    (base : Word)
+    (hbase : (base + 44 : Word) &&& 1 = 0)
+    (hne : expTwoMulIterCountNew iterCount ≠ 0)
+    (hk : k < 256)
+    (hBase : baseWord = expResultWord a0 a1 a2 a3)
+    (hCursor : expTwoMulFixedCursorInvariant exponentWord k e)
+    (hControl :
+      expTwoMulFixedControlInvariant exponentWord k c6 ptr nextLimb evmSp)
+    (hNextNext :
+      nextNextLimb = exponentWord.getLimbN (2 - (k + 1) / 64))
+    (hInv :
+      expTwoMulFixedAccumulatorInvariant baseWord exponentWord k
+        r0 r1 r2 r3)
+    (hBranch :
+      ∀ (bit : Bool)
+        (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        cpsTripleWithin nSteps (base + 44) exit
+          (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+          (let outW := expTwoMulFixedBranchResult bit
+            a0 a1 a2 a3 r0 r1 r2 r3
+          expTwoMulFixedIterPreNWithControlFrame (k + 1) baseWord exponentWord
+            (c6 + signExtend12 (-1 : BitVec 12))
+            (e <<< (1 : BitVec 6).toNat)
+            v6'
+            (expTwoMulIterCountNew iterCount)
+            v10'
+            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+            ptr nextLimb sp evmSp
+            (outW.getLimbN 3)
+            (expTwoMulFixedBranchReturnPc bit base)
+            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
+            (outW.getLimbN 3)
+            d0' d1' d2' d3'
+            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
+            (outW.getLimbN 3)
+            a0 a1 a2 a3 v7' v11'
+            empAssertion)
+          Q)
+    (hReload :
+      ∀ (bit : Bool)
+        (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        cpsTripleWithin nSteps (base + 44) exit
+          (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+          (expTwoMulFixedReloadBranchResidualWithControlFrame bit (k := k)
+            baseWord exponentWord iterCount e c6 ptr nextLimb nextNextLimb
+            sp evmSp r0 r1 r2 r3 a0 a1 a2 a3 base
+            v6' v7' v10' v11' d0' d1' d2' d3' empAssertion)
+          Q) :
+    cpsTripleWithin (193 + nSteps) (base + 44) exit
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterPre e c6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+        a0 a1 a2 a3 v7 v11)
+      Q :=
+  cpsTripleWithin_expTwoMulFixedIterPre_seq_stepPostNWithControl
+    e c6 iterCount v10 v18 ptr nextLimb nextNextLimb sp evmSp
+    tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+    a0 a1 a2 a3 v7 v11 base hbase hne hk hBase hCursor hControl
+    hNextNext hInv
+    (cpsTripleWithin_expTwoMulFixedIterStepPostNWithControlFrame_elim
+      hBranch hReload)
+
 end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStep.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStep.lean
@@ -94,4 +94,44 @@ theorem cpsTripleWithin_expTwoMulFixedIterPre_to_stepPostNWithControl
         exact hExit)
   simpa [Nat.add_zero] using hMerged
 
+theorem cpsTripleWithin_expTwoMulFixedIterPre_seq_stepPostNWithControl
+    {baseWord exponentWord : EvmWord} {k : Nat}
+    {nSteps : Nat} {exit : Word} {Q : Assertion}
+    (e c6 iterCount v10 v18 ptr nextLimb nextNextLimb sp evmSp
+      tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+      a0 a1 a2 a3 v7 v11 : Word)
+    (base : Word)
+    (hbase : (base + 44 : Word) &&& 1 = 0)
+    (hne : expTwoMulIterCountNew iterCount ≠ 0)
+    (hk : k < 256)
+    (hBase : baseWord = expResultWord a0 a1 a2 a3)
+    (hCursor : expTwoMulFixedCursorInvariant exponentWord k e)
+    (hControl :
+      expTwoMulFixedControlInvariant exponentWord k c6 ptr nextLimb evmSp)
+    (hNextNext :
+      nextNextLimb = exponentWord.getLimbN (2 - (k + 1) / 64))
+    (hInv :
+      expTwoMulFixedAccumulatorInvariant baseWord exponentWord k
+        r0 r1 r2 r3)
+    (hStepPost :
+      cpsTripleWithin nSteps (base + 44) exit
+        (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+        (expTwoMulFixedIterStepPostNWithControlFrame k baseWord exponentWord
+          iterCount e c6 ptr nextLimb nextNextLimb sp evmSp
+          r0 r1 r2 r3 a0 a1 a2 a3 base empAssertion)
+        Q) :
+    cpsTripleWithin (193 + nSteps) (base + 44) exit
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterPre e c6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+        a0 a1 a2 a3 v7 v11)
+      Q :=
+  cpsTripleWithin_seq_same_cr
+    (cpsTripleWithin_expTwoMulFixedIterPre_to_stepPostNWithControl
+      e c6 iterCount v10 v18 ptr nextLimb nextNextLimb sp evmSp
+      tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+      a0 a1 a2 a3 v7 v11 base hbase hne hk hBase hCursor hControl
+      hNextNext hInv)
+    hStepPost
+
 end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStepPost.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStepPost.lean
@@ -336,6 +336,72 @@ theorem expTwoMulFixedIterStepPostNWithControlFrame_reload_false
   apply expTwoMulFixedIterStepPostNWithControlFrame_reload (bit := false)
   simpa [expTwoMulFixedReloadBranchResidualWithControlFrame_false] using h
 
+theorem expTwoMulFixedReloadBranchResidualWithControlFrame_pures
+    {baseWord exponentWord : EvmWord} {k : Nat}
+    {iterCount e c6 ptr nextLimb nextNextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
+    {frame : Assertion} {ps : PartialState}
+    (bit : Bool) {v6 v7 v10 v11 d0 d1 d2 d3 : Word}
+    (h :
+      expTwoMulFixedReloadBranchResidualWithControlFrame bit (k := k)
+        baseWord exponentWord iterCount e c6 ptr nextLimb nextNextLimb
+        sp evmSp r0 r1 r2 r3 a0 a1 a2 a3 base
+        v6 v7 v10 v11 d0 d1 d2 d3 frame ps) :
+    expTwoMulIterCountNew iterCount ≠ 0 ∧
+    c6 + signExtend12 (-1 : BitVec 12) = 0 ∧
+    ((bit = true ∧
+        (e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12) ≠ 0) ∨
+      (bit = false ∧
+        (e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12) = 0)) := by
+  cases bit
+  · rw [expTwoMulFixedReloadBranchResidualWithControlFrame_false] at h
+    obtain ⟨psControl, _psFrame, _hDisjointControl, _hUnionControl,
+      hControlFrame, _hFrame⟩ := h
+    obtain ⟨psCursor, _psControl, _hDisjointCursor, _hUnionCursor,
+      hCursorFrame, _hControl⟩ := hControlFrame
+    obtain ⟨psSemantic, _psCursor, _hDisjointSemantic, _hUnionSemantic,
+      hSemanticFrame, _hCursor⟩ := hCursorFrame
+    obtain ⟨psScratch, _psSemantic, _hDisjointScratch, _hUnionScratch,
+      hScratch, _hSemantic⟩ := hSemanticFrame
+    have hScratchFrame :
+        (let squareW := expSquaringCallSquareW r0 r1 r2 r3
+        ((expTwoMulFixedIterSkipCountPostScratchPrefix iterCount sp evmSp
+          r0 r1 r2 r3
+          (expTwoMulIterCountNew iterCount ≠ 0) **
+          expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+          expTwoMulFixedIterReloadSkipCountPostScratchSuffixFrame
+            e c6 ptr nextLimb evmSp a0 a1 a2 a3 base) **
+          empAssertion) psScratch) := by
+      simpa [sepConj_emp_right'] using hScratch
+    have h_pures :=
+      expTwoMulFixedIterReloadSkipPointerScratchFrame_pures hScratchFrame
+    rcases h_pures with ⟨h_exit, h_c6, h_bit⟩
+    exact ⟨h_exit, h_c6, Or.inr ⟨rfl, h_bit⟩⟩
+  · rw [expTwoMulFixedReloadBranchResidualWithControlFrame_true] at h
+    obtain ⟨psControl, _psFrame, _hDisjointControl, _hUnionControl,
+      hControlFrame, _hFrame⟩ := h
+    obtain ⟨psCursor, _psControl, _hDisjointCursor, _hUnionCursor,
+      hCursorFrame, _hControl⟩ := hControlFrame
+    obtain ⟨psSemantic, _psCursor, _hDisjointSemantic, _hUnionSemantic,
+      hSemanticFrame, _hCursor⟩ := hCursorFrame
+    obtain ⟨psScratch, _psSemantic, _hDisjointScratch, _hUnionScratch,
+      hScratch, _hSemantic⟩ := hSemanticFrame
+    have hScratchFrame :
+        (let rw := expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3)
+          a0 a1 a2 a3
+        ((expTwoMulFixedIterSkipCondCountPostScratchPrefix iterCount sp evmSp
+          r0 r1 r2 r3 a0 a1 a2 a3
+          (expTwoMulIterCountNew iterCount ≠ 0) **
+          expTwoMulFixedIterScratchIs evmSp v6 v7 v10 v11 d0 d1 d2 d3 **
+          expTwoMulFixedIterReloadCondCountPostScratchSuffixFrame
+            e c6 ptr nextLimb base) **
+          empAssertion) psScratch) := by
+      simpa [sepConj_emp_right'] using hScratch
+    have h_pures :=
+      expTwoMulFixedIterReloadCondPointerScratchFrame_pures hScratchFrame
+    rcases h_pures with ⟨h_exit, h_c6, h_bit⟩
+    exact ⟨h_exit, h_c6, Or.inl ⟨rfl, h_bit⟩⟩
+
 theorem expTwoMulFixedIterStepPostNWithControlFrame_cases
     {baseWord exponentWord : EvmWord} {k : Nat}
     {iterCount e c6 ptr nextLimb nextNextLimb sp evmSp


### PR DESCRIPTION
## Summary
- add a Bool-indexed pure extractor for expTwoMulFixedReloadBranchResidualWithControlFrame
- expose the nonzero count, exhausted x6/control counter, and high-bit true/false fact needed to discharge reload continuations in the induction path

## Tests
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterStepPost
- lake build EvmAsm.Evm64.Exp
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh