### PR TITLE
feat(exp): bound fixed pren step post

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStep.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStep.lean
@@ -312,6 +312,74 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithFrame_seq_stepPost
       hNextNext)
     hStepPost
 
+theorem cpsTripleWithin_expTwoMulFixedIterPreNWithFrame_to_stepPost_bounded
+    {baseWord exponentWord : EvmWord} {k : Nat}
+    {nBound : Nat}
+    (e c6 iterCount v10 v18 ptr nextLimb nextNextLimb sp evmSp
+      tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+      a0 a1 a2 a3 v7 v11 : Word)
+    (base : Word)
+    (frame : Assertion)
+    (hFrame : frame.pcFree)
+    (hbase : (base + 44 : Word) &&& 1 = 0)
+    (hne : expTwoMulIterCountNew iterCount ≠ 0)
+    (hk : k < 256)
+    (hBase : baseWord = expResultWord a0 a1 a2 a3)
+    (hNextNext :
+      nextNextLimb = exponentWord.getLimbN (2 - (k + 1) / 64))
+    (hBound : 193 ≤ nBound) :
+    cpsTripleWithin nBound (base + 44) (base + 44)
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterPreNWithFrame k baseWord exponentWord
+        e c6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+        a0 a1 a2 a3 v7 v11 frame)
+      (expTwoMulFixedIterStepPostNWithControlFrame k baseWord exponentWord
+        iterCount e c6 ptr nextLimb nextNextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base frame) :=
+  cpsTripleWithin_mono_nSteps hBound
+    (cpsTripleWithin_expTwoMulFixedIterPreNWithFrame_to_stepPost
+      e c6 iterCount v10 v18 ptr nextLimb nextNextLimb sp evmSp
+      tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+      a0 a1 a2 a3 v7 v11 base frame hFrame hbase hne hk hBase
+      hNextNext)
+
+theorem cpsTripleWithin_expTwoMulFixedIterPreNWithFrame_seq_stepPost_bounded
+    {baseWord exponentWord : EvmWord} {k : Nat}
+    {nSteps nBound : Nat} {exit : Word} {frame Q : Assertion}
+    (e c6 iterCount v10 v18 ptr nextLimb nextNextLimb sp evmSp
+      tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+      a0 a1 a2 a3 v7 v11 : Word)
+    (base : Word)
+    (hFrame : frame.pcFree)
+    (hbase : (base + 44 : Word) &&& 1 = 0)
+    (hne : expTwoMulIterCountNew iterCount ≠ 0)
+    (hk : k < 256)
+    (hBase : baseWord = expResultWord a0 a1 a2 a3)
+    (hNextNext :
+      nextNextLimb = exponentWord.getLimbN (2 - (k + 1) / 64))
+    (hBound : 193 + nSteps ≤ nBound)
+    (hStepPost :
+      cpsTripleWithin nSteps (base + 44) exit
+        (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+        (expTwoMulFixedIterStepPostNWithControlFrame k baseWord exponentWord
+          iterCount e c6 ptr nextLimb nextNextLimb sp evmSp
+          r0 r1 r2 r3 a0 a1 a2 a3 base frame)
+        Q) :
+    cpsTripleWithin nBound (base + 44) exit
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterPreNWithFrame k baseWord exponentWord
+        e c6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+        a0 a1 a2 a3 v7 v11 frame)
+      Q :=
+  cpsTripleWithin_mono_nSteps hBound
+    (cpsTripleWithin_expTwoMulFixedIterPreNWithFrame_seq_stepPost
+      e c6 iterCount v10 v18 ptr nextLimb nextNextLimb sp evmSp
+      tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+      a0 a1 a2 a3 v7 v11 base hFrame hbase hne hk hBase hNextNext
+      hStepPost)
+
 theorem cpsTripleWithin_expTwoMulFixedIterPreNWithControlFrame_stepPost_elim_of_control_eq_machine
     {baseWord exponentWord : EvmWord} {k : Nat}
     {nSteps : Nat} {exit : Word} {frame Q : Assertion}


### PR DESCRIPTION
## Summary
- add bounded variants for the fixed PreNWithFrame named step-post wrappers
- expose cpsTripleWithin_expTwoMulFixedIterPreNWithFrame_to_stepPost_bounded
- expose cpsTripleWithin_expTwoMulFixedIterPreNWithFrame_seq_stepPost_bounded
- remove future loop-induction boilerplate around cpsTripleWithin_mono_nSteps

## Checks
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterStep
- lake build EvmAsm.Evm64.Exp
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh