### PR TITLE
feat(stateless): header_validate_extra_data_length (PR-K68)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -5751,6 +5751,82 @@ def ziskValidateHeaderBasicProbeUnit : BuildUnit := {
   dataAsm     := ziskValidateHeaderBasicDataSection
 }
 
+/-! ## header_validate_extra_data_length -- PR-K68
+
+    Verify the Ethereum spec constraint that `header.extra_data`
+    is at most 32 bytes (Yellow Paper §4.4.4).
+
+    Mirrors the Python check in `validate_header`:
+
+      assert len(header.extra_data) <= 32
+
+    Composes PR-K20 `rlp_list_nth_item` to extract field 12
+    (extra_data) and a single u64 compare.
+
+    Calling convention:
+      a0 (input)  : header_rlp ptr
+      a1 (input)  : header_rlp byte length
+      ra (input)  : return
+      a0 (output) :
+        0  : extra_data length ≤ 32 bytes
+        1  : extra_data length > 32 bytes (reject)
+        2  : RLP parse failure (e.g. not a list, field missing)
+
+    Uses two 8-byte `.data` scratch slots (`hved_off`,
+    `hved_len`). -/
+def headerValidateExtraDataLengthFunction : String :=
+  "header_validate_extra_data_length:\n" ++
+  "  addi sp, sp, -16\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  li a2, 12\n" ++
+  "  la a3, hved_off\n" ++
+  "  la a4, hved_len\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lhved_parse_fail\n" ++
+  "  la t0, hved_len; ld t1, 0(t0)\n" ++
+  "  li t2, 32\n" ++
+  "  bgtu t1, t2, .Lhved_too_long\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lhved_ret\n" ++
+  ".Lhved_too_long:\n" ++
+  "  li a0, 1\n" ++
+  "  j .Lhved_ret\n" ++
+  ".Lhved_parse_fail:\n" ++
+  "  li a0, 2\n" ++
+  ".Lhved_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  addi sp, sp, 16\n" ++
+  "  ret"
+
+/-- `zisk_header_validate_extra_data_length`: probe BuildUnit.
+    Reads (header_len, header_bytes), writes 8-byte status. -/
+def ziskHeaderValidateExtraDataLengthPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a3, 0x40000000\n" ++
+  "  ld a1, 8(a3)                # header_len\n" ++
+  "  addi a0, a3, 16             # header ptr\n" ++
+  "  jal ra, header_validate_extra_data_length\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lhved_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  headerValidateExtraDataLengthFunction ++ "\n" ++
+  ".Lhved_pdone:"
+
+def ziskHeaderValidateExtraDataLengthDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "hved_off:\n" ++
+  "  .zero 8\n" ++
+  "hved_len:\n" ++
+  "  .zero 8"
+
+def ziskHeaderValidateExtraDataLengthProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskHeaderValidateExtraDataLengthPrologue
+  dataAsm     := ziskHeaderValidateExtraDataLengthDataSection
+}
+
 /-! ## u256_add_be -- PR-K51 modular addition on BE u256 buffers
 
     Compute `(a + b) mod 2^256` over two 32-byte big-endian
@@ -8885,6 +8961,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_header_extended_decode" => some ziskHeaderExtendedDecodeProbeUnit
   | "zisk_coinbase_extract_from_header" => some ziskCoinbaseExtractFromHeaderProbeUnit
   | "zisk_validate_header_basic" => some ziskValidateHeaderBasicProbeUnit
+  | "zisk_header_validate_extra_data_length" => some ziskHeaderValidateExtraDataLengthProbeUnit
   | "zisk_u256_add_be"          => some ziskU256AddBeProbeUnit
   | "zisk_u256_sub_be"          => some ziskU256SubBeProbeUnit
   | "zisk_u256_eq"              => some ziskU256EqProbeUnit
@@ -8959,6 +9036,7 @@ def knownProgramNames : List String :=
    "zisk_header_extended_decode",
    "zisk_coinbase_extract_from_header",
    "zisk_validate_header_basic",
+   "zisk_header_validate_extra_data_length",
    "zisk_u256_add_be",
    "zisk_u256_sub_be",
    "zisk_u256_eq",

--- a/scripts/codegen-zisk-header-validate-extra-data-length-check.sh
+++ b/scripts/codegen-zisk-header-validate-extra-data-length-check.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# codegen-zisk-header-validate-extra-data-length-check.sh -- PR-K68.
+#
+# Verify header.extra_data <= 32 bytes per Ethereum spec.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_header_validate_extra_data_length ELF"
+lake exe codegen --program zisk_header_validate_extra_data_length --halt linux93 \
+  -o gen-out/zisk_header_validate_extra_data_length
+
+REPO_ROOT="$(pwd)"
+
+build_header() {
+  local extra_data_hex="$1"
+  uv run --directory execution-specs --quiet python3 -c "
+import sys
+import rlp
+extra = bytes.fromhex('$extra_data_hex')
+fields = [
+    b'\x11' * 32, b'\x22' * 32, b'\x33' * 20, b'\x44' * 32,
+    b'\x55' * 32, b'\x66' * 32, b'\x00' * 256, 0,
+    100, 0x1c9c380, 0x100, 1700000000,
+    extra,                # 12: extra_data (variable)
+    b'\x77' * 32,         # 13: prev_randao
+    b'\x00' * 8,          # 14: nonce
+]
+sys.stdout.buffer.write(rlp.encode(fields))
+"
+}
+
+# run_case <name> <expected_status> <extra_data_hex>
+run_case() {
+  local name="$1" expected_status="$2" extra_hex="$3"
+
+  local header_file="$REPO_ROOT/gen-out/zisk_header_validate_extra_data_length_${name}.header"
+  local in_file="$REPO_ROOT/gen-out/zisk_header_validate_extra_data_length_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_header_validate_extra_data_length_${name}.output"
+
+  build_header "$extra_hex" > "$header_file"
+  python3 -c "
+import struct, sys
+with open(sys.argv[1], 'rb') as f:
+    body = f.read()
+out  = struct.pack('<Q', len(body))
+out += body
+pad = (-(8 + len(body))) % 8
+if pad:
+    out += b'\x00' * pad
+sys.stdout.buffer.write(out)
+" "$header_file" > "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_header_validate_extra_data_length.elf \
+    -i "$in_file" -o "$out_file" -n 500000 \
+    >"$REPO_ROOT/gen-out/zisk_header_validate_extra_data_length_${name}.emu.log" 2>&1 || true
+
+  local actual; actual="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local exp_le; exp_le="$(python3 -c "print(int('$expected_status').to_bytes(8, 'little').hex())")"
+
+  if [[ "$actual" == "$exp_le" ]]; then
+    printf "  %-30s OK   status=%d (extra_len=%d)\n" "$name" "$expected_status" "$((${#extra_hex} / 2))"
+    return 0
+  else
+    printf "  %-30s FAIL  expected status=%d got 0x%s\n" "$name" "$expected_status" "$actual"
+    return 1
+  fi
+}
+
+FAILED=0
+# Pass cases (len ≤ 32)
+run_case "empty_extra"         0 ""                                                || FAILED=1
+run_case "one_byte"            0 "ff"                                              || FAILED=1
+run_case "4_bytes"             0 "74657374"                                         || FAILED=1  # b'test'
+run_case "31_bytes"            0 "$(printf 'aa%.0s' $(seq 1 31))"                  || FAILED=1
+run_case "32_bytes_max"        0 "$(printf 'aa%.0s' $(seq 1 32))"                  || FAILED=1
+run_case "32_zero_bytes"       0 "$(printf '00%.0s' $(seq 1 32))"                  || FAILED=1
+# Reject cases (len > 32)
+run_case "33_bytes"            1 "$(printf 'bb%.0s' $(seq 1 33))"                  || FAILED=1
+run_case "64_bytes"            1 "$(printf 'cc%.0s' $(seq 1 64))"                  || FAILED=1
+run_case "100_bytes"           1 "$(printf 'dd%.0s' $(seq 1 100))"                 || FAILED=1
+# 200 bytes — triggers long-string RLP prefix path
+run_case "200_bytes_long_rlp"  1 "$(printf 'ee%.0s' $(seq 1 200))"                 || FAILED=1
+
+# Non-list input (parse fail)
+NON_LIST_FILE="$REPO_ROOT/gen-out/zisk_header_validate_extra_data_length_non_list.input"
+python3 -c "
+import struct, sys
+b = bytes([0x80])
+with open(sys.argv[1], 'wb') as f:
+    f.write(struct.pack('<Q', len(b)))
+    f.write(b)
+    f.write(b'\x00' * 7)
+" "$NON_LIST_FILE"
+"$ZISKEMU" -e gen-out/zisk_header_validate_extra_data_length.elf \
+  -i "$NON_LIST_FILE" -o "$REPO_ROOT/gen-out/zisk_header_validate_extra_data_length_non_list.output" \
+  -n 500000 >"$REPO_ROOT/gen-out/zisk_header_validate_extra_data_length_non_list.emu.log" 2>&1 || true
+NL_STATUS="$(xxd -p -l 8 "$REPO_ROOT/gen-out/zisk_header_validate_extra_data_length_non_list.output" | tr -d '\n')"
+if [[ "$NL_STATUS" == "0200000000000000" ]]; then
+  printf "  %-30s OK   status=2 (parse fail)\n" "non_list_parse_fail"
+else
+  printf "  %-30s FAIL  status=0x%s\n" "non_list_parse_fail" "$NL_STATUS"
+  FAILED=1
+fi
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: header_validate_extra_data_length enforces ≤ 32-byte limit"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Verify the Ethereum spec constraint that `header.extra_data` is at most 32 bytes (Yellow Paper §4.4.4). Mirrors Python's check in `validate_header`:

```python
assert len(header.extra_data) <= 32
```

Composes PR-K20 `rlp_list_nth_item` to extract field 12 + single u64 compare. Distinct return codes:
- `0`: extra_data length ≤ 32
- `1`: extra_data length > 32 (reject)
- `2`: RLP parse failure (e.g. not a list, field missing)

## Test plan

- [x] `lake build` clean
- [x] `scripts/codegen-zisk-header-validate-extra-data-length-check.sh` passes 11 fixtures:
  - 6 pass cases (empty, 1 byte, `b'test'`, 31 bytes, 32 bytes max, 32 zero bytes)
  - 4 reject cases (33, 64, 100, 200 bytes — 200 exercises the long-string RLP path)
  - Non-list parse fail (status=2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)