### PR TITLE
feat(exp): bound fixed pren step eliminators

### DIFF
--- a/EvmAsm/Evm64/Exp.lean
+++ b/EvmAsm/Evm64/Exp.lean
@@ -81,6 +81,7 @@ import EvmAsm.Evm64.Exp.Compose.SavedBitFixedBoolStep
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterPreNPost
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterStepPost
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterStep
+import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterStepBounds
 import EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryEpilogueBase
 import EvmAsm.Evm64.Exp.Compose.SavedBitBoundarySeq
 import EvmAsm.Evm64.Exp.Compose.SavedBitLoopEntry

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStepBounds.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStepBounds.lean
@@ -1,0 +1,171 @@
+/-
+  EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterStepBounds
+
+  Bounded wrappers for fixed EXP iteration step eliminators.
+-/
+
+import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterStep
+
+namespace EvmAsm.Evm64.Exp.Compose
+
+open EvmAsm.Rv64
+
+theorem cpsTripleWithin_expTwoMulFixedIterPreNWithFrame_stepPost_elim_bounded
+    {baseWord exponentWord : EvmWord} {k : Nat}
+    {nSteps nBound : Nat} {exit : Word} {frame Q : Assertion}
+    (e c6 iterCount v10 v18 ptr nextLimb
+      nextNextLimb sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
+      e0 e1 e2 e3 a0 a1 a2 a3 v7 v11 : Word)
+    (base : Word)
+    (hFrame : frame.pcFree)
+    (hbase : (base + 44 : Word) &&& 1 = 0)
+    (hne : expTwoMulIterCountNew iterCount ≠ 0)
+    (hk : k < 256)
+    (hBase : baseWord = expResultWord a0 a1 a2 a3)
+    (hNextNext :
+      nextNextLimb = exponentWord.getLimbN (2 - (k + 1) / 64))
+    (hBound : 193 + nSteps ≤ nBound)
+    (hBranch :
+      ∀ (bit : Bool)
+        (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        cpsTripleWithin nSteps (base + 44) exit
+          (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+          (let outW := expTwoMulFixedBranchResult bit
+            a0 a1 a2 a3 r0 r1 r2 r3
+          expTwoMulFixedIterPreNWithControlFrame (k + 1) baseWord exponentWord
+            (c6 + signExtend12 (-1 : BitVec 12))
+            (e <<< (1 : BitVec 6).toNat)
+            v6'
+            (expTwoMulIterCountNew iterCount)
+            v10'
+            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+            ptr nextLimb sp evmSp
+            (outW.getLimbN 3)
+            (expTwoMulFixedBranchReturnPc bit base)
+            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
+            (outW.getLimbN 3)
+            d0' d1' d2' d3'
+            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
+            (outW.getLimbN 3)
+            a0 a1 a2 a3 v7' v11'
+            frame)
+          Q)
+    (hReload :
+      ∀ (bit : Bool)
+        (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        cpsTripleWithin nSteps (base + 44) exit
+          (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+          (expTwoMulFixedReloadBranchResidualWithControlFrame bit (k := k)
+            baseWord exponentWord iterCount e c6 ptr nextLimb
+            nextNextLimb sp evmSp r0 r1 r2 r3 a0 a1 a2 a3 base
+            v6' v7' v10' v11' d0' d1' d2' d3' frame)
+          Q) :
+    cpsTripleWithin nBound (base + 44) exit
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterPreNWithFrame k baseWord exponentWord
+        e c6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+        a0 a1 a2 a3 v7 v11 frame)
+      Q :=
+  cpsTripleWithin_mono_nSteps hBound
+    (cpsTripleWithin_expTwoMulFixedIterPreNWithFrame_stepPost_elim
+      e c6 iterCount v10 v18 ptr nextLimb nextNextLimb sp evmSp
+      tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+      a0 a1 a2 a3 v7 v11 base hFrame hbase hne hk hBase hNextNext
+      hBranch hReload)
+
+theorem cpsTripleWithin_expTwoMulFixedIterPreNWithFrame_stepPost_bit_elim_bounded
+    {baseWord exponentWord : EvmWord} {k : Nat}
+    {nSteps nBound : Nat} {exit : Word} {frame Q : Assertion}
+    (e c6 iterCount v10 v18 ptr nextLimb
+      nextNextLimb sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
+      e0 e1 e2 e3 a0 a1 a2 a3 v7 v11 : Word)
+    (base : Word)
+    (hFrame : frame.pcFree)
+    (hbase : (base + 44 : Word) &&& 1 = 0)
+    (hne : expTwoMulIterCountNew iterCount ≠ 0)
+    (hk : k < 256)
+    (hBase : baseWord = expResultWord a0 a1 a2 a3)
+    (hNextNext :
+      nextNextLimb = exponentWord.getLimbN (2 - (k + 1) / 64))
+    (hBound : 193 + nSteps ≤ nBound)
+    (hBranchTrue :
+      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        cpsTripleWithin nSteps (base + 44) exit
+          (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+          (let rw := expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3)
+            a0 a1 a2 a3
+          expTwoMulFixedIterPreNWithControlFrame (k + 1) baseWord exponentWord
+            (c6 + signExtend12 (-1 : BitVec 12))
+            (e <<< (1 : BitVec 6).toNat)
+            v6'
+            (expTwoMulIterCountNew iterCount)
+            v10'
+            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+            ptr nextLimb sp evmSp
+            (rw.getLimbN 3)
+            (((base + 44) + 140) + 68)
+            (rw.getLimbN 0) (rw.getLimbN 1) (rw.getLimbN 2)
+            (rw.getLimbN 3)
+            d0' d1' d2' d3'
+            (rw.getLimbN 0) (rw.getLimbN 1) (rw.getLimbN 2)
+            (rw.getLimbN 3)
+            a0 a1 a2 a3 v7' v11'
+            frame)
+          Q)
+    (hBranchFalse :
+      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        cpsTripleWithin nSteps (base + 44) exit
+          (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+          (let squareW := expSquaringCallSquareW r0 r1 r2 r3
+          expTwoMulFixedIterPreNWithControlFrame (k + 1) baseWord exponentWord
+            (c6 + signExtend12 (-1 : BitVec 12))
+            (e <<< (1 : BitVec 6).toNat)
+            v6'
+            (expTwoMulIterCountNew iterCount)
+            v10'
+            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+            ptr nextLimb sp evmSp
+            (squareW.getLimbN 3)
+            (((base + 44) + 32) + 68)
+            (squareW.getLimbN 0) (squareW.getLimbN 1)
+            (squareW.getLimbN 2) (squareW.getLimbN 3)
+            d0' d1' d2' d3'
+            (squareW.getLimbN 0) (squareW.getLimbN 1)
+            (squareW.getLimbN 2) (squareW.getLimbN 3)
+            a0 a1 a2 a3 v7' v11'
+            frame)
+          Q)
+    (hReloadTrue :
+      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        cpsTripleWithin nSteps (base + 44) exit
+          (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+          (expTwoMulFixedReloadBranchResidualWithControlFrame true (k := k)
+            baseWord exponentWord iterCount e c6 ptr nextLimb
+            nextNextLimb sp evmSp r0 r1 r2 r3 a0 a1 a2 a3 base
+            v6' v7' v10' v11' d0' d1' d2' d3' frame)
+          Q)
+    (hReloadFalse :
+      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        cpsTripleWithin nSteps (base + 44) exit
+          (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+          (expTwoMulFixedReloadBranchResidualWithControlFrame false (k := k)
+            baseWord exponentWord iterCount e c6 ptr nextLimb
+            nextNextLimb sp evmSp r0 r1 r2 r3 a0 a1 a2 a3 base
+            v6' v7' v10' v11' d0' d1' d2' d3' frame)
+          Q) :
+    cpsTripleWithin nBound (base + 44) exit
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterPreNWithFrame k baseWord exponentWord
+        e c6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+        a0 a1 a2 a3 v7 v11 frame)
+      Q :=
+  cpsTripleWithin_mono_nSteps hBound
+    (cpsTripleWithin_expTwoMulFixedIterPreNWithFrame_stepPost_bit_elim
+      e c6 iterCount v10 v18 ptr nextLimb nextNextLimb sp evmSp
+      tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+      a0 a1 a2 a3 v7 v11 base hFrame hbase hne hk hBase hNextNext
+      hBranchTrue hBranchFalse hReloadTrue hReloadFalse)
+
+end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- add SavedBitFixedIterStepBounds.lean for bounded direct fixed PreNWithFrame eliminators
- expose cpsTripleWithin_expTwoMulFixedIterPreNWithFrame_stepPost_elim_bounded
- expose cpsTripleWithin_expTwoMulFixedIterPreNWithFrame_stepPost_bit_elim_bounded
- keep SavedBitFixedIterStep.lean under the Compose file-size cap by splitting the new wrappers out

## Checks
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterStepBounds
- lake build EvmAsm.Evm64.Exp
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh