### PR TITLE
feat(div): preserve jgt0 store-loop x1

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopBody/StoreLoop.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody/StoreLoop.lean
@@ -554,4 +554,25 @@ theorem divK_store_loop_jgt0_v4_spec_within_noNop
     (fun h hp => by xperm_hyp hp)
     full
 
+/-- Store q[j] + loop back at j>0 over `sharedDivModCodeNoNop_v4`, with
+    exact caller-framed `x1` carried through the store-loop fragment. -/
+theorem divK_store_loop_jgt0_v4_spec_within_noNop_exact_x1
+    (sp j qHat v5Old v7Old qOld raVal : Word)
+    (base : Word)
+    (hj_pos : BitVec.slt (j + signExtend12 4095) 0 = false) :
+    let jX8 := j <<< (3 : BitVec 6).toNat
+    let qAddr := sp + signExtend12 4088 - jX8
+    let j' := j + signExtend12 4095
+    cpsTripleWithin 6 (base + storeLoopOff) (base + loopBodyOff) (sharedDivModCodeNoNop_v4 base)
+      (((.x9 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+        (.x5 ↦ᵣ v5Old) ** (.x7 ↦ᵣ v7Old) ** (.x0 ↦ᵣ (0 : Word)) **
+        (qAddr ↦ₘ qOld)) ** (.x1 ↦ᵣ raVal))
+      (((.x9 ↦ᵣ j') ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+        (.x5 ↦ᵣ jX8) ** (.x7 ↦ᵣ qAddr) ** (.x0 ↦ᵣ (0 : Word)) **
+        (qAddr ↦ₘ qHat)) ** (.x1 ↦ᵣ raVal)) := by
+  intro jX8 qAddr j'
+  have hStore := divK_store_loop_jgt0_v4_spec_within_noNop sp j qHat v5Old v7Old qOld base hj_pos
+  dsimp only [] at hStore
+  exact cpsTripleWithin_frameR (.x1 ↦ᵣ raVal) (by pcFree) hStore
+
 end EvmAsm.Evm64


### PR DESCRIPTION
Stacked on #5283.\n\nAdds `divK_store_loop_jgt0_v4_spec_within_noNop_exact_x1`, the j>0 sibling of the existing j=0 exact store-loop theorem. It frames concrete `.x1 ↦ᵣ raVal` through the v4/no-NOP store-loop fragment when the BGE branch loops back to the loop body.\n\nThis is substrate for exact-x1 n=1 j>0 call-skip/addback replay and higher loop composition.\n\nChecks:\n- `lake build EvmAsm.Evm64.DivMod.LoopBody.StoreLoop`\n- `lake build EvmAsm.Evm64.DivMod`\n- `git diff --check`\n- `scripts/check-file-size.sh EvmAsm/Evm64/DivMod/LoopBody/StoreLoop.lean`\n- diff-scoped forbidden scan for `sorry`, `admit`, `set_option maxHeartbeats`, `set_option maxRecDepth`