### PR TITLE
feat(stateless): tx_signing_hash (PR-K145)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -10047,6 +10047,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_tx_eip7702_extract_signature" => some ziskTxEip7702ExtractSignatureProbeUnit
   | "zisk_eip7702_authorization_extract_signature" => some ziskEip7702AuthorizationExtractSignatureProbeUnit
   | "zisk_rlp_list_truncate_to_n_fields" => some ziskRlpListTruncateToNFieldsProbeUnit
+  | "zisk_tx_signing_hash" => some ziskTxSigningHashProbeUnit
   | "zisk_header_minimal_decode" => some ziskHeaderMinimalDecodeProbeUnit
   | "zisk_header_extended_decode" => some ziskHeaderExtendedDecodeProbeUnit
   | "zisk_coinbase_extract_from_header" => some ziskCoinbaseExtractFromHeaderProbeUnit
@@ -10205,6 +10206,7 @@ def knownProgramNames : List String :=
    "zisk_tx_eip7702_extract_signature",
    "zisk_eip7702_authorization_extract_signature",
    "zisk_rlp_list_truncate_to_n_fields",
+   "zisk_tx_signing_hash",
    "zisk_header_minimal_decode",
    "zisk_header_extended_decode",
    "zisk_coinbase_extract_from_header",

--- a/EvmAsm/Codegen/Programs/Tx.lean
+++ b/EvmAsm/Codegen/Programs/Tx.lean
@@ -1920,6 +1920,164 @@ def ziskRlpListTruncateToNFieldsProbeUnit : BuildUnit := {
   dataAsm     := ziskRlpListTruncateToNFieldsDataSection
 }
 
+/-! ## tx_signing_hash -- PR-K145
+
+    Unified transaction signing-hash builder. Given a tx inner
+    RLP, the number of fields to retain (everything before
+    `y_parity, r, s`), and an optional type-prefix byte, compute
+
+      keccak256( [type_prefix?] || rlp([first n fields]) )
+
+    in a single call. This is the digest fed to
+    `zkvm_secp256k1_ecrecover` together with the extracted
+    `(y_parity, r, s)` to recover the tx sender's pubkey.
+
+    Per-tx-type usage:
+
+      type   | type_prefix | n  | description
+      -------|-------------|----|-----------------------------
+      legacy | 0           | 6  | pre-EIP-155 signing hash
+      EIP-2930 | 0x01      | 8  | type-1 signing hash
+      EIP-1559 | 0x02      | 9  | type-2 signing hash
+      EIP-4844 | 0x03      | 11 | type-3 signing hash
+      EIP-7702 | 0x04      | 10 | type-4 signing hash
+
+    Legacy EIP-155 (chain_id-bearing) signing hash is **not**
+    covered by this helper: it appends `(chain_id, 0, 0)` after
+    the first 6 fields, which requires building a new 9-field
+    list rather than just truncating. That variant lands as
+    `tx_signing_hash_legacy_eip155` in a follow-up PR.
+
+    EIP-7702 authorization signing hash is similarly out of scope
+    (it computes over `MAGIC=0x05 || rlp([chain_id, address,
+    nonce])` where the body is a 3-field list freshly built from
+    the authorization tuple, not a truncation); follow-up.
+
+    Composes:
+      - PR-K144 `rlp_list_truncate_to_n_fields`  -- truncation
+      - `zkvm_keccak256` (HashBridge)            -- hashing
+
+    Calling convention:
+      a0 (input)  : tx_inner_rlp ptr (caller has stripped any
+                    leading type byte)
+      a1 (input)  : tx_inner_rlp byte length
+      a2 (input)  : n_fields (u64) -- fields to keep
+      a3 (input)  : type_prefix (u8 in low bits; 0 = no prefix)
+      a4 (input)  : 32-byte output hash ptr
+      ra (input)  : return
+      a0 (output) :
+        0 : success -- hash written
+        1 : truncation parse failure / fewer than n fields
+
+    Uses two `.data` scratch buffers:
+      * `tsh_buf` (8 KiB) -- holds `[optional type byte] ||
+        rlp([first n fields])` immediately before the keccak
+        call.
+      * `zk3_state` (200 bytes) -- reused from the existing
+        keccak bridge. -/
+def txSigningHashFunction : String :=
+  "tx_signing_hash:\n" ++
+  "  addi sp, sp, -48\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp)\n" ++
+  "  mv s0, a0                   # inner_rlp ptr\n" ++
+  "  mv s1, a1                   # inner_rlp len\n" ++
+  "  mv s2, a2                   # n_fields\n" ++
+  "  mv s3, a3                   # type_prefix (low byte)\n" ++
+  "  mv s4, a4                   # output hash ptr (32 B)\n" ++
+  "  # ---- Write optional type prefix at tsh_buf[0] ----\n" ++
+  "  la t0, tsh_buf\n" ++
+  "  beqz s3, .Ltsh_after_prefix\n" ++
+  "  sb s3, 0(t0)\n" ++
+  ".Ltsh_after_prefix:\n" ++
+  "  # ---- Truncate inner_rlp into tsh_buf[1..] ----\n" ++
+  "  mv a0, s0; mv a1, s1; mv a2, s2\n" ++
+  "  la a3, tsh_buf; addi a3, a3, 1\n" ++
+  "  la a4, tsh_trunc_len\n" ++
+  "  jal ra, rlp_list_truncate_to_n_fields\n" ++
+  "  bnez a0, .Ltsh_fail\n" ++
+  "  la t0, tsh_trunc_len; ld t1, 0(t0)        # trunc_len\n" ++
+  "  # ---- Compute (hash_data_ptr, hash_data_len) ----\n" ++
+  "  beqz s3, .Ltsh_no_prefix\n" ++
+  "  la a0, tsh_buf                            # start at byte 0 (prefix)\n" ++
+  "  addi a1, t1, 1                            # length = trunc_len + 1\n" ++
+  "  j .Ltsh_do_hash\n" ++
+  ".Ltsh_no_prefix:\n" ++
+  "  la a0, tsh_buf; addi a0, a0, 1            # start at byte 1\n" ++
+  "  mv a1, t1                                 # length = trunc_len\n" ++
+  ".Ltsh_do_hash:\n" ++
+  "  mv a2, s4                                 # output ptr\n" ++
+  "  jal ra, zkvm_keccak256\n" ++
+  "  li a0, 0\n" ++
+  "  j .Ltsh_ret\n" ++
+  ".Ltsh_fail:\n" ++
+  "  li a0, 1\n" ++
+  ".Ltsh_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp)\n" ++
+  "  addi sp, sp, 48\n" ++
+  "  ret"
+
+/-- `zisk_tx_signing_hash`: probe BuildUnit.
+    Input layout:
+      bytes  0.. 8 : inner_rlp_len
+      bytes  8..16 : n_fields (u64 LE)
+      bytes 16..24 : type_prefix (u64 LE; low byte is the byte;
+                     0 = no prefix)
+      bytes 24..   : inner_rlp
+    Output layout:
+      bytes  0.. 8 : status
+      bytes  8..40 : 32-byte signing hash -/
+def ziskTxSigningHashPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a5, 0x40000000\n" ++
+  "  ld a1, 8(a5)                # inner_rlp_len\n" ++
+  "  ld a2, 16(a5)               # n_fields\n" ++
+  "  ld a3, 24(a5)               # type_prefix (u64; low byte)\n" ++
+  "  addi a0, a5, 32             # inner_rlp ptr\n" ++
+  "  li a4, 0xa0010008           # output hash ptr (32 B)\n" ++
+  "  jal ra, tx_signing_hash\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Ltsh_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpEncodeListPrefixFunction ++ "\n" ++
+  rlpListTruncateToNFieldsFunction ++ "\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  txSigningHashFunction ++ "\n" ++
+  ".Ltsh_pdone:"
+
+def ziskTxSigningHashDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  "tsh_buf:\n" ++
+  "  .zero 8192\n" ++
+  "tsh_trunc_len:\n" ++
+  "  .zero 8\n" ++
+  -- Scratch labels owned by `rlp_list_truncate_to_n_fields` (K144);
+  -- the truncate function references them at fixed offsets through
+  -- `la`, so we re-declare them in this probe's `.data` section.
+  "rltn_offset_lo:\n" ++
+  "  .zero 8\n" ++
+  "rltn_length_lo:\n" ++
+  "  .zero 8\n" ++
+  "rltn_offset_hi:\n" ++
+  "  .zero 8\n" ++
+  "rltn_length_hi:\n" ++
+  "  .zero 8\n" ++
+  "rltn_prefix_len:\n" ++
+  "  .zero 8"
+
+def ziskTxSigningHashProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskTxSigningHashPrologue
+  dataAsm     := ziskTxSigningHashDataSection
+}
+
 /-! ## blob_gas_used_from_versioned_hashes -- PR-K64
 
     Compute the EIP-4844 `blob_gas_used` field as:

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **167**
-- ziskemu round-trip scripts: **160** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **168**
+- ziskemu round-trip scripts: **161** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-tx-signing-hash-check.sh
+++ b/scripts/codegen-zisk-tx-signing-hash-check.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# codegen-zisk-tx-signing-hash-check.sh -- PR-K145.
+#
+# Unified tx signing-hash builder: keccak256([type_prefix?] || rlp([first n fields])).
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_tx_signing_hash ELF"
+lake exe codegen --program zisk_tx_signing_hash --halt linux93 \
+  -o gen-out/zisk_tx_signing_hash
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <fields_json> <n> <type_prefix>
+run_case() {
+  local name="$1" fields="$2" n="$3" prefix="$4"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_tx_signing_hash_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_tx_signing_hash_${name}.output"
+  local exp_hex_file="$REPO_ROOT/gen-out/zisk_tx_signing_hash_${name}.expected.hex"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import hashlib, json, struct, sys, rlp
+try:
+    from Crypto.Hash import keccak
+    def keccak256(b):
+        h = keccak.new(digest_bits=256); h.update(b); return h.digest()
+except Exception:
+    # Fallback to pysha3 if installed
+    import sha3
+    def keccak256(b): return sha3.keccak_256(b).digest()
+
+fields_raw = json.loads('''$fields''')
+def conv(x):
+    if isinstance(x, str) and x.startswith('hex:'): return bytes.fromhex(x[4:])
+    if isinstance(x, list): return [conv(e) for e in x]
+    return x
+fields = [conv(f) for f in fields_raw]
+n = $n
+prefix = $prefix
+inner_rlp = rlp.encode(fields)
+truncated = rlp.encode(fields[:n])
+hash_input = (bytes([prefix]) if prefix != 0 else b'') + truncated
+expected = keccak256(hash_input)
+with open(sys.argv[1], 'wb') as f:
+    f.write(struct.pack('<Q', len(inner_rlp)))
+    f.write(struct.pack('<Q', n))
+    f.write(struct.pack('<Q', prefix))
+    f.write(inner_rlp)
+    pad = (-(24 + len(inner_rlp))) % 8
+    if pad: f.write(b'\x00' * pad)
+with open(sys.argv[2], 'w') as f:
+    f.write(expected.hex())
+" "$in_file" "$exp_hex_file"
+
+  "$ZISKEMU" -e gen-out/zisk_tx_signing_hash.elf \
+    -i "$in_file" -o "$out_file" -n 5000000 \
+    >"$REPO_ROOT/gen-out/zisk_tx_signing_hash_${name}.emu.log" 2>&1 || true
+
+  local actual_status; actual_status="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local actual_hash;   actual_hash="$(dd if="$out_file" bs=1 skip=8 count=32 2>/dev/null | xxd -p | tr -d '\n')"
+  local expected_hex;  expected_hex="$(cat "$exp_hex_file")"
+
+  if [[ "$actual_status" == "0000000000000000" && "$actual_hash" == "$expected_hex" ]]; then
+    printf "  %-30s OK   n=%d prefix=0x%02x hash=%s...\n" "$name" "$n" "$prefix" "${actual_hash:0:16}"
+    return 0
+  else
+    printf "  %-30s FAIL status=0x%s\n" "$name" "$actual_status"
+    printf "      actual:   %s\n" "$actual_hash"
+    printf "      expected: %s\n" "$expected_hex"
+    return 1
+  fi
+}
+
+# Standard tx fields used by the cases below.
+ALICE='"hex:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"'
+R32='"hex:1111111111111111111111111111111111111111111111111111111111111111"'
+S32='"hex:2222222222222222222222222222222222222222222222222222222222222222"'
+
+FAILED=0
+# Legacy pre-EIP-155: 9 fields → 6, no type prefix (prefix=0).
+run_case "legacy_pre_eip155" \
+  "[42, 1000000000, 21000, $ALICE, 1000000000000000000, \"\", 27, $R32, $S32]" \
+  6 0 || FAILED=1
+
+# EIP-2930 (type 1): 11 fields → 8, type prefix 0x01.
+run_case "eip2930" \
+  "[1, 42, 1000000000, 21000, $ALICE, 1000000000000000000, \"\", [], 1, $R32, $S32]" \
+  8 1 || FAILED=1
+
+# EIP-1559 (type 2): 12 fields → 9, type prefix 0x02.
+run_case "eip1559" \
+  "[1, 42, 1000000000, 2000000000, 21000, $ALICE, 1000000000000000000, \"\", [], 1, $R32, $S32]" \
+  9 2 || FAILED=1
+
+# EIP-4844 (type 3): 14 fields → 11, type prefix 0x03.
+run_case "eip4844" \
+  "[1, 42, 1000000000, 2000000000, 21000, $ALICE, 1000000000000000000, \"\", [], 1000000000, [\"hex:01abababababababababababababababababababababababababababababababab\"], 1, $R32, $S32]" \
+  11 3 || FAILED=1
+
+# EIP-7702 (type 4): 13 fields → 10, type prefix 0x04.
+run_case "eip7702" \
+  "[1, 42, 1000000000, 2000000000, 21000, $ALICE, 1000000000000000000, \"\", [], [[1, \"hex:dededededededededededededededededededede\", 0, 1, $R32, $S32]], 1, $R32, $S32]" \
+  10 4 || FAILED=1
+
+# Smoke: empty list (just to verify n=0 + prefix codepath).
+run_case "empty_list_no_prefix" "[1, 2, 3]" 0 0 || FAILED=1
+run_case "empty_list_prefix_02" "[1, 2, 3]" 0 2 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: tx_signing_hash matches keccak256(prefix || rlp([first n])) for all tx types"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- \`tx_signing_hash\`: unified transaction signing-hash builder. Given a tx inner RLP, a field count \`n\`, and an optional type-prefix byte, compute \`keccak256([type_prefix?] || rlp([first n fields]))\` in a single call.
- **Completes the sender-recovery pipeline** for legacy-pre-EIP-155 / EIP-2930 / EIP-1559 / EIP-4844 / EIP-7702: combined with the K138-K142 sig extractors and the upcoming \`zkvm_secp256k1_ecrecover\` accelerator wiring, the verifier can now recover a tx sender from any of those five formats.
- Composes PR-K144 \`rlp_list_truncate_to_n_fields\` (truncation) and the existing \`zkvm_keccak256\` bridge (hashing).
- Function + probe defs live in \`Programs/Tx.lean\`; registry entries in \`Programs.lean\`.

### Per-tx-type usage

| type | type_prefix | n |
|---|---|---|
| legacy pre-EIP-155 | 0 | 6 |
| EIP-2930 | 0x01 | 8 |
| EIP-1559 | 0x02 | 9 |
| EIP-4844 | 0x03 | 11 |
| EIP-7702 | 0x04 | 10 |

### Out of scope (separate follow-ups)

- **Legacy EIP-155 signing hash**: appends \`(chain_id, 0, 0)\` after the first 6 fields — requires building a new 9-field list rather than just truncating. Will need a dedicated \`tx_signing_hash_legacy_eip155\` helper.
- **EIP-7702 authorization signing hash**: \`MAGIC=0x05 || rlp([chain_id, address, nonce])\` — a 3-field body freshly built from the authorization tuple, distinct from any truncation. Separate \`eip7702_authorization_signing_hash\` helper.

### Calling convention

| reg | role |
|---|---|
| a0 | tx_inner_rlp ptr (caller strips any leading type byte) |
| a1 | tx_inner_rlp byte length |
| a2 | n_fields (u64) — fields to keep |
| a3 | type_prefix (u8 in low bits; 0 = no prefix) |
| a4 | 32-byte output hash ptr |
| a0 (out) | 0 = ok, 1 = truncation parse fail / fewer than n fields |

Uses an 8 KiB \`tsh_buf\` scratch holding \`[optional type byte] || rlp([first n fields])\` immediately before the keccak call; the keccak bridge's \`zk3_state\` is re-declared in the probe's data section.

## Stacking

Base = \`feat/stateless-rlp-list-truncate-to-n-fields\` (PR #5916); GitHub auto-retargets to \`main\` on merge.

## Test plan

- [x] \`lake build\` clean
- [x] \`scripts/codegen-zisk-tx-signing-hash-check.sh\` — 7/7 fixtures pass against Python \`keccak256\`:
  - \`legacy_pre_eip155\`: n=6, prefix=0
  - \`eip2930\`, \`eip1559\`, \`eip4844\`, \`eip7702\`: one per typed tx
  - \`empty_list_no_prefix\`, \`empty_list_prefix_02\`: n=0 degenerate cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)