### PR TITLE
feat(stateless): withdrawals_sum_amounts (PR-K65)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -7624,6 +7624,152 @@ def ziskWithdrawalDecodeProbeUnit : BuildUnit := {
   dataAsm     := ziskWithdrawalDecodeDataSection
 }
 
+/-! ## withdrawals_sum_amounts -- PR-K65 block withdrawal-credit total
+
+    Walk an RLP-encoded list of Shanghai+ Withdrawal records
+    (one Withdrawal = `rlp([index, validator_index, address,
+    amount])`) and return the total of all `amount` fields
+    (in Gwei) as a `u64`.
+
+    Used by `apply_body` to compute the block's total
+    withdrawal credit before applying it to recipient
+    balances — useful as a sanity check against the
+    `withdrawals_root` MPT computation and for tracking
+    coinbase credits per block.
+
+    First multi-helper composition on the K-stack:
+    - PR-K47 `rlp_list_count_items` — outer cardinality
+    - PR-K20 `rlp_list_nth_item` — per-entry bounds
+    - PR-K49 `withdrawal_decode` — extract `amount` (u64 at
+      struct offset 40)
+
+    Each entry's `amount` is added to a u64 accumulator with
+    overflow detection (unsigned-wrap check: if `sum < prev`,
+    we overflowed). On overflow the function returns status=2
+    so the caller can react (in practice withdrawals per block
+    are capped at 16 with amounts ≤ ~2^41 Gwei, so overflow
+    can't occur on valid chains, but the check makes garbage
+    input safe).
+
+    Calling convention:
+      a0 (input)  : withdrawals_rlp ptr
+      a1 (input)  : withdrawals_rlp byte length
+      a2 (input)  : u64 out ptr (sum of all amounts in Gwei)
+      ra (input)  : return
+      a0 (output) :
+        0  : success
+        1  : parse fail (output zeroed)
+        2  : sum overflowed u64 (output zeroed)
+
+    Uses 64 bytes of `.data` scratch
+    (`wsa_count`, `wsa_entry_offset`, `wsa_entry_length`,
+    `wsa_struct[48]`). -/
+def withdrawalsSumAmountsFunction : String :=
+  "withdrawals_sum_amounts:\n" ++
+  "  addi sp, sp, -56\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp)\n" ++
+  "  mv s0, a0                   # rlp_ptr\n" ++
+  "  mv s1, a1                   # rlp_len\n" ++
+  "  mv s2, a2                   # out_ptr\n" ++
+  "  # Step 1: count = rlp_list_count_items(...)\n" ++
+  "  la a2, wsa_count\n" ++
+  "  jal ra, rlp_list_count_items\n" ++
+  "  bnez a0, .Lwsa_fail\n" ++
+  "  la t0, wsa_count; ld s3, 0(t0)\n" ++
+  "  li s4, 0                    # acc (u64)\n" ++
+  "  li s5, 0                    # i\n" ++
+  ".Lwsa_loop:\n" ++
+  "  beq s5, s3, .Lwsa_done\n" ++
+  "  # Step 2: get entry i bounds.\n" ++
+  "  mv a0, s0; mv a1, s1; mv a2, s5\n" ++
+  "  la a3, wsa_entry_offset\n" ++
+  "  la a4, wsa_entry_length\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lwsa_fail\n" ++
+  "  # Step 3: decode entry into wsa_struct.\n" ++
+  "  la t0, wsa_entry_offset; ld t1, 0(t0)\n" ++
+  "  la t0, wsa_entry_length; ld t2, 0(t0)\n" ++
+  "  add a0, s0, t1\n" ++
+  "  mv a1, t2\n" ++
+  "  la a2, wsa_struct\n" ++
+  "  jal ra, withdrawal_decode\n" ++
+  "  bnez a0, .Lwsa_fail\n" ++
+  "  # Step 4: accumulate amount (at struct offset 40) with overflow.\n" ++
+  "  la t0, wsa_struct; ld t1, 40(t0)\n" ++
+  "  add t2, s4, t1\n" ++
+  "  bltu t2, s4, .Lwsa_overflow\n" ++
+  "  mv s4, t2\n" ++
+  "  addi s5, s5, 1\n" ++
+  "  j .Lwsa_loop\n" ++
+  ".Lwsa_done:\n" ++
+  "  sd s4, 0(s2)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lwsa_ret\n" ++
+  ".Lwsa_overflow:\n" ++
+  "  sd zero, 0(s2)\n" ++
+  "  li a0, 2\n" ++
+  "  j .Lwsa_ret\n" ++
+  ".Lwsa_fail:\n" ++
+  "  sd zero, 0(s2)\n" ++
+  "  li a0, 1\n" ++
+  ".Lwsa_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp)\n" ++
+  "  addi sp, sp, 56\n" ++
+  "  ret"
+
+/-- `zisk_withdrawals_sum_amounts`: probe BuildUnit. Reads
+    (rlp_len, rlp_bytes) from host input, writes (status, sum)
+    to OUTPUT (16 bytes total). -/
+def ziskWithdrawalsSumAmountsPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a3, 0x40000000\n" ++
+  "  ld a1, 8(a3)                # rlp_len\n" ++
+  "  addi a0, a3, 16             # rlp ptr\n" ++
+  "  li a2, 0xa0010008           # out ptr\n" ++
+  "  sd zero, 0(a2)\n" ++
+  "  jal ra, withdrawals_sum_amounts\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lwsa_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpListCountItemsFunction ++ "\n" ++
+  rlpFieldToU64Function ++ "\n" ++
+  withdrawalDecodeFunction ++ "\n" ++
+  withdrawalsSumAmountsFunction ++ "\n" ++
+  ".Lwsa_pdone:"
+
+def ziskWithdrawalsSumAmountsDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "rfu_offset:\n" ++
+  "  .zero 8\n" ++
+  "rfu_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "wd_offset:\n" ++
+  "  .zero 8\n" ++
+  "wd_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "wsa_count:\n" ++
+  "  .zero 8\n" ++
+  "wsa_entry_offset:\n" ++
+  "  .zero 8\n" ++
+  "wsa_entry_length:\n" ++
+  "  .zero 8\n" ++
+  "wsa_struct:\n" ++
+  "  .zero 48"
+
+def ziskWithdrawalsSumAmountsProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskWithdrawalsSumAmountsPrologue
+  dataAsm     := ziskWithdrawalsSumAmountsDataSection
+}
+
 /-! ## zisk_ssz_pair_hash — PR-S4 SSZ merkleization primitive
 
     First consumer of the SSZ `hash_tree_root` shim:
@@ -8900,6 +9046,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_tx_eip4844_decode"    => some ziskTxEip4844DecodeProbeUnit
   | "zisk_intrinsic_gas_legacy" => some ziskIntrinsicGasLegacyProbeUnit
   | "zisk_withdrawal_decode"    => some ziskWithdrawalDecodeProbeUnit
+  | "zisk_withdrawals_sum_amounts" => some ziskWithdrawalsSumAmountsProbeUnit
   | "zisk_sha256_from_input"    => some ziskSha256FromInputProbeUnit
   | "zisk_ssz_pair_hash"        => some ziskSszPairHashProbeUnit
   | "zisk_ssz_zero_hashes"      => some ziskSszZeroHashesProbeUnit
@@ -8974,6 +9121,7 @@ def knownProgramNames : List String :=
    "zisk_tx_eip4844_decode",
    "zisk_intrinsic_gas_legacy",
    "zisk_withdrawal_decode",
+   "zisk_withdrawals_sum_amounts",
    "zisk_sha256_from_input",
    "zisk_ssz_pair_hash",
    "zisk_ssz_zero_hashes",

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **87**
-- ziskemu round-trip scripts: **80** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **88**
+- ziskemu round-trip scripts: **81** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-withdrawals-sum-amounts-check.sh
+++ b/scripts/codegen-zisk-withdrawals-sum-amounts-check.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# codegen-zisk-withdrawals-sum-amounts-check.sh -- PR-K65.
+#
+# Sum amount fields across an RLP list of Withdrawal records.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_withdrawals_sum_amounts ELF"
+lake exe codegen --program zisk_withdrawals_sum_amounts --halt linux93 \
+  -o gen-out/zisk_withdrawals_sum_amounts
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <withdrawals_json>
+#   withdrawals_json: list of [index, validator_idx, address_hex, amount] tuples.
+run_case() {
+  local name="$1" withdrawals_json="$2"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_withdrawals_sum_amounts_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_withdrawals_sum_amounts_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import json, struct, sys
+import rlp
+
+raw = json.loads('''$withdrawals_json''')
+ws = []
+for entry in raw:
+    idx, vi, addr_hex, amt = entry
+    ws.append([idx, vi, bytes.fromhex(addr_hex), amt])
+
+rlp_bytes = rlp.encode(ws)
+with open(sys.argv[1], 'wb') as f:
+    f.write(struct.pack('<Q', len(rlp_bytes)))
+    f.write(rlp_bytes)
+    pad = (-(8 + len(rlp_bytes))) % 8
+    if pad:
+        f.write(b'\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_withdrawals_sum_amounts.elf \
+    -i "$in_file" -o "$out_file" -n 1000000 \
+    >"$REPO_ROOT/gen-out/zisk_withdrawals_sum_amounts_${name}.emu.log" 2>&1 || true
+
+  local actual_status; actual_status="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local actual_sum;    actual_sum="$(dd if="$out_file" bs=1 skip=8 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+
+  local expected_sum; expected_sum="$(python3 -c "
+import json
+ws = json.loads('''$withdrawals_json''')
+print(sum(w[3] for w in ws))
+")"
+  local expected_status=0
+  local exp_status_le; exp_status_le="$(python3 -c "print(int('$expected_status').to_bytes(8, 'little').hex())")"
+  local exp_sum_le; exp_sum_le="$(python3 -c "print(int('$expected_sum').to_bytes(8, 'little').hex())")"
+
+  if [[ "$actual_status" == "$exp_status_le" && "$actual_sum" == "$exp_sum_le" ]]; then
+    printf "  %-30s OK   status=0 sum=%d\n" "$name" "$expected_sum"
+    return 0
+  else
+    printf "  %-30s FAIL  expected status=0 sum=%d, got status=0x%s sum=0x%s\n" \
+      "$name" "$expected_sum" "$actual_status" "$actual_sum"
+    return 1
+  fi
+}
+
+ALICE="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+BOB="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+FAILED=0
+# Empty list
+run_case "empty"           "[]"  || FAILED=1
+# Single withdrawal
+run_case "one_wd"          "[[0, 1, \"$ALICE\", 1000000000]]"  || FAILED=1
+# Two withdrawals — typical magnitudes
+run_case "two_wd_typical"  "[[10, 100, \"$ALICE\", 32000000000], [11, 101, \"$BOB\", 1500000000]]"  || FAILED=1
+# Three withdrawals, mixed amounts
+run_case "three_wd_mixed"  "[[1, 2, \"$ALICE\", 1], [2, 3, \"$BOB\", 1000000000], [3, 4, \"$ALICE\", 500000000]]"  || FAILED=1
+# Six withdrawals
+run_case "six_wd" "[[1, 1, \"$ALICE\", 100], [2, 2, \"$ALICE\", 200], [3, 3, \"$ALICE\", 300], [4, 4, \"$ALICE\", 400], [5, 5, \"$ALICE\", 500], [6, 6, \"$ALICE\", 600]]" || FAILED=1
+# Mainnet-cap: 16 withdrawals
+SIXTEEN_WD="$(python3 -c "
+import sys
+addr = '$ALICE'
+ws = [[i, i+1000, addr, (i+1) * 1000000000] for i in range(16)]
+import json
+sys.stdout.write(json.dumps(ws))
+")"
+run_case "sixteen_wd_mainnet_cap" "$SIXTEEN_WD"  || FAILED=1
+# Single max-u64 amount → sum equals it
+run_case "max_amount_single"   "[[0, 0, \"$ALICE\", 18446744073709551615]]"  || FAILED=1
+# Two max-u64 amounts → overflow → status=2
+OVERFLOW_WD="[[0, 0, \"$ALICE\", 18446744073709551615], [1, 0, \"$BOB\", 1]]"
+OVERFLOW_FILE="$REPO_ROOT/gen-out/zisk_withdrawals_sum_amounts_overflow.input"
+uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, json, rlp
+raw = json.loads('''$OVERFLOW_WD''')
+ws = [[w[0], w[1], bytes.fromhex(w[2]), w[3]] for w in raw]
+rlp_bytes = rlp.encode(ws)
+with open(sys.argv[1], 'wb') as f:
+    f.write(struct.pack('<Q', len(rlp_bytes)))
+    f.write(rlp_bytes)
+    pad = (-(8 + len(rlp_bytes))) % 8
+    if pad:
+        f.write(b'\x00' * pad)
+" "$OVERFLOW_FILE"
+"$ZISKEMU" -e gen-out/zisk_withdrawals_sum_amounts.elf \
+  -i "$OVERFLOW_FILE" -o "$REPO_ROOT/gen-out/zisk_withdrawals_sum_amounts_overflow.output" \
+  -n 1000000 >"$REPO_ROOT/gen-out/zisk_withdrawals_sum_amounts_overflow.emu.log" 2>&1 || true
+OF_STATUS="$(xxd -p -l 8 "$REPO_ROOT/gen-out/zisk_withdrawals_sum_amounts_overflow.output" | tr -d '\n')"
+if [[ "$OF_STATUS" == "0200000000000000" ]]; then
+  printf "  %-30s OK   status=2 (overflow detected)\n" "overflow_detected"
+else
+  printf "  %-30s FAIL  status=0x%s\n" "overflow_detected" "$OF_STATUS"
+  FAILED=1
+fi
+# Non-list input → status=1
+NON_LIST_FILE="$REPO_ROOT/gen-out/zisk_withdrawals_sum_amounts_non_list.input"
+python3 -c "
+import struct, sys
+b = bytes([0x80])
+with open(sys.argv[1], 'wb') as f:
+    f.write(struct.pack('<Q', len(b)))
+    f.write(b)
+    f.write(b'\x00' * 7)
+" "$NON_LIST_FILE"
+"$ZISKEMU" -e gen-out/zisk_withdrawals_sum_amounts.elf \
+  -i "$NON_LIST_FILE" -o "$REPO_ROOT/gen-out/zisk_withdrawals_sum_amounts_non_list.output" \
+  -n 1000000 >"$REPO_ROOT/gen-out/zisk_withdrawals_sum_amounts_non_list.emu.log" 2>&1 || true
+NL_STATUS="$(xxd -p -l 8 "$REPO_ROOT/gen-out/zisk_withdrawals_sum_amounts_non_list.output" | tr -d '\n')"
+if [[ "$NL_STATUS" == "0100000000000000" ]]; then
+  printf "  %-30s OK   status=1 (non-list rejected)\n" "non_list_rejected"
+else
+  printf "  %-30s FAIL  status=0x%s\n" "non_list_rejected" "$NL_STATUS"
+  FAILED=1
+fi
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: withdrawals_sum_amounts matches Python's sum() with overflow detection"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Walk an RLP-encoded list of Shanghai+ Withdrawal records (one Withdrawal = `rlp([index, validator_index, address, amount])`) and return the total of all `amount` fields in Gwei as a `u64`.

First multi-helper composition on the K-stack:

- PR-K47 `rlp_list_count_items` (#5532) — outer cardinality
- PR-K20 `rlp_list_nth_item` — per-entry bounds
- PR-K49 `withdrawal_decode` (#5537) — extract `amount` field

Each entry's `amount` is added to a u64 accumulator with overflow detection (unsigned-wrap check: if `sum < prev`, we overflowed). On overflow returns `status=2`; on RLP parse fail returns `status=1`. In practice mainnet withdrawals (≤ 16/block, amounts ≤ ~2^41 Gwei) can't overflow, but the check keeps garbage input safe.

Used by `apply_body` to compute the block's total withdrawal credit — useful as a sanity check against the `withdrawals_root` MPT computation and for tracking per-block credits.

## Test plan

- [x] `lake build` clean
- [x] `scripts/codegen-zisk-withdrawals-sum-amounts-check.sh` passes 9 fixtures:
  - Empty list
  - Single, typical-2-entry, mixed, 6-entry, mainnet-cap 16-entry
  - Max-u64 single amount (no overflow)
  - Overflow detected (max_u64 + 1 → status=2)
  - Non-list rejected (status=1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)