### PR TITLE
feat(stateless): u256_max (PR-K60)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -6128,6 +6128,85 @@ def ziskU256MinProbeUnit : BuildUnit := {
   dataAsm     := ziskU256MinDataSection
 }
 
+/-! ## u256_max -- PR-K60 maximum of two BE u256 buffers
+
+    Direct companion to PR-K59 `u256_min`. Compares two 32-byte
+    big-endian `u256` buffers and copies the larger (or `a` on
+    equality) into `out`. Same byte-walk + inline pick logic as
+    `u256_min` with inverted selection; no separate `u256_lt`
+    dependency.
+
+    Direct use case — EIP-1559 base-fee delta floor:
+
+      base_fee_delta = u256_max(target_fee_delta_div_8,
+                                u256_from_u64(1))
+
+    (Per Python `calculate_base_fee_per_gas`'s `max(..., 1)`
+    when parent.gas_used > parent_gas_target.)
+
+    BE storage convention: byte 0 = MSB, byte 31 = LSB.
+
+    Calling convention:
+      a0 (input)  : u256 a ptr (32 bytes, BE)
+      a1 (input)  : u256 b ptr (32 bytes, BE)
+      a2 (input)  : u256 out ptr (may alias a or b)
+      ra (input)  : return
+      a0 (output) : 0.
+
+    Short-circuits on the first differing byte. Pure register
+    arithmetic + 4 × (ld + sd) chunk copy. Leaf-callable.
+    Aliasing safe. -/
+def u256MaxFunction : String :=
+  "u256_max:\n" ++
+  "  li t0, 0                   # byte index\n" ++
+  "  li t6, 32\n" ++
+  ".Lumax_loop:\n" ++
+  "  beq t0, t6, .Lumax_pick_a  # all bytes equal → return a\n" ++
+  "  add t1, a0, t0\n" ++
+  "  add t2, a1, t0\n" ++
+  "  lbu t3, 0(t1)\n" ++
+  "  lbu t4, 0(t2)\n" ++
+  "  bgtu t3, t4, .Lumax_pick_a # a > b → return a\n" ++
+  "  bltu t3, t4, .Lumax_pick_b # a < b → return b\n" ++
+  "  addi t0, t0, 1\n" ++
+  "  j .Lumax_loop\n" ++
+  ".Lumax_pick_a:\n" ++
+  "  mv t0, a0\n" ++
+  "  j .Lumax_copy\n" ++
+  ".Lumax_pick_b:\n" ++
+  "  mv t0, a1\n" ++
+  ".Lumax_copy:\n" ++
+  "  ld t1,  0(t0); sd t1,  0(a2)\n" ++
+  "  ld t1,  8(t0); sd t1,  8(a2)\n" ++
+  "  ld t1, 16(t0); sd t1, 16(a2)\n" ++
+  "  ld t1, 24(t0); sd t1, 24(a2)\n" ++
+  "  li a0, 0\n" ++
+  "  ret"
+
+/-- `zisk_u256_max`: probe BuildUnit. Reads (32B a, 32B b) from
+    host input, writes the 32B max into OUTPUT. -/
+def ziskU256MaxPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a3, 0x40000000\n" ++
+  "  addi a0, a3, 8              # a ptr\n" ++
+  "  addi a1, a3, 40             # b ptr\n" ++
+  "  li a2, 0xa0010000           # out ptr at OUTPUT\n" ++
+  "  jal ra, u256_max\n" ++
+  "  j .Lumax_pdone\n" ++
+  u256MaxFunction ++ "\n" ++
+  ".Lumax_pdone:"
+
+def ziskU256MaxDataSection : String :=
+  ".section .data\n" ++
+  "umax_pad:\n" ++
+  "  .zero 8"
+
+def ziskU256MaxProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskU256MaxPrologue
+  dataAsm     := ziskU256MaxDataSection
+}
+
 
 /-! ## u256_eq -- PR-K53 equality companion to PR-K50 u256_lt
 
@@ -8814,6 +8893,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_u256_to_u64_be"       => some ziskU256ToU64BeProbeUnit
   | "zisk_u256_is_zero"         => some ziskU256IsZeroProbeUnit
   | "zisk_u256_min"             => some ziskU256MinProbeUnit
+  | "zisk_u256_max"             => some ziskU256MaxProbeUnit
   | "zisk_tx_type_dispatch"     => some ziskTxTypeDispatchProbeUnit
   | "zisk_tx_eip2930_decode"    => some ziskTxEip2930DecodeProbeUnit
   | "zisk_tx_eip7702_decode"    => some ziskTxEip7702DecodeProbeUnit
@@ -8887,6 +8967,7 @@ def knownProgramNames : List String :=
    "zisk_u256_to_u64_be",
    "zisk_u256_is_zero",
    "zisk_u256_min",
+   "zisk_u256_max",
    "zisk_tx_type_dispatch",
    "zisk_tx_eip2930_decode",
    "zisk_tx_eip7702_decode",

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **82**
-- ziskemu round-trip scripts: **75** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **83**
+- ziskemu round-trip scripts: **76** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-u256-max-check.sh
+++ b/scripts/codegen-zisk-u256-max-check.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# codegen-zisk-u256-max-check.sh -- PR-K60.
+#
+# Maximum of two 32-byte BE u256 buffers.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_u256_max ELF"
+lake exe codegen --program zisk_u256_max --halt linux93 \
+  -o gen-out/zisk_u256_max
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <a_dec> <b_dec>
+run_case() {
+  local name="$1" a="$2" b="$3"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_u256_max_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_u256_max_${name}.output"
+  local exp_file="$REPO_ROOT/gen-out/zisk_u256_max_${name}.expected"
+
+  python3 -c "
+import sys
+a = $a
+b = $b
+out  = a.to_bytes(32, 'big')
+out += b.to_bytes(32, 'big')
+sys.stdout.buffer.write(out)
+" > "$in_file"
+
+  python3 -c "
+import sys
+a = $a
+b = $b
+# On equality, asm picks a; on inequality, the larger
+mx = a if a >= b else b
+sys.stdout.buffer.write(mx.to_bytes(32, 'big'))
+" > "$exp_file"
+
+  "$ZISKEMU" -e gen-out/zisk_u256_max.elf \
+    -i "$in_file" -o "$out_file" -n 500000 \
+    >"$REPO_ROOT/gen-out/zisk_u256_max_${name}.emu.log" 2>&1 || true
+
+  local actual; actual="$(xxd -p -l 32 "$out_file" | tr -d '\n')"
+  local expected; expected="$(xxd -p -l 32 "$exp_file" | tr -d '\n')"
+
+  if [[ "$actual" == "$expected" ]]; then
+    local mx; mx="$(python3 -c "print($a if $a >= $b else $b)")"
+    printf "  %-30s OK   max=%s\n" "$name" "${mx:0:24}..."
+    return 0
+  else
+    printf "  %-30s FAIL\n    expected: %s\n    actual:   %s\n" \
+      "$name" "$expected" "$actual"
+    return 1
+  fi
+}
+
+MAX=115792089237316195423570985008687907853269984665640564039457584007913129639935
+H64=$(python3 -c "print(1 << 64)")
+H128=$(python3 -c "print(1 << 128)")
+ONE_GWEI=$(python3 -c "print(10**9)")
+HUNDRED_GWEI=$(python3 -c "print(100 * 10**9)")
+
+FAILED=0
+# Equality (asm picks a)
+run_case "zero_eq_zero"          0       0       || FAILED=1
+run_case "one_eq_one"            1       1       || FAILED=1
+run_case "max_eq_max"            "$MAX"  "$MAX"  || FAILED=1
+# a < b → max = b
+run_case "zero_lt_one"           0       1       || FAILED=1
+run_case "one_lt_two"            1       2       || FAILED=1
+run_case "zero_lt_max"           0       "$MAX"  || FAILED=1
+# a > b → max = a
+run_case "one_gt_zero"           1       0       || FAILED=1
+run_case "max_gt_zero"           "$MAX"  0       || FAILED=1
+run_case "two_gt_one"            2       1       || FAILED=1
+# MSB-only diff
+A_TOP=$(python3 -c "print(0x10 << (31*8))")
+B_TOP=$(python3 -c "print(0x20 << (31*8))")
+run_case "msb_a_lt_b"            "$A_TOP" "$B_TOP" || FAILED=1
+run_case "msb_a_gt_b"            "$B_TOP" "$A_TOP" || FAILED=1
+# LSB-only diff
+run_case "lsb_a_lt_b"            0       1        || FAILED=1
+# Mid-byte diff
+A_MID=$(python3 -c "print(1 << 80)")
+B_MID=$(python3 -c "print((1 << 80) + 1)")
+run_case "mid_a_lt_b"            "$A_MID" "$B_MID" || FAILED=1
+# Realistic: max(delta, 1) for EIP-1559 base-fee floor
+ONE=1
+DELTA_BIG=$(python3 -c "print(10**6)")
+run_case "max_delta_one_normal"  "$DELTA_BIG" "$ONE"  || FAILED=1   # delta dominates
+run_case "max_delta_one_zero"    0            "$ONE"  || FAILED=1   # floor wins (1 > 0)
+# 128-bit boundary
+run_case "h128_vs_h128m1"        "$H128" $(python3 -c "print((1<<128) - 1)") || FAILED=1
+# Crossing 64-bit boundary
+run_case "h64_vs_h64p1"          "$H64"  $(python3 -c "print((1<<64) + 1)")  || FAILED=1
+# Realistic priority-fee shape (lower-bounded)
+run_case "max_gwei_compare"      "$ONE_GWEI" "$HUNDRED_GWEI"   || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: u256_max matches Python's max() across 18 fixtures"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Maximum of two 32-byte BE `u256` buffers. Direct companion to PR-K59 `u256_min` (#5594).

Same byte-walk + inline pick logic as K59 with inverted selection; no separate `u256_lt` dependency.

## Direct use case — EIP-1559 base-fee delta floor

```
base_fee_delta = u256_max(target_fee_delta_div_8, u256_from_u64(1))
```

(Per Python `calculate_base_fee_per_gas`'s `max(..., 1)` clause when `parent.gas_used > parent_gas_target`.)

Pure register arithmetic + 4 × (`ld` + `sd`) chunk copy. Leaf-callable. Aliasing safe.

## Test plan

- [x] `lake build` clean
- [x] `scripts/codegen-zisk-u256-max-check.sh` passes 18 fixtures:
  - Equalities (asm picks `a`)
  - Strict ordering both ways
  - MSB-only diff (both directions), LSB-only diff, mid-byte diff
  - Two realistic `max(delta, 1)` shapes (normal + floor wins)
  - The 128-bit boundary, the 64-bit boundary, gwei vs gwei

🤖 Generated with [Claude Code](https://claude.com/claude-code)