### PR TITLE
feat(sdiv): add v4 block code subsumptions

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/BaseCode.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BaseCode.lean
@@ -119,6 +119,117 @@ theorem sdivCode_divCallable_sub {base : Word} :
     (by native_decide)
     (by rw [EvmAsm.Evm64.evm_sdiv_length]; norm_num)
 
+theorem sdivCodeV4_saveRa_sub {base : Word} :
+    ∀ a i, (saveRaCode base) a = some i → (sdivCodeV4 base) a = some i := by
+  unfold saveRaCode sdivCodeV4
+  exact EvmAsm.Rv64.CodeReq.ofProg_mono_sub base (base + saveRaOff)
+    EvmAsm.Evm64.evm_sdiv_v4 (EvmAsm.Evm64.evm_sdiv_save_ra_block .x18) 0
+    (by simp [saveRaOff])
+    (by native_decide)
+    (by native_decide)
+    (by rw [EvmAsm.Evm64.evm_sdiv_v4_length]; norm_num)
+
+theorem sdivCodeV4_dividendSign_sub {base : Word} :
+    ∀ a i, (dividendSignCode base) a = some i → (sdivCodeV4 base) a = some i := by
+  unfold dividendSignCode sdivCodeV4
+  exact EvmAsm.Rv64.CodeReq.ofProg_mono_sub base (base + dividendSignOff)
+    EvmAsm.Evm64.evm_sdiv_v4
+    (EvmAsm.Evm64.evm_sdiv_sign_bit_block .x12 .x8
+      EvmAsm.Evm64.evm_sdivDividendTopLimbOff) 1
+    (by simp [dividendSignOff])
+    (by native_decide)
+    (by native_decide)
+    (by rw [EvmAsm.Evm64.evm_sdiv_v4_length]; norm_num)
+
+theorem sdivCodeV4_divisorSign_sub {base : Word} :
+    ∀ a i, (divisorSignCode base) a = some i → (sdivCodeV4 base) a = some i := by
+  unfold divisorSignCode sdivCodeV4
+  exact EvmAsm.Rv64.CodeReq.ofProg_mono_sub base (base + divisorSignOff)
+    EvmAsm.Evm64.evm_sdiv_v4
+    (EvmAsm.Evm64.evm_sdiv_sign_bit_block .x12 .x9
+      EvmAsm.Evm64.evm_sdivDivisorTopLimbOff) 3
+    (by simp [divisorSignOff])
+    (by native_decide)
+    (by native_decide)
+    (by rw [EvmAsm.Evm64.evm_sdiv_v4_length]; norm_num)
+
+theorem sdivCodeV4_dividendAbs_sub {base : Word} :
+    ∀ a i, (dividendAbsCode base) a = some i → (sdivCodeV4 base) a = some i := by
+  unfold dividendAbsCode sdivCodeV4
+  exact EvmAsm.Rv64.CodeReq.ofProg_mono_sub base (base + dividendAbsOff)
+    EvmAsm.Evm64.evm_sdiv_v4
+    (EvmAsm.Evm64.evm_sdiv_cond_negate_256_block .x12 .x8 .x10 .x7 .x11
+      0 8 16 24) 5
+    (by simp [dividendAbsOff])
+    (by native_decide)
+    (by native_decide)
+    (by rw [EvmAsm.Evm64.evm_sdiv_v4_length]; norm_num)
+
+theorem sdivCodeV4_divisorAbs_sub {base : Word} :
+    ∀ a i, (divisorAbsCode base) a = some i → (sdivCodeV4 base) a = some i := by
+  unfold divisorAbsCode sdivCodeV4
+  exact EvmAsm.Rv64.CodeReq.ofProg_mono_sub base (base + divisorAbsOff)
+    EvmAsm.Evm64.evm_sdiv_v4
+    (EvmAsm.Evm64.evm_sdiv_cond_negate_256_block .x12 .x9 .x10 .x7 .x11
+      32 40 48 56) 26
+    (by simp [divisorAbsOff])
+    (by native_decide)
+    (by native_decide)
+    (by rw [EvmAsm.Evm64.evm_sdiv_v4_length]; norm_num)
+
+theorem sdivCodeV4_signXor_sub {base : Word} :
+    ∀ a i, (signXorCode base) a = some i → (sdivCodeV4 base) a = some i := by
+  unfold signXorCode sdivCodeV4
+  exact EvmAsm.Rv64.CodeReq.ofProg_mono_sub base (base + signXorOff)
+    EvmAsm.Evm64.evm_sdiv_v4 (EvmAsm.Rv64.XOR' .x8 .x8 .x9) 47
+    (by simp [signXorOff])
+    (by native_decide)
+    (by native_decide)
+    (by rw [EvmAsm.Evm64.evm_sdiv_v4_length]; norm_num)
+
+theorem sdivCodeV4_divCall_sub {base : Word} :
+    ∀ a i, (divCallCode base) a = some i → (sdivCodeV4 base) a = some i := by
+  unfold divCallCode sdivCodeV4
+  exact EvmAsm.Rv64.CodeReq.ofProg_mono_sub base (base + divCallOff)
+    EvmAsm.Evm64.evm_sdiv_v4
+    (EvmAsm.Evm64.evm_sdiv_div_call_block EvmAsm.Evm64.evm_sdivCallOff) 48
+    (by simp [divCallOff])
+    (by native_decide)
+    (by native_decide)
+    (by rw [EvmAsm.Evm64.evm_sdiv_v4_length]; norm_num)
+
+theorem sdivCodeV4_resultSignFix_sub {base : Word} :
+    ∀ a i, (resultSignFixCode base) a = some i → (sdivCodeV4 base) a = some i := by
+  unfold resultSignFixCode sdivCodeV4
+  exact EvmAsm.Rv64.CodeReq.ofProg_mono_sub base (base + resultSignFixOff)
+    EvmAsm.Evm64.evm_sdiv_v4
+    (EvmAsm.Evm64.evm_sdiv_cond_negate_256_block .x12 .x8 .x10 .x7 .x11
+      0 8 16 24) 49
+    (by simp [resultSignFixOff])
+    (by native_decide)
+    (by native_decide)
+    (by rw [EvmAsm.Evm64.evm_sdiv_v4_length]; norm_num)
+
+theorem sdivCodeV4_savedRaRet_sub {base : Word} :
+    ∀ a i, (savedRaRetCode base) a = some i → (sdivCodeV4 base) a = some i := by
+  unfold savedRaRetCode sdivCodeV4
+  exact EvmAsm.Rv64.CodeReq.ofProg_mono_sub base (base + savedRaRetOff)
+    EvmAsm.Evm64.evm_sdiv_v4 (EvmAsm.Evm64.evm_sdiv_saved_ra_ret_block .x18) 70
+    (by simp [savedRaRetOff])
+    (by native_decide)
+    (by native_decide)
+    (by rw [EvmAsm.Evm64.evm_sdiv_v4_length]; norm_num)
+
+theorem sdivCodeV4_divCallable_sub {base : Word} :
+    ∀ a i, (divCallableCodeV4 base) a = some i → (sdivCodeV4 base) a = some i := by
+  unfold divCallableCodeV4 sdivCodeV4
+  exact EvmAsm.Rv64.CodeReq.ofProg_mono_sub base (base + wrapperEndOff)
+    EvmAsm.Evm64.evm_sdiv_v4 EvmAsm.Evm64.evm_div_callable_v4 71
+    (by simp [wrapperEndOff])
+    (by native_decide)
+    (by native_decide)
+    (by rw [EvmAsm.Evm64.evm_sdiv_v4_length]; norm_num)
+
 theorem sdivCode_block_subs {base : Word} :
     (∀ a i, (saveRaCode base) a = some i → (sdivCode base) a = some i) ∧
     (∀ a i, (dividendSignCode base) a = some i → (sdivCode base) a = some i) ∧
@@ -135,5 +246,22 @@ theorem sdivCode_block_subs {base : Word} :
     sdivCode_divisorAbs_sub, sdivCode_signXor_sub, sdivCode_divCall_sub,
     sdivCode_resultSignFix_sub, sdivCode_savedRaRet_sub,
     sdivCode_divCallable_sub⟩
+
+theorem sdivCodeV4_block_subs {base : Word} :
+    (∀ a i, (saveRaCode base) a = some i → (sdivCodeV4 base) a = some i) ∧
+    (∀ a i, (dividendSignCode base) a = some i → (sdivCodeV4 base) a = some i) ∧
+    (∀ a i, (divisorSignCode base) a = some i → (sdivCodeV4 base) a = some i) ∧
+    (∀ a i, (dividendAbsCode base) a = some i → (sdivCodeV4 base) a = some i) ∧
+    (∀ a i, (divisorAbsCode base) a = some i → (sdivCodeV4 base) a = some i) ∧
+    (∀ a i, (signXorCode base) a = some i → (sdivCodeV4 base) a = some i) ∧
+    (∀ a i, (divCallCode base) a = some i → (sdivCodeV4 base) a = some i) ∧
+    (∀ a i, (resultSignFixCode base) a = some i → (sdivCodeV4 base) a = some i) ∧
+    (∀ a i, (savedRaRetCode base) a = some i → (sdivCodeV4 base) a = some i) ∧
+    (∀ a i, (divCallableCodeV4 base) a = some i → (sdivCodeV4 base) a = some i) := by
+  exact ⟨sdivCodeV4_saveRa_sub, sdivCodeV4_dividendSign_sub,
+    sdivCodeV4_divisorSign_sub, sdivCodeV4_dividendAbs_sub,
+    sdivCodeV4_divisorAbs_sub, sdivCodeV4_signXor_sub, sdivCodeV4_divCall_sub,
+    sdivCodeV4_resultSignFix_sub, sdivCodeV4_savedRaRet_sub,
+    sdivCodeV4_divCallable_sub⟩
 
 end EvmAsm.Evm64.SDiv.Compose

--- a/EvmAsm/Evm64/SDiv/Compose/BaseDividendAbsBlockSpec.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BaseDividendAbsBlockSpec.lean
@@ -36,4 +36,32 @@ theorem dividendAbs_spec_in_sdivCode
     EvmAsm.Evm64.condNegate256BlockPost_unfold] at hSpec
   exact EvmAsm.Rv64.cpsTripleWithin_extend_code hmono hSpec
 
+theorem dividendAbs_spec_in_sdivCodeV4
+    (sp sign maskOld valueOld carryOld limb0 limb1 limb2 limb3 : Word)
+    (base : Word) :
+    EvmAsm.Rv64.cpsTripleWithin 21 (base + dividendAbsOff) ((base + dividendAbsOff) + 84)
+      (sdivCodeV4 base)
+      (dividendAbsPre sp sign maskOld valueOld carryOld
+        limb0 limb1 limb2 limb3)
+      (dividendAbsPost sp sign limb0 limb1 limb2 limb3) := by
+  rw [dividendAbsPre_unfold, dividendAbsPost_unfold]
+  have hmono :
+      ∀ a i,
+        (EvmAsm.Evm64.evm_sdiv_cond_negate_256_block_code
+          .x12 .x8 .x10 .x7 .x11 0 8 16 24
+          (base + dividendAbsOff)) a = some i →
+        (sdivCodeV4 base) a = some i := by
+    intro a i h
+    exact sdivCodeV4_dividendAbs_sub (base := base) a i
+      (by simpa [dividendAbsCode,
+        EvmAsm.Evm64.evm_sdiv_cond_negate_256_block_code] using h)
+  have hSpec :=
+    EvmAsm.Evm64.evm_sdiv_cond_negate_256_block_spec_within
+      .x12 .x8 .x10 .x7 .x11 0 8 16 24
+      sp sign maskOld valueOld carryOld limb0 limb1 limb2 limb3
+      (base + dividendAbsOff) (by decide) (by decide) (by decide)
+  rw [EvmAsm.Evm64.condNegate256BlockPre_unfold,
+    EvmAsm.Evm64.condNegate256BlockPost_unfold] at hSpec
+  exact EvmAsm.Rv64.cpsTripleWithin_extend_code hmono hSpec
+
 end EvmAsm.Evm64.SDiv.Compose

--- a/EvmAsm/Evm64/SDiv/Compose/BaseDividendAbsSequence.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BaseDividendAbsSequence.lean
@@ -107,4 +107,100 @@ theorem saveRa_signs_then_dividendAbs_spec_in_sdivCode
       xperm_hyp hp) hPrefix hAbs
   simpa [pre, post] using hSeq
 
+theorem saveRa_signs_then_dividendAbs_spec_in_sdivCodeV4
+    (vRa vSavedOld sp sDividendOld sDivisorOld divisorTop
+      maskOld valueOld carryOld limb0 limb1 limb2 dividendTop : Word)
+    (base : Word) :
+    EvmAsm.Rv64.cpsTripleWithin 26 base ((base + dividendAbsOff) + 84) (sdivCodeV4 base)
+      (saveRaSignsThenDividendAbsPre vRa vSavedOld sp sDividendOld sDivisorOld
+        divisorTop maskOld valueOld carryOld
+        limb0 limb1 limb2 dividendTop)
+      (saveRaSignsThenDividendAbsPost vRa sp divisorTop
+        limb0 limb1 limb2 dividendTop) := by
+  rw [saveRaSignsThenDividendAbsPre_unfold,
+      saveRaSignsThenDividendAbsPost_unfold]
+  let sign := dividendTop >>> (63 : BitVec 6).toNat
+  let divisorSign := divisorTop >>> (63 : BitVec 6).toNat
+  let mem0 := sp + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)
+  let mem1 := sp + EvmAsm.Rv64.signExtend12 (8 : BitVec 12)
+  let mem2 := sp + EvmAsm.Rv64.signExtend12 (16 : BitVec 12)
+  let mem3 := sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff
+  let divisorMem3 := sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff
+  let mask := (0 : Word) - sign
+  let xored0 := limb0 ^^^ mask
+  let sum0 := xored0 + sign
+  let carry0 := if BitVec.ult sum0 sign then (1 : Word) else 0
+  let xored1 := limb1 ^^^ mask
+  let sum1 := xored1 + carry0
+  let carry1 := if BitVec.ult sum1 carry0 then (1 : Word) else 0
+  let xored2 := limb2 ^^^ mask
+  let sum2 := xored2 + carry1
+  let carry2 := if BitVec.ult sum2 carry1 then (1 : Word) else 0
+  let xored3 := dividendTop ^^^ mask
+  let sum3 := xored3 + carry2
+  let carry3 := if BitVec.ult sum3 carry2 then (1 : Word) else 0
+  let extra : EvmAsm.Rv64.Assertion :=
+    (((.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ maskOld) **
+      (.x7 ↦ᵣ valueOld) ** (.x11 ↦ᵣ carryOld)) **
+     ((mem0 ↦ₘ limb0) ** (mem1 ↦ₘ limb1) ** (mem2 ↦ₘ limb2)))
+  let pre : EvmAsm.Rv64.Assertion :=
+    (((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ vSavedOld)) **
+       ((.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sDividendOld) ** (mem3 ↦ₘ dividendTop))) **
+      ((.x9 ↦ᵣ sDivisorOld) ** (divisorMem3 ↦ₘ divisorTop))) **
+     extra)
+  let mid : EvmAsm.Rv64.Assertion :=
+    (((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))) **
+       ((.x8 ↦ᵣ sign) ** (mem3 ↦ₘ dividendTop))) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ divisorSign) ** (divisorMem3 ↦ₘ divisorTop))) **
+     extra)
+  let absPre : EvmAsm.Rv64.Assertion :=
+    ((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))) **
+      ((.x9 ↦ᵣ divisorSign) ** (divisorMem3 ↦ₘ divisorTop))) **
+     ((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sign) **
+      (.x10 ↦ᵣ maskOld) ** (.x7 ↦ᵣ valueOld) ** (.x11 ↦ᵣ carryOld) **
+      (mem0 ↦ₘ limb0) ** (mem1 ↦ₘ limb1) **
+      (mem2 ↦ₘ limb2) ** (mem3 ↦ₘ dividendTop)))
+  let post : EvmAsm.Rv64.Assertion :=
+    ((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))) **
+      ((.x9 ↦ᵣ divisorSign) ** (divisorMem3 ↦ₘ divisorTop))) **
+     ((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sign) **
+      (.x10 ↦ᵣ mask) ** (.x7 ↦ᵣ sum3) ** (.x11 ↦ᵣ carry3) **
+      (mem0 ↦ₘ sum0) ** (mem1 ↦ₘ sum1) **
+      (mem2 ↦ₘ sum2) ** (mem3 ↦ₘ sum3)))
+  have hPrefix : EvmAsm.Rv64.cpsTripleWithin 5 base (base + dividendAbsOff)
+      (sdivCodeV4 base) pre mid := by
+    dsimp [pre, mid, extra, mem3, divisorMem3, sign, divisorSign]
+    simpa [divisorSignOff, dividendAbsOff, BitVec.add_assoc,
+      saveRaDividendSignThenDivisorSignPre_unfold,
+      saveRaDividendSignThenDivisorSignPost_unfold] using
+      (EvmAsm.Rv64.cpsTripleWithin_frameR
+        (((.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ maskOld) **
+          (.x7 ↦ᵣ valueOld) ** (.x11 ↦ᵣ carryOld)) **
+         ((mem0 ↦ₘ limb0) ** (mem1 ↦ₘ limb1) ** (mem2 ↦ₘ limb2)))
+        (by pcFree)
+        (saveRa_dividendSign_then_divisorSign_spec_in_sdivCodeV4
+          vRa vSavedOld sp sDividendOld dividendTop sDivisorOld divisorTop
+          base))
+  have hAbs : EvmAsm.Rv64.cpsTripleWithin 21 (base + dividendAbsOff)
+      ((base + dividendAbsOff) + 84) (sdivCodeV4 base) absPre post := by
+    have hSpec := dividendAbs_spec_in_sdivCodeV4
+      sp sign maskOld valueOld carryOld limb0 limb1 limb2 dividendTop
+      base
+    rw [dividendAbsPre_unfold, dividendAbsPost_unfold] at hSpec
+    simpa [absPre, post, mem0, mem1, mem2, mem3,
+      EvmAsm.Evm64.evm_sdivDividendTopLimbOff, mask, xored0, sum0,
+      carry0, xored1, sum1, carry1, xored2, sum2, carry2, xored3, sum3,
+      carry3] using
+      EvmAsm.Rv64.cpsTripleWithin_frameL
+        ((((.x1 ↦ᵣ vRa) **
+          (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))) **
+          ((.x9 ↦ᵣ divisorSign) ** (divisorMem3 ↦ₘ divisorTop))))
+        (by pcFree)
+        hSpec
+  have hSeq := EvmAsm.Rv64.cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by
+      dsimp [mid, absPre, extra] at hp ⊢
+      xperm_hyp hp) hPrefix hAbs
+  simpa [pre, post] using hSeq
+
 end EvmAsm.Evm64.SDiv.Compose

--- a/EvmAsm/Evm64/SDiv/Compose/BaseDivisorAbsBlockSpec.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BaseDivisorAbsBlockSpec.lean
@@ -36,4 +36,32 @@ theorem divisorAbs_spec_in_sdivCode
     EvmAsm.Evm64.condNegate256BlockPost_unfold] at hSpec
   exact EvmAsm.Rv64.cpsTripleWithin_extend_code hmono hSpec
 
+theorem divisorAbs_spec_in_sdivCodeV4
+    (sp sign maskOld valueOld carryOld limb0 limb1 limb2 limb3 : Word)
+    (base : Word) :
+    EvmAsm.Rv64.cpsTripleWithin 21 (base + divisorAbsOff) ((base + divisorAbsOff) + 84)
+      (sdivCodeV4 base)
+      (divisorAbsPre sp sign maskOld valueOld carryOld
+        limb0 limb1 limb2 limb3)
+      (divisorAbsPost sp sign limb0 limb1 limb2 limb3) := by
+  rw [divisorAbsPre_unfold, divisorAbsPost_unfold]
+  have hmono :
+      ∀ a i,
+        (EvmAsm.Evm64.evm_sdiv_cond_negate_256_block_code
+          .x12 .x9 .x10 .x7 .x11 32 40 48 56
+          (base + divisorAbsOff)) a = some i →
+        (sdivCodeV4 base) a = some i := by
+    intro a i h
+    exact sdivCodeV4_divisorAbs_sub (base := base) a i
+      (by simpa [divisorAbsCode,
+        EvmAsm.Evm64.evm_sdiv_cond_negate_256_block_code] using h)
+  have hSpec :=
+    EvmAsm.Evm64.evm_sdiv_cond_negate_256_block_spec_within
+      .x12 .x9 .x10 .x7 .x11 32 40 48 56
+      sp sign maskOld valueOld carryOld limb0 limb1 limb2 limb3
+      (base + divisorAbsOff) (by decide) (by decide) (by decide)
+  rw [EvmAsm.Evm64.condNegate256BlockPre_unfold,
+    EvmAsm.Evm64.condNegate256BlockPost_unfold] at hSpec
+  exact EvmAsm.Rv64.cpsTripleWithin_extend_code hmono hSpec
+
 end EvmAsm.Evm64.SDiv.Compose

--- a/EvmAsm/Evm64/SDiv/Compose/BaseFinalBlockSpecs.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BaseFinalBlockSpecs.lean
@@ -29,6 +29,26 @@ theorem divCall_spec_in_sdivCode
     (EvmAsm.Evm64.evm_sdiv_div_call_block_spec_within
       EvmAsm.Evm64.evm_sdivCallOff vOld (base + divCallOff))
 
+theorem divCall_spec_in_sdivCodeV4
+    (vOld : Word) (base : Word) :
+    EvmAsm.Rv64.cpsTripleWithin 1 (base + divCallOff)
+        ((base + divCallOff) + EvmAsm.Rv64.signExtend21 EvmAsm.Evm64.evm_sdivCallOff)
+      (sdivCodeV4 base)
+      (.x1 ↦ᵣ vOld)
+      (.x1 ↦ᵣ ((base + divCallOff) + 4)) := by
+  have hmono :
+      ∀ a i,
+        (EvmAsm.Evm64.evm_sdiv_div_call_block_code
+          EvmAsm.Evm64.evm_sdivCallOff (base + divCallOff)) a = some i →
+        (sdivCodeV4 base) a = some i := by
+    intro a i h
+    exact sdivCodeV4_divCall_sub (base := base) a i
+      (by simpa [divCallCode,
+        EvmAsm.Evm64.evm_sdiv_div_call_block_code] using h)
+  exact EvmAsm.Rv64.cpsTripleWithin_extend_code hmono
+    (EvmAsm.Evm64.evm_sdiv_div_call_block_spec_within
+      EvmAsm.Evm64.evm_sdivCallOff vOld (base + divCallOff))
+
 theorem signXor_spec_in_sdivCode
     (signDividend signDivisor : Word) (base : Word) :
     EvmAsm.Rv64.cpsTripleWithin 1 (base + signXorOff) ((base + signXorOff) + 4)
@@ -40,6 +60,25 @@ theorem signXor_spec_in_sdivCode
         (sdivCode base) a = some i := by
     intro a i h
     exact sdivCode_signXor_sub (base := base) a i
+      (by
+        rw [signXorCode, EvmAsm.Rv64.XOR', EvmAsm.Rv64.single,
+          EvmAsm.Rv64.CodeReq.ofProg_singleton]
+        exact h)
+  exact EvmAsm.Rv64.cpsTripleWithin_extend_code hmono
+    (EvmAsm.Rv64.xor_spec_gen_rd_eq_rs1_within .x8 .x9 signDividend signDivisor
+      (base + signXorOff) (by decide))
+
+theorem signXor_spec_in_sdivCodeV4
+    (signDividend signDivisor : Word) (base : Word) :
+    EvmAsm.Rv64.cpsTripleWithin 1 (base + signXorOff) ((base + signXorOff) + 4)
+      (sdivCodeV4 base)
+      ((.x8 ↦ᵣ signDividend) ** (.x9 ↦ᵣ signDivisor))
+      ((.x8 ↦ᵣ (signDividend ^^^ signDivisor)) ** (.x9 ↦ᵣ signDivisor)) := by
+  have hmono :
+      ∀ a i, (EvmAsm.Rv64.CodeReq.singleton (base + signXorOff) (.XOR .x8 .x8 .x9)) a = some i →
+        (sdivCodeV4 base) a = some i := by
+    intro a i h
+    exact sdivCodeV4_signXor_sub (base := base) a i
       (by
         rw [signXorCode, EvmAsm.Rv64.XOR', EvmAsm.Rv64.single,
           EvmAsm.Rv64.CodeReq.ofProg_singleton]
@@ -62,6 +101,26 @@ theorem savedRaRet_spec_in_sdivCode
         (sdivCode base) a = some i := by
     intro a i h
     exact sdivCode_savedRaRet_sub (base := base) a i
+      (by simpa [savedRaRetCode,
+        EvmAsm.Evm64.evm_sdiv_saved_ra_ret_block_code] using h)
+  exact EvmAsm.Rv64.cpsTripleWithin_extend_code hmono
+    (EvmAsm.Evm64.evm_sdiv_saved_ra_ret_block_spec_within .x18
+      vSavedRa (base + savedRaRetOff))
+
+theorem savedRaRet_spec_in_sdivCodeV4
+    (vSavedRa : Word) (base : Word) :
+    EvmAsm.Rv64.cpsTripleWithin 1 (base + savedRaRetOff)
+        ((vSavedRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)) &&& ~~~1)
+      (sdivCodeV4 base)
+      (.x18 ↦ᵣ vSavedRa)
+      (.x18 ↦ᵣ vSavedRa) := by
+  have hmono :
+      ∀ a i,
+        (EvmAsm.Evm64.evm_sdiv_saved_ra_ret_block_code .x18
+          (base + savedRaRetOff)) a = some i →
+        (sdivCodeV4 base) a = some i := by
+    intro a i h
+    exact sdivCodeV4_savedRaRet_sub (base := base) a i
       (by simpa [savedRaRetCode,
         EvmAsm.Evm64.evm_sdiv_saved_ra_ret_block_code] using h)
   exact EvmAsm.Rv64.cpsTripleWithin_extend_code hmono

--- a/EvmAsm/Evm64/SDiv/Compose/BaseResultSignFixBlockSpec.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BaseResultSignFixBlockSpec.lean
@@ -37,4 +37,32 @@ theorem resultSignFix_spec_in_sdivCode
     EvmAsm.Evm64.condNegate256BlockPost_unfold] at hSpec
   exact EvmAsm.Rv64.cpsTripleWithin_extend_code hmono hSpec
 
+theorem resultSignFix_spec_in_sdivCodeV4
+    (sp sign maskOld valueOld carryOld limb0 limb1 limb2 limb3 : Word)
+    (base : Word) :
+    EvmAsm.Rv64.cpsTripleWithin 21 (base + resultSignFixOff)
+      ((base + resultSignFixOff) + 84) (sdivCodeV4 base)
+      (resultSignFixPre sp sign maskOld valueOld carryOld
+        limb0 limb1 limb2 limb3)
+      (resultSignFixPost sp sign limb0 limb1 limb2 limb3) := by
+  rw [resultSignFixPre_unfold, resultSignFixPost_unfold]
+  have hmono :
+      ∀ a i,
+        (EvmAsm.Evm64.evm_sdiv_cond_negate_256_block_code
+          .x12 .x8 .x10 .x7 .x11 0 8 16 24
+          (base + resultSignFixOff)) a = some i →
+        (sdivCodeV4 base) a = some i := by
+    intro a i h
+    exact sdivCodeV4_resultSignFix_sub (base := base) a i
+      (by simpa [resultSignFixCode,
+        EvmAsm.Evm64.evm_sdiv_cond_negate_256_block_code] using h)
+  have hSpec :=
+    EvmAsm.Evm64.evm_sdiv_cond_negate_256_block_spec_within
+      .x12 .x8 .x10 .x7 .x11 0 8 16 24
+      sp sign maskOld valueOld carryOld limb0 limb1 limb2 limb3
+      (base + resultSignFixOff) (by decide) (by decide) (by decide)
+  rw [EvmAsm.Evm64.condNegate256BlockPre_unfold,
+    EvmAsm.Evm64.condNegate256BlockPost_unfold] at hSpec
+  exact EvmAsm.Rv64.cpsTripleWithin_extend_code hmono hSpec
+
 end EvmAsm.Evm64.SDiv.Compose

--- a/EvmAsm/Evm64/SDiv/Compose/BaseSignSequence.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BaseSignSequence.lean
@@ -82,4 +82,76 @@ theorem saveRa_dividendSign_then_divisorSign_spec_in_sdivCode
       xperm_hyp hp) hPrefix hDivisor
   simpa [pre, post] using hSeq
 
+theorem saveRa_dividendSign_then_divisorSign_spec_in_sdivCodeV4
+    (vRa vSavedOld sp sDividendOld dividendTop sDivisorOld divisorTop : Word)
+    (base : Word) :
+    EvmAsm.Rv64.cpsTripleWithin 5 base ((base + divisorSignOff) + 8) (sdivCodeV4 base)
+      (saveRaDividendSignThenDivisorSignPre vRa vSavedOld sp sDividendOld
+        dividendTop sDivisorOld divisorTop)
+      (saveRaDividendSignThenDivisorSignPost vRa sp dividendTop divisorTop) := by
+  rw [saveRaDividendSignThenDivisorSignPre_unfold,
+      saveRaDividendSignThenDivisorSignPost_unfold]
+  let pre : EvmAsm.Rv64.Assertion :=
+    ((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ vSavedOld)) **
+      ((.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sDividendOld) **
+       ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ
+         dividendTop))) **
+     ((.x9 ↦ᵣ sDivisorOld) **
+      ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff) ↦ₘ
+        divisorTop)))
+  let mid : EvmAsm.Rv64.Assertion :=
+    ((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))) **
+      ((.x12 ↦ᵣ sp) **
+       (.x8 ↦ᵣ (dividendTop >>> (63 : BitVec 6).toNat)) **
+       ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ
+         dividendTop))) **
+     ((.x9 ↦ᵣ sDivisorOld) **
+      ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff) ↦ₘ
+        divisorTop)))
+  let midDivisor : EvmAsm.Rv64.Assertion :=
+    ((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))) **
+      ((.x8 ↦ᵣ (dividendTop >>> (63 : BitVec 6).toNat)) **
+       ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ
+         dividendTop))) **
+     ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ sDivisorOld) **
+      ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff) ↦ₘ
+        divisorTop)))
+  let post : EvmAsm.Rv64.Assertion :=
+    ((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))) **
+      ((.x8 ↦ᵣ (dividendTop >>> (63 : BitVec 6).toNat)) **
+       ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ
+         dividendTop))) **
+     ((.x12 ↦ᵣ sp) **
+      (.x9 ↦ᵣ (divisorTop >>> (63 : BitVec 6).toNat)) **
+      ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff) ↦ₘ
+        divisorTop)))
+  have hPrefix : EvmAsm.Rv64.cpsTripleWithin 3 base (base + divisorSignOff)
+      (sdivCodeV4 base) pre mid := by
+    dsimp [pre, mid]
+    simpa [dividendSignOff, divisorSignOff, BitVec.add_assoc] using
+      (EvmAsm.Rv64.cpsTripleWithin_frameR
+        ((.x9 ↦ᵣ sDivisorOld) **
+         ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff) ↦ₘ
+          divisorTop))
+        (by pcFree)
+        (saveRa_then_dividendSign_spec_in_sdivCodeV4
+          vRa vSavedOld sp sDividendOld dividendTop base))
+  have hDivisor : EvmAsm.Rv64.cpsTripleWithin 2 (base + divisorSignOff)
+      ((base + divisorSignOff) + 8) (sdivCodeV4 base) midDivisor post := by
+    dsimp [midDivisor, post]
+    exact
+      EvmAsm.Rv64.cpsTripleWithin_frameL
+        (((.x1 ↦ᵣ vRa) **
+          (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))) **
+         ((.x8 ↦ᵣ (dividendTop >>> (63 : BitVec 6).toNat)) **
+          ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ
+            dividendTop)))
+        (by pcFree)
+        (divisorSign_spec_in_sdivCodeV4 sp sDivisorOld divisorTop base)
+  have hSeq := EvmAsm.Rv64.cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by
+      dsimp [mid, midDivisor] at hp ⊢
+      xperm_hyp hp) hPrefix hDivisor
+  simpa [pre, post] using hSeq
+
 end EvmAsm.Evm64.SDiv.Compose

--- a/EvmAsm/Evm64/SDiv/Compose/SaveRaSignBlockSpecs.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/SaveRaSignBlockSpecs.lean
@@ -25,6 +25,22 @@ theorem saveRa_spec_in_sdivCode
     (EvmAsm.Evm64.evm_sdiv_save_ra_block_spec_within .x18
       vRa vSavedOld base (by decide))
 
+theorem saveRa_spec_in_sdivCodeV4
+    (vRa vSavedOld : Word) (base : Word) :
+    EvmAsm.Rv64.cpsTripleWithin 1 base (base + 4) (sdivCodeV4 base)
+      ((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ vSavedOld))
+      ((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))) := by
+  have hmono :
+      ∀ a i, (EvmAsm.Evm64.evm_sdiv_save_ra_block_code .x18 base) a = some i →
+        (sdivCodeV4 base) a = some i := by
+    intro a i h
+    exact sdivCodeV4_saveRa_sub (base := base) a i
+      (by simpa [saveRaCode, saveRaOff,
+        EvmAsm.Evm64.evm_sdiv_save_ra_block_code] using h)
+  exact EvmAsm.Rv64.cpsTripleWithin_extend_code hmono
+    (EvmAsm.Evm64.evm_sdiv_save_ra_block_spec_within .x18
+      vRa vSavedOld base (by decide))
+
 theorem dividendSign_spec_in_sdivCode
     (sp sOld dividendTop : Word) (base : Word) :
     EvmAsm.Rv64.cpsTripleWithin 2 (base + dividendSignOff) ((base + dividendSignOff) + 8)
@@ -51,6 +67,32 @@ theorem dividendSign_spec_in_sdivCode
       EvmAsm.Evm64.evm_sdivDividendTopLimbOff sp sOld dividendTop
       (base + dividendSignOff) (by decide))
 
+theorem dividendSign_spec_in_sdivCodeV4
+    (sp sOld dividendTop : Word) (base : Word) :
+    EvmAsm.Rv64.cpsTripleWithin 2 (base + dividendSignOff) ((base + dividendSignOff) + 8)
+      (sdivCodeV4 base)
+      ((.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sOld) **
+       ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ
+         dividendTop))
+      ((.x12 ↦ᵣ sp) **
+       (.x8 ↦ᵣ (dividendTop >>> (63 : BitVec 6).toNat)) **
+       ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ
+         dividendTop)) := by
+  have hmono :
+      ∀ a i,
+        (EvmAsm.Evm64.evm_sdiv_sign_bit_block_code .x12 .x8
+          EvmAsm.Evm64.evm_sdivDividendTopLimbOff
+          (base + dividendSignOff)) a = some i →
+        (sdivCodeV4 base) a = some i := by
+    intro a i h
+    exact sdivCodeV4_dividendSign_sub (base := base) a i
+      (by simpa [dividendSignCode,
+        EvmAsm.Evm64.evm_sdiv_sign_bit_block_code] using h)
+  exact EvmAsm.Rv64.cpsTripleWithin_extend_code hmono
+    (EvmAsm.Evm64.evm_sdiv_sign_bit_block_spec_within .x12 .x8
+      EvmAsm.Evm64.evm_sdivDividendTopLimbOff sp sOld dividendTop
+      (base + dividendSignOff) (by decide))
+
 theorem divisorSign_spec_in_sdivCode
     (sp sOld divisorTop : Word) (base : Word) :
     EvmAsm.Rv64.cpsTripleWithin 2 (base + divisorSignOff) ((base + divisorSignOff) + 8)
@@ -70,6 +112,32 @@ theorem divisorSign_spec_in_sdivCode
         (sdivCode base) a = some i := by
     intro a i h
     exact sdivCode_divisorSign_sub (base := base) a i
+      (by simpa [divisorSignCode,
+        EvmAsm.Evm64.evm_sdiv_sign_bit_block_code] using h)
+  exact EvmAsm.Rv64.cpsTripleWithin_extend_code hmono
+    (EvmAsm.Evm64.evm_sdiv_sign_bit_block_spec_within .x12 .x9
+      EvmAsm.Evm64.evm_sdivDivisorTopLimbOff sp sOld divisorTop
+      (base + divisorSignOff) (by decide))
+
+theorem divisorSign_spec_in_sdivCodeV4
+    (sp sOld divisorTop : Word) (base : Word) :
+    EvmAsm.Rv64.cpsTripleWithin 2 (base + divisorSignOff) ((base + divisorSignOff) + 8)
+      (sdivCodeV4 base)
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ sOld) **
+       ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff) ↦ₘ
+         divisorTop))
+      ((.x12 ↦ᵣ sp) **
+       (.x9 ↦ᵣ (divisorTop >>> (63 : BitVec 6).toNat)) **
+       ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff) ↦ₘ
+         divisorTop)) := by
+  have hmono :
+      ∀ a i,
+        (EvmAsm.Evm64.evm_sdiv_sign_bit_block_code .x12 .x9
+          EvmAsm.Evm64.evm_sdivDivisorTopLimbOff
+          (base + divisorSignOff)) a = some i →
+        (sdivCodeV4 base) a = some i := by
+    intro a i h
+    exact sdivCodeV4_divisorSign_sub (base := base) a i
       (by simpa [divisorSignCode,
         EvmAsm.Evm64.evm_sdiv_sign_bit_block_code] using h)
   exact EvmAsm.Rv64.cpsTripleWithin_extend_code hmono

--- a/EvmAsm/Evm64/SDiv/Compose/SaveRaSignBlocks.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/SaveRaSignBlocks.lean
@@ -37,4 +37,30 @@ theorem saveRa_then_dividendSign_spec_in_sdivCode
       (dividendSign_spec_in_sdivCode sp sOld dividendTop base)
   exact EvmAsm.Rv64.cpsTripleWithin_seq_same_cr hSave hSign
 
+theorem saveRa_then_dividendSign_spec_in_sdivCodeV4
+    (vRa vSavedOld sp sOld dividendTop : Word) (base : Word) :
+    EvmAsm.Rv64.cpsTripleWithin 3 base ((base + dividendSignOff) + 8) (sdivCodeV4 base)
+      (((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ vSavedOld)) **
+       ((.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sOld) **
+        ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ
+          dividendTop)))
+      (((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))) **
+       ((.x12 ↦ᵣ sp) **
+        (.x8 ↦ᵣ (dividendTop >>> (63 : BitVec 6).toNat)) **
+        ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ
+          dividendTop))) := by
+  have hSave :=
+    EvmAsm.Rv64.cpsTripleWithin_frameR
+      (((.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sOld) **
+        ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ
+          dividendTop)))
+      (by pcFree)
+      (saveRa_spec_in_sdivCodeV4 vRa vSavedOld base)
+  have hSign :=
+    EvmAsm.Rv64.cpsTripleWithin_frameL
+      (((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))))
+      (by pcFree)
+      (dividendSign_spec_in_sdivCodeV4 sp sOld dividendTop base)
+  exact EvmAsm.Rv64.cpsTripleWithin_seq_same_cr hSave hSign
+
 end EvmAsm.Evm64.SDiv.Compose


### PR DESCRIPTION
## Summary
- add sdivCodeV4 block-level code subsumption lemmas for every SDIV wrapper block
- add the v4 callable-code block subsumption and bundled sdivCodeV4_block_subs helper

## Verification
- lake build EvmAsm.Evm64.SDiv.Compose.BaseCode EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "sorry|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/BaseCode.lean