### PR TITLE
refactor(divmod): drop n1 max local recdepth override

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopIterN1/Max.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/Max.lean
@@ -17,7 +17,6 @@ open EvmAsm.Rv64
 -- n=1, BLTU not-taken (max path) + BEQ skip, j=0 → cpsTripleWithin to base+904
 -- ============================================================================
 
-set_option maxRecDepth 4096 in
 /-- Loop body cpsTripleWithin for n=1, max+skip, j=0.
     Since j=0, the BGE loop-back is not taken, giving a cpsTripleWithin to base+904. -/
 theorem divK_loop_body_n1_max_skip_j0_spec_within


### PR DESCRIPTION
## Summary
- remove the local maxRecDepth wrapper from DivMod LoopIterN1 Max proof

## Verification
- lake build EvmAsm.Evm64.DivMod.LoopIterN1.Max
- lake build EvmAsm.Evm64.DivMod
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- rg -n "set_option maxRecDepth|set_option maxHeartbeats|sorry|admit|native_decide|file-size-exception" EvmAsm/Evm64/DivMod/LoopIterN1/Max.lean (no matches)
- wc -l EvmAsm/Evm64/DivMod/LoopIterN1/Max.lean = 380