### PR TITLE
feat(stateless): process_withdrawal (PR-K77)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -9074,6 +9074,111 @@ def ziskWithdrawalDecodeProbeUnit : BuildUnit := {
   dataAsm     := ziskWithdrawalDecodeDataSection
 }
 
+/-! ## process_withdrawal -- PR-K77
+
+    Apply a Shanghai+ Withdrawal credit to a recipient's account
+    balance. Per Python's `process_withdrawal`:
+
+      account.balance += withdrawal.amount * 10^9
+
+    The withdrawal amount is denominated in Gwei; the balance is
+    in wei. We convert by multiplying by `GWEI_TO_WEI = 10^9`.
+
+    Composes:
+      - PR-K56 `u256_from_u64_be` — zero-extend amount to u256
+      - PR-K54 `u256_mul_u64_be`  — × 10^9 to convert Gwei → wei
+      - PR-K51 `u256_add_be`      — fold credit into balance
+
+    The mul step can't realistically overflow u256: amount ≤ 2^41
+    Gwei (full validator balance ~32 ETH ≈ 2^35 Gwei; ≤ 2^41
+    even for stake-pool aggregates), so amount × 10^9 < 2^71 ≪
+    2^256. The add can't realistically overflow either since
+    mainnet total wei < 2^87. Both are checked as safety nets.
+
+    Calling convention:
+      a0 (input)  : withdrawal struct ptr (48 B; from PR-K49
+                    `withdrawal_decode`, with amount at offset 40)
+      a1 (input)  : account.balance ptr (32 B u256 BE; modified
+                    in place)
+      ra (input)  : return
+      a0 (output) : 0 success / 1 overflow on mul or add.
+
+    Uses 32 bytes of `.data` scratch (`pw_amount_wei`) plus the
+    40-byte `u256m_acc` scratch from PR-K54. -/
+def processWithdrawalFunction : String :=
+  "process_withdrawal:\n" ++
+  "  addi sp, sp, -32\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp)\n" ++
+  "  mv s0, a0                   # withdrawal struct ptr\n" ++
+  "  mv s1, a1                   # balance ptr\n" ++
+  "  # Step 1: zero-extend amount (Gwei) to u256.\n" ++
+  "  ld t0, 40(s0)               # amount (u64)\n" ++
+  "  mv a0, t0\n" ++
+  "  la a1, pw_amount_wei\n" ++
+  "  jal ra, u256_from_u64_be\n" ++
+  "  # Step 2: amount_wei = amount × 10^9 (in place).\n" ++
+  "  la a0, pw_amount_wei\n" ++
+  "  li a1, 1000000000\n" ++
+  "  la a2, pw_amount_wei\n" ++
+  "  jal ra, u256_mul_u64_be\n" ++
+  "  bnez a0, .Lpw_fail\n" ++
+  "  # Step 3: balance += amount_wei.\n" ++
+  "  mv a0, s1\n" ++
+  "  la a1, pw_amount_wei\n" ++
+  "  mv a2, s1\n" ++
+  "  jal ra, u256_add_be\n" ++
+  "  bnez a0, .Lpw_fail\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lpw_ret\n" ++
+  ".Lpw_fail:\n" ++
+  "  li a0, 1\n" ++
+  ".Lpw_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp)\n" ++
+  "  addi sp, sp, 32\n" ++
+  "  ret"
+
+/-- `zisk_process_withdrawal`: probe BuildUnit. Reads (48 B
+    withdrawal struct, 32 B initial balance) from host input;
+    copies initial balance to OUTPUT + 8, calls
+    process_withdrawal on it, then writes status to OUTPUT. -/
+def ziskProcessWithdrawalPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a2, 0x40000000\n" ++
+  "  addi a0, a2, 8              # withdrawal struct ptr\n" ++
+  "  li a1, 0xa0010008           # balance buffer at OUTPUT + 8\n" ++
+  "  # Copy initial balance (input offset 48..80) to OUTPUT + 8.\n" ++
+  "  addi t0, a2, 56             # initial balance ptr\n" ++
+  "  ld t1,  0(t0); sd t1,  0(a1)\n" ++
+  "  ld t1,  8(t0); sd t1,  8(a1)\n" ++
+  "  ld t1, 16(t0); sd t1, 16(a1)\n" ++
+  "  ld t1, 24(t0); sd t1, 24(a1)\n" ++
+  "  jal ra, process_withdrawal\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)                # status\n" ++
+  "  j .Lpw_pdone\n" ++
+  u256FromU64BeFunction ++ "\n" ++
+  u256MulU64BeFunction ++ "\n" ++
+  u256AddBeFunction ++ "\n" ++
+  processWithdrawalFunction ++ "\n" ++
+  ".Lpw_pdone:"
+
+def ziskProcessWithdrawalDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "u256m_acc:\n" ++
+  "  .zero 40\n" ++
+  ".balign 32\n" ++
+  "pw_amount_wei:\n" ++
+  "  .zero 32"
+
+def ziskProcessWithdrawalProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskProcessWithdrawalPrologue
+  dataAsm     := ziskProcessWithdrawalDataSection
+}
+
 /-! ## withdrawals_sum_amounts -- PR-K65 block withdrawal-credit total
 
     Walk an RLP-encoded list of Shanghai+ Withdrawal records
@@ -10510,6 +10615,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_intrinsic_gas_legacy" => some ziskIntrinsicGasLegacyProbeUnit
   | "zisk_tx_validate_intrinsic_gas_legacy" => some ziskTxValidateIntrinsicGasLegacyProbeUnit
   | "zisk_withdrawal_decode"    => some ziskWithdrawalDecodeProbeUnit
+  | "zisk_process_withdrawal"   => some ziskProcessWithdrawalProbeUnit
   | "zisk_withdrawals_sum_amounts" => some ziskWithdrawalsSumAmountsProbeUnit
   | "zisk_sha256_from_input"    => some ziskSha256FromInputProbeUnit
   | "zisk_ssz_pair_hash"        => some ziskSszPairHashProbeUnit
@@ -10599,6 +10705,7 @@ def knownProgramNames : List String :=
    "zisk_intrinsic_gas_legacy",
    "zisk_tx_validate_intrinsic_gas_legacy",
    "zisk_withdrawal_decode",
+   "zisk_process_withdrawal",
    "zisk_withdrawals_sum_amounts",
    "zisk_sha256_from_input",
    "zisk_ssz_pair_hash",

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **99**
-- ziskemu round-trip scripts: **92** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **100**
+- ziskemu round-trip scripts: **93** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-process-withdrawal-check.sh
+++ b/scripts/codegen-zisk-process-withdrawal-check.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# codegen-zisk-process-withdrawal-check.sh -- PR-K77.
+#
+# Credit account.balance += withdrawal.amount × 10^9.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_process_withdrawal ELF"
+lake exe codegen --program zisk_process_withdrawal --halt linux93 \
+  -o gen-out/zisk_process_withdrawal
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <wd_index> <wd_validator> <wd_addr_hex> <wd_amount_gwei> <initial_balance_wei>
+run_case() {
+  local name="$1" wi="$2" wv="$3" wa="$4" amt="$5" bal="$6"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_process_withdrawal_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_process_withdrawal_${name}.output"
+  local exp_file="$REPO_ROOT/gen-out/zisk_process_withdrawal_${name}.expected"
+
+  python3 -c "
+import struct, sys
+wi, wv, amt, bal = $wi, $wv, $amt, $bal
+wa = bytes.fromhex('$wa')
+# Build withdrawal struct (48 B):
+#   0..8 index, 8..16 validator, 16..36 addr (20B), 36..40 pad, 40..48 amount
+struct_bytes  = struct.pack('<Q', wi)
+struct_bytes += struct.pack('<Q', wv)
+struct_bytes += wa.ljust(20, b'\x00')
+struct_bytes += b'\x00' * 4
+struct_bytes += struct.pack('<Q', amt)
+assert len(struct_bytes) == 48
+with open(sys.argv[1], 'wb') as f:
+    f.write(struct_bytes)
+    f.write(bal.to_bytes(32, 'big'))
+
+# Expected
+new_bal = bal + amt * 10**9
+status = 0 if new_bal < (1 << 256) else 1
+new_bal %= (1 << 256)
+with open(sys.argv[2], 'wb') as f:
+    f.write(struct.pack('<Q', status))
+    f.write(new_bal.to_bytes(32, 'big'))
+" "$in_file" "$exp_file"
+
+  "$ZISKEMU" -e gen-out/zisk_process_withdrawal.elf \
+    -i "$in_file" -o "$out_file" -n 500000 \
+    >"$REPO_ROOT/gen-out/zisk_process_withdrawal_${name}.emu.log" 2>&1 || true
+
+  local actual; actual="$(xxd -p -l 40 "$out_file" | tr -d '\n')"
+  local expected; expected="$(xxd -p -l 40 "$exp_file" | tr -d '\n')"
+
+  if [[ "$actual" == "$expected" ]]; then
+    local new_bal; new_bal="$(python3 -c "print(($bal + $amt * 10**9) % (1<<256))")"
+    printf "  %-30s OK   new_balance=%s\n" "$name" "${new_bal:0:24}..."
+    return 0
+  else
+    printf "  %-30s FAIL\n    expected: %s\n    actual:   %s\n" "$name" "$expected" "$actual"
+    return 1
+  fi
+}
+
+ALICE="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+ETH=$(python3 -c "print(10**18)")
+GWEI=$(python3 -c "print(10**9)")
+
+FAILED=0
+# Typical mainnet withdrawal: 1 ETH = 10^9 gwei → balance += 1 ETH
+run_case "one_eth_to_zero_balance" \
+  1 12345 "$ALICE" "$GWEI" 0 || FAILED=1
+
+# Existing 1 ETH balance + 32 ETH withdrawal (full validator)
+run_case "32_eth_to_1_eth_balance" \
+  10 100 "$ALICE" $(python3 -c "print(32 * 10**9)") "$ETH" || FAILED=1
+
+# Zero amount: balance unchanged
+run_case "zero_amount" \
+  0 0 "$ALICE" 0 "$ETH" || FAILED=1
+
+# Small amount (1 gwei): balance += 10^9
+run_case "one_gwei" \
+  5 50 "$ALICE" 1 0 || FAILED=1
+
+# Large amount (max u64 gwei): balance += max_u64 × 10^9
+MAX_U64=18446744073709551615
+run_case "max_u64_gwei" \
+  100 100 "$ALICE" "$MAX_U64" 0 || FAILED=1
+
+# Realistic partial withdrawal: 0.5 ETH worth
+run_case "half_eth" \
+  3 75 "$ALICE" $(python3 -c "print(5 * 10**8)") $(python3 -c "print(100 * 10**18)") || FAILED=1
+
+# Edge: balance already huge, add small withdrawal
+HUGE_BAL=$(python3 -c "print((1 << 200))")
+run_case "huge_balance_small_wd" \
+  7 77 "$ALICE" 1000 "$HUGE_BAL" || FAILED=1
+
+# Edge: amount × 10^9 + existing balance ~ 2^65 (still small relative to u256)
+run_case "tiny_wd_zero_bal" \
+  0 1 "$ALICE" 100 0 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: process_withdrawal credits balance with amount × 10^9"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Apply a Shanghai+ Withdrawal credit to a recipient's account balance. Per Python `process_withdrawal`:

```
account.balance += withdrawal.amount * 10^9   # Gwei → wei
```

Direct piece of `apply_body`'s withdrawals loop.

## Composition

- PR-K56 `u256_from_u64_be` — zero-extend amount to u256
- PR-K54 `u256_mul_u64_be` — × 10^9 to convert Gwei → wei
- PR-K51 `u256_add_be` — fold credit into balance

The mul step can't realistically overflow u256 (amount ≤ 2^41 Gwei × 10^9 < 2^71). The add can't realistically overflow either (mainnet total wei < 2^87). Both are checked as safety nets.

Operates in place: takes withdrawal struct ptr (from PR-K49 `withdrawal_decode`, amount at offset 40) and balance ptr; modifies `*balance` directly.

## Test plan

- [x] `lake build` clean
- [x] `scripts/codegen-zisk-process-withdrawal-check.sh` passes 8 fixtures:
  - 1 ETH credit from zero balance
  - 32 ETH credit to 1 ETH balance (full validator withdrawal)
  - Zero amount (no-op), 1 gwei, max_u64 gwei
  - 0.5 ETH partial withdrawal
  - Huge balance + small withdrawal
  - Tiny credit to zero balance

🤖 Generated with [Claude Code](https://claude.com/claude-code)