### PR TITLE
feat(smod): add save ra spec

### DIFF
--- a/EvmAsm/Evm64/SMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/SMod/Compose/Base.lean
@@ -37,6 +37,7 @@ import EvmAsm.Evm64.SMod.Compose.SavedRaRetFrame
 import EvmAsm.Evm64.SMod.Compose.ModCallReturnGeneric
 import EvmAsm.Evm64.SMod.Compose.ModCallReturnNamedPost
 import EvmAsm.Evm64.SMod.Compose.ModCallReturnNormalized
+import EvmAsm.Evm64.SMod.Compose.SaveRa
 
 namespace EvmAsm.Evm64.SMod.Compose
 

--- a/EvmAsm/Evm64/SMod/Compose/SaveRa.lean
+++ b/EvmAsm/Evm64/SMod/Compose/SaveRa.lean
@@ -1,0 +1,31 @@
+/-
+  EvmAsm.Evm64.SMod.Compose.SaveRa
+
+  Low-level SMOD wrapper spec for the saved-`ra` prologue instruction.
+-/
+
+import EvmAsm.Evm64.SMod.Compose.BaseCode
+
+namespace EvmAsm.Evm64.SMod.Compose
+
+theorem saveRa_spec_in_smodCodeV4
+    (vRa vSavedOld : Word) (base : Word) :
+    EvmAsm.Rv64.cpsTripleWithin 1 (base + saveRaOff) ((base + saveRaOff) + 4)
+      (smodCodeV4 base)
+      ((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ vSavedOld))
+      ((.x1 ↦ᵣ vRa) **
+        (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))) := by
+  have hmono :
+      ∀ a i,
+        (EvmAsm.Evm64.evm_smod_save_ra_block_code .x18
+          (base + saveRaOff)) a = some i →
+        (smodCodeV4 base) a = some i := by
+    intro a i h
+    exact smodCodeV4_saveRa_sub (base := base) a i
+      (by simpa [saveRaCode,
+        EvmAsm.Evm64.evm_smod_save_ra_block_code] using h)
+  exact EvmAsm.Rv64.cpsTripleWithin_extend_code hmono
+    (EvmAsm.Evm64.evm_smod_save_ra_block_spec_within .x18
+      vRa vSavedOld (base + saveRaOff) (by decide))
+
+end EvmAsm.Evm64.SMod.Compose


### PR DESCRIPTION
## Summary
- add saveRa_spec_in_smodCodeV4 for the SMOD saved-RA prologue block
- extend the local evm_smod_save_ra_block leaf spec into smodCodeV4
- wire the module into the SMOD compose umbrella

## Verification
- lake build EvmAsm.Evm64.SMod.Compose.SaveRa
- lake build EvmAsm.Evm64.SMod
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- rg -n "DivStackSpecCase|ModStackSpecCase|SDivStackSpecCase|SModStackSpecCase|StackSpecCase|set_option maxRecDepth|set_option maxHeartbeats|sorry|admit" EvmAsm/Evm64/SMod/Compose/SaveRa.lean EvmAsm/Evm64/SMod/Compose/Base.lean