### PR TITLE
feat(stateless): u256_min (PR-K59)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -6039,6 +6039,95 @@ def ziskU256IsZeroProbeUnit : BuildUnit := {
   dataAsm     := ziskU256IsZeroDataSection
 }
 
+/-! ## u256_min -- PR-K59 minimum of two BE u256 buffers
+
+    Compare two 32-byte big-endian `u256` buffers and copy the
+    smaller (or `a` on equality) into `out`. Standalone — does
+    not call `u256_lt` (PR-K50); the byte-walk-and-pick logic
+    is inlined to avoid the cross-PR dependency.
+
+    Direct use case — EIP-1559 effective priority fee:
+
+      surplus = u256_sub_be(tx.max_fee_per_gas, base_fee_per_gas)
+      priority = u256_min(tx.max_priority_fee_per_gas, surplus)
+
+    Per the Python `transaction_priority_fee_per_gas`:
+
+      def priority_fee(tx, base_fee):
+          if tx.type == 0:  # legacy
+              return tx.gas_price - base_fee
+          else:
+              return min(tx.max_priority_fee_per_gas,
+                         tx.max_fee_per_gas - base_fee)
+
+    BE storage convention: byte 0 = MSB, byte 31 = LSB.
+
+    Calling convention:
+      a0 (input)  : u256 a ptr (32 bytes, BE)
+      a1 (input)  : u256 b ptr (32 bytes, BE)
+      a2 (input)  : u256 out ptr (may alias a or b)
+      ra (input)  : return
+      a0 (output) : 0 (the selected pointer is internally chosen).
+
+    The byte-walk pass short-circuits on the first differing
+    byte. Then a 4 × (ld + sd) chunk copy emits 32 bytes. Pure
+    register arithmetic, no scratch memory, leaf-callable.
+
+    Note on aliasing: if `out` aliases either input, the byte
+    walk is read-only over both inputs, and the 4 × (ld + sd)
+    copy reads each chunk from one of them and writes to `out`
+    in the same step — fine since `ld` happens before `sd`. -/
+def u256MinFunction : String :=
+  "u256_min:\n" ++
+  "  li t0, 0                   # byte index\n" ++
+  "  li t6, 32\n" ++
+  ".Lumin_lt_loop:\n" ++
+  "  beq t0, t6, .Lumin_pick_a  # all bytes equal → return a\n" ++
+  "  add t1, a0, t0\n" ++
+  "  add t2, a1, t0\n" ++
+  "  lbu t3, 0(t1)\n" ++
+  "  lbu t4, 0(t2)\n" ++
+  "  bltu t3, t4, .Lumin_pick_a # a < b → return a\n" ++
+  "  bgtu t3, t4, .Lumin_pick_b # a > b → return b\n" ++
+  "  addi t0, t0, 1\n" ++
+  "  j .Lumin_lt_loop\n" ++
+  ".Lumin_pick_a:\n" ++
+  "  mv t0, a0\n" ++
+  "  j .Lumin_copy\n" ++
+  ".Lumin_pick_b:\n" ++
+  "  mv t0, a1\n" ++
+  ".Lumin_copy:\n" ++
+  "  ld t1,  0(t0); sd t1,  0(a2)\n" ++
+  "  ld t1,  8(t0); sd t1,  8(a2)\n" ++
+  "  ld t1, 16(t0); sd t1, 16(a2)\n" ++
+  "  ld t1, 24(t0); sd t1, 24(a2)\n" ++
+  "  li a0, 0\n" ++
+  "  ret"
+
+/-- `zisk_u256_min`: probe BuildUnit. Reads (32B a, 32B b) from
+    host input, writes the 32B min into OUTPUT. -/
+def ziskU256MinPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a3, 0x40000000\n" ++
+  "  addi a0, a3, 8              # a ptr\n" ++
+  "  addi a1, a3, 40             # b ptr\n" ++
+  "  li a2, 0xa0010000           # out ptr at OUTPUT\n" ++
+  "  jal ra, u256_min\n" ++
+  "  j .Lumin_pdone\n" ++
+  u256MinFunction ++ "\n" ++
+  ".Lumin_pdone:"
+
+def ziskU256MinDataSection : String :=
+  ".section .data\n" ++
+  "umin_pad:\n" ++
+  "  .zero 8"
+
+def ziskU256MinProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskU256MinPrologue
+  dataAsm     := ziskU256MinDataSection
+}
+
 
 /-! ## u256_eq -- PR-K53 equality companion to PR-K50 u256_lt
 
@@ -8724,6 +8813,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_u256_from_u64_be"     => some ziskU256FromU64BeProbeUnit
   | "zisk_u256_to_u64_be"       => some ziskU256ToU64BeProbeUnit
   | "zisk_u256_is_zero"         => some ziskU256IsZeroProbeUnit
+  | "zisk_u256_min"             => some ziskU256MinProbeUnit
   | "zisk_tx_type_dispatch"     => some ziskTxTypeDispatchProbeUnit
   | "zisk_tx_eip2930_decode"    => some ziskTxEip2930DecodeProbeUnit
   | "zisk_tx_eip7702_decode"    => some ziskTxEip7702DecodeProbeUnit
@@ -8796,6 +8886,7 @@ def knownProgramNames : List String :=
    "zisk_u256_from_u64_be",
    "zisk_u256_to_u64_be",
    "zisk_u256_is_zero",
+   "zisk_u256_min",
    "zisk_tx_type_dispatch",
    "zisk_tx_eip2930_decode",
    "zisk_tx_eip7702_decode",

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **81**
-- ziskemu round-trip scripts: **74** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **82**
+- ziskemu round-trip scripts: **75** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-u256-min-check.sh
+++ b/scripts/codegen-zisk-u256-min-check.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# codegen-zisk-u256-min-check.sh -- PR-K59.
+#
+# Minimum of two 32-byte BE u256 buffers.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_u256_min ELF"
+lake exe codegen --program zisk_u256_min --halt linux93 \
+  -o gen-out/zisk_u256_min
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <a_dec> <b_dec>
+run_case() {
+  local name="$1" a="$2" b="$3"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_u256_min_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_u256_min_${name}.output"
+  local exp_file="$REPO_ROOT/gen-out/zisk_u256_min_${name}.expected"
+
+  python3 -c "
+import sys
+a = $a
+b = $b
+out  = a.to_bytes(32, 'big')
+out += b.to_bytes(32, 'big')
+sys.stdout.buffer.write(out)
+" > "$in_file"
+
+  python3 -c "
+import sys
+a = $a
+b = $b
+mn = a if a <= b else b  # On equality, asm picks a; on inequality, the smaller.
+sys.stdout.buffer.write(mn.to_bytes(32, 'big'))
+" > "$exp_file"
+
+  "$ZISKEMU" -e gen-out/zisk_u256_min.elf \
+    -i "$in_file" -o "$out_file" -n 500000 \
+    >"$REPO_ROOT/gen-out/zisk_u256_min_${name}.emu.log" 2>&1 || true
+
+  local actual; actual="$(xxd -p -l 32 "$out_file" | tr -d '\n')"
+  local expected; expected="$(xxd -p -l 32 "$exp_file" | tr -d '\n')"
+
+  if [[ "$actual" == "$expected" ]]; then
+    local mn; mn="$(python3 -c "print($a if $a <= $b else $b)")"
+    printf "  %-30s OK   min=%s\n" "$name" "${mn:0:24}..."
+    return 0
+  else
+    printf "  %-30s FAIL\n    expected: %s\n    actual:   %s\n" \
+      "$name" "$expected" "$actual"
+    return 1
+  fi
+}
+
+MAX=115792089237316195423570985008687907853269984665640564039457584007913129639935
+H64=$(python3 -c "print(1 << 64)")
+H128=$(python3 -c "print(1 << 128)")
+ONE_GWEI=$(python3 -c "print(10**9)")
+HUNDRED_GWEI=$(python3 -c "print(100 * 10**9)")
+
+FAILED=0
+# Equality (asm picks a)
+run_case "zero_eq_zero"          0       0       || FAILED=1
+run_case "one_eq_one"            1       1       || FAILED=1
+run_case "max_eq_max"            "$MAX"  "$MAX"  || FAILED=1
+# Strict ordering: a < b
+run_case "zero_lt_one"           0       1       || FAILED=1
+run_case "one_lt_two"            1       2       || FAILED=1
+run_case "zero_lt_max"           0       "$MAX"  || FAILED=1
+# Strict ordering: a > b
+run_case "one_gt_zero"           1       0       || FAILED=1
+run_case "max_gt_zero"           "$MAX"  0       || FAILED=1
+run_case "two_gt_one"            2       1       || FAILED=1
+# MSB-only diff
+A_TOP=$(python3 -c "print(0x10 << (31*8))")
+B_TOP=$(python3 -c "print(0x20 << (31*8))")
+run_case "msb_a_lt_b"            "$A_TOP" "$B_TOP" || FAILED=1
+run_case "msb_a_gt_b"            "$B_TOP" "$A_TOP" || FAILED=1
+# LSB-only diff
+run_case "lsb_a_lt_b"            0       1        || FAILED=1
+# Mid-byte diff
+A_MID=$(python3 -c "print(1 << 80)")
+B_MID=$(python3 -c "print((1 << 80) + 1)")
+run_case "mid_a_lt_b"            "$A_MID" "$B_MID" || FAILED=1
+# Realistic priority-fee scenario
+run_case "priority_cap_below"    "$ONE_GWEI" "$HUNDRED_GWEI"   || FAILED=1   # max_priority < (max_fee - base) → use priority
+run_case "priority_cap_above"    "$HUNDRED_GWEI" "$ONE_GWEI"   || FAILED=1   # surplus < max_priority → use surplus
+run_case "priority_eq_surplus"   "$ONE_GWEI" "$ONE_GWEI"       || FAILED=1
+# 128-bit boundary
+run_case "h128_vs_h128m1"        "$H128" $(python3 -c "print((1<<128) - 1)") || FAILED=1
+# Crossing 64-bit boundary
+run_case "h64_vs_h64p1"          "$H64"  $(python3 -c "print((1<<64) + 1)")  || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: u256_min matches Python's min() across 18 fixtures"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Minimum of two 32-byte BE u256 buffers. Compares `a` vs `b` byte-by-byte from MSB to LSB and copies the smaller (or `a` on equality) to `out`.

Standalone — does not call PR-K50 `u256_lt`; the byte-walk-and-pick logic is inlined to avoid the cross-PR dependency. Pure register arithmetic + 4 × (`ld` + `sd`) chunk copy. Leaf-callable. Aliasing safe.

## Direct use case — EIP-1559 effective priority fee

```
surplus = u256_sub_be(tx.max_fee_per_gas, base_fee_per_gas)
priority = u256_min(tx.max_priority_fee_per_gas, surplus)
```

(Per Python `transaction_priority_fee_per_gas` for EIP-1559+.)

## Test plan

- [x] `lake build` clean
- [x] `scripts/codegen-zisk-u256-min-check.sh` passes 18 fixtures:
  - Equalities (`zero`, `one`, `max`)
  - Strict ordering both ways
  - MSB-only diff (both directions), LSB-only diff, mid-byte diff
  - Three realistic priority-fee scenarios (cap below/above surplus, equality)
  - The 128-bit boundary
  - The 64-bit boundary

🤖 Generated with [Claude Code](https://claude.com/claude-code)