### PR TITLE
feat(div): add v4 no-nop n2 jgt0 addback bridges

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNop.lean
@@ -71,6 +71,15 @@ def loopBodyN2CallSkipJgt0NormPreV4 (j : Word)
   (sp + signExtend12 3944 ↦ₘ scratchUn0) **
   (sp + signExtend12 3936 ↦ₘ scratchMem) ** regOwn .x1
 
+/-- n=2 call-addback j>0 precondition over `divCode_noNop_v4`. -/
+@[irreducible]
+def loopBodyN2CallAddbackJgt0NormPreV4 (j : Word)
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word) : Assertion :=
+  loopBodyN2CallAddbackJgt0PreV4 j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem
+
 /-- Loop body n=2, max+skip, j=0 over `divCode_noNop_v4`, with
     sp-relative addresses hidden behind a named precondition. -/
 theorem divK_loop_body_n2_max_skip_j0_norm_v4_noNop (sp base : Word)
@@ -115,6 +124,36 @@ theorem divK_loop_body_n2_max_skip_jgt0_norm_v4_noNop (j sp base : Word)
     sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base
     hbltu hborrow
+  have raw' := cpsTripleWithin_extend_code
+    (hmono := sharedDivModCodeNoNop_v4_sub_divCode_noNop_v4) raw
+  exact cpsTripleWithin_weaken
+    (fun h hp => by
+      delta loopBodyN2MaxSkipJgt0NormPreV4 at hp
+      xperm_hyp hp)
+    (fun h hp => hp)
+    raw'
+
+/-- Loop body n=2, max+addback (BEQ double-addback), j>0 over
+    `divCode_noNop_v4`, with the precondition hidden behind an irreducible
+    definition. -/
+theorem divK_loop_body_n2_max_addback_jgt0_beq_norm_v4_noNop (j sp base : Word)
+    (hpos : BitVec.slt (j + signExtend12 4095) 0 = false)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (hbltu : ¬BitVec.ult u2 v1)
+    (hcarry2_nz : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+     then (1 : Word) else 0) ≠ (0 : Word) →
+    cpsTripleWithin 152 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop_v4 base)
+      (loopBodyN2MaxSkipJgt0NormPreV4 j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld)
+      (loopBodyN2AddbackBeqPost sp j (signExtend12 4095 : Word)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro hborrow
+  have raw := divK_loop_body_n2_max_addback_jgt0_beq_v4_spec_within_noNop j hpos
+    sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base
+    hbltu hcarry2_nz hborrow
   have raw' := cpsTripleWithin_extend_code
     (hmono := sharedDivModCodeNoNop_v4_sub_divCode_noNop_v4) raw
   exact cpsTripleWithin_weaken
@@ -205,6 +244,37 @@ theorem divK_loop_body_n2_call_skip_jgt0_norm_v4_noNop (j sp base : Word)
     (fun h hp => by
       delta loopBodyN2CallSkipJgt0NormPreV4 loopBodyN2MaxSkipJgt0NormPreV4 at hp
       rw [loopBodyN2MaxJgt0Pre_unfold] at hp
+      xperm_hyp hp)
+    (fun h hp => hp)
+    raw'
+
+/-- Loop body n=2, call+addback (BEQ double-addback), j>0 over
+    `divCode_noNop_v4`, with the precondition hidden behind an irreducible
+    definition. -/
+theorem divK_loop_body_n2_call_addback_jgt0_beq_norm_v4_noNop (j sp base : Word)
+    (hpos : BitVec.slt (j + signExtend12 4095) 0 = false)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu : BitVec.ult u2 v1)
+    (hborrow : loopBodyN2CallAddbackBorrowV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hcarry2_nz : loopBodyN2CallAddbackCarry2NzV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 224 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop_v4 base)
+      (loopBodyN2CallAddbackJgt0NormPreV4 j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem)
+      (loopBodyN2CallAddbackJgt0PostV4 sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem) := by
+  have raw := divK_loop_body_n2_call_addback_jgt0_beq_v4_spec_within_noNop j hpos
+    sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
+    retMem dMem dloMem scratchUn0 scratchMem base
+    halign hbltu hborrow hcarry2_nz
+  have raw' := cpsTripleWithin_extend_code
+    (hmono := sharedDivModCodeNoNop_v4_sub_divCode_noNop_v4) raw
+  exact cpsTripleWithin_weaken
+    (fun h hp => by
+      delta loopBodyN2CallAddbackJgt0NormPreV4 at hp
       xperm_hyp hp)
     (fun h hp => hp)
     raw'


### PR DESCRIPTION
## Summary
- add irreducible n=2 j>0 addback precondition aliases over divCode_noNop_v4
- bridge existing sharedDivModCodeNoNop_v4 jgt0 max/call addback specs to divCode_noNop_v4
- keep j-dependent precondition chains behind named defs

## Verification
- lake build EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNop
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- scripts/check-file-size.sh EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNop.lean
- rg -n 'sorry|admit|placeholder|set_option maxHeartbeats|set_option maxRecDepth' EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNop.lean