### PR TITLE
feat(div): bridge n1 preloop nox1 post

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1LoopUnified.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1LoopUnified.lean
@@ -143,6 +143,24 @@ def preloopN1UnifiedPostNoX1 (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
   ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
   ((sp + signExtend12 3992) ↦ₘ (clzResult b0).1)
 
+theorem preloopN1UnifiedPostNoX1_frame_to_preloopN1UnifiedPost
+    (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
+    (sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 : Word) :
+    ∀ h,
+      (preloopN1UnifiedPostNoX1 bltu_3 bltu_2 bltu_1 bltu_0 sp base
+        a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 ** regOwn .x1) h →
+      preloopN1UnifiedPost bltu_3 bltu_2 bltu_1 bltu_0 sp base
+        a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 h := by
+  intro h hp
+  cases bltu_3 <;> cases bltu_2 <;> cases bltu_1 <;> cases bltu_0
+  all_goals
+    delta preloopN1UnifiedPostNoX1 preloopN1UnifiedPost loopN1UnifiedPostNoX1
+      loopN1UnifiedPost loopN1Iter210PostNoX1 loopN1Iter210Post loopN1Iter10PostNoX1
+      loopN1Iter10Post loopIterPostN1NoX1 loopIterPostN1 loopIterPostN1CallNoX1
+      loopIterPostN1Call loopIterPostN1Max at hp ⊢
+    simp only [iterN1_false, iterN1_true, ite_true, sepConj_emp_right'] at hp ⊢
+    xperm_hyp hp
+
 -- ============================================================================
 -- Double-addback loop instantiation helper (heartbeat isolation)
 -- ============================================================================


### PR DESCRIPTION
## Summary
- add preloopN1UnifiedPostNoX1_frame_to_preloopN1UnifiedPost
- lets callers recombine the new no-x1 normalized preloop post with framed x1 back into the historical preloop post
- keeps the exact-x1 path compatible with existing downstream proofs while avoiding the expensive denorm handoff proof

## Checks
- lake build EvmAsm.Evm64.DivMod.Compose.FullPathN1LoopUnified
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- scripts/check-file-size.sh EvmAsm/Evm64/DivMod/Compose/FullPathN1LoopUnified.lean
- rg -n '\b(sorry|admit)\b|set_option maxHeartbeats|set_option maxRecDepth' EvmAsm/Evm64/DivMod/Compose/FullPathN1LoopUnified.lean