### PR TITLE
feat(sdiv): add v4 program surface

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/Base.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/Base.lean
@@ -65,6 +65,32 @@ theorem sdivCode_div_callable_sub {base : Word} :
       norm_num)
     a i h
 
+/-- The appended v4 unsigned DIV callable sub-region inside `sdivCodeV4`. -/
+theorem sdivCodeV4_div_callable_sub {base : Word} :
+    ∀ a i, (evm_div_callable_code_v4 (base + 284)) a = some i →
+      (sdivCodeV4 base) a = some i := by
+  intro a i h
+  rw [evm_div_callable_code_v4_eq_ofProg (base + 284)] at h
+  unfold sdivCodeV4
+  exact EvmAsm.Rv64.CodeReq.ofProg_mono_sub base (base + 284)
+    evm_sdiv_v4 evm_div_callable_v4 71
+    (EvmAsm.Evm64.SDiv.AddrNorm.divCallableStart_addr base)
+    (by
+      unfold evm_sdiv_v4 EvmAsm.Rv64.seq
+      rw [← evm_sdiv_wrapper_length]
+      have h_drop :
+          List.drop evm_sdiv_wrapper.length
+              (evm_sdiv_wrapper ++ evm_div_callable_v4) =
+            evm_div_callable_v4 := by
+        exact List.drop_append_length
+      rw [h_drop]
+      simp only [List.take_length])
+    (by native_decide)
+    (by
+      rw [evm_sdiv_v4_length]
+      norm_num)
+    a i h
+
 /-- Bundled top-level SDIV code subsumptions for the wrapper and appended
     unsigned DIV callable. -/
 theorem sdivCode_top_level_subs {base : Word} :

--- a/EvmAsm/Evm64/SDiv/Compose/CodeHandles.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/CodeHandles.lean
@@ -14,6 +14,10 @@ namespace EvmAsm.Evm64.SDiv.Compose
 abbrev sdivCode (base : Word) : EvmAsm.Rv64.CodeReq :=
   EvmAsm.Rv64.CodeReq.ofProg base EvmAsm.Evm64.evm_sdiv
 
+/-- v4 full SDIV code region handle: wrapper followed by `evm_div_callable_v4`. -/
+abbrev sdivCodeV4 (base : Word) : EvmAsm.Rv64.CodeReq :=
+  EvmAsm.Rv64.CodeReq.ofProg base EvmAsm.Evm64.evm_sdiv_v4
+
 /-- Code handle for the saved-`ra` prologue block. -/
 abbrev saveRaCode (base : Word) : EvmAsm.Rv64.CodeReq :=
   EvmAsm.Rv64.CodeReq.ofProg (base + saveRaOff) (EvmAsm.Evm64.evm_sdiv_save_ra_block .x18)
@@ -65,5 +69,9 @@ abbrev savedRaRetCode (base : Word) : EvmAsm.Rv64.CodeReq :=
 /-- Code handle for the appended unsigned divider callable. -/
 abbrev divCallableCode (base : Word) : EvmAsm.Rv64.CodeReq :=
   EvmAsm.Rv64.CodeReq.ofProg (base + wrapperEndOff) EvmAsm.Evm64.evm_div_callable
+
+/-- Code handle for the appended v4 unsigned divider callable. -/
+abbrev divCallableCodeV4 (base : Word) : EvmAsm.Rv64.CodeReq :=
+  EvmAsm.Rv64.CodeReq.ofProg (base + wrapperEndOff) EvmAsm.Evm64.evm_div_callable_v4
 
 end EvmAsm.Evm64.SDiv.Compose

--- a/EvmAsm/Evm64/SDiv/Program.lean
+++ b/EvmAsm/Evm64/SDiv/Program.lean
@@ -211,11 +211,22 @@ theorem evm_sdiv_call_target_byte_offset :
 def evm_sdiv : EvmAsm.Rv64.Program :=
   evm_sdiv_wrapper ;; evm_div_callable
 
+/-- v4 full SDIV code region. This keeps the same SDIV wrapper and swaps the
+    appended unsigned DIV callable to the corrected v4 divider body. -/
+def evm_sdiv_v4 : EvmAsm.Rv64.Program :=
+  evm_sdiv_wrapper ;; evm_div_callable_v4
+
 theorem evm_sdiv_length : evm_sdiv.length = 390 := by
+  native_decide
+
+theorem evm_sdiv_v4_length : evm_sdiv_v4.length = 414 := by
   native_decide
 
 theorem evm_sdiv_byte_length : 4 * evm_sdiv.length = 1560 := by
   rw [evm_sdiv_length]
+
+theorem evm_sdiv_v4_byte_length : 4 * evm_sdiv_v4.length = 1656 := by
+  rw [evm_sdiv_v4_length]
 
 example :
     (evm_sdiv_sign_bit_block .x12 .x5 24).length +


### PR DESCRIPTION
## Summary
- add evm_sdiv_v4 using the existing SDIV wrapper with evm_div_callable_v4 appended
- add v4 SDIV code handles and the appended callable subregion helper

## Verification
- lake build EvmAsm.Evm64.SDiv.Program EvmAsm.Evm64.SDiv.Compose.CodeHandles EvmAsm.Evm64.SDiv.Compose.Base
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "sorry|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Program.lean EvmAsm/Evm64/SDiv/Compose/CodeHandles.lean EvmAsm/Evm64/SDiv/Compose/Base.lean