### PR TITLE
refactor(exp): hide state-step branch cps surface

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoop.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoop.lean
@@ -149,7 +149,8 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_state_step_fixedBou
     hControlMachine hk hCount hBase hNextNext
     (by rw [expTwoMulFixedReloadIterStepBound_eq])
     (fun bit v6' v7' v10' v11' d0' d1' d2' d3' => by
-      simpa only [expTwoMulFixedStateBranchPre] using
+      simpa only [expTwoMulFixedStateBranchPre,
+        expTwoMulFixedStateStepBranchPre] using
         hBranch bit v6' v7' v10' v11' d0' d1' d2' d3')
     hReload
 
@@ -213,7 +214,8 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_state_step_sameCode
     (cpsTripleWithin_expTwoMulFixedIterStepPostNWithControlFrame_state_elim
       (by omega) hCount
       (fun bit v6' v7' v10' v11' d0' d1' d2' d3' => by
-        simpa only [expTwoMulFixedStateBranchPre] using
+        simpa only [expTwoMulFixedStateBranchPre,
+          expTwoMulFixedStateStepBranchPre] using
           hBranch bit v6' v7' v10' v11' d0' d1' d2' d3')
       hReload)
 

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoop.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoop.lean
@@ -487,12 +487,16 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_state_step_reloadDi
         · exact
             cpsTripleWithin_expTwoMulFixedReloadBranchResidualWithStateFrame_false_to_iterPreNWithStateFrame
               (by
-                simpa only [expTwoMulFixedStateReloadFalsePre] using
+                simpa only [
+                  expTwoMulFixedReloadResidualFalseNextPre,
+                  expTwoMulFixedStateReloadFalsePre] using
                   hReloadFalse v6' v7' v10' v11' d0' d1' d2' d3')
         · exact
             cpsTripleWithin_expTwoMulFixedReloadBranchResidualWithStateFrame_true_to_iterPreNWithStateFrame
               (by
-                simpa only [expTwoMulFixedStateReloadTruePre] using
+                simpa only [
+                  expTwoMulFixedReloadResidualTrueNextPre,
+                  expTwoMulFixedStateReloadTruePre] using
                   hReloadTrue v6' v7' v10' v11' d0' d1' d2' d3'))
 
 /-- Final fixed-loop state-frame wrapper.

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoopDirect.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoopDirect.lean
@@ -189,12 +189,16 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_f
         · exact
             cpsTripleWithin_expTwoMulFixedReloadBranchResidualWithStateFrame_false_to_iterPreNWithStateFrame
               (by
-                simpa only [expReloadDirectFalsePre] using
+                simpa only [
+                  expTwoMulFixedReloadResidualFalseNextPre,
+                  expReloadDirectFalsePre] using
                   hReloadFalse hk_lt v6' v7' v10' v11' d0' d1' d2' d3')
         · exact
             cpsTripleWithin_expTwoMulFixedReloadBranchResidualWithStateFrame_true_to_iterPreNWithStateFrame
               (by
-                simpa only [expReloadDirectTruePre] using
+                simpa only [
+                  expTwoMulFixedReloadResidualTrueNextPre,
+                  expReloadDirectTruePre] using
                   hReloadTrue hk_lt v6' v7' v10' v11' d0' d1' d2' d3'))
       hExit
 

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateResidualBridge.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateResidualBridge.lean
@@ -11,6 +11,57 @@ namespace EvmAsm.Evm64.Exp.Compose
 
 open EvmAsm.Rv64
 
+@[irreducible]
+def expTwoMulFixedReloadResidualFalseNextPre
+    (k : Nat) (baseWord exponentWord : EvmWord)
+    (iterCount e c6 ptr nextLimb nextNextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base
+      v6 v7 v10 v11 d0 d1 d2 d3 : Word)
+    (frame : Assertion) : Assertion :=
+  let squareW := expSquaringCallSquareW r0 r1 r2 r3
+  expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
+    64 nextLimb v6 (expTwoMulIterCountNew iterCount) v10
+    ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+    (ptr + signExtend12 (-8 : BitVec 12)) nextNextLimb sp evmSp
+    (squareW.getLimbN 3) (((base + 44) + 32) + 68)
+    (squareW.getLimbN 0) (squareW.getLimbN 1)
+    (squareW.getLimbN 2) (squareW.getLimbN 3)
+    d0 d1 d2 d3
+    (squareW.getLimbN 0) (squareW.getLimbN 1)
+    (squareW.getLimbN 2) (squareW.getLimbN 3)
+    a0 a1 a2 a3 v7 v11
+    (((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
+      ⌜expTwoMulIterCountNew iterCount ≠ 0⌝ **
+      ⌜c6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
+      ⌜(e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12) = 0⌝ **
+      frame)
+
+@[irreducible]
+def expTwoMulFixedReloadResidualTrueNextPre
+    (k : Nat) (baseWord exponentWord : EvmWord)
+    (iterCount e c6 ptr nextLimb nextNextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base
+      v6 v7 v10 v11 d0 d1 d2 d3 : Word)
+    (frame : Assertion) : Assertion :=
+  let rw := expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3)
+    a0 a1 a2 a3
+  expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
+    64 nextLimb v6 (expTwoMulIterCountNew iterCount) v10
+    ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+    (ptr + signExtend12 (-8 : BitVec 12)) nextNextLimb sp evmSp
+    (rw.getLimbN 3) (((base + 44) + 140) + 68)
+    (rw.getLimbN 0) (rw.getLimbN 1)
+    (rw.getLimbN 2) (rw.getLimbN 3)
+    d0 d1 d2 d3
+    (rw.getLimbN 0) (rw.getLimbN 1)
+    (rw.getLimbN 2) (rw.getLimbN 3)
+    a0 a1 a2 a3 v7 v11
+    (((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
+      ⌜expTwoMulIterCountNew iterCount ≠ 0⌝ **
+      ⌜c6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
+      ⌜(e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12) ≠ 0⌝ **
+      frame)
+
 /-- A false-bit reload residual can re-enter the next state-carrying fixed
     iteration precondition once the remaining frame supplies the following
     pointer cell. -/
@@ -73,25 +124,11 @@ theorem cpsTripleWithin_expTwoMulFixedReloadBranchResidualWithStateFrame_false_t
       v6 v7 v10 v11 d0 d1 d2 d3 : Word}
     {frame Q : Assertion}
     (hNext :
-      let squareW := expSquaringCallSquareW r0 r1 r2 r3
       cpsTripleWithin nSteps entry exit cr
-        (expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-          64 nextLimb v6 (expTwoMulIterCountNew iterCount) v10
-          ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-          (ptr + signExtend12 (-8 : BitVec 12)) nextNextLimb sp evmSp
-          (squareW.getLimbN 3) (((base + 44) + 32) + 68)
-          (squareW.getLimbN 0) (squareW.getLimbN 1)
-          (squareW.getLimbN 2) (squareW.getLimbN 3)
-          d0 d1 d2 d3
-          (squareW.getLimbN 0) (squareW.getLimbN 1)
-          (squareW.getLimbN 2) (squareW.getLimbN 3)
-          a0 a1 a2 a3 v7 v11
-          (((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
-            ⌜expTwoMulIterCountNew iterCount ≠ 0⌝ **
-            ⌜c6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
-            ⌜(e >>> (63 : BitVec 6).toNat) +
-              signExtend12 (0 : BitVec 12) = 0⌝ **
-            frame))
+        (expTwoMulFixedReloadResidualFalseNextPre k baseWord exponentWord
+          iterCount e c6 ptr nextLimb nextNextLimb sp evmSp
+          r0 r1 r2 r3 a0 a1 a2 a3 base
+          v6 v7 v10 v11 d0 d1 d2 d3 frame)
         Q) :
     cpsTripleWithin nSteps entry exit cr
       (expTwoMulFixedReloadBranchResidualWithStateFrame false (k := k)
@@ -103,8 +140,10 @@ theorem cpsTripleWithin_expTwoMulFixedReloadBranchResidualWithStateFrame_false_t
       Q :=
   cpsTripleWithin_weaken
     (fun _ h =>
-      expTwoMulFixedReloadBranchResidualWithStateFrame_false_to_iterPreNWithStateFrame
-        h)
+      by
+        simpa only [expTwoMulFixedReloadResidualFalseNextPre] using
+          expTwoMulFixedReloadBranchResidualWithStateFrame_false_to_iterPreNWithStateFrame
+            h)
     (fun _ h => h)
     hNext
 
@@ -171,26 +210,11 @@ theorem cpsTripleWithin_expTwoMulFixedReloadBranchResidualWithStateFrame_true_to
       v6 v7 v10 v11 d0 d1 d2 d3 : Word}
     {frame Q : Assertion}
     (hNext :
-      let rw := expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3)
-        a0 a1 a2 a3
       cpsTripleWithin nSteps entry exit cr
-        (expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-          64 nextLimb v6 (expTwoMulIterCountNew iterCount) v10
-          ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-          (ptr + signExtend12 (-8 : BitVec 12)) nextNextLimb sp evmSp
-          (rw.getLimbN 3) (((base + 44) + 140) + 68)
-          (rw.getLimbN 0) (rw.getLimbN 1)
-          (rw.getLimbN 2) (rw.getLimbN 3)
-          d0 d1 d2 d3
-          (rw.getLimbN 0) (rw.getLimbN 1)
-          (rw.getLimbN 2) (rw.getLimbN 3)
-          a0 a1 a2 a3 v7 v11
-          (((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
-            ⌜expTwoMulIterCountNew iterCount ≠ 0⌝ **
-            ⌜c6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
-            ⌜(e >>> (63 : BitVec 6).toNat) +
-              signExtend12 (0 : BitVec 12) ≠ 0⌝ **
-            frame))
+        (expTwoMulFixedReloadResidualTrueNextPre k baseWord exponentWord
+          iterCount e c6 ptr nextLimb nextNextLimb sp evmSp
+          r0 r1 r2 r3 a0 a1 a2 a3 base
+          v6 v7 v10 v11 d0 d1 d2 d3 frame)
         Q) :
     cpsTripleWithin nSteps entry exit cr
       (expTwoMulFixedReloadBranchResidualWithStateFrame true (k := k)
@@ -202,8 +226,10 @@ theorem cpsTripleWithin_expTwoMulFixedReloadBranchResidualWithStateFrame_true_to
       Q :=
   cpsTripleWithin_weaken
     (fun _ h =>
-      expTwoMulFixedReloadBranchResidualWithStateFrame_true_to_iterPreNWithStateFrame
-        h)
+      by
+        simpa only [expTwoMulFixedReloadResidualTrueNextPre] using
+          expTwoMulFixedReloadBranchResidualWithStateFrame_true_to_iterPreNWithStateFrame
+            h)
     (fun _ h => h)
     hNext
 

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateStep.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateStep.lean
@@ -21,6 +21,33 @@ private theorem pure_assertion_eq_emp_of_true {p : Prop} (hp : p) :
   · intro h
     exact ⟨h.1, hp⟩
 
+@[irreducible]
+def expTwoMulFixedStateStepBranchPre
+    (k : Nat) (baseWord exponentWord : EvmWord)
+    (controlC6 e iterCount ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 : Word)
+    (bit : Bool)
+    (v6 v7 v10 v11 d0 d1 d2 d3 : Word)
+    (base : Word) (frame : Assertion) : Assertion :=
+  let outW := expTwoMulFixedBranchResult bit
+    a0 a1 a2 a3 r0 r1 r2 r3
+  expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
+    (controlC6 + signExtend12 (-1 : BitVec 12))
+    (e <<< (1 : BitVec 6).toNat)
+    v6
+    (expTwoMulIterCountNew iterCount)
+    v10
+    ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+    ptr nextLimb sp evmSp
+    (outW.getLimbN 3)
+    (expTwoMulFixedBranchReturnPc bit base)
+    (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
+    (outW.getLimbN 3)
+    d0 d1 d2 d3
+    (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
+    (outW.getLimbN 3)
+    a0 a1 a2 a3 v7 v11 frame
+
 /-- Reload-pointer residual with the successor iteration state bundled as a
     single pure state assertion.  This is the reload-side analogue of
     `expTwoMulFixedIterPreNWithStateFrame` for the fixed-loop induction. -/
@@ -562,25 +589,10 @@ theorem cpsTripleWithin_expTwoMulFixedIterStepPostNWithControlFrame_branchState_
       ∀ (bit : Bool)
         (v6 v7 v10 v11 d0 d1 d2 d3 : Word),
         cpsTripleWithin nSteps addr exit cr
-          (let outW := expTwoMulFixedBranchResult bit
-            a0 a1 a2 a3 r0 r1 r2 r3
-          expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-            (controlC6 + signExtend12 (-1 : BitVec 12))
-            (e <<< (1 : BitVec 6).toNat)
-            v6
-            (expTwoMulIterCountNew iterCount)
-            v10
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            ptr nextLimb sp evmSp
-            (outW.getLimbN 3)
-            (expTwoMulFixedBranchReturnPc bit base)
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            d0 d1 d2 d3
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            a0 a1 a2 a3 v7 v11
-            frame)
+          (expTwoMulFixedStateStepBranchPre k baseWord exponentWord
+            controlC6 e iterCount ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3 bit
+            v6 v7 v10 v11 d0 d1 d2 d3 base frame)
           Q)
     (hReload :
       ∀ (bit : Bool)
@@ -603,7 +615,9 @@ theorem cpsTripleWithin_expTwoMulFixedIterStepPostNWithControlFrame_branchState_
           expTwoMulFixedIterPreNWithControlFrame_to_iterPreNWithStateFrame
             (expTwoMulFixedIterCountInvariant_succ hk hCount) h)
         (fun _ h => h)
-        (hBranch bit v6 v7 v10 v11 d0 d1 d2 d3))
+        (by
+          simpa only [expTwoMulFixedStateStepBranchPre] using
+            hBranch bit v6 v7 v10 v11 d0 d1 d2 d3))
     hReload
 
 /-- CPS eliminator whose ordinary and reload continuations are both stated
@@ -620,25 +634,10 @@ theorem cpsTripleWithin_expTwoMulFixedIterStepPostNWithControlFrame_state_elim
       ∀ (bit : Bool)
         (v6 v7 v10 v11 d0 d1 d2 d3 : Word),
         cpsTripleWithin nSteps addr exit cr
-          (let outW := expTwoMulFixedBranchResult bit
-            a0 a1 a2 a3 r0 r1 r2 r3
-          expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-            (controlC6 + signExtend12 (-1 : BitVec 12))
-            (e <<< (1 : BitVec 6).toNat)
-            v6
-            (expTwoMulIterCountNew iterCount)
-            v10
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            ptr nextLimb sp evmSp
-            (outW.getLimbN 3)
-            (expTwoMulFixedBranchReturnPc bit base)
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            d0 d1 d2 d3
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            a0 a1 a2 a3 v7 v11
-            frame)
+          (expTwoMulFixedStateStepBranchPre k baseWord exponentWord
+            controlC6 e iterCount ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3 bit
+            v6 v7 v10 v11 d0 d1 d2 d3 base frame)
           Q)
     (hReload :
       ∀ (bit : Bool)
@@ -724,7 +723,11 @@ theorem cpsTripleWithin_expTwoMulFixedIterCaseLoopPost_branchState_elim
       (cpsTripleWithin_expTwoMulFixedIterCaseLoopPost_to_stepPostNWithControlFrame
         addr frame hk hBase hState.2.1 hState.2.2.1 hNextNext hState.1)
       (cpsTripleWithin_expTwoMulFixedIterStepPostNWithControlFrame_branchState_elim
-        hk hState.2.2.2 hBranch hReload)
+        hk hState.2.2.2
+        (fun bit v6 v7 v10 v11 d0 d1 d2 d3 => by
+          simpa only [expTwoMulFixedStateStepBranchPre] using
+            hBranch bit v6 v7 v10 v11 d0 d1 d2 d3)
+        hReload)
 
 /-- CPS case-loop bridge with both recursive edge shapes carrying the
     successor iteration state. -/
@@ -785,7 +788,11 @@ theorem cpsTripleWithin_expTwoMulFixedIterCaseLoopPost_state_elim
       (cpsTripleWithin_expTwoMulFixedIterCaseLoopPost_to_stepPostNWithControlFrame
         addr frame hk hBase hState.2.1 hState.2.2.1 hNextNext hState.1)
       (cpsTripleWithin_expTwoMulFixedIterStepPostNWithControlFrame_state_elim
-        hk hState.2.2.2 hBranch hReload)
+        hk hState.2.2.2
+        (fun bit v6 v7 v10 v11 d0 d1 d2 d3 => by
+          simpa only [expTwoMulFixedStateStepBranchPre] using
+            hBranch bit v6 v7 v10 v11 d0 d1 d2 d3)
+        hReload)
 
 /-- Bounded one-step wrapper whose nonzero decremented-count premise comes
     from the bundled fixed-loop count invariant. -/
@@ -893,7 +900,11 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_state_step
       a0 a1 a2 a3 v7 v11 base frame hFrame hbase hControlMachine
       hk hCount hBase hNextNext hBound)
     (cpsTripleWithin_expTwoMulFixedIterStepPostNWithControlFrame_state_elim
-      (by omega) hCount hBranch hReload)
+      (by omega) hCount
+      (fun bit v6' v7' v10' v11' d0' d1' d2' d3' => by
+        simpa only [expTwoMulFixedStateStepBranchPre] using
+          hBranch bit v6' v7' v10' v11' d0' d1' d2' d3')
+      hReload)
 
 /-- Unframed variant of
     `cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_state_step`. -/

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateStep.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateStep.lean
@@ -613,7 +613,9 @@ theorem cpsTripleWithin_expTwoMulFixedIterStepPostNWithControlFrame_branchState_
       cpsTripleWithin_weaken
         (fun _ h =>
           expTwoMulFixedIterPreNWithControlFrame_to_iterPreNWithStateFrame
-            (expTwoMulFixedIterCountInvariant_succ hk hCount) h)
+            (expTwoMulFixedIterCountInvariant_succ hk hCount)
+            (by
+              simpa only [expTwoMulFixedStepPostBranchPre] using h))
         (fun _ h => h)
         (by
           simpa only [expTwoMulFixedStateStepBranchPre] using

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateStep.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateStep.lean
@@ -685,25 +685,10 @@ theorem cpsTripleWithin_expTwoMulFixedIterCaseLoopPost_branchState_elim
       ∀ (bit : Bool)
         (v6 v7 v10 v11 d0 d1 d2 d3 : Word),
         cpsTripleWithin nSteps addr exit cr
-          (let outW := expTwoMulFixedBranchResult bit
-            a0 a1 a2 a3 r0 r1 r2 r3
-          expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-            (controlC6 + signExtend12 (-1 : BitVec 12))
-            (e <<< (1 : BitVec 6).toNat)
-            v6
-            (expTwoMulIterCountNew iterCount)
-            v10
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            ptr nextLimb sp evmSp
-            (outW.getLimbN 3)
-            (expTwoMulFixedBranchReturnPc bit base)
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            d0 d1 d2 d3
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            a0 a1 a2 a3 v7 v11
-            frame)
+          (expTwoMulFixedStateStepBranchPre k baseWord exponentWord
+            controlC6 e iterCount ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3 bit
+            v6 v7 v10 v11 d0 d1 d2 d3 base frame)
           Q)
     (hReload :
       ∀ (bit : Bool)
@@ -726,9 +711,7 @@ theorem cpsTripleWithin_expTwoMulFixedIterCaseLoopPost_branchState_elim
         addr frame hk hBase hState.2.1 hState.2.2.1 hNextNext hState.1)
       (cpsTripleWithin_expTwoMulFixedIterStepPostNWithControlFrame_branchState_elim
         hk hState.2.2.2
-        (fun bit v6 v7 v10 v11 d0 d1 d2 d3 => by
-          simpa only [expTwoMulFixedStateStepBranchPre] using
-            hBranch bit v6 v7 v10 v11 d0 d1 d2 d3)
+        hBranch
         hReload)
 
 /-- CPS case-loop bridge with both recursive edge shapes carrying the
@@ -750,25 +733,10 @@ theorem cpsTripleWithin_expTwoMulFixedIterCaseLoopPost_state_elim
       ∀ (bit : Bool)
         (v6 v7 v10 v11 d0 d1 d2 d3 : Word),
         cpsTripleWithin nSteps addr exit cr
-          (let outW := expTwoMulFixedBranchResult bit
-            a0 a1 a2 a3 r0 r1 r2 r3
-          expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-            (controlC6 + signExtend12 (-1 : BitVec 12))
-            (e <<< (1 : BitVec 6).toNat)
-            v6
-            (expTwoMulIterCountNew iterCount)
-            v10
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            ptr nextLimb sp evmSp
-            (outW.getLimbN 3)
-            (expTwoMulFixedBranchReturnPc bit base)
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            d0 d1 d2 d3
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            a0 a1 a2 a3 v7 v11
-            frame)
+          (expTwoMulFixedStateStepBranchPre k baseWord exponentWord
+            controlC6 e iterCount ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3 bit
+            v6 v7 v10 v11 d0 d1 d2 d3 base frame)
           Q)
     (hReload :
       ∀ (bit : Bool)
@@ -791,9 +759,7 @@ theorem cpsTripleWithin_expTwoMulFixedIterCaseLoopPost_state_elim
         addr frame hk hBase hState.2.1 hState.2.2.1 hNextNext hState.1)
       (cpsTripleWithin_expTwoMulFixedIterStepPostNWithControlFrame_state_elim
         hk hState.2.2.2
-        (fun bit v6 v7 v10 v11 d0 d1 d2 d3 => by
-          simpa only [expTwoMulFixedStateStepBranchPre] using
-            hBranch bit v6 v7 v10 v11 d0 d1 d2 d3)
+        hBranch
         hReload)
 
 /-- Bounded one-step wrapper whose nonzero decremented-count premise comes
@@ -858,25 +824,10 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_state_step
       ∀ (bit : Bool)
         (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin nSteps (base + 44) exit cr
-          (let outW := expTwoMulFixedBranchResult bit
-            a0 a1 a2 a3 r0 r1 r2 r3
-          expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-            (controlC6 + signExtend12 (-1 : BitVec 12))
-            (e <<< (1 : BitVec 6).toNat)
-            v6'
-            (expTwoMulIterCountNew iterCount)
-            v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            ptr nextLimb sp evmSp
-            (outW.getLimbN 3)
-            (expTwoMulFixedBranchReturnPc bit base)
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            d0' d1' d2' d3'
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
-            frame)
+          (expTwoMulFixedStateStepBranchPre k baseWord exponentWord
+            controlC6 e iterCount ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3 bit
+            v6' v7' v10' v11' d0' d1' d2' d3' base frame)
           Q)
     (hReload :
       ∀ (bit : Bool)
@@ -903,9 +854,7 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_state_step
       hk hCount hBase hNextNext hBound)
     (cpsTripleWithin_expTwoMulFixedIterStepPostNWithControlFrame_state_elim
       (by omega) hCount
-      (fun bit v6' v7' v10' v11' d0' d1' d2' d3' => by
-        simpa only [expTwoMulFixedStateStepBranchPre] using
-          hBranch bit v6' v7' v10' v11' d0' d1' d2' d3')
+      hBranch
       hReload)
 
 /-- Unframed variant of
@@ -932,25 +881,10 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithState_state_step
       ∀ (bit : Bool)
         (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin nSteps (base + 44) exit cr
-          (let outW := expTwoMulFixedBranchResult bit
-            a0 a1 a2 a3 r0 r1 r2 r3
-          expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-            (controlC6 + signExtend12 (-1 : BitVec 12))
-            (e <<< (1 : BitVec 6).toNat)
-            v6'
-            (expTwoMulIterCountNew iterCount)
-            v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            ptr nextLimb sp evmSp
-            (outW.getLimbN 3)
-            (expTwoMulFixedBranchReturnPc bit base)
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            d0' d1' d2' d3'
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
-            empAssertion)
+          (expTwoMulFixedStateStepBranchPre k baseWord exponentWord
+            controlC6 e iterCount ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3 bit
+            v6' v7' v10' v11' d0' d1' d2' d3' base empAssertion)
           Q)
     (hReload :
       ∀ (bit : Bool)
@@ -1041,25 +975,10 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_stepPost_elim_of_co
         (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin nSteps (base + 44) exit
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
-          (let outW := expTwoMulFixedBranchResult bit
-            a0 a1 a2 a3 r0 r1 r2 r3
-          expTwoMulFixedIterPreNWithControlFrame (k + 1) baseWord exponentWord
-            (controlC6 + signExtend12 (-1 : BitVec 12))
-            (e <<< (1 : BitVec 6).toNat)
-            v6'
-            (expTwoMulIterCountNew iterCount)
-            v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            ptr nextLimb sp evmSp
-            (outW.getLimbN 3)
-            (expTwoMulFixedBranchReturnPc bit base)
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            d0' d1' d2' d3'
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
-            frame)
+          (expTwoMulFixedStepPostBranchPre k baseWord exponentWord
+            iterCount e controlC6 ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3 base bit
+            v6' v7' v10' v11' d0' d1' d2' d3' frame)
           Q)
     (hReload :
       ∀ (bit : Bool)
@@ -1083,7 +1002,11 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_stepPost_elim_of_co
     sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
     a0 a1 a2 a3 v7 v11 base hFrame hbase hControlMachine
     (expTwoMulFixedIterCountInvariant_succ_ne_zero_of_lt_255 hk hCount)
-    (by omega) hBase hNextNext hBound hBranch hReload
+    (by omega) hBase hNextNext hBound
+    (fun bit v6' v7' v10' v11' d0' d1' d2' d3' => by
+      simpa only [expTwoMulFixedStepPostBranchPre] using
+        hBranch bit v6' v7' v10' v11' d0' d1' d2' d3')
+    hReload
 
 /-- Unframed variant of
     `cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_stepPost_elim_of_count_bounded`. -/
@@ -1107,25 +1030,10 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithState_stepPost_elim_of_count_b
         (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin nSteps (base + 44) exit
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
-          (let outW := expTwoMulFixedBranchResult bit
-            a0 a1 a2 a3 r0 r1 r2 r3
-          expTwoMulFixedIterPreNWithControlFrame (k + 1) baseWord exponentWord
-            (controlC6 + signExtend12 (-1 : BitVec 12))
-            (e <<< (1 : BitVec 6).toNat)
-            v6'
-            (expTwoMulIterCountNew iterCount)
-            v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            ptr nextLimb sp evmSp
-            (outW.getLimbN 3)
-            (expTwoMulFixedBranchReturnPc bit base)
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            d0' d1' d2' d3'
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
-            empAssertion)
+          (expTwoMulFixedStepPostBranchPre k baseWord exponentWord
+            iterCount e controlC6 ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3 base bit
+            v6' v7' v10' v11' d0' d1' d2' d3' empAssertion)
           Q)
     (hReload :
       ∀ (bit : Bool)

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStep.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStep.lean
@@ -443,7 +443,10 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithControlFrame_stepPost_elim_of_
     a0 a1 a2 a3 v7 v11 base hFrame hbase hControlMachine hne hk
     hBase hNextNext
     (cpsTripleWithin_expTwoMulFixedIterStepPostNWithControlFrame_elim
-      hBranch hReload)
+      (fun bit v6' v7' v10' v11' d0' d1' d2' d3' => by
+        simpa only [expTwoMulFixedStepPostBranchPre] using
+          hBranch bit v6' v7' v10' v11' d0' d1' d2' d3')
+      hReload)
 
 theorem cpsTripleWithin_expTwoMulFixedIterPreNWithControlFrame_stepPost_bit_elim_of_control_eq_machine
     {baseWord exponentWord : EvmWord} {k : Nat}
@@ -538,7 +541,17 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithControlFrame_stepPost_bit_elim
     a0 a1 a2 a3 v7 v11 base hFrame hbase hControlMachine hne hk
     hBase hNextNext
     (cpsTripleWithin_expTwoMulFixedIterStepPostNWithControlFrame_bit_elim
-      hBranchTrue hBranchFalse hReloadTrue hReloadFalse)
+      (fun v6' v7' v10' v11' d0' d1' d2' d3' => by
+        simpa only [expTwoMulFixedStepPostBranchPre,
+          expTwoMulFixedBranchResult_true,
+          expTwoMulFixedBranchReturnPc_true] using
+          hBranchTrue v6' v7' v10' v11' d0' d1' d2' d3')
+      (fun v6' v7' v10' v11' d0' d1' d2' d3' => by
+        simpa only [expTwoMulFixedStepPostBranchPre,
+          expTwoMulFixedBranchResult_false,
+          expTwoMulFixedBranchReturnPc_false] using
+          hBranchFalse v6' v7' v10' v11' d0' d1' d2' d3')
+      hReloadTrue hReloadFalse)
 
 theorem cpsTripleWithin_expTwoMulFixedIterPreNWithFrame_stepPost_elim
     {baseWord exponentWord : EvmWord} {k : Nat}
@@ -850,7 +863,10 @@ theorem cpsTripleWithin_expTwoMulFixedIterPre_stepPostNWithControl_elim
     a0 a1 a2 a3 v7 v11 base hbase hne hk hBase hCursor hControl
     hNextNext hInv
     (cpsTripleWithin_expTwoMulFixedIterStepPostNWithControlFrame_elim
-      hBranch hReload)
+      (fun bit v6' v7' v10' v11' d0' d1' d2' d3' => by
+        simpa only [expTwoMulFixedStepPostBranchPre] using
+          hBranch bit v6' v7' v10' v11' d0' d1' d2' d3')
+      hReload)
 
 theorem cpsTripleWithin_expTwoMulFixedIterPre_stepPostNWithControlFrame_elim
     {baseWord exponentWord : EvmWord} {k : Nat}
@@ -920,7 +936,10 @@ theorem cpsTripleWithin_expTwoMulFixedIterPre_stepPostNWithControlFrame_elim
     a0 a1 a2 a3 v7 v11 base hFrame hbase hne hk hBase hCursor
     hControl hNextNext hInv
     (cpsTripleWithin_expTwoMulFixedIterStepPostNWithControlFrame_elim
-      hBranch hReload)
+      (fun bit v6' v7' v10' v11' d0' d1' d2' d3' => by
+        simpa only [expTwoMulFixedStepPostBranchPre] using
+          hBranch bit v6' v7' v10' v11' d0' d1' d2' d3')
+      hReload)
 
 theorem cpsTripleWithin_expTwoMulFixedIterPre_stepPostNWithControl_bit_elim
     {baseWord exponentWord : EvmWord} {k : Nat}
@@ -1018,7 +1037,17 @@ theorem cpsTripleWithin_expTwoMulFixedIterPre_stepPostNWithControl_bit_elim
     a0 a1 a2 a3 v7 v11 base hbase hne hk hBase hCursor hControl
     hNextNext hInv
     (cpsTripleWithin_expTwoMulFixedIterStepPostNWithControlFrame_bit_elim
-      hBranchTrue hBranchFalse hReloadTrue hReloadFalse)
+      (fun v6' v7' v10' v11' d0' d1' d2' d3' => by
+        simpa only [expTwoMulFixedStepPostBranchPre,
+          expTwoMulFixedBranchResult_true,
+          expTwoMulFixedBranchReturnPc_true] using
+          hBranchTrue v6' v7' v10' v11' d0' d1' d2' d3')
+      (fun v6' v7' v10' v11' d0' d1' d2' d3' => by
+        simpa only [expTwoMulFixedStepPostBranchPre,
+          expTwoMulFixedBranchResult_false,
+          expTwoMulFixedBranchReturnPc_false] using
+          hBranchFalse v6' v7' v10' v11' d0' d1' d2' d3')
+      hReloadTrue hReloadFalse)
 
 theorem cpsTripleWithin_expTwoMulFixedIterPre_stepPostNWithControlFrame_bit_elim
     {baseWord exponentWord : EvmWord} {k : Nat}
@@ -1118,6 +1147,16 @@ theorem cpsTripleWithin_expTwoMulFixedIterPre_stepPostNWithControlFrame_bit_elim
     a0 a1 a2 a3 v7 v11 base hFrame hbase hne hk hBase hCursor
     hControl hNextNext hInv
     (cpsTripleWithin_expTwoMulFixedIterStepPostNWithControlFrame_bit_elim
-      hBranchTrue hBranchFalse hReloadTrue hReloadFalse)
+      (fun v6' v7' v10' v11' d0' d1' d2' d3' => by
+        simpa only [expTwoMulFixedStepPostBranchPre,
+          expTwoMulFixedBranchResult_true,
+          expTwoMulFixedBranchReturnPc_true] using
+          hBranchTrue v6' v7' v10' v11' d0' d1' d2' d3')
+      (fun v6' v7' v10' v11' d0' d1' d2' d3' => by
+        simpa only [expTwoMulFixedStepPostBranchPre,
+          expTwoMulFixedBranchResult_false,
+          expTwoMulFixedBranchReturnPc_false] using
+          hBranchFalse v6' v7' v10' v11' d0' d1' d2' d3')
+      hReloadTrue hReloadFalse)
 
 end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStepPost.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStepPost.lean
@@ -80,6 +80,33 @@ theorem expTwoMulFixedIterStepPostNWithControlFrame_unfold
   delta expTwoMulFixedIterStepPostNWithControlFrame
   rfl
 
+@[irreducible]
+def expTwoMulFixedStepPostBranchPre
+    (k : Nat) (baseWord exponentWord : EvmWord)
+    (iterCount e c6 ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 base : Word)
+    (bit : Bool)
+    (v6 v7 v10 v11 d0 d1 d2 d3 : Word)
+    (frame : Assertion) : Assertion :=
+  let outW := expTwoMulFixedBranchResult bit
+    a0 a1 a2 a3 r0 r1 r2 r3
+  expTwoMulFixedIterPreNWithControlFrame (k + 1) baseWord exponentWord
+    (c6 + signExtend12 (-1 : BitVec 12))
+    (e <<< (1 : BitVec 6).toNat)
+    v6
+    (expTwoMulIterCountNew iterCount)
+    v10
+    ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+    ptr nextLimb sp evmSp
+    (outW.getLimbN 3)
+    (expTwoMulFixedBranchReturnPc bit base)
+    (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
+    (outW.getLimbN 3)
+    d0 d1 d2 d3
+    (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
+    (outW.getLimbN 3)
+    a0 a1 a2 a3 v7 v11 frame
+
 theorem expTwoMulFixedIterStepPostNWithControlFrame_pcFree
     {k : Nat} {baseWord exponentWord : EvmWord}
     {iterCount e c6 ptr nextLimb nextNextLimb sp evmSp
@@ -580,25 +607,10 @@ theorem cpsTripleWithin_expTwoMulFixedIterStepPostNWithControlFrame_elim
       ∀ (bit : Bool)
         (v6 v7 v10 v11 d0 d1 d2 d3 : Word),
         cpsTripleWithin nSteps addr exit cr
-          (let outW := expTwoMulFixedBranchResult bit
-            a0 a1 a2 a3 r0 r1 r2 r3
-          expTwoMulFixedIterPreNWithControlFrame (k + 1) baseWord exponentWord
-            (c6 + signExtend12 (-1 : BitVec 12))
-            (e <<< (1 : BitVec 6).toNat)
-            v6
-            (expTwoMulIterCountNew iterCount)
-            v10
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            ptr nextLimb sp evmSp
-            (outW.getLimbN 3)
-            (expTwoMulFixedBranchReturnPc bit base)
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            d0 d1 d2 d3
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            a0 a1 a2 a3 v7 v11
-            frame)
+          (expTwoMulFixedStepPostBranchPre k baseWord exponentWord
+            iterCount e c6 ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3 base bit
+            v6 v7 v10 v11 d0 d1 d2 d3 frame)
           Q)
     (hReload :
       ∀ (bit : Bool)
@@ -627,7 +639,10 @@ theorem cpsTripleWithin_expTwoMulFixedIterStepPostNWithControlFrame_elim
         hBranch bit v6 v7 v10 v11 d0 d1 d2 d3
           R hR s hcr
           ⟨hp, hcompat,
-            ⟨hStep, hFrame, hdisj, hunion, hNext, hFramePart⟩⟩
+            ⟨hStep, hFrame, hdisj, hunion,
+              (by
+                simpa only [expTwoMulFixedStepPostBranchPre] using hNext),
+              hFramePart⟩⟩
           hpc)
       (fun bit v6 v7 v10 v11 d0 d1 d2 d3 hResidual =>
         hReload bit v6 v7 v10 v11 d0 d1 d2 d3
@@ -646,47 +661,18 @@ theorem cpsTripleWithin_expTwoMulFixedIterStepPostNWithControlFrame_bit_elim
     (hBranchTrue :
       ∀ (v6 v7 v10 v11 d0 d1 d2 d3 : Word),
         cpsTripleWithin nSteps addr exit cr
-          (let rw := expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3)
-            a0 a1 a2 a3
-          expTwoMulFixedIterPreNWithControlFrame (k + 1) baseWord exponentWord
-            (c6 + signExtend12 (-1 : BitVec 12))
-            (e <<< (1 : BitVec 6).toNat)
-            v6
-            (expTwoMulIterCountNew iterCount)
-            v10
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            ptr nextLimb sp evmSp
-            (rw.getLimbN 3)
-            (((base + 44) + 140) + 68)
-            (rw.getLimbN 0) (rw.getLimbN 1) (rw.getLimbN 2)
-            (rw.getLimbN 3)
-            d0 d1 d2 d3
-            (rw.getLimbN 0) (rw.getLimbN 1) (rw.getLimbN 2)
-            (rw.getLimbN 3)
-            a0 a1 a2 a3 v7 v11
-            frame)
+          (expTwoMulFixedStepPostBranchPre k baseWord exponentWord
+            iterCount e c6 ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3 base true
+            v6 v7 v10 v11 d0 d1 d2 d3 frame)
           Q)
     (hBranchFalse :
       ∀ (v6 v7 v10 v11 d0 d1 d2 d3 : Word),
         cpsTripleWithin nSteps addr exit cr
-          (let squareW := expSquaringCallSquareW r0 r1 r2 r3
-          expTwoMulFixedIterPreNWithControlFrame (k + 1) baseWord exponentWord
-            (c6 + signExtend12 (-1 : BitVec 12))
-            (e <<< (1 : BitVec 6).toNat)
-            v6
-            (expTwoMulIterCountNew iterCount)
-            v10
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            ptr nextLimb sp evmSp
-            (squareW.getLimbN 3)
-            (((base + 44) + 32) + 68)
-            (squareW.getLimbN 0) (squareW.getLimbN 1)
-            (squareW.getLimbN 2) (squareW.getLimbN 3)
-            d0 d1 d2 d3
-            (squareW.getLimbN 0) (squareW.getLimbN 1)
-            (squareW.getLimbN 2) (squareW.getLimbN 3)
-            a0 a1 a2 a3 v7 v11
-            frame)
+          (expTwoMulFixedStepPostBranchPre k baseWord exponentWord
+            iterCount e c6 ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3 base false
+            v6 v7 v10 v11 d0 d1 d2 d3 frame)
           Q)
     (hReloadTrue :
       ∀ (v6 v7 v10 v11 d0 d1 d2 d3 : Word),
@@ -712,11 +698,9 @@ theorem cpsTripleWithin_expTwoMulFixedIterStepPostNWithControlFrame_bit_elim
   cpsTripleWithin_expTwoMulFixedIterStepPostNWithControlFrame_elim
     (fun bit v6 v7 v10 v11 d0 d1 d2 d3 => by
       cases bit
-      · simpa [expTwoMulFixedBranchResult_false,
-          expTwoMulFixedBranchReturnPc_false] using
+      · simpa only using
           hBranchFalse v6 v7 v10 v11 d0 d1 d2 d3
-      · simpa [expTwoMulFixedBranchResult_true,
-          expTwoMulFixedBranchReturnPc_true] using
+      · simpa only using
           hBranchTrue v6 v7 v10 v11 d0 d1 d2 d3)
     (fun bit v6 v7 v10 v11 d0 d1 d2 d3 => by
       cases bit
@@ -850,25 +834,10 @@ theorem cpsTripleWithin_expTwoMulFixedIterCaseLoopPost_stepPostNWithControlFrame
       ∀ (bit : Bool)
         (v6 v7 v10 v11 d0 d1 d2 d3 : Word),
         cpsTripleWithin nSteps addr exit cr
-          (let outW := expTwoMulFixedBranchResult bit
-            a0 a1 a2 a3 r0 r1 r2 r3
-          expTwoMulFixedIterPreNWithControlFrame (k + 1) baseWord exponentWord
-            (c6 + signExtend12 (-1 : BitVec 12))
-            (e <<< (1 : BitVec 6).toNat)
-            v6
-            (expTwoMulIterCountNew iterCount)
-            v10
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            ptr nextLimb sp evmSp
-            (outW.getLimbN 3)
-            (expTwoMulFixedBranchReturnPc bit base)
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            d0 d1 d2 d3
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            a0 a1 a2 a3 v7 v11
-            frame)
+          (expTwoMulFixedStepPostBranchPre k baseWord exponentWord
+            iterCount e c6 ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3 base bit
+            v6 v7 v10 v11 d0 d1 d2 d3 frame)
           Q)
     (hReload :
       ∀ (bit : Bool)
@@ -911,47 +880,18 @@ theorem cpsTripleWithin_expTwoMulFixedIterCaseLoopPost_stepPostNWithControlFrame
     (hBranchTrue :
       ∀ (v6 v7 v10 v11 d0 d1 d2 d3 : Word),
         cpsTripleWithin nSteps addr exit cr
-          (let rw := expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3)
-            a0 a1 a2 a3
-          expTwoMulFixedIterPreNWithControlFrame (k + 1) baseWord exponentWord
-            (c6 + signExtend12 (-1 : BitVec 12))
-            (e <<< (1 : BitVec 6).toNat)
-            v6
-            (expTwoMulIterCountNew iterCount)
-            v10
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            ptr nextLimb sp evmSp
-            (rw.getLimbN 3)
-            (((base + 44) + 140) + 68)
-            (rw.getLimbN 0) (rw.getLimbN 1) (rw.getLimbN 2)
-            (rw.getLimbN 3)
-            d0 d1 d2 d3
-            (rw.getLimbN 0) (rw.getLimbN 1) (rw.getLimbN 2)
-            (rw.getLimbN 3)
-            a0 a1 a2 a3 v7 v11
-            frame)
+          (expTwoMulFixedStepPostBranchPre k baseWord exponentWord
+            iterCount e c6 ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3 base true
+            v6 v7 v10 v11 d0 d1 d2 d3 frame)
           Q)
     (hBranchFalse :
       ∀ (v6 v7 v10 v11 d0 d1 d2 d3 : Word),
         cpsTripleWithin nSteps addr exit cr
-          (let squareW := expSquaringCallSquareW r0 r1 r2 r3
-          expTwoMulFixedIterPreNWithControlFrame (k + 1) baseWord exponentWord
-            (c6 + signExtend12 (-1 : BitVec 12))
-            (e <<< (1 : BitVec 6).toNat)
-            v6
-            (expTwoMulIterCountNew iterCount)
-            v10
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            ptr nextLimb sp evmSp
-            (squareW.getLimbN 3)
-            (((base + 44) + 32) + 68)
-            (squareW.getLimbN 0) (squareW.getLimbN 1)
-            (squareW.getLimbN 2) (squareW.getLimbN 3)
-            d0 d1 d2 d3
-            (squareW.getLimbN 0) (squareW.getLimbN 1)
-            (squareW.getLimbN 2) (squareW.getLimbN 3)
-            a0 a1 a2 a3 v7 v11
-            frame)
+          (expTwoMulFixedStepPostBranchPre k baseWord exponentWord
+            iterCount e c6 ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3 base false
+            v6 v7 v10 v11 d0 d1 d2 d3 frame)
           Q)
     (hReloadTrue :
       ∀ (v6 v7 v10 v11 d0 d1 d2 d3 : Word),


### PR DESCRIPTION
## Summary
- add an irreducible precondition wrapper for the EXP state-step branch continuation
- route the state-step and state-loop adapters through the wrapper to hide long let chains

## Verification
- lake build EvmAsm.Evm64.Exp
- git diff --check origin/feat/exp-hide-state-loop-branch-surface...HEAD