### PR TITLE
feat(sdiv): expose concrete div callable wrapper

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/DivCallExactCallable.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallExactCallable.lean
@@ -94,6 +94,80 @@ theorem evm_div_callable_preserving_x1_x9_exact_pre_spec_in_sdivCode
         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
         nMem shiftMem jMem retMem dMem dloMem scratchUn0 hStack)
 
+/-- Concrete-post variant of
+    `evm_div_callable_preserving_x1_x9_exact_pre_spec_in_sdivCode`.
+
+    This keeps the concrete scratch/register post bundle across the embedded
+    unsigned-DIV callable before later SDIV handoffs weaken it to the public
+    callable postcondition. -/
+theorem evm_div_callable_concrete_preserving_x1_x9_exact_pre_spec_in_sdivCode
+    (sp base x9Val raVal : Word) (a b : EvmWord) (v2 v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (hStack :
+      EvmAsm.Rv64.cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
+        (base + wrapperEndOff)
+        ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
+        (EvmAsm.Evm64.divCode_noNop (base + wrapperEndOff))
+        (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp a b
+          x9Val raVal v2 v5 v6 v7 v10 v11
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+        (EvmAsm.Evm64.divConcretePostNoX1Frame sp a b x9Val raVal v2 v6 v7 v11
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0)) :
+    EvmAsm.Rv64.cpsTripleWithin (EvmAsm.Evm64.unifiedDivBound + 1)
+      (base + wrapperEndOff) (raVal &&& ~~~1) (sdivCode base)
+      (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp a b
+        x9Val raVal v2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+      (EvmAsm.Evm64.divConcretePostNoX1Frame sp a b x9Val raVal v2 v6 v7 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0) := by
+  exact
+    EvmAsm.Rv64.cpsTripleWithin_extend_code
+      (hmono := evm_div_callable_code_sub_sdivCode (base := base))
+      (EvmAsm.Evm64.evm_div_callable_spec_from_noNop_concrete_preserving_x1_x9
+        sp (base + wrapperEndOff) x9Val raVal a b v2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        nMem shiftMem jMem retMem dMem dloMem scratchUn0 hStack)
+
+/-- Framed variant of
+    `evm_div_callable_concrete_preserving_x1_x9_exact_pre_spec_in_sdivCode`. -/
+theorem evm_div_callable_concrete_preserving_x1_x9_exact_pre_framed_spec_in_sdivCode
+    {F : EvmAsm.Rv64.Assertion} [EvmAsm.Rv64.Assertion.PCFree F]
+    (sp base x9Val raVal : Word) (a b : EvmWord) (v2 v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (hStack :
+      EvmAsm.Rv64.cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
+        (base + wrapperEndOff)
+        ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
+        (EvmAsm.Evm64.divCode_noNop (base + wrapperEndOff))
+        (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp a b
+          x9Val raVal v2 v5 v6 v7 v10 v11
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+        (EvmAsm.Evm64.divConcretePostNoX1Frame sp a b x9Val raVal v2 v6 v7 v11
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0)) :
+    EvmAsm.Rv64.cpsTripleWithin (EvmAsm.Evm64.unifiedDivBound + 1)
+      (base + wrapperEndOff) (raVal &&& ~~~1) (sdivCode base)
+      (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp a b
+        x9Val raVal v2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 ** F)
+      (EvmAsm.Evm64.divConcretePostNoX1Frame sp a b x9Val raVal v2 v6 v7 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 ** F) := by
+  exact
+    EvmAsm.Rv64.cpsTripleWithin_frameR F (by pcFree)
+      (evm_div_callable_concrete_preserving_x1_x9_exact_pre_spec_in_sdivCode
+        sp base x9Val raVal a b v2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        nMem shiftMem jMem retMem dMem dloMem scratchUn0 hStack)
+
 /-- Branch-certificate specialization of
     `evm_div_callable_preserving_x1_exact_pre_spec_in_sdivCode`.
 


### PR DESCRIPTION
## Summary
- add an SDIV-embedded concrete-post wrapper around the unsigned DIV callable exact-pre surface
- add the matching PC-free framed wrapper for SDIV sign-frame handoffs
- keep the concrete divConcretePostNoX1Frame available inside sdivCode before downstream handoffs weaken to the public callable post

## Verification
- lake build EvmAsm.Evm64.SDiv.Compose.DivCallExactCallable
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh