### PR TITLE
refactor(multilimb): expose beq zero helper

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/MultiLimb.lean
+++ b/EvmAsm/Evm64/EvmWordArith/MultiLimb.lean
@@ -61,7 +61,7 @@ theorem halfword_decompose {x : Word} :
 -- rv64_divu Nat-level correctness
 -- ============================================================================
 
-private theorem beq_zero_false {b : Word} (hb : b ≠ 0) : (b == 0#64) = false := by
+theorem beq_zero_false {b : Word} (hb : b ≠ 0) : (b == 0#64) = false := by
   cases h : b == 0#64
   · rfl
   · exfalso; apply hb; exact eq_of_beq h


### PR DESCRIPTION
## Summary
- expose `beq_zero_false` from `EvmWordArith.MultiLimb`
- make the nonzero-divisor branch rewrite reusable for downstream RV64 division proofs

## Verification
- `lake build EvmAsm.Evm64.EvmWordArith.MultiLimb`
- `lake build EvmAsm.Evm64.EvmWordArith`
- `git diff --check`
- `rg -n "set_option maxHeartbeats|set_option maxRecDepth|sorry" EvmAsm/Evm64/EvmWordArith/MultiLimb.lean` (no matches)