### PR TITLE
feat(div): add n2 call addback jgt0 no-nop v4 spec

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopIterN2CallAddbackV4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN2CallAddbackV4NoNop.lean
@@ -22,6 +22,21 @@ def loopBodyN2CallAddbackBeqJ0PostV4
   (sp + signExtend12 3936 ↦ₘ scratchOut) **
   regOwn .x1
 
+@[irreducible]
+def loopBodyN2CallAddbackBeqJgt0PostV4
+    (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word) : Assertion :=
+  let dLo := divKTrialCallV4DLo v1
+  let div_un0 := divKTrialCallV4Un0 u1
+  let qHat := divKTrialCallV4QHat u2 u1 v1
+  let scratchOut := divKTrialCallV4ScratchOut u2 u1 v1 scratchMem
+  loopBodyN2AddbackBeqPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+  (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+  (sp + signExtend12 3960 ↦ₘ v1) **
+  (sp + signExtend12 3952 ↦ₘ dLo) **
+  (sp + signExtend12 3944 ↦ₘ div_un0) **
+  (sp + signExtend12 3936 ↦ₘ scratchOut) **
+  regOwn .x1
+
 private theorem divK_loop_body_n2_call_addback_j0_beq_v4_spec_within_noNop
     (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
@@ -136,6 +151,133 @@ private theorem divK_loop_body_n2_call_addback_j0_beq_v4_spec_within_noNop
     (fun h hp => by
       unfold loopBodyN2CallAddbackBeqJ0PostV4
       change (loopBodyN2AddbackBeqPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+        (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+        (sp + signExtend12 3960 ↦ₘ v1) **
+        (sp + signExtend12 3952 ↦ₘ dLo) **
+        (sp + signExtend12 3944 ↦ₘ div_un0) **
+        (sp + signExtend12 3936 ↦ₘ scratchOut) **
+        regOwn .x1) h
+      unfold loopBodyN2AddbackBeqPost loopBodyAddbackBeqPost
+      rw [loopExitPost_unfold]
+      rw [sepConj_assoc'] at hp; xperm_hyp hp)
+    full
+
+/-- No-NOP/v4 loop body cpsTripleWithin for n=2, call+addback, j>0. -/
+theorem divK_loop_body_n2_call_addback_jgt0_beq_v4_spec_within_noNop (j : Word)
+    (hpos : BitVec.slt (j + signExtend12 4095) 0 = false)
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratch_un0 scratchMem : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : BitVec.ult u2 v1)
+    (hborrow : (if BitVec.ult uTop
+        (mulsubN4 (divKTrialCallV4QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2
+      then (1 : Word) else 0) ≠ (0 : Word))
+    (hcarry2_nz :
+      let qHat := divKTrialCallV4QHat u2 u1 v1
+      let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+      let c3 := ms.2.2.2.2
+      let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
+      let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
+      carry = 0 → addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0) :
+    let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+    let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
+    cpsTripleWithin 224 (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCodeNoNop_v4 base)
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
+       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
+       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
+       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
+       (qAddr ↦ₘ qOld) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
+       (sp + signExtend12 3944 ↦ₘ scratch_un0) **
+       (sp + signExtend12 3936 ↦ₘ scratchMem) ** regOwn .x1)
+      (loopBodyN2CallAddbackBeqJgt0PostV4 sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem) := by
+  intro uBase qAddr
+  let dHi := divKTrialCallV4DHi v1
+  let dLo := divKTrialCallV4DLo v1
+  let div_un0 := divKTrialCallV4Un0 u1
+  let q1'' := divKTrialCallV4Q1dd u2 u1 v1
+  let q0'' := divKTrialCallV4Q0dd u2 u1 v1
+  let x7Exit := divKTrialCallV4X7Exit u2 u1 v1
+  let x9Exit := divKTrialCallV4X9Exit u2 u1 v1
+  let qHat := divKTrialCallV4QHat u2 u1 v1
+  let scratchOut := divKTrialCallV4ScratchOut u2 u1 v1 scratchMem
+  have TF := divK_trial_call_full_v4_spec_within_noNop sp j (2 : Word)
+    jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    u2 u1 v1 retMem dMem dloMem scratch_un0 scratchMem base
+    halign hbltu
+  unfold divKTrialCallFullPostV4 at TF
+  dsimp only [] at TF
+  rw [u_addr_eq_n2] at TF
+  rw [u_addr8_eq_n2] at TF
+  rw [vtop_eq_v1_n2] at TF
+  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+  let c3 := ms.2.2.2.2
+  let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
+  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
+  let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
+  let q_out := if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
+               else qHat + signExtend12 4095
+  let un0Out := if carry = 0 then ab'.1 else ab.1
+  let un1Out := if carry = 0 then ab'.2.1 else ab.2.1
+  let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
+  let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
+  let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
+  let carryOut := if carry = 0 then
+      addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
+    else carry
+  have MCA := divK_mulsub_correction_addback_beq_v4_spec_within_noNop
+    sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    x9Exit q0'' dHi x7Exit q1'' (base + div128CallRetOff) base
+  intro_lets at MCA
+  have hcarry2_nz' :
+      carry = 0 →
+        addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0 := by
+    dsimp only [] at hcarry2_nz
+    exact hcarry2_nz
+  have MCA0 := MCA hcarry2_nz' hborrow
+  have MCA0f := cpsTripleWithin_frameR ((sp + signExtend12 3936 ↦ₘ scratchOut) ** regOwn .x1)
+    (by pcFree) MCA0
+  have SL := divK_store_loop_jgt0_v4_spec_within_noNop sp j q_out u4_out carryOut qOld base hpos
+  intro_lets at SL
+  have TFf := cpsTripleWithin_frameR
+    (((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
+     (qAddr ↦ₘ qOld))
+    (by pcFree) TF
+  seqFrame TFf MCA0f
+  have SLf := cpsTripleWithin_frameR
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
+     (sp + signExtend12 3976 ↦ₘ j) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0Out) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1Out) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2Out) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3Out) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_out) **
+     (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
+     (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+     (sp + signExtend12 3960 ↦ₘ v1) **
+     (sp + signExtend12 3952 ↦ₘ dLo) **
+     (sp + signExtend12 3944 ↦ₘ div_un0) **
+     (sp + signExtend12 3936 ↦ₘ scratchOut) ** regOwn .x1)
+    (by pcFree) SL
+  have full := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0f SLf
+  exact cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by
+      unfold loopBodyN2CallAddbackBeqJgt0PostV4
+      change (loopBodyN2AddbackBeqPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
         (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
         (sp + signExtend12 3960 ↦ₘ v1) **
         (sp + signExtend12 3952 ↦ₘ dLo) **

--- a/EvmAsm/Evm64/DivMod/LoopIterN2CallAddbackV4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN2CallAddbackV4NoNop.lean
@@ -163,7 +163,7 @@ private theorem divK_loop_body_n2_call_addback_j0_beq_v4_spec_within_noNop
     full
 
 /-- No-NOP/v4 loop body cpsTripleWithin for n=2, call+addback, j>0. -/
-theorem divK_loop_body_n2_call_addback_jgt0_beq_v4_spec_within_noNop (j : Word)
+private theorem divK_loop_body_n2_call_addback_jgt0_beq_v4_spec_within_noNop (j : Word)
     (hpos : BitVec.slt (j + signExtend12 4095) 0 = false)
     (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)


### PR DESCRIPTION
## Summary
- add the v4/no-NOP N2 call-addback j>0 postcondition wrapper
- prove divK_loop_body_n2_call_addback_jgt0_beq_v4_spec_within_noNop
- stack on the N2 call-addback j=0 v4 slice

## Verification
- lake build EvmAsm.Evm64.DivMod.LoopIterN2CallAddbackV4NoNop
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- rg -n "sorry|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/LoopIterN2CallAddbackV4NoNop.lean