### PR TITLE
feat(smod): add dividend abs spec

### DIFF
--- a/EvmAsm/Evm64/SMod/Compose/AbsBlockSpecs.lean
+++ b/EvmAsm/Evm64/SMod/Compose/AbsBlockSpecs.lean
@@ -1,0 +1,37 @@
+/-
+  EvmAsm.Evm64.SMod.Compose.AbsBlockSpecs
+
+  Primitive SMOD wrapper specs for the in-place absolute-value blocks.
+-/
+
+import EvmAsm.Evm64.SMod.Compose.BaseCode
+import EvmAsm.Evm64.SDiv.LimbSpec
+
+namespace EvmAsm.Evm64.SMod.Compose
+
+theorem dividendAbs_spec_in_smodCodeV4
+    (sp sign maskOld valueOld carryOld limb0 limb1 limb2 limb3 : Word)
+    (base : Word) :
+    EvmAsm.Rv64.cpsTripleWithin 21 (base + dividendAbsOff) ((base + dividendAbsOff) + 84)
+      (smodCodeV4 base)
+      (EvmAsm.Evm64.condNegate256BlockPre .x12 .x8 .x10 .x7 .x11
+        0 8 16 24 sp sign maskOld valueOld carryOld limb0 limb1 limb2 limb3)
+      (EvmAsm.Evm64.condNegate256BlockPost .x12 .x8 .x10 .x7 .x11
+        0 8 16 24 sp sign limb0 limb1 limb2 limb3) := by
+  have hmono :
+      ∀ a i,
+        (EvmAsm.Evm64.evm_sdiv_cond_negate_256_block_code
+          .x12 .x8 .x10 .x7 .x11 0 8 16 24
+          (base + dividendAbsOff)) a = some i →
+        (smodCodeV4 base) a = some i := by
+    intro a i h
+    exact smodCodeV4_dividendAbs_sub (base := base) a i
+      (by simpa [dividendAbsCode,
+        EvmAsm.Evm64.evm_sdiv_cond_negate_256_block_code] using h)
+  exact EvmAsm.Rv64.cpsTripleWithin_extend_code hmono
+    (EvmAsm.Evm64.evm_sdiv_cond_negate_256_block_spec_within
+      .x12 .x8 .x10 .x7 .x11 0 8 16 24
+      sp sign maskOld valueOld carryOld limb0 limb1 limb2 limb3
+      (base + dividendAbsOff) (by decide) (by decide) (by decide))
+
+end EvmAsm.Evm64.SMod.Compose

--- a/EvmAsm/Evm64/SMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/SMod/Compose/Base.lean
@@ -40,6 +40,7 @@ import EvmAsm.Evm64.SMod.Compose.ModCallReturnNormalized
 import EvmAsm.Evm64.SMod.Compose.SaveRa
 import EvmAsm.Evm64.SMod.Compose.SignBlockSpecs
 import EvmAsm.Evm64.SMod.Compose.PreserveDividendSign
+import EvmAsm.Evm64.SMod.Compose.AbsBlockSpecs
 
 namespace EvmAsm.Evm64.SMod.Compose
 


### PR DESCRIPTION
## Summary
- add dividendAbs_spec_in_smodCodeV4 for the SMOD in-place dividend absolute-value block
- extend the shared 256-bit conditional-negation block spec into smodCodeV4 at dividendAbsOff
- wire AbsBlockSpecs into the SMOD compose umbrella

## Verification
- lake build EvmAsm.Evm64.SMod.Compose.AbsBlockSpecs
- lake build EvmAsm.Evm64.SMod
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- rg -n "DivStackSpecCase|ModStackSpecCase|SDivStackSpecCase|SModStackSpecCase|StackSpecCase|set_option maxRecDepth|set_option maxHeartbeats|sorry|admit" EvmAsm/Evm64/SMod/Compose/AbsBlockSpecs.lean EvmAsm/Evm64/SMod/Compose/Base.lean