### PR TITLE
feat(exp): add frame invariant pure helpers

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedLoopInvariant.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedLoopInvariant.lean
@@ -1153,4 +1153,47 @@ instance pcFreeInst_expTwoMulFixedIterPreNWithFrame
         frame) :=
   ⟨expTwoMulFixedIterPreNWithFrame_pcFree⟩
 
+theorem expTwoMulFixedIterPreN_pures
+    {k : Nat} {baseWord exponentWord : EvmWord}
+    {e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word}
+    {ps : PartialState}
+    (h :
+      expTwoMulFixedIterPreN k baseWord exponentWord
+        e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+        r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3 v7 v11 ps) :
+    expTwoMulFixedAccumulatorInvariant baseWord exponentWord k r0 r1 r2 r3 ∧
+    expTwoMulFixedCursorInvariant exponentWord k e ∧
+    expTwoMulFixedControlInvariant exponentWord k c6 ptr nextLimb evmSp := by
+  rw [expTwoMulFixedIterPreN_unfold,
+    expTwoMulFixedSemanticInvariant_unfold,
+    expTwoMulFixedCursorAssertion_unfold,
+    expTwoMulFixedControlAssertion_unfold] at h
+  obtain ⟨_psIter, psSemanticCursorControl, _hDisjointIter, _hUnionIter,
+    _hIter, hSemanticCursorControl⟩ := h
+  obtain ⟨_psSemantic, psCursorControl, _hDisjointSemantic,
+    _hUnionSemantic, hSemantic, hCursorControl⟩ := hSemanticCursorControl
+  obtain ⟨_psCursor, _psControl, _hDisjointCursor, _hUnionCursor,
+    hCursor, hControl⟩ := hCursorControl
+  exact ⟨hSemantic.2, hCursor.2, hControl.2⟩
+
+theorem expTwoMulFixedIterPreNWithFrame_pures
+    {k : Nat} {baseWord exponentWord : EvmWord}
+    {e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word}
+    {frame : Assertion} {ps : PartialState}
+    (h :
+      expTwoMulFixedIterPreNWithFrame k baseWord exponentWord
+        e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+        r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3 v7 v11
+        frame ps) :
+    expTwoMulFixedAccumulatorInvariant baseWord exponentWord k r0 r1 r2 r3 ∧
+    expTwoMulFixedCursorInvariant exponentWord k e ∧
+    expTwoMulFixedControlInvariant exponentWord k c6 ptr nextLimb evmSp := by
+  rw [expTwoMulFixedIterPreNWithFrame_unfold] at h
+  obtain ⟨_psPre, _psFrame, _hDisjoint, _hUnion, hPre, _hFrame⟩ := h
+  exact expTwoMulFixedIterPreN_pures hPre
+
 end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- add pure-extraction helpers for expTwoMulFixedIterPreN
- add framed pure-extraction helper for expTwoMulFixedIterPreNWithFrame
- support the EXP induction path by exposing accumulator/cursor/control facts from the parametric precondition family

## Verification
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedLoopInvariant
- lake build EvmAsm.Evm64.Exp
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh

Beads: evm-asm-20z6.13, evm-asm-20z6.13.1