### PR TITLE
feat(stateless): mpt_branch_get_value (PR-K116)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -9625,6 +9625,122 @@ def ziskMptBranchGetChildProbeUnit : BuildUnit := {
   dataAsm     := ziskMptBranchGetChildDataSection
 }
 
+/-! ## mpt_branch_get_value -- PR-K116
+
+    Extract the value field (item 16) of an MPT branch node.
+
+    A branch node is a 17-item RLP list: `[c0, c1, …, c15, value]`.
+    The trailing `value` slot holds the leaf payload when the
+    walked key terminates exactly at this branch level (i.e., when
+    the path's remaining nibble count equals zero on arrival). It
+    is the empty RLP string when no key terminates at this branch.
+
+    Sister to PR-K115 `mpt_branch_get_child` — same node, different
+    field. Pairs cleanly with the leaf/extension/branch decode
+    trio (K113/K114/K115) for full MPT walking.
+
+    Composes:
+      - PR-K47 `rlp_list_count_items` — sanity-check 17 items
+      - PR-K20 `rlp_list_nth_item`    — field 16 bounds
+
+    Calling convention:
+      a0 (input)  : branch_rlp ptr
+      a1 (input)  : branch_rlp byte length
+      a2 (input)  : u64 out ptr (value_ptr — absolute)
+      a3 (input)  : u64 out ptr (value_len)
+      ra (input)  : return
+      a0 (output) :
+        0 : success — value slot extracted (may be empty)
+        1 : not a 17-item list (or RLP parse failure)
+        2 : field 16 extraction failed (parse error)
+
+    Uses three 8-byte `.data` scratch slots
+    (`mbv_count`, `mbv_off`, `mbv_len`). -/
+def mptBranchGetValueFunction : String :=
+  "mpt_branch_get_value:\n" ++
+  "  addi sp, sp, -48\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  mv s0, a0                   # branch ptr\n" ++
+  "  mv s1, a1                   # branch len\n" ++
+  "  mv s2, a2                   # value_ptr out\n" ++
+  "  mv s3, a3                   # value_len out\n" ++
+  "  sd zero, 0(s2); sd zero, 0(s3)\n" ++
+  "  # Verify 17-item list.\n" ++
+  "  mv a0, s0; mv a1, s1\n" ++
+  "  la a2, mbv_count\n" ++
+  "  jal ra, rlp_list_count_items\n" ++
+  "  bnez a0, .Lmbv_not_branch\n" ++
+  "  la t0, mbv_count; ld t1, 0(t0)\n" ++
+  "  li t2, 17\n" ++
+  "  bne t1, t2, .Lmbv_not_branch\n" ++
+  "  # Extract field 16 (value).\n" ++
+  "  mv a0, s0; mv a1, s1\n" ++
+  "  li a2, 16\n" ++
+  "  la a3, mbv_off; la a4, mbv_len\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lmbv_nth_fail\n" ++
+  "  la t0, mbv_off; ld t1, 0(t0)\n" ++
+  "  add t2, s0, t1\n" ++
+  "  sd t2, 0(s2)\n" ++
+  "  la t0, mbv_len; ld t1, 0(t0)\n" ++
+  "  sd t1, 0(s3)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lmbv_ret\n" ++
+  ".Lmbv_not_branch:\n" ++
+  "  li a0, 1\n" ++
+  "  j .Lmbv_ret\n" ++
+  ".Lmbv_nth_fail:\n" ++
+  "  li a0, 2\n" ++
+  ".Lmbv_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  addi sp, sp, 48\n" ++
+  "  ret"
+
+/-- `zisk_mpt_branch_get_value`: probe BuildUnit. Reads
+    (branch_len, branch_bytes), writes (status, value_offset,
+    value_len, value_bytes...) to OUTPUT. The probe rewrites the
+    absolute `value_ptr` to a relative offset within `branch_rlp`. -/
+def ziskMptBranchGetValuePrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a4, 0x40000000\n" ++
+  "  ld a1, 8(a4)                # branch length\n" ++
+  "  addi a0, a4, 16             # branch ptr\n" ++
+  "  li a2, 0xa0010008           # value_ptr (absolute) out\n" ++
+  "  li a3, 0xa0010010           # value_len out\n" ++
+  "  jal ra, mpt_branch_get_value\n" ++
+  "  li t0, 0xa0010008\n" ++
+  "  ld t1, 0(t0)\n" ++
+  "  beqz t1, .Lmbv_skip_rel\n" ++
+  "  li t2, 0x40000010           # branch_rlp ptr (INPUT_ADDR + 16)\n" ++
+  "  sub t1, t1, t2\n" ++
+  "  sd t1, 0(t0)\n" ++
+  ".Lmbv_skip_rel:\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lmbv_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpListCountItemsFunction ++ "\n" ++
+  mptBranchGetValueFunction ++ "\n" ++
+  ".Lmbv_pdone:"
+
+def ziskMptBranchGetValueDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "mbv_count:\n" ++
+  "  .zero 8\n" ++
+  "mbv_off:\n" ++
+  "  .zero 8\n" ++
+  "mbv_len:\n" ++
+  "  .zero 8"
+
+def ziskMptBranchGetValueProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskMptBranchGetValuePrologue
+  dataAsm     := ziskMptBranchGetValueDataSection
+}
+
 
 /-! ## stateless_guest body — PR-K5 keccak hash field
 
@@ -9856,6 +9972,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_block_withdrawals_total" => some ziskBlockWithdrawalsTotalProbeUnit
   | "zisk_block_summary"        => some ziskBlockSummaryProbeUnit
   | "zisk_mpt_branch_get_child" => some ziskMptBranchGetChildProbeUnit
+  | "zisk_mpt_branch_get_value" => some ziskMptBranchGetValueProbeUnit
   | "zisk_sha256_from_input"    => some ziskSha256FromInputProbeUnit
   | "zisk_ssz_pair_hash"        => some ziskSszPairHashProbeUnit
   | "zisk_ssz_zero_hashes"      => some ziskSszZeroHashesProbeUnit
@@ -9957,6 +10074,7 @@ def knownProgramNames : List String :=
    "zisk_block_withdrawals_total",
    "zisk_block_summary",
    "zisk_mpt_branch_get_child",
+   "zisk_mpt_branch_get_value",
    "zisk_sha256_from_input",
    "zisk_ssz_pair_hash",
    "zisk_ssz_zero_hashes",

--- a/scripts/codegen-zisk-mpt-branch-get-value-check.sh
+++ b/scripts/codegen-zisk-mpt-branch-get-value-check.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# codegen-zisk-mpt-branch-get-value-check.sh -- PR-K116.
+#
+# Extract field 16 (value) of a 17-item branch node.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_mpt_branch_get_value ELF"
+lake exe codegen --program zisk_mpt_branch_get_value --halt linux93 \
+  -o gen-out/zisk_mpt_branch_get_value
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <kind> <value_hex> <expected_status>
+run_case() {
+  local name="$1" kind="$2" value_hex="$3" exp_status="${4:-0}"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_mpt_branch_get_value_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_mpt_branch_get_value_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+kind = '$kind'
+value = bytes.fromhex('$value_hex')
+
+if kind == 'branch':
+    children = [b''] * 16
+    node = children + [value]
+elif kind == 'branch_with_kids':
+    children = [bytes([0xaa]*32)] * 16
+    node = children + [value]
+elif kind == 'leaf':
+    node = [b'\x20', value]
+elif kind == 'invalid':
+    node = [b''] * 5
+else:
+    raise ValueError(kind)
+
+node_rlp = rlp.encode(node)
+with open(sys.argv[1], 'wb') as f:
+    f.write(struct.pack('<Q', len(node_rlp)))
+    f.write(node_rlp)
+    pad = (-(8 + len(node_rlp))) % 8
+    if pad: f.write(b'\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_mpt_branch_get_value.elf \
+    -i "$in_file" -o "$out_file" -n 5000000 \
+    >"$REPO_ROOT/gen-out/zisk_mpt_branch_get_value_${name}.emu.log" 2>&1 || true
+
+  local actual_status; actual_status="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local exp_status_le; exp_status_le="$(python3 -c "print(int('$exp_status').to_bytes(8, 'little').hex())")"
+
+  if [[ "$actual_status" != "$exp_status_le" ]]; then
+    printf "  %-32s FAIL status=0x%s expected=%d\n" "$name" "$actual_status" "$exp_status"
+    return 1
+  fi
+  if [[ "$exp_status" != "0" ]]; then
+    printf "  %-32s OK   status=%d (rejected)\n" "$name" "$exp_status"
+    return 0
+  fi
+  local actual_value_len_le; actual_value_len_le="$(dd if="$out_file" bs=1 skip=16 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local actual_value_len; actual_value_len="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$actual_value_len_le'))[0])")"
+  local expected_len; expected_len="$(python3 -c "print(len(bytes.fromhex('$value_hex')))")"
+  if [[ "$actual_value_len" != "$expected_len" ]]; then
+    printf "  %-32s FAIL value_len=%d expected=%d\n" "$name" "$actual_value_len" "$expected_len"
+    return 1
+  fi
+  if [[ "$expected_len" -gt 0 ]]; then
+    local offset_le; offset_le="$(dd if="$out_file" bs=1 skip=8 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+    local offset; offset="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$offset_le'))[0])")"
+    local file_off=$((8 + offset))
+    local actual_bytes; actual_bytes="$(dd if="$in_file" bs=1 skip="$file_off" count="$expected_len" 2>/dev/null | xxd -p | tr -d '\n')"
+    if [[ "$actual_bytes" != "$value_hex" ]]; then
+      printf "  %-32s FAIL\n    expected: %s\n    actual:   %s\n" "$name" "${value_hex:0:40}" "${actual_bytes:0:40}"
+      return 1
+    fi
+  fi
+  printf "  %-32s OK   value_len=%d\n" "$name" "$expected_len"
+  return 0
+}
+
+FAILED=0
+run_case "empty_value"          branch              ""             || FAILED=1
+run_case "short_value"          branch              "deadbeef"     || FAILED=1
+run_case "32B_value"            branch              "$(python3 -c "print('ee' * 32)")" || FAILED=1
+run_case "branch_with_kids_value" branch_with_kids  "feedface"     || FAILED=1
+run_case "long_value"           branch              "$(python3 -c "print('cd' * 200)")" || FAILED=1
+# Rejections
+run_case "leaf_node"            leaf                "0000"      1 || FAILED=1
+run_case "five_item_node"       invalid             ""          1 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: mpt_branch_get_value extracts field 16"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Extract the value field (item 16) of an MPT branch node.

A branch node is a 17-item RLP list: `[c0, c1, …, c15, value]`. The
trailing `value` slot holds the leaf payload when the walked key
terminates exactly at this branch level (i.e., when the path's
remaining nibble count equals zero on arrival). It is the empty
RLP string when no key terminates at this branch.

Sister to PR-K115 `mpt_branch_get_child` — same node, different
field. Pairs cleanly with the leaf/extension/branch decode trio
(K113/K114/K115) for full MPT walking.

Composes:
- PR-K47 `rlp_list_count_items` — sanity-check 17 items
- PR-K20 `rlp_list_nth_item`    — field 16 bounds

Status:
- `0` : success — value slot extracted (may be empty)
- `1` : not a 17-item list (or RLP parse failure)
- `2` : field 16 extraction failed

**Stacked on PR #5870** (refactor: split Programs.lean) and
PR-#5875 (K115 mpt_branch_get_child). Base will retarget once those land.

## Test plan

- [x] `scripts/codegen-zisk-mpt-branch-get-value-check.sh` passes
  7 fixtures: 5 successful extractions (empty value, short, 32B,
  branch-with-children, long 200B value) + 2 rejection cases (leaf
  node, 5-item list)
- [x] `lake build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)