### PR TITLE
fix(sdiv): switch implementation to callable v4

### DIFF
--- a/EvmAsm/Evm64/DivMod/Callable.lean
+++ b/EvmAsm/Evm64/DivMod/Callable.lean
@@ -82,6 +82,42 @@ def evm_mod_callable : Program :=
   cc_ret ;;            -- replaces the NOP at the exit slot
   divK_div128
 
+/-- v4 LP64-callable wrapper for `evm_div`, using the corrected
+    `divK_div128_v4` subroutine. -/
+def evm_div_callable_v4 : Program :=
+  divK_phaseA 1020 ;;
+  divK_phaseB ;;
+  divK_clz ;;
+  divK_phaseC2 172 ;;
+  divK_normB ;;
+  divK_normA 40 ;;
+  divK_copyAU ;;
+  divK_loopSetup 464 ;;
+  divK_loopBody 560 7736 ;;
+  divK_denorm ;;
+  divK_div_epilogue 24 ;;
+  divK_zeroPath ;;
+  cc_ret ;;
+  divK_div128_v4
+
+/-- v4 LP64-callable wrapper for `evm_mod`, using the corrected
+    `divK_div128_v4` subroutine. -/
+def evm_mod_callable_v4 : Program :=
+  divK_phaseA 1020 ;;
+  divK_phaseB ;;
+  divK_clz ;;
+  divK_phaseC2 172 ;;
+  divK_normB ;;
+  divK_normA 40 ;;
+  divK_copyAU ;;
+  divK_loopSetup 464 ;;
+  divK_loopBody 560 7736 ;;
+  divK_denorm ;;
+  divK_mod_epilogue 24 ;;
+  divK_zeroPath ;;
+  cc_ret ;;
+  divK_div128_v4
+
 -- ============================================================================
 -- CodeReq abbreviations
 -- ============================================================================
@@ -133,6 +169,44 @@ abbrev evm_mod_callable_code (base : Word) : CodeReq :=
     CodeReq.ofProg (base + zeroPathOff)   divK_zeroPath,
     cc_ret_code   (base + nopOff),                          -- block 12: NOP ↔ cc_ret swap
     CodeReq.ofProg (base + div128Off)     divK_div128
+  ]
+
+/-- 14-block CodeReq layout for `evm_div_callable_v4`. -/
+abbrev evm_div_callable_code_v4 (base : Word) : CodeReq :=
+  CodeReq.unionAll [
+    CodeReq.ofProg  base                  (divK_phaseA 1020),
+    CodeReq.ofProg (base + phaseBOff)     divK_phaseB,
+    CodeReq.ofProg (base + clzOff)        divK_clz,
+    CodeReq.ofProg (base + phaseC2Off)    (divK_phaseC2 172),
+    CodeReq.ofProg (base + normBOff)      divK_normB,
+    CodeReq.ofProg (base + normAOff)      (divK_normA 40),
+    CodeReq.ofProg (base + copyAUOff)     divK_copyAU,
+    CodeReq.ofProg (base + loopSetupOff)  (divK_loopSetup 464),
+    CodeReq.ofProg (base + loopBodyOff)   (divK_loopBody 560 7736),
+    CodeReq.ofProg (base + denormOff)     divK_denorm,
+    CodeReq.ofProg (base + epilogueOff)   (divK_div_epilogue 24),
+    CodeReq.ofProg (base + zeroPathOff)   divK_zeroPath,
+    cc_ret_code   (base + nopOff),
+    CodeReq.ofProg (base + div128Off)     divK_div128_v4
+  ]
+
+/-- 14-block CodeReq layout for `evm_mod_callable_v4`. -/
+abbrev evm_mod_callable_code_v4 (base : Word) : CodeReq :=
+  CodeReq.unionAll [
+    CodeReq.ofProg  base                  (divK_phaseA 1020),
+    CodeReq.ofProg (base + phaseBOff)     divK_phaseB,
+    CodeReq.ofProg (base + clzOff)        divK_clz,
+    CodeReq.ofProg (base + phaseC2Off)    (divK_phaseC2 172),
+    CodeReq.ofProg (base + normBOff)      divK_normB,
+    CodeReq.ofProg (base + normAOff)      (divK_normA 40),
+    CodeReq.ofProg (base + copyAUOff)     divK_copyAU,
+    CodeReq.ofProg (base + loopSetupOff)  (divK_loopSetup 464),
+    CodeReq.ofProg (base + loopBodyOff)   (divK_loopBody 560 7736),
+    CodeReq.ofProg (base + denormOff)     divK_denorm,
+    CodeReq.ofProg (base + epilogueOff)   (divK_mod_epilogue 24),
+    CodeReq.ofProg (base + zeroPathOff)   divK_zeroPath,
+    cc_ret_code   (base + nopOff),
+    CodeReq.ofProg (base + div128Off)     divK_div128_v4
   ]
 
 -- ============================================================================

--- a/EvmAsm/Evm64/SDiv/Compose/Base.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/Base.lean
@@ -29,14 +29,14 @@ theorem sdivCode_wrapper_sub {base : Word} :
     ∀ a i, (EvmAsm.Rv64.CodeReq.ofProg base evm_sdiv_wrapper) a = some i →
       (sdivCode base) a = some i := by
   unfold sdivCode
-  exact EvmAsm.Rv64.CodeReq.ofProg_mono_sub base base evm_sdiv evm_sdiv_wrapper 0
+  exact EvmAsm.Rv64.CodeReq.ofProg_mono_sub base base evm_sdiv_legacy evm_sdiv_wrapper 0
     (EvmAsm.Evm64.SDiv.AddrNorm.wrapperStart_addr base)
-    (by unfold evm_sdiv; simp only [EvmAsm.Rv64.seq, EvmAsm.Rv64.Program]; rfl)
+    (by unfold evm_sdiv_legacy; simp only [EvmAsm.Rv64.seq, EvmAsm.Rv64.Program]; rfl)
     (by
-      rw [evm_sdiv_length, evm_sdiv_wrapper_length]
+      rw [evm_sdiv_legacy_length, evm_sdiv_wrapper_length]
       norm_num)
     (by
-      rw [evm_sdiv_length]
+      rw [evm_sdiv_legacy_length]
       norm_num)
 
 /-- The appended unsigned DIV callable sub-region inside `sdivCode`. -/
@@ -47,10 +47,10 @@ theorem sdivCode_div_callable_sub {base : Word} :
   rw [evm_div_callable_code_eq_ofProg (base + 284)] at h
   unfold sdivCode
   exact EvmAsm.Rv64.CodeReq.ofProg_mono_sub base (base + 284)
-    evm_sdiv evm_div_callable 71
+    evm_sdiv_legacy evm_div_callable 71
     (EvmAsm.Evm64.SDiv.AddrNorm.divCallableStart_addr base)
     (by
-      unfold evm_sdiv EvmAsm.Rv64.seq
+      unfold evm_sdiv_legacy EvmAsm.Rv64.seq
       rw [← evm_sdiv_wrapper_length]
       have h_drop :
           List.drop evm_sdiv_wrapper.length
@@ -61,7 +61,7 @@ theorem sdivCode_div_callable_sub {base : Word} :
       simp only [List.take_length])
     (by native_decide)
     (by
-      rw [evm_sdiv_length]
+      rw [evm_sdiv_legacy_length]
       norm_num)
     a i h
 

--- a/EvmAsm/Evm64/SDiv/Compose/BaseCode.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BaseCode.lean
@@ -12,112 +12,112 @@ theorem sdivCode_saveRa_sub {base : Word} :
     ∀ a i, (saveRaCode base) a = some i → (sdivCode base) a = some i := by
   unfold saveRaCode sdivCode
   exact EvmAsm.Rv64.CodeReq.ofProg_mono_sub base (base + saveRaOff)
-    EvmAsm.Evm64.evm_sdiv (EvmAsm.Evm64.evm_sdiv_save_ra_block .x18) 0
+    EvmAsm.Evm64.evm_sdiv_legacy (EvmAsm.Evm64.evm_sdiv_save_ra_block .x18) 0
     (by simp [saveRaOff])
     (by native_decide)
     (by native_decide)
-    (by rw [EvmAsm.Evm64.evm_sdiv_length]; norm_num)
+    (by rw [EvmAsm.Evm64.evm_sdiv_legacy_length]; norm_num)
 
 theorem sdivCode_dividendSign_sub {base : Word} :
     ∀ a i, (dividendSignCode base) a = some i → (sdivCode base) a = some i := by
   unfold dividendSignCode sdivCode
   exact EvmAsm.Rv64.CodeReq.ofProg_mono_sub base (base + dividendSignOff)
-    EvmAsm.Evm64.evm_sdiv
+    EvmAsm.Evm64.evm_sdiv_legacy
     (EvmAsm.Evm64.evm_sdiv_sign_bit_block .x12 .x8
       EvmAsm.Evm64.evm_sdivDividendTopLimbOff) 1
     (by simp [dividendSignOff])
     (by native_decide)
     (by native_decide)
-    (by rw [EvmAsm.Evm64.evm_sdiv_length]; norm_num)
+    (by rw [EvmAsm.Evm64.evm_sdiv_legacy_length]; norm_num)
 
 theorem sdivCode_divisorSign_sub {base : Word} :
     ∀ a i, (divisorSignCode base) a = some i → (sdivCode base) a = some i := by
   unfold divisorSignCode sdivCode
   exact EvmAsm.Rv64.CodeReq.ofProg_mono_sub base (base + divisorSignOff)
-    EvmAsm.Evm64.evm_sdiv
+    EvmAsm.Evm64.evm_sdiv_legacy
     (EvmAsm.Evm64.evm_sdiv_sign_bit_block .x12 .x9
       EvmAsm.Evm64.evm_sdivDivisorTopLimbOff) 3
     (by simp [divisorSignOff])
     (by native_decide)
     (by native_decide)
-    (by rw [EvmAsm.Evm64.evm_sdiv_length]; norm_num)
+    (by rw [EvmAsm.Evm64.evm_sdiv_legacy_length]; norm_num)
 
 theorem sdivCode_dividendAbs_sub {base : Word} :
     ∀ a i, (dividendAbsCode base) a = some i → (sdivCode base) a = some i := by
   unfold dividendAbsCode sdivCode
   exact EvmAsm.Rv64.CodeReq.ofProg_mono_sub base (base + dividendAbsOff)
-    EvmAsm.Evm64.evm_sdiv
+    EvmAsm.Evm64.evm_sdiv_legacy
     (EvmAsm.Evm64.evm_sdiv_cond_negate_256_block .x12 .x8 .x10 .x7 .x11
       0 8 16 24) 5
     (by simp [dividendAbsOff])
     (by native_decide)
     (by native_decide)
-    (by rw [EvmAsm.Evm64.evm_sdiv_length]; norm_num)
+    (by rw [EvmAsm.Evm64.evm_sdiv_legacy_length]; norm_num)
 
 theorem sdivCode_divisorAbs_sub {base : Word} :
     ∀ a i, (divisorAbsCode base) a = some i → (sdivCode base) a = some i := by
   unfold divisorAbsCode sdivCode
   exact EvmAsm.Rv64.CodeReq.ofProg_mono_sub base (base + divisorAbsOff)
-    EvmAsm.Evm64.evm_sdiv
+    EvmAsm.Evm64.evm_sdiv_legacy
     (EvmAsm.Evm64.evm_sdiv_cond_negate_256_block .x12 .x9 .x10 .x7 .x11
       32 40 48 56) 26
     (by simp [divisorAbsOff])
     (by native_decide)
     (by native_decide)
-    (by rw [EvmAsm.Evm64.evm_sdiv_length]; norm_num)
+    (by rw [EvmAsm.Evm64.evm_sdiv_legacy_length]; norm_num)
 
 theorem sdivCode_signXor_sub {base : Word} :
     ∀ a i, (signXorCode base) a = some i → (sdivCode base) a = some i := by
   unfold signXorCode sdivCode
   exact EvmAsm.Rv64.CodeReq.ofProg_mono_sub base (base + signXorOff)
-    EvmAsm.Evm64.evm_sdiv (EvmAsm.Rv64.XOR' .x8 .x8 .x9) 47
+    EvmAsm.Evm64.evm_sdiv_legacy (EvmAsm.Rv64.XOR' .x8 .x8 .x9) 47
     (by simp [signXorOff])
     (by native_decide)
     (by native_decide)
-    (by rw [EvmAsm.Evm64.evm_sdiv_length]; norm_num)
+    (by rw [EvmAsm.Evm64.evm_sdiv_legacy_length]; norm_num)
 
 theorem sdivCode_divCall_sub {base : Word} :
     ∀ a i, (divCallCode base) a = some i → (sdivCode base) a = some i := by
   unfold divCallCode sdivCode
   exact EvmAsm.Rv64.CodeReq.ofProg_mono_sub base (base + divCallOff)
-    EvmAsm.Evm64.evm_sdiv
+    EvmAsm.Evm64.evm_sdiv_legacy
     (EvmAsm.Evm64.evm_sdiv_div_call_block EvmAsm.Evm64.evm_sdivCallOff) 48
     (by simp [divCallOff])
     (by native_decide)
     (by native_decide)
-    (by rw [EvmAsm.Evm64.evm_sdiv_length]; norm_num)
+    (by rw [EvmAsm.Evm64.evm_sdiv_legacy_length]; norm_num)
 
 theorem sdivCode_resultSignFix_sub {base : Word} :
     ∀ a i, (resultSignFixCode base) a = some i → (sdivCode base) a = some i := by
   unfold resultSignFixCode sdivCode
   exact EvmAsm.Rv64.CodeReq.ofProg_mono_sub base (base + resultSignFixOff)
-    EvmAsm.Evm64.evm_sdiv
+    EvmAsm.Evm64.evm_sdiv_legacy
     (EvmAsm.Evm64.evm_sdiv_cond_negate_256_block .x12 .x8 .x10 .x7 .x11
       0 8 16 24) 49
     (by simp [resultSignFixOff])
     (by native_decide)
     (by native_decide)
-    (by rw [EvmAsm.Evm64.evm_sdiv_length]; norm_num)
+    (by rw [EvmAsm.Evm64.evm_sdiv_legacy_length]; norm_num)
 
 theorem sdivCode_savedRaRet_sub {base : Word} :
     ∀ a i, (savedRaRetCode base) a = some i → (sdivCode base) a = some i := by
   unfold savedRaRetCode sdivCode
   exact EvmAsm.Rv64.CodeReq.ofProg_mono_sub base (base + savedRaRetOff)
-    EvmAsm.Evm64.evm_sdiv (EvmAsm.Evm64.evm_sdiv_saved_ra_ret_block .x18) 70
+    EvmAsm.Evm64.evm_sdiv_legacy (EvmAsm.Evm64.evm_sdiv_saved_ra_ret_block .x18) 70
     (by simp [savedRaRetOff])
     (by native_decide)
     (by native_decide)
-    (by rw [EvmAsm.Evm64.evm_sdiv_length]; norm_num)
+    (by rw [EvmAsm.Evm64.evm_sdiv_legacy_length]; norm_num)
 
 theorem sdivCode_divCallable_sub {base : Word} :
     ∀ a i, (divCallableCode base) a = some i → (sdivCode base) a = some i := by
   unfold divCallableCode sdivCode
   exact EvmAsm.Rv64.CodeReq.ofProg_mono_sub base (base + wrapperEndOff)
-    EvmAsm.Evm64.evm_sdiv EvmAsm.Evm64.evm_div_callable 71
+    EvmAsm.Evm64.evm_sdiv_legacy EvmAsm.Evm64.evm_div_callable 71
     (by simp [wrapperEndOff])
     (by native_decide)
     (by native_decide)
-    (by rw [EvmAsm.Evm64.evm_sdiv_length]; norm_num)
+    (by rw [EvmAsm.Evm64.evm_sdiv_legacy_length]; norm_num)
 
 theorem sdivCode_block_subs {base : Word} :
     (∀ a i, (saveRaCode base) a = some i → (sdivCode base) a = some i) ∧

--- a/EvmAsm/Evm64/SDiv/Compose/CodeHandles.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/CodeHandles.lean
@@ -10,9 +10,9 @@ import EvmAsm.Evm64.SDiv.Compose.BaseOffsets
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-/-- Full SDIV code region handle: wrapper followed by `evm_div_callable`. -/
+/-- Legacy verified SDIV code region handle: wrapper followed by `evm_div_callable`. -/
 abbrev sdivCode (base : Word) : EvmAsm.Rv64.CodeReq :=
-  EvmAsm.Rv64.CodeReq.ofProg base EvmAsm.Evm64.evm_sdiv
+  EvmAsm.Rv64.CodeReq.ofProg base EvmAsm.Evm64.evm_sdiv_legacy
 
 /-- Code handle for the saved-`ra` prologue block. -/
 abbrev saveRaCode (base : Word) : EvmAsm.Rv64.CodeReq :=

--- a/EvmAsm/Evm64/SDiv/Program.lean
+++ b/EvmAsm/Evm64/SDiv/Program.lean
@@ -206,15 +206,29 @@ theorem evm_sdiv_call_target_byte_offset :
     4 * evm_sdiv_wrapper.length := by
   native_decide
 
-/-- Full SDIV code region. The wrapper returns via `x18`; the appended
-    `evm_div_callable` block is reached only by the wrapper's near call. -/
-def evm_sdiv : EvmAsm.Rv64.Program :=
+/-- Legacy verified SDIV code region. The wrapper returns via `x18`; the
+    appended `evm_div_callable` block is reached only by the wrapper's near
+    call. Existing `sdivCode` composition proofs still target this surface
+    until the dispatcher proofs are lifted to the v4 no-NOP code surface. -/
+def evm_sdiv_legacy : EvmAsm.Rv64.Program :=
   evm_sdiv_wrapper ;; evm_div_callable
 
-theorem evm_sdiv_length : evm_sdiv.length = 390 := by
+theorem evm_sdiv_legacy_length : evm_sdiv_legacy.length = 390 := by
   native_decide
 
-theorem evm_sdiv_byte_length : 4 * evm_sdiv.length = 1560 := by
+theorem evm_sdiv_legacy_byte_length : 4 * evm_sdiv_legacy.length = 1560 := by
+  rw [evm_sdiv_legacy_length]
+
+/-- Corrected v4 SDIV code region. This is the same wrapper as `evm_sdiv_legacy`
+    with the appended unsigned divider callable switched to `divK_div128_v4`.
+    This is the exported implementation surface for SDIV. -/
+def evm_sdiv : EvmAsm.Rv64.Program :=
+  evm_sdiv_wrapper ;; evm_div_callable_v4
+
+theorem evm_sdiv_length : evm_sdiv.length = 414 := by
+  native_decide
+
+theorem evm_sdiv_byte_length : 4 * evm_sdiv.length = 1656 := by
   rw [evm_sdiv_length]
 
 example :


### PR DESCRIPTION
## Summary
- add v4 LP64 callable DIV/MOD program and CodeReq surfaces using divK_div128_v4
- switch the exported evm_sdiv program to append the v4 callable body
- keep existing SDIV composition proofs on an explicit evm_sdiv_legacy code surface until the dispatcher proofs are lifted to v4 no-NOP code

## Verification
- lake build EvmAsm.Evm64.DivMod.Callable EvmAsm.Evm64.SDiv.Program
- lake build EvmAsm.Evm64.SDiv
- git diff --check