### PR TITLE
feat(div): project n1 call exact hypotheses

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1V4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1V4NoNop.lean
@@ -1376,4 +1376,41 @@ def loopN1CallMaxmaxmaxExactHypotheses
   Carry2NzAll v0 v1 v2 v3 ∧
   isAddbackCarry2NzN1CallV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop
 
+/-- Project the j=3 BLTU-taken fact from the compact N1 call/max/max/max hypotheses. -/
+theorem loopN1CallMaxmaxmaxExactHypotheses_hbltu3
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig2 u0Orig1 : Word)
+    (h : loopN1CallMaxmaxmaxExactHypotheses
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig2 u0Orig1) :
+    BitVec.ult u1 v0 := by
+  unfold loopN1CallMaxmaxmaxExactHypotheses at h
+  exact h.1
+
+/-- Project the all-max branch facts from the compact N1 call/max/max/max hypotheses. -/
+theorem loopN1CallMaxmaxmaxExactHypotheses_branches
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig2 u0Orig1 : Word)
+    (h : loopN1CallMaxmaxmaxExactHypotheses
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig2 u0Orig1) :
+    loopN1CallMaxmaxmaxBranchFacts
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig2 u0Orig1 := by
+  unfold loopN1CallMaxmaxmaxExactHypotheses at h
+  exact h.2.1
+
+/-- Project the global carry2 condition from the compact N1 call/max/max/max hypotheses. -/
+theorem loopN1CallMaxmaxmaxExactHypotheses_carry2
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig2 u0Orig1 : Word)
+    (h : loopN1CallMaxmaxmaxExactHypotheses
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig2 u0Orig1) :
+    Carry2NzAll v0 v1 v2 v3 := by
+  unfold loopN1CallMaxmaxmaxExactHypotheses at h
+  exact h.2.2.1
+
+/-- Project the v4 N1 call carry condition from the compact N1 call/max/max/max hypotheses. -/
+theorem loopN1CallMaxmaxmaxExactHypotheses_carry2Call
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig2 u0Orig1 : Word)
+    (h : loopN1CallMaxmaxmaxExactHypotheses
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig2 u0Orig1) :
+    isAddbackCarry2NzN1CallV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+  unfold loopN1CallMaxmaxmaxExactHypotheses at h
+  exact h.2.2.2
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- adds projection lemmas for loopN1CallMaxmaxmaxExactHypotheses
- exposes the j=3 BLTU fact, packaged branch facts, Carry2NzAll, and v4 call carry predicate without repeatedly unfolding the bundle
- supports the next compact proof attempt for the N1 call/max/max/max exact scratch spec

## Verification
- lake build EvmAsm.Evm64.DivMod.Compose.FullPathN1V4NoNop
- lake build EvmAsm.Evm64.DivMod
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/Compose/FullPathN1V4NoNop.lean

Bead: evm-asm-9iqmw.2.1