### PR TITLE
feat(divmod): mark n3 no-x1 posts pc-free

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -72,6 +72,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN1V4
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1V4PreloopCallMax
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN2LoopUnified
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3LoopUnified
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3PcFree
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN3LoopUnified
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4NoNop

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3PcFree.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3PcFree.lean
@@ -1,0 +1,52 @@
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3LoopUnified
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+theorem fullDivN3ScratchNoX1_pcFree (bltu_1 bltu_0 : Bool)
+    (sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 : Word) :
+    (fullDivN3ScratchNoX1 bltu_1 bltu_0 sp base
+      a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0).pcFree := by
+  delta fullDivN3ScratchNoX1
+  pcFree
+
+instance pcFreeInst_fullDivN3ScratchNoX1 (bltu_1 bltu_0 : Bool)
+    (sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 : Word) :
+    Assertion.PCFree
+      (fullDivN3ScratchNoX1 bltu_1 bltu_0 sp base
+        a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0) :=
+  ⟨fullDivN3ScratchNoX1_pcFree bltu_1 bltu_0 sp base
+    a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0⟩
+
+theorem fullDivN3FrameNoX1_pcFree (bltu_1 bltu_0 : Bool)
+    (sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 : Word) :
+    (fullDivN3FrameNoX1 bltu_1 bltu_0 sp base
+      a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0).pcFree := by
+  delta fullDivN3FrameNoX1
+  pcFree
+
+instance pcFreeInst_fullDivN3FrameNoX1 (bltu_1 bltu_0 : Bool)
+    (sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 : Word) :
+    Assertion.PCFree
+      (fullDivN3FrameNoX1 bltu_1 bltu_0 sp base
+        a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0) :=
+  ⟨fullDivN3FrameNoX1_pcFree bltu_1 bltu_0 sp base
+    a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0⟩
+
+theorem fullDivN3UnifiedPostNoX1_pcFree (bltu_1 bltu_0 : Bool)
+    (sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 : Word) :
+    (fullDivN3UnifiedPostNoX1 bltu_1 bltu_0 sp base
+      a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0).pcFree := by
+  delta fullDivN3UnifiedPostNoX1
+  pcFree
+
+instance pcFreeInst_fullDivN3UnifiedPostNoX1 (bltu_1 bltu_0 : Bool)
+    (sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 : Word) :
+    Assertion.PCFree
+      (fullDivN3UnifiedPostNoX1 bltu_1 bltu_0 sp base
+        a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0) :=
+  ⟨fullDivN3UnifiedPostNoX1_pcFree bltu_1 bltu_0 sp base
+    a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0⟩
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add a small FullPathN3PcFree module with PCFree lemmas/instances for fullDivN3ScratchNoX1, fullDivN3FrameNoX1, and fullDivN3UnifiedPostNoX1
- import the helper module from the DivMod umbrella so downstream exact-frame dispatcher proofs can frame N3 no-X1 posts directly

## Verification
- lake build EvmAsm.Evm64.DivMod.Compose.FullPathN3PcFree
- lake build EvmAsm.Evm64.DivMod
- lake build EvmAsm.Evm64.SDiv
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- rg -n "DivStackSpecCase|ModStackSpecCase|SDivStackSpecCase|SModStackSpecCase|StackSpecCase|set_option maxRecDepth|set_option maxHeartbeats|sorry|admit" EvmAsm/Evm64/DivMod/Compose/FullPathN3PcFree.lean EvmAsm/Evm64/DivMod.lean