### PR TITLE
feat(stateless): calc_excess_blob_gas (PR-K63)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -5751,6 +5751,84 @@ def ziskValidateHeaderBasicProbeUnit : BuildUnit := {
   dataAsm     := ziskValidateHeaderBasicDataSection
 }
 
+/-! ## calc_excess_blob_gas -- PR-K63 EIP-4844 excess blob gas formula
+
+    Compute the next header's `excess_blob_gas` field from the
+    parent header. Python (`forks/cancun/fork.py::
+    calculate_excess_blob_gas`):
+
+      def calculate_excess_blob_gas(parent_header):
+          excess_blob_gas = (
+              parent_header.excess_blob_gas
+              + parent_header.blob_gas_used
+          )
+          if excess_blob_gas < TARGET_BLOB_GAS_PER_BLOCK:
+              return 0
+          return excess_blob_gas - TARGET_BLOB_GAS_PER_BLOCK
+
+    Equivalent to: `max(0, parent.excess_blob_gas +
+    parent.blob_gas_used - target)`.
+
+    Used by `validate_header` to check that
+    `header.excess_blob_gas == calc_excess_blob_gas(parent,
+    target)`.
+
+    The `target` is parameterized — Cancun uses 3 blobs × 131072
+    bytes = 393216; Prague/Amsterdam may use a higher target via
+    EIP-7691 (e.g. 6 blobs × 131072 = 786432). The function takes
+    `target` as an explicit u64 input so it works across forks.
+
+    ## Precondition
+
+    `parent_excess + parent_blob_used` must not overflow u64. In
+    practice both terms are small (each < 2^30 on mainnet), so
+    overflow doesn't occur. The function does NOT check.
+
+    Calling convention:
+      a0 (input)  : parent.excess_blob_gas (u64)
+      a1 (input)  : parent.blob_gas_used (u64)
+      a2 (input)  : target_blob_gas_per_block (u64)
+      ra (input)  : return
+      a0 (output) : excess_blob_gas for this header (u64).
+
+    Pure register arithmetic, no scratch memory, leaf-callable. -/
+def calcExcessBlobGasFunction : String :=
+  "calc_excess_blob_gas:\n" ++
+  "  add t0, a0, a1              # parent_excess + parent_used\n" ++
+  "  bgeu t0, a2, .Lcebg_pos     # >= target → return diff\n" ++
+  "  li a0, 0\n" ++
+  "  ret\n" ++
+  ".Lcebg_pos:\n" ++
+  "  sub a0, t0, a2\n" ++
+  "  ret"
+
+/-- `zisk_calc_excess_blob_gas`: probe BuildUnit. Reads
+    (parent_excess, parent_used, target) from host input, writes
+    the u64 result to OUTPUT. -/
+def ziskCalcExcessBlobGasPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a3, 0x40000000\n" ++
+  "  ld a0, 8(a3)                # parent_excess_blob_gas\n" ++
+  "  ld a1, 16(a3)               # parent_blob_gas_used\n" ++
+  "  ld a2, 24(a3)               # target_blob_gas_per_block\n" ++
+  "  jal ra, calc_excess_blob_gas\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lcebg_pdone\n" ++
+  calcExcessBlobGasFunction ++ "\n" ++
+  ".Lcebg_pdone:"
+
+def ziskCalcExcessBlobGasDataSection : String :=
+  ".section .data\n" ++
+  "cebg_pad:\n" ++
+  "  .zero 8"
+
+def ziskCalcExcessBlobGasProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskCalcExcessBlobGasPrologue
+  dataAsm     := ziskCalcExcessBlobGasDataSection
+}
+
 /-! ## u256_add_be -- PR-K51 modular addition on BE u256 buffers
 
     Compute `(a + b) mod 2^256` over two 32-byte big-endian
@@ -8885,6 +8963,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_header_extended_decode" => some ziskHeaderExtendedDecodeProbeUnit
   | "zisk_coinbase_extract_from_header" => some ziskCoinbaseExtractFromHeaderProbeUnit
   | "zisk_validate_header_basic" => some ziskValidateHeaderBasicProbeUnit
+  | "zisk_calc_excess_blob_gas" => some ziskCalcExcessBlobGasProbeUnit
   | "zisk_u256_add_be"          => some ziskU256AddBeProbeUnit
   | "zisk_u256_sub_be"          => some ziskU256SubBeProbeUnit
   | "zisk_u256_eq"              => some ziskU256EqProbeUnit
@@ -8959,6 +9038,7 @@ def knownProgramNames : List String :=
    "zisk_header_extended_decode",
    "zisk_coinbase_extract_from_header",
    "zisk_validate_header_basic",
+   "zisk_calc_excess_blob_gas",
    "zisk_u256_add_be",
    "zisk_u256_sub_be",
    "zisk_u256_eq",

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **85**
-- ziskemu round-trip scripts: **78** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **86**
+- ziskemu round-trip scripts: **79** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-calc-excess-blob-gas-check.sh
+++ b/scripts/codegen-zisk-calc-excess-blob-gas-check.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# codegen-zisk-calc-excess-blob-gas-check.sh -- PR-K63.
+#
+# EIP-4844 excess_blob_gas calculation:
+#   max(0, parent.excess_blob_gas + parent.blob_gas_used - target)
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_calc_excess_blob_gas ELF"
+lake exe codegen --program zisk_calc_excess_blob_gas --halt linux93 \
+  -o gen-out/zisk_calc_excess_blob_gas
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <parent_excess> <parent_used> <target>
+run_case() {
+  local name="$1" parent_excess="$2" parent_used="$3" target="$4"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_calc_excess_blob_gas_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_calc_excess_blob_gas_${name}.output"
+
+  python3 -c "
+import struct, sys
+out = struct.pack('<Q', $parent_excess)
+out += struct.pack('<Q', $parent_used)
+out += struct.pack('<Q', $target)
+sys.stdout.buffer.write(out)
+" > "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_calc_excess_blob_gas.elf \
+    -i "$in_file" -o "$out_file" -n 500000 \
+    >"$REPO_ROOT/gen-out/zisk_calc_excess_blob_gas_${name}.emu.log" 2>&1 || true
+
+  local expected; expected="$(python3 -c "
+pe, pu, t = $parent_excess, $parent_used, $target
+total = pe + pu
+print(0 if total < t else (total - t))
+")"
+  local actual; actual="$(python3 -c "
+with open('$out_file', 'rb') as f:
+    raw = f.read()[:8]
+print(int.from_bytes(raw, 'little'))
+")"
+
+  if [[ "$actual" == "$expected" ]]; then
+    printf "  %-30s OK   result=%d\n" "$name" "$expected"
+    return 0
+  else
+    printf "  %-30s FAIL  expected %d got %d\n" "$name" "$expected" "$actual"
+    return 1
+  fi
+}
+
+CANCUN_TARGET=393216           # 3 blobs × 131072
+PRAGUE_TARGET=786432           # 6 blobs × 131072 (EIP-7691 candidate)
+GAS_PER_BLOB=131072
+
+FAILED=0
+# Sum below target → 0
+run_case "below_target_zero"     0           0           "$CANCUN_TARGET" || FAILED=1
+run_case "below_target_small"    100         200         "$CANCUN_TARGET" || FAILED=1
+run_case "exactly_target"        0           "$CANCUN_TARGET" "$CANCUN_TARGET" || FAILED=1   # sum=target → 0
+run_case "exactly_target_split"  "$GAS_PER_BLOB" $((2 * GAS_PER_BLOB)) "$CANCUN_TARGET" || FAILED=1
+# Above target → positive diff
+run_case "above_target_small"    "$CANCUN_TARGET" 1     "$CANCUN_TARGET" || FAILED=1
+run_case "double_target"         "$CANCUN_TARGET" "$CANCUN_TARGET" "$CANCUN_TARGET" || FAILED=1
+run_case "much_higher"           5000000     0           "$CANCUN_TARGET" || FAILED=1
+# Realistic: parent block consumed 4 blobs (over target by 1 blob)
+run_case "parent_4_blobs"        0           $((4 * GAS_PER_BLOB)) "$CANCUN_TARGET" || FAILED=1
+# Realistic: parent had 2 blobs (under target by 1)
+run_case "parent_2_blobs"        500000      $((2 * GAS_PER_BLOB)) "$CANCUN_TARGET" || FAILED=1
+# Prague-era larger target
+run_case "prague_below_target"   "$CANCUN_TARGET" 0     "$PRAGUE_TARGET" || FAILED=1
+run_case "prague_above_target"   "$PRAGUE_TARGET" "$PRAGUE_TARGET" "$PRAGUE_TARGET" || FAILED=1
+# Edge: only parent_excess set
+run_case "only_excess"           1000        0           "$CANCUN_TARGET" || FAILED=1
+# Edge: only parent_used set
+run_case "only_used"             0           "$CANCUN_TARGET" "$CANCUN_TARGET" || FAILED=1
+# Edge: target = 0 (degenerate but allowed)
+run_case "target_zero"           100         200         0           || FAILED=1
+# Steady state typical: small excess, fewer blobs than target
+run_case "steady_state"          1000        $((1 * GAS_PER_BLOB)) "$CANCUN_TARGET" || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: calc_excess_blob_gas matches max(0, parent_excess + parent_used - target)"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Compute the next header's `excess_blob_gas` field from the parent header per EIP-4844 (Python `calculate_excess_blob_gas`):

```
max(0, parent.excess_blob_gas + parent.blob_gas_used - target)
```

Used by `validate_header` to verify `header.excess_blob_gas` matches.

Parameterized by `target` so it works across forks:
- Cancun: 3 blobs × 131072 = 393216
- Prague/Amsterdam may use a higher target via EIP-7691

Pure register arithmetic: `add` + `bgeu` + `sub`. No scratch memory, leaf-callable.

## Precondition

`parent_excess + parent_used` must not overflow u64. In practice both terms are small (each < 2^30 on mainnet), so overflow doesn't occur. The function does NOT check.

## Test plan

- [x] `lake build` clean
- [x] `scripts/codegen-zisk-calc-excess-blob-gas-check.sh` passes 15 fixtures:
  - Sum below target → 0
  - Sum at target → 0 (split between excess and used)
  - Sum above target → positive diff
  - Realistic 4-blob and 2-blob parent shapes
  - Prague-era larger target
  - Edge cases (`only_excess`, `only_used`, `target_zero`)
  - Steady-state shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)