### PR TITLE
feat(sdiv): add v4 leaf block specs

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/BaseDividendAbsBlockSpec.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BaseDividendAbsBlockSpec.lean
@@ -36,4 +36,32 @@ theorem dividendAbs_spec_in_sdivCode
     EvmAsm.Evm64.condNegate256BlockPost_unfold] at hSpec
   exact EvmAsm.Rv64.cpsTripleWithin_extend_code hmono hSpec
 
+theorem dividendAbs_spec_in_sdivCodeV4
+    (sp sign maskOld valueOld carryOld limb0 limb1 limb2 limb3 : Word)
+    (base : Word) :
+    EvmAsm.Rv64.cpsTripleWithin 21 (base + dividendAbsOff) ((base + dividendAbsOff) + 84)
+      (sdivCodeV4 base)
+      (dividendAbsPre sp sign maskOld valueOld carryOld
+        limb0 limb1 limb2 limb3)
+      (dividendAbsPost sp sign limb0 limb1 limb2 limb3) := by
+  rw [dividendAbsPre_unfold, dividendAbsPost_unfold]
+  have hmono :
+      ∀ a i,
+        (EvmAsm.Evm64.evm_sdiv_cond_negate_256_block_code
+          .x12 .x8 .x10 .x7 .x11 0 8 16 24
+          (base + dividendAbsOff)) a = some i →
+        (sdivCodeV4 base) a = some i := by
+    intro a i h
+    exact sdivCodeV4_dividendAbs_sub (base := base) a i
+      (by simpa [dividendAbsCode,
+        EvmAsm.Evm64.evm_sdiv_cond_negate_256_block_code] using h)
+  have hSpec :=
+    EvmAsm.Evm64.evm_sdiv_cond_negate_256_block_spec_within
+      .x12 .x8 .x10 .x7 .x11 0 8 16 24
+      sp sign maskOld valueOld carryOld limb0 limb1 limb2 limb3
+      (base + dividendAbsOff) (by decide) (by decide) (by decide)
+  rw [EvmAsm.Evm64.condNegate256BlockPre_unfold,
+    EvmAsm.Evm64.condNegate256BlockPost_unfold] at hSpec
+  exact EvmAsm.Rv64.cpsTripleWithin_extend_code hmono hSpec
+
 end EvmAsm.Evm64.SDiv.Compose

--- a/EvmAsm/Evm64/SDiv/Compose/BaseDivisorAbsBlockSpec.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BaseDivisorAbsBlockSpec.lean
@@ -36,4 +36,32 @@ theorem divisorAbs_spec_in_sdivCode
     EvmAsm.Evm64.condNegate256BlockPost_unfold] at hSpec
   exact EvmAsm.Rv64.cpsTripleWithin_extend_code hmono hSpec
 
+theorem divisorAbs_spec_in_sdivCodeV4
+    (sp sign maskOld valueOld carryOld limb0 limb1 limb2 limb3 : Word)
+    (base : Word) :
+    EvmAsm.Rv64.cpsTripleWithin 21 (base + divisorAbsOff) ((base + divisorAbsOff) + 84)
+      (sdivCodeV4 base)
+      (divisorAbsPre sp sign maskOld valueOld carryOld
+        limb0 limb1 limb2 limb3)
+      (divisorAbsPost sp sign limb0 limb1 limb2 limb3) := by
+  rw [divisorAbsPre_unfold, divisorAbsPost_unfold]
+  have hmono :
+      ∀ a i,
+        (EvmAsm.Evm64.evm_sdiv_cond_negate_256_block_code
+          .x12 .x9 .x10 .x7 .x11 32 40 48 56
+          (base + divisorAbsOff)) a = some i →
+        (sdivCodeV4 base) a = some i := by
+    intro a i h
+    exact sdivCodeV4_divisorAbs_sub (base := base) a i
+      (by simpa [divisorAbsCode,
+        EvmAsm.Evm64.evm_sdiv_cond_negate_256_block_code] using h)
+  have hSpec :=
+    EvmAsm.Evm64.evm_sdiv_cond_negate_256_block_spec_within
+      .x12 .x9 .x10 .x7 .x11 32 40 48 56
+      sp sign maskOld valueOld carryOld limb0 limb1 limb2 limb3
+      (base + divisorAbsOff) (by decide) (by decide) (by decide)
+  rw [EvmAsm.Evm64.condNegate256BlockPre_unfold,
+    EvmAsm.Evm64.condNegate256BlockPost_unfold] at hSpec
+  exact EvmAsm.Rv64.cpsTripleWithin_extend_code hmono hSpec
+
 end EvmAsm.Evm64.SDiv.Compose

--- a/EvmAsm/Evm64/SDiv/Compose/BaseFinalBlockSpecs.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BaseFinalBlockSpecs.lean
@@ -29,6 +29,26 @@ theorem divCall_spec_in_sdivCode
     (EvmAsm.Evm64.evm_sdiv_div_call_block_spec_within
       EvmAsm.Evm64.evm_sdivCallOff vOld (base + divCallOff))
 
+theorem divCall_spec_in_sdivCodeV4
+    (vOld : Word) (base : Word) :
+    EvmAsm.Rv64.cpsTripleWithin 1 (base + divCallOff)
+        ((base + divCallOff) + EvmAsm.Rv64.signExtend21 EvmAsm.Evm64.evm_sdivCallOff)
+      (sdivCodeV4 base)
+      (.x1 ↦ᵣ vOld)
+      (.x1 ↦ᵣ ((base + divCallOff) + 4)) := by
+  have hmono :
+      ∀ a i,
+        (EvmAsm.Evm64.evm_sdiv_div_call_block_code
+          EvmAsm.Evm64.evm_sdivCallOff (base + divCallOff)) a = some i →
+        (sdivCodeV4 base) a = some i := by
+    intro a i h
+    exact sdivCodeV4_divCall_sub (base := base) a i
+      (by simpa [divCallCode,
+        EvmAsm.Evm64.evm_sdiv_div_call_block_code] using h)
+  exact EvmAsm.Rv64.cpsTripleWithin_extend_code hmono
+    (EvmAsm.Evm64.evm_sdiv_div_call_block_spec_within
+      EvmAsm.Evm64.evm_sdivCallOff vOld (base + divCallOff))
+
 theorem signXor_spec_in_sdivCode
     (signDividend signDivisor : Word) (base : Word) :
     EvmAsm.Rv64.cpsTripleWithin 1 (base + signXorOff) ((base + signXorOff) + 4)
@@ -40,6 +60,25 @@ theorem signXor_spec_in_sdivCode
         (sdivCode base) a = some i := by
     intro a i h
     exact sdivCode_signXor_sub (base := base) a i
+      (by
+        rw [signXorCode, EvmAsm.Rv64.XOR', EvmAsm.Rv64.single,
+          EvmAsm.Rv64.CodeReq.ofProg_singleton]
+        exact h)
+  exact EvmAsm.Rv64.cpsTripleWithin_extend_code hmono
+    (EvmAsm.Rv64.xor_spec_gen_rd_eq_rs1_within .x8 .x9 signDividend signDivisor
+      (base + signXorOff) (by decide))
+
+theorem signXor_spec_in_sdivCodeV4
+    (signDividend signDivisor : Word) (base : Word) :
+    EvmAsm.Rv64.cpsTripleWithin 1 (base + signXorOff) ((base + signXorOff) + 4)
+      (sdivCodeV4 base)
+      ((.x8 ↦ᵣ signDividend) ** (.x9 ↦ᵣ signDivisor))
+      ((.x8 ↦ᵣ (signDividend ^^^ signDivisor)) ** (.x9 ↦ᵣ signDivisor)) := by
+  have hmono :
+      ∀ a i, (EvmAsm.Rv64.CodeReq.singleton (base + signXorOff) (.XOR .x8 .x8 .x9)) a = some i →
+        (sdivCodeV4 base) a = some i := by
+    intro a i h
+    exact sdivCodeV4_signXor_sub (base := base) a i
       (by
         rw [signXorCode, EvmAsm.Rv64.XOR', EvmAsm.Rv64.single,
           EvmAsm.Rv64.CodeReq.ofProg_singleton]
@@ -62,6 +101,26 @@ theorem savedRaRet_spec_in_sdivCode
         (sdivCode base) a = some i := by
     intro a i h
     exact sdivCode_savedRaRet_sub (base := base) a i
+      (by simpa [savedRaRetCode,
+        EvmAsm.Evm64.evm_sdiv_saved_ra_ret_block_code] using h)
+  exact EvmAsm.Rv64.cpsTripleWithin_extend_code hmono
+    (EvmAsm.Evm64.evm_sdiv_saved_ra_ret_block_spec_within .x18
+      vSavedRa (base + savedRaRetOff))
+
+theorem savedRaRet_spec_in_sdivCodeV4
+    (vSavedRa : Word) (base : Word) :
+    EvmAsm.Rv64.cpsTripleWithin 1 (base + savedRaRetOff)
+        ((vSavedRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)) &&& ~~~1)
+      (sdivCodeV4 base)
+      (.x18 ↦ᵣ vSavedRa)
+      (.x18 ↦ᵣ vSavedRa) := by
+  have hmono :
+      ∀ a i,
+        (EvmAsm.Evm64.evm_sdiv_saved_ra_ret_block_code .x18
+          (base + savedRaRetOff)) a = some i →
+        (sdivCodeV4 base) a = some i := by
+    intro a i h
+    exact sdivCodeV4_savedRaRet_sub (base := base) a i
       (by simpa [savedRaRetCode,
         EvmAsm.Evm64.evm_sdiv_saved_ra_ret_block_code] using h)
   exact EvmAsm.Rv64.cpsTripleWithin_extend_code hmono

--- a/EvmAsm/Evm64/SDiv/Compose/BaseResultSignFixBlockSpec.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BaseResultSignFixBlockSpec.lean
@@ -37,4 +37,32 @@ theorem resultSignFix_spec_in_sdivCode
     EvmAsm.Evm64.condNegate256BlockPost_unfold] at hSpec
   exact EvmAsm.Rv64.cpsTripleWithin_extend_code hmono hSpec
 
+theorem resultSignFix_spec_in_sdivCodeV4
+    (sp sign maskOld valueOld carryOld limb0 limb1 limb2 limb3 : Word)
+    (base : Word) :
+    EvmAsm.Rv64.cpsTripleWithin 21 (base + resultSignFixOff)
+      ((base + resultSignFixOff) + 84) (sdivCodeV4 base)
+      (resultSignFixPre sp sign maskOld valueOld carryOld
+        limb0 limb1 limb2 limb3)
+      (resultSignFixPost sp sign limb0 limb1 limb2 limb3) := by
+  rw [resultSignFixPre_unfold, resultSignFixPost_unfold]
+  have hmono :
+      ∀ a i,
+        (EvmAsm.Evm64.evm_sdiv_cond_negate_256_block_code
+          .x12 .x8 .x10 .x7 .x11 0 8 16 24
+          (base + resultSignFixOff)) a = some i →
+        (sdivCodeV4 base) a = some i := by
+    intro a i h
+    exact sdivCodeV4_resultSignFix_sub (base := base) a i
+      (by simpa [resultSignFixCode,
+        EvmAsm.Evm64.evm_sdiv_cond_negate_256_block_code] using h)
+  have hSpec :=
+    EvmAsm.Evm64.evm_sdiv_cond_negate_256_block_spec_within
+      .x12 .x8 .x10 .x7 .x11 0 8 16 24
+      sp sign maskOld valueOld carryOld limb0 limb1 limb2 limb3
+      (base + resultSignFixOff) (by decide) (by decide) (by decide)
+  rw [EvmAsm.Evm64.condNegate256BlockPre_unfold,
+    EvmAsm.Evm64.condNegate256BlockPost_unfold] at hSpec
+  exact EvmAsm.Rv64.cpsTripleWithin_extend_code hmono hSpec
+
 end EvmAsm.Evm64.SDiv.Compose

--- a/EvmAsm/Evm64/SDiv/Compose/SaveRaSignBlockSpecs.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/SaveRaSignBlockSpecs.lean
@@ -25,6 +25,22 @@ theorem saveRa_spec_in_sdivCode
     (EvmAsm.Evm64.evm_sdiv_save_ra_block_spec_within .x18
       vRa vSavedOld base (by decide))
 
+theorem saveRa_spec_in_sdivCodeV4
+    (vRa vSavedOld : Word) (base : Word) :
+    EvmAsm.Rv64.cpsTripleWithin 1 base (base + 4) (sdivCodeV4 base)
+      ((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ vSavedOld))
+      ((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))) := by
+  have hmono :
+      ∀ a i, (EvmAsm.Evm64.evm_sdiv_save_ra_block_code .x18 base) a = some i →
+        (sdivCodeV4 base) a = some i := by
+    intro a i h
+    exact sdivCodeV4_saveRa_sub (base := base) a i
+      (by simpa [saveRaCode, saveRaOff,
+        EvmAsm.Evm64.evm_sdiv_save_ra_block_code] using h)
+  exact EvmAsm.Rv64.cpsTripleWithin_extend_code hmono
+    (EvmAsm.Evm64.evm_sdiv_save_ra_block_spec_within .x18
+      vRa vSavedOld base (by decide))
+
 theorem dividendSign_spec_in_sdivCode
     (sp sOld dividendTop : Word) (base : Word) :
     EvmAsm.Rv64.cpsTripleWithin 2 (base + dividendSignOff) ((base + dividendSignOff) + 8)
@@ -51,6 +67,32 @@ theorem dividendSign_spec_in_sdivCode
       EvmAsm.Evm64.evm_sdivDividendTopLimbOff sp sOld dividendTop
       (base + dividendSignOff) (by decide))
 
+theorem dividendSign_spec_in_sdivCodeV4
+    (sp sOld dividendTop : Word) (base : Word) :
+    EvmAsm.Rv64.cpsTripleWithin 2 (base + dividendSignOff) ((base + dividendSignOff) + 8)
+      (sdivCodeV4 base)
+      ((.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sOld) **
+       ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ
+         dividendTop))
+      ((.x12 ↦ᵣ sp) **
+       (.x8 ↦ᵣ (dividendTop >>> (63 : BitVec 6).toNat)) **
+       ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ
+         dividendTop)) := by
+  have hmono :
+      ∀ a i,
+        (EvmAsm.Evm64.evm_sdiv_sign_bit_block_code .x12 .x8
+          EvmAsm.Evm64.evm_sdivDividendTopLimbOff
+          (base + dividendSignOff)) a = some i →
+        (sdivCodeV4 base) a = some i := by
+    intro a i h
+    exact sdivCodeV4_dividendSign_sub (base := base) a i
+      (by simpa [dividendSignCode,
+        EvmAsm.Evm64.evm_sdiv_sign_bit_block_code] using h)
+  exact EvmAsm.Rv64.cpsTripleWithin_extend_code hmono
+    (EvmAsm.Evm64.evm_sdiv_sign_bit_block_spec_within .x12 .x8
+      EvmAsm.Evm64.evm_sdivDividendTopLimbOff sp sOld dividendTop
+      (base + dividendSignOff) (by decide))
+
 theorem divisorSign_spec_in_sdivCode
     (sp sOld divisorTop : Word) (base : Word) :
     EvmAsm.Rv64.cpsTripleWithin 2 (base + divisorSignOff) ((base + divisorSignOff) + 8)
@@ -70,6 +112,32 @@ theorem divisorSign_spec_in_sdivCode
         (sdivCode base) a = some i := by
     intro a i h
     exact sdivCode_divisorSign_sub (base := base) a i
+      (by simpa [divisorSignCode,
+        EvmAsm.Evm64.evm_sdiv_sign_bit_block_code] using h)
+  exact EvmAsm.Rv64.cpsTripleWithin_extend_code hmono
+    (EvmAsm.Evm64.evm_sdiv_sign_bit_block_spec_within .x12 .x9
+      EvmAsm.Evm64.evm_sdivDivisorTopLimbOff sp sOld divisorTop
+      (base + divisorSignOff) (by decide))
+
+theorem divisorSign_spec_in_sdivCodeV4
+    (sp sOld divisorTop : Word) (base : Word) :
+    EvmAsm.Rv64.cpsTripleWithin 2 (base + divisorSignOff) ((base + divisorSignOff) + 8)
+      (sdivCodeV4 base)
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ sOld) **
+       ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff) ↦ₘ
+         divisorTop))
+      ((.x12 ↦ᵣ sp) **
+       (.x9 ↦ᵣ (divisorTop >>> (63 : BitVec 6).toNat)) **
+       ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff) ↦ₘ
+         divisorTop)) := by
+  have hmono :
+      ∀ a i,
+        (EvmAsm.Evm64.evm_sdiv_sign_bit_block_code .x12 .x9
+          EvmAsm.Evm64.evm_sdivDivisorTopLimbOff
+          (base + divisorSignOff)) a = some i →
+        (sdivCodeV4 base) a = some i := by
+    intro a i h
+    exact sdivCodeV4_divisorSign_sub (base := base) a i
       (by simpa [divisorSignCode,
         EvmAsm.Evm64.evm_sdiv_sign_bit_block_code] using h)
   exact EvmAsm.Rv64.cpsTripleWithin_extend_code hmono


### PR DESCRIPTION
## Summary
- add sdivCodeV4 leaf specs for save-ra and sign-bit wrapper blocks
- add sdivCodeV4 leaf specs for dividend/divisor absolute-value and result sign-fix blocks
- add sdivCodeV4 leaf specs for the div call, sign XOR, and saved-ra return blocks

## Verification
- lake build EvmAsm.Evm64.SDiv.Compose.SaveRaSignBlockSpecs EvmAsm.Evm64.SDiv.Compose.BaseDividendAbsBlockSpec EvmAsm.Evm64.SDiv.Compose.BaseDivisorAbsBlockSpec EvmAsm.Evm64.SDiv.Compose.BaseResultSignFixBlockSpec EvmAsm.Evm64.SDiv.Compose.BaseFinalBlockSpecs EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "sorry|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/SaveRaSignBlockSpecs.lean EvmAsm/Evm64/SDiv/Compose/BaseDividendAbsBlockSpec.lean EvmAsm/Evm64/SDiv/Compose/BaseDivisorAbsBlockSpec.lean EvmAsm/Evm64/SDiv/Compose/BaseResultSignFixBlockSpec.lean EvmAsm/Evm64/SDiv/Compose/BaseFinalBlockSpecs.lean