### PR TITLE
feat(smod): add dividend sign spec

### DIFF
--- a/EvmAsm/Evm64/SMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/SMod/Compose/Base.lean
@@ -38,6 +38,7 @@ import EvmAsm.Evm64.SMod.Compose.ModCallReturnGeneric
 import EvmAsm.Evm64.SMod.Compose.ModCallReturnNamedPost
 import EvmAsm.Evm64.SMod.Compose.ModCallReturnNormalized
 import EvmAsm.Evm64.SMod.Compose.SaveRa
+import EvmAsm.Evm64.SMod.Compose.SignBlockSpecs
 
 namespace EvmAsm.Evm64.SMod.Compose
 

--- a/EvmAsm/Evm64/SMod/Compose/SignBlockSpecs.lean
+++ b/EvmAsm/Evm64/SMod/Compose/SignBlockSpecs.lean
@@ -1,0 +1,38 @@
+/-
+  EvmAsm.Evm64.SMod.Compose.SignBlockSpecs
+
+  Primitive SMOD wrapper specs for sign-bit probe blocks.
+-/
+
+import EvmAsm.Evm64.SMod.Compose.BaseCode
+import EvmAsm.Evm64.SDiv.LimbSpec
+
+namespace EvmAsm.Evm64.SMod.Compose
+
+theorem dividendSign_spec_in_smodCodeV4
+    (sp sOld dividendTop : Word) (base : Word) :
+    EvmAsm.Rv64.cpsTripleWithin 2 (base + dividendSignOff) ((base + dividendSignOff) + 8)
+      (smodCodeV4 base)
+      ((.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sOld) **
+       ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_smodDividendTopLimbOff) ↦ₘ
+         dividendTop))
+      ((.x12 ↦ᵣ sp) **
+       (.x8 ↦ᵣ (dividendTop >>> (63 : BitVec 6).toNat)) **
+       ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_smodDividendTopLimbOff) ↦ₘ
+         dividendTop)) := by
+  have hmono :
+      ∀ a i,
+        (EvmAsm.Evm64.evm_sdiv_sign_bit_block_code .x12 .x8
+          EvmAsm.Evm64.evm_smodDividendTopLimbOff
+          (base + dividendSignOff)) a = some i →
+        (smodCodeV4 base) a = some i := by
+    intro a i h
+    exact smodCodeV4_dividendSign_sub (base := base) a i
+      (by simpa [dividendSignCode,
+        EvmAsm.Evm64.evm_sdiv_sign_bit_block_code] using h)
+  exact EvmAsm.Rv64.cpsTripleWithin_extend_code hmono
+    (EvmAsm.Evm64.evm_sdiv_sign_bit_block_spec_within .x12 .x8
+      EvmAsm.Evm64.evm_smodDividendTopLimbOff sp sOld dividendTop
+      (base + dividendSignOff) (by decide))
+
+end EvmAsm.Evm64.SMod.Compose


### PR DESCRIPTION
## Summary
- add dividendSign_spec_in_smodCodeV4 for the SMOD dividend sign-bit probe
- extend the shared sign-bit block leaf spec into smodCodeV4 at dividendSignOff
- wire the sign block specs module into the SMOD compose umbrella

## Verification
- lake build EvmAsm.Evm64.SMod.Compose.SignBlockSpecs
- lake build EvmAsm.Evm64.SMod
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- rg -n "DivStackSpecCase|ModStackSpecCase|SDivStackSpecCase|SModStackSpecCase|StackSpecCase|set_option maxRecDepth|set_option maxHeartbeats|sorry|admit" EvmAsm/Evm64/SMod/Compose/SignBlockSpecs.lean EvmAsm/Evm64/SMod/Compose/Base.lean