### PR TITLE
feat(codegen): M5 tiny EVM interpreter (M5a unrolled + M5b dispatch loop)

### DIFF
--- a/CODEGEN.md
+++ b/CODEGEN.md
@@ -37,13 +37,13 @@ untouched. Generated artifacts go in `gen-out/` (gitignored).
 |---|---|
 | `EvmAsm/Codegen.lean` | Top-level umbrella (mirrors `EvmAsm/Rv64.lean`, `EvmAsm/Evm64.lean`). |
 | `EvmAsm/Codegen/Emit.lean` | Pure `emitReg`, `emitInstr`, `emitProgram` — `Instr → String`. No `IO`. |
-| `EvmAsm/Codegen/Layout.lean` | `HaltConv` enum, halt stub, `_start`, `.option norvc`, `MEM_START`/`MEM_END` constants. |
-| `EvmAsm/Codegen/Programs.lean` | Registry: `"smoke"`, `"evm_add"`, `"interp_tiny"`, … → `Program`. |
+| `EvmAsm/Codegen/Layout.lean` | `HaltConv` enum, halt stubs, `_start` preamble, `.option norvc`, `MEM_START`/`MEM_END` constants, `BuildUnit` struct + `emitBuildUnit`/`emitDataLabel` helpers. |
+| `EvmAsm/Codegen/Programs.lean` | Registry (`smoke`, `evm_add`, `input_echo`, `evm_add_from_input`, `tiny_interp_{add,add2}`, `tiny_interp_dispatch_{add,add2}` → `BuildUnit`). Also hosts the M5b dispatcher scaffold (prologue/epilogue + 256-entry jump table generator) and shared helpers (`advancePc`, `copy64`, `evmAddEpilogue`). |
 | `EvmAsm/Codegen/Cli.lean` | Argument parsing (`--program`, `--halt`, `--out`, `--asm-only`). |
 | `EvmAsm/Codegen/Driver.lean` | `IO`: shells out to `as`/`ld` if available; `--asm-only` for CI without the cross toolchain. |
 | `Main.lean` | Already exists as `import EvmAsm`; extend to call `EvmAsm.Codegen.Cli.main`. |
 | `lakefile.toml` | Add `[[lean_exe]] name = "codegen"; root = "Main"; supportInterpreter = true`. |
-| `scripts/codegen-smoke.sh` | One-liner driving the M0 round-trip. |
+| `scripts/codegen-*.sh` | Per-milestone round-trip checks: `codegen-smoke.sh` (M0), `codegen-evm_add-check.sh` (M2), `codegen-evm_add-from-input-check.sh` (M4), `codegen-tiny-interp-check.sh` (M5a), `codegen-tiny-interp-dispatch-check.sh` (M5b). |
 | `gen-out/` | Generated `.s`/`.elf`/`.input`; gitignored. |
 
 ## Milestones
@@ -252,7 +252,7 @@ target only the zkvm-standards single-buffer shape.
   `ziskemu -i ...`, and diffs the public output against the expected
   value computed in Lean.
 
-### M5 — Tiny EVM interpreter (L)
+### M5 — Tiny EVM interpreter (L) — **DONE (2026-05-19)**
 
 Split into two slices. **M5a** unrolls verified opcode `Program`s as a
 linear chain (no runtime dispatch) to validate that the handlers
@@ -438,15 +438,34 @@ M5b's dispatcher relies on.
 
 ## Future work (post-M5)
 
-- Lean-native binary encoder (`Instr → BitVec 32` + ELF writer) to drop the
-  GNU binutils dependency. Cross-check the encoded bytes against the verified
-  `step` semantics.
-- STF integration: consume RLP-decoded transactions via `read_input` and drive
-  the full interpreter loop.
-- Precompile stubs aligned with
+Near-term (builds directly on M5b's dispatcher; no new design surface):
+
+- **Broaden opcode coverage.** Wire more verified handlers into the M5b
+  dispatch loop — `evm_push n` generically (PUSH2..32), stack ops
+  (`POP`, `DUP1`, `SWAP1`), and additional arithmetic (`SUB`, `MUL`) as
+  the corresponding verified `Program`s land. Pure registry expansion
+  against the existing jump table + handler-wrapper pattern.
+- **Hint-input demo via `evm_div`.** Closes the loop on M4's prover-hint
+  infrastructure once `evm_div` is a verified `Program` in the registry.
+  Guest reads `(q, r)` from `INPUT_ADDR + INPUT_DATA_OFFSET`, verifies
+  `q · d + r = n ∧ r < d`, writes `q` to `OUTPUT_ADDR`.
+
+Longer-term (genuine new design surface):
+
+- **JUMP / JUMPI + JUMPDEST table.** Real control flow. Handlers must
+  write `x10` directly (the wrapper baking in a fixed advance no longer
+  works) and JUMP/JUMPI need to consult a JUMPDEST validity table built
+  from the bytecode at codegen time.
+- **Lean-native binary encoder** (`Instr → BitVec 32` + ELF writer) to
+  drop the GNU binutils dependency. Cross-check the encoded bytes
+  against the verified `step` semantics.
+- **STF integration**: consume RLP-decoded transactions via `read_input`
+  and drive the full interpreter loop.
+- **Precompile stubs** aligned with
   `EvmAsm/Evm64/zkvm-standards/standards/c-interface-accelerators`.
-- Cross-zkVM testing (SP1, RISC0) to validate the halt-convention ADR closure
-  described in [`docs/host-io-halt-convention.md`](docs/host-io-halt-convention.md).
+- **Cross-zkVM testing** (SP1, RISC0) to validate the halt-convention
+  ADR closure described in
+  [`docs/host-io-halt-convention.md`](docs/host-io-halt-convention.md).
 
 ## References
 

--- a/CODEGEN.md
+++ b/CODEGEN.md
@@ -254,19 +254,123 @@ target only the zkvm-standards single-buffer shape.
 
 ### M5 — Tiny EVM interpreter (L)
 
-Codegen `EvmAsm/Evm64/InterpreterLoop.lean` + `EvmAsm/Evm64/Dispatch.lean` and
-run small bytecodes (`PUSH1 a; PUSH1 b; ADD; STOP`, a two-op branch, …). A
-reference oracle in Lean or Python diffs the expected stack against
-`ziskemu`'s public output.
+Split into two slices. **M5a** unrolls verified opcode `Program`s as a
+linear chain (no runtime dispatch) to validate that the handlers
+compose under `++` honoring the `x10` code-pointer convention.
+**M5b** codegens the actual fetch/decode/dispatch loop from
+`EvmAsm/Evm64/InterpreterLoop.lean` + `EvmAsm/Evm64/Dispatch.lean`.
 
-**Exit criteria.**
-2–3 hand-picked bytecodes round-trip end-to-end against an oracle; smoke +
-`evm_add` + tiny-interp all in a single CI-runnable script.
+#### M5a — Unrolled tiny interpreter (S) — **DONE (2026-05-19)**
+
+Chain verified opcode `Program`s end-to-end for two hand-picked
+bytecodes, no runtime dispatch. Each opcode handler reads its
+operands from the conventional registers (`x10` = EVM code pointer,
+`x12` = EVM stack pointer); a one-instruction `advancePc` between
+handlers does the dispatcher's PC-update job inline.
+
+**Delivered:**
+- `advancePc (off : Nat) : Program` helper in
+  `EvmAsm/Codegen/Programs.lean` — a single `ADDI .x10 .x10 off`
+  emitted between unrolled opcode handlers. Stays in the verified
+  `Program` world, so the existing `RoundTripTests.lean` already
+  covers it.
+- `tinyInterpAdd` / `tinyInterpAdd2` `Program`s composing
+  `EvmAsm.Evm64.evm_push 1`, `EvmAsm.Evm64.evm_add`, and `advancePc`
+  via `++`. STOP is handled by fall-through to the halt stub — no
+  RISC-V `Program` body needed in the unrolled chain.
+- `tinyInterpPrologue` + `tinyInterpDataSection` lay out the EVM
+  bytecode bytes as `.byte` directives under label `evm_code`,
+  followed by 256 bytes of writable scratch ending at label
+  `evm_stack_top`. Prologue initializes `x10 = &evm_code` and
+  `x12 = &evm_stack_top`.
+- Two `BuildUnit`s (`tinyInterpAddUnit`, `tinyInterpAdd2Unit`)
+  registered in `lookupProgram` and `knownProgramNames`. Both reuse
+  the existing `evmAddEpilogue` for the result-to-`OUTPUT_ADDR` copy.
+- `scripts/codegen-tiny-interp-check.sh`: builds, emits, links, runs
+  both ELFs on `ziskemu`, and diffs the first 32 bytes of public
+  output against the expected LE limbs. **PASSES** for both test
+  programs.
+
+**Test cases.**
+- `tiny_interp_add`: `PUSH1 0xFF; PUSH1 0x01; ADD; STOP`
+  → expected `[0x100, 0, 0, 0]` (first 8 bytes `00 01 00 00 00 00 00 00`).
+- `tiny_interp_add2`: `PUSH1 0x10; PUSH1 0x20; ADD; PUSH1 0x30; ADD; STOP`
+  → expected `[0x60, 0, 0, 0]` (first 8 bytes `60 00 00 00 00 00 00 00`).
+  Exercises chained ADDs and a stack pointer that walks back up after
+  each `evm_add`.
+
+**Exit criteria (met).**
+`scripts/codegen-tiny-interp-check.sh` exits 0; `riscv64-elf-objdump
+-d` shows the inline `addi a0, a0, N` advances between unrolled opcode
+handler bodies.
+
+#### M5b — Runtime fetch/decode/dispatch loop (M) — **DONE (2026-05-19)**
+
+A real fetch/decode/dispatch loop in RISC-V, with verified opcode
+`Program`s wrapped one-by-one in subroutines. Per §Tricky bits #9
+("Codegen is not verified") the loop scaffold lives as raw asm; only
+the opcode bodies remain verified.
+
+**Delivered:**
+- `opcodeHandlerLabel : Nat → String` + `emitOpcodeHandlerTable`
+  in `EvmAsm/Codegen/Programs.lean`: render a 256-entry jump table
+  in `.data` mapping each opcode byte to a handler label. Unhandled
+  bytes route to `h_invalid`.
+- `tinyInterpDispatchPrologue` — `_start` init (`la x10, evm_code`,
+  `la x12, evm_stack_top`) followed by `.dispatch_loop:`:
+    ```
+    lbu  x5, 0(x10)              # fetch opcode byte
+    la   x6, opcode_handlers
+    slli x5, x5, 3               # opcode * 8 (entry stride)
+    add  x6, x6, x5
+    ld   x7, 0(x6)               # load handler address
+    jalr x1, x7, 0               # call handler
+    j    .dispatch_loop
+    ```
+- `tinyInterpDispatchEpilogue` — handler subroutines + exit path:
+  - `h_PUSH1`: `<emitProgram (evm_push 1)>` + `addi x10, x10, 2` + `ret`
+  - `h_ADD`:   `<emitProgram evm_add>`     + `addi x10, x10, 1` + `ret`
+  - `h_STOP`:  `j .exit_label` (no return to dispatcher)
+  - `h_invalid`: `j .exit_label` (same exit path as STOP for this slice)
+  - `.exit_label`: `<emitProgram evmAddEpilogue>` — falls through to
+    the linux93 halt stub appended by `emitBuildUnit`.
+- Two `BuildUnit`s (`tinyInterpDispatchAddUnit`,
+  `tinyInterpDispatchAdd2Unit`) registered in `lookupProgram` and
+  `knownProgramNames`. They reuse `tinyInterpAddBytecode` /
+  `tinyInterpAdd2Bytecode` verbatim, so M5a and M5b run on identical
+  inputs and produce identical expected outputs — any regression is
+  isolated to the dispatcher.
+- `scripts/codegen-tiny-interp-dispatch-check.sh` mirrors the M5a
+  script and runs both dispatch units. **PASSES** for both bytecodes
+  with `-n 200000` step budget.
+
+**Calling convention (informal).** `x10` (EVM code pointer) is
+preserved across handler calls; each handler wrapper advances it by
+the opcode's byte width before returning. `x12` (EVM stack pointer)
+is updated freely by handlers and persists across the loop. `x1` is
+the standard return address. The dispatcher reloads its scratch
+(`x5`, `x6`, `x7`) from `x10` and the jump-table base every
+iteration, so the fact that verified handlers clobber them
+(`evm_add` uses `x5`/`x6`/`x7`/`x11`) is by design.
+
+**Layout note.** `evm_stack_top` and `opcode_handlers` end up at
+the same address (no `.balign` padding needed since the stack
+region already lands on an 8-byte boundary). Safe at the worst-case
+depth of 2 (= 64 bytes) for both test programs, but worth flagging
+if M5c expands to deeper bytecodes — give the stack its own
+explicit reserved tail before the jump table.
+
+**Exit criteria (met).**
+`scripts/codegen-tiny-interp-dispatch-check.sh` exits 0; both M5a
+and M5b produce identical bytes through `ziskemu`'s public output.
 
 ### Sequencing
 
-M0 ✅ → M1 ✅ → M2 ✅ → M4 ✅ → M5 (next). M3 is deferred; revisit only
-if M5 makes label-free emission unreadable. M4 unblocks M5.
+M0 ✅ → M1 ✅ → M2 ✅ → M4 ✅ → M5a ✅ → M5b ✅. M3 is deferred;
+revisit only if a future milestone (full opcode coverage, JUMP/JUMPI,
+or the binary encoder) makes label-free emission unreadable. M4
+unblocked M5; M5a pinned down the `x10`/`x12` calling convention that
+M5b's dispatcher relies on.
 
 ## Tricky bits / open questions
 
@@ -321,8 +425,16 @@ if M5 makes label-free emission unreadable. M4 unblocks M5.
 - **M4.** ✅ `scripts/codegen-evm_add-from-input-check.sh` exits 0
   (validated 2026-05-18). Same operands and expected sum as M2, but
   loaded at runtime from `ziskemu -i <file>` instead of `.data`.
-- **M5.** Per-bytecode regression script under `scripts/`; each test compares
-  `ziskemu`'s `write_output` against the reference oracle.
+- **M5a.** ✅ `scripts/codegen-tiny-interp-check.sh` exits 0
+  (validated 2026-05-19). Two unrolled bytecodes
+  (`PUSH1; PUSH1; ADD; STOP` and `PUSH1; PUSH1; ADD; PUSH1; ADD; STOP`)
+  round-trip through verified opcode `Program`s chained with
+  `advancePc`.
+- **M5b.** ✅ `scripts/codegen-tiny-interp-dispatch-check.sh` exits 0
+  (validated 2026-05-19). Same two bytecodes as M5a, but routed
+  through a 256-entry jump table + handler subroutines (`jalr ra,
+  …`) instead of an unrolled chain. Output bytes match M5a's, which
+  cross-checks the dispatcher against the unrolled reference.
 
 ## Future work (post-M5)
 

--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -7,6 +7,7 @@
 
 import EvmAsm.Rv64.Program
 import EvmAsm.Evm64.Add.Program
+import EvmAsm.Evm64.Push.Program
 import EvmAsm.Codegen.Layout
 
 namespace EvmAsm.Codegen
@@ -179,19 +180,249 @@ def evmAddFromInputUnit : BuildUnit := {
   dataAsm     := evmAddFromInputDataSection
 }
 
+/-! ## tiny_interp — M5a unrolled tiny EVM interpreter
+
+    Two hand-picked EVM bytecodes laid out as `.data` bytes, executed
+    by *chaining* verified opcode `Program`s with explicit `x10`
+    advances between handlers. No runtime fetch/decode/dispatch loop
+    (deferred to M5b). The point is to validate that verified opcode
+    Programs compose under `++` while honoring the `x10` code-pointer
+    convention that `evm_push` reads its immediates from.
+
+    Stack layout: 256 bytes of writable scratch ending at label
+    `evm_stack_top`. The EVM stack grows downward; the prologue
+    initializes `x12 = evm_stack_top` and each `evm_push` decrements
+    `x12` by 32 to allocate a new slot. Worst-case depth across both
+    test programs is 2 slots = 64 bytes, so 256 leaves comfortable
+    headroom. -/
+
+/-- Dispatcher glue between unrolled opcode `Program`s: advance the
+    EVM code pointer (`x10`) by the byte width of the opcode just
+    executed (`1 + n` for `PUSHn`, `1` for `ADD`/`STOP`).
+
+    In the M5b full dispatch loop this advance is computed inside the
+    decoder; M5a inlines it directly so chained verified Programs read
+    their PUSH immediates from the right byte. Stays in the verified
+    `Program` world. -/
+def advancePc (off : Nat) : Program :=
+  ADDI .x10 .x10 (BitVec.ofNat 12 off)
+
+/-- Prologue shared by all tiny-interp units. `la x10, evm_code`
+    points the EVM code pointer at the start of the bytecode; `la
+    x12, evm_stack_top` initializes the EVM stack pointer at the
+    high-address end of a 256-byte writable scratch region. -/
+def tinyInterpPrologue : String :=
+  "  la x10, evm_code\n" ++
+  "  la x12, evm_stack_top"
+
+/-- `.data` section: a label `evm_code` holding the bytecode bytes,
+    followed by 256 bytes of writable scratch ending at label
+    `evm_stack_top`. `bytecodeBytes` is a comma-separated `.byte`
+    directive payload (e.g. `"0x60, 0xff, 0x60, 0x01, 0x01, 0x00"`).
+
+    Written as raw asm text rather than `emitDataLabel` because the
+    layout is hybrid (`.byte` payload for the bytecode, `.zero` for
+    the stack scratch) — `emitDataLabel` only takes `UInt64` dwords. -/
+def tinyInterpDataSection (bytecodeBytes : String) : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "evm_code:\n" ++
+  s!"  .byte {bytecodeBytes}\n" ++
+  ".balign 32\n" ++
+  "evm_stack_low:\n" ++
+  "  .zero 256\n" ++
+  "evm_stack_top:"
+
+/-- M5a test case 1: `PUSH1 0xFF; PUSH1 0x01; ADD; STOP`. Expected
+    256-bit sum = `0x100`, which as four LE u64 limbs is
+    `[0x100, 0, 0, 0]` — first 8 bytes `00 01 00 00 00 00 00 00`.
+
+    The chain is `Program ++ Program ++ ...`; each `advancePc`
+    between opcode handlers is the only dispatcher glue. STOP needs
+    no body — falling through to the halt stub appended by
+    `emitBuildUnit` is equivalent. -/
+def tinyInterpAdd : Program :=
+  EvmAsm.Evm64.evm_push 1 ++ advancePc 2 ++
+  EvmAsm.Evm64.evm_push 1 ++ advancePc 2 ++
+  EvmAsm.Evm64.evm_add  ++ advancePc 1
+
+/-- Bytecode for `tinyInterpAdd`: `60 ff 60 01 01 00`. -/
+def tinyInterpAddBytecode : String :=
+  "0x60, 0xff, 0x60, 0x01, 0x01, 0x00"
+
+def tinyInterpAddUnit : BuildUnit := {
+  body        := tinyInterpAdd ++ evmAddEpilogue
+  prologueAsm := tinyInterpPrologue
+  dataAsm     := tinyInterpDataSection tinyInterpAddBytecode
+}
+
+/-- M5a test case 2: `PUSH1 0x10; PUSH1 0x20; ADD; PUSH1 0x30; ADD;
+    STOP`. Expected sum = `0x60`, LE limbs `[0x60, 0, 0, 0]` — first
+    8 bytes `60 00 00 00 00 00 00 00`. Exercises chained ADDs and a
+    stack-pointer history that walks back up after each ADD. -/
+def tinyInterpAdd2 : Program :=
+  EvmAsm.Evm64.evm_push 1 ++ advancePc 2 ++
+  EvmAsm.Evm64.evm_push 1 ++ advancePc 2 ++
+  EvmAsm.Evm64.evm_add  ++ advancePc 1 ++
+  EvmAsm.Evm64.evm_push 1 ++ advancePc 2 ++
+  EvmAsm.Evm64.evm_add  ++ advancePc 1
+
+/-- Bytecode for `tinyInterpAdd2`: `60 10 60 20 01 60 30 01 00`. -/
+def tinyInterpAdd2Bytecode : String :=
+  "0x60, 0x10, 0x60, 0x20, 0x01, 0x60, 0x30, 0x01, 0x00"
+
+def tinyInterpAdd2Unit : BuildUnit := {
+  body        := tinyInterpAdd2 ++ evmAddEpilogue
+  prologueAsm := tinyInterpPrologue
+  dataAsm     := tinyInterpDataSection tinyInterpAdd2Bytecode
+}
+
+/-! ## tiny_interp_dispatch — M5b runtime fetch/decode/dispatch loop
+
+    Same EVM bytecodes as M5a, but routed through an actual RISC-V
+    dispatch loop instead of an unrolled chain. Per CODEGEN.md
+    §Tricky bits #9 ("Codegen is not verified") the loop scaffold
+    lives as raw asm; the verified opcode `Program`s are wrapped
+    one-by-one in `h_*` subroutines (`<emitProgram body>` + raw asm
+    `addi x10, x10, <width>` + `ret`). The body of each handler stays
+    verbatim what the verified core produced.
+
+    Calling convention (informal):
+      x10  EVM code pointer  (preserved across handler calls; the
+                              wrapper advances it by the opcode's byte
+                              width before returning)
+      x12  EVM stack pointer (handlers update freely; persistent
+                              across the loop)
+      x1   return address    (clobbered by `jalr ra, ...`; each
+                              handler must end in `ret`)
+      x5, x6, x7   scratch   (clobbered by both the dispatcher's
+                              fetch/lookup *and* the verified handler
+                              bodies — see `evm_add` which uses
+                              x5/x6/x7/x11; the dispatcher reloads
+                              from x10 and the table base on every
+                              iteration, so no preservation needed)
+
+    Coverage: PUSH1, ADD, STOP. All other opcode bytes fall to
+    `h_invalid`, which (for this first slice) takes the same exit
+    path as STOP. -/
+
+/-- Label for the handler that bytes `b` dispatches to. Bytes not in
+    the table map to `h_invalid`. -/
+def opcodeHandlerLabel : Nat → String
+  | 0x00 => "h_STOP"
+  | 0x01 => "h_ADD"
+  | 0x60 => "h_PUSH1"
+  | _    => "h_invalid"
+
+/-- Emit a 256-entry jump table, one `.dword` per opcode byte, where
+    entry `b` is the address of the handler `opcodeHandlerLabel b`.
+    Lives in `.data` (alongside the bytecode + stack scratch) so the
+    `-Tdata=0xa0000000` link argument places it in writable RAM —
+    GNU `as` doesn't require the table to be writable, but keeping
+    everything in one section is simpler than adding `-Trodata=…`. -/
+def emitOpcodeHandlerTable : String :=
+  let entries :=
+    (List.range 256).map (fun b => s!"  .dword {opcodeHandlerLabel b}")
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "opcode_handlers:\n" ++
+  String.intercalate "\n" entries
+
+/-- Dispatcher prologue: init the EVM pointers and enter the main
+    fetch/decode/dispatch loop. Each iteration:
+      1. `lbu x5, 0(x10)`            — fetch opcode byte at code[x10]
+      2. `la x6, opcode_handlers`    — base of jump table
+      3. `slli x5, x5, 3`            — opcode * 8 (entry stride)
+      4. `add x6, x6, x5`            — &opcode_handlers[opcode]
+      5. `ld x7, 0(x6)`              — load handler address
+      6. `jalr x1, x7, 0`            — call handler (saves return PC in x1)
+      7. on return: `j .dispatch_loop`
+
+    Handlers themselves bake in the PC-advance + `ret`. STOP and
+    `invalid` handlers `j .exit_label` instead of returning. -/
+def tinyInterpDispatchPrologue : String :=
+  "  la x10, evm_code\n" ++
+  "  la x12, evm_stack_top\n" ++
+  ".dispatch_loop:\n" ++
+  "  lbu x5, 0(x10)\n" ++
+  "  la x6, opcode_handlers\n" ++
+  "  slli x5, x5, 3\n" ++
+  "  add x6, x6, x5\n" ++
+  "  ld x7, 0(x6)\n" ++
+  "  jalr x1, x7, 0\n" ++
+  "  j .dispatch_loop"
+
+/-- Dispatcher epilogue: handler subroutines + exit path. Order
+    matters — handlers come first (each ends with `ret` or `j
+    .exit_label`, so they don't fall through), then `.exit_label`
+    runs `evmAddEpilogue` and falls through to the halt stub that
+    `emitBuildUnit` appends. -/
+def tinyInterpDispatchEpilogue : String :=
+  -- h_PUSH1: verified evm_push 1 body, then advance x10 by 2 (opcode + 1 imm byte)
+  "h_PUSH1:\n" ++
+  emitProgram (EvmAsm.Evm64.evm_push 1) ++ "\n" ++
+  "  addi x10, x10, 2\n" ++
+  "  ret\n" ++
+  -- h_ADD: verified evm_add body, then advance x10 by 1 (opcode-only)
+  "h_ADD:\n" ++
+  emitProgram EvmAsm.Evm64.evm_add ++ "\n" ++
+  "  addi x10, x10, 1\n" ++
+  "  ret\n" ++
+  -- h_STOP: jump to exit (doesn't return to dispatcher)
+  "h_STOP:\n" ++
+  "  j .exit_label\n" ++
+  -- h_invalid: same exit path as STOP for this slice; future revs
+  -- may write a marker byte before exiting so the diff catches it.
+  "h_invalid:\n" ++
+  "  j .exit_label\n" ++
+  -- .exit_label: copy result limbs from [x12] to OUTPUT_ADDR, then
+  -- fall through to the linux93 halt stub appended by emitBuildUnit.
+  ".exit_label:\n" ++
+  emitProgram evmAddEpilogue
+
+/-- `.data` section: bytecode + stack scratch (M5a layout) followed
+    by the 256-entry jump table. GNU `as` is fine with multiple
+    `.section .data` directives — they coalesce. -/
+def tinyInterpDispatchDataSection (bytecodeBytes : String) : String :=
+  tinyInterpDataSection bytecodeBytes ++ "\n" ++
+  emitOpcodeHandlerTable
+
+/-- Build a dispatch `BuildUnit` for a given bytecode. Reuses the
+    M5a `tinyInterpAddBytecode` / `tinyInterpAdd2Bytecode` literals
+    so M5a and M5b run on identical input bytes and produce identical
+    expected outputs. -/
+def tinyInterpDispatchUnit (bytecodeBytes : String) : BuildUnit := {
+  body        := []
+  prologueAsm := tinyInterpDispatchPrologue
+  epilogueAsm := tinyInterpDispatchEpilogue
+  dataAsm     := tinyInterpDispatchDataSection bytecodeBytes
+}
+
+def tinyInterpDispatchAddUnit : BuildUnit :=
+  tinyInterpDispatchUnit tinyInterpAddBytecode
+
+def tinyInterpDispatchAdd2Unit : BuildUnit :=
+  tinyInterpDispatchUnit tinyInterpAdd2Bytecode
+
 /-! ## registry -/
 
 /-- Look up a program by name. Returns `none` for unknown names so the CLI
     can produce a clean error. -/
 def lookupProgram : String → Option BuildUnit
-  | "smoke"               => some smokeUnit
-  | "evm_add"             => some evmAddUnit
-  | "input_echo"          => some inputEchoUnit
-  | "evm_add_from_input"  => some evmAddFromInputUnit
-  | _                     => none
+  | "smoke"                     => some smokeUnit
+  | "evm_add"                   => some evmAddUnit
+  | "input_echo"                => some inputEchoUnit
+  | "evm_add_from_input"        => some evmAddFromInputUnit
+  | "tiny_interp_add"           => some tinyInterpAddUnit
+  | "tiny_interp_add2"          => some tinyInterpAdd2Unit
+  | "tiny_interp_dispatch_add"  => some tinyInterpDispatchAddUnit
+  | "tiny_interp_dispatch_add2" => some tinyInterpDispatchAdd2Unit
+  | _                           => none
 
 /-- List of known program names, for use in CLI usage strings. -/
 def knownProgramNames : List String :=
-  ["smoke", "evm_add", "input_echo", "evm_add_from_input"]
+  ["smoke", "evm_add", "input_echo", "evm_add_from_input",
+   "tiny_interp_add", "tiny_interp_add2",
+   "tiny_interp_dispatch_add", "tiny_interp_dispatch_add2"]
 
 end EvmAsm.Codegen

--- a/scripts/codegen-tiny-interp-check.sh
+++ b/scripts/codegen-tiny-interp-check.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# codegen-tiny-interp-check.sh — M5a verification.
+#
+# Builds two tiny EVM bytecode programs through codegen → as → ld,
+# runs each resulting ELF on ziskemu, and diffs the first 32 bytes
+# of ziskemu's public output against the expected 256-bit sum.
+#
+# Test cases (hardcoded in EvmAsm.Codegen.Programs):
+#
+#   tiny_interp_add  : PUSH1 0xFF; PUSH1 0x01; ADD; STOP
+#                      → 0x100, LE limbs [0x100, 0, 0, 0]
+#                      → first 8 bytes  00 01 00 00 00 00 00 00
+#
+#   tiny_interp_add2 : PUSH1 0x10; PUSH1 0x20; ADD; PUSH1 0x30; ADD; STOP
+#                      → 0x60,  LE limbs [0x60, 0, 0, 0]
+#                      → first 8 bytes  60 00 00 00 00 00 00 00
+#
+# Exit:
+#   0 — both outputs match expected
+#   1 — emission / build / emulation failed, or output mismatch
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found — install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+check_program() {
+  local prog="$1"
+  local expected_hex="$2"
+
+  echo
+  echo "==> emit $prog ELF"
+  lake exe codegen --program "$prog" --halt linux93 -o "gen-out/$prog"
+
+  echo "==> ziskemu -e gen-out/$prog.elf -o gen-out/$prog.output"
+  "$ZISKEMU" -e "gen-out/$prog.elf" -o "gen-out/$prog.output" -n 100000 \
+    >"gen-out/$prog.emu.log" 2>&1
+
+  local actual_hex
+  actual_hex="$(xxd -p -c 64 -l 32 "gen-out/$prog.output" | tr -d '\n')"
+
+  echo "expected:"
+  echo "  $expected_hex"
+  echo "actual:"
+  echo "  $actual_hex"
+
+  if [[ "$actual_hex" == "$expected_hex" ]]; then
+    echo "==> PASS: $prog"
+    return 0
+  else
+    echo "==> FAIL: $prog output mismatch"
+    return 1
+  fi
+}
+
+check_program tiny_interp_add  "0001000000000000000000000000000000000000000000000000000000000000"
+check_program tiny_interp_add2 "6000000000000000000000000000000000000000000000000000000000000000"
+
+echo
+echo "==> ALL PASS"

--- a/scripts/codegen-tiny-interp-dispatch-check.sh
+++ b/scripts/codegen-tiny-interp-dispatch-check.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# codegen-tiny-interp-dispatch-check.sh — M5b verification.
+#
+# Same two EVM bytecodes as M5a, but executed through an actual
+# RISC-V fetch/decode/dispatch loop (jump table in `.data`, handler
+# subroutines, `jalr` per opcode) instead of an unrolled chain of
+# verified `Program`s. Builds, runs, and diffs against the same
+# expected outputs as M5a — so any regression is isolated to the
+# dispatcher.
+#
+# Test cases (hardcoded in EvmAsm.Codegen.Programs):
+#
+#   tiny_interp_dispatch_add  : PUSH1 0xFF; PUSH1 0x01; ADD; STOP
+#                               → 0x100, LE limbs [0x100, 0, 0, 0]
+#                               → first 8 bytes  00 01 00 00 00 00 00 00
+#
+#   tiny_interp_dispatch_add2 : PUSH1 0x10; PUSH1 0x20; ADD; PUSH1 0x30; ADD; STOP
+#                               → 0x60,  LE limbs [0x60, 0, 0, 0]
+#                               → first 8 bytes  60 00 00 00 00 00 00 00
+#
+# Exit:
+#   0 — both outputs match expected
+#   1 — emission / build / emulation failed, or output mismatch
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found — install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+check_program() {
+  local prog="$1"
+  local expected_hex="$2"
+
+  echo
+  echo "==> emit $prog ELF"
+  lake exe codegen --program "$prog" --halt linux93 -o "gen-out/$prog"
+
+  echo "==> ziskemu -e gen-out/$prog.elf -o gen-out/$prog.output"
+  "$ZISKEMU" -e "gen-out/$prog.elf" -o "gen-out/$prog.output" -n 200000 \
+    >"gen-out/$prog.emu.log" 2>&1
+
+  local actual_hex
+  actual_hex="$(xxd -p -c 64 -l 32 "gen-out/$prog.output" | tr -d '\n')"
+
+  echo "expected:"
+  echo "  $expected_hex"
+  echo "actual:"
+  echo "  $actual_hex"
+
+  if [[ "$actual_hex" == "$expected_hex" ]]; then
+    echo "==> PASS: $prog"
+    return 0
+  else
+    echo "==> FAIL: $prog output mismatch"
+    return 1
+  fi
+}
+
+check_program tiny_interp_dispatch_add  "0001000000000000000000000000000000000000000000000000000000000000"
+check_program tiny_interp_dispatch_add2 "6000000000000000000000000000000000000000000000000000000000000000"
+
+echo
+echo "==> ALL PASS"


### PR DESCRIPTION
## Summary

- **M5a** runs two EVM bytecodes (`PUSH1 a; PUSH1 b; ADD; STOP` and a two-ADD variant) by chaining verified opcode `Program`s with `advancePc` between handlers — no runtime dispatch. First end-to-end EVM bytecode execution through codegen on ziskemu.
- **M5b** routes the same bytecodes through a real RISC-V fetch/decode/dispatch loop: 256-entry jump table in `.data`, handler subroutines (`h_PUSH1`, `h_ADD`, `h_STOP`, `h_invalid`), `jalr` per opcode, byte-identical output to M5a. Verified opcode bodies (`evm_push 1`, `evm_add`, `evmAddEpilogue`) emit verbatim via `emitProgram`; only the dispatcher scaffolding is raw asm (per CODEGEN.md §Tricky bits #9 "Codegen is not verified").
- Adds `scripts/codegen-tiny-interp-check.sh` (M5a) and `scripts/codegen-tiny-interp-dispatch-check.sh` (M5b); refreshes `CODEGEN.md` (file layout, M5 sections, Future work near-/longer-term split).

## Test plan

- [ ] `lake build codegen` passes
- [ ] `bash scripts/codegen-tiny-interp-check.sh` exits 0 (both `tiny_interp_add` and `tiny_interp_add2` PASS)
- [ ] `bash scripts/codegen-tiny-interp-dispatch-check.sh` exits 0 (both `tiny_interp_dispatch_add` and `tiny_interp_dispatch_add2` PASS)
- [ ] Spot-check `gen-out/tiny_interp_dispatch_add.s` and the disassembly: dispatcher loop fetches `lbu x5, 0(x10)`, looks up via the jump table, `jalr`s a handler; handler wrappers end with `addi x10, x10, <width>; ret`; STOP routes to `.exit_label` which calls `evmAddEpilogue` and falls through to the linux93 halt stub.
- [ ] Pre-existing scripts (`codegen-smoke.sh`, `codegen-evm_add-check.sh`, `codegen-evm_add-from-input-check.sh`) still exit 0 — M5 is purely additive to the registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)