### PR TITLE
feat(div): add v4 skip-tail loopbody surface

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopBody.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody.lean
@@ -835,6 +835,86 @@ theorem divK_mulsub_full_spec_within
   divK_mulsub_full_spec_within_of_sub sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
     v9Old v5Old v6Old v7Old v10Old v2Old base (sharedDivModCode base) lb_sub
 
+/-- Bundled precondition for mulsub-full wrappers. -/
+@[irreducible]
+def divKMulsubFullPre
+    (sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
+     v9Old v5Old v6Old v7Old v10Old v2Old : Word) : Assertion :=
+  let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+  (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+  (.x9 ↦ᵣ v9Old) ** (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+  (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x2 ↦ᵣ v2Old) **
+  (.x0 ↦ᵣ 0) **
+  (sp + signExtend12 3976 ↦ₘ j) **
+  ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+  ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+  ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+  ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+  ((uBase + signExtend12 4064) ↦ₘ uTop)
+
+/-- Bundled postcondition for mulsub-full wrappers. -/
+@[irreducible]
+def divKMulsubFullPost
+    (sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Assertion :=
+  let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+  let p0_lo := qHat * v0
+  let p0_hi := rv64_mulhu qHat v0
+  let fs0 := p0_lo + (signExtend12 0 : Word)
+  let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
+  let pc0 := ba0 + p0_hi
+  let bs0 := if BitVec.ult u0 fs0 then (1 : Word) else 0
+  let un0 := u0 - fs0
+  let c0 := pc0 + bs0
+  let p1_lo := qHat * v1
+  let p1_hi := rv64_mulhu qHat v1
+  let fs1 := p1_lo + c0
+  let ba1 := if BitVec.ult fs1 c0 then (1 : Word) else 0
+  let pc1 := ba1 + p1_hi
+  let bs1 := if BitVec.ult u1 fs1 then (1 : Word) else 0
+  let un1 := u1 - fs1
+  let c1 := pc1 + bs1
+  let p2_lo := qHat * v2
+  let p2_hi := rv64_mulhu qHat v2
+  let fs2 := p2_lo + c1
+  let ba2 := if BitVec.ult fs2 c1 then (1 : Word) else 0
+  let pc2 := ba2 + p2_hi
+  let bs2 := if BitVec.ult u2 fs2 then (1 : Word) else 0
+  let un2 := u2 - fs2
+  let c2 := pc2 + bs2
+  let p3_lo := qHat * v3
+  let p3_hi := rv64_mulhu qHat v3
+  let fs3 := p3_lo + c2
+  let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
+  let pc3 := ba3 + p3_hi
+  let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
+  let un3 := u3 - fs3
+  let c3 := pc3 + bs3
+  let borrow := if BitVec.ult uTop c3 then (1 : Word) else 0
+  let u4_new := uTop - c3
+  (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+  (.x9 ↦ᵣ j) ** (.x5 ↦ᵣ u4_new) ** (.x6 ↦ᵣ uBase) **
+  (.x7 ↦ᵣ borrow) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
+  (.x0 ↦ᵣ 0) **
+  (sp + signExtend12 3976 ↦ₘ j) **
+  ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0) **
+  ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1) **
+  ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2) **
+  ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3) **
+  ((uBase + signExtend12 4064) ↦ₘ u4_new)
+
+/-- `divK_mulsub_full_spec_within` replayed over `sharedDivModCode_v4`. -/
+theorem divK_mulsub_full_v4_spec_within
+    (sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+    (v9Old v5Old v6Old v7Old v10Old v2Old : Word)
+    (base : Word) :
+    cpsTripleWithin 53 (base + div128CallRetOff) (base + correctionSkipBeqOff) (sharedDivModCode_v4 base)
+      (divKMulsubFullPre sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
+        v9Old v5Old v6Old v7Old v10Old v2Old)
+      (divKMulsubFullPost sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  unfold divKMulsubFullPre divKMulsubFullPost
+  exact divK_mulsub_full_spec_within_of_sub sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    v9Old v5Old v6Old v7Old v10Old v2Old base (sharedDivModCode_v4 base) lb_sub_v4
+
 /-- `divK_mulsub_full_spec_within` replayed over the DIV no-NOP code surface. -/
 theorem divK_mulsub_full_spec_within_noNop
     (sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)

--- a/EvmAsm/Evm64/DivMod/LoopBody/CorrectionSkip.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody/CorrectionSkip.lean
@@ -72,6 +72,55 @@ theorem divK_correction_skip_spec_within
     (fun h hp => by xperm_hyp hp)
     skip_framed
 
+/-- Correction skip over `sharedDivModCode_v4`: when borrow=0, BEQ taken
+    → jump to base+884. No addback. -/
+theorem divK_correction_skip_v4_spec_within
+    (sp uBase qHat v0 v1 v2 v3 u0 u1 u2 u3 u4 : Word)
+    (v5Old v2Old : Word) (base : Word) :
+    cpsTripleWithin 1 (base + correctionSkipBeqOff) (base + storeLoopOff) (sharedDivModCode_v4 base)
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ uBase) ** (.x7 ↦ᵣ (0 : Word)) **
+       (.x11 ↦ᵣ qHat) ** (.x5 ↦ᵣ v5Old) ** (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ u4))
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ uBase) ** (.x7 ↦ᵣ (0 : Word)) **
+       (.x11 ↦ᵣ qHat) ** (.x5 ↦ᵣ v5Old) ** (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ u4)) := by
+  have hbeq := beq_spec_gen_within .x7 .x0 (156 : BitVec 13) (0 : Word) 0 (base + correctionSkipBeqOff)
+  rw [lb_beq_taken, lb_beq_ntaken] at hbeq
+  have hbeq_ext := cpsBranchWithin_extend_code (hmono :=
+    lb_sub_v4 70 _ _ (by decide) (by bv_addr) (by decide)) hbeq
+  have skip := cpsBranchWithin_takenPath hbeq_ext (fun hp hQf => by
+    obtain ⟨_, _, _, _, _, ⟨_, _, _, _, _, ⟨_, hpure⟩⟩⟩ := hQf
+    exact hpure rfl)
+  have skip_clean : cpsTripleWithin 1 (base + correctionSkipBeqOff) (base + storeLoopOff) (sharedDivModCode_v4 base)
+      ((.x7 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)))
+      ((.x7 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word))) :=
+    cpsTripleWithin_weaken
+      (fun h hp => hp)
+      (fun h hp => sepConj_mono_right
+        (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hp)
+      skip
+  have skip_framed := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ uBase) **
+     (.x11 ↦ᵣ qHat) ** (.x5 ↦ᵣ v5Old) ** (.x2 ↦ᵣ v2Old) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((uBase + signExtend12 4064) ↦ₘ u4))
+    (by pcFree) skip_clean
+  exact cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by xperm_hyp hp)
+    skip_framed
+
 /-- Correction skip over `divCode_noNop`: when borrow=0, BEQ taken → jump
     to base+884. No addback. -/
 theorem divK_correction_skip_spec_within_noNop

--- a/EvmAsm/Evm64/DivMod/LoopBody/MulsubCorrectionSkip.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody/MulsubCorrectionSkip.lean
@@ -100,6 +100,128 @@ theorem divK_mulsub_correction_skip_spec_within
     (fun h hq => by xperm_hyp hq)
     MSCS
 
+/-- Bundled precondition for mulsub+correction-skip wrappers. -/
+@[irreducible]
+def divKMulsubCorrectionSkipPre
+    (sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
+     v1Old v5Old v6Old v7Old v10Old v2Old : Word) : Assertion :=
+  let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+  (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+  (.x9 ↦ᵣ v1Old) ** (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+  (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x2 ↦ᵣ v2Old) **
+  (.x0 ↦ᵣ 0) **
+  (sp + signExtend12 3976 ↦ₘ j) **
+  ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+  ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+  ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+  ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+  ((uBase + signExtend12 4064) ↦ₘ uTop)
+
+/-- Borrow-free condition for the generic 4-limb mulsub chain. -/
+def mulsubN4NoBorrow (qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Prop :=
+  let c3 := (mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2
+  (if BitVec.ult uTop c3 then (1 : Word) else 0) = (0 : Word)
+
+/-- Bundled postcondition for the named skip wrapper. Hides `uBase`, `ms`,
+    `c3`, and `u4_new` so named specs do not expose the mulsub tuple plumbing. -/
+@[irreducible]
+def n4McaNamedSkipPost
+    (sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Assertion :=
+  let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+  let ms    := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+  let c3    := ms.2.2.2.2
+  let u4_new := uTop - c3
+  (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+  (.x9 ↦ᵣ j) ** (.x5 ↦ᵣ u4_new) ** (.x6 ↦ᵣ uBase) **
+  (.x7 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ ms.2.2.2.1) **
+  (.x0 ↦ᵣ 0) **
+  (sp + signExtend12 3976 ↦ₘ j) **
+  ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ ms.1) **
+  ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ ms.2.1) **
+  ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ ms.2.2.1) **
+  ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ ms.2.2.2.1) **
+  ((uBase + signExtend12 4064) ↦ₘ u4_new)
+
+theorem n4McaNamedSkipPost_unfold
+    {sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word} :
+    n4McaNamedSkipPost sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop =
+      (let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+       let ms    := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+       let c3    := ms.2.2.2.2
+       let u4_new := uTop - c3
+       (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+       (.x9 ↦ᵣ j) ** (.x5 ↦ᵣ u4_new) ** (.x6 ↦ᵣ uBase) **
+       (.x7 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ ms.2.2.2.1) **
+       (.x0 ↦ᵣ 0) **
+       (sp + signExtend12 3976 ↦ₘ j) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ ms.1) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ ms.2.1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ ms.2.2.1) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ ms.2.2.2.1) **
+       ((uBase + signExtend12 4064) ↦ₘ u4_new)) := by
+  delta n4McaNamedSkipPost; rfl
+
+/-- v4 variant of `divK_mulsub_correction_skip_spec_within`.
+
+    Entry: base+516, Exit: base+880, CodeReq: `sharedDivModCode_v4 base`. -/
+theorem divK_mulsub_correction_skip_v4_spec_within
+    (sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+    (v1Old v5Old v6Old v7Old v10Old v2Old : Word)
+    (base : Word) :
+    mulsubN4NoBorrow qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop →
+    cpsTripleWithin 54 (base + div128CallRetOff) (base + storeLoopOff) (sharedDivModCode_v4 base)
+      (divKMulsubCorrectionSkipPre sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
+        v1Old v5Old v6Old v7Old v10Old v2Old)
+      (n4McaNamedSkipPost sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro hborrow
+  have MS := divK_mulsub_full_v4_spec_within sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    v1Old v5Old v6Old v7Old v10Old v2Old base
+  unfold divKMulsubFullPre divKMulsubFullPost at MS
+  unfold mulsubN4NoBorrow mulsubN4 at hborrow
+  dsimp only [] at MS hborrow
+  rw [hborrow] at MS
+  let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+  let p0_lo := qHat * v0
+  let p0_hi := rv64_mulhu qHat v0
+  let fs0 := p0_lo + (signExtend12 0 : Word)
+  let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
+  let pc0 := ba0 + p0_hi
+  let bs0 := if BitVec.ult u0 fs0 then (1 : Word) else 0
+  let un0 := u0 - fs0
+  let c0 := pc0 + bs0
+  let p1_lo := qHat * v1
+  let p1_hi := rv64_mulhu qHat v1
+  let fs1 := p1_lo + c0
+  let ba1 := if BitVec.ult fs1 c0 then (1 : Word) else 0
+  let pc1 := ba1 + p1_hi
+  let bs1 := if BitVec.ult u1 fs1 then (1 : Word) else 0
+  let un1 := u1 - fs1
+  let c1 := pc1 + bs1
+  let p2_lo := qHat * v2
+  let p2_hi := rv64_mulhu qHat v2
+  let fs2 := p2_lo + c1
+  let ba2 := if BitVec.ult fs2 c1 then (1 : Word) else 0
+  let pc2 := ba2 + p2_hi
+  let bs2 := if BitVec.ult u2 fs2 then (1 : Word) else 0
+  let un2 := u2 - fs2
+  let c2 := pc2 + bs2
+  let p3_lo := qHat * v3
+  let p3_hi := rv64_mulhu qHat v3
+  let fs3 := p3_lo + c2
+  let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
+  let pc3 := ba3 + p3_hi
+  let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
+  let un3 := u3 - fs3
+  let c3 := pc3 + bs3
+  let u4_new := uTop - c3
+  have CS := divK_correction_skip_v4_spec_within sp uBase qHat v0 v1 v2 v3 un0 un1 un2 un3 u4_new
+    u4_new un3 base
+  seqFrame MS CS
+  exact cpsTripleWithin_weaken
+    (fun h hp => by unfold divKMulsubCorrectionSkipPre at hp; xperm_hyp hp)
+    (fun h hq => by simp only [n4McaNamedSkipPost_unfold]; unfold mulsubN4; xperm_hyp hq)
+    MSCS
+
 /-- No-NOP variant of `divK_mulsub_correction_skip_spec_within`.
 
     Entry: base+516, Exit: base+880, CodeReq: `divCode_noNop base`. -/
@@ -174,46 +296,6 @@ theorem divK_mulsub_correction_skip_spec_within_noNop
     (fun h hp => by xperm_hyp hp)
     (fun h hq => by xperm_hyp hq)
     MSCS
-
-/-- Bundled postcondition for the named skip wrapper.  Hides `uBase`, `ms`,
-    `c3`, and `u4_new` so the named spec statement exposes only 1 let (`c3`
-    for the borrow hypothesis) rather than 30+. -/
-@[irreducible]
-def n4McaNamedSkipPost
-    (sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Assertion :=
-  let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
-  let ms    := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
-  let c3    := ms.2.2.2.2
-  let u4_new := uTop - c3
-  (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
-  (.x9 ↦ᵣ j) ** (.x5 ↦ᵣ u4_new) ** (.x6 ↦ᵣ uBase) **
-  (.x7 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ ms.2.2.2.1) **
-  (.x0 ↦ᵣ 0) **
-  (sp + signExtend12 3976 ↦ₘ j) **
-  ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ ms.1) **
-  ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ ms.2.1) **
-  ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ ms.2.2.1) **
-  ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ ms.2.2.2.1) **
-  ((uBase + signExtend12 4064) ↦ₘ u4_new)
-
-theorem n4McaNamedSkipPost_unfold
-    {sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word} :
-    n4McaNamedSkipPost sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop =
-      (let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
-       let ms    := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
-       let c3    := ms.2.2.2.2
-       let u4_new := uTop - c3
-       (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
-       (.x9 ↦ᵣ j) ** (.x5 ↦ᵣ u4_new) ** (.x6 ↦ᵣ uBase) **
-       (.x7 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ ms.2.2.2.1) **
-       (.x0 ↦ᵣ 0) **
-       (sp + signExtend12 3976 ↦ₘ j) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ ms.1) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ ms.2.1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ ms.2.2.1) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ ms.2.2.2.1) **
-       ((uBase + signExtend12 4064) ↦ₘ u4_new)) := by
-  delta n4McaNamedSkipPost; rfl
 
 /-- Named-postcondition no-NOP wrapper for
     `divK_mulsub_correction_skip_spec_within_noNop`. Exposes only 1 statement

--- a/EvmAsm/Evm64/DivMod/LoopBody/StoreLoop.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody/StoreLoop.lean
@@ -106,6 +106,72 @@ theorem divK_store_loop_j0_spec_within
     (fun h hp => by xperm_hyp hp)
     full
 
+/-- Store q[0] + loop exit at j=0 over `sharedDivModCode_v4`. -/
+theorem divK_store_loop_j0_v4_spec_within
+    (sp qHat v5Old v7Old qOld : Word)
+    (base : Word) :
+    let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
+    let j' := (0 : Word) + signExtend12 4095
+    cpsTripleWithin 6 (base + storeLoopOff) (base + denormOff) (sharedDivModCode_v4 base)
+      ((.x9 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+       (.x5 ↦ᵣ v5Old) ** (.x7 ↦ᵣ v7Old) ** (.x0 ↦ᵣ (0 : Word)) **
+       (qAddr ↦ₘ qOld))
+      ((.x9 ↦ᵣ j') ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+       (.x5 ↦ᵣ (0 : Word) <<< (3 : BitVec 6).toNat) ** (.x7 ↦ᵣ qAddr) ** (.x0 ↦ᵣ (0 : Word)) **
+       (qAddr ↦ₘ qHat)) := by
+  intro qAddr j'
+  have SQ := divK_store_qj_spec_within sp (0 : Word) qHat v5Old v7Old qOld (base + storeLoopOff)
+  dsimp only [] at SQ
+  rw [lb_sqj] at SQ
+  have SQe := cpsTripleWithin_extend_code (hmono := by
+    exact CodeReq.union_sub (lb_sub_v4 109 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub_v4 110 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub_v4 111 _ _ (by decide) (by bv_addr) (by decide))
+      (lb_sub_v4 112 _ _ (by decide) (by bv_addr) (by decide))))) SQ
+  have haddi := addi_spec_gen_same_within .x9 (0 : Word) 4095 (base + loopControlOff) (by nofun)
+  rw [show (base + loopControlOff : Word) + 4 = base + loopBackBgeOff from by bv_addr] at haddi
+  have haddi_e := cpsTripleWithin_extend_code (hmono := by
+    exact lb_sub_v4 113 _ _ (by decide) (by bv_addr) (by decide)) haddi
+  have hbge_raw := bge_spec_gen_within .x9 .x0 (7736 : BitVec 13) j' (0 : Word) (base + loopBackBgeOff)
+  rw [show (base + loopBackBgeOff : Word) + signExtend13 (7736 : BitVec 13) = base + loopBodyOff from by rv64_addr,
+      show (base + loopBackBgeOff : Word) + 4 = base + denormOff from by bv_addr] at hbge_raw
+  have hbge_ext := cpsBranchWithin_extend_code (hmono := by
+    exact lb_sub_v4 114 _ _ (by decide) (by bv_addr) (by decide)) hbge_raw
+  have hbge_exit_raw := cpsBranchWithin_ntakenPath hbge_ext
+    (fun hp hQt => by
+      obtain ⟨_, _, _, _, _, ⟨_, _, _, _, _, ⟨_, hpure⟩⟩⟩ := hQt
+      exact hpure j0_slt_zero)
+  have hbge_exit := cpsTripleWithin_weaken
+    (fun h hp => hp)
+    (fun h hp => sepConj_mono_right
+      (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hp)
+    hbge_exit_raw
+  have SQx0 : cpsTripleWithin 4 (base + storeLoopOff) (base + loopControlOff) (sharedDivModCode_v4 base)
+      ((.x9 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+       (.x5 ↦ᵣ v5Old) ** (.x7 ↦ᵣ v7Old) ** (.x0 ↦ᵣ (0 : Word)) ** (qAddr ↦ₘ qOld))
+      ((.x9 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+       (.x5 ↦ᵣ (0 : Word) <<< (3 : BitVec 6).toNat) ** (.x7 ↦ᵣ qAddr) **
+       (.x0 ↦ᵣ (0 : Word)) ** (qAddr ↦ₘ qHat)) :=
+    cpsTripleWithin_weaken
+      (fun h hp => by xperm_hyp hp)
+      (fun h hp => by xperm_hyp hp)
+      (cpsTripleWithin_frameR (.x0 ↦ᵣ (0 : Word)) (by pcFree) SQe)
+  have haddi_x0 := cpsTripleWithin_frameR
+      (.x0 ↦ᵣ (0 : Word)) (by pcFree) haddi_e
+  have addi_bge := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) haddi_x0 hbge_exit
+  have addi_bge_framed := cpsTripleWithin_frameR
+      ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+       (.x5 ↦ᵣ (0 : Word) <<< (3 : BitVec 6).toNat) ** (.x7 ↦ᵣ qAddr) **
+       (qAddr ↦ₘ qHat))
+      (by pcFree) addi_bge
+  have full := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) SQx0 addi_bge_framed
+  exact cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by xperm_hyp hp)
+    full
+
 /-- Store q[0] + loop exit at j=0 over `divCode_noNop`. Since j' = -1 < 0,
     BGE is not taken, so this exits to base+908. -/
 theorem divK_store_loop_j0_spec_within_noNop

--- a/EvmAsm/Evm64/DivMod/LoopDefs/IterV4.lean
+++ b/EvmAsm/Evm64/DivMod/LoopDefs/IterV4.lean
@@ -1,21 +1,17 @@
 /-
   EvmAsm.Evm64.DivMod.LoopDefs.IterV4
 
-  Fully-corrected div128 trial quotient `div128Quot_v4` — Knuth's
-  classical Algorithm D with up to 2 D3 corrections in BOTH the
-  high-half (Phase-1b) and low-half (Phase-2) trial divisions.
+  v4 div128 trial quotient `div128Quot_v4` — the RV64 v4 program quotient.
 
   Bug history (v1, v2 deprecated; v3 removed in this PR):
   - `div128Quot` (v1): only 1 D3 correction in Phase-1b. Buggy on
     inputs where Knuth's classical D3 loop needs 2 iterations.
-  - `div128Quot_v2`: added a 2nd Phase-1b correction, but the 1st
-    correction had a truncation bug (no `rhatc >> 32 = 0` guard).
+  - `div128Quot_v2`: added a 2nd Phase-1b correction.
   - (v3 was a half-step that fixed Phase-1b but kept 1-correction
     Phase-2; obsolete since `phase2_no_wrap_lo` sub-case b was proven
     FALSE under 1-correction Phase-2.)
-  - `div128Quot_v4` (this file): full 2-correction in both phases.
-    With Knuth's full classical 2-correction loop, the output
-    `qHat = q*_full` exactly — no per-phase overshoot.
+  - `div128Quot_v4` (this file): keeps the v2 Phase-1b chain and adds the
+    Phase-2 2nd D3 correction implemented by `divK_div128_v4`.
 
   Why v4 matters:
   - `phase2_no_wrap_lo_under_runtime` was sorry'd in v2/v3 because
@@ -33,7 +29,7 @@
   Issue #1337 algorithm fix migration / Issue #61 stack spec closure.
 -/
 
-import EvmAsm.Evm64.DivMod.LimbSpec.Div128ProdCheck2
+import EvmAsm.Evm64.DivMod.LoopDefs.Iter
 
 namespace EvmAsm.Evm64
 
@@ -43,12 +39,8 @@ open EvmAsm.Rv64
     Algorithm D Step D3 with up to 2 correction iterations in BOTH the
     high-half (Phase-1b) and low-half (Phase-2) trial divisions.
 
-    With 2 D3 iterations in each phase, the output `qHat = q*_full =
-    ⌊(uHi*2^64+uLo)/vTop⌋` exactly — no per-phase overshoot.
-
-    Each correction is delegated to `div128Quot_phase2b_q0'` (which has
-    the `rhat' < 2^32` guard built in), so all corrections are idempotent
-    on inputs where the trial quotient is already correct. -/
+    Phase 1b is intentionally identical to the v2 executable/spec surface;
+    the v4 change is the second Phase-2 D3 correction. -/
 def div128Quot_v4 (uHi uLo vTop : Word) : Word :=
   let dHi := vTop >>> (32 : BitVec 6).toNat
   let dLo := (vTop <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
@@ -59,15 +51,11 @@ def div128Quot_v4 (uHi uLo vTop : Word) : Word :=
   let hi1 := q1 >>> (32 : BitVec 6).toNat
   let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
   let rhatc := if hi1 = 0 then rhat else rhat + dHi
-  -- Phase 1b: 1st D3 correction (same as v3 — guarded helper).
-  let q1' := div128Quot_phase2b_q0' q1c rhatc dLo div_un1
-  let rhat' :=
-    if rhatc >>> (32 : BitVec 6).toNat = 0 then
-      let qDlo := q1c * dLo
-      let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
-      if BitVec.ult rhatUn1 qDlo then rhatc + dHi else rhatc
-    else rhatc
-  -- Phase 1b: 2nd D3 correction (same as v3).
+  -- Phase 1b: v2's first and second D3 corrections.
+  let qDlo := q1c * dLo
+  let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
+  let q1' := if BitVec.ult rhatUn1 qDlo then q1c + signExtend12 4095 else q1c
+  let rhat' := if BitVec.ult rhatUn1 qDlo then rhatc + dHi else rhatc
   let q1'' := div128Quot_phase2b_q0' q1' rhat' dLo div_un1
   let rhat'' :=
     if rhat' >>> (32 : BitVec 6).toNat = 0 then
@@ -96,5 +84,11 @@ def div128Quot_v4 (uHi uLo vTop : Word) : Word :=
     else rhat2c
   let q0'' := div128Quot_phase2b_q0' q0' rhat2' dLo div_un0
   (q1'' <<< (32 : BitVec 6).toNat) ||| q0''
+
+/-- Borrow condition for n=1 call+skip with the fully-corrected v4
+    trial quotient: mulsub does not overflow. -/
+def isSkipBorrowN1CallV4 (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Prop :=
+  let qHat := div128Quot_v4 u1 u0 v0
+  (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word)
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LoopDefs/Post.lean
+++ b/EvmAsm/Evm64/DivMod/LoopDefs/Post.lean
@@ -13,6 +13,7 @@
 -/
 
 import EvmAsm.Evm64.DivMod.LoopDefs.Iter
+import EvmAsm.Evm64.DivMod.LoopDefs.IterV4
 
 open EvmAsm.Rv64.Tactics
 
@@ -196,6 +197,49 @@ def loopBodyN1CallSkipPostJ (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : As
   (sp + signExtend12 3960 ↦ₘ v0) **
   (sp + signExtend12 3952 ↦ₘ div128DLo v0) **
   (sp + signExtend12 3944 ↦ₘ div128Un0 u0) ** regOwn .x1
+
+/-- Call+skip postcondition for n=1 over the fully-corrected v4 trial
+    quotient. The v4 div128 body preserves the old scratch cells and also
+    exposes its extra Phase-2 scratch cell at `sp+3936`. -/
+@[irreducible]
+def loopBodyN1CallSkipPostJV4
+    (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word) : Assertion :=
+  let qHat := div128Quot_v4 u1 u0 v0
+  let dHi := v0 >>> (32 : BitVec 6).toNat
+  let dLo := (v0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  let div_un1 := u0 >>> (32 : BitVec 6).toNat
+  let div_un0 := (u0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  let q1 := rv64_divu u1 dHi
+  let rhat := u1 - q1 * dHi
+  let hi1 := q1 >>> (32 : BitVec 6).toNat
+  let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
+  let rhatc := if hi1 = 0 then rhat else rhat + dHi
+  let qDlo := q1c * dLo
+  let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
+  let q1' := if BitVec.ult rhatUn1 qDlo then q1c + signExtend12 4095 else q1c
+  let rhat' := if BitVec.ult rhatUn1 qDlo then rhatc + dHi else rhatc
+  let rhatHi2 := rhat' >>> (32 : BitVec 6).toNat
+  let qDlo2 := q1' * dLo
+  let rhatUn1' := (rhat' <<< (32 : BitVec 6).toNat) ||| div_un1
+  let q1'' := if rhatHi2 = 0 ∧ BitVec.ult rhatUn1' qDlo2
+              then q1' + signExtend12 4095 else q1'
+  let rhat'' := if rhatHi2 = 0 ∧ BitVec.ult rhatUn1' qDlo2
+                then rhat' + dHi else rhat'
+  let cu_rhat_un1 := (rhat'' <<< (32 : BitVec 6).toNat) ||| div_un1
+  let cu_q1_dlo := q1'' * dLo
+  let un21 := cu_rhat_un1 - cu_q1_dlo
+  let q0 := rv64_divu un21 dHi
+  let rhat2 := un21 - q0 * dHi
+  let hi2 := q0 >>> (32 : BitVec 6).toNat
+  let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
+  let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
+  loopBodyN1SkipPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+  (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+  (sp + signExtend12 3960 ↦ₘ v0) **
+  (sp + signExtend12 3952 ↦ₘ dLo) **
+  (sp + signExtend12 3944 ↦ₘ div_un0) **
+  (sp + signExtend12 3936 ↦ₘ (if rhat2cHi ≠ 0 then scratchMem else rhat2c)) **
+  regOwn .x1
 
 /-- Call+addback BEQ postcondition for n=1, generic j, with double-addback handling. -/
 @[irreducible]


### PR DESCRIPTION
## Summary
- align div128Quot_v4 with the composed v4 program surface and add the N1 v4 skip-borrow predicate
- add loopBodyN1CallSkipPostJV4 with the extra sp+3936 v4 scratch cell
- add sharedDivModCode_v4 wrappers for mulsub full, correction skip, combined skip-tail composition, and store_loop_j0

## Verification
- lake build EvmAsm.Evm64.DivMod.LoopBody.StoreLoop EvmAsm.Evm64.DivMod.LoopBody.MulsubCorrectionSkip
- lake build EvmAsm.Evm64.DivMod.LoopIterN1.Call
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- scripts/check-file-size.sh EvmAsm/Evm64/DivMod/LoopBody.lean EvmAsm/Evm64/DivMod/LoopBody/CorrectionSkip.lean EvmAsm/Evm64/DivMod/LoopBody/MulsubCorrectionSkip.lean EvmAsm/Evm64/DivMod/LoopBody/StoreLoop.lean EvmAsm/Evm64/DivMod/LoopDefs/IterV4.lean EvmAsm/Evm64/DivMod/LoopDefs/Post.lean
- scripts/check-unimported.sh

## Notes
- Tried wiring the first N1 v4 call+skip consumer directly; it hit the global heartbeat limit at theorem elaboration. This PR leaves the reusable v4 tail/store/post surfaces in place so the consumer can be split around smaller named bundles instead of increasing heartbeats.