### PR TITLE
feat(stateless): account_is_eip161_empty (PR-K137)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -1702,6 +1702,171 @@ def ziskAccountValidateCodeHashProbeUnit : BuildUnit := {
   dataAsm     := ziskAccountValidateCodeHashDataSection
 }
 
+/-! ## account_is_eip161_empty -- PR-K137
+
+    EIP-161 empty-account predicate:
+
+      is_empty ⇐ nonce == 0
+              ∧  balance == 0
+              ∧  code_hash == EMPTY_CODE_HASH
+
+    where
+
+      EMPTY_CODE_HASH =
+        0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470
+
+    Drives EIP-161 deletion: an account that satisfies this
+    predicate after a transaction is removed from the state trie
+    (i.e., its slot in the state MPT is deleted, not retained
+    with a zero-balance leaf). Also used by:
+      * SELFDESTRUCT recipient handling (re-creation of an empty
+        beneficiary)
+      * fee-charging paths in apply_body that decide whether the
+        sender account becomes empty post-tx and so must be
+        removed from the trie.
+
+    Strict reading of the EIP-161 spec compares Uint values, not
+    RLP-canonical byte patterns. We therefore accept both
+    canonical empty-byte and non-canonical zero-byte encodings:
+      * nonce: length ≤ 8, BE-decoded value == 0
+      * balance: length ≤ 32, all bytes == 0 (cheaper than full
+        32-byte decode + compare)
+      * code_hash: length == 32, bytes match EMPTY_CODE_HASH
+
+    Companions:
+      - PR-K131 `account_has_empty_code` (only the code_hash side)
+      - PR-K133 `account_storage_root_is_empty`
+      - PR-K136 `account_nonce_eq` (specialised to expected==0
+        when caller knows the strict predicate)
+
+    Composes:
+      - PR-K20 `rlp_list_nth_item` — field 0/1/3 bounds
+
+    Calling convention:
+      a0 (input)  : account_rlp ptr
+      a1 (input)  : account_rlp byte length
+      a2 (input)  : u64 out ptr (1 if empty, 0 if not)
+      ra (input)  : return
+      a0 (output) :
+        0 : success — predicate written
+        1 : RLP parse failure / nonce > 8 bytes / balance > 32 bytes
+        2 : code_hash field length != 32 -/
+def accountIsEip161EmptyFunction : String :=
+  "account_is_eip161_empty:\n" ++
+  "  addi sp, sp, -40\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp)\n" ++
+  "  mv s0, a0                   # account_ptr\n" ++
+  "  mv s1, a1                   # account_len\n" ++
+  "  mv s2, a2                   # is_empty out\n" ++
+  "  sd zero, 0(s2)\n" ++
+  "  # ---- Field 0: nonce ---- BE-decode and check == 0\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 0\n" ++
+  "  la a3, aie_offset; la a4, aie_length\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Laie_fail\n" ++
+  "  la t0, aie_length; ld t1, 0(t0)\n" ++
+  "  li t2, 8\n" ++
+  "  bgtu t1, t2, .Laie_fail      # nonce > 8 bytes\n" ++
+  "  la t0, aie_offset; ld t3, 0(t0); add t3, s0, t3\n" ++
+  "  li t2, 0\n" ++
+  ".Laie_nloop:\n" ++
+  "  beqz t1, .Laie_ndone\n" ++
+  "  slli t2, t2, 8\n" ++
+  "  lbu t4, 0(t3)\n" ++
+  "  or t2, t2, t4\n" ++
+  "  addi t3, t3, 1\n" ++
+  "  addi t1, t1, -1\n" ++
+  "  j .Laie_nloop\n" ++
+  ".Laie_ndone:\n" ++
+  "  bnez t2, .Laie_not_empty     # nonce != 0\n" ++
+  "  # ---- Field 1: balance ---- check all bytes == 0\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 1\n" ++
+  "  la a3, aie_offset; la a4, aie_length\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Laie_fail\n" ++
+  "  la t0, aie_length; ld t1, 0(t0)\n" ++
+  "  li t2, 32\n" ++
+  "  bgtu t1, t2, .Laie_fail      # balance > 32 bytes\n" ++
+  "  la t0, aie_offset; ld t3, 0(t0); add t3, s0, t3\n" ++
+  ".Laie_bloop:\n" ++
+  "  beqz t1, .Laie_bdone\n" ++
+  "  lbu t4, 0(t3)\n" ++
+  "  bnez t4, .Laie_not_empty     # balance non-zero byte\n" ++
+  "  addi t3, t3, 1\n" ++
+  "  addi t1, t1, -1\n" ++
+  "  j .Laie_bloop\n" ++
+  ".Laie_bdone:\n" ++
+  "  # ---- Field 3: code_hash ---- length == 32 and bytes match\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 3\n" ++
+  "  la a3, aie_offset; la a4, aie_length\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Laie_fail\n" ++
+  "  la t0, aie_length; ld t1, 0(t0)\n" ++
+  "  li t2, 32\n" ++
+  "  bne t1, t2, .Laie_sizefail\n" ++
+  "  la t0, aie_offset; ld t3, 0(t0); add t3, s0, t3\n" ++
+  "  la t6, aie_empty_code_hash\n" ++
+  "  ld t5,  0(t3); ld t4,  0(t6); bne t5, t4, .Laie_not_empty\n" ++
+  "  ld t5,  8(t3); ld t4,  8(t6); bne t5, t4, .Laie_not_empty\n" ++
+  "  ld t5, 16(t3); ld t4, 16(t6); bne t5, t4, .Laie_not_empty\n" ++
+  "  ld t5, 24(t3); ld t4, 24(t6); bne t5, t4, .Laie_not_empty\n" ++
+  "  li t0, 1\n" ++
+  "  sd t0, 0(s2)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Laie_ret\n" ++
+  ".Laie_not_empty:\n" ++
+  "  sd zero, 0(s2)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Laie_ret\n" ++
+  ".Laie_fail:\n" ++
+  "  li a0, 1\n" ++
+  "  j .Laie_ret\n" ++
+  ".Laie_sizefail:\n" ++
+  "  li a0, 2\n" ++
+  ".Laie_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp)\n" ++
+  "  addi sp, sp, 40\n" ++
+  "  ret"
+
+/-- `zisk_account_is_eip161_empty`: probe BuildUnit.
+    Input layout:
+      bytes  0.. 8 : account_rlp_len
+      bytes  8..   : account_rlp -/
+def ziskAccountIsEip161EmptyPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a4, 0x40000000\n" ++
+  "  ld a1, 8(a4)                # account_rlp_len\n" ++
+  "  addi a0, a4, 16             # account_rlp ptr\n" ++
+  "  li a2, 0xa0010008           # is_empty out\n" ++
+  "  jal ra, account_is_eip161_empty\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Laie_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  accountIsEip161EmptyFunction ++ "\n" ++
+  ".Laie_pdone:"
+
+def ziskAccountIsEip161EmptyDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "aie_offset:\n" ++
+  "  .zero 8\n" ++
+  "aie_length:\n" ++
+  "  .zero 8\n" ++
+  "aie_empty_code_hash:\n" ++
+  "  .byte 0xc5,0xd2,0x46,0x01,0x86,0xf7,0x23,0x3c\n" ++
+  "  .byte 0x92,0x7e,0x7d,0xb2,0xdc,0xc7,0x03,0xc0\n" ++
+  "  .byte 0xe5,0x00,0xb6,0x53,0xca,0x82,0x27,0x3b\n" ++
+  "  .byte 0x7b,0xfa,0xd8,0x04,0x5d,0x85,0xa4,0x70"
+
+def ziskAccountIsEip161EmptyProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskAccountIsEip161EmptyPrologue
+  dataAsm     := ziskAccountIsEip161EmptyDataSection
+}
+
 /-! ## account_extract_storage_root -- PR-K119
 
     Extract the 32-byte `storage_root` field (RLP field 2) from a
@@ -1805,124 +1970,9 @@ def ziskAccountExtractStorageRootProbeUnit : BuildUnit := {
   dataAsm     := ziskAccountExtractStorageRootDataSection
 }
 
-/-! ## rlp_list_count_items -- PR-K47 top-level item counter
-
-    Walk an RLP-encoded list once and return the number of
-    top-level items it contains. Building block for callers
-    that need cardinality but not the items themselves:
-    `access_list_count`, `authorization_list_count`,
-    `blob_versioned_hashes_count`, `tx_count_per_block`.
-
-    Mirrors the item-skip logic in PR-K20 `rlp_list_nth_item`
-    but doesn't track a target index; counts every item it
-    can walk past until the list payload ends.
-
-    Calling convention:
-      a0 (input)  : list bytes ptr (start of outer RLP list
-                    prefix, byte 0xc0..0xff)
-      a1 (input)  : total list byte length (full encoded item
-                    incl. prefix)
-      a2 (input)  : u64 out ptr (receives count on success)
-      ra (input)  : return
-      a0 (output) : 0 on success, 1 on parse error
-                    (not a list, truncated, item runs past end)
-
-    Pure register arithmetic except for the count store; no
-    scratch memory; leaf-callable. -/
-def rlpListCountItemsFunction : String :=
-  "rlp_list_count_items:\n" ++
-  "  beqz a1, .Lrlc_fail        # empty input cannot encode a list\n" ++
-  "  lbu t0, 0(a0)\n" ++
-  "  li t1, 0xc0\n" ++
-  "  bltu t0, t1, .Lrlc_fail    # not an RLP list\n" ++
-  "  li t1, 0xf8\n" ++
-  "  bltu t0, t1, .Lrlc_short_outer\n" ++
-  "  # Long outer list: prefix bytes = 1 + (t0 - 0xf7)\n" ++
-  "  li t1, 0xf7\n" ++
-  "  sub t2, t0, t1             # lol\n" ++
-  "  addi t2, t2, 1             # total prefix bytes\n" ++
-  "  add t3, a0, t2             # cursor at first item\n" ++
-  "  j .Lrlc_walk\n" ++
-  ".Lrlc_short_outer:\n" ++
-  "  addi t3, a0, 1\n" ++
-  ".Lrlc_walk:\n" ++
-  "  add t4, a0, a1             # end-of-list cursor (exclusive)\n" ++
-  "  li t5, 0                   # count\n" ++
-  ".Lrlc_loop:\n" ++
-  "  beq t3, t4, .Lrlc_done\n" ++
-  "  bgtu t3, t4, .Lrlc_fail    # cursor walked past end → malformed\n" ++
-  "  lbu t0, 0(t3)\n" ++
-  "  li t1, 0x80\n" ++
-  "  bltu t0, t1, .Lrlc_skip_single\n" ++
-  "  li t1, 0xb8\n" ++
-  "  bltu t0, t1, .Lrlc_skip_short_str\n" ++
-  "  li t1, 0xc0\n" ++
-  "  bltu t0, t1, .Lrlc_skip_long_str\n" ++
-  "  li t1, 0xf8\n" ++
-  "  bltu t0, t1, .Lrlc_skip_short_list\n" ++
-  "  # Long list at t3: lol = t0 - 0xf7\n" ++
-  "  li t1, 0xf7\n" ++
-  "  sub t2, t0, t1             # lol\n" ++
-  "  li a3, 0                   # decoded length accumulator\n" ++
-  "  mv a4, t2                  # remaining length bytes\n" ++
-  "  addi a5, t3, 1\n" ++
-  ".Lrlc_skll_be:\n" ++
-  "  beqz a4, .Lrlc_skll_done\n" ++
-  "  slli a3, a3, 8\n" ++
-  "  lbu a6, 0(a5)\n" ++
-  "  or  a3, a3, a6\n" ++
-  "  addi a5, a5, 1\n" ++
-  "  addi a4, a4, -1\n" ++
-  "  j .Lrlc_skll_be\n" ++
-  ".Lrlc_skll_done:\n" ++
-  "  addi a6, t2, 1\n" ++
-  "  add  a6, a6, a3            # 1 + lol + decoded\n" ++
-  "  add  t3, t3, a6\n" ++
-  "  j .Lrlc_step\n" ++
-  ".Lrlc_skip_short_list:\n" ++
-  "  li t1, 0xc0\n" ++
-  "  sub a6, t0, t1\n" ++
-  "  addi a6, a6, 1             # 1 + (t0 - 0xc0)\n" ++
-  "  add  t3, t3, a6\n" ++
-  "  j .Lrlc_step\n" ++
-  ".Lrlc_skip_long_str:\n" ++
-  "  li t1, 0xb7\n" ++
-  "  sub t2, t0, t1             # lol\n" ++
-  "  li a3, 0\n" ++
-  "  mv a4, t2\n" ++
-  "  addi a5, t3, 1\n" ++
-  ".Lrlc_skls_be:\n" ++
-  "  beqz a4, .Lrlc_skls_done\n" ++
-  "  slli a3, a3, 8\n" ++
-  "  lbu a6, 0(a5)\n" ++
-  "  or  a3, a3, a6\n" ++
-  "  addi a5, a5, 1\n" ++
-  "  addi a4, a4, -1\n" ++
-  "  j .Lrlc_skls_be\n" ++
-  ".Lrlc_skls_done:\n" ++
-  "  addi a6, t2, 1\n" ++
-  "  add  a6, a6, a3\n" ++
-  "  add  t3, t3, a6\n" ++
-  "  j .Lrlc_step\n" ++
-  ".Lrlc_skip_short_str:\n" ++
-  "  li t1, 0x80\n" ++
-  "  sub a6, t0, t1\n" ++
-  "  addi a6, a6, 1\n" ++
-  "  add  t3, t3, a6\n" ++
-  "  j .Lrlc_step\n" ++
-  ".Lrlc_skip_single:\n" ++
-  "  addi t3, t3, 1\n" ++
-  ".Lrlc_step:\n" ++
-  "  addi t5, t5, 1\n" ++
-  "  j .Lrlc_loop\n" ++
-  ".Lrlc_done:\n" ++
-  "  sd t5, 0(a2)\n" ++
-  "  li a0, 0\n" ++
-  "  ret\n" ++
-  ".Lrlc_fail:\n" ++
-  "  sd zero, 0(a2)\n" ++
-  "  li a0, 1\n" ++
-  "  ret"
+/-! ## rlp_list_count_items -- PR-K47
+    The function body now lives in `EvmAsm/Codegen/Programs/RlpRead.lean`
+    (see PR #5900). Only the zisk probe BuildUnit remains here. -/
 
 /-- `zisk_rlp_list_count_items`: probe BuildUnit. Reads
     (list_len, list_bytes) from host input, writes
@@ -12514,6 +12564,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_header_validate_parent_hash" => some ziskHeaderValidateParentHashProbeUnit
   | "zisk_header_chain_walk_step" => some ziskHeaderChainWalkStepProbeUnit
   | "zisk_account_validate_code_hash" => some ziskAccountValidateCodeHashProbeUnit
+  | "zisk_account_is_eip161_empty" => some ziskAccountIsEip161EmptyProbeUnit
   | "zisk_account_extract_storage_root" => some ziskAccountExtractStorageRootProbeUnit
   | "zisk_address_from_pubkey"  => some ziskAddressFromPubkeyProbeUnit
   | "zisk_mpt_account_path_nibbles" => some ziskMptAccountPathNibblesProbeUnit
@@ -12646,6 +12697,7 @@ def knownProgramNames : List String :=
    "zisk_header_validate_parent_hash",
    "zisk_header_chain_walk_step",
    "zisk_account_validate_code_hash",
+   "zisk_account_is_eip161_empty",
    "zisk_account_extract_storage_root",
    "zisk_address_from_pubkey",
    "zisk_mpt_account_path_nibbles",

--- a/scripts/codegen-zisk-account-is-eip161-empty-check.sh
+++ b/scripts/codegen-zisk-account-is-eip161-empty-check.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# codegen-zisk-account-is-eip161-empty-check.sh -- PR-K137.
+#
+# EIP-161 empty-account predicate:
+#   nonce == 0 AND balance == 0 AND code_hash == EMPTY_CODE_HASH.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_account_is_eip161_empty ELF"
+lake exe codegen --program zisk_account_is_eip161_empty --halt linux93 \
+  -o gen-out/zisk_account_is_eip161_empty
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <nonce> <balance> <code_hash_hex> <expected_is_empty>
+run_case() {
+  local name="$1" nonce="$2" balance="$3" ch="$4" exp="$5"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_account_is_eip161_empty_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_account_is_eip161_empty_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+EMPTY_TRIE_ROOT = bytes.fromhex(
+    '56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421')
+nonce = $nonce
+balance = $balance
+ch = bytes.fromhex('$ch')
+account = [nonce, balance, EMPTY_TRIE_ROOT, ch]
+account_rlp = rlp.encode(account)
+with open(sys.argv[1], 'wb') as f:
+    f.write(struct.pack('<Q', len(account_rlp)))
+    f.write(account_rlp)
+    pad = (-(8 + len(account_rlp))) % 8
+    if pad: f.write(b'\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_account_is_eip161_empty.elf \
+    -i "$in_file" -o "$out_file" -n 1000000 \
+    >"$REPO_ROOT/gen-out/zisk_account_is_eip161_empty_${name}.emu.log" 2>&1 || true
+
+  local actual_status; actual_status="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local actual_eq_le; actual_eq_le="$(dd if="$out_file" bs=1 skip=8 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local actual_eq; actual_eq="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$actual_eq_le'))[0])")"
+
+  if [[ "$actual_status" == "0000000000000000" && "$actual_eq" == "$exp" ]]; then
+    printf "  %-30s OK   nonce=%d bal=%d is_empty=%d\n" "$name" "$nonce" "$balance" "$exp"
+    return 0
+  else
+    printf "  %-30s FAIL status=0x%s is_empty=%d expected=%d\n" "$name" "$actual_status" "$actual_eq" "$exp"
+    return 1
+  fi
+}
+
+ECH="c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"
+OCH="aa$(python3 -c "print('00' * 31)")"
+
+FAILED=0
+# Positive cases: should be empty
+run_case "empty_minimal"   0 0          "$ECH" 1 || FAILED=1
+
+# Negative cases: any one field non-empty
+run_case "neg_nonce"       1 0          "$ECH" 0 || FAILED=1
+run_case "neg_big_nonce"   1000000 0    "$ECH" 0 || FAILED=1
+run_case "neg_balance"     0 1          "$ECH" 0 || FAILED=1
+run_case "neg_big_balance" 0 1000000000000000000 "$ECH" 0 || FAILED=1
+run_case "neg_max_balance" 0 $((2**63 - 1)) "$ECH" 0 || FAILED=1
+run_case "neg_codehash"    0 0          "$OCH"   0 || FAILED=1
+run_case "neg_all_fields"  42 999       "$OCH"   0 || FAILED=1
+
+# Zero-byte boundary: balance = 0 has b'' in RLP (length 0); confirm canonical path.
+# Non-canonical encodings (length>0, value 0) shouldn't occur in real state but the
+# byte-loop is robust anyway.
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: account_is_eip161_empty matches EIP-161 spec"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- `account_is_eip161_empty`: EIP-161 empty-account predicate. Computes `nonce == 0 ∧ balance == 0 ∧ code_hash == EMPTY_CODE_HASH` in one pass over the account RLP.
- Drives EIP-161 deletion: any account that satisfies the predicate after a transaction is removed from the state trie, not retained with a zero-balance leaf. Also used by SELFDESTRUCT recipient handling and post-tx fee-charging cleanup.
- Companion to PR-K131 `account_has_empty_code` (only the code_hash side), PR-K133 `account_storage_root_is_empty`, PR-K136 `account_nonce_eq` (specialised to expected==0).
- Side cleanup: removed a duplicate `rlpListCountItemsFunction` def that re-appeared in `Programs.lean` after the K119 merge into this refactor branch (canonical copy lives in `Programs/RlpRead.lean` per #5900). Same cleanup lands in PR-K135 / PR-K136.

### Spec interpretation

Strict reading of EIP-161 compares Uint values, not RLP-canonical byte patterns. The implementation therefore accepts both canonical empty-byte and non-canonical zero-byte encodings:
- nonce: length ≤ 8, BE-decoded value == 0
- balance: length ≤ 32, all bytes == 0 (cheaper than full 32-byte decode + compare)
- code_hash: length == 32, bytes match EMPTY_CODE_HASH

### Calling convention

| reg | role |
|---|---|
| a0 | account_rlp ptr |
| a1 | account_rlp byte length |
| a2 | u64 out (is_empty predicate) |
| a0 (out) | 0 = ok, 1 = parse fail, 2 = code_hash size != 32 |

Composes `rlp_list_nth_item` (PR-K20) on fields 0, 1, 3.

## Stacking

Base = `refactor/split-programs-mpt-and-rlp` (PR #5900); GitHub will auto-retarget to `main` once #5900 merges.

## Test plan

- [x] `lake build` clean
- [x] `scripts/codegen-zisk-account-is-eip161-empty-check.sh` — 8/8 fixtures pass:
  - `empty_minimal`: nonce=0, balance=0, EMPTY_CODE_HASH → empty
  - `neg_nonce`, `neg_big_nonce`: only nonce non-zero
  - `neg_balance`, `neg_big_balance`, `neg_max_balance`: only balance non-zero
  - `neg_codehash`: only code_hash != EMPTY_CODE_HASH
  - `neg_all_fields`: every field set

🤖 Generated with [Claude Code](https://claude.com/claude-code)