### PR TITLE
feat(div): mark callable dispatch pres pc-free

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -14,6 +14,7 @@ import EvmAsm.Evm64.DivMod.Spec.CallAddbackPureNat
 import EvmAsm.Evm64.DivMod.Spec.CallAddback
 import EvmAsm.Evm64.DivMod.Spec.N2RemainderWord
 import EvmAsm.Evm64.DivMod.Spec.Dispatcher
+import EvmAsm.Evm64.DivMod.Spec.DispatcherPcFree
 import EvmAsm.Evm64.DivMod.Spec.CallablePost
 import EvmAsm.Evm64.DivMod.Spec.N1QuotientWord
 import EvmAsm.Evm64.DivMod.Spec.N2QuotientWord

--- a/EvmAsm/Evm64/DivMod/Spec/DispatcherPcFree.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/DispatcherPcFree.lean
@@ -1,0 +1,63 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.DispatcherPcFree
+
+  PC-free helpers for callable-ready DIV/MOD dispatcher preconditions.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.Dispatcher
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+theorem divModStackDispatchPreNoX1_pcFree
+    (sp : Word) (a b : EvmWord)
+    (x9Val x1Val v2 v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratch_un0 : Word) :
+    (divModStackDispatchPreNoX1 sp a b x9Val x1Val v2 v5 v6 v7 v10 v11
+      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratch_un0).pcFree := by
+  rw [divModStackDispatchPreNoX1_unfold, divScratchValuesCallNoX1_unfold,
+    divScratchValues_unfold]
+  pcFree
+
+instance pcFreeInst_divModStackDispatchPreNoX1
+    (sp : Word) (a b : EvmWord)
+    (x9Val x1Val v2 v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratch_un0 : Word) :
+    Assertion.PCFree
+      (divModStackDispatchPreNoX1 sp a b x9Val x1Val v2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0) :=
+  ⟨divModStackDispatchPreNoX1_pcFree sp a b x9Val x1Val v2 v5 v6 v7 v10 v11
+    q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem retMem dMem
+    dloMem scratch_un0⟩
+
+theorem divModStackDispatchPreCallable_pcFree
+    (sp : Word) (a b : EvmWord)
+    (x1Val v2 v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratch_un0 : Word) :
+    (divModStackDispatchPreCallable sp a b x1Val v2 v5 v6 v7 v10 v11
+      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratch_un0).pcFree := by
+  rw [divModStackDispatchPreCallable_unfold, divScratchValuesCallNoX1_unfold,
+    divScratchValues_unfold]
+  pcFree
+
+instance pcFreeInst_divModStackDispatchPreCallable
+    (sp : Word) (a b : EvmWord)
+    (x1Val v2 v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratch_un0 : Word) :
+    Assertion.PCFree
+      (divModStackDispatchPreCallable sp a b x1Val v2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0) :=
+  ⟨divModStackDispatchPreCallable_pcFree sp a b x1Val v2 v5 v6 v7 v10 v11
+    q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem retMem dMem
+    dloMem scratch_un0⟩
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add a small DispatcherPcFree sidecar module with PCFree lemmas and instances for divModStackDispatchPreNoX1 and divModStackDispatchPreCallable
- import the sidecar from the DivMod Spec umbrella so SDIV branch-local callable proofs can frame sign/tail state around callable-ready dispatcher pres

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.DispatcherPcFree
- lake build EvmAsm.Evm64.SDiv
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- scripts/check-file-size.sh EvmAsm/Evm64/DivMod/Spec/DispatcherPcFree.lean EvmAsm/Evm64/DivMod/Spec.lean
- scripts/check-unimported.sh

Bead: evm-asm-9iqmw.2.1