### PR TITLE
feat(stateless): header_validate_base_fee (PR-K74)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -7452,6 +7452,109 @@ def ziskEip1559CalcBaseFeePerGasProbeUnit : BuildUnit := {
   dataAsm     := ziskEip1559CalcBaseFeePerGasDataSection
 }
 
+/-! ## header_validate_base_fee -- PR-K74
+
+    Verify a header's `base_fee_per_gas` matches the value
+    computed from the parent header by EIP-1559's
+    `calculate_base_fee_per_gas`:
+
+      expected = eip1559_calc_base_fee_per_gas(
+                   parent.gas_limit,
+                   parent.gas_used,
+                   parent.base_fee_per_gas)
+      assert header.base_fee_per_gas == expected
+
+    This is the per-block invariant added by EIP-1559 §4.4.4
+    (Python: `validate_header`).
+
+    Composes PR-K73 `eip1559_calc_base_fee_per_gas` +
+    PR-K53 `u256_eq`. The 32-byte computed expected base fee
+    lands in `.data` scratch, then is compared bytewise against
+    the header's claimed value.
+
+    Calling convention:
+      a0 (input)  : header.base_fee_per_gas ptr (u256 BE, 32 B)
+      a1 (input)  : parent.gas_limit (u64)
+      a2 (input)  : parent.gas_used (u64)
+      a3 (input)  : parent.base_fee_per_gas ptr (u256 BE, 32 B)
+      ra (input)  : return
+      a0 (output) :
+        0  : header.base_fee_per_gas == expected
+        1  : mismatch (reject)
+        2  : compute step (K73) overflow / precondition failure
+
+    Uses 32 bytes of `.data` scratch (`hvbf_expected`). -/
+def headerValidateBaseFeeFunction : String :=
+  "header_validate_base_fee:\n" ++
+  "  addi sp, sp, -16\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp)\n" ++
+  "  mv s0, a0                   # save header.base_fee ptr\n" ++
+  "  # expected = eip1559_calc_base_fee_per_gas(...)  → hvbf_expected\n" ++
+  "  mv a0, a1                   # parent.gas_limit\n" ++
+  "  mv a1, a2                   # parent.gas_used\n" ++
+  "  mv a2, a3                   # parent.base_fee\n" ++
+  "  la a3, hvbf_expected\n" ++
+  "  jal ra, eip1559_calc_base_fee_per_gas\n" ++
+  "  bnez a0, .Lhvbf_fail_compute\n" ++
+  "  # Compare header.base_fee vs expected.\n" ++
+  "  mv a0, s0\n" ++
+  "  la a1, hvbf_expected\n" ++
+  "  jal ra, u256_eq             # a0 = 1 if equal, 0 if not\n" ++
+  "  beqz a0, .Lhvbf_fail_mismatch\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lhvbf_ret\n" ++
+  ".Lhvbf_fail_mismatch:\n" ++
+  "  li a0, 1\n" ++
+  "  j .Lhvbf_ret\n" ++
+  ".Lhvbf_fail_compute:\n" ++
+  "  li a0, 2\n" ++
+  ".Lhvbf_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp)\n" ++
+  "  addi sp, sp, 16\n" ++
+  "  ret"
+
+/-- `zisk_header_validate_base_fee`: probe BuildUnit. Reads
+    (header_bf u256 BE, parent_gas_limit u64, parent_gas_used u64,
+    parent_bf u256 BE) from host input, writes 8-byte status. -/
+def ziskHeaderValidateBaseFeePrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a4, 0x40000000\n" ++
+  "  addi a0, a4, 8              # header_bf ptr\n" ++
+  "  ld a1, 40(a4)               # parent.gas_limit\n" ++
+  "  ld a2, 48(a4)               # parent.gas_used\n" ++
+  "  addi a3, a4, 56             # parent_bf ptr\n" ++
+  "  jal ra, header_validate_base_fee\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)                # status\n" ++
+  "  j .Lhvbf_pdone\n" ++
+  u256MulU64BeFunction ++ "\n" ++
+  u256DivU64BeFunction ++ "\n" ++
+  u256IsZeroFunction ++ "\n" ++
+  u256FromU64BeFunction ++ "\n" ++
+  u256AddBeFunction ++ "\n" ++
+  u256SubBeFunction ++ "\n" ++
+  u256EqFunction ++ "\n" ++
+  eip1559CalcBaseFeePerGasFunction ++ "\n" ++
+  headerValidateBaseFeeFunction ++ "\n" ++
+  ".Lhvbf_pdone:"
+
+def ziskHeaderValidateBaseFeeDataSection : String :=
+  ".section .data\n" ++
+  ".balign 32\n" ++
+  "hvbf_expected:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "u256m_acc:\n" ++
+  "  .zero 40"
+
+def ziskHeaderValidateBaseFeeProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskHeaderValidateBaseFeePrologue
+  dataAsm     := ziskHeaderValidateBaseFeeDataSection
+}
+
 /-! ## tx_cost_compute -- PR-K71
 
     Compute the full upfront cost of a transaction:
@@ -10221,6 +10324,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_u256_eq"              => some ziskU256EqProbeUnit
   | "zisk_u256_mul_u64_be"      => some ziskU256MulU64BeProbeUnit
   | "zisk_eip1559_calc_base_fee_per_gas" => some ziskEip1559CalcBaseFeePerGasProbeUnit
+  | "zisk_header_validate_base_fee" => some ziskHeaderValidateBaseFeeProbeUnit
   | "zisk_u256_from_u64_be"     => some ziskU256FromU64BeProbeUnit
   | "zisk_u256_to_u64_be"       => some ziskU256ToU64BeProbeUnit
   | "zisk_u256_is_zero"         => some ziskU256IsZeroProbeUnit
@@ -10308,6 +10412,7 @@ def knownProgramNames : List String :=
    "zisk_u256_eq",
    "zisk_u256_mul_u64_be",
    "zisk_eip1559_calc_base_fee_per_gas",
+   "zisk_header_validate_base_fee",
    "zisk_u256_from_u64_be",
    "zisk_u256_to_u64_be",
    "zisk_u256_is_zero",

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **96**
-- ziskemu round-trip scripts: **89** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **97**
+- ziskemu round-trip scripts: **90** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-header-validate-base-fee-check.sh
+++ b/scripts/codegen-zisk-header-validate-base-fee-check.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# codegen-zisk-header-validate-base-fee-check.sh -- PR-K74.
+#
+# Verify header.base_fee_per_gas matches the value computed from
+# the parent header by EIP-1559's base-fee formula.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_header_validate_base_fee ELF"
+lake exe codegen --program zisk_header_validate_base_fee --halt linux93 \
+  -o gen-out/zisk_header_validate_base_fee
+
+REPO_ROOT="$(pwd)"
+
+# python_calc_expected <parent_gas_limit> <parent_gas_used> <parent_bf>
+python_calc_expected() {
+  python3 -c "
+pgl, pgu, pbf = $1, $2, $3
+target = pgl // 2
+if pgu == target: print(pbf)
+elif pgu > target:
+    delta = pgu - target; pfgd = pbf*delta; tfgd = pfgd//target; bfd = max(tfgd//8, 1)
+    print(pbf + bfd)
+else:
+    delta = target - pgu; pfgd = pbf*delta; tfgd = pfgd//target; bfd = tfgd//8
+    print(pbf - bfd)
+"
+}
+
+# run_case <name> <expected_status> <header_bf> <pgl> <pgu> <pbf>
+run_case() {
+  local name="$1" expected_status="$2" hbf="$3" pgl="$4" pgu="$5" pbf="$6"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_header_validate_base_fee_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_header_validate_base_fee_${name}.output"
+
+  python3 -c "
+import struct, sys
+hbf, pgl, pgu, pbf = $hbf, $pgl, $pgu, $pbf
+with open(sys.argv[1], 'wb') as f:
+    f.write(hbf.to_bytes(32, 'big'))
+    f.write(struct.pack('<Q', pgl))
+    f.write(struct.pack('<Q', pgu))
+    f.write(pbf.to_bytes(32, 'big'))
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_header_validate_base_fee.elf \
+    -i "$in_file" -o "$out_file" -n 500000 \
+    >"$REPO_ROOT/gen-out/zisk_header_validate_base_fee_${name}.emu.log" 2>&1 || true
+
+  local actual; actual="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local exp_le; exp_le="$(python3 -c "print(int('$expected_status').to_bytes(8, 'little').hex())")"
+
+  if [[ "$actual" == "$exp_le" ]]; then
+    printf "  %-30s OK   status=%d\n" "$name" "$expected_status"
+    return 0
+  else
+    printf "  %-30s FAIL  expected status=%d got 0x%s\n" "$name" "$expected_status" "$actual"
+    return 1
+  fi
+}
+
+GWEI=$(python3 -c "print(10**9)")
+
+FAILED=0
+# Pass cases: header_bf == expected
+PBF50=$(python3 -c "print(50 * $GWEI)")
+EXP_FULL_BLOCK=$(python_calc_expected 30000000 30000000 "$PBF50")
+run_case "pass_full_block"        0 "$EXP_FULL_BLOCK" 30000000 30000000 "$PBF50" || FAILED=1
+
+EXP_HALF_EMPTY=$(python_calc_expected 30000000 7500000 "$PBF50")
+run_case "pass_half_empty"        0 "$EXP_HALF_EMPTY" 30000000 7500000  "$PBF50" || FAILED=1
+
+EXP_AT_TARGET=$(python_calc_expected 30000000 15000000 "$PBF50")
+run_case "pass_at_target"         0 "$EXP_AT_TARGET" 30000000 15000000 "$PBF50" || FAILED=1
+
+# Pass: realistic Holesky 60% used at 8 gwei
+PBF8=$(python3 -c "print(8 * $GWEI)")
+EXP_HOLESKY=$(python_calc_expected 30000000 18000000 "$PBF8")
+run_case "pass_holesky_60_used"   0 "$EXP_HOLESKY" 30000000 18000000 "$PBF8" || FAILED=1
+
+# Pass: zero base_fee
+EXP_ZERO=$(python_calc_expected 30000000 15000000 0)
+run_case "pass_zero_base"         0 "$EXP_ZERO" 30000000 15000000 0 || FAILED=1
+
+# Reject: header_bf claims one less than expected
+WRONG_LESS=$((EXP_FULL_BLOCK - 1))
+run_case "reject_one_less"        1 "$WRONG_LESS" 30000000 30000000 "$PBF50" || FAILED=1
+
+# Reject: header_bf claims one more
+WRONG_MORE=$((EXP_FULL_BLOCK + 1))
+run_case "reject_one_more"        1 "$WRONG_MORE" 30000000 30000000 "$PBF50" || FAILED=1
+
+# Reject: header_bf = 0 when expected > 0
+run_case "reject_zero_when_pos"   1 0            30000000 30000000 "$PBF50" || FAILED=1
+
+# Reject: header_bf claims parent's value (no adjustment)
+run_case "reject_no_adjustment"   1 "$PBF50"     30000000 30000000 "$PBF50" || FAILED=1
+
+# Reject: header_bf wildly off
+run_case "reject_huge_diff"       1 1            30000000 7500000  "$PBF50" || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: header_validate_base_fee enforces EIP-1559 base-fee continuity"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Verify `header.base_fee_per_gas` matches the value computed from the parent header by EIP-1559's base-fee formula. Per-block invariant from `validate_header`:

```
expected = eip1559_calc_base_fee_per_gas(parent.gas_limit,
                                          parent.gas_used,
                                          parent.base_fee_per_gas)
assert header.base_fee_per_gas == expected
```

## Composition

- PR-K73 `eip1559_calc_base_fee_per_gas` (#5731) — compute expected
- PR-K53 `u256_eq` — bytewise compare against header's claimed value

Stacks on PR-K73 (#5731).

## Test plan

- [x] `lake build` clean
- [x] `scripts/codegen-zisk-header-validate-base-fee-check.sh` passes 10 fixtures:
  - 5 pass cases (full block, half-empty, at target, realistic Holesky 60%, zero base)
  - 5 reject cases (one less, one more, zero when positive, no-adjustment claim, wildly off)

🤖 Generated with [Claude Code](https://claude.com/claude-code)