### PR TITLE
feat(divmod): lift v4 n1 loop body

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -61,6 +61,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN3V4
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1V4NoNop
+import EvmAsm.Evm64.DivMod.Compose.FullPathN1V4
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN2LoopUnified
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3LoopUnified
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN3LoopUnified

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1V4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1V4.lean
@@ -1,0 +1,25 @@
+import EvmAsm.Evm64.DivMod.Compose.FullPathN1V4NoNopLoopBody
+import EvmAsm.Evm64.DivMod.Compose.V4Code
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Loop body n=1, max+skip, j=0 over the full `divCode_v4` bundle. -/
+theorem divK_loop_body_n1_max_skip_j0_norm_v4 (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (hbltu : ¬BitVec.ult u1 v0) :
+    (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+     then (1 : Word) else 0) = (0 : Word) →
+    cpsTripleWithin 76 (base + loopBodyOff) (base + denormOff) (divCode_v4 base)
+      (loopBodyN1MaxSkipJ0NormPreV4 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld)
+      (loopBodyN1SkipPost sp (0 : Word) (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro hborrow
+  exact cpsTripleWithin_divCode_noNop_v4_to_divCode_v4
+    (divK_loop_body_n1_max_skip_j0_norm_v4_noNop sp base
+      jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld hbltu hborrow)
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add FullPathN1V4 as the full-code wrapper layer for N1 DIV v4 path proofs
- lift divK_loop_body_n1_max_skip_j0_norm_v4_noNop to divCode_v4 through cpsTripleWithin_divCode_noNop_v4_to_divCode_v4
- import the new module from the DivMod umbrella

## Tests
- lake build EvmAsm.Evm64.DivMod.Compose.FullPathN1V4
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- scripts/check-file-size.sh
- scripts/check-file-size.sh --report
- scripts/check-unimported.sh
- rg -n "DivStackSpecCase|ModStackSpecCase|SDivStackSpecCase|SModStackSpecCase|StackSpecCase|set_option maxRecDepth|set_option maxHeartbeats|sorry|admit" EvmAsm/Evm64/DivMod/Compose/FullPathN1V4.lean EvmAsm/Evm64/DivMod.lean