### PR TITLE
feat(divmod): add v4 full-code path prefix

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose.lean
+++ b/EvmAsm/Evm64/DivMod/Compose.lean
@@ -28,6 +28,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN1
 import EvmAsm.Evm64.DivMod.Compose.PhaseABNoNop
 import EvmAsm.Evm64.DivMod.Compose.PhaseABV4NoNop
 import EvmAsm.Evm64.DivMod.Compose.FullPathV4NoNop
+import EvmAsm.Evm64.DivMod.Compose.FullPathV4
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1NoNop
 import EvmAsm.Evm64.DivMod.Compose.ModFullPath
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN3

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathV4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathV4.lean
@@ -1,0 +1,35 @@
+import EvmAsm.Evm64.DivMod.Compose.FullPathV4NoNop
+import EvmAsm.Evm64.DivMod.Compose.V4Code
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- DIV PhaseAB(n=1) + CLZ over the full `divCode_v4` bundle. -/
+theorem evm_div_phaseAB_n1_clz_spec_v4 (sp base : Word)
+    (b0 b1 b2 b3 v5 v6 v7 v10 : Word)
+    (q0 q1 q2 q3 u5 u6 u7 nMem : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1z : b1 = 0) :
+    cpsTripleWithin (8 + 21 + 24) base (base + phaseC2Off) (divCode_v4 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem))
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (clzResult b0).2) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ (clzResult b0).1) ** (.x7 ↦ᵣ (clzResult b0).2 >>> (63 : Nat)) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (1 : Word))) := by
+  exact cpsTripleWithin_divCode_noNop_v4_to_divCode_v4
+    (evm_div_phaseAB_n1_clz_spec_v4_noNop sp base b0 b1 b2 b3
+      v5 v6 v7 v10 q0 q1 q2 q3 u5 u6 u7 nMem hbnz hb3z hb2z hb1z)
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add Compose.FullPathV4 as the first full divCode_v4 consumer wrapper
- lift the existing n=1 PhaseAB+CLZ v4 no-NOP proof to the full divCode_v4 bundle via the public code-lift helper
- import the new module from the DivMod Compose umbrella

## Verification
- lake build EvmAsm.Evm64.DivMod.Compose.FullPathV4
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- scripts/check-file-size.sh
- scripts/check-file-size.sh --report
- scripts/check-unimported.sh
- rg forbidden scan on EvmAsm/Evm64/DivMod/Compose/FullPathV4.lean EvmAsm/Evm64/DivMod/Compose.lean