### PR TITLE
feat(stateless): validate_transaction_full (PR-K80)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -7856,41 +7856,41 @@ def ziskTxCostComputeProbeUnit : BuildUnit := {
         1  : tx_cost computation overflowed u256
         2  : balance < tx_cost (insufficient funds)
 
-    Uses 32 bytes of `.data` scratch (`vtb_cost_scratch`). -/
+    Uses 32 bytes of `.data` scratch (`vtbal_cost_scratch`). -/
 def validateTransactionBalanceFunction : String :=
   "validate_transaction_balance:\n" ++
   "  addi sp, sp, -16\n" ++
   "  sd ra,  0(sp)\n" ++
   "  sd s0,  8(sp)\n" ++
   "  mv s0, a3                   # save balance ptr\n" ++
-  "  # tx_cost = tx_cost_compute(max_fee, gas_limit, value, vtb_cost_scratch)\n" ++
-  "  la a3, vtb_cost_scratch\n" ++
+  "  # tx_cost = tx_cost_compute(max_fee, gas_limit, value, vtbal_cost_scratch)\n" ++
+  "  la a3, vtbal_cost_scratch\n" ++
   "  jal ra, tx_cost_compute\n" ++
-  "  bnez a0, .Lvtb_overflow\n" ++
+  "  bnez a0, .Lvtbal_overflow\n" ++
   "  # Inline byte-walk: balance >= cost (MSB→LSB).\n" ++
-  "  la t0, vtb_cost_scratch     # cost ptr\n" ++
+  "  la t0, vtbal_cost_scratch   # cost ptr\n" ++
   "  mv t1, s0                   # balance ptr\n" ++
   "  li t2, 0\n" ++
   "  li t3, 32\n" ++
-  ".Lvtb_cmp:\n" ++
-  "  beq t2, t3, .Lvtb_ok        # all 32 bytes equal → balance == cost → ok\n" ++
+  ".Lvtbal_cmp:\n" ++
+  "  beq t2, t3, .Lvtbal_ok      # all 32 bytes equal → balance == cost → ok\n" ++
   "  add t4, t1, t2\n" ++
   "  add t5, t0, t2\n" ++
   "  lbu t6, 0(t4)\n" ++
   "  lbu a7, 0(t5)\n" ++
-  "  bltu t6, a7, .Lvtb_lt\n" ++
-  "  bgtu t6, a7, .Lvtb_ok\n" ++
+  "  bltu t6, a7, .Lvtbal_lt\n" ++
+  "  bgtu t6, a7, .Lvtbal_ok\n" ++
   "  addi t2, t2, 1\n" ++
-  "  j .Lvtb_cmp\n" ++
-  ".Lvtb_ok:\n" ++
+  "  j .Lvtbal_cmp\n" ++
+  ".Lvtbal_ok:\n" ++
   "  li a0, 0\n" ++
-  "  j .Lvtb_ret\n" ++
-  ".Lvtb_lt:\n" ++
+  "  j .Lvtbal_ret\n" ++
+  ".Lvtbal_lt:\n" ++
   "  li a0, 2\n" ++
-  "  j .Lvtb_ret\n" ++
-  ".Lvtb_overflow:\n" ++
+  "  j .Lvtbal_ret\n" ++
+  ".Lvtbal_overflow:\n" ++
   "  li a0, 1\n" ++
-  ".Lvtb_ret:\n" ++
+  ".Lvtbal_ret:\n" ++
   "  ld ra,  0(sp)\n" ++
   "  ld s0,  8(sp)\n" ++
   "  addi sp, sp, 16\n" ++
@@ -7909,12 +7909,12 @@ def ziskValidateTransactionBalancePrologue : String :=
   "  jal ra, validate_transaction_balance\n" ++
   "  li t0, 0xa0010000\n" ++
   "  sd a0, 0(t0)                # status\n" ++
-  "  j .Lvtb_pdone\n" ++
+  "  j .Lvtbal_pdone\n" ++
   u256MulU64BeFunction ++ "\n" ++
   u256AddBeFunction ++ "\n" ++
   txCostComputeFunction ++ "\n" ++
   validateTransactionBalanceFunction ++ "\n" ++
-  ".Lvtb_pdone:"
+  ".Lvtbal_pdone:"
 
 def ziskValidateTransactionBalanceDataSection : String :=
   ".section .data\n" ++
@@ -7922,7 +7922,7 @@ def ziskValidateTransactionBalanceDataSection : String :=
   "u256m_acc:\n" ++
   "  .zero 40\n" ++
   ".balign 32\n" ++
-  "vtb_cost_scratch:\n" ++
+  "vtbal_cost_scratch:\n" ++
   "  .zero 32"
 
 def ziskValidateTransactionBalanceProbeUnit : BuildUnit := {
@@ -9189,6 +9189,167 @@ def ziskValidateTransactionBasicProbeUnit : BuildUnit := {
   body        := NOP
   prologueAsm := ziskValidateTransactionBasicPrologue
   dataAsm     := ziskValidateTransactionBasicDataSection
+}
+
+/-! ## validate_transaction_full -- PR-K80
+
+    Top-level pre-EVM tx validator: compose all the cheap u64
+    checks with the u256-arithmetic balance check.
+
+      1. PR-K76 `validate_transaction_basic`   — chain_id / gas_limit /
+                                                  nonce / intrinsic_gas
+      2. PR-K79 `validate_transaction_balance` — balance >= max_fee * gas + value
+
+    If any sub-step fails, this helper returns immediately with
+    a composite status code (analogous to PR-K75 and K76):
+
+      0          : all checks pass — tx ready for EVM dispatch
+      101..103   : K76 step 1 (chain_id / gas_limit / nonce)
+      201        : K76 step 2 (intrinsic_gas > gas_limit)
+      301        : K79 step 1 (tx_cost overflow)
+      302        : K79 step 2 (balance < tx_cost)
+
+    Distinct decades let callers `floor(status/100)` to identify
+    the failing layer.
+
+    The argument packing follows K76 (a7 = (is_creation << 63) |
+    data_len) and inserts a `max_fee_per_gas ptr` / `value ptr` /
+    `balance ptr` triple in saved registers since RV64 has only
+    8 arg regs.
+
+    Calling convention:
+      a0 (input)  : tx.chain_id (u64)
+      a1 (input)  : block.chain_id (u64)
+      a2 (input)  : tx.gas_limit (u64)
+      a3 (input)  : block.gas_limit (u64)
+      a4 (input)  : tx.nonce (u64)
+      a5 (input)  : account.nonce (u64)
+      a6 (input)  : data ptr
+      a7 (input)  : packed input: low 32 = data_len, bit 63 = is_creation
+      ra (input)  : return
+
+    The three 32-byte pointers (max_fee_per_gas, value, balance)
+    are passed through fixed `.data` slots that the caller
+    populates BEFORE invoking this helper:
+      vtf_max_fee  : 32 B u256 BE
+      vtf_value    : 32 B u256 BE
+      vtf_balance  : 32 B u256 BE
+
+    a0 (output) : composite status code (see encoding above). -/
+def validateTransactionFullFunction : String :=
+  "validate_transaction_full:\n" ++
+  "  addi sp, sp, -32\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp)\n" ++
+  "  # Save tx.gas_limit (a2) for step 2 — K76 will not preserve\n" ++
+  "  # caller's args, and step 2 needs it as a1 input.\n" ++
+  "  mv s0, a2                   # tx.gas_limit\n" ++
+  "  # Step 1: K76 validate_transaction_basic — args already in a0..a7.\n" ++
+  "  jal ra, validate_transaction_basic\n" ++
+  "  beqz a0, .Lvtf_s2\n" ++
+  "  # Forward K76's code (100..201) directly — it's already in the\n" ++
+  "  # K80 status table since K76 and K80 share the same decades.\n" ++
+  "  j .Lvtf_ret\n" ++
+  ".Lvtf_s2:\n" ++
+  "  # Step 2: K79 validate_transaction_balance(max_fee, gas_limit,\n" ++
+  "  #                                         value, balance)\n" ++
+  "  la a0, vtf_max_fee\n" ++
+  "  mv a1, s0                   # restored tx.gas_limit\n" ++
+  "  la a2, vtf_value\n" ++
+  "  la a3, vtf_balance\n" ++
+  "  jal ra, validate_transaction_balance\n" ++
+  "  beqz a0, .Lvtf_ret\n" ++
+  "  li t0, 300\n" ++
+  "  add a0, a0, t0\n" ++
+  ".Lvtf_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp)\n" ++
+  "  addi sp, sp, 32\n" ++
+  "  ret"
+
+/-- `zisk_validate_transaction_full`: probe BuildUnit. Reads
+    (tx_chain, block_chain, tx_gas, block_gas, tx_nonce,
+    account_nonce, is_creation, data_len, max_fee, value,
+    balance, data_bytes) from host input; sets up the .data
+    slots and a-regs; writes 8-byte composite status. -/
+def ziskValidateTransactionFullPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li t0, 0x40000000\n" ++
+  "  ld a0,  8(t0)               # tx.chain_id\n" ++
+  "  ld a1, 16(t0)               # block.chain_id\n" ++
+  "  ld a2, 24(t0)               # tx.gas_limit\n" ++
+  "  ld a3, 32(t0)               # block.gas_limit\n" ++
+  "  ld a4, 40(t0)               # tx.nonce\n" ++
+  "  ld a5, 48(t0)               # account.nonce\n" ++
+  "  ld t1, 56(t0)               # is_creation\n" ++
+  "  ld t2, 64(t0)               # data_len\n" ++
+  "  # Copy max_fee (offset 72..104) → vtf_max_fee\n" ++
+  "  la t3, vtf_max_fee\n" ++
+  "  addi t4, t0, 72\n" ++
+  "  ld t5,  0(t4); sd t5,  0(t3)\n" ++
+  "  ld t5,  8(t4); sd t5,  8(t3)\n" ++
+  "  ld t5, 16(t4); sd t5, 16(t3)\n" ++
+  "  ld t5, 24(t4); sd t5, 24(t3)\n" ++
+  "  # Copy value (offset 104..136) → vtf_value\n" ++
+  "  la t3, vtf_value\n" ++
+  "  addi t4, t0, 104\n" ++
+  "  ld t5,  0(t4); sd t5,  0(t3)\n" ++
+  "  ld t5,  8(t4); sd t5,  8(t3)\n" ++
+  "  ld t5, 16(t4); sd t5, 16(t3)\n" ++
+  "  ld t5, 24(t4); sd t5, 24(t3)\n" ++
+  "  # Copy balance (offset 136..168) → vtf_balance\n" ++
+  "  la t3, vtf_balance\n" ++
+  "  addi t4, t0, 136\n" ++
+  "  ld t5,  0(t4); sd t5,  0(t3)\n" ++
+  "  ld t5,  8(t4); sd t5,  8(t3)\n" ++
+  "  ld t5, 16(t4); sd t5, 16(t3)\n" ++
+  "  ld t5, 24(t4); sd t5, 24(t3)\n" ++
+  "  addi a6, t0, 168            # data ptr (after balance)\n" ++
+  "  # Pack a7\n" ++
+  "  slli t1, t1, 63\n" ++
+  "  li t6, 0xffffffff\n" ++
+  "  and t2, t2, t6\n" ++
+  "  or  a7, t1, t2\n" ++
+  "  jal ra, validate_transaction_full\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)                # status\n" ++
+  "  j .Lvtf_pdone\n" ++
+  txValidateAgainstBlockFunction ++ "\n" ++
+  intrinsicGasLegacyFunction ++ "\n" ++
+  txValidateIntrinsicGasLegacyFunction ++ "\n" ++
+  validateTransactionBasicFunction ++ "\n" ++
+  u256MulU64BeFunction ++ "\n" ++
+  u256AddBeFunction ++ "\n" ++
+  txCostComputeFunction ++ "\n" ++
+  validateTransactionBalanceFunction ++ "\n" ++
+  validateTransactionFullFunction ++ "\n" ++
+  ".Lvtf_pdone:"
+
+def ziskValidateTransactionFullDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "u256m_acc:\n" ++
+  "  .zero 40\n" ++
+  ".balign 32\n" ++
+  "vtbal_cost_scratch:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "vtb_gas_scratch:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "vtf_max_fee:\n" ++
+  "  .zero 32\n" ++
+  ".balign 32\n" ++
+  "vtf_value:\n" ++
+  "  .zero 32\n" ++
+  ".balign 32\n" ++
+  "vtf_balance:\n" ++
+  "  .zero 32"
+
+def ziskValidateTransactionFullProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskValidateTransactionFullPrologue
+  dataAsm     := ziskValidateTransactionFullDataSection
 }
 
 /-! ## withdrawal_decode -- PR-K49 4-field withdrawal RLP decoder
@@ -11026,6 +11187,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_intrinsic_gas_legacy" => some ziskIntrinsicGasLegacyProbeUnit
   | "zisk_tx_validate_intrinsic_gas_legacy" => some ziskTxValidateIntrinsicGasLegacyProbeUnit
   | "zisk_validate_transaction_basic" => some ziskValidateTransactionBasicProbeUnit
+  | "zisk_validate_transaction_full" => some ziskValidateTransactionFullProbeUnit
   | "zisk_withdrawal_decode"    => some ziskWithdrawalDecodeProbeUnit
   | "zisk_process_withdrawal"   => some ziskProcessWithdrawalProbeUnit
   | "zisk_process_withdrawals_block" => some ziskProcessWithdrawalsBlockProbeUnit
@@ -11119,6 +11281,7 @@ def knownProgramNames : List String :=
    "zisk_intrinsic_gas_legacy",
    "zisk_tx_validate_intrinsic_gas_legacy",
    "zisk_validate_transaction_basic",
+   "zisk_validate_transaction_full",
    "zisk_withdrawal_decode",
    "zisk_process_withdrawal",
    "zisk_process_withdrawals_block",

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **102**
-- ziskemu round-trip scripts: **95** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **103**
+- ziskemu round-trip scripts: **96** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-validate-transaction-full-check.sh
+++ b/scripts/codegen-zisk-validate-transaction-full-check.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# codegen-zisk-validate-transaction-full-check.sh -- PR-K80.
+#
+# Top-level pre-EVM tx validator composing K76 + K79.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_validate_transaction_full ELF"
+lake exe codegen --program zisk_validate_transaction_full --halt linux93 \
+  -o gen-out/zisk_validate_transaction_full
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <expected_status>
+#         <tx_chain> <block_chain> <tx_gas> <block_gas>
+#         <tx_nonce> <account_nonce> <is_creation> <data_hex>
+#         <max_fee> <value> <balance>
+run_case() {
+  local name="$1" exp="$2"
+  local tcv="$3" bcv="$4" tg="$5" bg="$6" tn="$7" an="$8"
+  local ic="$9" dh="${10}"
+  local mf="${11}" v="${12}" b="${13}"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_validate_transaction_full_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_validate_transaction_full_${name}.output"
+
+  python3 -c "
+import struct, sys
+data = bytes.fromhex('$dh')
+out  = struct.pack('<Q', $tcv)
+out += struct.pack('<Q', $bcv)
+out += struct.pack('<Q', $tg)
+out += struct.pack('<Q', $bg)
+out += struct.pack('<Q', $tn)
+out += struct.pack('<Q', $an)
+out += struct.pack('<Q', $ic)
+out += struct.pack('<Q', len(data))
+out += ($mf).to_bytes(32, 'big')
+out += ($v).to_bytes(32, 'big')
+out += ($b).to_bytes(32, 'big')
+out += data
+pad = (-len(out)) % 8
+if pad:
+    out += b'\x00' * pad
+sys.stdout.buffer.write(out)
+" > "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_validate_transaction_full.elf \
+    -i "$in_file" -o "$out_file" -n 500000 \
+    >"$REPO_ROOT/gen-out/zisk_validate_transaction_full_${name}.emu.log" 2>&1 || true
+
+  local actual; actual="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local exp_le; exp_le="$(python3 -c "print(int('$exp').to_bytes(8, 'little').hex())")"
+
+  if [[ "$actual" == "$exp_le" ]]; then
+    printf "  %-30s OK   status=%d\n" "$name" "$exp"
+    return 0
+  else
+    printf "  %-30s FAIL  expected %d got 0x%s\n" "$name" "$exp" "$actual"
+    return 1
+  fi
+}
+
+GWEI=$(python3 -c "print(10**9)")
+ETH=$(python3 -c "print(10**18)")
+MF50=$(python3 -c "print(50 * 10**9)")
+COST_50G_21K=$(python3 -c "print(50 * 10**9 * 21000)")
+BAL_OK=$(python3 -c "print(10**18 + 50 * 10**9 * 21000)")  # 1 ETH value + gas
+
+FAILED=0
+# All pass
+run_case "all_pass" \
+  0 1 1 21000 30000000 5 5 0 "" "$MF50" "$ETH" "$BAL_OK"  || FAILED=1
+# K76 step 1 fail (chain_id mismatch) → 101
+run_case "k76_chain_fail" \
+  101 5 1 21000 30000000 5 5 0 "" "$MF50" "$ETH" "$BAL_OK"  || FAILED=1
+# K76 step 1 fail (gas overshoot block) → 102
+run_case "k76_gas_block" \
+  102 1 1 31000000 30000000 5 5 0 "" "$MF50" 0 "$BAL_OK"  || FAILED=1
+# K76 step 1 fail (nonce mismatch) → 103
+run_case "k76_nonce" \
+  103 1 1 21000 30000000 5 6 0 "" "$MF50" "$ETH" "$BAL_OK"  || FAILED=1
+# K76 step 2 fail (intrinsic > gas) → 201
+run_case "k76_intrinsic" \
+  201 1 1 20999 30000000 5 5 0 "" "$MF50" 0 "$BAL_OK"  || FAILED=1
+# K79 step 1 fail (cost overflow) → 301
+MAX256=115792089237316195423570985008687907853269984665640564039457584007913129639935
+run_case "k79_cost_overflow" \
+  301 1 1 21000 30000000 5 5 0 "" "$MAX256" 0 "$BAL_OK"  || FAILED=1
+# K79 step 2 fail (insufficient balance) → 302
+run_case "k79_insufficient" \
+  302 1 1 21000 30000000 5 5 0 "" "$MF50" "$ETH" 0  || FAILED=1
+# K76 priority over K79 (both would fail; K76 reported first)
+run_case "k76_first_priority" \
+  101 5 1 21000 30000000 5 5 0 "" "$MF50" "$ETH" 0  || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: validate_transaction_full routes through K76 + K79"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Top-level pre-EVM tx validator composing all the cheap u64 checks with the u256-arithmetic balance check:

1. PR-K76 `validate_transaction_basic` — `chain_id` / `gas_limit` / `nonce` / `intrinsic_gas`
2. PR-K79 `validate_transaction_balance` — `balance >= max_fee × gas + value`

Mirrors the full pre-EVM portion of Python's `validate_transaction`.

## Status encoding

| Status | Meaning |
|--------|---------|
| 0 | All checks pass → ready for EVM dispatch |
| 101..103 | K76 step 1 (chain_id / gas_limit / nonce) |
| 201 | K76 step 2 (intrinsic_gas > gas_limit) |
| 301 | K79 step 1 (tx_cost overflow) |
| 302 | K79 step 2 (balance < tx_cost) |

## ABI

The three 32-byte pointers (`max_fee_per_gas`, `value`, `balance`) are passed through fixed `.data` slots (`vtf_max_fee`, `vtf_value`, `vtf_balance`) that the caller populates before invocation, since RV64 has only 8 arg regs.

Stacks on PR-K79 (#5768). Along the way renames K79's labels from `.Lvtb_*` to `.Lvtbal_*` to avoid collision with K76's `.Lvtb_*` when both are inlined into the same probe BuildUnit.

## Test plan

- [x] `lake build` clean
- [x] Both K79 and K80 test scripts pass:
  - K79: 11 fixtures
  - K80: 8 fixtures (all-pass, one failure per K76 sub-step, two K79 failures, step priority)

🤖 Generated with [Claude Code](https://claude.com/claude-code)