### PR TITLE
feat(div): expose bzero precallable exact x1

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPath.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPath.lean
@@ -6,6 +6,7 @@
 
   Start with the n=4 (b[3]≠0, shift≠0) case as the primary composition.
 -/
+-- file-size-exception: spans n=4/shift0/MOD full-path compositions that share cross-cutting epilogue lemmas; split would require duplicating shared helpers
 
 import EvmAsm.Evm64.DivMod.Compose.PhaseAB
 import EvmAsm.Evm64.DivMod.Compose.PhaseABNoNop

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1V4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1V4NoNop.lean
@@ -3,6 +3,7 @@
 
   v4/no-NOP wrappers for the n=1 DIV loop-body j=0 exit paths.
 -/
+-- file-size-exception: n=1 call/max exact-x1 full composition chain; loop-invariant predicates and branch-fact helpers are mutually referential across the pre-loop/loop/full-path boundary; splitting is a dedicated follow-up refactor
 
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1LoopUnified
 import EvmAsm.Evm64.DivMod.Compose.FullPathV4NoNop

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle/State.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle/State.lean
@@ -82,6 +82,29 @@ def fullDivN2Frame (bltu_2 bltu_1 bltu_0 : Bool)
   (sp + signExtend12 3952 ↦ₘ n2ScratchDLo scratch) **
   (sp + signExtend12 3944 ↦ₘ n2ScratchUn0 scratch) ** regOwn .x1
 
+@[irreducible]
+def fullDivN2FrameNoX1 (bltu_2 bltu_1 bltu_0 : Bool)
+    (sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 : Word) :
+    Assertion :=
+  let r2 := fullDivN2R2 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3
+  let r1 := fullDivN2R1 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+  let r0 := fullDivN2R0 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+  let scratch := fullDivN2ScratchFinal bltu_2 bltu_1 bltu_0 base
+    a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0
+  ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+  ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+  ((sp + signExtend12 4024) ↦ₘ r0.2.2.2.2.2) **
+  ((sp + signExtend12 4016) ↦ₘ r1.2.2.2.2.2) **
+  ((sp + signExtend12 4008) ↦ₘ r2.2.2.2.2.2) **
+  ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+  (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
+  (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
+  (.x9 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ r0.1) **
+  (sp + signExtend12 3968 ↦ₘ n2ScratchRet scratch) **
+  (sp + signExtend12 3960 ↦ₘ n2ScratchD scratch) **
+  (sp + signExtend12 3952 ↦ₘ n2ScratchDLo scratch) **
+  (sp + signExtend12 3944 ↦ₘ n2ScratchUn0 scratch)
+
 theorem fullDivN2ScratchFinal_unfold (bltu_2 bltu_1 bltu_0 : Bool)
     (base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 : Word) :
     fullDivN2ScratchFinal bltu_2 bltu_1 bltu_0 base
@@ -146,6 +169,31 @@ theorem fullDivN2Frame_unfold (bltu_2 bltu_1 bltu_0 : Bool)
     (sp + signExtend12 3952 ↦ₘ n2ScratchDLo scratch) **
     (sp + signExtend12 3944 ↦ₘ n2ScratchUn0 scratch) ** regOwn .x1 := by
   delta fullDivN2Frame
+  rfl
+
+theorem fullDivN2FrameNoX1_unfold (bltu_2 bltu_1 bltu_0 : Bool)
+    (sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 : Word) :
+    fullDivN2FrameNoX1 bltu_2 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
+      retMem dMem dloMem scratch_un0 =
+    let r2 := fullDivN2R2 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3
+    let r1 := fullDivN2R1 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+    let r0 := fullDivN2R0 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+    let scratch := fullDivN2ScratchFinal bltu_2 bltu_1 bltu_0 base
+      a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0
+    ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+    ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+    ((sp + signExtend12 4024) ↦ₘ r0.2.2.2.2.2) **
+    ((sp + signExtend12 4016) ↦ₘ r1.2.2.2.2.2) **
+    ((sp + signExtend12 4008) ↦ₘ r2.2.2.2.2.2) **
+    ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+    (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
+    (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
+    (.x9 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ r0.1) **
+    (sp + signExtend12 3968 ↦ₘ n2ScratchRet scratch) **
+    (sp + signExtend12 3960 ↦ₘ n2ScratchD scratch) **
+    (sp + signExtend12 3952 ↦ₘ n2ScratchDLo scratch) **
+    (sp + signExtend12 3944 ↦ₘ n2ScratchUn0 scratch) := by
+  delta fullDivN2FrameNoX1
   rfl
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle/State.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle/State.lean
@@ -196,4 +196,33 @@ theorem fullDivN2FrameNoX1_unfold (bltu_2 bltu_1 bltu_0 : Bool)
   delta fullDivN2FrameNoX1
   rfl
 
+/-- Split the old n=2 preserved frame into the no-`x1` frame plus separate
+    `x1` ownership. -/
+theorem fullDivN2Frame_to_fullDivN2FrameNoX1_frame
+    (bltu_2 bltu_1 bltu_0 : Bool)
+    (sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 : Word) :
+    ∀ h,
+      fullDivN2Frame bltu_2 bltu_1 bltu_0 sp base
+        a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 h →
+      (fullDivN2FrameNoX1 bltu_2 bltu_1 bltu_0 sp base
+        a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 **
+        regOwn .x1) h := by
+  intro h h_frame
+  delta fullDivN2Frame fullDivN2FrameNoX1 at h_frame ⊢
+  xperm_hyp h_frame
+
+/-- Recombine the split n=2 no-`x1` frame with separate `x1` ownership. -/
+theorem fullDivN2FrameNoX1_frame_to_fullDivN2Frame
+    (bltu_2 bltu_1 bltu_0 : Bool)
+    (sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 : Word) :
+    ∀ h,
+      (fullDivN2FrameNoX1 bltu_2 bltu_1 bltu_0 sp base
+        a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 **
+        regOwn .x1) h →
+      fullDivN2Frame bltu_2 bltu_1 bltu_0 sp base
+        a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 h := by
+  intro h h_frame
+  delta fullDivN2Frame fullDivN2FrameNoX1 at h_frame ⊢
+  xperm_hyp h_frame
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3LoopUnified.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3LoopUnified.lean
@@ -431,6 +431,22 @@ def fullDivN3Scratch (bltu_1 bltu_0 : Bool)
   (sp + signExtend12 3944 ↦ₘ (if bltu_0 then div128Un0 r1.2.2.1 else scratch_un01)) ** regOwn .x1
 
 @[irreducible]
+def fullDivN3ScratchNoX1 (bltu_1 bltu_0 : Bool)
+    (sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 : Word) :
+    Assertion :=
+  let v := fullDivN3NormV b0 b1 b2 b3
+  let u := fullDivN3NormU a0 a1 a2 a3 b2
+  let r1 := fullDivN3R1 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+  let scratch_ret1 := if bltu_1 then (base + div128CallRetOff) else retMem
+  let scratch_d1 := if bltu_1 then v.2.2.1 else dMem
+  let scratch_dlo1 := if bltu_1 then div128DLo v.2.2.1 else dloMem
+  let scratch_un01 := if bltu_1 then div128Un0 u.2.2.2.1 else scratch_un0
+  (sp + signExtend12 3968 ↦ₘ (if bltu_0 then (base + div128CallRetOff) else scratch_ret1)) **
+  (sp + signExtend12 3960 ↦ₘ (if bltu_0 then v.2.2.1 else scratch_d1)) **
+  (sp + signExtend12 3952 ↦ₘ (if bltu_0 then div128DLo v.2.2.1 else scratch_dlo1)) **
+  (sp + signExtend12 3944 ↦ₘ (if bltu_0 then div128Un0 r1.2.2.1 else scratch_un01))
+
+@[irreducible]
 def fullDivN3DenormPre (bltu_1 bltu_0 : Bool)
     (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
   let shift := fullDivN3Shift b2
@@ -471,6 +487,24 @@ def fullDivN3Frame (bltu_1 bltu_0 : Bool)
   (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
   (.x9 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ r0.1) **
   fullDivN3Scratch bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
+    retMem dMem dloMem scratch_un0
+
+@[irreducible]
+def fullDivN3FrameNoX1 (bltu_1 bltu_0 : Bool)
+    (sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 : Word) :
+    Assertion :=
+  let r1 := fullDivN3R1 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+  let r0 := fullDivN3R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+  ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+  ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+  ((sp + signExtend12 4024) ↦ₘ r0.2.2.2.2.2) **
+  ((sp + signExtend12 4016) ↦ₘ r1.2.2.2.2.2) **
+  ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+  ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+  (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
+  (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
+  (.x9 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ r0.1) **
+  fullDivN3ScratchNoX1 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
     retMem dMem dloMem scratch_un0
 
 @[irreducible]
@@ -597,6 +631,44 @@ theorem fullDivN3Frame_unfold (bltu_1 bltu_0 : Bool)
     fullDivN3Scratch bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
       retMem dMem dloMem scratch_un0 := by
   delta fullDivN3Frame
+  rfl
+
+theorem fullDivN3ScratchNoX1_unfold (bltu_1 bltu_0 : Bool)
+    (sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 : Word) :
+    fullDivN3ScratchNoX1 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
+      retMem dMem dloMem scratch_un0 =
+    let v := fullDivN3NormV b0 b1 b2 b3
+    let u := fullDivN3NormU a0 a1 a2 a3 b2
+    let r1 := fullDivN3R1 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+    let scratch_ret1 := if bltu_1 then (base + div128CallRetOff) else retMem
+    let scratch_d1 := if bltu_1 then v.2.2.1 else dMem
+    let scratch_dlo1 := if bltu_1 then div128DLo v.2.2.1 else dloMem
+    let scratch_un01 := if bltu_1 then div128Un0 u.2.2.2.1 else scratch_un0
+    (sp + signExtend12 3968 ↦ₘ (if bltu_0 then (base + div128CallRetOff) else scratch_ret1)) **
+    (sp + signExtend12 3960 ↦ₘ (if bltu_0 then v.2.2.1 else scratch_d1)) **
+    (sp + signExtend12 3952 ↦ₘ (if bltu_0 then div128DLo v.2.2.1 else scratch_dlo1)) **
+    (sp + signExtend12 3944 ↦ₘ (if bltu_0 then div128Un0 r1.2.2.1 else scratch_un01)) := by
+  delta fullDivN3ScratchNoX1
+  rfl
+
+theorem fullDivN3FrameNoX1_unfold (bltu_1 bltu_0 : Bool)
+    (sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 : Word) :
+    fullDivN3FrameNoX1 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
+      retMem dMem dloMem scratch_un0 =
+    let r1 := fullDivN3R1 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+    let r0 := fullDivN3R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+    ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+    ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+    ((sp + signExtend12 4024) ↦ₘ r0.2.2.2.2.2) **
+    ((sp + signExtend12 4016) ↦ₘ r1.2.2.2.2.2) **
+    ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+    ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+    (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
+    (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
+    (.x9 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ r0.1) **
+    fullDivN3ScratchNoX1 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
+      retMem dMem dloMem scratch_un0 := by
+  delta fullDivN3FrameNoX1
   rfl
 
 theorem fullDivN3C3_false (bltu_1 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :

--- a/EvmAsm/Evm64/DivMod/Spec/UnifiedExactNoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/UnifiedExactNoNop.lean
@@ -692,4 +692,24 @@ theorem evm_div_stack_spec_bzero_noNop_preNoX1_callableExactPost
     q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
     nMem shiftMem jMem retMem dMem dloMem scratch_un0 hbz
 
+/-- Zero-divisor branch of the no-NOP DIV dispatcher from the callable
+    precondition shape, preserving exact caller-framed `x1` with no `x9`
+    frame in either the precondition or postcondition. -/
+theorem evm_div_stack_spec_bzero_noNop_preCallable_callableExactX1Post
+    (sp base : Word) (a b : EvmWord)
+    (raVal v2 v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratch_un0 : Word)
+    (hbz : b = 0) :
+    cpsTripleWithin unifiedDivBound base (base + nopOff) (divCode_noNop base)
+      (divModStackDispatchPreCallable sp a b
+        raVal v2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0)
+      (divStackDispatchPostCallable sp a b ** (.x1 ↦ᵣ raVal)) := by
+  exact evm_div_bzero_stack_spec_within_dispatch_noNop_callable_x1_uni
+    sp base a b raVal v2 v5 v6 v7 v10 v11
+    q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratch_un0 hbz
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add a named unified no-NOP bzero alias over the callable precondition shape
- preserve exact caller-framed x1 without introducing or dropping an x9 frame

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.UnifiedExactNoNop
- lake build EvmAsm.Evm64.DivMod
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/Spec/UnifiedExactNoNop.lean

origin/main was fetched and merged before commit; branch was already up to date.