### PR TITLE
feat(div): frame callable post x9 ownership

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/CallablePost.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/CallablePost.lean
@@ -110,6 +110,20 @@ theorem divStackDispatchPostNoX1_weaken_callable_own_x1
   rw [divScratchOwnCallNoX1_unfold]
   xperm_hyp hp
 
+/-- Framed variant of `divStackDispatchPostNoX1_weaken_callable_own_x1`
+    preserving an exact caller-owned `x9` atom. -/
+theorem divStackDispatchPostNoX1_weaken_callable_own_x1_frame_x9
+    (sp : Word) (a b : EvmWord) (x9Val : Word) :
+  ∀ h : PartialState,
+      (divStackDispatchPostNoX1 sp a b ** (.x9 ↦ᵣ x9Val)) h →
+      ((divStackDispatchPostCallable sp a b ** regOwn .x1) **
+        (.x9 ↦ᵣ x9Val)) h := by
+  intro h hp
+  apply sepConj_mono_left
+  · exact fun hLeft hpLeft =>
+      divStackDispatchPostNoX1_weaken_callable_own_x1 sp a b hLeft hpLeft
+  · exact hp
+
 /-- Concrete no-NOP MOD callable post bundle before weakening. -/
 @[irreducible]
 def modConcretePostNoX1Frame (sp : Word) (a b : EvmWord)


### PR DESCRIPTION
## Summary
- add divStackDispatchPostNoX1_weaken_callable_own_x1_frame_x9
- preserve an exact x9 atom while splitting the DIV no-x1 stack post into callable post plus separate x1 ownership
- prepares N1 no-NOP stack wrappers to consume the existing full-post surface without losing the x9 frame

## Commit
- 61438316c frame callable DIV post x9 ownership

## Checks
- lake build EvmAsm.Evm64.DivMod.Spec.CallablePost
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- scripts/check-file-size.sh EvmAsm/Evm64/DivMod/Spec/CallablePost.lean
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/Spec/CallablePost.lean (no matches)

Bead: evm-asm-9iqmw.2.1