### PR TITLE
feat(divmod): expose call addback runtime theorem

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/CallAddback.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/CallAddback.lean
@@ -993,12 +993,16 @@ theorem n4CallAddbackBeqQOutV4_toNat_eq_qTrue_qHatBranchEqQTrue {a b : EvmWord}
 
 /-- V4 semantic-correctness precondition for the n=4 call+addback-BEQ sub-path.
 
-    This is the v4 migration target for `n4CallAddbackBeqSemanticHolds`: it uses
-    the fully corrected `div128Quot_v4` trial quotient. The closure theorem
-    `n4CallAddbackBeqSemanticHolds_of_runtime_conditions` should target this
-    quotient surface and then retire the legacy v1 marker. -/
+    This is the named quotient-output surface for the repaired
+    `n4CallAddbackBeqSemanticHolds` marker. Both predicates use the fully
+    corrected `div128Quot_v4` trial quotient; the runtime-condition closure is
+    exported under the non-`V4` historical name in `CallAddbackRuntime.lean`. -/
 def n4CallAddbackBeqSemanticHoldsV4 (a b : EvmWord) : Prop :=
   (n4CallAddbackBeqQOutV4 a b).toNat = n4CallAddbackBeqQTrue a b
+
+theorem n4CallAddbackBeqSemanticHolds_eq_v4 {a b : EvmWord} :
+    n4CallAddbackBeqSemanticHolds a b = n4CallAddbackBeqSemanticHoldsV4 a b :=
+  rfl
 
 theorem n4CallAddbackBeqSemanticV4_unfold {a b : EvmWord} :
     n4CallAddbackBeqSemanticHoldsV4 a b =

--- a/EvmAsm/Evm64/DivMod/Spec/CallAddbackRuntime.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/CallAddbackRuntime.lean
@@ -667,19 +667,6 @@ theorem n4CallAddbackBeqSemanticHoldsV4_of_runtime_bounds
   n4CallAddbackBeqSemanticHoldsV4_of_runtime_conditions_compact
     hb3nz hshift_nz h_bounds.1 h_borrow h_carry2 h_bounds.2
 
-/-- Named v4 closure surface for the call-addback semantic predicate. The
-    remaining arithmetic is isolated in `n4CallAddbackBeqRuntimeBounds`. -/
-theorem n4CallAddbackBeqSemanticHolds_of_runtime_conditions
-    {a b : EvmWord}
-    (hb3nz : b.getLimbN 3 ≠ 0)
-    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
-    (h_bounds : n4CallAddbackBeqRuntimeBounds a b)
-    (h_borrow : isAddbackBorrowN4CallV4Evm a b)
-    (h_carry2 : isAddbackCarry2NzN4CallV4Evm a b) :
-    n4CallAddbackBeqSemanticHoldsV4 a b :=
-  n4CallAddbackBeqSemanticHoldsV4_of_runtime_bounds
-    hb3nz hshift_nz h_bounds h_borrow h_carry2
-
 end EvmWord
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/CallAddbackRuntime.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/CallAddbackRuntime.lean
@@ -609,6 +609,32 @@ theorem n4CallAddbackBeqSemanticHoldsV4_of_runtime_conditions
     hb3nz hq_over h_borrow h_carry2 h_rem_lt
     (n4CallAddbackBeqNormalized_div_eq_qTrue hshift_nz)
 
+/-- Historical non-`V4` spelling of the runtime-condition closure for the
+    repaired n=4 call+addback-BEQ semantic marker. -/
+theorem n4CallAddbackBeqSemanticHolds_of_runtime_conditions
+    {a b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (hq_over :
+      (n4CallAddbackBeqQHatV4 a b).toNat ≤
+        EvmWord.val256
+          (n4CallAddbackBeqU0 a b)
+          (n4CallAddbackBeqU1 a b)
+          (n4CallAddbackBeqU2 a b)
+          (n4CallAddbackBeqU3 a b) /
+          EvmWord.val256
+            (n4CallAddbackBeqB0Prime b)
+            (n4CallAddbackBeqB1Prime b)
+            (n4CallAddbackBeqB2Prime b)
+            (n4CallAddbackBeqB3Prime b) + 1)
+    (h_borrow : isAddbackBorrowN4CallV4Evm a b)
+    (h_carry2 : isAddbackCarry2NzN4CallV4Evm a b)
+    (h_rem_lt : n4CallAddbackBeqIterRNormVal a b < n4CallAddbackBeqBNormVal b) :
+    n4CallAddbackBeqSemanticHolds a b := by
+  simpa [n4CallAddbackBeqSemanticHolds_eq_v4] using
+    n4CallAddbackBeqSemanticHoldsV4_of_runtime_conditions
+      hb3nz hshift_nz hq_over h_borrow h_carry2 h_rem_lt
+
 /-- Compact runtime-condition semantic bridge with the qhat-over side
     condition stated using named normalized values. -/
 theorem n4CallAddbackBeqSemanticHoldsV4_of_runtime_conditions_compact


### PR DESCRIPTION
## Summary
- add n4CallAddbackBeqSemanticHolds_eq_v4, documenting that the historical marker now matches the repaired v4 quotient-output predicate
- expose the exact historical-name runtime closure theorem n4CallAddbackBeqSemanticHolds_of_runtime_conditions
- update the stale v4 predicate comment to point at the exported non-V4 theorem

## Verification
- lake build EvmAsm.Evm64.DivMod
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- forbidden-pattern scan on touched DivMod files: no matches