### PR TITLE
feat(stateless): account_extract_code_hash (PR-K122)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -1914,6 +1914,112 @@ def ziskAccountValidateCodeHashProbeUnit : BuildUnit := {
   dataAsm     := ziskAccountValidateCodeHashDataSection
 }
 
+/-! ## account_extract_code_hash -- PR-K122
+
+    Extract the 32-byte `code_hash` field (RLP field 3) from a
+    fully RLP-encoded Ethereum account:
+
+      account = [nonce, balance, storage_root, code_hash]
+
+    The code_hash is the keccak256 of this account's bytecode.
+    For EOAs and accounts that have never been touched as
+    contracts, code_hash equals the canonical empty-code hash:
+
+      EMPTY_CODE_HASH =
+        0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470
+
+    Direct input to:
+    - EOA detection (compare against EMPTY_CODE_HASH)
+    - EXTCODEHASH opcode evaluation
+    - Per-account contract-code lookup (use code_hash as DB key)
+
+    K98 `account_validate_code_hash` *verifies* this field against
+    a claimed bytecode buffer (computing the keccak256 inline);
+    K122 simply *returns* it. Use K98 when the bytecode is known
+    and we want a yes/no integrity check; use K122 when we want to
+    keep the hash for later use (e.g. as a code-DB index key).
+
+    Completes the per-field accessor set for accounts (alongside
+    PR-K119 storage_root, K120 balance, K121 nonce).
+
+    Composes:
+      - PR-K20 `rlp_list_nth_item` — field 3 bounds
+
+    Calling convention:
+      a0 (input)  : account_rlp ptr
+      a1 (input)  : account_rlp byte length
+      a2 (input)  : 32-byte output ptr
+      ra (input)  : return
+      a0 (output) :
+        0 : success
+        1 : RLP parse failure / field 3 missing
+        2 : field 3 length != 32 -/
+def accountExtractCodeHashFunction : String :=
+  "account_extract_code_hash:\n" ++
+  "  addi sp, sp, -32\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp)\n" ++
+  "  mv s0, a0                   # account_rlp ptr\n" ++
+  "  mv s1, a1                   # account_len\n" ++
+  "  mv s2, a2                   # 32B output ptr\n" ++
+  "  sd zero,  0(s2); sd zero,  8(s2); sd zero, 16(s2); sd zero, 24(s2)\n" ++
+  "  # Extract field 3 (code_hash).\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 3\n" ++
+  "  la a3, aech_offset; la a4, aech_length\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Laech_parse_fail\n" ++
+  "  la t0, aech_length; ld t1, 0(t0)\n" ++
+  "  li t2, 32\n" ++
+  "  bne t1, t2, .Laech_size_fail\n" ++
+  "  la t0, aech_offset; ld t3, 0(t0); add t3, s0, t3\n" ++
+  "  ld t4,  0(t3); sd t4,  0(s2)\n" ++
+  "  ld t4,  8(t3); sd t4,  8(s2)\n" ++
+  "  ld t4, 16(t3); sd t4, 16(s2)\n" ++
+  "  ld t4, 24(t3); sd t4, 24(s2)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Laech_ret\n" ++
+  ".Laech_parse_fail:\n" ++
+  "  li a0, 1\n" ++
+  "  j .Laech_ret\n" ++
+  ".Laech_size_fail:\n" ++
+  "  li a0, 2\n" ++
+  ".Laech_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp)\n" ++
+  "  addi sp, sp, 32\n" ++
+  "  ret"
+
+/-- `zisk_account_extract_code_hash`: probe BuildUnit. Reads
+    (account_len, account_bytes), writes (status, 32-byte
+    code_hash) to OUTPUT (40 bytes). -/
+def ziskAccountExtractCodeHashPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a3, 0x40000000\n" ++
+  "  ld a1, 8(a3)                # account_rlp_len\n" ++
+  "  addi a0, a3, 16             # account_rlp ptr\n" ++
+  "  li a2, 0xa0010008           # 32B output\n" ++
+  "  jal ra, account_extract_code_hash\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Laech_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  accountExtractCodeHashFunction ++ "\n" ++
+  ".Laech_pdone:"
+
+def ziskAccountExtractCodeHashDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "aech_offset:\n" ++
+  "  .zero 8\n" ++
+  "aech_length:\n" ++
+  "  .zero 8"
+
+def ziskAccountExtractCodeHashProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskAccountExtractCodeHashPrologue
+  dataAsm     := ziskAccountExtractCodeHashDataSection
+}
+
 /-! ## rlp_list_count_items -- PR-K47 top-level item counter
 
     Walk an RLP-encoded list once and return the number of
@@ -13547,6 +13653,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_header_validate_parent_hash" => some ziskHeaderValidateParentHashProbeUnit
   | "zisk_header_chain_walk_step" => some ziskHeaderChainWalkStepProbeUnit
   | "zisk_account_validate_code_hash" => some ziskAccountValidateCodeHashProbeUnit
+  | "zisk_account_extract_code_hash" => some ziskAccountExtractCodeHashProbeUnit
   | "zisk_address_from_pubkey"  => some ziskAddressFromPubkeyProbeUnit
   | "zisk_mpt_account_path_nibbles" => some ziskMptAccountPathNibblesProbeUnit
   | "zisk_headers_validate_chain" => some ziskHeadersValidateChainProbeUnit
@@ -13677,6 +13784,7 @@ def knownProgramNames : List String :=
    "zisk_header_validate_parent_hash",
    "zisk_header_chain_walk_step",
    "zisk_account_validate_code_hash",
+   "zisk_account_extract_code_hash",
    "zisk_address_from_pubkey",
    "zisk_mpt_account_path_nibbles",
    "zisk_headers_validate_chain",

--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -1979,8 +1979,39 @@ def ziskAccountValidateCodeHashProbeUnit : BuildUnit := {
     (`aesr_offset`, `aesr_length`). -/
 def accountExtractStorageRootFunction : String :=
   "account_extract_storage_root:\n" ++
-        1 : RLP parse failure / field 3 missing
-        2 : field 3 length != 32 -/
+  "  addi sp, sp, -32\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp)\n" ++
+  "  mv s0, a0                   # account_rlp ptr\n" ++
+  "  mv s1, a1                   # account_len\n" ++
+  "  mv s2, a2                   # 32B output ptr\n" ++
+  "  sd zero,  0(s2); sd zero,  8(s2); sd zero, 16(s2); sd zero, 24(s2)\n" ++
+  "  # Extract field 2 (storage_root).\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 2\n" ++
+  "  la a3, aesr_offset; la a4, aesr_length\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Laesr_parse_fail\n" ++
+  "  la t0, aesr_length; ld t1, 0(t0)\n" ++
+  "  li t2, 32\n" ++
+  "  bne t1, t2, .Laesr_size_fail\n" ++
+  "  la t0, aesr_offset; ld t3, 0(t0); add t3, s0, t3\n" ++
+  "  ld t4,  0(t3); sd t4,  0(s2)\n" ++
+  "  ld t4,  8(t3); sd t4,  8(s2)\n" ++
+  "  ld t4, 16(t3); sd t4, 16(s2)\n" ++
+  "  ld t4, 24(t3); sd t4, 24(s2)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Laesr_ret\n" ++
+  ".Laesr_parse_fail:\n" ++
+  "  li a0, 1\n" ++
+  "  j .Laesr_ret\n" ++
+  ".Laesr_size_fail:\n" ++
+  "  li a0, 2\n" ++
+  ".Laesr_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp)\n" ++
+  "  addi sp, sp, 32\n" ++
+  "  ret"
+
 def accountExtractCodeHashFunction : String :=
   "account_extract_code_hash:\n" ++
   "  addi sp, sp, -32\n" ++

--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -2036,10 +2036,6 @@ def accountExtractCodeHashFunction : String :=
     (account_len, account_bytes), writes (status, 32-byte
     storage_root) to OUTPUT (40 bytes total). -/
 def ziskAccountExtractStorageRootPrologue : String :=
-/-- `zisk_account_extract_code_hash`: probe BuildUnit. Reads
-    (account_len, account_bytes), writes (status, 32-byte
-    code_hash) to OUTPUT (40 bytes). -/
-def ziskAccountExtractCodeHashPrologue : String :=
   "  li sp, 0xa0050000\n" ++
   "  li a3, 0x40000000\n" ++
   "  ld a1, 8(a3)                # account_rlp_len\n" ++
@@ -2065,6 +2061,17 @@ def ziskAccountExtractStorageRootProbeUnit : BuildUnit := {
   body        := NOP
   prologueAsm := ziskAccountExtractStorageRootPrologue
   dataAsm     := ziskAccountExtractStorageRootDataSection
+}
+
+/-- `zisk_account_extract_code_hash`: probe BuildUnit. Reads
+    (account_len, account_bytes), writes (status, 32-byte
+    code_hash) to OUTPUT (40 bytes). -/
+def ziskAccountExtractCodeHashPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a3, 0x40000000\n" ++
+  "  ld a1, 8(a3)                # account_rlp_len\n" ++
+  "  addi a0, a3, 16             # account_rlp ptr\n" ++
+  "  li a2, 0xa0010008           # 32B output\n" ++
   "  jal ra, account_extract_code_hash\n" ++
   "  li t0, 0xa0010000\n" ++
   "  sd a0, 0(t0)\n" ++

--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -1917,6 +1917,40 @@ def ziskAccountValidateCodeHashProbeUnit : BuildUnit := {
 /-! ## account_extract_storage_root -- PR-K119
 
     Extract the 32-byte `storage_root` field (RLP field 2) from a
+    fully RLP-encoded Ethereum account:
+
+      account = [nonce, balance, storage_root, code_hash]
+
+    The storage_root is the MPT root of this account's per-account
+    storage trie (keccak256 of the empty trie's RLP encoding,
+    a.k.a. `EMPTY_TRIE_ROOT`, for EOAs and unused contracts):
+
+      EMPTY_TRIE_ROOT =
+        0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421
+
+    Direct input to per-account storage trie walks
+    (`mpt_lookup_by_key` for SLOAD) and to state-root recomputation
+    after SSTORE writes.
+
+    K27 `account_decode` already extracts the full account record;
+    K119 is the narrower accessor for callers that only need the
+    storage root and don't want to allocate the 96-byte struct.
+
+    Composes:
+      - PR-K20 `rlp_list_nth_item` — field 2 bounds
+
+    Calling convention:
+      a0 (input)  : account_rlp ptr
+      a1 (input)  : account_rlp byte length
+      a2 (input)  : 32-byte output ptr
+      ra (input)  : return
+      a0 (output) :
+        0 : success
+        1 : RLP parse failure / field 2 missing
+        2 : field 2 length != 32
+
+    Output zeroed on failure. Uses two 8-byte `.data` scratch slots
+    (`aesr_offset`, `aesr_length`). -/
 /-! ## account_extract_code_hash -- PR-K122
 
     Extract the 32-byte `code_hash` field (RLP field 3) from a

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **141**
-- ziskemu round-trip scripts: **134** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **142**
+- ziskemu round-trip scripts: **135** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -252,7 +252,7 @@ This is the verified gas-cost surrogate.
 ## D — Codegen reach
 
 - Programs in `EvmAsm/Codegen/Programs.lean` registry: **139**
-- ziskemu round-trip scripts: **132** under `scripts/codegen-*.sh`
+- ziskemu round-trip scripts: **133** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,11 +251,7 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-<<<<<<< HEAD
 - Programs in `EvmAsm/Codegen/Programs.lean` registry: **141**
-=======
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **141**
->>>>>>> origin/main
 - ziskemu round-trip scripts: **134** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 

--- a/scripts/codegen-zisk-account-extract-code-hash-check.sh
+++ b/scripts/codegen-zisk-account-extract-code-hash-check.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# codegen-zisk-account-extract-code-hash-check.sh -- PR-K122.
+#
+# Extract code_hash (32 B field 3) from account RLP.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_account_extract_code_hash ELF"
+lake exe codegen --program zisk_account_extract_code_hash --halt linux93 \
+  -o gen-out/zisk_account_extract_code_hash
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <code_hash_hex> <expected_status>
+run_case() {
+  local name="$1" code_hash="$2" exp_status="${3:-0}"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_account_extract_code_hash_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_account_extract_code_hash_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+code_hash = bytes.fromhex('$code_hash') if '$code_hash' else b''
+if len(code_hash) == 0:
+    # 3-field account (missing code_hash) — should fail
+    account = [0, 10**18, bytes([0x11]*32)]
+else:
+    account = [0, 10**18, bytes([0x11]*32), code_hash]
+account_rlp = rlp.encode(account)
+with open(sys.argv[1], 'wb') as f:
+    f.write(struct.pack('<Q', len(account_rlp)))
+    f.write(account_rlp)
+    pad = (-(8 + len(account_rlp))) % 8
+    if pad: f.write(b'\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_account_extract_code_hash.elf \
+    -i "$in_file" -o "$out_file" -n 1000000 \
+    >"$REPO_ROOT/gen-out/zisk_account_extract_code_hash_${name}.emu.log" 2>&1 || true
+
+  local actual_status; actual_status="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local exp_status_le; exp_status_le="$(python3 -c "print(int('$exp_status').to_bytes(8, 'little').hex())")"
+
+  if [[ "$actual_status" != "$exp_status_le" ]]; then
+    printf "  %-32s FAIL status=0x%s expected=%d\n" "$name" "$actual_status" "$exp_status"
+    return 1
+  fi
+  if [[ "$exp_status" != "0" ]]; then
+    printf "  %-32s OK   status=%d (rejected)\n" "$name" "$exp_status"
+    return 0
+  fi
+  local actual_hash; actual_hash="$(dd if="$out_file" bs=1 skip=8 count=32 2>/dev/null | xxd -p | tr -d '\n')"
+  if [[ "$actual_hash" == "$code_hash" ]]; then
+    printf "  %-32s OK   hash=%s..\n" "$name" "${actual_hash:0:16}"
+    return 0
+  else
+    printf "  %-32s FAIL\n    expected: %s\n    actual:   %s\n" "$name" "$code_hash" "$actual_hash"
+    return 1
+  fi
+}
+
+FAILED=0
+EMPTY_CODE_HASH="c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"
+RANDOM_HASH="$(python3 -c "print('ab' * 32)")"
+ANOTHER_HASH="$(python3 -c "print('de' * 32)")"
+
+run_case "empty_code_hash_eoa" "$EMPTY_CODE_HASH"  || FAILED=1
+run_case "contract_random"     "$RANDOM_HASH"     || FAILED=1
+run_case "contract_de"         "$ANOTHER_HASH"    || FAILED=1
+run_case "missing_field3"      ""                  1 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: account_extract_code_hash returns field 3"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Extract the 32-byte `code_hash` field (RLP field 3) from a fully
RLP-encoded Ethereum account:

```
account = [nonce, balance, storage_root, code_hash]
```

The `code_hash` is the keccak256 of this account's bytecode. For
EOAs and accounts that have never been touched as contracts,
`code_hash` equals the canonical empty-code hash:

```
EMPTY_CODE_HASH =
  0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470
```

Direct input to:
- EOA detection (compare against `EMPTY_CODE_HASH`)
- `EXTCODEHASH` opcode evaluation
- Per-account contract-code lookup (use `code_hash` as DB key)

K98 `account_validate_code_hash` *verifies* this field against a
claimed bytecode buffer (computing the keccak256 inline); K122
simply *returns* it. Use K98 when the bytecode is known and we want
a yes/no integrity check; use K122 when we want to keep the hash
for later use (e.g. as a code-DB index key).

Completes the per-field accessor set for accounts (alongside
PR-K119 `storage_root`, K120 `balance`, K121 `nonce`).

Composes PR-K20 `rlp_list_nth_item`.

Status:
- `0` : success
- `1` : RLP parse failure / field 3 missing
- `2` : field 3 length != 32

## Test plan

- [x] `scripts/codegen-zisk-account-extract-code-hash-check.sh`
  passes 4 fixtures: `EMPTY_CODE_HASH`-shaped EOA, two contract
  hashes, and a 3-field account missing field 3 (correctly
  rejected)
- [x] `lake build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)