### PR TITLE
refactor(calldata): expose copy offset helpers

### DIFF
--- a/EvmAsm/Evm64/Calldata/CopySpec.lean
+++ b/EvmAsm/Evm64/Calldata/CopySpec.lean
@@ -61,12 +61,12 @@ theorem evm_calldatacopy_preamble_length
   simp [evm_calldatacopy_preamble, LD, ADDI, ADD, single, seq,
     Program.length_append]
 
-private theorem signExtend12_callDataPtrOff :
+theorem signExtend12_callDataPtrOff :
     signExtend12 (BitVec.ofNat 12 callDataPtrOff) =
       BitVec.ofNat 64 callDataPtrOff := by
   rw [signExtend12_ofNat_small (by decide)]
 
-private theorem signExtend12_callDataLenOff :
+theorem signExtend12_callDataLenOff :
     signExtend12 (BitVec.ofNat 12 callDataLenOff) =
       BitVec.ofNat 64 callDataLenOff := by
   rw [signExtend12_ofNat_small (by decide)]


### PR DESCRIPTION
## Summary
- expose CALLDATACOPY preamble offset normalization helpers for calldata pointer and length loads
- keep the existing preamble proof unchanged, just make the helper surface reusable

## Verification
- lake build EvmAsm.Evm64.Calldata.CopySpec
- lake build EvmAsm.Evm64
- git diff --check
- rg -n "set_option maxHeartbeats|set_option maxRecDepth|sorry" EvmAsm/Evm64/Calldata/CopySpec.lean (no matches)