### PR TITLE
feat(div): add bzero callable no-x9 wrapper

### DIFF
--- a/EvmAsm/Evm64/DivMod/Callable.lean
+++ b/EvmAsm/Evm64/DivMod/Callable.lean
@@ -766,6 +766,34 @@ theorem evm_div_callable_bzero_preserving_x1_spec (sp base x9Val raVal : Word)
   exact cpsTripleWithin_weaken (fun _ hp => hp) (fun _ hp => by xperm_hyp hp)
     (cpsTripleWithin_seq_same_cr hStackForRet hRetFramed)
 
+/-- Zero-divisor DIV callable wrapper with exact `x1` and no `x9` frame. -/
+theorem evm_div_callable_bzero_preserving_x1_noX9_spec (sp base raVal : Word)
+    (a b : EvmWord) (v2 v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (hbz : b = 0) :
+    cpsTripleWithin (unifiedDivBound + 1) base (raVal &&& ~~~1)
+      (evm_div_callable_code base)
+      (divModStackDispatchPreCallable sp a b
+        raVal v2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+      (divStackDispatchPostCallable sp a b ** (.x1 ↦ᵣ raVal)) := by
+  have hStack :=
+    evm_div_bzero_stack_spec_within_dispatch_noNop_callable_x1_uni
+      sp base a b raVal v2 v5 v6 v7 v10 v11
+      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      nMem shiftMem jMem retMem dMem dloMem scratchUn0 hbz
+  have hStackCall :=
+    cpsTripleWithin_extend_code (hmono := divCode_noNop_sub_div_callable_code) hStack
+  have hRet :=
+    cpsTripleWithin_extend_code (hmono := evm_div_callable_code_ret_sub (base := base))
+      (ret_spec_within' (base + nopOff) raVal)
+  have hRetFramed :=
+    cpsTripleWithin_frameL (divStackDispatchPostCallable sp a b)
+      (divStackDispatchPostCallable_pcFree sp a b) hRet
+  exact cpsTripleWithin_seq_same_cr hStackCall hRetFramed
+
 /-- Generic callable DIV wrapper for no-NOP body proofs that already use the
     callable-ready precondition and preserve exact caller-framed `x1`/`x9`.
 

--- a/EvmAsm/Evm64/DivMod/Spec/UnifiedBzero.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/UnifiedBzero.lean
@@ -387,6 +387,71 @@ theorem evm_div_bzero_stack_spec_within_dispatch_noNop_callable_uni
       q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
       nMem shiftMem jMem retMem dMem dloMem scratch_un0 hbz)
 
+/-- Zero-divisor DIV dispatcher over `divCode_noNop` with exact `x1` and no
+    `x9` frame. Used by callers that keep `x9` entirely caller-framed. -/
+theorem evm_div_bzero_stack_spec_within_dispatch_noNop_callable_x1_uni
+    (sp base : Word)
+    (a b : EvmWord) (raVal v2 v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratch_un0 : Word)
+    (hbz : b = 0) :
+    cpsTripleWithin unifiedDivBound base (base + nopOff) (divCode_noNop base)
+      (divModStackDispatchPreCallable sp a b
+        raVal v2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0)
+      (divStackDispatchPostCallable sp a b ** (.x1 ↦ᵣ raVal)) := by
+  let frame : Assertion :=
+    (.x1 ↦ᵣ raVal) ** (.x2 ↦ᵣ v2) **
+    (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x11 ↦ᵣ v11) **
+    evmWordIs sp a **
+    divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratch_un0
+  have hBzero :=
+    evm_div_bzero_stack_spec_within_noNop sp base a b v5 v10 hbz
+  have hFramed :
+      cpsTripleWithin (8 + 5) base (base + nopOff) (divCode_noNop base)
+        (((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) **
+          (.x0 ↦ᵣ (0 : Word)) ** evmWordIs (sp + 32) b) ** frame)
+        ((((.x12 ↦ᵣ (sp + 32)) ** regOwn .x5 ** regOwn .x10 **
+          (.x0 ↦ᵣ (0 : Word)) ** evmWordIs (sp + 32) (EvmWord.div a b)) ** frame)) :=
+    cpsTripleWithin_frameR frame (by
+      dsimp [frame]
+      rw [divScratchValuesCallNoX1_unfold]
+      pcFree) hBzero
+  exact cpsTripleWithin_mono_nSteps (by decide) <|
+    cpsTripleWithin_weaken
+      (fun _ hp => by
+        rw [divModStackDispatchPreCallable_unfold] at hp
+        dsimp [frame]
+        simp only [sepConj_comm', sepConj_left_comm'] at hp ⊢
+        exact hp)
+      (fun h hq => by
+        dsimp [frame] at hq
+        rw [divStackDispatchPostCallable_unfold]
+        simp only [sepConj_assoc', sepConj_comm', sepConj_left_comm'] at hq ⊢
+        have hqOwn :
+            (divScratchOwnCallNoX1 sp ** evmWordIs sp a ** (.x0 ↦ᵣ (0 : Word)) **
+              (.x1 ↦ᵣ raVal) ** regOwn .x11 ** (.x12 ↦ᵣ (sp + 32)) **
+              regOwn .x2 ** regOwn .x6 ** regOwn .x7 **
+              regOwn .x10 ** regOwn .x5 ** evmWordIs (sp + 32) (EvmWord.div a b)) h := by
+          refine sepConj_mono ?_ ?_ h hq
+          · intro hLeft hpLeft
+            exact divScratchValuesCallNoX1_implies_divScratchOwnCallNoX1
+              sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem
+                retMem dMem dloMem scratch_un0 hLeft hpLeft
+          · apply sepConj_mono_right
+            apply sepConj_mono_right
+            apply sepConj_mono_right
+            apply sepConj_mono (regIs_implies_regOwn .x11 (v := v11))
+            apply sepConj_mono_right
+            apply sepConj_mono (regIs_implies_regOwn .x2 (v := v2))
+            apply sepConj_mono (regIs_implies_regOwn .x6 (v := v6))
+            apply sepConj_mono (regIs_implies_regOwn .x7 (v := v7))
+            exact fun _ hp => hp
+        exact by xperm_hyp hqOwn)
+      hFramed
+
 theorem modStackDispatchPost_weaken_bzero_frame
     (sp : Word) (a b : EvmWord)
     {v1 v2 v6 v7 v11 : Word}


### PR DESCRIPTION
## Summary
- add a zero-divisor DIV no-NOP dispatcher theorem over divModStackDispatchPreCallable, preserving exact x1 without carrying x9 in the pre/post
- add the corresponding callable wrapper, mirroring the existing MOD no-X9 bzero surface
- this gives SDIV a DIV bzero callable surface where x9 can remain entirely caller-framed

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.UnifiedBzero
- lake build EvmAsm.Evm64.DivMod.Callable
- lake build EvmAsm.Evm64.DivMod
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- scripts/check-file-size.sh EvmAsm/Evm64/DivMod/Spec/UnifiedBzero.lean EvmAsm/Evm64/DivMod/Callable.lean
- scripts/check-unimported.sh

Bead: evm-asm-9iqmw.2.1