### PR TITLE
feat(exp): full-loop composition skeleton with isolated body sorry

### DIFF
--- a/EvmAsm/Evm64/Exp.lean
+++ b/EvmAsm/Evm64/Exp.lean
@@ -64,6 +64,7 @@ import EvmAsm.Evm64.Exp.Compose.SavedBitBoundarySeq
 import EvmAsm.Evm64.Exp.Compose.SavedBitLoopEntry
 import EvmAsm.Evm64.Exp.Compose.SavedBitLoopExit
 import EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryLoop
+import EvmAsm.Evm64.Exp.Compose.SavedBitFullLoopBody
 import EvmAsm.Evm64.Exp.Compose.SavedBitTwoMulSkip
 import EvmAsm.Evm64.Exp.Compose.SavedBitTwoMulSkipCanonical
 import EvmAsm.Evm64.Exp.Compose.SavedBitTwoMulCondCall

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFullLoopBody.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFullLoopBody.lean
@@ -1,0 +1,144 @@
+/-
+  EvmAsm.Evm64.Exp.Compose.SavedBitFullLoopBody
+
+  Full-loop body composition for the 256-iteration EXP loop.
+
+  The loop always runs exactly 256 iterations (one per bit of the exponent),
+  counting down from `iterCount = 256` to 0. Each iteration:
+    - Reads the current MSB of the saved exponent register `e`
+    - Squares the accumulator `r`
+    - If the bit is 1, also multiplies by the base `a`
+    - Decrements `iterCount`
+
+  The semantic invariant after k iterations:
+    expResultWord r0..r3 = EvmWord.exp base (top k bits of exponent)
+  This holds at k=0 (r = 1 = base^0) and is maintained by each iteration.
+  After 256 iterations, r = EvmWord.exp base exponent.
+
+  Key proof obligation (left as `sorry`):
+  - `hEntry`: bridge from `expTwoMulLoopEntryPost` (initial r=1, iterCount=256)
+    to the first `expTwoMulIterPre` with concrete witnesses.
+  - `hBody`: 256-iteration body proof, needs the semantic invariant at each step.
+
+  Refs: GH #92, parent evm-asm-20z6, bead evm-asm-w5mk.
+  Authored by @pirapira; implemented by Claude Code.
+-/
+
+import EvmAsm.Evm64.Exp.Compose.SavedBitBoundaryLoop
+import EvmAsm.Evm64.Exp.Compose.SavedBitLoopEntry
+import EvmAsm.Evm64.Exp.Compose.SavedBitIterMerge
+import EvmAsm.Evm64.Exp.Compose.SavedBitIterPosts
+import EvmAsm.Evm64.Exp.Compose.SavedBitTwoMulCond
+import EvmAsm.Evm64.EvmWordArith.Exp
+
+namespace EvmAsm.Evm64.Exp.Compose
+
+open EvmAsm.Rv64 (Assertion CodeReq
+  cpsTripleWithin cpsTripleWithin_extend_code cpsTripleWithin_weaken
+  cpsTripleWithin_seq_same_cr cpsTripleWithin_mono_nSteps
+  memOwn regOwn signExtend12 signExtend21)
+
+-- ============================================================================
+-- Structural peeling lemma for one iteration
+-- ============================================================================
+
+/-- Peel one iteration from an `(n+1)`-iteration body spec.  A thin wrapper
+    around `exp_two_mul_iterations_body_peel_with_exit_cases_closed_bound_spec_within`
+    exposing the canonical shape used in `expFullLoopBodySpec`. -/
+theorem expFullLoopBodyNSpec
+    (n : Nat)
+    (e iterCount v18 sp evmSp vOld r0 r1 r2 r3 d0 d1 d2 d3
+      e0 e1 e2 e3 a0 a1 a2 a3 iterCountFinal tOld out0 out1 out2 out3 : Word)
+    (base : Word)
+    (baseWord : EvmWord) (rest : List EvmWord) (exitCond : Prop)
+    (hbase : base &&& 1 = 0)
+    (hCondExit :
+      ∀ hp,
+        expTwoMulIterCondPost (expTwoMulIterCountNew iterCount)
+          (expTwoMulIterBit e) sp evmSp base a0 a1 a2 a3
+          (expTwoMulIterRw r0 r1 r2 r3 a0 a1 a2 a3)
+          (expTwoMulIterCountNew iterCount = 0) hp →
+        expTwoMulLoopExitPre sp evmSp iterCountFinal tOld out0 out1 out2 out3
+          baseWord rest exitCond hp)
+    (hSkipExit :
+      ∀ hp,
+        expTwoMulIterSkipPost (expTwoMulIterCountNew iterCount)
+          (expTwoMulIterBit e) sp evmSp base a0 a1 a2 a3
+          (expTwoMulSquareW r0 r1 r2 r3)
+          (expTwoMulIterCountNew iterCount = 0) hp →
+        expTwoMulLoopExitPre sp evmSp iterCountFinal tOld out0 out1 out2 out3
+          baseWord rest exitCond hp)
+    (hTail :
+      cpsTripleWithin (n * 189) (base + 28) (base + 264)
+        (evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode base)
+        (expTwoMulIterLoopPost (expTwoMulIterCountNew iterCount)
+          (expTwoMulIterBit e) sp evmSp base a0 a1 a2 a3
+          (expTwoMulSquareW r0 r1 r2 r3)
+          (expTwoMulIterRw r0 r1 r2 r3 a0 a1 a2 a3))
+        (expTwoMulLoopExitPre sp evmSp iterCountFinal tOld out0 out1 out2 out3
+          baseWord rest exitCond)) :
+    cpsTripleWithin ((n + 1) * 189) (base + 28) (base + 264)
+      (evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode base)
+      (expTwoMulIterPre e iterCount v18 sp evmSp vOld r0 r1 r2 r3
+        d0 d1 d2 d3 e0 e1 e2 e3 a0 a1 a2 a3)
+      (expTwoMulLoopExitPre sp evmSp iterCountFinal tOld out0 out1 out2 out3
+        baseWord rest exitCond) :=
+  exp_two_mul_iterations_body_peel_with_exit_cases_closed_bound_spec_within
+    n e iterCount v18 sp evmSp vOld r0 r1 r2 r3 d0 d1 d2 d3
+    e0 e1 e2 e3 a0 a1 a2 a3 iterCountFinal tOld out0 out1 out2 out3
+    base baseWord rest exitCond hbase hCondExit hSkipExit hTail
+
+-- ============================================================================
+-- Full 256-iteration boundary spec
+-- ============================================================================
+
+/-- The full 256-iteration EXP boundary spec (bead evm-asm-w5mk, GH #92).
+
+    Pre:  `expTwoMulBoundaryPre sp evmSp cOld tOld m0..m3 vOld v18 baseWord exponentWord rest`
+    Post: `expTwoMulLoopExitPost sp evmSp 0 r0..r3 baseWord rest exitCond`
+          where `exitCond = expResultWord r0..r3 = EvmWord.exp baseWord exponentWord`.
+
+    The two `sorry`-marked proof obligations:
+    1. `hEntry`: bridge from the loop entry state (r=1, iterCount=256, a=baseWord)
+       to the first `expTwoMulIterPre` with concrete witnesses extracted from
+       the loop entry post-state.
+    2. `hBody`: the 256-step body proof from first `expTwoMulIterPre` to
+       `expTwoMulLoopExitPre`. This is built by 256 applications of
+       `expFullLoopBodyNSpec`, threading the semantic invariant
+       (expResultWord r = base^(top k bits of exp) after k iterations)
+       through each exit bridge. -/
+theorem expFullLoopBodySpec
+    (sp evmSp cOld tOld m0 m1 m2 m3 vOld v18 : Word)
+    (baseWord exponentWord : EvmWord) (rest : List EvmWord)
+    (base : Word) (hbase : base &&& 1 = 0) :
+    let result := EvmWord.exp baseWord exponentWord
+    let r0 := result.getLimbN 0
+    let r1 := result.getLimbN 1
+    let r2 := result.getLimbN 2
+    let r3 := result.getLimbN 3
+    cpsTripleWithin expTwoMulFullLoopBoundaryBound base (base + 304)
+      (evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode base)
+      (expTwoMulBoundaryPre sp evmSp cOld tOld m0 m1 m2 m3 vOld v18
+        baseWord exponentWord rest)
+      (expTwoMulLoopExitPost sp evmSp 0 r0 r1 r2 r3
+        baseWord rest (expResultWord r0 r1 r2 r3 = result)) := by
+  intro result
+  let r0 := result.getLimbN 0
+  let r1 := result.getLimbN 1
+  let r2 := result.getLimbN 2
+  let r3 := result.getLimbN 3
+  -- Both goals are left as `sorry` pending the semantic invariant proof.
+  -- The actual `P` is `expTwoMulIterPre` with witnesses extracted from the
+  -- loop entry state (iterCount=256, r=1, a=baseWord) per SavedBitLoopEntry.
+  -- hEntry maps `expTwoMulLoopEntryPost` to `P`.
+  -- hBody chains 256 peel applications via `expFullLoopBodyNSpec`.
+  exact @exp_two_mul_full_loop_boundary_of_entry_body_spec_within
+    sorry   -- P: first iteration's expTwoMulIterPre (witnesses from loop entry)
+    sp evmSp cOld tOld m0 m1 m2 m3 vOld v18 0 r0 r1 r2 r3
+    baseWord exponentWord rest
+    (expResultWord r0 r1 r2 r3 = result)
+    base
+    sorry   -- hEntry: expTwoMulLoopEntryPost → expTwoMulIterPre
+    sorry   -- hBody: 256-iteration proof from expTwoMulIterPre to loopExitPre
+
+end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFullLoopBody.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFullLoopBody.lean
@@ -17,16 +17,19 @@
 
   Architecture:
   - `expFullLoopBodyNSpec`: structural peel wrapper (sorry-free)
-  - `expFullLoopBodySpec`: full 256-iter boundary using the direct loop interface
-    `exp_two_mul_full_loop_boundary_of_bounded_body_spec_within` which takes:
-      hLoop : expTwoMulLoopEntryPost → expTwoMulLoopExitPre
-    directly, without needing the IterPre bridge.
+  - `expTwoMulLoopBodyCorrect`: named sorry for the 256-iteration invariant
+  - `expFullLoopBodySpec`: full boundary spec, proved using the above
 
-  The remaining `sorry` is the loop invariant proof in `hLoop`:
-  - Start: r = 1, iterCount = 256
-  - After k iterations: r = base^(top k bits of exponent), iterCount = 256-k
-  - End: r = base^exponent, iterCount = 0
-  This requires 256 applications of the single-iteration spec.
+  The single `sorry` in `expTwoMulLoopBodyCorrect` encapsulates the
+  MSB-first square-and-multiply algorithm correctness:
+    ∀ baseWord exponentWord, the 256-iteration loop starting from r=1
+    produces r = EvmWord.exp baseWord exponentWord.
+  This is a semantic proof obligation separate from the structural
+  composition (which is `expFullLoopBodySpec`).
+
+  Note: `expResultWord r.getLimbN 0..3 = r` holds by
+  `expResultWord_getLimbN_self`, so the exitCond in expFullLoopBodySpec
+  is a tautology — the loop needs only to produce the correct r values.
 
   Refs: GH #92, parent evm-asm-20z6, bead evm-asm-w5mk.
   Authored by @pirapira; implemented by Claude Code.
@@ -38,6 +41,7 @@ import EvmAsm.Evm64.Exp.Compose.SavedBitIterMerge
 import EvmAsm.Evm64.Exp.Compose.SavedBitIterPosts
 import EvmAsm.Evm64.Exp.Compose.SavedBitTwoMulCond
 import EvmAsm.Evm64.EvmWordArith.Exp
+import EvmAsm.Evm64.Exp.LimbSpec
 
 namespace EvmAsm.Evm64.Exp.Compose
 
@@ -97,29 +101,55 @@ theorem expFullLoopBodyNSpec
     base baseWord rest exitCond hbase hCondExit hSkipExit hTail
 
 -- ============================================================================
+-- Key semantic correctness lemma (sorry)
+-- ============================================================================
+
+/-- The 256-iteration MSB-first square-and-multiply loop body is correct:
+    starting from `expTwoMulLoopEntryPost` (r = 1, iterCount = 256),
+    the loop terminates with `expTwoMulLoopExitPre` (r = base^exp, iterCount = 0).
+
+    This is the ONLY sorry in `expFullLoopBodySpec`. Its proof requires:
+    1. An invariant: after k iterations, r = baseWord^(exponentWord >> (256-k)).
+    2. 256 applications of `expFullLoopBodyNSpec` threading this invariant.
+    3. Connection: the MSB-first bit processing of `exponentWord` gives base^exp.
+
+    The invariant proof is the core of the EXP algorithm correctness.
+    Steps 1-2 are purely structural (RISC-V operational).
+    Step 3 is mathematical (binary square-and-multiply is correct).
+
+    Note: `tOld` is the x5 value at loop exit (determined by the loop).
+    `expResultWord_getLimbN_self` ensures exitCond is trivially True. -/
+theorem expTwoMulLoopBodyCorrect
+    (sp evmSp vOld tOld v18 : Word)
+    (baseWord exponentWord : EvmWord) (rest : List EvmWord)
+    (base : Word) (hbase : base &&& 1 = 0) :
+    let result := EvmWord.exp baseWord exponentWord
+    cpsTripleWithin expTwoMulFullLoopBodyBound (base + 28) (base + 264)
+      (evmExpMsbSavedBitTwoMulCanonicalAppendedMulCode base)
+      (expTwoMulLoopEntryPost sp evmSp vOld v18 baseWord exponentWord rest)
+      (expTwoMulLoopExitPre sp evmSp 0 tOld
+        (result.getLimbN 0) (result.getLimbN 1) (result.getLimbN 2) (result.getLimbN 3)
+        baseWord rest
+        (expResultWord (result.getLimbN 0) (result.getLimbN 1)
+          (result.getLimbN 2) (result.getLimbN 3) = result)) := by
+  intro result
+  -- exitCond = expResultWord result.getLimbN 0..3 = result = True (by getLimbN_self)
+  -- The loop maintains r = base^(top k bits of exp) after k iterations.
+  -- After 256 iterations: r = base^exp, stored in scratch at sp+0..sp+24.
+  sorry
+
+-- ============================================================================
 -- Full 256-iteration boundary spec
 -- ============================================================================
 
 /-- The full 256-iteration EXP boundary spec (bead evm-asm-w5mk, GH #92).
 
-    Pre:  `expTwoMulBoundaryPre sp evmSp cOld tOld m0..m3 vOld v18 baseWord exponentWord rest`
-    Post: `expTwoMulLoopExitPost sp evmSp 0 r0..r3 baseWord rest exitCond`
-          where `exitCond = expResultWord r0..r3 = EvmWord.exp baseWord exponentWord`.
+    Reduces to `expTwoMulLoopBodyCorrect` (the semantic loop correctness)
+    via `exp_two_mul_full_loop_boundary_of_bounded_body_spec_within`.
 
-    Proof structure: `exp_two_mul_full_loop_boundary_of_bounded_body_spec_within`
-    wraps boundary prologue/epilogue around `hLoop`. The `hLoop` hypothesis proves:
-      expTwoMulLoopEntryPost → expTwoMulLoopExitPre
-    in ≤ 48384 steps, which is the key semantic obligation.
-
-    The `hLoop` proof requires the 256-iteration invariant:
-    - Initial: r = 1, iterCount = 256
-    - Step k: r = baseWord^(top k bits of exponentWord)
-    - Final: r = EvmWord.exp baseWord exponentWord, iterCount = 0
-
-    Each iteration applies `expFullLoopBodyNSpec` (via the peel lemma).
-
-    This `sorry` is the only remaining obligation: proving the 256-iteration
-    loop body invariant. -/
+    Key facts used:
+    - `expResultWord_getLimbN_self`: exitCond is a tautology.
+    - The boundary framework wraps prologue/epilogue around hLoop. -/
 theorem expFullLoopBodySpec
     (sp evmSp cOld tOld m0 m1 m2 m3 vOld v18 : Word)
     (baseWord exponentWord : EvmWord) (rest : List EvmWord)
@@ -136,23 +166,18 @@ theorem expFullLoopBodySpec
       (expTwoMulLoopExitPost sp evmSp 0 r0 r1 r2 r3
         baseWord rest (expResultWord r0 r1 r2 r3 = result)) := by
   intro result
-  let r0 := result.getLimbN 0
-  let r1 := result.getLimbN 1
-  let r2 := result.getLimbN 2
-  let r3 := result.getLimbN 3
-  -- Use the bounded-body boundary wrapper.
-  -- The key obligation is `hLoop`: 256 iterations from LoopEntryPost to LoopExitPre.
-  apply exp_two_mul_full_loop_boundary_of_bounded_body_spec_within
-      sp evmSp cOld tOld m0 m1 m2 m3 vOld v18 0 r0 r1 r2 r3
-      baseWord exponentWord rest
-      (expResultWord r0 r1 r2 r3 = result) base
-  -- Bound: expTwoMulFullLoopBodyBound = 48384
-  · exact le_refl _
-  -- hLoop: 256-iteration body proof
-  -- Start: expTwoMulLoopEntryPost (r=1, iterCount=256)
-  -- End: expTwoMulLoopExitPre (r=base^exp, iterCount=0)
-  -- Built by 256 applications of expFullLoopBodyNSpec via the peel lemma,
-  -- threading the semantic invariant at each step.
-  · sorry
+  -- Use expTwoMulLoopBodyCorrect with tOld = tOld (outer parameter)
+  -- to get hLoop with matching tOld in BoundaryPre and LoopExitPre.
+  have hLoop := expTwoMulLoopBodyCorrect sp evmSp vOld tOld v18
+    baseWord exponentWord rest base hbase
+  -- Apply the boundary wrapper
+  exact exp_two_mul_full_loop_boundary_of_bounded_body_spec_within
+    sp evmSp cOld tOld m0 m1 m2 m3 vOld v18 0
+    (result.getLimbN 0) (result.getLimbN 1)
+    (result.getLimbN 2) (result.getLimbN 3)
+    baseWord exponentWord rest
+    (expResultWord (result.getLimbN 0) (result.getLimbN 1)
+       (result.getLimbN 2) (result.getLimbN 3) = result)
+    base (le_refl _) hLoop
 
 end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/Compose/SavedBitFullLoopBody.lean
+++ b/EvmAsm/Evm64/Exp/Compose/SavedBitFullLoopBody.lean
@@ -15,10 +15,18 @@
   This holds at k=0 (r = 1 = base^0) and is maintained by each iteration.
   After 256 iterations, r = EvmWord.exp base exponent.
 
-  Key proof obligation (left as `sorry`):
-  - `hEntry`: bridge from `expTwoMulLoopEntryPost` (initial r=1, iterCount=256)
-    to the first `expTwoMulIterPre` with concrete witnesses.
-  - `hBody`: 256-iteration body proof, needs the semantic invariant at each step.
+  Architecture:
+  - `expFullLoopBodyNSpec`: structural peel wrapper (sorry-free)
+  - `expFullLoopBodySpec`: full 256-iter boundary using the direct loop interface
+    `exp_two_mul_full_loop_boundary_of_bounded_body_spec_within` which takes:
+      hLoop : expTwoMulLoopEntryPost → expTwoMulLoopExitPre
+    directly, without needing the IterPre bridge.
+
+  The remaining `sorry` is the loop invariant proof in `hLoop`:
+  - Start: r = 1, iterCount = 256
+  - After k iterations: r = base^(top k bits of exponent), iterCount = 256-k
+  - End: r = base^exponent, iterCount = 0
+  This requires 256 applications of the single-iteration spec.
 
   Refs: GH #92, parent evm-asm-20z6, bead evm-asm-w5mk.
   Authored by @pirapira; implemented by Claude Code.
@@ -98,15 +106,20 @@ theorem expFullLoopBodyNSpec
     Post: `expTwoMulLoopExitPost sp evmSp 0 r0..r3 baseWord rest exitCond`
           where `exitCond = expResultWord r0..r3 = EvmWord.exp baseWord exponentWord`.
 
-    The two `sorry`-marked proof obligations:
-    1. `hEntry`: bridge from the loop entry state (r=1, iterCount=256, a=baseWord)
-       to the first `expTwoMulIterPre` with concrete witnesses extracted from
-       the loop entry post-state.
-    2. `hBody`: the 256-step body proof from first `expTwoMulIterPre` to
-       `expTwoMulLoopExitPre`. This is built by 256 applications of
-       `expFullLoopBodyNSpec`, threading the semantic invariant
-       (expResultWord r = base^(top k bits of exp) after k iterations)
-       through each exit bridge. -/
+    Proof structure: `exp_two_mul_full_loop_boundary_of_bounded_body_spec_within`
+    wraps boundary prologue/epilogue around `hLoop`. The `hLoop` hypothesis proves:
+      expTwoMulLoopEntryPost → expTwoMulLoopExitPre
+    in ≤ 48384 steps, which is the key semantic obligation.
+
+    The `hLoop` proof requires the 256-iteration invariant:
+    - Initial: r = 1, iterCount = 256
+    - Step k: r = baseWord^(top k bits of exponentWord)
+    - Final: r = EvmWord.exp baseWord exponentWord, iterCount = 0
+
+    Each iteration applies `expFullLoopBodyNSpec` (via the peel lemma).
+
+    This `sorry` is the only remaining obligation: proving the 256-iteration
+    loop body invariant. -/
 theorem expFullLoopBodySpec
     (sp evmSp cOld tOld m0 m1 m2 m3 vOld v18 : Word)
     (baseWord exponentWord : EvmWord) (rest : List EvmWord)
@@ -127,18 +140,19 @@ theorem expFullLoopBodySpec
   let r1 := result.getLimbN 1
   let r2 := result.getLimbN 2
   let r3 := result.getLimbN 3
-  -- Both goals are left as `sorry` pending the semantic invariant proof.
-  -- The actual `P` is `expTwoMulIterPre` with witnesses extracted from the
-  -- loop entry state (iterCount=256, r=1, a=baseWord) per SavedBitLoopEntry.
-  -- hEntry maps `expTwoMulLoopEntryPost` to `P`.
-  -- hBody chains 256 peel applications via `expFullLoopBodyNSpec`.
-  exact @exp_two_mul_full_loop_boundary_of_entry_body_spec_within
-    sorry   -- P: first iteration's expTwoMulIterPre (witnesses from loop entry)
-    sp evmSp cOld tOld m0 m1 m2 m3 vOld v18 0 r0 r1 r2 r3
-    baseWord exponentWord rest
-    (expResultWord r0 r1 r2 r3 = result)
-    base
-    sorry   -- hEntry: expTwoMulLoopEntryPost → expTwoMulIterPre
-    sorry   -- hBody: 256-iteration proof from expTwoMulIterPre to loopExitPre
+  -- Use the bounded-body boundary wrapper.
+  -- The key obligation is `hLoop`: 256 iterations from LoopEntryPost to LoopExitPre.
+  apply exp_two_mul_full_loop_boundary_of_bounded_body_spec_within
+      sp evmSp cOld tOld m0 m1 m2 m3 vOld v18 0 r0 r1 r2 r3
+      baseWord exponentWord rest
+      (expResultWord r0 r1 r2 r3 = result) base
+  -- Bound: expTwoMulFullLoopBodyBound = 48384
+  · exact le_refl _
+  -- hLoop: 256-iteration body proof
+  -- Start: expTwoMulLoopEntryPost (r=1, iterCount=256)
+  -- End: expTwoMulLoopExitPre (r=base^exp, iterCount=0)
+  -- Built by 256 applications of expFullLoopBodyNSpec via the peel lemma,
+  -- threading the semantic invariant at each step.
+  · sorry
 
 end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
## Summary

Rescue PR — branch has 3 commits not on main and never had a PR opened.

- Adds `EvmAsm/Evm64/Exp/Compose/SavedBitFullLoopBody.lean` (+183 lines) — the full-loop composition skeleton for EXP.
- Final commit isolates the remaining open goal into a single named lemma `expTwoMulLoopBodyCorrect` so the surrounding scaffolding is closed and the residual proof obligation is well-localized.
- Tracked by bead `evm-asm-w5mk`.

## Test plan

- [ ] `lake build EvmAsm.Evm64.Exp`
- [ ] Confirm the only `sorry` in the new file is `expTwoMulLoopBodyCorrect` (intentional staging marker per the bead).
- [ ] No regressions in downstream `Exp/Spec.lean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)