### PR TITLE
feat(stateless): tx_signing_hash_legacy_eip155 (PR-K146) + K144 fix

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -4670,75 +4670,8 @@ def ziskSlotAtIndexProbeUnit : BuildUnit := {
   dataAsm     := ziskSlotAtIndexDataSection
 }
 
-/-! ## rlp_encode_uint_be -- PR-K30 RLP canonical-form encoder
+/-! ## rlp_encode_uint_be -- PR-K30 — def moved to `Programs/RlpRead.lean`. -/
 
-    Strip leading zeros from a big-endian byte array and emit
-    the canonical RLP encoding:
-
-      value == 0       → 0x80 (1 byte; RLP empty bytes)
-      value < 0x80     → single byte = value
-      else (1..32 B)   → 0x80 + len  +  stripped BE bytes
-
-    Building block for `account_encode` (PR-K31+), which calls
-    this for the nonce / balance fields, and for state-root
-    recompute after MPT mutation.
-
-    Calling convention:
-      a0 (input)  : src bytes ptr (BE, possibly with leading zeros)
-      a1 (input)  : src byte length (any; typical: 8 for u64,
-                    32 for u256)
-      a2 (input)  : output buffer ptr (≥ a1 + 1 bytes capacity)
-      ra (input)  : return
-      a0 (output) : number of bytes written
-
-    Pure register arithmetic, no scratch, leaf-callable. -/
-def rlpEncodeUintBeFunction : String :=
-  "rlp_encode_uint_be:\n" ++
-  "  # Find first non-zero byte; stripped_len = src_len - leading_zeros.\n" ++
-  "  mv t0, a0\n" ++
-  "  mv t1, a1\n" ++
-  ".Lreu_skip_zero:\n" ++
-  "  beqz t1, .Lreu_all_zero\n" ++
-  "  lbu t3, 0(t0)\n" ++
-  "  bnez t3, .Lreu_have\n" ++
-  "  addi t0, t0, 1\n" ++
-  "  addi t1, t1, -1\n" ++
-  "  j .Lreu_skip_zero\n" ++
-  ".Lreu_all_zero:\n" ++
-  "  li t3, 0x80\n" ++
-  "  sb t3, 0(a2)\n" ++
-  "  li a0, 1\n" ++
-  "  ret\n" ++
-  ".Lreu_have:\n" ++
-  "  # t0 = ptr to first non-zero byte; t1 = stripped_len.\n" ++
-  "  mv t6, t1\n" ++
-  "  li t3, 1\n" ++
-  "  bne t1, t3, .Lreu_multi\n" ++
-  "  lbu t4, 0(t0)\n" ++
-  "  li t5, 0x80\n" ++
-  "  bgeu t4, t5, .Lreu_multi\n" ++
-  "  # Single-byte form.\n" ++
-  "  sb t4, 0(a2)\n" ++
-  "  li a0, 1\n" ++
-  "  ret\n" ++
-  ".Lreu_multi:\n" ++
-  "  # Short-string form: 0x80 + stripped_len, then stripped bytes.\n" ++
-  "  li t3, 0x80\n" ++
-  "  add t3, t3, t6\n" ++
-  "  sb t3, 0(a2)\n" ++
-  "  addi t4, a2, 1\n" ++
-  "  mv t1, t6\n" ++
-  ".Lreu_copy:\n" ++
-  "  beqz t1, .Lreu_done\n" ++
-  "  lbu t5, 0(t0)\n" ++
-  "  sb  t5, 0(t4)\n" ++
-  "  addi t0, t0, 1\n" ++
-  "  addi t4, t4, 1\n" ++
-  "  addi t1, t1, -1\n" ++
-  "  j .Lreu_copy\n" ++
-  ".Lreu_done:\n" ++
-  "  addi a0, t6, 1               # 1 + stripped_len\n" ++
-  "  ret"
 
 /-- `zisk_rlp_encode_uint_be`: probe BuildUnit. Reads
     (src_len, src_bytes) from host input, writes
@@ -10048,6 +9981,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_eip7702_authorization_extract_signature" => some ziskEip7702AuthorizationExtractSignatureProbeUnit
   | "zisk_rlp_list_truncate_to_n_fields" => some ziskRlpListTruncateToNFieldsProbeUnit
   | "zisk_tx_signing_hash" => some ziskTxSigningHashProbeUnit
+  | "zisk_tx_signing_hash_legacy_eip155" => some ziskTxSigningHashLegacyEip155ProbeUnit
   | "zisk_header_minimal_decode" => some ziskHeaderMinimalDecodeProbeUnit
   | "zisk_header_extended_decode" => some ziskHeaderExtendedDecodeProbeUnit
   | "zisk_coinbase_extract_from_header" => some ziskCoinbaseExtractFromHeaderProbeUnit
@@ -10207,6 +10141,7 @@ def knownProgramNames : List String :=
    "zisk_eip7702_authorization_extract_signature",
    "zisk_rlp_list_truncate_to_n_fields",
    "zisk_tx_signing_hash",
+   "zisk_tx_signing_hash_legacy_eip155",
    "zisk_header_minimal_decode",
    "zisk_header_extended_decode",
    "zisk_coinbase_extract_from_header",

--- a/EvmAsm/Codegen/Programs/RlpRead.lean
+++ b/EvmAsm/Codegen/Programs/RlpRead.lean
@@ -428,4 +428,75 @@ def rlpEncodeListPrefixFunction : String :=
   "  li a0, 0\n" ++
   "  ret"
 
+
+/-! ## rlp_encode_uint_be -- PR-K30 RLP canonical-form encoder
+
+    Strip leading zeros from a big-endian byte array and emit
+    the canonical RLP encoding:
+
+      value == 0       → 0x80 (1 byte; RLP empty bytes)
+      value < 0x80     → single byte = value
+      else (1..32 B)   → 0x80 + len  +  stripped BE bytes
+
+    Building block for `account_encode` (PR-K31+), which calls
+    this for the nonce / balance fields, and for state-root
+    recompute after MPT mutation.
+
+    Calling convention:
+      a0 (input)  : src bytes ptr (BE, possibly with leading zeros)
+      a1 (input)  : src byte length (any; typical: 8 for u64,
+                    32 for u256)
+      a2 (input)  : output buffer ptr (≥ a1 + 1 bytes capacity)
+      ra (input)  : return
+      a0 (output) : number of bytes written
+
+    Pure register arithmetic, no scratch, leaf-callable. -/
+def rlpEncodeUintBeFunction : String :=
+  "rlp_encode_uint_be:\n" ++
+  "  # Find first non-zero byte; stripped_len = src_len - leading_zeros.\n" ++
+  "  mv t0, a0\n" ++
+  "  mv t1, a1\n" ++
+  ".Lreu_skip_zero:\n" ++
+  "  beqz t1, .Lreu_all_zero\n" ++
+  "  lbu t3, 0(t0)\n" ++
+  "  bnez t3, .Lreu_have\n" ++
+  "  addi t0, t0, 1\n" ++
+  "  addi t1, t1, -1\n" ++
+  "  j .Lreu_skip_zero\n" ++
+  ".Lreu_all_zero:\n" ++
+  "  li t3, 0x80\n" ++
+  "  sb t3, 0(a2)\n" ++
+  "  li a0, 1\n" ++
+  "  ret\n" ++
+  ".Lreu_have:\n" ++
+  "  # t0 = ptr to first non-zero byte; t1 = stripped_len.\n" ++
+  "  mv t6, t1\n" ++
+  "  li t3, 1\n" ++
+  "  bne t1, t3, .Lreu_multi\n" ++
+  "  lbu t4, 0(t0)\n" ++
+  "  li t5, 0x80\n" ++
+  "  bgeu t4, t5, .Lreu_multi\n" ++
+  "  # Single-byte form.\n" ++
+  "  sb t4, 0(a2)\n" ++
+  "  li a0, 1\n" ++
+  "  ret\n" ++
+  ".Lreu_multi:\n" ++
+  "  # Short-string form: 0x80 + stripped_len, then stripped bytes.\n" ++
+  "  li t3, 0x80\n" ++
+  "  add t3, t3, t6\n" ++
+  "  sb t3, 0(a2)\n" ++
+  "  addi t4, a2, 1\n" ++
+  "  mv t1, t6\n" ++
+  ".Lreu_copy:\n" ++
+  "  beqz t1, .Lreu_done\n" ++
+  "  lbu t5, 0(t0)\n" ++
+  "  sb  t5, 0(t4)\n" ++
+  "  addi t0, t0, 1\n" ++
+  "  addi t4, t4, 1\n" ++
+  "  addi t1, t1, -1\n" ++
+  "  j .Lreu_copy\n" ++
+  ".Lreu_done:\n" ++
+  "  addi a0, t6, 1               # 1 + stripped_len\n" ++
+  "  ret"
+
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/Tx.lean
+++ b/EvmAsm/Codegen/Programs/Tx.lean
@@ -1814,21 +1814,34 @@ def rlpListTruncateToNFieldsFunction : String :=
   "  mv s3, a3                   # output buffer ptr\n" ++
   "  mv s4, a4                   # out_length ptr\n" ++
   "  beqz s2, .Lrltn_empty       # n == 0 → emit `0xc0`\n" ++
-  "  # ---- Locate field 0 to get payload_start ----\n" ++
-  "  mv a0, s0; mv a1, s1; li a2, 0\n" ++
-  "  la a3, rltn_offset_lo; la a4, rltn_length_lo\n" ++
-  "  jal ra, rlp_list_nth_item\n" ++
-  "  bnez a0, .Lrltn_parse_fail\n" ++
+  "  # ---- Parse the outer list prefix to get payload_start ----\n" ++
+  "  # NOTE: we cannot use `rlp_list_nth_item(input, 0)` for this:\n" ++
+  "  # K20 returns the *content* offset for byte-string items, which\n" ++
+  "  # drops the field's RLP prefix byte. The truncation needs the\n" ++
+  "  # *item* offset = start of the outer payload = byte after the\n" ++
+  "  # outer list prefix.\n" ++
+  "  beqz s1, .Lrltn_parse_fail\n" ++
+  "  lbu t0, 0(s0)\n" ++
+  "  li t1, 0xc0\n" ++
+  "  bltu t0, t1, .Lrltn_parse_fail   # not an RLP list\n" ++
+  "  li t1, 0xf8\n" ++
+  "  bltu t0, t1, .Lrltn_short_list\n" ++
+  "  # Long list: payload_start = 1 + (t0 - 0xf7)\n" ++
+  "  addi s5, t0, -0xf7\n" ++
+  "  addi s5, s5, 1\n" ++
+  "  j .Lrltn_have_start\n" ++
+  ".Lrltn_short_list:\n" ++
+  "  li s5, 1                          # payload_start = 1\n" ++
+  ".Lrltn_have_start:\n" ++
   "  # ---- Locate field (n-1) to get end-of-payload ----\n" ++
   "  addi t0, s2, -1\n" ++
   "  mv a0, s0; mv a1, s1; mv a2, t0\n" ++
   "  la a3, rltn_offset_hi; la a4, rltn_length_hi\n" ++
   "  jal ra, rlp_list_nth_item\n" ++
   "  bnez a0, .Lrltn_too_few\n" ++
-  "  la t0, rltn_offset_lo; ld s5, 0(t0)        # payload_start\n" ++
   "  la t0, rltn_offset_hi; ld t1, 0(t0)\n" ++
   "  la t0, rltn_length_hi; ld t2, 0(t0)\n" ++
-  "  add t1, t1, t2                              # end-of-payload\n" ++
+  "  add t1, t1, t2                              # end-of-payload (after item n-1)\n" ++
   "  sub s6, t1, s5                              # new_payload_len\n" ++
   "  # ---- Write new outer list prefix ----\n" ++
   "  mv a0, s6; mv a1, s3\n" ++
@@ -2076,6 +2089,211 @@ def ziskTxSigningHashProbeUnit : BuildUnit := {
   body        := NOP
   prologueAsm := ziskTxSigningHashPrologue
   dataAsm     := ziskTxSigningHashDataSection
+}
+
+/-! ## tx_signing_hash_legacy_eip155 -- PR-K146
+
+    Legacy EIP-155 signing hash. Different from the typed-tx and
+    pre-EIP-155 cases (PR-K145 `tx_signing_hash`) because the
+    EIP-155 spec appends `(chain_id, 0, 0)` after the first six
+    fields rather than just truncating:
+
+      signing_hash = keccak256(rlp([nonce, gas_price, gas_limit,
+                                    to, value, data,
+                                    chain_id, 0, 0]))
+
+    So we splice rather than truncate:
+
+      new_payload = [old payload bytes of fields 0..5]
+                 || [RLP-canonical-encoded chain_id]
+                 || 0x80
+                 || 0x80
+
+      signing_hash = keccak256(new_outer_prefix || new_payload)
+
+    Used by every post-Spurious-Dragon mainnet legacy tx; the
+    pre-EIP-155 variant (`v ∈ {27, 28}`) is rare on modern
+    chains. PR-K37 `derive_chain_id_from_v` distinguishes the
+    two — caller routes here when `is_eip155 == 1`.
+
+    Composes:
+      - PR-K20 `rlp_list_nth_item`     -- locate fields 0 / 5
+      - PR-K30 `rlp_encode_uint_be`    -- chain_id encoding
+      - PR-K129 `rlp_encode_list_prefix` -- new outer prefix
+      - `zkvm_keccak256` (HashBridge)  -- hashing
+
+    Calling convention:
+      a0 (input)  : legacy_tx_rlp ptr (9-field RLP with v,r,s)
+      a1 (input)  : legacy_tx_rlp byte length
+      a2 (input)  : chain_id (u64)
+      a3 (input)  : 32-byte output hash ptr
+      ra (input)  : return
+      a0 (output) :
+        0 : success
+        1 : RLP parse failure / fewer than 6 fields -/
+def txSigningHashLegacyEip155Function : String :=
+  "tx_signing_hash_legacy_eip155:\n" ++
+  "  addi sp, sp, -56\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp)\n" ++
+  "  mv s0, a0                   # tx_rlp ptr\n" ++
+  "  mv s1, a1                   # tx_rlp len\n" ++
+  "  mv s2, a2                   # chain_id\n" ++
+  "  mv s3, a3                   # output hash ptr\n" ++
+  "  # ---- Parse outer list prefix to get payload_start ----\n" ++
+  "  # NOTE: K20 returns content offsets, not item-start offsets.\n" ++
+  "  # We need the byte right after the outer list prefix.\n" ++
+  "  beqz s1, .Lt155_fail\n" ++
+  "  lbu t0, 0(s0)\n" ++
+  "  li t1, 0xc0\n" ++
+  "  bltu t0, t1, .Lt155_fail\n" ++
+  "  li t1, 0xf8\n" ++
+  "  bltu t0, t1, .Lt155_short_list\n" ++
+  "  addi s4, t0, -0xf7\n" ++
+  "  addi s4, s4, 1                              # payload_start\n" ++
+  "  j .Lt155_have_start\n" ++
+  ".Lt155_short_list:\n" ++
+  "  li s4, 1\n" ++
+  ".Lt155_have_start:\n" ++
+  "  # ---- Locate field 5 to get end-of-body ----\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 5\n" ++
+  "  la a3, t155_offset_hi; la a4, t155_length_hi\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lt155_fail\n" ++
+  "  la t0, t155_offset_hi; ld t1, 0(t0)\n" ++
+  "  la t0, t155_length_hi; ld t2, 0(t0)\n" ++
+  "  add t1, t1, t2                              # end-of-body\n" ++
+  "  sub s5, t1, s4                              # body_len\n" ++
+  "  # ---- Encode chain_id as canonical RLP into t155_chain_be ----\n" ++
+  "  # Write chain_id as 8 BE bytes to t155_chain_be\n" ++
+  "  la t0, t155_chain_be\n" ++
+  "  li t1, 7\n" ++
+  ".Lt155_chain_be_loop:\n" ++
+  "  bltz t1, .Lt155_chain_be_done\n" ++
+  "  slli t2, t1, 3\n" ++
+  "  srl t3, s2, t2\n" ++
+  "  andi t3, t3, 0xff\n" ++
+  "  sb t3, 0(t0)\n" ++
+  "  addi t0, t0, 1\n" ++
+  "  addi t1, t1, -1\n" ++
+  "  j .Lt155_chain_be_loop\n" ++
+  ".Lt155_chain_be_done:\n" ++
+  "  la a0, t155_chain_be; li a1, 8\n" ++
+  "  la a2, t155_chain_enc\n" ++
+  "  jal ra, rlp_encode_uint_be\n" ++
+  "  mv t3, a0                                   # chain_id_enc_len\n" ++
+  "  # tail_len = chain_id_enc_len + 2  (two 0x80 bytes for 0, 0)\n" ++
+  "  addi t3, t3, 2\n" ++
+  "  # new_payload_len = body_len + tail_len\n" ++
+  "  add t4, s5, t3                              # new_payload_len\n" ++
+  "  # ---- Write new outer list prefix into t155_buf ----\n" ++
+  "  mv a0, t4; la a1, t155_buf\n" ++
+  "  la a2, t155_prefix_len\n" ++
+  "  jal ra, rlp_encode_list_prefix\n" ++
+  "  la t0, t155_prefix_len; ld t5, 0(t0)        # prefix_len\n" ++
+  "  # ---- Copy body bytes after the prefix ----\n" ++
+  "  la t0, t155_buf; add t0, t0, t5             # dst\n" ++
+  "  add t1, s0, s4                              # src = input + payload_start\n" ++
+  "  mv t2, s5                                   # body bytes remaining\n" ++
+  ".Lt155_body_cp:\n" ++
+  "  beqz t2, .Lt155_body_done\n" ++
+  "  lbu t6, 0(t1)\n" ++
+  "  sb t6, 0(t0)\n" ++
+  "  addi t0, t0, 1\n" ++
+  "  addi t1, t1, 1\n" ++
+  "  addi t2, t2, -1\n" ++
+  "  j .Lt155_body_cp\n" ++
+  ".Lt155_body_done:\n" ++
+  "  # ---- Append encoded chain_id ----\n" ++
+  "  la t1, t155_chain_enc\n" ++
+  "  la t6, t155_prefix_len; ld t6, 0(t6)        # reload prefix_len\n" ++
+  "  # Reload chain_id_enc_len: re-derive from tail_len-2 ... easier to recompute\n" ++
+  "  # Actually we lost t3 above; recompute by saving differently. Use t4 - s5 - 2.\n" ++
+  "  sub t2, t4, s5\n" ++
+  "  addi t2, t2, -2                             # chain_id_enc_len\n" ++
+  ".Lt155_chain_cp:\n" ++
+  "  beqz t2, .Lt155_chain_done\n" ++
+  "  lbu t6, 0(t1)\n" ++
+  "  sb t6, 0(t0)\n" ++
+  "  addi t0, t0, 1\n" ++
+  "  addi t1, t1, 1\n" ++
+  "  addi t2, t2, -1\n" ++
+  "  j .Lt155_chain_cp\n" ++
+  ".Lt155_chain_done:\n" ++
+  "  # ---- Append two 0x80 bytes for (0, 0) tail ----\n" ++
+  "  li t6, 0x80\n" ++
+  "  sb t6, 0(t0)\n" ++
+  "  sb t6, 1(t0)\n" ++
+  "  # ---- Total hash input length = prefix_len + new_payload_len ----\n" ++
+  "  la t0, t155_prefix_len; ld t6, 0(t0)\n" ++
+  "  add a1, t6, t4                              # total length\n" ++
+  "  la a0, t155_buf                             # data ptr\n" ++
+  "  mv a2, s3                                   # output hash ptr\n" ++
+  "  jal ra, zkvm_keccak256\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lt155_ret\n" ++
+  ".Lt155_fail:\n" ++
+  "  li a0, 1\n" ++
+  ".Lt155_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp)\n" ++
+  "  addi sp, sp, 56\n" ++
+  "  ret"
+
+/-- `zisk_tx_signing_hash_legacy_eip155`: probe BuildUnit.
+    Input layout:
+      bytes  0.. 8 : tx_rlp_len
+      bytes  8..16 : chain_id (u64 LE)
+      bytes 16..   : tx_rlp (full 9-field)
+    Output layout:
+      bytes  0.. 8 : status
+      bytes  8..40 : 32-byte signing hash -/
+def ziskTxSigningHashLegacyEip155Prologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a5, 0x40000000\n" ++
+  "  ld a1, 8(a5)                # tx_rlp_len\n" ++
+  "  ld a2, 16(a5)               # chain_id\n" ++
+  "  addi a0, a5, 24             # tx_rlp ptr\n" ++
+  "  li a3, 0xa0010008           # output hash ptr (32 B)\n" ++
+  "  jal ra, tx_signing_hash_legacy_eip155\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lt155_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpEncodeUintBeFunction ++ "\n" ++
+  rlpEncodeListPrefixFunction ++ "\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  txSigningHashLegacyEip155Function ++ "\n" ++
+  ".Lt155_pdone:"
+
+def ziskTxSigningHashLegacyEip155DataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  "t155_buf:\n" ++
+  "  .zero 8192\n" ++
+  "t155_offset_lo:\n" ++
+  "  .zero 8\n" ++
+  "t155_length_lo:\n" ++
+  "  .zero 8\n" ++
+  "t155_offset_hi:\n" ++
+  "  .zero 8\n" ++
+  "t155_length_hi:\n" ++
+  "  .zero 8\n" ++
+  "t155_chain_be:\n" ++
+  "  .zero 8\n" ++
+  "t155_chain_enc:\n" ++
+  "  .zero 9\n" ++
+  "t155_prefix_len:\n" ++
+  "  .zero 8"
+
+def ziskTxSigningHashLegacyEip155ProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskTxSigningHashLegacyEip155Prologue
+  dataAsm     := ziskTxSigningHashLegacyEip155DataSection
 }
 
 /-! ## blob_gas_used_from_versioned_hashes -- PR-K64

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **168**
-- ziskemu round-trip scripts: **161** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **169**
+- ziskemu round-trip scripts: **162** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-rlp-list-truncate-to-n-fields-check.sh
+++ b/scripts/codegen-zisk-rlp-list-truncate-to-n-fields-check.sh
@@ -105,6 +105,18 @@ run_case "auth_6to3" \
   '[1, "hex:dededededededededededededededededededede", 0, 1, "hex:1111111111111111111111111111111111111111111111111111111111111111", "hex:2222222222222222222222222222222222222222222222222222222222222222"]' \
   3 || FAILED=1
 
+# Regression: field 0 is empty bytes (RLP-canonical 0 → 0x80).
+# This trips the "K20 offset is content-not-item" trap if `payload_start`
+# is taken from `rlp_list_nth_item(0).offset` rather than parsed from the
+# outer list prefix. Pre-fix output was off-by-one for the body slice.
+run_case "field0_zero_short_str" \
+  '[0, 1000000000, 21000, "hex:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 1000000000000000000, "", 27, "hex:1111111111111111111111111111111111111111111111111111111111111111", "hex:2222222222222222222222222222222222222222222222222222222222222222"]' \
+  6 || FAILED=1
+
+# Regression: field 0 with multi-byte short-string prefix.
+run_case "field0_short_str_5b" \
+  '["hex:cafebabe00", 2, 3]' 2 || FAILED=1
+
 # n > number of fields → status 2
 in_too_few="$REPO_ROOT/gen-out/zisk_rlp_list_truncate_to_n_fields_too_few.input"
 out_too_few="$REPO_ROOT/gen-out/zisk_rlp_list_truncate_to_n_fields_too_few.output"

--- a/scripts/codegen-zisk-tx-signing-hash-legacy-eip155-check.sh
+++ b/scripts/codegen-zisk-tx-signing-hash-legacy-eip155-check.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# codegen-zisk-tx-signing-hash-legacy-eip155-check.sh -- PR-K146.
+#
+# Legacy EIP-155 signing hash:
+#   keccak256(rlp([nonce, gas_price, gas_limit, to, value, data, chain_id, 0, 0]))
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_tx_signing_hash_legacy_eip155 ELF"
+lake exe codegen --program zisk_tx_signing_hash_legacy_eip155 --halt linux93 \
+  -o gen-out/zisk_tx_signing_hash_legacy_eip155
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <chain_id> <nonce> <to_hex_or_empty>
+run_case() {
+  local name="$1" cid="$2" nonce="$3" to="$4"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_tx_signing_hash_legacy_eip155_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_tx_signing_hash_legacy_eip155_${name}.output"
+  local exp_hex_file="$REPO_ROOT/gen-out/zisk_tx_signing_hash_legacy_eip155_${name}.expected.hex"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+try:
+    from Crypto.Hash import keccak
+    def keccak256(b):
+        h = keccak.new(digest_bits=256); h.update(b); return h.digest()
+except Exception:
+    import sha3
+    def keccak256(b): return sha3.keccak_256(b).digest()
+
+cid = $cid
+nonce = $nonce
+to_hex = '$to'
+to = bytes.fromhex(to_hex) if to_hex else b''
+# EIP-155 form: v = chain_id*2 + 35 (or +36); for the signing hash itself
+# v/r/s are zero, but the full tx contains the real v/r/s. We're using
+# the *full* legacy tx as input and the helper splices out v/r/s.
+v = cid * 2 + 35
+r = int.from_bytes(bytes([0x11]*32), 'big')
+s = int.from_bytes(bytes([0x22]*32), 'big')
+full_tx = [nonce, 10**9, 21000, to, 10**18, b'', v, r, s]
+tx_rlp = rlp.encode(full_tx)
+signing_body = [nonce, 10**9, 21000, to, 10**18, b'', cid, 0, 0]
+expected = keccak256(rlp.encode(signing_body))
+with open(sys.argv[1], 'wb') as f:
+    f.write(struct.pack('<Q', len(tx_rlp)))
+    f.write(struct.pack('<Q', cid))
+    f.write(tx_rlp)
+    pad = (-(16 + len(tx_rlp))) % 8
+    if pad: f.write(b'\x00' * pad)
+with open(sys.argv[2], 'w') as f:
+    f.write(expected.hex())
+" "$in_file" "$exp_hex_file"
+
+  "$ZISKEMU" -e gen-out/zisk_tx_signing_hash_legacy_eip155.elf \
+    -i "$in_file" -o "$out_file" -n 5000000 \
+    >"$REPO_ROOT/gen-out/zisk_tx_signing_hash_legacy_eip155_${name}.emu.log" 2>&1 || true
+
+  local actual_status; actual_status="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local actual_hash;   actual_hash="$(dd if="$out_file" bs=1 skip=8 count=32 2>/dev/null | xxd -p | tr -d '\n')"
+  local expected_hex;  expected_hex="$(cat "$exp_hex_file")"
+
+  if [[ "$actual_status" == "0000000000000000" && "$actual_hash" == "$expected_hex" ]]; then
+    printf "  %-30s OK   cid=%d nonce=%d hash=%s...\n" "$name" "$cid" "$nonce" "${actual_hash:0:16}"
+    return 0
+  else
+    printf "  %-30s FAIL status=0x%s\n" "$name" "$actual_status"
+    printf "      actual:   %s\n" "$actual_hash"
+    printf "      expected: %s\n" "$expected_hex"
+    return 1
+  fi
+}
+
+ALICE="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+FAILED=0
+# Mainnet chain_id (1) — most common case.
+run_case "mainnet_value_transfer"    1   42      "$ALICE" || FAILED=1
+# Sepolia (11155111) — chain_id large enough to require multi-byte RLP.
+run_case "sepolia_value_transfer"    11155111 99 "$ALICE" || FAILED=1
+# nonce=0 (first tx)
+run_case "mainnet_nonce_zero"        1   0       "$ALICE" || FAILED=1
+# chain_id=128 (boundary: needs 0x81 0x80 in RLP)
+run_case "chain_id_128"              128 1       "$ALICE" || FAILED=1
+# chain_id=256 (multi-byte)
+run_case "chain_id_256"              256 1       "$ALICE" || FAILED=1
+# chain_id=large u64
+run_case "chain_id_large"            1099511627775 7 "$ALICE" || FAILED=1
+# Contract-creation (to is empty)
+run_case "creation_tx"               1   3       "" || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: tx_signing_hash_legacy_eip155 matches keccak256(rlp([fields0..5, cid, 0, 0]))"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- **K146** \`tx_signing_hash_legacy_eip155\`: legacy EIP-155 signing hash. Splices \`(chain_id, 0, 0)\` after the first 6 fields and keccak-hashes the result. Used by every post-Spurious-Dragon mainnet legacy tx.
- **Bugfix** for K144 \`rlp_list_truncate_to_n_fields\`: was deriving \`payload_start\` from \`rlp_list_nth_item(input, 0).offset\`, but K20 returns *content* offsets for byte-string items (stripping the RLP prefix). Latent for typical fixtures because every shipped test had field 0 in single-byte form (0x00..0x7f); manifested for nonce=0 (field 0 = 0x80) or any short-string field 0. Now parses the outer list prefix manually.
- Side move: \`rlpEncodeUintBeFunction\` def (PR-K30) moves from \`Programs.lean\` to \`Programs/RlpRead.lean\` so Tx.lean's K146 can compose it. RlpRead.lean now hosts all three RLP encoders (K30, K128, K129) plus the two readers (K20, K47).

### How K146 differs from K145

K145 (\`tx_signing_hash\`) handles the typed-tx + pre-EIP-155 cases — those just truncate. EIP-155's signing hash *appends* synthetic fields \`(chain_id, 0, 0)\` rather than dropping any, so it needs distinct logic:

\`\`\`
new_payload = old payload bytes of fields 0..5    # spliced from input
           || rlp(chain_id)                       # encoded via K30
           || 0x80                                # zero u64 → RLP empty bytes
           || 0x80                                # zero u64 → RLP empty bytes

signing_hash = keccak256(new_outer_prefix || new_payload)
\`\`\`

### Calling convention

| reg | role |
|---|---|
| a0 | legacy_tx_rlp ptr (9-field RLP with v, r, s) |
| a1 | legacy_tx_rlp byte length |
| a2 | chain_id (u64) |
| a3 | 32-byte output hash ptr |
| a0 (out) | 0 = ok, 1 = parse fail |

Composes K20 + K30 + K129 + \`zkvm_keccak256\`.

## Test plan

- [x] \`lake build\` clean
- [x] K146 fixtures (7/7) verified against Python \`keccak256\`:
  - \`mainnet_value_transfer\`, \`sepolia_value_transfer\`, \`mainnet_nonce_zero\`, \`chain_id_128\`, \`chain_id_256\`, \`chain_id_large\`, \`creation_tx\`
- [x] K144 regression fixtures (\`field0_zero_short_str\`, \`field0_short_str_5b\`) lock in the bugfix
- [x] All prior K144 and K145 fixtures still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)