### PR TITLE
feat(exp): expose fixed pren control extractors

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedLoopInvariantWithControl.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedLoopInvariantWithControl.lean
@@ -129,4 +129,72 @@ instance pcFreeInst_expTwoMulFixedIterPreNWithControlFrame
         frame) :=
   ⟨expTwoMulFixedIterPreNWithControlFrame_pcFree⟩
 
+private theorem pure_assertion_eq_emp_of_true {p : Prop} (hp : p) :
+    (⌜p⌝ : Assertion) = empAssertion := by
+  rw [← pure_true_eq_emp]
+  funext ps
+  apply propext
+  constructor
+  · intro h
+    exact ⟨h.1, trivial⟩
+  · intro h
+    exact ⟨h.1, hp⟩
+
+theorem expTwoMulFixedIterPreNWithControlFrame_pures
+    {k : Nat} {baseWord exponentWord : EvmWord} {controlC6 : Word}
+    {e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word}
+    {frame : Assertion} {ps : PartialState}
+    (h :
+      expTwoMulFixedIterPreNWithControlFrame k baseWord exponentWord
+        controlC6 e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+        a0 a1 a2 a3 v7 v11 frame ps) :
+    expTwoMulFixedAccumulatorInvariant baseWord exponentWord k r0 r1 r2 r3 ∧
+    expTwoMulFixedCursorInvariant exponentWord k e ∧
+    expTwoMulFixedControlInvariant exponentWord k controlC6 ptr nextLimb evmSp := by
+  rw [expTwoMulFixedIterPreNWithControlFrame_unfold,
+    expTwoMulFixedIterPreNWithControl_unfold,
+    expTwoMulFixedSemanticInvariant_unfold,
+    expTwoMulFixedCursorAssertion_unfold,
+    expTwoMulFixedControlAssertion_unfold] at h
+  obtain ⟨psCore, _psFrame, _hDisjointCore, _hUnionCore,
+    hCore, _hFrame⟩ := h
+  obtain ⟨_psIter, psSemanticCursorControl, _hDisjointIter, _hUnionIter,
+    _hIter, hSemanticCursorControl⟩ := hCore
+  obtain ⟨_psSemantic, psCursorControl, _hDisjointSemantic,
+    _hUnionSemantic, hSemantic, hCursorControl⟩ := hSemanticCursorControl
+  obtain ⟨_psCursor, _psControl, _hDisjointCursor, _hUnionCursor,
+    hCursor, hControl⟩ := hCursorControl
+  exact ⟨hSemantic.2, hCursor.2, hControl.2⟩
+
+theorem expTwoMulFixedIterPreNWithControlFrame_to_iterPre_frame
+    {k : Nat} {baseWord exponentWord : EvmWord} {controlC6 : Word}
+    {e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word}
+    {frame : Assertion} {ps : PartialState}
+    (h :
+      expTwoMulFixedIterPreNWithControlFrame k baseWord exponentWord
+        controlC6 e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+        a0 a1 a2 a3 v7 v11 frame ps) :
+    (expTwoMulFixedIterPre e machineC6 iterCount v10 v18 ptr nextLimb
+      sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+      a0 a1 a2 a3 v7 v11 **
+      frame) ps := by
+  rcases expTwoMulFixedIterPreNWithControlFrame_pures h with
+    ⟨h_acc, h_cursor, h_control⟩
+  rw [expTwoMulFixedIterPreNWithControlFrame_unfold,
+    expTwoMulFixedIterPreNWithControl_unfold,
+    expTwoMulFixedSemanticInvariant_unfold,
+    expTwoMulFixedCursorAssertion_unfold,
+    expTwoMulFixedControlAssertion_unfold] at h
+  rw [pure_assertion_eq_emp_of_true h_acc,
+    pure_assertion_eq_emp_of_true h_cursor,
+    pure_assertion_eq_emp_of_true h_control] at h
+  simp only [sepConj_emp_right'] at h
+  exact h
+
 end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- add pures extractor for expTwoMulFixedIterPreNWithControlFrame
- add bridge from the parametric precondition to the physical expTwoMulFixedIterPre framed assertion
- prepare the k-to-k+1 induction theorem to call the physical one-step spec from the invariant-carrying precondition

## Tests
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedLoopInvariantWithControl
- lake build EvmAsm.Evm64.Exp
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh