### PR TITLE
feat(divmod): lift v4 n4 loop body to full code

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -54,6 +54,7 @@ import EvmAsm.Evm64.DivMod.LoopIterN4CallV4NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN4AddbackV4NoNop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4BeqV4NoNop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V4NoNop
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4V4
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4CallV4NoNop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V4NoNop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNop

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4V4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4V4.lean
@@ -1,0 +1,34 @@
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4V4NoNop
+import EvmAsm.Evm64.DivMod.Compose.V4Code
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Loop body n=4, max+skip, j=0 over the full `divCode_v4` bundle. -/
+theorem divK_loop_body_n4_max_skip_j0_norm_v4 (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (hbltu : ¬BitVec.ult uTop v3) :
+    (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+     then (1 : Word) else 0) = (0 : Word) →
+    cpsTripleWithin 76 (base + loopBodyOff) (base + denormOff) (divCode_v4 base)
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
+       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
+       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
+       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
+       ((sp + 32) ↦ₘ v0) ** ((sp + signExtend12 4056) ↦ₘ u0) **
+       ((sp + 40) ↦ₘ v1) ** ((sp + signExtend12 4048) ↦ₘ u1) **
+       ((sp + 48) ↦ₘ v2) ** ((sp + signExtend12 4040) ↦ₘ u2) **
+       ((sp + 56) ↦ₘ v3) ** ((sp + signExtend12 4032) ↦ₘ u3) **
+       ((sp + signExtend12 4024) ↦ₘ uTop) **
+       ((sp + signExtend12 4088) ↦ₘ qOld))
+      (loopBodyN4SkipPost sp (0 : Word) (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro hborrow
+  exact cpsTripleWithin_divCode_noNop_v4_to_divCode_v4
+    (divK_loop_body_n4_max_skip_j0_norm_v4_noNop sp base
+      jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld hbltu hborrow)
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add Compose.FullPathN4V4 as a full divCode_v4 sibling for n=4 wrappers
- lift the n=4 max+skip j=0 loop body theorem from divCode_noNop_v4 to full divCode_v4
- import the new module from the DivMod umbrella

## Verification
- lake build EvmAsm.Evm64.DivMod.Compose.FullPathN4V4
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- scripts/check-file-size.sh
- scripts/check-file-size.sh --report
- scripts/check-unimported.sh
- rg forbidden scan on EvmAsm/Evm64/DivMod/Compose/FullPathN4V4.lean EvmAsm/Evm64/DivMod.lean