### PR TITLE
feat(stateless): priority_fee_per_gas_eip1559 (PR-K62)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -6207,6 +6207,101 @@ def ziskU256MaxProbeUnit : BuildUnit := {
   dataAsm     := ziskU256MaxDataSection
 }
 
+/-! ## priority_fee_per_gas_eip1559 -- PR-K62
+
+    Compute the effective priority fee per gas for a post-EIP-1559
+    transaction. Mirrors Python's
+    `transaction_priority_fee_per_gas` from
+    `forks/amsterdam/transaction_helpers.py`:
+
+      surplus = tx.max_fee_per_gas - block.base_fee_per_gas
+      priority_fee = min(tx.max_priority_fee_per_gas, surplus)
+
+    Where `surplus = max_fee - base_fee` would underflow
+    (`max_fee < base_fee`), the tx is invalid; this helper
+    returns `1` so the caller can reject without inspecting the
+    output. Otherwise returns `0` and the 32-byte priority fee
+    is written to `*out` in big-endian.
+
+    First higher-level helper composed on the K-stack's u256
+    toolkit: PR-K52 `u256_sub_be` + PR-K59 `u256_min`. Both are
+    inlined into the probe BuildUnit so this PR doesn't require
+    any new external symbols.
+
+    BE storage convention: byte 0 = MSB, byte 31 = LSB.
+
+    Calling convention:
+      a0 (input)  : max_priority_fee_per_gas ptr (32 B BE)
+      a1 (input)  : max_fee_per_gas ptr (32 B BE)
+      a2 (input)  : base_fee_per_gas ptr (32 B BE)
+      a3 (input)  : output ptr (32 B BE; receives priority fee)
+      ra (input)  : return
+      a0 (output) : 0 success / 1 max_fee < base_fee (reject tx). -/
+def priorityFeePerGasEip1559Function : String :=
+  "priority_fee_per_gas_eip1559:\n" ++
+  "  addi sp, sp, -48\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  mv s0, a0                   # max_priority ptr\n" ++
+  "  mv s1, a1                   # max_fee ptr\n" ++
+  "  mv s2, a2                   # base_fee ptr\n" ++
+  "  mv s3, a3                   # out ptr\n" ++
+  "  # surplus = max_fee - base_fee  (store in out)\n" ++
+  "  mv a0, s1; mv a1, s2; mv a2, s3\n" ++
+  "  jal ra, u256_sub_be\n" ++
+  "  bnez a0, .Lpfee_fail        # borrow → max_fee < base_fee\n" ++
+  "  # priority_fee = min(max_priority, surplus); aliasing OK\n" ++
+  "  mv a0, s0; mv a1, s3; mv a2, s3\n" ++
+  "  jal ra, u256_min\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lpfee_ret\n" ++
+  ".Lpfee_fail:\n" ++
+  "  li a0, 1\n" ++
+  ".Lpfee_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  addi sp, sp, 48\n" ++
+  "  ret"
+
+/-- `zisk_priority_fee_per_gas_eip1559`: probe BuildUnit. Reads
+    (32B max_priority, 32B max_fee, 32B base_fee) from host
+    input, writes (status, 32B priority fee BE) to OUTPUT (40
+    bytes total). -/
+def ziskPriorityFeePerGasEip1559Prologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a4, 0x40000000\n" ++
+  "  addi a0, a4, 8              # max_priority ptr\n" ++
+  "  addi a1, a4, 40             # max_fee ptr\n" ++
+  "  addi a2, a4, 72             # base_fee ptr\n" ++
+  "  li a3, 0xa0010008           # out ptr\n" ++
+  "  mv t0, a3; li t1, 4\n" ++
+  ".Lpfee_zout:\n" ++
+  "  beqz t1, .Lpfee_zout_done\n" ++
+  "  sd zero, 0(t0)\n" ++
+  "  addi t0, t0, 8\n" ++
+  "  addi t1, t1, -1\n" ++
+  "  j .Lpfee_zout\n" ++
+  ".Lpfee_zout_done:\n" ++
+  "  jal ra, priority_fee_per_gas_eip1559\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)                # status\n" ++
+  "  j .Lpfee_pdone\n" ++
+  u256SubBeFunction ++ "\n" ++
+  u256MinFunction ++ "\n" ++
+  priorityFeePerGasEip1559Function ++ "\n" ++
+  ".Lpfee_pdone:"
+
+def ziskPriorityFeePerGasEip1559DataSection : String :=
+  ".section .data\n" ++
+  "pfee_pad:\n" ++
+  "  .zero 8"
+
+def ziskPriorityFeePerGasEip1559ProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskPriorityFeePerGasEip1559Prologue
+  dataAsm     := ziskPriorityFeePerGasEip1559DataSection
+}
+
 
 /-! ## u256_eq -- PR-K53 equality companion to PR-K50 u256_lt
 
@@ -8894,6 +8989,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_u256_is_zero"         => some ziskU256IsZeroProbeUnit
   | "zisk_u256_min"             => some ziskU256MinProbeUnit
   | "zisk_u256_max"             => some ziskU256MaxProbeUnit
+  | "zisk_priority_fee_per_gas_eip1559" => some ziskPriorityFeePerGasEip1559ProbeUnit
   | "zisk_tx_type_dispatch"     => some ziskTxTypeDispatchProbeUnit
   | "zisk_tx_eip2930_decode"    => some ziskTxEip2930DecodeProbeUnit
   | "zisk_tx_eip7702_decode"    => some ziskTxEip7702DecodeProbeUnit
@@ -8968,6 +9064,7 @@ def knownProgramNames : List String :=
    "zisk_u256_is_zero",
    "zisk_u256_min",
    "zisk_u256_max",
+   "zisk_priority_fee_per_gas_eip1559",
    "zisk_tx_type_dispatch",
    "zisk_tx_eip2930_decode",
    "zisk_tx_eip7702_decode",

--- a/scripts/codegen-zisk-priority-fee-per-gas-eip1559-check.sh
+++ b/scripts/codegen-zisk-priority-fee-per-gas-eip1559-check.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# codegen-zisk-priority-fee-per-gas-eip1559-check.sh -- PR-K62.
+#
+# Compute the effective priority fee for an EIP-1559 tx:
+#   surplus = max_fee - base_fee
+#   priority_fee = min(max_priority, surplus)
+# Returns 1 if max_fee < base_fee (caller should reject).
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_priority_fee_per_gas_eip1559 ELF"
+lake exe codegen --program zisk_priority_fee_per_gas_eip1559 --halt linux93 \
+  -o gen-out/zisk_priority_fee_per_gas_eip1559
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <max_priority> <max_fee> <base_fee>
+run_case() {
+  local name="$1" mp="$2" mf="$3" bf="$4"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_priority_fee_per_gas_eip1559_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_priority_fee_per_gas_eip1559_${name}.output"
+  local exp_file="$REPO_ROOT/gen-out/zisk_priority_fee_per_gas_eip1559_${name}.expected"
+
+  python3 -c "
+import struct, sys
+mp = $mp; mf = $mf; bf = $bf
+with open(sys.argv[1], 'wb') as f:
+    f.write(mp.to_bytes(32, 'big'))
+    f.write(mf.to_bytes(32, 'big'))
+    f.write(bf.to_bytes(32, 'big'))
+
+if mf < bf:
+    status = 1
+    pf = (mf - bf) % (1 << 256)  # underflow result; caller ignores
+else:
+    status = 0
+    surplus = mf - bf
+    pf = min(mp, surplus)
+
+with open(sys.argv[2], 'wb') as f:
+    f.write(struct.pack('<Q', status))
+    f.write(pf.to_bytes(32, 'big'))
+" "$in_file" "$exp_file"
+
+  "$ZISKEMU" -e gen-out/zisk_priority_fee_per_gas_eip1559.elf \
+    -i "$in_file" -o "$out_file" -n 500000 \
+    >"$REPO_ROOT/gen-out/zisk_priority_fee_per_gas_eip1559_${name}.emu.log" 2>&1 || true
+
+  local exp_size; exp_size="$(stat -c%s "$exp_file")"
+  local actual expected
+  actual="$(xxd -p -l "$exp_size" "$out_file" 2>/dev/null | tr -d '\n')"
+  expected="$(xxd -p -l "$exp_size" "$exp_file" 2>/dev/null | tr -d '\n')"
+
+  if [[ "$actual" == "$expected" ]]; then
+    local status pf
+    status="$(python3 -c "print(1 if $mf < $bf else 0)")"
+    pf="$(python3 -c "
+mp, mf, bf = $mp, $mf, $bf
+if mf < bf: print('reject')
+else:       print(min(mp, mf - bf))
+")"
+    printf "  %-30s OK   status=%d priority_fee=%s\n" "$name" "$status" "$pf"
+    return 0
+  else
+    printf "  %-30s FAIL\n    expected: %s\n    actual:   %s\n" \
+      "$name" "$expected" "$actual"
+    return 1
+  fi
+}
+
+GWEI=$(python3 -c "print(10**9)")
+ETH=$(python3 -c "print(10**18)")
+
+FAILED=0
+# Surplus dominates → priority = max_priority
+run_case "priority_below_surplus" \
+  $(python3 -c "print(2 * $GWEI)")   $(python3 -c "print(100 * $GWEI)") $(python3 -c "print(50 * $GWEI)") \
+  || FAILED=1
+
+# max_priority caps the surplus → priority = max_priority (= 2 gwei)
+run_case "priority_caps_surplus" \
+  $(python3 -c "print(2 * $GWEI)")   $(python3 -c "print(100 * $GWEI)") $(python3 -c "print(50 * $GWEI)") \
+  || FAILED=1
+
+# Surplus is smaller than max_priority → priority = surplus
+run_case "surplus_caps_priority" \
+  $(python3 -c "print(100 * $GWEI)") $(python3 -c "print(55 * $GWEI)")  $(python3 -c "print(50 * $GWEI)") \
+  || FAILED=1
+
+# Exact equality of max_priority and surplus
+run_case "equal_max_priority_surplus" \
+  $(python3 -c "print(10 * $GWEI)")  $(python3 -c "print(60 * $GWEI)")  $(python3 -c "print(50 * $GWEI)") \
+  || FAILED=1
+
+# max_fee == base_fee → surplus = 0, priority = min(mp, 0) = 0
+run_case "zero_surplus" \
+  $(python3 -c "print(5 * $GWEI)")   $(python3 -c "print(50 * $GWEI)")  $(python3 -c "print(50 * $GWEI)") \
+  || FAILED=1
+
+# Reject: max_fee < base_fee
+run_case "reject_max_fee_below_base" \
+  $(python3 -c "print(5 * $GWEI)")   $(python3 -c "print(40 * $GWEI)")  $(python3 -c "print(50 * $GWEI)") \
+  || FAILED=1
+
+# Reject: max_fee = 0, base_fee > 0
+run_case "reject_zero_max_fee" \
+  0   0   "$GWEI" \
+  || FAILED=1
+
+# Edge: max_priority = 0 → priority = 0 (free tx)
+run_case "zero_max_priority" \
+  0   $(python3 -c "print(50 * $GWEI)") $(python3 -c "print(50 * $GWEI)") \
+  || FAILED=1
+
+# Realistic Holesky shape: large max_priority, modest surplus
+run_case "holesky_typical" \
+  $(python3 -c "print(3 * $GWEI)") $(python3 -c "print(35 * $GWEI)") $(python3 -c "print(8 * $GWEI)") \
+  || FAILED=1
+
+# Large u256 values (test the full byte-walk in u256_sub and u256_min)
+MAX=115792089237316195423570985008687907853269984665640564039457584007913129639935
+run_case "max_priority_huge" \
+  "$MAX"  "$MAX"  0 \
+  || FAILED=1
+
+# Underflow chain across 64-bit boundary
+H64=$(python3 -c "print(1 << 64)")
+run_case "h64_minus_h64_plus_1" \
+  $(python3 -c "print(2 * $GWEI)")  "$H64"  $(python3 -c "print((1<<64) + 1)") \
+  || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: priority_fee_per_gas_eip1559 matches Python's min(max_priority, max_fee - base_fee)"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

First higher-level helper composed on the K-stack's u256 toolkit. Computes the effective priority fee per gas for a post-EIP-1559 transaction (Python: `transaction_priority_fee_per_gas` in `forks/amsterdam/transaction_helpers.py`):

```
surplus = tx.max_fee_per_gas - block.base_fee_per_gas
priority_fee = min(tx.max_priority_fee_per_gas, surplus)
```

If `max_fee < base_fee` (would-underflow), returns `status=1` so the caller can reject the tx; otherwise `status=0` and the 32-byte priority fee is written to `*out` in big-endian.

## Composition

- PR-K52 `u256_sub_be` (#5553) — the `max_fee - base_fee` step, with borrow flag for underflow detection
- PR-K59 `u256_min` (#5594) — the `min(max_priority, surplus)` step

Both inlined into the probe BuildUnit; no new external symbols required.

## Test plan

- [x] `lake build` clean
- [x] `scripts/codegen-zisk-priority-fee-per-gas-eip1559-check.sh` passes 11 fixtures cross-validated against Python's `min(max_priority, max_fee - base_fee)`:
  - Priority below surplus, priority caps surplus, surplus caps priority
  - Exact equality, zero surplus
  - Two reject paths (`max_fee < base_fee`, zero `max_fee`)
  - Zero `max_priority` (free tx), realistic Holesky shape
  - Huge u256 values (full byte-walk in sub+min)
  - Underflow chain across the 64-bit boundary

🤖 Generated with [Claude Code](https://claude.com/claude-code)