### PR TITLE
test(divmod): pin canonical callables to v4 divider

### DIFF
--- a/EvmAsm/Evm64/DivMod/Counterexamples.lean
+++ b/EvmAsm/Evm64/DivMod/Counterexamples.lean
@@ -50,6 +50,40 @@ theorem evm_mod_uses_div128_v4 :
       single (.ADDI .x0 .x0 0) ;;
       divK_div128_v4) := rfl
 
+theorem evm_div_callable_uses_div128_v4 :
+    evm_div_callable =
+      (divK_phaseA 1020 ;;
+      divK_phaseB ;;
+      divK_clz ;;
+      divK_phaseC2 172 ;;
+      divK_normB ;;
+      divK_normA 40 ;;
+      divK_copyAU ;;
+      divK_loopSetup 464 ;;
+      divK_loopBody 560 7736 ;;
+      divK_denorm ;;
+      divK_div_epilogue 24 ;;
+      divK_zeroPath ;;
+      cc_ret ;;
+      divK_div128_v4) := rfl
+
+theorem evm_mod_callable_uses_div128_v4 :
+    evm_mod_callable =
+      (divK_phaseA 1020 ;;
+      divK_phaseB ;;
+      divK_clz ;;
+      divK_phaseC2 172 ;;
+      divK_normB ;;
+      divK_normA 40 ;;
+      divK_copyAU ;;
+      divK_loopSetup 464 ;;
+      divK_loopBody 560 7736 ;;
+      divK_denorm ;;
+      divK_mod_epilogue 24 ;;
+      divK_zeroPath ;;
+      cc_ret ;;
+      divK_div128_v4) := rfl
+
 theorem evm_div_callable_v4_uses_div128_v4 :
     evm_div_callable_v4 =
       (divK_phaseA 1020 ;;


### PR DESCRIPTION
Stacked on #5502.\n\n## Summary\n- add kernel-checked rfl pins that canonical evm_div_callable and evm_mod_callable end in divK_div128_v4\n- complements the existing standalone and _v4 callable regression pins in Counterexamples.lean\n\n## Verification\n- lake build EvmAsm.Evm64.DivMod.Counterexamples EvmAsm.Evm64.DivMod\n- git diff --check\n- scripts/check-file-size.sh\n- added-line scan for StackSpecCase/set_option/sorry/admit/native_decide