### PR TITLE
feat(sdiv): add v4 exact return stack tail

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/DivCallExactReturnHandoff.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallExactReturnHandoff.lean
@@ -222,6 +222,91 @@ theorem saveRa_signs_abs_signXor_then_divCall_exact_then_return_stack_tail_from_
       dsimp [scratchFrame] at h_old
       xperm_hyp h_old) (fun _ hp => hp) hFramed
 
+/-- v4 tail-framed exact SDIV path through result-sign-fix and the saved-RA
+    return. This is the caller-stack companion of the limb-level exact
+    handoff: the untouched stack tail is carried from `sp+64` through the
+    callable and return sequence. -/
+theorem saveRa_signs_abs_signXor_then_divCall_exact_then_return_stack_tail_from_handoff_spec_in_sdivCodeV4
+    (vRa vSavedOld sp sDividendOld sDivisorOld
+      dividendMaskOld dividendValueOld dividendCarryOld
+      v2 v5 v6 : Word)
+    (dividend divisor : EvmWord) (rest : List EvmWord)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (base : Word) (hbase : base &&& 1 = 0)
+    (hStack :
+      EvmAsm.Rv64.cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
+        (base + wrapperEndOff)
+        ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
+        (EvmAsm.Evm64.sharedDivModCodeNoNop_v4 (base + wrapperEndOff))
+        (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp
+          (sdivAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
+            (dividend.getLimbN 2) (dividend.getLimbN 3))
+          (sdivAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
+            (divisor.getLimbN 2) (divisor.getLimbN 3))
+          (sdivAbsSign (divisor.getLimbN 3)) ((base + divCallOff) + 4) v2 v5 v6
+          (sdivAbsSum3 (divisor.getLimbN 0) (divisor.getLimbN 1)
+            (divisor.getLimbN 2) (divisor.getLimbN 3))
+          (sdivAbsMask (divisor.getLimbN 3))
+          (sdivAbsCarry3 (divisor.getLimbN 0) (divisor.getLimbN 1)
+            (divisor.getLimbN 2) (divisor.getLimbN 3))
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+        (EvmAsm.Evm64.divStackDispatchPostCallable sp
+          (sdivAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
+            (dividend.getLimbN 2) (dividend.getLimbN 3))
+          (sdivAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
+            (divisor.getLimbN 2) (divisor.getLimbN 3)) **
+          (.x1 ↦ᵣ ((base + divCallOff) + 4)))) :
+    EvmAsm.Rv64.cpsTripleWithin (((49 + (EvmAsm.Evm64.unifiedDivBound + 1)) + 21) + 1)
+      base (vRa &&& ~~~(1 : Word)) (sdivCodeV4 base)
+      ((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ vSavedOld) ** (.x12 ↦ᵣ sp) **
+         (.x8 ↦ᵣ sDividendOld) ** (.x9 ↦ᵣ sDivisorOld) **
+         (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ dividendMaskOld) **
+         (.x7 ↦ᵣ dividendValueOld) ** (.x11 ↦ᵣ dividendCarryOld)) **
+        evmStackIs sp (dividend :: divisor :: rest)) **
+       ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
+        EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0))
+      (saveRaDivCallCallableReturnPostNoX9 vRa sp base
+        (dividend.getLimbN 0) (dividend.getLimbN 1)
+        (dividend.getLimbN 2) (dividend.getLimbN 3)
+        (divisor.getLimbN 0) (divisor.getLimbN 1)
+        (divisor.getLimbN 2) (divisor.getLimbN 3) **
+       evmStackIs (sp + 64) rest) := by
+  let scratchFrame : EvmAsm.Rv64.Assertion :=
+    ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
+     EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+       shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+  have hBase :=
+    saveRa_signs_abs_signXor_then_divCall_exact_then_return_normalized_named_post_from_handoff_spec_in_sdivCodeV4
+      vRa vSavedOld sp sDividendOld sDivisorOld
+      dividendMaskOld dividendValueOld dividendCarryOld
+      (dividend.getLimbN 0) (dividend.getLimbN 1)
+      (dividend.getLimbN 2) (dividend.getLimbN 3)
+      (divisor.getLimbN 0) (divisor.getLimbN 1)
+      (divisor.getLimbN 2) (divisor.getLimbN 3)
+      v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 base hbase hStack
+  have hFramed :=
+    EvmAsm.Rv64.cpsTripleWithin_frameR
+      (evmStackIs (sp + 64) rest) pcFree_evmStackIs hBase
+  exact EvmAsm.Rv64.cpsTripleWithin_weaken (fun h hp => by
+      have h_old :
+          ((saveRaSignsAbsSignXorThenDivCallPre
+              vRa vSavedOld sp sDividendOld sDivisorOld
+              dividendMaskOld dividendValueOld dividendCarryOld
+              (dividend.getLimbN 0) (dividend.getLimbN 1)
+              (dividend.getLimbN 2) (dividend.getLimbN 3)
+              (divisor.getLimbN 0) (divisor.getLimbN 1)
+              (divisor.getLimbN 2) (divisor.getLimbN 3) **
+            evmStackIs (sp + 64) rest) ** scratchFrame) h := by
+        rw [saveRaSignsAbsSignXorThenDivCallPre_stack_pair_rest]
+        dsimp [scratchFrame]
+        exact hp
+      dsimp [scratchFrame] at h_old
+      xperm_hyp h_old) (fun _ hp => hp) hFramed
+
 /-- Exact SDIV path through result-sign-fix and the saved-RA return, with the
     result slot folded as a single sign-fixed EVM word. -/
 theorem saveRa_signs_abs_signXor_then_divCall_exact_then_return_sign_fixed_word_spec_in_sdivCode


### PR DESCRIPTION
## Summary
- add the v4 exact return stack-tail wrapper for the SDIV nonzero path
- carry the caller stack tail through the v4 normalized exact return handoff

## Verification
- lake build EvmAsm.Evm64.SDiv.Compose.DivCallExactReturnHandoff EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "sorry|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/DivCallExactReturnHandoff.lean