### PR TITLE
test(codegen): add smod v4 cases script

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -10,6 +10,7 @@ import EvmAsm.Evm64.Add.Program
 import EvmAsm.Evm64.DivMod.Program
 import EvmAsm.Evm64.Push.Program
 import EvmAsm.Evm64.SDiv.Program
+import EvmAsm.Evm64.SMod.Program
 import EvmAsm.Codegen.Layout
 
 namespace EvmAsm.Codegen
@@ -667,6 +668,67 @@ def evmSdivV4FromInputUnit : BuildUnit := {
   dataAsm     := evmSdivV4FromInputDataSection
 }
 
+/-! ## evm_smod_v4 — signed MOD end-to-end through ziskemu -/
+
+def evmSmodV4Dividend : List UInt64 := [0xffffffffffffff9c, 0xffffffffffffffff,
+  0xffffffffffffffff, 0xffffffffffffffff]
+
+def evmSmodV4Divisor : List UInt64 := [7, 0, 0, 0]
+
+def evmSmodV4ExpectedRemainder : List UInt64 := [0xfffffffffffffffd,
+  0xffffffffffffffff, 0xffffffffffffffff, 0xffffffffffffffff]
+
+def evmSmodV4Prologue : String :=
+  "  la x1, after_smod\n" ++
+  "  la x12, operands"
+
+def evmSmodV4Epilogue : String :=
+  "after_smod:\n" ++ emitProgram evmAddEpilogue
+
+def evmSmodV4DataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "div_scratch:\n" ++
+  "  .zero 256\n" ++
+  ".balign 8\n" ++
+  "operands:\n" ++
+  String.intercalate "\n"
+    ((evmSmodV4Dividend ++ evmSmodV4Divisor).map emitDword)
+
+def evmSmodV4Unit : BuildUnit := {
+  body        := EvmAsm.Evm64.evm_smod_v4
+  prologueAsm := evmSmodV4Prologue
+  epilogueAsm := evmSmodV4Epilogue
+  dataAsm     := evmSmodV4DataSection
+}
+
+/-! ## evm_smod_v4_from_input — prover-supplied signed MOD operands -/
+
+def evm_smod_v4_from_input : Program :=
+  LI .x5 (INPUT_ADDR + (BitVec.ofNat 64 INPUT_DATA_OFFSET)) ;;
+  copy64 .x12 .x5 .x6 ++
+  EvmAsm.Evm64.evm_smod_v4
+
+def evmSmodV4FromInputPrologue : String :=
+  "  la x1, after_smod\n" ++
+  "  la x12, operands_ram"
+
+def evmSmodV4FromInputDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "div_scratch:\n" ++
+  "  .zero 256\n" ++
+  ".balign 8\n" ++
+  "operands_ram:\n" ++
+  "  .zero 64"
+
+def evmSmodV4FromInputUnit : BuildUnit := {
+  body        := evm_smod_v4_from_input
+  prologueAsm := evmSmodV4FromInputPrologue
+  epilogueAsm := evmSmodV4Epilogue
+  dataAsm     := evmSmodV4FromInputDataSection
+}
+
 /-! ## registry -/
 
 /-- Look up a program by name. Returns `none` for unknown names so the CLI
@@ -682,6 +744,10 @@ def lookupProgram : String → Option BuildUnit
   | "evm_sdiv_from_input"       => some evmSdivV4FromInputUnit
   | "evm_sdiv_v4"               => some evmSdivV4Unit
   | "evm_sdiv_v4_from_input"    => some evmSdivV4FromInputUnit
+  | "evm_smod"                  => some evmSmodV4Unit
+  | "evm_smod_from_input"       => some evmSmodV4FromInputUnit
+  | "evm_smod_v4"               => some evmSmodV4Unit
+  | "evm_smod_v4_from_input"    => some evmSmodV4FromInputUnit
   | "input_echo"                => some inputEchoUnit
   | "evm_add_from_input"        => some evmAddFromInputUnit
   | "tiny_interp_add"           => some tinyInterpAddUnit
@@ -696,6 +762,8 @@ def knownProgramNames : List String :=
    "evm_add_from_input", "evm_div_from_input", "evm_mod_from_input",
    "evm_sdiv", "evm_sdiv_from_input",
    "evm_sdiv_v4", "evm_sdiv_v4_from_input",
+   "evm_smod", "evm_smod_from_input",
+   "evm_smod_v4", "evm_smod_v4_from_input",
    "tiny_interp_add", "tiny_interp_add2",
    "tiny_interp_dispatch_add", "tiny_interp_dispatch_add2"]
 

--- a/EvmAsm/Evm64/SMod/Program.lean
+++ b/EvmAsm/Evm64/SMod/Program.lean
@@ -58,6 +58,7 @@ theorem evm_smod_saved_ra_ret_block_byte_length (savedRaReg : Reg) :
     Register layout:
     * `x18` saves the caller return address across the nested `JAL`.
     * `x8` stores `sign(dividend)` and drives the final remainder correction.
+    * `x13` preserves `sign(dividend)` across the nested MOD callable.
     * `x9` stores `sign(divisor)` only for absolute-value normalization.
     * `x10`, `x11`, and `x7` are scratch registers for conditional negation.
 
@@ -66,24 +67,26 @@ theorem evm_smod_saved_ra_ret_block_byte_length (savedRaReg : Reg) :
 def evm_smod_wrapper : Program :=
   evm_smod_save_ra_block .x18 ;;
   evm_sdiv_sign_bit_block .x12 .x8 evm_smodDividendTopLimbOff ;;
+  ADDI .x13 .x8 0 ;;
   evm_sdiv_sign_bit_block .x12 .x9 evm_smodDivisorTopLimbOff ;;
   evm_sdiv_cond_negate_256_block .x12 .x8 .x10 .x7 .x11 0 8 16 24 ;;
   evm_sdiv_cond_negate_256_block .x12 .x9 .x10 .x7 .x11 32 40 48 56 ;;
   evm_sdiv_div_call_block evm_smodCallOff ;;
-  evm_sdiv_cond_negate_256_block .x12 .x8 .x10 .x7 .x11 32 40 48 56 ;;
+  evm_sdiv_cond_negate_256_block .x12 .x13 .x10 .x7 .x11 0 8 16 24 ;;
   evm_smod_saved_ra_ret_block .x18
 
-theorem evm_smod_wrapper_length : evm_smod_wrapper.length = 70 := by
+theorem evm_smod_wrapper_length : evm_smod_wrapper.length = 71 := by
   native_decide
 
 theorem evm_smod_wrapper_byte_length :
-    4 * evm_smod_wrapper.length = 280 := by
+    4 * evm_smod_wrapper.length = 284 := by
   rw [evm_smod_wrapper_length]
 
 theorem evm_smod_call_target_byte_offset :
     4 *
       ((evm_smod_save_ra_block .x18).length +
        (evm_sdiv_sign_bit_block .x12 .x8 evm_smodDividendTopLimbOff).length +
+       (ADDI .x13 .x8 0).length +
        (evm_sdiv_sign_bit_block .x12 .x9 evm_smodDivisorTopLimbOff).length +
        (evm_sdiv_cond_negate_256_block .x12 .x8 .x10 .x7 .x11 0 8 16 24).length +
        (evm_sdiv_cond_negate_256_block .x12 .x9 .x10 .x7 .x11 32 40 48 56).length) +
@@ -96,10 +99,21 @@ theorem evm_smod_call_target_byte_offset :
 def evm_smod : Program :=
   evm_smod_wrapper ;; evm_mod_callable
 
-theorem evm_smod_length : evm_smod.length = 389 := by
+/-- v4 full SMOD code region. This keeps the same SMOD wrapper and swaps the
+    appended unsigned MOD callable to the corrected v4 divider body. -/
+def evm_smod_v4 : Program :=
+  evm_smod_wrapper ;; evm_mod_callable_v4
+
+theorem evm_smod_length : evm_smod.length = 390 := by
   native_decide
 
-theorem evm_smod_byte_length : 4 * evm_smod.length = 1556 := by
+theorem evm_smod_v4_length : evm_smod_v4.length = 414 := by
+  native_decide
+
+theorem evm_smod_byte_length : 4 * evm_smod.length = 1560 := by
   rw [evm_smod_length]
+
+theorem evm_smod_v4_byte_length : 4 * evm_smod_v4.length = 1656 := by
+  rw [evm_smod_v4_length]
 
 end EvmAsm.Evm64

--- a/scripts/codegen-evm_smod-cases-check.sh
+++ b/scripts/codegen-evm_smod-cases-check.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Compatibility entry point for the SMOD v4 ziskemu cases.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+exec scripts/codegen-evm_smod_v4-cases-check.sh "$@"

--- a/scripts/codegen-evm_smod_v4-cases-check.sh
+++ b/scripts/codegen-evm_smod_v4-cases-check.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# codegen-evm_smod_v4-cases-check.sh - ziskemu corner-case verification for SMOD v4.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found - install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit evm_smod_v4_from_input ELF"
+lake exe codegen --program evm_smod_v4_from_input --halt linux93 \
+  -o gen-out/evm_smod_v4_from_input
+
+ELF=gen-out/evm_smod_v4_from_input.elf
+INPUT=gen-out/evm_smod_v4_from_input.input.bin
+OUTPUT=gen-out/evm_smod_v4_from_input.output
+
+export ZISKEMU ELF INPUT OUTPUT
+
+python3 <<'PY'
+import os, struct, subprocess, sys, pathlib
+
+ZISKEMU = os.environ["ZISKEMU"]
+ELF     = os.environ["ELF"]
+INPUT   = os.environ["INPUT"]
+OUTPUT  = os.environ["OUTPUT"]
+
+MASK256 = (1 << 256) - 1
+SIGNBIT = 1 << 255
+MIN_INT = -(1 << 255)
+
+def word(x: int) -> int:
+    return x & MASK256
+
+def signed(u: int) -> int:
+    assert 0 <= u <= MASK256, "operands must fit in 256 bits"
+    return u - (1 << 256) if u >= SIGNBIT else u
+
+v1_counter1_a = ((1 << 63) + (1 << 33)) << 192
+v1_counter1_b = (1 << 192) + ((1 << 33) - 1) * (1 << 128)
+v1_counter2_a = ((1 << 64) - 2) << 192
+v1_counter2_b = (1 << 192) + ((1 << 64) - 2) * (1 << 128)
+
+cases = [
+    ("pos_pos_smoke",         word(100),                         word(7)),
+    ("neg_pos",               word(-100),                        word(7)),
+    ("pos_neg",               word(100),                         word(-7)),
+    ("neg_neg",               word(-100),                        word(-7)),
+    ("smod_by_zero",          word(-42),                         word(0)),
+    ("zero_dividend",         word(0),                           word(-7)),
+    ("min_mod_neg_one",       word(MIN_INT),                     word(-1)),
+    ("min_mod_two",           word(MIN_INT),                     word(2)),
+    ("a_lt_b_signed",         word(7),                           word(-100)),
+    ("dense_neg_neg",         word(-0xfedcba9876543210_0f1e2d3c4b5a6978),
+                              word(-0x0000000000000003_0000000000000005)),
+    ("v1_counter1_raw",       v1_counter1_a,                     v1_counter1_b),
+    ("v1_counter1_flip_b",    v1_counter1_a,                     word(-signed(v1_counter1_b))),
+    ("v1_counter2_raw",       v1_counter2_a,                     v1_counter2_b),
+    ("v1_counter2_flip_a",    word(-signed(v1_counter2_a)),      v1_counter2_b),
+]
+
+def pack_input(a_word: int, b_word: int) -> bytes:
+    assert 0 <= a_word <= MASK256 and 0 <= b_word <= MASK256, "operands must fit in 256 bits"
+    blob = a_word.to_bytes(32, "little") + b_word.to_bytes(32, "little")
+    return struct.pack("<Q", len(blob)) + blob
+
+def evm_smod_word(a_word: int, b_word: int) -> int:
+    a = signed(a_word)
+    b = signed(b_word)
+    if b == 0:
+        return 0
+    sign = -1 if a < 0 else 1
+    return word(sign * (abs(a) % abs(b)))
+
+failures = []
+for label, a_word, b_word in cases:
+    pathlib.Path(INPUT).write_bytes(pack_input(a_word, b_word))
+    expected = evm_smod_word(a_word, b_word).to_bytes(32, "little").hex()
+    log = pathlib.Path(f"gen-out/evm_smod_v4_from_input.{label}.emu.log")
+    try:
+        subprocess.run(
+            [ZISKEMU, "-e", ELF, "-i", INPUT, "-o", OUTPUT, "-n", "1000000"],
+            check=True, stdout=log.open("wb"), stderr=subprocess.STDOUT,
+        )
+    except subprocess.CalledProcessError as e:
+        print(f"  [FAIL] {label}: ziskemu exited {e.returncode} (see {log})")
+        failures.append(label)
+        continue
+    actual = pathlib.Path(OUTPUT).read_bytes()[:32].hex()
+    status = "PASS" if actual == expected else "FAIL"
+    print(f"  [{status}] {label}")
+    if actual != expected:
+        print(f"         a = 0x{a_word:064x} ({signed(a_word)})")
+        print(f"         b = 0x{b_word:064x} ({signed(b_word)})")
+        print(f"    expected = {expected}")
+        print(f"      actual = {actual}")
+        failures.append(label)
+
+print()
+if failures:
+    print(f"==> FAIL: {len(failures)} / {len(cases)} cases mismatched: {failures}")
+    sys.exit(1)
+print(f"==> PASS: all {len(cases)} cases matched expected signed remainders")
+PY


### PR DESCRIPTION
## Summary
- add evm_smod_v4 and codegen BuildUnits for evm_smod / evm_smod_from_input aliases
- fix the SMOD wrapper's signed-result correction by preserving dividend sign across the MOD callable and negating the post-call result window
- add ziskemu SMOD v4 cases covering sign combinations, zero divisor, min-int cases, and div128 counterexample-derived raw words

## Tests
- bash -n scripts/codegen-evm_smod-cases-check.sh scripts/codegen-evm_smod_v4-cases-check.sh
- lake build EvmAsm.Evm64.SMod.Program EvmAsm.Codegen.Programs
- lake build EvmAsm.Evm64.SMod EvmAsm.Codegen.Programs
- lake exe codegen --program evm_smod_from_input --asm-only --out gen-out/evm_smod_from_input_alias
- scripts/codegen-evm_smod-cases-check.sh
- scripts/codegen-evm_div-cases-check.sh
- scripts/codegen-evm_mod-cases-check.sh
- scripts/check-file-size.sh
- git diff --check
- rg -n "sorry|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SMod/Program.lean EvmAsm/Codegen/Programs.lean scripts/codegen-evm_smod-cases-check.sh scripts/codegen-evm_smod_v4-cases-check.sh