### PR TITLE
feat(div): add prenox1 callable dispatcher

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/UnifiedExactNoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/UnifiedExactNoNop.lean
@@ -601,4 +601,77 @@ theorem evm_div_stack_spec_noNop_callableOwnPost (sp base : Word) (a b : EvmWord
         hbnz hb3z hb2nz hshift_nz halign
         hbltu_1 hbltu_0 hcarry2 hdivWord
 
+/-- Single named no-NOP DIV stack spec over the dispatcher branch certificate
+    from the callable-ready precondition shape. This keeps `x1` outside the
+    scratch bundle on entry, and exposes the callable public post with
+    caller-owned `x1` plus exact `x9`. -/
+theorem evm_div_stack_spec_noNop_preNoX1_callableOwnPost
+    (sp base : Word) (a b : EvmWord)
+    (raVal v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratch_un0 : Word)
+    (branch : DivStackSpecCase base a b) :
+    cpsTripleWithin unifiedDivBound base (base + nopOff) (divCode_noNop base)
+      (divModStackDispatchPreNoX1 sp a b
+        branch.x9 raVal branch.x2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0)
+      ((divStackDispatchPostCallable sp a b ** regOwn .x1) **
+        (.x9 ↦ᵣ branch.returnX9)) := by
+  cases branch with
+  | bzero v1 v2 hbz =>
+      exact cpsTripleWithin_weaken (fun _ hp => hp)
+        (fun h hp => by
+          exact sepConj_mono_left
+            (sepConj_mono_right (regIs_implies_regOwn .x1 (v := raVal)))
+            h hp)
+        (evm_div_bzero_stack_spec_within_dispatch_noNop_callable_uni
+          sp base a b v1 raVal v2 v5 v6 v7 v10 v11
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          nMem shiftMem jMem retMem dMem dloMem scratch_un0 hbz)
+  | n1Full bltu_3 bltu_2 bltu_1 bltu_0 hbnz hb3z hb2z hb1z hshift_nz halign
+      hbltu_3 hbltu_2 hbltu_1 hbltu_0 hcarry2 hmulsub hge =>
+      have hdivWord :=
+        fullDivN1QuotientWord_eq_div_of_limbs_mulsub_overestimate
+          bltu_3 bltu_2 bltu_1 bltu_0 rfl rfl rfl rfl rfl rfl rfl rfl
+          hbnz hmulsub hge
+      exact evm_div_n1_stack_spec_within_word_noNop_preNoX1_callableOwnPost_uni
+        bltu_3 bltu_2 bltu_1 bltu_0 sp base a b
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+        v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        nMem shiftMem jMem retMem dMem dloMem scratch_un0 raVal
+        rfl rfl rfl rfl rfl rfl rfl rfl
+        hbnz hb3z hb2z hb1z hshift_nz halign
+        hbltu_3 hbltu_2 hbltu_1 hbltu_0 hcarry2 hdivWord
+  | n2Full bltu_2 bltu_1 bltu_0 hbnz hb3z hb2z hb1nz hshift_nz halign
+      hbltu_2 hbltu_1 hbltu_0 hcarry2 hmulsub hge =>
+      have hdivWord :=
+        fullDivN2QuotientWord_eq_div_of_limbs_mulsub_overestimate
+          bltu_2 bltu_1 bltu_0 rfl rfl rfl rfl rfl rfl rfl rfl
+          hbnz hmulsub hge
+      exact evm_div_n2_stack_spec_within_word_noNop_preNoX1_callableOwnPost_uni
+        bltu_2 bltu_1 bltu_0 sp base a b
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+        v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        nMem shiftMem jMem retMem dMem dloMem scratch_un0 raVal
+        rfl rfl rfl rfl rfl rfl rfl rfl
+        hbnz hb3z hb2z hb1nz hshift_nz halign
+        hbltu_2 hbltu_1 hbltu_0 hcarry2 hdivWord
+  | n3Full bltu_1 bltu_0 hbnz hb3z hb2nz hshift_nz halign
+      hbltu_1 hbltu_0 hcarry2 hmulsub hge =>
+      have hdivWord :=
+        fullDivN3QuotientWord_eq_div_of_limbs_mulsub_overestimate
+          bltu_1 bltu_0 rfl rfl rfl rfl rfl rfl rfl rfl hbnz hmulsub hge
+      exact evm_div_n3_stack_spec_within_word_noNop_preNoX1_callableOwnPost_uni
+        bltu_1 bltu_0 sp base a b
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+        v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        nMem shiftMem jMem retMem dMem dloMem scratch_un0 raVal
+        rfl rfl rfl rfl rfl rfl rfl rfl
+        hbnz hb3z hb2nz hshift_nz halign
+        hbltu_1 hbltu_0 hcarry2 hdivWord
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add evm_div_stack_spec_noNop_preNoX1_callableOwnPost over DivStackSpecCase
- dispatch from divModStackDispatchPreNoX1 using the bzero and n1/n2/n3 PreNoX1 branch surfaces
- expose the callable public post with caller-owned x1 and exact branch return x9

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.UnifiedExactNoNop
- lake build EvmAsm.Evm64.DivMod
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/Spec/UnifiedExactNoNop.lean

Merged origin/main before commit: already up to date.