### PR TITLE
feat(stateless): tx_decode_dispatch (PR-K87)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -9179,6 +9179,210 @@ def ziskTxEip4844DecodeProbeUnit : BuildUnit := {
   dataAsm     := ziskTxEip4844DecodeDataSection
 }
 
+/-! ## tx_decode_dispatch -- PR-K87 unified tx decoder
+
+    Dispatch on a tx envelope's type byte and route to the
+    appropriate inner decoder. Mirrors Python's
+    `decode_transaction`:
+
+      byte 0 ≥ 0xc0     → legacy        → tx_legacy_decode    (K36)
+      byte 0 == 0x01    → EIP-2930      → tx_eip2930_decode   (K42)
+      byte 0 == 0x02    → EIP-1559      → tx_eip1559_decode   (K41)
+      byte 0 == 0x03    → EIP-4844      → tx_eip4844_decode   (K45)
+      byte 0 == 0x04    → EIP-7702      → tx_eip7702_decode   (K44)
+      else              → status = type-unrecognized
+
+    The decoded struct's size depends on the tx type:
+      type 0 (legacy)   : 196 B
+      type 1 (EIP-2930) : 216 B
+      type 2 (EIP-1559) : 248 B
+      type 3 (EIP-4844) : 248 B
+      type 4 (EIP-7702) : 240 B
+
+    Status encoding packs both the tx_type and sub-status:
+
+      status = (tx_type << 8) | sub_status
+
+      sub_status 0  : success
+      sub_status 1  : type unrecognized (used with tx_type=0)
+      sub_status 2  : sub-decoder returned non-zero
+
+    Caller responsibilities:
+      - Pre-zero the 248-byte struct_out buffer.
+      - After success, infer struct_size from `tx_type` extracted
+        as `(status >> 8) & 0xff`.
+
+    Composes PR-K40 + each of K36, K41, K42, K44, K45.
+
+    Calling convention:
+      a0 (input)  : envelope ptr
+      a1 (input)  : envelope_len
+      a2 (input)  : struct_out ptr (must be ≥ 248 bytes, pre-zeroed)
+      ra (input)  : return
+      a0 (output) : packed status (see encoding above).
+
+    Uses 8 bytes of `.data` scratch (`tdd_inner_off`) plus the
+    inner-decoder scratches (rfu_offset/rfu_length etc.). -/
+def txDecodeDispatchFunction : String :=
+  "tx_decode_dispatch:\n" ++
+  "  addi sp, sp, -32\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp)\n" ++
+  "  mv s0, a0                   # envelope ptr\n" ++
+  "  mv s1, a1                   # envelope_len\n" ++
+  "  mv s2, a2                   # struct_out ptr\n" ++
+  "  # tx_type_dispatch(envelope, len, type_out=tdd_type, inner_offset_out=tdd_inner_off)\n" ++
+  "  la a2, tdd_type\n" ++
+  "  la a3, tdd_inner_off\n" ++
+  "  jal ra, tx_type_dispatch\n" ++
+  "  bnez a0, .Ltdd_unrec\n" ++
+  "  la t0, tdd_type; ld t1, 0(t0)\n" ++
+  "  la t0, tdd_inner_off; ld t2, 0(t0)\n" ++
+  "  add t3, s0, t2              # inner_ptr\n" ++
+  "  sub t4, s1, t2              # inner_len\n" ++
+  "  # Dispatch on tx_type (t1)\n" ++
+  "  beqz t1, .Ltdd_legacy\n" ++
+  "  li t5, 1\n" ++
+  "  beq t1, t5, .Ltdd_2930\n" ++
+  "  li t5, 2\n" ++
+  "  beq t1, t5, .Ltdd_1559\n" ++
+  "  li t5, 3\n" ++
+  "  beq t1, t5, .Ltdd_4844\n" ++
+  "  li t5, 4\n" ++
+  "  beq t1, t5, .Ltdd_7702\n" ++
+  "  j .Ltdd_unrec\n" ++
+  ".Ltdd_legacy:\n" ++
+  "  mv a0, s0; mv a1, s1; mv a2, s2\n" ++
+  "  jal ra, tx_legacy_decode\n" ++
+  "  bnez a0, .Ltdd_decode_fail_legacy\n" ++
+  "  li a0, 0\n" ++
+  "  j .Ltdd_ret\n" ++
+  ".Ltdd_2930:\n" ++
+  "  mv a0, t3; mv a1, t4; mv a2, s2\n" ++
+  "  jal ra, tx_eip2930_decode\n" ++
+  "  bnez a0, .Ltdd_decode_fail_2930\n" ++
+  "  li a0, 0x0100\n" ++
+  "  j .Ltdd_ret\n" ++
+  ".Ltdd_1559:\n" ++
+  "  mv a0, t3; mv a1, t4; mv a2, s2\n" ++
+  "  jal ra, tx_eip1559_decode\n" ++
+  "  bnez a0, .Ltdd_decode_fail_1559\n" ++
+  "  li a0, 0x0200\n" ++
+  "  j .Ltdd_ret\n" ++
+  ".Ltdd_4844:\n" ++
+  "  mv a0, t3; mv a1, t4; mv a2, s2\n" ++
+  "  jal ra, tx_eip4844_decode\n" ++
+  "  bnez a0, .Ltdd_decode_fail_4844\n" ++
+  "  li a0, 0x0300\n" ++
+  "  j .Ltdd_ret\n" ++
+  ".Ltdd_7702:\n" ++
+  "  mv a0, t3; mv a1, t4; mv a2, s2\n" ++
+  "  jal ra, tx_eip7702_decode\n" ++
+  "  bnez a0, .Ltdd_decode_fail_7702\n" ++
+  "  li a0, 0x0400\n" ++
+  "  j .Ltdd_ret\n" ++
+  ".Ltdd_unrec:\n" ++
+  "  li a0, 0x0001\n" ++
+  "  j .Ltdd_ret\n" ++
+  ".Ltdd_decode_fail_legacy:\n" ++
+  "  li a0, 0x0002\n" ++
+  "  j .Ltdd_ret\n" ++
+  ".Ltdd_decode_fail_2930:\n" ++
+  "  li a0, 0x0102\n" ++
+  "  j .Ltdd_ret\n" ++
+  ".Ltdd_decode_fail_1559:\n" ++
+  "  li a0, 0x0202\n" ++
+  "  j .Ltdd_ret\n" ++
+  ".Ltdd_decode_fail_4844:\n" ++
+  "  li a0, 0x0302\n" ++
+  "  j .Ltdd_ret\n" ++
+  ".Ltdd_decode_fail_7702:\n" ++
+  "  li a0, 0x0402\n" ++
+  ".Ltdd_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp)\n" ++
+  "  addi sp, sp, 32\n" ++
+  "  ret"
+
+/-- `zisk_tx_decode_dispatch`: probe BuildUnit. Reads (env_len,
+    env_bytes) from host input; pre-zeros 248-byte struct slot
+    at OUTPUT+8; calls helper; writes (packed status, struct)
+    to OUTPUT (256 bytes total). -/
+def ziskTxDecodeDispatchPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a3, 0x40000000\n" ++
+  "  ld a1, 8(a3)                # env_len\n" ++
+  "  addi a0, a3, 16             # env ptr\n" ++
+  "  li a2, 0xa0010008           # struct slot at OUTPUT + 8\n" ++
+  "  # Pre-zero 248 bytes (31 dwords).\n" ++
+  "  mv t0, a2; li t1, 31\n" ++
+  ".Ltdd_zout:\n" ++
+  "  beqz t1, .Ltdd_zout_done\n" ++
+  "  sd zero, 0(t0)\n" ++
+  "  addi t0, t0, 8\n" ++
+  "  addi t1, t1, -1\n" ++
+  "  j .Ltdd_zout\n" ++
+  ".Ltdd_zout_done:\n" ++
+  "  jal ra, tx_decode_dispatch\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)                # packed status\n" ++
+  "  j .Ltdd_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpFieldToU64Function ++ "\n" ++
+  rlpFieldToU256BeFunction ++ "\n" ++
+  txTypeDispatchFunction ++ "\n" ++
+  txLegacyDecodeFunction ++ "\n" ++
+  txEip2930DecodeFunction ++ "\n" ++
+  txEip1559DecodeFunction ++ "\n" ++
+  txEip4844DecodeFunction ++ "\n" ++
+  txEip7702DecodeFunction ++ "\n" ++
+  txDecodeDispatchFunction ++ "\n" ++
+  ".Ltdd_pdone:"
+
+def ziskTxDecodeDispatchDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "rfu_offset:\n" ++
+  "  .zero 8\n" ++
+  "rfu_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "txd_offset:\n" ++
+  "  .zero 8\n" ++
+  "txd_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "t1d_offset:\n" ++
+  "  .zero 8\n" ++
+  "t1d_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "t29_offset:\n" ++
+  "  .zero 8\n" ++
+  "t29_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "t48_offset:\n" ++
+  "  .zero 8\n" ++
+  "t48_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "t77_offset:\n" ++
+  "  .zero 8\n" ++
+  "t77_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "tdd_type:\n" ++
+  "  .zero 8\n" ++
+  "tdd_inner_off:\n" ++
+  "  .zero 8"
+
+def ziskTxDecodeDispatchProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskTxDecodeDispatchPrologue
+  dataAsm     := ziskTxDecodeDispatchDataSection
+}
+
 /-! ## intrinsic_gas_legacy -- PR-K46 base + creation + data gas
 
     Compute the intrinsic gas cost portion of a legacy /
@@ -11927,6 +12131,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_tx_eip2930_decode"    => some ziskTxEip2930DecodeProbeUnit
   | "zisk_tx_eip7702_decode"    => some ziskTxEip7702DecodeProbeUnit
   | "zisk_tx_eip4844_decode"    => some ziskTxEip4844DecodeProbeUnit
+  | "zisk_tx_decode_dispatch"   => some ziskTxDecodeDispatchProbeUnit
   | "zisk_intrinsic_gas_legacy" => some ziskIntrinsicGasLegacyProbeUnit
   | "zisk_tx_validate_intrinsic_gas_legacy" => some ziskTxValidateIntrinsicGasLegacyProbeUnit
   | "zisk_validate_transaction_basic" => some ziskValidateTransactionBasicProbeUnit
@@ -12027,6 +12232,7 @@ def knownProgramNames : List String :=
    "zisk_tx_eip2930_decode",
    "zisk_tx_eip7702_decode",
    "zisk_tx_eip4844_decode",
+   "zisk_tx_decode_dispatch",
    "zisk_intrinsic_gas_legacy",
    "zisk_tx_validate_intrinsic_gas_legacy",
    "zisk_validate_transaction_basic",

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **109**
-- ziskemu round-trip scripts: **102** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **110**
+- ziskemu round-trip scripts: **103** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-tx-decode-dispatch-check.sh
+++ b/scripts/codegen-zisk-tx-decode-dispatch-check.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# codegen-zisk-tx-decode-dispatch-check.sh -- PR-K87.
+#
+# Unified tx decoder routing to K36/K41/K42/K44/K45.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_tx_decode_dispatch ELF"
+lake exe codegen --program zisk_tx_decode_dispatch --halt linux93 \
+  -o gen-out/zisk_tx_decode_dispatch
+
+REPO_ROOT="$(pwd)"
+
+ALICE="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+R1="$(printf '11%.0s' $(seq 1 32))"
+S1="$(printf '22%.0s' $(seq 1 32))"
+
+# Build a tx envelope for each type.
+build_legacy() {
+  uv run --directory execution-specs --quiet python3 -c "
+import sys, rlp
+tx = [7, 1000000000, 21000, bytes.fromhex('$ALICE'), 10**18, b'', 27,
+      int.from_bytes(bytes.fromhex('$R1'), 'big'),
+      int.from_bytes(bytes.fromhex('$S1'), 'big')]
+sys.stdout.buffer.write(rlp.encode(tx))
+"
+}
+
+build_eip1559() {
+  uv run --directory execution-specs --quiet python3 -c "
+import sys, rlp
+inner = [1, 7, 10**9, 2*10**9, 21000, bytes.fromhex('$ALICE'), 10**18, b'', [], 0,
+         int.from_bytes(bytes.fromhex('$R1'), 'big'),
+         int.from_bytes(bytes.fromhex('$S1'), 'big')]
+sys.stdout.buffer.write(b'\\x02' + rlp.encode(inner))
+"
+}
+
+build_eip2930() {
+  uv run --directory execution-specs --quiet python3 -c "
+import sys, rlp
+inner = [1, 7, 10**9, 21000, bytes.fromhex('$ALICE'), 10**18, b'', [], 0,
+         int.from_bytes(bytes.fromhex('$R1'), 'big'),
+         int.from_bytes(bytes.fromhex('$S1'), 'big')]
+sys.stdout.buffer.write(b'\\x01' + rlp.encode(inner))
+"
+}
+
+build_eip4844() {
+  uv run --directory execution-specs --quiet python3 -c "
+import sys, rlp
+H1 = bytes([0x01] + [0xaa]*31)
+inner = [1, 7, 10**9, 2*10**9, 21000, bytes.fromhex('$ALICE'), 10**18, b'', [], 1, [H1], 0,
+         int.from_bytes(bytes.fromhex('$R1'), 'big'),
+         int.from_bytes(bytes.fromhex('$S1'), 'big')]
+sys.stdout.buffer.write(b'\\x03' + rlp.encode(inner))
+"
+}
+
+build_eip7702() {
+  uv run --directory execution-specs --quiet python3 -c "
+import sys, rlp
+inner = [1, 7, 10**9, 2*10**9, 21000, bytes.fromhex('$ALICE'), 10**18, b'', [], [], 0,
+         int.from_bytes(bytes.fromhex('$R1'), 'big'),
+         int.from_bytes(bytes.fromhex('$S1'), 'big')]
+sys.stdout.buffer.write(b'\\x04' + rlp.encode(inner))
+"
+}
+
+# run_case <name> <build_fn> <expected_status_hex>
+run_case() {
+  local name="$1" builder="$2" expected_status="$3"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_tx_decode_dispatch_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_tx_decode_dispatch_${name}.output"
+
+  local env_file="$REPO_ROOT/gen-out/zisk_tx_decode_dispatch_${name}.env"
+  $builder > "$env_file"
+  python3 -c "
+import struct, sys
+with open(sys.argv[1], 'rb') as f:
+    env = f.read()
+out  = struct.pack('<Q', len(env))
+out += env
+pad = (-(8 + len(env))) % 8
+if pad: out += b'\x00' * pad
+sys.stdout.buffer.write(out)
+" "$env_file" > "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_tx_decode_dispatch.elf \
+    -i "$in_file" -o "$out_file" -n 500000 \
+    >"$REPO_ROOT/gen-out/zisk_tx_decode_dispatch_${name}.emu.log" 2>&1 || true
+
+  local actual; actual="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local exp_le; exp_le="$(python3 -c "print(int('$expected_status', 16).to_bytes(8, 'little').hex())")"
+
+  if [[ "$actual" == "$exp_le" ]]; then
+    printf "  %-30s OK   status=0x%s\n" "$name" "$expected_status"
+    return 0
+  else
+    printf "  %-30s FAIL  expected 0x%s got 0x%s\n" "$name" "$expected_status" "$actual"
+    return 1
+  fi
+}
+
+FAILED=0
+run_case "legacy"      build_legacy   "0000"  || FAILED=1
+run_case "eip2930"     build_eip2930  "0100"  || FAILED=1
+run_case "eip1559"     build_eip1559  "0200"  || FAILED=1
+run_case "eip4844"     build_eip4844  "0300"  || FAILED=1
+run_case "eip7702"     build_eip7702  "0400"  || FAILED=1
+
+# Unrecognized: byte 0 = 0x05 (not in 0x00..0x04 typed range, < 0xc0)
+UNREC_FILE="$REPO_ROOT/gen-out/zisk_tx_decode_dispatch_unrec.env"
+python3 -c "
+import sys
+sys.stdout.buffer.write(b'\\x05\\x00\\x00')
+" > "$UNREC_FILE"
+python3 -c "
+import struct, sys
+with open(sys.argv[1], 'rb') as f:
+    env = f.read()
+out  = struct.pack('<Q', len(env))
+out += env
+out += b'\x00' * 5
+sys.stdout.buffer.write(out)
+" "$UNREC_FILE" > "$REPO_ROOT/gen-out/zisk_tx_decode_dispatch_unrec.input"
+
+"$ZISKEMU" -e gen-out/zisk_tx_decode_dispatch.elf \
+  -i "$REPO_ROOT/gen-out/zisk_tx_decode_dispatch_unrec.input" \
+  -o "$REPO_ROOT/gen-out/zisk_tx_decode_dispatch_unrec.output" -n 500000 \
+  >"$REPO_ROOT/gen-out/zisk_tx_decode_dispatch_unrec.emu.log" 2>&1 || true
+
+UR_STATUS="$(xxd -p -l 8 "$REPO_ROOT/gen-out/zisk_tx_decode_dispatch_unrec.output" | tr -d '\n')"
+if [[ "$UR_STATUS" == "0100000000000000" ]]; then
+  printf "  %-30s OK   status=0x0001 (unrec)\n" "unrec_type"
+else
+  printf "  %-30s FAIL  status=0x%s\n" "unrec_type" "$UR_STATUS"
+  FAILED=1
+fi
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: tx_decode_dispatch routes all 5 tx types correctly"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Dispatch on a tx envelope's type byte and route to the appropriate inner decoder. Mirrors Python's `decode_transaction`:

| Byte 0 | Type | Decoder |
|--------|------|---------|
| `≥ 0xc0` | 0 = legacy | PR-K36 |
| `0x01` | 1 = EIP-2930 | PR-K42 |
| `0x02` | 2 = EIP-1559 | PR-K41 |
| `0x03` | 3 = EIP-4844 | PR-K45 |
| `0x04` | 4 = EIP-7702 | PR-K44 |
| else | — | status = unrecognized |

Composes PR-K40 `tx_type_dispatch` + all five inner decoders.

## Status encoding

`status = (tx_type << 8) | sub_status`

| sub_status | Meaning |
|-----------|---------|
| 0 | Success |
| 1 | Type unrecognized (used with `tx_type=0`) |
| 2 | Sub-decoder returned non-zero |

So `0x0000` = legacy success, `0x0200` = EIP-1559 success, `0x0202` = EIP-1559 decode failure, `0x0001` = type unrecognized.

## Caller responsibilities

- Pre-zero the 248-byte `struct_out` buffer
- After success, infer `struct_size` from `(status >> 8) & 0xff`:
  - type 0 = 196 B, type 1 = 216 B, type 2/3 = 248 B, type 4 = 240 B

## Test plan

- [x] `lake build` clean
- [x] `scripts/codegen-zisk-tx-decode-dispatch-check.sh` passes 6 fixtures: all 5 tx types + unrecognized envelope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)