### PR TITLE
feat(smod): use v4 callable for signed programs

### DIFF
--- a/EvmAsm/Evm64/SDiv/Program.lean
+++ b/EvmAsm/Evm64/SDiv/Program.lean
@@ -9,7 +9,7 @@
       1. extract sign of each operand (top bit of limb 3)
       2. conditionally two's-complement negate operands so both are
          non-negative; remember the sign-pair
-      3. JAL to an `evm_div_callable` shim (LP64) for unsigned division
+      3. JAL to an `evm_div_callable_v4` shim (LP64) for unsigned division
       4. conditionally negate the quotient based on `sign(a) XOR sign(b)`.
 
   The `SDIV(-2^255, -1)` case follows this same bitvector path: the
@@ -125,7 +125,7 @@ theorem evm_sdiv_cond_negate_256_block_byte_length
       limb0Off limb1Off limb2Off limb3Off).length = 84 := by
   rw [evm_sdiv_cond_negate_256_block_length]
 
-/-- Near-call block from SDIV into the unsigned `evm_div_callable` body.
+/-- Near-call block from SDIV into the unsigned `evm_div_callable_v4` body.
     The concrete signed 21-bit offset is pinned by the eventual top-level
     `evm_sdiv` layout. -/
 def evm_sdiv_div_call_block (divOff : BitVec 21) : EvmAsm.Rv64.Program :=
@@ -174,7 +174,7 @@ def evm_sdivCallOff : BitVec 21 := 92
     * `x9` stores `sign(divisor)`.
     * `x10`, `x11`, and `x7` are scratch registers for conditional negation.
 
-    Memory layout matches `evm_div_callable`: dividend at `sp + 0..24`,
+    Memory layout matches `evm_div_callable_v4`: dividend at `sp + 0..24`,
     divisor at `sp + 32..56`, quotient result at `sp + 32..56`. -/
 def evm_sdiv_wrapper : EvmAsm.Rv64.Program :=
   evm_sdiv_save_ra_block .x18 ;;
@@ -219,27 +219,30 @@ theorem evm_sdiv_legacy_length : evm_sdiv_legacy.length = 390 := by
 theorem evm_sdiv_legacy_byte_length : 4 * evm_sdiv_legacy.length = 1560 := by
   rw [evm_sdiv_legacy_length]
 
-/-- Full SDIV code region (non-v4). -/
+/-- Full SDIV code region, using the corrected v4 unsigned DIV callable. -/
 def evm_sdiv : EvmAsm.Rv64.Program :=
-  evm_sdiv_wrapper ;; evm_div_callable
+  evm_sdiv_wrapper ;; evm_div_callable_v4
 
-/-- v4 full SDIV code region. This keeps the same SDIV wrapper and swaps the
-    appended unsigned DIV callable to the corrected v4 divider body. -/
+/-- v4 full SDIV code region. Kept as an explicit alias while downstream
+    scripts and proofs finish migrating to the canonical `evm_sdiv` name. -/
 def evm_sdiv_v4 : EvmAsm.Rv64.Program :=
   evm_sdiv_wrapper ;; evm_div_callable_v4
+
+/-- Regression pin: canonical executable SDIV is now the v4 body. -/
+theorem evm_sdiv_eq_v4 : evm_sdiv = evm_sdiv_v4 := rfl
 
 /-- Regression pin: the executable v4 SDIV body uses the corrected v4
     callable divider. -/
 theorem evm_sdiv_v4_uses_div_callable_v4 :
     evm_sdiv_v4 = (evm_sdiv_wrapper ;; evm_div_callable_v4) := rfl
 
-theorem evm_sdiv_length : evm_sdiv.length = 390 := by
+theorem evm_sdiv_length : evm_sdiv.length = 414 := by
   native_decide
 
 theorem evm_sdiv_v4_length : evm_sdiv_v4.length = 414 := by
   native_decide
 
-theorem evm_sdiv_byte_length : 4 * evm_sdiv.length = 1560 := by
+theorem evm_sdiv_byte_length : 4 * evm_sdiv.length = 1656 := by
   rw [evm_sdiv_length]
 
 theorem evm_sdiv_v4_byte_length : 4 * evm_sdiv_v4.length = 1656 := by

--- a/EvmAsm/Evm64/SMod/Program.lean
+++ b/EvmAsm/Evm64/SMod/Program.lean
@@ -9,7 +9,7 @@
       1. extract sign of each operand (top bit of limb 3)
       2. conditionally two's-complement negate operands so both are
          non-negative; remember `sign(a)`
-      3. JAL to an `evm_mod_callable` shim (LP64) for unsigned modulo
+      3. JAL to an `evm_mod_callable_v4` shim (LP64) for unsigned modulo
       4. conditionally negate the remainder based on `sign(a)`
          (EVM SMOD takes the sign of the dividend)
 
@@ -62,7 +62,7 @@ theorem evm_smod_saved_ra_ret_block_byte_length (savedRaReg : Reg) :
     * `x9` stores `sign(divisor)` only for absolute-value normalization.
     * `x10`, `x11`, and `x7` are scratch registers for conditional negation.
 
-    Memory layout matches `evm_mod_callable`: dividend at `sp + 0..24`,
+    Memory layout matches `evm_mod_callable_v4`: dividend at `sp + 0..24`,
     divisor at `sp + 32..56`, remainder result at `sp + 32..56`. -/
 def evm_smod_wrapper : Program :=
   evm_smod_save_ra_block .x18 ;;
@@ -94,23 +94,36 @@ theorem evm_smod_call_target_byte_offset :
     4 * evm_smod_wrapper.length := by
   native_decide
 
-/-- Full SMOD code region. The wrapper returns via `x18`; the appended
+/-- Legacy SMOD code region. The wrapper returns via `x18`; the appended
     `evm_mod_callable` block is reached only by the wrapper's near call. -/
-def evm_smod : Program :=
+def evm_smod_legacy : Program :=
   evm_smod_wrapper ;; evm_mod_callable
 
-/-- v4 full SMOD code region. This keeps the same SMOD wrapper and swaps the
-    appended unsigned MOD callable to the corrected v4 divider body. -/
+/-- Full SMOD code region, using the corrected v4 unsigned MOD callable. -/
+def evm_smod : Program :=
+  evm_smod_wrapper ;; evm_mod_callable_v4
+
+/-- v4 full SMOD code region. Kept as an explicit alias while downstream
+    scripts and proofs finish migrating to the canonical `evm_smod` name. -/
 def evm_smod_v4 : Program :=
   evm_smod_wrapper ;; evm_mod_callable_v4
 
-theorem evm_smod_length : evm_smod.length = 390 := by
+/-- Regression pin: canonical executable SMOD is now the v4 body. -/
+theorem evm_smod_eq_v4 : evm_smod = evm_smod_v4 := rfl
+
+theorem evm_smod_legacy_length : evm_smod_legacy.length = 390 := by
+  native_decide
+
+theorem evm_smod_length : evm_smod.length = 414 := by
   native_decide
 
 theorem evm_smod_v4_length : evm_smod_v4.length = 414 := by
   native_decide
 
-theorem evm_smod_byte_length : 4 * evm_smod.length = 1560 := by
+theorem evm_smod_legacy_byte_length : 4 * evm_smod_legacy.length = 1560 := by
+  rw [evm_smod_legacy_length]
+
+theorem evm_smod_byte_length : 4 * evm_smod.length = 1656 := by
   rw [evm_smod_length]
 
 theorem evm_smod_v4_byte_length : 4 * evm_smod_v4.length = 1656 := by


### PR DESCRIPTION
## Summary
- make canonical evm_sdiv and evm_smod append the corrected v4 unsigned callables
- keep explicit legacy signed program names for the old v1 callable surfaces
- pin canonical signed programs to their v4 aliases and update byte-length lemmas

## Verification
- lake build EvmAsm.Evm64.SDiv.Program
- lake build EvmAsm.Evm64.SMod.Program
- lake build EvmAsm.Evm64.SDiv
- lake build EvmAsm.Evm64.SMod
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- scripts/check-file-size.sh
- rg -n "DivStackSpecCase|ModStackSpecCase|SDivStackSpecCase|SModStackSpecCase|StackSpecCase|set_option maxHeartbeats|set_option maxRecDepth|sorry|admit" EvmAsm/Evm64/SDiv/Program.lean EvmAsm/Evm64/SMod/Program.lean (no matches)

Part of evm-asm-9iqmw.4.8; the bead remains open until the canonical callable/spec surfaces are migrated too.