### PR TITLE
feat(stateless): block_validate_ommers_empty (PR-K84)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -9583,6 +9583,91 @@ def ziskBlockBodyDecodeProbeUnit : BuildUnit := {
   dataAsm     := ziskBlockBodyDecodeDataSection
 }
 
+/-! ## block_validate_ommers_empty -- PR-K84
+
+    Verify the post-merge invariant that a block body's ommers
+    field is the empty RLP list (`0xc0`). The Merge fork removed
+    uncle blocks; every post-merge block must have an empty
+    ommers list, matching `EMPTY_OMMERS_HASH` in the header.
+
+    Composes PR-K83 `block_body_decode` + a single-byte check
+    on the ommers sub-list.
+
+    An empty RLP list is encoded as the single byte `0xc0`. So
+    the check is:
+      - ommers_length == 1
+      - body_rlp[ommers_offset] == 0xc0
+
+    Calling convention:
+      a0 (input)  : block_body_rlp ptr
+      a1 (input)  : block_body_rlp byte length
+      ra (input)  : return
+      a0 (output) :
+        0 : ommers is empty (post-merge ok)
+        1 : ommers is non-empty (reject — pre-merge or invalid)
+        2 : RLP parse failure
+
+    Uses 48 bytes of `.data` scratch (`bvoe_struct`). -/
+def blockValidateOmmersEmptyFunction : String :=
+  "block_validate_ommers_empty:\n" ++
+  "  addi sp, sp, -16\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp)\n" ++
+  "  mv s0, a0                   # body_rlp ptr\n" ++
+  "  la a2, bvoe_struct\n" ++
+  "  jal ra, block_body_decode\n" ++
+  "  bnez a0, .Lbvoe_parse_fail\n" ++
+  "  la t0, bvoe_struct\n" ++
+  "  ld t1, 24(t0)               # ommers_length\n" ++
+  "  li t2, 1\n" ++
+  "  bne t1, t2, .Lbvoe_not_empty\n" ++
+  "  ld t3, 16(t0)               # ommers_offset\n" ++
+  "  add t3, s0, t3\n" ++
+  "  lbu t4, 0(t3)\n" ++
+  "  li t5, 0xc0\n" ++
+  "  bne t4, t5, .Lbvoe_not_empty\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lbvoe_ret\n" ++
+  ".Lbvoe_not_empty:\n" ++
+  "  li a0, 1\n" ++
+  "  j .Lbvoe_ret\n" ++
+  ".Lbvoe_parse_fail:\n" ++
+  "  li a0, 2\n" ++
+  ".Lbvoe_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp)\n" ++
+  "  addi sp, sp, 16\n" ++
+  "  ret"
+
+/-- `zisk_block_validate_ommers_empty`: probe BuildUnit. Reads
+    (body_len, body_bytes) from host input, writes 8-byte status
+    to OUTPUT. -/
+def ziskBlockValidateOmmersEmptyPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a3, 0x40000000\n" ++
+  "  ld a1, 8(a3)                # body_len\n" ++
+  "  addi a0, a3, 16             # body ptr\n" ++
+  "  jal ra, block_validate_ommers_empty\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lbvoe_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  blockBodyDecodeFunction ++ "\n" ++
+  blockValidateOmmersEmptyFunction ++ "\n" ++
+  ".Lbvoe_pdone:"
+
+def ziskBlockValidateOmmersEmptyDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "bvoe_struct:\n" ++
+  "  .zero 48"
+
+def ziskBlockValidateOmmersEmptyProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskBlockValidateOmmersEmptyPrologue
+  dataAsm     := ziskBlockValidateOmmersEmptyDataSection
+}
+
 /-! ## process_withdrawal -- PR-K77
 
     Apply a Shanghai+ Withdrawal credit to a recipient's account
@@ -11301,6 +11386,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_validate_transaction_full" => some ziskValidateTransactionFullProbeUnit
   | "zisk_withdrawal_decode"    => some ziskWithdrawalDecodeProbeUnit
   | "zisk_block_body_decode"    => some ziskBlockBodyDecodeProbeUnit
+  | "zisk_block_validate_ommers_empty" => some ziskBlockValidateOmmersEmptyProbeUnit
   | "zisk_process_withdrawal"   => some ziskProcessWithdrawalProbeUnit
   | "zisk_process_withdrawals_block" => some ziskProcessWithdrawalsBlockProbeUnit
   | "zisk_withdrawals_sum_amounts" => some ziskWithdrawalsSumAmountsProbeUnit
@@ -11396,6 +11482,7 @@ def knownProgramNames : List String :=
    "zisk_validate_transaction_full",
    "zisk_withdrawal_decode",
    "zisk_block_body_decode",
+   "zisk_block_validate_ommers_empty",
    "zisk_process_withdrawal",
    "zisk_process_withdrawals_block",
    "zisk_withdrawals_sum_amounts",

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **106**
-- ziskemu round-trip scripts: **99** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **107**
+- ziskemu round-trip scripts: **100** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-block-validate-ommers-empty-check.sh
+++ b/scripts/codegen-zisk-block-validate-ommers-empty-check.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# codegen-zisk-block-validate-ommers-empty-check.sh -- PR-K84.
+#
+# Verify post-merge invariant: block.body.ommers == [] (= 0xc0).
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_block_validate_ommers_empty ELF"
+lake exe codegen --program zisk_block_validate_ommers_empty --halt linux93 \
+  -o gen-out/zisk_block_validate_ommers_empty
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <expected_status> <ommers_json>
+run_case() {
+  local name="$1" expected_status="$2" ommers="$3"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_block_validate_ommers_empty_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_block_validate_ommers_empty_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import json, struct, sys
+import rlp
+
+ommers_raw = json.loads('''$ommers''')
+# Convert hex strings → bytes; nested lists recurse.
+def conv(x):
+    if isinstance(x, str):
+        return bytes.fromhex(x)
+    if isinstance(x, list):
+        return [conv(e) for e in x]
+    return x
+
+# Build block body: [txs (empty), ommers (variable), wds (empty)]
+body = [[], conv(ommers_raw), []]
+body_rlp = rlp.encode(body)
+with open(sys.argv[1], 'wb') as f:
+    f.write(struct.pack('<Q', len(body_rlp)))
+    f.write(body_rlp)
+    pad = (-(8 + len(body_rlp))) % 8
+    if pad:
+        f.write(b'\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_block_validate_ommers_empty.elf \
+    -i "$in_file" -o "$out_file" -n 500000 \
+    >"$REPO_ROOT/gen-out/zisk_block_validate_ommers_empty_${name}.emu.log" 2>&1 || true
+
+  local actual; actual="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local exp_le; exp_le="$(python3 -c "print(int('$expected_status').to_bytes(8, 'little').hex())")"
+
+  if [[ "$actual" == "$exp_le" ]]; then
+    printf "  %-30s OK   status=%d\n" "$name" "$expected_status"
+    return 0
+  else
+    printf "  %-30s FAIL  expected status=%d got 0x%s\n" "$name" "$expected_status" "$actual"
+    return 1
+  fi
+}
+
+# A minimal "uncle" — just a stub list of empty fields. Not RLP-valid
+# as a full header, but valid as an RLP item.
+FAKE_OMMER='[]'
+
+FAILED=0
+# Post-merge canonical: empty ommers
+run_case "empty_ommers"      0 "[]"                       || FAILED=1
+
+# Single uncle (pre-merge) → reject
+run_case "one_uncle"         1 "[$FAKE_OMMER]"            || FAILED=1
+
+# Two uncles → reject
+run_case "two_uncles"        1 "[$FAKE_OMMER, $FAKE_OMMER]" || FAILED=1
+
+# Non-list body → parse fail
+NON_LIST_FILE="$REPO_ROOT/gen-out/zisk_block_validate_ommers_empty_non_list.input"
+python3 -c "
+import struct, sys
+b = bytes([0x80])
+with open(sys.argv[1], 'wb') as f:
+    f.write(struct.pack('<Q', len(b)))
+    f.write(b)
+    f.write(b'\x00' * 7)
+" "$NON_LIST_FILE"
+"$ZISKEMU" -e gen-out/zisk_block_validate_ommers_empty.elf \
+  -i "$NON_LIST_FILE" -o "$REPO_ROOT/gen-out/zisk_block_validate_ommers_empty_non_list.output" \
+  -n 500000 >"$REPO_ROOT/gen-out/zisk_block_validate_ommers_empty_non_list.emu.log" 2>&1 || true
+NL_STATUS="$(xxd -p -l 8 "$REPO_ROOT/gen-out/zisk_block_validate_ommers_empty_non_list.output" | tr -d '\n')"
+if [[ "$NL_STATUS" == "0200000000000000" ]]; then
+  printf "  %-30s OK   status=2 (parse fail)\n" "non_list_parse_fail"
+else
+  printf "  %-30s FAIL  status=0x%s\n" "non_list_parse_fail" "$NL_STATUS"
+  FAILED=1
+fi
+
+# 2-field body (missing withdrawals) — parse fail on field 2 lookup
+TWO_FIELD_FILE="$REPO_ROOT/gen-out/zisk_block_validate_ommers_empty_two_field.input"
+uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+body = [[], []]
+body_rlp = rlp.encode(body)
+with open(sys.argv[1], 'wb') as f:
+    f.write(struct.pack('<Q', len(body_rlp)))
+    f.write(body_rlp)
+    pad = (-(8 + len(body_rlp))) % 8
+    if pad:
+        f.write(b'\x00' * pad)
+" "$TWO_FIELD_FILE"
+"$ZISKEMU" -e gen-out/zisk_block_validate_ommers_empty.elf \
+  -i "$TWO_FIELD_FILE" -o "$REPO_ROOT/gen-out/zisk_block_validate_ommers_empty_two_field.output" \
+  -n 500000 >"$REPO_ROOT/gen-out/zisk_block_validate_ommers_empty_two_field.emu.log" 2>&1 || true
+TF_STATUS="$(xxd -p -l 8 "$REPO_ROOT/gen-out/zisk_block_validate_ommers_empty_two_field.output" | tr -d '\n')"
+if [[ "$TF_STATUS" == "0200000000000000" ]]; then
+  printf "  %-30s OK   status=2 (no withdrawals → parse fail)\n" "two_field_pre_shanghai"
+else
+  printf "  %-30s FAIL  status=0x%s\n" "two_field_pre_shanghai" "$TF_STATUS"
+  FAILED=1
+fi
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: block_validate_ommers_empty enforces post-merge empty-ommers invariant"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Verify the post-merge invariant that a block body's ommers field is the empty RLP list (`0xc0`). The Merge fork removed uncle blocks; every post-merge block must have an empty ommers list, matching `EMPTY_OMMERS_HASH` in the header.

## Composition

- PR-K83 `block_body_decode` (#5802) — splits body into 3 (offset, length) pairs
- Single-byte check on the ommers sub-list:
  - `ommers_length == 1` AND
  - `body_rlp[ommers_offset] == 0xc0`

Stacks on PR-K83 (#5802).

## Return codes

| `a0` | Meaning |
|------|---------|
| 0 | Ommers is empty (post-merge ok) |
| 1 | Ommers is non-empty (pre-merge or invalid) |
| 2 | RLP parse failure |

## Test plan

- [x] `lake build` clean
- [x] `scripts/codegen-zisk-block-validate-ommers-empty-check.sh` passes 5 fixtures:
  - Empty ommers (pass)
  - 1 uncle (reject)
  - 2 uncles (reject)
  - Non-list parse fail
  - Pre-Shanghai 2-field body parse fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)