### PR TITLE
refactor(exp): hide state-loop reload cps surfaces

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoop.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoop.lean
@@ -51,6 +51,47 @@ def expTwoMulFixedStateBranchPre
     (outW.getLimbN 3)
     a0 a1 a2 a3 v7' v11' frame
 
+@[irreducible]
+def expTwoMulFixedStateReloadFalsePre
+    (k : Nat) (baseWord exponentWord : EvmWord)
+    (e iterCount nextLimb ptr nextNextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 : Word)
+    (v6' v7' v10' v11' d0' d1' d2' d3' : Word)
+    (base : Word) (frame : Assertion) : Assertion :=
+  let squareW := expSquaringCallSquareW r0 r1 r2 r3
+  expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
+    64 nextLimb v6' (expTwoMulIterCountNew iterCount) v10'
+    ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+    (ptr + signExtend12 (-8 : BitVec 12)) nextNextLimb sp evmSp
+    (squareW.getLimbN 3) (((base + 44) + 32) + 68)
+    (squareW.getLimbN 0) (squareW.getLimbN 1)
+    (squareW.getLimbN 2) (squareW.getLimbN 3)
+    d0' d1' d2' d3'
+    (squareW.getLimbN 0) (squareW.getLimbN 1)
+    (squareW.getLimbN 2) (squareW.getLimbN 3)
+    a0 a1 a2 a3 v7' v11' frame
+
+@[irreducible]
+def expTwoMulFixedStateReloadTruePre
+    (k : Nat) (baseWord exponentWord : EvmWord)
+    (e iterCount nextLimb ptr nextNextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 : Word)
+    (v6' v7' v10' v11' d0' d1' d2' d3' : Word)
+    (base : Word) (frame : Assertion) : Assertion :=
+  let rw := expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3)
+    a0 a1 a2 a3
+  expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
+    64 nextLimb v6' (expTwoMulIterCountNew iterCount) v10'
+    ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+    (ptr + signExtend12 (-8 : BitVec 12)) nextNextLimb sp evmSp
+    (rw.getLimbN 3) (((base + 44) + 140) + 68)
+    (rw.getLimbN 0) (rw.getLimbN 1)
+    (rw.getLimbN 2) (rw.getLimbN 3)
+    d0' d1' d2' d3'
+    (rw.getLimbN 0) (rw.getLimbN 1)
+    (rw.getLimbN 2) (rw.getLimbN 3)
+    a0 a1 a2 a3 v7' v11' frame
+
 /-- Named-bound one-step wrapper for the fixed-loop induction.
 
     This specializes
@@ -385,21 +426,13 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_state_step_reloadDi
           Q)
     (hReloadFalse :
       ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
-        let squareW := expSquaringCallSquareW r0 r1 r2 r3
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) exit
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
-          (expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-            64 nextLimb v6' (expTwoMulIterCountNew iterCount) v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            (ptr + signExtend12 (-8 : BitVec 12)) nextNextLimb sp evmSp
-            (squareW.getLimbN 3) (((base + 44) + 32) + 68)
-            (squareW.getLimbN 0) (squareW.getLimbN 1)
-            (squareW.getLimbN 2) (squareW.getLimbN 3)
-            d0' d1' d2' d3'
-            (squareW.getLimbN 0) (squareW.getLimbN 1)
-            (squareW.getLimbN 2) (squareW.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
+          (expTwoMulFixedStateReloadFalsePre k baseWord exponentWord
+            e iterCount nextLimb ptr nextNextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3
+            v6' v7' v10' v11' d0' d1' d2' d3' base
             (((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
               ⌜expTwoMulIterCountNew iterCount ≠ 0⌝ **
               ⌜controlC6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
@@ -409,22 +442,13 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_state_step_reloadDi
           Q)
     (hReloadTrue :
       ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
-        let rw := expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3)
-          a0 a1 a2 a3
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) exit
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
-          (expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-            64 nextLimb v6' (expTwoMulIterCountNew iterCount) v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            (ptr + signExtend12 (-8 : BitVec 12)) nextNextLimb sp evmSp
-            (rw.getLimbN 3) (((base + 44) + 140) + 68)
-            (rw.getLimbN 0) (rw.getLimbN 1)
-            (rw.getLimbN 2) (rw.getLimbN 3)
-            d0' d1' d2' d3'
-            (rw.getLimbN 0) (rw.getLimbN 1)
-            (rw.getLimbN 2) (rw.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
+          (expTwoMulFixedStateReloadTruePre k baseWord exponentWord
+            e iterCount nextLimb ptr nextNextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3
+            v6' v7' v10' v11' d0' d1' d2' d3' base
             (((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
               ⌜expTwoMulIterCountNew iterCount ≠ 0⌝ **
               ⌜controlC6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
@@ -460,10 +484,14 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_state_step_reloadDi
         cases bit
         · exact
             cpsTripleWithin_expTwoMulFixedReloadBranchResidualWithStateFrame_false_to_iterPreNWithStateFrame
-              (hReloadFalse v6' v7' v10' v11' d0' d1' d2' d3')
+              (by
+                simpa only [expTwoMulFixedStateReloadFalsePre] using
+                  hReloadFalse v6' v7' v10' v11' d0' d1' d2' d3')
         · exact
             cpsTripleWithin_expTwoMulFixedReloadBranchResidualWithStateFrame_true_to_iterPreNWithStateFrame
-              (hReloadTrue v6' v7' v10' v11' d0' d1' d2' d3'))
+              (by
+                simpa only [expTwoMulFixedStateReloadTruePre] using
+                  hReloadTrue v6' v7' v10' v11' d0' d1' d2' d3'))
 
 /-- Final fixed-loop state-frame wrapper.
 


### PR DESCRIPTION
## Summary
- stack on #5015 and reuse the state-loop branch-surface cleanup
- add irreducible expTwoMulFixedStateReloadFalsePre / expTwoMulFixedStateReloadTruePre
- rewrite the reloadDirect false/true continuation surfaces to hide squareW and cond-rw let chains behind those defs

## Verification
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterStateLoop
- lake build EvmAsm.Evm64.Exp
- git diff --check
- scripts/check-file-size.sh EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoop.lean