### PR TITLE
feat(sdiv): route bzero handoff through concrete div callable

### DIFF
--- a/EvmAsm/Evm64/DivMod/Callable.lean
+++ b/EvmAsm/Evm64/DivMod/Callable.lean
@@ -634,6 +634,96 @@ theorem evm_div_callable_spec_from_noNop_branch_return_x1_framed
         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
         nMem shiftMem jMem retMem dMem dloMem scratchUn0 branch hStack)
 
+/-- Generic concrete callable DIV wrapper for no-NOP body proofs that preserve
+    exact caller-framed `x1`/`x9` and expose the concrete scratch/register
+    values needed by SDIV branch handoffs. -/
+theorem evm_div_callable_spec_from_noNop_concrete_preserving_x1_x9
+    (sp base x9Val raVal : Word) (a b : EvmWord)
+    (v2 v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (hStack :
+      cpsTripleWithin unifiedDivBound base (base + nopOff) (divCode_noNop base)
+        (divModStackDispatchPreNoX1 sp a b
+          x9Val raVal v2 v5 v6 v7 v10 v11
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+        (divConcretePostNoX1Frame sp a b x9Val raVal v2 v6 v7 v11
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0)) :
+    cpsTripleWithin (unifiedDivBound + 1) base (raVal &&& ~~~1)
+      (evm_div_callable_code base)
+      (divModStackDispatchPreNoX1 sp a b
+        x9Val raVal v2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+      (divConcretePostNoX1Frame sp a b x9Val raVal v2 v6 v7 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0) := by
+  let retFrame : Assertion :=
+    (((.x12 ↦ᵣ (sp + 32)) ** regOwn .x5 ** regOwn .x10 **
+      (.x0 ↦ᵣ (0 : Word)) ** evmWordIs (sp + 32) (EvmWord.div a b)) **
+     ((.x9 ↦ᵣ x9Val) ** (.x2 ↦ᵣ v2) **
+        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x11 ↦ᵣ v11) **
+        evmWordIs sp a **
+        divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0))
+  have hStackCall :=
+    cpsTripleWithin_extend_code (hmono := divCode_noNop_sub_div_callable_code) hStack
+  have hStackForRet :
+      cpsTripleWithin unifiedDivBound base (base + nopOff) (evm_div_callable_code base)
+        (divModStackDispatchPreNoX1 sp a b
+          x9Val raVal v2 v5 v6 v7 v10 v11
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+        (retFrame ** (.x1 ↦ᵣ raVal)) :=
+    cpsTripleWithin_weaken (fun _ hp => hp) (fun _ hp => by
+      rw [divConcretePostNoX1Frame_unfold] at hp
+      dsimp [retFrame] at hp ⊢
+      xperm_hyp hp) hStackCall
+  have hRet :=
+    cpsTripleWithin_extend_code (hmono := evm_div_callable_code_ret_sub (base := base))
+      (ret_spec_within' (base + nopOff) raVal)
+  have hRetFramed :=
+    cpsTripleWithin_frameL retFrame
+      (by
+        dsimp [retFrame]
+        rw [divScratchValuesCallNoX1_unfold, divScratchValues_unfold]
+        pcFree)
+      hRet
+  exact cpsTripleWithin_weaken (fun _ hp => hp) (fun _ hp => by
+    rw [divConcretePostNoX1Frame_unfold]
+    dsimp [retFrame] at hp ⊢
+    xperm_hyp hp)
+    (cpsTripleWithin_seq_same_cr hStackForRet hRetFramed)
+
+/-- Zero-divisor DIV callable wrapper in the concrete post shape used by SDIV
+    branch handoffs before weakening to the public callable postcondition. -/
+theorem evm_div_callable_bzero_concrete_preserving_x1_spec
+    (sp base x9Val raVal : Word)
+    (a b : EvmWord) (v2 v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (hbz : b = 0) :
+    cpsTripleWithin (unifiedDivBound + 1) base (raVal &&& ~~~1)
+      (evm_div_callable_code base)
+      (divModStackDispatchPreNoX1 sp a b
+        x9Val raVal v2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+      (divConcretePostNoX1Frame sp a b x9Val raVal v2 v6 v7 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0) := by
+  exact
+    evm_div_callable_spec_from_noNop_concrete_preserving_x1_x9
+      sp base x9Val raVal a b v2 v5 v6 v7 v10 v11
+      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      nMem shiftMem jMem retMem dMem dloMem scratchUn0
+      (evm_div_bzero_stack_spec_within_dispatch_noNop_concrete_callable_uni
+        sp base a b x9Val raVal v2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        nMem shiftMem jMem retMem dMem dloMem scratchUn0 hbz)
+
 /-- Zero-divisor DIV callable wrapper that preserves exact `x1` for return and
     exact `x9` as caller-framed state. This callable-only surface keeps `x1`
     out of the scratch bundle. -/

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallBzeroHandoff.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallBzeroHandoff.lean
@@ -53,7 +53,7 @@ theorem saveRaDivCallDispatchReadyPost_bzero_callable_spec_in_sdivCode
     ((.x8 ↦ᵣ resultSign) **
       (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12))))
   have hCallableRaw :=
-    EvmAsm.Evm64.evm_div_callable_bzero_preserving_x1_spec
+    EvmAsm.Evm64.evm_div_callable_bzero_concrete_preserving_x1_spec
       sp (base + wrapperEndOff) divisorSign ((base + divCallOff) + 4)
       dividendAbsWord divisorAbsWord v2 v5 v6 divisorSum3 divisorMask divisorCarry3
       q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
@@ -74,9 +74,10 @@ theorem saveRaDivCallDispatchReadyPost_bzero_callable_spec_in_sdivCode
           q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
           signFrameNoX9)
-        (((EvmAsm.Evm64.divStackDispatchPostCallable sp dividendAbsWord divisorAbsWord **
-          (.x1 ↦ᵣ ((base + divCallOff) + 4))) **
-          (.x9 ↦ᵣ divisorSign)) ** signFrameNoX9) := by
+        (EvmAsm.Evm64.divConcretePostNoX1Frame sp dividendAbsWord divisorAbsWord
+          divisorSign ((base + divCallOff) + 4) v2 v6 divisorSum3 divisorCarry3
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0 ** signFrameNoX9) := by
     rw [← divCall_return_andn_one_eq_resultSignFixOff base hbase]
     exact hCallableFramed
   exact EvmAsm.Rv64.cpsTripleWithin_weaken (fun h hp => by
@@ -89,10 +90,19 @@ theorem saveRaDivCallDispatchReadyPost_bzero_callable_spec_in_sdivCode
       sdivAbsCarry3] at hp ⊢
     dsimp [signFrameNoX9] at hp ⊢
     exact hp) (fun h hp => by
+    have hPublic :
+        ((((EvmAsm.Evm64.divStackDispatchPostCallable sp dividendAbsWord divisorAbsWord **
+          (.x1 ↦ᵣ ((base + divCallOff) + 4))) **
+          (.x9 ↦ᵣ divisorSign)) ** signFrameNoX9) h) := by
+      refine EvmAsm.Rv64.sepConj_mono ?_ ?_ h hp
+      · intro hLeft hpLeft
+        exact EvmAsm.Evm64.divConcretePostNoX1_weaken_callable_frame
+          sp dividendAbsWord divisorAbsWord hLeft hpLeft
+      · intro hRight hpRight
+        exact hpRight
     rw [saveRaDivCallBzeroCallablePost_unfold]
     dsimp [dividendAbsWord, divisorAbsWord, divisorSign, resultSign, signFrameNoX9,
-      saveRaDivCallSignFrame, sdivDivCallResultSign, sdivAbsSign] at hp ⊢
-    simpa only [EvmAsm.Rv64.sepConj_assoc', EvmAsm.Rv64.sepConj_comm',
-      EvmAsm.Rv64.sepConj_left_comm'] using hp) hCallableExit
+      saveRaDivCallSignFrame, sdivDivCallResultSign, sdivAbsSign] at hp hPublic ⊢
+    xperm_hyp hPublic) hCallableExit
 
 end EvmAsm.Evm64.SDiv.Compose


### PR DESCRIPTION
## Summary
- add a generic DIV callable wrapper that preserves the concrete no-NOP post through cc_ret
- add the bzero specialization over the existing concrete dispatcher theorem
- route the SDIV zero-divisor div-call handoff through the concrete DIV callable surface before weakening to the named public post

## Verification
- lake build EvmAsm.Evm64.DivMod.Callable
- lake build EvmAsm.Evm64.SDiv.Compose.DivCallBzeroHandoff
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh