### PR TITLE
feat(divmod): lift v4 n1 call j3

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1V4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1V4.lean
@@ -439,4 +439,37 @@ theorem divK_loop_body_n1_call_jgt0_exact_loopIterScratch_v4 (j sp base : Word)
       v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal
       retMem dMem dloMem scratchUn0 scratchMem halign hbltu hcarry2_nz)
 
+/-- Loop body n=1, call path, j=3 over the full `divCode_v4` bundle. -/
+theorem divK_loop_body_n1_call_j3_exact_loopIterScratch_v4 (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu : BitVec.ult u1 v0)
+    (hcarry2_nz :
+      let qHat := divKTrialCallV4QHat u1 u0 v0
+      let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+      let c3 := ms.2.2.2.2
+      let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
+      let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
+      carry = 0 → addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0) :
+    cpsTripleWithin 224 (base + loopBodyOff) (base + loopBodyOff) (divCode_v4 base)
+      (loopBodyN1CallSkipJgt0PreV4NoX1 sp (3 : Word)
+        jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopIterPostN1CallScratchNoX1 sp base (3 : Word)
+        (divKTrialCallV4QHat u1 u0 v0)
+        (divKTrialCallV4DLo v0)
+        (divKTrialCallV4Un0 u0)
+        (divKTrialCallV4ScratchOut u1 u0 v0 scratchMem)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+        (.x1 ↦ᵣ raVal)) := by
+  exact cpsTripleWithin_divCode_noNop_v4_to_divCode_v4
+    (divK_loop_body_n1_call_j3_exact_loopIterScratch_v4_noNop sp base
+      jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal
+      retMem dMem dloMem scratchUn0 scratchMem halign hbltu hcarry2_nz)
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add the full divCode_v4 bridge for the n=1 concrete call-path j=3 scratch loop-iteration wrapper
- keep the proof as a direct lift from the existing v4 no-NOP theorem

## Checks
- lake build EvmAsm.Evm64.DivMod.Compose.FullPathN1V4
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- scripts/check-file-size.sh
- scripts/check-file-size.sh --report
- scripts/check-unimported.sh
- forbidden-pattern scan on EvmAsm/Evm64/DivMod/Compose/FullPathN1V4.lean