### PR TITLE
refactor(divmod): drop n1 maxbeq local recdepth override

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopIterN1/MaxBeq.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/MaxBeq.lean
@@ -14,12 +14,11 @@ namespace EvmAsm.Evm64
 open EvmAsm.Rv64
 
 -- ============================================================================
--- BEQ variants: max path addback with double-addback handling (no sorry)
+-- BEQ variants: max path addback with double-addback handling.
 -- ============================================================================
 
 -- n=1, max+addback BEQ, j=0
 
-set_option maxRecDepth 4096 in
 theorem divK_loop_body_n1_max_addback_j0_beq_spec_within
     (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)


### PR DESCRIPTION
## Summary
- remove the local maxRecDepth wrapper from DivMod LoopIterN1 MaxBeq proof
- update the touched BEQ comment so forbidden-marker scans stay clean

## Verification
- lake build EvmAsm.Evm64.DivMod.LoopIterN1.MaxBeq
- lake build EvmAsm.Evm64.DivMod
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- rg -n "set_option maxRecDepth|set_option maxHeartbeats|sorry|admit|native_decide|file-size-exception" EvmAsm/Evm64/DivMod/LoopIterN1/MaxBeq.lean (no matches)
- wc -l EvmAsm/Evm64/DivMod/LoopIterN1/MaxBeq.lean = 344