### PR TITLE
feat(sdiv): name n1 v4 normalized operands

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/DivCallN1V4Handoff.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallN1V4Handoff.lean
@@ -9,6 +9,27 @@ import EvmAsm.Evm64.SDiv.Compose.DivCallExactHandoff
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
+/-- Normalized N1 dividend tuple for SDIV's absolute-value operands. -/
+abbrev sdivN1V4NormU
+    (dividendLimb0 dividendLimb1 dividendLimb2 dividendTop divisorLimb0 divisorTop : Word) :
+    Word × Word × Word × Word × Word :=
+  EvmAsm.Evm64.fullDivN1NormU
+    (sdivAbsSum0 dividendLimb0 dividendTop)
+    (sdivAbsSum1 dividendLimb0 dividendLimb1 dividendTop)
+    (sdivAbsSum2 dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+    (sdivAbsSum3 dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+    (sdivAbsSum0 divisorLimb0 divisorTop)
+
+/-- Normalized N1 divisor tuple for SDIV's absolute-value operands. -/
+abbrev sdivN1V4NormV
+    (divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word) :
+    Word × Word × Word × Word :=
+  EvmAsm.Evm64.fullDivN1NormV
+    (sdivAbsSum0 divisorLimb0 divisorTop)
+    (sdivAbsSum1 divisorLimb0 divisorLimb1 divisorTop)
+    (sdivAbsSum2 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+    (sdivAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+
 /-- The v4-only trial-call scratch cell after the SDIV N1 call/max/max/max
     DIV path, expressed over SDIV's absolute-value divisor limbs. -/
 abbrev sdivN1V4ScratchOut


### PR DESCRIPTION
## Summary
- add sdivN1V4NormU and sdivN1V4NormV aliases for SDIV absolute-value operands
- prepare the N1/v4 quotient and scratch/handoff surfaces to share named normalized tuples instead of repeating fullDivN1NormU/V expressions

## Verification
- lake build EvmAsm.Evm64.SDiv.Compose.DivCallN1V4Handoff
- lake build EvmAsm.Evm64.SDiv
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/DivCallN1V4Handoff.lean

## Bead
- evm-asm-9iqmw.2.1