### PR TITLE
feat(exp): add unframed state step wrapper

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateStep.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateStep.lean
@@ -778,6 +778,78 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_state_step
       (by omega) hCount hBranch hReload)
 
 /-- Unframed variant of
+    `cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_state_step`. -/
+theorem cpsTripleWithin_expTwoMulFixedIterPreNWithState_state_step
+    {baseWord exponentWord : EvmWord} {k : Nat}
+    {nBound nSteps : Nat} {exit : Word} {cr : CodeReq}
+    (controlC6 e machineC6 iterCount v10 v18 ptr nextLimb
+      nextNextLimb sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
+      e0 e1 e2 e3 a0 a1 a2 a3 v7 v11 : Word)
+    (base : Word)
+    (Q : Assertion)
+    (hDisjoint :
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base).Disjoint cr)
+    (hbase : (base + 44 : Word) &&& 1 = 0)
+    (hControlMachine : controlC6 = machineC6)
+    (hk : k < 255)
+    (hCount : expTwoMulFixedIterCountInvariant k iterCount)
+    (hBase : baseWord = expResultWord a0 a1 a2 a3)
+    (hNextNext :
+      nextNextLimb = exponentWord.getLimbN (2 - (k + 1) / 64))
+    (hBound : 193 ≤ nBound)
+    (hBranch :
+      ∀ (bit : Bool)
+        (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        cpsTripleWithin nSteps (base + 44) exit cr
+          (let outW := expTwoMulFixedBranchResult bit
+            a0 a1 a2 a3 r0 r1 r2 r3
+          expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
+            (controlC6 + signExtend12 (-1 : BitVec 12))
+            (e <<< (1 : BitVec 6).toNat)
+            v6'
+            (expTwoMulIterCountNew iterCount)
+            v10'
+            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+            ptr nextLimb sp evmSp
+            (outW.getLimbN 3)
+            (expTwoMulFixedBranchReturnPc bit base)
+            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
+            (outW.getLimbN 3)
+            d0' d1' d2' d3'
+            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
+            (outW.getLimbN 3)
+            a0 a1 a2 a3 v7' v11'
+            empAssertion)
+          Q)
+    (hReload :
+      ∀ (bit : Bool)
+        (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        cpsTripleWithin nSteps (base + 44) exit cr
+          (expTwoMulFixedReloadBranchResidualWithStateFrame bit (k := k)
+            baseWord exponentWord iterCount e controlC6 ptr nextLimb
+            nextNextLimb sp evmSp r0 r1 r2 r3 a0 a1 a2 a3 base
+            v6' v7' v10' v11' d0' d1' d2' d3' empAssertion)
+          Q) :
+    cpsTripleWithin (nBound + nSteps) (base + 44) exit
+      ((evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base).union cr)
+      (expTwoMulFixedIterPreNWithState k baseWord exponentWord
+        controlC6 e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+        a0 a1 a2 a3 v7 v11)
+      Q :=
+  cpsTripleWithin_weaken
+    (fun _ h => by
+      rw [expTwoMulFixedIterPreNWithStateFrame_unfold, sepConj_emp_right']
+      exact h)
+    (fun _ h => h)
+    (cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_state_step
+      controlC6 e machineC6 iterCount v10 v18 ptr nextLimb nextNextLimb
+      sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+      a0 a1 a2 a3 v7 v11 base empAssertion Q hDisjoint
+      (by pcFree) hbase hControlMachine hk hCount hBase hNextNext hBound
+      hBranch hReload)
+
+/-- Unframed variant of
     `cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_to_stepPost_of_count_bounded`. -/
 theorem cpsTripleWithin_expTwoMulFixedIterPreNWithState_to_stepPost_of_count_bounded
     {baseWord exponentWord : EvmWord} {k : Nat}


### PR DESCRIPTION
## Summary
- add the unframed counterpart to the EXP state-step continuation wrapper
- instantiate the framed state-step theorem at `empAssertion` and weaken from `expTwoMulFixedIterPreNWithState`
- keep ordinary and reload recursive continuations on successor-state surfaces

## Validation
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterStateStep
- lake build EvmAsm.Evm64.Exp
- git diff --check origin/main
- scripts/check-file-size.sh
- scripts/check-unimported.sh

Builds on merged PR #4962.
Bead: evm-asm-20z6.13.7.1