### PR TITLE
feat(stateless): account_storage_root_eq (PR-K134)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -1702,6 +1702,107 @@ def ziskAccountValidateCodeHashProbeUnit : BuildUnit := {
   dataAsm     := ziskAccountValidateCodeHashDataSection
 }
 
+/-! ## account_storage_root_eq -- PR-K134
+
+    Generic equality check on an account's `storage_root` field:
+    does it equal the 32-byte hash passed in as `expected`?
+
+    Used during witness validation to assert that the storage trie
+    pointed at by an account matches a claimed root (e.g., the
+    pre-state root in a stateless witness's account proof). The
+    narrower PR-K133 `account_storage_root_is_empty` is the
+    specialization where the expected value is `EMPTY_TRIE_ROOT`.
+
+    Composes:
+      - PR-K20 `rlp_list_nth_item` — field 2 bounds
+
+    Calling convention:
+      a0 (input)  : account_rlp ptr
+      a1 (input)  : account_rlp byte length
+      a2 (input)  : expected_root ptr (32 bytes)
+      a3 (input)  : u64 out ptr (1 if equal, 0 if not)
+      ra (input)  : return
+      a0 (output) :
+        0 : success — predicate written
+        1 : RLP parse failure / field 2 missing
+        2 : field 2 length != 32 -/
+def accountStorageRootEqFunction : String :=
+  "account_storage_root_eq:\n" ++
+  "  addi sp, sp, -48\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  mv s0, a0                   # account_ptr\n" ++
+  "  mv s1, a1                   # account_len\n" ++
+  "  mv s2, a2                   # expected_root ptr\n" ++
+  "  mv s3, a3                   # u64 out ptr\n" ++
+  "  sd zero, 0(s3)\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 2\n" ++
+  "  la a3, asre_offset; la a4, asre_length\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lasre_parse_fail\n" ++
+  "  la t0, asre_length; ld t1, 0(t0)\n" ++
+  "  li t2, 32\n" ++
+  "  bne t1, t2, .Lasre_size_fail\n" ++
+  "  la t0, asre_offset; ld t3, 0(t0); add t3, s0, t3\n" ++
+  "  ld t5,  0(t3); ld t6,  0(s2); bne t5, t6, .Lasre_neq\n" ++
+  "  ld t5,  8(t3); ld t6,  8(s2); bne t5, t6, .Lasre_neq\n" ++
+  "  ld t5, 16(t3); ld t6, 16(s2); bne t5, t6, .Lasre_neq\n" ++
+  "  ld t5, 24(t3); ld t6, 24(s2); bne t5, t6, .Lasre_neq\n" ++
+  "  li t0, 1\n" ++
+  "  sd t0, 0(s3)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lasre_ret\n" ++
+  ".Lasre_neq:\n" ++
+  "  sd zero, 0(s3)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lasre_ret\n" ++
+  ".Lasre_parse_fail:\n" ++
+  "  li a0, 1\n" ++
+  "  j .Lasre_ret\n" ++
+  ".Lasre_size_fail:\n" ++
+  "  li a0, 2\n" ++
+  ".Lasre_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  addi sp, sp, 48\n" ++
+  "  ret"
+
+/-- `zisk_account_storage_root_eq`: probe BuildUnit. Reads
+    (account_len, expected_root[32], account_bytes), writes
+    (status, is_equal) to OUTPUT (16 bytes total).
+    Input layout:
+      bytes  0.. 8 : account_len
+      bytes  8..40 : expected_root (32 bytes)
+      bytes 40..   : account_rlp -/
+def ziskAccountStorageRootEqPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a4, 0x40000000\n" ++
+  "  ld a1, 8(a4)                # account_rlp_len\n" ++
+  "  addi a2, a4, 16             # expected_root ptr\n" ++
+  "  addi a0, a4, 48             # account_rlp ptr\n" ++
+  "  li a3, 0xa0010008           # is_equal out\n" ++
+  "  jal ra, account_storage_root_eq\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lasre_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  accountStorageRootEqFunction ++ "\n" ++
+  ".Lasre_pdone:"
+
+def ziskAccountStorageRootEqDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "asre_offset:\n" ++
+  "  .zero 8\n" ++
+  "asre_length:\n" ++
+  "  .zero 8"
+
+def ziskAccountStorageRootEqProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskAccountStorageRootEqPrologue
+  dataAsm     := ziskAccountStorageRootEqDataSection
+}
+
 
 /-- `zisk_rlp_list_count_items`: probe BuildUnit. Reads
     (list_len, list_bytes) from host input, writes
@@ -12181,6 +12282,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_header_validate_parent_hash" => some ziskHeaderValidateParentHashProbeUnit
   | "zisk_header_chain_walk_step" => some ziskHeaderChainWalkStepProbeUnit
   | "zisk_account_validate_code_hash" => some ziskAccountValidateCodeHashProbeUnit
+  | "zisk_account_storage_root_eq" => some ziskAccountStorageRootEqProbeUnit
   | "zisk_address_from_pubkey"  => some ziskAddressFromPubkeyProbeUnit
   | "zisk_mpt_account_path_nibbles" => some ziskMptAccountPathNibblesProbeUnit
   | "zisk_headers_validate_chain" => some ziskHeadersValidateChainProbeUnit
@@ -12311,6 +12413,7 @@ def knownProgramNames : List String :=
    "zisk_header_validate_parent_hash",
    "zisk_header_chain_walk_step",
    "zisk_account_validate_code_hash",
+   "zisk_account_storage_root_eq",
    "zisk_address_from_pubkey",
    "zisk_mpt_account_path_nibbles",
    "zisk_headers_validate_chain",

--- a/scripts/codegen-zisk-account-storage-root-eq-check.sh
+++ b/scripts/codegen-zisk-account-storage-root-eq-check.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# codegen-zisk-account-storage-root-eq-check.sh -- PR-K134.
+#
+# Compare account.storage_root against an expected 32-byte hash.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_account_storage_root_eq ELF"
+lake exe codegen --program zisk_account_storage_root_eq --halt linux93 \
+  -o gen-out/zisk_account_storage_root_eq
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <storage_root_hex> <expected_hex> <expected_is_equal>
+run_case() {
+  local name="$1" sr="$2" expected="$3" exp_eq="$4"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_account_storage_root_eq_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_account_storage_root_eq_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+sr = bytes.fromhex('$sr')
+expected = bytes.fromhex('$expected')
+account = [42, 10**18, sr, bytes([0xab]*32)]
+account_rlp = rlp.encode(account)
+with open(sys.argv[1], 'wb') as f:
+    f.write(struct.pack('<Q', len(account_rlp)))
+    f.write(expected)
+    f.write(account_rlp)
+    pad = (-(40 + len(account_rlp))) % 8
+    if pad: f.write(b'\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_account_storage_root_eq.elf \
+    -i "$in_file" -o "$out_file" -n 1000000 \
+    >"$REPO_ROOT/gen-out/zisk_account_storage_root_eq_${name}.emu.log" 2>&1 || true
+
+  local actual_status; actual_status="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local actual_eq_le; actual_eq_le="$(dd if="$out_file" bs=1 skip=8 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local actual_eq; actual_eq="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$actual_eq_le'))[0])")"
+
+  if [[ "$actual_status" == "0000000000000000" && "$actual_eq" == "$exp_eq" ]]; then
+    printf "  %-32s OK   is_equal=%d\n" "$name" "$exp_eq"
+    return 0
+  else
+    printf "  %-32s FAIL status=0x%s is_equal=%d expected=%d\n" "$name" "$actual_status" "$actual_eq" "$exp_eq"
+    return 1
+  fi
+}
+
+R1="$(python3 -c "print('aa' * 32)")"
+R2="$(python3 -c "print('bb' * 32)")"
+ETR="56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"
+# One bit flipped at the end
+R1_FLIP="$(python3 -c "print('aa' * 31 + 'ab')")"
+
+FAILED=0
+run_case "match"             "$R1"  "$R1"      1 || FAILED=1
+run_case "match_etr"         "$ETR" "$ETR"     1 || FAILED=1
+run_case "mismatch_diff"     "$R1"  "$R2"      0 || FAILED=1
+run_case "mismatch_flip"     "$R1"  "$R1_FLIP" 0 || FAILED=1
+run_case "match_zero"        "0000000000000000000000000000000000000000000000000000000000000000" "0000000000000000000000000000000000000000000000000000000000000000" 1 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: account_storage_root_eq compares account.storage_root to expected"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Generic equality check on an account's `storage_root` field: does
it equal the 32-byte hash passed in as `expected`?

Used during witness validation to assert that the storage trie
pointed at by an account matches a claimed root (e.g., the pre-
state root in a stateless witness's account proof). The narrower
PR-K133 `account_storage_root_is_empty` is the specialization
where the expected value is `EMPTY_TRIE_ROOT`.

Composes PR-K20 `rlp_list_nth_item`.

**Stacked on PR #5900** (Programs.lean refactor + size guard);
base will retarget to `main` once that lands.

Status:
- `0` : success — predicate written
- `1` : RLP parse failure / field 2 missing
- `2` : field 2 length != 32

## Test plan

- [x] `scripts/codegen-zisk-account-storage-root-eq-check.sh`
  passes 5 fixtures: match against random hash, match against
  `EMPTY_TRIE_ROOT`, two mismatch cases (totally different hash,
  single-byte flip at the tail), and all-zeros match (degenerate
  `storage_root` vs all-zeros expected)
- [x] `lake build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)