### PR TITLE
feat(exp): add state-pre step bound wrappers

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStepBounds.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStepBounds.lean
@@ -5,6 +5,7 @@
 -/
 
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterStep
+import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterStatePre
 
 namespace EvmAsm.Evm64.Exp.Compose
 
@@ -79,6 +80,82 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithControlFrame_seq_stepPost_boun
       sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
       a0 a1 a2 a3 v7 v11 base hFrame hbase hControlMachine hne
       hk hBase hNextNext hStepPost)
+
+theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_to_stepPost_bounded
+    {baseWord exponentWord : EvmWord} {k : Nat}
+    {nBound : Nat}
+    (controlC6 e machineC6 iterCount v10 v18 ptr nextLimb
+      nextNextLimb sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
+      e0 e1 e2 e3 a0 a1 a2 a3 v7 v11 : Word)
+    (base : Word)
+    (frame : Assertion)
+    (hFrame : frame.pcFree)
+    (hbase : (base + 44 : Word) &&& 1 = 0)
+    (hControlMachine : controlC6 = machineC6)
+    (hne : expTwoMulIterCountNew iterCount ≠ 0)
+    (hk : k < 256)
+    (hBase : baseWord = expResultWord a0 a1 a2 a3)
+    (hNextNext :
+      nextNextLimb = exponentWord.getLimbN (2 - (k + 1) / 64))
+    (hBound : 193 ≤ nBound) :
+    cpsTripleWithin nBound (base + 44) (base + 44)
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterPreNWithStateFrame k baseWord exponentWord
+        controlC6 e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+        a0 a1 a2 a3 v7 v11 frame)
+      (expTwoMulFixedIterStepPostNWithControlFrame k baseWord exponentWord
+        iterCount e controlC6 ptr nextLimb nextNextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base frame) :=
+  cpsTripleWithin_weaken
+    (fun _ h =>
+      expTwoMulFixedIterPreNWithStateFrame_to_iterPreNWithControlFrame h)
+    (fun _ h => h)
+    (cpsTripleWithin_expTwoMulFixedIterPreNWithControlFrame_to_stepPost_bounded
+      controlC6 e machineC6 iterCount v10 v18 ptr nextLimb nextNextLimb
+      sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+      a0 a1 a2 a3 v7 v11 base frame hFrame hbase hControlMachine hne
+      hk hBase hNextNext hBound)
+
+theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_seq_stepPost_bounded
+    {baseWord exponentWord : EvmWord} {k : Nat}
+    {nSteps nBound : Nat} {exit : Word} {frame Q : Assertion}
+    (controlC6 e machineC6 iterCount v10 v18 ptr nextLimb
+      nextNextLimb sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
+      e0 e1 e2 e3 a0 a1 a2 a3 v7 v11 : Word)
+    (base : Word)
+    (hFrame : frame.pcFree)
+    (hbase : (base + 44 : Word) &&& 1 = 0)
+    (hControlMachine : controlC6 = machineC6)
+    (hne : expTwoMulIterCountNew iterCount ≠ 0)
+    (hk : k < 256)
+    (hBase : baseWord = expResultWord a0 a1 a2 a3)
+    (hNextNext :
+      nextNextLimb = exponentWord.getLimbN (2 - (k + 1) / 64))
+    (hBound : 193 + nSteps ≤ nBound)
+    (hStepPost :
+      cpsTripleWithin nSteps (base + 44) exit
+        (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+        (expTwoMulFixedIterStepPostNWithControlFrame k baseWord exponentWord
+          iterCount e controlC6 ptr nextLimb nextNextLimb sp evmSp
+          r0 r1 r2 r3 a0 a1 a2 a3 base frame)
+        Q) :
+    cpsTripleWithin nBound (base + 44) exit
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterPreNWithStateFrame k baseWord exponentWord
+        controlC6 e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+        a0 a1 a2 a3 v7 v11 frame)
+      Q :=
+  cpsTripleWithin_weaken
+    (fun _ h =>
+      expTwoMulFixedIterPreNWithStateFrame_to_iterPreNWithControlFrame h)
+    (fun _ h => h)
+    (cpsTripleWithin_expTwoMulFixedIterPreNWithControlFrame_seq_stepPost_bounded
+      controlC6 e machineC6 iterCount v10 v18 ptr nextLimb nextNextLimb
+      sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+      a0 a1 a2 a3 v7 v11 base hFrame hbase hControlMachine hne
+      hk hBase hNextNext hBound hStepPost)
 
 theorem cpsTripleWithin_expTwoMulFixedIterPreNWithControlFrame_stepPost_elim_bounded
     {baseWord exponentWord : EvmWord} {k : Nat}


### PR DESCRIPTION
## Summary
- import the bundled fixed-iteration state precondition into the step-bounds adapter module
- add bounded step and step-sequence wrappers from expTwoMulFixedIterPreNWithStateFrame to the existing WithControl step post
- keep the physical one-step proof shared through the existing state-to-control bridge

## Checks
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterStepBounds
- lake build EvmAsm.Evm64.Exp
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh

Beads: evm-asm-20z6.13, evm-asm-20z6.13.1, evm-asm-20z6.13.2