### PR TITLE
feat(div): add v4 no-nop norma loopsetup wrapper

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathV4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathV4NoNop.lean
@@ -66,4 +66,96 @@ theorem evm_div_n4_to_normB_spec_v4_noNop (sp base : Word)
     (fun h hq => by delta normBPost; xperm_hyp hq)
     hFull
 
+/-- Full n=4 path from entry to loop body start over `divCode_noNop_v4`
+    (shift ≠ 0 case). Normalizes b[] and a[], then sets up loop parameters. -/
+theorem evm_div_n4_to_loopSetup_spec_v4_noNop (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3nz : b3 ≠ 0)
+    (hshift_nz : (clzResult b3).1 ≠ 0) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4) base (base + loopBodyOff) (divCode_noNop_v4 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+       ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+       ((sp + signExtend12 4024) ↦ₘ u4Old) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
+      (loopSetupPost sp (4 : Word) (clzResult b3).1 a0 a1 a2 a3 b0 b1 b2 b3) := by
+  let shift := (clzResult b3).1
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+  let b0' := b0 <<< (shift.toNat % 64)
+  let u4 := a3 >>> (antiShift.toNat % 64)
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
+  let u0 := a0 <<< (shift.toNat % 64)
+  have hNormB := evm_div_n4_to_normB_spec_v4_noNop sp base b0 b1 b2 b3 v5 v6 v7 v10
+    q0 q1 q2 q3 u5 u6 u7 nMem shiftMem hbnz hb3nz hshift_nz
+  have hNormBf := cpsTripleWithin_frameR
+    ((.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+     ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+     ((sp + signExtend12 4024) ↦ₘ u4Old))
+    (by pcFree) hNormB
+  have hNormA := divK_normA_full_spec_within_v4_noNop sp a0 a1 a2 a3
+    b0' (b0 >>> (antiShift.toNat % 64)) b3 shift antiShift
+    u0Old u1Old u2Old u3Old u4Old base
+  rw [divKNormAFullPreNoNop_unfold] at hNormA
+  simp only [normAFullPost_unfold] at hNormA
+  have hNormAf := cpsTripleWithin_frameR
+    ((.x0 ↦ᵣ (0 : Word)) **
+     (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
+     ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3') **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (4 : Word)) **
+     ((sp + signExtend12 3992) ↦ₘ shift))
+    (by pcFree) hNormA
+  have hNA := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by delta normBPost at hp; xperm_hyp hp) hNormBf hNormAf
+  have hLS := divK_loopSetup_ntaken_spec_within_v4_noNop sp (4 : Word)
+    (signExtend12 (4 : BitVec 12) - (4 : Word)) u1 base
+    (by decide)
+  simp only [divKLoopSetupNtakenPreNoNop_unfold,
+      divKLoopSetupNtakenPostNoNop_unfold] at hLS
+  have hLSf := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ (a0 >>> (antiShift.toNat % 64))) **
+     (.x6 ↦ᵣ shift) ** (.x7 ↦ᵣ u0) ** (.x2 ↦ᵣ antiShift) **
+     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
+     ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3') **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
+     ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3) **
+     ((sp + signExtend12 4024) ↦ₘ u4) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3992) ↦ₘ shift))
+    (by pcFree) hLS
+  have hFull := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hNA hLSf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by delta loopSetupPost; xperm_hyp hq)
+    hFull
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/NormA.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/NormA.lean
@@ -6,6 +6,7 @@
 -/
 
 import EvmAsm.Evm64.DivMod.Compose.Base
+import EvmAsm.Evm64.DivMod.Compose.V4NoNop
 
 open EvmAsm.Rv64.Tactics
 
@@ -32,6 +33,13 @@ private theorem divK_normA_code_sub_divCode_noNop {base : Word} :
   unfold divCode_noNop; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
   exact CodeReq.union_mono_left
+
+/-- NormA code (block 5) is subsumed by divCode_noNop_v4. -/
+private theorem divK_normA_code_sub_divCode_noNop_v4 {base : Word} :
+    ∀ a i, (CodeReq.ofProg (base + normAOff) (divK_normA 40)) a = some i →
+      (divCode_noNop_v4 base) a = some i := by
+  intro a i h
+  exact sharedNoNop_v4_b5_div a i h
 
 -- signExtend12 rewrites pulled from the divmod_addr global set (AddrNorm.lean).
 open EvmAsm.Evm64.DivMod.AddrNorm (se12_0 se12_8 se12_16 se12_24)
@@ -356,6 +364,127 @@ theorem divK_normA_full_spec_within_noNop (sp a0 a1 a2 a3 v5 v7 v10 shift antiSh
     (fun h hq => by xperm_hyp hq)
     h123456
 
+theorem divK_normA_full_spec_within_v4_noNop (sp a0 a1 a2 a3 v5 v7 v10 shift antiShift : Word)
+    (u0Old u1Old u2Old u3Old u4Old : Word) (base : Word) :
+    cpsTripleWithin 21 (base + normAOff) (base + loopSetupOff) (divCode_noNop_v4 base)
+      (divKNormAFullPreNoNop sp v5 v7 v10 shift antiShift
+        a0 a1 a2 a3 u0Old u1Old u2Old u3Old u4Old)
+      (normAFullPost sp a0 a1 a2 a3 shift antiShift) := by
+  rw [divKNormAFullPreNoNop_unfold, normAFullPost_unfold]
+  let u4 := a3 >>> (antiShift.toNat % 64)
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
+  let u0 := a0 <<< (shift.toNat % 64)
+  have htop := divK_normA_top_spec_within 24 4024 sp a3 v5 v7 antiShift u4Old (base + normAOff)
+  simp only [se12_24] at htop
+  have htope := cpsTripleWithin_extend_code (hmono := fun a i h =>
+    divK_normA_code_sub_divCode_noNop_v4 a i
+      (CodeReq.ofProg_mono_sub (base + normAOff) (base + normAOff) (divK_normA 40)
+        (divK_normA_top_prog 24 4024) 0
+        (by bv_addr) (by decide) (by decide) (by decide) a i h)) htop
+  have htopef := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ v10) ** (.x6 ↦ᵣ shift) **
+     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) **
+     ((sp + signExtend12 4032) ↦ₘ u3Old) **
+     ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+     ((sp + signExtend12 4056) ↦ₘ u0Old))
+    (by pcFree) htope
+  have hma1 := divK_normA_mergeA_spec_within 16 4032 sp a3 a2 u4 v10 shift antiShift u3Old (base + normAOff + 12)
+  simp only [se12_16] at hma1
+  rw [show (base + normAOff + 12 : Word) + 20 = base + normAOff + 32 from by bv_addr] at hma1
+  have hma1e := cpsTripleWithin_extend_code (hmono := fun a i h =>
+    divK_normA_code_sub_divCode_noNop_v4 a i
+      (CodeReq.ofProg_mono_sub (base + normAOff) (base + normAOff + 12) (divK_normA 40)
+        (divK_normA_mergeA_prog 16 4032) 3
+        (by bv_addr) (by decide) (by decide) (by decide) a i h)) hma1
+  have hma1ef := cpsTripleWithin_frameR
+    (((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 4024) ↦ₘ u4) **
+     ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+     ((sp + signExtend12 4056) ↦ₘ u0Old))
+    (by pcFree) hma1e
+  have h12 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) htopef hma1ef
+  have hmb := divK_normA_mergeB_spec_within 8 4040 sp a2 a1 u3 (a2 >>> (antiShift.toNat % 64))
+    shift antiShift u2Old (base + normAOff + 32)
+  simp only [se12_8] at hmb
+  rw [show (base + normAOff + 32 : Word) + 20 = base + normAOff + 52 from by bv_addr] at hmb
+  have hmbe := cpsTripleWithin_extend_code (hmono := fun a i h =>
+    divK_normA_code_sub_divCode_noNop_v4 a i
+      (CodeReq.ofProg_mono_sub (base + normAOff) (base + normAOff + 32) (divK_normA 40)
+        (divK_normA_mergeB_prog 8 4040) 8
+        (by bv_addr) (by decide) (by decide) (by decide) a i h)) hmb
+  have hmbef := cpsTripleWithin_frameR
+    (((sp + 0) ↦ₘ a0) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4032) ↦ₘ u3) **
+     ((sp + signExtend12 4048) ↦ₘ u1Old) ** ((sp + signExtend12 4056) ↦ₘ u0Old))
+    (by pcFree) hmbe
+  have h123 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) h12 hmbef
+  have hma2 := divK_normA_mergeA_spec_within 0 4048 sp a1 a0 u2 (a1 >>> (antiShift.toNat % 64))
+    shift antiShift u1Old (base + normAOff + 52)
+  simp only [se12_0] at hma2
+  rw [show (base + normAOff + 52 : Word) + 20 = base + normAOff + 72 from by bv_addr] at hma2
+  have hma2e := cpsTripleWithin_extend_code (hmono := fun a i h =>
+    divK_normA_code_sub_divCode_noNop_v4 a i
+      (CodeReq.ofProg_mono_sub (base + normAOff) (base + normAOff + 52) (divK_normA 40)
+        (divK_normA_mergeA_prog 0 4048) 13
+        (by bv_addr) (by decide) (by decide) (by decide) a i h)) hma2
+  have hma2ef := cpsTripleWithin_frameR
+    (((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4032) ↦ₘ u3) **
+     ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4056) ↦ₘ u0Old))
+    (by pcFree) hma2e
+  have h1234 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) h123 hma2ef
+  have hlast := divK_normA_last_spec_within 4056 sp a0 shift u0Old (base + normAOff + 72)
+  rw [show (base + normAOff + 72 : Word) + 8 = base + normAOff + 80 from by bv_addr] at hlast
+  have hlaste := cpsTripleWithin_extend_code (hmono := fun a i h =>
+    divK_normA_code_sub_divCode_noNop_v4 a i
+      (CodeReq.ofProg_mono_sub (base + normAOff) (base + normAOff + 72) (divK_normA 40)
+        (divK_normA_last_prog 4056) 18
+        (by bv_addr) (by decide) (by decide) (by decide) a i h)) hlast
+  have hlastef := cpsTripleWithin_frameR
+    ((.x5 ↦ᵣ u1) ** (.x10 ↦ᵣ (a0 >>> (antiShift.toNat % 64))) ** (.x2 ↦ᵣ antiShift) **
+     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4032) ↦ₘ u3) **
+     ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4048) ↦ₘ u1))
+    (by pcFree) hlaste
+  have h12345 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) h1234 hlastef
+  have hjal := jal_x0_spec_gen_within 40 (base + normAOff + 80)
+  rw [show (base + normAOff + 80 : Word) + signExtend21 40 = base + loopSetupOff from by rv64_addr] at hjal
+  have hjale := cpsTripleWithin_extend_code (hmono := by
+    intro a i h
+    exact divK_normA_code_sub_divCode_noNop_v4 a i
+      (CodeReq.singleton_mono (by
+        have hlookup := CodeReq.ofProg_lookup (base + normAOff) (divK_normA 40) 20
+          (by decide) (by decide)
+        rw [show (base + normAOff : Word) + BitVec.ofNat 64 (4 * 20) = base + normAOff + 80 from by bv_addr]
+          at hlookup
+        exact hlookup) a i h)) hjal
+  let postAll := (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ u1) ** (.x7 ↦ᵣ u0) **
+    (.x10 ↦ᵣ (a0 >>> (antiShift.toNat % 64))) **
+    (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
+    ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+    ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4032) ↦ₘ u3) **
+    ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4048) ↦ₘ u1) **
+    ((sp + signExtend12 4056) ↦ₘ u0)
+  have hjalef := cpsTripleWithin_frameR postAll (by pcFree) hjale
+  have hjal_clean : cpsTripleWithin 1 (base + normAOff + 80) (base + loopSetupOff) (divCode_noNop_v4 base) postAll postAll :=
+    cpsTripleWithin_weaken
+      (fun h hp => by show (empAssertion ** postAll) h; rw [sepConj_emp_left']; exact hp)
+      (fun h hp => by rw [sepConj_emp_left'] at hp; exact hp)
+      hjalef
+  have h123456 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) h12345 hjal_clean
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    h123456
+
 -- ============================================================================
 -- Section 10j: CopyAU composition (copy a[] to u[], 9 instructions)
 -- base+396: used when shift=0 (no normalization needed)
@@ -375,6 +504,13 @@ private theorem divK_copyAU_code_sub_divCode_noNop {base : Word} :
   unfold divCode_noNop divK_copyAU_code; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
   exact CodeReq.union_mono_left
+
+/-- CopyAU code (block 6) is subsumed by divCode_noNop_v4. -/
+private theorem divK_copyAU_code_sub_divCode_noNop_v4 {base : Word} :
+    ∀ a i, (divK_copyAU_code (base + copyAUOff)) a = some i →
+      (divCode_noNop_v4 base) a = some i := by
+  intro a i h
+  exact sharedNoNop_v4_b6_div a i h
 
 /-- Full CopyAU: copy a[0..3] to u[0..3], set u[4]=0.
     base+396 → base+432 (9 instructions). -/
@@ -416,6 +552,25 @@ theorem divK_copyAU_full_spec_within_noNop (sp : Word)
   rw [show (base + copyAUOff : Word) + 36 = base + loopSetupOff from by bv_addr] at hcopy
   exact cpsTripleWithin_extend_code divK_copyAU_code_sub_divCode_noNop hcopy
 
+theorem divK_copyAU_full_spec_within_v4_noNop (sp : Word)
+    (a0 a1 a2 a3 : Word) (u0 u1 u2 u3 u4 v5 : Word) (base : Word) :
+    cpsTripleWithin 9 (base + copyAUOff) (base + loopSetupOff) (divCode_noNop_v4 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) **
+       ((sp + signExtend12 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
+       ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3) **
+       ((sp + signExtend12 4024) ↦ₘ u4))
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ a3) **
+       ((sp + signExtend12 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + signExtend12 4056) ↦ₘ a0) ** ((sp + signExtend12 4048) ↦ₘ a1) **
+       ((sp + signExtend12 4040) ↦ₘ a2) ** ((sp + signExtend12 4032) ↦ₘ a3) **
+       ((sp + signExtend12 4024) ↦ₘ (0 : Word))) := by
+  have hcopy := divK_copyAU_spec_within sp (base + copyAUOff) a0 a1 a2 a3 u0 u1 u2 u3 u4 v5
+  rw [show (base + copyAUOff : Word) + 36 = base + loopSetupOff from by bv_addr] at hcopy
+  exact cpsTripleWithin_extend_code divK_copyAU_code_sub_divCode_noNop_v4 hcopy
+
 -- ============================================================================
 -- Section 10k: LoopSetup composition (4 instructions at base+432)
 -- LD n, ADDI 4, SUB m=4-n, BLT m<0
@@ -435,6 +590,13 @@ private theorem divK_loopSetup_code_sub_divCode_noNop {base : Word} :
   unfold divCode_noNop divK_loopSetup_code; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
   exact CodeReq.union_mono_left
+
+/-- LoopSetup code (block 7) is subsumed by divCode_noNop_v4. -/
+private theorem divK_loopSetup_code_sub_divCode_noNop_v4 {base : Word} :
+    ∀ a i, (divK_loopSetup_code 464 (base + loopSetupOff)) a = some i →
+      (divCode_noNop_v4 base) a = some i := by
+  intro a i h
+  exact sharedNoNop_v4_b7_div a i h
 
 /-- BLT singleton at base+loopSetupOff+12 (index 3 of loopSetup) is subsumed by divCode. -/
 private theorem blt_loopSetup_sub_divCode {base : Word} :
@@ -456,6 +618,17 @@ private theorem blt_loopSetup_sub_divCode_noNop {base : Word} :
     (by decide) (by decide)
   rw [bv64_4mul_3] at hlookup
   exact divK_loopSetup_code_sub_divCode_noNop a i
+    (CodeReq.singleton_mono hlookup a i h)
+
+/-- BLT singleton at base+loopSetupOff+12 is subsumed by divCode_noNop_v4. -/
+private theorem blt_loopSetup_sub_divCode_noNop_v4 {base : Word} :
+    ∀ a i, (CodeReq.singleton (base + loopSetupOff + 12) (.BLT .x9 .x0 464)) a = some i →
+      (divCode_noNop_v4 base) a = some i := by
+  intro a i h
+  have hlookup := CodeReq.ofProg_lookup (base + loopSetupOff) (divK_loopSetup 464) 3
+    (by decide) (by decide)
+  rw [bv64_4mul_3] at hlookup
+  exact divK_loopSetup_code_sub_divCode_noNop_v4 a i
     (CodeReq.singleton_mono hlookup a i h)
 
 -- `se13_464` moved to `Compose/Base.lean` (shared with ModNormA).
@@ -540,6 +713,34 @@ theorem divK_loopSetup_ntaken_spec_within_noNop (sp n v1 v5 : Word) (base : Word
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
       exact absurd ((sepConj_pure_right _).mp h_rest).2 hm_ge)
   have hblte := cpsTripleWithin_extend_code blt_loopSetup_sub_divCode_noNop hblt_clean
+  have hbltef := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ n) ** ((sp + signExtend12 3984) ↦ₘ n))
+    (by pcFree) hblte
+  have h12 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hbodye hbltef
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    h12
+
+theorem divK_loopSetup_ntaken_spec_within_v4_noNop (sp n v1 v5 : Word) (base : Word)
+    (hm_ge : ¬BitVec.slt (signExtend12 (4 : BitVec 12) - n) (0 : Word)) :
+    let m := signExtend12 (4 : BitVec 12) - n
+    cpsTripleWithin 4 (base + loopSetupOff) (base + loopBodyOff) (divCode_noNop_v4 base)
+      (divKLoopSetupNtakenPreNoNop sp v5 v1 n)
+      (divKLoopSetupNtakenPostNoNop sp n m) := by
+  intro m
+  rw [divKLoopSetupNtakenPreNoNop_unfold, divKLoopSetupNtakenPostNoNop_unfold]
+  have hbody := divK_loopSetup_body_spec_within sp n v1 v5 464 (base + loopSetupOff)
+  have hbodye := cpsTripleWithin_extend_code divK_loopSetup_code_sub_divCode_noNop_v4 hbody
+  have hblt_raw := blt_spec_gen_within .x9 .x0 464 m (0 : Word) (base + loopSetupOff + 12)
+  rw [show (base + loopSetupOff + 12 : Word) + signExtend13 464 = base + denormOff from by rv64_addr,
+      show (base + loopSetupOff + 12 : Word) + 4 = base + loopBodyOff from by bv_addr] at hblt_raw
+  have hblt_clean := cpsBranchWithin_ntakenStripPure2 hblt_raw
+    (fun hp hQt => by
+      obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
+      exact absurd ((sepConj_pure_right _).mp h_rest).2 hm_ge)
+  have hblte := cpsTripleWithin_extend_code blt_loopSetup_sub_divCode_noNop_v4 hblt_clean
   have hbltef := cpsTripleWithin_frameR
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ n) ** ((sp + signExtend12 3984) ↦ₘ n))
     (by pcFree) hblte


### PR DESCRIPTION
## Summary
- add v4 no-NOP code-inclusion hooks for NormA, CopyAU, and LoopSetup blocks
- add divK_normA_full_spec_within_v4_noNop and divK_loopSetup_ntaken_spec_within_v4_noNop
- extend FullPathV4NoNop with evm_div_n4_to_loopSetup_spec_v4_noNop

## Verification
- lake build EvmAsm.Evm64.DivMod.Compose.NormA
- lake build EvmAsm.Evm64.DivMod.Compose.FullPathV4NoNop
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- scripts/check-file-size.sh EvmAsm/Evm64/DivMod/Compose/NormA.lean EvmAsm/Evm64/DivMod/Compose/FullPathV4NoNop.lean
- rg -n "sorry|admit|placeholder|set_option" EvmAsm/Evm64/DivMod/Compose/NormA.lean EvmAsm/Evm64/DivMod/Compose/FullPathV4NoNop.lean