### PR TITLE
feat(stateless): account_extract_balance (PR-K120)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -1914,6 +1914,7 @@ def ziskAccountValidateCodeHashProbeUnit : BuildUnit := {
   dataAsm     := ziskAccountValidateCodeHashDataSection
 }
 
+
 /-! ## rlp_list_count_items -- PR-K47 top-level item counter
 
     Walk an RLP-encoded list once and return the number of
@@ -4582,6 +4583,89 @@ def ziskRlpFieldToU256BeProbeUnit : BuildUnit := {
   body        := NOP
   prologueAsm := ziskRlpFieldToU256BePrologue
   dataAsm     := ziskRlpFieldToU256BeDataSection
+}
+/-! ## account_extract_balance -- PR-K120
+
+    Extract the u256 BE `balance` field (RLP field 1) from a fully
+    RLP-encoded Ethereum account:
+
+      account = [nonce, balance, storage_root, code_hash]
+
+    The balance is the account's wei holdings, ranged in
+    `[0, 2^256)`. Direct input to balance-check predicates
+    (`balance >= value + gas_cost`), priority-fee credit, and
+    the trie-rebuild path after value transfers.
+
+    K27 `account_decode` already extracts the full account record;
+    K120 (with PR-K119 `account_extract_storage_root`) is the
+    narrower accessor for callers that only need a single field.
+
+    Composes the existing `rlp_field_to_u256_be` helper (which in
+    turn uses PR-K20 `rlp_list_nth_item`).
+
+    Calling convention:
+      a0 (input)  : account_rlp ptr
+      a1 (input)  : account_rlp byte length
+      a2 (input)  : 32-byte output ptr (u256 BE)
+      ra (input)  : return
+      a0 (output) :
+        0 : success
+        1 : RLP parse failure / field 1 missing / > 256 bits -/
+def accountExtractBalanceFunction : String :=
+  "account_extract_balance:\n" ++
+  "  addi sp, sp, -16\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp)\n" ++
+  "  mv s0, a2                   # output 32B ptr (stash)\n" ++
+  "  sd zero,  0(s0); sd zero,  8(s0); sd zero, 16(s0); sd zero, 24(s0)\n" ++
+  "  # a0, a1 still hold (account_ptr, account_len).\n" ++
+  "  li a2, 1\n" ++
+  "  mv a3, s0\n" ++
+  "  jal ra, rlp_field_to_u256_be\n" ++
+  "  beqz a0, .Laeb_ret\n" ++
+  "  sd zero,  0(s0); sd zero,  8(s0); sd zero, 16(s0); sd zero, 24(s0)\n" ++
+  "  li a0, 1\n" ++
+  ".Laeb_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp)\n" ++
+  "  addi sp, sp, 16\n" ++
+  "  ret"
+
+/-- `zisk_account_extract_balance`: probe BuildUnit. Reads
+    (account_len, account_bytes), writes (status, 32-byte balance
+    BE) to OUTPUT (40 bytes). -/
+def ziskAccountExtractBalancePrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a3, 0x40000000\n" ++
+  "  ld a1, 8(a3)                # account_rlp_len\n" ++
+  "  addi a0, a3, 16             # account_rlp ptr\n" ++
+  "  li a2, 0xa0010008           # 32B u256 output\n" ++
+  "  jal ra, account_extract_balance\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Laeb_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpFieldToU256BeFunction ++ "\n" ++
+  accountExtractBalanceFunction ++ "\n" ++
+  ".Laeb_pdone:"
+
+def ziskAccountExtractBalanceDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "rfu_offset:\n" ++
+  "  .zero 8\n" ++
+  "rfu_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "t48_offset:\n" ++
+  "  .zero 8\n" ++
+  "t48_length:\n" ++
+  "  .zero 8"
+
+def ziskAccountExtractBalanceProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskAccountExtractBalancePrologue
+  dataAsm     := ziskAccountExtractBalanceDataSection
 }
 
 /-! ## tx_legacy_decode -- PR-K36 full 9-field decoder
@@ -13547,6 +13631,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_header_validate_parent_hash" => some ziskHeaderValidateParentHashProbeUnit
   | "zisk_header_chain_walk_step" => some ziskHeaderChainWalkStepProbeUnit
   | "zisk_account_validate_code_hash" => some ziskAccountValidateCodeHashProbeUnit
+  | "zisk_account_extract_balance" => some ziskAccountExtractBalanceProbeUnit
   | "zisk_address_from_pubkey"  => some ziskAddressFromPubkeyProbeUnit
   | "zisk_mpt_account_path_nibbles" => some ziskMptAccountPathNibblesProbeUnit
   | "zisk_headers_validate_chain" => some ziskHeadersValidateChainProbeUnit
@@ -13677,6 +13762,7 @@ def knownProgramNames : List String :=
    "zisk_header_validate_parent_hash",
    "zisk_header_chain_walk_step",
    "zisk_account_validate_code_hash",
+   "zisk_account_extract_balance",
    "zisk_address_from_pubkey",
    "zisk_mpt_account_path_nibbles",
    "zisk_headers_validate_chain",

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **141**
-- ziskemu round-trip scripts: **134** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **142**
+- ziskemu round-trip scripts: **135** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -252,7 +252,7 @@ This is the verified gas-cost surrogate.
 ## D — Codegen reach
 
 - Programs in `EvmAsm/Codegen/Programs.lean` registry: **139**
-- ziskemu round-trip scripts: **132** under `scripts/codegen-*.sh`
+- ziskemu round-trip scripts: **133** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,11 +251,7 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-<<<<<<< HEAD
 - Programs in `EvmAsm/Codegen/Programs.lean` registry: **141**
-=======
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **141**
->>>>>>> origin/main
 - ziskemu round-trip scripts: **134** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 

--- a/scripts/codegen-zisk-account-extract-balance-check.sh
+++ b/scripts/codegen-zisk-account-extract-balance-check.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# codegen-zisk-account-extract-balance-check.sh -- PR-K120.
+#
+# Extract balance (u256 BE) from account RLP.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_account_extract_balance ELF"
+lake exe codegen --program zisk_account_extract_balance --halt linux93 \
+  -o gen-out/zisk_account_extract_balance
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <balance_python_expr>
+run_case() {
+  local name="$1" bal_expr="$2"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_account_extract_balance_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_account_extract_balance_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+bal = $bal_expr
+account = [42, bal, bytes([0x11]*32), bytes([0x22]*32)]
+account_rlp = rlp.encode(account)
+with open(sys.argv[1], 'wb') as f:
+    f.write(struct.pack('<Q', len(account_rlp)))
+    f.write(account_rlp)
+    pad = (-(8 + len(account_rlp))) % 8
+    if pad: f.write(b'\x00' * pad)
+with open(sys.argv[1] + '.expected', 'wb') as f:
+    f.write(bal.to_bytes(32, 'big'))
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_account_extract_balance.elf \
+    -i "$in_file" -o "$out_file" -n 1000000 \
+    >"$REPO_ROOT/gen-out/zisk_account_extract_balance_${name}.emu.log" 2>&1 || true
+
+  local actual_status; actual_status="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local actual_bal; actual_bal="$(dd if="$out_file" bs=1 skip=8 count=32 2>/dev/null | xxd -p | tr -d '\n')"
+  local expected_bal; expected_bal="$(xxd -p "$in_file.expected" | tr -d '\n')"
+
+  if [[ "$actual_status" == "0000000000000000" && "$actual_bal" == "$expected_bal" ]]; then
+    printf "  %-32s OK   bal=%s..\n" "$name" "${actual_bal:0:16}"
+    return 0
+  else
+    printf "  %-32s FAIL status=0x%s bal=%s expected=%s\n" "$name" "$actual_status" "${actual_bal:0:16}" "${expected_bal:0:16}"
+    return 1
+  fi
+}
+
+FAILED=0
+run_case "zero"               "0"                          || FAILED=1
+run_case "one_wei"            "1"                          || FAILED=1
+run_case "one_eth"            "10**18"                     || FAILED=1
+run_case "ten_eth"            "10 * 10**18"                || FAILED=1
+run_case "u64_max"            "(1 << 64) - 1"              || FAILED=1
+run_case "u128_max"           "(1 << 128) - 1"             || FAILED=1
+run_case "u200"               "(1 << 200) - 1"             || FAILED=1
+run_case "high_bit"           "1 << 255"                   || FAILED=1
+run_case "u256_max"           "(1 << 256) - 1"             || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: account_extract_balance returns field 1 as u256 BE"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Extract the u256 BE `balance` field (RLP field 1) from a fully
RLP-encoded Ethereum account:

```
account = [nonce, balance, storage_root, code_hash]
```

The balance is the account's wei holdings, ranged in `[0, 2^256)`.
Direct input to balance-check predicates
(`balance >= value + gas_cost`), priority-fee credit, and the
trie-rebuild path after value transfers.

K27 `account_decode` already extracts the full account record;
K120 (with PR-K119 `account_extract_storage_root`) is the narrower
accessor for callers that only need a single field.

Composes the existing `rlp_field_to_u256_be` helper (which in turn
uses PR-K20 `rlp_list_nth_item`).

Status:
- `0` : success
- `1` : RLP parse failure / field 1 missing / > 256 bits

## Test plan

- [x] `scripts/codegen-zisk-account-extract-balance-check.sh`
  passes 9 fixtures spanning balance values from 0 / 1 wei / 1 ETH
  / 10 ETH up to max u64 / u128 / u200 / high-bit (`1<<255`) /
  max u256
- [x] `lake build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)