### PR TITLE
feat(smod): compose generic mod call result fix

### DIFF
--- a/EvmAsm/Evm64/SMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/SMod/Compose/Base.lean
@@ -30,6 +30,7 @@ import EvmAsm.Evm64.SMod.Compose.ResultSignFixPCFree
 import EvmAsm.Evm64.SMod.Compose.ResultSignFixOwn
 import EvmAsm.Evm64.SMod.Compose.ModCallResultSignFixPost
 import EvmAsm.Evm64.SMod.Compose.ModCallResultSignFix
+import EvmAsm.Evm64.SMod.Compose.ModCallResultSignFixGeneric
 
 namespace EvmAsm.Evm64.SMod.Compose
 

--- a/EvmAsm/Evm64/SMod/Compose/ModCallResultSignFixGeneric.lean
+++ b/EvmAsm/Evm64/SMod/Compose/ModCallResultSignFixGeneric.lean
@@ -1,0 +1,74 @@
+/-
+  EvmAsm.Evm64.SMod.Compose.ModCallResultSignFixGeneric
+
+  Generic SMOD handoff from the normalized MOD-call dispatch-ready frame through
+  the unsigned MOD callable and the SMOD-local result-sign-fix block.
+-/
+
+import EvmAsm.Evm64.SMod.Compose.ModCallGenericHandoff
+import EvmAsm.Evm64.SMod.Compose.ModCallResultSignFix
+
+namespace EvmAsm.Evm64.SMod.Compose
+
+theorem saveRaAbsThenModCall_then_resultSignFix_from_noNop_spec_in_smodCodeV4
+    (vRa sp base : Word)
+    (dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word)
+    (v2 v5 v6 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (h_base : base &&& 1 = 0)
+    (h_stack :
+      EvmAsm.Rv64.cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
+        (base + wrapperEndOff) ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
+        (EvmAsm.Evm64.sharedDivModCodeNoNop_v4 (base + wrapperEndOff))
+        (EvmAsm.Evm64.divModStackDispatchPreCallable sp
+          (smodAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+          (smodAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          ((base + modCallOff) + 4)
+          v2 v5 v6
+          (smodAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          (smodAbsMask divisorTop)
+          (smodAbsCarry3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+        (EvmAsm.Evm64.modStackDispatchPostCallable sp
+          (smodAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+          (smodAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) **
+          (.x1 ↦ᵣ ((base + modCallOff) + 4)))) :
+    EvmAsm.Rv64.cpsTripleWithin ((EvmAsm.Evm64.unifiedDivBound + 1) + 21)
+      (base + wrapperEndOff) ((base + resultSignFixOff) + 84) (smodCodeV4 base)
+      (saveRaAbsThenModCallDispatchReadyPost vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+        v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+      (let dividendAbsWord : EvmWord :=
+         smodAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+       let divisorAbsWord : EvmWord :=
+         smodAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+       let modWord := EvmWord.mod dividendAbsWord divisorAbsWord
+       let resultSign := smodAbsSign dividendTop
+       smodResultSignFixPost (sp + 32) resultSign
+         (modWord.getLimbN 0) (modWord.getLimbN 1)
+         (modWord.getLimbN 2) (modWord.getLimbN 3) **
+       smodModCallResultSignFixFrame vRa sp base dividendTop divisorTop
+         dividendAbsWord) := by
+  have hCallable :=
+    saveRaAbsThenModCallDispatchReadyPost_callable_from_noNop_spec_in_smodCodeV4
+      vRa sp base
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+      v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0
+      h_base h_stack
+  exact
+    saveRaAbsThenModCall_then_resultSignFix_of_callable_post_spec_in_smodCodeV4
+      vRa sp base
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+      v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0
+      hCallable
+
+end EvmAsm.Evm64.SMod.Compose


### PR DESCRIPTION
## Summary
- add the generic SMOD theorem that instantiates the unsigned MOD callable handoff and sequences through result-sign-fix
- keep the proof on the v4 no-NOP callable surface and SMOD-local x13 result-sign-fix postcondition
- import the wrapper module through the SMOD compose umbrella

## Verification
- lake build EvmAsm.Evm64.SMod.Compose.ModCallResultSignFixGeneric
- lake build EvmAsm.Evm64.SMod
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- rg -n "DivStackSpecCase|ModStackSpecCase|SDivStackSpecCase|SModStackSpecCase|StackSpecCase|set_option maxRecDepth|set_option maxHeartbeats|sorry|admit" EvmAsm/Evm64/SMod/Compose/ModCallResultSignFixGeneric.lean EvmAsm/Evm64/SMod/Compose/Base.lean

Bead: evm-asm-9iqmw.9