### PR TITLE
feat(div): add n1 no-x1 pre full-post wrapper

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N1ExactNoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N1ExactNoNop.lean
@@ -224,4 +224,91 @@ theorem fullDivN1UnifiedPostNoX1_to_divConcretePostNoX1Frame
     exact fun _ hp => hp
     exact hpLeft
 
+/-- No-NOP n=1 DIV stack spec with the callable precondition shape. The
+    precondition keeps caller-framed `x1`/`x9` exact; the current full-path
+    proof preserves `x1` ownership, so the postcondition exposes the split
+    `fullDivN1UnifiedPostNoX1 ** regOwn .x1` surface. -/
+theorem evm_div_n1_stack_spec_within_word_noNop_preNoX1_fullPost
+    (bltu_3 bltu_2 bltu_1 bltu_0 : Bool) (sp base : Word)
+    (a b : EvmWord)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratch_un0 : Word)
+    (raVal : Word)
+    (ha0 : a.getLimbN 0 = a0) (ha1 : a.getLimbN 1 = a1)
+    (ha2 : a.getLimbN 2 = a2) (ha3 : a.getLimbN 3 = a3)
+    (hb0 : b.getLimbN 0 = b0) (hb1 : b.getLimbN 1 = b1)
+    (hb2 : b.getLimbN 2 = b2) (hb3 : b.getLimbN 3 = b3)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1z : b1 = 0)
+    (hshift_nz : (clzResult b0).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu_3 : isTrialN1_j3 bltu_3 a3 b0)
+    (hbltu_2 : isTrialN1_j2 bltu_3 bltu_2 a2 a3 b0 b1 b2 b3)
+    (hbltu_1 : isTrialN1_j1 bltu_3 bltu_2 bltu_1 a1 a2 a3 b0 b1 b2 b3)
+    (hbltu_0 : isTrialN1_j0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3)
+    (hcarry2 : Carry2NzAll (b0 <<< (((clzResult b0).1).toNat % 64))
+      ((b1 <<< (((clzResult b0).1).toNat % 64)) ||| (b0 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b0).1).toNat % 64)))
+      ((b2 <<< (((clzResult b0).1).toNat % 64)) ||| (b1 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b0).1).toNat % 64)))
+      ((b3 <<< (((clzResult b0).1).toNat % 64)) ||| (b2 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b0).1).toNat % 64)))) :
+    cpsTripleWithin 946 base (base + nopOff) (divCode_noNop base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult b0).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0)
+      (fullDivN1UnifiedPostNoX1 bltu_3 bltu_2 bltu_1 bltu_0 sp base
+        a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 ** regOwn .x1) := by
+  have hFull := evm_div_n1_noNop_full_unified_spec_noX1_post
+    bltu_3 bltu_2 bltu_1 bltu_0 sp base
+    a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratch_un0
+    hbnz hb3z hb2z hb1z hshift_nz halign
+    hbltu_3 hbltu_2 hbltu_1 hbltu_0 hcarry2
+  exact cpsTripleWithin_weaken
+    (fun h hp => by
+      rw [divModStackDispatchPreNoX1_unfold] at hp
+      rw [evmWordIs_sp_limbs_eq sp a _ _ _ _ ha0 ha1 ha2 ha3,
+          evmWordIs_sp32_limbs_eq sp b _ _ _ _ hb0 hb1 hb2 hb3,
+          divScratchValuesCallNoX1_unfold, divScratchValues_unfold] at hp
+      rw [word_add_zero]
+      have hpOwn :
+          ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (signExtend12 (4 : BitVec 12) - (4 : Word))) **
+            regOwn .x1 ** (.x2 ↦ᵣ (clzResult b0).2 >>> (63 : Nat)) **
+            (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+            (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11Old) ** (.x0 ↦ᵣ (0 : Word)) **
+            ((sp ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+             ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3)) **
+            (((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+             ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3)) **
+            (((sp + signExtend12 4088) ↦ₘ q0) **
+             ((sp + signExtend12 4080) ↦ₘ q1) **
+             ((sp + signExtend12 4072) ↦ₘ q2) **
+             ((sp + signExtend12 4064) ↦ₘ q3) **
+             ((sp + signExtend12 4056) ↦ₘ u0Old) **
+             ((sp + signExtend12 4048) ↦ₘ u1Old) **
+             ((sp + signExtend12 4040) ↦ₘ u2Old) **
+             ((sp + signExtend12 4032) ↦ₘ u3Old) **
+             ((sp + signExtend12 4024) ↦ₘ u4Old) **
+             ((sp + signExtend12 4016) ↦ₘ u5) **
+             ((sp + signExtend12 4008) ↦ₘ u6) **
+             ((sp + signExtend12 4000) ↦ₘ u7) **
+             ((sp + signExtend12 3992) ↦ₘ shiftMem) **
+             ((sp + signExtend12 3984) ↦ₘ nMem) **
+             ((sp + signExtend12 3976) ↦ₘ jMem)) **
+            ((sp + signExtend12 3968) ↦ₘ retMem) **
+            ((sp + signExtend12 3960) ↦ₘ dMem) **
+            ((sp + signExtend12 3952) ↦ₘ dloMem) **
+            ((sp + signExtend12 3944) ↦ₘ scratch_un0)) h := by
+        apply sepConj_mono_right
+        apply sepConj_mono_right
+        apply sepConj_mono (regIs_implies_regOwn .x1 (v := raVal))
+        exact fun _ hp => hp
+        exact hp
+      xperm_hyp hpOwn)
+    (fun _ hq => hq)
+    hFull
+
 end EvmAsm.Evm64


### PR DESCRIPTION
Stacked on #5274.\n\nAdds evm_div_n1_stack_spec_within_word_noNop_preNoX1_fullPost, bridging the callable divModStackDispatchPreNoX1 precondition into the existing n=1 full-path no-X1 post surface.\n\nThis intentionally exposes fullDivN1UnifiedPostNoX1 ** regOwn .x1, matching the currently proved full-path preservation strength. It does not yet prove the final concrete hStack obligation requiring exact x1 value preservation.\n\nChecks run before push:\n- lake build EvmAsm.Evm64.DivMod.Spec.N1ExactNoNop\n- lake build EvmAsm.Evm64.DivMod\n- git diff --check\n- scripts/check-file-size.sh EvmAsm/Evm64/DivMod/Spec/N1ExactNoNop.lean\n- diff-scoped forbidden scan for sorry/admit/set_option overrides