### PR TITLE
feat(stateless): tx_eip2930_decode (PR-K42)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -5319,6 +5319,193 @@ def ziskTxTypeDispatchProbeUnit : BuildUnit := {
   dataAsm     := ziskTxTypeDispatchDataSection
 }
 
+/-! ## tx_eip2930_decode -- PR-K42 full 11-field EIP-2930 decoder
+
+    Decode the inner (post-type-byte) RLP body of an EIP-2930
+    (type-1) access-list transaction into a flat 216-byte output
+    struct. Inner RLP shape (11 fields):
+
+      rlp([
+        chain_id, nonce, gas_price, gas_limit,
+        to, value, data, access_list,
+        y_parity, r, s
+      ])
+
+    EIP-2930 is structurally simpler than EIP-1559: a single
+    `gas_price` field (legacy-style) instead of the
+    `(max_priority_fee_per_gas, max_fee_per_gas)` pair.
+
+    Output struct (216 bytes):
+       0..  8  chain_id              (u64 LE)
+       8.. 16  nonce                 (u64 LE)
+      16.. 48  gas_price             (u256 BE)
+      48.. 56  gas_limit             (u64 LE)
+      56.. 76  to (20-byte address; zero for creation)
+      76.. 80  to_present (u32; 0 = creation, 1 = call)
+      80..112  value                 (u256 BE)
+     112..120  data_offset           (u64 within inner RLP)
+     120..128  data_length           (u64)
+     128..136  access_list_offset    (u64; whole encoded item incl. prefix)
+     136..144  access_list_length    (u64; whole encoded item incl. prefix)
+     144..152  y_parity              (u64; 0 or 1)
+     152..184  r                     (u256 BE)
+     184..216  s                     (u256 BE)
+
+    Caller passes the inner RLP body -- after stripping the 0x01
+    type byte that PR-K40 `tx_type_dispatch` reports via
+    `inner_offset`. access_list semantics mirror PR-K41
+    `tx_eip1559_decode`: the returned (offset, length) span the
+    *full* encoded sub-list including its RLP prefix, so the
+    caller can recurse into it.
+
+    Calling convention:
+      a0 (input)  : inner_rlp ptr
+      a1 (input)  : inner_rlp byte length
+      a2 (input)  : output struct ptr (216 bytes)
+      ra (input)  : return
+      a0 (output) : 0 success / 1 parse fail -/
+def txEip2930DecodeFunction : String :=
+  "tx_eip2930_decode:\n" ++
+  "  addi sp, sp, -48\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp)\n" ++
+  "  mv s0, a0                  # inner_rlp ptr\n" ++
+  "  mv s1, a1                  # inner_rlp_len\n" ++
+  "  mv s2, a2                  # struct out\n" ++
+  "  # Field 0: chain_id (u64 at offset 0)\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 0; mv a3, s2\n" ++
+  "  jal ra, rlp_field_to_u64\n" ++
+  "  bnez a0, .Lt29_fail\n" ++
+  "  # Field 1: nonce (u64 at offset 8)\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 1\n" ++
+  "  addi a3, s2, 8\n" ++
+  "  jal ra, rlp_field_to_u64\n" ++
+  "  bnez a0, .Lt29_fail\n" ++
+  "  # Field 2: gas_price (u256 at offset 16)\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 2\n" ++
+  "  addi a3, s2, 16\n" ++
+  "  jal ra, rlp_field_to_u256_be\n" ++
+  "  bnez a0, .Lt29_fail\n" ++
+  "  # Field 3: gas_limit (u64 at offset 48)\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 3\n" ++
+  "  addi a3, s2, 48\n" ++
+  "  jal ra, rlp_field_to_u64\n" ++
+  "  bnez a0, .Lt29_fail\n" ++
+  "  # Field 4: to (0 or 20 bytes at offset 56; to_present u32 at 76)\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 4\n" ++
+  "  la a3, t29_offset; la a4, t29_length\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lt29_fail\n" ++
+  "  la t0, t29_length; ld t1, 0(t0)\n" ++
+  "  beqz t1, .Lt29_to_creation\n" ++
+  "  li t2, 20\n" ++
+  "  bne t1, t2, .Lt29_fail\n" ++
+  "  la t0, t29_offset; ld t3, 0(t0); add t3, s0, t3\n" ++
+  "  addi t4, s2, 56\n" ++
+  "  ld t5,  0(t3); sd t5, 0(t4)\n" ++
+  "  ld t5,  8(t3); sd t5, 8(t4)\n" ++
+  "  lwu t5, 16(t3); sw t5, 16(t4)\n" ++
+  "  li t5, 1\n" ++
+  "  sw t5, 76(s2)              # to_present = 1\n" ++
+  "  j .Lt29_after_to\n" ++
+  ".Lt29_to_creation:\n" ++
+  "  addi t4, s2, 56\n" ++
+  "  sd zero, 0(t4); sd zero, 8(t4); sw zero, 16(t4)\n" ++
+  "  sw zero, 76(s2)            # to_present = 0\n" ++
+  ".Lt29_after_to:\n" ++
+  "  # Field 5: value (u256 at offset 80)\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 5\n" ++
+  "  addi a3, s2, 80\n" ++
+  "  jal ra, rlp_field_to_u256_be\n" ++
+  "  bnez a0, .Lt29_fail\n" ++
+  "  # Field 6: data (offset+length at 112/120)\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 6\n" ++
+  "  la a3, t29_offset; la a4, t29_length\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lt29_fail\n" ++
+  "  la t0, t29_offset; ld t1, 0(t0); sd t1, 112(s2)\n" ++
+  "  la t0, t29_length; ld t1, 0(t0); sd t1, 120(s2)\n" ++
+  "  # Field 7: access_list (offset+length at 128/136; full encoded item)\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 7\n" ++
+  "  la a3, t29_offset; la a4, t29_length\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lt29_fail\n" ++
+  "  la t0, t29_offset; ld t1, 0(t0); sd t1, 128(s2)\n" ++
+  "  la t0, t29_length; ld t1, 0(t0); sd t1, 136(s2)\n" ++
+  "  # Field 8: y_parity (u64 at offset 144)\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 8\n" ++
+  "  addi a3, s2, 144\n" ++
+  "  jal ra, rlp_field_to_u64\n" ++
+  "  bnez a0, .Lt29_fail\n" ++
+  "  # Field 9: r (u256 at offset 152)\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 9\n" ++
+  "  addi a3, s2, 152\n" ++
+  "  jal ra, rlp_field_to_u256_be\n" ++
+  "  bnez a0, .Lt29_fail\n" ++
+  "  # Field 10: s (u256 at offset 184)\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 10\n" ++
+  "  addi a3, s2, 184\n" ++
+  "  jal ra, rlp_field_to_u256_be\n" ++
+  "  bnez a0, .Lt29_fail\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lt29_ret\n" ++
+  ".Lt29_fail:\n" ++
+  "  li a0, 1\n" ++
+  ".Lt29_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp)\n" ++
+  "  addi sp, sp, 48\n" ++
+  "  ret"
+
+/-- `zisk_tx_eip2930_decode`: probe BuildUnit. Reads (inner_len,
+    inner_bytes) from host input -- caller is expected to have
+    stripped the 0x01 type byte. Writes (status, 216-byte struct)
+    to OUTPUT (224 bytes total). -/
+def ziskTxEip2930DecodePrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a3, 0x40000000\n" ++
+  "  ld a1, 8(a3)                # inner_len\n" ++
+  "  addi a0, a3, 16             # inner ptr\n" ++
+  "  li a2, 0xa0010008           # struct at OUTPUT + 8\n" ++
+  "  # Pre-zero 216 bytes (27 × 8 dwords).\n" ++
+  "  mv t0, a2\n" ++
+  "  li t1, 27\n" ++
+  ".Lt29_zinit:\n" ++
+  "  beqz t1, .Lt29_zdone\n" ++
+  "  sd zero, 0(t0)\n" ++
+  "  addi t0, t0, 8\n" ++
+  "  addi t1, t1, -1\n" ++
+  "  j .Lt29_zinit\n" ++
+  ".Lt29_zdone:\n" ++
+  "  jal ra, tx_eip2930_decode\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)                # status\n" ++
+  "  j .Lt29_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpFieldToU64Function ++ "\n" ++
+  rlpFieldToU256BeFunction ++ "\n" ++
+  txEip2930DecodeFunction ++ "\n" ++
+  ".Lt29_pdone:"
+
+def ziskTxEip2930DecodeDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "rfu_offset:\n" ++
+  "  .zero 8\n" ++
+  "rfu_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "t29_offset:\n" ++
+  "  .zero 8\n" ++
+  "t29_length:\n" ++
+  "  .zero 8"
+
+def ziskTxEip2930DecodeProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskTxEip2930DecodePrologue
+  dataAsm     := ziskTxEip2930DecodeDataSection
+}
+
 /-! ## zisk_ssz_pair_hash — PR-S4 SSZ merkleization primitive
 
     First consumer of the SSZ `hash_tree_root` shim:
@@ -6576,6 +6763,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_header_minimal_decode" => some ziskHeaderMinimalDecodeProbeUnit
   | "zisk_header_extended_decode" => some ziskHeaderExtendedDecodeProbeUnit
   | "zisk_tx_type_dispatch"     => some ziskTxTypeDispatchProbeUnit
+  | "zisk_tx_eip2930_decode"    => some ziskTxEip2930DecodeProbeUnit
   | "zisk_sha256_from_input"    => some ziskSha256FromInputProbeUnit
   | "zisk_ssz_pair_hash"        => some ziskSszPairHashProbeUnit
   | "zisk_ssz_zero_hashes"      => some ziskSszZeroHashesProbeUnit
@@ -6631,6 +6819,7 @@ def knownProgramNames : List String :=
    "zisk_header_minimal_decode",
    "zisk_header_extended_decode",
    "zisk_tx_type_dispatch",
+   "zisk_tx_eip2930_decode",
    "zisk_sha256_from_input",
    "zisk_ssz_pair_hash",
    "zisk_ssz_zero_hashes",

--- a/scripts/codegen-zisk-tx-eip2930-decode-check.sh
+++ b/scripts/codegen-zisk-tx-eip2930-decode-check.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+# codegen-zisk-tx-eip2930-decode-check.sh -- PR-K42.
+#
+# Decode all 11 fields of an EIP-2930 (type-1) access-list tx
+# inner body into a 216-byte struct. Cross-validated against
+# Python's RLP encoder. Caller is expected to have stripped the
+# 0x01 type byte beforehand (PR-K40 tx_type_dispatch gives the
+# offset).
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_tx_eip2930_decode ELF"
+lake exe codegen --program zisk_tx_eip2930_decode --halt linux93 \
+  -o gen-out/zisk_tx_eip2930_decode
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <chain_id> <nonce> <gas_price> <gas_limit>
+#         <to_hex> <value> <data_hex> <access_list_json>
+#         <y_parity> <r_hex> <s_hex>
+run_case() {
+  local name="$1"
+  local chain_id="$2" nonce="$3" gas_price="$4" gas_limit="$5"
+  local to_hex="$6" value="$7" data_hex="$8"
+  local access_list_json="$9" y_parity="${10}"
+  local r_hex="${11}" s_hex="${12}"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_tx_eip2930_decode_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_tx_eip2930_decode_${name}.output"
+  local exp_file="$REPO_ROOT/gen-out/zisk_tx_eip2930_decode_${name}.expected"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import json, struct, sys
+import rlp
+
+chain_id = $chain_id
+nonce = $nonce
+gas_price = $gas_price
+gas_limit = $gas_limit
+to = bytes.fromhex('$to_hex')
+value = $value
+data = bytes.fromhex('$data_hex')
+access_list_raw = json.loads('''$access_list_json''')
+y_parity = $y_parity
+r = int.from_bytes(bytes.fromhex('$r_hex'), 'big')
+s = int.from_bytes(bytes.fromhex('$s_hex'), 'big')
+
+access_list = []
+for entry in access_list_raw:
+    addr_hex, slots_hex = entry
+    addr = bytes.fromhex(addr_hex)
+    slots = [bytes.fromhex(k) for k in slots_hex]
+    access_list.append([addr, slots])
+
+inner_rlp = rlp.encode([
+    chain_id, nonce, gas_price, gas_limit,
+    to, value, data, access_list,
+    y_parity, r, s,
+])
+
+with open(sys.argv[1], 'wb') as f:
+    f.write(struct.pack('<Q', len(inner_rlp)))
+    f.write(inner_rlp)
+    pad = (-(8 + len(inner_rlp))) % 8
+    if pad:
+        f.write(b'\x00' * pad)
+
+# Expected: status u64 LE + 216-byte struct.
+expected = struct.pack('<Q', 0)
+expected += struct.pack('<Q', chain_id)
+expected += struct.pack('<Q', nonce)
+expected += gas_price.to_bytes(32, 'big')
+expected += struct.pack('<Q', gas_limit)
+to_present = 1 if len(to) > 0 else 0
+if len(to) == 20:
+    expected += to
+elif len(to) == 0:
+    expected += b'\x00' * 20
+expected += struct.pack('<I', to_present)
+expected += value.to_bytes(32, 'big')
+
+# Compute data/access_list offsets within inner_rlp.
+# byte-string items: content offset + length;
+# LIST items: whole-encoded-extent (offset = item_start, length = full).
+items = [
+    chain_id, nonce, gas_price, gas_limit,
+    to, value, data, access_list,
+    y_parity, r, s,
+]
+def field_offset(items, idx):
+    payload = b''.join(rlp.encode(it) for it in items)
+    if len(payload) < 56:
+        prefix_len = 1
+    else:
+        length_bits = (len(payload).bit_length() + 7) // 8
+        prefix_len = 1 + length_bits
+    offset = prefix_len
+    for i in range(idx):
+        offset += len(rlp.encode(items[i]))
+    item_rlp = rlp.encode(items[idx])
+    if len(item_rlp) == 1 and item_rlp[0] < 0x80:
+        return offset, 1
+    elif item_rlp[0] < 0xb8:
+        return offset + 1, item_rlp[0] - 0x80
+    elif item_rlp[0] < 0xc0:
+        lol = item_rlp[0] - 0xb7
+        return (offset + 1 + lol,
+                int.from_bytes(item_rlp[1:1+lol], 'big'))
+    else:
+        return offset, len(item_rlp)
+
+data_off, data_len = field_offset(items, 6)
+al_off, al_len = field_offset(items, 7)
+expected += struct.pack('<Q', data_off)
+expected += struct.pack('<Q', data_len)
+expected += struct.pack('<Q', al_off)
+expected += struct.pack('<Q', al_len)
+expected += struct.pack('<Q', y_parity)
+expected += r.to_bytes(32, 'big')
+expected += s.to_bytes(32, 'big')
+
+with open(sys.argv[2], 'wb') as f:
+    f.write(expected)
+" "$in_file" "$exp_file"
+
+  "$ZISKEMU" -e gen-out/zisk_tx_eip2930_decode.elf \
+    -i "$in_file" -o "$out_file" -n 500000 \
+    >"$REPO_ROOT/gen-out/zisk_tx_eip2930_decode_${name}.emu.log" 2>&1 || true
+
+  local exp_size; exp_size="$(stat -c%s "$exp_file")"
+  local actual expected
+  actual="$(xxd -p -l "$exp_size" "$out_file" 2>/dev/null | tr -d '\n')"
+  expected="$(xxd -p -l "$exp_size" "$exp_file" 2>/dev/null | tr -d '\n')"
+
+  if [[ "$actual" == "$expected" ]]; then
+    printf "  %-30s OK   nonce=%d to_len=%d al=%s\n" \
+      "$name" "$nonce" "$((${#to_hex} / 2))" \
+      "$([[ "$access_list_json" == "[]" ]] && echo "[]" || echo "<filled>")"
+    return 0
+  else
+    printf "  %-30s FAIL\n    expected: %s\n    actual:   %s\n" \
+      "$name" "$expected" "$actual"
+    return 1
+  fi
+}
+
+ALICE="$(printf 'aa%.0s' $(seq 1 20))"
+BOB="$(printf 'bb%.0s' $(seq 1 20))"
+R1="$(printf '11%.0s' $(seq 1 32))"
+S1="$(printf '22%.0s' $(seq 1 32))"
+R2="$(printf '33%.0s' $(seq 1 32))"
+S2="$(printf '44%.0s' $(seq 1 32))"
+K1="$(printf '55%.0s' $(seq 1 32))"
+K2="$(printf '66%.0s' $(seq 1 32))"
+
+FAILED=0
+# Simple ether transfer, empty access list, no data
+run_case "simple_transfer" \
+  1 7 1000000000 21000 \
+  "$ALICE" 1000000000000000000 "" \
+  "[]" 0 "$R1" "$S1" || FAILED=1
+
+# Contract creation (empty to)
+run_case "creation" \
+  1 0 1500000000 100000 \
+  "" 0 "6080604052" \
+  "[]" 1 "$R2" "$S2" || FAILED=1
+
+# With non-trivial data
+LONG_DATA="$(python3 -c "print(bytes((i & 0xff) for i in range(120)).hex())")"
+run_case "with_data" \
+  10 1 100 50000 \
+  "$ALICE" 0 "$LONG_DATA" \
+  "[]" 0 "$R1" "$S1" || FAILED=1
+
+# Non-empty access list (one entry, one slot)
+run_case "with_access_list_1" \
+  1 5 2000000000 60000 \
+  "$BOB" 100 "" \
+  "[[\"$ALICE\", [\"$K1\"]]]" 1 "$R1" "$S2" || FAILED=1
+
+# Non-empty access list (two entries, multi-slot)
+run_case "with_access_list_2" \
+  1 9 1 80000 \
+  "$BOB" 999999999999 "deadbeef" \
+  "[[\"$ALICE\", [\"$K1\", \"$K2\"]], [\"$BOB\", [\"$K1\"]]]" 0 "$R2" "$S1" || FAILED=1
+
+# Large chain_id
+run_case "big_chain_id" \
+  17000 42 3 100000 \
+  "$ALICE" 1 "" \
+  "[]" 1 "$R1" "$S1" || FAILED=1
+
+# Max values
+run_case "max_fields" \
+  1 1844674407370955160 1000000 30000000 \
+  "$ALICE" 115792089237316195423570985008687907853269984665640564039457584007913129639935 "" \
+  "[]" 1 "$R2" "$S2" || FAILED=1
+
+# Long data (>56 bytes, triggers long-string RLP prefix)
+LONGER_DATA="$(python3 -c "print(bytes((i & 0xff) for i in range(300)).hex())")"
+run_case "long_data" \
+  1 100 3 1000000 \
+  "$ALICE" 0 "$LONGER_DATA" \
+  "[]" 0 "$R1" "$S1" || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: tx_eip2930_decode produces the spec-compliant 11-field struct"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- New `tx_eip2930_decode` helper: decodes the 11-field inner RLP body of an EIP-2930 (type-1) access-list transaction into a flat 216-byte struct.
- Caller strips the leading `0x01` type byte first — PR-K40 `tx_type_dispatch` reports the `inner_offset`.
- Structurally simpler than PR-K41 EIP-1559: a single `gas_price` field instead of the `(max_priority_fee_per_gas, max_fee_per_gas)` pair.
- Access-list field returns the *whole encoded sub-list* (offset includes the RLP prefix, length is the full encoded length), mirroring PR-K41's contract so callers can recurse.

## Composition

- PR-K20 `rlp_list_nth_item` — outer walk and `to` / `data` / `access_list` field extraction
- PR-K34 `rlp_field_to_u64` — chain_id, nonce, gas_limit, y_parity
- PR-K35 `rlp_field_to_u256_be` — gas_price, value, r, s

## Test plan

- [x] `lake build` clean
- [x] `scripts/codegen-zisk-tx-eip2930-decode-check.sh` passes 8 fixtures cross-validated against Python's RLP encoder:
  - `simple_transfer`, `creation`, `with_data`, `with_access_list_1`, `with_access_list_2`, `big_chain_id`, `max_fields`, `long_data` (>56 B RLP prefix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)