### PR TITLE
feat(divmod): expose mod v4 phasec2 ntaken

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPathN4V4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPathN4V4NoNop.lean
@@ -17,6 +17,56 @@ namespace EvmAsm.Evm64
 open EvmAsm.Rv64
 open EvmAsm.Rv64.AddrNorm (bv64_4mul_3 se12_32 se12_40 se12_48 se12_56)
 
+/-- Phase C2 not-taken over the no-NOP v4 MOD code bundle. -/
+theorem divK_phaseC2_ntaken_spec_within_mod_v4_noNop
+    (sp shift v2 shiftMem : Word) (base : Word) (hshift_nz : shift ≠ 0) :
+    cpsTripleWithin 4 (base + phaseC2Off) (base + normBOff) (modCode_noNop_v4 base)
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - shift)) **
+       (.x0 ↦ᵣ (0 : Word)) ** ((sp + signExtend12 3992) ↦ₘ shift)) := by
+  have hbody := divK_phaseC2_body_spec_within sp shift v2 shiftMem 172 (base + phaseC2Off)
+  have hbodye := cpsTripleWithin_extend_code (hmono := by
+    unfold divK_phaseC2_code
+    intro a i h
+    exact sharedNoNop_v4_b3_mod a i h) hbody
+  have hbeq_raw := beq_spec_gen_within .x6 .x0 172 shift (0 : Word) (base + phaseC2Off + 12)
+  rw [show (base + phaseC2Off + 12 : Word) + signExtend13 172 = base + copyAUOff from by rv64_addr,
+      show (base + phaseC2Off + 12 : Word) + 4 = base + normBOff from by bv_addr] at hbeq_raw
+  have hbeq_clean := cpsBranchWithin_ntakenStripPure2 hbeq_raw
+    (fun hp hQt => by
+      obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
+      exact absurd ((sepConj_pure_right _).mp h_rest).2 (show shift ≠ (0 : Word) from hshift_nz))
+  have hbeq := cpsTripleWithin_extend_code (hmono := by
+    intro a i h
+    exact sharedNoNop_v4_b3_mod a i
+      (CodeReq.singleton_mono (by
+        have hlookup := CodeReq.ofProg_lookup (base + phaseC2Off) (divK_phaseC2 172) 3
+          (by decide) (by decide)
+        rw [bv64_4mul_3] at hlookup
+        exact hlookup) a i h)) hbeq_clean
+  have hbeqf := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - shift)) **
+     ((sp + signExtend12 3992) ↦ₘ shift))
+    (by pcFree) hbeq
+  have hC2 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hbodye hbeqf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    hC2
+
+/-- Phase C2 not-taken over the full v4 MOD code bundle. -/
+theorem divK_phaseC2_ntaken_spec_within_mod_v4
+    (sp shift v2 shiftMem : Word) (base : Word) (hshift_nz : shift ≠ 0) :
+    cpsTripleWithin 4 (base + phaseC2Off) (base + normBOff) (modCode_v4 base)
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - shift)) **
+       (.x0 ↦ᵣ (0 : Word)) ** ((sp + signExtend12 3992) ↦ₘ shift)) := by
+  exact cpsTripleWithin_modCode_noNop_v4_to_modCode_v4
+    (divK_phaseC2_ntaken_spec_within_mod_v4_noNop sp shift v2 shiftMem base hshift_nz)
+
 /-- MOD denorm body over the no-NOP v4 MOD code bundle. -/
 theorem mod_denorm_body_spec_within_noNop_v4
     (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Word) :


### PR DESCRIPTION
## Summary
- add PhaseC2 not-taken wrappers over modCode_noNop_v4 and modCode_v4
- use the public shared MOD no-NOP v4 block inclusion helper for PhaseC2
- prepare MOD v4 preloop composition without relying on DIV-only code bundles

## Checks
- lake build EvmAsm.Evm64.DivMod.Compose.ModFullPathN4V4NoNop
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- rg forbidden-pattern scan on EvmAsm/Evm64/DivMod/Compose/ModFullPathN4V4NoNop.lean