### PR TITLE
refactor(sdiv): hide loop cps precondition surfaces

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopComposeN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopComposeN2.lean
@@ -385,7 +385,7 @@ theorem divK_loop_body_n2_max_unified_j0_spec_within
       hcarry2_nz
     intro_lets at J0
     exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
-      (fun _ hp => by rw [loopBodyN2J0Pre_unfold] at hp; exact hp)
+      (fun _ hp => by rw [loopBodyN2J0Pre_unfold] at hp; rw [loopBodyN2MaxSkipJ0Pre_unfold]; exact hp)
       (fun h hp => by
         rw [← loopIterPostN2Max_addback hb]; exact hp)
       (J0 hborrow)
@@ -397,10 +397,7 @@ theorem divK_loop_body_n2_max_unified_j0_spec_within
       hbltu
     intro_lets at J0
     exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
-      (fun _ hp => by
-        rw [loopBodyN2J0Pre_unfold] at hp
-        rw [loopBodyN2MaxSkipJ0Pre_unfold]
-        exact hp)
+      (fun _ hp => by rw [loopBodyN2J0Pre_unfold] at hp; rw [loopBodyN2MaxSkipJ0Pre_unfold]; exact hp)
       (fun h hp => by
         rw [← loopIterPostN2Max_skip hb]; exact hp)
       (J0 hborrow)
@@ -425,7 +422,10 @@ theorem divK_loop_body_n2_max_unified_j0_spec_within_noNop
       hcarry2_nz
     intro_lets at J0
     exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
-      (fun _ hp => by rw [loopBodyN2J0Pre_unfold] at hp; exact hp)
+      (fun _ hp => by
+        rw [loopBodyN2J0Pre_unfold] at hp
+        rw [loopBodyN2MaxSkipJ0Pre_unfold]
+        exact hp)
       (fun h hp => by
         rw [← loopIterPostN2Max_addback hb]; exact hp)
       (J0 hborrow)
@@ -805,7 +805,7 @@ theorem divK_loop_body_n2_call_unified_j0_spec_within
       hcarry2_nz
     intro_lets at J0
     exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
-      (fun _ hp => by rw [loopBodyN2J0CallPre_unfold] at hp; exact hp)
+      (fun _ hp => by rw [loopBodyN2J0CallPre_unfold] at hp; rw [loopBodyN2CallSkipJ0Pre_unfold]; exact hp)
       (fun h hp => by
         rw [← loopIterPostN2Call_addback hb]; exact hp)
       J0
@@ -817,10 +817,7 @@ theorem divK_loop_body_n2_call_unified_j0_spec_within
       hbltu hborrow
     intro_lets at J0
     exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
-      (fun _ hp => by
-        rw [loopBodyN2J0CallPre_unfold] at hp
-        rw [loopBodyN2CallSkipJ0Pre_unfold]
-        exact hp)
+      (fun _ hp => by rw [loopBodyN2J0CallPre_unfold] at hp; rw [loopBodyN2CallSkipJ0Pre_unfold]; exact hp)
       (fun h hp => by
         rw [← loopIterPostN2Call_skip hb]; exact hp)
       J0
@@ -847,7 +844,10 @@ theorem divK_loop_body_n2_call_unified_j0_spec_within_noNop
       hcarry2_nz
     intro_lets at J0
     exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
-      (fun _ hp => by rw [loopBodyN2J0CallPre_unfold] at hp; exact hp)
+      (fun _ hp => by
+        rw [loopBodyN2J0CallPre_unfold] at hp
+        rw [loopBodyN2CallSkipJ0Pre_unfold]
+        exact hp)
       (fun h hp => by
         rw [← loopIterPostN2Call_addback hb]; exact hp)
       J0

--- a/EvmAsm/Evm64/DivMod/LoopComposeN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopComposeN2.lean
@@ -781,7 +781,10 @@ theorem divK_loop_body_n2_call_unified_j0_spec_within
       hbltu hborrow
     intro_lets at J0
     exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
-      (fun _ hp => by rw [loopBodyN2J0CallPre_unfold] at hp; exact hp)
+      (fun _ hp => by
+        rw [loopBodyN2J0CallPre_unfold] at hp
+        rw [loopBodyN2CallSkipJ0Pre_unfold]
+        exact hp)
       (fun h hp => by
         rw [← loopIterPostN2Call_skip hb]; exact hp)
       J0
@@ -819,7 +822,10 @@ theorem divK_loop_body_n2_call_unified_j0_spec_within_noNop
       hbltu hborrow
     intro_lets at J0
     exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
-      (fun _ hp => by rw [loopBodyN2J0CallPre_unfold] at hp; exact hp)
+      (fun _ hp => by
+        rw [loopBodyN2J0CallPre_unfold] at hp
+        rw [loopBodyN2CallSkipJ0Pre_unfold]
+        exact hp)
       (fun h hp => by
         rw [← loopIterPostN2Call_skip hb]; exact hp)
       J0

--- a/EvmAsm/Evm64/DivMod/LoopComposeN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopComposeN2.lean
@@ -139,7 +139,10 @@ theorem divK_loop_body_n2_max_unified_j2_spec_within
       v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base hbltu
     intro_lets at J2
     exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
-      (fun _ hp => by rw [loopBodyN2J2Pre_unfold] at hp; exact hp)
+      (fun _ hp => by
+        rw [loopBodyN2J2Pre_unfold] at hp
+        rw [loopBodyN2MaxSkipJgt0Pre_unfold]
+        exact hp)
       (fun h hp => by
         rw [← loopIterPostN2Max_skip hb]; exact hp)
       (J2 hborrow)
@@ -177,7 +180,10 @@ theorem divK_loop_body_n2_max_unified_j2_spec_within_noNop
       v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base hbltu
     intro_lets at J2
     exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
-      (fun _ hp => by rw [loopBodyN2J2Pre_unfold] at hp; exact hp)
+      (fun _ hp => by
+        rw [loopBodyN2J2Pre_unfold] at hp
+        rw [loopBodyN2MaxSkipJgt0Pre_unfold]
+        exact hp)
       (fun h hp => by
         rw [← loopIterPostN2Max_skip hb]; exact hp)
       (J2 hborrow)
@@ -257,7 +263,10 @@ theorem divK_loop_body_n2_max_unified_j1_spec_within
       hbltu
     intro_lets at J1
     exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
-      (fun _ hp => by rw [loopBodyN2J1Pre_unfold] at hp; exact hp)
+      (fun _ hp => by
+        rw [loopBodyN2J1Pre_unfold] at hp
+        rw [loopBodyN2MaxSkipJgt0Pre_unfold]
+        exact hp)
       (fun h hp => by
         rw [← loopIterPostN2Max_skip hb]; exact hp)
       (J1 hborrow)
@@ -296,7 +305,10 @@ theorem divK_loop_body_n2_max_unified_j1_spec_within_noNop
       hbltu
     intro_lets at J1
     exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
-      (fun _ hp => by rw [loopBodyN2J1Pre_unfold] at hp; exact hp)
+      (fun _ hp => by
+        rw [loopBodyN2J1Pre_unfold] at hp
+        rw [loopBodyN2MaxSkipJgt0Pre_unfold]
+        exact hp)
       (fun h hp => by
         rw [← loopIterPostN2Max_skip hb]; exact hp)
       (J1 hborrow)

--- a/EvmAsm/Evm64/DivMod/LoopComposeN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopComposeN2.lean
@@ -523,7 +523,7 @@ theorem divK_loop_body_n2_call_unified_j2_spec_within
       hcarry2_nz
     intro_lets at J2
     exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
-      (fun _ hp => by rw [loopBodyN2J2CallPre_unfold] at hp; exact hp)
+      (fun _ hp => by rw [loopBodyN2J2CallPre_unfold] at hp; rw [loopBodyN2CallJgt0Pre_unfold]; exact hp)
       (fun h hp => by
         rw [← loopIterPostN2Call_addback hb]; exact hp)
       J2
@@ -539,7 +539,7 @@ theorem divK_loop_body_n2_call_unified_j2_spec_within
     exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
       (fun _ hp => by
         rw [loopBodyN2J2CallPre_unfold] at hp
-        rw [loopBodyN2CallSkipJgt0Pre_unfold]
+        rw [loopBodyN2CallJgt0Pre_unfold]
         exact hp)
       (fun h hp => by
         rw [← loopIterPostN2Call_skip hb]; exact hp)
@@ -570,7 +570,7 @@ theorem divK_loop_body_n2_call_unified_j2_spec_within_noNop
       hcarry2_nz
     intro_lets at J2
     exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
-      (fun _ hp => by rw [loopBodyN2J2CallPre_unfold] at hp; exact hp)
+      (fun _ hp => by rw [loopBodyN2J2CallPre_unfold] at hp; rw [loopBodyN2CallJgt0Pre_unfold]; exact hp)
       (fun h hp => by
         rw [← loopIterPostN2Call_addback hb]; exact hp)
       J2
@@ -585,7 +585,7 @@ theorem divK_loop_body_n2_call_unified_j2_spec_within_noNop
     exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
       (fun _ hp => by
         rw [loopBodyN2J2CallPre_unfold] at hp
-        rw [loopBodyN2CallSkipJgt0Pre_unfold]
+        rw [loopBodyN2CallJgt0Pre_unfold]
         exact hp)
       (fun h hp => by
         rw [← loopIterPostN2Call_skip hb]; exact hp)
@@ -665,7 +665,7 @@ theorem divK_loop_body_n2_call_unified_j1_spec_within
       hcarry2_nz
     intro_lets at J1
     exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
-      (fun _ hp => by rw [loopBodyN2J1CallPre_unfold] at hp; exact hp)
+      (fun _ hp => by rw [loopBodyN2J1CallPre_unfold] at hp; rw [loopBodyN2CallJgt0Pre_unfold]; exact hp)
       (fun h hp => by
         rw [← loopIterPostN2Call_addback hb]; exact hp)
       J1
@@ -681,7 +681,7 @@ theorem divK_loop_body_n2_call_unified_j1_spec_within
     exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
       (fun _ hp => by
         rw [loopBodyN2J1CallPre_unfold] at hp
-        rw [loopBodyN2CallSkipJgt0Pre_unfold]
+        rw [loopBodyN2CallJgt0Pre_unfold]
         exact hp)
       (fun h hp => by
         rw [← loopIterPostN2Call_skip hb]; exact hp)
@@ -712,7 +712,7 @@ theorem divK_loop_body_n2_call_unified_j1_spec_within_noNop
       hcarry2_nz
     intro_lets at J1
     exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
-      (fun _ hp => by rw [loopBodyN2J1CallPre_unfold] at hp; exact hp)
+      (fun _ hp => by rw [loopBodyN2J1CallPre_unfold] at hp; rw [loopBodyN2CallJgt0Pre_unfold]; exact hp)
       (fun h hp => by
         rw [← loopIterPostN2Call_addback hb]; exact hp)
       J1
@@ -727,7 +727,7 @@ theorem divK_loop_body_n2_call_unified_j1_spec_within_noNop
     exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
       (fun _ hp => by
         rw [loopBodyN2J1CallPre_unfold] at hp
-        rw [loopBodyN2CallSkipJgt0Pre_unfold]
+        rw [loopBodyN2CallJgt0Pre_unfold]
         exact hp)
       (fun h hp => by
         rw [← loopIterPostN2Call_skip hb]; exact hp)

--- a/EvmAsm/Evm64/DivMod/LoopComposeN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopComposeN2.lean
@@ -121,12 +121,15 @@ theorem divK_loop_body_n2_max_unified_j2_spec_within
                     then (1 : Word) else 0) ≠ (0 : Word) := by rw [if_pos hb]; decide
     have J2 := divK_loop_body_n2_max_addback_jgt0_beq_spec_within (2 : Word)
       EvmAsm.Evm64.DivMod.AddrNorm.slt_jpos_2
-      sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base hbltu
-      hcarry2_nz
+        sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base hbltu
+        hcarry2_nz
     intro_lets at J2
     exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
-      (fun _ hp => by rw [loopBodyN2J2Pre_unfold] at hp; exact hp)
+      (fun _ hp => by
+        rw [loopBodyN2J2Pre_unfold] at hp
+        rw [loopBodyN2MaxJgt0Pre_unfold]
+        exact hp)
       (fun h hp => by
         rw [← loopIterPostN2Max_addback hb]; exact hp)
       (J2 hborrow)
@@ -141,7 +144,7 @@ theorem divK_loop_body_n2_max_unified_j2_spec_within
     exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
       (fun _ hp => by
         rw [loopBodyN2J2Pre_unfold] at hp
-        rw [loopBodyN2MaxSkipJgt0Pre_unfold]
+        rw [loopBodyN2MaxJgt0Pre_unfold]
         exact hp)
       (fun h hp => by
         rw [← loopIterPostN2Max_skip hb]; exact hp)
@@ -163,12 +166,15 @@ theorem divK_loop_body_n2_max_unified_j2_spec_within_noNop
                     then (1 : Word) else 0) ≠ (0 : Word) := by rw [if_pos hb]; decide
     have J2 := divK_loop_body_n2_max_addback_jgt0_beq_spec_within_noNop (2 : Word)
       EvmAsm.Evm64.DivMod.AddrNorm.slt_jpos_2
-      sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base hbltu
-      hcarry2_nz
+        sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base hbltu
+        hcarry2_nz
     intro_lets at J2
     exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
-      (fun _ hp => by rw [loopBodyN2J2Pre_unfold] at hp; exact hp)
+      (fun _ hp => by
+        rw [loopBodyN2J2Pre_unfold] at hp
+        rw [loopBodyN2MaxJgt0Pre_unfold]
+        exact hp)
       (fun h hp => by
         rw [← loopIterPostN2Max_addback hb]; exact hp)
       (J2 hborrow)
@@ -182,7 +188,7 @@ theorem divK_loop_body_n2_max_unified_j2_spec_within_noNop
     exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
       (fun _ hp => by
         rw [loopBodyN2J2Pre_unfold] at hp
-        rw [loopBodyN2MaxSkipJgt0Pre_unfold]
+        rw [loopBodyN2MaxJgt0Pre_unfold]
         exact hp)
       (fun h hp => by
         rw [← loopIterPostN2Max_skip hb]; exact hp)
@@ -244,12 +250,15 @@ theorem divK_loop_body_n2_max_unified_j1_spec_within
                     then (1 : Word) else 0) ≠ (0 : Word) := by rw [if_pos hb]; decide
     have J1 := divK_loop_body_n2_max_addback_jgt0_beq_spec_within (1 : Word)
       EvmAsm.Evm64.DivMod.AddrNorm.slt_jpos_1
-      sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base hbltu
-      hcarry2_nz
+        sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base hbltu
+        hcarry2_nz
     intro_lets at J1
     exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
-      (fun _ hp => by rw [loopBodyN2J1Pre_unfold] at hp; exact hp)
+      (fun _ hp => by
+        rw [loopBodyN2J1Pre_unfold] at hp
+        rw [loopBodyN2MaxJgt0Pre_unfold]
+        exact hp)
       (fun h hp => by
         rw [← loopIterPostN2Max_addback hb]; exact hp)
       (J1 hborrow)
@@ -265,7 +274,7 @@ theorem divK_loop_body_n2_max_unified_j1_spec_within
     exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
       (fun _ hp => by
         rw [loopBodyN2J1Pre_unfold] at hp
-        rw [loopBodyN2MaxSkipJgt0Pre_unfold]
+        rw [loopBodyN2MaxJgt0Pre_unfold]
         exact hp)
       (fun h hp => by
         rw [← loopIterPostN2Max_skip hb]; exact hp)
@@ -287,12 +296,15 @@ theorem divK_loop_body_n2_max_unified_j1_spec_within_noNop
                     then (1 : Word) else 0) ≠ (0 : Word) := by rw [if_pos hb]; decide
     have J1 := divK_loop_body_n2_max_addback_jgt0_beq_spec_within_noNop (1 : Word)
       EvmAsm.Evm64.DivMod.AddrNorm.slt_jpos_1
-      sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base hbltu
-      hcarry2_nz
+        sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base hbltu
+        hcarry2_nz
     intro_lets at J1
     exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
-      (fun _ hp => by rw [loopBodyN2J1Pre_unfold] at hp; exact hp)
+      (fun _ hp => by
+        rw [loopBodyN2J1Pre_unfold] at hp
+        rw [loopBodyN2MaxJgt0Pre_unfold]
+        exact hp)
       (fun h hp => by
         rw [← loopIterPostN2Max_addback hb]; exact hp)
       (J1 hborrow)
@@ -307,7 +319,7 @@ theorem divK_loop_body_n2_max_unified_j1_spec_within_noNop
     exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
       (fun _ hp => by
         rw [loopBodyN2J1Pre_unfold] at hp
-        rw [loopBodyN2MaxSkipJgt0Pre_unfold]
+        rw [loopBodyN2MaxJgt0Pre_unfold]
         exact hp)
       (fun h hp => by
         rw [← loopIterPostN2Max_skip hb]; exact hp)

--- a/EvmAsm/Evm64/DivMod/LoopComposeN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopComposeN2.lean
@@ -520,12 +520,15 @@ theorem divK_loop_body_n2_call_unified_j2_spec_within
     have J2 := divK_loop_body_n2_call_skip_jgt0_spec_within (2 : Word)
       EvmAsm.Evm64.DivMod.AddrNorm.slt_jpos_2
       sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 base
-      halign
-      hbltu hborrow
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 base
+        halign
+        hbltu hborrow
     intro_lets at J2
     exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
-      (fun _ hp => by rw [loopBodyN2J2CallPre_unfold] at hp; exact hp)
+      (fun _ hp => by
+        rw [loopBodyN2J2CallPre_unfold] at hp
+        rw [loopBodyN2CallSkipJgt0Pre_unfold]
+        exact hp)
       (fun h hp => by
         rw [← loopIterPostN2Call_skip hb]; exact hp)
       J2
@@ -563,12 +566,15 @@ theorem divK_loop_body_n2_call_unified_j2_spec_within_noNop
     have J2 := divK_loop_body_n2_call_skip_jgt0_spec_within_noNop (2 : Word)
       EvmAsm.Evm64.DivMod.AddrNorm.slt_jpos_2
       sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 base
-      halign
-      hbltu hborrow
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 base
+        halign
+        hbltu hborrow
     intro_lets at J2
     exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
-      (fun _ hp => by rw [loopBodyN2J2CallPre_unfold] at hp; exact hp)
+      (fun _ hp => by
+        rw [loopBodyN2J2CallPre_unfold] at hp
+        rw [loopBodyN2CallSkipJgt0Pre_unfold]
+        exact hp)
       (fun h hp => by
         rw [← loopIterPostN2Call_skip hb]; exact hp)
       J2
@@ -656,12 +662,15 @@ theorem divK_loop_body_n2_call_unified_j1_spec_within
     have J1 := divK_loop_body_n2_call_skip_jgt0_spec_within (1 : Word)
       EvmAsm.Evm64.DivMod.AddrNorm.slt_jpos_1
       sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 base
-      halign
-      hbltu hborrow
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 base
+        halign
+        hbltu hborrow
     intro_lets at J1
     exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
-      (fun _ hp => by rw [loopBodyN2J1CallPre_unfold] at hp; exact hp)
+      (fun _ hp => by
+        rw [loopBodyN2J1CallPre_unfold] at hp
+        rw [loopBodyN2CallSkipJgt0Pre_unfold]
+        exact hp)
       (fun h hp => by
         rw [← loopIterPostN2Call_skip hb]; exact hp)
       J1
@@ -699,12 +708,15 @@ theorem divK_loop_body_n2_call_unified_j1_spec_within_noNop
     have J1 := divK_loop_body_n2_call_skip_jgt0_spec_within_noNop (1 : Word)
       EvmAsm.Evm64.DivMod.AddrNorm.slt_jpos_1
       sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 base
-      halign
-      hbltu hborrow
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 base
+        halign
+        hbltu hborrow
     intro_lets at J1
     exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
-      (fun _ hp => by rw [loopBodyN2J1CallPre_unfold] at hp; exact hp)
+      (fun _ hp => by
+        rw [loopBodyN2J1CallPre_unfold] at hp
+        rw [loopBodyN2CallSkipJgt0Pre_unfold]
+        exact hp)
       (fun h hp => by
         rw [← loopIterPostN2Call_skip hb]; exact hp)
       J1

--- a/EvmAsm/Evm64/DivMod/LoopComposeN3.lean
+++ b/EvmAsm/Evm64/DivMod/LoopComposeN3.lean
@@ -51,6 +51,92 @@ theorem u_j1_4072_eq_j0_4064 {sp : Word} :
     (sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4064 := by
   divmod_addr
 
+@[irreducible] def loopBodyN3MaxUnifiedPre
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     j v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word) : Assertion :=
+  let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
+  ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
+   (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+   (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
+   (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
+   (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
+   ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+   ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+   ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+   ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+   ((uBase + signExtend12 4064) ↦ₘ uTop) **
+   (qAddr ↦ₘ qOld))
+
+theorem loopBodyN3MaxUnifiedPre_unfold
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     j v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word) :
+    loopBodyN3MaxUnifiedPre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      j v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld =
+    (let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+     let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
+     ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
+      (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+      (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
+      (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
+      (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
+      ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+      ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+      ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+      ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+      ((uBase + signExtend12 4064) ↦ₘ uTop) **
+      (qAddr ↦ₘ qOld)) : Assertion) := by
+  unfold loopBodyN3MaxUnifiedPre
+  rfl
+
+@[irreducible] def loopBodyN3CallUnifiedPre
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     j v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
+     retMem dMem dloMem scratch_un0 : Word) : Assertion :=
+  let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
+  ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
+   (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+   (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
+   (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
+   (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
+   ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+   ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+   ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+   ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+   ((uBase + signExtend12 4064) ↦ₘ uTop) **
+   (qAddr ↦ₘ qOld) **
+   (sp + signExtend12 3968 ↦ₘ retMem) **
+   (sp + signExtend12 3960 ↦ₘ dMem) **
+   (sp + signExtend12 3952 ↦ₘ dloMem) **
+   ((sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1))
+
+theorem loopBodyN3CallUnifiedPre_unfold
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     j v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
+     retMem dMem dloMem scratch_un0 : Word) :
+    loopBodyN3CallUnifiedPre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      j v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 =
+    (let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+     let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
+     ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
+      (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+      (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
+      (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
+      (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
+      ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+      ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+      ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+      ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+      ((uBase + signExtend12 4064) ↦ₘ uTop) **
+      (qAddr ↦ₘ qOld) **
+      (sp + signExtend12 3968 ↦ₘ retMem) **
+      (sp + signExtend12 3960 ↦ₘ dMem) **
+      (sp + signExtend12 3952 ↦ₘ dloMem) **
+      ((sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)) : Assertion) := by
+  unfold loopBodyN3CallUnifiedPre
+  rfl
+
 -- ============================================================================
 -- Double-addback () unified j=1 max-path spec
 -- Uses _beq LoopIter specs with borrow-branching loopIterPostN3Max.
@@ -62,22 +148,12 @@ theorem divK_loop_body_n3_max_unified_j1_spec_within
     (base : Word)
     (hbltu : ¬BitVec.ult u3 v2)
     (hcarry2_nz : isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
-    let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 152 (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (1 : Word)) **
-       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-       ((uBase + signExtend12 4064) ↦ₘ uTop) **
-       (qAddr ↦ₘ qOld))
+      (loopBodyN3MaxUnifiedPre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld)
       (loopIterPostN3Max sp (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro uBase qAddr
+  let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
   by_cases hb : BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
   · -- addback path: use _beq spec
     have hborrow : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
@@ -87,7 +163,9 @@ theorem divK_loop_body_n3_max_unified_j1_spec_within
       hbltu hcarry2_nz
     intro_lets at J1
     exact cpsTripleWithin_weaken
-      (fun h hp => hp)
+      (fun h hp => by
+        rw [loopBodyN3MaxUnifiedPre_unfold] at hp
+        exact hp)
       (fun h hp => by rw [← loopIterPostN3Max_addback hb]; exact hp)
       (cpsTripleWithin_mono_nSteps (by decide) (J1 hborrow))
   · -- skip path
@@ -98,7 +176,9 @@ theorem divK_loop_body_n3_max_unified_j1_spec_within
       hbltu
     intro_lets at J1
     exact cpsTripleWithin_weaken
-      (fun h hp => hp)
+      (fun h hp => by
+        rw [loopBodyN3MaxUnifiedPre_unfold] at hp
+        exact hp)
       (fun h hp => by rw [← loopIterPostN3Max_skip hb]; exact hp)
       (cpsTripleWithin_mono_nSteps (by decide) (J1 hborrow))
 
@@ -109,22 +189,12 @@ theorem divK_loop_body_n3_max_unified_j1_spec_within_noNop
     (base : Word)
     (hbltu : ¬BitVec.ult u3 v2)
     (hcarry2_nz : isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
-    let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 152 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (1 : Word)) **
-       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-       ((uBase + signExtend12 4064) ↦ₘ uTop) **
-       (qAddr ↦ₘ qOld))
+      (loopBodyN3MaxUnifiedPre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld)
       (loopIterPostN3Max sp (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro uBase qAddr
+  let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
   by_cases hb : BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
   · have hborrow : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
                     then (1 : Word) else 0) ≠ (0 : Word) := by rw [if_pos hb]; decide
@@ -133,7 +203,9 @@ theorem divK_loop_body_n3_max_unified_j1_spec_within_noNop
       hbltu hcarry2_nz
     intro_lets at J1
     exact cpsTripleWithin_weaken
-      (fun h hp => hp)
+      (fun h hp => by
+        rw [loopBodyN3MaxUnifiedPre_unfold] at hp
+        exact hp)
       (fun h hp => by rw [← loopIterPostN3Max_addback hb]; exact hp)
       (cpsTripleWithin_mono_nSteps (by decide) (J1 hborrow))
   · have hborrow : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
@@ -143,7 +215,9 @@ theorem divK_loop_body_n3_max_unified_j1_spec_within_noNop
       hbltu
     intro_lets at J1
     exact cpsTripleWithin_weaken
-      (fun h hp => hp)
+      (fun h hp => by
+        rw [loopBodyN3MaxUnifiedPre_unfold] at hp
+        exact hp)
       (fun h hp => by rw [← loopIterPostN3Max_skip hb]; exact hp)
       (cpsTripleWithin_mono_nSteps (by decide) (J1 hborrow))
 
@@ -158,22 +232,12 @@ theorem divK_loop_body_n3_max_unified_j0_spec_within
     (base : Word)
     (hbltu : ¬BitVec.ult u3 v2)
     (hcarry2_nz : isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
-    let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 152 (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
-       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-       ((uBase + signExtend12 4064) ↦ₘ uTop) **
-       (qAddr ↦ₘ qOld))
+      (loopBodyN3MaxUnifiedPre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld)
       (loopIterPostN3Max sp (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro uBase qAddr
+  let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
   by_cases hb : BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
   · -- addback path: use _beq spec
     have hborrow : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
@@ -183,7 +247,9 @@ theorem divK_loop_body_n3_max_unified_j0_spec_within
       hbltu hcarry2_nz
     intro_lets at J0
     exact cpsTripleWithin_weaken
-      (fun h hp => hp)
+      (fun h hp => by
+        rw [loopBodyN3MaxUnifiedPre_unfold] at hp
+        exact hp)
       (fun h hp => by rw [← loopIterPostN3Max_addback hb]; exact hp)
       (cpsTripleWithin_mono_nSteps (by decide) (J0 hborrow))
   · -- skip path
@@ -194,7 +260,9 @@ theorem divK_loop_body_n3_max_unified_j0_spec_within
       hbltu
     intro_lets at J0
     exact cpsTripleWithin_weaken
-      (fun h hp => hp)
+      (fun h hp => by
+        rw [loopBodyN3MaxUnifiedPre_unfold] at hp
+        exact hp)
       (fun h hp => by rw [← loopIterPostN3Max_skip hb]; exact hp)
       (cpsTripleWithin_mono_nSteps (by decide) (J0 hborrow))
 
@@ -205,22 +273,12 @@ theorem divK_loop_body_n3_max_unified_j0_spec_within_noNop
     (base : Word)
     (hbltu : ¬BitVec.ult u3 v2)
     (hcarry2_nz : isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
-    let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 152 (base + loopBodyOff) (base + denormOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
-       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-       ((uBase + signExtend12 4064) ↦ₘ uTop) **
-       (qAddr ↦ₘ qOld))
+      (loopBodyN3MaxUnifiedPre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld)
       (loopIterPostN3Max sp (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro uBase qAddr
+  let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
   by_cases hb : BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
   · have hborrow : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
                     then (1 : Word) else 0) ≠ (0 : Word) := by rw [if_pos hb]; decide
@@ -229,7 +287,9 @@ theorem divK_loop_body_n3_max_unified_j0_spec_within_noNop
       hbltu hcarry2_nz
     intro_lets at J0
     exact cpsTripleWithin_weaken
-      (fun h hp => hp)
+      (fun h hp => by
+        rw [loopBodyN3MaxUnifiedPre_unfold] at hp
+        exact hp)
       (fun h hp => by rw [← loopIterPostN3Max_addback hb]; exact hp)
       (cpsTripleWithin_mono_nSteps (by decide) (J0 hborrow))
   · have hborrow : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
@@ -239,7 +299,9 @@ theorem divK_loop_body_n3_max_unified_j0_spec_within_noNop
       hbltu
     intro_lets at J0
     exact cpsTripleWithin_weaken
-      (fun h hp => hp)
+      (fun h hp => by
+        rw [loopBodyN3MaxUnifiedPre_unfold] at hp
+        exact hp)
       (fun h hp => by rw [← loopIterPostN3Max_skip hb]; exact hp)
       (cpsTripleWithin_mono_nSteps (by decide) (J0 hborrow))
 
@@ -256,26 +318,12 @@ theorem divK_loop_body_n3_call_unified_j1_spec_within
     (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
     (hbltu : BitVec.ult u3 v2)
     (hcarry2_nz : isAddbackCarry2NzN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
-    let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 202 (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (1 : Word)) **
-       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-       ((uBase + signExtend12 4064) ↦ₘ uTop) **
-       (qAddr ↦ₘ qOld) **
-       (sp + signExtend12 3968 ↦ₘ retMem) **
-       (sp + signExtend12 3960 ↦ₘ dMem) **
-       (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
+      (loopBodyN3CallUnifiedPre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0)
       (loopIterPostN3Call sp base (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro uBase qAddr
+  let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
   by_cases hb : BitVec.ult uTop (mulsubN4_c3 (div128Quot u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3)
   · -- addback path: use _beq spec
     have hborrow : isAddbackBorrowN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
@@ -286,7 +334,9 @@ theorem divK_loop_body_n3_call_unified_j1_spec_within
       hbltu hborrow hcarry2_nz
     intro_lets at J1
     exact cpsTripleWithin_weaken
-      (fun h hp => hp)
+      (fun h hp => by
+        rw [loopBodyN3CallUnifiedPre_unfold] at hp
+        exact hp)
       (fun h hp => by rw [← loopIterPostN3Call_addback hb]; exact hp)
       (cpsTripleWithin_mono_nSteps (by decide) J1)
   · -- skip path
@@ -297,7 +347,9 @@ theorem divK_loop_body_n3_call_unified_j1_spec_within
       hbltu hborrow
     intro_lets at J1
     exact cpsTripleWithin_weaken
-      (fun h hp => hp)
+      (fun h hp => by
+        rw [loopBodyN3CallUnifiedPre_unfold] at hp
+        exact hp)
       (fun h hp => by rw [← loopIterPostN3Call_skip hb]; exact hp)
       (cpsTripleWithin_mono_nSteps (by decide) J1)
 
@@ -310,26 +362,12 @@ theorem divK_loop_body_n3_call_unified_j1_spec_within_noNop
     (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
     (hbltu : BitVec.ult u3 v2)
     (hcarry2_nz : isAddbackCarry2NzN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
-    let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 202 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (1 : Word)) **
-       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-       ((uBase + signExtend12 4064) ↦ₘ uTop) **
-       (qAddr ↦ₘ qOld) **
-       (sp + signExtend12 3968 ↦ₘ retMem) **
-       (sp + signExtend12 3960 ↦ₘ dMem) **
-       (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
+      (loopBodyN3CallUnifiedPre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0)
       (loopIterPostN3Call sp base (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro uBase qAddr
+  let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
   by_cases hb : BitVec.ult uTop (mulsubN4_c3 (div128Quot u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3)
   · have hborrow : isAddbackBorrowN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
       delta isAddbackBorrowN3Call; simp only []; rw [if_pos hb]; decide
@@ -339,7 +377,9 @@ theorem divK_loop_body_n3_call_unified_j1_spec_within_noNop
       hbltu hborrow hcarry2_nz
     intro_lets at J1
     exact cpsTripleWithin_weaken
-      (fun h hp => hp)
+      (fun h hp => by
+        rw [loopBodyN3CallUnifiedPre_unfold] at hp
+        exact hp)
       (fun h hp => by rw [← loopIterPostN3Call_addback hb]; exact hp)
       (cpsTripleWithin_mono_nSteps (by decide) J1)
   · have hborrow : isSkipBorrowN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := if_neg hb
@@ -349,7 +389,9 @@ theorem divK_loop_body_n3_call_unified_j1_spec_within_noNop
       hbltu hborrow
     intro_lets at J1
     exact cpsTripleWithin_weaken
-      (fun h hp => hp)
+      (fun h hp => by
+        rw [loopBodyN3CallUnifiedPre_unfold] at hp
+        exact hp)
       (fun h hp => by rw [← loopIterPostN3Call_skip hb]; exact hp)
       (cpsTripleWithin_mono_nSteps (by decide) J1)
 
@@ -366,26 +408,12 @@ theorem divK_loop_body_n3_call_unified_j0_spec_within
     (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
     (hbltu : BitVec.ult u3 v2)
     (hcarry2_nz : isAddbackCarry2NzN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
-    let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 202 (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
-       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-       ((uBase + signExtend12 4064) ↦ₘ uTop) **
-       (qAddr ↦ₘ qOld) **
-       (sp + signExtend12 3968 ↦ₘ retMem) **
-       (sp + signExtend12 3960 ↦ₘ dMem) **
-       (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
+      (loopBodyN3CallUnifiedPre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0)
       (loopIterPostN3Call sp base (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro uBase qAddr
+  let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
   by_cases hb : BitVec.ult uTop (mulsubN4_c3 (div128Quot u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3)
   · -- addback path: use _beq spec
     have hborrow : isAddbackBorrowN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
@@ -396,7 +424,9 @@ theorem divK_loop_body_n3_call_unified_j0_spec_within
       hbltu hborrow hcarry2_nz
     intro_lets at J0
     exact cpsTripleWithin_weaken
-      (fun h hp => hp)
+      (fun h hp => by
+        rw [loopBodyN3CallUnifiedPre_unfold] at hp
+        exact hp)
       (fun h hp => by
         rw [loopBodyN3CallAddbackBeqPost_eq_J] at hp
         rw [← loopIterPostN3Call_addback hb]; exact hp)
@@ -409,7 +439,9 @@ theorem divK_loop_body_n3_call_unified_j0_spec_within
       hbltu hborrow
     intro_lets at J0
     exact cpsTripleWithin_weaken
-      (fun h hp => hp)
+      (fun h hp => by
+        rw [loopBodyN3CallUnifiedPre_unfold] at hp
+        exact hp)
       (fun h hp => by
         delta loopIterPostN3Call iterN3Call iterWithDoubleAddback
               loopBodyN3CallSkipPost loopBodyN3SkipPost loopBodySkipPost
@@ -426,26 +458,12 @@ theorem divK_loop_body_n3_call_unified_j0_spec_within_noNop
     (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
     (hbltu : BitVec.ult u3 v2)
     (hcarry2_nz : isAddbackCarry2NzN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
-    let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 202 (base + loopBodyOff) (base + denormOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
-       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-       ((uBase + signExtend12 4064) ↦ₘ uTop) **
-       (qAddr ↦ₘ qOld) **
-       (sp + signExtend12 3968 ↦ₘ retMem) **
-       (sp + signExtend12 3960 ↦ₘ dMem) **
-       (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
+      (loopBodyN3CallUnifiedPre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0)
       (loopIterPostN3Call sp base (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro uBase qAddr
+  let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
   by_cases hb : BitVec.ult uTop (mulsubN4_c3 (div128Quot u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3)
   · have hborrow : isAddbackBorrowN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
       delta isAddbackBorrowN3Call; simp only []; rw [if_pos hb]; decide
@@ -455,7 +473,9 @@ theorem divK_loop_body_n3_call_unified_j0_spec_within_noNop
       hbltu hborrow hcarry2_nz
     intro_lets at J0
     exact cpsTripleWithin_weaken
-      (fun h hp => hp)
+      (fun h hp => by
+        rw [loopBodyN3CallUnifiedPre_unfold] at hp
+        exact hp)
       (fun h hp => by
         rw [loopBodyN3CallAddbackBeqPost_eq_J] at hp
         rw [← loopIterPostN3Call_addback hb]; exact hp)
@@ -467,7 +487,9 @@ theorem divK_loop_body_n3_call_unified_j0_spec_within_noNop
       hbltu hborrow
     intro_lets at J0
     exact cpsTripleWithin_weaken
-      (fun h hp => hp)
+      (fun h hp => by
+        rw [loopBodyN3CallUnifiedPre_unfold] at hp
+        exact hp)
       (fun h hp => by
         delta loopIterPostN3Call iterN3Call iterWithDoubleAddback
               loopBodyN3CallSkipPost loopBodyN3SkipPost loopBodySkipPost
@@ -545,11 +567,14 @@ theorem divK_loop_n3_max_max_spec_within
       rw [hj', u_j1_0_eq_j0_4088, u_j1_4088_eq_j0_4080,
           u_j1_4080_eq_j0_4072, u_j1_4072_eq_j0_4064] at hp
       rw [sepConj_assoc'] at hp
+      rw [loopBodyN3MaxUnifiedPre_unfold]
       xperm_chunked hp)
     J1f J0f
   -- 5. Clean up postcondition
   exact cpsTripleWithin_weaken
-    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by
+      rw [loopBodyN3MaxUnifiedPre_unfold]
+      xperm_hyp hp)
     (fun h hp => by
       delta loopN3MaxPost
       exact hp)
@@ -611,10 +636,13 @@ theorem divK_loop_n3_max_max_spec_within_noNop
       rw [hj', u_j1_0_eq_j0_4088, u_j1_4088_eq_j0_4080,
           u_j1_4080_eq_j0_4072, u_j1_4072_eq_j0_4064] at hp
       rw [sepConj_assoc'] at hp
+      rw [loopBodyN3MaxUnifiedPre_unfold]
       xperm_chunked hp)
     J1f J0f
   exact cpsTripleWithin_weaken
-    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by
+      rw [loopBodyN3MaxUnifiedPre_unfold]
+      xperm_hyp hp)
     (fun h hp => by
       delta loopN3MaxPost
       exact hp)
@@ -696,11 +724,14 @@ theorem divK_loop_n3_call_call_spec_within
       rw [hj', u_j1_0_eq_j0_4088, u_j1_4088_eq_j0_4080,
           u_j1_4080_eq_j0_4072, u_j1_4072_eq_j0_4064] at hp
       rw [sepConj_assoc'] at hp
+      rw [loopBodyN3CallUnifiedPre_unfold]
       xperm_hyp hp)
     J1f J0f
   -- 5. Clean up postcondition
   exact cpsTripleWithin_weaken
-    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by
+      rw [loopBodyN3CallUnifiedPre_unfold]
+      xperm_hyp hp)
     (fun h hp => by
       delta loopN3CallCallPost
       exact hp)
@@ -770,10 +801,13 @@ theorem divK_loop_n3_call_call_spec_within_noNop
       rw [hj', u_j1_0_eq_j0_4088, u_j1_4088_eq_j0_4080,
           u_j1_4080_eq_j0_4072, u_j1_4072_eq_j0_4064] at hp
       rw [sepConj_assoc'] at hp
+      rw [loopBodyN3CallUnifiedPre_unfold]
       xperm_hyp hp)
     J1f J0f
   exact cpsTripleWithin_weaken
-    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by
+      rw [loopBodyN3CallUnifiedPre_unfold]
+      xperm_hyp hp)
     (fun h hp => by
       delta loopN3CallCallPost
       exact hp)
@@ -857,11 +891,14 @@ theorem divK_loop_n3_max_call_spec_within
       rw [hj', u_j1_0_eq_j0_4088, u_j1_4088_eq_j0_4080,
           u_j1_4080_eq_j0_4072, u_j1_4072_eq_j0_4064] at hp
       rw [sepConj_assoc'] at hp
+      rw [loopBodyN3CallUnifiedPre_unfold]
       xperm_hyp hp)
     J1f J0f
   -- 5. Clean up postcondition
   exact cpsTripleWithin_weaken
-    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by
+      rw [loopBodyN3MaxUnifiedPre_unfold]
+      xperm_hyp hp)
     (fun h hp => by
       delta loopN3MaxCallPost
       exact hp)
@@ -933,10 +970,13 @@ theorem divK_loop_n3_max_call_spec_within_noNop
       rw [hj', u_j1_0_eq_j0_4088, u_j1_4088_eq_j0_4080,
           u_j1_4080_eq_j0_4072, u_j1_4072_eq_j0_4064] at hp
       rw [sepConj_assoc'] at hp
+      rw [loopBodyN3CallUnifiedPre_unfold]
       xperm_hyp hp)
     J1f J0f
   exact cpsTripleWithin_weaken
-    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by
+      rw [loopBodyN3MaxUnifiedPre_unfold]
+      xperm_hyp hp)
     (fun h hp => by
       delta loopN3MaxCallPost
       exact hp)
@@ -1017,11 +1057,14 @@ theorem divK_loop_n3_call_max_spec_within
       rw [hj', u_j1_0_eq_j0_4088, u_j1_4088_eq_j0_4080,
           u_j1_4080_eq_j0_4072, u_j1_4072_eq_j0_4064] at hp
       rw [sepConj_assoc'] at hp
+      rw [loopBodyN3MaxUnifiedPre_unfold]
       xperm_hyp hp)
     J1f J0f
   -- 5. Clean up postcondition
   exact cpsTripleWithin_weaken
-    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by
+      rw [loopBodyN3CallUnifiedPre_unfold]
+      xperm_hyp hp)
     (fun h hp => by
       delta loopN3CallMaxPost
       exact hp)
@@ -1090,10 +1133,13 @@ theorem divK_loop_n3_call_max_spec_within_noNop
       rw [hj', u_j1_0_eq_j0_4088, u_j1_4088_eq_j0_4080,
           u_j1_4080_eq_j0_4072, u_j1_4072_eq_j0_4064] at hp
       rw [sepConj_assoc'] at hp
+      rw [loopBodyN3MaxUnifiedPre_unfold]
       xperm_hyp hp)
     J1f J0f
   exact cpsTripleWithin_weaken
-    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by
+      rw [loopBodyN3CallUnifiedPre_unfold]
+      xperm_hyp hp)
     (fun h hp => by
       delta loopN3CallMaxPost
       exact hp)

--- a/EvmAsm/Evm64/DivMod/LoopComposeN3.lean
+++ b/EvmAsm/Evm64/DivMod/LoopComposeN3.lean
@@ -262,6 +262,7 @@ theorem divK_loop_body_n3_max_unified_j0_spec_within
     exact cpsTripleWithin_weaken
       (fun h hp => by
         rw [loopBodyN3MaxUnifiedPre_unfold] at hp
+        rw [loopBodyN3MaxSkipJ0Pre_unfold]
         exact hp)
       (fun h hp => by rw [← loopIterPostN3Max_skip hb]; exact hp)
       (cpsTripleWithin_mono_nSteps (by decide) (J0 hborrow))
@@ -301,6 +302,7 @@ theorem divK_loop_body_n3_max_unified_j0_spec_within_noNop
     exact cpsTripleWithin_weaken
       (fun h hp => by
         rw [loopBodyN3MaxUnifiedPre_unfold] at hp
+        rw [loopBodyN3MaxSkipJ0Pre_unfold]
         exact hp)
       (fun h hp => by rw [← loopIterPostN3Max_skip hb]; exact hp)
       (cpsTripleWithin_mono_nSteps (by decide) (J0 hborrow))

--- a/EvmAsm/Evm64/DivMod/LoopIterN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN2.lean
@@ -711,6 +711,54 @@ theorem divK_loop_body_n2_max_skip_jgt0_spec_within_noNop (j : Word)
 
 set_option maxRecDepth 4096 in
 /-- Loop body cpsTripleWithin for n=2, call+skip, j > 0 (parametric on `j : Word`). -/
+@[irreducible]
+def loopBodyN2CallSkipJgt0Pre (j : Word)
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratch_un0 : Word) : Assertion :=
+  let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
+  (.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
+  (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+  (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
+  (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
+  (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
+  ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+  ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+  ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+  ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+  ((uBase + signExtend12 4064) ↦ₘ uTop) **
+  (qAddr ↦ₘ qOld) **
+  (sp + signExtend12 3968 ↦ₘ retMem) **
+  (sp + signExtend12 3960 ↦ₘ dMem) **
+  (sp + signExtend12 3952 ↦ₘ dloMem) **
+  (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1
+
+theorem loopBodyN2CallSkipJgt0Pre_unfold (j : Word)
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratch_un0 : Word) :
+    loopBodyN2CallSkipJgt0Pre j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 =
+    (let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+     let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
+     (.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
+     (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+     (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
+     (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
+     (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((uBase + signExtend12 4064) ↦ₘ uTop) **
+     (qAddr ↦ₘ qOld) **
+     (sp + signExtend12 3968 ↦ₘ retMem) **
+     (sp + signExtend12 3960 ↦ₘ dMem) **
+     (sp + signExtend12 3952 ↦ₘ dloMem) **
+     (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1) := by
+  delta loopBodyN2CallSkipJgt0Pre; rfl
+
 theorem divK_loop_body_n2_call_skip_jgt0_spec_within (j : Word)
     (hpos : BitVec.slt (j + signExtend12 4095) 0 = false)
     (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
@@ -720,26 +768,12 @@ theorem divK_loop_body_n2_call_skip_jgt0_spec_within (j : Word)
     (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
     (hbltu : BitVec.ult u2 v1)
     (hborrow : isSkipBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
-    let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     cpsTripleWithin 126 (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
-       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-       ((uBase + signExtend12 4064) ↦ₘ uTop) **
-       (qAddr ↦ₘ qOld) **
-       (sp + signExtend12 3968 ↦ₘ retMem) **
-       (sp + signExtend12 3960 ↦ₘ dMem) **
-       (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
+      (loopBodyN2CallSkipJgt0Pre j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0)
       (loopBodyN2CallSkipPostJ sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro uBase qAddr
+  let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
   let dHi := v1 >>> (32 : BitVec 6).toNat
   let dLo := (v1 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   let div_un1 := u1 >>> (32 : BitVec 6).toNat
@@ -826,7 +860,7 @@ theorem divK_loop_body_n2_call_skip_jgt0_spec_within (j : Word)
   have full := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0f SLf
   exact cpsTripleWithin_weaken
-    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by rw [loopBodyN2CallSkipJgt0Pre_unfold] at hp; xperm_hyp hp)
     (fun h hp => by
       delta loopBodyN2CallSkipPostJ div128Quot div128DLo div128Un0
             loopBodyN2SkipPost loopBodySkipPost mulsubN4 loopExitPostN2 loopExitPost
@@ -843,26 +877,12 @@ theorem divK_loop_body_n2_call_skip_jgt0_spec_within_noNop (j : Word)
     (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
     (hbltu : BitVec.ult u2 v1)
     (hborrow : isSkipBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
-    let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     cpsTripleWithin 126 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
-       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-       ((uBase + signExtend12 4064) ↦ₘ uTop) **
-       (qAddr ↦ₘ qOld) **
-       (sp + signExtend12 3968 ↦ₘ retMem) **
-       (sp + signExtend12 3960 ↦ₘ dMem) **
-       (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
+      (loopBodyN2CallSkipJgt0Pre j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0)
       (loopBodyN2CallSkipPostJ sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro uBase qAddr
+  let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
   let dHi := v1 >>> (32 : BitVec 6).toNat
   let dLo := (v1 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   let div_un1 := u1 >>> (32 : BitVec 6).toNat
@@ -948,7 +968,7 @@ theorem divK_loop_body_n2_call_skip_jgt0_spec_within_noNop (j : Word)
   have full := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0f SLf
   exact cpsTripleWithin_weaken
-    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by rw [loopBodyN2CallSkipJgt0Pre_unfold] at hp; xperm_hyp hp)
     (fun h hp => by
       delta loopBodyN2CallSkipPostJ div128Quot div128DLo div128Un0
             loopBodyN2SkipPost loopBodySkipPost mulsubN4 loopExitPostN2 loopExitPost

--- a/EvmAsm/Evm64/DivMod/LoopIterN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN2.lean
@@ -993,24 +993,14 @@ theorem divK_loop_body_n2_max_addback_j0_beq_spec_within
     (base : Word)
     (hbltu : ¬BitVec.ult u2 v1)
     (hcarry2_nz : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
-
-    let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTripleWithin 152 (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
-       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-       ((uBase + signExtend12 4064) ↦ₘ uTop) **
-       (qAddr ↦ₘ qOld))
+      (loopBodyN2MaxSkipJ0Pre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld)
       (loopBodyN2AddbackBeqPost sp (0 : Word) (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro uBase qAddr hborrow
+  intro hborrow
+  let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
   let qHat : Word := signExtend12 4095
   let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
   let c3 := ms.2.2.2.2
@@ -1063,7 +1053,7 @@ theorem divK_loop_body_n2_max_addback_j0_beq_spec_within
   have full := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
   exact cpsTripleWithin_weaken
-    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by rw [loopBodyN2MaxSkipJ0Pre_unfold] at hp; xperm_hyp hp)
     (fun h hp => by delta loopBodyN2AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN2 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full
 
@@ -1074,24 +1064,14 @@ theorem divK_loop_body_n2_max_addback_j0_beq_spec_within_noNop
     (base : Word)
     (hbltu : ¬BitVec.ult u2 v1)
     (hcarry2_nz : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
-
-    let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTripleWithin 152 (base + loopBodyOff) (base + denormOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
-       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-       ((uBase + signExtend12 4064) ↦ₘ uTop) **
-       (qAddr ↦ₘ qOld))
+      (loopBodyN2MaxSkipJ0Pre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld)
       (loopBodyN2AddbackBeqPost sp (0 : Word) (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro uBase qAddr hborrow
+  intro hborrow
+  let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
   let qHat : Word := signExtend12 4095
   let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
   let c3 := ms.2.2.2.2
@@ -1143,7 +1123,7 @@ theorem divK_loop_body_n2_max_addback_j0_beq_spec_within_noNop
   have full := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
   exact cpsTripleWithin_weaken
-    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by rw [loopBodyN2MaxSkipJ0Pre_unfold] at hp; xperm_hyp hp)
     (fun h hp => by delta loopBodyN2AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN2 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full
 
@@ -1161,26 +1141,12 @@ theorem divK_loop_body_n2_call_addback_j0_beq_spec_within
     (hbltu : BitVec.ult u2 v1)
     (hborrow : isAddbackBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop)
     (hcarry2_nz : isAddbackCarry2NzN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
-    let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 202 (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
-       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-       ((uBase + signExtend12 4064) ↦ₘ uTop) **
-       (qAddr ↦ₘ qOld) **
-       (sp + signExtend12 3968 ↦ₘ retMem) **
-       (sp + signExtend12 3960 ↦ₘ dMem) **
-       (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
+      (loopBodyN2CallSkipJ0Pre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0)
       (loopBodyN2CallAddbackBeqPostJ sp base (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro uBase qAddr
+  let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
   -- Reconstruct div128 intermediates for n=2
   let dHi := v1 >>> (32 : BitVec 6).toNat
   let dLo := (v1 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
@@ -1274,7 +1240,7 @@ theorem divK_loop_body_n2_call_addback_j0_beq_spec_within
   have full := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0f SLf
   exact cpsTripleWithin_weaken
-    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by rw [loopBodyN2CallSkipJ0Pre_unfold] at hp; xperm_hyp hp)
     (fun h hp => by
       delta loopBodyN2CallAddbackBeqPostJ div128Quot div128DLo div128Un0
             loopBodyN2AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN2 loopExitPost

--- a/EvmAsm/Evm64/DivMod/LoopIterN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN2.lean
@@ -520,30 +520,58 @@ theorem divK_loop_body_n2_call_skip_j0_spec_within_noNop
 
 set_option maxRecDepth 4096 in
 /-- Loop body cpsTripleWithin for n=2, max+skip, j > 0 (parametric on `j : Word`). -/
+@[irreducible]
+def loopBodyN2MaxSkipJgt0Pre (j : Word)
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word) : Assertion :=
+  let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
+  (.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
+  (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+  (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
+  (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
+  (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
+  ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+  ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+  ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+  ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+  ((uBase + signExtend12 4064) ↦ₘ uTop) **
+  (qAddr ↦ₘ qOld)
+
+theorem loopBodyN2MaxSkipJgt0Pre_unfold (j : Word)
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word) :
+    loopBodyN2MaxSkipJgt0Pre j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld =
+    (let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+     let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
+     (.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
+     (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+     (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
+     (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
+     (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((uBase + signExtend12 4064) ↦ₘ uTop) **
+     (qAddr ↦ₘ qOld)) := by
+  delta loopBodyN2MaxSkipJgt0Pre; rfl
+
 theorem divK_loop_body_n2_max_skip_jgt0_spec_within (j : Word)
     (hpos : BitVec.slt (j + signExtend12 4095) 0 = false)
     (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u2 v1) :
-    let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
-
-    let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsTripleWithin 76 (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
-       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-       ((uBase + signExtend12 4064) ↦ₘ uTop) **
-       (qAddr ↦ₘ qOld))
+      (loopBodyN2MaxSkipJgt0Pre j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld)
       (loopBodyN2SkipPost sp j (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro uBase qAddr hborrow
+  intro hborrow
+  let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
   let qHat : Word := signExtend12 4095
   let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
   let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
@@ -599,7 +627,7 @@ theorem divK_loop_body_n2_max_skip_jgt0_spec_within (j : Word)
   have full := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
   exact cpsTripleWithin_weaken
-    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by rw [loopBodyN2MaxSkipJgt0Pre_unfold] at hp; xperm_hyp hp)
     (fun h hp => by delta loopBodyN2SkipPost loopBodySkipPost mulsubN4 loopExitPostN2 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full
 
@@ -610,24 +638,14 @@ theorem divK_loop_body_n2_max_skip_jgt0_spec_within_noNop (j : Word)
      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u2 v1) :
-    let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
-
-    let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsTripleWithin 76 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
-       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-       ((uBase + signExtend12 4064) ↦ₘ uTop) **
-       (qAddr ↦ₘ qOld))
+      (loopBodyN2MaxSkipJgt0Pre j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld)
       (loopBodyN2SkipPost sp j (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro uBase qAddr hborrow
+  intro hborrow
+  let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
   let qHat : Word := signExtend12 4095
   let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
   let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
@@ -682,7 +700,7 @@ theorem divK_loop_body_n2_max_skip_jgt0_spec_within_noNop (j : Word)
   have full := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
   exact cpsTripleWithin_weaken
-    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by rw [loopBodyN2MaxSkipJgt0Pre_unfold] at hp; xperm_hyp hp)
     (fun h hp => by delta loopBodyN2SkipPost loopBodySkipPost mulsubN4 loopExitPostN2 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full
 

--- a/EvmAsm/Evm64/DivMod/LoopIterN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN2.lean
@@ -712,7 +712,7 @@ theorem divK_loop_body_n2_max_skip_jgt0_spec_within_noNop (j : Word)
 set_option maxRecDepth 4096 in
 /-- Loop body cpsTripleWithin for n=2, call+skip, j > 0 (parametric on `j : Word`). -/
 @[irreducible]
-def loopBodyN2CallSkipJgt0Pre (j : Word)
+def loopBodyN2CallJgt0Pre (j : Word)
     (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
     (retMem dMem dloMem scratch_un0 : Word) : Assertion :=
@@ -734,11 +734,11 @@ def loopBodyN2CallSkipJgt0Pre (j : Word)
   (sp + signExtend12 3952 ↦ₘ dloMem) **
   (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1
 
-theorem loopBodyN2CallSkipJgt0Pre_unfold (j : Word)
+theorem loopBodyN2CallJgt0Pre_unfold (j : Word)
     (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
     (retMem dMem dloMem scratch_un0 : Word) :
-    loopBodyN2CallSkipJgt0Pre j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    loopBodyN2CallJgt0Pre j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 =
     (let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
      let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
@@ -757,7 +757,7 @@ theorem loopBodyN2CallSkipJgt0Pre_unfold (j : Word)
      (sp + signExtend12 3960 ↦ₘ dMem) **
      (sp + signExtend12 3952 ↦ₘ dloMem) **
      (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1) := by
-  delta loopBodyN2CallSkipJgt0Pre; rfl
+  delta loopBodyN2CallJgt0Pre; rfl
 
 theorem divK_loop_body_n2_call_skip_jgt0_spec_within (j : Word)
     (hpos : BitVec.slt (j + signExtend12 4095) 0 = false)
@@ -769,7 +769,7 @@ theorem divK_loop_body_n2_call_skip_jgt0_spec_within (j : Word)
     (hbltu : BitVec.ult u2 v1)
     (hborrow : isSkipBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
     cpsTripleWithin 126 (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
-      (loopBodyN2CallSkipJgt0Pre j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      (loopBodyN2CallJgt0Pre j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
         v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0)
       (loopBodyN2CallSkipPostJ sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
@@ -860,7 +860,7 @@ theorem divK_loop_body_n2_call_skip_jgt0_spec_within (j : Word)
   have full := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0f SLf
   exact cpsTripleWithin_weaken
-    (fun h hp => by rw [loopBodyN2CallSkipJgt0Pre_unfold] at hp; xperm_hyp hp)
+    (fun h hp => by rw [loopBodyN2CallJgt0Pre_unfold] at hp; xperm_hyp hp)
     (fun h hp => by
       delta loopBodyN2CallSkipPostJ div128Quot div128DLo div128Un0
             loopBodyN2SkipPost loopBodySkipPost mulsubN4 loopExitPostN2 loopExitPost
@@ -878,7 +878,7 @@ theorem divK_loop_body_n2_call_skip_jgt0_spec_within_noNop (j : Word)
     (hbltu : BitVec.ult u2 v1)
     (hborrow : isSkipBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
     cpsTripleWithin 126 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop base)
-      (loopBodyN2CallSkipJgt0Pre j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      (loopBodyN2CallJgt0Pre j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
         v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0)
       (loopBodyN2CallSkipPostJ sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
@@ -968,7 +968,7 @@ theorem divK_loop_body_n2_call_skip_jgt0_spec_within_noNop (j : Word)
   have full := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0f SLf
   exact cpsTripleWithin_weaken
-    (fun h hp => by rw [loopBodyN2CallSkipJgt0Pre_unfold] at hp; xperm_hyp hp)
+    (fun h hp => by rw [loopBodyN2CallJgt0Pre_unfold] at hp; xperm_hyp hp)
     (fun h hp => by
       delta loopBodyN2CallSkipPostJ div128Quot div128DLo div128Un0
             loopBodyN2SkipPost loopBodySkipPost mulsubN4 loopExitPostN2 loopExitPost
@@ -1373,26 +1373,12 @@ theorem divK_loop_body_n2_call_addback_jgt0_beq_spec_within (j : Word)
     (hbltu : BitVec.ult u2 v1)
     (hborrow : isAddbackBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop)
     (hcarry2_nz : isAddbackCarry2NzN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
-    let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     cpsTripleWithin 202 (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
-       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-       ((uBase + signExtend12 4064) ↦ₘ uTop) **
-       (qAddr ↦ₘ qOld) **
-       (sp + signExtend12 3968 ↦ₘ retMem) **
-       (sp + signExtend12 3960 ↦ₘ dMem) **
-       (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
+      (loopBodyN2CallJgt0Pre j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0)
       (loopBodyN2CallAddbackBeqPostJ sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro uBase qAddr
+  let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
   let dHi := v1 >>> (32 : BitVec 6).toNat
   let dLo := (v1 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   let div_un1 := u1 >>> (32 : BitVec 6).toNat
@@ -1477,7 +1463,7 @@ theorem divK_loop_body_n2_call_addback_jgt0_beq_spec_within (j : Word)
   have full := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0f SLf
   exact cpsTripleWithin_weaken
-    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by rw [loopBodyN2CallJgt0Pre_unfold] at hp; xperm_hyp hp)
     (fun h hp => by
       delta loopBodyN2CallAddbackBeqPostJ div128Quot div128DLo div128Un0
             loopBodyN2AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN2 loopExitPost

--- a/EvmAsm/Evm64/DivMod/LoopIterN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN2.lean
@@ -521,7 +521,7 @@ theorem divK_loop_body_n2_call_skip_j0_spec_within_noNop
 set_option maxRecDepth 4096 in
 /-- Loop body cpsTripleWithin for n=2, max+skip, j > 0 (parametric on `j : Word`). -/
 @[irreducible]
-def loopBodyN2MaxSkipJgt0Pre (j : Word)
+def loopBodyN2MaxJgt0Pre (j : Word)
     (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word) : Assertion :=
   let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
@@ -538,10 +538,10 @@ def loopBodyN2MaxSkipJgt0Pre (j : Word)
   ((uBase + signExtend12 4064) ↦ₘ uTop) **
   (qAddr ↦ₘ qOld)
 
-theorem loopBodyN2MaxSkipJgt0Pre_unfold (j : Word)
+theorem loopBodyN2MaxJgt0Pre_unfold (j : Word)
     (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word) :
-    loopBodyN2MaxSkipJgt0Pre j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    loopBodyN2MaxJgt0Pre j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld =
     (let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
      let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
@@ -556,7 +556,7 @@ theorem loopBodyN2MaxSkipJgt0Pre_unfold (j : Word)
      ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
      ((uBase + signExtend12 4064) ↦ₘ uTop) **
      (qAddr ↦ₘ qOld)) := by
-  delta loopBodyN2MaxSkipJgt0Pre; rfl
+  delta loopBodyN2MaxJgt0Pre; rfl
 
 theorem divK_loop_body_n2_max_skip_jgt0_spec_within (j : Word)
     (hpos : BitVec.slt (j + signExtend12 4095) 0 = false)
@@ -566,7 +566,7 @@ theorem divK_loop_body_n2_max_skip_jgt0_spec_within (j : Word)
     (hbltu : ¬BitVec.ult u2 v1) :
     (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsTripleWithin 76 (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
-      (loopBodyN2MaxSkipJgt0Pre j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      (loopBodyN2MaxJgt0Pre j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
         v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld)
       (loopBodyN2SkipPost sp j (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro hborrow
@@ -627,7 +627,7 @@ theorem divK_loop_body_n2_max_skip_jgt0_spec_within (j : Word)
   have full := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
   exact cpsTripleWithin_weaken
-    (fun h hp => by rw [loopBodyN2MaxSkipJgt0Pre_unfold] at hp; xperm_hyp hp)
+    (fun h hp => by rw [loopBodyN2MaxJgt0Pre_unfold] at hp; xperm_hyp hp)
     (fun h hp => by delta loopBodyN2SkipPost loopBodySkipPost mulsubN4 loopExitPostN2 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full
 
@@ -640,7 +640,7 @@ theorem divK_loop_body_n2_max_skip_jgt0_spec_within_noNop (j : Word)
     (hbltu : ¬BitVec.ult u2 v1) :
     (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsTripleWithin 76 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop base)
-      (loopBodyN2MaxSkipJgt0Pre j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      (loopBodyN2MaxJgt0Pre j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
         v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld)
       (loopBodyN2SkipPost sp j (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro hborrow
@@ -700,7 +700,7 @@ theorem divK_loop_body_n2_max_skip_jgt0_spec_within_noNop (j : Word)
   have full := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
   exact cpsTripleWithin_weaken
-    (fun h hp => by rw [loopBodyN2MaxSkipJgt0Pre_unfold] at hp; xperm_hyp hp)
+    (fun h hp => by rw [loopBodyN2MaxJgt0Pre_unfold] at hp; xperm_hyp hp)
     (fun h hp => by delta loopBodyN2SkipPost loopBodySkipPost mulsubN4 loopExitPostN2 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full
 
@@ -1286,7 +1286,6 @@ theorem divK_loop_body_n2_call_addback_j0_beq_spec_within
 -- Word-parametric: callers pass concrete j ∈ {1,2} + corresponding slt_jpos_k.
 -- ============================================================================
 
-set_option maxRecDepth 4096 in
 theorem divK_loop_body_n2_max_addback_jgt0_beq_spec_within (j : Word)
     (hpos : BitVec.slt (j + signExtend12 4095) 0 = false)
     (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
@@ -1294,24 +1293,14 @@ theorem divK_loop_body_n2_max_addback_jgt0_beq_spec_within (j : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u2 v1)
     (hcarry2_nz : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
-
-    let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTripleWithin 152 (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
-       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-       ((uBase + signExtend12 4064) ↦ₘ uTop) **
-       (qAddr ↦ₘ qOld))
+      (loopBodyN2MaxJgt0Pre j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld)
       (loopBodyN2AddbackBeqPost sp j (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro uBase qAddr hborrow
+  intro hborrow
+  let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
   let qHat : Word := signExtend12 4095
   let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
   let c3 := ms.2.2.2.2
@@ -1364,7 +1353,7 @@ theorem divK_loop_body_n2_max_addback_jgt0_beq_spec_within (j : Word)
   have full := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
   exact cpsTripleWithin_weaken
-    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by rw [loopBodyN2MaxJgt0Pre_unfold] at hp; xperm_hyp hp)
     (fun h hp => by delta loopBodyN2AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN2 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full
 

--- a/EvmAsm/Evm64/DivMod/LoopIterN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN2.lean
@@ -241,6 +241,54 @@ theorem divK_loop_body_n2_max_skip_j0_spec_within_noNop
 set_option maxRecDepth 4096 in
 /-- Loop body cpsTripleWithin for n=2, call+skip, j=0.
     Since j=0, the BGE loop-back is not taken, giving a cpsTripleWithin to base+904. -/
+@[irreducible]
+def loopBodyN2CallSkipJ0Pre
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratch_un0 : Word) : Assertion :=
+  let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
+  (.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
+  (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+  (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
+  (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
+  (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
+  ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+  ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+  ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+  ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+  ((uBase + signExtend12 4064) ↦ₘ uTop) **
+  (qAddr ↦ₘ qOld) **
+  (sp + signExtend12 3968 ↦ₘ retMem) **
+  (sp + signExtend12 3960 ↦ₘ dMem) **
+  (sp + signExtend12 3952 ↦ₘ dloMem) **
+  (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1
+
+theorem loopBodyN2CallSkipJ0Pre_unfold
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratch_un0 : Word) :
+    loopBodyN2CallSkipJ0Pre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 =
+    (let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
+     (.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
+     (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+     (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
+     (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
+     (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((uBase + signExtend12 4064) ↦ₘ uTop) **
+     (qAddr ↦ₘ qOld) **
+     (sp + signExtend12 3968 ↦ₘ retMem) **
+     (sp + signExtend12 3960 ↦ₘ dMem) **
+     (sp + signExtend12 3952 ↦ₘ dloMem) **
+     (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1) := by
+  delta loopBodyN2CallSkipJ0Pre; rfl
+
 theorem divK_loop_body_n2_call_skip_j0_spec_within
     (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
@@ -249,26 +297,12 @@ theorem divK_loop_body_n2_call_skip_j0_spec_within
     (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
     (hbltu : BitVec.ult u2 v1)
     (hborrow : isSkipBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
-    let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 126 (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
-       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-       ((uBase + signExtend12 4064) ↦ₘ uTop) **
-       (qAddr ↦ₘ qOld) **
-       (sp + signExtend12 3968 ↦ₘ retMem) **
-       (sp + signExtend12 3960 ↦ₘ dMem) **
-       (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
+      (loopBodyN2CallSkipJ0Pre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0)
       (loopBodyN2CallSkipPostJ sp base (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro uBase qAddr
+  let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
   -- Reconstruct div128 intermediates for n=2: vTop=v1, uHi=u2, uLo=u1
   let dHi := v1 >>> (32 : BitVec 6).toNat
   let dLo := (v1 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
@@ -365,7 +399,7 @@ theorem divK_loop_body_n2_call_skip_j0_spec_within
   have full := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0f SLf
   exact cpsTripleWithin_weaken
-    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by rw [loopBodyN2CallSkipJ0Pre_unfold] at hp; xperm_hyp hp)
     (fun h hp => by
       delta loopBodyN2CallSkipPostJ div128Quot div128DLo div128Un0
             loopBodyN2SkipPost loopBodySkipPost mulsubN4 loopExitPostN2 loopExitPost
@@ -381,26 +415,12 @@ theorem divK_loop_body_n2_call_skip_j0_spec_within_noNop
     (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
     (hbltu : BitVec.ult u2 v1)
     (hborrow : isSkipBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
-    let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 126 (base + loopBodyOff) (base + denormOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
-       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-       ((uBase + signExtend12 4064) ↦ₘ uTop) **
-       (qAddr ↦ₘ qOld) **
-       (sp + signExtend12 3968 ↦ₘ retMem) **
-       (sp + signExtend12 3960 ↦ₘ dMem) **
-       (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
+      (loopBodyN2CallSkipJ0Pre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0)
       (loopBodyN2CallSkipPostJ sp base (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro uBase qAddr
+  let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
   let dHi := v1 >>> (32 : BitVec 6).toNat
   let dLo := (v1 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   let div_un1 := u1 >>> (32 : BitVec 6).toNat
@@ -486,7 +506,7 @@ theorem divK_loop_body_n2_call_skip_j0_spec_within_noNop
   have full := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0f SLf
   exact cpsTripleWithin_weaken
-    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by rw [loopBodyN2CallSkipJ0Pre_unfold] at hp; xperm_hyp hp)
     (fun h hp => by
       delta loopBodyN2CallSkipPostJ div128Quot div128DLo div128Un0
             loopBodyN2SkipPost loopBodySkipPost mulsubN4 loopExitPostN2 loopExitPost

--- a/EvmAsm/Evm64/DivMod/LoopIterN2NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN2NoNop.lean
@@ -16,26 +16,12 @@ theorem divK_loop_body_n2_call_addback_j0_beq_spec_within_noNop
     (hbltu : BitVec.ult u2 v1)
     (hborrow : isAddbackBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop)
     (hcarry2_nz : isAddbackCarry2NzN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
-    let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     cpsTripleWithin 202 (base + loopBodyOff) (base + denormOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
-       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-       ((uBase + signExtend12 4064) ↦ₘ uTop) **
-       (qAddr ↦ₘ qOld) **
-       (sp + signExtend12 3968 ↦ₘ retMem) **
-       (sp + signExtend12 3960 ↦ₘ dMem) **
-       (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
+      (loopBodyN2CallSkipJ0Pre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0)
       (loopBodyN2CallAddbackBeqPostJ sp base (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro uBase qAddr
+  let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
   let dHi := v1 >>> (32 : BitVec 6).toNat
   let dLo := (v1 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   let div_un1 := u1 >>> (32 : BitVec 6).toNat
@@ -118,7 +104,7 @@ theorem divK_loop_body_n2_call_addback_j0_beq_spec_within_noNop
   have full := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0f SLf
   exact cpsTripleWithin_weaken
-    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by rw [loopBodyN2CallSkipJ0Pre_unfold] at hp; xperm_hyp hp)
     (fun h hp => by
       delta loopBodyN2CallAddbackBeqPostJ div128Quot div128DLo div128Un0
             loopBodyN2AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN2 loopExitPost

--- a/EvmAsm/Evm64/DivMod/LoopIterN2NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN2NoNop.lean
@@ -207,26 +207,12 @@ theorem divK_loop_body_n2_call_addback_jgt0_beq_spec_within_noNop (j : Word)
     (hbltu : BitVec.ult u2 v1)
     (hborrow : isAddbackBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop)
     (hcarry2_nz : isAddbackCarry2NzN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
-    let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     cpsTripleWithin 202 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
-       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-       ((uBase + signExtend12 4064) ↦ₘ uTop) **
-       (qAddr ↦ₘ qOld) **
-       (sp + signExtend12 3968 ↦ₘ retMem) **
-       (sp + signExtend12 3960 ↦ₘ dMem) **
-       (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1)
+      (loopBodyN2CallJgt0Pre j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0)
       (loopBodyN2CallAddbackBeqPostJ sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro uBase qAddr
+  let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
   let dHi := v1 >>> (32 : BitVec 6).toNat
   let dLo := (v1 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   let div_un1 := u1 >>> (32 : BitVec 6).toNat
@@ -309,7 +295,7 @@ theorem divK_loop_body_n2_call_addback_jgt0_beq_spec_within_noNop (j : Word)
   have full := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0f SLf
   exact cpsTripleWithin_weaken
-    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by rw [loopBodyN2CallJgt0Pre_unfold] at hp; xperm_hyp hp)
     (fun h hp => by
       delta loopBodyN2CallAddbackBeqPostJ div128Quot div128DLo div128Un0
             loopBodyN2AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN2 loopExitPost

--- a/EvmAsm/Evm64/DivMod/LoopIterN2NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN2NoNop.lean
@@ -133,23 +133,14 @@ theorem divK_loop_body_n2_max_addback_jgt0_beq_spec_within_noNop (j : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u2 v1)
     (hcarry2_nz : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
-    let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTripleWithin 152 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
-       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-       ((uBase + signExtend12 4064) ↦ₘ uTop) **
-       (qAddr ↦ₘ qOld))
+      (loopBodyN2MaxJgt0Pre j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld)
       (loopBodyN2AddbackBeqPost sp j (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro uBase qAddr hborrow
+  intro hborrow
+  let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
   let qHat : Word := signExtend12 4095
   let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
   let c3 := ms.2.2.2.2
@@ -201,7 +192,7 @@ theorem divK_loop_body_n2_max_addback_jgt0_beq_spec_within_noNop (j : Word)
   have full := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
   exact cpsTripleWithin_weaken
-    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by rw [loopBodyN2MaxJgt0Pre_unfold] at hp; xperm_hyp hp)
     (fun h hp => by delta loopBodyN2AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN2 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full
 

--- a/EvmAsm/Evm64/DivMod/LoopIterN3.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN3.lean
@@ -26,29 +26,57 @@ open EvmAsm.Evm64.DivMod.AddrNorm (slt_jpos_1)
 set_option maxRecDepth 4096 in
 /-- Loop body cpsTripleWithin for n=3, max+skip, j=0.
     Since j=0, the BGE loop-back is not taken, giving a cpsTripleWithin to base+904. -/
+@[irreducible]
+def loopBodyN3MaxSkipJ0Pre
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word) : Assertion :=
+  let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
+  (.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
+  (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+  (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
+  (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
+  (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
+  ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+  ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+  ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+  ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+  ((uBase + signExtend12 4064) ↦ₘ uTop) **
+  (qAddr ↦ₘ qOld)
+
+theorem loopBodyN3MaxSkipJ0Pre_unfold
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word) :
+    loopBodyN3MaxSkipJ0Pre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld =
+    (let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
+     (.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
+     (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+     (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
+     (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
+     (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((uBase + signExtend12 4064) ↦ₘ uTop) **
+     (qAddr ↦ₘ qOld)) := by
+  delta loopBodyN3MaxSkipJ0Pre; rfl
+
 theorem divK_loop_body_n3_max_skip_j0_spec_within
     (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u3 v2) :
-    let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
-
-    let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsTripleWithin 76 (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
-       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-       ((uBase + signExtend12 4064) ↦ₘ uTop) **
-       (qAddr ↦ₘ qOld))
+      (loopBodyN3MaxSkipJ0Pre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld)
       (loopBodyN3SkipPost sp (0 : Word) (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro uBase qAddr hborrow
+  intro hborrow
+  let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
   let qHat : Word := signExtend12 4095
   let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
   let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
@@ -119,7 +147,7 @@ theorem divK_loop_body_n3_max_skip_j0_spec_within
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
   -- 8. Permute final cpsTripleWithin to match target
   exact cpsTripleWithin_weaken
-    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by rw [loopBodyN3MaxSkipJ0Pre_unfold] at hp; xperm_hyp hp)
     (fun h hp => by delta loopBodyN3SkipPost loopBodySkipPost mulsubN4 loopExitPostN3 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full
 
@@ -129,24 +157,14 @@ theorem divK_loop_body_n3_max_skip_j0_spec_within_noNop
      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u3 v2) :
-    let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
-
-    let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsTripleWithin 76 (base + loopBodyOff) (base + denormOff) (divCode_noNop base)
-      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
-       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-       ((uBase + signExtend12 4064) ↦ₘ uTop) **
-       (qAddr ↦ₘ qOld))
+      (loopBodyN3MaxSkipJ0Pre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld)
       (loopBodyN3SkipPost sp (0 : Word) (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro uBase qAddr hborrow
+  intro hborrow
+  let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
   let qHat : Word := signExtend12 4095
   let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
   let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
@@ -208,7 +226,7 @@ theorem divK_loop_body_n3_max_skip_j0_spec_within_noNop
   have full := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
   exact cpsTripleWithin_weaken
-    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by rw [loopBodyN3MaxSkipJ0Pre_unfold] at hp; xperm_hyp hp)
     (fun h hp => by delta loopBodyN3SkipPost loopBodySkipPost mulsubN4 loopExitPostN3 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full
 


### PR DESCRIPTION
## Summary
- hide long SDIV/DivMod loop CPS precondition let-chains behind irreducible definitions
- reuse N2 precondition surfaces across skip/addback variants
- add N3 unified and j=0 max-skip precondition surfaces with explicit boundary unfolds

## Verification
- lake build EvmAsm.Evm64.DivMod.LoopIterN3
- lake build EvmAsm.Evm64.DivMod.LoopComposeN3
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- scripts/check-file-size.sh EvmAsm/Evm64/DivMod/LoopIterN3.lean EvmAsm/Evm64/DivMod/LoopComposeN3.lean