### PR TITLE
feat(stateless): block_body_blob_gas_total (PR-K89)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -9179,6 +9179,210 @@ def ziskTxEip4844DecodeProbeUnit : BuildUnit := {
   dataAsm     := ziskTxEip4844DecodeDataSection
 }
 
+/-! ## tx_decode_dispatch -- PR-K87 unified tx decoder
+
+    Dispatch on a tx envelope's type byte and route to the
+    appropriate inner decoder. Mirrors Python's
+    `decode_transaction`:
+
+      byte 0 ≥ 0xc0     → legacy        → tx_legacy_decode    (K36)
+      byte 0 == 0x01    → EIP-2930      → tx_eip2930_decode   (K42)
+      byte 0 == 0x02    → EIP-1559      → tx_eip1559_decode   (K41)
+      byte 0 == 0x03    → EIP-4844      → tx_eip4844_decode   (K45)
+      byte 0 == 0x04    → EIP-7702      → tx_eip7702_decode   (K44)
+      else              → status = type-unrecognized
+
+    The decoded struct's size depends on the tx type:
+      type 0 (legacy)   : 196 B
+      type 1 (EIP-2930) : 216 B
+      type 2 (EIP-1559) : 248 B
+      type 3 (EIP-4844) : 248 B
+      type 4 (EIP-7702) : 240 B
+
+    Status encoding packs both the tx_type and sub-status:
+
+      status = (tx_type << 8) | sub_status
+
+      sub_status 0  : success
+      sub_status 1  : type unrecognized (used with tx_type=0)
+      sub_status 2  : sub-decoder returned non-zero
+
+    Caller responsibilities:
+      - Pre-zero the 248-byte struct_out buffer.
+      - After success, infer struct_size from `tx_type` extracted
+        as `(status >> 8) & 0xff`.
+
+    Composes PR-K40 + each of K36, K41, K42, K44, K45.
+
+    Calling convention:
+      a0 (input)  : envelope ptr
+      a1 (input)  : envelope_len
+      a2 (input)  : struct_out ptr (must be ≥ 248 bytes, pre-zeroed)
+      ra (input)  : return
+      a0 (output) : packed status (see encoding above).
+
+    Uses 8 bytes of `.data` scratch (`tdd_inner_off`) plus the
+    inner-decoder scratches (rfu_offset/rfu_length etc.). -/
+def txDecodeDispatchFunction : String :=
+  "tx_decode_dispatch:\n" ++
+  "  addi sp, sp, -32\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp)\n" ++
+  "  mv s0, a0                   # envelope ptr\n" ++
+  "  mv s1, a1                   # envelope_len\n" ++
+  "  mv s2, a2                   # struct_out ptr\n" ++
+  "  # tx_type_dispatch(envelope, len, type_out=tdd_type, inner_offset_out=tdd_inner_off)\n" ++
+  "  la a2, tdd_type\n" ++
+  "  la a3, tdd_inner_off\n" ++
+  "  jal ra, tx_type_dispatch\n" ++
+  "  bnez a0, .Ltdd_unrec\n" ++
+  "  la t0, tdd_type; ld t1, 0(t0)\n" ++
+  "  la t0, tdd_inner_off; ld t2, 0(t0)\n" ++
+  "  add t3, s0, t2              # inner_ptr\n" ++
+  "  sub t4, s1, t2              # inner_len\n" ++
+  "  # Dispatch on tx_type (t1)\n" ++
+  "  beqz t1, .Ltdd_legacy\n" ++
+  "  li t5, 1\n" ++
+  "  beq t1, t5, .Ltdd_2930\n" ++
+  "  li t5, 2\n" ++
+  "  beq t1, t5, .Ltdd_1559\n" ++
+  "  li t5, 3\n" ++
+  "  beq t1, t5, .Ltdd_4844\n" ++
+  "  li t5, 4\n" ++
+  "  beq t1, t5, .Ltdd_7702\n" ++
+  "  j .Ltdd_unrec\n" ++
+  ".Ltdd_legacy:\n" ++
+  "  mv a0, s0; mv a1, s1; mv a2, s2\n" ++
+  "  jal ra, tx_legacy_decode\n" ++
+  "  bnez a0, .Ltdd_decode_fail_legacy\n" ++
+  "  li a0, 0\n" ++
+  "  j .Ltdd_ret\n" ++
+  ".Ltdd_2930:\n" ++
+  "  mv a0, t3; mv a1, t4; mv a2, s2\n" ++
+  "  jal ra, tx_eip2930_decode\n" ++
+  "  bnez a0, .Ltdd_decode_fail_2930\n" ++
+  "  li a0, 0x0100\n" ++
+  "  j .Ltdd_ret\n" ++
+  ".Ltdd_1559:\n" ++
+  "  mv a0, t3; mv a1, t4; mv a2, s2\n" ++
+  "  jal ra, tx_eip1559_decode\n" ++
+  "  bnez a0, .Ltdd_decode_fail_1559\n" ++
+  "  li a0, 0x0200\n" ++
+  "  j .Ltdd_ret\n" ++
+  ".Ltdd_4844:\n" ++
+  "  mv a0, t3; mv a1, t4; mv a2, s2\n" ++
+  "  jal ra, tx_eip4844_decode\n" ++
+  "  bnez a0, .Ltdd_decode_fail_4844\n" ++
+  "  li a0, 0x0300\n" ++
+  "  j .Ltdd_ret\n" ++
+  ".Ltdd_7702:\n" ++
+  "  mv a0, t3; mv a1, t4; mv a2, s2\n" ++
+  "  jal ra, tx_eip7702_decode\n" ++
+  "  bnez a0, .Ltdd_decode_fail_7702\n" ++
+  "  li a0, 0x0400\n" ++
+  "  j .Ltdd_ret\n" ++
+  ".Ltdd_unrec:\n" ++
+  "  li a0, 0x0001\n" ++
+  "  j .Ltdd_ret\n" ++
+  ".Ltdd_decode_fail_legacy:\n" ++
+  "  li a0, 0x0002\n" ++
+  "  j .Ltdd_ret\n" ++
+  ".Ltdd_decode_fail_2930:\n" ++
+  "  li a0, 0x0102\n" ++
+  "  j .Ltdd_ret\n" ++
+  ".Ltdd_decode_fail_1559:\n" ++
+  "  li a0, 0x0202\n" ++
+  "  j .Ltdd_ret\n" ++
+  ".Ltdd_decode_fail_4844:\n" ++
+  "  li a0, 0x0302\n" ++
+  "  j .Ltdd_ret\n" ++
+  ".Ltdd_decode_fail_7702:\n" ++
+  "  li a0, 0x0402\n" ++
+  ".Ltdd_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp)\n" ++
+  "  addi sp, sp, 32\n" ++
+  "  ret"
+
+/-- `zisk_tx_decode_dispatch`: probe BuildUnit. Reads (env_len,
+    env_bytes) from host input; pre-zeros 248-byte struct slot
+    at OUTPUT+8; calls helper; writes (packed status, struct)
+    to OUTPUT (256 bytes total). -/
+def ziskTxDecodeDispatchPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a3, 0x40000000\n" ++
+  "  ld a1, 8(a3)                # env_len\n" ++
+  "  addi a0, a3, 16             # env ptr\n" ++
+  "  li a2, 0xa0010008           # struct slot at OUTPUT + 8\n" ++
+  "  # Pre-zero 248 bytes (31 dwords).\n" ++
+  "  mv t0, a2; li t1, 31\n" ++
+  ".Ltdd_zout:\n" ++
+  "  beqz t1, .Ltdd_zout_done\n" ++
+  "  sd zero, 0(t0)\n" ++
+  "  addi t0, t0, 8\n" ++
+  "  addi t1, t1, -1\n" ++
+  "  j .Ltdd_zout\n" ++
+  ".Ltdd_zout_done:\n" ++
+  "  jal ra, tx_decode_dispatch\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)                # packed status\n" ++
+  "  j .Ltdd_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpFieldToU64Function ++ "\n" ++
+  rlpFieldToU256BeFunction ++ "\n" ++
+  txTypeDispatchFunction ++ "\n" ++
+  txLegacyDecodeFunction ++ "\n" ++
+  txEip2930DecodeFunction ++ "\n" ++
+  txEip1559DecodeFunction ++ "\n" ++
+  txEip4844DecodeFunction ++ "\n" ++
+  txEip7702DecodeFunction ++ "\n" ++
+  txDecodeDispatchFunction ++ "\n" ++
+  ".Ltdd_pdone:"
+
+def ziskTxDecodeDispatchDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "rfu_offset:\n" ++
+  "  .zero 8\n" ++
+  "rfu_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "txd_offset:\n" ++
+  "  .zero 8\n" ++
+  "txd_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "t1d_offset:\n" ++
+  "  .zero 8\n" ++
+  "t1d_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "t29_offset:\n" ++
+  "  .zero 8\n" ++
+  "t29_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "t48_offset:\n" ++
+  "  .zero 8\n" ++
+  "t48_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "t77_offset:\n" ++
+  "  .zero 8\n" ++
+  "t77_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "tdd_type:\n" ++
+  "  .zero 8\n" ++
+  "tdd_inner_off:\n" ++
+  "  .zero 8"
+
+def ziskTxDecodeDispatchProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskTxDecodeDispatchPrologue
+  dataAsm     := ziskTxDecodeDispatchDataSection
+}
+
 /-! ## tx_eip4844_compute_blob_gas -- PR-K88
 
     Given an EIP-4844 (type 3) tx inner RLP body, decode it and
@@ -10923,9 +11127,9 @@ def ziskBlockBodyBlobGasTotalPrologue : String :=
   "  j .Lbbbgt_pdone\n" ++
   rlpListNthItemFunction ++ "\n" ++
   rlpListCountItemsFunction ++ "\n" ++
+  txTypeDispatchFunction ++ "\n" ++
   rlpFieldToU64Function ++ "\n" ++
   rlpFieldToU256BeFunction ++ "\n" ++
-  txTypeDispatchFunction ++ "\n" ++
   txEip4844DecodeFunction ++ "\n" ++
   blobGasUsedFromVersionedHashesFunction ++ "\n" ++
   txEip4844ComputeBlobGasFunction ++ "\n" ++
@@ -12267,6 +12471,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_tx_eip4844_decode"    => some ziskTxEip4844DecodeProbeUnit
   | "zisk_tx_eip4844_compute_blob_gas" => some ziskTxEip4844ComputeBlobGasProbeUnit
   | "zisk_block_body_blob_gas_total" => some ziskBlockBodyBlobGasTotalProbeUnit
+  | "zisk_tx_decode_dispatch"   => some ziskTxDecodeDispatchProbeUnit
   | "zisk_intrinsic_gas_legacy" => some ziskIntrinsicGasLegacyProbeUnit
   | "zisk_tx_validate_intrinsic_gas_legacy" => some ziskTxValidateIntrinsicGasLegacyProbeUnit
   | "zisk_validate_transaction_basic" => some ziskValidateTransactionBasicProbeUnit
@@ -12369,6 +12574,7 @@ def knownProgramNames : List String :=
    "zisk_tx_eip4844_decode",
    "zisk_tx_eip4844_compute_blob_gas",
    "zisk_block_body_blob_gas_total",
+   "zisk_tx_decode_dispatch",
    "zisk_intrinsic_gas_legacy",
    "zisk_tx_validate_intrinsic_gas_legacy",
    "zisk_validate_transaction_basic",

--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -10762,6 +10762,218 @@ def ziskBlockSummaryProbeUnit : BuildUnit := {
   dataAsm     := ziskBlockSummaryDataSection
 }
 
+/-! ## block_body_blob_gas_total -- PR-K89
+
+    Sum blob_gas_used over all EIP-4844 (type 3) txs in a block body:
+
+      block.blob_gas_used = sum(
+        len(tx.blob_versioned_hashes) × GAS_PER_BLOB
+        for tx in block.transactions
+        if tx.type == 3
+      )
+
+    Useful for the consensus rule
+    `header.blob_gas_used == this sum` (post-Cancun).
+
+    Composes:
+      - PR-K83 `block_body_decode`            — split body
+      - PR-K47 `rlp_list_count_items`         — number of txs
+      - PR-K20 `rlp_list_nth_item`            — i-th tx bytes
+      - PR-K40 `tx_type_dispatch`             — typed-tx detector
+      - PR-K88 `tx_eip4844_compute_blob_gas`  — per-tx blob gas
+
+    Iteration policy: skip every non-type-3 tx without examining
+    its body. Pre-Cancun blocks (no type-3 txs) return 0 cleanly.
+
+    Status encoding (callers can floor(status/100) to identify
+    the failing step):
+
+      0          : success
+      1          : block_body_decode failed
+      101        : rlp_list_count_items failed
+      201        : rlp_list_nth_item failed
+      301        : tx_type_dispatch failed
+      401..402   : tx_eip4844_compute_blob_gas failed
+                   (1=K45 decode fail, 2=K64 sum fail)
+
+    Calling convention:
+      a0 (input)  : body_rlp ptr
+      a1 (input)  : body_rlp byte length
+      a2 (input)  : gas_per_blob (u64; 131072 on mainnet Cancun)
+      a3 (input)  : u64 out ptr (receives total blob_gas_used)
+      ra (input)  : return
+      a0 (output) : composite status code
+
+    Uses 48 bytes `.data` scratch (`bbbgt_struct`) plus the small
+    scratch buffers inherited from K88 / K83. -/
+def blockBodyBlobGasTotalFunction : String :=
+  "block_body_blob_gas_total:\n" ++
+  "  addi sp, sp, -80\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp); sd s7, 64(sp)\n" ++
+  "  mv s0, a0                   # body_rlp ptr\n" ++
+  "  mv s3, a2                   # gas_per_blob\n" ++
+  "  mv s4, a3                   # out ptr\n" ++
+  "  li s5, 0                    # total = 0\n" ++
+  "  # Step 1: block_body_decode → bbbgt_struct\n" ++
+  "  la a2, bbbgt_struct\n" ++
+  "  jal ra, block_body_decode\n" ++
+  "  bnez a0, .Lbbbgt_body_fail\n" ++
+  "  # Load txs sub-list bounds.\n" ++
+  "  la t0, bbbgt_struct\n" ++
+  "  ld t1, 0(t0)                # txs_offset\n" ++
+  "  ld s2, 8(t0)                # s2 = txs_length\n" ++
+  "  add s1, s0, t1              # s1 = absolute txs ptr\n" ++
+  "  # Step 2: tx_count = rlp_list_count_items(txs)\n" ++
+  "  mv a0, s1\n" ++
+  "  mv a1, s2\n" ++
+  "  la a2, bbbgt_count\n" ++
+  "  jal ra, rlp_list_count_items\n" ++
+  "  beqz a0, .Lbbbgt_loop_init\n" ++
+  "  li a0, 101\n" ++
+  "  j .Lbbbgt_ret\n" ++
+  ".Lbbbgt_loop_init:\n" ++
+  "  la t0, bbbgt_count\n" ++
+  "  ld s7, 0(t0)                # s7 = tx_count\n" ++
+  "  li s6, 0                    # s6 = i\n" ++
+  ".Lbbbgt_loop:\n" ++
+  "  beq s6, s7, .Lbbbgt_done\n" ++
+  "  # rlp_list_nth_item(s1, s2, s6, &item_off, &item_len)\n" ++
+  "  mv a0, s1\n" ++
+  "  mv a1, s2\n" ++
+  "  mv a2, s6\n" ++
+  "  la a3, bbbgt_item_off\n" ++
+  "  la a4, bbbgt_item_len\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  beqz a0, .Lbbbgt_after_nth\n" ++
+  "  li a0, 201\n" ++
+  "  j .Lbbbgt_ret\n" ++
+  ".Lbbbgt_after_nth:\n" ++
+  "  la t0, bbbgt_item_off\n" ++
+  "  ld t1, 0(t0)                # item_off\n" ++
+  "  la t0, bbbgt_item_len\n" ++
+  "  ld t2, 0(t0)                # item_len\n" ++
+  "  add t3, s1, t1              # tx_ptr = txs + item_off\n" ++
+  "  # tx_type_dispatch(tx_ptr, item_len, &type, &inner_off)\n" ++
+  "  mv a0, t3\n" ++
+  "  mv a1, t2\n" ++
+  "  la a2, bbbgt_type\n" ++
+  "  la a3, bbbgt_inner_off\n" ++
+  "  jal ra, tx_type_dispatch\n" ++
+  "  beqz a0, .Lbbbgt_after_dispatch\n" ++
+  "  li a0, 301\n" ++
+  "  j .Lbbbgt_ret\n" ++
+  ".Lbbbgt_after_dispatch:\n" ++
+  "  la t0, bbbgt_type\n" ++
+  "  ld t1, 0(t0)                # type\n" ++
+  "  li t4, 3\n" ++
+  "  bne t1, t4, .Lbbbgt_step\n" ++
+  "  # type 3: compute blob_gas\n" ++
+  "  la t0, bbbgt_item_off\n" ++
+  "  ld t1, 0(t0)                # item_off\n" ++
+  "  la t0, bbbgt_item_len\n" ++
+  "  ld t2, 0(t0)                # item_len\n" ++
+  "  la t0, bbbgt_inner_off\n" ++
+  "  ld t5, 0(t0)                # inner_off\n" ++
+  "  add t3, s1, t1\n" ++
+  "  add a0, t3, t5              # inner_ptr = tx_ptr + inner_off\n" ++
+  "  sub a1, t2, t5              # inner_len = item_len - inner_off\n" ++
+  "  mv a2, s3                   # gas_per_blob\n" ++
+  "  la a3, bbbgt_blob_gas\n" ++
+  "  jal ra, tx_eip4844_compute_blob_gas\n" ++
+  "  beqz a0, .Lbbbgt_after_blob\n" ++
+  "  li t0, 400\n" ++
+  "  add a0, a0, t0              # 1 → 401, 2 → 402\n" ++
+  "  j .Lbbbgt_ret\n" ++
+  ".Lbbbgt_after_blob:\n" ++
+  "  la t0, bbbgt_blob_gas\n" ++
+  "  ld t1, 0(t0)\n" ++
+  "  add s5, s5, t1              # total += blob_gas\n" ++
+  ".Lbbbgt_step:\n" ++
+  "  addi s6, s6, 1\n" ++
+  "  j .Lbbbgt_loop\n" ++
+  ".Lbbbgt_done:\n" ++
+  "  sd s5, 0(s4)                # *out = total\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lbbbgt_ret\n" ++
+  ".Lbbbgt_body_fail:\n" ++
+  "  li a0, 1\n" ++
+  ".Lbbbgt_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp); ld s7, 64(sp)\n" ++
+  "  addi sp, sp, 80\n" ++
+  "  ret"
+
+/-- `zisk_block_body_blob_gas_total`: probe BuildUnit. Reads
+    (body_len, gas_per_blob, body_bytes) from host input,
+    writes (status, total_blob_gas) to OUTPUT (16 bytes). -/
+def ziskBlockBodyBlobGasTotalPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a4, 0x40000000\n" ++
+  "  ld a1, 8(a4)                # body_len\n" ++
+  "  ld a2, 16(a4)               # gas_per_blob\n" ++
+  "  addi a0, a4, 24             # body ptr\n" ++
+  "  li a3, 0xa0010008           # out u64 ptr\n" ++
+  "  sd zero, 0(a3)\n" ++
+  "  jal ra, block_body_blob_gas_total\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)                # status\n" ++
+  "  j .Lbbbgt_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpListCountItemsFunction ++ "\n" ++
+  rlpFieldToU64Function ++ "\n" ++
+  rlpFieldToU256BeFunction ++ "\n" ++
+  txTypeDispatchFunction ++ "\n" ++
+  txEip4844DecodeFunction ++ "\n" ++
+  blobGasUsedFromVersionedHashesFunction ++ "\n" ++
+  txEip4844ComputeBlobGasFunction ++ "\n" ++
+  blockBodyDecodeFunction ++ "\n" ++
+  blockBodyBlobGasTotalFunction ++ "\n" ++
+  ".Lbbbgt_pdone:"
+
+def ziskBlockBodyBlobGasTotalDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "rfu_offset:\n" ++
+  "  .zero 8\n" ++
+  "rfu_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "t48_offset:\n" ++
+  "  .zero 8\n" ++
+  "t48_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "bgvh_count_scratch:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "tcbg_struct:\n" ++
+  "  .zero 248\n" ++
+  ".balign 8\n" ++
+  "bbbgt_struct:\n" ++
+  "  .zero 48\n" ++
+  ".balign 8\n" ++
+  "bbbgt_count:\n" ++
+  "  .zero 8\n" ++
+  "bbbgt_item_off:\n" ++
+  "  .zero 8\n" ++
+  "bbbgt_item_len:\n" ++
+  "  .zero 8\n" ++
+  "bbbgt_type:\n" ++
+  "  .zero 8\n" ++
+  "bbbgt_inner_off:\n" ++
+  "  .zero 8\n" ++
+  "bbbgt_blob_gas:\n" ++
+  "  .zero 8"
+
+def ziskBlockBodyBlobGasTotalProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskBlockBodyBlobGasTotalPrologue
+  dataAsm     := ziskBlockBodyBlobGasTotalDataSection
+}
+
 
 /-! ## zisk_ssz_pair_hash — PR-S4 SSZ merkleization primitive
 
@@ -12054,6 +12266,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_tx_eip7702_decode"    => some ziskTxEip7702DecodeProbeUnit
   | "zisk_tx_eip4844_decode"    => some ziskTxEip4844DecodeProbeUnit
   | "zisk_tx_eip4844_compute_blob_gas" => some ziskTxEip4844ComputeBlobGasProbeUnit
+  | "zisk_block_body_blob_gas_total" => some ziskBlockBodyBlobGasTotalProbeUnit
   | "zisk_intrinsic_gas_legacy" => some ziskIntrinsicGasLegacyProbeUnit
   | "zisk_tx_validate_intrinsic_gas_legacy" => some ziskTxValidateIntrinsicGasLegacyProbeUnit
   | "zisk_validate_transaction_basic" => some ziskValidateTransactionBasicProbeUnit
@@ -12155,6 +12368,7 @@ def knownProgramNames : List String :=
    "zisk_tx_eip7702_decode",
    "zisk_tx_eip4844_decode",
    "zisk_tx_eip4844_compute_blob_gas",
+   "zisk_block_body_blob_gas_total",
    "zisk_intrinsic_gas_legacy",
    "zisk_tx_validate_intrinsic_gas_legacy",
    "zisk_validate_transaction_basic",

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **109**
-- ziskemu round-trip scripts: **102** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **112**
+- ziskemu round-trip scripts: **105** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-block-body-blob-gas-total-check.sh
+++ b/scripts/codegen-zisk-block-body-blob-gas-total-check.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# codegen-zisk-block-body-blob-gas-total-check.sh -- PR-K89.
+#
+# Sum blob_gas_used over all EIP-4844 txs in a block body.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_block_body_blob_gas_total ELF"
+lake exe codegen --program zisk_block_body_blob_gas_total --halt linux93 \
+  -o gen-out/zisk_block_body_blob_gas_total
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <tx_spec_json> <gas_per_blob>
+# tx_spec_json: list of {"type": "legacy"|"eip4844", "blobs": N} entries.
+run_case() {
+  local name="$1" spec="$2" gpb="$3"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_block_body_blob_gas_total_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_block_body_blob_gas_total_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import json, struct, sys, rlp
+spec = json.loads('''$spec''')
+gpb = $gpb
+ALICE = bytes([0xaa]*20)
+R = int.from_bytes(bytes([0x11]*32), 'big')
+S = int.from_bytes(bytes([0x22]*32), 'big')
+
+txs = []
+total = 0
+for entry in spec:
+    if entry['type'] == 'legacy':
+        # legacy tx, RLP list
+        tx = [1, 10**9, 21000, ALICE, 10**18, b'', 27, R, S]
+        txs.append(tx)
+    elif entry['type'] == 'eip4844':
+        n = entry['blobs']
+        H = bytes([0x01] + [0xab]*31)
+        inner = [
+            1, 7, 10**9, 2*10**9, 21000,
+            ALICE, 10**18, b'', [],
+            1, [H]*n, 0,
+            R, S,
+        ]
+        inner_rlp = rlp.encode(inner)
+        # Typed tx is encoded in outer list as a byte string [0x03 || inner]
+        typed_bytes = b'\x03' + inner_rlp
+        txs.append(typed_bytes)
+        total += n * gpb
+    else:
+        raise ValueError(entry['type'])
+
+# Block body = [transactions, ommers, withdrawals]
+body = [txs, [], []]
+body_rlp = rlp.encode(body)
+
+with open(sys.argv[1], 'wb') as f:
+    f.write(struct.pack('<Q', len(body_rlp)))
+    f.write(struct.pack('<Q', gpb))
+    f.write(body_rlp)
+    pad = (-(16 + len(body_rlp))) % 8
+    if pad: f.write(b'\x00' * pad)
+
+with open(sys.argv[1] + '.expected.txt', 'w') as f:
+    f.write(str(total))
+" "$in_file"
+
+  local expected; expected="$(cat "$in_file.expected.txt")"
+
+  "$ZISKEMU" -e gen-out/zisk_block_body_blob_gas_total.elf \
+    -i "$in_file" -o "$out_file" -n 5000000 \
+    >"$REPO_ROOT/gen-out/zisk_block_body_blob_gas_total_${name}.emu.log" 2>&1 || true
+
+  local actual_status; actual_status="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local actual_total; actual_total="$(dd if="$out_file" bs=1 skip=8 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local exp_le; exp_le="$(python3 -c "print(int('$expected').to_bytes(8, 'little').hex())")"
+
+  if [[ "$actual_status" == "0000000000000000" && "$actual_total" == "$exp_le" ]]; then
+    printf "  %-32s OK   total=%s\n" "$name" "$expected"
+    return 0
+  else
+    printf "  %-32s FAIL status=0x%s total=0x%s (expected %s)\n" "$name" "$actual_status" "$actual_total" "$expected"
+    return 1
+  fi
+}
+
+GPB=131072
+
+FAILED=0
+run_case "empty"                     "[]"                                                "$GPB" || FAILED=1
+run_case "only_legacy"               '[{"type":"legacy"}]'                               "$GPB" || FAILED=1
+run_case "only_two_legacy"           '[{"type":"legacy"},{"type":"legacy"}]'             "$GPB" || FAILED=1
+run_case "one_eip4844_one_blob"      '[{"type":"eip4844","blobs":1}]'                    "$GPB" || FAILED=1
+run_case "one_eip4844_six_blobs"     '[{"type":"eip4844","blobs":6}]'                    "$GPB" || FAILED=1
+run_case "two_eip4844_mixed"         '[{"type":"eip4844","blobs":2},{"type":"eip4844","blobs":4}]' "$GPB" || FAILED=1
+run_case "mixed_legacy_and_blob"     '[{"type":"legacy"},{"type":"eip4844","blobs":3},{"type":"legacy"}]' "$GPB" || FAILED=1
+run_case "interleaved_three_eip4844" '[{"type":"eip4844","blobs":1},{"type":"legacy"},{"type":"eip4844","blobs":2},{"type":"legacy"},{"type":"eip4844","blobs":1}]' "$GPB" || FAILED=1
+run_case "custom_gpb"                '[{"type":"eip4844","blobs":3}]'                    1000   || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: block_body_blob_gas_total = sum over type-3 txs"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Sum `blob_gas_used` over all EIP-4844 (type 3) txs in a block body:

```
block.blob_gas_used = sum(
  len(tx.blob_versioned_hashes) * GAS_PER_BLOB
  for tx in block.transactions
  if tx.type == 3
)
```

Useful for the consensus rule `header.blob_gas_used == this sum`
(post-Cancun).

Composes:
- PR-K83 `block_body_decode`            — split body
- PR-K47 `rlp_list_count_items`         — number of txs
- PR-K20 `rlp_list_nth_item`            — i-th tx bytes
- PR-K40 `tx_type_dispatch`             — typed-tx detector
- PR-K88 `tx_eip4844_compute_blob_gas`  — per-tx blob gas

Iterates the txs sub-list, dispatches by type byte, and accumulates
blob gas only for type-3 entries. Skips legacy and other typed txs
without examining their bodies. Pre-Cancun blocks with no type-3 txs
return 0 cleanly.

Status decade encoding (`floor(status/100)` identifies the failing
step):
- `0` : success
- `1` : `block_body_decode` failed
- `101` : `rlp_list_count_items` failed
- `201` : `rlp_list_nth_item` failed
- `301` : `tx_type_dispatch` failed
- `401..402` : `tx_eip4844_compute_blob_gas` forwarded (1=K45 decode, 2=K64 sum)

**Stacked on #5832 (PR-K88).** Base will retarget to `main` once K88 merges.

## Test plan

- [x] `scripts/codegen-zisk-block-body-blob-gas-total-check.sh` passes
  9 fixtures: empty, all-legacy, single + multi type-3, and interleaved
  legacy/blob combinations, plus a custom `gas_per_blob` fixture
- [x] `lake build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)