### PR TITLE
feat(divmod): expose mod v4 epilogue code helper

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/V4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/V4NoNop.lean
@@ -195,6 +195,14 @@ theorem sharedNoNop_v4_b9_mod {b : Word} :
     ∀ a i, (CodeReq.ofProg (b + denormOff) divK_denorm) a = some i →
       (modCode_noNop_v4 b) a = some i := by
   unfold modCode_noNop_v4; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
+/-- MOD epilogue block is included in the MOD no-NOP v4 code surface. -/
+theorem modNoNop_v4_b10_modEpilogue {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + epilogueOff) (divK_mod_epilogue 24)) a = some i →
+      (modCode_noNop_v4 b) a = some i := by
+  unfold modCode_noNop_v4; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
+  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
+  exact CodeReq.union_mono_left
 theorem sharedNoNop_v4_b10_mod {b : Word} :
     ∀ a i, (CodeReq.ofProg (b + zeroPathOff) divK_zeroPath) a = some i →
       (modCode_noNop_v4 b) a = some i := by


### PR DESCRIPTION
## Summary
- add a public inclusion theorem for the MOD no-NOP v4 epilogue block
- prepare the v4 MOD denorm/epilogue composition layer to reuse the existing code surface helper

## Checks
- lake build EvmAsm.Evm64.DivMod.Compose.V4NoNop
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- rg forbidden-pattern scan on EvmAsm/Evm64/DivMod/Compose/V4NoNop.lean