### PR TITLE
feat(exp): add saved next-limb stability

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedControlFrame.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedControlFrame.lean
@@ -58,6 +58,20 @@ theorem expTwoMulFixedSavedNextLimbFrameN_eq_of_nextNext
       expTwoMulFixedSavedNextLimbFrameN exponentWord k ptr := by
   rw [expTwoMulFixedSavedNextLimbFrameN_unfold, hNextNext]
 
+theorem expTwoMulFixedSavedNextLimbFrameN_succ_no_reload
+    {exponentWord : EvmWord} {k : Nat} {ptr : Word}
+    (hMod : k % 64 < 62) :
+    expTwoMulFixedSavedNextLimbFrameN exponentWord k ptr =
+      expTwoMulFixedSavedNextLimbFrameN exponentWord (k + 1) ptr := by
+  rw [expTwoMulFixedSavedNextLimbFrameN_unfold,
+    expTwoMulFixedSavedNextLimbFrameN_unfold]
+  rw [expTwoMulFixedSavedNextLimbFrame_unfold,
+    expTwoMulFixedSavedNextLimbFrame_unfold]
+  congr 1
+  have hdiv : (k + 2) / 64 = (k + 1) / 64 := by
+    omega
+  rw [show (k + 1 + 1) / 64 = (k + 2) / 64 by ring, hdiv]
+
 @[irreducible]
 def expTwoMulFixedReloadLimbFrameN
     (exponentWord : EvmWord) (k : Nat) (ptr : Word) : Assertion :=


### PR DESCRIPTION
## Summary
- add expTwoMulFixedSavedNextLimbFrameN_succ_no_reload
- keep the condition at k % 64 < 62, matching the ordinary successor case and excluding the pre-reload boundary
- gives the EXP loop induction a named rewrite for saved next-limb frames across ordinary no-reload steps

## Verification
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedControlFrame
- lake build EvmAsm.Evm64.Exp
- git diff --check
- scripts/check-file-size.sh EvmAsm/Evm64/Exp/Compose/SavedBitFixedControlFrame.lean
- scripts/check-unimported.sh