### PR TITLE
feat(stateless): eip7702_authorization_signing_hash (PR-K147)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -9982,6 +9982,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_rlp_list_truncate_to_n_fields" => some ziskRlpListTruncateToNFieldsProbeUnit
   | "zisk_tx_signing_hash" => some ziskTxSigningHashProbeUnit
   | "zisk_tx_signing_hash_legacy_eip155" => some ziskTxSigningHashLegacyEip155ProbeUnit
+  | "zisk_eip7702_authorization_signing_hash" => some ziskEip7702AuthorizationSigningHashProbeUnit
   | "zisk_header_minimal_decode" => some ziskHeaderMinimalDecodeProbeUnit
   | "zisk_header_extended_decode" => some ziskHeaderExtendedDecodeProbeUnit
   | "zisk_coinbase_extract_from_header" => some ziskCoinbaseExtractFromHeaderProbeUnit
@@ -10142,6 +10143,7 @@ def knownProgramNames : List String :=
    "zisk_rlp_list_truncate_to_n_fields",
    "zisk_tx_signing_hash",
    "zisk_tx_signing_hash_legacy_eip155",
+   "zisk_eip7702_authorization_signing_hash",
    "zisk_header_minimal_decode",
    "zisk_header_extended_decode",
    "zisk_coinbase_extract_from_header",

--- a/EvmAsm/Codegen/Programs/Tx.lean
+++ b/EvmAsm/Codegen/Programs/Tx.lean
@@ -2296,6 +2296,113 @@ def ziskTxSigningHashLegacyEip155ProbeUnit : BuildUnit := {
   dataAsm     := ziskTxSigningHashLegacyEip155DataSection
 }
 
+/-! ## eip7702_authorization_signing_hash -- PR-K147
+
+    EIP-7702 per-authorization signing hash:
+
+      signing_hash =
+        keccak256(MAGIC || rlp([chain_id, address, nonce]))
+
+    where `MAGIC = 0x05`. This is the digest a delegator signs to
+    authorise their account to delegate execution to a target
+    address at a specific nonce.
+
+    Companion to PR-K143
+    `eip7702_authorization_extract_signature` (which extracts the
+    `(y_parity, r, s)` triple). Together, K143 + K147 + the
+    upcoming `zkvm_secp256k1_ecrecover` wiring + K99
+    `address_from_pubkey` recover the **delegator** address from
+    an authorization tuple.
+
+    The body operation is structurally identical to K145
+    `tx_signing_hash` with `n = 3` and `type_prefix = 0x05`:
+    truncate the 6-field authorization tuple to its first 3
+    fields and keccak the prefix-extended result. K147 is a
+    typed convenience wrapper -- callers don't need to remember
+    the MAGIC byte or the field count -- and delegates to
+    `tx_signing_hash` for the body.
+
+    Composes:
+      - PR-K145 `tx_signing_hash` (truncate + keccak)
+        which in turn composes K144 + K129 + K20 + Keccak.
+
+    Calling convention:
+      a0 (input)  : authorization_tuple_rlp ptr
+      a1 (input)  : authorization_tuple_rlp byte length
+      a2 (input)  : 32-byte output hash ptr
+      ra (input)  : return
+      a0 (output) :
+        0 : success
+        1 : RLP parse failure / fewer than 3 fields -/
+def eip7702AuthorizationSigningHashFunction : String :=
+  "eip7702_authorization_signing_hash:\n" ++
+  "  addi sp, sp, -16\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  # Forward to tx_signing_hash with n=3, type_prefix=0x05.\n" ++
+  "  # a0 = inner_rlp ptr      (unchanged)\n" ++
+  "  # a1 = inner_rlp byte len (unchanged)\n" ++
+  "  # a2 = 32-byte output ptr (move to a4 per K145 ABI)\n" ++
+  "  mv a4, a2\n" ++
+  "  li a2, 3                  # n_fields\n" ++
+  "  li a3, 0x05               # MAGIC type prefix\n" ++
+  "  jal ra, tx_signing_hash\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  addi sp, sp, 16\n" ++
+  "  ret"
+
+/-- `zisk_eip7702_authorization_signing_hash`: probe BuildUnit.
+    Input layout:
+      bytes  0.. 8 : tuple_rlp_len
+      bytes  8..   : tuple_rlp
+    Output layout:
+      bytes  0.. 8 : status
+      bytes  8..40 : 32-byte signing hash -/
+def ziskEip7702AuthorizationSigningHashPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a4, 0x40000000\n" ++
+  "  ld a1, 8(a4)                # tuple_rlp_len\n" ++
+  "  addi a0, a4, 16             # tuple_rlp ptr\n" ++
+  "  li a2, 0xa0010008           # output hash ptr (32 B)\n" ++
+  "  jal ra, eip7702_authorization_signing_hash\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Ltash_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpEncodeListPrefixFunction ++ "\n" ++
+  rlpListTruncateToNFieldsFunction ++ "\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  txSigningHashFunction ++ "\n" ++
+  eip7702AuthorizationSigningHashFunction ++ "\n" ++
+  ".Ltash_pdone:"
+
+/-- Reuse the same scratch labels as `ziskTxSigningHashDataSection`
+    (`tsh_buf`, `tsh_trunc_len`, `rltn_*`, `zk3_state`). -/
+def ziskEip7702AuthorizationSigningHashDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  "tsh_buf:\n" ++
+  "  .zero 8192\n" ++
+  "tsh_trunc_len:\n" ++
+  "  .zero 8\n" ++
+  "rltn_offset_lo:\n" ++
+  "  .zero 8\n" ++
+  "rltn_length_lo:\n" ++
+  "  .zero 8\n" ++
+  "rltn_offset_hi:\n" ++
+  "  .zero 8\n" ++
+  "rltn_length_hi:\n" ++
+  "  .zero 8\n" ++
+  "rltn_prefix_len:\n" ++
+  "  .zero 8"
+
+def ziskEip7702AuthorizationSigningHashProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskEip7702AuthorizationSigningHashPrologue
+  dataAsm     := ziskEip7702AuthorizationSigningHashDataSection
+}
+
 /-! ## blob_gas_used_from_versioned_hashes -- PR-K64
 
     Compute the EIP-4844 `blob_gas_used` field as:

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **169**
-- ziskemu round-trip scripts: **162** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **170**
+- ziskemu round-trip scripts: **163** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-eip7702-authorization-signing-hash-check.sh
+++ b/scripts/codegen-zisk-eip7702-authorization-signing-hash-check.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# codegen-zisk-eip7702-authorization-signing-hash-check.sh -- PR-K147.
+#
+# EIP-7702 per-authorization signing hash:
+#   keccak256(0x05 || rlp([chain_id, address, nonce]))
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_eip7702_authorization_signing_hash ELF"
+lake exe codegen --program zisk_eip7702_authorization_signing_hash --halt linux93 \
+  -o gen-out/zisk_eip7702_authorization_signing_hash
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <chain_id> <nonce>
+run_case() {
+  local name="$1" cid="$2" nonce="$3"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_eip7702_authorization_signing_hash_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_eip7702_authorization_signing_hash_${name}.output"
+  local exp_hex_file="$REPO_ROOT/gen-out/zisk_eip7702_authorization_signing_hash_${name}.expected.hex"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+try:
+    from Crypto.Hash import keccak
+    def keccak256(b):
+        h = keccak.new(digest_bits=256); h.update(b); return h.digest()
+except Exception:
+    import sha3
+    def keccak256(b): return sha3.keccak_256(b).digest()
+
+cid = $cid
+nonce = $nonce
+DELEGATE = bytes([0xde] * 20)
+y, r, s = 1, 0x11, 0x22
+auth_tuple = [cid, DELEGATE, nonce, y, r, s]
+tuple_rlp = rlp.encode(auth_tuple)
+expected = keccak256(bytes([0x05]) + rlp.encode([cid, DELEGATE, nonce]))
+with open(sys.argv[1], 'wb') as f:
+    f.write(struct.pack('<Q', len(tuple_rlp)))
+    f.write(tuple_rlp)
+    pad = (-(8 + len(tuple_rlp))) % 8
+    if pad: f.write(b'\x00' * pad)
+with open(sys.argv[2], 'w') as f:
+    f.write(expected.hex())
+" "$in_file" "$exp_hex_file"
+
+  "$ZISKEMU" -e gen-out/zisk_eip7702_authorization_signing_hash.elf \
+    -i "$in_file" -o "$out_file" -n 5000000 \
+    >"$REPO_ROOT/gen-out/zisk_eip7702_authorization_signing_hash_${name}.emu.log" 2>&1 || true
+
+  local actual_status; actual_status="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local actual_hash;   actual_hash="$(dd if="$out_file" bs=1 skip=8 count=32 2>/dev/null | xxd -p | tr -d '\n')"
+  local expected_hex;  expected_hex="$(cat "$exp_hex_file")"
+
+  if [[ "$actual_status" == "0000000000000000" && "$actual_hash" == "$expected_hex" ]]; then
+    printf "  %-30s OK   cid=%d nonce=%d hash=%s...\n" "$name" "$cid" "$nonce" "${actual_hash:0:16}"
+    return 0
+  else
+    printf "  %-30s FAIL status=0x%s\n" "$name" "$actual_status"
+    printf "      actual:   %s\n" "$actual_hash"
+    printf "      expected: %s\n" "$expected_hex"
+    return 1
+  fi
+}
+
+FAILED=0
+# Mainnet chain_id, typical
+run_case "mainnet_basic"          1         42         || FAILED=1
+# Sepolia chain_id (large)
+run_case "sepolia"                11155111  99         || FAILED=1
+# nonce=0 boundary (RLP-canonical empty)
+run_case "nonce_zero"             1         0          || FAILED=1
+# chain_id=0 boundary (RLP-canonical empty)
+run_case "chain_zero_nonce_zero"  0         0          || FAILED=1
+# Both fields requiring multi-byte RLP
+run_case "chain_256_nonce_300"    256       300        || FAILED=1
+# Large u64 chain_id and nonce
+run_case "max_chain_max_nonce"    $((2**63 - 1)) $((2**63 - 1))  || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: eip7702_authorization_signing_hash matches keccak256(0x05 || rlp([cid, addr, nonce]))"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- \`eip7702_authorization_signing_hash\`: EIP-7702 per-authorization signing hash. Computes \`keccak256(0x05 || rlp([chain_id, address, nonce]))\` — the digest a delegator signs to authorise their account to delegate execution to a target address at a specific nonce.
- The body operation is structurally identical to PR-K145 \`tx_signing_hash\` with \`n = 3\` and \`type_prefix = 0x05\`. K147 is a typed convenience wrapper that delegates to \`tx_signing_hash\`; callers don't need to remember the MAGIC byte or the field count.
- Function + probe defs live in \`Programs/Tx.lean\`; registry entries in \`Programs.lean\`.

### How it slots into the EIP-7702 delegation-recovery pipeline

| step | helper | input | output |
|---|---|---|---|
| 1 | K143 \`eip7702_authorization_extract_signature\` | auth tuple | (y_parity, r, s) |
| 2 | K147 (this PR) | auth tuple | 32-byte signing hash |
| 3 | \`zkvm_secp256k1_ecrecover\` (future) | (hash, sig) | 64-byte pubkey |
| 4 | K99 \`address_from_pubkey\` | pubkey | 20-byte delegator address |

### Calling convention

| reg | role |
|---|---|
| a0 | authorization_tuple_rlp ptr |
| a1 | authorization_tuple_rlp byte length |
| a2 | 32-byte output hash ptr |
| a0 (out) | 0 = ok, 1 = parse fail / fewer than 3 fields |

Composes PR-K145 \`tx_signing_hash\` (which composes K144 + K129 + K20 + \`zkvm_keccak256\`).

## Test plan

- [x] \`lake build\` clean
- [x] \`scripts/codegen-zisk-eip7702-authorization-signing-hash-check.sh\` — 6/6 fixtures pass against Python \`keccak256\`:
  - \`mainnet_basic\`, \`sepolia\`: typical chain_id values
  - \`nonce_zero\`: nonce=0 boundary (RLP-canonical empty bytes)
  - \`chain_zero_nonce_zero\`: both fields zero
  - \`chain_256_nonce_300\`: both fields requiring multi-byte RLP
  - \`max_chain_max_nonce\`: 2^63-1 stress test

🤖 Generated with [Claude Code](https://claude.com/claude-code)