### PR TITLE
feat(stateless): validate_header_basic (PR-K43)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -5214,6 +5214,84 @@ def ziskHeaderExtendedDecodeProbeUnit : BuildUnit := {
   dataAsm     := ziskHeaderExtendedDecodeDataSection
 }
 
+/-! ## validate_header_basic -- PR-K43 per-header semantic checks
+
+    Three u64 invariants from `validate_header` (Python:
+    `forks/amsterdam/fork.py`):
+
+      1. gas_used <= gas_limit
+      2. number == parent.number + 1
+      3. timestamp > parent.timestamp
+
+    Both inputs are 128-byte extended-header structs as produced
+    by PR-K39 `header_extended_decode`. Only the u64 fields at
+    offsets 64 (number), 72 (timestamp), 80 (gas_limit), 88
+    (gas_used) are read; the hash fields (parent_hash,
+    state_root) and base_fee_per_gas are ignored here -- those
+    are checked elsewhere (PR-K18 `validate_chain` for the hash
+    chain, future PR for the EIP-1559 base-fee formula).
+
+    Calling convention:
+      a0 (input)  : header_ptr (128-byte struct, this header)
+      a1 (input)  : parent_ptr (128-byte struct, parent header)
+      ra (input)  : return
+      a0 (output) : 0 ok
+                    1 gas_used > gas_limit
+                    2 number != parent.number + 1
+                    3 timestamp <= parent.timestamp
+
+    Pure register arithmetic, no scratch memory, leaf-callable. -/
+def validateHeaderBasicFunction : String :=
+  "validate_header_basic:\n" ++
+  "  ld t0, 88(a0)              # this.gas_used\n" ++
+  "  ld t1, 80(a0)              # this.gas_limit\n" ++
+  "  bgtu t0, t1, .Lvhb_fail_gas\n" ++
+  "  ld t0, 64(a0)              # this.number\n" ++
+  "  ld t1, 64(a1)              # parent.number\n" ++
+  "  addi t1, t1, 1\n" ++
+  "  bne t0, t1, .Lvhb_fail_number\n" ++
+  "  ld t0, 72(a0)              # this.timestamp\n" ++
+  "  ld t1, 72(a1)              # parent.timestamp\n" ++
+  "  bgeu t1, t0, .Lvhb_fail_timestamp  # parent_ts >= this_ts → fail\n" ++
+  "  li a0, 0\n" ++
+  "  ret\n" ++
+  ".Lvhb_fail_gas:\n" ++
+  "  li a0, 1\n" ++
+  "  ret\n" ++
+  ".Lvhb_fail_number:\n" ++
+  "  li a0, 2\n" ++
+  "  ret\n" ++
+  ".Lvhb_fail_timestamp:\n" ++
+  "  li a0, 3\n" ++
+  "  ret"
+
+/-- `zisk_validate_header_basic`: probe BuildUnit. Reads two
+    128-byte extended-header structs from host input (after an
+    8-byte tag) and writes the 8-byte status to OUTPUT. -/
+def ziskValidateHeaderBasicPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a3, 0x40000000\n" ++
+  "  # Input layout: [pad u64][header 128B][parent 128B]\n" ++
+  "  addi a0, a3, 8              # header_ptr\n" ++
+  "  addi a1, a3, 136            # parent_ptr (8 + 128)\n" ++
+  "  jal ra, validate_header_basic\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)                # status\n" ++
+  "  j .Lvhb_pdone\n" ++
+  validateHeaderBasicFunction ++ "\n" ++
+  ".Lvhb_pdone:"
+
+def ziskValidateHeaderBasicDataSection : String :=
+  ".section .data\n" ++
+  "vhb_pad:\n" ++
+  "  .zero 8"
+
+def ziskValidateHeaderBasicProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskValidateHeaderBasicPrologue
+  dataAsm     := ziskValidateHeaderBasicDataSection
+}
+
 /-! ## tx_type_dispatch -- PR-K40 typed-tx prefix detector
 
     Read the first byte of an RLP/typed-tx-encoded transaction
@@ -6575,6 +6653,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_derive_chain_id_from_v" => some ziskDeriveChainIdFromVProbeUnit
   | "zisk_header_minimal_decode" => some ziskHeaderMinimalDecodeProbeUnit
   | "zisk_header_extended_decode" => some ziskHeaderExtendedDecodeProbeUnit
+  | "zisk_validate_header_basic" => some ziskValidateHeaderBasicProbeUnit
   | "zisk_tx_type_dispatch"     => some ziskTxTypeDispatchProbeUnit
   | "zisk_sha256_from_input"    => some ziskSha256FromInputProbeUnit
   | "zisk_ssz_pair_hash"        => some ziskSszPairHashProbeUnit
@@ -6630,6 +6709,7 @@ def knownProgramNames : List String :=
    "zisk_derive_chain_id_from_v",
    "zisk_header_minimal_decode",
    "zisk_header_extended_decode",
+   "zisk_validate_header_basic",
    "zisk_tx_type_dispatch",
    "zisk_sha256_from_input",
    "zisk_ssz_pair_hash",

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **66**
-- ziskemu round-trip scripts: **59** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **67**
+- ziskemu round-trip scripts: **60** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-validate-header-basic-check.sh
+++ b/scripts/codegen-zisk-validate-header-basic-check.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# codegen-zisk-validate-header-basic-check.sh -- PR-K43.
+#
+# Per-header u64 semantic invariants from validate_header():
+#   1. gas_used <= gas_limit
+#   2. number == parent.number + 1
+#   3. timestamp > parent.timestamp
+#
+# Both inputs are 128-byte extended-header structs as produced
+# by PR-K39 header_extended_decode.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_validate_header_basic ELF"
+lake exe codegen --program zisk_validate_header_basic --halt linux93 \
+  -o gen-out/zisk_validate_header_basic
+
+REPO_ROOT="$(pwd)"
+
+# pack_header writes a 128-byte struct:
+#   0..32: parent_hash (zeros)
+#  32..64: state_root  (zeros)
+#  64..72: number      (u64 LE)
+#  72..80: timestamp   (u64 LE)
+#  80..88: gas_limit   (u64 LE)
+#  88..96: gas_used    (u64 LE)
+#  96..128: base_fee_per_gas (zeros - not checked here)
+pack_header() {
+  local number="$1" timestamp="$2" gas_limit="$3" gas_used="$4"
+  python3 -c "
+import struct, sys
+out  = b'\x00' * 32                     # parent_hash
+out += b'\x00' * 32                     # state_root
+out += struct.pack('<Q', $number)
+out += struct.pack('<Q', $timestamp)
+out += struct.pack('<Q', $gas_limit)
+out += struct.pack('<Q', $gas_used)
+out += b'\x00' * 32                     # base_fee_per_gas
+sys.stdout.buffer.write(out)
+"
+}
+
+run_case() {
+  local name="$1" expected_status="$2"
+  local p_number="$3" p_ts="$4" p_gas_limit="$5" p_gas_used="$6"
+  local h_number="$7" h_ts="$8" h_gas_limit="$9" h_gas_used="${10}"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_validate_header_basic_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_validate_header_basic_${name}.output"
+
+  # Input file maps to INPUT_ADDR + 8 onward, so the file starts
+  # directly with the this-header bytes (no leading pad).
+  : > "$in_file"
+  pack_header "$h_number" "$h_ts" "$h_gas_limit" "$h_gas_used" >> "$in_file"
+  pack_header "$p_number" "$p_ts" "$p_gas_limit" "$p_gas_used" >> "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_validate_header_basic.elf \
+    -i "$in_file" -o "$out_file" -n 500000 \
+    >"$REPO_ROOT/gen-out/zisk_validate_header_basic_${name}.emu.log" 2>&1 || true
+
+  local actual; actual="$(xxd -p -l 8 "$out_file" 2>/dev/null | tr -d '\n')"
+  local exp_le; exp_le="$(python3 -c "print(int('$expected_status').to_bytes(8, 'little').hex())")"
+
+  if [[ "$actual" == "$exp_le" ]]; then
+    printf "  %-30s OK   status=%d\n" "$name" "$expected_status"
+    return 0
+  else
+    printf "  %-30s FAIL  expected status=%d got 0x%s\n" "$name" "$expected_status" "$actual"
+    return 1
+  fi
+}
+
+FAILED=0
+# pass cases
+run_case "ok_zero_gas"          0  100 1000  30000000 0          101 2000  30000000 0          || FAILED=1
+run_case "ok_full_gas"          0  100 1000  30000000 0          101 2000  30000000 30000000   || FAILED=1
+run_case "ok_min_timestamp_gap" 0  100 1000  30000000 0          101 1001  30000000 21000      || FAILED=1
+run_case "ok_genesis_to_1"      0  0   0     30000000 0          1   1     30000000 21000      || FAILED=1
+# fail: gas_used > gas_limit
+run_case "fail_gas_overshoot"   1  100 1000  30000000 0          101 2000  30000000 30000001   || FAILED=1
+run_case "fail_gas_overshoot2"  1  100 1000  21000    0          101 2000  21000    21001      || FAILED=1
+# fail: number mismatch
+run_case "fail_number_same"     2  100 1000  30000000 0          100 2000  30000000 100        || FAILED=1
+run_case "fail_number_skip"     2  100 1000  30000000 0          102 2000  30000000 100        || FAILED=1
+run_case "fail_number_behind"   2  100 1000  30000000 0          99  2000  30000000 100        || FAILED=1
+# fail: timestamp not increasing
+run_case "fail_timestamp_same"  3  100 1000  30000000 0          101 1000  30000000 100        || FAILED=1
+run_case "fail_timestamp_back"  3  100 1000  30000000 0          101 999   30000000 100        || FAILED=1
+# Multi-failure: gas check fires FIRST per asm order.
+run_case "first_failure_gas"    1  100 1000  30000000 0          50  500   30000000 30000001   || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: validate_header_basic enforces gas_used/number/timestamp invariants"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Enforces three u64 invariants from Python `validate_header()`:

1. `gas_used <= gas_limit`
2. `number == parent.number + 1`
3. `timestamp > parent.timestamp`

Operates on two 128-byte extended-header structs as produced by PR-K39 `header_extended_decode`. Pure register arithmetic, no scratch memory, leaf-callable.

The hash-chain check (`parent_hash == keccak(parent)`) is already handled by PR-K18 `validate_chain`. The EIP-1559 base-fee formula check requires u256 arithmetic and lands in a follow-up PR.

## Return codes

| `a0` | Meaning |
|------|---------|
| 0 | OK |
| 1 | `gas_used > gas_limit` |
| 2 | `number != parent.number + 1` |
| 3 | `timestamp <= parent.timestamp` |

## Test plan

- [x] `lake build` clean
- [x] `scripts/codegen-zisk-validate-header-basic-check.sh` passes 12 fixtures:
  - 4 pass cases (zero-gas, full-gas, min timestamp gap, genesis→1)
  - 2 gas overshoots
  - 3 number mismatches (same, skip, behind)
  - 2 timestamp violations (same, back)
  - 1 first-failure ordering (gas fires before number/timestamp)

🤖 Generated with [Claude Code](https://claude.com/claude-code)