### PR TITLE
feat(stateless): u256_div_u64_be (PR-K61)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -6207,6 +6207,113 @@ def ziskU256MaxProbeUnit : BuildUnit := {
   dataAsm     := ziskU256MaxDataSection
 }
 
+/-! ## u256_div_u64_be -- PR-K61 u256 / u64 byte-by-byte long division
+
+    Compute `(quotient, remainder)` where
+    `src = quotient * b + remainder` with `0 <= remainder < b`.
+    Stores the 32-byte BE quotient at `out` and returns the
+    u64 remainder.
+
+    Direct use case — EIP-1559 base-fee formula:
+
+      parent_gas_target  = parent.gas_limit / 2   (b = 2)
+      target_fee_delta   = parent_fee_gas_delta / parent_gas_target  (b ≤ 2^30)
+      base_fee_per_gas_delta = target_fee_delta / BASE_FEE_MAX_CHANGE_DENOMINATOR  (b = 8)
+
+    All three divisors fit far inside the safe range.
+
+    ## Precondition: divisor ≤ 2^56
+
+    The byte-by-byte algorithm maintains `carry < b` across
+    iterations. Each step computes `num = (carry << 8) | a[i]`.
+    For `num` to fit in `u64` we need `carry << 8 < 2^64`, i.e.
+    `carry < 2^56`. Since `carry < b`, this is satisfied iff
+    `b ≤ 2^56`. The function does NOT check this precondition;
+    passing `b > 2^56` produces garbage but no crash.
+
+    The precondition still admits a 56-bit divisor (≈ `7.2e16`),
+    which covers every Ethereum-state-related divisor:
+
+      - Gas limits / targets:  < 2^30
+      - EIP-1559 denominator:  = 8
+      - Withdrawal counts:     < 2^32
+      - Per-block tx counts:   < 2^20
+
+    For larger divisors, a future PR can ship a bit-by-bit
+    long-division helper supporting `b ≤ 2^63`.
+
+    Also: caller must pass `b > 0`. Passing `b == 0` invokes
+    RV64's `divu`-by-zero behavior (quotient = all-1s, remainder
+    = dividend) — not a crash, but the output is meaningless.
+
+    BE storage convention: byte 0 = MSB, byte 31 = LSB.
+
+    Calling convention:
+      a0 (input)  : u256 src ptr (32 bytes, BE)
+      a1 (input)  : u64 b (0 < b ≤ 2^56)
+      a2 (input)  : u256 out ptr (32 bytes, BE; may alias src)
+      ra (input)  : return
+      a0 (output) : u64 remainder.
+
+    Aliasing safe: each iteration reads `src[i]` then writes
+    `out[i]`; subsequent iterations advance to `src[i+1]`. -/
+def u256DivU64BeFunction : String :=
+  "u256_div_u64_be:\n" ++
+  "  li t0, 0                   # carry (< b)\n" ++
+  "  li t1, 0                   # byte index (MSB → LSB)\n" ++
+  ".Lu256d_loop:\n" ++
+  "  li t2, 32\n" ++
+  "  beq t1, t2, .Lu256d_done\n" ++
+  "  add t3, a0, t1\n" ++
+  "  lbu t4, 0(t3)              # src[i]\n" ++
+  "  slli t5, t0, 8\n" ++
+  "  or t5, t5, t4              # num = (carry << 8) | src[i]\n" ++
+  "  divu t6, t5, a1            # q_byte = num / b  (< 256)\n" ++
+  "  remu t0, t5, a1            # new carry = num mod b\n" ++
+  "  add t3, a2, t1\n" ++
+  "  sb t6, 0(t3)               # out[i] = q_byte (low 8 bits)\n" ++
+  "  addi t1, t1, 1\n" ++
+  "  j .Lu256d_loop\n" ++
+  ".Lu256d_done:\n" ++
+  "  mv a0, t0                  # remainder\n" ++
+  "  ret"
+
+/-- `zisk_u256_div_u64_be`: probe BuildUnit. Reads (32B BE src,
+    8B LE b) from host input, writes (u64 remainder, 32B BE
+    quotient) to OUTPUT (40 bytes total). -/
+def ziskU256DivU64BePrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a3, 0x40000000\n" ++
+  "  addi a0, a3, 8              # src ptr (32B BE)\n" ++
+  "  ld a1, 40(a3)               # b (u64 LE)\n" ++
+  "  li a2, 0xa0010008           # out ptr at OUTPUT + 8\n" ++
+  "  # Pre-zero 32 output bytes (defensive).\n" ++
+  "  mv t0, a2; li t1, 4\n" ++
+  ".Lu256d_zout:\n" ++
+  "  beqz t1, .Lu256d_zout_done\n" ++
+  "  sd zero, 0(t0)\n" ++
+  "  addi t0, t0, 8\n" ++
+  "  addi t1, t1, -1\n" ++
+  "  j .Lu256d_zout\n" ++
+  ".Lu256d_zout_done:\n" ++
+  "  jal ra, u256_div_u64_be\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)                # remainder\n" ++
+  "  j .Lu256d_pdone\n" ++
+  u256DivU64BeFunction ++ "\n" ++
+  ".Lu256d_pdone:"
+
+def ziskU256DivU64BeDataSection : String :=
+  ".section .data\n" ++
+  "u256d_pad:\n" ++
+  "  .zero 8"
+
+def ziskU256DivU64BeProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskU256DivU64BePrologue
+  dataAsm     := ziskU256DivU64BeDataSection
+}
+
 
 /-! ## u256_eq -- PR-K53 equality companion to PR-K50 u256_lt
 
@@ -8894,6 +9001,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_u256_is_zero"         => some ziskU256IsZeroProbeUnit
   | "zisk_u256_min"             => some ziskU256MinProbeUnit
   | "zisk_u256_max"             => some ziskU256MaxProbeUnit
+  | "zisk_u256_div_u64_be"      => some ziskU256DivU64BeProbeUnit
   | "zisk_tx_type_dispatch"     => some ziskTxTypeDispatchProbeUnit
   | "zisk_tx_eip2930_decode"    => some ziskTxEip2930DecodeProbeUnit
   | "zisk_tx_eip7702_decode"    => some ziskTxEip7702DecodeProbeUnit
@@ -8968,6 +9076,7 @@ def knownProgramNames : List String :=
    "zisk_u256_is_zero",
    "zisk_u256_min",
    "zisk_u256_max",
+   "zisk_u256_div_u64_be",
    "zisk_tx_type_dispatch",
    "zisk_tx_eip2930_decode",
    "zisk_tx_eip7702_decode",

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **83**
-- ziskemu round-trip scripts: **76** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **84**
+- ziskemu round-trip scripts: **77** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-u256-div-u64-be-check.sh
+++ b/scripts/codegen-zisk-u256-div-u64-be-check.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# codegen-zisk-u256-div-u64-be-check.sh -- PR-K61.
+#
+# u256 / u64 long division on a BE buffer. b ≤ 2^56.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_u256_div_u64_be ELF"
+lake exe codegen --program zisk_u256_div_u64_be --halt linux93 \
+  -o gen-out/zisk_u256_div_u64_be
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <a_dec> <b_dec>
+run_case() {
+  local name="$1" a="$2" b="$3"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_u256_div_u64_be_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_u256_div_u64_be_${name}.output"
+  local exp_file="$REPO_ROOT/gen-out/zisk_u256_div_u64_be_${name}.expected"
+
+  python3 -c "
+import struct, sys
+a = $a
+b = $b
+with open(sys.argv[1], 'wb') as f:
+    f.write(a.to_bytes(32, 'big'))
+    f.write(struct.pack('<Q', b))
+
+q, r = divmod(a, b)
+with open(sys.argv[2], 'wb') as f:
+    f.write(struct.pack('<Q', r))
+    f.write(q.to_bytes(32, 'big'))
+" "$in_file" "$exp_file"
+
+  "$ZISKEMU" -e gen-out/zisk_u256_div_u64_be.elf \
+    -i "$in_file" -o "$out_file" -n 500000 \
+    >"$REPO_ROOT/gen-out/zisk_u256_div_u64_be_${name}.emu.log" 2>&1 || true
+
+  local exp_size; exp_size="$(stat -c%s "$exp_file")"
+  local actual expected
+  actual="$(xxd -p -l "$exp_size" "$out_file" 2>/dev/null | tr -d '\n')"
+  expected="$(xxd -p -l "$exp_size" "$exp_file" 2>/dev/null | tr -d '\n')"
+
+  if [[ "$actual" == "$expected" ]]; then
+    local q r; q="$(python3 -c "print($a // $b)")"; r="$(python3 -c "print($a % $b)")"
+    printf "  %-30s OK   q=%s r=%d\n" "$name" "${q:0:16}..." "$r"
+    return 0
+  else
+    printf "  %-30s FAIL\n    expected: %s\n    actual:   %s\n" \
+      "$name" "$expected" "$actual"
+    return 1
+  fi
+}
+
+MAX256=115792089237316195423570985008687907853269984665640564039457584007913129639935
+ONE_ETH=$(python3 -c "print(10**18)")
+H40=$(python3 -c "print(1 << 40)")
+H56=$(python3 -c "print(1 << 56)")  # Max allowed b
+
+FAILED=0
+# Divide by 1: q = a, r = 0
+run_case "div_by_one"            "$MAX256"  1          || FAILED=1
+run_case "div_by_one_zero"       0          1          || FAILED=1
+# Divide by 2 (gas_target denominator)
+run_case "div_by_two_max"        "$MAX256"  2          || FAILED=1
+run_case "div_by_two_odd"        $(python3 -c "print((1<<256) - 1)")  2  || FAILED=1
+run_case "div_by_two_eth"        "$ONE_ETH" 2          || FAILED=1
+# Divide by 8 (BASE_FEE_MAX_CHANGE_DENOMINATOR)
+run_case "div_by_eight"          "$ONE_ETH" 8          || FAILED=1
+run_case "div_by_eight_max"      "$MAX256"  8          || FAILED=1
+# Realistic EIP-1559 base-fee step
+GAS_LIMIT=30000000
+PARENT_GAS_TARGET=15000000
+run_case "div_by_gas_target"     $(python3 -c "print(100 * 10**9 * 1000000)")  "$PARENT_GAS_TARGET"  || FAILED=1
+# Divide-equal cases
+run_case "div_a_eq_b"            $(python3 -c "print(1 << 30)")  $(python3 -c "print(1 << 30)") || FAILED=1
+# Small-magnitude
+run_case "100_div_7"             100        7          || FAILED=1
+run_case "999_div_1000"          999        1000       || FAILED=1  # q = 0, r = 999
+# Boundary: divisor = max allowed (2^56)
+run_case "div_by_2_56_max"       "$MAX256"  "$H56"     || FAILED=1
+run_case "div_by_2_56_eth"       "$ONE_ETH" "$H56"     || FAILED=1
+# Mid-range divisor (2^40)
+run_case "div_by_2_40"           "$MAX256"  "$H40"     || FAILED=1
+# Realistic mainnet shape: 1 ETH / 100 gwei  ≈ 10M
+run_case "eth_div_100gwei"       "$ONE_ETH" $(python3 -c "print(100 * 10**9)") || FAILED=1
+# Pseudo-random
+PSEUDO=$(python3 -c "print(int.from_bytes(bytes((i*7+3) & 0xff for i in range(32)), 'big'))")
+run_case "pseudo_div_31337"      "$PSEUDO"  31337      || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: u256_div_u64_be matches Python's divmod() across 16 fixtures"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Byte-by-byte u256 / u64 long division on a 32-byte BE buffer using RV64 `divu`. Stores the 32-byte BE quotient at `out` and returns the u64 remainder.

**Precondition: `0 < b ≤ 2^56`** (the function does not check this).

The byte-by-byte algorithm maintains `carry < b` across iterations and computes `num = (carry << 8) | a[i]`. For `num` to fit in `u64` we need `carry << 8 < 2^64`, i.e. `b ≤ 2^56`.

## Direct use case — EIP-1559 base-fee formula

```
parent_gas_target = parent.gas_limit / 2          (b = 2)
target_fee_delta  = parent_fee_gas_delta / target (b ≤ 2^30)
base_fee_delta    = target_fee_delta / 8          (b = 8)
```

All three divisors fit comfortably below the `2^56` limit, as do other Ethereum-state-related divisors (gas limits, withdrawal counts, tx counts). For larger divisors a future PR can ship a bit-by-bit long-division helper supporting `b ≤ 2^63`.

Pure register arithmetic, no scratch memory, leaf-callable. Aliasing safe.

## Test plan

- [x] `lake build` clean
- [x] `scripts/codegen-zisk-u256-div-u64-be-check.sh` passes 16 fixtures cross-validated against Python `divmod()`:
  - Identity divisors (`1`)
  - `/2`, `/8` (real EIP-1559 inputs)
  - Realistic `parent_gas_target` shape
  - `a == b`, small-magnitude divisions
  - Boundary divisor `2^56`, mid-range divisor `2^40`
  - `1 ETH / 100 gwei = 10M` (typical wei conversion)
  - Pseudo-random / 31337

🤖 Generated with [Claude Code](https://claude.com/claude-code)