### PR TITLE
feat(stateless): blob_gas_used_from_versioned_hashes (PR-K64)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -2805,6 +2805,93 @@ def ziskAccessListCountProbeUnit : BuildUnit := {
   dataAsm     := ziskAccessListCountDataSection
 }
 
+/-! ## blob_gas_used_from_versioned_hashes -- PR-K64
+
+    Compute the EIP-4844 `blob_gas_used` field as:
+
+      blob_gas_used = len(tx.blob_versioned_hashes) × GAS_PER_BLOB
+
+    where `GAS_PER_BLOB = 131072 = 0x20000` per spec. The
+    `gas_per_blob` constant is parameterized so the helper works
+    across forks that might adjust it.
+
+    Direct use case — validating header.blob_gas_used and
+    rejecting blob-fee under-pays:
+
+      header.blob_gas_used  ==  sum(tx.blob_versioned_hashes count
+                                    × GAS_PER_BLOB
+                                    for tx in block.txs
+                                    if tx.is_blob)
+
+    Composes PR-K47 `rlp_list_count_items` (#5532) + a `mul`.
+    `rlp_list_count_items` is inlined into the probe BuildUnit.
+
+    Calling convention:
+      a0 (input)  : blob_versioned_hashes_rlp ptr (whole encoded
+                    sub-list as returned by PR-K45
+                    `tx_eip4844_decode` field 10)
+      a1 (input)  : blob_versioned_hashes_rlp byte length
+      a2 (input)  : gas_per_blob (u64; 131072 on mainnet)
+      a3 (input)  : u64 out ptr (receives blob_gas_used)
+      ra (input)  : return
+      a0 (output) : 0 success / 1 parse fail (output zeroed).
+
+    Uses 8 bytes of `.data` scratch (`bgvh_count_scratch`). -/
+def blobGasUsedFromVersionedHashesFunction : String :=
+  "blob_gas_used_from_versioned_hashes:\n" ++
+  "  addi sp, sp, -24\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp)\n" ++
+  "  mv s0, a2                   # gas_per_blob\n" ++
+  "  mv s1, a3                   # out ptr\n" ++
+  "  la a2, bgvh_count_scratch\n" ++
+  "  jal ra, rlp_list_count_items\n" ++
+  "  bnez a0, .Lbgvh_fail\n" ++
+  "  la t0, bgvh_count_scratch; ld t1, 0(t0)\n" ++
+  "  mul t2, t1, s0\n" ++
+  "  sd t2, 0(s1)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lbgvh_ret\n" ++
+  ".Lbgvh_fail:\n" ++
+  "  sd zero, 0(s1)\n" ++
+  "  li a0, 1\n" ++
+  ".Lbgvh_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp)\n" ++
+  "  addi sp, sp, 24\n" ++
+  "  ret"
+
+/-- `zisk_blob_gas_used_from_versioned_hashes`: probe BuildUnit.
+    Reads (list_len, gas_per_blob, list_bytes) from host input,
+    writes (status, blob_gas_used) to OUTPUT (16 bytes total). -/
+def ziskBlobGasUsedFromVersionedHashesPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a4, 0x40000000\n" ++
+  "  ld a1, 8(a4)                # list_len\n" ++
+  "  ld a2, 16(a4)               # gas_per_blob\n" ++
+  "  addi a0, a4, 24             # list ptr\n" ++
+  "  li a3, 0xa0010008           # out at OUTPUT + 8\n" ++
+  "  sd zero, 0(a3)\n" ++
+  "  jal ra, blob_gas_used_from_versioned_hashes\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)                # status\n" ++
+  "  j .Lbgvh_pdone\n" ++
+  rlpListCountItemsFunction ++ "\n" ++
+  blobGasUsedFromVersionedHashesFunction ++ "\n" ++
+  ".Lbgvh_pdone:"
+
+def ziskBlobGasUsedFromVersionedHashesDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "bgvh_count_scratch:\n" ++
+  "  .zero 8"
+
+def ziskBlobGasUsedFromVersionedHashesProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskBlobGasUsedFromVersionedHashesPrologue
+  dataAsm     := ziskBlobGasUsedFromVersionedHashesDataSection
+}
+
 /-! ## mpt_node_kind -- PR-K21 classifier
 
     Determines whether an RLP-encoded MPT node is a leaf,
@@ -8863,6 +8950,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_rlp_list_nth_item"    => some ziskRlpListNthItemProbeUnit
   | "zisk_rlp_list_count_items" => some ziskRlpListCountItemsProbeUnit
   | "zisk_access_list_count"    => some ziskAccessListCountProbeUnit
+  | "zisk_blob_gas_used_from_versioned_hashes" => some ziskBlobGasUsedFromVersionedHashesProbeUnit
   | "zisk_mpt_node_kind"        => some ziskMptNodeKindProbeUnit
   | "zisk_mpt_branch_child"     => some ziskMptBranchChildProbeUnit
   | "zisk_hp_decode_nibbles"    => some ziskHpDecodeNibblesProbeUnit
@@ -8937,6 +9025,7 @@ def knownProgramNames : List String :=
    "zisk_rlp_list_nth_item",
    "zisk_rlp_list_count_items",
    "zisk_access_list_count",
+   "zisk_blob_gas_used_from_versioned_hashes",
    "zisk_mpt_node_kind",
    "zisk_mpt_branch_child",
    "zisk_hp_decode_nibbles",

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **86**
-- ziskemu round-trip scripts: **79** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **87**
+- ziskemu round-trip scripts: **80** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-blob-gas-used-from-versioned-hashes-check.sh
+++ b/scripts/codegen-zisk-blob-gas-used-from-versioned-hashes-check.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# codegen-zisk-blob-gas-used-from-versioned-hashes-check.sh -- PR-K64.
+#
+# Compute EIP-4844 blob_gas_used = count(blob_versioned_hashes) × GAS_PER_BLOB.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_blob_gas_used_from_versioned_hashes ELF"
+lake exe codegen --program zisk_blob_gas_used_from_versioned_hashes --halt linux93 \
+  -o gen-out/zisk_blob_gas_used_from_versioned_hashes
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <expected_status> <gas_per_blob> <num_hashes>
+run_case() {
+  local name="$1" expected_status="$2" gas_per_blob="$3" num_hashes="$4"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_blob_gas_used_from_versioned_hashes_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_blob_gas_used_from_versioned_hashes_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys
+import rlp
+
+n = $num_hashes
+# Make each hash distinct enough to exercise the byte-walk
+hashes = [
+    bytes([0x01] + [(i*7+3) & 0xff for _ in range(31)]) for i in range(n)
+]
+list_rlp = rlp.encode(hashes)
+
+with open(sys.argv[1], 'wb') as f:
+    f.write(struct.pack('<Q', len(list_rlp)))
+    f.write(struct.pack('<Q', $gas_per_blob))
+    f.write(list_rlp)
+    pad = (-(16 + len(list_rlp))) % 8
+    if pad:
+        f.write(b'\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_blob_gas_used_from_versioned_hashes.elf \
+    -i "$in_file" -o "$out_file" -n 500000 \
+    >"$REPO_ROOT/gen-out/zisk_blob_gas_used_from_versioned_hashes_${name}.emu.log" 2>&1 || true
+
+  local actual_status; actual_status="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local actual_result; actual_result="$(dd if="$out_file" bs=1 skip=8 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local expected_result; expected_result="$(python3 -c "print($num_hashes * $gas_per_blob)")"
+
+  local exp_status_le; exp_status_le="$(python3 -c "print(int('$expected_status').to_bytes(8, 'little').hex())")"
+  local exp_result_le; exp_result_le="$(python3 -c "print(int('$expected_result').to_bytes(8, 'little').hex())")"
+
+  if [[ "$actual_status" == "$exp_status_le" && "$actual_result" == "$exp_result_le" ]]; then
+    printf "  %-30s OK   status=%d blob_gas_used=%d\n" "$name" "$expected_status" "$expected_result"
+    return 0
+  else
+    printf "  %-30s FAIL  expected status=%d result=%d got status=0x%s result=0x%s\n" \
+      "$name" "$expected_status" "$expected_result" "$actual_status" "$actual_result"
+    return 1
+  fi
+}
+
+GAS_PER_BLOB=131072
+
+FAILED=0
+# Edge cases
+run_case "empty_list"            0 "$GAS_PER_BLOB" 0  || FAILED=1
+run_case "one_blob"              0 "$GAS_PER_BLOB" 1  || FAILED=1
+run_case "two_blobs"             0 "$GAS_PER_BLOB" 2  || FAILED=1
+run_case "three_blobs_target"    0 "$GAS_PER_BLOB" 3  || FAILED=1
+# Cancun cap (6 blobs/tx)
+run_case "six_blobs_cancun_max"  0 "$GAS_PER_BLOB" 6  || FAILED=1
+# Prague-era max (9 blobs/tx)
+run_case "nine_blobs_prague"     0 "$GAS_PER_BLOB" 9  || FAILED=1
+# Hypothetical 16 blobs (stress test for long RLP prefix path)
+run_case "sixteen_blobs"         0 "$GAS_PER_BLOB" 16 || FAILED=1
+# Different gas_per_blob values (test the multiplication)
+run_case "one_blob_small_gas"    0 100             1  || FAILED=1
+run_case "three_blobs_big_gas"   0 1000000         3  || FAILED=1
+# Non-list input → status=1
+NON_LIST_FILE="$REPO_ROOT/gen-out/zisk_blob_gas_used_from_versioned_hashes_non_list.input"
+python3 -c "
+import struct, sys
+b = bytes([0x80])  # RLP empty string, not a list
+with open(sys.argv[1], 'wb') as f:
+    f.write(struct.pack('<Q', len(b)))
+    f.write(struct.pack('<Q', 131072))  # gas_per_blob
+    f.write(b)
+    f.write(b'\x00' * 7)
+" "$NON_LIST_FILE"
+"$ZISKEMU" -e gen-out/zisk_blob_gas_used_from_versioned_hashes.elf \
+  -i "$NON_LIST_FILE" -o "$REPO_ROOT/gen-out/zisk_blob_gas_used_from_versioned_hashes_non_list.output" \
+  -n 500000 >"$REPO_ROOT/gen-out/zisk_blob_gas_used_from_versioned_hashes_non_list.emu.log" 2>&1 || true
+NL_STATUS="$(xxd -p -l 8 "$REPO_ROOT/gen-out/zisk_blob_gas_used_from_versioned_hashes_non_list.output" | tr -d '\n')"
+NL_RESULT="$(dd if="$REPO_ROOT/gen-out/zisk_blob_gas_used_from_versioned_hashes_non_list.output" bs=1 skip=8 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+if [[ "$NL_STATUS" == "0100000000000000" && "$NL_RESULT" == "0000000000000000" ]]; then
+  printf "  %-30s OK   status=1 (non-list rejected)\n" "non_list_rejected"
+else
+  printf "  %-30s FAIL  status=0x%s result=0x%s\n" "non_list_rejected" "$NL_STATUS" "$NL_RESULT"
+  FAILED=1
+fi
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: blob_gas_used_from_versioned_hashes returns count × gas_per_blob"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Compute the EIP-4844 `blob_gas_used` field per blob tx:

```
blob_gas_used = count(tx.blob_versioned_hashes) × GAS_PER_BLOB
```

where `GAS_PER_BLOB = 131072` (mainnet) — parameterized so the helper works across forks.

Used by header validation to verify
```
header.blob_gas_used == sum(blob_hashes count × GAS_PER_BLOB
                            for tx in block.txs
                            if tx.is_blob)
```

## Composition

- PR-K47 `rlp_list_count_items` (#5532) — count the sub-list entries
- Single `mul` for `count × gas_per_blob`

Calling convention: `a0` = list ptr, `a1` = list len, `a2` = `gas_per_blob`, `a3` = u64 out ptr. Returns `0` ok / `1` parse fail (output zeroed).

## Test plan

- [x] `lake build` clean
- [x] `scripts/codegen-zisk-blob-gas-used-from-versioned-hashes-check.sh` passes 10 fixtures:
  - Empty list
  - 1, 2, 3 (target), 6 (Cancun cap), 9 (Prague), 16 blobs (exercises long-RLP-prefix path)
  - Two non-standard `gas_per_blob` multipliers (100, 1M)
  - Non-list rejection

🤖 Generated with [Claude Code](https://claude.com/claude-code)