### PR TITLE
feat(div): bridge n1 call input hypotheses

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1V4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1V4NoNop.lean
@@ -1490,6 +1490,20 @@ def loopN1CallMaxmaxmaxExactInputHypotheses
   loopN1CallMaxmaxmaxExactHypotheses
     I.v0 I.v1 I.v2 I.v3 I.u0 I.u1 I.u2 I.u3 I.uTop I.u0Orig2 I.u0Orig1
 
+/-- Build the bundled N1 call/max/max/max exact-path hypothesis wrapper
+    from the bundled branch facts plus the universal carry2 assumption. -/
+theorem loopN1CallMaxmaxmaxExactInputHypotheses_of_branches
+    (I : LoopN1CallMaxmaxmaxExactInputs)
+    (hbltu3 : BitVec.ult I.u1 I.v0)
+    (hbranches : loopN1CallMaxmaxmaxBranchFacts
+      I.v0 I.v1 I.v2 I.v3 I.u0 I.u1 I.u2 I.u3 I.uTop I.u0Orig2 I.u0Orig1)
+    (hcarry2 : Carry2NzAll I.v0 I.v1 I.v2 I.v3) :
+    loopN1CallMaxmaxmaxExactInputHypotheses I := by
+  unfold loopN1CallMaxmaxmaxExactInputHypotheses
+  exact loopN1CallMaxmaxmaxExactHypotheses_of_branches
+    I.v0 I.v1 I.v2 I.v3 I.u0 I.u1 I.u2 I.u3 I.uTop I.u0Orig2 I.u0Orig1
+    hbltu3 hbranches hcarry2
+
 /-- Project the j=3 BLTU-taken fact from bundled N1 call/max/max/max inputs. -/
 theorem loopN1CallMaxmaxmaxExactInputHypotheses_hbltu3
     (I : LoopN1CallMaxmaxmaxExactInputs)


### PR DESCRIPTION
## Summary
- add a bundled-input constructor for loopN1CallMaxmaxmaxExactInputHypotheses
- let downstream N1 call/max/max/max proofs build the record-level hypothesis wrapper from branch facts plus Carry2NzAll

## Verification
- lake build EvmAsm.Evm64.DivMod.Compose.FullPathN1V4NoNop
- lake build EvmAsm.Evm64.DivMod
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/Compose/FullPathN1V4NoNop.lean
- wc -l EvmAsm/Evm64/DivMod/Compose/FullPathN1V4NoNop.lean  # 1891

Bead: evm-asm-9iqmw.2.1