### PR TITLE
feat(smod): use canonical code in v4 handle

### DIFF
--- a/EvmAsm/Evm64/SMod/Compose/CodeHandles.lean
+++ b/EvmAsm/Evm64/SMod/Compose/CodeHandles.lean
@@ -14,9 +14,10 @@ namespace EvmAsm.Evm64.SMod.Compose
 abbrev smodCode (base : Word) : EvmAsm.Rv64.CodeReq :=
   EvmAsm.Rv64.CodeReq.ofProg base EvmAsm.Evm64.evm_smod_legacy
 
-/-- v4 full SMOD code region handle: wrapper followed by `evm_mod_callable_v4`. -/
+/-- v4 full SMOD code region handle: the canonical production `evm_smod`
+    body, which is the wrapper followed by `evm_mod_callable_v4`. -/
 abbrev smodCodeV4 (base : Word) : EvmAsm.Rv64.CodeReq :=
-  EvmAsm.Rv64.CodeReq.ofProg base EvmAsm.Evm64.evm_smod_v4
+  EvmAsm.Rv64.CodeReq.ofProg base EvmAsm.Evm64.evm_smod
 
 /-- Code handle for the saved-`ra` prologue block. -/
 abbrev saveRaCode (base : Word) : EvmAsm.Rv64.CodeReq :=


### PR DESCRIPTION
## Summary
- point the SMOD v4 CodeReq handle at canonical production evm_smod
- keep evm_smod_v4 as a compatibility alias while proofs/scripts migrate
- preserve the legacy smodCode handle separately for v1 compatibility proofs

## Checks
- lake build EvmAsm.Evm64.SMod
- lake build EvmAsm.Evm64.DivMod
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- rg forbidden scan on touched Lean file