### PR TITLE
feat(div): expose n1 callable no-nop bound

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/UnifiedExactNoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/UnifiedExactNoNop.lean
@@ -88,6 +88,50 @@ theorem evm_div_n1_stack_spec_within_word_exact_x1_noNop_uni
       hdivWord)
 
 /-- Unified-bound wrapper for
+    `evm_div_n1_stack_spec_within_word_noNop_callableOwnPost`. -/
+theorem evm_div_n1_stack_spec_within_word_noNop_callableOwnPost_uni
+    (bltu_3 bltu_2 bltu_1 bltu_0 : Bool) (sp base : Word)
+    (a b : EvmWord)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratch_un0 : Word)
+    (ha0 : a.getLimbN 0 = a0) (ha1 : a.getLimbN 1 = a1)
+    (ha2 : a.getLimbN 2 = a2) (ha3 : a.getLimbN 3 = a3)
+    (hb0 : b.getLimbN 0 = b0) (hb1 : b.getLimbN 1 = b1)
+    (hb2 : b.getLimbN 2 = b2) (hb3 : b.getLimbN 3 = b3)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1z : b1 = 0)
+    (hshift_nz : (clzResult b0).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu_3 : isTrialN1_j3 bltu_3 a3 b0)
+    (hbltu_2 : isTrialN1_j2 bltu_3 bltu_2 a2 a3 b0 b1 b2 b3)
+    (hbltu_1 : isTrialN1_j1 bltu_3 bltu_2 bltu_1 a1 a2 a3 b0 b1 b2 b3)
+    (hbltu_0 : isTrialN1_j0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3)
+    (hcarry2 : Carry2NzAll (b0 <<< (((clzResult b0).1).toNat % 64))
+      ((b1 <<< (((clzResult b0).1).toNat % 64)) ||| (b0 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b0).1).toNat % 64)))
+      ((b2 <<< (((clzResult b0).1).toNat % 64)) ||| (b1 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b0).1).toNat % 64)))
+      ((b3 <<< (((clzResult b0).1).toNat % 64)) ||| (b2 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b0).1).toNat % 64))))
+    (hdivWord : fullDivN1QuotientWord bltu_3 bltu_2 bltu_1 bltu_0
+      a0 a1 a2 a3 b0 b1 b2 b3 = EvmWord.div a b) :
+    cpsTripleWithin unifiedDivBound base (base + nopOff) (divCode_noNop base)
+      (divModStackDispatchPre sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word))
+        ((clzResult b0).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0)
+      ((divStackDispatchPostCallable sp a b ** regOwn .x1) **
+        (.x9 ↦ᵣ (signExtend12 4095 : Word))) := by
+  exact cpsTripleWithin_mono_nSteps (by decide)
+    (evm_div_n1_stack_spec_within_word_noNop_callableOwnPost
+      bltu_3 bltu_2 bltu_1 bltu_0 sp base a b
+      a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old
+      q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+      nMem shiftMem jMem retMem dMem dloMem scratch_un0
+      ha0 ha1 ha2 ha3 hb0 hb1 hb2 hb3 hbnz hb3z hb2z hb1z
+      hshift_nz halign hbltu_3 hbltu_2 hbltu_1 hbltu_0 hcarry2 hdivWord)
+
+/-- Unified-bound wrapper for
     `evm_div_n2_stack_spec_within_word_exact_x1_noNop`. -/
 theorem evm_div_n2_stack_spec_within_word_exact_x1_noNop_uni
     (bltu_2 bltu_1 bltu_0 : Bool) (sp base : Word)


### PR DESCRIPTION
## Summary
- add `evm_div_n1_stack_spec_within_word_noNop_callableOwnPost_uni`
- lift the existing n1 no-NOP callable-own post surface to `unifiedDivBound`
- completes the n1/n2/n3 trio of branch-local callable-own unified wrappers in this stack

## Verification
- `lake build EvmAsm.Evm64.DivMod.Spec.UnifiedExactNoNop`
- `lake build EvmAsm.Evm64.DivMod`
- `lake build EvmAsm.Evm64.SDiv`
- `git diff --check`
- `rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/Spec/UnifiedExactNoNop.lean` (no matches)

## Stack
- Base: #5432