### PR TITLE
refactor(exp): case split with-state induction frame

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFixedInductionFramePre.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFixedInductionFramePre.lean
@@ -116,4 +116,51 @@ theorem expTwoMulFixedIterPreNWithInductionFrame_ordinary_of_control
   rw [expTwoMulFixedIterPreNWithInductionFrame_unfold,
     expTwoMulFixedInductionFrameN_ordinary_of_control hC6 hNotPre]
 
+theorem expTwoMulFixedIterPreNWithInductionFrame_step_cases_of_control
+    {k : Nat} {baseWord exponentWord : EvmWord} {controlC6 : Word}
+    {e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp tOld vOld
+      r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3
+      v7 v11 : Word}
+    (hControl :
+      expTwoMulFixedControlInvariant exponentWord k controlC6 ptr
+        nextLimb evmSp) :
+    expTwoMulFixedIterPreNWithInductionFrame k baseWord exponentWord
+        controlC6 e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+        a0 a1 a2 a3 v7 v11 =
+        expTwoMulFixedIterPreNWithStateFrame k baseWord exponentWord
+          controlC6 e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp
+          tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+          a0 a1 a2 a3 v7 v11
+          (expTwoMulFixedReloadTailFrameN exponentWord k ptr) ∨
+      expTwoMulFixedIterPreNWithInductionFrame k baseWord exponentWord
+        controlC6 e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp
+        tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+        a0 a1 a2 a3 v7 v11 =
+        expTwoMulFixedIterPreNWithStateFrame k baseWord exponentWord
+          controlC6 e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp
+          tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+          a0 a1 a2 a3 v7 v11
+          (expTwoMulFixedPreReloadFrameN exponentWord k ptr) ∨
+      (expTwoMulFixedIterPreNWithInductionFrame k baseWord exponentWord
+          controlC6 e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp
+          tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+          a0 a1 a2 a3 v7 v11 =
+          expTwoMulFixedIterPreNWithStateFrame k baseWord exponentWord
+            controlC6 e machineC6 iterCount v10 v18 ptr nextLimb sp evmSp
+            tOld vOld r0 r1 r2 r3 d0 d1 d2 d3 e0 e1 e2 e3
+            a0 a1 a2 a3 v7 v11
+            (expTwoMulFixedSavedNextLimbFrameN exponentWord k ptr) ∧
+        k % 64 < 62) := by
+  rcases expTwoMulFixedControlInvariant_step_cases hControl with
+    hReload | hPre | ⟨hOrd, hNotPre, hMod⟩
+  · exact Or.inl
+      (expTwoMulFixedIterPreNWithInductionFrame_reload_of_control hReload)
+  · exact Or.inr (Or.inl
+      (expTwoMulFixedIterPreNWithInductionFrame_pre_reload_of_control hPre))
+  · exact Or.inr (Or.inr
+      ⟨expTwoMulFixedIterPreNWithInductionFrame_ordinary_of_control
+          hOrd hNotPre,
+        hMod⟩)
+
 end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary
- add a control-invariant case splitter for expTwoMulFixedIterPreNWithInductionFrame
- return the selected WithStateFrame surface for reload, pre-reload, or ordinary saved-next frames
- preserve the ordinary-case k % 64 < 62 fact for recursive no-reload callers

## Verification
- lake build EvmAsm.Evm64.Exp.Compose.SavedBitFixedInductionFramePre
- lake build EvmAsm.Evm64.Exp
- git diff --check
- scripts/check-file-size.sh EvmAsm/Evm64/Exp/Compose/SavedBitFixedInductionFramePre.lean
- rg scan for forbidden shortcuts in SavedBitFixedInductionFramePre.lean