### PR TITLE
feat(sdiv): add v4 bzero handoff wrappers

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/DivCallBzeroResultSignFixHandoff.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallBzeroResultSignFixHandoff.lean
@@ -5,6 +5,7 @@
 -/
 
 import EvmAsm.Evm64.SDiv.Compose.DivCallBzeroHandoff
+import EvmAsm.Evm64.SDiv.Compose.BzeroResultSignFix
 import EvmAsm.Evm64.SDiv.Compose.DivCallResultSignFixNamedPost
 
 namespace EvmAsm.Evm64.SDiv.Compose
@@ -47,5 +48,43 @@ theorem saveRa_signs_abs_signXor_then_divCall_bzero_then_resultSignFix_named_pos
         divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
         v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
         shiftMem nMem jMem retMem dMem dloMem scratchUn0 hbase hbz)
+
+/-- v4 zero-divisor SDIV path through result-sign-fix, exposed from the
+    sidecar bzero callable handoff layer. -/
+theorem saveRa_signs_abs_signXor_then_divCall_bzero_then_resultSignFix_from_handoff_spec_in_sdivCodeV4
+    (vRa vSavedOld sp sDividendOld sDivisorOld
+      dividendMaskOld dividendValueOld dividendCarryOld
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+      v2 v5 v6 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (base : Word) (hbase : base &&& 1 = 0)
+    (hbz : sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop = 0) :
+    EvmAsm.Rv64.cpsTripleWithin ((49 + (EvmAsm.Evm64.unifiedDivBound + 1)) + 21)
+      base ((base + resultSignFixOff) + 84) (sdivCodeV4 base)
+      (saveRaSignsAbsSignXorThenDivCallPre vRa vSavedOld sp sDividendOld sDivisorOld
+        dividendMaskOld dividendValueOld dividendCarryOld
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
+       ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
+        EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0))
+      (let dividendAbsWord :=
+         sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+       let resultSign :=
+         (dividendTop >>> (63 : BitVec 6).toNat) ^^^
+           (divisorTop >>> (63 : BitVec 6).toNat)
+       let divisorSign := divisorTop >>> (63 : BitVec 6).toNat
+       resultSignFixPost (sp + 32) resultSign 0 0 0 0 **
+       saveRaDivCallBzeroResultSignFixFrame vRa sp base divisorSign dividendAbsWord) := by
+  exact
+    saveRa_signs_abs_signXor_then_divCall_bzero_then_resultSignFix_spec_in_sdivCodeV4
+      vRa vSavedOld sp sDividendOld sDivisorOld
+      dividendMaskOld dividendValueOld dividendCarryOld
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+      v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 base hbase hbz
 
 end EvmAsm.Evm64.SDiv.Compose

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallBzeroReturnHandoff.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallBzeroReturnHandoff.lean
@@ -5,6 +5,7 @@
 -/
 
 import EvmAsm.Evm64.SDiv.Compose.DivCallBzeroHandoff
+import EvmAsm.Evm64.SDiv.Compose.BzeroReturnNormalizedView
 import EvmAsm.Evm64.SDiv.Compose.DivCallReturnComposition
 
 namespace EvmAsm.Evm64.SDiv.Compose
@@ -47,5 +48,44 @@ theorem saveRa_signs_abs_signXor_then_divCall_bzero_then_return_normalized_named
         divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
         v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
         shiftMem nMem jMem retMem dMem dloMem scratchUn0 hbase hbz)
+
+/-- v4 zero-divisor SDIV path through result-sign-fix and the saved-RA return,
+    exposed from the sidecar bzero callable handoff layer. -/
+theorem saveRa_signs_abs_signXor_then_divCall_bzero_then_return_normalized_from_handoff_spec_in_sdivCodeV4
+    (vRa vSavedOld sp sDividendOld sDivisorOld
+      dividendMaskOld dividendValueOld dividendCarryOld
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+      v2 v5 v6 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (base : Word) (hbase : base &&& 1 = 0)
+    (hbz : sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop = 0) :
+    EvmAsm.Rv64.cpsTripleWithin (((49 + (EvmAsm.Evm64.unifiedDivBound + 1)) + 21) + 1)
+      base (vRa &&& ~~~(1 : Word)) (sdivCodeV4 base)
+      (saveRaSignsAbsSignXorThenDivCallPre vRa vSavedOld sp sDividendOld sDivisorOld
+        dividendMaskOld dividendValueOld dividendCarryOld
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
+       ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
+        EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0))
+      (let dividendAbsWord :=
+         sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+       let resultSign :=
+         (dividendTop >>> (63 : BitVec 6).toNat) ^^^
+           (divisorTop >>> (63 : BitVec 6).toNat)
+       let divisorSign := divisorTop >>> (63 : BitVec 6).toNat
+       (.x18 ↦ᵣ vRa) **
+       (resultSignFixPost (sp + 32) resultSign 0 0 0 0 **
+        saveRaDivCallBzeroSavedRaRetFrame sp base divisorSign dividendAbsWord)) := by
+  exact
+    saveRa_signs_abs_signXor_then_divCall_bzero_then_return_normalized_spec_in_sdivCodeV4
+      vRa vSavedOld sp sDividendOld sDivisorOld
+      dividendMaskOld dividendValueOld dividendCarryOld
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+      v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 base hbase hbz
 
 end EvmAsm.Evm64.SDiv.Compose


### PR DESCRIPTION
Stacked on #5247.

## Summary
- add v4 sidecar wrapper for the zero-divisor result-sign-fix handoff
- add v4 sidecar wrapper for the zero-divisor normalized return handoff

## Verification
- lake build EvmAsm.Evm64.SDiv.Compose.DivCallBzeroResultSignFixHandoff
- lake build EvmAsm.Evm64.SDiv.Compose.DivCallBzeroReturnHandoff
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- scripts/check-file-size.sh EvmAsm/Evm64/SDiv/Compose/DivCallBzeroResultSignFixHandoff.lean EvmAsm/Evm64/SDiv/Compose/DivCallBzeroReturnHandoff.lean
- rg -n "sorry|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/DivCallBzeroResultSignFixHandoff.lean EvmAsm/Evm64/SDiv/Compose/DivCallBzeroReturnHandoff.lean