### PR TITLE
feat(divmod): lift v4 n3 call skip j1

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V4.lean
@@ -81,4 +81,24 @@ theorem divK_loop_body_n3_call_skip_j0_norm_v4 (sp base : Word)
       retMem dMem dloMem scratchUn0 scratchMem
       halign hbltu hborrow)
 
+/-- Loop body n=3, call+skip, j=1 over the full `divCode_v4` bundle. -/
+theorem divK_loop_body_n3_call_skip_j1_norm_v4 (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu : BitVec.ult u3 v2)
+    (hborrow : mulsubN4NoBorrow (divKTrialCallV4QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 148 (base + loopBodyOff) (base + loopBodyOff) (divCode_v4 base)
+      (loopBodyN3CallSkipJ1NormPreV4 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem)
+      (loopBodyN3CallSkipJgt0PostV4 sp base (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem) := by
+  exact cpsTripleWithin_divCode_noNop_v4_to_divCode_v4
+    (divK_loop_body_n3_call_skip_j1_norm_v4_noNop sp base
+      jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
+      retMem dMem dloMem scratchUn0 scratchMem
+      halign hbltu hborrow)
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- extend FullPathN3V4 with the call-skip j=1 full-code wrapper
- lift divK_loop_body_n3_call_skip_j1_norm_v4_noNop to divCode_v4 through cpsTripleWithin_divCode_noNop_v4_to_divCode_v4

## Tests
- lake build EvmAsm.Evm64.DivMod.Compose.FullPathN3V4
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- scripts/check-file-size.sh
- scripts/check-file-size.sh --report
- scripts/check-unimported.sh
- rg -n "DivStackSpecCase|ModStackSpecCase|SDivStackSpecCase|SModStackSpecCase|StackSpecCase|set_option maxRecDepth|set_option maxHeartbeats|sorry|admit" EvmAsm/Evm64/DivMod/Compose/FullPathN3V4.lean