### PR TITLE
feat(stateless): eip1559_calc_base_fee_per_gas (PR-K73)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -7283,6 +7283,175 @@ def ziskU256MulU64BeProbeUnit : BuildUnit := {
   dataAsm     := ziskU256MulU64BeDataSection
 }
 
+/-! ## eip1559_calc_base_fee_per_gas -- PR-K73
+
+    Full EIP-1559 base-fee formula. Mirrors Python's
+    `calculate_base_fee_per_gas`:
+
+      parent_gas_target = parent.gas_limit // 2
+
+      if parent.gas_used == parent_gas_target:
+          expected = parent.base_fee_per_gas
+      elif parent.gas_used > parent_gas_target:
+          gas_used_delta = parent.gas_used - parent_gas_target
+          parent_fee_gas_delta = parent.base_fee_per_gas * gas_used_delta
+          target_fee_gas_delta = parent_fee_gas_delta // parent_gas_target
+          base_fee_delta = max(target_fee_gas_delta // 8, 1)
+          expected = parent.base_fee_per_gas + base_fee_delta
+      else:
+          gas_used_delta = parent_gas_target - parent.gas_used
+          parent_fee_gas_delta = parent.base_fee_per_gas * gas_used_delta
+          target_fee_gas_delta = parent_fee_gas_delta // parent_gas_target
+          base_fee_delta = target_fee_gas_delta // 8
+          expected = parent.base_fee_per_gas - base_fee_delta
+
+    Where `ELASTICITY_MULTIPLIER = 2` and
+    `BASE_FEE_MAX_CHANGE_DENOMINATOR = 8`.
+
+    First end-to-end EIP-1559 helper composed on the u256 toolkit:
+    - PR-K54 `u256_mul_u64_be` — parent.base_fee × gas_used_delta
+    - PR-K61 `u256_div_u64_be` — divide by parent_gas_target, then by 8
+    - PR-K58 `u256_is_zero`    — max(_, 1) on the above path
+    - PR-K56 `u256_from_u64_be` — materialize the literal 1
+    - PR-K51 `u256_add_be`     — final add (above path)
+    - PR-K52 `u256_sub_be`     — final sub (below path)
+
+    ## Preconditions
+
+    - `parent.gas_limit >= 2` (so `parent_gas_target >= 1`; we
+      divide by it). Mainnet has GAS_LIMIT_MINIMUM = 5000, so
+      this always holds for valid chains.
+    - `parent.base_fee_per_gas <= 2^56` (PR-K61 div precondition).
+      All mainnet base fees fit easily.
+
+    Calling convention:
+      a0 (input)  : parent.gas_limit       (u64)
+      a1 (input)  : parent.gas_used        (u64)
+      a2 (input)  : parent.base_fee_per_gas ptr (u256 BE, 32 B)
+      a3 (input)  : output ptr (u256 BE, 32 B; receives expected
+                    base_fee_per_gas)
+      ra (input)  : return
+      a0 (output) : 0 on success, 1 on overflow at any step. -/
+def eip1559CalcBaseFeePerGasFunction : String :=
+  "eip1559_calc_base_fee_per_gas:\n" ++
+  "  addi sp, sp, -56\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp); sd s4, 40(sp)\n" ++
+  "  mv s0, a2                    # base_fee ptr\n" ++
+  "  mv s1, a3                    # out ptr\n" ++
+  "  srli s2, a0, 1               # parent_gas_target = parent.gas_limit / 2\n" ++
+  "  beq a1, s2, .Lebf_eq         # gas_used == target → expected = base_fee\n" ++
+  "  li s4, 0                     # path flag: 0 = below, 1 = above\n" ++
+  "  bgtu a1, s2, .Lebf_set_above\n" ++
+  "  sub s3, s2, a1               # below: delta = target - gas_used\n" ++
+  "  j .Lebf_compute\n" ++
+  ".Lebf_set_above:\n" ++
+  "  li s4, 1\n" ++
+  "  sub s3, a1, s2               # above: delta = gas_used - target\n" ++
+  ".Lebf_compute:\n" ++
+  "  # parent_fee_gas_delta = parent.base_fee × gas_used_delta\n" ++
+  "  mv a0, s0\n" ++
+  "  mv a1, s3\n" ++
+  "  mv a2, s1\n" ++
+  "  jal ra, u256_mul_u64_be\n" ++
+  "  bnez a0, .Lebf_fail\n" ++
+  "  # target_fee_gas_delta = parent_fee_gas_delta / parent_gas_target\n" ++
+  "  mv a0, s1\n" ++
+  "  mv a1, s2\n" ++
+  "  mv a2, s1\n" ++
+  "  jal ra, u256_div_u64_be\n" ++
+  "  # base_fee_delta = target_fee_gas_delta / 8\n" ++
+  "  mv a0, s1\n" ++
+  "  li a1, 8\n" ++
+  "  mv a2, s1\n" ++
+  "  jal ra, u256_div_u64_be\n" ++
+  "  # If above path: max(delta, 1).\n" ++
+  "  beqz s4, .Lebf_apply\n" ++
+  "  mv a0, s1\n" ++
+  "  jal ra, u256_is_zero\n" ++
+  "  beqz a0, .Lebf_apply\n" ++
+  "  li a0, 1\n" ++
+  "  mv a1, s1\n" ++
+  "  jal ra, u256_from_u64_be\n" ++
+  ".Lebf_apply:\n" ++
+  "  beqz s4, .Lebf_sub_path\n" ++
+  "  # above: out = base_fee + delta\n" ++
+  "  mv a0, s0\n" ++
+  "  mv a1, s1\n" ++
+  "  mv a2, s1\n" ++
+  "  jal ra, u256_add_be\n" ++
+  "  bnez a0, .Lebf_fail\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lebf_ret\n" ++
+  ".Lebf_sub_path:\n" ++
+  "  # below: out = base_fee - delta\n" ++
+  "  mv a0, s0\n" ++
+  "  mv a1, s1\n" ++
+  "  mv a2, s1\n" ++
+  "  jal ra, u256_sub_be\n" ++
+  "  bnez a0, .Lebf_fail\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lebf_ret\n" ++
+  ".Lebf_eq:\n" ++
+  "  # Copy base_fee to out (32 B chunk copy).\n" ++
+  "  ld t0,  0(s0); sd t0,  0(s1)\n" ++
+  "  ld t0,  8(s0); sd t0,  8(s1)\n" ++
+  "  ld t0, 16(s0); sd t0, 16(s1)\n" ++
+  "  ld t0, 24(s0); sd t0, 24(s1)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lebf_ret\n" ++
+  ".Lebf_fail:\n" ++
+  "  li a0, 1\n" ++
+  ".Lebf_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp); ld s4, 40(sp)\n" ++
+  "  addi sp, sp, 56\n" ++
+  "  ret"
+
+/-- `zisk_eip1559_calc_base_fee_per_gas`: probe BuildUnit. Reads
+    (parent_gas_limit u64, parent_gas_used u64, parent_base_fee
+    u256 BE) from host input, writes (status, expected_base_fee
+    BE) to OUTPUT (40 bytes total). -/
+def ziskEip1559CalcBaseFeePerGasPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a4, 0x40000000\n" ++
+  "  ld a0,  8(a4)               # parent.gas_limit\n" ++
+  "  ld a1, 16(a4)               # parent.gas_used\n" ++
+  "  addi a2, a4, 24             # parent.base_fee ptr\n" ++
+  "  li a3, 0xa0010008           # out ptr\n" ++
+  "  mv t0, a3; li t1, 4\n" ++
+  ".Lebf_zout:\n" ++
+  "  beqz t1, .Lebf_zout_done\n" ++
+  "  sd zero, 0(t0)\n" ++
+  "  addi t0, t0, 8\n" ++
+  "  addi t1, t1, -1\n" ++
+  "  j .Lebf_zout\n" ++
+  ".Lebf_zout_done:\n" ++
+  "  jal ra, eip1559_calc_base_fee_per_gas\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)                # status\n" ++
+  "  j .Lebf_pdone\n" ++
+  u256MulU64BeFunction ++ "\n" ++
+  u256DivU64BeFunction ++ "\n" ++
+  u256IsZeroFunction ++ "\n" ++
+  u256FromU64BeFunction ++ "\n" ++
+  u256AddBeFunction ++ "\n" ++
+  u256SubBeFunction ++ "\n" ++
+  eip1559CalcBaseFeePerGasFunction ++ "\n" ++
+  ".Lebf_pdone:"
+
+def ziskEip1559CalcBaseFeePerGasDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "u256m_acc:\n" ++
+  "  .zero 40"
+
+def ziskEip1559CalcBaseFeePerGasProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskEip1559CalcBaseFeePerGasPrologue
+  dataAsm     := ziskEip1559CalcBaseFeePerGasDataSection
+}
+
 /-! ## tx_cost_compute -- PR-K71
 
     Compute the full upfront cost of a transaction:
@@ -10051,6 +10220,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_u256_sub_be"          => some ziskU256SubBeProbeUnit
   | "zisk_u256_eq"              => some ziskU256EqProbeUnit
   | "zisk_u256_mul_u64_be"      => some ziskU256MulU64BeProbeUnit
+  | "zisk_eip1559_calc_base_fee_per_gas" => some ziskEip1559CalcBaseFeePerGasProbeUnit
   | "zisk_u256_from_u64_be"     => some ziskU256FromU64BeProbeUnit
   | "zisk_u256_to_u64_be"       => some ziskU256ToU64BeProbeUnit
   | "zisk_u256_is_zero"         => some ziskU256IsZeroProbeUnit
@@ -10137,6 +10307,7 @@ def knownProgramNames : List String :=
    "zisk_u256_sub_be",
    "zisk_u256_eq",
    "zisk_u256_mul_u64_be",
+   "zisk_eip1559_calc_base_fee_per_gas",
    "zisk_u256_from_u64_be",
    "zisk_u256_to_u64_be",
    "zisk_u256_is_zero",

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **95**
-- ziskemu round-trip scripts: **88** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **96**
+- ziskemu round-trip scripts: **89** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-eip1559-calc-base-fee-per-gas-check.sh
+++ b/scripts/codegen-zisk-eip1559-calc-base-fee-per-gas-check.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# codegen-zisk-eip1559-calc-base-fee-per-gas-check.sh -- PR-K73.
+#
+# Full EIP-1559 base-fee formula.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_eip1559_calc_base_fee_per_gas ELF"
+lake exe codegen --program zisk_eip1559_calc_base_fee_per_gas --halt linux93 \
+  -o gen-out/zisk_eip1559_calc_base_fee_per_gas
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <parent_gas_limit> <parent_gas_used> <parent_base_fee>
+run_case() {
+  local name="$1" pgl="$2" pgu="$3" pbf="$4"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_eip1559_calc_base_fee_per_gas_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_eip1559_calc_base_fee_per_gas_${name}.output"
+  local exp_file="$REPO_ROOT/gen-out/zisk_eip1559_calc_base_fee_per_gas_${name}.expected"
+
+  python3 -c "
+import struct, sys
+pgl = $pgl; pgu = $pgu; pbf = $pbf
+with open(sys.argv[1], 'wb') as f:
+    f.write(struct.pack('<Q', pgl))
+    f.write(struct.pack('<Q', pgu))
+    f.write(pbf.to_bytes(32, 'big'))
+
+# Python ref
+target = pgl // 2
+if pgu == target:
+    exp = pbf
+elif pgu > target:
+    delta = pgu - target
+    pfgd = pbf * delta
+    tfgd = pfgd // target
+    bfd = max(tfgd // 8, 1)
+    exp = pbf + bfd
+else:
+    delta = target - pgu
+    pfgd = pbf * delta
+    tfgd = pfgd // target
+    bfd = tfgd // 8
+    exp = pbf - bfd
+
+with open(sys.argv[2], 'wb') as f:
+    f.write(struct.pack('<Q', 0))
+    f.write(exp.to_bytes(32, 'big'))
+" "$in_file" "$exp_file"
+
+  "$ZISKEMU" -e gen-out/zisk_eip1559_calc_base_fee_per_gas.elf \
+    -i "$in_file" -o "$out_file" -n 500000 \
+    >"$REPO_ROOT/gen-out/zisk_eip1559_calc_base_fee_per_gas_${name}.emu.log" 2>&1 || true
+
+  local actual; actual="$(xxd -p -l 40 "$out_file" | tr -d '\n')"
+  local expected; expected="$(xxd -p -l 40 "$exp_file" | tr -d '\n')"
+
+  if [[ "$actual" == "$expected" ]]; then
+    local exp_dec; exp_dec="$(python3 -c "
+pgl, pgu, pbf = $pgl, $pgu, $pbf
+target = pgl // 2
+if pgu == target: print(pbf)
+elif pgu > target:
+    delta = pgu - target; pfgd = pbf*delta; tfgd = pfgd//target; bfd = max(tfgd//8, 1)
+    print(pbf + bfd)
+else:
+    delta = target - pgu; pfgd = pbf*delta; tfgd = pfgd//target; bfd = tfgd//8
+    print(pbf - bfd)
+")"
+    printf "  %-30s OK   expected=%s\n" "$name" "${exp_dec:0:24}..."
+    return 0
+  else
+    printf "  %-30s FAIL\n    expected: %s\n    actual:   %s\n" "$name" "$expected" "$actual"
+    return 1
+  fi
+}
+
+GWEI=$(python3 -c "print(10**9)")
+
+FAILED=0
+# gas_used == target → unchanged base fee
+run_case "eq_target"            30000000 15000000 $(python3 -c "print(50 * $GWEI)") || FAILED=1
+# gas_used > target (above path)
+run_case "above_small"          30000000 15000001 $(python3 -c "print(50 * $GWEI)") || FAILED=1  # delta tiny
+run_case "above_full"           30000000 30000000 $(python3 -c "print(50 * $GWEI)") || FAILED=1  # double block
+run_case "above_mid"            30000000 22500000 $(python3 -c "print(50 * $GWEI)") || FAILED=1
+# gas_used < target (below path)
+run_case "below_small"          30000000 14999999 $(python3 -c "print(50 * $GWEI)") || FAILED=1  # delta tiny
+run_case "below_empty"          30000000 0        $(python3 -c "print(50 * $GWEI)") || FAILED=1
+run_case "below_mid"            30000000 7500000  $(python3 -c "print(50 * $GWEI)") || FAILED=1
+# max(_,1) edge: gas_used just above target with small base_fee
+run_case "max_floor_kicks_in"   30000000 15000001 1                                  || FAILED=1
+# Realistic: 100 gwei base fee, full block
+run_case "100gwei_full_block"   30000000 30000000 $(python3 -c "print(100 * $GWEI)") || FAILED=1
+# Realistic: 1 gwei base fee, half-empty
+run_case "1gwei_half_empty"     30000000 5000000  "$GWEI"                            || FAILED=1
+# Edge: base_fee = 0 → both paths produce 0
+run_case "zero_base_above"      30000000 20000000 0                                  || FAILED=1
+run_case "zero_base_below"      30000000 5000000  0                                  || FAILED=1
+# Realistic Holesky shape: 30M gas_limit, 8 gwei base fee, 60% used
+run_case "holesky_60_used"      30000000 18000000 $(python3 -c "print(8 * $GWEI)")   || FAILED=1
+# Realistic Holesky shape: 30M gas_limit, 8 gwei base fee, 30% used
+run_case "holesky_30_used"      30000000 9000000  $(python3 -c "print(8 * $GWEI)")   || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: eip1559_calc_base_fee_per_gas matches Python's calculate_base_fee_per_gas"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Full EIP-1559 base-fee formula. Mirrors Python's `calculate_base_fee_per_gas`: given `parent.gas_limit`, `parent.gas_used`, and `parent.base_fee_per_gas`, compute the expected `base_fee_per_gas` for the next header.

First end-to-end EIP-1559 helper composed on the u256 toolkit.

## Composition

- PR-K54 `u256_mul_u64_be` — `parent.base_fee × gas_used_delta`
- PR-K61 `u256_div_u64_be` — divide by `parent_gas_target`, then by 8
- PR-K58 `u256_is_zero` — `max(_, 1)` on the above path
- PR-K56 `u256_from_u64_be` — materialize the literal `1`
- PR-K51 `u256_add_be` — final add (above path)
- PR-K52 `u256_sub_be` — final sub (below path)

## Three branches

1. `gas_used == target` → `base_fee` unchanged (32-byte chunk copy)
2. `gas_used > target` → above path with `max(_, 1)` floor
3. `gas_used < target` → below path (no floor)

## Preconditions

- `parent.gas_limit >= 2` (so `parent_gas_target >= 1`; we divide by it). Mainnet `GAS_LIMIT_MINIMUM = 5000` so this always holds.
- `parent.base_fee_per_gas <= 2^56` (PR-K61 div precondition). All realistic base fees fit easily.

## Test plan

- [x] `lake build` clean
- [x] `scripts/codegen-zisk-eip1559-calc-base-fee-per-gas-check.sh` passes 14 fixtures:
  - `eq_target`, `above_small/full/mid`, `below_small/empty/mid`
  - `max_floor_kicks_in` (base_fee=1, gas_used just above target → delta rounds to 0, floor → 1)
  - Realistic: 100 gwei full block, 1 gwei half-empty, zero base_fee both paths
  - Two Holesky shapes (60% and 30% used at 8 gwei base)

🤖 Generated with [Claude Code](https://claude.com/claude-code)