### PR TITLE
feat(smod): compose divisor abs block

### DIFF
--- a/EvmAsm/Evm64/SMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/SMod/Compose/Base.lean
@@ -46,6 +46,7 @@ import EvmAsm.Evm64.SMod.Compose.SaveRaSignSequence
 import EvmAsm.Evm64.SMod.Compose.PreserveDividendSignSequence
 import EvmAsm.Evm64.SMod.Compose.DivisorSignSequence
 import EvmAsm.Evm64.SMod.Compose.DividendAbsSequence
+import EvmAsm.Evm64.SMod.Compose.DivisorAbsSequence
 
 namespace EvmAsm.Evm64.SMod.Compose
 

--- a/EvmAsm/Evm64/SMod/Compose/DivisorAbsSequence.lean
+++ b/EvmAsm/Evm64/SMod/Compose/DivisorAbsSequence.lean
@@ -1,0 +1,225 @@
+/-
+  EvmAsm.Evm64.SMod.Compose.DivisorAbsSequence
+
+  SMOD wrapper composition through both operand absolute-value blocks.
+-/
+
+import EvmAsm.Evm64.SMod.Compose.DividendAbsSequence
+
+namespace EvmAsm.Evm64.SMod.Compose
+
+open EvmAsm.Rv64.Tactics
+
+theorem saveRa_signs_abs_then_divisorAbs_spec_in_smodCodeV4
+    (vRa vSavedOld sp sDividendOld x13Old sDivisorOld
+      dividendMaskOld dividendValueOld dividendCarryOld
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word)
+    (base : Word) :
+    EvmAsm.Rv64.cpsTripleWithin 48 base ((base + divisorAbsOff) + 84)
+      (smodCodeV4 base)
+      (((((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ vSavedOld)) **
+        ((.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sDividendOld) **
+         ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_smodDividendTopLimbOff) ↦ₘ
+           dividendTop))) **
+       (.x13 ↦ᵣ x13Old)) **
+       ((.x9 ↦ᵣ sDivisorOld) **
+        ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_smodDivisorTopLimbOff) ↦ₘ
+          divisorTop))) **
+       (((.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ dividendMaskOld) **
+         (.x7 ↦ᵣ dividendValueOld) ** (.x11 ↦ᵣ dividendCarryOld)) **
+        (((sp + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)) ↦ₘ dividendLimb0) **
+         ((sp + EvmAsm.Rv64.signExtend12 (8 : BitVec 12)) ↦ₘ dividendLimb1) **
+         ((sp + EvmAsm.Rv64.signExtend12 (16 : BitVec 12)) ↦ₘ dividendLimb2)))) **
+       (((sp + EvmAsm.Rv64.signExtend12 (32 : BitVec 12)) ↦ₘ divisorLimb0) **
+        ((sp + EvmAsm.Rv64.signExtend12 (40 : BitVec 12)) ↦ₘ divisorLimb1) **
+        ((sp + EvmAsm.Rv64.signExtend12 (48 : BitVec 12)) ↦ₘ divisorLimb2)))
+      (let dividendSign := dividendTop >>> (63 : BitVec 6).toNat
+       let divisorSign := divisorTop >>> (63 : BitVec 6).toNat
+       let dividendMask := (0 : Word) - dividendSign
+       let dividendXored0 := dividendLimb0 ^^^ dividendMask
+       let dividendSum0 := dividendXored0 + dividendSign
+       let dividendCarry0 := if BitVec.ult dividendSum0 dividendSign then (1 : Word) else 0
+       let dividendXored1 := dividendLimb1 ^^^ dividendMask
+       let dividendSum1 := dividendXored1 + dividendCarry0
+       let dividendCarry1 := if BitVec.ult dividendSum1 dividendCarry0 then (1 : Word) else 0
+       let dividendXored2 := dividendLimb2 ^^^ dividendMask
+       let dividendSum2 := dividendXored2 + dividendCarry1
+       let dividendCarry2 := if BitVec.ult dividendSum2 dividendCarry1 then (1 : Word) else 0
+       let dividendXored3 := dividendTop ^^^ dividendMask
+       let dividendSum3 := dividendXored3 + dividendCarry2
+       let divisorMask := (0 : Word) - divisorSign
+       let divisorXored0 := divisorLimb0 ^^^ divisorMask
+       let divisorSum0 := divisorXored0 + divisorSign
+       let divisorCarry0 := if BitVec.ult divisorSum0 divisorSign then (1 : Word) else 0
+       let divisorXored1 := divisorLimb1 ^^^ divisorMask
+       let divisorSum1 := divisorXored1 + divisorCarry0
+       let divisorCarry1 := if BitVec.ult divisorSum1 divisorCarry0 then (1 : Word) else 0
+       let divisorXored2 := divisorLimb2 ^^^ divisorMask
+       let divisorSum2 := divisorXored2 + divisorCarry1
+       let divisorCarry2 := if BitVec.ult divisorSum2 divisorCarry1 then (1 : Word) else 0
+       let divisorXored3 := divisorTop ^^^ divisorMask
+       let divisorSum3 := divisorXored3 + divisorCarry2
+       let divisorCarry3 := if BitVec.ult divisorSum3 divisorCarry2 then (1 : Word) else 0
+       (((((.x1 ↦ᵣ vRa) **
+         (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))) **
+        ((.x8 ↦ᵣ dividendSign) **
+         ((sp + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)) ↦ₘ dividendSum0) **
+         ((sp + EvmAsm.Rv64.signExtend12 (8 : BitVec 12)) ↦ₘ dividendSum1) **
+         ((sp + EvmAsm.Rv64.signExtend12 (16 : BitVec 12)) ↦ₘ dividendSum2) **
+         ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_smodDividendTopLimbOff) ↦ₘ
+           dividendSum3))) **
+        (.x13 ↦ᵣ (dividendSign + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))) **
+        ((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ divisorSign) **
+         (.x10 ↦ᵣ divisorMask) ** (.x7 ↦ᵣ divisorSum3) ** (.x11 ↦ᵣ divisorCarry3) **
+         ((sp + EvmAsm.Rv64.signExtend12 (32 : BitVec 12)) ↦ₘ divisorSum0) **
+         ((sp + EvmAsm.Rv64.signExtend12 (40 : BitVec 12)) ↦ₘ divisorSum1) **
+         ((sp + EvmAsm.Rv64.signExtend12 (48 : BitVec 12)) ↦ₘ divisorSum2) **
+         ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_smodDivisorTopLimbOff) ↦ₘ
+           divisorSum3)))) := by
+  let dividendSign := dividendTop >>> (63 : BitVec 6).toNat
+  let divisorSign := divisorTop >>> (63 : BitVec 6).toNat
+  let dividendMem0 := sp + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)
+  let dividendMem1 := sp + EvmAsm.Rv64.signExtend12 (8 : BitVec 12)
+  let dividendMem2 := sp + EvmAsm.Rv64.signExtend12 (16 : BitVec 12)
+  let dividendMem3 := sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_smodDividendTopLimbOff
+  let divisorMem0 := sp + EvmAsm.Rv64.signExtend12 (32 : BitVec 12)
+  let divisorMem1 := sp + EvmAsm.Rv64.signExtend12 (40 : BitVec 12)
+  let divisorMem2 := sp + EvmAsm.Rv64.signExtend12 (48 : BitVec 12)
+  let divisorMem3 := sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_smodDivisorTopLimbOff
+  let dividendMask := (0 : Word) - dividendSign
+  let dividendXored0 := dividendLimb0 ^^^ dividendMask
+  let dividendSum0 := dividendXored0 + dividendSign
+  let dividendCarry0 := if BitVec.ult dividendSum0 dividendSign then (1 : Word) else 0
+  let dividendXored1 := dividendLimb1 ^^^ dividendMask
+  let dividendSum1 := dividendXored1 + dividendCarry0
+  let dividendCarry1 := if BitVec.ult dividendSum1 dividendCarry0 then (1 : Word) else 0
+  let dividendXored2 := dividendLimb2 ^^^ dividendMask
+  let dividendSum2 := dividendXored2 + dividendCarry1
+  let dividendCarry2 := if BitVec.ult dividendSum2 dividendCarry1 then (1 : Word) else 0
+  let dividendXored3 := dividendTop ^^^ dividendMask
+  let dividendSum3 := dividendXored3 + dividendCarry2
+  let dividendCarry3 := if BitVec.ult dividendSum3 dividendCarry2 then (1 : Word) else 0
+  let divisorMask := (0 : Word) - divisorSign
+  let divisorXored0 := divisorLimb0 ^^^ divisorMask
+  let divisorSum0 := divisorXored0 + divisorSign
+  let divisorCarry0 := if BitVec.ult divisorSum0 divisorSign then (1 : Word) else 0
+  let divisorXored1 := divisorLimb1 ^^^ divisorMask
+  let divisorSum1 := divisorXored1 + divisorCarry0
+  let divisorCarry1 := if BitVec.ult divisorSum1 divisorCarry0 then (1 : Word) else 0
+  let divisorXored2 := divisorLimb2 ^^^ divisorMask
+  let divisorSum2 := divisorXored2 + divisorCarry1
+  let divisorCarry2 := if BitVec.ult divisorSum2 divisorCarry1 then (1 : Word) else 0
+  let divisorXored3 := divisorTop ^^^ divisorMask
+  let divisorSum3 := divisorXored3 + divisorCarry2
+  let divisorCarry3 := if BitVec.ult divisorSum3 divisorCarry2 then (1 : Word) else 0
+  let divisorLower : EvmAsm.Rv64.Assertion :=
+    ((divisorMem0 ↦ₘ divisorLimb0) ** (divisorMem1 ↦ₘ divisorLimb1) **
+     (divisorMem2 ↦ₘ divisorLimb2))
+  let pre : EvmAsm.Rv64.Assertion :=
+    (((((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ vSavedOld)) **
+      ((.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sDividendOld) ** (dividendMem3 ↦ₘ dividendTop))) **
+     (.x13 ↦ᵣ x13Old)) **
+     ((.x9 ↦ᵣ sDivisorOld) ** (divisorMem3 ↦ₘ divisorTop))) **
+     (((.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ dividendMaskOld) **
+       (.x7 ↦ᵣ dividendValueOld) ** (.x11 ↦ᵣ dividendCarryOld)) **
+      ((dividendMem0 ↦ₘ dividendLimb0) **
+       (dividendMem1 ↦ₘ dividendLimb1) **
+       (dividendMem2 ↦ₘ dividendLimb2)))) **
+     divisorLower)
+  let mid : EvmAsm.Rv64.Assertion :=
+    ((((((.x1 ↦ᵣ vRa) **
+      (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))) **
+     ((.x9 ↦ᵣ divisorSign) ** (divisorMem3 ↦ₘ divisorTop))) **
+     (.x13 ↦ᵣ (dividendSign + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))) **
+     ((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ dividendSign) **
+      (.x10 ↦ᵣ dividendMask) ** (.x7 ↦ᵣ dividendSum3) **
+      (.x11 ↦ᵣ dividendCarry3) **
+      (dividendMem0 ↦ₘ dividendSum0) **
+      (dividendMem1 ↦ₘ dividendSum1) **
+      (dividendMem2 ↦ₘ dividendSum2) **
+      (dividendMem3 ↦ₘ dividendSum3))) **
+     divisorLower)
+  let absPre : EvmAsm.Rv64.Assertion :=
+    (((((.x1 ↦ᵣ vRa) **
+      (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))) **
+     ((.x8 ↦ᵣ dividendSign) **
+      (dividendMem0 ↦ₘ dividendSum0) **
+      (dividendMem1 ↦ₘ dividendSum1) **
+      (dividendMem2 ↦ₘ dividendSum2) **
+      (dividendMem3 ↦ₘ dividendSum3))) **
+     (.x13 ↦ᵣ (dividendSign + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))) **
+     ((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ divisorSign) **
+      (.x10 ↦ᵣ dividendMask) ** (.x7 ↦ᵣ dividendSum3) **
+      (.x11 ↦ᵣ dividendCarry3) **
+      (divisorMem0 ↦ₘ divisorLimb0) **
+      (divisorMem1 ↦ₘ divisorLimb1) **
+      (divisorMem2 ↦ₘ divisorLimb2) **
+      (divisorMem3 ↦ₘ divisorTop)))
+  let post : EvmAsm.Rv64.Assertion :=
+    (((((.x1 ↦ᵣ vRa) **
+      (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))) **
+     ((.x8 ↦ᵣ dividendSign) **
+      (dividendMem0 ↦ₘ dividendSum0) **
+      (dividendMem1 ↦ₘ dividendSum1) **
+      (dividendMem2 ↦ₘ dividendSum2) **
+      (dividendMem3 ↦ₘ dividendSum3))) **
+     (.x13 ↦ᵣ (dividendSign + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))) **
+     ((.x0 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ divisorSign) **
+      (.x10 ↦ᵣ divisorMask) ** (.x7 ↦ᵣ divisorSum3) **
+      (.x11 ↦ᵣ divisorCarry3) **
+      (divisorMem0 ↦ₘ divisorSum0) ** (divisorMem1 ↦ₘ divisorSum1) **
+      (divisorMem2 ↦ₘ divisorSum2) ** (divisorMem3 ↦ₘ divisorSum3)))
+  have hPrefix : EvmAsm.Rv64.cpsTripleWithin 27 base (base + divisorAbsOff)
+      (smodCodeV4 base) pre mid := by
+    dsimp [pre, mid, divisorLower, dividendSign, divisorSign, dividendMem0,
+      dividendMem1, dividendMem2, dividendMem3, divisorMem3,
+      EvmAsm.Evm64.evm_smodDividendTopLimbOff,
+      EvmAsm.Evm64.evm_smodDivisorTopLimbOff, dividendMask, dividendXored0,
+      dividendSum0, dividendCarry0, dividendXored1, dividendSum1,
+      dividendCarry1, dividendXored2, dividendSum2, dividendCarry2,
+      dividendXored3, dividendSum3, dividendCarry3]
+    simpa [dividendAbsOff, divisorAbsOff, BitVec.add_assoc] using
+      (EvmAsm.Rv64.cpsTripleWithin_frameR
+        divisorLower
+        (by pcFree)
+        (saveRa_signs_then_dividendAbs_spec_in_smodCodeV4
+          vRa vSavedOld sp sDividendOld x13Old sDivisorOld divisorTop
+          dividendMaskOld dividendValueOld dividendCarryOld
+          dividendLimb0 dividendLimb1 dividendLimb2 dividendTop base))
+  have hAbs : EvmAsm.Rv64.cpsTripleWithin 21 (base + divisorAbsOff)
+      ((base + divisorAbsOff) + 84) (smodCodeV4 base) absPre post := by
+    simpa [absPre, post, divisorMem0, divisorMem1, divisorMem2, divisorMem3,
+      EvmAsm.Evm64.condNegate256BlockPre,
+      EvmAsm.Evm64.condNegate256BlockPost,
+      EvmAsm.Evm64.evm_smodDivisorTopLimbOff, divisorMask, divisorXored0,
+      divisorSum0, divisorCarry0, divisorXored1, divisorSum1, divisorCarry1,
+      divisorXored2, divisorSum2, divisorCarry2, divisorXored3, divisorSum3,
+      divisorCarry3] using
+      EvmAsm.Rv64.cpsTripleWithin_frameL
+        ((((.x1 ↦ᵣ vRa) **
+          (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))) **
+         ((.x8 ↦ᵣ dividendSign) **
+          (dividendMem0 ↦ₘ dividendSum0) **
+          (dividendMem1 ↦ₘ dividendSum1) **
+          (dividendMem2 ↦ₘ dividendSum2) **
+          (dividendMem3 ↦ₘ dividendSum3))) **
+         (.x13 ↦ᵣ (dividendSign + EvmAsm.Rv64.signExtend12 (0 : BitVec 12))))
+        (by pcFree)
+        (divisorAbs_spec_in_smodCodeV4
+          sp divisorSign dividendMask dividendSum3 dividendCarry3
+          divisorLimb0 divisorLimb1 divisorLimb2 divisorTop base)
+  have hSeq := EvmAsm.Rv64.cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by
+      dsimp [mid, absPre, divisorLower] at hp ⊢
+      xperm_hyp hp) hPrefix hAbs
+  simpa [pre, post, dividendSign, divisorSign, dividendMask, dividendXored0,
+    dividendSum0, dividendCarry0, dividendXored1, dividendSum1, dividendCarry1,
+    dividendXored2, dividendSum2, dividendCarry2, dividendXored3, dividendSum3,
+    dividendCarry3, divisorMask, divisorXored0, divisorSum0, divisorCarry0,
+    divisorXored1, divisorSum1, divisorCarry1, divisorXored2, divisorSum2,
+    divisorCarry2, divisorXored3, divisorSum3, divisorCarry3, dividendMem0,
+    dividendMem1, dividendMem2, dividendMem3, divisorMem0, divisorMem1,
+    divisorMem2, divisorMem3] using hSeq
+
+end EvmAsm.Evm64.SMod.Compose


### PR DESCRIPTION
## Summary
- add the SMOD prefix composition through both operand absolute-value blocks
- frame the dividend-abs sequence with divisor low limbs, then compose the divisor abs block
- import the new sequence proof through the SMOD compose umbrella

## Verification
- lake build EvmAsm.Evm64.SMod.Compose.DivisorAbsSequence
- lake build EvmAsm.Evm64.SMod
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- rg -n "DivStackSpecCase|ModStackSpecCase|SDivStackSpecCase|SModStackSpecCase|StackSpecCase|set_option maxRecDepth|set_option maxHeartbeats|sorry|admit" EvmAsm/Evm64/SMod/Compose/DivisorAbsSequence.lean EvmAsm/Evm64/SMod/Compose/Base.lean