### PR TITLE
feat(smod): compose save ra dividend sign

### DIFF
--- a/EvmAsm/Evm64/SMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/SMod/Compose/Base.lean
@@ -42,6 +42,7 @@ import EvmAsm.Evm64.SMod.Compose.SignBlockSpecs
 import EvmAsm.Evm64.SMod.Compose.PreserveDividendSign
 import EvmAsm.Evm64.SMod.Compose.AbsBlockSpecs
 import EvmAsm.Evm64.SMod.Compose.ModCall
+import EvmAsm.Evm64.SMod.Compose.SaveRaSignSequence
 
 namespace EvmAsm.Evm64.SMod.Compose
 

--- a/EvmAsm/Evm64/SMod/Compose/SaveRaSignSequence.lean
+++ b/EvmAsm/Evm64/SMod/Compose/SaveRaSignSequence.lean
@@ -1,0 +1,63 @@
+/-
+  EvmAsm.Evm64.SMod.Compose.SaveRaSignSequence
+
+  SMOD wrapper composition for the saved-`ra` prologue followed by the
+  dividend sign-bit probe.
+-/
+
+import EvmAsm.Evm64.SMod.Compose.SaveRa
+import EvmAsm.Evm64.SMod.Compose.SignBlockSpecs
+
+namespace EvmAsm.Evm64.SMod.Compose
+
+open EvmAsm.Rv64.Tactics
+
+theorem saveRa_then_dividendSign_spec_in_smodCodeV4
+    (vRa vSavedOld sp sOld dividendTop : Word) (base : Word) :
+    EvmAsm.Rv64.cpsTripleWithin 3 base ((base + dividendSignOff) + 8) (smodCodeV4 base)
+      (((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ vSavedOld)) **
+       ((.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sOld) **
+        ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_smodDividendTopLimbOff) ↦ₘ
+          dividendTop)))
+      (((.x1 ↦ᵣ vRa) **
+        (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))) **
+       ((.x12 ↦ᵣ sp) **
+        (.x8 ↦ᵣ (dividendTop >>> (63 : BitVec 6).toNat)) **
+        ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_smodDividendTopLimbOff) ↦ₘ
+          dividendTop))) := by
+  have hSave :=
+    EvmAsm.Rv64.cpsTripleWithin_frameR
+      (((.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sOld) **
+        ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_smodDividendTopLimbOff) ↦ₘ
+          dividendTop)))
+      (by pcFree)
+      (saveRa_spec_in_smodCodeV4 vRa vSavedOld base)
+  have hSign :=
+    EvmAsm.Rv64.cpsTripleWithin_frameL
+      (((.x1 ↦ᵣ vRa) **
+        (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))))
+      (by pcFree)
+      (dividendSign_spec_in_smodCodeV4 sp sOld dividendTop base)
+  have hFall :
+      (base + saveRaOff) + 4 = base + dividendSignOff := by
+    simp [saveRaOff, dividendSignOff]
+  have hSign' :
+      EvmAsm.Rv64.cpsTripleWithin 2 ((base + saveRaOff) + 4)
+        ((base + dividendSignOff) + 8) (smodCodeV4 base)
+        ((((.x1 ↦ᵣ vRa) **
+          (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))) **
+         (.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sOld) **
+         ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_smodDividendTopLimbOff) ↦ₘ
+           dividendTop)))
+        ((((.x1 ↦ᵣ vRa) **
+          (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))) **
+         (.x12 ↦ᵣ sp) **
+         (.x8 ↦ᵣ (dividendTop >>> (63 : BitVec 6).toNat)) **
+         ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_smodDividendTopLimbOff) ↦ₘ
+           dividendTop))) := by
+    rw [hFall]
+    exact hSign
+  have hSeq := EvmAsm.Rv64.cpsTripleWithin_seq_same_cr hSave hSign'
+  simpa [saveRaOff] using hSeq
+
+end EvmAsm.Evm64.SMod.Compose


### PR DESCRIPTION
## Summary
- compose the SMOD saved-RA prologue through the dividend sign-bit probe
- add saveRa_then_dividendSign_spec_in_smodCodeV4
- wire SaveRaSignSequence into the SMOD compose umbrella

## Verification
- lake build EvmAsm.Evm64.SMod.Compose.SaveRaSignSequence
- lake build EvmAsm.Evm64.SMod
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- rg -n "DivStackSpecCase|ModStackSpecCase|SDivStackSpecCase|SModStackSpecCase|StackSpecCase|set_option maxRecDepth|set_option maxHeartbeats|sorry|admit" EvmAsm/Evm64/SMod/Compose/SaveRaSignSequence.lean EvmAsm/Evm64/SMod/Compose/Base.lean