### PR TITLE
refactor(exp): name step wrapper branch pre surfaces

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStep.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStep.lean
@@ -400,24 +400,10 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithControlFrame_stepPost_elim_of_
         (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin nSteps (base + 44) exit
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
-          (let outW := expTwoMulFixedBranchResult bit
-            a0 a1 a2 a3 r0 r1 r2 r3
-          expTwoMulFixedIterPreNWithControlFrame (k + 1) baseWord exponentWord
-            (controlC6 + signExtend12 (-1 : BitVec 12))
-            (e <<< (1 : BitVec 6).toNat)
-            v6'
-            (expTwoMulIterCountNew iterCount)
-            v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            ptr nextLimb sp evmSp
-            (outW.getLimbN 3)
-            (expTwoMulFixedBranchReturnPc bit base)
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            d0' d1' d2' d3'
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
+          (expTwoMulFixedStepPostBranchPre k baseWord exponentWord
+            iterCount e controlC6 ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3 base bit
+            v6' v7' v10' v11' d0' d1' d2' d3'
             frame)
           Q)
     (hReload :
@@ -467,47 +453,20 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithControlFrame_stepPost_bit_elim
       ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin nSteps (base + 44) exit
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
-          (let rw := expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3)
-            a0 a1 a2 a3
-          expTwoMulFixedIterPreNWithControlFrame (k + 1) baseWord exponentWord
-            (controlC6 + signExtend12 (-1 : BitVec 12))
-            (e <<< (1 : BitVec 6).toNat)
-            v6'
-            (expTwoMulIterCountNew iterCount)
-            v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            ptr nextLimb sp evmSp
-            (rw.getLimbN 3)
-            (((base + 44) + 140) + 68)
-            (rw.getLimbN 0) (rw.getLimbN 1) (rw.getLimbN 2)
-            (rw.getLimbN 3)
-            d0' d1' d2' d3'
-            (rw.getLimbN 0) (rw.getLimbN 1) (rw.getLimbN 2)
-            (rw.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
+          (expTwoMulFixedStepPostBranchPre k baseWord exponentWord
+            iterCount e controlC6 ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3 base true
+            v6' v7' v10' v11' d0' d1' d2' d3'
             frame)
           Q)
     (hBranchFalse :
       ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin nSteps (base + 44) exit
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
-          (let squareW := expSquaringCallSquareW r0 r1 r2 r3
-          expTwoMulFixedIterPreNWithControlFrame (k + 1) baseWord exponentWord
-            (controlC6 + signExtend12 (-1 : BitVec 12))
-            (e <<< (1 : BitVec 6).toNat)
-            v6'
-            (expTwoMulIterCountNew iterCount)
-            v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            ptr nextLimb sp evmSp
-            (squareW.getLimbN 3)
-            (((base + 44) + 32) + 68)
-            (squareW.getLimbN 0) (squareW.getLimbN 1)
-            (squareW.getLimbN 2) (squareW.getLimbN 3)
-            d0' d1' d2' d3'
-            (squareW.getLimbN 0) (squareW.getLimbN 1)
-            (squareW.getLimbN 2) (squareW.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
+          (expTwoMulFixedStepPostBranchPre k baseWord exponentWord
+            iterCount e controlC6 ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3 base false
+            v6' v7' v10' v11' d0' d1' d2' d3'
             frame)
           Q)
     (hReloadTrue :
@@ -572,24 +531,10 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithFrame_stepPost_elim
         (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin nSteps (base + 44) exit
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
-          (let outW := expTwoMulFixedBranchResult bit
-            a0 a1 a2 a3 r0 r1 r2 r3
-          expTwoMulFixedIterPreNWithControlFrame (k + 1) baseWord exponentWord
-            (c6 + signExtend12 (-1 : BitVec 12))
-            (e <<< (1 : BitVec 6).toNat)
-            v6'
-            (expTwoMulIterCountNew iterCount)
-            v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            ptr nextLimb sp evmSp
-            (outW.getLimbN 3)
-            (expTwoMulFixedBranchReturnPc bit base)
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            d0' d1' d2' d3'
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
+          (expTwoMulFixedStepPostBranchPre k baseWord exponentWord
+            iterCount e c6 ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3 base bit
+            v6' v7' v10' v11' d0' d1' d2' d3'
             frame)
           Q)
     (hReload :
@@ -637,47 +582,20 @@ theorem cpsTripleWithin_expTwoMulFixedIterPreNWithFrame_stepPost_bit_elim
       ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin nSteps (base + 44) exit
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
-          (let rw := expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3)
-            a0 a1 a2 a3
-          expTwoMulFixedIterPreNWithControlFrame (k + 1) baseWord exponentWord
-            (c6 + signExtend12 (-1 : BitVec 12))
-            (e <<< (1 : BitVec 6).toNat)
-            v6'
-            (expTwoMulIterCountNew iterCount)
-            v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            ptr nextLimb sp evmSp
-            (rw.getLimbN 3)
-            (((base + 44) + 140) + 68)
-            (rw.getLimbN 0) (rw.getLimbN 1) (rw.getLimbN 2)
-            (rw.getLimbN 3)
-            d0' d1' d2' d3'
-            (rw.getLimbN 0) (rw.getLimbN 1) (rw.getLimbN 2)
-            (rw.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
+          (expTwoMulFixedStepPostBranchPre k baseWord exponentWord
+            iterCount e c6 ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3 base true
+            v6' v7' v10' v11' d0' d1' d2' d3'
             frame)
           Q)
     (hBranchFalse :
       ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin nSteps (base + 44) exit
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
-          (let squareW := expSquaringCallSquareW r0 r1 r2 r3
-          expTwoMulFixedIterPreNWithControlFrame (k + 1) baseWord exponentWord
-            (c6 + signExtend12 (-1 : BitVec 12))
-            (e <<< (1 : BitVec 6).toNat)
-            v6'
-            (expTwoMulIterCountNew iterCount)
-            v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            ptr nextLimb sp evmSp
-            (squareW.getLimbN 3)
-            (((base + 44) + 32) + 68)
-            (squareW.getLimbN 0) (squareW.getLimbN 1)
-            (squareW.getLimbN 2) (squareW.getLimbN 3)
-            d0' d1' d2' d3'
-            (squareW.getLimbN 0) (squareW.getLimbN 1)
-            (squareW.getLimbN 2) (squareW.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
+          (expTwoMulFixedStepPostBranchPre k baseWord exponentWord
+            iterCount e c6 ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3 base false
+            v6' v7' v10' v11' d0' d1' d2' d3'
             frame)
           Q)
     (hReloadTrue :
@@ -821,24 +739,10 @@ theorem cpsTripleWithin_expTwoMulFixedIterPre_stepPostNWithControl_elim
         (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin nSteps (base + 44) exit
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
-          (let outW := expTwoMulFixedBranchResult bit
-            a0 a1 a2 a3 r0 r1 r2 r3
-          expTwoMulFixedIterPreNWithControlFrame (k + 1) baseWord exponentWord
-            (c6 + signExtend12 (-1 : BitVec 12))
-            (e <<< (1 : BitVec 6).toNat)
-            v6'
-            (expTwoMulIterCountNew iterCount)
-            v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            ptr nextLimb sp evmSp
-            (outW.getLimbN 3)
-            (expTwoMulFixedBranchReturnPc bit base)
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            d0' d1' d2' d3'
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
+          (expTwoMulFixedStepPostBranchPre k baseWord exponentWord
+            iterCount e c6 ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3 base bit
+            v6' v7' v10' v11' d0' d1' d2' d3'
             empAssertion)
           Q)
     (hReload :
@@ -893,24 +797,10 @@ theorem cpsTripleWithin_expTwoMulFixedIterPre_stepPostNWithControlFrame_elim
         (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin nSteps (base + 44) exit
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
-          (let outW := expTwoMulFixedBranchResult bit
-            a0 a1 a2 a3 r0 r1 r2 r3
-          expTwoMulFixedIterPreNWithControlFrame (k + 1) baseWord exponentWord
-            (c6 + signExtend12 (-1 : BitVec 12))
-            (e <<< (1 : BitVec 6).toNat)
-            v6'
-            (expTwoMulIterCountNew iterCount)
-            v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            ptr nextLimb sp evmSp
-            (outW.getLimbN 3)
-            (expTwoMulFixedBranchReturnPc bit base)
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            d0' d1' d2' d3'
-            (outW.getLimbN 0) (outW.getLimbN 1) (outW.getLimbN 2)
-            (outW.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
+          (expTwoMulFixedStepPostBranchPre k baseWord exponentWord
+            iterCount e c6 ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3 base bit
+            v6' v7' v10' v11' d0' d1' d2' d3'
             frame)
           Q)
     (hReload :
@@ -964,47 +854,20 @@ theorem cpsTripleWithin_expTwoMulFixedIterPre_stepPostNWithControl_bit_elim
       ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin nSteps (base + 44) exit
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
-          (let rw := expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3)
-            a0 a1 a2 a3
-          expTwoMulFixedIterPreNWithControlFrame (k + 1) baseWord exponentWord
-            (c6 + signExtend12 (-1 : BitVec 12))
-            (e <<< (1 : BitVec 6).toNat)
-            v6'
-            (expTwoMulIterCountNew iterCount)
-            v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            ptr nextLimb sp evmSp
-            (rw.getLimbN 3)
-            (((base + 44) + 140) + 68)
-            (rw.getLimbN 0) (rw.getLimbN 1) (rw.getLimbN 2)
-            (rw.getLimbN 3)
-            d0' d1' d2' d3'
-            (rw.getLimbN 0) (rw.getLimbN 1) (rw.getLimbN 2)
-            (rw.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
+          (expTwoMulFixedStepPostBranchPre k baseWord exponentWord
+            iterCount e c6 ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3 base true
+            v6' v7' v10' v11' d0' d1' d2' d3'
             empAssertion)
           Q)
     (hBranchFalse :
       ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin nSteps (base + 44) exit
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
-          (let squareW := expSquaringCallSquareW r0 r1 r2 r3
-          expTwoMulFixedIterPreNWithControlFrame (k + 1) baseWord exponentWord
-            (c6 + signExtend12 (-1 : BitVec 12))
-            (e <<< (1 : BitVec 6).toNat)
-            v6'
-            (expTwoMulIterCountNew iterCount)
-            v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            ptr nextLimb sp evmSp
-            (squareW.getLimbN 3)
-            (((base + 44) + 32) + 68)
-            (squareW.getLimbN 0) (squareW.getLimbN 1)
-            (squareW.getLimbN 2) (squareW.getLimbN 3)
-            d0' d1' d2' d3'
-            (squareW.getLimbN 0) (squareW.getLimbN 1)
-            (squareW.getLimbN 2) (squareW.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
+          (expTwoMulFixedStepPostBranchPre k baseWord exponentWord
+            iterCount e c6 ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3 base false
+            v6' v7' v10' v11' d0' d1' d2' d3'
             empAssertion)
           Q)
     (hReloadTrue :
@@ -1073,47 +936,20 @@ theorem cpsTripleWithin_expTwoMulFixedIterPre_stepPostNWithControlFrame_bit_elim
       ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin nSteps (base + 44) exit
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
-          (let rw := expTwoMulCondRw (expSquaringCallSquareW r0 r1 r2 r3)
-            a0 a1 a2 a3
-          expTwoMulFixedIterPreNWithControlFrame (k + 1) baseWord exponentWord
-            (c6 + signExtend12 (-1 : BitVec 12))
-            (e <<< (1 : BitVec 6).toNat)
-            v6'
-            (expTwoMulIterCountNew iterCount)
-            v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            ptr nextLimb sp evmSp
-            (rw.getLimbN 3)
-            (((base + 44) + 140) + 68)
-            (rw.getLimbN 0) (rw.getLimbN 1) (rw.getLimbN 2)
-            (rw.getLimbN 3)
-            d0' d1' d2' d3'
-            (rw.getLimbN 0) (rw.getLimbN 1) (rw.getLimbN 2)
-            (rw.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
+          (expTwoMulFixedStepPostBranchPre k baseWord exponentWord
+            iterCount e c6 ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3 base true
+            v6' v7' v10' v11' d0' d1' d2' d3'
             frame)
           Q)
     (hBranchFalse :
       ∀ (v6' v7' v10' v11' d0' d1' d2' d3' : Word),
         cpsTripleWithin nSteps (base + 44) exit
           (evmExpMsbSavedBitTwoMulFixedCanonicalAppendedMulCode base)
-          (let squareW := expSquaringCallSquareW r0 r1 r2 r3
-          expTwoMulFixedIterPreNWithControlFrame (k + 1) baseWord exponentWord
-            (c6 + signExtend12 (-1 : BitVec 12))
-            (e <<< (1 : BitVec 6).toNat)
-            v6'
-            (expTwoMulIterCountNew iterCount)
-            v10'
-            ((e >>> (63 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12))
-            ptr nextLimb sp evmSp
-            (squareW.getLimbN 3)
-            (((base + 44) + 32) + 68)
-            (squareW.getLimbN 0) (squareW.getLimbN 1)
-            (squareW.getLimbN 2) (squareW.getLimbN 3)
-            d0' d1' d2' d3'
-            (squareW.getLimbN 0) (squareW.getLimbN 1)
-            (squareW.getLimbN 2) (squareW.getLimbN 3)
-            a0 a1 a2 a3 v7' v11'
+          (expTwoMulFixedStepPostBranchPre k baseWord exponentWord
+            iterCount e c6 ptr nextLimb sp evmSp
+            r0 r1 r2 r3 a0 a1 a2 a3 base false
+            v6' v7' v10' v11' d0' d1' d2' d3'
             frame)
           Q)
     (hReloadTrue :


### PR DESCRIPTION
Summary:
- replace repeated EXP step-wrapper branch continuation bodies with expTwoMulFixedStepPostBranchPre
- keep existing proof adapters at the opaque definition boundary

Verification:
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterStep
- lake build EvmAsm.Evm64.Exp
- git diff --check
- scripts/check-file-size.sh EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStep.lean
- rg -n 'set_option maxHeartbeats|set_option maxRecDepth|sorry|admit' EvmAsm/Evm64/Exp/Compose/SavedBitFixedIterStep.lean