### PR TITLE
feat(stateless): address_compute_create2 (PR-K126)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -1158,6 +1158,135 @@ def ziskAddressFromPubkeyProbeUnit : BuildUnit := {
   dataAsm     := ziskAddressFromPubkeyDataSection
 }
 
+/-! ## address_compute_create2 -- PR-K126
+
+    Compute the CREATE2 contract address per EIP-1014:
+
+      address = keccak256(0xff || sender || salt || keccak256(init_code))[12:32]
+
+    Preimage is exactly 85 bytes laid out as:
+       0       :  0xff (single byte marker)
+       1..21   :  sender (20 bytes)
+       21..53  :  salt (32 bytes, BE)
+       53..85  :  inner_hash = keccak256(init_code) (32 bytes)
+
+    Used by the EVM's `CREATE2` opcode and by off-chain tooling
+    that needs deterministic deploy addresses. Sister primitive to
+    PR-K99 `address_from_pubkey` (the ECRECOVER trailing step) and
+    a future `address_compute_create` (for the non-deterministic
+    nonce-based form).
+
+    Composes PR-K3 `zkvm_keccak256` (called twice — once over
+    `init_code` and once over the 85-byte preimage).
+
+    Calling convention:
+      a0 (input)  : sender ptr (20 B, big-endian)
+      a1 (input)  : salt ptr   (32 B, big-endian)
+      a2 (input)  : init_code ptr
+      a3 (input)  : init_code byte length
+      a4 (input)  : 20-byte output ptr
+      ra (input)  : return
+      a0 (output) : 0 (always succeeds; keccak is total).
+
+    Uses 85 + 32 + 32 = 149 bytes of `.data` scratch
+    (`ac2_preimage` 85 B + `ac2_inner_digest` 32 B + `ac2_outer_digest`
+    32 B), plus the keccak sponge state (`zk3_state`, 200 B). -/
+def addressComputeCreate2Function : String :=
+  "address_compute_create2:\n" ++
+  "  addi sp, sp, -48\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp); sd s4, 40(sp)\n" ++
+  "  mv s0, a0                   # sender ptr\n" ++
+  "  mv s1, a1                   # salt ptr\n" ++
+  "  mv s4, a4                   # output ptr (stash)\n" ++
+  "  # Step 1: inner = keccak256(init_code).\n" ++
+  "  # init_code ptr/len already in (a2, a3); rotate into (a0, a1).\n" ++
+  "  mv a0, a2\n" ++
+  "  mv a1, a3\n" ++
+  "  la a2, ac2_inner_digest\n" ++
+  "  jal ra, zkvm_keccak256\n" ++
+  "  # Step 2: build preimage.\n" ++
+  "  la s2, ac2_preimage\n" ++
+  "  li t0, 0xff\n" ++
+  "  sb t0, 0(s2)\n" ++
+  "  # Copy sender 20 B → preimage[1..21] (8 + 8 + 4).\n" ++
+  "  ld t0,  0(s0); sd t0,  1(s2)\n" ++
+  "  ld t0,  8(s0); sd t0,  9(s2)\n" ++
+  "  lwu t0, 16(s0); sw t0, 17(s2)\n" ++
+  "  # Copy salt 32 B → preimage[21..53] (8 × 4).\n" ++
+  "  ld t0,  0(s1); sd t0, 21(s2)\n" ++
+  "  ld t0,  8(s1); sd t0, 29(s2)\n" ++
+  "  ld t0, 16(s1); sd t0, 37(s2)\n" ++
+  "  ld t0, 24(s1); sd t0, 45(s2)\n" ++
+  "  # Copy inner digest 32 B → preimage[53..85].\n" ++
+  "  la t1, ac2_inner_digest\n" ++
+  "  ld t0,  0(t1); sd t0, 53(s2)\n" ++
+  "  ld t0,  8(t1); sd t0, 61(s2)\n" ++
+  "  ld t0, 16(t1); sd t0, 69(s2)\n" ++
+  "  ld t0, 24(t1); sd t0, 77(s2)\n" ++
+  "  # Step 3: outer = keccak256(preimage, 85).\n" ++
+  "  mv a0, s2\n" ++
+  "  li a1, 85\n" ++
+  "  la a2, ac2_outer_digest\n" ++
+  "  jal ra, zkvm_keccak256\n" ++
+  "  # Step 4: copy outer[12..32] (20 B) → out.\n" ++
+  "  la t0, ac2_outer_digest\n" ++
+  "  ld t1, 12(t0); sd t1,  0(s4)\n" ++
+  "  ld t1, 20(t0); sd t1,  8(s4)\n" ++
+  "  lwu t1, 28(t0); sw t1, 16(s4)\n" ++
+  "  li a0, 0\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp); ld s4, 40(sp)\n" ++
+  "  addi sp, sp, 48\n" ++
+  "  ret"
+
+/-- `zisk_address_compute_create2`: probe BuildUnit.
+    Input layout:
+      bytes  0.. 8 : init_code length
+      bytes  8..28 : sender (20 bytes)
+      bytes 28..60 : salt (32 bytes)
+      bytes 60..   : init_code bytes
+    Output layout:
+      bytes  0.. 8 : status
+      bytes  8..28 : 20-byte address
+      bytes 28..32 : padding -/
+def ziskAddressComputeCreate2Prologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a5, 0x40000000\n" ++
+  "  ld a3, 8(a5)                # init_code length\n" ++
+  "  addi a0, a5, 16             # sender ptr\n" ++
+  "  addi a1, a5, 36             # salt ptr\n" ++
+  "  addi a2, a5, 68             # init_code ptr\n" ++
+  "  li a4, 0xa0010008           # 20B address output\n" ++
+  "  sd zero, 0(a4); sd zero, 8(a4); sw zero, 16(a4)\n" ++
+  "  jal ra, address_compute_create2\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lac2_pdone\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  addressComputeCreate2Function ++ "\n" ++
+  ".Lac2_pdone:"
+
+def ziskAddressComputeCreate2DataSection : String :=
+  ".section .data\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  ".balign 8\n" ++
+  "ac2_inner_digest:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "ac2_outer_digest:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "ac2_preimage:\n" ++
+  "  .zero 88"  -- 85 + 3 padding for 8-byte alignment of next
+
+def ziskAddressComputeCreate2ProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskAddressComputeCreate2Prologue
+  dataAsm     := ziskAddressComputeCreate2DataSection
+}
+
 /-! ## mpt_account_path_nibbles -- PR-K100
 
     Compute the state trie's path for a given 20-byte address:
@@ -13548,6 +13677,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_header_chain_walk_step" => some ziskHeaderChainWalkStepProbeUnit
   | "zisk_account_validate_code_hash" => some ziskAccountValidateCodeHashProbeUnit
   | "zisk_address_from_pubkey"  => some ziskAddressFromPubkeyProbeUnit
+  | "zisk_address_compute_create2" => some ziskAddressComputeCreate2ProbeUnit
   | "zisk_mpt_account_path_nibbles" => some ziskMptAccountPathNibblesProbeUnit
   | "zisk_headers_validate_chain" => some ziskHeadersValidateChainProbeUnit
   | "zisk_witness_lookup_by_hash" => some ziskWitnessLookupByHashProbeUnit
@@ -13678,6 +13808,7 @@ def knownProgramNames : List String :=
    "zisk_header_chain_walk_step",
    "zisk_account_validate_code_hash",
    "zisk_address_from_pubkey",
+   "zisk_address_compute_create2",
    "zisk_mpt_account_path_nibbles",
    "zisk_headers_validate_chain",
    "zisk_witness_lookup_by_hash",

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **141**
-- ziskemu round-trip scripts: **134** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **142**
+- ziskemu round-trip scripts: **135** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -252,7 +252,7 @@ This is the verified gas-cost surrogate.
 ## D — Codegen reach
 
 - Programs in `EvmAsm/Codegen/Programs.lean` registry: **139**
-- ziskemu round-trip scripts: **132** under `scripts/codegen-*.sh`
+- ziskemu round-trip scripts: **133** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,11 +251,7 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-<<<<<<< HEAD
 - Programs in `EvmAsm/Codegen/Programs.lean` registry: **141**
-=======
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **141**
->>>>>>> origin/main
 - ziskemu round-trip scripts: **134** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 

--- a/scripts/codegen-zisk-address-compute-create2-check.sh
+++ b/scripts/codegen-zisk-address-compute-create2-check.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# codegen-zisk-address-compute-create2-check.sh -- PR-K126.
+#
+# CREATE2 contract address per EIP-1014.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_address_compute_create2 ELF"
+lake exe codegen --program zisk_address_compute_create2 --halt linux93 \
+  -o gen-out/zisk_address_compute_create2
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <sender_hex> <salt_hex> <init_code_hex>
+run_case() {
+  local name="$1" sender="$2" salt="$3" code="$4"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_address_compute_create2_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_address_compute_create2_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys
+from Crypto.Hash import keccak
+sender = bytes.fromhex('$sender')
+salt   = bytes.fromhex('$salt')
+code   = bytes.fromhex('$code')
+assert len(sender) == 20
+assert len(salt) == 32
+
+inner = keccak.new(digest_bits=256).update(code).digest()
+preimage = b'\xff' + sender + salt + inner
+outer = keccak.new(digest_bits=256).update(preimage).digest()
+addr = outer[-20:]
+
+with open(sys.argv[1], 'wb') as f:
+    f.write(struct.pack('<Q', len(code)))
+    f.write(sender)
+    f.write(salt)
+    f.write(code)
+    pad = (-(8 + 20 + 32 + len(code))) % 8
+    if pad: f.write(b'\x00' * pad)
+with open(sys.argv[1] + '.expected', 'wb') as f:
+    f.write(addr)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_address_compute_create2.elf \
+    -i "$in_file" -o "$out_file" -n 5000000 \
+    >"$REPO_ROOT/gen-out/zisk_address_compute_create2_${name}.emu.log" 2>&1 || true
+
+  local actual_status; actual_status="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local actual_addr; actual_addr="$(dd if="$out_file" bs=1 skip=8 count=20 2>/dev/null | xxd -p | tr -d '\n')"
+  local expected_addr; expected_addr="$(xxd -p "$in_file.expected" | tr -d '\n')"
+
+  if [[ "$actual_status" == "0000000000000000" && "$actual_addr" == "$expected_addr" ]]; then
+    printf "  %-32s OK   addr=0x%s..\n" "$name" "${actual_addr:0:12}"
+    return 0
+  else
+    printf "  %-32s FAIL\n    expected: %s\n    actual:   %s\n" "$name" "$expected_addr" "$actual_addr"
+    return 1
+  fi
+}
+
+# EIP-1014 example fixtures from the EIP spec
+FAILED=0
+run_case "eip1014_ex0" \
+  "0000000000000000000000000000000000000000" \
+  "0000000000000000000000000000000000000000000000000000000000000000" \
+  "00" || FAILED=1
+
+run_case "eip1014_ex1" \
+  "deadbeef00000000000000000000000000000000" \
+  "0000000000000000000000000000000000000000000000000000000000000000" \
+  "00" || FAILED=1
+
+run_case "eip1014_ex2" \
+  "deadbeef00000000000000000000000000000000" \
+  "000000000000000000000000feed000000000000000000000000000000000000" \
+  "00" || FAILED=1
+
+run_case "eip1014_ex3" \
+  "0000000000000000000000000000000000000000" \
+  "0000000000000000000000000000000000000000000000000000000000000000" \
+  "deadbeef" || FAILED=1
+
+run_case "eip1014_ex4" \
+  "00000000000000000000000000000000deadbeef" \
+  "00000000000000000000000000000000000000000000000000000000cafebabe" \
+  "deadbeef" || FAILED=1
+
+run_case "eip1014_ex5" \
+  "00000000000000000000000000000000deadbeef" \
+  "00000000000000000000000000000000000000000000000000000000cafebabe" \
+  "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef" || FAILED=1
+
+# Long init code
+run_case "long_init_code" \
+  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+  "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" \
+  "$(python3 -c "print('60' * 300)")" || FAILED=1
+
+# Empty init code
+run_case "empty_init_code" \
+  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+  "0000000000000000000000000000000000000000000000000000000000000000" \
+  "" || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: address_compute_create2 matches EIP-1014"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Compute the CREATE2 contract address per EIP-1014:

```
address = keccak256(0xff || sender || salt || keccak256(init_code))[12:32]
```

Preimage is exactly 85 bytes:
- `0`        :  `0xff` (single-byte marker)
- `1..21`    :  `sender` (20 bytes)
- `21..53`   :  `salt` (32 bytes, BE)
- `53..85`   :  `inner_hash = keccak256(init_code)` (32 bytes)

Used by the EVM's `CREATE2` opcode and by off-chain tooling that
needs deterministic deploy addresses. Sister primitive to PR-K99
`address_from_pubkey` (the ECRECOVER trailing step) and to a
future `address_compute_create` (for the non-deterministic nonce-
based form).

Composes PR-K3 `zkvm_keccak256` (called twice — once over
`init_code` and once over the 85-byte preimage).

Status: always `0` (total function; keccak is total).

## Test plan

- [x] `scripts/codegen-zisk-address-compute-create2-check.sh`
  passes 8 fixtures: all 6 canonical EIP-1014 example vectors,
  plus a long-init-code stress (300 bytes) and an empty-init-code
  case. Every result cross-validates against Python's
  `keccak256(preimage)[-20:]`
- [x] `lake build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)