### PR TITLE
refactor(divmod): decouple v1 mod callable spec

### DIFF
--- a/EvmAsm/Evm64/DivMod/CallableV1Legacy.lean
+++ b/EvmAsm/Evm64/DivMod/CallableV1Legacy.lean
@@ -506,10 +506,19 @@ theorem evm_mod_callable_v1_spec_from_noNop (sp base raVal : Word)
         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
         shiftMem nMem jMem retMem dMem dloMem scratchUn0 ** (.x1 ↦ᵣ raVal))
       (modStackDispatchPost sp a b ** (.x1 ↦ᵣ raVal)) := by
-  simpa [evm_mod_callable_code_v1_eq_current]
-    using evm_mod_callable_spec_from_noNop
-      sp base raVal a b v5 v6 v7 v10 v11
-      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-      nMem shiftMem jMem retMem dMem dloMem scratchUn0 branch hStack
+  have hpcFreePost : (modStackDispatchPost sp a b).pcFree := by
+    rw [modStackDispatchPost_unfold]
+    rw [divScratchOwnCall_unfold, divScratchOwn_unfold]
+    pcFree
+  have hStackCall :=
+    cpsTripleWithin_extend_code (hmono := modCode_noNop_sub_mod_callable_code_v1) hStack
+  have hStackFramed :=
+    cpsTripleWithin_frameR (.x1 ↦ᵣ raVal) (by pcFree) hStackCall
+  have hRet :=
+    cpsTripleWithin_extend_code (hmono := evm_mod_callable_code_v1_ret_sub (base := base))
+      (ret_spec_within' (base + nopOff) raVal)
+  have hRetFramed :=
+    cpsTripleWithin_frameL (modStackDispatchPost sp a b) hpcFreePost hRet
+  exact cpsTripleWithin_seq_same_cr hStackFramed hRetFramed
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- decouple `evm_mod_callable_v1_spec_from_noNop` from the current canonical MOD callable code surface
- compose it directly from the local v1 `modCode_noNop` subsumption and v1 return-slot lemmas
- keep this stacked on #5486

This completes the v1 wrapper decoupling in `CallableV1Legacy.lean`; the remaining work for `evm-asm-9iqmw.4.8` is the canonical callable flip to v4 and downstream fallout.

## Verification
- `lake build EvmAsm.Evm64.DivMod.CallableV1Legacy`
- `lake build EvmAsm.Evm64.DivMod`
- `git diff --check`
- `scripts/check-file-size.sh`
- `git diff -U0 -- EvmAsm/Evm64/DivMod/CallableV1Legacy.lean | rg -n "DivStackSpecCase|ModStackSpecCase|SDivStackSpecCase|SModStackSpecCase|StackSpecCase|set_option maxHeartbeats|set_option maxRecDepth|sorry|admit"` (no matches in added diff)
