### PR TITLE
refactor(divmod): expose div n4 nonzero helpers

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/DivN4Lemmas.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivN4Lemmas.lean
@@ -45,7 +45,7 @@ theorem div_nat_le_one_of_msb (uLo d : Word) (hd : d.toNat ≥ 2^63) :
 -- n=4 shift=0 correctness: q=0 case (a < b)
 -- ============================================================================
 
-private theorem bnz_of_lt {a b : EvmWord} (h : a.toNat < b.toNat) : b ≠ 0 := by
+theorem bnz_of_lt {a b : EvmWord} (h : a.toNat < b.toNat) : b ≠ 0 := by
   intro heq; subst heq; simp at h
 
 /-- When a < b, the quotient is 0. -/
@@ -62,7 +62,7 @@ theorem mod_self_of_lt {a b : EvmWord} (h_lt : a.toNat < b.toNat) :
 -- n=4 shift=0 correctness: q=1 case (b ≤ a < 2*b)
 -- ============================================================================
 
-private theorem bnz_of_lt2 {a b : EvmWord} (h : a.toNat < 2 * b.toNat) : b ≠ 0 := by
+theorem bnz_of_lt2 {a b : EvmWord} (h : a.toNat < 2 * b.toNat) : b ≠ 0 := by
   intro heq; subst heq; simp at h
 
 /-- When b ≤ a < 2b, the quotient is 1. -/


### PR DESCRIPTION
## Summary
- expose `bnz_of_lt` and `bnz_of_lt2` from `EvmWordArith.DivN4Lemmas`
- make the nonzero-divisor facts reusable for downstream q=0/q=1 DivMod proof slices

## Verification
- `lake build EvmAsm.Evm64.EvmWordArith.DivN4Lemmas`
- `lake build EvmAsm.Evm64.EvmWordArith`
- `git diff --check`
- `rg -n "set_option maxHeartbeats|set_option maxRecDepth|sorry" EvmAsm/Evm64/EvmWordArith/DivN4Lemmas.lean` (no matches)