### PR TITLE
feat(stateless): rlp_list_truncate_to_n_fields (PR-K144)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -4925,84 +4925,8 @@ def ziskRlpEncodeBytesProbeUnit : BuildUnit := {
   dataAsm     := ziskRlpEncodeBytesDataSection
 }
 
-/-! ## rlp_encode_list_prefix -- PR-K129
+/-! ## rlp_encode_list_prefix -- PR-K129 — def moved to `Programs/RlpRead.lean`. -/
 
-    Write the RLP list-header prefix bytes for a list whose total
-    pre-encoded payload size is `payload_length`. Matches the yellow
-    paper §B "list" rule:
-
-      payload_length < 56  → 0xc0 + payload_length   (1 byte)
-      else                 → 0xf7 + bc, then `bc`-byte BE length
-                             (`bc` = effective byte count of
-                             `payload_length`, 1..8)
-
-    Companion to PR-K128 `rlp_encode_bytes` (the string version)
-    and PR-K30 `rlp_encode_uint_be` (the uint version). Together
-    these three primitives cover the encoder side of the trie /
-    node / header / tx serialisation pipeline.
-
-    Calling convention:
-      a0 (input)  : payload_length (u64)
-      a1 (input)  : output bytes ptr (caller supplies ≥ 9 bytes)
-      a2 (input)  : u64 out ptr (prefix byte length)
-      ra (input)  : return
-      a0 (output) : 0 (always succeeds — total function).
-
-    Pure-leaf semantics: no scratch memory, no transitive calls. -/
-def rlpEncodeListPrefixFunction : String :=
-  "rlp_encode_list_prefix:\n" ++
-  "  li t0, 56\n" ++
-  "  bgeu a0, t0, .Lrelp_long\n" ++
-  "  # Short list: prefix = 0xc0 + payload_length (1 byte).\n" ++
-  "  addi t1, a0, 0xc0\n" ++
-  "  sb t1, 0(a1)\n" ++
-  "  li t2, 1\n" ++
-  "  sd t2, 0(a2)\n" ++
-  "  li a0, 0\n" ++
-  "  ret\n" ++
-  ".Lrelp_long:\n" ++
-  "  # Long list: prefix = 0xf7 + bc, then bc-byte BE length.\n" ++
-  "  li t3, 1\n" ++
-  "  li t4, 0x100\n" ++
-  "  bltu a0, t4, .Lrelp_have_bc\n" ++
-  "  li t3, 2\n" ++
-  "  slli t4, t4, 8\n" ++
-  "  bltu a0, t4, .Lrelp_have_bc\n" ++
-  "  li t3, 3\n" ++
-  "  slli t4, t4, 8\n" ++
-  "  bltu a0, t4, .Lrelp_have_bc\n" ++
-  "  li t3, 4\n" ++
-  "  slli t4, t4, 8\n" ++
-  "  bltu a0, t4, .Lrelp_have_bc\n" ++
-  "  li t3, 5\n" ++
-  "  slli t4, t4, 8\n" ++
-  "  bltu a0, t4, .Lrelp_have_bc\n" ++
-  "  li t3, 6\n" ++
-  "  slli t4, t4, 8\n" ++
-  "  bltu a0, t4, .Lrelp_have_bc\n" ++
-  "  li t3, 7\n" ++
-  "  slli t4, t4, 8\n" ++
-  "  bltu a0, t4, .Lrelp_have_bc\n" ++
-  "  li t3, 8\n" ++
-  ".Lrelp_have_bc:\n" ++
-  "  addi t4, t3, 0xf7\n" ++
-  "  sb t4, 0(a1)\n" ++
-  "  mv t5, a1\n" ++
-  "  addi t5, t5, 1\n" ++
-  "  addi t4, t3, -1\n" ++
-  ".Lrelp_emit_be:\n" ++
-  "  bltz t4, .Lrelp_be_done\n" ++
-  "  slli t6, t4, 3\n" ++
-  "  srl t0, a0, t6\n" ++
-  "  sb t0, 0(t5)\n" ++
-  "  addi t5, t5, 1\n" ++
-  "  addi t4, t4, -1\n" ++
-  "  j .Lrelp_emit_be\n" ++
-  ".Lrelp_be_done:\n" ++
-  "  addi t5, t3, 1\n" ++
-  "  sd t5, 0(a2)\n" ++
-  "  li a0, 0\n" ++
-  "  ret"
 
 /-- `zisk_rlp_encode_list_prefix`: probe BuildUnit. Reads
     (payload_length,) from host input, writes (status, out_len,
@@ -10122,6 +10046,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_tx_eip4844_extract_signature" => some ziskTxEip4844ExtractSignatureProbeUnit
   | "zisk_tx_eip7702_extract_signature" => some ziskTxEip7702ExtractSignatureProbeUnit
   | "zisk_eip7702_authorization_extract_signature" => some ziskEip7702AuthorizationExtractSignatureProbeUnit
+  | "zisk_rlp_list_truncate_to_n_fields" => some ziskRlpListTruncateToNFieldsProbeUnit
   | "zisk_header_minimal_decode" => some ziskHeaderMinimalDecodeProbeUnit
   | "zisk_header_extended_decode" => some ziskHeaderExtendedDecodeProbeUnit
   | "zisk_coinbase_extract_from_header" => some ziskCoinbaseExtractFromHeaderProbeUnit
@@ -10279,6 +10204,7 @@ def knownProgramNames : List String :=
    "zisk_tx_eip4844_extract_signature",
    "zisk_tx_eip7702_extract_signature",
    "zisk_eip7702_authorization_extract_signature",
+   "zisk_rlp_list_truncate_to_n_fields",
    "zisk_header_minimal_decode",
    "zisk_header_extended_decode",
    "zisk_coinbase_extract_from_header",

--- a/EvmAsm/Codegen/Programs/RlpRead.lean
+++ b/EvmAsm/Codegen/Programs/RlpRead.lean
@@ -348,4 +348,84 @@ def rlpListCountItemsFunction : String :=
   "  li a0, 1\n" ++
   "  ret"
 
+
+/-! ## rlp_encode_list_prefix -- PR-K129
+
+    Write the RLP list-header prefix bytes for a list whose total
+    pre-encoded payload size is `payload_length`. Matches the yellow
+    paper §B "list" rule:
+
+      payload_length < 56  → 0xc0 + payload_length   (1 byte)
+      else                 → 0xf7 + bc, then `bc`-byte BE length
+                             (`bc` = effective byte count of
+                             `payload_length`, 1..8)
+
+    Companion to PR-K128 `rlp_encode_bytes` (the string version)
+    and PR-K30 `rlp_encode_uint_be` (the uint version). Together
+    these three primitives cover the encoder side of the trie /
+    node / header / tx serialisation pipeline.
+
+    Calling convention:
+      a0 (input)  : payload_length (u64)
+      a1 (input)  : output bytes ptr (caller supplies ≥ 9 bytes)
+      a2 (input)  : u64 out ptr (prefix byte length)
+      ra (input)  : return
+      a0 (output) : 0 (always succeeds — total function).
+
+    Pure-leaf semantics: no scratch memory, no transitive calls. -/
+def rlpEncodeListPrefixFunction : String :=
+  "rlp_encode_list_prefix:\n" ++
+  "  li t0, 56\n" ++
+  "  bgeu a0, t0, .Lrelp_long\n" ++
+  "  # Short list: prefix = 0xc0 + payload_length (1 byte).\n" ++
+  "  addi t1, a0, 0xc0\n" ++
+  "  sb t1, 0(a1)\n" ++
+  "  li t2, 1\n" ++
+  "  sd t2, 0(a2)\n" ++
+  "  li a0, 0\n" ++
+  "  ret\n" ++
+  ".Lrelp_long:\n" ++
+  "  # Long list: prefix = 0xf7 + bc, then bc-byte BE length.\n" ++
+  "  li t3, 1\n" ++
+  "  li t4, 0x100\n" ++
+  "  bltu a0, t4, .Lrelp_have_bc\n" ++
+  "  li t3, 2\n" ++
+  "  slli t4, t4, 8\n" ++
+  "  bltu a0, t4, .Lrelp_have_bc\n" ++
+  "  li t3, 3\n" ++
+  "  slli t4, t4, 8\n" ++
+  "  bltu a0, t4, .Lrelp_have_bc\n" ++
+  "  li t3, 4\n" ++
+  "  slli t4, t4, 8\n" ++
+  "  bltu a0, t4, .Lrelp_have_bc\n" ++
+  "  li t3, 5\n" ++
+  "  slli t4, t4, 8\n" ++
+  "  bltu a0, t4, .Lrelp_have_bc\n" ++
+  "  li t3, 6\n" ++
+  "  slli t4, t4, 8\n" ++
+  "  bltu a0, t4, .Lrelp_have_bc\n" ++
+  "  li t3, 7\n" ++
+  "  slli t4, t4, 8\n" ++
+  "  bltu a0, t4, .Lrelp_have_bc\n" ++
+  "  li t3, 8\n" ++
+  ".Lrelp_have_bc:\n" ++
+  "  addi t4, t3, 0xf7\n" ++
+  "  sb t4, 0(a1)\n" ++
+  "  mv t5, a1\n" ++
+  "  addi t5, t5, 1\n" ++
+  "  addi t4, t3, -1\n" ++
+  ".Lrelp_emit_be:\n" ++
+  "  bltz t4, .Lrelp_be_done\n" ++
+  "  slli t6, t4, 3\n" ++
+  "  srl t0, a0, t6\n" ++
+  "  sb t0, 0(t5)\n" ++
+  "  addi t5, t5, 1\n" ++
+  "  addi t4, t4, -1\n" ++
+  "  j .Lrelp_emit_be\n" ++
+  ".Lrelp_be_done:\n" ++
+  "  addi t5, t3, 1\n" ++
+  "  sd t5, 0(a2)\n" ++
+  "  li a0, 0\n" ++
+  "  ret"
+
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/Tx.lean
+++ b/EvmAsm/Codegen/Programs/Tx.lean
@@ -1760,6 +1760,166 @@ def ziskEip7702AuthorizationExtractSignatureProbeUnit : BuildUnit := {
   dataAsm     := ziskEip7702AuthorizationExtractSignatureDataSection
 }
 
+/-! ## rlp_list_truncate_to_n_fields -- PR-K144
+
+    Given an RLP-encoded list and a count `n`, write a freshly
+    re-encoded RLP list containing only the first `n` fields of
+    the input. The child encodings are reused verbatim (RLP is
+    context-free at child level); only the outer list prefix is
+    re-emitted to reflect the smaller payload.
+
+    Direct building block for transaction signing-hash computation:
+
+      * Legacy pre-EIP-155 signing hash = `keccak256(rlp([nonce,
+        gas_price, gas_limit, to, value, data]))` — i.e., the
+        legacy tx's 9-field RLP truncated to its first 6 fields
+        (dropping `v, r, s`).
+      * EIP-1559 signing hash body = first 9 fields of the
+        12-field inner list (dropping `y_parity, r, s`).
+      * EIP-2930 signing hash body = first 8 fields of 11.
+      * EIP-4844 signing hash body = first 11 fields of 14.
+      * EIP-7702 signing hash body = first 10 fields of 13.
+      * EIP-7702 authorization signing hash body = first 3 fields
+        of the 6-field authorization tuple (dropping
+        `y_parity, r, s`).
+
+    Composes:
+      - PR-K20 `rlp_list_nth_item`     — locate first / last fields
+      - PR-K129 `rlp_encode_list_prefix` — new outer prefix
+
+    Calling convention:
+      a0 (input)  : input_rlp ptr (encoded list)
+      a1 (input)  : input_rlp byte length
+      a2 (input)  : n_fields (u64) — keep first n
+      a3 (input)  : output buffer ptr (caller supplies
+                    >= 9 + len(retained payload) bytes)
+      a4 (input)  : u64 out_length ptr (receives total written
+                    bytes, prefix + payload)
+      ra (input)  : return
+      a0 (output) :
+        0 : success
+        1 : RLP parse failure / input not a list
+        2 : input has fewer than `n` fields
+    Edge cases:
+      * n == 0 → output is `0xc0` (empty list, 1 byte). -/
+def rlpListTruncateToNFieldsFunction : String :=
+  "rlp_list_truncate_to_n_fields:\n" ++
+  "  addi sp, sp, -64\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp)\n" ++
+  "  mv s0, a0                   # input_rlp ptr\n" ++
+  "  mv s1, a1                   # input_rlp len\n" ++
+  "  mv s2, a2                   # n_fields\n" ++
+  "  mv s3, a3                   # output buffer ptr\n" ++
+  "  mv s4, a4                   # out_length ptr\n" ++
+  "  beqz s2, .Lrltn_empty       # n == 0 → emit `0xc0`\n" ++
+  "  # ---- Locate field 0 to get payload_start ----\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 0\n" ++
+  "  la a3, rltn_offset_lo; la a4, rltn_length_lo\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lrltn_parse_fail\n" ++
+  "  # ---- Locate field (n-1) to get end-of-payload ----\n" ++
+  "  addi t0, s2, -1\n" ++
+  "  mv a0, s0; mv a1, s1; mv a2, t0\n" ++
+  "  la a3, rltn_offset_hi; la a4, rltn_length_hi\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lrltn_too_few\n" ++
+  "  la t0, rltn_offset_lo; ld s5, 0(t0)        # payload_start\n" ++
+  "  la t0, rltn_offset_hi; ld t1, 0(t0)\n" ++
+  "  la t0, rltn_length_hi; ld t2, 0(t0)\n" ++
+  "  add t1, t1, t2                              # end-of-payload\n" ++
+  "  sub s6, t1, s5                              # new_payload_len\n" ++
+  "  # ---- Write new outer list prefix ----\n" ++
+  "  mv a0, s6; mv a1, s3\n" ++
+  "  la a2, rltn_prefix_len\n" ++
+  "  jal ra, rlp_encode_list_prefix\n" ++
+  "  la t0, rltn_prefix_len; ld t1, 0(t0)        # prefix_len\n" ++
+  "  # ---- Copy payload bytes ----\n" ++
+  "  add t2, s3, t1                              # dst = output + prefix\n" ++
+  "  add t3, s0, s5                              # src = input + payload_start\n" ++
+  "  mv t4, s6                                   # remaining bytes\n" ++
+  ".Lrltn_cploop:\n" ++
+  "  beqz t4, .Lrltn_cpdone\n" ++
+  "  lbu t5, 0(t3)\n" ++
+  "  sb t5, 0(t2)\n" ++
+  "  addi t2, t2, 1\n" ++
+  "  addi t3, t3, 1\n" ++
+  "  addi t4, t4, -1\n" ++
+  "  j .Lrltn_cploop\n" ++
+  ".Lrltn_cpdone:\n" ++
+  "  add t1, t1, s6                              # out_len = prefix + payload\n" ++
+  "  sd t1, 0(s4)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lrltn_ret\n" ++
+  ".Lrltn_empty:\n" ++
+  "  li t0, 0xc0\n" ++
+  "  sb t0, 0(s3)\n" ++
+  "  li t0, 1\n" ++
+  "  sd t0, 0(s4)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lrltn_ret\n" ++
+  ".Lrltn_parse_fail:\n" ++
+  "  li a0, 1\n" ++
+  "  j .Lrltn_ret\n" ++
+  ".Lrltn_too_few:\n" ++
+  "  li a0, 2\n" ++
+  ".Lrltn_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp)\n" ++
+  "  addi sp, sp, 64\n" ++
+  "  ret"
+
+/-- `zisk_rlp_list_truncate_to_n_fields`: probe BuildUnit.
+    Input layout:
+      bytes  0.. 8 : input_rlp_len
+      bytes  8..16 : n_fields (u64 LE)
+      bytes 16..   : input_rlp
+    Output layout (1 KiB ought to be plenty for fixtures):
+      bytes  0.. 8 : status
+      bytes  8..16 : out_length
+      bytes 16..   : written RLP bytes (truncated to 256-byte
+                     ziskemu cap; the fixture script reconstructs
+                     the slice from the input and the expected
+                     prefix). -/
+def ziskRlpListTruncateToNFieldsPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a5, 0x40000000\n" ++
+  "  ld a1, 8(a5)                # input_rlp_len\n" ++
+  "  ld a2, 16(a5)               # n_fields\n" ++
+  "  addi a0, a5, 24             # input_rlp ptr\n" ++
+  "  li a3, 0xa0010010           # output buffer\n" ++
+  "  li a4, 0xa0010008           # out_length\n" ++
+  "  jal ra, rlp_list_truncate_to_n_fields\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lrltn_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpEncodeListPrefixFunction ++ "\n" ++
+  rlpListTruncateToNFieldsFunction ++ "\n" ++
+  ".Lrltn_pdone:"
+
+def ziskRlpListTruncateToNFieldsDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "rltn_offset_lo:\n" ++
+  "  .zero 8\n" ++
+  "rltn_length_lo:\n" ++
+  "  .zero 8\n" ++
+  "rltn_offset_hi:\n" ++
+  "  .zero 8\n" ++
+  "rltn_length_hi:\n" ++
+  "  .zero 8\n" ++
+  "rltn_prefix_len:\n" ++
+  "  .zero 8"
+
+def ziskRlpListTruncateToNFieldsProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskRlpListTruncateToNFieldsPrologue
+  dataAsm     := ziskRlpListTruncateToNFieldsDataSection
+}
+
 /-! ## blob_gas_used_from_versioned_hashes -- PR-K64
 
     Compute the EIP-4844 `blob_gas_used` field as:

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **166**
-- ziskemu round-trip scripts: **159** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **167**
+- ziskemu round-trip scripts: **160** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-rlp-list-truncate-to-n-fields-check.sh
+++ b/scripts/codegen-zisk-rlp-list-truncate-to-n-fields-check.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# codegen-zisk-rlp-list-truncate-to-n-fields-check.sh -- PR-K144.
+#
+# Truncate an RLP list to its first n fields and re-encode the
+# outer list prefix.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_rlp_list_truncate_to_n_fields ELF"
+lake exe codegen --program zisk_rlp_list_truncate_to_n_fields --halt linux93 \
+  -o gen-out/zisk_rlp_list_truncate_to_n_fields
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <fields_json> <n>
+run_case() {
+  local name="$1" fields="$2" n="$3"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_rlp_list_truncate_to_n_fields_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_rlp_list_truncate_to_n_fields_${name}.output"
+  local exp_hex_file="$REPO_ROOT/gen-out/zisk_rlp_list_truncate_to_n_fields_${name}.expected.hex"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import json, struct, sys, rlp
+fields_raw = json.loads('''$fields''')
+def conv(x):
+    if isinstance(x, str) and x.startswith('hex:'): return bytes.fromhex(x[4:])
+    if isinstance(x, list): return [conv(e) for e in x]
+    return x
+fields = [conv(f) for f in fields_raw]
+n = $n
+list_rlp = rlp.encode(fields)
+with open(sys.argv[1], 'wb') as f:
+    f.write(struct.pack('<Q', len(list_rlp)))
+    f.write(struct.pack('<Q', n))
+    f.write(list_rlp)
+    pad = (-(16 + len(list_rlp))) % 8
+    if pad: f.write(b'\x00' * pad)
+expected = rlp.encode(fields[:n])
+with open(sys.argv[2], 'w') as f:
+    f.write(expected.hex())
+" "$in_file" "$exp_hex_file"
+
+  "$ZISKEMU" -e gen-out/zisk_rlp_list_truncate_to_n_fields.elf \
+    -i "$in_file" -o "$out_file" -n 1000000 \
+    >"$REPO_ROOT/gen-out/zisk_rlp_list_truncate_to_n_fields_${name}.emu.log" 2>&1 || true
+
+  local actual_status; actual_status="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local actual_len_le; actual_len_le="$(dd if="$out_file" bs=1 skip=8 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local actual_len; actual_len="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$actual_len_le'))[0])")"
+  local expected_hex; expected_hex="$(cat "$exp_hex_file")"
+  local expected_len; expected_len=$(( ${#expected_hex} / 2 ))
+  local actual_hex; actual_hex="$(dd if="$out_file" bs=1 skip=16 count="$expected_len" 2>/dev/null | xxd -p | tr -d '\n')"
+
+  if [[ "$actual_status" == "0000000000000000" \
+       && "$actual_len" == "$expected_len" \
+       && "$actual_hex" == "$expected_hex" ]]; then
+    printf "  %-30s OK   n=%d len=%d\n" "$name" "$n" "$expected_len"
+    return 0
+  else
+    printf "  %-30s FAIL status=0x%s actual_len=%d expected_len=%d\n" "$name" "$actual_status" "$actual_len" "$expected_len"
+    printf "      actual:   %s\n" "${actual_hex:0:80}"
+    printf "      expected: %s\n" "${expected_hex:0:80}"
+    return 1
+  fi
+}
+
+FAILED=0
+# Standard legacy tx → drop (v, r, s): 9 fields → 6
+run_case "legacy_9to6" \
+  '[42, 1000000000, 21000, "hex:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 1000000000000000000, "", 27, "hex:1111111111111111111111111111111111111111111111111111111111111111", "hex:2222222222222222222222222222222222222222222222222222222222222222"]' \
+  6 || FAILED=1
+
+# Same as above, n == full count → identity
+run_case "legacy_9to9_identity" \
+  '[42, 1000000000, 21000, "hex:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 1000000000000000000, "", 27, "hex:1111111111111111111111111111111111111111111111111111111111111111", "hex:2222222222222222222222222222222222222222222222222222222222222222"]' \
+  9 || FAILED=1
+
+# n == 0 → empty list (just 0xc0)
+run_case "empty_list_n0" '[1, 2, 3]' 0 || FAILED=1
+
+# n == 1 → single-field list
+run_case "single_field" '[1, 2, 3]' 1 || FAILED=1
+
+# EIP-7702 authorization tuple: 6 fields → 3 (sig drop), payload short enough to be a short list
+run_case "auth_6to3" \
+  '[1, "hex:dededededededededededededededededededede", 0, 1, "hex:1111111111111111111111111111111111111111111111111111111111111111", "hex:2222222222222222222222222222222222222222222222222222222222222222"]' \
+  3 || FAILED=1
+
+# n > number of fields → status 2
+in_too_few="$REPO_ROOT/gen-out/zisk_rlp_list_truncate_to_n_fields_too_few.input"
+out_too_few="$REPO_ROOT/gen-out/zisk_rlp_list_truncate_to_n_fields_too_few.output"
+uv run --directory execution-specs --quiet python3 -c "
+import struct, rlp
+list_rlp = rlp.encode([1, 2, 3])
+with open('$in_too_few', 'wb') as f:
+    f.write(struct.pack('<Q', len(list_rlp)))
+    f.write(struct.pack('<Q', 5))   # ask for 5 fields, only 3 exist
+    f.write(list_rlp)
+    pad = (-(16 + len(list_rlp))) % 8
+    if pad: f.write(b'\x00' * pad)
+"
+"$ZISKEMU" -e gen-out/zisk_rlp_list_truncate_to_n_fields.elf \
+  -i "$in_too_few" -o "$out_too_few" -n 1000000 \
+  >"$REPO_ROOT/gen-out/zisk_rlp_list_truncate_to_n_fields_too_few.emu.log" 2>&1 || true
+status_le="$(xxd -p -l 8 "$out_too_few" | tr -d '\n')"
+exp_status_le="$(python3 -c "print(int(2).to_bytes(8, 'little').hex())")"
+if [[ "$status_le" == "$exp_status_le" ]]; then
+  printf "  %-30s OK   status=2 (rejected too few fields)\n" "too_few_fields"
+else
+  printf "  %-30s FAIL status=0x%s expected=0x%s\n" "too_few_fields" "$status_le" "$exp_status_le"
+  FAILED=1
+fi
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: rlp_list_truncate_to_n_fields re-encodes correctly"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- \`rlp_list_truncate_to_n_fields\`: given an RLP-encoded list and a count \`n\`, write a freshly re-encoded RLP list containing only the first \`n\` fields of the input. The child encodings are reused verbatim (RLP is context-free at child level); only the outer list prefix is re-emitted to reflect the smaller payload.
- **Direct building block for transaction signing-hash computation** across all tx types:
  - Legacy pre-EIP-155: 9 → 6 (drop v, r, s)
  - EIP-1559: 12 → 9
  - EIP-2930: 11 → 8
  - EIP-4844: 14 → 11
  - EIP-7702: 13 → 10
  - EIP-7702 authorization tuple: 6 → 3
- Side move: \`rlpEncodeListPrefixFunction\` def moves from \`Programs.lean\` into \`Programs/RlpRead.lean\` so that \`Programs/Tx.lean\` (where K144 lives) can reference it without circular imports. RlpRead's purpose expands from "list-walking" to "RLP primitives (read + write)".

### Calling convention

| reg | role |
|---|---|
| a0 | input_rlp ptr (encoded list) |
| a1 | input_rlp byte length |
| a2 | n_fields (u64) — keep first n |
| a3 | output buffer ptr (≥ 9 + len(retained payload) bytes) |
| a4 | u64 out_length ptr |
| a0 (out) | 0 = ok, 1 = parse fail, 2 = fewer than n fields |

Composes \`rlp_list_nth_item\` (PR-K20) for locating field bounds and \`rlp_encode_list_prefix\` (PR-K129) for the new outer prefix. Edge case: \`n == 0\` → output is just \`0xc0\` (1 byte).

### Why it's needed

Next step in the sender-recovery pipeline: each tx type's signing-hash construction is \`keccak256(type_byte || rlp([fields_without_sig]))\` (or just \`keccak256(rlp([...]))\` for legacy). K144 produces \`rlp([fields_without_sig])\` in one call. The follow-up PR composes K144 + Keccak bridge into the actual signing-hash builders.

## Test plan

- [x] \`lake build\` clean
- [x] \`scripts/codegen-zisk-rlp-list-truncate-to-n-fields-check.sh\` — 6/6 fixtures pass:
  - \`legacy_9to6\`: legacy tx 9→6 fields (drop sig) — 41 bytes out
  - \`legacy_9to9_identity\`: n == full count → identity copy
  - \`empty_list_n0\`: n == 0 → just \`0xc0\`
  - \`single_field\`: n == 1 → single-element list
  - \`auth_6to3\`: EIP-7702 authorization 6→3 fields (drop sig)
  - \`too_few_fields\`: n > count → status 2 rejection

🤖 Generated with [Claude Code](https://claude.com/claude-code)