### PR TITLE
feat(sdiv): wrap div callable exact frame x9out

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/DivCallExactCallable.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallExactCallable.lean
@@ -652,6 +652,39 @@ theorem evm_div_callable_v4_preserving_x1_x9out_exact_pre_body_framed_spec_in_sd
         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
         nMem shiftMem jMem retMem dMem dloMem scratchUn0 hStack)
 
+/-- Named-post v4 SDIV wrapper for exact-pre unsigned-DIV body proofs that
+    already carry an explicit PC-free frame and return a possibly different
+    exact `x9` value. -/
+theorem evm_div_callable_v4_exact_frame_x9out_body_framed_spec_in_sdivCodeV4
+    {F : EvmAsm.Rv64.Assertion} [EvmAsm.Rv64.Assertion.PCFree F]
+    (sp base x9In x9Out raVal : Word) (a b : EvmWord) (v2 v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (hStack :
+      EvmAsm.Rv64.cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
+        (base + wrapperEndOff)
+        ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
+        (EvmAsm.Evm64.sharedDivModCodeNoNop_v4 (base + wrapperEndOff))
+        (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp a b
+          x9In raVal v2 v5 v6 v7 v10 v11
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0 ** F)
+        (EvmAsm.Evm64.divStackDispatchPostCallableExactFrame sp a b raVal x9Out ** F)) :
+    EvmAsm.Rv64.cpsTripleWithin (EvmAsm.Evm64.unifiedDivBound + 1)
+      (base + wrapperEndOff) (raVal &&& ~~~1) (sdivCodeV4 base)
+      (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp a b
+        x9In raVal v2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 ** F)
+      (EvmAsm.Evm64.divStackDispatchPostCallableExactFrame sp a b raVal x9Out ** F) := by
+  exact
+    EvmAsm.Rv64.cpsTripleWithin_extend_code
+      (hmono := evm_div_callable_code_v4_sub_sdivCodeV4 (base := base))
+      (EvmAsm.Evm64.evm_div_callable_v4_spec_from_noNop_exact_frame_x9out_body_framed
+        sp (base + wrapperEndOff) x9In x9Out raVal a b v2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        nMem shiftMem jMem retMem dMem dloMem scratchUn0 hStack)
+
 /-- v4 SDIV wrapper for full `divCode_noNop_v4` body proofs that already
     carry an explicit PC-free frame and return a possibly different exact x9. -/
 theorem evm_div_callable_v4_preserving_x1_x9out_exact_pre_divCode_body_framed_spec_in_sdivCodeV4


### PR DESCRIPTION
## Summary
- add evm_div_callable_v4_exact_frame_x9out_body_framed_spec_in_sdivCodeV4
- expose the named divStackDispatchPostCallableExactFrame surface through sdivCodeV4 for body-framed callable DIV proofs with a possibly changed exact x9
- keep the proof as a thin code-extension wrapper over the DivMod exact-frame x9out theorem

## Verification
- lake build EvmAsm.Evm64.SDiv.Compose.DivCallExactCallable
- lake build EvmAsm.Evm64.DivMod
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SDiv/Compose/DivCallExactCallable.lean (no matches)

## Guardrail
- touched file is 756 lines, under the 1200-line Compose cap
- scripts/check-file-size.sh currently fails on existing unrelated EvmAsm/Evm64/DivMod/Compose/FullPath.lean at 1235/1200 lines

## Stack sync
- PR #5465 merged into the feature-branch base before this PR; restored feat/sdiv-div-callable-exact-frame-framed at 73bcfcb32 so this PR has a one-slice diff
- origin/main was already up to date before the original commit