### PR TITLE
refactor(divmod): expose or zero helpers

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/DivLimbBridge.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivLimbBridge.lean
@@ -94,10 +94,10 @@ theorem fromLimbs_ne_zero_of_or {b0 b1 b2 b3 : Word}
 -- EvmWord nonzero ↔ getLimbN OR nonzero
 -- ============================================================================
 
-private theorem or_eq_zero_imp_left {a b : Word} (h : a ||| b = 0) : a = 0 := by
+theorem or_eq_zero_imp_left {a b : Word} (h : a ||| b = 0) : a = 0 := by
   bv_decide
 
-private theorem or_eq_zero_imp_right {a b : Word} (h : a ||| b = 0) : b = 0 := by
+theorem or_eq_zero_imp_right {a b : Word} (h : a ||| b = 0) : b = 0 := by
   bv_decide
 
 /-- An EvmWord is nonzero iff the OR of its four limbs is nonzero.


### PR DESCRIPTION
## Summary
- expose `or_eq_zero_imp_left` and `or_eq_zero_imp_right` from `EvmWordArith.DivLimbBridge`
- make fixed-side OR-zero projections reusable for downstream limb nonzero proofs

## Verification
- `lake build EvmAsm.Evm64.EvmWordArith.DivLimbBridge`
- `lake build EvmAsm.Evm64.EvmWordArith`
- `git diff --check`
- `rg -n "set_option maxHeartbeats|set_option maxRecDepth|sorry" EvmAsm/Evm64/EvmWordArith/DivLimbBridge.lean` (no matches)