### PR TITLE
feat(exp): add fixed control frame helpers

### DIFF
--- a/EvmAsm/Evm64/Exp.lean
+++ b/EvmAsm/Evm64/Exp.lean
@@ -79,6 +79,7 @@ import EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryLoopFixed
 import EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryLoopFixedEntryExists
 import EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryLoopFixedIterSpBounds
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedLoopInvariant
+import EvmAsm.Evm64.Exp.Compose.SavedBitFixedControlFrame
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedAccumulatorRun
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCount
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedBoolStep

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedControlFrame.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedControlFrame.lean
@@ -1,0 +1,35 @@
+/-
+  EvmAsm.Evm64.Exp.Compose.SavedBitFixedControlFrame
+
+  Small control-invariant helpers for the fixed-loop induction frame.
+-/
+
+import EvmAsm.Evm64.Exp.Compose.SavedBitFixedLoopInvariant
+
+namespace EvmAsm.Evm64.Exp.Compose
+
+open EvmAsm.Rv64
+
+theorem expTwoMulFixedControlInvariant_nextLimb
+    {exponentWord : EvmWord} {k : Nat}
+    {c6 ptr nextLimb evmSp : Word}
+    (hControl :
+      expTwoMulFixedControlInvariant exponentWord k c6 ptr nextLimb evmSp) :
+    nextLimb = exponentWord.getLimbN (2 - k / 64) := by
+  exact hControl.2
+
+theorem expTwoMulFixedControlInvariant_nextLimb_succ_no_reload
+    {exponentWord : EvmWord} {k : Nat}
+    {c6 ptr nextLimb evmSp : Word}
+    (hControl :
+      expTwoMulFixedControlInvariant exponentWord k c6 ptr nextLimb evmSp)
+    (hC6 : c6 + signExtend12 (-1 : BitVec 12) ≠ 0) :
+    nextLimb = exponentWord.getLimbN (2 - (k + 1) / 64) := by
+  have hMod :=
+    expTwoMulFixedControlInvariant_no_reload_mod hControl hC6
+  rw [expTwoMulFixedControlInvariant_nextLimb hControl]
+  have hdiv : (k + 1) / 64 = k / 64 := by
+    omega
+  rw [hdiv]
+
+end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- Add `SavedBitFixedControlFrame` with small pure control-invariant helpers for the fixed EXP loop induction frame.
- Expose `expTwoMulFixedControlInvariant_nextLimb` and the no-reload successor form `expTwoMulFixedControlInvariant_nextLimb_succ_no_reload`.
- Wire the new helper module into `EvmAsm.Evm64.Exp`.

## Checks
- `lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedControlFrame`
- `lake build EvmAsm.Evm64.Exp`
- `git diff --check`
- `scripts/check-file-size.sh EvmAsm/Evm64/Exp/Compose/SavedBitFixedControlFrame.lean EvmAsm/Evm64/Exp.lean`
- `scripts/check-unimported.sh`

Bead: `evm-asm-20z6.13.7.2`