### PR TITLE
feat(smod): add result fix named post

### DIFF
--- a/EvmAsm/Evm64/SMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/SMod/Compose/Base.lean
@@ -31,6 +31,7 @@ import EvmAsm.Evm64.SMod.Compose.ResultSignFixOwn
 import EvmAsm.Evm64.SMod.Compose.ModCallResultSignFixPost
 import EvmAsm.Evm64.SMod.Compose.ModCallResultSignFix
 import EvmAsm.Evm64.SMod.Compose.ModCallResultSignFixGeneric
+import EvmAsm.Evm64.SMod.Compose.ModCallResultSignFixNamedPost
 
 namespace EvmAsm.Evm64.SMod.Compose
 

--- a/EvmAsm/Evm64/SMod/Compose/ModCallResultSignFixNamedPost.lean
+++ b/EvmAsm/Evm64/SMod/Compose/ModCallResultSignFixNamedPost.lean
@@ -1,0 +1,129 @@
+/-
+  EvmAsm.Evm64.SMod.Compose.ModCallResultSignFixNamedPost
+
+  Named postcondition for the SMOD path after the unsigned MOD callable and
+  result-sign-fix block.
+-/
+
+import EvmAsm.Evm64.SMod.Compose.ModCallResultSignFixGeneric
+import EvmAsm.Evm64.SMod.Compose.ResultSignFixView
+
+namespace EvmAsm.Evm64.SMod.Compose
+
+@[irreducible]
+def saveRaAbsThenModCallResultSignFixPost
+    (vRa sp base : Word)
+    (dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word) :
+    EvmAsm.Rv64.Assertion :=
+  let dividendAbsWord : EvmWord :=
+    smodAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+  let divisorAbsWord : EvmWord :=
+    smodAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+  let modWord := EvmWord.mod dividendAbsWord divisorAbsWord
+  let resultSign := smodAbsSign dividendTop
+  let mask := (0 : Word) - resultSign
+  let sum0 := (modWord.getLimbN 0 ^^^ mask) + resultSign
+  let carry0 := if BitVec.ult sum0 resultSign then (1 : Word) else 0
+  let sum1 := (modWord.getLimbN 1 ^^^ mask) + carry0
+  let carry1 := if BitVec.ult sum1 carry0 then (1 : Word) else 0
+  let sum2 := (modWord.getLimbN 2 ^^^ mask) + carry1
+  let carry2 := if BitVec.ult sum2 carry1 then (1 : Word) else 0
+  let sum3 := (modWord.getLimbN 3 ^^^ mask) + carry2
+  let carry3 := if BitVec.ult sum3 carry2 then (1 : Word) else 0
+  ((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ (sp + 32)) **
+    (.x13 ↦ᵣ resultSign) ** (.x10 ↦ᵣ mask) **
+    (.x7 ↦ᵣ sum3) ** (.x11 ↦ᵣ carry3) **
+    evmWordIs (sp + 32)
+      (smodResultSignFixedWord dividendTop
+        (modWord.getLimbN 0) (modWord.getLimbN 1)
+        (modWord.getLimbN 2) (modWord.getLimbN 3))) **
+    smodModCallResultSignFixFrame vRa sp base dividendTop divisorTop
+      dividendAbsWord
+
+theorem saveRaAbsThenModCallResultSignFixPost_unfold
+    {vRa sp base : Word}
+    {dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word} :
+    saveRaAbsThenModCallResultSignFixPost vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop =
+      (let dividendAbsWord : EvmWord :=
+         smodAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+       let divisorAbsWord : EvmWord :=
+         smodAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+       let modWord := EvmWord.mod dividendAbsWord divisorAbsWord
+       let resultSign := smodAbsSign dividendTop
+       let mask := (0 : Word) - resultSign
+       let sum0 := (modWord.getLimbN 0 ^^^ mask) + resultSign
+       let carry0 := if BitVec.ult sum0 resultSign then (1 : Word) else 0
+       let sum1 := (modWord.getLimbN 1 ^^^ mask) + carry0
+       let carry1 := if BitVec.ult sum1 carry0 then (1 : Word) else 0
+       let sum2 := (modWord.getLimbN 2 ^^^ mask) + carry1
+       let carry2 := if BitVec.ult sum2 carry1 then (1 : Word) else 0
+       let sum3 := (modWord.getLimbN 3 ^^^ mask) + carry2
+       let carry3 := if BitVec.ult sum3 carry2 then (1 : Word) else 0
+       ((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ (sp + 32)) **
+         (.x13 ↦ᵣ resultSign) ** (.x10 ↦ᵣ mask) **
+         (.x7 ↦ᵣ sum3) ** (.x11 ↦ᵣ carry3) **
+         evmWordIs (sp + 32)
+           (smodResultSignFixedWord dividendTop
+             (modWord.getLimbN 0) (modWord.getLimbN 1)
+             (modWord.getLimbN 2) (modWord.getLimbN 3))) **
+         smodModCallResultSignFixFrame vRa sp base dividendTop divisorTop
+           dividendAbsWord) := by
+  delta saveRaAbsThenModCallResultSignFixPost
+  rfl
+
+theorem saveRaAbsThenModCall_then_resultSignFix_named_post_from_noNop_spec_in_smodCodeV4
+    (vRa sp base : Word)
+    (dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word)
+    (v2 v5 v6 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (h_base : base &&& 1 = 0)
+    (h_stack :
+      EvmAsm.Rv64.cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
+        (base + wrapperEndOff) ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
+        (EvmAsm.Evm64.sharedDivModCodeNoNop_v4 (base + wrapperEndOff))
+        (EvmAsm.Evm64.divModStackDispatchPreCallable sp
+          (smodAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+          (smodAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          ((base + modCallOff) + 4)
+          v2 v5 v6
+          (smodAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          (smodAbsMask divisorTop)
+          (smodAbsCarry3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+        (EvmAsm.Evm64.modStackDispatchPostCallable sp
+          (smodAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
+          (smodAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) **
+          (.x1 ↦ᵣ ((base + modCallOff) + 4)))) :
+    EvmAsm.Rv64.cpsTripleWithin ((EvmAsm.Evm64.unifiedDivBound + 1) + 21)
+      (base + wrapperEndOff) ((base + resultSignFixOff) + 84) (smodCodeV4 base)
+      (saveRaAbsThenModCallDispatchReadyPost vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+        v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+      (saveRaAbsThenModCallResultSignFixPost vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) := by
+  exact EvmAsm.Rv64.cpsTripleWithin_weaken
+    (fun _ hp => hp)
+    (fun _ hq => by
+      rw [saveRaAbsThenModCallResultSignFixPost_unfold]
+      dsimp only
+      rw [← smodResultSignFixPost_smodResultSign_word]
+      exact hq)
+    (saveRaAbsThenModCall_then_resultSignFix_from_noNop_spec_in_smodCodeV4
+      vRa sp base
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+      v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0
+      h_base h_stack)
+
+end EvmAsm.Evm64.SMod.Compose


### PR DESCRIPTION
## Summary
- add a named postcondition for the SMOD path after unsigned MOD and result-sign-fix
- fold the result limbs into evmWordIs at sp+32 using the SMOD-local x13 result-sign-fix view
- add a wrapper theorem from the v4 no-NOP callable handoff to the named postcondition

## Verification
- lake build EvmAsm.Evm64.SMod.Compose.ModCallResultSignFixNamedPost
- lake build EvmAsm.Evm64.SMod
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- rg -n "DivStackSpecCase|ModStackSpecCase|SDivStackSpecCase|SModStackSpecCase|StackSpecCase|set_option maxRecDepth|set_option maxHeartbeats|sorry|admit" EvmAsm/Evm64/SMod/Compose/ModCallResultSignFixNamedPost.lean EvmAsm/Evm64/SMod/Compose/Base.lean

Bead: evm-asm-9iqmw.9