### PR TITLE
refactor(exp): use generic reload frame helpers

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoopDirect.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoopDirect.lean
@@ -113,10 +113,8 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_f
             controlC6 e iterCount ptr nextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
             bit v6' v7' v10' v11' d0' d1' d2' d3' base
-            ((((ptr + signExtend12 (-8 : BitVec 12)) +
-              signExtend12 (0 : BitVec 12)) ↦ₘ nextNextLimb) ** frame))
-          (Q ** ((((ptr + signExtend12 (-8 : BitVec 12)) +
-            signExtend12 (0 : BitVec 12)) ↦ₘ nextNextLimb) ** frame)))
+            (expReloadDirectTailFrame ptr nextNextLimb frame))
+          (Q ** expReloadDirectTailFrame ptr nextNextLimb frame))
     (hReloadFalse :
       k < 255 →
       ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
@@ -127,14 +125,9 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_f
             e iterCount nextLimb ptr nextNextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
             v6' v7' v10' v11' d0' d1' d2' d3' base
-            (((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
-              ⌜expTwoMulIterCountNew iterCount ≠ 0⌝ **
-              ⌜controlC6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
-              ⌜(e >>> (63 : BitVec 6).toNat) +
-                signExtend12 (0 : BitVec 12) = 0⌝ **
+            (expReloadDirectFalseFrame controlC6 e iterCount ptr nextLimb
               frame))
-          (Q ** ((((ptr + signExtend12 (-8 : BitVec 12)) +
-            signExtend12 (0 : BitVec 12)) ↦ₘ nextNextLimb) ** frame)))
+          (Q ** expReloadDirectTailFrame ptr nextNextLimb frame))
     (hReloadTrue :
       k < 255 →
       ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
@@ -145,14 +138,9 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_f
             e iterCount nextLimb ptr nextNextLimb sp evmSp
             r0 r1 r2 r3 a0 a1 a2 a3
             v6' v7' v10' v11' d0' d1' d2' d3' base
-            (((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
-              ⌜expTwoMulIterCountNew iterCount ≠ 0⌝ **
-              ⌜controlC6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
-              ⌜(e >>> (63 : BitVec 6).toNat) +
-                signExtend12 (0 : BitVec 12) ≠ 0⌝ **
+            (expReloadDirectTrueFrame controlC6 e iterCount ptr nextLimb
               frame))
-          (Q ** ((((ptr + signExtend12 (-8 : BitVec 12)) +
-            signExtend12 (0 : BitVec 12)) ↦ₘ nextNextLimb) ** frame)))
+          (Q ** expReloadDirectTailFrame ptr nextNextLimb frame))
     (hExit :
       k = 255 →
       ∀ ps,
@@ -166,16 +154,14 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_f
         controlC6 e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp
         tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
         a0 a1 a2 a3 v7 v11
-        ((((ptr + signExtend12 (-8 : BitVec 12)) +
-          signExtend12 (0 : BitVec 12)) ↦ₘ nextNextLimb) ** frame))
-      (Q ** ((((ptr + signExtend12 (-8 : BitVec 12)) +
-        signExtend12 (0 : BitVec 12)) ↦ₘ nextNextLimb) ** frame)) := by
+        (expReloadDirectTailFrame ptr nextNextLimb frame))
+      (Q ** expReloadDirectTailFrame ptr nextNextLimb frame) := by
   have hFrameCurrent :
       (((((ptr + signExtend12 (-8 : BitVec 12)) +
         signExtend12 (0 : BitVec 12)) ↦ₘ nextNextLimb) ** frame).pcFree) := by
     pcFree
     exact hFrame
-  exact
+  simpa only [expReloadDirectTailFrame_unfold] using
     cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_iterationsBound_sameCode_from_pre
       controlC6 e machineC6 iterCount v10 v18 ptr nextLimb nextNextLimb
       sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
@@ -184,7 +170,8 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_f
         signExtend12 (0 : BitVec 12) ↦ₘ nextNextLimb) ** frame)
       Q hFrameCurrent hbase hControlMachine hk hBase hNextNext
       (fun hk_lt bit v6' v7' v10' v11' d0' d1' d2' d3' => by
-        simpa only [expReloadDirectBranchPre, expTwoMulFixedStateBranchPre] using
+        simpa only [expReloadDirectBranchPre, expTwoMulFixedStateBranchPre,
+          expReloadDirectTailFrame_unfold] using
           hBranch hk_lt bit v6' v7' v10' v11' d0' d1' d2' d3')
       (fun hk_lt bit v6' v7' v10' v11' d0' d1' d2' d3' => by
         cases bit
@@ -193,14 +180,18 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_f
               (by
                 simpa only [
                   expTwoMulFixedReloadResidualFalseNextPre,
-                  expReloadDirectFalsePre] using
+                  expReloadDirectFalsePre,
+                  expReloadDirectFalseFrame_unfold,
+                  expReloadDirectTailFrame_unfold] using
                   hReloadFalse hk_lt v6' v7' v10' v11' d0' d1' d2' d3')
         · exact
             cpsTripleWithin_expTwoMulFixedReloadBranchResidualWithStateFrame_true_to_iterPreNWithStateFrame
               (by
                 simpa only [
                   expTwoMulFixedReloadResidualTrueNextPre,
-                  expReloadDirectTruePre] using
+                  expReloadDirectTruePre,
+                  expReloadDirectTrueFrame_unfold,
+                  expReloadDirectTailFrame_unfold] using
                   hReloadTrue hk_lt v6' v7' v10' v11' d0' d1' d2' d3'))
       hExit
 
@@ -280,11 +271,11 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_p
   exact
     cpsTripleWithin_weaken
       (fun _ h => by
-        rw [sepConj_emp_right']
-        exact h)
+        simpa only [expReloadDirectTailFrame_emp,
+          expReloadLimbDirectTailFrame_unfold] using h)
       (fun _ h => by
-        rw [sepConj_emp_right'] at h
-        exact h)
+        simpa only [expReloadDirectTailFrame_emp,
+          expReloadLimbDirectTailFrame_unfold] using h)
       (cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_from_pre
         controlC6 e machineC6 iterCount v10 v18 ptr nextLimb nextNextLimb
         sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
@@ -293,32 +284,26 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_p
         (fun hk_lt bit v6' v7' v10' v11' d0' d1' d2' d3' =>
           cpsTripleWithin_weaken
             (fun _ h => by
-              rw [sepConj_emp_right'] at h
               simpa only [expReloadDirectBranchPre,
-                expReloadLimbDirectTailFrame_unfold] using h)
+                expReloadDirectTailFrame_emp] using h)
             (fun _ h => by
-              rw [sepConj_emp_right']
-              simpa only [expReloadLimbDirectTailFrame_unfold] using h)
+              simpa only [expReloadDirectTailFrame_emp] using h)
             (hBranch hk_lt bit v6' v7' v10' v11' d0' d1' d2' d3'))
         (fun hk_lt v6' v7' v10' v11' d0' d1' d2' d3' =>
           cpsTripleWithin_weaken
             (fun _ h => by
-              rw [sepConj_emp_right'] at h
               simpa only [expReloadDirectFalsePre,
-                expReloadLimbDirectFalseFrame_unfold] using h)
+                expReloadDirectFalseFrame_emp] using h)
             (fun _ h => by
-              rw [sepConj_emp_right']
-              simpa only [expReloadLimbDirectTailFrame_unfold] using h)
+              simpa only [expReloadDirectTailFrame_emp] using h)
             (hReloadFalse hk_lt v6' v7' v10' v11' d0' d1' d2' d3'))
         (fun hk_lt v6' v7' v10' v11' d0' d1' d2' d3' =>
           cpsTripleWithin_weaken
             (fun _ h => by
-              rw [sepConj_emp_right'] at h
               simpa only [expReloadDirectTruePre,
-                expReloadLimbDirectTrueFrame_unfold] using h)
+                expReloadDirectTrueFrame_emp] using h)
             (fun _ h => by
-              rw [sepConj_emp_right']
-              simpa only [expReloadLimbDirectTailFrame_unfold] using h)
+              simpa only [expReloadDirectTailFrame_emp] using h)
             (hReloadTrue hk_lt v6' v7' v10' v11' d0' d1' d2' d3'))
         hExit)
 
@@ -894,10 +879,10 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_r
       (fun _ h => by
         rw [hTailEq] at h
         rw [← hFrameEq, expTwoMulFixedSavedNextLimbFrame_unfold] at h
-        exact h)
+        simpa only [expReloadDirectTailFrame_unfold] using h)
       (fun _ h => by
         rw [hTailEq, ← hFrameEq, expTwoMulFixedSavedNextLimbFrame_unfold]
-        exact h)
+        simpa only [expReloadDirectTailFrame_unfold] using h)
       (cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_from_pre
         controlC6 e machineC6 iterCount v10 v18 ptr nextLimb nextNextLimb
         sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
@@ -912,15 +897,20 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_r
         hbase hControlMachine hk hBase hNextNext
         (fun hk_lt bit v6' v7' v10' v11' d0' d1' d2' d3' => by
           simpa only [expReloadDirectBranchPre,
+            expReloadDirectTailFrame_unfold,
             expReloadTailDirectTailFrameN_unfold] using
             hBranch hk_lt bit v6' v7' v10' v11' d0' d1' d2' d3')
         (fun hk_lt v6' v7' v10' v11' d0' d1' d2' d3' => by
           simpa only [expReloadDirectFalsePre,
+            expReloadDirectFalseFrame_unfold,
+            expReloadDirectTailFrame_unfold,
             expReloadTailDirectFalseFrameN_unfold,
             expReloadTailDirectTailFrameN_unfold] using
             hReloadFalse hk_lt v6' v7' v10' v11' d0' d1' d2' d3')
       (fun hk_lt v6' v7' v10' v11' d0' d1' d2' d3' => by
           simpa only [expReloadDirectTruePre,
+            expReloadDirectTrueFrame_unfold,
+            expReloadDirectTailFrame_unfold,
             expReloadTailDirectTrueFrameN_unfold,
             expReloadTailDirectTailFrameN_unfold] using
             hReloadTrue hk_lt v6' v7' v10' v11' d0' d1' d2' d3')

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoopPreReload.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoopPreReload.lean
@@ -171,10 +171,10 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_p
       (fun _ h => by
         rw [hPreReloadEq] at h
         rw [← hFrameEq, expTwoMulFixedSavedNextLimbFrame_unfold] at h
-        exact h)
+        simpa only [expReloadDirectTailFrame_unfold] using h)
       (fun _ h => by
         rw [hPreReloadEq, ← hFrameEq, expTwoMulFixedSavedNextLimbFrame_unfold]
-        exact h)
+        simpa only [expReloadDirectTailFrame_unfold] using h)
       (cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_from_pre
         controlC6 e machineC6 iterCount v10 v18 ptr nextLimb nextNextLimb
         sp evmSp tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
@@ -188,15 +188,20 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithStateFrame_head_reloadDirect_p
         hbase hControlMachine hk hBase hNextNext
         (fun hk_lt bit v6' v7' v10' v11' d0' d1' d2' d3' => by
           simpa only [expReloadDirectBranchPre,
+            expReloadDirectTailFrame_unfold,
             expPreReloadDirectTailFrameN_unfold] using
             hBranch hk_lt bit v6' v7' v10' v11' d0' d1' d2' d3')
         (fun hk_lt v6' v7' v10' v11' d0' d1' d2' d3' => by
           simpa only [expReloadDirectFalsePre,
+            expReloadDirectFalseFrame_unfold,
+            expReloadDirectTailFrame_unfold,
             expPreReloadDirectFalseFrameN_unfold,
             expPreReloadDirectTailFrameN_unfold] using
             hReloadFalse hk_lt v6' v7' v10' v11' d0' d1' d2' d3')
         (fun hk_lt v6' v7' v10' v11' d0' d1' d2' d3' => by
           simpa only [expReloadDirectTruePre,
+            expReloadDirectTrueFrame_unfold,
+            expReloadDirectTailFrame_unfold,
             expPreReloadDirectTrueFrameN_unfold,
             expPreReloadDirectTailFrameN_unfold] using
             hReloadTrue hk_lt v6' v7' v10' v11' d0' d1' d2' d3')

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoopReloadLimbFrames.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoopReloadLimbFrames.lean
@@ -36,6 +36,12 @@ theorem expReloadDirectTailFrame_unfold
         signExtend12 (0 : BitVec 12)) ↦ₘ nextNextLimb) ** frame) := by
   rw [expReloadDirectTailFrame, expReloadLimbDirectTailFrame_unfold]
 
+theorem expReloadDirectTailFrame_emp
+    {ptr nextNextLimb : Word} :
+    expReloadDirectTailFrame ptr nextNextLimb empAssertion =
+      expReloadLimbDirectTailFrame ptr nextNextLimb := by
+  rw [expReloadDirectTailFrame, sepConj_emp_right']
+
 @[irreducible]
 def expReloadLimbDirectFalseFrame
     (controlC6 e iterCount ptr nextLimb : Word) : Assertion :=
@@ -60,18 +66,32 @@ theorem expReloadLimbDirectFalseFrame_unfold
 def expReloadDirectFalseFrame
     (controlC6 e iterCount ptr nextLimb : Word)
     (frame : Assertion) : Assertion :=
-  expReloadLimbDirectFalseFrame controlC6 e iterCount ptr nextLimb ** frame
+  (((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
+    ⌜expTwoMulIterCountNew iterCount ≠ 0⌝ **
+    ⌜controlC6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
+    ⌜(e >>> (63 : BitVec 6).toNat) +
+      signExtend12 (0 : BitVec 12) = 0⌝ **
+    frame)
 
 theorem expReloadDirectFalseFrame_unfold
     {controlC6 e iterCount ptr nextLimb : Word} {frame : Assertion} :
     expReloadDirectFalseFrame controlC6 e iterCount ptr nextLimb frame =
-      ((((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
-          ⌜expTwoMulIterCountNew iterCount ≠ 0⌝ **
-          ⌜controlC6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
-          ⌜(e >>> (63 : BitVec 6).toNat) +
-            signExtend12 (0 : BitVec 12) = 0⌝) **
+      (((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
+        ⌜expTwoMulIterCountNew iterCount ≠ 0⌝ **
+        ⌜controlC6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
+        ⌜(e >>> (63 : BitVec 6).toNat) +
+          signExtend12 (0 : BitVec 12) = 0⌝ **
         frame) := by
-  rw [expReloadDirectFalseFrame, expReloadLimbDirectFalseFrame_unfold]
+  delta expReloadDirectFalseFrame
+  rfl
+
+theorem expReloadDirectFalseFrame_emp
+    {controlC6 e iterCount ptr nextLimb : Word} :
+    expReloadDirectFalseFrame controlC6 e iterCount ptr nextLimb
+        empAssertion =
+      expReloadLimbDirectFalseFrame controlC6 e iterCount ptr nextLimb := by
+  rw [expReloadDirectFalseFrame_unfold, expReloadLimbDirectFalseFrame_unfold,
+    sepConj_emp_right']
 
 @[irreducible]
 def expReloadLimbDirectTrueFrame
@@ -97,17 +117,31 @@ theorem expReloadLimbDirectTrueFrame_unfold
 def expReloadDirectTrueFrame
     (controlC6 e iterCount ptr nextLimb : Word)
     (frame : Assertion) : Assertion :=
-  expReloadLimbDirectTrueFrame controlC6 e iterCount ptr nextLimb ** frame
+  (((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
+    ⌜expTwoMulIterCountNew iterCount ≠ 0⌝ **
+    ⌜controlC6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
+    ⌜(e >>> (63 : BitVec 6).toNat) +
+      signExtend12 (0 : BitVec 12) ≠ 0⌝ **
+    frame)
 
 theorem expReloadDirectTrueFrame_unfold
     {controlC6 e iterCount ptr nextLimb : Word} {frame : Assertion} :
     expReloadDirectTrueFrame controlC6 e iterCount ptr nextLimb frame =
-      ((((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
-          ⌜expTwoMulIterCountNew iterCount ≠ 0⌝ **
-          ⌜controlC6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
-          ⌜(e >>> (63 : BitVec 6).toNat) +
-            signExtend12 (0 : BitVec 12) ≠ 0⌝) **
+      (((ptr + signExtend12 (0 : BitVec 12)) ↦ₘ nextLimb) **
+        ⌜expTwoMulIterCountNew iterCount ≠ 0⌝ **
+        ⌜controlC6 + signExtend12 (-1 : BitVec 12) = 0⌝ **
+        ⌜(e >>> (63 : BitVec 6).toNat) +
+          signExtend12 (0 : BitVec 12) ≠ 0⌝ **
         frame) := by
-  rw [expReloadDirectTrueFrame, expReloadLimbDirectTrueFrame_unfold]
+  delta expReloadDirectTrueFrame
+  rfl
+
+theorem expReloadDirectTrueFrame_emp
+    {controlC6 e iterCount ptr nextLimb : Word} :
+    expReloadDirectTrueFrame controlC6 e iterCount ptr nextLimb
+        empAssertion =
+      expReloadLimbDirectTrueFrame controlC6 e iterCount ptr nextLimb := by
+  rw [expReloadDirectTrueFrame_unfold, expReloadLimbDirectTrueFrame_unfold,
+    sepConj_emp_right']
 
 end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
Summary:
- Rewrite the low-level reload-direct wrapper to expose generic frame-parameterized continuation helpers.
- Add empAssertion bridge lemmas and align false/true helper definitions with existing right-associated frame shapes.
- Update reload-tail and pre-reload adapters that delegate through the generic wrapper to unfold the named frames at the boundary.

Verification:
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterStateLoopDirect
- lake build EvmAsm.Evm64.Exp
- git diff --check
- scripts/check-file-size.sh EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoopDirect.lean EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoopPreReload.lean EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateLoopReloadLimbFrames.lean
- rg -n set_option maxHeartbeats|set_option maxRecDepth|sorry|admit on touched files returned no matches