### PR TITLE
feat(divmod): bridge call addback carry2 runtime

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/CallAddbackRuntime.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/CallAddbackRuntime.lean
@@ -117,6 +117,21 @@ theorem n4CallAddbackBeqCarry2Nz_of_runtime {a b : EvmWord}
     n4CallAddbackBeqAntiShift
   simpa using h_raw
 
+/-- A nonzero original top divisor limb makes the normalized n=4 divisor
+    nonzero, as required by double-addback value conservation. -/
+theorem n4CallAddbackBeqNormalizedDivisor_ne_zero {b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0) :
+    n4CallAddbackBeqB0Prime b ||| n4CallAddbackBeqB1Prime b |||
+        n4CallAddbackBeqB2Prime b ||| n4CallAddbackBeqB3Prime b ≠ 0 := by
+  intro h_zero
+  have h_b3_zero : n4CallAddbackBeqB3Prime b = 0 := by
+    bv_decide
+  have h_top_ge := n4CallAddbackBeqB3Prime_ge_pow63 hb3nz
+  rw [h_b3_zero] at h_top_ge
+  have h_zero_toNat : (0 : Word).toNat = 0 := by decide
+  rw [h_zero_toNat] at h_top_ge
+  norm_num at h_top_ge
+
 /-- Runtime-condition wrapper for double-addback value conservation over the
     normalized n=4 v4 call+addback marker limbs. -/
 theorem n4CallAddbackBeqIterWithDoubleAddback_val256_conservation_of_runtime

--- a/EvmAsm/Evm64/DivMod/Spec/CallAddbackRuntime.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/CallAddbackRuntime.lean
@@ -132,6 +132,52 @@ theorem n4CallAddbackBeqNormalizedDivisor_ne_zero {b : EvmWord}
   rw [h_zero_toNat] at h_top_ge
   norm_num at h_top_ge
 
+/-- Runtime-normalized c3 bridge: if the normalized trial quotient is within
+    one of the normalized true quotient, the raw borrow condition pins the
+    mulsub carry-out to one. -/
+theorem n4CallAddbackBeqC3_eq_one_of_borrow_and_qhat_le_div_plus_one {a b : EvmWord}
+    (hbnz :
+      n4CallAddbackBeqB0Prime b ||| n4CallAddbackBeqB1Prime b |||
+        n4CallAddbackBeqB2Prime b ||| n4CallAddbackBeqB3Prime b ≠ 0)
+    (hq_over :
+      (n4CallAddbackBeqQHatV4 a b).toNat ≤
+        EvmWord.val256
+          (n4CallAddbackBeqU0 a b)
+          (n4CallAddbackBeqU1 a b)
+          (n4CallAddbackBeqU2 a b)
+          (n4CallAddbackBeqU3 a b) /
+          EvmWord.val256
+            (n4CallAddbackBeqB0Prime b)
+            (n4CallAddbackBeqB1Prime b)
+            (n4CallAddbackBeqB2Prime b)
+            (n4CallAddbackBeqB3Prime b) + 1)
+    (h_borrow :
+      BitVec.ult (n4CallAddbackBeqU4 a b)
+        (mulsubN4
+          (n4CallAddbackBeqQHatV4 a b)
+          (n4CallAddbackBeqB0Prime b)
+          (n4CallAddbackBeqB1Prime b)
+          (n4CallAddbackBeqB2Prime b)
+          (n4CallAddbackBeqB3Prime b)
+          (n4CallAddbackBeqU0 a b)
+          (n4CallAddbackBeqU1 a b)
+          (n4CallAddbackBeqU2 a b)
+          (n4CallAddbackBeqU3 a b)).2.2.2.2) :
+      (mulsubN4
+        (n4CallAddbackBeqQHatV4 a b)
+        (n4CallAddbackBeqB0Prime b)
+        (n4CallAddbackBeqB1Prime b)
+        (n4CallAddbackBeqB2Prime b)
+        (n4CallAddbackBeqB3Prime b)
+        (n4CallAddbackBeqU0 a b)
+        (n4CallAddbackBeqU1 a b)
+        (n4CallAddbackBeqU2 a b)
+        (n4CallAddbackBeqU3 a b)).2.2.2.2 = 1 := by
+  apply mulsubN4_c3_ne_zero_imp_one hbnz hq_over
+  intro h_zero
+  rw [h_zero] at h_borrow
+  simp [BitVec.ult] at h_borrow
+
 /-- Runtime-condition wrapper for double-addback value conservation over the
     normalized n=4 v4 call+addback marker limbs. -/
 theorem n4CallAddbackBeqIterWithDoubleAddback_val256_conservation_of_runtime

--- a/EvmAsm/Evm64/DivMod/Spec/CallAddbackRuntime.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/CallAddbackRuntime.lean
@@ -117,6 +117,75 @@ theorem n4CallAddbackBeqCarry2Nz_of_runtime {a b : EvmWord}
     n4CallAddbackBeqAntiShift
   simpa using h_raw
 
+/-- Runtime-condition wrapper for double-addback value conservation over the
+    normalized n=4 v4 call+addback marker limbs. -/
+theorem n4CallAddbackBeqIterWithDoubleAddback_val256_conservation_of_runtime
+    {a b : EvmWord}
+    (hbnz :
+      n4CallAddbackBeqB0Prime b ||| n4CallAddbackBeqB1Prime b |||
+        n4CallAddbackBeqB2Prime b ||| n4CallAddbackBeqB3Prime b ≠ 0)
+    (hc3_one_of_borrow :
+      BitVec.ult (n4CallAddbackBeqU4 a b)
+        (mulsubN4
+          (n4CallAddbackBeqQHatV4 a b)
+          (n4CallAddbackBeqB0Prime b)
+          (n4CallAddbackBeqB1Prime b)
+          (n4CallAddbackBeqB2Prime b)
+          (n4CallAddbackBeqB3Prime b)
+          (n4CallAddbackBeqU0 a b)
+          (n4CallAddbackBeqU1 a b)
+          (n4CallAddbackBeqU2 a b)
+          (n4CallAddbackBeqU3 a b)).2.2.2.2 →
+        (mulsubN4
+          (n4CallAddbackBeqQHatV4 a b)
+          (n4CallAddbackBeqB0Prime b)
+          (n4CallAddbackBeqB1Prime b)
+          (n4CallAddbackBeqB2Prime b)
+          (n4CallAddbackBeqB3Prime b)
+          (n4CallAddbackBeqU0 a b)
+          (n4CallAddbackBeqU1 a b)
+          (n4CallAddbackBeqU2 a b)
+          (n4CallAddbackBeqU3 a b)).2.2.2.2 = 1)
+    (h_carry2 : isAddbackCarry2NzN4CallV4Evm a b) :
+    let out := iterWithDoubleAddback
+      (n4CallAddbackBeqQHatV4 a b)
+      (n4CallAddbackBeqB0Prime b)
+      (n4CallAddbackBeqB1Prime b)
+      (n4CallAddbackBeqB2Prime b)
+      (n4CallAddbackBeqB3Prime b)
+      (n4CallAddbackBeqU0 a b)
+      (n4CallAddbackBeqU1 a b)
+      (n4CallAddbackBeqU2 a b)
+      (n4CallAddbackBeqU3 a b)
+      (n4CallAddbackBeqU4 a b)
+    EvmWord.val256
+        (n4CallAddbackBeqU0 a b)
+        (n4CallAddbackBeqU1 a b)
+        (n4CallAddbackBeqU2 a b)
+        (n4CallAddbackBeqU3 a b) +
+      (n4CallAddbackBeqU4 a b).toNat * 2^256 =
+      out.1.toNat * EvmWord.val256
+        (n4CallAddbackBeqB0Prime b)
+        (n4CallAddbackBeqB1Prime b)
+        (n4CallAddbackBeqB2Prime b)
+        (n4CallAddbackBeqB3Prime b) +
+      EvmWord.val256 out.2.1 out.2.2.1 out.2.2.2.1 out.2.2.2.2.1 +
+      out.2.2.2.2.2.toNat * 2^256 := by
+  exact iterWithDoubleAddback_val256_conservation_of_carry2
+    (n4CallAddbackBeqQHatV4 a b)
+    (n4CallAddbackBeqB0Prime b)
+    (n4CallAddbackBeqB1Prime b)
+    (n4CallAddbackBeqB2Prime b)
+    (n4CallAddbackBeqB3Prime b)
+    (n4CallAddbackBeqU0 a b)
+    (n4CallAddbackBeqU1 a b)
+    (n4CallAddbackBeqU2 a b)
+    (n4CallAddbackBeqU3 a b)
+    (n4CallAddbackBeqU4 a b)
+    hbnz
+    hc3_one_of_borrow
+    (n4CallAddbackBeqCarry2Nz_of_runtime h_carry2)
+
 end EvmWord
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/CallAddbackRuntime.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/CallAddbackRuntime.lean
@@ -91,6 +91,32 @@ theorem n4CallAddbackBeqIterWithDoubleAddback_qOutV4_of_runtime_borrow {a b : Ev
   n4CallAddbackBeqIterWithDoubleAddback_qOutV4_of_borrow
     (n4CallAddbackBeqBorrow_raw_of_runtime h_borrow)
 
+/-- The packaged v4 n=4 call-addback runtime carry2 predicate is the raw
+    double-addback progress predicate over the normalized marker limbs. -/
+theorem n4CallAddbackBeqCarry2Nz_of_runtime {a b : EvmWord}
+    (h_carry2 : isAddbackCarry2NzN4CallV4Evm a b) :
+    isAddbackCarry2Nz
+      (n4CallAddbackBeqQHatV4 a b)
+      (n4CallAddbackBeqB0Prime b)
+      (n4CallAddbackBeqB1Prime b)
+      (n4CallAddbackBeqB2Prime b)
+      (n4CallAddbackBeqB3Prime b)
+      (n4CallAddbackBeqU0 a b)
+      (n4CallAddbackBeqU1 a b)
+      (n4CallAddbackBeqU2 a b)
+      (n4CallAddbackBeqU3 a b)
+      (n4CallAddbackBeqU4 a b) := by
+  have h_raw := isAddbackCarry2NzN4CallV4Evm_raw h_carry2
+  simp_rw [divKTrialCallV4QHat_eq_div128Quot_v4] at h_raw
+  rw [n4CallAddbackBeqQHatV4_eq_normalized]
+  unfold isAddbackCarry2Nz
+  unfold n4CallAddbackBeqB0Prime n4CallAddbackBeqB1Prime
+    n4CallAddbackBeqB2Prime n4CallAddbackBeqB3Prime
+    n4CallAddbackBeqU0 n4CallAddbackBeqU1 n4CallAddbackBeqU2
+    n4CallAddbackBeqU3 n4CallAddbackBeqU4 n4CallAddbackBeqShift
+    n4CallAddbackBeqAntiShift
+  simpa using h_raw
+
 end EvmWord
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add n4CallAddbackBeqCarry2Nz_of_runtime to the CallAddbackRuntime helper surface
- convert isAddbackCarry2NzN4CallV4Evm into the raw isAddbackCarry2Nz predicate over the normalized marker limbs
- this gives the double-addback conservation theorem a direct runtime-condition carry2 premise

## Checks
- lake build EvmAsm.Evm64.DivMod.Spec.CallAddbackRuntime
- lake build EvmAsm.Evm64.DivMod
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- rg -n "DivStackSpecCase|ModStackSpecCase|SDivStackSpecCase|SModStackSpecCase|StackSpecCase|set_option maxRecDepth|set_option maxHeartbeats|sorry|admit" EvmAsm/Evm64/DivMod/Spec/CallAddbackRuntime.lean