### PR TITLE
feat(mod): frame callable post x9 ownership

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/CallablePost.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/CallablePost.lean
@@ -220,4 +220,18 @@ theorem modStackDispatchPostNoX1_weaken_callable_own_x1
   rw [divScratchOwnCallNoX1_unfold]
   xperm_hyp hp
 
+/-- Framed variant of `modStackDispatchPostNoX1_weaken_callable_own_x1`
+    preserving an exact caller-owned `x9` atom. -/
+theorem modStackDispatchPostNoX1_weaken_callable_own_x1_frame_x9
+    (sp : Word) (a b : EvmWord) (x9Val : Word) :
+  ∀ h : PartialState,
+      (modStackDispatchPostNoX1 sp a b ** (.x9 ↦ᵣ x9Val)) h →
+      ((modStackDispatchPostCallable sp a b ** regOwn .x1) **
+        (.x9 ↦ᵣ x9Val)) h := by
+  intro h hp
+  apply sepConj_mono_left
+  · exact fun hLeft hpLeft =>
+      modStackDispatchPostNoX1_weaken_callable_own_x1 sp a b hLeft hpLeft
+  · exact hp
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add modStackDispatchPostNoX1_weaken_callable_own_x1_frame_x9
- mirror the DIV framed bridge for MOD callable post surfaces
- preserve an exact x9 atom while splitting the MOD no-x1 stack post into callable post plus separate x1 ownership

## Commit
- 9cdf5ed61 frame callable MOD post x9 ownership

## Checks
- lake build EvmAsm.Evm64.DivMod.Spec.CallablePost
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- scripts/check-file-size.sh EvmAsm/Evm64/DivMod/Spec/CallablePost.lean
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/Spec/CallablePost.lean (no matches)

Bead: evm-asm-9iqmw.2.1