### PR TITLE
feat(divmod): expose mod n4 v4 max-skip loop

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -52,6 +52,7 @@ import EvmAsm.Evm64.DivMod.LoopIterN3CallAddbackV4NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN4MaxV4NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN4CallV4NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN4AddbackV4NoNop
+import EvmAsm.Evm64.DivMod.Compose.ModFullPathN4V4NoNop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4BeqV4NoNop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V4NoNop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V4

--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPathN4V4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPathN4V4NoNop.lean
@@ -1,0 +1,79 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.ModFullPathN4V4NoNop
+
+  v4/no-NOP wrappers for the n=4 MOD loop-body surfaces.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.V4Code
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4Loop
+import EvmAsm.Evm64.DivMod.LoopIterN4MaxV4NoNop
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)
+
+/-- Loop body n=4, max+skip, j=0 over `modCode_noNop_v4`, with
+    sp-relative addresses in the precondition. -/
+theorem divK_loop_body_n4_max_skip_j0_norm_mod_v4_noNop (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (hbltu : ¬BitVec.ult uTop v3) :
+    (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+     then (1 : Word) else 0) = (0 : Word) →
+    cpsTripleWithin 76 (base + loopBodyOff) (base + denormOff) (modCode_noNop_v4 base)
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
+       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
+       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
+       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
+       ((sp + 32) ↦ₘ v0) ** ((sp + signExtend12 4056) ↦ₘ u0) **
+       ((sp + 40) ↦ₘ v1) ** ((sp + signExtend12 4048) ↦ₘ u1) **
+       ((sp + 48) ↦ₘ v2) ** ((sp + signExtend12 4040) ↦ₘ u2) **
+       ((sp + 56) ↦ₘ v3) ** ((sp + signExtend12 4032) ↦ₘ u3) **
+       ((sp + signExtend12 4024) ↦ₘ uTop) **
+       ((sp + signExtend12 4088) ↦ₘ qOld))
+      (loopBodyN4SkipPost sp (0 : Word) (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro hborrow
+  have raw := divK_loop_body_n4_max_skip_j0_v4_spec_within_noNop
+    sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base
+    hbltu hborrow
+  have raw' := cpsTripleWithin_extend_code
+    (hmono := sharedDivModCodeNoNop_v4_sub_modCode_noNop_v4) raw
+  rw [loopBodyN4MaxSkipJ0Pre_unfold] at raw'
+  simp only [se12_32, se12_40, se12_48, se12_56,
+             u_base_off0_j0, u_base_off4088_j0, u_base_off4080_j0,
+             u_base_off4072_j0, u_base_off4064_j0, q_addr_j0] at raw'
+  rw [loopBodyN4MaxSkipJ0Post_unfold] at raw'
+  exact raw'
+
+/-- Loop body n=4, max+skip, j=0 over the full `modCode_v4` bundle. -/
+theorem divK_loop_body_n4_max_skip_j0_norm_mod_v4 (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (hbltu : ¬BitVec.ult uTop v3) :
+    (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+     then (1 : Word) else 0) = (0 : Word) →
+    cpsTripleWithin 76 (base + loopBodyOff) (base + denormOff) (modCode_v4 base)
+      ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
+       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
+       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
+       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
+       ((sp + 32) ↦ₘ v0) ** ((sp + signExtend12 4056) ↦ₘ u0) **
+       ((sp + 40) ↦ₘ v1) ** ((sp + signExtend12 4048) ↦ₘ u1) **
+       ((sp + 48) ↦ₘ v2) ** ((sp + signExtend12 4040) ↦ₘ u2) **
+       ((sp + 56) ↦ₘ v3) ** ((sp + signExtend12 4032) ↦ₘ u3) **
+       ((sp + signExtend12 4024) ↦ₘ uTop) **
+       ((sp + signExtend12 4088) ↦ₘ qOld))
+      (loopBodyN4SkipPost sp (0 : Word) (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro hborrow
+  exact cpsTripleWithin_modCode_noNop_v4_to_modCode_v4
+    (divK_loop_body_n4_max_skip_j0_norm_mod_v4_noNop sp base
+      jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld hbltu hborrow)
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add a MOD n=4 v4 max-skip loop-body wrapper over modCode_noNop_v4
- lift that wrapper to the full modCode_v4 bundle
- import the new surface from the DivMod umbrella without changing the core Compose umbrella import graph

## Checks
- lake build EvmAsm.Evm64.DivMod.Compose.ModFullPathN4V4NoNop
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- forbidden-pattern scan on touched Lean files