### PR TITLE
feat(stateless): check_gas_limit (PR-K72)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -5849,6 +5849,79 @@ def ziskValidateHeaderBasicProbeUnit : BuildUnit := {
   dataAsm     := ziskValidateHeaderBasicDataSection
 }
 
+/-! ## check_gas_limit -- PR-K72 gas-limit continuity check
+
+    Verify the per-header gas-limit elasticity rules per
+    Ethereum's `check_gas_limit`:
+
+      max_adjustment_delta = parent_gas_limit // 1024
+      |gas_limit - parent_gas_limit| < max_adjustment_delta
+      gas_limit >= GAS_LIMIT_MINIMUM (5000)
+
+    Used by `validate_header` to ensure consecutive blocks
+    smoothly adjust their gas-limit ceiling. Adoption is
+    EIP-1985 + EIP-1559 elasticity.
+
+    Pure u64 arithmetic (shift, sub, compare). No scratch
+    memory, leaf-callable.
+
+    Calling convention:
+      a0 (input)  : new.gas_limit    (u64)
+      a1 (input)  : parent.gas_limit (u64)
+      ra (input)  : return
+      a0 (output) :
+        0  : all checks pass
+        1  : new.gas_limit < GAS_LIMIT_MINIMUM (5000)
+        2  : |new - parent| >= parent / 1024 (jumped too far) -/
+def checkGasLimitFunction : String :=
+  "check_gas_limit:\n" ++
+  "  li t0, 5000                 # GAS_LIMIT_MINIMUM\n" ++
+  "  bltu a0, t0, .Lcgl_fail_min\n" ++
+  "  # max_adjustment_delta = parent_gas_limit >> 10  (== /1024)\n" ++
+  "  srli t1, a1, 10\n" ++
+  "  # abs_diff = |new - parent|\n" ++
+  "  bgtu a0, a1, .Lcgl_pos\n" ++
+  "  sub t2, a1, a0\n" ++
+  "  j .Lcgl_check\n" ++
+  ".Lcgl_pos:\n" ++
+  "  sub t2, a0, a1\n" ++
+  ".Lcgl_check:\n" ++
+  "  bgeu t2, t1, .Lcgl_fail_jump\n" ++
+  "  li a0, 0\n" ++
+  "  ret\n" ++
+  ".Lcgl_fail_min:\n" ++
+  "  li a0, 1\n" ++
+  "  ret\n" ++
+  ".Lcgl_fail_jump:\n" ++
+  "  li a0, 2\n" ++
+  "  ret"
+
+/-- `zisk_check_gas_limit`: probe BuildUnit. Reads (new_limit,
+    parent_limit) as 2 u64s from host input, writes 8-byte
+    status to OUTPUT. -/
+def ziskCheckGasLimitPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li t0, 0x40000000\n" ++
+  "  ld a0,  8(t0)               # new.gas_limit\n" ++
+  "  ld a1, 16(t0)               # parent.gas_limit\n" ++
+  "  jal ra, check_gas_limit\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)                # status\n" ++
+  "  j .Lcgl_pdone\n" ++
+  checkGasLimitFunction ++ "\n" ++
+  ".Lcgl_pdone:"
+
+def ziskCheckGasLimitDataSection : String :=
+  ".section .data\n" ++
+  "cgl_pad:\n" ++
+  "  .zero 8"
+
+def ziskCheckGasLimitProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskCheckGasLimitPrologue
+  dataAsm     := ziskCheckGasLimitDataSection
+}
+
 /-! ## tx_validate_against_block -- PR-K69
 
     Combine three u64 tx-validation invariants into one helper:
@@ -9969,6 +10042,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_header_extended_decode" => some ziskHeaderExtendedDecodeProbeUnit
   | "zisk_coinbase_extract_from_header" => some ziskCoinbaseExtractFromHeaderProbeUnit
   | "zisk_validate_header_basic" => some ziskValidateHeaderBasicProbeUnit
+  | "zisk_check_gas_limit"      => some ziskCheckGasLimitProbeUnit
   | "zisk_tx_validate_against_block" => some ziskTxValidateAgainstBlockProbeUnit
   | "zisk_calc_excess_blob_gas" => some ziskCalcExcessBlobGasProbeUnit
   | "zisk_header_validate_post_merge" => some ziskHeaderValidatePostMergeProbeUnit
@@ -10054,6 +10128,7 @@ def knownProgramNames : List String :=
    "zisk_header_extended_decode",
    "zisk_coinbase_extract_from_header",
    "zisk_validate_header_basic",
+   "zisk_check_gas_limit",
    "zisk_tx_validate_against_block",
    "zisk_calc_excess_blob_gas",
    "zisk_header_validate_post_merge",

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **94**
-- ziskemu round-trip scripts: **87** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **95**
+- ziskemu round-trip scripts: **88** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-check-gas-limit-check.sh
+++ b/scripts/codegen-zisk-check-gas-limit-check.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# codegen-zisk-check-gas-limit-check.sh -- PR-K72.
+#
+# Gas-limit continuity check per Ethereum check_gas_limit:
+#   |new - parent| < parent/1024
+#   new >= GAS_LIMIT_MINIMUM (5000)
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_check_gas_limit ELF"
+lake exe codegen --program zisk_check_gas_limit --halt linux93 \
+  -o gen-out/zisk_check_gas_limit
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <expected_status> <new> <parent>
+run_case() {
+  local name="$1" expected_status="$2" new="$3" parent="$4"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_check_gas_limit_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_check_gas_limit_${name}.output"
+
+  python3 -c "
+import struct, sys
+out = struct.pack('<Q', $new) + struct.pack('<Q', $parent)
+sys.stdout.buffer.write(out)
+" > "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_check_gas_limit.elf \
+    -i "$in_file" -o "$out_file" -n 500000 \
+    >"$REPO_ROOT/gen-out/zisk_check_gas_limit_${name}.emu.log" 2>&1 || true
+
+  local actual; actual="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local exp_le; exp_le="$(python3 -c "print(int('$expected_status').to_bytes(8, 'little').hex())")"
+
+  if [[ "$actual" == "$exp_le" ]]; then
+    printf "  %-30s OK   status=%d (new=%d parent=%d)\n" "$name" "$expected_status" "$new" "$parent"
+    return 0
+  else
+    printf "  %-30s FAIL  expected status=%d got 0x%s\n" "$name" "$expected_status" "$actual"
+    return 1
+  fi
+}
+
+FAILED=0
+# Pass cases — new within delta and ≥ 5000
+run_case "equal"               0 30000000 30000000 || FAILED=1
+run_case "small_increase"      0 30000001 30000000 || FAILED=1
+run_case "small_decrease"      0 29999999 30000000 || FAILED=1
+run_case "just_below_delta_up" 0 30029295 30000000 || FAILED=1  # 30000000/1024 = 29296; +29295 ok (diff < delta)
+run_case "just_below_delta_dn" 0 29970705 30000000 || FAILED=1  # -29295 ok
+run_case "min_pass_5000"       0 5000     5000     || FAILED=1
+run_case "min_pass_5001"       0 5001     5000     || FAILED=1
+# Reject: min violation
+run_case "below_min_4999"      1 4999     5000     || FAILED=1
+run_case "below_min_zero"      1 0        30000000 || FAILED=1
+# Reject: jump too far
+run_case "jump_up_at_delta"    2 30029297 30000000 || FAILED=1  # at parent/1024 → fail
+run_case "jump_up_above_delta" 2 30100000 30000000 || FAILED=1
+run_case "jump_dn_at_delta"    2 29970704 30000000 || FAILED=1
+run_case "jump_dn_far"         2 25000000 30000000 || FAILED=1
+# Edge: parent < 1024 → delta = 0 → only exact-match passes
+run_case "small_parent_equal"  0 5000     5000     || FAILED=1
+run_case "small_parent_diff"   2 5001     5500     || FAILED=1  # delta = 5500/1024 = 5; diff = 499 > 5
+# Edge: zero parent (degenerate)
+run_case "zero_parent_zero_new" 1 0       0        || FAILED=1  # new=0 < 5000
+# Edge: parent at MIN; delta = 5000/1024 = 4; |diff|=4 → 4 >= 4 → fail
+run_case "parent_at_min_at_delta" 2 5004 5000      || FAILED=1
+run_case "parent_at_min_below"   0 5003 5000      || FAILED=1  # diff=3 < delta=4 ok
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: check_gas_limit enforces |new - parent| < parent/1024 and new >= 5000"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Verify the per-header gas-limit elasticity rules per Ethereum's `check_gas_limit` (EIP-1985 + EIP-1559):

```
max_adjustment_delta = parent.gas_limit / 1024
|new.gas_limit - parent.gas_limit| < max_adjustment_delta
new.gas_limit >= GAS_LIMIT_MINIMUM (5000)
```

Used by `validate_header` to ensure consecutive blocks smoothly adjust their gas-limit ceiling.

Pure u64 arithmetic (shift, sub, compare). No scratch memory, leaf-callable.

## Return codes

| `a0` | Meaning |
|------|---------|
| 0 | All checks pass |
| 1 | `new.gas_limit < 5000` |
| 2 | `|new - parent| >= parent / 1024` |

## Test plan

- [x] `lake build` clean
- [x] `scripts/codegen-zisk-check-gas-limit-check.sh` passes 18 fixtures:
  - 7 pass (equal, small inc/dec, just-below-delta both directions, min=5000, min+1)
  - 2 min violations (4999, zero)
  - 4 jump rejects (at-delta up, at-delta down, up high, down far)
  - Small-parent edges (equal pass, diff fail), zero-parent, parent-at-min boundary

🤖 Generated with [Claude Code](https://claude.com/claude-code)