### PR TITLE
feat(div): add callable post weakeners

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -14,6 +14,7 @@ import EvmAsm.Evm64.DivMod.Spec.CallAddbackPureNat
 import EvmAsm.Evm64.DivMod.Spec.CallAddback
 import EvmAsm.Evm64.DivMod.Spec.N2RemainderWord
 import EvmAsm.Evm64.DivMod.Spec.Dispatcher
+import EvmAsm.Evm64.DivMod.Spec.CallablePost
 import EvmAsm.Evm64.DivMod.Spec.N1QuotientWord
 import EvmAsm.Evm64.DivMod.Spec.N2QuotientWord
 import EvmAsm.Evm64.DivMod.Spec.N2DivStackSpec

--- a/EvmAsm/Evm64/DivMod/Spec/CallablePost.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/CallablePost.lean
@@ -1,0 +1,155 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.CallablePost
+
+  Reusable postcondition weakeners for callable DIV/MOD no-NOP dispatcher
+  surfaces that frame exact x1/x9 separately.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.Dispatcher
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Concrete no-NOP DIV callable post bundle produced by the bzero and
+    branch-local dispatcher proofs before weakening to the public callable
+    postcondition. -/
+@[irreducible]
+def divConcretePostNoX1Frame (sp : Word) (a b : EvmWord)
+    (x9Val raVal v2 v6 v7 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratch_un0 : Word) : Assertion :=
+  (((.x12 ↦ᵣ (sp + 32)) ** regOwn .x5 ** regOwn .x10 **
+    (.x0 ↦ᵣ (0 : Word)) ** evmWordIs (sp + 32) (EvmWord.div a b)) **
+   ((.x9 ↦ᵣ x9Val) ** (.x1 ↦ᵣ raVal) ** (.x2 ↦ᵣ v2) **
+      (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x11 ↦ᵣ v11) **
+      evmWordIs sp a **
+      divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0))
+
+theorem divConcretePostNoX1Frame_unfold
+    {sp : Word} {a b : EvmWord}
+    {x9Val raVal v2 v6 v7 v11 : Word}
+    {q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratch_un0 : Word} :
+    divConcretePostNoX1Frame sp a b x9Val raVal v2 v6 v7 v11
+      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratch_un0 =
+    (((.x12 ↦ᵣ (sp + 32)) ** regOwn .x5 ** regOwn .x10 **
+      (.x0 ↦ᵣ (0 : Word)) ** evmWordIs (sp + 32) (EvmWord.div a b)) **
+     ((.x9 ↦ᵣ x9Val) ** (.x1 ↦ᵣ raVal) ** (.x2 ↦ᵣ v2) **
+        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x11 ↦ᵣ v11) **
+        evmWordIs sp a **
+        divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratch_un0)) := by
+  delta divConcretePostNoX1Frame
+  rfl
+
+/-- Weaken the concrete no-NOP DIV callable post bundle to the public
+    callable postcondition plus the caller-framed exact `x1` and `x9` atoms. -/
+theorem divConcretePostNoX1_weaken_callable_frame
+    (sp : Word) (a b : EvmWord)
+    {x9Val raVal v2 v6 v7 v11 : Word}
+    {q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratch_un0 : Word} :
+    ∀ h : PartialState,
+      divConcretePostNoX1Frame sp a b x9Val raVal v2 v6 v7 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0 h →
+      (((divStackDispatchPostCallable sp a b ** (.x1 ↦ᵣ raVal)) **
+        (.x9 ↦ᵣ x9Val)) h) := by
+  intro h hp
+  rw [divConcretePostNoX1Frame_unfold] at hp
+  rw [divStackDispatchPostCallable_unfold]
+  simp only [sepConj_assoc', sepConj_comm', sepConj_left_comm'] at hp ⊢
+  have hOwn :
+      (divScratchOwnCallNoX1 sp ** evmWordIs sp a ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x1 ↦ᵣ raVal) ** regOwn .x11 ** (.x12 ↦ᵣ (sp + 32)) **
+        regOwn .x2 ** regOwn .x6 ** regOwn .x7 ** (.x9 ↦ᵣ x9Val) **
+        regOwn .x10 ** regOwn .x5 ** evmWordIs (sp + 32) (EvmWord.div a b)) h := by
+    refine sepConj_mono ?_ ?_ h hp
+    · intro hLeft hpLeft
+      exact divScratchValuesCallNoX1_implies_divScratchOwnCallNoX1
+        sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem
+          retMem dMem dloMem scratch_un0 hLeft hpLeft
+    · apply sepConj_mono_right
+      apply sepConj_mono_right
+      apply sepConj_mono_right
+      apply sepConj_mono (regIs_implies_regOwn .x11 (v := v11))
+      apply sepConj_mono_right
+      apply sepConj_mono (regIs_implies_regOwn .x2 (v := v2))
+      apply sepConj_mono (regIs_implies_regOwn .x6 (v := v6))
+      apply sepConj_mono (regIs_implies_regOwn .x7 (v := v7))
+      exact fun _ hp => hp
+  exact by xperm_hyp hOwn
+
+/-- Concrete no-NOP MOD callable post bundle before weakening. -/
+@[irreducible]
+def modConcretePostNoX1Frame (sp : Word) (a b : EvmWord)
+    (x9Val raVal v2 v6 v7 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratch_un0 : Word) : Assertion :=
+  (((.x12 ↦ᵣ (sp + 32)) ** regOwn .x5 ** regOwn .x10 **
+    (.x0 ↦ᵣ (0 : Word)) ** evmWordIs (sp + 32) (EvmWord.mod a b)) **
+   ((.x9 ↦ᵣ x9Val) ** (.x1 ↦ᵣ raVal) ** (.x2 ↦ᵣ v2) **
+      (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x11 ↦ᵣ v11) **
+      evmWordIs sp a **
+      divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0))
+
+theorem modConcretePostNoX1Frame_unfold
+    {sp : Word} {a b : EvmWord}
+    {x9Val raVal v2 v6 v7 v11 : Word}
+    {q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratch_un0 : Word} :
+    modConcretePostNoX1Frame sp a b x9Val raVal v2 v6 v7 v11
+      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratch_un0 =
+    (((.x12 ↦ᵣ (sp + 32)) ** regOwn .x5 ** regOwn .x10 **
+      (.x0 ↦ᵣ (0 : Word)) ** evmWordIs (sp + 32) (EvmWord.mod a b)) **
+     ((.x9 ↦ᵣ x9Val) ** (.x1 ↦ᵣ raVal) ** (.x2 ↦ᵣ v2) **
+      (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x11 ↦ᵣ v11) **
+      evmWordIs sp a **
+      divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0)) := by
+  delta modConcretePostNoX1Frame
+  rfl
+
+/-- MOD counterpart of `divConcretePostNoX1_weaken_callable_frame`. -/
+theorem modConcretePostNoX1_weaken_callable_frame
+    (sp : Word) (a b : EvmWord)
+    {x9Val raVal v2 v6 v7 v11 : Word}
+    {q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratch_un0 : Word} :
+    ∀ h : PartialState,
+      modConcretePostNoX1Frame sp a b x9Val raVal v2 v6 v7 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0 h →
+      (((modStackDispatchPostCallable sp a b ** (.x1 ↦ᵣ raVal)) **
+        (.x9 ↦ᵣ x9Val)) h) := by
+  intro h hp
+  rw [modConcretePostNoX1Frame_unfold] at hp
+  rw [modStackDispatchPostCallable_unfold]
+  simp only [sepConj_assoc', sepConj_comm', sepConj_left_comm'] at hp ⊢
+  have hOwn :
+      (divScratchOwnCallNoX1 sp ** evmWordIs sp a ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x1 ↦ᵣ raVal) ** regOwn .x11 ** (.x12 ↦ᵣ (sp + 32)) **
+        regOwn .x2 ** regOwn .x6 ** regOwn .x7 ** (.x9 ↦ᵣ x9Val) **
+        regOwn .x10 ** regOwn .x5 ** evmWordIs (sp + 32) (EvmWord.mod a b)) h := by
+    refine sepConj_mono ?_ ?_ h hp
+    · intro hLeft hpLeft
+      exact divScratchValuesCallNoX1_implies_divScratchOwnCallNoX1
+        sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem
+          retMem dMem dloMem scratch_un0 hLeft hpLeft
+    · apply sepConj_mono_right
+      apply sepConj_mono_right
+      apply sepConj_mono_right
+      apply sepConj_mono (regIs_implies_regOwn .x11 (v := v11))
+      apply sepConj_mono_right
+      apply sepConj_mono (regIs_implies_regOwn .x2 (v := v2))
+      apply sepConj_mono (regIs_implies_regOwn .x6 (v := v6))
+      apply sepConj_mono (regIs_implies_regOwn .x7 (v := v7))
+      exact fun _ hp => hp
+  exact by xperm_hyp hOwn
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add reusable DIV/MOD no-X1 concrete post bundles for callable dispatcher surfaces
- add weakeners from those bundles to div/mod callable postconditions with exact x1/x9 framed
- import the helper through DivMod.Spec for downstream SDIV Phase 0 work

## Bead
- Progress on evm-asm-9iqmw.2.1; this is a helper slice, not closure of the blocker.

## Tests
- lake build EvmAsm.Evm64.DivMod.Spec.CallablePost
- lake build EvmAsm.Evm64.DivMod
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh