### PR TITLE
feat(divmod): add v4 div callable nox9 bzero spec

### DIFF
--- a/EvmAsm/Evm64/DivMod/CallableBzeroV4.lean
+++ b/EvmAsm/Evm64/DivMod/CallableBzeroV4.lean
@@ -81,4 +81,27 @@ theorem evm_div_callable_bzero_v4_preserving_x1_framed_spec
         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
         nMem shiftMem jMem retMem dMem dloMem scratchUn0 hbz)
 
+/-- v4 zero-divisor DIV callable wrapper with exact `x1` and no `x9` frame. -/
+theorem evm_div_callable_bzero_v4_preserving_x1_noX9_spec (sp base raVal : Word)
+    (a b : EvmWord) (v2 v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (hbz : b = 0) :
+    cpsTripleWithin (unifiedDivBound + 1) base (raVal &&& ~~~1)
+      (evm_div_callable_code_v4 base)
+      (divModStackDispatchPreCallable sp a b
+        raVal v2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+      (divStackDispatchPostCallable sp a b ** (.x1 ↦ᵣ raVal)) := by
+  exact
+    evm_div_callable_v4_spec_from_noNop_preserving_x1_noX9
+      sp base raVal a b v2 v5 v6 v7 v10 v11
+      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      nMem shiftMem jMem retMem dMem dloMem scratchUn0
+      (evm_div_bzero_stack_spec_within_dispatch_noNop_v4_callable_x1_uni
+        sp base a b raVal v2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        nMem shiftMem jMem retMem dMem dloMem scratchUn0 hbz)
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/CallableV4Div.lean
+++ b/EvmAsm/Evm64/DivMod/CallableV4Div.lean
@@ -302,6 +302,40 @@ theorem evm_div_callable_v4_spec_from_noNop_preserving_x1_framed
         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
         nMem shiftMem jMem retMem dMem dloMem scratchUn0 branch hStack)
 
+/-- v4 DIV callable wrapper with exact `x1` and no `x9` frame.
+
+This is the return/`cc_ret` adapter only: callers supply a v4 no-NOP stack
+proof already shaped for `divModStackDispatchPreCallable`. -/
+theorem evm_div_callable_v4_spec_from_noNop_preserving_x1_noX9
+    (sp base raVal : Word)
+    (a b : EvmWord) (v2 v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (hStack :
+      cpsTripleWithin unifiedDivBound base (base + nopOff) (sharedDivModCodeNoNop_v4 base)
+        (divModStackDispatchPreCallable sp a b
+          raVal v2 v5 v6 v7 v10 v11
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+        (divStackDispatchPostCallable sp a b ** (.x1 ↦ᵣ raVal))) :
+    cpsTripleWithin (unifiedDivBound + 1) base (raVal &&& ~~~1)
+      (evm_div_callable_code_v4 base)
+      (divModStackDispatchPreCallable sp a b
+        raVal v2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+      (divStackDispatchPostCallable sp a b ** (.x1 ↦ᵣ raVal)) := by
+  have hStackCall :=
+    cpsTripleWithin_extend_code
+      (hmono := sharedDivModCodeNoNop_v4_sub_div_callable_code_v4) hStack
+  have hRet :=
+    cpsTripleWithin_extend_code (hmono := evm_div_callable_code_v4_ret_sub (base := base))
+      (ret_spec_within' (base + nopOff) raVal)
+  have hRetFramed :=
+    cpsTripleWithin_frameL (divStackDispatchPostCallable sp a b)
+      (divStackDispatchPostCallable_pcFree sp a b) hRet
+  exact cpsTripleWithin_seq_same_cr hStackCall hRetFramed
+
 /-- Generic concrete callable DIV wrapper for v4 no-NOP body proofs that
     preserve exact caller-framed `x1`/`x9` and expose the concrete scratch and
     register values needed by SDIV branch handoffs. -/

--- a/EvmAsm/Evm64/DivMod/Spec/UnifiedBzero.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/UnifiedBzero.lean
@@ -460,6 +460,72 @@ theorem evm_div_bzero_stack_spec_within_dispatch_noNop_v4_concrete_callable_uni
           sepConj_assoc', sepConj_comm', sepConj_left_comm'] using hq)
       hFramed
 
+/-- v4 zero-divisor DIV dispatcher over the shared no-NOP code surface with
+    exact `x1` and no `x9` frame. Used by callers that keep `x9` entirely
+    caller-framed. -/
+theorem evm_div_bzero_stack_spec_within_dispatch_noNop_v4_callable_x1_uni
+    (sp base : Word)
+    (a b : EvmWord) (raVal v2 v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratch_un0 : Word)
+    (hbz : b = 0) :
+    cpsTripleWithin unifiedDivBound base (base + nopOff) (sharedDivModCodeNoNop_v4 base)
+      (divModStackDispatchPreCallable sp a b
+        raVal v2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0)
+      (divStackDispatchPostCallable sp a b ** (.x1 ↦ᵣ raVal)) := by
+  let frame : Assertion :=
+    (.x1 ↦ᵣ raVal) ** (.x2 ↦ᵣ v2) **
+    (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x11 ↦ᵣ v11) **
+    evmWordIs sp a **
+    divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratch_un0
+  have hBzero :=
+    evm_div_bzero_stack_spec_within_noNop_v4 sp base a b v5 v10 hbz
+  have hFramed :
+      cpsTripleWithin (8 + 5) base (base + nopOff) (sharedDivModCodeNoNop_v4 base)
+        (((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) **
+          (.x0 ↦ᵣ (0 : Word)) ** evmWordIs (sp + 32) b) ** frame)
+        ((((.x12 ↦ᵣ (sp + 32)) ** regOwn .x5 ** regOwn .x10 **
+          (.x0 ↦ᵣ (0 : Word)) ** evmWordIs (sp + 32) (EvmWord.div a b)) ** frame)) :=
+    cpsTripleWithin_frameR frame (by
+      dsimp [frame]
+      rw [divScratchValuesCallNoX1_unfold]
+      pcFree) hBzero
+  exact cpsTripleWithin_mono_nSteps (by decide) <|
+    cpsTripleWithin_weaken
+      (fun _ hp => by
+        rw [divModStackDispatchPreCallable_unfold] at hp
+        dsimp [frame]
+        simp only [sepConj_comm', sepConj_left_comm'] at hp ⊢
+        exact hp)
+      (fun h hq => by
+        dsimp [frame] at hq
+        rw [divStackDispatchPostCallable_unfold]
+        simp only [sepConj_assoc', sepConj_comm', sepConj_left_comm'] at hq ⊢
+        have hqOwn :
+            (divScratchOwnCallNoX1 sp ** evmWordIs sp a ** (.x0 ↦ᵣ (0 : Word)) **
+              (.x1 ↦ᵣ raVal) ** regOwn .x11 ** (.x12 ↦ᵣ (sp + 32)) **
+              regOwn .x2 ** regOwn .x6 ** regOwn .x7 **
+              regOwn .x10 ** regOwn .x5 ** evmWordIs (sp + 32) (EvmWord.div a b)) h := by
+          refine sepConj_mono ?_ ?_ h hq
+          · intro hLeft hpLeft
+            exact divScratchValuesCallNoX1_implies_divScratchOwnCallNoX1
+              sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem
+                retMem dMem dloMem scratch_un0 hLeft hpLeft
+          · apply sepConj_mono_right
+            apply sepConj_mono_right
+            apply sepConj_mono_right
+            apply sepConj_mono (regIs_implies_regOwn .x11 (v := v11))
+            apply sepConj_mono_right
+            apply sepConj_mono (regIs_implies_regOwn .x2 (v := v2))
+            apply sepConj_mono (regIs_implies_regOwn .x6 (v := v6))
+            apply sepConj_mono (regIs_implies_regOwn .x7 (v := v7))
+            exact fun _ hp => hp
+        exact by xperm_hyp hqOwn)
+      hFramed
+
 /-- Zero-divisor DIV dispatcher over `divCode_noNop` in the callable-only
     surface: exact `x1` is preserved for `cc_ret`, and exact `x9` is framed
     separately from the DIV loop-counter ownership surface. -/


### PR DESCRIPTION
Stacked on #5499.\n\n## Summary\n- add a v4 DIV callable return adapter for caller-shaped preconditions with exact x1 and no x9 frame\n- add the v4 zero-divisor DIV stack theorem over sharedDivModCodeNoNop_v4 for that no-x9 callable shape\n- expose a closed evm_div_callable_bzero_v4_preserving_x1_noX9_spec wrapper\n\n## Verification\n- lake build EvmAsm.Evm64.DivMod.Spec.UnifiedBzero EvmAsm.Evm64.DivMod.CallableV4Div EvmAsm.Evm64.DivMod.CallableBzeroV4\n- lake build EvmAsm.Evm64.DivMod\n- git diff --check\n- scripts/check-file-size.sh\n- added-line scan for StackSpecCase/set_option/sorry/admit