### PR TITLE
feat(stateless): address_compute_create (PR-K127)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -1250,6 +1250,43 @@ def addressComputeCreate2Function : String :=
       bytes  0.. 8 : status
       bytes  8..28 : 20-byte address
       bytes 28..32 : padding -/
+def ziskAddressComputeCreate2Prologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a5, 0x40000000\n" ++
+  "  ld a3, 8(a5)                # init_code length\n" ++
+  "  addi a0, a5, 16             # sender ptr\n" ++
+  "  addi a1, a5, 36             # salt ptr\n" ++
+  "  addi a2, a5, 68             # init_code ptr\n" ++
+  "  li a4, 0xa0010008           # 20B address output\n" ++
+  "  sd zero, 0(a4); sd zero, 8(a4); sw zero, 16(a4)\n" ++
+  "  jal ra, address_compute_create2\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lac2_pdone\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  addressComputeCreate2Function ++ "\n" ++
+  ".Lac2_pdone:"
+
+def ziskAddressComputeCreate2DataSection : String :=
+  ".section .data\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  ".balign 8\n" ++
+  "ac2_inner_digest:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "ac2_outer_digest:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "ac2_preimage:\n" ++
+  "  .zero 88"  -- 85 + 3 padding for 8-byte alignment of next
+
+def ziskAddressComputeCreate2ProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskAddressComputeCreate2Prologue
+  dataAsm     := ziskAddressComputeCreate2DataSection
+}
+
 /-! ## address_compute_create -- PR-K127
 
     Compute the CREATE contract address (non-deterministic form):

--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -1158,6 +1158,174 @@ def ziskAddressFromPubkeyProbeUnit : BuildUnit := {
   dataAsm     := ziskAddressFromPubkeyDataSection
 }
 
+/-! ## address_compute_create -- PR-K127
+
+    Compute the CREATE contract address (non-deterministic form):
+
+      address = keccak256(rlp.encode([sender, nonce]))[12:32]
+
+    Used by:
+    - the EVM's `CREATE` opcode (when a contract creates another)
+    - the tx-level contract-creation path (when `tx.to == empty`),
+      where `sender` is the tx sender (recovered via ECRECOVER)
+      and `nonce` is the sender's pre-tx account nonce.
+
+    Sister primitive to PR-K126 `address_compute_create2` (the
+    deterministic salt-based form). EIP-2681 caps `nonce` at
+    `2^64 - 1` so the u64 input always fits the RLP encoding's
+    1+8-byte upper bound.
+
+    RLP encoding of `[sender, nonce]`:
+      [0]   : list prefix = 0xc0 + payload_len
+      [1]   : sender prefix = 0x94 (20-byte string marker)
+      [2..22] : sender 20 bytes
+      [22..] : nonce RLP, one of:
+        nonce == 0       : single byte 0x80
+        nonce in 1..127  : single byte = nonce
+        nonce >= 128     : 0x80 + bc, then `bc` BE-encoded bytes,
+                           where `bc ∈ {1..8}` (= effective byte
+                           count, no leading zeros)
+
+    Payload (sender_rlp + nonce_rlp) is at most 21 + 9 = 30 bytes,
+    so the list prefix is always the short form `0xc0..0xde`.
+
+    Composes PR-K3 `zkvm_keccak256`. Uses 32 + 8 + 32 bytes of
+    `.data` scratch (`ac_buffer` for the RLP, `ac_nonce_be` for
+    long-form byte counting, `ac_digest` for keccak output).
+
+    Calling convention:
+      a0 (input)  : sender ptr (20 B, big-endian)
+      a1 (input)  : nonce (u64)
+      a2 (input)  : 20-byte output ptr
+      ra (input)  : return
+      a0 (output) : 0 (always succeeds; keccak is total). -/
+def addressComputeCreateFunction : String :=
+  "address_compute_create:\n" ++
+  "  addi sp, sp, -32\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp)\n" ++
+  "  mv s0, a0                   # sender ptr\n" ++
+  "  mv s1, a1                   # nonce\n" ++
+  "  mv s2, a2                   # output ptr\n" ++
+  "  la t0, ac_buffer\n" ++
+  "  li t1, 0x94\n" ++
+  "  sb t1, 1(t0)\n" ++
+  "  ld t1,  0(s0); sd t1,  2(t0)\n" ++
+  "  ld t1,  8(s0); sd t1, 10(t0)\n" ++
+  "  lwu t1, 16(s0); sw t1, 18(t0)\n" ++
+  "  beqz s1, .Lac_nonce_zero\n" ++
+  "  li t1, 128\n" ++
+  "  bgeu s1, t1, .Lac_nonce_long\n" ++
+  "  # nonce in 1..127: single byte = nonce.\n" ++
+  "  sb s1, 22(t0)\n" ++
+  "  li t2, 1\n" ++
+  "  j .Lac_have_nonce_len\n" ++
+  ".Lac_nonce_zero:\n" ++
+  "  li t1, 0x80\n" ++
+  "  sb t1, 22(t0)\n" ++
+  "  li t2, 1\n" ++
+  "  j .Lac_have_nonce_len\n" ++
+  ".Lac_nonce_long:\n" ++
+  "  la t3, ac_nonce_be\n" ++
+  "  srli t4, s1, 56; sb t4, 0(t3)\n" ++
+  "  srli t4, s1, 48; sb t4, 1(t3)\n" ++
+  "  srli t4, s1, 40; sb t4, 2(t3)\n" ++
+  "  srli t4, s1, 32; sb t4, 3(t3)\n" ++
+  "  srli t4, s1, 24; sb t4, 4(t3)\n" ++
+  "  srli t4, s1, 16; sb t4, 5(t3)\n" ++
+  "  srli t4, s1,  8; sb t4, 6(t3)\n" ++
+  "  sb s1, 7(t3)\n" ++
+  "  li t4, 0                    # leading zero count\n" ++
+  ".Lac_find_nz:\n" ++
+  "  add t5, t3, t4\n" ++
+  "  lbu t6, 0(t5)\n" ++
+  "  bnez t6, .Lac_found\n" ++
+  "  addi t4, t4, 1\n" ++
+  "  j .Lac_find_nz\n" ++
+  ".Lac_found:\n" ++
+  "  li t5, 8\n" ++
+  "  sub t2, t5, t4\n" ++
+  "  # Write prefix byte 0x80 + byte_count at offset 22.\n" ++
+  "  addi t5, t2, 0x80\n" ++
+  "  sb t5, 22(t0)\n" ++
+  "  addi t6, t0, 23             # dst cursor\n" ++
+  "  add t5, t3, t4              # src cursor\n" ++
+  "  mv t1, t2                   # remaining\n" ++
+  ".Lac_copy_nz:\n" ++
+  "  beqz t1, .Lac_have_nonce_len_pp\n" ++
+  "  lbu t4, 0(t5)\n" ++
+  "  sb t4, 0(t6)\n" ++
+  "  addi t5, t5, 1\n" ++
+  "  addi t6, t6, 1\n" ++
+  "  addi t1, t1, -1\n" ++
+  "  j .Lac_copy_nz\n" ++
+  ".Lac_have_nonce_len_pp:\n" ++
+  "  # In the long path, t2 = data byte count. Add 1 for the prefix.\n" ++
+  "  addi t2, t2, 1\n" ++
+  ".Lac_have_nonce_len:\n" ++
+  "  # payload_len = 21 (sender_rlp) + nonce_rlp_len (t2)\n" ++
+  "  addi t1, t2, 21\n" ++
+  "  # list prefix = 0xc0 + payload_len\n" ++
+  "  addi t3, t1, 0xc0\n" ++
+  "  sb t3, 0(t0)\n" ++
+  "  # Total length = 1 + payload_len = 22 + nonce_rlp_len.\n" ++
+  "  addi a1, t2, 22\n" ++
+  "  mv a0, t0\n" ++
+  "  la a2, ac_digest\n" ++
+  "  jal ra, zkvm_keccak256\n" ++
+  "  la t0, ac_digest\n" ++
+  "  ld t1, 12(t0); sd t1,  0(s2)\n" ++
+  "  ld t1, 20(t0); sd t1,  8(s2)\n" ++
+  "  lwu t1, 28(t0); sw t1, 16(s2)\n" ++
+  "  li a0, 0\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp)\n" ++
+  "  addi sp, sp, 32\n" ++
+  "  ret"
+
+/-- `zisk_address_compute_create`: probe BuildUnit.
+    Input layout:
+      bytes  0.. 8 : nonce (u64)
+      bytes  8..28 : sender (20 bytes)
+    Output layout:
+      bytes  0.. 8 : status
+      bytes  8..28 : 20-byte address
+      bytes 28..32 : padding -/
+def ziskAddressComputeCreatePrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a3, 0x40000000\n" ++
+  "  ld a1, 8(a3)                # nonce\n" ++
+  "  addi a0, a3, 16             # sender ptr\n" ++
+  "  li a2, 0xa0010008           # 20B address output\n" ++
+  "  sd zero, 0(a2); sd zero, 8(a2); sw zero, 16(a2)\n" ++
+  "  jal ra, address_compute_create\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lac_pdone\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  addressComputeCreateFunction ++ "\n" ++
+  ".Lac_pdone:"
+
+def ziskAddressComputeCreateDataSection : String :=
+  ".section .data\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  ".balign 8\n" ++
+  "ac_buffer:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "ac_nonce_be:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "ac_digest:\n" ++
+  "  .zero 32"
+
+def ziskAddressComputeCreateProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskAddressComputeCreatePrologue
+  dataAsm     := ziskAddressComputeCreateDataSection
+}
+
 /-! ## mpt_account_path_nibbles -- PR-K100
 
     Compute the state trie's path for a given 20-byte address:
@@ -13548,6 +13716,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_header_chain_walk_step" => some ziskHeaderChainWalkStepProbeUnit
   | "zisk_account_validate_code_hash" => some ziskAccountValidateCodeHashProbeUnit
   | "zisk_address_from_pubkey"  => some ziskAddressFromPubkeyProbeUnit
+  | "zisk_address_compute_create" => some ziskAddressComputeCreateProbeUnit
   | "zisk_mpt_account_path_nibbles" => some ziskMptAccountPathNibblesProbeUnit
   | "zisk_headers_validate_chain" => some ziskHeadersValidateChainProbeUnit
   | "zisk_witness_lookup_by_hash" => some ziskWitnessLookupByHashProbeUnit
@@ -13678,6 +13847,7 @@ def knownProgramNames : List String :=
    "zisk_header_chain_walk_step",
    "zisk_account_validate_code_hash",
    "zisk_address_from_pubkey",
+   "zisk_address_compute_create",
    "zisk_mpt_account_path_nibbles",
    "zisk_headers_validate_chain",
    "zisk_witness_lookup_by_hash",

--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -1420,24 +1420,6 @@ def addressComputeCreateFunction : String :=
       bytes  0.. 8 : status
       bytes  8..28 : 20-byte address
       bytes 28..32 : padding -/
-def ziskAddressComputeCreate2Prologue : String :=
-  "  li sp, 0xa0050000\n" ++
-  "  li a5, 0x40000000\n" ++
-  "  ld a3, 8(a5)                # init_code length\n" ++
-  "  addi a0, a5, 16             # sender ptr\n" ++
-  "  addi a1, a5, 36             # salt ptr\n" ++
-  "  addi a2, a5, 68             # init_code ptr\n" ++
-  "  li a4, 0xa0010008           # 20B address output\n" ++
-  "  sd zero, 0(a4); sd zero, 8(a4); sw zero, 16(a4)\n" ++
-  "  jal ra, address_compute_create2\n" ++
-  "  li t0, 0xa0010000\n" ++
-  "  sd a0, 0(t0)\n" ++
-  "  j .Lac2_pdone\n" ++
-  zkvmKeccak256Function ++ "\n" ++
-  addressComputeCreate2Function ++ "\n" ++
-  ".Lac2_pdone:"
-
-def ziskAddressComputeCreate2DataSection : String :=
 def ziskAddressComputeCreatePrologue : String :=
   "  li sp, 0xa0050000\n" ++
   "  li a3, 0x40000000\n" ++
@@ -1458,19 +1440,6 @@ def ziskAddressComputeCreateDataSection : String :=
   "zk3_state:\n" ++
   "  .zero 200\n" ++
   ".balign 8\n" ++
-  "ac2_inner_digest:\n" ++
-  "  .zero 32\n" ++
-  ".balign 8\n" ++
-  "ac2_outer_digest:\n" ++
-  "  .zero 32\n" ++
-  ".balign 8\n" ++
-  "ac2_preimage:\n" ++
-  "  .zero 88"  -- 85 + 3 padding for 8-byte alignment of next
-
-def ziskAddressComputeCreate2ProbeUnit : BuildUnit := {
-  body        := NOP
-  prologueAsm := ziskAddressComputeCreate2Prologue
-  dataAsm     := ziskAddressComputeCreate2DataSection
   "ac_buffer:\n" ++
   "  .zero 32\n" ++
   ".balign 8\n" ++

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **141**
-- ziskemu round-trip scripts: **134** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **142**
+- ziskemu round-trip scripts: **135** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -252,7 +252,7 @@ This is the verified gas-cost surrogate.
 ## D — Codegen reach
 
 - Programs in `EvmAsm/Codegen/Programs.lean` registry: **139**
-- ziskemu round-trip scripts: **132** under `scripts/codegen-*.sh`
+- ziskemu round-trip scripts: **133** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,11 +251,7 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-<<<<<<< HEAD
 - Programs in `EvmAsm/Codegen/Programs.lean` registry: **141**
-=======
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **141**
->>>>>>> origin/main
 - ziskemu round-trip scripts: **134** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 

--- a/scripts/codegen-zisk-address-compute-create-check.sh
+++ b/scripts/codegen-zisk-address-compute-create-check.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# codegen-zisk-address-compute-create-check.sh -- PR-K127.
+#
+# CREATE address: keccak256(rlp.encode([sender, nonce]))[12:].
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_address_compute_create ELF"
+lake exe codegen --program zisk_address_compute_create --halt linux93 \
+  -o gen-out/zisk_address_compute_create
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <sender_hex> <nonce>
+run_case() {
+  local name="$1" sender="$2" nonce="$3"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_address_compute_create_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_address_compute_create_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+from Crypto.Hash import keccak
+sender = bytes.fromhex('$sender')
+assert len(sender) == 20
+nonce = $nonce
+preimage = rlp.encode([sender, nonce])
+addr = keccak.new(digest_bits=256).update(preimage).digest()[-20:]
+
+with open(sys.argv[1], 'wb') as f:
+    f.write(struct.pack('<Q', nonce))
+    f.write(sender)
+    pad = (-(8 + 20)) % 8
+    if pad: f.write(b'\x00' * pad)
+with open(sys.argv[1] + '.expected', 'wb') as f:
+    f.write(addr)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_address_compute_create.elf \
+    -i "$in_file" -o "$out_file" -n 5000000 \
+    >"$REPO_ROOT/gen-out/zisk_address_compute_create_${name}.emu.log" 2>&1 || true
+
+  local actual_status; actual_status="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local actual_addr; actual_addr="$(dd if="$out_file" bs=1 skip=8 count=20 2>/dev/null | xxd -p | tr -d '\n')"
+  local expected_addr; expected_addr="$(xxd -p "$in_file.expected" | tr -d '\n')"
+
+  if [[ "$actual_status" == "0000000000000000" && "$actual_addr" == "$expected_addr" ]]; then
+    printf "  %-32s OK   addr=0x%s..\n" "$name" "${actual_addr:0:12}"
+    return 0
+  else
+    printf "  %-32s FAIL\n    expected: %s\n    actual:   %s\n" "$name" "$expected_addr" "$actual_addr"
+    return 1
+  fi
+}
+
+ALICE="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+BOB="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+FAILED=0
+# Cover all nonce-RLP branches:
+# nonce == 0 (single 0x80)
+run_case "nonce_zero"          "$ALICE"  0      || FAILED=1
+# 1..127 (single byte)
+run_case "nonce_1"             "$ALICE"  1      || FAILED=1
+run_case "nonce_127"           "$ALICE"  127    || FAILED=1
+# 128..255 (0x81 || 1B)
+run_case "nonce_128"           "$ALICE"  128    || FAILED=1
+run_case "nonce_255"           "$ALICE"  255    || FAILED=1
+# 256..65535 (0x82 || 2B)
+run_case "nonce_256"           "$ALICE"  256    || FAILED=1
+run_case "nonce_65535"         "$ALICE"  65535  || FAILED=1
+# 3..4-byte nonces
+run_case "nonce_65536"         "$BOB"    65536  || FAILED=1
+run_case "nonce_1000000"       "$BOB"    1000000 || FAILED=1
+# Near u64 max
+run_case "nonce_huge"          "$ALICE"  "(1 << 56) - 1" || FAILED=1
+run_case "nonce_max"           "$ALICE"  "(1 << 64) - 1" || FAILED=1
+# Zero sender
+run_case "zero_sender"         "0000000000000000000000000000000000000000" 0 || FAILED=1
+# Sender with random pattern
+run_case "interesting_sender"  "1234567890abcdef1234567890abcdef12345678" 42 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: address_compute_create matches keccak256(rlp([sender, nonce]))[12:]"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Compute the CREATE contract address (non-deterministic form):

```
address = keccak256(rlp.encode([sender, nonce]))[12:32]
```

Used by:
- the EVM's `CREATE` opcode (when a contract creates another)
- the tx-level contract-creation path (when `tx.to == empty`),
  where `sender` is the tx sender (recovered via ECRECOVER) and
  `nonce` is the sender's pre-tx account nonce.

Sister primitive to PR-K126 `address_compute_create2` (the
deterministic salt-based form). EIP-2681 caps `nonce` at
`2^64 - 1` so the u64 input always fits.

RLP encoding of `[sender, nonce]`:
- `[0]`     : list prefix = `0xc0 + payload_len`
- `[1]`     : sender prefix = `0x94` (20-byte string marker)
- `[2..22]` : sender 20 bytes
- `[22..]`  : nonce RLP, one of:
  - `nonce == 0`       : single byte `0x80`
  - `nonce in 1..127`  : single byte = `nonce`
  - `nonce >= 128`     : `0x80 + bc`, then `bc` BE-encoded bytes
                         (`bc ∈ {1..8}`, no leading zeros)

Payload (`sender_rlp + nonce_rlp`) is at most `21 + 9 = 30` bytes,
so the list prefix is always the short form `0xc0..0xde`.

Composes PR-K3 `zkvm_keccak256`.

Status: always `0` (total function; keccak is total).

## Test plan

- [x] `scripts/codegen-zisk-address-compute-create-check.sh` passes
  13 fixtures covering every nonce-RLP branch (0, 1, 127, 128, 255,
  256, 65535, 65536, 1M, 2⁵⁶-1, max u64) plus zero-sender and an
  interesting-pattern sender. Each result cross-validates against
  Python's `keccak256(rlp.encode([sender, nonce]))[-20:]`
- [x] `lake build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)