### PR TITLE
feat(div): bridge n1 skip jgt0 scratch post

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopIterN1/CallV4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/CallV4NoNop.lean
@@ -153,6 +153,18 @@ theorem loopBodyN1CallSkipJgt0PostV4NoX1_to_loopBodyN1CallSkipJgt0PostV4
   delta loopBodyN1CallSkipJgt0PostV4NoX1 loopBodyN1CallSkipJgt0PostV4 at hp ⊢
   simpa only [sepConj_assoc'] using hp
 
+theorem loopBodyN1CallSkipJgt0PostV4NoX1_eq_scratch
+    (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word) :
+    loopBodyN1CallSkipJgt0PostV4NoX1 sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem =
+      loopBodyN1CallSkipPostJScratchNoX1 sp base j
+        (divKTrialCallV4QHat u1 u0 v0)
+        (divKTrialCallV4DLo v0)
+        (divKTrialCallV4Un0 u0)
+        (divKTrialCallV4ScratchOut u1 u0 v0 scratchMem)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+  delta loopBodyN1CallSkipJgt0PostV4NoX1 loopBodyN1CallSkipPostJScratchNoX1
+  rfl
+
 /-- No-NOP/v4 loop body cpsTripleWithin for n=1, call+skip, j=0.
     This consumes the v4 div128 call path and exits to denorm. -/
 theorem divK_loop_body_n1_call_skip_j0_v4_spec_within_noNop


### PR DESCRIPTION
Stacked on #5294.

Adds loopBodyN1CallSkipJgt0PostV4NoX1_eq_scratch, exposing the concrete v4 no-x1 skip j>0 post as the new qHat-parameterized scratch post target. This is a definitional bridge and avoids unfolding div128Quot_v4 in the branch composition path.

Checks:
- lake build EvmAsm.Evm64.DivMod.LoopIterN1.CallV4NoNop
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- scripts/check-file-size.sh EvmAsm/Evm64/DivMod/LoopIterN1/CallV4NoNop.lean
- diff scan for sorry, admit, set_option maxHeartbeats, set_option maxRecDepth