### PR TITLE
feat(stateless): block_validate_blob_gas_consistency (PR-K91)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -9179,6 +9179,210 @@ def ziskTxEip4844DecodeProbeUnit : BuildUnit := {
   dataAsm     := ziskTxEip4844DecodeDataSection
 }
 
+/-! ## tx_decode_dispatch -- PR-K87 unified tx decoder
+
+    Dispatch on a tx envelope's type byte and route to the
+    appropriate inner decoder. Mirrors Python's
+    `decode_transaction`:
+
+      byte 0 ≥ 0xc0     → legacy        → tx_legacy_decode    (K36)
+      byte 0 == 0x01    → EIP-2930      → tx_eip2930_decode   (K42)
+      byte 0 == 0x02    → EIP-1559      → tx_eip1559_decode   (K41)
+      byte 0 == 0x03    → EIP-4844      → tx_eip4844_decode   (K45)
+      byte 0 == 0x04    → EIP-7702      → tx_eip7702_decode   (K44)
+      else              → status = type-unrecognized
+
+    The decoded struct's size depends on the tx type:
+      type 0 (legacy)   : 196 B
+      type 1 (EIP-2930) : 216 B
+      type 2 (EIP-1559) : 248 B
+      type 3 (EIP-4844) : 248 B
+      type 4 (EIP-7702) : 240 B
+
+    Status encoding packs both the tx_type and sub-status:
+
+      status = (tx_type << 8) | sub_status
+
+      sub_status 0  : success
+      sub_status 1  : type unrecognized (used with tx_type=0)
+      sub_status 2  : sub-decoder returned non-zero
+
+    Caller responsibilities:
+      - Pre-zero the 248-byte struct_out buffer.
+      - After success, infer struct_size from `tx_type` extracted
+        as `(status >> 8) & 0xff`.
+
+    Composes PR-K40 + each of K36, K41, K42, K44, K45.
+
+    Calling convention:
+      a0 (input)  : envelope ptr
+      a1 (input)  : envelope_len
+      a2 (input)  : struct_out ptr (must be ≥ 248 bytes, pre-zeroed)
+      ra (input)  : return
+      a0 (output) : packed status (see encoding above).
+
+    Uses 8 bytes of `.data` scratch (`tdd_inner_off`) plus the
+    inner-decoder scratches (rfu_offset/rfu_length etc.). -/
+def txDecodeDispatchFunction : String :=
+  "tx_decode_dispatch:\n" ++
+  "  addi sp, sp, -32\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp)\n" ++
+  "  mv s0, a0                   # envelope ptr\n" ++
+  "  mv s1, a1                   # envelope_len\n" ++
+  "  mv s2, a2                   # struct_out ptr\n" ++
+  "  # tx_type_dispatch(envelope, len, type_out=tdd_type, inner_offset_out=tdd_inner_off)\n" ++
+  "  la a2, tdd_type\n" ++
+  "  la a3, tdd_inner_off\n" ++
+  "  jal ra, tx_type_dispatch\n" ++
+  "  bnez a0, .Ltdd_unrec\n" ++
+  "  la t0, tdd_type; ld t1, 0(t0)\n" ++
+  "  la t0, tdd_inner_off; ld t2, 0(t0)\n" ++
+  "  add t3, s0, t2              # inner_ptr\n" ++
+  "  sub t4, s1, t2              # inner_len\n" ++
+  "  # Dispatch on tx_type (t1)\n" ++
+  "  beqz t1, .Ltdd_legacy\n" ++
+  "  li t5, 1\n" ++
+  "  beq t1, t5, .Ltdd_2930\n" ++
+  "  li t5, 2\n" ++
+  "  beq t1, t5, .Ltdd_1559\n" ++
+  "  li t5, 3\n" ++
+  "  beq t1, t5, .Ltdd_4844\n" ++
+  "  li t5, 4\n" ++
+  "  beq t1, t5, .Ltdd_7702\n" ++
+  "  j .Ltdd_unrec\n" ++
+  ".Ltdd_legacy:\n" ++
+  "  mv a0, s0; mv a1, s1; mv a2, s2\n" ++
+  "  jal ra, tx_legacy_decode\n" ++
+  "  bnez a0, .Ltdd_decode_fail_legacy\n" ++
+  "  li a0, 0\n" ++
+  "  j .Ltdd_ret\n" ++
+  ".Ltdd_2930:\n" ++
+  "  mv a0, t3; mv a1, t4; mv a2, s2\n" ++
+  "  jal ra, tx_eip2930_decode\n" ++
+  "  bnez a0, .Ltdd_decode_fail_2930\n" ++
+  "  li a0, 0x0100\n" ++
+  "  j .Ltdd_ret\n" ++
+  ".Ltdd_1559:\n" ++
+  "  mv a0, t3; mv a1, t4; mv a2, s2\n" ++
+  "  jal ra, tx_eip1559_decode\n" ++
+  "  bnez a0, .Ltdd_decode_fail_1559\n" ++
+  "  li a0, 0x0200\n" ++
+  "  j .Ltdd_ret\n" ++
+  ".Ltdd_4844:\n" ++
+  "  mv a0, t3; mv a1, t4; mv a2, s2\n" ++
+  "  jal ra, tx_eip4844_decode\n" ++
+  "  bnez a0, .Ltdd_decode_fail_4844\n" ++
+  "  li a0, 0x0300\n" ++
+  "  j .Ltdd_ret\n" ++
+  ".Ltdd_7702:\n" ++
+  "  mv a0, t3; mv a1, t4; mv a2, s2\n" ++
+  "  jal ra, tx_eip7702_decode\n" ++
+  "  bnez a0, .Ltdd_decode_fail_7702\n" ++
+  "  li a0, 0x0400\n" ++
+  "  j .Ltdd_ret\n" ++
+  ".Ltdd_unrec:\n" ++
+  "  li a0, 0x0001\n" ++
+  "  j .Ltdd_ret\n" ++
+  ".Ltdd_decode_fail_legacy:\n" ++
+  "  li a0, 0x0002\n" ++
+  "  j .Ltdd_ret\n" ++
+  ".Ltdd_decode_fail_2930:\n" ++
+  "  li a0, 0x0102\n" ++
+  "  j .Ltdd_ret\n" ++
+  ".Ltdd_decode_fail_1559:\n" ++
+  "  li a0, 0x0202\n" ++
+  "  j .Ltdd_ret\n" ++
+  ".Ltdd_decode_fail_4844:\n" ++
+  "  li a0, 0x0302\n" ++
+  "  j .Ltdd_ret\n" ++
+  ".Ltdd_decode_fail_7702:\n" ++
+  "  li a0, 0x0402\n" ++
+  ".Ltdd_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp)\n" ++
+  "  addi sp, sp, 32\n" ++
+  "  ret"
+
+/-- `zisk_tx_decode_dispatch`: probe BuildUnit. Reads (env_len,
+    env_bytes) from host input; pre-zeros 248-byte struct slot
+    at OUTPUT+8; calls helper; writes (packed status, struct)
+    to OUTPUT (256 bytes total). -/
+def ziskTxDecodeDispatchPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a3, 0x40000000\n" ++
+  "  ld a1, 8(a3)                # env_len\n" ++
+  "  addi a0, a3, 16             # env ptr\n" ++
+  "  li a2, 0xa0010008           # struct slot at OUTPUT + 8\n" ++
+  "  # Pre-zero 248 bytes (31 dwords).\n" ++
+  "  mv t0, a2; li t1, 31\n" ++
+  ".Ltdd_zout:\n" ++
+  "  beqz t1, .Ltdd_zout_done\n" ++
+  "  sd zero, 0(t0)\n" ++
+  "  addi t0, t0, 8\n" ++
+  "  addi t1, t1, -1\n" ++
+  "  j .Ltdd_zout\n" ++
+  ".Ltdd_zout_done:\n" ++
+  "  jal ra, tx_decode_dispatch\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)                # packed status\n" ++
+  "  j .Ltdd_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpFieldToU64Function ++ "\n" ++
+  rlpFieldToU256BeFunction ++ "\n" ++
+  txTypeDispatchFunction ++ "\n" ++
+  txLegacyDecodeFunction ++ "\n" ++
+  txEip2930DecodeFunction ++ "\n" ++
+  txEip1559DecodeFunction ++ "\n" ++
+  txEip4844DecodeFunction ++ "\n" ++
+  txEip7702DecodeFunction ++ "\n" ++
+  txDecodeDispatchFunction ++ "\n" ++
+  ".Ltdd_pdone:"
+
+def ziskTxDecodeDispatchDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "rfu_offset:\n" ++
+  "  .zero 8\n" ++
+  "rfu_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "txd_offset:\n" ++
+  "  .zero 8\n" ++
+  "txd_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "t1d_offset:\n" ++
+  "  .zero 8\n" ++
+  "t1d_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "t29_offset:\n" ++
+  "  .zero 8\n" ++
+  "t29_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "t48_offset:\n" ++
+  "  .zero 8\n" ++
+  "t48_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "t77_offset:\n" ++
+  "  .zero 8\n" ++
+  "t77_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "tdd_type:\n" ++
+  "  .zero 8\n" ++
+  "tdd_inner_off:\n" ++
+  "  .zero 8"
+
+def ziskTxDecodeDispatchProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskTxDecodeDispatchPrologue
+  dataAsm     := ziskTxDecodeDispatchDataSection
+}
+
 /-! ## tx_eip4844_compute_blob_gas -- PR-K88
 
     Given an EIP-4844 (type 3) tx inner RLP body, decode it and
@@ -10923,9 +11127,9 @@ def ziskBlockBodyBlobGasTotalPrologue : String :=
   "  j .Lbbbgt_pdone\n" ++
   rlpListNthItemFunction ++ "\n" ++
   rlpListCountItemsFunction ++ "\n" ++
+  txTypeDispatchFunction ++ "\n" ++
   rlpFieldToU64Function ++ "\n" ++
   rlpFieldToU256BeFunction ++ "\n" ++
-  txTypeDispatchFunction ++ "\n" ++
   txEip4844DecodeFunction ++ "\n" ++
   blobGasUsedFromVersionedHashesFunction ++ "\n" ++
   txEip4844ComputeBlobGasFunction ++ "\n" ++
@@ -11144,6 +11348,7 @@ def ziskBlockValidateBlobGasConsistencyProbeUnit : BuildUnit := {
   prologueAsm := ziskBlockValidateBlobGasConsistencyPrologue
   dataAsm     := ziskBlockValidateBlobGasConsistencyDataSection
 }
+
 
 
 /-! ## zisk_ssz_pair_hash — PR-S4 SSZ merkleization primitive
@@ -12439,6 +12644,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_tx_eip4844_compute_blob_gas" => some ziskTxEip4844ComputeBlobGasProbeUnit
   | "zisk_block_body_blob_gas_total" => some ziskBlockBodyBlobGasTotalProbeUnit
   | "zisk_block_validate_blob_gas_consistency" => some ziskBlockValidateBlobGasConsistencyProbeUnit
+  | "zisk_tx_decode_dispatch"   => some ziskTxDecodeDispatchProbeUnit
   | "zisk_intrinsic_gas_legacy" => some ziskIntrinsicGasLegacyProbeUnit
   | "zisk_tx_validate_intrinsic_gas_legacy" => some ziskTxValidateIntrinsicGasLegacyProbeUnit
   | "zisk_validate_transaction_basic" => some ziskValidateTransactionBasicProbeUnit
@@ -12542,6 +12748,7 @@ def knownProgramNames : List String :=
    "zisk_tx_eip4844_compute_blob_gas",
    "zisk_block_body_blob_gas_total",
    "zisk_block_validate_blob_gas_consistency",
+   "zisk_tx_decode_dispatch",
    "zisk_intrinsic_gas_legacy",
    "zisk_tx_validate_intrinsic_gas_legacy",
    "zisk_validate_transaction_basic",

--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -10974,6 +10974,177 @@ def ziskBlockBodyBlobGasTotalProbeUnit : BuildUnit := {
   dataAsm     := ziskBlockBodyBlobGasTotalDataSection
 }
 
+/-! ## block_validate_blob_gas_consistency -- PR-K91
+
+    Cancun-era consensus rule: the value of `header.blob_gas_used`
+    must equal the sum of per-tx blob gas across the block's body.
+
+      header.blob_gas_used == sum(
+        len(tx.blob_versioned_hashes) × GAS_PER_BLOB
+        for tx in block.transactions
+        if tx.type == 3
+      )
+
+    Composes:
+      - PR-K53 `rlp_field_to_u64`        — extract header field 17
+      - PR-K89 `block_body_blob_gas_total` — sum over body
+
+    The Python reference (`forks/amsterdam/fork.py`) enforces this
+    inside `apply_body`. This helper packages the check into a
+    single ECALL-shaped routine so callers don't need to thread
+    intermediate values through registers.
+
+    Calling convention:
+      a0 (input)  : header_rlp ptr
+      a1 (input)  : header_rlp byte length
+      a2 (input)  : body_rlp ptr
+      a3 (input)  : body_rlp byte length
+      a4 (input)  : gas_per_blob (u64; 131072 on mainnet Cancun)
+      ra (input)  : return
+      a0 (output) : composite status code
+
+    Status decade encoding (floor(status/100) identifies the
+    failing step):
+
+      0          : success — header.blob_gas_used == body total
+      1          : header parse / field 17 missing / not u64
+      2          : mismatch (header.blob_gas_used ≠ body total)
+      101        : body decode failed
+      201        : body rlp_list_count_items failed
+      301        : body rlp_list_nth_item failed
+      401        : body tx_type_dispatch failed
+      501..502   : body tx_eip4844_compute_blob_gas forwarded
+                   (501 = K45 decode, 502 = K64 sum)
+
+    Uses 32 bytes of `.data` scratch (`bvbgc_header_bgu` +
+    `bvbgc_body_total`) plus the scratch buffers inherited from
+    PR-K89 / K88 / K83. -/
+def blockValidateBlobGasConsistencyFunction : String :=
+  "block_validate_blob_gas_consistency:\n" ++
+  "  addi sp, sp, -32\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp)\n" ++
+  "  mv s0, a2                   # body_rlp ptr\n" ++
+  "  mv s1, a3                   # body_len\n" ++
+  "  mv s2, a4                   # gas_per_blob\n" ++
+  "  # Step 1: extract header.blob_gas_used (field 17, u64).\n" ++
+  "  # a0,a1 still hold (header_ptr, header_len).\n" ++
+  "  li a2, 17\n" ++
+  "  la a3, bvbgc_header_bgu\n" ++
+  "  jal ra, rlp_field_to_u64\n" ++
+  "  beqz a0, .Lbvbgc_step2\n" ++
+  "  li a0, 1\n" ++
+  "  j .Lbvbgc_ret\n" ++
+  ".Lbvbgc_step2:\n" ++
+  "  # Step 2: body total via K89.\n" ++
+  "  mv a0, s0\n" ++
+  "  mv a1, s1\n" ++
+  "  mv a2, s2                   # gas_per_blob\n" ++
+  "  la a3, bvbgc_body_total\n" ++
+  "  jal ra, block_body_blob_gas_total\n" ++
+  "  beqz a0, .Lbvbgc_compare\n" ++
+  "  # K89 returns: 1=body decode, 101=count, 201=nth, 301=dispatch,\n" ++
+  "  # 401..402=K88 forwarded. Re-map onto our 101+ decade space.\n" ++
+  "  li t0, 100\n" ++
+  "  add a0, a0, t0              # 1→101, 101→201, 201→301, 301→401,\n" ++
+  "                              # 401→501, 402→502\n" ++
+  "  j .Lbvbgc_ret\n" ++
+  ".Lbvbgc_compare:\n" ++
+  "  la t0, bvbgc_header_bgu\n" ++
+  "  ld t1, 0(t0)\n" ++
+  "  la t0, bvbgc_body_total\n" ++
+  "  ld t2, 0(t0)\n" ++
+  "  beq t1, t2, .Lbvbgc_ok\n" ++
+  "  li a0, 2\n" ++
+  "  j .Lbvbgc_ret\n" ++
+  ".Lbvbgc_ok:\n" ++
+  "  li a0, 0\n" ++
+  ".Lbvbgc_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp)\n" ++
+  "  addi sp, sp, 32\n" ++
+  "  ret"
+
+/-- `zisk_block_validate_blob_gas_consistency`: probe BuildUnit.
+    Input layout (LE u64s + variable bytes):
+      bytes  0.. 8 : header_len
+      bytes  8..16 : body_len
+      bytes 16..24 : gas_per_blob
+      bytes 24..   : header_rlp ‖ body_rlp (concatenated, no padding
+                     between)
+    OUTPUT layout (8 bytes):
+      bytes  0.. 8 : status code -/
+def ziskBlockValidateBlobGasConsistencyPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a5, 0x40000000\n" ++
+  "  ld a1, 8(a5)                # header_len\n" ++
+  "  ld a3, 16(a5)               # body_len\n" ++
+  "  ld a4, 24(a5)               # gas_per_blob\n" ++
+  "  addi a0, a5, 32             # header_ptr\n" ++
+  "  add a2, a0, a1              # body_ptr = header_ptr + header_len\n" ++
+  "  jal ra, block_validate_blob_gas_consistency\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)                # status\n" ++
+  "  j .Lbvbgc_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpListCountItemsFunction ++ "\n" ++
+  rlpFieldToU64Function ++ "\n" ++
+  rlpFieldToU256BeFunction ++ "\n" ++
+  txTypeDispatchFunction ++ "\n" ++
+  txEip4844DecodeFunction ++ "\n" ++
+  blobGasUsedFromVersionedHashesFunction ++ "\n" ++
+  txEip4844ComputeBlobGasFunction ++ "\n" ++
+  blockBodyDecodeFunction ++ "\n" ++
+  blockBodyBlobGasTotalFunction ++ "\n" ++
+  blockValidateBlobGasConsistencyFunction ++ "\n" ++
+  ".Lbvbgc_pdone:"
+
+def ziskBlockValidateBlobGasConsistencyDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "rfu_offset:\n" ++
+  "  .zero 8\n" ++
+  "rfu_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "t48_offset:\n" ++
+  "  .zero 8\n" ++
+  "t48_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "bgvh_count_scratch:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "tcbg_struct:\n" ++
+  "  .zero 248\n" ++
+  ".balign 8\n" ++
+  "bbbgt_struct:\n" ++
+  "  .zero 48\n" ++
+  ".balign 8\n" ++
+  "bbbgt_count:\n" ++
+  "  .zero 8\n" ++
+  "bbbgt_item_off:\n" ++
+  "  .zero 8\n" ++
+  "bbbgt_item_len:\n" ++
+  "  .zero 8\n" ++
+  "bbbgt_type:\n" ++
+  "  .zero 8\n" ++
+  "bbbgt_inner_off:\n" ++
+  "  .zero 8\n" ++
+  "bbbgt_blob_gas:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "bvbgc_header_bgu:\n" ++
+  "  .zero 8\n" ++
+  "bvbgc_body_total:\n" ++
+  "  .zero 8"
+
+def ziskBlockValidateBlobGasConsistencyProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskBlockValidateBlobGasConsistencyPrologue
+  dataAsm     := ziskBlockValidateBlobGasConsistencyDataSection
+}
+
 
 /-! ## zisk_ssz_pair_hash — PR-S4 SSZ merkleization primitive
 
@@ -12267,6 +12438,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_tx_eip4844_decode"    => some ziskTxEip4844DecodeProbeUnit
   | "zisk_tx_eip4844_compute_blob_gas" => some ziskTxEip4844ComputeBlobGasProbeUnit
   | "zisk_block_body_blob_gas_total" => some ziskBlockBodyBlobGasTotalProbeUnit
+  | "zisk_block_validate_blob_gas_consistency" => some ziskBlockValidateBlobGasConsistencyProbeUnit
   | "zisk_intrinsic_gas_legacy" => some ziskIntrinsicGasLegacyProbeUnit
   | "zisk_tx_validate_intrinsic_gas_legacy" => some ziskTxValidateIntrinsicGasLegacyProbeUnit
   | "zisk_validate_transaction_basic" => some ziskValidateTransactionBasicProbeUnit
@@ -12369,6 +12541,7 @@ def knownProgramNames : List String :=
    "zisk_tx_eip4844_decode",
    "zisk_tx_eip4844_compute_blob_gas",
    "zisk_block_body_blob_gas_total",
+   "zisk_block_validate_blob_gas_consistency",
    "zisk_intrinsic_gas_legacy",
    "zisk_tx_validate_intrinsic_gas_legacy",
    "zisk_validate_transaction_basic",

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **109**
-- ziskemu round-trip scripts: **102** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **113**
+- ziskemu round-trip scripts: **106** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-block-validate-blob-gas-consistency-check.sh
+++ b/scripts/codegen-zisk-block-validate-blob-gas-consistency-check.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# codegen-zisk-block-validate-blob-gas-consistency-check.sh -- PR-K91.
+#
+# Cancun consensus check: header.blob_gas_used == sum(tx blob gas).
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_block_validate_blob_gas_consistency ELF"
+lake exe codegen --program zisk_block_validate_blob_gas_consistency --halt linux93 \
+  -o gen-out/zisk_block_validate_blob_gas_consistency
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <header_bgu> <tx_spec_json> <gas_per_blob> <expected_status>
+run_case() {
+  local name="$1" hbgu="$2" spec="$3" gpb="$4" exp="$5"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_block_validate_blob_gas_consistency_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_block_validate_blob_gas_consistency_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import json, struct, sys, rlp
+hbgu = $hbgu
+spec = json.loads('''$spec''')
+gpb = $gpb
+ALICE = bytes([0xaa]*20)
+R = int.from_bytes(bytes([0x11]*32), 'big')
+S = int.from_bytes(bytes([0x22]*32), 'big')
+
+# Build header: 22 fields; only field 17 (blob_gas_used) varies.
+header_fields = [
+    bytes(32),                  # 0 parent_hash
+    bytes(32),                  # 1 ommers_hash
+    bytes(20),                  # 2 coinbase
+    bytes(32),                  # 3 state_root
+    bytes(32),                  # 4 transactions_root
+    bytes(32),                  # 5 receipt_root
+    bytes(256),                 # 6 bloom
+    0,                          # 7 difficulty
+    1,                          # 8 number
+    30_000_000,                 # 9 gas_limit
+    100_000,                    # 10 gas_used
+    1700000000,                 # 11 timestamp
+    b'',                        # 12 extra_data
+    bytes(32),                  # 13 prev_randao
+    bytes(8),                   # 14 nonce
+    10**9,                      # 15 base_fee_per_gas
+    bytes(32),                  # 16 withdrawals_root
+    hbgu,                       # 17 blob_gas_used
+    0,                          # 18 excess_blob_gas
+    bytes(32),                  # 19 parent_beacon_block_root
+    bytes(32),                  # 20 requests_hash
+    bytes(32),                  # 21 block_access_list_hash
+]
+header_rlp = rlp.encode(header_fields)
+
+# Build body.
+txs = []
+for entry in spec:
+    if entry['type'] == 'legacy':
+        tx = [1, 10**9, 21000, ALICE, 10**18, b'', 27, R, S]
+        txs.append(tx)
+    elif entry['type'] == 'eip4844':
+        n = entry['blobs']
+        H = bytes([0x01] + [0xab]*31)
+        inner = [
+            1, 7, 10**9, 2*10**9, 21000,
+            ALICE, 10**18, b'', [],
+            1, [H]*n, 0,
+            R, S,
+        ]
+        inner_rlp = rlp.encode(inner)
+        typed_bytes = b'\x03' + inner_rlp
+        txs.append(typed_bytes)
+    else:
+        raise ValueError(entry['type'])
+
+body_rlp = rlp.encode([txs, [], []])
+
+with open(sys.argv[1], 'wb') as f:
+    f.write(struct.pack('<Q', len(header_rlp)))
+    f.write(struct.pack('<Q', len(body_rlp)))
+    f.write(struct.pack('<Q', gpb))
+    f.write(header_rlp)
+    f.write(body_rlp)
+    total = 24 + len(header_rlp) + len(body_rlp)
+    pad = (-total) % 8
+    if pad: f.write(b'\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_block_validate_blob_gas_consistency.elf \
+    -i "$in_file" -o "$out_file" -n 5000000 \
+    >"$REPO_ROOT/gen-out/zisk_block_validate_blob_gas_consistency_${name}.emu.log" 2>&1 || true
+
+  local actual_status; actual_status="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local exp_status_le; exp_status_le="$(python3 -c "print(int('$exp').to_bytes(8, 'little').hex())")"
+
+  if [[ "$actual_status" == "$exp_status_le" ]]; then
+    printf "  %-40s OK   status=%d\n" "$name" "$exp"
+    return 0
+  else
+    printf "  %-40s FAIL status=0x%s expected=%d\n" "$name" "$actual_status" "$exp"
+    return 1
+  fi
+}
+
+GPB=131072
+
+FAILED=0
+# Match cases (status=0)
+run_case "empty_block_zero_bgu"          0 '[]'                                                "$GPB" 0 || FAILED=1
+run_case "legacy_only_zero_bgu"          0 '[{"type":"legacy"},{"type":"legacy"}]'              "$GPB" 0 || FAILED=1
+run_case "one_blob_match"                131072 '[{"type":"eip4844","blobs":1}]'               "$GPB" 0 || FAILED=1
+run_case "six_blob_match"                786432 '[{"type":"eip4844","blobs":6}]'               "$GPB" 0 || FAILED=1
+run_case "two_eip4844_mixed_match"       786432 '[{"type":"eip4844","blobs":2},{"type":"eip4844","blobs":4}]' "$GPB" 0 || FAILED=1
+run_case "legacy_and_blob_match"         393216 '[{"type":"legacy"},{"type":"eip4844","blobs":3}]' "$GPB" 0 || FAILED=1
+
+# Mismatch cases (status=2)
+run_case "mismatch_header_too_high"      262144 '[{"type":"eip4844","blobs":1}]'               "$GPB" 2 || FAILED=1
+run_case "mismatch_header_too_low"       0      '[{"type":"eip4844","blobs":1}]'               "$GPB" 2 || FAILED=1
+run_case "mismatch_off_by_one_blob"      262144 '[{"type":"eip4844","blobs":1}]'               "$GPB" 2 || FAILED=1
+run_case "mismatch_legacy_with_nonzero"  131072 '[{"type":"legacy"}]'                          "$GPB" 2 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: block_validate_blob_gas_consistency matches header to body sum"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Cancun-era consensus rule packaged into a single call:

```
header.blob_gas_used == sum(
  len(tx.blob_versioned_hashes) * GAS_PER_BLOB
  for tx in block.transactions
  if tx.type == 3
)
```

Composes:
- PR-K53 `rlp_field_to_u64`           — extract header field 17
- PR-K89 `block_body_blob_gas_total`  — sum over body

The Python reference (`forks/amsterdam/fork.py`) enforces this inside
`apply_body`. This helper bundles the check so callers don't need to
thread intermediate u64 values through registers.

Status decade encoding (`floor(status/100)` identifies failing step):
- `0`         : match — header.blob_gas_used == body total
- `1`         : header field 17 missing / not u64
- `2`         : mismatch
- `101`       : body decode failed
- `201`       : body `rlp_list_count_items` failed
- `301`       : body `rlp_list_nth_item` failed
- `401`       : body `tx_type_dispatch` failed
- `501..502`  : body `tx_eip4844_compute_blob_gas` forwarded

**Stacked on #5833 (PR-K89).** Base will retarget to `main` once K89 / K88 merge.

## Test plan

- [x] `scripts/codegen-zisk-block-validate-blob-gas-consistency-check.sh`
  passes 10 fixtures: 6 match cases (empty, all-legacy, single/multi
  type-3, mixed legacy+blob) + 4 mismatch cases (header too high/low,
  off-by-one blob, legacy-only block with nonzero header)
- [x] `lake build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)