### PR TITLE
feat(div): name n3 exact callable post frame

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N3DivStackSpec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3DivStackSpec.lean
@@ -322,6 +322,34 @@ theorem fullDivN3UnifiedPostNoX1_frame_to_divStackDispatchPostCallableExact
       a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 raVal
       ha0 ha1 ha2 ha3 hdiv0 hdiv1 hdiv2 hdiv3 h hp)
 
+/-- Named-post version of
+    `fullDivN3UnifiedPostNoX1_frame_to_divStackDispatchPostCallableExact`. -/
+theorem fullDivN3UnifiedPostNoX1_frame_to_divStackDispatchPostCallableExactFrame
+    (bltu_1 bltu_0 : Bool)
+    (sp base : Word) (a b : EvmWord)
+    (a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 : Word)
+    (raVal : Word)
+    (ha0 : a.getLimbN 0 = a0) (ha1 : a.getLimbN 1 = a1)
+    (ha2 : a.getLimbN 2 = a2) (ha3 : a.getLimbN 3 = a3)
+    (hdiv0 : (EvmWord.div a b).getLimbN 0 =
+      (fullDivN3R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).1)
+    (hdiv1 : (EvmWord.div a b).getLimbN 1 =
+      (fullDivN3R1 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1)
+    (hdiv2 : (EvmWord.div a b).getLimbN 2 = (0 : Word))
+    (hdiv3 : (EvmWord.div a b).getLimbN 3 = (0 : Word)) :
+    ∀ h,
+      (fullDivN3UnifiedPostNoX1 bltu_1 bltu_0 sp base
+        a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 **
+        (.x1 ↦ᵣ raVal)) h →
+      divStackDispatchPostCallableExactFrame sp a b raVal
+        (signExtend12 4095 : Word) h := by
+  intro h hp
+  rw [divStackDispatchPostCallableExactFrame_unfold]
+  exact fullDivN3UnifiedPostNoX1_frame_to_divStackDispatchPostCallableExact
+    bltu_1 bltu_0 sp base a b
+    a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 raVal
+    ha0 ha1 ha2 ha3 hdiv0 hdiv1 hdiv2 hdiv3 h hp
+
 /-- No-NOP n=3 DIV stack spec weakened to the callable post surface with
     separate `x1` ownership and exact `x9`. -/
 theorem evm_div_n3_stack_spec_within_word_noNop_callableOwnPost


### PR DESCRIPTION
## Summary
- add a named-post n=3 adapter from fullDivN3UnifiedPostNoX1 plus exact caller x1 to divStackDispatchPostCallableExactFrame
- reuse the existing raw exact callable post bridge; no new StackSpecCase surface is introduced

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.N3DivStackSpec EvmAsm.Evm64.DivMod EvmAsm.Evm64.SDiv
- git diff --check
- scripts/check-file-size.sh
- added-line scan for StackSpecCase/set_option/sorry/admit/native_decide