### PR TITLE
feat(smod): add divisor sign spec

### DIFF
--- a/EvmAsm/Evm64/SMod/Compose/AbsBlockSpecs.lean
+++ b/EvmAsm/Evm64/SMod/Compose/AbsBlockSpecs.lean
@@ -1,0 +1,37 @@
+/-
+  EvmAsm.Evm64.SMod.Compose.AbsBlockSpecs
+
+  Primitive SMOD wrapper specs for the in-place absolute-value blocks.
+-/
+
+import EvmAsm.Evm64.SMod.Compose.BaseCode
+import EvmAsm.Evm64.SDiv.LimbSpec
+
+namespace EvmAsm.Evm64.SMod.Compose
+
+theorem dividendAbs_spec_in_smodCodeV4
+    (sp sign maskOld valueOld carryOld limb0 limb1 limb2 limb3 : Word)
+    (base : Word) :
+    EvmAsm.Rv64.cpsTripleWithin 21 (base + dividendAbsOff) ((base + dividendAbsOff) + 84)
+      (smodCodeV4 base)
+      (EvmAsm.Evm64.condNegate256BlockPre .x12 .x8 .x10 .x7 .x11
+        0 8 16 24 sp sign maskOld valueOld carryOld limb0 limb1 limb2 limb3)
+      (EvmAsm.Evm64.condNegate256BlockPost .x12 .x8 .x10 .x7 .x11
+        0 8 16 24 sp sign limb0 limb1 limb2 limb3) := by
+  have hmono :
+      ∀ a i,
+        (EvmAsm.Evm64.evm_sdiv_cond_negate_256_block_code
+          .x12 .x8 .x10 .x7 .x11 0 8 16 24
+          (base + dividendAbsOff)) a = some i →
+        (smodCodeV4 base) a = some i := by
+    intro a i h
+    exact smodCodeV4_dividendAbs_sub (base := base) a i
+      (by simpa [dividendAbsCode,
+        EvmAsm.Evm64.evm_sdiv_cond_negate_256_block_code] using h)
+  exact EvmAsm.Rv64.cpsTripleWithin_extend_code hmono
+    (EvmAsm.Evm64.evm_sdiv_cond_negate_256_block_spec_within
+      .x12 .x8 .x10 .x7 .x11 0 8 16 24
+      sp sign maskOld valueOld carryOld limb0 limb1 limb2 limb3
+      (base + dividendAbsOff) (by decide) (by decide) (by decide))
+
+end EvmAsm.Evm64.SMod.Compose

--- a/EvmAsm/Evm64/SMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/SMod/Compose/Base.lean
@@ -39,6 +39,7 @@ import EvmAsm.Evm64.SMod.Compose.ModCallReturnNamedPost
 import EvmAsm.Evm64.SMod.Compose.ModCallReturnNormalized
 import EvmAsm.Evm64.SMod.Compose.SaveRa
 import EvmAsm.Evm64.SMod.Compose.SignBlockSpecs
+import EvmAsm.Evm64.SMod.Compose.PreserveDividendSign
 
 namespace EvmAsm.Evm64.SMod.Compose
 

--- a/EvmAsm/Evm64/SMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/SMod/Compose/Base.lean
@@ -40,6 +40,7 @@ import EvmAsm.Evm64.SMod.Compose.ModCallReturnNormalized
 import EvmAsm.Evm64.SMod.Compose.SaveRa
 import EvmAsm.Evm64.SMod.Compose.SignBlockSpecs
 import EvmAsm.Evm64.SMod.Compose.PreserveDividendSign
+import EvmAsm.Evm64.SMod.Compose.AbsBlockSpecs
 
 namespace EvmAsm.Evm64.SMod.Compose
 

--- a/EvmAsm/Evm64/SMod/Compose/PreserveDividendSign.lean
+++ b/EvmAsm/Evm64/SMod/Compose/PreserveDividendSign.lean
@@ -1,0 +1,35 @@
+/-
+  EvmAsm.Evm64.SMod.Compose.PreserveDividendSign
+
+  Low-level SMOD wrapper spec for preserving the dividend sign across the
+  nested MOD callable.
+-/
+
+import EvmAsm.Evm64.SMod.Compose.BaseCode
+
+namespace EvmAsm.Evm64.SMod.Compose
+
+theorem preserveDividendSign_spec_in_smodCodeV4
+    (dividendSign x13Old : Word) (base : Word) :
+    EvmAsm.Rv64.cpsTripleWithin 1 (base + preserveDividendSignOff)
+      ((base + preserveDividendSignOff) + 4)
+      (smodCodeV4 base)
+      ((.x8 ↦ᵣ dividendSign) ** (.x13 ↦ᵣ x13Old))
+      ((.x8 ↦ᵣ dividendSign) **
+        (.x13 ↦ᵣ (dividendSign + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))) := by
+  have hmono :
+      ∀ a i,
+        (EvmAsm.Rv64.CodeReq.singleton (base + preserveDividendSignOff)
+          (.ADDI .x13 .x8 0)) a = some i →
+        (smodCodeV4 base) a = some i := by
+    intro a i h
+    exact smodCodeV4_preserveDividendSign_sub (base := base) a i
+      (by
+        rw [preserveDividendSignCode, EvmAsm.Rv64.ADDI,
+          EvmAsm.Rv64.single, EvmAsm.Rv64.CodeReq.ofProg_singleton]
+        exact h)
+  exact EvmAsm.Rv64.cpsTripleWithin_extend_code hmono
+    (EvmAsm.Rv64.addi_spec_within .x13 .x8 dividendSign x13Old
+      0 (base + preserveDividendSignOff) (by decide))
+
+end EvmAsm.Evm64.SMod.Compose

--- a/EvmAsm/Evm64/SMod/Compose/SignBlockSpecs.lean
+++ b/EvmAsm/Evm64/SMod/Compose/SignBlockSpecs.lean
@@ -35,4 +35,30 @@ theorem dividendSign_spec_in_smodCodeV4
       EvmAsm.Evm64.evm_smodDividendTopLimbOff sp sOld dividendTop
       (base + dividendSignOff) (by decide))
 
+theorem divisorSign_spec_in_smodCodeV4
+    (sp sOld divisorTop : Word) (base : Word) :
+    EvmAsm.Rv64.cpsTripleWithin 2 (base + divisorSignOff) ((base + divisorSignOff) + 8)
+      (smodCodeV4 base)
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ sOld) **
+       ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_smodDivisorTopLimbOff) ↦ₘ
+         divisorTop))
+      ((.x12 ↦ᵣ sp) **
+       (.x9 ↦ᵣ (divisorTop >>> (63 : BitVec 6).toNat)) **
+       ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_smodDivisorTopLimbOff) ↦ₘ
+         divisorTop)) := by
+  have hmono :
+      ∀ a i,
+        (EvmAsm.Evm64.evm_sdiv_sign_bit_block_code .x12 .x9
+          EvmAsm.Evm64.evm_smodDivisorTopLimbOff
+          (base + divisorSignOff)) a = some i →
+        (smodCodeV4 base) a = some i := by
+    intro a i h
+    exact smodCodeV4_divisorSign_sub (base := base) a i
+      (by simpa [divisorSignCode,
+        EvmAsm.Evm64.evm_sdiv_sign_bit_block_code] using h)
+  exact EvmAsm.Rv64.cpsTripleWithin_extend_code hmono
+    (EvmAsm.Evm64.evm_sdiv_sign_bit_block_spec_within .x12 .x9
+      EvmAsm.Evm64.evm_smodDivisorTopLimbOff sp sOld divisorTop
+      (base + divisorSignOff) (by decide))
+
 end EvmAsm.Evm64.SMod.Compose


### PR DESCRIPTION
## Summary
- add divisorSign_spec_in_smodCodeV4 for the SMOD divisor sign-bit probe
- extend the shared sign-bit block leaf spec into smodCodeV4 at divisorSignOff

## Verification
- lake build EvmAsm.Evm64.SMod.Compose.SignBlockSpecs
- lake build EvmAsm.Evm64.SMod
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- rg -n "DivStackSpecCase|ModStackSpecCase|SDivStackSpecCase|SModStackSpecCase|StackSpecCase|set_option maxRecDepth|set_option maxHeartbeats|sorry|admit" EvmAsm/Evm64/SMod/Compose/SignBlockSpecs.lean