### PR TITLE
refactor(exp): add generic reload frame helpers

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoopReloadLimbFrames.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoopReloadLimbFrames.lean
@@ -25,6 +25,18 @@ theorem expReloadLimbDirectTailFrame_unfold
   rfl
 
 @[irreducible]
+def expReloadDirectTailFrame
+    (ptr nextNextLimb : Word) (frame : Assertion) : Assertion :=
+  expReloadLimbDirectTailFrame ptr nextNextLimb ** frame
+
+theorem expReloadDirectTailFrame_unfold
+    {ptr nextNextLimb : Word} {frame : Assertion} :
+    expReloadDirectTailFrame ptr nextNextLimb frame =
+      ((((ptr + signExtend12 (-8 : BitVec 12)) +
+        signExtend12 (0 : BitVec 12)) ↦ₘ nextNextLimb) ** frame) := by
+  rw [expReloadDirectTailFrame, expReloadLimbDirectTailFrame_unfold]
+
+@[irreducible]
 def expReloadLimbDirectFalseFrame
     (controlC6 e iterCount ptr nextLimb : Word) : Assertion :=
   (((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
@@ -45,6 +57,23 @@ theorem expReloadLimbDirectFalseFrame_unfold
   rfl
 
 @[irreducible]
+def expReloadDirectFalseFrame
+    (controlC6 e iterCount ptr nextLimb : Word)
+    (frame : Assertion) : Assertion :=
+  expReloadLimbDirectFalseFrame controlC6 e iterCount ptr nextLimb ** frame
+
+theorem expReloadDirectFalseFrame_unfold
+    {controlC6 e iterCount ptr nextLimb : Word} {frame : Assertion} :
+    expReloadDirectFalseFrame controlC6 e iterCount ptr nextLimb frame =
+      ((((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
+          ⌜expTwoMulIterCountNew iterCount ≠ 0⌝ **
+          ⌜controlC6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
+          ⌜(e >>> (63 : BitVec 6).toNat) +
+            signExtend12 (0 : BitVec 12) = 0⌝) **
+        frame) := by
+  rw [expReloadDirectFalseFrame, expReloadLimbDirectFalseFrame_unfold]
+
+@[irreducible]
 def expReloadLimbDirectTrueFrame
     (controlC6 e iterCount ptr nextLimb : Word) : Assertion :=
   (((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
@@ -63,5 +92,22 @@ theorem expReloadLimbDirectTrueFrame_unfold
           signExtend12 (0 : BitVec 12) ≠ 0⌝) := by
   delta expReloadLimbDirectTrueFrame
   rfl
+
+@[irreducible]
+def expReloadDirectTrueFrame
+    (controlC6 e iterCount ptr nextLimb : Word)
+    (frame : Assertion) : Assertion :=
+  expReloadLimbDirectTrueFrame controlC6 e iterCount ptr nextLimb ** frame
+
+theorem expReloadDirectTrueFrame_unfold
+    {controlC6 e iterCount ptr nextLimb : Word} {frame : Assertion} :
+    expReloadDirectTrueFrame controlC6 e iterCount ptr nextLimb frame =
+      ((((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
+          ⌜expTwoMulIterCountNew iterCount ≠ 0⌝ **
+          ⌜controlC6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
+          ⌜(e >>> (63 : BitVec 6).toNat) +
+            signExtend12 (0 : BitVec 12) ≠ 0⌝) **
+        frame) := by
+  rw [expReloadDirectTrueFrame, expReloadLimbDirectTrueFrame_unfold]
 
 end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
Summary:
- Add public irreducible frame-parameterized reload direct helper definitions.
- Provide unfold lemmas that preserve the existing separation-conjunction parenthesization.
- Keep proof wrapper rewrites for a follow-up slice after the helper names are available.

Verification:
- lake build EvmAsm.Evm64.Exp
- git diff --check
- scripts/check-file-size.sh EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoopReloadLimbFrames.lean
- rg -n set_option maxHeartbeats|set_option maxRecDepth|sorry|admit on the helper file returned no matches