### PR TITLE
feat(divmod): add legacy mod callable spec aliases

### DIFF
--- a/EvmAsm/Evm64/DivMod/CallableV1Legacy.lean
+++ b/EvmAsm/Evm64/DivMod/CallableV1Legacy.lean
@@ -238,4 +238,54 @@ theorem evm_div_callable_v1_spec_from_noNop_branch_return_x1_framed
       q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
       nMem shiftMem jMem retMem dMem dloMem scratchUn0 branch hStack
 
+theorem evm_mod_callable_v1_spec_from_noNop_preserving_x1 (sp base raVal : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (branch : ModStackSpecCase base a b)
+    (hStack :
+      cpsTripleWithin unifiedDivBound base (base + nopOff) (modCode_noNop base)
+        (divModStackDispatchPre sp a b
+          branch.x1 branch.x2 v5 v6 v7 v10 v11
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+        (modStackDispatchPostNoX1 sp a b ** (.x1 ↦ᵣ raVal))) :
+    cpsTripleWithin (unifiedDivBound + 1) base (raVal &&& ~~~1)
+      (evm_mod_callable_code_v1 base)
+      (divModStackDispatchPre sp a b
+        branch.x1 branch.x2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+      (modStackDispatchPostNoX1 sp a b ** (.x1 ↦ᵣ raVal)) := by
+  simpa [evm_mod_callable_code_v1_eq_current]
+    using evm_mod_callable_spec_from_noNop_preserving_x1
+      sp base raVal a b v5 v6 v7 v10 v11
+      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      nMem shiftMem jMem retMem dMem dloMem scratchUn0 branch hStack
+
+theorem evm_mod_callable_v1_spec_from_noNop (sp base raVal : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (branch : ModStackSpecCase base a b)
+    (hStack :
+      cpsTripleWithin unifiedDivBound base (base + nopOff) (modCode_noNop base)
+        (divModStackDispatchPre sp a b
+          branch.x1 branch.x2 v5 v6 v7 v10 v11
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+        (modStackDispatchPost sp a b)) :
+    cpsTripleWithin (unifiedDivBound + 1) base (raVal &&& ~~~1)
+      (evm_mod_callable_code_v1 base)
+      (divModStackDispatchPre sp a b
+        branch.x1 branch.x2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 ** (.x1 ↦ᵣ raVal))
+      (modStackDispatchPost sp a b ** (.x1 ↦ᵣ raVal)) := by
+  simpa [evm_mod_callable_code_v1_eq_current]
+    using evm_mod_callable_spec_from_noNop
+      sp base raVal a b v5 v6 v7 v10 v11
+      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      nMem shiftMem jMem retMem dMem dloMem scratchUn0 branch hStack
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add v1-named aliases for MOD callable no-NOP spec helpers
- cover preserving-x1 and framed postcondition variants over the legacy MOD callable CodeReq
- keep aliases over current default callable specs so the default-v4 migration can retarget legacy users first

## Verification
- lake build EvmAsm.Evm64.DivMod.CallableV1Legacy
- lake build EvmAsm.Evm64.DivMod EvmAsm.Evm64.SDiv EvmAsm.Evm64.SMod
- scripts/check-file-size.sh
- git diff --check
- rg -n "sorry|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/CallableV1Legacy.lean