### PR TITLE
feat(sdiv): name n1 v4 scratch output

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/DivCallN1V4Handoff.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallN1V4Handoff.lean
@@ -9,6 +9,32 @@ import EvmAsm.Evm64.SDiv.Compose.DivCallExactHandoff
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
+/-- The v4-only trial-call scratch cell after the SDIV N1 call/max/max/max
+    DIV path, expressed over SDIV's absolute-value divisor limbs. -/
+abbrev sdivN1V4ScratchOut
+    (dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop scratchMem : Word) :
+    Word :=
+  EvmAsm.Evm64.divKTrialCallV4ScratchOut
+    (EvmAsm.Evm64.fullDivN1NormU
+      (sdivAbsSum0 dividendLimb0 dividendTop)
+      (sdivAbsSum1 dividendLimb0 dividendLimb1 dividendTop)
+      (sdivAbsSum2 dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+      (sdivAbsSum3 dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+      (sdivAbsSum0 divisorLimb0 divisorTop)).2.2.2.2
+    (EvmAsm.Evm64.fullDivN1NormU
+      (sdivAbsSum0 dividendLimb0 dividendTop)
+      (sdivAbsSum1 dividendLimb0 dividendLimb1 dividendTop)
+      (sdivAbsSum2 dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+      (sdivAbsSum3 dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+      (sdivAbsSum0 divisorLimb0 divisorTop)).2.2.2.1
+    (EvmAsm.Evm64.fullDivN1NormV
+      (sdivAbsSum0 divisorLimb0 divisorTop)
+      (sdivAbsSum1 divisorLimb0 divisorLimb1 divisorTop)
+      (sdivAbsSum2 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+      (sdivAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)).1
+    scratchMem
+
 /-- Exact SDIV div-call handoff specialized to the v4 scratch frame shape
     produced by the N1 call/max/max/max no-NOP DIV path. -/
 theorem saveRaDivCallDispatchReadyPost_exact_callable_x9out_divCode_n1_v4Scratch_spec_in_sdivCodeV4
@@ -63,6 +89,66 @@ theorem saveRaDivCallDispatchReadyPost_exact_callable_x9out_divCode_n1_v4Scratch
       v2 v5 v6 (EvmAsm.Rv64.signExtend12 4095 : Word)
       q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
       shiftMem nMem jMem retMem dMem dloMem scratchUn0
+      hbase hStack
+
+/-- Exact SDIV div-call handoff specialized to the named N1/v4 scratch output
+    produced by the call/max/max/max DIV path. -/
+theorem saveRaDivCallDispatchReadyPost_exact_callable_x9out_divCode_n1_v4ScratchOut_spec_in_sdivCodeV4
+    (vRa sp base
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+      v2 v5 v6 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hbase : base &&& 1 = 0)
+    (hStack :
+      EvmAsm.Rv64.cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
+        (base + wrapperEndOff)
+        ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
+        (EvmAsm.Evm64.divCode_noNop_v4 (base + wrapperEndOff))
+        (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp
+          (sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+          (sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          (sdivAbsSign divisorTop) ((base + divCallOff) + 4) v2 v5 v6
+          (sdivAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          (sdivAbsMask divisorTop)
+          (sdivAbsCarry3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+         ((sp + EvmAsm.Rv64.signExtend12 3936) ↦ₘ scratchMem))
+        (((EvmAsm.Evm64.divStackDispatchPostCallable sp
+          (sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+          (sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) **
+          (.x1 ↦ᵣ ((base + divCallOff) + 4))) **
+          (.x9 ↦ᵣ (EvmAsm.Rv64.signExtend12 4095 : Word))) **
+         ((sp + EvmAsm.Rv64.signExtend12 3936) ↦ₘ
+          sdivN1V4ScratchOut dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+            divisorLimb0 divisorLimb1 divisorLimb2 divisorTop scratchMem))) :
+    EvmAsm.Rv64.cpsTripleWithin (EvmAsm.Evm64.unifiedDivBound + 1)
+      (base + wrapperEndOff) (base + resultSignFixOff) (sdivCodeV4 base)
+      (saveRaDivCallDispatchReadyPost vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+        v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + EvmAsm.Rv64.signExtend12 3936) ↦ₘ scratchMem))
+      (((saveRaDivCallCallablePostNoX9 vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
+        (.x9 ↦ᵣ (EvmAsm.Rv64.signExtend12 4095 : Word))) **
+       ((sp + EvmAsm.Rv64.signExtend12 3936) ↦ₘ
+        sdivN1V4ScratchOut dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+          divisorLimb0 divisorLimb1 divisorLimb2 divisorTop scratchMem))) := by
+  exact
+    saveRaDivCallDispatchReadyPost_exact_callable_x9out_divCode_n1_v4Scratch_spec_in_sdivCodeV4
+      vRa sp base
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+      v2 v5 v6
+      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 scratchMem
+      (sdivN1V4ScratchOut dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop scratchMem)
       hbase hStack
 
 /-- Exact SDIV div-call handoff specialized to the N1/v4 scratch frame shape,


### PR DESCRIPTION
## Summary
- add sdivN1V4ScratchOut to name the v4 trial-call scratch cell produced by the SDIV N1 call/max/max/max DIV path
- add a named-output handoff wrapper so downstream concrete N1 wrappers can target this postcondition directly

## Verification
- lake build EvmAsm.Evm64.SDiv.Compose.DivCallN1V4Handoff
- lake build EvmAsm.Evm64.SDiv
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/DivCallN1V4Handoff.lean

## Bead
- evm-asm-9iqmw.2.1