### PR TITLE
feat(smod): expose return stack spec surface

### DIFF
--- a/EvmAsm/Evm64/SMod/Spec.lean
+++ b/EvmAsm/Evm64/SMod/Spec.lean
@@ -79,6 +79,79 @@ theorem evm_smod_prefix_mod_call_dispatch_ready_stack_spec_within
       v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
       shiftMem nMem jMem retMem dMem dloMem scratchUn0 base)
 
+/-- Stack-level SMOD v4 bridge from the public two-word EVM stack assertion
+    through the wrapper prefix, unsigned-MOD callable, result-sign fix, and
+    saved-RA return.
+
+    The unsigned-MOD callable proof remains an explicit parameter. This keeps
+    the public SMOD spec surface free of branch-certificate case types while
+    still exposing the full wrapper return path for callers that can supply the
+    current no-NOP MOD callable theorem. -/
+theorem evm_smod_mod_call_return_stack_spec_within
+    (vRa vSavedOld sp sDividendOld x13Old sDivisorOld
+      dividendMaskOld dividendValueOld dividendCarryOld : Word)
+    (dividend divisor : EvmWord)
+    (v2 v5 v6 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (base : Word) (h_base : base &&& 1 = 0)
+    (h_stack :
+      EvmAsm.Rv64.cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
+        (base + wrapperEndOff) ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
+        (EvmAsm.Evm64.sharedDivModCodeNoNop_v4 (base + wrapperEndOff))
+        (EvmAsm.Evm64.divModStackDispatchPreCallable sp
+          (smodAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
+            (dividend.getLimbN 2) (dividend.getLimbN 3))
+          (smodAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
+            (divisor.getLimbN 2) (divisor.getLimbN 3))
+          ((base + modCallOff) + 4)
+          v2 v5 v6
+          (smodAbsSum3 (divisor.getLimbN 0) (divisor.getLimbN 1)
+            (divisor.getLimbN 2) (divisor.getLimbN 3))
+          (smodAbsMask (divisor.getLimbN 3))
+          (smodAbsCarry3 (divisor.getLimbN 0) (divisor.getLimbN 1)
+            (divisor.getLimbN 2) (divisor.getLimbN 3))
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+        (EvmAsm.Evm64.modStackDispatchPostCallable sp
+          (smodAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
+            (dividend.getLimbN 2) (dividend.getLimbN 3))
+          (smodAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
+            (divisor.getLimbN 2) (divisor.getLimbN 3)) **
+          (.x1 ↦ᵣ ((base + modCallOff) + 4)))) :
+    EvmAsm.Rv64.cpsTripleWithin
+      (49 + (((EvmAsm.Evm64.unifiedDivBound + 1) + 21) + 1))
+      base (vRa &&& ~~~(1 : Word)) (smodCodeV4 base)
+      (((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ vSavedOld)) **
+        ((.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sDividendOld) ** (.x13 ↦ᵣ x13Old) **
+          (.x9 ↦ᵣ sDivisorOld) ** (.x0 ↦ᵣ (0 : Word)) **
+          (.x10 ↦ᵣ dividendMaskOld) ** (.x7 ↦ᵣ dividendValueOld) **
+          (.x11 ↦ᵣ dividendCarryOld))) **
+        evmStackIs sp [dividend, divisor]) **
+        ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
+          EvmAsm.Evm64.divScratchValuesCallNoX1 sp
+            q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+            shiftMem nMem jMem retMem dMem dloMem scratchUn0))
+      (saveRaAbsThenModCallReturnPost vRa sp base
+        (dividend.getLimbN 0) (dividend.getLimbN 1)
+        (dividend.getLimbN 2) (dividend.getLimbN 3)
+        (divisor.getLimbN 0) (divisor.getLimbN 1)
+        (divisor.getLimbN 2) (divisor.getLimbN 3)) := by
+  exact EvmAsm.Rv64.cpsTripleWithin_seq_same_cr
+    (evm_smod_prefix_mod_call_dispatch_ready_stack_spec_within
+      vRa vSavedOld sp sDividendOld x13Old sDivisorOld
+      dividendMaskOld dividendValueOld dividendCarryOld dividend divisor
+      v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 base)
+    (saveRaAbsThenModCall_then_return_named_post_normalized_from_noNop_spec_in_smodCodeV4
+      vRa sp base
+      (dividend.getLimbN 0) (dividend.getLimbN 1)
+      (dividend.getLimbN 2) (dividend.getLimbN 3)
+      (divisor.getLimbN 0) (divisor.getLimbN 1)
+      (divisor.getLimbN 2) (divisor.getLimbN 3)
+      v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 h_base h_stack)
+
 -- Placeholder: final `evm_smod_stack_spec_within` lands after the remaining
 -- callable-return and semantic-handler bridges are collapsed into one theorem.
 


### PR DESCRIPTION
## Summary
- add a stacked SMOD v4 stack theorem sequencing the public prefix spec through the callable return path
- keep the unsigned MOD no-NOP callable proof explicit as h_stack
- expose saveRaAbsThenModCallReturnPost from the public evmStackIs [dividend, divisor] precondition without branch-certificate case types

## Verification
- lake build EvmAsm.Evm64.SMod.Spec
- lake build EvmAsm.Evm64.SMod
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- rg -n "DivStackSpecCase|ModStackSpecCase|SDivStackSpecCase|SModStackSpecCase|StackSpecCase|set_option maxRecDepth|set_option maxHeartbeats|sorry|admit" EvmAsm/Evm64/SMod/Spec.lean