### PR TITLE
refactor(msize): expose word unfold helper

### DIFF
--- a/EvmAsm/Evm64/MSize/Spec.lean
+++ b/EvmAsm/Evm64/MSize/Spec.lean
@@ -74,7 +74,7 @@ theorem evm_msize_spec_within
   EVM execution — gas costs bound `sizeBytes` well below `2^64`).
 -/
 
-private theorem evmWordIs_msize_unfold (nsp : Word) (sizeBytes : Nat)
+theorem evmWordIs_msize_unfold (nsp : Word) (sizeBytes : Nat)
     (h_size_lt : sizeBytes < 2 ^ 64) :
     evmWordIs nsp (BitVec.ofNat 256 sizeBytes) =
       ((nsp ↦ₘ BitVec.ofNat 64 sizeBytes) ** ((nsp + 8) ↦ₘ 0) **


### PR DESCRIPTION
## Summary
- expose evmWordIs_msize_unfold for downstream MSIZE stack/lift proof reuse
- keep the existing MSIZE stack spec and fold lemmas unchanged

## Verification
- lake build EvmAsm.Evm64.MSize.Spec
- lake build EvmAsm.Evm64.MSize
- lake build EvmAsm.Evm64
- git diff --check
- rg -n "set_option maxHeartbeats|set_option maxRecDepth|sorry" EvmAsm/Evm64/MSize/Spec.lean (no matches)