### PR TITLE
feat(div): add generic no-x9 callable wrapper

### DIFF
--- a/EvmAsm/Evm64/DivMod/Callable.lean
+++ b/EvmAsm/Evm64/DivMod/Callable.lean
@@ -794,6 +794,37 @@ theorem evm_div_callable_bzero_preserving_x1_noX9_spec (sp base raVal : Word)
       (divStackDispatchPostCallable_pcFree sp a b) hRet
   exact cpsTripleWithin_seq_same_cr hStackCall hRetFramed
 
+/-- Generic callable DIV wrapper for no-NOP body proofs that preserve exact
+    `x1` and keep `x9` entirely outside the callable surface. -/
+theorem evm_div_callable_spec_from_noNop_preserving_x1_noX9
+    (sp base raVal : Word) (a b : EvmWord)
+    (v2 v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (hStack :
+      cpsTripleWithin unifiedDivBound base (base + nopOff) (divCode_noNop base)
+        (divModStackDispatchPreCallable sp a b
+          raVal v2 v5 v6 v7 v10 v11
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+        (divStackDispatchPostCallable sp a b ** (.x1 ↦ᵣ raVal))) :
+    cpsTripleWithin (unifiedDivBound + 1) base (raVal &&& ~~~1)
+      (evm_div_callable_code base)
+      (divModStackDispatchPreCallable sp a b
+        raVal v2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+      (divStackDispatchPostCallable sp a b ** (.x1 ↦ᵣ raVal)) := by
+  have hStackCall :=
+    cpsTripleWithin_extend_code (hmono := divCode_noNop_sub_div_callable_code) hStack
+  have hRet :=
+    cpsTripleWithin_extend_code (hmono := evm_div_callable_code_ret_sub (base := base))
+      (ret_spec_within' (base + nopOff) raVal)
+  have hRetFramed :=
+    cpsTripleWithin_frameL (divStackDispatchPostCallable sp a b)
+      (divStackDispatchPostCallable_pcFree sp a b) hRet
+  exact cpsTripleWithin_seq_same_cr hStackCall hRetFramed
+
 /-- Generic callable DIV wrapper for no-NOP body proofs that already use the
     callable-ready precondition and preserve exact caller-framed `x1`/`x9`.
 


### PR DESCRIPTION
## Summary
- Add `evm_div_callable_spec_from_noNop_preserving_x1_noX9`, a generic callable wrapper for no-NOP DIV body proofs over `divModStackDispatchPreCallable`.
- The wrapper preserves exact `x1` through the callable return while keeping `x9` outside the callable surface.
- This generalizes the bzero no-`x9` callable path so future n1/n2/n3 callable body proofs can feed the same surface.

## Checks
- `lake build EvmAsm.Evm64.DivMod.Callable`
- `lake build EvmAsm.Evm64.DivMod`
- `lake build EvmAsm.Evm64.SDiv`
- `git diff --check`
- `scripts/check-file-size.sh EvmAsm/Evm64/DivMod/Callable.lean`
- `scripts/check-unimported.sh`

Bead: `evm-asm-9iqmw.2.1`