### PR TITLE
feat(stateless): account_code_hash_eq (PR-K135)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -1702,6 +1702,110 @@ def ziskAccountValidateCodeHashProbeUnit : BuildUnit := {
   dataAsm     := ziskAccountValidateCodeHashDataSection
 }
 
+/-! ## account_code_hash_eq -- PR-K135
+
+    Generic equality check on an account's `code_hash` field:
+    does it equal the 32-byte hash passed in as `expected`?
+
+    PR-K98 `account_validate_code_hash` *computes* the expected
+    digest from a bytecode buffer; K135 simply *compares* against
+    a caller-supplied digest. Use K98 when the bytecode is known
+    locally and we need an integrity check; use K135 when the
+    expected hash is already in hand (e.g., from a code-DB lookup
+    in a stateless witness, where the bytecode lives elsewhere).
+
+    Companion to PR-K131 `account_has_empty_code` (the specialised
+    EMPTY_CODE_HASH variant) and PR-K134
+    `account_storage_root_eq` (the storage-side equivalent).
+
+    Composes:
+      - PR-K20 `rlp_list_nth_item` — field 3 bounds
+
+    Calling convention:
+      a0 (input)  : account_rlp ptr
+      a1 (input)  : account_rlp byte length
+      a2 (input)  : expected_hash ptr (32 bytes)
+      a3 (input)  : u64 out ptr (1 if equal, 0 if not)
+      ra (input)  : return
+      a0 (output) :
+        0 : success — predicate written
+        1 : RLP parse failure / field 3 missing
+        2 : field 3 length != 32 -/
+def accountCodeHashEqFunction : String :=
+  "account_code_hash_eq:\n" ++
+  "  addi sp, sp, -48\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  mv s0, a0                   # account_ptr\n" ++
+  "  mv s1, a1                   # account_len\n" ++
+  "  mv s2, a2                   # expected_hash ptr\n" ++
+  "  mv s3, a3                   # u64 out ptr\n" ++
+  "  sd zero, 0(s3)\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 3\n" ++
+  "  la a3, ache_offset; la a4, ache_length\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lache_parse_fail\n" ++
+  "  la t0, ache_length; ld t1, 0(t0)\n" ++
+  "  li t2, 32\n" ++
+  "  bne t1, t2, .Lache_size_fail\n" ++
+  "  la t0, ache_offset; ld t3, 0(t0); add t3, s0, t3\n" ++
+  "  ld t5,  0(t3); ld t6,  0(s2); bne t5, t6, .Lache_neq\n" ++
+  "  ld t5,  8(t3); ld t6,  8(s2); bne t5, t6, .Lache_neq\n" ++
+  "  ld t5, 16(t3); ld t6, 16(s2); bne t5, t6, .Lache_neq\n" ++
+  "  ld t5, 24(t3); ld t6, 24(s2); bne t5, t6, .Lache_neq\n" ++
+  "  li t0, 1\n" ++
+  "  sd t0, 0(s3)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lache_ret\n" ++
+  ".Lache_neq:\n" ++
+  "  sd zero, 0(s3)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lache_ret\n" ++
+  ".Lache_parse_fail:\n" ++
+  "  li a0, 1\n" ++
+  "  j .Lache_ret\n" ++
+  ".Lache_size_fail:\n" ++
+  "  li a0, 2\n" ++
+  ".Lache_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  addi sp, sp, 48\n" ++
+  "  ret"
+
+/-- `zisk_account_code_hash_eq`: probe BuildUnit.
+    Input layout:
+      bytes  0.. 8 : account_rlp_len
+      bytes  8..40 : expected_hash (32 bytes)
+      bytes 40..   : account_rlp -/
+def ziskAccountCodeHashEqPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a4, 0x40000000\n" ++
+  "  ld a1, 8(a4)                # account_rlp_len\n" ++
+  "  addi a2, a4, 16             # expected_hash ptr\n" ++
+  "  addi a0, a4, 48             # account_rlp ptr\n" ++
+  "  li a3, 0xa0010008           # is_equal out\n" ++
+  "  jal ra, account_code_hash_eq\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lache_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  accountCodeHashEqFunction ++ "\n" ++
+  ".Lache_pdone:"
+
+def ziskAccountCodeHashEqDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "ache_offset:\n" ++
+  "  .zero 8\n" ++
+  "ache_length:\n" ++
+  "  .zero 8"
+
+def ziskAccountCodeHashEqProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskAccountCodeHashEqPrologue
+  dataAsm     := ziskAccountCodeHashEqDataSection
+}
+
 /-! ## account_extract_storage_root -- PR-K119
 
     Extract the 32-byte `storage_root` field (RLP field 2) from a
@@ -1805,124 +1909,9 @@ def ziskAccountExtractStorageRootProbeUnit : BuildUnit := {
   dataAsm     := ziskAccountExtractStorageRootDataSection
 }
 
-/-! ## rlp_list_count_items -- PR-K47 top-level item counter
-
-    Walk an RLP-encoded list once and return the number of
-    top-level items it contains. Building block for callers
-    that need cardinality but not the items themselves:
-    `access_list_count`, `authorization_list_count`,
-    `blob_versioned_hashes_count`, `tx_count_per_block`.
-
-    Mirrors the item-skip logic in PR-K20 `rlp_list_nth_item`
-    but doesn't track a target index; counts every item it
-    can walk past until the list payload ends.
-
-    Calling convention:
-      a0 (input)  : list bytes ptr (start of outer RLP list
-                    prefix, byte 0xc0..0xff)
-      a1 (input)  : total list byte length (full encoded item
-                    incl. prefix)
-      a2 (input)  : u64 out ptr (receives count on success)
-      ra (input)  : return
-      a0 (output) : 0 on success, 1 on parse error
-                    (not a list, truncated, item runs past end)
-
-    Pure register arithmetic except for the count store; no
-    scratch memory; leaf-callable. -/
-def rlpListCountItemsFunction : String :=
-  "rlp_list_count_items:\n" ++
-  "  beqz a1, .Lrlc_fail        # empty input cannot encode a list\n" ++
-  "  lbu t0, 0(a0)\n" ++
-  "  li t1, 0xc0\n" ++
-  "  bltu t0, t1, .Lrlc_fail    # not an RLP list\n" ++
-  "  li t1, 0xf8\n" ++
-  "  bltu t0, t1, .Lrlc_short_outer\n" ++
-  "  # Long outer list: prefix bytes = 1 + (t0 - 0xf7)\n" ++
-  "  li t1, 0xf7\n" ++
-  "  sub t2, t0, t1             # lol\n" ++
-  "  addi t2, t2, 1             # total prefix bytes\n" ++
-  "  add t3, a0, t2             # cursor at first item\n" ++
-  "  j .Lrlc_walk\n" ++
-  ".Lrlc_short_outer:\n" ++
-  "  addi t3, a0, 1\n" ++
-  ".Lrlc_walk:\n" ++
-  "  add t4, a0, a1             # end-of-list cursor (exclusive)\n" ++
-  "  li t5, 0                   # count\n" ++
-  ".Lrlc_loop:\n" ++
-  "  beq t3, t4, .Lrlc_done\n" ++
-  "  bgtu t3, t4, .Lrlc_fail    # cursor walked past end → malformed\n" ++
-  "  lbu t0, 0(t3)\n" ++
-  "  li t1, 0x80\n" ++
-  "  bltu t0, t1, .Lrlc_skip_single\n" ++
-  "  li t1, 0xb8\n" ++
-  "  bltu t0, t1, .Lrlc_skip_short_str\n" ++
-  "  li t1, 0xc0\n" ++
-  "  bltu t0, t1, .Lrlc_skip_long_str\n" ++
-  "  li t1, 0xf8\n" ++
-  "  bltu t0, t1, .Lrlc_skip_short_list\n" ++
-  "  # Long list at t3: lol = t0 - 0xf7\n" ++
-  "  li t1, 0xf7\n" ++
-  "  sub t2, t0, t1             # lol\n" ++
-  "  li a3, 0                   # decoded length accumulator\n" ++
-  "  mv a4, t2                  # remaining length bytes\n" ++
-  "  addi a5, t3, 1\n" ++
-  ".Lrlc_skll_be:\n" ++
-  "  beqz a4, .Lrlc_skll_done\n" ++
-  "  slli a3, a3, 8\n" ++
-  "  lbu a6, 0(a5)\n" ++
-  "  or  a3, a3, a6\n" ++
-  "  addi a5, a5, 1\n" ++
-  "  addi a4, a4, -1\n" ++
-  "  j .Lrlc_skll_be\n" ++
-  ".Lrlc_skll_done:\n" ++
-  "  addi a6, t2, 1\n" ++
-  "  add  a6, a6, a3            # 1 + lol + decoded\n" ++
-  "  add  t3, t3, a6\n" ++
-  "  j .Lrlc_step\n" ++
-  ".Lrlc_skip_short_list:\n" ++
-  "  li t1, 0xc0\n" ++
-  "  sub a6, t0, t1\n" ++
-  "  addi a6, a6, 1             # 1 + (t0 - 0xc0)\n" ++
-  "  add  t3, t3, a6\n" ++
-  "  j .Lrlc_step\n" ++
-  ".Lrlc_skip_long_str:\n" ++
-  "  li t1, 0xb7\n" ++
-  "  sub t2, t0, t1             # lol\n" ++
-  "  li a3, 0\n" ++
-  "  mv a4, t2\n" ++
-  "  addi a5, t3, 1\n" ++
-  ".Lrlc_skls_be:\n" ++
-  "  beqz a4, .Lrlc_skls_done\n" ++
-  "  slli a3, a3, 8\n" ++
-  "  lbu a6, 0(a5)\n" ++
-  "  or  a3, a3, a6\n" ++
-  "  addi a5, a5, 1\n" ++
-  "  addi a4, a4, -1\n" ++
-  "  j .Lrlc_skls_be\n" ++
-  ".Lrlc_skls_done:\n" ++
-  "  addi a6, t2, 1\n" ++
-  "  add  a6, a6, a3\n" ++
-  "  add  t3, t3, a6\n" ++
-  "  j .Lrlc_step\n" ++
-  ".Lrlc_skip_short_str:\n" ++
-  "  li t1, 0x80\n" ++
-  "  sub a6, t0, t1\n" ++
-  "  addi a6, a6, 1\n" ++
-  "  add  t3, t3, a6\n" ++
-  "  j .Lrlc_step\n" ++
-  ".Lrlc_skip_single:\n" ++
-  "  addi t3, t3, 1\n" ++
-  ".Lrlc_step:\n" ++
-  "  addi t5, t5, 1\n" ++
-  "  j .Lrlc_loop\n" ++
-  ".Lrlc_done:\n" ++
-  "  sd t5, 0(a2)\n" ++
-  "  li a0, 0\n" ++
-  "  ret\n" ++
-  ".Lrlc_fail:\n" ++
-  "  sd zero, 0(a2)\n" ++
-  "  li a0, 1\n" ++
-  "  ret"
+/-! ## rlp_list_count_items -- PR-K47
+    The function body now lives in `EvmAsm/Codegen/Programs/RlpRead.lean`
+    (see PR #5900). Only the zisk probe BuildUnit remains here. -/
 
 /-- `zisk_rlp_list_count_items`: probe BuildUnit. Reads
     (list_len, list_bytes) from host input, writes
@@ -12514,6 +12503,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_header_validate_parent_hash" => some ziskHeaderValidateParentHashProbeUnit
   | "zisk_header_chain_walk_step" => some ziskHeaderChainWalkStepProbeUnit
   | "zisk_account_validate_code_hash" => some ziskAccountValidateCodeHashProbeUnit
+  | "zisk_account_code_hash_eq" => some ziskAccountCodeHashEqProbeUnit
   | "zisk_account_extract_storage_root" => some ziskAccountExtractStorageRootProbeUnit
   | "zisk_address_from_pubkey"  => some ziskAddressFromPubkeyProbeUnit
   | "zisk_mpt_account_path_nibbles" => some ziskMptAccountPathNibblesProbeUnit
@@ -12646,6 +12636,7 @@ def knownProgramNames : List String :=
    "zisk_header_validate_parent_hash",
    "zisk_header_chain_walk_step",
    "zisk_account_validate_code_hash",
+   "zisk_account_code_hash_eq",
    "zisk_account_extract_storage_root",
    "zisk_address_from_pubkey",
    "zisk_mpt_account_path_nibbles",

--- a/scripts/codegen-zisk-account-code-hash-eq-check.sh
+++ b/scripts/codegen-zisk-account-code-hash-eq-check.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# codegen-zisk-account-code-hash-eq-check.sh -- PR-K135.
+#
+# Compare account.code_hash against an expected 32-byte hash.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_account_code_hash_eq ELF"
+lake exe codegen --program zisk_account_code_hash_eq --halt linux93 \
+  -o gen-out/zisk_account_code_hash_eq
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <code_hash_hex> <expected_hex> <expected_is_equal>
+run_case() {
+  local name="$1" ch="$2" expected="$3" exp_eq="$4"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_account_code_hash_eq_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_account_code_hash_eq_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+ch = bytes.fromhex('$ch')
+expected = bytes.fromhex('$expected')
+# Fix storage_root to EMPTY_TRIE_ROOT; vary code_hash field.
+EMPTY_TRIE_ROOT = bytes.fromhex(
+    '56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421')
+account = [42, 10**18, EMPTY_TRIE_ROOT, ch]
+account_rlp = rlp.encode(account)
+with open(sys.argv[1], 'wb') as f:
+    f.write(struct.pack('<Q', len(account_rlp)))
+    f.write(expected)
+    f.write(account_rlp)
+    pad = (-(40 + len(account_rlp))) % 8
+    if pad: f.write(b'\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_account_code_hash_eq.elf \
+    -i "$in_file" -o "$out_file" -n 1000000 \
+    >"$REPO_ROOT/gen-out/zisk_account_code_hash_eq_${name}.emu.log" 2>&1 || true
+
+  local actual_status; actual_status="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local actual_eq_le; actual_eq_le="$(dd if="$out_file" bs=1 skip=8 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local actual_eq; actual_eq="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$actual_eq_le'))[0])")"
+
+  if [[ "$actual_status" == "0000000000000000" && "$actual_eq" == "$exp_eq" ]]; then
+    printf "  %-32s OK   is_equal=%d\n" "$name" "$exp_eq"
+    return 0
+  else
+    printf "  %-32s FAIL status=0x%s is_equal=%d expected=%d\n" "$name" "$actual_status" "$actual_eq" "$exp_eq"
+    return 1
+  fi
+}
+
+R1="$(python3 -c "print('aa' * 32)")"
+R2="$(python3 -c "print('bb' * 32)")"
+ECH="c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"
+# One bit flipped at the end
+R1_FLIP="$(python3 -c "print('aa' * 31 + 'ab')")"
+
+FAILED=0
+run_case "match"             "$R1"  "$R1"      1 || FAILED=1
+run_case "match_ech"         "$ECH" "$ECH"     1 || FAILED=1
+run_case "mismatch_diff"     "$R1"  "$R2"      0 || FAILED=1
+run_case "mismatch_flip"     "$R1"  "$R1_FLIP" 0 || FAILED=1
+run_case "match_zero"        "0000000000000000000000000000000000000000000000000000000000000000" "0000000000000000000000000000000000000000000000000000000000000000" 1 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: account_code_hash_eq compares account.code_hash to expected"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- `account_code_hash_eq`: generic 32-byte equality check on an account's `code_hash` field.
- Companion to PR-K131 `account_has_empty_code` (specialised to `EMPTY_CODE_HASH`) and PR-K134 `account_storage_root_eq` (storage-side equivalent).
- Distinct from PR-K98 `account_validate_code_hash` (which *computes* the digest from bytecode); K135 just *compares* against a caller-supplied digest.
- Side cleanup: removed a duplicate `rlpListCountItemsFunction` def in `Programs.lean` that re-appeared after the K119 merge into this refactor branch (canonical copy lives in `Programs/RlpRead.lean` per #5900).

### Calling convention

| reg | role |
|---|---|
| a0 | account_rlp ptr |
| a1 | account_rlp byte length |
| a2 | expected_hash ptr (32 bytes) |
| a3 | u64 out (is_equal predicate) |
| a0 (out) | 0 = ok, 1 = RLP parse fail, 2 = size != 32 |

Composes `rlp_list_nth_item` (PR-K20) for the field-3 bounds.

### Why it's needed

In a stateless witness, the executor receives the contract bytecode separately from the account record. The code DB key is `keccak256(bytecode)`; verifying that the account's `code_hash` field matches that key is what binds the witness-supplied bytecode to the on-chain account. K135 is exactly that comparison.

## Stacking

Base = `refactor/split-programs-mpt-and-rlp` (PR #5900); GitHub will auto-retarget to `main` once #5900 merges.

## Test plan

- [x] `lake build` clean
- [x] `scripts/codegen-zisk-account-code-hash-eq-check.sh` — 5/5 fixtures pass:
  - `match` random hashes match
  - `match_ech` both = EMPTY_CODE_HASH
  - `mismatch_diff` disjoint hashes
  - `mismatch_flip` single-byte tail flip
  - `match_zero` both = 0x00...

🤖 Generated with [Claude Code](https://claude.com/claude-code)