### PR TITLE
feat(stateless): tx_eip4844_decode (PR-K45)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -6054,6 +6054,221 @@ def ziskTxEip7702DecodeProbeUnit : BuildUnit := {
   dataAsm     := ziskTxEip7702DecodeDataSection
 }
 
+/-! ## tx_eip4844_decode -- PR-K45 full 14-field EIP-4844 decoder
+
+    Decode the inner (post-type-byte) RLP body of an EIP-4844
+    (type-3) blob transaction into a flat 248-byte output struct.
+    Inner RLP shape (14 fields):
+
+      rlp([
+        chain_id, nonce,
+        max_priority_fee_per_gas, max_fee_per_gas,
+        gas_limit, to, value, data,
+        access_list,
+        max_fee_per_blob_gas, blob_versioned_hashes,
+        y_parity, r, s
+      ])
+
+    Compared to PR-K41 EIP-1559 (12 fields), EIP-4844 inserts
+    `max_fee_per_blob_gas` (u256) and `blob_versioned_hashes`
+    (list of 32-byte hashes) between `access_list` and `y_parity`.
+
+    NOTE on max_fee_per_blob_gas: the spec type is u256, but
+    real-world blob fees fit comfortably in u64 (mainnet typical
+    range is 1 wei .. low gwei). To keep the struct within
+    ziskemu's 256-byte output cap, this decoder stores the
+    field as `u64` and rejects (status=1) any encoded value
+    longer than 8 bytes. Callers needing the full u256 can
+    re-extract via `rlp_field_to_u256_be` at field index 9.
+
+    Output struct (248 bytes; u32 offsets/lengths):
+
+       0..  8  chain_id                  (u64 LE)
+       8.. 16  nonce                     (u64 LE)
+      16.. 48  max_priority_fee_per_gas  (u256 BE)
+      48.. 80  max_fee_per_gas           (u256 BE)
+      80.. 88  gas_limit                 (u64 LE)
+      88..108  to (20-byte address; zero for creation -- but
+                  EIP-4844 spec disallows creation, so empty
+                  to is just reported via to_present=0)
+     108..112  to_present (u32; 0 = creation, 1 = call)
+     112..144  value                     (u256 BE)
+     144..148  data_offset               (u32)
+     148..152  data_length               (u32)
+     152..156  access_list_offset        (u32; whole encoded item)
+     156..160  access_list_length        (u32; whole encoded item)
+     160..168  max_fee_per_blob_gas      (u64 LE; rejects > 8 B BE)
+     168..172  blob_versioned_hashes_off (u32; whole encoded item)
+     172..176  blob_versioned_hashes_len (u32; whole encoded item)
+     176..184  y_parity                  (u64; 0 or 1)
+     184..216  r                         (u256 BE)
+     216..248  s                         (u256 BE)
+
+    Calling convention:
+      a0 (input)  : inner_rlp ptr
+      a1 (input)  : inner_rlp byte length
+      a2 (input)  : output struct ptr (248 bytes)
+      ra (input)  : return
+      a0 (output) : 0 success / 1 parse fail (incl. blob fee > u64) -/
+def txEip4844DecodeFunction : String :=
+  "tx_eip4844_decode:\n" ++
+  "  addi sp, sp, -48\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp)\n" ++
+  "  mv s0, a0                  # inner_rlp ptr\n" ++
+  "  mv s1, a1                  # inner_rlp_len\n" ++
+  "  mv s2, a2                  # struct out\n" ++
+  "  # Field 0: chain_id\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 0; mv a3, s2\n" ++
+  "  jal ra, rlp_field_to_u64\n" ++
+  "  bnez a0, .Lt48_fail\n" ++
+  "  # Field 1: nonce\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 1\n" ++
+  "  addi a3, s2, 8\n" ++
+  "  jal ra, rlp_field_to_u64\n" ++
+  "  bnez a0, .Lt48_fail\n" ++
+  "  # Field 2: max_priority_fee_per_gas\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 2\n" ++
+  "  addi a3, s2, 16\n" ++
+  "  jal ra, rlp_field_to_u256_be\n" ++
+  "  bnez a0, .Lt48_fail\n" ++
+  "  # Field 3: max_fee_per_gas\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 3\n" ++
+  "  addi a3, s2, 48\n" ++
+  "  jal ra, rlp_field_to_u256_be\n" ++
+  "  bnez a0, .Lt48_fail\n" ++
+  "  # Field 4: gas_limit\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 4\n" ++
+  "  addi a3, s2, 80\n" ++
+  "  jal ra, rlp_field_to_u64\n" ++
+  "  bnez a0, .Lt48_fail\n" ++
+  "  # Field 5: to (0 or 20 B at 88; to_present u32 at 108)\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 5\n" ++
+  "  la a3, t48_offset; la a4, t48_length\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lt48_fail\n" ++
+  "  la t0, t48_length; ld t1, 0(t0)\n" ++
+  "  beqz t1, .Lt48_to_creation\n" ++
+  "  li t2, 20\n" ++
+  "  bne t1, t2, .Lt48_fail\n" ++
+  "  la t0, t48_offset; ld t3, 0(t0); add t3, s0, t3\n" ++
+  "  addi t4, s2, 88\n" ++
+  "  ld t5,  0(t3); sd t5, 0(t4)\n" ++
+  "  ld t5,  8(t3); sd t5, 8(t4)\n" ++
+  "  lwu t5, 16(t3); sw t5, 16(t4)\n" ++
+  "  li t5, 1\n" ++
+  "  sw t5, 108(s2)             # to_present = 1\n" ++
+  "  j .Lt48_after_to\n" ++
+  ".Lt48_to_creation:\n" ++
+  "  addi t4, s2, 88\n" ++
+  "  sd zero, 0(t4); sd zero, 8(t4); sw zero, 16(t4)\n" ++
+  "  sw zero, 108(s2)           # to_present = 0\n" ++
+  ".Lt48_after_to:\n" ++
+  "  # Field 6: value\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 6\n" ++
+  "  addi a3, s2, 112\n" ++
+  "  jal ra, rlp_field_to_u256_be\n" ++
+  "  bnez a0, .Lt48_fail\n" ++
+  "  # Field 7: data (u32 off+len at 144/148)\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 7\n" ++
+  "  la a3, t48_offset; la a4, t48_length\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lt48_fail\n" ++
+  "  la t0, t48_offset; ld t1, 0(t0); sw t1, 144(s2)\n" ++
+  "  la t0, t48_length; ld t1, 0(t0); sw t1, 148(s2)\n" ++
+  "  # Field 8: access_list (u32 off+len at 152/156)\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 8\n" ++
+  "  la a3, t48_offset; la a4, t48_length\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lt48_fail\n" ++
+  "  la t0, t48_offset; ld t1, 0(t0); sw t1, 152(s2)\n" ++
+  "  la t0, t48_length; ld t1, 0(t0); sw t1, 156(s2)\n" ++
+  "  # Field 9: max_fee_per_blob_gas (u64 at 160; rejects > 8B BE)\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 9\n" ++
+  "  addi a3, s2, 160\n" ++
+  "  jal ra, rlp_field_to_u64\n" ++
+  "  bnez a0, .Lt48_fail\n" ++
+  "  # Field 10: blob_versioned_hashes (u32 off+len at 168/172)\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 10\n" ++
+  "  la a3, t48_offset; la a4, t48_length\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lt48_fail\n" ++
+  "  la t0, t48_offset; ld t1, 0(t0); sw t1, 168(s2)\n" ++
+  "  la t0, t48_length; ld t1, 0(t0); sw t1, 172(s2)\n" ++
+  "  # Field 11: y_parity (u64 at 176)\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 11\n" ++
+  "  addi a3, s2, 176\n" ++
+  "  jal ra, rlp_field_to_u64\n" ++
+  "  bnez a0, .Lt48_fail\n" ++
+  "  # Field 12: r (u256 at 184)\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 12\n" ++
+  "  addi a3, s2, 184\n" ++
+  "  jal ra, rlp_field_to_u256_be\n" ++
+  "  bnez a0, .Lt48_fail\n" ++
+  "  # Field 13: s (u256 at 216)\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 13\n" ++
+  "  addi a3, s2, 216\n" ++
+  "  jal ra, rlp_field_to_u256_be\n" ++
+  "  bnez a0, .Lt48_fail\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lt48_ret\n" ++
+  ".Lt48_fail:\n" ++
+  "  li a0, 1\n" ++
+  ".Lt48_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp)\n" ++
+  "  addi sp, sp, 48\n" ++
+  "  ret"
+
+/-- `zisk_tx_eip4844_decode`: probe BuildUnit. Reads (inner_len,
+    inner_bytes) from host input -- caller is expected to have
+    stripped the 0x03 type byte. Writes (status, 248-byte struct)
+    to OUTPUT (256 bytes total). -/
+def ziskTxEip4844DecodePrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a3, 0x40000000\n" ++
+  "  ld a1, 8(a3)                # inner_len\n" ++
+  "  addi a0, a3, 16             # inner ptr\n" ++
+  "  li a2, 0xa0010008           # struct at OUTPUT + 8\n" ++
+  "  # Pre-zero 248 bytes (31 × 8 dwords).\n" ++
+  "  mv t0, a2\n" ++
+  "  li t1, 31\n" ++
+  ".Lt48_zinit:\n" ++
+  "  beqz t1, .Lt48_zdone\n" ++
+  "  sd zero, 0(t0)\n" ++
+  "  addi t0, t0, 8\n" ++
+  "  addi t1, t1, -1\n" ++
+  "  j .Lt48_zinit\n" ++
+  ".Lt48_zdone:\n" ++
+  "  jal ra, tx_eip4844_decode\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)                # status\n" ++
+  "  j .Lt48_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpFieldToU64Function ++ "\n" ++
+  rlpFieldToU256BeFunction ++ "\n" ++
+  txEip4844DecodeFunction ++ "\n" ++
+  ".Lt48_pdone:"
+
+def ziskTxEip4844DecodeDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "rfu_offset:\n" ++
+  "  .zero 8\n" ++
+  "rfu_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "t48_offset:\n" ++
+  "  .zero 8\n" ++
+  "t48_length:\n" ++
+  "  .zero 8"
+
+def ziskTxEip4844DecodeProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskTxEip4844DecodePrologue
+  dataAsm     := ziskTxEip4844DecodeDataSection
+}
+
 /-! ## zisk_ssz_pair_hash — PR-S4 SSZ merkleization primitive
 
     First consumer of the SSZ `hash_tree_root` shim:
@@ -7315,6 +7530,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_tx_type_dispatch"     => some ziskTxTypeDispatchProbeUnit
   | "zisk_tx_eip2930_decode"    => some ziskTxEip2930DecodeProbeUnit
   | "zisk_tx_eip7702_decode"    => some ziskTxEip7702DecodeProbeUnit
+  | "zisk_tx_eip4844_decode"    => some ziskTxEip4844DecodeProbeUnit
   | "zisk_sha256_from_input"    => some ziskSha256FromInputProbeUnit
   | "zisk_ssz_pair_hash"        => some ziskSszPairHashProbeUnit
   | "zisk_ssz_zero_hashes"      => some ziskSszZeroHashesProbeUnit
@@ -7374,6 +7590,7 @@ def knownProgramNames : List String :=
    "zisk_tx_type_dispatch",
    "zisk_tx_eip2930_decode",
    "zisk_tx_eip7702_decode",
+   "zisk_tx_eip4844_decode",
    "zisk_sha256_from_input",
    "zisk_ssz_pair_hash",
    "zisk_ssz_zero_hashes",

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **68**
-- ziskemu round-trip scripts: **61** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **69**
+- ziskemu round-trip scripts: **62** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-tx-eip4844-decode-check.sh
+++ b/scripts/codegen-zisk-tx-eip4844-decode-check.sh
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+# codegen-zisk-tx-eip4844-decode-check.sh -- PR-K45.
+#
+# Decode all 14 fields of an EIP-4844 (type-3) blob tx inner body
+# into a 248-byte struct. Cross-validated against Python's RLP
+# encoder. Caller is expected to have stripped the 0x03 type byte
+# beforehand (PR-K40 tx_type_dispatch gives the offset).
+#
+# Note: max_fee_per_blob_gas is stored as u64 (rejects > 8 B BE);
+# callers needing the full u256 can re-extract via
+# rlp_field_to_u256_be at field index 9.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_tx_eip4844_decode ELF"
+lake exe codegen --program zisk_tx_eip4844_decode --halt linux93 \
+  -o gen-out/zisk_tx_eip4844_decode
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <chain_id> <nonce> <max_priority> <max_fee> <gas_limit>
+#         <to_hex> <value> <data_hex>
+#         <access_list_json> <max_fee_per_blob_gas>
+#         <blob_hashes_json>
+#         <y_parity> <r_hex> <s_hex>
+#
+# blob_hashes_json: list of 32-byte hex strings, e.g. '["aabb..", "ccdd.."]'
+run_case() {
+  local name="$1"
+  local chain_id="$2" nonce="$3" max_priority="$4" max_fee="$5" gas_limit="$6"
+  local to_hex="$7" value="$8" data_hex="$9"
+  local access_list_json="${10}" max_blob_fee="${11}"
+  local blob_hashes_json="${12}"
+  local y_parity="${13}" r_hex="${14}" s_hex="${15}"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_tx_eip4844_decode_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_tx_eip4844_decode_${name}.output"
+  local exp_file="$REPO_ROOT/gen-out/zisk_tx_eip4844_decode_${name}.expected"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import json, struct, sys
+import rlp
+
+chain_id = $chain_id
+nonce = $nonce
+max_priority = $max_priority
+max_fee = $max_fee
+gas_limit = $gas_limit
+to = bytes.fromhex('$to_hex')
+value = $value
+data = bytes.fromhex('$data_hex')
+access_list_raw = json.loads('''$access_list_json''')
+max_blob_fee = $max_blob_fee
+blob_hashes_raw = json.loads('''$blob_hashes_json''')
+y_parity = $y_parity
+r = int.from_bytes(bytes.fromhex('$r_hex'), 'big')
+s = int.from_bytes(bytes.fromhex('$s_hex'), 'big')
+
+access_list = []
+for entry in access_list_raw:
+    addr_hex, slots_hex = entry
+    addr = bytes.fromhex(addr_hex)
+    slots = [bytes.fromhex(k) for k in slots_hex]
+    access_list.append([addr, slots])
+
+blob_hashes = [bytes.fromhex(h) for h in blob_hashes_raw]
+
+inner_rlp = rlp.encode([
+    chain_id, nonce, max_priority, max_fee, gas_limit,
+    to, value, data, access_list,
+    max_blob_fee, blob_hashes,
+    y_parity, r, s,
+])
+
+with open(sys.argv[1], 'wb') as f:
+    f.write(struct.pack('<Q', len(inner_rlp)))
+    f.write(inner_rlp)
+    pad = (-(8 + len(inner_rlp))) % 8
+    if pad:
+        f.write(b'\x00' * pad)
+
+# Expected: status u64 LE + 248-byte struct.
+expected = struct.pack('<Q', 0)
+expected += struct.pack('<Q', chain_id)
+expected += struct.pack('<Q', nonce)
+expected += max_priority.to_bytes(32, 'big')
+expected += max_fee.to_bytes(32, 'big')
+expected += struct.pack('<Q', gas_limit)
+to_present = 1 if len(to) > 0 else 0
+if len(to) == 20:
+    expected += to
+elif len(to) == 0:
+    expected += b'\x00' * 20
+expected += struct.pack('<I', to_present)
+expected += value.to_bytes(32, 'big')
+
+items = [
+    chain_id, nonce, max_priority, max_fee, gas_limit,
+    to, value, data, access_list,
+    max_blob_fee, blob_hashes,
+    y_parity, r, s,
+]
+def field_offset(items, idx):
+    payload = b''.join(rlp.encode(it) for it in items)
+    if len(payload) < 56:
+        prefix_len = 1
+    else:
+        length_bits = (len(payload).bit_length() + 7) // 8
+        prefix_len = 1 + length_bits
+    offset = prefix_len
+    for i in range(idx):
+        offset += len(rlp.encode(items[i]))
+    item_rlp = rlp.encode(items[idx])
+    if len(item_rlp) == 1 and item_rlp[0] < 0x80:
+        return offset, 1
+    elif item_rlp[0] < 0xb8:
+        return offset + 1, item_rlp[0] - 0x80
+    elif item_rlp[0] < 0xc0:
+        lol = item_rlp[0] - 0xb7
+        return (offset + 1 + lol,
+                int.from_bytes(item_rlp[1:1+lol], 'big'))
+    else:
+        return offset, len(item_rlp)
+
+data_off, data_len = field_offset(items, 7)
+al_off, al_len = field_offset(items, 8)
+bh_off, bh_len = field_offset(items, 10)
+expected += struct.pack('<I', data_off)
+expected += struct.pack('<I', data_len)
+expected += struct.pack('<I', al_off)
+expected += struct.pack('<I', al_len)
+expected += struct.pack('<Q', max_blob_fee)
+expected += struct.pack('<I', bh_off)
+expected += struct.pack('<I', bh_len)
+expected += struct.pack('<Q', y_parity)
+expected += r.to_bytes(32, 'big')
+expected += s.to_bytes(32, 'big')
+
+with open(sys.argv[2], 'wb') as f:
+    f.write(expected)
+" "$in_file" "$exp_file"
+
+  "$ZISKEMU" -e gen-out/zisk_tx_eip4844_decode.elf \
+    -i "$in_file" -o "$out_file" -n 500000 \
+    >"$REPO_ROOT/gen-out/zisk_tx_eip4844_decode_${name}.emu.log" 2>&1 || true
+
+  local exp_size; exp_size="$(stat -c%s "$exp_file")"
+  local actual expected
+  actual="$(xxd -p -l "$exp_size" "$out_file" 2>/dev/null | tr -d '\n')"
+  expected="$(xxd -p -l "$exp_size" "$exp_file" 2>/dev/null | tr -d '\n')"
+
+  if [[ "$actual" == "$expected" ]]; then
+    printf "  %-30s OK   nonce=%d blob_hashes=%d blob_fee=%d\n" \
+      "$name" "$nonce" "$(python3 -c "import json; print(len(json.loads('''$blob_hashes_json''')))")" \
+      "$max_blob_fee"
+    return 0
+  else
+    printf "  %-30s FAIL\n    expected: %s\n    actual:   %s\n" \
+      "$name" "$expected" "$actual"
+    return 1
+  fi
+}
+
+ALICE="$(printf 'aa%.0s' $(seq 1 20))"
+BOB="$(printf 'bb%.0s' $(seq 1 20))"
+R1="$(printf '11%.0s' $(seq 1 32))"
+S1="$(printf '22%.0s' $(seq 1 32))"
+R2="$(printf '33%.0s' $(seq 1 32))"
+S2="$(printf '44%.0s' $(seq 1 32))"
+K1="$(printf '55%.0s' $(seq 1 32))"
+# Blob versioned hashes (32 B each, all start with 0x01 per spec)
+H1="01$(printf 'aa%.0s' $(seq 1 31))"
+H2="01$(printf 'bb%.0s' $(seq 1 31))"
+H3="01$(printf 'cc%.0s' $(seq 1 31))"
+
+FAILED=0
+# One blob, empty access list
+run_case "one_blob" \
+  1 7 1000000000 2000000000 21000 \
+  "$ALICE" 1000000000000000000 "" \
+  "[]" 1 \
+  "[\"$H1\"]" \
+  0 "$R1" "$S1" || FAILED=1
+
+# Multiple blobs (Cancun cap is 6)
+run_case "three_blobs" \
+  1 9 100 200 50000 \
+  "$BOB" 100 "deadbeef" \
+  "[]" 1000000000 \
+  "[\"$H1\", \"$H2\", \"$H3\"]" \
+  1 "$R2" "$S2" || FAILED=1
+
+# Six blobs (Cancun-era max)
+run_case "six_blobs" \
+  1 0 1 2 100000 \
+  "$BOB" 0 "" \
+  "[]" 1 \
+  "[\"$H1\", \"$H1\", \"$H2\", \"$H2\", \"$H3\", \"$H3\"]" \
+  0 "$R1" "$S2" || FAILED=1
+
+# With access list
+run_case "blobs_and_access" \
+  1 3 1 2 60000 \
+  "$BOB" 1 "" \
+  "[[\"$ALICE\", [\"$K1\"]]]" 5 \
+  "[\"$H1\", \"$H2\"]" \
+  1 "$R1" "$S1" || FAILED=1
+
+# Big blob_fee (still u64-fit)
+run_case "big_blob_fee_u64" \
+  1 5 1 1 30000 \
+  "$BOB" 0 "" \
+  "[]" 18446744073709551615 \
+  "[\"$H1\"]" \
+  0 "$R1" "$S1" || FAILED=1
+
+# Long data path
+LONGER_DATA="$(python3 -c "print(bytes((i & 0xff) for i in range(300)).hex())")"
+run_case "long_data" \
+  1 100 2 3 1000000 \
+  "$ALICE" 0 "$LONGER_DATA" \
+  "[]" 7 \
+  "[\"$H1\", \"$H2\"]" \
+  0 "$R1" "$S1" || FAILED=1
+
+# Big chain_id
+run_case "big_chain_id" \
+  17000 42 3 4 100000 \
+  "$ALICE" 1 "" \
+  "[]" 1 \
+  "[\"$H1\"]" \
+  1 "$R1" "$S1" || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: tx_eip4844_decode produces the spec-compliant 14-field struct"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- New `tx_eip4844_decode` helper: decodes the 14-field inner RLP body of an EIP-4844 (type-3) blob transaction into a flat 248-byte struct.
- Caller strips the leading `0x03` type byte first — PR-K40 `tx_type_dispatch` reports the `inner_offset`.
- Compared to PR-K41 EIP-1559 (12 fields), EIP-4844 inserts `max_fee_per_blob_gas` (u256) and `blob_versioned_hashes` (list of 32-byte hashes) between `access_list` and `y_parity`.

## max_fee_per_blob_gas u64 tradeoff

To keep the struct within ziskemu's 256-byte output cap, `max_fee_per_blob_gas` is stored as **u64** (production blob fees fit comfortably). The decoder rejects (status=1) any encoded value longer than 8 bytes BE. Callers needing the full u256 can re-extract via `rlp_field_to_u256_be` at field index 9.

This completes the typed-tx decoder set: legacy (K36), EIP-2930 (K42), EIP-1559 (K41), EIP-4844 (K45), EIP-7702 (K44).

## Composition

- PR-K20 `rlp_list_nth_item` — outer walk and `to` / `data` / `access_list` / `blob_versioned_hashes` extraction
- PR-K34 `rlp_field_to_u64` — chain_id, nonce, gas_limit, max_fee_per_blob_gas, y_parity
- PR-K35 `rlp_field_to_u256_be` — max_priority_fee_per_gas, max_fee_per_gas, value, r, s

## Test plan

- [x] `lake build` clean
- [x] `scripts/codegen-zisk-tx-eip4844-decode-check.sh` passes 7 fixtures cross-validated against Python's RLP encoder:
  - `one_blob`, `three_blobs`, `six_blobs` (Cancun cap), `blobs_and_access`, `big_blob_fee_u64` (max u64), `long_data` (>56 B prefix), `big_chain_id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)