### PR TITLE
feat(stateless): tx_eip2930_extract_signature (PR-K140)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -10118,6 +10118,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_derive_chain_id_from_v" => some ziskDeriveChainIdFromVProbeUnit
   | "zisk_tx_legacy_extract_signature" => some ziskTxLegacyExtractSignatureProbeUnit
   | "zisk_tx_eip1559_extract_signature" => some ziskTxEip1559ExtractSignatureProbeUnit
+  | "zisk_tx_eip2930_extract_signature" => some ziskTxEip2930ExtractSignatureProbeUnit
   | "zisk_header_minimal_decode" => some ziskHeaderMinimalDecodeProbeUnit
   | "zisk_header_extended_decode" => some ziskHeaderExtendedDecodeProbeUnit
   | "zisk_coinbase_extract_from_header" => some ziskCoinbaseExtractFromHeaderProbeUnit
@@ -10271,6 +10272,7 @@ def knownProgramNames : List String :=
    "zisk_derive_chain_id_from_v",
    "zisk_tx_legacy_extract_signature",
    "zisk_tx_eip1559_extract_signature",
+   "zisk_tx_eip2930_extract_signature",
    "zisk_header_minimal_decode",
    "zisk_header_extended_decode",
    "zisk_coinbase_extract_from_header",

--- a/EvmAsm/Codegen/Programs/Tx.lean
+++ b/EvmAsm/Codegen/Programs/Tx.lean
@@ -1107,6 +1107,165 @@ def ziskTxEip1559ExtractSignatureProbeUnit : BuildUnit := {
   prologueAsm := ziskTxEip1559ExtractSignaturePrologue
   dataAsm     := ziskTxEip1559ExtractSignatureDataSection
 }
+
+/-! ## tx_eip2930_extract_signature -- PR-K140
+
+    Extract `(y_parity, r, s)` from the inner RLP body of an
+    EIP-2930 (type-1) access-list transaction:
+
+      inner = rlp([chain_id, nonce, gas_price, gas_limit,
+                   to, value, data, access_list,
+                   y_parity, r, s])
+
+    EIP-2930 is structurally simpler than EIP-1559 (a single
+    `gas_price` field instead of the
+    `(max_priority_fee_per_gas, max_fee_per_gas)` pair), so the
+    signature triple sits at fields 8/9/10 of an 11-field list.
+
+    Caller is expected to have stripped the leading `0x01` type
+    byte (matching PR-K42 `tx_eip2930_decode`'s convention), so
+    `a0` points at the inner list's RLP prefix.
+
+    Companion in the sender-recovery pipeline to PR-K138
+    (legacy) and PR-K139 (EIP-1559); EIP-4844 / EIP-7702 variants
+    land in follow-up PRs.
+
+    Composes:
+      - PR-K20 `rlp_list_nth_item` on fields 8, 9, 10
+
+    Calling convention:
+      a0 (input)  : inner_rlp ptr
+      a1 (input)  : inner_rlp byte length
+      a2 (input)  : y_parity u64 out ptr
+      a3 (input)  : r 32-byte BE out ptr
+      a4 (input)  : s 32-byte BE out ptr
+      ra (input)  : return
+      a0 (output) :
+        0 : success
+        1 : RLP parse failure / fields 8/9/10 missing
+        2 : y_parity > 8 bytes or r/s > 32 bytes -/
+def txEip2930ExtractSignatureFunction : String :=
+  "tx_eip2930_extract_signature:\n" ++
+  "  addi sp, sp, -56\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp)\n" ++
+  "  mv s0, a0                   # inner_rlp ptr\n" ++
+  "  mv s1, a1                   # inner_rlp len\n" ++
+  "  mv s2, a2                   # y_parity out\n" ++
+  "  mv s3, a3                   # r out (32 B)\n" ++
+  "  mv s4, a4                   # s out (32 B)\n" ++
+  "  # ---- Field 8: y_parity (uint <= 8 bytes) → u64 ----\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 8\n" ++
+  "  la a3, t29es_offset; la a4, t29es_length\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lt29es_fail\n" ++
+  "  la t0, t29es_length; ld t1, 0(t0)\n" ++
+  "  li t2, 8\n" ++
+  "  bgtu t1, t2, .Lt29es_size\n" ++
+  "  la t0, t29es_offset; ld t3, 0(t0); add t3, s0, t3\n" ++
+  "  li t2, 0\n" ++
+  ".Lt29es_yloop:\n" ++
+  "  beqz t1, .Lt29es_ydone\n" ++
+  "  slli t2, t2, 8\n" ++
+  "  lbu t4, 0(t3)\n" ++
+  "  or t2, t2, t4\n" ++
+  "  addi t3, t3, 1\n" ++
+  "  addi t1, t1, -1\n" ++
+  "  j .Lt29es_yloop\n" ++
+  ".Lt29es_ydone:\n" ++
+  "  sd t2, 0(s2)\n" ++
+  "  # ---- Field 9: r (u256 BE <= 32 bytes) ----\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 9\n" ++
+  "  la a3, t29es_offset; la a4, t29es_length\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lt29es_fail\n" ++
+  "  la t0, t29es_length; ld t1, 0(t0)\n" ++
+  "  li t2, 32\n" ++
+  "  bgtu t1, t2, .Lt29es_size\n" ++
+  "  sd zero,  0(s3); sd zero,  8(s3); sd zero, 16(s3); sd zero, 24(s3)\n" ++
+  "  sub t2, t2, t1\n" ++
+  "  add t4, s3, t2\n" ++
+  "  la t0, t29es_offset; ld t3, 0(t0); add t3, s0, t3\n" ++
+  ".Lt29es_rloop:\n" ++
+  "  beqz t1, .Lt29es_rdone\n" ++
+  "  lbu t5, 0(t3)\n" ++
+  "  sb  t5, 0(t4)\n" ++
+  "  addi t3, t3, 1\n" ++
+  "  addi t4, t4, 1\n" ++
+  "  addi t1, t1, -1\n" ++
+  "  j .Lt29es_rloop\n" ++
+  ".Lt29es_rdone:\n" ++
+  "  # ---- Field 10: s (u256 BE <= 32 bytes) ----\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 10\n" ++
+  "  la a3, t29es_offset; la a4, t29es_length\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lt29es_fail\n" ++
+  "  la t0, t29es_length; ld t1, 0(t0)\n" ++
+  "  li t2, 32\n" ++
+  "  bgtu t1, t2, .Lt29es_size\n" ++
+  "  sd zero,  0(s4); sd zero,  8(s4); sd zero, 16(s4); sd zero, 24(s4)\n" ++
+  "  sub t2, t2, t1\n" ++
+  "  add t4, s4, t2\n" ++
+  "  la t0, t29es_offset; ld t3, 0(t0); add t3, s0, t3\n" ++
+  ".Lt29es_sloop:\n" ++
+  "  beqz t1, .Lt29es_sdone\n" ++
+  "  lbu t5, 0(t3)\n" ++
+  "  sb  t5, 0(t4)\n" ++
+  "  addi t3, t3, 1\n" ++
+  "  addi t4, t4, 1\n" ++
+  "  addi t1, t1, -1\n" ++
+  "  j .Lt29es_sloop\n" ++
+  ".Lt29es_sdone:\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lt29es_ret\n" ++
+  ".Lt29es_fail:\n" ++
+  "  li a0, 1\n" ++
+  "  j .Lt29es_ret\n" ++
+  ".Lt29es_size:\n" ++
+  "  li a0, 2\n" ++
+  ".Lt29es_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp)\n" ++
+  "  addi sp, sp, 56\n" ++
+  "  ret"
+
+/-- `zisk_tx_eip2930_extract_signature`: probe BuildUnit.
+    Input layout (after the host header):
+      bytes  0.. 8 : inner_rlp_len
+      bytes  8..   : inner_rlp (no leading 0x01 type byte)
+    Output layout (80 bytes): status, y_parity, r (32 B), s (32 B). -/
+def ziskTxEip2930ExtractSignaturePrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a5, 0x40000000\n" ++
+  "  ld a1, 8(a5)                # inner_rlp_len\n" ++
+  "  addi a0, a5, 16             # inner_rlp ptr\n" ++
+  "  li a2, 0xa0010008           # y_parity out\n" ++
+  "  li a3, 0xa0010010           # r out (32 B)\n" ++
+  "  li a4, 0xa0010030           # s out (32 B)\n" ++
+  "  jal ra, tx_eip2930_extract_signature\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lt29es_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  txEip2930ExtractSignatureFunction ++ "\n" ++
+  ".Lt29es_pdone:"
+
+def ziskTxEip2930ExtractSignatureDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "t29es_offset:\n" ++
+  "  .zero 8\n" ++
+  "t29es_length:\n" ++
+  "  .zero 8"
+
+def ziskTxEip2930ExtractSignatureProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskTxEip2930ExtractSignaturePrologue
+  dataAsm     := ziskTxEip2930ExtractSignatureDataSection
+}
+
 /-! ## blob_gas_used_from_versioned_hashes -- PR-K64
 
     Compute the EIP-4844 `blob_gas_used` field as:

--- a/scripts/codegen-zisk-tx-eip2930-extract-signature-check.sh
+++ b/scripts/codegen-zisk-tx-eip2930-extract-signature-check.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# codegen-zisk-tx-eip2930-extract-signature-check.sh -- PR-K140.
+#
+# Extract (y_parity, r, s) from the inner RLP of an EIP-2930
+# (type-1) access-list transaction.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_tx_eip2930_extract_signature ELF"
+lake exe codegen --program zisk_tx_eip2930_extract_signature --halt linux93 \
+  -o gen-out/zisk_tx_eip2930_extract_signature
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <y_parity> <r_hex> <s_hex>
+run_case() {
+  local name="$1" y="$2" r="$3" s="$4"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_tx_eip2930_extract_signature_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_tx_eip2930_extract_signature_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+y = $y
+r = int.from_bytes(bytes.fromhex('$r'), 'big')
+s = int.from_bytes(bytes.fromhex('$s'), 'big')
+ALICE = bytes([0xaa] * 20)
+inner = [1, 42, 10**9, 21000, ALICE, 10**18, b'', [], y, r, s]
+inner_rlp = rlp.encode(inner)
+with open(sys.argv[1], 'wb') as f:
+    f.write(struct.pack('<Q', len(inner_rlp)))
+    f.write(inner_rlp)
+    pad = (-(8 + len(inner_rlp))) % 8
+    if pad: f.write(b'\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_tx_eip2930_extract_signature.elf \
+    -i "$in_file" -o "$out_file" -n 1000000 \
+    >"$REPO_ROOT/gen-out/zisk_tx_eip2930_extract_signature_${name}.emu.log" 2>&1 || true
+
+  local actual_status; actual_status="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local actual_y_le;   actual_y_le="$(dd if="$out_file" bs=1 skip=8  count=8  2>/dev/null | xxd -p | tr -d '\n')"
+  local actual_r;      actual_r="$(dd if="$out_file" bs=1 skip=16 count=32 2>/dev/null | xxd -p | tr -d '\n')"
+  local actual_s;      actual_s="$(dd if="$out_file" bs=1 skip=48 count=32 2>/dev/null | xxd -p | tr -d '\n')"
+  local actual_y;      actual_y="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$actual_y_le'))[0])")"
+
+  local exp_r; exp_r="$(python3 -c "v=bytes.fromhex('$r'); print(('00'*(32-len(v)) + '$r'))")"
+  local exp_s; exp_s="$(python3 -c "v=bytes.fromhex('$s'); print(('00'*(32-len(v)) + '$s'))")"
+
+  if [[ "$actual_status" == "0000000000000000" \
+       && "$actual_y" == "$y" \
+       && "$actual_r" == "$exp_r" \
+       && "$actual_s" == "$exp_s" ]]; then
+    printf "  %-30s OK   y=%d r=%s... s=%s...\n" "$name" "$y" "${actual_r:0:8}" "${actual_s:0:8}"
+    return 0
+  else
+    printf "  %-30s FAIL status=0x%s y=%d expected=%d\n" "$name" "$actual_status" "$actual_y" "$y"
+    printf "      r got %s\n      r exp %s\n" "$actual_r" "$exp_r"
+    printf "      s got %s\n      s exp %s\n" "$actual_s" "$exp_s"
+    return 1
+  fi
+}
+
+R32="1111111111111111111111111111111111111111111111111111111111111111"
+S32="2222222222222222222222222222222222222222222222222222222222222222"
+R_SHORT="cafebabe"
+S_SHORT="deadbeef00"
+
+FAILED=0
+run_case "y0_full"                0  "$R32"      "$S32"     || FAILED=1
+run_case "y1_full"                1  "$R32"      "$S32"     || FAILED=1
+run_case "y0_short_rs"            0  "$R_SHORT"  "$S_SHORT" || FAILED=1
+run_case "y1_min_rs"              1  "01"        "01"       || FAILED=1
+run_case "y0_r_leading_zero_word" 0  "0000000000000001${R32:16}" "$S32" || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: tx_eip2930_extract_signature recovers (y_parity, r, s) correctly"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- \`tx_eip2930_extract_signature\`: extract \`(y_parity, r, s)\` from the inner RLP body of an EIP-2930 (type-1) access-list transaction.
- Companion to PR-K138 \`tx_legacy_extract_signature\` and PR-K139 \`tx_eip1559_extract_signature\` in the sender-recovery pipeline. EIP-4844 / EIP-7702 variants will land in follow-up PRs.
- Caller is expected to have stripped the leading 0x01 type byte (matching PR-K42 \`tx_eip2930_decode\`'s convention), so \`a0\` points at the inner list's RLP prefix.
- The function + probe defs live in \`Programs/Tx.lean\` (the new submodule introduced by the refactor #5911 this PR is stacked on); only the two registry entries (\`lookupProgram\` match + \`knownProgramNames\` entry) live in \`Programs.lean\`.

### EIP-2930 inner shape (11 fields, sig at 8/9/10)

\`\`\`
rlp([chain_id, nonce, gas_price, gas_limit,
     to, value, data, access_list,
     y_parity, r, s])
\`\`\`

Simpler than EIP-1559 (single \`gas_price\` instead of the \`(max_priority_fee_per_gas, max_fee_per_gas)\` pair), so the signature triple is one field earlier.

### Calling convention

| reg | role |
|---|---|
| a0 | inner_rlp ptr |
| a1 | inner_rlp byte length |
| a2 | y_parity u64 out (0 or 1) |
| a3 | r 32-byte BE out (right-aligned, zero-padded) |
| a4 | s 32-byte BE out (right-aligned, zero-padded) |
| a0 (out) | 0 = ok, 1 = parse fail, 2 = field size out of range |

Composes \`rlp_list_nth_item\` (PR-K20) on fields 8, 9, 10.

## Stacking

Base = \`refactor/split-programs-tx-and-u256\` (PR #5911); GitHub will auto-retarget to \`main\` once #5911 merges.

## Test plan

- [x] \`lake build\` clean
- [x] \`scripts/codegen-zisk-tx-eip2930-extract-signature-check.sh\` — 5/5 fixtures pass:
  - \`y0_full\`, \`y1_full\`: y_parity in {0, 1}, full 32-byte r/s
  - \`y0_short_rs\`: canonical RLP with leading zeros stripped
  - \`y1_min_rs\`: smallest non-zero r/s (one byte)
  - \`y0_r_leading_zero_word\`: r where the top 8 bytes are 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)