### PR TITLE
feat(div): add v4 no-nop n3 addback bridges

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V4NoNop.lean
@@ -8,6 +8,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN3LoopUnified
 import EvmAsm.Evm64.DivMod.Compose.FullPathV4NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN3MaxV4NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN3CallV4NoNop
+import EvmAsm.Evm64.DivMod.LoopIterN3AddbackV4NoNop
 
 open EvmAsm.Rv64.Tactics
 
@@ -95,6 +96,71 @@ theorem divK_loop_body_n3_call_skip_j0_norm_v4_noNop (sp base : Word)
         v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
         retMem dMem dloMem scratchUn0 scratchMem base
         halign hbltu hborrow)
+  rw [loopBodyN3CallSkipJ0PreV4_unfold] at raw
+  rw [loopBodyN3CallSkipPre_unfold] at raw
+  simp only [se12_32, se12_40, se12_48, se12_56,
+             u_base_off0_j0, u_base_off4088_j0, u_base_off4080_j0,
+             u_base_off4072_j0, u_base_off4064_j0, q_addr_j0] at raw
+  exact cpsTripleWithin_weaken
+    (fun h hp => by
+      delta loopBodyN3CallSkipJ0NormPreV4 loopBodyN3MaxSkipJ0NormPreV4 at hp
+      xperm_hyp hp)
+    (fun h hp => hp)
+    raw
+
+/-- Loop body n=3, max+addback (BEQ double-addback), j=0 over
+    `divCode_noNop_v4`, with sp-relative addresses hidden behind a named
+    precondition. -/
+theorem divK_loop_body_n3_max_addback_j0_beq_norm_v4_noNop (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (hbltu : ¬BitVec.ult u3 v2)
+    (hcarry2_nz : isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+     then (1 : Word) else 0) ≠ (0 : Word) →
+    cpsTripleWithin 152 (base + loopBodyOff) (base + denormOff) (divCode_noNop_v4 base)
+      (loopBodyN3MaxSkipJ0NormPreV4 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld)
+      (loopBodyN3AddbackBeqPost sp (0 : Word) (signExtend12 4095 : Word)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro hborrow
+  have raw := divK_loop_body_n3_max_addback_j0_beq_v4_spec_within_noNop
+    sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base
+    hbltu hcarry2_nz hborrow
+  have raw' := cpsTripleWithin_extend_code
+    (hmono := sharedDivModCodeNoNop_v4_sub_divCode_noNop_v4) raw
+  rw [loopBodyN3MaxSkipPre_unfold] at raw'
+  simp only [se12_32, se12_40, se12_48, se12_56,
+             u_base_off0_j0, u_base_off4088_j0, u_base_off4080_j0,
+             u_base_off4072_j0, u_base_off4064_j0, q_addr_j0] at raw'
+  delta loopBodyN3MaxSkipJ0NormPreV4
+  exact raw'
+
+/-- Loop body n=3, call+addback (BEQ double-addback), j=0 over
+    `divCode_noNop_v4`, with sp-relative addresses hidden behind a named
+    precondition. -/
+theorem divK_loop_body_n3_call_addback_j0_beq_norm_v4_noNop (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu : BitVec.ult u3 v2)
+    (hborrow : loopBodyN3CallAddbackBorrowV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hcarry2_nz : loopBodyN3CallAddbackCarry2NzV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 224 (base + loopBodyOff) (base + denormOff) (divCode_noNop_v4 base)
+      (loopBodyN3CallSkipJ0NormPreV4 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem)
+      (loopBodyN3CallAddbackJ0PostV4 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem) := by
+  have raw :=
+    cpsTripleWithin_extend_code
+      (hmono := sharedDivModCodeNoNop_v4_sub_divCode_noNop_v4)
+      (divK_loop_body_n3_call_addback_j0_beq_v4_spec_within_noNop
+        sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
+        retMem dMem dloMem scratchUn0 scratchMem base
+        halign hbltu hborrow hcarry2_nz)
   rw [loopBodyN3CallSkipJ0PreV4_unfold] at raw
   rw [loopBodyN3CallSkipPre_unfold] at raw
   simp only [se12_32, se12_40, se12_48, se12_56,


### PR DESCRIPTION
## Summary
- add n=3 j=0 max-addback and call-addback bridges over divCode_noNop_v4
- reuse the irreducible normalized n=3 j=0 preconditions from the prior stack layer
- extend the n=3 v4/no-NOP compose surface toward the four loop-body exit paths

## Verification
- lake build EvmAsm.Evm64.DivMod.Compose.FullPathN3V4NoNop
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- scripts/check-file-size.sh EvmAsm/Evm64/DivMod/Compose/FullPathN3V4NoNop.lean
- rg -n 'sorry|admit|placeholder|set_option maxHeartbeats' EvmAsm/Evm64/DivMod/Compose/FullPathN3V4NoNop.lean