### PR TITLE
feat(divmod): expose n3 call loop exact x1

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -64,6 +64,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN4V4NoNop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4V4
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4CallV4NoNop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V4NoNop
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V4NoNopMaxCall
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V4
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V4NoNop.lean
@@ -805,4 +805,209 @@ theorem divK_loop_n3_call_call_from_source_exact_loopIterScratch_v4_noNop (sp ba
       v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q0Old raVal)
     J1 J0f
 
+/-- A j=1 call iteration postcondition with v4 scratch cells specializes to the
+    j=0 max-body precondition, retaining scratch, exact `x1`, and j=1 carried
+    u4/q atoms as frame. -/
+theorem loopIterPostN3CallScratchNoX1_j1_to_max_j0_pre
+    (sp base qHat dLo divUn0 scratchOut : Word)
+    (v0 v1 v2 v3 u0J1 u1 u2 u3 uTop u0Orig q0Old raVal : Word) :
+    let r := iterWithDoubleAddback qHat v0 v1 v2 v3 u0J1 u1 u2 u3 uTop
+    let c3 := mulsubN4_c3 qHat v0 v1 v2 v3 u0J1 u1 u2 u3
+    let uBase1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+    ∀ h,
+      (((loopIterPostN3CallScratchNoX1 sp base (1 : Word)
+        qHat dLo divUn0 scratchOut v0 v1 v2 v3 u0J1 u1 u2 u3 uTop **
+        (.x1 ↦ᵣ raVal)) **
+        (((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) +
+          signExtend12 0 ↦ₘ u0Orig) **
+         ((sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q0Old))) h) →
+      (((loopBodyN3MaxSkipJ0NormPreV4 sp (1 : Word)
+          ((1 : Word) <<< (3 : BitVec 6).toNat) uBase1 qAddr1 c3 r.1
+          r.2.2.2.2.1 v0 v1 v2 v3 u0Orig r.2.1 r.2.2.1 r.2.2.2.1
+          r.2.2.2.2.1 q0Old **
+          (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+          (sp + signExtend12 3960 ↦ₘ v2) **
+          (sp + signExtend12 3952 ↦ₘ dLo) **
+          (sp + signExtend12 3944 ↦ₘ divUn0) **
+          (sp + signExtend12 3936 ↦ₘ scratchOut) **
+          (.x1 ↦ᵣ raVal)) **
+        ((uBase1 + signExtend12 4064 ↦ₘ r.2.2.2.2.2) **
+         (qAddr1 ↦ₘ r.1))) h) := by
+  intro r c3 uBase1 qAddr1 h hp
+  subst uBase1
+  subst qAddr1
+  subst c3
+  subst r
+  delta loopIterPostN3CallScratchNoX1 loopExitPostN3 loopExitPost at hp
+  delta loopBodyN3MaxSkipJ0NormPreV4
+  unfold mulsubN4_c3
+  simp only [] at hp ⊢
+  have hj' := EvmAsm.Evm64.DivMod.AddrNorm.jpred_1
+  rw [hj', u_j1_0_eq_j0_4088, u_j1_4088_eq_j0_4080,
+      u_j1_4080_eq_j0_4072, u_j1_4072_eq_j0_4064] at hp
+  simp only [se12_32, se12_40, se12_48, se12_56,
+             u_base_off0_j0, u_base_off4088_j0, u_base_off4080_j0,
+             u_base_off4072_j0, u_base_off4064_j0, q_addr_j0] at hp ⊢
+  rw [sepConj_assoc'] at hp
+  xperm_hyp hp
+
+/-- Loop body n=3, max path, j=0 over `divCode_noNop_v4`, preserving
+    concrete `x1` and callable scratch cells as frame. -/
+theorem divK_loop_body_n3_max_j0_exact_loopIterScratch_v4_noNop (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hbltu : ¬BitVec.ult u3 v2)
+    (hcarry2_nz : isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 152 (base + loopBodyOff) (base + denormOff) (divCode_noNop_v4 base)
+      ((loopBodyN3MaxSkipJ0NormPreV4 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal)))
+      ((loopIterPostN3Max sp (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal))) := by
+  by_cases hborrow : BitVec.ult uTop
+      (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+  · have hborrow_nz :
+        (if BitVec.ult uTop
+          (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+         then (1 : Word) else 0) ≠ (0 : Word) := by
+      rw [if_pos hborrow]
+      decide
+    have J := divK_loop_body_n3_max_addback_j0_beq_norm_v4_noNop
+      sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld hbltu hcarry2_nz hborrow_nz
+    have Jf := cpsTripleWithin_frameR
+      ((sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
+       (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+       (sp + signExtend12 3936 ↦ₘ scratchMem) **
+       (.x1 ↦ᵣ raVal))
+      (by pcFree) J
+    exact cpsTripleWithin_weaken
+      (fun h hp => by xperm_hyp hp)
+      (fun h hp => by
+        rw [loopIterPostN3Max_addback hborrow] at hp
+        xperm_hyp hp)
+      Jf
+  · have hborrow_zero :
+        (if BitVec.ult uTop
+          (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+         then (1 : Word) else 0) = (0 : Word) := by
+      rw [if_neg hborrow]
+    have J := divK_loop_body_n3_max_skip_j0_norm_v4_noNop
+      sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld hbltu hborrow_zero
+    have Jf := cpsTripleWithin_frameR
+      ((sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
+       (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+       (sp + signExtend12 3936 ↦ₘ scratchMem) **
+       (.x1 ↦ᵣ raVal))
+      (by pcFree) J
+    exact cpsTripleWithin_mono_nSteps (by decide) <|
+      cpsTripleWithin_weaken
+        (fun h hp => by xperm_hyp hp)
+        (fun h hp => by
+          rw [loopIterPostN3Max_skip hborrow] at hp
+          xperm_hyp hp)
+        Jf
+
+/-- Full n=3 call×max path from the callable-ready v4 loop source, preserving
+    concrete `x1`, scratch, and the j=1 stored u4/q atoms. -/
+theorem divK_loop_n3_call_max_from_source_exact_loopIterScratch_v4_noNop (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_1 : BitVec.ult u3 v2)
+    (hcarry2_nz_1 : loopBodyN3CallAddbackCarry2NzV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hbltu_0 :
+      let r1 := iterWithDoubleAddback (divKTrialCallV4QHat u3 u2 v2)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      ¬BitVec.ult r1.2.2.2.1 v2)
+    (hcarry2_nz_0 :
+      let r1 := iterWithDoubleAddback (divKTrialCallV4QHat u3 u2 v2)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      isAddbackCarry2NzN3Max v0 v1 v2 v3
+        u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1) :
+    let r1 := iterWithDoubleAddback (divKTrialCallV4QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    let uBase1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+    cpsTripleWithin (224 + 152) (base + loopBodyOff) (base + denormOff) (divCode_noNop_v4 base)
+      (loopN3PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      ((loopIterPostN3Max sp (0 : Word) v0 v1 v2 v3
+        u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 **
+        (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+        (sp + signExtend12 3960 ↦ₘ v2) **
+        (sp + signExtend12 3952 ↦ₘ (divKTrialCallV4DLo v2)) **
+        (sp + signExtend12 3944 ↦ₘ (divKTrialCallV4Un0 u2)) **
+        (sp + signExtend12 3936 ↦ₘ (divKTrialCallV4ScratchOut u3 u2 v2 scratchMem)) **
+        (.x1 ↦ᵣ raVal)) **
+        ((uBase1 + signExtend12 4064 ↦ₘ r1.2.2.2.2.2) **
+         (qAddr1 ↦ₘ r1.1))) := by
+  intro r1 uBase1 qAddr1
+  have J1 := divK_loop_n3_call_j1_from_source_exact_loopIterScratch_v4_noNop
+    sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal
+    retMem dMem dloMem scratchUn0 scratchMem halign hbltu_1 hcarry2_nz_1
+  subst r1
+  subst uBase1
+  subst qAddr1
+  have J0 := divK_loop_body_n3_max_j0_exact_loopIterScratch_v4_noNop sp base
+    (1 : Word)
+    ((1 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat)
+    (mulsubN4_c3 (divKTrialCallV4QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3)
+    (iterWithDoubleAddback (divKTrialCallV4QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).1
+    (iterWithDoubleAddback (divKTrialCallV4QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
+    v0 v1 v2 v3 u0Orig
+    (iterWithDoubleAddback (divKTrialCallV4QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+    (iterWithDoubleAddback (divKTrialCallV4QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+    (iterWithDoubleAddback (divKTrialCallV4QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+    (iterWithDoubleAddback (divKTrialCallV4QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
+    q0Old raVal
+    (base + div128CallRetOff) v2 (divKTrialCallV4DLo v2)
+    (divKTrialCallV4Un0 u2) (divKTrialCallV4ScratchOut u3 u2 v2 scratchMem)
+    hbltu_0 hcarry2_nz_0
+  have J0f := cpsTripleWithin_frameR
+    (((sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 4064 ↦ₘ
+        (iterWithDoubleAddback (divKTrialCallV4QHat u3 u2 v2)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.2) **
+     ((sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ
+        (iterWithDoubleAddback (divKTrialCallV4QHat u3 u2 v2)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).1))
+    (by pcFree) J0
+  exact cpsTripleWithin_seq_perm_same_cr
+    (loopIterPostN3CallScratchNoX1_j1_to_max_j0_pre
+      sp base (divKTrialCallV4QHat u3 u2 v2) (divKTrialCallV4DLo v2)
+      (divKTrialCallV4Un0 u2) (divKTrialCallV4ScratchOut u3 u2 v2 scratchMem)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q0Old raVal)
+    J1 J0f
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V4NoNop.lean
@@ -685,14 +685,14 @@ theorem divK_loop_n3_call_j1_from_source_exact_loopIterScratch_v4_noNop (sp base
     j=0 call-body precondition, retaining the j=1 carried u4/q atoms as frame. -/
 theorem loopIterPostN3CallScratchNoX1_j1_to_call_j0_pre
     (sp base qHat dLo divUn0 scratchOut : Word)
-    (v0 v1 v2 v3 u0Orig u1 u2 u3 uTop q0Old raVal : Word) :
-    let r := iterWithDoubleAddback qHat v0 v1 v2 v3 u0Orig u1 u2 u3 uTop
-    let c3 := mulsubN4_c3 qHat v0 v1 v2 v3 u0Orig u1 u2 u3
+    (v0 v1 v2 v3 u0J1 u1 u2 u3 uTop u0Orig q0Old raVal : Word) :
+    let r := iterWithDoubleAddback qHat v0 v1 v2 v3 u0J1 u1 u2 u3 uTop
+    let c3 := mulsubN4_c3 qHat v0 v1 v2 v3 u0J1 u1 u2 u3
     let uBase1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
     let qAddr1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
     ∀ h,
       (((loopIterPostN3CallScratchNoX1 sp base (1 : Word)
-        qHat dLo divUn0 scratchOut v0 v1 v2 v3 u0Orig u1 u2 u3 uTop **
+        qHat dLo divUn0 scratchOut v0 v1 v2 v3 u0J1 u1 u2 u3 uTop **
         (.x1 ↦ᵣ raVal)) **
         (((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) +
           signExtend12 0 ↦ₘ u0Orig) **
@@ -719,5 +719,90 @@ theorem loopIterPostN3CallScratchNoX1_j1_to_call_j0_pre
       u_j1_4080_eq_j0_4072, u_j1_4072_eq_j0_4064] at hp
   rw [sepConj_assoc'] at hp
   xperm_hyp hp
+
+/-- Full n=3 call×call path from the callable-ready v4 loop source, preserving
+    concrete `x1` and carrying the j=1 stored u4/q atoms. -/
+theorem divK_loop_n3_call_call_from_source_exact_loopIterScratch_v4_noNop (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_1 : BitVec.ult u3 v2)
+    (hcarry2_nz_1 : loopBodyN3CallAddbackCarry2NzV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hbltu_0 :
+      BitVec.ult
+        (iterWithDoubleAddback (divKTrialCallV4QHat u3 u2 v2)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1 v2)
+    (hcarry2_nz_0 :
+      let r1 := iterWithDoubleAddback (divKTrialCallV4QHat u3 u2 v2)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      loopBodyN3CallAddbackCarry2NzV4 v0 v1 v2 v3
+        u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1) :
+    let r1 := iterWithDoubleAddback (divKTrialCallV4QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    let uBase1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+    cpsTripleWithin (224 + 224) (base + loopBodyOff) (base + denormOff) (divCode_noNop_v4 base)
+      (loopN3PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      ((loopIterPostN3CallScratchNoX1 sp base (0 : Word)
+        (divKTrialCallV4QHat r1.2.2.2.1 r1.2.2.1 v2)
+        (divKTrialCallV4DLo v2)
+        (divKTrialCallV4Un0 r1.2.2.1)
+        (divKTrialCallV4ScratchOut r1.2.2.2.1 r1.2.2.1 v2
+          (divKTrialCallV4ScratchOut u3 u2 v2 scratchMem))
+        v0 v1 v2 v3 u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 **
+        (.x1 ↦ᵣ raVal)) **
+        ((uBase1 + signExtend12 4064 ↦ₘ r1.2.2.2.2.2) **
+         (qAddr1 ↦ₘ r1.1))) := by
+  intro r1 uBase1 qAddr1
+  have J1 := divK_loop_n3_call_j1_from_source_exact_loopIterScratch_v4_noNop
+    sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal
+    retMem dMem dloMem scratchUn0 scratchMem halign hbltu_1 hcarry2_nz_1
+  subst r1
+  subst uBase1
+  subst qAddr1
+  have J0 := divK_loop_body_n3_call_j0_exact_loopIterScratch_v4_noNop sp base
+    (1 : Word)
+    ((1 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat)
+    (mulsubN4_c3 (divKTrialCallV4QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3)
+    (iterWithDoubleAddback (divKTrialCallV4QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).1
+    (iterWithDoubleAddback (divKTrialCallV4QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
+    v0 v1 v2 v3 u0Orig
+    (iterWithDoubleAddback (divKTrialCallV4QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+    (iterWithDoubleAddback (divKTrialCallV4QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+    (iterWithDoubleAddback (divKTrialCallV4QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+    (iterWithDoubleAddback (divKTrialCallV4QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
+    q0Old raVal
+    (base + div128CallRetOff) v2 (divKTrialCallV4DLo v2)
+    (divKTrialCallV4Un0 u2) (divKTrialCallV4ScratchOut u3 u2 v2 scratchMem)
+    halign hbltu_0 hcarry2_nz_0
+  have J0f := cpsTripleWithin_frameR
+    (((sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 4064 ↦ₘ
+        (iterWithDoubleAddback (divKTrialCallV4QHat u3 u2 v2)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.2) **
+     ((sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ
+        (iterWithDoubleAddback (divKTrialCallV4QHat u3 u2 v2)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).1))
+    (by pcFree) J0
+  exact cpsTripleWithin_seq_perm_same_cr
+    (loopIterPostN3CallScratchNoX1_j1_to_call_j0_pre
+      sp base (divKTrialCallV4QHat u3 u2 v2) (divKTrialCallV4DLo v2)
+      (divKTrialCallV4Un0 u2) (divKTrialCallV4ScratchOut u3 u2 v2 scratchMem)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q0Old raVal)
+    J1 J0f
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V4NoNop.lean
@@ -324,4 +324,213 @@ theorem divK_loop_body_n3_call_addback_j0_beq_norm_v4_noNop (sp base : Word)
     (fun h hp => hp)
     raw
 
+/-- Loop body n=3, call+skip, j=0 over `divCode_noNop_v4`, preserving
+    concrete `x1` and exposing the scratch loop-iteration post. -/
+theorem divK_loop_body_n3_call_skip_j0_exact_loopIterScratch_v4_noNop (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu : BitVec.ult u3 v2)
+    (hborrow : loopBodyN3CallSkipJ0BorrowV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 148 (base + loopBodyOff) (base + denormOff) (divCode_noNop_v4 base)
+      (loopBodyN3CallSkipJ0PreV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopIterPostN3CallScratchNoX1 sp base (0 : Word)
+        (divKTrialCallV4QHat u3 u2 v2)
+        (divKTrialCallV4DLo v2)
+        (divKTrialCallV4Un0 u2)
+        (divKTrialCallV4ScratchOut u3 u2 v2 scratchMem)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+        (.x1 ↦ᵣ raVal)) := by
+  have hb :
+      ¬BitVec.ult uTop
+        (mulsubN4_c3 (divKTrialCallV4QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3) := by
+    unfold loopBodyN3CallSkipJ0BorrowV4 mulsubN4NoBorrow at hborrow
+    dsimp only [] at hborrow
+    intro hlt
+    unfold mulsubN4_c3 at hlt
+    rw [if_pos hlt] at hborrow
+    exact (by decide : (1 : Word) ≠ (0 : Word)) hborrow
+  exact cpsTripleWithin_weaken
+    (fun h hp => hp)
+    (fun h hp => by
+      have hpost :
+          ((loopBodyN3CallSkipPostJScratchNoX1 sp base (0 : Word)
+            (divKTrialCallV4QHat u3 u2 v2)
+            (divKTrialCallV4DLo v2)
+            (divKTrialCallV4Un0 u2)
+            (divKTrialCallV4ScratchOut u3 u2 v2 scratchMem)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop) ** (.x1 ↦ᵣ raVal)) h := by
+        unfold loopBodyN3CallSkipJ0PostV4NoX1 at hp
+        unfold loopBodyN3CallSkipPostJScratchNoX1
+        simpa only [sepConj_assoc'] using hp
+      rw [loopIterPostN3CallScratchNoX1_skip hb] at hpost
+      exact hpost)
+    (cpsTripleWithin_extend_code
+      (hmono := sharedDivModCodeNoNop_v4_sub_divCode_noNop_v4)
+      (divK_loop_body_n3_call_skip_j0_v4_spec_within_noNop_exact_x1
+        sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal
+        retMem dMem dloMem scratchUn0 scratchMem base halign hbltu hborrow))
+
+/-- Loop body n=3, call+skip, j=1 over `divCode_noNop_v4`, preserving
+    concrete `x1` and exposing the scratch loop-iteration post. -/
+theorem divK_loop_body_n3_call_skip_j1_exact_loopIterScratch_v4_noNop (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu : BitVec.ult u3 v2)
+    (hborrow : mulsubN4NoBorrow (divKTrialCallV4QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 148 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop_v4 base)
+      (loopBodyN3CallSkipJgt0PreV4NoX1 sp (1 : Word) jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopIterPostN3CallScratchNoX1 sp base (1 : Word)
+        (divKTrialCallV4QHat u3 u2 v2)
+        (divKTrialCallV4DLo v2)
+        (divKTrialCallV4Un0 u2)
+        (divKTrialCallV4ScratchOut u3 u2 v2 scratchMem)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+        (.x1 ↦ᵣ raVal)) := by
+  have hb :
+      ¬BitVec.ult uTop
+        (mulsubN4_c3 (divKTrialCallV4QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3) := by
+    unfold mulsubN4NoBorrow at hborrow
+    dsimp only [] at hborrow
+    intro hlt
+    unfold mulsubN4_c3 at hlt
+    rw [if_pos hlt] at hborrow
+    exact (by decide : (1 : Word) ≠ (0 : Word)) hborrow
+  exact cpsTripleWithin_weaken
+    (fun h hp => hp)
+    (fun h hp => by
+      have hpost :
+          ((loopBodyN3CallSkipPostJScratchNoX1 sp base (1 : Word)
+            (divKTrialCallV4QHat u3 u2 v2)
+            (divKTrialCallV4DLo v2)
+            (divKTrialCallV4Un0 u2)
+            (divKTrialCallV4ScratchOut u3 u2 v2 scratchMem)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop) ** (.x1 ↦ᵣ raVal)) h := by
+        unfold loopBodyN3CallSkipJgt0PostV4NoX1 at hp
+        unfold loopBodyN3CallSkipPostJScratchNoX1
+        simpa only [sepConj_assoc'] using hp
+      rw [loopIterPostN3CallScratchNoX1_skip hb] at hpost
+      exact hpost)
+    (cpsTripleWithin_extend_code
+      (hmono := sharedDivModCodeNoNop_v4_sub_divCode_noNop_v4)
+      (divK_loop_body_n3_call_skip_j1_v4_spec_within_noNop_exact_x1
+        sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal
+        retMem dMem dloMem scratchUn0 scratchMem base halign hbltu hborrow))
+
+/-- Loop body n=3, call+addback, j=0 over `divCode_noNop_v4`, preserving
+    concrete `x1` and exposing the scratch loop-iteration post. -/
+theorem divK_loop_body_n3_call_addback_j0_exact_loopIterScratch_v4_noNop (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu : BitVec.ult u3 v2)
+    (hborrow : loopBodyN3CallAddbackBorrowV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hcarry2_nz : loopBodyN3CallAddbackCarry2NzV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 224 (base + loopBodyOff) (base + denormOff) (divCode_noNop_v4 base)
+      (loopBodyN3CallSkipJ0PreV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopIterPostN3CallScratchNoX1 sp base (0 : Word)
+        (divKTrialCallV4QHat u3 u2 v2)
+        (divKTrialCallV4DLo v2)
+        (divKTrialCallV4Un0 u2)
+        (divKTrialCallV4ScratchOut u3 u2 v2 scratchMem)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+        (.x1 ↦ᵣ raVal)) := by
+  have hb :
+      BitVec.ult uTop
+        (mulsubN4_c3 (divKTrialCallV4QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3) := by
+    unfold loopBodyN3CallAddbackBorrowV4 at hborrow
+    dsimp only [] at hborrow
+    by_contra hlt
+    rw [if_neg hlt] at hborrow
+    exact hborrow rfl
+  exact cpsTripleWithin_weaken
+    (fun h hp => hp)
+    (fun h hp => by
+      have hpost :
+          ((loopBodyN3CallAddbackBeqPostJScratchNoX1 sp base (0 : Word)
+            (divKTrialCallV4QHat u3 u2 v2)
+            (divKTrialCallV4DLo v2)
+            (divKTrialCallV4Un0 u2)
+            (divKTrialCallV4ScratchOut u3 u2 v2 scratchMem)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop) ** (.x1 ↦ᵣ raVal)) h := by
+        unfold loopBodyN3CallAddbackJ0PostV4NoX1 at hp
+        unfold loopBodyN3CallAddbackBeqPostJScratchNoX1
+        simpa only [sepConj_assoc'] using hp
+      rw [loopIterPostN3CallScratchNoX1_addback hb] at hpost
+      exact hpost)
+    (cpsTripleWithin_extend_code
+      (hmono := sharedDivModCodeNoNop_v4_sub_divCode_noNop_v4)
+      (divK_loop_body_n3_call_addback_j0_beq_v4_spec_within_noNop_exact_x1
+        sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal
+        retMem dMem dloMem scratchUn0 scratchMem base halign hbltu hborrow hcarry2_nz))
+
+/-- Loop body n=3, call+addback, j>0 over `divCode_noNop_v4`, preserving
+    concrete `x1` and exposing the scratch loop-iteration post. -/
+theorem divK_loop_body_n3_call_addback_jgt0_exact_loopIterScratch_v4_noNop (j sp base : Word)
+    (hpos : BitVec.slt (j + signExtend12 4095) 0 = false)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu : BitVec.ult u3 v2)
+    (hborrow : loopBodyN3CallAddbackBorrowV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hcarry2_nz : loopBodyN3CallAddbackCarry2NzV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 224 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop_v4 base)
+      (loopBodyN3CallSkipJgt0PreV4NoX1 sp j jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopIterPostN3CallScratchNoX1 sp base j
+        (divKTrialCallV4QHat u3 u2 v2)
+        (divKTrialCallV4DLo v2)
+        (divKTrialCallV4Un0 u2)
+        (divKTrialCallV4ScratchOut u3 u2 v2 scratchMem)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+        (.x1 ↦ᵣ raVal)) := by
+  have hb :
+      BitVec.ult uTop
+        (mulsubN4_c3 (divKTrialCallV4QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3) := by
+    unfold loopBodyN3CallAddbackBorrowV4 at hborrow
+    dsimp only [] at hborrow
+    by_contra hlt
+    rw [if_neg hlt] at hborrow
+    exact hborrow rfl
+  exact cpsTripleWithin_weaken
+    (fun h hp => hp)
+    (fun h hp => by
+      have hpost :
+          ((loopBodyN3CallAddbackBeqPostJScratchNoX1 sp base j
+            (divKTrialCallV4QHat u3 u2 v2)
+            (divKTrialCallV4DLo v2)
+            (divKTrialCallV4Un0 u2)
+            (divKTrialCallV4ScratchOut u3 u2 v2 scratchMem)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop) ** (.x1 ↦ᵣ raVal)) h := by
+        unfold loopBodyN3CallAddbackJgt0PostV4NoX1 at hp
+        unfold loopBodyN3CallAddbackBeqPostJScratchNoX1
+        simpa only [sepConj_assoc'] using hp
+      rw [loopIterPostN3CallScratchNoX1_addback hb] at hpost
+      exact hpost)
+    (cpsTripleWithin_extend_code
+      (hmono := sharedDivModCodeNoNop_v4_sub_divCode_noNop_v4)
+      (divK_loop_body_n3_call_addback_jgt0_beq_v4_spec_within_noNop_exact_x1 j hpos
+        sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal
+        retMem dMem dloMem scratchUn0 scratchMem base halign hbltu hborrow hcarry2_nz))
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V4NoNop.lean
@@ -681,4 +681,43 @@ theorem divK_loop_n3_call_j1_from_source_exact_loopIterScratch_v4_noNop (sp base
     (fun h hp => hp)
     J1f
 
+/-- A j=1 call iteration postcondition with v4 scratch cells specializes to the
+    j=0 call-body precondition, retaining the j=1 carried u4/q atoms as frame. -/
+theorem loopIterPostN3CallScratchNoX1_j1_to_call_j0_pre
+    (sp base qHat dLo divUn0 scratchOut : Word)
+    (v0 v1 v2 v3 u0Orig u1 u2 u3 uTop q0Old raVal : Word) :
+    let r := iterWithDoubleAddback qHat v0 v1 v2 v3 u0Orig u1 u2 u3 uTop
+    let c3 := mulsubN4_c3 qHat v0 v1 v2 v3 u0Orig u1 u2 u3
+    let uBase1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+    ∀ h,
+      (((loopIterPostN3CallScratchNoX1 sp base (1 : Word)
+        qHat dLo divUn0 scratchOut v0 v1 v2 v3 u0Orig u1 u2 u3 uTop **
+        (.x1 ↦ᵣ raVal)) **
+        (((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) +
+          signExtend12 0 ↦ₘ u0Orig) **
+         ((sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q0Old))) h) →
+      (((loopBodyN3CallSkipJ0PreV4NoX1 sp (1 : Word)
+          ((1 : Word) <<< (3 : BitVec 6).toNat) uBase1 qAddr1 c3 r.1
+          r.2.2.2.2.1 v0 v1 v2 v3 u0Orig r.2.1 r.2.2.1 r.2.2.2.1
+          r.2.2.2.2.1 q0Old
+          (base + div128CallRetOff) v2 dLo divUn0 scratchOut **
+          (.x1 ↦ᵣ raVal)) **
+        ((uBase1 + signExtend12 4064 ↦ₘ r.2.2.2.2.2) **
+         (qAddr1 ↦ₘ r.1))) h) := by
+  intro r c3 uBase1 qAddr1 h hp
+  subst uBase1
+  subst qAddr1
+  subst c3
+  subst r
+  delta loopIterPostN3CallScratchNoX1 loopExitPostN3 loopExitPost at hp
+  delta loopBodyN3CallSkipJ0PreV4NoX1
+  unfold mulsubN4_c3
+  simp only [] at hp ⊢
+  have hj' := EvmAsm.Evm64.DivMod.AddrNorm.jpred_1
+  rw [hj', u_j1_0_eq_j0_4088, u_j1_4088_eq_j0_4080,
+      u_j1_4080_eq_j0_4072, u_j1_4072_eq_j0_4064] at hp
+  rw [sepConj_assoc'] at hp
+  xperm_hyp hp
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V4NoNop.lean
@@ -616,4 +616,69 @@ theorem divK_loop_body_n3_call_j1_exact_loopIterScratch_v4_noNop (sp base : Word
         v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal
         retMem dMem dloMem scratchUn0 scratchMem halign hbltu hborrow_zero
 
+/-- The callable-ready v4 n=3 loop source specializes to the j=1 call-body
+    precondition, with j=0 source atoms retained as a frame. -/
+theorem loopN3PreWithScratchV4NoX1_to_call_j1_pre
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word) :
+    ∀ h,
+      (loopN3PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem ** (.x1 ↦ᵣ raVal)) h →
+      ((loopBodyN3CallSkipJgt0PreV4NoX1 sp (1 : Word)
+        jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop q1Old
+        retMem dMem dloMem scratchUn0 scratchMem ** (.x1 ↦ᵣ raVal)) **
+        (((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) +
+          signExtend12 0 ↦ₘ u0Orig) **
+         ((sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q0Old))) h := by
+  intro h hp
+  delta loopN3PreWithScratchV4NoX1 loopN3PreWithScratchNoX1 loopN3Pre at hp
+  delta loopBodyN3CallSkipJgt0PreV4NoX1
+  simp only []
+  xperm_hyp hp
+
+/-- First n=3 call iteration from the callable-ready v4 loop source, preserving
+    concrete `x1` and carrying the j=0 source atoms as a frame. -/
+theorem divK_loop_n3_call_j1_from_source_exact_loopIterScratch_v4_noNop (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu : BitVec.ult u3 v2)
+    (hcarry2_nz : loopBodyN3CallAddbackCarry2NzV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 224 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop_v4 base)
+      (loopN3PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      ((loopIterPostN3CallScratchNoX1 sp base (1 : Word)
+        (divKTrialCallV4QHat u3 u2 v2)
+        (divKTrialCallV4DLo v2)
+        (divKTrialCallV4Un0 u2)
+        (divKTrialCallV4ScratchOut u3 u2 v2 scratchMem)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+        (.x1 ↦ᵣ raVal)) **
+        (((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) +
+          signExtend12 0 ↦ₘ u0Orig) **
+         ((sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q0Old))) := by
+  have J1 := divK_loop_body_n3_call_j1_exact_loopIterScratch_v4_noNop sp base
+    jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop q1Old raVal
+    retMem dMem dloMem scratchUn0 scratchMem halign hbltu hcarry2_nz
+  have J1f := cpsTripleWithin_frameR
+    ((((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 0 ↦ₘ u0Orig) **
+     ((sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q0Old)))
+    (by pcFree) J1
+  exact cpsTripleWithin_weaken
+    (loopN3PreWithScratchV4NoX1_to_call_j1_pre
+      sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal
+      retMem dMem dloMem scratchUn0 scratchMem)
+    (fun h hp => hp)
+    J1f
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V4NoNop.lean
@@ -533,4 +533,87 @@ theorem divK_loop_body_n3_call_addback_jgt0_exact_loopIterScratch_v4_noNop (j sp
         v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal
         retMem dMem dloMem scratchUn0 scratchMem base halign hbltu hborrow hcarry2_nz))
 
+/-- Loop body n=3, call path, j=0 over `divCode_noNop_v4`, selecting the
+    skip or addback correction from the computed mulsub borrow bit. -/
+theorem divK_loop_body_n3_call_j0_exact_loopIterScratch_v4_noNop (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu : BitVec.ult u3 v2)
+    (hcarry2_nz : loopBodyN3CallAddbackCarry2NzV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 224 (base + loopBodyOff) (base + denormOff) (divCode_noNop_v4 base)
+      (loopBodyN3CallSkipJ0PreV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopIterPostN3CallScratchNoX1 sp base (0 : Word)
+        (divKTrialCallV4QHat u3 u2 v2)
+        (divKTrialCallV4DLo v2)
+        (divKTrialCallV4Un0 u2)
+        (divKTrialCallV4ScratchOut u3 u2 v2 scratchMem)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+        (.x1 ↦ᵣ raVal)) := by
+  by_cases hborrow : BitVec.ult uTop
+      (mulsubN4_c3 (divKTrialCallV4QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3)
+  · have hborrow_nz : loopBodyN3CallAddbackBorrowV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+      simp [loopBodyN3CallAddbackBorrowV4, hborrow]
+    exact divK_loop_body_n3_call_addback_j0_exact_loopIterScratch_v4_noNop
+      sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal
+      retMem dMem dloMem scratchUn0 scratchMem halign hbltu hborrow_nz hcarry2_nz
+  · have hborrow_zero :
+        loopBodyN3CallSkipJ0BorrowV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+      unfold loopBodyN3CallSkipJ0BorrowV4 mulsubN4NoBorrow
+      dsimp only
+      unfold mulsubN4_c3 at hborrow
+      rw [if_neg hborrow]
+    exact cpsTripleWithin_mono_nSteps (by decide) <|
+      divK_loop_body_n3_call_skip_j0_exact_loopIterScratch_v4_noNop
+        sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal
+        retMem dMem dloMem scratchUn0 scratchMem halign hbltu hborrow_zero
+
+/-- Loop body n=3, call path, j=1 over `divCode_noNop_v4`, selecting the
+    skip or addback correction from the computed mulsub borrow bit. -/
+theorem divK_loop_body_n3_call_j1_exact_loopIterScratch_v4_noNop (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu : BitVec.ult u3 v2)
+    (hcarry2_nz : loopBodyN3CallAddbackCarry2NzV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 224 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop_v4 base)
+      (loopBodyN3CallSkipJgt0PreV4NoX1 sp (1 : Word) jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopIterPostN3CallScratchNoX1 sp base (1 : Word)
+        (divKTrialCallV4QHat u3 u2 v2)
+        (divKTrialCallV4DLo v2)
+        (divKTrialCallV4Un0 u2)
+        (divKTrialCallV4ScratchOut u3 u2 v2 scratchMem)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+        (.x1 ↦ᵣ raVal)) := by
+  by_cases hborrow : BitVec.ult uTop
+      (mulsubN4_c3 (divKTrialCallV4QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3)
+  · have hborrow_nz : loopBodyN3CallAddbackBorrowV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+      simp [loopBodyN3CallAddbackBorrowV4, hborrow]
+    exact divK_loop_body_n3_call_addback_jgt0_exact_loopIterScratch_v4_noNop
+      (1 : Word) sp base EvmAsm.Evm64.DivMod.AddrNorm.slt_jpos_1
+      jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal
+      retMem dMem dloMem scratchUn0 scratchMem halign hbltu hborrow_nz hcarry2_nz
+  · have hborrow_zero :
+        mulsubN4NoBorrow (divKTrialCallV4QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+      unfold mulsubN4NoBorrow
+      dsimp only
+      unfold mulsubN4_c3 at hborrow
+      rw [if_neg hborrow]
+    exact cpsTripleWithin_mono_nSteps (by decide) <|
+      divK_loop_body_n3_call_skip_j1_exact_loopIterScratch_v4_noNop
+        sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal
+        retMem dMem dloMem scratchUn0 scratchMem halign hbltu hborrow_zero
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V4NoNop.lean
@@ -925,6 +925,154 @@ theorem divK_loop_body_n3_max_j0_exact_loopIterScratch_v4_noNop (sp base : Word)
           xperm_hyp hp)
         Jf
 
+/-- Loop body n=3, max path, j=1 over `divCode_noNop_v4`, preserving
+    concrete `x1` and callable scratch cells as frame. -/
+theorem divK_loop_body_n3_max_j1_exact_loopIterScratch_v4_noNop (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hbltu : ¬BitVec.ult u3 v2)
+    (hcarry2_nz : isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 152 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop_v4 base)
+      ((loopBodyN3MaxSkipJ1NormPreV4 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal)))
+      ((loopIterPostN3Max sp (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal))) := by
+  by_cases hborrow : BitVec.ult uTop
+      (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+  · have hborrow_nz :
+        (if BitVec.ult uTop
+          (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+         then (1 : Word) else 0) ≠ (0 : Word) := by
+      rw [if_pos hborrow]
+      decide
+    have J := divK_loop_body_n3_max_addback_jgt0_beq_norm_v4_noNop
+      (1 : Word) sp base EvmAsm.Evm64.DivMod.AddrNorm.slt_jpos_1
+      jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld hbltu hcarry2_nz hborrow_nz
+    have Jf := cpsTripleWithin_frameR
+      ((sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
+       (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+       (sp + signExtend12 3936 ↦ₘ scratchMem) **
+       (.x1 ↦ᵣ raVal))
+      (by pcFree) J
+    exact cpsTripleWithin_weaken
+      (fun h hp => by
+        delta loopBodyN3MaxSkipJ1NormPreV4 loopBodyN3MaxAddbackJgt0NormPreV4 at hp ⊢
+        xperm_hyp hp)
+      (fun h hp => by
+        rw [loopIterPostN3Max_addback hborrow] at hp
+        xperm_hyp hp)
+      Jf
+  · have hborrow_zero :
+        (if BitVec.ult uTop
+          (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+         then (1 : Word) else 0) = (0 : Word) := by
+      rw [if_neg hborrow]
+    have J := divK_loop_body_n3_max_skip_j1_norm_v4_noNop
+      sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld hbltu hborrow_zero
+    have Jf := cpsTripleWithin_frameR
+      ((sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
+       (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+       (sp + signExtend12 3936 ↦ₘ scratchMem) **
+       (.x1 ↦ᵣ raVal))
+      (by pcFree) J
+    exact cpsTripleWithin_mono_nSteps (by decide) <|
+      cpsTripleWithin_weaken
+        (fun h hp => by xperm_hyp hp)
+        (fun h hp => by
+          rw [loopIterPostN3Max_skip hborrow] at hp
+          xperm_hyp hp)
+        Jf
+
+/-- The callable-ready v4 n=3 loop source specializes to the j=1 max-body
+    precondition, with j=0 source atoms retained as a frame. -/
+theorem loopN3PreWithScratchV4NoX1_to_max_j1_pre
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word) :
+    ∀ h,
+      (loopN3PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem ** (.x1 ↦ᵣ raVal)) h →
+      ((loopBodyN3MaxSkipJ1NormPreV4 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop q1Old **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal)) **
+        (((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) +
+          signExtend12 0 ↦ₘ u0Orig) **
+         ((sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q0Old))) h := by
+  intro h hp
+  delta loopN3PreWithScratchV4NoX1 loopN3PreWithScratchNoX1 loopN3Pre at hp
+  delta loopBodyN3MaxSkipJ1NormPreV4
+  rw [loopBodyN3MaxSkipPre_unfold]
+  xperm_hyp hp
+
+/-- A j=1 max iteration postcondition with v4 scratch cells specializes to the
+    j=0 call-body precondition, retaining exact `x1` and j=1 carried u4/q
+    atoms as frame. -/
+theorem loopIterPostN3MaxScratchX1_j1_to_call_j0_pre
+    (sp retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (v0 v1 v2 v3 u0J1 u1 u2 u3 uTop u0Orig q0Old raVal : Word) :
+    let r := iterN3Max v0 v1 v2 v3 u0J1 u1 u2 u3 uTop
+    let c3 := mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0J1 u1 u2 u3
+    let uBase1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+    ∀ h,
+      (((loopIterPostN3Max sp (1 : Word) v0 v1 v2 v3 u0J1 u1 u2 u3 uTop **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal)) **
+        (((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) +
+          signExtend12 0 ↦ₘ u0Orig) **
+         ((sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q0Old))) h) →
+      (((loopBodyN3CallSkipJ0PreV4NoX1 sp (1 : Word)
+          ((1 : Word) <<< (3 : BitVec 6).toNat) uBase1 qAddr1 c3 r.1
+          r.2.2.2.2.1 v0 v1 v2 v3 u0Orig r.2.1 r.2.2.1 r.2.2.2.1
+          r.2.2.2.2.1 q0Old retMem dMem dloMem scratchUn0 scratchMem **
+          (.x1 ↦ᵣ raVal)) **
+        ((uBase1 + signExtend12 4064 ↦ₘ r.2.2.2.2.2) **
+         (qAddr1 ↦ₘ r.1))) h) := by
+  intro r c3 uBase1 qAddr1 h hp
+  subst uBase1
+  subst qAddr1
+  subst c3
+  subst r
+  delta loopIterPostN3Max loopExitPostN3 loopExitPost at hp
+  delta loopBodyN3CallSkipJ0PreV4NoX1
+  unfold mulsubN4_c3
+  simp only [] at hp ⊢
+  have hj' := EvmAsm.Evm64.DivMod.AddrNorm.jpred_1
+  rw [hj', u_j1_0_eq_j0_4088, u_j1_4088_eq_j0_4080,
+      u_j1_4080_eq_j0_4072, u_j1_4072_eq_j0_4064] at hp
+  simp only [se12_32, se12_40, se12_48, se12_56,
+             u_base_off0_j0, q_addr_j0] at hp ⊢
+  rw [sepConj_assoc'] at hp
+  xperm_hyp hp
+
 /-- Full n=3 call×max path from the callable-ready v4 loop source, preserving
     concrete `x1`, scratch, and the j=1 stored u4/q atoms. -/
 theorem divK_loop_n3_call_max_from_source_exact_loopIterScratch_v4_noNop (sp base : Word)

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V4NoNopMaxCall.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V4NoNopMaxCall.lean
@@ -11,6 +11,138 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)
+
+/-- A j=1 max iteration postcondition with v4 scratch cells specializes to the
+    j=0 max-body precondition, retaining exact `x1` and j=1 carried u4/q
+    atoms as frame. -/
+theorem loopIterPostN3MaxScratchX1_j1_to_max_j0_pre
+    (sp retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (v0 v1 v2 v3 u0J1 u1 u2 u3 uTop u0Orig q0Old raVal : Word) :
+    let r := iterN3Max v0 v1 v2 v3 u0J1 u1 u2 u3 uTop
+    let c3 := mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0J1 u1 u2 u3
+    let uBase1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+    ∀ h,
+      (((loopIterPostN3Max sp (1 : Word) v0 v1 v2 v3 u0J1 u1 u2 u3 uTop **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal)) **
+        (((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) +
+          signExtend12 0 ↦ₘ u0Orig) **
+         ((sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q0Old))) h) →
+      (((loopBodyN3MaxSkipJ0NormPreV4 sp (1 : Word)
+          ((1 : Word) <<< (3 : BitVec 6).toNat) uBase1 qAddr1 c3 r.1
+          r.2.2.2.2.1 v0 v1 v2 v3 u0Orig r.2.1 r.2.2.1 r.2.2.2.1
+          r.2.2.2.2.1 q0Old **
+          (sp + signExtend12 3968 ↦ₘ retMem) **
+          (sp + signExtend12 3960 ↦ₘ dMem) **
+          (sp + signExtend12 3952 ↦ₘ dloMem) **
+          (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+          (sp + signExtend12 3936 ↦ₘ scratchMem) **
+          (.x1 ↦ᵣ raVal)) **
+        ((uBase1 + signExtend12 4064 ↦ₘ r.2.2.2.2.2) **
+         (qAddr1 ↦ₘ r.1))) h) := by
+  intro r c3 uBase1 qAddr1 h hp
+  subst uBase1
+  subst qAddr1
+  subst c3
+  subst r
+  delta loopIterPostN3Max loopExitPostN3 loopExitPost at hp
+  delta loopBodyN3MaxSkipJ0NormPreV4
+  unfold mulsubN4_c3
+  simp only [] at hp ⊢
+  have hj' := EvmAsm.Evm64.DivMod.AddrNorm.jpred_1
+  rw [hj', u_j1_0_eq_j0_4088, u_j1_4088_eq_j0_4080,
+      u_j1_4080_eq_j0_4072, u_j1_4072_eq_j0_4064] at hp
+  simp only [se12_32, se12_40, se12_48, se12_56,
+             u_base_off0_j0, u_base_off4088_j0, u_base_off4080_j0,
+             u_base_off4072_j0, u_base_off4064_j0, q_addr_j0] at hp ⊢
+  rw [sepConj_assoc'] at hp
+  xperm_hyp hp
+
+/-- Full n=3 max×max path from the callable-ready v4 loop source, preserving
+    concrete `x1`, scratch, and the j=1 stored u4/q atoms. -/
+theorem divK_loop_n3_max_max_from_source_exact_loopIterScratch_v4_noNop (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hbltu_1 : ¬BitVec.ult u3 v2)
+    (hcarry2_nz_1 : isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hbltu_0 :
+      let r1 := iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      ¬BitVec.ult r1.2.2.2.1 v2)
+    (hcarry2_nz_0 :
+      let r1 := iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      isAddbackCarry2NzN3Max v0 v1 v2 v3
+        u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1) :
+    let r1 := iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    let uBase1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+    cpsTripleWithin (152 + 152) (base + loopBodyOff) (base + denormOff) (divCode_noNop_v4 base)
+      (loopN3PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      ((loopIterPostN3Max sp (0 : Word) v0 v1 v2 v3
+        u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal)) **
+        ((uBase1 + signExtend12 4064 ↦ₘ r1.2.2.2.2.2) **
+         (qAddr1 ↦ₘ r1.1))) := by
+  intro r1 uBase1 qAddr1
+  have J1 := divK_loop_body_n3_max_j1_exact_loopIterScratch_v4_noNop sp base
+    jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop q1Old raVal
+    retMem dMem dloMem scratchUn0 scratchMem hbltu_1 hcarry2_nz_1
+  subst r1
+  subst uBase1
+  subst qAddr1
+  have J1f := cpsTripleWithin_frameR
+    ((((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 0 ↦ₘ u0Orig) **
+     ((sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q0Old)))
+    (by pcFree) J1
+  have J0 := divK_loop_body_n3_max_j0_exact_loopIterScratch_v4_noNop sp base
+    (1 : Word)
+    ((1 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat)
+    (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).1
+    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
+    v0 v1 v2 v3 u0Orig
+    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
+    q0Old raVal retMem dMem dloMem scratchUn0 scratchMem hbltu_0 hcarry2_nz_0
+  have J0f := cpsTripleWithin_frameR
+    (((sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 4064 ↦ₘ
+        (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.2) **
+     ((sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ
+        (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).1))
+    (by pcFree) J0
+  exact cpsTripleWithin_seq_perm_same_cr
+    (loopIterPostN3MaxScratchX1_j1_to_max_j0_pre
+      sp retMem dMem dloMem scratchUn0 scratchMem
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q0Old raVal)
+    (cpsTripleWithin_weaken
+      (loopN3PreWithScratchV4NoX1_to_max_j1_pre
+        sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal
+        retMem dMem dloMem scratchUn0 scratchMem)
+      (fun h hp => hp)
+      J1f)
+    J0f
 
 /-- Full n=3 max×call path from the callable-ready v4 loop source, preserving
     concrete `x1`, scratch, and the j=1 stored u4/q atoms. -/

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V4NoNopMaxCall.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V4NoNopMaxCall.lean
@@ -1,0 +1,98 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN3V4NoNopMaxCall
+
+  Split-out n=3 max×call exact-source theorem for the v4 no-NOP loop.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V4NoNop
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Full n=3 max×call path from the callable-ready v4 loop source, preserving
+    concrete `x1`, scratch, and the j=1 stored u4/q atoms. -/
+theorem divK_loop_n3_max_call_from_source_exact_loopIterScratch_v4_noNop (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_1 : ¬BitVec.ult u3 v2)
+    (hcarry2_nz_1 : isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hbltu_0 :
+      let r1 := iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      BitVec.ult r1.2.2.2.1 v2)
+    (hcarry2_nz_0 :
+      let r1 := iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      loopBodyN3CallAddbackCarry2NzV4 v0 v1 v2 v3
+        u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1) :
+    let r1 := iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    let uBase1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+    cpsTripleWithin (152 + 224) (base + loopBodyOff) (base + denormOff) (divCode_noNop_v4 base)
+      (loopN3PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      ((loopIterPostN3CallScratchNoX1 sp base (0 : Word)
+        (divKTrialCallV4QHat r1.2.2.2.1 r1.2.2.1 v2)
+        (divKTrialCallV4DLo v2)
+        (divKTrialCallV4Un0 r1.2.2.1)
+        (divKTrialCallV4ScratchOut r1.2.2.2.1 r1.2.2.1 v2 scratchMem)
+        v0 v1 v2 v3 u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 **
+        (.x1 ↦ᵣ raVal)) **
+        ((uBase1 + signExtend12 4064 ↦ₘ r1.2.2.2.2.2) **
+         (qAddr1 ↦ₘ r1.1))) := by
+  intro r1 uBase1 qAddr1
+  have J1 := divK_loop_body_n3_max_j1_exact_loopIterScratch_v4_noNop sp base
+    jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop q1Old raVal
+    retMem dMem dloMem scratchUn0 scratchMem hbltu_1 hcarry2_nz_1
+  subst r1
+  subst uBase1
+  subst qAddr1
+  have J1f := cpsTripleWithin_frameR
+    ((((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 0 ↦ₘ u0Orig) **
+     ((sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q0Old)))
+    (by pcFree) J1
+  have J0 := divK_loop_body_n3_call_j0_exact_loopIterScratch_v4_noNop sp base
+    (1 : Word)
+    ((1 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat)
+    (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).1
+    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
+    v0 v1 v2 v3 u0Orig
+    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
+    q0Old raVal
+    retMem dMem dloMem scratchUn0 scratchMem
+    halign hbltu_0 hcarry2_nz_0
+  have J0f := cpsTripleWithin_frameR
+    (((sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 4064 ↦ₘ
+        (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.2) **
+     ((sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ
+        (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).1))
+    (by pcFree) J0
+  exact cpsTripleWithin_seq_perm_same_cr
+    (loopIterPostN3MaxScratchX1_j1_to_call_j0_pre
+      sp retMem dMem dloMem scratchUn0 scratchMem
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q0Old raVal)
+    (cpsTripleWithin_weaken
+      (loopN3PreWithScratchV4NoX1_to_max_j1_pre
+        sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal
+        retMem dMem dloMem scratchUn0 scratchMem)
+      (fun h hp => hp)
+      J1f)
+    J0f
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V4NoNopMaxCall.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V4NoNopMaxCall.lean
@@ -472,4 +472,51 @@ theorem evm_div_n3_loop_unified_inst_noNop_exact_x1_v4
     retMem dMem dloMem scratchUn0 scratchMem
     halign hbltu_1 hbltu_0 hcarry2
 
+/-- Handoff from the n=3 preloop postcondition to the v4 no-`x1` loop source,
+    preserving caller-owned `x1` and the v4 div128 scratch cell. -/
+theorem loopSetupPost_to_loopN3PreWithScratchV4NoX1_framed
+    (sp : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v11Old : Word)
+    (jMem retMem dMem dloMem scratchUn0 scratchMem raVal : Word) :
+    ∀ h,
+      (loopSetupPost sp (3 : Word) (clzResult b2).1 a0 a1 a2 a3 b0 b1 b2 b3 **
+       ((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal))) h →
+      (((loopN3PreWithScratchV4NoX1 sp
+        jMem (3 : Word) (fullDivN3Shift b2)
+        (fullDivN3NormU a0 a1 a2 a3 b2).1
+        (a0 >>> ((fullDivN3AntiShift b2).toNat % 64)) v11Old (fullDivN3AntiShift b2)
+        (fullDivN3NormV b0 b1 b2 b3).1
+        (fullDivN3NormV b0 b1 b2 b3).2.1
+        (fullDivN3NormV b0 b1 b2 b3).2.2.1
+        (fullDivN3NormV b0 b1 b2 b3).2.2.2
+        (fullDivN3NormU a0 a1 a2 a3 b2).2.1
+        (fullDivN3NormU a0 a1 a2 a3 b2).2.2.1
+        (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.1
+        (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.2
+        (0 : Word)
+        (fullDivN3NormU a0 a1 a2 a3 b2).1
+        (0 : Word) (0 : Word)
+        retMem dMem dloMem scratchUn0 scratchMem ** (.x1 ↦ᵣ raVal)) **
+       (((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+        ((sp + signExtend12 4072) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 3992) ↦ₘ (clzResult b2).1))) h) := by
+  intro h hp
+  delta loopN3PreWithScratchV4NoX1 loopN3PreWithScratchNoX1 loopN3Pre at ⊢
+  delta loopSetupPost fullDivN3NormV fullDivN3NormU fullDivN3Shift fullDivN3AntiShift at hp ⊢
+  simp only [x1_val_n3] at hp
+  simp only [n3_ub1_off0, n3_ub1_off4088, n3_ub1_off4080,
+              n3_ub1_off4072, n3_ub1_off4064, n3_ub0_off0,
+              n3_qa1, n3_qa0, se12_32, se12_40, se12_48, se12_56] at hp ⊢
+  xperm_hyp hp
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V4NoNopMaxCall.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V4NoNopMaxCall.lean
@@ -436,4 +436,40 @@ theorem divK_loop_n3_unified_from_source_exact_loopIterScratch_v4_noNop
         v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal
         retMem dMem dloMem scratchUn0 scratchMem halign hb1 hc1 hb0 hc0)
 
+/-- Helper: instantiate the v4 no-NOP exact-`x1` n=3 loop with explicit
+    normalized values. This is the callable-ready analogue of
+    `evm_div_n3_loop_unified_inst_noNop`, with the v4 div128 scratch cell and
+    caller-owned `x1` split out of the loop source. -/
+theorem evm_div_n3_loop_unified_inst_noNop_exact_x1_v4
+    (bltu_1 bltu_0 : Bool) (sp base : Word)
+    (shift antiShift b0' b1' b2' b3' u0 u1 u2 u3 u4 : Word)
+    (v10Old v11Old jMem : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem raVal : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_1 : bltu_1 = BitVec.ult u4 b2')
+    (hbltu_0 : bltu_0 =
+      match bltu_1 with
+      | false => BitVec.ult (iterN3Max b0' b1' b2' b3' u1 u2 u3 u4 (0 : Word)).2.2.2.1 b2'
+      | true =>
+        BitVec.ult
+          (iterWithDoubleAddback (divKTrialCallV4QHat u4 u3 b2')
+            b0' b1' b2' b3' u1 u2 u3 u4 (0 : Word)).2.2.2.1 b2')
+    (hcarry2 : Carry2NzAll b0' b1' b2' b3') :
+    cpsTripleWithin 448 (base + loopBodyOff) (base + denormOff) (divCode_noNop_v4 base)
+      (loopN3PreWithScratchV4NoX1 sp jMem (3 : Word) shift u0 v10Old v11Old antiShift
+        b0' b1' b2' b3' u1 u2 u3 u4 (0 : Word) u0 (0 : Word) (0 : Word)
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopN3UnifiedPostV4NoX1 bltu_1 bltu_0 sp base
+        b0' b1' b2' b3' u1 u2 u3 u4 (0 : Word) u0
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal)) :=
+  divK_loop_n3_unified_from_source_exact_loopIterScratch_v4_noNop
+    bltu_1 bltu_0 sp base
+    jMem (3 : Word) shift u0 v10Old v11Old antiShift
+    b0' b1' b2' b3' u1 u2 u3 u4 (0 : Word) u0 (0 : Word) (0 : Word) raVal
+    retMem dMem dloMem scratchUn0 scratchMem
+    halign hbltu_1 hbltu_0 hcarry2
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V4NoNopMaxCall.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V4NoNopMaxCall.lean
@@ -13,6 +13,68 @@ namespace EvmAsm.Evm64
 open EvmAsm.Rv64
 open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)
 
+/-- Unified n=3 v4 no-`x1` loop postcondition.  It mirrors
+    `loopN3UnifiedPost`, but keeps the v4 div128 scratch cell at `sp+3936`
+    explicit and leaves the caller-owned `x1` outside the post. -/
+@[irreducible]
+def loopN3UnifiedPostV4NoX1 (bltu_1 bltu_0 : Bool)
+    (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word) : Assertion :=
+  match bltu_1, bltu_0 with
+  | false, false =>
+    let r1 := iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    let uBase1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+    loopIterPostN3Max sp (0 : Word) v0 v1 v2 v3
+      u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 **
+    (sp + signExtend12 3968 ↦ₘ retMem) **
+    (sp + signExtend12 3960 ↦ₘ dMem) **
+    (sp + signExtend12 3952 ↦ₘ dloMem) **
+    (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+    (sp + signExtend12 3936 ↦ₘ scratchMem) **
+    ((uBase1 + signExtend12 4064 ↦ₘ r1.2.2.2.2.2) **
+     (qAddr1 ↦ₘ r1.1))
+  | false, true =>
+    let r1 := iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    let uBase1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+    loopIterPostN3CallScratchNoX1 sp base (0 : Word)
+      (divKTrialCallV4QHat r1.2.2.2.1 r1.2.2.1 v2)
+      (divKTrialCallV4DLo v2)
+      (divKTrialCallV4Un0 r1.2.2.1)
+      (divKTrialCallV4ScratchOut r1.2.2.2.1 r1.2.2.1 v2 scratchMem)
+      v0 v1 v2 v3 u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 **
+    ((uBase1 + signExtend12 4064 ↦ₘ r1.2.2.2.2.2) **
+     (qAddr1 ↦ₘ r1.1))
+  | true, false =>
+    let r1 := iterWithDoubleAddback (divKTrialCallV4QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    let uBase1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+    loopIterPostN3Max sp (0 : Word) v0 v1 v2 v3
+      u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 **
+    (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+    (sp + signExtend12 3960 ↦ₘ v2) **
+    (sp + signExtend12 3952 ↦ₘ (divKTrialCallV4DLo v2)) **
+    (sp + signExtend12 3944 ↦ₘ (divKTrialCallV4Un0 u2)) **
+    (sp + signExtend12 3936 ↦ₘ (divKTrialCallV4ScratchOut u3 u2 v2 scratchMem)) **
+    ((uBase1 + signExtend12 4064 ↦ₘ r1.2.2.2.2.2) **
+     (qAddr1 ↦ₘ r1.1))
+  | true, true =>
+    let r1 := iterWithDoubleAddback (divKTrialCallV4QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    let uBase1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+    loopIterPostN3CallScratchNoX1 sp base (0 : Word)
+      (divKTrialCallV4QHat r1.2.2.2.1 r1.2.2.1 v2)
+      (divKTrialCallV4DLo v2)
+      (divKTrialCallV4Un0 r1.2.2.1)
+      (divKTrialCallV4ScratchOut r1.2.2.2.1 r1.2.2.1 v2
+        (divKTrialCallV4ScratchOut u3 u2 v2 scratchMem))
+      v0 v1 v2 v3 u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 **
+    ((uBase1 + signExtend12 4064 ↦ₘ r1.2.2.2.2.2) **
+     (qAddr1 ↦ₘ r1.1))
+
 /-- A j=1 max iteration postcondition with v4 scratch cells specializes to the
     j=0 max-body precondition, retaining exact `x1` and j=1 carried u4/q
     atoms as frame. -/
@@ -226,5 +288,152 @@ theorem divK_loop_n3_max_call_from_source_exact_loopIterScratch_v4_noNop (sp bas
       (fun h hp => hp)
       J1f)
     J0f
+
+/-- Unified n=3 v4 no-NOP loop path from the callable-ready no-`x1` source,
+    selecting the max/call branch for both iterations and preserving concrete
+    caller `x1`. -/
+theorem divK_loop_n3_unified_from_source_exact_loopIterScratch_v4_noNop
+    (bltu_1 bltu_0 : Bool) (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_1 : bltu_1 = BitVec.ult u3 v2)
+    (hbltu_0 : bltu_0 =
+      match bltu_1 with
+      | false => BitVec.ult (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1 v2
+      | true =>
+        BitVec.ult
+          (iterWithDoubleAddback (divKTrialCallV4QHat u3 u2 v2)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1 v2)
+    (hcarry2 : Carry2NzAll v0 v1 v2 v3) :
+    cpsTripleWithin 448 (base + loopBodyOff) (base + denormOff) (divCode_noNop_v4 base)
+      (loopN3PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopN3UnifiedPostV4NoX1 bltu_1 bltu_0 sp base
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal)) := by
+  cases bltu_1 <;> cases bltu_0
+  · have hb1 : ¬BitVec.ult u3 v2 := by
+      rw [← hbltu_1]
+      decide
+    have hb0 : ¬BitVec.ult (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1 v2 := by
+      simp only at hbltu_0
+      rw [← hbltu_0]
+      decide
+    have hc1 : isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop :=
+      hcarry2 (signExtend12 4095) u0 u1 u2 u3 uTop
+    have hc0 :
+        let r1 := iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+        isAddbackCarry2NzN3Max v0 v1 v2 v3
+          u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 := by
+      intro r1
+      exact hcarry2 (signExtend12 4095) u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+    exact cpsTripleWithin_mono_nSteps (by decide) <|
+      cpsTripleWithin_weaken
+        (fun h hp => hp)
+        (fun h hp => by
+          unfold loopN3UnifiedPostV4NoX1
+          simp only at hp ⊢
+          rw [sepConj_assoc'] at hp
+          xperm_hyp hp)
+        (divK_loop_n3_max_max_from_source_exact_loopIterScratch_v4_noNop
+          sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal
+          retMem dMem dloMem scratchUn0 scratchMem hb1 hc1 hb0 hc0)
+  · have hb1 : ¬BitVec.ult u3 v2 := by
+      rw [← hbltu_1]
+      decide
+    have hb0 : BitVec.ult (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1 v2 := by
+      simp only at hbltu_0
+      exact hbltu_0.symm
+    have hc1 : isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop :=
+      hcarry2 (signExtend12 4095) u0 u1 u2 u3 uTop
+    have hc0 :
+        let r1 := iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+        loopBodyN3CallAddbackCarry2NzV4 v0 v1 v2 v3
+          u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 := by
+      intro r1
+      unfold loopBodyN3CallAddbackCarry2NzV4
+      exact hcarry2 (divKTrialCallV4QHat r1.2.2.2.1 r1.2.2.1 v2)
+        u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+    exact cpsTripleWithin_mono_nSteps (by decide) <|
+      cpsTripleWithin_weaken
+        (fun h hp => hp)
+        (fun h hp => by
+          unfold loopN3UnifiedPostV4NoX1
+          simp only at hp ⊢
+          rw [sepConj_assoc'] at hp
+          xperm_hyp hp)
+        (divK_loop_n3_max_call_from_source_exact_loopIterScratch_v4_noNop
+          sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal
+          retMem dMem dloMem scratchUn0 scratchMem halign hb1 hc1 hb0 hc0)
+  · have hb1 : BitVec.ult u3 v2 := by
+      exact hbltu_1.symm
+    have hb0 :
+        ¬BitVec.ult
+          (iterWithDoubleAddback (divKTrialCallV4QHat u3 u2 v2)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1 v2 := by
+      simp only at hbltu_0
+      rw [← hbltu_0]
+      decide
+    have hc1 : loopBodyN3CallAddbackCarry2NzV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+      unfold loopBodyN3CallAddbackCarry2NzV4
+      exact hcarry2 (divKTrialCallV4QHat u3 u2 v2) u0 u1 u2 u3 uTop
+    have hc0 :
+        let r1 := iterWithDoubleAddback (divKTrialCallV4QHat u3 u2 v2)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop
+        isAddbackCarry2NzN3Max v0 v1 v2 v3
+          u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 := by
+      intro r1
+      exact hcarry2 (signExtend12 4095) u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+    exact cpsTripleWithin_mono_nSteps (by decide) <|
+      cpsTripleWithin_weaken
+        (fun h hp => hp)
+        (fun h hp => by
+          unfold loopN3UnifiedPostV4NoX1
+          simp only at hp ⊢
+          rw [sepConj_assoc'] at hp
+          xperm_hyp hp)
+        (divK_loop_n3_call_max_from_source_exact_loopIterScratch_v4_noNop
+          sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal
+          retMem dMem dloMem scratchUn0 scratchMem halign hb1 hc1 hb0 hc0)
+  · have hb1 : BitVec.ult u3 v2 := by
+      exact hbltu_1.symm
+    have hb0 :
+        BitVec.ult
+          (iterWithDoubleAddback (divKTrialCallV4QHat u3 u2 v2)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1 v2 := by
+      simp only at hbltu_0
+      exact hbltu_0.symm
+    have hc1 : loopBodyN3CallAddbackCarry2NzV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+      unfold loopBodyN3CallAddbackCarry2NzV4
+      exact hcarry2 (divKTrialCallV4QHat u3 u2 v2) u0 u1 u2 u3 uTop
+    have hc0 :
+        let r1 := iterWithDoubleAddback (divKTrialCallV4QHat u3 u2 v2)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop
+        loopBodyN3CallAddbackCarry2NzV4 v0 v1 v2 v3
+          u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 := by
+      intro r1
+      unfold loopBodyN3CallAddbackCarry2NzV4
+      exact hcarry2 (divKTrialCallV4QHat r1.2.2.2.1 r1.2.2.1 v2)
+        u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+    exact cpsTripleWithin_weaken
+      (fun h hp => hp)
+      (fun h hp => by
+        unfold loopN3UnifiedPostV4NoX1
+        simp only at hp ⊢
+        rw [sepConj_assoc'] at hp
+        xperm_hyp hp)
+      (divK_loop_n3_call_call_from_source_exact_loopIterScratch_v4_noNop
+        sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal
+        retMem dMem dloMem scratchUn0 scratchMem halign hb1 hc1 hb0 hc0)
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LoopDefs/Bundle.lean
+++ b/EvmAsm/Evm64/DivMod/LoopDefs/Bundle.lean
@@ -81,6 +81,40 @@ def loopN3PreWithScratchNoX1
   (sp + signExtend12 3952 ↦ₘ dloMem) **
   (sp + signExtend12 3944 ↦ₘ scratch_un0)
 
+/-- Callable-ready n=3 v4 loop precondition with scratch cells and no `x1`.
+    The v4 call-body path also preserves the scratch cell at `sp+3936`. -/
+@[irreducible]
+def loopN3PreWithScratchV4NoX1
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+      retMem dMem dloMem scratch_un0 scratchMem : Word) : Assertion :=
+  loopN3PreWithScratchNoX1 sp jOld v5Old v6Old v7Old v10Old
+    v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+    retMem dMem dloMem scratch_un0 **
+  (sp + signExtend12 3936 ↦ₘ scratchMem)
+
+theorem loopN3PreWithScratchV4NoX1_pcFree
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+      retMem dMem dloMem scratch_un0 scratchMem : Word) :
+    (loopN3PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old
+      v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+      retMem dMem dloMem scratch_un0 scratchMem).pcFree := by
+  delta loopN3PreWithScratchV4NoX1 loopN3PreWithScratchNoX1 loopN3Pre
+  pcFree
+
+instance pcFreeInst_loopN3PreWithScratchV4NoX1
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+      retMem dMem dloMem scratch_un0 scratchMem : Word) :
+    Assertion.PCFree
+      (loopN3PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old
+        v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+        retMem dMem dloMem scratch_un0 scratchMem) :=
+  ⟨loopN3PreWithScratchV4NoX1_pcFree sp jOld v5Old v6Old v7Old v10Old
+    v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+    retMem dMem dloMem scratch_un0 scratchMem⟩
+
 theorem loopN3PreWithScratchNoX1_unfold
     {sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old

--- a/EvmAsm/Evm64/DivMod/LoopDefs/Post.lean
+++ b/EvmAsm/Evm64/DivMod/LoopDefs/Post.lean
@@ -658,6 +658,64 @@ theorem loopIterPostN3Call_skip {sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word}
         loopBodyN3CallSkipPostJ loopBodyN3SkipPost loopBodySkipPost loopExitPostN3 loopExitPost
   unfold mulsubN4_c3 at hb; simp only [if_neg hb]
 
+@[irreducible] def loopIterPostN3CallScratchNoX1
+    (sp base j qHat dLo divUn0 scratchOut v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
+    Assertion :=
+  let r := iterWithDoubleAddback qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  let c3 := (mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2
+  loopExitPostN3 sp j r.1 c3 r.2.1 r.2.2.1 r.2.2.2.1 r.2.2.2.2.1 r.2.2.2.2.2 v0 v1 v2 v3 **
+  (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+  (sp + signExtend12 3960 ↦ₘ v2) **
+  (sp + signExtend12 3952 ↦ₘ dLo) **
+  (sp + signExtend12 3944 ↦ₘ divUn0) **
+  (sp + signExtend12 3936 ↦ₘ scratchOut)
+
+@[irreducible] def loopBodyN3CallSkipPostJScratchNoX1
+    (sp base j qHat dLo divUn0 scratchOut v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
+    Assertion :=
+  loopBodyN3SkipPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+  (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+  (sp + signExtend12 3960 ↦ₘ v2) **
+  (sp + signExtend12 3952 ↦ₘ dLo) **
+  (sp + signExtend12 3944 ↦ₘ divUn0) **
+  (sp + signExtend12 3936 ↦ₘ scratchOut)
+
+@[irreducible] def loopBodyN3CallAddbackBeqPostJScratchNoX1
+    (sp base j qHat dLo divUn0 scratchOut v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
+    Assertion :=
+  loopBodyN3AddbackBeqPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+  (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+  (sp + signExtend12 3960 ↦ₘ v2) **
+  (sp + signExtend12 3952 ↦ₘ dLo) **
+  (sp + signExtend12 3944 ↦ₘ divUn0) **
+  (sp + signExtend12 3936 ↦ₘ scratchOut)
+
+theorem loopIterPostN3CallScratchNoX1_skip
+    {sp base j qHat dLo divUn0 scratchOut v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word}
+    (hb : ¬BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3)) :
+    loopBodyN3CallSkipPostJScratchNoX1 sp base j qHat dLo divUn0 scratchOut
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop =
+      loopIterPostN3CallScratchNoX1 sp base j qHat dLo divUn0 scratchOut
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+  delta loopIterPostN3CallScratchNoX1 loopBodyN3CallSkipPostJScratchNoX1
+    iterWithDoubleAddback loopBodyN3SkipPost loopBodySkipPost loopExitPostN3 loopExitPost
+  unfold mulsubN4_c3 at hb
+  simp only [if_neg hb]
+
+theorem loopIterPostN3CallScratchNoX1_addback
+    {sp base j qHat dLo divUn0 scratchOut v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word}
+    (hb : BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3)) :
+    loopBodyN3CallAddbackBeqPostJScratchNoX1 sp base j qHat dLo divUn0 scratchOut
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop =
+      loopIterPostN3CallScratchNoX1 sp base j qHat dLo divUn0 scratchOut
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+  delta loopIterPostN3CallScratchNoX1 loopBodyN3CallAddbackBeqPostJScratchNoX1
+    iterWithDoubleAddback loopBodyN3AddbackBeqPost loopBodyAddbackBeqPost
+    loopExitPostN3 loopExitPost
+  unfold mulsubN4_c3 at hb
+  simp only [if_pos hb]
+  split <;> rfl
+
 -- (Bool-dispatch wrapper loopIterPostN3 was removed as dead code; callers use
 -- loopIterPostN3Max / loopIterPostN3Call directly per execution path.)
 


### PR DESCRIPTION
## Summary
- includes the N3 exact call-path work from PR #5881
- add loopIterPostN3CallScratchNoX1 and scratch/no-x1 skip/addback producer posts
- prove skip/addback equations into the N3 scratch loop-iteration post
- expose exact-x1 loop-iteration wrappers for N3 call skip/addback branches over divCode_noNop_v4

## Stack note
GitHub is not accepting intermediate exact-x1 branches as PR base refs, so this PR is based on feat/div-n3-exact-x1-source and supersets PR #5881.

## Verification
- lake build EvmAsm.Evm64.DivMod.LoopDefs.Post
- lake build EvmAsm.Evm64.DivMod.Compose.FullPathN3V4NoNop
- lake build EvmAsm.Evm64.DivMod
- lake build EvmAsm.Evm64.SDiv
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- rg -n "DivStackSpecCase|ModStackSpecCase|SDivStackSpecCase|SModStackSpecCase|StackSpecCase|set_option maxRecDepth|set_option maxHeartbeats|sorry|admit" EvmAsm/Evm64/DivMod/LoopDefs/Post.lean EvmAsm/Evm64/DivMod/Compose/FullPathN3V4NoNop.lean