### PR TITLE
feat(smod): bridge mod call to dispatch-ready post

### DIFF
--- a/EvmAsm/Evm64/SMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/SMod/Compose/Base.lean
@@ -48,6 +48,7 @@ import EvmAsm.Evm64.SMod.Compose.DivisorSignSequence
 import EvmAsm.Evm64.SMod.Compose.DividendAbsSequence
 import EvmAsm.Evm64.SMod.Compose.DivisorAbsSequence
 import EvmAsm.Evm64.SMod.Compose.ModCallSequence
+import EvmAsm.Evm64.SMod.Compose.ModCallDispatchReadySequence
 
 namespace EvmAsm.Evm64.SMod.Compose
 

--- a/EvmAsm/Evm64/SMod/Compose/ModCallDispatchReadySequence.lean
+++ b/EvmAsm/Evm64/SMod/Compose/ModCallDispatchReadySequence.lean
@@ -1,0 +1,69 @@
+/-
+  EvmAsm.Evm64.SMod.Compose.ModCallDispatchReadySequence
+
+  SMOD wrapper prefix through the JAL into the appended unsigned MOD callable,
+  weakened to the named dispatch-ready postcondition.
+-/
+
+import EvmAsm.Evm64.SMod.Compose.ModCallSequence
+import EvmAsm.Evm64.SMod.Compose.DispatchReadyView
+
+namespace EvmAsm.Evm64.SMod.Compose
+
+open EvmAsm.Rv64.Tactics
+
+theorem saveRa_signs_abs_then_modCall_dispatchReady_spec_in_smodCodeV4
+    (vRa vSavedOld sp sDividendOld x13Old sDivisorOld
+      dividendMaskOld dividendValueOld dividendCarryOld
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word)
+    (v2 v5 v6 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (base : Word) :
+    EvmAsm.Rv64.cpsTripleWithin 49 base (base + wrapperEndOff)
+      (smodCodeV4 base)
+      ((((((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ vSavedOld)) **
+        ((.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sDividendOld) **
+         ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_smodDividendTopLimbOff) ↦ₘ
+           dividendTop))) **
+       (.x13 ↦ᵣ x13Old)) **
+       ((.x9 ↦ᵣ sDivisorOld) **
+        ((sp + EvmAsm.Rv64.signExtend12 EvmAsm.Evm64.evm_smodDivisorTopLimbOff) ↦ₘ
+          divisorTop))) **
+       (((.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ dividendMaskOld) **
+         (.x7 ↦ᵣ dividendValueOld) ** (.x11 ↦ᵣ dividendCarryOld)) **
+        (((sp + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)) ↦ₘ dividendLimb0) **
+         ((sp + EvmAsm.Rv64.signExtend12 (8 : BitVec 12)) ↦ₘ dividendLimb1) **
+         ((sp + EvmAsm.Rv64.signExtend12 (16 : BitVec 12)) ↦ₘ dividendLimb2)))) **
+       (((sp + EvmAsm.Rv64.signExtend12 (32 : BitVec 12)) ↦ₘ divisorLimb0) **
+        ((sp + EvmAsm.Rv64.signExtend12 (40 : BitVec 12)) ↦ₘ divisorLimb1) **
+        ((sp + EvmAsm.Rv64.signExtend12 (48 : BitVec 12)) ↦ₘ divisorLimb2))) **
+       ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
+        EvmAsm.Evm64.divScratchValuesCallNoX1 sp
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0))
+      (saveRaAbsThenModCallDispatchReadyPost vRa sp base
+        dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+        v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0) := by
+  exact EvmAsm.Rv64.cpsTripleWithin_weaken
+    (fun _ hp => hp)
+    (fun h hp => by
+      rw [saveRaAbsThenModCallDispatchReadyPost_unfold_explicit_smod_components]
+      simp only [smodAbsSign, smodAbsMask, smodAbsSum0, smodAbsCarry0,
+        smodAbsSum1, smodAbsCarry1, smodAbsSum2, smodAbsCarry2,
+        smodAbsSum3, smodAbsCarry3]
+      rw [EvmAsm.Rv64.signExtend12_0] at hp ⊢
+      simp at hp ⊢
+      xperm_hyp hp)
+    (saveRa_signs_abs_then_modCall_spec_in_smodCodeV4
+      vRa vSavedOld sp sDividendOld x13Old sDivisorOld
+      dividendMaskOld dividendValueOld dividendCarryOld
+      dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
+      divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
+      v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 base)
+
+end EvmAsm.Evm64.SMod.Compose


### PR DESCRIPTION
## Summary
- add a postcondition-weakened SMOD prefix theorem through the MOD call
- expose the named dispatch-ready post from the explicit MOD-call sequence
- import the new sequence through the SMOD compose umbrella

## Verification
- lake build EvmAsm.Evm64.SMod.Compose.ModCallDispatchReadySequence
- lake build EvmAsm.Evm64.SMod
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- forbidden-pattern scan on touched Lean files