### PR TITLE
feat(codegen): M7 — wire MLOAD / MSTORE / MSTORE8 into the dispatcher

### DIFF
--- a/CODEGEN.md
+++ b/CODEGEN.md
@@ -39,7 +39,7 @@ untouched. Generated artifacts go in `gen-out/` (gitignored).
 | `EvmAsm/Codegen/Emit.lean` | Pure `emitReg`, `emitInstr`, `emitProgram` — `Instr → String`. No `IO`. |
 | `EvmAsm/Codegen/Layout.lean` | `HaltConv` enum, halt stubs, `_start` preamble, `.option norvc`, `MEM_START`/`MEM_END` constants, `BuildUnit` struct + `emitBuildUnit`/`emitDataLabel` helpers. |
 | `EvmAsm/Codegen/Dispatch.lean` | M5b dispatcher scaffolding: `OpcodeHandlerSpec` (with optional `preBody` for x10-clobbering handlers) + `HandlerTail` types, `emitDispatcherPrologue`/`Epilogue`/`DataSection` and `buildDispatchUnit` helpers. Pure (no IO). |
-| `EvmAsm/Codegen/Programs.lean` | Registry (`smoke`, `evm_add`, `evm_div`, `evm_mod`, `input_echo`, `evm_add_from_input`, `evm_div_from_input`, `evm_mod_from_input`, `tiny_interp_{add,add2}`, `tiny_interp_dispatch_{add,add2}` → `BuildUnit`) plus the M5b opcode handler registry (`tinyInterpRegistry`) composed from `pushHandlers` (PUSH0..32), `dupHandlers` (DUP1..16), `swapHandlers` (SWAP1..16), `singletonHandlers` (17 fixed-shape opcodes), `stopHandler`; shared helpers (`advancePc`, `copy64`, `evmAddEpilogue`, `evmDivPatched`/`evmModPatched` for the DIV/MOD NOP-splice). |
+| `EvmAsm/Codegen/Programs.lean` | Registry (`smoke`, `evm_add`, `evm_div`, `evm_mod`, `input_echo`, `evm_add_from_input`, `evm_div_from_input`, `evm_mod_from_input`, `tiny_interp_{add,add2}`, `tiny_interp_dispatch_{add,add2}` → `BuildUnit`) plus the M5b opcode handler registry (`tinyInterpRegistry`) composed from `pushHandlers` (PUSH0..32), `dupHandlers` (DUP1..16), `swapHandlers` (SWAP1..16), `singletonHandlers` (17 fixed-shape opcodes), `memoryHandlers` (MLOAD/MSTORE/MSTORE8, M7), `stopHandler`; shared helpers (`advancePc`, `copy64`, `evmAddEpilogue`, `evmDivPatched`/`evmModPatched` for the DIV/MOD NOP-splice). |
 | `EvmAsm/Codegen/Tests/Cases.lean` | Per-opcode regression test registry: `OpcodeTestCase` struct + `opcodeTestCases` list. Wraps each bytecode through the M5b dispatcher for end-to-end ziskemu validation. |
 | `EvmAsm/Codegen/Cli.lean` | Argument parsing (`--program`, `--test-case`, `--list-test-cases`, `--halt`, `--out`, `--asm-only`). |
 | `EvmAsm/Codegen/Driver.lean` | `IO`: shells out to `as`/`ld` if available; `--asm-only` for CI without the cross toolchain. |
@@ -455,13 +455,66 @@ PASS; `scripts/codegen-tiny-interp{,-dispatch}-check.sh`,
 exit 0; full M6b suite runs in ~48 s (under the 60 s threshold
 for considering the runtime-bytecode optimization).
 
+### M7 — Memory opcodes (S/M) — **DONE (2026-05-20)**
+
+Wires MLOAD / MSTORE / MSTORE8 into `tinyInterpRegistry`. First
+milestone needing infrastructure beyond a stack-only ABI: the
+dispatcher prologue now initialises a third persistent register
+(`x13` = EVM memory base) alongside `x10` (code pointer) and `x12`
+(stack pointer). MSIZE is deferred — the verified core doesn't
+yet bookkeep memory expansion (`evmMemSizeIs` lives outside the
+verified `Program`s; see `docs/99-mload-design.md` §4 and the
+`evm_mload` docstring).
+
+**Delivered:**
+- `EvmAsm/Codegen/Dispatch.lean` — `emitDispatcherPrologue` adds
+  `la x13, evm_memory`. `emitDispatcherDataSection` now declares
+  a 32 KiB `evm_memory:` `.zero` block between `evm_stack_top:`
+  and `opcode_handlers:`.
+- `EvmAsm/Codegen/Programs.lean` — new `memoryHandlers` list with
+  three entries:
+    - `h_MLOAD` (0x51): `evm_mload .x15 .x16 .x17 .x18 .x13`
+    - `h_MSTORE` (0x52): `evm_mstore .x15 .x14 .x16 .x17 .x18 .x13`
+    - `h_MSTORE8` (0x53): `evm_mstore8 .x15 .x14 .x18 .x13`
+  All three use `.advanceAndRet 1` — no `preBody` needed (none
+  touch `x10`). MSTORE / MSTORE8's internal `ADDI .x12 .x12 64`
+  handles the stack shrink.
+- `EvmAsm/Codegen/Tests/Cases.lean` — two new cases
+  (`mstore_mload`, `mstore8_basic`). Total now 24.
+
+**Register convention.**
+- `x10` = EVM code pointer (preserved across handlers)
+- `x12` = EVM stack pointer (handlers update freely)
+- `x13` = EVM memory base, init'd in dispatcher prologue (new in M7)
+- `x14, x15, x16, x17, x18` = caller-saved scratch for memory handlers
+
+**`.data` budget.**
+The dispatcher's `.data` section starts at `0xa0000000` and must
+stay under `0xa0010000` (= `OUTPUT_ADDR`). Post-M7 layout: ~50 B
+bytecode + 256 B stack scratch + 32 KiB EVM memory + 2 KiB jump
+table ≈ 35 KiB. Comfortably under the 64 KiB cap. A future
+milestone that needs > 32 KiB of EVM memory should either grow
+the budget (extending `.data` is bounded by `OUTPUT_ADDR`) or
+relocate `evm_memory` to a separate section linked above
+`OUTPUT_ADDR + 0x10000`.
+
+**Exit criteria (met).**
+`scripts/codegen-opcodes-check.sh` exits 0 with all 24 cases
+PASS; legacy scripts (`codegen-tiny-interp{,-dispatch}-check.sh`,
+`codegen-smoke.sh`, `codegen-evm_add{,-from-input}-check.sh`,
+`codegen-evm_div{,-cases}-check.sh`, `codegen-evm_mod{,-cases}-check.sh`)
+all still exit 0. Full M7 suite runs in **~57 s** — just under
+the 60 s threshold; the next milestone that materially grows the
+dispatcher ELF should consider the runtime-bytecode optimization.
+
 ### Sequencing
 
-M0 ✅ → M1 ✅ → M2 ✅ → M4 ✅ → M5a ✅ → M5b ✅ → M6a ✅ → M6b ✅.
+M0 ✅ → M1 ✅ → M2 ✅ → M4 ✅ → M5a ✅ → M5b ✅ → M6a ✅ → M6b ✅ → M7 ✅.
 M3 is deferred; revisit only if a future milestone (full opcode
 coverage, JUMP/JUMPI, or the binary encoder) makes label-free
-emission unreadable. M6b unblocks M7 (memory opcodes) by validating
-the registry pattern at scale.
+emission unreadable. M7 unblocks M8 (hint-dependent opcodes
+through the dispatcher) and any non-trivial EVM bytecode that
+exercises memory.
 
 ## Tricky bits / open questions
 
@@ -540,16 +593,16 @@ the registry pattern at scale.
   Four handlers that clobber `x10` (MUL, SIGNEXTEND, BYTE, SHR)
   use the new `OpcodeHandlerSpec.preBody` field to save the EVM
   code pointer in `x9` before the body and restore it in the tail.
+- **M7.** ✅ `scripts/codegen-opcodes-check.sh` exits 0 with **24
+  test cases** PASS (validated 2026-05-20). Three memory opcodes
+  wired (MLOAD, MSTORE, MSTORE8) plus a 32 KiB `evm_memory:`
+  `.data` region and `x13` = memory-base in the dispatcher prologue.
+  MSIZE deferred pending verified memory-expansion bookkeeping.
+  Suite runtime: ~57 s (just under the 60 s threshold).
 
-## Future work (post-M6b)
+## Future work (post-M7)
 
 Near-term (builds directly on M6a's registry; no new design surface):
-
-- **M7 — memory opcodes.** MLOAD / MSTORE / MSTORE8 / MSIZE are
-  register-parameterized verified `Program`s (take a `memBase` /
-  `sizeReg`). Need to extend `emitDispatcherPrologue` to init an
-  additional EVM-memory base register (likely `x13`) and a size
-  register (`x14`), and declare a 64 KB `evm_memory:` `.data` block.
 - **M8 — hint-input demo via `evm_div` / `evm_mod`.** Closes the loop
   on M4's prover-hint infrastructure. The standalone `evm_div` /
   `evm_mod` wrappers in `Programs.lean` already exercise the

--- a/EvmAsm/Codegen/Dispatch.lean
+++ b/EvmAsm/Codegen/Dispatch.lean
@@ -94,12 +94,19 @@ def emitJumpTable (registry : List OpcodeHandlerSpec) : String :=
   String.intercalate "\n" entries
 
 /-- Dispatcher prologue: init EVM pointers (`x10` = code, `x12` =
-    stack top) and enter the main fetch/decode/dispatch loop. Each
-    iteration loads the opcode byte at `[x10]`, indexes the jump
-    table, `jalr`s to the handler, then jumps back to `.dispatch_loop`. -/
+    stack top, `x13` = EVM memory base) and enter the main
+    fetch/decode/dispatch loop. Each iteration loads the opcode byte
+    at `[x10]`, indexes the jump table, `jalr`s to the handler, then
+    jumps back to `.dispatch_loop`.
+
+    `x13` is added in M7 for the memory opcodes (MLOAD, MSTORE,
+    MSTORE8). Handlers that don't touch memory ignore it; the verified
+    bodies that do use it take `memBaseReg` as a Lean argument and our
+    M7 handler entries pass `.x13`. -/
 def emitDispatcherPrologue : String :=
   "  la x10, evm_code\n" ++
   "  la x12, evm_stack_top\n" ++
+  "  la x13, evm_memory\n" ++
   ".dispatch_loop:\n" ++
   "  lbu x5, 0(x10)\n" ++
   "  la x6, opcode_handlers\n" ++
@@ -121,14 +128,27 @@ def emitDispatcherEpilogue
   ".exit_label:\n" ++
   emitProgram exitBody
 
-/-- `.data` section: bytecode bytes under `evm_code:`, 256 bytes of
-    writable stack scratch ending at `evm_stack_top:`, then the
-    256-entry jump table under `opcode_handlers:`. The stack region
-    grows downward from `evm_stack_top`; the jump table lives at the
-    same address (no padding needed since `evm_stack_top` is already
-    8-byte aligned) — safe at the worst-case M5b depth of 2 (= 64
-    bytes), but worth allocating an explicit reserved tail if a
-    future test program uses deeper stacks. -/
+/-- `.data` section layout (starts at `0xa0000000` per
+    `Driver.lean`'s `-Tdata=...`):
+
+    ```
+    evm_code:         <bytecode> (~50 B)
+    .balign 32
+    evm_stack_low:    .zero 256             (256-byte EVM stack scratch)
+    evm_stack_top:
+    .balign 32
+    evm_memory:       .zero 0x8000          (32 KiB EVM memory, M7 onward)
+    .balign 8
+    opcode_handlers:  256 × .dword (jump table, 2 KiB)
+    ```
+
+    Total: ~50 + 256 + 32768 + 2048 ≈ 35 KiB, well under the 64 KiB
+    cap before `OUTPUT_ADDR = 0xa0010000`. Going beyond 32 KiB of
+    EVM memory would risk overrunning OUTPUT_ADDR.
+
+    The EVM stack region grows downward from `evm_stack_top`; safe at
+    the worst-case M5b depth of 2 (= 64 bytes). The EVM memory region
+    grows upward from `evm_memory` indexed by `memBaseReg + offset`. -/
 def emitDispatcherDataSection
     (bytecodeBytes : String) (registry : List OpcodeHandlerSpec) : String :=
   ".section .data\n" ++
@@ -139,6 +159,9 @@ def emitDispatcherDataSection
   "evm_stack_low:\n" ++
   "  .zero 256\n" ++
   "evm_stack_top:\n" ++
+  ".balign 32\n" ++
+  "evm_memory:\n" ++
+  "  .zero 0x8000\n" ++   -- 32 KiB EVM memory (M7 onward)
   emitJumpTable registry
 
 /-- Build a `BuildUnit` that runs the dispatcher over `bytecodeBytes`

--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -15,6 +15,9 @@ import EvmAsm.Evm64.Eq.Program
 import EvmAsm.Evm64.Gt.Program
 import EvmAsm.Evm64.IsZero.Program
 import EvmAsm.Evm64.Lt.Program
+import EvmAsm.Evm64.MLoad.Program
+import EvmAsm.Evm64.MStore.Program
+import EvmAsm.Evm64.MStore8.Program
 import EvmAsm.Evm64.Multiply.Program
 import EvmAsm.Evm64.Not.Program
 import EvmAsm.Evm64.Or.Program
@@ -403,6 +406,36 @@ def singletonHandlers : List OpcodeHandlerSpec :=
   , { label := "h_SHR"        , opcodes := [0x1c], preBody := "  mv x9, x10", body := EvmAsm.Evm64.evm_shr       , tail := x10RestoreAdvance1 }
   , { label := "h_POP"        , opcodes := [0x50], body := EvmAsm.Evm64.evm_pop       , tail := .advanceAndRet 1 } ]
 
+/-- M7 memory opcodes. Register-parameterized; the dispatcher
+    prologue sets up `x13 = &evm_memory` (see
+    `EvmAsm/Codegen/Dispatch.lean`). The scratch registers `x14..x18`
+    are caller-saved across the `jalr` from the dispatcher loop;
+    nothing else in the registry preserves them.
+
+    Stack-pointer bookkeeping is internal to the verified bodies:
+    `evm_mload` is net stack-neutral, while `evm_mstore` and
+    `evm_mstore8` each end with `ADDI .x12 .x12 64` so the wrapper
+    uses the standard `.advanceAndRet 1` tail. None of the memory
+    opcodes touch `x10`, so no `preBody` is needed. -/
+def memoryHandlers : List OpcodeHandlerSpec :=
+  [ -- MLOAD: pop offset, push value. memBase=x13;
+    -- scratch: offReg=x15, byteReg=x16, accReg=x17, addrReg=x18.
+    { label   := "h_MLOAD"
+      opcodes := [0x51]
+      body    := EvmAsm.Evm64.evm_mload .x15 .x16 .x17 .x18 .x13
+      tail    := .advanceAndRet 1 }
+  , -- MSTORE: pop offset + value, write 32 bytes BE to memory.
+    -- valReg=x14 (scratch; placeholder per evm_mstore docstring).
+    { label   := "h_MSTORE"
+      opcodes := [0x52]
+      body    := EvmAsm.Evm64.evm_mstore .x15 .x14 .x16 .x17 .x18 .x13
+      tail    := .advanceAndRet 1 }
+  , -- MSTORE8: pop offset + value, write 1 byte to memory.
+    { label   := "h_MSTORE8"
+      opcodes := [0x53]
+      body    := EvmAsm.Evm64.evm_mstore8 .x15 .x14 .x18 .x13
+      tail    := .advanceAndRet 1 } ]
+
 /-- STOP: transitions out of the dispatcher loop instead of returning
     to it. The body is empty; the dispatcher's `jalr` lands on
     `h_STOP:` which jumps to `.exit_label`. -/
@@ -417,7 +450,7 @@ def stopHandler : OpcodeHandlerSpec :=
     the list for a spec whose `opcodes` contains the byte. -/
 def tinyInterpRegistry : List OpcodeHandlerSpec :=
   pushHandlers ++ dupHandlers ++ swapHandlers ++ singletonHandlers ++
-  [stopHandler]
+  memoryHandlers ++ [stopHandler]
 
 def tinyInterpDispatchAddUnit : BuildUnit :=
   buildDispatchUnit tinyInterpRegistry evmAddEpilogue tinyInterpAddBytecode

--- a/EvmAsm/Codegen/Tests/Cases.lean
+++ b/EvmAsm/Codegen/Tests/Cases.lean
@@ -146,6 +146,22 @@ def opcodeTestCases : List OpcodeTestCase :=
     { name           := "arith_mix"
       bytecode       := "0x60, 0x03, 0x60, 0x05, 0x02, 0x60, 0x10, 0x03, 0x00"
       expectedOutHex := "0100000000000000000000000000000000000000000000000000000000000000" }
+    -- ## M7 memory opcodes (MLOAD / MSTORE / MSTORE8)
+  , -- PUSH1 0x42; PUSH1 0x00; MSTORE; PUSH1 0x00; MLOAD; STOP
+    -- MSTORE writes 0x42 big-endian to memory[0..32]; MLOAD reads it
+    -- back to the stack. EVM word = 0x42, on the stack as four LE u64
+    -- limbs with limb 0 = 0x42 (decimal 66).
+    { name           := "mstore_mload"
+      bytecode       := "0x60, 0x42, 0x60, 0x00, 0x52, 0x60, 0x00, 0x51, 0x00"
+      expectedOutHex := "4200000000000000000000000000000000000000000000000000000000000000" }
+  , -- PUSH1 0xff; PUSH1 0x00; MSTORE8; PUSH1 0x00; MLOAD; STOP
+    -- MSTORE8 writes one byte (0xff) at memory[0]. MLOAD reads 32 bytes
+    -- big-endian → EVM word = 0xff · 2^248. As LE limbs that's
+    -- [0, 0, 0, 0xff00000000000000]; limb 3 written to bytes 24..31
+    -- in LE order ends with 0xff at byte 31.
+    { name           := "mstore8_basic"
+      bytecode       := "0x60, 0xff, 0x60, 0x00, 0x53, 0x60, 0x00, 0x51, 0x00"
+      expectedOutHex := "00000000000000000000000000000000000000000000000000000000000000ff" }
   ]
 
 /-- Find a test case by name. -/


### PR DESCRIPTION
## Summary

First milestone needing infrastructure beyond a stack-only ABI. The dispatcher prologue now initialises three persistent registers (was x10/x12; M7 adds **x13 = EVM memory base**). The `.data` section grows a 32 KiB `evm_memory:` block between the stack scratch and the 256-entry jump table — comfortably under the 64 KiB cap before `OUTPUT_ADDR = 0xa0010000`.

- `EvmAsm/Codegen/Dispatch.lean` — `emitDispatcherPrologue` adds `la x13, evm_memory`; `emitDispatcherDataSection` declares the 32 KiB `.zero` block.
- `EvmAsm/Codegen/Programs.lean` — new `memoryHandlers` list:
  - `h_MLOAD` (0x51) = `evm_mload .x15 .x16 .x17 .x18 .x13`
  - `h_MSTORE` (0x52) = `evm_mstore .x15 .x14 .x16 .x17 .x18 .x13`
  - `h_MSTORE8` (0x53) = `evm_mstore8 .x15 .x14 .x18 .x13`
  No `preBody` needed — none of the memory bodies touch x10. MSTORE/MSTORE8 internally end with `ADDI .x12 .x12 64` so the wrappers use the standard `.advanceAndRet 1` tail.
- `EvmAsm/Codegen/Tests/Cases.lean` — two new cases (`mstore_mload`, `mstore8_basic`); 24 total.

## What's deferred

**MSIZE** — the verified core doesn't yet bookkeep memory expansion. `evm_msize` returns `sizeReg`, which we'd never update without that plumbing, so the handler isn't wired this slice. Revisit when the verification track lands `evmMemSizeIs` updates (`docs/99-mload-design.md` §4).

## Test plan

- [ ] `lake build codegen` passes
- [ ] `bash scripts/codegen-opcodes-check.sh` exits 0 with all 24 cases PASS (runtime ~57 s on a macOS dev box; under the 60 s plan threshold)
- [ ] Pre-existing scripts unchanged: `codegen-tiny-interp{,-dispatch}-check.sh`, `codegen-smoke.sh`, `codegen-evm_add{,-from-input}-check.sh`, `codegen-evm_div{,-cases}-check.sh`, `codegen-evm_mod{,-cases}-check.sh`
- [ ] `bash scripts/check-progress.sh` exits 0 (regen produces only the ignored snapshot-line drift)
- [ ] Layout sanity: `riscv64-elf-objdump -d gen-out/mstore_mload.elf` shows `evm_memory:` between `evm_stack_top:` and `opcode_handlers:`, all addresses below `0xa0010000`
- [ ] Spot-check disassembly: `h_MLOAD`, `h_MSTORE`, `h_MSTORE8` subroutines each end with `addi x10, x10, 1; ret` (no preBody, no special tail). MSTORE / MSTORE8 internally show `addi x12, x12, 64` before the wrapper tail.

## Test vectors

- `mstore_mload`: `PUSH1 0x42; PUSH1 0x00; MSTORE; PUSH1 0x00; MLOAD; STOP` → EVM word 0x42 round-trips through memory; output `4200…00`.
- `mstore8_basic`: `PUSH1 0xff; PUSH1 0x00; MSTORE8; PUSH1 0x00; MLOAD; STOP` → MSTORE8 writes one byte (0xff) at memory[0]; MLOAD reads 32 bytes big-endian, so the EVM word is `0xff · 2^248`; output ends in `…00ff`.

## Runtime watch

M7 pushes the opcode suite to ~57 s (from ~48 s in M6b). The next milestone that materially grows the dispatcher ELF (M8, M9, or anything else adding several hundred more handler-body instructions) should consider the **runtime-bytecode optimization** flagged in the plan: build the dispatcher ELF once, vary bytecode via `ziskemu -i <file>`, drop the per-case rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)