### PR TITLE
feat(stateless): tx_eip4844_compute_blob_gas (PR-K88)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -9179,6 +9179,132 @@ def ziskTxEip4844DecodeProbeUnit : BuildUnit := {
   dataAsm     := ziskTxEip4844DecodeDataSection
 }
 
+/-! ## tx_eip4844_compute_blob_gas -- PR-K88
+
+    Given an EIP-4844 (type 3) tx inner RLP body, decode it and
+    compute the per-tx `blob_gas_used` field:
+
+      blob_gas_used = len(tx.blob_versioned_hashes) × GAS_PER_BLOB
+
+    Where `GAS_PER_BLOB = 131072` (mainnet Cancun); parameterized
+    so the helper works across forks that adjust it.
+
+    Composes:
+      - PR-K45 `tx_eip4844_decode` — decode inner body → 248 B struct
+      - PR-K64 `blob_gas_used_from_versioned_hashes` — count × gas_per_blob
+
+    Useful for verifying that
+    `header.blob_gas_used == sum(tx.blob_gas_used for tx in block)`.
+
+    The K45 struct at offsets 168..172 (u32 LE) holds
+    `blob_versioned_hashes_offset` (relative to `inner_ptr`), and
+    offsets 172..176 hold `blob_versioned_hashes_length`. This
+    helper reads those, computes the absolute pointer, and
+    invokes K64.
+
+    Calling convention:
+      a0 (input)  : inner_rlp ptr (post-0x03 type byte)
+      a1 (input)  : inner_rlp byte length
+      a2 (input)  : gas_per_blob (u64; 131072 on mainnet)
+      a3 (input)  : u64 out ptr (receives blob_gas_used)
+      ra (input)  : return
+      a0 (output) :
+        0  : success
+        1  : tx_eip4844_decode failed (parse error)
+        2  : blob_gas_used_from_versioned_hashes failed (parse error)
+
+    Uses 248 + 8 bytes of `.data` scratch (`tcbg_struct` for the
+    decoded EIP-4844 struct, plus an inherited count scratch). -/
+def txEip4844ComputeBlobGasFunction : String :=
+  "tx_eip4844_compute_blob_gas:\n" ++
+  "  addi sp, sp, -32\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp)\n" ++
+  "  mv s0, a0                   # inner_rlp ptr\n" ++
+  "  mv s1, a2                   # gas_per_blob\n" ++
+  "  mv s2, a3                   # out ptr\n" ++
+  "  # Step 1: K45 tx_eip4844_decode(inner, len, tcbg_struct)\n" ++
+  "  la a2, tcbg_struct\n" ++
+  "  # Pre-zero 248 bytes (31 dwords)\n" ++
+  "  mv t0, a2; li t1, 31\n" ++
+  ".Ltcbg_zinit:\n" ++
+  "  beqz t1, .Ltcbg_zdone\n" ++
+  "  sd zero, 0(t0)\n" ++
+  "  addi t0, t0, 8\n" ++
+  "  addi t1, t1, -1\n" ++
+  "  j .Ltcbg_zinit\n" ++
+  ".Ltcbg_zdone:\n" ++
+  "  jal ra, tx_eip4844_decode\n" ++
+  "  bnez a0, .Ltcbg_decode_fail\n" ++
+  "  # Step 2: K64 blob_gas_used_from_versioned_hashes(...)\n" ++
+  "  la t0, tcbg_struct\n" ++
+  "  lwu t1, 168(t0)             # blob_versioned_hashes_offset (u32)\n" ++
+  "  lwu t2, 172(t0)             # blob_versioned_hashes_length (u32)\n" ++
+  "  add a0, s0, t1              # absolute blob_list ptr\n" ++
+  "  mv a1, t2                   # blob_list length\n" ++
+  "  mv a2, s1                   # gas_per_blob\n" ++
+  "  mv a3, s2                   # out ptr\n" ++
+  "  jal ra, blob_gas_used_from_versioned_hashes\n" ++
+  "  beqz a0, .Ltcbg_ret\n" ++
+  "  li a0, 2\n" ++
+  "  j .Ltcbg_ret\n" ++
+  ".Ltcbg_decode_fail:\n" ++
+  "  li a0, 1\n" ++
+  ".Ltcbg_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp)\n" ++
+  "  addi sp, sp, 32\n" ++
+  "  ret"
+
+/-- `zisk_tx_eip4844_compute_blob_gas`: probe BuildUnit. Reads
+    (inner_len, gas_per_blob, inner_bytes) from host input,
+    writes (status, blob_gas_used) to OUTPUT (16 bytes). -/
+def ziskTxEip4844ComputeBlobGasPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a4, 0x40000000\n" ++
+  "  ld a1, 8(a4)                # inner_len\n" ++
+  "  ld a2, 16(a4)               # gas_per_blob\n" ++
+  "  addi a0, a4, 24             # inner_ptr\n" ++
+  "  li a3, 0xa0010008           # out u64 ptr\n" ++
+  "  sd zero, 0(a3)\n" ++
+  "  jal ra, tx_eip4844_compute_blob_gas\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)                # status\n" ++
+  "  j .Ltcbg_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpListCountItemsFunction ++ "\n" ++
+  rlpFieldToU64Function ++ "\n" ++
+  rlpFieldToU256BeFunction ++ "\n" ++
+  txEip4844DecodeFunction ++ "\n" ++
+  blobGasUsedFromVersionedHashesFunction ++ "\n" ++
+  txEip4844ComputeBlobGasFunction ++ "\n" ++
+  ".Ltcbg_pdone:"
+
+def ziskTxEip4844ComputeBlobGasDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "rfu_offset:\n" ++
+  "  .zero 8\n" ++
+  "rfu_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "t48_offset:\n" ++
+  "  .zero 8\n" ++
+  "t48_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "bgvh_count_scratch:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "tcbg_struct:\n" ++
+  "  .zero 248"
+
+def ziskTxEip4844ComputeBlobGasProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskTxEip4844ComputeBlobGasPrologue
+  dataAsm     := ziskTxEip4844ComputeBlobGasDataSection
+}
+
 /-! ## intrinsic_gas_legacy -- PR-K46 base + creation + data gas
 
     Compute the intrinsic gas cost portion of a legacy /
@@ -11927,6 +12053,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_tx_eip2930_decode"    => some ziskTxEip2930DecodeProbeUnit
   | "zisk_tx_eip7702_decode"    => some ziskTxEip7702DecodeProbeUnit
   | "zisk_tx_eip4844_decode"    => some ziskTxEip4844DecodeProbeUnit
+  | "zisk_tx_eip4844_compute_blob_gas" => some ziskTxEip4844ComputeBlobGasProbeUnit
   | "zisk_intrinsic_gas_legacy" => some ziskIntrinsicGasLegacyProbeUnit
   | "zisk_tx_validate_intrinsic_gas_legacy" => some ziskTxValidateIntrinsicGasLegacyProbeUnit
   | "zisk_validate_transaction_basic" => some ziskValidateTransactionBasicProbeUnit
@@ -12027,6 +12154,7 @@ def knownProgramNames : List String :=
    "zisk_tx_eip2930_decode",
    "zisk_tx_eip7702_decode",
    "zisk_tx_eip4844_decode",
+   "zisk_tx_eip4844_compute_blob_gas",
    "zisk_intrinsic_gas_legacy",
    "zisk_tx_validate_intrinsic_gas_legacy",
    "zisk_validate_transaction_basic",

--- a/scripts/codegen-zisk-tx-eip4844-compute-blob-gas-check.sh
+++ b/scripts/codegen-zisk-tx-eip4844-compute-blob-gas-check.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# codegen-zisk-tx-eip4844-compute-blob-gas-check.sh -- PR-K88.
+#
+# Decode an EIP-4844 inner RLP and compute blob_gas_used.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_tx_eip4844_compute_blob_gas ELF"
+lake exe codegen --program zisk_tx_eip4844_compute_blob_gas --halt linux93 \
+  -o gen-out/zisk_tx_eip4844_compute_blob_gas
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <num_blobs> <gas_per_blob>
+run_case() {
+  local name="$1" n="$2" gpb="$3"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_tx_eip4844_compute_blob_gas_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_tx_eip4844_compute_blob_gas_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+n = $n
+gpb = $gpb
+ALICE = bytes([0xaa] * 20)
+R = bytes([0x11] * 32)
+S = bytes([0x22] * 32)
+H = bytes([0x01] + [0xab]*31)
+inner = [
+    1, 7, 10**9, 2*10**9, 21000,
+    ALICE, 10**18, b'', [],
+    1, [H]*n, 0,
+    int.from_bytes(R, 'big'), int.from_bytes(S, 'big'),
+]
+inner_rlp = rlp.encode(inner)
+with open(sys.argv[1], 'wb') as f:
+    f.write(struct.pack('<Q', len(inner_rlp)))
+    f.write(struct.pack('<Q', gpb))
+    f.write(inner_rlp)
+    pad = (-(16 + len(inner_rlp))) % 8
+    if pad: f.write(b'\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_tx_eip4844_compute_blob_gas.elf \
+    -i "$in_file" -o "$out_file" -n 1000000 \
+    >"$REPO_ROOT/gen-out/zisk_tx_eip4844_compute_blob_gas_${name}.emu.log" 2>&1 || true
+
+  local expected=$((n * gpb))
+  local actual_status; actual_status="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local actual_blob_gas; actual_blob_gas="$(dd if="$out_file" bs=1 skip=8 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local exp_blob_gas_le; exp_blob_gas_le="$(python3 -c "print(int('$expected').to_bytes(8, 'little').hex())")"
+
+  if [[ "$actual_status" == "0000000000000000" && "$actual_blob_gas" == "$exp_blob_gas_le" ]]; then
+    printf "  %-30s OK   n=%d blob_gas=%d\n" "$name" "$n" "$expected"
+    return 0
+  else
+    printf "  %-30s FAIL  status=0x%s blob_gas=0x%s (expected %d)\n" "$name" "$actual_status" "$actual_blob_gas" "$expected"
+    return 1
+  fi
+}
+
+GAS_PER_BLOB=131072
+
+FAILED=0
+run_case "one_blob"       1 "$GAS_PER_BLOB"  || FAILED=1
+run_case "three_blobs"    3 "$GAS_PER_BLOB"  || FAILED=1
+run_case "six_blobs"      6 "$GAS_PER_BLOB"  || FAILED=1
+run_case "nine_blobs"     9 "$GAS_PER_BLOB"  || FAILED=1
+# Different gas_per_blob
+run_case "one_blob_custom_gas" 1 100  || FAILED=1
+run_case "two_blobs_big_gas"   2 1000000  || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: tx_eip4844_compute_blob_gas matches count × gas_per_blob"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Given an EIP-4844 (type 3) tx inner RLP body, decode it and compute the
per-tx `blob_gas_used` field:

```
blob_gas_used = len(tx.blob_versioned_hashes) * GAS_PER_BLOB
```

Useful for verifying that `header.blob_gas_used == sum of all
tx.blob_gas_used values in a block`.

Composes:
- PR-K45 `tx_eip4844_decode` (parses inner RLP into 248-byte struct)
- PR-K64 `blob_gas_used_from_versioned_hashes` (count × gas_per_blob)

Reads the u32 LE `blob_versioned_hashes` (offset, length) from the K45
struct slot 168..176, computes the absolute pointer, then invokes K64.

Distinct return codes:
- `0` : success
- `1` : `tx_eip4844_decode` failed (parse error)
- `2` : `blob_gas_used_from_versioned_hashes` failed

## Test plan

- [x] `scripts/codegen-zisk-tx-eip4844-compute-blob-gas-check.sh` passes
  6 fixtures: 1/3/6/9 blobs at standard `GAS_PER_BLOB`, plus two with
  custom `gas_per_blob` values
- [x] `lake build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)