### PR TITLE
refactor(divmod): pin callable v4 lengths

### DIFF
--- a/EvmAsm/Evm64/DivMod/Callable.lean
+++ b/EvmAsm/Evm64/DivMod/Callable.lean
@@ -121,6 +121,55 @@ def evm_mod_callable_v4 : Program :=
   cc_ret ;;
   divK_div128_v4
 
+/-- `cc_ret = JALR x0 x1 0` is exactly one instruction. -/
+theorem cc_ret_len : cc_ret.length = 1 := by decide
+
+theorem evm_div_callable_length : evm_div_callable.length = 319 := by
+  unfold evm_div_callable
+  simp only [seq, Program.length_append, divK_phaseA_len, divK_phaseB_len, divK_clz_len,
+    divK_phaseC2_len,
+    divK_normB_len, divK_normA_len, divK_copyAU_len, divK_loopSetup_len,
+    divK_loopBody_len, divK_denorm_len, divK_divEpilogue_len, divK_zeroPath_len,
+    cc_ret_len, divK_div128_len]
+
+theorem evm_mod_callable_length : evm_mod_callable.length = 319 := by
+  unfold evm_mod_callable
+  simp only [seq, Program.length_append, divK_phaseA_len, divK_phaseB_len, divK_clz_len,
+    divK_phaseC2_len,
+    divK_normB_len, divK_normA_len, divK_copyAU_len, divK_loopSetup_len,
+    divK_loopBody_len, divK_denorm_len, divK_modEpilogue_len, divK_zeroPath_len,
+    cc_ret_len, divK_div128_len]
+
+theorem evm_div_callable_byte_length : 4 * evm_div_callable.length = 1276 := by
+  rw [evm_div_callable_length]
+
+theorem evm_mod_callable_byte_length : 4 * evm_mod_callable.length = 1276 := by
+  rw [evm_mod_callable_length]
+
+theorem evm_div_callable_v4_length : evm_div_callable_v4.length = 343 := by
+  unfold evm_div_callable_v4
+  simp only [seq, Program.length_append, divK_phaseA_len, divK_phaseB_len, divK_clz_len,
+    divK_phaseC2_len,
+    divK_normB_len, divK_normA_len, divK_copyAU_len, divK_loopSetup_len,
+    divK_loopBody_len, divK_denorm_len, divK_divEpilogue_len, divK_zeroPath_len,
+    cc_ret_len, divK_div128_v4_len]
+
+theorem evm_mod_callable_v4_length : evm_mod_callable_v4.length = 343 := by
+  unfold evm_mod_callable_v4
+  simp only [seq, Program.length_append, divK_phaseA_len, divK_phaseB_len, divK_clz_len,
+    divK_phaseC2_len,
+    divK_normB_len, divK_normA_len, divK_copyAU_len, divK_loopSetup_len,
+    divK_loopBody_len, divK_denorm_len, divK_modEpilogue_len, divK_zeroPath_len,
+    cc_ret_len, divK_div128_v4_len]
+
+theorem evm_div_callable_v4_byte_length :
+    4 * evm_div_callable_v4.length = 1372 := by
+  rw [evm_div_callable_v4_length]
+
+theorem evm_mod_callable_v4_byte_length :
+    4 * evm_mod_callable_v4.length = 1372 := by
+  rw [evm_mod_callable_v4_length]
+
 -- ============================================================================
 -- CodeReq abbreviations
 -- ============================================================================
@@ -295,9 +344,6 @@ theorem evm_div_callable_code_eq_ofProg (base : Word) :
 -- instead of the NOP — the offset is identical (both length 1), so the
 -- disjointness side conditions match modulo a `cc_ret.length = 1` fact.
 -- ============================================================================
-
-/-- `cc_ret = JALR x0 x1 0` is exactly one instruction. -/
-theorem cc_ret_len : cc_ret.length = 1 := by decide
 
 /-- Variant of `skipBlock` (from `Compose.Base`) that also knows
     `cc_ret.length = 1`. Needed when the block-being-skipped is


### PR DESCRIPTION
## Summary
- add explicit length and byte-length pins for v1 and v4 DIV/MOD callable programs
- move `cc_ret_len` next to the callable program definitions so these pins and later code proofs share the same fact
- use existing block length lemmas instead of expanding the full program with `decide`

This is a preparatory slice for evm-asm-9iqmw.4.8. It does not flip the canonical callable definitions yet; it records the old 319-instruction/v4 343-instruction lengths needed by that migration.

## Verification
- `lake build EvmAsm.Evm64.DivMod.Callable`
- `lake build EvmAsm.Evm64.DivMod`
- `git diff --check`
- `scripts/check-file-size.sh`
- `git diff -U0 -- EvmAsm/Evm64/DivMod/Callable.lean | rg -n "DivStackSpecCase|ModStackSpecCase|SDivStackSpecCase|SModStackSpecCase|StackSpecCase|set_option maxHeartbeats|set_option maxRecDepth|sorry|admit"` (no matches in added diff)

Note: a broad scan of `Callable.lean` still sees pre-existing `DivStackSpecCase`/`ModStackSpecCase` theorem parameters; this PR adds none.
