### PR TITLE
feat(exp): add pointer-only direct reload head step

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoopDirect.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoopDirect.lean
@@ -154,4 +154,160 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_f
               (hReloadTrue hk_lt v6' v7' v10' v11' d0' d1' d2' d3'))
       hExit
 
+/-- Convenience form of
+    `cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_from_pre`
+    when the only carried frame is the next pointer cell required by reload
+    re-entry. -/
+theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_pointer_from_pre
+    {baseWord exponentWord : EvmWord} {k iterations : Nat}
+    (controlC6 e machineC6 iterCount v10 v18 ptr nextLimb
+      nextNextLimb sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
+      e0 e1 e2 e3 a0 a1 a2 a3 v7 v11 : Word)
+    (base : Word)
+    (Q : Assertion)
+    (hbase : (base + 44 : Word) &&& 1 = 0)
+    (hControlMachine : controlC6 = machineC6)
+    (hk : k < 256)
+    (hBase : baseWord = expResultWord a0 a1 a2 a3)
+    (hNextNext :
+      nextNextLimb = exponentWord.getLimbN (2 - (k + 1) / 64))
+    (hBranch :
+      k < 255 →
+      ∀ (bit : Bool)
+        (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
+          (base + 44) (base + 296)
+          (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+          (let outW := expTwoMulFixedBranchResult bit
+            a0 a1 a2 a3 r0 r1 r2 r3
+          expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
+            (controlC6 + signExtend12 (-1 : BitVec 12))
+            (e <<< (1 : BitVec 6).toNat)
+            v6'
+            (expTwoMulIterCountNew iterCount)
+            v10'
+            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+            ptr nextLimb sp evmSp
+            (outW.getLimbN 3)
+            (expTwoMulFixedBranchReturnPc bit base)
+            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
+            (outW.getLimbN 3)
+            d0' d1' d2' d3'
+            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
+            (outW.getLimbN 3)
+            a0 a1 a2 a3 v7' v11'
+            (((ptr + signExtend12 (-8 : BitVec 12)) +
+              signExtend12 (0 : BitVec 12)) ↦ₘ nextNextLimb))
+          (Q ** (((ptr + signExtend12 (-8 : BitVec 12)) +
+            signExtend12 (0 : BitVec 12)) ↦ₘ nextNextLimb)))
+    (hReloadFalse :
+      k < 255 →
+      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        let squareW := expSquaringCallSquareW r0 r1 r2 r3
+        cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
+          (base + 44) (base + 296)
+          (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+          (expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
+            64 nextLimb v6' (expTwoMulIterCountNew iterCount) v10'
+            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+            (ptr + signExtend12 (-8 : BitVec 12)) nextNextLimb sp evmSp
+            (squareW.getLimbN 3) (((base + 44) + 32) + 68)
+            (squareW.getLimbN 0) (squareW.getLimbN 1)
+            (squareW.getLimbN 2) (squareW.getLimbN 3)
+            d0' d1' d2' d3'
+            (squareW.getLimbN 0) (squareW.getLimbN 1)
+            (squareW.getLimbN 2) (squareW.getLimbN 3)
+            a0 a1 a2 a3 v7' v11'
+            (((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
+              ⌜expTwoMulIterCountNew iterCount ≠ 0⌝ **
+              ⌜controlC6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
+              ⌜(e >>> (63 : BitVec 6).toNat) +
+                signExtend12 (0 : BitVec 12) = 0⌝))
+          (Q ** (((ptr + signExtend12 (-8 : BitVec 12)) +
+            signExtend12 (0 : BitVec 12)) ↦ₘ nextNextLimb)))
+    (hReloadTrue :
+      k < 255 →
+      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        let rw := expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3)
+          a0 a1 a2 a3
+        cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
+          (base + 44) (base + 296)
+          (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+          (expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
+            64 nextLimb v6' (expTwoMulIterCountNew iterCount) v10'
+            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+            (ptr + signExtend12 (-8 : BitVec 12)) nextNextLimb sp evmSp
+            (rw.getLimbN 3) (((base + 44) + 140) + 68)
+            (rw.getLimbN 0) (rw.getLimbN 1)
+            (rw.getLimbN 2) (rw.getLimbN 3)
+            d0' d1' d2' d3'
+            (rw.getLimbN 0) (rw.getLimbN 1)
+            (rw.getLimbN 2) (rw.getLimbN 3)
+            a0 a1 a2 a3 v7' v11'
+            (((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
+              ⌜expTwoMulIterCountNew iterCount ≠ 0⌝ **
+              ⌜controlC6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
+              ⌜(e >>> (63 : BitVec 6).toNat) +
+                signExtend12 (0 : BitVec 12) ≠ 0⌝))
+          (Q ** (((ptr + signExtend12 (-8 : BitVec 12)) +
+            signExtend12 (0 : BitVec 12)) ↦ₘ nextNextLimb)))
+    (hExit :
+      k = 255 →
+      ∀ ps,
+        expTwoMulFixedIterCaseExitPost iterCount e machineC6 ptr nextLimb
+          sp evmSp r0 r1 r2 r3 a0 a1 a2 a3 base ps →
+        Q ps) :
+    cpsTripleWithin (expTwoMulFixedIterationsBodyBound (iterations + 1))
+      (base + 44) (base + 296)
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterPreNWithStateFrame k baseWord exponentWord
+        controlC6 e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+        a0 a1 a2 a3 v7 v11
+        (((ptr + signExtend12 (-8 : BitVec 12)) +
+          signExtend12 (0 : BitVec 12)) ↦ₘ nextNextLimb))
+      (Q ** (((ptr + signExtend12 (-8 : BitVec 12)) +
+        signExtend12 (0 : BitVec 12)) ↦ₘ nextNextLimb)) := by
+  exact
+    cpsTripleWithin_weaken
+      (fun _ h => by
+        rw [sepConj_emp_right']
+        exact h)
+      (fun _ h => by
+        rw [sepConj_emp_right'] at h
+        exact h)
+      (cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_from_pre
+        controlC6 e machineC6 iterCount v10 v18 ptr nextLimb nextNextLimb
+        sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+        a0 a1 a2 a3 v7 v11 base empAssertion Q (by pcFree) hbase
+        hControlMachine hk hBase hNextNext
+        (fun hk_lt bit v6' v7' v10' v11' d0' d1' d2' d3' =>
+          cpsTripleWithin_weaken
+            (fun _ h => by
+              rw [sepConj_emp_right'] at h
+              exact h)
+            (fun _ h => by
+              rw [sepConj_emp_right']
+              exact h)
+            (hBranch hk_lt bit v6' v7' v10' v11' d0' d1' d2' d3'))
+        (fun hk_lt v6' v7' v10' v11' d0' d1' d2' d3' =>
+          cpsTripleWithin_weaken
+            (fun _ h => by
+              rw [sepConj_emp_right'] at h
+              exact h)
+            (fun _ h => by
+              rw [sepConj_emp_right']
+              exact h)
+            (hReloadFalse hk_lt v6' v7' v10' v11' d0' d1' d2' d3'))
+        (fun hk_lt v6' v7' v10' v11' d0' d1' d2' d3' =>
+          cpsTripleWithin_weaken
+            (fun _ h => by
+              rw [sepConj_emp_right'] at h
+              exact h)
+            (fun _ h => by
+              rw [sepConj_emp_right']
+              exact h)
+            (hReloadTrue hk_lt v6' v7' v10' v11' d0' d1' d2' d3'))
+        hExit)
+
 end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- Add a pointer-only wrapper for the EXP fixed-iteration direct reload head step.
- Instantiate the existing direct reload helper with `empAssertion` so callers can preserve just the next-pointer memory cell without extra frame noise.
- Keeps bead `evm-asm-20z6.13.7` open; this is one helper toward the induction path, not the final loop theorem.

## Checks
- `lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterStateLoopDirect`
- `lake build EvmAsm.Evm64.Exp`
- `git diff --check`
- `scripts/check-file-size.sh EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoopDirect.lean`
- `scripts/check-unimported.sh`