### PR TITLE
feat(codegen): M6b — wire 83 EVM opcodes through the M5b dispatcher

### DIFF
--- a/CODEGEN.md
+++ b/CODEGEN.md
@@ -38,8 +38,8 @@ untouched. Generated artifacts go in `gen-out/` (gitignored).
 | `EvmAsm/Codegen.lean` | Top-level umbrella (mirrors `EvmAsm/Rv64.lean`, `EvmAsm/Evm64.lean`). |
 | `EvmAsm/Codegen/Emit.lean` | Pure `emitReg`, `emitInstr`, `emitProgram` — `Instr → String`. No `IO`. |
 | `EvmAsm/Codegen/Layout.lean` | `HaltConv` enum, halt stubs, `_start` preamble, `.option norvc`, `MEM_START`/`MEM_END` constants, `BuildUnit` struct + `emitBuildUnit`/`emitDataLabel` helpers. |
-| `EvmAsm/Codegen/Dispatch.lean` | M5b dispatcher scaffolding: `OpcodeHandlerSpec` + `HandlerTail` types, `emitDispatcherPrologue`/`Epilogue`/`DataSection` and `buildDispatchUnit` helpers. Pure (no IO). |
-| `EvmAsm/Codegen/Programs.lean` | Registry (`smoke`, `evm_add`, `evm_div`, `evm_mod`, `input_echo`, `evm_add_from_input`, `evm_div_from_input`, `evm_mod_from_input`, `tiny_interp_{add,add2}`, `tiny_interp_dispatch_{add,add2}` → `BuildUnit`) plus the M5b opcode handler registry (`tinyInterpRegistry`) and shared helpers (`advancePc`, `copy64`, `evmAddEpilogue`, `evmDivPatched`/`evmModPatched` for the DIV/MOD NOP-splice). |
+| `EvmAsm/Codegen/Dispatch.lean` | M5b dispatcher scaffolding: `OpcodeHandlerSpec` (with optional `preBody` for x10-clobbering handlers) + `HandlerTail` types, `emitDispatcherPrologue`/`Epilogue`/`DataSection` and `buildDispatchUnit` helpers. Pure (no IO). |
+| `EvmAsm/Codegen/Programs.lean` | Registry (`smoke`, `evm_add`, `evm_div`, `evm_mod`, `input_echo`, `evm_add_from_input`, `evm_div_from_input`, `evm_mod_from_input`, `tiny_interp_{add,add2}`, `tiny_interp_dispatch_{add,add2}` → `BuildUnit`) plus the M5b opcode handler registry (`tinyInterpRegistry`) composed from `pushHandlers` (PUSH0..32), `dupHandlers` (DUP1..16), `swapHandlers` (SWAP1..16), `singletonHandlers` (17 fixed-shape opcodes), `stopHandler`; shared helpers (`advancePc`, `copy64`, `evmAddEpilogue`, `evmDivPatched`/`evmModPatched` for the DIV/MOD NOP-splice). |
 | `EvmAsm/Codegen/Tests/Cases.lean` | Per-opcode regression test registry: `OpcodeTestCase` struct + `opcodeTestCases` list. Wraps each bytecode through the M5b dispatcher for end-to-end ziskemu validation. |
 | `EvmAsm/Codegen/Cli.lean` | Argument parsing (`--program`, `--test-case`, `--list-test-cases`, `--halt`, `--out`, `--asm-only`). |
 | `EvmAsm/Codegen/Driver.lean` | `IO`: shells out to `as`/`ld` if available; `--asm-only` for CI without the cross toolchain. |
@@ -408,13 +408,60 @@ the same order.
 pass); `scripts/codegen-tiny-interp{,-dispatch}-check.sh` continue
 to exit 0; M2/M4 scripts unchanged.
 
+### M6b — Mass wire-up of fixed-shape opcodes (M) — **DONE (2026-05-20)**
+
+Bring M5b dispatcher coverage from 3 → 82 opcodes by registering
+every verified handler that matches the standard ABI (`<body>` +
+`addi x10, x10, width` + `ret`). Pure registry expansion against
+M6a's infrastructure; the dispatcher scaffolding (loop, jump table,
+exit path) is unchanged from M6a.
+
+**Delivered:**
+- `EvmAsm/Codegen/Programs.lean` `tinyInterpRegistry` now composed
+  from four builders:
+  - `pushHandlers` — PUSH0..PUSH32 (33 entries, opcode bytes
+    `0x5f + n`, tail `.advanceAndRet (1 + n)`).
+  - `dupHandlers` — DUP1..DUP16 (16 entries, opcode bytes
+    `0x7f + n`, tail `.advanceAndRet 1`).
+  - `swapHandlers` — SWAP1..SWAP16 (16 entries, opcode bytes
+    `0x8f + n`, tail `.advanceAndRet 1`).
+  - `singletonHandlers` — 17 fixed-shape singletons: ADD, MUL, SUB,
+    SIGNEXTEND, LT, GT, SLT, SGT, EQ, ISZERO, AND, OR, XOR, NOT,
+    BYTE, SHR, POP.
+  Plus `stopHandler` for STOP. Total: 33 + 16 + 16 + 17 + 1 =
+  **83 wired opcodes**; remaining 173 bytes fall to `h_invalid`.
+- **`OpcodeHandlerSpec.preBody : String`** added in
+  `EvmAsm/Codegen/Dispatch.lean`. Used to inject raw asm between
+  the handler's label and verified body. Required because four
+  verified bodies (`evm_mul`, `evm_signextend`, `evm_byte`,
+  `evm_shr`) use `x10` as a scratch accumulator, which clobbers
+  our dispatcher's preserved EVM code pointer. Those handlers
+  carry `preBody := "  mv x9, x10"` to stash the code pointer in
+  `x9` (a register no verified opcode body touches) and a
+  `x10RestoreAdvance1` tail that restores it before the standard
+  advance + ret. Discovered empirically when `mul_basic` panicked
+  ziskemu with `Mem::read() section not found for addr: 1` — the
+  `addi x10, x10, 1` after `MULHU .x10 ...` landed at address 1.
+- **`EvmAsm/Codegen/Tests/Cases.lean`** grew from 2 to 22 cases:
+  16 singleton tests (one per opcode), 3 family representatives
+  (`push32_basic`, `dup1_basic`, `swap1_basic`), one `arith_mix`
+  kitchen sink, plus the two M6a baseline cases (`add_basic`,
+  `add_chain`).
+
+**Exit criteria (met).**
+`scripts/codegen-opcodes-check.sh` exits 0 with all 22 cases
+PASS; `scripts/codegen-tiny-interp{,-dispatch}-check.sh`,
+`codegen-smoke.sh`, and `codegen-evm_add-check.sh` continue to
+exit 0; full M6b suite runs in ~48 s (under the 60 s threshold
+for considering the runtime-bytecode optimization).
+
 ### Sequencing
 
-M0 ✅ → M1 ✅ → M2 ✅ → M4 ✅ → M5a ✅ → M5b ✅ → M6a ✅.
+M0 ✅ → M1 ✅ → M2 ✅ → M4 ✅ → M5a ✅ → M5b ✅ → M6a ✅ → M6b ✅.
 M3 is deferred; revisit only if a future milestone (full opcode
 coverage, JUMP/JUMPI, or the binary encoder) makes label-free
-emission unreadable. M6a unblocks mass opcode wire-up (M6b) by
-making each new opcode a one-record registry append.
+emission unreadable. M6b unblocks M7 (memory opcodes) by validating
+the registry pattern at scale.
 
 ## Tricky bits / open questions
 
@@ -485,17 +532,19 @@ making each new opcode a one-record registry append.
   `add_chain`) migrated as the seed regression suite. `--list-test-cases`
   emits TSV with expected outputs so the bash runner stays in sync
   with `Tests/Cases.lean` automatically.
+- **M6b.** ✅ `scripts/codegen-opcodes-check.sh` exits 0 with **22
+  test cases** PASS (validated 2026-05-20). 83 opcodes wired through
+  `tinyInterpRegistry`: PUSH0..32, DUP1..16, SWAP1..16, plus 17
+  fixed-shape singletons (ADD, MUL, SUB, SIGNEXTEND, LT, GT, SLT,
+  SGT, EQ, ISZERO, AND, OR, XOR, NOT, BYTE, SHR, POP) and STOP.
+  Four handlers that clobber `x10` (MUL, SIGNEXTEND, BYTE, SHR)
+  use the new `OpcodeHandlerSpec.preBody` field to save the EVM
+  code pointer in `x9` before the body and restore it in the tail.
 
-## Future work (post-M6a)
+## Future work (post-M6b)
 
 Near-term (builds directly on M6a's registry; no new design surface):
 
-- **M6b — mass wire-up of fixed-shape opcodes.** SUB, MUL, AND, OR,
-  XOR, NOT, LT, GT, SLT, SGT, EQ, ISZERO, BYTE, SHR, POP, PUSH0
-  (one `OpcodeHandlerSpec` each), then parametric PUSH2..32 / DUP1..16
-  / SWAP1..16 builders. ~80 opcodes wired with one batch + a test
-  case per family. Pure registry expansion against M6a's
-  `tinyInterpRegistry`.
 - **M7 — memory opcodes.** MLOAD / MSTORE / MSTORE8 / MSIZE are
   register-parameterized verified `Program`s (take a `memBase` /
   `sizeReg`). Need to extend `emitDispatcherPrologue` to init an

--- a/EvmAsm/Codegen/Dispatch.lean
+++ b/EvmAsm/Codegen/Dispatch.lean
@@ -42,6 +42,15 @@ structure OpcodeHandlerSpec where
   /-- Opcode bytes this handler covers. Bytes not claimed by any
       spec route to `h_invalid` via the jump table fill. -/
   opcodes : List Nat
+  /-- Raw asm emitted *between* the label and the verified body.
+      Used to save dispatcher-state registers that the verified body
+      may clobber. For example, `evm_mul` / `evm_signextend` /
+      `evm_byte` / `evm_shr` use `x10` as a scratch accumulator —
+      our dispatcher expects `x10` to be the preserved EVM code
+      pointer, so those handlers carry `preBody := "  mv x9, x10"`
+      and a tail that restores via `mv x10, x9` before advancing.
+      Empty string means "no save needed". -/
+  preBody : String := ""
   /-- Verified RV64 body, rendered verbatim via `emitProgram`.
       May be empty (e.g. STOP has no work to do before exiting). -/
   body    : Program
@@ -57,11 +66,13 @@ def emitTail : HandlerTail → String
 
 /-- Render the handler as a labeled subroutine. Empty bodies (STOP,
     INVALID-style entries) skip the body line entirely to avoid a
-    blank line after the label. -/
+    blank line after the label. `preBody` is inserted between the
+    label and the body (used for clobber-saving). -/
 def emitSubroutine (h : OpcodeHandlerSpec) : String :=
+  let preLine  := if h.preBody.isEmpty then "" else h.preBody ++ "\n"
   let bodyText := emitProgram h.body
   let bodyLine := if bodyText.isEmpty then "" else bodyText ++ "\n"
-  s!"{h.label}:\n" ++ bodyLine ++ emitTail h.tail
+  s!"{h.label}:\n" ++ preLine ++ bodyLine ++ emitTail h.tail
 
 end OpcodeHandlerSpec
 

--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -7,8 +7,26 @@
 
 import EvmAsm.Rv64.Program
 import EvmAsm.Evm64.Add.Program
+import EvmAsm.Evm64.And.Program
+import EvmAsm.Evm64.Byte.Program
 import EvmAsm.Evm64.DivMod.Program
+import EvmAsm.Evm64.Dup.Program
+import EvmAsm.Evm64.Eq.Program
+import EvmAsm.Evm64.Gt.Program
+import EvmAsm.Evm64.IsZero.Program
+import EvmAsm.Evm64.Lt.Program
+import EvmAsm.Evm64.Multiply.Program
+import EvmAsm.Evm64.Not.Program
+import EvmAsm.Evm64.Or.Program
+import EvmAsm.Evm64.Pop.Program
 import EvmAsm.Evm64.Push.Program
+import EvmAsm.Evm64.Sgt.Program
+import EvmAsm.Evm64.Shift.Program
+import EvmAsm.Evm64.SignExtend.Program
+import EvmAsm.Evm64.Slt.Program
+import EvmAsm.Evm64.Sub.Program
+import EvmAsm.Evm64.Swap.Program
+import EvmAsm.Evm64.Xor.Program
 import EvmAsm.Codegen.Layout
 import EvmAsm.Codegen.Dispatch
 
@@ -303,26 +321,102 @@ def tinyInterpAdd2Unit : BuildUnit := {
                               and the table base on every iteration,
                               so no preservation needed)
 
-    Coverage: PUSH1, ADD, STOP. All other opcode bytes fall to
-    `h_invalid` (emitted automatically by `emitDispatcherEpilogue`),
-    which takes the same exit path as STOP. -/
+    Coverage (M6b): 81 opcodes wired —
+      - **PUSH0..PUSH32** (33) via `pushHandlers`
+      - **DUP1..DUP16** (16) via `dupHandlers`
+      - **SWAP1..SWAP16** (16) via `swapHandlers`
+      - **16 fixed-shape singletons** via `singletonHandlers`:
+        SUB, MUL, SIGNEXTEND, AND, OR, XOR, NOT, LT, GT, SLT, SGT,
+        EQ, ISZERO, BYTE, SHR, POP — each a parameter-free verified
+        `Program` with the standard `<body>` + `addi x10, x10, 1` +
+        `ret` ABI.
+      - **STOP** via `stopHandler` (jumps to `.exit_label` instead
+        of returning to the dispatcher).
+
+    All other opcode bytes fall to `h_invalid` (emitted automatically
+    by `emitDispatcherEpilogue`), which takes the same exit path as
+    STOP. -/
+
+/-- PUSH0..PUSH32. Opcode byte = `0x5f + n`; the handler advances
+    `x10` by `1 + n` (one opcode byte + `n` immediate bytes). -/
+def pushHandlers : List OpcodeHandlerSpec :=
+  (List.range 33).map (fun n =>
+    { label   := s!"h_PUSH{n}"
+      opcodes := [0x5f + n]
+      body    := EvmAsm.Evm64.evm_push n
+      tail    := .advanceAndRet (1 + n) })
+
+/-- DUP1..DUP16. Opcode byte = `0x7f + n` (so DUP1 = `0x80`);
+    width 1. `evm_dup n` duplicates the n-th stack item (1-indexed
+    from top) onto the top. -/
+def dupHandlers : List OpcodeHandlerSpec :=
+  (List.range 16).map (fun i =>
+    let n := i + 1
+    { label   := s!"h_DUP{n}"
+      opcodes := [0x7f + n]
+      body    := EvmAsm.Evm64.evm_dup n
+      tail    := .advanceAndRet 1 })
+
+/-- SWAP1..SWAP16. Opcode byte = `0x8f + n` (so SWAP1 = `0x90`);
+    width 1. `evm_swap n` swaps the top with the (n+1)-th stack
+    item. -/
+def swapHandlers : List OpcodeHandlerSpec :=
+  (List.range 16).map (fun i =>
+    let n := i + 1
+    { label   := s!"h_SWAP{n}"
+      opcodes := [0x8f + n]
+      body    := EvmAsm.Evm64.evm_swap n
+      tail    := .advanceAndRet 1 })
+
+/-- Tail used by handlers whose verified body clobbers `x10` (the
+    EVM code pointer in our dispatcher convention). Restores `x10`
+    from `x9` (saved via `preBody`), then advances by 1 and returns. -/
+private def x10RestoreAdvance1 : HandlerTail :=
+  .custom "  mv x10, x9\n  addi x10, x10, 1\n  ret"
+
+/-- Fixed-shape singleton opcodes: parameter-free verified `Program`s
+    that fit the standard `<body>` + `addi x10, x10, 1` + `ret` ABI.
+
+    Four bodies (`evm_mul`, `evm_signextend`, `evm_byte`, `evm_shr`)
+    use `x10` as an internal scratch / accumulator register, which
+    clobbers our dispatcher's preserved EVM code pointer. They carry
+    `preBody := "  mv x9, x10"` to stash x10 in x9 (a register no
+    verified opcode body touches) and use `x10RestoreAdvance1` as
+    the tail to restore before advancing. -/
+def singletonHandlers : List OpcodeHandlerSpec :=
+  [ { label := "h_ADD"        , opcodes := [0x01], body := EvmAsm.Evm64.evm_add       , tail := .advanceAndRet 1 }
+  , { label := "h_MUL"        , opcodes := [0x02], preBody := "  mv x9, x10", body := EvmAsm.Evm64.evm_mul       , tail := x10RestoreAdvance1 }
+  , { label := "h_SUB"        , opcodes := [0x03], body := EvmAsm.Evm64.evm_sub       , tail := .advanceAndRet 1 }
+  , { label := "h_SIGNEXTEND" , opcodes := [0x0b], preBody := "  mv x9, x10", body := EvmAsm.Evm64.evm_signextend, tail := x10RestoreAdvance1 }
+  , { label := "h_LT"         , opcodes := [0x10], body := EvmAsm.Evm64.evm_lt        , tail := .advanceAndRet 1 }
+  , { label := "h_GT"         , opcodes := [0x11], body := EvmAsm.Evm64.evm_gt        , tail := .advanceAndRet 1 }
+  , { label := "h_SLT"        , opcodes := [0x12], body := EvmAsm.Evm64.evm_slt       , tail := .advanceAndRet 1 }
+  , { label := "h_SGT"        , opcodes := [0x13], body := EvmAsm.Evm64.evm_sgt       , tail := .advanceAndRet 1 }
+  , { label := "h_EQ"         , opcodes := [0x14], body := EvmAsm.Evm64.evm_eq        , tail := .advanceAndRet 1 }
+  , { label := "h_ISZERO"     , opcodes := [0x15], body := EvmAsm.Evm64.evm_iszero    , tail := .advanceAndRet 1 }
+  , { label := "h_AND"        , opcodes := [0x16], body := EvmAsm.Evm64.evm_and       , tail := .advanceAndRet 1 }
+  , { label := "h_OR"         , opcodes := [0x17], body := EvmAsm.Evm64.evm_or        , tail := .advanceAndRet 1 }
+  , { label := "h_XOR"        , opcodes := [0x18], body := EvmAsm.Evm64.evm_xor       , tail := .advanceAndRet 1 }
+  , { label := "h_NOT"        , opcodes := [0x19], body := EvmAsm.Evm64.evm_not       , tail := .advanceAndRet 1 }
+  , { label := "h_BYTE"       , opcodes := [0x1a], preBody := "  mv x9, x10", body := EvmAsm.Evm64.evm_byte      , tail := x10RestoreAdvance1 }
+  , { label := "h_SHR"        , opcodes := [0x1c], preBody := "  mv x9, x10", body := EvmAsm.Evm64.evm_shr       , tail := x10RestoreAdvance1 }
+  , { label := "h_POP"        , opcodes := [0x50], body := EvmAsm.Evm64.evm_pop       , tail := .advanceAndRet 1 } ]
+
+/-- STOP: transitions out of the dispatcher loop instead of returning
+    to it. The body is empty; the dispatcher's `jalr` lands on
+    `h_STOP:` which jumps to `.exit_label`. -/
+def stopHandler : OpcodeHandlerSpec :=
+  { label   := "h_STOP"
+    opcodes := [0x00]
+    body    := []
+    tail    := .custom "  j .exit_label" }
 
 /-- M5b dispatch registry. Order doesn't affect correctness — the
     256-entry jump table is built by `jumpTargetLabel`, which scans
     the list for a spec whose `opcodes` contains the byte. -/
 def tinyInterpRegistry : List OpcodeHandlerSpec :=
-  [ { label   := "h_PUSH1"
-      opcodes := [0x60]
-      body    := EvmAsm.Evm64.evm_push 1
-      tail    := .advanceAndRet 2 }
-  , { label   := "h_ADD"
-      opcodes := [0x01]
-      body    := EvmAsm.Evm64.evm_add
-      tail    := .advanceAndRet 1 }
-  , { label   := "h_STOP"
-      opcodes := [0x00]
-      body    := []
-      tail    := .custom "  j .exit_label" } ]
+  pushHandlers ++ dupHandlers ++ swapHandlers ++ singletonHandlers ++
+  [stopHandler]
 
 def tinyInterpDispatchAddUnit : BuildUnit :=
   buildDispatchUnit tinyInterpRegistry evmAddEpilogue tinyInterpAddBytecode

--- a/EvmAsm/Codegen/Tests/Cases.lean
+++ b/EvmAsm/Codegen/Tests/Cases.lean
@@ -32,11 +32,23 @@ structure OpcodeTestCase where
   expectedOutHex : String
 
 /-- Registry of test cases. M5a/M5b's two original bytecodes are
-    migrated here; they keep the original expected hex strings so
-    the new harness cross-checks against the existing per-bytecode
-    scripts. -/
+    migrated as `add_basic` / `add_chain`; M6b adds ~20 more — one
+    per singleton opcode, one per parametric family, plus a kitchen-
+    sink case that chains multiple opcodes.
+
+    EVM convention reminder: stack values are 256-bit big-endian;
+    `OUTPUT_ADDR` receives the post-STOP stack top as 32 bytes,
+    interpreted as four little-endian u64 limbs. So `0x42` on the
+    EVM stack surfaces as `42 00 00 00 00 00 00 00 ...` (low byte
+    first in the LE limb encoding).
+
+    Binary opcodes pop top (`a`) then second (`b`); the order
+    matters for non-commutative ones (`SUB`, `DIV`, `MOD`, `SHR`,
+    comparisons). For SUB specifically: pushes `a - b` where `a`
+    was the top — so `PUSH1 0x03; PUSH1 0x05; SUB` yields `5 - 3 = 2`. -/
 def opcodeTestCases : List OpcodeTestCase :=
-  [ -- PUSH1 0xFF; PUSH1 0x01; ADD; STOP → 0x100, LE limbs [0x100, 0, 0, 0]
+  [ -- ## Baseline (migrated from M5a/M5b)
+    -- PUSH1 0xff; PUSH1 0x01; ADD; STOP → 0x100
     { name           := "add_basic"
       bytecode       := "0x60, 0xff, 0x60, 0x01, 0x01, 0x00"
       expectedOutHex := "0001000000000000000000000000000000000000000000000000000000000000" }
@@ -44,6 +56,96 @@ def opcodeTestCases : List OpcodeTestCase :=
     { name           := "add_chain"
       bytecode       := "0x60, 0x10, 0x60, 0x20, 0x01, 0x60, 0x30, 0x01, 0x00"
       expectedOutHex := "6000000000000000000000000000000000000000000000000000000000000000" }
+    -- ## Singletons (16, one per fixed-shape opcode)
+  , -- PUSH1 0x03; PUSH1 0x05; SUB; STOP → 5 - 3 = 2
+    { name           := "sub_basic"
+      bytecode       := "0x60, 0x03, 0x60, 0x05, 0x03, 0x00"
+      expectedOutHex := "0200000000000000000000000000000000000000000000000000000000000000" }
+  , -- PUSH1 0x03; PUSH1 0x04; MUL; STOP → 4 * 3 = 12 = 0x0c
+    { name           := "mul_basic"
+      bytecode       := "0x60, 0x03, 0x60, 0x04, 0x02, 0x00"
+      expectedOutHex := "0c00000000000000000000000000000000000000000000000000000000000000" }
+  , -- PUSH1 0x7f; PUSH1 0x00; SIGNEXTEND; STOP — byte 0 of 0x7f has
+    -- high bit 0, so sign-extension is a no-op → 0x7f.
+    { name           := "signextend_basic"
+      bytecode       := "0x60, 0x7f, 0x60, 0x00, 0x0b, 0x00"
+      expectedOutHex := "7f00000000000000000000000000000000000000000000000000000000000000" }
+  , -- PUSH1 0x05; PUSH1 0x03; LT; STOP → 3 < 5 = 1
+    { name           := "lt_basic"
+      bytecode       := "0x60, 0x05, 0x60, 0x03, 0x10, 0x00"
+      expectedOutHex := "0100000000000000000000000000000000000000000000000000000000000000" }
+  , -- PUSH1 0x03; PUSH1 0x05; GT; STOP → 5 > 3 = 1
+    { name           := "gt_basic"
+      bytecode       := "0x60, 0x03, 0x60, 0x05, 0x11, 0x00"
+      expectedOutHex := "0100000000000000000000000000000000000000000000000000000000000000" }
+  , -- PUSH1 0x02; PUSH1 0x01; SLT; STOP — signed `a < b` with a=1, b=2 → 1
+    { name           := "slt_basic"
+      bytecode       := "0x60, 0x02, 0x60, 0x01, 0x12, 0x00"
+      expectedOutHex := "0100000000000000000000000000000000000000000000000000000000000000" }
+  , -- PUSH1 0x03; PUSH1 0x05; SGT; STOP — signed `a > b` with a=5, b=3 → 1
+    { name           := "sgt_basic"
+      bytecode       := "0x60, 0x03, 0x60, 0x05, 0x13, 0x00"
+      expectedOutHex := "0100000000000000000000000000000000000000000000000000000000000000" }
+  , -- PUSH1 0x42; PUSH1 0x42; EQ; STOP → 1
+    { name           := "eq_basic"
+      bytecode       := "0x60, 0x42, 0x60, 0x42, 0x14, 0x00"
+      expectedOutHex := "0100000000000000000000000000000000000000000000000000000000000000" }
+  , -- PUSH1 0x00; ISZERO; STOP → 1
+    { name           := "iszero_basic"
+      bytecode       := "0x60, 0x00, 0x15, 0x00"
+      expectedOutHex := "0100000000000000000000000000000000000000000000000000000000000000" }
+  , -- PUSH1 0x0f; PUSH1 0xff; AND; STOP → 0xff & 0x0f = 0x0f
+    { name           := "and_basic"
+      bytecode       := "0x60, 0x0f, 0x60, 0xff, 0x16, 0x00"
+      expectedOutHex := "0f00000000000000000000000000000000000000000000000000000000000000" }
+  , -- PUSH1 0x0f; PUSH1 0xa0; OR; STOP → 0xa0 | 0x0f = 0xaf
+    { name           := "or_basic"
+      bytecode       := "0x60, 0x0f, 0x60, 0xa0, 0x17, 0x00"
+      expectedOutHex := "af00000000000000000000000000000000000000000000000000000000000000" }
+  , -- PUSH1 0x0f; PUSH1 0xff; XOR; STOP → 0xff ^ 0x0f = 0xf0
+    { name           := "xor_basic"
+      bytecode       := "0x60, 0x0f, 0x60, 0xff, 0x18, 0x00"
+      expectedOutHex := "f000000000000000000000000000000000000000000000000000000000000000" }
+  , -- PUSH1 0x00; NOT; STOP → ~0 (32 bytes of 0xff)
+    { name           := "not_basic"
+      bytecode       := "0x60, 0x00, 0x19, 0x00"
+      expectedOutHex := "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff" }
+  , -- PUSH32 0x0102…20; PUSH1 0x1f; BYTE; STOP — byte 31 (LSByte
+    -- big-endian) of 0x0102…1f20 is 0x20.
+    { name           := "byte_basic"
+      bytecode       := "0x7f, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20, 0x60, 0x1f, 0x1a, 0x00"
+      expectedOutHex := "2000000000000000000000000000000000000000000000000000000000000000" }
+  , -- PUSH1 0x80; PUSH1 0x04; SHR; STOP — shift=4 on top, value=0x80
+    -- → 0x80 >> 4 = 0x08.
+    { name           := "shr_basic"
+      bytecode       := "0x60, 0x80, 0x60, 0x04, 0x1c, 0x00"
+      expectedOutHex := "0800000000000000000000000000000000000000000000000000000000000000" }
+  , -- PUSH1 0x42; PUSH1 0xff; POP; STOP — POP removes 0xff, leaves 0x42
+    { name           := "pop_basic"
+      bytecode       := "0x60, 0x42, 0x60, 0xff, 0x50, 0x00"
+      expectedOutHex := "4200000000000000000000000000000000000000000000000000000000000000" }
+    -- ## Family representatives (3, one per parametric family)
+  , -- PUSH32 0x0102…20; STOP — the 32 immediate bytes are read
+    -- big-endian into the EVM word; surfaced LE in OUTPUT_ADDR.
+    { name           := "push32_basic"
+      bytecode       := "0x7f, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20, 0x00"
+      expectedOutHex := "201f1e1d1c1b1a191817161514131211100f0e0d0c0b0a090807060504030201" }
+  , -- PUSH1 0x42; DUP1; ADD; STOP — DUP1 makes stack [0x42, 0x42];
+    -- ADD → 0x84.
+    { name           := "dup1_basic"
+      bytecode       := "0x60, 0x42, 0x80, 0x01, 0x00"
+      expectedOutHex := "8400000000000000000000000000000000000000000000000000000000000000" }
+  , -- PUSH1 0x05; PUSH1 0x02; SWAP1; SUB; STOP — SWAP1 yields top=5,
+    -- second=2; SUB → 5 - 2 = 3.
+    { name           := "swap1_basic"
+      bytecode       := "0x60, 0x05, 0x60, 0x02, 0x90, 0x03, 0x00"
+      expectedOutHex := "0300000000000000000000000000000000000000000000000000000000000000" }
+    -- ## Kitchen sink (cross-family chain)
+  , -- PUSH1 0x03; PUSH1 0x05; MUL; PUSH1 0x10; SUB; STOP
+    -- MUL: 5*3=15=0x0f. SUB: 0x10 - 0x0f = 0x01.
+    { name           := "arith_mix"
+      bytecode       := "0x60, 0x03, 0x60, 0x05, 0x02, 0x60, 0x10, 0x03, 0x00"
+      expectedOutHex := "0100000000000000000000000000000000000000000000000000000000000000" }
   ]
 
 /-- Find a test case by name. -/


### PR DESCRIPTION
## Summary

- **Dispatcher coverage 3 → 83 opcodes.** `tinyInterpRegistry` is now composed from four builders against M6a's `OpcodeHandlerSpec` infrastructure: `pushHandlers` (PUSH0..32), `dupHandlers` (DUP1..16), `swapHandlers` (SWAP1..16), and `singletonHandlers` (17 fixed-shape opcodes: ADD, MUL, SUB, SIGNEXTEND, LT, GT, SLT, SGT, EQ, ISZERO, AND, OR, XOR, NOT, BYTE, SHR, POP). Plus `stopHandler`. All other bytes route to `h_invalid` per M6a.
- **New `OpcodeHandlerSpec.preBody : String` field.** Discovered empirically: four verified bodies (`evm_mul`, `evm_signextend`, `evm_byte`, `evm_shr`) use `x10` as an internal scratch accumulator, which clobbers our dispatcher's preserved EVM code pointer. The first push of this branch crashed `mul_basic` on ziskemu with `Mem::read() section not found for addr: 1` because `addi x10, x10, 1` after `MULHU .x10 ...` landed at address 1. Fix: `preBody := "  mv x9, x10"` stashes the code pointer in `x9` (a register no verified opcode body touches), and the tail restores via `mv x10, x9` before the standard advance + ret.
- **22 test cases**, up from 2: one bytecode per singleton (16), one per parametric family (`push32_basic`, `dup1_basic`, `swap1_basic`), one cross-family `arith_mix` kitchen sink, plus the M6a baselines (`add_basic`, `add_chain`). All PASS.

## Test plan

- [ ] `lake build codegen` passes (the parametric builders typecheck)
- [ ] `bash scripts/codegen-opcodes-check.sh` exits 0 with all 22 cases PASS
- [ ] Pre-existing scripts still pass: `codegen-tiny-interp-check.sh`, `codegen-tiny-interp-dispatch-check.sh`, `codegen-smoke.sh`, `codegen-evm_add-check.sh`, `codegen-evm_add-from-input-check.sh`, `codegen-evm_div-check.sh`, `codegen-evm_mod-check.sh`
- [ ] `bash scripts/check-progress.sh` exits 0 (no PROGRESS.md drift — section D's program-count and script-count are unchanged by M6b since the changes are inside `tinyInterpRegistry` rather than `lookupProgram`)
- [ ] `lake exe codegen --program tiny_interp_dispatch_add --asm-only -o /tmp/sanity` — the jump table shows 83 distinct handler labels and 173 `h_invalid` fallbacks (256 total entries)
- [ ] Disassembly spot-check on the four x10-saving handlers (`h_MUL`, `h_SIGNEXTEND`, `h_BYTE`, `h_SHR`) — each starts with `mv x9, x10`, ends with `mv x10, x9; addi x10, x10, 1; ret`

## Runtime note

`scripts/codegen-opcodes-check.sh` takes ~48 s wall-clock for the full 22-case suite — under the 60 s threshold from the M6b plan, so the runtime-bytecode-dispatcher optimization (build once, vary bytecode via `ziskemu -i`) is **not** triggered as part of this PR. Revisit if M7 / further opcode batches push the suite over.

## What this unblocks

M7 (memory opcodes: MLOAD / MSTORE / MSTORE8 / MSIZE) — they're register-parameterized (`memBase`, `sizeReg`) verified `Program`s, so the dispatcher prologue needs to set up an additional register and `.data` region. The `preBody` field added here also generalizes to that case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)