### PR TITLE
refactor(divmod): decouple v1 mod preserving spec

### DIFF
--- a/EvmAsm/Evm64/DivMod/CallableV1Legacy.lean
+++ b/EvmAsm/Evm64/DivMod/CallableV1Legacy.lean
@@ -476,11 +476,16 @@ theorem evm_mod_callable_v1_spec_from_noNop_preserving_x1 (sp base raVal : Word)
         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
         shiftMem nMem jMem retMem dMem dloMem scratchUn0)
       (modStackDispatchPostNoX1 sp a b ** (.x1 ↦ᵣ raVal)) := by
-  simpa [evm_mod_callable_code_v1_eq_current]
-    using evm_mod_callable_spec_from_noNop_preserving_x1
-      sp base raVal a b v5 v6 v7 v10 v11
-      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-      nMem shiftMem jMem retMem dMem dloMem scratchUn0 branch hStack
+  have hpcFreePost : (modStackDispatchPostNoX1 sp a b).pcFree :=
+    modStackDispatchPostNoX1_pcFree sp a b
+  have hStackCall :=
+    cpsTripleWithin_extend_code (hmono := modCode_noNop_sub_mod_callable_code_v1) hStack
+  have hRet :=
+    cpsTripleWithin_extend_code (hmono := evm_mod_callable_code_v1_ret_sub (base := base))
+      (ret_spec_within' (base + nopOff) raVal)
+  have hRetFramed :=
+    cpsTripleWithin_frameL (modStackDispatchPostNoX1 sp a b) hpcFreePost hRet
+  exact cpsTripleWithin_seq_same_cr hStackCall hRetFramed
 
 theorem evm_mod_callable_v1_spec_from_noNop (sp base raVal : Word)
     (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)


### PR DESCRIPTION
## Summary
- decouple `evm_mod_callable_v1_spec_from_noNop_preserving_x1` from the current canonical MOD callable code surface
- compose it directly from the local v1 `modCode_noNop` subsumption and v1 return-slot lemmas
- keep this stacked on #5485

This starts the MOD-side v1 wrapper decoupling needed before `evm-asm-9iqmw.4.8` can flip the canonical callable names to v4.

## Verification
- `lake build EvmAsm.Evm64.DivMod.CallableV1Legacy`
- `lake build EvmAsm.Evm64.DivMod`
- `git diff --check`
- `scripts/check-file-size.sh`
- `git diff -U0 -- EvmAsm/Evm64/DivMod/CallableV1Legacy.lean | rg -n "DivStackSpecCase|ModStackSpecCase|SDivStackSpecCase|SModStackSpecCase|StackSpecCase|set_option maxHeartbeats|set_option maxRecDepth|sorry|admit"` (no matches in added diff)
