### PR TITLE
docs(codegen): mark smod runtime path v4

### DIFF
--- a/CODEGEN.md
+++ b/CODEGEN.md
@@ -638,7 +638,7 @@ verified body ends with a saved-ra-ret (`JALR x0, x18, 0`).
   - `evmSmodPatched := (evm_smod : List Instr).drop 1` — same.
   - `signedDivModTail` — restores `x10` from `x14`, advances PC,
     then `j .dispatch_loop` (NOT `ret`: the wrapper's inner
-    `JAL .x1` into `evm_div_callable_v4` / `evm_mod_callable`
+    `JAL .x1` into `evm_div_callable_v4` / `evm_mod_callable_v4`
     clobbers x1, so a standard `ret` would jump to garbage).
   - `signedDivModHandlers` — two entries (`h_SDIV`, `h_SMOD`).
     Each carries `preBody := "  mv x14, x10\n  la x18, h_<NAME>_done"`,
@@ -664,11 +664,10 @@ at the dispatcher's continuation. Fix: replaced `ret` with
 `j .dispatch_loop` (a direct jump to the dispatcher loop entry,
 bypassing the `x1`-mediated return).
 
-**SMOD v4 caveat (carried over from M8).** `evm_smod` still uses
-the legacy non-v4 `evm_mod_callable`. SDIV migrated to v4 in
-commit `43bb53070`; SMOD's surface hasn't flipped yet. When the
-verification track migrates SMOD, this entry rebinds to the new
-symbol with no other changes.
+**SMOD v4 status.** `evm_smod` now uses the v4 modulo callable, matching
+`evm_sdiv`'s v4 division path. The trampoline shape did not need to
+change: both signed wrappers still end through the same saved-ra return
+stub, and `signedDivModTail` still jumps directly back to `.dispatch_loop`.
 
 **Exit criteria (met).**
 `scripts/codegen-opcodes-runtime-check.sh` exits 0 with all 29

--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -528,7 +528,7 @@ def divModHandlers : List OpcodeHandlerSpec :=
     code pointer by 1, then jump directly to `.dispatch_loop`
     rather than `ret`-ing. The standard `ret` (= `jalr x0, x1, 0`)
     won't work for these handlers because the wrapper's inner
-    `JAL .x1` into `evm_div_callable_v4` / `evm_mod_callable`
+    `JAL .x1` into `evm_div_callable_v4` / `evm_mod_callable_v4`
     clobbers `x1` mid-body — `x1` no longer holds the dispatcher's
     continuation by the time control reaches this tail. -/
 private def signedDivModTail : HandlerTail :=
@@ -546,7 +546,7 @@ private def signedDivModTail : HandlerTail :=
     1. `preBody` saves `x10` to `x14` (same register convention as
        M8 DIV/MOD; `x14` is untouched by both the SDIV/SMOD
        wrappers and the inner `evm_div_callable_v4` /
-       `evm_mod_callable`) AND loads `x18` with the address of the
+       `evm_mod_callable_v4`) AND loads `x18` with the address of the
        per-handler `postBodyLabel` stub via `la x18, h_<NAME>_done`.
     2. The verified body is `evmSdivPatched` / `evmSmodPatched`,
        which is the verified `evm_sdiv` / `evm_smod` with the
@@ -562,11 +562,9 @@ private def signedDivModTail : HandlerTail :=
        `ret` because the inner `JAL` into the divider clobbered
        `x1` (so `ret` would jump to garbage).
 
-    SMOD note: `evm_smod` still uses the legacy non-v4
-    `evm_mod_callable` (SDIV migrated to v4 in commit `43bb53070`,
-    SMOD's surface hasn't flipped yet). When the verification
-    track migrates SMOD to `evm_mod_callable_v4`, this entry
-    rebinds to the new symbol without other changes. -/
+    Both canonical signed wrappers now route through the v4 callable
+    divider/modulo bodies; the trampoline shape is unchanged by that
+    migration because the saved-ra return convention is the same. -/
 def signedDivModHandlers : List OpcodeHandlerSpec :=
   [ { label         := "h_SDIV"
       opcodes       := [0x05]


### PR DESCRIPTION
## Summary
- update the M9 signed DIV/MOD trampoline notes to name `evm_mod_callable_v4`
- replace the stale PR #5472 SMOD v4 caveat with the current status: canonical `evm_smod` now routes through the v4 modulo callable
- document that the trampoline shape remains unchanged after the SMOD migration

Tracks bead `evm-asm-9iqmw.4.10`.

## Verification
- `lake build codegen`
- `scripts/codegen-opcodes-runtime-check.sh` (29/29 cases passed, including `smod_negative`)
- `scripts/check-file-size.sh`
- `git diff --check`
- stale-wording scan for legacy SMOD v4 caveat
- added-lines scan for forbidden StackSpecCase assumptions, heartbeat/recursion overrides, sorries/admits, and new native_decide additions