### PR TITLE
feat(sdiv): expose abs word limb projections

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/DivCallAbsComponents.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallAbsComponents.lean
@@ -72,6 +72,62 @@ theorem sdivAbsDivisorWord_eq_components
         | 3 => sdivAbsSum3 limb0 limb1 limb2 top := by
   rfl
 
+theorem sdivAbsDividendWord_getLimbN_0
+    (limb0 limb1 limb2 top : Word) :
+    (sdivAbsDividendWord limb0 limb1 limb2 top).getLimbN 0 =
+      sdivAbsSum0 limb0 top := by
+  rw [sdivAbsDividendWord_eq_components, EvmWord.getLimbN_lt _ 0 (by decide)]
+  exact EvmWord.getLimb_fromLimbs
+
+theorem sdivAbsDividendWord_getLimbN_1
+    (limb0 limb1 limb2 top : Word) :
+    (sdivAbsDividendWord limb0 limb1 limb2 top).getLimbN 1 =
+      sdivAbsSum1 limb0 limb1 top := by
+  rw [sdivAbsDividendWord_eq_components, EvmWord.getLimbN_lt _ 1 (by decide)]
+  exact EvmWord.getLimb_fromLimbs
+
+theorem sdivAbsDividendWord_getLimbN_2
+    (limb0 limb1 limb2 top : Word) :
+    (sdivAbsDividendWord limb0 limb1 limb2 top).getLimbN 2 =
+      sdivAbsSum2 limb0 limb1 limb2 top := by
+  rw [sdivAbsDividendWord_eq_components, EvmWord.getLimbN_lt _ 2 (by decide)]
+  exact EvmWord.getLimb_fromLimbs
+
+theorem sdivAbsDividendWord_getLimbN_3
+    (limb0 limb1 limb2 top : Word) :
+    (sdivAbsDividendWord limb0 limb1 limb2 top).getLimbN 3 =
+      sdivAbsSum3 limb0 limb1 limb2 top := by
+  rw [sdivAbsDividendWord_eq_components, EvmWord.getLimbN_lt _ 3 (by decide)]
+  exact EvmWord.getLimb_fromLimbs
+
+theorem sdivAbsDivisorWord_getLimbN_0
+    (limb0 limb1 limb2 top : Word) :
+    (sdivAbsDivisorWord limb0 limb1 limb2 top).getLimbN 0 =
+      sdivAbsSum0 limb0 top := by
+  rw [sdivAbsDivisorWord_eq_components, EvmWord.getLimbN_lt _ 0 (by decide)]
+  exact EvmWord.getLimb_fromLimbs
+
+theorem sdivAbsDivisorWord_getLimbN_1
+    (limb0 limb1 limb2 top : Word) :
+    (sdivAbsDivisorWord limb0 limb1 limb2 top).getLimbN 1 =
+      sdivAbsSum1 limb0 limb1 top := by
+  rw [sdivAbsDivisorWord_eq_components, EvmWord.getLimbN_lt _ 1 (by decide)]
+  exact EvmWord.getLimb_fromLimbs
+
+theorem sdivAbsDivisorWord_getLimbN_2
+    (limb0 limb1 limb2 top : Word) :
+    (sdivAbsDivisorWord limb0 limb1 limb2 top).getLimbN 2 =
+      sdivAbsSum2 limb0 limb1 limb2 top := by
+  rw [sdivAbsDivisorWord_eq_components, EvmWord.getLimbN_lt _ 2 (by decide)]
+  exact EvmWord.getLimb_fromLimbs
+
+theorem sdivAbsDivisorWord_getLimbN_3
+    (limb0 limb1 limb2 top : Word) :
+    (sdivAbsDivisorWord limb0 limb1 limb2 top).getLimbN 3 =
+      sdivAbsSum3 limb0 limb1 limb2 top := by
+  rw [sdivAbsDivisorWord_eq_components, EvmWord.getLimbN_lt _ 3 (by decide)]
+  exact EvmWord.getLimb_fromLimbs
+
 theorem sdivAbsDividendWord_evmWordIs_sp_components
     (sp limb0 limb1 limb2 top : Word) :
     evmWordIs sp (sdivAbsDividendWord limb0 limb1 limb2 top) =


### PR DESCRIPTION
## Summary
- add getLimbN projection lemmas for sdivAbsDividendWord and sdivAbsDivisorWord
- express each projection in terms of the existing sdivAbsSum0..3 component abbreviations
- prepare concrete SDIV N1 DIV-call handoffs that instantiate stack-level DivMod theorems with SDIV absolute words

## Verification
- lake build EvmAsm.Evm64.SDiv.Compose.DivCallAbsComponents
- lake build EvmAsm.Evm64.DivMod
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/DivCallAbsComponents.lean

Stacked on #5410.