### PR TITLE
refactor(sdiv): use v1 callable code handles

### DIFF
--- a/EvmAsm/Evm64/SDiv/Compose/BaseCode.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BaseCode.lean
@@ -113,7 +113,7 @@ theorem sdivCode_divCallable_sub {base : Word} :
     ∀ a i, (divCallableCode base) a = some i → (sdivCode base) a = some i := by
   unfold divCallableCode sdivCode
   exact EvmAsm.Rv64.CodeReq.ofProg_mono_sub base (base + wrapperEndOff)
-    EvmAsm.Evm64.evm_sdiv_legacy EvmAsm.Evm64.evm_div_callable 71
+    EvmAsm.Evm64.evm_sdiv_legacy EvmAsm.Evm64.evm_div_callable_v1 71
     (by simp [wrapperEndOff])
     (by native_decide)
     (by native_decide)

--- a/EvmAsm/Evm64/SDiv/Compose/BzeroCallable.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/BzeroCallable.lean
@@ -74,7 +74,7 @@ theorem saveRa_signs_abs_signXor_then_divCall_bzero_callable_spec_in_sdivCode
       (by simpa [divisorAbsWord] using hbz)
   have hCallableCode :=
     EvmAsm.Rv64.cpsTripleWithin_extend_code
-      (hmono := evm_div_callable_code_sub_sdivCode (base := base)) hCallableRaw
+      (hmono := evm_div_callable_code_v1_sub_sdivCode (base := base)) hCallableRaw
   have hCallableFramed :=
     EvmAsm.Rv64.cpsTripleWithin_frameR signFrameNoX9 (by
       dsimp [signFrameNoX9]

--- a/EvmAsm/Evm64/SDiv/Compose/CodeHandles.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/CodeHandles.lean
@@ -10,7 +10,7 @@ import EvmAsm.Evm64.SDiv.Compose.BaseOffsets
 
 namespace EvmAsm.Evm64.SDiv.Compose
 
-/-- Legacy verified SDIV code region handle: wrapper followed by `evm_div_callable`. -/
+/-- Legacy verified SDIV code region handle: wrapper followed by `evm_div_callable_v1`. -/
 abbrev sdivCode (base : Word) : EvmAsm.Rv64.CodeReq :=
   EvmAsm.Rv64.CodeReq.ofProg base EvmAsm.Evm64.evm_sdiv_legacy
 
@@ -50,7 +50,7 @@ abbrev divisorAbsCode (base : Word) : EvmAsm.Rv64.CodeReq :=
 abbrev signXorCode (base : Word) : EvmAsm.Rv64.CodeReq :=
   EvmAsm.Rv64.CodeReq.ofProg (base + signXorOff) (EvmAsm.Rv64.XOR' .x8 .x8 .x9)
 
-/-- Code handle for the near call into `evm_div_callable`. -/
+/-- Code handle for the near call into the legacy v1 DIV callable. -/
 abbrev divCallCode (base : Word) : EvmAsm.Rv64.CodeReq :=
   EvmAsm.Rv64.CodeReq.ofProg (base + divCallOff)
     (EvmAsm.Evm64.evm_sdiv_div_call_block EvmAsm.Evm64.evm_sdivCallOff)
@@ -66,9 +66,9 @@ abbrev savedRaRetCode (base : Word) : EvmAsm.Rv64.CodeReq :=
   EvmAsm.Rv64.CodeReq.ofProg (base + savedRaRetOff)
     (EvmAsm.Evm64.evm_sdiv_saved_ra_ret_block .x18)
 
-/-- Code handle for the appended unsigned divider callable. -/
+/-- Code handle for the appended legacy v1 unsigned divider callable. -/
 abbrev divCallableCode (base : Word) : EvmAsm.Rv64.CodeReq :=
-  EvmAsm.Rv64.CodeReq.ofProg (base + wrapperEndOff) EvmAsm.Evm64.evm_div_callable
+  EvmAsm.Rv64.CodeReq.ofProg (base + wrapperEndOff) EvmAsm.Evm64.evm_div_callable_v1
 
 /-- Code handle for the appended v4 unsigned divider callable. -/
 abbrev divCallableCodeV4 (base : Word) : EvmAsm.Rv64.CodeReq :=

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallBzeroHandoff.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallBzeroHandoff.lean
@@ -62,7 +62,7 @@ theorem saveRaDivCallDispatchReadyPost_bzero_callable_spec_in_sdivCode
       (by simpa [divisorAbsWord] using hbz)
   have hCallableCode :=
     EvmAsm.Rv64.cpsTripleWithin_extend_code
-      (hmono := evm_div_callable_code_sub_sdivCode (base := base)) hCallableRaw
+      (hmono := evm_div_callable_code_v1_sub_sdivCode (base := base)) hCallableRaw
   have hCallableFramed :=
     EvmAsm.Rv64.cpsTripleWithin_frameR signFrameNoX9 (by
       dsimp [signFrameNoX9]

--- a/EvmAsm/Evm64/SDiv/Compose/DivCallExactCallable.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/DivCallExactCallable.lean
@@ -138,7 +138,7 @@ theorem evm_div_callable_preserving_x1_x9_exact_pre_spec_in_sdivCode
         (.x9 ↦ᵣ x9Val)) := by
   exact
     EvmAsm.Rv64.cpsTripleWithin_extend_code
-      (hmono := evm_div_callable_code_sub_sdivCode (base := base))
+      (hmono := evm_div_callable_code_v1_sub_sdivCode (base := base))
       (EvmAsm.Evm64.evm_div_callable_v1_spec_from_noNop_preserving_x1_x9
         sp (base + wrapperEndOff) x9Val raVal a b v2 v5 v6 v7 v10 v11
         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
@@ -210,7 +210,7 @@ theorem evm_div_callable_concrete_preserving_x1_x9_exact_pre_spec_in_sdivCode
         shiftMem nMem jMem retMem dMem dloMem scratchUn0) := by
   exact
     EvmAsm.Rv64.cpsTripleWithin_extend_code
-      (hmono := evm_div_callable_code_sub_sdivCode (base := base))
+      (hmono := evm_div_callable_code_v1_sub_sdivCode (base := base))
       (EvmAsm.Evm64.evm_div_callable_v1_spec_from_noNop_concrete_preserving_x1_x9
         sp (base + wrapperEndOff) x9Val raVal a b v2 v5 v6 v7 v10 v11
         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7


### PR DESCRIPTION
## Summary
- point the legacy SDiv appended divider code handle at evm_div_callable_v1
- use the explicit v1 SDiv code subsumption theorem at DIV-call handoff sites
- keep this as a small stack slice ahead of flipping the canonical DIV callable

## Verification
- lake build EvmAsm.Evm64.SDiv.Compose.BaseCode EvmAsm.Evm64.SDiv.Compose.DivCallExactCallable EvmAsm.Evm64.SDiv.Compose.DivCallBzeroHandoff EvmAsm.Evm64.SDiv.Compose.BzeroCallable
- lake build EvmAsm.Evm64.DivMod EvmAsm.Evm64.SDiv
- git diff --check
- scripts/check-file-size.sh
- added-diff scan for StackSpecCase/heartbeat/recDepth/sorry/admit additions