### PR TITLE
feat(divmod): add v4 full-code cps lifts

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/V4Code.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/V4Code.lean
@@ -129,6 +129,13 @@ theorem divCode_noNop_v4_sub_divCode_v4 {base : Word} :
     (CodeReq.union_split_mono div128_v4_ofProg_sub_divCode_v4
     (fun _ _ h => by simp [CodeReq.unionAll_nil, CodeReq.empty] at h)))))))))))))
 
+/-- Lift a DIV proof over the no-NOP v4 code surface to the full v4 bundle. -/
+theorem cpsTripleWithin_divCode_noNop_v4_to_divCode_v4
+    {nSteps : Nat} {entry exit_ base : Word} {P Q : Assertion}
+    (h : cpsTripleWithin nSteps entry exit_ (divCode_noNop_v4 base) P Q) :
+    cpsTripleWithin nSteps entry exit_ (divCode_v4 base) P Q := by
+  exact cpsTripleWithin_extend_code (hmono := divCode_noNop_v4_sub_divCode_v4) h
+
 -- Per-block bridge from the no-NOP v4 MOD surface to the full MOD v4 bundle.
 private theorem noNop_v4_b0_mod {b : Word} :
     ∀ a i, (CodeReq.ofProg b (divK_phaseA 1020)) a = some i → (modCode_v4 b) a = some i := by
@@ -185,5 +192,12 @@ theorem modCode_noNop_v4_sub_modCode_v4 {base : Word} :
     (CodeReq.union_split_mono noNop_v4_b11_mod
     (CodeReq.union_split_mono div128_v4_ofProg_sub_modCode_v4
     (fun _ _ h => by simp [CodeReq.unionAll_nil, CodeReq.empty] at h)))))))))))))
+
+/-- Lift a MOD proof over the no-NOP v4 code surface to the full v4 bundle. -/
+theorem cpsTripleWithin_modCode_noNop_v4_to_modCode_v4
+    {nSteps : Nat} {entry exit_ base : Word} {P Q : Assertion}
+    (h : cpsTripleWithin nSteps entry exit_ (modCode_noNop_v4 base) P Q) :
+    cpsTripleWithin nSteps entry exit_ (modCode_v4 base) P Q := by
+  exact cpsTripleWithin_extend_code (hmono := modCode_noNop_v4_sub_modCode_v4) h
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add public cpsTripleWithin lifts from divCode_noNop_v4 to divCode_v4 and from modCode_noNop_v4 to modCode_v4
- reuse the CodeReq monotonicity bridges from the previous stacked PR so downstream consumers can migrate by applying a named adapter

## Verification
- lake build EvmAsm.Evm64.DivMod.Compose.V4Code
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- scripts/check-file-size.sh
- scripts/check-file-size.sh --report
- scripts/check-unimported.sh
- rg forbidden scan on EvmAsm/Evm64/DivMod/Compose/V4Code.lean