### PR TITLE
feat(exp): add pre-reload direct adapter

### DIFF
--- a/EvmAsm/Evm64/Exp.lean
+++ b/EvmAsm/Evm64/Exp.lean
@@ -94,6 +94,7 @@ import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterStateResidualPures
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterStateResidualBridge
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterStateLoop
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterStateLoopDirect
+import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterStateLoopPreReload
 import EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryEpilogueBase
 import EvmAsm.Evm64.Exp.Compose.SavedBitBoundarySeq
 import EvmAsm.Evm64.Exp.Compose.SavedBitLoopEntry

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoopPreReload.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoopPreReload.lean
@@ -1,0 +1,146 @@
+/-
+  EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterStateLoopPreReload
+
+  Pre-reload direct-loop adapters for the fixed EXP induction frame.
+-/
+
+import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterStateLoopDirect
+
+namespace EvmAsm.Evm64.Exp.Compose
+
+open EvmAsm.Rv64
+
+/-- Pre-reload direct head step over the two-cell lookahead frame.
+
+    At `k % 64 = 62`, this step is still a no-reload step, but the recursive
+    successor has `c6 = 1` and needs the reload-limb frame for the imminent
+    reload. The pre-reload frame carries both the current saved-next cell and
+    the successor reload cell. -/
+theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_preReloadFrameN_of_control_from_pre
+    {baseWord exponentWord : EvmWord} {k iterations : Nat}
+    (controlC6 e machineC6 iterCount v10 v18 ptr nextLimb
+      nextNextLimb sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3
+      e0 e1 e2 e3 a0 a1 a2 a3 v7 v11 : Word)
+    (base : Word)
+    (Q : Assertion)
+    (hbase : (base + 44 : Word) &&& 1 = 0)
+    (hControlMachine : controlC6 = machineC6)
+    (hk : k < 256)
+    (hBase : baseWord = expResultWord a0 a1 a2 a3)
+    (hControl :
+      expTwoMulFixedControlInvariant exponentWord k controlC6 ptr nextLimb
+        evmSp)
+    (hC6 : (controlC6 + signExtend12 (-1 : BitVec 12)).toNat = 1)
+    (hNextNext :
+      nextNextLimb = exponentWord.getLimbN (2 - (k + 1) / 64))
+    (hBranch :
+      k < 255 →
+      ∀ (bit : Bool)
+        (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
+          (base + 44) (base + 296)
+          (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+          (expReloadDirectBranchPre k baseWord exponentWord
+            controlC6 e iterCount ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3
+            bit v6' v7' v10' v11' d0' d1' d2' d3' base
+            (((((ptr + signExtend12 (-8 : BitVec 12)) +
+              signExtend12 (0 : BitVec 12)) ↦ₘ nextNextLimb) **
+              expTwoMulFixedReloadLimbFrameN exponentWord (k + 1) ptr)))
+          (Q ** (((((ptr + signExtend12 (-8 : BitVec 12)) +
+            signExtend12 (0 : BitVec 12)) ↦ₘ nextNextLimb) **
+            expTwoMulFixedReloadLimbFrameN exponentWord (k + 1) ptr))))
+    (hReloadFalse :
+      k < 255 →
+      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
+          (base + 44) (base + 296)
+          (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+          (expReloadDirectFalsePre k baseWord exponentWord
+            e iterCount nextLimb ptr nextNextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3
+            v6' v7' v10' v11' d0' d1' d2' d3' base
+            (((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
+              ⌜expTwoMulIterCountNew iterCount ≠ 0⌝ **
+              ⌜controlC6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
+              ⌜(e >>> (63 : BitVec 6).toNat) +
+                signExtend12 (0 : BitVec 12) = 0⌝ **
+              expTwoMulFixedReloadLimbFrameN exponentWord (k + 1) ptr))
+          (Q ** (((((ptr + signExtend12 (-8 : BitVec 12)) +
+            signExtend12 (0 : BitVec 12)) ↦ₘ nextNextLimb) **
+            expTwoMulFixedReloadLimbFrameN exponentWord (k + 1) ptr))))
+    (hReloadTrue :
+      k < 255 →
+      ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
+        cpsTripleWithin (expTwoMulFixedIterationsBodyBound iterations)
+          (base + 44) (base + 296)
+          (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+          (expReloadDirectTruePre k baseWord exponentWord
+            e iterCount nextLimb ptr nextNextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3
+            v6' v7' v10' v11' d0' d1' d2' d3' base
+            (((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
+              ⌜expTwoMulIterCountNew iterCount ≠ 0⌝ **
+              ⌜controlC6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
+              ⌜(e >>> (63 : BitVec 6).toNat) +
+                signExtend12 (0 : BitVec 12) ≠ 0⌝ **
+              expTwoMulFixedReloadLimbFrameN exponentWord (k + 1) ptr))
+          (Q ** (((((ptr + signExtend12 (-8 : BitVec 12)) +
+            signExtend12 (0 : BitVec 12)) ↦ₘ nextNextLimb) **
+            expTwoMulFixedReloadLimbFrameN exponentWord (k + 1) ptr))))
+    (hExit :
+      k = 255 →
+      ∀ ps,
+        expTwoMulFixedIterCaseExitPost iterCount e machineC6 ptr nextLimb
+          sp evmSp r0 r1 r2 r3 a0 a1 a2 a3 base ps →
+        Q ps) :
+    cpsTripleWithin (expTwoMulFixedIterationsBodyBound (iterations + 1))
+      (base + 44) (base + 296)
+      (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
+      (expTwoMulFixedIterPreNWithStateFrame k baseWord exponentWord
+        controlC6 e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+        a0 a1 a2 a3 v7 v11
+        (expTwoMulFixedPreReloadFrameN exponentWord k ptr))
+      (Q ** expTwoMulFixedPreReloadFrameN exponentWord k ptr) := by
+  have hFrameEq :
+      expTwoMulFixedSavedNextLimbFrame ptr nextNextLimb =
+        expTwoMulFixedSavedNextLimbFrameN exponentWord k ptr :=
+    expTwoMulFixedSavedNextLimbFrameN_eq_of_nextNext hNextNext
+  have hPreReloadEq :
+      expTwoMulFixedPreReloadFrameN exponentWord k ptr =
+        (expTwoMulFixedSavedNextLimbFrameN exponentWord k ptr **
+          expTwoMulFixedReloadLimbFrameN exponentWord (k + 1) ptr) :=
+    expTwoMulFixedPreReloadFrameN_handoff_of_control hControl hC6
+  exact
+    cpsTripleWithin_weaken
+      (fun _ h => by
+        rw [hPreReloadEq] at h
+        rw [← hFrameEq, expTwoMulFixedSavedNextLimbFrame_unfold] at h
+        exact h)
+      (fun _ h => by
+        rw [hPreReloadEq, ← hFrameEq, expTwoMulFixedSavedNextLimbFrame_unfold]
+        exact h)
+      (cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_from_pre
+        controlC6 e machineC6 iterCount v10 v18 ptr nextLimb nextNextLimb
+        sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+        a0 a1 a2 a3 v7 v11 base
+        (expTwoMulFixedReloadLimbFrameN exponentWord (k + 1) ptr)
+        Q
+        (by
+          rw [expTwoMulFixedReloadLimbFrameN_unfold,
+            expTwoMulFixedSavedNextLimbFrame_unfold]
+          pcFree)
+        hbase hControlMachine hk hBase hNextNext
+        (fun hk_lt bit v6' v7' v10' v11' d0' d1' d2' d3' => by
+          simpa only [expReloadDirectBranchPre] using
+            hBranch hk_lt bit v6' v7' v10' v11' d0' d1' d2' d3')
+        (fun hk_lt v6' v7' v10' v11' d0' d1' d2' d3' => by
+          simpa only [expReloadDirectFalsePre] using
+            hReloadFalse hk_lt v6' v7' v10' v11' d0' d1' d2' d3')
+        (fun hk_lt v6' v7' v10' v11' d0' d1' d2' d3' => by
+          simpa only [expReloadDirectTruePre] using
+            hReloadTrue hk_lt v6' v7' v10' v11' d0' d1' d2' d3')
+        hExit)
+
+end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
Summary:
- Add a pre-reload direct head-step adapter over the fixed EXP two-cell lookahead frame.
- Carry the successor reload-limb frame into branch, false-reload, and true-reload continuations.
- Keep the adapter in a companion module so SavedBitFixedIterStateLoopDirect stays below the Compose file-size cap.

Verification:
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterStateLoopPreReload
- lake build EvmAsm.Evm64.Exp
- git diff --check
- scripts/check-file-size.sh EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoopDirect.lean EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoopPreReload.lean
- rg -n forbidden shortcut scan on the new file