### PR TITLE
feat(stateless): validate_transaction_balance (PR-K79)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -7821,6 +7821,116 @@ def ziskTxCostComputeProbeUnit : BuildUnit := {
   dataAsm     := ziskTxCostComputeDataSection
 }
 
+/-! ## validate_transaction_balance -- PR-K79
+
+    Verify that the sender's account balance covers the
+    worst-case (pre-execution) tx cost:
+
+      tx_cost = tx.max_fee_per_gas × tx.gas_limit + tx.value
+      assert sender.balance >= tx_cost
+
+    This is the pre-flight check from Python's
+    `validate_transaction`:
+
+      max_gas_fee = tx.gas * tx.max_fee_per_gas
+      if sender.balance < max_gas_fee + tx.value:
+          raise InsufficientBalance
+
+    Note: this uses `max_fee_per_gas` (the absolute cap), not
+    `effective_gas_price` — the worst-case cost the sender could
+    incur. Post-execution, the actual cost uses the lower
+    effective_gas_price.
+
+    Composes PR-K71 `tx_cost_compute` (#5723) + an inline
+    byte-walk `>=` comparison (no dependency on still-pending
+    PR-K50 `u256_lt`).
+
+    Calling convention:
+      a0 (input)  : max_fee_per_gas ptr (32 B BE)
+      a1 (input)  : gas_limit (u64)
+      a2 (input)  : value ptr (32 B BE)
+      a3 (input)  : sender.balance ptr (32 B BE)
+      ra (input)  : return
+      a0 (output) :
+        0  : balance >= tx_cost (ok)
+        1  : tx_cost computation overflowed u256
+        2  : balance < tx_cost (insufficient funds)
+
+    Uses 32 bytes of `.data` scratch (`vtb_cost_scratch`). -/
+def validateTransactionBalanceFunction : String :=
+  "validate_transaction_balance:\n" ++
+  "  addi sp, sp, -16\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp)\n" ++
+  "  mv s0, a3                   # save balance ptr\n" ++
+  "  # tx_cost = tx_cost_compute(max_fee, gas_limit, value, vtb_cost_scratch)\n" ++
+  "  la a3, vtb_cost_scratch\n" ++
+  "  jal ra, tx_cost_compute\n" ++
+  "  bnez a0, .Lvtb_overflow\n" ++
+  "  # Inline byte-walk: balance >= cost (MSB→LSB).\n" ++
+  "  la t0, vtb_cost_scratch     # cost ptr\n" ++
+  "  mv t1, s0                   # balance ptr\n" ++
+  "  li t2, 0\n" ++
+  "  li t3, 32\n" ++
+  ".Lvtb_cmp:\n" ++
+  "  beq t2, t3, .Lvtb_ok        # all 32 bytes equal → balance == cost → ok\n" ++
+  "  add t4, t1, t2\n" ++
+  "  add t5, t0, t2\n" ++
+  "  lbu t6, 0(t4)\n" ++
+  "  lbu a7, 0(t5)\n" ++
+  "  bltu t6, a7, .Lvtb_lt\n" ++
+  "  bgtu t6, a7, .Lvtb_ok\n" ++
+  "  addi t2, t2, 1\n" ++
+  "  j .Lvtb_cmp\n" ++
+  ".Lvtb_ok:\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lvtb_ret\n" ++
+  ".Lvtb_lt:\n" ++
+  "  li a0, 2\n" ++
+  "  j .Lvtb_ret\n" ++
+  ".Lvtb_overflow:\n" ++
+  "  li a0, 1\n" ++
+  ".Lvtb_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp)\n" ++
+  "  addi sp, sp, 16\n" ++
+  "  ret"
+
+/-- `zisk_validate_transaction_balance`: probe BuildUnit. Reads
+    (32B max_fee, 8B gas_limit LE, 32B value, 32B balance) from
+    host input, writes 8-byte status to OUTPUT. -/
+def ziskValidateTransactionBalancePrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a4, 0x40000000\n" ++
+  "  addi a0, a4, 8              # max_fee ptr\n" ++
+  "  ld a1, 40(a4)               # gas_limit (u64)\n" ++
+  "  addi a2, a4, 48             # value ptr\n" ++
+  "  addi a3, a4, 80             # balance ptr\n" ++
+  "  jal ra, validate_transaction_balance\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)                # status\n" ++
+  "  j .Lvtb_pdone\n" ++
+  u256MulU64BeFunction ++ "\n" ++
+  u256AddBeFunction ++ "\n" ++
+  txCostComputeFunction ++ "\n" ++
+  validateTransactionBalanceFunction ++ "\n" ++
+  ".Lvtb_pdone:"
+
+def ziskValidateTransactionBalanceDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "u256m_acc:\n" ++
+  "  .zero 40\n" ++
+  ".balign 32\n" ++
+  "vtb_cost_scratch:\n" ++
+  "  .zero 32"
+
+def ziskValidateTransactionBalanceProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskValidateTransactionBalancePrologue
+  dataAsm     := ziskValidateTransactionBalanceDataSection
+}
+
 /-! ## u256_to_u64_be -- PR-K57 truncate BE u256 → u64 with overflow flag
 
     Truncate a 32-byte big-endian `u256` buffer down to its
@@ -10908,6 +11018,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_priority_fee_per_gas_eip1559" => some ziskPriorityFeePerGasEip1559ProbeUnit
   | "zisk_effective_gas_price_eip1559" => some ziskEffectiveGasPriceEip1559ProbeUnit
   | "zisk_tx_cost_compute"      => some ziskTxCostComputeProbeUnit
+  | "zisk_validate_transaction_balance" => some ziskValidateTransactionBalanceProbeUnit
   | "zisk_tx_type_dispatch"     => some ziskTxTypeDispatchProbeUnit
   | "zisk_tx_eip2930_decode"    => some ziskTxEip2930DecodeProbeUnit
   | "zisk_tx_eip7702_decode"    => some ziskTxEip7702DecodeProbeUnit
@@ -11000,6 +11111,7 @@ def knownProgramNames : List String :=
    "zisk_priority_fee_per_gas_eip1559",
    "zisk_effective_gas_price_eip1559",
    "zisk_tx_cost_compute",
+   "zisk_validate_transaction_balance",
    "zisk_tx_type_dispatch",
    "zisk_tx_eip2930_decode",
    "zisk_tx_eip7702_decode",

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **101**
-- ziskemu round-trip scripts: **94** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **102**
+- ziskemu round-trip scripts: **95** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-validate-transaction-balance-check.sh
+++ b/scripts/codegen-zisk-validate-transaction-balance-check.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# codegen-zisk-validate-transaction-balance-check.sh -- PR-K79.
+#
+# Verify sender.balance >= max_fee_per_gas × gas_limit + value.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_validate_transaction_balance ELF"
+lake exe codegen --program zisk_validate_transaction_balance --halt linux93 \
+  -o gen-out/zisk_validate_transaction_balance
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <expected_status> <max_fee> <gas_limit> <value> <balance>
+run_case() {
+  local name="$1" expected_status="$2" mf="$3" gl="$4" val="$5" bal="$6"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_validate_transaction_balance_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_validate_transaction_balance_${name}.output"
+
+  python3 -c "
+import struct, sys
+mf, gl, val, bal = $mf, $gl, $val, $bal
+with open(sys.argv[1], 'wb') as f:
+    f.write(mf.to_bytes(32, 'big'))
+    f.write(struct.pack('<Q', gl))
+    f.write(val.to_bytes(32, 'big'))
+    f.write(bal.to_bytes(32, 'big'))
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_validate_transaction_balance.elf \
+    -i "$in_file" -o "$out_file" -n 500000 \
+    >"$REPO_ROOT/gen-out/zisk_validate_transaction_balance_${name}.emu.log" 2>&1 || true
+
+  local actual; actual="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local exp_le; exp_le="$(python3 -c "print(int('$expected_status').to_bytes(8, 'little').hex())")"
+
+  if [[ "$actual" == "$exp_le" ]]; then
+    printf "  %-30s OK   status=%d\n" "$name" "$expected_status"
+    return 0
+  else
+    printf "  %-30s FAIL  expected status=%d got 0x%s\n" "$name" "$expected_status" "$actual"
+    return 1
+  fi
+}
+
+GWEI=$(python3 -c "print(10**9)")
+ETH=$(python3 -c "print(10**18)")
+MAX256=115792089237316195423570985008687907853269984665640564039457584007913129639935
+
+FAILED=0
+# Pass cases (balance >= cost)
+run_case "simple_ok"            0 $(python3 -c "print(50 * $GWEI)") 21000 "$ETH" $(python3 -c "print(10**18 + 50 * 10**9 * 21000)") || FAILED=1
+run_case "balance_eq_cost"      0 $(python3 -c "print(50 * $GWEI)") 21000 0 $(python3 -c "print(50 * $GWEI * 21000)") || FAILED=1
+run_case "huge_balance"         0 $(python3 -c "print(50 * $GWEI)") 21000 "$ETH" "$MAX256" || FAILED=1
+run_case "zero_cost_zero_bal"   0 0 0 0 0 || FAILED=1
+run_case "zero_value_balance_ok" 0 $(python3 -c "print(100 * $GWEI)") 30000 0 "$ETH" || FAILED=1
+# Reject (balance < cost)
+run_case "balance_one_less"     2 $(python3 -c "print(50 * $GWEI)") 21000 0 $(python3 -c "print(50 * $GWEI * 21000 - 1)") || FAILED=1
+run_case "zero_balance"         2 $(python3 -c "print(50 * $GWEI)") 21000 0 0 || FAILED=1
+run_case "value_exceeds"        2 $(python3 -c "print(50 * $GWEI)") 21000 "$ETH" 1 || FAILED=1
+# Overflow (cost computation overflows u256)
+run_case "cost_mul_overflow"    1 "$MAX256" 2 0 "$ETH" || FAILED=1
+# Realistic Holesky shape
+run_case "holesky_ok" \
+  0 $(python3 -c "print(8 * $GWEI)") 30000000 $(python3 -c "print(2 * 10**16)") "$ETH" || FAILED=1
+# Realistic Holesky shape that should fail (balance too low)
+run_case "holesky_insufficient" \
+  2 $(python3 -c "print(8 * $GWEI)") 30000000 "$ETH" 1 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: validate_transaction_balance enforces balance >= max_fee*gas + value"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Verify the sender's account balance covers the worst-case (pre-execution) tx cost:

```
tx_cost = tx.max_fee_per_gas × tx.gas_limit + tx.value
assert sender.balance >= tx_cost
```

Pre-flight check from Python's `validate_transaction`. Uses `max_fee_per_gas` (the absolute cap), not `effective_gas_price` — the worst-case cost the sender could incur. Post-execution, the actual cost uses the lower `effective_gas_price`.

## Composition

- PR-K71 `tx_cost_compute` (#5723) — compute `max_fee × gas_limit + value`
- Inline byte-walk `>=` comparison (no dependency on still-pending PR-K50 `u256_lt`)

## Return codes

| `a0` | Meaning |
|------|---------|
| 0 | `balance >= tx_cost` (ok) |
| 1 | `tx_cost` computation overflowed u256 |
| 2 | `balance < tx_cost` (insufficient funds) |

## Test plan

- [x] `lake build` clean
- [x] `scripts/codegen-zisk-validate-transaction-balance-check.sh` passes 11 fixtures:
  - 5 pass cases (simple, equality boundary, huge balance, zero edge cases)
  - 3 reject paths (one less, zero balance, value exceeds)
  - Cost-mul overflow
  - Realistic Holesky pass + insufficient

🤖 Generated with [Claude Code](https://claude.com/claude-code)