### PR TITLE
feat(exp): add accumulator suffix result helper

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedAccumulatorRun.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedAccumulatorRun.lean
@@ -24,4 +24,36 @@ theorem expTwoMulFixedAccumulatorRun_add
       congr 1
       rw [Nat.add_assoc]
 
+/-- Running the remaining fixed-loop suffix from a semantically correct prefix
+    reaches the full EXP result. -/
+theorem expTwoMulFixedAccumulatorRun_suffix_eq_exp_of_start
+    {baseWord exponentWord accWord : EvmWord} {k : Nat}
+    (hk : k ≤ 256)
+    (hStart :
+      accWord = expTwoMulFixedAccumulatorTarget baseWord exponentWord k) :
+    expTwoMulFixedAccumulatorRun baseWord exponentWord accWord k (256 - k) =
+      EvmWord.exp baseWord exponentWord := by
+  have hBound : k + (256 - k) ≤ 256 := by omega
+  rw [expTwoMulFixedAccumulatorRun_eq_target_add hBound hStart]
+  have hAdd : k + (256 - k) = 256 := by omega
+  rw [hAdd, expTwoMulFixedAccumulatorTarget_full]
+
+/-- The remaining fixed-loop suffix preserves the full semantic invariant. -/
+theorem expTwoMulFixedAccumulatorInvariant_full_of_suffix_run
+    {baseWord exponentWord : EvmWord} {k : Nat}
+    {r0 r1 r2 r3 r0' r1' r2' r3' : Word}
+    (hk : k ≤ 256)
+    (hInv :
+      expTwoMulFixedAccumulatorInvariant baseWord exponentWord k
+        r0 r1 r2 r3)
+    (hRun :
+      expResultWord r0' r1' r2' r3' =
+        expTwoMulFixedAccumulatorRun baseWord exponentWord
+          (expResultWord r0 r1 r2 r3) k (256 - k)) :
+    expResultWord r0' r1' r2' r3' =
+      EvmWord.exp baseWord exponentWord := by
+  unfold expTwoMulFixedAccumulatorInvariant at hInv
+  rw [hRun]
+  exact expTwoMulFixedAccumulatorRun_suffix_eq_exp_of_start hk hInv
+
 end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- add `expTwoMulFixedAccumulatorRun_suffix_eq_exp_of_start` for running the remaining `256 - k` fixed-loop suffix from a semantically correct prefix
- add `expTwoMulFixedAccumulatorInvariant_full_of_suffix_run` to expose the final `EvmWord.exp` result from a suffix run

## Checks
- `lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedAccumulatorRun`
- `lake build EvmAsm.Evm64.Exp`
- `git diff --check`
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
