### PR TITLE
feat(div): preserve trial-call x1

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopBody/TrialCall.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody/TrialCall.lean
@@ -255,6 +255,34 @@ def divKTrialCallFullPostV4 (sp j n uHi uLo vTop base scratchMem : Word) : Asser
   (sp + signExtend12 3944 ↦ₘ un0Div) **
   (sp + signExtend12 3936 ↦ₘ divKTrialCallV4ScratchOut uHi uLo vTop scratchMem)
 
+/-- Exact-x1 version of `divKTrialCallFullPostV4`, used by callable
+    compositions that must preserve the caller return address concretely. -/
+@[irreducible]
+def divKTrialCallFullPostV4ExactX1
+    (sp j n uHi uLo vTop base scratchMem raVal : Word) : Assertion :=
+  let uAddr := sp + signExtend12 4056 - (j + n) <<< (3 : BitVec 6).toNat
+  let vtopBase := sp + (n + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  let dHi := divKTrialCallV4DHi vTop
+  let dLo := divKTrialCallV4DLo vTop
+  let un0Div := divKTrialCallV4Un0 uLo
+  let q1'' := divKTrialCallV4Q1dd uHi uLo vTop
+  let q0'' := divKTrialCallV4Q0dd uHi uLo vTop
+  let x7Exit := divKTrialCallV4X7Exit uHi uLo vTop
+  let x9Exit := divKTrialCallV4X9Exit uHi uLo vTop
+  let q := divKTrialCallV4QHat uHi uLo vTop
+  (.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ x9Exit) ** (.x1 ↦ᵣ raVal) **
+  (.x5 ↦ᵣ q0'') ** (.x6 ↦ᵣ dHi) **
+  (.x7 ↦ᵣ x7Exit) ** (.x10 ↦ᵣ q1'') ** (.x11 ↦ᵣ q) **
+  (.x2 ↦ᵣ (base + div128CallRetOff)) ** (.x0 ↦ᵣ (0 : Word)) **
+  (sp + signExtend12 3976 ↦ₘ j) ** (sp + signExtend12 3984 ↦ₘ n) **
+  (uAddr ↦ₘ uHi) ** ((uAddr + 8) ↦ₘ uLo) **
+  (vtopBase + signExtend12 32 ↦ₘ vTop) **
+  (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+  (sp + signExtend12 3960 ↦ₘ vTop) **
+  (sp + signExtend12 3952 ↦ₘ dLo) **
+  (sp + signExtend12 3944 ↦ₘ un0Div) **
+  (sp + signExtend12 3936 ↦ₘ divKTrialCallV4ScratchOut uHi uLo vTop scratchMem)
+
 private theorem tc_lb_save_j {base : Word} :
     (base + loopBodyOff : Word) + 4 = base + (loopBodyOff + 4) := by
   simp [BitVec.add_assoc]
@@ -775,6 +803,94 @@ theorem divK_trial_call_full_v4_spec_within_noNop
   have full := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) STLf_taken_scratch TCPf
   unfold divKTrialCallFullPostV4
+  exact cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by
+      simp only [divKTrialCallV4DHi, divKTrialCallV4DLo, divKTrialCallV4Un1, divKTrialCallV4Un0,
+        divKTrialCallV4Q1dd, divKTrialCallV4Rhatdd, divKTrialCallV4Un21,
+        divKTrialCallV4Rhat2c, divKTrialCallV4Q0c, divKTrialCallV4Q0d,
+        divKTrialCallV4Rhat2d, divKTrialCallV4Q0dd, divKTrialCallV4QHat,
+        divKTrialCallV4X7Exit, divKTrialCallV4X9Exit, divKTrialCallV4ScratchOut]
+      xperm_hyp hq)
+    full
+
+/-- Exact-x1 version of `divK_trial_call_full_v4_spec_within_noNop`.
+    This avoids hiding the caller return address behind `regOwn .x1`. -/
+theorem divK_trial_call_full_v4_spec_within_noNop_exact_x1
+    (sp j n jOld v5Old v6Old v7Old v10Old v11Old v2Old uHi uLo vTop : Word)
+    (retMem dMem dloMem un0Mem scratchMem raVal : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : BitVec.ult uHi vTop) :
+    let uAddr := sp + signExtend12 4056 - (j + n) <<< (3 : BitVec 6).toNat
+    let vtopBase := sp + (n + signExtend12 4095) <<< (3 : BitVec 6).toNat
+    cpsTripleWithin 88 (base + loopBodyOff) (base + div128CallRetOff) (sharedDivModCodeNoNop_v4 base)
+      (((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
+       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
+       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
+       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ n) **
+       (uAddr ↦ₘ uHi) ** ((uAddr + 8) ↦ₘ uLo) **
+       (vtopBase + signExtend12 32 ↦ₘ vTop) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
+       (sp + signExtend12 3944 ↦ₘ un0Mem) **
+       (sp + signExtend12 3936 ↦ₘ scratchMem)) ** (.x1 ↦ᵣ raVal))
+      (divKTrialCallFullPostV4ExactX1 sp j n uHi uLo vTop base scratchMem raVal) := by
+  intro uAddr vtopBase
+  have STL := divK_save_trial_load_v4_spec_within_noNop
+    sp j n jOld v5Old v6Old v7Old v10Old uHi uLo vTop base
+  dsimp only [] at STL
+  have hbltu_raw := bltu_spec_gen_within .x7 .x10 (12 : BitVec 13) uHi vTop (base + trialCallOff)
+  rw [lb_bltu_taken, lb_bltu_ntaken] at hbltu_raw
+  have hbltu_ext := cpsBranchWithin_extend_code (hmono :=
+    lb_sub_noNop_v4 13 _ _ (by decide) (by bv_addr) (by decide)) hbltu_raw
+  have taken := cpsBranchWithin_takenPath hbltu_ext (fun hp hQf => by
+    obtain ⟨_, _, _, _, _, ⟨_, _, _, _, _, ⟨_, hpure⟩⟩⟩ := hQf
+    exact hpure hbltu)
+  have taken_clean := cpsTripleWithin_weaken
+    (fun h hp => hp)
+    (fun h hp => sepConj_mono_right
+      (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hp) taken
+  have TCP := divK_trial_call_path_v4_spec_within_noNop_preserving_x1
+    sp j uLo uHi vTop vtopBase base raVal v2Old v11Old
+    retMem dMem dloMem un0Mem scratchMem halign
+  unfold div128V4SpecPost at TCP
+  have STLf := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raVal) ** (.x11 ↦ᵣ v11Old) ** (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
+     (sp + signExtend12 3968 ↦ₘ retMem) **
+     (sp + signExtend12 3960 ↦ₘ dMem) **
+     (sp + signExtend12 3952 ↦ₘ dloMem) **
+     (sp + signExtend12 3944 ↦ₘ un0Mem))
+    (by pcFree) STL
+  have taken_framed := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) ** (.x1 ↦ᵣ raVal) **
+     (.x5 ↦ᵣ uLo) ** (.x6 ↦ᵣ vtopBase) **
+     (.x11 ↦ᵣ v11Old) ** (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
+     (sp + signExtend12 3976 ↦ₘ j) **
+     (sp + signExtend12 3984 ↦ₘ n) **
+     (uAddr ↦ₘ uHi) ** ((uAddr + 8) ↦ₘ uLo) **
+     (vtopBase + signExtend12 32 ↦ₘ vTop) **
+     (sp + signExtend12 3968 ↦ₘ retMem) **
+     (sp + signExtend12 3960 ↦ₘ dMem) **
+     (sp + signExtend12 3952 ↦ₘ dloMem) **
+     (sp + signExtend12 3944 ↦ₘ un0Mem))
+    (by pcFree) taken_clean
+  have TCPf := cpsTripleWithin_frameR
+    ((sp + signExtend12 3976 ↦ₘ j) **
+     (sp + signExtend12 3984 ↦ₘ n) **
+     (uAddr ↦ₘ uHi) ** ((uAddr + 8) ↦ₘ uLo) **
+     (vtopBase + signExtend12 32 ↦ₘ vTop))
+    (by pcFree) TCP
+  have STLf_taken_clean := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) STLf taken_framed
+  have STLf_taken_scratch := cpsTripleWithin_frameR
+    (sp + signExtend12 3936 ↦ₘ scratchMem)
+    (by pcFree) STLf_taken_clean
+  have full := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) STLf_taken_scratch TCPf
+  unfold divKTrialCallFullPostV4ExactX1
   exact cpsTripleWithin_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hq => by

--- a/EvmAsm/Evm64/DivMod/LoopBody/TrialCallPath.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody/TrialCallPath.lean
@@ -308,9 +308,9 @@ theorem divK_trial_call_path_spec_within_noNop
     v1Old v2Old v11Old retMem dMem dloMem un0Mem halign
 
 /-- Trial call path over `sharedDivModCodeNoNop_v4`: JAL x2 560 (instr [16])
-    plus the v4 div128 subroutine, with exact x1 framing and the additional
-    v4 scratch cell threaded explicitly. -/
-theorem divK_trial_call_path_v4_spec_within_noNop_exact_x1
+    plus the v4 div128 subroutine, preserving the framed concrete x1 value
+    and threading the additional v4 scratch cell explicitly. -/
+theorem divK_trial_call_path_v4_spec_within_noNop_preserving_x1
     (sp j uLo uHi vTop vtopBase : Word) (base : Word)
     (v1Old v2Old v11Old : Word)
     (retMem dMem dloMem un0Mem scratchMem : Word)
@@ -326,7 +326,7 @@ theorem divK_trial_call_path_v4_spec_within_noNop_exact_x1
        (sp + signExtend12 3944 ↦ₘ un0Mem) **
        (sp + signExtend12 3936 ↦ₘ scratchMem)) ** (.x1 ↦ᵣ v1Old))
       (div128V4SpecPost sp (base + div128CallRetOff) vTop uLo uHi scratchMem **
-        regOwn .x1) := by
+        (.x1 ↦ᵣ v1Old)) := by
   have J := jal_spec_within .x2 v2Old (560 : BitVec 21) (base + trialJalOff) (by nofun)
   rw [lb_jal_target, lb_jal_ret] at J
   have Je := cpsTripleWithin_extend_code (hmono :=
@@ -350,10 +350,37 @@ theorem divK_trial_call_path_v4_spec_within_noNop_exact_x1
     (fun h hp => by xperm_hyp hp) Jf Df
   exact cpsTripleWithin_weaken
     (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    full
+
+/-- Trial call path over `sharedDivModCodeNoNop_v4`: JAL x2 560 (instr [16])
+    plus the v4 div128 subroutine, with exact x1 framing and the additional
+    v4 scratch cell threaded explicitly. -/
+theorem divK_trial_call_path_v4_spec_within_noNop_exact_x1
+    (sp j uLo uHi vTop vtopBase : Word) (base : Word)
+    (v1Old v2Old v11Old : Word)
+    (retMem dMem dloMem un0Mem scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff) :
+    cpsTripleWithin 74 (base + trialJalOff) (base + div128CallRetOff) (sharedDivModCodeNoNop_v4 base)
+      (((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
+       (.x5 ↦ᵣ uLo) ** (.x6 ↦ᵣ vtopBase) **
+       (.x7 ↦ᵣ uHi) ** (.x10 ↦ᵣ vTop) **
+       (.x2 ↦ᵣ v2Old) ** (.x11 ↦ᵣ v11Old) ** (.x0 ↦ᵣ (0 : Word)) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
+       (sp + signExtend12 3944 ↦ₘ un0Mem) **
+       (sp + signExtend12 3936 ↦ₘ scratchMem)) ** (.x1 ↦ᵣ v1Old))
+      (div128V4SpecPost sp (base + div128CallRetOff) vTop uLo uHi scratchMem **
+        regOwn .x1) := by
+  exact cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
     (fun h hq => by
       apply sepConj_mono_right (regIs_implies_regOwn .x1) h
       xperm_hyp hq)
-    full
+    (divK_trial_call_path_v4_spec_within_noNop_preserving_x1
+      sp j uLo uHi vTop vtopBase base v1Old v2Old v11Old
+      retMem dMem dloMem un0Mem scratchMem halign)
 
 /-- Trial call path over `sharedDivModCodeNoNop_v4`, with `x1`
     existentially owned. -/


### PR DESCRIPTION
Stacked on #5279.\n\nAdds exact-x1 substrate for the v4/no-NOP trial-call path:\n- `divK_trial_call_path_v4_spec_within_noNop_preserving_x1` keeps the framed concrete `.x1 ↦ᵣ v1Old` after the JAL + `divK_div128_v4` path.\n- `divKTrialCallFullPostV4ExactX1` and `divK_trial_call_full_v4_spec_within_noNop_exact_x1` expose the full save/load/BLTU/trial-call path without hiding x1 behind `regOwn .x1`.\n\nThis is the next substrate for replaying n=1 call-skip/addback exact-x1 composition.\n\nChecks:\n- `lake build EvmAsm.Evm64.DivMod.LoopBody.TrialCallPath EvmAsm.Evm64.DivMod.LoopBody.TrialCall`\n- `lake build EvmAsm.Evm64.DivMod`\n- `git diff --check`\n- `scripts/check-file-size.sh EvmAsm/Evm64/DivMod/LoopBody/TrialCallPath.lean EvmAsm/Evm64/DivMod/LoopBody/TrialCall.lean`\n- diff-scoped forbidden scan for `sorry`, `admit`, `set_option maxHeartbeats`, `set_option maxRecDepth`