### PR TITLE
feat(stateless): account_storage_root_is_empty (PR-K133)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -1914,6 +1914,112 @@ def ziskAccountValidateCodeHashProbeUnit : BuildUnit := {
   dataAsm     := ziskAccountValidateCodeHashDataSection
 }
 
+/-! ## account_storage_root_is_empty -- PR-K133
+
+    Predicate: does this account's `storage_root` field equal
+    `EMPTY_TRIE_ROOT = keccak256(rlp.encode(b''))`?
+
+      EMPTY_TRIE_ROOT =
+        0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421
+
+    A `true` result means the account has no storage entries
+    (its storage trie is empty). EOAs and untouched contracts
+    carry this canonical empty value.
+
+    Companion to PR-K131 `account_has_empty_code` (the code-side
+    EOA predicate) and PR-K123 `account_is_empty` (the EIP-161
+    nonce+balance+code variant — but explicitly *not* requiring
+    empty storage).
+
+    Composes:
+      - PR-K20 `rlp_list_nth_item` — field 2 bounds
+
+    Calling convention:
+      a0 (input)  : account_rlp ptr
+      a1 (input)  : account_rlp byte length
+      a2 (input)  : u64 out ptr (1 if storage_root == EMPTY_TRIE_ROOT,
+                                 0 otherwise)
+      ra (input)  : return
+      a0 (output) :
+        0 : success — predicate written
+        1 : RLP parse failure / field 2 missing
+        2 : field 2 length != 32 -/
+def accountStorageRootIsEmptyFunction : String :=
+  "account_storage_root_is_empty:\n" ++
+  "  addi sp, sp, -32\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp)\n" ++
+  "  mv s0, a0                   # account_ptr\n" ++
+  "  mv s1, a1                   # account_len\n" ++
+  "  mv s2, a2                   # u64 out ptr\n" ++
+  "  sd zero, 0(s2)\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 2\n" ++
+  "  la a3, asrie_offset; la a4, asrie_length\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lasrie_parse_fail\n" ++
+  "  la t0, asrie_length; ld t1, 0(t0)\n" ++
+  "  li t2, 32\n" ++
+  "  bne t1, t2, .Lasrie_size_fail\n" ++
+  "  la t0, asrie_offset; ld t3, 0(t0); add t3, s0, t3\n" ++
+  "  la t4, asrie_empty_trie_root\n" ++
+  "  ld t5,  0(t3); ld t6,  0(t4); bne t5, t6, .Lasrie_neq\n" ++
+  "  ld t5,  8(t3); ld t6,  8(t4); bne t5, t6, .Lasrie_neq\n" ++
+  "  ld t5, 16(t3); ld t6, 16(t4); bne t5, t6, .Lasrie_neq\n" ++
+  "  ld t5, 24(t3); ld t6, 24(t4); bne t5, t6, .Lasrie_neq\n" ++
+  "  li t0, 1\n" ++
+  "  sd t0, 0(s2)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lasrie_ret\n" ++
+  ".Lasrie_neq:\n" ++
+  "  sd zero, 0(s2)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lasrie_ret\n" ++
+  ".Lasrie_parse_fail:\n" ++
+  "  li a0, 1\n" ++
+  "  j .Lasrie_ret\n" ++
+  ".Lasrie_size_fail:\n" ++
+  "  li a0, 2\n" ++
+  ".Lasrie_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp)\n" ++
+  "  addi sp, sp, 32\n" ++
+  "  ret"
+
+/-- `zisk_account_storage_root_is_empty`: probe BuildUnit. -/
+def ziskAccountStorageRootIsEmptyPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a3, 0x40000000\n" ++
+  "  ld a1, 8(a3)                # account_rlp_len\n" ++
+  "  addi a0, a3, 16             # account_rlp ptr\n" ++
+  "  li a2, 0xa0010008           # is_empty out\n" ++
+  "  jal ra, account_storage_root_is_empty\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lasrie_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  accountStorageRootIsEmptyFunction ++ "\n" ++
+  ".Lasrie_pdone:"
+
+def ziskAccountStorageRootIsEmptyDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "asrie_offset:\n" ++
+  "  .zero 8\n" ++
+  "asrie_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "asrie_empty_trie_root:\n" ++
+  "  .byte 0x56, 0xe8, 0x1f, 0x17, 0x1b, 0xcc, 0x55, 0xa6\n" ++
+  "  .byte 0xff, 0x83, 0x45, 0xe6, 0x92, 0xc0, 0xf8, 0x6e\n" ++
+  "  .byte 0x5b, 0x48, 0xe0, 0x1b, 0x99, 0x6c, 0xad, 0xc0\n" ++
+  "  .byte 0x01, 0x62, 0x2f, 0xb5, 0xe3, 0x63, 0xb4, 0x21"
+
+def ziskAccountStorageRootIsEmptyProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskAccountStorageRootIsEmptyPrologue
+  dataAsm     := ziskAccountStorageRootIsEmptyDataSection
+}
+
 /-! ## rlp_list_count_items -- PR-K47 top-level item counter
 
     Walk an RLP-encoded list once and return the number of
@@ -13547,6 +13653,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_header_validate_parent_hash" => some ziskHeaderValidateParentHashProbeUnit
   | "zisk_header_chain_walk_step" => some ziskHeaderChainWalkStepProbeUnit
   | "zisk_account_validate_code_hash" => some ziskAccountValidateCodeHashProbeUnit
+  | "zisk_account_storage_root_is_empty" => some ziskAccountStorageRootIsEmptyProbeUnit
   | "zisk_address_from_pubkey"  => some ziskAddressFromPubkeyProbeUnit
   | "zisk_mpt_account_path_nibbles" => some ziskMptAccountPathNibblesProbeUnit
   | "zisk_headers_validate_chain" => some ziskHeadersValidateChainProbeUnit
@@ -13677,6 +13784,7 @@ def knownProgramNames : List String :=
    "zisk_header_validate_parent_hash",
    "zisk_header_chain_walk_step",
    "zisk_account_validate_code_hash",
+   "zisk_account_storage_root_is_empty",
    "zisk_address_from_pubkey",
    "zisk_mpt_account_path_nibbles",
    "zisk_headers_validate_chain",

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **141**
-- ziskemu round-trip scripts: **134** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **142**
+- ziskemu round-trip scripts: **135** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-account-storage-root-is-empty-check.sh
+++ b/scripts/codegen-zisk-account-storage-root-is-empty-check.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# codegen-zisk-account-storage-root-is-empty-check.sh -- PR-K133.
+#
+# Predicate: storage_root == EMPTY_TRIE_ROOT?
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_account_storage_root_is_empty ELF"
+lake exe codegen --program zisk_account_storage_root_is_empty --halt linux93 \
+  -o gen-out/zisk_account_storage_root_is_empty
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <storage_root_hex> <expected_is_empty>
+run_case() {
+  local name="$1" sr="$2" exp_empty="$3"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_account_storage_root_is_empty_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_account_storage_root_is_empty_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+sr = bytes.fromhex('$sr')
+account = [42, 10**18, sr, bytes([0xab]*32)]
+account_rlp = rlp.encode(account)
+with open(sys.argv[1], 'wb') as f:
+    f.write(struct.pack('<Q', len(account_rlp)))
+    f.write(account_rlp)
+    pad = (-(8 + len(account_rlp))) % 8
+    if pad: f.write(b'\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_account_storage_root_is_empty.elf \
+    -i "$in_file" -o "$out_file" -n 1000000 \
+    >"$REPO_ROOT/gen-out/zisk_account_storage_root_is_empty_${name}.emu.log" 2>&1 || true
+
+  local actual_status; actual_status="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local actual_empty_le; actual_empty_le="$(dd if="$out_file" bs=1 skip=8 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local actual_empty; actual_empty="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$actual_empty_le'))[0])")"
+
+  if [[ "$actual_status" == "0000000000000000" && "$actual_empty" == "$exp_empty" ]]; then
+    printf "  %-32s OK   is_empty=%d\n" "$name" "$exp_empty"
+    return 0
+  else
+    printf "  %-32s FAIL status=0x%s is_empty=%d expected=%d\n" "$name" "$actual_status" "$actual_empty" "$exp_empty"
+    return 1
+  fi
+}
+
+ETR="56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"
+ZEROS="$(python3 -c "print('00' * 32)")"
+ONES="$(python3 -c "print('ff' * 32)")"
+NEAR_ETR="56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b422"
+
+FAILED=0
+run_case "canonical_empty_trie"    "$ETR"      1 || FAILED=1
+run_case "all_zeros"               "$ZEROS"    0 || FAILED=1
+run_case "all_ones"                "$ONES"     0 || FAILED=1
+run_case "near_etr_last_byte"      "$NEAR_ETR" 0 || FAILED=1
+run_case "random_root"             "$(python3 -c "print('ab' * 32)")" 0 || FAILED=1
+# Boundary: only first byte differs
+NEAR_ETR_FIRST="57e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"
+run_case "near_etr_first_byte"     "$NEAR_ETR_FIRST" 0 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: account_storage_root_is_empty matches storage_root == EMPTY_TRIE_ROOT"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Predicate: does this account's `storage_root` field equal
`EMPTY_TRIE_ROOT = keccak256(rlp.encode(b''))`?

```
EMPTY_TRIE_ROOT =
  0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421
```

A `true` result means the account has no storage entries (its
storage trie is empty). EOAs and untouched contracts carry this
canonical empty value.

Companion to PR-K131 `account_has_empty_code` (the code-side EOA
predicate) and PR-K123 `account_is_empty` (the EIP-161
nonce+balance+code variant — but explicitly *not* requiring
empty storage).

Composes PR-K20 `rlp_list_nth_item`.

Status:
- `0` : success — predicate written
- `1` : RLP parse failure / field 2 missing
- `2` : field 2 length != 32

## Test plan

- [x] `scripts/codegen-zisk-account-storage-root-is-empty-check.sh`
  passes 6 fixtures: canonical `EMPTY_TRIE_ROOT` (true), plus
  all-zeros, all-ones, near-ETR (last byte differs), near-ETR
  (first byte differs), and a random root (all false)
- [x] `lake build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)