### PR TITLE
feat(divmod): lift v4 n1 all max

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1V4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1V4.lean
@@ -159,4 +159,56 @@ theorem divK_loop_n1_iter210_maxmaxmax_exact_x1_v4 (sp base : Word)
       v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old
       retMem dMem dloMem scratch_un0 raVal hbltu_2 hbltu_1 hbltu_0 hcarry2)
 
+/-- Exact-`x1` N1 four-iteration all-max path over the full `divCode_v4` bundle. -/
+theorem divK_loop_n1_maxmaxmaxmax_exact_x1_v4 (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop
+     u0Orig2 u0Orig1 u0Orig0 q3Old q2Old q1Old q0Old : Word)
+    (retMem dMem dloMem scratch_un0 raVal : Word)
+    (hbltu_3 : ¬BitVec.ult u1 v0)
+    (hbltu_2 : ¬BitVec.ult (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v0)
+    (hbltu_1 : ¬BitVec.ult
+      (iterN1Max v0 v1 v2 v3 u0Orig2
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.1 v0)
+    (hbltu_0 : ¬BitVec.ult
+      (iterN1Max v0 v1 v2 v3 u0Orig1
+        (iterN1Max v0 v1 v2 v3 u0Orig2
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.1
+        (iterN1Max v0 v1 v2 v3 u0Orig2
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.1
+        (iterN1Max v0 v1 v2 v3 u0Orig2
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.1
+        (iterN1Max v0 v1 v2 v3 u0Orig2
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.2.1).2.1 v0)
+    (hcarry2 : Carry2NzAll v0 v1 v2 v3) :
+    cpsTripleWithin 758 (base + loopBodyOff) (base + denormOff) (divCode_v4 base)
+      (loopN1PreWithScratchNoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop
+        u0Orig2 u0Orig1 u0Orig0 q3Old q2Old q1Old q0Old
+        retMem dMem dloMem scratch_un0 ** (.x1 ↦ᵣ raVal))
+      (loopN1UnifiedPostNoX1 false false false false sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop
+        u0Orig2 u0Orig1 u0Orig0 retMem dMem dloMem scratch_un0 ** (.x1 ↦ᵣ raVal)) := by
+  exact cpsTripleWithin_divCode_noNop_v4_to_divCode_v4
+    (divK_loop_n1_maxmaxmaxmax_exact_x1_v4_noNop sp base
+      jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      u0Orig2 u0Orig1 u0Orig0 q3Old q2Old q1Old q0Old
+      retMem dMem dloMem scratch_un0 raVal
+      hbltu_3 hbltu_2 hbltu_1 hbltu_0 hcarry2)
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add the full divCode_v4 bridge for the exact-x1 n=1 four-iteration all-max wrapper
- keep the proof as a direct lift from the existing v4 no-NOP theorem

## Checks
- lake build EvmAsm.Evm64.DivMod.Compose.FullPathN1V4
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- scripts/check-file-size.sh
- scripts/check-file-size.sh --report
- scripts/check-unimported.sh
- forbidden-pattern scan on EvmAsm/Evm64/DivMod/Compose/FullPathN1V4.lean