### PR TITLE
feat(smod): compose mod call through result fix

### DIFF
--- a/EvmAsm/Evm64/SMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/SMod/Compose/Base.lean
@@ -29,6 +29,7 @@ import EvmAsm.Evm64.SMod.Compose.ResultSignFixView
 import EvmAsm.Evm64.SMod.Compose.ResultSignFixPCFree
 import EvmAsm.Evm64.SMod.Compose.ResultSignFixOwn
 import EvmAsm.Evm64.SMod.Compose.ModCallResultSignFixPost
+import EvmAsm.Evm64.SMod.Compose.ModCallResultSignFix
 
 namespace EvmAsm.Evm64.SMod.Compose
 

--- a/EvmAsm/Evm64/SMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/SMod/Compose/Base.lean
@@ -33,6 +33,7 @@ import EvmAsm.Evm64.SMod.Compose.ModCallResultSignFix
 import EvmAsm.Evm64.SMod.Compose.ModCallResultSignFixGeneric
 import EvmAsm.Evm64.SMod.Compose.ModCallResultSignFixNamedPost
 import EvmAsm.Evm64.SMod.Compose.SavedRaRet
+import EvmAsm.Evm64.SMod.Compose.SavedRaRetFrame
 
 namespace EvmAsm.Evm64.SMod.Compose
 

--- a/EvmAsm/Evm64/SMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/SMod/Compose/Base.lean
@@ -30,6 +30,7 @@ import EvmAsm.Evm64.SMod.Compose.ResultSignFixPCFree
 import EvmAsm.Evm64.SMod.Compose.ResultSignFixOwn
 import EvmAsm.Evm64.SMod.Compose.ModCallResultSignFixPost
 import EvmAsm.Evm64.SMod.Compose.ModCallResultSignFix
+import EvmAsm.Evm64.SMod.Compose.ModCallResultSignFixGeneric
 
 namespace EvmAsm.Evm64.SMod.Compose
 

--- a/EvmAsm/Evm64/SMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/SMod/Compose/Base.lean
@@ -35,6 +35,7 @@ import EvmAsm.Evm64.SMod.Compose.ModCallResultSignFixNamedPost
 import EvmAsm.Evm64.SMod.Compose.SavedRaRet
 import EvmAsm.Evm64.SMod.Compose.SavedRaRetFrame
 import EvmAsm.Evm64.SMod.Compose.ModCallReturnGeneric
+import EvmAsm.Evm64.SMod.Compose.ModCallReturnNamedPost
 
 namespace EvmAsm.Evm64.SMod.Compose
 

--- a/EvmAsm/Evm64/SMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/SMod/Compose/Base.lean
@@ -32,6 +32,7 @@ import EvmAsm.Evm64.SMod.Compose.ModCallResultSignFixPost
 import EvmAsm.Evm64.SMod.Compose.ModCallResultSignFix
 import EvmAsm.Evm64.SMod.Compose.ModCallResultSignFixGeneric
 import EvmAsm.Evm64.SMod.Compose.ModCallResultSignFixNamedPost
+import EvmAsm.Evm64.SMod.Compose.SavedRaRet
 
 namespace EvmAsm.Evm64.SMod.Compose
 

--- a/EvmAsm/Evm64/SMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/SMod/Compose/Base.lean
@@ -34,6 +34,7 @@ import EvmAsm.Evm64.SMod.Compose.ModCallResultSignFixGeneric
 import EvmAsm.Evm64.SMod.Compose.ModCallResultSignFixNamedPost
 import EvmAsm.Evm64.SMod.Compose.SavedRaRet
 import EvmAsm.Evm64.SMod.Compose.SavedRaRetFrame
+import EvmAsm.Evm64.SMod.Compose.ModCallReturnGeneric
 
 namespace EvmAsm.Evm64.SMod.Compose
 

--- a/EvmAsm/Evm64/SMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/SMod/Compose/Base.lean
@@ -31,6 +31,7 @@ import EvmAsm.Evm64.SMod.Compose.ResultSignFixOwn
 import EvmAsm.Evm64.SMod.Compose.ModCallResultSignFixPost
 import EvmAsm.Evm64.SMod.Compose.ModCallResultSignFix
 import EvmAsm.Evm64.SMod.Compose.ModCallResultSignFixGeneric
+import EvmAsm.Evm64.SMod.Compose.ModCallResultSignFixNamedPost
 
 namespace EvmAsm.Evm64.SMod.Compose
 

--- a/EvmAsm/Evm64/SMod/Compose/ModCallResultSignFix.lean
+++ b/EvmAsm/Evm64/SMod/Compose/ModCallResultSignFix.lean
@@ -1,0 +1,81 @@
+/-
+  EvmAsm.Evm64.SMod.Compose.ModCallResultSignFix
+
+  Composition from the unsigned MOD callable return point through the SMOD-local
+  result-sign-fix block.
+-/
+
+import EvmAsm.Evm64.SMod.Compose.ModCallResultSignFixPost
+
+namespace EvmAsm.Evm64.SMod.Compose
+
+theorem saveRaAbsThenModCall_then_resultSignFix_of_callable_post_spec_in_smodCodeV4
+    {nSteps : Nat}
+    (vRa sp base : Word)
+    (dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word)
+    (v2 v5 v6 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (hCallable :
+      EvmAsm.Rv64.cpsTripleWithin nSteps
+        (base + wrapperEndOff) (base + resultSignFixOff) (smodCodeV4 base)
+        (saveRaAbsThenModCallDispatchReadyPost vRa sp base
+          dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+          divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+          v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+        (saveRaAbsThenModCallCallablePost vRa sp base
+          dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+          divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)) :
+    EvmAsm.Rv64.cpsTripleWithin (nSteps + 21)
+      (base + wrapperEndOff) ((base + resultSignFixOff) + 84) (smodCodeV4 base)
+      (saveRaAbsThenModCallDispatchReadyPost vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+        v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+      (let dividendAbsWord : EvmWord :=
+         smodAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+       let divisorAbsWord : EvmWord :=
+         smodAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+       let modWord := EvmWord.mod dividendAbsWord divisorAbsWord
+       let resultSign := smodAbsSign dividendTop
+       smodResultSignFixPost (sp + 32) resultSign
+         (modWord.getLimbN 0) (modWord.getLimbN 1)
+         (modWord.getLimbN 2) (modWord.getLimbN 3) **
+       smodModCallResultSignFixFrame vRa sp base dividendTop divisorTop
+         dividendAbsWord) := by
+  let dividendAbsWord : EvmWord :=
+    smodAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+  let divisorAbsWord : EvmWord :=
+    smodAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+  let modWord := EvmWord.mod dividendAbsWord divisorAbsWord
+  let resultSign := smodAbsSign dividendTop
+  let frame := smodModCallResultSignFixFrame vRa sp base dividendTop divisorTop
+    dividendAbsWord
+  have hFramePc : frame.pcFree := by
+    dsimp [frame]
+    exact smodModCallResultSignFixFrame_pcFree
+  have hFix :
+      EvmAsm.Rv64.cpsTripleWithin 21 (base + resultSignFixOff)
+        ((base + resultSignFixOff) + 84) (smodCodeV4 base)
+        (smodResultSignFixPreOwnScratch (sp + 32) resultSign
+          (modWord.getLimbN 0) (modWord.getLimbN 1)
+          (modWord.getLimbN 2) (modWord.getLimbN 3) ** frame)
+        (smodResultSignFixPost (sp + 32) resultSign
+          (modWord.getLimbN 0) (modWord.getLimbN 1)
+          (modWord.getLimbN 2) (modWord.getLimbN 3) ** frame) := by
+    exact EvmAsm.Rv64.cpsTripleWithin_frameR frame hFramePc
+      (resultSignFix_regOwn_scratch_spec_in_smodCodeV4
+        (sp + 32) resultSign
+        (modWord.getLimbN 0) (modWord.getLimbN 1)
+        (modWord.getLimbN 2) (modWord.getLimbN 3) base)
+  exact EvmAsm.Rv64.cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by
+      rw [saveRaAbsThenModCallCallablePost_smodResultSignFixPreOwnScratch] at hp
+      dsimp [dividendAbsWord, divisorAbsWord, modWord, resultSign, frame] at hp
+      exact hp)
+    hCallable hFix
+
+end EvmAsm.Evm64.SMod.Compose

--- a/EvmAsm/Evm64/SMod/Compose/ModCallResultSignFixGeneric.lean
+++ b/EvmAsm/Evm64/SMod/Compose/ModCallResultSignFixGeneric.lean
@@ -1,0 +1,74 @@
+/-
+  EvmAsm.Evm64.SMod.Compose.ModCallResultSignFixGeneric
+
+  Generic SMOD handoff from the normalized MOD-call dispatch-ready frame through
+  the unsigned MOD callable and the SMOD-local result-sign-fix block.
+-/
+
+import EvmAsm.Evm64.SMod.Compose.ModCallGenericHandoff
+import EvmAsm.Evm64.SMod.Compose.ModCallResultSignFix
+
+namespace EvmAsm.Evm64.SMod.Compose
+
+theorem saveRaAbsThenModCall_then_resultSignFix_from_noNop_spec_in_smodCodeV4
+    (vRa sp base : Word)
+    (dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word)
+    (v2 v5 v6 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (h_base : base &&& 1 = 0)
+    (h_stack :
+      EvmAsm.Rv64.cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
+        (base + wrapperEndOff) ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
+        (EvmAsm.Evm64.sharedDivModCodeNoNop_v4 (base + wrapperEndOff))
+        (EvmAsm.Evm64.divModStackDispatchPreCallable sp
+          (smodAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+          (smodAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          ((base + modCallOff) + 4)
+          v2 v5 v6
+          (smodAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          (smodAbsMask divisorTop)
+          (smodAbsCarry3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+        (EvmAsm.Evm64.modStackDispatchPostCallable sp
+          (smodAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+          (smodAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) **
+          (.x1 ↦ᵣ ((base + modCallOff) + 4)))) :
+    EvmAsm.Rv64.cpsTripleWithin ((EvmAsm.Evm64.unifiedDivBound + 1) + 21)
+      (base + wrapperEndOff) ((base + resultSignFixOff) + 84) (smodCodeV4 base)
+      (saveRaAbsThenModCallDispatchReadyPost vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+        v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+      (let dividendAbsWord : EvmWord :=
+         smodAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+       let divisorAbsWord : EvmWord :=
+         smodAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+       let modWord := EvmWord.mod dividendAbsWord divisorAbsWord
+       let resultSign := smodAbsSign dividendTop
+       smodResultSignFixPost (sp + 32) resultSign
+         (modWord.getLimbN 0) (modWord.getLimbN 1)
+         (modWord.getLimbN 2) (modWord.getLimbN 3) **
+       smodModCallResultSignFixFrame vRa sp base dividendTop divisorTop
+         dividendAbsWord) := by
+  have hCallable :=
+    saveRaAbsThenModCallDispatchReadyPost_callable_from_noNop_spec_in_smodCodeV4
+      vRa sp base
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+      v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0
+      h_base h_stack
+  exact
+    saveRaAbsThenModCall_then_resultSignFix_of_callable_post_spec_in_smodCodeV4
+      vRa sp base
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+      v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0
+      hCallable
+
+end EvmAsm.Evm64.SMod.Compose

--- a/EvmAsm/Evm64/SMod/Compose/ModCallResultSignFixNamedPost.lean
+++ b/EvmAsm/Evm64/SMod/Compose/ModCallResultSignFixNamedPost.lean
@@ -1,0 +1,129 @@
+/-
+  EvmAsm.Evm64.SMod.Compose.ModCallResultSignFixNamedPost
+
+  Named postcondition for the SMOD path after the unsigned MOD callable and
+  result-sign-fix block.
+-/
+
+import EvmAsm.Evm64.SMod.Compose.ModCallResultSignFixGeneric
+import EvmAsm.Evm64.SMod.Compose.ResultSignFixView
+
+namespace EvmAsm.Evm64.SMod.Compose
+
+@[irreducible]
+def saveRaAbsThenModCallResultSignFixPost
+    (vRa sp base : Word)
+    (dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word) :
+    EvmAsm.Rv64.Assertion :=
+  let dividendAbsWord : EvmWord :=
+    smodAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+  let divisorAbsWord : EvmWord :=
+    smodAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+  let modWord := EvmWord.mod dividendAbsWord divisorAbsWord
+  let resultSign := smodAbsSign dividendTop
+  let mask := (0 : Word) - resultSign
+  let sum0 := (modWord.getLimbN 0 ^^^ mask) + resultSign
+  let carry0 := if BitVec.ult sum0 resultSign then (1 : Word) else 0
+  let sum1 := (modWord.getLimbN 1 ^^^ mask) + carry0
+  let carry1 := if BitVec.ult sum1 carry0 then (1 : Word) else 0
+  let sum2 := (modWord.getLimbN 2 ^^^ mask) + carry1
+  let carry2 := if BitVec.ult sum2 carry1 then (1 : Word) else 0
+  let sum3 := (modWord.getLimbN 3 ^^^ mask) + carry2
+  let carry3 := if BitVec.ult sum3 carry2 then (1 : Word) else 0
+  ((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ (sp + 32)) **
+    (.x13 ↦ᵣ resultSign) ** (.x10 ↦ᵣ mask) **
+    (.x7 ↦ᵣ sum3) ** (.x11 ↦ᵣ carry3) **
+    evmWordIs (sp + 32)
+      (smodResultSignFixedWord dividendTop
+        (modWord.getLimbN 0) (modWord.getLimbN 1)
+        (modWord.getLimbN 2) (modWord.getLimbN 3))) **
+    smodModCallResultSignFixFrame vRa sp base dividendTop divisorTop
+      dividendAbsWord
+
+theorem saveRaAbsThenModCallResultSignFixPost_unfold
+    {vRa sp base : Word}
+    {dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word} :
+    saveRaAbsThenModCallResultSignFixPost vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop =
+      (let dividendAbsWord : EvmWord :=
+         smodAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+       let divisorAbsWord : EvmWord :=
+         smodAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+       let modWord := EvmWord.mod dividendAbsWord divisorAbsWord
+       let resultSign := smodAbsSign dividendTop
+       let mask := (0 : Word) - resultSign
+       let sum0 := (modWord.getLimbN 0 ^^^ mask) + resultSign
+       let carry0 := if BitVec.ult sum0 resultSign then (1 : Word) else 0
+       let sum1 := (modWord.getLimbN 1 ^^^ mask) + carry0
+       let carry1 := if BitVec.ult sum1 carry0 then (1 : Word) else 0
+       let sum2 := (modWord.getLimbN 2 ^^^ mask) + carry1
+       let carry2 := if BitVec.ult sum2 carry1 then (1 : Word) else 0
+       let sum3 := (modWord.getLimbN 3 ^^^ mask) + carry2
+       let carry3 := if BitVec.ult sum3 carry2 then (1 : Word) else 0
+       ((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ (sp + 32)) **
+         (.x13 ↦ᵣ resultSign) ** (.x10 ↦ᵣ mask) **
+         (.x7 ↦ᵣ sum3) ** (.x11 ↦ᵣ carry3) **
+         evmWordIs (sp + 32)
+           (smodResultSignFixedWord dividendTop
+             (modWord.getLimbN 0) (modWord.getLimbN 1)
+             (modWord.getLimbN 2) (modWord.getLimbN 3))) **
+         smodModCallResultSignFixFrame vRa sp base dividendTop divisorTop
+           dividendAbsWord) := by
+  delta saveRaAbsThenModCallResultSignFixPost
+  rfl
+
+theorem saveRaAbsThenModCall_then_resultSignFix_named_post_from_noNop_spec_in_smodCodeV4
+    (vRa sp base : Word)
+    (dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word)
+    (v2 v5 v6 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (h_base : base &&& 1 = 0)
+    (h_stack :
+      EvmAsm.Rv64.cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
+        (base + wrapperEndOff) ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
+        (EvmAsm.Evm64.sharedDivModCodeNoNop_v4 (base + wrapperEndOff))
+        (EvmAsm.Evm64.divModStackDispatchPreCallable sp
+          (smodAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+          (smodAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          ((base + modCallOff) + 4)
+          v2 v5 v6
+          (smodAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          (smodAbsMask divisorTop)
+          (smodAbsCarry3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+        (EvmAsm.Evm64.modStackDispatchPostCallable sp
+          (smodAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+          (smodAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) **
+          (.x1 ↦ᵣ ((base + modCallOff) + 4)))) :
+    EvmAsm.Rv64.cpsTripleWithin ((EvmAsm.Evm64.unifiedDivBound + 1) + 21)
+      (base + wrapperEndOff) ((base + resultSignFixOff) + 84) (smodCodeV4 base)
+      (saveRaAbsThenModCallDispatchReadyPost vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+        v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+      (saveRaAbsThenModCallResultSignFixPost vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) := by
+  exact EvmAsm.Rv64.cpsTripleWithin_weaken
+    (fun _ hp => hp)
+    (fun _ hq => by
+      rw [saveRaAbsThenModCallResultSignFixPost_unfold]
+      dsimp only
+      rw [← smodResultSignFixPost_smodResultSign_word]
+      exact hq)
+    (saveRaAbsThenModCall_then_resultSignFix_from_noNop_spec_in_smodCodeV4
+      vRa sp base
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+      v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0
+      h_base h_stack)
+
+end EvmAsm.Evm64.SMod.Compose

--- a/EvmAsm/Evm64/SMod/Compose/ModCallReturnGeneric.lean
+++ b/EvmAsm/Evm64/SMod/Compose/ModCallReturnGeneric.lean
@@ -1,0 +1,119 @@
+/-
+  EvmAsm.Evm64.SMod.Compose.ModCallReturnGeneric
+
+  Composition from the unsigned MOD callable and SMOD result-sign-fix block
+  through the final saved-`ra` return instruction.
+-/
+
+import EvmAsm.Evm64.SMod.Compose.SavedRaRetFrame
+import EvmAsm.Evm64.SMod.Compose.ModCallResultSignFixGeneric
+import EvmAsm.Evm64.SMod.Compose.SavedRaRet
+
+namespace EvmAsm.Evm64.SMod.Compose
+
+open EvmAsm.Rv64.Tactics
+
+theorem saveRaAbsThenModCall_then_return_from_noNop_spec_in_smodCodeV4
+    (vRa sp base : Word)
+    (dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word)
+    (v2 v5 v6 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (h_base : base &&& 1 = 0)
+    (h_stack :
+      EvmAsm.Rv64.cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
+        (base + wrapperEndOff) ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
+        (EvmAsm.Evm64.sharedDivModCodeNoNop_v4 (base + wrapperEndOff))
+        (EvmAsm.Evm64.divModStackDispatchPreCallable sp
+          (smodAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+          (smodAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          ((base + modCallOff) + 4)
+          v2 v5 v6
+          (smodAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          (smodAbsMask divisorTop)
+          (smodAbsCarry3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+        (EvmAsm.Evm64.modStackDispatchPostCallable sp
+          (smodAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+          (smodAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) **
+          (.x1 ↦ᵣ ((base + modCallOff) + 4)))) :
+    EvmAsm.Rv64.cpsTripleWithin (((EvmAsm.Evm64.unifiedDivBound + 1) + 21) + 1)
+      (base + wrapperEndOff)
+      (((vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)) +
+        EvmAsm.Rv64.signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word))
+      (smodCodeV4 base)
+      (saveRaAbsThenModCallDispatchReadyPost vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+        v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+      (let dividendAbsWord : EvmWord :=
+         smodAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+       let divisorAbsWord : EvmWord :=
+         smodAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+       let modWord := EvmWord.mod dividendAbsWord divisorAbsWord
+       let resultSign := smodAbsSign dividendTop
+       (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12))) **
+       (smodResultSignFixPost (sp + 32) resultSign
+         (modWord.getLimbN 0) (modWord.getLimbN 1)
+         (modWord.getLimbN 2) (modWord.getLimbN 3) **
+        smodSavedRaRetFrame sp base dividendTop divisorTop dividendAbsWord)) := by
+  let dividendAbsWord : EvmWord :=
+    smodAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+  let divisorAbsWord : EvmWord :=
+    smodAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+  let modWord := EvmWord.mod dividendAbsWord divisorAbsWord
+  let resultSign := smodAbsSign dividendTop
+  have hPrefix :=
+    saveRaAbsThenModCall_then_resultSignFix_from_noNop_spec_in_smodCodeV4
+      vRa sp base
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+      v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0
+      h_base h_stack
+  have hRetFramePc :
+      (smodResultSignFixPost (sp + 32) resultSign
+        (modWord.getLimbN 0) (modWord.getLimbN 1)
+        (modWord.getLimbN 2) (modWord.getLimbN 3) **
+       smodSavedRaRetFrame sp base dividendTop divisorTop dividendAbsWord).pcFree := by
+    pcFree
+  have hRetFramed :=
+    EvmAsm.Rv64.cpsTripleWithin_frameR
+      (smodResultSignFixPost (sp + 32) resultSign
+        (modWord.getLimbN 0) (modWord.getLimbN 1)
+        (modWord.getLimbN 2) (modWord.getLimbN 3) **
+       smodSavedRaRetFrame sp base dividendTop divisorTop dividendAbsWord)
+      hRetFramePc
+      (savedRaRet_spec_in_smodCodeV4
+        (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)) base)
+  have hFall :
+      (base + resultSignFixOff) + 84 = base + savedRaRetOff := by
+    simp [resultSignFixOff, savedRaRetOff]
+    bv_addr
+  have hRetFramed' :
+      EvmAsm.Rv64.cpsTripleWithin 1 ((base + resultSignFixOff) + 84)
+        (((vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)) +
+          EvmAsm.Rv64.signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word))
+        (smodCodeV4 base)
+        ((.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12))) **
+         (smodResultSignFixPost (sp + 32) resultSign
+          (modWord.getLimbN 0) (modWord.getLimbN 1)
+          (modWord.getLimbN 2) (modWord.getLimbN 3) **
+          smodSavedRaRetFrame sp base dividendTop divisorTop dividendAbsWord))
+        ((.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12))) **
+         (smodResultSignFixPost (sp + 32) resultSign
+          (modWord.getLimbN 0) (modWord.getLimbN 1)
+          (modWord.getLimbN 2) (modWord.getLimbN 3) **
+          smodSavedRaRetFrame sp base dividendTop divisorTop dividendAbsWord)) := by
+    rw [hFall]
+    exact hRetFramed
+  exact EvmAsm.Rv64.cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by
+      rw [smodModCallResultSignFixFrame_to_savedRaRet] at hp
+      xperm_hyp hp)
+    hPrefix hRetFramed'
+
+end EvmAsm.Evm64.SMod.Compose

--- a/EvmAsm/Evm64/SMod/Compose/ModCallReturnNamedPost.lean
+++ b/EvmAsm/Evm64/SMod/Compose/ModCallReturnNamedPost.lean
@@ -1,0 +1,132 @@
+/-
+  EvmAsm.Evm64.SMod.Compose.ModCallReturnNamedPost
+
+  Named postcondition for the SMOD path after the unsigned MOD callable,
+  result-sign-fix block, and final saved-`ra` return instruction.
+-/
+
+import EvmAsm.Evm64.SMod.Compose.ModCallReturnGeneric
+import EvmAsm.Evm64.SMod.Compose.ResultSignFixView
+
+namespace EvmAsm.Evm64.SMod.Compose
+
+@[irreducible]
+def saveRaAbsThenModCallReturnPost
+    (vRa sp base : Word)
+    (dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word) :
+    EvmAsm.Rv64.Assertion :=
+  let dividendAbsWord : EvmWord :=
+    smodAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+  let divisorAbsWord : EvmWord :=
+    smodAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+  let modWord := EvmWord.mod dividendAbsWord divisorAbsWord
+  let resultSign := smodAbsSign dividendTop
+  let mask := (0 : Word) - resultSign
+  let sum0 := (modWord.getLimbN 0 ^^^ mask) + resultSign
+  let carry0 := if BitVec.ult sum0 resultSign then (1 : Word) else 0
+  let sum1 := (modWord.getLimbN 1 ^^^ mask) + carry0
+  let carry1 := if BitVec.ult sum1 carry0 then (1 : Word) else 0
+  let sum2 := (modWord.getLimbN 2 ^^^ mask) + carry1
+  let carry2 := if BitVec.ult sum2 carry1 then (1 : Word) else 0
+  let sum3 := (modWord.getLimbN 3 ^^^ mask) + carry2
+  let carry3 := if BitVec.ult sum3 carry2 then (1 : Word) else 0
+  (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12))) **
+    (((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ (sp + 32)) **
+      (.x13 ↦ᵣ resultSign) ** (.x10 ↦ᵣ mask) **
+      (.x7 ↦ᵣ sum3) ** (.x11 ↦ᵣ carry3) **
+      evmWordIs (sp + 32)
+        (smodResultSignFixedWord dividendTop
+          (modWord.getLimbN 0) (modWord.getLimbN 1)
+          (modWord.getLimbN 2) (modWord.getLimbN 3))) **
+      smodSavedRaRetFrame sp base dividendTop divisorTop dividendAbsWord)
+
+theorem saveRaAbsThenModCallReturnPost_unfold
+    {vRa sp base : Word}
+    {dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word} :
+    saveRaAbsThenModCallReturnPost vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop =
+      (let dividendAbsWord : EvmWord :=
+         smodAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+       let divisorAbsWord : EvmWord :=
+         smodAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+       let modWord := EvmWord.mod dividendAbsWord divisorAbsWord
+       let resultSign := smodAbsSign dividendTop
+       let mask := (0 : Word) - resultSign
+       let sum0 := (modWord.getLimbN 0 ^^^ mask) + resultSign
+       let carry0 := if BitVec.ult sum0 resultSign then (1 : Word) else 0
+       let sum1 := (modWord.getLimbN 1 ^^^ mask) + carry0
+       let carry1 := if BitVec.ult sum1 carry0 then (1 : Word) else 0
+       let sum2 := (modWord.getLimbN 2 ^^^ mask) + carry1
+       let carry2 := if BitVec.ult sum2 carry1 then (1 : Word) else 0
+       let sum3 := (modWord.getLimbN 3 ^^^ mask) + carry2
+       let carry3 := if BitVec.ult sum3 carry2 then (1 : Word) else 0
+       (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12))) **
+         (((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ (sp + 32)) **
+           (.x13 ↦ᵣ resultSign) ** (.x10 ↦ᵣ mask) **
+           (.x7 ↦ᵣ sum3) ** (.x11 ↦ᵣ carry3) **
+           evmWordIs (sp + 32)
+             (smodResultSignFixedWord dividendTop
+               (modWord.getLimbN 0) (modWord.getLimbN 1)
+               (modWord.getLimbN 2) (modWord.getLimbN 3))) **
+           smodSavedRaRetFrame sp base dividendTop divisorTop dividendAbsWord)) := by
+  delta saveRaAbsThenModCallReturnPost
+  rfl
+
+theorem saveRaAbsThenModCall_then_return_named_post_from_noNop_spec_in_smodCodeV4
+    (vRa sp base : Word)
+    (dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word)
+    (v2 v5 v6 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (h_base : base &&& 1 = 0)
+    (h_stack :
+      EvmAsm.Rv64.cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
+        (base + wrapperEndOff) ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
+        (EvmAsm.Evm64.sharedDivModCodeNoNop_v4 (base + wrapperEndOff))
+        (EvmAsm.Evm64.divModStackDispatchPreCallable sp
+          (smodAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+          (smodAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          ((base + modCallOff) + 4)
+          v2 v5 v6
+          (smodAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          (smodAbsMask divisorTop)
+          (smodAbsCarry3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+        (EvmAsm.Evm64.modStackDispatchPostCallable sp
+          (smodAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+          (smodAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) **
+          (.x1 ↦ᵣ ((base + modCallOff) + 4)))) :
+    EvmAsm.Rv64.cpsTripleWithin (((EvmAsm.Evm64.unifiedDivBound + 1) + 21) + 1)
+      (base + wrapperEndOff)
+      (((vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)) +
+        EvmAsm.Rv64.signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word))
+      (smodCodeV4 base)
+      (saveRaAbsThenModCallDispatchReadyPost vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+        v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+      (saveRaAbsThenModCallReturnPost vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) := by
+  exact EvmAsm.Rv64.cpsTripleWithin_weaken
+    (fun _ hp => hp)
+    (fun _ hq => by
+      rw [saveRaAbsThenModCallReturnPost_unfold]
+      dsimp only
+      rw [← smodResultSignFixPost_smodResultSign_word]
+      exact hq)
+    (saveRaAbsThenModCall_then_return_from_noNop_spec_in_smodCodeV4
+      vRa sp base
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+      v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0
+      h_base h_stack)
+
+end EvmAsm.Evm64.SMod.Compose

--- a/EvmAsm/Evm64/SMod/Compose/SavedRaRet.lean
+++ b/EvmAsm/Evm64/SMod/Compose/SavedRaRet.lean
@@ -1,0 +1,31 @@
+/-
+  EvmAsm.Evm64.SMod.Compose.SavedRaRet
+
+  Low-level SMOD wrapper spec for the final saved-`ra` return instruction.
+-/
+
+import EvmAsm.Evm64.SMod.Compose.BaseCode
+
+namespace EvmAsm.Evm64.SMod.Compose
+
+theorem savedRaRet_spec_in_smodCodeV4
+    (vSavedRa : Word) (base : Word) :
+    EvmAsm.Rv64.cpsTripleWithin 1 (base + savedRaRetOff)
+        ((vSavedRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)) &&& ~~~1)
+      (smodCodeV4 base)
+      (.x18 ↦ᵣ vSavedRa)
+      (.x18 ↦ᵣ vSavedRa) := by
+  have hmono :
+      ∀ a i,
+        (EvmAsm.Evm64.evm_smod_saved_ra_ret_block_code .x18
+          (base + savedRaRetOff)) a = some i →
+        (smodCodeV4 base) a = some i := by
+    intro a i h
+    exact smodCodeV4_savedRaRet_sub (base := base) a i
+      (by simpa [savedRaRetCode,
+        EvmAsm.Evm64.evm_smod_saved_ra_ret_block_code] using h)
+  exact EvmAsm.Rv64.cpsTripleWithin_extend_code hmono
+    (EvmAsm.Evm64.evm_smod_saved_ra_ret_block_spec_within .x18
+      vSavedRa (base + savedRaRetOff))
+
+end EvmAsm.Evm64.SMod.Compose

--- a/EvmAsm/Evm64/SMod/Compose/SavedRaRetFrame.lean
+++ b/EvmAsm/Evm64/SMod/Compose/SavedRaRetFrame.lean
@@ -1,0 +1,66 @@
+/-
+  EvmAsm.Evm64.SMod.Compose.SavedRaRetFrame
+
+  Frame split for exposing the saved return address before the final SMOD
+  return instruction.
+-/
+
+import EvmAsm.Evm64.SMod.Compose.ModCallResultSignFixPost
+import EvmAsm.Rv64.Tactics.XSimp
+
+namespace EvmAsm.Evm64.SMod.Compose
+
+open EvmAsm.Rv64.Tactics
+
+/-- Frame remaining after exposing `x18` for the saved-RA return. -/
+@[irreducible]
+def smodSavedRaRetFrame
+    (sp base dividendTop divisorTop : Word) (dividendAbsWord : EvmWord) :
+    EvmAsm.Rv64.Assertion :=
+  let dividendSign := smodAbsSign dividendTop
+  let divisorSign := smodAbsSign divisorTop
+  (.x1 ↦ᵣ ((base + modCallOff) + 4)) **
+    (.x9 ↦ᵣ divisorSign) ** (.x8 ↦ᵣ dividendSign) **
+    EvmAsm.Rv64.regOwn .x2 ** EvmAsm.Rv64.regOwn .x5 **
+    EvmAsm.Rv64.regOwn .x6 ** evmWordIs sp dividendAbsWord **
+    EvmAsm.Evm64.divScratchOwnCallNoX1 sp
+
+theorem smodSavedRaRetFrame_unfold
+    {sp base dividendTop divisorTop : Word} {dividendAbsWord : EvmWord} :
+    smodSavedRaRetFrame sp base dividendTop divisorTop dividendAbsWord =
+      (let dividendSign := smodAbsSign dividendTop
+       let divisorSign := smodAbsSign divisorTop
+       (.x1 ↦ᵣ ((base + modCallOff) + 4)) **
+         (.x9 ↦ᵣ divisorSign) ** (.x8 ↦ᵣ dividendSign) **
+         EvmAsm.Rv64.regOwn .x2 ** EvmAsm.Rv64.regOwn .x5 **
+         EvmAsm.Rv64.regOwn .x6 ** evmWordIs sp dividendAbsWord **
+         EvmAsm.Evm64.divScratchOwnCallNoX1 sp) := by
+  delta smodSavedRaRetFrame
+  rfl
+
+theorem smodSavedRaRetFrame_pcFree
+    {sp base dividendTop divisorTop : Word} {dividendAbsWord : EvmWord} :
+    (smodSavedRaRetFrame sp base dividendTop divisorTop dividendAbsWord).pcFree := by
+  rw [smodSavedRaRetFrame_unfold,
+    EvmAsm.Evm64.divScratchOwnCallNoX1_unfold,
+    EvmAsm.Evm64.divScratchOwn_unfold]
+  dsimp only
+  pcFree
+
+instance pcFreeInst_smodSavedRaRetFrame
+    (sp base dividendTop divisorTop : Word) (dividendAbsWord : EvmWord) :
+    EvmAsm.Rv64.Assertion.PCFree
+      (smodSavedRaRetFrame sp base dividendTop divisorTop dividendAbsWord) :=
+  ⟨smodSavedRaRetFrame_pcFree⟩
+
+/-- Expose the saved return address atom from the SMOD result-sign-fix frame,
+    leaving the rest as an explicit return frame. -/
+theorem smodModCallResultSignFixFrame_to_savedRaRet
+    {vRa sp base dividendTop divisorTop : Word} {dividendAbsWord : EvmWord} :
+    smodModCallResultSignFixFrame vRa sp base dividendTop divisorTop dividendAbsWord =
+      ((.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12))) **
+       smodSavedRaRetFrame sp base dividendTop divisorTop dividendAbsWord) := by
+  rw [smodModCallResultSignFixFrame_unfold, smodSavedRaRetFrame_unfold]
+  xperm
+
+end EvmAsm.Evm64.SMod.Compose


### PR DESCRIPTION
## Summary
- add the SMOD composition theorem that sequences an unsigned MOD callable post through result-sign-fix
- frame the callable residue across result-sign-fix using the SMOD-local x13 result sign-fix pre/post surface
- import the composition module through the SMOD compose umbrella

## Verification
- lake build EvmAsm.Evm64.SMod.Compose.ModCallResultSignFix
- lake build EvmAsm.Evm64.SMod
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- rg -n "DivStackSpecCase|ModStackSpecCase|SDivStackSpecCase|SModStackSpecCase|StackSpecCase|set_option maxRecDepth|set_option maxHeartbeats|sorry|admit" EvmAsm/Evm64/SMod/Compose/ModCallResultSignFix.lean EvmAsm/Evm64/SMod/Compose/Base.lean

Bead: evm-asm-9iqmw.9