### PR TITLE
refactor(exp): hide state-loop branch cps surface

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoop.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoop.lean
@@ -51,6 +51,47 @@ def expTwoMulFixedStateBranchPre
     (outW.getLimbN 3)
     a0 a1 a2 a3 v7' v11' frame
 
+@[irreducible]
+def expTwoMulFixedStateReloadFalsePre
+    (k : Nat) (baseWord exponentWord : EvmWord)
+    (e iterCount nextLimb ptr nextNextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 : Word)
+    (v6' v7' v10' v11' d0' d1' d2' d3' : Word)
+    (base : Word) (frame : Assertion) : Assertion :=
+  let squareW := expSquaringCallSquareW r0 r1 r2 r3
+  expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
+    64 nextLimb v6' (expTwoMulIterCountNew iterCount) v10'
+    ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+    (ptr + signExtend12 (-8 : BitVec 12)) nextNextLimb sp evmSp
+    (squareW.getLimbN 3) (((base + 44) + 32) + 68)
+    (squareW.getLimbN 0) (squareW.getLimbN 1)
+    (squareW.getLimbN 2) (squareW.getLimbN 3)
+    d0' d1' d2' d3'
+    (squareW.getLimbN 0) (squareW.getLimbN 1)
+    (squareW.getLimbN 2) (squareW.getLimbN 3)
+    a0 a1 a2 a3 v7' v11' frame
+
+@[irreducible]
+def expTwoMulFixedStateReloadTruePre
+    (k : Nat) (baseWord exponentWord : EvmWord)
+    (e iterCount nextLimb ptr nextNextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 : Word)
+    (v6' v7' v10' v11' d0' d1' d2' d3' : Word)
+    (base : Word) (frame : Assertion) : Assertion :=
+  let rw := expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3)
+    a0 a1 a2 a3
+  expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
+    64 nextLimb v6' (expTwoMulIterCountNew iterCount) v10'
+    ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+    (ptr + signExtend12 (-8 : BitVec 12)) nextNextLimb sp evmSp
+    (rw.getLimbN 3) (((base + 44) + 140) + 68)
+    (rw.getLimbN 0) (rw.getLimbN 1)
+    (rw.getLimbN 2) (rw.getLimbN 3)
+    d0' d1' d2' d3'
+    (rw.getLimbN 0) (rw.getLimbN 1)
+    (rw.getLimbN 2) (rw.getLimbN 3)
+    a0 a1 a2 a3 v7' v11' frame
+
 /-- Named-bound one-step wrapper for the fixed-loop induction.
 
     This specializes
@@ -385,21 +426,13 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_state_step_reloadDi
           Q)
     (hReloadFalse :
       ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
-        let squareW := expSquaringCallSquareW r0 r1 r2 r3
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) exit
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
-          (expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-            64 nextLimb v6' (expTwoMulIterCountNew iterCount) v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            (ptr + signExtend12 (-8 : BitVec 12)) nextNextLimb sp evmSp
-            (squareW.getLimbN 3) (((base + 44) + 32) + 68)
-            (squareW.getLimbN 0) (squareW.getLimbN 1)
-            (squareW.getLimbN 2) (squareW.getLimbN 3)
-            d0' d1' d2' d3'
-            (squareW.getLimbN 0) (squareW.getLimbN 1)
-            (squareW.getLimbN 2) (squareW.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
+          (expTwoMulFixedStateReloadFalsePre k baseWord exponentWord
+            e iterCount nextLimb ptr nextNextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3
+            v6' v7' v10' v11' d0' d1' d2' d3' base
             (((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
               ⌜expTwoMulIterCountNew iterCount ≠ 0⌝ **
               ⌜controlC6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
@@ -409,22 +442,13 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_state_step_reloadDi
           Q)
     (hReloadTrue :
       ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
-        let rw := expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3)
-          a0 a1 a2 a3
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) exit
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
-          (expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-            64 nextLimb v6' (expTwoMulIterCountNew iterCount) v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            (ptr + signExtend12 (-8 : BitVec 12)) nextNextLimb sp evmSp
-            (rw.getLimbN 3) (((base + 44) + 140) + 68)
-            (rw.getLimbN 0) (rw.getLimbN 1)
-            (rw.getLimbN 2) (rw.getLimbN 3)
-            d0' d1' d2' d3'
-            (rw.getLimbN 0) (rw.getLimbN 1)
-            (rw.getLimbN 2) (rw.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
+          (expTwoMulFixedStateReloadTruePre k baseWord exponentWord
+            e iterCount nextLimb ptr nextNextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3
+            v6' v7' v10' v11' d0' d1' d2' d3' base
             (((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
               ⌜expTwoMulIterCountNew iterCount ≠ 0⌝ **
               ⌜controlC6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
@@ -460,10 +484,14 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_state_step_reloadDi
         cases bit
         · exact
             cpsTripleWithin_expTwoMulFixedReloadBranchResidualWithStateFrame_false_to_iterPreNWithStateFrame
-              (hReloadFalse v6' v7' v10' v11' d0' d1' d2' d3')
+              (by
+                simpa only [expTwoMulFixedStateReloadFalsePre] using
+                  hReloadFalse v6' v7' v10' v11' d0' d1' d2' d3')
         · exact
             cpsTripleWithin_expTwoMulFixedReloadBranchResidualWithStateFrame_true_to_iterPreNWithStateFrame
-              (hReloadTrue v6' v7' v10' v11' d0' d1' d2' d3'))
+              (by
+                simpa only [expTwoMulFixedStateReloadTruePre] using
+                  hReloadTrue v6' v7' v10' v11' d0' d1' d2' d3'))
 
 /-- Final fixed-loop state-frame wrapper.
 

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoop.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoop.lean
@@ -24,6 +24,33 @@ private theorem pure_assertion_eq_emp_of_true {p : Prop} (hp : p) :
   · intro h
     exact ⟨h.1, hp⟩
 
+@[irreducible]
+def expTwoMulFixedStateBranchPre
+    (k : Nat) (baseWord exponentWord : EvmWord)
+    (controlC6 e iterCount ptr nextLimb sp evmSp
+      r0 r1 r2 r3 a0 a1 a2 a3 : Word)
+    (bit : Bool)
+    (v6' v7' v10' v11' d0' d1' d2' d3' : Word)
+    (base : Word) (frame : Assertion) : Assertion :=
+  let outW := expTwoMulFixedBranchResult bit
+    a0 a1 a2 a3 r0 r1 r2 r3
+  expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
+    (controlC6 + signExtend12 (-1 : BitVec 12))
+    (e <<< (1 : BitVec 6).toNat)
+    v6'
+    (expTwoMulIterCountNew iterCount)
+    v10'
+    ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
+    ptr nextLimb sp evmSp
+    (outW.getLimbN 3)
+    (expTwoMulFixedBranchReturnPc bit base)
+    (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
+    (outW.getLimbN 3)
+    d0' d1' d2' d3'
+    (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
+    (outW.getLimbN 3)
+    a0 a1 a2 a3 v7' v11' frame
+
 /-- Named-bound one-step wrapper for the fixed-loop induction.
 
     This specializes
@@ -52,25 +79,10 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_state_step_fixedBou
       ∀ (bit : Bool)
         (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin nSteps (base + 44) exit cr
-          (let outW := expTwoMulFixedBranchResult bit
-            a0 a1 a2 a3 r0 r1 r2 r3
-          expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-            (controlC6 + signExtend12 (-1 : BitVec 12))
-            (e <<< (1 : BitVec 6).toNat)
-            v6'
-            (expTwoMulIterCountNew iterCount)
-            v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            ptr nextLimb sp evmSp
-            (outW.getLimbN 3)
-            (expTwoMulFixedBranchReturnPc bit base)
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            d0' d1' d2' d3'
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
-            frame)
+          (expTwoMulFixedStateBranchPre k baseWord exponentWord
+            controlC6 e iterCount ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3 bit
+            v6' v7' v10' v11' d0' d1' d2' d3' base frame)
           Q)
     (hReload :
       ∀ (bit : Bool)
@@ -95,7 +107,10 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_state_step_fixedBou
     a0 a1 a2 a3 v7 v11 base frame Q hDisjoint hFrame hbase
     hControlMachine hk hCount hBase hNextNext
     (by rw [expTwoMulFixedReloadIterStepBound_eq])
-    hBranch hReload
+    (fun bit v6' v7' v10' v11' d0' d1' d2' d3' => by
+      simpa only [expTwoMulFixedStateBranchPre] using
+        hBranch bit v6' v7' v10' v11' d0' d1' d2' d3')
+    hReload
 
 /-- Same-code one-step wrapper for the fixed-loop induction.
 
@@ -126,25 +141,10 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_state_step_sameCode
         (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin nSteps (base + 44) exit
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
-          (let outW := expTwoMulFixedBranchResult bit
-            a0 a1 a2 a3 r0 r1 r2 r3
-          expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-            (controlC6 + signExtend12 (-1 : BitVec 12))
-            (e <<< (1 : BitVec 6).toNat)
-            v6'
-            (expTwoMulIterCountNew iterCount)
-            v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            ptr nextLimb sp evmSp
-            (outW.getLimbN 3)
-            (expTwoMulFixedBranchReturnPc bit base)
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            d0' d1' d2' d3'
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
-            frame)
+          (expTwoMulFixedStateBranchPre k baseWord exponentWord
+            controlC6 e iterCount ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3 bit
+            v6' v7' v10' v11' d0' d1' d2' d3' base frame)
           Q)
     (hReload :
       ∀ (bit : Bool)
@@ -170,7 +170,11 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_state_step_sameCode
       a0 a1 a2 a3 v7 v11 base frame hFrame hbase hControlMachine
       hk hCount hBase hNextNext hBound)
     (cpsTripleWithin_expTwoMulFixedIterStepPostNWithControlFrame_state_elim
-      (by omega) hCount hBranch hReload)
+      (by omega) hCount
+      (fun bit v6' v7' v10' v11' d0' d1' d2' d3' => by
+        simpa only [expTwoMulFixedStateBranchPre] using
+          hBranch bit v6' v7' v10' v11' d0' d1' d2' d3')
+      hReload)
 
 /-- Fixed-bound same-code state step for the recursive loop induction. -/
 theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_state_step_fixedBound_sameCode
@@ -194,25 +198,10 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_state_step_fixedBou
         (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin nSteps (base + 44) exit
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
-          (let outW := expTwoMulFixedBranchResult bit
-            a0 a1 a2 a3 r0 r1 r2 r3
-          expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-            (controlC6 + signExtend12 (-1 : BitVec 12))
-            (e <<< (1 : BitVec 6).toNat)
-            v6'
-            (expTwoMulIterCountNew iterCount)
-            v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            ptr nextLimb sp evmSp
-            (outW.getLimbN 3)
-            (expTwoMulFixedBranchReturnPc bit base)
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            d0' d1' d2' d3'
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
-            frame)
+          (expTwoMulFixedStateBranchPre k baseWord exponentWord
+            controlC6 e iterCount ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3 bit
+            v6' v7' v10' v11' d0' d1' d2' d3' base frame)
           Q)
     (hReload :
       ∀ (bit : Bool)
@@ -268,25 +257,10 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_state_step_iteratio
         (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) exit cr
-          (let outW := expTwoMulFixedBranchResult bit
-            a0 a1 a2 a3 r0 r1 r2 r3
-          expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-            (controlC6 + signExtend12 (-1 : BitVec 12))
-            (e <<< (1 : BitVec 6).toNat)
-            v6'
-            (expTwoMulIterCountNew iterCount)
-            v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            ptr nextLimb sp evmSp
-            (outW.getLimbN 3)
-            (expTwoMulFixedBranchReturnPc bit base)
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            d0' d1' d2' d3'
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
-            frame)
+          (expTwoMulFixedStateBranchPre k baseWord exponentWord
+            controlC6 e iterCount ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3 bit
+            v6' v7' v10' v11' d0' d1' d2' d3' base frame)
           Q)
     (hReload :
       ∀ (bit : Bool)
@@ -340,25 +314,10 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_state_step_iteratio
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) exit
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
-          (let outW := expTwoMulFixedBranchResult bit
-            a0 a1 a2 a3 r0 r1 r2 r3
-          expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-            (controlC6 + signExtend12 (-1 : BitVec 12))
-            (e <<< (1 : BitVec 6).toNat)
-            v6'
-            (expTwoMulIterCountNew iterCount)
-            v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            ptr nextLimb sp evmSp
-            (outW.getLimbN 3)
-            (expTwoMulFixedBranchReturnPc bit base)
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            d0' d1' d2' d3'
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
-            frame)
+          (expTwoMulFixedStateBranchPre k baseWord exponentWord
+            controlC6 e iterCount ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3 bit
+            v6' v7' v10' v11' d0' d1' d2' d3' base frame)
           Q)
     (hReload :
       ∀ (bit : Bool)
@@ -510,7 +469,9 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_state_step_reloadDi
       (((ptr + signExtend12 (-8 : BitVec 12)) +
         signExtend12 (0 : BitVec 12) ↦ₘ nextNextLimb) ** frame)
       Q hFrameCurrent hbase hControlMachine hk hCount hBase hNextNext
-      hBranch
+      (fun bit v6' v7' v10' v11' d0' d1' d2' d3' => by
+        simpa only [expTwoMulFixedStateBranchPre] using
+          hBranch bit v6' v7' v10' v11' d0' d1' d2' d3')
       (fun bit v6' v7' v10' v11' d0' d1' d2' d3' => by
         cases bit
         · exact
@@ -667,7 +628,10 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_iterationsBoun
         sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
         a0 a1 a2 a3 v7 v11 base frame (Q ** frame) hFrame hbase
         hControlMachine hk_lt hState.2.2.2 hBase hNextNext
-        (hBranch hk_lt) (hReload hk_lt)
+        (fun bit v6' v7' v10' v11' d0' d1' d2' d3' => by
+          simpa only [expTwoMulFixedStateBranchPre] using
+            hBranch hk_lt bit v6' v7' v10' v11' d0' d1' d2' d3')
+        (hReload hk_lt)
   · subst k
     exact
       cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_final_iterationsBound

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoop.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoop.lean
@@ -376,24 +376,10 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_state_step_reloadDi
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) exit
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
-          (let outW := expTwoMulFixedBranchResult bit
-            a0 a1 a2 a3 r0 r1 r2 r3
-          expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-            (controlC6 + signExtend12 (-1 : BitVec 12))
-            (e <<< (1 : BitVec 6).toNat)
-            v6'
-            (expTwoMulIterCountNew iterCount)
-            v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            ptr nextLimb sp evmSp
-            (outW.getLimbN 3)
-            (expTwoMulFixedBranchReturnPc bit base)
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            d0' d1' d2' d3'
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
+          (expTwoMulFixedStateBranchPre k baseWord exponentWord
+            controlC6 e iterCount ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3 bit
+            v6' v7' v10' v11' d0' d1' d2' d3' base
             ((((ptr + signExtend12 (-8 : BitVec 12)) +
               signExtend12 (0 : BitVec 12)) ↦ₘ nextNextLimb) ** frame))
           Q)
@@ -469,9 +455,7 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_state_step_reloadDi
       (((ptr + signExtend12 (-8 : BitVec 12)) +
         signExtend12 (0 : BitVec 12) ↦ₘ nextNextLimb) ** frame)
       Q hFrameCurrent hbase hControlMachine hk hCount hBase hNextNext
-      (fun bit v6' v7' v10' v11' d0' d1' d2' d3' => by
-        simpa only [expTwoMulFixedStateBranchPre] using
-          hBranch bit v6' v7' v10' v11' d0' d1' d2' d3')
+      hBranch
       (fun bit v6' v7' v10' v11' d0' d1' d2' d3' => by
         cases bit
         · exact
@@ -574,25 +558,10 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_iterationsBoun
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
-          (let outW := expTwoMulFixedBranchResult bit
-            a0 a1 a2 a3 r0 r1 r2 r3
-          expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-            (controlC6 + signExtend12 (-1 : BitVec 12))
-            (e <<< (1 : BitVec 6).toNat)
-            v6'
-            (expTwoMulIterCountNew iterCount)
-            v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            ptr nextLimb sp evmSp
-            (outW.getLimbN 3)
-            (expTwoMulFixedBranchReturnPc bit base)
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            d0' d1' d2' d3'
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
-            frame)
+          (expTwoMulFixedStateBranchPre k baseWord exponentWord
+            controlC6 e iterCount ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3 bit
+            v6' v7' v10' v11' d0' d1' d2' d3' base frame)
           (Q ** frame))
     (hReload :
       k < 255 →
@@ -628,9 +597,7 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_iterationsBoun
         sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
         a0 a1 a2 a3 v7 v11 base frame (Q ** frame) hFrame hbase
         hControlMachine hk_lt hState.2.2.2 hBase hNextNext
-        (fun bit v6' v7' v10' v11' d0' d1' d2' d3' => by
-          simpa only [expTwoMulFixedStateBranchPre] using
-            hBranch hk_lt bit v6' v7' v10' v11' d0' d1' d2' d3')
+        (hBranch hk_lt)
         (hReload hk_lt)
   · subst k
     exact
@@ -667,25 +634,10 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_iterationsBoun
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
-          (let outW := expTwoMulFixedBranchResult bit
-            a0 a1 a2 a3 r0 r1 r2 r3
-          expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-            (controlC6 + signExtend12 (-1 : BitVec 12))
-            (e <<< (1 : BitVec 6).toNat)
-            v6'
-            (expTwoMulIterCountNew iterCount)
-            v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            ptr nextLimb sp evmSp
-            (outW.getLimbN 3)
-            (expTwoMulFixedBranchReturnPc bit base)
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            d0' d1' d2' d3'
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
-            frame)
+          (expTwoMulFixedStateBranchPre k baseWord exponentWord
+            controlC6 e iterCount ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3 bit
+            v6' v7' v10' v11' d0' d1' d2' d3' base frame)
           (Q ** frame))
     (hReload :
       k < 255 →
@@ -751,25 +703,10 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithState_head_iterationsBound_sam
         cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
           (base + 44) (base + 296)
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
-          (let outW := expTwoMulFixedBranchResult bit
-            a0 a1 a2 a3 r0 r1 r2 r3
-          expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-            (controlC6 + signExtend12 (-1 : BitVec 12))
-            (e <<< (1 : BitVec 6).toNat)
-            v6'
-            (expTwoMulIterCountNew iterCount)
-            v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            ptr nextLimb sp evmSp
-            (outW.getLimbN 3)
-            (expTwoMulFixedBranchReturnPc bit base)
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            d0' d1' d2' d3'
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
-            empAssertion)
+          (expTwoMulFixedStateBranchPre k baseWord exponentWord
+            controlC6 e iterCount ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3 bit
+            v6' v7' v10' v11' d0' d1' d2' d3' base empAssertion)
           Q)
     (hReload :
       k < 255 →

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoopDirect.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoopDirect.lean
@@ -182,7 +182,7 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_f
         signExtend12 (0 : BitVec 12) ↦ₘ nextNextLimb) ** frame)
       Q hFrameCurrent hbase hControlMachine hk hBase hNextNext
       (fun hk_lt bit v6' v7' v10' v11' d0' d1' d2' d3' => by
-        simpa only [expReloadDirectBranchPre] using
+        simpa only [expReloadDirectBranchPre, expTwoMulFixedStateBranchPre] using
           hBranch hk_lt bit v6' v7' v10' v11' d0' d1' d2' d3')
       (fun hk_lt bit v6' v7' v10' v11' d0' d1' d2' d3' => by
         cases bit

--- a/docs/pr-summary-progress-prompt.md
+++ b/docs/pr-summary-progress-prompt.md
@@ -1,0 +1,95 @@
+<!--
+  Project-specific instructions appended to the PR-summary LLM context
+  via `additional_instructions_path` in `lean-summary-workflow`. Fed
+  into the workflow alongside `CONTRIBUTING.md` and the computed
+  progress delta produced by `scripts/progress-delta.sh`.
+
+  Keep this file project-specific. Generic LLM guidance lives upstream
+  in the workflow's prompt templates.
+-->
+
+# Progress-assessment instructions for the PR-summary agent
+
+evm-asm tracks per-PR progress against a kernel-checked registry
+(`EvmAsm/Progress.lean`) rendered to `PROGRESS.md`. The deployment
+pre-step has already computed a deterministic delta and inserted it
+above under "Computed progress delta for this PR". Use those numbers
+verbatim — do not recompute or infer them from the diff.
+
+## Output shape
+
+Emit a top-level section titled exactly `## Progress assessment` at
+the **end** of the PR summary. The section is short, factual, and
+narrates what the computed delta means in the project's vocabulary.
+
+If the computed delta shows no count changes and no tier transitions,
+write exactly:
+
+    ## Progress assessment
+
+    Metric-neutral PR (no tier transitions, no count deltas).
+
+Otherwise, include up to four bullets covering:
+
+- **Tier transitions**: list every transition from the computed delta
+  verbatim (e.g. `SDIV: partial → proven`). Do not invent or filter.
+- **Count deltas**: cite only counts that changed; omit unchanged
+  ones. Keep them as numbers, not adjectives ("provenCount +2", not
+  "significant progress").
+- **Drift risks**: if the diff adds an `evm_<name>_stack_spec_within`
+  theorem but the registry change does not mention a matching
+  `_<name>_witness` abbrev in `EvmAsm/Progress.lean`, flag it as a
+  drift risk. The deterministic gate in `scripts/check-progress.sh`
+  catches `PROGRESS.md` drift, but theorem-without-witness is a
+  registry-completeness issue the gate does not catch.
+- **Obligation mapping**: when a tier transition advances one of the
+  9 guest-program obligations from `PROGRESS.md` ("Role in the
+  L1-zkEVM stack" section), say so explicitly (e.g.
+  `Advances obligation #5: full opcode coverage`). At most one
+  obligation per bullet.
+
+## What NOT to do
+
+- **Do not recompute counts** from the diff. The numbers above are
+  derived from the kernel-checked registry and are authoritative.
+- **Do not editorialize** ("major step forward", "significant
+  improvement", "well done"). Stay factual.
+- **Do not duplicate** the existing `Mathematical Formalization` /
+  `Proof Completion (sorries removed)` / `Infrastructure` sections
+  the workflow already produces. The Progress assessment is a
+  *quantitative* commentary on top of those.
+- **Do not flag tier downgrades** as failures. A `proven` → `partial`
+  transition might mean a generalization is in progress and the
+  spec has been deliberately weakened. State the transition;
+  don't judge it.
+- **Do not invent obligation mappings.** If you cannot point at a
+  specific obligation number from `PROGRESS.md` for a given change,
+  skip the mapping. False mappings are worse than no mapping.
+
+## Vocabulary reference
+
+These terms appear in the project and the registry; use them
+consistently:
+
+- `proven` / `partial` / `execSpec` / `notStarted` — the four
+  `ProofTier` values defined in `EvmAsm/Progress.lean`.
+- `cpsTripleWithin N` — bounded Hoare triple over a verified RV64
+  step count of at most `N`.
+- `EvmWord` — `BitVec 256`; 4-limb 64-bit representation in RV64.
+- `stack spec` — top-level Hoare triple over the EVM stack
+  (precondition: stack pointer + EvmWord operands; postcondition:
+  stack pointer advanced + EvmWord result).
+- `witness abbrev` — the `_<lower>_witness := @<theorem>` declarations
+  in `EvmAsm/Progress.lean` that fail elaboration if a referenced
+  theorem is renamed or deleted.
+- `guest program` — in this project, the RV64 ELF that runs inside an
+  L1 zkVM and validates a block + execution witness (see
+  `PROGRESS.md` for the 9-item obligation list).
+
+## When to keep the section short
+
+If the PR is a refactor, a doc edit, a test addition, an
+infrastructure change, or any other change that does not move any
+metric or tier, write the metric-neutral one-liner. Do not pad.
+Reviewers read silence as "this PR is not about progress" — that's
+the correct signal.

--- a/scripts/progress-delta.sh
+++ b/scripts/progress-delta.sh
@@ -1,0 +1,282 @@
+#!/usr/bin/env bash
+#
+# progress-delta.sh — deterministic PR-level progress delta.
+#
+# Reads PROGRESS.md at two commits (base + head), parses the
+# kernel-checked count tables and per-opcode tier table, emits a
+# structured Markdown block to stdout suitable for splicing into the
+# augmented-instructions file consumed by the AI PR-summary workflow.
+#
+# No LLM. No mutation. Pure git + awk.
+#
+# Usage:
+#   scripts/progress-delta.sh <base-sha> <head-sha>
+#
+# Typical CI invocation (see .github/workflows/summary.yml):
+#   scripts/progress-delta.sh \
+#       "${{ github.event.pull_request.base.sha }}" \
+#       "${{ github.event.pull_request.head.sha }}"
+#
+# Exit codes:
+#   0 — emitted a delta block (possibly "metric-neutral").
+#   1 — git access error or PROGRESS.md missing on one side.
+#
+# Idempotent: re-running on the same pair of SHAs produces identical
+# output. PROGRESS.md drift is enforced separately by
+# scripts/check-progress.sh, so the inputs here are trustworthy.
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "usage: $0 <base-sha> <head-sha>" >&2
+  exit 2
+fi
+
+BASE="$1"
+HEAD="$2"
+
+cd "$(dirname "$0")/.."
+
+# --------------------------------------------------------------------
+# Fetch both versions of PROGRESS.md. If either side is missing the
+# file (e.g. this PR is the one introducing PROGRESS.md), fall back
+# gracefully — emit a block that flags the introduction event.
+# --------------------------------------------------------------------
+
+TMP_BASE="$(mktemp)"
+TMP_HEAD="$(mktemp)"
+trap 'rm -f "$TMP_BASE" "$TMP_HEAD"' EXIT
+
+if ! git show "${BASE}:PROGRESS.md" > "$TMP_BASE" 2>/dev/null; then
+  : > "$TMP_BASE"
+  BASE_MISSING=1
+else
+  BASE_MISSING=0
+fi
+
+if ! git show "${HEAD}:PROGRESS.md" > "$TMP_HEAD" 2>/dev/null; then
+  : > "$TMP_HEAD"
+  HEAD_MISSING=1
+else
+  HEAD_MISSING=0
+fi
+
+# --------------------------------------------------------------------
+# Helpers — extract a single named count from a PROGRESS.md.
+# The exe (`lake exe progress-report`) renders count lines like:
+#     | ✅ proven      | 43 |
+# We grep the icon + label and pull the trailing integer.
+# --------------------------------------------------------------------
+
+count_field() {
+  local file="$1"
+  local label="$2"   # e.g. "proven", "partial", "execSpec", "notStarted"
+  awk -v lbl="$label" '
+    $0 ~ ("\\| (✅|🟡|⏳|✗) " lbl " *\\|") {
+      # The integer is the last pipe-separated cell on this line.
+      n = split($0, cells, "|")
+      gsub(/ /, "", cells[n-1])
+      print cells[n-1]
+      exit
+    }
+  ' "$file"
+}
+
+bytes_field() {
+  # Distinguish entry-count tables from byte-count tables by looking at
+  # the nearest preceding section header. We rely on the rendered order:
+  # the entry-count table comes first, the byte-count table second.
+  # We pick the second occurrence by `awk` counting.
+  local file="$1"
+  local label="$2"
+  awk -v lbl="$label" '
+    /^By \*\*opcode byte\*\*/ { in_bytes = 1 }
+    in_bytes && $0 ~ ("\\| (✅|🟡|⏳|✗) " lbl " *\\|") {
+      n = split($0, cells, "|")
+      gsub(/ /, "", cells[n-1])
+      print cells[n-1]
+      exit
+    }
+  ' "$file"
+}
+
+conformance_count() {
+  local file="$1"
+  awk '
+    /Conformance vectors .* allConformanceVectors_length/ {
+      n = split($0, cells, "|")
+      gsub(/ /, "", cells[n-1])
+      print cells[n-1]
+      exit
+    }
+  ' "$file"
+}
+
+sorry_field() {
+  local file="$1"
+  awk '
+    /sorry. count in/ {
+      n = split($0, cells, "|")
+      gsub(/ /, "", cells[n-1])
+      print cells[n-1]
+      exit
+    }
+  ' "$file"
+}
+
+axiom_field() {
+  local file="$1"
+  awk '
+    /axiom. count in/ {
+      n = split($0, cells, "|")
+      gsub(/ /, "", cells[n-1])
+      print cells[n-1]
+      exit
+    }
+  ' "$file"
+}
+
+# --------------------------------------------------------------------
+# Per-opcode tier table — extract rows of the form:
+#   | <icon> <NAME> | <tier> | `<witness>` | <notes> |
+# Output as: NAME<TAB>TIER per line.
+# --------------------------------------------------------------------
+
+opcode_tiers() {
+  local file="$1"
+  awk '
+    BEGIN { in_table = 0 }
+    /^### Per-opcode registry/ { in_table = 1; next }
+    in_table && /^\| (✅|🟡|⏳|✗) / {
+      # Strip the leading icon, then split.
+      sub(/^\| (✅|🟡|⏳|✗) /, "| ", $0)
+      n = split($0, cells, "|")
+      # cells[2] = name, cells[3] = tier
+      name = cells[2]; gsub(/^ +| +$/, "", name)
+      tier = cells[3]; gsub(/^ +| +$/, "", tier)
+      print name "\t" tier
+    }
+    in_table && /^## / { in_table = 0 }
+  ' "$file"
+}
+
+# --------------------------------------------------------------------
+# Compose the delta
+# --------------------------------------------------------------------
+
+# Pulls — base then head — for each tracked scalar.
+B_PROVEN="$(count_field "$TMP_BASE" "proven" 2>/dev/null || echo "")"
+B_PARTIAL="$(count_field "$TMP_BASE" "partial" 2>/dev/null || echo "")"
+B_EXECSPEC="$(count_field "$TMP_BASE" "execSpec" 2>/dev/null || echo "")"
+B_NOTSTARTED="$(count_field "$TMP_BASE" "notStarted" 2>/dev/null || echo "")"
+
+H_PROVEN="$(count_field "$TMP_HEAD" "proven" 2>/dev/null || echo "")"
+H_PARTIAL="$(count_field "$TMP_HEAD" "partial" 2>/dev/null || echo "")"
+H_EXECSPEC="$(count_field "$TMP_HEAD" "execSpec" 2>/dev/null || echo "")"
+H_NOTSTARTED="$(count_field "$TMP_HEAD" "notStarted" 2>/dev/null || echo "")"
+
+B_BYTES_PROVEN="$(bytes_field "$TMP_BASE" "proven" 2>/dev/null || echo "")"
+H_BYTES_PROVEN="$(bytes_field "$TMP_HEAD" "proven" 2>/dev/null || echo "")"
+
+B_CONF="$(conformance_count "$TMP_BASE" 2>/dev/null || echo "")"
+H_CONF="$(conformance_count "$TMP_HEAD" 2>/dev/null || echo "")"
+
+B_SORRY="$(sorry_field "$TMP_BASE" 2>/dev/null || echo "")"
+H_SORRY="$(sorry_field "$TMP_HEAD" 2>/dev/null || echo "")"
+
+B_AXIOM="$(axiom_field "$TMP_BASE" 2>/dev/null || echo "")"
+H_AXIOM="$(axiom_field "$TMP_HEAD" 2>/dev/null || echo "")"
+
+# Per-opcode transitions: compare BASE→HEAD tier per opcode name.
+TIER_DIFF="$(mktemp)"
+trap 'rm -f "$TMP_BASE" "$TMP_HEAD" "$TIER_DIFF"' EXIT
+
+opcode_tiers "$TMP_BASE" > "${TIER_DIFF}.base" 2>/dev/null || : > "${TIER_DIFF}.base"
+opcode_tiers "$TMP_HEAD" > "${TIER_DIFF}.head" 2>/dev/null || : > "${TIER_DIFF}.head"
+
+# Join on opcode name, emit transitions where tier differs or entry is new/removed.
+TRANSITIONS="$(awk -F'\t' '
+  NR == FNR { base[$1] = $2; next }
+  {
+    if (!($1 in base)) {
+      print "+ " $1 " (new entry, tier: " $2 ")"
+    } else if (base[$1] != $2) {
+      print "* " $1 ": " base[$1] " → " $2
+    }
+    seen[$1] = 1
+  }
+  END {
+    for (op in base) {
+      if (!(op in seen)) {
+        print "- " op " (removed, was: " base[op] ")"
+      }
+    }
+  }
+' "${TIER_DIFF}.base" "${TIER_DIFF}.head" 2>/dev/null || true)"
+
+rm -f "${TIER_DIFF}.base" "${TIER_DIFF}.head"
+
+# --------------------------------------------------------------------
+# Format a count delta as "old → new (±n)" or omit if unchanged.
+# --------------------------------------------------------------------
+
+count_delta_line() {
+  local label="$1" old="$2" new="$3"
+  if [[ -z "$old" && -z "$new" ]]; then return; fi
+  if [[ "$old" == "$new" ]]; then
+    printf -- "- %s: %s (unchanged)\n" "$label" "${new:-unknown}"
+  else
+    local sign
+    if [[ -z "$old" || -z "$new" ]]; then
+      sign="?"
+    else
+      local delta=$((new - old))
+      if (( delta >= 0 )); then sign="+${delta}"; else sign="${delta}"; fi
+    fi
+    printf -- "- %s: %s → %s (%s)\n" "$label" "${old:-?}" "${new:-?}" "$sign"
+  fi
+}
+
+# --------------------------------------------------------------------
+# Emit
+# --------------------------------------------------------------------
+
+cat <<EOF
+## Computed progress delta for this PR
+
+Inputs: \`PROGRESS.md\` at base \`${BASE:0:7}\` vs head \`${HEAD:0:7}\`.
+Source is the kernel-checked registry in \`EvmAsm/Progress.lean\`;
+drift between the registry and \`PROGRESS.md\` is gated separately by
+\`scripts/check-progress.sh\` in CI.
+
+EOF
+
+if (( BASE_MISSING )); then
+  echo "_Note: PROGRESS.md did not exist at base; this PR appears to introduce it._"
+  echo
+fi
+if (( HEAD_MISSING )); then
+  echo "_Note: PROGRESS.md is absent at head; downstream sections may be empty._"
+  echo
+fi
+
+echo "### Count deltas"
+echo
+count_delta_line "proven (entries)"      "$B_PROVEN"        "$H_PROVEN"
+count_delta_line "partial (entries)"     "$B_PARTIAL"       "$H_PARTIAL"
+count_delta_line "execSpec (entries)"    "$B_EXECSPEC"      "$H_EXECSPEC"
+count_delta_line "notStarted (entries)"  "$B_NOTSTARTED"    "$H_NOTSTARTED"
+count_delta_line "proven (opcode bytes)" "$B_BYTES_PROVEN"  "$H_BYTES_PROVEN"
+count_delta_line "conformance vectors"   "$B_CONF"          "$H_CONF"
+count_delta_line "sorry count"           "$B_SORRY"         "$H_SORRY"
+count_delta_line "axiom count"           "$B_AXIOM"         "$H_AXIOM"
+echo
+
+echo "### Per-opcode tier transitions"
+echo
+if [[ -z "$TRANSITIONS" ]]; then
+  echo "_No tier transitions._"
+else
+  echo "$TRANSITIONS" | sed 's/^/    /'
+fi
+echo


### PR DESCRIPTION
## Summary
- add irreducible expTwoMulFixedStateBranchPre for the fixed-loop state branch continuation
- rewrite the lower induction-facing state-loop wrappers to use the named precondition instead of exposing the expTwoMulFixedBranchResult let chain
- adapt higher wrappers with local bridges where their public shape still exposes the older raw continuation

Re-opens #5014 (and stack-mates #5015, #5016), which were accidentally merged into the head branch of the now-closed #5017 (`ci/restore-progress-delta-summary-helper`) instead of `main`. Branch tip `ccd7ba1cf` carries the three intended commits; PR 5017's restore commit `d3c275c6b` is a no-op against current `main` (its two files were also merged via #4998).

## Verification
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterStateLoop
- lake build EvmAsm.Evm64.Exp
- git diff --check
- scripts/check-file-size.sh EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoop.lean