### PR TITLE
feat(sdiv): add v4 sign sequence specs

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/BaseDividendAbsSequence.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BaseDividendAbsSequence.lean
@@ -107,4 +107,100 @@ theorem saveRa_signs_then_dividendAbs_spec_in_sdivCode
       xperm_hyp hp) hPrefix hAbs
   simpa [pre, post] using hSeq
 
+theorem saveRa_signs_then_dividendAbs_spec_in_sdivCodeV4
+    (vRa vSavedOld sp sDividendOld sDivisorOld divisorTop
+      maskOld valueOld carryOld limb0 limb1 limb2 dividendTop : Word)
+    (base : Word) :
+    EvmAsm.Rv64.cpsTripleWithin 26 base ((base + dividendAbsOff) + 84) (sdivCodeV4 base)
+      (saveRaSignsThenDividendAbsPre vRa vSavedOld sp sDividendOld sDivisorOld
+        divisorTop maskOld valueOld carryOld
+        limb0 limb1 limb2 dividendTop)
+      (saveRaSignsThenDividendAbsPost vRa sp divisorTop
+        limb0 limb1 limb2 dividendTop) := by
+  rw [saveRaSignsThenDividendAbsPre_unfold,
+      saveRaSignsThenDividendAbsPost_unfold]
+  let sign := dividendTop >>> (63 : BitVec 6).toNat
+  let divisorSign := divisorTop >>> (63 : BitVec 6).toNat
+  let mem0 := sp + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)
+  let mem1 := sp + EvmAsm.Rv64.signExtend12 (8 : BitVec 12)
+  let mem2 := sp + EvmAsm.Rv64.signExtend12 (16 : BitVec 12)
+  let mem3 := sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff
+  let divisorMem3 := sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff
+  let mask := (0 : Word) - sign
+  let xored0 := limb0 ^^^ mask
+  let sum0 := xored0 + sign
+  let carry0 := if BitVec.ult sum0 sign then (1 : Word) else 0
+  let xored1 := limb1 ^^^ mask
+  let sum1 := xored1 + carry0
+  let carry1 := if BitVec.ult sum1 carry0 then (1 : Word) else 0
+  let xored2 := limb2 ^^^ mask
+  let sum2 := xored2 + carry1
+  let carry2 := if BitVec.ult sum2 carry1 then (1 : Word) else 0
+  let xored3 := dividendTop ^^^ mask
+  let sum3 := xored3 + carry2
+  let carry3 := if BitVec.ult sum3 carry2 then (1 : Word) else 0
+  let extra : EvmAsm.Rv64.Assertion :=
+    (((.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ maskOld) **
+      (.x7 ↦ᵣ valueOld) ** (.x11 ↦ᵣ carryOld)) **
+     ((mem0 ↦ₘ limb0) ** (mem1 ↦ₘ limb1) ** (mem2 ↦ₘ limb2)))
+  let pre : EvmAsm.Rv64.Assertion :=
+    (((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ vSavedOld)) **
+       ((.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sDividendOld) ** (mem3 ↦ₘ dividendTop))) **
+      ((.x9 ↦ᵣ sDivisorOld) ** (divisorMem3 ↦ₘ divisorTop))) **
+     extra)
+  let mid : EvmAsm.Rv64.Assertion :=
+    (((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))) **
+       ((.x8 ↦ᵣ sign) ** (mem3 ↦ₘ dividendTop))) **
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ divisorSign) ** (divisorMem3 ↦ₘ divisorTop))) **
+     extra)
+  let absPre : EvmAsm.Rv64.Assertion :=
+    ((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))) **
+      ((.x9 ↦ᵣ divisorSign) ** (divisorMem3 ↦ₘ divisorTop))) **
+     ((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sign) **
+      (.x10 ↦ᵣ maskOld) ** (.x7 ↦ᵣ valueOld) ** (.x11 ↦ᵣ carryOld) **
+      (mem0 ↦ₘ limb0) ** (mem1 ↦ₘ limb1) **
+      (mem2 ↦ₘ limb2) ** (mem3 ↦ₘ dividendTop)))
+  let post : EvmAsm.Rv64.Assertion :=
+    ((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))) **
+      ((.x9 ↦ᵣ divisorSign) ** (divisorMem3 ↦ₘ divisorTop))) **
+     ((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sign) **
+      (.x10 ↦ᵣ mask) ** (.x7 ↦ᵣ sum3) ** (.x11 ↦ᵣ carry3) **
+      (mem0 ↦ₘ sum0) ** (mem1 ↦ₘ sum1) **
+      (mem2 ↦ₘ sum2) ** (mem3 ↦ₘ sum3)))
+  have hPrefix : EvmAsm.Rv64.cpsTripleWithin 5 base (base + dividendAbsOff)
+      (sdivCodeV4 base) pre mid := by
+    dsimp [pre, mid, extra, mem3, divisorMem3, sign, divisorSign]
+    simpa [divisorSignOff, dividendAbsOff, BitVec.add_assoc,
+      saveRaDividendSignThenDivisorSignPre_unfold,
+      saveRaDividendSignThenDivisorSignPost_unfold] using
+      (EvmAsm.Rv64.cpsTripleWithin_frameR
+        (((.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ maskOld) **
+          (.x7 ↦ᵣ valueOld) ** (.x11 ↦ᵣ carryOld)) **
+         ((mem0 ↦ₘ limb0) ** (mem1 ↦ₘ limb1) ** (mem2 ↦ₘ limb2)))
+        (by pcFree)
+        (saveRa_dividendSign_then_divisorSign_spec_in_sdivCodeV4
+          vRa vSavedOld sp sDividendOld dividendTop sDivisorOld divisorTop
+          base))
+  have hAbs : EvmAsm.Rv64.cpsTripleWithin 21 (base + dividendAbsOff)
+      ((base + dividendAbsOff) + 84) (sdivCodeV4 base) absPre post := by
+    have hSpec := dividendAbs_spec_in_sdivCodeV4
+      sp sign maskOld valueOld carryOld limb0 limb1 limb2 dividendTop
+      base
+    rw [dividendAbsPre_unfold, dividendAbsPost_unfold] at hSpec
+    simpa [absPre, post, mem0, mem1, mem2, mem3,
+      EvmAsm.Evm64.evm_sdivDividendTopLimbOff, mask, xored0, sum0,
+      carry0, xored1, sum1, carry1, xored2, sum2, carry2, xored3, sum3,
+      carry3] using
+      EvmAsm.Rv64.cpsTripleWithin_frameL
+        ((((.x1 ↦ᵣ vRa) **
+          (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))) **
+          ((.x9 ↦ᵣ divisorSign) ** (divisorMem3 ↦ₘ divisorTop))))
+        (by pcFree)
+        hSpec
+  have hSeq := EvmAsm.Rv64.cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by
+      dsimp [mid, absPre, extra] at hp ⊢
+      xperm_hyp hp) hPrefix hAbs
+  simpa [pre, post] using hSeq
+
 end EvmAsm.Evm64.SDiv.Compose

--- a/EvmAsm/Evm64/SDiv/Compose/BaseSignSequence.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BaseSignSequence.lean
@@ -82,4 +82,76 @@ theorem saveRa_dividendSign_then_divisorSign_spec_in_sdivCode
       xperm_hyp hp) hPrefix hDivisor
   simpa [pre, post] using hSeq
 
+theorem saveRa_dividendSign_then_divisorSign_spec_in_sdivCodeV4
+    (vRa vSavedOld sp sDividendOld dividendTop sDivisorOld divisorTop : Word)
+    (base : Word) :
+    EvmAsm.Rv64.cpsTripleWithin 5 base ((base + divisorSignOff) + 8) (sdivCodeV4 base)
+      (saveRaDividendSignThenDivisorSignPre vRa vSavedOld sp sDividendOld
+        dividendTop sDivisorOld divisorTop)
+      (saveRaDividendSignThenDivisorSignPost vRa sp dividendTop divisorTop) := by
+  rw [saveRaDividendSignThenDivisorSignPre_unfold,
+      saveRaDividendSignThenDivisorSignPost_unfold]
+  let pre : EvmAsm.Rv64.Assertion :=
+    ((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ vSavedOld)) **
+      ((.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sDividendOld) **
+       ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ
+         dividendTop))) **
+     ((.x9 ↦ᵣ sDivisorOld) **
+      ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff) ↦ₘ
+        divisorTop)))
+  let mid : EvmAsm.Rv64.Assertion :=
+    ((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))) **
+      ((.x12 ↦ᵣ sp) **
+       (.x8 ↦ᵣ (dividendTop >>> (63 : BitVec 6).toNat)) **
+       ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ
+         dividendTop))) **
+     ((.x9 ↦ᵣ sDivisorOld) **
+      ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff) ↦ₘ
+        divisorTop)))
+  let midDivisor : EvmAsm.Rv64.Assertion :=
+    ((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))) **
+      ((.x8 ↦ᵣ (dividendTop >>> (63 : BitVec 6).toNat)) **
+       ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ
+         dividendTop))) **
+     ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ sDivisorOld) **
+      ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff) ↦ₘ
+        divisorTop)))
+  let post : EvmAsm.Rv64.Assertion :=
+    ((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))) **
+      ((.x8 ↦ᵣ (dividendTop >>> (63 : BitVec 6).toNat)) **
+       ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ
+         dividendTop))) **
+     ((.x12 ↦ᵣ sp) **
+      (.x9 ↦ᵣ (divisorTop >>> (63 : BitVec 6).toNat)) **
+      ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff) ↦ₘ
+        divisorTop)))
+  have hPrefix : EvmAsm.Rv64.cpsTripleWithin 3 base (base + divisorSignOff)
+      (sdivCodeV4 base) pre mid := by
+    dsimp [pre, mid]
+    simpa [dividendSignOff, divisorSignOff, BitVec.add_assoc] using
+      (EvmAsm.Rv64.cpsTripleWithin_frameR
+        ((.x9 ↦ᵣ sDivisorOld) **
+         ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDivisorTopLimbOff) ↦ₘ
+          divisorTop))
+        (by pcFree)
+        (saveRa_then_dividendSign_spec_in_sdivCodeV4
+          vRa vSavedOld sp sDividendOld dividendTop base))
+  have hDivisor : EvmAsm.Rv64.cpsTripleWithin 2 (base + divisorSignOff)
+      ((base + divisorSignOff) + 8) (sdivCodeV4 base) midDivisor post := by
+    dsimp [midDivisor, post]
+    exact
+      EvmAsm.Rv64.cpsTripleWithin_frameL
+        (((.x1 ↦ᵣ vRa) **
+          (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))) **
+         ((.x8 ↦ᵣ (dividendTop >>> (63 : BitVec 6).toNat)) **
+          ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ
+            dividendTop)))
+        (by pcFree)
+        (divisorSign_spec_in_sdivCodeV4 sp sDivisorOld divisorTop base)
+  have hSeq := EvmAsm.Rv64.cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by
+      dsimp [mid, midDivisor] at hp ⊢
+      xperm_hyp hp) hPrefix hDivisor
+  simpa [pre, post] using hSeq
+
 end EvmAsm.Evm64.SDiv.Compose

--- a/EvmAsm/Evm64/SDiv/Compose/SaveRaSignBlocks.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/SaveRaSignBlocks.lean
@@ -37,4 +37,30 @@ theorem saveRa_then_dividendSign_spec_in_sdivCode
       (dividendSign_spec_in_sdivCode sp sOld dividendTop base)
   exact EvmAsm.Rv64.cpsTripleWithin_seq_same_cr hSave hSign
 
+theorem saveRa_then_dividendSign_spec_in_sdivCodeV4
+    (vRa vSavedOld sp sOld dividendTop : Word) (base : Word) :
+    EvmAsm.Rv64.cpsTripleWithin 3 base ((base + dividendSignOff) + 8) (sdivCodeV4 base)
+      (((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ vSavedOld)) **
+       ((.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sOld) **
+        ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ
+          dividendTop)))
+      (((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))) **
+       ((.x12 ↦ᵣ sp) **
+        (.x8 ↦ᵣ (dividendTop >>> (63 : BitVec 6).toNat)) **
+        ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ
+          dividendTop))) := by
+  have hSave :=
+    EvmAsm.Rv64.cpsTripleWithin_frameR
+      (((.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sOld) **
+        ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_sdivDividendTopLimbOff) ↦ₘ
+          dividendTop)))
+      (by pcFree)
+      (saveRa_spec_in_sdivCodeV4 vRa vSavedOld base)
+  have hSign :=
+    EvmAsm.Rv64.cpsTripleWithin_frameL
+      (((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))))
+      (by pcFree)
+      (dividendSign_spec_in_sdivCodeV4 sp sOld dividendTop base)
+  exact EvmAsm.Rv64.cpsTripleWithin_seq_same_cr hSave hSign
+
 end EvmAsm.Evm64.SDiv.Compose


### PR DESCRIPTION
## Summary
- add a sdivCodeV4 composition for save-ra followed by dividend sign probing
- add a sdivCodeV4 composition for save-ra, dividend sign, then divisor sign probing

## Verification
- lake build EvmAsm.Evm64.SDiv.Compose.SaveRaSignBlocks EvmAsm.Evm64.SDiv.Compose.BaseSignSequence EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "sorry|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/SaveRaSignBlocks.lean EvmAsm/Evm64/SDiv/Compose/BaseSignSequence.lean