### PR TITLE
refactor(calldata): expose size word unfold

### DIFF
--- a/EvmAsm/Evm64/Calldata/SizeSpec.lean
+++ b/EvmAsm/Evm64/Calldata/SizeSpec.lean
@@ -83,7 +83,7 @@ theorem evm_calldatasize_spec_within
 /-- Concretization of `evmWordIs nsp (BitVec.ofNat 256 callDataLen.toNat)`
     as four limb cells: low limb is `callDataLen`, upper three are zero.
     Mirror of `evmWordIs_msize_unfold`. -/
-private theorem evmWordIs_calldatasize_unfold
+theorem evmWordIs_calldatasize_unfold
     (nsp : Word) (callDataLen : Word) :
     evmWordIs nsp (BitVec.ofNat 256 callDataLen.toNat) =
       ((nsp ↦ₘ callDataLen) ** ((nsp + 8) ↦ₘ 0) **


### PR DESCRIPTION
## Summary
- expose evmWordIs_calldatasize_unfold for downstream CALLDATASIZE stack/lift proofs

## Verification
- lake build EvmAsm.Evm64.Calldata.SizeSpec
- lake build EvmAsm.Evm64
- git diff --check
- rg -n "set_option maxHeartbeats|set_option maxRecDepth|sorry" EvmAsm/Evm64/Calldata/SizeSpec.lean (no matches)

Note: lake build EvmAsm.Evm64.Calldata is not a valid target because there is no EvmAsm/Evm64/Calldata.lean umbrella file.