### PR TITLE
refactor(sdiv): hide loopiter n2 jgt0 call skip pre

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopComposeN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopComposeN2.lean
@@ -523,7 +523,7 @@ theorem divK_loop_body_n2_call_unified_j2_spec_within
       hcarry2_nz
     intro_lets at J2
     exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
-      (fun _ hp => by rw [loopBodyN2J2CallPre_unfold] at hp; exact hp)
+      (fun _ hp => by rw [loopBodyN2J2CallPre_unfold] at hp; rw [loopBodyN2CallJgt0Pre_unfold]; exact hp)
       (fun h hp => by
         rw [← loopIterPostN2Call_addback hb]; exact hp)
       J2
@@ -539,7 +539,7 @@ theorem divK_loop_body_n2_call_unified_j2_spec_within
     exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
       (fun _ hp => by
         rw [loopBodyN2J2CallPre_unfold] at hp
-        rw [loopBodyN2CallSkipJgt0Pre_unfold]
+        rw [loopBodyN2CallJgt0Pre_unfold]
         exact hp)
       (fun h hp => by
         rw [← loopIterPostN2Call_skip hb]; exact hp)
@@ -570,7 +570,7 @@ theorem divK_loop_body_n2_call_unified_j2_spec_within_noNop
       hcarry2_nz
     intro_lets at J2
     exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
-      (fun _ hp => by rw [loopBodyN2J2CallPre_unfold] at hp; exact hp)
+      (fun _ hp => by rw [loopBodyN2J2CallPre_unfold] at hp; rw [loopBodyN2CallJgt0Pre_unfold]; exact hp)
       (fun h hp => by
         rw [← loopIterPostN2Call_addback hb]; exact hp)
       J2
@@ -585,7 +585,7 @@ theorem divK_loop_body_n2_call_unified_j2_spec_within_noNop
     exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
       (fun _ hp => by
         rw [loopBodyN2J2CallPre_unfold] at hp
-        rw [loopBodyN2CallSkipJgt0Pre_unfold]
+        rw [loopBodyN2CallJgt0Pre_unfold]
         exact hp)
       (fun h hp => by
         rw [← loopIterPostN2Call_skip hb]; exact hp)
@@ -665,7 +665,7 @@ theorem divK_loop_body_n2_call_unified_j1_spec_within
       hcarry2_nz
     intro_lets at J1
     exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
-      (fun _ hp => by rw [loopBodyN2J1CallPre_unfold] at hp; exact hp)
+      (fun _ hp => by rw [loopBodyN2J1CallPre_unfold] at hp; rw [loopBodyN2CallJgt0Pre_unfold]; exact hp)
       (fun h hp => by
         rw [← loopIterPostN2Call_addback hb]; exact hp)
       J1
@@ -681,7 +681,7 @@ theorem divK_loop_body_n2_call_unified_j1_spec_within
     exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
       (fun _ hp => by
         rw [loopBodyN2J1CallPre_unfold] at hp
-        rw [loopBodyN2CallSkipJgt0Pre_unfold]
+        rw [loopBodyN2CallJgt0Pre_unfold]
         exact hp)
       (fun h hp => by
         rw [← loopIterPostN2Call_skip hb]; exact hp)
@@ -712,7 +712,7 @@ theorem divK_loop_body_n2_call_unified_j1_spec_within_noNop
       hcarry2_nz
     intro_lets at J1
     exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
-      (fun _ hp => by rw [loopBodyN2J1CallPre_unfold] at hp; exact hp)
+      (fun _ hp => by rw [loopBodyN2J1CallPre_unfold] at hp; rw [loopBodyN2CallJgt0Pre_unfold]; exact hp)
       (fun h hp => by
         rw [← loopIterPostN2Call_addback hb]; exact hp)
       J1
@@ -727,7 +727,7 @@ theorem divK_loop_body_n2_call_unified_j1_spec_within_noNop
     exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
       (fun _ hp => by
         rw [loopBodyN2J1CallPre_unfold] at hp
-        rw [loopBodyN2CallSkipJgt0Pre_unfold]
+        rw [loopBodyN2CallJgt0Pre_unfold]
         exact hp)
       (fun h hp => by
         rw [← loopIterPostN2Call_skip hb]; exact hp)

--- a/EvmAsm/Evm64/DivMod/LoopComposeN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopComposeN2.lean
@@ -121,12 +121,15 @@ theorem divK_loop_body_n2_max_unified_j2_spec_within
                     then (1 : Word) else 0) ≠ (0 : Word) := by rw [if_pos hb]; decide
     have J2 := divK_loop_body_n2_max_addback_jgt0_beq_spec_within (2 : Word)
       EvmAsm.Evm64.DivMod.AddrNorm.slt_jpos_2
-      sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base hbltu
-      hcarry2_nz
+        sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base hbltu
+        hcarry2_nz
     intro_lets at J2
     exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
-      (fun _ hp => by rw [loopBodyN2J2Pre_unfold] at hp; exact hp)
+      (fun _ hp => by
+        rw [loopBodyN2J2Pre_unfold] at hp
+        rw [loopBodyN2MaxJgt0Pre_unfold]
+        exact hp)
       (fun h hp => by
         rw [← loopIterPostN2Max_addback hb]; exact hp)
       (J2 hborrow)
@@ -141,7 +144,7 @@ theorem divK_loop_body_n2_max_unified_j2_spec_within
     exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
       (fun _ hp => by
         rw [loopBodyN2J2Pre_unfold] at hp
-        rw [loopBodyN2MaxSkipJgt0Pre_unfold]
+        rw [loopBodyN2MaxJgt0Pre_unfold]
         exact hp)
       (fun h hp => by
         rw [← loopIterPostN2Max_skip hb]; exact hp)
@@ -163,12 +166,15 @@ theorem divK_loop_body_n2_max_unified_j2_spec_within_noNop
                     then (1 : Word) else 0) ≠ (0 : Word) := by rw [if_pos hb]; decide
     have J2 := divK_loop_body_n2_max_addback_jgt0_beq_spec_within_noNop (2 : Word)
       EvmAsm.Evm64.DivMod.AddrNorm.slt_jpos_2
-      sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base hbltu
-      hcarry2_nz
+        sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base hbltu
+        hcarry2_nz
     intro_lets at J2
     exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
-      (fun _ hp => by rw [loopBodyN2J2Pre_unfold] at hp; exact hp)
+      (fun _ hp => by
+        rw [loopBodyN2J2Pre_unfold] at hp
+        rw [loopBodyN2MaxJgt0Pre_unfold]
+        exact hp)
       (fun h hp => by
         rw [← loopIterPostN2Max_addback hb]; exact hp)
       (J2 hborrow)
@@ -182,7 +188,7 @@ theorem divK_loop_body_n2_max_unified_j2_spec_within_noNop
     exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
       (fun _ hp => by
         rw [loopBodyN2J2Pre_unfold] at hp
-        rw [loopBodyN2MaxSkipJgt0Pre_unfold]
+        rw [loopBodyN2MaxJgt0Pre_unfold]
         exact hp)
       (fun h hp => by
         rw [← loopIterPostN2Max_skip hb]; exact hp)
@@ -244,12 +250,15 @@ theorem divK_loop_body_n2_max_unified_j1_spec_within
                     then (1 : Word) else 0) ≠ (0 : Word) := by rw [if_pos hb]; decide
     have J1 := divK_loop_body_n2_max_addback_jgt0_beq_spec_within (1 : Word)
       EvmAsm.Evm64.DivMod.AddrNorm.slt_jpos_1
-      sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base hbltu
-      hcarry2_nz
+        sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base hbltu
+        hcarry2_nz
     intro_lets at J1
     exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
-      (fun _ hp => by rw [loopBodyN2J1Pre_unfold] at hp; exact hp)
+      (fun _ hp => by
+        rw [loopBodyN2J1Pre_unfold] at hp
+        rw [loopBodyN2MaxJgt0Pre_unfold]
+        exact hp)
       (fun h hp => by
         rw [← loopIterPostN2Max_addback hb]; exact hp)
       (J1 hborrow)
@@ -265,7 +274,7 @@ theorem divK_loop_body_n2_max_unified_j1_spec_within
     exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
       (fun _ hp => by
         rw [loopBodyN2J1Pre_unfold] at hp
-        rw [loopBodyN2MaxSkipJgt0Pre_unfold]
+        rw [loopBodyN2MaxJgt0Pre_unfold]
         exact hp)
       (fun h hp => by
         rw [← loopIterPostN2Max_skip hb]; exact hp)
@@ -287,12 +296,15 @@ theorem divK_loop_body_n2_max_unified_j1_spec_within_noNop
                     then (1 : Word) else 0) ≠ (0 : Word) := by rw [if_pos hb]; decide
     have J1 := divK_loop_body_n2_max_addback_jgt0_beq_spec_within_noNop (1 : Word)
       EvmAsm.Evm64.DivMod.AddrNorm.slt_jpos_1
-      sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base hbltu
-      hcarry2_nz
+        sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base hbltu
+        hcarry2_nz
     intro_lets at J1
     exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
-      (fun _ hp => by rw [loopBodyN2J1Pre_unfold] at hp; exact hp)
+      (fun _ hp => by
+        rw [loopBodyN2J1Pre_unfold] at hp
+        rw [loopBodyN2MaxJgt0Pre_unfold]
+        exact hp)
       (fun h hp => by
         rw [← loopIterPostN2Max_addback hb]; exact hp)
       (J1 hborrow)
@@ -307,7 +319,7 @@ theorem divK_loop_body_n2_max_unified_j1_spec_within_noNop
     exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
       (fun _ hp => by
         rw [loopBodyN2J1Pre_unfold] at hp
-        rw [loopBodyN2MaxSkipJgt0Pre_unfold]
+        rw [loopBodyN2MaxJgt0Pre_unfold]
         exact hp)
       (fun h hp => by
         rw [← loopIterPostN2Max_skip hb]; exact hp)

--- a/EvmAsm/Evm64/DivMod/LoopComposeN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopComposeN2.lean
@@ -520,12 +520,15 @@ theorem divK_loop_body_n2_call_unified_j2_spec_within
     have J2 := divK_loop_body_n2_call_skip_jgt0_spec_within (2 : Word)
       EvmAsm.Evm64.DivMod.AddrNorm.slt_jpos_2
       sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 base
-      halign
-      hbltu hborrow
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 base
+        halign
+        hbltu hborrow
     intro_lets at J2
     exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
-      (fun _ hp => by rw [loopBodyN2J2CallPre_unfold] at hp; exact hp)
+      (fun _ hp => by
+        rw [loopBodyN2J2CallPre_unfold] at hp
+        rw [loopBodyN2CallSkipJgt0Pre_unfold]
+        exact hp)
       (fun h hp => by
         rw [← loopIterPostN2Call_skip hb]; exact hp)
       J2
@@ -563,12 +566,15 @@ theorem divK_loop_body_n2_call_unified_j2_spec_within_noNop
     have J2 := divK_loop_body_n2_call_skip_jgt0_spec_within_noNop (2 : Word)
       EvmAsm.Evm64.DivMod.AddrNorm.slt_jpos_2
       sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 base
-      halign
-      hbltu hborrow
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 base
+        halign
+        hbltu hborrow
     intro_lets at J2
     exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
-      (fun _ hp => by rw [loopBodyN2J2CallPre_unfold] at hp; exact hp)
+      (fun _ hp => by
+        rw [loopBodyN2J2CallPre_unfold] at hp
+        rw [loopBodyN2CallSkipJgt0Pre_unfold]
+        exact hp)
       (fun h hp => by
         rw [← loopIterPostN2Call_skip hb]; exact hp)
       J2
@@ -656,12 +662,15 @@ theorem divK_loop_body_n2_call_unified_j1_spec_within
     have J1 := divK_loop_body_n2_call_skip_jgt0_spec_within (1 : Word)
       EvmAsm.Evm64.DivMod.AddrNorm.slt_jpos_1
       sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 base
-      halign
-      hbltu hborrow
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 base
+        halign
+        hbltu hborrow
     intro_lets at J1
     exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
-      (fun _ hp => by rw [loopBodyN2J1CallPre_unfold] at hp; exact hp)
+      (fun _ hp => by
+        rw [loopBodyN2J1CallPre_unfold] at hp
+        rw [loopBodyN2CallSkipJgt0Pre_unfold]
+        exact hp)
       (fun h hp => by
         rw [← loopIterPostN2Call_skip hb]; exact hp)
       J1
@@ -699,12 +708,15 @@ theorem divK_loop_body_n2_call_unified_j1_spec_within_noNop
     have J1 := divK_loop_body_n2_call_skip_jgt0_spec_within_noNop (1 : Word)
       EvmAsm.Evm64.DivMod.AddrNorm.slt_jpos_1
       sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 base
-      halign
-      hbltu hborrow
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 base
+        halign
+        hbltu hborrow
     intro_lets at J1
     exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
-      (fun _ hp => by rw [loopBodyN2J1CallPre_unfold] at hp; exact hp)
+      (fun _ hp => by
+        rw [loopBodyN2J1CallPre_unfold] at hp
+        rw [loopBodyN2CallSkipJgt0Pre_unfold]
+        exact hp)
       (fun h hp => by
         rw [← loopIterPostN2Call_skip hb]; exact hp)
       J1

--- a/EvmAsm/Evm64/DivMod/LoopIterN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN2.lean
@@ -711,6 +711,54 @@ theorem divK_loop_body_n2_max_skip_jgt0_spec_within_noNop (j : Word)
 
 set_option maxRecDepth 4096 in
 /-- Loop body cpsTripleWithin for n=2, call+skip, j > 0 (parametric on `j : Word`). -/
+@[irreducible]
+def loopBodyN2CallSkipJgt0Pre (j : Word)
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratch_un0 : Word) : Assertion :=
+  let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
+  (.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
+  (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+  (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
+  (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
+  (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
+  ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+  ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+  ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+  ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+  ((uBase + signExtend12 4064) ↦ₘ uTop) **
+  (qAddr ↦ₘ qOld) **
+  (sp + signExtend12 3968 ↦ₘ retMem) **
+  (sp + signExtend12 3960 ↦ₘ dMem) **
+  (sp + signExtend12 3952 ↦ₘ dloMem) **
+  (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1
+
+theorem loopBodyN2CallSkipJgt0Pre_unfold (j : Word)
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratch_un0 : Word) :
+    loopBodyN2CallSkipJgt0Pre j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 =
+    (let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+     let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
+     (.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
+     (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+     (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
+     (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
+     (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((uBase + signExtend12 4064) ↦ₘ uTop) **
+     (qAddr ↦ₘ qOld) **
+     (sp + signExtend12 3968 ↦ₘ retMem) **
+     (sp + signExtend12 3960 ↦ₘ dMem) **
+     (sp + signExtend12 3952 ↦ₘ dloMem) **
+     (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1) := by
+  delta loopBodyN2CallSkipJgt0Pre; rfl
+
 theorem divK_loop_body_n2_call_skip_jgt0_spec_within (j : Word)
     (hpos : BitVec.slt (j + signExtend12 4095) 0 = false)
     (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
@@ -720,26 +768,12 @@ theorem divK_loop_body_n2_call_skip_jgt0_spec_within (j : Word)
     (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
     (hbltu : BitVec.ult u2 v1)
     (hborrow : isSkipBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
-    let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     cpsTripleWithin 126 (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
-       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-       ((uBase + signExtend12 4064) ↦ₘ uTop) **
-       (qAddr ↦ₘ qOld) **
-       (sp + signExtend12 3968 ↦ₘ retMem) **
-       (sp + signExtend12 3960 ↦ₘ dMem) **
-       (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
+      (loopBodyN2CallSkipJgt0Pre j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0)
       (loopBodyN2CallSkipPostJ sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro uBase qAddr
+  let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
   let dHi := v1 >>> (32 : BitVec 6).toNat
   let dLo := (v1 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   let div_un1 := u1 >>> (32 : BitVec 6).toNat
@@ -826,7 +860,7 @@ theorem divK_loop_body_n2_call_skip_jgt0_spec_within (j : Word)
   have full := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0f SLf
   exact cpsTripleWithin_weaken
-    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by rw [loopBodyN2CallSkipJgt0Pre_unfold] at hp; xperm_hyp hp)
     (fun h hp => by
       delta loopBodyN2CallSkipPostJ div128Quot div128DLo div128Un0
             loopBodyN2SkipPost loopBodySkipPost mulsubN4 loopExitPostN2 loopExitPost
@@ -843,26 +877,12 @@ theorem divK_loop_body_n2_call_skip_jgt0_spec_within_noNop (j : Word)
     (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
     (hbltu : BitVec.ult u2 v1)
     (hborrow : isSkipBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
-    let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     cpsTripleWithin 126 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
-       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-       ((uBase + signExtend12 4064) ↦ₘ uTop) **
-       (qAddr ↦ₘ qOld) **
-       (sp + signExtend12 3968 ↦ₘ retMem) **
-       (sp + signExtend12 3960 ↦ₘ dMem) **
-       (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
+      (loopBodyN2CallSkipJgt0Pre j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0)
       (loopBodyN2CallSkipPostJ sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro uBase qAddr
+  let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
   let dHi := v1 >>> (32 : BitVec 6).toNat
   let dLo := (v1 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   let div_un1 := u1 >>> (32 : BitVec 6).toNat
@@ -948,7 +968,7 @@ theorem divK_loop_body_n2_call_skip_jgt0_spec_within_noNop (j : Word)
   have full := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0f SLf
   exact cpsTripleWithin_weaken
-    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by rw [loopBodyN2CallSkipJgt0Pre_unfold] at hp; xperm_hyp hp)
     (fun h hp => by
       delta loopBodyN2CallSkipPostJ div128Quot div128DLo div128Un0
             loopBodyN2SkipPost loopBodySkipPost mulsubN4 loopExitPostN2 loopExitPost

--- a/EvmAsm/Evm64/DivMod/LoopIterN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN2.lean
@@ -712,7 +712,7 @@ theorem divK_loop_body_n2_max_skip_jgt0_spec_within_noNop (j : Word)
 set_option maxRecDepth 4096 in
 /-- Loop body cpsTripleWithin for n=2, call+skip, j > 0 (parametric on `j : Word`). -/
 @[irreducible]
-def loopBodyN2CallSkipJgt0Pre (j : Word)
+def loopBodyN2CallJgt0Pre (j : Word)
     (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
     (retMem dMem dloMem scratch_un0 : Word) : Assertion :=
@@ -734,11 +734,11 @@ def loopBodyN2CallSkipJgt0Pre (j : Word)
   (sp + signExtend12 3952 ↦ₘ dloMem) **
   (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1
 
-theorem loopBodyN2CallSkipJgt0Pre_unfold (j : Word)
+theorem loopBodyN2CallJgt0Pre_unfold (j : Word)
     (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
     (retMem dMem dloMem scratch_un0 : Word) :
-    loopBodyN2CallSkipJgt0Pre j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    loopBodyN2CallJgt0Pre j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 =
     (let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
      let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
@@ -757,7 +757,7 @@ theorem loopBodyN2CallSkipJgt0Pre_unfold (j : Word)
      (sp + signExtend12 3960 ↦ₘ dMem) **
      (sp + signExtend12 3952 ↦ₘ dloMem) **
      (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1) := by
-  delta loopBodyN2CallSkipJgt0Pre; rfl
+  delta loopBodyN2CallJgt0Pre; rfl
 
 theorem divK_loop_body_n2_call_skip_jgt0_spec_within (j : Word)
     (hpos : BitVec.slt (j + signExtend12 4095) 0 = false)
@@ -769,7 +769,7 @@ theorem divK_loop_body_n2_call_skip_jgt0_spec_within (j : Word)
     (hbltu : BitVec.ult u2 v1)
     (hborrow : isSkipBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
     cpsTripleWithin 126 (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
-      (loopBodyN2CallSkipJgt0Pre j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      (loopBodyN2CallJgt0Pre j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
         v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0)
       (loopBodyN2CallSkipPostJ sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
@@ -860,7 +860,7 @@ theorem divK_loop_body_n2_call_skip_jgt0_spec_within (j : Word)
   have full := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0f SLf
   exact cpsTripleWithin_weaken
-    (fun h hp => by rw [loopBodyN2CallSkipJgt0Pre_unfold] at hp; xperm_hyp hp)
+    (fun h hp => by rw [loopBodyN2CallJgt0Pre_unfold] at hp; xperm_hyp hp)
     (fun h hp => by
       delta loopBodyN2CallSkipPostJ div128Quot div128DLo div128Un0
             loopBodyN2SkipPost loopBodySkipPost mulsubN4 loopExitPostN2 loopExitPost
@@ -878,7 +878,7 @@ theorem divK_loop_body_n2_call_skip_jgt0_spec_within_noNop (j : Word)
     (hbltu : BitVec.ult u2 v1)
     (hborrow : isSkipBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
     cpsTripleWithin 126 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop base)
-      (loopBodyN2CallSkipJgt0Pre j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      (loopBodyN2CallJgt0Pre j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
         v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0)
       (loopBodyN2CallSkipPostJ sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
@@ -968,7 +968,7 @@ theorem divK_loop_body_n2_call_skip_jgt0_spec_within_noNop (j : Word)
   have full := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0f SLf
   exact cpsTripleWithin_weaken
-    (fun h hp => by rw [loopBodyN2CallSkipJgt0Pre_unfold] at hp; xperm_hyp hp)
+    (fun h hp => by rw [loopBodyN2CallJgt0Pre_unfold] at hp; xperm_hyp hp)
     (fun h hp => by
       delta loopBodyN2CallSkipPostJ div128Quot div128DLo div128Un0
             loopBodyN2SkipPost loopBodySkipPost mulsubN4 loopExitPostN2 loopExitPost
@@ -1373,26 +1373,12 @@ theorem divK_loop_body_n2_call_addback_jgt0_beq_spec_within (j : Word)
     (hbltu : BitVec.ult u2 v1)
     (hborrow : isAddbackBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop)
     (hcarry2_nz : isAddbackCarry2NzN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
-    let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     cpsTripleWithin 202 (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
-       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-       ((uBase + signExtend12 4064) ↦ₘ uTop) **
-       (qAddr ↦ₘ qOld) **
-       (sp + signExtend12 3968 ↦ₘ retMem) **
-       (sp + signExtend12 3960 ↦ₘ dMem) **
-       (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
+      (loopBodyN2CallJgt0Pre j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0)
       (loopBodyN2CallAddbackBeqPostJ sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro uBase qAddr
+  let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
   let dHi := v1 >>> (32 : BitVec 6).toNat
   let dLo := (v1 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   let div_un1 := u1 >>> (32 : BitVec 6).toNat
@@ -1477,7 +1463,7 @@ theorem divK_loop_body_n2_call_addback_jgt0_beq_spec_within (j : Word)
   have full := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0f SLf
   exact cpsTripleWithin_weaken
-    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by rw [loopBodyN2CallJgt0Pre_unfold] at hp; xperm_hyp hp)
     (fun h hp => by
       delta loopBodyN2CallAddbackBeqPostJ div128Quot div128DLo div128Un0
             loopBodyN2AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN2 loopExitPost

--- a/EvmAsm/Evm64/DivMod/LoopIterN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN2.lean
@@ -521,7 +521,7 @@ theorem divK_loop_body_n2_call_skip_j0_spec_within_noNop
 set_option maxRecDepth 4096 in
 /-- Loop body cpsTripleWithin for n=2, max+skip, j > 0 (parametric on `j : Word`). -/
 @[irreducible]
-def loopBodyN2MaxSkipJgt0Pre (j : Word)
+def loopBodyN2MaxJgt0Pre (j : Word)
     (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word) : Assertion :=
   let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
@@ -538,10 +538,10 @@ def loopBodyN2MaxSkipJgt0Pre (j : Word)
   ((uBase + signExtend12 4064) ↦ₘ uTop) **
   (qAddr ↦ₘ qOld)
 
-theorem loopBodyN2MaxSkipJgt0Pre_unfold (j : Word)
+theorem loopBodyN2MaxJgt0Pre_unfold (j : Word)
     (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word) :
-    loopBodyN2MaxSkipJgt0Pre j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    loopBodyN2MaxJgt0Pre j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld =
     (let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
      let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
@@ -556,7 +556,7 @@ theorem loopBodyN2MaxSkipJgt0Pre_unfold (j : Word)
      ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
      ((uBase + signExtend12 4064) ↦ₘ uTop) **
      (qAddr ↦ₘ qOld)) := by
-  delta loopBodyN2MaxSkipJgt0Pre; rfl
+  delta loopBodyN2MaxJgt0Pre; rfl
 
 theorem divK_loop_body_n2_max_skip_jgt0_spec_within (j : Word)
     (hpos : BitVec.slt (j + signExtend12 4095) 0 = false)
@@ -566,7 +566,7 @@ theorem divK_loop_body_n2_max_skip_jgt0_spec_within (j : Word)
     (hbltu : ¬BitVec.ult u2 v1) :
     (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsTripleWithin 76 (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
-      (loopBodyN2MaxSkipJgt0Pre j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      (loopBodyN2MaxJgt0Pre j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
         v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld)
       (loopBodyN2SkipPost sp j (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro hborrow
@@ -627,7 +627,7 @@ theorem divK_loop_body_n2_max_skip_jgt0_spec_within (j : Word)
   have full := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
   exact cpsTripleWithin_weaken
-    (fun h hp => by rw [loopBodyN2MaxSkipJgt0Pre_unfold] at hp; xperm_hyp hp)
+    (fun h hp => by rw [loopBodyN2MaxJgt0Pre_unfold] at hp; xperm_hyp hp)
     (fun h hp => by delta loopBodyN2SkipPost loopBodySkipPost mulsubN4 loopExitPostN2 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full
 
@@ -640,7 +640,7 @@ theorem divK_loop_body_n2_max_skip_jgt0_spec_within_noNop (j : Word)
     (hbltu : ¬BitVec.ult u2 v1) :
     (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsTripleWithin 76 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop base)
-      (loopBodyN2MaxSkipJgt0Pre j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      (loopBodyN2MaxJgt0Pre j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
         v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld)
       (loopBodyN2SkipPost sp j (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro hborrow
@@ -700,7 +700,7 @@ theorem divK_loop_body_n2_max_skip_jgt0_spec_within_noNop (j : Word)
   have full := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
   exact cpsTripleWithin_weaken
-    (fun h hp => by rw [loopBodyN2MaxSkipJgt0Pre_unfold] at hp; xperm_hyp hp)
+    (fun h hp => by rw [loopBodyN2MaxJgt0Pre_unfold] at hp; xperm_hyp hp)
     (fun h hp => by delta loopBodyN2SkipPost loopBodySkipPost mulsubN4 loopExitPostN2 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full
 
@@ -1286,7 +1286,6 @@ theorem divK_loop_body_n2_call_addback_j0_beq_spec_within
 -- Word-parametric: callers pass concrete j ∈ {1,2} + corresponding slt_jpos_k.
 -- ============================================================================
 
-set_option maxRecDepth 4096 in
 theorem divK_loop_body_n2_max_addback_jgt0_beq_spec_within (j : Word)
     (hpos : BitVec.slt (j + signExtend12 4095) 0 = false)
     (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
@@ -1294,24 +1293,14 @@ theorem divK_loop_body_n2_max_addback_jgt0_beq_spec_within (j : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u2 v1)
     (hcarry2_nz : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
-
-    let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTripleWithin 152 (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
-       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-       ((uBase + signExtend12 4064) ↦ₘ uTop) **
-       (qAddr ↦ₘ qOld))
+      (loopBodyN2MaxJgt0Pre j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld)
       (loopBodyN2AddbackBeqPost sp j (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro uBase qAddr hborrow
+  intro hborrow
+  let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
   let qHat : Word := signExtend12 4095
   let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
   let c3 := ms.2.2.2.2
@@ -1364,7 +1353,7 @@ theorem divK_loop_body_n2_max_addback_jgt0_beq_spec_within (j : Word)
   have full := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
   exact cpsTripleWithin_weaken
-    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by rw [loopBodyN2MaxJgt0Pre_unfold] at hp; xperm_hyp hp)
     (fun h hp => by delta loopBodyN2AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN2 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full
 

--- a/EvmAsm/Evm64/DivMod/LoopIterN2NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN2NoNop.lean
@@ -207,26 +207,12 @@ theorem divK_loop_body_n2_call_addback_jgt0_beq_spec_within_noNop (j : Word)
     (hbltu : BitVec.ult u2 v1)
     (hborrow : isAddbackBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop)
     (hcarry2_nz : isAddbackCarry2NzN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
-    let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     cpsTripleWithin 202 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
-       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-       ((uBase + signExtend12 4064) ↦ₘ uTop) **
-       (qAddr ↦ₘ qOld) **
-       (sp + signExtend12 3968 ↦ₘ retMem) **
-       (sp + signExtend12 3960 ↦ₘ dMem) **
-       (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
+      (loopBodyN2CallJgt0Pre j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0)
       (loopBodyN2CallAddbackBeqPostJ sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro uBase qAddr
+  let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
   let dHi := v1 >>> (32 : BitVec 6).toNat
   let dLo := (v1 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   let div_un1 := u1 >>> (32 : BitVec 6).toNat
@@ -309,7 +295,7 @@ theorem divK_loop_body_n2_call_addback_jgt0_beq_spec_within_noNop (j : Word)
   have full := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0f SLf
   exact cpsTripleWithin_weaken
-    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by rw [loopBodyN2CallJgt0Pre_unfold] at hp; xperm_hyp hp)
     (fun h hp => by
       delta loopBodyN2CallAddbackBeqPostJ div128Quot div128DLo div128Un0
             loopBodyN2AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN2 loopExitPost

--- a/EvmAsm/Evm64/DivMod/LoopIterN2NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN2NoNop.lean
@@ -133,23 +133,14 @@ theorem divK_loop_body_n2_max_addback_jgt0_beq_spec_within_noNop (j : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u2 v1)
     (hcarry2_nz : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
-    let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTripleWithin 152 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
-       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-       ((uBase + signExtend12 4064) ↦ₘ uTop) **
-       (qAddr ↦ₘ qOld))
+      (loopBodyN2MaxJgt0Pre j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld)
       (loopBodyN2AddbackBeqPost sp j (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro uBase qAddr hborrow
+  intro hborrow
+  let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
   let qHat : Word := signExtend12 4095
   let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
   let c3 := ms.2.2.2.2
@@ -201,7 +192,7 @@ theorem divK_loop_body_n2_max_addback_jgt0_beq_spec_within_noNop (j : Word)
   have full := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
   exact cpsTripleWithin_weaken
-    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by rw [loopBodyN2MaxJgt0Pre_unfold] at hp; xperm_hyp hp)
     (fun h hp => by delta loopBodyN2AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN2 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full
 


### PR DESCRIPTION
## Summary
- hide the LoopIterN2 parametric n=2 j>0 call+skip precondition behind an irreducible definition
- update j=1/j=2 shared and noNop compose call skip bridges to unfold the hidden precondition at the boundary

## Verification
- lake build EvmAsm.Evm64.DivMod.LoopIterN2
- lake build EvmAsm.Evm64.DivMod.LoopComposeN2
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- scripts/check-file-size.sh EvmAsm/Evm64/DivMod/LoopIterN2.lean EvmAsm/Evm64/DivMod/LoopComposeN2.lean