### PR TITLE
fix(divmod): point call addback predicate at v4

### DIFF
--- a/EvmAsm/Evm64/DivMod/Counterexamples.lean
+++ b/EvmAsm/Evm64/DivMod/Counterexamples.lean
@@ -8,6 +8,7 @@
 import EvmAsm.Evm64.DivMod.Callable
 import EvmAsm.Evm64.DivMod.Program
 import EvmAsm.Evm64.DivMod.LoopDefs.IterV4
+import EvmAsm.Evm64.DivMod.Spec.CallAddback
 
 namespace EvmAsm.Evm64
 
@@ -130,6 +131,12 @@ abbrev ceA_u4 : Word := ceA_a3 >>> 1
 abbrev ceA_u3 : Word := ceA_a3 <<< 63
 abbrev ceA_qTrue : Nat := 2^63 + 2^32 - 2
 abbrev ceA_qHatV4 : Word := BitVec.ofNat 64 (ceA_qTrue + 1)
+abbrev ceA_a : EvmWord :=
+  EvmWord.fromLimbs fun i : Fin 4 =>
+    match i with | 0 => 0 | 1 => 0 | 2 => 0 | 3 => ceA_a3
+abbrev ceA_b : EvmWord :=
+  EvmWord.fromLimbs fun i : Fin 4 =>
+    match i with | 0 => 0 | 1 => 0 | 2 => ceA_b2 | 3 => ceA_b3
 
 theorem div128Quot_v4_counterexampleA_exact :
     div128Quot_v4 ceA_u4 ceA_u3 ceA_b3Norm = ceA_qHatV4 := by
@@ -138,6 +145,11 @@ theorem div128Quot_v4_counterexampleA_exact :
 theorem div128Quot_v4_counterexampleA_within_two_addbacks :
     (div128Quot_v4 ceA_u4 ceA_u3 ceA_b3Norm).toNat ≤ ceA_qTrue + 2 := by
   decide
+
+theorem n4CallAddbackBeqSemanticHolds_counterexampleA_v4 :
+    n4CallAddbackBeqSemanticHolds ceA_a ceA_b := by
+  rw [n4CallAddbackBeqSemantic_unfold]
+  native_decide
 
 /-- Per-counterexample regression pin: the executable DIV body is on the v4
     path, and the normalized trial quotient for counterexample A has the v4

--- a/EvmAsm/Evm64/DivMod/Spec/CallAddback.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/CallAddback.lean
@@ -15,6 +15,7 @@
 
 import EvmAsm.Evm64.DivMod.Spec.CallSkip
 import EvmAsm.Evm64.DivMod.Spec.CallSkipUnconditional
+import EvmAsm.Evm64.DivMod.LoopDefs.IterV4
 
 namespace EvmAsm.Evm64
 
@@ -27,63 +28,20 @@ open EvmAsm.Rv64.Tactics
 -- Call+addback BEQ semantic predicate marker (n=4, shift ≠ 0)
 -- ============================================================================
 
-/-- Semantic-correctness precondition for the n=4 call+addback-BEQ sub-path:
-    the final `q_out` (= `qHat - 1` single-addback or `qHat - 2` double-addback)
-    equals `⌊val256(a)/val256(b)⌋`.
+/-- Semantic-correctness precondition for the n=4 call+addback-BEQ sub-path
+    under the repaired v4 trial quotient: the final `q_out`
+    (= `qHat - 1` single-addback or `qHat - 2` double-addback) equals
+    `⌊val256(a)/val256(b)⌋`.
 
-    Unlike `n4CallSkipSemanticHolds` which states a lower-bound on the raw
-    `div128Quot`, this predicate directly states that the post-addback
-    corrected quotient is the true quotient. Proving it from first
-    principles requires the Knuth TAOCP Theorem B overestimate bound
-    (`q̂ ≤ q_true + 2`) plus the algorithm's addback-correction semantics,
-    which combine to ensure q_out is exactly correct. Deferred to a future
-    task; the stack spec delegates the proof to callers.
-
-    **🚨 STATUS (2026-04-27, updated): real correctness bug in algorithm**.
-
-    Verified via `lean_run_code`: with
-    `a3 = 2^63 + 2^33, a2 = a1 = a0 = 0, b3 = 1, b2 = 2^33 - 1,
-    b1 = b0 = 0`, the input satisfies ALL runtime preconditions for
-    the call-addback-BEQ branch (hbnz, hb3nz, hshift_nz, hbltu,
-    hborrow, hcarry2_nz), but the algorithm computes
-    `q_out = qHat - 1 = 2^63 + 2^33 - 4 = 9223372045444710396` while
-    `q_true = val256(a) / val256(b) = 2^63 + 2^32 - 2 = 9223372041149743102`.
-    The discrepancy is `2^32 - 2` ≈ 4.3 × 10⁹.
-
-    **Root cause**: our `div128Quot` does only 1 Phase 1b correction
-    (vs Knuth classical 2-correction loop), so qHat can overshoot at
-    val256 level by up to ~2^33. The actual RISC-V program at
-    `Program.lean:386` has an addback LOOP (`BEQ x7 x0` jumps back if
-    x7 = 0), but the loop-exit heuristic "limb-3 carry of addback ≠ 0"
-    fires after 1 addback in this case — leaving q_out = qHat - 1,
-    still ~2^32 too large.
-
-    **Implication**: the algorithm is genuinely buggy on this input
-    class. This predicate is provably FALSE on runtime-reachable inputs.
-    Closure theorems for it cannot be proven; the
-    user-facing `evm_div_n4_full_call_addback_beq_stack_pre_spec` and
-    its relatives are vacuous on this input class.
-
-    See `memory/project_n4callbeq_addback_overshoot_2pow32.md` and
-    `memory/project_knuth_d_one_correction_design.md` for the full
-    analysis.
-
-    **Remediation options**:
-    1. Modify `div128Quot` to do 2 Phase 1b corrections (matching Knuth
-       classical D3 loop). Restores Knuth Theorem B's per-digit ≤ 2
-       overshoot bound. Requires changing both Lean abstraction and
-       RISC-V code.
-    2. Modify the addback loop's exit condition to detect 2^32-scale
-       overshoots (e.g., bound iteration count by some explicit limit
-       and re-check). Non-trivial.
-    3. Document the input class as out-of-scope and gate it externally.
-       Pragmatically blocks complete EVM-level verification.
-
-    **BLOCKER for Phase 2a**: do not try to discharge this predicate under the
-    current algorithm. It is false on runtime-reachable inputs until the
-    addback loop / qHat correction logic is repaired.
-
-    Mirror of `n4CallSkipSemanticHolds` for the call+addback branch. -/
+    Unlike `n4CallSkipSemanticHolds`, which states a lower-bound on the raw
+    trial quotient, this predicate directly states that the post-addback
+    corrected quotient is the true quotient. The old v1 marker used
+    `div128Quot`; that version was false on runtime-reachable inputs because
+    the one-correction quotient could overshoot by a 2^32-scale amount. The
+    executable DIV/MOD paths now use `div128Quot_v4`, which performs the
+    repaired two-correction trial quotient. The remaining closure theorem for
+    this predicate is expected to combine the v4 Knuth-B overestimate
+    (`qHat ≤ q_true + 2`) with the double-addback loop semantics. -/
 def n4CallAddbackBeqSemanticHolds (a b : EvmWord) : Prop :=
   let shift := (clzResult (b.getLimbN 3)).1.toNat % 64
   let antiShift := (signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 3)).1).toNat % 64
@@ -96,7 +54,7 @@ def n4CallAddbackBeqSemanticHolds (a b : EvmWord) : Prop :=
   let u2 := ((a.getLimbN 2) <<< shift) ||| ((a.getLimbN 1) >>> antiShift)
   let u1 := ((a.getLimbN 1) <<< shift) ||| ((a.getLimbN 0) >>> antiShift)
   let u0 := (a.getLimbN 0) <<< shift
-  let qHat := div128Quot u4 u3 b3'
+  let qHat := div128Quot_v4 u4 u3 b3'
   let ms := mulsubN4 qHat b0' b1' b2' b3' u0 u1 u2 u3
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 b0' b1' b2' b3'
   let q_out : Word :=
@@ -129,7 +87,7 @@ theorem n4CallAddbackBeqSemantic_unfold {a b : EvmWord} :
      let u2 := ((a.getLimbN 2) <<< shift) ||| ((a.getLimbN 1) >>> antiShift)
      let u1 := ((a.getLimbN 1) <<< shift) ||| ((a.getLimbN 0) >>> antiShift)
      let u0 := (a.getLimbN 0) <<< shift
-     let qHat := div128Quot u4 u3 b3'
+     let qHat := div128Quot_v4 u4 u3 b3'
      let ms := mulsubN4 qHat b0' b1' b2' b3' u0 u1 u2 u3
      let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 b0' b1' b2' b3'
      let q_out : Word :=


### PR DESCRIPTION
## Summary
- migrate n4CallAddbackBeqSemanticHolds from the known-false v1 div128Quot marker to div128Quot_v4
- replace the stale false-algorithm doc block with the current v4 closure note
- keep the unfold theorem in sync with the v4 quotient expression

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.CallAddback
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- rg -n "DivStackSpecCase|ModStackSpecCase|SDivStackSpecCase|SModStackSpecCase|StackSpecCase|set_option maxRecDepth|set_option maxHeartbeats|sorry|admit" EvmAsm/Evm64/DivMod/Spec/CallAddback.lean