### PR TITLE
feat(div): preserve x1 in n1 max j1 wrapper

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1V4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1V4NoNop.lean
@@ -17,7 +17,7 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)
-open EvmAsm.Evm64.DivMod.AddrNorm (slt_jpos_2 slt_jpos_3)
+open EvmAsm.Evm64.DivMod.AddrNorm (slt_jpos_1 slt_jpos_2 slt_jpos_3)
 
 /-- Sp-relative n=1 max-skip j=0 precondition over `divCode_noNop_v4`. -/
 @[irreducible]
@@ -322,6 +322,82 @@ theorem divK_loop_body_n1_max_j2_exact_loopIter_v4_noNop (sp base : Word)
          then (1 : Word) else 0) = (0 : Word) := if_neg hb
     have raw := divK_loop_body_n1_max_skip_jgt0_norm_v4_noNop
       (2 : Word) sp base slt_jpos_2
+      jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld hbltu hborrow
+    have framed := cpsTripleWithin_frameR (.x1 ↦ᵣ raVal) (by pcFree) raw
+    exact cpsTripleWithin_weaken
+      (fun h hp => hp)
+      (fun h hp => by
+        rw [← loopIterPostN1Max_skip hb]
+        exact hp)
+      (cpsTripleWithin_mono_nSteps (by decide) framed)
+
+/-- Loop body n=1, max path, j=1 over `divCode_noNop_v4`, selecting the
+    skip or addback correction from the computed mulsub borrow bit while
+    preserving concrete `x1`. -/
+theorem divK_loop_body_n1_max_j1_exact_loopIter_v4_noNop (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal : Word)
+    (hbltu : ¬BitVec.ult u1 v0)
+    (hcarry2_nz : isAddbackCarry2NzN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 152 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop_v4 base)
+      (loopBodyN1MaxSkipJgt0NormPreV4 (1 : Word)
+        sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld **
+        (.x1 ↦ᵣ raVal))
+      (loopIterPostN1Max sp (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+        (.x1 ↦ᵣ raVal)) := by
+  by_cases hb : BitVec.ult uTop
+      (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+  · have hborrow :
+        (if BitVec.ult uTop
+            (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+         then (1 : Word) else 0) ≠ (0 : Word) := by
+      rw [if_pos hb]
+      decide
+    have raw := divK_loop_body_n1_max_addback_jgt0_beq_v4_spec_within_noNop
+      (1 : Word) slt_jpos_1
+      sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
+      base hbltu hcarry2_nz
+    change (let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+      let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+      (if BitVec.ult uTop
+          (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+       then (1 : Word) else 0) ≠ (0 : Word) →
+      cpsTripleWithin 152 (base + loopBodyOff) (base + loopBodyOff)
+        (sharedDivModCodeNoNop_v4 base)
+        ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (1 : Word)) **
+         (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+         (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
+         (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
+         (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
+         ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+         ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+         ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+         ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+         ((uBase + signExtend12 4064) ↦ₘ uTop) **
+         (qAddr ↦ₘ qOld))
+        (loopBodyN1AddbackBeqPost sp (1 : Word) (signExtend12 4095 : Word)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop)) at raw
+    have raw0 := raw hborrow
+    have raw' := cpsTripleWithin_extend_code
+      (hmono := sharedDivModCodeNoNop_v4_sub_divCode_noNop_v4) raw0
+    have framed := cpsTripleWithin_frameR (.x1 ↦ᵣ raVal) (by pcFree) raw'
+    exact cpsTripleWithin_weaken
+      (fun h hp => by
+        delta loopBodyN1MaxSkipJgt0NormPreV4 at hp
+        xperm_hyp hp)
+      (fun h hp => by
+        rw [← loopIterPostN1Max_addback hb]
+        exact hp)
+      framed
+  · have hborrow :
+        (if BitVec.ult uTop
+            (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+         then (1 : Word) else 0) = (0 : Word) := if_neg hb
+    have raw := divK_loop_body_n1_max_skip_jgt0_norm_v4_noNop
+      (1 : Word) sp base slt_jpos_1
       jOld v5Old v6Old v7Old v10Old v11Old v2Old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld hbltu hborrow
     have framed := cpsTripleWithin_frameR (.x1 ↦ᵣ raVal) (by pcFree) raw


### PR DESCRIPTION
## Summary
- add the v4/no-NOP N1 max j=1 wrapper preserving concrete x1
- expose loopIterPostN1Max while framing .x1 ↦ᵣ raVal through addback and skip cases

## Verification
- lake build EvmAsm.Evm64.DivMod.Compose.FullPathN1V4NoNop
- lake build EvmAsm.Evm64.DivMod
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/Compose/FullPathN1V4NoNop.lean