### PR TITLE
feat(divmod): add word-level NormU/NormV val256 conservation wrappers

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N3RemainderWordV4.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3RemainderWordV4.lean
@@ -482,6 +482,32 @@ theorem fullDivN3NormU_val256_eq_scaled_with_overflow
   delta fullDivN3NormU fullDivN3Shift fullDivN3AntiShift at hshift_nz ⊢
   exact u_val256_eq_scaled_with_overflow a0 a1 a2 a3 b2 hshift_nz
 
+theorem fullDivN3NormU_val256_eq_scaled_with_overflow_word
+    (a b : EvmWord)
+    (hshift_nz : fullDivN3Shift (b.getLimbN 2) ≠ 0) :
+    EvmWord.val256
+        (fullDivN3NormU
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 2)).1
+        (fullDivN3NormU
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 2)).2.1
+        (fullDivN3NormU
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 2)).2.2.1
+        (fullDivN3NormU
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 2)).2.2.2.1 +
+      (fullDivN3NormU
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 2)).2.2.2.2.toNat * 2 ^ 256 =
+    EvmWord.val256
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3) *
+      2 ^ (fullDivN3Shift (b.getLimbN 2)).toNat :=
+  fullDivN3NormU_val256_eq_scaled_with_overflow
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+    (b.getLimbN 2) hshift_nz
+
 theorem fullDivN3NormV_val256_eq_scaled_of_b3_zero
     (b0 b1 b2 b3 : Word)
     (hshift_nz : fullDivN3Shift b2 ≠ 0)
@@ -508,6 +534,26 @@ theorem fullDivN3NormV_val256_eq_scaled_of_b3_zero
   dsimp only
   rw [fullDivN3Shift_toNat_mod_eq, hanti]
   exact EvmWord.val256_normalize hs0 hs b0 b1 b2 b3 hb3_bound
+
+theorem fullDivN3NormV_val256_eq_scaled_of_b3_zero_word
+    (b : EvmWord)
+    (hshift_nz : fullDivN3Shift (b.getLimbN 2) ≠ 0)
+    (hb3z : b.getLimbN 3 = 0) :
+    EvmWord.val256
+        (fullDivN3NormV
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1
+        (fullDivN3NormV
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.1
+        (fullDivN3NormV
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+        (fullDivN3NormV
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2 =
+    EvmWord.val256
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) *
+      2 ^ (fullDivN3Shift (b.getLimbN 2)).toNat :=
+  fullDivN3NormV_val256_eq_scaled_of_b3_zero
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+    hshift_nz hb3z
 
 private theorem limbs_or_ne_zero_of_val256_pos
     {b0 b1 b2 b3 : Word}


### PR DESCRIPTION
## Summary
- Add `fullDivN3NormU_val256_eq_scaled_with_overflow_word`: EvmWord-level form of the NormU val256 conservation equation (`val256(normU.limbs) + overflow * 2^256 = val256(a) * 2^shift`)
- Add `fullDivN3NormV_val256_eq_scaled_of_b3_zero_word`: EvmWord-level form of the NormV val256 scaling equation (`val256(normV.limbs) = val256(b) * 2^shift` when b3=0)

These word-level wrappers package the existing limb-level normalization bridges in terms of `EvmWord.getLimbN` projections, completing the N3 v4 normalized conservation toolkit for downstream EvmWord-level proofs.

Refs #61 (DIV/MOD stack spec). Bead: evm-asm-44xrc.1.

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.N3RemainderWordV4
- lake build EvmAsm.Evm64.DivMod
- scripts/check-file-size.sh
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/Spec/N3RemainderWordV4.lean (no results)

Authored by @pirapira; implemented by Claude Code