### PR TITLE
feat(stateless): header_extract_block_roots (PR-K95)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -5771,6 +5771,146 @@ def ziskCoinbaseExtractFromHeaderProbeUnit : BuildUnit := {
   dataAsm     := ziskCoinbaseExtractFromHeaderDataSection
 }
 
+/-! ## header_extract_block_roots -- PR-K95
+
+    Extract the three remaining 32-byte root fields from an
+    Amsterdam header that the existing extended-decode helpers
+    don't cover:
+
+       0..32   transactions_root  (field 4)
+      32..64   receipt_root       (field 5)
+      64..96   withdrawals_root   (field 16)
+
+    Used by `validate_block_body` callers that cross-check the
+    body's tx/receipt/withdrawal MPT roots against the consensus-
+    layer commitment, and by the trie-rebuild path. The state_root
+    (field 3) is already covered by PR-K39 `header_extended_decode`;
+    `parent_hash` by PR-K17; `coinbase` by PR-K55.
+
+    Calling convention:
+      a0 (input)  : header_rlp ptr
+      a1 (input)  : header_rlp byte length
+      a2 (input)  : 96-byte output ptr (caller-supplied)
+      ra (input)  : return
+      a0 (output) :
+        0 : success
+        1 : field 4 (transactions_root) missing / not 32 B
+        2 : field 5 (receipt_root) missing / not 32 B
+        3 : field 16 (withdrawals_root) missing / not 32 B
+            (pre-Shanghai headers don't have this field)
+
+    Composes PR-K20 `rlp_list_nth_item`. Uses two 8-byte `.data`
+    scratch slots (`hebr_offset`, `hebr_length`). -/
+def headerExtractBlockRootsFunction : String :=
+  "header_extract_block_roots:\n" ++
+  "  addi sp, sp, -32\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp)\n" ++
+  "  mv s0, a0                  # header_rlp ptr\n" ++
+  "  mv s1, a1                  # header_len\n" ++
+  "  mv s2, a2                  # 96B output ptr\n" ++
+  "  # Field 4: transactions_root → out[0..32]\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 4\n" ++
+  "  la a3, hebr_offset; la a4, hebr_length\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lhebr_f4_fail\n" ++
+  "  la t0, hebr_length; ld t1, 0(t0)\n" ++
+  "  li t2, 32\n" ++
+  "  bne t1, t2, .Lhebr_f4_fail\n" ++
+  "  la t0, hebr_offset; ld t3, 0(t0); add t3, s0, t3\n" ++
+  "  ld t4,  0(t3); sd t4,  0(s2)\n" ++
+  "  ld t4,  8(t3); sd t4,  8(s2)\n" ++
+  "  ld t4, 16(t3); sd t4, 16(s2)\n" ++
+  "  ld t4, 24(t3); sd t4, 24(s2)\n" ++
+  "  # Field 5: receipt_root → out[32..64]\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 5\n" ++
+  "  la a3, hebr_offset; la a4, hebr_length\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lhebr_f5_fail\n" ++
+  "  la t0, hebr_length; ld t1, 0(t0)\n" ++
+  "  li t2, 32\n" ++
+  "  bne t1, t2, .Lhebr_f5_fail\n" ++
+  "  la t0, hebr_offset; ld t3, 0(t0); add t3, s0, t3\n" ++
+  "  addi t5, s2, 32\n" ++
+  "  ld t4,  0(t3); sd t4,  0(t5)\n" ++
+  "  ld t4,  8(t3); sd t4,  8(t5)\n" ++
+  "  ld t4, 16(t3); sd t4, 16(t5)\n" ++
+  "  ld t4, 24(t3); sd t4, 24(t5)\n" ++
+  "  # Field 16: withdrawals_root → out[64..96]\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 16\n" ++
+  "  la a3, hebr_offset; la a4, hebr_length\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lhebr_f16_fail\n" ++
+  "  la t0, hebr_length; ld t1, 0(t0)\n" ++
+  "  li t2, 32\n" ++
+  "  bne t1, t2, .Lhebr_f16_fail\n" ++
+  "  la t0, hebr_offset; ld t3, 0(t0); add t3, s0, t3\n" ++
+  "  addi t5, s2, 64\n" ++
+  "  ld t4,  0(t3); sd t4,  0(t5)\n" ++
+  "  ld t4,  8(t3); sd t4,  8(t5)\n" ++
+  "  ld t4, 16(t3); sd t4, 16(t5)\n" ++
+  "  ld t4, 24(t3); sd t4, 24(t5)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lhebr_ret\n" ++
+  ".Lhebr_f4_fail:\n" ++
+  "  li a0, 1\n" ++
+  "  j .Lhebr_zero_ret\n" ++
+  ".Lhebr_f5_fail:\n" ++
+  "  li a0, 2\n" ++
+  "  j .Lhebr_zero_ret\n" ++
+  ".Lhebr_f16_fail:\n" ++
+  "  li a0, 3\n" ++
+  ".Lhebr_zero_ret:\n" ++
+  "  # Zero the output on any failure.\n" ++
+  "  mv t0, s2; li t1, 12\n" ++
+  ".Lhebr_zero:\n" ++
+  "  beqz t1, .Lhebr_ret\n" ++
+  "  sd zero, 0(t0); addi t0, t0, 8; addi t1, t1, -1\n" ++
+  "  j .Lhebr_zero\n" ++
+  ".Lhebr_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp)\n" ++
+  "  addi sp, sp, 32\n" ++
+  "  ret"
+
+/-- `zisk_header_extract_block_roots`: probe BuildUnit. Reads
+    (header_len, header_bytes), writes (status, 3 × 32-byte roots)
+    to OUTPUT (104 bytes total). -/
+def ziskHeaderExtractBlockRootsPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a3, 0x40000000\n" ++
+  "  ld a1, 8(a3)                # header_len\n" ++
+  "  addi a0, a3, 16             # header ptr\n" ++
+  "  li a2, 0xa0010008           # 96B output at OUTPUT + 8\n" ++
+  "  # Pre-zero 96 bytes (12 dwords).\n" ++
+  "  mv t0, a2; li t1, 12\n" ++
+  ".Lhebr_pzero:\n" ++
+  "  beqz t1, .Lhebr_pzdone\n" ++
+  "  sd zero, 0(t0); addi t0, t0, 8; addi t1, t1, -1\n" ++
+  "  j .Lhebr_pzero\n" ++
+  ".Lhebr_pzdone:\n" ++
+  "  jal ra, header_extract_block_roots\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)                # status\n" ++
+  "  j .Lhebr_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  headerExtractBlockRootsFunction ++ "\n" ++
+  ".Lhebr_pdone:"
+
+def ziskHeaderExtractBlockRootsDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "hebr_offset:\n" ++
+  "  .zero 8\n" ++
+  "hebr_length:\n" ++
+  "  .zero 8"
+
+def ziskHeaderExtractBlockRootsProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskHeaderExtractBlockRootsPrologue
+  dataAsm     := ziskHeaderExtractBlockRootsDataSection
+}
+
 /-! ## validate_header_basic -- PR-K43 per-header semantic checks
 
     Three u64 invariants from `validate_header` (Python:
@@ -11898,6 +12038,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_header_minimal_decode" => some ziskHeaderMinimalDecodeProbeUnit
   | "zisk_header_extended_decode" => some ziskHeaderExtendedDecodeProbeUnit
   | "zisk_coinbase_extract_from_header" => some ziskCoinbaseExtractFromHeaderProbeUnit
+  | "zisk_header_extract_block_roots" => some ziskHeaderExtractBlockRootsProbeUnit
   | "zisk_validate_header_basic" => some ziskValidateHeaderBasicProbeUnit
   | "zisk_check_gas_limit"      => some ziskCheckGasLimitProbeUnit
   | "zisk_tx_validate_against_block" => some ziskTxValidateAgainstBlockProbeUnit
@@ -11998,6 +12139,7 @@ def knownProgramNames : List String :=
    "zisk_header_minimal_decode",
    "zisk_header_extended_decode",
    "zisk_coinbase_extract_from_header",
+   "zisk_header_extract_block_roots",
    "zisk_validate_header_basic",
    "zisk_check_gas_limit",
    "zisk_tx_validate_against_block",

--- a/scripts/codegen-zisk-header-extract-block-roots-check.sh
+++ b/scripts/codegen-zisk-header-extract-block-roots-check.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# codegen-zisk-header-extract-block-roots-check.sh -- PR-K95.
+#
+# Extract transactions_root / receipt_root / withdrawals_root from header.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_header_extract_block_roots ELF"
+lake exe codegen --program zisk_header_extract_block_roots --halt linux93 \
+  -o gen-out/zisk_header_extract_block_roots
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <tx_root_hex> <rec_root_hex> <wd_root_hex> [truncate]
+run_case() {
+  local name="$1" tx="$2" rec="$3" wd="$4" trunc="${5:-}"
+  local exp_status; if [[ "$trunc" == "drop16" ]]; then exp_status=3; else exp_status=0; fi
+
+  local in_file="$REPO_ROOT/gen-out/zisk_header_extract_block_roots_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_header_extract_block_roots_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+tx = bytes.fromhex('$tx')
+rec = bytes.fromhex('$rec')
+wd = bytes.fromhex('$wd')
+trunc = '$trunc'
+fields = [
+    bytes(32), bytes(32), bytes(20), bytes(32),
+    tx,                         # 4 transactions_root
+    rec,                        # 5 receipt_root
+    bytes(256), 0, 1, 30_000_000,
+    100_000, 1700000000, b'', bytes(32), bytes(8),
+    10**9,
+    wd,                         # 16 withdrawals_root
+    0, 0,
+    bytes(32), bytes(32), bytes(32),
+]
+if trunc == 'drop16':
+    fields = fields[:16]
+header_rlp = rlp.encode(fields)
+with open(sys.argv[1], 'wb') as f:
+    f.write(struct.pack('<Q', len(header_rlp)))
+    f.write(header_rlp)
+    pad = (-(8 + len(header_rlp))) % 8
+    if pad: f.write(b'\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_header_extract_block_roots.elf \
+    -i "$in_file" -o "$out_file" -n 1000000 \
+    >"$REPO_ROOT/gen-out/zisk_header_extract_block_roots_${name}.emu.log" 2>&1 || true
+
+  local actual_status; actual_status="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local exp_status_le; exp_status_le="$(python3 -c "print(int('$exp_status').to_bytes(8, 'little').hex())")"
+
+  if [[ "$exp_status" == "0" ]]; then
+    local actual_tx; actual_tx="$(dd if="$out_file" bs=1 skip=8 count=32 2>/dev/null | xxd -p | tr -d '\n')"
+    local actual_rec; actual_rec="$(dd if="$out_file" bs=1 skip=40 count=32 2>/dev/null | xxd -p | tr -d '\n')"
+    local actual_wd; actual_wd="$(dd if="$out_file" bs=1 skip=72 count=32 2>/dev/null | xxd -p | tr -d '\n')"
+    if [[ "$actual_status" == "$exp_status_le" && "$actual_tx" == "$tx" && "$actual_rec" == "$rec" && "$actual_wd" == "$wd" ]]; then
+      printf "  %-32s OK\n" "$name"
+      return 0
+    else
+      printf "  %-32s FAIL  status=0x%s tx=%s rec=%s wd=%s\n" "$name" "$actual_status" "${actual_tx:0:8}.." "${actual_rec:0:8}.." "${actual_wd:0:8}.."
+      return 1
+    fi
+  else
+    if [[ "$actual_status" == "$exp_status_le" ]]; then
+      printf "  %-32s OK   status=%d (rejected as expected)\n" "$name" "$exp_status"
+      return 0
+    else
+      printf "  %-32s FAIL expected status=%d got 0x%s\n" "$name" "$exp_status" "$actual_status"
+      return 1
+    fi
+  fi
+}
+
+A=$(printf '%.0s%s' {1..32} 'aa')
+A="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+B="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+C="cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+Z="0000000000000000000000000000000000000000000000000000000000000000"
+
+FAILED=0
+run_case "all_distinct"    "$A" "$B" "$C" || FAILED=1
+run_case "all_zero"        "$Z" "$Z" "$Z" || FAILED=1
+run_case "mixed"           "$A" "$Z" "$B" || FAILED=1
+run_case "premerge_no_wd"  "$A" "$B" "$Z" drop16 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: header_extract_block_roots extracts transactions/receipt/withdrawals roots"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Extract the three remaining 32-byte root fields from an Amsterdam
header that the existing extended-decode helpers don't cover:

| offset    | field                  | RLP idx |
|-----------|------------------------|---------|
| `0..32`   | `transactions_root`    | 4       |
| `32..64`  | `receipt_root`         | 5       |
| `64..96`  | `withdrawals_root`     | 16      |

Used by `validate_block_body` callers that cross-check the body's
tx/receipt/withdrawal MPT roots against the consensus-layer
commitment, and by the trie-rebuild path.

The `state_root` (field 3) is already covered by PR-K39
`header_extended_decode`; `parent_hash` by PR-K17; `coinbase` by
PR-K55. K95 fills the gap.

Composes PR-K20 `rlp_list_nth_item`. Output zeroed on any failure.

Status:
- `0` : success
- `1` : field 4 missing / not 32 B
- `2` : field 5 missing / not 32 B
- `3` : field 16 missing / not 32 B (pre-Shanghai)

## Test plan

- [x] `scripts/codegen-zisk-header-extract-block-roots-check.sh`
  passes 4 fixtures: all distinct roots, all zero, mixed (one zero),
  and a pre-Shanghai-shaped header truncated before field 16
  (correctly rejected with status 3)
- [x] `lake build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)