### PR TITLE
feat(div): add v4 no-nop n3 jgt0 addback bridges

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1LoopUnified.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1LoopUnified.lean
@@ -125,7 +125,7 @@ def preloopN1UnifiedPost (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
 
 /-- Helper: instantiate unified n=1 loop (double-addback) with explicit normalized values.
     Separates the loop application from the composition for heartbeat budgeting. -/
-private theorem evm_div_n1_loop_unified_inst
+theorem evm_div_n1_loop_unified_inst
     (bltu_3 bltu_2 bltu_1 bltu_0 : Bool) (sp base : Word)
     (shift antiShift v0' v1' v2' v3' u0S u1S u2S u3S u4_s : Word)
     (v10_val v11Old jMem : Word)
@@ -183,7 +183,7 @@ private theorem evm_div_n1_loop_unified_inst
     hbltu_3 hbltu_2 hbltu_1 hbltu_0 hcarry2
 
 /-- No-NOP helper: instantiate unified n=1 loop with explicit normalized values. -/
-private theorem evm_div_n1_loop_unified_inst_noNop
+theorem evm_div_n1_loop_unified_inst_noNop
     (bltu_3 bltu_2 bltu_1 bltu_0 : Bool) (sp base : Word)
     (shift antiShift v0' v1' v2' v3' u0S u1S u2S u3S u4_s : Word)
     (v10_val v11Old jMem : Word)

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2LoopUnified.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2LoopUnified.lean
@@ -106,7 +106,7 @@ def preloopN2UnifiedPost (bltu_2 bltu_1 bltu_0 : Bool)
 
 /-- Helper: instantiate unified n=2 loop (double-addback) with explicit normalized values.
     Separates the loop application from the composition for heartbeat budgeting. -/
-private theorem evm_div_n2_loop_unified_inst
+theorem evm_div_n2_loop_unified_inst
     (bltu_2 bltu_1 bltu_0 : Bool) (sp base : Word)
     (shift antiShift v0' v1' v2' v3' u0S u1S u2S u3S u4_s : Word)
     (v10_val v11Old jMem : Word)
@@ -141,7 +141,7 @@ private theorem evm_div_n2_loop_unified_inst
     hbltu_2 hbltu_1 hbltu_0 hcarry2
 
 /-- Helper: instantiate unified n=2 loop (double-addback) over `divCode_noNop`. -/
-private theorem evm_div_n2_loop_unified_inst_noNop
+theorem evm_div_n2_loop_unified_inst_noNop
     (bltu_2 bltu_1 bltu_0 : Bool) (sp base : Word)
     (shift antiShift v0' v1' v2' v3' u0S u1S u2S u3S u4_s : Word)
     (v10_val v11Old jMem : Word)

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3LoopUnified.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3LoopUnified.lean
@@ -87,7 +87,7 @@ def preloopN3UnifiedPost (bltu_1 bltu_0 : Bool)
 
 /-- Helper: instantiate unified n=3 loop (double-addback) with explicit normalized values.
     Separates the loop application from the composition for heartbeat budgeting. -/
-private theorem evm_div_n3_loop_unified_inst
+theorem evm_div_n3_loop_unified_inst
     (bltu_1 bltu_0 : Bool) (sp base : Word)
     (shift antiShift b0' b1' b2' b3' u0 u1 u2 u3 u4 : Word)
     (v10Old v11Old jMem : Word)
@@ -111,7 +111,7 @@ private theorem evm_div_n3_loop_unified_inst
     hbltu_1 hbltu_0 hcarry2
 
 /-- No-NOP variant of `evm_div_n3_loop_unified_inst`. -/
-private theorem evm_div_n3_loop_unified_inst_noNop
+theorem evm_div_n3_loop_unified_inst_noNop
     (bltu_1 bltu_0 : Bool) (sp base : Word)
     (shift antiShift b0' b1' b2' b3' u0 u1 u2 u3 u4 : Word)
     (v10Old v11Old jMem : Word)

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V4NoNop.lean
@@ -66,6 +66,23 @@ def loopBodyN3CallSkipJ1NormPreV4
     (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 **
   (sp + signExtend12 3936 ↦ₘ scratchMem)
 
+/-- n=3 max-addback j>0 precondition over `divCode_noNop_v4`. -/
+@[irreducible]
+def loopBodyN3MaxAddbackJgt0NormPreV4 (j : Word)
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word) : Assertion :=
+  loopBodyN3MaxSkipPre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    j v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
+
+/-- n=3 call-addback j>0 precondition over `divCode_noNop_v4`. -/
+@[irreducible]
+def loopBodyN3CallAddbackJgt0NormPreV4 (j : Word)
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word) : Assertion :=
+  loopBodyN3CallAddbackJgt0PreV4 j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem
+
 /-- Loop body n=3, max+skip, j=0 over `divCode_noNop_v4`, with
     sp-relative addresses hidden behind a named precondition. -/
 theorem divK_loop_body_n3_max_skip_j0_norm_v4_noNop (sp base : Word)
@@ -115,6 +132,36 @@ theorem divK_loop_body_n3_max_skip_j1_norm_v4_noNop (sp base : Word)
   exact cpsTripleWithin_weaken
     (fun h hp => by
       delta loopBodyN3MaxSkipJ1NormPreV4 at hp
+      xperm_hyp hp)
+    (fun h hp => hp)
+    raw'
+
+/-- Loop body n=3, max+addback (BEQ double-addback), j>0 over
+    `divCode_noNop_v4`, with the precondition hidden behind an irreducible
+    definition. -/
+theorem divK_loop_body_n3_max_addback_jgt0_beq_norm_v4_noNop (j sp base : Word)
+    (hpos : BitVec.slt (j + signExtend12 4095) 0 = false)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (hbltu : ¬BitVec.ult u3 v2)
+    (hcarry2_nz : isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+     then (1 : Word) else 0) ≠ (0 : Word) →
+    cpsTripleWithin 152 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop_v4 base)
+      (loopBodyN3MaxAddbackJgt0NormPreV4 j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld)
+      (loopBodyN3AddbackBeqPost sp j (signExtend12 4095 : Word)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro hborrow
+  have raw := divK_loop_body_n3_max_addback_jgt0_beq_v4_spec_within_noNop j hpos
+    sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base
+    hbltu hcarry2_nz hborrow
+  have raw' := cpsTripleWithin_extend_code
+    (hmono := sharedDivModCodeNoNop_v4_sub_divCode_noNop_v4) raw
+  exact cpsTripleWithin_weaken
+    (fun h hp => by
+      delta loopBodyN3MaxAddbackJgt0NormPreV4 at hp
       xperm_hyp hp)
     (fun h hp => hp)
     raw'
@@ -177,6 +224,37 @@ theorem divK_loop_body_n3_call_skip_j1_norm_v4_noNop (sp base : Word)
   exact cpsTripleWithin_weaken
     (fun h hp => by
       delta loopBodyN3CallSkipJ1NormPreV4 at hp
+      xperm_hyp hp)
+    (fun h hp => hp)
+    raw'
+
+/-- Loop body n=3, call+addback (BEQ double-addback), j>0 over
+    `divCode_noNop_v4`, with the precondition hidden behind an irreducible
+    definition. -/
+theorem divK_loop_body_n3_call_addback_jgt0_beq_norm_v4_noNop (j sp base : Word)
+    (hpos : BitVec.slt (j + signExtend12 4095) 0 = false)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu : BitVec.ult u3 v2)
+    (hborrow : loopBodyN3CallAddbackBorrowV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hcarry2_nz : loopBodyN3CallAddbackCarry2NzV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 224 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop_v4 base)
+      (loopBodyN3CallAddbackJgt0NormPreV4 j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem)
+      (loopBodyN3CallAddbackJgt0PostV4 sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem) := by
+  have raw := divK_loop_body_n3_call_addback_jgt0_beq_v4_spec_within_noNop j hpos
+    sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
+    retMem dMem dloMem scratchUn0 scratchMem base
+    halign hbltu hborrow hcarry2_nz
+  have raw' := cpsTripleWithin_extend_code
+    (hmono := sharedDivModCodeNoNop_v4_sub_divCode_noNop_v4) raw
+  exact cpsTripleWithin_weaken
+    (fun h hp => by
+      delta loopBodyN3CallAddbackJgt0NormPreV4 at hp
       xperm_hyp hp)
     (fun h hp => hp)
     raw'


### PR DESCRIPTION
## Summary
- add irreducible n=3 j>0 addback precondition aliases over divCode_noNop_v4
- bridge existing sharedDivModCodeNoNop_v4 jgt0 max/call addback specs to divCode_noNop_v4
- keep j-dependent precondition chains behind named defs

## Verification
- lake build EvmAsm.Evm64.DivMod.Compose.FullPathN3V4NoNop
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- scripts/check-file-size.sh EvmAsm/Evm64/DivMod/Compose/FullPathN3V4NoNop.lean
- rg -n 'sorry|admit|placeholder|set_option maxHeartbeats|set_option maxRecDepth' EvmAsm/Evm64/DivMod/Compose/FullPathN3V4NoNop.lean