### PR TITLE
feat(divmod): lift v4 n1 callmax input iter210

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1V4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1V4.lean
@@ -779,4 +779,54 @@ theorem divK_loop_n1_call_j3_exact_x1_framed_v4_input
     (isAddbackCarry2NzN1CallV4_raw I.v0 I.v1 I.v2 I.v3 I.u0 I.u1 I.u2 I.u3 I.uTop
       (loopN1CallMaxmaxmaxExactInputHypotheses_carry2Call I hh))
 
+/-- Bundled full-code statement for the j=2/j=1/j=0 all-max tail after
+    the first j=3 call-body step in the N1 call/max/max/max exact path. -/
+@[irreducible]
+def loopN1CallMaxmaxmaxIter210ExactInputSpecV4
+    (I : LoopN1CallMaxmaxmaxExactInputs) : Prop :=
+  let r3 := loopN1CallMaxmaxmaxR3 I.v0 I.v1 I.v2 I.v3 I.u0 I.u1 I.u2 I.u3 I.uTop
+  cpsTripleWithin 556 (I.base + loopBodyOff) (I.base + denormOff)
+    (divCode_v4 I.base)
+    (loopN1Iter210PreWithScratchNoX1 I.sp
+      I.jOld I.v5Old I.v6Old I.v7Old I.v10Old I.v11Old I.v2Old
+      I.v0 I.v1 I.v2 I.v3
+      I.u0Orig2 r3.2.1 r3.2.2.1 r3.2.2.2.1 r3.2.2.2.2.1
+      I.u0Orig1 I.u0Orig0 I.q2Old I.q1Old I.q0Old
+      (I.base + div128CallRetOff) I.v0 (divKTrialCallV4DLo I.v0)
+      (divKTrialCallV4Un0 I.u0) ** (.x1 ↦ᵣ I.raVal))
+    (loopN1Iter210PostNoX1 false false false I.sp I.base I.v0 I.v1 I.v2 I.v3
+      I.u0Orig2 r3.2.1 r3.2.2.1 r3.2.2.2.1 r3.2.2.2.2.1
+      I.u0Orig1 I.u0Orig0 (I.base + div128CallRetOff) I.v0
+      (divKTrialCallV4DLo I.v0) (divKTrialCallV4Un0 I.u0) ** (.x1 ↦ᵣ I.raVal))
+
+/-- Bundled all-max tail after the first j=3 call-body step over the full `divCode_v4` bundle. -/
+theorem divK_loop_n1_call_iter210_exact_x1_framed_v4_input
+    (I : LoopN1CallMaxmaxmaxExactInputs)
+    (hh : loopN1CallMaxmaxmaxExactInputHypotheses I) :
+    loopN1CallMaxmaxmaxIter210ExactInputSpecV4 I := by
+  unfold loopN1CallMaxmaxmaxIter210ExactInputSpecV4
+  let r3 := loopN1CallMaxmaxmaxR3 I.v0 I.v1 I.v2 I.v3 I.u0 I.u1 I.u2 I.u3 I.uTop
+  exact divK_loop_n1_iter210_maxmaxmax_exact_x1_v4 I.sp I.base
+    I.jOld I.v5Old I.v6Old I.v7Old I.v10Old I.v11Old I.v2Old
+    I.v0 I.v1 I.v2 I.v3
+    I.u0Orig2 r3.2.1 r3.2.2.1 r3.2.2.2.1 r3.2.2.2.2.1
+    I.u0Orig1 I.u0Orig0 I.q2Old I.q1Old I.q0Old
+    (I.base + div128CallRetOff) I.v0 (divKTrialCallV4DLo I.v0)
+    (divKTrialCallV4Un0 I.u0) I.raVal
+    (by
+      dsimp only [r3]
+      exact loopN1CallMaxmaxmaxExactInputHypotheses_hbltu2 I hh)
+    (by
+      dsimp only [r3]
+      have h := loopN1CallMaxmaxmaxExactInputHypotheses_hbltu1 I hh
+      unfold loopN1CallMaxmaxmaxR2 at h
+      exact h)
+    (by
+      dsimp only [r3]
+      have h := loopN1CallMaxmaxmaxExactInputHypotheses_hbltu0 I hh
+      unfold loopN1CallMaxmaxmaxR1 at h
+      unfold loopN1CallMaxmaxmaxR2 at h
+      exact h)
+    (loopN1CallMaxmaxmaxExactInputHypotheses_carry2 I hh)
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add a full divCode_v4 bundled spec for the n=1 call/max/max/max iter210 input tail
- prove the bundled iter210 input bridge via the existing full-code iter210 wrapper

## Verification
- lake build EvmAsm.Evm64.DivMod.Compose.FullPathN1V4
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- scripts/check-file-size.sh
- scripts/check-file-size.sh --report
- scripts/check-unimported.sh
- rg -n "DivStackSpecCase|ModStackSpecCase|SDivStackSpecCase|SModStackSpecCase|StackSpecCase|set_option maxRecDepth|set_option maxHeartbeats|sorry|admit" EvmAsm/Evm64/DivMod/Compose/FullPathN1V4.lean