### PR TITLE
feat(divmod): expose mod v4 loopsetup

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPathN4V4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPathN4V4NoNop.lean
@@ -324,6 +324,56 @@ theorem divK_normA_full_spec_within_mod_v4 (sp a0 a1 a2 a3 v5 v7 v10 shift antiS
     (divK_normA_full_spec_within_mod_v4_noNop sp a0 a1 a2 a3 v5 v7 v10 shift antiShift
       u0Old u1Old u2Old u3Old u4Old base)
 
+/-- LoopSetup not-taken over the no-NOP v4 MOD code bundle. -/
+theorem divK_loopSetup_ntaken_spec_within_mod_v4_noNop (sp n v1 v5 : Word) (base : Word)
+    (hm_ge : ¬BitVec.slt (signExtend12 (4 : BitVec 12) - n) (0 : Word)) :
+    let m := signExtend12 (4 : BitVec 12) - n
+    cpsTripleWithin 4 (base + loopSetupOff) (base + loopBodyOff) (modCode_noNop_v4 base)
+      (divKLoopSetupNtakenPreNoNop sp v5 v1 n)
+      (divKLoopSetupNtakenPostNoNop sp n m) := by
+  intro m
+  rw [divKLoopSetupNtakenPreNoNop_unfold, divKLoopSetupNtakenPostNoNop_unfold]
+  have hbody := divK_loopSetup_body_spec_within sp n v1 v5 464 (base + loopSetupOff)
+  have hbodye := cpsTripleWithin_extend_code (hmono := by
+    unfold divK_loopSetup_code
+    intro a i h
+    exact sharedNoNop_v4_b7_mod a i h) hbody
+  have hblt_raw := blt_spec_gen_within .x9 .x0 464 m (0 : Word) (base + loopSetupOff + 12)
+  rw [show (base + loopSetupOff + 12 : Word) + signExtend13 464 = base + denormOff from by rv64_addr,
+      show (base + loopSetupOff + 12 : Word) + 4 = base + loopBodyOff from by bv_addr] at hblt_raw
+  have hblt_clean := cpsBranchWithin_ntakenStripPure2 hblt_raw
+    (fun hp hQt => by
+      obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
+      exact absurd ((sepConj_pure_right _).mp h_rest).2 hm_ge)
+  have hblte := cpsTripleWithin_extend_code (hmono := by
+    intro a i h
+    exact sharedNoNop_v4_b7_mod a i
+      (CodeReq.singleton_mono (by
+        have hlookup := CodeReq.ofProg_lookup (base + loopSetupOff) (divK_loopSetup 464) 3
+          (by decide) (by decide)
+        rw [bv64_4mul_3] at hlookup
+        exact hlookup) a i h)) hblt_clean
+  have hbltef := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ n) ** ((sp + signExtend12 3984) ↦ₘ n))
+    (by pcFree) hblte
+  have h12 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hbodye hbltef
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    h12
+
+/-- LoopSetup not-taken over the full v4 MOD code bundle. -/
+theorem divK_loopSetup_ntaken_spec_within_mod_v4 (sp n v1 v5 : Word) (base : Word)
+    (hm_ge : ¬BitVec.slt (signExtend12 (4 : BitVec 12) - n) (0 : Word)) :
+    let m := signExtend12 (4 : BitVec 12) - n
+    cpsTripleWithin 4 (base + loopSetupOff) (base + loopBodyOff) (modCode_v4 base)
+      (divKLoopSetupNtakenPreNoNop sp v5 v1 n)
+      (divKLoopSetupNtakenPostNoNop sp n m) := by
+  intro m
+  exact cpsTripleWithin_modCode_noNop_v4_to_modCode_v4
+    (divK_loopSetup_ntaken_spec_within_mod_v4_noNop sp n v1 v5 base hm_ge)
+
 /-- MOD denorm body over the no-NOP v4 MOD code bundle. -/
 theorem mod_denorm_body_spec_within_noNop_v4
     (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Word) :


### PR DESCRIPTION
## Summary
- add LoopSetup not-taken wrappers over modCode_noNop_v4 and modCode_v4
- reuse the public shared MOD no-NOP v4 LoopSetup block inclusion helper
- complete the core MOD v4 preloop component surface after PhaseC2, NormB, and NormA

## Checks
- lake build EvmAsm.Evm64.DivMod.Compose.ModFullPathN4V4NoNop
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- rg forbidden-pattern scan on EvmAsm/Evm64/DivMod/Compose/ModFullPathN4V4NoNop.lean