### PR TITLE
feat(sdiv): remove n1 v4 abs handoff stack arg

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/DivCallN1V4Handoff.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallN1V4Handoff.lean
@@ -525,7 +525,7 @@ theorem saveRaDivCallDispatchReadyPost_exact_callable_x9out_divCode_n1_v4_abs_sp
     (vRa sp base
       dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
       divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
-      v2 v5 v6 : Word)
+      v5 v6 : Word)
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
      shiftMem nMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
     (hbase : base &&& 1 = 0)
@@ -655,36 +655,14 @@ theorem saveRaDivCallDispatchReadyPost_exact_callable_x9out_divCode_n1_v4_abs_sp
         (sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
         (sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)).getLimbN 3 =
         sdivN1V4Quot3 dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-          divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
-    (hStack :
-      EvmAsm.Rv64.cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
-        (base + wrapperEndOff)
-        ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
-        (EvmAsm.Evm64.divCode_noNop_v4 (base + wrapperEndOff))
-        (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp
-          (sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
-          (sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
-          (sdivAbsSign divisorTop) ((base + divCallOff) + 4) v2 v5 v6
-          (sdivAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
-          (sdivAbsMask divisorTop)
-          (sdivAbsCarry3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
-          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-          shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
-         ((sp + EvmAsm.Rv64.signExtend12 3936) ↦ₘ scratchMem))
-        (((EvmAsm.Evm64.divStackDispatchPostCallable sp
-          (sdivAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
-          (sdivAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) **
-          (.x1 ↦ᵣ ((base + divCallOff) + 4))) **
-          (.x9 ↦ᵣ (EvmAsm.Rv64.signExtend12 4095 : Word))) **
-         ((sp + EvmAsm.Rv64.signExtend12 3936) ↦ₘ
-          sdivN1V4ScratchOut dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-            divisorLimb0 divisorLimb1 divisorLimb2 divisorTop scratchMem))) :
+          divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) :
     EvmAsm.Rv64.cpsTripleWithin (EvmAsm.Evm64.unifiedDivBound + 1)
       (base + wrapperEndOff) (base + resultSignFixOff) (sdivCodeV4 base)
       (saveRaDivCallDispatchReadyPost vRa sp base
         dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
         divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
-        v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        ((EvmAsm.Evm64.clzResult (sdivAbsSum0 divisorLimb0 divisorTop)).2 >>> (63 : Nat))
+        v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
        ((sp + EvmAsm.Rv64.signExtend12 3936) ↦ₘ scratchMem))
       (((saveRaDivCallCallablePostNoX9 vRa sp base
@@ -699,10 +677,20 @@ theorem saveRaDivCallDispatchReadyPost_exact_callable_x9out_divCode_n1_v4_abs_sp
       vRa sp base
       dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
       divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
-      v2 v5 v6
+      ((EvmAsm.Evm64.clzResult (sdivAbsSum0 divisorLimb0 divisorTop)).2 >>> (63 : Nat))
+      v5 v6
       q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
       shiftMem nMem jMem retMem dMem dloMem scratchUn0 scratchMem
-      hbase hStack
+      hbase
+      (sdivN1V4_abs_stack_spec
+        sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+        v5 v6
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 scratchMem
+        _hbnz _hb3z _hb2z _hb1z _hshift_nz _halign _hbltu3 _hbltu2
+        _hbltu1 _hbltu0 _hcarry2 _hdiv0 _hdiv1 _hdiv2 _hdiv3)
 
 /-- Exact SDIV div-call handoff specialized to the N1/v4 scratch frame shape,
     accepting the N1 path's native bound and lifting it to `unifiedDivBound`. -/


### PR DESCRIPTION
## Summary
- tighten `saveRaDivCallDispatchReadyPost_exact_callable_x9out_divCode_n1_v4_abs_spec_in_sdivCodeV4` to the concrete clz-derived dispatch value
- remove its external `hStack` parameter
- construct the stack proof internally with `sdivN1V4_abs_stack_spec`

## Verification
- `lake build EvmAsm.Evm64.SDiv.Compose.DivCallN1V4Handoff`
- `lake build EvmAsm.Evm64.SDiv`
- `lake build EvmAsm.Evm64.DivMod`
- `git diff --check`
- `rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/DivCallN1V4Handoff.lean` (no matches)

## Stack
- Base: #5428