### PR TITLE
feat(divmod): compose mod v4 shift0 loopsetup

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -53,6 +53,7 @@ import EvmAsm.Evm64.DivMod.LoopIterN4MaxV4NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN4CallV4NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN4AddbackV4NoNop
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN4V4NoNop
+import EvmAsm.Evm64.DivMod.Compose.ModShift0LoopSetupN4V4NoNop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4BeqV4NoNop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V4NoNop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V4

--- a/EvmAsm/Evm64/DivMod/Compose/ModShift0LoopSetupN4V4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModShift0LoopSetupN4V4NoNop.lean
@@ -1,0 +1,283 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.ModShift0LoopSetupN4V4NoNop
+
+  v4/no-NOP MOD n=4 shift-zero path from entry to loop setup.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.ModFullPathN4V4NoNop
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (bv64_4mul_3 se12_0)
+
+/-- Phase C2 taken over the no-NOP v4 MOD code bundle. -/
+theorem divK_phaseC2_taken_spec_within_mod_v4_noNop
+    (sp shift v2 shiftMem : Word) (base : Word) (hshift_z : shift = 0) :
+    cpsTripleWithin 4 (base + phaseC2Off) (base + copyAUOff) (modCode_noNop_v4 base)
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - shift)) **
+       (.x0 ↦ᵣ (0 : Word)) ** ((sp + signExtend12 3992) ↦ₘ shift)) := by
+  have hbody := divK_phaseC2_body_spec_within sp shift v2 shiftMem 172 (base + phaseC2Off)
+  have hbodye := cpsTripleWithin_extend_code (hmono := by
+    unfold divK_phaseC2_code
+    intro a i h
+    exact sharedNoNop_v4_b3_mod a i h) hbody
+  have hbeq_raw := beq_spec_gen_within .x6 .x0 172 shift (0 : Word) (base + phaseC2Off + 12)
+  rw [show (base + phaseC2Off + 12 : Word) + signExtend13 172 = base + copyAUOff from by rv64_addr,
+      show (base + phaseC2Off + 12 : Word) + 4 = base + normBOff from by bv_addr] at hbeq_raw
+  have hbeq_clean := cpsBranchWithin_takenStripPure2 hbeq_raw
+    (fun hp hQf => by
+      obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
+      exact absurd hshift_z ((sepConj_pure_right _).mp h_rest).2)
+  have hbeq := cpsTripleWithin_extend_code (hmono := by
+    intro a i h
+    exact @sharedNoNop_v4_b3_mod base a i
+      (CodeReq.singleton_mono (by
+        have hlookup := CodeReq.ofProg_lookup (base + phaseC2Off) (divK_phaseC2 172) 3
+          (by decide) (by decide)
+        rw [bv64_4mul_3] at hlookup
+        exact hlookup) a i h)) hbeq_clean
+  have hbeqf := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - shift)) **
+     ((sp + signExtend12 3992) ↦ₘ shift))
+    (by pcFree) hbeq
+  have hC2 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hbodye hbeqf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    hC2
+
+/-- Phase C2 taken over the full v4 MOD code bundle. -/
+theorem divK_phaseC2_taken_spec_within_mod_v4
+    (sp shift v2 shiftMem : Word) (base : Word) (hshift_z : shift = 0) :
+    cpsTripleWithin 4 (base + phaseC2Off) (base + copyAUOff) (modCode_v4 base)
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - shift)) **
+       (.x0 ↦ᵣ (0 : Word)) ** ((sp + signExtend12 3992) ↦ₘ shift)) := by
+  exact cpsTripleWithin_modCode_noNop_v4_to_modCode_v4
+    (divK_phaseC2_taken_spec_within_mod_v4_noNop sp shift v2 shiftMem base hshift_z)
+
+/-- CopyAU over the no-NOP v4 MOD code bundle. -/
+theorem mod_copyAU_full_spec_within_v4_noNop (sp : Word)
+    (a0 a1 a2 a3 : Word)
+    (u0 u1 u2 u3 u4 : Word)
+    (v5 : Word) (base : Word) :
+    cpsTripleWithin 9 (base + copyAUOff) (base + loopSetupOff) (modCode_noNop_v4 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + signExtend12 4056) ↦ₘ u0) **
+       ((sp + signExtend12 4048) ↦ₘ u1) **
+       ((sp + signExtend12 4040) ↦ₘ u2) **
+       ((sp + signExtend12 4032) ↦ₘ u3) **
+       ((sp + signExtend12 4024) ↦ₘ u4))
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ a3) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + signExtend12 4056) ↦ₘ a0) **
+       ((sp + signExtend12 4048) ↦ₘ a1) **
+       ((sp + signExtend12 4040) ↦ₘ a2) **
+       ((sp + signExtend12 4032) ↦ₘ a3) **
+       ((sp + signExtend12 4024) ↦ₘ (0 : Word))) := by
+  have hcopy := divK_copyAU_spec_within sp (base + copyAUOff) a0 a1 a2 a3 u0 u1 u2 u3 u4 v5
+  simp only [se12_0] at hcopy
+  rw [show (base + copyAUOff : Word) + 36 = base + loopSetupOff from by bv_addr] at hcopy
+  exact cpsTripleWithin_extend_code (hmono := fun a i h =>
+    sharedNoNop_v4_b6_mod a i h) hcopy
+
+/-- CopyAU over the full v4 MOD code bundle. -/
+theorem mod_copyAU_full_spec_within_v4 (sp : Word)
+    (a0 a1 a2 a3 : Word)
+    (u0 u1 u2 u3 u4 : Word)
+    (v5 : Word) (base : Word) :
+    cpsTripleWithin 9 (base + copyAUOff) (base + loopSetupOff) (modCode_v4 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + signExtend12 4056) ↦ₘ u0) **
+       ((sp + signExtend12 4048) ↦ₘ u1) **
+       ((sp + signExtend12 4040) ↦ₘ u2) **
+       ((sp + signExtend12 4032) ↦ₘ u3) **
+       ((sp + signExtend12 4024) ↦ₘ u4))
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ a3) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + signExtend12 4056) ↦ₘ a0) **
+       ((sp + signExtend12 4048) ↦ₘ a1) **
+       ((sp + signExtend12 4040) ↦ₘ a2) **
+       ((sp + signExtend12 4032) ↦ₘ a3) **
+       ((sp + signExtend12 4024) ↦ₘ (0 : Word))) := by
+  exact cpsTripleWithin_modCode_noNop_v4_to_modCode_v4
+    (mod_copyAU_full_spec_within_v4_noNop sp a0 a1 a2 a3 u0 u1 u2 u3 u4 v5 base)
+
+/-- MOD n=4 shift-zero path from entry to loop body start over the no-NOP v4 MOD code bundle. -/
+theorem evm_mod_n4_shift0_to_loopSetup_spec_within_v4_noNop (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3nz : b3 ≠ 0)
+    (hshift_z : (clzResult b3).1 = 0) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 9 + 4) base (base + loopBodyOff) (modCode_noNop_v4 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+       ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+       ((sp + signExtend12 4024) ↦ₘ u4Old) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (4 : Word)) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ (clzResult b3).1) ** (.x7 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
+       (.x2 ↦ᵣ signExtend12 (0 : BitVec 12) - (clzResult b3).1) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4056) ↦ₘ a0) ** ((sp + signExtend12 4048) ↦ₘ a1) **
+       ((sp + signExtend12 4040) ↦ₘ a2) ** ((sp + signExtend12 4032) ↦ₘ a3) **
+       ((sp + signExtend12 4024) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (4 : Word)) **
+       ((sp + signExtend12 3992) ↦ₘ (clzResult b3).1)) := by
+  have hABCLZ := evm_mod_phaseAB_n4_clz_spec_within_v4_noNop sp base b0 b1 b2 b3 v5 v6 v7 v10
+    q0 q1 q2 q3 u5 u6 u7 nMem hbnz hb3nz
+  have hABCLZf := cpsTripleWithin_frameR
+    ((.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
+     (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+     ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+     ((sp + signExtend12 4024) ↦ₘ u4Old) **
+     ((sp + signExtend12 3992) ↦ₘ shiftMem))
+    (by pcFree) hABCLZ
+  have hC2 := divK_phaseC2_taken_spec_within_mod_v4_noNop sp ((clzResult b3).1)
+    ((clzResult b3).2 >>> (63 : Nat)) shiftMem base hshift_z
+  have hC2f := cpsTripleWithin_frameR
+    ((.x5 ↦ᵣ (clzResult b3).2) ** (.x10 ↦ᵣ b3) **
+     (.x7 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
+     (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+     ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+     ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+     ((sp + signExtend12 4024) ↦ₘ u4Old) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (4 : Word)))
+    (by pcFree) hC2
+  have hABC2 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hABCLZf hC2f
+  have hCopy := mod_copyAU_full_spec_within_v4_noNop sp a0 a1 a2 a3
+    u0Old u1Old u2Old u3Old u4Old ((clzResult b3).2) base
+  have hCopyf := cpsTripleWithin_frameR
+    ((.x6 ↦ᵣ (clzResult b3).1) **
+     (.x2 ↦ᵣ signExtend12 (0 : BitVec 12) - (clzResult b3).1) **
+     (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ b3) **
+     (.x7 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
+     (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+     ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (4 : Word)) **
+     ((sp + signExtend12 3992) ↦ₘ (clzResult b3).1))
+    (by pcFree) hCopy
+  have hABC2C := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hABC2 hCopyf
+  have hLS := divK_loopSetup_ntaken_spec_within_mod_v4_noNop sp (4 : Word)
+    (signExtend12 (4 : BitVec 12) - (4 : Word)) a3 base
+    (by decide)
+  simp only [divKLoopSetupNtakenPreNoNop_unfold,
+      divKLoopSetupNtakenPostNoNop_unfold] at hLS
+  have hLSf := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ b3) **
+     (.x6 ↦ᵣ (clzResult b3).1) **
+     (.x2 ↦ᵣ signExtend12 (0 : BitVec 12) - (clzResult b3).1) **
+     (.x7 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
+     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+     ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4056) ↦ₘ a0) ** ((sp + signExtend12 4048) ↦ₘ a1) **
+     ((sp + signExtend12 4040) ↦ₘ a2) ** ((sp + signExtend12 4032) ↦ₘ a3) **
+     ((sp + signExtend12 4024) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3992) ↦ₘ (clzResult b3).1))
+    (by pcFree) hLS
+  have hFull := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hABC2C hLSf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    hFull
+
+/-- MOD n=4 shift-zero path from entry to loop body start over the full v4 MOD code bundle. -/
+theorem evm_mod_n4_shift0_to_loopSetup_spec_within_v4 (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3nz : b3 ≠ 0)
+    (hshift_z : (clzResult b3).1 = 0) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 9 + 4) base (base + loopBodyOff) (modCode_v4 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+       ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+       ((sp + signExtend12 4024) ↦ₘ u4Old) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (4 : Word)) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ (clzResult b3).1) ** (.x7 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
+       (.x2 ↦ᵣ signExtend12 (0 : BitVec 12) - (clzResult b3).1) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4056) ↦ₘ a0) ** ((sp + signExtend12 4048) ↦ₘ a1) **
+       ((sp + signExtend12 4040) ↦ₘ a2) ** ((sp + signExtend12 4032) ↦ₘ a3) **
+       ((sp + signExtend12 4024) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (4 : Word)) **
+       ((sp + signExtend12 3992) ↦ₘ (clzResult b3).1)) := by
+  exact cpsTripleWithin_modCode_noNop_v4_to_modCode_v4
+    (evm_mod_n4_shift0_to_loopSetup_spec_within_v4_noNop sp base
+      a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10
+      q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem
+      hbnz hb3nz hshift_z)
+
+end EvmAsm.Evm64


### PR DESCRIPTION
Summary:
- add MOD v4/no-NOP wrappers for PhaseC2 taken and CopyAU
- compose the MOD n=4 shift-zero path from entry to LoopSetup in a split module
- import the new module from the DivMod umbrella

Tests:
- lake build EvmAsm.Evm64.DivMod.Compose.ModShift0LoopSetupN4V4NoNop
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- forbidden scan: rg -n "DivStackSpecCase|ModStackSpecCase|SDivStackSpecCase|SModStackSpecCase|StackSpecCase|set_option maxRecDepth|set_option maxHeartbeats|sorry|admit" EvmAsm/Evm64/DivMod/Compose/ModShift0LoopSetupN4V4NoNop.lean EvmAsm/Evm64/DivMod.lean