### PR TITLE
feat(exp): add CPS reload residual re-entry wrappers

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateResidualBridge.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateResidualBridge.lean
@@ -63,6 +63,51 @@ theorem expTwoMulFixedReloadBranchResidualWithStateFrame_false_to_iterPreNWithSt
     evmWordIs] at h ⊢
   sep_perm h
 
+/-- CPS form of
+    `expTwoMulFixedReloadBranchResidualWithStateFrame_false_to_iterPreNWithStateFrame`. -/
+theorem cpsTripleWithin_expTwoMulFixedReloadBranchResidualWithStateFrame_false_to_iterPreNWithStateFrame
+    {nSteps : Nat} {entry exit : Word} {cr : CodeReq}
+    {baseWord exponentWord : EvmWord} {k : Nat}
+    {iterCount e c6 ptr nextLimb nextNextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base
+      v6 v7 v10 v11 d0 d1 d2 d3 : Word}
+    {frame Q : Assertion}
+    (hNext :
+      let squareW := expSquaringCallSquareW r0 r1 r2 r3
+      cpsTripleWithin nSteps entry exit cr
+        (expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
+          64 nextLimb v6 (expTwoMulIterCountNew iterCount) v10
+          ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+          (ptr + signExtend12 (-8 : BitVec 12)) nextNextLimb sp evmSp
+          (squareW.getLimbN 3) (((base + 44) + 32) + 68)
+          (squareW.getLimbN 0) (squareW.getLimbN 1)
+          (squareW.getLimbN 2) (squareW.getLimbN 3)
+          d0 d1 d2 d3
+          (squareW.getLimbN 0) (squareW.getLimbN 1)
+          (squareW.getLimbN 2) (squareW.getLimbN 3)
+          a0 a1 a2 a3 v7 v11
+          (((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
+            ⌜expTwoMulIterCountNew iterCount ≠ 0⌝ **
+            ⌜c6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
+            ⌜(e >>> (63 : BitVec 6).toNat) +
+              signExtend12 (0 : BitVec 12) = 0⌝ **
+            frame))
+        Q) :
+    cpsTripleWithin nSteps entry exit cr
+      (expTwoMulFixedReloadBranchResidualWithStateFrame false (k := k)
+        baseWord exponentWord iterCount e c6 ptr nextLimb nextNextLimb
+        sp evmSp r0 r1 r2 r3 a0 a1 a2 a3 base
+        v6 v7 v10 v11 d0 d1 d2 d3
+        (((ptr + signExtend12 (-8 : BitVec 12) +
+            signExtend12 (0 : BitVec 12)) ↦ₘ nextNextLimb) ** frame))
+      Q :=
+  cpsTripleWithin_weaken
+    (fun _ h =>
+      expTwoMulFixedReloadBranchResidualWithStateFrame_false_to_iterPreNWithStateFrame
+        h)
+    (fun _ h => h)
+    hNext
+
 /-- A true-bit reload residual can re-enter the next state-carrying fixed
     iteration precondition once the remaining frame supplies the following
     pointer cell. -/
@@ -115,5 +160,51 @@ theorem expTwoMulFixedReloadBranchResidualWithStateFrame_true_to_iterPreNWithSta
     ne_eq,
     evmWordIs] at h ⊢
   sep_perm h
+
+/-- CPS form of
+    `expTwoMulFixedReloadBranchResidualWithStateFrame_true_to_iterPreNWithStateFrame`. -/
+theorem cpsTripleWithin_expTwoMulFixedReloadBranchResidualWithStateFrame_true_to_iterPreNWithStateFrame
+    {nSteps : Nat} {entry exit : Word} {cr : CodeReq}
+    {baseWord exponentWord : EvmWord} {k : Nat}
+    {iterCount e c6 ptr nextLimb nextNextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base
+      v6 v7 v10 v11 d0 d1 d2 d3 : Word}
+    {frame Q : Assertion}
+    (hNext :
+      let rw := expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3)
+        a0 a1 a2 a3
+      cpsTripleWithin nSteps entry exit cr
+        (expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
+          64 nextLimb v6 (expTwoMulIterCountNew iterCount) v10
+          ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+          (ptr + signExtend12 (-8 : BitVec 12)) nextNextLimb sp evmSp
+          (rw.getLimbN 3) (((base + 44) + 140) + 68)
+          (rw.getLimbN 0) (rw.getLimbN 1)
+          (rw.getLimbN 2) (rw.getLimbN 3)
+          d0 d1 d2 d3
+          (rw.getLimbN 0) (rw.getLimbN 1)
+          (rw.getLimbN 2) (rw.getLimbN 3)
+          a0 a1 a2 a3 v7 v11
+          (((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
+            ⌜expTwoMulIterCountNew iterCount ≠ 0⌝ **
+            ⌜c6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
+            ⌜(e >>> (63 : BitVec 6).toNat) +
+              signExtend12 (0 : BitVec 12) ≠ 0⌝ **
+            frame))
+        Q) :
+    cpsTripleWithin nSteps entry exit cr
+      (expTwoMulFixedReloadBranchResidualWithStateFrame true (k := k)
+        baseWord exponentWord iterCount e c6 ptr nextLimb nextNextLimb
+        sp evmSp r0 r1 r2 r3 a0 a1 a2 a3 base
+        v6 v7 v10 v11 d0 d1 d2 d3
+        (((ptr + signExtend12 (-8 : BitVec 12) +
+            signExtend12 (0 : BitVec 12)) ↦ₘ nextNextLimb) ** frame))
+      Q :=
+  cpsTripleWithin_weaken
+    (fun _ h =>
+      expTwoMulFixedReloadBranchResidualWithStateFrame_true_to_iterPreNWithStateFrame
+        h)
+    (fun _ h => h)
+    hNext
 
 end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- add CPS weaken wrappers for the false/true reload-residual re-entry bridges
- let recursive callers discharge hReload by supplying the next expTwoMulFixedIterPreNWithStateFrame continuation directly
- builds on the assertion-level residual bridge merged in #4971

## Verification
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterStateResidualBridge
- lake build EvmAsm.Evm64.Exp
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh

Bead: evm-asm-20z6.13.7