### PR TITLE
feat(div): add divcode v4 callable x9 output wrapper

### DIFF
--- a/EvmAsm/Evm64/DivMod/CallableV4Div.lean
+++ b/EvmAsm/Evm64/DivMod/CallableV4Div.lean
@@ -159,6 +159,27 @@ theorem sharedDivModCodeNoNop_v4_sub_div_callable_code_v4 {base : Word} :
     (CodeReq.union_split_mono callable_b13_div_v4
     (fun _ _ h => by simp [CodeReq.unionAll_nil, CodeReq.empty] at h))))))))))))
 
+/-- `divCode_noNop_v4 ⊆ evm_div_callable_code_v4`: the callable DIV code is
+    the exact no-NOP DIV body followed by the callable return. -/
+theorem divCode_noNop_v4_sub_div_callable_code_v4 {base : Word} :
+    ∀ a i, (divCode_noNop_v4 base) a = some i →
+           (evm_div_callable_code_v4 base) a = some i := by
+  unfold divCode_noNop_v4; simp only [CodeReq.unionAll_cons]
+  exact CodeReq.union_split_mono callable_b0_div_v4
+    (CodeReq.union_split_mono callable_b1_div_v4
+    (CodeReq.union_split_mono callable_b2_div_v4
+    (CodeReq.union_split_mono callable_b3_div_v4
+    (CodeReq.union_split_mono callable_b4_div_v4
+    (CodeReq.union_split_mono callable_b5_div_v4
+    (CodeReq.union_split_mono callable_b6_div_v4
+    (CodeReq.union_split_mono callable_b7_div_v4
+    (CodeReq.union_split_mono callable_b8_div_v4
+    (CodeReq.union_split_mono callable_b9_div_v4
+    (CodeReq.union_split_mono callable_b10_div_v4
+    (CodeReq.union_split_mono callable_b11_div_v4
+    (CodeReq.union_split_mono callable_b13_div_v4
+    (fun _ _ h => by simp [CodeReq.unionAll_nil, CodeReq.empty] at h)))))))))))))
+
 theorem evm_div_callable_v4_spec_from_noNop (sp base raVal : Word)
     (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
@@ -500,6 +521,56 @@ theorem evm_div_callable_v4_spec_from_noNop_preserving_x1_x9out_body_framed
   have hStackCall :=
     cpsTripleWithin_extend_code
       (hmono := sharedDivModCodeNoNop_v4_sub_div_callable_code_v4) hStack
+  have hStackForRet :
+      cpsTripleWithin unifiedDivBound base (base + nopOff) (evm_div_callable_code_v4 base)
+        (divModStackDispatchPreNoX1 sp a b
+          x9In raVal v2 v5 v6 v7 v10 v11
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0 ** F)
+        (((divStackDispatchPostCallable sp a b ** (.x9 ↦ᵣ x9Out)) ** F) **
+          (.x1 ↦ᵣ raVal)) :=
+    cpsTripleWithin_weaken (fun _ hp => hp) (fun _ hp => by xperm_hyp hp) hStackCall
+  have hRet :=
+    cpsTripleWithin_extend_code (hmono := evm_div_callable_code_v4_ret_sub (base := base))
+      (ret_spec_within' (base + nopOff) raVal)
+  have hRetFramed :=
+    cpsTripleWithin_frameL ((divStackDispatchPostCallable sp a b ** (.x9 ↦ᵣ x9Out)) ** F)
+      (by
+        rw [divStackDispatchPostCallable_unfold, divScratchOwnCallNoX1_unfold,
+          divScratchOwn_unfold]
+        pcFree)
+      hRet
+  exact cpsTripleWithin_weaken (fun _ hp => hp) (fun _ hp => by xperm_hyp hp)
+    (cpsTripleWithin_seq_same_cr hStackForRet hRetFramed)
+
+/-- v4 callable DIV wrapper for full `divCode_noNop_v4` body proofs that
+    already carry an explicit PC-free frame and return a possibly different
+    exact x9 value. -/
+theorem evm_div_callable_v4_spec_from_divCode_noNop_preserving_x1_x9out_body_framed
+    {F : Assertion} [Assertion.PCFree F]
+    (sp base x9In x9Out raVal : Word) (a b : EvmWord)
+    (v2 v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (hStack :
+      cpsTripleWithin unifiedDivBound base (base + nopOff) (divCode_noNop_v4 base)
+        (divModStackDispatchPreNoX1 sp a b
+          x9In raVal v2 v5 v6 v7 v10 v11
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0 ** F)
+        (((divStackDispatchPostCallable sp a b ** (.x1 ↦ᵣ raVal)) **
+          (.x9 ↦ᵣ x9Out)) ** F)) :
+    cpsTripleWithin (unifiedDivBound + 1) base (raVal &&& ~~~1)
+      (evm_div_callable_code_v4 base)
+      (divModStackDispatchPreNoX1 sp a b
+        x9In raVal v2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 ** F)
+      (((divStackDispatchPostCallable sp a b ** (.x1 ↦ᵣ raVal)) **
+        (.x9 ↦ᵣ x9Out)) ** F) := by
+  have hStackCall :=
+    cpsTripleWithin_extend_code
+      (hmono := divCode_noNop_v4_sub_div_callable_code_v4) hStack
   have hStackForRet :
       cpsTripleWithin unifiedDivBound base (base + nopOff) (evm_div_callable_code_v4 base)
         (divModStackDispatchPreNoX1 sp a b

--- a/EvmAsm/Evm64/DivMod/CallableV4Div.lean
+++ b/EvmAsm/Evm64/DivMod/CallableV4Div.lean
@@ -593,6 +593,56 @@ theorem evm_div_callable_v4_spec_from_divCode_noNop_preserving_x1_x9out_body_fra
   exact cpsTripleWithin_weaken (fun _ hp => hp) (fun _ hp => by xperm_hyp hp)
     (cpsTripleWithin_seq_same_cr hStackForRet hRetFramed)
 
+/-- v4 callable DIV wrapper for full `divCode_noNop_v4` body proofs that
+    transform an explicit PC-free frame and return a possibly different exact
+    x9 value. -/
+theorem evm_div_callable_v4_spec_from_divCode_noNop_preserving_x1_x9out_body_frame_transform
+    {FPre FPost : Assertion} [Assertion.PCFree FPost]
+    (sp base x9In x9Out raVal : Word) (a b : EvmWord)
+    (v2 v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (hStack :
+      cpsTripleWithin unifiedDivBound base (base + nopOff) (divCode_noNop_v4 base)
+        (divModStackDispatchPreNoX1 sp a b
+          x9In raVal v2 v5 v6 v7 v10 v11
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0 ** FPre)
+        (((divStackDispatchPostCallable sp a b ** (.x1 ↦ᵣ raVal)) **
+          (.x9 ↦ᵣ x9Out)) ** FPost)) :
+    cpsTripleWithin (unifiedDivBound + 1) base (raVal &&& ~~~1)
+      (evm_div_callable_code_v4 base)
+      (divModStackDispatchPreNoX1 sp a b
+        x9In raVal v2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 ** FPre)
+      (((divStackDispatchPostCallable sp a b ** (.x1 ↦ᵣ raVal)) **
+        (.x9 ↦ᵣ x9Out)) ** FPost) := by
+  have hStackCall :=
+    cpsTripleWithin_extend_code
+      (hmono := divCode_noNop_v4_sub_div_callable_code_v4) hStack
+  have hStackForRet :
+      cpsTripleWithin unifiedDivBound base (base + nopOff) (evm_div_callable_code_v4 base)
+        (divModStackDispatchPreNoX1 sp a b
+          x9In raVal v2 v5 v6 v7 v10 v11
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0 ** FPre)
+        (((divStackDispatchPostCallable sp a b ** (.x9 ↦ᵣ x9Out)) ** FPost) **
+          (.x1 ↦ᵣ raVal)) :=
+    cpsTripleWithin_weaken (fun _ hp => hp) (fun _ hp => by xperm_hyp hp) hStackCall
+  have hRet :=
+    cpsTripleWithin_extend_code (hmono := evm_div_callable_code_v4_ret_sub (base := base))
+      (ret_spec_within' (base + nopOff) raVal)
+  have hRetFramed :=
+    cpsTripleWithin_frameL ((divStackDispatchPostCallable sp a b ** (.x9 ↦ᵣ x9Out)) ** FPost)
+      (by
+        rw [divStackDispatchPostCallable_unfold, divScratchOwnCallNoX1_unfold,
+          divScratchOwn_unfold]
+        pcFree)
+      hRet
+  exact cpsTripleWithin_weaken (fun _ hp => hp) (fun _ hp => by xperm_hyp hp)
+    (cpsTripleWithin_seq_same_cr hStackForRet hRetFramed)
+
 theorem evm_div_callable_v4_spec_from_noNop_branch_return_x1 (sp base : Word)
     (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1V4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1V4NoNop.lean
@@ -158,6 +158,102 @@ theorem evm_div_n1_to_loopSetup_spec_v4_noNop (sp base : Word)
     (fun h hq => by delta loopSetupPost; xperm_hyp hq)
     hFull
 
+/-- Full n=1 path from entry to loop body start over `divCode_noNop_v4`,
+    generalized over the incoming value of `x9`. The loop setup code overwrites
+    `x9` with `4 - n`; earlier stages only carry it as a frame. -/
+theorem evm_div_n1_to_loopSetup_spec_v4_noNop_x9In (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 x9In : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1z : b1 = 0)
+    (hshift_nz : (clzResult b0).1 ≠ 0) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4) base (base + loopBodyOff)
+      (divCode_noNop_v4 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b0).2 >>> (63 : Nat)) **
+       (.x9 ↦ᵣ x9In) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+       ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+       ((sp + signExtend12 4024) ↦ₘ u4Old) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
+      (loopSetupPost sp (1 : Word) (clzResult b0).1 a0 a1 a2 a3 b0 b1 b2 b3) := by
+  let shift := (clzResult b0).1
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+  let b0' := b0 <<< (shift.toNat % 64)
+  let u4 := a3 >>> (antiShift.toNat % 64)
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
+  let u0 := a0 <<< (shift.toNat % 64)
+  have hNB := evm_div_phaseAB_n1_clz_c2_normB_spec_v4_noNop sp base
+    b0 b1 b2 b3 v5 v6 v7 v10 q0 q1 q2 q3 u5 u6 u7 nMem shiftMem
+    hbnz hb3z hb2z hb1z hshift_nz
+  simp only [evmDivPhaseABN1ClzC2NormBPre_unfold,
+      evmDivPhaseABN1ClzC2NormBFullPost_unfold] at hNB
+  have hNBf := cpsTripleWithin_frameR
+    ((.x9 ↦ᵣ x9In) **
+     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+     ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+     ((sp + signExtend12 4024) ↦ₘ u4Old))
+    (by pcFree) hNB
+  have hNormA := divK_normA_full_spec_within_v4_noNop sp a0 a1 a2 a3
+    b0' (b0 >>> (antiShift.toNat % 64)) b3 shift antiShift
+    u0Old u1Old u2Old u3Old u4Old base
+  rw [divKNormAFullPreNoNop_unfold] at hNormA
+  simp only [normAFullPost_unfold] at hNormA
+  have hNormAf := cpsTripleWithin_frameR
+    ((.x0 ↦ᵣ (0 : Word)) **
+     (.x9 ↦ᵣ x9In) **
+     ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
+     ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3') **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (1 : Word)) **
+     ((sp + signExtend12 3992) ↦ₘ shift))
+    (by pcFree) hNormA
+  have hNA := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hNBf hNormAf
+  have hLS := divK_loopSetup_ntaken_spec_within_v4_noNop sp (1 : Word)
+    x9In u1 base (by decide)
+  simp only [divKLoopSetupNtakenPreNoNop_unfold,
+      divKLoopSetupNtakenPostNoNop_unfold] at hLS
+  have hLSf := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ (a0 >>> (antiShift.toNat % 64))) **
+     (.x6 ↦ᵣ shift) ** (.x7 ↦ᵣ u0) ** (.x2 ↦ᵣ antiShift) **
+     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
+     ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3') **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
+     ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3) **
+     ((sp + signExtend12 4024) ↦ₘ u4) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3992) ↦ₘ shift))
+    (by pcFree) hLS
+  have hFull := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hNA hLSf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by delta loopSetupPost; xperm_hyp hq)
+    hFull
+
 /-- v4/no-NOP n=1 preloop setup with the exact caller-framed `x1` and
     the loop scratch handoff frame carried explicitly. -/
 theorem evm_div_n1_to_loopSetup_spec_v4_noNop_exact_x1_scratch_frame

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1V4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1V4NoNop.lean
@@ -3257,4 +3257,138 @@ theorem fullDivN1_preloop_call_maxmaxmax_denorm_epilogue_exact_x1_v4_noNop_of_bl
       xperm_hyp hpBridge)
     hA hB
 
+/-- Full-DIV n=1 v4/no-NOP preloop, call/max/max/max loop path, and
+    denormalization+DIV epilogue, with arbitrary incoming `x9` and caller
+    `x1` retained exactly. -/
+theorem fullDivN1_preloop_call_maxmaxmax_denorm_epilogue_exact_x1_v4_noNop_x9In_of_bltu
+    (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old x9In : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem : Word)
+    (jMem retMem dMem dloMem scratchUn0 scratchMem raVal : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1z : b1 = 0)
+    (hshift_nz : (clzResult b0).1 ≠ 0)
+    (halign : fullDivN1CallMaxmaxmaxExactInputAligned sp base
+      jMem (1 : Word) (fullDivN1Shift b0) (fullDivN1NormU a0 a1 a2 a3 b0).1
+      (a0 >>> ((fullDivN1AntiShift b0).toNat % 64)) v11Old (fullDivN1AntiShift b0)
+      a0 a1 a2 a3 b0 b1 b2 b3
+      (0 : Word) (0 : Word) (0 : Word) (0 : Word)
+      retMem dMem dloMem scratchUn0 scratchMem raVal)
+    (hbltu3 : isTrialN1_j3 true a3 b0)
+    (hbltu2 : ¬BitVec.ult
+      (loopN1CallMaxmaxmaxR3
+        (fullDivN1NormV b0 b1 b2 b3).1
+        (fullDivN1NormV b0 b1 b2 b3).2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.2
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
+        0 0 0).2.1
+      (fullDivN1NormV b0 b1 b2 b3).1)
+    (hbltu1 : ¬BitVec.ult
+      (loopN1CallMaxmaxmaxR2
+        (fullDivN1NormV b0 b1 b2 b3).1
+        (fullDivN1NormV b0 b1 b2 b3).2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.2
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
+        0 0 0
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.1).2.1
+      (fullDivN1NormV b0 b1 b2 b3).1)
+    (hbltu0 : ¬BitVec.ult
+      (loopN1CallMaxmaxmaxR1
+        (fullDivN1NormV b0 b1 b2 b3).1
+        (fullDivN1NormV b0 b1 b2 b3).2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.2
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
+        0 0 0
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.1
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.1).2.1
+      (fullDivN1NormV b0 b1 b2 b3).1)
+    (hcarry2 : Carry2NzAll
+      (fullDivN1NormV b0 b1 b2 b3).1
+      (fullDivN1NormV b0 b1 b2 b3).2.1
+      (fullDivN1NormV b0 b1 b2 b3).2.2.1
+      (fullDivN1NormV b0 b1 b2 b3).2.2.2) :
+    cpsTripleWithin ((8 + 21 + 24 + 4 + 21 + 21 + 4 + 780) + (2 + 23 + 10))
+      base (base + nopOff) (divCode_noNop_v4 base)
+      ((((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+         (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b0).2 >>> (63 : Nat)) **
+         (.x9 ↦ᵣ x9In) **
+         ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+         ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+         ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+         ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+         ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+         ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+         ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+         ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+         ((sp + signExtend12 4024) ↦ₘ u4Old) **
+         ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+         ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+         ((sp + signExtend12 3992) ↦ₘ shiftMem)) **
+        ((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
+         (sp + signExtend12 3968 ↦ₘ retMem) **
+         (sp + signExtend12 3960 ↦ₘ dMem) **
+         (sp + signExtend12 3952 ↦ₘ dloMem) **
+         (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+         (sp + signExtend12 3936 ↦ₘ scratchMem) **
+         (.x1 ↦ᵣ raVal))))
+      (fullDivN1CallMaxmaxmaxUnifiedPostNoX1 sp base (clzResult b0).1
+        a0 a1 a2 a3
+        (fullDivN1NormV b0 b1 b2 b3).1
+        (fullDivN1NormV b0 b1 b2 b3).2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.2
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
+        (0 : Word) (0 : Word) (0 : Word)
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.1
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.1
+        (fullDivN1NormU a0 a1 a2 a3 b0).1
+        scratchMem **
+       (.x1 ↦ᵣ raVal)) := by
+  have hA := fullDivN1_preloop_call_maxmaxmax_exact_x1_scratch_v4_noNop_x9In_of_bltu
+    sp base
+    a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old x9In
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem
+    jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+    hbnz hb3z hb2z hb1z hshift_nz halign hbltu3 hbltu2 hbltu1 hbltu0 hcarry2
+  unfold fullDivN1PreloopCallMaxmaxmaxExactSpecX9In at hA
+  have hB := evm_div_n1_call_maxmaxmax_denorm_epilogue_spec_v4_noNop_exact_x1
+    sp base (clzResult b0).1
+    a0 a1 a2 a3
+    (fullDivN1NormV b0 b1 b2 b3).1
+    (fullDivN1NormV b0 b1 b2 b3).2.1
+    (fullDivN1NormV b0 b1 b2 b3).2.2.1
+    (fullDivN1NormV b0 b1 b2 b3).2.2.2
+    (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1
+    (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
+    (0 : Word) (0 : Word) (0 : Word)
+    (fullDivN1NormU a0 a1 a2 a3 b0).2.2.1
+    (fullDivN1NormU a0 a1 a2 a3 b0).2.1
+    (fullDivN1NormU a0 a1 a2 a3 b0).1
+    scratchMem raVal hshift_nz
+  exact cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by
+      have hpBridge := loopN1CallMaxmaxmaxScratchPostNoX1_to_denormPre_frame
+        sp base
+        a0 a1 a2 a3
+        (fullDivN1NormV b0 b1 b2 b3).1
+        (fullDivN1NormV b0 b1 b2 b3).2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.2
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
+        (0 : Word) (0 : Word) (0 : Word)
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.1
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.1
+        (fullDivN1NormU a0 a1 a2 a3 b0).1
+        scratchMem (clzResult b0).1 raVal h hp
+      xperm_hyp hpBridge)
+    hA hB
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1V4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1V4NoNop.lean
@@ -315,6 +315,67 @@ theorem evm_div_n1_to_loopSetup_spec_v4_noNop_exact_x1_scratch_frame
     (fun h hq => by xperm_hyp hq)
     hFramed
 
+/-- v4/no-NOP n=1 preloop setup with arbitrary incoming `x9`, exact
+    caller-framed `x1`, and the loop scratch handoff frame carried explicitly. -/
+theorem evm_div_n1_to_loopSetup_spec_v4_noNop_x9In_exact_x1_scratch_frame
+    (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old x9In : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem : Word)
+    (jMem retMem dMem dloMem scratchUn0 scratchMem raVal : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1z : b1 = 0)
+    (hshift_nz : (clzResult b0).1 ≠ 0) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4) base (base + loopBodyOff)
+      (divCode_noNop_v4 base)
+      (((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b0).2 >>> (63 : Nat)) **
+        (.x9 ↦ᵣ x9In) **
+        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+        ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+        ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+        ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+        ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+        ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+        ((sp + signExtend12 4024) ↦ₘ u4Old) **
+        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+        ((sp + signExtend12 3992) ↦ₘ shiftMem)) **
+       ((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal)))
+      (loopSetupPost sp (1 : Word) (clzResult b0).1 a0 a1 a2 a3 b0 b1 b2 b3 **
+       ((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal))) := by
+  have hPre :=
+    evm_div_n1_to_loopSetup_spec_v4_noNop_x9In sp base
+      a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 x9In
+      q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem
+      hbnz hb3z hb2z hb1z hshift_nz
+  have hFramed := cpsTripleWithin_frameR
+    (((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
+      (sp + signExtend12 3968 ↦ₘ retMem) **
+      (sp + signExtend12 3960 ↦ₘ dMem) **
+      (sp + signExtend12 3952 ↦ₘ dloMem) **
+      (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+      (sp + signExtend12 3936 ↦ₘ scratchMem) **
+      (.x1 ↦ᵣ raVal)))
+    (by pcFree) hPre
+  exact cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    hFramed
+
 /-- Sp-relative n=1 max-skip j=0 precondition over `divCode_noNop_v4`. -/
 @[irreducible]
 def loopBodyN1MaxSkipJ0NormPreV4

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1V4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1V4NoNop.lean
@@ -2897,6 +2897,53 @@ def fullDivN1PreloopCallMaxmaxmaxExactSpec (sp base : Word)
       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
       ((sp + signExtend12 3992) ↦ₘ (clzResult b0).1)))
 
+/-- Opaque full-DIV n=1 v4/no-NOP preloop plus call/max/max/max path,
+    generalized over the incoming `x9` value. -/
+@[irreducible]
+def fullDivN1PreloopCallMaxmaxmaxExactSpecX9In (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old x9In : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem : Word)
+    (jMem retMem dMem dloMem scratchUn0 scratchMem raVal : Word) : Prop :=
+  cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 780) base (base + denormOff)
+    (divCode_noNop_v4 base)
+    ((((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b0).2 >>> (63 : Nat)) **
+       (.x9 ↦ᵣ x9In) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+       ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+       ((sp + signExtend12 4024) ↦ₘ u4Old) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem)) **
+      ((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
+       (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+       (sp + signExtend12 3936 ↦ₘ scratchMem) **
+       (.x1 ↦ᵣ raVal))))
+    ((loopN1CallMaxmaxmaxScratchPostNoX1 sp base
+      (fullDivN1NormV b0 b1 b2 b3).1
+      (fullDivN1NormV b0 b1 b2 b3).2.1
+      (fullDivN1NormV b0 b1 b2 b3).2.2.1
+      (fullDivN1NormV b0 b1 b2 b3).2.2.2
+      (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1
+      (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
+      (0 : Word) (0 : Word) (0 : Word)
+      (fullDivN1NormU a0 a1 a2 a3 b0).2.2.1
+      (fullDivN1NormU a0 a1 a2 a3 b0).2.1
+      (fullDivN1NormU a0 a1 a2 a3 b0).1
+      scratchMem ** (.x1 ↦ᵣ raVal)) **
+     (((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+      ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+      ((sp + signExtend12 3992) ↦ₘ (clzResult b0).1)))
+
 /-- Full-DIV n=1 v4/no-NOP preloop composed with the call/max/max/max
     exact loop path. -/
 theorem fullDivN1_preloop_call_maxmaxmax_exact_x1_scratch_v4_noNop_of_bltu
@@ -2959,6 +3006,96 @@ theorem fullDivN1_preloop_call_maxmaxmax_exact_x1_scratch_v4_noNop_of_bltu
   unfold fullDivN1PreloopCallMaxmaxmaxExactSpec
   have hPre := evm_div_n1_to_loopSetup_spec_v4_noNop_exact_x1_scratch_frame
     sp base a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem
+    jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+    hbnz hb3z hb2z hb1z hshift_nz
+  have hLoop := fullDivN1_call_maxmaxmax_exact_x1_scratch_v4_noNop_of_bltu
+    sp base
+    jMem (1 : Word) (fullDivN1Shift b0) (fullDivN1NormU a0 a1 a2 a3 b0).1
+    (a0 >>> ((fullDivN1AntiShift b0).toNat % 64)) v11Old (fullDivN1AntiShift b0)
+    a0 a1 a2 a3 b0 b1 b2 b3
+    (0 : Word) (0 : Word) (0 : Word) (0 : Word)
+    retMem dMem dloMem scratchUn0 scratchMem raVal
+    halign hbltu3 hbltu2 hbltu1 hbltu0 hcarry2
+  unfold fullDivN1CallMaxmaxmaxExactInputSpec at hLoop
+  unfold loopN1CallMaxmaxmaxExactInputSpec at hLoop
+  unfold loopN1CallMaxmaxmaxExactX1ScratchSpec at hLoop
+  unfold fullDivN1CallMaxmaxmaxExactInputs at hLoop
+  dsimp only at hLoop
+  have hLoopF := cpsTripleWithin_frameR
+    (((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 3992) ↦ₘ (clzResult b0).1))
+    (by pcFree) hLoop
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by
+      exact loopSetupPost_to_fullDivN1CallMaxmaxmaxScratchPreNoX1_framed
+        sp a0 a1 a2 a3 b0 b1 b2 b3 v11Old
+        jMem retMem dMem dloMem scratchUn0 scratchMem raVal h hp)
+    hPre hLoopF
+
+/-- Full-DIV n=1 v4/no-NOP preloop with arbitrary incoming `x9`, composed
+    with the call/max/max/max loop path. -/
+theorem fullDivN1_preloop_call_maxmaxmax_exact_x1_scratch_v4_noNop_x9In_of_bltu
+    (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old x9In : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem : Word)
+    (jMem retMem dMem dloMem scratchUn0 scratchMem raVal : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1z : b1 = 0)
+    (hshift_nz : (clzResult b0).1 ≠ 0)
+    (halign : fullDivN1CallMaxmaxmaxExactInputAligned sp base
+      jMem (1 : Word) (fullDivN1Shift b0) (fullDivN1NormU a0 a1 a2 a3 b0).1
+      (a0 >>> ((fullDivN1AntiShift b0).toNat % 64)) v11Old (fullDivN1AntiShift b0)
+      a0 a1 a2 a3 b0 b1 b2 b3
+      (0 : Word) (0 : Word) (0 : Word) (0 : Word)
+      retMem dMem dloMem scratchUn0 scratchMem raVal)
+    (hbltu3 : isTrialN1_j3 true a3 b0)
+    (hbltu2 : ¬BitVec.ult
+      (loopN1CallMaxmaxmaxR3
+        (fullDivN1NormV b0 b1 b2 b3).1
+        (fullDivN1NormV b0 b1 b2 b3).2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.2
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
+        0 0 0).2.1
+      (fullDivN1NormV b0 b1 b2 b3).1)
+    (hbltu1 : ¬BitVec.ult
+      (loopN1CallMaxmaxmaxR2
+        (fullDivN1NormV b0 b1 b2 b3).1
+        (fullDivN1NormV b0 b1 b2 b3).2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.2
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
+        0 0 0
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.1).2.1
+      (fullDivN1NormV b0 b1 b2 b3).1)
+    (hbltu0 : ¬BitVec.ult
+      (loopN1CallMaxmaxmaxR1
+        (fullDivN1NormV b0 b1 b2 b3).1
+        (fullDivN1NormV b0 b1 b2 b3).2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.2
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
+        0 0 0
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.1
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.1).2.1
+      (fullDivN1NormV b0 b1 b2 b3).1)
+    (hcarry2 : Carry2NzAll
+      (fullDivN1NormV b0 b1 b2 b3).1
+      (fullDivN1NormV b0 b1 b2 b3).2.1
+      (fullDivN1NormV b0 b1 b2 b3).2.2.1
+      (fullDivN1NormV b0 b1 b2 b3).2.2.2) :
+    fullDivN1PreloopCallMaxmaxmaxExactSpecX9In sp base
+      a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old x9In
+      q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem
+      jMem retMem dMem dloMem scratchUn0 scratchMem raVal := by
+  unfold fullDivN1PreloopCallMaxmaxmaxExactSpecX9In
+  have hPre := evm_div_n1_to_loopSetup_spec_v4_noNop_x9In_exact_x1_scratch_frame
+    sp base a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old x9In
     q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem
     jMem retMem dMem dloMem scratchUn0 scratchMem raVal
     hbnz hb3z hb2z hb1z hshift_nz

--- a/EvmAsm/Evm64/DivMod/Spec/N1ExactNoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N1ExactNoNop.lean
@@ -596,6 +596,194 @@ theorem evm_div_n1_call_maxmaxmax_stack_spec_within_word_noNop_v4_preNoX1_callab
       exact divConcretePostNoX1_weaken_callable_frame sp a b hLeft hpLeft)
     hFull
 
+/-- Stack-level N1 v4 call/max/max/max path with arbitrary incoming `x9`
+    and the v4-only scratch cell framed explicitly. -/
+theorem evm_div_n1_call_maxmaxmax_stack_spec_within_word_noNop_v4_preNoX1_callableExtra_x9In
+    (sp base : Word) (a b : EvmWord)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old x9In : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (ha0 : a.getLimbN 0 = a0) (ha1 : a.getLimbN 1 = a1)
+    (ha2 : a.getLimbN 2 = a2) (ha3 : a.getLimbN 3 = a3)
+    (hb0 : b.getLimbN 0 = b0) (hb1 : b.getLimbN 1 = b1)
+    (hb2 : b.getLimbN 2 = b2) (hb3 : b.getLimbN 3 = b3)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1z : b1 = 0)
+    (hshift_nz : (clzResult b0).1 ≠ 0)
+    (halign : fullDivN1CallMaxmaxmaxExactInputAligned sp base
+      jMem (1 : Word) (fullDivN1Shift b0) (fullDivN1NormU a0 a1 a2 a3 b0).1
+      (a0 >>> ((fullDivN1AntiShift b0).toNat % 64)) v11Old (fullDivN1AntiShift b0)
+      a0 a1 a2 a3 b0 b1 b2 b3
+      (0 : Word) (0 : Word) (0 : Word) (0 : Word)
+      retMem dMem dloMem scratchUn0 scratchMem raVal)
+    (hbltu3 : isTrialN1_j3 true a3 b0)
+    (hbltu2 : ¬BitVec.ult
+      (loopN1CallMaxmaxmaxR3
+        (fullDivN1NormV b0 b1 b2 b3).1
+        (fullDivN1NormV b0 b1 b2 b3).2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.2
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
+        0 0 0).2.1
+      (fullDivN1NormV b0 b1 b2 b3).1)
+    (hbltu1 : ¬BitVec.ult
+      (loopN1CallMaxmaxmaxR2
+        (fullDivN1NormV b0 b1 b2 b3).1
+        (fullDivN1NormV b0 b1 b2 b3).2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.2
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
+        0 0 0
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.1).2.1
+      (fullDivN1NormV b0 b1 b2 b3).1)
+    (hbltu0 : ¬BitVec.ult
+      (loopN1CallMaxmaxmaxR1
+        (fullDivN1NormV b0 b1 b2 b3).1
+        (fullDivN1NormV b0 b1 b2 b3).2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.2
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
+        0 0 0
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.1
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.1).2.1
+      (fullDivN1NormV b0 b1 b2 b3).1)
+    (hcarry2 : Carry2NzAll
+      (fullDivN1NormV b0 b1 b2 b3).1
+      (fullDivN1NormV b0 b1 b2 b3).2.1
+      (fullDivN1NormV b0 b1 b2 b3).2.2.1
+      (fullDivN1NormV b0 b1 b2 b3).2.2.2)
+    (hdiv0 : (EvmWord.div a b).getLimbN 0 =
+      (iterN1Max
+        (fullDivN1NormV b0 b1 b2 b3).1
+        (fullDivN1NormV b0 b1 b2 b3).2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.2
+        (fullDivN1NormU a0 a1 a2 a3 b0).1
+        (loopN1CallMaxmaxmaxR1
+          (fullDivN1NormV b0 b1 b2 b3).1
+          (fullDivN1NormV b0 b1 b2 b3).2.1
+          (fullDivN1NormV b0 b1 b2 b3).2.2.1
+          (fullDivN1NormV b0 b1 b2 b3).2.2.2
+          (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1
+          (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
+          0 0 0
+          (fullDivN1NormU a0 a1 a2 a3 b0).2.2.1
+          (fullDivN1NormU a0 a1 a2 a3 b0).2.1).2.1
+        (loopN1CallMaxmaxmaxR1
+          (fullDivN1NormV b0 b1 b2 b3).1
+          (fullDivN1NormV b0 b1 b2 b3).2.1
+          (fullDivN1NormV b0 b1 b2 b3).2.2.1
+          (fullDivN1NormV b0 b1 b2 b3).2.2.2
+          (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1
+          (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
+          0 0 0
+          (fullDivN1NormU a0 a1 a2 a3 b0).2.2.1
+          (fullDivN1NormU a0 a1 a2 a3 b0).2.1).2.2.1
+        (loopN1CallMaxmaxmaxR1
+          (fullDivN1NormV b0 b1 b2 b3).1
+          (fullDivN1NormV b0 b1 b2 b3).2.1
+          (fullDivN1NormV b0 b1 b2 b3).2.2.1
+          (fullDivN1NormV b0 b1 b2 b3).2.2.2
+          (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1
+          (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
+          0 0 0
+          (fullDivN1NormU a0 a1 a2 a3 b0).2.2.1
+          (fullDivN1NormU a0 a1 a2 a3 b0).2.1).2.2.2.1
+        (loopN1CallMaxmaxmaxR1
+          (fullDivN1NormV b0 b1 b2 b3).1
+          (fullDivN1NormV b0 b1 b2 b3).2.1
+          (fullDivN1NormV b0 b1 b2 b3).2.2.1
+          (fullDivN1NormV b0 b1 b2 b3).2.2.2
+          (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1
+          (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
+          0 0 0
+          (fullDivN1NormU a0 a1 a2 a3 b0).2.2.1
+          (fullDivN1NormU a0 a1 a2 a3 b0).2.1).2.2.2.2.1).1)
+    (hdiv1 : (EvmWord.div a b).getLimbN 1 =
+      (loopN1CallMaxmaxmaxR1
+        (fullDivN1NormV b0 b1 b2 b3).1
+        (fullDivN1NormV b0 b1 b2 b3).2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.2
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
+        0 0 0
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.1
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.1).1)
+    (hdiv2 : (EvmWord.div a b).getLimbN 2 =
+      (loopN1CallMaxmaxmaxR2
+        (fullDivN1NormV b0 b1 b2 b3).1
+        (fullDivN1NormV b0 b1 b2 b3).2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.2
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
+        0 0 0
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.1).1)
+    (hdiv3 : (EvmWord.div a b).getLimbN 3 =
+      (loopN1CallMaxmaxmaxR3
+        (fullDivN1NormV b0 b1 b2 b3).1
+        (fullDivN1NormV b0 b1 b2 b3).2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.2
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
+        0 0 0).1) :
+    cpsTripleWithin ((8 + 21 + 24 + 4 + 21 + 21 + 4 + 780) + (2 + 23 + 10))
+      base (base + nopOff) (divCode_noNop_v4 base)
+      (divModStackDispatchPreNoX1 sp a b x9In raVal
+        ((clzResult b0).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (((divStackDispatchPostCallable sp a b ** (.x1 ↦ᵣ raVal)) **
+        (.x9 ↦ᵣ (signExtend12 4095 : Word))) **
+       ((sp + signExtend12 3936) ↦ₘ
+        divKTrialCallV4ScratchOut
+          (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
+          (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1
+          (fullDivN1NormV b0 b1 b2 b3).1 scratchMem)) := by
+  have hFull :=
+    fullDivN1_preloop_call_maxmaxmax_denorm_epilogue_exact_x1_v4_noNop_x9In_of_bltu
+      sp base
+      a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old x9In
+      q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem
+      jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+      hbnz hb3z hb2z hb1z hshift_nz halign hbltu3 hbltu2 hbltu1 hbltu0 hcarry2
+  exact cpsTripleWithin_weaken
+    (fun h hp => by
+      rw [divModStackDispatchPreNoX1_unfold] at hp
+      rw [evmWordIs_sp_limbs_eq sp a _ _ _ _ ha0 ha1 ha2 ha3,
+          evmWordIs_sp32_limbs_eq sp b _ _ _ _ hb0 hb1 hb2 hb3,
+          divScratchValuesCallNoX1_unfold, divScratchValues_unfold] at hp
+      rw [word_add_zero]
+      xperm_hyp hp)
+    (fun h hp => by
+      have hConcrete :=
+        fullDivN1CallMaxmaxmaxUnifiedPostNoX1_to_divConcretePostNoX1Frame_extra
+          sp base (clzResult b0).1 a b
+          a0 a1 a2 a3
+          (fullDivN1NormV b0 b1 b2 b3).1
+          (fullDivN1NormV b0 b1 b2 b3).2.1
+          (fullDivN1NormV b0 b1 b2 b3).2.2.1
+          (fullDivN1NormV b0 b1 b2 b3).2.2.2
+          (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1
+          (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
+          (0 : Word) (0 : Word) (0 : Word)
+          (fullDivN1NormU a0 a1 a2 a3 b0).2.2.1
+          (fullDivN1NormU a0 a1 a2 a3 b0).2.1
+          (fullDivN1NormU a0 a1 a2 a3 b0).1
+          scratchMem raVal
+          ha0 ha1 ha2 ha3 hdiv0 hdiv1 hdiv2 hdiv3 h hp
+      refine sepConj_mono_left (fun hLeft hpLeft => ?_) h hConcrete
+      exact divConcretePostNoX1_weaken_callable_frame sp a b hLeft hpLeft)
+    hFull
+
 /-- Recombine the split no-`x1` full-path post with separate `x1` ownership. -/
 theorem fullDivN1UnifiedPostNoX1_frame_to_fullDivN1UnifiedPost
     (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallAbsComponents.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallAbsComponents.lean
@@ -72,6 +72,62 @@ theorem sdivAbsDivisorWord_eq_components
         | 3 => sdivAbsSum3 limb0 limb1 limb2 top := by
   rfl
 
+theorem sdivAbsDividendWord_getLimbN_0
+    (limb0 limb1 limb2 top : Word) :
+    (sdivAbsDividendWord limb0 limb1 limb2 top).getLimbN 0 =
+      sdivAbsSum0 limb0 top := by
+  rw [sdivAbsDividendWord_eq_components, EvmWord.getLimbN_lt _ 0 (by decide)]
+  exact EvmWord.getLimb_fromLimbs
+
+theorem sdivAbsDividendWord_getLimbN_1
+    (limb0 limb1 limb2 top : Word) :
+    (sdivAbsDividendWord limb0 limb1 limb2 top).getLimbN 1 =
+      sdivAbsSum1 limb0 limb1 top := by
+  rw [sdivAbsDividendWord_eq_components, EvmWord.getLimbN_lt _ 1 (by decide)]
+  exact EvmWord.getLimb_fromLimbs
+
+theorem sdivAbsDividendWord_getLimbN_2
+    (limb0 limb1 limb2 top : Word) :
+    (sdivAbsDividendWord limb0 limb1 limb2 top).getLimbN 2 =
+      sdivAbsSum2 limb0 limb1 limb2 top := by
+  rw [sdivAbsDividendWord_eq_components, EvmWord.getLimbN_lt _ 2 (by decide)]
+  exact EvmWord.getLimb_fromLimbs
+
+theorem sdivAbsDividendWord_getLimbN_3
+    (limb0 limb1 limb2 top : Word) :
+    (sdivAbsDividendWord limb0 limb1 limb2 top).getLimbN 3 =
+      sdivAbsSum3 limb0 limb1 limb2 top := by
+  rw [sdivAbsDividendWord_eq_components, EvmWord.getLimbN_lt _ 3 (by decide)]
+  exact EvmWord.getLimb_fromLimbs
+
+theorem sdivAbsDivisorWord_getLimbN_0
+    (limb0 limb1 limb2 top : Word) :
+    (sdivAbsDivisorWord limb0 limb1 limb2 top).getLimbN 0 =
+      sdivAbsSum0 limb0 top := by
+  rw [sdivAbsDivisorWord_eq_components, EvmWord.getLimbN_lt _ 0 (by decide)]
+  exact EvmWord.getLimb_fromLimbs
+
+theorem sdivAbsDivisorWord_getLimbN_1
+    (limb0 limb1 limb2 top : Word) :
+    (sdivAbsDivisorWord limb0 limb1 limb2 top).getLimbN 1 =
+      sdivAbsSum1 limb0 limb1 top := by
+  rw [sdivAbsDivisorWord_eq_components, EvmWord.getLimbN_lt _ 1 (by decide)]
+  exact EvmWord.getLimb_fromLimbs
+
+theorem sdivAbsDivisorWord_getLimbN_2
+    (limb0 limb1 limb2 top : Word) :
+    (sdivAbsDivisorWord limb0 limb1 limb2 top).getLimbN 2 =
+      sdivAbsSum2 limb0 limb1 limb2 top := by
+  rw [sdivAbsDivisorWord_eq_components, EvmWord.getLimbN_lt _ 2 (by decide)]
+  exact EvmWord.getLimb_fromLimbs
+
+theorem sdivAbsDivisorWord_getLimbN_3
+    (limb0 limb1 limb2 top : Word) :
+    (sdivAbsDivisorWord limb0 limb1 limb2 top).getLimbN 3 =
+      sdivAbsSum3 limb0 limb1 limb2 top := by
+  rw [sdivAbsDivisorWord_eq_components, EvmWord.getLimbN_lt _ 3 (by decide)]
+  exact EvmWord.getLimb_fromLimbs
+
 theorem sdivAbsDividendWord_evmWordIs_sp_components
     (sp limb0 limb1 limb2 top : Word) :
     evmWordIs sp (sdivAbsDividendWord limb0 limb1 limb2 top) =

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallExactCallable.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallExactCallable.lean
@@ -591,4 +591,38 @@ theorem evm_div_callable_v4_preserving_x1_x9out_exact_pre_body_framed_spec_in_sd
         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
         nMem shiftMem jMem retMem dMem dloMem scratchUn0 hStack)
 
+/-- v4 SDIV wrapper for full `divCode_noNop_v4` body proofs that already
+    carry an explicit PC-free frame and return a possibly different exact x9. -/
+theorem evm_div_callable_v4_preserving_x1_x9out_exact_pre_divCode_body_framed_spec_in_sdivCodeV4
+    {F : EvmAsm.Rv64.Assertion} [EvmAsm.Rv64.Assertion.PCFree F]
+    (sp base x9In x9Out raVal : Word) (a b : EvmWord) (v2 v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (hStack :
+      EvmAsm.Rv64.cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
+        (base + wrapperEndOff)
+        ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
+        (EvmAsm.Evm64.divCode_noNop_v4 (base + wrapperEndOff))
+        (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp a b
+          x9In raVal v2 v5 v6 v7 v10 v11
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0 ** F)
+        (((EvmAsm.Evm64.divStackDispatchPostCallable sp a b ** (.x1 ↦ᵣ raVal)) **
+          (.x9 ↦ᵣ x9Out)) ** F)) :
+    EvmAsm.Rv64.cpsTripleWithin (EvmAsm.Evm64.unifiedDivBound + 1)
+      (base + wrapperEndOff) (raVal &&& ~~~1) (sdivCodeV4 base)
+      (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp a b
+        x9In raVal v2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 ** F)
+      (((EvmAsm.Evm64.divStackDispatchPostCallable sp a b ** (.x1 ↦ᵣ raVal)) **
+        (.x9 ↦ᵣ x9Out)) ** F) := by
+  exact
+    EvmAsm.Rv64.cpsTripleWithin_extend_code
+      (hmono := evm_div_callable_code_v4_sub_sdivCodeV4 (base := base))
+      (EvmAsm.Evm64.evm_div_callable_v4_spec_from_divCode_noNop_preserving_x1_x9out_body_framed
+        sp (base + wrapperEndOff) x9In x9Out raVal a b v2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        nMem shiftMem jMem retMem dMem dloMem scratchUn0 hStack)
+
 end EvmAsm.Evm64.SDiv.Compose

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallExactCallable.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallExactCallable.lean
@@ -625,4 +625,38 @@ theorem evm_div_callable_v4_preserving_x1_x9out_exact_pre_divCode_body_framed_sp
         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
         nMem shiftMem jMem retMem dMem dloMem scratchUn0 hStack)
 
+/-- v4 embedded DIV callable wrapper for full `divCode_noNop_v4` body proofs
+    that transform an explicit frame. -/
+theorem evm_div_callable_v4_preserving_x1_x9out_exact_pre_divCode_body_frame_transform_spec_in_sdivCodeV4
+    {FPre FPost : EvmAsm.Rv64.Assertion} [EvmAsm.Rv64.Assertion.PCFree FPost]
+    (sp base x9In x9Out raVal : Word) (a b : EvmWord) (v2 v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (hStack :
+      EvmAsm.Rv64.cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
+        (base + wrapperEndOff)
+        ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
+        (EvmAsm.Evm64.divCode_noNop_v4 (base + wrapperEndOff))
+        (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp a b
+          x9In raVal v2 v5 v6 v7 v10 v11
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0 ** FPre)
+        (((EvmAsm.Evm64.divStackDispatchPostCallable sp a b ** (.x1 ↦ᵣ raVal)) **
+          (.x9 ↦ᵣ x9Out)) ** FPost)) :
+    EvmAsm.Rv64.cpsTripleWithin (EvmAsm.Evm64.unifiedDivBound + 1)
+      (base + wrapperEndOff) (raVal &&& ~~~1) (sdivCodeV4 base)
+      (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp a b
+        x9In raVal v2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 ** FPre)
+      (((EvmAsm.Evm64.divStackDispatchPostCallable sp a b ** (.x1 ↦ᵣ raVal)) **
+        (.x9 ↦ᵣ x9Out)) ** FPost) := by
+  exact
+    EvmAsm.Rv64.cpsTripleWithin_extend_code
+      (hmono := evm_div_callable_code_v4_sub_sdivCodeV4 (base := base))
+      (EvmAsm.Evm64.evm_div_callable_v4_spec_from_divCode_noNop_preserving_x1_x9out_body_frame_transform
+        sp (base + wrapperEndOff) x9In x9Out raVal a b v2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        nMem shiftMem jMem retMem dMem dloMem scratchUn0 hStack)
+
 end EvmAsm.Evm64.SDiv.Compose

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallExactHandoff.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallExactHandoff.lean
@@ -402,6 +402,108 @@ theorem saveRaDivCallDispatchReadyPost_exact_callable_x9out_divCode_framed_spec_
       signFrameNoX9, sdivDivCallResultSign, sdivAbsSign] at hp ⊢
     exact hp) hCallableExit
 
+/-- v4 exact callable handoff for full `divCode_noNop_v4` unsigned-DIV body
+    proofs that transform an explicit frame and return an exact `x9` value. -/
+theorem saveRaDivCallDispatchReadyPost_exact_callable_x9out_divCode_frame_transform_spec_in_sdivCodeV4
+    {FPre FPost : EvmAsm.Rv64.Assertion} [EvmAsm.Rv64.Assertion.PCFree FPost]
+    (vRa sp base
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+      v2 v5 v6 x9Out : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (hbase : base &&& 1 = 0)
+    (hStack :
+      EvmAsm.Rv64.cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
+        (base + wrapperEndOff)
+        ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
+        (EvmAsm.Evm64.divCode_noNop_v4 (base + wrapperEndOff))
+        (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp
+          (sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+          (sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          (sdivAbsSign divisorTop) ((base + divCallOff) + 4) v2 v5 v6
+          (sdivAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          (sdivAbsMask divisorTop)
+          (sdivAbsCarry3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0 ** FPre)
+        (((EvmAsm.Evm64.divStackDispatchPostCallable sp
+          (sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+          (sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) **
+          (.x1 ↦ᵣ ((base + divCallOff) + 4))) **
+          (.x9 ↦ᵣ x9Out)) ** FPost)) :
+    EvmAsm.Rv64.cpsTripleWithin (EvmAsm.Evm64.unifiedDivBound + 1)
+      (base + wrapperEndOff) (base + resultSignFixOff) (sdivCodeV4 base)
+      (saveRaDivCallDispatchReadyPost vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+        v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 ** FPre)
+      (((saveRaDivCallCallablePostNoX9 vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
+        (.x9 ↦ᵣ x9Out)) ** FPost)) := by
+  let dividendAbsWord :=
+    sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+  let divisorAbsWord :=
+    sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+  let divisorSign := sdivAbsSign divisorTop
+  let divisorMask := sdivAbsMask divisorTop
+  let divisorSum0 := sdivAbsSum0 divisorLimb0 divisorTop
+  let divisorCarry0 := sdivAbsCarry0 divisorLimb0 divisorTop
+  let divisorSum1 := sdivAbsSum1 divisorLimb0 divisorLimb1 divisorTop
+  let divisorCarry1 := sdivAbsCarry1 divisorLimb0 divisorLimb1 divisorTop
+  let divisorSum2 := sdivAbsSum2 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+  let divisorCarry2 := sdivAbsCarry2 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+  let divisorSum3 := sdivAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+  let divisorCarry3 := sdivAbsCarry3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+  let resultSign := sdivDivCallResultSign dividendTop divisorTop
+  let signFrameNoX9 : EvmAsm.Rv64.Assertion :=
+    (.x8 ↦ᵣ resultSign) ** (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))
+  have hCallableFramed :=
+    evm_div_callable_v4_preserving_x1_x9out_exact_pre_divCode_body_frame_transform_spec_in_sdivCodeV4
+      (FPre := signFrameNoX9 ** FPre) (FPost := signFrameNoX9 ** FPost)
+      sp base divisorSign x9Out ((base + divCallOff) + 4)
+      dividendAbsWord divisorAbsWord v2 v5 v6 divisorSum3 divisorMask divisorCarry3
+      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      nMem shiftMem jMem retMem dMem dloMem scratchUn0
+      (by
+        dsimp [dividendAbsWord, divisorAbsWord, divisorSum3, divisorMask,
+          divisorCarry3] at hStack ⊢
+        exact EvmAsm.Rv64.cpsTripleWithin_weaken (fun h hp => by
+          xperm_hyp hp) (fun h hp => by
+          xperm_hyp hp)
+          (EvmAsm.Rv64.cpsTripleWithin_frameR signFrameNoX9 (by
+            dsimp [signFrameNoX9]
+            pcFree) hStack))
+  have hCallableExit :
+      EvmAsm.Rv64.cpsTripleWithin (EvmAsm.Evm64.unifiedDivBound + 1)
+        (base + wrapperEndOff) (base + resultSignFixOff) (sdivCodeV4 base)
+        ((EvmAsm.Evm64.divModStackDispatchPreNoX1 sp dividendAbsWord divisorAbsWord
+          divisorSign ((base + divCallOff) + 4) v2 v5 v6 divisorSum3 divisorMask
+          divisorCarry3 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0 ** signFrameNoX9) ** FPre)
+        ((((EvmAsm.Evm64.divStackDispatchPostCallable sp dividendAbsWord divisorAbsWord **
+          (.x1 ↦ᵣ ((base + divCallOff) + 4))) ** signFrameNoX9) **
+          (.x9 ↦ᵣ x9Out)) ** FPost) := by
+    rw [← divCall_return_andn_one_eq_resultSignFixOff base hbase]
+    exact EvmAsm.Rv64.cpsTripleWithin_weaken (fun h hp => by
+      xperm_hyp hp) (fun h hp => by
+      xperm_hyp hp) hCallableFramed
+  exact EvmAsm.Rv64.cpsTripleWithin_weaken (fun h hp => by
+    rw [saveRaDivCallDispatchReadyPost_unfold] at hp
+    dsimp [dividendAbsWord, divisorAbsWord, divisorSign, divisorMask, divisorSum0,
+      divisorCarry0, divisorSum1, divisorCarry1, divisorSum2, divisorCarry2,
+      divisorSum3, divisorCarry3, resultSign, saveRaDivCallSignFrame,
+      sdivDivCallResultSign, sdivAbsSign, sdivAbsMask, sdivAbsSum0, sdivAbsCarry0,
+      sdivAbsSum1, sdivAbsCarry1, sdivAbsSum2, sdivAbsCarry2, sdivAbsSum3,
+      sdivAbsCarry3, signFrameNoX9] at hp ⊢
+    exact hp) (fun h hp => by
+    rw [saveRaDivCallCallablePostNoX9_unfold]
+    dsimp [dividendAbsWord, divisorAbsWord, divisorSign, resultSign,
+      signFrameNoX9, sdivDivCallResultSign, sdivAbsSign] at hp ⊢
+    exact hp) hCallableExit
+
 /-- v4 exact callable handoff for full `divCode_noNop_v4` body proofs whose
     precondition has the N1-style zero `x9` value. This specializes the generic
     SDIV handoff to the branch where the saved divisor sign is zero. -/

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallExactHandoff.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallExactHandoff.lean
@@ -402,4 +402,57 @@ theorem saveRaDivCallDispatchReadyPost_exact_callable_x9out_divCode_framed_spec_
       signFrameNoX9, sdivDivCallResultSign, sdivAbsSign] at hp ⊢
     exact hp) hCallableExit
 
+/-- v4 exact callable handoff for full `divCode_noNop_v4` body proofs whose
+    precondition has the N1-style zero `x9` value. This specializes the generic
+    SDIV handoff to the branch where the saved divisor sign is zero. -/
+theorem saveRaDivCallDispatchReadyPost_exact_callable_x9out_divCode_zeroX9_framed_spec_in_sdivCodeV4
+    {F : EvmAsm.Rv64.Assertion} [EvmAsm.Rv64.Assertion.PCFree F]
+    (vRa sp base
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+      v2 v5 v6 x9Out : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (hbase : base &&& 1 = 0)
+    (hdivisorSign :
+      sdivAbsSign divisorTop = EvmAsm.Rv64.signExtend12 (4 : BitVec 12) - (4 : Word))
+    (hStack :
+      EvmAsm.Rv64.cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
+        (base + wrapperEndOff)
+        ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
+        (EvmAsm.Evm64.divCode_noNop_v4 (base + wrapperEndOff))
+        (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp
+          (sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+          (sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          (EvmAsm.Rv64.signExtend12 (4 : BitVec 12) - (4 : Word))
+          ((base + divCallOff) + 4)
+          v2 v5 v6
+          (sdivAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          (sdivAbsMask divisorTop)
+          (sdivAbsCarry3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0 ** F)
+        (((EvmAsm.Evm64.divStackDispatchPostCallable sp
+          (sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+          (sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) **
+          (.x1 ↦ᵣ ((base + divCallOff) + 4))) **
+          (.x9 ↦ᵣ x9Out)) ** F)) :
+    EvmAsm.Rv64.cpsTripleWithin (EvmAsm.Evm64.unifiedDivBound + 1)
+      (base + wrapperEndOff) (base + resultSignFixOff) (sdivCodeV4 base)
+      (saveRaDivCallDispatchReadyPost vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+        v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 ** F)
+      (((saveRaDivCallCallablePostNoX9 vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
+        (.x9 ↦ᵣ x9Out)) ** F)) := by
+  apply saveRaDivCallDispatchReadyPost_exact_callable_x9out_divCode_framed_spec_in_sdivCodeV4
+    (F := F) vRa sp base dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+    divisorLimb0 divisorLimb1 divisorLimb2 divisorTop v2 v5 v6 x9Out
+    q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    shiftMem nMem jMem retMem dMem dloMem scratchUn0 hbase
+  rwa [hdivisorSign]
+
 end EvmAsm.Evm64.SDiv.Compose

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallExactHandoff.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallExactHandoff.lean
@@ -300,4 +300,106 @@ theorem saveRaDivCallDispatchReadyPost_exact_callable_x9out_framed_spec_in_sdivC
       signFrameNoX9, sdivDivCallResultSign, sdivAbsSign] at hp ⊢
     exact hp) hCallableExit
 
+/-- v4 exact callable handoff for already-framed full `divCode_noNop_v4`
+    unsigned-DIV body proofs that return an exact `x9` value. -/
+theorem saveRaDivCallDispatchReadyPost_exact_callable_x9out_divCode_framed_spec_in_sdivCodeV4
+    {F : EvmAsm.Rv64.Assertion} [EvmAsm.Rv64.Assertion.PCFree F]
+    (vRa sp base
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+      v2 v5 v6 x9Out : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (hbase : base &&& 1 = 0)
+    (hStack :
+      EvmAsm.Rv64.cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
+        (base + wrapperEndOff)
+        ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
+        (EvmAsm.Evm64.divCode_noNop_v4 (base + wrapperEndOff))
+        (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp
+          (sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+          (sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          (sdivAbsSign divisorTop) ((base + divCallOff) + 4) v2 v5 v6
+          (sdivAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          (sdivAbsMask divisorTop)
+          (sdivAbsCarry3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0 ** F)
+        (((EvmAsm.Evm64.divStackDispatchPostCallable sp
+          (sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+          (sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) **
+          (.x1 ↦ᵣ ((base + divCallOff) + 4))) **
+          (.x9 ↦ᵣ x9Out)) ** F)) :
+    EvmAsm.Rv64.cpsTripleWithin (EvmAsm.Evm64.unifiedDivBound + 1)
+      (base + wrapperEndOff) (base + resultSignFixOff) (sdivCodeV4 base)
+      (saveRaDivCallDispatchReadyPost vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+        v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 ** F)
+      (((saveRaDivCallCallablePostNoX9 vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
+        (.x9 ↦ᵣ x9Out)) ** F)) := by
+  let dividendAbsWord :=
+    sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+  let divisorAbsWord :=
+    sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+  let divisorSign := sdivAbsSign divisorTop
+  let divisorMask := sdivAbsMask divisorTop
+  let divisorSum0 := sdivAbsSum0 divisorLimb0 divisorTop
+  let divisorCarry0 := sdivAbsCarry0 divisorLimb0 divisorTop
+  let divisorSum1 := sdivAbsSum1 divisorLimb0 divisorLimb1 divisorTop
+  let divisorCarry1 := sdivAbsCarry1 divisorLimb0 divisorLimb1 divisorTop
+  let divisorSum2 := sdivAbsSum2 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+  let divisorCarry2 := sdivAbsCarry2 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+  let divisorSum3 := sdivAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+  let divisorCarry3 := sdivAbsCarry3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+  let resultSign := sdivDivCallResultSign dividendTop divisorTop
+  let signFrameNoX9 : EvmAsm.Rv64.Assertion :=
+    (.x8 ↦ᵣ resultSign) ** (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))
+  have hCallableFramed :=
+    evm_div_callable_v4_preserving_x1_x9out_exact_pre_divCode_body_framed_spec_in_sdivCodeV4
+      (F := signFrameNoX9 ** F)
+      sp base divisorSign x9Out ((base + divCallOff) + 4)
+      dividendAbsWord divisorAbsWord v2 v5 v6 divisorSum3 divisorMask divisorCarry3
+      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      nMem shiftMem jMem retMem dMem dloMem scratchUn0
+      (by
+        dsimp [dividendAbsWord, divisorAbsWord, divisorSum3, divisorMask,
+          divisorCarry3] at hStack ⊢
+        exact EvmAsm.Rv64.cpsTripleWithin_weaken (fun h hp => by
+          xperm_hyp hp) (fun h hp => by
+          xperm_hyp hp)
+          (EvmAsm.Rv64.cpsTripleWithin_frameR signFrameNoX9 (by
+            dsimp [signFrameNoX9]
+            pcFree) hStack))
+  have hCallableExit :
+      EvmAsm.Rv64.cpsTripleWithin (EvmAsm.Evm64.unifiedDivBound + 1)
+        (base + wrapperEndOff) (base + resultSignFixOff) (sdivCodeV4 base)
+        ((EvmAsm.Evm64.divModStackDispatchPreNoX1 sp dividendAbsWord divisorAbsWord
+          divisorSign ((base + divCallOff) + 4) v2 v5 v6 divisorSum3 divisorMask
+          divisorCarry3 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0 ** signFrameNoX9) ** F)
+        ((((EvmAsm.Evm64.divStackDispatchPostCallable sp dividendAbsWord divisorAbsWord **
+          (.x1 ↦ᵣ ((base + divCallOff) + 4))) ** signFrameNoX9) **
+          (.x9 ↦ᵣ x9Out)) ** F) := by
+    rw [← divCall_return_andn_one_eq_resultSignFixOff base hbase]
+    exact EvmAsm.Rv64.cpsTripleWithin_weaken (fun h hp => by
+      xperm_hyp hp) (fun h hp => by
+      xperm_hyp hp) hCallableFramed
+  exact EvmAsm.Rv64.cpsTripleWithin_weaken (fun h hp => by
+    rw [saveRaDivCallDispatchReadyPost_unfold] at hp
+    dsimp [dividendAbsWord, divisorAbsWord, divisorSign, divisorMask, divisorSum0,
+      divisorCarry0, divisorSum1, divisorCarry1, divisorSum2, divisorCarry2,
+      divisorSum3, divisorCarry3, resultSign, saveRaDivCallSignFrame,
+      sdivDivCallResultSign, sdivAbsSign, sdivAbsMask, sdivAbsSum0, sdivAbsCarry0,
+      sdivAbsSum1, sdivAbsCarry1, sdivAbsSum2, sdivAbsCarry2, sdivAbsSum3,
+      sdivAbsCarry3, signFrameNoX9] at hp ⊢
+    exact hp) (fun h hp => by
+    rw [saveRaDivCallCallablePostNoX9_unfold]
+    dsimp [dividendAbsWord, divisorAbsWord, divisorSign, resultSign,
+      signFrameNoX9, sdivDivCallResultSign, sdivAbsSign] at hp ⊢
+    exact hp) hCallableExit
+
 end EvmAsm.Evm64.SDiv.Compose


### PR DESCRIPTION
## Summary
- add divCode_noNop_v4_sub_div_callable_code_v4 for the full DIV v4 no-NOP body
- add DivMod and SDiv callable wrappers for already-framed divCode_noNop_v4 body proofs with separate x9 input/output

## Verification
- lake build EvmAsm.Evm64.DivMod.CallableV4Div
- lake build EvmAsm.Evm64.SDiv.Compose.DivCallExactCallable
- lake build EvmAsm.Evm64.DivMod
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/CallableV4Div.lean EvmAsm/Evm64/SDiv/Compose/DivCallExactCallable.lean

Stacked on #5400.