### PR TITLE
feat(div): add v4 no-nop n4 call skip bridge

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -50,3 +50,4 @@ import EvmAsm.Evm64.DivMod.Compose.ModFullPathN3LoopUnified
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4NoNop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V4NoNop
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4CallV4NoNop

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4CallV4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4CallV4NoNop.lean
@@ -1,11 +1,12 @@
 /-
-  EvmAsm.Evm64.DivMod.Compose.FullPathN4BeqV4NoNop
+  EvmAsm.Evm64.DivMod.Compose.FullPathN4CallV4NoNop
 
-  V4/no-NOP bridges for n=4 call+addback BEQ composition.
+  v4/no-NOP wrappers for the n=4 DIV call+skip path.
 -/
 
-import EvmAsm.Evm64.DivMod.Compose.FullPathN4Beq
-import EvmAsm.Evm64.DivMod.LoopIterN4AddbackV4NoNop
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4
+import EvmAsm.Evm64.DivMod.Compose.FullPathV4NoNop
+import EvmAsm.Evm64.DivMod.LoopIterN4CallV4NoNop
 
 open EvmAsm.Rv64.Tactics
 
@@ -14,23 +15,17 @@ namespace EvmAsm.Evm64
 open EvmAsm.Rv64
 open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)
 
-/-- Loop body n=4, call+addback (BEQ double-addback), j=0 with
-    sp-relative addresses over the v4 DIV no-NOP code surface.
-
-    This is the v4 analogue of
-    `divK_loop_body_n4_call_addback_j0_beq_norm_noNop`; it carries the
-    extra `divK_div128_v4` scratch cell at `sp + 3936` and keeps the
-    v4 quotient/carry side conditions behind irreducible predicates. -/
-theorem divK_loop_body_n4_call_addback_j0_beq_norm_v4_noNop (sp base : Word)
+/-- Loop body n=4, call+skip, j=0 over `divCode_noNop_v4`, with
+    sp-relative addresses in the precondition. -/
+theorem divK_loop_body_n4_call_skip_j0_norm_v4_noNop (sp base : Word)
     (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
     (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
     (retMem dMem dloMem scratchUn0 scratchMem : Word)
     (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
       base + div128CallRetOff)
     (hbltu : BitVec.ult uTop v3)
-    (hborrow : loopBodyN4CallAddbackBorrowV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop)
-    (hcarry2_nz : loopBodyN4CallAddbackCarry2NzV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    cpsTripleWithin 224 (base + loopBodyOff) (base + denormOff) (divCode_noNop_v4 base)
+    (hborrow : loopBodyN4CallSkipJ0BorrowV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 148 (base + loopBodyOff) (base + denormOff) (divCode_noNop_v4 base)
       (((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
@@ -46,17 +41,16 @@ theorem divK_loop_body_n4_call_addback_j0_beq_norm_v4_noNop (sp base : Word)
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
-       regOwn .x1) **
-       (sp + signExtend12 3936 ↦ₘ scratchMem))
-      (loopBodyN4CallAddbackJ0PostV4 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem) := by
+       regOwn .x1) ** (sp + signExtend12 3936 ↦ₘ scratchMem))
+      (loopBodyN4CallSkipJ0PostV4 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem) := by
   have raw :=
     cpsTripleWithin_extend_code
       (hmono := sharedDivModCodeNoNop_v4_sub_divCode_noNop_v4)
-      (divK_loop_body_n4_call_addback_j0_beq_v4_spec_within_noNop
+      (divK_loop_body_n4_call_skip_j0_v4_spec_within_noNop
         sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
         v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
         retMem dMem dloMem scratchUn0 scratchMem base
-        halign hbltu hborrow hcarry2_nz)
+        halign hbltu hborrow)
   rw [loopBodyN4CallSkipJ0PreV4_unfold] at raw
   rw [loopBodyN4CallSkipJ0Pre_unfold] at raw
   simp only [se12_32, se12_40, se12_48, se12_56,
@@ -64,11 +58,9 @@ theorem divK_loop_body_n4_call_addback_j0_beq_norm_v4_noNop (sp base : Word)
              u_base_off4072_j0, u_base_off4064_j0, q_addr_j0] at raw
   exact raw
 
-/-- Pre-loop + v4 call-addback BEQ postcondition for n=4.  This packages
-    the normalized limb chain and the v4 trial-call scratch cell so theorem
-    statements do not expose the full sequence of intermediate lets. -/
+/-- Pre-loop + v4 call-skip postcondition for n=4. -/
 @[irreducible]
-def preloopCallAddbackBeqPostN4V4
+def preloopCallSkipPostN4V4
     (sp base a0 a1 a2 a3 b0 b1 b2 b3 scratchMem : Word) : Assertion :=
   let shift := (clzResult b3).1
   let antiShift := signExtend12 (0 : BitVec 12) - shift
@@ -81,7 +73,7 @@ def preloopCallAddbackBeqPostN4V4
   let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
   let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
   let u0 := a0 <<< (shift.toNat % 64)
-  loopBodyN4CallAddbackJ0PostV4 sp base b0' b1' b2' b3' u0 u1 u2 u3 u4 scratchMem **
+  loopBodyN4CallSkipJ0PostV4 sp base b0' b1' b2' b3' u0 u1 u2 u3 u4 scratchMem **
   ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
   ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
   ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
@@ -92,9 +84,9 @@ def preloopCallAddbackBeqPostN4V4
   ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
   ((sp + signExtend12 3992) ↦ₘ shift)
 
-/-- v4 call-addback borrow condition after n=4 pre-loop normalization. -/
+/-- v4 call-skip no-borrow condition after n=4 pre-loop normalization. -/
 @[irreducible]
-def isAddbackBorrowN4CallV4Ab (a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Prop :=
+def isSkipBorrowN4CallV4Ab (a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Prop :=
   let shift := (clzResult b3).1
   let antiShift := signExtend12 (0 : BitVec 12) - shift
   let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
@@ -106,43 +98,30 @@ def isAddbackBorrowN4CallV4Ab (a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Prop :=
   let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
   let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
   let u0 := a0 <<< (shift.toNat % 64)
-  loopBodyN4CallAddbackBorrowV4 b0' b1' b2' b3' u0 u1 u2 u3 u4
+  loopBodyN4CallSkipJ0BorrowV4 b0' b1' b2' b3' u0 u1 u2 u3 u4
 
-/-- v4 call-addback carry2 condition after n=4 pre-loop normalization. -/
-@[irreducible]
-def isAddbackCarry2NzN4CallV4Ab (a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Prop :=
-  let shift := (clzResult b3).1
-  let antiShift := signExtend12 (0 : BitVec 12) - shift
-  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
-  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
-  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
-  let b0' := b0 <<< (shift.toNat % 64)
-  let u4 := a3 >>> (antiShift.toNat % 64)
-  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
-  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
-  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
-  let u0 := a0 <<< (shift.toNat % 64)
-  loopBodyN4CallAddbackCarry2NzV4 b0' b1' b2' b3' u0 u1 u2 u3 u4
-
-/-- n=4 pre-loop + call+addback BEQ loop body over `divCode_noNop_v4`. -/
-theorem evm_div_n4_preloop_call_addback_beq_spec_v4_noNop (sp base : Word)
+/-- n=4 pre-loop + call+skip loop body over `divCode_noNop_v4`. -/
+theorem evm_div_n4_preloop_call_skip_spec_v4_noNop (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old : Word)
     (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem : Word)
     (retMem dMem dloMem scratchUn0 scratchMem : Word)
-    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0) (hb3nz : b3 ≠ 0)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3nz : b3 ≠ 0)
     (hshift_nz : (clzResult b3).1 ≠ 0)
     (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
       base + div128CallRetOff)
     (hbltu : isCallTrialN4 a3 b2 b3)
-    (hcarry2_nz : isAddbackCarry2NzN4CallV4Ab a0 a1 a2 a3 b0 b1 b2 b3)
-    (hborrow : isAddbackBorrowN4CallV4Ab a0 a1 a2 a3 b0 b1 b2 b3) :
-    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224) base (base + denormOff)
+    (hborrow : isSkipBorrowN4CallV4Ab a0 a1 a2 a3 b0 b1 b2 b3) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 148) base (base + denormOff)
       (divCode_noNop_v4 base)
       (((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
-       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) ** (.x11 ↦ᵣ v11Old) **
-       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
-       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x11 ↦ᵣ v11Old) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
        ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
        ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
        ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
@@ -150,14 +129,14 @@ theorem evm_div_n4_preloop_call_addback_beq_spec_v4_noNop (sp base : Word)
        ((sp + signExtend12 4024) ↦ₘ u4Old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
-       ((sp + signExtend12 3992) ↦ₘ shiftMem) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem) **
+       ((sp + signExtend12 3976) ↦ₘ jMem) **
        (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratchUn0) **
        regOwn .x1) ** (sp + signExtend12 3936 ↦ₘ scratchMem))
-      (preloopCallAddbackBeqPostN4V4 sp base a0 a1 a2 a3 b0 b1 b2 b3 scratchMem) := by
+      (preloopCallSkipPostN4V4 sp base a0 a1 a2 a3 b0 b1 b2 b3 scratchMem) := by
   unfold isCallTrialN4 at hbltu
-  unfold isAddbackBorrowN4CallV4Ab at hborrow
-  unfold isAddbackCarry2NzN4CallV4Ab at hcarry2_nz
+  unfold isSkipBorrowN4CallV4Ab at hborrow
   let shift := (clzResult b3).1
   let antiShift := signExtend12 (0 : BitVec 12) - shift
   let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
@@ -179,11 +158,11 @@ theorem evm_div_n4_preloop_call_addback_beq_spec_v4_noNop (sp base : Word)
      (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratchUn0) **
      regOwn .x1) ** (sp + signExtend12 3936 ↦ₘ scratchMem))
     (by pcFree) hPre
-  have hLoop := divK_loop_body_n4_call_addback_j0_beq_norm_v4_noNop sp base
+  have hLoop := divK_loop_body_n4_call_skip_j0_norm_v4_noNop sp base
     jMem (4 : Word) shift u0 (a0 >>> (antiShift.toNat % 64)) v11Old antiShift
     b0' b1' b2' b3' u0 u1 u2 u3 u4 (0 : Word)
     retMem dMem dloMem scratchUn0 scratchMem
-    halign hbltu hborrow hcarry2_nz
+    halign hbltu hborrow
   have hLoopF := cpsTripleWithin_frameR
     (((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
      ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
@@ -203,7 +182,7 @@ theorem evm_div_n4_preloop_call_addback_beq_spec_v4_noNop (sp base : Word)
   exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hq => by
-      delta preloopCallAddbackBeqPostN4V4
+      delta preloopCallSkipPostN4V4
       xperm_hyp hq)
     hFull
 

--- a/EvmAsm/Evm64/DivMod/LoopIterN4CallV4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN4CallV4NoNop.lean
@@ -21,6 +21,18 @@ def loopBodyN4CallSkipJ0PreV4
     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 **
   (sp + signExtend12 3936 ↦ₘ scratchMem)
 
+theorem loopBodyN4CallSkipJ0PreV4_unfold
+    {sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
+     retMem dMem dloMem scratchUn0 scratchMem : Word} :
+    loopBodyN4CallSkipJ0PreV4 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem =
+    (loopBodyN4CallSkipJ0Pre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 **
+    (sp + signExtend12 3936 ↦ₘ scratchMem)) := by
+  unfold loopBodyN4CallSkipJ0PreV4
+  rfl
+
 @[irreducible]
 def loopBodyN4CallSkipJ0PostV4
     (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word) : Assertion :=


### PR DESCRIPTION
## Summary
- move the v4 n=4 call precondition unfold helper into the public loop-iteration module
- add FullPathN4CallV4NoNop with the v4/no-NOP n=4 call+skip loop wrapper
- add the pre-loop-to-denorm n=4 call+skip composition bridge with irreducible predicates/postcondition hiding normalized lets

## Verification
- lake build EvmAsm.Evm64.DivMod.Compose.FullPathN4CallV4NoNop
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- scripts/check-file-size.sh EvmAsm/Evm64/DivMod/Compose/FullPathN4CallV4NoNop.lean EvmAsm/Evm64/DivMod/LoopIterN4CallV4NoNop.lean EvmAsm/Evm64/DivMod/Compose/FullPathN4BeqV4NoNop.lean EvmAsm/Evm64/DivMod.lean
- rg -n 'sorry|admit|placeholder|set_option' touched files