### PR TITLE
refactor(sdiv): use legacy v1 callable code bridge

### DIFF
--- a/EvmAsm/Evm64/DivMod/CallableV1Legacy.lean
+++ b/EvmAsm/Evm64/DivMod/CallableV1Legacy.lean
@@ -95,6 +95,56 @@ theorem evm_mod_callable_code_v1_eq_current (base : Word) :
     evm_mod_callable_code_v1 base = evm_mod_callable_code base := by
   rfl
 
+open EvmAsm.Rv64.CodeReq in
+theorem evm_div_callable_code_v1_eq_ofProg (base : Word) :
+    evm_div_callable_code_v1 base = CodeReq.ofProg base evm_div_callable_v1 := by
+  unfold evm_div_callable_code_v1 evm_div_callable_v1 cc_ret_code
+  simp only [unionAll_cons, unionAll_nil, union_empty_right]
+  unfold seq
+  unfold Program
+  symm
+  rw [ofProg_append]
+  rw [show base + BitVec.ofNat 64 (4 * (divK_phaseA 1020).length) =
+        base + phaseBOff by rw [divK_phaseA_len]; rfl]
+  rw [ofProg_append]
+  rw [show (base + phaseBOff) + BitVec.ofNat 64 (4 * divK_phaseB.length) =
+        base + clzOff by rw [divK_phaseB_len]; bv_omega]
+  rw [ofProg_append]
+  rw [show (base + clzOff) + BitVec.ofNat 64 (4 * divK_clz.length) =
+        base + phaseC2Off by rw [divK_clz_len]; bv_omega]
+  rw [ofProg_append]
+  rw [show (base + phaseC2Off) + BitVec.ofNat 64 (4 * (divK_phaseC2 172).length) =
+        base + normBOff by rw [divK_phaseC2_len]; bv_omega]
+  rw [ofProg_append]
+  rw [show (base + normBOff) + BitVec.ofNat 64 (4 * divK_normB.length) =
+        base + normAOff by rw [divK_normB_len]; bv_omega]
+  rw [ofProg_append]
+  rw [show (base + normAOff) + BitVec.ofNat 64 (4 * (divK_normA 40).length) =
+        base + copyAUOff by rw [divK_normA_len]; bv_omega]
+  rw [ofProg_append]
+  rw [show (base + copyAUOff) + BitVec.ofNat 64 (4 * divK_copyAU.length) =
+        base + loopSetupOff by rw [divK_copyAU_len]; bv_omega]
+  rw [ofProg_append]
+  rw [show (base + loopSetupOff) + BitVec.ofNat 64 (4 * (divK_loopSetup 464).length) =
+        base + loopBodyOff by rw [divK_loopSetup_len]; bv_omega]
+  rw [ofProg_append]
+  rw [show (base + loopBodyOff) + BitVec.ofNat 64 (4 * (divK_loopBody 560 7736).length) =
+        base + denormOff by rw [divK_loopBody_len]; bv_omega]
+  rw [ofProg_append]
+  rw [show (base + denormOff) + BitVec.ofNat 64 (4 * divK_denorm.length) =
+        base + epilogueOff by rw [divK_denorm_len]; bv_omega]
+  rw [ofProg_append]
+  rw [show (base + epilogueOff) + BitVec.ofNat 64 (4 * (divK_div_epilogue 24).length) =
+        base + zeroPathOff by rw [divK_divEpilogue_len]; bv_omega]
+  rw [ofProg_append]
+  rw [show (base + zeroPathOff) + BitVec.ofNat 64 (4 * divK_zeroPath.length) =
+        base + nopOff by rw [divK_zeroPath_len]; bv_omega]
+  rw [ofProg_append]
+  rw [show (base + nopOff) + BitVec.ofNat 64 (4 * cc_ret.length) =
+        base + div128Off by
+    show (base + nopOff) + BitVec.ofNat 64 (4 * 1) = base + div128Off
+    bv_omega]
+
 -- ----------------------------------------------------------------------------
 -- Legacy v1 code subsumption lemmas
 -- ----------------------------------------------------------------------------

--- a/EvmAsm/Evm64/SDiv/Compose/Base.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/Base.lean
@@ -61,8 +61,8 @@ theorem sdivCode_div_callable_v1_sub {base : Word} :
     ∀ a i, (evm_div_callable_code_v1 (base + 284)) a = some i →
       (sdivCode base) a = some i := by
   intro a i h
-  rw [evm_div_callable_code_v1_eq_current (base + 284)] at h
-  rw [evm_div_callable_code_eq_ofProg (base + 284)] at h
+  rw [evm_div_callable_code_v1_eq_ofProg (base + 284)] at h
+  rw [evm_div_callable_v1_eq_current] at h
   unfold sdivCode
   exact EvmAsm.Rv64.CodeReq.ofProg_mono_sub base (base + 284)
     evm_sdiv_legacy evm_div_callable 71

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallCallable.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallCallable.lean
@@ -30,8 +30,17 @@ theorem evm_div_callable_code_v1_sub_sdivCode {base : Word} :
     ∀ a i,
       (EvmAsm.Evm64.evm_div_callable_code_v1 (base + wrapperEndOff)) a = some i →
       (sdivCode base) a = some i := by
-  simpa [EvmAsm.Evm64.evm_div_callable_code_v1_eq_current]
-    using evm_div_callable_code_sub_sdivCode (base := base)
+  intro a i h
+  have hOfProg :
+      (EvmAsm.Rv64.CodeReq.ofProg
+        (base + wrapperEndOff) EvmAsm.Evm64.evm_div_callable) a =
+        some i := by
+    rw [← EvmAsm.Evm64.evm_div_callable_v1_eq_current]
+    rw [← EvmAsm.Evm64.evm_div_callable_code_v1_eq_ofProg (base + wrapperEndOff)]
+    exact h
+  exact sdivCode_divCallable_sub (base := base) a i
+    (by
+      simpa [divCallableCode] using hOfProg)
 
 theorem evm_div_callable_code_v4_sub_sdivCodeV4 {base : Word} :
     ∀ a i,


### PR DESCRIPTION
Stacked on PR #5487.

Summary:
- Add a legacy v1 DIV callable code-to-ofProg bridge.
- Switch SDiv compose subsumption proofs away from evm_div_callable_code_v1_eq_current.
- Leave only the legacy v1 code equality declarations themselves.

Verification:
- lake build EvmAsm.Evm64.DivMod.CallableV1Legacy
- lake build EvmAsm.Evm64.SDiv.Compose.Base
- lake build EvmAsm.Evm64.SDiv.Compose.DivCallCallable
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- scripts/check-file-size.sh
- added-diff forbidden-pattern scan for stack-case assumptions, sorry/admit, and local heartbeat/recursion options