### PR TITLE
feat(sdiv): add v4 exact return handoff

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/DivCallExactReturnHandoff.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallExactReturnHandoff.lean
@@ -74,6 +74,69 @@ theorem saveRa_signs_abs_signXor_then_divCall_exact_then_return_normalized_named
         v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
         shiftMem nMem jMem retMem dMem dloMem scratchUn0 hbase hStack)
 
+/-- v4 exact SDIV path through result-sign-fix and the saved-RA return,
+    specialized from the sidecar exact callable handoff. -/
+theorem saveRa_signs_abs_signXor_then_divCall_exact_then_return_normalized_named_post_from_handoff_spec_in_sdivCodeV4
+    (vRa vSavedOld sp sDividendOld sDivisorOld
+      dividendMaskOld dividendValueOld dividendCarryOld
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+      v2 v5 v6 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (base : Word) (hbase : base &&& 1 = 0)
+    (hStack :
+      EvmAsm.Rv64.cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
+        (base + wrapperEndOff)
+        ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
+        (EvmAsm.Evm64.sharedDivModCodeNoNop_v4 (base + wrapperEndOff))
+        (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp
+          (sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+          (sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          (sdivAbsSign divisorTop) ((base + divCallOff) + 4) v2 v5 v6
+          (sdivAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          (sdivAbsMask divisorTop)
+          (sdivAbsCarry3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+        (EvmAsm.Evm64.divStackDispatchPostCallable sp
+          (sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+          (sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) **
+          (.x1 ↦ᵣ ((base + divCallOff) + 4)))) :
+    EvmAsm.Rv64.cpsTripleWithin (((49 + (EvmAsm.Evm64.unifiedDivBound + 1)) + 21) + 1)
+      base (vRa &&& ~~~(1 : Word)) (sdivCodeV4 base)
+      (saveRaSignsAbsSignXorThenDivCallPre vRa vSavedOld sp sDividendOld sDivisorOld
+        dividendMaskOld dividendValueOld dividendCarryOld
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
+       ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
+        EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0))
+      (saveRaDivCallCallableReturnPostNoX9 vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) := by
+  have hExit :
+      (((vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)) +
+        EvmAsm.Rv64.signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word)) =
+        (vRa &&& ~~~(1 : Word)) := by
+    rw [EvmAsm.Rv64.signExtend12_0]
+    bv_decide
+  rw [← hExit]
+  exact
+    saveRa_signs_abs_signXor_then_divCall_then_return_of_callable_post_noX9_spec_in_sdivCodeV4
+      vRa vSavedOld sp sDividendOld sDivisorOld
+      dividendMaskOld dividendValueOld dividendCarryOld
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+      v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 base
+      (saveRaDivCallDispatchReadyPost_exact_callable_spec_in_sdivCodeV4
+        vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+        v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 hbase hStack)
+
 /-- Tail-framed exact SDIV path through result-sign-fix and the saved-RA
     return. This is the caller-stack companion of the limb-level exact
     handoff: the untouched stack tail is carried from `sp+64` through the


### PR DESCRIPTION
## Summary
- add the v4 exact normalized return handoff for the SDIV nonzero path
- compose the v4 exact callable handoff through the v4 generic no-X9 return helper

## Verification
- lake build EvmAsm.Evm64.SDiv.Compose.DivCallExactReturnHandoff EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "sorry|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/DivCallExactReturnHandoff.lean