### PR TITLE
feat(divmod): bridge v4 noNop code to full bundles

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/V4Code.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/V4Code.lean
@@ -4,7 +4,7 @@
   Full DIV/MOD CodeReq bundles for the v4 div128 migration.
 -/
 
-import EvmAsm.Evm64.DivMod.Compose.Base
+import EvmAsm.Evm64.DivMod.Compose.V4NoNop
 
 open EvmAsm.Rv64.Tactics
 
@@ -71,5 +71,119 @@ theorem div128_v4_ofProg_sub_modCode_v4 {base : Word} :
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
   skipBlock
   exact CodeReq.union_mono_left
+
+-- Per-block bridge from the no-NOP v4 DIV surface to the full DIV v4 bundle.
+private theorem noNop_v4_b0_div {b : Word} :
+    ∀ a i, (CodeReq.ofProg b (divK_phaseA 1020)) a = some i → (divCode_v4 b) a = some i := by
+  unfold divCode_v4; simp only [CodeReq.unionAll_cons]; exact CodeReq.union_mono_left
+private theorem noNop_v4_b1_div {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + phaseBOff) divK_phaseB) a = some i → (divCode_v4 b) a = some i := by
+  unfold divCode_v4; simp only [CodeReq.unionAll_cons]; skipBlock; exact CodeReq.union_mono_left
+private theorem noNop_v4_b2_div {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + clzOff) divK_clz) a = some i → (divCode_v4 b) a = some i := by
+  unfold divCode_v4; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; exact CodeReq.union_mono_left
+private theorem noNop_v4_b3_div {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + phaseC2Off) (divK_phaseC2 172)) a = some i → (divCode_v4 b) a = some i := by
+  unfold divCode_v4; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
+private theorem noNop_v4_b4_div {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + normBOff) divK_normB) a = some i → (divCode_v4 b) a = some i := by
+  unfold divCode_v4; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
+private theorem noNop_v4_b5_div {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + normAOff) (divK_normA 40)) a = some i → (divCode_v4 b) a = some i := by
+  unfold divCode_v4; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
+private theorem noNop_v4_b6_div {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + copyAUOff) divK_copyAU) a = some i → (divCode_v4 b) a = some i := by
+  unfold divCode_v4; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
+private theorem noNop_v4_b7_div {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + loopSetupOff) (divK_loopSetup 464)) a = some i → (divCode_v4 b) a = some i := by
+  unfold divCode_v4; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
+private theorem noNop_v4_b8_div {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + loopBodyOff) (divK_loopBody 560 7736)) a = some i → (divCode_v4 b) a = some i := by
+  unfold divCode_v4; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
+private theorem noNop_v4_b9_div {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + denormOff) divK_denorm) a = some i → (divCode_v4 b) a = some i := by
+  unfold divCode_v4; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
+private theorem noNop_v4_b10_div {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + epilogueOff) (divK_div_epilogue 24)) a = some i → (divCode_v4 b) a = some i := by
+  unfold divCode_v4; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
+private theorem noNop_v4_b11_div {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + zeroPathOff) divK_zeroPath) a = some i → (divCode_v4 b) a = some i := by
+  unfold divCode_v4; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
+
+/-- The DIV no-NOP v4 surface is included in the full DIV v4 code bundle. -/
+theorem divCode_noNop_v4_sub_divCode_v4 {base : Word} :
+    ∀ a i, (divCode_noNop_v4 base) a = some i → (divCode_v4 base) a = some i := by
+  unfold divCode_noNop_v4; simp only [CodeReq.unionAll_cons]
+  exact CodeReq.union_split_mono noNop_v4_b0_div
+    (CodeReq.union_split_mono noNop_v4_b1_div
+    (CodeReq.union_split_mono noNop_v4_b2_div
+    (CodeReq.union_split_mono noNop_v4_b3_div
+    (CodeReq.union_split_mono noNop_v4_b4_div
+    (CodeReq.union_split_mono noNop_v4_b5_div
+    (CodeReq.union_split_mono noNop_v4_b6_div
+    (CodeReq.union_split_mono noNop_v4_b7_div
+    (CodeReq.union_split_mono noNop_v4_b8_div
+    (CodeReq.union_split_mono noNop_v4_b9_div
+    (CodeReq.union_split_mono noNop_v4_b10_div
+    (CodeReq.union_split_mono noNop_v4_b11_div
+    (CodeReq.union_split_mono div128_v4_ofProg_sub_divCode_v4
+    (fun _ _ h => by simp [CodeReq.unionAll_nil, CodeReq.empty] at h)))))))))))))
+
+-- Per-block bridge from the no-NOP v4 MOD surface to the full MOD v4 bundle.
+private theorem noNop_v4_b0_mod {b : Word} :
+    ∀ a i, (CodeReq.ofProg b (divK_phaseA 1020)) a = some i → (modCode_v4 b) a = some i := by
+  unfold modCode_v4; simp only [CodeReq.unionAll_cons]; exact CodeReq.union_mono_left
+private theorem noNop_v4_b1_mod {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + phaseBOff) divK_phaseB) a = some i → (modCode_v4 b) a = some i := by
+  unfold modCode_v4; simp only [CodeReq.unionAll_cons]; skipBlock; exact CodeReq.union_mono_left
+private theorem noNop_v4_b2_mod {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + clzOff) divK_clz) a = some i → (modCode_v4 b) a = some i := by
+  unfold modCode_v4; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; exact CodeReq.union_mono_left
+private theorem noNop_v4_b3_mod {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + phaseC2Off) (divK_phaseC2 172)) a = some i → (modCode_v4 b) a = some i := by
+  unfold modCode_v4; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
+private theorem noNop_v4_b4_mod {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + normBOff) divK_normB) a = some i → (modCode_v4 b) a = some i := by
+  unfold modCode_v4; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
+private theorem noNop_v4_b5_mod {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + normAOff) (divK_normA 40)) a = some i → (modCode_v4 b) a = some i := by
+  unfold modCode_v4; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
+private theorem noNop_v4_b6_mod {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + copyAUOff) divK_copyAU) a = some i → (modCode_v4 b) a = some i := by
+  unfold modCode_v4; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
+private theorem noNop_v4_b7_mod {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + loopSetupOff) (divK_loopSetup 464)) a = some i → (modCode_v4 b) a = some i := by
+  unfold modCode_v4; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
+private theorem noNop_v4_b8_mod {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + loopBodyOff) (divK_loopBody 560 7736)) a = some i → (modCode_v4 b) a = some i := by
+  unfold modCode_v4; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
+private theorem noNop_v4_b9_mod {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + denormOff) divK_denorm) a = some i → (modCode_v4 b) a = some i := by
+  unfold modCode_v4; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
+private theorem noNop_v4_b10_mod {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + epilogueOff) (divK_mod_epilogue 24)) a = some i → (modCode_v4 b) a = some i := by
+  unfold modCode_v4; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
+private theorem noNop_v4_b11_mod {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + zeroPathOff) divK_zeroPath) a = some i → (modCode_v4 b) a = some i := by
+  unfold modCode_v4; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
+
+/-- The MOD no-NOP v4 surface is included in the full MOD v4 code bundle. -/
+theorem modCode_noNop_v4_sub_modCode_v4 {base : Word} :
+    ∀ a i, (modCode_noNop_v4 base) a = some i → (modCode_v4 base) a = some i := by
+  unfold modCode_noNop_v4; simp only [CodeReq.unionAll_cons]
+  exact CodeReq.union_split_mono noNop_v4_b0_mod
+    (CodeReq.union_split_mono noNop_v4_b1_mod
+    (CodeReq.union_split_mono noNop_v4_b2_mod
+    (CodeReq.union_split_mono noNop_v4_b3_mod
+    (CodeReq.union_split_mono noNop_v4_b4_mod
+    (CodeReq.union_split_mono noNop_v4_b5_mod
+    (CodeReq.union_split_mono noNop_v4_b6_mod
+    (CodeReq.union_split_mono noNop_v4_b7_mod
+    (CodeReq.union_split_mono noNop_v4_b8_mod
+    (CodeReq.union_split_mono noNop_v4_b9_mod
+    (CodeReq.union_split_mono noNop_v4_b10_mod
+    (CodeReq.union_split_mono noNop_v4_b11_mod
+    (CodeReq.union_split_mono div128_v4_ofProg_sub_modCode_v4
+    (fun _ _ h => by simp [CodeReq.unionAll_nil, CodeReq.empty] at h)))))))))))))
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- import the v4 no-NOP code surface into V4Code
- add CodeReq monotonicity lemmas from divCode_noNop_v4 to divCode_v4 and from modCode_noNop_v4 to modCode_v4
- keep the adapter separate from legacy divCode/modCode so downstream v4 consumers can move from no-NOP proofs to full current evm_div/evm_mod bundles

## Verification
- lake build EvmAsm.Evm64.DivMod.Compose.V4Code
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- scripts/check-file-size.sh
- scripts/check-file-size.sh --report
- scripts/check-unimported.sh
- rg forbidden scan on EvmAsm/Evm64/DivMod/Compose/V4Code.lean