### PR TITLE
feat(stateless): eip7702_authorization_extract_signature (PR-K143)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -10121,6 +10121,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_tx_eip2930_extract_signature" => some ziskTxEip2930ExtractSignatureProbeUnit
   | "zisk_tx_eip4844_extract_signature" => some ziskTxEip4844ExtractSignatureProbeUnit
   | "zisk_tx_eip7702_extract_signature" => some ziskTxEip7702ExtractSignatureProbeUnit
+  | "zisk_eip7702_authorization_extract_signature" => some ziskEip7702AuthorizationExtractSignatureProbeUnit
   | "zisk_header_minimal_decode" => some ziskHeaderMinimalDecodeProbeUnit
   | "zisk_header_extended_decode" => some ziskHeaderExtendedDecodeProbeUnit
   | "zisk_coinbase_extract_from_header" => some ziskCoinbaseExtractFromHeaderProbeUnit
@@ -10277,6 +10278,7 @@ def knownProgramNames : List String :=
    "zisk_tx_eip2930_extract_signature",
    "zisk_tx_eip4844_extract_signature",
    "zisk_tx_eip7702_extract_signature",
+   "zisk_eip7702_authorization_extract_signature",
    "zisk_header_minimal_decode",
    "zisk_header_extended_decode",
    "zisk_coinbase_extract_from_header",

--- a/EvmAsm/Codegen/Programs/Tx.lean
+++ b/EvmAsm/Codegen/Programs/Tx.lean
@@ -1587,6 +1587,179 @@ def ziskTxEip7702ExtractSignatureProbeUnit : BuildUnit := {
   dataAsm     := ziskTxEip7702ExtractSignatureDataSection
 }
 
+/-! ## eip7702_authorization_extract_signature -- PR-K143
+
+    Extract `(y_parity, r, s)` from a single EIP-7702
+    *authorization tuple*. Each entry inside an EIP-7702
+    transaction's `authorization_list` is a 6-field RLP list:
+
+      authorization = rlp([chain_id, address, nonce,
+                           y_parity, r, s])
+
+    so the signature triple sits at fields 3/4/5 of a 6-field
+    list — one field earlier on each axis than the legacy tx
+    layout because there is no `data`, `to`, or `access_list`
+    field in an authorization tuple.
+
+    Companion to PR-K142 `tx_eip7702_extract_signature`, which
+    extracts the *outer* transaction signature. EIP-7702 carries
+    two layers of signatures:
+
+      * Outer transaction sig (K142): authorises the whole tx.
+      * Per-authorization sig (K143): authorises a single
+        `(chain_id, address, nonce)` delegation to be applied
+        before the tx body runs.
+
+    The full sender-recovery pipeline for an EIP-7702 delegation:
+      1. K143 extracts (y_parity, r, s) from the authorization
+         tuple.
+      2. tx_eip7702_authorization_signing_hash (future) =
+         keccak256(MAGIC || rlp([chain_id, address, nonce]))
+         where `MAGIC = 0x05` per the EIP.
+      3. `zkvm_secp256k1_ecrecover` → 64-byte pubkey of the
+         **delegator** (not the tx sender).
+      4. K99 `address_from_pubkey` → 20-byte delegator address.
+
+    The caller is responsible for first using K20
+    `rlp_list_nth_item` to extract the i-th authorization tuple
+    from `authorization_list`; K143 operates on the already-
+    extracted tuple bytes.
+
+    Composes:
+      - PR-K20 `rlp_list_nth_item` on fields 3, 4, 5
+
+    Calling convention:
+      a0 (input)  : authorization_tuple_rlp ptr
+      a1 (input)  : authorization_tuple_rlp byte length
+      a2 (input)  : y_parity u64 out ptr
+      a3 (input)  : r 32-byte BE out ptr
+      a4 (input)  : s 32-byte BE out ptr
+      ra (input)  : return
+      a0 (output) :
+        0 : success
+        1 : RLP parse failure / fields 3/4/5 missing
+        2 : y_parity > 8 bytes or r/s > 32 bytes -/
+def eip7702AuthorizationExtractSignatureFunction : String :=
+  "eip7702_authorization_extract_signature:\n" ++
+  "  addi sp, sp, -56\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp)\n" ++
+  "  mv s0, a0                   # tuple_rlp ptr\n" ++
+  "  mv s1, a1                   # tuple_rlp len\n" ++
+  "  mv s2, a2                   # y_parity out\n" ++
+  "  mv s3, a3                   # r out (32 B)\n" ++
+  "  mv s4, a4                   # s out (32 B)\n" ++
+  "  # ---- Field 3: y_parity (uint <= 8 bytes) → u64 ----\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 3\n" ++
+  "  la a3, ta77es_offset; la a4, ta77es_length\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lta77es_fail\n" ++
+  "  la t0, ta77es_length; ld t1, 0(t0)\n" ++
+  "  li t2, 8\n" ++
+  "  bgtu t1, t2, .Lta77es_size\n" ++
+  "  la t0, ta77es_offset; ld t3, 0(t0); add t3, s0, t3\n" ++
+  "  li t2, 0\n" ++
+  ".Lta77es_yloop:\n" ++
+  "  beqz t1, .Lta77es_ydone\n" ++
+  "  slli t2, t2, 8\n" ++
+  "  lbu t4, 0(t3)\n" ++
+  "  or t2, t2, t4\n" ++
+  "  addi t3, t3, 1\n" ++
+  "  addi t1, t1, -1\n" ++
+  "  j .Lta77es_yloop\n" ++
+  ".Lta77es_ydone:\n" ++
+  "  sd t2, 0(s2)\n" ++
+  "  # ---- Field 4: r (u256 BE <= 32 bytes) ----\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 4\n" ++
+  "  la a3, ta77es_offset; la a4, ta77es_length\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lta77es_fail\n" ++
+  "  la t0, ta77es_length; ld t1, 0(t0)\n" ++
+  "  li t2, 32\n" ++
+  "  bgtu t1, t2, .Lta77es_size\n" ++
+  "  sd zero,  0(s3); sd zero,  8(s3); sd zero, 16(s3); sd zero, 24(s3)\n" ++
+  "  sub t2, t2, t1\n" ++
+  "  add t4, s3, t2\n" ++
+  "  la t0, ta77es_offset; ld t3, 0(t0); add t3, s0, t3\n" ++
+  ".Lta77es_rloop:\n" ++
+  "  beqz t1, .Lta77es_rdone\n" ++
+  "  lbu t5, 0(t3)\n" ++
+  "  sb  t5, 0(t4)\n" ++
+  "  addi t3, t3, 1\n" ++
+  "  addi t4, t4, 1\n" ++
+  "  addi t1, t1, -1\n" ++
+  "  j .Lta77es_rloop\n" ++
+  ".Lta77es_rdone:\n" ++
+  "  # ---- Field 5: s (u256 BE <= 32 bytes) ----\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 5\n" ++
+  "  la a3, ta77es_offset; la a4, ta77es_length\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lta77es_fail\n" ++
+  "  la t0, ta77es_length; ld t1, 0(t0)\n" ++
+  "  li t2, 32\n" ++
+  "  bgtu t1, t2, .Lta77es_size\n" ++
+  "  sd zero,  0(s4); sd zero,  8(s4); sd zero, 16(s4); sd zero, 24(s4)\n" ++
+  "  sub t2, t2, t1\n" ++
+  "  add t4, s4, t2\n" ++
+  "  la t0, ta77es_offset; ld t3, 0(t0); add t3, s0, t3\n" ++
+  ".Lta77es_sloop:\n" ++
+  "  beqz t1, .Lta77es_sdone\n" ++
+  "  lbu t5, 0(t3)\n" ++
+  "  sb  t5, 0(t4)\n" ++
+  "  addi t3, t3, 1\n" ++
+  "  addi t4, t4, 1\n" ++
+  "  addi t1, t1, -1\n" ++
+  "  j .Lta77es_sloop\n" ++
+  ".Lta77es_sdone:\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lta77es_ret\n" ++
+  ".Lta77es_fail:\n" ++
+  "  li a0, 1\n" ++
+  "  j .Lta77es_ret\n" ++
+  ".Lta77es_size:\n" ++
+  "  li a0, 2\n" ++
+  ".Lta77es_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp)\n" ++
+  "  addi sp, sp, 56\n" ++
+  "  ret"
+
+/-- `zisk_eip7702_authorization_extract_signature`: probe BuildUnit.
+    Input layout (after the host header):
+      bytes  0.. 8 : tuple_rlp_len
+      bytes  8..   : tuple_rlp -/
+def ziskEip7702AuthorizationExtractSignaturePrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a5, 0x40000000\n" ++
+  "  ld a1, 8(a5)                # tuple_rlp_len\n" ++
+  "  addi a0, a5, 16             # tuple_rlp ptr\n" ++
+  "  li a2, 0xa0010008           # y_parity out\n" ++
+  "  li a3, 0xa0010010           # r out (32 B)\n" ++
+  "  li a4, 0xa0010030           # s out (32 B)\n" ++
+  "  jal ra, eip7702_authorization_extract_signature\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lta77es_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  eip7702AuthorizationExtractSignatureFunction ++ "\n" ++
+  ".Lta77es_pdone:"
+
+def ziskEip7702AuthorizationExtractSignatureDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "ta77es_offset:\n" ++
+  "  .zero 8\n" ++
+  "ta77es_length:\n" ++
+  "  .zero 8"
+
+def ziskEip7702AuthorizationExtractSignatureProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskEip7702AuthorizationExtractSignaturePrologue
+  dataAsm     := ziskEip7702AuthorizationExtractSignatureDataSection
+}
+
 /-! ## blob_gas_used_from_versioned_hashes -- PR-K64
 
     Compute the EIP-4844 `blob_gas_used` field as:

--- a/scripts/codegen-zisk-eip7702-authorization-extract-signature-check.sh
+++ b/scripts/codegen-zisk-eip7702-authorization-extract-signature-check.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# codegen-zisk-eip7702-authorization-extract-signature-check.sh -- PR-K143.
+#
+# Extract (y_parity, r, s) from a single EIP-7702 authorization
+# tuple: rlp([chain_id, address, nonce, y_parity, r, s]).
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_eip7702_authorization_extract_signature ELF"
+lake exe codegen --program zisk_eip7702_authorization_extract_signature --halt linux93 \
+  -o gen-out/zisk_eip7702_authorization_extract_signature
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <chain_id> <nonce> <y_parity> <r_hex> <s_hex>
+run_case() {
+  local name="$1" cid="$2" nonce="$3" y="$4" r="$5" s="$6"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_eip7702_authorization_extract_signature_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_eip7702_authorization_extract_signature_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+cid = $cid
+nonce = $nonce
+y = $y
+r = int.from_bytes(bytes.fromhex('$r'), 'big')
+s = int.from_bytes(bytes.fromhex('$s'), 'big')
+DELEGATE = bytes([0xde] * 20)
+tuple_rlp = rlp.encode([cid, DELEGATE, nonce, y, r, s])
+with open(sys.argv[1], 'wb') as f:
+    f.write(struct.pack('<Q', len(tuple_rlp)))
+    f.write(tuple_rlp)
+    pad = (-(8 + len(tuple_rlp))) % 8
+    if pad: f.write(b'\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_eip7702_authorization_extract_signature.elf \
+    -i "$in_file" -o "$out_file" -n 1000000 \
+    >"$REPO_ROOT/gen-out/zisk_eip7702_authorization_extract_signature_${name}.emu.log" 2>&1 || true
+
+  local actual_status; actual_status="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local actual_y_le;   actual_y_le="$(dd if="$out_file" bs=1 skip=8  count=8  2>/dev/null | xxd -p | tr -d '\n')"
+  local actual_r;      actual_r="$(dd if="$out_file" bs=1 skip=16 count=32 2>/dev/null | xxd -p | tr -d '\n')"
+  local actual_s;      actual_s="$(dd if="$out_file" bs=1 skip=48 count=32 2>/dev/null | xxd -p | tr -d '\n')"
+  local actual_y;      actual_y="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$actual_y_le'))[0])")"
+
+  local exp_r; exp_r="$(python3 -c "v=bytes.fromhex('$r'); print(('00'*(32-len(v)) + '$r'))")"
+  local exp_s; exp_s="$(python3 -c "v=bytes.fromhex('$s'); print(('00'*(32-len(v)) + '$s'))")"
+
+  if [[ "$actual_status" == "0000000000000000" \
+       && "$actual_y" == "$y" \
+       && "$actual_r" == "$exp_r" \
+       && "$actual_s" == "$exp_s" ]]; then
+    printf "  %-30s OK   cid=%d nonce=%d y=%d r=%s... s=%s...\n" "$name" "$cid" "$nonce" "$y" "${actual_r:0:8}" "${actual_s:0:8}"
+    return 0
+  else
+    printf "  %-30s FAIL status=0x%s y=%d expected=%d\n" "$name" "$actual_status" "$actual_y" "$y"
+    printf "      r got %s\n      r exp %s\n" "$actual_r" "$exp_r"
+    printf "      s got %s\n      s exp %s\n" "$actual_s" "$exp_s"
+    return 1
+  fi
+}
+
+R32="1111111111111111111111111111111111111111111111111111111111111111"
+S32="2222222222222222222222222222222222222222222222222222222222222222"
+R_SHORT="cafebabe"
+S_SHORT="deadbeef00"
+
+FAILED=0
+# Mainnet chain_id, typical nonces, y_parity ∈ {0, 1}
+run_case "mainnet_y0"             1   42       0  "$R32"      "$S32"     || FAILED=1
+run_case "mainnet_y1"             1   42       1  "$R32"      "$S32"     || FAILED=1
+# Sepolia-like big chain_id (>8 bytes? no, fits in 4)
+run_case "sepolia_y0"             11155111 99  0  "$R32"      "$S32"     || FAILED=1
+# nonce=0 boundary (RLP-canonical empty bytes)
+run_case "nonce_zero"             1   0        1  "$R32"      "$S32"     || FAILED=1
+# Short r/s
+run_case "short_rs"               1   1        0  "$R_SHORT"  "$S_SHORT" || FAILED=1
+# Smallest non-zero r/s
+run_case "min_rs"                 1   1        1  "01"        "01"       || FAILED=1
+# r leading-zero word
+run_case "r_leading_zero"         1   1        0  "0000000000000001${R32:16}" "$S32" || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: eip7702_authorization_extract_signature recovers (y_parity, r, s) correctly"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- \`eip7702_authorization_extract_signature\`: extract \`(y_parity, r, s)\` from a single EIP-7702 authorization tuple — \`rlp([chain_id, address, nonce, y_parity, r, s])\` — at fields 3/4/5 of a 6-field list.
- Companion to PR-K142 \`tx_eip7702_extract_signature\` (which extracts the *outer* tx sig). EIP-7702 carries two sig layers; K142 + K143 cover both.
- The caller is responsible for first using \`rlp_list_nth_item\` (PR-K20) to extract the i-th authorization tuple from \`authorization_list\`; K143 operates on the already-extracted tuple bytes.
- The function + probe defs live in \`Programs/Tx.lean\`; the two registry entries live in \`Programs.lean\`.

### Why it's needed

EIP-7702 delegations are authorised *by the delegator*, not by the transaction sender. To validate a delegation, the verifier must:

1. Extract \`(y_parity, r, s)\` from the authorization tuple — **this PR**.
2. Compute \`tx_eip7702_authorization_signing_hash = keccak256(MAGIC || rlp([chain_id, address, nonce]))\` where \`MAGIC = 0x05\` — future PR.
3. Recover the delegator pubkey via \`zkvm_secp256k1_ecrecover\` — future.
4. Derive the delegator address via PR-K99 \`address_from_pubkey\` — already shipped.

### Calling convention

| reg | role |
|---|---|
| a0 | authorization_tuple_rlp ptr |
| a1 | authorization_tuple_rlp byte length |
| a2 | y_parity u64 out (0 or 1) |
| a3 | r 32-byte BE out (right-aligned, zero-padded) |
| a4 | s 32-byte BE out (right-aligned, zero-padded) |
| a0 (out) | 0 = ok, 1 = parse fail, 2 = field size out of range |

Composes \`rlp_list_nth_item\` (PR-K20) on fields 3, 4, 5.

## Test plan

- [x] \`lake build\` clean
- [x] \`scripts/codegen-zisk-eip7702-authorization-extract-signature-check.sh\` — 7/7 fixtures pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)