### PR TITLE
refactor(addmod): name phase1 compose post

### DIFF
--- a/EvmAsm/Evm64/AddMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/AddMod/Compose/Base.lean
@@ -398,6 +398,48 @@ def evmAddModPhase1LimbPost (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
   ((sp + 32) ↦ₘ sum0) ** ((sp + 40) ↦ₘ result1) **
   ((sp + 48) ↦ₘ result2) ** ((sp + 56) ↦ₘ result3)
 
+theorem evmAddModPhase1LimbPost_unfold (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    evmAddModPhase1LimbPost sp a0 a1 a2 a3 b0 b1 b2 b3 =
+      (let sum0 := a0 + b0
+       let carry0 := if BitVec.ult sum0 b0 then (1 : Word) else 0
+       let psum1 := a1 + b1
+       let carry1a := if BitVec.ult psum1 b1 then (1 : Word) else 0
+       let result1 := psum1 + carry0
+       let carry1b := if BitVec.ult result1 carry0 then (1 : Word) else 0
+       let carry1 := carry1a ||| carry1b
+       let psum2 := a2 + b2
+       let carry2a := if BitVec.ult psum2 b2 then (1 : Word) else 0
+       let result2 := psum2 + carry1
+       let carry2b := if BitVec.ult result2 carry1 then (1 : Word) else 0
+       let carry2 := carry2a ||| carry2b
+       let psum3 := a3 + b3
+       let carry3a := if BitVec.ult psum3 b3 then (1 : Word) else 0
+       let result3 := psum3 + carry2
+       let carry3b := if BitVec.ult result3 carry2 then (1 : Word) else 0
+       let carry3 := carry3a ||| carry3b
+       (.x12 ↦ᵣ (sp + 32)) **
+       (.x7 ↦ᵣ (carry3 + signExtend12 (0 : BitVec 12))) **
+       (.x6 ↦ᵣ carry3b) ** (.x5 ↦ᵣ carry3) ** (.x11 ↦ᵣ carry3a) **
+       (sp ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ sum0) ** ((sp + 40) ↦ₘ result1) **
+       ((sp + 48) ↦ₘ result2) ** ((sp + 56) ↦ₘ result3)) := by
+  delta evmAddModPhase1LimbPost; rfl
+
+theorem evm_addmod_prologue_phase1_named_spec_within
+    (sp : Word) (base : Word) (modOff : BitVec 21)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word) (v7 v6 v5 v11 : Word) :
+    cpsTripleWithin (30 + 1) base (base + 124)
+      (evm_addmod_program_code base modOff)
+      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7) ** (.x6 ↦ᵣ v6) ** (.x5 ↦ᵣ v5) ** (.x11 ↦ᵣ v11) **
+       (sp ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3))
+      (evmAddModPhase1LimbPost sp a0 a1 a2 a3 b0 b1 b2 b3) :=
+  cpsTripleWithin_weaken
+    (fun h hp => hp)
+    (fun h hp => by simp only [evmAddModPhase1LimbPost_unfold]; exact hp)
+    (evm_addmod_prologue_phase1_spec_within sp base modOff
+      a0 a1 a2 a3 b0 b1 b2 b3 v7 v6 v5 v11)
+
 @[irreducible]
 def evmAddModPhase1Phase2LimbPost (base sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
   let sum0 := a0 + b0


### PR DESCRIPTION
## Summary
- add `evmAddModPhase1LimbPost_unfold` for the existing opaque phase1 ADDMOD postcondition
- add `evm_addmod_prologue_phase1_named_spec_within`, matching the named-post style already used by the phase1+phase2 composition wrapper

## Verification
- `lake build EvmAsm.Evm64.AddMod.Compose.Base`
- `lake build EvmAsm.Evm64.AddMod`
- `lake build EvmAsm.Evm64`
- `git diff --check`
- `rg -n "set_option maxHeartbeats|set_option maxRecDepth|sorry|admit" EvmAsm/Evm64/AddMod/Compose/Base.lean`