### PR TITLE
feat(codegen): M8 — wire DIV and MOD through the dispatcher

### DIFF
--- a/CODEGEN.md
+++ b/CODEGEN.md
@@ -507,14 +507,63 @@ all still exit 0. Full M7 suite runs in **~57 s** — just under
 the 60 s threshold; the next milestone that materially grows the
 dispatcher ELF should consider the runtime-bytecode optimization.
 
+### M8 — Unsigned division (DIV, MOD) through the dispatcher (M) — **DONE (2026-05-20)**
+
+Routes the verified `evm_div` (0x04) and `evm_mod` (0x06) bodies
+through `tinyInterpRegistry` using the existing `evmDivPatched` /
+`evmModPatched` NOP-splice helpers (lifted out of the M2 standalone
+DIV/MOD wrappers and hoisted before the M5b registry section).
+
+**Delivered:**
+- `EvmAsm/Codegen/Programs.lean`:
+  - Hoisted `evmDivPatched` / `evmModPatched` above the M5b
+    registry so both the M2 standalone wrappers (`evmDivUnit`,
+    `evmModUnit`, etc.) and the new M8 dispatcher handlers can
+    reference them.
+  - New `divModHandlers : List OpcodeHandlerSpec` with two entries
+    (`h_DIV`, `h_MOD`). Both use `preBody := "  mv x14, x10"` and a
+    custom tail (`divModTail`) that restores via `mv x10, x14`.
+    **`x14` instead of `x9`** because `evm_div` / `evm_mod` use `x9`
+    as the Knuth-D loop counter `j` (94 references); the standard
+    M6b `mv x9, x10` save would be destroyed mid-body.
+- `EvmAsm/Codegen/Tests/Cases.lean`: two new cases — `div_basic`
+  (10/2 = 5) and `mod_basic` (10%3 = 1). Total now 26.
+
+**Discovered scope reduction.** SDIV (0x05) and SMOD (0x07) ended up
+deferred. The earlier plan assumed they'd ride the same wrapping
+pattern, but their verified bodies (`evm_sdiv` / `evm_smod`) end with
+a "saved-ra-ret" pattern — `JALR x0, x18, 0` after the wrapper has
+copied `x1` into `x18` at the start — which **bypasses the dispatcher's
+standard wrapper tail entirely**. Integrating them needs a
+trampoline-style wrapper: set `x18` to point at a per-handler restore
+stub *before* the body runs, and splice off the body's initial
+`save_ra_block` so the trampoline target sticks. That's a new
+infrastructure surface; tracked as a separate codegen PR (M8.5 or
+M9-prep).
+
+**Register clobber audit lesson.** M6b's `mv x9, x10` save trick
+isn't universal — it assumed `x9` was unused by the verified body.
+For DIV/MOD (which use `x9` as `j`) we picked `x14` instead. **The
+M7-and-beyond habit of `grep -c '\.x10\b'` before adding a handler
+needs to extend to the chosen save register too:** verify
+`grep -c '\.<save-reg>\b'` is zero across the body's `Program.lean`
+and any callable subroutines.
+
+**Exit criteria (met).**
+`scripts/codegen-opcodes-check.sh` exits 0 with all 26 cases PASS
+(24 prior + 2 new). Pre-existing scripts unchanged. Full M8 suite
+runs in **~60 s** — at the threshold. The next opcode batch (M9
+self-calling, or M8.5 SDIV/SMOD via trampoline) should bundle the
+runtime-bytecode optimization to keep the suite snappy.
+
 ### Sequencing
 
-M0 ✅ → M1 ✅ → M2 ✅ → M4 ✅ → M5a ✅ → M5b ✅ → M6a ✅ → M6b ✅ → M7 ✅.
+M0 ✅ → M1 ✅ → M2 ✅ → M4 ✅ → M5a ✅ → M5b ✅ → M6a ✅ → M6b ✅ → M7 ✅ → M8 ✅.
 M3 is deferred; revisit only if a future milestone (full opcode
 coverage, JUMP/JUMPI, or the binary encoder) makes label-free
-emission unreadable. M7 unblocks M8 (hint-dependent opcodes
-through the dispatcher) and any non-trivial EVM bytecode that
-exercises memory.
+emission unreadable. M8 (DIV/MOD only) is followed by M8.5 / M9
+which need new "callable" / "trampoline" handler ABI extensions
+for SDIV/SMOD and ADDMOD/EXP.
 
 ## Tricky bits / open questions
 
@@ -599,19 +648,33 @@ exercises memory.
   `.data` region and `x13` = memory-base in the dispatcher prologue.
   MSIZE deferred pending verified memory-expansion bookkeeping.
   Suite runtime: ~57 s (just under the 60 s threshold).
+- **M8.** ✅ `scripts/codegen-opcodes-check.sh` exits 0 with **26
+  test cases** PASS (validated 2026-05-20). DIV (0x04) and MOD (0x06)
+  routed through `tinyInterpRegistry` using the
+  `evmDivPatched` / `evmModPatched` NOP-splice helpers. Save register
+  switched from `x9` to `x14` for these two handlers because the
+  verified bodies use `x9` as the Knuth-D loop counter. SDIV/SMOD
+  deferred — their bodies use a saved-ra-ret pattern that bypasses
+  the dispatcher's wrapper tail.
 
-## Future work (post-M7)
+## Future work (post-M8)
 
-Near-term (builds directly on M6a's registry; no new design surface):
-- **M8 — hint-input demo via `evm_div` / `evm_mod`.** Closes the loop
-  on M4's prover-hint infrastructure. The standalone `evm_div` /
-  `evm_mod` wrappers in `Programs.lean` already exercise the
-  hint-input path end-to-end through ziskemu (with `evm_div_from_input`
-  / `evm_mod_from_input`); M8 routes them through the dispatcher
-  instead, so the same bytecode that runs ADD can also run DIV.
-  Likely needs a `callableLabel?` extension to `OpcodeHandlerSpec`
-  to expose distinct entry points for opcodes that are also
-  near-called from within other handlers.
+Near-term (builds directly on M6a's registry):
+
+- **M8.5 / M9 — SDIV / SMOD + self-calling opcodes (ADDMOD, EXP)
+  + runtime-bytecode optimization.** Three concerns that should
+  bundle:
+  - **Trampoline wrapper** for handlers whose bodies end with a
+    saved-ra-ret (SDIV, SMOD): pre-stage the saved-ra register
+    to point at a per-handler restore stub, splice off the body's
+    initial save_ra_block.
+  - **`callableLabel?` field** on `OpcodeHandlerSpec` for opcodes
+    also near-called from within other handlers (ADDMOD calls MOD,
+    EXP calls MUL).
+  - **Runtime-bytecode optimization** (Cross-cutting section below):
+    M8 puts the suite at ~60 s; the next opcode batch will tip it
+    over. Building the dispatcher ELF once + varying bytecode via
+    `ziskemu -i <file>` is the cleanest unblock.
 
 Longer-term (genuine new design surface):
 

--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -301,6 +301,30 @@ def tinyInterpAdd2Unit : BuildUnit := {
   dataAsm     := tinyInterpDataSection tinyInterpAdd2Bytecode
 }
 
+/-! ## divK NOP-splice helpers (used by both M2 standalone DIV/MOD
+    wrappers and the M8 dispatcher handlers, so hoisted above the
+    M5b registry section that references them) -/
+
+/-- `EvmAsm.Evm64.evm_div` with the NOP "exit PC" at internal index 267
+    replaced by a forward `JAL .x0 +304` that skips the 75-instruction
+    inline `divK_div128_v4` subroutine and lands at the instruction
+    immediately following the body. In the M2 standalone wrapper that
+    landing site is the start of `evmAddEpilogue`; in the M8
+    dispatcher wrapper (M5b registry) it is the `mv x10, x9` of the
+    handler's `x10RestoreAdvance1` tail. -/
+def evmDivPatched : Program :=
+  (EvmAsm.Evm64.evm_div : List Instr).take 267 ++
+  [Instr.JAL .x0 (304 : BitVec 21)] ++
+  (EvmAsm.Evm64.evm_div : List Instr).drop 268
+
+/-- `EvmAsm.Evm64.evm_mod` with the same NOP-splice as `evmDivPatched`.
+    Same +304 byte offset because the MOD body has the identical
+    343-instruction layout (267 main + NOP + 75 subroutine). -/
+def evmModPatched : Program :=
+  (EvmAsm.Evm64.evm_mod : List Instr).take 267 ++
+  [Instr.JAL .x0 (304 : BitVec 21)] ++
+  (EvmAsm.Evm64.evm_mod : List Instr).drop 268
+
 /-! ## tiny_interp_dispatch — M5b runtime fetch/decode/dispatch loop
 
     Same EVM bytecodes as M5a, but routed through an actual RISC-V
@@ -436,6 +460,47 @@ def memoryHandlers : List OpcodeHandlerSpec :=
       body    := EvmAsm.Evm64.evm_mstore8 .x15 .x14 .x18 .x13
       tail    := .advanceAndRet 1 } ]
 
+/-- M8 unsigned division opcodes. Both `evm_div` and `evm_mod` carry
+    a 75-instruction `divK_div128_v4` subroutine appended after a
+    NOP "exit PC" at body index 267; the `evmDivPatched` /
+    `evmModPatched` helpers (above) replace that NOP with `JAL .x0
+    (304 : BitVec 21)` so the main path skips the inline subroutine
+    and lands at the handler's wrapper tail.
+
+    Both bodies clobber `x10` heavily (Knuth-D quotient accumulator,
+    69 references) AND `x9` heavily (loop counter `j`, 94 refs).
+    So we can't reuse the standard `x9`-as-save pattern from M6b —
+    DIV/MOD save `x10` to **`x14`** instead, with a custom tail that
+    restores from `x14`. `x14` is unused by `evm_div` / `evm_mod` (and
+    their internal subroutine `divK_div128_v4`), and it's outside the
+    dispatcher's preserved set, so clobbering it post-handler is fine.
+
+    Stack-scratch: `evm_div` writes to negative `x12` offsets down to
+    `-152` bytes (per `divK_*` scratch layout). The dispatcher's
+    256-byte `evm_stack_low` block leaves 192 bytes below `x12`
+    after two PUSH ops — comfortably > 152.
+
+    **SDIV / SMOD are deferred to M8.5 / M9.** Their verified bodies
+    end with a "saved-ra-ret" pattern (`JALR x0, x18, 0`) that
+    bypasses the dispatcher's standard wrapper tail; integrating them
+    needs a trampoline-style wrapper (set `x18` to a per-handler
+    "restore" stub before the body runs, splice off the body's
+    initial save_ra_block). Tracked as the next codegen PR. -/
+private def divModTail : HandlerTail :=
+  .custom "  mv x10, x14\n  addi x10, x10, 1\n  ret"
+
+def divModHandlers : List OpcodeHandlerSpec :=
+  [ { label   := "h_DIV"
+      opcodes := [0x04]
+      preBody := "  mv x14, x10"
+      body    := evmDivPatched
+      tail    := divModTail }
+  , { label   := "h_MOD"
+      opcodes := [0x06]
+      preBody := "  mv x14, x10"
+      body    := evmModPatched
+      tail    := divModTail } ]
+
 /-- STOP: transitions out of the dispatcher loop instead of returning
     to it. The body is empty; the dispatcher's `jalr` lands on
     `h_STOP:` which jumps to `.exit_label`. -/
@@ -450,7 +515,7 @@ def stopHandler : OpcodeHandlerSpec :=
     the list for a spec whose `opcodes` contains the byte. -/
 def tinyInterpRegistry : List OpcodeHandlerSpec :=
   pushHandlers ++ dupHandlers ++ swapHandlers ++ singletonHandlers ++
-  memoryHandlers ++ [stopHandler]
+  memoryHandlers ++ divModHandlers ++ [stopHandler]
 
 def tinyInterpDispatchAddUnit : BuildUnit :=
   buildDispatchUnit tinyInterpRegistry evmAddEpilogue tinyInterpAddBytecode
@@ -489,16 +554,6 @@ def tinyInterpDispatchAdd2Unit : BuildUnit :=
     the subroutine still use the original `jal x2, +560` offsets, which
     remain correct because we only replaced the NOP, not the
     subroutine's position relative to its callers. -/
-
-/-- `EvmAsm.Evm64.evm_div` with the NOP "exit PC" at internal index 267
-    replaced by a forward JAL that skips the 75-instruction subroutine
-    and lands at the instruction immediately following the body — i.e.
-    the start of whatever `Program` is appended next (`evmAddEpilogue`
-    in both DIV BuildUnits below). -/
-def evmDivPatched : Program :=
-  (EvmAsm.Evm64.evm_div : List Instr).take 267 ++
-  [Instr.JAL .x0 (304 : BitVec 21)] ++
-  (EvmAsm.Evm64.evm_div : List Instr).drop 268
 
 /-- Dividend as four LE limbs. 2^64, exercises the phase-B n=2 cascade
     plus the normalize/loop path (not an early-exit). -/
@@ -585,15 +640,6 @@ def evmDivFromInputUnit : BuildUnit := {
     same NOP-splice fix applies. Like `evm_div`, `evm_mod` is not yet
     proven correct in Lean — the scripts under `scripts/codegen-evm_mod*`
     provide empirical confirmation by running on ziskemu. -/
-
-/-- `EvmAsm.Evm64.evm_mod` with the NOP "exit PC" at index 267 replaced
-    by a forward JAL skipping the 75-instruction subroutine to land at
-    `evmAddEpilogue`. Same +304 byte offset as `evmDivPatched` because
-    the MOD body has the identical 343-instruction layout. -/
-def evmModPatched : Program :=
-  (EvmAsm.Evm64.evm_mod : List Instr).take 267 ++
-  [Instr.JAL .x0 (304 : BitVec 21)] ++
-  (EvmAsm.Evm64.evm_mod : List Instr).drop 268
 
 /-- Dividend as four LE limbs. 2^64, exercises the phase-B n=1 cascade
     on the divisor (b=3, limb 0 only) plus the loop body. -/

--- a/EvmAsm/Codegen/Tests/Cases.lean
+++ b/EvmAsm/Codegen/Tests/Cases.lean
@@ -162,6 +162,19 @@ def opcodeTestCases : List OpcodeTestCase :=
     { name           := "mstore8_basic"
       bytecode       := "0x60, 0xff, 0x60, 0x00, 0x53, 0x60, 0x00, 0x51, 0x00"
       expectedOutHex := "00000000000000000000000000000000000000000000000000000000000000ff" }
+    -- ## M8 unsigned division opcodes
+    -- (SDIV / SMOD deferred: their verified bodies use a saved-ra-ret
+    -- pattern that bypasses the dispatcher's standard wrapper tail;
+    -- integrating them needs a trampoline approach planned as the
+    -- next codegen PR.)
+  , -- PUSH1 0x02; PUSH1 0x0a; DIV; STOP — 10 / 2 = 5
+    { name           := "div_basic"
+      bytecode       := "0x60, 0x02, 0x60, 0x0a, 0x04, 0x00"
+      expectedOutHex := "0500000000000000000000000000000000000000000000000000000000000000" }
+  , -- PUSH1 0x03; PUSH1 0x0a; MOD; STOP — 10 % 3 = 1
+    { name           := "mod_basic"
+      bytecode       := "0x60, 0x03, 0x60, 0x0a, 0x06, 0x00"
+      expectedOutHex := "0100000000000000000000000000000000000000000000000000000000000000" }
   ]
 
 /-- Find a test case by name. -/


### PR DESCRIPTION
## Summary

Routes the verified `evm_div` (0x04) and `evm_mod` (0x06) bodies through `tinyInterpRegistry` using the existing `evmDivPatched` / `evmModPatched` NOP-splice helpers.

- `Programs.lean`: hoisted `evmDivPatched` / `evmModPatched` above the M5b registry section so they're shared with the M2 standalone wrappers further down. New `divModHandlers` list with `h_DIV` and `h_MOD`. Both use **`mv x14, x10`** (not M6b's `mv x9, x10`) because `evm_div` / `evm_mod` use `x9` as the Knuth-D loop counter `j` (94 references) — the standard save would be destroyed mid-body.
- `Tests/Cases.lean`: two new cases — `div_basic` (10/2 = 5) and `mod_basic` (10%3 = 1). Total **26 cases**, all PASS.
- `CODEGEN.md`: M8 milestone marked DONE, file layout / sequencing / Future work updated.

## SDIV / SMOD deferred — scope-reduction discovered mid-implementation

The pre-PR plan scoped all four (DIV, MOD, SDIV, SMOD), but `evm_sdiv` / `evm_smod` end with a **saved-ra-ret pattern** (`JALR x0, x18, 0` after the body has copied x1 into x18 at the start of the wrapper) that **bypasses the dispatcher's standard `mv x10, x9; addi; ret` tail entirely**.

Integrating SDIV/SMOD needs a trampoline-style wrapper: set `x18` to point at a per-handler restore stub *before* the body runs, splice off the body's initial `save_ra_block` so our trampoline target sticks. That's enough new infrastructure to deserve its own PR (M8.5 or M9-prep).

## Lesson logged in CODEGEN.md

M6b's `mv x9, x10` save trick isn't universal — it assumed `x9` was unused. For DIV/MOD we picked `x14` instead. **Future opcode-handler adds should `grep -c '\.<save-reg>\b'` against the body and any callable subroutines** before reusing the standard pattern.

## Test plan

- [ ] `lake build codegen` passes
- [ ] `bash scripts/codegen-opcodes-check.sh` exits 0 with all 26 cases PASS (~60 s on a macOS dev box — at the runtime-optimization threshold)
- [ ] Pre-existing scripts unchanged: `codegen-tiny-interp{,-dispatch}-check.sh`, `codegen-smoke.sh`, `codegen-evm_add{,-from-input}-check.sh`, `codegen-evm_div{,-cases}-check.sh`, `codegen-evm_mod{,-cases}-check.sh`
- [ ] `bash scripts/check-progress.sh` exits 0
- [ ] Disassembly spot-check on `gen-out/div_basic.elf`: `h_DIV` starts with `mv x14, x10`, the body's instruction-267 JAL skips +304 bytes to land at the `mv x10, x14` of the restore tail. `divK_div128_v4` (75 instructions) sits between.

## Runtime watch

M8 puts the opcode suite at **~60 s** wall-clock (from ~57 s in M7). The next opcode batch (M8.5 SDIV/SMOD trampoline, or M9 self-calling ADDMOD/EXP) should bundle the **runtime-bytecode optimization** — build the dispatcher ELF once, vary bytecode via `ziskemu -i <file>` — to keep the suite snappy. See CODEGEN.md "Future work" for the proposed bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)