### PR TITLE
feat(stateless): block_body_decode (PR-K83)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -9472,6 +9472,117 @@ def ziskWithdrawalDecodeProbeUnit : BuildUnit := {
   dataAsm     := ziskWithdrawalDecodeDataSection
 }
 
+/-! ## block_body_decode -- PR-K83
+
+    Decode a post-Shanghai block body RLP into three sub-list
+    (offset, length) pairs. The body is `rlp([transactions,
+    ommers, withdrawals])`:
+
+      Field 0: transactions   (list of typed tx envelopes)
+      Field 1: ommers         (empty list post-merge: 0xc0)
+      Field 2: withdrawals    (Shanghai+: list of [index, vi,
+                              address, amount])
+
+    Output struct layout (48 bytes):
+
+         0..  8  transactions_offset (u64; within body_rlp)
+         8.. 16  transactions_length (u64; full encoded sub-list)
+        16.. 24  ommers_offset       (u64)
+        24.. 32  ommers_length       (u64)
+        32.. 40  withdrawals_offset  (u64)
+        40.. 48  withdrawals_length  (u64)
+
+    Composes PR-K20 `rlp_list_nth_item` three times. The
+    (offset, length) of each sub-list is the FULL encoded item
+    (including its own RLP list prefix), per K20's list-item
+    contract — so callers can recurse into each with another
+    `rlp_list_nth_item` call.
+
+    For pre-Shanghai bodies (only 2 fields), this helper fails
+    on the third call. Such bodies aren't relevant for the
+    amsterdam stateless guest.
+
+    Calling convention:
+      a0 (input)  : body_rlp ptr
+      a1 (input)  : body_rlp byte length
+      a2 (input)  : 48-byte output struct ptr
+      ra (input)  : return
+      a0 (output) : 0 success / 1 parse fail (not a 3-item list).
+
+    Pure composition of PR-K20. No new `.data` scratch beyond
+    what K20 needs (none). -/
+def blockBodyDecodeFunction : String :=
+  "block_body_decode:\n" ++
+  "  addi sp, sp, -32\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp)\n" ++
+  "  mv s0, a0                   # body_rlp ptr\n" ++
+  "  mv s1, a1                   # body_len\n" ++
+  "  mv s2, a2                   # output struct ptr\n" ++
+  "  # Field 0: transactions\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 0\n" ++
+  "  mv a3, s2\n" ++
+  "  addi a4, s2, 8\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lbbd_fail\n" ++
+  "  # Field 1: ommers\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 1\n" ++
+  "  addi a3, s2, 16\n" ++
+  "  addi a4, s2, 24\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lbbd_fail\n" ++
+  "  # Field 2: withdrawals\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 2\n" ++
+  "  addi a3, s2, 32\n" ++
+  "  addi a4, s2, 40\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lbbd_fail\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lbbd_ret\n" ++
+  ".Lbbd_fail:\n" ++
+  "  li a0, 1\n" ++
+  ".Lbbd_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp)\n" ++
+  "  addi sp, sp, 32\n" ++
+  "  ret"
+
+/-- `zisk_block_body_decode`: probe BuildUnit. Reads (body_len,
+    body_bytes) from host input, writes (status, 48-byte struct)
+    to OUTPUT (56 bytes total). -/
+def ziskBlockBodyDecodePrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a3, 0x40000000\n" ++
+  "  ld a1, 8(a3)                # body_len\n" ++
+  "  addi a0, a3, 16             # body ptr\n" ++
+  "  li a2, 0xa0010008           # struct at OUTPUT + 8\n" ++
+  "  mv t0, a2; li t1, 6\n" ++
+  ".Lbbd_zinit:\n" ++
+  "  beqz t1, .Lbbd_zdone\n" ++
+  "  sd zero, 0(t0)\n" ++
+  "  addi t0, t0, 8\n" ++
+  "  addi t1, t1, -1\n" ++
+  "  j .Lbbd_zinit\n" ++
+  ".Lbbd_zdone:\n" ++
+  "  jal ra, block_body_decode\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)                # status\n" ++
+  "  j .Lbbd_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  blockBodyDecodeFunction ++ "\n" ++
+  ".Lbbd_pdone:"
+
+def ziskBlockBodyDecodeDataSection : String :=
+  ".section .data\n" ++
+  "bbd_pad:\n" ++
+  "  .zero 8"
+
+def ziskBlockBodyDecodeProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskBlockBodyDecodePrologue
+  dataAsm     := ziskBlockBodyDecodeDataSection
+}
+
 /-! ## process_withdrawal -- PR-K77
 
     Apply a Shanghai+ Withdrawal credit to a recipient's account
@@ -11189,6 +11300,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_validate_transaction_basic" => some ziskValidateTransactionBasicProbeUnit
   | "zisk_validate_transaction_full" => some ziskValidateTransactionFullProbeUnit
   | "zisk_withdrawal_decode"    => some ziskWithdrawalDecodeProbeUnit
+  | "zisk_block_body_decode"    => some ziskBlockBodyDecodeProbeUnit
   | "zisk_process_withdrawal"   => some ziskProcessWithdrawalProbeUnit
   | "zisk_process_withdrawals_block" => some ziskProcessWithdrawalsBlockProbeUnit
   | "zisk_withdrawals_sum_amounts" => some ziskWithdrawalsSumAmountsProbeUnit
@@ -11283,6 +11395,7 @@ def knownProgramNames : List String :=
    "zisk_validate_transaction_basic",
    "zisk_validate_transaction_full",
    "zisk_withdrawal_decode",
+   "zisk_block_body_decode",
    "zisk_process_withdrawal",
    "zisk_process_withdrawals_block",
    "zisk_withdrawals_sum_amounts",

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **105**
-- ziskemu round-trip scripts: **98** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **106**
+- ziskemu round-trip scripts: **99** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-block-body-decode-check.sh
+++ b/scripts/codegen-zisk-block-body-decode-check.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# codegen-zisk-block-body-decode-check.sh -- PR-K83.
+#
+# Decode a post-Shanghai block body into three (offset, length)
+# pairs for txs, ommers, withdrawals.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_block_body_decode ELF"
+lake exe codegen --program zisk_block_body_decode --halt linux93 \
+  -o gen-out/zisk_block_body_decode
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <txs_json> <ommers_json> <withdrawals_json>
+run_case() {
+  local name="$1" txs="$2" ommers="$3" wds="$4"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_block_body_decode_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_block_body_decode_${name}.output"
+  local exp_file="$REPO_ROOT/gen-out/zisk_block_body_decode_${name}.expected"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import json, struct, sys
+import rlp
+
+txs_raw     = json.loads('''$txs''')
+ommers_raw  = json.loads('''$ommers''')
+wds_raw     = json.loads('''$wds''')
+
+# Convert hex strings → bytes; lists recurse.
+def conv(x):
+    if isinstance(x, str):
+        return bytes.fromhex(x)
+    if isinstance(x, list):
+        return [conv(e) for e in x]
+    return x
+
+txs    = conv(txs_raw)
+ommers = conv(ommers_raw)
+wds    = []
+for w in wds_raw:
+    idx, vi, addr_hex, amt = w
+    wds.append([idx, vi, bytes.fromhex(addr_hex), amt])
+
+body_rlp = rlp.encode([txs, ommers, wds])
+with open(sys.argv[1], 'wb') as f:
+    f.write(struct.pack('<Q', len(body_rlp)))
+    f.write(body_rlp)
+    pad = (-(8 + len(body_rlp))) % 8
+    if pad:
+        f.write(b'\x00' * pad)
+
+# Expected struct: (txs_off, txs_len, ommers_off, ommers_len, wd_off, wd_len)
+def field_offset(items, idx):
+    payload = b''.join(rlp.encode(it) for it in items)
+    if len(payload) < 56:
+        prefix_len = 1
+    else:
+        length_bits = (len(payload).bit_length() + 7) // 8
+        prefix_len = 1 + length_bits
+    offset = prefix_len
+    for i in range(idx):
+        offset += len(rlp.encode(items[i]))
+    item_rlp = rlp.encode(items[idx])
+    if len(item_rlp) == 1 and item_rlp[0] < 0x80:
+        return offset, 1
+    elif item_rlp[0] < 0xb8:
+        return offset + 1, item_rlp[0] - 0x80
+    elif item_rlp[0] < 0xc0:
+        lol = item_rlp[0] - 0xb7
+        return (offset + 1 + lol,
+                int.from_bytes(item_rlp[1:1+lol], 'big'))
+    else:
+        return offset, len(item_rlp)
+
+items = [txs, ommers, wds]
+exp = struct.pack('<Q', 0)  # status
+for i in range(3):
+    o, l = field_offset(items, i)
+    exp += struct.pack('<Q', o)
+    exp += struct.pack('<Q', l)
+
+with open(sys.argv[2], 'wb') as f:
+    f.write(exp)
+" "$in_file" "$exp_file"
+
+  "$ZISKEMU" -e gen-out/zisk_block_body_decode.elf \
+    -i "$in_file" -o "$out_file" -n 500000 \
+    >"$REPO_ROOT/gen-out/zisk_block_body_decode_${name}.emu.log" 2>&1 || true
+
+  local actual; actual="$(xxd -p -l 56 "$out_file" | tr -d '\n')"
+  local expected; expected="$(xxd -p -l 56 "$exp_file" | tr -d '\n')"
+
+  if [[ "$actual" == "$expected" ]]; then
+    printf "  %-30s OK\n" "$name"
+    return 0
+  else
+    printf "  %-30s FAIL\n    expected: %s\n    actual:   %s\n" "$name" "$expected" "$actual"
+    return 1
+  fi
+}
+
+ALICE="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+FAILED=0
+# Empty block: 0 txs, 0 ommers, 0 withdrawals
+run_case "empty_block" "[]" "[]" "[]"  || FAILED=1
+
+# Withdrawals only
+run_case "withdrawals_only" "[]" "[]" "[[0, 1, \"$ALICE\", 1000000000]]"  || FAILED=1
+
+# Transactions only (txs as raw bytes — typed-tx envelopes)
+TX_LEGACY="f8650184ee6b280082520894aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa881bc16d674ec80000801ba01111111111111111111111111111111111111111111111111111111111111111a02222222222222222222222222222222222222222222222222222222222222222"
+run_case "one_legacy_tx" "[\"$TX_LEGACY\"]" "[]" "[]"  || FAILED=1
+
+# Mainnet shape: 2 txs, 0 ommers, 1 withdrawal
+run_case "mixed_block" \
+  "[\"$TX_LEGACY\", \"$TX_LEGACY\"]" "[]" \
+  "[[100, 12345, \"$ALICE\", 32000000000]]"  || FAILED=1
+
+# Many withdrawals
+SIX_WDS="$(python3 -c "
+import json
+addr = '$ALICE'
+ws = [[i, i+1000, addr, (i+1) * 10**9] for i in range(6)]
+print(json.dumps(ws))
+")"
+run_case "six_withdrawals" "[]" "[]" "$SIX_WDS"  || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: block_body_decode returns 3 (offset, length) pairs"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Decode a post-Shanghai block body RLP into three `(offset, length)` pairs for the txs, ommers, and withdrawals sub-lists:

```
body = rlp([transactions, ommers, withdrawals])
```

Output struct (48 bytes):

| Offset | Field |
|--------|-------|
| 0..8 | transactions_offset |
| 8..16 | transactions_length |
| 16..24 | ommers_offset |
| 24..32 | ommers_length |
| 32..40 | withdrawals_offset |
| 40..48 | withdrawals_length |

The `(offset, length)` per K20's contract is the FULL encoded sub-list (including its own RLP prefix), so callers can recurse into each with another `rlp_list_nth_item` call.

Pure composition of PR-K20 (three calls). No new `.data` scratch.

For pre-Shanghai bodies (only 2 fields), this helper fails on the third call. Such bodies aren't relevant for the amsterdam stateless guest.

## Test plan

- [x] `lake build` clean
- [x] `scripts/codegen-zisk-block-body-decode-check.sh` passes 5 fixtures:
  - Empty block
  - Withdrawals-only
  - `one_legacy_tx`
  - `mixed_block` (2 txs + 1 withdrawal)
  - `six_withdrawals`

🤖 Generated with [Claude Code](https://claude.com/claude-code)