### PR TITLE
feat(div): add v4 trial-call loopbody surface

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopBody.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody.lean
@@ -44,6 +44,27 @@ theorem lb_sub {base : Word} (k : Nat) (addr : Word) (instr : Instr)
     (CodeReq.singleton_mono
       (CodeReq.ofProg_lookup (base + loopBodyOff) (divK_loopBody 560 7736) k hk (by decide)) a i h)
 
+/-- The loopBody ofProg (block 8) is subsumed by sharedDivModCode_v4. -/
+private theorem divK_loopBody_ofProg_sub_sharedCode_v4 {base : Word} :
+    ∀ a i, (CodeReq.ofProg (base + loopBodyOff) (divK_loopBody 560 7736)) a = some i →
+      (sharedDivModCode_v4 base) a = some i := by
+  unfold sharedDivModCode_v4; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
+  skipBlock; skipBlock
+  exact CodeReq.union_mono_left
+
+/-- Helper: singleton at index k of divK_loopBody ⊆ sharedDivModCode_v4 base. -/
+theorem lb_sub_v4 {base : Word} (k : Nat) (addr : Word) (instr : Instr)
+    (hk : k < (divK_loopBody 560 7736).length)
+    (h_addr : addr = (base + loopBodyOff) + BitVec.ofNat 64 (4 * k))
+    (h_instr : (divK_loopBody 560 7736).get ⟨k, hk⟩ = instr) :
+    ∀ a i, CodeReq.singleton addr instr a = some i →
+      (sharedDivModCode_v4 base) a = some i := by
+  subst h_addr; subst h_instr
+  exact fun a i h => divK_loopBody_ofProg_sub_sharedCode_v4 a i
+    (CodeReq.singleton_mono
+      (CodeReq.ofProg_lookup (base + loopBodyOff) (divK_loopBody 560 7736) k hk (by decide)) a i h)
+
 /-- Helper: singleton at index k of divK_loopBody ⊆ divCode_noNop base. -/
 theorem lb_sub_noNop {base : Word} (k : Nat) (addr : Word) (instr : Instr)
     (hk : k < (divK_loopBody 560 7736).length)

--- a/EvmAsm/Evm64/DivMod/LoopBody/TrialCallPath.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody/TrialCallPath.lean
@@ -16,6 +16,7 @@
 -/
 
 import EvmAsm.Evm64.DivMod.LoopBody
+import EvmAsm.Evm64.DivMod.Compose.Div128V4
 
 open EvmAsm.Rv64.Tactics
 
@@ -135,6 +136,79 @@ theorem divK_trial_call_path_spec_within
   intro v1Old
   exact divK_trial_call_path_spec_within_exact_x1 sp j uLo uHi vTop vtopBase base
     v1Old v2Old v11Old retMem dMem dloMem un0Mem halign
+
+/-- Trial call path over `sharedDivModCode_v4`: JAL x2 560 (instr [16]) +
+    the v4 div128 subroutine, with exact x1 framing and the additional v4
+    scratch cell threaded explicitly. -/
+theorem divK_trial_call_path_v4_spec_within_exact_x1
+    (sp j uLo uHi vTop vtopBase : Word) (base : Word)
+    (v1Old v2Old v11Old : Word)
+    (retMem dMem dloMem un0Mem scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff) :
+    cpsTripleWithin 74 (base + trialJalOff) (base + div128CallRetOff) (sharedDivModCode_v4 base)
+      (((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
+       (.x5 ↦ᵣ uLo) ** (.x6 ↦ᵣ vtopBase) **
+       (.x7 ↦ᵣ uHi) ** (.x10 ↦ᵣ vTop) **
+       (.x2 ↦ᵣ v2Old) ** (.x11 ↦ᵣ v11Old) ** (.x0 ↦ᵣ (0 : Word)) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
+       (sp + signExtend12 3944 ↦ₘ un0Mem) **
+       (sp + signExtend12 3936 ↦ₘ scratchMem)) ** (.x1 ↦ᵣ v1Old))
+      (div128V4SpecPost sp (base + div128CallRetOff) vTop uLo uHi scratchMem **
+        regOwn .x1) := by
+  have J := jal_spec_within .x2 v2Old (560 : BitVec 21) (base + trialJalOff) (by nofun)
+  rw [lb_jal_target, lb_jal_ret] at J
+  have Je := cpsTripleWithin_extend_code (hmono :=
+    lb_sub_v4 16 _ _ (by decide) (by bv_addr) (by decide)) J
+  have D := div128_v4_spec_shared sp (base + div128CallRetOff) vTop uLo uHi base
+    j vtopBase v11Old retMem dMem dloMem un0Mem scratchMem
+    halign
+  have Df := cpsTripleWithin_frameR (.x1 ↦ᵣ v1Old) (by pcFree) D
+  have Jf := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) ** (.x1 ↦ᵣ v1Old) **
+     (.x5 ↦ᵣ uLo) ** (.x6 ↦ᵣ vtopBase) **
+     (.x7 ↦ᵣ uHi) ** (.x10 ↦ᵣ vTop) **
+     (.x11 ↦ᵣ v11Old) ** (.x0 ↦ᵣ (0 : Word)) **
+     (sp + signExtend12 3968 ↦ₘ retMem) **
+     (sp + signExtend12 3960 ↦ₘ dMem) **
+     (sp + signExtend12 3952 ↦ₘ dloMem) **
+     (sp + signExtend12 3944 ↦ₘ un0Mem) **
+     (sp + signExtend12 3936 ↦ₘ scratchMem))
+    (by pcFree) Je
+  have full := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) Jf Df
+  exact cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by
+      apply sepConj_mono_right (regIs_implies_regOwn .x1) h
+      xperm_hyp hq)
+    full
+
+/-- Trial call path over `sharedDivModCode_v4`, with `x1` existentially
+    owned. -/
+theorem divK_trial_call_path_v4_spec_within
+    (sp j uLo uHi vTop vtopBase : Word) (base : Word)
+    (v2Old v11Old : Word)
+    (retMem dMem dloMem un0Mem scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff) :
+    cpsTripleWithin 74 (base + trialJalOff) (base + div128CallRetOff) (sharedDivModCode_v4 base)
+      (((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
+       (.x5 ↦ᵣ uLo) ** (.x6 ↦ᵣ vtopBase) **
+       (.x7 ↦ᵣ uHi) ** (.x10 ↦ᵣ vTop) **
+       (.x2 ↦ᵣ v2Old) ** (.x11 ↦ᵣ v11Old) ** (.x0 ↦ᵣ (0 : Word)) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
+       (sp + signExtend12 3944 ↦ₘ un0Mem) **
+       (sp + signExtend12 3936 ↦ₘ scratchMem)) ** regOwn .x1)
+      (div128V4SpecPost sp (base + div128CallRetOff) vTop uLo uHi scratchMem **
+        regOwn .x1) := by
+  apply cpsTripleWithin_of_forall_regIs_to_regOwn
+  intro v1Old
+  exact divK_trial_call_path_v4_spec_within_exact_x1
+    sp j uLo uHi vTop vtopBase base v1Old v2Old v11Old
+    retMem dMem dloMem un0Mem scratchMem halign
 
 /-- Trial call path over `divCode_noNop`: JAL x2 560 (instr [16]) + div128
     subroutine. -/


### PR DESCRIPTION
## Summary
- add loop-body singleton subsumption into sharedDivModCode_v4
- add v4 trial-call path specs over sharedDivModCode_v4, threading the extra div128_v4 scratch cell explicitly

## Verification
- lake build EvmAsm.Evm64.DivMod.LoopBody.TrialCallPath
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- scripts/check-file-size.sh EvmAsm/Evm64/DivMod/LoopBody.lean EvmAsm/Evm64/DivMod/LoopBody/TrialCallPath.lean
- scripts/check-unimported.sh

Bead: evm-asm-9iqmw.4.2