### PR TITLE
feat(divmod): add call addback semantic iff

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/CallAddback.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/CallAddback.lean
@@ -1130,10 +1130,48 @@ theorem n4CallAddbackBeqSemanticHoldsV4_direct {a b : EvmWord}
       if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
       else qHat + signExtend12 4095
     qOut.toNat =
-      val256 (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3) /
-        val256 (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) := by
+        val256 (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3) /
+          val256 (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) := by
   rw [n4CallAddbackBeqSemanticHoldsV4_eq_direct hshift_nz] at hsem
   exact hsem
+
+theorem n4CallAddbackBeqSemanticHoldsV4_direct_iff {a b : EvmWord}
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0) :
+    n4CallAddbackBeqSemanticHoldsV4 a b ↔
+      (let b3' :=
+        ((b.getLimbN 3) <<< (clzResult (b.getLimbN 3)).1.toNat) |||
+          ((b.getLimbN 2) >>> (64 - (clzResult (b.getLimbN 3)).1.toNat))
+       let b2' :=
+        ((b.getLimbN 2) <<< (clzResult (b.getLimbN 3)).1.toNat) |||
+          ((b.getLimbN 1) >>> (64 - (clzResult (b.getLimbN 3)).1.toNat))
+       let b1' :=
+        ((b.getLimbN 1) <<< (clzResult (b.getLimbN 3)).1.toNat) |||
+          ((b.getLimbN 0) >>> (64 - (clzResult (b.getLimbN 3)).1.toNat))
+       let b0' := (b.getLimbN 0) <<< (clzResult (b.getLimbN 3)).1.toNat
+       let u3 :=
+        ((a.getLimbN 3) <<< (clzResult (b.getLimbN 3)).1.toNat) |||
+          ((a.getLimbN 2) >>> (64 - (clzResult (b.getLimbN 3)).1.toNat))
+       let u2 :=
+        ((a.getLimbN 2) <<< (clzResult (b.getLimbN 3)).1.toNat) |||
+          ((a.getLimbN 1) >>> (64 - (clzResult (b.getLimbN 3)).1.toNat))
+       let u1 :=
+        ((a.getLimbN 1) <<< (clzResult (b.getLimbN 3)).1.toNat) |||
+          ((a.getLimbN 0) >>> (64 - (clzResult (b.getLimbN 3)).1.toNat))
+       let u0 := (a.getLimbN 0) <<< (clzResult (b.getLimbN 3)).1.toNat
+       let qHat :=
+        div128Quot_v4
+          ((a.getLimbN 3) >>> (64 - (clzResult (b.getLimbN 3)).1.toNat))
+          u3
+          b3'
+       let ms := mulsubN4 qHat b0' b1' b2' b3' u0 u1 u2 u3
+       let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 b0' b1' b2' b3'
+       let qOut : Word :=
+        if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
+        else qHat + signExtend12 4095
+       qOut.toNat =
+        val256 (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3) /
+          val256 (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)) := by
+  rw [n4CallAddbackBeqSemanticHoldsV4_eq_direct hshift_nz]
 
 theorem n4CallAddbackBeqSemanticHoldsV4_qOutV4_eq {a b : EvmWord} :
     n4CallAddbackBeqSemanticHoldsV4 a b =


### PR DESCRIPTION
## Summary
- add n4CallAddbackBeqSemanticHoldsV4_direct_iff
- complete the direct semantic helper surface with an iff form under shift != 0
- keep the runtime proof target rewriteable without manually expanding qOut/qHat/carry

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.CallAddback
- lake build EvmAsm.Evm64.DivMod
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- forbidden scan on EvmAsm/Evm64/DivMod/Spec/CallAddback.lean (no matches)