### PR TITLE
feat(exp): add closed fixed-iteration peel splits

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostBridge.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterCasePostBridge.lean
@@ -1020,4 +1020,69 @@ theorem exp_two_mul_fixed_iterations_body_peel_with_case_continuations_closed_bo
       r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
       v7 v11 base exit_ R hbase hLoop hExit
 
+/-- Closed-form non-final arbitrary-iteration peel.  This is the arithmetic
+    presentation used by Nat induction over the remaining fixed-loop length. -/
+theorem exp_two_mul_fixed_iterations_body_peel_case_nonfinal_closed_bound_spec_within
+    (iterations : Nat)
+    (e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word)
+    (base : Word) (R : Assertion)
+    (hbase : (base + 44 : Word) &&& 1 = 0)
+    (hne : expTwoMulIterCountNew iterCount ≠ 0) :
+    (cpsTripleWithin (iterations * 193)
+      (base + 44) (base + 296)
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterCaseLoopPost iterCount e c6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base)
+      R) →
+    cpsTripleWithin ((iterations + 1) * 193)
+      (base + 44)
+      (base + 296)
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterPre e c6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+        v7 v11)
+      R := by
+  intro hLoop
+  rw [← expTwoMulFixedIterationsBodyBound_eq iterations] at hLoop
+  rw [← expTwoMulFixedIterationsBodyBound_eq (iterations + 1)]
+  exact
+    exp_two_mul_fixed_iterations_body_peel_case_nonfinal_spec_within
+      iterations
+      e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 base R hbase hne hLoop
+
+/-- Closed-form final arbitrary-iteration peel.  The remaining loop branch is
+    impossible, so the theorem exposes only the final exit bridge. -/
+theorem exp_two_mul_fixed_iterations_body_peel_case_final_closed_bound_spec_within
+    (iterations : Nat)
+    (e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word)
+    (base : Word) (R : Assertion)
+    (hbase : (base + 44 : Word) &&& 1 = 0)
+    (hzero : expTwoMulIterCountNew iterCount = 0)
+    (hExit :
+      ∀ ps,
+        expTwoMulFixedIterCaseExitPost iterCount e c6 ptr nextLimb sp evmSp
+          r0 r1 r2 r3 a0 a1 a2 a3 base ps →
+        R ps) :
+    cpsTripleWithin ((iterations + 1) * 193)
+      (base + 44)
+      (base + 296)
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterPre e c6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+        v7 v11)
+      R := by
+  rw [← expTwoMulFixedIterationsBodyBound_eq (iterations + 1)]
+  exact
+    exp_two_mul_fixed_iterations_body_peel_case_final_spec_within
+      iterations
+      e c6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 base R hbase hzero hExit
+
 end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- add closed-bound non-final arbitrary fixed-iteration peel helper
- add closed-bound final arbitrary fixed-iteration peel helper
- expose the arithmetic form needed by Nat induction over the remaining EXP fixed-loop length

## Validation
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCasePostBridge
- lake build EvmAsm.Evm64.Exp
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh