### PR TITLE
feat(divmod): add v4 qout raw unfold

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/CallAddback.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/CallAddback.lean
@@ -209,6 +209,27 @@ theorem n4CallAddbackBeqQOutV4_unfold {a b : EvmWord} :
        else qHat + signExtend12 4095) :=
   rfl
 
+theorem n4CallAddbackBeqQOutV4_raw_unfold {a b : EvmWord} :
+    n4CallAddbackBeqQOutV4 a b =
+      (let shift := (clzResult (b.getLimbN 3)).1.toNat % 64
+       let antiShift :=
+         (signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 3)).1).toNat % 64
+       let b3' := ((b.getLimbN 3) <<< shift) ||| ((b.getLimbN 2) >>> antiShift)
+       let b2' := ((b.getLimbN 2) <<< shift) ||| ((b.getLimbN 1) >>> antiShift)
+       let b1' := ((b.getLimbN 1) <<< shift) ||| ((b.getLimbN 0) >>> antiShift)
+       let b0' := (b.getLimbN 0) <<< shift
+       let u4 := (a.getLimbN 3) >>> antiShift
+       let u3 := ((a.getLimbN 3) <<< shift) ||| ((a.getLimbN 2) >>> antiShift)
+       let u2 := ((a.getLimbN 2) <<< shift) ||| ((a.getLimbN 1) >>> antiShift)
+       let u1 := ((a.getLimbN 1) <<< shift) ||| ((a.getLimbN 0) >>> antiShift)
+       let u0 := (a.getLimbN 0) <<< shift
+       let qHat := div128Quot_v4 u4 u3 b3'
+       let ms := mulsubN4 qHat b0' b1' b2' b3' u0 u1 u2 u3
+       let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 b0' b1' b2' b3'
+       if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
+       else qHat + signExtend12 4095) :=
+  rfl
+
 /-- The zero-carry call+addback-BEQ case decrements the trial quotient twice. -/
 theorem n4CallAddbackBeqQOutV4_of_carry_eq_zero {a b : EvmWord}
     (h_carry : n4CallAddbackBeqCarryV4 a b = 0) :


### PR DESCRIPTION
## Summary
- add n4CallAddbackBeqQOutV4_raw_unfold
- expose qOut directly as the normalized v4 qHat / mulsub / addback-carry expression
- keep the existing compact qHat/carry-based unfold lemma available for smaller rewrites

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.CallAddback
- lake build EvmAsm.Evm64.DivMod
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- rg -n "DivStackSpecCase|ModStackSpecCase|SDivStackSpecCase|SModStackSpecCase|StackSpecCase|set_option maxRecDepth|set_option maxHeartbeats|sorry|admit" EvmAsm/Evm64/DivMod/Spec/CallAddback.lean