### PR TITLE
feat(divmod): lift v4 n2 call skip j0

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4.lean
@@ -61,4 +61,24 @@ theorem divK_loop_body_n2_max_addback_jgt0_beq_norm_v4 (j sp base : Word)
       jOld v5Old v6Old v7Old v10Old v11Old v2Old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld hbltu hcarry2_nz hborrow)
 
+/-- Loop body n=2, call+skip, j=0 over the full `divCode_v4` bundle. -/
+theorem divK_loop_body_n2_call_skip_j0_norm_v4 (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu : BitVec.ult u2 v1)
+    (hborrow : loopBodyN2CallSkipJ0BorrowV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 148 (base + loopBodyOff) (base + denormOff) (divCode_v4 base)
+      (loopBodyN2CallSkipJ0NormPreV4 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem)
+      (loopBodyN2CallSkipJ0PostV4 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem) := by
+  exact cpsTripleWithin_divCode_noNop_v4_to_divCode_v4
+    (divK_loop_body_n2_call_skip_j0_norm_v4_noNop sp base
+      jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
+      retMem dMem dloMem scratchUn0 scratchMem
+      halign hbltu hborrow)
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- extend FullPathN2V4 with the call-skip j=0 full-code wrapper
- lift divK_loop_body_n2_call_skip_j0_norm_v4_noNop to divCode_v4 through cpsTripleWithin_divCode_noNop_v4_to_divCode_v4

## Tests
- lake build EvmAsm.Evm64.DivMod.Compose.FullPathN2V4
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- scripts/check-file-size.sh
- scripts/check-file-size.sh --report
- scripts/check-unimported.sh
- rg -n "DivStackSpecCase|ModStackSpecCase|SDivStackSpecCase|SModStackSpecCase|StackSpecCase|set_option maxRecDepth|set_option maxHeartbeats|sorry|admit" EvmAsm/Evm64/DivMod/Compose/FullPathN2V4.lean