### PR TITLE
feat(div): expose n3 prenox1 callable path

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N3DivStackSpec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3DivStackSpec.lean
@@ -228,6 +228,71 @@ theorem evm_div_n3_stack_spec_within_word_noNop_callableOwnPost
       ha0 ha1 ha2 ha3 hb0 hb1 hb2 hb3 hbnz hb3z hb2nz
       hshift_nz halign hbltu_1 hbltu_0 hcarry2 hdivWord)
 
+/-- No-NOP n=3 DIV stack spec from the callable precondition shape to the
+    public callable post, with separate `x1` ownership and exact `x9`. -/
+theorem evm_div_n3_stack_spec_within_word_noNop_preNoX1_callableOwnPost
+    (bltu_1 bltu_0 : Bool) (sp base : Word)
+    (a b : EvmWord)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratch_un0 : Word)
+    (raVal : Word)
+    (ha0 : a.getLimbN 0 = a0) (ha1 : a.getLimbN 1 = a1)
+    (ha2 : a.getLimbN 2 = a2) (ha3 : a.getLimbN 3 = a3)
+    (hb0 : b.getLimbN 0 = b0) (hb1 : b.getLimbN 1 = b1)
+    (hb2 : b.getLimbN 2 = b2) (hb3 : b.getLimbN 3 = b3)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2nz : b2 ≠ 0)
+    (hshift_nz : (clzResult b2).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu_1 : isTrialN3_j1 bltu_1 a3 b1 b2)
+    (hbltu_0 : isTrialN3_j0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3)
+    (hcarry2 : Carry2NzAll (b0 <<< (((clzResult b2).1).toNat % 64))
+      ((b1 <<< (((clzResult b2).1).toNat % 64)) ||| (b0 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b2).1).toNat % 64)))
+      ((b2 <<< (((clzResult b2).1).toNat % 64)) ||| (b1 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b2).1).toNat % 64)))
+      ((b3 <<< (((clzResult b2).1).toNat % 64)) ||| (b2 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b2).1).toNat % 64))))
+    (hdivWord : fullDivN3QuotientWord bltu_1 bltu_0
+      a0 a1 a2 a3 b0 b1 b2 b3 = EvmWord.div a b) :
+    cpsTripleWithin 542 base (base + nopOff) (divCode_noNop base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult b2).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0)
+      ((divStackDispatchPostCallable sp a b ** regOwn .x1) **
+        (.x9 ↦ᵣ (signExtend12 4095 : Word))) := by
+  exact cpsTripleWithin_weaken
+    (fun h hp => by
+      rw [divModStackDispatchPreNoX1_unfold, divScratchValuesCallNoX1_unfold] at hp
+      rw [divModStackDispatchPre_unfold, divScratchValuesCall_unfold]
+      have hpOwn :
+          ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (signExtend12 (4 : BitVec 12) - (4 : Word))) **
+            regOwn .x1 ** (.x2 ↦ᵣ ((clzResult b2).2 >>> (63 : Nat))) **
+            (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+            (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11Old) ** (.x0 ↦ᵣ (0 : Word)) **
+            evmWordIs sp a ** evmWordIs (sp + 32) b **
+            divScratchValues sp q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+              shiftMem nMem jMem **
+            ((sp + signExtend12 3968) ↦ₘ retMem) **
+            ((sp + signExtend12 3960) ↦ₘ dMem) **
+            ((sp + signExtend12 3952) ↦ₘ dloMem) **
+            ((sp + signExtend12 3944) ↦ₘ scratch_un0)) h := by
+        apply sepConj_mono_right
+        apply sepConj_mono_right
+        apply sepConj_mono (regIs_implies_regOwn .x1 (v := raVal))
+        exact fun _ hp => hp
+        exact hp
+      xperm_hyp hpOwn)
+    (fun _ hq => hq)
+    (evm_div_n3_stack_spec_within_word_noNop_callableOwnPost
+      bltu_1 bltu_0 sp base
+      a b a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old
+      q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+      nMem shiftMem jMem retMem dMem dloMem scratch_un0
+      ha0 ha1 ha2 ha3 hb0 hb1 hb2 hb3 hbnz hb3z hb2nz
+      hshift_nz halign hbltu_1 hbltu_0 hcarry2 hdivWord)
+
 /-- No-NOP variant of `evm_div_n3_stack_spec_within_word`. -/
 theorem evm_div_n3_stack_spec_within_word_noNop
     (bltu_1 bltu_0 : Bool) (sp base : Word)

--- a/EvmAsm/Evm64/DivMod/Spec/UnifiedExactNoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/UnifiedExactNoNop.lean
@@ -439,6 +439,49 @@ theorem evm_div_n3_stack_spec_within_word_noNop_callableOwnPost_uni
       ha0 ha1 ha2 ha3 hb0 hb1 hb2 hb3 hbnz hb3z hb2nz
       hshift_nz halign hbltu_1 hbltu_0 hcarry2 hdivWord)
 
+/-- Unified-bound wrapper for the n=3 no-NOP DIV callable surface whose
+    precondition keeps `x1` outside the scratch bundle. -/
+theorem evm_div_n3_stack_spec_within_word_noNop_preNoX1_callableOwnPost_uni
+    (bltu_1 bltu_0 : Bool) (sp base : Word)
+    (a b : EvmWord)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratch_un0 : Word)
+    (raVal : Word)
+    (ha0 : a.getLimbN 0 = a0) (ha1 : a.getLimbN 1 = a1)
+    (ha2 : a.getLimbN 2 = a2) (ha3 : a.getLimbN 3 = a3)
+    (hb0 : b.getLimbN 0 = b0) (hb1 : b.getLimbN 1 = b1)
+    (hb2 : b.getLimbN 2 = b2) (hb3 : b.getLimbN 3 = b3)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2nz : b2 ≠ 0)
+    (hshift_nz : (clzResult b2).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu_1 : isTrialN3_j1 bltu_1 a3 b1 b2)
+    (hbltu_0 : isTrialN3_j0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3)
+    (hcarry2 : Carry2NzAll (b0 <<< (((clzResult b2).1).toNat % 64))
+      ((b1 <<< (((clzResult b2).1).toNat % 64)) ||| (b0 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b2).1).toNat % 64)))
+      ((b2 <<< (((clzResult b2).1).toNat % 64)) ||| (b1 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b2).1).toNat % 64)))
+      ((b3 <<< (((clzResult b2).1).toNat % 64)) ||| (b2 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b2).1).toNat % 64))))
+    (hdivWord : fullDivN3QuotientWord bltu_1 bltu_0
+      a0 a1 a2 a3 b0 b1 b2 b3 = EvmWord.div a b) :
+    cpsTripleWithin unifiedDivBound base (base + nopOff) (divCode_noNop base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult b2).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0)
+      ((divStackDispatchPostCallable sp a b ** regOwn .x1) **
+        (.x9 ↦ᵣ (signExtend12 4095 : Word))) := by
+  exact cpsTripleWithin_mono_nSteps (by decide)
+    (evm_div_n3_stack_spec_within_word_noNop_preNoX1_callableOwnPost
+      bltu_1 bltu_0 sp base a b
+      a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old
+      q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+      nMem shiftMem jMem retMem dMem dloMem scratch_un0 raVal
+      ha0 ha1 ha2 ha3 hb0 hb1 hb2 hb3 hbnz hb3z hb2nz
+      hshift_nz halign hbltu_1 hbltu_0 hcarry2 hdivWord)
+
 /-- Single named exact-`x1` DIV stack spec over `divCode_noNop`. -/
 theorem evm_div_stack_spec_exact_x1_noNop (sp base : Word) (a b : EvmWord)
     (v5 v6 v7 v10 v11 : Word)


### PR DESCRIPTION
## Summary
- add evm_div_n3_stack_spec_within_word_noNop_preNoX1_callableOwnPost
- lift it to unifiedDivBound as evm_div_n3_stack_spec_within_word_noNop_preNoX1_callableOwnPost_uni
- convert the exact x1 PreNoX1 dispatch precondition to the legacy n3 callable path without hiding x1 in callers

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.N3DivStackSpec
- lake build EvmAsm.Evm64.DivMod.Spec.UnifiedExactNoNop
- lake build EvmAsm.Evm64.DivMod
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/Spec/N3DivStackSpec.lean EvmAsm/Evm64/DivMod/Spec/UnifiedExactNoNop.lean

Merged origin/main before commit: already up to date.