### PR TITLE
feat(sdiv): add v4 result signfix ownership specs

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/ResultSignFixOwn.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/ResultSignFixOwn.lean
@@ -71,4 +71,60 @@ theorem resultSignFix_regOwn_scratch_spec_in_sdivCode
     (resultSignFix_regOwn_x10_x7_spec_in_sdivCode sp sign carryOld
       limb0 limb1 limb2 limb3 base)
 
+/-- v4 SDIV result sign-fix spec that consumes owned `x10` instead of requiring
+    a concrete old mask value. -/
+theorem resultSignFix_regOwn_x10_spec_in_sdivCodeV4
+    (sp sign valueOld carryOld limb0 limb1 limb2 limb3 : Word) (base : Word) :
+    EvmAsm.Rv64.cpsTripleWithin 21 (base + resultSignFixOff)
+      ((base + resultSignFixOff) + 84) (sdivCodeV4 base)
+      (resultSignFixPreOwnX10 sp sign valueOld carryOld limb0 limb1 limb2 limb3)
+      (resultSignFixPost sp sign limb0 limb1 limb2 limb3) := by
+  rw [resultSignFixPreOwnX10_unfold]
+  apply EvmAsm.Rv64.cpsTripleWithin_of_forall_regIs_to_regOwn
+  intro maskOld
+  exact EvmAsm.Rv64.cpsTripleWithin_weaken
+    (fun _ hp => by
+      rw [resultSignFixPre_unfold]
+      xperm_hyp hp)
+    (fun _ hq => hq)
+    (resultSignFix_spec_in_sdivCodeV4 sp sign maskOld valueOld carryOld
+      limb0 limb1 limb2 limb3 base)
+
+/-- v4 SDIV result sign-fix spec that consumes owned `x10` and `x7`, leaving
+    only the old `x11` carry value concrete. -/
+theorem resultSignFix_regOwn_x10_x7_spec_in_sdivCodeV4
+    (sp sign carryOld limb0 limb1 limb2 limb3 : Word) (base : Word) :
+    EvmAsm.Rv64.cpsTripleWithin 21 (base + resultSignFixOff)
+      ((base + resultSignFixOff) + 84) (sdivCodeV4 base)
+      (resultSignFixPreOwnX10X7 sp sign carryOld limb0 limb1 limb2 limb3)
+      (resultSignFixPost sp sign limb0 limb1 limb2 limb3) := by
+  rw [resultSignFixPreOwnX10X7_unfold]
+  apply EvmAsm.Rv64.cpsTripleWithin_of_forall_regIs_to_regOwn
+  intro valueOld
+  exact EvmAsm.Rv64.cpsTripleWithin_weaken
+    (fun _ hp => by
+      rw [resultSignFixPreOwnX10_unfold]
+      xperm_hyp hp)
+    (fun _ hq => hq)
+    (resultSignFix_regOwn_x10_spec_in_sdivCodeV4 sp sign valueOld carryOld
+      limb0 limb1 limb2 limb3 base)
+
+/-- v4 SDIV result sign-fix spec that consumes owned `x10`, `x7`, and `x11`. -/
+theorem resultSignFix_regOwn_scratch_spec_in_sdivCodeV4
+    (sp sign limb0 limb1 limb2 limb3 : Word) (base : Word) :
+    EvmAsm.Rv64.cpsTripleWithin 21 (base + resultSignFixOff)
+      ((base + resultSignFixOff) + 84) (sdivCodeV4 base)
+      (resultSignFixPreOwnScratch sp sign limb0 limb1 limb2 limb3)
+      (resultSignFixPost sp sign limb0 limb1 limb2 limb3) := by
+  rw [resultSignFixPreOwnScratch_unfold]
+  apply EvmAsm.Rv64.cpsTripleWithin_of_forall_regIs_to_regOwn
+  intro carryOld
+  exact EvmAsm.Rv64.cpsTripleWithin_weaken
+    (fun _ hp => by
+      rw [resultSignFixPreOwnX10X7_unfold]
+      xperm_hyp hp)
+    (fun _ hq => hq)
+    (resultSignFix_regOwn_x10_x7_spec_in_sdivCodeV4 sp sign carryOld
+      limb0 limb1 limb2 limb3 base)
+
 end EvmAsm.Evm64.SDiv.Compose


### PR DESCRIPTION
## Summary
- add v4 result-sign-fix register-ownership wrappers for x10, x7, and x11
- route the scratch-owned result-sign-fix spec through sdivCodeV4

## Verification
- lake build EvmAsm.Evm64.SDiv.Compose.ResultSignFixOwn EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "sorry|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/ResultSignFixOwn.lean