### PR TITLE
feat(div): bridge n1 addback j0 scratch post

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopIterN1/CallAddbackV4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/CallAddbackV4NoNop.lean
@@ -59,6 +59,18 @@ theorem loopBodyN1CallAddbackBeqJ0PostV4NoX1_to_loopBodyN1CallAddbackBeqJ0PostV4
   delta loopBodyN1CallAddbackBeqJ0PostV4NoX1 loopBodyN1CallAddbackBeqJ0PostV4 at hp ⊢
   simpa only [sepConj_assoc'] using hp
 
+theorem loopBodyN1CallAddbackBeqJ0PostV4NoX1_eq_scratch
+    (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word) :
+    loopBodyN1CallAddbackBeqJ0PostV4NoX1 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem =
+      loopBodyN1CallAddbackBeqPostJScratchNoX1 sp base (0 : Word)
+        (divKTrialCallV4QHat u1 u0 v0)
+        (divKTrialCallV4DLo v0)
+        (divKTrialCallV4Un0 u0)
+        (divKTrialCallV4ScratchOut u1 u0 v0 scratchMem)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+  delta loopBodyN1CallAddbackBeqJ0PostV4NoX1 loopBodyN1CallAddbackBeqPostJScratchNoX1
+  rfl
+
 @[irreducible]
 def loopBodyN1CallAddbackBeqJgt0PostV4
     (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word) : Assertion :=


### PR DESCRIPTION
Stacked on #5296.

Adds loopBodyN1CallAddbackBeqJ0PostV4NoX1_eq_scratch, exposing the concrete v4 no-x1 addback j=0 post as the qHat-parameterized scratch post target from #5294. This mirrors the skip bridges and remains definitional.

Checks:
- lake build EvmAsm.Evm64.DivMod.LoopIterN1.CallAddbackV4NoNop
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- scripts/check-file-size.sh EvmAsm/Evm64/DivMod/LoopIterN1/CallAddbackV4NoNop.lean
- diff scan for sorry, admit, set_option maxHeartbeats, set_option maxRecDepth