### PR TITLE
refactor(sdiv): hide loopcompose n3 unified pre

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopComposeN3.lean
+++ b/EvmAsm/Evm64/DivMod/LoopComposeN3.lean
@@ -51,6 +51,92 @@ theorem u_j1_4072_eq_j0_4064 {sp : Word} :
     (sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4064 := by
   divmod_addr
 
+@[irreducible] def loopBodyN3MaxUnifiedPre
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     j v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word) : Assertion :=
+  let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
+  ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
+   (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+   (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
+   (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
+   (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
+   ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+   ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+   ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+   ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+   ((uBase + signExtend12 4064) ↦ₘ uTop) **
+   (qAddr ↦ₘ qOld))
+
+theorem loopBodyN3MaxUnifiedPre_unfold
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     j v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word) :
+    loopBodyN3MaxUnifiedPre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      j v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld =
+    (let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+     let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
+     ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
+      (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+      (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
+      (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
+      (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
+      ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+      ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+      ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+      ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+      ((uBase + signExtend12 4064) ↦ₘ uTop) **
+      (qAddr ↦ₘ qOld)) : Assertion) := by
+  unfold loopBodyN3MaxUnifiedPre
+  rfl
+
+@[irreducible] def loopBodyN3CallUnifiedPre
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     j v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
+     retMem dMem dloMem scratch_un0 : Word) : Assertion :=
+  let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
+  ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
+   (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+   (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
+   (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
+   (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
+   ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+   ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+   ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+   ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+   ((uBase + signExtend12 4064) ↦ₘ uTop) **
+   (qAddr ↦ₘ qOld) **
+   (sp + signExtend12 3968 ↦ₘ retMem) **
+   (sp + signExtend12 3960 ↦ₘ dMem) **
+   (sp + signExtend12 3952 ↦ₘ dloMem) **
+   ((sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1))
+
+theorem loopBodyN3CallUnifiedPre_unfold
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     j v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
+     retMem dMem dloMem scratch_un0 : Word) :
+    loopBodyN3CallUnifiedPre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      j v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 =
+    (let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+     let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
+     ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
+      (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+      (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
+      (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
+      (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
+      ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+      ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+      ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+      ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+      ((uBase + signExtend12 4064) ↦ₘ uTop) **
+      (qAddr ↦ₘ qOld) **
+      (sp + signExtend12 3968 ↦ₘ retMem) **
+      (sp + signExtend12 3960 ↦ₘ dMem) **
+      (sp + signExtend12 3952 ↦ₘ dloMem) **
+      ((sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)) : Assertion) := by
+  unfold loopBodyN3CallUnifiedPre
+  rfl
+
 -- ============================================================================
 -- Double-addback () unified j=1 max-path spec
 -- Uses _beq LoopIter specs with borrow-branching loopIterPostN3Max.
@@ -62,22 +148,12 @@ theorem divK_loop_body_n3_max_unified_j1_spec_within
     (base : Word)
     (hbltu : ¬BitVec.ult u3 v2)
     (hcarry2_nz : isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
-    let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 152 (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (1 : Word)) **
-       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-       ((uBase + signExtend12 4064) ↦ₘ uTop) **
-       (qAddr ↦ₘ qOld))
+      (loopBodyN3MaxUnifiedPre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld)
       (loopIterPostN3Max sp (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro uBase qAddr
+  let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
   by_cases hb : BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
   · -- addback path: use _beq spec
     have hborrow : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
@@ -87,7 +163,9 @@ theorem divK_loop_body_n3_max_unified_j1_spec_within
       hbltu hcarry2_nz
     intro_lets at J1
     exact cpsTripleWithin_weaken
-      (fun h hp => hp)
+      (fun h hp => by
+        rw [loopBodyN3MaxUnifiedPre_unfold] at hp
+        exact hp)
       (fun h hp => by rw [← loopIterPostN3Max_addback hb]; exact hp)
       (cpsTripleWithin_mono_nSteps (by decide) (J1 hborrow))
   · -- skip path
@@ -98,7 +176,9 @@ theorem divK_loop_body_n3_max_unified_j1_spec_within
       hbltu
     intro_lets at J1
     exact cpsTripleWithin_weaken
-      (fun h hp => hp)
+      (fun h hp => by
+        rw [loopBodyN3MaxUnifiedPre_unfold] at hp
+        exact hp)
       (fun h hp => by rw [← loopIterPostN3Max_skip hb]; exact hp)
       (cpsTripleWithin_mono_nSteps (by decide) (J1 hborrow))
 
@@ -109,22 +189,12 @@ theorem divK_loop_body_n3_max_unified_j1_spec_within_noNop
     (base : Word)
     (hbltu : ¬BitVec.ult u3 v2)
     (hcarry2_nz : isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
-    let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 152 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (1 : Word)) **
-       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-       ((uBase + signExtend12 4064) ↦ₘ uTop) **
-       (qAddr ↦ₘ qOld))
+      (loopBodyN3MaxUnifiedPre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld)
       (loopIterPostN3Max sp (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro uBase qAddr
+  let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
   by_cases hb : BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
   · have hborrow : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
                     then (1 : Word) else 0) ≠ (0 : Word) := by rw [if_pos hb]; decide
@@ -133,7 +203,9 @@ theorem divK_loop_body_n3_max_unified_j1_spec_within_noNop
       hbltu hcarry2_nz
     intro_lets at J1
     exact cpsTripleWithin_weaken
-      (fun h hp => hp)
+      (fun h hp => by
+        rw [loopBodyN3MaxUnifiedPre_unfold] at hp
+        exact hp)
       (fun h hp => by rw [← loopIterPostN3Max_addback hb]; exact hp)
       (cpsTripleWithin_mono_nSteps (by decide) (J1 hborrow))
   · have hborrow : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
@@ -143,7 +215,9 @@ theorem divK_loop_body_n3_max_unified_j1_spec_within_noNop
       hbltu
     intro_lets at J1
     exact cpsTripleWithin_weaken
-      (fun h hp => hp)
+      (fun h hp => by
+        rw [loopBodyN3MaxUnifiedPre_unfold] at hp
+        exact hp)
       (fun h hp => by rw [← loopIterPostN3Max_skip hb]; exact hp)
       (cpsTripleWithin_mono_nSteps (by decide) (J1 hborrow))
 
@@ -158,22 +232,12 @@ theorem divK_loop_body_n3_max_unified_j0_spec_within
     (base : Word)
     (hbltu : ¬BitVec.ult u3 v2)
     (hcarry2_nz : isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
-    let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 152 (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
-       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-       ((uBase + signExtend12 4064) ↦ₘ uTop) **
-       (qAddr ↦ₘ qOld))
+      (loopBodyN3MaxUnifiedPre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld)
       (loopIterPostN3Max sp (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro uBase qAddr
+  let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
   by_cases hb : BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
   · -- addback path: use _beq spec
     have hborrow : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
@@ -183,7 +247,9 @@ theorem divK_loop_body_n3_max_unified_j0_spec_within
       hbltu hcarry2_nz
     intro_lets at J0
     exact cpsTripleWithin_weaken
-      (fun h hp => hp)
+      (fun h hp => by
+        rw [loopBodyN3MaxUnifiedPre_unfold] at hp
+        exact hp)
       (fun h hp => by rw [← loopIterPostN3Max_addback hb]; exact hp)
       (cpsTripleWithin_mono_nSteps (by decide) (J0 hborrow))
   · -- skip path
@@ -194,7 +260,9 @@ theorem divK_loop_body_n3_max_unified_j0_spec_within
       hbltu
     intro_lets at J0
     exact cpsTripleWithin_weaken
-      (fun h hp => hp)
+      (fun h hp => by
+        rw [loopBodyN3MaxUnifiedPre_unfold] at hp
+        exact hp)
       (fun h hp => by rw [← loopIterPostN3Max_skip hb]; exact hp)
       (cpsTripleWithin_mono_nSteps (by decide) (J0 hborrow))
 
@@ -205,22 +273,12 @@ theorem divK_loop_body_n3_max_unified_j0_spec_within_noNop
     (base : Word)
     (hbltu : ¬BitVec.ult u3 v2)
     (hcarry2_nz : isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
-    let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 152 (base + loopBodyOff) (base + denormOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
-       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-       ((uBase + signExtend12 4064) ↦ₘ uTop) **
-       (qAddr ↦ₘ qOld))
+      (loopBodyN3MaxUnifiedPre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld)
       (loopIterPostN3Max sp (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro uBase qAddr
+  let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
   by_cases hb : BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
   · have hborrow : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
                     then (1 : Word) else 0) ≠ (0 : Word) := by rw [if_pos hb]; decide
@@ -229,7 +287,9 @@ theorem divK_loop_body_n3_max_unified_j0_spec_within_noNop
       hbltu hcarry2_nz
     intro_lets at J0
     exact cpsTripleWithin_weaken
-      (fun h hp => hp)
+      (fun h hp => by
+        rw [loopBodyN3MaxUnifiedPre_unfold] at hp
+        exact hp)
       (fun h hp => by rw [← loopIterPostN3Max_addback hb]; exact hp)
       (cpsTripleWithin_mono_nSteps (by decide) (J0 hborrow))
   · have hborrow : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
@@ -239,7 +299,9 @@ theorem divK_loop_body_n3_max_unified_j0_spec_within_noNop
       hbltu
     intro_lets at J0
     exact cpsTripleWithin_weaken
-      (fun h hp => hp)
+      (fun h hp => by
+        rw [loopBodyN3MaxUnifiedPre_unfold] at hp
+        exact hp)
       (fun h hp => by rw [← loopIterPostN3Max_skip hb]; exact hp)
       (cpsTripleWithin_mono_nSteps (by decide) (J0 hborrow))
 
@@ -256,26 +318,12 @@ theorem divK_loop_body_n3_call_unified_j1_spec_within
     (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
     (hbltu : BitVec.ult u3 v2)
     (hcarry2_nz : isAddbackCarry2NzN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
-    let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 202 (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (1 : Word)) **
-       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-       ((uBase + signExtend12 4064) ↦ₘ uTop) **
-       (qAddr ↦ₘ qOld) **
-       (sp + signExtend12 3968 ↦ₘ retMem) **
-       (sp + signExtend12 3960 ↦ₘ dMem) **
-       (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
+      (loopBodyN3CallUnifiedPre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0)
       (loopIterPostN3Call sp base (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro uBase qAddr
+  let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
   by_cases hb : BitVec.ult uTop (mulsubN4_c3 (div128Quot u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3)
   · -- addback path: use _beq spec
     have hborrow : isAddbackBorrowN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
@@ -286,7 +334,9 @@ theorem divK_loop_body_n3_call_unified_j1_spec_within
       hbltu hborrow hcarry2_nz
     intro_lets at J1
     exact cpsTripleWithin_weaken
-      (fun h hp => hp)
+      (fun h hp => by
+        rw [loopBodyN3CallUnifiedPre_unfold] at hp
+        exact hp)
       (fun h hp => by rw [← loopIterPostN3Call_addback hb]; exact hp)
       (cpsTripleWithin_mono_nSteps (by decide) J1)
   · -- skip path
@@ -297,7 +347,9 @@ theorem divK_loop_body_n3_call_unified_j1_spec_within
       hbltu hborrow
     intro_lets at J1
     exact cpsTripleWithin_weaken
-      (fun h hp => hp)
+      (fun h hp => by
+        rw [loopBodyN3CallUnifiedPre_unfold] at hp
+        exact hp)
       (fun h hp => by rw [← loopIterPostN3Call_skip hb]; exact hp)
       (cpsTripleWithin_mono_nSteps (by decide) J1)
 
@@ -310,26 +362,12 @@ theorem divK_loop_body_n3_call_unified_j1_spec_within_noNop
     (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
     (hbltu : BitVec.ult u3 v2)
     (hcarry2_nz : isAddbackCarry2NzN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
-    let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 202 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (1 : Word)) **
-       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-       ((uBase + signExtend12 4064) ↦ₘ uTop) **
-       (qAddr ↦ₘ qOld) **
-       (sp + signExtend12 3968 ↦ₘ retMem) **
-       (sp + signExtend12 3960 ↦ₘ dMem) **
-       (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
+      (loopBodyN3CallUnifiedPre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0)
       (loopIterPostN3Call sp base (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro uBase qAddr
+  let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
   by_cases hb : BitVec.ult uTop (mulsubN4_c3 (div128Quot u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3)
   · have hborrow : isAddbackBorrowN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
       delta isAddbackBorrowN3Call; simp only []; rw [if_pos hb]; decide
@@ -339,7 +377,9 @@ theorem divK_loop_body_n3_call_unified_j1_spec_within_noNop
       hbltu hborrow hcarry2_nz
     intro_lets at J1
     exact cpsTripleWithin_weaken
-      (fun h hp => hp)
+      (fun h hp => by
+        rw [loopBodyN3CallUnifiedPre_unfold] at hp
+        exact hp)
       (fun h hp => by rw [← loopIterPostN3Call_addback hb]; exact hp)
       (cpsTripleWithin_mono_nSteps (by decide) J1)
   · have hborrow : isSkipBorrowN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := if_neg hb
@@ -349,7 +389,9 @@ theorem divK_loop_body_n3_call_unified_j1_spec_within_noNop
       hbltu hborrow
     intro_lets at J1
     exact cpsTripleWithin_weaken
-      (fun h hp => hp)
+      (fun h hp => by
+        rw [loopBodyN3CallUnifiedPre_unfold] at hp
+        exact hp)
       (fun h hp => by rw [← loopIterPostN3Call_skip hb]; exact hp)
       (cpsTripleWithin_mono_nSteps (by decide) J1)
 
@@ -366,26 +408,12 @@ theorem divK_loop_body_n3_call_unified_j0_spec_within
     (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
     (hbltu : BitVec.ult u3 v2)
     (hcarry2_nz : isAddbackCarry2NzN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
-    let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 202 (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
-       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-       ((uBase + signExtend12 4064) ↦ₘ uTop) **
-       (qAddr ↦ₘ qOld) **
-       (sp + signExtend12 3968 ↦ₘ retMem) **
-       (sp + signExtend12 3960 ↦ₘ dMem) **
-       (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
+      (loopBodyN3CallUnifiedPre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0)
       (loopIterPostN3Call sp base (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro uBase qAddr
+  let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
   by_cases hb : BitVec.ult uTop (mulsubN4_c3 (div128Quot u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3)
   · -- addback path: use _beq spec
     have hborrow : isAddbackBorrowN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
@@ -396,7 +424,9 @@ theorem divK_loop_body_n3_call_unified_j0_spec_within
       hbltu hborrow hcarry2_nz
     intro_lets at J0
     exact cpsTripleWithin_weaken
-      (fun h hp => hp)
+      (fun h hp => by
+        rw [loopBodyN3CallUnifiedPre_unfold] at hp
+        exact hp)
       (fun h hp => by
         rw [loopBodyN3CallAddbackBeqPost_eq_J] at hp
         rw [← loopIterPostN3Call_addback hb]; exact hp)
@@ -409,7 +439,9 @@ theorem divK_loop_body_n3_call_unified_j0_spec_within
       hbltu hborrow
     intro_lets at J0
     exact cpsTripleWithin_weaken
-      (fun h hp => hp)
+      (fun h hp => by
+        rw [loopBodyN3CallUnifiedPre_unfold] at hp
+        exact hp)
       (fun h hp => by
         delta loopIterPostN3Call iterN3Call iterWithDoubleAddback
               loopBodyN3CallSkipPost loopBodyN3SkipPost loopBodySkipPost
@@ -426,26 +458,12 @@ theorem divK_loop_body_n3_call_unified_j0_spec_within_noNop
     (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
     (hbltu : BitVec.ult u3 v2)
     (hcarry2_nz : isAddbackCarry2NzN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
-    let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 202 (base + loopBodyOff) (base + denormOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
-       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-       ((uBase + signExtend12 4064) ↦ₘ uTop) **
-       (qAddr ↦ₘ qOld) **
-       (sp + signExtend12 3968 ↦ₘ retMem) **
-       (sp + signExtend12 3960 ↦ₘ dMem) **
-       (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
+      (loopBodyN3CallUnifiedPre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0)
       (loopIterPostN3Call sp base (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro uBase qAddr
+  let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
   by_cases hb : BitVec.ult uTop (mulsubN4_c3 (div128Quot u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3)
   · have hborrow : isAddbackBorrowN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
       delta isAddbackBorrowN3Call; simp only []; rw [if_pos hb]; decide
@@ -455,7 +473,9 @@ theorem divK_loop_body_n3_call_unified_j0_spec_within_noNop
       hbltu hborrow hcarry2_nz
     intro_lets at J0
     exact cpsTripleWithin_weaken
-      (fun h hp => hp)
+      (fun h hp => by
+        rw [loopBodyN3CallUnifiedPre_unfold] at hp
+        exact hp)
       (fun h hp => by
         rw [loopBodyN3CallAddbackBeqPost_eq_J] at hp
         rw [← loopIterPostN3Call_addback hb]; exact hp)
@@ -467,7 +487,9 @@ theorem divK_loop_body_n3_call_unified_j0_spec_within_noNop
       hbltu hborrow
     intro_lets at J0
     exact cpsTripleWithin_weaken
-      (fun h hp => hp)
+      (fun h hp => by
+        rw [loopBodyN3CallUnifiedPre_unfold] at hp
+        exact hp)
       (fun h hp => by
         delta loopIterPostN3Call iterN3Call iterWithDoubleAddback
               loopBodyN3CallSkipPost loopBodyN3SkipPost loopBodySkipPost
@@ -545,11 +567,14 @@ theorem divK_loop_n3_max_max_spec_within
       rw [hj', u_j1_0_eq_j0_4088, u_j1_4088_eq_j0_4080,
           u_j1_4080_eq_j0_4072, u_j1_4072_eq_j0_4064] at hp
       rw [sepConj_assoc'] at hp
+      rw [loopBodyN3MaxUnifiedPre_unfold]
       xperm_chunked hp)
     J1f J0f
   -- 5. Clean up postcondition
   exact cpsTripleWithin_weaken
-    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by
+      rw [loopBodyN3MaxUnifiedPre_unfold]
+      xperm_hyp hp)
     (fun h hp => by
       delta loopN3MaxPost
       exact hp)
@@ -611,10 +636,13 @@ theorem divK_loop_n3_max_max_spec_within_noNop
       rw [hj', u_j1_0_eq_j0_4088, u_j1_4088_eq_j0_4080,
           u_j1_4080_eq_j0_4072, u_j1_4072_eq_j0_4064] at hp
       rw [sepConj_assoc'] at hp
+      rw [loopBodyN3MaxUnifiedPre_unfold]
       xperm_chunked hp)
     J1f J0f
   exact cpsTripleWithin_weaken
-    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by
+      rw [loopBodyN3MaxUnifiedPre_unfold]
+      xperm_hyp hp)
     (fun h hp => by
       delta loopN3MaxPost
       exact hp)
@@ -696,11 +724,14 @@ theorem divK_loop_n3_call_call_spec_within
       rw [hj', u_j1_0_eq_j0_4088, u_j1_4088_eq_j0_4080,
           u_j1_4080_eq_j0_4072, u_j1_4072_eq_j0_4064] at hp
       rw [sepConj_assoc'] at hp
+      rw [loopBodyN3CallUnifiedPre_unfold]
       xperm_hyp hp)
     J1f J0f
   -- 5. Clean up postcondition
   exact cpsTripleWithin_weaken
-    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by
+      rw [loopBodyN3CallUnifiedPre_unfold]
+      xperm_hyp hp)
     (fun h hp => by
       delta loopN3CallCallPost
       exact hp)
@@ -770,10 +801,13 @@ theorem divK_loop_n3_call_call_spec_within_noNop
       rw [hj', u_j1_0_eq_j0_4088, u_j1_4088_eq_j0_4080,
           u_j1_4080_eq_j0_4072, u_j1_4072_eq_j0_4064] at hp
       rw [sepConj_assoc'] at hp
+      rw [loopBodyN3CallUnifiedPre_unfold]
       xperm_hyp hp)
     J1f J0f
   exact cpsTripleWithin_weaken
-    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by
+      rw [loopBodyN3CallUnifiedPre_unfold]
+      xperm_hyp hp)
     (fun h hp => by
       delta loopN3CallCallPost
       exact hp)
@@ -857,11 +891,14 @@ theorem divK_loop_n3_max_call_spec_within
       rw [hj', u_j1_0_eq_j0_4088, u_j1_4088_eq_j0_4080,
           u_j1_4080_eq_j0_4072, u_j1_4072_eq_j0_4064] at hp
       rw [sepConj_assoc'] at hp
+      rw [loopBodyN3CallUnifiedPre_unfold]
       xperm_hyp hp)
     J1f J0f
   -- 5. Clean up postcondition
   exact cpsTripleWithin_weaken
-    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by
+      rw [loopBodyN3MaxUnifiedPre_unfold]
+      xperm_hyp hp)
     (fun h hp => by
       delta loopN3MaxCallPost
       exact hp)
@@ -933,10 +970,13 @@ theorem divK_loop_n3_max_call_spec_within_noNop
       rw [hj', u_j1_0_eq_j0_4088, u_j1_4088_eq_j0_4080,
           u_j1_4080_eq_j0_4072, u_j1_4072_eq_j0_4064] at hp
       rw [sepConj_assoc'] at hp
+      rw [loopBodyN3CallUnifiedPre_unfold]
       xperm_hyp hp)
     J1f J0f
   exact cpsTripleWithin_weaken
-    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by
+      rw [loopBodyN3MaxUnifiedPre_unfold]
+      xperm_hyp hp)
     (fun h hp => by
       delta loopN3MaxCallPost
       exact hp)
@@ -1017,11 +1057,14 @@ theorem divK_loop_n3_call_max_spec_within
       rw [hj', u_j1_0_eq_j0_4088, u_j1_4088_eq_j0_4080,
           u_j1_4080_eq_j0_4072, u_j1_4072_eq_j0_4064] at hp
       rw [sepConj_assoc'] at hp
+      rw [loopBodyN3MaxUnifiedPre_unfold]
       xperm_hyp hp)
     J1f J0f
   -- 5. Clean up postcondition
   exact cpsTripleWithin_weaken
-    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by
+      rw [loopBodyN3CallUnifiedPre_unfold]
+      xperm_hyp hp)
     (fun h hp => by
       delta loopN3CallMaxPost
       exact hp)
@@ -1090,10 +1133,13 @@ theorem divK_loop_n3_call_max_spec_within_noNop
       rw [hj', u_j1_0_eq_j0_4088, u_j1_4088_eq_j0_4080,
           u_j1_4080_eq_j0_4072, u_j1_4072_eq_j0_4064] at hp
       rw [sepConj_assoc'] at hp
+      rw [loopBodyN3MaxUnifiedPre_unfold]
       xperm_hyp hp)
     J1f J0f
   exact cpsTripleWithin_weaken
-    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by
+      rw [loopBodyN3CallUnifiedPre_unfold]
+      xperm_hyp hp)
     (fun h hp => by
       delta loopN3CallMaxPost
       exact hp)


### PR DESCRIPTION
## Summary
- add irreducible N3 unified max/call precondition definitions for LoopComposeN3 wrappers
- replace the eight inline uBase/qAddr theorem precondition surfaces with named preconditions
- unfold the named preconditions at wrapper and composition bridge boundaries only

## Verification
- lake build EvmAsm.Evm64.DivMod.LoopComposeN3
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- scripts/check-file-size.sh EvmAsm/Evm64/DivMod/LoopComposeN3.lean