### PR TITLE
feat(stateless): u256_from_u64_be (PR-K56)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -5823,6 +5823,67 @@ def ziskU256SubBeProbeUnit : BuildUnit := {
   dataAsm     := ziskU256SubBeDataSection
 }
 
+/-! ## u256_from_u64_be -- PR-K56 zero-extend u64 → BE u256 buffer
+
+    Materialize a `u64` value as a 32-byte big-endian `u256`
+    buffer by zero-extending. Lets callers feed small operands
+    (`gas_limit`, `nonce`, `data_length`, etc.) into the u256
+    arithmetic and comparison toolkit (`u256_add_be`,
+    `u256_sub_be`, `u256_lt`, `u256_eq`, `u256_mul_u64_be`).
+
+    BE storage convention: byte 0 = MSB, byte 31 = LSB. Output:
+      bytes 0..24  = 0x00
+      bytes 24..32 = u64 value in big-endian order
+
+    Calling convention:
+      a0 (input)  : u64 value (in register)
+      a1 (input)  : u256 out ptr (32 bytes; will be fully written)
+      ra (input)  : return
+
+    Pure register arithmetic except for the 4 zero-stores + 8
+    byte-stores; no scratch memory; leaf-callable. Uses RV64 `sb`
+    semantics (stores low 8 bits of rs2), so no `andi 0xff`
+    masking is needed before each byte write. -/
+def u256FromU64BeFunction : String :=
+  "u256_from_u64_be:\n" ++
+  "  # Zero the high 24 bytes.\n" ++
+  "  sd zero,  0(a1)\n" ++
+  "  sd zero,  8(a1)\n" ++
+  "  sd zero, 16(a1)\n" ++
+  "  # Write the u64 in BE order at bytes 24..32.\n" ++
+  "  srli t0, a0, 56; sb t0, 24(a1)\n" ++
+  "  srli t0, a0, 48; sb t0, 25(a1)\n" ++
+  "  srli t0, a0, 40; sb t0, 26(a1)\n" ++
+  "  srli t0, a0, 32; sb t0, 27(a1)\n" ++
+  "  srli t0, a0, 24; sb t0, 28(a1)\n" ++
+  "  srli t0, a0, 16; sb t0, 29(a1)\n" ++
+  "  srli t0, a0,  8; sb t0, 30(a1)\n" ++
+  "                  sb a0, 31(a1)\n" ++
+  "  ret"
+
+/-- `zisk_u256_from_u64_be`: probe BuildUnit. Reads (u64 value)
+    from host input, writes the 32-byte BE u256 to OUTPUT. -/
+def ziskU256FromU64BePrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a2, 0x40000000\n" ++
+  "  ld a0, 8(a2)                # value\n" ++
+  "  li a1, 0xa0010000           # out ptr at OUTPUT\n" ++
+  "  jal ra, u256_from_u64_be\n" ++
+  "  j .Lu256f_pdone\n" ++
+  u256FromU64BeFunction ++ "\n" ++
+  ".Lu256f_pdone:"
+
+def ziskU256FromU64BeDataSection : String :=
+  ".section .data\n" ++
+  "u256f_pad:\n" ++
+  "  .zero 8"
+
+def ziskU256FromU64BeProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskU256FromU64BePrologue
+  dataAsm     := ziskU256FromU64BeDataSection
+}
+
 
 /-! ## tx_type_dispatch -- PR-K40 typed-tx prefix detector
 
@@ -8185,6 +8246,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_validate_header_basic" => some ziskValidateHeaderBasicProbeUnit
   | "zisk_u256_add_be"          => some ziskU256AddBeProbeUnit
   | "zisk_u256_sub_be"          => some ziskU256SubBeProbeUnit
+  | "zisk_u256_from_u64_be"     => some ziskU256FromU64BeProbeUnit
   | "zisk_tx_type_dispatch"     => some ziskTxTypeDispatchProbeUnit
   | "zisk_tx_eip2930_decode"    => some ziskTxEip2930DecodeProbeUnit
   | "zisk_tx_eip7702_decode"    => some ziskTxEip7702DecodeProbeUnit
@@ -8251,6 +8313,7 @@ def knownProgramNames : List String :=
    "zisk_validate_header_basic",
    "zisk_u256_add_be",
    "zisk_u256_sub_be",
+   "zisk_u256_from_u64_be",
    "zisk_tx_type_dispatch",
    "zisk_tx_eip2930_decode",
    "zisk_tx_eip7702_decode",

--- a/scripts/codegen-zisk-u256-from-u64-be-check.sh
+++ b/scripts/codegen-zisk-u256-from-u64-be-check.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# codegen-zisk-u256-from-u64-be-check.sh -- PR-K56.
+#
+# Zero-extend a u64 value into a 32-byte BE u256 buffer.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_u256_from_u64_be ELF"
+lake exe codegen --program zisk_u256_from_u64_be --halt linux93 \
+  -o gen-out/zisk_u256_from_u64_be
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <value_dec>
+run_case() {
+  local name="$1" value="$2"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_u256_from_u64_be_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_u256_from_u64_be_${name}.output"
+  local exp_file="$REPO_ROOT/gen-out/zisk_u256_from_u64_be_${name}.expected"
+
+  python3 -c "
+import struct, sys
+v = $value
+out = struct.pack('<Q', v)  # u64 LE, since asm uses ld
+sys.stdout.buffer.write(out)
+" > "$in_file"
+
+  python3 -c "
+import sys
+v = $value
+sys.stdout.buffer.write(v.to_bytes(32, 'big'))
+" > "$exp_file"
+
+  "$ZISKEMU" -e gen-out/zisk_u256_from_u64_be.elf \
+    -i "$in_file" -o "$out_file" -n 500000 \
+    >"$REPO_ROOT/gen-out/zisk_u256_from_u64_be_${name}.emu.log" 2>&1 || true
+
+  local actual; actual="$(xxd -p -l 32 "$out_file" | tr -d '\n')"
+  local expected; expected="$(xxd -p -l 32 "$exp_file" | tr -d '\n')"
+
+  if [[ "$actual" == "$expected" ]]; then
+    printf "  %-30s OK   value=%s\n" "$name" "$value"
+    return 0
+  else
+    printf "  %-30s FAIL\n    expected: %s\n    actual:   %s\n" \
+      "$name" "$expected" "$actual"
+    return 1
+  fi
+}
+
+MAX64=18446744073709551615
+GAS_30M=30000000
+
+FAILED=0
+# Edge values
+run_case "zero"                   0          || FAILED=1
+run_case "one"                    1          || FAILED=1
+run_case "255"                    255        || FAILED=1
+run_case "256"                    256        || FAILED=1
+run_case "two_to_15"              32768      || FAILED=1
+run_case "two_to_16"              65536      || FAILED=1
+run_case "two_to_24"              16777216   || FAILED=1
+run_case "two_to_31"              2147483648 || FAILED=1
+run_case "two_to_32"              4294967296 || FAILED=1
+run_case "max_u32"                4294967295 || FAILED=1
+# Realistic Ethereum values
+run_case "gas_21k"                21000      || FAILED=1
+run_case "gas_30M"                "$GAS_30M" || FAILED=1
+run_case "typical_nonce"          12345      || FAILED=1
+run_case "block_number_19M"       19000000   || FAILED=1
+run_case "timestamp_2026"         1779580800 || FAILED=1
+# Limb-boundary values
+run_case "two_to_56"              $(python3 -c "print(1 << 56)") || FAILED=1
+run_case "max_u64_minus_1"        $(python3 -c "print((1 << 64) - 2)") || FAILED=1
+run_case "max_u64"                "$MAX64"   || FAILED=1
+# Pseudo-random values
+run_case "0xdeadbeef_cafebabe"    $(python3 -c "print(0xdeadbeef_cafebabe)") || FAILED=1
+run_case "all_alternating_bits"   $(python3 -c "print(0xaaaaaaaaaaaaaaaa)") || FAILED=1
+run_case "byte_pattern"           $(python3 -c "print(0x0123456789abcdef)") || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: u256_from_u64_be matches Python's int.to_bytes(32, 'big') for 21 fixtures"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Materialize a `u64` value as a 32-byte big-endian `u256` buffer by zero-extending. Lets callers feed small operands (`gas_limit`, `nonce`, `data_length`, etc.) into the u256 arithmetic and comparison toolkit:

- PR-K50 `u256_lt`
- PR-K51 `u256_add_be`
- PR-K52 `u256_sub_be`
- PR-K53 `u256_eq`
- PR-K54 `u256_mul_u64_be`

Output layout:
- `bytes 0..24`  = `0x00`
- `bytes 24..32` = u64 in big-endian order

Pure register arithmetic + 4 zero-stores + 8 byte-stores; no scratch memory, no looping; leaf-callable. Uses RV64 `sb` semantics (stores low 8 bits of `rs2`), so no `andi 0xff` masking is needed before each byte write.

## Test plan

- [x] `lake build` clean
- [x] `scripts/codegen-zisk-u256-from-u64-be-check.sh` passes 21 fixtures:
  - Edge values (`0`, `1`, `255`, `256`)
  - Boundary exponents (`2^15`, `2^16`, `2^24`, `2^31`, `2^32`, `2^56`)
  - `max u32`, `max u64 - 1`, `max u64`
  - Realistic Ethereum values (21k / 30M gas, typical nonce, 19M block number, 2026 timestamp)
  - Pseudo-random byte patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)