### PR TITLE
feat(exp): add accumulator run split helper

### DIFF
--- a/EvmAsm/Evm64/Exp.lean
+++ b/EvmAsm/Evm64/Exp.lean
@@ -77,6 +77,7 @@ import EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryLoopFixed
 import EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryLoopFixedEntryExists
 import EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryLoopFixedIterSpBounds
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedLoopInvariant
+import EvmAsm.Evm64.Exp.Compose.SavedBitFixedAccumulatorRun
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCount
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedBoolStep
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterState

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedAccumulatorRun.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedAccumulatorRun.lean
@@ -1,0 +1,27 @@
+/-
+  EvmAsm.Evm64.Exp.Compose.SavedBitFixedAccumulatorRun
+
+  Small algebraic helpers for composing the pure fixed-loop accumulator run.
+-/
+
+import EvmAsm.Evm64.Exp.Compose.SavedBitFixedLoopInvariant
+
+namespace EvmAsm.Evm64.Exp.Compose
+
+/-- Split a pure fixed-loop accumulator run into a prefix and suffix. -/
+theorem expTwoMulFixedAccumulatorRun_add
+    (baseWord exponentWord accWord : EvmWord) (k m n : Nat) :
+    expTwoMulFixedAccumulatorRun baseWord exponentWord accWord k (m + n) =
+      expTwoMulFixedAccumulatorRun baseWord exponentWord
+        (expTwoMulFixedAccumulatorRun baseWord exponentWord accWord k m)
+        (k + m) n := by
+  induction n with
+  | zero =>
+      simp [expTwoMulFixedAccumulatorRun]
+  | succ n ih =>
+      rw [Nat.add_succ, expTwoMulFixedAccumulatorRun_succ,
+        expTwoMulFixedAccumulatorRun_succ, ih]
+      congr 1
+      rw [Nat.add_assoc]
+
+end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- add a small companion module for pure fixed-loop accumulator run algebra
- prove expTwoMulFixedAccumulatorRun_add, splitting a run into prefix and suffix iterations
- import the helper through the EXP umbrella without growing the saturated invariant file

## Verification
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedAccumulatorRun
- lake build EvmAsm.Evm64.Exp
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh