### PR TITLE
feat(divmod): name legacy callable div128 surfaces

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -21,6 +21,7 @@ import EvmAsm.Evm64.DivMod.Spec
 
 import EvmAsm.Evm64.DivMod.Shift0Dispatcher
 import EvmAsm.Evm64.DivMod.SpecCall
+import EvmAsm.Evm64.DivMod.CallableV1Legacy
 import EvmAsm.Evm64.DivMod.CallableV4Mod
 import EvmAsm.Evm64.DivMod.N4StackSpec
 import EvmAsm.Evm64.DivMod.N4StackSpecWithin

--- a/EvmAsm/Evm64/DivMod/CallableV1Legacy.lean
+++ b/EvmAsm/Evm64/DivMod/CallableV1Legacy.lean
@@ -1,0 +1,98 @@
+import EvmAsm.Evm64.DivMod.Callable
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Legacy LP64-callable DIV wrapper pinned to the original one-correction
+    `divK_div128` subroutine. This gives existing v1 no-NOP specs a stable
+    target when the default callable name migrates to v4. -/
+def evm_div_callable_v1 : Program :=
+  divK_phaseA 1020 ;;
+  divK_phaseB ;;
+  divK_clz ;;
+  divK_phaseC2 172 ;;
+  divK_normB ;;
+  divK_normA 40 ;;
+  divK_copyAU ;;
+  divK_loopSetup 464 ;;
+  divK_loopBody 560 7736 ;;
+  divK_denorm ;;
+  divK_div_epilogue 24 ;;
+  divK_zeroPath ;;
+  cc_ret ;;
+  divK_div128
+
+/-- Legacy LP64-callable MOD wrapper pinned to the original one-correction
+    `divK_div128` subroutine. -/
+def evm_mod_callable_v1 : Program :=
+  divK_phaseA 1020 ;;
+  divK_phaseB ;;
+  divK_clz ;;
+  divK_phaseC2 172 ;;
+  divK_normB ;;
+  divK_normA 40 ;;
+  divK_copyAU ;;
+  divK_loopSetup 464 ;;
+  divK_loopBody 560 7736 ;;
+  divK_denorm ;;
+  divK_mod_epilogue 24 ;;
+  divK_zeroPath ;;
+  cc_ret ;;
+  divK_div128
+
+/-- Legacy v1 CodeReq layout for `evm_div_callable_v1`. -/
+abbrev evm_div_callable_code_v1 (base : Word) : CodeReq :=
+  CodeReq.unionAll [
+    CodeReq.ofProg  base                  (divK_phaseA 1020),
+    CodeReq.ofProg (base + phaseBOff)     divK_phaseB,
+    CodeReq.ofProg (base + clzOff)        divK_clz,
+    CodeReq.ofProg (base + phaseC2Off)    (divK_phaseC2 172),
+    CodeReq.ofProg (base + normBOff)      divK_normB,
+    CodeReq.ofProg (base + normAOff)      (divK_normA 40),
+    CodeReq.ofProg (base + copyAUOff)     divK_copyAU,
+    CodeReq.ofProg (base + loopSetupOff)  (divK_loopSetup 464),
+    CodeReq.ofProg (base + loopBodyOff)   (divK_loopBody 560 7736),
+    CodeReq.ofProg (base + denormOff)     divK_denorm,
+    CodeReq.ofProg (base + epilogueOff)   (divK_div_epilogue 24),
+    CodeReq.ofProg (base + zeroPathOff)   divK_zeroPath,
+    cc_ret_code   (base + nopOff),
+    CodeReq.ofProg (base + div128Off)     divK_div128
+  ]
+
+/-- Legacy v1 CodeReq layout for `evm_mod_callable_v1`. -/
+abbrev evm_mod_callable_code_v1 (base : Word) : CodeReq :=
+  CodeReq.unionAll [
+    CodeReq.ofProg  base                  (divK_phaseA 1020),
+    CodeReq.ofProg (base + phaseBOff)     divK_phaseB,
+    CodeReq.ofProg (base + clzOff)        divK_clz,
+    CodeReq.ofProg (base + phaseC2Off)    (divK_phaseC2 172),
+    CodeReq.ofProg (base + normBOff)      divK_normB,
+    CodeReq.ofProg (base + normAOff)      (divK_normA 40),
+    CodeReq.ofProg (base + copyAUOff)     divK_copyAU,
+    CodeReq.ofProg (base + loopSetupOff)  (divK_loopSetup 464),
+    CodeReq.ofProg (base + loopBodyOff)   (divK_loopBody 560 7736),
+    CodeReq.ofProg (base + denormOff)     divK_denorm,
+    CodeReq.ofProg (base + epilogueOff)   (divK_mod_epilogue 24),
+    CodeReq.ofProg (base + zeroPathOff)   divK_zeroPath,
+    cc_ret_code   (base + nopOff),
+    CodeReq.ofProg (base + div128Off)     divK_div128
+  ]
+
+theorem evm_div_callable_v1_eq_current :
+    evm_div_callable_v1 = evm_div_callable := by
+  rfl
+
+theorem evm_mod_callable_v1_eq_current :
+    evm_mod_callable_v1 = evm_mod_callable := by
+  rfl
+
+theorem evm_div_callable_code_v1_eq_current (base : Word) :
+    evm_div_callable_code_v1 base = evm_div_callable_code base := by
+  rfl
+
+theorem evm_mod_callable_code_v1_eq_current (base : Word) :
+    evm_mod_callable_code_v1 base = evm_mod_callable_code base := by
+  rfl
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add explicit legacy v1 callable program names for DIV and MOD
- add matching legacy v1 CodeReq aliases for the current one-correction divK_div128 layout
- wire the aliases into the DivMod umbrella so the eventual default-v4 migration can move old proofs to stable v1 names

## Notes
This intentionally does not change the current default callable definitions. Today, the new v1 aliases are definitionally equal to the current defaults; after the default callable names switch to v4, this module can preserve the old no-NOP/spec surface without forcing every caller to migrate in the same PR.

## Verification
- lake build EvmAsm.Evm64.DivMod.CallableV1Legacy
- lake build EvmAsm.Evm64.DivMod EvmAsm.Evm64.SDiv EvmAsm.Evm64.SMod
- scripts/check-file-size.sh
- git diff --check
- rg -n "sorry|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/CallableV1Legacy.lean EvmAsm/Evm64/DivMod.lean