### PR TITLE
feat(stateless): block_count_withdrawals (PR-K124)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -11430,6 +11430,105 @@ def ziskBlockWithdrawalsTotalProbeUnit : BuildUnit := {
   dataAsm     := ziskBlockWithdrawalsTotalDataSection
 }
 
+/-! ## block_count_withdrawals -- PR-K124
+
+    Return `len(block.withdrawals)` as a u64, directly from the
+    body RLP. Useful for receipt bookkeeping, withdrawal-array
+    sizing, and as a pre-flight before per-withdrawal processing
+    via PR-K78 `process_withdrawals_block`.
+
+    PR-K85 `block_withdrawals_total` already does the per-withdrawal
+    sum across the same list; K124 is the narrow counter when only
+    the cardinality matters.
+
+    Composes:
+      - PR-K83 `block_body_decode`    — split body
+      - PR-K47 `rlp_list_count_items` — N
+
+    Status decade encoding (floor(status/100) identifies failing
+    step):
+
+      0          : success
+      1          : `block_body_decode` failed
+      101        : `rlp_list_count_items` on withdrawals failed
+
+    Calling convention:
+      a0 (input)  : body_rlp ptr
+      a1 (input)  : body_rlp byte length
+      a2 (input)  : u64 out ptr (count)
+      ra (input)  : return
+      a0 (output) : composite status
+
+    Uses 48 bytes of `.data` scratch (`bcw_struct`) plus K83/K47's
+    own scratch slots. -/
+def blockCountWithdrawalsFunction : String :=
+  "block_count_withdrawals:\n" ++
+  "  addi sp, sp, -32\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp)\n" ++
+  "  mv s0, a0                   # body_rlp ptr\n" ++
+  "  mv s1, a1                   # body_rlp_len\n" ++
+  "  mv s2, a2                   # count out\n" ++
+  "  sd zero, 0(s2)\n" ++
+  "  # Step 1: block_body_decode → bcw_struct.\n" ++
+  "  la a2, bcw_struct\n" ++
+  "  jal ra, block_body_decode\n" ++
+  "  bnez a0, .Lbcw_body_fail\n" ++
+  "  # Step 2: rlp_list_count_items on withdrawals sub-list.\n" ++
+  "  la t0, bcw_struct\n" ++
+  "  ld t1, 32(t0)               # withdrawals_offset\n" ++
+  "  ld t2, 40(t0)               # withdrawals_length\n" ++
+  "  add a0, s0, t1\n" ++
+  "  mv a1, t2\n" ++
+  "  mv a2, s2\n" ++
+  "  jal ra, rlp_list_count_items\n" ++
+  "  beqz a0, .Lbcw_ret\n" ++
+  "  li a0, 101\n" ++
+  "  j .Lbcw_ret\n" ++
+  ".Lbcw_body_fail:\n" ++
+  "  li a0, 1\n" ++
+  ".Lbcw_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp)\n" ++
+  "  addi sp, sp, 32\n" ++
+  "  ret"
+
+/-- `zisk_block_count_withdrawals`: probe BuildUnit. Reads
+    (body_len, body_bytes), writes (status, withdrawal_count) to
+    OUTPUT (16 bytes). -/
+def ziskBlockCountWithdrawalsPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a3, 0x40000000\n" ++
+  "  ld a1, 8(a3)                # body_len\n" ++
+  "  addi a0, a3, 16             # body ptr\n" ++
+  "  li a2, 0xa0010008           # count out\n" ++
+  "  jal ra, block_count_withdrawals\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lbcw_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpListCountItemsFunction ++ "\n" ++
+  blockBodyDecodeFunction ++ "\n" ++
+  blockCountWithdrawalsFunction ++ "\n" ++
+  ".Lbcw_pdone:"
+
+def ziskBlockCountWithdrawalsDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "rfu_offset:\n" ++
+  "  .zero 8\n" ++
+  "rfu_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "bcw_struct:\n" ++
+  "  .zero 48"
+
+def ziskBlockCountWithdrawalsProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskBlockCountWithdrawalsPrologue
+  dataAsm     := ziskBlockCountWithdrawalsDataSection
+}
+
 /-! ## block_summary -- PR-K86
 
     One-pass block body audit. Decode the body, then extract:
@@ -13629,6 +13728,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_process_withdrawals_block" => some ziskProcessWithdrawalsBlockProbeUnit
   | "zisk_withdrawals_sum_amounts" => some ziskWithdrawalsSumAmountsProbeUnit
   | "zisk_block_withdrawals_total" => some ziskBlockWithdrawalsTotalProbeUnit
+  | "zisk_block_count_withdrawals" => some ziskBlockCountWithdrawalsProbeUnit
   | "zisk_block_summary"        => some ziskBlockSummaryProbeUnit
   | "zisk_block_compute_tx_hashes" => some ziskBlockComputeTxHashesProbeUnit
   | "zisk_calldata_byte_counts" => some ziskCalldataByteCountsProbeUnit
@@ -13759,6 +13859,7 @@ def knownProgramNames : List String :=
    "zisk_process_withdrawals_block",
    "zisk_withdrawals_sum_amounts",
    "zisk_block_withdrawals_total",
+   "zisk_block_count_withdrawals",
    "zisk_block_summary",
    "zisk_block_compute_tx_hashes",
    "zisk_calldata_byte_counts",

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **141**
-- ziskemu round-trip scripts: **134** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **142**
+- ziskemu round-trip scripts: **135** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -252,7 +252,7 @@ This is the verified gas-cost surrogate.
 ## D — Codegen reach
 
 - Programs in `EvmAsm/Codegen/Programs.lean` registry: **139**
-- ziskemu round-trip scripts: **132** under `scripts/codegen-*.sh`
+- ziskemu round-trip scripts: **133** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,11 +251,7 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-<<<<<<< HEAD
 - Programs in `EvmAsm/Codegen/Programs.lean` registry: **141**
-=======
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **141**
->>>>>>> origin/main
 - ziskemu round-trip scripts: **134** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 

--- a/scripts/codegen-zisk-block-count-withdrawals-check.sh
+++ b/scripts/codegen-zisk-block-count-withdrawals-check.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# codegen-zisk-block-count-withdrawals-check.sh -- PR-K124.
+#
+# Count withdrawals in a block body.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_block_count_withdrawals ELF"
+lake exe codegen --program zisk_block_count_withdrawals --halt linux93 \
+  -o gen-out/zisk_block_count_withdrawals
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <wds_json>
+run_case() {
+  local name="$1" wds_json="$2"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_block_count_withdrawals_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_block_count_withdrawals_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import json, struct, sys, rlp
+wds_raw = json.loads('''$wds_json''')
+wds = []
+for w in wds_raw:
+    idx, vi, addr_hex, amt = w
+    wds.append([idx, vi, bytes.fromhex(addr_hex), amt])
+body_rlp = rlp.encode([[], [], wds])
+with open(sys.argv[1], 'wb') as f:
+    f.write(struct.pack('<Q', len(body_rlp)))
+    f.write(body_rlp)
+    pad = (-(8 + len(body_rlp))) % 8
+    if pad: f.write(b'\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_block_count_withdrawals.elf \
+    -i "$in_file" -o "$out_file" -n 1000000 \
+    >"$REPO_ROOT/gen-out/zisk_block_count_withdrawals_${name}.emu.log" 2>&1 || true
+
+  local actual_status; actual_status="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local actual_count_le; actual_count_le="$(dd if="$out_file" bs=1 skip=8 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local actual_count; actual_count="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$actual_count_le'))[0])")"
+  local expected_count; expected_count="$(python3 -c "import json; print(len(json.loads('''$wds_json''')))")"
+
+  if [[ "$actual_status" == "0000000000000000" && "$actual_count" == "$expected_count" ]]; then
+    printf "  %-32s OK   count=%d\n" "$name" "$expected_count"
+    return 0
+  else
+    printf "  %-32s FAIL status=0x%s count=%d expected=%d\n" "$name" "$actual_status" "$actual_count" "$expected_count"
+    return 1
+  fi
+}
+
+ALICE="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+GWEI=$(python3 -c "print(10**9)")
+
+FAILED=0
+run_case "empty"                "[]"                                            || FAILED=1
+run_case "one_wd"               "[[0, 1, \"$ALICE\", $GWEI]]"                   || FAILED=1
+run_case "two_wd" \
+  "[[0, 1, \"$ALICE\", $GWEI], [1, 2, \"$ALICE\", $GWEI]]"                      || FAILED=1
+run_case "sixteen_wd"           "$(python3 -c "
+import json
+addr = '$ALICE'
+print(json.dumps([[i, i+1000, addr, (i+1) * 10**9] for i in range(16)]))
+")"                                                                              || FAILED=1
+run_case "one_hundred_wd"       "$(python3 -c "
+import json
+addr = '$ALICE'
+print(json.dumps([[i, i+1000, addr, (i+1) * 10**9] for i in range(100)]))
+")"                                                                              || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: block_count_withdrawals returns len(block.withdrawals)"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Return `len(block.withdrawals)` as a u64, directly from the body
RLP. Useful for receipt bookkeeping, withdrawal-array sizing, and
as a pre-flight before per-withdrawal processing via PR-K78
`process_withdrawals_block`.

PR-K85 `block_withdrawals_total` already does the per-withdrawal
sum across the same list; K124 is the narrow counter when only
the cardinality matters.

Composes:
- PR-K83 `block_body_decode`    — split body
- PR-K47 `rlp_list_count_items` — N

Status decade encoding (`floor(status/100)` identifies failing
step):
- `0`   : success
- `1`   : `block_body_decode` failed
- `101` : `rlp_list_count_items` on withdrawals failed

## Test plan

- [x] `scripts/codegen-zisk-block-count-withdrawals-check.sh`
  passes 5 fixtures covering 0, 1, 2, 16, 100 withdrawals
- [x] `lake build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)