### PR TITLE
feat(div): expose n1 call branch entry

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1V4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1V4NoNop.lean
@@ -1932,4 +1932,25 @@ theorem divK_loop_n1_call_maxmaxmax_exact_x1_scratch_input_v4_noNop
       exact hp)
     J3 Htail
 
+/-- Final bundled N1 call/max/max/max exact path, with hypotheses supplied
+    directly as path branch facts plus the universal carry2 assumption. -/
+theorem divK_loop_n1_call_maxmaxmax_exact_x1_scratch_input_v4_noNop_of_bltu
+    (I : LoopN1CallMaxmaxmaxExactInputs)
+    (halign : loopN1CallMaxmaxmaxExactInputAligned I)
+    (hbltu3 : BitVec.ult I.u1 I.v0)
+    (hbltu2 : ¬BitVec.ult
+      (loopN1CallMaxmaxmaxR3 I.v0 I.v1 I.v2 I.v3 I.u0 I.u1 I.u2 I.u3 I.uTop).2.1
+      I.v0)
+    (hbltu1 : ¬BitVec.ult
+      (loopN1CallMaxmaxmaxR2 I.v0 I.v1 I.v2 I.v3 I.u0 I.u1 I.u2 I.u3 I.uTop
+        I.u0Orig2).2.1 I.v0)
+    (hbltu0 : ¬BitVec.ult
+      (loopN1CallMaxmaxmaxR1 I.v0 I.v1 I.v2 I.v3 I.u0 I.u1 I.u2 I.u3 I.uTop
+        I.u0Orig2 I.u0Orig1).2.1 I.v0)
+    (hcarry2 : Carry2NzAll I.v0 I.v1 I.v2 I.v3) :
+    loopN1CallMaxmaxmaxExactInputSpec I := by
+  exact divK_loop_n1_call_maxmaxmax_exact_x1_scratch_input_v4_noNop I halign
+    (loopN1CallMaxmaxmaxExactInputHypotheses_of_bltu I
+      hbltu3 hbltu2 hbltu1 hbltu0 hcarry2)
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- expose a final bundled N1 call/max/max/max exact-path theorem that accepts the four path branch facts directly
- reuse the bundled hypothesis constructor from the previous stack slice to avoid downstream callers rebuilding loopN1CallMaxmaxmaxExactInputHypotheses by hand

## Verification
- lake build EvmAsm.Evm64.DivMod.Compose.FullPathN1V4NoNop
- lake build EvmAsm.Evm64.DivMod
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/Compose/FullPathN1V4NoNop.lean
- wc -l EvmAsm/Evm64/DivMod/Compose/FullPathN1V4NoNop.lean  # 1956

Bead: evm-asm-9iqmw.2.1