### PR TITLE
refactor(exp): bundle reload-direct cps shapes

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoopDirect.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoopDirect.lean
@@ -12,6 +12,74 @@ namespace EvmAsm.Evm64.Exp.Compose
 
 open EvmAsm.Rv64
 
+@[irreducible]
+def expReloadDirectBranchPre
+    (k : Nat) (baseWord exponentWord : EvmWord)
+    (controlC6 e iterCount ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 : Word)
+    (bit : Bool)
+    (v6' v7' v10' v11' d0' d1' d2' d3' : Word)
+    (base : Word) (tail : Assertion) : Assertion :=
+  let outW := expTwoMulFixedBranchResult bit
+    a0 a1 a2 a3 r0 r1 r2 r3
+  expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
+    (controlC6 + signExtend12 (-1 : BitVec 12))
+    (e <<< (1 : BitVec 6).toNat)
+    v6'
+    (expTwoMulIterCountNew iterCount)
+    v10'
+    ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+    ptr nextLimb sp evmSp
+    (outW.getLimbN 3)
+    (expTwoMulFixedBranchReturnPc bit base)
+    (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
+    (outW.getLimbN 3)
+    d0' d1' d2' d3'
+    (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
+    (outW.getLimbN 3)
+    a0 a1 a2 a3 v7' v11' tail
+
+@[irreducible]
+def expReloadDirectFalsePre
+    (k : Nat) (baseWord exponentWord : EvmWord)
+    (e iterCount nextLimb ptr nextNextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 : Word)
+    (v6' v7' v10' v11' d0' d1' d2' d3' : Word)
+    (base : Word) (tail : Assertion) : Assertion :=
+  let squareW := expSquaringCallSquareW r0 r1 r2 r3
+  expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
+    64 nextLimb v6' (expTwoMulIterCountNew iterCount) v10'
+    ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+    (ptr + signExtend12 (-8 : BitVec 12)) nextNextLimb sp evmSp
+    (squareW.getLimbN 3) (((base + 44) + 32) + 68)
+    (squareW.getLimbN 0) (squareW.getLimbN 1)
+    (squareW.getLimbN 2) (squareW.getLimbN 3)
+    d0' d1' d2' d3'
+    (squareW.getLimbN 0) (squareW.getLimbN 1)
+    (squareW.getLimbN 2) (squareW.getLimbN 3)
+    a0 a1 a2 a3 v7' v11' tail
+
+@[irreducible]
+def expReloadDirectTruePre
+    (k : Nat) (baseWord exponentWord : EvmWord)
+    (e iterCount nextLimb ptr nextNextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 : Word)
+    (v6' v7' v10' v11' d0' d1' d2' d3' : Word)
+    (base : Word) (tail : Assertion) : Assertion :=
+  let rw := expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3)
+    a0 a1 a2 a3
+  expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
+    64 nextLimb v6' (expTwoMulIterCountNew iterCount) v10'
+    ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+    (ptr + signExtend12 (-8 : BitVec 12)) nextNextLimb sp evmSp
+    (rw.getLimbN 3) (((base + 44) + 140) + 68)
+    (rw.getLimbN 0) (rw.getLimbN 1)
+    (rw.getLimbN 2) (rw.getLimbN 3)
+    d0' d1' d2' d3'
+    (rw.getLimbN 0) (rw.getLimbN 1)
+    (rw.getLimbN 2) (rw.getLimbN 3)
+    a0 a1 a2 a3 v7' v11' tail
+
 /-- Head step wrapper with direct reload re-entry continuations.
 
     This combines the `k < 255` reload-direct step with the `k = 255` final
@@ -39,24 +107,10 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_f
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
-          (let outW := expTwoMulFixedBranchResult bit
-            a0 a1 a2 a3 r0 r1 r2 r3
-          expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-            (controlC6 + signExtend12 (-1 : BitVec 12))
-            (e <<< (1 : BitVec 6).toNat)
-            v6'
-            (expTwoMulIterCountNew iterCount)
-            v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            ptr nextLimb sp evmSp
-            (outW.getLimbN 3)
-            (expTwoMulFixedBranchReturnPc bit base)
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            d0' d1' d2' d3'
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
+          (expReloadDirectBranchPre k baseWord exponentWord
+            controlC6 e iterCount ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3
+            bit v6' v7' v10' v11' d0' d1' d2' d3' base
             ((((ptr + signExtend12 (-8 : BitVec 12)) +
               signExtend12 (0 : BitVec 12)) ↦ₘ nextNextLimb) ** frame))
           (Q ** ((((ptr + signExtend12 (-8 : BitVec 12)) +
@@ -64,21 +118,13 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_f
     (hReloadFalse :
       k < 255 →
       ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
-        let squareW := expSquaringCallSquareW r0 r1 r2 r3
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
-          (expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-            64 nextLimb v6' (expTwoMulIterCountNew iterCount) v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            (ptr + signExtend12 (-8 : BitVec 12)) nextNextLimb sp evmSp
-            (squareW.getLimbN 3) (((base + 44) + 32) + 68)
-            (squareW.getLimbN 0) (squareW.getLimbN 1)
-            (squareW.getLimbN 2) (squareW.getLimbN 3)
-            d0' d1' d2' d3'
-            (squareW.getLimbN 0) (squareW.getLimbN 1)
-            (squareW.getLimbN 2) (squareW.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
+          (expReloadDirectFalsePre k baseWord exponentWord
+            e iterCount nextLimb ptr nextNextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3
+            v6' v7' v10' v11' d0' d1' d2' d3' base
             (((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
               ⌜expTwoMulIterCountNew iterCount ≠ 0⌝ **
               ⌜controlC6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
@@ -90,22 +136,13 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_f
     (hReloadTrue :
       k < 255 →
       ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
-        let rw := expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3)
-          a0 a1 a2 a3
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
-          (expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-            64 nextLimb v6' (expTwoMulIterCountNew iterCount) v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            (ptr + signExtend12 (-8 : BitVec 12)) nextNextLimb sp evmSp
-            (rw.getLimbN 3) (((base + 44) + 140) + 68)
-            (rw.getLimbN 0) (rw.getLimbN 1)
-            (rw.getLimbN 2) (rw.getLimbN 3)
-            d0' d1' d2' d3'
-            (rw.getLimbN 0) (rw.getLimbN 1)
-            (rw.getLimbN 2) (rw.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
+          (expReloadDirectTruePre k baseWord exponentWord
+            e iterCount nextLimb ptr nextNextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3
+            v6' v7' v10' v11' d0' d1' d2' d3' base
             (((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
               ⌜expTwoMulIterCountNew iterCount ≠ 0⌝ **
               ⌜controlC6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
@@ -144,15 +181,21 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_f
       (((ptr + signExtend12 (-8 : BitVec 12)) +
         signExtend12 (0 : BitVec 12) ↦ₘ nextNextLimb) ** frame)
       Q hFrameCurrent hbase hControlMachine hk hBase hNextNext
-      hBranch
+      (fun hk_lt bit v6' v7' v10' v11' d0' d1' d2' d3' => by
+        simpa only [expReloadDirectBranchPre] using
+          hBranch hk_lt bit v6' v7' v10' v11' d0' d1' d2' d3')
       (fun hk_lt bit v6' v7' v10' v11' d0' d1' d2' d3' => by
         cases bit
         · exact
             cpsTripleWithin_expTwoMulFixedReloadBranchResidualWithStateFrame_false_to_iterPreNWithStateFrame
-              (hReloadFalse hk_lt v6' v7' v10' v11' d0' d1' d2' d3')
+              (by
+                simpa only [expReloadDirectFalsePre] using
+                  hReloadFalse hk_lt v6' v7' v10' v11' d0' d1' d2' d3')
         · exact
             cpsTripleWithin_expTwoMulFixedReloadBranchResidualWithStateFrame_true_to_iterPreNWithStateFrame
-              (hReloadTrue hk_lt v6' v7' v10' v11' d0' d1' d2' d3'))
+              (by
+                simpa only [expReloadDirectTruePre] using
+                  hReloadTrue hk_lt v6' v7' v10' v11' d0' d1' d2' d3'))
       hExit
 
 /-- Convenience form of
@@ -179,24 +222,10 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_p
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
-          (let outW := expTwoMulFixedBranchResult bit
-            a0 a1 a2 a3 r0 r1 r2 r3
-          expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-            (controlC6 + signExtend12 (-1 : BitVec 12))
-            (e <<< (1 : BitVec 6).toNat)
-            v6'
-            (expTwoMulIterCountNew iterCount)
-            v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            ptr nextLimb sp evmSp
-            (outW.getLimbN 3)
-            (expTwoMulFixedBranchReturnPc bit base)
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            d0' d1' d2' d3'
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
+          (expReloadDirectBranchPre k baseWord exponentWord
+            controlC6 e iterCount ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3
+            bit v6' v7' v10' v11' d0' d1' d2' d3' base
             (((ptr + signExtend12 (-8 : BitVec 12)) +
               signExtend12 (0 : BitVec 12)) ↦ₘ nextNextLimb))
           (Q ** (((ptr + signExtend12 (-8 : BitVec 12)) +
@@ -204,21 +233,13 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_p
     (hReloadFalse :
       k < 255 →
       ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
-        let squareW := expSquaringCallSquareW r0 r1 r2 r3
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
-          (expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-            64 nextLimb v6' (expTwoMulIterCountNew iterCount) v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            (ptr + signExtend12 (-8 : BitVec 12)) nextNextLimb sp evmSp
-            (squareW.getLimbN 3) (((base + 44) + 32) + 68)
-            (squareW.getLimbN 0) (squareW.getLimbN 1)
-            (squareW.getLimbN 2) (squareW.getLimbN 3)
-            d0' d1' d2' d3'
-            (squareW.getLimbN 0) (squareW.getLimbN 1)
-            (squareW.getLimbN 2) (squareW.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
+          (expReloadDirectFalsePre k baseWord exponentWord
+            e iterCount nextLimb ptr nextNextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3
+            v6' v7' v10' v11' d0' d1' d2' d3' base
             (((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
               ⌜expTwoMulIterCountNew iterCount ≠ 0⌝ **
               ⌜controlC6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
@@ -229,22 +250,13 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_p
     (hReloadTrue :
       k < 255 →
       ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
-        let rw := expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3)
-          a0 a1 a2 a3
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
-          (expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-            64 nextLimb v6' (expTwoMulIterCountNew iterCount) v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            (ptr + signExtend12 (-8 : BitVec 12)) nextNextLimb sp evmSp
-            (rw.getLimbN 3) (((base + 44) + 140) + 68)
-            (rw.getLimbN 0) (rw.getLimbN 1)
-            (rw.getLimbN 2) (rw.getLimbN 3)
-            d0' d1' d2' d3'
-            (rw.getLimbN 0) (rw.getLimbN 1)
-            (rw.getLimbN 2) (rw.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
+          (expReloadDirectTruePre k baseWord exponentWord
+            e iterCount nextLimb ptr nextNextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3
+            v6' v7' v10' v11' d0' d1' d2' d3' base
             (((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
               ⌜expTwoMulIterCountNew iterCount ≠ 0⌝ **
               ⌜controlC6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
@@ -333,24 +345,10 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_f
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
-          (let outW := expTwoMulFixedBranchResult bit
-            a0 a1 a2 a3 r0 r1 r2 r3
-          expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-            (controlC6 + signExtend12 (-1 : BitVec 12))
-            (e <<< (1 : BitVec 6).toNat)
-            v6'
-            (expTwoMulIterCountNew iterCount)
-            v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            ptr nextLimb sp evmSp
-            (outW.getLimbN 3)
-            (expTwoMulFixedBranchReturnPc bit base)
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            d0' d1' d2' d3'
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
+          (expReloadDirectBranchPre k baseWord exponentWord
+            controlC6 e iterCount ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3
+            bit v6' v7' v10' v11' d0' d1' d2' d3' base
             (((ptr + signExtend12 (-8 : BitVec 12)) +
               signExtend12 (0 : BitVec 12)) ↦ₘ nextNextLimb))
           (Q ** (((ptr + signExtend12 (-8 : BitVec 12)) +
@@ -358,21 +356,13 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_f
     (hReloadFalse :
       k < 255 →
       ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
-        let squareW := expSquaringCallSquareW r0 r1 r2 r3
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
-          (expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-            64 nextLimb v6' (expTwoMulIterCountNew iterCount) v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            (ptr + signExtend12 (-8 : BitVec 12)) nextNextLimb sp evmSp
-            (squareW.getLimbN 3) (((base + 44) + 32) + 68)
-            (squareW.getLimbN 0) (squareW.getLimbN 1)
-            (squareW.getLimbN 2) (squareW.getLimbN 3)
-            d0' d1' d2' d3'
-            (squareW.getLimbN 0) (squareW.getLimbN 1)
-            (squareW.getLimbN 2) (squareW.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
+          (expReloadDirectFalsePre k baseWord exponentWord
+            e iterCount nextLimb ptr nextNextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3
+            v6' v7' v10' v11' d0' d1' d2' d3' base
             (((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
               ⌜expTwoMulIterCountNew iterCount ≠ 0⌝ **
               ⌜controlC6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
@@ -383,22 +373,13 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_f
     (hReloadTrue :
       k < 255 →
       ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
-        let rw := expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3)
-          a0 a1 a2 a3
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
-          (expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-            64 nextLimb v6' (expTwoMulIterCountNew iterCount) v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            (ptr + signExtend12 (-8 : BitVec 12)) nextNextLimb sp evmSp
-            (rw.getLimbN 3) (((base + 44) + 140) + 68)
-            (rw.getLimbN 0) (rw.getLimbN 1)
-            (rw.getLimbN 2) (rw.getLimbN 3)
-            d0' d1' d2' d3'
-            (rw.getLimbN 0) (rw.getLimbN 1)
-            (rw.getLimbN 2) (rw.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
+          (expReloadDirectTruePre k baseWord exponentWord
+            e iterCount nextLimb ptr nextNextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3
+            v6' v7' v10' v11' d0' d1' d2' d3' base
             (((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
               ⌜expTwoMulIterCountNew iterCount ≠ 0⌝ **
               ⌜controlC6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
@@ -437,7 +418,17 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_f
         controlC6 e machineC6 iterCount v10 v18 ptr nextLimb nextNextLimb
         sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
         a0 a1 a2 a3 v7 v11 base Q hbase hControlMachine hk hBase
-        hNextNext hBranch hReloadFalse hReloadTrue hExit)
+        hNextNext
+        (fun hk_lt bit v6' v7' v10' v11' d0' d1' d2' d3' => by
+          simpa only [expReloadDirectBranchPre] using
+            hBranch hk_lt bit v6' v7' v10' v11' d0' d1' d2' d3')
+        (fun hk_lt v6' v7' v10' v11' d0' d1' d2' d3' => by
+          simpa only [expReloadDirectFalsePre] using
+            hReloadFalse hk_lt v6' v7' v10' v11' d0' d1' d2' d3')
+        (fun hk_lt v6' v7' v10' v11' d0' d1' d2' d3' => by
+          simpa only [expReloadDirectTruePre] using
+            hReloadTrue hk_lt v6' v7' v10' v11' d0' d1' d2' d3')
+        hExit)
 
 /-- Ordinary no-reload direct head step with the saved-limb frame advanced to
     the recursive successor index. -/
@@ -462,24 +453,10 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_f
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
-          (let outW := expTwoMulFixedBranchResult bit
-            a0 a1 a2 a3 r0 r1 r2 r3
-          expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-            (controlC6 + signExtend12 (-1 : BitVec 12))
-            (e <<< (1 : BitVec 6).toNat)
-            v6'
-            (expTwoMulIterCountNew iterCount)
-            v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            ptr nextLimb sp evmSp
-            (outW.getLimbN 3)
-            (expTwoMulFixedBranchReturnPc bit base)
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            d0' d1' d2' d3'
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
+          (expReloadDirectBranchPre k baseWord exponentWord
+            controlC6 e iterCount ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3
+            bit v6' v7' v10' v11' d0' d1' d2' d3' base
             (((ptr + signExtend12 (-8 : BitVec 12)) +
               signExtend12 (0 : BitVec 12)) ↦ₘ nextNextLimb))
           (Q ** (((ptr + signExtend12 (-8 : BitVec 12)) +
@@ -487,21 +464,13 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_f
     (hReloadFalse :
       k < 255 →
       ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
-        let squareW := expSquaringCallSquareW r0 r1 r2 r3
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
-          (expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-            64 nextLimb v6' (expTwoMulIterCountNew iterCount) v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            (ptr + signExtend12 (-8 : BitVec 12)) nextNextLimb sp evmSp
-            (squareW.getLimbN 3) (((base + 44) + 32) + 68)
-            (squareW.getLimbN 0) (squareW.getLimbN 1)
-            (squareW.getLimbN 2) (squareW.getLimbN 3)
-            d0' d1' d2' d3'
-            (squareW.getLimbN 0) (squareW.getLimbN 1)
-            (squareW.getLimbN 2) (squareW.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
+          (expReloadDirectFalsePre k baseWord exponentWord
+            e iterCount nextLimb ptr nextNextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3
+            v6' v7' v10' v11' d0' d1' d2' d3' base
             (((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
               ⌜expTwoMulIterCountNew iterCount ≠ 0⌝ **
               ⌜controlC6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
@@ -512,22 +481,13 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_f
     (hReloadTrue :
       k < 255 →
       ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
-        let rw := expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3)
-          a0 a1 a2 a3
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
-          (expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-            64 nextLimb v6' (expTwoMulIterCountNew iterCount) v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            (ptr + signExtend12 (-8 : BitVec 12)) nextNextLimb sp evmSp
-            (rw.getLimbN 3) (((base + 44) + 140) + 68)
-            (rw.getLimbN 0) (rw.getLimbN 1)
-            (rw.getLimbN 2) (rw.getLimbN 3)
-            d0' d1' d2' d3'
-            (rw.getLimbN 0) (rw.getLimbN 1)
-            (rw.getLimbN 2) (rw.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
+          (expReloadDirectTruePre k baseWord exponentWord
+            e iterCount nextLimb ptr nextNextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3
+            v6' v7' v10' v11' d0' d1' d2' d3' base
             (((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
               ⌜expTwoMulIterCountNew iterCount ≠ 0⌝ **
               ⌜controlC6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
@@ -555,7 +515,17 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_f
       controlC6 e machineC6 iterCount v10 v18 ptr nextLimb nextNextLimb
       sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
       a0 a1 a2 a3 v7 v11 base Q hbase hControlMachine hk hBase
-      hNextNext hBranch hReloadFalse hReloadTrue hExit
+      hNextNext
+      (fun hk_lt bit v6' v7' v10' v11' d0' d1' d2' d3' => by
+        simpa only [expReloadDirectBranchPre] using
+          hBranch hk_lt bit v6' v7' v10' v11' d0' d1' d2' d3')
+      (fun hk_lt v6' v7' v10' v11' d0' d1' d2' d3' => by
+        simpa only [expReloadDirectFalsePre] using
+          hReloadFalse hk_lt v6' v7' v10' v11' d0' d1' d2' d3')
+      (fun hk_lt v6' v7' v10' v11' d0' d1' d2' d3' => by
+        simpa only [expReloadDirectTruePre] using
+          hReloadTrue hk_lt v6' v7' v10' v11' d0' d1' d2' d3')
+      hExit
   exact cpsTripleWithin_weaken
     (fun _ h => h)
     (fun _ h => by
@@ -587,24 +557,10 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_r
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
-          (let outW := expTwoMulFixedBranchResult bit
-            a0 a1 a2 a3 r0 r1 r2 r3
-          expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-            (controlC6 + signExtend12 (-1 : BitVec 12))
-            (e <<< (1 : BitVec 6).toNat)
-            v6'
-            (expTwoMulIterCountNew iterCount)
-            v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            ptr nextLimb sp evmSp
-            (outW.getLimbN 3)
-            (expTwoMulFixedBranchReturnPc bit base)
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            d0' d1' d2' d3'
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
+          (expReloadDirectBranchPre k baseWord exponentWord
+            controlC6 e iterCount ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3
+            bit v6' v7' v10' v11' d0' d1' d2' d3' base
             (((ptr + signExtend12 (-8 : BitVec 12)) +
               signExtend12 (0 : BitVec 12)) ↦ₘ nextNextLimb))
           (Q ** (((ptr + signExtend12 (-8 : BitVec 12)) +
@@ -612,21 +568,13 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_r
     (hReloadFalse :
       k < 255 →
       ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
-        let squareW := expSquaringCallSquareW r0 r1 r2 r3
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
-          (expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-            64 nextLimb v6' (expTwoMulIterCountNew iterCount) v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            (ptr + signExtend12 (-8 : BitVec 12)) nextNextLimb sp evmSp
-            (squareW.getLimbN 3) (((base + 44) + 32) + 68)
-            (squareW.getLimbN 0) (squareW.getLimbN 1)
-            (squareW.getLimbN 2) (squareW.getLimbN 3)
-            d0' d1' d2' d3'
-            (squareW.getLimbN 0) (squareW.getLimbN 1)
-            (squareW.getLimbN 2) (squareW.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
+          (expReloadDirectFalsePre k baseWord exponentWord
+            e iterCount nextLimb ptr nextNextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3
+            v6' v7' v10' v11' d0' d1' d2' d3' base
             (((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
               ⌜expTwoMulIterCountNew iterCount ≠ 0⌝ **
               ⌜controlC6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
@@ -637,22 +585,13 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_r
     (hReloadTrue :
       k < 255 →
       ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
-        let rw := expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3)
-          a0 a1 a2 a3
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
-          (expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-            64 nextLimb v6' (expTwoMulIterCountNew iterCount) v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            (ptr + signExtend12 (-8 : BitVec 12)) nextNextLimb sp evmSp
-            (rw.getLimbN 3) (((base + 44) + 140) + 68)
-            (rw.getLimbN 0) (rw.getLimbN 1)
-            (rw.getLimbN 2) (rw.getLimbN 3)
-            d0' d1' d2' d3'
-            (rw.getLimbN 0) (rw.getLimbN 1)
-            (rw.getLimbN 2) (rw.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
+          (expReloadDirectTruePre k baseWord exponentWord
+            e iterCount nextLimb ptr nextNextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3
+            v6' v7' v10' v11' d0' d1' d2' d3' base
             (((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
               ⌜expTwoMulIterCountNew iterCount ≠ 0⌝ **
               ⌜controlC6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
@@ -691,7 +630,17 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_r
         controlC6 e machineC6 iterCount v10 v18 ptr nextLimb nextNextLimb
         sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
         a0 a1 a2 a3 v7 v11 base Q hbase hControlMachine hk hBase
-        hNextNext hBranch hReloadFalse hReloadTrue hExit)
+        hNextNext
+        (fun hk_lt bit v6' v7' v10' v11' d0' d1' d2' d3' => by
+          simpa only [expReloadDirectBranchPre] using
+            hBranch hk_lt bit v6' v7' v10' v11' d0' d1' d2' d3')
+        (fun hk_lt v6' v7' v10' v11' d0' d1' d2' d3' => by
+          simpa only [expReloadDirectFalsePre] using
+            hReloadFalse hk_lt v6' v7' v10' v11' d0' d1' d2' d3')
+        (fun hk_lt v6' v7' v10' v11' d0' d1' d2' d3' => by
+          simpa only [expReloadDirectTruePre] using
+            hReloadTrue hk_lt v6' v7' v10' v11' d0' d1' d2' d3')
+        hExit)
 
 /-- Control-invariant form of the reload-boundary direct head step.
 
@@ -722,24 +671,10 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_r
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
-          (let outW := expTwoMulFixedBranchResult bit
-            a0 a1 a2 a3 r0 r1 r2 r3
-          expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-            (controlC6 + signExtend12 (-1 : BitVec 12))
-            (e <<< (1 : BitVec 6).toNat)
-            v6'
-            (expTwoMulIterCountNew iterCount)
-            v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            ptr nextLimb sp evmSp
-            (outW.getLimbN 3)
-            (expTwoMulFixedBranchReturnPc bit base)
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            d0' d1' d2' d3'
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
+          (expReloadDirectBranchPre k baseWord exponentWord
+            controlC6 e iterCount ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3
+            bit v6' v7' v10' v11' d0' d1' d2' d3' base
             (((ptr + signExtend12 (-8 : BitVec 12)) +
               signExtend12 (0 : BitVec 12)) ↦ₘ nextNextLimb))
           (Q ** (((ptr + signExtend12 (-8 : BitVec 12)) +
@@ -747,21 +682,13 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_r
     (hReloadFalse :
       k < 255 →
       ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
-        let squareW := expSquaringCallSquareW r0 r1 r2 r3
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
-          (expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-            64 nextLimb v6' (expTwoMulIterCountNew iterCount) v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            (ptr + signExtend12 (-8 : BitVec 12)) nextNextLimb sp evmSp
-            (squareW.getLimbN 3) (((base + 44) + 32) + 68)
-            (squareW.getLimbN 0) (squareW.getLimbN 1)
-            (squareW.getLimbN 2) (squareW.getLimbN 3)
-            d0' d1' d2' d3'
-            (squareW.getLimbN 0) (squareW.getLimbN 1)
-            (squareW.getLimbN 2) (squareW.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
+          (expReloadDirectFalsePre k baseWord exponentWord
+            e iterCount nextLimb ptr nextNextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3
+            v6' v7' v10' v11' d0' d1' d2' d3' base
             (((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
               ⌜expTwoMulIterCountNew iterCount ≠ 0⌝ **
               ⌜controlC6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
@@ -772,22 +699,13 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_r
     (hReloadTrue :
       k < 255 →
       ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
-        let rw := expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3)
-          a0 a1 a2 a3
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
-          (expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-            64 nextLimb v6' (expTwoMulIterCountNew iterCount) v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            (ptr + signExtend12 (-8 : BitVec 12)) nextNextLimb sp evmSp
-            (rw.getLimbN 3) (((base + 44) + 140) + 68)
-            (rw.getLimbN 0) (rw.getLimbN 1)
-            (rw.getLimbN 2) (rw.getLimbN 3)
-            d0' d1' d2' d3'
-            (rw.getLimbN 0) (rw.getLimbN 1)
-            (rw.getLimbN 2) (rw.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
+          (expReloadDirectTruePre k baseWord exponentWord
+            e iterCount nextLimb ptr nextNextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3
+            v6' v7' v10' v11' d0' d1' d2' d3' base
             (((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
               ⌜expTwoMulIterCountNew iterCount ≠ 0⌝ **
               ⌜controlC6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
@@ -844,24 +762,10 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_r
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
-          (let outW := expTwoMulFixedBranchResult bit
-            a0 a1 a2 a3 r0 r1 r2 r3
-          expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-            (controlC6 + signExtend12 (-1 : BitVec 12))
-            (e <<< (1 : BitVec 6).toNat)
-            v6'
-            (expTwoMulIterCountNew iterCount)
-            v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            ptr nextLimb sp evmSp
-            (outW.getLimbN 3)
-            (expTwoMulFixedBranchReturnPc bit base)
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            d0' d1' d2' d3'
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
+          (expReloadDirectBranchPre k baseWord exponentWord
+            controlC6 e iterCount ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3
+            bit v6' v7' v10' v11' d0' d1' d2' d3' base
             (((ptr + signExtend12 (-8 : BitVec 12)) +
               signExtend12 (0 : BitVec 12)) ↦ₘ nextNextLimb))
           (Q ** (((ptr + signExtend12 (-8 : BitVec 12)) +
@@ -869,21 +773,13 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_r
     (hReloadFalse :
       k < 255 →
       ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
-        let squareW := expSquaringCallSquareW r0 r1 r2 r3
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
-          (expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-            64 nextLimb v6' (expTwoMulIterCountNew iterCount) v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            (ptr + signExtend12 (-8 : BitVec 12)) nextNextLimb sp evmSp
-            (squareW.getLimbN 3) (((base + 44) + 32) + 68)
-            (squareW.getLimbN 0) (squareW.getLimbN 1)
-            (squareW.getLimbN 2) (squareW.getLimbN 3)
-            d0' d1' d2' d3'
-            (squareW.getLimbN 0) (squareW.getLimbN 1)
-            (squareW.getLimbN 2) (squareW.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
+          (expReloadDirectFalsePre k baseWord exponentWord
+            e iterCount nextLimb ptr nextNextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3
+            v6' v7' v10' v11' d0' d1' d2' d3' base
             (((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
               ⌜expTwoMulIterCountNew iterCount ≠ 0⌝ **
               ⌜controlC6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
@@ -894,22 +790,13 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_r
     (hReloadTrue :
       k < 255 →
       ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
-        let rw := expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3)
-          a0 a1 a2 a3
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
-          (expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-            64 nextLimb v6' (expTwoMulIterCountNew iterCount) v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            (ptr + signExtend12 (-8 : BitVec 12)) nextNextLimb sp evmSp
-            (rw.getLimbN 3) (((base + 44) + 140) + 68)
-            (rw.getLimbN 0) (rw.getLimbN 1)
-            (rw.getLimbN 2) (rw.getLimbN 3)
-            d0' d1' d2' d3'
-            (rw.getLimbN 0) (rw.getLimbN 1)
-            (rw.getLimbN 2) (rw.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
+          (expReloadDirectTruePre k baseWord exponentWord
+            e iterCount nextLimb ptr nextNextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3
+            v6' v7' v10' v11' d0' d1' d2' d3' base
             (((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
               ⌜expTwoMulIterCountNew iterCount ≠ 0⌝ **
               ⌜controlC6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
@@ -977,24 +864,10 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_r
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
-          (let outW := expTwoMulFixedBranchResult bit
-            a0 a1 a2 a3 r0 r1 r2 r3
-          expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-            (controlC6 + signExtend12 (-1 : BitVec 12))
-            (e <<< (1 : BitVec 6).toNat)
-            v6'
-            (expTwoMulIterCountNew iterCount)
-            v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            ptr nextLimb sp evmSp
-            (outW.getLimbN 3)
-            (expTwoMulFixedBranchReturnPc bit base)
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            d0' d1' d2' d3'
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
+          (expReloadDirectBranchPre k baseWord exponentWord
+            controlC6 e iterCount ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3
+            bit v6' v7' v10' v11' d0' d1' d2' d3' base
             (((((ptr + signExtend12 (-8 : BitVec 12)) +
               signExtend12 (0 : BitVec 12)) ↦ₘ nextNextLimb) **
               expTwoMulFixedReloadLimbFrameN exponentWord (k + 1)
@@ -1006,21 +879,13 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_r
     (hReloadFalse :
       k < 255 →
       ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
-        let squareW := expSquaringCallSquareW r0 r1 r2 r3
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
-          (expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-            64 nextLimb v6' (expTwoMulIterCountNew iterCount) v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            (ptr + signExtend12 (-8 : BitVec 12)) nextNextLimb sp evmSp
-            (squareW.getLimbN 3) (((base + 44) + 32) + 68)
-            (squareW.getLimbN 0) (squareW.getLimbN 1)
-            (squareW.getLimbN 2) (squareW.getLimbN 3)
-            d0' d1' d2' d3'
-            (squareW.getLimbN 0) (squareW.getLimbN 1)
-            (squareW.getLimbN 2) (squareW.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
+          (expReloadDirectFalsePre k baseWord exponentWord
+            e iterCount nextLimb ptr nextNextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3
+            v6' v7' v10' v11' d0' d1' d2' d3' base
             (((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
               ⌜expTwoMulIterCountNew iterCount ≠ 0⌝ **
               ⌜controlC6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
@@ -1035,22 +900,13 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_r
     (hReloadTrue :
       k < 255 →
       ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
-        let rw := expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3)
-          a0 a1 a2 a3
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
-          (expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-            64 nextLimb v6' (expTwoMulIterCountNew iterCount) v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            (ptr + signExtend12 (-8 : BitVec 12)) nextNextLimb sp evmSp
-            (rw.getLimbN 3) (((base + 44) + 140) + 68)
-            (rw.getLimbN 0) (rw.getLimbN 1)
-            (rw.getLimbN 2) (rw.getLimbN 3)
-            d0' d1' d2' d3'
-            (rw.getLimbN 0) (rw.getLimbN 1)
-            (rw.getLimbN 2) (rw.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
+          (expReloadDirectTruePre k baseWord exponentWord
+            e iterCount nextLimb ptr nextNextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3
+            v6' v7' v10' v11' d0' d1' d2' d3' base
             (((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
               ⌜expTwoMulIterCountNew iterCount ≠ 0⌝ **
               ⌜controlC6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
@@ -1109,6 +965,15 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_r
             expTwoMulFixedSavedNextLimbFrame_unfold]
           pcFree)
         hbase hControlMachine hk hBase hNextNext
-        hBranch hReloadFalse hReloadTrue hExit)
+        (fun hk_lt bit v6' v7' v10' v11' d0' d1' d2' d3' => by
+          simpa only [expReloadDirectBranchPre] using
+            hBranch hk_lt bit v6' v7' v10' v11' d0' d1' d2' d3')
+        (fun hk_lt v6' v7' v10' v11' d0' d1' d2' d3' => by
+          simpa only [expReloadDirectFalsePre] using
+            hReloadFalse hk_lt v6' v7' v10' v11' d0' d1' d2' d3')
+        (fun hk_lt v6' v7' v10' v11' d0' d1' d2' d3' => by
+          simpa only [expReloadDirectTruePre] using
+            hReloadTrue hk_lt v6' v7' v10' v11' d0' d1' d2' d3')
+        hExit)
 
 end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- add irreducible EXP reload-direct continuation precondition bundles
- rewrite reload-direct head-step wrappers to keep outW/squareW/rw let chains inside those bundles
- preserve local compatibility with existing callers via explicit local unfolds/simpa adapters

## Verification
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterStateLoopDirect
- lake build EvmAsm.Evm64.Exp
- git diff --check
- scripts/check-file-size.sh EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoopDirect.lean

Bead: evm-asm-20z6.13.7.3