### PR TITLE
feat(div): expose bzero prenox1 exact dispatch

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/UnifiedExactNoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/UnifiedExactNoNop.lean
@@ -672,4 +672,24 @@ theorem evm_div_stack_spec_noNop_preNoX1_callableOwnPost
         hbnz hb3z hb2nz hshift_nz halign
         hbltu_1 hbltu_0 hcarry2 hdivWord
 
+/-- Zero-divisor branch of the no-NOP DIV dispatcher from the callable-ready
+    precondition shape, preserving exact caller-framed `x1` and `x9`. -/
+theorem evm_div_stack_spec_bzero_noNop_preNoX1_callableExactPost
+    (sp base : Word) (a b : EvmWord)
+    (x9Val raVal v2 v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratch_un0 : Word)
+    (hbz : b = 0) :
+    cpsTripleWithin unifiedDivBound base (base + nopOff) (divCode_noNop base)
+      (divModStackDispatchPreNoX1 sp a b
+        x9Val raVal v2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0)
+      ((divStackDispatchPostCallable sp a b ** (.x1 ↦ᵣ raVal)) **
+        (.x9 ↦ᵣ x9Val)) := by
+  exact evm_div_bzero_stack_spec_within_dispatch_noNop_callable_uni
+    sp base a b x9Val raVal v2 v5 v6 v7 v10 v11
+    q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratch_un0 hbz
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add evm_div_stack_spec_bzero_noNop_preNoX1_callableExactPost
- expose the bzero DIV no-NOP branch from divModStackDispatchPreNoX1 with exact x1 and exact x9
- keep it as a thin alias over the existing bzero callable theorem for downstream dispatcher composition

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.UnifiedExactNoNop
- lake build EvmAsm.Evm64.DivMod
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/Spec/UnifiedExactNoNop.lean

Merged origin/main before commit: already up to date.