### PR TITLE
feat(div): expose bzero v4 dispatch spec

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/Base.lean
@@ -478,6 +478,55 @@ theorem evm_div_bzero_stack_spec_within_noNop (sp base : Word)
         from by xperm) h).mp w1)
     h_raw
 
+/-- v4 no-NOP variant of `evm_div_bzero_stack_spec_within`.
+
+    This zero-divisor path only executes phaseA, the taken BEQ, and zeroPath;
+    it is therefore valid over the shared v4 no-NOP code surface. -/
+theorem evm_div_bzero_stack_spec_within_noNop_v4 (sp base : Word)
+    (a b : EvmWord) (v5 v10 : Word)
+    (hbz : b = 0) :
+    cpsTripleWithin (8 + 5) base (base + nopOff) (sharedDivModCodeNoNop_v4 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       evmWordIs (sp + 32) b)
+      ((.x12 ↦ᵣ (sp + 32)) ** (regOwn .x5) ** (regOwn .x10) ** (.x0 ↦ᵣ (0 : Word)) **
+       evmWordIs (sp + 32) (EvmWord.div a b)) := by
+  subst hbz
+  have hg0 := EvmWord.getLimbN_zero 0
+  have hg1 := EvmWord.getLimbN_zero 1
+  have hg2 := EvmWord.getLimbN_zero 2
+  have hg3 := EvmWord.getLimbN_zero 3
+  have hlimbs_or : (0 : EvmWord).getLimbN 0 ||| (0 : EvmWord).getLimbN 1 |||
+      (0 : EvmWord).getLimbN 2 ||| (0 : EvmWord).getLimbN 3 = (0 : Word) := by decide
+  have h_raw := evm_div_bzero_spec_within_noNop_v4 sp base
+    ((0 : EvmWord).getLimbN 0) ((0 : EvmWord).getLimbN 1)
+    ((0 : EvmWord).getLimbN 2) ((0 : EvmWord).getLimbN 3)
+    v5 v10 hlimbs_or
+  simp only [hg0, hg1, hg2, hg3] at h_raw
+  have hr0 := EvmWord.div_getLimbN_zero_right a 0
+  have hr1 := EvmWord.div_getLimbN_zero_right a 1
+  have hr2 := EvmWord.div_getLimbN_zero_right a 2
+  have hr3 := EvmWord.div_getLimbN_zero_right a 3
+  exact cpsTripleWithin_weaken
+    (fun h hp => by
+      rw [evmWordIs_sp32_limbs_eq sp 0 0 0 0 0 hg0 hg1 hg2 hg3] at hp
+      xperm_hyp hp)
+    (fun h hq => by
+      rw [evmWordIs_sp32_limbs_eq sp _ 0 0 0 0 hr0 hr1 hr2 hr3]
+      have w0 := sepConj_mono_left (regIs_implies_regOwn .x5) h
+        ((congrFun (show _ =
+          ((.x5 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ (0 : Word)) **
+           (.x12 ↦ᵣ (sp + 32)) ** (.x0 ↦ᵣ (0 : Word)) **
+           ((sp + 32) ↦ₘ (0 : Word)) ** ((sp + 40) ↦ₘ (0 : Word)) **
+           ((sp + 48) ↦ₘ (0 : Word)) ** ((sp + 56) ↦ₘ (0 : Word)))
+          from by xperm) h).mp hq)
+      have w1 := sepConj_mono_right (sepConj_mono_left (regIs_implies_regOwn .x10)) h w0
+      exact (congrFun (show _ =
+        ((.x12 ↦ᵣ (sp + 32)) ** (regOwn .x5) ** (regOwn .x10) ** (.x0 ↦ᵣ (0 : Word)) **
+         ((sp + 32) ↦ₘ (0 : Word)) ** ((sp + 40) ↦ₘ (0 : Word)) **
+         ((sp + 48) ↦ₘ (0 : Word)) ** ((sp + 56) ↦ₘ (0 : Word)))
+        from by xperm) h).mp w1)
+    h_raw
+
 -- DIV n=4 call+skip full-path stack-pre wrappers live in `DivMod/SpecCall.lean`
 -- to stay under the Spec.lean file-size guardrail.
 

--- a/EvmAsm/Evm64/DivMod/Spec/UnifiedBzero.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/UnifiedBzero.lean
@@ -167,6 +167,56 @@ theorem evm_div_bzero_stack_spec_within_dispatch_noNop_uni (sp base : Word)
         exact hq)
       hFramed
 
+/-- v4 zero-divisor DIV dispatcher over the shared no-NOP code surface. -/
+theorem evm_div_bzero_stack_spec_within_dispatch_noNop_v4_uni (sp base : Word)
+    (a b : EvmWord) (v1 v2 v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratch_un0 : Word)
+    (hbz : b = 0) :
+    cpsTripleWithin unifiedDivBound base (base + nopOff) (sharedDivModCodeNoNop_v4 base)
+      (divModStackDispatchPre sp a b
+        v1 v2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0)
+      (divStackDispatchPost sp a b) := by
+  let frame : Assertion :=
+    (.x9 ↦ᵣ v1) ** (.x2 ↦ᵣ v2) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+    (.x11 ↦ᵣ v11) ** evmWordIs sp a **
+    divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratch_un0
+  have hBzero :=
+    evm_div_bzero_stack_spec_within_noNop_v4 sp base a b v5 v10 hbz
+  have hFramed :
+      cpsTripleWithin (8 + 5) base (base + nopOff) (sharedDivModCodeNoNop_v4 base)
+        (((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) **
+          (.x0 ↦ᵣ (0 : Word)) ** evmWordIs (sp + 32) b) ** frame)
+        ((((.x12 ↦ᵣ (sp + 32)) ** regOwn .x5 ** regOwn .x10 **
+          (.x0 ↦ᵣ (0 : Word)) ** evmWordIs (sp + 32) (EvmWord.div a b)) ** frame)) :=
+    cpsTripleWithin_frameR frame (by
+      dsimp [frame]
+      rw [divScratchValuesCall_unfold]
+      pcFree) hBzero
+  exact cpsTripleWithin_mono_nSteps (by decide) <|
+    cpsTripleWithin_weaken
+      (fun _ hp => by
+        rw [divModStackDispatchPre_unfold] at hp
+        dsimp [frame]
+        simp only [sepConj_comm', sepConj_left_comm'] at hp ⊢
+        exact hp)
+      (fun _ hq => by
+        dsimp [frame] at hq
+        refine divStackDispatchPost_weaken_bzero_frame (sp := sp) (a := a) (b := b)
+          (v1 := v1) (v2 := v2) (v6 := v6) (v7 := v7) (v11 := v11)
+          (q0 := q0) (q1 := q1) (q2 := q2) (q3 := q3)
+          (u0 := u0) (u1 := u1) (u2 := u2) (u3 := u3)
+          (u4 := u4) (u5 := u5) (u6 := u6) (u7 := u7)
+          (shiftMem := shiftMem) (nMem := nMem) (jMem := jMem)
+          (retMem := retMem) (dMem := dMem) (dloMem := dloMem)
+          (scratch_un0 := scratch_un0) _ ?_
+        simp only [sepConj_assoc', sepConj_comm', sepConj_left_comm'] at hq ⊢
+        exact hq)
+      hFramed
+
 /-- Framed zero-divisor DIV dispatcher post over `divCode_noNop`, before the
     usual weakening to `divStackDispatchPost`. This keeps the incoming `x1`
     value concrete for callable wrappers that need the following `ret` address


### PR DESCRIPTION
## Summary
- add EvmWord-level DIV bzero no-NOP wrapper over sharedDivModCodeNoNop_v4
- expose the unified-bound zero-divisor dispatcher wrapper on the v4 no-NOP code surface

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.Base EvmAsm.Evm64.DivMod.Spec.UnifiedBzero
- git diff --check
- rg -n "sorry|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/Spec/Base.lean EvmAsm/Evm64/DivMod/Spec/UnifiedBzero.lean