### PR TITLE
refactor(exp): name state-step branch pre surfaces

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateStep.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStateStep.lean
@@ -392,25 +392,10 @@ theorem expTwoMulFixedIterStepPostNWithControlFrame_branchState_or_reload
         iterCount e controlC6 ptr nextLimb nextNextLimb sp evmSp
         r0 r1 r2 r3 a0 a1 a2 a3 base frame ps) :
     (∃ bit v6 v7 v10 v11 d0 d1 d2 d3,
-      let outW := expTwoMulFixedBranchResult bit
-        a0 a1 a2 a3 r0 r1 r2 r3
-      expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-        (controlC6 + signExtend12 (-1 : BitVec 12))
-        (e <<< (1 : BitVec 6).toNat)
-        v6
-        (expTwoMulIterCountNew iterCount)
-        v10
-        ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-        ptr nextLimb sp evmSp
-        (outW.getLimbN 3)
-        (expTwoMulFixedBranchReturnPc bit base)
-        (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-        (outW.getLimbN 3)
-        d0 d1 d2 d3
-        (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-        (outW.getLimbN 3)
-        a0 a1 a2 a3 v7 v11
-        frame ps) ∨
+      expTwoMulFixedStateStepBranchPre k baseWord exponentWord
+        controlC6 e iterCount ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 bit
+        v6 v7 v10 v11 d0 d1 d2 d3 base frame ps) ∨
     (∃ bit v6 v7 v10 v11 d0 d1 d2 d3,
       expTwoMulFixedReloadBranchResidualWithControlFrame bit (k := k)
         baseWord exponentWord iterCount e controlC6 ptr nextLimb
@@ -421,8 +406,11 @@ theorem expTwoMulFixedIterStepPostNWithControlFrame_branchState_or_reload
   · rcases hBranch with ⟨bit, v6, v7, v10, v11, d0, d1, d2, d3, hPre⟩
     exact Or.inl
       ⟨bit, v6, v7, v10, v11, d0, d1, d2, d3,
-        expTwoMulFixedIterPreNWithControlFrame_to_iterPreNWithStateFrame
-          (expTwoMulFixedIterCountInvariant_succ hk hCount) hPre⟩
+        by
+          simpa only [expTwoMulFixedStateStepBranchPre,
+            expTwoMulFixedStepPostBranchPre] using
+            expTwoMulFixedIterPreNWithControlFrame_to_iterPreNWithStateFrame
+              (expTwoMulFixedIterCountInvariant_succ hk hCount) hPre⟩
   · exact Or.inr hReload
 
 /-- State-shaped version of
@@ -441,25 +429,10 @@ theorem expTwoMulFixedIterStepPostNWithControlFrame_branchState_or_reloadState
         iterCount e controlC6 ptr nextLimb nextNextLimb sp evmSp
         r0 r1 r2 r3 a0 a1 a2 a3 base frame ps) :
     (∃ bit v6 v7 v10 v11 d0 d1 d2 d3,
-      let outW := expTwoMulFixedBranchResult bit
-        a0 a1 a2 a3 r0 r1 r2 r3
-      expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-        (controlC6 + signExtend12 (-1 : BitVec 12))
-        (e <<< (1 : BitVec 6).toNat)
-        v6
-        (expTwoMulIterCountNew iterCount)
-        v10
-        ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-        ptr nextLimb sp evmSp
-        (outW.getLimbN 3)
-        (expTwoMulFixedBranchReturnPc bit base)
-        (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-        (outW.getLimbN 3)
-        d0 d1 d2 d3
-        (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-        (outW.getLimbN 3)
-        a0 a1 a2 a3 v7 v11
-        frame ps) ∨
+      expTwoMulFixedStateStepBranchPre k baseWord exponentWord
+        controlC6 e iterCount ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 bit
+        v6 v7 v10 v11 d0 d1 d2 d3 base frame ps) ∨
     (∃ bit v6 v7 v10 v11 d0 d1 d2 d3,
       expTwoMulFixedReloadBranchResidualWithStateFrame bit (k := k)
         baseWord exponentWord iterCount e controlC6 ptr nextLimb
@@ -496,25 +469,10 @@ theorem expTwoMulFixedIterCaseLoopPost_branchState_or_reload
         r0 r1 r2 r3 a0 a1 a2 a3 base **
         frame) ps) :
     (∃ bit v6 v7 v10 v11 d0 d1 d2 d3,
-      let outW := expTwoMulFixedBranchResult bit
-        a0 a1 a2 a3 r0 r1 r2 r3
-      expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-        (controlC6 + signExtend12 (-1 : BitVec 12))
-        (e <<< (1 : BitVec 6).toNat)
-        v6
-        (expTwoMulIterCountNew iterCount)
-        v10
-        ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-        ptr nextLimb sp evmSp
-        (outW.getLimbN 3)
-        (expTwoMulFixedBranchReturnPc bit base)
-        (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-        (outW.getLimbN 3)
-        d0 d1 d2 d3
-        (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-        (outW.getLimbN 3)
-        a0 a1 a2 a3 v7 v11
-        frame ps) ∨
+      expTwoMulFixedStateStepBranchPre k baseWord exponentWord
+        controlC6 e iterCount ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 bit
+        v6 v7 v10 v11 d0 d1 d2 d3 base frame ps) ∨
     (∃ bit v6 v7 v10 v11 d0 d1 d2 d3,
       expTwoMulFixedReloadBranchResidualWithControlFrame bit (k := k)
         baseWord exponentWord iterCount e controlC6 ptr nextLimb
@@ -545,25 +503,10 @@ theorem expTwoMulFixedIterCaseLoopPost_branchState_or_reloadState
         r0 r1 r2 r3 a0 a1 a2 a3 base **
         frame) ps) :
     (∃ bit v6 v7 v10 v11 d0 d1 d2 d3,
-      let outW := expTwoMulFixedBranchResult bit
-        a0 a1 a2 a3 r0 r1 r2 r3
-      expTwoMulFixedIterPreNWithStateFrame (k + 1) baseWord exponentWord
-        (controlC6 + signExtend12 (-1 : BitVec 12))
-        (e <<< (1 : BitVec 6).toNat)
-        v6
-        (expTwoMulIterCountNew iterCount)
-        v10
-        ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-        ptr nextLimb sp evmSp
-        (outW.getLimbN 3)
-        (expTwoMulFixedBranchReturnPc bit base)
-        (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-        (outW.getLimbN 3)
-        d0 d1 d2 d3
-        (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-        (outW.getLimbN 3)
-        a0 a1 a2 a3 v7 v11
-        frame ps) ∨
+      expTwoMulFixedStateStepBranchPre k baseWord exponentWord
+        controlC6 e iterCount ptr nextLimb sp evmSp
+        r0 r1 r2 r3 a0 a1 a2 a3 bit
+        v6 v7 v10 v11 d0 d1 d2 d3 base frame ps) ∨
     (∃ bit v6 v7 v10 v11 d0 d1 d2 d3,
       expTwoMulFixedReloadBranchResidualWithStateFrame bit (k := k)
         baseWord exponentWord iterCount e controlC6 ptr nextLimb


### PR DESCRIPTION
## Summary
- replaces repeated successor branch precondition bodies in state-step bridge statements with the existing irreducible branch-pre helper
- keeps the older control-frame bridge compatible through local unfold at the proof boundary
- reduces the induction-facing theorem statement size without changing the proof shape

## Verification
- built the state-step module
- built the EXP umbrella module
- ran whitespace, file-size, and forbidden-shortcut checks