### PR TITLE
feat(divmod): lift v4 n4 loopsetup prefix

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathV4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathV4.lean
@@ -88,4 +88,33 @@ theorem evm_div_n4_to_normB_spec_v4 (sp base : Word)
       v5 v6 v7 v10 q0 q1 q2 q3 u5 u6 u7 nMem shiftMem
       hbnz hb3nz hshift_nz)
 
+/-- Full n=4 path to loop setup over the full `divCode_v4` bundle. -/
+theorem evm_div_n4_to_loopSetup_spec_v4 (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3nz : b3 ≠ 0)
+    (hshift_nz : (clzResult b3).1 ≠ 0) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4) base (base + loopBodyOff) (divCode_v4 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+       ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+       ((sp + signExtend12 4024) ↦ₘ u4Old) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
+      (loopSetupPost sp (4 : Word) (clzResult b3).1 a0 a1 a2 a3 b0 b1 b2 b3) := by
+  exact cpsTripleWithin_divCode_noNop_v4_to_divCode_v4
+    (evm_div_n4_to_loopSetup_spec_v4_noNop sp base a0 a1 a2 a3 b0 b1 b2 b3
+      v5 v6 v7 v10 q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem
+      hbnz hb3nz hshift_nz)
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- extend Compose.FullPathV4 with the n=4 shift-nonzero path through loop setup over full divCode_v4
- keep the proof as a narrow lift from the existing v4 no-NOP theorem through the public code-lift helper

## Verification
- lake build EvmAsm.Evm64.DivMod.Compose.FullPathV4
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- scripts/check-file-size.sh
- scripts/check-file-size.sh --report
- scripts/check-unimported.sh
- rg forbidden scan on EvmAsm/Evm64/DivMod/Compose/FullPathV4.lean