### PR TITLE
feat(div): add v4 no-nop n3 j0 bridges

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -51,3 +51,4 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4NoNop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V4NoNop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4CallV4NoNop
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V4NoNop

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V4NoNop.lean
@@ -1,0 +1,110 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN3V4NoNop
+
+  v4/no-NOP wrappers for the n=3 DIV loop-body j=0 exit paths.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3LoopUnified
+import EvmAsm.Evm64.DivMod.Compose.FullPathV4NoNop
+import EvmAsm.Evm64.DivMod.LoopIterN3MaxV4NoNop
+import EvmAsm.Evm64.DivMod.LoopIterN3CallV4NoNop
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)
+
+/-- Sp-relative n=3 max-skip j=0 precondition over `divCode_noNop_v4`. -/
+@[irreducible]
+def loopBodyN3MaxSkipJ0NormPreV4
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word) : Assertion :=
+  (.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
+  (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+  (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
+  (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
+  (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
+  ((sp + 32) ↦ₘ v0) ** ((sp + signExtend12 4056) ↦ₘ u0) **
+  ((sp + 40) ↦ₘ v1) ** ((sp + signExtend12 4048) ↦ₘ u1) **
+  ((sp + 48) ↦ₘ v2) ** ((sp + signExtend12 4040) ↦ₘ u2) **
+  ((sp + 56) ↦ₘ v3) ** ((sp + signExtend12 4032) ↦ₘ u3) **
+  ((sp + signExtend12 4024) ↦ₘ uTop) **
+  ((sp + signExtend12 4088) ↦ₘ qOld)
+
+/-- Sp-relative n=3 call-skip j=0 precondition over `divCode_noNop_v4`. -/
+@[irreducible]
+def loopBodyN3CallSkipJ0NormPreV4
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word) : Assertion :=
+  loopBodyN3MaxSkipJ0NormPreV4 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld **
+  (sp + signExtend12 3968 ↦ₘ retMem) **
+  (sp + signExtend12 3960 ↦ₘ dMem) **
+  (sp + signExtend12 3952 ↦ₘ dloMem) **
+  (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+  regOwn .x1 ** (sp + signExtend12 3936 ↦ₘ scratchMem)
+
+/-- Loop body n=3, max+skip, j=0 over `divCode_noNop_v4`, with
+    sp-relative addresses hidden behind a named precondition. -/
+theorem divK_loop_body_n3_max_skip_j0_norm_v4_noNop (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (hbltu : ¬BitVec.ult u3 v2) :
+    (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+     then (1 : Word) else 0) = (0 : Word) →
+    cpsTripleWithin 76 (base + loopBodyOff) (base + denormOff) (divCode_noNop_v4 base)
+      (loopBodyN3MaxSkipJ0NormPreV4 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld)
+      (loopBodyN3SkipPost sp (0 : Word) (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro hborrow
+  have raw := divK_loop_body_n3_max_skip_j0_v4_spec_within_noNop
+    sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base
+    hbltu hborrow
+  have raw' := cpsTripleWithin_extend_code
+    (hmono := sharedDivModCodeNoNop_v4_sub_divCode_noNop_v4) raw
+  rw [loopBodyN3MaxSkipPre_unfold] at raw'
+  simp only [se12_32, se12_40, se12_48, se12_56,
+             u_base_off0_j0, u_base_off4088_j0, u_base_off4080_j0,
+             u_base_off4072_j0, u_base_off4064_j0, q_addr_j0] at raw'
+  delta loopBodyN3MaxSkipJ0NormPreV4
+  exact raw'
+
+/-- Loop body n=3, call+skip, j=0 over `divCode_noNop_v4`, with
+    sp-relative addresses hidden behind a named precondition. -/
+theorem divK_loop_body_n3_call_skip_j0_norm_v4_noNop (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu : BitVec.ult u3 v2)
+    (hborrow : loopBodyN3CallSkipJ0BorrowV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 148 (base + loopBodyOff) (base + denormOff) (divCode_noNop_v4 base)
+      (loopBodyN3CallSkipJ0NormPreV4 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem)
+      (loopBodyN3CallSkipJ0PostV4 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem) := by
+  have raw :=
+    cpsTripleWithin_extend_code
+      (hmono := sharedDivModCodeNoNop_v4_sub_divCode_noNop_v4)
+      (divK_loop_body_n3_call_skip_j0_v4_spec_within_noNop
+        sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
+        retMem dMem dloMem scratchUn0 scratchMem base
+        halign hbltu hborrow)
+  rw [loopBodyN3CallSkipJ0PreV4_unfold] at raw
+  rw [loopBodyN3CallSkipPre_unfold] at raw
+  simp only [se12_32, se12_40, se12_48, se12_56,
+             u_base_off0_j0, u_base_off4088_j0, u_base_off4080_j0,
+             u_base_off4072_j0, u_base_off4064_j0, q_addr_j0] at raw
+  exact cpsTripleWithin_weaken
+    (fun h hp => by
+      delta loopBodyN3CallSkipJ0NormPreV4 loopBodyN3MaxSkipJ0NormPreV4 at hp
+      xperm_hyp hp)
+    (fun h hp => hp)
+    raw
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LoopIterN3CallV4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN3CallV4NoNop.lean
@@ -22,6 +22,18 @@ def loopBodyN3CallSkipJ0PreV4
     (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 **
   (sp + signExtend12 3936 ↦ₘ scratchMem)
 
+theorem loopBodyN3CallSkipJ0PreV4_unfold
+    {sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word}
+    {retMem dMem dloMem scratchUn0 scratchMem : Word} :
+    loopBodyN3CallSkipJ0PreV4 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem =
+    (loopBodyN3CallSkipPre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 **
+     (sp + signExtend12 3936 ↦ₘ scratchMem)) := by
+  unfold loopBodyN3CallSkipJ0PreV4
+  rfl
+
 @[irreducible]
 def loopBodyN3CallSkipJ0PostV4
     (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word) : Assertion :=


### PR DESCRIPTION
## Summary
- add a v4/no-NOP compose module for n=3 j=0 max-skip and call-skip loop-body exit bridges
- hide the normalized sp-relative precondition chains behind irreducible precondition definitions
- expose the n=3 call-skip v4 j=0 precondition unfold helper for reuse

## Verification
- lake build EvmAsm.Evm64.DivMod.Compose.FullPathN3V4NoNop
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- scripts/check-file-size.sh EvmAsm/Evm64/DivMod/Compose/FullPathN3V4NoNop.lean EvmAsm/Evm64/DivMod/LoopIterN3CallV4NoNop.lean
- rg -n 'sorry|admit|placeholder|set_option maxHeartbeats' EvmAsm/Evm64/DivMod/Compose/FullPathN3V4NoNop.lean EvmAsm/Evm64/DivMod/LoopIterN3CallV4NoNop.lean EvmAsm/Evm64/DivMod.lean