### PR TITLE
feat(exp): add fixed loop count invariant

### DIFF
--- a/EvmAsm/Evm64/Exp.lean
+++ b/EvmAsm/Evm64/Exp.lean
@@ -77,6 +77,7 @@ import EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryLoopFixed
 import EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryLoopFixedEntryExists
 import EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryLoopFixedIterSpBounds
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedLoopInvariant
+import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCount
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedBoolStep
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterPreNPost
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterStepPost

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCount.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCount.lean
@@ -1,0 +1,140 @@
+/-
+  EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCount
+
+  Loop-counter invariant for the fixed x19 two-MUL saved-bit EXP induction.
+-/
+
+import EvmAsm.Evm64.Exp.Compose.SavedBitFixedLoopInvariant
+
+namespace EvmAsm.Evm64.Exp.Compose
+
+open EvmAsm.Rv64
+
+/-- Expected remaining fixed-loop iterations at the start of semantic
+    iteration `k`. -/
+def expTwoMulFixedRemainingIterations (k : Nat) : Nat :=
+  256 - k
+
+/-- Machine loop-counter invariant for the fixed 256-iteration EXP loop. -/
+def expTwoMulFixedIterCountInvariant (k : Nat) (iterCount : Word) : Prop :=
+  iterCount.toNat = expTwoMulFixedRemainingIterations k
+
+theorem expTwoMulFixedRemainingIterations_zero :
+    expTwoMulFixedRemainingIterations 0 = 256 := by
+  rfl
+
+theorem expTwoMulFixedRemainingIterations_succ
+    {k : Nat} (hk : k < 256) :
+    expTwoMulFixedRemainingIterations (k + 1) + 1 =
+      expTwoMulFixedRemainingIterations k := by
+  unfold expTwoMulFixedRemainingIterations
+  omega
+
+theorem expTwoMulFixedRemainingIterations_succ_pos
+    {k : Nat} (hk : k + 1 < 256) :
+    0 < expTwoMulFixedRemainingIterations (k + 1) := by
+  unfold expTwoMulFixedRemainingIterations
+  omega
+
+theorem expTwoMulFixedRemainingIterations_succ_final :
+    expTwoMulFixedRemainingIterations (255 + 1) = 0 := by
+  rfl
+
+theorem expTwoMulFixedIterCountInvariant_zero :
+    expTwoMulFixedIterCountInvariant 0 (256 : Word) := by
+  unfold expTwoMulFixedIterCountInvariant
+  simp [expTwoMulFixedRemainingIterations]
+
+private theorem signExtend12_neg1_toNat :
+    (signExtend12 (-1 : BitVec 12)).toNat = 2^64 - 1 := by
+  decide
+
+theorem expTwoMulIterCountNew_toNat_of_eq_succ
+    {iterCount : Word} {n : Nat}
+    (hCount : iterCount.toNat = n + 1) :
+    (expTwoMulIterCountNew iterCount).toNat = n := by
+  simp only [expTwoMulIterCountNew]
+  rw [BitVec.toNat_add, signExtend12_neg1_toNat, hCount]
+  have h_lt : n + 1 < 2^64 := by
+    rw [← hCount]
+    exact iterCount.isLt
+  omega
+
+theorem expTwoMulIterCountNew_ne_zero_of_toNat_succ_pos
+    {iterCount : Word} {n : Nat}
+    (hCount : iterCount.toNat = n + 1) (h_pos : 0 < n) :
+    expTwoMulIterCountNew iterCount ≠ 0 := by
+  intro h_zero
+  have h_toNat : (expTwoMulIterCountNew iterCount).toNat = 0 := by
+    simp [h_zero]
+  rw [expTwoMulIterCountNew_toNat_of_eq_succ hCount] at h_toNat
+  omega
+
+theorem expTwoMulIterCountNew_eq_zero_of_toNat_one
+    {iterCount : Word} (hCount : iterCount.toNat = 1) :
+    expTwoMulIterCountNew iterCount = 0 := by
+  apply BitVec.eq_of_toNat_eq
+  simp [expTwoMulIterCountNew_toNat_of_eq_succ
+    (show iterCount.toNat = 0 + 1 from by omega)]
+
+theorem expTwoMulFixedIterCountInvariant_succ
+    {k : Nat} {iterCount : Word}
+    (hk : k < 256)
+    (hCount : expTwoMulFixedIterCountInvariant k iterCount) :
+    expTwoMulFixedIterCountInvariant (k + 1)
+      (expTwoMulIterCountNew iterCount) := by
+  unfold expTwoMulFixedIterCountInvariant at *
+  have h_succ :
+      iterCount.toNat =
+        expTwoMulFixedRemainingIterations (k + 1) + 1 := by
+    rw [hCount, expTwoMulFixedRemainingIterations_succ hk]
+  exact expTwoMulIterCountNew_toNat_of_eq_succ h_succ
+
+theorem expTwoMulFixedIterCountInvariant_succ_ne_zero
+    {k : Nat} {iterCount : Word}
+    (hk : k + 1 < 256)
+    (hCount : expTwoMulFixedIterCountInvariant k iterCount) :
+    expTwoMulIterCountNew iterCount ≠ 0 := by
+  unfold expTwoMulFixedIterCountInvariant at hCount
+  have hk_lt : k < 256 := by omega
+  have h_succ :
+      iterCount.toNat =
+        expTwoMulFixedRemainingIterations (k + 1) + 1 := by
+    rw [hCount, expTwoMulFixedRemainingIterations_succ hk_lt]
+  exact expTwoMulIterCountNew_ne_zero_of_toNat_succ_pos h_succ
+    (expTwoMulFixedRemainingIterations_succ_pos hk)
+
+theorem expTwoMulFixedIterCountInvariant_succ_eq_zero
+    {iterCount : Word}
+    (hCount : expTwoMulFixedIterCountInvariant 255 iterCount) :
+    expTwoMulIterCountNew iterCount = 0 := by
+  unfold expTwoMulFixedIterCountInvariant at hCount
+  have h_one : iterCount.toNat = 1 := by
+    simpa [expTwoMulFixedRemainingIterations] using hCount
+  exact expTwoMulIterCountNew_eq_zero_of_toNat_one h_one
+
+@[irreducible]
+def expTwoMulFixedIterCountAssertion
+    (k : Nat) (iterCount : Word) : Assertion :=
+  ⌜expTwoMulFixedIterCountInvariant k iterCount⌝
+
+theorem expTwoMulFixedIterCountAssertion_unfold
+    {k : Nat} {iterCount : Word} :
+    expTwoMulFixedIterCountAssertion k iterCount =
+      ⌜expTwoMulFixedIterCountInvariant k iterCount⌝ := by
+  delta expTwoMulFixedIterCountAssertion
+  rfl
+
+theorem expTwoMulFixedIterCountAssertion_pcFree
+    {k : Nat} {iterCount : Word} :
+    (expTwoMulFixedIterCountAssertion k iterCount).pcFree := by
+  rw [expTwoMulFixedIterCountAssertion_unfold]
+  pcFree
+
+instance pcFreeInst_expTwoMulFixedIterCountAssertion
+    (k : Nat) (iterCount : Word) :
+    Assertion.PCFree
+      (expTwoMulFixedIterCountAssertion k iterCount) :=
+  ⟨expTwoMulFixedIterCountAssertion_pcFree⟩
+
+end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- add a fixed-loop remaining-iteration invariant indexed by semantic iteration k
- expose decrement, nonzero, and final-zero lemmas for expTwoMulIterCountNew
- add a pcFree pure assertion wrapper for future PreN induction composition

## Checks
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCount
- lake build EvmAsm.Evm64.Exp
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh