### PR TITLE
feat(stateless): withdrawal_compute_hash (PR-K132)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -4171,6 +4171,118 @@ def ziskWithdrawalRlpEncodeProbeUnit : BuildUnit := {
   dataAsm     := ziskWithdrawalRlpEncodeDataSection
 }
 
+/-! ## withdrawal_compute_hash -- PR-K132
+
+    Compute the keccak256 hash of an EIP-4895 Withdrawal record:
+
+      hash = keccak256(rlp.encode([index, validator_index, address, amount]))
+
+    Used as the leaf value when building/walking the withdrawals
+    trie, and for receipt-side `process_withdrawal` bookkeeping.
+    Direct composition of:
+
+      - PR-K130 `withdrawal_rlp_encode` — produce the RLP bytes
+      - PR-K3   `zkvm_keccak256`        — hash them
+
+    Calling convention:
+      a0 (input)  : index (u64)
+      a1 (input)  : validator_index (u64)
+      a2 (input)  : address ptr (20 bytes)
+      a3 (input)  : amount (u64, Gwei)
+      a4 (input)  : 32-byte output ptr (hash)
+      ra (input)  : return
+      a0 (output) : 0 (always succeeds — both legs are total).
+
+    Uses 64 bytes of `.data` scratch (`wch_rlp_buf` for the encoded
+    withdrawal, ≤ 49 bytes max; `wch_rlp_len` for the length). -/
+def withdrawalComputeHashFunction : String :=
+  "withdrawal_compute_hash:\n" ++
+  "  addi sp, sp, -16\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp)\n" ++
+  "  mv s0, a4                   # output ptr (stash)\n" ++
+  "  # Call withdrawal_rlp_encode(index, validator_idx, addr, amt,\n" ++
+  "  #                           wch_rlp_buf, wch_rlp_len)\n" ++
+  "  # a0, a1, a2, a3 already hold the four input fields.\n" ++
+  "  la a4, wch_rlp_buf\n" ++
+  "  la a5, wch_rlp_len\n" ++
+  "  jal ra, withdrawal_rlp_encode\n" ++
+  "  # Call zkvm_keccak256(wch_rlp_buf, wch_rlp_len, s0)\n" ++
+  "  la a0, wch_rlp_buf\n" ++
+  "  la t0, wch_rlp_len; ld a1, 0(t0)\n" ++
+  "  mv a2, s0\n" ++
+  "  jal ra, zkvm_keccak256\n" ++
+  "  li a0, 0\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp)\n" ++
+  "  addi sp, sp, 16\n" ++
+  "  ret"
+
+/-- `zisk_withdrawal_compute_hash`: probe BuildUnit. Reads
+    (index, validator_index, amount, address_20B) from host input,
+    writes (status, hash[32]) to OUTPUT (40 bytes total). -/
+def ziskWithdrawalComputeHashPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a6, 0x40000000\n" ++
+  "  ld a0, 8(a6)                # index\n" ++
+  "  ld a1, 16(a6)               # validator_index\n" ++
+  "  ld a3, 24(a6)               # amount\n" ++
+  "  addi a2, a6, 40             # address ptr (INPUT + 40)\n" ++
+  "  li a4, 0xa0010008           # 32B hash output\n" ++
+  "  jal ra, withdrawal_compute_hash\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lwch_pdone\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  rlpEncodeUintBeFunction ++ "\n" ++
+  withdrawalRlpEncodeFunction ++ "\n" ++
+  withdrawalComputeHashFunction ++ "\n" ++
+  ".Lwch_pdone:"
+
+def ziskWithdrawalComputeHashDataSection : String :=
+  ".section .data\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  ".balign 8\n" ++
+  "wre_idx_be:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "wre_idx_rlp:\n" ++
+  "  .zero 16\n" ++
+  ".balign 8\n" ++
+  "wre_idx_len:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "wre_val_be:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "wre_val_rlp:\n" ++
+  "  .zero 16\n" ++
+  ".balign 8\n" ++
+  "wre_val_len:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "wre_amt_be:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "wre_amt_rlp:\n" ++
+  "  .zero 16\n" ++
+  ".balign 8\n" ++
+  "wre_amt_len:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "wch_rlp_buf:\n" ++
+  "  .zero 64\n" ++
+  ".balign 8\n" ++
+  "wch_rlp_len:\n" ++
+  "  .zero 8"
+
+def ziskWithdrawalComputeHashProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskWithdrawalComputeHashPrologue
+  dataAsm     := ziskWithdrawalComputeHashDataSection
+}
+
 /-! ## account_encode -- PR-K31 mutating side of account_decode
 
     Encode (nonce, balance, storage_root, code_hash) into the
@@ -13786,6 +13898,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_slot_at_index"        => some ziskSlotAtIndexProbeUnit
   | "zisk_rlp_encode_uint_be"   => some ziskRlpEncodeUintBeProbeUnit
   | "zisk_withdrawal_rlp_encode" => some ziskWithdrawalRlpEncodeProbeUnit
+  | "zisk_withdrawal_compute_hash" => some ziskWithdrawalComputeHashProbeUnit
   | "zisk_account_encode"       => some ziskAccountEncodeProbeUnit
   | "zisk_hp_encode_nibbles"    => some ziskHpEncodeNibblesProbeUnit
   | "zisk_state_root_single_account" => some ziskStateRootSingleAccountProbeUnit
@@ -13917,6 +14030,7 @@ def knownProgramNames : List String :=
    "zisk_slot_at_index",
    "zisk_rlp_encode_uint_be",
    "zisk_withdrawal_rlp_encode",
+   "zisk_withdrawal_compute_hash",
    "zisk_account_encode",
    "zisk_hp_encode_nibbles",
    "zisk_state_root_single_account",

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,12 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **141**
-<<<<<<< HEAD
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **142**
 - ziskemu round-trip scripts: **135** under `scripts/codegen-*.sh`
-=======
-- ziskemu round-trip scripts: **135** under `scripts/codegen-*.sh`
->>>>>>> origin/main
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **139**
-- ziskemu round-trip scripts: **132** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **140**
+- ziskemu round-trip scripts: **134** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **142**
-- ziskemu round-trip scripts: **135** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **143**
+- ziskemu round-trip scripts: **136** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-withdrawal-compute-hash-check.sh
+++ b/scripts/codegen-zisk-withdrawal-compute-hash-check.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# codegen-zisk-withdrawal-compute-hash-check.sh -- PR-K132.
+#
+# keccak256(rlp.encode(withdrawal)).
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_withdrawal_compute_hash ELF"
+lake exe codegen --program zisk_withdrawal_compute_hash --halt linux93 \
+  -o gen-out/zisk_withdrawal_compute_hash
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <index> <validator> <address_hex> <amount>
+run_case() {
+  local name="$1" idx="$2" val="$3" addr="$4" amt="$5"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_withdrawal_compute_hash_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_withdrawal_compute_hash_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+from Crypto.Hash import keccak
+idx = $idx; val = $val; amt = $amt
+addr = bytes.fromhex('$addr')
+encoded = rlp.encode([idx, val, addr, amt])
+h = keccak.new(digest_bits=256).update(encoded).digest()
+with open(sys.argv[1], 'wb') as f:
+    f.write(struct.pack('<Q', idx))
+    f.write(struct.pack('<Q', val))
+    f.write(struct.pack('<Q', amt))
+    f.write(b'\x00' * 8)
+    f.write(addr)
+    pad = (-(40 + 20)) % 8
+    if pad: f.write(b'\x00' * pad)
+with open(sys.argv[1] + '.expected', 'wb') as f:
+    f.write(h)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_withdrawal_compute_hash.elf \
+    -i "$in_file" -o "$out_file" -n 5000000 \
+    >"$REPO_ROOT/gen-out/zisk_withdrawal_compute_hash_${name}.emu.log" 2>&1 || true
+
+  local actual_status; actual_status="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local actual_hash; actual_hash="$(dd if="$out_file" bs=1 skip=8 count=32 2>/dev/null | xxd -p | tr -d '\n')"
+  local expected_hash; expected_hash="$(xxd -p "$in_file.expected" | tr -d '\n')"
+
+  if [[ "$actual_status" == "0000000000000000" && "$actual_hash" == "$expected_hash" ]]; then
+    printf "  %-32s OK   hash=%s..\n" "$name" "${actual_hash:0:16}"
+    return 0
+  else
+    printf "  %-32s FAIL\n    expected: %s\n    actual:   %s\n" "$name" "$expected_hash" "$actual_hash"
+    return 1
+  fi
+}
+
+ALICE="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+BOB="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+ZERO="0000000000000000000000000000000000000000"
+
+FAILED=0
+run_case "all_zero"     0     0     "$ZERO"  0                       || FAILED=1
+run_case "simple"       1     1     "$ALICE" "10**9"                 || FAILED=1
+run_case "typical"      42    1000  "$BOB"   "$((32 * 10**9))"       || FAILED=1
+run_case "large"        65536 1024  "$ALICE" "$((1000 * 10**9))"     || FAILED=1
+run_case "max_u64_all"  "(1<<64)-1" "(1<<64)-1" "$BOB" "(1<<64)-1"   || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: withdrawal_compute_hash matches keccak256(rlp.encode(withdrawal))"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Compute the keccak256 hash of an EIP-4895 Withdrawal record:

```
hash = keccak256(rlp.encode([index, validator_index, address, amount]))
```

Used as the leaf value when building/walking the withdrawals trie,
and for receipt-side `process_withdrawal` bookkeeping. Direct
composition of:

- PR-K130 `withdrawal_rlp_encode` — produce the RLP bytes
- PR-K3   `zkvm_keccak256`        — hash them

**Stacked on PR #5896 (K130).** Base will retarget to `main` once
that lands.

Status: always `0` (both legs are total).

## Test plan

- [x] `scripts/codegen-zisk-withdrawal-compute-hash-check.sh` passes
  5 fixtures: all-zero baseline, simple / typical mainnet shapes,
  large index/amount, and max-u64-in-every-slot stress. Each
  cross-validates against Python `keccak256(rlp.encode(...))`
- [x] `lake build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)