### PR TITLE
feat(div): add callable v4 branch return spec

### DIFF
--- a/EvmAsm/Evm64/DivMod/Callable.lean
+++ b/EvmAsm/Evm64/DivMod/Callable.lean
@@ -940,6 +940,69 @@ theorem evm_div_callable_spec_from_noNop_branch_return_x1_framed
         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
         nMem shiftMem jMem retMem dMem dloMem scratchUn0 branch hStack)
 
+/-- v4 callable wrapper whose no-NOP body proof uses the exact return address
+    selected by the branch certificate in the dispatch precondition. -/
+theorem evm_div_callable_v4_spec_from_noNop_branch_return_x1 (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (branch : DivStackSpecCase base a b)
+    (hStack :
+      cpsTripleWithin unifiedDivBound base (base + nopOff) (sharedDivModCodeNoNop_v4 base)
+        (divModStackDispatchPre sp a b
+          branch.returnX1 branch.x2 v5 v6 v7 v10 v11
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+        (divStackDispatchPostNoX1 sp a b ** (.x1 ↦ᵣ branch.returnX1))) :
+    cpsTripleWithin (unifiedDivBound + 1) base (branch.returnX1 &&& ~~~1)
+      (evm_div_callable_code_v4 base)
+      (divModStackDispatchPre sp a b
+        branch.returnX1 branch.x2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+      (divStackDispatchPostNoX1 sp a b ** (.x1 ↦ᵣ branch.returnX1)) := by
+  have hpcFreePost : (divStackDispatchPostNoX1 sp a b).pcFree := by
+    rw [divStackDispatchPostNoX1_unfold]
+    rw [divScratchOwnCall_unfold, divScratchOwn_unfold]
+    pcFree
+  have hStackCall :=
+    cpsTripleWithin_extend_code
+      (hmono := sharedDivModCodeNoNop_v4_sub_div_callable_code_v4) hStack
+  have hRet :=
+    cpsTripleWithin_extend_code (hmono := evm_div_callable_code_v4_ret_sub (base := base))
+      (ret_spec_within' (base + nopOff) branch.returnX1)
+  have hRetFramed :=
+    cpsTripleWithin_frameL (divStackDispatchPostNoX1 sp a b) hpcFreePost hRet
+  exact cpsTripleWithin_seq_same_cr hStackCall hRetFramed
+
+/-- Framed variant of `evm_div_callable_v4_spec_from_noNop_branch_return_x1`. -/
+theorem evm_div_callable_v4_spec_from_noNop_branch_return_x1_framed
+    {F : Assertion} [Assertion.PCFree F] (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (branch : DivStackSpecCase base a b)
+    (hStack :
+      cpsTripleWithin unifiedDivBound base (base + nopOff) (sharedDivModCodeNoNop_v4 base)
+        (divModStackDispatchPre sp a b
+          branch.returnX1 branch.x2 v5 v6 v7 v10 v11
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+        (divStackDispatchPostNoX1 sp a b ** (.x1 ↦ᵣ branch.returnX1))) :
+    cpsTripleWithin (unifiedDivBound + 1) base (branch.returnX1 &&& ~~~1)
+      (evm_div_callable_code_v4 base)
+      (divModStackDispatchPre sp a b
+        branch.returnX1 branch.x2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 ** F)
+      ((divStackDispatchPostNoX1 sp a b ** (.x1 ↦ᵣ branch.returnX1)) ** F) := by
+  exact
+    cpsTripleWithin_frameR F (by pcFree)
+      (evm_div_callable_v4_spec_from_noNop_branch_return_x1
+        sp base a b v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        nMem shiftMem jMem retMem dMem dloMem scratchUn0 branch hStack)
+
 /-- Generic concrete callable DIV wrapper for no-NOP body proofs that preserve
     exact caller-framed `x1`/`x9` and expose the concrete scratch/register
     values needed by SDIV branch handoffs. -/


### PR DESCRIPTION
## Summary
- add the v4 branch-return callable wrapper for no-NOP DivMod proofs
- add the framed variant needed by SDIV exact handoff proofs

## Verification
- lake build EvmAsm.Evm64.DivMod.Callable EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "sorry|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/Callable.lean