### PR TITLE
feat(stateless): account_is_empty (PR-K123)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -4584,6 +4584,164 @@ def ziskRlpFieldToU256BeProbeUnit : BuildUnit := {
   dataAsm     := ziskRlpFieldToU256BeDataSection
 }
 
+/-! ## account_is_empty -- PR-K123
+
+    EIP-161 "empty" predicate. An account is empty iff all three:
+    - `nonce == 0`
+    - `balance == 0`
+    - `code_hash == EMPTY_CODE_HASH`
+
+    The `storage_root` field is **not** part of the empty check —
+    storage that's unreachable due to empty code is considered to
+    not exist for this purpose. (Compare against `EMPTY_TRIE_ROOT`
+    is a stricter invariant maintained by the state machine, not
+    by this predicate.)
+
+    Used by:
+    - state-cleanup pass post-tx (delete-empty rule from EIP-161)
+    - `account_exists_and_is_empty` in
+      `forks/amsterdam/state_tracker.py`
+    - beneficiary credit (a coinbase with no priority fee &
+      previously empty becomes alive again only if balance > 0)
+
+    EMPTY_CODE_HASH (keccak256(b'')) is hard-coded as a 32-byte
+    constant in `.data`:
+
+      0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470
+
+    Composes:
+      - PR-K20 `rlp_list_nth_item`         — field bounds
+      - existing `rlp_field_to_u64`        — nonce
+      - existing `rlp_field_to_u256_be`    — balance
+
+    Calling convention:
+      a0 (input)  : account_rlp ptr
+      a1 (input)  : account_rlp byte length
+      a2 (input)  : u64 out ptr (1 if empty, 0 if non-empty)
+      ra (input)  : return
+      a0 (output) :
+        0 : success — predicate written to *out
+        1 : RLP parse failure / field missing / wrong width
+
+    Uses 8 + 32 + 8 + 8 + 32 = 88 bytes of `.data` scratch
+    (`aie_nonce` u64, `aie_balance` 32 B, `aie_offset` + `aie_length`,
+    `aie_empty_code_hash` constant). -/
+def accountIsEmptyFunction : String :=
+  "account_is_empty:\n" ++
+  "  addi sp, sp, -32\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp)\n" ++
+  "  mv s0, a0                   # account_ptr\n" ++
+  "  mv s1, a1                   # account_len\n" ++
+  "  mv s2, a2                   # out u64 ptr\n" ++
+  "  sd zero, 0(s2)\n" ++
+  "  # Step 1: nonce (field 0) → aie_nonce.\n" ++
+  "  mv a0, s0; mv a1, s1\n" ++
+  "  li a2, 0\n" ++
+  "  la a3, aie_nonce\n" ++
+  "  jal ra, rlp_field_to_u64\n" ++
+  "  bnez a0, .Laie_parse_fail\n" ++
+  "  la t0, aie_nonce; ld t1, 0(t0)\n" ++
+  "  bnez t1, .Laie_not_empty\n" ++
+  "  # Step 2: balance (field 1, u256 BE) → aie_balance.\n" ++
+  "  mv a0, s0; mv a1, s1\n" ++
+  "  li a2, 1\n" ++
+  "  la a3, aie_balance\n" ++
+  "  jal ra, rlp_field_to_u256_be\n" ++
+  "  bnez a0, .Laie_parse_fail\n" ++
+  "  la t0, aie_balance\n" ++
+  "  ld t1,  0(t0); bnez t1, .Laie_not_empty\n" ++
+  "  ld t1,  8(t0); bnez t1, .Laie_not_empty\n" ++
+  "  ld t1, 16(t0); bnez t1, .Laie_not_empty\n" ++
+  "  ld t1, 24(t0); bnez t1, .Laie_not_empty\n" ++
+  "  # Step 3: code_hash (field 3) compared against EMPTY_CODE_HASH.\n" ++
+  "  mv a0, s0; mv a1, s1\n" ++
+  "  li a2, 3\n" ++
+  "  la a3, aie_offset; la a4, aie_length\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Laie_parse_fail\n" ++
+  "  la t0, aie_length; ld t1, 0(t0)\n" ++
+  "  li t2, 32\n" ++
+  "  bne t1, t2, .Laie_parse_fail\n" ++
+  "  la t0, aie_offset; ld t3, 0(t0); add t3, s0, t3\n" ++
+  "  la t4, aie_empty_code_hash\n" ++
+  "  ld t5,  0(t3); ld t6,  0(t4); bne t5, t6, .Laie_not_empty\n" ++
+  "  ld t5,  8(t3); ld t6,  8(t4); bne t5, t6, .Laie_not_empty\n" ++
+  "  ld t5, 16(t3); ld t6, 16(t4); bne t5, t6, .Laie_not_empty\n" ++
+  "  ld t5, 24(t3); ld t6, 24(t4); bne t5, t6, .Laie_not_empty\n" ++
+  "  # Empty.\n" ++
+  "  li t0, 1\n" ++
+  "  sd t0, 0(s2)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Laie_ret\n" ++
+  ".Laie_not_empty:\n" ++
+  "  sd zero, 0(s2)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Laie_ret\n" ++
+  ".Laie_parse_fail:\n" ++
+  "  sd zero, 0(s2)\n" ++
+  "  li a0, 1\n" ++
+  ".Laie_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp)\n" ++
+  "  addi sp, sp, 32\n" ++
+  "  ret"
+
+/-- `zisk_account_is_empty`: probe BuildUnit. Reads
+    (account_len, account_bytes), writes (status, is_empty) to
+    OUTPUT (16 bytes). -/
+def ziskAccountIsEmptyPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a3, 0x40000000\n" ++
+  "  ld a1, 8(a3)                # account_rlp_len\n" ++
+  "  addi a0, a3, 16             # account_rlp ptr\n" ++
+  "  li a2, 0xa0010008           # is_empty out\n" ++
+  "  jal ra, account_is_empty\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Laie_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpFieldToU64Function ++ "\n" ++
+  rlpFieldToU256BeFunction ++ "\n" ++
+  accountIsEmptyFunction ++ "\n" ++
+  ".Laie_pdone:"
+
+def ziskAccountIsEmptyDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "rfu_offset:\n" ++
+  "  .zero 8\n" ++
+  "rfu_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "t48_offset:\n" ++
+  "  .zero 8\n" ++
+  "t48_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "aie_nonce:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "aie_balance:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "aie_offset:\n" ++
+  "  .zero 8\n" ++
+  "aie_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "aie_empty_code_hash:\n" ++
+  "  .byte 0xc5, 0xd2, 0x46, 0x01, 0x86, 0xf7, 0x23, 0x3c\n" ++
+  "  .byte 0x92, 0x7e, 0x7d, 0xb2, 0xdc, 0xc7, 0x03, 0xc0\n" ++
+  "  .byte 0xe5, 0x00, 0xb6, 0x53, 0xca, 0x82, 0x27, 0x3b\n" ++
+  "  .byte 0x7b, 0xfa, 0xd8, 0x04, 0x5d, 0x85, 0xa4, 0x70"
+
+def ziskAccountIsEmptyProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskAccountIsEmptyPrologue
+  dataAsm     := ziskAccountIsEmptyDataSection
+}
+
 /-! ## tx_legacy_decode -- PR-K36 full 9-field decoder
 
     Decode an RLP-encoded legacy Ethereum transaction into a
@@ -13547,6 +13705,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_header_validate_parent_hash" => some ziskHeaderValidateParentHashProbeUnit
   | "zisk_header_chain_walk_step" => some ziskHeaderChainWalkStepProbeUnit
   | "zisk_account_validate_code_hash" => some ziskAccountValidateCodeHashProbeUnit
+  | "zisk_account_is_empty"     => some ziskAccountIsEmptyProbeUnit
   | "zisk_address_from_pubkey"  => some ziskAddressFromPubkeyProbeUnit
   | "zisk_mpt_account_path_nibbles" => some ziskMptAccountPathNibblesProbeUnit
   | "zisk_headers_validate_chain" => some ziskHeadersValidateChainProbeUnit
@@ -13677,6 +13836,7 @@ def knownProgramNames : List String :=
    "zisk_header_validate_parent_hash",
    "zisk_header_chain_walk_step",
    "zisk_account_validate_code_hash",
+   "zisk_account_is_empty",
    "zisk_address_from_pubkey",
    "zisk_mpt_account_path_nibbles",
    "zisk_headers_validate_chain",

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **141**
-- ziskemu round-trip scripts: **134** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **142**
+- ziskemu round-trip scripts: **135** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -252,7 +252,7 @@ This is the verified gas-cost surrogate.
 ## D — Codegen reach
 
 - Programs in `EvmAsm/Codegen/Programs.lean` registry: **139**
-- ziskemu round-trip scripts: **132** under `scripts/codegen-*.sh`
+- ziskemu round-trip scripts: **133** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,11 +251,7 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-<<<<<<< HEAD
 - Programs in `EvmAsm/Codegen/Programs.lean` registry: **141**
-=======
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **141**
->>>>>>> origin/main
 - ziskemu round-trip scripts: **134** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 

--- a/scripts/codegen-zisk-account-is-empty-check.sh
+++ b/scripts/codegen-zisk-account-is-empty-check.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# codegen-zisk-account-is-empty-check.sh -- PR-K123.
+#
+# EIP-161 empty-account predicate.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_account_is_empty ELF"
+lake exe codegen --program zisk_account_is_empty --halt linux93 \
+  -o gen-out/zisk_account_is_empty
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <nonce> <balance> <code_hash_hex> <storage_root_hex> <expected_is_empty>
+run_case() {
+  local name="$1" nonce="$2" bal="$3" code_hash="$4" storage_root="$5" exp_empty="$6"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_account_is_empty_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_account_is_empty_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+nonce = $nonce
+bal = $bal
+ch = bytes.fromhex('$code_hash')
+sr = bytes.fromhex('$storage_root')
+account = [nonce, bal, sr, ch]
+account_rlp = rlp.encode(account)
+with open(sys.argv[1], 'wb') as f:
+    f.write(struct.pack('<Q', len(account_rlp)))
+    f.write(account_rlp)
+    pad = (-(8 + len(account_rlp))) % 8
+    if pad: f.write(b'\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_account_is_empty.elf \
+    -i "$in_file" -o "$out_file" -n 1000000 \
+    >"$REPO_ROOT/gen-out/zisk_account_is_empty_${name}.emu.log" 2>&1 || true
+
+  local actual_status; actual_status="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local actual_empty_le; actual_empty_le="$(dd if="$out_file" bs=1 skip=8 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local actual_empty; actual_empty="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$actual_empty_le'))[0])")"
+
+  if [[ "$actual_status" == "0000000000000000" && "$actual_empty" == "$exp_empty" ]]; then
+    printf "  %-32s OK   is_empty=%d\n" "$name" "$exp_empty"
+    return 0
+  else
+    printf "  %-32s FAIL status=0x%s is_empty=%d expected=%d\n" "$name" "$actual_status" "$actual_empty" "$exp_empty"
+    return 1
+  fi
+}
+
+ECH="c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"
+ETR="56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"
+RCH="$(python3 -c "print('ab' * 32)")"
+ZEROS="$(python3 -c "print('00' * 32)")"
+
+FAILED=0
+# Empty cases: nonce=0, balance=0, code_hash=EMPTY_CODE_HASH
+run_case "empty_canonical"     0 0 "$ECH" "$ETR" 1 || FAILED=1
+run_case "empty_zero_storage"  0 0 "$ECH" "$ZEROS" 1 || FAILED=1
+# Non-empty cases
+run_case "nonzero_nonce"       1 0 "$ECH" "$ETR" 0 || FAILED=1
+run_case "nonzero_balance"     0 1 "$ECH" "$ETR" 0 || FAILED=1
+run_case "contract_code"       0 0 "$RCH" "$ETR" 0 || FAILED=1
+run_case "all_nonzero"         42 "10**18" "$RCH" "$ZEROS" 0 || FAILED=1
+run_case "balance_big"         0 "(1 << 200)" "$ECH" "$ETR" 0 || FAILED=1
+run_case "high_nonce_no_code"  99999 0 "$ECH" "$ETR" 0 || FAILED=1
+# Empty with high storage_root — still empty per EIP-161
+run_case "empty_high_storage"  0 0 "$ECH" "$(python3 -c "print('ff' * 32)")" 1 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: account_is_empty matches EIP-161 predicate"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

EIP-161 "empty" predicate. An account is empty iff all three:
- `nonce == 0`
- `balance == 0`
- `code_hash == EMPTY_CODE_HASH`

The `storage_root` field is **not** part of the empty check —
storage that's unreachable due to empty code is considered to not
exist for this purpose.

Used by:
- state-cleanup pass post-tx (delete-empty rule from EIP-161)
- `account_exists_and_is_empty` in
  `forks/amsterdam/state_tracker.py`
- beneficiary credit (a coinbase with no priority fee & previously
  empty becomes alive again only if balance > 0)

`EMPTY_CODE_HASH` (keccak256(b'')) is hard-coded as a 32-byte
constant in `.data`:

```
0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470
```

Composes:
- PR-K20 `rlp_list_nth_item`         — field bounds
- existing `rlp_field_to_u64`        — nonce
- existing `rlp_field_to_u256_be`    — balance

Status:
- `0` : success — predicate written to `*out`
- `1` : RLP parse failure / field missing / wrong width

## Test plan

- [x] `scripts/codegen-zisk-account-is-empty-check.sh` passes 9
  fixtures: 3 empty (canonical, zero storage_root, high
  storage_root — `storage_root` correctly ignored) + 6 non-empty
  (nonzero nonce, nonzero balance, contract code, all nonzero,
  balance > 2²⁰⁰, high nonce with empty code)
- [x] `lake build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)