### PR TITLE
feat(divmod): add v4 full code bundles

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose.lean
+++ b/EvmAsm/Evm64/DivMod/Compose.lean
@@ -20,6 +20,7 @@
 -- ModFullPathN{2,1} cover ModPhaseBn21.
 import EvmAsm.Evm64.DivMod.Compose.Div128
 import EvmAsm.Evm64.DivMod.Compose.Div128V4
+import EvmAsm.Evm64.DivMod.Compose.V4Code
 import EvmAsm.Evm64.DivMod.Compose.FullPath
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2

--- a/EvmAsm/Evm64/DivMod/Compose/V4Code.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/V4Code.lean
@@ -1,0 +1,53 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.V4Code
+
+  Full DIV/MOD CodeReq bundles for the v4 div128 migration.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.Base
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- v4 DIV code bundle matching the current `evm_div` program body. This keeps
+    the legacy `divCode` surface stable while downstream migration proofs move
+    to the full Knuth-D `divK_div128_v4` block. -/
+abbrev divCode_v4 (base : Word) : CodeReq :=
+  CodeReq.unionAll [
+    CodeReq.ofProg  base                  (divK_phaseA 1020),     -- block 0
+    CodeReq.ofProg (base + phaseBOff)     divK_phaseB,            -- block 1
+    CodeReq.ofProg (base + clzOff)        divK_clz,               -- block 2
+    CodeReq.ofProg (base + phaseC2Off)    (divK_phaseC2 172),     -- block 3
+    CodeReq.ofProg (base + normBOff)      divK_normB,             -- block 4
+    CodeReq.ofProg (base + normAOff)      (divK_normA 40),        -- block 5
+    CodeReq.ofProg (base + copyAUOff)     divK_copyAU,            -- block 6
+    CodeReq.ofProg (base + loopSetupOff)  (divK_loopSetup 464),   -- block 7
+    CodeReq.ofProg (base + loopBodyOff)   (divK_loopBody 560 7736),-- block 8
+    CodeReq.ofProg (base + denormOff)     divK_denorm,            -- block 9
+    CodeReq.ofProg (base + epilogueOff)   (divK_div_epilogue 24), -- block 10
+    CodeReq.ofProg (base + zeroPathOff)   divK_zeroPath,          -- block 11
+    CodeReq.ofProg (base + nopOff)        (ADDI .x0 .x0 0),       -- block 12
+    CodeReq.ofProg (base + div128Off)     divK_div128_v4          -- block 13
+  ]
+
+/-- v4 MOD code bundle matching the current `evm_mod` program body. -/
+abbrev modCode_v4 (base : Word) : CodeReq :=
+  CodeReq.unionAll [
+    CodeReq.ofProg  base                  (divK_phaseA 1020),
+    CodeReq.ofProg (base + phaseBOff)     divK_phaseB,
+    CodeReq.ofProg (base + clzOff)        divK_clz,
+    CodeReq.ofProg (base + phaseC2Off)    (divK_phaseC2 172),
+    CodeReq.ofProg (base + normBOff)      divK_normB,
+    CodeReq.ofProg (base + normAOff)      (divK_normA 40),
+    CodeReq.ofProg (base + copyAUOff)     divK_copyAU,
+    CodeReq.ofProg (base + loopSetupOff)  (divK_loopSetup 464),
+    CodeReq.ofProg (base + loopBodyOff)   (divK_loopBody 560 7736),
+    CodeReq.ofProg (base + denormOff)     divK_denorm,
+    CodeReq.ofProg (base + epilogueOff)   (divK_mod_epilogue 24),
+    CodeReq.ofProg (base + zeroPathOff)   divK_zeroPath,
+    CodeReq.ofProg (base + nopOff)        (ADDI .x0 .x0 0),
+    CodeReq.ofProg (base + div128Off)     divK_div128_v4
+  ]
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add split Compose/V4Code.lean with full divCode_v4 and modCode_v4 CodeReq bundles
- keep legacy divCode / modCode stable while downstream proofs migrate to the current divK_div128_v4 program block
- import the new v4 bundle surface through the DivMod compose umbrella

## Verification
- lake build EvmAsm.Evm64.DivMod.Compose.V4Code
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- scripts/check-file-size.sh
- scripts/check-file-size.sh --report
- scripts/check-unimported.sh
- forbidden-pattern scan on touched Lean files