### PR TITLE
feat(div): add v4 no-nop n2 jgt0 skip bridges

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNop.lean
@@ -48,6 +48,29 @@ def loopBodyN2CallSkipJ0NormPreV4
   (sp + signExtend12 3944 ↦ₘ scratchUn0) **
   regOwn .x1 ** (sp + signExtend12 3936 ↦ₘ scratchMem)
 
+/-- n=2 max-skip j>0 precondition over `divCode_noNop_v4`.
+    The j-dependent address lets stay behind this irreducible boundary. -/
+@[irreducible]
+def loopBodyN2MaxSkipJgt0NormPreV4 (j : Word)
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word) : Assertion :=
+  loopBodyN2MaxJgt0Pre j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
+
+/-- n=2 call-skip j>0 precondition over `divCode_noNop_v4`. -/
+@[irreducible]
+def loopBodyN2CallSkipJgt0NormPreV4 (j : Word)
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word) : Assertion :=
+  loopBodyN2MaxSkipJgt0NormPreV4 j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld **
+  (sp + signExtend12 3968 ↦ₘ retMem) **
+  (sp + signExtend12 3960 ↦ₘ dMem) **
+  (sp + signExtend12 3952 ↦ₘ dloMem) **
+  (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+  (sp + signExtend12 3936 ↦ₘ scratchMem) ** regOwn .x1
+
 /-- Loop body n=2, max+skip, j=0 over `divCode_noNop_v4`, with
     sp-relative addresses hidden behind a named precondition. -/
 theorem divK_loop_body_n2_max_skip_j0_norm_v4_noNop (sp base : Word)
@@ -73,6 +96,33 @@ theorem divK_loop_body_n2_max_skip_j0_norm_v4_noNop (sp base : Word)
              u_base_off4072_j0, u_base_off4064_j0, q_addr_j0] at raw'
   delta loopBodyN2MaxSkipJ0NormPreV4
   exact raw'
+
+/-- Loop body n=2, max+skip, j>0 over `divCode_noNop_v4`, with
+    computed addresses hidden behind a named precondition. -/
+theorem divK_loop_body_n2_max_skip_jgt0_norm_v4_noNop (j sp base : Word)
+    (hpos : BitVec.slt (j + signExtend12 4095) 0 = false)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (hbltu : ¬BitVec.ult u2 v1) :
+    (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+     then (1 : Word) else 0) = (0 : Word) →
+    cpsTripleWithin 76 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop_v4 base)
+      (loopBodyN2MaxSkipJgt0NormPreV4 j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld)
+      (loopBodyN2SkipPost sp j (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro hborrow
+  have raw := divK_loop_body_n2_max_skip_jgt0_v4_spec_within_noNop j hpos
+    sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base
+    hbltu hborrow
+  have raw' := cpsTripleWithin_extend_code
+    (hmono := sharedDivModCodeNoNop_v4_sub_divCode_noNop_v4) raw
+  exact cpsTripleWithin_weaken
+    (fun h hp => by
+      delta loopBodyN2MaxSkipJgt0NormPreV4 at hp
+      xperm_hyp hp)
+    (fun h hp => hp)
+    raw'
 
 /-- Loop body n=2, call+skip, j=0 over `divCode_noNop_v4`, with
     sp-relative addresses hidden behind a named precondition. -/
@@ -107,6 +157,57 @@ theorem divK_loop_body_n2_call_skip_j0_norm_v4_noNop (sp base : Word)
       xperm_hyp hp)
     (fun h hp => hp)
     raw
+
+/-- Loop body n=2, call+skip, j>0 over `divCode_noNop_v4`, with
+    computed addresses hidden behind a named precondition. -/
+theorem divK_loop_body_n2_call_skip_jgt0_norm_v4_noNop (j sp base : Word)
+    (hpos : BitVec.slt (j + signExtend12 4095) 0 = false)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu : BitVec.ult u2 v1)
+    (hborrow : mulsubN4NoBorrow (divKTrialCallV4QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 148 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop_v4 base)
+      (loopBodyN2CallSkipJgt0NormPreV4 j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem)
+      (loopBodyN2CallSkipJgt0PostV4 sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem) := by
+  have raw := divK_loop_body_n2_call_skip_jgt0_v4_spec_within_noNop j hpos
+    sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
+    retMem dMem dloMem scratchUn0 scratchMem base
+    halign hbltu hborrow
+  change (let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+    let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
+    cpsTripleWithin 148 (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCodeNoNop_v4 base)
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
+       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
+       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
+       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
+       (qAddr ↦ₘ qOld) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
+       (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+       (sp + signExtend12 3936 ↦ₘ scratchMem) ** regOwn .x1)
+      (loopBodyN2CallSkipJgt0PostV4 sp base j
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem)) at raw
+  have raw' := cpsTripleWithin_extend_code
+    (hmono := sharedDivModCodeNoNop_v4_sub_divCode_noNop_v4) raw
+  exact cpsTripleWithin_weaken
+    (fun h hp => by
+      delta loopBodyN2CallSkipJgt0NormPreV4 loopBodyN2MaxSkipJgt0NormPreV4 at hp
+      rw [loopBodyN2MaxJgt0Pre_unfold] at hp
+      xperm_hyp hp)
+    (fun h hp => hp)
+    raw'
 
 /-- Loop body n=2, max+addback (BEQ double-addback), j=0 over
     `divCode_noNop_v4`, with sp-relative addresses hidden behind a named


### PR DESCRIPTION
## Summary
- add irreducible n=2 j>0 max/call skip preconditions over divCode_noNop_v4
- bridge existing sharedDivModCodeNoNop_v4 jgt0 skip specs to divCode_noNop_v4
- keep the long j-dependent address let chain out of public bridge statements

## Verification
- lake build EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNop
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- scripts/check-file-size.sh EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNop.lean
- rg -n 'sorry|admit|placeholder|set_option maxHeartbeats|set_option maxRecDepth' EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNop.lean