### PR TITLE
test(smod): pin min-int modulo edge case

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/SMod.lean
+++ b/EvmAsm/Evm64/EvmWordArith/SMod.lean
@@ -66,6 +66,9 @@ theorem smod_pos_neg_sign : smod (3 : EvmWord) (-2) = (1 : EvmWord) := by
 theorem smod_neg_neg_sign : smod (-3 : EvmWord) (-2) = (-1 : EvmWord) := by
   native_decide
 
+theorem smod_intMin_neg_one : smod (BitVec.intMin 256) (-1) = 0 := by
+  native_decide
+
 -- ============================================================================
 -- Correctness vs `Int.tmod` (the spec formula)
 -- ============================================================================

--- a/EvmAsm/Evm64/SMod/Args.lean
+++ b/EvmAsm/Evm64/SMod/Args.lean
@@ -61,6 +61,10 @@ theorem stackAfterSMod_eq (args : Args) (rest : List EvmWord) :
     smodResultFromArgs (smodArgs 0 divisor) = 0 := by
   exact EvmWord.zero_smod_left
 
+theorem smodResultFromArgs_intMin_neg_one :
+    smodResultFromArgs (smodArgs (BitVec.intMin 256) (-1)) = 0 := by
+  exact EvmWord.smod_intMin_neg_one
+
 theorem smodResultFromArgs_neg_pos_sign :
     smodResultFromArgs (smodArgs (-3) 2) = (-1 : EvmWord) := by
   exact EvmWord.smod_neg_pos_sign

--- a/EvmAsm/Evm64/SMod/HandlerBridge.lean
+++ b/EvmAsm/Evm64/SMod/HandlerBridge.lean
@@ -133,6 +133,14 @@ theorem smodHandler_stack_zero_divisor
   simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler]
   exact EvmWord.smod_zero_right
 
+theorem smodHandler_stack_intMin_neg_one
+    (state : EvmState) (rest : List EvmWord) :
+    (ArithmeticHandlers.smodHandler
+      { state with stack := BitVec.intMin 256 :: (-1 : EvmWord) :: rest }).stack =
+        0 :: rest := by
+  simp [ArithmeticHandlers.smodHandler, ArithmeticHandlers.binaryHandler]
+  exact EvmWord.smod_intMin_neg_one
+
 theorem smodHandler_stack_neg_pos_sign
     (state : EvmState) (rest : List EvmWord) :
     (ArithmeticHandlers.smodHandler

--- a/EvmAsm/Evm64/SMod/StackExecutionBridge.lean
+++ b/EvmAsm/Evm64/SMod/StackExecutionBridge.lean
@@ -171,6 +171,13 @@ theorem runSModStack?_zero_divisor
   rw [runSModStack?_cons]
   rw [SModArgs.smodResultFromArgs_zero_divisor]
 
+theorem runSModStack?_intMin_neg_one
+    (rest : List EvmWord) :
+    runSModStack? { stack := BitVec.intMin 256 :: (-1 : EvmWord) :: rest } =
+      some { effects := { stackWords := [0] }, stack := rest } := by
+  rw [runSModStack?_cons]
+  rw [SModArgs.smodResultFromArgs_intMin_neg_one]
+
 theorem runSModStack?_neg_pos_sign
     (rest : List EvmWord) :
     runSModStack? { stack := (-3 : EvmWord) :: 2 :: rest } =


### PR DESCRIPTION
## Summary
- add a closed EvmWord.smod min-int / -1 edge-case theorem
- thread the case through SMOD args, stack execution, and handler bridge pins

## Verification
- lake build EvmAsm.Evm64.EvmWordArith.SMod
- lake build EvmAsm.Evm64.SMod
- git diff --check
- scripts/check-file-size.sh EvmAsm/Evm64/EvmWordArith/SMod.lean EvmAsm/Evm64/SMod/Args.lean EvmAsm/Evm64/SMod/StackExecutionBridge.lean EvmAsm/Evm64/SMod/HandlerBridge.lean
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/EvmWordArith/SMod.lean EvmAsm/Evm64/SMod/Args.lean EvmAsm/Evm64/SMod/StackExecutionBridge.lean EvmAsm/Evm64/SMod/HandlerBridge.lean