### PR TITLE
feat(stateless): u256_to_u64_be (PR-K57)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -6154,6 +6154,82 @@ def ziskU256MulU64BeProbeUnit : BuildUnit := {
   dataAsm     := ziskU256MulU64BeDataSection
 }
 
+/-! ## u256_to_u64_be -- PR-K57 truncate BE u256 → u64 with overflow flag
+
+    Truncate a 32-byte big-endian `u256` buffer down to its
+    low 64 bits, storing them at `*out`. Returns a 0/1 overflow
+    flag: `1` if any of the high 192 bits are nonzero, `0`
+    otherwise.
+
+    Natural inverse of PR-K56 `u256_from_u64_be`. Together they
+    let callers move values between the u256 BE byte-buffer
+    representation and the u64 register-resident form.
+
+    Direct use cases:
+      - `gas_left = u256_to_u64_be(account.balance / gas_price)`
+      - Tx validation: check `intrinsic_gas <= tx.gas_limit`
+        after computing intrinsic gas as a u64
+      - Compact a small u256 result for further u64-domain work
+
+    BE storage convention: byte 0 = MSB, byte 31 = LSB.
+
+    Calling convention:
+      a0 (input)  : u256 src ptr (32 bytes, BE)
+      a1 (input)  : u64 out ptr
+      ra (input)  : return
+      a0 (output) : 1 on overflow (high 192 bits nonzero), 0 otherwise.
+
+    Pure register arithmetic, no scratch memory, leaf-callable.
+    Always writes the low-64-bit value to `*out`, even on
+    overflow (so callers don't need to branch on the flag to
+    read a defined value). -/
+def u256ToU64BeFunction : String :=
+  "u256_to_u64_be:\n" ++
+  "  # Check high 24 bytes (positions 0..24) are all zero.\n" ++
+  "  ld t0,  0(a0)\n" ++
+  "  ld t1,  8(a0)\n" ++
+  "  ld t2, 16(a0)\n" ++
+  "  or t0, t0, t1\n" ++
+  "  or t0, t0, t2\n" ++
+  "  # Assemble low u64 from BE bytes at positions 24..32.\n" ++
+  "  lbu t1, 24(a0); slli t1, t1, 56\n" ++
+  "  lbu t2, 25(a0); slli t2, t2, 48; or t1, t1, t2\n" ++
+  "  lbu t2, 26(a0); slli t2, t2, 40; or t1, t1, t2\n" ++
+  "  lbu t2, 27(a0); slli t2, t2, 32; or t1, t1, t2\n" ++
+  "  lbu t2, 28(a0); slli t2, t2, 24; or t1, t1, t2\n" ++
+  "  lbu t2, 29(a0); slli t2, t2, 16; or t1, t1, t2\n" ++
+  "  lbu t2, 30(a0); slli t2, t2,  8; or t1, t1, t2\n" ++
+  "  lbu t2, 31(a0);                  or t1, t1, t2\n" ++
+  "  sd t1, 0(a1)\n" ++
+  "  snez a0, t0                      # overflow = (high bits != 0)\n" ++
+  "  ret"
+
+/-- `zisk_u256_to_u64_be`: probe BuildUnit. Reads 32B BE u256
+    from host input, writes (overflow_flag, u64 result LE) to
+    OUTPUT (16 bytes total). -/
+def ziskU256ToU64BePrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a2, 0x40000000\n" ++
+  "  addi a0, a2, 8              # src ptr\n" ++
+  "  li a1, 0xa0010008           # u64 out\n" ++
+  "  jal ra, u256_to_u64_be\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)                # overflow flag\n" ++
+  "  j .Lu256t_pdone\n" ++
+  u256ToU64BeFunction ++ "\n" ++
+  ".Lu256t_pdone:"
+
+def ziskU256ToU64BeDataSection : String :=
+  ".section .data\n" ++
+  "u256t_pad:\n" ++
+  "  .zero 8"
+
+def ziskU256ToU64BeProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskU256ToU64BePrologue
+  dataAsm     := ziskU256ToU64BeDataSection
+}
+
 
 /-! ## tx_type_dispatch -- PR-K40 typed-tx prefix detector
 
@@ -8519,6 +8595,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_u256_sub_be"          => some ziskU256SubBeProbeUnit
   | "zisk_u256_eq"              => some ziskU256EqProbeUnit
   | "zisk_u256_mul_u64_be"      => some ziskU256MulU64BeProbeUnit
+  | "zisk_u256_to_u64_be"       => some ziskU256ToU64BeProbeUnit
   | "zisk_tx_type_dispatch"     => some ziskTxTypeDispatchProbeUnit
   | "zisk_tx_eip2930_decode"    => some ziskTxEip2930DecodeProbeUnit
   | "zisk_tx_eip7702_decode"    => some ziskTxEip7702DecodeProbeUnit
@@ -8588,6 +8665,7 @@ def knownProgramNames : List String :=
    "zisk_u256_sub_be",
    "zisk_u256_eq",
    "zisk_u256_mul_u64_be",
+   "zisk_u256_to_u64_be",
    "zisk_tx_type_dispatch",
    "zisk_tx_eip2930_decode",
    "zisk_tx_eip7702_decode",

--- a/scripts/codegen-zisk-u256-to-u64-be-check.sh
+++ b/scripts/codegen-zisk-u256-to-u64-be-check.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# codegen-zisk-u256-to-u64-be-check.sh -- PR-K57.
+#
+# Truncate a 32-byte BE u256 buffer to u64 with overflow flag.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_u256_to_u64_be ELF"
+lake exe codegen --program zisk_u256_to_u64_be --halt linux93 \
+  -o gen-out/zisk_u256_to_u64_be
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <value_dec>
+run_case() {
+  local name="$1" value="$2"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_u256_to_u64_be_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_u256_to_u64_be_${name}.output"
+  local exp_file="$REPO_ROOT/gen-out/zisk_u256_to_u64_be_${name}.expected"
+
+  python3 -c "
+import struct, sys
+v = $value
+sys.stdout.buffer.write(v.to_bytes(32, 'big'))  # u256 BE
+" > "$in_file"
+
+  python3 -c "
+import struct, sys
+v = $value
+MOD = 1 << 64
+overflow = 1 if v >= MOD else 0
+low64 = v & (MOD - 1)
+sys.stdout.buffer.write(struct.pack('<Q', overflow))
+sys.stdout.buffer.write(struct.pack('<Q', low64))
+" > "$exp_file"
+
+  "$ZISKEMU" -e gen-out/zisk_u256_to_u64_be.elf \
+    -i "$in_file" -o "$out_file" -n 500000 \
+    >"$REPO_ROOT/gen-out/zisk_u256_to_u64_be_${name}.emu.log" 2>&1 || true
+
+  local actual; actual="$(xxd -p -l 16 "$out_file" | tr -d '\n')"
+  local expected; expected="$(xxd -p -l 16 "$exp_file" | tr -d '\n')"
+
+  if [[ "$actual" == "$expected" ]]; then
+    local of; of="$(python3 -c "print(1 if $value >= (1<<64) else 0)")"
+    printf "  %-30s OK   overflow=%d low64=%d\n" "$name" "$of" $(($value & (2**64 - 1)))
+    return 0
+  else
+    printf "  %-30s FAIL\n    expected: %s\n    actual:   %s\n" \
+      "$name" "$expected" "$actual"
+    return 1
+  fi
+}
+
+MAX256=115792089237316195423570985008687907853269984665640564039457584007913129639935
+MAX64=18446744073709551615
+H64=$(python3 -c "print(1 << 64)")
+H128=$(python3 -c "print(1 << 128)")
+H192=$(python3 -c "print(1 << 192)")
+H255=$(python3 -c "print(1 << 255)")
+
+FAILED=0
+# Fits in u64
+run_case "zero"                  0          || FAILED=1
+run_case "one"                   1          || FAILED=1
+run_case "ff"                    255        || FAILED=1
+run_case "0x100"                 256        || FAILED=1
+run_case "two_to_32"             4294967296 || FAILED=1
+run_case "two_to_56"             $(python3 -c "print(1 << 56)") || FAILED=1
+run_case "two_to_63"             $(python3 -c "print(1 << 63)") || FAILED=1
+run_case "max_u64_minus_1"       $(python3 -c "print((1 << 64) - 2)") || FAILED=1
+run_case "max_u64"               "$MAX64"   || FAILED=1
+# Overflows
+run_case "two_to_64"             "$H64"     || FAILED=1
+run_case "two_to_64_plus_1"      $(python3 -c "print((1 << 64) + 1)") || FAILED=1
+run_case "two_to_128"            "$H128"    || FAILED=1
+run_case "two_to_192"            "$H192"    || FAILED=1
+run_case "two_to_255"            "$H255"    || FAILED=1
+run_case "max_u256"              "$MAX256"  || FAILED=1
+# Realistic: u128-shaped value (high bits set but only mid-magnitude)
+run_case "tx_cost_typical"       $(python3 -c "print(100 * 10**9 * 30_000_000)") || FAILED=1
+# Edge: only bit 64 set, low part 0
+run_case "only_bit_64"           $(python3 -c "print(1 << 64)") || FAILED=1
+# Pattern: low 64 = max, high 192 nonzero
+run_case "pattern_high_set"      $(python3 -c "print((1 << 128) | ((1 << 64) - 1))") || FAILED=1
+# Pattern: only some MSBs nonzero, low 64 = 0xdeadbeef
+run_case "msbs_with_low_known"   $(python3 -c "print((1 << 200) | 0xdeadbeef)") || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: u256_to_u64_be truncates correctly and flags overflow"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Truncate a 32-byte big-endian `u256` buffer to its low 64 bits, storing them at `*out`. Returns a 0/1 overflow flag: `1` if any of the high 192 bits are nonzero, `0` otherwise.

Natural inverse of PR-K56 `u256_from_u64_be`. Together they let callers move values between u256 BE byte-buffer and u64 register-resident forms.

## Direct use cases

- `gas_left = u256_to_u64_be(account.balance / gas_price)` for the remaining-gas portion of a tx execution
- Tx validation: check `intrinsic_gas <= tx.gas_limit` after computing intrinsic gas as u64
- Compact a small u256 result for further u64-domain work

Always writes the low-64-bit value to `*out` (even on overflow), so callers don't need to branch on the flag to read a defined value.

Pure register arithmetic, no scratch memory, leaf-callable.

## Test plan

- [x] `lake build` clean
- [x] `scripts/codegen-zisk-u256-to-u64-be-check.sh` passes 19 fixtures:
  - Small values (`0..max_u64` — no overflow)
  - Boundary overflows (`2^64`, `2^64+1`, `2^128`, `2^192`, `2^255`, `max_u256`)
  - Realistic `tx_cost` (`100 gwei × 30M gas = 3e18 wei` — fits in u64)
  - "Only high bits set / low 64 = pattern" probes for the OR-mask overflow detector

🤖 Generated with [Claude Code](https://claude.com/claude-code)