### PR TITLE
feat(div): add n4 addback v4 no-nop loop

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -45,6 +45,7 @@ import EvmAsm.Evm64.DivMod.LoopIterN3MaxV4NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN3AddbackV4NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN4MaxV4NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN4CallV4NoNop
+import EvmAsm.Evm64.DivMod.LoopIterN4AddbackV4NoNop
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN2LoopUnified
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3LoopUnified
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN3LoopUnified

--- a/EvmAsm/Evm64/DivMod/LoopIterN3AddbackV4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN3AddbackV4NoNop.lean
@@ -8,36 +8,6 @@ import EvmAsm.Evm64.DivMod.LoopIterN3CallV4NoNop
 import EvmAsm.Evm64.DivMod.LoopBody.CorrectionAddbackBeq
 import EvmAsm.Evm64.DivMod.LoopBody.CorrectionAddbackBeqV4NoNop
 
-open EvmAsm.Rv64.Tactics
-open EvmAsm.Evm64.DivMod.AddrNorm (slt_jpos_1)
-
-namespace EvmAsm.Evm64
-
-open EvmAsm.Rv64
-
-@[irreducible]
-def loopBodyN3CallAddbackJ0PostV4
-    (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word) : Assertion :=
-  let dLo := divKTrialCallV4DLo v2
-  let divUn0 := divKTrialCallV4Un0 u2
-  let qHat := divKTrialCallV4QHat u3 u2 v2
-  let scratchOut := divKTrialCallV4ScratchOut u3 u2 v2 scratchMem
-  loopBodyN3AddbackBeqPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
-  (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
-  (sp + signExtend12 3960 ↦ₘ v2) **
-  (sp + signExtend12 3952 ↦ₘ dLo) **
-  (sp + signExtend12 3944 ↦ₘ divUn0) **
-  (sp + signExtend12 3936 ↦ₘ scratchOut) **
-  regOwn .x1
-
-@[irreducible]
-def loopBodyN3CallAddbackJgt0PreV4
-    (j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
-     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
-    (retMem dMem dloMem scratchUn0 scratchMem : Word) : Assertion :=
-  loopBodyN3CallPreV4 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
-    j v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem
-
 @[irreducible]
 def loopBodyN3CallAddbackJgt0PostV4
     (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word) : Assertion :=

--- a/EvmAsm/Evm64/DivMod/LoopIterN3AddbackV4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN3AddbackV4NoNop.lean
@@ -8,6 +8,12 @@ import EvmAsm.Evm64.DivMod.LoopIterN3CallV4NoNop
 import EvmAsm.Evm64.DivMod.LoopBody.CorrectionAddbackBeq
 import EvmAsm.Evm64.DivMod.LoopBody.CorrectionAddbackBeqV4NoNop
 
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
 @[irreducible]
 def loopBodyN3CallAddbackJgt0PostV4
     (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word) : Assertion :=
@@ -188,6 +194,21 @@ theorem divK_loop_body_n3_max_addback_jgt0_beq_v4_spec_within_noNop (j : Word)
       xperm_hyp hp)
     full
 
+@[irreducible]
+def loopBodyN3CallAddbackJ0PostV4
+    (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word) : Assertion :=
+  let dLo := divKTrialCallV4DLo v2
+  let divUn0 := divKTrialCallV4Un0 u2
+  let qHat := divKTrialCallV4QHat u3 u2 v2
+  let scratchOut := divKTrialCallV4ScratchOut u3 u2 v2 scratchMem
+  loopBodyN3AddbackBeqPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+  (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+  (sp + signExtend12 3960 ↦ₘ v2) **
+  (sp + signExtend12 3952 ↦ₘ dLo) **
+  (sp + signExtend12 3944 ↦ₘ divUn0) **
+  (sp + signExtend12 3936 ↦ₘ scratchOut) **
+  regOwn .x1
+
 /-- No-NOP/v4 variant of `divK_loop_body_n3_call_addback_j0_beq_spec_within_noNop`. -/
 theorem divK_loop_body_n3_call_addback_j0_beq_v4_spec_within_noNop
     (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
@@ -280,6 +301,14 @@ theorem divK_loop_body_n3_call_addback_j0_beq_v4_spec_within_noNop
       rw [sepConj_assoc'] at hp
       xperm_hyp hp)
     full
+
+@[irreducible]
+def loopBodyN3CallAddbackJgt0PreV4
+    (j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word) : Assertion :=
+  loopBodyN3CallPreV4 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    j v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem
 
 /-- No-NOP/v4 variant of `divK_loop_body_n3_call_addback_jgt0_beq_spec_within_noNop`. -/
 theorem divK_loop_body_n3_call_addback_jgt0_beq_v4_spec_within_noNop (j : Word)

--- a/EvmAsm/Evm64/DivMod/LoopIterN3CallV4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN3CallV4NoNop.lean
@@ -1,12 +1,13 @@
 /-
   EvmAsm.Evm64.DivMod.LoopIterN3CallV4NoNop
 
-  No-NOP/v4 replay for the n=3 call+skip j=0 loop-body spec.
+  No-NOP/v4 replays for n=3 call+skip loop-body specs.
 -/
 
 import EvmAsm.Evm64.DivMod.LoopIterN3
 
 open EvmAsm.Rv64.Tactics
+open EvmAsm.Evm64.DivMod.AddrNorm (slt_jpos_1)
 
 namespace EvmAsm.Evm64
 
@@ -48,7 +49,23 @@ def loopBodyN3CallSkipPostV4
   (sp + signExtend12 3960 ↦ₘ v2) **
   (sp + signExtend12 3952 ↦ₘ dLo) **
   (sp + signExtend12 3944 ↦ₘ div_un0) **
-  (sp + signExtend12 3936 ↦ₘ scratchOut) ** regOwn .x1
+  (sp + signExtend12 3936 ↦ₘ scratchOut) **
+  regOwn .x1
+
+@[irreducible]
+def loopBodyN3CallSkipJgt0PostV4
+    (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word) : Assertion :=
+  let dLo := divKTrialCallV4DLo v2
+  let div_un0 := divKTrialCallV4Un0 u2
+  let qHat := divKTrialCallV4QHat u3 u2 v2
+  let scratchOut := divKTrialCallV4ScratchOut u3 u2 v2 scratchMem
+  loopBodyN3SkipPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+  (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+  (sp + signExtend12 3960 ↦ₘ v2) **
+  (sp + signExtend12 3952 ↦ₘ dLo) **
+  (sp + signExtend12 3944 ↦ₘ div_un0) **
+  (sp + signExtend12 3936 ↦ₘ scratchOut) **
+  regOwn .x1
 
 /-- No-NOP/v4 loop body cpsTripleWithin for n=3, call+skip, j=0. -/
 theorem divK_loop_body_n3_call_skip_j0_v4_spec_within_noNop
@@ -145,6 +162,109 @@ theorem divK_loop_body_n3_call_skip_j0_v4_spec_within_noNop
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
       unfold loopBodyN3CallSkipPostV4
+      unfold loopBodyN3SkipPost loopBodySkipPost loopExitPost
+      unfold mulsubN4
+      dsimp only []
+      rw [sepConj_assoc'] at hp
+      xperm_hyp hp)
+    full
+
+/-- No-NOP/v4 loop body cpsTripleWithin for n=3, call+skip, j=1.
+    This consumes the v4 div128 call path and loops back to the loop body. -/
+theorem divK_loop_body_n3_call_skip_j1_v4_spec_within_noNop
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : BitVec.ult u3 v2)
+    (hborrow : mulsubN4NoBorrow (divKTrialCallV4QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 148 (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCodeNoNop_v4 base)
+      (loopBodyN3CallPreV4 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem)
+      (loopBodyN3CallSkipJgt0PostV4 sp base (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem) := by
+  unfold loopBodyN3CallPreV4
+  let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+  let dHi := divKTrialCallV4DHi v2
+  let dLo := divKTrialCallV4DLo v2
+  let div_un0 := divKTrialCallV4Un0 u2
+  let q1'' := divKTrialCallV4Q1dd u3 u2 v2
+  let q0'' := divKTrialCallV4Q0dd u3 u2 v2
+  let x7Exit := divKTrialCallV4X7Exit u3 u2 v2
+  let x9Exit := divKTrialCallV4X9Exit u3 u2 v2
+  let qHat := divKTrialCallV4QHat u3 u2 v2
+  let scratchOut := divKTrialCallV4ScratchOut u3 u2 v2 scratchMem
+  have TF := divK_trial_call_full_v4_spec_within_noNop sp (1 : Word) (3 : Word)
+    jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    u3 u2 v2 retMem dMem dloMem scratchUn0 scratchMem base
+    halign hbltu
+  unfold divKTrialCallFullPostV4 at TF
+  dsimp only [] at TF
+  rw [u_addr_eq_n3] at TF
+  rw [u_addr8_eq_n3] at TF
+  rw [vtop_eq_v2_n3] at TF
+  have hborrow' :
+      mulsubN4NoBorrow qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+    exact hborrow
+  have MCS := divK_mulsub_correction_skip_v4_spec_within_noNop sp qHat (1 : Word)
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    x9Exit q0'' dHi x7Exit q1'' (base + div128CallRetOff) base
+  have MCS0 := MCS hborrow'
+  unfold divKMulsubCorrectionSkipPre at MCS0
+  unfold n4McaNamedSkipPost at MCS0
+  unfold mulsubN4 at MCS0
+  dsimp only [] at MCS0
+  have MCS0f := cpsTripleWithin_frameR ((sp + signExtend12 3936 ↦ₘ scratchOut) ** regOwn .x1)
+    (by pcFree) MCS0
+  let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
+  let fs0 := p0_lo + (signExtend12 0 : Word)
+  let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
+  let pc0 := ba0 + p0_hi; let bs0 := if BitVec.ult u0 fs0 then (1 : Word) else 0
+  let un0 := u0 - fs0; let c0 := pc0 + bs0
+  let p1_lo := qHat * v1; let p1_hi := rv64_mulhu qHat v1
+  let fs1 := p1_lo + c0; let ba1 := if BitVec.ult fs1 c0 then (1 : Word) else 0
+  let pc1 := ba1 + p1_hi; let bs1 := if BitVec.ult u1 fs1 then (1 : Word) else 0
+  let un1 := u1 - fs1; let c1 := pc1 + bs1
+  let p2_lo := qHat * v2; let p2_hi := rv64_mulhu qHat v2
+  let fs2 := p2_lo + c1; let ba2 := if BitVec.ult fs2 c1 then (1 : Word) else 0
+  let pc2 := ba2 + p2_hi; let bs2 := if BitVec.ult u2 fs2 then (1 : Word) else 0
+  let un2 := u2 - fs2; let c2 := pc2 + bs2
+  let p3_lo := qHat * v3; let p3_hi := rv64_mulhu qHat v3
+  let fs3 := p3_lo + c2; let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
+  let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
+  let un3 := u3 - fs3; let c3 := pc3 + bs3
+  let u4_new := uTop - c3
+  have SL := divK_store_loop_jgt0_v4_spec_within_noNop sp (1 : Word) qHat u4_new (0 : Word) qOld base slt_jpos_1
+  intro_lets at SL
+  have TFf := cpsTripleWithin_frameR
+    (((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
+     (qAddr ↦ₘ qOld))
+    (by pcFree) TF
+  seqFrame TFf MCS0f
+  have SLf := cpsTripleWithin_frameR
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
+     (sp + signExtend12 3976 ↦ₘ (1 : Word)) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_new) **
+     (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
+     (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+     (sp + signExtend12 3960 ↦ₘ v2) **
+     (sp + signExtend12 3952 ↦ₘ dLo) **
+     (sp + signExtend12 3944 ↦ₘ div_un0) **
+     (sp + signExtend12 3936 ↦ₘ scratchOut) ** regOwn .x1)
+    (by pcFree) SL
+  have full := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0f SLf
+  exact cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by
+      unfold loopBodyN3CallSkipJgt0PostV4
       unfold loopBodyN3SkipPost loopBodySkipPost loopExitPost
       unfold mulsubN4
       dsimp only []

--- a/EvmAsm/Evm64/DivMod/LoopIterN4AddbackV4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN4AddbackV4NoNop.lean
@@ -6,6 +6,7 @@
 
 import EvmAsm.Evm64.DivMod.LoopIterN4CallV4NoNop
 import EvmAsm.Evm64.DivMod.LoopBody.CorrectionAddbackBeq
+import EvmAsm.Evm64.DivMod.LoopBody.CorrectionAddbackBeqV4NoNop
 
 open EvmAsm.Rv64.Tactics
 

--- a/EvmAsm/Evm64/DivMod/LoopIterN4AddbackV4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN4AddbackV4NoNop.lean
@@ -1,0 +1,145 @@
+/-
+  EvmAsm.Evm64.DivMod.LoopIterN4AddbackV4NoNop
+
+  No-NOP/v4 replay for the n=4 call+addback loop-body spec.
+-/
+
+import EvmAsm.Evm64.DivMod.LoopIterN4CallV4NoNop
+import EvmAsm.Evm64.DivMod.LoopBody.CorrectionAddbackBeq
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+@[irreducible]
+def loopBodyN4CallAddbackJ0PostV4
+    (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word) : Assertion :=
+  let dLo := divKTrialCallV4DLo v3
+  let divUn0 := divKTrialCallV4Un0 u3
+  let qHat := divKTrialCallV4QHat uTop u3 v3
+  let scratchOut := divKTrialCallV4ScratchOut uTop u3 v3 scratchMem
+  loopBodyN4AddbackBeqPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+  (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+  (sp + signExtend12 3960 ↦ₘ v3) **
+  (sp + signExtend12 3952 ↦ₘ dLo) **
+  (sp + signExtend12 3944 ↦ₘ divUn0) **
+  (sp + signExtend12 3936 ↦ₘ scratchOut) **
+  regOwn .x1
+
+@[irreducible]
+def loopBodyN4CallAddbackBorrowV4
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Prop :=
+  let qHat := divKTrialCallV4QHat uTop u3 v3
+  let c3 := mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3
+  (if BitVec.ult uTop c3 then (1 : Word) else 0) ≠ (0 : Word)
+
+@[irreducible]
+def loopBodyN4CallAddbackCarry2NzV4
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Prop :=
+  let qHat := divKTrialCallV4QHat uTop u3 v3
+  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+  let c3 := ms.2.2.2.2
+  let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
+  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
+  carry = 0 →
+    addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0
+
+/-- No-NOP/v4 loop body cpsTripleWithin for n=4, call+addback, j=0.
+    This consumes the v4 div128 call path and exits to denorm. -/
+theorem divK_loop_body_n4_call_addback_j0_beq_v4_spec_within_noNop
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : BitVec.ult uTop v3)
+    (hborrow : loopBodyN4CallAddbackBorrowV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hcarry2_nz : loopBodyN4CallAddbackCarry2NzV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 224 (base + loopBodyOff) (base + denormOff) (sharedDivModCodeNoNop_v4 base)
+      (loopBodyN4CallSkipJ0PreV4 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem)
+      (loopBodyN4CallAddbackJ0PostV4 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem) := by
+  unfold loopBodyN4CallSkipJ0PreV4
+  let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
+  let dHi := divKTrialCallV4DHi v3
+  let dLo := divKTrialCallV4DLo v3
+  let divUn0 := divKTrialCallV4Un0 u3
+  let q1'' := divKTrialCallV4Q1dd uTop u3 v3
+  let q0'' := divKTrialCallV4Q0dd uTop u3 v3
+  let x7Exit := divKTrialCallV4X7Exit uTop u3 v3
+  let x9Exit := divKTrialCallV4X9Exit uTop u3 v3
+  let qHat := divKTrialCallV4QHat uTop u3 v3
+  let scratchOut := divKTrialCallV4ScratchOut uTop u3 v3 scratchMem
+  have TF := divK_trial_call_full_v4_spec_within_noNop sp (0 : Word) (4 : Word)
+    jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    uTop u3 v3 retMem dMem dloMem scratchUn0 scratchMem base
+    halign hbltu
+  unfold divKTrialCallFullPostV4 at TF
+  dsimp only [] at TF
+  rw [u_addr_eq_n4] at TF
+  rw [u_addr8_eq_n4] at TF
+  rw [vtop_eq_v3_n4] at TF
+  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+  let c3 := ms.2.2.2.2
+  let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
+  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
+  let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
+  let q_out := if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
+               else qHat + signExtend12 4095
+  let un0Out := if carry = 0 then ab'.1 else ab.1
+  let un1Out := if carry = 0 then ab'.2.1 else ab.2.1
+  let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
+  let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
+  let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
+  let carryOut := if carry = 0 then
+      addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
+    else carry
+  have MCA := divK_mulsub_correction_addback_beq_v4_spec_within_noNop sp qHat (0 : Word)
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    x9Exit q0'' dHi x7Exit q1'' (base + div128CallRetOff) base
+  unfold loopBodyN4CallAddbackCarry2NzV4 at hcarry2_nz
+  unfold loopBodyN4CallAddbackBorrowV4 at hborrow
+  have MCA0 := MCA hcarry2_nz hborrow
+  have MCA0f := cpsTripleWithin_frameR ((sp + signExtend12 3936 ↦ₘ scratchOut) ** regOwn .x1)
+    (by pcFree) MCA0
+  have SL := divK_store_loop_j0_v4_spec_within_noNop sp q_out u4_out carryOut qOld base
+  intro_lets at SL
+  have TFf := cpsTripleWithin_frameR
+    (((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+     (qAddr ↦ₘ qOld))
+    (by pcFree) TF
+  seqFrame TFf MCA0f
+  have SLf := cpsTripleWithin_frameR
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
+     (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0Out) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1Out) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2Out) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3Out) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_out) **
+     (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
+     (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+     (sp + signExtend12 3960 ↦ₘ v3) **
+     (sp + signExtend12 3952 ↦ₘ dLo) **
+     (sp + signExtend12 3944 ↦ₘ divUn0) **
+     (sp + signExtend12 3936 ↦ₘ scratchOut) ** regOwn .x1)
+    (by pcFree) SL
+  have full := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0f SLf
+  exact cpsTripleWithin_weaken
+    (fun h hp => by
+      rw [loopBodyN4CallSkipJ0Pre_unfold] at hp
+      xperm_hyp hp)
+    (fun h hp => by
+      unfold loopBodyN4CallAddbackJ0PostV4
+      unfold loopBodyN4AddbackBeqPost loopBodyAddbackBeqPost loopExitPost
+      rw [sepConj_assoc'] at hp
+      xperm_hyp hp)
+    full
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add n=4 call addback j=0 loop-body proof over the v4 div128 call path
- hide the v4 addback post and side conditions behind irreducible definitions
- import the new module through the DivMod umbrella

## Tests
- lake build EvmAsm.Evm64.DivMod.LoopIterN4AddbackV4NoNop
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- scripts/check-file-size.sh EvmAsm/Evm64/DivMod/LoopIterN4AddbackV4NoNop.lean
- rg -n "sorry|admit|placeholder|set_option" EvmAsm/Evm64/DivMod/LoopIterN4AddbackV4NoNop.lean