### PR TITLE
refactor(exp): hide state-loop branch cps surface

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoop.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoop.lean
@@ -51,6 +51,47 @@ def expTwoMulFixedStateBranchPre
     (outW.getLimbN 3)
     a0 a1 a2 a3 v7' v11' frame
 
+@[irreducible]
+def expTwoMulFixedStateReloadFalsePre
+    (k : Nat) (baseWord exponentWord : EvmWord)
+    (e iterCount nextLimb ptr nextNextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 : Word)
+    (v6' v7' v10' v11' d0' d1' d2' d3' : Word)
+    (base : Word) (frame : Assertion) : Assertion :=
+  let squareW := expSquaringCallSquareW r0 r1 r2 r3
+  expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
+    64 nextLimb v6' (expTwoMulIterCountNew iterCount) v10'
+    ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+    (ptr + signExtend12 (-8 : BitVec 12)) nextNextLimb sp evmSp
+    (squareW.getLimbN 3) (((base + 44) + 32) + 68)
+    (squareW.getLimbN 0) (squareW.getLimbN 1)
+    (squareW.getLimbN 2) (squareW.getLimbN 3)
+    d0' d1' d2' d3'
+    (squareW.getLimbN 0) (squareW.getLimbN 1)
+    (squareW.getLimbN 2) (squareW.getLimbN 3)
+    a0 a1 a2 a3 v7' v11' frame
+
+@[irreducible]
+def expTwoMulFixedStateReloadTruePre
+    (k : Nat) (baseWord exponentWord : EvmWord)
+    (e iterCount nextLimb ptr nextNextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 : Word)
+    (v6' v7' v10' v11' d0' d1' d2' d3' : Word)
+    (base : Word) (frame : Assertion) : Assertion :=
+  let rw := expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3)
+    a0 a1 a2 a3
+  expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
+    64 nextLimb v6' (expTwoMulIterCountNew iterCount) v10'
+    ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+    (ptr + signExtend12 (-8 : BitVec 12)) nextNextLimb sp evmSp
+    (rw.getLimbN 3) (((base + 44) + 140) + 68)
+    (rw.getLimbN 0) (rw.getLimbN 1)
+    (rw.getLimbN 2) (rw.getLimbN 3)
+    d0' d1' d2' d3'
+    (rw.getLimbN 0) (rw.getLimbN 1)
+    (rw.getLimbN 2) (rw.getLimbN 3)
+    a0 a1 a2 a3 v7' v11' frame
+
 /-- Named-bound one-step wrapper for the fixed-loop induction.
 
     This specializes
@@ -385,21 +426,13 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_state_step_reloadDi
           Q)
     (hReloadFalse :
       ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
-        let squareW := expSquaringCallSquareW r0 r1 r2 r3
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) exit
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
-          (expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-            64 nextLimb v6' (expTwoMulIterCountNew iterCount) v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            (ptr + signExtend12 (-8 : BitVec 12)) nextNextLimb sp evmSp
-            (squareW.getLimbN 3) (((base + 44) + 32) + 68)
-            (squareW.getLimbN 0) (squareW.getLimbN 1)
-            (squareW.getLimbN 2) (squareW.getLimbN 3)
-            d0' d1' d2' d3'
-            (squareW.getLimbN 0) (squareW.getLimbN 1)
-            (squareW.getLimbN 2) (squareW.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
+          (expTwoMulFixedStateReloadFalsePre k baseWord exponentWord
+            e iterCount nextLimb ptr nextNextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3
+            v6' v7' v10' v11' d0' d1' d2' d3' base
             (((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
               ⌜expTwoMulIterCountNew iterCount ≠ 0⌝ **
               ⌜controlC6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
@@ -409,22 +442,13 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_state_step_reloadDi
           Q)
     (hReloadTrue :
       ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
-        let rw := expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3)
-          a0 a1 a2 a3
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) exit
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
-          (expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-            64 nextLimb v6' (expTwoMulIterCountNew iterCount) v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            (ptr + signExtend12 (-8 : BitVec 12)) nextNextLimb sp evmSp
-            (rw.getLimbN 3) (((base + 44) + 140) + 68)
-            (rw.getLimbN 0) (rw.getLimbN 1)
-            (rw.getLimbN 2) (rw.getLimbN 3)
-            d0' d1' d2' d3'
-            (rw.getLimbN 0) (rw.getLimbN 1)
-            (rw.getLimbN 2) (rw.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
+          (expTwoMulFixedStateReloadTruePre k baseWord exponentWord
+            e iterCount nextLimb ptr nextNextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3
+            v6' v7' v10' v11' d0' d1' d2' d3' base
             (((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
               ⌜expTwoMulIterCountNew iterCount ≠ 0⌝ **
               ⌜controlC6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
@@ -460,10 +484,14 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_state_step_reloadDi
         cases bit
         · exact
             cpsTripleWithin_expTwoMulFixedReloadBranchResidualWithStateFrame_false_to_iterPreNWithStateFrame
-              (hReloadFalse v6' v7' v10' v11' d0' d1' d2' d3')
+              (by
+                simpa only [expTwoMulFixedStateReloadFalsePre] using
+                  hReloadFalse v6' v7' v10' v11' d0' d1' d2' d3')
         · exact
             cpsTripleWithin_expTwoMulFixedReloadBranchResidualWithStateFrame_true_to_iterPreNWithStateFrame
-              (hReloadTrue v6' v7' v10' v11' d0' d1' d2' d3'))
+              (by
+                simpa only [expTwoMulFixedStateReloadTruePre] using
+                  hReloadTrue v6' v7' v10' v11' d0' d1' d2' d3'))
 
 /-- Final fixed-loop state-frame wrapper.
 

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoop.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoop.lean
@@ -24,6 +24,33 @@ private theorem pure_assertion_eq_emp_of_true {p : Prop} (hp : p) :
   · intro h
     exact ⟨h.1, hp⟩
 
+@[irreducible]
+def expTwoMulFixedStateBranchPre
+    (k : Nat) (baseWord exponentWord : EvmWord)
+    (controlC6 e iterCount ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 : Word)
+    (bit : Bool)
+    (v6' v7' v10' v11' d0' d1' d2' d3' : Word)
+    (base : Word) (frame : Assertion) : Assertion :=
+  let outW := expTwoMulFixedBranchResult bit
+    a0 a1 a2 a3 r0 r1 r2 r3
+  expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
+    (controlC6 + signExtend12 (-1 : BitVec 12))
+    (e <<< (1 : BitVec 6).toNat)
+    v6'
+    (expTwoMulIterCountNew iterCount)
+    v10'
+    ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+    ptr nextLimb sp evmSp
+    (outW.getLimbN 3)
+    (expTwoMulFixedBranchReturnPc bit base)
+    (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
+    (outW.getLimbN 3)
+    d0' d1' d2' d3'
+    (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
+    (outW.getLimbN 3)
+    a0 a1 a2 a3 v7' v11' frame
+
 /-- Named-bound one-step wrapper for the fixed-loop induction.
 
     This specializes
@@ -52,25 +79,10 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_state_step_fixedBou
       ∀ (bit : Bool)
         (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin nSteps (base + 44) exit cr
-          (let outW := expTwoMulFixedBranchResult bit
-            a0 a1 a2 a3 r0 r1 r2 r3
-          expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-            (controlC6 + signExtend12 (-1 : BitVec 12))
-            (e <<< (1 : BitVec 6).toNat)
-            v6'
-            (expTwoMulIterCountNew iterCount)
-            v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            ptr nextLimb sp evmSp
-            (outW.getLimbN 3)
-            (expTwoMulFixedBranchReturnPc bit base)
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            d0' d1' d2' d3'
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
-            frame)
+          (expTwoMulFixedStateBranchPre k baseWord exponentWord
+            controlC6 e iterCount ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3 bit
+            v6' v7' v10' v11' d0' d1' d2' d3' base frame)
           Q)
     (hReload :
       ∀ (bit : Bool)
@@ -95,7 +107,10 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_state_step_fixedBou
     a0 a1 a2 a3 v7 v11 base frame Q hDisjoint hFrame hbase
     hControlMachine hk hCount hBase hNextNext
     (by rw [expTwoMulFixedReloadIterStepBound_eq])
-    hBranch hReload
+    (fun bit v6' v7' v10' v11' d0' d1' d2' d3' => by
+      simpa only [expTwoMulFixedStateBranchPre] using
+        hBranch bit v6' v7' v10' v11' d0' d1' d2' d3')
+    hReload
 
 /-- Same-code one-step wrapper for the fixed-loop induction.
 
@@ -126,25 +141,10 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_state_step_sameCode
         (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin nSteps (base + 44) exit
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
-          (let outW := expTwoMulFixedBranchResult bit
-            a0 a1 a2 a3 r0 r1 r2 r3
-          expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-            (controlC6 + signExtend12 (-1 : BitVec 12))
-            (e <<< (1 : BitVec 6).toNat)
-            v6'
-            (expTwoMulIterCountNew iterCount)
-            v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            ptr nextLimb sp evmSp
-            (outW.getLimbN 3)
-            (expTwoMulFixedBranchReturnPc bit base)
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            d0' d1' d2' d3'
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
-            frame)
+          (expTwoMulFixedStateBranchPre k baseWord exponentWord
+            controlC6 e iterCount ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3 bit
+            v6' v7' v10' v11' d0' d1' d2' d3' base frame)
           Q)
     (hReload :
       ∀ (bit : Bool)
@@ -170,7 +170,11 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_state_step_sameCode
       a0 a1 a2 a3 v7 v11 base frame hFrame hbase hControlMachine
       hk hCount hBase hNextNext hBound)
     (cpsTripleWithin_expTwoMulFixedIterStepPostNWithControlFrame_state_elim
-      (by omega) hCount hBranch hReload)
+      (by omega) hCount
+      (fun bit v6' v7' v10' v11' d0' d1' d2' d3' => by
+        simpa only [expTwoMulFixedStateBranchPre] using
+          hBranch bit v6' v7' v10' v11' d0' d1' d2' d3')
+      hReload)
 
 /-- Fixed-bound same-code state step for the recursive loop induction. -/
 theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_state_step_fixedBound_sameCode
@@ -194,25 +198,10 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_state_step_fixedBou
         (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin nSteps (base + 44) exit
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
-          (let outW := expTwoMulFixedBranchResult bit
-            a0 a1 a2 a3 r0 r1 r2 r3
-          expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-            (controlC6 + signExtend12 (-1 : BitVec 12))
-            (e <<< (1 : BitVec 6).toNat)
-            v6'
-            (expTwoMulIterCountNew iterCount)
-            v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            ptr nextLimb sp evmSp
-            (outW.getLimbN 3)
-            (expTwoMulFixedBranchReturnPc bit base)
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            d0' d1' d2' d3'
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
-            frame)
+          (expTwoMulFixedStateBranchPre k baseWord exponentWord
+            controlC6 e iterCount ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3 bit
+            v6' v7' v10' v11' d0' d1' d2' d3' base frame)
           Q)
     (hReload :
       ∀ (bit : Bool)
@@ -268,25 +257,10 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_state_step_iteratio
         (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) exit cr
-          (let outW := expTwoMulFixedBranchResult bit
-            a0 a1 a2 a3 r0 r1 r2 r3
-          expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-            (controlC6 + signExtend12 (-1 : BitVec 12))
-            (e <<< (1 : BitVec 6).toNat)
-            v6'
-            (expTwoMulIterCountNew iterCount)
-            v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            ptr nextLimb sp evmSp
-            (outW.getLimbN 3)
-            (expTwoMulFixedBranchReturnPc bit base)
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            d0' d1' d2' d3'
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
-            frame)
+          (expTwoMulFixedStateBranchPre k baseWord exponentWord
+            controlC6 e iterCount ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3 bit
+            v6' v7' v10' v11' d0' d1' d2' d3' base frame)
           Q)
     (hReload :
       ∀ (bit : Bool)
@@ -340,25 +314,10 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_state_step_iteratio
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) exit
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
-          (let outW := expTwoMulFixedBranchResult bit
-            a0 a1 a2 a3 r0 r1 r2 r3
-          expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-            (controlC6 + signExtend12 (-1 : BitVec 12))
-            (e <<< (1 : BitVec 6).toNat)
-            v6'
-            (expTwoMulIterCountNew iterCount)
-            v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            ptr nextLimb sp evmSp
-            (outW.getLimbN 3)
-            (expTwoMulFixedBranchReturnPc bit base)
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            d0' d1' d2' d3'
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
-            frame)
+          (expTwoMulFixedStateBranchPre k baseWord exponentWord
+            controlC6 e iterCount ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3 bit
+            v6' v7' v10' v11' d0' d1' d2' d3' base frame)
           Q)
     (hReload :
       ∀ (bit : Bool)
@@ -510,7 +469,9 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_state_step_reloadDi
       (((ptr + signExtend12 (-8 : BitVec 12)) +
         signExtend12 (0 : BitVec 12) ↦ₘ nextNextLimb) ** frame)
       Q hFrameCurrent hbase hControlMachine hk hCount hBase hNextNext
-      hBranch
+      (fun bit v6' v7' v10' v11' d0' d1' d2' d3' => by
+        simpa only [expTwoMulFixedStateBranchPre] using
+          hBranch bit v6' v7' v10' v11' d0' d1' d2' d3')
       (fun bit v6' v7' v10' v11' d0' d1' d2' d3' => by
         cases bit
         · exact
@@ -667,7 +628,10 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_iterationsBoun
         sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
         a0 a1 a2 a3 v7 v11 base frame (Q ** frame) hFrame hbase
         hControlMachine hk_lt hState.2.2.2 hBase hNextNext
-        (hBranch hk_lt) (hReload hk_lt)
+        (fun bit v6' v7' v10' v11' d0' d1' d2' d3' => by
+          simpa only [expTwoMulFixedStateBranchPre] using
+            hBranch hk_lt bit v6' v7' v10' v11' d0' d1' d2' d3')
+        (hReload hk_lt)
   · subst k
     exact
       cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_final_iterationsBound

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoop.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoop.lean
@@ -376,24 +376,10 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_state_step_reloadDi
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) exit
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
-          (let outW := expTwoMulFixedBranchResult bit
-            a0 a1 a2 a3 r0 r1 r2 r3
-          expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-            (controlC6 + signExtend12 (-1 : BitVec 12))
-            (e <<< (1 : BitVec 6).toNat)
-            v6'
-            (expTwoMulIterCountNew iterCount)
-            v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            ptr nextLimb sp evmSp
-            (outW.getLimbN 3)
-            (expTwoMulFixedBranchReturnPc bit base)
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            d0' d1' d2' d3'
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
+          (expTwoMulFixedStateBranchPre k baseWord exponentWord
+            controlC6 e iterCount ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3 bit
+            v6' v7' v10' v11' d0' d1' d2' d3' base
             ((((ptr + signExtend12 (-8 : BitVec 12)) +
               signExtend12 (0 : BitVec 12)) ↦ₘ nextNextLimb) ** frame))
           Q)
@@ -469,9 +455,7 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_state_step_reloadDi
       (((ptr + signExtend12 (-8 : BitVec 12)) +
         signExtend12 (0 : BitVec 12) ↦ₘ nextNextLimb) ** frame)
       Q hFrameCurrent hbase hControlMachine hk hCount hBase hNextNext
-      (fun bit v6' v7' v10' v11' d0' d1' d2' d3' => by
-        simpa only [expTwoMulFixedStateBranchPre] using
-          hBranch bit v6' v7' v10' v11' d0' d1' d2' d3')
+      hBranch
       (fun bit v6' v7' v10' v11' d0' d1' d2' d3' => by
         cases bit
         · exact
@@ -574,25 +558,10 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_iterationsBoun
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
-          (let outW := expTwoMulFixedBranchResult bit
-            a0 a1 a2 a3 r0 r1 r2 r3
-          expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-            (controlC6 + signExtend12 (-1 : BitVec 12))
-            (e <<< (1 : BitVec 6).toNat)
-            v6'
-            (expTwoMulIterCountNew iterCount)
-            v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            ptr nextLimb sp evmSp
-            (outW.getLimbN 3)
-            (expTwoMulFixedBranchReturnPc bit base)
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            d0' d1' d2' d3'
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
-            frame)
+          (expTwoMulFixedStateBranchPre k baseWord exponentWord
+            controlC6 e iterCount ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3 bit
+            v6' v7' v10' v11' d0' d1' d2' d3' base frame)
           (Q ** frame))
     (hReload :
       k < 255 →
@@ -628,9 +597,7 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_iterationsBoun
         sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
         a0 a1 a2 a3 v7 v11 base frame (Q ** frame) hFrame hbase
         hControlMachine hk_lt hState.2.2.2 hBase hNextNext
-        (fun bit v6' v7' v10' v11' d0' d1' d2' d3' => by
-          simpa only [expTwoMulFixedStateBranchPre] using
-            hBranch hk_lt bit v6' v7' v10' v11' d0' d1' d2' d3')
+        (hBranch hk_lt)
         (hReload hk_lt)
   · subst k
     exact
@@ -667,25 +634,10 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_iterationsBoun
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
-          (let outW := expTwoMulFixedBranchResult bit
-            a0 a1 a2 a3 r0 r1 r2 r3
-          expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-            (controlC6 + signExtend12 (-1 : BitVec 12))
-            (e <<< (1 : BitVec 6).toNat)
-            v6'
-            (expTwoMulIterCountNew iterCount)
-            v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            ptr nextLimb sp evmSp
-            (outW.getLimbN 3)
-            (expTwoMulFixedBranchReturnPc bit base)
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            d0' d1' d2' d3'
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
-            frame)
+          (expTwoMulFixedStateBranchPre k baseWord exponentWord
+            controlC6 e iterCount ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3 bit
+            v6' v7' v10' v11' d0' d1' d2' d3' base frame)
           (Q ** frame))
     (hReload :
       k < 255 →
@@ -751,25 +703,10 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithState_head_iterationsBound_sam
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
-          (let outW := expTwoMulFixedBranchResult bit
-            a0 a1 a2 a3 r0 r1 r2 r3
-          expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-            (controlC6 + signExtend12 (-1 : BitVec 12))
-            (e <<< (1 : BitVec 6).toNat)
-            v6'
-            (expTwoMulIterCountNew iterCount)
-            v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            ptr nextLimb sp evmSp
-            (outW.getLimbN 3)
-            (expTwoMulFixedBranchReturnPc bit base)
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            d0' d1' d2' d3'
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
-            empAssertion)
+          (expTwoMulFixedStateBranchPre k baseWord exponentWord
+            controlC6 e iterCount ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3 bit
+            v6' v7' v10' v11' d0' d1' d2' d3' base empAssertion)
           Q)
     (hReload :
       k < 255 →

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoopDirect.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoopDirect.lean
@@ -182,7 +182,7 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_f
         signExtend12 (0 : BitVec 12) ↦ₘ nextNextLimb) ** frame)
       Q hFrameCurrent hbase hControlMachine hk hBase hNextNext
       (fun hk_lt bit v6' v7' v10' v11' d0' d1' d2' d3' => by
-        simpa only [expReloadDirectBranchPre] using
+        simpa only [expReloadDirectBranchPre, expTwoMulFixedStateBranchPre] using
           hBranch hk_lt bit v6' v7' v10' v11' d0' d1' d2' d3')
       (fun hk_lt bit v6' v7' v10' v11' d0' d1' d2' d3' => by
         cases bit


### PR DESCRIPTION
## Summary
- add irreducible expTwoMulFixedStateBranchPre for the fixed-loop state branch continuation
- rewrite the lower induction-facing state-loop wrappers to use the named precondition instead of exposing the expTwoMulFixedBranchResult let chain
- adapt higher wrappers with local bridges where their public shape still exposes the older raw continuation

## Verification
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterStateLoop
- lake build EvmAsm.Evm64.Exp
- git diff --check
- scripts/check-file-size.sh EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoop.lean