### PR TITLE
feat(div): split loop preconditions without x1 ownership

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1Loop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1Loop.lean
@@ -207,4 +207,57 @@ theorem divK_loop_n1_unified_divCode_noNop (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
     retMem dMem dloMem scratch_un0 base halign
     hbltu_3 hbltu_2 hbltu_1 hbltu_0 hcarry2
 
+/-- No-NOP divCode wrapper for the n=1 unified loop with the scratch
+    precondition split so callers can keep exact `x1` ownership outside it. -/
+theorem divK_loop_n1_unified_divCode_noNop_noX1_pre (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop
+     u0_orig_2 u0_orig_1 u0_orig_0
+     q3Old q2Old q1Old q0Old : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu_3 : bltu_3 = BitVec.ult u1 v0)
+    (hbltu_2 : bltu_2 = BitVec.ult (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v0)
+    (hbltu_1 : bltu_1 = BitVec.ult (iterN1 bltu_2 v0 v1 v2 v3 u0_orig_2
+      (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.1 v0)
+    (hbltu_0 : bltu_0 = BitVec.ult (iterN1 bltu_1 v0 v1 v2 v3 u0_orig_1
+      (iterN1 bltu_2 v0 v1 v2 v3 u0_orig_2
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.1
+      (iterN1 bltu_2 v0 v1 v2 v3 u0_orig_2
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.1
+      (iterN1 bltu_2 v0 v1 v2 v3 u0_orig_2
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.1
+      (iterN1 bltu_2 v0 v1 v2 v3 u0_orig_2
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.2.1).2.1 v0)
+    (hcarry2 : Carry2NzAll v0 v1 v2 v3) :
+    cpsTripleWithin 808 (base + loopBodyOff) (base + denormOff) (divCode_noNop base)
+      (loopN1PreWithScratchNoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop
+        u0_orig_2 u0_orig_1 u0_orig_0 q3Old q2Old q1Old q0Old
+        retMem dMem dloMem scratch_un0 ** regOwn .x1)
+      (loopN1UnifiedPost bltu_3 bltu_2 bltu_1 bltu_0 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop
+        u0_orig_2 u0_orig_1 u0_orig_0 retMem dMem dloMem scratch_un0) :=
+  divK_loop_n1_unified_spec_within_noNop_noX1_pre bltu_3 bltu_2 bltu_1 bltu_0
+    sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig_2 u0_orig_1 u0_orig_0
+    q3Old q2Old q1Old q0Old
+    retMem dMem dloMem scratch_un0 base halign
+    hbltu_3 hbltu_2 hbltu_1 hbltu_0 hcarry2
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LoopDefs/Bundle.lean
+++ b/EvmAsm/Evm64/DivMod/LoopDefs/Bundle.lean
@@ -67,6 +67,73 @@ def loopN3PreWithScratch (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
   (sp + signExtend12 3952 ↦ₘ dloMem) **
   (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1
 
+/-- Callable-ready n=3 two-iteration loop precondition with scratch cells
+    and no ownership claim over `x1`. -/
+@[irreducible]
+def loopN3PreWithScratchNoX1
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+      retMem dMem dloMem scratch_un0 : Word) : Assertion :=
+  loopN3Pre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old **
+  (sp + signExtend12 3968 ↦ₘ retMem) **
+  (sp + signExtend12 3960 ↦ₘ dMem) **
+  (sp + signExtend12 3952 ↦ₘ dloMem) **
+  (sp + signExtend12 3944 ↦ₘ scratch_un0)
+
+theorem loopN3PreWithScratchNoX1_unfold
+    {sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+      retMem dMem dloMem scratch_un0 : Word} :
+    loopN3PreWithScratchNoX1 sp jOld v5Old v6Old v7Old v10Old
+      v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+      retMem dMem dloMem scratch_un0 =
+    (loopN3Pre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old **
+    (sp + signExtend12 3968 ↦ₘ retMem) **
+    (sp + signExtend12 3960 ↦ₘ dMem) **
+    (sp + signExtend12 3952 ↦ₘ dloMem) **
+    (sp + signExtend12 3944 ↦ₘ scratch_un0)) := by
+  delta loopN3PreWithScratchNoX1
+  rfl
+
+theorem loopN3PreWithScratchNoX1_pcFree
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+      retMem dMem dloMem scratch_un0 : Word) :
+    (loopN3PreWithScratchNoX1 sp jOld v5Old v6Old v7Old v10Old
+      v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+      retMem dMem dloMem scratch_un0).pcFree := by
+  delta loopN3PreWithScratchNoX1 loopN3Pre
+  pcFree
+
+instance pcFreeInst_loopN3PreWithScratchNoX1
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+      retMem dMem dloMem scratch_un0 : Word) :
+    Assertion.PCFree
+      (loopN3PreWithScratchNoX1 sp jOld v5Old v6Old v7Old v10Old
+        v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+        retMem dMem dloMem scratch_un0) :=
+  ⟨loopN3PreWithScratchNoX1_pcFree sp jOld v5Old v6Old v7Old v10Old
+    v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+    retMem dMem dloMem scratch_un0⟩
+
+theorem loopN3PreWithScratchNoX1_to_loopN3PreWithScratch
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+      retMem dMem dloMem scratch_un0 : Word) :
+    ∀ h,
+      (loopN3PreWithScratchNoX1 sp jOld v5Old v6Old v7Old v10Old
+        v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+        retMem dMem dloMem scratch_un0 ** regOwn .x1) h →
+      loopN3PreWithScratch sp jOld v5Old v6Old v7Old v10Old
+        v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+        retMem dMem dloMem scratch_un0 h := by
+  intro h hp
+  delta loopN3PreWithScratchNoX1 loopN3PreWithScratch at hp ⊢
+  simpa only [sepConj_assoc'] using hp
+
 
 -- ============================================================================
 -- Three-iteration loop precondition for n=2 (j=2, j=1, j=0)
@@ -118,6 +185,90 @@ def loopN2PreWithScratch (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
   (sp + signExtend12 3952 ↦ₘ dloMem) **
   (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1
 
+/-- Callable-ready n=2 three-iteration loop precondition with scratch cells
+    and no ownership claim over `x1`. -/
+@[irreducible]
+def loopN2PreWithScratchNoX1
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      u0_orig_1 u0_orig_0
+      q2Old q1Old q0Old
+      retMem dMem dloMem scratch_un0 : Word) : Assertion :=
+  loopN2Pre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    u0_orig_1 u0_orig_0 q2Old q1Old q0Old **
+  (sp + signExtend12 3968 ↦ₘ retMem) **
+  (sp + signExtend12 3960 ↦ₘ dMem) **
+  (sp + signExtend12 3952 ↦ₘ dloMem) **
+  (sp + signExtend12 3944 ↦ₘ scratch_un0)
+
+theorem loopN2PreWithScratchNoX1_unfold
+    {sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      u0_orig_1 u0_orig_0
+      q2Old q1Old q0Old
+      retMem dMem dloMem scratch_un0 : Word} :
+    loopN2PreWithScratchNoX1 sp jOld v5Old v6Old v7Old v10Old
+      v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      u0_orig_1 u0_orig_0 q2Old q1Old q0Old
+      retMem dMem dloMem scratch_un0 =
+    (loopN2Pre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      u0_orig_1 u0_orig_0 q2Old q1Old q0Old **
+    (sp + signExtend12 3968 ↦ₘ retMem) **
+    (sp + signExtend12 3960 ↦ₘ dMem) **
+    (sp + signExtend12 3952 ↦ₘ dloMem) **
+    (sp + signExtend12 3944 ↦ₘ scratch_un0)) := by
+  delta loopN2PreWithScratchNoX1
+  rfl
+
+theorem loopN2PreWithScratchNoX1_pcFree
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      u0_orig_1 u0_orig_0
+      q2Old q1Old q0Old
+      retMem dMem dloMem scratch_un0 : Word) :
+    (loopN2PreWithScratchNoX1 sp jOld v5Old v6Old v7Old v10Old
+      v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      u0_orig_1 u0_orig_0 q2Old q1Old q0Old
+      retMem dMem dloMem scratch_un0).pcFree := by
+  delta loopN2PreWithScratchNoX1 loopN2Pre
+  pcFree
+
+instance pcFreeInst_loopN2PreWithScratchNoX1
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      u0_orig_1 u0_orig_0
+      q2Old q1Old q0Old
+      retMem dMem dloMem scratch_un0 : Word) :
+    Assertion.PCFree
+      (loopN2PreWithScratchNoX1 sp jOld v5Old v6Old v7Old v10Old
+        v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop
+        u0_orig_1 u0_orig_0 q2Old q1Old q0Old
+        retMem dMem dloMem scratch_un0) :=
+  ⟨loopN2PreWithScratchNoX1_pcFree sp jOld v5Old v6Old v7Old v10Old
+    v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig_1 u0_orig_0
+    q2Old q1Old q0Old retMem dMem dloMem scratch_un0⟩
+
+theorem loopN2PreWithScratchNoX1_to_loopN2PreWithScratch
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      u0_orig_1 u0_orig_0
+      q2Old q1Old q0Old
+      retMem dMem dloMem scratch_un0 : Word) :
+    ∀ h,
+      (loopN2PreWithScratchNoX1 sp jOld v5Old v6Old v7Old v10Old
+        v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop
+        u0_orig_1 u0_orig_0 q2Old q1Old q0Old
+        retMem dMem dloMem scratch_un0 ** regOwn .x1) h →
+      loopN2PreWithScratch sp jOld v5Old v6Old v7Old v10Old
+        v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop
+        u0_orig_1 u0_orig_0 q2Old q1Old q0Old
+        retMem dMem dloMem scratch_un0 h := by
+  intro h hp
+  delta loopN2PreWithScratchNoX1 loopN2PreWithScratch at hp ⊢
+  simpa only [sepConj_assoc'] using hp
+
 
 -- ============================================================================
 -- Two-iteration loop precondition for n=2 (j=1, j=0)
@@ -157,6 +308,73 @@ def loopN2Iter10PreWithScratch (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
   (sp + signExtend12 3960 ↦ₘ dMem) **
   (sp + signExtend12 3952 ↦ₘ dloMem) **
   (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1
+
+/-- Callable-ready n=2 two-iteration loop precondition with scratch cells
+    and no ownership claim over `x1`. -/
+@[irreducible]
+def loopN2Iter10PreWithScratchNoX1
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+      retMem dMem dloMem scratch_un0 : Word) : Assertion :=
+  loopN2Iter10Pre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old **
+  (sp + signExtend12 3968 ↦ₘ retMem) **
+  (sp + signExtend12 3960 ↦ₘ dMem) **
+  (sp + signExtend12 3952 ↦ₘ dloMem) **
+  (sp + signExtend12 3944 ↦ₘ scratch_un0)
+
+theorem loopN2Iter10PreWithScratchNoX1_unfold
+    {sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+      retMem dMem dloMem scratch_un0 : Word} :
+    loopN2Iter10PreWithScratchNoX1 sp jOld v5Old v6Old v7Old v10Old
+      v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+      retMem dMem dloMem scratch_un0 =
+    (loopN2Iter10Pre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old **
+    (sp + signExtend12 3968 ↦ₘ retMem) **
+    (sp + signExtend12 3960 ↦ₘ dMem) **
+    (sp + signExtend12 3952 ↦ₘ dloMem) **
+    (sp + signExtend12 3944 ↦ₘ scratch_un0)) := by
+  delta loopN2Iter10PreWithScratchNoX1
+  rfl
+
+theorem loopN2Iter10PreWithScratchNoX1_pcFree
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+      retMem dMem dloMem scratch_un0 : Word) :
+    (loopN2Iter10PreWithScratchNoX1 sp jOld v5Old v6Old v7Old v10Old
+      v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+      retMem dMem dloMem scratch_un0).pcFree := by
+  delta loopN2Iter10PreWithScratchNoX1 loopN2Iter10Pre
+  pcFree
+
+instance pcFreeInst_loopN2Iter10PreWithScratchNoX1
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+      retMem dMem dloMem scratch_un0 : Word) :
+    Assertion.PCFree
+      (loopN2Iter10PreWithScratchNoX1 sp jOld v5Old v6Old v7Old v10Old
+        v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+        retMem dMem dloMem scratch_un0) :=
+  ⟨loopN2Iter10PreWithScratchNoX1_pcFree sp jOld v5Old v6Old v7Old v10Old
+    v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+    retMem dMem dloMem scratch_un0⟩
+
+theorem loopN2Iter10PreWithScratchNoX1_to_loopN2Iter10PreWithScratch
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+      retMem dMem dloMem scratch_un0 : Word) :
+    ∀ h,
+      (loopN2Iter10PreWithScratchNoX1 sp jOld v5Old v6Old v7Old v10Old
+        v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+        retMem dMem dloMem scratch_un0 ** regOwn .x1) h →
+      loopN2Iter10PreWithScratch sp jOld v5Old v6Old v7Old v10Old
+        v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+        retMem dMem dloMem scratch_un0 h := by
+  intro h hp
+  delta loopN2Iter10PreWithScratchNoX1 loopN2Iter10PreWithScratch at hp ⊢
+  simpa only [sepConj_assoc'] using hp
 
 
 -- ============================================================================
@@ -213,6 +431,93 @@ def loopN1PreWithScratch (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
   (sp + signExtend12 3952 ↦ₘ dloMem) **
   (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1
 
+/-- Callable-ready n=1 four-iteration loop precondition with scratch cells
+    and no ownership claim over `x1`. This lets callers frame exact return
+    addresses through the loop body instead of consuming them as `regOwn .x1`. -/
+@[irreducible]
+def loopN1PreWithScratchNoX1 (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    u0_orig_2 u0_orig_1 u0_orig_0
+    q3Old q2Old q1Old q0Old
+    retMem dMem dloMem scratch_un0 : Word) : Assertion :=
+  loopN1Pre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    u0_orig_2 u0_orig_1 u0_orig_0 q3Old q2Old q1Old q0Old **
+  (sp + signExtend12 3968 ↦ₘ retMem) **
+  (sp + signExtend12 3960 ↦ₘ dMem) **
+  (sp + signExtend12 3952 ↦ₘ dloMem) **
+  (sp + signExtend12 3944 ↦ₘ scratch_un0)
+
+theorem loopN1PreWithScratchNoX1_unfold
+    {sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      u0_orig_2 u0_orig_1 u0_orig_0
+      q3Old q2Old q1Old q0Old
+      retMem dMem dloMem scratch_un0 : Word} :
+    loopN1PreWithScratchNoX1 sp jOld v5Old v6Old v7Old v10Old v11Old
+      v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      u0_orig_2 u0_orig_1 u0_orig_0 q3Old q2Old q1Old q0Old
+      retMem dMem dloMem scratch_un0 =
+    (
+    loopN1Pre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      u0_orig_2 u0_orig_1 u0_orig_0 q3Old q2Old q1Old q0Old **
+    (sp + signExtend12 3968 ↦ₘ retMem) **
+    (sp + signExtend12 3960 ↦ₘ dMem) **
+    (sp + signExtend12 3952 ↦ₘ dloMem) **
+    (sp + signExtend12 3944 ↦ₘ scratch_un0)) := by
+  delta loopN1PreWithScratchNoX1
+  rfl
+
+theorem loopN1PreWithScratchNoX1_pcFree
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      u0_orig_2 u0_orig_1 u0_orig_0
+      q3Old q2Old q1Old q0Old
+      retMem dMem dloMem scratch_un0 : Word) :
+    (loopN1PreWithScratchNoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      u0_orig_2 u0_orig_1 u0_orig_0
+      q3Old q2Old q1Old q0Old
+      retMem dMem dloMem scratch_un0).pcFree := by
+  delta loopN1PreWithScratchNoX1 loopN1Pre
+  pcFree
+
+instance pcFreeInst_loopN1PreWithScratchNoX1
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      u0_orig_2 u0_orig_1 u0_orig_0
+      q3Old q2Old q1Old q0Old
+      retMem dMem dloMem scratch_un0 : Word) :
+    Assertion.PCFree
+      (loopN1PreWithScratchNoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop
+        u0_orig_2 u0_orig_1 u0_orig_0
+        q3Old q2Old q1Old q0Old
+        retMem dMem dloMem scratch_un0) :=
+  ⟨loopN1PreWithScratchNoX1_pcFree sp jOld v5Old v6Old v7Old v10Old v11Old
+    v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig_2 u0_orig_1 u0_orig_0
+    q3Old q2Old q1Old q0Old retMem dMem dloMem scratch_un0⟩
+
+theorem loopN1PreWithScratchNoX1_to_loopN1PreWithScratch
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      u0_orig_2 u0_orig_1 u0_orig_0
+      q3Old q2Old q1Old q0Old
+      retMem dMem dloMem scratch_un0 : Word) :
+    ∀ h,
+      (loopN1PreWithScratchNoX1 sp jOld v5Old v6Old v7Old v10Old v11Old
+        v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop
+        u0_orig_2 u0_orig_1 u0_orig_0
+        q3Old q2Old q1Old q0Old retMem dMem dloMem scratch_un0 ** regOwn .x1) h →
+      loopN1PreWithScratch sp jOld v5Old v6Old v7Old v10Old v11Old
+        v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop
+        u0_orig_2 u0_orig_1 u0_orig_0
+        q3Old q2Old q1Old q0Old retMem dMem dloMem scratch_un0 h := by
+  intro h hp
+  delta loopN1PreWithScratchNoX1 loopN1PreWithScratch at hp ⊢
+  simpa only [sepConj_assoc'] using hp
+
 
 -- ============================================================================
 -- Two-iteration loop precondition for n=1 (j=1, j=0)
@@ -252,6 +557,74 @@ def loopN1Iter10PreWithScratch (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
   (sp + signExtend12 3960 ↦ₘ dMem) **
   (sp + signExtend12 3952 ↦ₘ dloMem) **
   (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1
+
+/-- Callable-ready n=1 two-iteration loop precondition with scratch cells
+    and no ownership claim over `x1`. -/
+@[irreducible]
+def loopN1Iter10PreWithScratchNoX1
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+      retMem dMem dloMem scratch_un0 : Word) : Assertion :=
+  loopN1Iter10Pre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old **
+  (sp + signExtend12 3968 ↦ₘ retMem) **
+  (sp + signExtend12 3960 ↦ₘ dMem) **
+  (sp + signExtend12 3952 ↦ₘ dloMem) **
+  (sp + signExtend12 3944 ↦ₘ scratch_un0)
+
+theorem loopN1Iter10PreWithScratchNoX1_unfold
+    {sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+      retMem dMem dloMem scratch_un0 : Word} :
+    loopN1Iter10PreWithScratchNoX1 sp jOld v5Old v6Old v7Old v10Old
+      v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+      retMem dMem dloMem scratch_un0 =
+    (
+    loopN1Iter10Pre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old **
+    (sp + signExtend12 3968 ↦ₘ retMem) **
+    (sp + signExtend12 3960 ↦ₘ dMem) **
+    (sp + signExtend12 3952 ↦ₘ dloMem) **
+    (sp + signExtend12 3944 ↦ₘ scratch_un0)) := by
+  delta loopN1Iter10PreWithScratchNoX1
+  rfl
+
+theorem loopN1Iter10PreWithScratchNoX1_pcFree
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+      retMem dMem dloMem scratch_un0 : Word) :
+    (loopN1Iter10PreWithScratchNoX1 sp jOld v5Old v6Old v7Old v10Old
+      v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+      retMem dMem dloMem scratch_un0).pcFree := by
+  delta loopN1Iter10PreWithScratchNoX1 loopN1Iter10Pre
+  pcFree
+
+instance pcFreeInst_loopN1Iter10PreWithScratchNoX1
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+      retMem dMem dloMem scratch_un0 : Word) :
+    Assertion.PCFree
+      (loopN1Iter10PreWithScratchNoX1 sp jOld v5Old v6Old v7Old v10Old
+        v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+        retMem dMem dloMem scratch_un0) :=
+  ⟨loopN1Iter10PreWithScratchNoX1_pcFree sp jOld v5Old v6Old v7Old v10Old
+    v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+    retMem dMem dloMem scratch_un0⟩
+
+theorem loopN1Iter10PreWithScratchNoX1_to_loopN1Iter10PreWithScratch
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+      retMem dMem dloMem scratch_un0 : Word) :
+    ∀ h,
+      (loopN1Iter10PreWithScratchNoX1 sp jOld v5Old v6Old v7Old v10Old
+        v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+        retMem dMem dloMem scratch_un0 ** regOwn .x1) h →
+      loopN1Iter10PreWithScratch sp jOld v5Old v6Old v7Old v10Old
+        v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+        retMem dMem dloMem scratch_un0 h := by
+  intro h hp
+  delta loopN1Iter10PreWithScratchNoX1 loopN1Iter10PreWithScratch at hp ⊢
+  simpa only [sepConj_assoc'] using hp
 
 
 -- ============================================================================
@@ -301,6 +674,91 @@ def loopN1Iter210PreWithScratch (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
   (sp + signExtend12 3960 ↦ₘ dMem) **
   (sp + signExtend12 3952 ↦ₘ dloMem) **
   (sp + signExtend12 3944 ↦ₘ scratch_un0) ** regOwn .x1
+
+/-- Callable-ready n=1 three-iteration loop precondition with scratch cells
+    and no ownership claim over `x1`. -/
+@[irreducible]
+def loopN1Iter210PreWithScratchNoX1
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      u0_orig_1 u0_orig_0
+      q2Old q1Old q0Old
+      retMem dMem dloMem scratch_un0 : Word) : Assertion :=
+  loopN1Iter210Pre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    u0_orig_1 u0_orig_0 q2Old q1Old q0Old **
+  (sp + signExtend12 3968 ↦ₘ retMem) **
+  (sp + signExtend12 3960 ↦ₘ dMem) **
+  (sp + signExtend12 3952 ↦ₘ dloMem) **
+  (sp + signExtend12 3944 ↦ₘ scratch_un0)
+
+theorem loopN1Iter210PreWithScratchNoX1_unfold
+    {sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      u0_orig_1 u0_orig_0
+      q2Old q1Old q0Old
+      retMem dMem dloMem scratch_un0 : Word} :
+    loopN1Iter210PreWithScratchNoX1 sp jOld v5Old v6Old v7Old v10Old
+      v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      u0_orig_1 u0_orig_0 q2Old q1Old q0Old
+      retMem dMem dloMem scratch_un0 =
+    (
+    loopN1Iter210Pre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      u0_orig_1 u0_orig_0 q2Old q1Old q0Old **
+    (sp + signExtend12 3968 ↦ₘ retMem) **
+    (sp + signExtend12 3960 ↦ₘ dMem) **
+    (sp + signExtend12 3952 ↦ₘ dloMem) **
+    (sp + signExtend12 3944 ↦ₘ scratch_un0)) := by
+  delta loopN1Iter210PreWithScratchNoX1
+  rfl
+
+theorem loopN1Iter210PreWithScratchNoX1_pcFree
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      u0_orig_1 u0_orig_0
+      q2Old q1Old q0Old
+      retMem dMem dloMem scratch_un0 : Word) :
+    (loopN1Iter210PreWithScratchNoX1 sp jOld v5Old v6Old v7Old v10Old
+      v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      u0_orig_1 u0_orig_0 q2Old q1Old q0Old
+      retMem dMem dloMem scratch_un0).pcFree := by
+  delta loopN1Iter210PreWithScratchNoX1 loopN1Iter210Pre
+  pcFree
+
+instance pcFreeInst_loopN1Iter210PreWithScratchNoX1
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      u0_orig_1 u0_orig_0
+      q2Old q1Old q0Old
+      retMem dMem dloMem scratch_un0 : Word) :
+    Assertion.PCFree
+      (loopN1Iter210PreWithScratchNoX1 sp jOld v5Old v6Old v7Old v10Old
+        v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop
+        u0_orig_1 u0_orig_0 q2Old q1Old q0Old
+        retMem dMem dloMem scratch_un0) :=
+  ⟨loopN1Iter210PreWithScratchNoX1_pcFree sp jOld v5Old v6Old v7Old v10Old
+    v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig_1 u0_orig_0
+    q2Old q1Old q0Old retMem dMem dloMem scratch_un0⟩
+
+theorem loopN1Iter210PreWithScratchNoX1_to_loopN1Iter210PreWithScratch
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      u0_orig_1 u0_orig_0
+      q2Old q1Old q0Old
+      retMem dMem dloMem scratch_un0 : Word) :
+    ∀ h,
+      (loopN1Iter210PreWithScratchNoX1 sp jOld v5Old v6Old v7Old v10Old
+        v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop
+        u0_orig_1 u0_orig_0 q2Old q1Old q0Old
+        retMem dMem dloMem scratch_un0 ** regOwn .x1) h →
+      loopN1Iter210PreWithScratch sp jOld v5Old v6Old v7Old v10Old
+        v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop
+        u0_orig_1 u0_orig_0 q2Old q1Old q0Old
+        retMem dMem dloMem scratch_un0 h := by
+  intro h hp
+  delta loopN1Iter210PreWithScratchNoX1 loopN1Iter210PreWithScratch at hp ⊢
+  simpa only [sepConj_assoc'] using hp
 
 -- (Removed dead defs `loopBodyPre` and `loopBodyPreWithScratch`: shared
 -- one-iteration loop-body preconditions parametric on the stored divisor

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/Call.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/Call.lean
@@ -42,6 +42,63 @@ def loopBodyN1CallSkipJ0PreV4
    (sp + signExtend12 3936 ↦ₘ scratchMem) ** regOwn .x1)
 
 @[irreducible]
+def loopBodyN1CallSkipJ0PreV4NoX1
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratch_un0 scratchMem : Word) : Assertion :=
+  let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
+  ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
+   (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+   (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
+   (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
+   (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
+   ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+   ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+   ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+   ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+   ((uBase + signExtend12 4064) ↦ₘ uTop) **
+   (qAddr ↦ₘ qOld) **
+   (sp + signExtend12 3968 ↦ₘ retMem) **
+   (sp + signExtend12 3960 ↦ₘ dMem) **
+   (sp + signExtend12 3952 ↦ₘ dloMem) **
+   (sp + signExtend12 3944 ↦ₘ scratch_un0) **
+   (sp + signExtend12 3936 ↦ₘ scratchMem))
+
+theorem loopBodyN1CallSkipJ0PreV4NoX1_pcFree
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratch_un0 scratchMem : Word) :
+    (loopBodyN1CallSkipJ0PreV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 scratchMem).pcFree := by
+  delta loopBodyN1CallSkipJ0PreV4NoX1
+  pcFree
+
+instance pcFreeInst_loopBodyN1CallSkipJ0PreV4NoX1
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratch_un0 scratchMem : Word) :
+    Assertion.PCFree
+      (loopBodyN1CallSkipJ0PreV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 scratchMem) :=
+  ⟨loopBodyN1CallSkipJ0PreV4NoX1_pcFree sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 scratchMem⟩
+
+theorem loopBodyN1CallSkipJ0PreV4NoX1_to_loopBodyN1CallSkipJ0PreV4
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratch_un0 scratchMem : Word) :
+    ∀ h,
+      (loopBodyN1CallSkipJ0PreV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 scratchMem **
+        regOwn .x1) h →
+      loopBodyN1CallSkipJ0PreV4 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 scratchMem h := by
+  intro h hp
+  delta loopBodyN1CallSkipJ0PreV4NoX1 loopBodyN1CallSkipJ0PreV4 at hp ⊢
+  simpa only [sepConj_assoc'] using hp
+
+@[irreducible]
 def loopBodyN1CallSkipJ0PostV4
     (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word) : Assertion :=
   let dLo := divKTrialCallV4DLo v0
@@ -54,6 +111,58 @@ def loopBodyN1CallSkipJ0PostV4
   (sp + signExtend12 3944 ↦ₘ div_un0) **
   (sp + signExtend12 3936 ↦ₘ divKTrialCallV4ScratchOut u1 u0 v0 scratchMem) **
   regOwn .x1
+
+@[irreducible]
+def loopBodyN1CallSkipJ0PostV4NoX1
+    (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word) : Assertion :=
+  let dLo := divKTrialCallV4DLo v0
+  let div_un0 := divKTrialCallV4Un0 u0
+  let qHat := divKTrialCallV4QHat u1 u0 v0
+  loopBodyN1SkipPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+  (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+  (sp + signExtend12 3960 ↦ₘ v0) **
+  (sp + signExtend12 3952 ↦ₘ dLo) **
+  (sp + signExtend12 3944 ↦ₘ div_un0) **
+  (sp + signExtend12 3936 ↦ₘ divKTrialCallV4ScratchOut u1 u0 v0 scratchMem)
+
+theorem loopBodyN1CallSkipJ0PostV4NoX1_unfold
+    {sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word} :
+    loopBodyN1CallSkipJ0PostV4NoX1 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem =
+    (
+    let dLo := divKTrialCallV4DLo v0
+    let div_un0 := divKTrialCallV4Un0 u0
+    let qHat := divKTrialCallV4QHat u1 u0 v0
+    loopBodyN1SkipPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+    (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+    (sp + signExtend12 3960 ↦ₘ v0) **
+    (sp + signExtend12 3952 ↦ₘ dLo) **
+    (sp + signExtend12 3944 ↦ₘ div_un0) **
+    (sp + signExtend12 3936 ↦ₘ divKTrialCallV4ScratchOut u1 u0 v0 scratchMem)) := by
+  delta loopBodyN1CallSkipJ0PostV4NoX1
+  rfl
+
+theorem loopBodyN1CallSkipJ0PostV4NoX1_pcFree
+    (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word) :
+    (loopBodyN1CallSkipJ0PostV4NoX1 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem).pcFree := by
+  delta loopBodyN1CallSkipJ0PostV4NoX1 loopBodyN1SkipPost
+        loopBodySkipPost mulsubN4 loopExitPostN1 loopExitPost
+  pcFree
+
+instance pcFreeInst_loopBodyN1CallSkipJ0PostV4NoX1
+    (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word) :
+    Assertion.PCFree
+      (loopBodyN1CallSkipJ0PostV4NoX1 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem) :=
+  ⟨loopBodyN1CallSkipJ0PostV4NoX1_pcFree sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem⟩
+
+theorem loopBodyN1CallSkipJ0PostV4NoX1_to_loopBodyN1CallSkipJ0PostV4
+    (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word) :
+    ∀ h,
+      (loopBodyN1CallSkipJ0PostV4NoX1 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem **
+        regOwn .x1) h →
+      loopBodyN1CallSkipJ0PostV4 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem h := by
+  intro h hp
+  delta loopBodyN1CallSkipJ0PostV4NoX1 loopBodyN1CallSkipJ0PostV4 at hp ⊢
+  simpa only [sepConj_assoc'] using hp
 
 @[irreducible]
 def loopBodyN1CallSkipJ0BorrowV4

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/CallAddbackV4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/CallAddbackV4NoNop.lean
@@ -23,6 +23,43 @@ def loopBodyN1CallAddbackBeqJ0PostV4
   regOwn .x1
 
 @[irreducible]
+def loopBodyN1CallAddbackBeqJ0PostV4NoX1
+    (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word) : Assertion :=
+  let dLo := divKTrialCallV4DLo v0
+  let div_un0 := divKTrialCallV4Un0 u0
+  let qHat := divKTrialCallV4QHat u1 u0 v0
+  let scratchOut := divKTrialCallV4ScratchOut u1 u0 v0 scratchMem
+  loopBodyN1AddbackBeqPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+  (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+  (sp + signExtend12 3960 ↦ₘ v0) **
+  (sp + signExtend12 3952 ↦ₘ dLo) **
+  (sp + signExtend12 3944 ↦ₘ div_un0) **
+  (sp + signExtend12 3936 ↦ₘ scratchOut)
+
+theorem loopBodyN1CallAddbackBeqJ0PostV4NoX1_pcFree
+    (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word) :
+    (loopBodyN1CallAddbackBeqJ0PostV4NoX1 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem).pcFree := by
+  delta loopBodyN1CallAddbackBeqJ0PostV4NoX1 loopBodyN1AddbackBeqPost
+        loopBodyAddbackBeqPost loopExitPostN1 loopExitPost
+  pcFree
+
+instance pcFreeInst_loopBodyN1CallAddbackBeqJ0PostV4NoX1
+    (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word) :
+    Assertion.PCFree
+      (loopBodyN1CallAddbackBeqJ0PostV4NoX1 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem) :=
+  ⟨loopBodyN1CallAddbackBeqJ0PostV4NoX1_pcFree sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem⟩
+
+theorem loopBodyN1CallAddbackBeqJ0PostV4NoX1_to_loopBodyN1CallAddbackBeqJ0PostV4
+    (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word) :
+    ∀ h,
+      (loopBodyN1CallAddbackBeqJ0PostV4NoX1 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem **
+        regOwn .x1) h →
+      loopBodyN1CallAddbackBeqJ0PostV4 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem h := by
+  intro h hp
+  delta loopBodyN1CallAddbackBeqJ0PostV4NoX1 loopBodyN1CallAddbackBeqJ0PostV4 at hp ⊢
+  simpa only [sepConj_assoc'] using hp
+
+@[irreducible]
 def loopBodyN1CallAddbackBeqJgt0PostV4
     (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word) : Assertion :=
   let dLo := divKTrialCallV4DLo v0
@@ -36,6 +73,43 @@ def loopBodyN1CallAddbackBeqJgt0PostV4
   (sp + signExtend12 3944 ↦ₘ div_un0) **
   (sp + signExtend12 3936 ↦ₘ scratchOut) **
   regOwn .x1
+
+@[irreducible]
+def loopBodyN1CallAddbackBeqJgt0PostV4NoX1
+    (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word) : Assertion :=
+  let dLo := divKTrialCallV4DLo v0
+  let div_un0 := divKTrialCallV4Un0 u0
+  let qHat := divKTrialCallV4QHat u1 u0 v0
+  let scratchOut := divKTrialCallV4ScratchOut u1 u0 v0 scratchMem
+  loopBodyN1AddbackBeqPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+  (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+  (sp + signExtend12 3960 ↦ₘ v0) **
+  (sp + signExtend12 3952 ↦ₘ dLo) **
+  (sp + signExtend12 3944 ↦ₘ div_un0) **
+  (sp + signExtend12 3936 ↦ₘ scratchOut)
+
+theorem loopBodyN1CallAddbackBeqJgt0PostV4NoX1_pcFree
+    (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word) :
+    (loopBodyN1CallAddbackBeqJgt0PostV4NoX1 sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem).pcFree := by
+  delta loopBodyN1CallAddbackBeqJgt0PostV4NoX1 loopBodyN1AddbackBeqPost
+        loopBodyAddbackBeqPost loopExitPostN1 loopExitPost
+  pcFree
+
+instance pcFreeInst_loopBodyN1CallAddbackBeqJgt0PostV4NoX1
+    (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word) :
+    Assertion.PCFree
+      (loopBodyN1CallAddbackBeqJgt0PostV4NoX1 sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem) :=
+  ⟨loopBodyN1CallAddbackBeqJgt0PostV4NoX1_pcFree sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem⟩
+
+theorem loopBodyN1CallAddbackBeqJgt0PostV4NoX1_to_loopBodyN1CallAddbackBeqJgt0PostV4
+    (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word) :
+    ∀ h,
+      (loopBodyN1CallAddbackBeqJgt0PostV4NoX1 sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem **
+        regOwn .x1) h →
+      loopBodyN1CallAddbackBeqJgt0PostV4 sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem h := by
+  intro h hp
+  delta loopBodyN1CallAddbackBeqJgt0PostV4NoX1 loopBodyN1CallAddbackBeqJgt0PostV4 at hp ⊢
+  simpa only [sepConj_assoc'] using hp
 
 /-- No-NOP/v4 loop body cpsTripleWithin for n=1, call+addback, j=0. -/
 theorem divK_loop_body_n1_call_addback_j0_beq_v4_spec_within_noNop
@@ -148,6 +222,44 @@ theorem divK_loop_body_n1_call_addback_j0_beq_v4_spec_within_noNop
       rw [loopExitPost_unfold]
       rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full
+
+/-- No-NOP/v4 n=1 call+addback j=0 spec with the call frame split so future
+    callers can keep `x1` outside the loop-body assertion. -/
+theorem divK_loop_body_n1_call_addback_j0_beq_v4_spec_within_noNop_noX1
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratch_un0 scratchMem : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : BitVec.ult u1 v0)
+    (hborrow : (if BitVec.ult uTop
+        (mulsubN4 (divKTrialCallV4QHat u1 u0 v0) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2
+      then (1 : Word) else 0) ≠ (0 : Word))
+    (hcarry2_nz :
+      let qHat := divKTrialCallV4QHat u1 u0 v0
+      let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+      let c3 := ms.2.2.2.2
+      let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
+      let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
+      carry = 0 → addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0) :
+    cpsTripleWithin 224 (base + loopBodyOff) (base + denormOff) (sharedDivModCodeNoNop_v4 base)
+      (loopBodyN1CallSkipJ0PreV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 scratchMem **
+        regOwn .x1)
+      (loopBodyN1CallAddbackBeqJ0PostV4NoX1 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem **
+        regOwn .x1) := by
+  exact cpsTripleWithin_weaken
+    (loopBodyN1CallSkipJ0PreV4NoX1_to_loopBodyN1CallSkipJ0PreV4
+      sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 scratchMem)
+    (fun h hp => by
+      unfold loopBodyN1CallAddbackBeqJ0PostV4 at hp
+      unfold loopBodyN1CallAddbackBeqJ0PostV4NoX1
+      simpa only [sepConj_assoc'] using hp)
+    (divK_loop_body_n1_call_addback_j0_beq_v4_spec_within_noNop
+      sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
+      retMem dMem dloMem scratch_un0 scratchMem base halign hbltu hborrow hcarry2_nz)
 
 /-- No-NOP/v4 loop body cpsTripleWithin for n=1, call+addback, j>0. -/
 theorem divK_loop_body_n1_call_addback_jgt0_beq_v4_spec_within_noNop (j : Word)
@@ -275,5 +387,46 @@ theorem divK_loop_body_n1_call_addback_jgt0_beq_v4_spec_within_noNop (j : Word)
       rw [loopExitPost_unfold]
       rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full
+
+/-- No-NOP/v4 n=1 call+addback j>0 spec with the call frame split so future
+    callers can keep `x1` outside the loop-body assertion. -/
+theorem divK_loop_body_n1_call_addback_jgt0_beq_v4_spec_within_noNop_noX1 (j : Word)
+    (hpos : BitVec.slt (j + signExtend12 4095) 0 = false)
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratch_un0 scratchMem : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : BitVec.ult u1 v0)
+    (hborrow : (if BitVec.ult uTop
+        (mulsubN4 (divKTrialCallV4QHat u1 u0 v0) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2
+      then (1 : Word) else 0) ≠ (0 : Word))
+    (hcarry2_nz :
+      let qHat := divKTrialCallV4QHat u1 u0 v0
+      let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+      let c3 := ms.2.2.2.2
+      let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
+      let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
+      carry = 0 → addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0) :
+    cpsTripleWithin 224 (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCodeNoNop_v4 base)
+      (loopBodyN1CallSkipJgt0PreV4NoX1 sp j jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 scratchMem **
+        regOwn .x1)
+      (loopBodyN1CallAddbackBeqJgt0PostV4NoX1 sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem **
+        regOwn .x1) := by
+  have legacy := divK_loop_body_n1_call_addback_jgt0_beq_v4_spec_within_noNop j hpos
+    sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
+    retMem dMem dloMem scratch_un0 scratchMem base halign hbltu hborrow hcarry2_nz
+  dsimp only [] at legacy
+  exact cpsTripleWithin_weaken
+    (loopBodyN1CallSkipJgt0PreV4NoX1_to_legacy
+      sp j jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 scratchMem)
+    (fun h hp => by
+      unfold loopBodyN1CallAddbackBeqJgt0PostV4 at hp
+      unfold loopBodyN1CallAddbackBeqJgt0PostV4NoX1
+      simpa only [sepConj_assoc'] using hp)
+    legacy
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/CallV4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/CallV4NoNop.lean
@@ -13,6 +13,78 @@ namespace EvmAsm.Evm64
 open EvmAsm.Rv64
 
 @[irreducible]
+def loopBodyN1CallSkipJgt0PreV4NoX1
+    (sp j jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratch_un0 scratchMem : Word) : Assertion :=
+  let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
+  ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
+   (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+   (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
+   (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
+   (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
+   ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+   ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+   ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+   ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+   ((uBase + signExtend12 4064) ↦ₘ uTop) **
+   (qAddr ↦ₘ qOld) **
+   (sp + signExtend12 3968 ↦ₘ retMem) **
+   (sp + signExtend12 3960 ↦ₘ dMem) **
+   (sp + signExtend12 3952 ↦ₘ dloMem) **
+   (sp + signExtend12 3944 ↦ₘ scratch_un0) **
+   (sp + signExtend12 3936 ↦ₘ scratchMem))
+
+theorem loopBodyN1CallSkipJgt0PreV4NoX1_pcFree
+    (sp j jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratch_un0 scratchMem : Word) :
+    (loopBodyN1CallSkipJgt0PreV4NoX1 sp j jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 scratchMem).pcFree := by
+  delta loopBodyN1CallSkipJgt0PreV4NoX1
+  pcFree
+
+instance pcFreeInst_loopBodyN1CallSkipJgt0PreV4NoX1
+    (sp j jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratch_un0 scratchMem : Word) :
+    Assertion.PCFree
+      (loopBodyN1CallSkipJgt0PreV4NoX1 sp j jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 scratchMem) :=
+  ⟨loopBodyN1CallSkipJgt0PreV4NoX1_pcFree sp j jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 scratchMem⟩
+
+theorem loopBodyN1CallSkipJgt0PreV4NoX1_to_legacy
+    (sp j jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratch_un0 scratchMem : Word) :
+    let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+    let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
+    ∀ h,
+      (loopBodyN1CallSkipJgt0PreV4NoX1 sp j jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 scratchMem **
+        regOwn .x1) h →
+      (((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
+       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
+       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
+       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
+       (qAddr ↦ₘ qOld) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
+       (sp + signExtend12 3944 ↦ₘ scratch_un0) **
+       (sp + signExtend12 3936 ↦ₘ scratchMem) ** regOwn .x1) h) := by
+  intro uBase qAddr h hp
+  simpa only [loopBodyN1CallSkipJgt0PreV4NoX1, sepConj_assoc'] using hp
+
+@[irreducible]
 def loopBodyN1CallSkipJgt0PostV4
     (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word) : Assertion :=
   let dLo := divKTrialCallV4DLo v0
@@ -26,6 +98,60 @@ def loopBodyN1CallSkipJgt0PostV4
   (sp + signExtend12 3944 ↦ₘ div_un0) **
   (sp + signExtend12 3936 ↦ₘ scratchOut) **
   regOwn .x1
+
+@[irreducible]
+def loopBodyN1CallSkipJgt0PostV4NoX1
+    (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word) : Assertion :=
+  let dLo := divKTrialCallV4DLo v0
+  let div_un0 := divKTrialCallV4Un0 u0
+  let qHat := divKTrialCallV4QHat u1 u0 v0
+  let scratchOut := divKTrialCallV4ScratchOut u1 u0 v0 scratchMem
+  loopBodyN1SkipPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+  (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+  (sp + signExtend12 3960 ↦ₘ v0) **
+  (sp + signExtend12 3952 ↦ₘ dLo) **
+  (sp + signExtend12 3944 ↦ₘ div_un0) **
+  (sp + signExtend12 3936 ↦ₘ scratchOut)
+
+theorem loopBodyN1CallSkipJgt0PostV4NoX1_unfold
+    {sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word} :
+    loopBodyN1CallSkipJgt0PostV4NoX1 sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem =
+    (
+    let dLo := divKTrialCallV4DLo v0
+    let div_un0 := divKTrialCallV4Un0 u0
+    let qHat := divKTrialCallV4QHat u1 u0 v0
+    let scratchOut := divKTrialCallV4ScratchOut u1 u0 v0 scratchMem
+    loopBodyN1SkipPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+    (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+    (sp + signExtend12 3960 ↦ₘ v0) **
+    (sp + signExtend12 3952 ↦ₘ dLo) **
+    (sp + signExtend12 3944 ↦ₘ div_un0) **
+    (sp + signExtend12 3936 ↦ₘ scratchOut)) := by
+  delta loopBodyN1CallSkipJgt0PostV4NoX1
+  rfl
+
+theorem loopBodyN1CallSkipJgt0PostV4NoX1_pcFree
+    (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word) :
+    (loopBodyN1CallSkipJgt0PostV4NoX1 sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem).pcFree := by
+  delta loopBodyN1CallSkipJgt0PostV4NoX1 loopBodyN1SkipPost
+        loopBodySkipPost mulsubN4 loopExitPostN1 loopExitPost
+  pcFree
+
+instance pcFreeInst_loopBodyN1CallSkipJgt0PostV4NoX1
+    (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word) :
+    Assertion.PCFree
+      (loopBodyN1CallSkipJgt0PostV4NoX1 sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem) :=
+  ⟨loopBodyN1CallSkipJgt0PostV4NoX1_pcFree sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem⟩
+
+theorem loopBodyN1CallSkipJgt0PostV4NoX1_to_loopBodyN1CallSkipJgt0PostV4
+    (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word) :
+    ∀ h,
+      (loopBodyN1CallSkipJgt0PostV4NoX1 sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem **
+        regOwn .x1) h →
+      loopBodyN1CallSkipJgt0PostV4 sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem h := by
+  intro h hp
+  delta loopBodyN1CallSkipJgt0PostV4NoX1 loopBodyN1CallSkipJgt0PostV4 at hp ⊢
+  simpa only [sepConj_assoc'] using hp
 
 /-- No-NOP/v4 loop body cpsTripleWithin for n=1, call+skip, j=0.
     This consumes the v4 div128 call path and exits to denorm. -/
@@ -129,6 +255,35 @@ theorem divK_loop_body_n1_call_skip_j0_v4_spec_within_noNop
       dsimp only []
       rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full
+
+/-- No-NOP/v4 n=1 call+skip j=0 spec with the call frame split so future
+    callers can keep `x1` outside the loop-body assertion. -/
+theorem divK_loop_body_n1_call_skip_j0_v4_spec_within_noNop_noX1
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratch_un0 scratchMem : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : BitVec.ult u1 v0)
+    (hborrow : loopBodyN1CallSkipJ0BorrowV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 148 (base + loopBodyOff) (base + denormOff) (sharedDivModCodeNoNop_v4 base)
+      (loopBodyN1CallSkipJ0PreV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 scratchMem **
+        regOwn .x1)
+      (loopBodyN1CallSkipJ0PostV4NoX1 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem **
+        regOwn .x1) := by
+  exact cpsTripleWithin_weaken
+    (loopBodyN1CallSkipJ0PreV4NoX1_to_loopBodyN1CallSkipJ0PreV4
+      sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 scratchMem)
+    (fun h hp => by
+      unfold loopBodyN1CallSkipJ0PostV4 at hp
+      unfold loopBodyN1CallSkipJ0PostV4NoX1
+      simpa only [sepConj_assoc'] using hp)
+    (divK_loop_body_n1_call_skip_j0_v4_spec_within_noNop
+      sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
+      retMem dMem dloMem scratch_un0 scratchMem base halign hbltu hborrow)
 
 /-- No-NOP/v4 loop body cpsTripleWithin for n=1, call+skip, j>0.
     This consumes the v4 div128 call path and loops back to the loop body. -/
@@ -246,5 +401,37 @@ theorem divK_loop_body_n1_call_skip_jgt0_v4_spec_within_noNop (j : Word)
       dsimp only []
       rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full
+
+/-- No-NOP/v4 n=1 call+skip j>0 spec with the call frame split so future
+    callers can keep `x1` outside the loop-body assertion. -/
+theorem divK_loop_body_n1_call_skip_jgt0_v4_spec_within_noNop_noX1 (j : Word)
+    (hpos : BitVec.slt (j + signExtend12 4095) 0 = false)
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratch_un0 scratchMem : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : BitVec.ult u1 v0)
+    (hborrow : mulsubN4NoBorrow (divKTrialCallV4QHat u1 u0 v0) v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 148 (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCodeNoNop_v4 base)
+      (loopBodyN1CallSkipJgt0PreV4NoX1 sp j jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 scratchMem **
+        regOwn .x1)
+      (loopBodyN1CallSkipJgt0PostV4NoX1 sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem **
+        regOwn .x1) := by
+  have legacy := divK_loop_body_n1_call_skip_jgt0_v4_spec_within_noNop j hpos
+    sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
+    retMem dMem dloMem scratch_un0 scratchMem base halign hbltu hborrow
+  dsimp only [] at legacy
+  exact cpsTripleWithin_weaken
+    (loopBodyN1CallSkipJgt0PreV4NoX1_to_legacy
+      sp j jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 scratchMem)
+    (fun h hp => by
+      unfold loopBodyN1CallSkipJgt0PostV4 at hp
+      unfold loopBodyN1CallSkipJgt0PostV4NoX1
+      simpa only [sepConj_assoc'] using hp)
+    legacy
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LoopUnifiedN1/CallIter210NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/LoopUnifiedN1/CallIter210NoNop.lean
@@ -113,4 +113,64 @@ theorem divK_loop_n1_call_iter210_spec_within_noNop (bltu_2 bltu_1 bltu_0 : Bool
       cases bltu_2 <;> cases bltu_1 <;> cases bltu_0 <;> xperm_hyp hp)
     full
 
+/-- No-NOP N1 call path wrapper with the loop scratch precondition split so
+    callers can keep exact `x1` ownership outside the loop precondition. -/
+theorem divK_loop_n1_call_iter210_spec_within_noNop_noX1_pre (bltu_2 bltu_1 bltu_0 : Bool)
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop
+     u0_orig_2 u0_orig_1 u0_orig_0
+     q3Old q2Old q1Old q0Old : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu_3 : BitVec.ult u1 v0)
+    (hbltu_2 : bltu_2 = BitVec.ult (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v0)
+    (hbltu_1 : bltu_1 = BitVec.ult (iterN1 bltu_2 v0 v1 v2 v3 u0_orig_2
+      (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.1 v0)
+    (hbltu_0 : bltu_0 = BitVec.ult (iterN1 bltu_1 v0 v1 v2 v3 u0_orig_1
+      (iterN1 bltu_2 v0 v1 v2 v3 u0_orig_2
+        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.1
+      (iterN1 bltu_2 v0 v1 v2 v3 u0_orig_2
+        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.1
+      (iterN1 bltu_2 v0 v1 v2 v3 u0_orig_2
+        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.1
+      (iterN1 bltu_2 v0 v1 v2 v3 u0_orig_2
+        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.2.1).2.1 v0)
+    (hcarry2 : Carry2NzAll v0 v1 v2 v3) :
+    cpsTripleWithin 808 (base + loopBodyOff) (base + denormOff) (divCode_noNop base)
+      (loopN1PreWithScratchNoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop
+        u0_orig_2 u0_orig_1 u0_orig_0 q3Old q2Old q1Old q0Old
+        retMem dMem dloMem scratch_un0 ** regOwn .x1)
+      (loopN1UnifiedPost true bltu_2 bltu_1 bltu_0 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop
+        u0_orig_2 u0_orig_1 u0_orig_0 retMem dMem dloMem scratch_un0) := by
+  exact cpsTripleWithin_weaken
+    (loopN1PreWithScratchNoX1_to_loopN1PreWithScratch
+      sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      u0_orig_2 u0_orig_1 u0_orig_0
+      q3Old q2Old q1Old q0Old retMem dMem dloMem scratch_un0)
+    (fun h hp => hp)
+    (divK_loop_n1_call_iter210_spec_within_noNop bltu_2 bltu_1 bltu_0
+      sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      u0_orig_2 u0_orig_1 u0_orig_0
+      q3Old q2Old q1Old q0Old retMem dMem dloMem scratch_un0
+      base halign hbltu_3 hbltu_2 hbltu_1 hbltu_0 hcarry2)
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LoopUnifiedN1/UnifiedNoNop.lean
+++ b/EvmAsm/Evm64/DivMod/LoopUnifiedN1/UnifiedNoNop.lean
@@ -70,4 +70,64 @@ theorem divK_loop_n1_unified_spec_within_noNop (bltu_3 bltu_2 bltu_1 bltu_0 : Bo
       halign
       hbltu_3' hbltu_2 hbltu_1 hbltu_0 hcarry2
 
+/-- No-NOP N1 unified wrapper with the loop scratch precondition split so
+    callers can keep exact `x1` ownership outside the loop precondition. -/
+theorem divK_loop_n1_unified_spec_within_noNop_noX1_pre (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop
+     u0_orig_2 u0_orig_1 u0_orig_0
+     q3Old q2Old q1Old q0Old : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu_3 : bltu_3 = BitVec.ult u1 v0)
+    (hbltu_2 : bltu_2 = BitVec.ult (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v0)
+    (hbltu_1 : bltu_1 = BitVec.ult (iterN1 bltu_2 v0 v1 v2 v3 u0_orig_2
+      (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.1 v0)
+    (hbltu_0 : bltu_0 = BitVec.ult (iterN1 bltu_1 v0 v1 v2 v3 u0_orig_1
+      (iterN1 bltu_2 v0 v1 v2 v3 u0_orig_2
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.1
+      (iterN1 bltu_2 v0 v1 v2 v3 u0_orig_2
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.1
+      (iterN1 bltu_2 v0 v1 v2 v3 u0_orig_2
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.1
+      (iterN1 bltu_2 v0 v1 v2 v3 u0_orig_2
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.2.1).2.1 v0)
+    (hcarry2 : Carry2NzAll v0 v1 v2 v3) :
+    cpsTripleWithin 808 (base + loopBodyOff) (base + denormOff) (divCode_noNop base)
+      (loopN1PreWithScratchNoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop
+        u0_orig_2 u0_orig_1 u0_orig_0 q3Old q2Old q1Old q0Old
+        retMem dMem dloMem scratch_un0 ** regOwn .x1)
+      (loopN1UnifiedPost bltu_3 bltu_2 bltu_1 bltu_0 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop
+        u0_orig_2 u0_orig_1 u0_orig_0 retMem dMem dloMem scratch_un0) := by
+  exact cpsTripleWithin_weaken
+    (loopN1PreWithScratchNoX1_to_loopN1PreWithScratch
+      sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      u0_orig_2 u0_orig_1 u0_orig_0
+      q3Old q2Old q1Old q0Old retMem dMem dloMem scratch_un0)
+    (fun h hp => hp)
+    (divK_loop_n1_unified_spec_within_noNop bltu_3 bltu_2 bltu_1 bltu_0
+      sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      u0_orig_2 u0_orig_1 u0_orig_0
+      q3Old q2Old q1Old q0Old retMem dMem dloMem scratch_un0
+      base halign hbltu_3 hbltu_2 hbltu_1 hbltu_0 hcarry2)
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- split n=1 loop scratch preconditions into no-x1 variants with compatibility weakeners back to legacy x1-owned forms
- add no-x1 v4/no-NOP n=1 call skip preconditions and postconditions for j=0 and j>0, with pcFree instances and compatibility weakeners
- add no-x1 wrapper specs for the n=1 v4/no-NOP call-skip loop-body paths, so higher-level composition can preserve caller-owned x1 without rewriting the legacy proof bodies
- keeps existing legacy specs intact while adding substrate for exact caller x1 framing needed by the PR #5190 hStack blocker

## Verification
- lake build EvmAsm.Evm64.DivMod.LoopIterN1.CallV4NoNop
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- scripts/check-file-size.sh EvmAsm/Evm64/DivMod/LoopDefs/Bundle.lean EvmAsm/Evm64/DivMod/LoopIterN1/Call.lean EvmAsm/Evm64/DivMod/LoopIterN1/CallV4NoNop.lean
- diff-scoped scan for sorry/admit/set_option maxHeartbeats/set_option maxRecDepth

Note: a file-wide forbidden scan of Call.lean still reports a pre-existing set_option maxRecDepth; this patch did not add it.