### PR TITLE
feat(sdiv): name n1 v4 scratch handoff

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N1ExactNoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N1ExactNoNop.lean
@@ -795,6 +795,170 @@ theorem evm_div_n1_call_maxmaxmax_stack_spec_within_word_noNop_v4_preNoX1_callab
     cpsTripleWithin unifiedDivBound base (base + nopOff) (divCode_noNop_v4 base) P Q := by
   exact cpsTripleWithin_mono_nSteps (by unfold unifiedDivBound; decide) h
 
+/-- Unified-bound form of the N1 v4 call/max/max/max path with arbitrary
+    incoming `x9` and the v4-only scratch cell framed explicitly. -/
+theorem evm_div_n1_call_maxmaxmax_stack_spec_within_word_noNop_v4_preNoX1_callableExtra_x9In_unified
+    (sp base : Word) (a b : EvmWord)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old x9In : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (ha0 : a.getLimbN 0 = a0) (ha1 : a.getLimbN 1 = a1)
+    (ha2 : a.getLimbN 2 = a2) (ha3 : a.getLimbN 3 = a3)
+    (hb0 : b.getLimbN 0 = b0) (hb1 : b.getLimbN 1 = b1)
+    (hb2 : b.getLimbN 2 = b2) (hb3 : b.getLimbN 3 = b3)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1z : b1 = 0)
+    (hshift_nz : (clzResult b0).1 ≠ 0)
+    (halign : fullDivN1CallMaxmaxmaxExactInputAligned sp base
+      jMem (1 : Word) (fullDivN1Shift b0) (fullDivN1NormU a0 a1 a2 a3 b0).1
+      (a0 >>> ((fullDivN1AntiShift b0).toNat % 64)) v11Old (fullDivN1AntiShift b0)
+      a0 a1 a2 a3 b0 b1 b2 b3
+      (0 : Word) (0 : Word) (0 : Word) (0 : Word)
+      retMem dMem dloMem scratchUn0 scratchMem raVal)
+    (hbltu3 : isTrialN1_j3 true a3 b0)
+    (hbltu2 : ¬BitVec.ult
+      (loopN1CallMaxmaxmaxR3
+        (fullDivN1NormV b0 b1 b2 b3).1
+        (fullDivN1NormV b0 b1 b2 b3).2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.2
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
+        0 0 0).2.1
+      (fullDivN1NormV b0 b1 b2 b3).1)
+    (hbltu1 : ¬BitVec.ult
+      (loopN1CallMaxmaxmaxR2
+        (fullDivN1NormV b0 b1 b2 b3).1
+        (fullDivN1NormV b0 b1 b2 b3).2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.2
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
+        0 0 0
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.1).2.1
+      (fullDivN1NormV b0 b1 b2 b3).1)
+    (hbltu0 : ¬BitVec.ult
+      (loopN1CallMaxmaxmaxR1
+        (fullDivN1NormV b0 b1 b2 b3).1
+        (fullDivN1NormV b0 b1 b2 b3).2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.2
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
+        0 0 0
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.1
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.1).2.1
+      (fullDivN1NormV b0 b1 b2 b3).1)
+    (hcarry2 : Carry2NzAll
+      (fullDivN1NormV b0 b1 b2 b3).1
+      (fullDivN1NormV b0 b1 b2 b3).2.1
+      (fullDivN1NormV b0 b1 b2 b3).2.2.1
+      (fullDivN1NormV b0 b1 b2 b3).2.2.2)
+    (hdiv0 : (EvmWord.div a b).getLimbN 0 =
+      (iterN1Max
+        (fullDivN1NormV b0 b1 b2 b3).1
+        (fullDivN1NormV b0 b1 b2 b3).2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.2
+        (fullDivN1NormU a0 a1 a2 a3 b0).1
+        (loopN1CallMaxmaxmaxR1
+          (fullDivN1NormV b0 b1 b2 b3).1
+          (fullDivN1NormV b0 b1 b2 b3).2.1
+          (fullDivN1NormV b0 b1 b2 b3).2.2.1
+          (fullDivN1NormV b0 b1 b2 b3).2.2.2
+          (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1
+          (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
+          0 0 0
+          (fullDivN1NormU a0 a1 a2 a3 b0).2.2.1
+          (fullDivN1NormU a0 a1 a2 a3 b0).2.1).2.1
+        (loopN1CallMaxmaxmaxR1
+          (fullDivN1NormV b0 b1 b2 b3).1
+          (fullDivN1NormV b0 b1 b2 b3).2.1
+          (fullDivN1NormV b0 b1 b2 b3).2.2.1
+          (fullDivN1NormV b0 b1 b2 b3).2.2.2
+          (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1
+          (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
+          0 0 0
+          (fullDivN1NormU a0 a1 a2 a3 b0).2.2.1
+          (fullDivN1NormU a0 a1 a2 a3 b0).2.1).2.2.1
+        (loopN1CallMaxmaxmaxR1
+          (fullDivN1NormV b0 b1 b2 b3).1
+          (fullDivN1NormV b0 b1 b2 b3).2.1
+          (fullDivN1NormV b0 b1 b2 b3).2.2.1
+          (fullDivN1NormV b0 b1 b2 b3).2.2.2
+          (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1
+          (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
+          0 0 0
+          (fullDivN1NormU a0 a1 a2 a3 b0).2.2.1
+          (fullDivN1NormU a0 a1 a2 a3 b0).2.1).2.2.2.1
+        (loopN1CallMaxmaxmaxR1
+          (fullDivN1NormV b0 b1 b2 b3).1
+          (fullDivN1NormV b0 b1 b2 b3).2.1
+          (fullDivN1NormV b0 b1 b2 b3).2.2.1
+          (fullDivN1NormV b0 b1 b2 b3).2.2.2
+          (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1
+          (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
+          0 0 0
+          (fullDivN1NormU a0 a1 a2 a3 b0).2.2.1
+          (fullDivN1NormU a0 a1 a2 a3 b0).2.1).2.2.2.2.1).1)
+    (hdiv1 : (EvmWord.div a b).getLimbN 1 =
+      (loopN1CallMaxmaxmaxR1
+        (fullDivN1NormV b0 b1 b2 b3).1
+        (fullDivN1NormV b0 b1 b2 b3).2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.2
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
+        0 0 0
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.1
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.1).1)
+    (hdiv2 : (EvmWord.div a b).getLimbN 2 =
+      (loopN1CallMaxmaxmaxR2
+        (fullDivN1NormV b0 b1 b2 b3).1
+        (fullDivN1NormV b0 b1 b2 b3).2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.2
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
+        0 0 0
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.1).1)
+    (hdiv3 : (EvmWord.div a b).getLimbN 3 =
+      (loopN1CallMaxmaxmaxR3
+        (fullDivN1NormV b0 b1 b2 b3).1
+        (fullDivN1NormV b0 b1 b2 b3).2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.2
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
+        0 0 0).1) :
+    cpsTripleWithin unifiedDivBound base (base + nopOff) (divCode_noNop_v4 base)
+      (divModStackDispatchPreNoX1 sp a b x9In raVal
+        ((clzResult b0).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (((divStackDispatchPostCallable sp a b ** (.x1 ↦ᵣ raVal)) **
+        (.x9 ↦ᵣ (signExtend12 4095 : Word))) **
+       ((sp + signExtend12 3936) ↦ₘ
+        divKTrialCallV4ScratchOut
+          (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
+          (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1
+          (fullDivN1NormV b0 b1 b2 b3).1 scratchMem)) := by
+  exact
+    evm_div_n1_call_maxmaxmax_stack_spec_within_word_noNop_v4_preNoX1_callableExtra_bound_unified
+      base
+      (evm_div_n1_call_maxmaxmax_stack_spec_within_word_noNop_v4_preNoX1_callableExtra_x9In
+        sp base a b
+        a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old x9In
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+        raVal
+        ha0 ha1 ha2 ha3 hb0 hb1 hb2 hb3 hbnz hb3z hb2z hb1z
+        hshift_nz halign hbltu3 hbltu2 hbltu1 hbltu0 hcarry2
+        hdiv0 hdiv1 hdiv2 hdiv3)
+
 /-- Recombine the split no-`x1` full-path post with separate `x1` ownership. -/
 theorem fullDivN1UnifiedPostNoX1_frame_to_fullDivN1UnifiedPost
     (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)

--- a/EvmAsm/Evm64/SDiv.lean
+++ b/EvmAsm/Evm64/SDiv.lean
@@ -57,6 +57,7 @@ import EvmAsm.Evm64.SDiv.Compose.DivCallPostPcFreeBasics
 import EvmAsm.Evm64.SDiv.Compose.DivCallExactCallable
 import EvmAsm.Evm64.SDiv.Compose.DivCallFramedCallable
 import EvmAsm.Evm64.SDiv.Compose.DivCallExactHandoff
+import EvmAsm.Evm64.SDiv.Compose.DivCallN1V4Handoff
 import EvmAsm.Evm64.SDiv.Compose.DivCallBzeroHandoff
 import EvmAsm.Evm64.SDiv.Compose.DivCallBzeroCallableHandoff
 import EvmAsm.Evm64.SDiv.Compose.DivCallExactResultSignFixHandoff

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallN1V4Handoff.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallN1V4Handoff.lean
@@ -9,6 +9,27 @@ import EvmAsm.Evm64.SDiv.Compose.DivCallExactHandoff
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
+/-- Normalized N1 dividend tuple for SDIV's absolute-value operands. -/
+abbrev sdivN1V4NormU
+    (dividendLimb0 dividendLimb1 dividendLimb2 dividendTop divisorLimb0 divisorTop : Word) :
+    Word × Word × Word × Word × Word :=
+  EvmAsm.Evm64.fullDivN1NormU
+    (sdivAbsSum0 dividendLimb0 dividendTop)
+    (sdivAbsSum1 dividendLimb0 dividendLimb1 dividendTop)
+    (sdivAbsSum2 dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+    (sdivAbsSum3 dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+    (sdivAbsSum0 divisorLimb0 divisorTop)
+
+/-- Normalized N1 divisor tuple for SDIV's absolute-value operands. -/
+abbrev sdivN1V4NormV
+    (divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word) :
+    Word × Word × Word × Word :=
+  EvmAsm.Evm64.fullDivN1NormV
+    (sdivAbsSum0 divisorLimb0 divisorTop)
+    (sdivAbsSum1 divisorLimb0 divisorLimb1 divisorTop)
+    (sdivAbsSum2 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+    (sdivAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+
 /-- The v4-only trial-call scratch cell after the SDIV N1 call/max/max/max
     DIV path, expressed over SDIV's absolute-value divisor limbs. -/
 abbrev sdivN1V4ScratchOut

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallN1V4Handoff.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallN1V4Handoff.lean
@@ -37,23 +37,11 @@ abbrev sdivN1V4ScratchOut
       divisorLimb0 divisorLimb1 divisorLimb2 divisorTop scratchMem : Word) :
     Word :=
   EvmAsm.Evm64.divKTrialCallV4ScratchOut
-    (EvmAsm.Evm64.fullDivN1NormU
-      (sdivAbsSum0 dividendLimb0 dividendTop)
-      (sdivAbsSum1 dividendLimb0 dividendLimb1 dividendTop)
-      (sdivAbsSum2 dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
-      (sdivAbsSum3 dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
-      (sdivAbsSum0 divisorLimb0 divisorTop)).2.2.2.2
-    (EvmAsm.Evm64.fullDivN1NormU
-      (sdivAbsSum0 dividendLimb0 dividendTop)
-      (sdivAbsSum1 dividendLimb0 dividendLimb1 dividendTop)
-      (sdivAbsSum2 dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
-      (sdivAbsSum3 dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
-      (sdivAbsSum0 divisorLimb0 divisorTop)).2.2.2.1
-    (EvmAsm.Evm64.fullDivN1NormV
-      (sdivAbsSum0 divisorLimb0 divisorTop)
-      (sdivAbsSum1 divisorLimb0 divisorLimb1 divisorTop)
-      (sdivAbsSum2 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
-      (sdivAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)).1
+    (sdivN1V4NormU dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorTop).2.2.2.2
+    (sdivN1V4NormU dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorTop).2.2.2.1
+    (sdivN1V4NormV divisorLimb0 divisorLimb1 divisorLimb2 divisorTop).1
     scratchMem
 
 /-- SDIV absolute-limb spelling of the N1 `j = 1` non-borrow branch

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallN1V4Handoff.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallN1V4Handoff.lean
@@ -1,0 +1,67 @@
+/-
+  EvmAsm.Evm64.SDiv.Compose.DivCallN1V4Handoff
+
+  N1/v4-shaped exact handoff wrappers for the SDIV div-call path.
+-/
+
+import EvmAsm.Evm64.SDiv.Compose.DivCallExactHandoff
+
+namespace EvmAsm.Evm64.SDiv.Compose
+
+/-- Exact SDIV div-call handoff specialized to the v4 scratch frame shape
+    produced by the N1 call/max/max/max no-NOP DIV path. -/
+theorem saveRaDivCallDispatchReadyPost_exact_callable_x9out_divCode_n1_v4Scratch_spec_in_sdivCodeV4
+    (vRa sp base
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+      v2 v5 v6 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratchUn0 scratchMem scratchOut : Word)
+    (hbase : base &&& 1 = 0)
+    (hStack :
+      EvmAsm.Rv64.cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
+        (base + wrapperEndOff)
+        ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
+        (EvmAsm.Evm64.divCode_noNop_v4 (base + wrapperEndOff))
+        (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp
+          (sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+          (sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          (sdivAbsSign divisorTop) ((base + divCallOff) + 4) v2 v5 v6
+          (sdivAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          (sdivAbsMask divisorTop)
+          (sdivAbsCarry3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+         ((sp + EvmAsm.Rv64.signExtend12 3936) ↦ₘ scratchMem))
+        (((EvmAsm.Evm64.divStackDispatchPostCallable sp
+          (sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+          (sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) **
+          (.x1 ↦ᵣ ((base + divCallOff) + 4))) **
+          (.x9 ↦ᵣ (EvmAsm.Rv64.signExtend12 4095 : Word))) **
+         ((sp + EvmAsm.Rv64.signExtend12 3936) ↦ₘ scratchOut))) :
+    EvmAsm.Rv64.cpsTripleWithin (EvmAsm.Evm64.unifiedDivBound + 1)
+      (base + wrapperEndOff) (base + resultSignFixOff) (sdivCodeV4 base)
+      (saveRaDivCallDispatchReadyPost vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+        v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + EvmAsm.Rv64.signExtend12 3936) ↦ₘ scratchMem))
+      (((saveRaDivCallCallablePostNoX9 vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
+        (.x9 ↦ᵣ (EvmAsm.Rv64.signExtend12 4095 : Word))) **
+       ((sp + EvmAsm.Rv64.signExtend12 3936) ↦ₘ scratchOut))) := by
+  exact
+    saveRaDivCallDispatchReadyPost_exact_callable_x9out_divCode_frame_transform_spec_in_sdivCodeV4
+      (FPre := ((sp + EvmAsm.Rv64.signExtend12 3936) ↦ₘ scratchMem))
+      (FPost := ((sp + EvmAsm.Rv64.signExtend12 3936) ↦ₘ scratchOut))
+      vRa sp base
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+      v2 v5 v6 (EvmAsm.Rv64.signExtend12 4095 : Word)
+      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0
+      hbase hStack
+
+end EvmAsm.Evm64.SDiv.Compose

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallN1V4Handoff.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallN1V4Handoff.lean
@@ -4,6 +4,7 @@
   N1/v4-shaped exact handoff wrappers for the SDIV div-call path.
 -/
 
+import EvmAsm.Evm64.DivMod.Spec.N1ExactNoNop
 import EvmAsm.Evm64.SDiv.Compose.DivCallExactHandoff
 
 namespace EvmAsm.Evm64.SDiv.Compose
@@ -63,5 +64,63 @@ theorem saveRaDivCallDispatchReadyPost_exact_callable_x9out_divCode_n1_v4Scratch
       q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
       shiftMem nMem jMem retMem dMem dloMem scratchUn0
       hbase hStack
+
+/-- Exact SDIV div-call handoff specialized to the N1/v4 scratch frame shape,
+    accepting the N1 path's native bound and lifting it to `unifiedDivBound`. -/
+theorem saveRaDivCallDispatchReadyPost_exact_callable_x9out_divCode_n1_v4Scratch_bound_spec_in_sdivCodeV4
+    (vRa sp base
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+      v2 v5 v6 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratchUn0 scratchMem scratchOut : Word)
+    (hbase : base &&& 1 = 0)
+    (hStack :
+      EvmAsm.Rv64.cpsTripleWithin
+        ((8 + 21 + 24 + 4 + 21 + 21 + 4 + 780) + (2 + 23 + 10))
+        (base + wrapperEndOff)
+        ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
+        (EvmAsm.Evm64.divCode_noNop_v4 (base + wrapperEndOff))
+        (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp
+          (sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+          (sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          (sdivAbsSign divisorTop) ((base + divCallOff) + 4) v2 v5 v6
+          (sdivAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          (sdivAbsMask divisorTop)
+          (sdivAbsCarry3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+         ((sp + EvmAsm.Rv64.signExtend12 3936) ↦ₘ scratchMem))
+        (((EvmAsm.Evm64.divStackDispatchPostCallable sp
+          (sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+          (sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) **
+          (.x1 ↦ᵣ ((base + divCallOff) + 4))) **
+          (.x9 ↦ᵣ (EvmAsm.Rv64.signExtend12 4095 : Word))) **
+         ((sp + EvmAsm.Rv64.signExtend12 3936) ↦ₘ scratchOut))) :
+    EvmAsm.Rv64.cpsTripleWithin (EvmAsm.Evm64.unifiedDivBound + 1)
+      (base + wrapperEndOff) (base + resultSignFixOff) (sdivCodeV4 base)
+      (saveRaDivCallDispatchReadyPost vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+        v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + EvmAsm.Rv64.signExtend12 3936) ↦ₘ scratchMem))
+      (((saveRaDivCallCallablePostNoX9 vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
+        (.x9 ↦ᵣ (EvmAsm.Rv64.signExtend12 4095 : Word))) **
+       ((sp + EvmAsm.Rv64.signExtend12 3936) ↦ₘ scratchOut))) := by
+  apply
+    saveRaDivCallDispatchReadyPost_exact_callable_x9out_divCode_n1_v4Scratch_spec_in_sdivCodeV4
+      vRa sp base
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+      v2 v5 v6
+      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 scratchMem scratchOut
+      hbase
+  exact
+    EvmAsm.Evm64.evm_div_n1_call_maxmaxmax_stack_spec_within_word_noNop_v4_preNoX1_callableExtra_bound_unified
+      (base + wrapperEndOff) hStack
 
 end EvmAsm.Evm64.SDiv.Compose

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallN1V4Handoff.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallN1V4Handoff.lean
@@ -9,6 +9,32 @@ import EvmAsm.Evm64.SDiv.Compose.DivCallExactHandoff
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
+/-- The v4-only trial-call scratch cell after the SDIV N1 call/max/max/max
+    DIV path, expressed over SDIV's absolute-value divisor limbs. -/
+abbrev sdivN1V4ScratchOut
+    (dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop scratchMem : Word) :
+    Word :=
+  EvmAsm.Evm64.divKTrialCallV4ScratchOut
+    (EvmAsm.Evm64.fullDivN1NormU
+      (sdivAbsSum0 dividendLimb0 dividendTop)
+      (sdivAbsSum1 dividendLimb0 dividendLimb1 dividendTop)
+      (sdivAbsSum2 dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+      (sdivAbsSum3 dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+      (sdivAbsSum0 divisorLimb0 divisorTop)).2.2.2.2
+    (EvmAsm.Evm64.fullDivN1NormU
+      (sdivAbsSum0 dividendLimb0 dividendTop)
+      (sdivAbsSum1 dividendLimb0 dividendLimb1 dividendTop)
+      (sdivAbsSum2 dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+      (sdivAbsSum3 dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+      (sdivAbsSum0 divisorLimb0 divisorTop)).2.2.2.1
+    (EvmAsm.Evm64.fullDivN1NormV
+      (sdivAbsSum0 divisorLimb0 divisorTop)
+      (sdivAbsSum1 divisorLimb0 divisorLimb1 divisorTop)
+      (sdivAbsSum2 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+      (sdivAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)).1
+    scratchMem
+
 /-- Exact SDIV div-call handoff specialized to the v4 scratch frame shape
     produced by the N1 call/max/max/max no-NOP DIV path. -/
 theorem saveRaDivCallDispatchReadyPost_exact_callable_x9out_divCode_n1_v4Scratch_spec_in_sdivCodeV4
@@ -63,6 +89,66 @@ theorem saveRaDivCallDispatchReadyPost_exact_callable_x9out_divCode_n1_v4Scratch
       v2 v5 v6 (EvmAsm.Rv64.signExtend12 4095 : Word)
       q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
       shiftMem nMem jMem retMem dMem dloMem scratchUn0
+      hbase hStack
+
+/-- Exact SDIV div-call handoff specialized to the named N1/v4 scratch output
+    produced by the call/max/max/max DIV path. -/
+theorem saveRaDivCallDispatchReadyPost_exact_callable_x9out_divCode_n1_v4ScratchOut_spec_in_sdivCodeV4
+    (vRa sp base
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+      v2 v5 v6 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hbase : base &&& 1 = 0)
+    (hStack :
+      EvmAsm.Rv64.cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
+        (base + wrapperEndOff)
+        ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
+        (EvmAsm.Evm64.divCode_noNop_v4 (base + wrapperEndOff))
+        (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp
+          (sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+          (sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          (sdivAbsSign divisorTop) ((base + divCallOff) + 4) v2 v5 v6
+          (sdivAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          (sdivAbsMask divisorTop)
+          (sdivAbsCarry3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+         ((sp + EvmAsm.Rv64.signExtend12 3936) ↦ₘ scratchMem))
+        (((EvmAsm.Evm64.divStackDispatchPostCallable sp
+          (sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+          (sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) **
+          (.x1 ↦ᵣ ((base + divCallOff) + 4))) **
+          (.x9 ↦ᵣ (EvmAsm.Rv64.signExtend12 4095 : Word))) **
+         ((sp + EvmAsm.Rv64.signExtend12 3936) ↦ₘ
+          sdivN1V4ScratchOut dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+            divisorLimb0 divisorLimb1 divisorLimb2 divisorTop scratchMem))) :
+    EvmAsm.Rv64.cpsTripleWithin (EvmAsm.Evm64.unifiedDivBound + 1)
+      (base + wrapperEndOff) (base + resultSignFixOff) (sdivCodeV4 base)
+      (saveRaDivCallDispatchReadyPost vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+        v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + EvmAsm.Rv64.signExtend12 3936) ↦ₘ scratchMem))
+      (((saveRaDivCallCallablePostNoX9 vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
+        (.x9 ↦ᵣ (EvmAsm.Rv64.signExtend12 4095 : Word))) **
+       ((sp + EvmAsm.Rv64.signExtend12 3936) ↦ₘ
+        sdivN1V4ScratchOut dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+          divisorLimb0 divisorLimb1 divisorLimb2 divisorTop scratchMem))) := by
+  exact
+    saveRaDivCallDispatchReadyPost_exact_callable_x9out_divCode_n1_v4Scratch_spec_in_sdivCodeV4
+      vRa sp base
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+      v2 v5 v6
+      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 scratchMem
+      (sdivN1V4ScratchOut dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop scratchMem)
       hbase hStack
 
 /-- Exact SDIV div-call handoff specialized to the N1/v4 scratch frame shape,

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallN1V4Handoff.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallN1V4Handoff.lean
@@ -35,6 +35,116 @@ abbrev sdivN1V4ScratchOut
       (sdivAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)).1
     scratchMem
 
+/-- SDIV absolute-limb spelling of the N1 `j = 1` non-borrow branch
+    condition used by the call/max/max/max DIV path. -/
+abbrev sdivN1V4Hbltu1
+    (dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word) : Prop :=
+  ¬BitVec.ult
+    (EvmAsm.Evm64.loopN1CallMaxmaxmaxR2
+      (EvmAsm.Evm64.fullDivN1NormV
+        (sdivAbsSum0 divisorLimb0 divisorTop)
+        (sdivAbsSum1 divisorLimb0 divisorLimb1 divisorTop)
+        (sdivAbsSum2 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+        (sdivAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)).1
+      (EvmAsm.Evm64.fullDivN1NormV
+        (sdivAbsSum0 divisorLimb0 divisorTop)
+        (sdivAbsSum1 divisorLimb0 divisorLimb1 divisorTop)
+        (sdivAbsSum2 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+        (sdivAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)).2.1
+      (EvmAsm.Evm64.fullDivN1NormV
+        (sdivAbsSum0 divisorLimb0 divisorTop)
+        (sdivAbsSum1 divisorLimb0 divisorLimb1 divisorTop)
+        (sdivAbsSum2 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+        (sdivAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)).2.2.1
+      (EvmAsm.Evm64.fullDivN1NormV
+        (sdivAbsSum0 divisorLimb0 divisorTop)
+        (sdivAbsSum1 divisorLimb0 divisorLimb1 divisorTop)
+        (sdivAbsSum2 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+        (sdivAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)).2.2.2
+      (EvmAsm.Evm64.fullDivN1NormU
+        (sdivAbsSum0 dividendLimb0 dividendTop)
+        (sdivAbsSum1 dividendLimb0 dividendLimb1 dividendTop)
+        (sdivAbsSum2 dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+        (sdivAbsSum3 dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+        (sdivAbsSum0 divisorLimb0 divisorTop)).2.2.2.1
+      (EvmAsm.Evm64.fullDivN1NormU
+        (sdivAbsSum0 dividendLimb0 dividendTop)
+        (sdivAbsSum1 dividendLimb0 dividendLimb1 dividendTop)
+        (sdivAbsSum2 dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+        (sdivAbsSum3 dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+        (sdivAbsSum0 divisorLimb0 divisorTop)).2.2.2.2
+      0 0 0
+      (EvmAsm.Evm64.fullDivN1NormU
+        (sdivAbsSum0 dividendLimb0 dividendTop)
+        (sdivAbsSum1 dividendLimb0 dividendLimb1 dividendTop)
+        (sdivAbsSum2 dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+        (sdivAbsSum3 dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+        (sdivAbsSum0 divisorLimb0 divisorTop)).2.2.1).2.1
+    (EvmAsm.Evm64.fullDivN1NormV
+      (sdivAbsSum0 divisorLimb0 divisorTop)
+      (sdivAbsSum1 divisorLimb0 divisorLimb1 divisorTop)
+      (sdivAbsSum2 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+      (sdivAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)).1
+
+/-- SDIV absolute-limb spelling of the N1 `j = 0` non-borrow branch
+    condition used by the call/max/max/max DIV path. -/
+abbrev sdivN1V4Hbltu0
+    (dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word) : Prop :=
+  ¬BitVec.ult
+    (EvmAsm.Evm64.loopN1CallMaxmaxmaxR1
+      (EvmAsm.Evm64.fullDivN1NormV
+        (sdivAbsSum0 divisorLimb0 divisorTop)
+        (sdivAbsSum1 divisorLimb0 divisorLimb1 divisorTop)
+        (sdivAbsSum2 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+        (sdivAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)).1
+      (EvmAsm.Evm64.fullDivN1NormV
+        (sdivAbsSum0 divisorLimb0 divisorTop)
+        (sdivAbsSum1 divisorLimb0 divisorLimb1 divisorTop)
+        (sdivAbsSum2 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+        (sdivAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)).2.1
+      (EvmAsm.Evm64.fullDivN1NormV
+        (sdivAbsSum0 divisorLimb0 divisorTop)
+        (sdivAbsSum1 divisorLimb0 divisorLimb1 divisorTop)
+        (sdivAbsSum2 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+        (sdivAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)).2.2.1
+      (EvmAsm.Evm64.fullDivN1NormV
+        (sdivAbsSum0 divisorLimb0 divisorTop)
+        (sdivAbsSum1 divisorLimb0 divisorLimb1 divisorTop)
+        (sdivAbsSum2 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+        (sdivAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)).2.2.2
+      (EvmAsm.Evm64.fullDivN1NormU
+        (sdivAbsSum0 dividendLimb0 dividendTop)
+        (sdivAbsSum1 dividendLimb0 dividendLimb1 dividendTop)
+        (sdivAbsSum2 dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+        (sdivAbsSum3 dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+        (sdivAbsSum0 divisorLimb0 divisorTop)).2.2.2.1
+      (EvmAsm.Evm64.fullDivN1NormU
+        (sdivAbsSum0 dividendLimb0 dividendTop)
+        (sdivAbsSum1 dividendLimb0 dividendLimb1 dividendTop)
+        (sdivAbsSum2 dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+        (sdivAbsSum3 dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+        (sdivAbsSum0 divisorLimb0 divisorTop)).2.2.2.2
+      0 0 0
+      (EvmAsm.Evm64.fullDivN1NormU
+        (sdivAbsSum0 dividendLimb0 dividendTop)
+        (sdivAbsSum1 dividendLimb0 dividendLimb1 dividendTop)
+        (sdivAbsSum2 dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+        (sdivAbsSum3 dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+        (sdivAbsSum0 divisorLimb0 divisorTop)).2.2.1
+      (EvmAsm.Evm64.fullDivN1NormU
+        (sdivAbsSum0 dividendLimb0 dividendTop)
+        (sdivAbsSum1 dividendLimb0 dividendLimb1 dividendTop)
+        (sdivAbsSum2 dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+        (sdivAbsSum3 dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+        (sdivAbsSum0 divisorLimb0 divisorTop)).2.1).2.1
+    (EvmAsm.Evm64.fullDivN1NormV
+      (sdivAbsSum0 divisorLimb0 divisorTop)
+      (sdivAbsSum1 divisorLimb0 divisorLimb1 divisorTop)
+      (sdivAbsSum2 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+      (sdivAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)).1
+
 /-- Exact SDIV div-call handoff specialized to the v4 scratch frame shape
     produced by the N1 call/max/max/max no-NOP DIV path. -/
 theorem saveRaDivCallDispatchReadyPost_exact_callable_x9out_divCode_n1_v4Scratch_spec_in_sdivCodeV4
@@ -237,6 +347,12 @@ theorem saveRaDivCallDispatchReadyPost_exact_callable_x9out_divCode_n1_v4_abs_sp
         (sdivAbsSum1 divisorLimb0 divisorLimb1 divisorTop)
         (sdivAbsSum2 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
         (sdivAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)).1)
+    (_hbltu1 :
+      sdivN1V4Hbltu1 dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+    (_hbltu0 :
+      sdivN1V4Hbltu0 dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
     (_hcarry2 : EvmAsm.Evm64.Carry2NzAll
       (EvmAsm.Evm64.fullDivN1NormV
         (sdivAbsSum0 divisorLimb0 divisorTop)

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallN1V4Handoff.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallN1V4Handoff.lean
@@ -151,6 +151,161 @@ theorem saveRaDivCallDispatchReadyPost_exact_callable_x9out_divCode_n1_v4Scratch
         divisorLimb0 divisorLimb1 divisorLimb2 divisorTop scratchMem)
       hbase hStack
 
+/-- Concrete N1 call/max/max/max SDIV handoff over the absolute-value
+    dividend and divisor words, using the v4 scratch-output postcondition. -/
+theorem saveRaDivCallDispatchReadyPost_exact_callable_x9out_divCode_n1_v4_abs_spec_in_sdivCodeV4
+    (vRa sp base
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+      v2 v5 v6 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hbase : base &&& 1 = 0)
+    (_hbnz :
+      sdivAbsSum0 divisorLimb0 divisorTop |||
+        sdivAbsSum1 divisorLimb0 divisorLimb1 divisorTop |||
+        sdivAbsSum2 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop |||
+        sdivAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop ≠ 0)
+    (_hb3z : sdivAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop = 0)
+    (_hb2z : sdivAbsSum2 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop = 0)
+    (_hb1z : sdivAbsSum1 divisorLimb0 divisorLimb1 divisorTop = 0)
+    (_hshift_nz : (EvmAsm.Evm64.clzResult (sdivAbsSum0 divisorLimb0 divisorTop)).1 ≠ 0)
+    (_halign : EvmAsm.Evm64.fullDivN1CallMaxmaxmaxExactInputAligned sp
+      (base + wrapperEndOff) jMem (1 : Word)
+      (EvmAsm.Evm64.fullDivN1Shift (sdivAbsSum0 divisorLimb0 divisorTop))
+      (EvmAsm.Evm64.fullDivN1NormU
+        (sdivAbsSum0 dividendLimb0 dividendTop)
+        (sdivAbsSum1 dividendLimb0 dividendLimb1 dividendTop)
+        (sdivAbsSum2 dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+        (sdivAbsSum3 dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+        (sdivAbsSum0 divisorLimb0 divisorTop)).1
+      (sdivAbsSum0 dividendLimb0 dividendTop >>>
+        ((EvmAsm.Evm64.fullDivN1AntiShift
+          (sdivAbsSum0 divisorLimb0 divisorTop)).toNat % 64))
+      (sdivAbsCarry3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+      (EvmAsm.Evm64.fullDivN1AntiShift (sdivAbsSum0 divisorLimb0 divisorTop))
+      (sdivAbsSum0 dividendLimb0 dividendTop)
+      (sdivAbsSum1 dividendLimb0 dividendLimb1 dividendTop)
+      (sdivAbsSum2 dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+      (sdivAbsSum3 dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+      (sdivAbsSum0 divisorLimb0 divisorTop)
+      (sdivAbsSum1 divisorLimb0 divisorLimb1 divisorTop)
+      (sdivAbsSum2 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+      (sdivAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+      (0 : Word) (0 : Word) (0 : Word) (0 : Word)
+      retMem dMem dloMem scratchUn0 scratchMem ((base + divCallOff) + 4))
+    (_hbltu3 : EvmAsm.Evm64.isTrialN1_j3 true
+      (sdivAbsSum3 dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+      (sdivAbsSum0 divisorLimb0 divisorTop))
+    (_hbltu2 : ¬BitVec.ult
+      (EvmAsm.Evm64.loopN1CallMaxmaxmaxR3
+        (EvmAsm.Evm64.fullDivN1NormV
+          (sdivAbsSum0 divisorLimb0 divisorTop)
+          (sdivAbsSum1 divisorLimb0 divisorLimb1 divisorTop)
+          (sdivAbsSum2 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          (sdivAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)).1
+        (EvmAsm.Evm64.fullDivN1NormV
+          (sdivAbsSum0 divisorLimb0 divisorTop)
+          (sdivAbsSum1 divisorLimb0 divisorLimb1 divisorTop)
+          (sdivAbsSum2 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          (sdivAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)).2.1
+        (EvmAsm.Evm64.fullDivN1NormV
+          (sdivAbsSum0 divisorLimb0 divisorTop)
+          (sdivAbsSum1 divisorLimb0 divisorLimb1 divisorTop)
+          (sdivAbsSum2 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          (sdivAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)).2.2.1
+        (EvmAsm.Evm64.fullDivN1NormV
+          (sdivAbsSum0 divisorLimb0 divisorTop)
+          (sdivAbsSum1 divisorLimb0 divisorLimb1 divisorTop)
+          (sdivAbsSum2 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          (sdivAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)).2.2.2
+        (EvmAsm.Evm64.fullDivN1NormU
+          (sdivAbsSum0 dividendLimb0 dividendTop)
+          (sdivAbsSum1 dividendLimb0 dividendLimb1 dividendTop)
+          (sdivAbsSum2 dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+          (sdivAbsSum3 dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+          (sdivAbsSum0 divisorLimb0 divisorTop)).2.2.2.1
+        (EvmAsm.Evm64.fullDivN1NormU
+          (sdivAbsSum0 dividendLimb0 dividendTop)
+          (sdivAbsSum1 dividendLimb0 dividendLimb1 dividendTop)
+          (sdivAbsSum2 dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+          (sdivAbsSum3 dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+          (sdivAbsSum0 divisorLimb0 divisorTop)).2.2.2.2
+        0 0 0).2.1
+      (EvmAsm.Evm64.fullDivN1NormV
+        (sdivAbsSum0 divisorLimb0 divisorTop)
+        (sdivAbsSum1 divisorLimb0 divisorLimb1 divisorTop)
+        (sdivAbsSum2 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+        (sdivAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)).1)
+    (_hcarry2 : EvmAsm.Evm64.Carry2NzAll
+      (EvmAsm.Evm64.fullDivN1NormV
+        (sdivAbsSum0 divisorLimb0 divisorTop)
+        (sdivAbsSum1 divisorLimb0 divisorLimb1 divisorTop)
+        (sdivAbsSum2 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+        (sdivAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)).1
+      (EvmAsm.Evm64.fullDivN1NormV
+        (sdivAbsSum0 divisorLimb0 divisorTop)
+        (sdivAbsSum1 divisorLimb0 divisorLimb1 divisorTop)
+        (sdivAbsSum2 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+        (sdivAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)).2.1
+      (EvmAsm.Evm64.fullDivN1NormV
+        (sdivAbsSum0 divisorLimb0 divisorTop)
+        (sdivAbsSum1 divisorLimb0 divisorLimb1 divisorTop)
+        (sdivAbsSum2 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+        (sdivAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)).2.2.1
+      (EvmAsm.Evm64.fullDivN1NormV
+        (sdivAbsSum0 divisorLimb0 divisorTop)
+        (sdivAbsSum1 divisorLimb0 divisorLimb1 divisorTop)
+        (sdivAbsSum2 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+        (sdivAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)).2.2.2)
+    (hStack :
+      EvmAsm.Rv64.cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
+        (base + wrapperEndOff)
+        ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
+        (EvmAsm.Evm64.divCode_noNop_v4 (base + wrapperEndOff))
+        (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp
+          (sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+          (sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          (sdivAbsSign divisorTop) ((base + divCallOff) + 4) v2 v5 v6
+          (sdivAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          (sdivAbsMask divisorTop)
+          (sdivAbsCarry3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+         ((sp + EvmAsm.Rv64.signExtend12 3936) ↦ₘ scratchMem))
+        (((EvmAsm.Evm64.divStackDispatchPostCallable sp
+          (sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+          (sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) **
+          (.x1 ↦ᵣ ((base + divCallOff) + 4))) **
+          (.x9 ↦ᵣ (EvmAsm.Rv64.signExtend12 4095 : Word))) **
+         ((sp + EvmAsm.Rv64.signExtend12 3936) ↦ₘ
+          sdivN1V4ScratchOut dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+            divisorLimb0 divisorLimb1 divisorLimb2 divisorTop scratchMem))) :
+    EvmAsm.Rv64.cpsTripleWithin (EvmAsm.Evm64.unifiedDivBound + 1)
+      (base + wrapperEndOff) (base + resultSignFixOff) (sdivCodeV4 base)
+      (saveRaDivCallDispatchReadyPost vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+        v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + EvmAsm.Rv64.signExtend12 3936) ↦ₘ scratchMem))
+      (((saveRaDivCallCallablePostNoX9 vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
+        (.x9 ↦ᵣ (EvmAsm.Rv64.signExtend12 4095 : Word))) **
+       ((sp + EvmAsm.Rv64.signExtend12 3936) ↦ₘ
+        sdivN1V4ScratchOut dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+          divisorLimb0 divisorLimb1 divisorLimb2 divisorTop scratchMem))) := by
+  exact
+    saveRaDivCallDispatchReadyPost_exact_callable_x9out_divCode_n1_v4ScratchOut_spec_in_sdivCodeV4
+      vRa sp base
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+      v2 v5 v6
+      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 scratchMem
+      hbase hStack
+
 /-- Exact SDIV div-call handoff specialized to the N1/v4 scratch frame shape,
     accepting the N1 path's native bound and lifting it to `unifiedDivBound`. -/
 theorem saveRaDivCallDispatchReadyPost_exact_callable_x9out_divCode_n1_v4Scratch_bound_spec_in_sdivCodeV4


### PR DESCRIPTION
## Summary
- add DivCallN1V4Handoff, a named SDIV exact handoff wrapper for the N1/v4 scratch frame shape
- wire the new file into the SDIV umbrella import list
- keep the branch-specific DIV stack proof as the explicit hStack obligation, ready for the N1 callable-extra theorem to discharge next

## Verification
- lake build EvmAsm.Evm64.SDiv.Compose.DivCallN1V4Handoff
- lake build EvmAsm.Evm64.SDiv
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/DivCallN1V4Handoff.lean EvmAsm/Evm64/SDiv.lean

## Bead
- evm-asm-9iqmw.2.1