### PR TITLE
test(sdiv): pin v4 callable divider wiring

### DIFF
--- a/EvmAsm/Evm64/SDiv/Program.lean
+++ b/EvmAsm/Evm64/SDiv/Program.lean
@@ -216,6 +216,11 @@ def evm_sdiv : EvmAsm.Rv64.Program :=
 def evm_sdiv_v4 : EvmAsm.Rv64.Program :=
   evm_sdiv_wrapper ;; evm_div_callable_v4
 
+/-- Regression pin: the executable v4 SDIV body uses the corrected v4
+    callable divider. -/
+theorem evm_sdiv_v4_uses_div_callable_v4 :
+    evm_sdiv_v4 = (evm_sdiv_wrapper ;; evm_div_callable_v4) := rfl
+
 theorem evm_sdiv_length : evm_sdiv.length = 390 := by
   native_decide
 


### PR DESCRIPTION
## Summary
- add a kernel-checked regression pin that evm_sdiv_v4 is wired to evm_div_callable_v4
- makes the SDIV executable v4 dependency on the corrected callable divider explicit

## Verification
- lake build EvmAsm.Evm64.SDiv.Program
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- scripts/check-file-size.sh EvmAsm/Evm64/SDiv/Program.lean
- rg -n 'sorry|set_option maxHeartbeats|set_option maxRecDepth' EvmAsm/Evm64/SDiv/Program.lean