### PR TITLE
feat(stateless): account_refund_gas_post_exec (PR-K82)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -7374,6 +7374,41 @@ def ziskAccountChargeGasPreExecPrologue : String :=
   "  # Copy balance to OUTPUT + 8 (in-place mutation target)\n" ++
   "  li a0, 0xa0010008\n" ++
   "  addi t1, a4, 8\n" ++
+  "  ld t2,  0(t1); sd t2,  0(a0)\n" ++
+  "  ld t2,  8(t1); sd t2,  8(a0)\n" ++
+  "  ld t2, 16(t1); sd t2, 16(a0)\n" ++
+  "  ld t2, 24(t1); sd t2, 24(a0)\n" ++
+  "  # egp ptr → input region\n" ++
+  "  addi a1, a4, 40             # egp ptr at file offset 32\n" ++
+  "  ld a2, 72(a4)               # gas_limit\n" ++
+  "  # Copy nonce to OUTPUT + 40 (8 B in-out scratch)\n" ++
+  "  li a3, 0xa0010028\n" ++
+  "  ld t2, 80(a4)\n" ++
+  "  sd t2, 0(a3)\n" ++
+  "  jal ra, account_charge_gas_pre_exec\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)                # status\n" ++
+  "  j .Lacpg_pdone\n" ++
+  u256MulU64BeFunction ++ "\n" ++
+  u256SubBeFunction ++ "\n" ++
+  accountChargeGasPreExecFunction ++ "\n" ++
+  ".Lacpg_pdone:"
+
+def ziskAccountChargeGasPreExecDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "u256m_acc:\n" ++
+  "  .zero 40\n" ++
+  ".balign 32\n" ++
+  "acpg_gas_fee:\n" ++
+  "  .zero 32"
+
+def ziskAccountChargeGasPreExecProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskAccountChargeGasPreExecPrologue
+  dataAsm     := ziskAccountChargeGasPreExecDataSection
+}
+
 /-! ## account_refund_gas_post_exec -- PR-K82
 
     Apply the post-EVM gas accounting mutations per Python's
@@ -7478,23 +7513,6 @@ def ziskAccountRefundGasPostExecPrologue : String :=
   "  ld t2,  8(t1); sd t2,  8(a0)\n" ++
   "  ld t2, 16(t1); sd t2, 16(a0)\n" ++
   "  ld t2, 24(t1); sd t2, 24(a0)\n" ++
-  "  # egp ptr → input region\n" ++
-  "  addi a1, a4, 40             # egp ptr at file offset 32\n" ++
-  "  ld a2, 72(a4)               # gas_limit\n" ++
-  "  # Copy nonce to OUTPUT + 40 (8 B in-out scratch)\n" ++
-  "  li a3, 0xa0010028\n" ++
-  "  ld t2, 80(a4)\n" ++
-  "  sd t2, 0(a3)\n" ++
-  "  jal ra, account_charge_gas_pre_exec\n" ++
-  "  li t0, 0xa0010000\n" ++
-  "  sd a0, 0(t0)                # status\n" ++
-  "  j .Lacpg_pdone\n" ++
-  u256MulU64BeFunction ++ "\n" ++
-  u256SubBeFunction ++ "\n" ++
-  accountChargeGasPreExecFunction ++ "\n" ++
-  ".Lacpg_pdone:"
-
-def ziskAccountChargeGasPreExecDataSection : String :=
   "  # Copy coinbase balance to OUTPUT + 40\n" ++
   "  li a1, 0xa0010028\n" ++
   "  addi t1, a6, 40\n" ++
@@ -7521,13 +7539,6 @@ def ziskAccountRefundGasPostExecDataSection : String :=
   "u256m_acc:\n" ++
   "  .zero 40\n" ++
   ".balign 32\n" ++
-  "acpg_gas_fee:\n" ++
-  "  .zero 32"
-
-def ziskAccountChargeGasPreExecProbeUnit : BuildUnit := {
-  body        := NOP
-  prologueAsm := ziskAccountChargeGasPreExecPrologue
-  dataAsm     := ziskAccountChargeGasPreExecDataSection
   "arg_sender_refund:\n" ++
   "  .zero 32\n" ++
   ".balign 32\n" ++

--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -7283,6 +7283,148 @@ def ziskU256MulU64BeProbeUnit : BuildUnit := {
   dataAsm     := ziskU256MulU64BeDataSection
 }
 
+/-! ## account_refund_gas_post_exec -- PR-K82
+
+    Apply the post-EVM gas accounting mutations per Python's
+    `process_transaction`:
+
+      gas_refund    = remaining_gas * effective_gas_price
+      sender.balance   += gas_refund
+      priority_credit  = gas_used * priority_fee_per_gas
+      coinbase.balance += priority_credit
+
+    Where `priority_fee_per_gas = effective_gas_price - base_fee_per_gas`
+    (the pre-computed result from PR-K62
+    `priority_fee_per_gas_eip1559`).
+
+    Sister to PR-K81 `account_charge_gas_pre_exec`. Together they
+    bracket `execute_message`:
+
+      pre:  K81 → sender.balance -= max_gas_fee; sender.nonce++
+      ...   EVM run
+      post: K82 → sender.balance += gas_refund;
+                 coinbase.balance += priority_credit
+
+    Composes:
+      - PR-K54 `u256_mul_u64_be` × 2 (sender_refund + coinbase_credit)
+      - PR-K51 `u256_add_be` × 2
+
+    Calling convention:
+      a0 (input)  : sender.balance ptr (32 B u256 BE; mod in place)
+      a1 (input)  : coinbase.balance ptr (32 B u256 BE; mod in place)
+      a2 (input)  : effective_gas_price ptr (32 B u256 BE)
+      a3 (input)  : priority_fee_per_gas ptr (32 B u256 BE)
+      a4 (input)  : gas_used (u64)
+      a5 (input)  : remaining_gas (u64)
+      ra (input)  : return
+      a0 (output) :
+        0  : success — both balances updated
+        1  : mul overflow on refund or credit
+        2  : add overflow on either balance
+
+    Uses 64 bytes of `.data` scratch (`arg_sender_refund` +
+    `arg_coinbase_credit`) plus the 40-byte `u256m_acc`. -/
+def accountRefundGasPostExecFunction : String :=
+  "account_refund_gas_post_exec:\n" ++
+  "  addi sp, sp, -48\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp); sd s4, 40(sp)\n" ++
+  "  mv s0, a0                   # sender ptr\n" ++
+  "  mv s1, a1                   # coinbase ptr\n" ++
+  "  mv s2, a3                   # priority_fee ptr (saved for step 2)\n" ++
+  "  mv s3, a4                   # gas_used (saved for step 2)\n" ++
+  "  mv s4, a2                   # egp ptr (also saved; step 1 uses)\n" ++
+  "  # Step 1: sender_refund = remaining_gas × egp\n" ++
+  "  mv a0, s4\n" ++
+  "  mv a1, a5\n" ++
+  "  la a2, arg_sender_refund\n" ++
+  "  jal ra, u256_mul_u64_be\n" ++
+  "  bnez a0, .Largpe_fail_mul\n" ++
+  "  # Step 2: coinbase_credit = gas_used × priority_fee\n" ++
+  "  mv a0, s2\n" ++
+  "  mv a1, s3\n" ++
+  "  la a2, arg_coinbase_credit\n" ++
+  "  jal ra, u256_mul_u64_be\n" ++
+  "  bnez a0, .Largpe_fail_mul\n" ++
+  "  # Step 3: sender.balance += sender_refund\n" ++
+  "  mv a0, s0\n" ++
+  "  la a1, arg_sender_refund\n" ++
+  "  mv a2, s0\n" ++
+  "  jal ra, u256_add_be\n" ++
+  "  bnez a0, .Largpe_fail_add\n" ++
+  "  # Step 4: coinbase.balance += coinbase_credit\n" ++
+  "  mv a0, s1\n" ++
+  "  la a1, arg_coinbase_credit\n" ++
+  "  mv a2, s1\n" ++
+  "  jal ra, u256_add_be\n" ++
+  "  bnez a0, .Largpe_fail_add\n" ++
+  "  li a0, 0\n" ++
+  "  j .Largpe_ret\n" ++
+  ".Largpe_fail_mul:\n" ++
+  "  li a0, 1\n" ++
+  "  j .Largpe_ret\n" ++
+  ".Largpe_fail_add:\n" ++
+  "  li a0, 2\n" ++
+  ".Largpe_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp); ld s4, 40(sp)\n" ++
+  "  addi sp, sp, 48\n" ++
+  "  ret"
+
+/-- `zisk_account_refund_gas_post_exec`: probe BuildUnit. Reads
+    (32B sender_bal, 32B coinbase_bal, 32B egp, 32B priority_fee,
+    8B gas_used, 8B remaining_gas) from host input. Copies the
+    two balances to OUTPUT-resident scratch buffers, calls the
+    helper, then writes (status, new_sender, new_coinbase) to
+    OUTPUT. Total OUTPUT bytes: 8 + 32 + 32 = 72. -/
+def ziskAccountRefundGasPostExecPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a6, 0x40000000\n" ++
+  "  # Copy sender balance to OUTPUT + 8\n" ++
+  "  li a0, 0xa0010008\n" ++
+  "  addi t1, a6, 8\n" ++
+  "  ld t2,  0(t1); sd t2,  0(a0)\n" ++
+  "  ld t2,  8(t1); sd t2,  8(a0)\n" ++
+  "  ld t2, 16(t1); sd t2, 16(a0)\n" ++
+  "  ld t2, 24(t1); sd t2, 24(a0)\n" ++
+  "  # Copy coinbase balance to OUTPUT + 40\n" ++
+  "  li a1, 0xa0010028\n" ++
+  "  addi t1, a6, 40\n" ++
+  "  ld t2,  0(t1); sd t2,  0(a1)\n" ++
+  "  ld t2,  8(t1); sd t2,  8(a1)\n" ++
+  "  ld t2, 16(t1); sd t2, 16(a1)\n" ++
+  "  ld t2, 24(t1); sd t2, 24(a1)\n" ++
+  "  addi a2, a6, 72             # egp ptr\n" ++
+  "  addi a3, a6, 104            # priority_fee ptr\n" ++
+  "  ld a4, 136(a6)              # gas_used\n" ++
+  "  ld a5, 144(a6)              # remaining_gas\n" ++
+  "  jal ra, account_refund_gas_post_exec\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)                # status\n" ++
+  "  j .Largpe_pdone\n" ++
+  u256MulU64BeFunction ++ "\n" ++
+  u256AddBeFunction ++ "\n" ++
+  accountRefundGasPostExecFunction ++ "\n" ++
+  ".Largpe_pdone:"
+
+def ziskAccountRefundGasPostExecDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "u256m_acc:\n" ++
+  "  .zero 40\n" ++
+  ".balign 32\n" ++
+  "arg_sender_refund:\n" ++
+  "  .zero 32\n" ++
+  ".balign 32\n" ++
+  "arg_coinbase_credit:\n" ++
+  "  .zero 32"
+
+def ziskAccountRefundGasPostExecProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskAccountRefundGasPostExecPrologue
+  dataAsm     := ziskAccountRefundGasPostExecDataSection
+}
+
 /-! ## eip1559_calc_base_fee_per_gas -- PR-K73
 
     Full EIP-1559 base-fee formula. Mirrors Python's
@@ -11167,6 +11309,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_u256_sub_be"          => some ziskU256SubBeProbeUnit
   | "zisk_u256_eq"              => some ziskU256EqProbeUnit
   | "zisk_u256_mul_u64_be"      => some ziskU256MulU64BeProbeUnit
+  | "zisk_account_refund_gas_post_exec" => some ziskAccountRefundGasPostExecProbeUnit
   | "zisk_eip1559_calc_base_fee_per_gas" => some ziskEip1559CalcBaseFeePerGasProbeUnit
   | "zisk_header_validate_base_fee" => some ziskHeaderValidateBaseFeeProbeUnit
   | "zisk_validate_header_full" => some ziskValidateHeaderFullProbeUnit
@@ -11261,6 +11404,7 @@ def knownProgramNames : List String :=
    "zisk_u256_sub_be",
    "zisk_u256_eq",
    "zisk_u256_mul_u64_be",
+   "zisk_account_refund_gas_post_exec",
    "zisk_eip1559_calc_base_fee_per_gas",
    "zisk_header_validate_base_fee",
    "zisk_validate_header_full",

--- a/scripts/codegen-zisk-account-refund-gas-post-exec-check.sh
+++ b/scripts/codegen-zisk-account-refund-gas-post-exec-check.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# codegen-zisk-account-refund-gas-post-exec-check.sh -- PR-K82.
+#
+# Post-EVM gas accounting: refund sender + credit coinbase.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_account_refund_gas_post_exec ELF"
+lake exe codegen --program zisk_account_refund_gas_post_exec --halt linux93 \
+  -o gen-out/zisk_account_refund_gas_post_exec
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <sender_bal> <coinbase_bal> <egp> <priority_fee> <gas_used> <remaining_gas>
+run_case() {
+  local name="$1" sb="$2" cb="$3" egp="$4" pf="$5" gu="$6" rg="$7"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_account_refund_gas_post_exec_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_account_refund_gas_post_exec_${name}.output"
+  local exp_file="$REPO_ROOT/gen-out/zisk_account_refund_gas_post_exec_${name}.expected"
+
+  python3 -c "
+import struct, sys
+sb, cb, egp, pf, gu, rg = $sb, $cb, $egp, $pf, $gu, $rg
+with open(sys.argv[1], 'wb') as f:
+    f.write(sb.to_bytes(32, 'big'))
+    f.write(cb.to_bytes(32, 'big'))
+    f.write(egp.to_bytes(32, 'big'))
+    f.write(pf.to_bytes(32, 'big'))
+    f.write(struct.pack('<Q', gu))
+    f.write(struct.pack('<Q', rg))
+
+MOD = 1 << 256
+refund = (egp * rg)
+credit = (pf * gu)
+mul_of = (refund >= MOD) or (credit >= MOD)
+refund %= MOD
+credit %= MOD
+new_sb = sb + refund
+new_cb = cb + credit
+add_of = (new_sb >= MOD) or (new_cb >= MOD)
+new_sb %= MOD
+new_cb %= MOD
+
+if mul_of:
+    status = 1
+    new_sb, new_cb = sb, cb
+elif add_of:
+    status = 2
+    new_sb, new_cb = sb, cb  # rollback semantics; asm doesn't actually rollback, but expected matches what asm reports
+else:
+    status = 0
+
+with open(sys.argv[2], 'wb') as f:
+    f.write(struct.pack('<Q', status))
+    f.write(new_sb.to_bytes(32, 'big'))
+    f.write(new_cb.to_bytes(32, 'big'))
+" "$in_file" "$exp_file"
+
+  "$ZISKEMU" -e gen-out/zisk_account_refund_gas_post_exec.elf \
+    -i "$in_file" -o "$out_file" -n 500000 \
+    >"$REPO_ROOT/gen-out/zisk_account_refund_gas_post_exec_${name}.emu.log" 2>&1 || true
+
+  # On non-success paths the asm may have partially updated state; we
+  # only enforce that the STATUS matches. On success we enforce full
+  # 72-byte equivalence.
+  local exp_status; exp_status="$(python3 -c "
+MOD = 1 << 256
+refund = ($egp * $rg)
+credit = ($pf * $gu)
+if (refund >= MOD) or (credit >= MOD): print(1)
+elif (($sb + refund % MOD) >= MOD) or (($cb + credit % MOD) >= MOD): print(2)
+else: print(0)
+")"
+  local actual_status; actual_status="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local exp_status_le; exp_status_le="$(python3 -c "print(int('$exp_status').to_bytes(8, 'little').hex())")"
+
+  if [[ "$actual_status" != "$exp_status_le" ]]; then
+    printf "  %-30s FAIL  status expected %d got 0x%s\n" "$name" "$exp_status" "$actual_status"
+    return 1
+  fi
+
+  if [[ "$exp_status" == "0" ]]; then
+    local actual; actual="$(xxd -p -l 72 "$out_file" | tr -d '\n')"
+    local expected; expected="$(xxd -p -l 72 "$exp_file" | tr -d '\n')"
+    if [[ "$actual" != "$expected" ]]; then
+      printf "  %-30s FAIL on balance comparison\n" "$name"
+      return 1
+    fi
+  fi
+
+  local refund credit
+  refund="$(python3 -c "print($egp * $rg % (1<<256))")"
+  credit="$(python3 -c "print($pf * $gu % (1<<256))")"
+  printf "  %-30s OK   status=%d refund=%s credit=%s\n" "$name" "$exp_status" "${refund:0:18}" "${credit:0:18}"
+  return 0
+}
+
+GWEI=$(python3 -c "print(10**9)")
+ETH=$(python3 -c "print(10**18)")
+MAX256=115792089237316195423570985008687907853269984665640564039457584007913129639935
+
+FAILED=0
+# Typical: 1 ETH sender, 100 wei coinbase, 50 gwei egp, 3 gwei priority fee
+# tx used 21000 gas, remaining 0 (full burn)
+run_case "typical_full_burn" \
+  $(python3 -c "print(10**18 - 50 * 10**9 * 21000)") 100 \
+  $(python3 -c "print(50 * $GWEI)") $(python3 -c "print(3 * $GWEI)") 21000 0 \
+  || FAILED=1
+
+# Mainnet: sender keeps some refund, coinbase gets priority
+run_case "with_refund" \
+  $(python3 -c "print(10**18 - 50 * 10**9 * 100000)") 1000 \
+  $(python3 -c "print(50 * $GWEI)") $(python3 -c "print(2 * $GWEI)") 50000 50000 \
+  || FAILED=1
+
+# Free tx: zero priority fee → no coinbase credit
+run_case "zero_priority_fee" \
+  $(python3 -c "print(10**18 - 50 * 10**9 * 21000)") "$ETH" \
+  $(python3 -c "print(50 * $GWEI)") 0 21000 0 \
+  || FAILED=1
+
+# Zero gas_used + zero remaining (no execution) → identity
+run_case "no_gas_used_no_remain" \
+  "$ETH" "$ETH" "$GWEI" "$GWEI" 0 0 \
+  || FAILED=1
+
+# All remaining: refund full, coinbase zero
+run_case "all_remaining" \
+  0 0 "$GWEI" "$GWEI" 0 100000 \
+  || FAILED=1
+
+# All used: no refund, coinbase gets priority × full gas
+run_case "all_used" \
+  0 0 "$GWEI" "$GWEI" 100000 0 \
+  || FAILED=1
+
+# Holesky-realistic shape
+run_case "holesky" \
+  $(python3 -c "print(10**18)") 0 \
+  $(python3 -c "print(10 * $GWEI)") $(python3 -c "print(2 * $GWEI)") 50000 50000 \
+  || FAILED=1
+
+# Mul overflow: max egp × big remaining
+run_case "mul_overflow" \
+  0 0 "$MAX256" 0 0 2 \
+  || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: account_refund_gas_post_exec credits sender + coinbase correctly"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Apply the post-EVM gas accounting mutations per Python's `process_transaction`:

```
gas_refund      = remaining_gas * effective_gas_price
sender.balance  += gas_refund
priority_credit  = gas_used * priority_fee_per_gas
coinbase.balance += priority_credit
```

Where `priority_fee_per_gas = effective_gas_price - base_fee_per_gas` (pre-computed via PR-K62 `priority_fee_per_gas_eip1559`).

## Sister to PR-K81

Together they bracket `execute_message`:

```
pre:  K81 → sender.balance -= max_gas_fee; sender.nonce++
...   EVM run
post: K82 → sender.balance += gas_refund;
            coinbase.balance += priority_credit
```

## Composition

- PR-K54 `u256_mul_u64_be` × 2 (sender_refund + coinbase_credit)
- PR-K51 `u256_add_be` × 2 (apply each)

## Test plan

- [x] `lake build` clean
- [x] `scripts/codegen-zisk-account-refund-gas-post-exec-check.sh` passes 8 fixtures:
  - Typical full burn
  - With refund (50% gas remaining)
  - Zero priority fee (free tx → no coinbase credit)
  - Zero gas used + remaining (no execution)
  - All remaining (full refund, no coinbase credit)
  - All used (no refund, all goes to coinbase priority)
  - Realistic Holesky shape
  - Mul overflow safety net

🤖 Generated with [Claude Code](https://claude.com/claude-code)