### PR TITLE
feat(smod): expose canonical production code spec

### DIFF
--- a/EvmAsm/Evm64/SMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/SMod/Compose/Base.lean
@@ -1,9 +1,12 @@
 /-
   EvmAsm.Evm64.SMod.Compose.Base
 
-  Shared composition infrastructure for SMOD: `smodCode` (the union of
-  all sub-block `CodeReq`s), subsumption helpers tying sub-block codes
-  back to `smodCode`, and shared length lemmas.
+  Shared composition infrastructure for SMOD.
+
+  `smodCodeCanonical` is the production code handle for the current
+  `evm_smod` implementation, which appends the v4 unsigned MOD callable.
+  `smodCode` remains as the legacy v1 compatibility handle while downstream
+  proofs finish migrating.
 
   This module re-exports the first concrete SMOD compose scaffolding:
   wrapper offsets, code handles, and top-level code subsumption lemmas.

--- a/EvmAsm/Evm64/SMod/Compose/BaseCode.lean
+++ b/EvmAsm/Evm64/SMod/Compose/BaseCode.lean
@@ -264,6 +264,22 @@ theorem smodCodeV4_block_subs {base : Word} :
     smodCodeV4_resultSignFix_sub, smodCodeV4_savedRaRet_sub,
     smodCodeV4_modCallable_sub⟩
 
+/-- Canonical production-code block subsumptions for SMOD. -/
+theorem smodCodeCanonical_block_subs {base : Word} :
+    (∀ a i, (saveRaCode base) a = some i → (smodCodeCanonical base) a = some i) ∧
+    (∀ a i, (dividendSignCode base) a = some i → (smodCodeCanonical base) a = some i) ∧
+    (∀ a i, (preserveDividendSignCode base) a = some i →
+      (smodCodeCanonical base) a = some i) ∧
+    (∀ a i, (divisorSignCode base) a = some i → (smodCodeCanonical base) a = some i) ∧
+    (∀ a i, (dividendAbsCode base) a = some i → (smodCodeCanonical base) a = some i) ∧
+    (∀ a i, (divisorAbsCode base) a = some i → (smodCodeCanonical base) a = some i) ∧
+    (∀ a i, (modCallCode base) a = some i → (smodCodeCanonical base) a = some i) ∧
+    (∀ a i, (resultSignFixCode base) a = some i → (smodCodeCanonical base) a = some i) ∧
+    (∀ a i, (savedRaRetCode base) a = some i → (smodCodeCanonical base) a = some i) ∧
+    (∀ a i, (modCallableCodeV4 base) a = some i →
+      (smodCodeCanonical base) a = some i) := by
+  simpa [smodCodeCanonical] using smodCodeV4_block_subs (base := base)
+
 /-- Bundled top-level SMOD code subsumptions for the wrapper and appended
     legacy v1 unsigned MOD callable. -/
 theorem smodCode_top_level_subs {base : Word} :
@@ -299,5 +315,14 @@ theorem smodCodeV4_top_level_subs {base : Word} :
       (by rw [EvmAsm.Evm64.evm_smod_length]; norm_num)
       a i h
   · exact smodCodeV4_modCallable_sub
+
+/-- Bundled top-level SMOD code subsumptions for the canonical production
+    wrapper and appended v4 unsigned MOD callable. -/
+theorem smodCodeCanonical_top_level_subs {base : Word} :
+    (∀ a i, (EvmAsm.Rv64.CodeReq.ofProg base EvmAsm.Evm64.evm_smod_wrapper) a = some i →
+      (smodCodeCanonical base) a = some i) ∧
+    (∀ a i, (modCallableCodeV4 base) a = some i →
+      (smodCodeCanonical base) a = some i) := by
+  simpa [smodCodeCanonical] using smodCodeV4_top_level_subs (base := base)
 
 end EvmAsm.Evm64.SMod.Compose

--- a/EvmAsm/Evm64/SMod/Compose/BaseCode.lean
+++ b/EvmAsm/Evm64/SMod/Compose/BaseCode.lean
@@ -276,9 +276,9 @@ theorem smodCodeCanonical_block_subs {base : Word} :
     (∀ a i, (modCallCode base) a = some i → (smodCodeCanonical base) a = some i) ∧
     (∀ a i, (resultSignFixCode base) a = some i → (smodCodeCanonical base) a = some i) ∧
     (∀ a i, (savedRaRetCode base) a = some i → (smodCodeCanonical base) a = some i) ∧
-    (∀ a i, (modCallableCodeV4 base) a = some i →
+    (∀ a i, (modCallableCodeCanonical base) a = some i →
       (smodCodeCanonical base) a = some i) := by
-  simpa [smodCodeCanonical] using smodCodeV4_block_subs (base := base)
+  simpa [smodCodeCanonical, modCallableCodeCanonical] using smodCodeV4_block_subs (base := base)
 
 /-- Bundled top-level SMOD code subsumptions for the wrapper and appended
     legacy v1 unsigned MOD callable. -/

--- a/EvmAsm/Evm64/SMod/Compose/BaseTopLevel.lean
+++ b/EvmAsm/Evm64/SMod/Compose/BaseTopLevel.lean
@@ -39,6 +39,12 @@ theorem smodCodeV4_wrapper_sub {base : Word} :
       rw [evm_smod_length]
       norm_num)
 
+/-- Wrapper sub-region inside the canonical production SMOD code region. -/
+theorem smodCodeCanonical_wrapper_sub {base : Word} :
+    ∀ a i, (EvmAsm.Rv64.CodeReq.ofProg base evm_smod_wrapper) a = some i →
+      (smodCodeCanonical base) a = some i := by
+  simpa [smodCodeCanonical] using smodCodeV4_wrapper_sub (base := base)
+
 /-- Bundled top-level SMOD code subsumptions for the wrapper and named appended
     legacy v1 unsigned MOD callable code. -/
 theorem smodCode_named_top_level_subs {base : Word} :
@@ -56,6 +62,15 @@ theorem smodCodeV4_named_top_level_subs {base : Word} :
     (∀ a i, (EvmAsm.Evm64.evm_mod_callable_code_v4 (base + wrapperEndOff)) a = some i →
       (smodCodeV4 base) a = some i) := by
   exact ⟨smodCodeV4_wrapper_sub, evm_mod_callable_code_v4_sub_smodCodeV4⟩
+
+/-- Bundled top-level SMOD code subsumptions for the canonical production
+    wrapper and named appended v4 unsigned MOD callable code. -/
+theorem smodCodeCanonical_named_top_level_subs {base : Word} :
+    (∀ a i, (EvmAsm.Rv64.CodeReq.ofProg base evm_smod_wrapper) a = some i →
+      (smodCodeCanonical base) a = some i) ∧
+    (∀ a i, (EvmAsm.Evm64.evm_mod_callable_code_v4 (base + wrapperEndOff)) a = some i →
+      (smodCodeCanonical base) a = some i) := by
+  simpa [smodCodeCanonical] using smodCodeV4_named_top_level_subs (base := base)
 
 /-- The near `JAL` at the SMOD wrapper's `modCall` block targets the appended
     unsigned MOD callable, which starts at `base + wrapperEndOff`. -/

--- a/EvmAsm/Evm64/SMod/Compose/CodeHandles.lean
+++ b/EvmAsm/Evm64/SMod/Compose/CodeHandles.lean
@@ -87,4 +87,12 @@ abbrev modCallableCode (base : Word) : EvmAsm.Rv64.CodeReq :=
 abbrev modCallableCodeV4 (base : Word) : EvmAsm.Rv64.CodeReq :=
   EvmAsm.Rv64.CodeReq.ofProg (base + wrapperEndOff) EvmAsm.Evm64.evm_mod_callable_v4
 
+/-- Code handle for the appended canonical production unsigned modulo callable. -/
+abbrev modCallableCodeCanonical (base : Word) : EvmAsm.Rv64.CodeReq :=
+  modCallableCodeV4 base
+
+theorem modCallableCodeCanonical_eq_v4 {base : Word} :
+    modCallableCodeCanonical base = modCallableCodeV4 base :=
+  rfl
+
 end EvmAsm.Evm64.SMod.Compose

--- a/EvmAsm/Evm64/SMod/Compose/CodeHandles.lean
+++ b/EvmAsm/Evm64/SMod/Compose/CodeHandles.lean
@@ -19,6 +19,18 @@ abbrev smodCode (base : Word) : EvmAsm.Rv64.CodeReq :=
 abbrev smodCodeV4 (base : Word) : EvmAsm.Rv64.CodeReq :=
   EvmAsm.Rv64.CodeReq.ofProg base EvmAsm.Evm64.evm_smod
 
+/-- Canonical production SMOD code region handle.
+
+    This is the non-legacy public handle for the current executable
+    `evm_smod`, kept separate from `smodCode` while legacy v1 compatibility
+    lemmas are still present. -/
+abbrev smodCodeCanonical (base : Word) : EvmAsm.Rv64.CodeReq :=
+  smodCodeV4 base
+
+theorem smodCodeCanonical_eq_v4 {base : Word} :
+    smodCodeCanonical base = smodCodeV4 base :=
+  rfl
+
 /-- Code handle for the saved-`ra` prologue block. -/
 abbrev saveRaCode (base : Word) : EvmAsm.Rv64.CodeReq :=
   EvmAsm.Rv64.CodeReq.ofProg (base + saveRaOff) (EvmAsm.Evm64.evm_smod_save_ra_block .x18)

--- a/EvmAsm/Evm64/SMod/Compose/ModCallCallable.lean
+++ b/EvmAsm/Evm64/SMod/Compose/ModCallCallable.lean
@@ -40,4 +40,12 @@ theorem evm_mod_callable_code_v4_sub_smodCodeV4 {base : Word} :
     (by
       simpa [modCallableCodeV4] using hOfProg)
 
+/-- The appended v4 unsigned MOD callable is a sub-region of the canonical
+    production SMOD code handle. -/
+theorem evm_mod_callable_code_v4_sub_smodCodeCanonical {base : Word} :
+    ∀ a i,
+      (EvmAsm.Evm64.evm_mod_callable_code_v4 (base + wrapperEndOff)) a = some i →
+      (smodCodeCanonical base) a = some i := by
+  simpa [smodCodeCanonical] using evm_mod_callable_code_v4_sub_smodCodeV4 (base := base)
+
 end EvmAsm.Evm64.SMod.Compose

--- a/EvmAsm/Evm64/SMod/Spec.lean
+++ b/EvmAsm/Evm64/SMod/Spec.lean
@@ -79,6 +79,42 @@ theorem evm_smod_prefix_mod_call_dispatch_ready_stack_spec_within
       v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
       shiftMem nMem jMem retMem dMem dloMem scratchUn0 base)
 
+/-- Canonical production-code spelling of
+    `evm_smod_prefix_mod_call_dispatch_ready_stack_spec_within`. -/
+theorem evm_smod_canonical_prefix_mod_call_dispatch_ready_stack_spec_within
+    (vRa vSavedOld sp sDividendOld x13Old sDivisorOld
+      dividendMaskOld dividendValueOld dividendCarryOld : Word)
+    (dividend divisor : EvmWord)
+    (v2 v5 v6 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (base : Word) :
+    EvmAsm.Rv64.cpsTripleWithin 49 base (base + wrapperEndOff)
+      (smodCodeCanonical base)
+      (((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ vSavedOld)) **
+        ((.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sDividendOld) ** (.x13 ↦ᵣ x13Old) **
+          (.x9 ↦ᵣ sDivisorOld) ** (.x0 ↦ᵣ (0 : Word)) **
+          (.x10 ↦ᵣ dividendMaskOld) ** (.x7 ↦ᵣ dividendValueOld) **
+          (.x11 ↦ᵣ dividendCarryOld))) **
+        evmStackIs sp [dividend, divisor]) **
+        ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
+          EvmAsm.Evm64.divScratchValuesCallNoX1 sp
+            q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+            shiftMem nMem jMem retMem dMem dloMem scratchUn0))
+      (saveRaAbsThenModCallDispatchReadyPost vRa sp base
+        (dividend.getLimbN 0) (dividend.getLimbN 1)
+        (dividend.getLimbN 2) (dividend.getLimbN 3)
+        (divisor.getLimbN 0) (divisor.getLimbN 1)
+        (divisor.getLimbN 2) (divisor.getLimbN 3)
+        v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0) := by
+  simpa [smodCodeCanonical] using
+    evm_smod_prefix_mod_call_dispatch_ready_stack_spec_within
+      vRa vSavedOld sp sDividendOld x13Old sDivisorOld
+      dividendMaskOld dividendValueOld dividendCarryOld dividend divisor
+      v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 base
+
 /-- Stack-level SMOD v4 bridge from the public two-word EVM stack assertion
     through the wrapper prefix, unsigned-MOD callable, result-sign fix, and
     saved-RA return.

--- a/EvmAsm/Evm64/SMod/Spec.lean
+++ b/EvmAsm/Evm64/SMod/Spec.lean
@@ -152,6 +152,65 @@ theorem evm_smod_mod_call_return_stack_spec_within
       v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
       shiftMem nMem jMem retMem dMem dloMem scratchUn0 h_base h_stack)
 
+/-- Canonical production-code spelling of
+    `evm_smod_mod_call_return_stack_spec_within`. -/
+theorem evm_smod_canonical_mod_call_return_stack_spec_within
+    (vRa vSavedOld sp sDividendOld x13Old sDivisorOld
+      dividendMaskOld dividendValueOld dividendCarryOld : Word)
+    (dividend divisor : EvmWord)
+    (v2 v5 v6 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (base : Word) (h_base : base &&& 1 = 0)
+    (h_stack :
+      EvmAsm.Rv64.cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
+        (base + wrapperEndOff) ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
+        (EvmAsm.Evm64.sharedDivModCodeNoNop_v4 (base + wrapperEndOff))
+        (EvmAsm.Evm64.divModStackDispatchPreCallable sp
+          (smodAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
+            (dividend.getLimbN 2) (dividend.getLimbN 3))
+          (smodAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
+            (divisor.getLimbN 2) (divisor.getLimbN 3))
+          ((base + modCallOff) + 4)
+          v2 v5 v6
+          (smodAbsSum3 (divisor.getLimbN 0) (divisor.getLimbN 1)
+            (divisor.getLimbN 2) (divisor.getLimbN 3))
+          (smodAbsMask (divisor.getLimbN 3))
+          (smodAbsCarry3 (divisor.getLimbN 0) (divisor.getLimbN 1)
+            (divisor.getLimbN 2) (divisor.getLimbN 3))
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+        (EvmAsm.Evm64.modStackDispatchPostCallable sp
+          (smodAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
+            (dividend.getLimbN 2) (dividend.getLimbN 3))
+          (smodAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
+            (divisor.getLimbN 2) (divisor.getLimbN 3)) **
+          (.x1 ↦ᵣ ((base + modCallOff) + 4)))) :
+    EvmAsm.Rv64.cpsTripleWithin
+      (49 + (((EvmAsm.Evm64.unifiedDivBound + 1) + 21) + 1))
+      base (vRa &&& ~~~(1 : Word)) (smodCodeCanonical base)
+      (((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ vSavedOld)) **
+        ((.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sDividendOld) ** (.x13 ↦ᵣ x13Old) **
+          (.x9 ↦ᵣ sDivisorOld) ** (.x0 ↦ᵣ (0 : Word)) **
+          (.x10 ↦ᵣ dividendMaskOld) ** (.x7 ↦ᵣ dividendValueOld) **
+          (.x11 ↦ᵣ dividendCarryOld))) **
+        evmStackIs sp [dividend, divisor]) **
+        ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
+          EvmAsm.Evm64.divScratchValuesCallNoX1 sp
+            q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+            shiftMem nMem jMem retMem dMem dloMem scratchUn0))
+      (saveRaAbsThenModCallReturnPost vRa sp base
+        (dividend.getLimbN 0) (dividend.getLimbN 1)
+        (dividend.getLimbN 2) (dividend.getLimbN 3)
+        (divisor.getLimbN 0) (divisor.getLimbN 1)
+        (divisor.getLimbN 2) (divisor.getLimbN 3)) := by
+  simpa [smodCodeCanonical] using
+    evm_smod_mod_call_return_stack_spec_within
+      vRa vSavedOld sp sDividendOld x13Old sDivisorOld
+      dividendMaskOld dividendValueOld dividendCarryOld dividend divisor
+      v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 base h_base h_stack
+
 -- Placeholder: final `evm_smod_stack_spec_within` lands after the remaining
 -- callable-return and semantic-handler bridges are collapsed into one theorem.
 


### PR DESCRIPTION
## Summary
- add `smodCodeCanonical` as the non-legacy production code handle for current `evm_smod`
- expose canonical block/top-level subsumption aliases over the v4 unsigned MOD callable path
- add a canonical public spelling of the current SMOD mod-call return stack spec

## Verification
- lake build EvmAsm.Evm64.SMod
- lake build EvmAsm.Evm64.DivMod EvmAsm.Evm64.SDiv
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- rg forbidden-pattern scan on touched SMOD files

Bead: evm-asm-9iqmw.9