### PR TITLE
feat(mod): split callable post x1 ownership

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/CallablePost.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/CallablePost.lean
@@ -191,4 +191,19 @@ theorem modConcretePostNoX1_weaken_callable_frame
       exact fun _ hp => hp
   exact by xperm_hyp hOwn
 
+/-- Split the historical no-`x1` MOD stack post into the callable public post
+    plus separate `x1` ownership. This mirrors
+    `divStackDispatchPostNoX1_weaken_callable_own_x1`. -/
+theorem modStackDispatchPostNoX1_weaken_callable_own_x1
+    (sp : Word) (a b : EvmWord) :
+  ∀ h : PartialState,
+      modStackDispatchPostNoX1 sp a b h →
+      (modStackDispatchPostCallable sp a b ** regOwn .x1) h := by
+  intro h hp
+  rw [modStackDispatchPostNoX1_unfold] at hp
+  rw [modStackDispatchPostCallable_unfold]
+  rw [divScratchOwnCall_unfold] at hp
+  rw [divScratchOwnCallNoX1_unfold]
+  xperm_hyp hp
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add modStackDispatchPostNoX1_weaken_callable_own_x1
- mirror the DIV ownership bridge for MOD callable post surfaces
- split the historical MOD no-x1 stack post into the public callable post plus separate x1 ownership

## Commit
- 4973d05ff split callable MOD post x1 ownership

## Checks
- lake build EvmAsm.Evm64.DivMod.Spec.CallablePost
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- scripts/check-file-size.sh EvmAsm/Evm64/DivMod/Spec/CallablePost.lean
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/Spec/CallablePost.lean (no matches)

Bead: evm-asm-9iqmw.2.1