### PR TITLE
feat(exp): expose direct head step with named frame

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoopDirect.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoopDirect.lean
@@ -6,6 +6,7 @@
 -/
 
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterStateLoop
+import EvmAsm.Evm64.Exp.Compose.SavedBitFixedControlFrame
 
 namespace EvmAsm.Evm64.Exp.Compose
 
@@ -309,5 +310,133 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_p
               exact h)
             (hReloadTrue hk_lt v6' v7' v10' v11' d0' d1' d2' d3'))
         hExit)
+
+/-- Pointer-only direct head step with the current saved-limb cell expressed
+    through the semantic iteration-indexed frame name. -/
+theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_frameN_from_pre
+    {baseWord exponentWord : EvmWord} {k iterations : Nat}
+    (controlC6 e machineC6 iterCount v10 v18 ptr nextLimb
+      nextNextLimb sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
+      e0 e1 e2 e3 a0 a1 a2 a3 v7 v11 : Word)
+    (base : Word)
+    (Q : Assertion)
+    (hbase : (base + 44 : Word) &&& 1 = 0)
+    (hControlMachine : controlC6 = machineC6)
+    (hk : k < 256)
+    (hBase : baseWord = expResultWord a0 a1 a2 a3)
+    (hNextNext :
+      nextNextLimb = exponentWord.getLimbN (2 - (k + 1) / 64))
+    (hBranch :
+      k < 255 →
+      ∀ (bit : Bool)
+        (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
+          (base + 44) (base + 296)
+          (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+          (let outW := expTwoMulFixedBranchResult bit
+            a0 a1 a2 a3 r0 r1 r2 r3
+          expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
+            (controlC6 + signExtend12 (-1 : BitVec 12))
+            (e <<< (1 : BitVec 6).toNat)
+            v6'
+            (expTwoMulIterCountNew iterCount)
+            v10'
+            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+            ptr nextLimb sp evmSp
+            (outW.getLimbN 3)
+            (expTwoMulFixedBranchReturnPc bit base)
+            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
+            (outW.getLimbN 3)
+            d0' d1' d2' d3'
+            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
+            (outW.getLimbN 3)
+            a0 a1 a2 a3 v7' v11'
+            (((ptr + signExtend12 (-8 : BitVec 12)) +
+              signExtend12 (0 : BitVec 12)) ↦ₘ nextNextLimb))
+          (Q ** (((ptr + signExtend12 (-8 : BitVec 12)) +
+            signExtend12 (0 : BitVec 12)) ↦ₘ nextNextLimb)))
+    (hReloadFalse :
+      k < 255 →
+      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        let squareW := expSquaringCallSquareW r0 r1 r2 r3
+        cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
+          (base + 44) (base + 296)
+          (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+          (expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
+            64 nextLimb v6' (expTwoMulIterCountNew iterCount) v10'
+            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+            (ptr + signExtend12 (-8 : BitVec 12)) nextNextLimb sp evmSp
+            (squareW.getLimbN 3) (((base + 44) + 32) + 68)
+            (squareW.getLimbN 0) (squareW.getLimbN 1)
+            (squareW.getLimbN 2) (squareW.getLimbN 3)
+            d0' d1' d2' d3'
+            (squareW.getLimbN 0) (squareW.getLimbN 1)
+            (squareW.getLimbN 2) (squareW.getLimbN 3)
+            a0 a1 a2 a3 v7' v11'
+            (((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
+              ⌜expTwoMulIterCountNew iterCount ≠ 0⌝ **
+              ⌜controlC6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
+              ⌜(e >>> (63 : BitVec 6).toNat) +
+                signExtend12 (0 : BitVec 12) = 0⌝))
+          (Q ** (((ptr + signExtend12 (-8 : BitVec 12)) +
+            signExtend12 (0 : BitVec 12)) ↦ₘ nextNextLimb)))
+    (hReloadTrue :
+      k < 255 →
+      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        let rw := expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3)
+          a0 a1 a2 a3
+        cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
+          (base + 44) (base + 296)
+          (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+          (expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
+            64 nextLimb v6' (expTwoMulIterCountNew iterCount) v10'
+            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+            (ptr + signExtend12 (-8 : BitVec 12)) nextNextLimb sp evmSp
+            (rw.getLimbN 3) (((base + 44) + 140) + 68)
+            (rw.getLimbN 0) (rw.getLimbN 1)
+            (rw.getLimbN 2) (rw.getLimbN 3)
+            d0' d1' d2' d3'
+            (rw.getLimbN 0) (rw.getLimbN 1)
+            (rw.getLimbN 2) (rw.getLimbN 3)
+            a0 a1 a2 a3 v7' v11'
+            (((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
+              ⌜expTwoMulIterCountNew iterCount ≠ 0⌝ **
+              ⌜controlC6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
+              ⌜(e >>> (63 : BitVec 6).toNat) +
+                signExtend12 (0 : BitVec 12) ≠ 0⌝))
+          (Q ** (((ptr + signExtend12 (-8 : BitVec 12)) +
+            signExtend12 (0 : BitVec 12)) ↦ₘ nextNextLimb)))
+    (hExit :
+      k = 255 →
+      ∀ ps,
+        expTwoMulFixedIterCaseExitPost iterCount e machineC6 ptr nextLimb
+          sp evmSp r0 r1 r2 r3 a0 a1 a2 a3 base ps →
+        Q ps) :
+    cpsTripleWithin (expTwoMulFixedIterationsBodyBound (iterations + 1))
+      (base + 44) (base + 296)
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterPreNWithStateFrame k baseWord exponentWord
+        controlC6 e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+        a0 a1 a2 a3 v7 v11
+        (expTwoMulFixedSavedNextLimbFrameN exponentWord k ptr))
+      (Q ** expTwoMulFixedSavedNextLimbFrameN exponentWord k ptr) := by
+  have hFrameEq :
+      expTwoMulFixedSavedNextLimbFrame ptr nextNextLimb =
+        expTwoMulFixedSavedNextLimbFrameN exponentWord k ptr :=
+    expTwoMulFixedSavedNextLimbFrameN_eq_of_nextNext hNextNext
+  exact
+    cpsTripleWithin_weaken
+      (fun _ h => by
+        rw [← hFrameEq, expTwoMulFixedSavedNextLimbFrame_unfold] at h
+        exact h)
+      (fun _ h => by
+        rw [← hFrameEq, expTwoMulFixedSavedNextLimbFrame_unfold]
+        exact h)
+      (cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_pointer_from_pre
+        controlC6 e machineC6 iterCount v10 v18 ptr nextLimb nextNextLimb
+        sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+        a0 a1 a2 a3 v7 v11 base Q hbase hControlMachine hk hBase
+        hNextNext hBranch hReloadFalse hReloadTrue hExit)
 
 end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- Import `SavedBitFixedControlFrame` into the direct fixed-loop head-step module.
- Add `cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_frameN_from_pre`.
- The wrapper exposes the current saved next-limb cell through `expTwoMulFixedSavedNextLimbFrameN exponentWord k ptr`, while reusing the existing pointer-only direct head-step proof.

## Checks
- `lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterStateLoopDirect`
- `lake build EvmAsm.Evm64.Exp`
- `git diff --check`
- `scripts/check-file-size.sh EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoopDirect.lean`
- `scripts/check-unimported.sh`

Bead: `evm-asm-20z6.13.7.2`