### PR TITLE
feat(div): move v4 concrete callable wrapper

### DIFF
--- a/EvmAsm/Evm64/DivMod/CallableBzeroV4.lean
+++ b/EvmAsm/Evm64/DivMod/CallableBzeroV4.lean
@@ -10,69 +10,6 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 
-/-- v4 generic concrete callable DIV wrapper for no-NOP body proofs that
-    preserve exact caller-framed `x1`/`x9`. -/
-theorem evm_div_callable_v4_spec_from_noNop_concrete_preserving_x1_x9
-    (sp base x9Val raVal : Word) (a b : EvmWord)
-    (v2 v5 v6 v7 v10 v11 : Word)
-    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-     nMem shiftMem jMem retMem dMem dloMem scratchUn0 : Word)
-    (hStack :
-      cpsTripleWithin unifiedDivBound base (base + nopOff) (sharedDivModCodeNoNop_v4 base)
-        (divModStackDispatchPreNoX1 sp a b
-          x9Val raVal v2 v5 v6 v7 v10 v11
-          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
-        (divConcretePostNoX1Frame sp a b x9Val raVal v2 v6 v7 v11
-          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-          shiftMem nMem jMem retMem dMem dloMem scratchUn0)) :
-    cpsTripleWithin (unifiedDivBound + 1) base (raVal &&& ~~~1)
-      (evm_div_callable_code_v4 base)
-      (divModStackDispatchPreNoX1 sp a b
-        x9Val raVal v2 v5 v6 v7 v10 v11
-        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-        shiftMem nMem jMem retMem dMem dloMem scratchUn0)
-      (divConcretePostNoX1Frame sp a b x9Val raVal v2 v6 v7 v11
-        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-        shiftMem nMem jMem retMem dMem dloMem scratchUn0) := by
-  let retFrame : Assertion :=
-    (((.x12 ↦ᵣ (sp + 32)) ** regOwn .x5 ** regOwn .x10 **
-      (.x0 ↦ᵣ (0 : Word)) ** evmWordIs (sp + 32) (EvmWord.div a b)) **
-     ((.x9 ↦ᵣ x9Val) ** (.x2 ↦ᵣ v2) **
-        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x11 ↦ᵣ v11) **
-        evmWordIs sp a **
-        divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-          shiftMem nMem jMem retMem dMem dloMem scratchUn0))
-  have hStackCall :=
-    cpsTripleWithin_extend_code
-      (hmono := sharedDivModCodeNoNop_v4_sub_div_callable_code_v4) hStack
-  have hStackForRet :
-      cpsTripleWithin unifiedDivBound base (base + nopOff) (evm_div_callable_code_v4 base)
-        (divModStackDispatchPreNoX1 sp a b
-          x9Val raVal v2 v5 v6 v7 v10 v11
-          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
-        (retFrame ** (.x1 ↦ᵣ raVal)) :=
-    cpsTripleWithin_weaken (fun _ hp => hp) (fun _ hp => by
-      rw [divConcretePostNoX1Frame_unfold] at hp
-      dsimp [retFrame] at hp ⊢
-      xperm_hyp hp) hStackCall
-  have hRet :=
-    cpsTripleWithin_extend_code (hmono := evm_div_callable_code_v4_ret_sub (base := base))
-      (ret_spec_within' (base + nopOff) raVal)
-  have hRetFramed :=
-    cpsTripleWithin_frameL retFrame
-      (by
-        dsimp [retFrame]
-        rw [divScratchValuesCallNoX1_unfold, divScratchValues_unfold]
-        pcFree)
-      hRet
-  exact cpsTripleWithin_weaken (fun _ hp => hp) (fun _ hp => by
-    rw [divConcretePostNoX1Frame_unfold]
-    dsimp [retFrame] at hp ⊢
-    xperm_hyp hp)
-    (cpsTripleWithin_seq_same_cr hStackForRet hRetFramed)
-
 /-- v4 zero-divisor DIV callable wrapper in the concrete post shape used by
     SDIV branch handoffs before weakening to the public callable postcondition. -/
 theorem evm_div_callable_bzero_v4_concrete_preserving_x1_spec

--- a/EvmAsm/Evm64/DivMod/CallableV4Div.lean
+++ b/EvmAsm/Evm64/DivMod/CallableV4Div.lean
@@ -281,6 +281,70 @@ theorem evm_div_callable_v4_spec_from_noNop_preserving_x1_framed
         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
         nMem shiftMem jMem retMem dMem dloMem scratchUn0 branch hStack)
 
+/-- Generic concrete callable DIV wrapper for v4 no-NOP body proofs that
+    preserve exact caller-framed `x1`/`x9` and expose the concrete scratch and
+    register values needed by SDIV branch handoffs. -/
+theorem evm_div_callable_v4_spec_from_noNop_concrete_preserving_x1_x9
+    (sp base x9Val raVal : Word) (a b : EvmWord)
+    (v2 v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (hStack :
+      cpsTripleWithin unifiedDivBound base (base + nopOff) (sharedDivModCodeNoNop_v4 base)
+        (divModStackDispatchPreNoX1 sp a b
+          x9Val raVal v2 v5 v6 v7 v10 v11
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+        (divConcretePostNoX1Frame sp a b x9Val raVal v2 v6 v7 v11
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0)) :
+    cpsTripleWithin (unifiedDivBound + 1) base (raVal &&& ~~~1)
+      (evm_div_callable_code_v4 base)
+      (divModStackDispatchPreNoX1 sp a b
+        x9Val raVal v2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+      (divConcretePostNoX1Frame sp a b x9Val raVal v2 v6 v7 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0) := by
+  let retFrame : Assertion :=
+    (((.x12 ↦ᵣ (sp + 32)) ** regOwn .x5 ** regOwn .x10 **
+      (.x0 ↦ᵣ (0 : Word)) ** evmWordIs (sp + 32) (EvmWord.div a b)) **
+     ((.x9 ↦ᵣ x9Val) ** (.x2 ↦ᵣ v2) **
+        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x11 ↦ᵣ v11) **
+        evmWordIs sp a **
+        divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0))
+  have hStackCall :=
+    cpsTripleWithin_extend_code
+      (hmono := sharedDivModCodeNoNop_v4_sub_div_callable_code_v4) hStack
+  have hStackForRet :
+      cpsTripleWithin unifiedDivBound base (base + nopOff) (evm_div_callable_code_v4 base)
+        (divModStackDispatchPreNoX1 sp a b
+          x9Val raVal v2 v5 v6 v7 v10 v11
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+        (retFrame ** (.x1 ↦ᵣ raVal)) :=
+    cpsTripleWithin_weaken (fun _ hp => hp) (fun _ hp => by
+      rw [divConcretePostNoX1Frame_unfold] at hp
+      dsimp [retFrame] at hp ⊢
+      xperm_hyp hp) hStackCall
+  have hRet :=
+    cpsTripleWithin_extend_code (hmono := evm_div_callable_code_v4_ret_sub (base := base))
+      (ret_spec_within' (base + nopOff) raVal)
+  have hRetFramed :=
+    cpsTripleWithin_frameL retFrame
+      (by
+        dsimp [retFrame]
+        rw [divScratchValuesCallNoX1_unfold, divScratchValues_unfold]
+        pcFree)
+      hRet
+  exact cpsTripleWithin_weaken (fun _ hp => hp) (fun _ hp => by
+    rw [divConcretePostNoX1Frame_unfold]
+    dsimp [retFrame] at hp ⊢
+    xperm_hyp hp)
+    (cpsTripleWithin_seq_same_cr hStackForRet hRetFramed)
+
 theorem evm_div_callable_v4_spec_from_noNop_branch_return_x1 (sp base : Word)
     (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1LoopUnified.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1LoopUnified.lean
@@ -796,6 +796,19 @@ theorem fullDivN1UnifiedPost_weaken (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
   delta fullDivN1UnifiedPost
   exact hq
 
+theorem fullDivN1UnifiedPost_to_fullDivN1UnifiedPostNoX1_frame
+    (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
+    (sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 : Word)
+    (h : PartialState)
+    (hq :
+      fullDivN1UnifiedPost bltu_3 bltu_2 bltu_1 bltu_0 sp base
+        a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 h) :
+    (fullDivN1UnifiedPostNoX1 bltu_3 bltu_2 bltu_1 bltu_0 sp base
+      a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 ** regOwn .x1) h := by
+  delta fullDivN1UnifiedPost fullDivN1Frame fullDivN1Scratch
+    fullDivN1UnifiedPostNoX1 fullDivN1FrameNoX1 fullDivN1ScratchNoX1 at hq ⊢
+  xperm_hyp hq
+
 theorem preloopN1UnifiedPost_to_fullDivN1DenormPre_frame
     (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
     (sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 : Word)
@@ -956,6 +969,63 @@ theorem evm_div_n1_noNop_full_unified_spec
     (fun h hq =>
       fullDivN1UnifiedPost_weaken bltu_3 bltu_2 bltu_1 bltu_0
         sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 h hq)
+    hFull
+
+/-- Full n=1 unified DIV path over the no-NOP DIV code with exact `x1`
+    ownership split out of the postcondition. -/
+theorem evm_div_n1_noNop_full_unified_spec_noX1_post
+    (bltu_3 bltu_2 bltu_1 bltu_0 : Bool) (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1z : b1 = 0)
+    (hshift_nz : (clzResult b0).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu_3 : isTrialN1_j3 bltu_3 a3 b0)
+    (hbltu_2 : isTrialN1_j2 bltu_3 bltu_2 a2 a3 b0 b1 b2 b3)
+    (hbltu_1 : isTrialN1_j1 bltu_3 bltu_2 bltu_1 a1 a2 a3 b0 b1 b2 b3)
+    (hbltu_0 : isTrialN1_j0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3)
+    (hcarry2 : Carry2NzAll (b0 <<< (((clzResult b0).1).toNat % 64))
+      ((b1 <<< (((clzResult b0).1).toNat % 64)) ||| (b0 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b0).1).toNat % 64)))
+      ((b2 <<< (((clzResult b0).1).toNat % 64)) ||| (b1 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b0).1).toNat % 64)))
+      ((b3 <<< (((clzResult b0).1).toNat % 64)) ||| (b2 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b0).1).toNat % 64)))) :
+    cpsTripleWithin 946 base (base + nopOff) (divCode_noNop base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b0).2 >>> (63 : Nat)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x11 ↦ᵣ v11Old) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+       ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+       ((sp + signExtend12 4024) ↦ₘ u4Old) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem) **
+       ((sp + signExtend12 3976) ↦ₘ jMem) **
+       ((sp + signExtend12 3968) ↦ₘ retMem) **
+       ((sp + signExtend12 3960) ↦ₘ dMem) **
+       ((sp + signExtend12 3952) ↦ₘ dloMem) **
+       ((sp + signExtend12 3944) ↦ₘ scratch_un0) ** regOwn .x1)
+      (fullDivN1UnifiedPostNoX1 bltu_3 bltu_2 bltu_1 bltu_0 sp base
+        a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 ** regOwn .x1) := by
+  have hFull := evm_div_n1_noNop_full_unified_spec bltu_3 bltu_2 bltu_1 bltu_0 sp base
+    a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem
+    retMem dMem dloMem scratch_un0
+    hbnz hb3z hb2z hb1z hshift_nz halign
+    hbltu_3 hbltu_2 hbltu_1 hbltu_0 hcarry2
+  exact cpsTripleWithin_weaken
+    (fun h hp => hp)
+    (fun h hq =>
+      fullDivN1UnifiedPost_to_fullDivN1UnifiedPostNoX1_frame
+        bltu_3 bltu_2 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
+        retMem dMem dloMem scratch_un0 h hq)
     hFull
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Stack on the live SDIV v4 callable base.
- Move evm_div_callable_v4_spec_from_noNop_concrete_preserving_x1_x9 from the bzero-specific split file into CallableV4Div, where generic v4 DIV callable wrappers live.
- Existing bzero wrappers continue to use the same theorem through the CallableV4Div import, while branch-local v4 no-NOP body proofs can now target divModStackDispatchPreNoX1 and divConcretePostNoX1Frame directly.

## Checks
- lake build EvmAsm.Evm64.DivMod.CallableV4Div EvmAsm.Evm64.DivMod.CallableBzeroV4 EvmAsm.Evm64
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- scripts/check-file-size.sh EvmAsm/Evm64/DivMod/CallableV4Div.lean EvmAsm/Evm64/DivMod/CallableBzeroV4.lean
- diff-scoped forbidden scan for sorry/admit/set_option maxHeartbeats/set_option maxRecDepth