### PR TITLE
feat(exp): bridge fixed loop post to state pre

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateStep.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateStep.lean
@@ -10,6 +10,225 @@ namespace EvmAsm.Evm64.Exp.Compose
 
 open EvmAsm.Rv64
 
+/-- Repackage the branch side of a fixed-loop step post from the older
+    `WithControlFrame` surface to the state-carrying `WithStateFrame` surface.
+    Reload-pointer branches remain as residuals because they still need their
+    reload block before re-entering the next iteration precondition. -/
+theorem expTwoMulFixedIterStepPostNWithControlFrame_branchState_or_reload
+    {baseWord exponentWord : EvmWord} {k : Nat}
+    {iterCount e controlC6 ptr nextLimb nextNextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
+    {frame : Assertion} {ps : PartialState}
+    (hk : k < 256)
+    (hCount : expTwoMulFixedIterCountInvariant k iterCount)
+    (h :
+      expTwoMulFixedIterStepPostNWithControlFrame k baseWord exponentWord
+        iterCount e controlC6 ptr nextLimb nextNextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base frame ps) :
+    (∃ bit v6 v7 v10 v11 d0 d1 d2 d3,
+      let outW := expTwoMulFixedBranchResult bit
+        a0 a1 a2 a3 r0 r1 r2 r3
+      expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
+        (controlC6 + signExtend12 (-1 : BitVec 12))
+        (e <<< (1 : BitVec 6).toNat)
+        v6
+        (expTwoMulIterCountNew iterCount)
+        v10
+        ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+        ptr nextLimb sp evmSp
+        (outW.getLimbN 3)
+        (expTwoMulFixedBranchReturnPc bit base)
+        (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
+        (outW.getLimbN 3)
+        d0 d1 d2 d3
+        (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
+        (outW.getLimbN 3)
+        a0 a1 a2 a3 v7 v11
+        frame ps) ∨
+    (∃ bit v6 v7 v10 v11 d0 d1 d2 d3,
+      expTwoMulFixedReloadBranchResidualWithControlFrame bit (k := k)
+        baseWord exponentWord iterCount e controlC6 ptr nextLimb
+        nextNextLimb sp evmSp r0 r1 r2 r3 a0 a1 a2 a3 base
+        v6 v7 v10 v11 d0 d1 d2 d3 frame ps) := by
+  rcases expTwoMulFixedIterStepPostNWithControlFrame_cases h with
+    hBranch | hReload
+  · rcases hBranch with ⟨bit, v6, v7, v10, v11, d0, d1, d2, d3, hPre⟩
+    exact Or.inl
+      ⟨bit, v6, v7, v10, v11, d0, d1, d2, d3,
+        expTwoMulFixedIterPreNWithControlFrame_to_iterPreNWithStateFrame
+          (expTwoMulFixedIterCountInvariant_succ hk hCount) hPre⟩
+  · exact Or.inr hReload
+
+/-- Case-loop post bridge for the fixed-loop induction: from the current
+    semantic state, the loop-back post either re-enters the next state-carrying
+    iteration precondition, or lands in the reload-pointer residual branch. -/
+theorem expTwoMulFixedIterCaseLoopPost_branchState_or_reload
+    {baseWord exponentWord : EvmWord} {k : Nat}
+    {iterCount e controlC6 ptr nextLimb nextNextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
+    {frame : Assertion} {ps : PartialState}
+    (hk : k < 256)
+    (hBase : baseWord = expResultWord a0 a1 a2 a3)
+    (hNextNext :
+      nextNextLimb = exponentWord.getLimbN (2 - (k + 1) / 64))
+    (hState :
+      expTwoMulFixedIterStateInvariant baseWord exponentWord k
+        iterCount e controlC6 ptr nextLimb evmSp r0 r1 r2 r3)
+    (h :
+      (expTwoMulFixedIterCaseLoopPost iterCount e controlC6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base **
+        frame) ps) :
+    (∃ bit v6 v7 v10 v11 d0 d1 d2 d3,
+      let outW := expTwoMulFixedBranchResult bit
+        a0 a1 a2 a3 r0 r1 r2 r3
+      expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
+        (controlC6 + signExtend12 (-1 : BitVec 12))
+        (e <<< (1 : BitVec 6).toNat)
+        v6
+        (expTwoMulIterCountNew iterCount)
+        v10
+        ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+        ptr nextLimb sp evmSp
+        (outW.getLimbN 3)
+        (expTwoMulFixedBranchReturnPc bit base)
+        (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
+        (outW.getLimbN 3)
+        d0 d1 d2 d3
+        (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
+        (outW.getLimbN 3)
+        a0 a1 a2 a3 v7 v11
+        frame ps) ∨
+    (∃ bit v6 v7 v10 v11 d0 d1 d2 d3,
+      expTwoMulFixedReloadBranchResidualWithControlFrame bit (k := k)
+        baseWord exponentWord iterCount e controlC6 ptr nextLimb
+        nextNextLimb sp evmSp r0 r1 r2 r3 a0 a1 a2 a3 base
+        v6 v7 v10 v11 d0 d1 d2 d3 frame ps) := by
+  exact
+    expTwoMulFixedIterStepPostNWithControlFrame_branchState_or_reload
+      hk hState.2.2.2
+      (expTwoMulFixedIterCaseLoopPost_to_stepPostNWithControlFrame
+        hk hBase hState.2.1 hState.2.2.1 hNextNext hState.1 h)
+
+/-- CPS eliminator for a fixed step post whose ordinary branch continuations
+    are already stated over the state-carrying next-iteration precondition. -/
+theorem cpsTripleWithin_expTwoMulFixedIterStepPostNWithControlFrame_branchState_elim
+    {nSteps : Nat} {addr exit : Word} {cr : CodeReq}
+    {baseWord exponentWord : EvmWord} {k : Nat}
+    {iterCount e controlC6 ptr nextLimb nextNextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
+    {frame Q : Assertion}
+    (hk : k < 256)
+    (hCount : expTwoMulFixedIterCountInvariant k iterCount)
+    (hBranch :
+      ∀ (bit : Bool)
+        (v6 v7 v10 v11 d0 d1 d2 d3 : Word),
+        cpsTripleWithin nSteps addr exit cr
+          (let outW := expTwoMulFixedBranchResult bit
+            a0 a1 a2 a3 r0 r1 r2 r3
+          expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
+            (controlC6 + signExtend12 (-1 : BitVec 12))
+            (e <<< (1 : BitVec 6).toNat)
+            v6
+            (expTwoMulIterCountNew iterCount)
+            v10
+            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+            ptr nextLimb sp evmSp
+            (outW.getLimbN 3)
+            (expTwoMulFixedBranchReturnPc bit base)
+            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
+            (outW.getLimbN 3)
+            d0 d1 d2 d3
+            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
+            (outW.getLimbN 3)
+            a0 a1 a2 a3 v7 v11
+            frame)
+          Q)
+    (hReload :
+      ∀ (bit : Bool)
+        (v6 v7 v10 v11 d0 d1 d2 d3 : Word),
+        cpsTripleWithin nSteps addr exit cr
+          (expTwoMulFixedReloadBranchResidualWithControlFrame bit (k := k)
+            baseWord exponentWord iterCount e controlC6 ptr nextLimb
+            nextNextLimb sp evmSp r0 r1 r2 r3 a0 a1 a2 a3 base
+            v6 v7 v10 v11 d0 d1 d2 d3 frame)
+          Q) :
+    cpsTripleWithin nSteps addr exit cr
+      (expTwoMulFixedIterStepPostNWithControlFrame k baseWord exponentWord
+        iterCount e controlC6 ptr nextLimb nextNextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base frame)
+      Q :=
+  cpsTripleWithin_expTwoMulFixedIterStepPostNWithControlFrame_elim
+    (fun bit v6 v7 v10 v11 d0 d1 d2 d3 =>
+      cpsTripleWithin_weaken
+        (fun _ h =>
+          expTwoMulFixedIterPreNWithControlFrame_to_iterPreNWithStateFrame
+            (expTwoMulFixedIterCountInvariant_succ hk hCount) h)
+        (fun _ h => h)
+        (hBranch bit v6 v7 v10 v11 d0 d1 d2 d3))
+    hReload
+
+/-- CPS case-loop bridge for the fixed-loop induction.  The non-reload
+    recursive edge is presented as a `WithStateFrame (k+1)` precondition;
+    reload-pointer edges stay as residuals for the existing reload handlers. -/
+theorem cpsTripleWithin_expTwoMulFixedIterCaseLoopPost_branchState_elim
+    {nSteps : Nat} {addr exit : Word} {cr : CodeReq}
+    {baseWord exponentWord : EvmWord} {k : Nat}
+    {iterCount e controlC6 ptr nextLimb nextNextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word}
+    {frame Q : Assertion}
+    (hk : k < 256)
+    (hBase : baseWord = expResultWord a0 a1 a2 a3)
+    (hNextNext :
+      nextNextLimb = exponentWord.getLimbN (2 - (k + 1) / 64))
+    (hState :
+      expTwoMulFixedIterStateInvariant baseWord exponentWord k
+        iterCount e controlC6 ptr nextLimb evmSp r0 r1 r2 r3)
+    (hBranch :
+      ∀ (bit : Bool)
+        (v6 v7 v10 v11 d0 d1 d2 d3 : Word),
+        cpsTripleWithin nSteps addr exit cr
+          (let outW := expTwoMulFixedBranchResult bit
+            a0 a1 a2 a3 r0 r1 r2 r3
+          expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
+            (controlC6 + signExtend12 (-1 : BitVec 12))
+            (e <<< (1 : BitVec 6).toNat)
+            v6
+            (expTwoMulIterCountNew iterCount)
+            v10
+            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+            ptr nextLimb sp evmSp
+            (outW.getLimbN 3)
+            (expTwoMulFixedBranchReturnPc bit base)
+            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
+            (outW.getLimbN 3)
+            d0 d1 d2 d3
+            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
+            (outW.getLimbN 3)
+            a0 a1 a2 a3 v7 v11
+            frame)
+          Q)
+    (hReload :
+      ∀ (bit : Bool)
+        (v6 v7 v10 v11 d0 d1 d2 d3 : Word),
+        cpsTripleWithin nSteps addr exit cr
+          (expTwoMulFixedReloadBranchResidualWithControlFrame bit (k := k)
+            baseWord exponentWord iterCount e controlC6 ptr nextLimb
+            nextNextLimb sp evmSp r0 r1 r2 r3 a0 a1 a2 a3 base
+            v6 v7 v10 v11 d0 d1 d2 d3 frame)
+          Q) :
+    cpsTripleWithin nSteps addr exit cr
+      (expTwoMulFixedIterCaseLoopPost iterCount e controlC6 ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 base **
+        frame)
+      Q := by
+  simpa [Nat.zero_add, CodeReq.union_empty_left] using
+    cpsTripleWithin_seq
+      (CodeReq.Disjoint.empty_left cr)
+      (cpsTripleWithin_expTwoMulFixedIterCaseLoopPost_to_stepPostNWithControlFrame
+        addr frame hk hBase hState.2.1 hState.2.2.1 hNextNext hState.1)
+      (cpsTripleWithin_expTwoMulFixedIterStepPostNWithControlFrame_branchState_elim
+        hk hState.2.2.2 hBranch hReload)
+
 /-- Bounded one-step wrapper whose nonzero decremented-count premise comes
     from the bundled fixed-loop count invariant. -/
 theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_to_stepPost_of_count_bounded


### PR DESCRIPTION
## Summary
- add assertion-level fixed-loop bridges that repackage branch step posts from WithControlFrame to WithStateFrame at k+1
- add a case-loop post bridge that uses the current expTwoMulFixedIterStateInvariant to expose the next state-carrying precondition
- add CPS eliminators so the future Nat induction can provide recursive branch continuations over WithStateFrame directly, while leaving reload-pointer residuals to the existing reload handlers

## Verification
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterStateStep
- lake build EvmAsm.Evm64.Exp
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh