### PR TITLE
feat(divmod): lift v4 n3 j1 loop body

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V4.lean
@@ -22,4 +22,22 @@ theorem divK_loop_body_n3_max_skip_j0_norm_v4 (sp base : Word)
       jOld v5Old v6Old v7Old v10Old v11Old v2Old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld hbltu hborrow)
 
+/-- Loop body n=3, max+skip, j=1 over the full `divCode_v4` bundle. -/
+theorem divK_loop_body_n3_max_skip_j1_norm_v4 (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (hbltu : ¬BitVec.ult u3 v2) :
+    (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+     then (1 : Word) else 0) = (0 : Word) →
+    cpsTripleWithin 76 (base + loopBodyOff) (base + loopBodyOff) (divCode_v4 base)
+      (loopBodyN3MaxSkipJ1NormPreV4 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld)
+      (loopBodyN3SkipPost sp (1 : Word) (signExtend12 4095 : Word)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro hborrow
+  exact cpsTripleWithin_divCode_noNop_v4_to_divCode_v4
+    (divK_loop_body_n3_max_skip_j1_norm_v4_noNop sp base
+      jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld hbltu hborrow)
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- extend FullPathN3V4 with the max-skip j=1 full-code wrapper
- lift divK_loop_body_n3_max_skip_j1_norm_v4_noNop to divCode_v4 through cpsTripleWithin_divCode_noNop_v4_to_divCode_v4

## Tests
- lake build EvmAsm.Evm64.DivMod.Compose.FullPathN3V4
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- scripts/check-file-size.sh
- scripts/check-file-size.sh --report
- scripts/check-unimported.sh
- rg -n "DivStackSpecCase|ModStackSpecCase|SDivStackSpecCase|SModStackSpecCase|StackSpecCase|set_option maxRecDepth|set_option maxHeartbeats|sorry|admit" EvmAsm/Evm64/DivMod/Compose/FullPathN3V4.lean