### PR TITLE
feat(stateless): validate_header_full (PR-K75)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -7555,6 +7555,174 @@ def ziskHeaderValidateBaseFeeProbeUnit : BuildUnit := {
   dataAsm     := ziskHeaderValidateBaseFeeDataSection
 }
 
+/-! ## validate_header_full -- PR-K75 complete per-header validation
+
+    Run all five per-header validation checks in sequence, returning
+    a single status code that distinguishes which step failed:
+
+      1. PR-K67 `header_validate_post_merge`        — ommers/difficulty/nonce
+      2. PR-K68 `header_validate_extra_data_length` — extra_data ≤ 32 bytes
+      3. PR-K43 `validate_header_basic`             — gas_used ≤ gas_limit + number/timestamp
+      4. PR-K72 `check_gas_limit`                   — elasticity
+      5. PR-K74 `header_validate_base_fee`          — EIP-1559 invariant
+
+    Chain-level checks (parent_hash continuity, validate_chain
+    PR-K18) are NOT included here — they iterate across multiple
+    headers and live at the SSZ-list walk level.
+
+    Status encoding:
+
+      0                : all five checks pass
+      100..104         : step 1 failed with K67's sub-status 0..4
+      201..202         : step 2 failed with K68's sub-status 1..2
+      301..303         : step 3 failed with K43's sub-status 1..3
+      401..402         : step 4 failed with K72's sub-status 1..2
+      501..502         : step 5 failed with K74's sub-status 1..2
+
+    Distinct decades let callers `floor(status/100)` to identify
+    the failing step.
+
+    Calling convention:
+      a0 (input)  : this header's RLP ptr
+      a1 (input)  : this header's RLP byte length
+      a2 (input)  : this header's PR-K39 extended-decode struct
+                    (128 B, with gas_limit @ 80, gas_used @ 88,
+                    base_fee_per_gas @ 96..128)
+      a3 (input)  : parent header's PR-K39 extended-decode struct
+                    (same layout)
+      ra (input)  : return
+      a0 (output) : composite status (see encoding above).
+
+    Composes 5 validators + their transitive deps (rlp_list_nth_item,
+    eip1559_calc_base_fee_per_gas plus the u256 toolkit). The probe
+    inlines every function it transitively calls. -/
+def validateHeaderFullFunction : String :=
+  "validate_header_full:\n" ++
+  "  addi sp, sp, -56\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  mv s0, a0                   # this_rlp ptr\n" ++
+  "  mv s1, a1                   # this_rlp_len\n" ++
+  "  mv s2, a2                   # this_struct (128 B)\n" ++
+  "  mv s3, a3                   # parent_struct (128 B)\n" ++
+  "  # Step 1: post_merge check\n" ++
+  "  mv a0, s0; mv a1, s1\n" ++
+  "  jal ra, header_validate_post_merge\n" ++
+  "  beqz a0, .Lvhf_s2\n" ++
+  "  li t0, 100\n" ++
+  "  add a0, a0, t0\n" ++
+  "  j .Lvhf_ret\n" ++
+  ".Lvhf_s2:\n" ++
+  "  # Step 2: extra_data length check\n" ++
+  "  mv a0, s0; mv a1, s1\n" ++
+  "  jal ra, header_validate_extra_data_length\n" ++
+  "  beqz a0, .Lvhf_s3\n" ++
+  "  li t0, 200\n" ++
+  "  add a0, a0, t0\n" ++
+  "  j .Lvhf_ret\n" ++
+  ".Lvhf_s3:\n" ++
+  "  # Step 3: gas_used/number/timestamp\n" ++
+  "  mv a0, s2; mv a1, s3\n" ++
+  "  jal ra, validate_header_basic\n" ++
+  "  beqz a0, .Lvhf_s4\n" ++
+  "  li t0, 300\n" ++
+  "  add a0, a0, t0\n" ++
+  "  j .Lvhf_ret\n" ++
+  ".Lvhf_s4:\n" ++
+  "  # Step 4: check_gas_limit(this.gas_limit, parent.gas_limit)\n" ++
+  "  ld a0, 80(s2)\n" ++
+  "  ld a1, 80(s3)\n" ++
+  "  jal ra, check_gas_limit\n" ++
+  "  beqz a0, .Lvhf_s5\n" ++
+  "  li t0, 400\n" ++
+  "  add a0, a0, t0\n" ++
+  "  j .Lvhf_ret\n" ++
+  ".Lvhf_s5:\n" ++
+  "  # Step 5: base_fee continuity\n" ++
+  "  addi a0, s2, 96\n" ++
+  "  ld a1, 80(s3)\n" ++
+  "  ld a2, 88(s3)\n" ++
+  "  addi a3, s3, 96\n" ++
+  "  jal ra, header_validate_base_fee\n" ++
+  "  beqz a0, .Lvhf_ret\n" ++
+  "  li t0, 500\n" ++
+  "  add a0, a0, t0\n" ++
+  ".Lvhf_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  addi sp, sp, 56\n" ++
+  "  ret"
+
+/-- `zisk_validate_header_full`: probe BuildUnit. Reads (this_rlp_len,
+    this_rlp_bytes [up to 1024 B], this_struct 128 B, parent_struct
+    128 B) from host input, writes 8-byte composite status to OUTPUT. -/
+def ziskValidateHeaderFullPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a4, 0x40000000\n" ++
+  "  ld a1, 8(a4)                # this_rlp_len\n" ++
+  "  addi a0, a4, 16             # this_rlp ptr\n" ++
+  "  addi a2, a4, 16             # placeholder; reset after rlp\n" ++
+  "  # this_struct offset = 16 + rlp_len_aligned\n" ++
+  "  # parent_struct offset = this_struct + 128\n" ++
+  "  # We require the caller to lay them out at fixed positions:\n" ++
+  "  # bytes 8..16  : rlp_len\n" ++
+  "  # bytes 16..16+1024 : this_rlp (padded to 1024)\n" ++
+  "  # bytes 1040..1168  : this_struct (128 B)\n" ++
+  "  # bytes 1168..1296  : parent_struct (128 B)\n" ++
+  "  li a2, 0x40000410           # this_struct  (= INPUT_ADDR + 1040)\n" ++
+  "  li a3, 0x40000490           # parent_struct (= INPUT_ADDR + 1168)\n" ++
+  "  jal ra, validate_header_full\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)                # status\n" ++
+  "  j .Lvhf_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  u256MulU64BeFunction ++ "\n" ++
+  u256DivU64BeFunction ++ "\n" ++
+  u256IsZeroFunction ++ "\n" ++
+  u256FromU64BeFunction ++ "\n" ++
+  u256AddBeFunction ++ "\n" ++
+  u256SubBeFunction ++ "\n" ++
+  u256EqFunction ++ "\n" ++
+  validateHeaderBasicFunction ++ "\n" ++
+  checkGasLimitFunction ++ "\n" ++
+  headerValidatePostMergeFunction ++ "\n" ++
+  headerValidateExtraDataLengthFunction ++ "\n" ++
+  eip1559CalcBaseFeePerGasFunction ++ "\n" ++
+  headerValidateBaseFeeFunction ++ "\n" ++
+  validateHeaderFullFunction ++ "\n" ++
+  ".Lvhf_pdone:"
+
+def ziskValidateHeaderFullDataSection : String :=
+  ".section .data\n" ++
+  ".balign 32\n" ++
+  "empty_ommers_hash:\n" ++
+  "  .byte 0x1d, 0xcc, 0x4d, 0xe8, 0xde, 0xc7, 0x5d, 0x7a\n" ++
+  "  .byte 0xab, 0x85, 0xb5, 0x67, 0xb6, 0xcc, 0xd4, 0x1a\n" ++
+  "  .byte 0xd3, 0x12, 0x45, 0x1b, 0x94, 0x8a, 0x74, 0x13\n" ++
+  "  .byte 0xf0, 0xa1, 0x42, 0xfd, 0x40, 0xd4, 0x93, 0x47\n" ++
+  ".balign 32\n" ++
+  "hvbf_expected:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "u256m_acc:\n" ++
+  "  .zero 40\n" ++
+  ".balign 8\n" ++
+  "hvpm_off:\n" ++
+  "  .zero 8\n" ++
+  "hvpm_len:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "hved_off:\n" ++
+  "  .zero 8\n" ++
+  "hved_len:\n" ++
+  "  .zero 8"
+
+def ziskValidateHeaderFullProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskValidateHeaderFullPrologue
+  dataAsm     := ziskValidateHeaderFullDataSection
+}
+
 /-! ## tx_cost_compute -- PR-K71
 
     Compute the full upfront cost of a transaction:
@@ -10325,6 +10493,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_u256_mul_u64_be"      => some ziskU256MulU64BeProbeUnit
   | "zisk_eip1559_calc_base_fee_per_gas" => some ziskEip1559CalcBaseFeePerGasProbeUnit
   | "zisk_header_validate_base_fee" => some ziskHeaderValidateBaseFeeProbeUnit
+  | "zisk_validate_header_full" => some ziskValidateHeaderFullProbeUnit
   | "zisk_u256_from_u64_be"     => some ziskU256FromU64BeProbeUnit
   | "zisk_u256_to_u64_be"       => some ziskU256ToU64BeProbeUnit
   | "zisk_u256_is_zero"         => some ziskU256IsZeroProbeUnit
@@ -10413,6 +10582,7 @@ def knownProgramNames : List String :=
    "zisk_u256_mul_u64_be",
    "zisk_eip1559_calc_base_fee_per_gas",
    "zisk_header_validate_base_fee",
+   "zisk_validate_header_full",
    "zisk_u256_from_u64_be",
    "zisk_u256_to_u64_be",
    "zisk_u256_is_zero",

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **97**
-- ziskemu round-trip scripts: **90** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **98**
+- ziskemu round-trip scripts: **91** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-validate-header-full-check.sh
+++ b/scripts/codegen-zisk-validate-header-full-check.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+# codegen-zisk-validate-header-full-check.sh -- PR-K75.
+#
+# Run all five header validation checks (post_merge, extra_data,
+# basic, gas_limit, base_fee) in sequence and verify the
+# composite return code.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_validate_header_full ELF"
+lake exe codegen --program zisk_validate_header_full --halt linux93 \
+  -o gen-out/zisk_validate_header_full
+
+REPO_ROOT="$(pwd)"
+
+EMPTY_OMMERS_HASH="1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+
+# build_test <name> <expected_status>
+#   <this_ommers> <this_diff> <this_nonce_hex>
+#   <this_extra_data_hex>
+#   <this_number> <this_timestamp> <this_gas_limit> <this_gas_used> <this_base_fee>
+#   <parent_number> <parent_timestamp> <parent_gas_limit> <parent_gas_used> <parent_base_fee>
+build_test() {
+  local name="$1" expected_status="$2"
+  local this_ommers="$3" this_diff="$4" this_nonce="$5"
+  local this_extra="$6"
+  local this_number="$7" this_ts="$8" this_gas_limit="$9" this_gas_used="${10}" this_bf="${11}"
+  local p_number="${12}" p_ts="${13}" p_gas_limit="${14}" p_gas_used="${15}" p_bf="${16}"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_validate_header_full_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_validate_header_full_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys
+import rlp
+
+# Build this-header RLP (15 fields)
+this_fields = [
+    b'\x11' * 32,                              # 0: parent_hash
+    bytes.fromhex('$this_ommers'),             # 1: ommers_hash
+    b'\x33' * 20,                              # 2: coinbase
+    b'\x44' * 32,                              # 3: state_root
+    b'\x55' * 32,                              # 4: transactions_root
+    b'\x66' * 32,                              # 5: receipts_root
+    b'\x00' * 256,                             # 6: bloom
+    $this_diff,                                # 7: difficulty
+    $this_number,                              # 8: number
+    $this_gas_limit,                           # 9: gas_limit
+    $this_gas_used,                            # 10: gas_used
+    $this_ts,                                  # 11: timestamp
+    bytes.fromhex('$this_extra'),              # 12: extra_data
+    b'\x77' * 32,                              # 13: prev_randao
+    bytes.fromhex('$this_nonce'),              # 14: nonce
+]
+rlp_bytes = rlp.encode(this_fields)
+if len(rlp_bytes) > 1024:
+    raise RuntimeError(f'rlp too long for fixture: {len(rlp_bytes)}')
+
+# Build extended-decode structs (128 B each)
+def build_struct(parent_hash, state_root, number, ts, gl, gu, bf):
+    out  = parent_hash
+    out += state_root
+    out += struct.pack('<Q', number)
+    out += struct.pack('<Q', ts)
+    out += struct.pack('<Q', gl)
+    out += struct.pack('<Q', gu)
+    out += bf.to_bytes(32, 'big')
+    assert len(out) == 128
+    return out
+
+this_struct   = build_struct(b'\x11' * 32, b'\x44' * 32,
+                              $this_number, $this_ts,
+                              $this_gas_limit, $this_gas_used, $this_bf)
+parent_struct = build_struct(b'\x22' * 32, b'\x55' * 32,
+                              $p_number, $p_ts,
+                              $p_gas_limit, $p_gas_used, $p_bf)
+
+# Assemble input file
+out  = struct.pack('<Q', len(rlp_bytes))   # bytes 0..8: rlp_len
+out += rlp_bytes
+out += b'\x00' * (1024 - len(rlp_bytes))   # pad rlp area to 1024 B
+out += this_struct                          # 128 B
+out += parent_struct                        # 128 B
+assert len(out) == 8 + 1024 + 256
+
+with open(sys.argv[1], 'wb') as f:
+    f.write(out)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_validate_header_full.elf \
+    -i "$in_file" -o "$out_file" -n 1000000 \
+    >"$REPO_ROOT/gen-out/zisk_validate_header_full_${name}.emu.log" 2>&1 || true
+
+  local actual; actual="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local exp_le; exp_le="$(python3 -c "print(int('$expected_status').to_bytes(8, 'little').hex())")"
+
+  if [[ "$actual" == "$exp_le" ]]; then
+    printf "  %-30s OK   status=%d\n" "$name" "$expected_status"
+    return 0
+  else
+    printf "  %-30s FAIL  expected status=%d got 0x%s\n" "$name" "$expected_status" "$actual"
+    return 1
+  fi
+}
+
+ZERO_NONCE="0000000000000000"
+
+FAILED=0
+# All pass: gas_used == parent_gas_target → base_fee unchanged
+# parent_gas_limit=30000000, parent_gas_used=15000000 (= target), parent.bf=50 gwei
+# this matches struct: gas_limit=30000000, gas_used=15000000, base_fee=50 gwei (unchanged)
+# this RLP has same fields; nonce=0; difficulty=0; ommers=EMPTY; extra_data <= 32B
+GWEI=$(python3 -c "print(10**9)")
+BF_50=$(python3 -c "print(50 * $GWEI)")
+
+build_test "all_pass_at_target" 0 \
+  "$EMPTY_OMMERS_HASH" 0 "$ZERO_NONCE" \
+  "74657374" \
+  101 1700000100 30000000 15000000 "$BF_50" \
+  100 1700000000 30000000 15000000 "$BF_50" || FAILED=1
+
+# Step 1 fail: ommers_hash mismatch → status = 100 + 1 = 101
+build_test "step1_ommers_fail" 101 \
+  "0000000000000000000000000000000000000000000000000000000000000000" 0 "$ZERO_NONCE" \
+  "74657374" \
+  101 1700000100 30000000 15000000 "$BF_50" \
+  100 1700000000 30000000 15000000 "$BF_50" || FAILED=1
+
+# Step 1 fail: difficulty != 0 → status = 102
+build_test "step1_diff_nonzero" 102 \
+  "$EMPTY_OMMERS_HASH" 1 "$ZERO_NONCE" \
+  "74657374" \
+  101 1700000100 30000000 15000000 "$BF_50" \
+  100 1700000000 30000000 15000000 "$BF_50" || FAILED=1
+
+# Step 2 fail: extra_data > 32 bytes → status = 200 + 1 = 201
+build_test "step2_extra_too_long" 201 \
+  "$EMPTY_OMMERS_HASH" 0 "$ZERO_NONCE" \
+  "$(printf 'aa%.0s' $(seq 1 40))" \
+  101 1700000100 30000000 15000000 "$BF_50" \
+  100 1700000000 30000000 15000000 "$BF_50" || FAILED=1
+
+# Step 3 fail: gas_used > gas_limit → 301
+# struct has this.gas_used=31M, this.gas_limit=30M
+# (RLP and struct must agree for base_fee step; we use struct values)
+build_test "step3_gas_used_overshoot" 301 \
+  "$EMPTY_OMMERS_HASH" 0 "$ZERO_NONCE" \
+  "74657374" \
+  101 1700000100 30000000 31000000 "$BF_50" \
+  100 1700000000 30000000 15000000 "$BF_50" || FAILED=1
+
+# Step 3 fail: number not parent+1 → 302
+build_test "step3_number_skip" 302 \
+  "$EMPTY_OMMERS_HASH" 0 "$ZERO_NONCE" \
+  "74657374" \
+  102 1700000100 30000000 15000000 "$BF_50" \
+  100 1700000000 30000000 15000000 "$BF_50" || FAILED=1
+
+# Step 3 fail: timestamp not strictly greater → 303
+build_test "step3_timestamp_eq" 303 \
+  "$EMPTY_OMMERS_HASH" 0 "$ZERO_NONCE" \
+  "74657374" \
+  101 1700000000 30000000 15000000 "$BF_50" \
+  100 1700000000 30000000 15000000 "$BF_50" || FAILED=1
+
+# Step 4 fail: gas_limit jumped too far → 402
+# this.gas_limit = parent.gas_limit + parent.gas_limit/1024 (= 30029296)
+# But we also need this.gas_used <= this.gas_limit. Let this.gas_used = 1 to pass step 3.
+build_test "step4_gas_limit_jump" 402 \
+  "$EMPTY_OMMERS_HASH" 0 "$ZERO_NONCE" \
+  "74657374" \
+  101 1700000100 30029296 1 "$BF_50" \
+  100 1700000000 30000000 15000000 "$BF_50" || FAILED=1
+
+# Step 5 fail: base_fee != calculated → 501
+# parent.gas_used == target → expected = parent.base_fee = BF_50.
+# So this.base_fee = BF_50 + 1 should fail step 5.
+WRONG_BF=$((BF_50 + 1))
+build_test "step5_base_fee_wrong" 501 \
+  "$EMPTY_OMMERS_HASH" 0 "$ZERO_NONCE" \
+  "74657374" \
+  101 1700000100 30000000 15000000 "$WRONG_BF" \
+  100 1700000000 30000000 15000000 "$BF_50" || FAILED=1
+
+# All pass: realistic Holesky 60% used scenario
+# parent.gas_used=18000000, target=15000000 (above), bf grows
+# expected = bf + delta where delta = max((bf*3M/15M)/8, 1) = (bf*0.2)/8 = bf*0.025
+BF_8=$(python3 -c "print(8 * $GWEI)")
+EXP_HOLESKY=$(python3 -c "
+pbf, pgl, pgu = $BF_8, 30000000, 18000000
+target = pgl // 2
+delta = pgu - target
+pfgd = pbf * delta
+tfgd = pfgd // target
+bfd = max(tfgd // 8, 1)
+print(pbf + bfd)
+")
+build_test "all_pass_holesky_60" 0 \
+  "$EMPTY_OMMERS_HASH" 0 "$ZERO_NONCE" \
+  "" \
+  101 1700000100 30000000 18000000 "$EXP_HOLESKY" \
+  100 1700000000 30000000 18000000 "$BF_8" || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: validate_header_full runs all 5 checks and routes via composite codes"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Run all five per-header validation checks in sequence and return a single composite status code that identifies which step failed (if any):

1. PR-K67 `header_validate_post_merge` — ommers/difficulty/nonce
2. PR-K68 `header_validate_extra_data_length` — `extra_data ≤ 32 bytes`
3. PR-K43 `validate_header_basic` — gas_used/number/timestamp
4. PR-K72 `check_gas_limit` — elasticity
5. PR-K74 `header_validate_base_fee` — EIP-1559 invariant

Status encoding lets callers `floor(status / 100)` to identify the failing step:

| Status | Meaning |
|--------|---------|
| 0 | All pass |
| 101..104 | Step 1 failed (K67 codes 1..4) |
| 201..202 | Step 2 failed (K68 codes 1..2) |
| 301..303 | Step 3 failed (K43 codes 1..3) |
| 401..402 | Step 4 failed (K72 codes 1..2) |
| 501..502 | Step 5 failed (K74 codes 1..2) |

Chain-level checks (parent_hash continuity, PR-K18 `validate_chain`) are NOT included here — they iterate across multiple headers and live at the SSZ-list walk level.

Substantial composition pulling in 5 validators + transitive deps (`rlp_list_nth_item`, `eip1559_calc_base_fee_per_gas` + u256 toolkit). The probe inlines every function it transitively calls.

## Test plan

- [x] `lake build` clean
- [x] `scripts/codegen-zisk-validate-header-full-check.sh` passes 10 fixtures:
  - 2 all-pass (at target, realistic Holesky 60% with growing base_fee)
  - One failure per step: ommers_fail, diff_nonzero, extra_too_long, gas_used_overshoot, number_skip, timestamp_eq, gas_limit_jump, base_fee_wrong

🤖 Generated with [Claude Code](https://claude.com/claude-code)