### PR TITLE
feat(div): select n1 j0 exact scratch correction

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1V4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1V4NoNop.lean
@@ -393,4 +393,54 @@ theorem divK_loop_body_n1_call_addback_j0_exact_loopIterScratch_v4_noNop (sp bas
       v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal
       retMem dMem dloMem scratchUn0 scratchMem base halign hbltu hborrow hcarry2_nz)
 
+/-- Loop body n=1, call path, j=0 over `divCode_noNop_v4`, selecting the
+    skip or addback correction from the computed mulsub borrow bit. -/
+theorem divK_loop_body_n1_call_j0_exact_loopIterScratch_v4_noNop (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu : BitVec.ult u1 v0)
+    (hcarry2_nz :
+      let qHat := divKTrialCallV4QHat u1 u0 v0
+      let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+      let c3 := ms.2.2.2.2
+      let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
+      let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
+      carry = 0 → addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0) :
+    cpsTripleWithin 224 (base + loopBodyOff) (base + denormOff) (divCode_noNop_v4 base)
+      (loopBodyN1CallSkipJ0PreV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopIterPostN1CallScratchNoX1 sp base (0 : Word)
+        (divKTrialCallV4QHat u1 u0 v0)
+        (divKTrialCallV4DLo v0)
+        (divKTrialCallV4Un0 u0)
+        (divKTrialCallV4ScratchOut u1 u0 v0 scratchMem)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+        (.x1 ↦ᵣ raVal)) := by
+  by_cases hborrow : BitVec.ult uTop
+      (mulsubN4 (divKTrialCallV4QHat u1 u0 v0) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2
+  · have hborrow_nz :
+        (if BitVec.ult uTop
+            (mulsubN4 (divKTrialCallV4QHat u1 u0 v0) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2
+          then (1 : Word) else 0) ≠ (0 : Word) := by
+      rw [if_pos hborrow]
+      decide
+    exact divK_loop_body_n1_call_addback_j0_exact_loopIterScratch_v4_noNop
+      sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal
+      retMem dMem dloMem scratchUn0 scratchMem halign hbltu hborrow_nz hcarry2_nz
+  · have hborrow_zero :
+        loopBodyN1CallSkipJ0BorrowV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+      unfold loopBodyN1CallSkipJ0BorrowV4 mulsubN4NoBorrow
+      dsimp only
+      rw [if_neg hborrow]
+    exact cpsTripleWithin_mono_nSteps (by decide) <|
+      divK_loop_body_n1_call_skip_j0_exact_loopIterScratch_v4_noNop
+        sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal
+        retMem dMem dloMem scratchUn0 scratchMem halign hbltu hborrow_zero
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1V4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1V4NoNop.lean
@@ -356,4 +356,41 @@ theorem divK_loop_body_n1_call_skip_jgt0_exact_loopIterScratch_v4_noNop (j sp ba
       v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal
       retMem dMem dloMem scratchUn0 scratchMem base halign hbltu hborrow)
 
+/-- Loop body n=1, call+addback, j=0 over `divCode_noNop_v4`, preserving
+    concrete `x1` and exposing the scratch loop-iteration post. -/
+theorem divK_loop_body_n1_call_addback_j0_exact_loopIterScratch_v4_noNop (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu : BitVec.ult u1 v0)
+    (hborrow : (if BitVec.ult uTop
+        (mulsubN4 (divKTrialCallV4QHat u1 u0 v0) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2
+      then (1 : Word) else 0) ≠ (0 : Word))
+    (hcarry2_nz :
+      let qHat := divKTrialCallV4QHat u1 u0 v0
+      let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+      let c3 := ms.2.2.2.2
+      let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
+      let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
+      carry = 0 → addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0) :
+    cpsTripleWithin 224 (base + loopBodyOff) (base + denormOff) (divCode_noNop_v4 base)
+      (loopBodyN1CallSkipJ0PreV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopIterPostN1CallScratchNoX1 sp base (0 : Word)
+        (divKTrialCallV4QHat u1 u0 v0)
+        (divKTrialCallV4DLo v0)
+        (divKTrialCallV4Un0 u0)
+        (divKTrialCallV4ScratchOut u1 u0 v0 scratchMem)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+        (.x1 ↦ᵣ raVal)) := by
+  exact cpsTripleWithin_extend_code
+    (hmono := sharedDivModCodeNoNop_v4_sub_divCode_noNop_v4)
+    (divK_loop_body_n1_call_addback_j0_beq_v4_spec_within_noNop_exact_x1_loopIterScratch
+      sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal
+      retMem dMem dloMem scratchUn0 scratchMem base halign hbltu hborrow hcarry2_nz)
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- expose the n=1 addback j=0 exact-x1 scratch loop-post theorem over divCode_noNop_v4
- add divK_loop_body_n1_call_j0_exact_loopIterScratch_v4_noNop, which selects skip vs addback from the computed mulsub borrow bit
- widen the skip case to the addback step budget so downstream loop composition has one j=0 call-path theorem

## Commits
- 12e9cf1c2 expose n=1 addback j=0 exact scratch full-code wrapper
- cb201bf3f select n=1 j=0 exact scratch correction

## Checks
- lake build EvmAsm.Evm64.DivMod.Compose.FullPathN1V4NoNop
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- scripts/check-file-size.sh EvmAsm/Evm64/DivMod/Compose/FullPathN1V4NoNop.lean
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/Compose/FullPathN1V4NoNop.lean (no matches)

Bead: evm-asm-9iqmw.2.1