### PR TITLE
feat(stateless): effective_gas_price_eip1559 (PR-K70)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -6864,6 +6864,101 @@ def ziskPriorityFeePerGasEip1559ProbeUnit : BuildUnit := {
   dataAsm     := ziskPriorityFeePerGasEip1559DataSection
 }
 
+/-! ## effective_gas_price_eip1559 -- PR-K70
+
+    Compute the effective gas price for an EIP-1559 transaction:
+
+      effective_gas_price = base_fee
+                           + min(max_priority_fee, max_fee - base_fee)
+
+    Equivalent (per Python `transaction_effective_gas_price`):
+
+      effective_gas_price = min(max_fee, base_fee + max_priority_fee)
+
+    The two formulations match because
+    `base + min(max_priority, max_fee - base) =
+     min(base + max_priority, max_fee)`.
+
+    Composes PR-K62 `priority_fee_per_gas_eip1559` (#5612) with
+    PR-K51 `u256_add_be`. The priority-fee step writes its
+    result to `out`; the add step folds `base_fee` in place.
+
+    If `max_fee < base_fee` (would-underflow in the priority-fee
+    step), this helper returns `1` so the caller can reject the
+    tx without inspecting the output.
+
+    Calling convention:
+      a0 (input)  : max_priority_fee_per_gas ptr (32 B BE)
+      a1 (input)  : max_fee_per_gas ptr (32 B BE)
+      a2 (input)  : base_fee_per_gas ptr (32 B BE)
+      a3 (input)  : output ptr (32 B BE; receives effective gas price)
+      ra (input)  : return
+      a0 (output) : 0 success / 1 max_fee < base_fee (reject tx). -/
+def effectiveGasPriceEip1559Function : String :=
+  "effective_gas_price_eip1559:\n" ++
+  "  addi sp, sp, -32\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp)\n" ++
+  "  mv s0, a2                   # base_fee ptr\n" ++
+  "  mv s1, a3                   # out ptr\n" ++
+  "  # Step 1: priority_fee = priority_fee_per_gas_eip1559(...)\n" ++
+  "  jal ra, priority_fee_per_gas_eip1559\n" ++
+  "  bnez a0, .Legpe_fail\n" ++
+  "  # Step 2: effective = base_fee + priority_fee   (out = base + out)\n" ++
+  "  mv a0, s0\n" ++
+  "  mv a1, s1\n" ++
+  "  mv a2, s1\n" ++
+  "  jal ra, u256_add_be         # overflow flag in a0 (always 0 in practice)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Legpe_ret\n" ++
+  ".Legpe_fail:\n" ++
+  "  li a0, 1\n" ++
+  ".Legpe_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp)\n" ++
+  "  addi sp, sp, 32\n" ++
+  "  ret"
+
+/-- `zisk_effective_gas_price_eip1559`: probe BuildUnit. Reads
+    (max_priority, max_fee, base_fee) from host input, writes
+    (status, effective_gas_price) to OUTPUT (40 bytes). -/
+def ziskEffectiveGasPriceEip1559Prologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a4, 0x40000000\n" ++
+  "  addi a0, a4, 8              # max_priority ptr\n" ++
+  "  addi a1, a4, 40             # max_fee ptr\n" ++
+  "  addi a2, a4, 72             # base_fee ptr\n" ++
+  "  li a3, 0xa0010008           # out ptr\n" ++
+  "  mv t0, a3; li t1, 4\n" ++
+  ".Legpe_zout:\n" ++
+  "  beqz t1, .Legpe_zout_done\n" ++
+  "  sd zero, 0(t0)\n" ++
+  "  addi t0, t0, 8\n" ++
+  "  addi t1, t1, -1\n" ++
+  "  j .Legpe_zout\n" ++
+  ".Legpe_zout_done:\n" ++
+  "  jal ra, effective_gas_price_eip1559\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)                # status\n" ++
+  "  j .Legpe_pdone\n" ++
+  u256SubBeFunction ++ "\n" ++
+  u256MinFunction ++ "\n" ++
+  u256AddBeFunction ++ "\n" ++
+  priorityFeePerGasEip1559Function ++ "\n" ++
+  effectiveGasPriceEip1559Function ++ "\n" ++
+  ".Legpe_pdone:"
+
+def ziskEffectiveGasPriceEip1559DataSection : String :=
+  ".section .data\n" ++
+  "egpe_pad:\n" ++
+  "  .zero 8"
+
+def ziskEffectiveGasPriceEip1559ProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskEffectiveGasPriceEip1559Prologue
+  dataAsm     := ziskEffectiveGasPriceEip1559DataSection
+}
+
 
 /-! ## u256_eq -- PR-K53 equality companion to PR-K50 u256_lt
 
@@ -9781,6 +9876,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_u256_max"             => some ziskU256MaxProbeUnit
   | "zisk_u256_div_u64_be"      => some ziskU256DivU64BeProbeUnit
   | "zisk_priority_fee_per_gas_eip1559" => some ziskPriorityFeePerGasEip1559ProbeUnit
+  | "zisk_effective_gas_price_eip1559" => some ziskEffectiveGasPriceEip1559ProbeUnit
   | "zisk_tx_type_dispatch"     => some ziskTxTypeDispatchProbeUnit
   | "zisk_tx_eip2930_decode"    => some ziskTxEip2930DecodeProbeUnit
   | "zisk_tx_eip7702_decode"    => some ziskTxEip7702DecodeProbeUnit
@@ -9864,6 +9960,7 @@ def knownProgramNames : List String :=
    "zisk_u256_max",
    "zisk_u256_div_u64_be",
    "zisk_priority_fee_per_gas_eip1559",
+   "zisk_effective_gas_price_eip1559",
    "zisk_tx_type_dispatch",
    "zisk_tx_eip2930_decode",
    "zisk_tx_eip7702_decode",

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **92**
-- ziskemu round-trip scripts: **85** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **93**
+- ziskemu round-trip scripts: **86** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-effective-gas-price-eip1559-check.sh
+++ b/scripts/codegen-zisk-effective-gas-price-eip1559-check.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# codegen-zisk-effective-gas-price-eip1559-check.sh -- PR-K70.
+#
+# effective_gas_price = base_fee + min(max_priority, max_fee - base_fee)
+#                     = min(max_fee, base_fee + max_priority)
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_effective_gas_price_eip1559 ELF"
+lake exe codegen --program zisk_effective_gas_price_eip1559 --halt linux93 \
+  -o gen-out/zisk_effective_gas_price_eip1559
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <max_priority> <max_fee> <base_fee>
+run_case() {
+  local name="$1" mp="$2" mf="$3" bf="$4"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_effective_gas_price_eip1559_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_effective_gas_price_eip1559_${name}.output"
+  local exp_file="$REPO_ROOT/gen-out/zisk_effective_gas_price_eip1559_${name}.expected"
+
+  python3 -c "
+import struct, sys
+mp = $mp; mf = $mf; bf = $bf
+with open(sys.argv[1], 'wb') as f:
+    f.write(mp.to_bytes(32, 'big'))
+    f.write(mf.to_bytes(32, 'big'))
+    f.write(bf.to_bytes(32, 'big'))
+
+if mf < bf:
+    status = 1
+    egp = 0  # caller ignores; we don't constrain
+else:
+    status = 0
+    surplus = mf - bf
+    priority = min(mp, surplus)
+    egp = bf + priority
+
+with open(sys.argv[2], 'wb') as f:
+    f.write(struct.pack('<Q', status))
+    f.write(egp.to_bytes(32, 'big'))
+" "$in_file" "$exp_file"
+
+  "$ZISKEMU" -e gen-out/zisk_effective_gas_price_eip1559.elf \
+    -i "$in_file" -o "$out_file" -n 500000 \
+    >"$REPO_ROOT/gen-out/zisk_effective_gas_price_eip1559_${name}.emu.log" 2>&1 || true
+
+  # For reject path, only compare status (the out bytes are ignored)
+  local exp_status; exp_status="$(python3 -c "print(1 if $mf < $bf else 0)")"
+  local actual_status; actual_status="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local exp_status_le; exp_status_le="$(python3 -c "print(int('$exp_status').to_bytes(8, 'little').hex())")"
+
+  if [[ "$actual_status" != "$exp_status_le" ]]; then
+    printf "  %-30s FAIL  status expected %d got 0x%s\n" "$name" "$exp_status" "$actual_status"
+    return 1
+  fi
+
+  if [[ "$exp_status" == "1" ]]; then
+    printf "  %-30s OK   status=1 (reject)\n" "$name"
+    return 0
+  fi
+
+  # Pass path: compare full 40-byte output
+  local actual expected
+  actual="$(xxd -p -l 40 "$out_file" | tr -d '\n')"
+  expected="$(xxd -p -l 40 "$exp_file" | tr -d '\n')"
+  if [[ "$actual" == "$expected" ]]; then
+    local egp; egp="$(python3 -c "print($bf + min($mp, $mf - $bf))")"
+    printf "  %-30s OK   status=0 egp=%s\n" "$name" "$egp"
+    return 0
+  else
+    printf "  %-30s FAIL  egp mismatch\n    expected: %s\n    actual:   %s\n" "$name" "$expected" "$actual"
+    return 1
+  fi
+}
+
+GWEI=$(python3 -c "print(10**9)")
+ETH=$(python3 -c "print(10**18)")
+
+FAILED=0
+# Common scenarios
+# 1) max_priority caps; egp = base + max_priority
+run_case "priority_caps_egp"  $(python3 -c "print(2 * $GWEI)") $(python3 -c "print(100 * $GWEI)") $(python3 -c "print(50 * $GWEI)") || FAILED=1
+# 2) surplus caps; egp = max_fee
+run_case "surplus_caps_egp"   $(python3 -c "print(100 * $GWEI)") $(python3 -c "print(55 * $GWEI)") $(python3 -c "print(50 * $GWEI)") || FAILED=1
+# 3) equal max_priority and surplus
+run_case "equal_priority_surplus" $(python3 -c "print(10 * $GWEI)") $(python3 -c "print(60 * $GWEI)") $(python3 -c "print(50 * $GWEI)") || FAILED=1
+# 4) max_fee == base_fee → priority = 0 → egp = base_fee
+run_case "zero_surplus_egp_eq_base" $(python3 -c "print(5 * $GWEI)") $(python3 -c "print(50 * $GWEI)") $(python3 -c "print(50 * $GWEI)") || FAILED=1
+# 5) max_priority == 0 → egp = base
+run_case "zero_priority_egp_eq_base" 0 $(python3 -c "print(50 * $GWEI)") $(python3 -c "print(50 * $GWEI)") || FAILED=1
+# 6) Reject: max_fee < base_fee
+run_case "reject_max_fee_below_base" $(python3 -c "print(5 * $GWEI)") $(python3 -c "print(40 * $GWEI)") $(python3 -c "print(50 * $GWEI)") || FAILED=1
+# 7) base_fee = 0, priority caps
+run_case "zero_base_priority_caps"   $(python3 -c "print(5 * $GWEI)") $(python3 -c "print(50 * $GWEI)") 0 || FAILED=1
+# 8) base_fee = 0, surplus caps
+run_case "zero_base_surplus_caps"    $(python3 -c "print(50 * $GWEI)") $(python3 -c "print(5 * $GWEI)") 0 || FAILED=1
+# 9) Realistic Holesky shape
+run_case "holesky_typical"           $(python3 -c "print(3 * $GWEI)") $(python3 -c "print(35 * $GWEI)") $(python3 -c "print(8 * $GWEI)") || FAILED=1
+# 10) Large u256 values
+MAX=115792089237316195423570985008687907853269984665640564039457584007913129639935
+run_case "max_priority_huge_zero_base" "$MAX" "$MAX" 0 || FAILED=1
+# 11) Cross u128 boundary
+H128=$(python3 -c "print(1 << 128)")
+run_case "h128_boundary"             "$H128" $(python3 -c "print((1 << 128) + 1000)") 999 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: effective_gas_price_eip1559 matches base + min(max_priority, max_fee - base)"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Compute the effective gas price for an EIP-1559 transaction:

```
effective_gas_price = base_fee + min(max_priority_fee, max_fee - base_fee)
                   = min(max_fee, base_fee + max_priority_fee)
```

Mirrors Python `transaction_effective_gas_price`.

## Composition

- PR-K62 `priority_fee_per_gas_eip1559` (#5612) — writes the priority fee to `out`
- PR-K51 `u256_add_be` — folds `base_fee` into `out` in place

If `max_fee < base_fee` (would-underflow in the priority-fee step), K62 returns reject and this helper passes that through as `status=1`.

## Test plan

- [x] `lake build` clean
- [x] `scripts/codegen-zisk-effective-gas-price-eip1559-check.sh` passes 11 fixtures:
  - Priority caps egp, surplus caps egp, exact equality
  - Zero surplus (egp = base), zero max_priority (egp = base)
  - Reject path (`max_fee < base_fee`)
  - Two zero-base shapes (priority/surplus cap)
  - Realistic Holesky
  - Large u256 values (max_priority huge, h128 boundary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)