### PR TITLE
refactor(env): expose one-limb program helper

### DIFF
--- a/EvmAsm/Evm64/Env/Program.lean
+++ b/EvmAsm/Evm64/Env/Program.lean
@@ -43,7 +43,7 @@ open SimpleEnvField
 /-- Load and push a single 64-bit limb of the environment field at
     `field.offset + 8 * i` onto the EVM stack slot `8 * i` above the
     new top-of-stack pointer in `x12`. -/
-private def env_one_limb (envBaseReg tmpReg : Reg) (field : SimpleEnvField)
+def env_one_limb (envBaseReg tmpReg : Reg) (field : SimpleEnvField)
     (i : Nat) : Program :=
   LD tmpReg envBaseReg (BitVec.ofNat 12 (field.offset + 8 * i)) ;;
   SD .x12   tmpReg     (BitVec.ofNat 12 (8 * i))


### PR DESCRIPTION
## Summary
- expose env_one_limb so downstream Env opcode proofs can reuse the two-instruction limb block directly
- keep the existing program and length proofs unchanged

## Verification
- lake build EvmAsm.Evm64.Env.Program
- lake build EvmAsm.Evm64
- git diff --check
- rg -n "set_option maxHeartbeats|set_option maxRecDepth|sorry" EvmAsm/Evm64/Env/Program.lean (no matches)

Note: lake build EvmAsm.Evm64.Env is not a valid target because there is no EvmAsm/Evm64/Env.lean umbrella file.