### PR TITLE
feat(div): add no-nop v4 correction skip specs

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopBody.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody.lean
@@ -667,7 +667,7 @@ set_option maxRecDepth 4096 in
 /-- Mulsub full: setup + 4-limb multiply-subtract + carry subtraction from u[j+4].
     53 instructions, loop body indices [17]-[69].
     Entry: base+516, Exit: base+728, CodeReq: sharedDivModCode base. -/
-private theorem divK_mulsub_full_spec_within_of_sub
+theorem divK_mulsub_full_spec_within_of_sub
     (sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
     (v9Old v5Old v6Old v7Old v10Old v2Old : Word)
     (base : Word)
@@ -911,14 +911,10 @@ def divKMulsubFullPost
   ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3) **
   ((uBase + signExtend12 4064) ↦ₘ u4_new)
 
-/-- `divK_mulsub_full_spec_within` replayed over `sharedDivModCode_v4`. -/
 theorem divK_mulsub_full_v4_spec_within
-    (sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
-    (v9Old v5Old v6Old v7Old v10Old v2Old : Word)
-    (base : Word) :
+    (sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) (v9Old v5Old v6Old v7Old v10Old v2Old : Word) (base : Word) :
     cpsTripleWithin 53 (base + div128CallRetOff) (base + correctionSkipBeqOff) (sharedDivModCode_v4 base)
-      (divKMulsubFullPre sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
-        v9Old v5Old v6Old v7Old v10Old v2Old)
+      (divKMulsubFullPre sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop v9Old v5Old v6Old v7Old v10Old v2Old)
       (divKMulsubFullPost sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   unfold divKMulsubFullPre divKMulsubFullPost
   exact divK_mulsub_full_spec_within_of_sub sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop

--- a/EvmAsm/Evm64/DivMod/LoopBody/CorrectionSkip.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody/CorrectionSkip.lean
@@ -121,6 +121,55 @@ theorem divK_correction_skip_v4_spec_within
     (fun h hp => by xperm_hyp hp)
     skip_framed
 
+/-- Correction skip over `sharedDivModCodeNoNop_v4`: when borrow=0, BEQ taken
+    → jump to base+884. No addback. -/
+theorem divK_correction_skip_v4_spec_within_noNop
+    (sp uBase qHat v0 v1 v2 v3 u0 u1 u2 u3 u4 : Word)
+    (v5Old v2Old : Word) (base : Word) :
+    cpsTripleWithin 1 (base + correctionSkipBeqOff) (base + storeLoopOff) (sharedDivModCodeNoNop_v4 base)
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ uBase) ** (.x7 ↦ᵣ (0 : Word)) **
+       (.x11 ↦ᵣ qHat) ** (.x5 ↦ᵣ v5Old) ** (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ u4))
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ uBase) ** (.x7 ↦ᵣ (0 : Word)) **
+       (.x11 ↦ᵣ qHat) ** (.x5 ↦ᵣ v5Old) ** (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ u4)) := by
+  have hbeq := beq_spec_gen_within .x7 .x0 (156 : BitVec 13) (0 : Word) 0 (base + correctionSkipBeqOff)
+  rw [lb_beq_taken, lb_beq_ntaken] at hbeq
+  have hbeq_ext := cpsBranchWithin_extend_code (hmono :=
+    lb_sub_noNop_v4 70 _ _ (by decide) (by bv_addr) (by decide)) hbeq
+  have skip := cpsBranchWithin_takenPath hbeq_ext (fun hp hQf => by
+    obtain ⟨_, _, _, _, _, ⟨_, _, _, _, _, ⟨_, hpure⟩⟩⟩ := hQf
+    exact hpure rfl)
+  have skip_clean : cpsTripleWithin 1 (base + correctionSkipBeqOff) (base + storeLoopOff) (sharedDivModCodeNoNop_v4 base)
+      ((.x7 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)))
+      ((.x7 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word))) :=
+    cpsTripleWithin_weaken
+      (fun h hp => hp)
+      (fun h hp => sepConj_mono_right
+        (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hp)
+      skip
+  have skip_framed := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ uBase) **
+     (.x11 ↦ᵣ qHat) ** (.x5 ↦ᵣ v5Old) ** (.x2 ↦ᵣ v2Old) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((uBase + signExtend12 4064) ↦ₘ u4))
+    (by pcFree) skip_clean
+  exact cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by xperm_hyp hp)
+    skip_framed
+
 /-- Correction skip over `divCode_noNop`: when borrow=0, BEQ taken → jump
     to base+884. No addback. -/
 theorem divK_correction_skip_spec_within_noNop

--- a/EvmAsm/Evm64/DivMod/LoopBody/MulsubCorrectionSkip.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody/MulsubCorrectionSkip.lean
@@ -222,6 +222,78 @@ theorem divK_mulsub_correction_skip_v4_spec_within
     (fun h hq => by simp only [n4McaNamedSkipPost_unfold]; unfold mulsubN4; xperm_hyp hq)
     MSCS
 
+theorem divK_mulsub_full_v4_spec_within_noNop
+    (sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+    (v9Old v5Old v6Old v7Old v10Old v2Old : Word) (base : Word) :
+    cpsTripleWithin 53 (base + div128CallRetOff) (base + correctionSkipBeqOff) (sharedDivModCodeNoNop_v4 base)
+      (divKMulsubFullPre sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
+        v9Old v5Old v6Old v7Old v10Old v2Old)
+      (divKMulsubFullPost sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  unfold divKMulsubFullPre divKMulsubFullPost
+  exact divK_mulsub_full_spec_within_of_sub sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    v9Old v5Old v6Old v7Old v10Old v2Old base (sharedDivModCodeNoNop_v4 base) lb_sub_noNop_v4
+
+/-- No-NOP v4 variant of `divK_mulsub_correction_skip_spec_within`.
+
+    Entry: base+516, Exit: base+880, CodeReq: `sharedDivModCodeNoNop_v4 base`. -/
+theorem divK_mulsub_correction_skip_v4_spec_within_noNop
+    (sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+    (v1Old v5Old v6Old v7Old v10Old v2Old : Word)
+    (base : Word) :
+    mulsubN4NoBorrow qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop →
+    cpsTripleWithin 54 (base + div128CallRetOff) (base + storeLoopOff) (sharedDivModCodeNoNop_v4 base)
+      (divKMulsubCorrectionSkipPre sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
+        v1Old v5Old v6Old v7Old v10Old v2Old)
+      (n4McaNamedSkipPost sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro hborrow
+  have MS := divK_mulsub_full_v4_spec_within_noNop sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    v1Old v5Old v6Old v7Old v10Old v2Old base
+  unfold divKMulsubFullPre divKMulsubFullPost at MS
+  unfold mulsubN4NoBorrow mulsubN4 at hborrow
+  dsimp only [] at MS hborrow
+  rw [hborrow] at MS
+  let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+  let p0_lo := qHat * v0
+  let p0_hi := rv64_mulhu qHat v0
+  let fs0 := p0_lo + (signExtend12 0 : Word)
+  let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
+  let pc0 := ba0 + p0_hi
+  let bs0 := if BitVec.ult u0 fs0 then (1 : Word) else 0
+  let un0 := u0 - fs0
+  let c0 := pc0 + bs0
+  let p1_lo := qHat * v1
+  let p1_hi := rv64_mulhu qHat v1
+  let fs1 := p1_lo + c0
+  let ba1 := if BitVec.ult fs1 c0 then (1 : Word) else 0
+  let pc1 := ba1 + p1_hi
+  let bs1 := if BitVec.ult u1 fs1 then (1 : Word) else 0
+  let un1 := u1 - fs1
+  let c1 := pc1 + bs1
+  let p2_lo := qHat * v2
+  let p2_hi := rv64_mulhu qHat v2
+  let fs2 := p2_lo + c1
+  let ba2 := if BitVec.ult fs2 c1 then (1 : Word) else 0
+  let pc2 := ba2 + p2_hi
+  let bs2 := if BitVec.ult u2 fs2 then (1 : Word) else 0
+  let un2 := u2 - fs2
+  let c2 := pc2 + bs2
+  let p3_lo := qHat * v3
+  let p3_hi := rv64_mulhu qHat v3
+  let fs3 := p3_lo + c2
+  let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
+  let pc3 := ba3 + p3_hi
+  let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
+  let un3 := u3 - fs3
+  let c3 := pc3 + bs3
+  let u4_new := uTop - c3
+  have CS := divK_correction_skip_v4_spec_within_noNop sp uBase qHat v0 v1 v2 v3 un0 un1 un2 un3 u4_new
+    u4_new un3 base
+  seqFrame MS CS
+  exact cpsTripleWithin_weaken
+    (fun h hp => by unfold divKMulsubCorrectionSkipPre at hp; xperm_hyp hp)
+    (fun h hq => by simp only [n4McaNamedSkipPost_unfold]; unfold mulsubN4; xperm_hyp hq)
+    MSCS
+
 /-- No-NOP variant of `divK_mulsub_correction_skip_spec_within`.
 
     Entry: base+516, Exit: base+880, CodeReq: `divCode_noNop base`. -/


### PR DESCRIPTION
## Summary
- make the generic mulsub-full replay helper public for split proof reuse
- add correction-skip and mulsub-correction-skip proofs over sharedDivModCodeNoNop_v4
- keep the no-NOP v4 mulsub-full replay in the split MulsubCorrectionSkip file so LoopBody.lean stays under the size cap

Stacked on #5045.

## Verification
- lake build EvmAsm.Evm64.DivMod.LoopBody.MulsubCorrectionSkip
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- scripts/check-file-size.sh EvmAsm/Evm64/DivMod/LoopBody.lean EvmAsm/Evm64/DivMod/LoopBody/CorrectionSkip.lean EvmAsm/Evm64/DivMod/LoopBody/MulsubCorrectionSkip.lean