### PR TITLE
refactor(divmod): decouple v1 div framed spec

### DIFF
--- a/EvmAsm/Evm64/DivMod/CallableV1Legacy.lean
+++ b/EvmAsm/Evm64/DivMod/CallableV1Legacy.lean
@@ -450,11 +450,12 @@ theorem evm_div_callable_v1_spec_from_noNop_branch_return_x1_framed
         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
         shiftMem nMem jMem retMem dMem dloMem scratchUn0 ** F)
       ((divStackDispatchPostNoX1 sp a b ** (.x1 ↦ᵣ branch.returnX1)) ** F) := by
-  simpa [evm_div_callable_code_v1_eq_current]
-    using evm_div_callable_spec_from_noNop_branch_return_x1_framed
-      (F := F) sp base a b v5 v6 v7 v10 v11
-      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-      nMem shiftMem jMem retMem dMem dloMem scratchUn0 branch hStack
+  exact
+    cpsTripleWithin_frameR F (by pcFree)
+      (evm_div_callable_v1_spec_from_noNop_branch_return_x1
+        sp base a b v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        nMem shiftMem jMem retMem dMem dloMem scratchUn0 branch hStack)
 
 theorem evm_mod_callable_v1_spec_from_noNop_preserving_x1 (sp base raVal : Word)
     (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)


### PR DESCRIPTION
## Summary
- decouple `evm_div_callable_v1_spec_from_noNop_branch_return_x1_framed` from the current canonical DIV callable code surface
- prove the framed v1 wrapper by framing the local v1 branch-return theorem
- keep this stacked on #5484

This completes the small DIV-side v1 wrapper decoupling chain. The MOD wrappers still need the same treatment before the canonical callable names can move cleanly to v4.

## Verification
- `lake build EvmAsm.Evm64.DivMod.CallableV1Legacy`
- `lake build EvmAsm.Evm64.DivMod`
- `git diff --check`
- `scripts/check-file-size.sh`
- `git diff -U0 -- EvmAsm/Evm64/DivMod/CallableV1Legacy.lean | rg -n "DivStackSpecCase|ModStackSpecCase|SDivStackSpecCase|SModStackSpecCase|StackSpecCase|set_option maxHeartbeats|set_option maxRecDepth|sorry|admit"` (no matches in added diff)
