### PR TITLE
feat(divmod): expose bzero callable exact frame

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -31,6 +31,7 @@ import EvmAsm.Evm64.DivMod.Spec.N3QuotientWord
 import EvmAsm.Evm64.DivMod.Spec.N3DivStackSpec
 import EvmAsm.Evm64.DivMod.Spec.Unified
 import EvmAsm.Evm64.DivMod.Spec.UnifiedExactNoNop
+import EvmAsm.Evm64.DivMod.Spec.UnifiedExactNoNopCallableFrame
 import EvmAsm.Evm64.DivMod.Spec.N1ExactV4
 import EvmAsm.Evm64.DivMod.Spec.DispatcherN1NoHdivWord
 import EvmAsm.Evm64.DivMod.Spec.DispatcherN2NoHdivWord

--- a/EvmAsm/Evm64/DivMod/Spec/UnifiedExactNoNopCallableFrame.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/UnifiedExactNoNopCallableFrame.lean
@@ -1,0 +1,33 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.UnifiedExactNoNopCallableFrame
+
+  Named exact-frame callable wrappers for no-NOP DIV dispatcher facts.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.UnifiedExactNoNop
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Zero-divisor branch of the no-NOP DIV dispatcher exposed through the
+    named exact-frame callable postcondition. -/
+theorem evm_div_stack_spec_bzero_noNop_preNoX1_callableExactFrame
+    (sp base : Word) (a b : EvmWord)
+    (x9Val raVal v2 v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratch_un0 : Word)
+    (hbz : b = 0) :
+    cpsTripleWithin unifiedDivBound base (base + nopOff) (divCode_noNop base)
+      (divModStackDispatchPreNoX1 sp a b
+        x9Val raVal v2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0)
+      (divStackDispatchPostCallableExactFrame sp a b raVal x9Val) := by
+  simpa [divStackDispatchPostCallableExactFrame_unfold] using
+    evm_div_stack_spec_bzero_noNop_preNoX1_callableExactPost
+      sp base a b x9Val raVal v2 v5 v6 v7 v10 v11
+      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      nMem shiftMem jMem retMem dMem dloMem scratch_un0 hbz
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add a public no-NOP DIV zero-divisor wrapper with the named divStackDispatchPostCallableExactFrame postcondition
- import the wrapper through the DivMod spec umbrella so callable proofs can consume it downstream

## Verification
- lake build EvmAsm.Evm64.DivMod EvmAsm.Evm64.SDiv
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- rg -n "DivStackSpecCase|ModStackSpecCase|SDivStackSpecCase|SModStackSpecCase|StackSpecCase|set_option maxRecDepth|set_option maxHeartbeats|sorry|admit" EvmAsm/Evm64/DivMod/Spec/UnifiedExactNoNopCallableFrame.lean EvmAsm/Evm64/DivMod/Spec.lean