### PR TITLE
feat(stateless): header_validate_post_merge (PR-K67)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -5751,6 +5751,134 @@ def ziskValidateHeaderBasicProbeUnit : BuildUnit := {
   dataAsm     := ziskValidateHeaderBasicDataSection
 }
 
+/-! ## header_validate_post_merge -- PR-K67
+
+    Verify the three post-merge header invariants:
+
+      1. header.ommers_hash == EMPTY_OMMERS_HASH
+         (= keccak256(rlp([])) = 0x1dcc4de8...49347)
+      2. header.difficulty == 0   (canonical RLP: empty-string,
+                                   content_length == 0)
+      3. header.nonce == 0x0000000000000000   (8 zero bytes)
+
+    Mirrors the Python `validate_header` checks added at the
+    Merge fork:
+
+      assert header.ommers_hash == EMPTY_OMMERS_HASH
+      assert header.difficulty == 0
+      assert header.nonce == b"\\x00" * 8
+
+    Composes PR-K20 `rlp_list_nth_item` for field extraction.
+    Each check has a distinct return code so callers can pinpoint
+    which invariant failed.
+
+    Calling convention:
+      a0 (input)  : header_rlp ptr
+      a1 (input)  : header_rlp byte length
+      ra (input)  : return
+      a0 (output) :
+        0  : all three invariants hold
+        1  : ommers_hash mismatch
+        2  : difficulty != 0
+        3  : nonce not 8 zero bytes
+        4  : RLP parse failure (e.g. not a list, field missing)
+
+    Uses 40 bytes of `.data` scratch (`hvpm_off`, `hvpm_len`
+    + 32-byte `empty_ommers_hash` constant). -/
+def headerValidatePostMergeFunction : String :=
+  "header_validate_post_merge:\n" ++
+  "  addi sp, sp, -24\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp)\n" ++
+  "  mv s0, a0                   # header ptr\n" ++
+  "  mv s1, a1                   # header_len\n" ++
+  "  # Check 1: field 1 (ommers_hash) == EMPTY_OMMERS_HASH.\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 1\n" ++
+  "  la a3, hvpm_off; la a4, hvpm_len\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lhvpm_fail_parse\n" ++
+  "  la t0, hvpm_len; ld t1, 0(t0)\n" ++
+  "  li t2, 32\n" ++
+  "  bne t1, t2, .Lhvpm_fail_oh\n" ++
+  "  la t0, hvpm_off; ld t3, 0(t0); add t3, s0, t3\n" ++
+  "  la t4, empty_ommers_hash\n" ++
+  "  ld t5,  0(t3); ld t6,  0(t4); bne t5, t6, .Lhvpm_fail_oh\n" ++
+  "  ld t5,  8(t3); ld t6,  8(t4); bne t5, t6, .Lhvpm_fail_oh\n" ++
+  "  ld t5, 16(t3); ld t6, 16(t4); bne t5, t6, .Lhvpm_fail_oh\n" ++
+  "  ld t5, 24(t3); ld t6, 24(t4); bne t5, t6, .Lhvpm_fail_oh\n" ++
+  "  # Check 2: field 7 (difficulty) is canonical-zero (len 0).\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 7\n" ++
+  "  la a3, hvpm_off; la a4, hvpm_len\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lhvpm_fail_parse\n" ++
+  "  la t0, hvpm_len; ld t1, 0(t0)\n" ++
+  "  bnez t1, .Lhvpm_fail_diff\n" ++
+  "  # Check 3: field 14 (nonce) is 8 zero bytes.\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 14\n" ++
+  "  la a3, hvpm_off; la a4, hvpm_len\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lhvpm_fail_parse\n" ++
+  "  la t0, hvpm_len; ld t1, 0(t0)\n" ++
+  "  li t2, 8\n" ++
+  "  bne t1, t2, .Lhvpm_fail_nonce\n" ++
+  "  la t0, hvpm_off; ld t3, 0(t0); add t3, s0, t3\n" ++
+  "  ld t5, 0(t3)\n" ++
+  "  bnez t5, .Lhvpm_fail_nonce\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lhvpm_ret\n" ++
+  ".Lhvpm_fail_oh:\n" ++
+  "  li a0, 1\n" ++
+  "  j .Lhvpm_ret\n" ++
+  ".Lhvpm_fail_diff:\n" ++
+  "  li a0, 2\n" ++
+  "  j .Lhvpm_ret\n" ++
+  ".Lhvpm_fail_nonce:\n" ++
+  "  li a0, 3\n" ++
+  "  j .Lhvpm_ret\n" ++
+  ".Lhvpm_fail_parse:\n" ++
+  "  li a0, 4\n" ++
+  ".Lhvpm_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp)\n" ++
+  "  addi sp, sp, 24\n" ++
+  "  ret"
+
+/-- `zisk_header_validate_post_merge`: probe BuildUnit. Reads
+    (header_len, header_bytes) from host input, writes 8-byte
+    status to OUTPUT. -/
+def ziskHeaderValidatePostMergePrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a3, 0x40000000\n" ++
+  "  ld a1, 8(a3)                # header_len\n" ++
+  "  addi a0, a3, 16             # header ptr\n" ++
+  "  jal ra, header_validate_post_merge\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lhvpm_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  headerValidatePostMergeFunction ++ "\n" ++
+  ".Lhvpm_pdone:"
+
+def ziskHeaderValidatePostMergeDataSection : String :=
+  ".section .data\n" ++
+  ".balign 32\n" ++
+  "empty_ommers_hash:\n" ++
+  "  .byte 0x1d, 0xcc, 0x4d, 0xe8, 0xde, 0xc7, 0x5d, 0x7a\n" ++
+  "  .byte 0xab, 0x85, 0xb5, 0x67, 0xb6, 0xcc, 0xd4, 0x1a\n" ++
+  "  .byte 0xd3, 0x12, 0x45, 0x1b, 0x94, 0x8a, 0x74, 0x13\n" ++
+  "  .byte 0xf0, 0xa1, 0x42, 0xfd, 0x40, 0xd4, 0x93, 0x47\n" ++
+  ".balign 8\n" ++
+  "hvpm_off:\n" ++
+  "  .zero 8\n" ++
+  "hvpm_len:\n" ++
+  "  .zero 8"
+
+def ziskHeaderValidatePostMergeProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskHeaderValidatePostMergePrologue
+  dataAsm     := ziskHeaderValidatePostMergeDataSection
+}
+
 /-! ## u256_add_be -- PR-K51 modular addition on BE u256 buffers
 
     Compute `(a + b) mod 2^256` over two 32-byte big-endian
@@ -8885,6 +9013,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_header_extended_decode" => some ziskHeaderExtendedDecodeProbeUnit
   | "zisk_coinbase_extract_from_header" => some ziskCoinbaseExtractFromHeaderProbeUnit
   | "zisk_validate_header_basic" => some ziskValidateHeaderBasicProbeUnit
+  | "zisk_header_validate_post_merge" => some ziskHeaderValidatePostMergeProbeUnit
   | "zisk_u256_add_be"          => some ziskU256AddBeProbeUnit
   | "zisk_u256_sub_be"          => some ziskU256SubBeProbeUnit
   | "zisk_u256_eq"              => some ziskU256EqProbeUnit
@@ -8959,6 +9088,7 @@ def knownProgramNames : List String :=
    "zisk_header_extended_decode",
    "zisk_coinbase_extract_from_header",
    "zisk_validate_header_basic",
+   "zisk_header_validate_post_merge",
    "zisk_u256_add_be",
    "zisk_u256_sub_be",
    "zisk_u256_eq",

--- a/scripts/codegen-zisk-header-validate-post-merge-check.sh
+++ b/scripts/codegen-zisk-header-validate-post-merge-check.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# codegen-zisk-header-validate-post-merge-check.sh -- PR-K67.
+#
+# Verify three post-merge header invariants:
+#   1. ommers_hash == EMPTY_OMMERS_HASH
+#   2. difficulty == 0
+#   3. nonce == 8 zero bytes
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_header_validate_post_merge ELF"
+lake exe codegen --program zisk_header_validate_post_merge --halt linux93 \
+  -o gen-out/zisk_header_validate_post_merge
+
+REPO_ROOT="$(pwd)"
+
+EMPTY_OMMERS_HASH="1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+ZERO_NONCE="0000000000000000"
+
+# build_header writes a 15-field header RLP with overridable fields.
+build_header() {
+  local ommers_hash_hex="$1" difficulty="$2" nonce_hex="$3"
+  uv run --directory execution-specs --quiet python3 -c "
+import sys
+import rlp
+ommers_hash = bytes.fromhex('$ommers_hash_hex')
+nonce = bytes.fromhex('$nonce_hex')
+fields = [
+    b'\x11' * 32,       # 0: parent_hash
+    ommers_hash,        # 1: ommers_hash
+    b'\x33' * 20,       # 2: coinbase
+    b'\x44' * 32,       # 3: state_root
+    b'\x55' * 32,       # 4: transactions_root
+    b'\x66' * 32,       # 5: receipts_root
+    b'\x00' * 256,      # 6: bloom
+    $difficulty,        # 7: difficulty
+    100,                # 8: number
+    0x1c9c380,          # 9: gas_limit
+    0x100,              # 10: gas_used
+    1700000000,         # 11: timestamp
+    b'test',            # 12: extra_data
+    b'\x77' * 32,       # 13: prev_randao
+    nonce,              # 14: nonce
+]
+sys.stdout.buffer.write(rlp.encode(fields))
+"
+}
+
+# run_case <name> <expected_status> <ommers_hash> <difficulty> <nonce_hex>
+run_case() {
+  local name="$1" expected_status="$2" ommers="$3" diff="$4" nonce="$5"
+
+  local header_file="$REPO_ROOT/gen-out/zisk_header_validate_post_merge_${name}.header"
+  local in_file="$REPO_ROOT/gen-out/zisk_header_validate_post_merge_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_header_validate_post_merge_${name}.output"
+
+  build_header "$ommers" "$diff" "$nonce" > "$header_file"
+  python3 -c "
+import struct, sys
+with open(sys.argv[1], 'rb') as f:
+    body = f.read()
+out  = struct.pack('<Q', len(body))
+out += body
+pad = (-(8 + len(body))) % 8
+if pad:
+    out += b'\x00' * pad
+sys.stdout.buffer.write(out)
+" "$header_file" > "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_header_validate_post_merge.elf \
+    -i "$in_file" -o "$out_file" -n 500000 \
+    >"$REPO_ROOT/gen-out/zisk_header_validate_post_merge_${name}.emu.log" 2>&1 || true
+
+  local actual; actual="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local exp_le; exp_le="$(python3 -c "print(int('$expected_status').to_bytes(8, 'little').hex())")"
+
+  if [[ "$actual" == "$exp_le" ]]; then
+    printf "  %-30s OK   status=%d\n" "$name" "$expected_status"
+    return 0
+  else
+    printf "  %-30s FAIL  expected status=%d got 0x%s\n" "$name" "$expected_status" "$actual"
+    return 1
+  fi
+}
+
+FAILED=0
+# Pass: all three invariants hold
+run_case "post_merge_canonical"     0 "$EMPTY_OMMERS_HASH" 0 "$ZERO_NONCE" || FAILED=1
+# Fail 1: ommers_hash mismatch
+run_case "ommers_mismatch_zero"     1 "0000000000000000000000000000000000000000000000000000000000000000" 0 "$ZERO_NONCE" || FAILED=1
+run_case "ommers_mismatch_pattern"  1 "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899" 0 "$ZERO_NONCE" || FAILED=1
+# Fail 2: difficulty != 0
+run_case "diff_nonzero_small"       2 "$EMPTY_OMMERS_HASH" 1 "$ZERO_NONCE" || FAILED=1
+run_case "diff_nonzero_large"       2 "$EMPTY_OMMERS_HASH" 1000000 "$ZERO_NONCE" || FAILED=1
+# Fail 3: nonce not zero
+run_case "nonce_lsb_set"            3 "$EMPTY_OMMERS_HASH" 0 "0000000000000001" || FAILED=1
+run_case "nonce_msb_set"            3 "$EMPTY_OMMERS_HASH" 0 "0100000000000000" || FAILED=1
+run_case "nonce_random"             3 "$EMPTY_OMMERS_HASH" 0 "deadbeefcafebabe" || FAILED=1
+# Compound failures (asm should report whichever check fires first)
+# Check order: ommers → difficulty → nonce
+run_case "ommers_and_diff_fail"     1 "0000000000000000000000000000000000000000000000000000000000000000" 5 "$ZERO_NONCE" || FAILED=1
+run_case "diff_and_nonce_fail"      2 "$EMPTY_OMMERS_HASH" 5 "deadbeefcafebabe" || FAILED=1
+
+# Fail 4: non-list input
+NON_LIST_FILE="$REPO_ROOT/gen-out/zisk_header_validate_post_merge_non_list.input"
+python3 -c "
+import struct, sys
+b = bytes([0x80])
+with open(sys.argv[1], 'wb') as f:
+    f.write(struct.pack('<Q', len(b)))
+    f.write(b)
+    f.write(b'\x00' * 7)
+" "$NON_LIST_FILE"
+"$ZISKEMU" -e gen-out/zisk_header_validate_post_merge.elf \
+  -i "$NON_LIST_FILE" -o "$REPO_ROOT/gen-out/zisk_header_validate_post_merge_non_list.output" \
+  -n 500000 >"$REPO_ROOT/gen-out/zisk_header_validate_post_merge_non_list.emu.log" 2>&1 || true
+NL_STATUS="$(xxd -p -l 8 "$REPO_ROOT/gen-out/zisk_header_validate_post_merge_non_list.output" | tr -d '\n')"
+if [[ "$NL_STATUS" == "0400000000000000" ]]; then
+  printf "  %-30s OK   status=4 (parse fail)\n" "non_list_parse_fail"
+else
+  printf "  %-30s FAIL  status=0x%s\n" "non_list_parse_fail" "$NL_STATUS"
+  FAILED=1
+fi
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: header_validate_post_merge enforces ommers_hash + difficulty + nonce invariants"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Verify the three post-merge header invariants that `validate_header` added at the Merge fork:

1. `header.ommers_hash == EMPTY_OMMERS_HASH` (= `keccak256(rlp([])) = 0x1dcc4de8...49347`)
2. `header.difficulty == 0` (canonical RLP: `content_length == 0`)
3. `header.nonce == 0x0000000000000000` (8 zero bytes)

Composes PR-K20 `rlp_list_nth_item` for field extraction. Distinct return codes (`1`/`2`/`3`) pinpoint which invariant failed; `status=4` signals RLP parse failure (non-list input or missing field).

The `EMPTY_OMMERS_HASH` constant is embedded as a 32-byte aligned `.data` literal so the comparison is a fast `4 × (ld + bne)`.

## Test plan

- [x] `lake build` clean
- [x] `scripts/codegen-zisk-header-validate-post-merge-check.sh` passes 11 fixtures:
  - Canonical post-merge (pass)
  - 2 `ommers_hash` mismatches (zero hash, random pattern)
  - 2 `difficulty` violations (small, large)
  - 3 `nonce` violations (LSB-set, MSB-set, random)
  - 2 compound failures (verifies check ordering: `ommers → diff → nonce`)
  - Non-list parse fail (status=4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)