### PR TITLE
feat(stateless): mpt_branch_get_child (PR-K115)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -9496,6 +9496,134 @@ def ziskBlockSummaryProbeUnit : BuildUnit := {
   dataAsm     := ziskBlockSummaryDataSection
 }
 
+/-! ## mpt_branch_get_child -- PR-K115
+
+    Extract the i-th child reference of an MPT branch node.
+
+    A branch node is a 17-item RLP list: `[c0, c1, …, c15, value]`.
+    Each child slot `ci` (i in 0..15) holds the i-th child's node
+    reference — either a 32-byte keccak digest or an embedded RLP
+    blob (see PR-K112 `encode_internal_node`). An empty child slot
+    is encoded as the empty RLP string (length 0).
+
+    Pairs with PR-K113 `mpt_leaf_extract` and PR-K114
+    `mpt_extension_extract` to cover the three MPT node shapes
+    (leaf / extension / branch). Used by the MPT walker
+    (PR-K24 `mpt_walk`) every time it descends through a branch
+    along the path's current nibble.
+
+    Composes:
+      - PR-K47 `rlp_list_count_items` — sanity-check 17 items
+      - PR-K20 `rlp_list_nth_item`    — i-th field bounds
+
+    Calling convention:
+      a0 (input)  : branch_rlp ptr
+      a1 (input)  : branch_rlp byte length
+      a2 (input)  : nibble index (0..15)
+      a3 (input)  : u64 out ptr (child_ptr — absolute)
+      a4 (input)  : u64 out ptr (child_len)
+      ra (input)  : return
+      a0 (output) :
+        0 : success — child slot extracted (may be empty / 32 B / embedded)
+        1 : not a 17-item list (or RLP parse failure)
+        2 : invalid index (> 15)
+        3 : i-th field extraction failed (mid-list parse error)
+
+    Uses two 8-byte `.data` scratch slots
+    (`mbc_count`, `mbc_off` + `mbc_len`). -/
+def mptBranchGetChildFunction : String :=
+  "mpt_branch_get_child:\n" ++
+  "  addi sp, sp, -48\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp); sd s4, 40(sp)\n" ++
+  "  mv s0, a0                   # branch ptr\n" ++
+  "  mv s1, a1                   # branch len\n" ++
+  "  mv s2, a2                   # index\n" ++
+  "  mv s3, a3                   # child_ptr out\n" ++
+  "  mv s4, a4                   # child_len out\n" ++
+  "  sd zero, 0(s3); sd zero, 0(s4)\n" ++
+  "  # Bounds-check index.\n" ++
+  "  li t0, 16\n" ++
+  "  bgeu s2, t0, .Lmbc_bad_idx\n" ++
+  "  # Verify 17-item list.\n" ++
+  "  mv a0, s0; mv a1, s1\n" ++
+  "  la a2, mbc_count\n" ++
+  "  jal ra, rlp_list_count_items\n" ++
+  "  bnez a0, .Lmbc_not_branch\n" ++
+  "  la t0, mbc_count; ld t1, 0(t0)\n" ++
+  "  li t2, 17\n" ++
+  "  bne t1, t2, .Lmbc_not_branch\n" ++
+  "  # Extract i-th field.\n" ++
+  "  mv a0, s0; mv a1, s1\n" ++
+  "  mv a2, s2\n" ++
+  "  la a3, mbc_off; la a4, mbc_len\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lmbc_nth_fail\n" ++
+  "  la t0, mbc_off; ld t1, 0(t0)\n" ++
+  "  add t2, s0, t1\n" ++
+  "  sd t2, 0(s3)\n" ++
+  "  la t0, mbc_len; ld t1, 0(t0)\n" ++
+  "  sd t1, 0(s4)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lmbc_ret\n" ++
+  ".Lmbc_bad_idx:\n" ++
+  "  li a0, 2\n" ++
+  "  j .Lmbc_ret\n" ++
+  ".Lmbc_not_branch:\n" ++
+  "  li a0, 1\n" ++
+  "  j .Lmbc_ret\n" ++
+  ".Lmbc_nth_fail:\n" ++
+  "  li a0, 3\n" ++
+  ".Lmbc_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp); ld s4, 40(sp)\n" ++
+  "  addi sp, sp, 48\n" ++
+  "  ret"
+
+/-- `zisk_mpt_branch_get_child`: probe BuildUnit. Reads
+    (branch_len, index, branch_bytes), writes
+    (status, child_offset, child_len, child_bytes...) to OUTPUT.
+    Probe converts the absolute `child_ptr` to a relative offset
+    within `branch_rlp` so the test harness can rehydrate. -/
+def ziskMptBranchGetChildPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a5, 0x40000000\n" ++
+  "  ld a1, 8(a5)                # branch length\n" ++
+  "  ld a2, 16(a5)               # index\n" ++
+  "  addi a0, a5, 24             # branch ptr\n" ++
+  "  li a3, 0xa0010008           # child_ptr (absolute) out\n" ++
+  "  li a4, 0xa0010010           # child_len out\n" ++
+  "  jal ra, mpt_branch_get_child\n" ++
+  "  li t0, 0xa0010008\n" ++
+  "  ld t1, 0(t0)\n" ++
+  "  beqz t1, .Lmbc_skip_rel\n" ++
+  "  addi t2, a5, 24\n" ++
+  "  sub t1, t1, t2\n" ++
+  "  sd t1, 0(t0)\n" ++
+  ".Lmbc_skip_rel:\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lmbc_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpListCountItemsFunction ++ "\n" ++
+  mptBranchGetChildFunction ++ "\n" ++
+  ".Lmbc_pdone:"
+
+def ziskMptBranchGetChildDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "mbc_count:\n" ++
+  "  .zero 8\n" ++
+  "mbc_off:\n" ++
+  "  .zero 8\n" ++
+  "mbc_len:\n" ++
+  "  .zero 8"
+
+def ziskMptBranchGetChildProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskMptBranchGetChildPrologue
+  dataAsm     := ziskMptBranchGetChildDataSection
+}
 
 
 /-! ## stateless_guest body — PR-K5 keccak hash field
@@ -9727,6 +9855,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_withdrawals_sum_amounts" => some ziskWithdrawalsSumAmountsProbeUnit
   | "zisk_block_withdrawals_total" => some ziskBlockWithdrawalsTotalProbeUnit
   | "zisk_block_summary"        => some ziskBlockSummaryProbeUnit
+  | "zisk_mpt_branch_get_child" => some ziskMptBranchGetChildProbeUnit
   | "zisk_sha256_from_input"    => some ziskSha256FromInputProbeUnit
   | "zisk_ssz_pair_hash"        => some ziskSszPairHashProbeUnit
   | "zisk_ssz_zero_hashes"      => some ziskSszZeroHashesProbeUnit
@@ -9827,6 +9956,7 @@ def knownProgramNames : List String :=
    "zisk_withdrawals_sum_amounts",
    "zisk_block_withdrawals_total",
    "zisk_block_summary",
+   "zisk_mpt_branch_get_child",
    "zisk_sha256_from_input",
    "zisk_ssz_pair_hash",
    "zisk_ssz_zero_hashes",

--- a/scripts/codegen-zisk-mpt-branch-get-child-check.sh
+++ b/scripts/codegen-zisk-mpt-branch-get-child-check.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# codegen-zisk-mpt-branch-get-child-check.sh -- PR-K115.
+#
+# Extract i-th child reference of a 17-item branch node.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_mpt_branch_get_child ELF"
+lake exe codegen --program zisk_mpt_branch_get_child --halt linux93 \
+  -o gen-out/zisk_mpt_branch_get_child
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <kind> <index> <expected_child_hex_or_empty>
+# kind: "branch_default", "leaf", "ext", "thirteen_items"
+run_case() {
+  local name="$1" kind="$2" idx="$3" exp_child_hex="$4" exp_status="${5:-0}"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_mpt_branch_get_child_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_mpt_branch_get_child_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+kind = '$kind'
+
+if kind == 'branch_default':
+    children = []
+    for i in range(16):
+        if i == 0:
+            children.append(bytes([0xaa] * 32))
+        elif i == 5:
+            children.append(bytes([0xbb] * 32))
+        elif i == 15:
+            children.append(bytes([0xcc] * 32))
+        elif i == 3:
+            children.append(bytes.fromhex('c102'))  # embedded
+        else:
+            children.append(b'')
+    node = children + [b'branch_value']
+elif kind == 'leaf':
+    node = [b'\x20', b'value']
+elif kind == 'ext':
+    node = [b'\x00', bytes([0xab]*32)]
+elif kind == 'thirteen_items':
+    node = [b''] * 13
+else:
+    raise ValueError(kind)
+
+node_rlp = rlp.encode(node)
+with open(sys.argv[1], 'wb') as f:
+    f.write(struct.pack('<Q', len(node_rlp)))
+    f.write(struct.pack('<Q', $idx))
+    f.write(node_rlp)
+    pad = (-(16 + len(node_rlp))) % 8
+    if pad: f.write(b'\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_mpt_branch_get_child.elf \
+    -i "$in_file" -o "$out_file" -n 5000000 \
+    >"$REPO_ROOT/gen-out/zisk_mpt_branch_get_child_${name}.emu.log" 2>&1 || true
+
+  local actual_status; actual_status="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local exp_status_le; exp_status_le="$(python3 -c "print(int('$exp_status').to_bytes(8, 'little').hex())")"
+
+  if [[ "$actual_status" != "$exp_status_le" ]]; then
+    printf "  %-32s FAIL status=0x%s expected=%d\n" "$name" "$actual_status" "$exp_status"
+    return 1
+  fi
+  if [[ "$exp_status" != "0" ]]; then
+    printf "  %-32s OK   status=%d (rejected)\n" "$name" "$exp_status"
+    return 0
+  fi
+  local actual_child_len_le; actual_child_len_le="$(dd if="$out_file" bs=1 skip=16 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local actual_child_len; actual_child_len="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$actual_child_len_le'))[0])")"
+  local expected_len; expected_len="$(python3 -c "print(len(bytes.fromhex('$exp_child_hex')))")"
+  if [[ "$actual_child_len" != "$expected_len" ]]; then
+    printf "  %-32s FAIL child_len=%d expected=%d\n" "$name" "$actual_child_len" "$expected_len"
+    return 1
+  fi
+  if [[ "$expected_len" -gt 0 ]]; then
+    # Need to read child bytes from input file at the reported offset.
+    local offset_le; offset_le="$(dd if="$out_file" bs=1 skip=8 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+    local offset; offset="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$offset_le'))[0])")"
+    local file_off=$((16 + offset))  # skip 8B len + 8B idx + offset into rlp
+    local actual_bytes; actual_bytes="$(dd if="$in_file" bs=1 skip="$file_off" count="$expected_len" 2>/dev/null | xxd -p | tr -d '\n')"
+    if [[ "$actual_bytes" != "$exp_child_hex" ]]; then
+      printf "  %-32s FAIL\n    expected: %s\n    actual:   %s\n" "$name" "${exp_child_hex:0:40}" "${actual_bytes:0:40}"
+      return 1
+    fi
+  fi
+  printf "  %-32s OK   len=%d\n" "$name" "$expected_len"
+  return 0
+}
+
+FAILED=0
+H_AA="$(python3 -c "print('aa' * 32)")"
+H_BB="$(python3 -c "print('bb' * 32)")"
+H_CC="$(python3 -c "print('cc' * 32)")"
+
+run_case "idx_0_aa"     branch_default 0  "$H_AA"   || FAILED=1
+run_case "idx_5_bb"     branch_default 5  "$H_BB"   || FAILED=1
+run_case "idx_15_cc"    branch_default 15 "$H_CC"   || FAILED=1
+run_case "idx_3_embed"  branch_default 3  "c102"    || FAILED=1
+run_case "idx_7_empty"  branch_default 7  ""        || FAILED=1
+# Rejections
+run_case "leaf_node"           leaf         0  ""    1 || FAILED=1
+run_case "ext_node"            ext          0  ""    1 || FAILED=1
+run_case "thirteen_item_node"  thirteen_items 0 ""   1 || FAILED=1
+run_case "idx_16_oob"          branch_default 16 ""  2 || FAILED=1
+run_case "idx_99_oob"          branch_default 99 ""  2 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: mpt_branch_get_child returns i-th child reference"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Extract the i-th child reference of an MPT branch node.

A branch node is a 17-item RLP list: `[c0, c1, …, c15, value]`. Each
child slot `ci` (i in 0..15) holds the i-th child's node reference —
either a 32-byte keccak digest or an embedded RLP blob (see PR-K112
`encode_internal_node`). An empty child slot is encoded as the
empty RLP string (length 0).

Pairs with PR-K113 `mpt_leaf_extract` and PR-K114
`mpt_extension_extract` to cover the three MPT node shapes (leaf /
extension / branch). Used by the MPT walker (PR-K24 `mpt_walk`)
every time it descends through a branch along the path's current
nibble.

Composes:
- PR-K47 `rlp_list_count_items` — sanity-check 17 items
- PR-K20 `rlp_list_nth_item`    — i-th field bounds

Status:
- `0` : success — child slot extracted (may be empty / 32 B / embedded)
- `1` : not a 17-item list (or RLP parse failure)
- `2` : invalid index (> 15)
- `3` : i-th field extraction failed

**Stacked on PR #5870** (refactor: split Programs.lean) so it
applies cleanly against the new file layout. Base will retarget
to `main` once the refactor lands.

## Test plan

- [x] `scripts/codegen-zisk-mpt-branch-get-child-check.sh` passes
  10 fixtures: 5 child-slot extractions (32-byte hash at idx 0/5/15,
  embedded RLP at idx 3, empty slot at idx 7), 5 rejection cases
  (leaf node, extension node, 13-item list, idx 16, idx 99 OOB)
- [x] `lake build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)