### PR TITLE
feat(divmod): lift v4 n2 max addback j0

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4.lean
@@ -125,4 +125,24 @@ theorem divK_loop_body_n2_call_addback_jgt0_beq_norm_v4 (j sp base : Word)
       retMem dMem dloMem scratchUn0 scratchMem
       halign hbltu hborrow hcarry2_nz)
 
+/-- Loop body n=2, max+addback (BEQ double-addback), j=0 over the full
+    `divCode_v4` bundle. -/
+theorem divK_loop_body_n2_max_addback_j0_beq_norm_v4 (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (hbltu : ¬BitVec.ult u2 v1)
+    (hcarry2_nz : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+     then (1 : Word) else 0) ≠ (0 : Word) →
+    cpsTripleWithin 152 (base + loopBodyOff) (base + denormOff) (divCode_v4 base)
+      (loopBodyN2MaxSkipJ0NormPreV4 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld)
+      (loopBodyN2AddbackBeqPost sp (0 : Word) (signExtend12 4095 : Word)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro hborrow
+  exact cpsTripleWithin_divCode_noNop_v4_to_divCode_v4
+    (divK_loop_body_n2_max_addback_j0_beq_norm_v4_noNop sp base
+      jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld hbltu hcarry2_nz hborrow)
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- extend FullPathN2V4 with the max-addback j=0 BEQ full-code wrapper
- lift divK_loop_body_n2_max_addback_j0_beq_norm_v4_noNop to divCode_v4 through cpsTripleWithin_divCode_noNop_v4_to_divCode_v4

## Tests
- lake build EvmAsm.Evm64.DivMod.Compose.FullPathN2V4
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- scripts/check-file-size.sh
- scripts/check-file-size.sh --report
- scripts/check-unimported.sh
- rg -n "DivStackSpecCase|ModStackSpecCase|SDivStackSpecCase|SModStackSpecCase|StackSpecCase|set_option maxRecDepth|set_option maxHeartbeats|sorry|admit" EvmAsm/Evm64/DivMod/Compose/FullPathN2V4.lean