### PR TITLE
feat(stateless): scaffold run_stateless_guest module tree (PR1)

### DIFF
--- a/EvmAsm.lean
+++ b/EvmAsm.lean
@@ -2,4 +2,5 @@ import EvmAsm.Rv64
 import EvmAsm.Evm64
 import EvmAsm.EL
 import EvmAsm.Codegen
+import EvmAsm.Stateless
 import EvmAsm.Progress

--- a/EvmAsm/Stateless.lean
+++ b/EvmAsm/Stateless.lean
@@ -1,0 +1,17 @@
+/-
+  EvmAsm.Stateless
+
+  Umbrella for the `run_stateless_guest` port of
+  `execution-specs/src/ethereum/forks/amsterdam/stateless_guest.py`.
+
+  PR1 (this commit): minimal compiling scaffold (memory layout +
+  Unimplemented exit + top-level Entry stub + placeholder spec).
+  Follow-up PRs flesh out the sub-trees listed in the plan file
+  (`SSZ/`, `Headers/`, `Witness/`, `State/`, `ExecutionEngine/`,
+  `Block/`, `Transaction/`, `VM/`, `Bridges/`).
+-/
+
+import EvmAsm.Stateless.MemoryLayout
+import EvmAsm.Stateless.Unimplemented
+import EvmAsm.Stateless.Entry
+import EvmAsm.Stateless.EntrySpec

--- a/EvmAsm/Stateless/Entry.lean
+++ b/EvmAsm/Stateless/Entry.lean
@@ -1,0 +1,73 @@
+/-
+  EvmAsm.Stateless.Entry
+
+  Top-level `run_stateless_guest` Program. Mirrors the Python
+  `execution-specs/src/ethereum/forks/amsterdam/stateless_guest.py:33`
+  entry point, but with the body stubbed to `unimplemented_exit
+  REASON_STF_BODY` until the SSZ codec, header validator, MPT walker,
+  and EVM interpreter land in subsequent PRs.
+
+  Once `Stateless.SSZ.Decode`, `Stateless.SSZ.Encode`,
+  `Stateless.Headers`, `Stateless.Witness`, `Stateless.Block`,
+  `Stateless.Transaction`, and `Stateless.VM` are populated, this file
+  will compose them in the canonical order:
+
+  ```
+  read_input from INPUT_ADDR + INPUT_DATA_OFFSET
+      |
+      v
+  Stateless.SSZ.Decode.deserialize_stateless_input
+      |
+      v
+  Stateless.Headers.validate_headers
+      |
+      v
+  Stateless.Witness.{NodeDb,CodeDb}.build
+      |
+      v
+  Stateless.ExecutionEngine.execute_new_payload_request
+      | (recursively into Block / Transaction / VM)
+      v
+  Stateless.SSZ.Encode.serialize_stateless_output
+      |
+      v
+  write_output to OUTPUT_ADDR + 0
+      |
+      v
+  HALT
+  ```
+
+  ## Memory layout (preconditions)
+  - `INPUT_ADDR + INPUT_DATA_OFFSET` holds the host-supplied
+    SSZ-encoded `SszStatelessInput`.
+  - All RAM in `STATELESS_WORK_BASE .. STATELESS_WORK_BASE + 0x20000000`
+    is available for scratch (see `MemoryLayout.lean`).
+
+  ## Side effects (postconditions when fully implemented)
+  - Writes the SSZ encoding of `StatelessValidationResult` to
+    `OUTPUT_ADDR + 0..N`.
+  - Halts with `t0 = 0`.
+
+  Current PR1 stub: jumps straight to `unimplemented_exit` with
+  `REASON_STF_BODY` so the build wires together and the codegen path
+  produces a runnable ELF whose output marker can be diffed by the
+  Python harness.
+-/
+
+import EvmAsm.Rv64.Program
+import EvmAsm.Stateless.MemoryLayout
+import EvmAsm.Stateless.Unimplemented
+
+namespace EvmAsm.Stateless
+
+open EvmAsm.Rv64
+
+/-- PR1 stub: load `REASON_STF_BODY` into `a0` and fall through to
+    `unimplemented_exit`. The whole stateless guest body is one
+    `LI` instruction followed by the 6-instruction `unimplemented_exit`
+    sequence. -/
+def run_stateless_guest : Program :=
+  LI .x10 REASON_STF_BODY ;;
+  unimplemented_exit
+
+end EvmAsm.Stateless

--- a/EvmAsm/Stateless/EntrySpec.lean
+++ b/EvmAsm/Stateless/EntrySpec.lean
@@ -1,0 +1,27 @@
+/-
+  EvmAsm.Stateless.EntrySpec
+
+  Placeholder for the top-level `cpsTripleWithin` spec of
+  `Stateless.Entry.run_stateless_guest`.
+
+  Final form (post all PRs):
+    given an SSZ-encoded `SszStatelessInput` on `INPUT_ADDR`,
+    `run_stateless_guest` reaches HALT and the bytes on `OUTPUT_ADDR`
+    equal the SSZ encoding of the Python reference's
+    `verify_stateless_new_payload` output.
+
+  PR1 form (current): no spec; the body is `unimplemented_exit`. The
+  spec will be added in lock-step with the SSZ codec PR.
+
+  TODO(stateless-proofs): per-module cpsTripleWithin specs feed into
+  this top-level statement. See `EvmAsm/Stateless/MemoryLayout.lean`
+  for the memory contract.
+-/
+
+import EvmAsm.Stateless.Entry
+
+namespace EvmAsm.Stateless
+
+-- TODO(stateless-proofs): theorem run_stateless_guest_spec : ...
+
+end EvmAsm.Stateless

--- a/EvmAsm/Stateless/MemoryLayout.lean
+++ b/EvmAsm/Stateless/MemoryLayout.lean
@@ -14,17 +14,26 @@
 
   ## Top-level map (RV64IM, ZisK host-IO compatible)
 
+  Authoritative ziskemu addresses (see `EvmAsm/Codegen/Driver.lean:68-82`
+  for the linker flags and `EvmAsm/Codegen/Programs.lean` for the
+  `INPUT_ADDR`/`OUTPUT_ADDR` constants):
+
   ```
-  0x00000020 .. 0x40000000   .text + .rodata + .bss
+  0x00000020 .. 0x78000000   verified `isValidMemAddr` range
+                             (see `EvmAsm/Rv64/Basic.lean:244,247`)
   0x40000000 .. 0x40002000   INPUT_ADDR  (8 KiB, host-supplied SSZ input)
                                [+ 0..8]   ZisK metadata (zero)
                                [+ 8..16]  LE u64 length of first record
                                [+16..]    SSZ-encoded SszStatelessInput
-  0x80000000 .. 0xa0000000   working RAM (decoded structures, DBs, frames)
+  0x80000000 .. 0xa0000000   .text + .rodata + .bss (ELF `-Ttext=0x80000000`)
+  0xa0000000 .. 0xa0010000   .data (`-Tdata=0xa0000000`; small operand
+                             seeds for existing build units)
   0xa0010000 .. 0xa0020000   OUTPUT_ADDR (64 KiB, public output)
                                [+ 0..N]   SSZ-encoded
                                           SszStatelessValidationResult
-  0xa0020000 .. 0xc0000000   spare RAM
+  0xa0020000 .. 0xc0000000   working RAM (decoded structures, DBs,
+                             frames) -- the Stateless guest claims this
+                             tail of ziskemu's RAM region.
   ```
 
   `INPUT_ADDR`, `INPUT_DATA_OFFSET`, and `OUTPUT_ADDR` mirror the
@@ -32,26 +41,40 @@
   numeric values here -- the working-RAM sub-region anchors below are
   the new contribution.
 
-  ## Working-RAM sub-regions (0x80000000 .. 0xa0000000)
+  Note: the verified-side `isValidMemAddr` range
+  (`0x20..0x78000000`) does **not** cover ziskemu's RAM at
+  `0xa0000000..0xc0000000`. This is the same gap that the existing
+  `evm_add` build unit already lives with (it writes `.data` at
+  `0xa0000000` and `OUTPUT_ADDR` at `0xa0010000`, both outside
+  `isValidMemAddr`). Future proof PRs will have to relax the
+  verified memory predicate or introduce a second memory region;
+  out of scope for the Stateless guest scaffold.
+
+  ## Working-RAM sub-regions (0xa0020000 .. 0xc0000000)
 
   Each anchor is the start of a region whose size is sized at codegen
   time. Sizes will be tightened as modules land; for now we reserve
   generous slabs so successive PRs do not have to reflow addresses.
+  Total reserved through `SHA256_SCRATCH` end is ~28 MiB; ziskemu's
+  RAM region carries ~512 MiB of headroom past `0xa0020000`.
 
   | Anchor                       | Address          | Size budget |
   |------------------------------|------------------|-------------|
-  | `STATELESS_WORK_BASE`        | `0x80000000`     | base ref    |
-  | `SSZ_INPUT_DECODED`          | `0x80000000`     | 64 KiB      |
-  | `EXECUTION_WITNESS_AREA`     | `0x80010000`     | 1 MiB       |
-  | `NODE_DB_BUCKETS`            | `0x80110000`     | 4 MiB       |
-  | `CODE_DB_BUCKETS`            | `0x80510000`     | 1 MiB       |
-  | `STATE_TRACKER_AREA`         | `0x80610000`     | 4 MiB       |
-  | `EVM_FRAME_STACK`            | `0x80a10000`     | 256 KiB     |
-  | `EVM_VALUE_STACK`            | `0x80a50000`     | 1 MiB       |
-  | `EVM_MEMORY_AREA`            | `0x80b50000`     | 16 MiB      |
-  | `KECCAK_SCRATCH`             | `0x81b50000`     | 64 KiB      |
-  | `ECRECOVER_SCRATCH`          | `0x81b60000`     | 64 KiB      |
-  | `SHA256_SCRATCH`             | `0x81b70000`     | 64 KiB      |
+  | `STATELESS_WORK_BASE`        | `0xa0020000`     | base ref    |
+  | `SSZ_INPUT_DECODED`          | `0xa0020000`     | 64 KiB      |
+  | `EXECUTION_WITNESS_AREA`     | `0xa0030000`     | 1 MiB       |
+  | `NODE_DB_BUCKETS`            | `0xa0130000`     | 4 MiB       |
+  | `CODE_DB_BUCKETS`            | `0xa0530000`     | 1 MiB       |
+  | `STATE_TRACKER_AREA`         | `0xa0630000`     | 4 MiB       |
+  | `EVM_FRAME_STACK`            | `0xa0a30000`     | 256 KiB     |
+  | `EVM_VALUE_STACK`            | `0xa0a70000`     | 1 MiB       |
+  | `EVM_MEMORY_AREA`            | `0xa0b70000`     | 16 MiB      |
+  | `KECCAK_SCRATCH`             | `0xa1b70000`     | 64 KiB      |
+  | `ECRECOVER_SCRATCH`          | `0xa1b80000`     | 64 KiB      |
+  | `SHA256_SCRATCH`             | `0xa1b90000`     | 64 KiB      |
+
+  (`EVM_MEMORY_AREA` budget is per-frame nominal; with max call depth
+  1024 the precise per-frame slicing is tracked in `Stateless/VM/`.)
 
   ## Calling convention (non-leaf stateless code)
 
@@ -79,17 +102,17 @@ open EvmAsm.Rv64
 
 /-! ## Working-RAM anchors (see table above). -/
 
-def STATELESS_WORK_BASE     : Word := 0x80000000
-def SSZ_INPUT_DECODED       : Word := 0x80000000
-def EXECUTION_WITNESS_AREA  : Word := 0x80010000
-def NODE_DB_BUCKETS         : Word := 0x80110000
-def CODE_DB_BUCKETS         : Word := 0x80510000
-def STATE_TRACKER_AREA      : Word := 0x80610000
-def EVM_FRAME_STACK         : Word := 0x80a10000
-def EVM_VALUE_STACK         : Word := 0x80a50000
-def EVM_MEMORY_AREA         : Word := 0x80b50000
-def KECCAK_SCRATCH          : Word := 0x81b50000
-def ECRECOVER_SCRATCH       : Word := 0x81b60000
-def SHA256_SCRATCH          : Word := 0x81b70000
+def STATELESS_WORK_BASE     : Word := 0xa0020000
+def SSZ_INPUT_DECODED       : Word := 0xa0020000
+def EXECUTION_WITNESS_AREA  : Word := 0xa0030000
+def NODE_DB_BUCKETS         : Word := 0xa0130000
+def CODE_DB_BUCKETS         : Word := 0xa0530000
+def STATE_TRACKER_AREA      : Word := 0xa0630000
+def EVM_FRAME_STACK         : Word := 0xa0a30000
+def EVM_VALUE_STACK         : Word := 0xa0a70000
+def EVM_MEMORY_AREA         : Word := 0xa0b70000
+def KECCAK_SCRATCH          : Word := 0xa1b70000
+def ECRECOVER_SCRATCH       : Word := 0xa1b80000
+def SHA256_SCRATCH          : Word := 0xa1b90000
 
 end EvmAsm.Stateless

--- a/EvmAsm/Stateless/MemoryLayout.lean
+++ b/EvmAsm/Stateless/MemoryLayout.lean
@@ -1,0 +1,95 @@
+/-
+  EvmAsm.Stateless.MemoryLayout
+
+  Single source of truth for the address-space layout used by the
+  stateless-guest port of `run_stateless_guest`
+  (`execution-specs/src/ethereum/forks/amsterdam/stateless_guest.py`).
+
+  All RISC-V modules under `EvmAsm/Stateless/` agree on the constants
+  declared here. Treat this file as the contract: any new module must
+  document, in its file header, which regions it reads, writes, and
+  leaves untouched, plus which exit ECALLs it can take. Mirrors the
+  "memory layout + side effects" convention already used by
+  `EvmAsm/Evm64/DivMod/AddrNorm.lean` and the Keccak ECALL bridge.
+
+  ## Top-level map (RV64IM, ZisK host-IO compatible)
+
+  ```
+  0x00000020 .. 0x40000000   .text + .rodata + .bss
+  0x40000000 .. 0x40002000   INPUT_ADDR  (8 KiB, host-supplied SSZ input)
+                               [+ 0..8]   ZisK metadata (zero)
+                               [+ 8..16]  LE u64 length of first record
+                               [+16..]    SSZ-encoded SszStatelessInput
+  0x80000000 .. 0xa0000000   working RAM (decoded structures, DBs, frames)
+  0xa0010000 .. 0xa0020000   OUTPUT_ADDR (64 KiB, public output)
+                               [+ 0..N]   SSZ-encoded
+                                          SszStatelessValidationResult
+  0xa0020000 .. 0xc0000000   spare RAM
+  ```
+
+  `INPUT_ADDR`, `INPUT_DATA_OFFSET`, and `OUTPUT_ADDR` mirror the
+  constants in `EvmAsm/Codegen/Programs.lean`; do not duplicate the
+  numeric values here -- the working-RAM sub-region anchors below are
+  the new contribution.
+
+  ## Working-RAM sub-regions (0x80000000 .. 0xa0000000)
+
+  Each anchor is the start of a region whose size is sized at codegen
+  time. Sizes will be tightened as modules land; for now we reserve
+  generous slabs so successive PRs do not have to reflow addresses.
+
+  | Anchor                       | Address          | Size budget |
+  |------------------------------|------------------|-------------|
+  | `STATELESS_WORK_BASE`        | `0x80000000`     | base ref    |
+  | `SSZ_INPUT_DECODED`          | `0x80000000`     | 64 KiB      |
+  | `EXECUTION_WITNESS_AREA`     | `0x80010000`     | 1 MiB       |
+  | `NODE_DB_BUCKETS`            | `0x80110000`     | 4 MiB       |
+  | `CODE_DB_BUCKETS`            | `0x80510000`     | 1 MiB       |
+  | `STATE_TRACKER_AREA`         | `0x80610000`     | 4 MiB       |
+  | `EVM_FRAME_STACK`            | `0x80a10000`     | 256 KiB     |
+  | `EVM_VALUE_STACK`            | `0x80a50000`     | 1 MiB       |
+  | `EVM_MEMORY_AREA`            | `0x80b50000`     | 16 MiB      |
+  | `KECCAK_SCRATCH`             | `0x81b50000`     | 64 KiB      |
+  | `ECRECOVER_SCRATCH`          | `0x81b60000`     | 64 KiB      |
+  | `SHA256_SCRATCH`             | `0x81b70000`     | 64 KiB      |
+
+  ## Calling convention (non-leaf stateless code)
+
+  The existing opcode handlers are leaf functions. The stateless guest
+  is deeply nested, so non-leaf code in `EvmAsm/Stateless/` follows a
+  standard RV64 ABI:
+
+  - `x1 (ra)`           : return address
+  - `x2 (sp)`           : RV64 call stack pointer (distinct from EVM
+                          value-stack `x12`)
+  - `x10..x17 (a0..a7)` : args / returns
+  - `x12`               : EVM value-stack pointer (preserved across
+                          opcode handler calls, saved/restored at
+                          message-frame boundaries)
+  - `x18..x27 (s2..s11)`: callee-saved
+  - Each non-leaf entry sets up an explicit `sp` adjust; the per-module
+    frame size is documented at the top of that module's `Program.lean`.
+-/
+
+import EvmAsm.Rv64.Basic
+
+namespace EvmAsm.Stateless
+
+open EvmAsm.Rv64
+
+/-! ## Working-RAM anchors (see table above). -/
+
+def STATELESS_WORK_BASE     : Word := 0x80000000
+def SSZ_INPUT_DECODED       : Word := 0x80000000
+def EXECUTION_WITNESS_AREA  : Word := 0x80010000
+def NODE_DB_BUCKETS         : Word := 0x80110000
+def CODE_DB_BUCKETS         : Word := 0x80510000
+def STATE_TRACKER_AREA      : Word := 0x80610000
+def EVM_FRAME_STACK         : Word := 0x80a10000
+def EVM_VALUE_STACK         : Word := 0x80a50000
+def EVM_MEMORY_AREA         : Word := 0x80b50000
+def KECCAK_SCRATCH          : Word := 0x81b50000
+def ECRECOVER_SCRATCH       : Word := 0x81b60000
+def SHA256_SCRATCH          : Word := 0x81b70000
+
+end EvmAsm.Stateless

--- a/EvmAsm/Stateless/Unimplemented.lean
+++ b/EvmAsm/Stateless/Unimplemented.lean
@@ -1,0 +1,84 @@
+/-
+  EvmAsm.Stateless.Unimplemented
+
+  The stateless-guest port reaches `unimplemented_exit` whenever it
+  encounters a code path that has not been implemented yet -- most
+  notably every EVM precompile, every cryptographic operation we haven't
+  routed through an ECALL bridge yet, and every transaction-type
+  variant outside the current scope.
+
+  Distinct from HALT (t0 = 0): we use t0 = 0x10 (write_output) to
+  surface a 32-byte marker on `OUTPUT_ADDR`, then halt. The marker is
+  `0xFE` repeated 8 times to make Unimplemented exits easy to spot
+  in a hex dump and distinguishable from a normal SSZ
+  `StatelessValidationResult` (the first byte of a normal
+  `new_payload_request_root` is unconstrained, but the full 8-byte
+  `0xFE..FE` prefix has negligible collision probability).
+
+  This is also distinct from a normal validation failure
+  (`successful_validation = false`): "Unimplemented" means the
+  RISC-V code refused to even *try* to validate the input, whereas
+  `successful_validation = false` means the RISC-V code attempted
+  validation and detected a problem.
+
+  Reason codes (the second 8-byte word in the marker is the reason
+  code, written by the caller before invoking `unimplemented_exit`):
+
+  | Reason | Code | Meaning |
+  |---|---|---|
+  | `PRECOMPILE`           | 0x01 | precompile dispatch (a0 holds addr 0x01..0x14) |
+  | `TX_TYPE_UNSUPPORTED`  | 0x02 | unsupported transaction envelope |
+  | `EIP7702_DELEGATION`   | 0x03 | SetCodeTransaction delegation |
+  | `EIP4844_BLOB`         | 0x04 | blob-tx handling |
+  | `EIP7609_BAL`          | 0x05 | block access list generation |
+  | `WITNESS_MISSING_NODE` | 0x06 | MPT walk hit a missing witness node |
+  | `STATE_ROOT_MISMATCH`  | 0x07 | recomputed state root != header |
+  | `STF_BODY`             | 0x08 | the STF body itself is not yet implemented |
+
+  ## Memory it reads / writes
+  - reads:  caller-supplied reason code via `x10 (a0)`
+  - writes: 32 bytes to `OUTPUT_ADDR + 0..32`
+  - exits:  `ECALL` with `t0 = 0` (HALT)
+-/
+
+import EvmAsm.Rv64.Program
+import EvmAsm.Stateless.MemoryLayout
+
+namespace EvmAsm.Stateless
+
+open EvmAsm.Rv64
+
+/-! ## Reason codes (see table above). -/
+
+def REASON_PRECOMPILE           : Word := 0x01
+def REASON_TX_TYPE_UNSUPPORTED  : Word := 0x02
+def REASON_EIP7702_DELEGATION   : Word := 0x03
+def REASON_EIP4844_BLOB         : Word := 0x04
+def REASON_EIP7609_BAL          : Word := 0x05
+def REASON_WITNESS_MISSING_NODE : Word := 0x06
+def REASON_STATE_ROOT_MISMATCH  : Word := 0x07
+def REASON_STF_BODY             : Word := 0x08
+
+/-- Address of the public-output region. Mirrors
+    `EvmAsm.Codegen.OUTPUT_ADDR = 0xa0010000`. Duplicated here so
+    `EvmAsm/Stateless/*` does not pull in the codegen umbrella. -/
+def UNIMPL_OUTPUT_ADDR : Word := 0xa0010000
+
+/-- The 8-byte 0xFE.. marker stored at `OUTPUT_ADDR + 0`. -/
+def UNIMPL_MARKER : Word := 0xFEFEFEFEFEFEFEFE
+
+/-- Emit an Unimplemented exit. Caller passes the reason code in `a0`
+    (`x10`). The body writes the 0xFE marker at `OUTPUT_ADDR + 0`,
+    the reason code at `OUTPUT_ADDR + 8`, then halts with `t0 = 0`.
+
+    Frame: 6 instructions. Side effects: writes 16 bytes to
+    `OUTPUT_ADDR`, sets `t0 = 0`, then `ECALL`. Does not return. -/
+def unimplemented_exit : Program :=
+  LI .x6  UNIMPL_OUTPUT_ADDR ;;
+  LI .x7  UNIMPL_MARKER ;;
+  SD .x6 .x7 0 ;;
+  SD .x6 .x10 8 ;;
+  LI .x5 0 ;;
+  ECALL
+
+end EvmAsm.Stateless

--- a/PLAN.md
+++ b/PLAN.md
@@ -945,6 +945,52 @@ This is the heart of the STF — the inner loop that executes EVM bytecode.
 
 ---
 
+## Stateless Guest (parallel STF track)
+
+Full plan: `~/.claude/plans/please-cut-a-branch-warm-wand.md`.
+Branch: `feat/run-stateless-guest-scaffold`.
+
+Stakeholders asked for `run_stateless_guest`
+(`execution-specs/src/ethereum/forks/amsterdam/stateless_guest.py:33`)
+to be implemented in RV64IM macro-assembly **early**, so testing can
+start before the proof effort catches up. Lands in a multi-PR sequence
+under `EvmAsm/Stateless/`. Each module ships with a `Program.lean` and
+a `Spec.lean` placeholder so CPS-triple proofs slot in later without
+restructuring. Precompiles raise a distinct `Unimplemented` exit code
+(0xFE marker at `OUTPUT_ADDR`); KECCAK256, ECRECOVER, SHA256, etc. go
+through ECALL bridges (extending `EvmAsm/EL/Keccak*EcallBridge.lean`).
+
+### PR sequence
+
+| PR | Scope | First fixture that passes |
+|---|---|---|
+| PR1 | Scaffold + `Unimplemented` exit + `Entry` stub | `empty_witness` (Unimplemented marker round-trip) |
+| PR2 | SSZ decode/encode + roundtrip script | `empty_witness` (false-validation roundtrip) |
+| PR3 | Headers RLP decode + validate + Witness DBs | `single_header`, `chain_3_headers` |
+| PR4 | MPT walk + read-side WitnessState | `mpt_one_account` |
+| PR5 | SSZ `hash_tree_root` + SHA256 bridge | `compute_new_payload_request_root` |
+| PR6 | Block + Transaction + ECRECOVER bridge | `tx_transfer` |
+| PR7 | EVM interpreter dispatch + opcode wiring | `bytecode_push_add` |
+| PR8+ | Remaining opcodes, MPT mutation, state-root | tracked under Phase 5–11 above |
+
+### Status
+
+- ✅ PR1 scaffold committed: `EvmAsm/Stateless/` with
+  `MemoryLayout.lean`, `Unimplemented.lean`, `Entry.lean`,
+  `EntrySpec.lean`, and the `Stateless.lean` umbrella. `Entry`'s body
+  is one `LI` + `unimplemented_exit`, so the codegen path is live but
+  every input lands on the 0xFE marker.
+
+### Cross-references
+
+- Memory layout: `EvmAsm/Stateless/MemoryLayout.lean`.
+- Reason codes (precompile, EIP-7702, EIP-4844, etc.):
+  `EvmAsm/Stateless/Unimplemented.lean`.
+- SDIV blocker (`evm-asm-9iqmw`) does **not** block this track —
+  fixtures avoiding SDIV are picked first.
+
+---
+
 ## Priority Order
 
 **Immediate (recreate deleted specs) — ✅ ALL DONE:**


### PR DESCRIPTION
## Summary

- First PR in a multi-PR series porting `run_stateless_guest`
  (`execution-specs/src/ethereum/forks/amsterdam/stateless_guest.py:33`)
  into RV64IM macro-assembly under `EvmAsm/Stateless/`.
- Lands the **minimum compiling scaffold**: address-space contract,
  Unimplemented exit (0xFE marker + 8 reason codes), top-level `Entry`
  stub that currently routes every input to
  `unimplemented_exit REASON_STF_BODY`, and the placeholder `EntrySpec`
  slot for the eventual `cpsTripleWithin` statement.
- Wires into `EvmAsm.lean`; full multi-PR roadmap recorded under
  "Stateless Guest" in `PLAN.md`.

## Why now

Stakeholders asked for `run_stateless_guest` end-to-end coverage in
RISC-V *before* the proof effort catches up, so testing and
integration can start early. Implementation will land across many
PRs; this one stakes out the directory shape and the
`Unimplemented`-exit ABI so each successor PR can drop in a Program
or a Spec without restructuring.

Scope decisions baked in (recorded in the approved plan):
- Precompiles -> `Unimplemented` exit (distinct from HALT and
  distinct from `successful_validation = false`).
- KECCAK256 / ECRECOVER / SHA256 / etc. that are used internally go
  through ECALL bridges (extending the existing
  `EvmAsm/EL/Keccak*EcallBridge.lean` pattern).
- WitnessState lands as pure-Lean RISC-V from day one (no host-bridge
  MPT).
- Branch: `feat/run-stateless-guest-scaffold`.

## Files

- `EvmAsm/Stateless.lean` (umbrella).
- `EvmAsm/Stateless/MemoryLayout.lean` -- single source of truth for
  the address-space layout + non-leaf calling convention.
- `EvmAsm/Stateless/Unimplemented.lean` -- 8 reason codes; 6-instruction
  body that writes a `0xFE..FE` marker + reason code at `OUTPUT_ADDR`,
  then halts.
- `EvmAsm/Stateless/Entry.lean` -- `run_stateless_guest` Program;
  currently `LI a0, REASON_STF_BODY ;; unimplemented_exit`.
- `EvmAsm/Stateless/EntrySpec.lean` -- placeholder for the top-level
  `cpsTripleWithin`.
- `EvmAsm.lean` -- adds `import EvmAsm.Stateless`.
- `PLAN.md` -- new "Stateless Guest" milestone section listing the
  full PR sequence (PR1..PR8+) and per-PR first-passing fixture.

## Test plan

- [x] `lake build` -- 2012 jobs, all green.
- [x] `scripts/check-unimported.sh` -- 949/949 modules reachable.
- [ ] End-to-end ziskemu round-trip is **out of scope for PR1**; lands
  in PR2 once SSZ decode + encode + `scripts/codegen-stateless-roundtrip-check.sh`
  are in.
- [ ] CPS-triple proofs are out of scope for every PR in this series
  until each module's body stabilises; the `Spec.lean` placeholder
  slot is in place so they can be added incrementally.

Full plan: `~/.claude/plans/please-cut-a-branch-warm-wand.md` (also
linked from PLAN.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)