### PR TITLE
feat(div): split callable div post x1 ownership

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/CallablePost.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/CallablePost.lean
@@ -95,6 +95,21 @@ theorem divConcretePostNoX1_weaken_callable_frame
       exact fun _ hp => hp
   exact by xperm_hyp hOwn
 
+/-- Split the historical no-`x1` DIV stack post into the callable public post
+    plus separate `x1` ownership. This is the ownership-only bridge; exact
+    return-address preservation requires a stronger upstream post. -/
+theorem divStackDispatchPostNoX1_weaken_callable_own_x1
+    (sp : Word) (a b : EvmWord) :
+  ∀ h : PartialState,
+      divStackDispatchPostNoX1 sp a b h →
+      (divStackDispatchPostCallable sp a b ** regOwn .x1) h := by
+  intro h hp
+  rw [divStackDispatchPostNoX1_unfold] at hp
+  rw [divStackDispatchPostCallable_unfold]
+  rw [divScratchOwnCall_unfold] at hp
+  rw [divScratchOwnCallNoX1_unfold]
+  xperm_hyp hp
+
 /-- Concrete no-NOP MOD callable post bundle before weakening. -/
 @[irreducible]
 def modConcretePostNoX1Frame (sp : Word) (a b : EvmWord)


### PR DESCRIPTION
## Summary
- add divStackDispatchPostNoX1_weaken_callable_own_x1
- split the historical no-x1 DIV stack post into the public callable post plus separate x1 ownership
- keep this as an ownership-only bridge; exact return-address preservation still depends on strengthening the upstream full-path post

## Commit
- 0cf5b2fc3 split callable DIV post x1 ownership

## Checks
- lake build EvmAsm.Evm64.DivMod.Spec.CallablePost
- lake build EvmAsm.Evm64.DivMod.Spec.N1ExactNoNop
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- scripts/check-file-size.sh EvmAsm/Evm64/DivMod/Spec/CallablePost.lean EvmAsm/Evm64/DivMod/Spec/N1ExactNoNop.lean
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/Spec/CallablePost.lean EvmAsm/Evm64/DivMod/Spec/N1ExactNoNop.lean (no matches)

Bead: evm-asm-9iqmw.2.1