### PR TITLE
refactor(divmod): split div callable v4 helpers

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -22,6 +22,7 @@ import EvmAsm.Evm64.DivMod.Spec
 import EvmAsm.Evm64.DivMod.Shift0Dispatcher
 import EvmAsm.Evm64.DivMod.SpecCall
 import EvmAsm.Evm64.DivMod.CallableV1Legacy
+import EvmAsm.Evm64.DivMod.CallableV4Div
 import EvmAsm.Evm64.DivMod.CallableV4Mod
 import EvmAsm.Evm64.DivMod.N4StackSpec
 import EvmAsm.Evm64.DivMod.N4StackSpecWithin

--- a/EvmAsm/Evm64/DivMod/Callable.lean
+++ b/EvmAsm/Evm64/DivMod/Callable.lean
@@ -287,57 +287,6 @@ theorem evm_div_callable_code_eq_ofProg (base : Word) :
     show (base + nopOff) + BitVec.ofNat 64 (4 * 1) = base + div128Off
     bv_omega]
 
--- v4 variant of `evm_div_callable_code_eq_ofProg`.
-open EvmAsm.Rv64.CodeReq in
-theorem evm_div_callable_code_v4_eq_ofProg (base : Word) :
-    evm_div_callable_code_v4 base = CodeReq.ofProg base evm_div_callable_v4 := by
-  unfold evm_div_callable_code_v4 evm_div_callable_v4 cc_ret_code
-  simp only [unionAll_cons, unionAll_nil, union_empty_right]
-  unfold seq
-  unfold Program
-  symm
-  rw [ofProg_append]
-  rw [show base + BitVec.ofNat 64 (4 * (divK_phaseA 1020).length) =
-        base + phaseBOff by rw [divK_phaseA_len]; rfl]
-  rw [ofProg_append]
-  rw [show (base + phaseBOff) + BitVec.ofNat 64 (4 * divK_phaseB.length) =
-        base + clzOff by rw [divK_phaseB_len]; bv_omega]
-  rw [ofProg_append]
-  rw [show (base + clzOff) + BitVec.ofNat 64 (4 * divK_clz.length) =
-        base + phaseC2Off by rw [divK_clz_len]; bv_omega]
-  rw [ofProg_append]
-  rw [show (base + phaseC2Off) + BitVec.ofNat 64 (4 * (divK_phaseC2 172).length) =
-        base + normBOff by rw [divK_phaseC2_len]; bv_omega]
-  rw [ofProg_append]
-  rw [show (base + normBOff) + BitVec.ofNat 64 (4 * divK_normB.length) =
-        base + normAOff by rw [divK_normB_len]; bv_omega]
-  rw [ofProg_append]
-  rw [show (base + normAOff) + BitVec.ofNat 64 (4 * (divK_normA 40).length) =
-        base + copyAUOff by rw [divK_normA_len]; bv_omega]
-  rw [ofProg_append]
-  rw [show (base + copyAUOff) + BitVec.ofNat 64 (4 * divK_copyAU.length) =
-        base + loopSetupOff by rw [divK_copyAU_len]; bv_omega]
-  rw [ofProg_append]
-  rw [show (base + loopSetupOff) + BitVec.ofNat 64 (4 * (divK_loopSetup 464).length) =
-        base + loopBodyOff by rw [divK_loopSetup_len]; bv_omega]
-  rw [ofProg_append]
-  rw [show (base + loopBodyOff) + BitVec.ofNat 64 (4 * (divK_loopBody 560 7736).length) =
-        base + denormOff by rw [divK_loopBody_len]; bv_omega]
-  rw [ofProg_append]
-  rw [show (base + denormOff) + BitVec.ofNat 64 (4 * divK_denorm.length) =
-        base + epilogueOff by rw [divK_denorm_len]; bv_omega]
-  rw [ofProg_append]
-  rw [show (base + epilogueOff) + BitVec.ofNat 64 (4 * (divK_div_epilogue 24).length) =
-        base + zeroPathOff by rw [divK_divEpilogue_len]; bv_omega]
-  rw [ofProg_append]
-  rw [show (base + zeroPathOff) + BitVec.ofNat 64 (4 * divK_zeroPath.length) =
-        base + nopOff by rw [divK_zeroPath_len]; bv_omega]
-  rw [ofProg_append]
-  rw [show (base + nopOff) + BitVec.ofNat 64 (4 * cc_ret.length) =
-        base + div128Off by
-    show (base + nopOff) + BitVec.ofNat 64 (4 * 1) = base + div128Off
-    bv_omega]
-
 -- Per-block subsumption lemmas for evm_div_callable_code / evm_mod_callable_code
 --
 -- Mirror the `shared_b*_div` / `shared_b*_mod` pattern from
@@ -447,98 +396,11 @@ private theorem callable_b13_div {b : Word} :
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlockCC; exact CodeReq.union_mono_left
 
-private theorem callable_b0_div_v4 {b : Word} :
-    ∀ a i, (CodeReq.ofProg b (divK_phaseA 1020)) a = some i →
-      (evm_div_callable_code_v4 b) a = some i := by
-  unfold evm_div_callable_code_v4; simp only [CodeReq.unionAll_cons]
-  exact CodeReq.union_mono_left
-private theorem callable_b1_div_v4 {b : Word} :
-    ∀ a i, (CodeReq.ofProg (b + phaseBOff) divK_phaseB) a = some i →
-      (evm_div_callable_code_v4 b) a = some i := by
-  unfold evm_div_callable_code_v4; simp only [CodeReq.unionAll_cons]
-  skipBlock; exact CodeReq.union_mono_left
-private theorem callable_b2_div_v4 {b : Word} :
-    ∀ a i, (CodeReq.ofProg (b + clzOff) divK_clz) a = some i →
-      (evm_div_callable_code_v4 b) a = some i := by
-  unfold evm_div_callable_code_v4; simp only [CodeReq.unionAll_cons]
-  skipBlock; skipBlock; exact CodeReq.union_mono_left
-private theorem callable_b3_div_v4 {b : Word} :
-    ∀ a i, (CodeReq.ofProg (b + phaseC2Off) (divK_phaseC2 172)) a = some i →
-      (evm_div_callable_code_v4 b) a = some i := by
-  unfold evm_div_callable_code_v4; simp only [CodeReq.unionAll_cons]
-  skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
-private theorem callable_b4_div_v4 {b : Word} :
-    ∀ a i, (CodeReq.ofProg (b + normBOff) divK_normB) a = some i →
-      (evm_div_callable_code_v4 b) a = some i := by
-  unfold evm_div_callable_code_v4; simp only [CodeReq.unionAll_cons]
-  skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
-private theorem callable_b5_div_v4 {b : Word} :
-    ∀ a i, (CodeReq.ofProg (b + normAOff) (divK_normA 40)) a = some i →
-      (evm_div_callable_code_v4 b) a = some i := by
-  unfold evm_div_callable_code_v4; simp only [CodeReq.unionAll_cons]
-  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
-private theorem callable_b6_div_v4 {b : Word} :
-    ∀ a i, (CodeReq.ofProg (b + copyAUOff) divK_copyAU) a = some i →
-      (evm_div_callable_code_v4 b) a = some i := by
-  unfold evm_div_callable_code_v4; simp only [CodeReq.unionAll_cons]
-  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
-private theorem callable_b7_div_v4 {b : Word} :
-    ∀ a i, (CodeReq.ofProg (b + loopSetupOff) (divK_loopSetup 464)) a = some i →
-      (evm_div_callable_code_v4 b) a = some i := by
-  unfold evm_div_callable_code_v4; simp only [CodeReq.unionAll_cons]
-  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
-  exact CodeReq.union_mono_left
-private theorem callable_b8_div_v4 {b : Word} :
-    ∀ a i, (CodeReq.ofProg (b + loopBodyOff) (divK_loopBody 560 7736)) a = some i →
-      (evm_div_callable_code_v4 b) a = some i := by
-  unfold evm_div_callable_code_v4; simp only [CodeReq.unionAll_cons]
-  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
-  exact CodeReq.union_mono_left
-private theorem callable_b9_div_v4 {b : Word} :
-    ∀ a i, (CodeReq.ofProg (b + denormOff) divK_denorm) a = some i →
-      (evm_div_callable_code_v4 b) a = some i := by
-  unfold evm_div_callable_code_v4; simp only [CodeReq.unionAll_cons]
-  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
-  skipBlock; exact CodeReq.union_mono_left
-private theorem callable_b10_div_v4 {b : Word} :
-    ∀ a i, (CodeReq.ofProg (b + epilogueOff) (divK_div_epilogue 24)) a = some i →
-      (evm_div_callable_code_v4 b) a = some i := by
-  unfold evm_div_callable_code_v4; simp only [CodeReq.unionAll_cons]
-  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
-  skipBlock; skipBlock; exact CodeReq.union_mono_left
-private theorem callable_b11_div_v4 {b : Word} :
-    ∀ a i, (CodeReq.ofProg (b + zeroPathOff) divK_zeroPath) a = some i →
-      (evm_div_callable_code_v4 b) a = some i := by
-  unfold evm_div_callable_code_v4; simp only [CodeReq.unionAll_cons]
-  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
-  skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
-private theorem callable_b12_div_v4 {b : Word} :
-    ∀ a i, (cc_ret_code (b + nopOff)) a = some i →
-      (evm_div_callable_code_v4 b) a = some i := by
-  unfold evm_div_callable_code_v4; simp only [CodeReq.unionAll_cons]
-  skipBlockCC; skipBlockCC; skipBlockCC; skipBlockCC; skipBlockCC; skipBlockCC
-  skipBlockCC; skipBlockCC; skipBlockCC; skipBlockCC; skipBlockCC; skipBlockCC
-  exact CodeReq.union_mono_left
-private theorem callable_b13_div_v4 {b : Word} :
-    ∀ a i, (CodeReq.ofProg (b + div128Off) divK_div128_v4) a = some i →
-      (evm_div_callable_code_v4 b) a = some i := by
-  unfold evm_div_callable_code_v4; simp only [CodeReq.unionAll_cons, cc_ret_code]
-  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
-  skipBlock; skipBlock; skipBlock; skipBlock; skipBlockCC; exact CodeReq.union_mono_left
-
 theorem evm_div_callable_code_ret_sub {base : Word} :
     ∀ a i, (CodeReq.singleton (base + nopOff) (.JALR .x0 .x1 0)) a = some i →
       (evm_div_callable_code base) a = some i := by
   intro a i h
   apply callable_b12_div
-  unfold cc_ret_code cc_ret
-  simpa [CodeReq.ofProg] using h
-
-theorem evm_div_callable_code_v4_ret_sub {base : Word} :
-    ∀ a i, (CodeReq.singleton (base + nopOff) (.JALR .x0 .x1 0)) a = some i →
-      (evm_div_callable_code_v4 base) a = some i := by
-  intro a i h
-  apply callable_b12_div_v4
   unfold cc_ret_code cc_ret
   simpa [CodeReq.ofProg] using h
 
@@ -667,29 +529,6 @@ theorem divCode_noNop_sub_div_callable_code {base : Word} :
     (CodeReq.union_split_mono callable_b13_div
     (fun _ _ h => by simp [CodeReq.unionAll_nil, CodeReq.empty] at h)))))))))))))
 
-/-- `sharedDivModCodeNoNop_v4` is included in `evm_div_callable_code_v4`.
-    This is the v4 analogue of `divCode_noNop_sub_div_callable_code`;
-    the callable swaps the omitted NOP slot for `cc_ret`, while all shared
-    no-NOP blocks remain at the same offsets and the final block is
-    `divK_div128_v4`. -/
-theorem sharedDivModCodeNoNop_v4_sub_div_callable_code_v4 {base : Word} :
-    ∀ a i, (sharedDivModCodeNoNop_v4 base) a = some i →
-           (evm_div_callable_code_v4 base) a = some i := by
-  unfold sharedDivModCodeNoNop_v4; simp only [CodeReq.unionAll_cons]
-  exact CodeReq.union_split_mono callable_b0_div_v4
-    (CodeReq.union_split_mono callable_b1_div_v4
-    (CodeReq.union_split_mono callable_b2_div_v4
-    (CodeReq.union_split_mono callable_b3_div_v4
-    (CodeReq.union_split_mono callable_b4_div_v4
-    (CodeReq.union_split_mono callable_b5_div_v4
-    (CodeReq.union_split_mono callable_b6_div_v4
-    (CodeReq.union_split_mono callable_b7_div_v4
-    (CodeReq.union_split_mono callable_b8_div_v4
-    (CodeReq.union_split_mono callable_b9_div_v4
-    (CodeReq.union_split_mono callable_b11_div_v4
-    (CodeReq.union_split_mono callable_b13_div_v4
-    (fun _ _ h => by simp [CodeReq.unionAll_nil, CodeReq.empty] at h))))))))))))
-
 /-- modCode_noNop ⊆ evm_mod_callable_code. Mirror of
     `divCode_noNop_sub_div_callable_code` for the MOD epilogue. -/
 theorem modCode_noNop_sub_mod_callable_code {base : Word} :
@@ -754,41 +593,6 @@ theorem evm_div_callable_spec_from_noNop (sp base raVal : Word)
     cpsTripleWithin_frameL (divStackDispatchPost sp a b) hpcFreePost hRet
   exact cpsTripleWithin_seq_same_cr hStackFramed hRetFramed
 
-theorem evm_div_callable_v4_spec_from_noNop (sp base raVal : Word)
-    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
-    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-     nMem shiftMem jMem retMem dMem dloMem scratchUn0 : Word)
-    (branch : DivStackSpecCase base a b)
-    (hStack :
-      cpsTripleWithin unifiedDivBound base (base + nopOff) (sharedDivModCodeNoNop_v4 base)
-        (divModStackDispatchPre sp a b
-          branch.x1 branch.x2 v5 v6 v7 v10 v11
-          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
-        (divStackDispatchPost sp a b)) :
-    cpsTripleWithin (unifiedDivBound + 1) base (raVal &&& ~~~1)
-      (evm_div_callable_code_v4 base)
-      (divModStackDispatchPre sp a b
-        branch.x1 branch.x2 v5 v6 v7 v10 v11
-        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-        shiftMem nMem jMem retMem dMem dloMem scratchUn0 ** (.x1 ↦ᵣ raVal))
-      (divStackDispatchPost sp a b ** (.x1 ↦ᵣ raVal)) := by
-  have hpcFreePost : (divStackDispatchPost sp a b).pcFree := by
-    rw [divStackDispatchPost_unfold]
-    rw [divScratchOwnCall_unfold, divScratchOwn_unfold]
-    pcFree
-  have hStackCall :=
-    cpsTripleWithin_extend_code
-      (hmono := sharedDivModCodeNoNop_v4_sub_div_callable_code_v4) hStack
-  have hStackFramed :=
-    cpsTripleWithin_frameR (.x1 ↦ᵣ raVal) (by pcFree) hStackCall
-  have hRet :=
-    cpsTripleWithin_extend_code (hmono := evm_div_callable_code_v4_ret_sub (base := base))
-      (ret_spec_within' (base + nopOff) raVal)
-  have hRetFramed :=
-    cpsTripleWithin_frameL (divStackDispatchPost sp a b) hpcFreePost hRet
-  exact cpsTripleWithin_seq_same_cr hStackFramed hRetFramed
-
 /-- Callable DIV wrapper with the no-NOP dispatcher proof discharged by the
     branch certificate. This packages the existing bzero/n1/n2/n3 closed
     cases without reopening the n4 addback path. -/
@@ -840,39 +644,6 @@ theorem evm_div_callable_spec_from_noNop_preserving_x1 (sp base raVal : Word)
     cpsTripleWithin_extend_code (hmono := divCode_noNop_sub_div_callable_code) hStack
   have hRet :=
     cpsTripleWithin_extend_code (hmono := evm_div_callable_code_ret_sub (base := base))
-      (ret_spec_within' (base + nopOff) raVal)
-  have hRetFramed :=
-    cpsTripleWithin_frameL (divStackDispatchPostNoX1 sp a b) hpcFreePost hRet
-  exact cpsTripleWithin_seq_same_cr hStackCall hRetFramed
-
-theorem evm_div_callable_v4_spec_from_noNop_preserving_x1 (sp base raVal : Word)
-    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
-    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-     nMem shiftMem jMem retMem dMem dloMem scratchUn0 : Word)
-    (branch : DivStackSpecCase base a b)
-    (hStack :
-      cpsTripleWithin unifiedDivBound base (base + nopOff) (sharedDivModCodeNoNop_v4 base)
-        (divModStackDispatchPre sp a b
-          branch.x1 branch.x2 v5 v6 v7 v10 v11
-          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
-        (divStackDispatchPostNoX1 sp a b ** (.x1 ↦ᵣ raVal))) :
-    cpsTripleWithin (unifiedDivBound + 1) base (raVal &&& ~~~1)
-      (evm_div_callable_code_v4 base)
-      (divModStackDispatchPre sp a b
-        branch.x1 branch.x2 v5 v6 v7 v10 v11
-        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-        shiftMem nMem jMem retMem dMem dloMem scratchUn0)
-      (divStackDispatchPostNoX1 sp a b ** (.x1 ↦ᵣ raVal)) := by
-  have hpcFreePost : (divStackDispatchPostNoX1 sp a b).pcFree := by
-    rw [divStackDispatchPostNoX1_unfold]
-    rw [divScratchOwnCall_unfold, divScratchOwn_unfold]
-    pcFree
-  have hStackCall :=
-    cpsTripleWithin_extend_code
-      (hmono := sharedDivModCodeNoNop_v4_sub_div_callable_code_v4) hStack
-  have hRet :=
-    cpsTripleWithin_extend_code (hmono := evm_div_callable_code_v4_ret_sub (base := base))
       (ret_spec_within' (base + nopOff) raVal)
   have hRetFramed :=
     cpsTripleWithin_frameL (divStackDispatchPostNoX1 sp a b) hpcFreePost hRet
@@ -936,69 +707,6 @@ theorem evm_div_callable_spec_from_noNop_branch_return_x1_framed
   exact
     cpsTripleWithin_frameR F (by pcFree)
       (evm_div_callable_spec_from_noNop_branch_return_x1
-        sp base a b v5 v6 v7 v10 v11
-        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-        nMem shiftMem jMem retMem dMem dloMem scratchUn0 branch hStack)
-
-/-- v4 callable wrapper whose no-NOP body proof uses the exact return address
-    selected by the branch certificate in the dispatch precondition. -/
-theorem evm_div_callable_v4_spec_from_noNop_branch_return_x1 (sp base : Word)
-    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
-    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-     nMem shiftMem jMem retMem dMem dloMem scratchUn0 : Word)
-    (branch : DivStackSpecCase base a b)
-    (hStack :
-      cpsTripleWithin unifiedDivBound base (base + nopOff) (sharedDivModCodeNoNop_v4 base)
-        (divModStackDispatchPre sp a b
-          branch.returnX1 branch.x2 v5 v6 v7 v10 v11
-          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
-        (divStackDispatchPostNoX1 sp a b ** (.x1 ↦ᵣ branch.returnX1))) :
-    cpsTripleWithin (unifiedDivBound + 1) base (branch.returnX1 &&& ~~~1)
-      (evm_div_callable_code_v4 base)
-      (divModStackDispatchPre sp a b
-        branch.returnX1 branch.x2 v5 v6 v7 v10 v11
-        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-        shiftMem nMem jMem retMem dMem dloMem scratchUn0)
-      (divStackDispatchPostNoX1 sp a b ** (.x1 ↦ᵣ branch.returnX1)) := by
-  have hpcFreePost : (divStackDispatchPostNoX1 sp a b).pcFree := by
-    rw [divStackDispatchPostNoX1_unfold]
-    rw [divScratchOwnCall_unfold, divScratchOwn_unfold]
-    pcFree
-  have hStackCall :=
-    cpsTripleWithin_extend_code
-      (hmono := sharedDivModCodeNoNop_v4_sub_div_callable_code_v4) hStack
-  have hRet :=
-    cpsTripleWithin_extend_code (hmono := evm_div_callable_code_v4_ret_sub (base := base))
-      (ret_spec_within' (base + nopOff) branch.returnX1)
-  have hRetFramed :=
-    cpsTripleWithin_frameL (divStackDispatchPostNoX1 sp a b) hpcFreePost hRet
-  exact cpsTripleWithin_seq_same_cr hStackCall hRetFramed
-
-/-- Framed variant of `evm_div_callable_v4_spec_from_noNop_branch_return_x1`. -/
-theorem evm_div_callable_v4_spec_from_noNop_branch_return_x1_framed
-    {F : Assertion} [Assertion.PCFree F] (sp base : Word)
-    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
-    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-     nMem shiftMem jMem retMem dMem dloMem scratchUn0 : Word)
-    (branch : DivStackSpecCase base a b)
-    (hStack :
-      cpsTripleWithin unifiedDivBound base (base + nopOff) (sharedDivModCodeNoNop_v4 base)
-        (divModStackDispatchPre sp a b
-          branch.returnX1 branch.x2 v5 v6 v7 v10 v11
-          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
-        (divStackDispatchPostNoX1 sp a b ** (.x1 ↦ᵣ branch.returnX1))) :
-    cpsTripleWithin (unifiedDivBound + 1) base (branch.returnX1 &&& ~~~1)
-      (evm_div_callable_code_v4 base)
-      (divModStackDispatchPre sp a b
-        branch.returnX1 branch.x2 v5 v6 v7 v10 v11
-        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-        shiftMem nMem jMem retMem dMem dloMem scratchUn0 ** F)
-      ((divStackDispatchPostNoX1 sp a b ** (.x1 ↦ᵣ branch.returnX1)) ** F) := by
-  exact
-    cpsTripleWithin_frameR F (by pcFree)
-      (evm_div_callable_v4_spec_from_noNop_branch_return_x1
         sp base a b v5 v6 v7 v10 v11
         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
         nMem shiftMem jMem retMem dMem dloMem scratchUn0 branch hStack)

--- a/EvmAsm/Evm64/DivMod/CallableBzeroV4.lean
+++ b/EvmAsm/Evm64/DivMod/CallableBzeroV4.lean
@@ -4,7 +4,7 @@
   Split v4 zero-divisor callable wrappers for DIV.
 -/
 
-import EvmAsm.Evm64.DivMod.Callable
+import EvmAsm.Evm64.DivMod.CallableV4Div
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/DivMod/CallableV4Div.lean
+++ b/EvmAsm/Evm64/DivMod/CallableV4Div.lean
@@ -1,0 +1,290 @@
+import EvmAsm.Evm64.DivMod.Callable
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+open EvmAsm.Rv64.CodeReq in
+theorem evm_div_callable_code_v4_eq_ofProg (base : Word) :
+    evm_div_callable_code_v4 base = CodeReq.ofProg base evm_div_callable_v4 := by
+  unfold evm_div_callable_code_v4 evm_div_callable_v4 cc_ret_code
+  simp only [unionAll_cons, unionAll_nil, union_empty_right]
+  unfold seq
+  unfold Program
+  symm
+  rw [ofProg_append]
+  rw [show base + BitVec.ofNat 64 (4 * (divK_phaseA 1020).length) =
+        base + phaseBOff by rw [divK_phaseA_len]; rfl]
+  rw [ofProg_append]
+  rw [show (base + phaseBOff) + BitVec.ofNat 64 (4 * divK_phaseB.length) =
+        base + clzOff by rw [divK_phaseB_len]; bv_omega]
+  rw [ofProg_append]
+  rw [show (base + clzOff) + BitVec.ofNat 64 (4 * divK_clz.length) =
+        base + phaseC2Off by rw [divK_clz_len]; bv_omega]
+  rw [ofProg_append]
+  rw [show (base + phaseC2Off) + BitVec.ofNat 64 (4 * (divK_phaseC2 172).length) =
+        base + normBOff by rw [divK_phaseC2_len]; bv_omega]
+  rw [ofProg_append]
+  rw [show (base + normBOff) + BitVec.ofNat 64 (4 * divK_normB.length) =
+        base + normAOff by rw [divK_normB_len]; bv_omega]
+  rw [ofProg_append]
+  rw [show (base + normAOff) + BitVec.ofNat 64 (4 * (divK_normA 40).length) =
+        base + copyAUOff by rw [divK_normA_len]; bv_omega]
+  rw [ofProg_append]
+  rw [show (base + copyAUOff) + BitVec.ofNat 64 (4 * divK_copyAU.length) =
+        base + loopSetupOff by rw [divK_copyAU_len]; bv_omega]
+  rw [ofProg_append]
+  rw [show (base + loopSetupOff) + BitVec.ofNat 64 (4 * (divK_loopSetup 464).length) =
+        base + loopBodyOff by rw [divK_loopSetup_len]; bv_omega]
+  rw [ofProg_append]
+  rw [show (base + loopBodyOff) + BitVec.ofNat 64 (4 * (divK_loopBody 560 7736).length) =
+        base + denormOff by rw [divK_loopBody_len]; bv_omega]
+  rw [ofProg_append]
+  rw [show (base + denormOff) + BitVec.ofNat 64 (4 * divK_denorm.length) =
+        base + epilogueOff by rw [divK_denorm_len]; bv_omega]
+  rw [ofProg_append]
+  rw [show (base + epilogueOff) + BitVec.ofNat 64 (4 * (divK_div_epilogue 24).length) =
+        base + zeroPathOff by rw [divK_divEpilogue_len]; bv_omega]
+  rw [ofProg_append]
+  rw [show (base + zeroPathOff) + BitVec.ofNat 64 (4 * divK_zeroPath.length) =
+        base + nopOff by rw [divK_zeroPath_len]; bv_omega]
+  rw [ofProg_append]
+  rw [show (base + nopOff) + BitVec.ofNat 64 (4 * cc_ret.length) =
+        base + div128Off by
+    show (base + nopOff) + BitVec.ofNat 64 (4 * 1) = base + div128Off
+    bv_omega]
+
+private theorem callable_b0_div_v4 {b : Word} :
+    ∀ a i, (CodeReq.ofProg b (divK_phaseA 1020)) a = some i →
+      (evm_div_callable_code_v4 b) a = some i := by
+  unfold evm_div_callable_code_v4; simp only [CodeReq.unionAll_cons]
+  exact CodeReq.union_mono_left
+private theorem callable_b1_div_v4 {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + phaseBOff) divK_phaseB) a = some i →
+      (evm_div_callable_code_v4 b) a = some i := by
+  unfold evm_div_callable_code_v4; simp only [CodeReq.unionAll_cons]
+  skipBlock; exact CodeReq.union_mono_left
+private theorem callable_b2_div_v4 {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + clzOff) divK_clz) a = some i →
+      (evm_div_callable_code_v4 b) a = some i := by
+  unfold evm_div_callable_code_v4; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock; exact CodeReq.union_mono_left
+private theorem callable_b3_div_v4 {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + phaseC2Off) (divK_phaseC2 172)) a = some i →
+      (evm_div_callable_code_v4 b) a = some i := by
+  unfold evm_div_callable_code_v4; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
+private theorem callable_b4_div_v4 {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + normBOff) divK_normB) a = some i →
+      (evm_div_callable_code_v4 b) a = some i := by
+  unfold evm_div_callable_code_v4; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
+private theorem callable_b5_div_v4 {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + normAOff) (divK_normA 40)) a = some i →
+      (evm_div_callable_code_v4 b) a = some i := by
+  unfold evm_div_callable_code_v4; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
+private theorem callable_b6_div_v4 {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + copyAUOff) divK_copyAU) a = some i →
+      (evm_div_callable_code_v4 b) a = some i := by
+  unfold evm_div_callable_code_v4; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
+private theorem callable_b7_div_v4 {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + loopSetupOff) (divK_loopSetup 464)) a = some i →
+      (evm_div_callable_code_v4 b) a = some i := by
+  unfold evm_div_callable_code_v4; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
+  exact CodeReq.union_mono_left
+private theorem callable_b8_div_v4 {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + loopBodyOff) (divK_loopBody 560 7736)) a = some i →
+      (evm_div_callable_code_v4 b) a = some i := by
+  unfold evm_div_callable_code_v4; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
+  exact CodeReq.union_mono_left
+private theorem callable_b9_div_v4 {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + denormOff) divK_denorm) a = some i →
+      (evm_div_callable_code_v4 b) a = some i := by
+  unfold evm_div_callable_code_v4; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
+  skipBlock; exact CodeReq.union_mono_left
+private theorem callable_b10_div_v4 {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + epilogueOff) (divK_div_epilogue 24)) a = some i →
+      (evm_div_callable_code_v4 b) a = some i := by
+  unfold evm_div_callable_code_v4; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
+  skipBlock; skipBlock; exact CodeReq.union_mono_left
+private theorem callable_b11_div_v4 {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + zeroPathOff) divK_zeroPath) a = some i →
+      (evm_div_callable_code_v4 b) a = some i := by
+  unfold evm_div_callable_code_v4; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
+  skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
+private theorem callable_b12_div_v4 {b : Word} :
+    ∀ a i, (cc_ret_code (b + nopOff)) a = some i →
+      (evm_div_callable_code_v4 b) a = some i := by
+  unfold evm_div_callable_code_v4; simp only [CodeReq.unionAll_cons]
+  skipBlockCC; skipBlockCC; skipBlockCC; skipBlockCC; skipBlockCC; skipBlockCC
+  skipBlockCC; skipBlockCC; skipBlockCC; skipBlockCC; skipBlockCC; skipBlockCC
+  exact CodeReq.union_mono_left
+private theorem callable_b13_div_v4 {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + div128Off) divK_div128_v4) a = some i →
+      (evm_div_callable_code_v4 b) a = some i := by
+  unfold evm_div_callable_code_v4; simp only [CodeReq.unionAll_cons, cc_ret_code]
+  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
+  skipBlock; skipBlock; skipBlock; skipBlock; skipBlockCC; exact CodeReq.union_mono_left
+
+theorem evm_div_callable_code_v4_ret_sub {base : Word} :
+    ∀ a i, (CodeReq.singleton (base + nopOff) (.JALR .x0 .x1 0)) a = some i →
+      (evm_div_callable_code_v4 base) a = some i := by
+  intro a i h
+  apply callable_b12_div_v4
+  unfold cc_ret_code cc_ret
+  simpa [CodeReq.ofProg] using h
+
+theorem sharedDivModCodeNoNop_v4_sub_div_callable_code_v4 {base : Word} :
+    ∀ a i, (sharedDivModCodeNoNop_v4 base) a = some i →
+           (evm_div_callable_code_v4 base) a = some i := by
+  unfold sharedDivModCodeNoNop_v4; simp only [CodeReq.unionAll_cons]
+  exact CodeReq.union_split_mono callable_b0_div_v4
+    (CodeReq.union_split_mono callable_b1_div_v4
+    (CodeReq.union_split_mono callable_b2_div_v4
+    (CodeReq.union_split_mono callable_b3_div_v4
+    (CodeReq.union_split_mono callable_b4_div_v4
+    (CodeReq.union_split_mono callable_b5_div_v4
+    (CodeReq.union_split_mono callable_b6_div_v4
+    (CodeReq.union_split_mono callable_b7_div_v4
+    (CodeReq.union_split_mono callable_b8_div_v4
+    (CodeReq.union_split_mono callable_b9_div_v4
+    (CodeReq.union_split_mono callable_b11_div_v4
+    (CodeReq.union_split_mono callable_b13_div_v4
+    (fun _ _ h => by simp [CodeReq.unionAll_nil, CodeReq.empty] at h))))))))))))
+
+theorem evm_div_callable_v4_spec_from_noNop (sp base raVal : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (branch : DivStackSpecCase base a b)
+    (hStack :
+      cpsTripleWithin unifiedDivBound base (base + nopOff) (sharedDivModCodeNoNop_v4 base)
+        (divModStackDispatchPre sp a b
+          branch.x1 branch.x2 v5 v6 v7 v10 v11
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+        (divStackDispatchPost sp a b)) :
+    cpsTripleWithin (unifiedDivBound + 1) base (raVal &&& ~~~1)
+      (evm_div_callable_code_v4 base)
+      (divModStackDispatchPre sp a b
+        branch.x1 branch.x2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 ** (.x1 ↦ᵣ raVal))
+      (divStackDispatchPost sp a b ** (.x1 ↦ᵣ raVal)) := by
+  have hpcFreePost : (divStackDispatchPost sp a b).pcFree := by
+    rw [divStackDispatchPost_unfold]
+    rw [divScratchOwnCall_unfold, divScratchOwn_unfold]
+    pcFree
+  have hStackCall :=
+    cpsTripleWithin_extend_code
+      (hmono := sharedDivModCodeNoNop_v4_sub_div_callable_code_v4) hStack
+  have hStackFramed :=
+    cpsTripleWithin_frameR (.x1 ↦ᵣ raVal) (by pcFree) hStackCall
+  have hRet :=
+    cpsTripleWithin_extend_code (hmono := evm_div_callable_code_v4_ret_sub (base := base))
+      (ret_spec_within' (base + nopOff) raVal)
+  have hRetFramed :=
+    cpsTripleWithin_frameL (divStackDispatchPost sp a b) hpcFreePost hRet
+  exact cpsTripleWithin_seq_same_cr hStackFramed hRetFramed
+
+theorem evm_div_callable_v4_spec_from_noNop_preserving_x1 (sp base raVal : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (branch : DivStackSpecCase base a b)
+    (hStack :
+      cpsTripleWithin unifiedDivBound base (base + nopOff) (sharedDivModCodeNoNop_v4 base)
+        (divModStackDispatchPre sp a b
+          branch.x1 branch.x2 v5 v6 v7 v10 v11
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+        (divStackDispatchPostNoX1 sp a b ** (.x1 ↦ᵣ raVal))) :
+    cpsTripleWithin (unifiedDivBound + 1) base (raVal &&& ~~~1)
+      (evm_div_callable_code_v4 base)
+      (divModStackDispatchPre sp a b
+        branch.x1 branch.x2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+      (divStackDispatchPostNoX1 sp a b ** (.x1 ↦ᵣ raVal)) := by
+  have hpcFreePost : (divStackDispatchPostNoX1 sp a b).pcFree := by
+    rw [divStackDispatchPostNoX1_unfold]
+    rw [divScratchOwnCall_unfold, divScratchOwn_unfold]
+    pcFree
+  have hStackCall :=
+    cpsTripleWithin_extend_code
+      (hmono := sharedDivModCodeNoNop_v4_sub_div_callable_code_v4) hStack
+  have hRet :=
+    cpsTripleWithin_extend_code (hmono := evm_div_callable_code_v4_ret_sub (base := base))
+      (ret_spec_within' (base + nopOff) raVal)
+  have hRetFramed :=
+    cpsTripleWithin_frameL (divStackDispatchPostNoX1 sp a b) hpcFreePost hRet
+  exact cpsTripleWithin_seq_same_cr hStackCall hRetFramed
+
+theorem evm_div_callable_v4_spec_from_noNop_branch_return_x1 (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (branch : DivStackSpecCase base a b)
+    (hStack :
+      cpsTripleWithin unifiedDivBound base (base + nopOff) (sharedDivModCodeNoNop_v4 base)
+        (divModStackDispatchPre sp a b
+          branch.returnX1 branch.x2 v5 v6 v7 v10 v11
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+        (divStackDispatchPostNoX1 sp a b ** (.x1 ↦ᵣ branch.returnX1))) :
+    cpsTripleWithin (unifiedDivBound + 1) base (branch.returnX1 &&& ~~~1)
+      (evm_div_callable_code_v4 base)
+      (divModStackDispatchPre sp a b
+        branch.returnX1 branch.x2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+      (divStackDispatchPostNoX1 sp a b ** (.x1 ↦ᵣ branch.returnX1)) := by
+  have hpcFreePost : (divStackDispatchPostNoX1 sp a b).pcFree := by
+    rw [divStackDispatchPostNoX1_unfold]
+    rw [divScratchOwnCall_unfold, divScratchOwn_unfold]
+    pcFree
+  have hStackCall :=
+    cpsTripleWithin_extend_code
+      (hmono := sharedDivModCodeNoNop_v4_sub_div_callable_code_v4) hStack
+  have hRet :=
+    cpsTripleWithin_extend_code (hmono := evm_div_callable_code_v4_ret_sub (base := base))
+      (ret_spec_within' (base + nopOff) branch.returnX1)
+  have hRetFramed :=
+    cpsTripleWithin_frameL (divStackDispatchPostNoX1 sp a b) hpcFreePost hRet
+  exact cpsTripleWithin_seq_same_cr hStackCall hRetFramed
+
+theorem evm_div_callable_v4_spec_from_noNop_branch_return_x1_framed
+    {F : Assertion} [Assertion.PCFree F] (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (branch : DivStackSpecCase base a b)
+    (hStack :
+      cpsTripleWithin unifiedDivBound base (base + nopOff) (sharedDivModCodeNoNop_v4 base)
+        (divModStackDispatchPre sp a b
+          branch.returnX1 branch.x2 v5 v6 v7 v10 v11
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+        (divStackDispatchPostNoX1 sp a b ** (.x1 ↦ᵣ branch.returnX1))) :
+    cpsTripleWithin (unifiedDivBound + 1) base (branch.returnX1 &&& ~~~1)
+      (evm_div_callable_code_v4 base)
+      (divModStackDispatchPre sp a b
+        branch.returnX1 branch.x2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 ** F)
+      ((divStackDispatchPostNoX1 sp a b ** (.x1 ↦ᵣ branch.returnX1)) ** F) := by
+  exact
+    cpsTripleWithin_frameR F (by pcFree)
+      (evm_div_callable_v4_spec_from_noNop_branch_return_x1
+        sp base a b v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        nMem shiftMem jMem retMem dMem dloMem scratchUn0 branch hStack)
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/SDiv/Compose/Base.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/Base.lean
@@ -13,6 +13,7 @@
 
 import EvmAsm.Evm64.SDiv.LimbSpec
 import EvmAsm.Evm64.SDiv.AddrNorm
+import EvmAsm.Evm64.DivMod.CallableV4Div
 import EvmAsm.Evm64.SDiv.Compose.BaseCode
 import EvmAsm.Evm64.SDiv.Compose.BaseOffsets
 import EvmAsm.Evm64.SDiv.Compose.BaseSignSequence

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallCallable.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallCallable.lean
@@ -5,7 +5,7 @@
   the full SDIV code region.
 -/
 
-import EvmAsm.Evm64.DivMod.Callable
+import EvmAsm.Evm64.DivMod.CallableV4Div
 import EvmAsm.Evm64.SDiv.Compose.BaseCode
 
 namespace EvmAsm.Evm64.SDiv.Compose

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallExactCallable.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallExactCallable.lean
@@ -6,6 +6,7 @@
 -/
 
 import EvmAsm.Evm64.SDiv.Compose.DivCallPostPcFreeBasics
+import EvmAsm.Evm64.DivMod.CallableV4Div
 
 namespace EvmAsm.Evm64.SDiv.Compose
 


### PR DESCRIPTION
## Summary
- move DIV v4 callable proof helpers from Callable.lean into CallableV4Div.lean
- keep core callable program/code definitions in Callable.lean while importing the split helper where theorem consumers need it
- reduce Callable.lean from 1444 lines to 1152 lines, leaving room for the follow-up default-v4 migration

## Verification
- lake build EvmAsm.Evm64.DivMod.CallableV4Div
- lake build EvmAsm.Evm64.DivMod EvmAsm.Evm64.SDiv EvmAsm.Evm64.SMod
- scripts/check-file-size.sh
- git diff --check
- rg -n "sorry|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/Callable.lean EvmAsm/Evm64/DivMod/CallableV4Div.lean EvmAsm/Evm64/DivMod.lean EvmAsm/Evm64/DivMod/CallableBzeroV4.lean EvmAsm/Evm64/SDiv/Compose/Base.lean EvmAsm/Evm64/SDiv/Compose/DivCallCallable.lean EvmAsm/Evm64/SDiv/Compose/DivCallExactCallable.lean