### PR TITLE
refactor(exp): add with-state induction frame pre

### DIFF
--- a/EvmAsm/Evm64/Exp.lean
+++ b/EvmAsm/Evm64/Exp.lean
@@ -85,6 +85,7 @@ import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterCount
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedBoolStep
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterState
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterStatePre
+import EvmAsm.Evm64.Exp.Compose.SavedBitFixedInductionFramePre
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterPreNPost
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterStepPost
 import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterStep

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedInductionFramePre.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedInductionFramePre.lean
@@ -1,0 +1,119 @@
+/-
+  EvmAsm.Evm64.Exp.Compose.SavedBitFixedInductionFramePre
+
+  With-state precondition helpers that instantiate the saved-limb induction
+  frame selected by the fixed-loop control counter.
+-/
+
+import EvmAsm.Evm64.Exp.Compose.SavedBitFixedControlFrame
+import EvmAsm.Evm64.Exp.Compose.SavedBitFixedIterStatePre
+
+namespace EvmAsm.Evm64.Exp.Compose
+
+open EvmAsm.Rv64
+
+@[irreducible]
+def expTwoMulFixedIterPreNWithInductionFrame
+    (k : Nat) (baseWord exponentWord : EvmWord)
+    (controlC6 : Word)
+    (e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word) : Assertion :=
+  expTwoMulFixedIterPreNWithStateFrame k baseWord exponentWord controlC6
+    e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+    r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3 v7 v11
+    (expTwoMulFixedInductionFrameN exponentWord k controlC6 ptr)
+
+theorem expTwoMulFixedIterPreNWithInductionFrame_unfold
+    {k : Nat} {baseWord exponentWord : EvmWord} {controlC6 : Word}
+    {e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word} :
+    expTwoMulFixedIterPreNWithInductionFrame k baseWord exponentWord
+      controlC6 e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp
+      tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 =
+    expTwoMulFixedIterPreNWithStateFrame k baseWord exponentWord controlC6
+      e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3 v7 v11
+      (expTwoMulFixedInductionFrameN exponentWord k controlC6 ptr) := by
+  delta expTwoMulFixedIterPreNWithInductionFrame
+  rfl
+
+theorem expTwoMulFixedIterPreNWithInductionFrame_pcFree
+    {k : Nat} {baseWord exponentWord : EvmWord} {controlC6 : Word}
+    {e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word} :
+    (expTwoMulFixedIterPreNWithInductionFrame k baseWord exponentWord
+      controlC6 e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp
+      tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11).pcFree := by
+  rw [expTwoMulFixedIterPreNWithInductionFrame_unfold]
+  pcFree
+
+instance pcFreeInst_expTwoMulFixedIterPreNWithInductionFrame
+    (k : Nat) (baseWord exponentWord : EvmWord) (controlC6 : Word)
+    (e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word) :
+    Assertion.PCFree
+      (expTwoMulFixedIterPreNWithInductionFrame k baseWord exponentWord
+        controlC6 e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+        v7 v11) :=
+  ⟨expTwoMulFixedIterPreNWithInductionFrame_pcFree⟩
+
+theorem expTwoMulFixedIterPreNWithInductionFrame_reload_of_control
+    {k : Nat} {baseWord exponentWord : EvmWord} {controlC6 : Word}
+    {e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word}
+    (hC6 : controlC6 + signExtend12 (-1 : BitVec 12) = 0) :
+    expTwoMulFixedIterPreNWithInductionFrame k baseWord exponentWord
+      controlC6 e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp
+      tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 =
+    expTwoMulFixedIterPreNWithStateFrame k baseWord exponentWord controlC6
+      e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3 v7 v11
+      (expTwoMulFixedReloadTailFrameN exponentWord k ptr) := by
+  rw [expTwoMulFixedIterPreNWithInductionFrame_unfold,
+    expTwoMulFixedInductionFrameN_reload_of_control hC6]
+
+theorem expTwoMulFixedIterPreNWithInductionFrame_pre_reload_of_control
+    {k : Nat} {baseWord exponentWord : EvmWord} {controlC6 : Word}
+    {e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word}
+    (hC6 : (controlC6 + signExtend12 (-1 : BitVec 12)).toNat = 1) :
+    expTwoMulFixedIterPreNWithInductionFrame k baseWord exponentWord
+      controlC6 e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp
+      tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 =
+    expTwoMulFixedIterPreNWithStateFrame k baseWord exponentWord controlC6
+      e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3 v7 v11
+      (expTwoMulFixedPreReloadFrameN exponentWord k ptr) := by
+  rw [expTwoMulFixedIterPreNWithInductionFrame_unfold,
+    expTwoMulFixedInductionFrameN_pre_reload_of_control hC6]
+
+theorem expTwoMulFixedIterPreNWithInductionFrame_ordinary_of_control
+    {k : Nat} {baseWord exponentWord : EvmWord} {controlC6 : Word}
+    {e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word}
+    (hC6 : controlC6 + signExtend12 (-1 : BitVec 12) ≠ 0)
+    (hNotPre : (controlC6 + signExtend12 (-1 : BitVec 12)).toNat ≠ 1) :
+    expTwoMulFixedIterPreNWithInductionFrame k baseWord exponentWord
+      controlC6 e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp
+      tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 =
+    expTwoMulFixedIterPreNWithStateFrame k baseWord exponentWord controlC6
+      e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3 v7 v11
+      (expTwoMulFixedSavedNextLimbFrameN exponentWord k ptr) := by
+  rw [expTwoMulFixedIterPreNWithInductionFrame_unfold,
+    expTwoMulFixedInductionFrameN_ordinary_of_control hC6 hNotPre]
+
+end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- add SavedBitFixedInductionFramePre, a with-state precondition wrapper instantiated with expTwoMulFixedInductionFrameN
- expose pcFree and unfold surfaces for the new precondition
- add reload, pre-reload, and ordinary selector lemmas that lift the induction-frame control cases through expTwoMulFixedIterPreNWithStateFrame

## Verification
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedInductionFramePre
- lake build EvmAsm.Evm64.Exp
- git diff --check
- scripts/check-file-size.sh EvmAsm/Evm64/Exp/Compose/SavedBitFixedInductionFramePre.lean EvmAsm/Evm64/Exp.lean
- scripts/check-unimported.sh
- rg scan for forbidden shortcuts in changed files