### PR TITLE
refactor(div): share addback full code replay

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopBody.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody.lean
@@ -391,11 +391,17 @@ set_option maxRecDepth 4096 in
 /-- Full add-back correction: init carry + 4 limb corrections + final u[j+4] adjust + qHat--.
     37 instructions, loop body indices [71]-[107].
     Entry: base+732, Exit: base+880, CodeReq: sharedDivModCode base. -/
-private theorem divK_addback_full_spec_within
+theorem divK_addback_full_spec_within_of_sub
     (sp uBase qHat v0 v1 v2 v3 u0 u1 u2 u3 u4 : Word)
     (v7_init v5_init v2_init : Word)
-    (base : Word) :
-    cpsTripleWithin 37 (base + addbackInitOff) (base + addbackBeqOff) (sharedDivModCode base)
+    (base : Word)
+    (code : CodeReq)
+    (hsub : ∀ (k : Nat) (addr : Word) (instr : Instr)
+        (hk : k < (divK_loopBody 560 7736).length)
+        (_h_addr : addr = (base + loopBodyOff) + BitVec.ofNat 64 (4 * k))
+        (_h_instr : (divK_loopBody 560 7736).get ⟨k, hk⟩ = instr),
+        ∀ a i, CodeReq.singleton addr instr a = some i → code a = some i) :
+    cpsTripleWithin 37 (base + addbackInitOff) (base + addbackBeqOff) code
       (addbackFullPre sp uBase qHat v0 v1 v2 v3 u0 u1 u2 u3 u4
         v7_init v5_init v2_init)
       (addbackFullPost sp uBase qHat v0 v1 v2 v3 u0 u1 u2 u3 u4) := by
@@ -426,7 +432,7 @@ private theorem divK_addback_full_spec_within
   have I := divK_addback_init_spec_within v7_init (base + addbackInitOff)
   rw [lb_ab0] at I
   have Ie := cpsTripleWithin_extend_code (hmono := by
-    exact lb_sub 71 _ _ (by decide) (by bv_addr) (by decide)) I
+    exact hsub 71 _ _ (by decide) (by bv_addr) (by decide)) I
   -- Frame init with all addback state
   have If := cpsTripleWithin_frameR
     ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ uBase) ** (.x11 ↦ᵣ qHat) **
@@ -442,14 +448,14 @@ private theorem divK_addback_full_spec_within
     v5_init v2_init v0 u0 32 0 (base + addbackLimb0Off)
   rw [lb_ab0_end] at A0
   have A0e := cpsTripleWithin_extend_code (hmono := by
-    exact CodeReq.union_sub (lb_sub 72 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (lb_sub 73 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (lb_sub 74 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (lb_sub 75 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (lb_sub 76 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (lb_sub 77 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (lb_sub 78 _ _ (by decide) (by bv_addr) (by decide))
-      (lb_sub 79 _ _ (by decide) (by bv_addr) (by decide)))))))))
+    exact CodeReq.union_sub (hsub 72 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (hsub 73 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (hsub 74 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (hsub 75 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (hsub 76 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (hsub 77 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (hsub 78 _ _ (by decide) (by bv_addr) (by decide))
+      (hsub 79 _ _ (by decide) (by bv_addr) (by decide)))))))))
     A0
   -- Compose init + limb 0
   seqFrame If A0e
@@ -458,14 +464,14 @@ private theorem divK_addback_full_spec_within
     ac2_0 aun0 v1 u1 40 4088 (base + addbackLimb1Off)
   rw [lb_ab1_end] at A1
   have A1e := cpsTripleWithin_extend_code (hmono := by
-    exact CodeReq.union_sub (lb_sub 80 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (lb_sub 81 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (lb_sub 82 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (lb_sub 83 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (lb_sub 84 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (lb_sub 85 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (lb_sub 86 _ _ (by decide) (by bv_addr) (by decide))
-      (lb_sub 87 _ _ (by decide) (by bv_addr) (by decide)))))))))
+    exact CodeReq.union_sub (hsub 80 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (hsub 81 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (hsub 82 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (hsub 83 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (hsub 84 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (hsub 85 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (hsub 86 _ _ (by decide) (by bv_addr) (by decide))
+      (hsub 87 _ _ (by decide) (by bv_addr) (by decide)))))))))
     A1
   seqFrame IfA0e A1e
   -- Limb 2: instrs [88]-[95] at base+addbackLimb2Off
@@ -473,14 +479,14 @@ private theorem divK_addback_full_spec_within
     ac2_1 aun1 v2 u2 48 4080 (base + addbackLimb2Off)
   rw [lb_ab2_end] at A2
   have A2e := cpsTripleWithin_extend_code (hmono := by
-    exact CodeReq.union_sub (lb_sub 88 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (lb_sub 89 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (lb_sub 90 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (lb_sub 91 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (lb_sub 92 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (lb_sub 93 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (lb_sub 94 _ _ (by decide) (by bv_addr) (by decide))
-      (lb_sub 95 _ _ (by decide) (by bv_addr) (by decide)))))))))
+    exact CodeReq.union_sub (hsub 88 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (hsub 89 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (hsub 90 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (hsub 91 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (hsub 92 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (hsub 93 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (hsub 94 _ _ (by decide) (by bv_addr) (by decide))
+      (hsub 95 _ _ (by decide) (by bv_addr) (by decide)))))))))
     A2
   seqFrame IfA0eA1e A2e
   -- Limb 3: instrs [96]-[103] at base+addbackLimb3Off
@@ -488,24 +494,24 @@ private theorem divK_addback_full_spec_within
     ac2_2 aun2 v3 u3 56 4072 (base + addbackLimb3Off)
   rw [lb_ab3_end] at A3
   have A3e := cpsTripleWithin_extend_code (hmono := by
-    exact CodeReq.union_sub (lb_sub 96 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (lb_sub 97 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (lb_sub 98 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (lb_sub 99 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (lb_sub 100 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (lb_sub 101 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (lb_sub 102 _ _ (by decide) (by bv_addr) (by decide))
-      (lb_sub 103 _ _ (by decide) (by bv_addr) (by decide)))))))))
+    exact CodeReq.union_sub (hsub 96 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (hsub 97 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (hsub 98 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (hsub 99 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (hsub 100 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (hsub 101 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (hsub 102 _ _ (by decide) (by bv_addr) (by decide))
+      (hsub 103 _ _ (by decide) (by bv_addr) (by decide)))))))))
     A3
   seqFrame IfA0eA1eA2e A3e
   -- Final: instrs [104]-[107] at base+addbackFinalOff
   have AF := divK_addback_final_spec_within uBase aco3 qHat ac2_3 u4 4064 (base + addbackFinalOff)
   rw [lb_abf_end] at AF
   have AFe := cpsTripleWithin_extend_code (hmono := by
-    exact CodeReq.union_sub (lb_sub 104 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (lb_sub 105 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (lb_sub 106 _ _ (by decide) (by bv_addr) (by decide))
-      (lb_sub 107 _ _ (by decide) (by bv_addr) (by decide)))))
+    exact CodeReq.union_sub (hsub 104 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (hsub 105 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (hsub 106 _ _ (by decide) (by bv_addr) (by decide))
+      (hsub 107 _ _ (by decide) (by bv_addr) (by decide)))))
     AF
   seqFrame IfA0eA1eA2eA3e AFe
   -- Final permutation
@@ -514,7 +520,31 @@ private theorem divK_addback_full_spec_within
     (fun h hq => by xperm_hyp hq)
     IfA0eA1eA2eA3eAFe
 
-/-- `divK_addback_full_spec_within` replayed over the DIV no-NOP code surface. -/
+/-- Full add-back correction over `sharedDivModCode`. -/
+private theorem divK_addback_full_spec_within
+    (sp uBase qHat v0 v1 v2 v3 u0 u1 u2 u3 u4 : Word)
+    (v7_init v5_init v2_init : Word)
+    (base : Word) :
+    cpsTripleWithin 37 (base + addbackInitOff) (base + addbackBeqOff) (sharedDivModCode base)
+      (addbackFullPre sp uBase qHat v0 v1 v2 v3 u0 u1 u2 u3 u4
+        v7_init v5_init v2_init)
+      (addbackFullPost sp uBase qHat v0 v1 v2 v3 u0 u1 u2 u3 u4) :=
+  divK_addback_full_spec_within_of_sub sp uBase qHat v0 v1 v2 v3 u0 u1 u2 u3 u4
+    v7_init v5_init v2_init base (sharedDivModCode base) lb_sub
+
+/-- Full add-back correction over `sharedDivModCodeNoNop_v4`. -/
+private theorem divK_addback_full_v4_spec_within_noNop
+    (sp uBase qHat v0 v1 v2 v3 u0 u1 u2 u3 u4 : Word)
+    (v7_init v5_init v2_init : Word)
+    (base : Word) :
+    cpsTripleWithin 37 (base + addbackInitOff) (base + addbackBeqOff) (sharedDivModCodeNoNop_v4 base)
+      (addbackFullPre sp uBase qHat v0 v1 v2 v3 u0 u1 u2 u3 u4
+        v7_init v5_init v2_init)
+      (addbackFullPost sp uBase qHat v0 v1 v2 v3 u0 u1 u2 u3 u4) :=
+  divK_addback_full_spec_within_of_sub sp uBase qHat v0 v1 v2 v3 u0 u1 u2 u3 u4
+    v7_init v5_init v2_init base (sharedDivModCodeNoNop_v4 base) lb_sub_noNop_v4
+
+/-- Full add-back correction over the DIV no-NOP code surface. -/
 private theorem divK_addback_full_spec_within_noNop
     (sp uBase qHat v0 v1 v2 v3 u0 u1 u2 u3 u4 : Word)
     (v7_init v5_init v2_init : Word)
@@ -522,121 +552,9 @@ private theorem divK_addback_full_spec_within_noNop
     cpsTripleWithin 37 (base + addbackInitOff) (base + addbackBeqOff) (divCode_noNop base)
       (addbackFullPre sp uBase qHat v0 v1 v2 v3 u0 u1 u2 u3 u4
         v7_init v5_init v2_init)
-      (addbackFullPost sp uBase qHat v0 v1 v2 v3 u0 u1 u2 u3 u4) := by
-  unfold addbackFullPre addbackFullPost
-  let upc0 := u0 + (signExtend12 0 : Word)
-  let ac1_0 := if BitVec.ult upc0 (signExtend12 0 : Word) then (1 : Word) else 0
-  let aun0 := upc0 + v0
-  let ac2_0 := if BitVec.ult aun0 v0 then (1 : Word) else 0
-  let aco0 := ac1_0 ||| ac2_0
-  let upc1 := u1 + aco0
-  let ac1_1 := if BitVec.ult upc1 aco0 then (1 : Word) else 0
-  let aun1 := upc1 + v1
-  let ac2_1 := if BitVec.ult aun1 v1 then (1 : Word) else 0
-  let aco1 := ac1_1 ||| ac2_1
-  let upc2 := u2 + aco1
-  let ac1_2 := if BitVec.ult upc2 aco1 then (1 : Word) else 0
-  let aun2 := upc2 + v2
-  let ac2_2 := if BitVec.ult aun2 v2 then (1 : Word) else 0
-  let aco2 := ac1_2 ||| ac2_2
-  let upc3 := u3 + aco2
-  let ac1_3 := if BitVec.ult upc3 aco2 then (1 : Word) else 0
-  let aun3 := upc3 + v3
-  let ac2_3 := if BitVec.ult aun3 v3 then (1 : Word) else 0
-  let aco3 := ac1_3 ||| ac2_3
-  let aun4 := u4 + aco3
-  let qHat' := qHat + signExtend12 4095
-  -- Init: instr [71] at base+732
-  have I := divK_addback_init_spec_within v7_init (base + addbackInitOff)
-  rw [lb_ab0] at I
-  have Ie := cpsTripleWithin_extend_code (hmono := by
-    exact lb_sub_noNop 71 _ _ (by decide) (by bv_addr) (by decide)) I
-  -- Frame init with all addback state
-  have If := cpsTripleWithin_frameR
-    ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ uBase) ** (.x11 ↦ᵣ qHat) **
-     (.x5 ↦ᵣ v5_init) ** (.x2 ↦ᵣ v2_init) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-     ((uBase + signExtend12 4064) ↦ₘ u4))
-    (by pcFree) Ie
-  -- Limb 0: instrs [72]-[79] at base+addbackLimb0Off
-  have A0 := divK_addback_limb_spec_within sp uBase (signExtend12 0 : Word)
-    v5_init v2_init v0 u0 32 0 (base + addbackLimb0Off)
-  rw [lb_ab0_end] at A0
-  have A0e := cpsTripleWithin_extend_code (hmono := by
-    exact CodeReq.union_sub (lb_sub_noNop 72 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (lb_sub_noNop 73 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (lb_sub_noNop 74 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (lb_sub_noNop 75 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (lb_sub_noNop 76 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (lb_sub_noNop 77 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (lb_sub_noNop 78 _ _ (by decide) (by bv_addr) (by decide))
-      (lb_sub_noNop 79 _ _ (by decide) (by bv_addr) (by decide)))))))))
-    A0
-  -- Compose init + limb 0
-  seqFrame If A0e
-  -- Limb 1: instrs [80]-[87] at base+addbackLimb1Off
-  have A1 := divK_addback_limb_spec_within sp uBase aco0
-    ac2_0 aun0 v1 u1 40 4088 (base + addbackLimb1Off)
-  rw [lb_ab1_end] at A1
-  have A1e := cpsTripleWithin_extend_code (hmono := by
-    exact CodeReq.union_sub (lb_sub_noNop 80 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (lb_sub_noNop 81 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (lb_sub_noNop 82 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (lb_sub_noNop 83 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (lb_sub_noNop 84 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (lb_sub_noNop 85 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (lb_sub_noNop 86 _ _ (by decide) (by bv_addr) (by decide))
-      (lb_sub_noNop 87 _ _ (by decide) (by bv_addr) (by decide)))))))))
-    A1
-  seqFrame IfA0e A1e
-  -- Limb 2: instrs [88]-[95] at base+addbackLimb2Off
-  have A2 := divK_addback_limb_spec_within sp uBase aco1
-    ac2_1 aun1 v2 u2 48 4080 (base + addbackLimb2Off)
-  rw [lb_ab2_end] at A2
-  have A2e := cpsTripleWithin_extend_code (hmono := by
-    exact CodeReq.union_sub (lb_sub_noNop 88 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (lb_sub_noNop 89 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (lb_sub_noNop 90 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (lb_sub_noNop 91 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (lb_sub_noNop 92 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (lb_sub_noNop 93 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (lb_sub_noNop 94 _ _ (by decide) (by bv_addr) (by decide))
-      (lb_sub_noNop 95 _ _ (by decide) (by bv_addr) (by decide)))))))))
-    A2
-  seqFrame IfA0eA1e A2e
-  -- Limb 3: instrs [96]-[103] at base+addbackLimb3Off
-  have A3 := divK_addback_limb_spec_within sp uBase aco2
-    ac2_2 aun2 v3 u3 56 4072 (base + addbackLimb3Off)
-  rw [lb_ab3_end] at A3
-  have A3e := cpsTripleWithin_extend_code (hmono := by
-    exact CodeReq.union_sub (lb_sub_noNop 96 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (lb_sub_noNop 97 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (lb_sub_noNop 98 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (lb_sub_noNop 99 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (lb_sub_noNop 100 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (lb_sub_noNop 101 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (lb_sub_noNop 102 _ _ (by decide) (by bv_addr) (by decide))
-      (lb_sub_noNop 103 _ _ (by decide) (by bv_addr) (by decide)))))))))
-    A3
-  seqFrame IfA0eA1eA2e A3e
-  -- Final: instrs [104]-[107] at base+addbackFinalOff
-  have AF := divK_addback_final_spec_within uBase aco3 qHat ac2_3 u4 4064 (base + addbackFinalOff)
-  rw [lb_abf_end] at AF
-  have AFe := cpsTripleWithin_extend_code (hmono := by
-    exact CodeReq.union_sub (lb_sub_noNop 104 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (lb_sub_noNop 105 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (lb_sub_noNop 106 _ _ (by decide) (by bv_addr) (by decide))
-      (lb_sub_noNop 107 _ _ (by decide) (by bv_addr) (by decide)))))
-    AF
-  seqFrame IfA0eA1eA2eA3e AFe
-  -- Final permutation
-  exact cpsTripleWithin_weaken
-    (fun h hp => by xperm_hyp hp)
-    (fun h hq => by xperm_hyp hq)
-    IfA0eA1eA2eA3eAFe
+      (addbackFullPost sp uBase qHat v0 v1 v2 v3 u0 u1 u2 u3 u4) :=
+  divK_addback_full_spec_within_of_sub sp uBase qHat v0 v1 v2 v3 u0 u1 u2 u3 u4
+    v7_init v5_init v2_init base (divCode_noNop base) lb_sub_noNop
 
 /-- Named-postcondition no-NOP wrapper for `divK_addback_full_spec_within_noNop`.
     Bundles the 22-let result into `addbackFullPost`; 0 statement lets. -/
@@ -657,6 +575,24 @@ theorem divK_addback_full_named_spec_within_noNop
     (fun h hp => by unfold addbackFullPre; exact hp)
     (fun h hp => hp)
     (divK_addback_full_spec_within_noNop sp uBase qHat v0 v1 v2 v3 u0 u1 u2 u3 u4 v7_init v5_init v2_init base)
+
+theorem divK_addback_full_named_v4_spec_within_noNop
+    (sp uBase qHat v0 v1 v2 v3 u0 u1 u2 u3 u4 : Word)
+    (v7_init v5_init v2_init : Word)
+    (base : Word) :
+    cpsTripleWithin 37 (base + addbackInitOff) (base + addbackBeqOff) (sharedDivModCodeNoNop_v4 base)
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ uBase) ** (.x7 ↦ᵣ v7_init) **
+       (.x11 ↦ᵣ qHat) ** (.x5 ↦ᵣ v5_init) ** (.x2 ↦ᵣ v2_init) ** (.x0 ↦ᵣ (0 : Word)) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ u4))
+      (addbackFullPost sp uBase qHat v0 v1 v2 v3 u0 u1 u2 u3 u4) :=
+  cpsTripleWithin_weaken
+    (fun h hp => by unfold addbackFullPre; exact hp)
+    (fun h hp => hp)
+    (divK_addback_full_v4_spec_within_noNop sp uBase qHat v0 v1 v2 v3 u0 u1 u2 u3 u4 v7_init v5_init v2_init base)
 
 private theorem lb_ms_setup {base : Word} : (base + div128CallRetOff : Word) + 20 = base + mulsubOff := by bv_addr
 
@@ -1153,7 +1089,6 @@ theorem divK_correction_addback_spec_within_noNop
     (fun h hp => by xperm_hyp hp)
     (fun h hq => by xperm_hyp hq)
     ntaken_framedAB
-
 
 private theorem lb_save_j {base : Word} :
     (base + loopBodyOff : Word) + 4 = base + (loopBodyOff + 4) := by


### PR DESCRIPTION
## Summary
- factor the addback-full proof through a generic code-inclusion helper
- remove the duplicated no-NOP addback-full proof body
- add a sharedDivModCodeNoNop_v4 addback-full named surface for later v4 addback composition proofs

Stacked on #5046.

## Verification
- lake build EvmAsm.Evm64.DivMod.LoopBody
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- scripts/check-file-size.sh EvmAsm/Evm64/DivMod/LoopBody.lean