### PR TITLE
feat(sdiv): expose n1 v4 abs handoff surface

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/DivCallN1V4Handoff.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallN1V4Handoff.lean
@@ -151,6 +151,161 @@ theorem saveRaDivCallDispatchReadyPost_exact_callable_x9out_divCode_n1_v4Scratch
         divisorLimb0 divisorLimb1 divisorLimb2 divisorTop scratchMem)
       hbase hStack
 
+/-- Concrete N1 call/max/max/max SDIV handoff over the absolute-value
+    dividend and divisor words, using the v4 scratch-output postcondition. -/
+theorem saveRaDivCallDispatchReadyPost_exact_callable_x9out_divCode_n1_v4_abs_spec_in_sdivCodeV4
+    (vRa sp base
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+      v2 v5 v6 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hbase : base &&& 1 = 0)
+    (_hbnz :
+      sdivAbsSum0 divisorLimb0 divisorTop |||
+        sdivAbsSum1 divisorLimb0 divisorLimb1 divisorTop |||
+        sdivAbsSum2 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop |||
+        sdivAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop ≠ 0)
+    (_hb3z : sdivAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop = 0)
+    (_hb2z : sdivAbsSum2 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop = 0)
+    (_hb1z : sdivAbsSum1 divisorLimb0 divisorLimb1 divisorTop = 0)
+    (_hshift_nz : (EvmAsm.Evm64.clzResult (sdivAbsSum0 divisorLimb0 divisorTop)).1 ≠ 0)
+    (_halign : EvmAsm.Evm64.fullDivN1CallMaxmaxmaxExactInputAligned sp
+      (base + wrapperEndOff) jMem (1 : Word)
+      (EvmAsm.Evm64.fullDivN1Shift (sdivAbsSum0 divisorLimb0 divisorTop))
+      (EvmAsm.Evm64.fullDivN1NormU
+        (sdivAbsSum0 dividendLimb0 dividendTop)
+        (sdivAbsSum1 dividendLimb0 dividendLimb1 dividendTop)
+        (sdivAbsSum2 dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+        (sdivAbsSum3 dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+        (sdivAbsSum0 divisorLimb0 divisorTop)).1
+      (sdivAbsSum0 dividendLimb0 dividendTop >>>
+        ((EvmAsm.Evm64.fullDivN1AntiShift
+          (sdivAbsSum0 divisorLimb0 divisorTop)).toNat % 64))
+      (sdivAbsCarry3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+      (EvmAsm.Evm64.fullDivN1AntiShift (sdivAbsSum0 divisorLimb0 divisorTop))
+      (sdivAbsSum0 dividendLimb0 dividendTop)
+      (sdivAbsSum1 dividendLimb0 dividendLimb1 dividendTop)
+      (sdivAbsSum2 dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+      (sdivAbsSum3 dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+      (sdivAbsSum0 divisorLimb0 divisorTop)
+      (sdivAbsSum1 divisorLimb0 divisorLimb1 divisorTop)
+      (sdivAbsSum2 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+      (sdivAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+      (0 : Word) (0 : Word) (0 : Word) (0 : Word)
+      retMem dMem dloMem scratchUn0 scratchMem ((base + divCallOff) + 4))
+    (_hbltu3 : EvmAsm.Evm64.isTrialN1_j3 true
+      (sdivAbsSum3 dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+      (sdivAbsSum0 divisorLimb0 divisorTop))
+    (_hbltu2 : ¬BitVec.ult
+      (EvmAsm.Evm64.loopN1CallMaxmaxmaxR3
+        (EvmAsm.Evm64.fullDivN1NormV
+          (sdivAbsSum0 divisorLimb0 divisorTop)
+          (sdivAbsSum1 divisorLimb0 divisorLimb1 divisorTop)
+          (sdivAbsSum2 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          (sdivAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)).1
+        (EvmAsm.Evm64.fullDivN1NormV
+          (sdivAbsSum0 divisorLimb0 divisorTop)
+          (sdivAbsSum1 divisorLimb0 divisorLimb1 divisorTop)
+          (sdivAbsSum2 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          (sdivAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)).2.1
+        (EvmAsm.Evm64.fullDivN1NormV
+          (sdivAbsSum0 divisorLimb0 divisorTop)
+          (sdivAbsSum1 divisorLimb0 divisorLimb1 divisorTop)
+          (sdivAbsSum2 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          (sdivAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)).2.2.1
+        (EvmAsm.Evm64.fullDivN1NormV
+          (sdivAbsSum0 divisorLimb0 divisorTop)
+          (sdivAbsSum1 divisorLimb0 divisorLimb1 divisorTop)
+          (sdivAbsSum2 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          (sdivAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)).2.2.2
+        (EvmAsm.Evm64.fullDivN1NormU
+          (sdivAbsSum0 dividendLimb0 dividendTop)
+          (sdivAbsSum1 dividendLimb0 dividendLimb1 dividendTop)
+          (sdivAbsSum2 dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+          (sdivAbsSum3 dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+          (sdivAbsSum0 divisorLimb0 divisorTop)).2.2.2.1
+        (EvmAsm.Evm64.fullDivN1NormU
+          (sdivAbsSum0 dividendLimb0 dividendTop)
+          (sdivAbsSum1 dividendLimb0 dividendLimb1 dividendTop)
+          (sdivAbsSum2 dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+          (sdivAbsSum3 dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+          (sdivAbsSum0 divisorLimb0 divisorTop)).2.2.2.2
+        0 0 0).2.1
+      (EvmAsm.Evm64.fullDivN1NormV
+        (sdivAbsSum0 divisorLimb0 divisorTop)
+        (sdivAbsSum1 divisorLimb0 divisorLimb1 divisorTop)
+        (sdivAbsSum2 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+        (sdivAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)).1)
+    (_hcarry2 : EvmAsm.Evm64.Carry2NzAll
+      (EvmAsm.Evm64.fullDivN1NormV
+        (sdivAbsSum0 divisorLimb0 divisorTop)
+        (sdivAbsSum1 divisorLimb0 divisorLimb1 divisorTop)
+        (sdivAbsSum2 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+        (sdivAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)).1
+      (EvmAsm.Evm64.fullDivN1NormV
+        (sdivAbsSum0 divisorLimb0 divisorTop)
+        (sdivAbsSum1 divisorLimb0 divisorLimb1 divisorTop)
+        (sdivAbsSum2 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+        (sdivAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)).2.1
+      (EvmAsm.Evm64.fullDivN1NormV
+        (sdivAbsSum0 divisorLimb0 divisorTop)
+        (sdivAbsSum1 divisorLimb0 divisorLimb1 divisorTop)
+        (sdivAbsSum2 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+        (sdivAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)).2.2.1
+      (EvmAsm.Evm64.fullDivN1NormV
+        (sdivAbsSum0 divisorLimb0 divisorTop)
+        (sdivAbsSum1 divisorLimb0 divisorLimb1 divisorTop)
+        (sdivAbsSum2 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+        (sdivAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)).2.2.2)
+    (hStack :
+      EvmAsm.Rv64.cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
+        (base + wrapperEndOff)
+        ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
+        (EvmAsm.Evm64.divCode_noNop_v4 (base + wrapperEndOff))
+        (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp
+          (sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+          (sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          (sdivAbsSign divisorTop) ((base + divCallOff) + 4) v2 v5 v6
+          (sdivAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          (sdivAbsMask divisorTop)
+          (sdivAbsCarry3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+         ((sp + EvmAsm.Rv64.signExtend12 3936) ↦ₘ scratchMem))
+        (((EvmAsm.Evm64.divStackDispatchPostCallable sp
+          (sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+          (sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) **
+          (.x1 ↦ᵣ ((base + divCallOff) + 4))) **
+          (.x9 ↦ᵣ (EvmAsm.Rv64.signExtend12 4095 : Word))) **
+         ((sp + EvmAsm.Rv64.signExtend12 3936) ↦ₘ
+          sdivN1V4ScratchOut dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+            divisorLimb0 divisorLimb1 divisorLimb2 divisorTop scratchMem))) :
+    EvmAsm.Rv64.cpsTripleWithin (EvmAsm.Evm64.unifiedDivBound + 1)
+      (base + wrapperEndOff) (base + resultSignFixOff) (sdivCodeV4 base)
+      (saveRaDivCallDispatchReadyPost vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+        v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + EvmAsm.Rv64.signExtend12 3936) ↦ₘ scratchMem))
+      (((saveRaDivCallCallablePostNoX9 vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
+        (.x9 ↦ᵣ (EvmAsm.Rv64.signExtend12 4095 : Word))) **
+       ((sp + EvmAsm.Rv64.signExtend12 3936) ↦ₘ
+        sdivN1V4ScratchOut dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+          divisorLimb0 divisorLimb1 divisorLimb2 divisorTop scratchMem))) := by
+  exact
+    saveRaDivCallDispatchReadyPost_exact_callable_x9out_divCode_n1_v4ScratchOut_spec_in_sdivCodeV4
+      vRa sp base
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+      v2 v5 v6
+      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 scratchMem
+      hbase hStack
+
 /-- Exact SDIV div-call handoff specialized to the N1/v4 scratch frame shape,
     accepting the N1 path's native bound and lifting it to `unifiedDivBound`. -/
 theorem saveRaDivCallDispatchReadyPost_exact_callable_x9out_divCode_n1_v4Scratch_bound_spec_in_sdivCodeV4


### PR DESCRIPTION
## Summary
- add a concrete SDIV N1/v4 absolute-limb handoff surface targeting the named scratch-output postcondition
- spell out the N1 branch-hypothesis shapes over SDIV absolute dividend/divisor limb expressions while keeping the stack proof explicit for the next instantiation step

## Verification
- lake build EvmAsm.Evm64.SDiv.Compose.DivCallN1V4Handoff
- lake build EvmAsm.Evm64.SDiv
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/DivCallN1V4Handoff.lean

## Bead
- evm-asm-9iqmw.2.1