### PR TITLE
refactor(divmod): split mod shift0 epilogue from fullpath

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPath.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPath.lean
@@ -6,8 +6,6 @@
 
   Start with the n=4 (b[3]≠0, shift≠0) case as the primary composition.
 -/
--- file-size-exception: spans n=4/shift0/MOD full-path compositions that share cross-cutting epilogue lemmas; split would require duplicating shared helpers
-
 import EvmAsm.Evm64.DivMod.Compose.PhaseAB
 import EvmAsm.Evm64.DivMod.Compose.PhaseABNoNop
 import EvmAsm.Evm64.DivMod.Compose.PhaseABV4NoNop
@@ -973,19 +971,6 @@ theorem evm_div_preamble_denorm_epilogue_spec_v4_noNop (sp base : Word)
     hFull
 
 -- ============================================================================
--- Denorm code subsumption for modCode (re-proved here since private in ModEpilogue)
--- ============================================================================
-
-/-- Denorm code (block 9) is subsumed by modCode.
-    Re-proved here because the version in ModEpilogue.lean is private. -/
-private theorem divK_denorm_code_sub_modCode' (base : Word) :
-    ∀ a i, (CodeReq.ofProg (base + denormOff) divK_denorm) a = some i → (modCode base) a = some i := by
-  unfold modCode; simp only [CodeReq.unionAll_cons]
-  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
-  skipBlock; skipBlock; skipBlock; skipBlock
-  exact CodeReq.union_mono_left
-
--- ============================================================================
 -- Denorm code subsumption for divCode (re-proved here since private in Epilogue)
 -- ============================================================================
 
@@ -1151,83 +1136,6 @@ theorem evm_div_shift0_epilogue_spec_within_noNop (sp base : Word)
     ((.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) **
      ((sp + signExtend12 3992) ↦ₘ shift))
     (by pcFree) hEpi
-  have hFull := cpsTripleWithin_seq_perm_same_cr
-    (fun h hp => by xperm_hyp hp) hPreF hEpiF
-  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
-    (fun h hp => by xperm_hyp hp)
-    (fun h hq => by xperm_hyp hq)
-    hFull
-
-theorem evm_mod_shift0_epilogue_spec_within (sp base : Word)
-    (u0 u1 u2 u3 shift v2 v5 v6 v7 v10 : Word)
-    (m0 m8 m16 m24 : Word)
-    (hshift_z : shift = 0) :
-    cpsTripleWithin 12 (base + denormOff) (base + nopOff) (modCode base)
-      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ v6) ** (.x0 ↦ᵣ (0 : Word)) **
-       (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ v2) ** (.x10 ↦ᵣ v10) **
-       ((sp + signExtend12 3992) ↦ₘ shift) **
-       ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
-       ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3) **
-       ((sp + 32) ↦ₘ m0) ** ((sp + 40) ↦ₘ m8) **
-       ((sp + 48) ↦ₘ m16) ** ((sp + 56) ↦ₘ m24))
-      ((.x12 ↦ᵣ (sp + 32)) ** (.x5 ↦ᵣ u0) ** (.x6 ↦ᵣ u1) ** (.x7 ↦ᵣ u2) **
-       (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ u3) **
-       ((sp + signExtend12 3992) ↦ₘ shift) **
-       ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
-       ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3) **
-       ((sp + 32) ↦ₘ u0) ** ((sp + 40) ↦ₘ u1) **
-       ((sp + 48) ↦ₘ u2) ** ((sp + 56) ↦ₘ u3)) := by
-  -- 1. LD x6 x12 3992 at base+908 (denorm instr [0])
-  have hld := ld_spec_gen_within .x6 .x12 sp v6 shift (3992 : BitVec 12) (base + denormOff) (by nofun)
-  have hlde := cpsTripleWithin_extend_code (hmono := by
-    intro a i h
-    exact divK_denorm_code_sub_modCode' base a i
-      (CodeReq.ofProg_mono_sub (base + denormOff) (base + denormOff) divK_denorm
-        [.LD .x6 .x12 3992] 0 (by bv_addr) (by decide) (by decide) (by decide) a i h)) hld
-  -- 2. BEQ x6 x0 96 at base+912 (denorm instr [1])
-  have hbeq := beq_spec_gen_within .x6 .x0 (96 : BitVec 13) shift (0 : Word) (base + denormOff + 4)
-  rw [show (base + denormOff + 4 : Word) + signExtend13 (96 : BitVec 13) = base + epilogueOff from by rv64_addr,
-      show (base + denormOff + 4 : Word) + 4 = base + denormOff + 8 from by bv_addr] at hbeq
-  have hbeqe := cpsBranchWithin_extend_code (hmono := by
-    intro a i h
-    exact divK_denorm_code_sub_modCode' base a i
-      (CodeReq.ofProg_mono_sub (base + denormOff) (base + denormOff + 4) divK_denorm
-        [.BEQ .x6 .x0 96] 1 (by bv_addr) (by decide) (by decide) (by decide) a i h)) hbeq
-  -- 3. Eliminate not-taken branch: shift = 0 means BEQ taken
-  --    BEQ not-taken postcondition: (.x6 ↦ᵣ shift) ** (.x0 ↦ᵣ 0) ** ⌜shift ≠ 0⌝
-  have hbeq_exit := cpsBranchWithin_takenStripPure2 hbeqe
-    (fun hp hQf => by
-      obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
-      exact absurd hshift_z ((sepConj_pure_right _).mp h_rest).2)
-  -- 4. Frame LD with x0, x5, x7, x2, x10
-  have hldf := cpsTripleWithin_frameR
-    ((.x0 ↦ᵣ (0 : Word)) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ v2) ** (.x10 ↦ᵣ v10))
-    (by pcFree) hlde
-  -- 5. Frame BEQ taken with x12, x5, x7, x2, x10, shiftMem
-  have hbeqf := cpsTripleWithin_frameR
-    ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ v2) ** (.x10 ↦ᵣ v10) **
-     ((sp + signExtend12 3992) ↦ₘ shift))
-    (by pcFree) hbeq_exit
-  -- 6. Compose LD → BEQ taken: base+908 → base+1008
-  have hPre := cpsTripleWithin_seq_perm_same_cr
-    (fun h hp => by xperm_hyp hp) hldf hbeqf
-  -- Frame preamble with u[], output memory
-  have hPreF := cpsTripleWithin_frameR
-    (((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
-     ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3) **
-     ((sp + 32) ↦ₘ m0) ** ((sp + 40) ↦ₘ m8) **
-     ((sp + 48) ↦ₘ m16) ** ((sp + 56) ↦ₘ m24))
-    (by pcFree) hPre
-  -- 7. MOD epilogue (base+1008 → base+1068)
-  have hEpi := divK_mod_epilogue_spec_within sp base u0 u1 u2 u3
-    v5 shift v7 v10 m0 m8 m16 m24
-
-  -- Frame epilogue with x2, x0, shiftMem
-  have hEpiF := cpsTripleWithin_frameR
-    ((.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) **
-     ((sp + signExtend12 3992) ↦ₘ shift))
-    (by pcFree) hEpi
-  -- 8. Compose preamble → epilogue: base+908 → base+1068
   have hFull := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hPreF hEpiF
   exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathModShift0.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathModShift0.lean
@@ -1,0 +1,102 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathModShift0
+
+  MOD shift=0 epilogue composition split out from FullPath.lean to keep the
+  shared DIV full-path file below the Compose file-size guardrail.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPath
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Denorm code (block 9) is subsumed by modCode.
+    Re-proved here because the version in ModEpilogue.lean is private. -/
+private theorem divK_denorm_code_sub_modCode' (base : Word) :
+    ∀ a i, (CodeReq.ofProg (base + denormOff) divK_denorm) a = some i → (modCode base) a = some i := by
+  unfold modCode; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
+  skipBlock; skipBlock; skipBlock; skipBlock
+  exact CodeReq.union_mono_left
+
+theorem evm_mod_shift0_epilogue_spec_within (sp base : Word)
+    (u0 u1 u2 u3 shift v2 v5 v6 v7 v10 : Word)
+    (m0 m8 m16 m24 : Word)
+    (hshift_z : shift = 0) :
+    cpsTripleWithin 12 (base + denormOff) (base + nopOff) (modCode base)
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ v6) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ v2) ** (.x10 ↦ᵣ v10) **
+       ((sp + signExtend12 3992) ↦ₘ shift) **
+       ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
+       ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3) **
+       ((sp + 32) ↦ₘ m0) ** ((sp + 40) ↦ₘ m8) **
+       ((sp + 48) ↦ₘ m16) ** ((sp + 56) ↦ₘ m24))
+      ((.x12 ↦ᵣ (sp + 32)) ** (.x5 ↦ᵣ u0) ** (.x6 ↦ᵣ u1) ** (.x7 ↦ᵣ u2) **
+       (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ u3) **
+       ((sp + signExtend12 3992) ↦ₘ shift) **
+       ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
+       ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3) **
+       ((sp + 32) ↦ₘ u0) ** ((sp + 40) ↦ₘ u1) **
+       ((sp + 48) ↦ₘ u2) ** ((sp + 56) ↦ₘ u3)) := by
+  -- 1. LD x6 x12 3992 at base+908 (denorm instr [0])
+  have hld := ld_spec_gen_within .x6 .x12 sp v6 shift (3992 : BitVec 12) (base + denormOff) (by nofun)
+  have hlde := cpsTripleWithin_extend_code (hmono := by
+    intro a i h
+    exact divK_denorm_code_sub_modCode' base a i
+      (CodeReq.ofProg_mono_sub (base + denormOff) (base + denormOff) divK_denorm
+        [.LD .x6 .x12 3992] 0 (by bv_addr) (by decide) (by decide) (by decide) a i h)) hld
+  -- 2. BEQ x6 x0 96 at base+912 (denorm instr [1])
+  have hbeq := beq_spec_gen_within .x6 .x0 (96 : BitVec 13) shift (0 : Word) (base + denormOff + 4)
+  rw [show (base + denormOff + 4 : Word) + signExtend13 (96 : BitVec 13) = base + epilogueOff from by rv64_addr,
+      show (base + denormOff + 4 : Word) + 4 = base + denormOff + 8 from by bv_addr] at hbeq
+  have hbeqe := cpsBranchWithin_extend_code (hmono := by
+    intro a i h
+    exact divK_denorm_code_sub_modCode' base a i
+      (CodeReq.ofProg_mono_sub (base + denormOff) (base + denormOff + 4) divK_denorm
+        [.BEQ .x6 .x0 96] 1 (by bv_addr) (by decide) (by decide) (by decide) a i h)) hbeq
+  -- 3. Eliminate not-taken branch: shift = 0 means BEQ taken
+  --    BEQ not-taken postcondition: (.x6 ↦ᵣ shift) ** (.x0 ↦ᵣ 0) ** ⌜shift ≠ 0⌝
+  have hbeq_exit := cpsBranchWithin_takenStripPure2 hbeqe
+    (fun hp hQf => by
+      obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
+      exact absurd hshift_z ((sepConj_pure_right _).mp h_rest).2)
+  -- 4. Frame LD with x0, x5, x7, x2, x10
+  have hldf := cpsTripleWithin_frameR
+    ((.x0 ↦ᵣ (0 : Word)) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ v2) ** (.x10 ↦ᵣ v10))
+    (by pcFree) hlde
+  -- 5. Frame BEQ taken with x12, x5, x7, x2, x10, shiftMem
+  have hbeqf := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ v2) ** (.x10 ↦ᵣ v10) **
+     ((sp + signExtend12 3992) ↦ₘ shift))
+    (by pcFree) hbeq_exit
+  -- 6. Compose LD → BEQ taken: base+908 → base+1008
+  have hPre := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hldf hbeqf
+  -- Frame preamble with u[], output memory
+  have hPreF := cpsTripleWithin_frameR
+    (((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
+     ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3) **
+     ((sp + 32) ↦ₘ m0) ** ((sp + 40) ↦ₘ m8) **
+     ((sp + 48) ↦ₘ m16) ** ((sp + 56) ↦ₘ m24))
+    (by pcFree) hPre
+  -- 7. MOD epilogue (base+1008 → base+1068)
+  have hEpi := divK_mod_epilogue_spec_within sp base u0 u1 u2 u3
+    v5 shift v7 v10 m0 m8 m16 m24
+
+  -- Frame epilogue with x2, x0, shiftMem
+  have hEpiF := cpsTripleWithin_frameR
+    ((.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) **
+     ((sp + signExtend12 3992) ↦ₘ shift))
+    (by pcFree) hEpi
+  -- 8. Compose preamble → epilogue: base+908 → base+1068
+  have hFull := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hPreF hEpiF
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    hFull
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPathN4Shift0.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPathN4Shift0.lean
@@ -13,6 +13,7 @@
 
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4Shift0
 import EvmAsm.Evm64.DivMod.Compose.ModFullPath
+import EvmAsm.Evm64.DivMod.Compose.FullPathModShift0
 
 open EvmAsm.Rv64.Tactics
 


### PR DESCRIPTION
## Summary
- extract `evm_mod_shift0_epilogue_spec_within` and its local mod-code subsumption helper into `FullPathModShift0.lean`
- import the extracted module from `ModFullPathN4Shift0.lean`
- remove the `file-size-exception` marker from `FullPath.lean`, bringing it under the Compose cap

Tracks bead `evm-asm-nv3od`.

## Guardrail impact
- `FullPath.lean`: 1236 -> 1144 lines
- `FullPathModShift0.lean`: 102 lines
- `scripts/check-file-size.sh`: 711 files checked, all within cap, 2 exempted

## Verification
- `lake build EvmAsm.Evm64.DivMod.Compose.FullPathModShift0 EvmAsm.Evm64.DivMod.Compose.ModFullPathN4Shift0 EvmAsm.Evm64.DivMod.Compose.FullPath`
- `lake build EvmAsm.Evm64.DivMod`
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `git diff --check`
- added-lines scan for forbidden StackSpecCase assumptions, heartbeat/recursion overrides, sorries/admits, and new native_decide additions