### PR TITLE
feat(divmod): expose n3 call-skip exact x1

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopIterN3CallV4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN3CallV4NoNop.lean
@@ -59,6 +59,30 @@ def loopBodyN3CallSkipJ0PreV4NoX1
    (sp + signExtend12 3936 ↦ₘ scratchMem))
 
 @[irreducible]
+def loopBodyN3CallSkipJgt0PreV4NoX1
+    (sp j jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word) : Assertion :=
+  let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
+  ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
+   (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+   (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
+   (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
+   (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
+   ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+   ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+   ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+   ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+   ((uBase + signExtend12 4064) ↦ₘ uTop) **
+   (qAddr ↦ₘ qOld) **
+   (sp + signExtend12 3968 ↦ₘ retMem) **
+   (sp + signExtend12 3960 ↦ₘ dMem) **
+   (sp + signExtend12 3952 ↦ₘ dloMem) **
+   (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+   (sp + signExtend12 3936 ↦ₘ scratchMem))
+
+@[irreducible]
 def loopBodyN3CallSkipJ0PostV4
     (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word) : Assertion :=
   let dLo := divKTrialCallV4DLo v2
@@ -101,6 +125,20 @@ def loopBodyN3CallSkipJgt0PostV4
   (sp + signExtend12 3944 ↦ₘ divUn0) **
   (sp + signExtend12 3936 ↦ₘ scratchOut) **
   regOwn .x1
+
+@[irreducible]
+def loopBodyN3CallSkipJgt0PostV4NoX1
+    (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word) : Assertion :=
+  let dLo := divKTrialCallV4DLo v2
+  let divUn0 := divKTrialCallV4Un0 u2
+  let qHat := divKTrialCallV4QHat u3 u2 v2
+  let scratchOut := divKTrialCallV4ScratchOut u3 u2 v2 scratchMem
+  loopBodyN3SkipPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+  (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+  (sp + signExtend12 3960 ↦ₘ v2) **
+  (sp + signExtend12 3952 ↦ₘ dLo) **
+  (sp + signExtend12 3944 ↦ₘ divUn0) **
+  (sp + signExtend12 3936 ↦ₘ scratchOut)
 
 @[irreducible]
 def loopBodyN3CallSkipJ0BorrowV4
@@ -418,6 +456,112 @@ theorem divK_loop_body_n3_call_skip_j1_v4_spec_within_noNop
       xperm_hyp hp)
     (fun h hp => by
       unfold loopBodyN3CallSkipJgt0PostV4
+      unfold loopBodyN3SkipPost loopBodySkipPost loopExitPost
+      unfold mulsubN4
+      dsimp only []
+      rw [sepConj_assoc'] at hp
+      xperm_hyp hp)
+    full
+
+/-- No-NOP/v4 n=3 call+skip j=1 spec preserving the concrete caller `x1`
+    through trial-call, mulsub/correction-skip, and store-loop loop-back. -/
+theorem divK_loop_body_n3_call_skip_j1_v4_spec_within_noNop_exact_x1
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : BitVec.ult u3 v2)
+    (hborrow : mulsubN4NoBorrow (divKTrialCallV4QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 148 (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCodeNoNop_v4 base)
+      (loopBodyN3CallSkipJgt0PreV4NoX1 sp (1 : Word) jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopBodyN3CallSkipJgt0PostV4NoX1 sp base (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem **
+        (.x1 ↦ᵣ raVal)) := by
+  unfold loopBodyN3CallSkipJgt0PreV4NoX1
+  let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+  let dHi := divKTrialCallV4DHi v2
+  let dLo := divKTrialCallV4DLo v2
+  let divUn0 := divKTrialCallV4Un0 u2
+  let q1'' := divKTrialCallV4Q1dd u3 u2 v2
+  let q0'' := divKTrialCallV4Q0dd u3 u2 v2
+  let x7Exit := divKTrialCallV4X7Exit u3 u2 v2
+  let x9Exit := divKTrialCallV4X9Exit u3 u2 v2
+  let qHat := divKTrialCallV4QHat u3 u2 v2
+  let scratchOut := divKTrialCallV4ScratchOut u3 u2 v2 scratchMem
+  have TF := divK_trial_call_full_v4_spec_within_noNop_exact_x1 sp (1 : Word) (3 : Word)
+    jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    u3 u2 v2 retMem dMem dloMem scratchUn0 scratchMem raVal base
+    halign hbltu
+  unfold divKTrialCallFullPostV4ExactX1 at TF
+  dsimp only [] at TF
+  rw [u_addr_eq_n3] at TF
+  rw [u_addr8_eq_n3] at TF
+  rw [vtop_eq_v2_n3] at TF
+  have hborrow' :
+      mulsubN4NoBorrow qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+    exact hborrow
+  have MCS := divK_mulsub_correction_skip_v4_spec_within_noNop sp qHat (1 : Word)
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    x9Exit q0'' dHi x7Exit q1'' (base + div128CallRetOff) base
+  have MCS0 := MCS hborrow'
+  unfold divKMulsubCorrectionSkipPre at MCS0
+  unfold n4McaNamedSkipPost at MCS0
+  unfold mulsubN4 at MCS0
+  dsimp only [] at MCS0
+  have MCS0f := cpsTripleWithin_frameR ((sp + signExtend12 3936 ↦ₘ scratchOut) ** (.x1 ↦ᵣ raVal))
+    (by pcFree) MCS0
+  let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
+  let fs0 := p0_lo + (signExtend12 0 : Word)
+  let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
+  let pc0 := ba0 + p0_hi; let bs0 := if BitVec.ult u0 fs0 then (1 : Word) else 0
+  let un0 := u0 - fs0; let c0 := pc0 + bs0
+  let p1_lo := qHat * v1; let p1_hi := rv64_mulhu qHat v1
+  let fs1 := p1_lo + c0; let ba1 := if BitVec.ult fs1 c0 then (1 : Word) else 0
+  let pc1 := ba1 + p1_hi; let bs1 := if BitVec.ult u1 fs1 then (1 : Word) else 0
+  let un1 := u1 - fs1; let c1 := pc1 + bs1
+  let p2_lo := qHat * v2; let p2_hi := rv64_mulhu qHat v2
+  let fs2 := p2_lo + c1; let ba2 := if BitVec.ult fs2 c1 then (1 : Word) else 0
+  let pc2 := ba2 + p2_hi; let bs2 := if BitVec.ult u2 fs2 then (1 : Word) else 0
+  let un2 := u2 - fs2; let c2 := pc2 + bs2
+  let p3_lo := qHat * v3; let p3_hi := rv64_mulhu qHat v3
+  let fs3 := p3_lo + c2; let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
+  let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
+  let un3 := u3 - fs3; let c3 := pc3 + bs3
+  let u4_new := uTop - c3
+  have SL := divK_store_loop_jgt0_v4_spec_within_noNop_exact_x1 sp (1 : Word) qHat u4_new
+    (0 : Word) qOld raVal base slt_jpos_1
+  intro_lets at SL
+  have TFf := cpsTripleWithin_frameR
+    (((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
+     (qAddr ↦ₘ qOld))
+    (by pcFree) TF
+  seqFrame TFf MCS0f
+  have SLf := cpsTripleWithin_frameR
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
+     (sp + signExtend12 3976 ↦ₘ (1 : Word)) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_new) **
+     (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
+     (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+     (sp + signExtend12 3960 ↦ₘ v2) **
+     (sp + signExtend12 3952 ↦ₘ dLo) **
+     (sp + signExtend12 3944 ↦ₘ divUn0) **
+     (sp + signExtend12 3936 ↦ₘ scratchOut))
+    (by pcFree) SL
+  have full := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0f SLf
+  exact cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by
+      unfold loopBodyN3CallSkipJgt0PostV4NoX1
       unfold loopBodyN3SkipPost loopBodySkipPost loopExitPost
       unfold mulsubN4
       dsimp only []


### PR DESCRIPTION
## Summary
- add no-x1 pre/post assertions for the n=3 call-skip j=0 and j>0 v4 no-NOP paths
- prove exact-x1 call-skip body specs for j=0 and j=1 using exact-x1 trial-call/store-loop specs

## Stack note
This supersets PR #5877 because GitHub is not currently accepting feat/div-n3-call-skip-j0-exact-x1 as a base ref for a deeper stack.

## Verification
- lake build EvmAsm.Evm64.DivMod.LoopIterN3CallV4NoNop
- lake build EvmAsm.Evm64.DivMod
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- rg -n "DivStackSpecCase|ModStackSpecCase|SDivStackSpecCase|SModStackSpecCase|StackSpecCase|set_option maxRecDepth|set_option maxHeartbeats|sorry|admit" EvmAsm/Evm64/DivMod/LoopIterN3CallV4NoNop.lean