### PR TITLE
feat(stateless): tx_cost_compute (PR-K71)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -6970,7 +6970,6 @@ def ziskEffectiveGasPriceEip1559ProbeUnit : BuildUnit := {
   dataAsm     := ziskEffectiveGasPriceEip1559DataSection
 }
 
-
 /-! ## u256_eq -- PR-K53 equality companion to PR-K50 u256_lt
 
     Equality predicate on two 32-byte big-endian `u256` buffers.
@@ -7209,6 +7208,104 @@ def ziskU256MulU64BeProbeUnit : BuildUnit := {
   body        := NOP
   prologueAsm := ziskU256MulU64BePrologue
   dataAsm     := ziskU256MulU64BeDataSection
+}
+
+/-! ## tx_cost_compute -- PR-K71
+
+    Compute the full upfront cost of a transaction:
+
+      tx_cost = gas_limit × effective_gas_price + value
+
+    This is the value that must not exceed `account.balance` for
+    the tx to be valid. Mirrors the Python check in
+    `validate_transaction` / `process_transaction`:
+
+      max_gas_fee = tx.gas * effective_gas_price
+      if sender.balance < max_gas_fee + tx.value:
+          raise InsufficientBalance
+
+    Composes:
+      - PR-K54 `u256_mul_u64_be` for the multiplication step
+      - PR-K51 `u256_add_be` for adding `value`
+
+    Reports overflow on either step via `status=1`. In practice
+    `effective_gas_price ≤ max_fee_per_gas` is u128-sized at
+    most, so the multiplicand fits comfortably; overflow is a
+    "garbage input" safety net.
+
+    BE storage convention: byte 0 = MSB, byte 31 = LSB.
+
+    Calling convention:
+      a0 (input)  : effective_gas_price ptr (32 B BE)
+      a1 (input)  : gas_limit (u64)
+      a2 (input)  : value ptr (32 B BE)
+      a3 (input)  : out ptr (32 B BE; receives tx_cost)
+      ra (input)  : return
+      a0 (output) : 0 success / 1 overflow on mul or add. -/
+def txCostComputeFunction : String :=
+  "tx_cost_compute:\n" ++
+  "  addi sp, sp, -32\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp)\n" ++
+  "  mv s0, a2                   # value ptr\n" ++
+  "  mv s1, a3                   # out ptr\n" ++
+  "  # Step 1: out = effective_gas_price × gas_limit.\n" ++
+  "  mv a2, s1\n" ++
+  "  jal ra, u256_mul_u64_be\n" ++
+  "  bnez a0, .Ltcc_fail\n" ++
+  "  # Step 2: out = out + value.\n" ++
+  "  mv a0, s1\n" ++
+  "  mv a1, s0\n" ++
+  "  mv a2, s1\n" ++
+  "  jal ra, u256_add_be\n" ++
+  "  bnez a0, .Ltcc_fail\n" ++
+  "  li a0, 0\n" ++
+  "  j .Ltcc_ret\n" ++
+  ".Ltcc_fail:\n" ++
+  "  li a0, 1\n" ++
+  ".Ltcc_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp)\n" ++
+  "  addi sp, sp, 32\n" ++
+  "  ret"
+
+/-- `zisk_tx_cost_compute`: probe BuildUnit. Reads (32B egp, 8B
+    gas_limit LE, 32B value) from host input, writes (status,
+    32B tx_cost BE) to OUTPUT (40 bytes total). -/
+def ziskTxCostComputePrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a4, 0x40000000\n" ++
+  "  addi a0, a4, 8              # egp ptr\n" ++
+  "  ld a1, 40(a4)               # gas_limit (u64)\n" ++
+  "  addi a2, a4, 48             # value ptr\n" ++
+  "  li a3, 0xa0010008           # out ptr\n" ++
+  "  mv t0, a3; li t1, 4\n" ++
+  ".Ltcc_zout:\n" ++
+  "  beqz t1, .Ltcc_zout_done\n" ++
+  "  sd zero, 0(t0)\n" ++
+  "  addi t0, t0, 8\n" ++
+  "  addi t1, t1, -1\n" ++
+  "  j .Ltcc_zout\n" ++
+  ".Ltcc_zout_done:\n" ++
+  "  jal ra, tx_cost_compute\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)                # status\n" ++
+  "  j .Ltcc_pdone\n" ++
+  u256MulU64BeFunction ++ "\n" ++
+  u256AddBeFunction ++ "\n" ++
+  txCostComputeFunction ++ "\n" ++
+  ".Ltcc_pdone:"
+
+def ziskTxCostComputeDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "u256m_acc:\n" ++
+  "  .zero 40"
+
+def ziskTxCostComputeProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskTxCostComputePrologue
+  dataAsm     := ziskTxCostComputeDataSection
 }
 
 /-! ## u256_to_u64_be -- PR-K57 truncate BE u256 → u64 with overflow flag
@@ -9888,6 +9985,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_u256_div_u64_be"      => some ziskU256DivU64BeProbeUnit
   | "zisk_priority_fee_per_gas_eip1559" => some ziskPriorityFeePerGasEip1559ProbeUnit
   | "zisk_effective_gas_price_eip1559" => some ziskEffectiveGasPriceEip1559ProbeUnit
+  | "zisk_tx_cost_compute"      => some ziskTxCostComputeProbeUnit
   | "zisk_tx_type_dispatch"     => some ziskTxTypeDispatchProbeUnit
   | "zisk_tx_eip2930_decode"    => some ziskTxEip2930DecodeProbeUnit
   | "zisk_tx_eip7702_decode"    => some ziskTxEip7702DecodeProbeUnit
@@ -9972,6 +10070,7 @@ def knownProgramNames : List String :=
    "zisk_u256_div_u64_be",
    "zisk_priority_fee_per_gas_eip1559",
    "zisk_effective_gas_price_eip1559",
+   "zisk_tx_cost_compute",
    "zisk_tx_type_dispatch",
    "zisk_tx_eip2930_decode",
    "zisk_tx_eip7702_decode",

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **93**
-- ziskemu round-trip scripts: **86** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **94**
+- ziskemu round-trip scripts: **87** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-tx-cost-compute-check.sh
+++ b/scripts/codegen-zisk-tx-cost-compute-check.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# codegen-zisk-tx-cost-compute-check.sh -- PR-K71.
+#
+# tx_cost = gas_limit × effective_gas_price + value
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_tx_cost_compute ELF"
+lake exe codegen --program zisk_tx_cost_compute --halt linux93 \
+  -o gen-out/zisk_tx_cost_compute
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <egp> <gas_limit> <value>
+run_case() {
+  local name="$1" egp="$2" gas="$3" value="$4"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_tx_cost_compute_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_tx_cost_compute_${name}.output"
+  local exp_file="$REPO_ROOT/gen-out/zisk_tx_cost_compute_${name}.expected"
+
+  python3 -c "
+import struct, sys
+egp = $egp; gas = $gas; value = $value
+with open(sys.argv[1], 'wb') as f:
+    f.write(egp.to_bytes(32, 'big'))
+    f.write(struct.pack('<Q', gas))
+    f.write(value.to_bytes(32, 'big'))
+
+MOD = 1 << 256
+mul_overflow = (egp * gas) >= MOD
+gas_fee = (egp * gas) % MOD
+add_overflow = (gas_fee + value) >= MOD
+tx_cost = (gas_fee + value) % MOD
+status = 1 if (mul_overflow or add_overflow) else 0
+
+with open(sys.argv[2], 'wb') as f:
+    f.write(struct.pack('<Q', status))
+    f.write(tx_cost.to_bytes(32, 'big'))
+" "$in_file" "$exp_file"
+
+  "$ZISKEMU" -e gen-out/zisk_tx_cost_compute.elf \
+    -i "$in_file" -o "$out_file" -n 500000 \
+    >"$REPO_ROOT/gen-out/zisk_tx_cost_compute_${name}.emu.log" 2>&1 || true
+
+  local exp_status; exp_status="$(python3 -c "
+egp, gas, value = $egp, $gas, $value
+MOD = 1 << 256
+print(1 if (egp * gas >= MOD) or ((egp * gas + value) >= MOD) else 0)
+")"
+
+  local actual_status; actual_status="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local exp_status_le; exp_status_le="$(python3 -c "print(int('$exp_status').to_bytes(8, 'little').hex())")"
+
+  if [[ "$actual_status" != "$exp_status_le" ]]; then
+    printf "  %-30s FAIL  status expected %d got 0x%s\n" "$name" "$exp_status" "$actual_status"
+    return 1
+  fi
+
+  if [[ "$exp_status" == "1" ]]; then
+    printf "  %-30s OK   status=1 (overflow)\n" "$name"
+    return 0
+  fi
+
+  # Pass: compare 40-byte output
+  local actual expected
+  actual="$(xxd -p -l 40 "$out_file" | tr -d '\n')"
+  expected="$(xxd -p -l 40 "$exp_file" | tr -d '\n')"
+  if [[ "$actual" == "$expected" ]]; then
+    local cost; cost="$(python3 -c "print($egp * $gas + $value)")"
+    printf "  %-30s OK   status=0 tx_cost=%s\n" "$name" "${cost:0:24}..."
+    return 0
+  else
+    printf "  %-30s FAIL  cost mismatch\n    expected: %s\n    actual:   %s\n" "$name" "$expected" "$actual"
+    return 1
+  fi
+}
+
+GWEI=$(python3 -c "print(10**9)")
+ETH=$(python3 -c "print(10**18)")
+
+FAILED=0
+# Typical mainnet transfer: 21000 × 50 gwei + 1 ETH
+run_case "mainnet_transfer"   $(python3 -c "print(50 * $GWEI)")  21000  "$ETH"  || FAILED=1
+# Contract creation: 100000 × 100 gwei + 0
+run_case "creation_no_value"  $(python3 -c "print(100 * $GWEI)") 100000 0       || FAILED=1
+# Zero gas → tx_cost = value
+run_case "zero_gas"           $(python3 -c "print(100 * $GWEI)") 0      "$ETH"  || FAILED=1
+# Zero value → tx_cost = gas × egp
+run_case "zero_value"         $(python3 -c "print(50 * $GWEI)")  21000  0       || FAILED=1
+# Zero egp → tx_cost = value
+run_case "zero_egp"           0                                  21000  "$ETH"  || FAILED=1
+# All zero
+run_case "all_zero"           0                                  0      0       || FAILED=1
+# Realistic high-fee: 30M gas × 100 gwei + 0
+run_case "block_full_30M"     $(python3 -c "print(100 * $GWEI)") 30000000 0     || FAILED=1
+# Overflow on mul: max egp × big gas
+MAX=115792089237316195423570985008687907853269984665640564039457584007913129639935
+run_case "mul_overflow"       "$MAX"                             2      0       || FAILED=1
+# Overflow on add: max gas_fee + max value
+run_case "add_overflow"       $(python3 -c "print(2**254)")      2      $(python3 -c "print(2**254)") || FAILED=1
+# u128-bound egp (realistic)
+H128=$(python3 -c "print((1 << 128) - 1)")
+run_case "h128_egp_realistic" "$H128"                            30000000  "$ETH"  || FAILED=1
+# Edge: gas = max u64
+MAX_U64=18446744073709551615
+run_case "max_u64_gas_one_egp" 1 "$MAX_U64" 0 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: tx_cost_compute matches Python's (egp × gas + value) mod 2^256"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Compute the full upfront cost of a transaction:

```
tx_cost = gas_limit × effective_gas_price + value
```

This is the value that must not exceed `account.balance` for the tx to be valid. Mirrors Python's check in `validate_transaction` / `process_transaction`.

## Composition

- PR-K54 `u256_mul_u64_be` — `effective_gas_price × gas_limit`
- PR-K51 `u256_add_be` — fold `value` into `out` in place

Reports overflow on either step via `status=1`. In practice `effective_gas_price ≤ max_fee_per_gas` is u128-sized at most, so the multiplicand fits comfortably; overflow is a garbage-input safety net.

## Test plan

- [x] `lake build` clean
- [x] `scripts/codegen-zisk-tx-cost-compute-check.sh` passes 11 fixtures:
  - Mainnet transfer (21k × 50 gwei + 1 ETH)
  - Creation, zero gas / zero value / zero egp / all-zero
  - Block-full 30M gas × 100 gwei
  - `mul_overflow` (max u256 × 2 → status=1)
  - Add-boundary, u128-bound egp realistic, max-u64 gas

🤖 Generated with [Claude Code](https://claude.com/claude-code)