### PR TITLE
feat(stateless): block_withdrawals_total (PR-K85)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -10007,6 +10007,124 @@ def ziskWithdrawalsSumAmountsProbeUnit : BuildUnit := {
   dataAsm     := ziskWithdrawalsSumAmountsDataSection
 }
 
+/-! ## block_withdrawals_total -- PR-K85
+
+    Extract the withdrawals sub-list from a block body RLP and
+    return the total of all withdrawal `amount` fields (in Gwei)
+    as a u64.
+
+    Composes:
+      - PR-K83 `block_body_decode` — split body → 3 (off, len) pairs
+      - PR-K65 `withdrawals_sum_amounts` — sum amount across the
+        decoded withdrawals sub-list
+
+    Useful for cross-checking block-level invariants (e.g., the
+    `withdrawals_root` MPT computation) and for receipt analysis.
+
+    Status encoding lets callers floor(status / 100) to identify
+    the failing step:
+
+      0          : success — total written to *out
+      1          : block_body_decode failed (not a 3-item list)
+      101..102   : withdrawals_sum_amounts failed
+                   (101 = parse error, 102 = u64 overflow)
+
+    Calling convention:
+      a0 (input)  : body_rlp ptr
+      a1 (input)  : body_rlp byte length
+      a2 (input)  : u64 out ptr (total Gwei across all
+                    withdrawals)
+      ra (input)  : return
+      a0 (output) : composite status code.
+
+    Uses 48 bytes of `.data` scratch (`bwt_struct`) — separate
+    from K83's probe-only struct so the two compose cleanly. -/
+def blockWithdrawalsTotalFunction : String :=
+  "block_withdrawals_total:\n" ++
+  "  addi sp, sp, -32\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp)\n" ++
+  "  mv s0, a0                   # body_rlp ptr\n" ++
+  "  mv s1, a1                   # body_len\n" ++
+  "  mv s2, a2                   # out ptr\n" ++
+  "  # Step 1: block_body_decode\n" ++
+  "  la a2, bwt_struct\n" ++
+  "  jal ra, block_body_decode\n" ++
+  "  bnez a0, .Lbwt_body_fail\n" ++
+  "  # Step 2: withdrawals_sum_amounts on withdrawals sub-list.\n" ++
+  "  la t0, bwt_struct\n" ++
+  "  ld t1, 32(t0)               # withdrawals_offset\n" ++
+  "  ld t2, 40(t0)               # withdrawals_length\n" ++
+  "  add a0, s0, t1\n" ++
+  "  mv a1, t2\n" ++
+  "  mv a2, s2\n" ++
+  "  jal ra, withdrawals_sum_amounts\n" ++
+  "  beqz a0, .Lbwt_ret\n" ++
+  "  li t3, 100\n" ++
+  "  add a0, a0, t3              # 1 → 101, 2 → 102\n" ++
+  "  j .Lbwt_ret\n" ++
+  ".Lbwt_body_fail:\n" ++
+  "  li a0, 1\n" ++
+  ".Lbwt_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp)\n" ++
+  "  addi sp, sp, 32\n" ++
+  "  ret"
+
+/-- `zisk_block_withdrawals_total`: probe BuildUnit. Reads
+    (body_len, body_bytes) from host input, writes (status,
+    total_gwei u64) to OUTPUT (16 bytes total). -/
+def ziskBlockWithdrawalsTotalPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a3, 0x40000000\n" ++
+  "  ld a1, 8(a3)                # body_len\n" ++
+  "  addi a0, a3, 16             # body ptr\n" ++
+  "  li a2, 0xa0010008           # out ptr\n" ++
+  "  sd zero, 0(a2)\n" ++
+  "  jal ra, block_withdrawals_total\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lbwt_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpListCountItemsFunction ++ "\n" ++
+  rlpFieldToU64Function ++ "\n" ++
+  withdrawalDecodeFunction ++ "\n" ++
+  withdrawalsSumAmountsFunction ++ "\n" ++
+  blockBodyDecodeFunction ++ "\n" ++
+  blockWithdrawalsTotalFunction ++ "\n" ++
+  ".Lbwt_pdone:"
+
+def ziskBlockWithdrawalsTotalDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "rfu_offset:\n" ++
+  "  .zero 8\n" ++
+  "rfu_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "wd_offset:\n" ++
+  "  .zero 8\n" ++
+  "wd_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "wsa_count:\n" ++
+  "  .zero 8\n" ++
+  "wsa_entry_offset:\n" ++
+  "  .zero 8\n" ++
+  "wsa_entry_length:\n" ++
+  "  .zero 8\n" ++
+  "wsa_struct:\n" ++
+  "  .zero 48\n" ++
+  ".balign 8\n" ++
+  "bwt_struct:\n" ++
+  "  .zero 48"
+
+def ziskBlockWithdrawalsTotalProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskBlockWithdrawalsTotalPrologue
+  dataAsm     := ziskBlockWithdrawalsTotalDataSection
+}
+
 /-! ## zisk_ssz_pair_hash — PR-S4 SSZ merkleization primitive
 
     First consumer of the SSZ `hash_tree_root` shim:
@@ -11304,6 +11422,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_process_withdrawal"   => some ziskProcessWithdrawalProbeUnit
   | "zisk_process_withdrawals_block" => some ziskProcessWithdrawalsBlockProbeUnit
   | "zisk_withdrawals_sum_amounts" => some ziskWithdrawalsSumAmountsProbeUnit
+  | "zisk_block_withdrawals_total" => some ziskBlockWithdrawalsTotalProbeUnit
   | "zisk_sha256_from_input"    => some ziskSha256FromInputProbeUnit
   | "zisk_ssz_pair_hash"        => some ziskSszPairHashProbeUnit
   | "zisk_ssz_zero_hashes"      => some ziskSszZeroHashesProbeUnit
@@ -11399,6 +11518,7 @@ def knownProgramNames : List String :=
    "zisk_process_withdrawal",
    "zisk_process_withdrawals_block",
    "zisk_withdrawals_sum_amounts",
+   "zisk_block_withdrawals_total",
    "zisk_sha256_from_input",
    "zisk_ssz_pair_hash",
    "zisk_ssz_zero_hashes",

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **107**
-- ziskemu round-trip scripts: **100** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **108**
+- ziskemu round-trip scripts: **101** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-block-withdrawals-total-check.sh
+++ b/scripts/codegen-zisk-block-withdrawals-total-check.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# codegen-zisk-block-withdrawals-total-check.sh -- PR-K85.
+#
+# Extract withdrawals from a block body and sum amounts.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_block_withdrawals_total ELF"
+lake exe codegen --program zisk_block_withdrawals_total --halt linux93 \
+  -o gen-out/zisk_block_withdrawals_total
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <withdrawals_json>
+run_case() {
+  local name="$1" wds="$2"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_block_withdrawals_total_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_block_withdrawals_total_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import json, struct, sys, rlp
+wds_raw = json.loads('''$wds''')
+wds = []
+for w in wds_raw:
+    idx, vi, addr_hex, amt = w
+    wds.append([idx, vi, bytes.fromhex(addr_hex), amt])
+body = [[], [], wds]
+body_rlp = rlp.encode(body)
+with open(sys.argv[1], 'wb') as f:
+    f.write(struct.pack('<Q', len(body_rlp)))
+    f.write(body_rlp)
+    pad = (-(8 + len(body_rlp))) % 8
+    if pad: f.write(b'\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_block_withdrawals_total.elf \
+    -i "$in_file" -o "$out_file" -n 1000000 \
+    >"$REPO_ROOT/gen-out/zisk_block_withdrawals_total_${name}.emu.log" 2>&1 || true
+
+  local expected; expected="$(python3 -c "
+import json
+ws = json.loads('''$wds''')
+print(sum(w[3] for w in ws))
+")"
+  local actual_status; actual_status="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local actual_total;  actual_total="$(dd if="$out_file" bs=1 skip=8 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local exp_total_le;  exp_total_le="$(python3 -c "print(int('$expected').to_bytes(8, 'little').hex())")"
+
+  if [[ "$actual_status" == "0000000000000000" && "$actual_total" == "$exp_total_le" ]]; then
+    printf "  %-30s OK   total=%d\n" "$name" "$expected"
+    return 0
+  else
+    printf "  %-30s FAIL  status=0x%s total=0x%s (expected %d)\n" "$name" "$actual_status" "$actual_total" "$expected"
+    return 1
+  fi
+}
+
+ALICE="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+FAILED=0
+run_case "empty"              "[]"                                                    || FAILED=1
+run_case "one_wd"             "[[0, 1, \"$ALICE\", 1000000000]]"                       || FAILED=1
+run_case "three_wd" \
+  "[[1, 1, \"$ALICE\", 100], [2, 2, \"$ALICE\", 200], [3, 3, \"$ALICE\", 300]]"        || FAILED=1
+SIX_WD="$(python3 -c "
+import json
+addr = '$ALICE'
+print(json.dumps([[i, i+1000, addr, (i+1) * 10**9] for i in range(6)]))
+")"
+run_case "six_wd"             "$SIX_WD"                                                || FAILED=1
+SIXTEEN_WD="$(python3 -c "
+import json
+addr = '$ALICE'
+print(json.dumps([[i, i+1000, addr, (i+1) * 10**9] for i in range(16)]))
+")"
+run_case "sixteen_wd"         "$SIXTEEN_WD"                                            || FAILED=1
+
+# Body decode fail: 2-field body
+TWO_FIELD_FILE="$REPO_ROOT/gen-out/zisk_block_withdrawals_total_two_field.input"
+uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+body_rlp = rlp.encode([[], []])
+with open(sys.argv[1], 'wb') as f:
+    f.write(struct.pack('<Q', len(body_rlp)))
+    f.write(body_rlp)
+    pad = (-(8 + len(body_rlp))) % 8
+    if pad: f.write(b'\x00' * pad)
+" "$TWO_FIELD_FILE"
+"$ZISKEMU" -e gen-out/zisk_block_withdrawals_total.elf \
+  -i "$TWO_FIELD_FILE" -o "$REPO_ROOT/gen-out/zisk_block_withdrawals_total_two_field.output" \
+  -n 500000 >"$REPO_ROOT/gen-out/zisk_block_withdrawals_total_two_field.emu.log" 2>&1 || true
+TF_STATUS="$(xxd -p -l 8 "$REPO_ROOT/gen-out/zisk_block_withdrawals_total_two_field.output" | tr -d '\n')"
+if [[ "$TF_STATUS" == "0100000000000000" ]]; then
+  printf "  %-30s OK   status=1 (body decode fail)\n" "two_field_reject"
+else
+  printf "  %-30s FAIL  status=0x%s\n" "two_field_reject" "$TF_STATUS"
+  FAILED=1
+fi
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: block_withdrawals_total extracts withdrawals and sums amounts"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Extract the withdrawals sub-list from a block body RLP and return the total of all withdrawal `amount` fields (in Gwei) as `u64`. Useful for cross-checking block-level invariants (e.g., the `withdrawals_root` MPT) and receipt analysis.

## Composition

- PR-K83 `block_body_decode` (#5802) — split body → 3 `(off, len)` pairs
- PR-K65 `withdrawals_sum_amounts` — sum amount across the decoded withdrawals sub-list

Stacks on PR-K83 (#5802).

## Status encoding

| Status | Meaning |
|--------|---------|
| 0 | Success |
| 1 | `block_body_decode` failed (not a 3-item list) |
| 101..102 | `withdrawals_sum_amounts` failed (parse error / u64 overflow) |

## Test plan

- [x] `lake build` clean
- [x] `scripts/codegen-zisk-block-withdrawals-total-check.sh` passes 6 fixtures:
  - Empty withdrawals
  - `one_wd`, `three_wd` (mixed amounts), `six_wd`, `sixteen_wd` (mainnet cap)
  - Two-field body reject (no withdrawals → status=1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)