### PR TITLE
feat(stateless): account_extract_nonce (PR-K121)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -4493,6 +4493,86 @@ def ziskRlpFieldToU64ProbeUnit : BuildUnit := {
   dataAsm     := ziskRlpFieldToU64DataSection
 }
 
+/-! ## account_extract_nonce -- PR-K121
+
+    Extract the u64 `nonce` field (RLP field 0) from a fully
+    RLP-encoded Ethereum account:
+
+      account = [nonce, balance, storage_root, code_hash]
+
+    The nonce counts the number of outbound transactions an EOA
+    has issued (or contract creations for a contract). EIP-2681
+    caps it at `2^64 - 1` so a u64 fits.
+
+    K27 `account_decode` already extracts the full account record;
+    this narrower accessor avoids the 96-byte struct when only the
+    nonce is needed (e.g., the tx-replay-protection check inside
+    `check_transaction`, or to thread the nonce-mismatch error path
+    without unpacking balance / storage_root / code_hash).
+
+    Composes the existing `rlp_field_to_u64` helper (which in turn
+    uses PR-K20 `rlp_list_nth_item`).
+
+    Calling convention:
+      a0 (input)  : account_rlp ptr
+      a1 (input)  : account_rlp byte length
+      a2 (input)  : u64 output ptr
+      ra (input)  : return
+      a0 (output) :
+        0 : success
+        1 : RLP parse failure / field 0 missing / > 64 bits -/
+def accountExtractNonceFunction : String :=
+  "account_extract_nonce:\n" ++
+  "  addi sp, sp, -16\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp)\n" ++
+  "  mv s0, a2                   # u64 out ptr (stash)\n" ++
+  "  sd zero, 0(s0)\n" ++
+  "  # a0, a1 still hold (account_ptr, account_len).\n" ++
+  "  li a2, 0\n" ++
+  "  mv a3, s0\n" ++
+  "  jal ra, rlp_field_to_u64\n" ++
+  "  beqz a0, .Laen_ret\n" ++
+  "  sd zero, 0(s0)\n" ++
+  "  li a0, 1\n" ++
+  ".Laen_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp)\n" ++
+  "  addi sp, sp, 16\n" ++
+  "  ret"
+
+/-- `zisk_account_extract_nonce`: probe BuildUnit. Reads
+    (account_len, account_bytes), writes (status, nonce u64) to
+    OUTPUT (16 bytes). -/
+def ziskAccountExtractNoncePrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a3, 0x40000000\n" ++
+  "  ld a1, 8(a3)                # account_rlp_len\n" ++
+  "  addi a0, a3, 16             # account_rlp ptr\n" ++
+  "  li a2, 0xa0010008           # nonce out\n" ++
+  "  jal ra, account_extract_nonce\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Laen_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpFieldToU64Function ++ "\n" ++
+  accountExtractNonceFunction ++ "\n" ++
+  ".Laen_pdone:"
+
+def ziskAccountExtractNonceDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "rfu_offset:\n" ++
+  "  .zero 8\n" ++
+  "rfu_length:\n" ++
+  "  .zero 8"
+
+def ziskAccountExtractNonceProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskAccountExtractNoncePrologue
+  dataAsm     := ziskAccountExtractNonceDataSection
+}
+
 /-! ## rlp_field_to_u256_be -- PR-K35
 
     Extract the N-th field of an RLP list and right-align its
@@ -13547,6 +13627,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_header_validate_parent_hash" => some ziskHeaderValidateParentHashProbeUnit
   | "zisk_header_chain_walk_step" => some ziskHeaderChainWalkStepProbeUnit
   | "zisk_account_validate_code_hash" => some ziskAccountValidateCodeHashProbeUnit
+  | "zisk_account_extract_nonce" => some ziskAccountExtractNonceProbeUnit
   | "zisk_address_from_pubkey"  => some ziskAddressFromPubkeyProbeUnit
   | "zisk_mpt_account_path_nibbles" => some ziskMptAccountPathNibblesProbeUnit
   | "zisk_headers_validate_chain" => some ziskHeadersValidateChainProbeUnit
@@ -13677,6 +13758,7 @@ def knownProgramNames : List String :=
    "zisk_header_validate_parent_hash",
    "zisk_header_chain_walk_step",
    "zisk_account_validate_code_hash",
+   "zisk_account_extract_nonce",
    "zisk_address_from_pubkey",
    "zisk_mpt_account_path_nibbles",
    "zisk_headers_validate_chain",

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **141**
-- ziskemu round-trip scripts: **134** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **142**
+- ziskemu round-trip scripts: **135** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -252,7 +252,7 @@ This is the verified gas-cost surrogate.
 ## D — Codegen reach
 
 - Programs in `EvmAsm/Codegen/Programs.lean` registry: **139**
-- ziskemu round-trip scripts: **132** under `scripts/codegen-*.sh`
+- ziskemu round-trip scripts: **133** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,11 +251,7 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-<<<<<<< HEAD
 - Programs in `EvmAsm/Codegen/Programs.lean` registry: **141**
-=======
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **141**
->>>>>>> origin/main
 - ziskemu round-trip scripts: **134** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 

--- a/scripts/codegen-zisk-account-extract-nonce-check.sh
+++ b/scripts/codegen-zisk-account-extract-nonce-check.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# codegen-zisk-account-extract-nonce-check.sh -- PR-K121.
+#
+# Extract u64 nonce (field 0) from account RLP.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_account_extract_nonce ELF"
+lake exe codegen --program zisk_account_extract_nonce --halt linux93 \
+  -o gen-out/zisk_account_extract_nonce
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <nonce_python_expr>
+run_case() {
+  local name="$1" nonce_expr="$2"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_account_extract_nonce_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_account_extract_nonce_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+nonce = $nonce_expr
+account = [nonce, 10**18, bytes([0x11]*32), bytes([0x22]*32)]
+account_rlp = rlp.encode(account)
+with open(sys.argv[1], 'wb') as f:
+    f.write(struct.pack('<Q', len(account_rlp)))
+    f.write(account_rlp)
+    pad = (-(8 + len(account_rlp))) % 8
+    if pad: f.write(b'\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_account_extract_nonce.elf \
+    -i "$in_file" -o "$out_file" -n 1000000 \
+    >"$REPO_ROOT/gen-out/zisk_account_extract_nonce_${name}.emu.log" 2>&1 || true
+
+  local actual_status; actual_status="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local actual_nonce_le; actual_nonce_le="$(dd if="$out_file" bs=1 skip=8 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local actual_nonce; actual_nonce="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$actual_nonce_le'))[0])")"
+  local expected_nonce; expected_nonce="$(python3 -c "print($nonce_expr)")"
+
+  if [[ "$actual_status" == "0000000000000000" && "$actual_nonce" == "$expected_nonce" ]]; then
+    printf "  %-32s OK   nonce=%s\n" "$name" "$expected_nonce"
+    return 0
+  else
+    printf "  %-32s FAIL status=0x%s nonce=%s expected=%s\n" "$name" "$actual_status" "$actual_nonce" "$expected_nonce"
+    return 1
+  fi
+}
+
+FAILED=0
+run_case "zero"          "0"                          || FAILED=1
+run_case "one"           "1"                          || FAILED=1
+run_case "small"         "42"                         || FAILED=1
+run_case "large"         "999999"                     || FAILED=1
+run_case "u32_max"       "(1 << 32) - 1"              || FAILED=1
+run_case "u48"           "1234567890123"              || FAILED=1
+# EIP-2681: nonce capped at u64. RLP would truncate over-u64 anyway.
+run_case "near_u64_max"  "(1 << 64) - 2"              || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: account_extract_nonce returns field 0 as u64"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Extract the u64 `nonce` field (RLP field 0) from a fully RLP-encoded
Ethereum account:

```
account = [nonce, balance, storage_root, code_hash]
```

The nonce counts the number of outbound transactions an EOA has
issued (or contract creations for a contract). EIP-2681 caps it at
`2^64 - 1` so a u64 fits.

K27 `account_decode` already extracts the full account record; this
narrower accessor avoids the 96-byte struct when only the nonce is
needed (e.g., the tx-replay-protection check inside
`check_transaction`).

Companion to PR-K119 (`storage_root`), PR-K120 (`balance`), and
PR-K98 (`validate_code_hash`) — completes the per-field accessor set
across `account_decode`'s four fields.

Composes the existing `rlp_field_to_u64` helper (which in turn uses
PR-K20 `rlp_list_nth_item`).

Status:
- `0` : success
- `1` : RLP parse failure / field 0 missing / > 64 bits

## Test plan

- [x] `scripts/codegen-zisk-account-extract-nonce-check.sh` passes
  7 fixtures spanning nonce values from 0 / 1 / typical counters /
  u32_max / u48 up to near-u64_max
- [x] `lake build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)