### PR TITLE
feat(stateless): block_summary (PR-K86)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -10360,6 +10360,164 @@ def ziskWithdrawalsSumAmountsProbeUnit : BuildUnit := {
   dataAsm     := ziskWithdrawalsSumAmountsDataSection
 }
 
+/-! ## block_summary -- PR-K86
+
+    One-pass block body audit. Decode the body, then extract:
+
+      tx_count                u64   — count of transactions
+      withdrawal_total_gwei   u64   — sum of withdrawal amounts
+      ommers_empty            u64   — 1 if ommers is empty, else 0
+
+    Useful for receipt / consensus-layer cross-checks and as a
+    convenient single-call entry point for callers that need
+    multiple block-level summaries.
+
+    Composes:
+      - PR-K83 `block_body_decode`      — split body
+      - PR-K47 `rlp_list_count_items`   — count txs
+      - PR-K65 `withdrawals_sum_amounts` — sum withdrawal amounts
+      - Inline check                    — ommers length == 1, byte == 0xc0
+
+    Output struct (24 bytes):
+      0..  8  tx_count
+      8.. 16  withdrawal_total_gwei
+     16.. 24  ommers_empty (0 or 1)
+
+    Status encoding:
+      0          : success
+      1          : block_body_decode failed
+      101..102   : rlp_list_count_items on txs failed (1=parse fail)
+                   — only code 101 is observed in practice
+      201..202   : withdrawals_sum_amounts failed (1=parse / 2=overflow)
+
+    Calling convention:
+      a0 (input)  : body_rlp ptr
+      a1 (input)  : body_rlp byte length
+      a2 (input)  : 24-byte output struct ptr
+      ra (input)  : return
+      a0 (output) : composite status code.
+
+    Uses 48 bytes of `.data` scratch (`bsum_struct`). -/
+def blockSummaryFunction : String :=
+  "block_summary:\n" ++
+  "  addi sp, sp, -32\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp)\n" ++
+  "  mv s0, a0                   # body_rlp ptr\n" ++
+  "  mv s1, a1                   # body_len\n" ++
+  "  mv s2, a2                   # output struct ptr\n" ++
+  "  # Step 1: block_body_decode → bsum_struct.\n" ++
+  "  la a2, bsum_struct\n" ++
+  "  jal ra, block_body_decode\n" ++
+  "  bnez a0, .Lbsum_body_fail\n" ++
+  "  # Step 2: tx_count = rlp_list_count_items(txs sub-list).\n" ++
+  "  la t0, bsum_struct\n" ++
+  "  ld t1, 0(t0)                # txs_offset\n" ++
+  "  ld t2, 8(t0)                # txs_length\n" ++
+  "  add a0, s0, t1\n" ++
+  "  mv a1, t2\n" ++
+  "  addi a2, s2, 0              # out[0..8] = tx_count\n" ++
+  "  jal ra, rlp_list_count_items\n" ++
+  "  beqz a0, .Lbsum_s3\n" ++
+  "  li t3, 100\n" ++
+  "  add a0, a0, t3              # 1 → 101\n" ++
+  "  j .Lbsum_ret\n" ++
+  ".Lbsum_s3:\n" ++
+  "  # Step 3: withdrawals_sum_amounts → out[8..16].\n" ++
+  "  la t0, bsum_struct\n" ++
+  "  ld t1, 32(t0)               # withdrawals_offset\n" ++
+  "  ld t2, 40(t0)               # withdrawals_length\n" ++
+  "  add a0, s0, t1\n" ++
+  "  mv a1, t2\n" ++
+  "  addi a2, s2, 8              # out[8..16] = total\n" ++
+  "  jal ra, withdrawals_sum_amounts\n" ++
+  "  beqz a0, .Lbsum_s4\n" ++
+  "  li t3, 200\n" ++
+  "  add a0, a0, t3              # 1 → 201, 2 → 202\n" ++
+  "  j .Lbsum_ret\n" ++
+  ".Lbsum_s4:\n" ++
+  "  # Step 4: ommers_empty check → out[16..24] (0 or 1).\n" ++
+  "  la t0, bsum_struct\n" ++
+  "  ld t1, 24(t0)               # ommers_length\n" ++
+  "  li t2, 1\n" ++
+  "  bne t1, t2, .Lbsum_ommers_not_empty\n" ++
+  "  ld t3, 16(t0)               # ommers_offset\n" ++
+  "  add t3, s0, t3\n" ++
+  "  lbu t4, 0(t3)\n" ++
+  "  li t5, 0xc0\n" ++
+  "  bne t4, t5, .Lbsum_ommers_not_empty\n" ++
+  "  li t6, 1\n" ++
+  "  sd t6, 16(s2)\n" ++
+  "  j .Lbsum_ok\n" ++
+  ".Lbsum_ommers_not_empty:\n" ++
+  "  sd zero, 16(s2)\n" ++
+  ".Lbsum_ok:\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lbsum_ret\n" ++
+  ".Lbsum_body_fail:\n" ++
+  "  li a0, 1\n" ++
+  ".Lbsum_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp)\n" ++
+  "  addi sp, sp, 32\n" ++
+  "  ret"
+
+/-- `zisk_block_summary`: probe BuildUnit. Reads (body_len,
+    body_bytes), writes (status, tx_count, wd_total, ommers_empty)
+    to OUTPUT (32 bytes total). -/
+def ziskBlockSummaryPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a3, 0x40000000\n" ++
+  "  ld a1, 8(a3)                # body_len\n" ++
+  "  addi a0, a3, 16             # body ptr\n" ++
+  "  li a2, 0xa0010008           # struct at OUTPUT + 8\n" ++
+  "  sd zero,  0(a2)\n" ++
+  "  sd zero,  8(a2)\n" ++
+  "  sd zero, 16(a2)\n" ++
+  "  jal ra, block_summary\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)                # status\n" ++
+  "  j .Lbsum_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpListCountItemsFunction ++ "\n" ++
+  rlpFieldToU64Function ++ "\n" ++
+  withdrawalDecodeFunction ++ "\n" ++
+  withdrawalsSumAmountsFunction ++ "\n" ++
+  blockBodyDecodeFunction ++ "\n" ++
+  blockSummaryFunction ++ "\n" ++
+  ".Lbsum_pdone:"
+
+def ziskBlockSummaryDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "rfu_offset:\n" ++
+  "  .zero 8\n" ++
+  "rfu_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "wd_offset:\n" ++
+  "  .zero 8\n" ++
+  "wd_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "wsa_count:\n" ++
+  "  .zero 8\n" ++
+  "wsa_entry_offset:\n" ++
+  "  .zero 8\n" ++
+  "wsa_entry_length:\n" ++
+  "  .zero 8\n" ++
+  "wsa_struct:\n" ++
+  "  .zero 48\n" ++
+  ".balign 8\n" ++
+  "bsum_struct:\n" ++
+  "  .zero 48"
+
+def ziskBlockSummaryProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskBlockSummaryPrologue
+  dataAsm     := ziskBlockSummaryDataSection
+}
+
 /-! ## zisk_ssz_pair_hash — PR-S4 SSZ merkleization primitive
 
     First consumer of the SSZ `hash_tree_root` shim:
@@ -11660,6 +11818,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_process_withdrawal"   => some ziskProcessWithdrawalProbeUnit
   | "zisk_process_withdrawals_block" => some ziskProcessWithdrawalsBlockProbeUnit
   | "zisk_withdrawals_sum_amounts" => some ziskWithdrawalsSumAmountsProbeUnit
+  | "zisk_block_summary"        => some ziskBlockSummaryProbeUnit
   | "zisk_sha256_from_input"    => some ziskSha256FromInputProbeUnit
   | "zisk_ssz_pair_hash"        => some ziskSszPairHashProbeUnit
   | "zisk_ssz_zero_hashes"      => some ziskSszZeroHashesProbeUnit
@@ -11758,6 +11917,7 @@ def knownProgramNames : List String :=
    "zisk_process_withdrawal",
    "zisk_process_withdrawals_block",
    "zisk_withdrawals_sum_amounts",
+   "zisk_block_summary",
    "zisk_sha256_from_input",
    "zisk_ssz_pair_hash",
    "zisk_ssz_zero_hashes",

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **107**
-- ziskemu round-trip scripts: **100** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **108**
+- ziskemu round-trip scripts: **101** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-block-summary-check.sh
+++ b/scripts/codegen-zisk-block-summary-check.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# codegen-zisk-block-summary-check.sh -- PR-K86.
+#
+# One-pass block body audit: tx_count + withdrawal_total + ommers_empty.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_block_summary ELF"
+lake exe codegen --program zisk_block_summary --halt linux93 \
+  -o gen-out/zisk_block_summary
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <txs_json> <ommers_json> <wds_json>
+run_case() {
+  local name="$1" txs="$2" ommers="$3" wds="$4"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_block_summary_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_block_summary_${name}.output"
+  local exp_file="$REPO_ROOT/gen-out/zisk_block_summary_${name}.expected"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import json, struct, sys, rlp
+txs_raw    = json.loads('''$txs''')
+ommers_raw = json.loads('''$ommers''')
+wds_raw    = json.loads('''$wds''')
+def conv(x):
+    if isinstance(x, str): return bytes.fromhex(x)
+    if isinstance(x, list): return [conv(e) for e in x]
+    return x
+txs = conv(txs_raw)
+ommers = conv(ommers_raw)
+wds = []
+for w in wds_raw:
+    idx, vi, addr_hex, amt = w
+    wds.append([idx, vi, bytes.fromhex(addr_hex), amt])
+
+body_rlp = rlp.encode([txs, ommers, wds])
+with open(sys.argv[1], 'wb') as f:
+    f.write(struct.pack('<Q', len(body_rlp)))
+    f.write(body_rlp)
+    pad = (-(8 + len(body_rlp))) % 8
+    if pad: f.write(b'\x00' * pad)
+
+# Expected: status + tx_count + wd_total + ommers_empty
+exp_total = sum(w[3] for w in wds_raw)
+exp_ommers_empty = 1 if len(ommers_raw) == 0 else 0
+exp_tx_count = len(txs_raw)
+with open(sys.argv[2], 'wb') as f:
+    f.write(struct.pack('<Q', 0))                  # status
+    f.write(struct.pack('<Q', exp_tx_count))
+    f.write(struct.pack('<Q', exp_total))
+    f.write(struct.pack('<Q', exp_ommers_empty))
+" "$in_file" "$exp_file"
+
+  "$ZISKEMU" -e gen-out/zisk_block_summary.elf \
+    -i "$in_file" -o "$out_file" -n 1000000 \
+    >"$REPO_ROOT/gen-out/zisk_block_summary_${name}.emu.log" 2>&1 || true
+
+  local actual; actual="$(xxd -p -l 32 "$out_file" | tr -d '\n')"
+  local expected; expected="$(xxd -p -l 32 "$exp_file" | tr -d '\n')"
+  if [[ "$actual" == "$expected" ]]; then
+    local tcount wtotal oempty
+    tcount="$(python3 -c "import json; print(len(json.loads('''$txs''')))")"
+    wtotal="$(python3 -c "import json; print(sum(w[3] for w in json.loads('''$wds''')))")"
+    oempty="$(python3 -c "import json; print(1 if len(json.loads('''$ommers''')) == 0 else 0)")"
+    printf "  %-30s OK   txs=%d wd_total=%d ommers_empty=%d\n" "$name" "$tcount" "$wtotal" "$oempty"
+    return 0
+  else
+    printf "  %-30s FAIL\n    expected: %s\n    actual:   %s\n" "$name" "$expected" "$actual"
+    return 1
+  fi
+}
+
+ALICE="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+TX_LEGACY="f8650184ee6b280082520894aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa881bc16d674ec80000801ba01111111111111111111111111111111111111111111111111111111111111111a02222222222222222222222222222222222222222222222222222222222222222"
+
+FAILED=0
+# Empty block
+run_case "empty_block"            "[]"                 "[]" "[]"                          || FAILED=1
+# Withdrawals only, post-merge
+run_case "wd_only_post_merge"     "[]"                 "[]" \
+  "[[0, 1, \"$ALICE\", 1000000000]]" || FAILED=1
+# Txs only
+run_case "txs_only"               "[\"$TX_LEGACY\"]"   "[]" "[]"                          || FAILED=1
+# Mixed: 2 txs, 1 withdrawal
+run_case "mixed_block" \
+  "[\"$TX_LEGACY\", \"$TX_LEGACY\"]" "[]" \
+  "[[100, 12345, \"$ALICE\", 32000000000]]" || FAILED=1
+# Mainnet shape: 16 withdrawals
+SIXTEEN_WD="$(python3 -c "
+import json
+addr = '$ALICE'
+print(json.dumps([[i, i+1000, addr, (i+1) * 10**9] for i in range(16)]))
+")"
+run_case "mainnet_full_wds"       "[]" "[]" "$SIXTEEN_WD"  || FAILED=1
+# Pre-merge: ommers non-empty
+run_case "pre_merge_with_ommers"  "[]" "[[]]" "[]"     || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: block_summary extracts tx_count + wd_total + ommers_empty"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

One-pass block body audit. Decode the body, then extract:

- `tx_count` (u64) — count of transactions
- `withdrawal_total_gwei` (u64) — sum of withdrawal amounts
- `ommers_empty` (u64) — `1` if ommers is empty, else `0`

Useful for receipt / consensus-layer cross-checks and as a convenient single-call entry point for callers that need multiple block-level summaries.

## Composition

- PR-K83 `block_body_decode` — split body
- PR-K47 `rlp_list_count_items` — count txs
- PR-K65 `withdrawals_sum_amounts` — sum withdrawal amounts
- Inline check — ommers length == 1, byte == `0xc0`

## Status encoding

| Status | Meaning |
|--------|---------|
| 0 | Success |
| 1 | `block_body_decode` failed |
| 101 | `rlp_list_count_items` on txs failed |
| 201..202 | `withdrawals_sum_amounts` failed (parse / u64 overflow) |

## Test plan

- [x] `lake build` clean
- [x] `scripts/codegen-zisk-block-summary-check.sh` passes 6 fixtures:
  - `empty_block`, `wd_only_post_merge`, `txs_only`, `mixed_block` (2 txs + 1 wd)
  - `mainnet_full_wds` (16 withdrawals)
  - `pre_merge_with_ommers` (`ommers_empty = 0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)