### PR TITLE
feat(codegen): M10 — wire ADDMOD through the dispatcher

### DIFF
--- a/CODEGEN.md
+++ b/CODEGEN.md
@@ -789,16 +789,42 @@ emission unreadable. M9 unblocks M10 (ADDMOD/EXP via
   `OpcodeHandlerSpec.postBodyLabel : Option String` field.
   `signedDivModTail` uses `j .dispatch_loop` instead of `ret`
   because the wrapper's inner `JAL .x1` clobbers x1 mid-body.
+- **M10.** ✅ `scripts/codegen-opcodes-runtime-check.sh` exits 0 with
+  **31 test cases** PASS (validated 2026-05-21). ADDMOD (0x08)
+  wired via an inline-callable composition: the handler body is
+  `evm_addmod_prologue ;; phase1_carry ;; phase2_reduce 8 ;;
+  skip-JAL ;; evm_mod_callable_v4`. The JAL inside `phase2_reduce`
+  targets the inlined callable's first instruction; the skip-JAL
+  (`JAL .x0 +1376`) jumps past the callable to the tail so the
+  wrapper doesn't fall through. `evm_addmod_epilogue` is
+  **deliberately omitted**: its `ADDI x12, x12, 32` would compound
+  the `divK_mod_epilogue`'s own `ADDI x12, x12, 32` inside
+  `evm_mod_callable_v4`, over-advancing `x12` by 32 bytes. Net
+  advance: 32 (prologue) + 32 (callable) = 64 B (pop 3, push 1).
+  Reuses M9's `signedDivModTail` + `mv x14, x10` preBody because
+  the inner `JAL .x1` into the callable clobbers `x1`. EXP (0x0a)
+  was planned for M10 but deferred — the verified
+  `evm_exp_msb_saved_bit_two_mul_fixed` wrapper uses `x6` and `x16`
+  as per-limb counter / limb pointer state across `mul_callable`
+  calls, but those are LP64 caller-saved registers and
+  `mul_callable` clobbers `x6` 39 times per call. The upstream
+  "fix" only addresses `x19` (cursor) clobber, not `x6`/`x16`, so
+  the bit-test reload logic produces garbage after the first
+  squaring. EXP can ship once upstream lands a fully callee-saved
+  variant.
 
-## Future work (post-M9)
+## Future work (post-M10)
 
 Near-term:
 
-- **M10 — ADDMOD / EXP via `callableLabel?`.** Adds 2 opcodes that
-  internally `JAL` to callable variants of other handlers (`evm_mul`
-  for EXP, MOD for ADDMOD). Needs a new `callableLabel?` field on
-  `OpcodeHandlerSpec` so the same body gets both a dispatcher-entry
-  label and a callable-entry label.
+- **EXP (0x0a).** Blocked on upstream: needs an
+  `evm_exp_msb_saved_bit_two_mul_fixed_fixed` variant that moves
+  the per-limb counter (`x6`) and limb pointer (`x16`) to
+  callee-saved registers (e.g. `x20`/`x21`). Once that lands, EXP
+  can drop into `selfCallingHandlers` next to ADDMOD using the
+  same inline-callable + `signedDivModTail` pattern; the skip-JAL
+  offset and `mulOff` / `condMulOff` derivations from this PR's
+  preliminary work are recorded in the git history.
 
 Longer-term (genuine new design surface):
 

--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -7,17 +7,24 @@
 
 import EvmAsm.Rv64.Program
 import EvmAsm.Evm64.Add.Program
+import EvmAsm.Evm64.AddMod.Program
 import EvmAsm.Evm64.And.Program
 import EvmAsm.Evm64.Byte.Program
+import EvmAsm.Evm64.DivMod.Callable
 import EvmAsm.Evm64.DivMod.Program
 import EvmAsm.Evm64.Dup.Program
 import EvmAsm.Evm64.Eq.Program
+-- EXP wrapper is parametric over caller-saved registers (x6, x16)
+-- that mul_callable clobbers; deferred until upstream lands a
+-- fully callee-saved variant. import re-added when wiring lands.
+-- import EvmAsm.Evm64.Exp.Program
 import EvmAsm.Evm64.Gt.Program
 import EvmAsm.Evm64.IsZero.Program
 import EvmAsm.Evm64.Lt.Program
 import EvmAsm.Evm64.MLoad.Program
 import EvmAsm.Evm64.MStore.Program
 import EvmAsm.Evm64.MStore8.Program
+-- import EvmAsm.Evm64.Multiply.Callable -- only needed by EXP (deferred)
 import EvmAsm.Evm64.Multiply.Program
 import EvmAsm.Evm64.Not.Program
 import EvmAsm.Evm64.Or.Program
@@ -581,6 +588,74 @@ def signedDivModHandlers : List OpcodeHandlerSpec :=
       postBodyLabel := some "h_SMOD_done"
       tail          := signedDivModTail } ]
 
+/-! ## M10 self-calling opcode — ADDMOD (0x08)
+
+    `evm_addmod` is parametric over a JAL byte offset that targets
+    a callable variant of another handler (`evm_mod_callable_v4`).
+    The natural composition is `<wrapper>(<offset>) ++ <callable>`
+    — the callable is inlined in the same handler subroutine; the
+    offset is chosen so the wrapper's JAL lands on the callable's
+    first instruction.
+
+    Unlike SDIV/SMOD's M9 trampoline, ADDMOD doesn't have a
+    saved-ra-ret pattern. It DOES clobber `x1` (via the inner
+    `JAL .x1` into the callable), so the wrapper tail must use
+    `j .dispatch_loop` instead of `ret` — reusing M9's
+    `signedDivModTail` helper. It also clobbers `x10` via the
+    inline mod callable, so `preBody` saves `x10` to `x14`.
+
+    EXP (0x0a) was planned for this milestone but is deferred. The
+    `evm_exp_msb_saved_bit_two_mul_fixed` wrapper uses `x6` and
+    `x16` as per-limb counter / limb pointer, but those are LP64
+    caller-saved registers — `mul_callable` clobbers `x6` 39 times
+    per call. The "fix" only addresses `x19` (cursor) clobber, not
+    `x6`/`x16`. A complete fix requires a `_fixed_fixed` variant
+    using callee-saved registers (e.g. `x20`/`x21`) for the
+    per-limb counter and limb pointer; until that lands upstream,
+    EXP can't run through the dispatcher. -/
+
+/-- ADDMOD handler body. **Skips `evm_addmod_epilogue` deliberately**:
+    the verified `evm_addmod` composes prologue + phase1_carry +
+    phase2_reduce + epilogue, but the epilogue does `ADDI x12, x12, 32`
+    on TOP of the `ADDI x12, x12, 32` already done by
+    `divK_mod_epilogue` inside `evm_mod_callable_v4`. Including both
+    over-advances `x12` by 32, leaving the result outside the EVM
+    stack. (The verified `evm_addmod` is a slice 3a skeleton; slice
+    3c hasn't been implemented.)
+
+    Composition:
+      - prologue (`evm_add`): 30 instr (120 B), pops 2 / pushes 1, x12 += 32
+      - phase1_carry: 1 instr (4 B), `ADDI x7, x5, 0`
+      - phase2_reduce 8: 1 instr (4 B), `JAL .x1 +8` → mod_callable_v4
+      - skip-JAL: 1 instr (4 B), `JAL .x0 +1372` → past callable to tail
+      - `evm_mod_callable_v4`: 343 instr (1372 B), advances x12 by 32
+
+    Net x12 advance: 32 (prologue) + 32 (callable) = 64 B (= 3 pops -
+    1 push). ✓
+
+    modOff for phase2_reduce: JAL at byte 124, callable at byte 132,
+    offset = 8 bytes. Skip-JAL at byte 128, target = byte 128 + 1376
+    = 1504 (end of body, just past the callable), offset = 1376 bytes
+    (= 4 bytes for the skip-JAL itself + 1372 bytes for the callable). -/
+def evmAddmodComposed : Program :=
+  EvmAsm.Evm64.evm_addmod_prologue ;;
+  EvmAsm.Evm64.evm_addmod_phase1_carry ;;
+  EvmAsm.Evm64.evm_addmod_phase2_reduce 8 ;;
+  single (Instr.JAL .x0 (1376 : BitVec 21)) ;;
+  EvmAsm.Evm64.evm_mod_callable_v4
+
+/-- M10 self-calling handlers. Currently just ADDMOD; EXP is
+    deferred (see the milestone-header comment). Reuses
+    `signedDivModTail` because the wrapper's inner `JAL .x1` into
+    the inline callable clobbers `x1`, so the standard `ret` (=
+    `jalr x0, x1, 0`) would jump to garbage. -/
+def selfCallingHandlers : List OpcodeHandlerSpec :=
+  [ { label         := "h_ADDMOD"
+      opcodes       := [0x08]
+      preBody       := "  mv x14, x10"
+      body          := evmAddmodComposed
+      tail          := signedDivModTail } ]
+
 /-- STOP: transitions out of the dispatcher loop instead of returning
     to it. The body is empty; the dispatcher's `jalr` lands on
     `h_STOP:` which jumps to `.exit_label`. -/
@@ -595,7 +670,8 @@ def stopHandler : OpcodeHandlerSpec :=
     the list for a spec whose `opcodes` contains the byte. -/
 def tinyInterpRegistry : List OpcodeHandlerSpec :=
   pushHandlers ++ dupHandlers ++ swapHandlers ++ singletonHandlers ++
-  memoryHandlers ++ divModHandlers ++ signedDivModHandlers ++ [stopHandler]
+  memoryHandlers ++ divModHandlers ++ signedDivModHandlers ++
+  selfCallingHandlers ++ [stopHandler]
 
 def tinyInterpDispatchAddUnit : BuildUnit :=
   buildDispatchUnit tinyInterpRegistry evmAddEpilogue tinyInterpAddBytecode

--- a/EvmAsm/Codegen/Tests/Cases.lean
+++ b/EvmAsm/Codegen/Tests/Cases.lean
@@ -193,6 +193,17 @@ def opcodeTestCases : List OpcodeTestCase :=
     { name           := "smod_negative"
       bytecode       := "0x60, 0x05, 0x60, 0x01, 0x19, 0x07, 0x00"
       expectedOutHex := "feffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff" }
+    -- ## M10 self-calling opcodes (inline mod_callable / mul_callable)
+  , -- PUSH1 0x04; PUSH1 0x03; PUSH1 0x02; ADDMOD; STOP — (2+3) % 4 = 1
+    -- ADDMOD pops `a` (top), then `b`, then `N`. So stack
+    -- [N=4, b=3, a=2] yields (a+b) mod N = 5 mod 4 = 1.
+    { name           := "addmod_basic"
+      bytecode       := "0x60, 0x04, 0x60, 0x03, 0x60, 0x02, 0x08, 0x00"
+      expectedOutHex := "0100000000000000000000000000000000000000000000000000000000000000" }
+  , -- PUSH1 0x00; PUSH1 0x03; PUSH1 0x02; ADDMOD; STOP — divisor=0 ⇒ 0
+    { name           := "addmod_div_zero"
+      bytecode       := "0x60, 0x00, 0x60, 0x03, 0x60, 0x02, 0x08, 0x00"
+      expectedOutHex := "0000000000000000000000000000000000000000000000000000000000000000" }
   ]
 
 /-- Find a test case by name. -/


### PR DESCRIPTION
## Summary

- Routes EVM **ADDMOD (0x08)** through `tinyInterpRegistry` via an inline-callable composition: `evm_addmod_prologue ;; phase1_carry ;; phase2_reduce 8 ;; skip-JAL ;; evm_mod_callable_v4`. The in-body JAL targets the appended callable; a 4-byte skip-JAL hops past the callable to the tail. `evm_addmod_epilogue` is omitted to avoid compounding the `divK_mod_epilogue`'s own `ADDI x12, x12, 32` already inside `evm_mod_callable_v4`. Net x12 advance: 32 (prologue) + 32 (callable) = 64 B (pop 3, push 1). ✓
- Reuses M9's `signedDivModTail` (`j .dispatch_loop` instead of `ret`, because the inner `JAL .x1` clobbers x1) and `mv x14, x10` preBody.
- 2 new regression cases (`addmod_basic`, `addmod_div_zero`); suite count 29 → 31, all PASS.

## EXP (0x0a) deferred

EXP was planned for M10 but is blocked upstream. The verified `evm_exp_msb_saved_bit_two_mul_fixed` wrapper uses `x6` (per-limb counter) and `x16` (limb pointer) as state across `mul_callable` calls — but those are LP64 **caller-saved** registers, and `mul_callable` clobbers `x6` 39 times per call. The upstream "fix" only addresses `x19` (cursor) clobber, not `x6`/`x16`, so the bit-test reload logic returns garbage after the first squaring; the wrapper effectively never detects a 1-bit and result stays at 1 for all inputs (verified empirically via instrumented tail).

EXP will ship once upstream provides an `evm_exp_msb_saved_bit_two_mul_fixed_fixed` variant that moves `x6`/`x16` to callee-saved registers (e.g. `x20`/`x21`). The skip-JAL / `mulOff` / `condMulOff` derivations for the dispatcher side are recorded in this PR's git history for reuse.

## Test plan

- [x] `lake build codegen` passes
- [x] `bash scripts/codegen-opcodes-runtime-check.sh` exits 0 (31/31 PASS)
- [x] `bash scripts/codegen-opcodes-check.sh` legacy runner exits 0
- [x] `bash scripts/codegen-tiny-interp-check.sh` exits 0
- [x] `bash scripts/codegen-tiny-interp-dispatch-check.sh` exits 0
- [x] `bash scripts/codegen-smoke.sh` exits 0
- [x] `bash scripts/codegen-evm_{add,div,mod}{-cases,-from-input,}-check.sh` all exit 0
- [x] `bash scripts/check-progress.sh` exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)