### PR TITLE
feat(exp): add control reload direct wrapper

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedControlFrame.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedControlFrame.lean
@@ -116,6 +116,20 @@ theorem expTwoMulFixedReloadLimbFrameN_eq_of_reload_nextNext
   · rw [Nat.sub_eq_zero_of_le (by omega : 2 ≤ k / 64 + 1),
       Nat.sub_eq_zero_of_le (by omega : 1 ≤ k / 64)]
 
+theorem expTwoMulFixedReloadLimbFrameN_eq_of_control_reload_nextNext
+    {exponentWord : EvmWord} {k : Nat}
+    {c6 ptr nextLimb nextNextLimb evmSp : Word}
+    (hControl :
+      expTwoMulFixedControlInvariant exponentWord k c6 ptr nextLimb evmSp)
+    (hC6 : c6 + signExtend12 (-1 : BitVec 12) = 0)
+    (hNextNext :
+      nextNextLimb = exponentWord.getLimbN (2 - (k + 1) / 64)) :
+    expTwoMulFixedSavedNextLimbFrame ptr nextNextLimb =
+      expTwoMulFixedReloadLimbFrameN exponentWord k ptr :=
+  expTwoMulFixedReloadLimbFrameN_eq_of_reload_nextNext
+    (expTwoMulFixedControlInvariant_reload_mod hControl hC6)
+    hNextNext
+
 theorem expTwoMulFixedControlInvariant_nextLimb
     {exponentWord : EvmWord} {k : Nat}
     {c6 ptr nextLimb evmSp : Word}

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoopDirect.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoopDirect.lean
@@ -568,4 +568,128 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_r
         a0 a1 a2 a3 v7 v11 base Q hbase hControlMachine hk hBase
         hNextNext hBranch hReloadFalse hReloadTrue hExit)
 
+/-- Control-invariant form of the reload-boundary direct head step.
+
+    Recursive reload branches naturally have the current control invariant and
+    the machine fact that decrementing `c6` reaches zero; this wrapper derives
+    the modulo boundary fact used by the lower-level named-frame theorem. -/
+theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_reloadLimbFrameN_of_control_from_pre
+    {baseWord exponentWord : EvmWord} {k iterations : Nat}
+    (controlC6 e machineC6 iterCount v10 v18 ptr nextLimb
+      nextNextLimb sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
+      e0 e1 e2 e3 a0 a1 a2 a3 v7 v11 : Word)
+    (base : Word)
+    (Q : Assertion)
+    (hbase : (base + 44 : Word) &&& 1 = 0)
+    (hControlMachine : controlC6 = machineC6)
+    (hk : k < 256)
+    (hBase : baseWord = expResultWord a0 a1 a2 a3)
+    (hControl :
+      expTwoMulFixedControlInvariant exponentWord k controlC6 ptr nextLimb
+        evmSp)
+    (hC6 : controlC6 + signExtend12 (-1 : BitVec 12) = 0)
+    (hNextNext :
+      nextNextLimb = exponentWord.getLimbN (2 - (k + 1) / 64))
+    (hBranch :
+      k < 255 →
+      ∀ (bit : Bool)
+        (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
+          (base + 44) (base + 296)
+          (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+          (let outW := expTwoMulFixedBranchResult bit
+            a0 a1 a2 a3 r0 r1 r2 r3
+          expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
+            (controlC6 + signExtend12 (-1 : BitVec 12))
+            (e <<< (1 : BitVec 6).toNat)
+            v6'
+            (expTwoMulIterCountNew iterCount)
+            v10'
+            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+            ptr nextLimb sp evmSp
+            (outW.getLimbN 3)
+            (expTwoMulFixedBranchReturnPc bit base)
+            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
+            (outW.getLimbN 3)
+            d0' d1' d2' d3'
+            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
+            (outW.getLimbN 3)
+            a0 a1 a2 a3 v7' v11'
+            (((ptr + signExtend12 (-8 : BitVec 12)) +
+              signExtend12 (0 : BitVec 12)) ↦ₘ nextNextLimb))
+          (Q ** (((ptr + signExtend12 (-8 : BitVec 12)) +
+            signExtend12 (0 : BitVec 12)) ↦ₘ nextNextLimb)))
+    (hReloadFalse :
+      k < 255 →
+      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        let squareW := expSquaringCallSquareW r0 r1 r2 r3
+        cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
+          (base + 44) (base + 296)
+          (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+          (expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
+            64 nextLimb v6' (expTwoMulIterCountNew iterCount) v10'
+            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+            (ptr + signExtend12 (-8 : BitVec 12)) nextNextLimb sp evmSp
+            (squareW.getLimbN 3) (((base + 44) + 32) + 68)
+            (squareW.getLimbN 0) (squareW.getLimbN 1)
+            (squareW.getLimbN 2) (squareW.getLimbN 3)
+            d0' d1' d2' d3'
+            (squareW.getLimbN 0) (squareW.getLimbN 1)
+            (squareW.getLimbN 2) (squareW.getLimbN 3)
+            a0 a1 a2 a3 v7' v11'
+            (((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
+              ⌜expTwoMulIterCountNew iterCount ≠ 0⌝ **
+              ⌜controlC6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
+              ⌜(e >>> (63 : BitVec 6).toNat) +
+                signExtend12 (0 : BitVec 12) = 0⌝))
+          (Q ** (((ptr + signExtend12 (-8 : BitVec 12)) +
+            signExtend12 (0 : BitVec 12)) ↦ₘ nextNextLimb)))
+    (hReloadTrue :
+      k < 255 →
+      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        let rw := expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3)
+          a0 a1 a2 a3
+        cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
+          (base + 44) (base + 296)
+          (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+          (expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
+            64 nextLimb v6' (expTwoMulIterCountNew iterCount) v10'
+            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+            (ptr + signExtend12 (-8 : BitVec 12)) nextNextLimb sp evmSp
+            (rw.getLimbN 3) (((base + 44) + 140) + 68)
+            (rw.getLimbN 0) (rw.getLimbN 1)
+            (rw.getLimbN 2) (rw.getLimbN 3)
+            d0' d1' d2' d3'
+            (rw.getLimbN 0) (rw.getLimbN 1)
+            (rw.getLimbN 2) (rw.getLimbN 3)
+            a0 a1 a2 a3 v7' v11'
+            (((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
+              ⌜expTwoMulIterCountNew iterCount ≠ 0⌝ **
+              ⌜controlC6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
+              ⌜(e >>> (63 : BitVec 6).toNat) +
+                signExtend12 (0 : BitVec 12) ≠ 0⌝))
+          (Q ** (((ptr + signExtend12 (-8 : BitVec 12)) +
+            signExtend12 (0 : BitVec 12)) ↦ₘ nextNextLimb)))
+    (hExit :
+      k = 255 →
+      ∀ ps,
+        expTwoMulFixedIterCaseExitPost iterCount e machineC6 ptr nextLimb
+          sp evmSp r0 r1 r2 r3 a0 a1 a2 a3 base ps →
+        Q ps) :
+    cpsTripleWithin (expTwoMulFixedIterationsBodyBound (iterations + 1))
+      (base + 44) (base + 296)
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterPreNWithStateFrame k baseWord exponentWord
+        controlC6 e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+        a0 a1 a2 a3 v7 v11
+        (expTwoMulFixedReloadLimbFrameN exponentWord k ptr))
+      (Q ** expTwoMulFixedReloadLimbFrameN exponentWord k ptr) :=
+  cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_reloadLimbFrameN_from_pre
+    controlC6 e machineC6 iterCount v10 v18 ptr nextLimb nextNextLimb
+    sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+    a0 a1 a2 a3 v7 v11 base Q hbase hControlMachine hk hBase
+    (expTwoMulFixedControlInvariant_reload_mod hControl hC6)
+    hNextNext hBranch hReloadFalse hReloadTrue hExit
+
 end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- add a control-invariant wrapper for rewriting the saved reload cell into expTwoMulFixedReloadLimbFrameN on reload steps
- add a direct-head reload-limb wrapper that takes hControl and hC6 = 0, deriving the k % 64 = 63 boundary internally
- gives recursive EXP reload continuations the argument shape they naturally have from state-frame pures

## Verification
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedControlFrame
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterStateLoopDirect
- lake build EvmAsm.Evm64.Exp
- git diff --check
- scripts/check-file-size.sh EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoopDirect.lean EvmAsm/Evm64/Exp/Compose/SavedBitFixedControlFrame.lean
- scripts/check-unimported.sh