### PR TITLE
feat(exp): add fixed state precondition

### DIFF
--- a/EvmAsm/Evm64/Exp.lean
+++ b/EvmAsm/Evm64/Exp.lean
@@ -80,6 +80,7 @@ import EvmAsm.Evm64.Exp.Compose.SavedBitFixedLoopInvariant
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCount
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedBoolStep
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterState
+import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterStatePre
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterPreNPost
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterStepPost
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterStep

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStatePre.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStatePre.lean
@@ -1,0 +1,156 @@
+/-
+  EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterStatePre
+
+  Fixed-loop preconditions that carry the bundled induction state.
+-/
+
+import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterState
+
+namespace EvmAsm.Evm64.Exp.Compose
+
+open EvmAsm.Rv64
+
+/-- Fixed iteration precondition indexed by semantic iteration count, carrying
+    the bundled accumulator/cursor/control/count state as one pure assertion. -/
+@[irreducible]
+def expTwoMulFixedIterPreNWithState
+    (k : Nat) (baseWord exponentWord : EvmWord)
+    (controlC6 : Word)
+    (e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word) : Assertion :=
+  expTwoMulFixedIterPre e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp
+    tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3 v7 v11 **
+  expTwoMulFixedIterStateAssertion baseWord exponentWord k
+    iterCount e controlC6 ptr nextLimb evmSp r0 r1 r2 r3
+
+theorem expTwoMulFixedIterPreNWithState_unfold
+    {k : Nat} {baseWord exponentWord : EvmWord} {controlC6 : Word}
+    {e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word} :
+    expTwoMulFixedIterPreNWithState k baseWord exponentWord controlC6
+      e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3 v7 v11 =
+      (expTwoMulFixedIterPre e machineC6 iterCount v10 v18 ptr nextLimb sp
+        evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+        a0 a1 a2 a3 v7 v11 **
+       expTwoMulFixedIterStateAssertion baseWord exponentWord k
+        iterCount e controlC6 ptr nextLimb evmSp r0 r1 r2 r3) := by
+  delta expTwoMulFixedIterPreNWithState
+  rfl
+
+theorem expTwoMulFixedIterPreNWithState_pcFree
+    {k : Nat} {baseWord exponentWord : EvmWord} {controlC6 : Word}
+    {e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word} :
+    (expTwoMulFixedIterPreNWithState k baseWord exponentWord controlC6
+      e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3 v7 v11).pcFree := by
+  rw [expTwoMulFixedIterPreNWithState_unfold]
+  pcFree
+
+instance pcFreeInst_expTwoMulFixedIterPreNWithState
+    (k : Nat) (baseWord exponentWord : EvmWord) (controlC6 : Word)
+    (e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word) :
+    Assertion.PCFree
+      (expTwoMulFixedIterPreNWithState k baseWord exponentWord controlC6
+        e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+        r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3 v7 v11) :=
+  ⟨expTwoMulFixedIterPreNWithState_pcFree⟩
+
+/-- Framed version of `expTwoMulFixedIterPreNWithState`. -/
+@[irreducible]
+def expTwoMulFixedIterPreNWithStateFrame
+    (k : Nat) (baseWord exponentWord : EvmWord)
+    (controlC6 : Word)
+    (e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word)
+    (frame : Assertion) : Assertion :=
+  expTwoMulFixedIterPreNWithState k baseWord exponentWord controlC6
+    e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+    r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3 v7 v11 **
+  frame
+
+theorem expTwoMulFixedIterPreNWithStateFrame_unfold
+    {k : Nat} {baseWord exponentWord : EvmWord} {controlC6 : Word}
+    {e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word}
+    {frame : Assertion} :
+    expTwoMulFixedIterPreNWithStateFrame k baseWord exponentWord controlC6
+      e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3 v7 v11
+      frame =
+      (expTwoMulFixedIterPreNWithState k baseWord exponentWord controlC6
+        e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+        r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3 v7 v11 **
+       frame) := by
+  delta expTwoMulFixedIterPreNWithStateFrame
+  rfl
+
+theorem expTwoMulFixedIterPreNWithStateFrame_pcFree
+    {k : Nat} {baseWord exponentWord : EvmWord} {controlC6 : Word}
+    {e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word}
+    {frame : Assertion} [Assertion.PCFree frame] :
+    (expTwoMulFixedIterPreNWithStateFrame k baseWord exponentWord controlC6
+      e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3 v7 v11
+      frame).pcFree := by
+  rw [expTwoMulFixedIterPreNWithStateFrame_unfold]
+  pcFree
+
+instance pcFreeInst_expTwoMulFixedIterPreNWithStateFrame
+    (k : Nat) (baseWord exponentWord : EvmWord) (controlC6 : Word)
+    (e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word)
+    (frame : Assertion) [Assertion.PCFree frame] :
+    Assertion.PCFree
+      (expTwoMulFixedIterPreNWithStateFrame k baseWord exponentWord controlC6
+        e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+        r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3 v7 v11
+        frame) :=
+  ⟨expTwoMulFixedIterPreNWithStateFrame_pcFree⟩
+
+theorem expTwoMulFixedIterPreNWithState_pure
+    {k : Nat} {baseWord exponentWord : EvmWord} {controlC6 : Word}
+    {e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word}
+    {ps : PartialState}
+    (h :
+      expTwoMulFixedIterPreNWithState k baseWord exponentWord controlC6
+        e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+        r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3 v7 v11 ps) :
+    expTwoMulFixedIterStateInvariant baseWord exponentWord k
+      iterCount e controlC6 ptr nextLimb evmSp r0 r1 r2 r3 := by
+  rw [expTwoMulFixedIterPreNWithState_unfold,
+    expTwoMulFixedIterStateAssertion_unfold] at h
+  obtain ⟨_psIter, _psState, _hDisjoint, _hUnion, _hIter, hState⟩ := h
+  exact hState.2
+
+theorem expTwoMulFixedIterPreNWithStateFrame_pure
+    {k : Nat} {baseWord exponentWord : EvmWord} {controlC6 : Word}
+    {e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word}
+    {frame : Assertion} {ps : PartialState}
+    (h :
+      expTwoMulFixedIterPreNWithStateFrame k baseWord exponentWord controlC6
+        e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+        r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3 v7 v11
+        frame ps) :
+    expTwoMulFixedIterStateInvariant baseWord exponentWord k
+      iterCount e controlC6 ptr nextLimb evmSp r0 r1 r2 r3 := by
+  rw [expTwoMulFixedIterPreNWithStateFrame_unfold] at h
+  obtain ⟨_psPre, _psFrame, _hDisjoint, _hUnion, hPre, _hFrame⟩ := h
+  exact expTwoMulFixedIterPreNWithState_pure hPre
+
+end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- add SavedBitFixedIterStatePre.lean for the Nat-induction EXP path
- define expTwoMulFixedIterPreNWithState and framed variant, pairing the concrete iteration precondition with the bundled fixed iteration state assertion
- add unfold, PC-free, and pure-extraction helpers so future induction composition can recover the bundled accumulator/cursor/control/count invariant from a single assertion
- wire the module through the EXP umbrella import list

## Checks
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterStatePre
- lake build EvmAsm.Evm64.Exp
- git diff --check HEAD~1..HEAD
- scripts/check-file-size.sh
- scripts/check-unimported.sh

Bead: evm-asm-20z6.13.1 / evm-asm-20z6.13