### PR TITLE
feat(divmod): add n3 v4 callable stack path

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -65,6 +65,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN4V4
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4CallV4NoNop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V4NoNop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V4NoNopMaxCall
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V4NoNopPreloop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V4
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -55,6 +55,7 @@ import EvmAsm.Evm64.DivMod.LoopIterN4CallV4NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN4AddbackV4NoNop
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN4V4NoNop
 import EvmAsm.Evm64.DivMod.Compose.ModPreloopN4V4NoNop
+import EvmAsm.Evm64.DivMod.Compose.ModFullPathN3V4NoNop
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN4MaxSkipV4NoNop
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN4CallSkipV4NoNop
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN4CallAddbackV4NoNop

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -68,6 +68,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN3V4NoNopMaxCall
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V4NoNopPreloop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V4
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNop
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopSource
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1V4NoNop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1V4

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -69,6 +69,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN3V4NoNopPreloop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V4
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopSource
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopFinalPost
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1V4NoNop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1V4

--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -56,6 +56,7 @@ import EvmAsm.Evm64.DivMod.LoopIterN4AddbackV4NoNop
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN4V4NoNop
 import EvmAsm.Evm64.DivMod.Compose.ModPreloopN4V4NoNop
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN3V4NoNop
+import EvmAsm.Evm64.DivMod.Compose.ModFullPathN3V4NoNopPreloop
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN4MaxSkipV4NoNop
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN4CallSkipV4NoNop
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN4CallAddbackV4NoNop

--- a/EvmAsm/Evm64/DivMod/CallableV4Div.lean
+++ b/EvmAsm/Evm64/DivMod/CallableV4Div.lean
@@ -922,11 +922,8 @@ theorem evm_div_callable_v4_n3_stack_pre_to_callable_post_scratch_word
             (0 : Word)).2.2.2.1
           (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
             (b.getLimbN 2) (b.getLimbN 3)).2.2.1)
-    (hcarry2 : Carry2NzAll
-      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1
-      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.1
-      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
-      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2)
+    (hcarry2 : fullDivN3Carry2NzV4
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3))
     (hdivWord : fullDivN3QuotientWordV4 bltu_1 bltu_0
       (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
       (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) =
@@ -996,11 +993,8 @@ theorem evm_div_callable_v4_n3_stack_pre_to_callable_post_scratch_of_mulsub_over
     (hbltu_0 : isTrialN3V4_j0 bltu_1 bltu_0
       (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
       (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3))
-    (hcarry2 : Carry2NzAll
-      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1
-      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.1
-      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
-      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2)
+    (hcarry2 : fullDivN3Carry2NzV4
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3))
     (hmulsub : fullDivN3MulSubEqV4 bltu_1 bltu_0
       (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
       (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3))

--- a/EvmAsm/Evm64/DivMod/CallableV4Div.lean
+++ b/EvmAsm/Evm64/DivMod/CallableV4Div.lean
@@ -1,4 +1,5 @@
 import EvmAsm.Evm64.DivMod.Callable
+import EvmAsm.Evm64.DivMod.Spec.N3V4StackPre
 
 namespace EvmAsm.Evm64
 
@@ -682,6 +683,35 @@ theorem evm_div_callable_v4_spec_from_divCode_noNop_preserving_x1_x9out_body_fra
   exact cpsTripleWithin_weaken (fun _ hp => hp) (fun _ hp => by xperm_hyp hp)
     (cpsTripleWithin_seq_same_cr hStackForRet hRetFramed)
 
+/-- Named-post variant of the v4 callable DIV wrapper for `divCode_noNop_v4`
+    body proofs that carry a PC-free frame and return a possibly different
+    exact `x9` value. -/
+theorem evm_div_callable_v4_spec_from_divCode_noNop_exact_frame_x9out_body_framed
+    {F : Assertion} [Assertion.PCFree F]
+    (sp base x9In x9Out raVal : Word) (a b : EvmWord)
+    (v2 v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (hStack :
+      cpsTripleWithin unifiedDivBound base (base + nopOff) (divCode_noNop_v4 base)
+        (divModStackDispatchPreNoX1 sp a b
+          x9In raVal v2 v5 v6 v7 v10 v11
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0 ** F)
+        (divStackDispatchPostCallableExactFrame sp a b raVal x9Out ** F)) :
+    cpsTripleWithin (unifiedDivBound + 1) base (raVal &&& ~~~1)
+      (evm_div_callable_code_v4 base)
+      (divModStackDispatchPreNoX1 sp a b
+        x9In raVal v2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 ** F)
+      (divStackDispatchPostCallableExactFrame sp a b raVal x9Out ** F) := by
+  rw [divStackDispatchPostCallableExactFrame_unfold] at hStack ⊢
+  exact evm_div_callable_v4_spec_from_divCode_noNop_preserving_x1_x9out_body_framed
+    sp base x9In x9Out raVal a b v2 v5 v6 v7 v10 v11
+    q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 hStack
+
 /-- v4 callable DIV wrapper for full `divCode_noNop_v4` body proofs that
     transform an explicit PC-free frame and return a possibly different exact
     x9 value. -/
@@ -731,6 +761,35 @@ theorem evm_div_callable_v4_spec_from_divCode_noNop_preserving_x1_x9out_body_fra
       hRet
   exact cpsTripleWithin_weaken (fun _ hp => hp) (fun _ hp => by xperm_hyp hp)
     (cpsTripleWithin_seq_same_cr hStackForRet hRetFramed)
+
+/-- Named-post variant of the v4 callable DIV wrapper for `divCode_noNop_v4`
+    body proofs that transform an explicit PC-free frame and return a possibly
+    different exact `x9` value. -/
+theorem evm_div_callable_v4_spec_from_divCode_noNop_exact_frame_x9out_body_frame_transform
+    {FPre FPost : Assertion} [Assertion.PCFree FPost]
+    (sp base x9In x9Out raVal : Word) (a b : EvmWord)
+    (v2 v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (hStack :
+      cpsTripleWithin unifiedDivBound base (base + nopOff) (divCode_noNop_v4 base)
+        (divModStackDispatchPreNoX1 sp a b
+          x9In raVal v2 v5 v6 v7 v10 v11
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0 ** FPre)
+        (divStackDispatchPostCallableExactFrame sp a b raVal x9Out ** FPost)) :
+    cpsTripleWithin (unifiedDivBound + 1) base (raVal &&& ~~~1)
+      (evm_div_callable_code_v4 base)
+      (divModStackDispatchPreNoX1 sp a b
+        x9In raVal v2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 ** FPre)
+      (divStackDispatchPostCallableExactFrame sp a b raVal x9Out ** FPost) := by
+  rw [divStackDispatchPostCallableExactFrame_unfold] at hStack ⊢
+  exact evm_div_callable_v4_spec_from_divCode_noNop_preserving_x1_x9out_body_frame_transform
+    sp base x9In x9Out raVal a b v2 v5 v6 v7 v10 v11
+    q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 hStack
 
 theorem evm_div_callable_v4_spec_from_noNop_branch_return_x1 (sp base : Word)
     (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
@@ -791,5 +850,131 @@ theorem evm_div_callable_v4_spec_from_noNop_branch_return_x1_framed
         sp base a b v5 v6 v7 v10 v11
         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
         nMem shiftMem jMem retMem dMem dloMem scratchUn0 branch hStack)
+
+/-- Callable-program N3 v4 DIV surface from the no-NOP stack bridge, with the
+    v4 trial-call scratch cell framed through the callable return. -/
+theorem evm_div_callable_v4_n3_stack_pre_to_callable_post_scratch_word
+    (sp base : Word) (a b : EvmWord)
+    (v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (hbnz : b ≠ 0)
+    (hb3z : b.getLimbN 3 = 0) (hb2nz : b.getLimbN 2 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 2)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_1 : bltu_1 =
+      BitVec.ult (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+        (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).2.2.1)
+    (hbltu_0 : bltu_0 =
+      match bltu_1, hbltu_1 with
+      | false, _ =>
+        BitVec.ult
+          (iterN3Max
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+            (0 : Word)).2.2.2.1
+          (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+            (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+      | true, _ =>
+        BitVec.ult
+          (iterWithDoubleAddback
+            (divKTrialCallV4QHat
+              (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+                (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+              (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+                (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.1
+              (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+                (b.getLimbN 2) (b.getLimbN 3)).2.2.1)
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+            (0 : Word)).2.2.2.1
+          (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+            (b.getLimbN 2) (b.getLimbN 3)).2.2.1)
+    (hcarry2 : Carry2NzAll
+      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1
+      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.1
+      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2)
+    (hdivWord : fullDivN3QuotientWordV4 bltu_1 bltu_0
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) =
+        EvmWord.div a b) :
+    cpsTripleWithin (unifiedDivBound + 1) base (raVal &&& ~~~1)
+      (evm_div_callable_code_v4 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult (b.getLimbN 2)).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divStackDispatchPostCallableExactFrame sp a b raVal
+        (signExtend12 4095 : Word) **
+       ((sp + signExtend12 3936) ↦ₘ
+        fullDivN3ScratchMemV4 bltu_1 bltu_0
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+          scratchMem)) := by
+  obtain ⟨hdiv0, hdiv1, hdiv2, hdiv3⟩ :=
+    fullDivN3V4_hdivs_of_word_eq bltu_1 bltu_0 a b
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+      hdivWord
+  have hBody :=
+    evm_div_n3_stack_pre_to_callable_post_v4_scratch_noNop
+      sp base a b v5 v6 v7 v10 v11Old
+      q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+      nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+      hbnz hb3z hb2nz hshift_nz halign hbltu_1 hbltu_0 hcarry2
+      hdiv0 hdiv1 hdiv2 hdiv3
+  have hBodyUnified :=
+    evm_div_n3_stack_pre_to_callable_post_v4_scratch_noNop_bound_unified
+      (base := base) hBody
+  exact
+    evm_div_callable_v4_spec_from_divCode_noNop_exact_frame_x9out_body_frame_transform
+      (FPre := ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (FPost := ((sp + signExtend12 3936) ↦ₘ
+        fullDivN3ScratchMemV4 bltu_1 bltu_0
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+          scratchMem))
+      sp base (signExtend12 (4 : BitVec 12) - (4 : Word))
+      (signExtend12 4095 : Word) raVal a b
+      ((clzResult (b.getLimbN 2)).2 >>> (63 : Nat))
+      v5 v6 v7 v10 v11Old
+      q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+      nMem shiftMem jMem retMem dMem dloMem scratchUn0 hBodyUnified
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/CallableV4Div.lean
+++ b/EvmAsm/Evm64/DivMod/CallableV4Div.lean
@@ -944,18 +944,18 @@ theorem evm_div_callable_v4_n3_stack_pre_to_callable_post_scratch_word
           (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
           (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
           scratchMem)) := by
-  obtain ⟨hdiv0, hdiv1, hdiv2, hdiv3⟩ :=
-    fullDivN3V4_hdivs_of_word_eq bltu_1 bltu_0 a b
-      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
-      hdivWord
   have hBody :=
-    evm_div_n3_stack_pre_to_callable_post_v4_scratch_noNop
-      sp base a b v5 v6 v7 v10 v11Old
-      q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
-      nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
-      hbnz hb3z hb2nz hshift_nz halign hbltu_1 hbltu_0 hcarry2
-      hdiv0 hdiv1 hdiv2 hdiv3
+    cpsTripleWithin_weaken
+      (fun _ hp => hp)
+      (fun h hq =>
+        fullDivN3UnifiedPostNoX1V4_frame_to_divStackDispatchPostCallableExactFrame_scratch_word
+          bltu_1 bltu_0 sp base a b
+          retMem dMem dloMem scratchUn0 scratchMem raVal hdivWord h hq)
+      (evm_div_n3_stack_pre_to_unified_post_v4_noNop
+        sp base a b v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+        hbnz hb3z hb2nz hshift_nz halign hbltu_1 hbltu_0 hcarry2)
   have hBodyUnified :=
     evm_div_n3_stack_pre_to_callable_post_v4_scratch_noNop_bound_unified
       (base := base) hBody

--- a/EvmAsm/Evm64/DivMod/CallableV4Div.lean
+++ b/EvmAsm/Evm64/DivMod/CallableV4Div.lean
@@ -990,64 +990,12 @@ theorem evm_div_callable_v4_n3_stack_pre_to_callable_post_scratch_of_mulsub_over
     (hshift_nz : (clzResult (b.getLimbN 2)).1 ≠ 0)
     (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
       base + div128CallRetOff)
-    (hbltu_1 : bltu_1 =
-      BitVec.ult (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
-          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
-        (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
-          (b.getLimbN 2) (b.getLimbN 3)).2.2.1)
-    (hbltu_0 : bltu_0 =
-      match bltu_1, hbltu_1 with
-      | false, _ =>
-        BitVec.ult
-          (iterN3Max
-            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
-              (b.getLimbN 2) (b.getLimbN 3)).1
-            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
-              (b.getLimbN 2) (b.getLimbN 3)).2.1
-            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
-              (b.getLimbN 2) (b.getLimbN 3)).2.2.1
-            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
-              (b.getLimbN 2) (b.getLimbN 3)).2.2.2
-            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
-              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.1
-            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
-              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.1
-            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
-              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.1
-            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
-              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
-            (0 : Word)).2.2.2.1
-          (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
-            (b.getLimbN 2) (b.getLimbN 3)).2.2.1
-      | true, _ =>
-        BitVec.ult
-          (iterWithDoubleAddback
-            (divKTrialCallV4QHat
-              (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
-                (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
-              (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
-                (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.1
-              (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
-                (b.getLimbN 2) (b.getLimbN 3)).2.2.1)
-            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
-              (b.getLimbN 2) (b.getLimbN 3)).1
-            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
-              (b.getLimbN 2) (b.getLimbN 3)).2.1
-            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
-              (b.getLimbN 2) (b.getLimbN 3)).2.2.1
-            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
-              (b.getLimbN 2) (b.getLimbN 3)).2.2.2
-            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
-              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.1
-            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
-              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.1
-            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
-              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.1
-            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
-              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
-            (0 : Word)).2.2.2.1
-          (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
-            (b.getLimbN 2) (b.getLimbN 3)).2.2.1)
+    (hbltu_1 : isTrialN3V4_j1 bltu_1
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3))
+    (hbltu_0 : isTrialN3V4_j0 bltu_1 bltu_0
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3))
     (hcarry2 : Carry2NzAll
       (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1
       (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.1
@@ -1089,6 +1037,8 @@ theorem evm_div_callable_v4_n3_stack_pre_to_callable_post_scratch_of_mulsub_over
     sp base a b v5 v6 v7 v10 v11Old
     q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
-    hbnz hb3z hb2nz hshift_nz halign hbltu_1 hbltu_0 hcarry2 hdivWord
+    hbnz hb3z hb2nz hshift_nz halign hbltu_1
+    (by cases bltu_1 <;> simpa [isTrialN3V4_j0] using hbltu_0)
+    hcarry2 hdivWord
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/CallableV4Div.lean
+++ b/EvmAsm/Evm64/DivMod/CallableV4Div.lean
@@ -987,18 +987,7 @@ theorem evm_div_callable_v4_n3_stack_pre_to_callable_post_scratch_of_mulsub_over
     (hshift_nz : (clzResult (b.getLimbN 2)).1 ≠ 0)
     (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
       base + div128CallRetOff)
-    (hbltu_1 : isTrialN3V4_j1 bltu_1
-      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3))
-    (hbltu_0 : isTrialN3V4_j0 bltu_1 bltu_0
-      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3))
-    (hcarry2 : fullDivN3Carry2NzV4
-      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3))
-    (hmulsub : fullDivN3MulSubEqV4 bltu_1 bltu_0
-      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3))
-    (hge : fullDivN3QuotientOverestimateV4 bltu_1 bltu_0
+    (hpath : fullDivN3PathConditionsV4 bltu_1 bltu_0
       (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
       (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)) :
     cpsTripleWithin (unifiedDivBound + 1) base (raVal &&& ~~~1)
@@ -1017,6 +1006,7 @@ theorem evm_div_callable_v4_n3_stack_pre_to_callable_post_scratch_of_mulsub_over
           (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
           (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
           scratchMem)) := by
+  obtain ⟨hbltu_1, hbltu_0, hcarry2, hmulsub, hge⟩ := hpath
   have hbnz' : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 ≠ 0 :=
     (EvmWord.ne_zero_iff_getLimbN_or).mp hbnz
   have hdivWord :=

--- a/EvmAsm/Evm64/DivMod/CallableV4Div.lean
+++ b/EvmAsm/Evm64/DivMod/CallableV4Div.lean
@@ -1006,17 +1006,18 @@ theorem evm_div_callable_v4_n3_stack_pre_to_callable_post_scratch_of_mulsub_over
           (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
           (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
           scratchMem)) := by
-  obtain ⟨hbltu_1, hbltu_0, hcarry2, hmulsub, hge⟩ := hpath
+  have hpath' := hpath
+  obtain ⟨hbltu_1, hbltu_0, hcarry2, _, _⟩ := hpath'
   have hbnz' : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 ≠ 0 :=
     (EvmWord.ne_zero_iff_getLimbN_or).mp hbnz
   have hdivWord :=
-    fullDivN3QuotientWordV4_eq_div_of_limbs_mulsub_overestimate
+    fullDivN3QuotientWordV4_eq_div_of_path_conditions
       bltu_1 bltu_0 (a := a) (b := b)
       (a0 := a.getLimbN 0) (a1 := a.getLimbN 1)
       (a2 := a.getLimbN 2) (a3 := a.getLimbN 3)
       (b0 := b.getLimbN 0) (b1 := b.getLimbN 1)
       (b2 := b.getLimbN 2) (b3 := b.getLimbN 3)
-      rfl rfl rfl rfl rfl rfl rfl rfl hbnz' hmulsub hge
+      rfl rfl rfl rfl rfl rfl rfl rfl hbnz' hpath
   exact evm_div_callable_v4_n3_stack_pre_to_callable_post_scratch_word
     sp base a b v5 v6 v7 v10 v11Old
     q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7

--- a/EvmAsm/Evm64/DivMod/CallableV4Div.lean
+++ b/EvmAsm/Evm64/DivMod/CallableV4Div.lean
@@ -987,9 +987,7 @@ theorem evm_div_callable_v4_n3_stack_pre_to_callable_post_scratch_of_mulsub_over
     (hshift_nz : (clzResult (b.getLimbN 2)).1 ≠ 0)
     (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
       base + div128CallRetOff)
-    (hpath : fullDivN3PathConditionsV4 bltu_1 bltu_0
-      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)) :
+    (hpath : fullDivN3PathConditionsWordV4 bltu_1 bltu_0 a b) :
     cpsTripleWithin (unifiedDivBound + 1) base (raVal &&& ~~~1)
       (evm_div_callable_code_v4 base)
       (divModStackDispatchPreNoX1 sp a b
@@ -1011,13 +1009,8 @@ theorem evm_div_callable_v4_n3_stack_pre_to_callable_post_scratch_of_mulsub_over
   have hbnz' : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 ≠ 0 :=
     (EvmWord.ne_zero_iff_getLimbN_or).mp hbnz
   have hdivWord :=
-    fullDivN3QuotientWordV4_eq_div_of_path_conditions
-      bltu_1 bltu_0 (a := a) (b := b)
-      (a0 := a.getLimbN 0) (a1 := a.getLimbN 1)
-      (a2 := a.getLimbN 2) (a3 := a.getLimbN 3)
-      (b0 := b.getLimbN 0) (b1 := b.getLimbN 1)
-      (b2 := b.getLimbN 2) (b3 := b.getLimbN 3)
-      rfl rfl rfl rfl rfl rfl rfl rfl hbnz' hpath
+    fullDivN3QuotientWordV4_eq_div_of_word_path_conditions
+      bltu_1 bltu_0 a b hbnz' hpath
   exact evm_div_callable_v4_n3_stack_pre_to_callable_post_scratch_word
     sp base a b v5 v6 v7 v10 v11Old
     q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7

--- a/EvmAsm/Evm64/DivMod/CallableV4Div.lean
+++ b/EvmAsm/Evm64/DivMod/CallableV4Div.lean
@@ -977,4 +977,118 @@ theorem evm_div_callable_v4_n3_stack_pre_to_callable_post_scratch_word
       q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
       nMem shiftMem jMem retMem dMem dloMem scratchUn0 hBodyUnified
 
+/-- Arithmetic-assumption version of
+    `evm_div_callable_v4_n3_stack_pre_to_callable_post_scratch_word`. -/
+theorem evm_div_callable_v4_n3_stack_pre_to_callable_post_scratch_of_mulsub_overestimate
+    (sp base : Word) (a b : EvmWord)
+    (v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (hbnz : b ≠ 0)
+    (hb3z : b.getLimbN 3 = 0) (hb2nz : b.getLimbN 2 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 2)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_1 : bltu_1 =
+      BitVec.ult (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+        (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).2.2.1)
+    (hbltu_0 : bltu_0 =
+      match bltu_1, hbltu_1 with
+      | false, _ =>
+        BitVec.ult
+          (iterN3Max
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+            (0 : Word)).2.2.2.1
+          (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+            (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+      | true, _ =>
+        BitVec.ult
+          (iterWithDoubleAddback
+            (divKTrialCallV4QHat
+              (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+                (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+              (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+                (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.1
+              (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+                (b.getLimbN 2) (b.getLimbN 3)).2.2.1)
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+            (0 : Word)).2.2.2.1
+          (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+            (b.getLimbN 2) (b.getLimbN 3)).2.2.1)
+    (hcarry2 : Carry2NzAll
+      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1
+      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.1
+      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2)
+    (hmulsub : fullDivN3MulSubEqV4 bltu_1 bltu_0
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3))
+    (hge : fullDivN3QuotientOverestimateV4 bltu_1 bltu_0
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)) :
+    cpsTripleWithin (unifiedDivBound + 1) base (raVal &&& ~~~1)
+      (evm_div_callable_code_v4 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult (b.getLimbN 2)).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divStackDispatchPostCallableExactFrame sp a b raVal
+        (signExtend12 4095 : Word) **
+       ((sp + signExtend12 3936) ↦ₘ
+        fullDivN3ScratchMemV4 bltu_1 bltu_0
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+          scratchMem)) := by
+  have hbnz' : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 ≠ 0 :=
+    (EvmWord.ne_zero_iff_getLimbN_or).mp hbnz
+  have hdivWord :=
+    fullDivN3QuotientWordV4_eq_div_of_limbs_mulsub_overestimate
+      bltu_1 bltu_0 (a := a) (b := b)
+      (a0 := a.getLimbN 0) (a1 := a.getLimbN 1)
+      (a2 := a.getLimbN 2) (a3 := a.getLimbN 3)
+      (b0 := b.getLimbN 0) (b1 := b.getLimbN 1)
+      (b2 := b.getLimbN 2) (b3 := b.getLimbN 3)
+      rfl rfl rfl rfl rfl rfl rfl rfl hbnz' hmulsub hge
+  exact evm_div_callable_v4_n3_stack_pre_to_callable_post_scratch_word
+    sp base a b v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+    hbnz hb3z hb2nz hshift_nz halign hbltu_1 hbltu_0 hcarry2 hdivWord
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/CallableV4Mod.lean
+++ b/EvmAsm/Evm64/DivMod/CallableV4Mod.lean
@@ -159,6 +159,27 @@ theorem sharedDivModCodeNoNop_v4_sub_mod_callable_code_v4 {base : Word} :
     (CodeReq.union_split_mono callable_b13_mod_v4
     (fun _ _ h => by simp [CodeReq.unionAll_nil, CodeReq.empty] at h))))))))))))
 
+/-- `modCode_noNop_v4 ⊆ evm_mod_callable_code_v4`: the callable MOD code is
+    the no-NOP MOD body plus the return slot. -/
+theorem modCode_noNop_v4_sub_mod_callable_code_v4 {base : Word} :
+    ∀ a i, (modCode_noNop_v4 base) a = some i →
+           (evm_mod_callable_code_v4 base) a = some i := by
+  unfold modCode_noNop_v4; simp only [CodeReq.unionAll_cons]
+  exact CodeReq.union_split_mono callable_b0_mod_v4
+    (CodeReq.union_split_mono callable_b1_mod_v4
+    (CodeReq.union_split_mono callable_b2_mod_v4
+    (CodeReq.union_split_mono callable_b3_mod_v4
+    (CodeReq.union_split_mono callable_b4_mod_v4
+    (CodeReq.union_split_mono callable_b5_mod_v4
+    (CodeReq.union_split_mono callable_b6_mod_v4
+    (CodeReq.union_split_mono callable_b7_mod_v4
+    (CodeReq.union_split_mono callable_b8_mod_v4
+    (CodeReq.union_split_mono callable_b9_mod_v4
+    (CodeReq.union_split_mono callable_b10_mod_v4
+    (CodeReq.union_split_mono callable_b11_mod_v4
+    (CodeReq.union_split_mono callable_b13_mod_v4
+    (fun _ _ h => by simp [CodeReq.unionAll_nil, CodeReq.empty] at h)))))))))))))
+
 theorem evm_mod_callable_v4_spec_from_noNop_preserving_x1 (sp base raVal : Word)
     (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
@@ -275,6 +296,85 @@ theorem evm_mod_callable_bzero_v4_preserving_x1_noX9_spec (sp base raVal : Word)
         sp base a b raVal v2 v5 v6 v7 v10 v11
         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
         nMem shiftMem jMem retMem dMem dloMem scratchUn0 hbz)
+
+/-- v4 callable MOD wrapper for `modCode_noNop_v4` body proofs that transform
+    an explicit PC-free frame and return a possibly different exact `x9`
+    value. -/
+theorem evm_mod_callable_v4_spec_from_modCode_noNop_preserving_x1_x9out_body_frame_transform
+    {FPre FPost : Assertion} [Assertion.PCFree FPost]
+    (sp base x9In x9Out raVal : Word) (a b : EvmWord)
+    (v2 v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (hStack :
+      cpsTripleWithin unifiedDivBound base (base + nopOff) (modCode_noNop_v4 base)
+        (divModStackDispatchPreNoX1 sp a b
+          x9In raVal v2 v5 v6 v7 v10 v11
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0 ** FPre)
+        (((modStackDispatchPostCallable sp a b ** (.x1 ↦ᵣ raVal)) **
+          (.x9 ↦ᵣ x9Out)) ** FPost)) :
+    cpsTripleWithin (unifiedDivBound + 1) base (raVal &&& ~~~1)
+      (evm_mod_callable_code_v4 base)
+      (divModStackDispatchPreNoX1 sp a b
+        x9In raVal v2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 ** FPre)
+      (((modStackDispatchPostCallable sp a b ** (.x1 ↦ᵣ raVal)) **
+        (.x9 ↦ᵣ x9Out)) ** FPost) := by
+  have hStackCall :=
+    cpsTripleWithin_extend_code
+      (hmono := modCode_noNop_v4_sub_mod_callable_code_v4) hStack
+  have hStackForRet :
+      cpsTripleWithin unifiedDivBound base (base + nopOff) (evm_mod_callable_code_v4 base)
+        (divModStackDispatchPreNoX1 sp a b
+          x9In raVal v2 v5 v6 v7 v10 v11
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0 ** FPre)
+        (((modStackDispatchPostCallable sp a b ** (.x9 ↦ᵣ x9Out)) ** FPost) **
+          (.x1 ↦ᵣ raVal)) :=
+    cpsTripleWithin_weaken (fun _ hp => hp) (fun _ hp => by xperm_hyp hp) hStackCall
+  have hRet :=
+    cpsTripleWithin_extend_code (hmono := evm_mod_callable_code_v4_ret_sub (base := base))
+      (ret_spec_within' (base + nopOff) raVal)
+  have hRetFramed :=
+    cpsTripleWithin_frameL ((modStackDispatchPostCallable sp a b ** (.x9 ↦ᵣ x9Out)) ** FPost)
+      (by
+        rw [modStackDispatchPostCallable_unfold, divScratchOwnCallNoX1_unfold,
+          divScratchOwn_unfold]
+        pcFree)
+      hRet
+  exact cpsTripleWithin_weaken (fun _ hp => hp) (fun _ hp => by xperm_hyp hp)
+    (cpsTripleWithin_seq_same_cr hStackForRet hRetFramed)
+
+/-- Named-post variant of the v4 callable MOD wrapper for `modCode_noNop_v4`
+    body proofs that transform an explicit PC-free frame and return a possibly
+    different exact `x9` value. -/
+theorem evm_mod_callable_v4_spec_from_modCode_noNop_exact_frame_x9out_body_frame_transform
+    {FPre FPost : Assertion} [Assertion.PCFree FPost]
+    (sp base x9In x9Out raVal : Word) (a b : EvmWord)
+    (v2 v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (hStack :
+      cpsTripleWithin unifiedDivBound base (base + nopOff) (modCode_noNop_v4 base)
+        (divModStackDispatchPreNoX1 sp a b
+          x9In raVal v2 v5 v6 v7 v10 v11
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0 ** FPre)
+        (modStackDispatchPostCallableExactFrame sp a b raVal x9Out ** FPost)) :
+    cpsTripleWithin (unifiedDivBound + 1) base (raVal &&& ~~~1)
+      (evm_mod_callable_code_v4 base)
+      (divModStackDispatchPreNoX1 sp a b
+        x9In raVal v2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 ** FPre)
+      (modStackDispatchPostCallableExactFrame sp a b raVal x9Out ** FPost) := by
+  rw [modStackDispatchPostCallableExactFrame_unfold] at hStack ⊢
+  exact evm_mod_callable_v4_spec_from_modCode_noNop_preserving_x1_x9out_body_frame_transform
+    sp base x9In x9Out raVal a b v2 v5 v6 v7 v10 v11
+    q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 hStack
 
 theorem evm_mod_callable_v4_spec_from_noNop (sp base raVal : Word)
     (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)

--- a/EvmAsm/Evm64/DivMod/CallableV4Mod.lean
+++ b/EvmAsm/Evm64/DivMod/CallableV4Mod.lean
@@ -675,6 +675,47 @@ theorem evm_mod_callable_v4_n3_stack_pre_to_callable_post_scratch_of_normalized_
     hbnz hb3z hb2nz hshift_nz halign
     (fullModN3PathConditionsScaledV4_of_normalized bltu_1 bltu_0 a b hpath)
 
+/-- Callable-program N3 v4 MOD surface from the remaining normalized mulsub
+equation. The normalized remainder bound follows from the existing N3 DIV path
+overestimate, so this wrapper leaves only the loop conservation equation as
+the explicit MOD arithmetic obligation. -/
+theorem evm_mod_callable_v4_n3_stack_pre_to_callable_post_scratch_of_normalized_mulsub
+    (sp base : Word) (a b : EvmWord)
+    (v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (hbnz : b ≠ 0)
+    (hb3z : b.getLimbN 3 = 0) (hb2nz : b.getLimbN 2 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 2)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hdivPath : fullDivN3PathConditionsWordV4 bltu_1 bltu_0 a b)
+    (hmulsub : fullDivN3NormalizedMulSubEqV4 bltu_1 bltu_0 a b) :
+    cpsTripleWithin (unifiedDivBound + 1) base (raVal &&& ~~~1)
+      (evm_mod_callable_code_v4 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult (b.getLimbN 2)).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (modStackDispatchPostCallableExactFrame sp a b raVal
+        (signExtend12 4095 : Word) **
+       ((sp + signExtend12 3936) ↦ₘ
+        fullDivN3ScratchMemV4 bltu_1 bltu_0
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+          scratchMem)) := by
+  exact evm_mod_callable_v4_n3_stack_pre_to_callable_post_scratch_of_normalized_path_conditions
+    sp base a b v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+    hbnz hb3z hb2nz hshift_nz halign
+    (fullModN3PathConditionsNormalizedV4_of_mulsub
+      bltu_1 bltu_0 a b hbnz hdivPath hmulsub)
+
 theorem evm_mod_callable_v4_spec_from_noNop (sp base raVal : Word)
     (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7

--- a/EvmAsm/Evm64/DivMod/CallableV4Mod.lean
+++ b/EvmAsm/Evm64/DivMod/CallableV4Mod.lean
@@ -1,4 +1,5 @@
 import EvmAsm.Evm64.DivMod.Callable
+import EvmAsm.Evm64.DivMod.Spec.N3V4StackPre
 
 namespace EvmAsm.Evm64
 
@@ -375,6 +376,143 @@ theorem evm_mod_callable_v4_spec_from_modCode_noNop_exact_frame_x9out_body_frame
     sp base x9In x9Out raVal a b v2 v5 v6 v7 v10 v11
     q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
     nMem shiftMem jMem retMem dMem dloMem scratchUn0 hStack
+
+/-- Callable-program N3 v4 MOD surface from the no-NOP stack bridge, with the
+    v4 trial-call scratch cell framed through the callable return. -/
+theorem evm_mod_callable_v4_n3_stack_pre_to_callable_post_scratch_word
+    (sp base : Word) (a b : EvmWord)
+    (v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (hbnz : b ≠ 0)
+    (hb3z : b.getLimbN 3 = 0) (hb2nz : b.getLimbN 2 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 2)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_1 : bltu_1 =
+      BitVec.ult (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+        (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).2.2.1)
+    (hbltu_0 : bltu_0 =
+      match bltu_1, hbltu_1 with
+      | false, _ =>
+        BitVec.ult
+          (iterN3Max
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+            (0 : Word)).2.2.2.1
+          (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+            (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+      | true, _ =>
+        BitVec.ult
+          (iterWithDoubleAddback
+            (divKTrialCallV4QHat
+              (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+                (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+              (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+                (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.1
+              (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+                (b.getLimbN 2) (b.getLimbN 3)).2.2.1)
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+            (0 : Word)).2.2.2.1
+          (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+            (b.getLimbN 2) (b.getLimbN 3)).2.2.1)
+    (hcarry2 : fullDivN3Carry2NzV4
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3))
+    (hmodWord : fullModN3RemainderWordV4 bltu_1 bltu_0
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) =
+        EvmWord.mod a b) :
+    cpsTripleWithin (unifiedDivBound + 1) base (raVal &&& ~~~1)
+      (evm_mod_callable_code_v4 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult (b.getLimbN 2)).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (modStackDispatchPostCallableExactFrame sp a b raVal
+        (signExtend12 4095 : Word) **
+       ((sp + signExtend12 3936) ↦ₘ
+        fullDivN3ScratchMemV4 bltu_1 bltu_0
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+          scratchMem)) := by
+  have hBody :=
+    cpsTripleWithin_weaken
+      (fun _ hp => hp)
+      (fun h hq =>
+        fullModN3UnifiedPostNoX1V4_frame_to_modStackDispatchPostCallableExactFrame_scratch_word
+          bltu_1 bltu_0 sp base a b
+          retMem dMem dloMem scratchUn0 scratchMem raVal hmodWord h hq)
+      (evm_mod_n3_stack_pre_to_unified_post_v4_noNop
+        sp base a b v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+        hbnz hb3z hb2nz hshift_nz halign hbltu_1 hbltu_0 hcarry2)
+  have hBodyUnified :
+      cpsTripleWithin unifiedDivBound base (base + nopOff) (modCode_noNop_v4 base)
+        (divModStackDispatchPreNoX1 sp a b
+          (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+          ((clzResult (b.getLimbN 2)).2 >>> (63 : Nat))
+          v5 v6 v7 v10 v11Old
+          q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+         ((sp + signExtend12 3936) ↦ₘ scratchMem))
+        (modStackDispatchPostCallableExactFrame sp a b raVal
+          (signExtend12 4095 : Word) **
+         ((sp + signExtend12 3936) ↦ₘ
+          fullDivN3ScratchMemV4 bltu_1 bltu_0
+            (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+            (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+            scratchMem)) :=
+    cpsTripleWithin_mono_nSteps (by unfold unifiedDivBound; decide) hBody
+  exact
+    evm_mod_callable_v4_spec_from_modCode_noNop_exact_frame_x9out_body_frame_transform
+      (FPre := ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (FPost := ((sp + signExtend12 3936) ↦ₘ
+        fullDivN3ScratchMemV4 bltu_1 bltu_0
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+          scratchMem))
+      sp base (signExtend12 (4 : BitVec 12) - (4 : Word))
+      (signExtend12 4095 : Word) raVal a b
+      ((clzResult (b.getLimbN 2)).2 >>> (63 : Nat))
+      v5 v6 v7 v10 v11Old
+      q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+      nMem shiftMem jMem retMem dMem dloMem scratchUn0 hBodyUnified
 
 theorem evm_mod_callable_v4_spec_from_noNop (sp base raVal : Word)
     (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)

--- a/EvmAsm/Evm64/DivMod/CallableV4Mod.lean
+++ b/EvmAsm/Evm64/DivMod/CallableV4Mod.lean
@@ -757,6 +757,47 @@ theorem evm_mod_callable_v4_n3_stack_pre_to_callable_post_scratch_of_normalized_
     (fullDivN3NormalizedMulSubEqV4_of_conservation
       bltu_1 bltu_0 a b hcons hcarry_zero)
 
+/-- Callable-program N3 v4 MOD surface from raw normalized conservation. The
+final overflow-carry-zero fact follows from the N3 quotient overestimate and
+the `b3 = 0` branch invariant, so this wrapper leaves only raw conservation
+as the MOD arithmetic obligation. -/
+theorem evm_mod_callable_v4_n3_stack_pre_to_callable_post_scratch_of_conservation_path
+    (sp base : Word) (a b : EvmWord)
+    (v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (hbnz : b ≠ 0)
+    (hb3z : b.getLimbN 3 = 0) (hb2nz : b.getLimbN 2 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 2)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hdivPath : fullDivN3PathConditionsWordV4 bltu_1 bltu_0 a b)
+    (hcons : fullDivN3NormalizedConservationV4 bltu_1 bltu_0 a b) :
+    cpsTripleWithin (unifiedDivBound + 1) base (raVal &&& ~~~1)
+      (evm_mod_callable_code_v4 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult (b.getLimbN 2)).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (modStackDispatchPostCallableExactFrame sp a b raVal
+        (signExtend12 4095 : Word) **
+       ((sp + signExtend12 3936) ↦ₘ
+        fullDivN3ScratchMemV4 bltu_1 bltu_0
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+          scratchMem)) := by
+  exact evm_mod_callable_v4_n3_stack_pre_to_callable_post_scratch_of_normalized_path_conditions
+    sp base a b v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+    hbnz hb3z hb2nz hshift_nz halign
+    (fullModN3PathConditionsNormalizedV4_of_conservation
+      bltu_1 bltu_0 a b hbnz hb3z hdivPath hcons)
+
 theorem evm_mod_callable_v4_spec_from_noNop (sp base raVal : Word)
     (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7

--- a/EvmAsm/Evm64/DivMod/CallableV4Mod.lean
+++ b/EvmAsm/Evm64/DivMod/CallableV4Mod.lean
@@ -595,6 +595,47 @@ theorem evm_mod_callable_v4_n3_stack_pre_to_callable_post_scratch_of_val256_path
     hbnz hb3z hb2nz hshift_nz halign
     (fullModN3PathConditionsWordV4_of_val256 bltu_1 bltu_0 a b hbnz' hpath)
 
+/-- Callable-program N3 v4 MOD surface from the normalized scaled-remainder
+path predicate. This is the closest caller-facing wrapper to the remaining
+loop arithmetic obligation. -/
+theorem evm_mod_callable_v4_n3_stack_pre_to_callable_post_scratch_of_scaled_path_conditions
+    (sp base : Word) (a b : EvmWord)
+    (v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (hbnz : b ≠ 0)
+    (hb3z : b.getLimbN 3 = 0) (hb2nz : b.getLimbN 2 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 2)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hpath : fullModN3PathConditionsScaledV4 bltu_1 bltu_0 a b) :
+    cpsTripleWithin (unifiedDivBound + 1) base (raVal &&& ~~~1)
+      (evm_mod_callable_code_v4 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult (b.getLimbN 2)).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (modStackDispatchPostCallableExactFrame sp a b raVal
+        (signExtend12 4095 : Word) **
+       ((sp + signExtend12 3936) ↦ₘ
+        fullDivN3ScratchMemV4 bltu_1 bltu_0
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+          scratchMem)) := by
+  have hshift_nz' : fullDivN3Shift (b.getLimbN 2) ≠ 0 := by
+    rw [fullDivN3Shift]
+    exact hshift_nz
+  exact evm_mod_callable_v4_n3_stack_pre_to_callable_post_scratch_of_val256_path_conditions
+    sp base a b v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+    hbnz hb3z hb2nz hshift_nz halign
+    (fullModN3PathConditionsVal256V4_of_scaled bltu_1 bltu_0 a b hshift_nz' hpath)
+
 theorem evm_mod_callable_v4_spec_from_noNop (sp base raVal : Word)
     (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7

--- a/EvmAsm/Evm64/DivMod/CallableV4Mod.lean
+++ b/EvmAsm/Evm64/DivMod/CallableV4Mod.lean
@@ -716,6 +716,47 @@ theorem evm_mod_callable_v4_n3_stack_pre_to_callable_post_scratch_of_normalized_
     (fullModN3PathConditionsNormalizedV4_of_mulsub
       bltu_1 bltu_0 a b hbnz hdivPath hmulsub)
 
+/-- Callable-program N3 v4 MOD surface from raw normalized conservation plus
+the final overflow-carry-zero fact. The conservation equation is the direct
+shape produced by chaining the two `iterWithDoubleAddback` conservation lemmas. -/
+theorem evm_mod_callable_v4_n3_stack_pre_to_callable_post_scratch_of_normalized_conservation
+    (sp base : Word) (a b : EvmWord)
+    (v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (hbnz : b ≠ 0)
+    (hb3z : b.getLimbN 3 = 0) (hb2nz : b.getLimbN 2 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 2)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hdivPath : fullDivN3PathConditionsWordV4 bltu_1 bltu_0 a b)
+    (hcons : fullDivN3NormalizedConservationV4 bltu_1 bltu_0 a b)
+    (hcarry_zero : fullDivN3FinalCarryZeroV4 bltu_1 bltu_0 a b) :
+    cpsTripleWithin (unifiedDivBound + 1) base (raVal &&& ~~~1)
+      (evm_mod_callable_code_v4 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult (b.getLimbN 2)).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (modStackDispatchPostCallableExactFrame sp a b raVal
+        (signExtend12 4095 : Word) **
+       ((sp + signExtend12 3936) ↦ₘ
+        fullDivN3ScratchMemV4 bltu_1 bltu_0
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+          scratchMem)) := by
+  exact evm_mod_callable_v4_n3_stack_pre_to_callable_post_scratch_of_normalized_mulsub
+    sp base a b v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+    hbnz hb3z hb2nz hshift_nz halign hdivPath
+    (fullDivN3NormalizedMulSubEqV4_of_conservation
+      bltu_1 bltu_0 a b hcons hcarry_zero)
+
 theorem evm_mod_callable_v4_spec_from_noNop (sp base raVal : Word)
     (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7

--- a/EvmAsm/Evm64/DivMod/CallableV4Mod.lean
+++ b/EvmAsm/Evm64/DivMod/CallableV4Mod.lean
@@ -514,6 +514,45 @@ theorem evm_mod_callable_v4_n3_stack_pre_to_callable_post_scratch_word
       q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
       nMem shiftMem jMem retMem dMem dloMem scratchUn0 hBodyUnified
 
+/-- Callable-program N3 v4 MOD surface from the bundled MOD path predicate. -/
+theorem evm_mod_callable_v4_n3_stack_pre_to_callable_post_scratch_of_mod_path_conditions
+    (sp base : Word) (a b : EvmWord)
+    (v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (hbnz : b ≠ 0)
+    (hb3z : b.getLimbN 3 = 0) (hb2nz : b.getLimbN 2 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 2)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hpath : fullModN3PathConditionsWordV4 bltu_1 bltu_0 a b) :
+    cpsTripleWithin (unifiedDivBound + 1) base (raVal &&& ~~~1)
+      (evm_mod_callable_code_v4 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult (b.getLimbN 2)).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (modStackDispatchPostCallableExactFrame sp a b raVal
+        (signExtend12 4095 : Word) **
+       ((sp + signExtend12 3936) ↦ₘ
+        fullDivN3ScratchMemV4 bltu_1 bltu_0
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+          scratchMem)) := by
+  obtain ⟨hdivPath, hmodWord⟩ := hpath
+  obtain ⟨hbltu_1, hbltu_0, hcarry2, _, _⟩ := hdivPath
+  exact evm_mod_callable_v4_n3_stack_pre_to_callable_post_scratch_word
+    sp base a b v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+    hbnz hb3z hb2nz hshift_nz halign hbltu_1
+    (by cases bltu_1 <;> simpa [isTrialN3V4_j0] using hbltu_0)
+    hcarry2 hmodWord
+
 theorem evm_mod_callable_v4_spec_from_noNop (sp base raVal : Word)
     (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7

--- a/EvmAsm/Evm64/DivMod/CallableV4Mod.lean
+++ b/EvmAsm/Evm64/DivMod/CallableV4Mod.lean
@@ -553,6 +553,48 @@ theorem evm_mod_callable_v4_n3_stack_pre_to_callable_post_scratch_of_mod_path_co
     (by cases bltu_1 <;> simpa [isTrialN3V4_j0] using hbltu_0)
     hcarry2 hmodWord
 
+/-- Callable-program N3 v4 MOD surface from the bundled `val256` MOD path
+predicate. This is equivalent to
+`evm_mod_callable_v4_n3_stack_pre_to_callable_post_scratch_of_mod_path_conditions`,
+but exposes the remaining MOD proof obligation in the arithmetic form expected
+from the normalized-remainder closure. -/
+theorem evm_mod_callable_v4_n3_stack_pre_to_callable_post_scratch_of_val256_path_conditions
+    (sp base : Word) (a b : EvmWord)
+    (v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (hbnz : b ≠ 0)
+    (hb3z : b.getLimbN 3 = 0) (hb2nz : b.getLimbN 2 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 2)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hpath : fullModN3PathConditionsVal256V4 bltu_1 bltu_0 a b) :
+    cpsTripleWithin (unifiedDivBound + 1) base (raVal &&& ~~~1)
+      (evm_mod_callable_code_v4 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult (b.getLimbN 2)).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (modStackDispatchPostCallableExactFrame sp a b raVal
+        (signExtend12 4095 : Word) **
+       ((sp + signExtend12 3936) ↦ₘ
+        fullDivN3ScratchMemV4 bltu_1 bltu_0
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+          scratchMem)) := by
+  have hbnz' : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 ≠ 0 :=
+    (EvmWord.ne_zero_iff_getLimbN_or).mp hbnz
+  exact evm_mod_callable_v4_n3_stack_pre_to_callable_post_scratch_of_mod_path_conditions
+    sp base a b v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+    hbnz hb3z hb2nz hshift_nz halign
+    (fullModN3PathConditionsWordV4_of_val256 bltu_1 bltu_0 a b hbnz' hpath)
+
 theorem evm_mod_callable_v4_spec_from_noNop (sp base raVal : Word)
     (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7

--- a/EvmAsm/Evm64/DivMod/CallableV4Mod.lean
+++ b/EvmAsm/Evm64/DivMod/CallableV4Mod.lean
@@ -636,6 +636,45 @@ theorem evm_mod_callable_v4_n3_stack_pre_to_callable_post_scratch_of_scaled_path
     hbnz hb3z hb2nz hshift_nz halign
     (fullModN3PathConditionsVal256V4_of_scaled bltu_1 bltu_0 a b hshift_nz' hpath)
 
+/-- Callable-program N3 v4 MOD surface from the normalized Euclidean path
+predicate. This is the public wrapper for the next loop-arithmetic closure:
+prove the normalized mulsub equation and remainder bound, then the existing
+scaled/val256/word bridge completes the stack-level MOD post. -/
+theorem evm_mod_callable_v4_n3_stack_pre_to_callable_post_scratch_of_normalized_path_conditions
+    (sp base : Word) (a b : EvmWord)
+    (v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (hbnz : b ≠ 0)
+    (hb3z : b.getLimbN 3 = 0) (hb2nz : b.getLimbN 2 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 2)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hpath : fullModN3PathConditionsNormalizedV4 bltu_1 bltu_0 a b) :
+    cpsTripleWithin (unifiedDivBound + 1) base (raVal &&& ~~~1)
+      (evm_mod_callable_code_v4 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult (b.getLimbN 2)).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (modStackDispatchPostCallableExactFrame sp a b raVal
+        (signExtend12 4095 : Word) **
+       ((sp + signExtend12 3936) ↦ₘ
+        fullDivN3ScratchMemV4 bltu_1 bltu_0
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+          scratchMem)) := by
+  exact evm_mod_callable_v4_n3_stack_pre_to_callable_post_scratch_of_scaled_path_conditions
+    sp base a b v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+    hbnz hb3z hb2nz hshift_nz halign
+    (fullModN3PathConditionsScaledV4_of_normalized bltu_1 bltu_0 a b hpath)
+
 theorem evm_mod_callable_v4_spec_from_noNop (sp base raVal : Word)
     (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2LoopUnified.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2LoopUnified.lean
@@ -384,4 +384,62 @@ theorem evm_div_n2_preloop_loop_unified_spec_noNop
     (fun h hq => by delta preloopN2UnifiedPost; xperm_hyp hq)
     hFull
 
+/-- No-NOP n=2 preloop setup with the exact caller-framed `x1` and the
+    loop scratch handoff frame carried explicitly. -/
+theorem evm_div_n2_to_loopSetup_spec_within_noNop_exact_x1_frame
+    (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem : Word)
+    (jMem retMem dMem dloMem scratch_un0 raVal : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0)
+    (hshift_nz : (clzResult b1).1 ≠ 0) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4) base (base + loopBodyOff)
+      (divCode_noNop base)
+      (((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
+        (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+        ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+        ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+        ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+        ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+        ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+        ((sp + signExtend12 4024) ↦ₘ u4Old) **
+        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+        ((sp + signExtend12 3992) ↦ₘ shiftMem)) **
+       ((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratch_un0) **
+        (.x1 ↦ᵣ raVal)))
+      (loopSetupPost sp (2 : Word) (clzResult b1).1 a0 a1 a2 a3 b0 b1 b2 b3 **
+       ((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratch_un0) **
+        (.x1 ↦ᵣ raVal))) := by
+  have hPre :=
+    evm_div_n2_to_loopSetup_spec_within_noNop sp base
+      a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10
+      q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem
+      hbnz hb3z hb2z hb1nz hshift_nz
+  have hFramed := cpsTripleWithin_frameR
+    (((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
+      (sp + signExtend12 3968 ↦ₘ retMem) **
+      (sp + signExtend12 3960 ↦ₘ dMem) **
+      (sp + signExtend12 3952 ↦ₘ dloMem) **
+      (sp + signExtend12 3944 ↦ₘ scratch_un0) **
+      (.x1 ↦ᵣ raVal)))
+    (by pcFree) hPre
+  exact cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    hFramed
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNop.lean
@@ -703,4 +703,81 @@ theorem divK_loop_body_n2_call_j2_exact_loopIterScratch_v4_noNop (sp base : Word
           retMem dMem dloMem scratchUn0 scratchMem raVal
           halign hbltu hborrow_zero)
 
+/-- Unified j=2 N2 max iteration over v4/no-NOP code, preserving concrete
+    `x1` and carrying the v4 scratch cell as frame. -/
+theorem divK_loop_body_n2_max_j2_exact_loopIterScratch_v4_noNop (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hbltu : ¬BitVec.ult u2 v1)
+    (hcarry2_nz : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 152 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop_v4 base)
+      ((loopBodyN2MaxSkipJgt0NormPreV4 (2 : Word) sp
+        jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal)))
+      ((loopIterPostN2Max sp (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal))) := by
+  by_cases hborrow :
+      BitVec.ult uTop
+        (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+  · have hborrow_nz :
+        (if BitVec.ult uTop
+          (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+         then (1 : Word) else 0) ≠ (0 : Word) := by
+      rw [if_pos hborrow]
+      decide
+    have J := divK_loop_body_n2_max_addback_jgt0_beq_norm_v4_noNop
+      (2 : Word) sp base EvmAsm.Evm64.DivMod.AddrNorm.slt_jpos_2
+      jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld hbltu hcarry2_nz hborrow_nz
+    have Jf := cpsTripleWithin_frameR
+      ((sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
+       (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+       (sp + signExtend12 3936 ↦ₘ scratchMem) **
+       (.x1 ↦ᵣ raVal))
+      (by pcFree) J
+    exact cpsTripleWithin_weaken
+      (fun h hp => by xperm_hyp hp)
+      (fun h hp => by
+        rw [loopIterPostN2Max_addback hborrow] at hp
+        xperm_hyp hp)
+      Jf
+  · have hborrow_zero :
+        (if BitVec.ult uTop
+          (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+         then (1 : Word) else 0) = (0 : Word) := by
+      rw [if_neg hborrow]
+    have J := divK_loop_body_n2_max_skip_jgt0_norm_v4_noNop
+      (2 : Word) sp base EvmAsm.Evm64.DivMod.AddrNorm.slt_jpos_2
+      jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld hbltu hborrow_zero
+    have Jf := cpsTripleWithin_frameR
+      ((sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
+       (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+       (sp + signExtend12 3936 ↦ₘ scratchMem) **
+       (.x1 ↦ᵣ raVal))
+      (by pcFree) J
+    exact cpsTripleWithin_mono_nSteps (by decide) <|
+      cpsTripleWithin_weaken
+        (fun h hp => by xperm_hyp hp)
+        (fun h hp => by
+          rw [loopIterPostN2Max_skip hborrow] at hp
+          xperm_hyp hp)
+        Jf
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNop.lean
@@ -107,6 +107,63 @@ def loopBodyN2CallAddbackJgt0NormPreV4 (j : Word)
   loopBodyN2CallAddbackJgt0PreV4 j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem
 
+/-- The callable-ready v4 n=2 loop source specializes to the j=2 max-body
+    precondition, with j=1/j=0 source atoms retained as a frame. -/
+theorem loopN2PreWithScratchV4NoX1_to_max_j2_pre
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word) :
+    ∀ h,
+      (loopN2PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem ** (.x1 ↦ᵣ raVal)) h →
+      ((loopBodyN2MaxSkipJgt0NormPreV4 (2 : Word) sp
+        jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop q2Old **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal)) **
+        (((sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) +
+          signExtend12 0 ↦ₘ u0Orig1) **
+         ((sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q1Old) **
+         (((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) +
+          signExtend12 0 ↦ₘ u0Orig0) **
+         ((sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q0Old)))) h := by
+  intro h hp
+  delta loopN2PreWithScratchV4NoX1 loopN2PreWithScratchNoX1 loopN2Pre at hp
+  delta loopBodyN2MaxSkipJgt0NormPreV4
+  rw [loopBodyN2MaxJgt0Pre_unfold]
+  xperm_hyp hp
+
+/-- The callable-ready v4 n=2 loop source specializes to the j=2 call-body
+    precondition, with j=1/j=0 source atoms retained as a frame. -/
+theorem loopN2PreWithScratchV4NoX1_to_call_j2_pre
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word) :
+    ∀ h,
+      (loopN2PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem ** (.x1 ↦ᵣ raVal)) h →
+      ((loopBodyN2CallSkipJgt0NormPreV4NoX1 (2 : Word) sp
+        jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop q2Old
+        retMem dMem dloMem scratchUn0 scratchMem ** (.x1 ↦ᵣ raVal)) **
+        (((sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) +
+          signExtend12 0 ↦ₘ u0Orig1) **
+         ((sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q1Old) **
+         (((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) +
+          signExtend12 0 ↦ₘ u0Orig0) **
+         ((sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q0Old)))) h := by
+  intro h hp
+  delta loopN2PreWithScratchV4NoX1 loopN2PreWithScratchNoX1 loopN2Pre at hp
+  delta loopBodyN2CallSkipJgt0NormPreV4NoX1 loopBodyN2MaxSkipJgt0NormPreV4 at ⊢
+  rw [loopBodyN2MaxJgt0Pre_unfold]
+  xperm_hyp hp
+
 /-- Loop body n=2, max+skip, j=0 over `divCode_noNop_v4`, with
     sp-relative addresses hidden behind a named precondition. -/
 theorem divK_loop_body_n2_max_skip_j0_norm_v4_noNop (sp base : Word)

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNop.lean
@@ -644,4 +644,63 @@ theorem divK_loop_body_n2_call_addback_j0_beq_norm_v4_noNop_exact_x1 (sp base : 
     (fun h hp => hp)
     raw
 
+/-- Unified j=2 N2 call iteration over v4/no-NOP code, preserving concrete
+    `x1` and exposing the v4 scratch cell in the postcondition. -/
+theorem divK_loop_body_n2_call_j2_exact_loopIterScratch_v4_noNop (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu : BitVec.ult u2 v1)
+    (hcarry2_nz : loopBodyN2CallAddbackCarry2NzV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 224 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop_v4 base)
+      (loopBodyN2CallSkipJgt0NormPreV4NoX1 (2 : Word) sp
+        jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
+        retMem dMem dloMem scratchUn0 scratchMem ** (.x1 ↦ᵣ raVal))
+      (loopIterPostN2CallScratchNoX1 sp base (2 : Word)
+        (divKTrialCallV4QHat u2 u1 v1)
+        (divKTrialCallV4DLo v1)
+        (divKTrialCallV4Un0 u1)
+        (divKTrialCallV4ScratchOut u2 u1 v1 scratchMem)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop ** (.x1 ↦ᵣ raVal)) := by
+  by_cases hborrow :
+      BitVec.ult uTop
+        (mulsubN4_c3 (divKTrialCallV4QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3)
+  · have hborrow_nz : loopBodyN2CallAddbackBorrowV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+      simp [loopBodyN2CallAddbackBorrowV4, hborrow]
+    exact cpsTripleWithin_weaken
+      (fun h hp => hp)
+      (fun h hp => by
+        rw [loopBodyN2CallAddbackBeqJgt0PostV4NoX1_eq_scratch] at hp
+        rw [loopIterPostN2CallScratchNoX1_addback hborrow] at hp
+        xperm_hyp hp)
+      (divK_loop_body_n2_call_addback_jgt0_beq_norm_v4_noNop_exact_x1
+        (2 : Word) sp base EvmAsm.Evm64.DivMod.AddrNorm.slt_jpos_2
+        jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
+        retMem dMem dloMem scratchUn0 scratchMem raVal
+        halign hbltu hborrow_nz hcarry2_nz)
+  · have hborrow_zero :
+        mulsubN4NoBorrow (divKTrialCallV4QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+      unfold mulsubN4NoBorrow
+      dsimp only
+      unfold mulsubN4_c3 at hborrow
+      rw [if_neg hborrow]
+    exact cpsTripleWithin_mono_nSteps (by decide) <|
+      cpsTripleWithin_weaken
+        (fun h hp => hp)
+        (fun h hp => by
+          rw [loopBodyN2CallSkipJgt0PostV4NoX1_eq_scratch] at hp
+          rw [loopIterPostN2CallScratchNoX1_skip hborrow] at hp
+          xperm_hyp hp)
+        (divK_loop_body_n2_call_skip_jgt0_norm_v4_noNop_exact_x1
+          (2 : Word) sp base EvmAsm.Evm64.DivMod.AddrNorm.slt_jpos_2
+          jOld v5Old v6Old v7Old v10Old v11Old v2Old
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
+          retMem dMem dloMem scratchUn0 scratchMem raVal
+          halign hbltu hborrow_zero)
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNop.lean
@@ -48,6 +48,19 @@ def loopBodyN2CallSkipJ0NormPreV4
   (sp + signExtend12 3944 ↦ₘ scratchUn0) **
   regOwn .x1 ** (sp + signExtend12 3936 ↦ₘ scratchMem)
 
+@[irreducible]
+def loopBodyN2CallSkipJ0NormPreV4NoX1
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word) : Assertion :=
+  loopBodyN2MaxSkipJ0NormPreV4 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld **
+  (sp + signExtend12 3968 ↦ₘ retMem) **
+  (sp + signExtend12 3960 ↦ₘ dMem) **
+  (sp + signExtend12 3952 ↦ₘ dloMem) **
+  (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+  (sp + signExtend12 3936 ↦ₘ scratchMem)
+
 /-- n=2 max-skip j>0 precondition over `divCode_noNop_v4`.
     The j-dependent address lets stay behind this irreducible boundary. -/
 @[irreducible]
@@ -193,6 +206,41 @@ theorem divK_loop_body_n2_call_skip_j0_norm_v4_noNop (sp base : Word)
   exact cpsTripleWithin_weaken
     (fun h hp => by
       delta loopBodyN2CallSkipJ0NormPreV4 loopBodyN2MaxSkipJ0NormPreV4 at hp
+      xperm_hyp hp)
+    (fun h hp => hp)
+    raw
+
+/-- Loop body n=2, call+skip, j=0 over `divCode_noNop_v4`, preserving the
+    concrete caller `x1` outside the normalized call precondition. -/
+theorem divK_loop_body_n2_call_skip_j0_norm_v4_noNop_exact_x1 (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem raVal : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu : BitVec.ult u2 v1)
+    (hborrow : loopBodyN2CallSkipJ0BorrowV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 148 (base + loopBodyOff) (base + denormOff) (divCode_noNop_v4 base)
+      (loopBodyN2CallSkipJ0NormPreV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopBodyN2CallSkipJ0PostV4NoX1 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem **
+        (.x1 ↦ᵣ raVal)) := by
+  have raw :=
+    cpsTripleWithin_extend_code
+      (hmono := sharedDivModCodeNoNop_v4_sub_divCode_noNop_v4)
+      (divK_loop_body_n2_call_skip_j0_v4_spec_within_noNop_exact_x1
+        sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal
+        retMem dMem dloMem scratchUn0 scratchMem base
+        halign hbltu hborrow)
+  unfold loopBodyN2CallSkipJ0PreV4NoX1 at raw
+  simp only [se12_32, se12_40, se12_48, se12_56,
+             u_base_off0_j0, u_base_off4088_j0, u_base_off4080_j0,
+             u_base_off4072_j0, u_base_off4064_j0, q_addr_j0] at raw
+  exact cpsTripleWithin_weaken
+    (fun h hp => by
+      delta loopBodyN2CallSkipJ0NormPreV4NoX1 loopBodyN2MaxSkipJ0NormPreV4 at hp
       xperm_hyp hp)
     (fun h hp => hp)
     raw

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNop.lean
@@ -780,4 +780,140 @@ theorem divK_loop_body_n2_max_j2_exact_loopIterScratch_v4_noNop (sp base : Word)
           xperm_hyp hp)
         Jf
 
+/-- Unified j=1 N2 call iteration over v4/no-NOP code, preserving concrete
+    `x1` and exposing the v4 scratch cell in the postcondition. -/
+theorem divK_loop_body_n2_call_j1_exact_loopIterScratch_v4_noNop (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu : BitVec.ult u2 v1)
+    (hcarry2_nz : loopBodyN2CallAddbackCarry2NzV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 224 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop_v4 base)
+      (loopBodyN2CallSkipJgt0NormPreV4NoX1 (1 : Word) sp
+        jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
+        retMem dMem dloMem scratchUn0 scratchMem ** (.x1 ↦ᵣ raVal))
+      (loopIterPostN2CallScratchNoX1 sp base (1 : Word)
+        (divKTrialCallV4QHat u2 u1 v1)
+        (divKTrialCallV4DLo v1)
+        (divKTrialCallV4Un0 u1)
+        (divKTrialCallV4ScratchOut u2 u1 v1 scratchMem)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop ** (.x1 ↦ᵣ raVal)) := by
+  by_cases hborrow :
+      BitVec.ult uTop
+        (mulsubN4_c3 (divKTrialCallV4QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3)
+  · have hborrow_nz : loopBodyN2CallAddbackBorrowV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+      simp [loopBodyN2CallAddbackBorrowV4, hborrow]
+    exact cpsTripleWithin_weaken
+      (fun h hp => hp)
+      (fun h hp => by
+        rw [loopBodyN2CallAddbackBeqJgt0PostV4NoX1_eq_scratch] at hp
+        rw [loopIterPostN2CallScratchNoX1_addback hborrow] at hp
+        xperm_hyp hp)
+      (divK_loop_body_n2_call_addback_jgt0_beq_norm_v4_noNop_exact_x1
+        (1 : Word) sp base EvmAsm.Evm64.DivMod.AddrNorm.slt_jpos_1
+        jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
+        retMem dMem dloMem scratchUn0 scratchMem raVal
+        halign hbltu hborrow_nz hcarry2_nz)
+  · have hborrow_zero :
+        mulsubN4NoBorrow (divKTrialCallV4QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+      unfold mulsubN4NoBorrow
+      dsimp only
+      unfold mulsubN4_c3 at hborrow
+      rw [if_neg hborrow]
+    exact cpsTripleWithin_mono_nSteps (by decide) <|
+      cpsTripleWithin_weaken
+        (fun h hp => hp)
+        (fun h hp => by
+          rw [loopBodyN2CallSkipJgt0PostV4NoX1_eq_scratch] at hp
+          rw [loopIterPostN2CallScratchNoX1_skip hborrow] at hp
+          xperm_hyp hp)
+        (divK_loop_body_n2_call_skip_jgt0_norm_v4_noNop_exact_x1
+          (1 : Word) sp base EvmAsm.Evm64.DivMod.AddrNorm.slt_jpos_1
+          jOld v5Old v6Old v7Old v10Old v11Old v2Old
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
+          retMem dMem dloMem scratchUn0 scratchMem raVal
+          halign hbltu hborrow_zero)
+
+/-- Unified j=1 N2 max iteration over v4/no-NOP code, preserving concrete
+    `x1` and carrying the v4 scratch cell as frame. -/
+theorem divK_loop_body_n2_max_j1_exact_loopIterScratch_v4_noNop (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hbltu : ¬BitVec.ult u2 v1)
+    (hcarry2_nz : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 152 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop_v4 base)
+      ((loopBodyN2MaxSkipJgt0NormPreV4 (1 : Word) sp
+        jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal)))
+      ((loopIterPostN2Max sp (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal))) := by
+  by_cases hborrow :
+      BitVec.ult uTop
+        (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+  · have hborrow_nz :
+        (if BitVec.ult uTop
+          (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+         then (1 : Word) else 0) ≠ (0 : Word) := by
+      rw [if_pos hborrow]
+      decide
+    have J := divK_loop_body_n2_max_addback_jgt0_beq_norm_v4_noNop
+      (1 : Word) sp base EvmAsm.Evm64.DivMod.AddrNorm.slt_jpos_1
+      jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld hbltu hcarry2_nz hborrow_nz
+    have Jf := cpsTripleWithin_frameR
+      ((sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
+       (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+       (sp + signExtend12 3936 ↦ₘ scratchMem) **
+       (.x1 ↦ᵣ raVal))
+      (by pcFree) J
+    exact cpsTripleWithin_weaken
+      (fun h hp => by xperm_hyp hp)
+      (fun h hp => by
+        rw [loopIterPostN2Max_addback hborrow] at hp
+        xperm_hyp hp)
+      Jf
+  · have hborrow_zero :
+        (if BitVec.ult uTop
+          (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+         then (1 : Word) else 0) = (0 : Word) := by
+      rw [if_neg hborrow]
+    have J := divK_loop_body_n2_max_skip_jgt0_norm_v4_noNop
+      (1 : Word) sp base EvmAsm.Evm64.DivMod.AddrNorm.slt_jpos_1
+      jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld hbltu hborrow_zero
+    have Jf := cpsTripleWithin_frameR
+      ((sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
+       (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+       (sp + signExtend12 3936 ↦ₘ scratchMem) **
+       (.x1 ↦ᵣ raVal))
+      (by pcFree) J
+    exact cpsTripleWithin_mono_nSteps (by decide) <|
+      cpsTripleWithin_weaken
+        (fun h hp => by xperm_hyp hp)
+        (fun h hp => by
+          rw [loopIterPostN2Max_skip hborrow] at hp
+          xperm_hyp hp)
+        Jf
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNop.lean
@@ -84,6 +84,19 @@ def loopBodyN2CallSkipJgt0NormPreV4 (j : Word)
   (sp + signExtend12 3944 ↦ₘ scratchUn0) **
   (sp + signExtend12 3936 ↦ₘ scratchMem) ** regOwn .x1
 
+@[irreducible]
+def loopBodyN2CallSkipJgt0NormPreV4NoX1 (j : Word)
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word) : Assertion :=
+  loopBodyN2MaxSkipJgt0NormPreV4 j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld **
+  (sp + signExtend12 3968 ↦ₘ retMem) **
+  (sp + signExtend12 3960 ↦ₘ dMem) **
+  (sp + signExtend12 3952 ↦ₘ dloMem) **
+  (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+  (sp + signExtend12 3936 ↦ₘ scratchMem)
+
 /-- n=2 call-addback j>0 precondition over `divCode_noNop_v4`. -/
 @[irreducible]
 def loopBodyN2CallAddbackJgt0NormPreV4 (j : Word)
@@ -295,6 +308,41 @@ theorem divK_loop_body_n2_call_skip_jgt0_norm_v4_noNop (j sp base : Word)
       xperm_hyp hp)
     (fun h hp => hp)
     raw'
+
+/-- Loop body n=2, call+skip, j>0 over `divCode_noNop_v4`, preserving the
+    concrete caller `x1` outside the normalized call precondition. -/
+theorem divK_loop_body_n2_call_skip_jgt0_norm_v4_noNop_exact_x1 (j sp base : Word)
+    (hpos : BitVec.slt (j + signExtend12 4095) 0 = false)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem raVal : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu : BitVec.ult u2 v1)
+    (hborrow : mulsubN4NoBorrow (divKTrialCallV4QHat u2 u1 v1)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 148 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop_v4 base)
+      (loopBodyN2CallSkipJgt0NormPreV4NoX1 j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopBodyN2CallSkipJgt0PostV4NoX1 sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem **
+        (.x1 ↦ᵣ raVal)) := by
+  have raw :=
+    cpsTripleWithin_extend_code
+      (hmono := sharedDivModCodeNoNop_v4_sub_divCode_noNop_v4)
+      (divK_loop_body_n2_call_skip_jgt0_v4_spec_within_noNop_exact_x1 j hpos
+        sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal
+        retMem dMem dloMem scratchUn0 scratchMem base
+        halign hbltu hborrow)
+  exact cpsTripleWithin_weaken
+    (fun h hp => by
+      delta loopBodyN2CallSkipJgt0NormPreV4NoX1 loopBodyN2MaxSkipJgt0NormPreV4 at hp
+      unfold loopBodyN2CallSkipJgt0PreV4NoX1
+      rw [loopBodyN2MaxJgt0Pre_unfold] at hp
+      xperm_hyp hp)
+    (fun h hp => hp)
+    raw
 
 /-- Loop body n=2, call+addback (BEQ double-addback), j>0 over
     `divCode_noNop_v4`, with the precondition hidden behind an irreducible

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNop.lean
@@ -9,6 +9,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathV4NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN2MaxV4NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN2CallV4NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN2AddbackV4NoNop
+import EvmAsm.Evm64.DivMod.LoopIterN2CallAddbackV4NoNop
 
 open EvmAsm.Rv64.Tactics
 
@@ -375,6 +376,54 @@ theorem divK_loop_body_n2_call_addback_jgt0_beq_norm_v4_noNop (j sp base : Word)
     (fun h hp => hp)
     raw'
 
+/-- Loop body n=2, call+addback (BEQ double-addback), j>0 over
+    `divCode_noNop_v4`, preserving the concrete caller `x1` outside the
+    normalized call precondition. -/
+theorem divK_loop_body_n2_call_addback_jgt0_beq_norm_v4_noNop_exact_x1 (j sp base : Word)
+    (hpos : BitVec.slt (j + signExtend12 4095) 0 = false)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem raVal : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu : BitVec.ult u2 v1)
+    (hborrow : loopBodyN2CallAddbackBorrowV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hcarry2_nz : loopBodyN2CallAddbackCarry2NzV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 224 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop_v4 base)
+      (loopBodyN2CallSkipJgt0NormPreV4NoX1 j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopBodyN2CallAddbackBeqJgt0PostV4NoX1 sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop
+        scratchMem ** (.x1 ↦ᵣ raVal)) := by
+  have hborrow' : (if BitVec.ult uTop
+        (mulsubN4 (divKTrialCallV4QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2
+      then (1 : Word) else 0) ≠ (0 : Word) := by
+    simpa [loopBodyN2CallAddbackBorrowV4, mulsubN4_c3] using hborrow
+  have hcarry2_nz' :
+      let qHat := divKTrialCallV4QHat u2 u1 v1
+      let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+      let c3 := ms.2.2.2.2
+      let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
+      let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
+      carry = 0 → addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0 := by
+    simpa [loopBodyN2CallAddbackCarry2NzV4] using hcarry2_nz
+  have raw :=
+    cpsTripleWithin_extend_code
+      (hmono := sharedDivModCodeNoNop_v4_sub_divCode_noNop_v4)
+      (divK_loop_body_n2_call_addback_jgt0_beq_v4_spec_within_noNop_exact_x1 j hpos
+        sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal
+        retMem dMem dloMem scratchUn0 scratchMem base
+        halign hbltu hborrow' hcarry2_nz')
+  exact cpsTripleWithin_weaken
+    (fun h hp => by
+      delta loopBodyN2CallSkipJgt0NormPreV4NoX1 loopBodyN2MaxSkipJgt0NormPreV4 at hp
+      unfold loopBodyN2CallSkipJgt0PreV4NoX1
+      rw [loopBodyN2MaxJgt0Pre_unfold] at hp
+      xperm_hyp hp)
+    (fun h hp => hp)
+    raw
+
 /-- Loop body n=2, max+addback (BEQ double-addback), j=0 over
     `divCode_noNop_v4`, with sp-relative addresses hidden behind a named
     precondition. -/
@@ -436,6 +485,55 @@ theorem divK_loop_body_n2_call_addback_j0_beq_norm_v4_noNop (sp base : Word)
   exact cpsTripleWithin_weaken
     (fun h hp => by
       delta loopBodyN2CallSkipJ0NormPreV4 loopBodyN2MaxSkipJ0NormPreV4 at hp
+      xperm_hyp hp)
+    (fun h hp => hp)
+    raw
+
+/-- Loop body n=2, call+addback (BEQ double-addback), j=0 over
+    `divCode_noNop_v4`, preserving the concrete caller `x1` outside the
+    normalized call precondition. -/
+theorem divK_loop_body_n2_call_addback_j0_beq_norm_v4_noNop_exact_x1 (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem raVal : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu : BitVec.ult u2 v1)
+    (hborrow : loopBodyN2CallAddbackBorrowV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hcarry2_nz : loopBodyN2CallAddbackCarry2NzV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 224 (base + loopBodyOff) (base + denormOff) (divCode_noNop_v4 base)
+      (loopBodyN2CallSkipJ0NormPreV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopBodyN2CallAddbackBeqJ0PostV4NoX1 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem **
+        (.x1 ↦ᵣ raVal)) := by
+  have hborrow' : (if BitVec.ult uTop
+        (mulsubN4 (divKTrialCallV4QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2
+      then (1 : Word) else 0) ≠ (0 : Word) := by
+    simpa [loopBodyN2CallAddbackBorrowV4, mulsubN4_c3] using hborrow
+  have hcarry2_nz' :
+      let qHat := divKTrialCallV4QHat u2 u1 v1
+      let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+      let c3 := ms.2.2.2.2
+      let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
+      let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
+      carry = 0 → addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0 := by
+    simpa [loopBodyN2CallAddbackCarry2NzV4] using hcarry2_nz
+  have raw :=
+    cpsTripleWithin_extend_code
+      (hmono := sharedDivModCodeNoNop_v4_sub_divCode_noNop_v4)
+      (divK_loop_body_n2_call_addback_j0_beq_v4_spec_within_noNop_exact_x1
+        sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal
+        retMem dMem dloMem scratchUn0 scratchMem base
+        halign hbltu hborrow' hcarry2_nz')
+  unfold loopBodyN2CallSkipJ0PreV4NoX1 at raw
+  simp only [se12_32, se12_40, se12_48, se12_56,
+             u_base_off0_j0, u_base_off4088_j0, u_base_off4080_j0,
+             u_base_off4072_j0, u_base_off4064_j0, q_addr_j0] at raw
+  exact cpsTripleWithin_weaken
+    (fun h hp => by
+      delta loopBodyN2CallSkipJ0NormPreV4NoX1 loopBodyN2MaxSkipJ0NormPreV4 at hp
       xperm_hyp hp)
     (fun h hp => hp)
     raw

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNop.lean
@@ -164,6 +164,55 @@ theorem loopN2PreWithScratchV4NoX1_to_call_j2_pre
   rw [loopBodyN2MaxJgt0Pre_unfold]
   xperm_hyp hp
 
+theorem loopBodyN2CallSkipJ0PostV4NoX1_eq_scratch
+    (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word) :
+    loopBodyN2CallSkipJ0PostV4NoX1 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem =
+      loopBodyN2CallSkipPostJScratchNoX1 sp base (0 : Word)
+        (divKTrialCallV4QHat u2 u1 v1)
+        (divKTrialCallV4DLo v1)
+        (divKTrialCallV4Un0 u1)
+        (divKTrialCallV4ScratchOut u2 u1 v1 scratchMem)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+  delta loopBodyN2CallSkipJ0PostV4NoX1 loopBodyN2CallSkipPostJScratchNoX1
+  rfl
+
+theorem loopBodyN2CallSkipJgt0PostV4NoX1_eq_scratch
+    (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word) :
+    loopBodyN2CallSkipJgt0PostV4NoX1 sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem =
+      loopBodyN2CallSkipPostJScratchNoX1 sp base j
+        (divKTrialCallV4QHat u2 u1 v1)
+        (divKTrialCallV4DLo v1)
+        (divKTrialCallV4Un0 u1)
+        (divKTrialCallV4ScratchOut u2 u1 v1 scratchMem)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+  delta loopBodyN2CallSkipJgt0PostV4NoX1 loopBodyN2CallSkipPostJScratchNoX1
+  rfl
+
+theorem loopBodyN2CallAddbackBeqJ0PostV4NoX1_eq_scratch
+    (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word) :
+    loopBodyN2CallAddbackBeqJ0PostV4NoX1 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem =
+      loopBodyN2CallAddbackBeqPostJScratchNoX1 sp base (0 : Word)
+        (divKTrialCallV4QHat u2 u1 v1)
+        (divKTrialCallV4DLo v1)
+        (divKTrialCallV4Un0 u1)
+        (divKTrialCallV4ScratchOut u2 u1 v1 scratchMem)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+  delta loopBodyN2CallAddbackBeqJ0PostV4NoX1 loopBodyN2CallAddbackBeqPostJScratchNoX1
+  rfl
+
+theorem loopBodyN2CallAddbackBeqJgt0PostV4NoX1_eq_scratch
+    (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word) :
+    loopBodyN2CallAddbackBeqJgt0PostV4NoX1 sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop
+        scratchMem =
+      loopBodyN2CallAddbackBeqPostJScratchNoX1 sp base j
+        (divKTrialCallV4QHat u2 u1 v1)
+        (divKTrialCallV4DLo v1)
+        (divKTrialCallV4Un0 u1)
+        (divKTrialCallV4ScratchOut u2 u1 v1 scratchMem)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+  delta loopBodyN2CallAddbackBeqJgt0PostV4NoX1 loopBodyN2CallAddbackBeqPostJScratchNoX1
+  rfl
+
 /-- Loop body n=2, max+skip, j=0 over `divCode_noNop_v4`, with
     sp-relative addresses hidden behind a named precondition. -/
 theorem divK_loop_body_n2_max_skip_j0_norm_v4_noNop (sp base : Word)

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNop.lean
@@ -916,4 +916,214 @@ theorem divK_loop_body_n2_max_j1_exact_loopIterScratch_v4_noNop (sp base : Word)
           xperm_hyp hp)
         Jf
 
+/-- A j=2 call iteration postcondition with v4 scratch cells specializes to the
+    j=1 call-body precondition, retaining exact `x1`, j=2 stored u4/q atoms,
+    and the j=0 source atoms as frame. -/
+theorem loopIterPostN2CallScratchNoX1_j2_to_call_j1_pre
+    (sp base qHat dLo divUn0 scratchOut : Word)
+    (v0 v1 v2 v3 u0J2 u1 u2 u3 uTop u0Orig1 u0Orig0 q1Old q0Old raVal : Word) :
+    let r := iterWithDoubleAddback qHat v0 v1 v2 v3 u0J2 u1 u2 u3 uTop
+    let c3 := mulsubN4_c3 qHat v0 v1 v2 v3 u0J2 u1 u2 u3
+    let uBase2 := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr2 := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
+    let uBase0 := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr0 := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
+    ∀ h,
+      (((loopIterPostN2CallScratchNoX1 sp base (2 : Word)
+        qHat dLo divUn0 scratchOut v0 v1 v2 v3 u0J2 u1 u2 u3 uTop **
+        (.x1 ↦ᵣ raVal)) **
+        ((((sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) +
+          signExtend12 0 ↦ₘ u0Orig1) **
+         ((sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q1Old)) **
+         (((uBase0 + signExtend12 0) ↦ₘ u0Orig0) **
+          (qAddr0 ↦ₘ q0Old)))) h) →
+      (((loopBodyN2CallSkipJgt0NormPreV4NoX1 (1 : Word) sp
+          (2 : Word) ((2 : Word) <<< (3 : BitVec 6).toNat) uBase2 qAddr2 c3 r.1
+          r.2.2.2.2.1 v0 v1 v2 v3 u0Orig1 r.2.1 r.2.2.1
+          r.2.2.2.1 r.2.2.2.2.1 q1Old (base + div128CallRetOff) v1 dLo divUn0
+          scratchOut ** (.x1 ↦ᵣ raVal)) **
+        (((uBase2 + signExtend12 4064 ↦ₘ r.2.2.2.2.2) **
+          (qAddr2 ↦ₘ r.1)) **
+         (((uBase0 + signExtend12 0) ↦ₘ u0Orig0) **
+          (qAddr0 ↦ₘ q0Old)))) h) := by
+  intro r c3 uBase2 qAddr2 uBase0 qAddr0 h hp
+  subst uBase2
+  subst qAddr2
+  subst uBase0
+  subst qAddr0
+  subst c3
+  subst r
+  delta loopIterPostN2CallScratchNoX1 loopExitPostN2 loopExitPost at hp
+  delta loopBodyN2CallSkipJgt0NormPreV4NoX1 loopBodyN2MaxSkipJgt0NormPreV4
+  rw [loopBodyN2MaxJgt0Pre_unfold]
+  unfold mulsubN4_c3
+  simp only [] at hp ⊢
+  have hj' := EvmAsm.Evm64.DivMod.AddrNorm.jpred_2
+  rw [hj', u_j2_0_eq_j1_4088, u_j2_4088_eq_j1_4080,
+      u_j2_4080_eq_j1_4072, u_j2_4072_eq_j1_4064] at hp
+  rw [sepConj_assoc'] at hp
+  xperm_hyp hp
+
+/-- A j=2 call iteration postcondition with v4 scratch cells specializes to the
+    j=1 max-body precondition, retaining exact `x1`, scratch, j=2 stored u4/q
+    atoms, and the j=0 source atoms as frame. -/
+theorem loopIterPostN2CallScratchNoX1_j2_to_max_j1_pre
+    (sp base qHat dLo divUn0 scratchOut : Word)
+    (v0 v1 v2 v3 u0J2 u1 u2 u3 uTop u0Orig1 u0Orig0 q1Old q0Old raVal : Word) :
+    let r := iterWithDoubleAddback qHat v0 v1 v2 v3 u0J2 u1 u2 u3 uTop
+    let c3 := mulsubN4_c3 qHat v0 v1 v2 v3 u0J2 u1 u2 u3
+    let uBase2 := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr2 := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
+    let uBase0 := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr0 := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
+    ∀ h,
+      (((loopIterPostN2CallScratchNoX1 sp base (2 : Word)
+        qHat dLo divUn0 scratchOut v0 v1 v2 v3 u0J2 u1 u2 u3 uTop **
+        (.x1 ↦ᵣ raVal)) **
+        ((((sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) +
+          signExtend12 0 ↦ₘ u0Orig1) **
+         ((sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q1Old)) **
+         (((uBase0 + signExtend12 0) ↦ₘ u0Orig0) **
+          (qAddr0 ↦ₘ q0Old)))) h) →
+      (((loopBodyN2MaxSkipJgt0NormPreV4 (1 : Word) sp
+          (2 : Word) ((2 : Word) <<< (3 : BitVec 6).toNat) uBase2 qAddr2 c3 r.1
+          r.2.2.2.2.1 v0 v1 v2 v3 u0Orig1 r.2.1 r.2.2.1
+          r.2.2.2.1 r.2.2.2.2.1 q1Old **
+        (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+        (sp + signExtend12 3960 ↦ₘ v1) **
+        (sp + signExtend12 3952 ↦ₘ dLo) **
+        (sp + signExtend12 3944 ↦ₘ divUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchOut) **
+        (.x1 ↦ᵣ raVal)) **
+        (((uBase2 + signExtend12 4064 ↦ₘ r.2.2.2.2.2) **
+          (qAddr2 ↦ₘ r.1)) **
+         (((uBase0 + signExtend12 0) ↦ₘ u0Orig0) **
+          (qAddr0 ↦ₘ q0Old)))) h) := by
+  intro r c3 uBase2 qAddr2 uBase0 qAddr0 h hp
+  subst uBase2
+  subst qAddr2
+  subst uBase0
+  subst qAddr0
+  subst c3
+  subst r
+  delta loopIterPostN2CallScratchNoX1 loopExitPostN2 loopExitPost at hp
+  delta loopBodyN2MaxSkipJgt0NormPreV4
+  rw [loopBodyN2MaxJgt0Pre_unfold]
+  unfold mulsubN4_c3
+  simp only [] at hp ⊢
+  have hj' := EvmAsm.Evm64.DivMod.AddrNorm.jpred_2
+  rw [hj', u_j2_0_eq_j1_4088, u_j2_4088_eq_j1_4080,
+      u_j2_4080_eq_j1_4072, u_j2_4072_eq_j1_4064] at hp
+  rw [sepConj_assoc'] at hp
+  xperm_hyp hp
+
+/-- A j=2 max iteration postcondition with v4 scratch cells specializes to the
+    j=1 call-body precondition, retaining exact `x1`, j=2 stored u4/q atoms,
+    and the j=0 source atoms as frame. -/
+theorem loopIterPostN2MaxScratchX1_j2_to_call_j1_pre
+    (sp retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (v0 v1 v2 v3 u0J2 u1 u2 u3 uTop u0Orig1 u0Orig0 q1Old q0Old raVal : Word) :
+    let r := iterN2Max v0 v1 v2 v3 u0J2 u1 u2 u3 uTop
+    let c3 := mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0J2 u1 u2 u3
+    let uBase2 := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr2 := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
+    let uBase0 := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr0 := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
+    ∀ h,
+      (((loopIterPostN2Max sp (2 : Word) v0 v1 v2 v3 u0J2 u1 u2 u3 uTop **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal)) **
+        ((((sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) +
+          signExtend12 0 ↦ₘ u0Orig1) **
+         ((sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q1Old)) **
+         (((uBase0 + signExtend12 0) ↦ₘ u0Orig0) **
+          (qAddr0 ↦ₘ q0Old)))) h) →
+      (((loopBodyN2CallSkipJgt0NormPreV4NoX1 (1 : Word) sp
+          (2 : Word) ((2 : Word) <<< (3 : BitVec 6).toNat) uBase2 qAddr2 c3 r.1
+          r.2.2.2.2.1 v0 v1 v2 v3 u0Orig1 r.2.1 r.2.2.1
+          r.2.2.2.1 r.2.2.2.2.1 q1Old retMem dMem dloMem scratchUn0 scratchMem **
+          (.x1 ↦ᵣ raVal)) **
+        (((uBase2 + signExtend12 4064 ↦ₘ r.2.2.2.2.2) **
+          (qAddr2 ↦ₘ r.1)) **
+         (((uBase0 + signExtend12 0) ↦ₘ u0Orig0) **
+          (qAddr0 ↦ₘ q0Old)))) h) := by
+  intro r c3 uBase2 qAddr2 uBase0 qAddr0 h hp
+  subst uBase2
+  subst qAddr2
+  subst uBase0
+  subst qAddr0
+  subst c3
+  subst r
+  delta loopIterPostN2Max loopExitPostN2 loopExitPost at hp
+  delta loopBodyN2CallSkipJgt0NormPreV4NoX1 loopBodyN2MaxSkipJgt0NormPreV4
+  rw [loopBodyN2MaxJgt0Pre_unfold]
+  unfold mulsubN4_c3
+  simp only [] at hp ⊢
+  have hj' := EvmAsm.Evm64.DivMod.AddrNorm.jpred_2
+  rw [hj', u_j2_0_eq_j1_4088, u_j2_4088_eq_j1_4080,
+      u_j2_4080_eq_j1_4072, u_j2_4072_eq_j1_4064] at hp
+  rw [sepConj_assoc'] at hp
+  xperm_hyp hp
+
+/-- A j=2 max iteration postcondition with v4 scratch cells specializes to the
+    j=1 max-body precondition, retaining exact `x1`, scratch, j=2 stored u4/q
+    atoms, and the j=0 source atoms as frame. -/
+theorem loopIterPostN2MaxScratchX1_j2_to_max_j1_pre
+    (sp retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (v0 v1 v2 v3 u0J2 u1 u2 u3 uTop u0Orig1 u0Orig0 q1Old q0Old raVal : Word) :
+    let r := iterN2Max v0 v1 v2 v3 u0J2 u1 u2 u3 uTop
+    let c3 := mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0J2 u1 u2 u3
+    let uBase2 := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr2 := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
+    let uBase0 := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr0 := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
+    ∀ h,
+      (((loopIterPostN2Max sp (2 : Word) v0 v1 v2 v3 u0J2 u1 u2 u3 uTop **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal)) **
+        ((((sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) +
+          signExtend12 0 ↦ₘ u0Orig1) **
+         ((sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q1Old)) **
+         (((uBase0 + signExtend12 0) ↦ₘ u0Orig0) **
+          (qAddr0 ↦ₘ q0Old)))) h) →
+      (((loopBodyN2MaxSkipJgt0NormPreV4 (1 : Word) sp
+          (2 : Word) ((2 : Word) <<< (3 : BitVec 6).toNat) uBase2 qAddr2 c3 r.1
+          r.2.2.2.2.1 v0 v1 v2 v3 u0Orig1 r.2.1 r.2.2.1
+          r.2.2.2.1 r.2.2.2.2.1 q1Old **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal)) **
+        (((uBase2 + signExtend12 4064 ↦ₘ r.2.2.2.2.2) **
+          (qAddr2 ↦ₘ r.1)) **
+         (((uBase0 + signExtend12 0) ↦ₘ u0Orig0) **
+          (qAddr0 ↦ₘ q0Old)))) h) := by
+  intro r c3 uBase2 qAddr2 uBase0 qAddr0 h hp
+  subst uBase2
+  subst qAddr2
+  subst uBase0
+  subst qAddr0
+  subst c3
+  subst r
+  delta loopIterPostN2Max loopExitPostN2 loopExitPost at hp
+  delta loopBodyN2MaxSkipJgt0NormPreV4
+  rw [loopBodyN2MaxJgt0Pre_unfold]
+  unfold mulsubN4_c3
+  simp only [] at hp ⊢
+  have hj' := EvmAsm.Evm64.DivMod.AddrNorm.jpred_2
+  rw [hj', u_j2_0_eq_j1_4088, u_j2_4088_eq_j1_4080,
+      u_j2_4080_eq_j1_4072, u_j2_4072_eq_j1_4064] at hp
+  rw [sepConj_assoc'] at hp
+  xperm_hyp hp
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNopFinalPost.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNopFinalPost.lean
@@ -1,5 +1,7 @@
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopSource
 
+open EvmAsm.Rv64.Tactics
+
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
@@ -61,6 +63,46 @@ theorem loopN2CallCallCallSourceFinalPostNoX1_unfold (sp base : Word)
        ((uBase2 + signExtend12 4064 ↦ₘ r2.2.2.2.2.2) **
         (qAddr2 ↦ₘ r2.1)))) := by
   delta loopN2CallCallCallSourceFinalPostNoX1
+  rfl
+
+/-- Branch/runtime conditions for the n=2 v4/no-NOP source path whose three
+    loop iterations all take the callable trial-division path.  Bundling these
+    conditions keeps downstream theorem signatures small. -/
+@[irreducible]
+def loopN2CallCallCallSourceConds
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 : Word) : Prop :=
+  let r2 := iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  let qHat1 := divKTrialCallV4QHat r2.2.2.1 r2.2.1 v1
+  let r1 := iterWithDoubleAddback qHat1
+    v0 v1 v2 v3 u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
+  BitVec.ult u2 v1 ∧
+  loopBodyN2CallAddbackCarry2NzV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop ∧
+  BitVec.ult r2.2.2.1 v1 ∧
+  loopBodyN2CallAddbackCarry2NzV4 v0 v1 v2 v3
+    u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1 ∧
+  BitVec.ult r1.2.2.1 v1 ∧
+  loopBodyN2CallAddbackCarry2NzV4 v0 v1 v2 v3
+    u0Orig0 r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+
+theorem loopN2CallCallCallSourceConds_unfold
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 : Word) :
+    loopN2CallCallCallSourceConds
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 =
+    let r2 := iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    let qHat1 := divKTrialCallV4QHat r2.2.2.1 r2.2.1 v1
+    let r1 := iterWithDoubleAddback qHat1
+      v0 v1 v2 v3 u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
+    BitVec.ult u2 v1 ∧
+    loopBodyN2CallAddbackCarry2NzV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop ∧
+    BitVec.ult r2.2.2.1 v1 ∧
+    loopBodyN2CallAddbackCarry2NzV4 v0 v1 v2 v3
+      u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1 ∧
+    BitVec.ult r1.2.2.1 v1 ∧
+    loopBodyN2CallAddbackCarry2NzV4 v0 v1 v2 v3
+      u0Orig0 r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 := by
+  delta loopN2CallCallCallSourceConds
   rfl
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNopFinalPost.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNopFinalPost.lean
@@ -15,8 +15,10 @@ open EvmAsm.Rv64
 def loopN2CallCallCallSourceFinalPostNoX1 (sp base : Word)
     (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 raVal scratchMem : Word) :
     Assertion :=
-  let r2 := iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop
-  let r1 := iterN2Call v0 v1 v2 v3 u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1
+  let r2 := iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  let r1 := iterWithDoubleAddback (divKTrialCallV4QHat r2.2.2.1 r2.2.1 v1)
+    v0 v1 v2 v3 u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1
     r2.2.2.2.2.1
   let qHat0 := divKTrialCallV4QHat r1.2.2.1 r1.2.1 v1
   let dLo0 := divKTrialCallV4DLo v1
@@ -41,8 +43,10 @@ theorem loopN2CallCallCallSourceFinalPostNoX1_unfold (sp base : Word)
     (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 raVal scratchMem : Word) :
     loopN2CallCallCallSourceFinalPostNoX1 sp base
       v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 raVal scratchMem =
-    let r2 := iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    let r1 := iterN2Call v0 v1 v2 v3 u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1
+    let r2 := iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    let r1 := iterWithDoubleAddback (divKTrialCallV4QHat r2.2.2.1 r2.2.1 v1)
+      v0 v1 v2 v3 u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1
       r2.2.2.2.2.1
     let qHat0 := divKTrialCallV4QHat r1.2.2.1 r1.2.1 v1
     let dLo0 := divKTrialCallV4DLo v1

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNopFinalPost.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNopFinalPost.lean
@@ -1,0 +1,66 @@
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopSource
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Compact postcondition for the n=2 v4/no-NOP source path whose three loop
+    iterations all take the callable trial-division path.  The definition keeps
+    the final source-to-j0 theorem statement small enough for Lean to elaborate:
+    the expanded form is the j=0 call post plus retained j=1/j=2 stored u4/q
+    atoms and exact caller `x1`. -/
+@[irreducible]
+def loopN2CallCallCallSourceFinalPostNoX1 (sp base : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 raVal scratchMem : Word) :
+    Assertion :=
+  let r2 := iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  let r1 := iterN2Call v0 v1 v2 v3 u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1
+    r2.2.2.2.2.1
+  let qHat0 := divKTrialCallV4QHat r1.2.2.1 r1.2.1 v1
+  let dLo0 := divKTrialCallV4DLo v1
+  let divUn00 := divKTrialCallV4Un0 r1.2.1
+  let scratch2 := divKTrialCallV4ScratchOut u2 u1 v1 scratchMem
+  let scratch1 := divKTrialCallV4ScratchOut r2.2.2.1 r2.2.1 v1 scratch2
+  let scratch0 := divKTrialCallV4ScratchOut r1.2.2.1 r1.2.1 v1 scratch1
+  let uBase2 := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
+  let qAddr2 := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
+  let uBase1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+  let qAddr1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+  ((loopIterPostN2CallScratchNoX1 sp base (0 : Word)
+    qHat0 dLo0 divUn00 scratch0
+    v0 v1 v2 v3 u0Orig0 r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 **
+    (.x1 ↦ᵣ raVal)) **
+    (((uBase1 + signExtend12 4064 ↦ₘ r1.2.2.2.2.2) **
+      (qAddr1 ↦ₘ r1.1)) **
+     ((uBase2 + signExtend12 4064 ↦ₘ r2.2.2.2.2.2) **
+      (qAddr2 ↦ₘ r2.1))))
+
+theorem loopN2CallCallCallSourceFinalPostNoX1_unfold (sp base : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 raVal scratchMem : Word) :
+    loopN2CallCallCallSourceFinalPostNoX1 sp base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 raVal scratchMem =
+    let r2 := iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    let r1 := iterN2Call v0 v1 v2 v3 u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1
+      r2.2.2.2.2.1
+    let qHat0 := divKTrialCallV4QHat r1.2.2.1 r1.2.1 v1
+    let dLo0 := divKTrialCallV4DLo v1
+    let divUn00 := divKTrialCallV4Un0 r1.2.1
+    let scratch2 := divKTrialCallV4ScratchOut u2 u1 v1 scratchMem
+    let scratch1 := divKTrialCallV4ScratchOut r2.2.2.1 r2.2.1 v1 scratch2
+    let scratch0 := divKTrialCallV4ScratchOut r1.2.2.1 r1.2.1 v1 scratch1
+    let uBase2 := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr2 := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
+    let uBase1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+    ((loopIterPostN2CallScratchNoX1 sp base (0 : Word)
+      qHat0 dLo0 divUn00 scratch0
+      v0 v1 v2 v3 u0Orig0 r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 **
+      (.x1 ↦ᵣ raVal)) **
+      (((uBase1 + signExtend12 4064 ↦ₘ r1.2.2.2.2.2) **
+        (qAddr1 ↦ₘ r1.1)) **
+       ((uBase2 + signExtend12 4064 ↦ₘ r2.2.2.2.2.2) **
+        (qAddr2 ↦ₘ r2.1)))) := by
+  delta loopN2CallCallCallSourceFinalPostNoX1
+  rfl
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNopFinalPost.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNopFinalPost.lean
@@ -105,4 +105,41 @@ theorem loopN2CallCallCallSourceConds_unfold
   delta loopN2CallCallCallSourceConds
   rfl
 
+/-- Compact CPS spec for the n=2 v4/no-NOP source path whose three loop
+    iterations all take the callable trial-division path.  This names the full
+    `cpsTripleWithin` proposition so the proof theorem can expose a small
+    result type and unfold the CPS surface only inside the proof. -/
+@[irreducible]
+def loopN2CallCallCallSourceSpec (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word) : Prop :=
+  cpsTripleWithin (224 + 224 + 224) (base + loopBodyOff) (base + denormOff)
+    (divCode_noNop_v4 base)
+    (loopN2PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old
+      retMem dMem dloMem scratchUn0 scratchMem **
+      (.x1 ↦ᵣ raVal))
+    (loopN2CallCallCallSourceFinalPostNoX1 sp base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 raVal scratchMem)
+
+theorem loopN2CallCallCallSourceSpec_unfold (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word) :
+    loopN2CallCallCallSourceSpec sp base
+      jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old raVal
+      retMem dMem dloMem scratchUn0 scratchMem =
+    cpsTripleWithin (224 + 224 + 224) (base + loopBodyOff) (base + denormOff)
+      (divCode_noNop_v4 base)
+      (loopN2PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopN2CallCallCallSourceFinalPostNoX1 sp base
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 raVal scratchMem) := by
+  delta loopN2CallCallCallSourceSpec
+  rfl
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNopFinalPost.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNopFinalPost.lean
@@ -142,4 +142,67 @@ theorem loopN2CallCallCallSourceSpec_unfold (sp base : Word)
   delta loopN2CallCallCallSourceSpec
   rfl
 
+/-- Inputs for the n=2 call×call×call v4/no-NOP source path, bundled so the
+    eventual source theorem does not expose a large telescoped parameter list. -/
+structure LoopN2CallCallCallSourceInput where
+  sp : Word
+  base : Word
+  jOld : Word
+  v5Old : Word
+  v6Old : Word
+  v7Old : Word
+  v10Old : Word
+  v11Old : Word
+  v2Old : Word
+  v0 : Word
+  v1 : Word
+  v2 : Word
+  v3 : Word
+  u0 : Word
+  u1 : Word
+  u2 : Word
+  u3 : Word
+  uTop : Word
+  u0Orig1 : Word
+  u0Orig0 : Word
+  q2Old : Word
+  q1Old : Word
+  q0Old : Word
+  raVal : Word
+  retMem : Word
+  dMem : Word
+  dloMem : Word
+  scratchUn0 : Word
+  scratchMem : Word
+
+@[irreducible]
+def LoopN2CallCallCallSourceInput.Conds (I : LoopN2CallCallCallSourceInput) : Prop :=
+  loopN2CallCallCallSourceConds I.v0 I.v1 I.v2 I.v3 I.u0 I.u1 I.u2 I.u3 I.uTop
+    I.u0Orig1 I.u0Orig0
+
+@[irreducible]
+def LoopN2CallCallCallSourceInput.Spec (I : LoopN2CallCallCallSourceInput) : Prop :=
+  loopN2CallCallCallSourceSpec I.sp I.base I.jOld I.v5Old I.v6Old I.v7Old I.v10Old
+    I.v11Old I.v2Old I.v0 I.v1 I.v2 I.v3 I.u0 I.u1 I.u2 I.u3 I.uTop
+    I.u0Orig1 I.u0Orig0 I.q2Old I.q1Old I.q0Old I.raVal I.retMem I.dMem I.dloMem
+    I.scratchUn0 I.scratchMem
+
+theorem LoopN2CallCallCallSourceInput.Conds_unfold
+    (I : LoopN2CallCallCallSourceInput) :
+    I.Conds =
+      loopN2CallCallCallSourceConds I.v0 I.v1 I.v2 I.v3 I.u0 I.u1 I.u2 I.u3 I.uTop
+        I.u0Orig1 I.u0Orig0 := by
+  delta LoopN2CallCallCallSourceInput.Conds
+  rfl
+
+theorem LoopN2CallCallCallSourceInput.Spec_unfold
+    (I : LoopN2CallCallCallSourceInput) :
+    I.Spec =
+      loopN2CallCallCallSourceSpec I.sp I.base I.jOld I.v5Old I.v6Old I.v7Old I.v10Old
+        I.v11Old I.v2Old I.v0 I.v1 I.v2 I.v3 I.u0 I.u1 I.u2 I.u3 I.uTop
+        I.u0Orig1 I.u0Orig0 I.q2Old I.q1Old I.q0Old I.raVal I.retMem I.dMem I.dloMem
+        I.scratchUn0 I.scratchMem := by
+  delta LoopN2CallCallCallSourceInput.Spec
+  rfl
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNopSource.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNopSource.lean
@@ -309,4 +309,91 @@ theorem divK_loop_n2_call_max_from_source_exact_loopIterScratch_v4_noNop (sp bas
       v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q1Old q0Old raVal)
     J2 J1f
 
+/-- Full n=2 max×call prefix from the callable-ready v4 loop source,
+    preserving concrete `x1`, scratch, j=2 stored u4/q atoms, and the j=0
+    source atoms. -/
+theorem divK_loop_n2_max_call_from_source_exact_loopIterScratch_v4_noNop (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_2 : ¬BitVec.ult u2 v1)
+    (hcarry2_nz_2 : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hbltu_1 :
+      BitVec.ult
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1 v1)
+    (hcarry2_nz_1 :
+      let r2 := iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      loopBodyN2CallAddbackCarry2NzV4 v0 v1 v2 v3
+        u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1) :
+    let r2 := iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    let qHat1 := divKTrialCallV4QHat r2.2.2.1 r2.2.1 v1
+    let dLo1 := divKTrialCallV4DLo v1
+    let divUn01 := divKTrialCallV4Un0 r2.2.1
+    let scratch1 := divKTrialCallV4ScratchOut r2.2.2.1 r2.2.1 v1 scratchMem
+    let uBase2 := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr2 := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
+    let uBase0 := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr0 := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
+    cpsTripleWithin (152 + 224) (base + loopBodyOff) (base + loopBodyOff)
+      (divCode_noNop_v4 base)
+      (loopN2PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      ((loopIterPostN2CallScratchNoX1 sp base (1 : Word)
+        qHat1 dLo1 divUn01 scratch1
+        v0 v1 v2 v3 u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1 **
+        (.x1 ↦ᵣ raVal)) **
+        (((uBase2 + signExtend12 4064 ↦ₘ r2.2.2.2.2.2) **
+          (qAddr2 ↦ₘ r2.1)) **
+         (((uBase0 + signExtend12 0) ↦ₘ u0Orig0) **
+          (qAddr0 ↦ₘ q0Old)))) := by
+  intro r2 qHat1 dLo1 divUn01 scratch1 uBase2 qAddr2 uBase0 qAddr0
+  have J2 := divK_loop_n2_max_j2_from_source_exact_loopIterScratch_v4_noNop
+    sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old raVal
+    retMem dMem dloMem scratchUn0 scratchMem hbltu_2 hcarry2_nz_2
+  subst r2
+  subst qHat1
+  subst dLo1
+  subst divUn01
+  subst scratch1
+  subst uBase2
+  subst qAddr2
+  subst uBase0
+  subst qAddr0
+  have J1 := divK_loop_body_n2_call_j1_exact_loopIterScratch_v4_noNop sp base
+    (2 : Word)
+    ((2 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat)
+    (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+    (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).1
+    (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
+    v0 v1 v2 v3 u0Orig1
+    (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+    (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+    (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+    (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
+    q1Old raVal
+    retMem dMem dloMem scratchUn0 scratchMem
+    halign hbltu_1 hcarry2_nz_1
+  have J1f := cpsTripleWithin_frameR
+    ((((sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 4064 ↦ₘ
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.2) **
+      ((sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).1)) **
+     (((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 0 ↦ₘ u0Orig0) **
+     ((sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q0Old)))
+    (by pcFree) J1
+  exact cpsTripleWithin_seq_perm_same_cr
+    (loopIterPostN2MaxScratchX1_j2_to_call_j1_pre
+      sp retMem dMem dloMem scratchUn0 scratchMem
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q1Old q0Old raVal)
+    J2 J1f
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNopSource.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNopSource.lean
@@ -211,4 +211,102 @@ theorem divK_loop_n2_call_call_from_source_exact_loopIterScratch_v4_noNop (sp ba
       v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q1Old q0Old raVal)
     J2 J1f
 
+/-- Full n=2 call×max prefix from the callable-ready v4 loop source,
+    preserving concrete `x1`, scratch, j=2 stored u4/q atoms, and the j=0
+    source atoms. -/
+theorem divK_loop_n2_call_max_from_source_exact_loopIterScratch_v4_noNop (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_2 : BitVec.ult u2 v1)
+    (hcarry2_nz_2 : loopBodyN2CallAddbackCarry2NzV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hbltu_1 :
+      let r2 := iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      ¬BitVec.ult r2.2.2.1 v1)
+    (hcarry2_nz_1 :
+      let r2 := iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      isAddbackCarry2NzN2Max v0 v1 v2 v3
+        u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1) :
+    let r2 := iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    let scratch2 := divKTrialCallV4ScratchOut u2 u1 v1 scratchMem
+    let uBase2 := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr2 := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
+    let uBase0 := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr0 := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
+    cpsTripleWithin (224 + 152) (base + loopBodyOff) (base + loopBodyOff)
+      (divCode_noNop_v4 base)
+      (loopN2PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      ((loopIterPostN2Max sp (1 : Word) v0 v1 v2 v3
+        u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1 **
+        (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+        (sp + signExtend12 3960 ↦ₘ v1) **
+        (sp + signExtend12 3952 ↦ₘ (divKTrialCallV4DLo v1)) **
+        (sp + signExtend12 3944 ↦ₘ (divKTrialCallV4Un0 u1)) **
+        (sp + signExtend12 3936 ↦ₘ scratch2) **
+        (.x1 ↦ᵣ raVal)) **
+        (((uBase2 + signExtend12 4064 ↦ₘ r2.2.2.2.2.2) **
+          (qAddr2 ↦ₘ r2.1)) **
+         (((uBase0 + signExtend12 0) ↦ₘ u0Orig0) **
+          (qAddr0 ↦ₘ q0Old)))) := by
+  intro r2 scratch2 uBase2 qAddr2 uBase0 qAddr0
+  have J2 := divK_loop_n2_call_j2_from_source_exact_loopIterScratch_v4_noNop
+    sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old raVal
+    retMem dMem dloMem scratchUn0 scratchMem halign hbltu_2 hcarry2_nz_2
+  subst r2
+  subst scratch2
+  subst uBase2
+  subst qAddr2
+  subst uBase0
+  subst qAddr0
+  have J1 := divK_loop_body_n2_max_j1_exact_loopIterScratch_v4_noNop sp base
+    (2 : Word)
+    ((2 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat)
+    (mulsubN4_c3 (divKTrialCallV4QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3)
+    (iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).1
+    (iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
+    v0 v1 v2 v3 u0Orig1
+    (iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+    (iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+    (iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+    (iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
+    q1Old raVal
+    (base + div128CallRetOff) v1 (divKTrialCallV4DLo v1)
+    (divKTrialCallV4Un0 u1) (divKTrialCallV4ScratchOut u2 u1 v1 scratchMem)
+    hbltu_1 hcarry2_nz_1
+  have J1f := cpsTripleWithin_frameR
+    ((((sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 4064 ↦ₘ
+        (iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.2) **
+      ((sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ
+        (iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).1)) **
+     (((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 0 ↦ₘ u0Orig0) **
+     ((sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q0Old)))
+    (by pcFree) J1
+  exact cpsTripleWithin_seq_perm_same_cr
+    (loopIterPostN2CallScratchNoX1_j2_to_max_j1_pre
+      sp base (divKTrialCallV4QHat u2 u1 v1) (divKTrialCallV4DLo v1)
+      (divKTrialCallV4Un0 u1) (divKTrialCallV4ScratchOut u2 u1 v1 scratchMem)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q1Old q0Old raVal)
+    J2 J1f
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNopSource.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNopSource.lean
@@ -616,6 +616,58 @@ theorem loopIterPostN2CallScratchNoX1_j1_to_max_j0_pre
   rw [sepConj_assoc'] at hp
   xperm_hyp hp
 
+/-- A j=1 call iteration postcondition with v4 scratch cells specializes to the
+    j=0 max-body precondition while retaining both the j=1 and j=2 carried
+    u4/q atoms as frame. -/
+theorem loopIterPostN2CallScratchNoX1_j1_to_max_j0_pre_with_j2_frame
+    (sp base qHat dLo divUn0 scratchOut : Word)
+    (v0 v1 v2 v3 u0J1 u1 u2 u3 uTop u0Orig0 q0Old raVal : Word)
+    (uBase2 qAddr2 u4J2 q2 : Word) :
+    let r := iterWithDoubleAddback qHat v0 v1 v2 v3 u0J1 u1 u2 u3 uTop
+    let c3 := mulsubN4_c3 qHat v0 v1 v2 v3 u0J1 u1 u2 u3
+    let uBase1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+    ∀ h,
+      (((loopIterPostN2CallScratchNoX1 sp base (1 : Word)
+        qHat dLo divUn0 scratchOut v0 v1 v2 v3 u0J1 u1 u2 u3 uTop **
+        (.x1 ↦ᵣ raVal)) **
+        (((uBase2 + signExtend12 4064 ↦ₘ u4J2) **
+          (qAddr2 ↦ₘ q2)) **
+         (((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) +
+          signExtend12 0 ↦ₘ u0Orig0) **
+         ((sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q0Old)))) h) →
+      (((loopBodyN2MaxSkipJ0NormPreV4 sp (1 : Word)
+          ((1 : Word) <<< (3 : BitVec 6).toNat) uBase1 qAddr1 c3 r.1
+          r.2.2.2.2.1 v0 v1 v2 v3 u0Orig0 r.2.1 r.2.2.1 r.2.2.2.1
+          r.2.2.2.2.1 q0Old **
+          (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+          (sp + signExtend12 3960 ↦ₘ v1) **
+          (sp + signExtend12 3952 ↦ₘ dLo) **
+          (sp + signExtend12 3944 ↦ₘ divUn0) **
+          (sp + signExtend12 3936 ↦ₘ scratchOut) **
+          (.x1 ↦ᵣ raVal)) **
+        (((uBase1 + signExtend12 4064 ↦ₘ r.2.2.2.2.2) **
+          (qAddr1 ↦ₘ r.1)) **
+         ((uBase2 + signExtend12 4064 ↦ₘ u4J2) **
+          (qAddr2 ↦ₘ q2)))) h) := by
+  intro r c3 uBase1 qAddr1 h hp
+  subst uBase1
+  subst qAddr1
+  subst c3
+  subst r
+  delta loopIterPostN2CallScratchNoX1 loopExitPostN2 loopExitPost at hp
+  delta loopBodyN2MaxSkipJ0NormPreV4
+  unfold mulsubN4_c3
+  simp only [] at hp ⊢
+  have hj' := EvmAsm.Evm64.DivMod.AddrNorm.jpred_1
+  rw [hj', u_j1_0_eq_j0_4088, u_j1_4088_eq_j0_4080,
+      u_j1_4080_eq_j0_4072, u_j1_4072_eq_j0_4064] at hp
+  simp only [se12_32, se12_40, se12_48, se12_56,
+             u_base_off0_j0, u_base_off4088_j0, u_base_off4080_j0,
+             u_base_off4072_j0, u_base_off4064_j0, q_addr_j0] at hp ⊢
+  rw [sepConj_assoc'] at hp
+  xperm_hyp hp
+
 /-- A j=1 max iteration postcondition with v4 scratch cells specializes to the
     j=0 call-body precondition, retaining exact `x1` and j=1 carried u4/q
     atoms as frame. -/
@@ -644,6 +696,57 @@ theorem loopIterPostN2MaxScratchX1_j1_to_call_j0_pre
           (.x1 ↦ᵣ raVal)) **
         ((uBase1 + signExtend12 4064 ↦ₘ r.2.2.2.2.2) **
          (qAddr1 ↦ₘ r.1))) h) := by
+  intro r c3 uBase1 qAddr1 h hp
+  subst uBase1
+  subst qAddr1
+  subst c3
+  subst r
+  delta loopIterPostN2Max loopExitPostN2 loopExitPost at hp
+  delta loopBodyN2CallSkipJ0NormPreV4NoX1 loopBodyN2MaxSkipJ0NormPreV4
+  unfold mulsubN4_c3
+  simp only [] at hp ⊢
+  have hj' := EvmAsm.Evm64.DivMod.AddrNorm.jpred_1
+  rw [hj', u_j1_0_eq_j0_4088, u_j1_4088_eq_j0_4080,
+      u_j1_4080_eq_j0_4072, u_j1_4072_eq_j0_4064] at hp
+  simp only [se12_32, se12_40, se12_48, se12_56,
+             u_base_off0_j0, u_base_off4088_j0, u_base_off4080_j0,
+             u_base_off4072_j0, u_base_off4064_j0, q_addr_j0] at hp ⊢
+  rw [sepConj_assoc'] at hp
+  xperm_hyp hp
+
+/-- A j=1 max iteration postcondition with v4 scratch cells specializes to the
+    j=0 call-body precondition while retaining both the j=1 and j=2 carried
+    u4/q atoms as frame. -/
+theorem loopIterPostN2MaxScratchX1_j1_to_call_j0_pre_with_j2_frame
+    (sp retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (v0 v1 v2 v3 u0J1 u1 u2 u3 uTop u0Orig0 q0Old raVal : Word)
+    (uBase2 qAddr2 u4J2 q2 : Word) :
+    let r := iterN2Max v0 v1 v2 v3 u0J1 u1 u2 u3 uTop
+    let c3 := mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0J1 u1 u2 u3
+    let uBase1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+    ∀ h,
+      (((loopIterPostN2Max sp (1 : Word) v0 v1 v2 v3 u0J1 u1 u2 u3 uTop **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal)) **
+        (((uBase2 + signExtend12 4064 ↦ₘ u4J2) **
+          (qAddr2 ↦ₘ q2)) **
+         (((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) +
+          signExtend12 0 ↦ₘ u0Orig0) **
+         ((sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q0Old)))) h) →
+      (((loopBodyN2CallSkipJ0NormPreV4NoX1 sp (1 : Word)
+          ((1 : Word) <<< (3 : BitVec 6).toNat) uBase1 qAddr1 c3 r.1
+          r.2.2.2.2.1 v0 v1 v2 v3 u0Orig0 r.2.1 r.2.2.1 r.2.2.2.1
+          r.2.2.2.2.1 q0Old retMem dMem dloMem scratchUn0 scratchMem **
+          (.x1 ↦ᵣ raVal)) **
+        (((uBase1 + signExtend12 4064 ↦ₘ r.2.2.2.2.2) **
+          (qAddr1 ↦ₘ r.1)) **
+         ((uBase2 + signExtend12 4064 ↦ₘ u4J2) **
+          (qAddr2 ↦ₘ q2)))) h) := by
   intro r c3 uBase1 qAddr1 h hp
   subst uBase1
   subst qAddr1
@@ -695,6 +798,62 @@ theorem loopIterPostN2MaxScratchX1_j1_to_max_j0_pre
           (.x1 ↦ᵣ raVal)) **
         ((uBase1 + signExtend12 4064 ↦ₘ r.2.2.2.2.2) **
          (qAddr1 ↦ₘ r.1))) h) := by
+  intro r c3 uBase1 qAddr1 h hp
+  subst uBase1
+  subst qAddr1
+  subst c3
+  subst r
+  delta loopIterPostN2Max loopExitPostN2 loopExitPost at hp
+  delta loopBodyN2MaxSkipJ0NormPreV4
+  unfold mulsubN4_c3
+  simp only [] at hp ⊢
+  have hj' := EvmAsm.Evm64.DivMod.AddrNorm.jpred_1
+  rw [hj', u_j1_0_eq_j0_4088, u_j1_4088_eq_j0_4080,
+      u_j1_4080_eq_j0_4072, u_j1_4072_eq_j0_4064] at hp
+  simp only [se12_32, se12_40, se12_48, se12_56,
+             u_base_off0_j0, u_base_off4088_j0, u_base_off4080_j0,
+             u_base_off4072_j0, u_base_off4064_j0, q_addr_j0] at hp ⊢
+  rw [sepConj_assoc'] at hp
+  xperm_hyp hp
+
+/-- A j=1 max iteration postcondition with v4 scratch cells specializes to the
+    j=0 max-body precondition while retaining both the j=1 and j=2 carried
+    u4/q atoms as frame. -/
+theorem loopIterPostN2MaxScratchX1_j1_to_max_j0_pre_with_j2_frame
+    (sp retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (v0 v1 v2 v3 u0J1 u1 u2 u3 uTop u0Orig0 q0Old raVal : Word)
+    (uBase2 qAddr2 u4J2 q2 : Word) :
+    let r := iterN2Max v0 v1 v2 v3 u0J1 u1 u2 u3 uTop
+    let c3 := mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0J1 u1 u2 u3
+    let uBase1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+    ∀ h,
+      (((loopIterPostN2Max sp (1 : Word) v0 v1 v2 v3 u0J1 u1 u2 u3 uTop **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal)) **
+        (((uBase2 + signExtend12 4064 ↦ₘ u4J2) **
+          (qAddr2 ↦ₘ q2)) **
+         (((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) +
+          signExtend12 0 ↦ₘ u0Orig0) **
+         ((sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q0Old)))) h) →
+      (((loopBodyN2MaxSkipJ0NormPreV4 sp (1 : Word)
+          ((1 : Word) <<< (3 : BitVec 6).toNat) uBase1 qAddr1 c3 r.1
+          r.2.2.2.2.1 v0 v1 v2 v3 u0Orig0 r.2.1 r.2.2.1 r.2.2.2.1
+          r.2.2.2.2.1 q0Old **
+          (sp + signExtend12 3968 ↦ₘ retMem) **
+          (sp + signExtend12 3960 ↦ₘ dMem) **
+          (sp + signExtend12 3952 ↦ₘ dloMem) **
+          (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+          (sp + signExtend12 3936 ↦ₘ scratchMem) **
+          (.x1 ↦ᵣ raVal)) **
+        (((uBase1 + signExtend12 4064 ↦ₘ r.2.2.2.2.2) **
+          (qAddr1 ↦ₘ r.1)) **
+         ((uBase2 + signExtend12 4064 ↦ₘ u4J2) **
+          (qAddr2 ↦ₘ q2)))) h) := by
   intro r c3 uBase1 qAddr1 h hp
   subst uBase1
   subst qAddr1

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNopSource.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNopSource.lean
@@ -665,4 +665,135 @@ theorem loopIterPostN2MaxScratchX1_j1_to_max_j0_pre
   rw [sepConj_assoc'] at hp
   xperm_hyp hp
 
+/-- Unified j=0 N2 call iteration over v4/no-NOP code, preserving concrete
+    `x1` and exposing the v4 scratch cell in the final loop postcondition. -/
+theorem divK_loop_body_n2_call_j0_exact_loopIterScratch_v4_noNop (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu : BitVec.ult u2 v1)
+    (hcarry2_nz : loopBodyN2CallAddbackCarry2NzV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 224 (base + loopBodyOff) (base + denormOff) (divCode_noNop_v4 base)
+      (loopBodyN2CallSkipJ0NormPreV4NoX1 sp
+        jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
+        retMem dMem dloMem scratchUn0 scratchMem ** (.x1 ↦ᵣ raVal))
+      (loopIterPostN2CallScratchNoX1 sp base (0 : Word)
+        (divKTrialCallV4QHat u2 u1 v1)
+        (divKTrialCallV4DLo v1)
+        (divKTrialCallV4Un0 u1)
+        (divKTrialCallV4ScratchOut u2 u1 v1 scratchMem)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop ** (.x1 ↦ᵣ raVal)) := by
+  by_cases hborrow :
+      BitVec.ult uTop
+        (mulsubN4_c3 (divKTrialCallV4QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3)
+  · have hborrow_nz : loopBodyN2CallAddbackBorrowV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+      simp [loopBodyN2CallAddbackBorrowV4, hborrow]
+    exact cpsTripleWithin_weaken
+      (fun h hp => hp)
+      (fun h hp => by
+        rw [loopBodyN2CallAddbackBeqJ0PostV4NoX1_eq_scratch] at hp
+        rw [loopIterPostN2CallScratchNoX1_addback hborrow] at hp
+        xperm_hyp hp)
+      (divK_loop_body_n2_call_addback_j0_beq_norm_v4_noNop_exact_x1
+        sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
+        retMem dMem dloMem scratchUn0 scratchMem raVal
+        halign hbltu hborrow_nz hcarry2_nz)
+  · have hborrow_zero :
+        loopBodyN2CallSkipJ0BorrowV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+      unfold loopBodyN2CallSkipJ0BorrowV4 mulsubN4NoBorrow
+      dsimp only
+      unfold mulsubN4_c3 at hborrow
+      rw [if_neg hborrow]
+    exact cpsTripleWithin_mono_nSteps (by decide) <|
+      cpsTripleWithin_weaken
+        (fun h hp => hp)
+        (fun h hp => by
+          rw [loopBodyN2CallSkipJ0PostV4NoX1_eq_scratch] at hp
+          rw [loopIterPostN2CallScratchNoX1_skip hborrow] at hp
+          xperm_hyp hp)
+        (divK_loop_body_n2_call_skip_j0_norm_v4_noNop_exact_x1
+          sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
+          retMem dMem dloMem scratchUn0 scratchMem raVal
+          halign hbltu hborrow_zero)
+
+/-- Unified j=0 N2 max iteration over v4/no-NOP code, preserving concrete
+    `x1` and carrying the v4 scratch cell as frame. -/
+theorem divK_loop_body_n2_max_j0_exact_loopIterScratch_v4_noNop (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hbltu : ¬BitVec.ult u2 v1)
+    (hcarry2_nz : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 152 (base + loopBodyOff) (base + denormOff) (divCode_noNop_v4 base)
+      ((loopBodyN2MaxSkipJ0NormPreV4 sp
+        jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal)))
+      ((loopIterPostN2Max sp (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal))) := by
+  by_cases hborrow :
+      BitVec.ult uTop
+        (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+  · have hborrow_nz :
+        (if BitVec.ult uTop
+          (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+         then (1 : Word) else 0) ≠ (0 : Word) := by
+      rw [if_pos hborrow]
+      decide
+    have J := divK_loop_body_n2_max_addback_j0_beq_norm_v4_noNop
+      sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld hbltu hcarry2_nz hborrow_nz
+    have Jf := cpsTripleWithin_frameR
+      ((sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
+       (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+       (sp + signExtend12 3936 ↦ₘ scratchMem) **
+       (.x1 ↦ᵣ raVal))
+      (by pcFree) J
+    exact cpsTripleWithin_weaken
+      (fun h hp => by xperm_hyp hp)
+      (fun h hp => by
+        rw [loopIterPostN2Max_addback hborrow] at hp
+        xperm_hyp hp)
+      Jf
+  · have hborrow_zero :
+        (if BitVec.ult uTop
+          (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+         then (1 : Word) else 0) = (0 : Word) := by
+      rw [if_neg hborrow]
+    have J := divK_loop_body_n2_max_skip_j0_norm_v4_noNop
+      sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld hbltu hborrow_zero
+    have Jf := cpsTripleWithin_frameR
+      ((sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
+       (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+       (sp + signExtend12 3936 ↦ₘ scratchMem) **
+       (.x1 ↦ᵣ raVal))
+      (by pcFree) J
+    exact cpsTripleWithin_mono_nSteps (by decide) <|
+      cpsTripleWithin_weaken
+        (fun h hp => by xperm_hyp hp)
+        (fun h hp => by
+          rw [loopIterPostN2Max_skip hborrow] at hp
+          xperm_hyp hp)
+        Jf
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNopSource.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNopSource.lean
@@ -396,4 +396,85 @@ theorem divK_loop_n2_max_call_from_source_exact_loopIterScratch_v4_noNop (sp bas
       v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q1Old q0Old raVal)
     J2 J1f
 
+/-- Full n=2 max×max prefix from the callable-ready v4 loop source,
+    preserving concrete `x1`, scratch, j=2 stored u4/q atoms, and the j=0
+    source atoms. -/
+theorem divK_loop_n2_max_max_from_source_exact_loopIterScratch_v4_noNop (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hbltu_2 : ¬BitVec.ult u2 v1)
+    (hcarry2_nz_2 : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hbltu_1 :
+      let r2 := iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      ¬BitVec.ult r2.2.2.1 v1)
+    (hcarry2_nz_1 :
+      let r2 := iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      isAddbackCarry2NzN2Max v0 v1 v2 v3
+        u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1) :
+    let r2 := iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    let uBase2 := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr2 := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
+    let uBase0 := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr0 := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
+    cpsTripleWithin (152 + 152) (base + loopBodyOff) (base + loopBodyOff)
+      (divCode_noNop_v4 base)
+      (loopN2PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      ((loopIterPostN2Max sp (1 : Word) v0 v1 v2 v3
+        u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1 **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal)) **
+        (((uBase2 + signExtend12 4064 ↦ₘ r2.2.2.2.2.2) **
+          (qAddr2 ↦ₘ r2.1)) **
+         (((uBase0 + signExtend12 0) ↦ₘ u0Orig0) **
+          (qAddr0 ↦ₘ q0Old)))) := by
+  intro r2 uBase2 qAddr2 uBase0 qAddr0
+  have J2 := divK_loop_n2_max_j2_from_source_exact_loopIterScratch_v4_noNop
+    sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old raVal
+    retMem dMem dloMem scratchUn0 scratchMem hbltu_2 hcarry2_nz_2
+  subst r2
+  subst uBase2
+  subst qAddr2
+  subst uBase0
+  subst qAddr0
+  have J1 := divK_loop_body_n2_max_j1_exact_loopIterScratch_v4_noNop sp base
+    (2 : Word)
+    ((2 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat)
+    (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+    (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).1
+    (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
+    v0 v1 v2 v3 u0Orig1
+    (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+    (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+    (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+    (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
+    q1Old raVal
+    retMem dMem dloMem scratchUn0 scratchMem
+    hbltu_1 hcarry2_nz_1
+  have J1f := cpsTripleWithin_frameR
+    ((((sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 4064 ↦ₘ
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.2) **
+      ((sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).1)) **
+     (((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 0 ↦ₘ u0Orig0) **
+     ((sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q0Old)))
+    (by pcFree) J1
+  exact cpsTripleWithin_seq_perm_same_cr
+    (loopIterPostN2MaxScratchX1_j2_to_max_j1_pre
+      sp retMem dMem dloMem scratchUn0 scratchMem
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q1Old q0Old raVal)
+    J2 J1f
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNopSource.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNopSource.lean
@@ -1,0 +1,112 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopSource
+
+  Source-level v4/no-NOP wrappers for the n=2 DIV loop.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNop
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- First n=2 call iteration from the callable-ready v4 loop source, preserving
+    concrete `x1` and carrying the j=1/j=0 source atoms as a frame. -/
+theorem divK_loop_n2_call_j2_from_source_exact_loopIterScratch_v4_noNop (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu : BitVec.ult u2 v1)
+    (hcarry2_nz : loopBodyN2CallAddbackCarry2NzV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 224 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop_v4 base)
+      (loopN2PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      ((loopIterPostN2CallScratchNoX1 sp base (2 : Word)
+        (divKTrialCallV4QHat u2 u1 v1)
+        (divKTrialCallV4DLo v1)
+        (divKTrialCallV4Un0 u1)
+        (divKTrialCallV4ScratchOut u2 u1 v1 scratchMem)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop ** (.x1 ↦ᵣ raVal)) **
+        ((((sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) +
+          signExtend12 0 ↦ₘ u0Orig1) **
+         ((sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q1Old)) **
+         (((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) +
+          signExtend12 0 ↦ₘ u0Orig0) **
+         ((sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q0Old)))) := by
+  have J2 := divK_loop_body_n2_call_j2_exact_loopIterScratch_v4_noNop sp base
+    jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop q2Old raVal
+    retMem dMem dloMem scratchUn0 scratchMem halign hbltu hcarry2_nz
+  have J2f := cpsTripleWithin_frameR
+    ((((sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 0 ↦ₘ u0Orig1) **
+     ((sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q1Old)) **
+     (((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 0 ↦ₘ u0Orig0) **
+     ((sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q0Old)))
+    (by pcFree) J2
+  exact cpsTripleWithin_weaken
+    (fun h hp => by
+      have hp' := loopN2PreWithScratchV4NoX1_to_call_j2_pre
+        sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old raVal
+        retMem dMem dloMem scratchUn0 scratchMem h hp
+      xperm_hyp hp')
+    (fun h hp => hp)
+    J2f
+
+/-- First n=2 max iteration from the callable-ready v4 loop source, preserving
+    concrete `x1`, scratch, and the j=1/j=0 source atoms as a frame. -/
+theorem divK_loop_n2_max_j2_from_source_exact_loopIterScratch_v4_noNop (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hbltu : ¬BitVec.ult u2 v1)
+    (hcarry2_nz : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 152 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop_v4 base)
+      (loopN2PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      ((loopIterPostN2Max sp (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal)) **
+        ((((sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) +
+          signExtend12 0 ↦ₘ u0Orig1) **
+         ((sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q1Old)) **
+         (((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) +
+          signExtend12 0 ↦ₘ u0Orig0) **
+         ((sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q0Old)))) := by
+  have J2 := divK_loop_body_n2_max_j2_exact_loopIterScratch_v4_noNop sp base
+    jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop q2Old raVal
+    retMem dMem dloMem scratchUn0 scratchMem hbltu hcarry2_nz
+  have J2f := cpsTripleWithin_frameR
+    ((((sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 0 ↦ₘ u0Orig1) **
+     ((sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q1Old)) **
+     (((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 0 ↦ₘ u0Orig0) **
+     ((sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q0Old)))
+    (by pcFree) J2
+  exact cpsTripleWithin_weaken
+    (fun h hp => by
+      have hp' := loopN2PreWithScratchV4NoX1_to_max_j2_pre
+        sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old raVal
+        retMem dMem dloMem scratchUn0 scratchMem h hp
+      xperm_hyp hp')
+    (fun h hp => hp)
+    J2f
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNopSource.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNopSource.lean
@@ -109,4 +109,106 @@ theorem divK_loop_n2_max_j2_from_source_exact_loopIterScratch_v4_noNop (sp base 
     (fun h hp => hp)
     J2f
 
+/-- Full n=2 call×call prefix from the callable-ready v4 loop source,
+    preserving concrete `x1` and carrying the j=2 stored u4/q atoms plus the
+    j=0 source atoms. -/
+theorem divK_loop_n2_call_call_from_source_exact_loopIterScratch_v4_noNop (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_2 : BitVec.ult u2 v1)
+    (hcarry2_nz_2 : loopBodyN2CallAddbackCarry2NzV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hbltu_1 :
+      BitVec.ult
+        (iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1 v1)
+    (hcarry2_nz_1 :
+      let r2 := iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      loopBodyN2CallAddbackCarry2NzV4 v0 v1 v2 v3
+        u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1) :
+    let r2 := iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    let qHat1 := divKTrialCallV4QHat r2.2.2.1 r2.2.1 v1
+    let dLo1 := divKTrialCallV4DLo v1
+    let divUn01 := divKTrialCallV4Un0 r2.2.1
+    let scratch2 := divKTrialCallV4ScratchOut u2 u1 v1 scratchMem
+    let scratch1 := divKTrialCallV4ScratchOut r2.2.2.1 r2.2.1 v1 scratch2
+    let uBase2 := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr2 := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
+    let uBase0 := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr0 := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
+    cpsTripleWithin (224 + 224) (base + loopBodyOff) (base + loopBodyOff)
+      (divCode_noNop_v4 base)
+      (loopN2PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      ((loopIterPostN2CallScratchNoX1 sp base (1 : Word)
+        qHat1 dLo1 divUn01 scratch1
+        v0 v1 v2 v3 u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1 **
+        (.x1 ↦ᵣ raVal)) **
+        (((uBase2 + signExtend12 4064 ↦ₘ r2.2.2.2.2.2) **
+          (qAddr2 ↦ₘ r2.1)) **
+         (((uBase0 + signExtend12 0) ↦ₘ u0Orig0) **
+          (qAddr0 ↦ₘ q0Old)))) := by
+  intro r2 qHat1 dLo1 divUn01 scratch2 scratch1 uBase2 qAddr2 uBase0 qAddr0
+  have J2 := divK_loop_n2_call_j2_from_source_exact_loopIterScratch_v4_noNop
+    sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old raVal
+    retMem dMem dloMem scratchUn0 scratchMem halign hbltu_2 hcarry2_nz_2
+  subst r2
+  subst qHat1
+  subst dLo1
+  subst divUn01
+  subst scratch2
+  subst scratch1
+  subst uBase2
+  subst qAddr2
+  subst uBase0
+  subst qAddr0
+  have J1 := divK_loop_body_n2_call_j1_exact_loopIterScratch_v4_noNop sp base
+    (2 : Word)
+    ((2 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat)
+    (mulsubN4_c3 (divKTrialCallV4QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3)
+    (iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).1
+    (iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
+    v0 v1 v2 v3 u0Orig1
+    (iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+    (iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+    (iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+    (iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
+    q1Old raVal
+    (base + div128CallRetOff) v1 (divKTrialCallV4DLo v1)
+    (divKTrialCallV4Un0 u1) (divKTrialCallV4ScratchOut u2 u1 v1 scratchMem)
+    halign hbltu_1 hcarry2_nz_1
+  have J1f := cpsTripleWithin_frameR
+    ((((sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 4064 ↦ₘ
+        (iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.2) **
+      ((sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ
+        (iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).1)) **
+     (((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 0 ↦ₘ u0Orig0) **
+     ((sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q0Old)))
+    (by pcFree) J1
+  exact cpsTripleWithin_seq_perm_same_cr
+    (loopIterPostN2CallScratchNoX1_j2_to_call_j1_pre
+      sp base (divKTrialCallV4QHat u2 u1 v1) (divKTrialCallV4DLo v1)
+      (divKTrialCallV4Un0 u1) (divKTrialCallV4ScratchOut u2 u1 v1 scratchMem)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q1Old q0Old raVal)
+    J2 J1f
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNopSource.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNopSource.lean
@@ -11,6 +11,7 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)
 
 /-- First n=2 call iteration from the callable-ready v4 loop source, preserving
     concrete `x1` and carrying the j=1/j=0 source atoms as a frame. -/
@@ -476,5 +477,192 @@ theorem divK_loop_n2_max_max_from_source_exact_loopIterScratch_v4_noNop (sp base
       sp retMem dMem dloMem scratchUn0 scratchMem
       v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q1Old q0Old raVal)
     J2 J1f
+
+/-- A j=1 call iteration postcondition with v4 scratch cells specializes to the
+    j=0 call-body precondition, retaining exact `x1` and j=1 carried u4/q
+    atoms as frame. -/
+theorem loopIterPostN2CallScratchNoX1_j1_to_call_j0_pre
+    (sp base qHat dLo divUn0 scratchOut : Word)
+    (v0 v1 v2 v3 u0J1 u1 u2 u3 uTop u0Orig0 q0Old raVal : Word) :
+    let r := iterWithDoubleAddback qHat v0 v1 v2 v3 u0J1 u1 u2 u3 uTop
+    let c3 := mulsubN4_c3 qHat v0 v1 v2 v3 u0J1 u1 u2 u3
+    let uBase1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+    ∀ h,
+      (((loopIterPostN2CallScratchNoX1 sp base (1 : Word)
+        qHat dLo divUn0 scratchOut v0 v1 v2 v3 u0J1 u1 u2 u3 uTop **
+        (.x1 ↦ᵣ raVal)) **
+        (((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) +
+          signExtend12 0 ↦ₘ u0Orig0) **
+         ((sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q0Old))) h) →
+      (((loopBodyN2CallSkipJ0NormPreV4NoX1 sp (1 : Word)
+          ((1 : Word) <<< (3 : BitVec 6).toNat) uBase1 qAddr1 c3 r.1
+          r.2.2.2.2.1 v0 v1 v2 v3 u0Orig0 r.2.1 r.2.2.1 r.2.2.2.1
+          r.2.2.2.2.1 q0Old
+          (base + div128CallRetOff) v1 dLo divUn0 scratchOut **
+          (.x1 ↦ᵣ raVal)) **
+        ((uBase1 + signExtend12 4064 ↦ₘ r.2.2.2.2.2) **
+         (qAddr1 ↦ₘ r.1))) h) := by
+  intro r c3 uBase1 qAddr1 h hp
+  subst uBase1
+  subst qAddr1
+  subst c3
+  subst r
+  delta loopIterPostN2CallScratchNoX1 loopExitPostN2 loopExitPost at hp
+  delta loopBodyN2CallSkipJ0NormPreV4NoX1 loopBodyN2MaxSkipJ0NormPreV4
+  unfold mulsubN4_c3
+  simp only [] at hp ⊢
+  have hj' := EvmAsm.Evm64.DivMod.AddrNorm.jpred_1
+  rw [hj', u_j1_0_eq_j0_4088, u_j1_4088_eq_j0_4080,
+      u_j1_4080_eq_j0_4072, u_j1_4072_eq_j0_4064] at hp
+  simp only [se12_32, se12_40, se12_48, se12_56,
+             u_base_off0_j0, u_base_off4088_j0, u_base_off4080_j0,
+             u_base_off4072_j0, u_base_off4064_j0, q_addr_j0] at hp ⊢
+  rw [sepConj_assoc'] at hp
+  xperm_hyp hp
+
+/-- A j=1 call iteration postcondition with v4 scratch cells specializes to the
+    j=0 max-body precondition, retaining scratch, exact `x1`, and j=1 carried
+    u4/q atoms as frame. -/
+theorem loopIterPostN2CallScratchNoX1_j1_to_max_j0_pre
+    (sp base qHat dLo divUn0 scratchOut : Word)
+    (v0 v1 v2 v3 u0J1 u1 u2 u3 uTop u0Orig0 q0Old raVal : Word) :
+    let r := iterWithDoubleAddback qHat v0 v1 v2 v3 u0J1 u1 u2 u3 uTop
+    let c3 := mulsubN4_c3 qHat v0 v1 v2 v3 u0J1 u1 u2 u3
+    let uBase1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+    ∀ h,
+      (((loopIterPostN2CallScratchNoX1 sp base (1 : Word)
+        qHat dLo divUn0 scratchOut v0 v1 v2 v3 u0J1 u1 u2 u3 uTop **
+        (.x1 ↦ᵣ raVal)) **
+        (((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) +
+          signExtend12 0 ↦ₘ u0Orig0) **
+         ((sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q0Old))) h) →
+      (((loopBodyN2MaxSkipJ0NormPreV4 sp (1 : Word)
+          ((1 : Word) <<< (3 : BitVec 6).toNat) uBase1 qAddr1 c3 r.1
+          r.2.2.2.2.1 v0 v1 v2 v3 u0Orig0 r.2.1 r.2.2.1 r.2.2.2.1
+          r.2.2.2.2.1 q0Old **
+          (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+          (sp + signExtend12 3960 ↦ₘ v1) **
+          (sp + signExtend12 3952 ↦ₘ dLo) **
+          (sp + signExtend12 3944 ↦ₘ divUn0) **
+          (sp + signExtend12 3936 ↦ₘ scratchOut) **
+          (.x1 ↦ᵣ raVal)) **
+        ((uBase1 + signExtend12 4064 ↦ₘ r.2.2.2.2.2) **
+         (qAddr1 ↦ₘ r.1))) h) := by
+  intro r c3 uBase1 qAddr1 h hp
+  subst uBase1
+  subst qAddr1
+  subst c3
+  subst r
+  delta loopIterPostN2CallScratchNoX1 loopExitPostN2 loopExitPost at hp
+  delta loopBodyN2MaxSkipJ0NormPreV4
+  unfold mulsubN4_c3
+  simp only [] at hp ⊢
+  have hj' := EvmAsm.Evm64.DivMod.AddrNorm.jpred_1
+  rw [hj', u_j1_0_eq_j0_4088, u_j1_4088_eq_j0_4080,
+      u_j1_4080_eq_j0_4072, u_j1_4072_eq_j0_4064] at hp
+  simp only [se12_32, se12_40, se12_48, se12_56,
+             u_base_off0_j0, u_base_off4088_j0, u_base_off4080_j0,
+             u_base_off4072_j0, u_base_off4064_j0, q_addr_j0] at hp ⊢
+  rw [sepConj_assoc'] at hp
+  xperm_hyp hp
+
+/-- A j=1 max iteration postcondition with v4 scratch cells specializes to the
+    j=0 call-body precondition, retaining exact `x1` and j=1 carried u4/q
+    atoms as frame. -/
+theorem loopIterPostN2MaxScratchX1_j1_to_call_j0_pre
+    (sp retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (v0 v1 v2 v3 u0J1 u1 u2 u3 uTop u0Orig0 q0Old raVal : Word) :
+    let r := iterN2Max v0 v1 v2 v3 u0J1 u1 u2 u3 uTop
+    let c3 := mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0J1 u1 u2 u3
+    let uBase1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+    ∀ h,
+      (((loopIterPostN2Max sp (1 : Word) v0 v1 v2 v3 u0J1 u1 u2 u3 uTop **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal)) **
+        (((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) +
+          signExtend12 0 ↦ₘ u0Orig0) **
+         ((sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q0Old))) h) →
+      (((loopBodyN2CallSkipJ0NormPreV4NoX1 sp (1 : Word)
+          ((1 : Word) <<< (3 : BitVec 6).toNat) uBase1 qAddr1 c3 r.1
+          r.2.2.2.2.1 v0 v1 v2 v3 u0Orig0 r.2.1 r.2.2.1 r.2.2.2.1
+          r.2.2.2.2.1 q0Old retMem dMem dloMem scratchUn0 scratchMem **
+          (.x1 ↦ᵣ raVal)) **
+        ((uBase1 + signExtend12 4064 ↦ₘ r.2.2.2.2.2) **
+         (qAddr1 ↦ₘ r.1))) h) := by
+  intro r c3 uBase1 qAddr1 h hp
+  subst uBase1
+  subst qAddr1
+  subst c3
+  subst r
+  delta loopIterPostN2Max loopExitPostN2 loopExitPost at hp
+  delta loopBodyN2CallSkipJ0NormPreV4NoX1 loopBodyN2MaxSkipJ0NormPreV4
+  unfold mulsubN4_c3
+  simp only [] at hp ⊢
+  have hj' := EvmAsm.Evm64.DivMod.AddrNorm.jpred_1
+  rw [hj', u_j1_0_eq_j0_4088, u_j1_4088_eq_j0_4080,
+      u_j1_4080_eq_j0_4072, u_j1_4072_eq_j0_4064] at hp
+  simp only [se12_32, se12_40, se12_48, se12_56,
+             u_base_off0_j0, u_base_off4088_j0, u_base_off4080_j0,
+             u_base_off4072_j0, u_base_off4064_j0, q_addr_j0] at hp ⊢
+  rw [sepConj_assoc'] at hp
+  xperm_hyp hp
+
+/-- A j=1 max iteration postcondition with v4 scratch cells specializes to the
+    j=0 max-body precondition, retaining exact `x1` and j=1 carried u4/q
+    atoms as frame. -/
+theorem loopIterPostN2MaxScratchX1_j1_to_max_j0_pre
+    (sp retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (v0 v1 v2 v3 u0J1 u1 u2 u3 uTop u0Orig0 q0Old raVal : Word) :
+    let r := iterN2Max v0 v1 v2 v3 u0J1 u1 u2 u3 uTop
+    let c3 := mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0J1 u1 u2 u3
+    let uBase1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+    ∀ h,
+      (((loopIterPostN2Max sp (1 : Word) v0 v1 v2 v3 u0J1 u1 u2 u3 uTop **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal)) **
+        (((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) +
+          signExtend12 0 ↦ₘ u0Orig0) **
+         ((sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q0Old))) h) →
+      (((loopBodyN2MaxSkipJ0NormPreV4 sp (1 : Word)
+          ((1 : Word) <<< (3 : BitVec 6).toNat) uBase1 qAddr1 c3 r.1
+          r.2.2.2.2.1 v0 v1 v2 v3 u0Orig0 r.2.1 r.2.2.1 r.2.2.2.1
+          r.2.2.2.2.1 q0Old **
+          (sp + signExtend12 3968 ↦ₘ retMem) **
+          (sp + signExtend12 3960 ↦ₘ dMem) **
+          (sp + signExtend12 3952 ↦ₘ dloMem) **
+          (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+          (sp + signExtend12 3936 ↦ₘ scratchMem) **
+          (.x1 ↦ᵣ raVal)) **
+        ((uBase1 + signExtend12 4064 ↦ₘ r.2.2.2.2.2) **
+         (qAddr1 ↦ₘ r.1))) h) := by
+  intro r c3 uBase1 qAddr1 h hp
+  subst uBase1
+  subst qAddr1
+  subst c3
+  subst r
+  delta loopIterPostN2Max loopExitPostN2 loopExitPost at hp
+  delta loopBodyN2MaxSkipJ0NormPreV4
+  unfold mulsubN4_c3
+  simp only [] at hp ⊢
+  have hj' := EvmAsm.Evm64.DivMod.AddrNorm.jpred_1
+  rw [hj', u_j1_0_eq_j0_4088, u_j1_4088_eq_j0_4080,
+      u_j1_4080_eq_j0_4072, u_j1_4072_eq_j0_4064] at hp
+  simp only [se12_32, se12_40, se12_48, se12_56,
+             u_base_off0_j0, u_base_off4088_j0, u_base_off4080_j0,
+             u_base_off4072_j0, u_base_off4064_j0, q_addr_j0] at hp ⊢
+  rw [sepConj_assoc'] at hp
+  xperm_hyp hp
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNopSource.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNopSource.lean
@@ -522,6 +522,54 @@ theorem loopIterPostN2CallScratchNoX1_j1_to_call_j0_pre
   xperm_hyp hp
 
 /-- A j=1 call iteration postcondition with v4 scratch cells specializes to the
+    j=0 call-body precondition while retaining both the j=1 and j=2 carried
+    u4/q atoms as frame. -/
+theorem loopIterPostN2CallScratchNoX1_j1_to_call_j0_pre_with_j2_frame
+    (sp base qHat dLo divUn0 scratchOut : Word)
+    (v0 v1 v2 v3 u0J1 u1 u2 u3 uTop u0Orig0 q0Old raVal : Word)
+    (uBase2 qAddr2 u4J2 q2 : Word) :
+    let r := iterWithDoubleAddback qHat v0 v1 v2 v3 u0J1 u1 u2 u3 uTop
+    let c3 := mulsubN4_c3 qHat v0 v1 v2 v3 u0J1 u1 u2 u3
+    let uBase1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+    ∀ h,
+      (((loopIterPostN2CallScratchNoX1 sp base (1 : Word)
+        qHat dLo divUn0 scratchOut v0 v1 v2 v3 u0J1 u1 u2 u3 uTop **
+        (.x1 ↦ᵣ raVal)) **
+        (((uBase2 + signExtend12 4064 ↦ₘ u4J2) **
+          (qAddr2 ↦ₘ q2)) **
+         (((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) +
+          signExtend12 0 ↦ₘ u0Orig0) **
+         ((sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q0Old)))) h) →
+      (((loopBodyN2CallSkipJ0NormPreV4NoX1 sp (1 : Word)
+          ((1 : Word) <<< (3 : BitVec 6).toNat) uBase1 qAddr1 c3 r.1
+          r.2.2.2.2.1 v0 v1 v2 v3 u0Orig0 r.2.1 r.2.2.1 r.2.2.2.1
+          r.2.2.2.2.1 q0Old
+          (base + div128CallRetOff) v1 dLo divUn0 scratchOut **
+          (.x1 ↦ᵣ raVal)) **
+        (((uBase1 + signExtend12 4064 ↦ₘ r.2.2.2.2.2) **
+          (qAddr1 ↦ₘ r.1)) **
+         ((uBase2 + signExtend12 4064 ↦ₘ u4J2) **
+          (qAddr2 ↦ₘ q2)))) h) := by
+  intro r c3 uBase1 qAddr1 h hp
+  subst uBase1
+  subst qAddr1
+  subst c3
+  subst r
+  delta loopIterPostN2CallScratchNoX1 loopExitPostN2 loopExitPost at hp
+  delta loopBodyN2CallSkipJ0NormPreV4NoX1 loopBodyN2MaxSkipJ0NormPreV4
+  unfold mulsubN4_c3
+  simp only [] at hp ⊢
+  have hj' := EvmAsm.Evm64.DivMod.AddrNorm.jpred_1
+  rw [hj', u_j1_0_eq_j0_4088, u_j1_4088_eq_j0_4080,
+      u_j1_4080_eq_j0_4072, u_j1_4072_eq_j0_4064] at hp
+  simp only [se12_32, se12_40, se12_48, se12_56,
+             u_base_off0_j0, u_base_off4088_j0, u_base_off4080_j0,
+             u_base_off4072_j0, u_base_off4064_j0, q_addr_j0] at hp ⊢
+  rw [sepConj_assoc'] at hp
+  xperm_hyp hp
+
+/-- A j=1 call iteration postcondition with v4 scratch cells specializes to the
     j=0 max-body precondition, retaining scratch, exact `x1`, and j=1 carried
     u4/q atoms as frame. -/
 theorem loopIterPostN2CallScratchNoX1_j1_to_max_j0_pre

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V4.lean
@@ -1,4 +1,5 @@
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V4NoNop
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V4NoNopPreloop
 import EvmAsm.Evm64.DivMod.Compose.V4Code
 
 namespace EvmAsm.Evm64
@@ -123,5 +124,16 @@ theorem divK_loop_body_n3_call_addback_jgt0_beq_norm_v4 (j sp base : Word)
       v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
       retMem dMem dloMem scratchUn0 scratchMem
       halign hbltu hborrow hcarry2_nz)
+
+/-- Lift the n=3 exact-x1/scratch v4 preloop+loop path from the no-NOP body
+    to the full `divCode_v4` dispatcher bundle. -/
+theorem fullDivN3_preloop_loop_unified_exact_x1_scratch_v4
+    {P Q : Assertion} (base : Word)
+    (h :
+      cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 448)
+        base (base + denormOff) (divCode_noNop_v4 base) P Q) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 448)
+      base (base + denormOff) (divCode_v4 base) P Q := by
+  exact cpsTripleWithin_divCode_noNop_v4_to_divCode_v4 h
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V4.lean
@@ -138,6 +138,83 @@ theorem fullDivN3_preloop_loop_unified_exact_x1_scratch_v4
       base (base + denormOff) (divCode_v4 base) P Q := by
   exact cpsTripleWithin_divCode_noNop_v4_to_divCode_v4 h
 
+@[irreducible]
+def iterN3V4 (bltu : Bool) (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
+    Word × Word × Word × Word × Word × Word :=
+  if bltu then
+    iterWithDoubleAddback (divKTrialCallV4QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  else
+    iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+
+@[irreducible]
+def fullDivN3R1V4 (bltu_1 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    Word × Word × Word × Word × Word × Word :=
+  let v := fullDivN3NormV b0 b1 b2 b3
+  let u := fullDivN3NormU a0 a1 a2 a3 b2
+  iterN3V4 bltu_1 v.1 v.2.1 v.2.2.1 v.2.2.2
+    u.2.1 u.2.2.1 u.2.2.2.1 u.2.2.2.2 (0 : Word)
+
+@[irreducible]
+def fullDivN3R0V4 (bltu_1 bltu_0 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    Word × Word × Word × Word × Word × Word :=
+  let v := fullDivN3NormV b0 b1 b2 b3
+  let u := fullDivN3NormU a0 a1 a2 a3 b2
+  let r1 := fullDivN3R1V4 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+  iterN3V4 bltu_0 v.1 v.2.1 v.2.2.1 v.2.2.2 u.1
+    r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+
+@[irreducible]
+def fullDivN3C3V4 (bltu_1 bltu_0 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    Word :=
+  let v := fullDivN3NormV b0 b1 b2 b3
+  let u := fullDivN3NormU a0 a1 a2 a3 b2
+  let r1 := fullDivN3R1V4 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+  if bltu_0 then
+    (mulsubN4 (divKTrialCallV4QHat r1.2.2.2.1 r1.2.2.1 v.2.2.1)
+      v.1 v.2.1 v.2.2.1 v.2.2.2 u.1 r1.2.1 r1.2.2.1 r1.2.2.2.1).2.2.2.2
+  else
+    (mulsubN4 (signExtend12 4095 : Word)
+      v.1 v.2.1 v.2.2.1 v.2.2.2 u.1 r1.2.1 r1.2.2.1 r1.2.2.2.1).2.2.2.2
+
+/-- N3 denorm precondition whose call-path arithmetic matches the v4 callable
+    trial-division qhat, rather than the older `div128Quot` model. -/
+@[irreducible]
+def fullDivN3DenormPreV4 (bltu_1 bltu_0 : Bool)
+    (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
+  let shift := fullDivN3Shift b2
+  let v := fullDivN3NormV b0 b1 b2 b3
+  let r1 := fullDivN3R1V4 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+  let r0 := fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+  ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ sp + signExtend12 4056) ** (.x0 ↦ᵣ (0 : Word)) **
+   (.x5 ↦ᵣ (0 : Word)) ** (.x7 ↦ᵣ sp + signExtend12 4088) **
+   (.x2 ↦ᵣ r0.2.2.2.2.1) **
+   (.x10 ↦ᵣ fullDivN3C3V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3) **
+   ((sp + signExtend12 3992) ↦ₘ shift) **
+   ((sp + signExtend12 4056) ↦ₘ r0.2.1) **
+   ((sp + signExtend12 4048) ↦ₘ r0.2.2.1) **
+   ((sp + signExtend12 4040) ↦ₘ r0.2.2.2.1) **
+   ((sp + signExtend12 4032) ↦ₘ r0.2.2.2.2.1) **
+   ((sp + signExtend12 4088) ↦ₘ r0.1) **
+   ((sp + signExtend12 4080) ↦ₘ r1.1) **
+   ((sp + signExtend12 4072) ↦ₘ (0 : Word)) **
+   ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+   ((sp + signExtend12 32) ↦ₘ v.1) **
+   ((sp + signExtend12 40) ↦ₘ v.2.1) **
+   ((sp + signExtend12 48) ↦ₘ v.2.2.1) **
+   ((sp + signExtend12 56) ↦ₘ v.2.2.2))
+
+/-- N3 denorm postcondition paired with `fullDivN3DenormPreV4`. -/
+@[irreducible]
+def fullDivN3DenormPostV4 (bltu_1 bltu_0 : Bool)
+    (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
+  let shift := fullDivN3Shift b2
+  let r1 := fullDivN3R1V4 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+  let r0 := fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+  denormDivPost sp shift r0.2.1 r0.2.2.1 r0.2.2.2.1 r0.2.2.2.2.1
+    r0.1 r1.1 (0 : Word) (0 : Word) **
+  ((sp + signExtend12 3992) ↦ₘ shift)
+
 /-- N3 denormalization and DIV epilogue over the v4/no-NOP dispatcher body. -/
 theorem evm_div_n3_denorm_epilogue_bundled_spec_v4_noNop (bltu_1 bltu_0 : Bool)
     (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word)
@@ -164,6 +241,37 @@ theorem evm_div_n3_denorm_epilogue_bundled_spec_v4_noNop (bltu_1 bltu_0 : Bool)
     (fun h hq => by
       subst shift; subst r1; subst r0
       delta fullDivN3DenormPost
+      xperm_hyp hq)
+    h
+
+/-- N3 denormalization and DIV epilogue over the v4/no-NOP dispatcher body,
+    using the v4 callable-trial final computation family. -/
+theorem evm_div_n3_denorm_epilogue_bundled_spec_v4_noNop_v4Final
+    (bltu_1 bltu_0 : Bool)
+    (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hshift_nz : fullDivN3Shift b2 ≠ 0) :
+    cpsTripleWithin (2 + 23 + 10) (base + denormOff) (base + nopOff) (divCode_noNop_v4 base)
+      (fullDivN3DenormPreV4 bltu_1 bltu_0 sp a0 a1 a2 a3 b0 b1 b2 b3)
+      (fullDivN3DenormPostV4 bltu_1 bltu_0 sp a0 a1 a2 a3 b0 b1 b2 b3) := by
+  let shift := fullDivN3Shift b2
+  let v := fullDivN3NormV b0 b1 b2 b3
+  let r1 := fullDivN3R1V4 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+  let r0 := fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+  let c3 := fullDivN3C3V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+  have h := evm_div_preamble_denorm_epilogue_spec_v4_noNop sp base
+    r0.2.1 r0.2.2.1 r0.2.2.2.1 r0.2.2.2.2.1 shift
+    r0.2.2.2.2.1 (0 : Word) (sp + signExtend12 4056) (sp + signExtend12 4088)
+    c3 r0.1 r1.1 (0 : Word) (0 : Word)
+    v.1 v.2.1 v.2.2.1 v.2.2.2 hshift_nz
+  exact cpsTripleWithin_weaken
+    (fun h hp => by
+      subst shift; subst v; subst r1; subst r0; subst c3
+      delta fullDivN3DenormPreV4 at hp
+      simp only [se12_32, se12_40, se12_48, se12_56] at hp
+      xperm_hyp hp)
+    (fun h hq => by
+      subst shift; subst r1; subst r0
+      delta fullDivN3DenormPostV4
       xperm_hyp hq)
     h
 

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V4.lean
@@ -477,6 +477,140 @@ theorem loopN3UnifiedPostV4NoX1_to_fullDivN3DenormPreV4_frame_FT
   subst qHat
   xperm_hyp hp
 
+theorem loopN3UnifiedPostV4NoX1_to_fullDivN3DenormPreV4_frame_TF
+    (sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0
+      scratchMem raVal : Word)
+    (h : PartialState)
+    (hp :
+      ((loopN3UnifiedPostV4NoX1 true false sp base
+        (fullDivN3NormV b0 b1 b2 b3).1
+        (fullDivN3NormV b0 b1 b2 b3).2.1
+        (fullDivN3NormV b0 b1 b2 b3).2.2.1
+        (fullDivN3NormV b0 b1 b2 b3).2.2.2
+        (fullDivN3NormU a0 a1 a2 a3 b2).2.1
+        (fullDivN3NormU a0 a1 a2 a3 b2).2.2.1
+        (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.1
+        (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.2
+        (0 : Word)
+        (fullDivN3NormU a0 a1 a2 a3 b2).1
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal)) **
+       (((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+        ((sp + signExtend12 4072) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 3992) ↦ₘ (clzResult b2).1))) h) :
+    (fullDivN3DenormPreV4 true false sp a0 a1 a2 a3 b0 b1 b2 b3 **
+     fullDivN3FrameNoX1V4 true false sp base a0 a1 a2 a3 b0 b1 b2 b3
+       retMem dMem dloMem scratchUn0 **
+     ((sp + signExtend12 3936) ↦ₘ
+       fullDivN3ScratchMemV4 true false a0 a1 a2 a3 b0 b1 b2 b3 scratchMem) **
+     (.x1 ↦ᵣ raVal)) h := by
+  delta loopN3UnifiedPostV4NoX1 loopIterPostN3Max at hp
+  simp (config := { decide := true }) only [] at hp
+  simp (config := { decide := true }) only
+    [loopExitPostN3_j0_eq, n3_ub1_off4064, n3_qa1,
+      se12_32, se12_40, se12_48, se12_56] at hp
+  delta fullDivN3Shift fullDivN3AntiShift fullDivN3NormV fullDivN3NormU at hp
+  simp (config := { decide := true }) only [] at hp
+  delta fullDivN3DenormPreV4 fullDivN3FrameNoX1V4 fullDivN3ScratchNoX1V4
+    fullDivN3ScratchMemV4 fullDivN3Shift fullDivN3AntiShift fullDivN3NormV
+    fullDivN3NormU fullDivN3R1V4 fullDivN3R0V4 fullDivN3C3V4 iterN3V4
+  simp (config := { decide := true }) only
+    [ite_false, ite_true, se12_32, se12_40, se12_48, se12_56]
+  set shift := (clzResult b2).1 with hshift
+  set antiShift := (signExtend12 (0 : BitVec 12) - shift) with hantiShift
+  set v0 := b0 <<< (shift.toNat % 64) with hv0
+  set v1 := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64)) with hv1
+  set v2 := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64)) with hv2
+  set v3 := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64)) with hv3
+  set u0 := a0 <<< (shift.toNat % 64) with hu0
+  set u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64)) with hu1
+  set u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64)) with hu2
+  set u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64)) with hu3
+  set u4 := a3 >>> (antiShift.toNat % 64) with hu4
+  set qHat1 := divKTrialCallV4QHat u4 u3 v2 with hqHat1
+  set r1 := iterWithDoubleAddback qHat1 v0 v1 v2 v3 u1 u2 u3 u4 (0 : Word) with hr1
+  set r0 := iterN3Max v0 v1 v2 v3 u0 r1.2.1 r1.2.2.1 r1.2.2.2.1
+    r1.2.2.2.2.1 with hr0
+  set c3 := (mulsubN4 (signExtend12 4095 : Word) v0 v1 v2 v3 u0
+    r1.2.1 r1.2.2.1 r1.2.2.2.1).2.2.2.2 with hc3
+  subst c3
+  subst r0
+  subst r1
+  subst qHat1
+  xperm_hyp hp
+
+theorem loopN3UnifiedPostV4NoX1_to_fullDivN3DenormPreV4_frame_TT
+    (sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0
+      scratchMem raVal : Word)
+    (h : PartialState)
+    (hp :
+      ((loopN3UnifiedPostV4NoX1 true true sp base
+        (fullDivN3NormV b0 b1 b2 b3).1
+        (fullDivN3NormV b0 b1 b2 b3).2.1
+        (fullDivN3NormV b0 b1 b2 b3).2.2.1
+        (fullDivN3NormV b0 b1 b2 b3).2.2.2
+        (fullDivN3NormU a0 a1 a2 a3 b2).2.1
+        (fullDivN3NormU a0 a1 a2 a3 b2).2.2.1
+        (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.1
+        (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.2
+        (0 : Word)
+        (fullDivN3NormU a0 a1 a2 a3 b2).1
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal)) **
+       (((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+        ((sp + signExtend12 4072) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 3992) ↦ₘ (clzResult b2).1))) h) :
+    (fullDivN3DenormPreV4 true true sp a0 a1 a2 a3 b0 b1 b2 b3 **
+     fullDivN3FrameNoX1V4 true true sp base a0 a1 a2 a3 b0 b1 b2 b3
+       retMem dMem dloMem scratchUn0 **
+     ((sp + signExtend12 3936) ↦ₘ
+       fullDivN3ScratchMemV4 true true a0 a1 a2 a3 b0 b1 b2 b3 scratchMem) **
+     (.x1 ↦ᵣ raVal)) h := by
+  delta loopN3UnifiedPostV4NoX1 loopIterPostN3CallScratchNoX1 at hp
+  simp (config := { decide := true }) only [] at hp
+  simp (config := { decide := true }) only
+    [loopExitPostN3_j0_eq, n3_ub1_off4064, n3_qa1,
+      se12_32, se12_40, se12_48, se12_56] at hp
+  delta fullDivN3Shift fullDivN3AntiShift fullDivN3NormV fullDivN3NormU at hp
+  simp (config := { decide := true }) only [] at hp
+  delta fullDivN3DenormPreV4 fullDivN3FrameNoX1V4 fullDivN3ScratchNoX1V4
+    fullDivN3ScratchMemV4 fullDivN3Shift fullDivN3AntiShift fullDivN3NormV
+    fullDivN3NormU fullDivN3R1V4 fullDivN3R0V4 fullDivN3C3V4 iterN3V4
+  simp (config := { decide := true }) only
+    [ite_true, se12_32, se12_40, se12_48, se12_56]
+  set shift := (clzResult b2).1 with hshift
+  set antiShift := (signExtend12 (0 : BitVec 12) - shift) with hantiShift
+  set v0 := b0 <<< (shift.toNat % 64) with hv0
+  set v1 := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64)) with hv1
+  set v2 := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64)) with hv2
+  set v3 := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64)) with hv3
+  set u0 := a0 <<< (shift.toNat % 64) with hu0
+  set u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64)) with hu1
+  set u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64)) with hu2
+  set u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64)) with hu3
+  set u4 := a3 >>> (antiShift.toNat % 64) with hu4
+  set qHat1 := divKTrialCallV4QHat u4 u3 v2 with hqHat1
+  set r1 := iterWithDoubleAddback qHat1 v0 v1 v2 v3 u1 u2 u3 u4 (0 : Word) with hr1
+  set qHat0 := divKTrialCallV4QHat r1.2.2.2.1 r1.2.2.1 v2 with hqHat0
+  set r0 := iterWithDoubleAddback qHat0 v0 v1 v2 v3 u0 r1.2.1 r1.2.2.1
+    r1.2.2.2.1 r1.2.2.2.2.1 with hr0
+  set c3 := (mulsubN4 qHat0 v0 v1 v2 v3 u0 r1.2.1 r1.2.2.1
+    r1.2.2.2.1).2.2.2.2 with hc3
+  subst c3
+  subst r0
+  subst qHat0
+  subst r1
+  subst qHat1
+  xperm_hyp hp
+
 /-- N3 denormalization and DIV epilogue over v4/no-NOP, preserving exact caller
     `x1` and carrying the v4 div128 scratch cell as frame. -/
 theorem evm_div_n3_denorm_epilogue_bundled_spec_v4_noNop_exact_x1_scratch_frame

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V4.lean
@@ -1,10 +1,12 @@
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V4NoNop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V4NoNopPreloop
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3PcFree
 import EvmAsm.Evm64.DivMod.Compose.V4Code
 
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)
 
 /-- Loop body n=3, max+skip, j=0 over the full `divCode_v4` bundle. -/
 theorem divK_loop_body_n3_max_skip_j0_norm_v4 (sp base : Word)
@@ -135,5 +137,67 @@ theorem fullDivN3_preloop_loop_unified_exact_x1_scratch_v4
     cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 448)
       base (base + denormOff) (divCode_v4 base) P Q := by
   exact cpsTripleWithin_divCode_noNop_v4_to_divCode_v4 h
+
+/-- N3 denormalization and DIV epilogue over the v4/no-NOP dispatcher body. -/
+theorem evm_div_n3_denorm_epilogue_bundled_spec_v4_noNop (bltu_1 bltu_0 : Bool)
+    (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hshift_nz : fullDivN3Shift b2 ≠ 0) :
+    cpsTripleWithin (2 + 23 + 10) (base + denormOff) (base + nopOff) (divCode_noNop_v4 base)
+      (fullDivN3DenormPre bltu_1 bltu_0 sp a0 a1 a2 a3 b0 b1 b2 b3)
+      (fullDivN3DenormPost bltu_1 bltu_0 sp a0 a1 a2 a3 b0 b1 b2 b3) := by
+  let shift := fullDivN3Shift b2
+  let v := fullDivN3NormV b0 b1 b2 b3
+  let r1 := fullDivN3R1 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+  let r0 := fullDivN3R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+  let c3 := fullDivN3C3 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+  have h := evm_div_preamble_denorm_epilogue_spec_v4_noNop sp base
+    r0.2.1 r0.2.2.1 r0.2.2.2.1 r0.2.2.2.2.1 shift
+    r0.2.2.2.2.1 (0 : Word) (sp + signExtend12 4056) (sp + signExtend12 4088)
+    c3 r0.1 r1.1 (0 : Word) (0 : Word)
+    v.1 v.2.1 v.2.2.1 v.2.2.2 hshift_nz
+  exact cpsTripleWithin_weaken
+    (fun h hp => by
+      subst shift; subst v; subst r1; subst r0; subst c3
+      delta fullDivN3DenormPre at hp
+      simp only [se12_32, se12_40, se12_48, se12_56] at hp
+      xperm_hyp hp)
+    (fun h hq => by
+      subst shift; subst r1; subst r0
+      delta fullDivN3DenormPost
+      xperm_hyp hq)
+    h
+
+/-- N3 denormalization and DIV epilogue over v4/no-NOP, preserving exact caller
+    `x1` and carrying the v4 div128 scratch cell as frame. -/
+theorem evm_div_n3_denorm_epilogue_bundled_spec_v4_noNop_exact_x1_scratch_frame
+    (bltu_1 bltu_0 : Bool)
+    (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem raVal : Word)
+    (hshift_nz : fullDivN3Shift b2 ≠ 0) :
+    cpsTripleWithin (2 + 23 + 10) (base + denormOff) (base + nopOff)
+      (divCode_noNop_v4 base)
+      (fullDivN3DenormPre bltu_1 bltu_0 sp a0 a1 a2 a3 b0 b1 b2 b3 **
+       fullDivN3FrameNoX1 bltu_1 bltu_0 sp base
+         a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem) **
+       (.x1 ↦ᵣ raVal))
+      (fullDivN3UnifiedPostNoX1 bltu_1 bltu_0 sp base
+        a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem) **
+       (.x1 ↦ᵣ raVal)) := by
+  have hDenorm := evm_div_n3_denorm_epilogue_bundled_spec_v4_noNop
+    bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3 hshift_nz
+  have hFramed := cpsTripleWithin_frameR
+    (fullDivN3FrameNoX1 bltu_1 bltu_0 sp base
+     a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 **
+     ((sp + signExtend12 3936) ↦ₘ scratchMem) **
+     (.x1 ↦ᵣ raVal))
+    (by pcFree) hDenorm
+  exact cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by
+      delta fullDivN3UnifiedPostNoX1 fullDivN3DenormPost at hq ⊢
+      xperm_hyp hq)
+    hFramed
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V4.lean
@@ -215,6 +215,65 @@ def fullDivN3DenormPostV4 (bltu_1 bltu_0 : Bool)
     r0.1 r1.1 (0 : Word) (0 : Word) **
   ((sp + signExtend12 3992) ↦ₘ shift)
 
+@[irreducible]
+def fullDivN3ScratchNoX1V4 (bltu_1 bltu_0 : Bool)
+    (sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 : Word) :
+    Assertion :=
+  let v := fullDivN3NormV b0 b1 b2 b3
+  let u := fullDivN3NormU a0 a1 a2 a3 b2
+  let r1 := fullDivN3R1V4 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+  let scratchRet1 := if bltu_1 then (base + div128CallRetOff) else retMem
+  let scratchD1 := if bltu_1 then v.2.2.1 else dMem
+  let scratchDLo1 := if bltu_1 then divKTrialCallV4DLo v.2.2.1 else dloMem
+  let scratchUn01 := if bltu_1 then divKTrialCallV4Un0 u.2.2.2.1 else scratchUn0
+  (sp + signExtend12 3968 ↦ₘ (if bltu_0 then (base + div128CallRetOff) else scratchRet1)) **
+  (sp + signExtend12 3960 ↦ₘ (if bltu_0 then v.2.2.1 else scratchD1)) **
+  (sp + signExtend12 3952 ↦ₘ (if bltu_0 then divKTrialCallV4DLo v.2.2.1 else scratchDLo1)) **
+  (sp + signExtend12 3944 ↦ₘ (if bltu_0 then divKTrialCallV4Un0 r1.2.2.1 else scratchUn01))
+
+@[irreducible]
+def fullDivN3ScratchMemV4 (bltu_1 bltu_0 : Bool)
+    (a0 a1 a2 a3 b0 b1 b2 b3 scratchMem : Word) : Word :=
+  let v := fullDivN3NormV b0 b1 b2 b3
+  let u := fullDivN3NormU a0 a1 a2 a3 b2
+  let scratch1 := if bltu_1 then
+      divKTrialCallV4ScratchOut u.2.2.2.2 u.2.2.2.1 v.2.2.1 scratchMem
+    else
+      scratchMem
+  let r1 := fullDivN3R1V4 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+  if bltu_0 then
+    divKTrialCallV4ScratchOut r1.2.2.2.1 r1.2.2.1 v.2.2.1 scratch1
+  else
+    scratch1
+
+@[irreducible]
+def fullDivN3FrameNoX1V4 (bltu_1 bltu_0 : Bool)
+    (sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 : Word) :
+    Assertion :=
+  let r1 := fullDivN3R1V4 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+  let r0 := fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+  ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+  ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+  ((sp + signExtend12 4024) ↦ₘ r0.2.2.2.2.2) **
+  ((sp + signExtend12 4016) ↦ₘ r1.2.2.2.2.2) **
+  ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+  ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+  (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
+  (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
+  (.x9 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ r0.1) **
+  fullDivN3ScratchNoX1V4 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
+    retMem dMem dloMem scratchUn0
+
+@[irreducible]
+def fullDivN3UnifiedPostNoX1V4 (bltu_1 bltu_0 : Bool)
+    (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word) : Assertion :=
+  fullDivN3DenormPostV4 bltu_1 bltu_0 sp a0 a1 a2 a3 b0 b1 b2 b3 **
+  fullDivN3FrameNoX1V4 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
+    retMem dMem dloMem scratchUn0 **
+  ((sp + signExtend12 3936) ↦ₘ
+    fullDivN3ScratchMemV4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3 scratchMem)
+
 /-- N3 denormalization and DIV epilogue over the v4/no-NOP dispatcher body. -/
 theorem evm_div_n3_denorm_epilogue_bundled_spec_v4_noNop (bltu_1 bltu_0 : Bool)
     (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word)
@@ -274,6 +333,149 @@ theorem evm_div_n3_denorm_epilogue_bundled_spec_v4_noNop_v4Final
       delta fullDivN3DenormPostV4
       xperm_hyp hq)
     h
+
+/-- N3 denormalization and DIV epilogue over v4/no-NOP for the v4 final
+    computation family, preserving exact caller `x1` and the final v4 div128
+    scratch cell. -/
+theorem evm_div_n3_denorm_epilogue_bundled_spec_v4_noNop_v4Final_exact_x1_scratch_frame
+    (bltu_1 bltu_0 : Bool)
+    (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem raVal : Word)
+    (hshift_nz : fullDivN3Shift b2 ≠ 0) :
+    cpsTripleWithin (2 + 23 + 10) (base + denormOff) (base + nopOff)
+      (divCode_noNop_v4 base)
+      (fullDivN3DenormPreV4 bltu_1 bltu_0 sp a0 a1 a2 a3 b0 b1 b2 b3 **
+       fullDivN3FrameNoX1V4 bltu_1 bltu_0 sp base
+         a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ
+         fullDivN3ScratchMemV4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3 scratchMem) **
+       (.x1 ↦ᵣ raVal))
+      (fullDivN3UnifiedPostNoX1V4 bltu_1 bltu_0 sp base
+        a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 scratchMem **
+       (.x1 ↦ᵣ raVal)) := by
+  have hDenorm := evm_div_n3_denorm_epilogue_bundled_spec_v4_noNop_v4Final
+    bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3 hshift_nz
+  have hFramed := cpsTripleWithin_frameR
+    (fullDivN3FrameNoX1V4 bltu_1 bltu_0 sp base
+     a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 **
+     ((sp + signExtend12 3936) ↦ₘ
+       fullDivN3ScratchMemV4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3 scratchMem) **
+     (.x1 ↦ᵣ raVal))
+    (by
+      delta fullDivN3FrameNoX1V4 fullDivN3ScratchNoX1V4
+      pcFree) hDenorm
+  exact cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by
+      delta fullDivN3UnifiedPostNoX1V4
+      xperm_hyp hq)
+    hFramed
+
+theorem loopN3UnifiedPostV4NoX1_to_fullDivN3DenormPreV4_frame_FF
+    (sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0
+      scratchMem raVal : Word)
+    (h : PartialState)
+    (hp :
+      ((loopN3UnifiedPostV4NoX1 false false sp base
+        (fullDivN3NormV b0 b1 b2 b3).1
+        (fullDivN3NormV b0 b1 b2 b3).2.1
+        (fullDivN3NormV b0 b1 b2 b3).2.2.1
+        (fullDivN3NormV b0 b1 b2 b3).2.2.2
+        (fullDivN3NormU a0 a1 a2 a3 b2).2.1
+        (fullDivN3NormU a0 a1 a2 a3 b2).2.2.1
+        (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.1
+        (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.2
+        (0 : Word)
+        (fullDivN3NormU a0 a1 a2 a3 b2).1
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal)) **
+       (((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+        ((sp + signExtend12 4072) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 3992) ↦ₘ (clzResult b2).1))) h) :
+    (fullDivN3DenormPreV4 false false sp a0 a1 a2 a3 b0 b1 b2 b3 **
+     fullDivN3FrameNoX1V4 false false sp base a0 a1 a2 a3 b0 b1 b2 b3
+       retMem dMem dloMem scratchUn0 **
+     ((sp + signExtend12 3936) ↦ₘ
+       fullDivN3ScratchMemV4 false false a0 a1 a2 a3 b0 b1 b2 b3 scratchMem) **
+     (.x1 ↦ᵣ raVal)) h := by
+  delta loopN3UnifiedPostV4NoX1 loopIterPostN3Max at hp
+  delta fullDivN3DenormPreV4 fullDivN3FrameNoX1V4 fullDivN3ScratchNoX1V4
+    fullDivN3ScratchMemV4 fullDivN3Shift fullDivN3AntiShift fullDivN3NormV
+    fullDivN3NormU fullDivN3R1V4 fullDivN3R0V4 fullDivN3C3V4 iterN3V4 at hp ⊢
+  simp (config := { decide := true }) only [ite_false] at hp ⊢
+  rw [loopExitPostN3_j0_eq] at hp
+  simp (config := { decide := true }) only
+    [n3_ub1_off4064, n3_qa1, se12_32, se12_40, se12_48, se12_56] at hp ⊢
+  sep_perm hp
+
+theorem loopN3UnifiedPostV4NoX1_to_fullDivN3DenormPreV4_frame_FT
+    (sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0
+      scratchMem raVal : Word)
+    (h : PartialState)
+    (hp :
+      ((loopN3UnifiedPostV4NoX1 false true sp base
+        (fullDivN3NormV b0 b1 b2 b3).1
+        (fullDivN3NormV b0 b1 b2 b3).2.1
+        (fullDivN3NormV b0 b1 b2 b3).2.2.1
+        (fullDivN3NormV b0 b1 b2 b3).2.2.2
+        (fullDivN3NormU a0 a1 a2 a3 b2).2.1
+        (fullDivN3NormU a0 a1 a2 a3 b2).2.2.1
+        (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.1
+        (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.2
+        (0 : Word)
+        (fullDivN3NormU a0 a1 a2 a3 b2).1
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal)) **
+       (((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+        ((sp + signExtend12 4072) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 3992) ↦ₘ (clzResult b2).1))) h) :
+    (fullDivN3DenormPreV4 false true sp a0 a1 a2 a3 b0 b1 b2 b3 **
+     fullDivN3FrameNoX1V4 false true sp base a0 a1 a2 a3 b0 b1 b2 b3
+       retMem dMem dloMem scratchUn0 **
+     ((sp + signExtend12 3936) ↦ₘ
+       fullDivN3ScratchMemV4 false true a0 a1 a2 a3 b0 b1 b2 b3 scratchMem) **
+     (.x1 ↦ᵣ raVal)) h := by
+  delta loopN3UnifiedPostV4NoX1 loopIterPostN3CallScratchNoX1 at hp
+  simp (config := { decide := true }) only [] at hp
+  simp (config := { decide := true }) only
+    [loopExitPostN3_j0_eq, n3_ub1_off4064, n3_qa1,
+      se12_32, se12_40, se12_48, se12_56] at hp
+  delta fullDivN3Shift fullDivN3AntiShift fullDivN3NormV fullDivN3NormU at hp
+  simp (config := { decide := true }) only [] at hp
+  delta fullDivN3DenormPreV4 fullDivN3FrameNoX1V4 fullDivN3ScratchNoX1V4
+    fullDivN3ScratchMemV4 fullDivN3Shift fullDivN3AntiShift fullDivN3NormV
+    fullDivN3NormU fullDivN3R1V4 fullDivN3R0V4 fullDivN3C3V4 iterN3V4
+  simp (config := { decide := true }) only
+    [ite_false, ite_true, se12_32, se12_40, se12_48, se12_56]
+  set shift := (clzResult b2).1 with hshift
+  set antiShift := (signExtend12 (0 : BitVec 12) - shift) with hantiShift
+  set v0 := b0 <<< (shift.toNat % 64) with hv0
+  set v1 := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64)) with hv1
+  set v2 := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64)) with hv2
+  set v3 := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64)) with hv3
+  set u0 := a0 <<< (shift.toNat % 64) with hu0
+  set u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64)) with hu1
+  set u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64)) with hu2
+  set u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64)) with hu3
+  set u4 := a3 >>> (antiShift.toNat % 64) with hu4
+  set r1 := iterN3Max v0 v1 v2 v3 u1 u2 u3 u4 (0 : Word) with hr1
+  set qHat := divKTrialCallV4QHat r1.2.2.2.1 r1.2.2.1 v2 with hqHat
+  set r0 := iterWithDoubleAddback qHat v0 v1 v2 v3 u0 r1.2.1 r1.2.2.1
+    r1.2.2.2.1 r1.2.2.2.2.1 with hr0
+  set c3 := (mulsubN4 qHat v0 v1 v2 v3 u0 r1.2.1 r1.2.2.1
+    r1.2.2.2.1).2.2.2.2 with hc3
+  subst c3
+  subst r0
+  subst qHat
+  xperm_hyp hp
 
 /-- N3 denormalization and DIV epilogue over v4/no-NOP, preserving exact caller
     `x1` and carrying the v4 div128 scratch cell as frame. -/

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V4NoNopPreloop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V4NoNopPreloop.lean
@@ -1,0 +1,407 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN3V4NoNopPreloop
+
+  Preloop setup wrappers for the n=3 v4/no-NOP full DIV path.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathV4NoNop
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V4NoNopMaxCall
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- PhaseAB(n=3) + CLZ over `divCode_noNop_v4`. -/
+theorem evm_div_phaseAB_n3_clz_spec_within_v4_noNop (sp base : Word)
+    (b0 b1 b2 b3 v5 v6 v7 v10 : Word)
+    (q0 q1 q2 q3 u5 u6 u7 nMem : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2nz : b2 ≠ 0) :
+    cpsTripleWithin (8 + 21 + 24) base (base + phaseC2Off) (divCode_noNop_v4 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem))
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (clzResult b2).2) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ (clzResult b2).1) ** (.x7 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (3 : Word))) := by
+  have hAB := evm_div_phaseAB_n3_spec_within_v4_noNop sp base b0 b1 b2 b3
+    v5 v6 v7 v10 q0 q1 q2 q3 u5 u6 u7 nMem hbnz hb3z hb2nz
+  have hCLZ := divK_clz_spec_within_v4_noNop b2 b1 b2 base
+  have hCLZf := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ b3) **
+     ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+     ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (3 : Word)))
+    (by pcFree) hCLZ
+  have hABCLZ := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hAB hCLZf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    hABCLZ
+
+/-- PhaseAB(n=3) + CLZ + PhaseC2(ntaken) + NormB over `divCode_noNop_v4`. -/
+theorem evm_div_n3_to_normB_spec_within_v4_noNop (sp base : Word)
+    (b0 b1 b2 b3 v5 v6 v7 v10 : Word)
+    (q0 q1 q2 q3 u5 u6 u7 nMem shiftMem : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2nz : b2 ≠ 0)
+    (hshift_nz : (clzResult b2).1 ≠ 0) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21) base (base + normAOff) (divCode_noNop_v4 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
+      (normBPost sp (3 : Word) (clzResult b2).1 b0 b1 b2 b3) := by
+  let shift := (clzResult b2).1
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  have hABCLZ := evm_div_phaseAB_n3_clz_spec_within_v4_noNop sp base b0 b1 b2 b3
+    v5 v6 v7 v10 q0 q1 q2 q3 u5 u6 u7 nMem hbnz hb3z hb2nz
+  have hABCLZf := cpsTripleWithin_frameR
+    ((.x2 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
+     ((sp + signExtend12 3992) ↦ₘ shiftMem))
+    (by pcFree) hABCLZ
+  have hC2 := divK_phaseC2_ntaken_spec_within_v4_noNop sp shift
+    ((clzResult b2).2 >>> (63 : Nat)) shiftMem base hshift_nz
+  have hC2f := cpsTripleWithin_frameR
+    ((.x5 ↦ᵣ (clzResult b2).2) ** (.x10 ↦ᵣ b3) **
+     (.x7 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
+     ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+     ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (3 : Word)))
+    (by pcFree) hC2
+  have hABC2 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hABCLZf hC2f
+  have hNB := divK_normB_full_spec_within_v4_noNop sp b0 b1 b2 b3
+    (clzResult b2).2 ((clzResult b2).2 >>> (63 : Nat))
+    shift antiShift base
+  simp only [normBFullPost_unfold] at hNB
+  have hNBf := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (3 : Word)) **
+     ((sp + signExtend12 3992) ↦ₘ shift))
+    (by pcFree) hNB
+  have hFull := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hABC2 hNBf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by delta normBPost; xperm_hyp hq)
+    hFull
+
+/-- Full n=3 path from entry to loop body start over `divCode_noNop_v4`
+    (shift ≠ 0). -/
+theorem evm_div_n3_to_loopSetup_spec_within_v4_noNop (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2nz : b2 ≠ 0)
+    (hshift_nz : (clzResult b2).1 ≠ 0) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4) base (base + loopBodyOff) (divCode_noNop_v4 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+       ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+       ((sp + signExtend12 4024) ↦ₘ u4Old) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
+      (loopSetupPost sp (3 : Word) (clzResult b2).1 a0 a1 a2 a3 b0 b1 b2 b3) := by
+  let shift := (clzResult b2).1
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+  let b0' := b0 <<< (shift.toNat % 64)
+  let u4 := a3 >>> (antiShift.toNat % 64)
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
+  let u0 := a0 <<< (shift.toNat % 64)
+  have hNB := evm_div_n3_to_normB_spec_within_v4_noNop sp base b0 b1 b2 b3 v5 v6 v7 v10
+    q0 q1 q2 q3 u5 u6 u7 nMem shiftMem hbnz hb3z hb2nz hshift_nz
+  have hNBf := cpsTripleWithin_frameR
+    ((.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+     ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+     ((sp + signExtend12 4024) ↦ₘ u4Old))
+    (by pcFree) hNB
+  have hNormA := divK_normA_full_spec_within_v4_noNop sp a0 a1 a2 a3
+    b0' (b0 >>> (antiShift.toNat % 64)) b3 shift antiShift
+    u0Old u1Old u2Old u3Old u4Old base
+  rw [divKNormAFullPreNoNop_unfold] at hNormA
+  simp only [normAFullPost_unfold] at hNormA
+  have hNormAf := cpsTripleWithin_frameR
+    ((.x0 ↦ᵣ (0 : Word)) **
+     (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
+     ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3') **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (3 : Word)) **
+     ((sp + signExtend12 3992) ↦ₘ shift))
+    (by pcFree) hNormA
+  have hNA := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by delta normBPost at hp; xperm_hyp hp) hNBf hNormAf
+  have hLS := divK_loopSetup_ntaken_spec_within_v4_noNop sp (3 : Word)
+    (signExtend12 (4 : BitVec 12) - (4 : Word)) u1 base
+    (by decide)
+  simp only [divKLoopSetupNtakenPreNoNop_unfold,
+      divKLoopSetupNtakenPostNoNop_unfold] at hLS
+  have hLSf := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ (a0 >>> (antiShift.toNat % 64))) **
+     (.x6 ↦ᵣ shift) ** (.x7 ↦ᵣ u0) ** (.x2 ↦ᵣ antiShift) **
+     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
+     ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3') **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
+     ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3) **
+     ((sp + signExtend12 4024) ↦ₘ u4) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3992) ↦ₘ shift))
+    (by pcFree) hLS
+  have hFull := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hNA hLSf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by delta loopSetupPost; xperm_hyp hq)
+    hFull
+
+/-- v4/no-NOP n=3 preloop setup with exact caller-framed `x1` and the loop
+    scratch handoff frame carried explicitly. -/
+theorem evm_div_n3_to_loopSetup_spec_within_v4_noNop_exact_x1_scratch_frame
+    (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem : Word)
+    (jMem retMem dMem dloMem scratchUn0 scratchMem raVal : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2nz : b2 ≠ 0)
+    (hshift_nz : (clzResult b2).1 ≠ 0) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4) base (base + loopBodyOff)
+      (divCode_noNop_v4 base)
+      (((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
+        (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+        ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+        ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+        ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+        ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+        ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+        ((sp + signExtend12 4024) ↦ₘ u4Old) **
+        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+        ((sp + signExtend12 3992) ↦ₘ shiftMem)) **
+       ((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal)))
+      (loopSetupPost sp (3 : Word) (clzResult b2).1 a0 a1 a2 a3 b0 b1 b2 b3 **
+       ((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal))) := by
+  have hPre :=
+    evm_div_n3_to_loopSetup_spec_within_v4_noNop sp base
+      a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10
+      q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem
+      hbnz hb3z hb2nz hshift_nz
+  have hFramed := cpsTripleWithin_frameR
+    (((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
+      (sp + signExtend12 3968 ↦ₘ retMem) **
+      (sp + signExtend12 3960 ↦ₘ dMem) **
+      (sp + signExtend12 3952 ↦ₘ dloMem) **
+      (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+      (sp + signExtend12 3936 ↦ₘ scratchMem) **
+      (.x1 ↦ᵣ raVal)))
+    (by pcFree) hPre
+  exact cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    hFramed
+
+/-- n=3 v4/no-NOP path from entry through the exact-x1 loop handoff. -/
+theorem fullDivN3_preloop_loop_unified_exact_x1_scratch_v4_noNop
+    (bltu_1 bltu_0 : Bool) (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem : Word)
+    (jMem retMem dMem dloMem scratchUn0 scratchMem raVal : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2nz : b2 ≠ 0)
+    (hshift_nz : (clzResult b2).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_1 : bltu_1 =
+      BitVec.ult (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.2
+        (fullDivN3NormV b0 b1 b2 b3).2.2.1)
+    (hbltu_0 : bltu_0 =
+      match bltu_1, hbltu_1 with
+      | false, _ =>
+        BitVec.ult
+          (iterN3Max (fullDivN3NormV b0 b1 b2 b3).1
+            (fullDivN3NormV b0 b1 b2 b3).2.1
+            (fullDivN3NormV b0 b1 b2 b3).2.2.1
+            (fullDivN3NormV b0 b1 b2 b3).2.2.2
+            (fullDivN3NormU a0 a1 a2 a3 b2).2.1
+            (fullDivN3NormU a0 a1 a2 a3 b2).2.2.1
+            (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.1
+            (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.2
+            (0 : Word)).2.2.2.1
+          (fullDivN3NormV b0 b1 b2 b3).2.2.1
+      | true, _ =>
+        BitVec.ult
+          (iterWithDoubleAddback
+            (divKTrialCallV4QHat
+              (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.2
+              (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.1
+              (fullDivN3NormV b0 b1 b2 b3).2.2.1)
+            (fullDivN3NormV b0 b1 b2 b3).1
+            (fullDivN3NormV b0 b1 b2 b3).2.1
+            (fullDivN3NormV b0 b1 b2 b3).2.2.1
+            (fullDivN3NormV b0 b1 b2 b3).2.2.2
+            (fullDivN3NormU a0 a1 a2 a3 b2).2.1
+            (fullDivN3NormU a0 a1 a2 a3 b2).2.2.1
+            (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.1
+            (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.2
+            (0 : Word)).2.2.2.1
+          (fullDivN3NormV b0 b1 b2 b3).2.2.1)
+    (hcarry2 : Carry2NzAll
+      (fullDivN3NormV b0 b1 b2 b3).1
+      (fullDivN3NormV b0 b1 b2 b3).2.1
+      (fullDivN3NormV b0 b1 b2 b3).2.2.1
+      (fullDivN3NormV b0 b1 b2 b3).2.2.2) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 448) base (base + denormOff)
+      (divCode_noNop_v4 base)
+      (((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
+        (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+        ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+        ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+        ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+        ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+        ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+        ((sp + signExtend12 4024) ↦ₘ u4Old) **
+        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+        ((sp + signExtend12 3992) ↦ₘ shiftMem)) **
+       ((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal)))
+      ((loopN3UnifiedPostV4NoX1 bltu_1 bltu_0 sp base
+        (fullDivN3NormV b0 b1 b2 b3).1
+        (fullDivN3NormV b0 b1 b2 b3).2.1
+        (fullDivN3NormV b0 b1 b2 b3).2.2.1
+        (fullDivN3NormV b0 b1 b2 b3).2.2.2
+        (fullDivN3NormU a0 a1 a2 a3 b2).2.1
+        (fullDivN3NormU a0 a1 a2 a3 b2).2.2.1
+        (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.1
+        (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.2
+        (0 : Word)
+        (fullDivN3NormU a0 a1 a2 a3 b2).1
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal)) **
+       (((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+        ((sp + signExtend12 4072) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 3992) ↦ₘ (clzResult b2).1))) := by
+  have hPre := evm_div_n3_to_loopSetup_spec_within_v4_noNop_exact_x1_scratch_frame
+    sp base a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem
+    jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+    hbnz hb3z hb2nz hshift_nz
+  have hLoop := evm_div_n3_loop_unified_inst_noNop_exact_x1_v4
+    bltu_1 bltu_0 sp base
+    (fullDivN3Shift b2) (fullDivN3AntiShift b2)
+    (fullDivN3NormV b0 b1 b2 b3).1
+    (fullDivN3NormV b0 b1 b2 b3).2.1
+    (fullDivN3NormV b0 b1 b2 b3).2.2.1
+    (fullDivN3NormV b0 b1 b2 b3).2.2.2
+    (fullDivN3NormU a0 a1 a2 a3 b2).1
+    (fullDivN3NormU a0 a1 a2 a3 b2).2.1
+    (fullDivN3NormU a0 a1 a2 a3 b2).2.2.1
+    (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.1
+    (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.2
+    (a0 >>> ((fullDivN3AntiShift b2).toNat % 64)) v11Old jMem
+    retMem dMem dloMem scratchUn0 scratchMem raVal
+    halign hbltu_1 (by cases bltu_1 <;> simpa using hbltu_0) hcarry2
+  have hLoopf := cpsTripleWithin_frameR
+    ((((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+      ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+      ((sp + signExtend12 4072) ↦ₘ (0 : Word)) **
+      ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+      ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+      ((sp + signExtend12 3992) ↦ₘ (clzResult b2).1)))
+    (by pcFree) hLoop
+  have hBridge := loopSetupPost_to_loopN3PreWithScratchV4NoX1_framed
+    sp a0 a1 a2 a3 b0 b1 b2 b3 v11Old
+    jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+  have hPre' := cpsTripleWithin_weaken
+    (fun h hp => hp)
+    hBridge
+    hPre
+  have hFull := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hPre' hLoopf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => hp)
+    (fun h hq => hq)
+    hFull
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPathN3V4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPathN3V4NoNop.lean
@@ -1,0 +1,165 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.ModFullPathN3V4NoNop
+
+  v4/no-NOP MOD full-path preloop wrappers for the n=3 case.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.ModFullPathN4V4NoNop
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- MOD n=3 path from entry to NormA over the no-NOP v4 MOD code bundle. -/
+theorem evm_mod_n3_to_normB_spec_within_v4_noNop (sp base : Word)
+    (b0 b1 b2 b3 v5 v6 v7 v10 : Word)
+    (q0 q1 q2 q3 u5 u6 u7 nMem shiftMem : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2nz : b2 ≠ 0)
+    (hshift_nz : (clzResult b2).1 ≠ 0) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21) base (base + normAOff) (modCode_noNop_v4 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
+      (normBPost sp (3 : Word) (clzResult b2).1 b0 b1 b2 b3) := by
+  let shift := (clzResult b2).1
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  have hABCLZ := evm_mod_phaseAB_n3_clz_spec_within_v4_noNop sp base b0 b1 b2 b3 v5 v6 v7 v10
+    q0 q1 q2 q3 u5 u6 u7 nMem hbnz hb3z hb2nz
+  have hABCLZf := cpsTripleWithin_frameR
+    ((.x2 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
+     ((sp + signExtend12 3992) ↦ₘ shiftMem))
+    (by pcFree) hABCLZ
+  have hC2 := divK_phaseC2_ntaken_spec_within_mod_v4_noNop sp shift ((clzResult b2).2 >>> (63 : Nat))
+    shiftMem base hshift_nz
+  have hC2f := cpsTripleWithin_frameR
+    ((.x5 ↦ᵣ (clzResult b2).2) ** (.x10 ↦ᵣ b3) **
+     (.x7 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
+     ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+     ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (3 : Word)))
+    (by pcFree) hC2
+  have hABC2 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hABCLZf hC2f
+  have hNB := divK_normB_full_spec_within_mod_v4_noNop sp b0 b1 b2 b3
+    (clzResult b2).2 ((clzResult b2).2 >>> (63 : Nat))
+    shift antiShift base
+  simp only [normBFullPost_unfold] at hNB
+  have hNBf := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (3 : Word)) **
+     ((sp + signExtend12 3992) ↦ₘ shift))
+    (by pcFree) hNB
+  have hFull := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hABC2 hNBf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by delta normBPost; xperm_hyp hq)
+    hFull
+
+/-- MOD n=3 path from entry to loop body start over the no-NOP v4 MOD code bundle. -/
+theorem evm_mod_n3_to_loopSetup_spec_within_v4_noNop (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2nz : b2 ≠ 0)
+    (hshift_nz : (clzResult b2).1 ≠ 0) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4) base (base + loopBodyOff) (modCode_noNop_v4 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+       ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+       ((sp + signExtend12 4024) ↦ₘ u4Old) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
+      (loopSetupPost sp (3 : Word) (clzResult b2).1 a0 a1 a2 a3 b0 b1 b2 b3) := by
+  let shift := (clzResult b2).1
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+  let b0' := b0 <<< (shift.toNat % 64)
+  let u4 := a3 >>> (antiShift.toNat % 64)
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
+  let u0 := a0 <<< (shift.toNat % 64)
+  have hNormB := evm_mod_n3_to_normB_spec_within_v4_noNop sp base b0 b1 b2 b3 v5 v6 v7 v10
+    q0 q1 q2 q3 u5 u6 u7 nMem shiftMem hbnz hb3z hb2nz hshift_nz
+  have hNormBf := cpsTripleWithin_frameR
+    ((.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+     ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+     ((sp + signExtend12 4024) ↦ₘ u4Old))
+    (by pcFree) hNormB
+  have hNormA := divK_normA_full_spec_within_mod_v4_noNop sp a0 a1 a2 a3
+    b0' (b0 >>> (antiShift.toNat % 64)) b3 shift antiShift
+    u0Old u1Old u2Old u3Old u4Old base
+  rw [divKNormAFullPreNoNop_unfold] at hNormA
+  simp only [normAFullPost_unfold] at hNormA
+  have hNormAf := cpsTripleWithin_frameR
+    ((.x0 ↦ᵣ (0 : Word)) **
+     (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
+     ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3') **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (3 : Word)) **
+     ((sp + signExtend12 3992) ↦ₘ shift))
+    (by pcFree) hNormA
+  have hNA := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by delta normBPost at hp; xperm_hyp hp) hNormBf hNormAf
+  have hLS := divK_loopSetup_ntaken_spec_within_mod_v4_noNop sp (3 : Word)
+    (signExtend12 (4 : BitVec 12) - (4 : Word)) u1 base
+    (by decide)
+  simp only [divKLoopSetupNtakenPreNoNop_unfold,
+      divKLoopSetupNtakenPostNoNop_unfold] at hLS
+  have hLSf := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ (a0 >>> (antiShift.toNat % 64))) **
+     (.x6 ↦ᵣ shift) ** (.x7 ↦ᵣ u0) ** (.x2 ↦ᵣ antiShift) **
+     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
+     ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3') **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
+     ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3) **
+     ((sp + signExtend12 4024) ↦ₘ u4) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3992) ↦ₘ shift))
+    (by pcFree) hLS
+  have hFull := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hNA hLSf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by delta loopSetupPost; xperm_hyp hq)
+    hFull
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPathN3V4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPathN3V4NoNop.lean
@@ -1041,154 +1041,151 @@ theorem divK_loop_n3_call_max_mod_v4_from_source_exact_loopIterScratch_noNop (sp
       v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q0Old raVal)
     J1 J0f
 
-/-- MOD n=3 path from entry to NormA over the no-NOP v4 MOD code bundle. -/
-theorem evm_mod_n3_to_normB_spec_within_v4_noNop (sp base : Word)
-    (b0 b1 b2 b3 v5 v6 v7 v10 : Word)
-    (q0 q1 q2 q3 u5 u6 u7 nMem shiftMem : Word)
-    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
-    (hb3z : b3 = 0) (hb2nz : b2 ≠ 0)
-    (hshift_nz : (clzResult b2).1 ≠ 0) :
-    cpsTripleWithin (8 + 21 + 24 + 4 + 21) base (base + normAOff) (modCode_noNop_v4 base)
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
-       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
-       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
-       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
-       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
-       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
-       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
-       ((sp + signExtend12 3992) ↦ₘ shiftMem))
-      (normBPost sp (3 : Word) (clzResult b2).1 b0 b1 b2 b3) := by
-  let shift := (clzResult b2).1
-  let antiShift := signExtend12 (0 : BitVec 12) - shift
-  have hABCLZ := evm_mod_phaseAB_n3_clz_spec_within_v4_noNop sp base b0 b1 b2 b3 v5 v6 v7 v10
-    q0 q1 q2 q3 u5 u6 u7 nMem hbnz hb3z hb2nz
-  have hABCLZf := cpsTripleWithin_frameR
-    ((.x2 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
-     ((sp + signExtend12 3992) ↦ₘ shiftMem))
-    (by pcFree) hABCLZ
-  have hC2 := divK_phaseC2_ntaken_spec_within_mod_v4_noNop sp shift ((clzResult b2).2 >>> (63 : Nat))
-    shiftMem base hshift_nz
-  have hC2f := cpsTripleWithin_frameR
-    ((.x5 ↦ᵣ (clzResult b2).2) ** (.x10 ↦ᵣ b3) **
-     (.x7 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
-     ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
-     ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
-     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (3 : Word)))
-    (by pcFree) hC2
-  have hABC2 := cpsTripleWithin_seq_perm_same_cr
-    (fun h hp => by xperm_hyp hp) hABCLZf hC2f
-  have hNB := divK_normB_full_spec_within_mod_v4_noNop sp b0 b1 b2 b3
-    (clzResult b2).2 ((clzResult b2).2 >>> (63 : Nat))
-    shift antiShift base
-  simp only [normBFullPost_unfold] at hNB
-  have hNBf := cpsTripleWithin_frameR
-    ((.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
-     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (3 : Word)) **
-     ((sp + signExtend12 3992) ↦ₘ shift))
-    (by pcFree) hNB
-  have hFull := cpsTripleWithin_seq_perm_same_cr
-    (fun h hp => by xperm_hyp hp) hABC2 hNBf
-  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
-    (fun h hp => by xperm_hyp hp)
-    (fun h hq => by delta normBPost; xperm_hyp hq)
-    hFull
-
-/-- MOD n=3 path from entry to loop body start over the no-NOP v4 MOD code bundle. -/
-theorem evm_mod_n3_to_loopSetup_spec_within_v4_noNop (sp base : Word)
-    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 : Word)
-    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem : Word)
-    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
-    (hb3z : b3 = 0) (hb2nz : b2 ≠ 0)
-    (hshift_nz : (clzResult b2).1 ≠ 0) :
-    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4) base (base + loopBodyOff) (modCode_noNop_v4 base)
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
-       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
-       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
-       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
-       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
-       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
-       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
-       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
-       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
-       ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
-       ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
-       ((sp + signExtend12 4024) ↦ₘ u4Old) **
-       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
-       ((sp + signExtend12 3992) ↦ₘ shiftMem))
-      (loopSetupPost sp (3 : Word) (clzResult b2).1 a0 a1 a2 a3 b0 b1 b2 b3) := by
-  let shift := (clzResult b2).1
-  let antiShift := signExtend12 (0 : BitVec 12) - shift
-  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
-  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
-  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
-  let b0' := b0 <<< (shift.toNat % 64)
-  let u4 := a3 >>> (antiShift.toNat % 64)
-  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
-  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
-  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
-  let u0 := a0 <<< (shift.toNat % 64)
-  have hNormB := evm_mod_n3_to_normB_spec_within_v4_noNop sp base b0 b1 b2 b3 v5 v6 v7 v10
-    q0 q1 q2 q3 u5 u6 u7 nMem shiftMem hbnz hb3z hb2nz hshift_nz
-  have hNormBf := cpsTripleWithin_frameR
-    ((.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
-     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
-     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
-     ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
-     ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
-     ((sp + signExtend12 4024) ↦ₘ u4Old))
-    (by pcFree) hNormB
-  have hNormA := divK_normA_full_spec_within_mod_v4_noNop sp a0 a1 a2 a3
-    b0' (b0 >>> (antiShift.toNat % 64)) b3 shift antiShift
-    u0Old u1Old u2Old u3Old u4Old base
-  rw [divKNormAFullPreNoNop_unfold] at hNormA
-  simp only [normAFullPost_unfold] at hNormA
-  have hNormAf := cpsTripleWithin_frameR
-    ((.x0 ↦ᵣ (0 : Word)) **
-     (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
-     ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
-     ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3') **
-     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (3 : Word)) **
-     ((sp + signExtend12 3992) ↦ₘ shift))
-    (by pcFree) hNormA
-  have hNA := cpsTripleWithin_seq_perm_same_cr
-    (fun h hp => by delta normBPost at hp; xperm_hyp hp) hNormBf hNormAf
-  have hLS := divK_loopSetup_ntaken_spec_within_mod_v4_noNop sp (3 : Word)
-    (signExtend12 (4 : BitVec 12) - (4 : Word)) u1 base
-    (by decide)
-  simp only [divKLoopSetupNtakenPreNoNop_unfold,
-      divKLoopSetupNtakenPostNoNop_unfold] at hLS
-  have hLSf := cpsTripleWithin_frameR
-    ((.x10 ↦ᵣ (a0 >>> (antiShift.toNat % 64))) **
-     (.x6 ↦ᵣ shift) ** (.x7 ↦ᵣ u0) ** (.x2 ↦ᵣ antiShift) **
-     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
-     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
-     ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
-     ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3') **
-     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
-     ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3) **
-     ((sp + signExtend12 4024) ↦ₘ u4) **
-     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 3992) ↦ₘ shift))
-    (by pcFree) hLS
-  have hFull := cpsTripleWithin_seq_perm_same_cr
-    (fun h hp => by xperm_hyp hp) hNA hLSf
-  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
-    (fun h hp => by xperm_hyp hp)
-    (fun h hq => by delta loopSetupPost; xperm_hyp hq)
-    hFull
+/-- Unified n=3 v4 no-NOP loop path over `modCode_noNop_v4` from the
+    callable-ready no-`x1` source, selecting the max/call branch for both
+    iterations and preserving concrete caller `x1`. -/
+theorem divK_loop_n3_unified_from_source_exact_loopIterScratch_mod_v4_noNop
+    (bltu_1 bltu_0 : Bool) (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_1 : bltu_1 = BitVec.ult u3 v2)
+    (hbltu_0 : bltu_0 =
+      match bltu_1 with
+      | false => BitVec.ult (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1 v2
+      | true =>
+        BitVec.ult
+          (iterWithDoubleAddback (divKTrialCallV4QHat u3 u2 v2)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1 v2)
+    (hcarry2 : Carry2NzAll v0 v1 v2 v3) :
+    cpsTripleWithin 448 (base + loopBodyOff) (base + denormOff) (modCode_noNop_v4 base)
+      (loopN3PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopN3UnifiedPostV4NoX1 bltu_1 bltu_0 sp base
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal)) := by
+  cases bltu_1 <;> cases bltu_0
+  · have hb1 : ¬BitVec.ult u3 v2 := by
+      rw [← hbltu_1]
+      decide
+    have hb0 : ¬BitVec.ult (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1 v2 := by
+      simp only at hbltu_0
+      rw [← hbltu_0]
+      decide
+    have hc1 : isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop :=
+      hcarry2 (signExtend12 4095) u0 u1 u2 u3 uTop
+    have hc0 :
+        let r1 := iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+        isAddbackCarry2NzN3Max v0 v1 v2 v3
+          u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 := by
+      intro r1
+      exact hcarry2 (signExtend12 4095) u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+    exact cpsTripleWithin_mono_nSteps (show 152 + 152 ≤ 448 by decide) <|
+      cpsTripleWithin_weaken
+        (fun h hp => hp)
+        (fun h hp => by
+          unfold loopN3UnifiedPostV4NoX1
+          simp only at hp ⊢
+          rw [sepConj_assoc'] at hp
+          xperm_hyp hp)
+        (divK_loop_n3_max_max_mod_v4_from_source_exact_loopIterScratch_noNop
+          sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal
+          retMem dMem dloMem scratchUn0 scratchMem hb1 hc1 hb0 hc0)
+  · have hb1 : ¬BitVec.ult u3 v2 := by
+      rw [← hbltu_1]
+      decide
+    have hb0 : BitVec.ult (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1 v2 := by
+      simp only at hbltu_0
+      exact hbltu_0.symm
+    have hc1 : isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop :=
+      hcarry2 (signExtend12 4095) u0 u1 u2 u3 uTop
+    have hc0 :
+        let r1 := iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+        loopBodyN3CallAddbackCarry2NzV4 v0 v1 v2 v3
+          u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 := by
+      intro r1
+      unfold loopBodyN3CallAddbackCarry2NzV4
+      exact hcarry2 (divKTrialCallV4QHat r1.2.2.2.1 r1.2.2.1 v2)
+        u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+    exact cpsTripleWithin_mono_nSteps (show 152 + 224 ≤ 448 by decide) <|
+      cpsTripleWithin_weaken
+        (fun h hp => hp)
+        (fun h hp => by
+          unfold loopN3UnifiedPostV4NoX1
+          simp only at hp ⊢
+          rw [sepConj_assoc'] at hp
+          xperm_hyp hp)
+        (divK_loop_n3_max_call_mod_v4_from_source_exact_loopIterScratch_noNop
+          sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal
+          retMem dMem dloMem scratchUn0 scratchMem halign hb1 hc1 hb0 hc0)
+  · have hb1 : BitVec.ult u3 v2 := by
+      exact hbltu_1.symm
+    have hb0 :
+        ¬BitVec.ult
+          (iterWithDoubleAddback (divKTrialCallV4QHat u3 u2 v2)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1 v2 := by
+      simp only at hbltu_0
+      rw [← hbltu_0]
+      decide
+    have hc1 : loopBodyN3CallAddbackCarry2NzV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+      unfold loopBodyN3CallAddbackCarry2NzV4
+      exact hcarry2 (divKTrialCallV4QHat u3 u2 v2) u0 u1 u2 u3 uTop
+    have hc0 :
+        let r1 := iterWithDoubleAddback (divKTrialCallV4QHat u3 u2 v2)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop
+        isAddbackCarry2NzN3Max v0 v1 v2 v3
+          u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 := by
+      intro r1
+      exact hcarry2 (signExtend12 4095) u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+    exact cpsTripleWithin_mono_nSteps (show 224 + 152 ≤ 448 by decide) <|
+      cpsTripleWithin_weaken
+        (fun h hp => hp)
+        (fun h hp => by
+          unfold loopN3UnifiedPostV4NoX1
+          simp only at hp ⊢
+          rw [sepConj_assoc'] at hp
+          xperm_hyp hp)
+        (divK_loop_n3_call_max_mod_v4_from_source_exact_loopIterScratch_noNop
+          sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal
+          retMem dMem dloMem scratchUn0 scratchMem halign hb1 hc1 hb0 hc0)
+  · have hb1 : BitVec.ult u3 v2 := by
+      exact hbltu_1.symm
+    have hb0 :
+        BitVec.ult
+          (iterWithDoubleAddback (divKTrialCallV4QHat u3 u2 v2)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1 v2 := by
+      simp only at hbltu_0
+      exact hbltu_0.symm
+    have hc1 : loopBodyN3CallAddbackCarry2NzV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+      unfold loopBodyN3CallAddbackCarry2NzV4
+      exact hcarry2 (divKTrialCallV4QHat u3 u2 v2) u0 u1 u2 u3 uTop
+    have hc0 :
+        let r1 := iterWithDoubleAddback (divKTrialCallV4QHat u3 u2 v2)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop
+        loopBodyN3CallAddbackCarry2NzV4 v0 v1 v2 v3
+          u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 := by
+      intro r1
+      unfold loopBodyN3CallAddbackCarry2NzV4
+      exact hcarry2 (divKTrialCallV4QHat r1.2.2.2.1 r1.2.2.1 v2)
+        u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+    exact cpsTripleWithin_weaken
+      (fun h hp => hp)
+      (fun h hp => by
+        unfold loopN3UnifiedPostV4NoX1
+        simp only at hp ⊢
+        rw [sepConj_assoc'] at hp
+        xperm_hyp hp)
+      (divK_loop_n3_call_call_mod_v4_from_source_exact_loopIterScratch_noNop
+        sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal
+        retMem dMem dloMem scratchUn0 scratchMem halign hb1 hc1 hb0 hc0)
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPathN3V4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPathN3V4NoNop.lean
@@ -5,6 +5,8 @@
 -/
 
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN4V4NoNop
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V4NoNop
+import EvmAsm.Evm64.DivMod.LoopIterN3MaxV4NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN3CallV4NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN3AddbackV4NoNop
 
@@ -13,6 +15,269 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)
+
+/-- Loop body n=3, max+skip, j=0 over `modCode_noNop_v4`, with
+    sp-relative addresses hidden behind a named precondition. -/
+theorem divK_loop_body_n3_max_skip_j0_norm_mod_v4_noNop (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (hbltu : ¬BitVec.ult u3 v2) :
+    (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+     then (1 : Word) else 0) = (0 : Word) →
+    cpsTripleWithin 76 (base + loopBodyOff) (base + denormOff) (modCode_noNop_v4 base)
+      (loopBodyN3MaxSkipJ0NormPreV4 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld)
+      (loopBodyN3SkipPost sp (0 : Word) (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro hborrow
+  have raw := divK_loop_body_n3_max_skip_j0_v4_spec_within_noNop
+    sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base
+    hbltu hborrow
+  have raw' := cpsTripleWithin_extend_code
+    (hmono := sharedDivModCodeNoNop_v4_sub_modCode_noNop_v4) raw
+  rw [loopBodyN3MaxSkipPre_unfold] at raw'
+  simp only [se12_32, se12_40, se12_48, se12_56,
+             u_base_off0_j0, u_base_off4088_j0, u_base_off4080_j0,
+             u_base_off4072_j0, u_base_off4064_j0, q_addr_j0] at raw'
+  delta loopBodyN3MaxSkipJ0NormPreV4
+  exact raw'
+
+/-- Loop body n=3, max+skip, j=1 over `modCode_noNop_v4`, with the
+    precondition hidden behind an irreducible definition. -/
+theorem divK_loop_body_n3_max_skip_j1_norm_mod_v4_noNop (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (hbltu : ¬BitVec.ult u3 v2) :
+    (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+     then (1 : Word) else 0) = (0 : Word) →
+    cpsTripleWithin 76 (base + loopBodyOff) (base + loopBodyOff) (modCode_noNop_v4 base)
+      (loopBodyN3MaxSkipJ1NormPreV4 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld)
+      (loopBodyN3SkipPost sp (1 : Word) (signExtend12 4095 : Word)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro hborrow
+  have raw := divK_loop_body_n3_max_skip_j1_v4_spec_within_noNop
+    sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base
+    hbltu hborrow
+  have raw' := cpsTripleWithin_extend_code
+    (hmono := sharedDivModCodeNoNop_v4_sub_modCode_noNop_v4) raw
+  exact cpsTripleWithin_weaken
+    (fun h hp => by
+      delta loopBodyN3MaxSkipJ1NormPreV4 at hp
+      xperm_hyp hp)
+    (fun h hp => hp)
+    raw'
+
+/-- Loop body n=3, max+addback, j=0 over `modCode_noNop_v4`, with
+    sp-relative addresses hidden behind a named precondition. -/
+theorem divK_loop_body_n3_max_addback_j0_beq_norm_mod_v4_noNop (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (hbltu : ¬BitVec.ult u3 v2)
+    (hcarry2_nz : isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+     then (1 : Word) else 0) ≠ (0 : Word) →
+    cpsTripleWithin 152 (base + loopBodyOff) (base + denormOff) (modCode_noNop_v4 base)
+      (loopBodyN3MaxSkipJ0NormPreV4 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld)
+      (loopBodyN3AddbackBeqPost sp (0 : Word) (signExtend12 4095 : Word)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro hborrow
+  have raw := divK_loop_body_n3_max_addback_j0_beq_v4_spec_within_noNop
+    sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base
+    hbltu hcarry2_nz hborrow
+  have raw' := cpsTripleWithin_extend_code
+    (hmono := sharedDivModCodeNoNop_v4_sub_modCode_noNop_v4) raw
+  rw [loopBodyN3MaxSkipPre_unfold] at raw'
+  simp only [se12_32, se12_40, se12_48, se12_56,
+             u_base_off0_j0, u_base_off4088_j0, u_base_off4080_j0,
+             u_base_off4072_j0, u_base_off4064_j0, q_addr_j0] at raw'
+  delta loopBodyN3MaxSkipJ0NormPreV4
+  exact raw'
+
+/-- Loop body n=3, max+addback, j=1 over `modCode_noNop_v4`, with the
+    precondition hidden behind an irreducible definition. -/
+theorem divK_loop_body_n3_max_addback_jgt0_beq_norm_mod_v4_noNop (j : Word)
+    (hpos : BitVec.slt (j + signExtend12 4095) 0 = false)
+    (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (hbltu : ¬BitVec.ult u3 v2)
+    (hcarry2_nz : isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+     then (1 : Word) else 0) ≠ (0 : Word) →
+    cpsTripleWithin 152 (base + loopBodyOff) (base + loopBodyOff) (modCode_noNop_v4 base)
+      (loopBodyN3MaxAddbackJgt0NormPreV4 j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld)
+      (loopBodyN3AddbackBeqPost sp j (signExtend12 4095 : Word)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro hborrow
+  have raw := divK_loop_body_n3_max_addback_jgt0_beq_v4_spec_within_noNop j hpos
+    sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base
+    hbltu hcarry2_nz hborrow
+  have raw' := cpsTripleWithin_extend_code
+    (hmono := sharedDivModCodeNoNop_v4_sub_modCode_noNop_v4) raw
+  exact cpsTripleWithin_weaken
+    (fun h hp => by
+      delta loopBodyN3MaxAddbackJgt0NormPreV4 at hp
+      xperm_hyp hp)
+    (fun h hp => hp)
+    raw'
+
+/-- Loop body n=3, max path, j=0 over `modCode_noNop_v4`, preserving
+    concrete `x1` and callable scratch cells as frame. -/
+theorem divK_loop_body_n3_max_j0_mod_v4_spec_within_noNop_exact_x1 (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hbltu : ¬BitVec.ult u3 v2)
+    (hcarry2_nz : isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 152 (base + loopBodyOff) (base + denormOff) (modCode_noNop_v4 base)
+      ((loopBodyN3MaxSkipJ0NormPreV4 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal)))
+      ((loopIterPostN3Max sp (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal))) := by
+  by_cases hborrow : BitVec.ult uTop
+      (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+  · have hborrow_nz :
+        (if BitVec.ult uTop
+          (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+         then (1 : Word) else 0) ≠ (0 : Word) := by
+      rw [if_pos hborrow]
+      decide
+    have J := divK_loop_body_n3_max_addback_j0_beq_norm_mod_v4_noNop
+      sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld hbltu hcarry2_nz hborrow_nz
+    have Jf := cpsTripleWithin_frameR
+      ((sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
+       (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+       (sp + signExtend12 3936 ↦ₘ scratchMem) **
+       (.x1 ↦ᵣ raVal))
+      (by pcFree) J
+    exact cpsTripleWithin_weaken
+      (fun h hp => by xperm_hyp hp)
+      (fun h hp => by
+        rw [loopIterPostN3Max_addback hborrow] at hp
+        xperm_hyp hp)
+      Jf
+  · have hborrow_zero :
+        (if BitVec.ult uTop
+          (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+         then (1 : Word) else 0) = (0 : Word) := by
+      rw [if_neg hborrow]
+    have J := divK_loop_body_n3_max_skip_j0_norm_mod_v4_noNop
+      sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld hbltu hborrow_zero
+    have Jf := cpsTripleWithin_frameR
+      ((sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
+       (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+       (sp + signExtend12 3936 ↦ₘ scratchMem) **
+       (.x1 ↦ᵣ raVal))
+      (by pcFree) J
+    exact cpsTripleWithin_mono_nSteps (by decide) <|
+      cpsTripleWithin_weaken
+        (fun h hp => by xperm_hyp hp)
+        (fun h hp => by
+          rw [loopIterPostN3Max_skip hborrow] at hp
+          xperm_hyp hp)
+        Jf
+
+/-- Loop body n=3, max path, j=1 over `modCode_noNop_v4`, preserving
+    concrete `x1` and callable scratch cells as frame. -/
+theorem divK_loop_body_n3_max_j1_mod_v4_spec_within_noNop_exact_x1 (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hbltu : ¬BitVec.ult u3 v2)
+    (hcarry2_nz : isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 152 (base + loopBodyOff) (base + loopBodyOff) (modCode_noNop_v4 base)
+      ((loopBodyN3MaxSkipJ1NormPreV4 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal)))
+      ((loopIterPostN3Max sp (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal))) := by
+  by_cases hborrow : BitVec.ult uTop
+      (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+  · have hborrow_nz :
+        (if BitVec.ult uTop
+          (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+         then (1 : Word) else 0) ≠ (0 : Word) := by
+      rw [if_pos hborrow]
+      decide
+    have J := divK_loop_body_n3_max_addback_jgt0_beq_norm_mod_v4_noNop
+      (1 : Word) EvmAsm.Evm64.DivMod.AddrNorm.slt_jpos_1
+      sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld hbltu hcarry2_nz hborrow_nz
+    have Jf := cpsTripleWithin_frameR
+      ((sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
+       (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+       (sp + signExtend12 3936 ↦ₘ scratchMem) **
+       (.x1 ↦ᵣ raVal))
+      (by pcFree) J
+    exact cpsTripleWithin_weaken
+      (fun h hp => by
+        delta loopBodyN3MaxSkipJ1NormPreV4 loopBodyN3MaxAddbackJgt0NormPreV4 at hp ⊢
+        xperm_hyp hp)
+      (fun h hp => by
+        rw [loopIterPostN3Max_addback hborrow] at hp
+        xperm_hyp hp)
+      Jf
+  · have hborrow_zero :
+        (if BitVec.ult uTop
+          (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+         then (1 : Word) else 0) = (0 : Word) := by
+      rw [if_neg hborrow]
+    have J := divK_loop_body_n3_max_skip_j1_norm_mod_v4_noNop
+      sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld hbltu hborrow_zero
+    have Jf := cpsTripleWithin_frameR
+      ((sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
+       (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+       (sp + signExtend12 3936 ↦ₘ scratchMem) **
+       (.x1 ↦ᵣ raVal))
+      (by pcFree) J
+    exact cpsTripleWithin_mono_nSteps (by decide) <|
+      cpsTripleWithin_weaken
+        (fun h hp => by
+          delta loopBodyN3MaxSkipJ1NormPreV4 at hp ⊢
+          xperm_hyp hp)
+        (fun h hp => by
+          rw [loopIterPostN3Max_skip hborrow] at hp
+          xperm_hyp hp)
+        Jf
 
 /-- No-NOP/v4 n=3 call+skip j=0 over the MOD code bundle, preserving
     concrete caller `x1`. -/

--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPathN3V4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPathN3V4NoNop.lean
@@ -409,6 +409,231 @@ theorem divK_loop_body_n3_call_addback_j0_mod_v4_spec_within_noNop_exact_x1
       v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal
       retMem dMem dloMem scratchUn0 scratchMem base halign hbltu hborrow hcarry2_nz)
 
+/-- Loop body n=3, call+skip, j=0 over `modCode_noNop_v4`, preserving
+    concrete `x1` and exposing the scratch loop-iteration post. -/
+theorem divK_loop_body_n3_call_skip_j0_loopIter_mod_v4_spec_within_noNop_exact_x1 (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu : BitVec.ult u3 v2)
+    (hborrow : loopBodyN3CallSkipJ0BorrowV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 148 (base + loopBodyOff) (base + denormOff) (modCode_noNop_v4 base)
+      (loopBodyN3CallSkipJ0PreV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopIterPostN3CallScratchNoX1 sp base (0 : Word)
+        (divKTrialCallV4QHat u3 u2 v2)
+        (divKTrialCallV4DLo v2)
+        (divKTrialCallV4Un0 u2)
+        (divKTrialCallV4ScratchOut u3 u2 v2 scratchMem)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+        (.x1 ↦ᵣ raVal)) := by
+  have hb :
+      ¬BitVec.ult uTop
+        (mulsubN4_c3 (divKTrialCallV4QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3) := by
+    unfold loopBodyN3CallSkipJ0BorrowV4 mulsubN4NoBorrow at hborrow
+    dsimp only [] at hborrow
+    intro hlt
+    unfold mulsubN4_c3 at hlt
+    rw [if_pos hlt] at hborrow
+    exact (by decide : (1 : Word) ≠ (0 : Word)) hborrow
+  exact cpsTripleWithin_weaken
+    (fun h hp => hp)
+    (fun h hp => by
+      have hpost :
+          ((loopBodyN3CallSkipPostJScratchNoX1 sp base (0 : Word)
+            (divKTrialCallV4QHat u3 u2 v2)
+            (divKTrialCallV4DLo v2)
+            (divKTrialCallV4Un0 u2)
+            (divKTrialCallV4ScratchOut u3 u2 v2 scratchMem)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop) ** (.x1 ↦ᵣ raVal)) h := by
+        unfold loopBodyN3CallSkipJ0PostV4NoX1 at hp
+        unfold loopBodyN3CallSkipPostJScratchNoX1
+        simpa only [sepConj_assoc'] using hp
+      rw [loopIterPostN3CallScratchNoX1_skip hb] at hpost
+      exact hpost)
+    (divK_loop_body_n3_call_skip_j0_mod_v4_spec_within_noNop_exact_x1
+      sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal
+      retMem dMem dloMem scratchUn0 scratchMem base halign hbltu hborrow)
+
+/-- Loop body n=3, call+addback, j=0 over `modCode_noNop_v4`, preserving
+    concrete `x1` and exposing the scratch loop-iteration post. -/
+theorem divK_loop_body_n3_call_addback_j0_loopIter_mod_v4_spec_within_noNop_exact_x1 (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu : BitVec.ult u3 v2)
+    (hborrow : loopBodyN3CallAddbackBorrowV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hcarry2_nz : loopBodyN3CallAddbackCarry2NzV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 224 (base + loopBodyOff) (base + denormOff) (modCode_noNop_v4 base)
+      (loopBodyN3CallSkipJ0PreV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopIterPostN3CallScratchNoX1 sp base (0 : Word)
+        (divKTrialCallV4QHat u3 u2 v2)
+        (divKTrialCallV4DLo v2)
+        (divKTrialCallV4Un0 u2)
+        (divKTrialCallV4ScratchOut u3 u2 v2 scratchMem)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+        (.x1 ↦ᵣ raVal)) := by
+  have hb :
+      BitVec.ult uTop
+        (mulsubN4_c3 (divKTrialCallV4QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3) := by
+    unfold loopBodyN3CallAddbackBorrowV4 at hborrow
+    dsimp only [] at hborrow
+    by_contra hlt
+    rw [if_neg hlt] at hborrow
+    exact hborrow rfl
+  exact cpsTripleWithin_weaken
+    (fun h hp => hp)
+    (fun h hp => by
+      have hpost :
+          ((loopBodyN3CallAddbackBeqPostJScratchNoX1 sp base (0 : Word)
+            (divKTrialCallV4QHat u3 u2 v2)
+            (divKTrialCallV4DLo v2)
+            (divKTrialCallV4Un0 u2)
+            (divKTrialCallV4ScratchOut u3 u2 v2 scratchMem)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop) ** (.x1 ↦ᵣ raVal)) h := by
+        unfold loopBodyN3CallAddbackJ0PostV4NoX1 at hp
+        unfold loopBodyN3CallAddbackBeqPostJScratchNoX1
+        simpa only [sepConj_assoc'] using hp
+      rw [loopIterPostN3CallScratchNoX1_addback hb] at hpost
+      exact hpost)
+    (divK_loop_body_n3_call_addback_j0_mod_v4_spec_within_noNop_exact_x1
+      sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal
+      retMem dMem dloMem scratchUn0 scratchMem base halign hbltu hborrow hcarry2_nz)
+
+/-- Loop body n=3, call path, j=0 over `modCode_noNop_v4`, selecting the
+    skip or addback correction from the computed mulsub borrow bit. -/
+theorem divK_loop_body_n3_call_j0_mod_v4_spec_within_noNop_exact_x1 (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu : BitVec.ult u3 v2)
+    (hcarry2_nz : loopBodyN3CallAddbackCarry2NzV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 224 (base + loopBodyOff) (base + denormOff) (modCode_noNop_v4 base)
+      (loopBodyN3CallSkipJ0PreV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopIterPostN3CallScratchNoX1 sp base (0 : Word)
+        (divKTrialCallV4QHat u3 u2 v2)
+        (divKTrialCallV4DLo v2)
+        (divKTrialCallV4Un0 u2)
+        (divKTrialCallV4ScratchOut u3 u2 v2 scratchMem)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+        (.x1 ↦ᵣ raVal)) := by
+  by_cases hborrow : BitVec.ult uTop
+      (mulsubN4_c3 (divKTrialCallV4QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3)
+  · have hborrow_nz : loopBodyN3CallAddbackBorrowV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+      simp [loopBodyN3CallAddbackBorrowV4, hborrow]
+    exact divK_loop_body_n3_call_addback_j0_loopIter_mod_v4_spec_within_noNop_exact_x1
+      sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal
+      retMem dMem dloMem scratchUn0 scratchMem halign hbltu hborrow_nz hcarry2_nz
+  · have hborrow_zero :
+        loopBodyN3CallSkipJ0BorrowV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+      unfold loopBodyN3CallSkipJ0BorrowV4 mulsubN4NoBorrow
+      dsimp only
+      unfold mulsubN4_c3 at hborrow
+      rw [if_neg hborrow]
+    exact cpsTripleWithin_mono_nSteps (show 148 ≤ 224 by decide) <|
+      divK_loop_body_n3_call_skip_j0_loopIter_mod_v4_spec_within_noNop_exact_x1
+        sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal
+        retMem dMem dloMem scratchUn0 scratchMem halign hbltu hborrow_zero
+
+/-- Full n=3 max×call path over `modCode_noNop_v4` from the callable-ready
+    v4 loop source, preserving concrete `x1`, scratch, and the j=1 stored
+    u4/q atoms. -/
+theorem divK_loop_n3_max_call_mod_v4_from_source_exact_loopIterScratch_noNop (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_1 : ¬BitVec.ult u3 v2)
+    (hcarry2_nz_1 : isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hbltu_0 :
+      let r1 := iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      BitVec.ult r1.2.2.2.1 v2)
+    (hcarry2_nz_0 :
+      let r1 := iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      loopBodyN3CallAddbackCarry2NzV4 v0 v1 v2 v3
+        u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1) :
+    let r1 := iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    let uBase1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+    cpsTripleWithin (152 + 224) (base + loopBodyOff) (base + denormOff) (modCode_noNop_v4 base)
+      (loopN3PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      ((loopIterPostN3CallScratchNoX1 sp base (0 : Word)
+        (divKTrialCallV4QHat r1.2.2.2.1 r1.2.2.1 v2)
+        (divKTrialCallV4DLo v2)
+        (divKTrialCallV4Un0 r1.2.2.1)
+        (divKTrialCallV4ScratchOut r1.2.2.2.1 r1.2.2.1 v2 scratchMem)
+        v0 v1 v2 v3 u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 **
+        (.x1 ↦ᵣ raVal)) **
+        ((uBase1 + signExtend12 4064 ↦ₘ r1.2.2.2.2.2) **
+         (qAddr1 ↦ₘ r1.1))) := by
+  intro r1 uBase1 qAddr1
+  have J1 := divK_loop_body_n3_max_j1_mod_v4_spec_within_noNop_exact_x1 sp base
+    jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop q1Old raVal
+    retMem dMem dloMem scratchUn0 scratchMem hbltu_1 hcarry2_nz_1
+  subst r1
+  subst uBase1
+  subst qAddr1
+  have J1f := cpsTripleWithin_frameR
+    ((((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 0 ↦ₘ u0Orig) **
+     ((sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q0Old)))
+    (by pcFree) J1
+  have J0 := divK_loop_body_n3_call_j0_mod_v4_spec_within_noNop_exact_x1 sp base
+    (1 : Word)
+    ((1 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat)
+    (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).1
+    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
+    v0 v1 v2 v3 u0Orig
+    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
+    q0Old raVal
+    retMem dMem dloMem scratchUn0 scratchMem
+    halign hbltu_0 hcarry2_nz_0
+  have J0f := cpsTripleWithin_frameR
+    (((sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 4064 ↦ₘ
+        (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.2) **
+     ((sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ
+        (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).1))
+    (by pcFree) J0
+  exact cpsTripleWithin_seq_perm_same_cr
+    (loopIterPostN3MaxScratchX1_j1_to_call_j0_pre
+      sp retMem dMem dloMem scratchUn0 scratchMem
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q0Old raVal)
+    (cpsTripleWithin_weaken
+      (loopN3PreWithScratchV4NoX1_to_max_j1_pre
+        sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal
+        retMem dMem dloMem scratchUn0 scratchMem)
+      (fun h hp => hp)
+      J1f)
+    J0f
+
 /-- No-NOP/v4 n=3 call+skip j=1 over the MOD code bundle, preserving
     concrete caller `x1`. -/
 theorem divK_loop_body_n3_call_skip_j1_mod_v4_spec_within_noNop_exact_x1
@@ -460,6 +685,361 @@ theorem divK_loop_body_n3_call_addback_j1_mod_v4_spec_within_noNop_exact_x1
       sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal
       retMem dMem dloMem scratchUn0 scratchMem base halign hbltu hborrow hcarry2_nz)
+
+/-- Loop body n=3, call+skip, j=1 over `modCode_noNop_v4`, preserving
+    concrete `x1` and exposing the scratch loop-iteration post. -/
+theorem divK_loop_body_n3_call_skip_j1_loopIter_mod_v4_spec_within_noNop_exact_x1 (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu : BitVec.ult u3 v2)
+    (hborrow : mulsubN4NoBorrow (divKTrialCallV4QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 148 (base + loopBodyOff) (base + loopBodyOff) (modCode_noNop_v4 base)
+      (loopBodyN3CallSkipJgt0PreV4NoX1 sp (1 : Word) jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopIterPostN3CallScratchNoX1 sp base (1 : Word)
+        (divKTrialCallV4QHat u3 u2 v2)
+        (divKTrialCallV4DLo v2)
+        (divKTrialCallV4Un0 u2)
+        (divKTrialCallV4ScratchOut u3 u2 v2 scratchMem)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+        (.x1 ↦ᵣ raVal)) := by
+  have hb :
+      ¬BitVec.ult uTop
+        (mulsubN4_c3 (divKTrialCallV4QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3) := by
+    unfold mulsubN4NoBorrow at hborrow
+    dsimp only [] at hborrow
+    intro hlt
+    unfold mulsubN4_c3 at hlt
+    rw [if_pos hlt] at hborrow
+    exact (by decide : (1 : Word) ≠ (0 : Word)) hborrow
+  exact cpsTripleWithin_weaken
+    (fun h hp => hp)
+    (fun h hp => by
+      have hpost :
+          ((loopBodyN3CallSkipPostJScratchNoX1 sp base (1 : Word)
+            (divKTrialCallV4QHat u3 u2 v2)
+            (divKTrialCallV4DLo v2)
+            (divKTrialCallV4Un0 u2)
+            (divKTrialCallV4ScratchOut u3 u2 v2 scratchMem)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop) ** (.x1 ↦ᵣ raVal)) h := by
+        unfold loopBodyN3CallSkipJgt0PostV4NoX1 at hp
+        unfold loopBodyN3CallSkipPostJScratchNoX1
+        simpa only [sepConj_assoc'] using hp
+      rw [loopIterPostN3CallScratchNoX1_skip hb] at hpost
+      exact hpost)
+    (divK_loop_body_n3_call_skip_j1_mod_v4_spec_within_noNop_exact_x1
+      sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal
+      retMem dMem dloMem scratchUn0 scratchMem base halign hbltu hborrow)
+
+/-- Loop body n=3, call+addback, j=1 over `modCode_noNop_v4`, preserving
+    concrete `x1` and exposing the scratch loop-iteration post. -/
+theorem divK_loop_body_n3_call_addback_j1_loopIter_mod_v4_spec_within_noNop_exact_x1 (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu : BitVec.ult u3 v2)
+    (hborrow : loopBodyN3CallAddbackBorrowV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hcarry2_nz : loopBodyN3CallAddbackCarry2NzV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 224 (base + loopBodyOff) (base + loopBodyOff) (modCode_noNop_v4 base)
+      (loopBodyN3CallSkipJgt0PreV4NoX1 sp (1 : Word) jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopIterPostN3CallScratchNoX1 sp base (1 : Word)
+        (divKTrialCallV4QHat u3 u2 v2)
+        (divKTrialCallV4DLo v2)
+        (divKTrialCallV4Un0 u2)
+        (divKTrialCallV4ScratchOut u3 u2 v2 scratchMem)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+        (.x1 ↦ᵣ raVal)) := by
+  have hb :
+      BitVec.ult uTop
+        (mulsubN4_c3 (divKTrialCallV4QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3) := by
+    unfold loopBodyN3CallAddbackBorrowV4 at hborrow
+    dsimp only [] at hborrow
+    by_contra hlt
+    rw [if_neg hlt] at hborrow
+    exact hborrow rfl
+  exact cpsTripleWithin_weaken
+    (fun h hp => hp)
+    (fun h hp => by
+      have hpost :
+          ((loopBodyN3CallAddbackBeqPostJScratchNoX1 sp base (1 : Word)
+            (divKTrialCallV4QHat u3 u2 v2)
+            (divKTrialCallV4DLo v2)
+            (divKTrialCallV4Un0 u2)
+            (divKTrialCallV4ScratchOut u3 u2 v2 scratchMem)
+            v0 v1 v2 v3 u0 u1 u2 u3 uTop) ** (.x1 ↦ᵣ raVal)) h := by
+        unfold loopBodyN3CallAddbackJgt0PostV4NoX1 at hp
+        unfold loopBodyN3CallAddbackBeqPostJScratchNoX1
+        simpa only [sepConj_assoc'] using hp
+      rw [loopIterPostN3CallScratchNoX1_addback hb] at hpost
+      exact hpost)
+    (divK_loop_body_n3_call_addback_j1_mod_v4_spec_within_noNop_exact_x1
+      sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal
+      retMem dMem dloMem scratchUn0 scratchMem base halign hbltu hborrow hcarry2_nz)
+
+/-- Loop body n=3, call path, j=1 over `modCode_noNop_v4`, selecting the
+    skip or addback correction from the computed mulsub borrow bit. -/
+theorem divK_loop_body_n3_call_j1_mod_v4_spec_within_noNop_exact_x1 (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu : BitVec.ult u3 v2)
+    (hcarry2_nz : loopBodyN3CallAddbackCarry2NzV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 224 (base + loopBodyOff) (base + loopBodyOff) (modCode_noNop_v4 base)
+      (loopBodyN3CallSkipJgt0PreV4NoX1 sp (1 : Word) jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopIterPostN3CallScratchNoX1 sp base (1 : Word)
+        (divKTrialCallV4QHat u3 u2 v2)
+        (divKTrialCallV4DLo v2)
+        (divKTrialCallV4Un0 u2)
+        (divKTrialCallV4ScratchOut u3 u2 v2 scratchMem)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+        (.x1 ↦ᵣ raVal)) := by
+  by_cases hborrow : BitVec.ult uTop
+      (mulsubN4_c3 (divKTrialCallV4QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3)
+  · have hborrow_nz : loopBodyN3CallAddbackBorrowV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+      simp [loopBodyN3CallAddbackBorrowV4, hborrow]
+    exact divK_loop_body_n3_call_addback_j1_loopIter_mod_v4_spec_within_noNop_exact_x1
+      sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal
+      retMem dMem dloMem scratchUn0 scratchMem halign hbltu hborrow_nz hcarry2_nz
+  · have hborrow_zero :
+        mulsubN4NoBorrow (divKTrialCallV4QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+      unfold mulsubN4NoBorrow
+      dsimp only
+      unfold mulsubN4_c3 at hborrow
+      rw [if_neg hborrow]
+    exact cpsTripleWithin_mono_nSteps (show 148 ≤ 224 by decide) <|
+      divK_loop_body_n3_call_skip_j1_loopIter_mod_v4_spec_within_noNop_exact_x1
+        sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal
+        retMem dMem dloMem scratchUn0 scratchMem halign hbltu hborrow_zero
+
+/-- First n=3 call iteration from the callable-ready v4 loop source over
+    `modCode_noNop_v4`, preserving concrete `x1` and carrying the j=0 source
+    atoms as a frame. -/
+theorem divK_loop_n3_call_j1_mod_v4_from_source_exact_loopIterScratch_noNop (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu : BitVec.ult u3 v2)
+    (hcarry2_nz : loopBodyN3CallAddbackCarry2NzV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 224 (base + loopBodyOff) (base + loopBodyOff) (modCode_noNop_v4 base)
+      (loopN3PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      ((loopIterPostN3CallScratchNoX1 sp base (1 : Word)
+        (divKTrialCallV4QHat u3 u2 v2)
+        (divKTrialCallV4DLo v2)
+        (divKTrialCallV4Un0 u2)
+        (divKTrialCallV4ScratchOut u3 u2 v2 scratchMem)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+        (.x1 ↦ᵣ raVal)) **
+        (((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) +
+          signExtend12 0 ↦ₘ u0Orig) **
+         ((sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q0Old))) := by
+  have J1 := divK_loop_body_n3_call_j1_mod_v4_spec_within_noNop_exact_x1 sp base
+    jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop q1Old raVal
+    retMem dMem dloMem scratchUn0 scratchMem halign hbltu hcarry2_nz
+  have J1f := cpsTripleWithin_frameR
+    ((((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 0 ↦ₘ u0Orig) **
+     ((sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q0Old)))
+    (by pcFree) J1
+  exact cpsTripleWithin_weaken
+    (loopN3PreWithScratchV4NoX1_to_call_j1_pre
+      sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal
+      retMem dMem dloMem scratchUn0 scratchMem)
+    (fun h hp => hp)
+    J1f
+
+/-- Full n=3 call×call path over `modCode_noNop_v4` from the callable-ready
+    v4 loop source, preserving concrete `x1` and the j=1 stored u4/q atoms. -/
+theorem divK_loop_n3_call_call_mod_v4_from_source_exact_loopIterScratch_noNop (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_1 : BitVec.ult u3 v2)
+    (hcarry2_nz_1 : loopBodyN3CallAddbackCarry2NzV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hbltu_0 :
+      BitVec.ult
+        (iterWithDoubleAddback (divKTrialCallV4QHat u3 u2 v2)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1 v2)
+    (hcarry2_nz_0 :
+      let r1 := iterWithDoubleAddback (divKTrialCallV4QHat u3 u2 v2)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      loopBodyN3CallAddbackCarry2NzV4 v0 v1 v2 v3
+        u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1) :
+    let r1 := iterWithDoubleAddback (divKTrialCallV4QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    let uBase1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+    cpsTripleWithin (224 + 224) (base + loopBodyOff) (base + denormOff) (modCode_noNop_v4 base)
+      (loopN3PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      ((loopIterPostN3CallScratchNoX1 sp base (0 : Word)
+        (divKTrialCallV4QHat r1.2.2.2.1 r1.2.2.1 v2)
+        (divKTrialCallV4DLo v2)
+        (divKTrialCallV4Un0 r1.2.2.1)
+        (divKTrialCallV4ScratchOut r1.2.2.2.1 r1.2.2.1 v2
+          (divKTrialCallV4ScratchOut u3 u2 v2 scratchMem))
+        v0 v1 v2 v3 u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 **
+        (.x1 ↦ᵣ raVal)) **
+        ((uBase1 + signExtend12 4064 ↦ₘ r1.2.2.2.2.2) **
+         (qAddr1 ↦ₘ r1.1))) := by
+  intro r1 uBase1 qAddr1
+  have J1 := divK_loop_n3_call_j1_mod_v4_from_source_exact_loopIterScratch_noNop
+    sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal
+    retMem dMem dloMem scratchUn0 scratchMem halign hbltu_1 hcarry2_nz_1
+  subst r1
+  subst uBase1
+  subst qAddr1
+  have J0 := divK_loop_body_n3_call_j0_mod_v4_spec_within_noNop_exact_x1 sp base
+    (1 : Word)
+    ((1 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat)
+    (mulsubN4_c3 (divKTrialCallV4QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3)
+    (iterWithDoubleAddback (divKTrialCallV4QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).1
+    (iterWithDoubleAddback (divKTrialCallV4QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
+    v0 v1 v2 v3 u0Orig
+    (iterWithDoubleAddback (divKTrialCallV4QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+    (iterWithDoubleAddback (divKTrialCallV4QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+    (iterWithDoubleAddback (divKTrialCallV4QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+    (iterWithDoubleAddback (divKTrialCallV4QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
+    q0Old raVal
+    (base + div128CallRetOff) v2 (divKTrialCallV4DLo v2)
+    (divKTrialCallV4Un0 u2) (divKTrialCallV4ScratchOut u3 u2 v2 scratchMem)
+    halign hbltu_0 hcarry2_nz_0
+  have J0f := cpsTripleWithin_frameR
+    (((sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 4064 ↦ₘ
+        (iterWithDoubleAddback (divKTrialCallV4QHat u3 u2 v2)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.2) **
+     ((sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ
+        (iterWithDoubleAddback (divKTrialCallV4QHat u3 u2 v2)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).1))
+    (by pcFree) J0
+  exact cpsTripleWithin_seq_perm_same_cr
+    (loopIterPostN3CallScratchNoX1_j1_to_call_j0_pre
+      sp base (divKTrialCallV4QHat u3 u2 v2) (divKTrialCallV4DLo v2)
+      (divKTrialCallV4Un0 u2) (divKTrialCallV4ScratchOut u3 u2 v2 scratchMem)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q0Old raVal)
+    J1 J0f
+
+/-- Full n=3 call×max path over `modCode_noNop_v4` from the callable-ready
+    v4 loop source, preserving concrete `x1`, scratch, and the j=1 stored
+    u4/q atoms. -/
+theorem divK_loop_n3_call_max_mod_v4_from_source_exact_loopIterScratch_noNop (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_1 : BitVec.ult u3 v2)
+    (hcarry2_nz_1 : loopBodyN3CallAddbackCarry2NzV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hbltu_0 :
+      let r1 := iterWithDoubleAddback (divKTrialCallV4QHat u3 u2 v2)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      ¬BitVec.ult r1.2.2.2.1 v2)
+    (hcarry2_nz_0 :
+      let r1 := iterWithDoubleAddback (divKTrialCallV4QHat u3 u2 v2)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      isAddbackCarry2NzN3Max v0 v1 v2 v3
+        u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1) :
+    let r1 := iterWithDoubleAddback (divKTrialCallV4QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    let uBase1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+    cpsTripleWithin (224 + 152) (base + loopBodyOff) (base + denormOff) (modCode_noNop_v4 base)
+      (loopN3PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      ((loopIterPostN3Max sp (0 : Word) v0 v1 v2 v3
+        u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 **
+        (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+        (sp + signExtend12 3960 ↦ₘ v2) **
+        (sp + signExtend12 3952 ↦ₘ (divKTrialCallV4DLo v2)) **
+        (sp + signExtend12 3944 ↦ₘ (divKTrialCallV4Un0 u2)) **
+        (sp + signExtend12 3936 ↦ₘ (divKTrialCallV4ScratchOut u3 u2 v2 scratchMem)) **
+        (.x1 ↦ᵣ raVal)) **
+        ((uBase1 + signExtend12 4064 ↦ₘ r1.2.2.2.2.2) **
+         (qAddr1 ↦ₘ r1.1))) := by
+  intro r1 uBase1 qAddr1
+  have J1 := divK_loop_n3_call_j1_mod_v4_from_source_exact_loopIterScratch_noNop
+    sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal
+    retMem dMem dloMem scratchUn0 scratchMem halign hbltu_1 hcarry2_nz_1
+  subst r1
+  subst uBase1
+  subst qAddr1
+  have J0 := divK_loop_body_n3_max_j0_mod_v4_spec_within_noNop_exact_x1 sp base
+    (1 : Word)
+    ((1 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat)
+    (mulsubN4_c3 (divKTrialCallV4QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3)
+    (iterWithDoubleAddback (divKTrialCallV4QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).1
+    (iterWithDoubleAddback (divKTrialCallV4QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
+    v0 v1 v2 v3 u0Orig
+    (iterWithDoubleAddback (divKTrialCallV4QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+    (iterWithDoubleAddback (divKTrialCallV4QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+    (iterWithDoubleAddback (divKTrialCallV4QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+    (iterWithDoubleAddback (divKTrialCallV4QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
+    q0Old raVal
+    (base + div128CallRetOff) v2 (divKTrialCallV4DLo v2)
+    (divKTrialCallV4Un0 u2) (divKTrialCallV4ScratchOut u3 u2 v2 scratchMem)
+    hbltu_0 hcarry2_nz_0
+  have J0f := cpsTripleWithin_frameR
+    (((sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 4064 ↦ₘ
+        (iterWithDoubleAddback (divKTrialCallV4QHat u3 u2 v2)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.2) **
+     ((sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ
+        (iterWithDoubleAddback (divKTrialCallV4QHat u3 u2 v2)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).1))
+    (by pcFree) J0
+  exact cpsTripleWithin_seq_perm_same_cr
+    (loopIterPostN3CallScratchNoX1_j1_to_max_j0_pre
+      sp base (divKTrialCallV4QHat u3 u2 v2) (divKTrialCallV4DLo v2)
+      (divKTrialCallV4Un0 u2) (divKTrialCallV4ScratchOut u3 u2 v2 scratchMem)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q0Old raVal)
+    J1 J0f
 
 /-- MOD n=3 path from entry to NormA over the no-NOP v4 MOD code bundle. -/
 theorem evm_mod_n3_to_normB_spec_within_v4_noNop (sp base : Word)

--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPathN3V4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPathN3V4NoNop.lean
@@ -5,12 +5,115 @@
 -/
 
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN4V4NoNop
+import EvmAsm.Evm64.DivMod.LoopIterN3CallV4NoNop
+import EvmAsm.Evm64.DivMod.LoopIterN3AddbackV4NoNop
 
 open EvmAsm.Rv64.Tactics
 
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
+
+/-- No-NOP/v4 n=3 call+skip j=0 over the MOD code bundle, preserving
+    concrete caller `x1`. -/
+theorem divK_loop_body_n3_call_skip_j0_mod_v4_spec_within_noNop_exact_x1
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu : BitVec.ult u3 v2)
+    (hborrow : loopBodyN3CallSkipJ0BorrowV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 148 (base + loopBodyOff) (base + denormOff) (modCode_noNop_v4 base)
+      (loopBodyN3CallSkipJ0PreV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopBodyN3CallSkipJ0PostV4NoX1 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem **
+        (.x1 ↦ᵣ raVal)) := by
+  exact cpsTripleWithin_extend_code
+    (hmono := sharedDivModCodeNoNop_v4_sub_modCode_noNop_v4)
+    (divK_loop_body_n3_call_skip_j0_v4_spec_within_noNop_exact_x1
+      sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal
+      retMem dMem dloMem scratchUn0 scratchMem base halign hbltu hborrow)
+
+/-- No-NOP/v4 n=3 call+addback j=0 over the MOD code bundle, preserving
+    concrete caller `x1`. -/
+theorem divK_loop_body_n3_call_addback_j0_mod_v4_spec_within_noNop_exact_x1
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu : BitVec.ult u3 v2)
+    (hborrow : loopBodyN3CallAddbackBorrowV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hcarry2_nz : loopBodyN3CallAddbackCarry2NzV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 224 (base + loopBodyOff) (base + denormOff) (modCode_noNop_v4 base)
+      (loopBodyN3CallSkipJ0PreV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopBodyN3CallAddbackJ0PostV4NoX1 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem **
+        (.x1 ↦ᵣ raVal)) := by
+  exact cpsTripleWithin_extend_code
+    (hmono := sharedDivModCodeNoNop_v4_sub_modCode_noNop_v4)
+    (divK_loop_body_n3_call_addback_j0_beq_v4_spec_within_noNop_exact_x1
+      sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal
+      retMem dMem dloMem scratchUn0 scratchMem base halign hbltu hborrow hcarry2_nz)
+
+/-- No-NOP/v4 n=3 call+skip j=1 over the MOD code bundle, preserving
+    concrete caller `x1`. -/
+theorem divK_loop_body_n3_call_skip_j1_mod_v4_spec_within_noNop_exact_x1
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu : BitVec.ult u3 v2)
+    (hborrow : mulsubN4NoBorrow (divKTrialCallV4QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 148 (base + loopBodyOff) (base + loopBodyOff) (modCode_noNop_v4 base)
+      (loopBodyN3CallSkipJgt0PreV4NoX1 sp (1 : Word) jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopBodyN3CallSkipJgt0PostV4NoX1 sp base (1 : Word)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem **
+        (.x1 ↦ᵣ raVal)) := by
+  exact cpsTripleWithin_extend_code
+    (hmono := sharedDivModCodeNoNop_v4_sub_modCode_noNop_v4)
+    (divK_loop_body_n3_call_skip_j1_v4_spec_within_noNop_exact_x1
+      sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal
+      retMem dMem dloMem scratchUn0 scratchMem base halign hbltu hborrow)
+
+/-- No-NOP/v4 n=3 call+addback j=1 over the MOD code bundle, preserving
+    concrete caller `x1`. -/
+theorem divK_loop_body_n3_call_addback_j1_mod_v4_spec_within_noNop_exact_x1
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu : BitVec.ult u3 v2)
+    (hborrow : loopBodyN3CallAddbackBorrowV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hcarry2_nz : loopBodyN3CallAddbackCarry2NzV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 224 (base + loopBodyOff) (base + loopBodyOff) (modCode_noNop_v4 base)
+      (loopBodyN3CallSkipJgt0PreV4NoX1 sp (1 : Word) jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopBodyN3CallAddbackJgt0PostV4NoX1 sp base (1 : Word)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem **
+        (.x1 ↦ᵣ raVal)) := by
+  exact cpsTripleWithin_extend_code
+    (hmono := sharedDivModCodeNoNop_v4_sub_modCode_noNop_v4)
+    (divK_loop_body_n3_call_addback_jgt0_beq_v4_spec_within_noNop_exact_x1
+      (1 : Word) EvmAsm.Evm64.DivMod.AddrNorm.slt_jpos_1
+      sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal
+      retMem dMem dloMem scratchUn0 scratchMem base halign hbltu hborrow hcarry2_nz)
 
 /-- MOD n=3 path from entry to NormA over the no-NOP v4 MOD code bundle. -/
 theorem evm_mod_n3_to_normB_spec_within_v4_noNop (sp base : Word)

--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPathN3V4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPathN3V4NoNop.lean
@@ -5,7 +5,7 @@
 -/
 
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN4V4NoNop
-import EvmAsm.Evm64.DivMod.Compose.FullPathN3V4NoNop
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V4NoNopMaxCall
 import EvmAsm.Evm64.DivMod.LoopIterN3MaxV4NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN3CallV4NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN3AddbackV4NoNop
@@ -278,6 +278,87 @@ theorem divK_loop_body_n3_max_j1_mod_v4_spec_within_noNop_exact_x1 (sp base : Wo
           rw [loopIterPostN3Max_skip hborrow] at hp
           xperm_hyp hp)
         Jf
+
+/-- Full n=3 max×max path over `modCode_noNop_v4` from the callable-ready
+    v4 loop source, preserving concrete `x1`, scratch, and the j=1 stored
+    u4/q atoms. -/
+theorem divK_loop_n3_max_max_mod_v4_from_source_exact_loopIterScratch_noNop (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hbltu_1 : ¬BitVec.ult u3 v2)
+    (hcarry2_nz_1 : isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hbltu_0 :
+      let r1 := iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      ¬BitVec.ult r1.2.2.2.1 v2)
+    (hcarry2_nz_0 :
+      let r1 := iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      isAddbackCarry2NzN3Max v0 v1 v2 v3
+        u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1) :
+    let r1 := iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    let uBase1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+    cpsTripleWithin (152 + 152) (base + loopBodyOff) (base + denormOff) (modCode_noNop_v4 base)
+      (loopN3PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      ((loopIterPostN3Max sp (0 : Word) v0 v1 v2 v3
+        u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal)) **
+        ((uBase1 + signExtend12 4064 ↦ₘ r1.2.2.2.2.2) **
+         (qAddr1 ↦ₘ r1.1))) := by
+  intro r1 uBase1 qAddr1
+  have J1 := divK_loop_body_n3_max_j1_mod_v4_spec_within_noNop_exact_x1 sp base
+    jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop q1Old raVal
+    retMem dMem dloMem scratchUn0 scratchMem hbltu_1 hcarry2_nz_1
+  subst r1
+  subst uBase1
+  subst qAddr1
+  have J1f := cpsTripleWithin_frameR
+    ((((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 0 ↦ₘ u0Orig) **
+     ((sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ q0Old)))
+    (by pcFree) J1
+  have J0 := divK_loop_body_n3_max_j0_mod_v4_spec_within_noNop_exact_x1 sp base
+    (1 : Word)
+    ((1 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat)
+    (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).1
+    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
+    v0 v1 v2 v3 u0Orig
+    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
+    q0Old raVal retMem dMem dloMem scratchUn0 scratchMem hbltu_0 hcarry2_nz_0
+  have J0f := cpsTripleWithin_frameR
+    (((sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 4064 ↦ₘ
+        (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.2) **
+     ((sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ
+        (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).1))
+    (by pcFree) J0
+  exact cpsTripleWithin_seq_perm_same_cr
+    (loopIterPostN3MaxScratchX1_j1_to_max_j0_pre
+      sp retMem dMem dloMem scratchUn0 scratchMem
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q0Old raVal)
+    (cpsTripleWithin_weaken
+      (loopN3PreWithScratchV4NoX1_to_max_j1_pre
+        sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old raVal
+        retMem dMem dloMem scratchUn0 scratchMem)
+      (fun h hp => hp)
+      J1f)
+    J0f
 
 /-- No-NOP/v4 n=3 call+skip j=0 over the MOD code bundle, preserving
     concrete caller `x1`. -/

--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPathN3V4NoNopPreloop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPathN3V4NoNopPreloop.lean
@@ -1,0 +1,200 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.ModFullPathN3V4NoNopPreloop
+
+  v4/no-NOP MOD n=3 preloop wrappers from entry to loop setup.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.ModFullPathN3V4NoNop
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Helper: instantiate the MOD v4 no-NOP exact-`x1` n=3 loop with explicit
+    normalized values, keeping the v4 div128 scratch cell and caller-owned
+    `x1` split out of the loop source. -/
+theorem evm_mod_n3_loop_unified_inst_noNop_exact_x1_v4
+    (bltu_1 bltu_0 : Bool) (sp base : Word)
+    (shift antiShift b0' b1' b2' b3' u0 u1 u2 u3 u4 : Word)
+    (v10Old v11Old jMem : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem raVal : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_1 : bltu_1 = BitVec.ult u4 b2')
+    (hbltu_0 : bltu_0 =
+      match bltu_1 with
+      | false => BitVec.ult (iterN3Max b0' b1' b2' b3' u1 u2 u3 u4 (0 : Word)).2.2.2.1 b2'
+      | true =>
+        BitVec.ult
+          (iterWithDoubleAddback (divKTrialCallV4QHat u4 u3 b2')
+            b0' b1' b2' b3' u1 u2 u3 u4 (0 : Word)).2.2.2.1 b2')
+    (hcarry2 : Carry2NzAll b0' b1' b2' b3') :
+    cpsTripleWithin 448 (base + loopBodyOff) (base + denormOff) (modCode_noNop_v4 base)
+      (loopN3PreWithScratchV4NoX1 sp jMem (3 : Word) shift u0 v10Old v11Old antiShift
+        b0' b1' b2' b3' u1 u2 u3 u4 (0 : Word) u0 (0 : Word) (0 : Word)
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopN3UnifiedPostV4NoX1 bltu_1 bltu_0 sp base
+        b0' b1' b2' b3' u1 u2 u3 u4 (0 : Word) u0
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal)) :=
+  divK_loop_n3_unified_from_source_exact_loopIterScratch_mod_v4_noNop
+    bltu_1 bltu_0 sp base
+    jMem (3 : Word) shift u0 v10Old v11Old antiShift
+    b0' b1' b2' b3' u1 u2 u3 u4 (0 : Word) u0 (0 : Word) (0 : Word) raVal
+    retMem dMem dloMem scratchUn0 scratchMem
+    halign hbltu_1 hbltu_0 hcarry2
+
+/-- MOD n=3 path from entry to NormA over the no-NOP v4 MOD code bundle. -/
+theorem evm_mod_n3_to_normB_spec_within_v4_noNop (sp base : Word)
+    (b0 b1 b2 b3 v5 v6 v7 v10 : Word)
+    (q0 q1 q2 q3 u5 u6 u7 nMem shiftMem : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2nz : b2 ≠ 0)
+    (hshift_nz : (clzResult b2).1 ≠ 0) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21) base (base + normAOff) (modCode_noNop_v4 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
+      (normBPost sp (3 : Word) (clzResult b2).1 b0 b1 b2 b3) := by
+  let shift := (clzResult b2).1
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  have hABCLZ := evm_mod_phaseAB_n3_clz_spec_within_v4_noNop sp base b0 b1 b2 b3 v5 v6 v7 v10
+    q0 q1 q2 q3 u5 u6 u7 nMem hbnz hb3z hb2nz
+  have hABCLZf := cpsTripleWithin_frameR
+    ((.x2 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
+     ((sp + signExtend12 3992) ↦ₘ shiftMem))
+    (by pcFree) hABCLZ
+  have hC2 := divK_phaseC2_ntaken_spec_within_mod_v4_noNop sp shift ((clzResult b2).2 >>> (63 : Nat))
+    shiftMem base hshift_nz
+  have hC2f := cpsTripleWithin_frameR
+    ((.x5 ↦ᵣ (clzResult b2).2) ** (.x10 ↦ᵣ b3) **
+     (.x7 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
+     ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+     ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (3 : Word)))
+    (by pcFree) hC2
+  have hABC2 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hABCLZf hC2f
+  have hNB := divK_normB_full_spec_within_mod_v4_noNop sp b0 b1 b2 b3
+    (clzResult b2).2 ((clzResult b2).2 >>> (63 : Nat))
+    shift antiShift base
+  simp only [normBFullPost_unfold] at hNB
+  have hNBf := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (3 : Word)) **
+     ((sp + signExtend12 3992) ↦ₘ shift))
+    (by pcFree) hNB
+  have hFull := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hABC2 hNBf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by delta normBPost; xperm_hyp hq)
+    hFull
+
+/-- MOD n=3 path from entry to loop body start over the no-NOP v4 MOD code bundle. -/
+theorem evm_mod_n3_to_loopSetup_spec_within_v4_noNop (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2nz : b2 ≠ 0)
+    (hshift_nz : (clzResult b2).1 ≠ 0) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4) base (base + loopBodyOff) (modCode_noNop_v4 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+       ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+       ((sp + signExtend12 4024) ↦ₘ u4Old) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
+      (loopSetupPost sp (3 : Word) (clzResult b2).1 a0 a1 a2 a3 b0 b1 b2 b3) := by
+  let shift := (clzResult b2).1
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+  let b0' := b0 <<< (shift.toNat % 64)
+  let u4 := a3 >>> (antiShift.toNat % 64)
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
+  let u0 := a0 <<< (shift.toNat % 64)
+  have hNormB := evm_mod_n3_to_normB_spec_within_v4_noNop sp base b0 b1 b2 b3 v5 v6 v7 v10
+    q0 q1 q2 q3 u5 u6 u7 nMem shiftMem hbnz hb3z hb2nz hshift_nz
+  have hNormBf := cpsTripleWithin_frameR
+    ((.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+     ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+     ((sp + signExtend12 4024) ↦ₘ u4Old))
+    (by pcFree) hNormB
+  have hNormA := divK_normA_full_spec_within_mod_v4_noNop sp a0 a1 a2 a3
+    b0' (b0 >>> (antiShift.toNat % 64)) b3 shift antiShift
+    u0Old u1Old u2Old u3Old u4Old base
+  rw [divKNormAFullPreNoNop_unfold] at hNormA
+  simp only [normAFullPost_unfold] at hNormA
+  have hNormAf := cpsTripleWithin_frameR
+    ((.x0 ↦ᵣ (0 : Word)) **
+     (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
+     ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3') **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (3 : Word)) **
+     ((sp + signExtend12 3992) ↦ₘ shift))
+    (by pcFree) hNormA
+  have hNA := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by delta normBPost at hp; xperm_hyp hp) hNormBf hNormAf
+  have hLS := divK_loopSetup_ntaken_spec_within_mod_v4_noNop sp (3 : Word)
+    (signExtend12 (4 : BitVec 12) - (4 : Word)) u1 base
+    (by decide)
+  simp only [divKLoopSetupNtakenPreNoNop_unfold,
+      divKLoopSetupNtakenPostNoNop_unfold] at hLS
+  have hLSf := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ (a0 >>> (antiShift.toNat % 64))) **
+     (.x6 ↦ᵣ shift) ** (.x7 ↦ᵣ u0) ** (.x2 ↦ᵣ antiShift) **
+     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
+     ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3') **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
+     ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3) **
+     ((sp + signExtend12 4024) ↦ₘ u4) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3992) ↦ₘ shift))
+    (by pcFree) hLS
+  have hFull := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hNA hLSf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by delta loopSetupPost; xperm_hyp hq)
+    hFull
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/ModPhaseABN4V4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModPhaseABN4V4NoNop.lean
@@ -13,7 +13,8 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 open EvmAsm.Rv64.AddrNorm
-  (bv64_4mul_9 bv64_4mul_10 se12_32)
+  (bv64_4mul_9 bv64_4mul_10 bv64_4mul_11 bv64_4mul_12 se12_32)
+open EvmAsm.Evm64.DivMod.AddrNorm (se12_3)
 
 private theorem divK_phaseA_code_sub_modCode_noNop_v4 {base : Word} :
     ∀ a i, (divK_phaseA_code base) a = some i → (modCode_noNop_v4 base) a = some i := by
@@ -76,19 +77,49 @@ private theorem bne_x10_singleton_sub_modCode_noNop_v4 {base : Word} :
       show (base + phaseBOff : Word) + 40 = base + phaseBBneOff from by bv_addr] at hlookup
   exact sharedNoNop_v4_b1_mod a i (CodeReq.singleton_mono hlookup a i h)
 
+private theorem addi_x5_3_sub_modCode_noNop_v4 {base : Word} :
+    ∀ a i, (CodeReq.singleton (base + phaseBStep1Off) (.ADDI .x5 .x0 3)) a = some i →
+      (modCode_noNop_v4 base) a = some i := by
+  intro a i h
+  have hlookup := CodeReq.ofProg_lookup (base + phaseBOff) divK_phaseB 11
+    (by decide) (by decide)
+  rw [bv64_4mul_11,
+      show (base + phaseBOff : Word) + 44 = base + phaseBStep1Off from by bv_addr] at hlookup
+  exact sharedNoNop_v4_b1_mod a i (CodeReq.singleton_mono hlookup a i h)
+
+private theorem bne_x7_16_sub_modCode_noNop_v4 {base : Word} :
+    ∀ a i, (CodeReq.singleton (base + phaseBBne2Off) (.BNE .x7 .x0 16)) a = some i →
+      (modCode_noNop_v4 base) a = some i := by
+  intro a i h
+  have hlookup := CodeReq.ofProg_lookup (base + phaseBOff) divK_phaseB 12
+    (by decide) (by decide)
+  rw [bv64_4mul_12,
+      show (base + phaseBOff : Word) + 48 = base + phaseBBne2Off from by bv_addr] at hlookup
+  exact sharedNoNop_v4_b1_mod a i (CodeReq.singleton_mono hlookup a i h)
+
 private theorem phB_i2_8_mod_v4 {base : Word} :
     (base + phaseBInit2Off : Word) + 8 = base + phaseBStep0Off := by bv_addr
 private theorem phB_addi_4_mod_v4 {base : Word} :
     (base + phaseBStep0Off : Word) + 4 = base + phaseBBneOff := by bv_addr
 private theorem phB_bne_4_mod_v4 {base : Word} :
     (base + phaseBBneOff : Word) + 4 = base + phaseBStep1Off := by bv_addr
+private theorem phB_step1_4_mod_v4 {base : Word} :
+    (base + phaseBStep1Off : Word) + 4 = base + phaseBBne2Off := by bv_addr
+private theorem phB_step1_8_mod_v4 {base : Word} :
+    (base + phaseBBne2Off : Word) + 4 = base + phaseBStep2Off := by bv_addr
 private theorem phB_t_20_mod_v4 {base : Word} :
     (base + phaseBTailOff : Word) + 20 = base + clzOff := by bv_addr
 private theorem divK_phaseB_n4_nm1_x8_mod_v4 :
     ((4 : Word) + signExtend12 (4095 : BitVec 12)) <<< (3 : BitVec 6).toNat = (24 : Word) := by
   decide
+private theorem divK_phaseB_n3_nm1_x8_mod_v4 :
+    ((3 : Word) + signExtend12 (4095 : BitVec 12)) <<< (3 : BitVec 6).toNat = (16 : Word) := by
+  decide
 private theorem phB_sp24_32_mod_v4 {sp : Word} :
     (sp + (24 : Word) + (32 : Word)) = sp + 56 := by
+  bv_addr
+private theorem phB_sp16_32_mod_v4 {sp : Word} :
+    (sp + (16 : Word) + (32 : Word)) = sp + 48 := by
   bv_addr
 
 /-- PhaseA nonzero path over the no-NOP v4 MOD code bundle. -/
@@ -179,6 +210,222 @@ theorem evm_mod_phaseB_n4_spec_within_v4_noNop (sp base : Word)
     (fun h hp => by xperm_hyp hp)
     (fun h hq => by xperm_hyp hq)
     hinit1fhinit2haddihbnehtail
+
+/-- PhaseB n=3 over the no-NOP v4 MOD code bundle. -/
+theorem evm_mod_phaseB_n3_spec_within_v4_noNop (sp base : Word)
+    (b1 b2 b3 : Word) (v5 v6 v7 : Word)
+    (q0 q1 q2 q3 u5 u6 u7 nMem : Word)
+    (hb3z : b3 = 0) (hb2nz : b2 ≠ 0) :
+    cpsTripleWithin 21 (base + phaseBOff) (base + clzOff) (modCode_noNop_v4 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+       ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) **
+       ((sp + signExtend12 3984) ↦ₘ nMem))
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b2) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
+       ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 3984) ↦ₘ (3 : Word))) := by
+  have hinit1_raw := divK_phaseB_init1_spec_within sp (base + phaseBOff) q0 q1 q2 q3 u5 u6 u7
+  simp only [phB_off_28] at hinit1_raw
+  have hinit1 := cpsTripleWithin_extend_code divK_phaseB_init1_code_sub_modCode_noNop_v4 hinit1_raw
+  have hinit1f := cpsTripleWithin_frameR
+    ((.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+     ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 3984) ↦ₘ nMem))
+    (by pcFree) hinit1
+  have hinit2_raw := divK_phaseB_init2_spec_within sp (base + phaseBInit2Off) b1 b2 v6 v7
+  simp only [phB_i2_8_mod_v4] at hinit2_raw
+  have hinit2 := cpsTripleWithin_extend_code divK_phaseB_init2_code_sub_modCode_noNop_v4 hinit2_raw
+  have hinit2f := cpsTripleWithin_frameR
+    ((.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
+     ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3984) ↦ₘ nMem))
+    (by pcFree) hinit2
+  have h12 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hinit1f hinit2f
+  have haddi0_raw := addi_x0_spec_gen_within .x5 v5 4 (base + phaseBStep0Off) (by nofun)
+  simp only [phB_addi_4_mod_v4, signExtend12_4] at haddi0_raw
+  have haddi0 := cpsTripleWithin_extend_code addi_x5_singleton_sub_modCode_noNop_v4 haddi0_raw
+  have haddi0f := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ b3) ** (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
+     ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3984) ↦ₘ nMem))
+    (by pcFree) haddi0
+  have h123 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) h12 haddi0f
+  have hbne0_raw := bne_spec_gen_within .x10 .x0 24 b3 (0 : Word) (base + phaseBBneOff)
+  rw [show (base + phaseBBneOff : Word) + signExtend13 24 = base + phaseBTailOff from by
+        rv64_addr, phB_bne_4_mod_v4] at hbne0_raw
+  have hbne0_clean := cpsBranchWithin_ntakenStripPure2 hbne0_raw
+    (fun hp hQt => by
+      obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
+      exact absurd hb3z ((sepConj_pure_right _).mp h_rest).2)
+  have hbne0 := cpsTripleWithin_extend_code bne_x10_singleton_sub_modCode_noNop_v4 hbne0_clean
+  have hbne0f := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (4 : Word)) ** (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
+     ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3984) ↦ₘ nMem))
+    (by pcFree) hbne0
+  have h1234 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) h123 hbne0f
+  have haddi1_raw := addi_x0_spec_gen_within .x5 (4 : Word) 3 (base + phaseBStep1Off) (by nofun)
+  simp only [phB_step1_4_mod_v4, se12_3] at haddi1_raw
+  have haddi1 := cpsTripleWithin_extend_code addi_x5_3_sub_modCode_noNop_v4 haddi1_raw
+  have haddi1f := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ b3) ** (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
+     ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3984) ↦ₘ nMem))
+    (by pcFree) haddi1
+  have h12345 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) h1234 haddi1f
+  have hbne1_raw := bne_spec_gen_within .x7 .x0 16 b2 (0 : Word) (base + phaseBBne2Off)
+  rw [show (base + phaseBBne2Off : Word) + signExtend13 16 = base + phaseBTailOff from by
+        rv64_addr, phB_step1_8_mod_v4] at hbne1_raw
+  have hbne1_clean := cpsBranchWithin_takenStripPure2 hbne1_raw
+    (fun hp hQf => by
+      obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
+      exact absurd ((sepConj_pure_right _).mp h_rest).2 hb2nz)
+  have hbne1 := cpsTripleWithin_extend_code bne_x7_16_sub_modCode_noNop_v4 hbne1_clean
+  have hbne1f := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (3 : Word)) ** (.x10 ↦ᵣ b3) ** (.x6 ↦ᵣ b1) **
+     ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3984) ↦ₘ nMem))
+    (by pcFree) hbne1
+  have h123456 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) h12345 hbne1f
+  have htail_raw := divK_phaseB_tail_spec_within sp (3 : Word) b2 nMem (base + phaseBTailOff)
+  simp only [divK_phaseB_tail_pre_unfold, divK_phaseB_tail_post_unfold,
+             phB_t_20_mod_v4, divK_phaseB_n3_nm1_x8_mod_v4, signExtend12_32,
+             phB_sp16_32_mod_v4] at htail_raw
+  have htail := cpsTripleWithin_extend_code divK_phaseB_tail_code_sub_modCode_noNop_v4 htail_raw
+  have htailf := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) ** (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
+     ((sp + 40) ↦ₘ b1) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)))
+    (by pcFree) htail
+  have hphaseB := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) h123456 htailf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    hphaseB
+
+/-- PhaseAB n=3 over the no-NOP v4 MOD code bundle. -/
+theorem evm_mod_phaseAB_n3_spec_within_v4_noNop (sp base : Word)
+    (b0 b1 b2 b3 v5 v6 v7 v10 : Word)
+    (q0 q1 q2 q3 u5 u6 u7 nMem : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2nz : b2 ≠ 0) :
+    cpsTripleWithin (8 + 21) base (base + clzOff) (modCode_noNop_v4 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem))
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b2) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
+       ((sp + 32) ↦ₘ b0) **
+       ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (3 : Word))) := by
+  have hA := evm_mod_phaseA_ntaken_spec_within_v4_noNop sp base b0 b1 b2 b3 v5 v10 hbnz
+  have hAf := cpsTripleWithin_frameR
+    ((.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+     ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+     ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+     ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+     ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem))
+    (by pcFree) hA
+  have hB := evm_mod_phaseB_n3_spec_within_v4_noNop sp base b1 b2 b3
+    (b0 ||| b1 ||| b2 ||| b3) v6 v7 q0 q1 q2 q3 u5 u6 u7 nMem
+    hb3z hb2nz
+  have hBf := cpsTripleWithin_frameR
+    (((sp + 32) ↦ₘ b0))
+    (by pcFree) hB
+  have hAB := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hAf hBf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    hAB
+
+/-- MOD PhaseAB n=3 plus CLZ over the no-NOP v4 MOD code bundle. -/
+theorem evm_mod_phaseAB_n3_clz_spec_within_v4_noNop (sp base : Word)
+    (b0 b1 b2 b3 v5 v6 v7 v10 : Word)
+    (q0 q1 q2 q3 u5 u6 u7 nMem : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2nz : b2 ≠ 0) :
+    cpsTripleWithin (8 + 21 + 24) base (base + phaseC2Off) (modCode_noNop_v4 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem))
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (clzResult b2).2) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ (clzResult b2).1) ** (.x7 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (3 : Word))) := by
+  have hAB := evm_mod_phaseAB_n3_spec_within_v4_noNop sp base b0 b1 b2 b3 v5 v6 v7 v10
+    q0 q1 q2 q3 u5 u6 u7 nMem hbnz hb3z hb2nz
+  have hCLZ := mod_clz_spec_within_v4_noNop b2 b1 b2 base
+  have hCLZf := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ b3) **
+     ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+     ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (3 : Word)))
+    (by pcFree) hCLZ
+  have hABCLZ := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hAB hCLZf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    hABCLZ
 
 /-- PhaseA nonzero path over the full v4 MOD code bundle. -/
 theorem evm_mod_phaseA_ntaken_spec_within_v4 (sp base : Word)

--- a/EvmAsm/Evm64/DivMod/Compose/PhaseABV4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/PhaseABV4NoNop.lean
@@ -37,11 +37,17 @@ private theorem phB_t_20_v4 {base : Word} :
 private theorem divK_phaseB_n1_nm1_x8_v4 :
     ((1 : Word) + signExtend12 (4095 : BitVec 12)) <<< (3 : BitVec 6).toNat = (0 : Word) := by
   decide
+private theorem divK_phaseB_n3_nm1_x8_v4 :
+    ((3 : Word) + signExtend12 (4095 : BitVec 12)) <<< (3 : BitVec 6).toNat = (16 : Word) := by
+  decide
 private theorem divK_phaseB_n4_nm1_x8_v4 :
     ((4 : Word) + signExtend12 (4095 : BitVec 12)) <<< (3 : BitVec 6).toNat = (24 : Word) := by
   decide
 private theorem phB_sp0_32_v4 {sp : Word} :
     (sp + (0 : Word) + (32 : Word)) = sp + 32 := by
+  bv_addr
+private theorem phB_sp16_32_v4 {sp : Word} :
+    (sp + (16 : Word) + (32 : Word)) = sp + 48 := by
   bv_addr
 private theorem phB_sp24_32_v4 {sp : Word} :
     (sp + (24 : Word) + (32 : Word)) = sp + 56 := by
@@ -247,6 +253,135 @@ theorem evm_div_phaseB_n4_spec_within_v4_noNop (sp base : Word)
     (fun h hp => by xperm_chunked hp)
     (fun h hq => by xperm_chunked hq)
     hinit1fhinit2haddihbnehtail
+
+/-- PhaseB n=3 over `divCode_noNop_v4`. -/
+theorem evm_div_phaseB_n3_spec_within_v4_noNop (sp base : Word)
+    (b1 b2 b3 : Word) (v5 v6 v7 : Word)
+    (q0 q1 q2 q3 u5 u6 u7 nMem : Word)
+    (hb3z : b3 = 0) (hb2nz : b2 ≠ 0) :
+    cpsTripleWithin 21 (base + phaseBOff) (base + clzOff) (divCode_noNop_v4 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+       ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) **
+       ((sp + signExtend12 3984) ↦ₘ nMem))
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b2) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
+       ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 3984) ↦ₘ (3 : Word))) := by
+  have hinit1_raw := divK_phaseB_init1_spec_within sp (base + phaseBOff) q0 q1 q2 q3 u5 u6 u7
+  simp only [phB_off_28] at hinit1_raw
+  have hinit1 := cpsTripleWithin_extend_code divK_phaseB_init1_code_sub_divCode_noNop_v4 hinit1_raw
+  have hinit1f := cpsTripleWithin_frameR
+    ((.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+     ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 3984) ↦ₘ nMem))
+    (by pcFree) hinit1
+  have hinit2_raw := divK_phaseB_init2_spec_within sp (base + phaseBInit2Off) b1 b2 v6 v7
+  simp only [phB_i2_8_v4] at hinit2_raw
+  have hinit2 := cpsTripleWithin_extend_code divK_phaseB_init2_code_sub_divCode_noNop_v4 hinit2_raw
+  have hinit2f := cpsTripleWithin_frameR
+    ((.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
+     ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3984) ↦ₘ nMem))
+    (by pcFree) hinit2
+  have h12 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_chunked hp) hinit1f hinit2f
+  have haddi0_raw := addi_x0_spec_gen_within .x5 v5 4 (base + phaseBStep0Off) (by nofun)
+  simp only [phB_addi_4_v4, signExtend12_4] at haddi0_raw
+  have haddi0 := cpsTripleWithin_extend_code addi_x5_singleton_sub_divCode_noNop_v4 haddi0_raw
+  have haddi0f := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ b3) ** (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
+     ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3984) ↦ₘ nMem))
+    (by pcFree) haddi0
+  have h123 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_chunked hp) h12 haddi0f
+  have hbne0_raw := bne_spec_gen_within .x10 .x0 24 b3 (0 : Word) (base + phaseBBneOff)
+  rw [show (base + phaseBBneOff : Word) + signExtend13 24 = base + phaseBTailOff from by
+        rv64_addr, phB_bne_4_v4] at hbne0_raw
+  have hbne0_clean := cpsBranchWithin_ntakenStripPure2 hbne0_raw
+    (fun hp hQt => by
+      obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
+      exact absurd hb3z ((sepConj_pure_right _).mp h_rest).2)
+  have hbne0 := cpsTripleWithin_extend_code bne_x10_singleton_sub_divCode_noNop_v4 hbne0_clean
+  have hbne0f := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (4 : Word)) ** (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
+     ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3984) ↦ₘ nMem))
+    (by pcFree) hbne0
+  have h1234 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_chunked hp) h123 hbne0f
+  have haddi1_raw := addi_x0_spec_gen_within .x5 (4 : Word) 3 (base + phaseBStep1Off) (by nofun)
+  simp only [phB_step1_4_v4, signExtend12_3] at haddi1_raw
+  have haddi1 := cpsTripleWithin_extend_code addi_x5_3_sub_divCode_noNop_v4 haddi1_raw
+  have haddi1f := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ b3) ** (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
+     ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3984) ↦ₘ nMem))
+    (by pcFree) haddi1
+  have h12345 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_chunked hp) h1234 haddi1f
+  have hbne1_raw := bne_spec_gen_within .x7 .x0 16 b2 (0 : Word) (base + phaseBBne2Off)
+  rw [show (base + phaseBBne2Off : Word) + signExtend13 16 = base + phaseBTailOff from by
+        rv64_addr, phB_step1_8_v4] at hbne1_raw
+  have hbne1_clean := cpsBranchWithin_takenStripPure2 hbne1_raw
+    (fun hp hQf => by
+      obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
+      exact absurd ((sepConj_pure_right _).mp h_rest).2 hb2nz)
+  have hbne1 := cpsTripleWithin_extend_code bne_x7_16_sub_divCode_noNop_v4 hbne1_clean
+  have hbne1f := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (3 : Word)) ** (.x10 ↦ᵣ b3) ** (.x6 ↦ᵣ b1) **
+     ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3984) ↦ₘ nMem))
+    (by pcFree) hbne1
+  have h123456 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_chunked hp) h12345 hbne1f
+  have htail_raw := divK_phaseB_tail_spec_within sp (3 : Word) b2 nMem (base + phaseBTailOff)
+  simp only [divK_phaseB_tail_pre_unfold, divK_phaseB_tail_post_unfold,
+             phB_t_20_v4, divK_phaseB_n3_nm1_x8_v4, signExtend12_32, phB_sp16_32_v4] at htail_raw
+  have htail := cpsTripleWithin_extend_code divK_phaseB_tail_code_sub_divCode_noNop_v4 htail_raw
+  have htailf := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) ** (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
+     ((sp + 40) ↦ₘ b1) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)))
+    (by pcFree) htail
+  have hphaseB := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) h123456 htailf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    hphaseB
 
 /-- PhaseB n=1 over `divCode_noNop_v4`. -/
 theorem evm_div_phaseB_n1_spec_within_v4_noNop (sp base : Word)
@@ -458,6 +593,50 @@ theorem evm_div_phaseAB_n4_spec_within_v4_noNop (sp base : Word)
   have hB := evm_div_phaseB_n4_spec_within_v4_noNop sp base b1 b2 b3
     (b0 ||| b1 ||| b2 ||| b3) v6 v7 q0 q1 q2 q3 u5 u6 u7 nMem
     hb3nz
+  have hBf := cpsTripleWithin_frameR
+    (((sp + 32) ↦ₘ b0))
+    (by pcFree) hB
+  have hAB := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_chunked hp) hAf hBf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_chunked hp)
+    (fun h hq => by xperm_chunked hq)
+    hAB
+
+/-- PhaseAB n=3 over `divCode_noNop_v4`. -/
+theorem evm_div_phaseAB_n3_spec_within_v4_noNop (sp base : Word)
+    (b0 b1 b2 b3 v5 v6 v7 v10 : Word)
+    (q0 q1 q2 q3 u5 u6 u7 nMem : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2nz : b2 ≠ 0) :
+    cpsTripleWithin (8 + 21) base (base + clzOff) (divCode_noNop_v4 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem))
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b2) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
+       ((sp + 32) ↦ₘ b0) **
+       ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (3 : Word))) := by
+  have hA := evm_div_phaseA_ntaken_spec_within_v4_noNop sp base b0 b1 b2 b3 v5 v10 hbnz
+  have hAf := cpsTripleWithin_frameR
+    ((.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+     ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+     ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+     ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+     ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem))
+    (by pcFree) hA
+  have hB := evm_div_phaseB_n3_spec_within_v4_noNop sp base b1 b2 b3
+    (b0 ||| b1 ||| b2 ||| b3) v6 v7 q0 q1 q2 q3 u5 u6 u7 nMem
+    hb3z hb2nz
   have hBf := cpsTripleWithin_frameR
     (((sp + 32) ↦ₘ b0))
     (by pcFree) hB

--- a/EvmAsm/Evm64/DivMod/LoopDefs/Bundle.lean
+++ b/EvmAsm/Evm64/DivMod/LoopDefs/Bundle.lean
@@ -284,6 +284,47 @@ instance pcFreeInst_loopN2PreWithScratchNoX1
     v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig_1 u0_orig_0
     q2Old q1Old q0Old retMem dMem dloMem scratch_un0⟩
 
+@[irreducible]
+def loopN2PreWithScratchV4NoX1
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      u0_orig_1 u0_orig_0
+      q2Old q1Old q0Old
+      retMem dMem dloMem scratchUn0 scratchMem : Word) : Assertion :=
+  loopN2PreWithScratchNoX1 sp jOld v5Old v6Old v7Old v10Old
+    v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    u0_orig_1 u0_orig_0 q2Old q1Old q0Old
+    retMem dMem dloMem scratchUn0 **
+  (sp + signExtend12 3936 ↦ₘ scratchMem)
+
+theorem loopN2PreWithScratchV4NoX1_pcFree
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      u0_orig_1 u0_orig_0
+      q2Old q1Old q0Old
+      retMem dMem dloMem scratchUn0 scratchMem : Word) :
+    (loopN2PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old
+      v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      u0_orig_1 u0_orig_0 q2Old q1Old q0Old
+      retMem dMem dloMem scratchUn0 scratchMem).pcFree := by
+  delta loopN2PreWithScratchV4NoX1
+  pcFree
+
+instance pcFreeInst_loopN2PreWithScratchV4NoX1
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      u0_orig_1 u0_orig_0
+      q2Old q1Old q0Old
+      retMem dMem dloMem scratchUn0 scratchMem : Word) :
+    Assertion.PCFree
+      (loopN2PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old
+        v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop
+        u0_orig_1 u0_orig_0 q2Old q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem) :=
+  ⟨loopN2PreWithScratchV4NoX1_pcFree sp jOld v5Old v6Old v7Old v10Old
+    v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig_1 u0_orig_0
+    q2Old q1Old q0Old retMem dMem dloMem scratchUn0 scratchMem⟩
+
 theorem loopN2PreWithScratchNoX1_to_loopN2PreWithScratch
     (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop

--- a/EvmAsm/Evm64/DivMod/LoopDefs/Post.lean
+++ b/EvmAsm/Evm64/DivMod/LoopDefs/Post.lean
@@ -628,6 +628,65 @@ theorem loopIterPostN2Call_skip {sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word}
         loopBodyN2CallSkipPostJ loopBodyN2SkipPost loopBodySkipPost loopExitPostN2 loopExitPost
   unfold mulsubN4_c3 at hb; simp only [if_neg hb]
 
+@[irreducible] def loopIterPostN2CallScratchNoX1
+    (sp base j qHat dLo divUn0 scratchOut v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
+    Assertion :=
+  let r := iterWithDoubleAddback qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  let c3 := (mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2
+  loopExitPostN2 sp j r.1 c3 r.2.1 r.2.2.1 r.2.2.2.1 r.2.2.2.2.1
+    r.2.2.2.2.2 v0 v1 v2 v3 **
+  (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+  (sp + signExtend12 3960 ↦ₘ v1) **
+  (sp + signExtend12 3952 ↦ₘ dLo) **
+  (sp + signExtend12 3944 ↦ₘ divUn0) **
+  (sp + signExtend12 3936 ↦ₘ scratchOut)
+
+@[irreducible] def loopBodyN2CallSkipPostJScratchNoX1
+    (sp base j qHat dLo divUn0 scratchOut v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
+    Assertion :=
+  loopBodyN2SkipPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+  (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+  (sp + signExtend12 3960 ↦ₘ v1) **
+  (sp + signExtend12 3952 ↦ₘ dLo) **
+  (sp + signExtend12 3944 ↦ₘ divUn0) **
+  (sp + signExtend12 3936 ↦ₘ scratchOut)
+
+@[irreducible] def loopBodyN2CallAddbackBeqPostJScratchNoX1
+    (sp base j qHat dLo divUn0 scratchOut v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
+    Assertion :=
+  loopBodyN2AddbackBeqPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+  (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+  (sp + signExtend12 3960 ↦ₘ v1) **
+  (sp + signExtend12 3952 ↦ₘ dLo) **
+  (sp + signExtend12 3944 ↦ₘ divUn0) **
+  (sp + signExtend12 3936 ↦ₘ scratchOut)
+
+theorem loopIterPostN2CallScratchNoX1_skip
+    {sp base j qHat dLo divUn0 scratchOut v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word}
+    (hb : ¬BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3)) :
+    loopBodyN2CallSkipPostJScratchNoX1 sp base j qHat dLo divUn0 scratchOut
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop =
+      loopIterPostN2CallScratchNoX1 sp base j qHat dLo divUn0 scratchOut
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+  delta loopIterPostN2CallScratchNoX1 loopBodyN2CallSkipPostJScratchNoX1
+    iterWithDoubleAddback loopBodyN2SkipPost loopBodySkipPost loopExitPostN2 loopExitPost
+  unfold mulsubN4_c3 at hb
+  simp only [if_neg hb]
+
+theorem loopIterPostN2CallScratchNoX1_addback
+    {sp base j qHat dLo divUn0 scratchOut v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word}
+    (hb : BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3)) :
+    loopBodyN2CallAddbackBeqPostJScratchNoX1 sp base j qHat dLo divUn0 scratchOut
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop =
+      loopIterPostN2CallScratchNoX1 sp base j qHat dLo divUn0 scratchOut
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+  delta loopIterPostN2CallScratchNoX1 loopBodyN2CallAddbackBeqPostJScratchNoX1
+    iterWithDoubleAddback loopBodyN2AddbackBeqPost loopBodyAddbackBeqPost
+    loopExitPostN2 loopExitPost
+  unfold mulsubN4_c3 at hb
+  simp only [if_pos hb]
+  split <;> rfl
+
 @[irreducible] def loopIterPostN3Max (sp j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Assertion :=
   let r := iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
   let c3 := (mulsubN4 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2

--- a/EvmAsm/Evm64/DivMod/LoopDefs/Post.lean
+++ b/EvmAsm/Evm64/DivMod/LoopDefs/Post.lean
@@ -591,6 +591,27 @@ theorem loopIterPostN2Max_skip {sp j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word}
   (sp + signExtend12 3952 ↦ₘ div128DLo v1) **
   (sp + signExtend12 3944 ↦ₘ div128Un0 u1) ** regOwn .x1
 
+@[irreducible] def loopIterPostN2CallNoX1
+    (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Assertion :=
+  let r := iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  let qHat := div128Quot u2 u1 v1
+  let c3 := (mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2
+  loopExitPostN2 sp j r.1 c3 r.2.1 r.2.2.1 r.2.2.2.1 r.2.2.2.2.1 r.2.2.2.2.2 v0 v1 v2 v3 **
+  (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+  (sp + signExtend12 3960 ↦ₘ v1) **
+  (sp + signExtend12 3952 ↦ₘ div128DLo v1) **
+  (sp + signExtend12 3944 ↦ₘ div128Un0 u1)
+
+theorem loopIterPostN2CallNoX1_to_loopIterPostN2Call
+    (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
+    ∀ h,
+      (loopIterPostN2CallNoX1 sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+        regOwn .x1) h →
+      loopIterPostN2Call sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop h := by
+  intro h hp
+  delta loopIterPostN2CallNoX1 loopIterPostN2Call at hp ⊢
+  simpa only [sepConj_assoc'] using hp
+
 theorem loopIterPostN2Call_addback {sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word}
     (hb : BitVec.ult uTop (mulsubN4_c3 (div128Quot u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3)) :
     loopBodyN2CallAddbackBeqPostJ sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop =
@@ -845,6 +866,62 @@ def loopN2Iter10Post (bltu_1 bltu_0 : Bool)
   | false, true  => loopN2MaxCallPost sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig
   | true,  false => loopN2CallMaxPost sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig
 
+@[irreducible]
+def loopN2MaxPostNoX1
+    (sp v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig : Word)
+    (retMem dMem dloMem scratch_un0 : Word) : Assertion :=
+  loopN2MaxPost sp v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig **
+  (sp + signExtend12 3968 ↦ₘ retMem) **
+  (sp + signExtend12 3960 ↦ₘ dMem) **
+  (sp + signExtend12 3952 ↦ₘ dloMem) **
+  (sp + signExtend12 3944 ↦ₘ scratch_un0)
+
+@[irreducible]
+def loopN2CallCallPostNoX1
+    (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig : Word) : Assertion :=
+  let r1 := iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  let uBase1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+  let qAddr1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+  loopIterPostN2CallNoX1 sp base (0 : Word) v0 v1 v2 v3
+    u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 **
+  ((uBase1 + signExtend12 4064) ↦ₘ r1.2.2.2.2.2) ** (qAddr1 ↦ₘ r1.1)
+
+@[irreducible]
+def loopN2MaxCallPostNoX1
+    (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig : Word) : Assertion :=
+  let r1 := iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  let uBase1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+  let qAddr1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+  loopIterPostN2CallNoX1 sp base (0 : Word) v0 v1 v2 v3
+    u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 **
+  ((uBase1 + signExtend12 4064) ↦ₘ r1.2.2.2.2.2) ** (qAddr1 ↦ₘ r1.1)
+
+@[irreducible]
+def loopN2CallMaxPostNoX1
+    (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig : Word) : Assertion :=
+  let r1 := iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  let uBase1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+  let qAddr1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+  loopIterPostN2Max sp (0 : Word) v0 v1 v2 v3
+    u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 **
+  ((uBase1 + signExtend12 4064) ↦ₘ r1.2.2.2.2.2) ** (qAddr1 ↦ₘ r1.1) **
+  (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+  (sp + signExtend12 3960 ↦ₘ v1) **
+  (sp + signExtend12 3952 ↦ₘ div128DLo v1) **
+  (sp + signExtend12 3944 ↦ₘ div128Un0 u1)
+
+/-- Unified n=2 two-iteration postcondition with caller-owned `x1` external. -/
+def loopN2Iter10PostNoX1 (bltu_1 bltu_0 : Bool)
+    (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig : Word)
+    (retMem dMem dloMem scratch_un0 : Word) : Assertion :=
+  match bltu_1, bltu_0 with
+  | false, false =>
+    loopN2MaxPostNoX1 sp v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig
+      retMem dMem dloMem scratch_un0
+  | true,  true  => loopN2CallCallPostNoX1 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig
+  | false, true  => loopN2MaxCallPostNoX1 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig
+  | true,  false => loopN2CallMaxPostNoX1 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig
+
 /-- Unified n=2 three-iteration postcondition with double addback.
     Parameterized by `(bltu_2 bltu_1 bltu_0 : Bool)` covering all 8 path combinations. -/
 @[irreducible]
@@ -868,6 +945,45 @@ def loopN2UnifiedPost (bltu_2 bltu_1 bltu_0 : Bool)
     scratch_ret scratch_d scratch_dlo scratch_un0 **
   -- Carried atoms from j=2
   ((u_base_2 + signExtend12 4064) ↦ₘ r2.2.2.2.2.2) ** (q_addr_2 ↦ₘ r2.1)
+
+@[irreducible]
+def loopN2UnifiedPostNoX1 (bltu_2 bltu_1 bltu_0 : Bool)
+    (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop
+     u0_orig_1 u0_orig_0
+     retMem dMem dloMem scratch_un0 : Word) : Assertion :=
+  let r2 := iterN2 bltu_2 v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  let uBase2 := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
+  let qAddr2 := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
+  let scratchRet := if bltu_2 then (base + div128CallRetOff) else retMem
+  let scratchD := if bltu_2 then v1 else dMem
+  let scratchDLo := if bltu_2 then div128DLo v1 else dloMem
+  let scratchUn0 := if bltu_2 then div128Un0 u1 else scratch_un0
+  loopN2Iter10PostNoX1 bltu_1 bltu_0 sp base v0 v1 v2 v3
+    u0_orig_1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1 u0_orig_0
+    scratchRet scratchD scratchDLo scratchUn0 **
+  ((uBase2 + signExtend12 4064) ↦ₘ r2.2.2.2.2.2) ** (qAddr2 ↦ₘ r2.1)
+
+theorem loopN2UnifiedPostNoX1_to_loopN2UnifiedPost
+    (bltu_2 bltu_1 bltu_0 : Bool)
+    (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop
+     u0_orig_1 u0_orig_0
+     retMem dMem dloMem scratch_un0 : Word) :
+    ∀ h,
+      (loopN2UnifiedPostNoX1 bltu_2 bltu_1 bltu_0 sp base
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig_1 u0_orig_0
+        retMem dMem dloMem scratch_un0 ** regOwn .x1) h →
+      loopN2UnifiedPost bltu_2 bltu_1 bltu_0 sp base
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig_1 u0_orig_0
+        retMem dMem dloMem scratch_un0 h := by
+  intro h hp
+  cases bltu_2 <;> cases bltu_1 <;> cases bltu_0
+  all_goals
+    delta loopN2UnifiedPostNoX1 loopN2UnifiedPost loopN2Iter10PostNoX1 loopN2Iter10Post
+      loopN2MaxPostNoX1 loopN2CallCallPostNoX1 loopN2MaxCallPostNoX1
+      loopN2CallMaxPostNoX1 loopN2CallCallPost loopN2MaxCallPost loopN2CallMaxPost
+      loopIterPostN2CallNoX1 loopIterPostN2Call at hp ⊢
+    simp only [iterN2_true, iterN2_false] at hp ⊢
+    xperm_hyp hp
 
 -- ============================================================================
 -- Two-/three-/four-iteration path postconditions with double addback for n=1

--- a/EvmAsm/Evm64/DivMod/LoopIterN2CallAddbackV4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN2CallAddbackV4NoNop.lean
@@ -52,6 +52,20 @@ def loopBodyN2CallAddbackBeqJgt0PostV4
   (sp + signExtend12 3936 ↦ₘ scratchOut) **
   regOwn .x1
 
+@[irreducible]
+def loopBodyN2CallAddbackBeqJgt0PostV4NoX1
+    (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word) : Assertion :=
+  let dLo := divKTrialCallV4DLo v1
+  let div_un0 := divKTrialCallV4Un0 u1
+  let qHat := divKTrialCallV4QHat u2 u1 v1
+  let scratchOut := divKTrialCallV4ScratchOut u2 u1 v1 scratchMem
+  loopBodyN2AddbackBeqPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+  (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+  (sp + signExtend12 3960 ↦ₘ v1) **
+  (sp + signExtend12 3952 ↦ₘ dLo) **
+  (sp + signExtend12 3944 ↦ₘ div_un0) **
+  (sp + signExtend12 3936 ↦ₘ scratchOut)
+
 /-- No-NOP/v4 loop body cpsTripleWithin for n=2, call+addback, j=0. -/
 private theorem divK_loop_body_n2_call_addback_j0_beq_v4_spec_within_noNop
     (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
@@ -419,6 +433,123 @@ private theorem divK_loop_body_n2_call_addback_jgt0_beq_v4_spec_within_noNop (j 
       unfold loopBodyN2AddbackBeqPost loopBodyAddbackBeqPost
       rw [loopExitPost_unfold]
       rw [sepConj_assoc'] at hp; xperm_hyp hp)
+    full
+
+/-- No-NOP/v4 n=2 call+addback j>0 spec preserving the concrete caller `x1`
+    through trial-call, mulsub/correction-addback, and store-loop continue. -/
+theorem divK_loop_body_n2_call_addback_jgt0_beq_v4_spec_within_noNop_exact_x1 (j : Word)
+    (hpos : BitVec.slt (j + signExtend12 4095) 0 = false)
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal : Word)
+    (retMem dMem dloMem scratch_un0 scratchMem : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : BitVec.ult u2 v1)
+    (hborrow : (if BitVec.ult uTop
+        (mulsubN4 (divKTrialCallV4QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2
+      then (1 : Word) else 0) ≠ (0 : Word))
+    (hcarry2_nz :
+      let qHat := divKTrialCallV4QHat u2 u1 v1
+      let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+      let c3 := ms.2.2.2.2
+      let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
+      let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
+      carry = 0 → addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0) :
+    cpsTripleWithin 224 (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCodeNoNop_v4 base)
+      (loopBodyN2CallSkipJgt0PreV4NoX1 sp j jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopBodyN2CallAddbackBeqJgt0PostV4NoX1 sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem **
+        (.x1 ↦ᵣ raVal)) := by
+  unfold loopBodyN2CallSkipJgt0PreV4NoX1
+  let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
+  let dHi := divKTrialCallV4DHi v1
+  let dLo := divKTrialCallV4DLo v1
+  let div_un0 := divKTrialCallV4Un0 u1
+  let q1'' := divKTrialCallV4Q1dd u2 u1 v1
+  let q0'' := divKTrialCallV4Q0dd u2 u1 v1
+  let x7Exit := divKTrialCallV4X7Exit u2 u1 v1
+  let x9Exit := divKTrialCallV4X9Exit u2 u1 v1
+  let qHat := divKTrialCallV4QHat u2 u1 v1
+  let scratchOut := divKTrialCallV4ScratchOut u2 u1 v1 scratchMem
+  have TF := divK_trial_call_full_v4_spec_within_noNop_exact_x1 sp j (2 : Word)
+    jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    u2 u1 v1 retMem dMem dloMem scratch_un0 scratchMem raVal base
+    halign hbltu
+  unfold divKTrialCallFullPostV4ExactX1 at TF
+  dsimp only [] at TF
+  rw [u_addr_eq_n2] at TF
+  rw [u_addr8_eq_n2] at TF
+  rw [vtop_eq_v1_n2] at TF
+  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+  let c3 := ms.2.2.2.2
+  let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
+  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
+  let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
+  let q_out := if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
+               else qHat + signExtend12 4095
+  let un0Out := if carry = 0 then ab'.1 else ab.1
+  let un1Out := if carry = 0 then ab'.2.1 else ab.2.1
+  let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
+  let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
+  let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
+  let carryOut := if carry = 0 then
+      addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
+    else carry
+  have MCA := divK_mulsub_correction_addback_beq_v4_spec_within_noNop
+    sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    x9Exit q0'' dHi x7Exit q1'' (base + div128CallRetOff) base
+  intro_lets at MCA
+  have hcarry2_nz' :
+      carry = 0 →
+        addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0 := by
+    dsimp only [] at hcarry2_nz
+    exact hcarry2_nz
+  have MCA0 := MCA hcarry2_nz' hborrow
+  have MCA0f := cpsTripleWithin_frameR ((sp + signExtend12 3936 ↦ₘ scratchOut) ** (.x1 ↦ᵣ raVal))
+    (by pcFree) MCA0
+  have SL := divK_store_loop_jgt0_v4_spec_within_noNop_exact_x1 sp j q_out u4_out carryOut qOld raVal base hpos
+  intro_lets at SL
+  have TFf := cpsTripleWithin_frameR
+    (((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
+     (qAddr ↦ₘ qOld))
+    (by pcFree) TF
+  seqFrame TFf MCA0f
+  have SLf := cpsTripleWithin_frameR
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
+     (sp + signExtend12 3976 ↦ₘ j) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0Out) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1Out) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2Out) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3Out) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_out) **
+     (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
+     (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+     (sp + signExtend12 3960 ↦ₘ v1) **
+     (sp + signExtend12 3952 ↦ₘ dLo) **
+     (sp + signExtend12 3944 ↦ₘ div_un0) **
+     (sp + signExtend12 3936 ↦ₘ scratchOut))
+    (by pcFree) SL
+  have full := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0f SLf
+  exact cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by
+      unfold loopBodyN2CallAddbackBeqJgt0PostV4NoX1
+      change ((loopBodyN2AddbackBeqPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+        (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+        (sp + signExtend12 3960 ↦ₘ v1) **
+        (sp + signExtend12 3952 ↦ₘ dLo) **
+        (sp + signExtend12 3944 ↦ₘ div_un0) **
+        (sp + signExtend12 3936 ↦ₘ scratchOut)) **
+        (.x1 ↦ᵣ raVal)) h
+      unfold loopBodyN2AddbackBeqPost loopBodyAddbackBeqPost
+      rw [loopExitPost_unfold]
+      rw [sepConj_assoc'] at hp
+      xperm_hyp hp)
     full
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LoopIterN2CallAddbackV4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN2CallAddbackV4NoNop.lean
@@ -1,4 +1,5 @@
 import EvmAsm.Evm64.DivMod.LoopBody.CorrectionAddbackBeqV4NoNop
+import EvmAsm.Evm64.DivMod.LoopIterN2CallV4NoNop
 import EvmAsm.Evm64.DivMod.LoopIterN2NoNop
 
 open EvmAsm.Rv64.Tactics
@@ -21,6 +22,20 @@ def loopBodyN2CallAddbackBeqJ0PostV4
   (sp + signExtend12 3944 ↦ₘ div_un0) **
   (sp + signExtend12 3936 ↦ₘ scratchOut) **
   regOwn .x1
+
+@[irreducible]
+def loopBodyN2CallAddbackBeqJ0PostV4NoX1
+    (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word) : Assertion :=
+  let dLo := divKTrialCallV4DLo v1
+  let div_un0 := divKTrialCallV4Un0 u1
+  let qHat := divKTrialCallV4QHat u2 u1 v1
+  let scratchOut := divKTrialCallV4ScratchOut u2 u1 v1 scratchMem
+  loopBodyN2AddbackBeqPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+  (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+  (sp + signExtend12 3960 ↦ₘ v1) **
+  (sp + signExtend12 3952 ↦ₘ dLo) **
+  (sp + signExtend12 3944 ↦ₘ div_un0) **
+  (sp + signExtend12 3936 ↦ₘ scratchOut)
 
 @[irreducible]
 def loopBodyN2CallAddbackBeqJgt0PostV4
@@ -161,6 +176,122 @@ private theorem divK_loop_body_n2_call_addback_j0_beq_v4_spec_within_noNop
       unfold loopBodyN2AddbackBeqPost loopBodyAddbackBeqPost
       rw [loopExitPost_unfold]
       rw [sepConj_assoc'] at hp; xperm_hyp hp)
+    full
+
+/-- No-NOP/v4 n=2 call+addback j=0 spec preserving the concrete caller `x1`
+    through trial-call, mulsub/correction-addback, and store-loop exit. -/
+theorem divK_loop_body_n2_call_addback_j0_beq_v4_spec_within_noNop_exact_x1
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal : Word)
+    (retMem dMem dloMem scratch_un0 scratchMem : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : BitVec.ult u2 v1)
+    (hborrow : (if BitVec.ult uTop
+        (mulsubN4 (divKTrialCallV4QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2
+      then (1 : Word) else 0) ≠ (0 : Word))
+    (hcarry2_nz :
+      let qHat := divKTrialCallV4QHat u2 u1 v1
+      let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+      let c3 := ms.2.2.2.2
+      let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
+      let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
+      carry = 0 → addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0) :
+    cpsTripleWithin 224 (base + loopBodyOff) (base + denormOff) (sharedDivModCodeNoNop_v4 base)
+      (loopBodyN2CallSkipJ0PreV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopBodyN2CallAddbackBeqJ0PostV4NoX1 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem **
+        (.x1 ↦ᵣ raVal)) := by
+  unfold loopBodyN2CallSkipJ0PreV4NoX1
+  let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
+  let dHi := divKTrialCallV4DHi v1
+  let dLo := divKTrialCallV4DLo v1
+  let div_un0 := divKTrialCallV4Un0 u1
+  let q1'' := divKTrialCallV4Q1dd u2 u1 v1
+  let q0'' := divKTrialCallV4Q0dd u2 u1 v1
+  let x7Exit := divKTrialCallV4X7Exit u2 u1 v1
+  let x9Exit := divKTrialCallV4X9Exit u2 u1 v1
+  let qHat := divKTrialCallV4QHat u2 u1 v1
+  let scratchOut := divKTrialCallV4ScratchOut u2 u1 v1 scratchMem
+  have TF := divK_trial_call_full_v4_spec_within_noNop_exact_x1 sp (0 : Word) (2 : Word)
+    jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    u2 u1 v1 retMem dMem dloMem scratch_un0 scratchMem raVal base
+    halign hbltu
+  unfold divKTrialCallFullPostV4ExactX1 at TF
+  dsimp only [] at TF
+  rw [u_addr_eq_n2] at TF
+  rw [u_addr8_eq_n2] at TF
+  rw [vtop_eq_v1_n2] at TF
+  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+  let c3 := ms.2.2.2.2
+  let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
+  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
+  let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
+  let q_out := if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
+               else qHat + signExtend12 4095
+  let un0Out := if carry = 0 then ab'.1 else ab.1
+  let un1Out := if carry = 0 then ab'.2.1 else ab.2.1
+  let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
+  let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
+  let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
+  let carryOut := if carry = 0 then
+      addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
+    else carry
+  have MCA := divK_mulsub_correction_addback_beq_v4_spec_within_noNop
+    sp qHat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    x9Exit q0'' dHi x7Exit q1'' (base + div128CallRetOff) base
+  intro_lets at MCA
+  have hcarry2_nz' :
+      carry = 0 →
+        addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0 := by
+    dsimp only [] at hcarry2_nz
+    exact hcarry2_nz
+  have MCA0 := MCA hcarry2_nz' hborrow
+  have MCA0f := cpsTripleWithin_frameR ((sp + signExtend12 3936 ↦ₘ scratchOut) ** (.x1 ↦ᵣ raVal))
+    (by pcFree) MCA0
+  have SL := divK_store_loop_j0_v4_spec_within_noNop_exact_x1 sp q_out u4_out carryOut qOld raVal base
+  intro_lets at SL
+  have TFf := cpsTripleWithin_frameR
+    (((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
+     (qAddr ↦ₘ qOld))
+    (by pcFree) TF
+  seqFrame TFf MCA0f
+  have SLf := cpsTripleWithin_frameR
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
+     (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0Out) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1Out) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2Out) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3Out) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_out) **
+     (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
+     (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+     (sp + signExtend12 3960 ↦ₘ v1) **
+     (sp + signExtend12 3952 ↦ₘ dLo) **
+     (sp + signExtend12 3944 ↦ₘ div_un0) **
+     (sp + signExtend12 3936 ↦ₘ scratchOut))
+    (by pcFree) SL
+  have full := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0f SLf
+  exact cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by
+      unfold loopBodyN2CallAddbackBeqJ0PostV4NoX1
+      change ((loopBodyN2AddbackBeqPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+        (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+        (sp + signExtend12 3960 ↦ₘ v1) **
+        (sp + signExtend12 3952 ↦ₘ dLo) **
+        (sp + signExtend12 3944 ↦ₘ div_un0) **
+        (sp + signExtend12 3936 ↦ₘ scratchOut)) **
+        (.x1 ↦ᵣ raVal)) h
+      unfold loopBodyN2AddbackBeqPost loopBodyAddbackBeqPost
+      rw [loopExitPost_unfold]
+      rw [sepConj_assoc'] at hp
+      xperm_hyp hp)
     full
 
 /-- No-NOP/v4 loop body cpsTripleWithin for n=2, call+addback, j>0. -/

--- a/EvmAsm/Evm64/DivMod/LoopIterN2CallV4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN2CallV4NoNop.lean
@@ -49,6 +49,30 @@ def loopBodyN2CallSkipJ0PostV4
   regOwn .x1
 
 @[irreducible]
+def loopBodyN2CallSkipJ0PostV4NoX1
+    (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word) : Assertion :=
+  let dLo := divKTrialCallV4DLo v1
+  let divUn0 := divKTrialCallV4Un0 u1
+  let qHat := divKTrialCallV4QHat u2 u1 v1
+  let scratchOut := divKTrialCallV4ScratchOut u2 u1 v1 scratchMem
+  loopBodyN2SkipPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+  (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+  (sp + signExtend12 3960 ↦ₘ v1) **
+  (sp + signExtend12 3952 ↦ₘ dLo) **
+  (sp + signExtend12 3944 ↦ₘ divUn0) **
+  (sp + signExtend12 3936 ↦ₘ scratchOut)
+
+theorem loopBodyN2CallSkipJ0PostV4NoX1_to_loopBodyN2CallSkipJ0PostV4
+    (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word) :
+    ∀ h,
+      (loopBodyN2CallSkipJ0PostV4NoX1 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem **
+        regOwn .x1) h →
+      loopBodyN2CallSkipJ0PostV4 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem h := by
+  intro h hp
+  delta loopBodyN2CallSkipJ0PostV4NoX1 loopBodyN2CallSkipJ0PostV4 at hp ⊢
+  xperm_hyp hp
+
+@[irreducible]
 def loopBodyN2CallSkipJgt0PostV4
     (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word) : Assertion :=
   let dLo := divKTrialCallV4DLo v1
@@ -62,6 +86,30 @@ def loopBodyN2CallSkipJgt0PostV4
   (sp + signExtend12 3944 ↦ₘ divUn0) **
   (sp + signExtend12 3936 ↦ₘ scratchOut) **
   regOwn .x1
+
+@[irreducible]
+def loopBodyN2CallSkipJgt0PostV4NoX1
+    (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word) : Assertion :=
+  let dLo := divKTrialCallV4DLo v1
+  let divUn0 := divKTrialCallV4Un0 u1
+  let qHat := divKTrialCallV4QHat u2 u1 v1
+  let scratchOut := divKTrialCallV4ScratchOut u2 u1 v1 scratchMem
+  loopBodyN2SkipPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+  (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+  (sp + signExtend12 3960 ↦ₘ v1) **
+  (sp + signExtend12 3952 ↦ₘ dLo) **
+  (sp + signExtend12 3944 ↦ₘ divUn0) **
+  (sp + signExtend12 3936 ↦ₘ scratchOut)
+
+theorem loopBodyN2CallSkipJgt0PostV4NoX1_to_loopBodyN2CallSkipJgt0PostV4
+    (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word) :
+    ∀ h,
+      (loopBodyN2CallSkipJgt0PostV4NoX1 sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem **
+        regOwn .x1) h →
+      loopBodyN2CallSkipJgt0PostV4 sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem h := by
+  intro h hp
+  delta loopBodyN2CallSkipJgt0PostV4NoX1 loopBodyN2CallSkipJgt0PostV4 at hp ⊢
+  xperm_hyp hp
 
 @[irreducible]
 def loopBodyN2CallSkipJ0BorrowV4

--- a/EvmAsm/Evm64/DivMod/LoopIterN2CallV4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN2CallV4NoNop.lean
@@ -495,4 +495,111 @@ theorem divK_loop_body_n2_call_skip_jgt0_v4_spec_within_noNop (j : Word)
       xperm_hyp hp)
     full
 
+/-- No-NOP/v4 n=2 call+skip j>0 spec preserving the concrete caller `x1`
+    through trial-call, mulsub/correction-skip, and store-loop loop-back. -/
+theorem divK_loop_body_n2_call_skip_jgt0_v4_spec_within_noNop_exact_x1 (j : Word)
+    (hpos : BitVec.slt (j + signExtend12 4095) 0 = false)
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : BitVec.ult u2 v1)
+    (hborrow : mulsubN4NoBorrow (divKTrialCallV4QHat u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 148 (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCodeNoNop_v4 base)
+      (loopBodyN2CallSkipJgt0PreV4NoX1 sp j jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopBodyN2CallSkipJgt0PostV4NoX1 sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem **
+        (.x1 ↦ᵣ raVal)) := by
+  unfold loopBodyN2CallSkipJgt0PreV4NoX1
+  let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
+  let dHi := divKTrialCallV4DHi v1
+  let dLo := divKTrialCallV4DLo v1
+  let divUn0 := divKTrialCallV4Un0 u1
+  let q1'' := divKTrialCallV4Q1dd u2 u1 v1
+  let q0'' := divKTrialCallV4Q0dd u2 u1 v1
+  let x7Exit := divKTrialCallV4X7Exit u2 u1 v1
+  let x9Exit := divKTrialCallV4X9Exit u2 u1 v1
+  let qHat := divKTrialCallV4QHat u2 u1 v1
+  let scratchOut := divKTrialCallV4ScratchOut u2 u1 v1 scratchMem
+  have TF := divK_trial_call_full_v4_spec_within_noNop_exact_x1 sp j (2 : Word)
+    jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    u2 u1 v1 retMem dMem dloMem scratchUn0 scratchMem raVal base
+    halign hbltu
+  unfold divKTrialCallFullPostV4ExactX1 at TF
+  dsimp only [] at TF
+  rw [u_addr_eq_n2] at TF
+  rw [u_addr8_eq_n2] at TF
+  rw [vtop_eq_v1_n2] at TF
+  have hborrow' :
+      mulsubN4NoBorrow qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+    exact hborrow
+  have MCS := divK_mulsub_correction_skip_v4_spec_within_noNop sp qHat j
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    x9Exit q0'' dHi x7Exit q1'' (base + div128CallRetOff) base
+  have MCS0 := MCS hborrow'
+  unfold divKMulsubCorrectionSkipPre at MCS0
+  unfold n4McaNamedSkipPost at MCS0
+  unfold mulsubN4 at MCS0
+  dsimp only [] at MCS0
+  have MCS0f := cpsTripleWithin_frameR ((sp + signExtend12 3936 ↦ₘ scratchOut) ** (.x1 ↦ᵣ raVal))
+    (by pcFree) MCS0
+  let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
+  let fs0 := p0_lo + (signExtend12 0 : Word)
+  let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
+  let pc0 := ba0 + p0_hi; let bs0 := if BitVec.ult u0 fs0 then (1 : Word) else 0
+  let un0 := u0 - fs0; let c0 := pc0 + bs0
+  let p1_lo := qHat * v1; let p1_hi := rv64_mulhu qHat v1
+  let fs1 := p1_lo + c0; let ba1 := if BitVec.ult fs1 c0 then (1 : Word) else 0
+  let pc1 := ba1 + p1_hi; let bs1 := if BitVec.ult u1 fs1 then (1 : Word) else 0
+  let un1 := u1 - fs1; let c1 := pc1 + bs1
+  let p2_lo := qHat * v2; let p2_hi := rv64_mulhu qHat v2
+  let fs2 := p2_lo + c1; let ba2 := if BitVec.ult fs2 c1 then (1 : Word) else 0
+  let pc2 := ba2 + p2_hi; let bs2 := if BitVec.ult u2 fs2 then (1 : Word) else 0
+  let un2 := u2 - fs2; let c2 := pc2 + bs2
+  let p3_lo := qHat * v3; let p3_hi := rv64_mulhu qHat v3
+  let fs3 := p3_lo + c2; let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
+  let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
+  let un3 := u3 - fs3; let c3 := pc3 + bs3
+  let u4_new := uTop - c3
+  have SL := divK_store_loop_jgt0_v4_spec_within_noNop_exact_x1 sp j qHat u4_new
+    (0 : Word) qOld raVal base hpos
+  intro_lets at SL
+  have TFf := cpsTripleWithin_frameR
+    (((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
+     (qAddr ↦ₘ qOld))
+    (by pcFree) TF
+  seqFrame TFf MCS0f
+  have SLf := cpsTripleWithin_frameR
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
+     (sp + signExtend12 3976 ↦ₘ j) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_new) **
+     (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
+     (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+     (sp + signExtend12 3960 ↦ₘ v1) **
+     (sp + signExtend12 3952 ↦ₘ dLo) **
+     (sp + signExtend12 3944 ↦ₘ divUn0) **
+     (sp + signExtend12 3936 ↦ₘ scratchOut))
+    (by pcFree) SL
+  have full := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0f SLf
+  exact cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by
+      unfold loopBodyN2CallSkipJgt0PostV4NoX1
+      unfold loopBodyN2SkipPost loopBodySkipPost loopExitPost
+      unfold mulsubN4
+      dsimp only []
+      rw [sepConj_assoc'] at hp
+      xperm_hyp hp)
+    full
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LoopIterN2CallV4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN2CallV4NoNop.lean
@@ -34,6 +34,54 @@ theorem loopBodyN2CallSkipJ0PreV4_unfold
   rfl
 
 @[irreducible]
+def loopBodyN2CallSkipJ0PreV4NoX1
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word) : Assertion :=
+  let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
+  ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ (0 : Word)) **
+   (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+   (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
+   (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
+   (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
+   ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+   ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+   ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+   ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+   ((uBase + signExtend12 4064) ↦ₘ uTop) **
+   (qAddr ↦ₘ qOld) **
+   (sp + signExtend12 3968 ↦ₘ retMem) **
+   (sp + signExtend12 3960 ↦ₘ dMem) **
+   (sp + signExtend12 3952 ↦ₘ dloMem) **
+   (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+   (sp + signExtend12 3936 ↦ₘ scratchMem))
+
+@[irreducible]
+def loopBodyN2CallSkipJgt0PreV4NoX1
+    (sp j jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word) : Assertion :=
+  let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
+  ((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ j) **
+   (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+   (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
+   (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
+   (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
+   ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+   ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+   ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+   ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+   ((uBase + signExtend12 4064) ↦ₘ uTop) **
+   (qAddr ↦ₘ qOld) **
+   (sp + signExtend12 3968 ↦ₘ retMem) **
+   (sp + signExtend12 3960 ↦ₘ dMem) **
+   (sp + signExtend12 3952 ↦ₘ dloMem) **
+   (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+   (sp + signExtend12 3936 ↦ₘ scratchMem))
+
+@[irreducible]
 def loopBodyN2CallSkipJ0PostV4
     (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem : Word) : Assertion :=
   let dLo := divKTrialCallV4DLo v1
@@ -216,6 +264,112 @@ theorem divK_loop_body_n2_call_skip_j0_v4_spec_within_noNop
       xperm_hyp hp)
     (fun h hp => by
       unfold loopBodyN2CallSkipJ0PostV4
+      unfold loopBodyN2SkipPost loopBodySkipPost loopExitPost
+      unfold mulsubN4
+      dsimp only []
+      rw [sepConj_assoc'] at hp
+      xperm_hyp hp)
+    full
+
+/-- No-NOP/v4 n=2 call+skip j=0 spec preserving the concrete caller `x1`
+    through trial-call, mulsub/correction-skip, and store-loop exit. -/
+theorem divK_loop_body_n2_call_skip_j0_v4_spec_within_noNop_exact_x1
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : BitVec.ult u2 v1)
+    (hborrow : loopBodyN2CallSkipJ0BorrowV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 148 (base + loopBodyOff) (base + denormOff) (sharedDivModCodeNoNop_v4 base)
+      (loopBodyN2CallSkipJ0PreV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopBodyN2CallSkipJ0PostV4NoX1 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem **
+        (.x1 ↦ᵣ raVal)) := by
+  unfold loopBodyN2CallSkipJ0PreV4NoX1
+  let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
+  let dHi := divKTrialCallV4DHi v1
+  let dLo := divKTrialCallV4DLo v1
+  let divUn0 := divKTrialCallV4Un0 u1
+  let q1'' := divKTrialCallV4Q1dd u2 u1 v1
+  let q0'' := divKTrialCallV4Q0dd u2 u1 v1
+  let x7Exit := divKTrialCallV4X7Exit u2 u1 v1
+  let x9Exit := divKTrialCallV4X9Exit u2 u1 v1
+  let qHat := divKTrialCallV4QHat u2 u1 v1
+  let scratchOut := divKTrialCallV4ScratchOut u2 u1 v1 scratchMem
+  have TF := divK_trial_call_full_v4_spec_within_noNop_exact_x1 sp (0 : Word) (2 : Word)
+    jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    u2 u1 v1 retMem dMem dloMem scratchUn0 scratchMem raVal base
+    halign hbltu
+  unfold divKTrialCallFullPostV4ExactX1 at TF
+  dsimp only [] at TF
+  rw [u_addr_eq_n2] at TF
+  rw [u_addr8_eq_n2] at TF
+  rw [vtop_eq_v1_n2] at TF
+  have hborrow' :
+      mulsubN4NoBorrow qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+    unfold loopBodyN2CallSkipJ0BorrowV4 at hborrow
+    exact hborrow
+  have MCS := divK_mulsub_correction_skip_v4_spec_within_noNop sp qHat (0 : Word)
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    x9Exit q0'' dHi x7Exit q1'' (base + div128CallRetOff) base
+  have MCS0 := MCS hborrow'
+  unfold divKMulsubCorrectionSkipPre at MCS0
+  unfold n4McaNamedSkipPost at MCS0
+  unfold mulsubN4 at MCS0
+  dsimp only [] at MCS0
+  have MCS0f := cpsTripleWithin_frameR ((sp + signExtend12 3936 ↦ₘ scratchOut) ** (.x1 ↦ᵣ raVal))
+    (by pcFree) MCS0
+  let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
+  let fs0 := p0_lo + (signExtend12 0 : Word)
+  let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
+  let pc0 := ba0 + p0_hi; let bs0 := if BitVec.ult u0 fs0 then (1 : Word) else 0
+  let un0 := u0 - fs0; let c0 := pc0 + bs0
+  let p1_lo := qHat * v1; let p1_hi := rv64_mulhu qHat v1
+  let fs1 := p1_lo + c0; let ba1 := if BitVec.ult fs1 c0 then (1 : Word) else 0
+  let pc1 := ba1 + p1_hi; let bs1 := if BitVec.ult u1 fs1 then (1 : Word) else 0
+  let un1 := u1 - fs1; let c1 := pc1 + bs1
+  let p2_lo := qHat * v2; let p2_hi := rv64_mulhu qHat v2
+  let fs2 := p2_lo + c1; let ba2 := if BitVec.ult fs2 c1 then (1 : Word) else 0
+  let pc2 := ba2 + p2_hi; let bs2 := if BitVec.ult u2 fs2 then (1 : Word) else 0
+  let un2 := u2 - fs2; let c2 := pc2 + bs2
+  let p3_lo := qHat * v3; let p3_hi := rv64_mulhu qHat v3
+  let fs3 := p3_lo + c2; let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
+  let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
+  let un3 := u3 - fs3; let c3 := pc3 + bs3
+  let u4_new := uTop - c3
+  have SL := divK_store_loop_j0_v4_spec_within_noNop_exact_x1 sp qHat u4_new (0 : Word) qOld raVal base
+  intro_lets at SL
+  have TFf := cpsTripleWithin_frameR
+    (((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
+     (qAddr ↦ₘ qOld))
+    (by pcFree) TF
+  seqFrame TFf MCS0f
+  have SLf := cpsTripleWithin_frameR
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
+     (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_new) **
+     (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
+     (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
+     (sp + signExtend12 3960 ↦ₘ v1) **
+     (sp + signExtend12 3952 ↦ₘ dLo) **
+     (sp + signExtend12 3944 ↦ₘ divUn0) **
+     (sp + signExtend12 3936 ↦ₘ scratchOut))
+    (by pcFree) SL
+  have full := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0f SLf
+  exact cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by
+      unfold loopBodyN2CallSkipJ0PostV4NoX1
       unfold loopBodyN2SkipPost loopBodySkipPost loopExitPost
       unfold mulsubN4
       dsimp only []

--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -14,6 +14,7 @@ import EvmAsm.Evm64.DivMod.Spec.CallAddbackPureNat
 import EvmAsm.Evm64.DivMod.Spec.CallAddback
 import EvmAsm.Evm64.DivMod.Spec.CallAddbackRuntime
 import EvmAsm.Evm64.DivMod.Spec.N4V4StackPre
+import EvmAsm.Evm64.DivMod.Spec.N3V4StackPre
 import EvmAsm.Evm64.DivMod.Spec.DivMaxSkipV4
 import EvmAsm.Evm64.DivMod.Spec.ModN4V4StackPre
 import EvmAsm.Evm64.DivMod.Spec.ModMaxSkipV4

--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -19,6 +19,7 @@ import EvmAsm.Evm64.DivMod.Spec.DivMaxSkipV4
 import EvmAsm.Evm64.DivMod.Spec.ModN4V4StackPre
 import EvmAsm.Evm64.DivMod.Spec.ModMaxSkipV4
 import EvmAsm.Evm64.DivMod.Spec.N2RemainderWord
+import EvmAsm.Evm64.DivMod.Spec.N3RemainderWordV4
 import EvmAsm.Evm64.DivMod.Spec.Dispatcher
 import EvmAsm.Evm64.DivMod.Spec.DispatcherPcFree
 import EvmAsm.Evm64.DivMod.Spec.CallablePost

--- a/EvmAsm/Evm64/DivMod/Spec/CallablePost.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/CallablePost.lean
@@ -327,6 +327,92 @@ theorem modConcretePostNoX1Frame_pcFree
     divScratchValues_unfold]
   pcFree
 
+/-- Concrete no-NOP MOD callable post bundle before weakening, preserving
+    exact values for `x5` and `x10` as produced by full-path proofs. -/
+@[irreducible]
+def modConcretePostNoX1ExactRegsFrame (sp : Word) (a b : EvmWord)
+    (x9Val raVal v2 v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratch_un0 : Word) : Assertion :=
+  (((.x12 ↦ᵣ (sp + 32)) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) **
+    (.x0 ↦ᵣ (0 : Word)) ** evmWordIs (sp + 32) (EvmWord.mod a b)) **
+   ((.x9 ↦ᵣ x9Val) ** (.x1 ↦ᵣ raVal) ** (.x2 ↦ᵣ v2) **
+      (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x11 ↦ᵣ v11) **
+      evmWordIs sp a **
+      divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0))
+
+theorem modConcretePostNoX1ExactRegsFrame_unfold
+    {sp : Word} {a b : EvmWord}
+    {x9Val raVal v2 v5 v6 v7 v10 v11 : Word}
+    {q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratch_un0 : Word} :
+    modConcretePostNoX1ExactRegsFrame sp a b x9Val raVal v2 v5 v6 v7 v10 v11
+      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratch_un0 =
+    (((.x12 ↦ᵣ (sp + 32)) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) **
+      (.x0 ↦ᵣ (0 : Word)) ** evmWordIs (sp + 32) (EvmWord.mod a b)) **
+     ((.x9 ↦ᵣ x9Val) ** (.x1 ↦ᵣ raVal) ** (.x2 ↦ᵣ v2) **
+        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x11 ↦ᵣ v11) **
+        evmWordIs sp a **
+        divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratch_un0)) := by
+  delta modConcretePostNoX1ExactRegsFrame
+  rfl
+
+theorem modConcretePostNoX1ExactRegsFrame_pcFree
+    (sp : Word) (a b : EvmWord)
+    (x9Val raVal v2 v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratch_un0 : Word) :
+    (modConcretePostNoX1ExactRegsFrame sp a b x9Val raVal v2 v5 v6 v7 v10 v11
+      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratch_un0).pcFree := by
+  rw [modConcretePostNoX1ExactRegsFrame_unfold, divScratchValuesCallNoX1_unfold,
+    divScratchValues_unfold]
+  pcFree
+
+/-- Weaken the exact-register concrete no-NOP MOD callable post bundle to the
+    public callable postcondition plus caller-framed exact `x1` and `x9`. -/
+theorem modConcretePostNoX1ExactRegs_weaken_callable_frame
+    (sp : Word) (a b : EvmWord)
+    {x9Val raVal v2 v5 v6 v7 v10 v11 : Word}
+    {q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratch_un0 : Word} :
+    ∀ h : PartialState,
+      modConcretePostNoX1ExactRegsFrame sp a b x9Val raVal v2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0 h →
+      (((modStackDispatchPostCallable sp a b ** (.x1 ↦ᵣ raVal)) **
+        (.x9 ↦ᵣ x9Val)) h) := by
+  intro h hp
+  rw [modConcretePostNoX1ExactRegsFrame_unfold] at hp
+  rw [modStackDispatchPostCallable_unfold]
+  simp only [sepConj_assoc', sepConj_comm', sepConj_left_comm'] at hp ⊢
+  have hOwn :
+      (divScratchOwnCallNoX1 sp ** evmWordIs sp a ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x1 ↦ᵣ raVal) ** regOwn .x10 ** regOwn .x11 **
+        (.x12 ↦ᵣ (sp + 32)) ** regOwn .x2 ** regOwn .x5 **
+        regOwn .x6 ** regOwn .x7 ** (.x9 ↦ᵣ x9Val) **
+        evmWordIs (sp + 32) (EvmWord.mod a b)) h := by
+    refine sepConj_mono ?_ ?_ h hp
+    · intro hLeft hpLeft
+      exact divScratchValuesCallNoX1_implies_divScratchOwnCallNoX1
+        sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem
+          retMem dMem dloMem scratch_un0 hLeft hpLeft
+    · apply sepConj_mono_right
+      apply sepConj_mono_right
+      apply sepConj_mono_right
+      apply sepConj_mono (regIs_implies_regOwn .x10 (v := v10))
+      apply sepConj_mono (regIs_implies_regOwn .x11 (v := v11))
+      apply sepConj_mono_right
+      apply sepConj_mono (regIs_implies_regOwn .x2 (v := v2))
+      apply sepConj_mono (regIs_implies_regOwn .x5 (v := v5))
+      apply sepConj_mono (regIs_implies_regOwn .x6 (v := v6))
+      apply sepConj_mono (regIs_implies_regOwn .x7 (v := v7))
+      exact fun _ hp => hp
+  exact by xperm_hyp hOwn
+
 /-- MOD counterpart of `divConcretePostNoX1_weaken_callable_frame`. -/
 theorem modConcretePostNoX1_weaken_callable_frame
     (sp : Word) (a b : EvmWord)

--- a/EvmAsm/Evm64/DivMod/Spec/N3QuotientStackBridge.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3QuotientStackBridge.lean
@@ -82,6 +82,14 @@ abbrev fullDivN3Carry2NzV4 (b0 b1 b2 b3 : Word) : Prop :=
     (fullDivN3NormV b0 b1 b2 b3).2.2.1
     (fullDivN3NormV b0 b1 b2 b3).2.2.2
 
+abbrev fullDivN3PathConditionsV4 (bltu_1 bltu_0 : Bool)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Prop :=
+  isTrialN3V4_j1 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3 ∧
+  isTrialN3V4_j0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3 ∧
+  fullDivN3Carry2NzV4 b0 b1 b2 b3 ∧
+  fullDivN3MulSubEqV4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3 ∧
+  fullDivN3QuotientOverestimateV4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+
 /-- n=3 quotient bridge specialized to the explicit limb variables used by the
     unified-bound wrappers. -/
 theorem fullDivN3QuotientWord_eq_div_of_limbs_mulsub_overestimate

--- a/EvmAsm/Evm64/DivMod/Spec/N3QuotientStackBridge.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3QuotientStackBridge.lean
@@ -11,6 +11,45 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 
+def isTrialN3V4_j1 (bltu : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Prop :=
+  bltu =
+    BitVec.ult (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.2
+      (fullDivN3NormV b0 b1 b2 b3).2.2.1
+
+def isTrialN3V4_j0 (bltu_1 bltu_0 : Bool)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Prop :=
+  bltu_0 =
+    if bltu_1 then
+      BitVec.ult
+        (iterWithDoubleAddback
+          (divKTrialCallV4QHat
+            (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.2
+            (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.1
+            (fullDivN3NormV b0 b1 b2 b3).2.2.1)
+          (fullDivN3NormV b0 b1 b2 b3).1
+          (fullDivN3NormV b0 b1 b2 b3).2.1
+          (fullDivN3NormV b0 b1 b2 b3).2.2.1
+          (fullDivN3NormV b0 b1 b2 b3).2.2.2
+          (fullDivN3NormU a0 a1 a2 a3 b2).2.1
+          (fullDivN3NormU a0 a1 a2 a3 b2).2.2.1
+          (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.1
+          (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.2
+          (0 : Word)).2.2.2.1
+        (fullDivN3NormV b0 b1 b2 b3).2.2.1
+    else
+      BitVec.ult
+        (iterN3Max
+          (fullDivN3NormV b0 b1 b2 b3).1
+          (fullDivN3NormV b0 b1 b2 b3).2.1
+          (fullDivN3NormV b0 b1 b2 b3).2.2.1
+          (fullDivN3NormV b0 b1 b2 b3).2.2.2
+          (fullDivN3NormU a0 a1 a2 a3 b2).2.1
+          (fullDivN3NormU a0 a1 a2 a3 b2).2.2.1
+          (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.1
+          (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.2
+          (0 : Word)).2.2.2.1
+        (fullDivN3NormV b0 b1 b2 b3).2.2.1
+
 abbrev fullDivN3MulSubEqV4 (bltu_1 bltu_0 : Bool)
     (a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Prop :=
   EvmWord.val256 a0 a1 a2 a3 =

--- a/EvmAsm/Evm64/DivMod/Spec/N3QuotientStackBridge.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3QuotientStackBridge.lean
@@ -76,6 +76,12 @@ abbrev fullDivN3QuotientOverestimateV4 (bltu_1 bltu_0 : Bool)
       ((fullDivN3R0V4 bltu_1 bltu_0
         a0 a1 a2 a3 b0 b1 b2 b3).1).toNat
 
+abbrev fullDivN3Carry2NzV4 (b0 b1 b2 b3 : Word) : Prop :=
+  Carry2NzAll (fullDivN3NormV b0 b1 b2 b3).1
+    (fullDivN3NormV b0 b1 b2 b3).2.1
+    (fullDivN3NormV b0 b1 b2 b3).2.2.1
+    (fullDivN3NormV b0 b1 b2 b3).2.2.2
+
 /-- n=3 quotient bridge specialized to the explicit limb variables used by the
     unified-bound wrappers. -/
 theorem fullDivN3QuotientWord_eq_div_of_limbs_mulsub_overestimate

--- a/EvmAsm/Evm64/DivMod/Spec/N3QuotientStackBridge.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3QuotientStackBridge.lean
@@ -78,4 +78,70 @@ theorem fullDivN3QuotientWord_eq_div_of_limbs_mulsub_overestimate
     · exact EvmWord.fromLimbs_match_getLimbN_id a
     · exact EvmWord.fromLimbs_match_getLimbN_id b)
 
+/-- Explicit-limb n=3 quotient bridge for the v4 call/max path. -/
+theorem fullDivN3QuotientWordV4_eq_div_of_limbs_mulsub_overestimate
+    (bltu_1 bltu_0 : Bool) {a b : EvmWord}
+    {a0 a1 a2 a3 b0 b1 b2 b3 : Word}
+    (ha0 : a.getLimbN 0 = a0) (ha1 : a.getLimbN 1 = a1)
+    (ha2 : a.getLimbN 2 = a2) (ha3 : a.getLimbN 3 = a3)
+    (hb0 : b.getLimbN 0 = b0) (hb1 : b.getLimbN 1 = b1)
+    (hb2 : b.getLimbN 2 = b2) (hb3 : b.getLimbN 3 = b3)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hmulsub :
+      EvmWord.val256 a0 a1 a2 a3 =
+        (((fullDivN3R1V4 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1).toNat *
+            2^64 +
+          ((fullDivN3R0V4 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).1).toNat) *
+          EvmWord.val256 b0 b1 b2 b3 +
+        EvmWord.val256
+          ((fullDivN3R0V4 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).2.1)
+          ((fullDivN3R0V4 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).2.2.1)
+          ((fullDivN3R0V4 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1)
+          ((fullDivN3R0V4 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1))
+    (hge :
+      EvmWord.val256 a0 a1 a2 a3 / EvmWord.val256 b0 b1 b2 b3 ≤
+        ((fullDivN3R1V4 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1).toNat *
+            2^64 +
+          ((fullDivN3R0V4 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).1).toNat) :
+    fullDivN3QuotientWordV4 bltu_1 bltu_0
+      a0 a1 a2 a3 b0 b1 b2 b3 = EvmWord.div a b := by
+  subst a0
+  subst a1
+  subst a2
+  subst a3
+  subst b0
+  subst b1
+  subst b2
+  subst b3
+  have hraw :=
+    fullDivN3QuotientWordV4_eq_div_of_mulsub_overestimate
+      bltu_1 bltu_0 hbnz hmulsub hge
+  change
+    fullDivN3QuotientWordV4 bltu_1 bltu_0
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) =
+        EvmWord.div
+          (EvmWord.fromLimbs fun i : Fin 4 =>
+            match i with
+            | 0 => a.getLimbN 0
+            | 1 => a.getLimbN 1
+            | 2 => a.getLimbN 2
+            | 3 => a.getLimbN 3)
+          (EvmWord.fromLimbs fun i : Fin 4 =>
+            match i with
+            | 0 => b.getLimbN 0
+            | 1 => b.getLimbN 1
+            | 2 => b.getLimbN 2
+            | 3 => b.getLimbN 3) at hraw
+  exact hraw.trans (by
+    congr
+    · exact EvmWord.fromLimbs_match_getLimbN_id a
+    · exact EvmWord.fromLimbs_match_getLimbN_id b)
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N3QuotientStackBridge.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3QuotientStackBridge.lean
@@ -205,4 +205,21 @@ theorem fullDivN3QuotientWordV4_eq_div_of_limbs_mulsub_overestimate
     · exact EvmWord.fromLimbs_match_getLimbN_id a
     · exact EvmWord.fromLimbs_match_getLimbN_id b)
 
+/-- Explicit-limb v4 quotient bridge from the bundled N3 path predicate. -/
+theorem fullDivN3QuotientWordV4_eq_div_of_path_conditions
+    (bltu_1 bltu_0 : Bool) {a b : EvmWord}
+    {a0 a1 a2 a3 b0 b1 b2 b3 : Word}
+    (ha0 : a.getLimbN 0 = a0) (ha1 : a.getLimbN 1 = a1)
+    (ha2 : a.getLimbN 2 = a2) (ha3 : a.getLimbN 3 = a3)
+    (hb0 : b.getLimbN 0 = b0) (hb1 : b.getLimbN 1 = b1)
+    (hb2 : b.getLimbN 2 = b2) (hb3 : b.getLimbN 3 = b3)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hpath : fullDivN3PathConditionsV4 bltu_1 bltu_0
+      a0 a1 a2 a3 b0 b1 b2 b3) :
+    fullDivN3QuotientWordV4 bltu_1 bltu_0
+      a0 a1 a2 a3 b0 b1 b2 b3 = EvmWord.div a b := by
+  obtain ⟨_, _, _, hmulsub, hge⟩ := hpath
+  exact fullDivN3QuotientWordV4_eq_div_of_limbs_mulsub_overestimate
+    bltu_1 bltu_0 ha0 ha1 ha2 ha3 hb0 hb1 hb2 hb3 hbnz hmulsub hge
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N3QuotientStackBridge.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3QuotientStackBridge.lean
@@ -11,6 +11,32 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 
+abbrev fullDivN3MulSubEqV4 (bltu_1 bltu_0 : Bool)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Prop :=
+  EvmWord.val256 a0 a1 a2 a3 =
+    (((fullDivN3R1V4 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1).toNat *
+        2^64 +
+      ((fullDivN3R0V4 bltu_1 bltu_0
+        a0 a1 a2 a3 b0 b1 b2 b3).1).toNat) *
+      EvmWord.val256 b0 b1 b2 b3 +
+    EvmWord.val256
+      ((fullDivN3R0V4 bltu_1 bltu_0
+        a0 a1 a2 a3 b0 b1 b2 b3).2.1)
+      ((fullDivN3R0V4 bltu_1 bltu_0
+        a0 a1 a2 a3 b0 b1 b2 b3).2.2.1)
+      ((fullDivN3R0V4 bltu_1 bltu_0
+        a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1)
+      ((fullDivN3R0V4 bltu_1 bltu_0
+        a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1)
+
+abbrev fullDivN3QuotientOverestimateV4 (bltu_1 bltu_0 : Bool)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Prop :=
+  EvmWord.val256 a0 a1 a2 a3 / EvmWord.val256 b0 b1 b2 b3 ≤
+    ((fullDivN3R1V4 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1).toNat *
+        2^64 +
+      ((fullDivN3R0V4 bltu_1 bltu_0
+        a0 a1 a2 a3 b0 b1 b2 b3).1).toNat
+
 /-- n=3 quotient bridge specialized to the explicit limb variables used by the
     unified-bound wrappers. -/
 theorem fullDivN3QuotientWord_eq_div_of_limbs_mulsub_overestimate
@@ -87,28 +113,10 @@ theorem fullDivN3QuotientWordV4_eq_div_of_limbs_mulsub_overestimate
     (hb0 : b.getLimbN 0 = b0) (hb1 : b.getLimbN 1 = b1)
     (hb2 : b.getLimbN 2 = b2) (hb3 : b.getLimbN 3 = b3)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
-    (hmulsub :
-      EvmWord.val256 a0 a1 a2 a3 =
-        (((fullDivN3R1V4 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1).toNat *
-            2^64 +
-          ((fullDivN3R0V4 bltu_1 bltu_0
-            a0 a1 a2 a3 b0 b1 b2 b3).1).toNat) *
-          EvmWord.val256 b0 b1 b2 b3 +
-        EvmWord.val256
-          ((fullDivN3R0V4 bltu_1 bltu_0
-            a0 a1 a2 a3 b0 b1 b2 b3).2.1)
-          ((fullDivN3R0V4 bltu_1 bltu_0
-            a0 a1 a2 a3 b0 b1 b2 b3).2.2.1)
-          ((fullDivN3R0V4 bltu_1 bltu_0
-            a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1)
-          ((fullDivN3R0V4 bltu_1 bltu_0
-            a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1))
-    (hge :
-      EvmWord.val256 a0 a1 a2 a3 / EvmWord.val256 b0 b1 b2 b3 ≤
-        ((fullDivN3R1V4 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1).toNat *
-            2^64 +
-          ((fullDivN3R0V4 bltu_1 bltu_0
-            a0 a1 a2 a3 b0 b1 b2 b3).1).toNat) :
+    (hmulsub : fullDivN3MulSubEqV4 bltu_1 bltu_0
+      a0 a1 a2 a3 b0 b1 b2 b3)
+    (hge : fullDivN3QuotientOverestimateV4 bltu_1 bltu_0
+      a0 a1 a2 a3 b0 b1 b2 b3) :
     fullDivN3QuotientWordV4 bltu_1 bltu_0
       a0 a1 a2 a3 b0 b1 b2 b3 = EvmWord.div a b := by
   subst a0

--- a/EvmAsm/Evm64/DivMod/Spec/N3QuotientStackBridge.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3QuotientStackBridge.lean
@@ -90,6 +90,12 @@ abbrev fullDivN3PathConditionsV4 (bltu_1 bltu_0 : Bool)
   fullDivN3MulSubEqV4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3 ∧
   fullDivN3QuotientOverestimateV4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
 
+abbrev fullDivN3PathConditionsWordV4 (bltu_1 bltu_0 : Bool)
+    (a b : EvmWord) : Prop :=
+  fullDivN3PathConditionsV4 bltu_1 bltu_0
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+
 /-- n=3 quotient bridge specialized to the explicit limb variables used by the
     unified-bound wrappers. -/
 theorem fullDivN3QuotientWord_eq_div_of_limbs_mulsub_overestimate
@@ -221,5 +227,22 @@ theorem fullDivN3QuotientWordV4_eq_div_of_path_conditions
   obtain ⟨_, _, _, hmulsub, hge⟩ := hpath
   exact fullDivN3QuotientWordV4_eq_div_of_limbs_mulsub_overestimate
     bltu_1 bltu_0 ha0 ha1 ha2 ha3 hb0 hb1 hb2 hb3 hbnz hmulsub hge
+
+/-- EvmWord-level v4 quotient bridge from the bundled N3 path predicate. -/
+theorem fullDivN3QuotientWordV4_eq_div_of_word_path_conditions
+    (bltu_1 bltu_0 : Bool) (a b : EvmWord)
+    (hbnz : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 ≠ 0)
+    (hpath : fullDivN3PathConditionsWordV4 bltu_1 bltu_0 a b) :
+    fullDivN3QuotientWordV4 bltu_1 bltu_0
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) =
+        EvmWord.div a b := by
+  exact fullDivN3QuotientWordV4_eq_div_of_path_conditions
+    bltu_1 bltu_0 (a := a) (b := b)
+    (a0 := a.getLimbN 0) (a1 := a.getLimbN 1)
+    (a2 := a.getLimbN 2) (a3 := a.getLimbN 3)
+    (b0 := b.getLimbN 0) (b1 := b.getLimbN 1)
+    (b2 := b.getLimbN 2) (b3 := b.getLimbN 3)
+    rfl rfl rfl rfl rfl rfl rfl rfl hbnz hpath
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N3QuotientWord.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3QuotientWord.lean
@@ -17,6 +17,7 @@
 -/
 
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3LoopUnified
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V4
 import EvmAsm.Evm64.EvmWordArith.DivAccumulate
 
 namespace EvmAsm.Evm64
@@ -112,6 +113,103 @@ theorem fullDivN3QuotientWord_eq_div_of_mulsub_overestimate
     hbnz (by simpa [q0, q1, r0, r1, r2, r3] using hmulsub)
     (by simpa [q0, q1] using hge)
   delta fullDivN3QuotientWord
+  change
+    EvmWord.fromLimbs (fun i : Fin 4 =>
+      match i with | 0 => q0 | 1 => q1 | 2 => (0 : Word) | 3 => (0 : Word)) =
+      EvmWord.div
+        (EvmWord.fromLimbs fun i : Fin 4 =>
+          match i with | 0 => a0 | 1 => a1 | 2 => a2 | 3 => a3)
+        (EvmWord.fromLimbs fun i : Fin 4 =>
+          match i with | 0 => b0 | 1 => b1 | 2 => b2 | 3 => b3)
+  exact h_correct.1
+
+/-- Pack the four per-limb DIV results from the n=3 v4 call/max path into a
+    single `EvmWord`. The top two limbs are `0`, matching the n=3 range. -/
+@[irreducible]
+def fullDivN3QuotientWordV4 (bltu_1 bltu_0 : Bool)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word) : EvmWord :=
+  EvmWord.fromLimbs (fun i : Fin 4 =>
+    match i with
+    | 0 => (fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).1
+    | 1 => (fullDivN3R1V4 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1
+    | 2 => (0 : Word)
+    | 3 => (0 : Word))
+
+/-- If `fullDivN3QuotientWordV4 ... = EvmWord.div a b`, then each limb of
+    `EvmWord.div a b` matches the corresponding v4 `fullDivN3R{0,1}` result
+    (and limbs 2, 3 are zero). -/
+theorem fullDivN3V4_hdivs_of_word_eq
+    (bltu_1 bltu_0 : Bool)
+    (a b : EvmWord) (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hdiv : fullDivN3QuotientWordV4 bltu_1 bltu_0
+      a0 a1 a2 a3 b0 b1 b2 b3 = EvmWord.div a b) :
+    (EvmWord.div a b).getLimbN 0 =
+      (fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).1 ∧
+    (EvmWord.div a b).getLimbN 1 =
+      (fullDivN3R1V4 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1 ∧
+    (EvmWord.div a b).getLimbN 2 = (0 : Word) ∧
+    (EvmWord.div a b).getLimbN 3 = (0 : Word) := by
+  refine ⟨?_, ?_, ?_, ?_⟩
+  · rw [← hdiv]
+    delta fullDivN3QuotientWordV4
+    exact EvmWord.getLimbN_fromLimbs_0
+  · rw [← hdiv]
+    delta fullDivN3QuotientWordV4
+    exact EvmWord.getLimbN_fromLimbs_1
+  · rw [← hdiv]
+    delta fullDivN3QuotientWordV4
+    exact EvmWord.getLimbN_fromLimbs_2
+  · rw [← hdiv]
+    delta fullDivN3QuotientWordV4
+    exact EvmWord.getLimbN_fromLimbs_3
+
+/-- Semantic bridge for the n=3 v4 quotient word once the loop proof supplies
+    the accumulated mulsub equation and quotient-overestimate bound. -/
+theorem fullDivN3QuotientWordV4_eq_div_of_mulsub_overestimate
+    (bltu_1 bltu_0 : Bool)
+    {a0 a1 a2 a3 b0 b1 b2 b3 : Word}
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hmulsub :
+      val256 a0 a1 a2 a3 =
+        (((fullDivN3R1V4 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1).toNat *
+            2^64 +
+          ((fullDivN3R0V4 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).1).toNat) *
+          val256 b0 b1 b2 b3 +
+        val256
+          ((fullDivN3R0V4 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).2.1)
+          ((fullDivN3R0V4 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).2.2.1)
+          ((fullDivN3R0V4 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1)
+          ((fullDivN3R0V4 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1))
+    (hge :
+      val256 a0 a1 a2 a3 / val256 b0 b1 b2 b3 ≤
+        ((fullDivN3R1V4 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1).toNat *
+            2^64 +
+          ((fullDivN3R0V4 bltu_1 bltu_0
+            a0 a1 a2 a3 b0 b1 b2 b3).1).toNat) :
+    fullDivN3QuotientWordV4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3 =
+      EvmWord.div
+        (EvmWord.fromLimbs fun i : Fin 4 =>
+          match i with | 0 => a0 | 1 => a1 | 2 => a2 | 3 => a3)
+        (EvmWord.fromLimbs fun i : Fin 4 =>
+          match i with | 0 => b0 | 1 => b1 | 2 => b2 | 3 => b3) := by
+  let q0 := (fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).1
+  let q1 := (fullDivN3R1V4 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1
+  let r0 := (fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.1
+  let r1 := (fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1
+  let r2 := (fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1
+  let r3 := (fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1
+  have h_correct := div_correct_n3_no_shift
+    (a0 := a0) (a1 := a1) (a2 := a2) (a3 := a3)
+    (b0 := b0) (b1 := b1) (b2 := b2) (b3 := b3)
+    (q0 := q0) (q1 := q1) (r0 := r0) (r1 := r1) (r2 := r2) (r3 := r3)
+    hbnz (by simpa [q0, q1, r0, r1, r2, r3] using hmulsub)
+    (by simpa [q0, q1] using hge)
+  delta fullDivN3QuotientWordV4
   change
     EvmWord.fromLimbs (fun i : Fin 4 =>
       match i with | 0 => q0 | 1 => q1 | 2 => (0 : Word) | 3 => (0 : Word)) =

--- a/EvmAsm/Evm64/DivMod/Spec/N3RemainderWordV4.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3RemainderWordV4.lean
@@ -551,6 +551,25 @@ theorem iterN3V4MaxQHat_val256_conservation_of_carry2
     hbnz hc3_max
     (hcarry2 (signExtend12 4095 : Word) u0 u1 u2 u3 uTop)
 
+theorem iterN3Max_val256_conservation_of_carry2
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+    (hbnz : v0 ||| v1 ||| v2 ||| v3 ≠ 0)
+    (hc3_max :
+      BitVec.ult uTop
+          (mulsubN4 (signExtend12 4095 : Word)
+            v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2 →
+        (mulsubN4 (signExtend12 4095 : Word)
+          v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2 = 1)
+    (hcarry2 : Carry2NzAll v0 v1 v2 v3) :
+    let out := iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    EvmWord.val256 u0 u1 u2 u3 + uTop.toNat * 2 ^ 256 =
+      out.1.toNat * EvmWord.val256 v0 v1 v2 v3 +
+        EvmWord.val256 out.2.1 out.2.2.1 out.2.2.2.1 out.2.2.2.2.1 +
+        out.2.2.2.2.2.toNat * 2 ^ 256 := by
+  unfold iterN3Max
+  exact iterN3V4MaxQHat_val256_conservation_of_carry2
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop hbnz hc3_max hcarry2
+
 theorem fullDivN3NormalizedConservationV4_of_scaled_iter_conservation
     (bltu_1 bltu_0 : Bool) (a b : EvmWord)
     (hshift_nz : fullDivN3Shift (b.getLimbN 2) ≠ 0)

--- a/EvmAsm/Evm64/DivMod/Spec/N3RemainderWordV4.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3RemainderWordV4.lean
@@ -154,6 +154,31 @@ abbrev fullModN3PathConditionsWordV4 (bltu_1 bltu_0 : Bool)
     (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) =
       EvmWord.mod a b
 
+/-- MOD-specific N3 v4 path predicate with the remaining arithmetic obligation
+stated at `val256` level. This is the preferred shape for closing the current
+N3 MOD semantic gap, since it can be discharged by normalized-remainder
+arithmetic and then bridged to `EvmWord.mod`. -/
+abbrev fullModN3PathConditionsVal256V4 (bltu_1 bltu_0 : Bool)
+    (a b : EvmWord) : Prop :=
+  fullDivN3PathConditionsWordV4 bltu_1 bltu_0 a b ∧
+  fullModN3RemainderVal256V4 bltu_1 bltu_0
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) =
+      EvmWord.val256
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3) %
+      EvmWord.val256
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+
+theorem fullModN3PathConditionsWordV4_of_val256
+    (bltu_1 bltu_0 : Bool) (a b : EvmWord)
+    (hbnz : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 ≠ 0)
+    (hpath : fullModN3PathConditionsVal256V4 bltu_1 bltu_0 a b) :
+    fullModN3PathConditionsWordV4 bltu_1 bltu_0 a b := by
+  obtain ⟨hdivPath, hval⟩ := hpath
+  exact ⟨hdivPath,
+    fullModN3RemainderWordV4_eq_mod_of_val256_eq_mod
+      bltu_1 bltu_0 a b hbnz hval⟩
+
 theorem fullModN3RemainderWordV4_eq_mod_of_mod_path_conditions
     (bltu_1 bltu_0 : Bool) (a b : EvmWord)
     (hpath : fullModN3PathConditionsWordV4 bltu_1 bltu_0 a b) :

--- a/EvmAsm/Evm64/DivMod/Spec/N3RemainderWordV4.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3RemainderWordV4.lean
@@ -8,6 +8,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN3V4
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN4V4NoNop
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN3LoopUnified
 import EvmAsm.Evm64.DivMod.Spec.CallablePost
+import EvmAsm.Evm64.DivMod.Spec.N3QuotientStackBridge
 
 namespace EvmAsm.Evm64
 
@@ -39,6 +40,26 @@ def fullModN3RemainderWordV4 (bltu_1 bltu_0 : Bool)
     | 3 =>
         ((fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1 >>>
           ((fullDivN3Shift b2).toNat % 64)))
+
+/-- MOD-specific N3 v4 path predicate for caller-facing bridges. The first
+component is the shared DIV quotient/path predicate; the second records that
+the packed denormalized remainder is the EVM MOD result. -/
+abbrev fullModN3PathConditionsWordV4 (bltu_1 bltu_0 : Bool)
+    (a b : EvmWord) : Prop :=
+  fullDivN3PathConditionsWordV4 bltu_1 bltu_0 a b ∧
+  fullModN3RemainderWordV4 bltu_1 bltu_0
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) =
+      EvmWord.mod a b
+
+theorem fullModN3RemainderWordV4_eq_mod_of_mod_path_conditions
+    (bltu_1 bltu_0 : Bool) (a b : EvmWord)
+    (hpath : fullModN3PathConditionsWordV4 bltu_1 bltu_0 a b) :
+    fullModN3RemainderWordV4 bltu_1 bltu_0
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) =
+        EvmWord.mod a b :=
+  hpath.2
 
 /-- N3 MOD denorm post paired with the v4 call-path final computation. -/
 @[irreducible]

--- a/EvmAsm/Evm64/DivMod/Spec/N3RemainderWordV4.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3RemainderWordV4.lean
@@ -11,6 +11,7 @@ import EvmAsm.Evm64.DivMod.Spec.CallablePost
 import EvmAsm.Evm64.DivMod.Spec.N3QuotientStackBridge
 import EvmAsm.Evm64.EvmWordArith.DivAccumulate
 import EvmAsm.Evm64.EvmWordArith.KnuthTheoremB
+import EvmAsm.Evm64.EvmWordArith.ModBridgeUtop
 
 namespace EvmAsm.Evm64
 
@@ -281,6 +282,23 @@ theorem fullDivN3NormalizedMulSubEqV4_of_conservation
   rw [hcarry_zero] at hcons
   simpa using hcons
 
+private theorem finalCarryZero_of_conservation_bound
+    {a b q r carry : Nat}
+    (hbpos : 0 < b)
+    (hcons : a = q * b + r + carry * 2 ^ 256)
+    (hge : a / b ≤ q)
+    (hb_lt : b < 2 ^ 256) :
+    carry = 0 := by
+  have hcons' : a = q * b + (r + carry * 2 ^ 256) := by
+    omega
+  have hrem_lt : r + carry * 2 ^ 256 < b :=
+    (EvmWord.remainder_lt_of_ge_floor hbpos hcons' hge).2
+  by_contra hcarry_nz
+  have hcarry_pos : 0 < carry := by omega
+  have hrem_ge : 2 ^ 256 ≤ r + carry * 2 ^ 256 := by
+    nlinarith
+  omega
+
 /-- Normalized remainder bound paired with
 `fullDivN3NormalizedMulSubEqV4`. Together these are the standard Euclidean
 facts needed to recover the EVM MOD remainder. -/
@@ -416,6 +434,103 @@ theorem fullDivN3AntiShift_toNat_mod_eq_of_shift_ne {b2 : Word}
     omega
   have h63 := fullDivN3Shift_toNat_le_63 b2
   exact antiShift_toNat_mod_eq h1 h63
+
+theorem fullDivN3FinalCarryZeroV4_of_conservation_path
+    (bltu_1 bltu_0 : Bool) (a b : EvmWord)
+    (hbnz : b ≠ 0)
+    (hb3z : b.getLimbN 3 = 0)
+    (hdivPath : fullDivN3PathConditionsWordV4 bltu_1 bltu_0 a b)
+    (hcons : fullDivN3NormalizedConservationV4 bltu_1 bltu_0 a b) :
+    fullDivN3FinalCarryZeroV4 bltu_1 bltu_0 a b := by
+  obtain ⟨_, _, _, _, hge⟩ := hdivPath
+  have hbnz' :
+      b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 ≠ 0 :=
+    (EvmWord.ne_zero_iff_getLimbN_or).mp hbnz
+  have hbVal : 0 <
+      EvmWord.val256
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) :=
+    EvmWord.val256_pos_of_or_ne_zero hbnz'
+  have hpow : 0 < 2 ^ (fullDivN3Shift (b.getLimbN 2)).toNat := by
+    positivity
+  have hbScaled_pos : 0 <
+      EvmWord.val256
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) *
+        2 ^ (fullDivN3Shift (b.getLimbN 2)).toNat := by
+    positivity
+  have hgeScaled :
+      (EvmWord.val256
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3) *
+          2 ^ (fullDivN3Shift (b.getLimbN 2)).toNat) /
+        (EvmWord.val256
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) *
+          2 ^ (fullDivN3Shift (b.getLimbN 2)).toNat) ≤
+        ((fullDivN3R1V4 bltu_1
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1).toNat *
+          2 ^ 64 +
+        ((fullDivN3R0V4 bltu_1 bltu_0
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1).toNat := by
+    rw [Nat.mul_div_mul_right _ _ hpow]
+    exact hge
+  have hs_le64 : (fullDivN3Shift (b.getLimbN 2)).toNat ≤ 64 := by
+    have hs_le63 := fullDivN3Shift_toNat_le_63 (b.getLimbN 2)
+    omega
+  have hb3_bound :
+      (b.getLimbN 3).toNat <
+        2 ^ (64 - (fullDivN3Shift (b.getLimbN 2)).toNat) := by
+    rw [hb3z]
+    simp
+  have hbVal_lt :
+      EvmWord.val256
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) <
+        2 ^ (256 - (fullDivN3Shift (b.getLimbN 2)).toNat) :=
+    EvmWord.val256_lt_of_b3_bound
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+      hs_le64 hb3_bound
+  have hbScaled_lt :
+      EvmWord.val256
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) *
+          2 ^ (fullDivN3Shift (b.getLimbN 2)).toNat <
+        2 ^ 256 := by
+    calc
+      EvmWord.val256
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) *
+          2 ^ (fullDivN3Shift (b.getLimbN 2)).toNat
+          < 2 ^ (256 - (fullDivN3Shift (b.getLimbN 2)).toNat) *
+              2 ^ (fullDivN3Shift (b.getLimbN 2)).toNat :=
+            (Nat.mul_lt_mul_right hpow).mpr hbVal_lt
+      _ = 2 ^ 256 := by
+            rw [← pow_add]
+            congr 1
+            have hs_le256 :
+                (fullDivN3Shift (b.getLimbN 2)).toNat ≤ 256 := by
+              omega
+            omega
+  have hcarry_toNat_zero :
+      ((fullDivN3R0V4 bltu_1 bltu_0
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2.2.2).toNat = 0 := by
+    unfold fullDivN3NormalizedConservationV4 at hcons
+    exact finalCarryZero_of_conservation_bound
+      (hbpos := hbScaled_pos)
+      (hcons := hcons)
+      (hge := hgeScaled)
+      (hb_lt := hbScaled_lt)
+  unfold fullDivN3FinalCarryZeroV4
+  exact BitVec.eq_of_toNat_eq hcarry_toNat_zero
+
+theorem fullModN3PathConditionsNormalizedV4_of_conservation
+    (bltu_1 bltu_0 : Bool) (a b : EvmWord)
+    (hbnz : b ≠ 0)
+    (hb3z : b.getLimbN 3 = 0)
+    (hdivPath : fullDivN3PathConditionsWordV4 bltu_1 bltu_0 a b)
+    (hcons : fullDivN3NormalizedConservationV4 bltu_1 bltu_0 a b) :
+    fullModN3PathConditionsNormalizedV4 bltu_1 bltu_0 a b :=
+  fullModN3PathConditionsNormalizedV4_of_mulsub bltu_1 bltu_0 a b hbnz hdivPath
+    (fullDivN3NormalizedMulSubEqV4_of_conservation bltu_1 bltu_0 a b hcons
+      (fullDivN3FinalCarryZeroV4_of_conservation_path
+        bltu_1 bltu_0 a b hbnz hb3z hdivPath hcons))
 
 /-- Reduce the N3 v4 MOD `val256` remainder obligation to the normalized
 scaled-remainder equality produced before denormalization. -/

--- a/EvmAsm/Evm64/DivMod/Spec/N3RemainderWordV4.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3RemainderWordV4.lean
@@ -549,6 +549,23 @@ theorem fullDivN3NormV_or_ne_zero_of_b_ne_zero_b3_zero
     positivity
   exact limbs_or_ne_zero_of_val256_pos hnorm_pos
 
+theorem fullDivN3NormV_or_ne_zero_of_word_ne_zero_b3_zero
+    (b : EvmWord)
+    (hbnz : b ≠ 0)
+    (hshift_nz : fullDivN3Shift (b.getLimbN 2) ≠ 0)
+    (hb3z : b.getLimbN 3 = 0) :
+    (fullDivN3NormV
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1 |||
+      (fullDivN3NormV
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.1 |||
+      (fullDivN3NormV
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1 |||
+      (fullDivN3NormV
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2 ≠ 0 := by
+  exact fullDivN3NormV_or_ne_zero_of_b_ne_zero_b3_zero
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+    ((EvmWord.ne_zero_iff_getLimbN_or).mp hbnz) hshift_nz hb3z
+
 theorem iterN3V4CallQHat_val256_conservation_of_carry2
     (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
     (hbnz : v0 ||| v1 ||| v2 ||| v3 ≠ 0)

--- a/EvmAsm/Evm64/DivMod/Spec/N3RemainderWordV4.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3RemainderWordV4.lean
@@ -228,6 +228,59 @@ abbrev fullDivN3NormalizedMulSubEqV4 (bltu_1 bltu_0 : Bool)
         (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
         (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2.2.1
 
+/-- Raw normalized conservation equation for the N3 v4 final state, before
+separately proving that the final overflow carry is zero. This matches the
+shape produced by `iterWithDoubleAddback` conservation. -/
+abbrev fullDivN3NormalizedConservationV4 (bltu_1 bltu_0 : Bool)
+    (a b : EvmWord) : Prop :=
+  EvmWord.val256
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3) *
+      2 ^ (fullDivN3Shift (b.getLimbN 2)).toNat =
+    (((fullDivN3R1V4 bltu_1
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1).toNat *
+        2 ^ 64 +
+      ((fullDivN3R0V4 bltu_1 bltu_0
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1).toNat) *
+      (EvmWord.val256
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) *
+        2 ^ (fullDivN3Shift (b.getLimbN 2)).toNat) +
+    EvmWord.val256
+      (fullDivN3R0V4 bltu_1 bltu_0
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.1
+      (fullDivN3R0V4 bltu_1 bltu_0
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+      (fullDivN3R0V4 bltu_1 bltu_0
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2.1
+      (fullDivN3R0V4 bltu_1 bltu_0
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2.2.1 +
+    ((fullDivN3R0V4 bltu_1 bltu_0
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2.2.2).toNat *
+      2 ^ 256
+
+abbrev fullDivN3FinalCarryZeroV4 (bltu_1 bltu_0 : Bool)
+    (a b : EvmWord) : Prop :=
+  (fullDivN3R0V4 bltu_1 bltu_0
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2.2.2 = 0
+
+theorem fullDivN3NormalizedMulSubEqV4_of_conservation
+    (bltu_1 bltu_0 : Bool) (a b : EvmWord)
+    (hcons : fullDivN3NormalizedConservationV4 bltu_1 bltu_0 a b)
+    (hcarry_zero : fullDivN3FinalCarryZeroV4 bltu_1 bltu_0 a b) :
+    fullDivN3NormalizedMulSubEqV4 bltu_1 bltu_0 a b := by
+  unfold fullDivN3NormalizedConservationV4 at hcons
+  unfold fullDivN3FinalCarryZeroV4 at hcarry_zero
+  unfold fullDivN3NormalizedMulSubEqV4
+  rw [hcarry_zero] at hcons
+  simpa using hcons
+
 /-- Normalized remainder bound paired with
 `fullDivN3NormalizedMulSubEqV4`. Together these are the standard Euclidean
 facts needed to recover the EVM MOD remainder. -/

--- a/EvmAsm/Evm64/DivMod/Spec/N3RemainderWordV4.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3RemainderWordV4.lean
@@ -250,6 +250,15 @@ abbrev fullDivN3NormalizedRemainderLtV4 (bltu_1 bltu_0 : Bool)
       (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) *
       2 ^ (fullDivN3Shift (b.getLimbN 2)).toNat
 
+/-- MOD-specific N3 v4 path predicate at the normalized Euclidean boundary.
+This is the next closure target for the loop proof: the shared DIV path facts,
+the normalized mulsub equation, and the normalized remainder bound. -/
+abbrev fullModN3PathConditionsNormalizedV4 (bltu_1 bltu_0 : Bool)
+    (a b : EvmWord) : Prop :=
+  fullDivN3PathConditionsWordV4 bltu_1 bltu_0 a b ∧
+  fullDivN3NormalizedMulSubEqV4 bltu_1 bltu_0 a b ∧
+  fullDivN3NormalizedRemainderLtV4 bltu_1 bltu_0 a b
+
 theorem fullModN3PathConditionsScaledV4_of_normalized_euclidean
     (bltu_1 bltu_0 : Bool) (a b : EvmWord)
     (hdivPath : fullDivN3PathConditionsWordV4 bltu_1 bltu_0 a b)
@@ -259,6 +268,14 @@ theorem fullModN3PathConditionsScaledV4_of_normalized_euclidean
   refine ⟨hdivPath, ?_⟩
   exact EvmWord.normalized_remainder_eq_mod_mul_pow
     ((fullDivN3Shift (b.getLimbN 2)).toNat) hmulsub hrlt
+
+theorem fullModN3PathConditionsScaledV4_of_normalized
+    (bltu_1 bltu_0 : Bool) (a b : EvmWord)
+    (hpath : fullModN3PathConditionsNormalizedV4 bltu_1 bltu_0 a b) :
+    fullModN3PathConditionsScaledV4 bltu_1 bltu_0 a b := by
+  obtain ⟨hdivPath, hmulsub, hrlt⟩ := hpath
+  exact fullModN3PathConditionsScaledV4_of_normalized_euclidean
+    bltu_1 bltu_0 a b hdivPath hmulsub hrlt
 
 theorem fullModN3PathConditionsWordV4_of_val256
     (bltu_1 bltu_0 : Bool) (a b : EvmWord)

--- a/EvmAsm/Evm64/DivMod/Spec/N3RemainderWordV4.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3RemainderWordV4.lean
@@ -5,13 +5,14 @@
 -/
 
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V4
+import EvmAsm.Evm64.DivMod.Compose.ModFullPathN4V4NoNop
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN3LoopUnified
 import EvmAsm.Evm64.DivMod.Spec.CallablePost
 
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
-open EvmAsm.Rv64.AddrNorm (word_add_zero)
+open EvmAsm.Rv64.AddrNorm (word_add_zero se12_32 se12_40 se12_48 se12_56)
 
 /-- v4 n=3 MOD remainder word, using the v4 call-path `fullDivN3R0V4`
 computation before the usual denormalization shift. -/
@@ -64,6 +65,79 @@ def fullModN3UnifiedPostNoX1V4 (bltu_1 bltu_0 : Bool)
     retMem dMem dloMem scratchUn0 **
   ((sp + signExtend12 3936) ↦ₘ
     fullDivN3ScratchMemV4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3 scratchMem)
+
+/-- N3 denormalization and MOD epilogue over the v4/no-NOP dispatcher body,
+    using the v4 callable-trial final computation family. -/
+theorem evm_mod_n3_denorm_epilogue_bundled_spec_v4_noNop_v4Final
+    (bltu_1 bltu_0 : Bool)
+    (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hshift_nz : fullDivN3Shift b2 ≠ 0) :
+    cpsTripleWithin (2 + 23 + 10) (base + denormOff) (base + nopOff) (modCode_noNop_v4 base)
+      (fullDivN3DenormPreV4 bltu_1 bltu_0 sp a0 a1 a2 a3 b0 b1 b2 b3)
+      (fullModN3DenormPostV4 bltu_1 bltu_0 sp a0 a1 a2 a3 b0 b1 b2 b3) := by
+  let shift := fullDivN3Shift b2
+  let v := fullDivN3NormV b0 b1 b2 b3
+  let r1 := fullDivN3R1V4 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+  let r0 := fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+  let c3 := fullDivN3C3V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+  have h := evm_mod_preamble_denorm_epilogue_spec_within_noNop_v4 sp base
+    r0.2.1 r0.2.2.1 r0.2.2.2.1 r0.2.2.2.2.1 shift
+    r0.2.2.2.2.1 (0 : Word) (sp + signExtend12 4056) (sp + signExtend12 4088)
+    c3 v.1 v.2.1 v.2.2.1 v.2.2.2 hshift_nz
+  have hF := cpsTripleWithin_frameR
+    (((sp + signExtend12 4088) ↦ₘ r0.1) **
+     ((sp + signExtend12 4080) ↦ₘ r1.1) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4064) ↦ₘ (0 : Word)))
+    (by pcFree) h
+  exact cpsTripleWithin_weaken
+    (fun h hp => by
+      subst shift; subst v; subst r1; subst r0; subst c3
+      delta fullDivN3DenormPreV4 at hp
+      simp only [se12_32, se12_40, se12_48, se12_56] at hp
+      xperm_hyp hp)
+    (fun h hq => by
+      subst shift; subst r1; subst r0
+      delta fullModN3DenormPostV4
+      xperm_hyp hq)
+    hF
+
+/-- N3 denormalization and MOD epilogue over v4/no-NOP for the v4 final
+    computation family, preserving exact caller `x1` and the final v4 div128
+    scratch cell. -/
+theorem evm_mod_n3_denorm_epilogue_bundled_spec_v4_noNop_v4Final_exact_x1_scratch_frame
+    (bltu_1 bltu_0 : Bool)
+    (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem raVal : Word)
+    (hshift_nz : fullDivN3Shift b2 ≠ 0) :
+    cpsTripleWithin (2 + 23 + 10) (base + denormOff) (base + nopOff)
+      (modCode_noNop_v4 base)
+      (fullDivN3DenormPreV4 bltu_1 bltu_0 sp a0 a1 a2 a3 b0 b1 b2 b3 **
+       fullDivN3FrameNoX1V4 bltu_1 bltu_0 sp base
+         a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ
+         fullDivN3ScratchMemV4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3 scratchMem) **
+       (.x1 ↦ᵣ raVal))
+      (fullModN3UnifiedPostNoX1V4 bltu_1 bltu_0 sp base
+        a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 scratchMem **
+       (.x1 ↦ᵣ raVal)) := by
+  have hDenorm := evm_mod_n3_denorm_epilogue_bundled_spec_v4_noNop_v4Final
+    bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3 hshift_nz
+  have hFramed := cpsTripleWithin_frameR
+    (fullDivN3FrameNoX1V4 bltu_1 bltu_0 sp base
+     a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 **
+     ((sp + signExtend12 3936) ↦ₘ
+       fullDivN3ScratchMemV4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3 scratchMem) **
+     (.x1 ↦ᵣ raVal))
+    (by
+      delta fullDivN3FrameNoX1V4 fullDivN3ScratchNoX1V4
+      pcFree) hDenorm
+  exact cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by
+      delta fullModN3UnifiedPostNoX1V4
+      xperm_hyp hq)
+    hFramed
 
 /-- Project a packed v4 n=3 MOD remainder equality into limb equalities. -/
 theorem fullModN3V4_hmods_of_word_eq

--- a/EvmAsm/Evm64/DivMod/Spec/N3RemainderWordV4.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3RemainderWordV4.lean
@@ -9,6 +9,7 @@ import EvmAsm.Evm64.DivMod.Compose.ModFullPathN4V4NoNop
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN3LoopUnified
 import EvmAsm.Evm64.DivMod.Spec.CallablePost
 import EvmAsm.Evm64.DivMod.Spec.N3QuotientStackBridge
+import EvmAsm.Evm64.EvmWordArith.DivAccumulate
 import EvmAsm.Evm64.EvmWordArith.KnuthTheoremB
 
 namespace EvmAsm.Evm64
@@ -194,6 +195,70 @@ abbrev fullModN3PathConditionsScaledV4 (bltu_1 bltu_0 : Bool)
       EvmWord.val256
         (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) *
       2 ^ (fullDivN3Shift (b.getLimbN 2)).toNat
+
+/-- Normalized Euclidean equation expected from the remaining N3 v4 loop
+arithmetic proof. The final normalized remainder `fullDivN3R0V4` is paired
+with the two accumulated quotient limbs. -/
+abbrev fullDivN3NormalizedMulSubEqV4 (bltu_1 bltu_0 : Bool)
+    (a b : EvmWord) : Prop :=
+  EvmWord.val256
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3) *
+      2 ^ (fullDivN3Shift (b.getLimbN 2)).toNat =
+    (((fullDivN3R1V4 bltu_1
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1).toNat *
+        2 ^ 64 +
+      ((fullDivN3R0V4 bltu_1 bltu_0
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1).toNat) *
+      (EvmWord.val256
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) *
+        2 ^ (fullDivN3Shift (b.getLimbN 2)).toNat) +
+    EvmWord.val256
+      (fullDivN3R0V4 bltu_1 bltu_0
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.1
+      (fullDivN3R0V4 bltu_1 bltu_0
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+      (fullDivN3R0V4 bltu_1 bltu_0
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2.1
+      (fullDivN3R0V4 bltu_1 bltu_0
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2.2.1
+
+/-- Normalized remainder bound paired with
+`fullDivN3NormalizedMulSubEqV4`. Together these are the standard Euclidean
+facts needed to recover the EVM MOD remainder. -/
+abbrev fullDivN3NormalizedRemainderLtV4 (bltu_1 bltu_0 : Bool)
+    (a b : EvmWord) : Prop :=
+  EvmWord.val256
+      (fullDivN3R0V4 bltu_1 bltu_0
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.1
+      (fullDivN3R0V4 bltu_1 bltu_0
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+      (fullDivN3R0V4 bltu_1 bltu_0
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2.1
+      (fullDivN3R0V4 bltu_1 bltu_0
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2.2.1 <
+    EvmWord.val256
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) *
+      2 ^ (fullDivN3Shift (b.getLimbN 2)).toNat
+
+theorem fullModN3PathConditionsScaledV4_of_normalized_euclidean
+    (bltu_1 bltu_0 : Bool) (a b : EvmWord)
+    (hdivPath : fullDivN3PathConditionsWordV4 bltu_1 bltu_0 a b)
+    (hmulsub : fullDivN3NormalizedMulSubEqV4 bltu_1 bltu_0 a b)
+    (hrlt : fullDivN3NormalizedRemainderLtV4 bltu_1 bltu_0 a b) :
+    fullModN3PathConditionsScaledV4 bltu_1 bltu_0 a b := by
+  refine ⟨hdivPath, ?_⟩
+  exact EvmWord.normalized_remainder_eq_mod_mul_pow
+    ((fullDivN3Shift (b.getLimbN 2)).toNat) hmulsub hrlt
 
 theorem fullModN3PathConditionsWordV4_of_val256
     (bltu_1 bltu_0 : Bool) (a b : EvmWord)

--- a/EvmAsm/Evm64/DivMod/Spec/N3RemainderWordV4.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3RemainderWordV4.lean
@@ -299,6 +299,23 @@ private theorem finalCarryZero_of_conservation_bound
     nlinarith
   omega
 
+private theorem val256_with_overflow_eq_low_add_tail
+    (u0 u1 u2 u3 u4 : Word) :
+    EvmWord.val256 u0 u1 u2 u3 + u4.toNat * 2 ^ 256 =
+      u0.toNat + 2 ^ 64 * EvmWord.val256 u1 u2 u3 u4 := by
+  unfold EvmWord.val256
+  ring
+
+private theorem n3_two_step_conservation_nat
+    {a b q1 q0 uhi r0 r1 c0 : Nat}
+    (u0 : Nat)
+    (hfirst : a = u0 + 2 ^ 64 * uhi)
+    (hiter1 : uhi = q1 * b + r1)
+    (hiter0 : u0 + 2 ^ 64 * r1 = q0 * b + r0 + c0 * 2 ^ 256) :
+    a = (q1 * 2 ^ 64 + q0) * b + r0 + c0 * 2 ^ 256 := by
+  rw [hfirst, hiter1]
+  nlinarith
+
 /-- Normalized remainder bound paired with
 `fullDivN3NormalizedMulSubEqV4`. Together these are the standard Euclidean
 facts needed to recover the EVM MOD remainder. -/

--- a/EvmAsm/Evm64/DivMod/Spec/N3RemainderWordV4.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3RemainderWordV4.lean
@@ -635,6 +635,22 @@ theorem fullModN3PathConditionsVal256V4_of_scaled
     fullModN3RemainderVal256V4_eq_mod_of_scaled_remainder_shift_ne
       bltu_1 bltu_0 a b hshift_nz hscaled⟩
 
+theorem fullModN3PathConditionsWordV4_of_conservation
+    (bltu_1 bltu_0 : Bool) (a b : EvmWord)
+    (hbnz : b ≠ 0)
+    (hb3z : b.getLimbN 3 = 0)
+    (hshift_nz : fullDivN3Shift (b.getLimbN 2) ≠ 0)
+    (hdivPath : fullDivN3PathConditionsWordV4 bltu_1 bltu_0 a b)
+    (hcons : fullDivN3NormalizedConservationV4 bltu_1 bltu_0 a b) :
+    fullModN3PathConditionsWordV4 bltu_1 bltu_0 a b := by
+  have hbnz' : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 ≠ 0 :=
+    (EvmWord.ne_zero_iff_getLimbN_or).mp hbnz
+  exact fullModN3PathConditionsWordV4_of_val256 bltu_1 bltu_0 a b hbnz'
+    (fullModN3PathConditionsVal256V4_of_scaled bltu_1 bltu_0 a b hshift_nz
+      (fullModN3PathConditionsScaledV4_of_normalized bltu_1 bltu_0 a b
+        (fullModN3PathConditionsNormalizedV4_of_conservation
+          bltu_1 bltu_0 a b hbnz hb3z hdivPath hcons)))
+
 theorem fullModN3RemainderWordV4_eq_mod_of_mod_path_conditions
     (bltu_1 bltu_0 : Bool) (a b : EvmWord)
     (hpath : fullModN3PathConditionsWordV4 bltu_1 bltu_0 a b) :

--- a/EvmAsm/Evm64/DivMod/Spec/N3RemainderWordV4.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3RemainderWordV4.lean
@@ -9,6 +9,7 @@ import EvmAsm.Evm64.DivMod.Compose.ModFullPathN4V4NoNop
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN3LoopUnified
 import EvmAsm.Evm64.DivMod.Spec.CallablePost
 import EvmAsm.Evm64.DivMod.Spec.N3QuotientStackBridge
+import EvmAsm.Evm64.EvmWordArith.KnuthTheoremB
 
 namespace EvmAsm.Evm64
 
@@ -179,6 +180,34 @@ theorem fullModN3PathConditionsWordV4_of_val256
     fullModN3RemainderWordV4_eq_mod_of_val256_eq_mod
       bltu_1 bltu_0 a b hbnz hval⟩
 
+theorem fullDivN3Shift_toNat_pos_of_ne {b2 : Word}
+    (hshift_nz : fullDivN3Shift b2 ≠ 0) :
+    0 < (fullDivN3Shift b2).toNat := by
+  exact Nat.pos_of_ne_zero (by
+    intro h_zero
+    exact hshift_nz (BitVec.eq_of_toNat_eq h_zero))
+
+theorem fullDivN3Shift_toNat_le_63 (b2 : Word) :
+    (fullDivN3Shift b2).toNat ≤ 63 := by
+  delta fullDivN3Shift
+  exact clzResult_fst_toNat_le b2
+
+theorem fullDivN3Shift_toNat_mod_eq (b2 : Word) :
+    (fullDivN3Shift b2).toNat % 64 = (fullDivN3Shift b2).toNat :=
+  Nat.mod_eq_of_lt (by
+    have h_le := fullDivN3Shift_toNat_le_63 b2
+    omega)
+
+theorem fullDivN3AntiShift_toNat_mod_eq_of_shift_ne {b2 : Word}
+    (hshift_nz : fullDivN3Shift b2 ≠ 0) :
+    (signExtend12 (0 : BitVec 12) - fullDivN3Shift b2).toNat % 64 =
+      64 - (fullDivN3Shift b2).toNat := by
+  have h1 : 1 ≤ (fullDivN3Shift b2).toNat := by
+    have h_pos := fullDivN3Shift_toNat_pos_of_ne hshift_nz
+    omega
+  have h63 := fullDivN3Shift_toNat_le_63 b2
+  exact antiShift_toNat_mod_eq h1 h63
+
 /-- Reduce the N3 v4 MOD `val256` remainder obligation to the normalized
 scaled-remainder equality produced before denormalization. -/
 theorem fullModN3RemainderVal256V4_eq_mod_of_scaled_remainder
@@ -230,6 +259,47 @@ theorem fullModN3RemainderVal256V4_eq_mod_of_scaled_remainder
   delta fullModN3RemainderVal256V4
   rw [hshift, hanti, hdenorm, hscaled]
   exact Nat.mul_div_cancel _ (by positivity : 0 < 2 ^ s)
+
+/-- Version of `fullModN3RemainderVal256V4_eq_mod_of_scaled_remainder` with
+the CLZ shift side conditions discharged from `fullDivN3Shift b2 ≠ 0`. -/
+theorem fullModN3RemainderVal256V4_eq_mod_of_scaled_remainder_shift_ne
+    (bltu_1 bltu_0 : Bool) (a b : EvmWord)
+    (hshift_nz : fullDivN3Shift (b.getLimbN 2) ≠ 0)
+    (hscaled :
+      EvmWord.val256
+        (fullDivN3R0V4 bltu_1 bltu_0
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.1
+        (fullDivN3R0V4 bltu_1 bltu_0
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+        (fullDivN3R0V4 bltu_1 bltu_0
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2.1
+        (fullDivN3R0V4 bltu_1 bltu_0
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2.2.1 =
+      EvmWord.val256
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3) %
+        EvmWord.val256
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) *
+        2 ^ (fullDivN3Shift (b.getLimbN 2)).toNat) :
+    fullModN3RemainderVal256V4 bltu_1 bltu_0
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) =
+        EvmWord.val256
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3) %
+        EvmWord.val256
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) :=
+  fullModN3RemainderVal256V4_eq_mod_of_scaled_remainder
+    bltu_1 bltu_0 a b
+    (fullDivN3Shift_toNat_pos_of_ne hshift_nz)
+    (by
+      have h_le := fullDivN3Shift_toNat_le_63 (b.getLimbN 2)
+      omega)
+    (fullDivN3Shift_toNat_mod_eq (b.getLimbN 2))
+    (fullDivN3AntiShift_toNat_mod_eq_of_shift_ne hshift_nz)
+    hscaled
 
 theorem fullModN3RemainderWordV4_eq_mod_of_mod_path_conditions
     (bltu_1 bltu_0 : Bool) (a b : EvmWord)

--- a/EvmAsm/Evm64/DivMod/Spec/N3RemainderWordV4.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3RemainderWordV4.lean
@@ -41,6 +41,108 @@ def fullModN3RemainderWordV4 (bltu_1 bltu_0 : Bool)
         ((fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1 >>>
           ((fullDivN3Shift b2).toNat % 64)))
 
+/-- `val256` view of `fullModN3RemainderWordV4`.  This is the arithmetic
+target needed to discharge the current word-level MOD path predicate. -/
+@[irreducible]
+def fullModN3RemainderVal256V4 (bltu_1 bltu_0 : Bool)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Nat :=
+  EvmWord.val256
+    (((fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.1 >>>
+        ((fullDivN3Shift b2).toNat % 64)) |||
+      ((fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 <<<
+        ((signExtend12 (0 : BitVec 12) - fullDivN3Shift b2).toNat % 64)))
+    (((fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 >>>
+        ((fullDivN3Shift b2).toNat % 64)) |||
+      ((fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1 <<<
+        ((signExtend12 (0 : BitVec 12) - fullDivN3Shift b2).toNat % 64)))
+    (((fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1 >>>
+        ((fullDivN3Shift b2).toNat % 64)) |||
+      ((fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1 <<<
+        ((signExtend12 (0 : BitVec 12) - fullDivN3Shift b2).toNat % 64)))
+    ((fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1 >>>
+      ((fullDivN3Shift b2).toNat % 64))
+
+/-- Turn the `val256` denormalized-remainder equality into the public
+`EvmWord.mod` word equality for the n=3 v4 final computation. -/
+theorem fullModN3RemainderWordV4_eq_mod_of_val256_eq_mod
+    (bltu_1 bltu_0 : Bool) (a b : EvmWord)
+    (hbnz : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 ≠ 0)
+    (hval : fullModN3RemainderVal256V4 bltu_1 bltu_0
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) =
+        EvmWord.val256
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3) %
+        EvmWord.val256
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)) :
+    fullModN3RemainderWordV4 bltu_1 bltu_0
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) =
+        EvmWord.mod a b := by
+  let r0 :=
+    (((fullDivN3R0V4 bltu_1 bltu_0
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.1 >>>
+        ((fullDivN3Shift (b.getLimbN 2)).toNat % 64)) |||
+      ((fullDivN3R0V4 bltu_1 bltu_0
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1 <<<
+        ((signExtend12 (0 : BitVec 12) - fullDivN3Shift (b.getLimbN 2)).toNat % 64)))
+  let r1 :=
+    (((fullDivN3R0V4 bltu_1 bltu_0
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1 >>>
+        ((fullDivN3Shift (b.getLimbN 2)).toNat % 64)) |||
+      ((fullDivN3R0V4 bltu_1 bltu_0
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2.1 <<<
+        ((signExtend12 (0 : BitVec 12) - fullDivN3Shift (b.getLimbN 2)).toNat % 64)))
+  let r2 :=
+    (((fullDivN3R0V4 bltu_1 bltu_0
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2.1 >>>
+        ((fullDivN3Shift (b.getLimbN 2)).toNat % 64)) |||
+      ((fullDivN3R0V4 bltu_1 bltu_0
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2.2.1 <<<
+        ((signExtend12 (0 : BitVec 12) - fullDivN3Shift (b.getLimbN 2)).toNat % 64)))
+  let r3 :=
+    ((fullDivN3R0V4 bltu_1 bltu_0
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2.2.1 >>>
+      ((fullDivN3Shift (b.getLimbN 2)).toNat % 64))
+  have hraw := EvmWord.mod_of_val256_eq_mod
+    (a0 := a.getLimbN 0) (a1 := a.getLimbN 1)
+    (a2 := a.getLimbN 2) (a3 := a.getLimbN 3)
+    (b0 := b.getLimbN 0) (b1 := b.getLimbN 1)
+    (b2 := b.getLimbN 2) (b3 := b.getLimbN 3)
+    (r0 := r0) (r1 := r1) (r2 := r2) (r3 := r3)
+    hbnz (by
+      subst r0; subst r1; subst r2; subst r3
+      delta fullModN3RemainderVal256V4 at hval
+      exact hval)
+  dsimp only at hraw
+  have haFold : (EvmWord.fromLimbs fun i : Fin 4 => match i with
+      | 0 => a.getLimbN 0 | 1 => a.getLimbN 1
+      | 2 => a.getLimbN 2 | 3 => a.getLimbN 3) = a :=
+    EvmWord.fromLimbs_match_getLimbN_id a
+  have hbFold : (EvmWord.fromLimbs fun i : Fin 4 => match i with
+      | 0 => b.getLimbN 0 | 1 => b.getLimbN 1
+      | 2 => b.getLimbN 2 | 3 => b.getLimbN 3) = b :=
+    EvmWord.fromLimbs_match_getLimbN_id b
+  have hmodFold :
+      EvmWord.mod
+        (EvmWord.fromLimbs fun i : Fin 4 => match i with
+          | 0 => a.getLimbN 0 | 1 => a.getLimbN 1
+          | 2 => a.getLimbN 2 | 3 => a.getLimbN 3)
+        (EvmWord.fromLimbs fun i : Fin 4 => match i with
+          | 0 => b.getLimbN 0 | 1 => b.getLimbN 1
+          | 2 => b.getLimbN 2 | 3 => b.getLimbN 3) =
+        EvmWord.mod a b := by
+    rw [haFold, hbFold]
+  subst r0; subst r1; subst r2; subst r3
+  delta fullModN3RemainderWordV4
+  exact hraw.trans hmodFold
+
 /-- MOD-specific N3 v4 path predicate for caller-facing bridges. The first
 component is the shared DIV quotient/path predicate; the second records that
 the packed denormalized remainder is the EVM MOD result. -/

--- a/EvmAsm/Evm64/DivMod/Spec/N3RemainderWordV4.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3RemainderWordV4.lean
@@ -179,6 +179,58 @@ theorem fullModN3PathConditionsWordV4_of_val256
     fullModN3RemainderWordV4_eq_mod_of_val256_eq_mod
       bltu_1 bltu_0 a b hbnz hval⟩
 
+/-- Reduce the N3 v4 MOD `val256` remainder obligation to the normalized
+scaled-remainder equality produced before denormalization. -/
+theorem fullModN3RemainderVal256V4_eq_mod_of_scaled_remainder
+    (bltu_1 bltu_0 : Bool) (a b : EvmWord)
+    {s : Nat} (hs0 : 0 < s) (hs : s < 64)
+    (hshift : (fullDivN3Shift (b.getLimbN 2)).toNat % 64 = s)
+    (hanti :
+      (signExtend12 (0 : BitVec 12) - fullDivN3Shift (b.getLimbN 2)).toNat % 64 =
+        64 - s)
+    (hscaled :
+      EvmWord.val256
+        (fullDivN3R0V4 bltu_1 bltu_0
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.1
+        (fullDivN3R0V4 bltu_1 bltu_0
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+        (fullDivN3R0V4 bltu_1 bltu_0
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2.1
+        (fullDivN3R0V4 bltu_1 bltu_0
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2.2.1 =
+      EvmWord.val256
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3) %
+        EvmWord.val256
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) * 2 ^ s) :
+    fullModN3RemainderVal256V4 bltu_1 bltu_0
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) =
+        EvmWord.val256
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3) %
+        EvmWord.val256
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) := by
+  let r0 := (fullDivN3R0V4 bltu_1 bltu_0
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.1
+  let r1 := (fullDivN3R0V4 bltu_1 bltu_0
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+  let r2 := (fullDivN3R0V4 bltu_1 bltu_0
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2.1
+  let r3 := (fullDivN3R0V4 bltu_1 bltu_0
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2.2.1
+  have hdenorm := EvmWord.val256_denormalize hs0 hs r0 r1 r2 r3
+  subst r0; subst r1; subst r2; subst r3
+  delta fullModN3RemainderVal256V4
+  rw [hshift, hanti, hdenorm, hscaled]
+  exact Nat.mul_div_cancel _ (by positivity : 0 < 2 ^ s)
+
 theorem fullModN3RemainderWordV4_eq_mod_of_mod_path_conditions
     (bltu_1 bltu_0 : Bool) (a b : EvmWord)
     (hpath : fullModN3PathConditionsWordV4 bltu_1 bltu_0 a b) :

--- a/EvmAsm/Evm64/DivMod/Spec/N3RemainderWordV4.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3RemainderWordV4.lean
@@ -5,6 +5,7 @@
 -/
 
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V4
+import EvmAsm.Evm64.DivMod.Compose.ModFullPathN3LoopUnified
 
 namespace EvmAsm.Evm64
 
@@ -35,6 +36,32 @@ def fullModN3RemainderWordV4 (bltu_1 bltu_0 : Bool)
     | 3 =>
         ((fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1 >>>
           ((fullDivN3Shift b2).toNat % 64)))
+
+/-- N3 MOD denorm post paired with the v4 call-path final computation. -/
+@[irreducible]
+def fullModN3DenormPostV4 (bltu_1 bltu_0 : Bool)
+    (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
+  let shift := fullDivN3Shift b2
+  let r1 := fullDivN3R1V4 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+  let r0 := fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+  denormModPost sp shift r0.2.1 r0.2.2.1 r0.2.2.2.1 r0.2.2.2.2.1 **
+  ((sp + signExtend12 3992) ↦ₘ shift) **
+  ((sp + signExtend12 4088) ↦ₘ r0.1) **
+  ((sp + signExtend12 4080) ↦ₘ r1.1) **
+  ((sp + signExtend12 4072) ↦ₘ (0 : Word)) **
+  ((sp + signExtend12 4064) ↦ₘ (0 : Word))
+
+/-- N3 MOD unified post with caller `x1` outside the assertion and the v4
+div128 scratch cell framed explicitly. -/
+@[irreducible]
+def fullModN3UnifiedPostNoX1V4 (bltu_1 bltu_0 : Bool)
+    (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word) : Assertion :=
+  fullModN3DenormPostV4 bltu_1 bltu_0 sp a0 a1 a2 a3 b0 b1 b2 b3 **
+  fullDivN3FrameNoX1V4 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
+    retMem dMem dloMem scratchUn0 **
+  ((sp + signExtend12 3936) ↦ₘ
+    fullDivN3ScratchMemV4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3 scratchMem)
 
 /-- Project a packed v4 n=3 MOD remainder equality into limb equalities. -/
 theorem fullModN3V4_hmods_of_word_eq

--- a/EvmAsm/Evm64/DivMod/Spec/N3RemainderWordV4.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3RemainderWordV4.lean
@@ -316,6 +316,17 @@ private theorem n3_two_step_conservation_nat
   rw [hfirst, hiter1]
   nlinarith
 
+private theorem n3_two_step_conservation_of_iter_nat
+    {a b q1 q0 uhi r0 r1 c1 c0 : Nat}
+    (u0 : Nat)
+    (hfirst : a = u0 + 2 ^ 64 * uhi)
+    (hiter1 : uhi = q1 * b + r1 + c1 * 2 ^ 256)
+    (hc1 : c1 = 0)
+    (hiter0 : u0 + 2 ^ 64 * r1 = q0 * b + r0 + c0 * 2 ^ 256) :
+    a = (q1 * 2 ^ 64 + q0) * b + r0 + c0 * 2 ^ 256 := by
+  subst c1
+  exact n3_two_step_conservation_nat u0 hfirst (by simpa using hiter1) hiter0
+
 /-- Normalized remainder bound paired with
 `fullDivN3NormalizedMulSubEqV4`. Together these are the standard Euclidean
 facts needed to recover the EVM MOD remainder. -/

--- a/EvmAsm/Evm64/DivMod/Spec/N3RemainderWordV4.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3RemainderWordV4.lean
@@ -1,0 +1,77 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N3RemainderWordV4
+
+  Packed n=3 MOD remainder word for the v4 call/max final computation.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V4
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- v4 n=3 MOD remainder word, using the v4 call-path `fullDivN3R0V4`
+computation before the usual denormalization shift. -/
+@[irreducible]
+def fullModN3RemainderWordV4 (bltu_1 bltu_0 : Bool)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word) : EvmWord :=
+  EvmWord.fromLimbs (fun i : Fin 4 =>
+    match i with
+    | 0 =>
+        (((fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.1 >>>
+            ((fullDivN3Shift b2).toNat % 64)) |||
+          ((fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 <<<
+            ((signExtend12 (0 : BitVec 12) - fullDivN3Shift b2).toNat % 64)))
+    | 1 =>
+        (((fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 >>>
+            ((fullDivN3Shift b2).toNat % 64)) |||
+          ((fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1 <<<
+            ((signExtend12 (0 : BitVec 12) - fullDivN3Shift b2).toNat % 64)))
+    | 2 =>
+        (((fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1 >>>
+            ((fullDivN3Shift b2).toNat % 64)) |||
+          ((fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1 <<<
+            ((signExtend12 (0 : BitVec 12) - fullDivN3Shift b2).toNat % 64)))
+    | 3 =>
+        ((fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1 >>>
+          ((fullDivN3Shift b2).toNat % 64)))
+
+/-- Project a packed v4 n=3 MOD remainder equality into limb equalities. -/
+theorem fullModN3V4_hmods_of_word_eq
+    (bltu_1 bltu_0 : Bool)
+    (a b : EvmWord) (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hmod : fullModN3RemainderWordV4 bltu_1 bltu_0
+      a0 a1 a2 a3 b0 b1 b2 b3 = EvmWord.mod a b) :
+    (EvmWord.mod a b).getLimbN 0 =
+      (((fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.1 >>>
+          ((fullDivN3Shift b2).toNat % 64)) |||
+        ((fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 <<<
+          ((signExtend12 (0 : BitVec 12) - fullDivN3Shift b2).toNat % 64))) ∧
+    (EvmWord.mod a b).getLimbN 1 =
+      (((fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 >>>
+          ((fullDivN3Shift b2).toNat % 64)) |||
+        ((fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1 <<<
+          ((signExtend12 (0 : BitVec 12) - fullDivN3Shift b2).toNat % 64))) ∧
+    (EvmWord.mod a b).getLimbN 2 =
+      (((fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1 >>>
+          ((fullDivN3Shift b2).toNat % 64)) |||
+        ((fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1 <<<
+          ((signExtend12 (0 : BitVec 12) - fullDivN3Shift b2).toNat % 64))) ∧
+    (EvmWord.mod a b).getLimbN 3 =
+      ((fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1 >>>
+        ((fullDivN3Shift b2).toNat % 64)) := by
+  refine ⟨?_, ?_, ?_, ?_⟩
+  · rw [← hmod]
+    delta fullModN3RemainderWordV4
+    exact EvmWord.getLimbN_fromLimbs_0
+  · rw [← hmod]
+    delta fullModN3RemainderWordV4
+    exact EvmWord.getLimbN_fromLimbs_1
+  · rw [← hmod]
+    delta fullModN3RemainderWordV4
+    exact EvmWord.getLimbN_fromLimbs_2
+  · rw [← hmod]
+    delta fullModN3RemainderWordV4
+    exact EvmWord.getLimbN_fromLimbs_3
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N3RemainderWordV4.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3RemainderWordV4.lean
@@ -566,6 +566,31 @@ theorem fullDivN3NormV_or_ne_zero_of_word_ne_zero_b3_zero
     (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
     ((EvmWord.ne_zero_iff_getLimbN_or).mp hbnz) hshift_nz hb3z
 
+theorem fullDivN3NormV_val256_pos_of_b_ne_zero_b3_zero
+    (b : EvmWord)
+    (hbnz : b ≠ 0)
+    (hshift_nz : fullDivN3Shift (b.getLimbN 2) ≠ 0)
+    (hb3z : b.getLimbN 3 = 0) :
+    0 < EvmWord.val256
+      (fullDivN3NormV
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1
+      (fullDivN3NormV
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.1
+      (fullDivN3NormV
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+      (fullDivN3NormV
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2 := by
+  have h_scaled := fullDivN3NormV_val256_eq_scaled_of_b3_zero
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+    hshift_nz hb3z
+  have hb_pos : 0 <
+      EvmWord.val256
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) :=
+    EvmWord.val256_pos_of_or_ne_zero
+      ((EvmWord.ne_zero_iff_getLimbN_or).mp hbnz)
+  rw [h_scaled]
+  positivity
+
 theorem iterN3V4CallQHat_val256_conservation_of_carry2
     (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
     (hbnz : v0 ||| v1 ||| v2 ||| v3 ≠ 0)

--- a/EvmAsm/Evm64/DivMod/Spec/N3RemainderWordV4.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3RemainderWordV4.lean
@@ -287,4 +287,42 @@ theorem fullModN3UnifiedPostNoX1V4_frame_to_modStackDispatchPostCallableExactFra
     (fun h hp => modConcretePostNoX1ExactRegs_weaken_callable_frame sp a b h hp)
     h hExact
 
+/-- Remainder-word form of
+    `fullModN3UnifiedPostNoX1V4_frame_to_modStackDispatchPostCallableExactFrame_scratch`. -/
+theorem fullModN3UnifiedPostNoX1V4_frame_to_modStackDispatchPostCallableExactFrame_scratch_word
+    (bltu_1 bltu_0 : Bool)
+    (sp base : Word) (a b : EvmWord)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (hmodWord : fullModN3RemainderWordV4 bltu_1 bltu_0
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) =
+        EvmWord.mod a b) :
+    ∀ h,
+      (fullModN3UnifiedPostNoX1V4 bltu_1 bltu_0 sp base
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal)) h →
+      (modStackDispatchPostCallableExactFrame sp a b raVal
+        (signExtend12 4095 : Word) **
+       ((sp + signExtend12 3936) ↦ₘ
+        fullDivN3ScratchMemV4 bltu_1 bltu_0
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+          scratchMem)) h := by
+  obtain ⟨hmod0, hmod1, hmod2, hmod3⟩ :=
+    fullModN3V4_hmods_of_word_eq bltu_1 bltu_0 a b
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+      hmodWord
+  intro h hp
+  rw [modStackDispatchPostCallableExactFrame_unfold]
+  exact fullModN3UnifiedPostNoX1V4_frame_to_modStackDispatchPostCallableExactFrame_scratch
+    bltu_1 bltu_0 sp base a b
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+    retMem dMem dloMem scratchUn0 scratchMem raVal
+    rfl rfl rfl rfl hmod0 hmod1 hmod2 hmod3 h hp
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N3RemainderWordV4.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3RemainderWordV4.lean
@@ -269,6 +269,55 @@ theorem fullModN3PathConditionsScaledV4_of_normalized_euclidean
   exact EvmWord.normalized_remainder_eq_mod_mul_pow
     ((fullDivN3Shift (b.getLimbN 2)).toNat) hmulsub hrlt
 
+theorem fullDivN3NormalizedRemainderLtV4_of_mulsub_path
+    (bltu_1 bltu_0 : Bool) (a b : EvmWord)
+    (hbnz : b ≠ 0)
+    (hdivPath : fullDivN3PathConditionsWordV4 bltu_1 bltu_0 a b)
+    (hmulsub : fullDivN3NormalizedMulSubEqV4 bltu_1 bltu_0 a b) :
+    fullDivN3NormalizedRemainderLtV4 bltu_1 bltu_0 a b := by
+  obtain ⟨_, _, _, _, hge⟩ := hdivPath
+  have hbnz' :
+      b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 ≠ 0 :=
+    (EvmWord.ne_zero_iff_getLimbN_or).mp hbnz
+  have hbVal : 0 <
+      EvmWord.val256
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) :=
+    EvmWord.val256_pos_of_or_ne_zero hbnz'
+  have hpow : 0 < 2 ^ (fullDivN3Shift (b.getLimbN 2)).toNat := by
+    positivity
+  have hbScaled : 0 <
+      EvmWord.val256
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) *
+        2 ^ (fullDivN3Shift (b.getLimbN 2)).toNat := by
+    positivity
+  have hgeScaled :
+      (EvmWord.val256
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3) *
+          2 ^ (fullDivN3Shift (b.getLimbN 2)).toNat) /
+        (EvmWord.val256
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) *
+          2 ^ (fullDivN3Shift (b.getLimbN 2)).toNat) ≤
+        ((fullDivN3R1V4 bltu_1
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1).toNat *
+          2 ^ 64 +
+        ((fullDivN3R0V4 bltu_1 bltu_0
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1).toNat := by
+    rw [Nat.mul_div_mul_right _ _ hpow]
+    exact hge
+  exact (EvmWord.remainder_lt_of_ge_floor hbScaled hmulsub hgeScaled).2
+
+theorem fullModN3PathConditionsNormalizedV4_of_mulsub
+    (bltu_1 bltu_0 : Bool) (a b : EvmWord)
+    (hbnz : b ≠ 0)
+    (hdivPath : fullDivN3PathConditionsWordV4 bltu_1 bltu_0 a b)
+    (hmulsub : fullDivN3NormalizedMulSubEqV4 bltu_1 bltu_0 a b) :
+    fullModN3PathConditionsNormalizedV4 bltu_1 bltu_0 a b :=
+  ⟨hdivPath, hmulsub,
+    fullDivN3NormalizedRemainderLtV4_of_mulsub_path
+      bltu_1 bltu_0 a b hbnz hdivPath hmulsub⟩
+
 theorem fullModN3PathConditionsScaledV4_of_normalized
     (bltu_1 bltu_0 : Bool) (a b : EvmWord)
     (hpath : fullModN3PathConditionsNormalizedV4 bltu_1 bltu_0 a b) :

--- a/EvmAsm/Evm64/DivMod/Spec/N3RemainderWordV4.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3RemainderWordV4.lean
@@ -271,6 +271,12 @@ abbrev fullDivN3FinalCarryZeroV4 (bltu_1 bltu_0 : Bool)
     (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
     (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2.2.2 = 0
 
+abbrev fullDivN3R1CarryZeroV4 (bltu_1 : Bool)
+    (a b : EvmWord) : Prop :=
+  (fullDivN3R1V4 bltu_1
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2.2.2 = 0
+
 theorem fullDivN3NormalizedMulSubEqV4_of_conservation
     (bltu_1 bltu_0 : Bool) (a b : EvmWord)
     (hcons : fullDivN3NormalizedConservationV4 bltu_1 bltu_0 a b)
@@ -502,6 +508,144 @@ theorem fullDivN3NormV_val256_eq_scaled_of_b3_zero
   dsimp only
   rw [fullDivN3Shift_toNat_mod_eq, hanti]
   exact EvmWord.val256_normalize hs0 hs b0 b1 b2 b3 hb3_bound
+
+theorem fullDivN3NormalizedConservationV4_of_scaled_iter_conservation
+    (bltu_1 bltu_0 : Bool) (a b : EvmWord)
+    (hshift_nz : fullDivN3Shift (b.getLimbN 2) ≠ 0)
+    (hcarry1 : fullDivN3R1CarryZeroV4 bltu_1 a b)
+    (hiter1 :
+      EvmWord.val256
+          (fullDivN3NormU
+            (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+            (b.getLimbN 2)).2.1
+          (fullDivN3NormU
+            (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+            (b.getLimbN 2)).2.2.1
+          (fullDivN3NormU
+            (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+            (b.getLimbN 2)).2.2.2.1
+          (fullDivN3NormU
+            (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+            (b.getLimbN 2)).2.2.2.2 =
+        ((fullDivN3R1V4 bltu_1
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1).toNat *
+          (EvmWord.val256
+            (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) *
+            2 ^ (fullDivN3Shift (b.getLimbN 2)).toNat) +
+        EvmWord.val256
+          (fullDivN3R1V4 bltu_1
+            (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+            (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.1
+          (fullDivN3R1V4 bltu_1
+            (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+            (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+          (fullDivN3R1V4 bltu_1
+            (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+            (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2.1
+          (fullDivN3R1V4 bltu_1
+            (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+            (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2.2.1 +
+        ((fullDivN3R1V4 bltu_1
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2.2.2).toNat *
+          2 ^ 256)
+    (hiter0 :
+      (fullDivN3NormU
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 2)).1.toNat +
+        2 ^ 64 *
+          EvmWord.val256
+            (fullDivN3R1V4 bltu_1
+              (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+              (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.1
+            (fullDivN3R1V4 bltu_1
+              (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+              (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+            (fullDivN3R1V4 bltu_1
+              (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+              (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2.1
+            (fullDivN3R1V4 bltu_1
+              (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+              (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2.2.1 =
+        ((fullDivN3R0V4 bltu_1 bltu_0
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1).toNat *
+          (EvmWord.val256
+            (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) *
+            2 ^ (fullDivN3Shift (b.getLimbN 2)).toNat) +
+        EvmWord.val256
+          (fullDivN3R0V4 bltu_1 bltu_0
+            (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+            (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.1
+          (fullDivN3R0V4 bltu_1 bltu_0
+            (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+            (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+          (fullDivN3R0V4 bltu_1 bltu_0
+            (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+            (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2.1
+          (fullDivN3R0V4 bltu_1 bltu_0
+            (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+            (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2.2.1 +
+        ((fullDivN3R0V4 bltu_1 bltu_0
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2.2.2).toNat *
+          2 ^ 256) :
+    fullDivN3NormalizedConservationV4 bltu_1 bltu_0 a b := by
+  have hnormU := fullDivN3NormU_val256_eq_scaled_with_overflow
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+    (b.getLimbN 2) hshift_nz
+  have hfirst :
+      EvmWord.val256
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3) *
+          2 ^ (fullDivN3Shift (b.getLimbN 2)).toNat =
+        (fullDivN3NormU
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 2)).1.toNat +
+          2 ^ 64 *
+            EvmWord.val256
+              (fullDivN3NormU
+                (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+                (b.getLimbN 2)).2.1
+              (fullDivN3NormU
+                (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+                (b.getLimbN 2)).2.2.1
+              (fullDivN3NormU
+                (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+                (b.getLimbN 2)).2.2.2.1
+              (fullDivN3NormU
+                (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+                (b.getLimbN 2)).2.2.2.2 := by
+    rw [← hnormU]
+    exact val256_with_overflow_eq_low_add_tail
+      (fullDivN3NormU
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 2)).1
+      (fullDivN3NormU
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 2)).2.1
+      (fullDivN3NormU
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 2)).2.2.1
+      (fullDivN3NormU
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 2)).2.2.2.1
+      (fullDivN3NormU
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 2)).2.2.2.2
+  have hc1 :
+      ((fullDivN3R1V4 bltu_1
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2.2.2).toNat = 0 := by
+    unfold fullDivN3R1CarryZeroV4 at hcarry1
+    rw [hcarry1]
+    rfl
+  unfold fullDivN3NormalizedConservationV4
+  exact n3_two_step_conservation_of_iter_nat
+    ((fullDivN3NormU
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 2)).1.toNat)
+    hfirst hiter1 hc1 hiter0
 
 theorem fullDivN3FinalCarryZeroV4_of_conservation_path
     (bltu_1 bltu_0 : Bool) (a b : EvmWord)

--- a/EvmAsm/Evm64/DivMod/Spec/N3RemainderWordV4.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3RemainderWordV4.lean
@@ -509,6 +509,48 @@ theorem fullDivN3NormV_val256_eq_scaled_of_b3_zero
   rw [fullDivN3Shift_toNat_mod_eq, hanti]
   exact EvmWord.val256_normalize hs0 hs b0 b1 b2 b3 hb3_bound
 
+theorem iterN3V4CallQHat_val256_conservation_of_carry2
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+    (hbnz : v0 ||| v1 ||| v2 ||| v3 ≠ 0)
+    (hc3_call :
+      BitVec.ult uTop
+          (mulsubN4 (divKTrialCallV4QHat u3 u2 v2)
+            v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2 →
+        (mulsubN4 (divKTrialCallV4QHat u3 u2 v2)
+          v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2 = 1)
+    (hcarry2 : Carry2NzAll v0 v1 v2 v3) :
+    let out := iterWithDoubleAddback (divKTrialCallV4QHat u3 u2 v2)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    EvmWord.val256 u0 u1 u2 u3 + uTop.toNat * 2 ^ 256 =
+      out.1.toNat * EvmWord.val256 v0 v1 v2 v3 +
+        EvmWord.val256 out.2.1 out.2.2.1 out.2.2.2.1 out.2.2.2.2.1 +
+        out.2.2.2.2.2.toNat * 2 ^ 256 := by
+  exact iterWithDoubleAddback_val256_conservation_of_carry2
+    (divKTrialCallV4QHat u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    hbnz hc3_call
+    (hcarry2 (divKTrialCallV4QHat u3 u2 v2) u0 u1 u2 u3 uTop)
+
+theorem iterN3V4MaxQHat_val256_conservation_of_carry2
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+    (hbnz : v0 ||| v1 ||| v2 ||| v3 ≠ 0)
+    (hc3_max :
+      BitVec.ult uTop
+          (mulsubN4 (signExtend12 4095 : Word)
+            v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2 →
+        (mulsubN4 (signExtend12 4095 : Word)
+          v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2 = 1)
+    (hcarry2 : Carry2NzAll v0 v1 v2 v3) :
+    let out := iterWithDoubleAddback (signExtend12 4095 : Word)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    EvmWord.val256 u0 u1 u2 u3 + uTop.toNat * 2 ^ 256 =
+      out.1.toNat * EvmWord.val256 v0 v1 v2 v3 +
+        EvmWord.val256 out.2.1 out.2.2.1 out.2.2.2.1 out.2.2.2.2.1 +
+        out.2.2.2.2.2.toNat * 2 ^ 256 := by
+  exact iterWithDoubleAddback_val256_conservation_of_carry2
+    (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    hbnz hc3_max
+    (hcarry2 (signExtend12 4095 : Word) u0 u1 u2 u3 uTop)
+
 theorem fullDivN3NormalizedConservationV4_of_scaled_iter_conservation
     (bltu_1 bltu_0 : Bool) (a b : EvmWord)
     (hshift_nz : fullDivN3Shift (b.getLimbN 2) ≠ 0)

--- a/EvmAsm/Evm64/DivMod/Spec/N3RemainderWordV4.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3RemainderWordV4.lean
@@ -435,6 +435,46 @@ theorem fullDivN3AntiShift_toNat_mod_eq_of_shift_ne {b2 : Word}
   have h63 := fullDivN3Shift_toNat_le_63 b2
   exact antiShift_toNat_mod_eq h1 h63
 
+theorem fullDivN3NormU_val256_eq_scaled_with_overflow
+    (a0 a1 a2 a3 b2 : Word)
+    (hshift_nz : fullDivN3Shift b2 ≠ 0) :
+    EvmWord.val256
+        (fullDivN3NormU a0 a1 a2 a3 b2).1
+        (fullDivN3NormU a0 a1 a2 a3 b2).2.1
+        (fullDivN3NormU a0 a1 a2 a3 b2).2.2.1
+        (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.1 +
+      (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.2.toNat * 2 ^ 256 =
+  EvmWord.val256 a0 a1 a2 a3 * 2 ^ (fullDivN3Shift b2).toNat := by
+  delta fullDivN3NormU fullDivN3Shift fullDivN3AntiShift at hshift_nz ⊢
+  exact u_val256_eq_scaled_with_overflow a0 a1 a2 a3 b2 hshift_nz
+
+theorem fullDivN3NormV_val256_eq_scaled_of_b3_zero
+    (b0 b1 b2 b3 : Word)
+    (hshift_nz : fullDivN3Shift b2 ≠ 0)
+    (hb3z : b3 = 0) :
+    EvmWord.val256
+        (fullDivN3NormV b0 b1 b2 b3).1
+        (fullDivN3NormV b0 b1 b2 b3).2.1
+        (fullDivN3NormV b0 b1 b2 b3).2.2.1
+        (fullDivN3NormV b0 b1 b2 b3).2.2.2 =
+    EvmWord.val256 b0 b1 b2 b3 * 2 ^ (fullDivN3Shift b2).toNat := by
+  have hs0 := fullDivN3Shift_toNat_pos_of_ne hshift_nz
+  have hs : (fullDivN3Shift b2).toNat < 64 := by
+    have h_le := fullDivN3Shift_toNat_le_63 b2
+    omega
+  have hb3_bound : b3.toNat < 2 ^ (64 - (fullDivN3Shift b2).toNat) := by
+    rw [hb3z]
+    simp
+  have hanti :
+      (fullDivN3AntiShift b2).toNat % 64 =
+        64 - (fullDivN3Shift b2).toNat := by
+    unfold fullDivN3AntiShift
+    exact fullDivN3AntiShift_toNat_mod_eq_of_shift_ne hshift_nz
+  rw [fullDivN3NormV_unfold]
+  dsimp only
+  rw [fullDivN3Shift_toNat_mod_eq, hanti]
+  exact EvmWord.val256_normalize hs0 hs b0 b1 b2 b3 hb3_bound
+
 theorem fullDivN3FinalCarryZeroV4_of_conservation_path
     (bltu_1 bltu_0 : Bool) (a b : EvmWord)
     (hbnz : b ≠ 0)

--- a/EvmAsm/Evm64/DivMod/Spec/N3RemainderWordV4.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3RemainderWordV4.lean
@@ -170,6 +170,31 @@ abbrev fullModN3PathConditionsVal256V4 (bltu_1 bltu_0 : Bool)
       EvmWord.val256
         (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
 
+/-- MOD-specific N3 v4 path predicate at the normalized-remainder level.
+This is the shape expected from the remaining loop arithmetic proof: the
+normalized final remainder is the true EVM remainder scaled by `2^shift`. -/
+abbrev fullModN3PathConditionsScaledV4 (bltu_1 bltu_0 : Bool)
+    (a b : EvmWord) : Prop :=
+  fullDivN3PathConditionsWordV4 bltu_1 bltu_0 a b ∧
+  EvmWord.val256
+    (fullDivN3R0V4 bltu_1 bltu_0
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.1
+    (fullDivN3R0V4 bltu_1 bltu_0
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+    (fullDivN3R0V4 bltu_1 bltu_0
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2.1
+    (fullDivN3R0V4 bltu_1 bltu_0
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2.2.1 =
+    EvmWord.val256
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3) %
+      EvmWord.val256
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) *
+      2 ^ (fullDivN3Shift (b.getLimbN 2)).toNat
+
 theorem fullModN3PathConditionsWordV4_of_val256
     (bltu_1 bltu_0 : Bool) (a b : EvmWord)
     (hbnz : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 ≠ 0)
@@ -300,6 +325,16 @@ theorem fullModN3RemainderVal256V4_eq_mod_of_scaled_remainder_shift_ne
     (fullDivN3Shift_toNat_mod_eq (b.getLimbN 2))
     (fullDivN3AntiShift_toNat_mod_eq_of_shift_ne hshift_nz)
     hscaled
+
+theorem fullModN3PathConditionsVal256V4_of_scaled
+    (bltu_1 bltu_0 : Bool) (a b : EvmWord)
+    (hshift_nz : fullDivN3Shift (b.getLimbN 2) ≠ 0)
+    (hpath : fullModN3PathConditionsScaledV4 bltu_1 bltu_0 a b) :
+    fullModN3PathConditionsVal256V4 bltu_1 bltu_0 a b := by
+  obtain ⟨hdivPath, hscaled⟩ := hpath
+  exact ⟨hdivPath,
+    fullModN3RemainderVal256V4_eq_mod_of_scaled_remainder_shift_ne
+      bltu_1 bltu_0 a b hshift_nz hscaled⟩
 
 theorem fullModN3RemainderWordV4_eq_mod_of_mod_path_conditions
     (bltu_1 bltu_0 : Bool) (a b : EvmWord)

--- a/EvmAsm/Evm64/DivMod/Spec/N3RemainderWordV4.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3RemainderWordV4.lean
@@ -6,10 +6,12 @@
 
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V4
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN3LoopUnified
+import EvmAsm.Evm64.DivMod.Spec.CallablePost
 
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (word_add_zero)
 
 /-- v4 n=3 MOD remainder word, using the v4 call-path `fullDivN3R0V4`
 computation before the usual denormalization shift. -/
@@ -100,5 +102,189 @@ theorem fullModN3V4_hmods_of_word_eq
   · rw [← hmod]
     delta fullModN3RemainderWordV4
     exact EvmWord.getLimbN_fromLimbs_3
+
+/-- Convert the n=3 MOD v4 final post plus exact caller `x1` to the
+    exact-register concrete MOD callable surface, preserving the v4 trial-call
+    scratch cell that is not part of the public callable post. -/
+theorem fullModN3UnifiedPostNoX1V4_frame_to_modConcretePostNoX1ExactRegsFrame_scratch
+    (bltu_1 bltu_0 : Bool)
+    (sp base : Word) (a b : EvmWord)
+    (a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (ha0 : a.getLimbN 0 = a0) (ha1 : a.getLimbN 1 = a1)
+    (ha2 : a.getLimbN 2 = a2) (ha3 : a.getLimbN 3 = a3)
+    (hmod0 : (EvmWord.mod a b).getLimbN 0 =
+      (((fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.1 >>>
+          ((fullDivN3Shift b2).toNat % 64)) |||
+        ((fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 <<<
+          ((signExtend12 (0 : BitVec 12) - fullDivN3Shift b2).toNat % 64))))
+    (hmod1 : (EvmWord.mod a b).getLimbN 1 =
+      (((fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 >>>
+          ((fullDivN3Shift b2).toNat % 64)) |||
+        ((fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1 <<<
+          ((signExtend12 (0 : BitVec 12) - fullDivN3Shift b2).toNat % 64))))
+    (hmod2 : (EvmWord.mod a b).getLimbN 2 =
+      (((fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1 >>>
+          ((fullDivN3Shift b2).toNat % 64)) |||
+        ((fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1 <<<
+          ((signExtend12 (0 : BitVec 12) - fullDivN3Shift b2).toNat % 64))))
+    (hmod3 : (EvmWord.mod a b).getLimbN 3 =
+      ((fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1 >>>
+        ((fullDivN3Shift b2).toNat % 64))) :
+    ∀ h,
+      (fullModN3UnifiedPostNoX1V4 bltu_1 bltu_0 sp base
+        a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal)) h →
+      (modConcretePostNoX1ExactRegsFrame sp a b
+        (signExtend12 4095) raVal
+        (signExtend12 (0 : BitVec 12) - fullDivN3Shift b2)
+        (((fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.1 >>>
+            ((fullDivN3Shift b2).toNat % 64)) |||
+          ((fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 <<<
+            ((signExtend12 (0 : BitVec 12) - fullDivN3Shift b2).toNat % 64)))
+        (((fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 >>>
+            ((fullDivN3Shift b2).toNat % 64)) |||
+          ((fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1 <<<
+            ((signExtend12 (0 : BitVec 12) - fullDivN3Shift b2).toNat % 64)))
+        (((fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1 >>>
+            ((fullDivN3Shift b2).toNat % 64)) |||
+          ((fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1 <<<
+            ((signExtend12 (0 : BitVec 12) - fullDivN3Shift b2).toNat % 64)))
+        ((fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1 >>>
+          ((fullDivN3Shift b2).toNat % 64))
+        (fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).1
+        (fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).1
+        (fullDivN3R1V4 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1
+        (0 : Word)
+        (0 : Word)
+        (((fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.1 >>>
+            ((fullDivN3Shift b2).toNat % 64)) |||
+          ((fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 <<<
+            ((signExtend12 (0 : BitVec 12) - fullDivN3Shift b2).toNat % 64)))
+        (((fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 >>>
+            ((fullDivN3Shift b2).toNat % 64)) |||
+          ((fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1 <<<
+            ((signExtend12 (0 : BitVec 12) - fullDivN3Shift b2).toNat % 64)))
+        (((fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1 >>>
+            ((fullDivN3Shift b2).toNat % 64)) |||
+          ((fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1 <<<
+            ((signExtend12 (0 : BitVec 12) - fullDivN3Shift b2).toNat % 64)))
+        ((fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1 >>>
+          ((fullDivN3Shift b2).toNat % 64))
+        (fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.2
+        (fullDivN3R1V4 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.2
+        (0 : Word)
+        (0 : Word)
+        (fullDivN3Shift b2) (3 : Word) (0 : Word)
+        (if bltu_0 then (base + div128CallRetOff)
+          else if bltu_1 then (base + div128CallRetOff) else retMem)
+        (if bltu_0 then (fullDivN3NormV b0 b1 b2 b3).2.2.1
+          else if bltu_1 then (fullDivN3NormV b0 b1 b2 b3).2.2.1 else dMem)
+        (if bltu_0 then divKTrialCallV4DLo (fullDivN3NormV b0 b1 b2 b3).2.2.1
+          else if bltu_1 then divKTrialCallV4DLo
+            (fullDivN3NormV b0 b1 b2 b3).2.2.1 else dloMem)
+        (if bltu_0 then divKTrialCallV4Un0
+            (fullDivN3R1V4 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1
+          else if bltu_1 then divKTrialCallV4Un0
+            (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.1
+          else scratchUn0) **
+       ((sp + signExtend12 3936) ↦ₘ
+        fullDivN3ScratchMemV4 bltu_1 bltu_0
+          a0 a1 a2 a3 b0 b1 b2 b3 scratchMem)) h := by
+  intro h hq
+  let shift := fullDivN3Shift b2
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let r1 := fullDivN3R1V4 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+  let r0 := fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+  let v := fullDivN3NormV b0 b1 b2 b3
+  let u := fullDivN3NormU a0 a1 a2 a3 b2
+  let scratchRet := if bltu_0 then (base + div128CallRetOff)
+    else if bltu_1 then (base + div128CallRetOff) else retMem
+  let scratchD := if bltu_0 then v.2.2.1
+    else if bltu_1 then v.2.2.1 else dMem
+  let scratchDLo := if bltu_0 then divKTrialCallV4DLo v.2.2.1
+    else if bltu_1 then divKTrialCallV4DLo v.2.2.1 else dloMem
+  let scratchUn0' := if bltu_0 then divKTrialCallV4Un0 r1.2.2.1
+    else if bltu_1 then divKTrialCallV4Un0 u.2.2.2.1 else scratchUn0
+  let u0' := (r0.2.1 >>> (shift.toNat % 64)) ||| (r0.2.2.1 <<< (antiShift.toNat % 64))
+  let u1' := (r0.2.2.1 >>> (shift.toNat % 64)) ||| (r0.2.2.2.1 <<< (antiShift.toNat % 64))
+  let u2' := (r0.2.2.2.1 >>> (shift.toNat % 64)) ||| (r0.2.2.2.2.1 <<< (antiShift.toNat % 64))
+  let u3' := r0.2.2.2.2.1 >>> (shift.toNat % 64)
+  rw [modConcretePostNoX1ExactRegsFrame_unfold]
+  change
+    ((((.x12 ↦ᵣ (sp + 32)) ** (.x5 ↦ᵣ u0') ** (.x10 ↦ᵣ u3') **
+      (.x0 ↦ᵣ (0 : Word)) ** evmWordIs (sp + 32) (EvmWord.mod a b)) **
+     ((.x9 ↦ᵣ (signExtend12 4095 : Word)) ** (.x1 ↦ᵣ raVal) **
+      (.x2 ↦ᵣ antiShift) ** (.x6 ↦ᵣ u1') ** (.x7 ↦ᵣ u2') **
+      (.x11 ↦ᵣ r0.1) ** evmWordIs sp a **
+      divScratchValuesCallNoX1 sp r0.1 r1.1 (0 : Word) (0 : Word)
+        u0' u1' u2' u3' r0.2.2.2.2.2 r1.2.2.2.2.2
+        (0 : Word) (0 : Word) shift (3 : Word) (0 : Word)
+        scratchRet scratchD scratchDLo scratchUn0')) **
+     ((sp + signExtend12 3936) ↦ₘ
+      fullDivN3ScratchMemV4 bltu_1 bltu_0
+        a0 a1 a2 a3 b0 b1 b2 b3 scratchMem)) h
+  delta fullModN3UnifiedPostNoX1V4 fullModN3DenormPostV4 fullDivN3FrameNoX1V4
+    fullDivN3ScratchNoX1V4 at hq
+  simp only [denormModPost_unfold] at hq
+  rw [show evmWordIs sp a =
+      ((sp ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3))
+      from by rw [evmWordIs_sp_limbs_eq sp a _ _ _ _ ha0 ha1 ha2 ha3]]
+  rw [show evmWordIs (sp + 32) (EvmWord.mod a b) =
+      (((sp + 32) ↦ₘ u0') ** ((sp + 40) ↦ₘ u1') **
+       ((sp + 48) ↦ₘ u2') ** ((sp + 56) ↦ₘ u3'))
+      from by
+        rw [evmWordIs_sp32_limbs_eq sp (EvmWord.mod a b) _ _ _ _
+          hmod0 hmod1 hmod2 hmod3]]
+  rw [divScratchValuesCallNoX1_unfold, divScratchValues_unfold]
+  rw [word_add_zero] at hq
+  xperm_hyp hq
+
+/-- Named callable-frame version of
+    `fullModN3UnifiedPostNoX1V4_frame_to_modConcretePostNoX1ExactRegsFrame_scratch`. -/
+theorem fullModN3UnifiedPostNoX1V4_frame_to_modStackDispatchPostCallableExactFrame_scratch
+    (bltu_1 bltu_0 : Bool)
+    (sp base : Word) (a b : EvmWord)
+    (a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (ha0 : a.getLimbN 0 = a0) (ha1 : a.getLimbN 1 = a1)
+    (ha2 : a.getLimbN 2 = a2) (ha3 : a.getLimbN 3 = a3)
+    (hmod0 : (EvmWord.mod a b).getLimbN 0 =
+      (((fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.1 >>>
+          ((fullDivN3Shift b2).toNat % 64)) |||
+        ((fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 <<<
+          ((signExtend12 (0 : BitVec 12) - fullDivN3Shift b2).toNat % 64))))
+    (hmod1 : (EvmWord.mod a b).getLimbN 1 =
+      (((fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 >>>
+          ((fullDivN3Shift b2).toNat % 64)) |||
+        ((fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1 <<<
+          ((signExtend12 (0 : BitVec 12) - fullDivN3Shift b2).toNat % 64))))
+    (hmod2 : (EvmWord.mod a b).getLimbN 2 =
+      (((fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1 >>>
+          ((fullDivN3Shift b2).toNat % 64)) |||
+        ((fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1 <<<
+          ((signExtend12 (0 : BitVec 12) - fullDivN3Shift b2).toNat % 64))))
+    (hmod3 : (EvmWord.mod a b).getLimbN 3 =
+      ((fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1 >>>
+        ((fullDivN3Shift b2).toNat % 64))) :
+    ∀ h,
+      (fullModN3UnifiedPostNoX1V4 bltu_1 bltu_0 sp base
+        a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal)) h →
+      (((modStackDispatchPostCallable sp a b ** (.x1 ↦ᵣ raVal)) **
+        (.x9 ↦ᵣ signExtend12 4095)) **
+       ((sp + signExtend12 3936) ↦ₘ
+        fullDivN3ScratchMemV4 bltu_1 bltu_0
+          a0 a1 a2 a3 b0 b1 b2 b3 scratchMem)) h := by
+  intro h hp
+  have hExact :=
+    fullModN3UnifiedPostNoX1V4_frame_to_modConcretePostNoX1ExactRegsFrame_scratch
+      bltu_1 bltu_0 sp base a b
+      a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 scratchMem
+      raVal ha0 ha1 ha2 ha3 hmod0 hmod1 hmod2 hmod3 h hp
+  exact sepConj_mono_left
+    (fun h hp => modConcretePostNoX1ExactRegs_weaken_callable_frame sp a b h hp)
+    h hExact
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N3RemainderWordV4.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3RemainderWordV4.lean
@@ -509,6 +509,46 @@ theorem fullDivN3NormV_val256_eq_scaled_of_b3_zero
   rw [fullDivN3Shift_toNat_mod_eq, hanti]
   exact EvmWord.val256_normalize hs0 hs b0 b1 b2 b3 hb3_bound
 
+private theorem limbs_or_ne_zero_of_val256_pos
+    {b0 b1 b2 b3 : Word}
+    (h_pos : 0 < EvmWord.val256 b0 b1 b2 b3) :
+    b0 ||| b1 ||| b2 ||| b3 ≠ 0 := by
+  intro h_or
+  have h3 := EvmWord.or_eq_zero_imp_right h_or
+  have h012 := EvmWord.or_eq_zero_imp_left h_or
+  have h2 := EvmWord.or_eq_zero_imp_right h012
+  have h01 := EvmWord.or_eq_zero_imp_left h012
+  have h1 := EvmWord.or_eq_zero_imp_right h01
+  have h0 := EvmWord.or_eq_zero_imp_left h01
+  unfold EvmWord.val256 at h_pos
+  rw [h0, h1, h2, h3] at h_pos
+  have hzero : (0 : Word).toNat = 0 := by rfl
+  rw [hzero] at h_pos
+  omega
+
+theorem fullDivN3NormV_or_ne_zero_of_b_ne_zero_b3_zero
+    (b0 b1 b2 b3 : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hshift_nz : fullDivN3Shift b2 ≠ 0)
+    (hb3z : b3 = 0) :
+    (fullDivN3NormV b0 b1 b2 b3).1 |||
+      (fullDivN3NormV b0 b1 b2 b3).2.1 |||
+      (fullDivN3NormV b0 b1 b2 b3).2.2.1 |||
+      (fullDivN3NormV b0 b1 b2 b3).2.2.2 ≠ 0 := by
+  have h_scaled := fullDivN3NormV_val256_eq_scaled_of_b3_zero
+    b0 b1 b2 b3 hshift_nz hb3z
+  have hb_pos : 0 < EvmWord.val256 b0 b1 b2 b3 :=
+    EvmWord.val256_pos_of_or_ne_zero hbnz
+  have hnorm_pos :
+      0 < EvmWord.val256
+        (fullDivN3NormV b0 b1 b2 b3).1
+        (fullDivN3NormV b0 b1 b2 b3).2.1
+        (fullDivN3NormV b0 b1 b2 b3).2.2.1
+        (fullDivN3NormV b0 b1 b2 b3).2.2.2 := by
+    rw [h_scaled]
+    positivity
+  exact limbs_or_ne_zero_of_val256_pos hnorm_pos
+
 theorem iterN3V4CallQHat_val256_conservation_of_carry2
     (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
     (hbnz : v0 ||| v1 ||| v2 ||| v3 ≠ 0)

--- a/EvmAsm/Evm64/DivMod/Spec/N3V4StackPre.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3V4StackPre.lean
@@ -10,6 +10,7 @@ import EvmAsm.Evm64.DivMod.Spec.N3QuotientWord
 import EvmAsm.Evm64.DivMod.Spec.N3QuotientStackBridge
 import EvmAsm.Evm64.DivMod.Spec.UnifiedBzero
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V4
+import EvmAsm.Evm64.DivMod.Compose.ModFullPathN3V4NoNop
 
 namespace EvmAsm.Evm64
 
@@ -148,6 +149,66 @@ theorem evm_div_n3_preloop_loop_stack_pre_spec_v4_noNop (sp base : Word)
       xperm_hyp hp)
     (fun _ hq => hq)
     hrawNoNop
+
+/-- EvmWord-level wrapper around the n=3 MOD v4/no-NOP path from dispatcher
+    entry to loop setup, preserving the callable `x1` and v4 scratch frame. -/
+theorem evm_mod_n3_to_loopSetup_stack_pre_spec_v4_noNop (sp base : Word)
+    (a b : EvmWord)
+    (v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (hbnz : b ≠ 0)
+    (hb3z : b.getLimbN 3 = 0) (hb2nz : b.getLimbN 2 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 2)).1 ≠ 0) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4)
+      base (base + loopBodyOff) (modCode_noNop_v4 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult (b.getLimbN 2)).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (loopSetupPost sp (3 : Word) (clzResult (b.getLimbN 2)).1
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) **
+       (.x11 ↦ᵣ v11Old) **
+       ((sp + signExtend12 3976) ↦ₘ jMem) **
+       ((sp + signExtend12 3968) ↦ₘ retMem) **
+       ((sp + signExtend12 3960) ↦ₘ dMem) **
+       ((sp + signExtend12 3952) ↦ₘ dloMem) **
+       ((sp + signExtend12 3944) ↦ₘ scratchUn0) **
+       (.x1 ↦ᵣ raVal) **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem)) := by
+  have hbnz' : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 ≠ 0 :=
+    (EvmWord.ne_zero_iff_getLimbN_or).mp hbnz
+  have hraw := evm_mod_n3_to_loopSetup_spec_within_v4_noNop sp base
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+    v5 v6 v7 v10
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem
+    hbnz' hb3z hb2nz hshift_nz
+  have hfr := cpsTripleWithin_frameR
+    ((.x11 ↦ᵣ v11Old) **
+     ((sp + signExtend12 3976) ↦ₘ jMem) **
+     ((sp + signExtend12 3968) ↦ₘ retMem) **
+     ((sp + signExtend12 3960) ↦ₘ dMem) **
+     ((sp + signExtend12 3952) ↦ₘ dloMem) **
+     ((sp + signExtend12 3944) ↦ₘ scratchUn0) **
+     (.x1 ↦ᵣ raVal) **
+     ((sp + signExtend12 3936) ↦ₘ scratchMem))
+    (by pcFree) hraw
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by
+      rw [divModStackDispatchPreNoX1_unfold, divScratchValuesCallNoX1_unfold] at hp
+      rw [evmWordIs_sp_limbs_eq sp a _ _ _ _ rfl rfl rfl rfl,
+          evmWordIs_sp32_limbs_eq sp b _ _ _ _ rfl rfl rfl rfl,
+          divScratchValues_unfold] at hp
+      rw [word_add_zero]
+      xperm_hyp hp)
+    (fun _ hq => hq)
+    hfr
 
 /-- Compose the n=3 v4 stack preloop+loop path through denormalization to the
     v4 final no-`x1` post, preserving the exact caller `x1`. -/

--- a/EvmAsm/Evm64/DivMod/Spec/N3V4StackPre.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3V4StackPre.lean
@@ -775,18 +775,18 @@ theorem evm_div_n3_stack_pre_to_callable_post_v4_scratch_word (sp base : Word)
           (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
           (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
           scratchMem)) := by
-  obtain ⟨hdiv0, hdiv1, hdiv2, hdiv3⟩ :=
-    fullDivN3V4_hdivs_of_word_eq bltu_1 bltu_0 a b
-      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
-      hdivWord
   exact cpsTripleWithin_divCode_noNop_v4_to_divCode_v4 <|
-    evm_div_n3_stack_pre_to_callable_post_v4_scratch_noNop
-      sp base a b v5 v6 v7 v10 v11Old
-      q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
-      nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
-      hbnz hb3z hb2nz hshift_nz halign hbltu_1 hbltu_0 hcarry2
-      hdiv0 hdiv1 hdiv2 hdiv3
+    cpsTripleWithin_weaken
+      (fun _ hp => hp)
+      (fun h hq =>
+        fullDivN3UnifiedPostNoX1V4_frame_to_divStackDispatchPostCallableExactFrame_scratch_word
+          bltu_1 bltu_0 sp base a b
+          retMem dMem dloMem scratchUn0 scratchMem raVal hdivWord h hq)
+      (evm_div_n3_stack_pre_to_unified_post_v4_noNop
+        sp base a b v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+        hbnz hb3z hb2nz hshift_nz halign hbltu_1 hbltu_0 hcarry2)
 
 /-- Arithmetic-assumption version of
     `evm_div_n3_stack_pre_to_callable_post_v4_scratch_word`. -/

--- a/EvmAsm/Evm64/DivMod/Spec/N3V4StackPre.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3V4StackPre.lean
@@ -765,9 +765,7 @@ theorem evm_div_n3_stack_pre_to_callable_post_v4_scratch_of_mulsub_overestimate
     (hshift_nz : (clzResult (b.getLimbN 2)).1 ≠ 0)
     (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
       base + div128CallRetOff)
-    (hpath : fullDivN3PathConditionsV4 bltu_1 bltu_0
-      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)) :
+    (hpath : fullDivN3PathConditionsWordV4 bltu_1 bltu_0 a b) :
     cpsTripleWithin ((8 + 21 + 24 + 4 + 21 + 21 + 4 + 448) + (2 + 23 + 10))
       base (base + nopOff) (divCode_v4 base)
       (divModStackDispatchPreNoX1 sp a b
@@ -789,13 +787,8 @@ theorem evm_div_n3_stack_pre_to_callable_post_v4_scratch_of_mulsub_overestimate
   have hbnz' : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 ≠ 0 :=
     (EvmWord.ne_zero_iff_getLimbN_or).mp hbnz
   have hdivWord :=
-    fullDivN3QuotientWordV4_eq_div_of_path_conditions
-      bltu_1 bltu_0 (a := a) (b := b)
-      (a0 := a.getLimbN 0) (a1 := a.getLimbN 1)
-      (a2 := a.getLimbN 2) (a3 := a.getLimbN 3)
-      (b0 := b.getLimbN 0) (b1 := b.getLimbN 1)
-      (b2 := b.getLimbN 2) (b3 := b.getLimbN 3)
-      rfl rfl rfl rfl rfl rfl rfl rfl hbnz' hpath
+    fullDivN3QuotientWordV4_eq_div_of_word_path_conditions
+      bltu_1 bltu_0 a b hbnz' hpath
   exact evm_div_n3_stack_pre_to_callable_post_v4_scratch_word
     sp base a b v5 v6 v7 v10 v11Old
     q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7

--- a/EvmAsm/Evm64/DivMod/Spec/N3V4StackPre.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3V4StackPre.lean
@@ -8,6 +8,7 @@ import EvmAsm.Evm64.DivMod.Spec.Dispatcher
 import EvmAsm.Evm64.DivMod.Spec.CallablePost
 import EvmAsm.Evm64.DivMod.Spec.N3QuotientWord
 import EvmAsm.Evm64.DivMod.Spec.N3QuotientStackBridge
+import EvmAsm.Evm64.DivMod.Spec.UnifiedBzero
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V4
 
 namespace EvmAsm.Evm64
@@ -798,5 +799,15 @@ theorem evm_div_n3_stack_pre_to_callable_post_v4_scratch_of_mulsub_overestimate
     q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
     hbnz hb3z hb2nz hshift_nz halign hbltu_1 hbltu_0 hcarry2 hdivWord
+
+/-- Lift the N3 v4 stack-pre/callable-post path to the shared
+    `unifiedDivBound` used by dispatcher-facing stack specs. -/
+theorem evm_div_n3_stack_pre_to_callable_post_v4_scratch_bound_unified
+    {P Q : Assertion} (base : Word)
+    (h :
+      cpsTripleWithin ((8 + 21 + 24 + 4 + 21 + 21 + 4 + 448) + (2 + 23 + 10))
+        base (base + nopOff) (divCode_v4 base) P Q) :
+    cpsTripleWithin unifiedDivBound base (base + nopOff) (divCode_v4 base) P Q := by
+  exact cpsTripleWithin_mono_nSteps (by unfold unifiedDivBound; decide) h
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N3V4StackPre.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3V4StackPre.lean
@@ -10,7 +10,8 @@ import EvmAsm.Evm64.DivMod.Spec.N3QuotientWord
 import EvmAsm.Evm64.DivMod.Spec.N3QuotientStackBridge
 import EvmAsm.Evm64.DivMod.Spec.UnifiedBzero
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V4
-import EvmAsm.Evm64.DivMod.Compose.ModFullPathN3V4NoNop
+import EvmAsm.Evm64.DivMod.Compose.ModFullPathN3V4NoNopPreloop
+import EvmAsm.Evm64.DivMod.Spec.N3RemainderWordV4
 
 namespace EvmAsm.Evm64
 
@@ -176,11 +177,11 @@ theorem evm_mod_n3_to_loopSetup_stack_pre_spec_v4_noNop (sp base : Word)
        (.x11 ↦ᵣ v11Old) **
        ((sp + signExtend12 3976) ↦ₘ jMem) **
        ((sp + signExtend12 3968) ↦ₘ retMem) **
-       ((sp + signExtend12 3960) ↦ₘ dMem) **
-       ((sp + signExtend12 3952) ↦ₘ dloMem) **
-       ((sp + signExtend12 3944) ↦ₘ scratchUn0) **
-       (.x1 ↦ᵣ raVal) **
-       ((sp + signExtend12 3936) ↦ₘ scratchMem)) := by
+         ((sp + signExtend12 3960) ↦ₘ dMem) **
+         ((sp + signExtend12 3952) ↦ₘ dloMem) **
+         ((sp + signExtend12 3944) ↦ₘ scratchUn0) **
+         ((sp + signExtend12 3936) ↦ₘ scratchMem) **
+         (.x1 ↦ᵣ raVal)) := by
   have hbnz' : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 ≠ 0 :=
     (EvmWord.ne_zero_iff_getLimbN_or).mp hbnz
   have hraw := evm_mod_n3_to_loopSetup_spec_within_v4_noNop sp base
@@ -189,16 +190,6 @@ theorem evm_mod_n3_to_loopSetup_stack_pre_spec_v4_noNop (sp base : Word)
     v5 v6 v7 v10
     q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem
     hbnz' hb3z hb2nz hshift_nz
-  have hfr := cpsTripleWithin_frameR
-    ((.x11 ↦ᵣ v11Old) **
-     ((sp + signExtend12 3976) ↦ₘ jMem) **
-     ((sp + signExtend12 3968) ↦ₘ retMem) **
-     ((sp + signExtend12 3960) ↦ₘ dMem) **
-     ((sp + signExtend12 3952) ↦ₘ dloMem) **
-     ((sp + signExtend12 3944) ↦ₘ scratchUn0) **
-     (.x1 ↦ᵣ raVal) **
-     ((sp + signExtend12 3936) ↦ₘ scratchMem))
-    (by pcFree) hraw
   exact cpsTripleWithin_weaken
     (fun _ hp => by
       rw [divModStackDispatchPreNoX1_unfold, divScratchValuesCallNoX1_unfold] at hp
@@ -207,8 +198,298 @@ theorem evm_mod_n3_to_loopSetup_stack_pre_spec_v4_noNop (sp base : Word)
           divScratchValues_unfold] at hp
       rw [word_add_zero]
       xperm_hyp hp)
-    (fun _ hq => hq)
-    hfr
+    (fun _ hq => by xperm_hyp hq)
+    (cpsTripleWithin_frameR
+      ((.x11 ↦ᵣ v11Old) **
+       ((sp + signExtend12 3976) ↦ₘ jMem) **
+       ((sp + signExtend12 3968) ↦ₘ retMem) **
+         ((sp + signExtend12 3960) ↦ₘ dMem) **
+         ((sp + signExtend12 3952) ↦ₘ dloMem) **
+         ((sp + signExtend12 3944) ↦ₘ scratchUn0) **
+         ((sp + signExtend12 3936) ↦ₘ scratchMem) **
+         (.x1 ↦ᵣ raVal))
+      (by pcFree)
+      hraw)
+
+/-- EvmWord-level wrapper around the n=3 MOD v4/no-NOP path from dispatcher
+    entry through the unified loop, preserving the callable `x1` and v4
+    scratch frame. -/
+theorem evm_mod_n3_preloop_loop_stack_pre_spec_v4_noNop (sp base : Word)
+    (a b : EvmWord)
+    (v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (hbnz : b ≠ 0)
+    (hb3z : b.getLimbN 3 = 0) (hb2nz : b.getLimbN 2 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 2)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_1 : bltu_1 =
+      BitVec.ult (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+        (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).2.2.1)
+    (hbltu_0 : bltu_0 =
+      match bltu_1, hbltu_1 with
+      | false, _ =>
+        BitVec.ult
+          (iterN3Max
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+            (0 : Word)).2.2.2.1
+          (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+            (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+      | true, _ =>
+        BitVec.ult
+          (iterWithDoubleAddback
+            (divKTrialCallV4QHat
+              (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+                (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+              (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+                (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.1
+              (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+                (b.getLimbN 2) (b.getLimbN 3)).2.2.1)
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+            (0 : Word)).2.2.2.1
+          (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+            (b.getLimbN 2) (b.getLimbN 3)).2.2.1)
+    (hcarry2 : Carry2NzAll
+      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1
+      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.1
+      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 448)
+      base (base + denormOff) (modCode_noNop_v4 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult (b.getLimbN 2)).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      ((loopN3UnifiedPostV4NoX1 bltu_1 bltu_0 sp base
+        (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1
+        (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.1
+        (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+        (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+        (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 2)).2.1
+        (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 2)).2.2.1
+        (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 2)).2.2.2.1
+        (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 2)).2.2.2.2
+        (0 : Word)
+        (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 2)).1
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal)) **
+       (((sp + 0) ↦ₘ a.getLimbN 0) ** ((sp + 8) ↦ₘ a.getLimbN 1) **
+        ((sp + 16) ↦ₘ a.getLimbN 2) ** ((sp + 24) ↦ₘ a.getLimbN 3) **
+        ((sp + signExtend12 4072) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 3992) ↦ₘ (clzResult (b.getLimbN 2)).1))) := by
+  have hSetup := evm_mod_n3_to_loopSetup_stack_pre_spec_v4_noNop
+    sp base a b v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+    hbnz hb3z hb2nz hshift_nz
+  have hLoop := evm_mod_n3_loop_unified_inst_noNop_exact_x1_v4
+    bltu_1 bltu_0 sp base
+    (fullDivN3Shift (b.getLimbN 2)) (fullDivN3AntiShift (b.getLimbN 2))
+    (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1
+    (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.1
+    (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+    (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+    (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 2)).1
+    (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 2)).2.1
+    (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 2)).2.2.1
+    (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 2)).2.2.2.1
+    (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 2)).2.2.2.2
+    (a.getLimbN 0 >>> ((fullDivN3AntiShift (b.getLimbN 2)).toNat % 64))
+    v11Old jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+    halign hbltu_1 (by cases bltu_1 <;> simpa using hbltu_0) hcarry2
+  have hLoopF := cpsTripleWithin_frameR
+    ((((sp + 0) ↦ₘ a.getLimbN 0) ** ((sp + 8) ↦ₘ a.getLimbN 1) **
+      ((sp + 16) ↦ₘ a.getLimbN 2) ** ((sp + 24) ↦ₘ a.getLimbN 3) **
+      ((sp + signExtend12 4072) ↦ₘ (0 : Word)) **
+      ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+      ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+      ((sp + signExtend12 3992) ↦ₘ (clzResult (b.getLimbN 2)).1)))
+    (by pcFree) hLoop
+  exact cpsTripleWithin_seq_perm_same_cr
+    (loopSetupPost_to_loopN3PreWithScratchV4NoX1_framed sp
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+      v11Old jMem retMem dMem dloMem scratchUn0 scratchMem raVal)
+    hSetup hLoopF
+
+/-- Compose the n=3 MOD v4 stack precondition through the v4 no-NOP path to the
+    v4 final no-`x1` MOD post, preserving the exact caller `x1`. -/
+theorem evm_mod_n3_stack_pre_to_unified_post_v4_noNop (sp base : Word)
+    (a b : EvmWord)
+    (v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (hbnz : b ≠ 0)
+    (hb3z : b.getLimbN 3 = 0) (hb2nz : b.getLimbN 2 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 2)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_1 : bltu_1 =
+      BitVec.ult (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+        (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).2.2.1)
+    (hbltu_0 : bltu_0 =
+      match bltu_1, hbltu_1 with
+      | false, _ =>
+        BitVec.ult
+          (iterN3Max
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+            (0 : Word)).2.2.2.1
+          (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+            (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+      | true, _ =>
+        BitVec.ult
+          (iterWithDoubleAddback
+            (divKTrialCallV4QHat
+              (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+                (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+              (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+                (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.1
+              (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+                (b.getLimbN 2) (b.getLimbN 3)).2.2.1)
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+            (0 : Word)).2.2.2.1
+          (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+            (b.getLimbN 2) (b.getLimbN 3)).2.2.1)
+    (hcarry2 : Carry2NzAll
+      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1
+      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.1
+      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2) :
+    cpsTripleWithin ((8 + 21 + 24 + 4 + 21 + 21 + 4 + 448) + (2 + 23 + 10))
+      base (base + nopOff) (modCode_noNop_v4 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult (b.getLimbN 2)).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (fullModN3UnifiedPostNoX1V4 bltu_1 bltu_0 sp base
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+        retMem dMem dloMem scratchUn0 scratchMem **
+       (.x1 ↦ᵣ raVal)) := by
+  have hA := evm_mod_n3_preloop_loop_stack_pre_spec_v4_noNop
+    sp base a b v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+    hbnz hb3z hb2nz hshift_nz halign hbltu_1 hbltu_0 hcarry2
+  have hshift_nz' : fullDivN3Shift (b.getLimbN 2) ≠ 0 := by
+    rw [fullDivN3Shift_unfold]
+    exact hshift_nz
+  have hB := evm_mod_n3_denorm_epilogue_bundled_spec_v4_noNop_v4Final_exact_x1_scratch_frame
+    bltu_1 bltu_0 sp base
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+    retMem dMem dloMem scratchUn0 scratchMem raVal hshift_nz'
+  have hFull := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by
+      cases bltu_1 <;> cases bltu_0
+      · exact loopN3UnifiedPostV4NoX1_to_fullDivN3DenormPreV4_frame_FF
+          sp base (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+          retMem dMem dloMem scratchUn0 scratchMem raVal h hp
+      · exact loopN3UnifiedPostV4NoX1_to_fullDivN3DenormPreV4_frame_FT
+          sp base (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+          retMem dMem dloMem scratchUn0 scratchMem raVal h hp
+      · exact loopN3UnifiedPostV4NoX1_to_fullDivN3DenormPreV4_frame_TF
+          sp base (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+          retMem dMem dloMem scratchUn0 scratchMem raVal h hp
+      · exact loopN3UnifiedPostV4NoX1_to_fullDivN3DenormPreV4_frame_TT
+          sp base (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+          retMem dMem dloMem scratchUn0 scratchMem raVal h hp)
+    hA hB
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => hp)
+    (fun h hq => hq)
+    hFull
 
 /-- Compose the n=3 v4 stack preloop+loop path through denormalization to the
     v4 final no-`x1` post, preserving the exact caller `x1`. -/

--- a/EvmAsm/Evm64/DivMod/Spec/N3V4StackPre.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3V4StackPre.lean
@@ -528,6 +528,42 @@ theorem fullDivN3UnifiedPostNoX1V4_frame_to_divStackDispatchPostCallableExactFra
     (fun h hp => divConcretePostNoX1ExactRegs_weaken_callable_frame sp a b h hp)
     h hExact
 
+/-- Word-quotient form of
+    `fullDivN3UnifiedPostNoX1V4_frame_to_divStackDispatchPostCallableExactFrame_scratch`. -/
+theorem fullDivN3UnifiedPostNoX1V4_frame_to_divStackDispatchPostCallableExactFrame_scratch_word
+    (bltu_1 bltu_0 : Bool)
+    (sp base : Word) (a b : EvmWord)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (hdivWord : fullDivN3QuotientWordV4 bltu_1 bltu_0
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) =
+        EvmWord.div a b) :
+    ∀ h,
+      (fullDivN3UnifiedPostNoX1V4 bltu_1 bltu_0 sp base
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal)) h →
+      (divStackDispatchPostCallableExactFrame sp a b raVal
+        (signExtend12 4095 : Word) **
+       ((sp + signExtend12 3936) ↦ₘ
+        fullDivN3ScratchMemV4 bltu_1 bltu_0
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+          scratchMem)) h := by
+  obtain ⟨hdiv0, hdiv1, hdiv2, hdiv3⟩ :=
+    fullDivN3V4_hdivs_of_word_eq bltu_1 bltu_0 a b
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+      hdivWord
+  exact fullDivN3UnifiedPostNoX1V4_frame_to_divStackDispatchPostCallableExactFrame_scratch
+    bltu_1 bltu_0 sp base a b
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+    retMem dMem dloMem scratchUn0 scratchMem raVal
+    rfl rfl rfl rfl hdiv0 hdiv1 hdiv2 hdiv3
+
 /-- Compose the n=3 v4 stack precondition through the v4 no-NOP path to the
     public callable DIV post, keeping the v4 trial-call scratch cell framed. -/
 theorem evm_div_n3_stack_pre_to_callable_post_v4_scratch_noNop (sp base : Word)

--- a/EvmAsm/Evm64/DivMod/Spec/N3V4StackPre.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3V4StackPre.lean
@@ -765,18 +765,7 @@ theorem evm_div_n3_stack_pre_to_callable_post_v4_scratch_of_mulsub_overestimate
     (hshift_nz : (clzResult (b.getLimbN 2)).1 ≠ 0)
     (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
       base + div128CallRetOff)
-    (hbltu_1 : isTrialN3V4_j1 bltu_1
-      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3))
-    (hbltu_0 : isTrialN3V4_j0 bltu_1 bltu_0
-      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3))
-    (hcarry2 : fullDivN3Carry2NzV4
-      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3))
-    (hmulsub : fullDivN3MulSubEqV4 bltu_1 bltu_0
-      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3))
-    (hge : fullDivN3QuotientOverestimateV4 bltu_1 bltu_0
+    (hpath : fullDivN3PathConditionsV4 bltu_1 bltu_0
       (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
       (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)) :
     cpsTripleWithin ((8 + 21 + 24 + 4 + 21 + 21 + 4 + 448) + (2 + 23 + 10))
@@ -795,6 +784,7 @@ theorem evm_div_n3_stack_pre_to_callable_post_v4_scratch_of_mulsub_overestimate
           (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
           (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
           scratchMem)) := by
+  obtain ⟨hbltu_1, hbltu_0, hcarry2, hmulsub, hge⟩ := hpath
   have hbnz' : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 ≠ 0 :=
     (EvmWord.ne_zero_iff_getLimbN_or).mp hbnz
   have hdivWord :=

--- a/EvmAsm/Evm64/DivMod/Spec/N3V4StackPre.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3V4StackPre.lean
@@ -146,4 +146,133 @@ theorem evm_div_n3_preloop_loop_stack_pre_spec_v4 (sp base : Word)
     (fun _ hq => hq)
     hraw
 
+/-- Compose the n=3 v4 stack preloop+loop path through denormalization to the
+    v4 final no-`x1` post, preserving the exact caller `x1`. -/
+theorem evm_div_n3_stack_pre_to_unified_post_v4 (sp base : Word)
+    (a b : EvmWord)
+    (v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (hbnz : b ≠ 0)
+    (hb3z : b.getLimbN 3 = 0) (hb2nz : b.getLimbN 2 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 2)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_1 : bltu_1 =
+      BitVec.ult (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+        (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).2.2.1)
+    (hbltu_0 : bltu_0 =
+      match bltu_1, hbltu_1 with
+      | false, _ =>
+        BitVec.ult
+          (iterN3Max
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+            (0 : Word)).2.2.2.1
+          (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+            (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+      | true, _ =>
+        BitVec.ult
+          (iterWithDoubleAddback
+            (divKTrialCallV4QHat
+              (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+                (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+              (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+                (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.1
+              (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+                (b.getLimbN 2) (b.getLimbN 3)).2.2.1)
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+            (0 : Word)).2.2.2.1
+          (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+            (b.getLimbN 2) (b.getLimbN 3)).2.2.1)
+    (hcarry2 : Carry2NzAll
+      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1
+      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.1
+      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2) :
+    cpsTripleWithin ((8 + 21 + 24 + 4 + 21 + 21 + 4 + 448) + (2 + 23 + 10))
+      base (base + nopOff) (divCode_v4 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult (b.getLimbN 2)).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (fullDivN3UnifiedPostNoX1V4 bltu_1 bltu_0 sp base
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+        retMem dMem dloMem scratchUn0 scratchMem **
+       (.x1 ↦ᵣ raVal)) := by
+  have hA := evm_div_n3_preloop_loop_stack_pre_spec_v4
+    sp base a b v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+    hbnz hb3z hb2nz hshift_nz halign hbltu_1 hbltu_0 hcarry2
+  have hshift_nz' : fullDivN3Shift (b.getLimbN 2) ≠ 0 := by
+    rw [fullDivN3Shift_unfold]
+    exact hshift_nz
+  have hBNoNop := evm_div_n3_denorm_epilogue_bundled_spec_v4_noNop_v4Final_exact_x1_scratch_frame
+    bltu_1 bltu_0 sp base
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+    retMem dMem dloMem scratchUn0 scratchMem raVal hshift_nz'
+  have hB := cpsTripleWithin_divCode_noNop_v4_to_divCode_v4 hBNoNop
+  have hFull := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by
+      cases bltu_1 <;> cases bltu_0
+      · exact loopN3UnifiedPostV4NoX1_to_fullDivN3DenormPreV4_frame_FF
+          sp base (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+          retMem dMem dloMem scratchUn0 scratchMem raVal h hp
+      · exact loopN3UnifiedPostV4NoX1_to_fullDivN3DenormPreV4_frame_FT
+          sp base (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+          retMem dMem dloMem scratchUn0 scratchMem raVal h hp
+      · exact loopN3UnifiedPostV4NoX1_to_fullDivN3DenormPreV4_frame_TF
+          sp base (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+          retMem dMem dloMem scratchUn0 scratchMem raVal h hp
+      · exact loopN3UnifiedPostV4NoX1_to_fullDivN3DenormPreV4_frame_TT
+          sp base (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+          retMem dMem dloMem scratchUn0 scratchMem raVal h hp)
+    hA hB
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => hp)
+    (fun h hq => hq)
+    hFull
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N3V4StackPre.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3V4StackPre.lean
@@ -7,6 +7,7 @@
 import EvmAsm.Evm64.DivMod.Spec.Dispatcher
 import EvmAsm.Evm64.DivMod.Spec.CallablePost
 import EvmAsm.Evm64.DivMod.Spec.N3QuotientWord
+import EvmAsm.Evm64.DivMod.Spec.N3QuotientStackBridge
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V4
 
 namespace EvmAsm.Evm64
@@ -656,5 +657,146 @@ theorem evm_div_n3_stack_pre_to_callable_post_v4_scratch_word (sp base : Word)
     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
     hbnz hb3z hb2nz hshift_nz halign hbltu_1 hbltu_0 hcarry2
     hdiv0 hdiv1 hdiv2 hdiv3
+
+/-- Arithmetic-assumption version of
+    `evm_div_n3_stack_pre_to_callable_post_v4_scratch_word`. -/
+theorem evm_div_n3_stack_pre_to_callable_post_v4_scratch_of_mulsub_overestimate
+    (sp base : Word) (a b : EvmWord)
+    (v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (hbnz : b ≠ 0)
+    (hb3z : b.getLimbN 3 = 0) (hb2nz : b.getLimbN 2 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 2)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_1 : bltu_1 =
+      BitVec.ult (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+        (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).2.2.1)
+    (hbltu_0 : bltu_0 =
+      match bltu_1, hbltu_1 with
+      | false, _ =>
+        BitVec.ult
+          (iterN3Max
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+            (0 : Word)).2.2.2.1
+          (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+            (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+      | true, _ =>
+        BitVec.ult
+          (iterWithDoubleAddback
+            (divKTrialCallV4QHat
+              (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+                (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+              (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+                (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.1
+              (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+                (b.getLimbN 2) (b.getLimbN 3)).2.2.1)
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+            (0 : Word)).2.2.2.1
+          (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+            (b.getLimbN 2) (b.getLimbN 3)).2.2.1)
+    (hcarry2 : Carry2NzAll
+      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1
+      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.1
+      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2)
+    (hmulsub :
+      EvmWord.val256 (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3) =
+        (((fullDivN3R1V4 bltu_1
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1).toNat *
+            2^64 +
+          ((fullDivN3R0V4 bltu_1 bltu_0
+            (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+            (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1).toNat) *
+          EvmWord.val256 (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) +
+        EvmWord.val256
+          ((fullDivN3R0V4 bltu_1 bltu_0
+            (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+            (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.1)
+          ((fullDivN3R0V4 bltu_1 bltu_0
+            (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+            (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1)
+          ((fullDivN3R0V4 bltu_1 bltu_0
+            (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+            (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2.1)
+          ((fullDivN3R0V4 bltu_1 bltu_0
+            (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+            (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2.2.1))
+    (hge :
+      EvmWord.val256 (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3) /
+          EvmWord.val256 (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) ≤
+        ((fullDivN3R1V4 bltu_1
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1).toNat *
+            2^64 +
+          ((fullDivN3R0V4 bltu_1 bltu_0
+            (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+            (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1).toNat) :
+    cpsTripleWithin ((8 + 21 + 24 + 4 + 21 + 21 + 4 + 448) + (2 + 23 + 10))
+      base (base + nopOff) (divCode_v4 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult (b.getLimbN 2)).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divStackDispatchPostCallableExactFrame sp a b raVal
+        (signExtend12 4095 : Word) **
+       ((sp + signExtend12 3936) ↦ₘ
+        fullDivN3ScratchMemV4 bltu_1 bltu_0
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+          scratchMem)) := by
+  have hbnz' : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 ≠ 0 :=
+    (EvmWord.ne_zero_iff_getLimbN_or).mp hbnz
+  have hdivWord :=
+    fullDivN3QuotientWordV4_eq_div_of_limbs_mulsub_overestimate
+      bltu_1 bltu_0 (a := a) (b := b)
+      (a0 := a.getLimbN 0) (a1 := a.getLimbN 1)
+      (a2 := a.getLimbN 2) (a3 := a.getLimbN 3)
+      (b0 := b.getLimbN 0) (b1 := b.getLimbN 1)
+      (b2 := b.getLimbN 2) (b3 := b.getLimbN 3)
+      rfl rfl rfl rfl rfl rfl rfl rfl hbnz' hmulsub hge
+  exact evm_div_n3_stack_pre_to_callable_post_v4_scratch_word
+    sp base a b v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+    hbnz hb3z hb2nz hshift_nz halign hbltu_1 hbltu_0 hcarry2 hdivWord
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N3V4StackPre.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3V4StackPre.lean
@@ -17,9 +17,9 @@ open EvmAsm.Rv64
 open EvmAsm.Rv64.AddrNorm (word_add_zero)
 
 /-- EvmWord-level wrapper around the n=3 exact-x1/scratch v4 preloop+loop
-    path. It exposes the proof over the full `divCode_v4` bundle while keeping
-    the stack precondition bundled as `evmWordIs` plus the v4 scratch cell. -/
-theorem evm_div_n3_preloop_loop_stack_pre_spec_v4 (sp base : Word)
+    path over the no-NOP v4 body. It keeps the stack precondition bundled as
+    `evmWordIs` plus the v4 scratch cell. -/
+theorem evm_div_n3_preloop_loop_stack_pre_spec_v4_noNop (sp base : Word)
     (a b : EvmWord)
     (v5 v6 v7 v10 v11Old : Word)
     (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
@@ -94,7 +94,7 @@ theorem evm_div_n3_preloop_loop_stack_pre_spec_v4 (sp base : Word)
       (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
       (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2) :
     cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 448)
-      base (base + denormOff) (divCode_v4 base)
+      base (base + denormOff) (divCode_noNop_v4 base)
       (divModStackDispatchPreNoX1 sp a b
         (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
         ((clzResult (b.getLimbN 2)).2 >>> (63 : Nat))
@@ -138,7 +138,6 @@ theorem evm_div_n3_preloop_loop_stack_pre_spec_v4 (sp base : Word)
     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
     hbnz' hb3z hb2nz hshift_nz halign hbltu_1
     (by cases bltu_1 <;> simpa using hbltu_0) hcarry2
-  have hraw := fullDivN3_preloop_loop_unified_exact_x1_scratch_v4 base hrawNoNop
   exact cpsTripleWithin_weaken
     (fun _ hp => by
       rw [divModStackDispatchPreNoX1_unfold, divScratchValuesCallNoX1_unfold] at hp
@@ -148,7 +147,7 @@ theorem evm_div_n3_preloop_loop_stack_pre_spec_v4 (sp base : Word)
       rw [word_add_zero]
       xperm_hyp hp)
     (fun _ hq => hq)
-    hraw
+    hrawNoNop
 
 /-- Compose the n=3 v4 stack preloop+loop path through denormalization to the
     v4 final no-`x1` post, preserving the exact caller `x1`. -/
@@ -240,7 +239,7 @@ theorem evm_div_n3_stack_pre_to_unified_post_v4 (sp base : Word)
         (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
         retMem dMem dloMem scratchUn0 scratchMem **
        (.x1 ↦ᵣ raVal)) := by
-  have hA := evm_div_n3_preloop_loop_stack_pre_spec_v4
+  have hA := evm_div_n3_preloop_loop_stack_pre_spec_v4_noNop
     sp base a b v5 v6 v7 v10 v11Old
     q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
@@ -253,7 +252,6 @@ theorem evm_div_n3_stack_pre_to_unified_post_v4 (sp base : Word)
     (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
     (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
     retMem dMem dloMem scratchUn0 scratchMem raVal hshift_nz'
-  have hB := cpsTripleWithin_divCode_noNop_v4_to_divCode_v4 hBNoNop
   have hFull := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by
       cases bltu_1 <;> cases bltu_0
@@ -273,8 +271,9 @@ theorem evm_div_n3_stack_pre_to_unified_post_v4 (sp base : Word)
           sp base (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
           (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
           retMem dMem dloMem scratchUn0 scratchMem raVal h hp)
-    hA hB
-  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    hA hBNoNop
+  exact cpsTripleWithin_divCode_noNop_v4_to_divCode_v4 <|
+    cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
     (fun h hp => hp)
     (fun h hq => hq)
     hFull

--- a/EvmAsm/Evm64/DivMod/Spec/N3V4StackPre.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3V4StackPre.lean
@@ -151,6 +151,133 @@ theorem evm_div_n3_preloop_loop_stack_pre_spec_v4_noNop (sp base : Word)
 
 /-- Compose the n=3 v4 stack preloop+loop path through denormalization to the
     v4 final no-`x1` post, preserving the exact caller `x1`. -/
+theorem evm_div_n3_stack_pre_to_unified_post_v4_noNop (sp base : Word)
+    (a b : EvmWord)
+    (v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (hbnz : b ≠ 0)
+    (hb3z : b.getLimbN 3 = 0) (hb2nz : b.getLimbN 2 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 2)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_1 : bltu_1 =
+      BitVec.ult (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+        (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).2.2.1)
+    (hbltu_0 : bltu_0 =
+      match bltu_1, hbltu_1 with
+      | false, _ =>
+        BitVec.ult
+          (iterN3Max
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+            (0 : Word)).2.2.2.1
+          (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+            (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+      | true, _ =>
+        BitVec.ult
+          (iterWithDoubleAddback
+            (divKTrialCallV4QHat
+              (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+                (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+              (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+                (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.1
+              (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+                (b.getLimbN 2) (b.getLimbN 3)).2.2.1)
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+            (0 : Word)).2.2.2.1
+          (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+            (b.getLimbN 2) (b.getLimbN 3)).2.2.1)
+    (hcarry2 : Carry2NzAll
+      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1
+      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.1
+      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2) :
+    cpsTripleWithin ((8 + 21 + 24 + 4 + 21 + 21 + 4 + 448) + (2 + 23 + 10))
+      base (base + nopOff) (divCode_noNop_v4 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult (b.getLimbN 2)).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (fullDivN3UnifiedPostNoX1V4 bltu_1 bltu_0 sp base
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+        retMem dMem dloMem scratchUn0 scratchMem **
+       (.x1 ↦ᵣ raVal)) := by
+  have hA := evm_div_n3_preloop_loop_stack_pre_spec_v4_noNop
+    sp base a b v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+    hbnz hb3z hb2nz hshift_nz halign hbltu_1 hbltu_0 hcarry2
+  have hshift_nz' : fullDivN3Shift (b.getLimbN 2) ≠ 0 := by
+    rw [fullDivN3Shift_unfold]
+    exact hshift_nz
+  have hBNoNop := evm_div_n3_denorm_epilogue_bundled_spec_v4_noNop_v4Final_exact_x1_scratch_frame
+    bltu_1 bltu_0 sp base
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+    retMem dMem dloMem scratchUn0 scratchMem raVal hshift_nz'
+  have hFull := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by
+      cases bltu_1 <;> cases bltu_0
+      · exact loopN3UnifiedPostV4NoX1_to_fullDivN3DenormPreV4_frame_FF
+          sp base (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+          retMem dMem dloMem scratchUn0 scratchMem raVal h hp
+      · exact loopN3UnifiedPostV4NoX1_to_fullDivN3DenormPreV4_frame_FT
+          sp base (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+          retMem dMem dloMem scratchUn0 scratchMem raVal h hp
+      · exact loopN3UnifiedPostV4NoX1_to_fullDivN3DenormPreV4_frame_TF
+          sp base (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+          retMem dMem dloMem scratchUn0 scratchMem raVal h hp
+      · exact loopN3UnifiedPostV4NoX1_to_fullDivN3DenormPreV4_frame_TT
+          sp base (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+          retMem dMem dloMem scratchUn0 scratchMem raVal h hp)
+    hA hBNoNop
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => hp)
+    (fun h hq => hq)
+    hFull
+
+/-- Full-code form of `evm_div_n3_stack_pre_to_unified_post_v4_noNop`. -/
 theorem evm_div_n3_stack_pre_to_unified_post_v4 (sp base : Word)
     (a b : EvmWord)
     (v5 v6 v7 v10 v11Old : Word)
@@ -239,44 +366,12 @@ theorem evm_div_n3_stack_pre_to_unified_post_v4 (sp base : Word)
         (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
         retMem dMem dloMem scratchUn0 scratchMem **
        (.x1 ↦ᵣ raVal)) := by
-  have hA := evm_div_n3_preloop_loop_stack_pre_spec_v4_noNop
-    sp base a b v5 v6 v7 v10 v11Old
-    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
-    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
-    hbnz hb3z hb2nz hshift_nz halign hbltu_1 hbltu_0 hcarry2
-  have hshift_nz' : fullDivN3Shift (b.getLimbN 2) ≠ 0 := by
-    rw [fullDivN3Shift_unfold]
-    exact hshift_nz
-  have hBNoNop := evm_div_n3_denorm_epilogue_bundled_spec_v4_noNop_v4Final_exact_x1_scratch_frame
-    bltu_1 bltu_0 sp base
-    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
-    retMem dMem dloMem scratchUn0 scratchMem raVal hshift_nz'
-  have hFull := cpsTripleWithin_seq_perm_same_cr
-    (fun h hp => by
-      cases bltu_1 <;> cases bltu_0
-      · exact loopN3UnifiedPostV4NoX1_to_fullDivN3DenormPreV4_frame_FF
-          sp base (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
-          retMem dMem dloMem scratchUn0 scratchMem raVal h hp
-      · exact loopN3UnifiedPostV4NoX1_to_fullDivN3DenormPreV4_frame_FT
-          sp base (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
-          retMem dMem dloMem scratchUn0 scratchMem raVal h hp
-      · exact loopN3UnifiedPostV4NoX1_to_fullDivN3DenormPreV4_frame_TF
-          sp base (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
-          retMem dMem dloMem scratchUn0 scratchMem raVal h hp
-      · exact loopN3UnifiedPostV4NoX1_to_fullDivN3DenormPreV4_frame_TT
-          sp base (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
-          retMem dMem dloMem scratchUn0 scratchMem raVal h hp)
-    hA hBNoNop
-  exact cpsTripleWithin_divCode_noNop_v4_to_divCode_v4 <|
-    cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
-    (fun h hp => hp)
-    (fun h hq => hq)
-    hFull
+  exact cpsTripleWithin_divCode_noNop_v4_to_divCode_v4
+    (evm_div_n3_stack_pre_to_unified_post_v4_noNop
+      sp base a b v5 v6 v7 v10 v11Old
+      q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+      nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+      hbnz hb3z hb2nz hshift_nz halign hbltu_1 hbltu_0 hcarry2)
 
 /-- Convert the n=3 v4 final post plus exact caller `x1` to the
     exact-register concrete DIV callable surface, preserving the v4 trial-call
@@ -433,9 +528,9 @@ theorem fullDivN3UnifiedPostNoX1V4_frame_to_divStackDispatchPostCallableExactFra
     (fun h hp => divConcretePostNoX1ExactRegs_weaken_callable_frame sp a b h hp)
     h hExact
 
-/-- Compose the n=3 v4 stack precondition through the v4 full path to the
+/-- Compose the n=3 v4 stack precondition through the v4 no-NOP path to the
     public callable DIV post, keeping the v4 trial-call scratch cell framed. -/
-theorem evm_div_n3_stack_pre_to_callable_post_v4_scratch (sp base : Word)
+theorem evm_div_n3_stack_pre_to_callable_post_v4_scratch_noNop (sp base : Word)
     (a b : EvmWord)
     (v5 v6 v7 v10 v11Old : Word)
     (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
@@ -520,7 +615,7 @@ theorem evm_div_n3_stack_pre_to_callable_post_v4_scratch (sp base : Word)
     (hdiv2 : (EvmWord.div a b).getLimbN 2 = (0 : Word))
     (hdiv3 : (EvmWord.div a b).getLimbN 3 = (0 : Word)) :
     cpsTripleWithin ((8 + 21 + 24 + 4 + 21 + 21 + 4 + 448) + (2 + 23 + 10))
-      base (base + nopOff) (divCode_v4 base)
+      base (base + nopOff) (divCode_noNop_v4 base)
       (divModStackDispatchPreNoX1 sp a b
         (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
         ((clzResult (b.getLimbN 2)).2 >>> (63 : Nat))
@@ -544,13 +639,14 @@ theorem evm_div_n3_stack_pre_to_callable_post_v4_scratch (sp base : Word)
         (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
         retMem dMem dloMem scratchUn0 scratchMem raVal
         rfl rfl rfl rfl hdiv0 hdiv1 hdiv2 hdiv3 h hq)
-    (evm_div_n3_stack_pre_to_unified_post_v4
+    (evm_div_n3_stack_pre_to_unified_post_v4_noNop
       sp base a b v5 v6 v7 v10 v11Old
       q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
       nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
       hbnz hb3z hb2nz hshift_nz halign hbltu_1 hbltu_0 hcarry2)
 
-/-- Quotient-word version of `evm_div_n3_stack_pre_to_callable_post_v4_scratch`.
+/-- Quotient-word version of
+    `evm_div_n3_stack_pre_to_callable_post_v4_scratch_noNop`.
     This is the callable N3 v4 bridge shape expected by dispatcher code. -/
 theorem evm_div_n3_stack_pre_to_callable_post_v4_scratch_word (sp base : Word)
     (a b : EvmWord)
@@ -651,12 +747,13 @@ theorem evm_div_n3_stack_pre_to_callable_post_v4_scratch_word (sp base : Word)
       (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
       (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
       hdivWord
-  exact evm_div_n3_stack_pre_to_callable_post_v4_scratch
-    sp base a b v5 v6 v7 v10 v11Old
-    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
-    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
-    hbnz hb3z hb2nz hshift_nz halign hbltu_1 hbltu_0 hcarry2
-    hdiv0 hdiv1 hdiv2 hdiv3
+  exact cpsTripleWithin_divCode_noNop_v4_to_divCode_v4 <|
+    evm_div_n3_stack_pre_to_callable_post_v4_scratch_noNop
+      sp base a b v5 v6 v7 v10 v11Old
+      q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+      nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+      hbnz hb3z hb2nz hshift_nz halign hbltu_1 hbltu_0 hcarry2
+      hdiv0 hdiv1 hdiv2 hdiv3
 
 /-- Arithmetic-assumption version of
     `evm_div_n3_stack_pre_to_callable_post_v4_scratch_word`. -/
@@ -800,7 +897,18 @@ theorem evm_div_n3_stack_pre_to_callable_post_v4_scratch_of_mulsub_overestimate
     hbnz hb3z hb2nz hshift_nz halign hbltu_1 hbltu_0 hcarry2 hdivWord
 
 /-- Lift the N3 v4 stack-pre/callable-post path to the shared
-    `unifiedDivBound` used by dispatcher-facing stack specs. -/
+    `unifiedDivBound` used by dispatcher-facing stack specs, over the no-NOP
+    v4 body expected by callable wrappers. -/
+theorem evm_div_n3_stack_pre_to_callable_post_v4_scratch_noNop_bound_unified
+    {P Q : Assertion} (base : Word)
+    (h :
+      cpsTripleWithin ((8 + 21 + 24 + 4 + 21 + 21 + 4 + 448) + (2 + 23 + 10))
+        base (base + nopOff) (divCode_noNop_v4 base) P Q) :
+    cpsTripleWithin unifiedDivBound base (base + nopOff) (divCode_noNop_v4 base) P Q := by
+  exact cpsTripleWithin_mono_nSteps (by unfold unifiedDivBound; decide) h
+
+/-- Full-code form of
+    `evm_div_n3_stack_pre_to_callable_post_v4_scratch_noNop_bound_unified`. -/
 theorem evm_div_n3_stack_pre_to_callable_post_v4_scratch_bound_unified
     {P Q : Assertion} (base : Word)
     (h :

--- a/EvmAsm/Evm64/DivMod/Spec/N3V4StackPre.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3V4StackPre.lean
@@ -5,6 +5,7 @@
 -/
 
 import EvmAsm.Evm64.DivMod.Spec.Dispatcher
+import EvmAsm.Evm64.DivMod.Spec.CallablePost
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V4
 
 namespace EvmAsm.Evm64
@@ -274,5 +275,277 @@ theorem evm_div_n3_stack_pre_to_unified_post_v4 (sp base : Word)
     (fun h hp => hp)
     (fun h hq => hq)
     hFull
+
+/-- Convert the n=3 v4 final post plus exact caller `x1` to the
+    exact-register concrete DIV callable surface, preserving the v4 trial-call
+    scratch cell that is not part of the public callable post. -/
+theorem fullDivN3UnifiedPostNoX1V4_frame_to_divConcretePostNoX1ExactRegsFrame_scratch
+    (bltu_1 bltu_0 : Bool)
+    (sp base : Word) (a b : EvmWord)
+    (a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (ha0 : a.getLimbN 0 = a0) (ha1 : a.getLimbN 1 = a1)
+    (ha2 : a.getLimbN 2 = a2) (ha3 : a.getLimbN 3 = a3)
+    (hdiv0 : (EvmWord.div a b).getLimbN 0 =
+      (fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).1)
+    (hdiv1 : (EvmWord.div a b).getLimbN 1 =
+      (fullDivN3R1V4 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1)
+    (hdiv2 : (EvmWord.div a b).getLimbN 2 = (0 : Word))
+    (hdiv3 : (EvmWord.div a b).getLimbN 3 = (0 : Word)) :
+    ∀ h,
+      (fullDivN3UnifiedPostNoX1V4 bltu_1 bltu_0 sp base
+        a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal)) h →
+      (divConcretePostNoX1ExactRegsFrame sp a b
+        (signExtend12 4095) raVal
+        (signExtend12 (0 : BitVec 12) - fullDivN3Shift b2)
+        (fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).1
+        (fullDivN3R1V4 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1
+        (0 : Word)
+        (0 : Word)
+        (fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).1
+        (fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).1
+        (fullDivN3R1V4 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1
+        (0 : Word)
+        (0 : Word)
+        (((fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.1 >>>
+            ((fullDivN3Shift b2).toNat % 64)) |||
+          ((fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 <<<
+            (((signExtend12 (0 : BitVec 12) - fullDivN3Shift b2).toNat) % 64)))
+        (((fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 >>>
+            ((fullDivN3Shift b2).toNat % 64)) |||
+          ((fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1 <<<
+            (((signExtend12 (0 : BitVec 12) - fullDivN3Shift b2).toNat) % 64)))
+        (((fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1 >>>
+            ((fullDivN3Shift b2).toNat % 64)) |||
+          ((fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1 <<<
+            (((signExtend12 (0 : BitVec 12) - fullDivN3Shift b2).toNat) % 64)))
+        ((fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1 >>>
+          ((fullDivN3Shift b2).toNat % 64))
+        (fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.2
+        (fullDivN3R1V4 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.2
+        (0 : Word)
+        (0 : Word)
+        (fullDivN3Shift b2) (3 : Word) (0 : Word)
+        (if bltu_0 then (base + div128CallRetOff)
+          else if bltu_1 then (base + div128CallRetOff) else retMem)
+        (if bltu_0 then (fullDivN3NormV b0 b1 b2 b3).2.2.1
+          else if bltu_1 then (fullDivN3NormV b0 b1 b2 b3).2.2.1 else dMem)
+        (if bltu_0 then divKTrialCallV4DLo (fullDivN3NormV b0 b1 b2 b3).2.2.1
+          else if bltu_1 then divKTrialCallV4DLo
+            (fullDivN3NormV b0 b1 b2 b3).2.2.1 else dloMem)
+        (if bltu_0 then divKTrialCallV4Un0
+            (fullDivN3R1V4 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1
+          else if bltu_1 then divKTrialCallV4Un0
+            (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.1
+          else scratchUn0) **
+       ((sp + signExtend12 3936) ↦ₘ
+        fullDivN3ScratchMemV4 bltu_1 bltu_0
+          a0 a1 a2 a3 b0 b1 b2 b3 scratchMem)) h := by
+  intro h hq
+  let shift := fullDivN3Shift b2
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let r1 := fullDivN3R1V4 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+  let r0 := fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+  let v := fullDivN3NormV b0 b1 b2 b3
+  let u := fullDivN3NormU a0 a1 a2 a3 b2
+  let scratchRet := if bltu_0 then (base + div128CallRetOff)
+    else if bltu_1 then (base + div128CallRetOff) else retMem
+  let scratchD := if bltu_0 then v.2.2.1
+    else if bltu_1 then v.2.2.1 else dMem
+  let scratchDLo := if bltu_0 then divKTrialCallV4DLo v.2.2.1
+    else if bltu_1 then divKTrialCallV4DLo v.2.2.1 else dloMem
+  let scratchUn0' := if bltu_0 then divKTrialCallV4Un0 r1.2.2.1
+    else if bltu_1 then divKTrialCallV4Un0 u.2.2.2.1 else scratchUn0
+  let u0' := (r0.2.1 >>> (shift.toNat % 64)) ||| (r0.2.2.1 <<< (antiShift.toNat % 64))
+  let u1' := (r0.2.2.1 >>> (shift.toNat % 64)) ||| (r0.2.2.2.1 <<< (antiShift.toNat % 64))
+  let u2' := (r0.2.2.2.1 >>> (shift.toNat % 64)) ||| (r0.2.2.2.2.1 <<< (antiShift.toNat % 64))
+  let u3' := r0.2.2.2.2.1 >>> (shift.toNat % 64)
+  rw [divConcretePostNoX1ExactRegsFrame_unfold]
+  change
+    ((((.x12 ↦ᵣ (sp + 32)) ** (.x5 ↦ᵣ r0.1) ** (.x10 ↦ᵣ (0 : Word)) **
+      (.x0 ↦ᵣ (0 : Word)) ** evmWordIs (sp + 32) (EvmWord.div a b)) **
+     ((.x9 ↦ᵣ (signExtend12 4095 : Word)) ** (.x1 ↦ᵣ raVal) **
+      (.x2 ↦ᵣ antiShift) ** (.x6 ↦ᵣ r1.1) ** (.x7 ↦ᵣ (0 : Word)) **
+      (.x11 ↦ᵣ r0.1) ** evmWordIs sp a **
+      divScratchValuesCallNoX1 sp r0.1 r1.1 (0 : Word) (0 : Word)
+        u0' u1' u2' u3' r0.2.2.2.2.2 r1.2.2.2.2.2
+        (0 : Word) (0 : Word) shift (3 : Word) (0 : Word)
+        scratchRet scratchD scratchDLo scratchUn0')) **
+     ((sp + signExtend12 3936) ↦ₘ
+      fullDivN3ScratchMemV4 bltu_1 bltu_0
+        a0 a1 a2 a3 b0 b1 b2 b3 scratchMem)) h
+  delta fullDivN3UnifiedPostNoX1V4 fullDivN3DenormPostV4 fullDivN3FrameNoX1V4
+    fullDivN3ScratchNoX1V4 at hq
+  simp only [denormDivPost_unfold] at hq
+  rw [show evmWordIs sp a =
+      ((sp ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3))
+      from by rw [evmWordIs_sp_limbs_eq sp a _ _ _ _ ha0 ha1 ha2 ha3]]
+  rw [show evmWordIs (sp + 32) (EvmWord.div a b) =
+      (((sp + 32) ↦ₘ
+          (fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).1) **
+       ((sp + 40) ↦ₘ
+          (fullDivN3R1V4 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1) **
+       ((sp + 48) ↦ₘ (0 : Word)) **
+       ((sp + 56) ↦ₘ (0 : Word)))
+      from by
+        rw [evmWordIs_sp32_limbs_eq sp (EvmWord.div a b) _ _ _ _
+          hdiv0 hdiv1 hdiv2 hdiv3]]
+  rw [divScratchValuesCallNoX1_unfold, divScratchValues_unfold]
+  rw [word_add_zero] at hq
+  xperm_hyp hq
+
+/-- Named callable-frame version of
+    `fullDivN3UnifiedPostNoX1V4_frame_to_divConcretePostNoX1ExactRegsFrame_scratch`. -/
+theorem fullDivN3UnifiedPostNoX1V4_frame_to_divStackDispatchPostCallableExactFrame_scratch
+    (bltu_1 bltu_0 : Bool)
+    (sp base : Word) (a b : EvmWord)
+    (a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (ha0 : a.getLimbN 0 = a0) (ha1 : a.getLimbN 1 = a1)
+    (ha2 : a.getLimbN 2 = a2) (ha3 : a.getLimbN 3 = a3)
+    (hdiv0 : (EvmWord.div a b).getLimbN 0 =
+      (fullDivN3R0V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).1)
+    (hdiv1 : (EvmWord.div a b).getLimbN 1 =
+      (fullDivN3R1V4 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1)
+    (hdiv2 : (EvmWord.div a b).getLimbN 2 = (0 : Word))
+    (hdiv3 : (EvmWord.div a b).getLimbN 3 = (0 : Word)) :
+    ∀ h,
+      (fullDivN3UnifiedPostNoX1V4 bltu_1 bltu_0 sp base
+        a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal)) h →
+      (divStackDispatchPostCallableExactFrame sp a b raVal
+        (signExtend12 4095 : Word) **
+       ((sp + signExtend12 3936) ↦ₘ
+        fullDivN3ScratchMemV4 bltu_1 bltu_0
+          a0 a1 a2 a3 b0 b1 b2 b3 scratchMem)) h := by
+  intro h hp
+  rw [divStackDispatchPostCallableExactFrame_unfold]
+  have hExact :=
+    fullDivN3UnifiedPostNoX1V4_frame_to_divConcretePostNoX1ExactRegsFrame_scratch
+      bltu_1 bltu_0 sp base a b
+      a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 scratchMem
+      raVal ha0 ha1 ha2 ha3 hdiv0 hdiv1 hdiv2 hdiv3 h hp
+  exact sepConj_mono_left
+    (fun h hp => divConcretePostNoX1ExactRegs_weaken_callable_frame sp a b h hp)
+    h hExact
+
+/-- Compose the n=3 v4 stack precondition through the v4 full path to the
+    public callable DIV post, keeping the v4 trial-call scratch cell framed. -/
+theorem evm_div_n3_stack_pre_to_callable_post_v4_scratch (sp base : Word)
+    (a b : EvmWord)
+    (v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (hbnz : b ≠ 0)
+    (hb3z : b.getLimbN 3 = 0) (hb2nz : b.getLimbN 2 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 2)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_1 : bltu_1 =
+      BitVec.ult (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+        (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).2.2.1)
+    (hbltu_0 : bltu_0 =
+      match bltu_1, hbltu_1 with
+      | false, _ =>
+        BitVec.ult
+          (iterN3Max
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+            (0 : Word)).2.2.2.1
+          (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+            (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+      | true, _ =>
+        BitVec.ult
+          (iterWithDoubleAddback
+            (divKTrialCallV4QHat
+              (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+                (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+              (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+                (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.1
+              (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+                (b.getLimbN 2) (b.getLimbN 3)).2.2.1)
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+            (0 : Word)).2.2.2.1
+          (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+            (b.getLimbN 2) (b.getLimbN 3)).2.2.1)
+    (hcarry2 : Carry2NzAll
+      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1
+      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.1
+      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2)
+    (hdiv0 : (EvmWord.div a b).getLimbN 0 =
+      (fullDivN3R0V4 bltu_1 bltu_0
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1)
+    (hdiv1 : (EvmWord.div a b).getLimbN 1 =
+      (fullDivN3R1V4 bltu_1
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1)
+    (hdiv2 : (EvmWord.div a b).getLimbN 2 = (0 : Word))
+    (hdiv3 : (EvmWord.div a b).getLimbN 3 = (0 : Word)) :
+    cpsTripleWithin ((8 + 21 + 24 + 4 + 21 + 21 + 4 + 448) + (2 + 23 + 10))
+      base (base + nopOff) (divCode_v4 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult (b.getLimbN 2)).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divStackDispatchPostCallableExactFrame sp a b raVal
+        (signExtend12 4095 : Word) **
+       ((sp + signExtend12 3936) ↦ₘ
+        fullDivN3ScratchMemV4 bltu_1 bltu_0
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+          scratchMem)) := by
+  exact cpsTripleWithin_weaken
+    (fun _ hp => hp)
+    (fun h hq =>
+      fullDivN3UnifiedPostNoX1V4_frame_to_divStackDispatchPostCallableExactFrame_scratch
+        bltu_1 bltu_0 sp base a b
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+        retMem dMem dloMem scratchUn0 scratchMem raVal
+        rfl rfl rfl rfl hdiv0 hdiv1 hdiv2 hdiv3 h hq)
+    (evm_div_n3_stack_pre_to_unified_post_v4
+      sp base a b v5 v6 v7 v10 v11Old
+      q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+      nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+      hbnz hb3z hb2nz hshift_nz halign hbltu_1 hbltu_0 hcarry2)
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N3V4StackPre.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3V4StackPre.lean
@@ -599,11 +599,8 @@ theorem evm_div_n3_stack_pre_to_callable_post_v4_scratch_noNop (sp base : Word)
             (0 : Word)).2.2.2.1
           (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
             (b.getLimbN 2) (b.getLimbN 3)).2.2.1)
-    (hcarry2 : Carry2NzAll
-      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1
-      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.1
-      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
-      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2)
+    (hcarry2 : fullDivN3Carry2NzV4
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3))
     (hdiv0 : (EvmWord.div a b).getLimbN 0 =
       (fullDivN3R0V4 bltu_1 bltu_0
         (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
@@ -774,11 +771,8 @@ theorem evm_div_n3_stack_pre_to_callable_post_v4_scratch_of_mulsub_overestimate
     (hbltu_0 : isTrialN3V4_j0 bltu_1 bltu_0
       (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
       (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3))
-    (hcarry2 : Carry2NzAll
-      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1
-      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.1
-      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
-      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2)
+    (hcarry2 : fullDivN3Carry2NzV4
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3))
     (hmulsub : fullDivN3MulSubEqV4 bltu_1 bltu_0
       (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
       (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3))

--- a/EvmAsm/Evm64/DivMod/Spec/N3V4StackPre.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3V4StackPre.lean
@@ -831,39 +831,12 @@ theorem evm_div_n3_stack_pre_to_callable_post_v4_scratch_of_mulsub_overestimate
       (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.1
       (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
       (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2)
-    (hmulsub :
-      EvmWord.val256 (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3) =
-        (((fullDivN3R1V4 bltu_1
-          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1).toNat *
-            2^64 +
-          ((fullDivN3R0V4 bltu_1 bltu_0
-            (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-            (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1).toNat) *
-          EvmWord.val256 (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) +
-        EvmWord.val256
-          ((fullDivN3R0V4 bltu_1 bltu_0
-            (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-            (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.1)
-          ((fullDivN3R0V4 bltu_1 bltu_0
-            (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-            (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1)
-          ((fullDivN3R0V4 bltu_1 bltu_0
-            (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-            (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2.1)
-          ((fullDivN3R0V4 bltu_1 bltu_0
-            (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-            (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2.2.1))
-    (hge :
-      EvmWord.val256 (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3) /
-          EvmWord.val256 (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) ≤
-        ((fullDivN3R1V4 bltu_1
-          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1).toNat *
-            2^64 +
-          ((fullDivN3R0V4 bltu_1 bltu_0
-            (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-            (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1).toNat) :
+    (hmulsub : fullDivN3MulSubEqV4 bltu_1 bltu_0
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3))
+    (hge : fullDivN3QuotientOverestimateV4 bltu_1 bltu_0
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)) :
     cpsTripleWithin ((8 + 21 + 24 + 4 + 21 + 21 + 4 + 448) + (2 + 23 + 10))
       base (base + nopOff) (divCode_v4 base)
       (divModStackDispatchPreNoX1 sp a b
@@ -894,7 +867,9 @@ theorem evm_div_n3_stack_pre_to_callable_post_v4_scratch_of_mulsub_overestimate
     sp base a b v5 v6 v7 v10 v11Old
     q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
-    hbnz hb3z hb2nz hshift_nz halign hbltu_1 hbltu_0 hcarry2 hdivWord
+    hbnz hb3z hb2nz hshift_nz halign hbltu_1
+    (by cases bltu_1 <;> simpa [isTrialN3V4_j0] using hbltu_0)
+    hcarry2 hdivWord
 
 /-- Lift the N3 v4 stack-pre/callable-post path to the shared
     `unifiedDivBound` used by dispatcher-facing stack specs, over the no-NOP

--- a/EvmAsm/Evm64/DivMod/Spec/N3V4StackPre.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3V4StackPre.lean
@@ -784,17 +784,18 @@ theorem evm_div_n3_stack_pre_to_callable_post_v4_scratch_of_mulsub_overestimate
           (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
           (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
           scratchMem)) := by
-  obtain ⟨hbltu_1, hbltu_0, hcarry2, hmulsub, hge⟩ := hpath
+  have hpath' := hpath
+  obtain ⟨hbltu_1, hbltu_0, hcarry2, _, _⟩ := hpath'
   have hbnz' : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 ≠ 0 :=
     (EvmWord.ne_zero_iff_getLimbN_or).mp hbnz
   have hdivWord :=
-    fullDivN3QuotientWordV4_eq_div_of_limbs_mulsub_overestimate
+    fullDivN3QuotientWordV4_eq_div_of_path_conditions
       bltu_1 bltu_0 (a := a) (b := b)
       (a0 := a.getLimbN 0) (a1 := a.getLimbN 1)
       (a2 := a.getLimbN 2) (a3 := a.getLimbN 3)
       (b0 := b.getLimbN 0) (b1 := b.getLimbN 1)
       (b2 := b.getLimbN 2) (b3 := b.getLimbN 3)
-      rfl rfl rfl rfl rfl rfl rfl rfl hbnz' hmulsub hge
+      rfl rfl rfl rfl rfl rfl rfl rfl hbnz' hpath
   exact evm_div_n3_stack_pre_to_callable_post_v4_scratch_word
     sp base a b v5 v6 v7 v10 v11Old
     q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7

--- a/EvmAsm/Evm64/DivMod/Spec/N3V4StackPre.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3V4StackPre.lean
@@ -768,64 +768,12 @@ theorem evm_div_n3_stack_pre_to_callable_post_v4_scratch_of_mulsub_overestimate
     (hshift_nz : (clzResult (b.getLimbN 2)).1 ≠ 0)
     (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
       base + div128CallRetOff)
-    (hbltu_1 : bltu_1 =
-      BitVec.ult (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
-          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
-        (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
-          (b.getLimbN 2) (b.getLimbN 3)).2.2.1)
-    (hbltu_0 : bltu_0 =
-      match bltu_1, hbltu_1 with
-      | false, _ =>
-        BitVec.ult
-          (iterN3Max
-            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
-              (b.getLimbN 2) (b.getLimbN 3)).1
-            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
-              (b.getLimbN 2) (b.getLimbN 3)).2.1
-            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
-              (b.getLimbN 2) (b.getLimbN 3)).2.2.1
-            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
-              (b.getLimbN 2) (b.getLimbN 3)).2.2.2
-            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
-              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.1
-            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
-              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.1
-            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
-              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.1
-            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
-              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
-            (0 : Word)).2.2.2.1
-          (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
-            (b.getLimbN 2) (b.getLimbN 3)).2.2.1
-      | true, _ =>
-        BitVec.ult
-          (iterWithDoubleAddback
-            (divKTrialCallV4QHat
-              (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
-                (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
-              (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
-                (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.1
-              (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
-                (b.getLimbN 2) (b.getLimbN 3)).2.2.1)
-            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
-              (b.getLimbN 2) (b.getLimbN 3)).1
-            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
-              (b.getLimbN 2) (b.getLimbN 3)).2.1
-            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
-              (b.getLimbN 2) (b.getLimbN 3)).2.2.1
-            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
-              (b.getLimbN 2) (b.getLimbN 3)).2.2.2
-            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
-              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.1
-            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
-              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.1
-            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
-              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.1
-            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
-              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
-            (0 : Word)).2.2.2.1
-          (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
-            (b.getLimbN 2) (b.getLimbN 3)).2.2.1)
+    (hbltu_1 : isTrialN3V4_j1 bltu_1
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3))
+    (hbltu_0 : isTrialN3V4_j0 bltu_1 bltu_0
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3))
     (hcarry2 : Carry2NzAll
       (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1
       (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.1

--- a/EvmAsm/Evm64/DivMod/Spec/N3V4StackPre.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3V4StackPre.lean
@@ -6,6 +6,7 @@
 
 import EvmAsm.Evm64.DivMod.Spec.Dispatcher
 import EvmAsm.Evm64.DivMod.Spec.CallablePost
+import EvmAsm.Evm64.DivMod.Spec.N3QuotientWord
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3V4
 
 namespace EvmAsm.Evm64
@@ -547,5 +548,113 @@ theorem evm_div_n3_stack_pre_to_callable_post_v4_scratch (sp base : Word)
       q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
       nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
       hbnz hb3z hb2nz hshift_nz halign hbltu_1 hbltu_0 hcarry2)
+
+/-- Quotient-word version of `evm_div_n3_stack_pre_to_callable_post_v4_scratch`.
+    This is the callable N3 v4 bridge shape expected by dispatcher code. -/
+theorem evm_div_n3_stack_pre_to_callable_post_v4_scratch_word (sp base : Word)
+    (a b : EvmWord)
+    (v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (hbnz : b ≠ 0)
+    (hb3z : b.getLimbN 3 = 0) (hb2nz : b.getLimbN 2 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 2)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_1 : bltu_1 =
+      BitVec.ult (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+        (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).2.2.1)
+    (hbltu_0 : bltu_0 =
+      match bltu_1, hbltu_1 with
+      | false, _ =>
+        BitVec.ult
+          (iterN3Max
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+            (0 : Word)).2.2.2.1
+          (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+            (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+      | true, _ =>
+        BitVec.ult
+          (iterWithDoubleAddback
+            (divKTrialCallV4QHat
+              (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+                (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+              (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+                (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.1
+              (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+                (b.getLimbN 2) (b.getLimbN 3)).2.2.1)
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+            (0 : Word)).2.2.2.1
+          (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+            (b.getLimbN 2) (b.getLimbN 3)).2.2.1)
+    (hcarry2 : Carry2NzAll
+      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1
+      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.1
+      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2)
+    (hdivWord : fullDivN3QuotientWordV4 bltu_1 bltu_0
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) =
+        EvmWord.div a b) :
+    cpsTripleWithin ((8 + 21 + 24 + 4 + 21 + 21 + 4 + 448) + (2 + 23 + 10))
+      base (base + nopOff) (divCode_v4 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult (b.getLimbN 2)).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divStackDispatchPostCallableExactFrame sp a b raVal
+        (signExtend12 4095 : Word) **
+       ((sp + signExtend12 3936) ↦ₘ
+        fullDivN3ScratchMemV4 bltu_1 bltu_0
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+          scratchMem)) := by
+  obtain ⟨hdiv0, hdiv1, hdiv2, hdiv3⟩ :=
+    fullDivN3V4_hdivs_of_word_eq bltu_1 bltu_0 a b
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+      hdivWord
+  exact evm_div_n3_stack_pre_to_callable_post_v4_scratch
+    sp base a b v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+    hbnz hb3z hb2nz hshift_nz halign hbltu_1 hbltu_0 hcarry2
+    hdiv0 hdiv1 hdiv2 hdiv3
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N3V4StackPre.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3V4StackPre.lean
@@ -1,0 +1,149 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N3V4StackPre
+
+  Stack-level wrappers for n=3 DIV v4 preloop+loop paths.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.Dispatcher
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3V4
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (word_add_zero)
+
+/-- EvmWord-level wrapper around the n=3 exact-x1/scratch v4 preloop+loop
+    path. It exposes the proof over the full `divCode_v4` bundle while keeping
+    the stack precondition bundled as `evmWordIs` plus the v4 scratch cell. -/
+theorem evm_div_n3_preloop_loop_stack_pre_spec_v4 (sp base : Word)
+    (a b : EvmWord)
+    (v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (hbnz : b ≠ 0)
+    (hb3z : b.getLimbN 3 = 0) (hb2nz : b.getLimbN 2 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 2)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_1 : bltu_1 =
+      BitVec.ult (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+        (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).2.2.1)
+    (hbltu_0 : bltu_0 =
+      match bltu_1, hbltu_1 with
+      | false, _ =>
+        BitVec.ult
+          (iterN3Max
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+            (0 : Word)).2.2.2.1
+          (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+            (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+      | true, _ =>
+        BitVec.ult
+          (iterWithDoubleAddback
+            (divKTrialCallV4QHat
+              (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+                (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+              (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+                (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.1
+              (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+                (b.getLimbN 2) (b.getLimbN 3)).2.2.1)
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+            (0 : Word)).2.2.2.1
+          (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+            (b.getLimbN 2) (b.getLimbN 3)).2.2.1)
+    (hcarry2 : Carry2NzAll
+      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1
+      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.1
+      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 448)
+      base (base + denormOff) (divCode_v4 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult (b.getLimbN 2)).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      ((loopN3UnifiedPostV4NoX1 bltu_1 bltu_0 sp base
+        (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1
+        (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.1
+        (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+        (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+        (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 2)).2.1
+        (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 2)).2.2.1
+        (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 2)).2.2.2.1
+        (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 2)).2.2.2.2
+        (0 : Word)
+        (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 2)).1
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal)) **
+       (((sp + 0) ↦ₘ a.getLimbN 0) ** ((sp + 8) ↦ₘ a.getLimbN 1) **
+        ((sp + 16) ↦ₘ a.getLimbN 2) ** ((sp + 24) ↦ₘ a.getLimbN 3) **
+        ((sp + signExtend12 4072) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 3992) ↦ₘ (clzResult (b.getLimbN 2)).1))) := by
+  have hbnz' : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 ≠ 0 :=
+    (EvmWord.ne_zero_iff_getLimbN_or).mp hbnz
+  have hrawNoNop := fullDivN3_preloop_loop_unified_exact_x1_scratch_v4_noNop
+    bltu_1 bltu_0 sp base
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+    v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+    hbnz' hb3z hb2nz hshift_nz halign hbltu_1
+    (by cases bltu_1 <;> simpa using hbltu_0) hcarry2
+  have hraw := fullDivN3_preloop_loop_unified_exact_x1_scratch_v4 base hrawNoNop
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by
+      rw [divModStackDispatchPreNoX1_unfold, divScratchValuesCallNoX1_unfold] at hp
+      rw [evmWordIs_sp_limbs_eq sp a _ _ _ _ rfl rfl rfl rfl,
+          evmWordIs_sp32_limbs_eq sp b _ _ _ _ rfl rfl rfl rfl,
+          divScratchValues_unfold] at hp
+      rw [word_add_zero]
+      xperm_hyp hp)
+    (fun _ hq => hq)
+    hraw
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- compose MOD n=3 v4 no-NOP call/max loop paths through the stack-pre and callable surfaces
- add the MOD n=3 v4 callable stack wrapper for evm_mod_callable_code_v4
- bundle the remaining MOD n=3 v4 path/remainder obligation as fullModN3PathConditionsWordV4

## Verification
- lake build EvmAsm.Evm64.DivMod.Compose.ModFullPathN3V4NoNop
- lake build EvmAsm.Evm64.DivMod.Spec.N3V4StackPre
- lake build EvmAsm.Evm64.DivMod.CallableV4Mod
- lake build EvmAsm.Evm64.DivMod
- git diff --check
- scripts/check-file-size.sh on touched files
- scripts/check-unimported.sh

## Remaining work
This PR does not complete unconditional DIV/MOD v4 stack specs. MOD n=3 still needs the arithmetic proof discharging fullModN3RemainderWordV4 = EvmWord.mod from runtime/path facts.