### PR TITLE
feat(codegen): M9 — wire SDIV and SMOD via trampoline wrapper

### DIFF
--- a/CODEGEN.md
+++ b/CODEGEN.md
@@ -38,7 +38,7 @@ untouched. Generated artifacts go in `gen-out/` (gitignored).
 | `EvmAsm/Codegen.lean` | Top-level umbrella (mirrors `EvmAsm/Rv64.lean`, `EvmAsm/Evm64.lean`). |
 | `EvmAsm/Codegen/Emit.lean` | Pure `emitReg`, `emitInstr`, `emitProgram` — `Instr → String`. No `IO`. |
 | `EvmAsm/Codegen/Layout.lean` | `HaltConv` enum, halt stubs, `_start` preamble, `.option norvc`, `MEM_START`/`MEM_END` constants, `BuildUnit` struct + `emitBuildUnit`/`emitDataLabel` helpers. |
-| `EvmAsm/Codegen/Dispatch.lean` | M5b dispatcher scaffolding: `OpcodeHandlerSpec` (with optional `preBody` for x10-clobbering handlers) + `HandlerTail` types, `emitDispatcherPrologue`/`Epilogue`/`DataSection` and `buildDispatchUnit` helpers. M8.5 adds the parallel runtime-bytecode helpers (`emitRuntimeDispatcherPrologue` / `emitRuntimeDispatcherDataSection` / `buildRuntimeDispatchUnit`) that read bytecode from `INPUT_ADDR + INPUT_DATA_OFFSET` at runtime. Pure (no IO). |
+| `EvmAsm/Codegen/Dispatch.lean` | M5b dispatcher scaffolding: `OpcodeHandlerSpec` (optional `preBody` for x10-clobbering handlers + optional `postBodyLabel` for M9's trampoline pattern) + `HandlerTail` types, `emitDispatcherPrologue`/`Epilogue`/`DataSection` and `buildDispatchUnit` helpers. M8.5 adds the parallel runtime-bytecode helpers (`emitRuntimeDispatcherPrologue` / `emitRuntimeDispatcherDataSection` / `buildRuntimeDispatchUnit`) that read bytecode from `INPUT_ADDR + INPUT_DATA_OFFSET` at runtime. Pure (no IO). |
 | `EvmAsm/Codegen/Programs.lean` | Registry (`smoke`, `evm_add`, `evm_div`, `evm_mod`, `input_echo`, `evm_add_from_input`, `evm_div_from_input`, `evm_mod_from_input`, `tiny_interp_{add,add2}`, `tiny_interp_dispatch_{add,add2}` → `BuildUnit`) plus the M5b opcode handler registry (`tinyInterpRegistry`) composed from `pushHandlers` (PUSH0..32), `dupHandlers` (DUP1..16), `swapHandlers` (SWAP1..16), `singletonHandlers` (17 fixed-shape opcodes), `memoryHandlers` (MLOAD/MSTORE/MSTORE8, M7), `stopHandler`; shared helpers (`advancePc`, `copy64`, `evmAddEpilogue`, `evmDivPatched`/`evmModPatched` for the DIV/MOD NOP-splice). |
 | `EvmAsm/Codegen/Tests/Cases.lean` | Per-opcode regression test registry: `OpcodeTestCase` struct + `opcodeTestCases` list. Wraps each bytecode through the M5b dispatcher for end-to-end ziskemu validation. |
 | `EvmAsm/Codegen/Cli.lean` | Argument parsing (`--program`, `--test-case`, `--list-test-cases`, `--halt`, `--out`, `--asm-only`). |
@@ -617,14 +617,73 @@ cases PASS. Pre-existing M2/M4/M5/M7/M8 scripts unchanged.
 PROGRESS.md regenerated (program count 16 → 17, script count
 14 → 15).
 
+### M9 — SDIV / SMOD via trampoline wrapper (M) — **DONE (2026-05-21)**
+
+Closes the M8 scope-reduction debt: SDIV (0x05) and SMOD (0x07)
+now route through `tinyInterpRegistry`. New trampoline wrapper
+pattern via a `postBodyLabel : Option String` field on
+`OpcodeHandlerSpec` — generalisable to any future opcode whose
+verified body ends with a saved-ra-ret (`JALR x0, x18, 0`).
+
+**Delivered:**
+- `EvmAsm/Codegen/Dispatch.lean` — extended `OpcodeHandlerSpec`
+  with `postBodyLabel : Option String := none`. `emitSubroutine`
+  emits an optional label between body and tail. Handlers that
+  leave this `none` (all M5b–M8 handlers) emit byte-identical
+  asm.
+- `EvmAsm/Codegen/Programs.lean` — new helpers:
+  - `evmSdivPatched := (evm_sdiv : List Instr).drop 1` — strips
+    the leading `ADDI .x18 .x1 0` save_ra_block (413 instructions
+    instead of 414).
+  - `evmSmodPatched := (evm_smod : List Instr).drop 1` — same.
+  - `signedDivModTail` — restores `x10` from `x14`, advances PC,
+    then `j .dispatch_loop` (NOT `ret`: the wrapper's inner
+    `JAL .x1` into `evm_div_callable_v4` / `evm_mod_callable`
+    clobbers x1, so a standard `ret` would jump to garbage).
+  - `signedDivModHandlers` — two entries (`h_SDIV`, `h_SMOD`).
+    Each carries `preBody := "  mv x14, x10\n  la x18, h_<NAME>_done"`,
+    `postBodyLabel := some "h_<NAME>_done"`, and `tail := signedDivModTail`.
+  - `tinyInterpRegistry` appends `signedDivModHandlers` between
+    `divModHandlers` and `[stopHandler]`.
+- `EvmAsm/Codegen/Tests/Cases.lean` — three new cases:
+  `sdiv_basic` (5/2 = 2, positive path), `sdiv_negative` (NOT trick
+  → −2 / 2 = −1, exercises sign-extract + conditional-negate),
+  `smod_negative` (NOT trick → −2 % 5 = −2, sign(result) = sign(a)
+  per EVM SMOD semantics).
+- `scripts/codegen-opcodes-runtime-check.sh` — bumped per-case
+  step budget from 200K to 500K. SDIV/SMOD's Knuth-D inner loop
+  plus the trampoline overhead pushes beyond 200K even for small
+  operands; the legacy `codegen-evm_div-check.sh` already used 500K.
+
+**Trampoline mechanics gotcha.** First attempt used `divModTail`
+(= `mv x10, x14; addi; ret`) for the SDIV/SMOD restore stub —
+ziskemu hung with `EmulationNoCompleted`. Cause: the wrapper's
+inner `JAL .x1` into the callable divider clobbers `x1`, so by
+the time control reaches the restore stub, `x1` no longer points
+at the dispatcher's continuation. Fix: replaced `ret` with
+`j .dispatch_loop` (a direct jump to the dispatcher loop entry,
+bypassing the `x1`-mediated return).
+
+**SMOD v4 caveat (carried over from M8).** `evm_smod` still uses
+the legacy non-v4 `evm_mod_callable`. SDIV migrated to v4 in
+commit `43bb53070`; SMOD's surface hasn't flipped yet. When the
+verification track migrates SMOD, this entry rebinds to the new
+symbol with no other changes.
+
+**Exit criteria (met).**
+`scripts/codegen-opcodes-runtime-check.sh` exits 0 with all 29
+cases PASS (26 prior + 3 new). Legacy `codegen-opcodes-check.sh`
+also exits 0. Pre-existing M2/M4/M5/M7/M8/M8.5 scripts unchanged.
+PROGRESS.md needs only a snapshot-line bump (ignored by CI's
+drift check) — no commit.
+
 ### Sequencing
 
-M0 ✅ → M1 ✅ → M2 ✅ → M4 ✅ → M5a ✅ → M5b ✅ → M6a ✅ → M6b ✅ → M7 ✅ → M8 ✅ → M8.5 ✅.
+M0 ✅ → M1 ✅ → M2 ✅ → M4 ✅ → M5a ✅ → M5b ✅ → M6a ✅ → M6b ✅ → M7 ✅ → M8 ✅ → M8.5 ✅ → M9 ✅.
 M3 is deferred; revisit only if a future milestone (full opcode
 coverage, JUMP/JUMPI, or the binary encoder) makes label-free
-emission unreadable. M8.5 unblocks the next opcode batches (M9
-SDIV/SMOD trampoline, M10 ADDMOD/EXP callable, M11 control flow)
-by keeping the test suite fast.
+emission unreadable. M9 unblocks M10 (ADDMOD/EXP via
+`callableLabel?`) and the rest of the long arc.
 
 ## Tricky bits / open questions
 
@@ -724,15 +783,17 @@ by keeping the test suite fast.
   of baking it into `.data`. Suite runtime dropped from ~60 s to
   ~20 s (3× speedup). Legacy `codegen-opcodes-check.sh` still
   passes as the fallback.
+- **M9.** ✅ `scripts/codegen-opcodes-runtime-check.sh` exits 0 with
+  **29 test cases** PASS (validated 2026-05-21). SDIV (0x05) and
+  SMOD (0x07) wired via the new trampoline pattern + the
+  `OpcodeHandlerSpec.postBodyLabel : Option String` field.
+  `signedDivModTail` uses `j .dispatch_loop` instead of `ret`
+  because the wrapper's inner `JAL .x1` clobbers x1 mid-body.
 
-## Future work (post-M8.5)
+## Future work (post-M9)
 
 Near-term:
 
-- **M9 — SDIV / SMOD trampoline.** Adds 2 opcodes. New trampoline
-  wrapper for handlers whose verified bodies end with a saved-ra-ret
-  (`JALR x0, x18, 0`): pre-stage `x18` to a per-handler restore stub
-  before the body runs, splice off the body's initial save_ra_block.
 - **M10 — ADDMOD / EXP via `callableLabel?`.** Adds 2 opcodes that
   internally `JAL` to callable variants of other handlers (`evm_mul`
   for EXP, MOD for ADDMOD). Needs a new `callableLabel?` field on

--- a/EvmAsm/Codegen/Dispatch.lean
+++ b/EvmAsm/Codegen/Dispatch.lean
@@ -54,7 +54,16 @@ structure OpcodeHandlerSpec where
   /-- Verified RV64 body, rendered verbatim via `emitProgram`.
       May be empty (e.g. STOP has no work to do before exiting). -/
   body    : Program
-  /-- Tail emitted after the body. -/
+  /-- Optional label emitted *between* the verified body and the tail.
+      Used by M9's trampoline pattern for handlers whose verified
+      bodies end with a saved-ra-ret (`JALR x0, x18, 0`): the body's
+      ret-jump targets this label (set in `preBody` via
+      `la x18, <postBodyLabel>`), and the tail then restores `x10`
+      and falls through. Handlers that return cleanly via the
+      standard `addi; ret` tail leave this `none` — emission is then
+      byte-identical to pre-M9. -/
+  postBodyLabel : Option String := none
+  /-- Tail emitted after the body (or after `postBodyLabel:` if set). -/
   tail    : HandlerTail
 
 namespace OpcodeHandlerSpec
@@ -67,12 +76,17 @@ def emitTail : HandlerTail → String
 /-- Render the handler as a labeled subroutine. Empty bodies (STOP,
     INVALID-style entries) skip the body line entirely to avoid a
     blank line after the label. `preBody` is inserted between the
-    label and the body (used for clobber-saving). -/
+    label and the body (used for clobber-saving). `postBodyLabel`,
+    when set, emits an additional label between the body and the
+    tail (M9 trampoline pattern). -/
 def emitSubroutine (h : OpcodeHandlerSpec) : String :=
   let preLine  := if h.preBody.isEmpty then "" else h.preBody ++ "\n"
   let bodyText := emitProgram h.body
   let bodyLine := if bodyText.isEmpty then "" else bodyText ++ "\n"
-  s!"{h.label}:\n" ++ preLine ++ bodyLine ++ emitTail h.tail
+  let postLine := match h.postBodyLabel with
+                  | some lbl => s!"{lbl}:\n"
+                  | none     => ""
+  s!"{h.label}:\n" ++ preLine ++ bodyLine ++ postLine ++ emitTail h.tail
 
 end OpcodeHandlerSpec
 

--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -328,6 +328,26 @@ def evmModPatched : Program :=
   [Instr.JAL .x0 (304 : BitVec 21)] ++
   (EvmAsm.Evm64.evm_mod : List Instr).drop 268
 
+/-- `EvmAsm.Evm64.evm_sdiv` with the leading `ADDI .x18 .x1 0`
+    save_ra_block removed (413 instructions instead of 414). The
+    M9 trampoline handler sets `x18 = &h_SDIV_done` in `preBody`;
+    the body's existing `JALR x0, x18, 0` then jumps to our
+    restore stub instead of clobbering `x18` with `x1`.
+
+    The first instruction of `evm_sdiv_wrapper` is
+    `evm_sdiv_save_ra_block .x18` = `ADDI .x18 .x1 0`
+    (`EvmAsm/Evm64/SDiv/Program.lean:180`). Splicing it off lets
+    our trampoline target stick. -/
+def evmSdivPatched : Program :=
+  (EvmAsm.Evm64.evm_sdiv : List Instr).drop 1
+
+/-- `EvmAsm.Evm64.evm_smod` with the same leading-save_ra splice
+    as `evmSdivPatched`. SMOD's wrapper is structurally identical
+    to SDIV's at the entry/exit boundary (only the conditional-
+    negate path differs). -/
+def evmSmodPatched : Program :=
+  (EvmAsm.Evm64.evm_smod : List Instr).drop 1
+
 /-! ## tiny_interp_dispatch — M5b runtime fetch/decode/dispatch loop
 
     Same EVM bytecodes as M5a, but routed through an actual RISC-V
@@ -504,6 +524,63 @@ def divModHandlers : List OpcodeHandlerSpec :=
       body    := evmModPatched
       tail    := divModTail } ]
 
+/-- Tail for SDIV/SMOD: restore `x10` from `x14`, advance the EVM
+    code pointer by 1, then jump directly to `.dispatch_loop`
+    rather than `ret`-ing. The standard `ret` (= `jalr x0, x1, 0`)
+    won't work for these handlers because the wrapper's inner
+    `JAL .x1` into `evm_div_callable_v4` / `evm_mod_callable`
+    clobbers `x1` mid-body — `x1` no longer holds the dispatcher's
+    continuation by the time control reaches this tail. -/
+private def signedDivModTail : HandlerTail :=
+  .custom "  mv x10, x14\n  addi x10, x10, 1\n  j .dispatch_loop"
+
+/-- M9 signed division handlers: SDIV (0x05) and SMOD (0x07).
+
+    Different wrapping than M8's DIV/MOD because `evm_sdiv` /
+    `evm_smod` end with a "saved-ra-ret" pattern (`JALR x0, x18, 0`
+    after the wrapper copies `x1` into `x18` at entry) — this
+    bypasses the dispatcher's standard `.advanceAndRet` / `divModTail`
+    tail entirely.
+
+    **Trampoline pattern:**
+    1. `preBody` saves `x10` to `x14` (same register convention as
+       M8 DIV/MOD; `x14` is untouched by both the SDIV/SMOD
+       wrappers and the inner `evm_div_callable_v4` /
+       `evm_mod_callable`) AND loads `x18` with the address of the
+       per-handler `postBodyLabel` stub via `la x18, h_<NAME>_done`.
+    2. The verified body is `evmSdivPatched` / `evmSmodPatched`,
+       which is the verified `evm_sdiv` / `evm_smod` with the
+       leading `ADDI .x18 .x1 0` save_ra_block dropped. Without
+       the splice, that instruction would overwrite the `x18` we
+       just set up in `preBody`.
+    3. When the body's `JALR x0, x18, 0` fires (mid-body, at the
+       wrapper's `evm_sdiv_saved_ra_ret_block`), control jumps to
+       our `postBodyLabel` stub (one of `h_SDIV_done` /
+       `h_SMOD_done`).
+    4. `signedDivModTail` restores `x10` from `x14`, advances the
+       EVM PC, then `j .dispatch_loop` — bypassing the standard
+       `ret` because the inner `JAL` into the divider clobbered
+       `x1` (so `ret` would jump to garbage).
+
+    SMOD note: `evm_smod` still uses the legacy non-v4
+    `evm_mod_callable` (SDIV migrated to v4 in commit `43bb53070`,
+    SMOD's surface hasn't flipped yet). When the verification
+    track migrates SMOD to `evm_mod_callable_v4`, this entry
+    rebinds to the new symbol without other changes. -/
+def signedDivModHandlers : List OpcodeHandlerSpec :=
+  [ { label         := "h_SDIV"
+      opcodes       := [0x05]
+      preBody       := "  mv x14, x10\n  la x18, h_SDIV_done"
+      body          := evmSdivPatched
+      postBodyLabel := some "h_SDIV_done"
+      tail          := signedDivModTail }
+  , { label         := "h_SMOD"
+      opcodes       := [0x07]
+      preBody       := "  mv x14, x10\n  la x18, h_SMOD_done"
+      body          := evmSmodPatched
+      postBodyLabel := some "h_SMOD_done"
+      tail          := signedDivModTail } ]
+
 /-- STOP: transitions out of the dispatcher loop instead of returning
     to it. The body is empty; the dispatcher's `jalr` lands on
     `h_STOP:` which jumps to `.exit_label`. -/
@@ -518,7 +595,7 @@ def stopHandler : OpcodeHandlerSpec :=
     the list for a spec whose `opcodes` contains the byte. -/
 def tinyInterpRegistry : List OpcodeHandlerSpec :=
   pushHandlers ++ dupHandlers ++ swapHandlers ++ singletonHandlers ++
-  memoryHandlers ++ divModHandlers ++ [stopHandler]
+  memoryHandlers ++ divModHandlers ++ signedDivModHandlers ++ [stopHandler]
 
 def tinyInterpDispatchAddUnit : BuildUnit :=
   buildDispatchUnit tinyInterpRegistry evmAddEpilogue tinyInterpAddBytecode

--- a/EvmAsm/Codegen/Tests/Cases.lean
+++ b/EvmAsm/Codegen/Tests/Cases.lean
@@ -175,6 +175,24 @@ def opcodeTestCases : List OpcodeTestCase :=
     { name           := "mod_basic"
       bytecode       := "0x60, 0x03, 0x60, 0x0a, 0x06, 0x00"
       expectedOutHex := "0100000000000000000000000000000000000000000000000000000000000000" }
+    -- ## M9 signed division opcodes (trampoline wrapper for saved-ra-ret)
+  , -- PUSH1 0x02; PUSH1 0x05; SDIV; STOP — signed 5 / 2 = 2 (positive path)
+    { name           := "sdiv_basic"
+      bytecode       := "0x60, 0x02, 0x60, 0x05, 0x05, 0x00"
+      expectedOutHex := "0200000000000000000000000000000000000000000000000000000000000000" }
+  , -- PUSH1 0x02; PUSH1 0x01; NOT; SDIV; STOP
+    -- Stack at SDIV: top = NOT(1) = -2 (= 0xff..fe), second = 2.
+    -- EVM SDIV pops `a` (top) then `b`; computes `a / b` in two's
+    -- complement. -2 / 2 = -1 (= 0xff..ff).
+    { name           := "sdiv_negative"
+      bytecode       := "0x60, 0x02, 0x60, 0x01, 0x19, 0x05, 0x00"
+      expectedOutHex := "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff" }
+  , -- PUSH1 0x05; PUSH1 0x01; NOT; SMOD; STOP
+    -- Stack at SMOD: top = -2, second = 5. EVM SMOD: a % b with
+    -- sign(result) = sign(a). -2 % 5 = -2 (= 0xff..fe).
+    { name           := "smod_negative"
+      bytecode       := "0x60, 0x05, 0x60, 0x01, 0x19, 0x07, 0x00"
+      expectedOutHex := "feffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff" }
   ]
 
 /-- Find a test case by name. -/

--- a/scripts/codegen-opcodes-runtime-check.sh
+++ b/scripts/codegen-opcodes-runtime-check.sh
@@ -76,7 +76,7 @@ while IFS=$'\t' read -r name expected bytecode_csv; do
 
   echo "==> ziskemu -e runtime_dispatcher.elf -i gen-out/$name.input"
   "$ZISKEMU" -e gen-out/runtime_dispatcher.elf -i "gen-out/$name.input" \
-    -o "gen-out/$name.output" -n 200000 \
+    -o "gen-out/$name.output" -n 500000 \
     >"gen-out/$name.emu.log" 2>&1
 
   actual="$(xxd -p -c 64 -l 32 "gen-out/$name.output" | tr -d '\n')"


### PR DESCRIPTION
## Summary

Closes the M8 scope-reduction debt. **SDIV (0x05) and SMOD (0x07)** now route through `tinyInterpRegistry`. Their verified bodies end with a saved-ra-ret (`JALR x0, x18, 0`) that bypasses the dispatcher's standard `mv x10, x14; addi; ret` tail; M9 introduces a **trampoline pattern** via a new `OpcodeHandlerSpec.postBodyLabel : Option String` field — generalisable to any future opcode with the same shape.

- `EvmAsm/Codegen/Dispatch.lean` — extended `OpcodeHandlerSpec` with `postBodyLabel`; `emitSubroutine` emits the optional label between body and tail. Handlers that leave it `none` (all pre-M9) emit byte-identical asm.
- `EvmAsm/Codegen/Programs.lean`:
  - `evmSdivPatched := (evm_sdiv : List Instr).drop 1` and `evmSmodPatched := (evm_smod : List Instr).drop 1` — strip the leading `ADDI .x18 .x1 0` save_ra_block so our trampoline target sticks in x18.
  - `signedDivModTail` = `mv x10, x14; addi x10, x10, 1; j .dispatch_loop` — **NOT** `ret`: the wrapper's inner `JAL .x1` into the callable divider clobbers x1 mid-body, so `ret` would jump to garbage.
  - `signedDivModHandlers` — two entries (`h_SDIV`, `h_SMOD`). Each: `preBody := "  mv x14, x10\n  la x18, h_<NAME>_done"`, `postBodyLabel := some "h_<NAME>_done"`, `tail := signedDivModTail`.
- `EvmAsm/Codegen/Tests/Cases.lean` — 3 new cases:
  - `sdiv_basic` (5 / 2 = 2, positive path)
  - `sdiv_negative` (`NOT` trick yields −2; SDIV(−2, 2) = −1)
  - `smod_negative` (SMOD(−2, 5) = −2, sign(result) = sign(a) per EVM SMOD)
- `scripts/codegen-opcodes-runtime-check.sh` — per-case step budget bumped from 200K → 500K (Knuth-D inner loop + trampoline overhead pushes beyond 200K even for small operands).

## Trampoline mechanics gotcha logged

First attempt used the M8 `divModTail` (= `mv x10, x14; addi; ret`). ziskemu hung with `EmulationNoCompleted`. **Cause:** the wrapper's inner `JAL .x1` into `evm_div_callable_v4` clobbers `x1`, so by the time control reaches the restore stub `x1` no longer points at the dispatcher's continuation. **Fix:** swap `ret` for `j .dispatch_loop`. Logged in CODEGEN.md.

## Test plan

- [ ] `lake build codegen` passes (the `postBodyLabel` field default + patched bodies typecheck)
- [ ] `bash scripts/codegen-opcodes-runtime-check.sh` exits 0 with all **29 cases PASS** (~30 s wall-clock; the SDIV/SMOD inner loops add some time but still well under the 60 s threshold)
- [ ] `bash scripts/codegen-opcodes-check.sh` (legacy fallback) still passes the same 29 cases
- [ ] Pre-existing scripts unchanged: `codegen-smoke.sh`, `codegen-tiny-interp{,-dispatch}-check.sh`, `codegen-evm_add{,-from-input}-check.sh`, `codegen-evm_div{,-cases}-check.sh`, `codegen-evm_mod{,-cases}-check.sh`
- [ ] `bash scripts/check-progress.sh` exits 0 (PROGRESS.md drift is snapshot-line-only, ignored)
- [ ] Disassembly spot-check on `gen-out/runtime_dispatcher.s` — `h_SDIV:` starts with `mv x14, x10` then `la x18, h_SDIV_done`, body's `jalr x0, 0(x18)` jumps forward to `h_SDIV_done:`, which falls through to `mv x10, x14; addi x10, x10, 1; j .dispatch_loop`. Body splice means the spliced-off `ADDI x18, x1, 0` is **not** present at the start of the body.

## SMOD v4 follow-up

`evm_smod` still uses the legacy non-v4 `evm_mod_callable`. SDIV migrated to v4 in commit `43bb53070`; SMOD's surface hasn't flipped yet. When the verification track migrates SMOD, this PR's `evmSmodPatched` definition rebinds to the new symbol with no other changes.

## What this unblocks

- **M10 — ADDMOD / EXP via `callableLabel?`** can now extend `OpcodeHandlerSpec` with a parallel field for opcodes that are **near-called** from other handler bodies (ADDMOD calls MOD; EXP calls MUL).
- **M11 — JUMP / JUMPI / JUMPDEST / PC / GAS** is the biggest remaining unblock toward running real EVM programs.
- **M12+ — Stateless guest bridge** still on the long arc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)