### PR TITLE
feat(stateless): u256_is_zero (PR-K58)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -5974,6 +5974,71 @@ def ziskU256FromU64BeProbeUnit : BuildUnit := {
   dataAsm     := ziskU256FromU64BeDataSection
 }
 
+/-! ## u256_is_zero -- PR-K58 all-zero predicate on BE u256 buffers
+
+    Test whether a 32-byte big-endian `u256` buffer encodes the
+    value `0`. Returns `1` if all 32 bytes are zero, else `0`.
+
+    Saves callers from keeping a 32-byte zero buffer around just
+    to call `u256_eq` against it. Common pattern in tx
+    validation:
+
+      // Reject zero-value txs to a contract creation address
+      if not u256_is_zero(tx.value) and tx.is_creation: ...
+
+      // Skip the priority-fee credit if no surplus
+      if u256_is_zero(priority_fee_after_cap): goto next
+
+    BE storage convention: byte 0 = MSB, byte 31 = LSB. (For
+    is-zero the endian doesn't matter — all-zero bytes mean
+    value 0 either way — but kept consistent with the K50/K53
+    convention.)
+
+    Calling convention:
+      a0 (input)  : u256 ptr (32 bytes)
+      ra (input)  : return
+      a0 (output) : 1 if all-zero, 0 otherwise.
+
+    Pure register arithmetic: 4 ld + 3 or + 1 seqz. No
+    short-circuit (we always read all 32 bytes), keeping
+    timing data-independent for any future side-channel
+    considerations. Leaf-callable. -/
+def u256IsZeroFunction : String :=
+  "u256_is_zero:\n" ++
+  "  ld t0,  0(a0)\n" ++
+  "  ld t1,  8(a0)\n" ++
+  "  ld t2, 16(a0)\n" ++
+  "  ld t3, 24(a0)\n" ++
+  "  or t0, t0, t1\n" ++
+  "  or t0, t0, t2\n" ++
+  "  or t0, t0, t3\n" ++
+  "  seqz a0, t0\n" ++
+  "  ret"
+
+/-- `zisk_u256_is_zero`: probe BuildUnit. Reads 32B u256 from host
+    input, writes the u64 result. -/
+def ziskU256IsZeroPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a1, 0x40000000\n" ++
+  "  addi a0, a1, 8              # u256 ptr\n" ++
+  "  jal ra, u256_is_zero\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)                # result\n" ++
+  "  j .Lu256z_pdone\n" ++
+  u256IsZeroFunction ++ "\n" ++
+  ".Lu256z_pdone:"
+
+def ziskU256IsZeroDataSection : String :=
+  ".section .data\n" ++
+  "u256z_pad:\n" ++
+  "  .zero 8"
+
+def ziskU256IsZeroProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskU256IsZeroPrologue
+  dataAsm     := ziskU256IsZeroDataSection
+}
+
 
 /-! ## u256_eq -- PR-K53 equality companion to PR-K50 u256_lt
 
@@ -8581,6 +8646,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_u256_eq"              => some ziskU256EqProbeUnit
   | "zisk_u256_mul_u64_be"      => some ziskU256MulU64BeProbeUnit
   | "zisk_u256_from_u64_be"     => some ziskU256FromU64BeProbeUnit
+  | "zisk_u256_is_zero"         => some ziskU256IsZeroProbeUnit
   | "zisk_tx_type_dispatch"     => some ziskTxTypeDispatchProbeUnit
   | "zisk_tx_eip2930_decode"    => some ziskTxEip2930DecodeProbeUnit
   | "zisk_tx_eip7702_decode"    => some ziskTxEip7702DecodeProbeUnit
@@ -8651,6 +8717,7 @@ def knownProgramNames : List String :=
    "zisk_u256_eq",
    "zisk_u256_mul_u64_be",
    "zisk_u256_from_u64_be",
+   "zisk_u256_is_zero",
    "zisk_tx_type_dispatch",
    "zisk_tx_eip2930_decode",
    "zisk_tx_eip7702_decode",

--- a/scripts/codegen-zisk-u256-is-zero-check.sh
+++ b/scripts/codegen-zisk-u256-is-zero-check.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# codegen-zisk-u256-is-zero-check.sh -- PR-K58.
+#
+# All-zero predicate on 32-byte u256 buffer.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_u256_is_zero ELF"
+lake exe codegen --program zisk_u256_is_zero --halt linux93 \
+  -o gen-out/zisk_u256_is_zero
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <value_dec> <expected 0|1>
+run_case() {
+  local name="$1" value="$2" expected="$3"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_u256_is_zero_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_u256_is_zero_${name}.output"
+
+  python3 -c "
+import sys
+v = $value
+sys.stdout.buffer.write(v.to_bytes(32, 'big'))
+" > "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_u256_is_zero.elf \
+    -i "$in_file" -o "$out_file" -n 500000 \
+    >"$REPO_ROOT/gen-out/zisk_u256_is_zero_${name}.emu.log" 2>&1 || true
+
+  local actual; actual="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local exp_le; exp_le="$(python3 -c "print(int('$expected').to_bytes(8, 'little').hex())")"
+
+  if [[ "$actual" == "$exp_le" ]]; then
+    printf "  %-30s OK   result=%d\n" "$name" "$expected"
+    return 0
+  else
+    printf "  %-30s FAIL  expected %d got 0x%s\n" "$name" "$expected" "$actual"
+    return 1
+  fi
+}
+
+MAX=115792089237316195423570985008687907853269984665640564039457584007913129639935
+
+FAILED=0
+# True
+run_case "all_zero"              0          1   || FAILED=1
+# False — pin one bit at each interesting position
+run_case "lsb_set"               1          0   || FAILED=1
+run_case "byte0_set_low"         255        0   || FAILED=1
+run_case "byte1_set"             256        0   || FAILED=1
+run_case "byte7_set"             $(python3 -c "print(1 << 56)") 0  || FAILED=1
+run_case "byte8_set"             $(python3 -c "print(1 << 64)") 0  || FAILED=1
+run_case "byte15_set"            $(python3 -c "print(1 << 120)") 0 || FAILED=1
+run_case "byte16_set"            $(python3 -c "print(1 << 128)") 0 || FAILED=1
+run_case "byte23_set"            $(python3 -c "print(1 << 184)") 0 || FAILED=1
+run_case "byte24_set"            $(python3 -c "print(1 << 192)") 0 || FAILED=1
+run_case "byte31_set"            $(python3 -c "print(1 << 248)") 0 || FAILED=1
+run_case "msb_set"               $(python3 -c "print(1 << 255)") 0 || FAILED=1
+run_case "max_u256"              "$MAX"     0   || FAILED=1
+# Realistic
+ONE_ETH=$(python3 -c "print(10**18)")
+run_case "one_eth"               "$ONE_ETH" 0   || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: u256_is_zero detects all-zero buffer across all 32 byte positions"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

All-zero predicate on a 32-byte `u256` buffer. Returns `1` if all 32 bytes are zero, else `0`.

Saves callers from keeping a 32-byte zero buffer around just to call `u256_eq` against it. Common tx-validation pattern:

```
if not u256_is_zero(tx.value) and tx.is_creation: ...
if u256_is_zero(priority_fee_after_cap): goto next
```

Completes the u256 comparison set: PR-K50 `u256_lt`, PR-K53 `u256_eq`, PR-K58 `u256_is_zero`.

## Implementation

Pure register arithmetic: 4 `ld` + 3 `or` + 1 `seqz`. No short-circuit — always reads all 32 bytes, keeping timing data-independent. Leaf-callable.

## Test plan

- [x] `lake build` clean
- [x] `scripts/codegen-zisk-u256-is-zero-check.sh` passes 14 fixtures:
  - All-zero (true)
  - One-bit-set probes at every byte boundary (byte 0/1/7/8/15/16/23/24/31)
  - LSB, MSB, `max_u256`, 1 ETH (all false)

🤖 Generated with [Claude Code](https://claude.com/claude-code)