### PR TITLE
feat(div): add v4 no-nop trial-call surface

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Div128V4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Div128V4.lean
@@ -16,6 +16,7 @@
 -/
 
 import EvmAsm.Evm64.DivMod.Compose.Div128
+import EvmAsm.Evm64.DivMod.Compose.V4NoNop
 import EvmAsm.Evm64.DivMod.LimbSpec.Div128Step2v4
 import EvmAsm.Evm64.DivMod.LoopDefs.IterV4
 
@@ -355,6 +356,26 @@ theorem div128_v4_spec_shared (sp retAddr d uLo uHi : Word) (base : Word)
        (sp + signExtend12 3936 ↦ₘ scratchMem))
       (div128V4SpecPost sp retAddr d uLo uHi scratchMem) :=
   cpsTripleWithin_extend_code (hmono := shared_b12_div128_v4_sub)
+    (div128_v4_spec sp retAddr d uLo uHi base v9Old v6Old v11Old
+      retMem dMem dloMem un0Mem scratchMem halign)
+
+/-- Lifted `div128_v4_spec` over `sharedDivModCodeNoNop_v4 base`. -/
+theorem div128_v4_spec_shared_noNop (sp retAddr d uLo uHi : Word) (base : Word)
+    (v9Old v6Old v11Old : Word)
+    (retMem dMem dloMem un0Mem scratchMem : Word)
+    (halign : (retAddr + signExtend12 0) &&& ~~~1 = retAddr) :
+    cpsTripleWithin 73 (base + div128Off) retAddr (sharedDivModCodeNoNop_v4 base)
+      ((.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ retAddr) ** (.x10 ↦ᵣ d) **
+       (.x5 ↦ᵣ uLo) ** (.x7 ↦ᵣ uHi) **
+       (.x6 ↦ᵣ v6Old) ** (.x9 ↦ᵣ v9Old) ** (.x11 ↦ᵣ v11Old) **
+       (.x0 ↦ᵣ (0 : Word)) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
+       (sp + signExtend12 3944 ↦ₘ un0Mem) **
+       (sp + signExtend12 3936 ↦ₘ scratchMem))
+      (div128V4SpecPost sp retAddr d uLo uHi scratchMem) :=
+  cpsTripleWithin_extend_code (hmono := sharedNoNop_b11_div128_v4_sub)
     (div128_v4_spec sp retAddr d uLo uHi base v9Old v6Old v11Old
       retMem dMem dloMem un0Mem scratchMem halign)
 

--- a/EvmAsm/Evm64/DivMod/Compose/V4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/V4NoNop.lean
@@ -1,0 +1,42 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.V4NoNop
+
+  Shared no-NOP code surface for v4 div128 migration.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.Base
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- v4 mirror of `sharedDivModCodeNoNop`: shared DIV/MOD blocks with the
+    NOP return slot omitted and the final block using `divK_div128_v4`. -/
+abbrev sharedDivModCodeNoNop_v4 (base : Word) : CodeReq :=
+  CodeReq.unionAll [
+    CodeReq.ofProg  base                  (divK_phaseA 1020),
+    CodeReq.ofProg (base + phaseBOff)     divK_phaseB,
+    CodeReq.ofProg (base + clzOff)        divK_clz,
+    CodeReq.ofProg (base + phaseC2Off)    (divK_phaseC2 172),
+    CodeReq.ofProg (base + normBOff)      divK_normB,
+    CodeReq.ofProg (base + normAOff)      (divK_normA 40),
+    CodeReq.ofProg (base + copyAUOff)     divK_copyAU,
+    CodeReq.ofProg (base + loopSetupOff)  (divK_loopSetup 464),
+    CodeReq.ofProg (base + loopBodyOff)   (divK_loopBody 560 7736),
+    CodeReq.ofProg (base + denormOff)     divK_denorm,
+    CodeReq.ofProg (base + zeroPathOff)   divK_zeroPath,
+    CodeReq.ofProg (base + div128Off)     divK_div128_v4
+  ]
+
+/-- v4 div128 block is included in `sharedDivModCodeNoNop_v4 base`. -/
+theorem sharedNoNop_b11_div128_v4_sub {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + div128Off) divK_div128_v4) a = some i →
+           (sharedDivModCodeNoNop_v4 b) a = some i := by
+  unfold sharedDivModCodeNoNop_v4; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
+  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
+  exact CodeReq.union_mono_left
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LoopBody.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody.lean
@@ -65,6 +65,27 @@ theorem lb_sub_v4 {base : Word} (k : Nat) (addr : Word) (instr : Instr)
     (CodeReq.singleton_mono
       (CodeReq.ofProg_lookup (base + loopBodyOff) (divK_loopBody 560 7736) k hk (by decide)) a i h)
 
+/-- The loopBody ofProg (block 8) is subsumed by sharedDivModCodeNoNop_v4. -/
+private theorem divK_loopBody_ofProg_sub_sharedCodeNoNop_v4 {base : Word} :
+    ∀ a i, (CodeReq.ofProg (base + loopBodyOff) (divK_loopBody 560 7736)) a = some i →
+      (sharedDivModCodeNoNop_v4 base) a = some i := by
+  unfold sharedDivModCodeNoNop_v4; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
+  skipBlock; skipBlock
+  exact CodeReq.union_mono_left
+
+/-- Helper: singleton at index k of divK_loopBody ⊆ sharedDivModCodeNoNop_v4 base. -/
+theorem lb_sub_noNop_v4 {base : Word} (k : Nat) (addr : Word) (instr : Instr)
+    (hk : k < (divK_loopBody 560 7736).length)
+    (h_addr : addr = (base + loopBodyOff) + BitVec.ofNat 64 (4 * k))
+    (h_instr : (divK_loopBody 560 7736).get ⟨k, hk⟩ = instr) :
+    ∀ a i, CodeReq.singleton addr instr a = some i →
+      (sharedDivModCodeNoNop_v4 base) a = some i := by
+  subst h_addr; subst h_instr
+  exact fun a i h => divK_loopBody_ofProg_sub_sharedCodeNoNop_v4 a i
+    (CodeReq.singleton_mono
+      (CodeReq.ofProg_lookup (base + loopBodyOff) (divK_loopBody 560 7736) k hk (by decide)) a i h)
+
 /-- Helper: singleton at index k of divK_loopBody ⊆ divCode_noNop base. -/
 theorem lb_sub_noNop {base : Word} (k : Nat) (addr : Word) (instr : Instr)
     (hk : k < (divK_loopBody 560 7736).length)

--- a/EvmAsm/Evm64/DivMod/LoopBody/TrialCallPath.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody/TrialCallPath.lean
@@ -307,4 +307,77 @@ theorem divK_trial_call_path_spec_within_noNop
   exact divK_trial_call_path_spec_within_noNop_exact_x1 sp j uLo uHi vTop vtopBase base
     v1Old v2Old v11Old retMem dMem dloMem un0Mem halign
 
+/-- Trial call path over `sharedDivModCodeNoNop_v4`: JAL x2 560 (instr [16])
+    plus the v4 div128 subroutine, with exact x1 framing and the additional
+    v4 scratch cell threaded explicitly. -/
+theorem divK_trial_call_path_v4_spec_within_noNop_exact_x1
+    (sp j uLo uHi vTop vtopBase : Word) (base : Word)
+    (v1Old v2Old v11Old : Word)
+    (retMem dMem dloMem un0Mem scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff) :
+    cpsTripleWithin 74 (base + trialJalOff) (base + div128CallRetOff) (sharedDivModCodeNoNop_v4 base)
+      (((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
+       (.x5 ↦ᵣ uLo) ** (.x6 ↦ᵣ vtopBase) **
+       (.x7 ↦ᵣ uHi) ** (.x10 ↦ᵣ vTop) **
+       (.x2 ↦ᵣ v2Old) ** (.x11 ↦ᵣ v11Old) ** (.x0 ↦ᵣ (0 : Word)) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
+       (sp + signExtend12 3944 ↦ₘ un0Mem) **
+       (sp + signExtend12 3936 ↦ₘ scratchMem)) ** (.x1 ↦ᵣ v1Old))
+      (div128V4SpecPost sp (base + div128CallRetOff) vTop uLo uHi scratchMem **
+        regOwn .x1) := by
+  have J := jal_spec_within .x2 v2Old (560 : BitVec 21) (base + trialJalOff) (by nofun)
+  rw [lb_jal_target, lb_jal_ret] at J
+  have Je := cpsTripleWithin_extend_code (hmono :=
+    lb_sub_noNop_v4 16 _ _ (by decide) (by bv_addr) (by decide)) J
+  have D := div128_v4_spec_shared_noNop sp (base + div128CallRetOff) vTop uLo uHi base
+    j vtopBase v11Old retMem dMem dloMem un0Mem scratchMem
+    halign
+  have Df := cpsTripleWithin_frameR (.x1 ↦ᵣ v1Old) (by pcFree) D
+  have Jf := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) ** (.x1 ↦ᵣ v1Old) **
+     (.x5 ↦ᵣ uLo) ** (.x6 ↦ᵣ vtopBase) **
+     (.x7 ↦ᵣ uHi) ** (.x10 ↦ᵣ vTop) **
+     (.x11 ↦ᵣ v11Old) ** (.x0 ↦ᵣ (0 : Word)) **
+     (sp + signExtend12 3968 ↦ₘ retMem) **
+     (sp + signExtend12 3960 ↦ₘ dMem) **
+     (sp + signExtend12 3952 ↦ₘ dloMem) **
+     (sp + signExtend12 3944 ↦ₘ un0Mem) **
+     (sp + signExtend12 3936 ↦ₘ scratchMem))
+    (by pcFree) Je
+  have full := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) Jf Df
+  exact cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by
+      apply sepConj_mono_right (regIs_implies_regOwn .x1) h
+      xperm_hyp hq)
+    full
+
+/-- Trial call path over `sharedDivModCodeNoNop_v4`, with `x1`
+    existentially owned. -/
+theorem divK_trial_call_path_v4_spec_within_noNop
+    (sp j uLo uHi vTop vtopBase : Word) (base : Word)
+    (v2Old v11Old : Word)
+    (retMem dMem dloMem un0Mem scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff) :
+    cpsTripleWithin 74 (base + trialJalOff) (base + div128CallRetOff) (sharedDivModCodeNoNop_v4 base)
+      (((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
+       (.x5 ↦ᵣ uLo) ** (.x6 ↦ᵣ vtopBase) **
+       (.x7 ↦ᵣ uHi) ** (.x10 ↦ᵣ vTop) **
+       (.x2 ↦ᵣ v2Old) ** (.x11 ↦ᵣ v11Old) ** (.x0 ↦ᵣ (0 : Word)) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
+       (sp + signExtend12 3944 ↦ₘ un0Mem) **
+       (sp + signExtend12 3936 ↦ₘ scratchMem)) ** regOwn .x1)
+      (div128V4SpecPost sp (base + div128CallRetOff) vTop uLo uHi scratchMem **
+        regOwn .x1) := by
+  apply cpsTripleWithin_of_forall_regIs_to_regOwn
+  intro v1Old
+  exact divK_trial_call_path_v4_spec_within_noNop_exact_x1
+    sp j uLo uHi vTop vtopBase base v1Old v2Old v11Old
+    retMem dMem dloMem un0Mem scratchMem halign
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add sharedDivModCodeNoNop_v4 as the shared no-NOP code surface for div128_v4
- lift div128_v4_spec over the shared no-NOP v4 surface
- add no-NOP v4 trial-call path specs threading the extra div128_v4 scratch cell

## Verification
- lake build EvmAsm.Evm64.DivMod.LoopBody.TrialCallPath
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- git diff --cached --check
- scripts/check-file-size.sh EvmAsm/Evm64/DivMod/Compose/Base.lean EvmAsm/Evm64/DivMod/Compose/V4NoNop.lean EvmAsm/Evm64/DivMod/Compose/Div128V4.lean EvmAsm/Evm64/DivMod/LoopBody.lean EvmAsm/Evm64/DivMod/LoopBody/TrialCallPath.lean
- scripts/check-unimported.sh