### PR TITLE
feat(smod): use canonical body in codegen fixtures

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -962,7 +962,7 @@ def evmSmodV4DataSection : String :=
     ((evmSmodV4Dividend ++ evmSmodV4Divisor).map emitDword)
 
 def evmSmodV4Unit : BuildUnit := {
-  body        := EvmAsm.Evm64.evm_smod_v4
+  body        := EvmAsm.Evm64.evm_smod
   prologueAsm := evmSmodV4Prologue
   epilogueAsm := evmSmodV4Epilogue
   dataAsm     := evmSmodV4DataSection
@@ -973,7 +973,7 @@ def evmSmodV4Unit : BuildUnit := {
 def evm_smod_v4_from_input : Program :=
   LI .x5 (INPUT_ADDR + (BitVec.ofNat 64 INPUT_DATA_OFFSET)) ;;
   copy64 .x12 .x5 .x6 ++
-  EvmAsm.Evm64.evm_smod_v4
+  EvmAsm.Evm64.evm_smod
 
 def evmSmodV4FromInputPrologue : String :=
   "  la x1, after_smod\n" ++


### PR DESCRIPTION
## Summary
- keep the existing evm_smod_v4 codegen fixture names but execute canonical evm_smod as the body
- migrate the prover-input SMOD fixture to append canonical evm_smod as well

## Tests
- lake build EvmAsm.Codegen.Programs
- lake build EvmAsm.Codegen
- lake build EvmAsm.Evm64.SMod
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- rg -n "DivStackSpecCase|ModStackSpecCase|SDivStackSpecCase|SModStackSpecCase|StackSpecCase|set_option maxRecDepth|set_option maxHeartbeats|sorry|admit" EvmAsm/Codegen/Programs.lean