### PR TITLE
feat(stateless): withdrawal_rlp_encode (PR-K130)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -3951,6 +3951,226 @@ def ziskRlpEncodeUintBeProbeUnit : BuildUnit := {
   dataAsm     := ziskRlpEncodeUintBeDataSection
 }
 
+/-! ## withdrawal_rlp_encode -- PR-K130
+
+    RLP-encode an EIP-4895 `Withdrawal`:
+
+      Withdrawal = [index, validator_index, address, amount]
+
+    Field types:
+    - index           : u64 (RLP uint, canonical form)
+    - validator_index : u64 (RLP uint, canonical form)
+    - address         : 20-byte bytestring (0x94 prefix + 20 bytes)
+    - amount          : u64 in Gwei (RLP uint, canonical form)
+
+    Output is the full `rlp.encode(withdrawal)` bytes — a short
+    list (payload always < 56 bytes), so the outer prefix is the
+    1-byte `0xc0 + payload_len` form.
+
+    Used by:
+    - the withdrawals MPT root computation (value field of each
+      `[rlp(i), rlp(withdrawal)]` leaf)
+    - PR-K77 `process_withdrawal`'s receipt-log path
+    - block-body re-serialization
+
+    Composes:
+      - PR-K30 `rlp_encode_uint_be` — for u64 uint fields
+      - hardcoded `0x94 || address` — for the 20-byte string field
+      - 1-byte list prefix — computed inline
+
+    Calling convention:
+      a0 (input)  : index (u64)
+      a1 (input)  : validator_index (u64)
+      a2 (input)  : address ptr (20 bytes)
+      a3 (input)  : amount (u64, Gwei)
+      a4 (input)  : output bytes ptr (caller supplies ≥ 56 bytes)
+      a5 (input)  : u64 out ptr (output byte length)
+      ra (input)  : return
+      a0 (output) : 0 (always succeeds — total function). -/
+def withdrawalRlpEncodeFunction : String :=
+  "withdrawal_rlp_encode:\n" ++
+  "  addi sp, sp, -64\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp)\n" ++
+  "  mv s0, a0                   # index\n" ++
+  "  mv s1, a1                   # validator_index\n" ++
+  "  mv s2, a2                   # address ptr\n" ++
+  "  mv s3, a3                   # amount\n" ++
+  "  mv s4, a4                   # output bytes ptr\n" ++
+  "  mv s5, a5                   # output length out\n" ++
+  "  # Write index as 8 BE bytes to wre_idx_be, then RLP-encode.\n" ++
+  "  la t0, wre_idx_be\n" ++
+  "  srli t1, s0, 56; sb t1, 0(t0)\n" ++
+  "  srli t1, s0, 48; sb t1, 1(t0)\n" ++
+  "  srli t1, s0, 40; sb t1, 2(t0)\n" ++
+  "  srli t1, s0, 32; sb t1, 3(t0)\n" ++
+  "  srli t1, s0, 24; sb t1, 4(t0)\n" ++
+  "  srli t1, s0, 16; sb t1, 5(t0)\n" ++
+  "  srli t1, s0,  8; sb t1, 6(t0)\n" ++
+  "  sb s0, 7(t0)\n" ++
+  "  mv a0, t0\n" ++
+  "  li a1, 8\n" ++
+  "  la a2, wre_idx_rlp\n" ++
+  "  jal ra, rlp_encode_uint_be\n" ++
+  "  la t0, wre_idx_len\n" ++
+  "  sd a0, 0(t0)                # save returned length\n" ++
+  "  # Write validator_index as 8 BE bytes.\n" ++
+  "  la t0, wre_val_be\n" ++
+  "  srli t1, s1, 56; sb t1, 0(t0)\n" ++
+  "  srli t1, s1, 48; sb t1, 1(t0)\n" ++
+  "  srli t1, s1, 40; sb t1, 2(t0)\n" ++
+  "  srli t1, s1, 32; sb t1, 3(t0)\n" ++
+  "  srli t1, s1, 24; sb t1, 4(t0)\n" ++
+  "  srli t1, s1, 16; sb t1, 5(t0)\n" ++
+  "  srli t1, s1,  8; sb t1, 6(t0)\n" ++
+  "  sb s1, 7(t0)\n" ++
+  "  mv a0, t0\n" ++
+  "  li a1, 8\n" ++
+  "  la a2, wre_val_rlp\n" ++
+  "  jal ra, rlp_encode_uint_be\n" ++
+  "  la t0, wre_val_len\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  # Write amount as 8 BE bytes.\n" ++
+  "  la t0, wre_amt_be\n" ++
+  "  srli t1, s3, 56; sb t1, 0(t0)\n" ++
+  "  srli t1, s3, 48; sb t1, 1(t0)\n" ++
+  "  srli t1, s3, 40; sb t1, 2(t0)\n" ++
+  "  srli t1, s3, 32; sb t1, 3(t0)\n" ++
+  "  srli t1, s3, 24; sb t1, 4(t0)\n" ++
+  "  srli t1, s3, 16; sb t1, 5(t0)\n" ++
+  "  srli t1, s3,  8; sb t1, 6(t0)\n" ++
+  "  sb s3, 7(t0)\n" ++
+  "  mv a0, t0\n" ++
+  "  li a1, 8\n" ++
+  "  la a2, wre_amt_rlp\n" ++
+  "  jal ra, rlp_encode_uint_be\n" ++
+  "  la t0, wre_amt_len\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  la t0, wre_idx_len; ld t1, 0(t0)\n" ++
+  "  la t0, wre_val_len; ld t2, 0(t0)\n" ++
+  "  la t0, wre_amt_len; ld t3, 0(t0)\n" ++
+  "  add t4, t1, t2\n" ++
+  "  addi t4, t4, 21\n" ++
+  "  add t4, t4, t3\n" ++
+  "  mv s6, t4\n" ++
+  "  addi t5, t4, 0xc0\n" ++
+  "  sb t5, 0(s4)\n" ++
+  "  addi t6, s4, 1\n" ++
+  "  la t5, wre_idx_rlp\n" ++
+  "  mv t4, t1\n" ++
+  ".Lwre_copy_idx:\n" ++
+  "  beqz t4, .Lwre_idx_done\n" ++
+  "  lbu t0, 0(t5)\n" ++
+  "  sb t0, 0(t6)\n" ++
+  "  addi t5, t5, 1\n" ++
+  "  addi t6, t6, 1\n" ++
+  "  addi t4, t4, -1\n" ++
+  "  j .Lwre_copy_idx\n" ++
+  ".Lwre_idx_done:\n" ++
+  "  la t5, wre_val_rlp\n" ++
+  "  mv t4, t2\n" ++
+  ".Lwre_copy_val:\n" ++
+  "  beqz t4, .Lwre_val_done\n" ++
+  "  lbu t0, 0(t5)\n" ++
+  "  sb t0, 0(t6)\n" ++
+  "  addi t5, t5, 1\n" ++
+  "  addi t6, t6, 1\n" ++
+  "  addi t4, t4, -1\n" ++
+  "  j .Lwre_copy_val\n" ++
+  ".Lwre_val_done:\n" ++
+  "  li t0, 0x94\n" ++
+  "  sb t0, 0(t6)\n" ++
+  "  addi t6, t6, 1\n" ++
+  "  ld t0,  0(s2); sd t0,  0(t6)\n" ++
+  "  ld t0,  8(s2); sd t0,  8(t6)\n" ++
+  "  lwu t0, 16(s2); sw t0, 16(t6)\n" ++
+  "  addi t6, t6, 20\n" ++
+  "  la t5, wre_amt_rlp\n" ++
+  "  mv t4, t3\n" ++
+  ".Lwre_copy_amt:\n" ++
+  "  beqz t4, .Lwre_amt_done\n" ++
+  "  lbu t0, 0(t5)\n" ++
+  "  sb t0, 0(t6)\n" ++
+  "  addi t5, t5, 1\n" ++
+  "  addi t6, t6, 1\n" ++
+  "  addi t4, t4, -1\n" ++
+  "  j .Lwre_copy_amt\n" ++
+  ".Lwre_amt_done:\n" ++
+  "  addi t0, s6, 1\n" ++
+  "  sd t0, 0(s5)\n" ++
+  "  li a0, 0\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp)\n" ++
+  "  addi sp, sp, 64\n" ++
+  "  ret"
+
+/-- `zisk_withdrawal_rlp_encode`: probe BuildUnit. Reads
+    (index, validator_index, amount, address_20B) from host input,
+    writes (status, out_len, rlp_bytes...) to OUTPUT.
+    Input layout:
+      bytes  0.. 8 : index
+      bytes  8..16 : validator_index
+      bytes 16..24 : amount
+      bytes 24..44 : address (20 bytes)
+    Output layout:
+      bytes  0.. 8 : status
+      bytes  8..16 : out_len
+      bytes 16..   : withdrawal_rlp bytes -/
+def ziskWithdrawalRlpEncodePrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a6, 0x40000000\n" ++
+  "  ld a0, 8(a6)                # index\n" ++
+  "  ld a1, 16(a6)               # validator_index\n" ++
+  "  ld a3, 24(a6)               # amount\n" ++
+  "  addi a2, a6, 40             # address ptr (INPUT + 40)\n" ++
+  "  li a4, 0xa0010010           # out bytes\n" ++
+  "  li a5, 0xa0010008           # out_len out\n" ++
+  "  jal ra, withdrawal_rlp_encode\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lwre_pdone\n" ++
+  rlpEncodeUintBeFunction ++ "\n" ++
+  withdrawalRlpEncodeFunction ++ "\n" ++
+  ".Lwre_pdone:"
+
+def ziskWithdrawalRlpEncodeDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "wre_idx_be:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "wre_idx_rlp:\n" ++
+  "  .zero 16\n" ++
+  ".balign 8\n" ++
+  "wre_idx_len:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "wre_val_be:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "wre_val_rlp:\n" ++
+  "  .zero 16\n" ++
+  ".balign 8\n" ++
+  "wre_val_len:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "wre_amt_be:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "wre_amt_rlp:\n" ++
+  "  .zero 16\n" ++
+  ".balign 8\n" ++
+  "wre_amt_len:\n" ++
+  "  .zero 8"
+
+def ziskWithdrawalRlpEncodeProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskWithdrawalRlpEncodePrologue
+  dataAsm     := ziskWithdrawalRlpEncodeDataSection
+}
+
 /-! ## account_encode -- PR-K31 mutating side of account_decode
 
     Encode (nonce, balance, storage_root, code_hash) into the
@@ -13565,6 +13785,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_account_at_address"   => some ziskAccountAtAddressProbeUnit
   | "zisk_slot_at_index"        => some ziskSlotAtIndexProbeUnit
   | "zisk_rlp_encode_uint_be"   => some ziskRlpEncodeUintBeProbeUnit
+  | "zisk_withdrawal_rlp_encode" => some ziskWithdrawalRlpEncodeProbeUnit
   | "zisk_account_encode"       => some ziskAccountEncodeProbeUnit
   | "zisk_hp_encode_nibbles"    => some ziskHpEncodeNibblesProbeUnit
   | "zisk_state_root_single_account" => some ziskStateRootSingleAccountProbeUnit
@@ -13695,6 +13916,7 @@ def knownProgramNames : List String :=
    "zisk_account_at_address",
    "zisk_slot_at_index",
    "zisk_rlp_encode_uint_be",
+   "zisk_withdrawal_rlp_encode",
    "zisk_account_encode",
    "zisk_hp_encode_nibbles",
    "zisk_state_root_single_account",

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **141**
-- ziskemu round-trip scripts: **134** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **142**
+- ziskemu round-trip scripts: **135** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -252,7 +252,7 @@ This is the verified gas-cost surrogate.
 ## D — Codegen reach
 
 - Programs in `EvmAsm/Codegen/Programs.lean` registry: **139**
-- ziskemu round-trip scripts: **132** under `scripts/codegen-*.sh`
+- ziskemu round-trip scripts: **133** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,11 +251,7 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-<<<<<<< HEAD
 - Programs in `EvmAsm/Codegen/Programs.lean` registry: **141**
-=======
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **141**
->>>>>>> origin/main
 - ziskemu round-trip scripts: **134** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 

--- a/scripts/codegen-zisk-withdrawal-rlp-encode-check.sh
+++ b/scripts/codegen-zisk-withdrawal-rlp-encode-check.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# codegen-zisk-withdrawal-rlp-encode-check.sh -- PR-K130.
+#
+# RLP-encode an EIP-4895 Withdrawal.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_withdrawal_rlp_encode ELF"
+lake exe codegen --program zisk_withdrawal_rlp_encode --halt linux93 \
+  -o gen-out/zisk_withdrawal_rlp_encode
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <index> <validator> <address_hex> <amount>
+run_case() {
+  local name="$1" idx="$2" val="$3" addr="$4" amt="$5"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_withdrawal_rlp_encode_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_withdrawal_rlp_encode_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+idx = $idx
+val = $val
+amt = $amt
+addr = bytes.fromhex('$addr')
+expected = rlp.encode([idx, val, addr, amt])
+with open(sys.argv[1], 'wb') as f:
+    f.write(struct.pack('<Q', idx))
+    f.write(struct.pack('<Q', val))
+    f.write(struct.pack('<Q', amt))
+    f.write(b'\x00' * 8)  # padding to 32B before address
+    f.write(addr)
+    pad = (-(40 + 20)) % 8
+    if pad: f.write(b'\x00' * pad)
+with open(sys.argv[1] + '.expected', 'wb') as f:
+    f.write(struct.pack('<Q', len(expected)))
+    f.write(expected)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_withdrawal_rlp_encode.elf \
+    -i "$in_file" -o "$out_file" -n 1000000 \
+    >"$REPO_ROOT/gen-out/zisk_withdrawal_rlp_encode_${name}.emu.log" 2>&1 || true
+
+  local actual_status; actual_status="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local actual_len_le; actual_len_le="$(dd if="$out_file" bs=1 skip=8 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local actual_len; actual_len="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$actual_len_le'))[0])")"
+  local expected_len_le; expected_len_le="$(dd if="$in_file.expected" bs=1 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local expected_len; expected_len="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$expected_len_le'))[0])")"
+
+  if [[ "$actual_status" != "0000000000000000" ]]; then
+    printf "  %-32s FAIL status=0x%s\n" "$name" "$actual_status"
+    return 1
+  fi
+  if [[ "$actual_len" != "$expected_len" ]]; then
+    printf "  %-32s FAIL len=%d expected=%d\n" "$name" "$actual_len" "$expected_len"
+    return 1
+  fi
+  local actual_bytes; actual_bytes="$(dd if="$out_file" bs=1 skip=16 count="$actual_len" 2>/dev/null | xxd -p | tr -d '\n')"
+  local expected_bytes; expected_bytes="$(dd if="$in_file.expected" bs=1 skip=8 count="$expected_len" 2>/dev/null | xxd -p | tr -d '\n')"
+  if [[ "$actual_bytes" == "$expected_bytes" ]]; then
+    printf "  %-32s OK   len=%d\n" "$name" "$actual_len"
+    return 0
+  else
+    printf "  %-32s FAIL\n    expected: %s\n    actual:   %s\n" "$name" "$expected_bytes" "$actual_bytes"
+    return 1
+  fi
+}
+
+ALICE="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+BOB="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+ZERO="0000000000000000000000000000000000000000"
+
+FAILED=0
+run_case "all_zero"           0     0     "$ZERO"  0                       || FAILED=1
+run_case "simple"             1     1     "$ALICE" "10**9"                 || FAILED=1
+run_case "small_values"       42    100   "$ALICE" "$((32 * 10**9))"       || FAILED=1
+run_case "large_index"        65536 1000  "$BOB"   "$((1000 * 10**9))"     || FAILED=1
+run_case "huge_index"         "(1<<48)" "(1<<32)" "$ALICE" "$((10**15))"   || FAILED=1
+run_case "max_u64_index"      "(1<<64)-1" "(1<<64)-1" "$BOB" "(1<<64)-1"   || FAILED=1
+run_case "small_amount"       7     8     "$ALICE" 1                       || FAILED=1
+run_case "amount_127"         5     5     "$BOB"   127                     || FAILED=1
+run_case "amount_128"         5     5     "$BOB"   128                     || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: withdrawal_rlp_encode matches Python rlp.encode([idx, val, addr, amt])"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

RLP-encode an EIP-4895 `Withdrawal`:

```
Withdrawal = [index, validator_index, address, amount]
```

Field types:
- `index`           : u64 (RLP uint, canonical form)
- `validator_index` : u64 (RLP uint, canonical form)
- `address`         : 20-byte bytestring (`0x94` prefix + 20 bytes)
- `amount`          : u64 in Gwei (RLP uint, canonical form)

Output is the full `rlp.encode(withdrawal)` bytes — a short list
(payload always < 56 bytes), so the outer prefix is the 1-byte
`0xc0 + payload_len` form.

Used by:
- the withdrawals MPT root computation (value field of each
  `[rlp(i), rlp(withdrawal)]` leaf)
- PR-K77 `process_withdrawal`'s receipt-log path
- block-body re-serialization

Composes:
- PR-K30 `rlp_encode_uint_be` — for u64 uint fields (canonical
  leading-zero-stripped encoding)
- hardcoded `0x94 || address` — for the 20-byte string field
- 1-byte list prefix — computed inline

Status: always `0` (total function).

## Test plan

- [x] `scripts/codegen-zisk-withdrawal-rlp-encode-check.sh` passes
  9 fixtures spanning all-zero, simple/typical mainnet shapes, large
  values (`1<<48` index), max-u64 in every u64 slot, and boundary
  cases around the RLP uint encoding cutoff (amount=127, 128)
- [x] `lake build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)