### PR TITLE
feat(divmod): add n3 exact nonop div spec

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -23,6 +23,7 @@ import EvmAsm.Evm64.DivMod.Spec.N3ModBridge
 import EvmAsm.Evm64.DivMod.Spec.N3QuotientWord
 import EvmAsm.Evm64.DivMod.Spec.N3DivStackSpec
 import EvmAsm.Evm64.DivMod.Spec.Unified
+import EvmAsm.Evm64.DivMod.Spec.UnifiedExactNoNop
 import EvmAsm.Evm64.DivMod.Spec.DispatcherN1NoHdivWord
 import EvmAsm.Evm64.DivMod.Spec.DispatcherN2NoHdivWord
 import EvmAsm.Evm64.DivMod.Spec.DispatcherN3NoHdivWord

--- a/EvmAsm/Evm64/DivMod/Spec/N3DivStackSpec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3DivStackSpec.lean
@@ -125,6 +125,62 @@ theorem evm_div_n3_stack_spec_within_word_exact_x1
         ha0 ha1 ha2 ha3 hdiv0 hdiv1 hdiv2 hdiv3 h hq)
     hFull
 
+/-- No-NOP exact-x1 variant of `evm_div_n3_stack_spec_within_word`. -/
+theorem evm_div_n3_stack_spec_within_word_exact_x1_noNop
+    (bltu_1 bltu_0 : Bool) (sp base : Word)
+    (a b : EvmWord)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratch_un0 : Word)
+    (ha0 : a.getLimbN 0 = a0) (ha1 : a.getLimbN 1 = a1)
+    (ha2 : a.getLimbN 2 = a2) (ha3 : a.getLimbN 3 = a3)
+    (hb0 : b.getLimbN 0 = b0) (hb1 : b.getLimbN 1 = b1)
+    (hb2 : b.getLimbN 2 = b2) (hb3 : b.getLimbN 3 = b3)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2nz : b2 ≠ 0)
+    (hshift_nz : (clzResult b2).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu_1 : isTrialN3_j1 bltu_1 a3 b1 b2)
+    (hbltu_0 : isTrialN3_j0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3)
+    (hcarry2 : Carry2NzAll (b0 <<< (((clzResult b2).1).toNat % 64))
+      ((b1 <<< (((clzResult b2).1).toNat % 64)) ||| (b0 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b2).1).toNat % 64)))
+      ((b2 <<< (((clzResult b2).1).toNat % 64)) ||| (b1 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b2).1).toNat % 64)))
+      ((b3 <<< (((clzResult b2).1).toNat % 64)) ||| (b2 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b2).1).toNat % 64))))
+    (hdivWord : fullDivN3QuotientWord bltu_1 bltu_0
+      a0 a1 a2 a3 b0 b1 b2 b3 = EvmWord.div a b) :
+    cpsTripleWithin 542 base (base + nopOff) (divCode_noNop base)
+      (divModStackDispatchPre sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word))
+        ((clzResult b2).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0)
+      (divStackDispatchPostNoX1 sp a b **
+        (.x9 ↦ᵣ (signExtend12 4095 : Word))) := by
+  obtain ⟨hdiv0, hdiv1, hdiv2, hdiv3⟩ :=
+    fullDivN3_hdivs_of_word_eq bltu_1 bltu_0
+      a b a0 a1 a2 a3 b0 b1 b2 b3 hdivWord
+  have hFull := evm_div_n3_full_unified_spec_noNop
+    bltu_1 bltu_0 sp base
+    a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratch_un0
+    hbnz hb3z hb2nz hshift_nz halign hbltu_1 hbltu_0 hcarry2
+  exact cpsTripleWithin_weaken
+    (fun h hp => by
+      delta divModStackDispatchPre at hp
+      rw [evmWordIs_sp_limbs_eq sp a _ _ _ _ ha0 ha1 ha2 ha3,
+          evmWordIs_sp32_limbs_eq sp b _ _ _ _ hb0 hb1 hb2 hb3,
+          divScratchValuesCall_unfold, divScratchValues_unfold] at hp
+      rw [word_add_zero]
+      xperm_hyp hp)
+    (fun h hq =>
+      fullDivN3UnifiedPost_to_divStackDispatchPostNoX1
+        bltu_1 bltu_0 sp base a b
+        a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0
+        ha0 ha1 ha2 ha3 hdiv0 hdiv1 hdiv2 hdiv3 h hq)
+    hFull
+
 /-- No-NOP variant of `evm_div_n3_stack_spec_within_word`. -/
 theorem evm_div_n3_stack_spec_within_word_noNop
     (bltu_1 bltu_0 : Bool) (sp base : Word)

--- a/EvmAsm/Evm64/DivMod/Spec/UnifiedExactNoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/UnifiedExactNoNop.lean
@@ -1,0 +1,79 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.UnifiedExactNoNop
+
+  Unified-bound exact-x1 no-NOP DIV branch wrappers split out from
+  `Spec.Unified` to keep the public dispatcher file under the size cap.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.Unified
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Unified-bound wrapper for
+    `evm_div_n3_stack_spec_within_word_exact_x1_noNop`. -/
+theorem evm_div_n3_stack_spec_within_word_exact_x1_noNop_uni
+    (bltu_1 bltu_0 : Bool) (sp base : Word)
+    (a b : EvmWord)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratch_un0 : Word)
+    (ha0 : a.getLimbN 0 = a0) (ha1 : a.getLimbN 1 = a1)
+    (ha2 : a.getLimbN 2 = a2) (ha3 : a.getLimbN 3 = a3)
+    (hb0 : b.getLimbN 0 = b0) (hb1 : b.getLimbN 1 = b1)
+    (hb2 : b.getLimbN 2 = b2) (hb3 : b.getLimbN 3 = b3)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2nz : b2 ≠ 0)
+    (hshift_nz : (clzResult b2).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu_1 : isTrialN3_j1 bltu_1 a3 b1 b2)
+    (hbltu_0 : isTrialN3_j0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3)
+    (hcarry2 : Carry2NzAll (b0 <<< (((clzResult b2).1).toNat % 64))
+      ((b1 <<< (((clzResult b2).1).toNat % 64)) ||| (b0 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b2).1).toNat % 64)))
+      ((b2 <<< (((clzResult b2).1).toNat % 64)) ||| (b1 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b2).1).toNat % 64)))
+      ((b3 <<< (((clzResult b2).1).toNat % 64)) ||| (b2 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b2).1).toNat % 64))))
+    (hmulsub :
+      EvmWord.val256 a0 a1 a2 a3 =
+        (((fullDivN3R1 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1).toNat *
+            2^64 +
+          ((fullDivN3R0 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).1).toNat) *
+          EvmWord.val256 b0 b1 b2 b3 +
+        EvmWord.val256
+          ((fullDivN3R0 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).2.1)
+          ((fullDivN3R0 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).2.2.1)
+          ((fullDivN3R0 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1)
+          ((fullDivN3R0 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1))
+    (hge :
+      EvmWord.val256 a0 a1 a2 a3 / EvmWord.val256 b0 b1 b2 b3 ≤
+        ((fullDivN3R1 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1).toNat *
+            2^64 +
+          ((fullDivN3R0 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).1).toNat) :
+    cpsTripleWithin unifiedDivBound base (base + nopOff) (divCode_noNop base)
+      (divModStackDispatchPre sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word))
+        ((clzResult b2).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0)
+      (divStackDispatchPostNoX1 sp a b **
+        (.x9 ↦ᵣ (signExtend12 4095 : Word))) := by
+  have hdivWord :=
+    fullDivN3QuotientWord_eq_div_of_limbs_mulsub_overestimate
+      bltu_1 bltu_0 ha0 ha1 ha2 ha3 hb0 hb1 hb2 hb3 hbnz hmulsub hge
+  exact
+  cpsTripleWithin_mono_nSteps (by decide)
+    (evm_div_n3_stack_spec_within_word_exact_x1_noNop bltu_1 bltu_0
+      sp base a b a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old
+      q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+      nMem shiftMem jMem retMem dMem dloMem scratch_un0
+      ha0 ha1 ha2 ha3 hb0 hb1 hb2 hb3 hbnz hb3z hb2nz
+      hshift_nz halign hbltu_1 hbltu_0 hcarry2 hdivWord)
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add evm_div_n3_stack_spec_within_word_exact_x1_noNop over divCode_noNop
- add a unifiedDivBound wrapper in new split module Spec.UnifiedExactNoNop to keep Spec.Unified under the file-size cap
- import the split wrapper from the DivMod spec umbrella
- this is a closed n3 path slice toward the exact no-NOP surface needed by SDIV; n1/n2 and n4 addback remain separate work

## Checks
- lake build EvmAsm.Evm64.DivMod.Spec.UnifiedExactNoNop
- lake build EvmAsm.Evm64.DivMod
- lake build EvmAsm.Evm64.SDiv
- git diff --check HEAD~1..HEAD
- scripts/check-file-size.sh
- scripts/check-unimported.sh

Bead: evm-asm-9iqmw.2