### PR TITLE
feat(divmod): prove n=2 call-max-call source path (TMT)

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -75,6 +75,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopFinalPost
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopCallCallCall
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopMaxMaxMax
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopCallCallMax
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopTMT
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1V4NoNop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1V4

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNopTMT.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNopTMT.lean
@@ -1,0 +1,289 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopTMT
+
+  Three-iteration call-max-call composition for the n=2 v4/no-NOP source path.
+  j=2 takes the callable trial-division (call) path; j=1 takes the max-trial
+  branch; j=0 takes the callable trial-division (call) path.
+  Conditions: bltu_2=true (call), bltu_1=false (max), bltu_0=true (call).
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopFinalPost
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Opaque alias for the j=1 `iterN2Max` result in the n=2 call-max-call path,
+    parameterized on `r2 := r2CCCN2V4 ...`. -/
+@[irreducible]
+def r1TMTN2V4 (v0 v1 v2 v3 u0Orig1 u0 u1 u2 u3 uTop : Word) :
+    Word × Word × Word × Word × Word × Word :=
+  let r2 := r2CCCN2V4 v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  iterN2Max v0 v1 v2 v3 u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
+
+theorem r1TMTN2V4_eq (v0 v1 v2 v3 u0Orig1 u0 u1 u2 u3 uTop : Word) :
+    r1TMTN2V4 v0 v1 v2 v3 u0Orig1 u0 u1 u2 u3 uTop =
+      (let r2 := r2CCCN2V4 v0 v1 v2 v3 u0 u1 u2 u3 uTop
+       iterN2Max v0 v1 v2 v3 u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1) := by
+  delta r1TMTN2V4; rfl
+
+/-- Compact postcondition for the n=2 v4/no-NOP source path whose j=2 iteration
+    takes the callable trial-division path, j=1 takes the max-trial branch, and
+    j=0 takes the callable trial-division path again.  The j=1 max iteration does
+    not update the v4 scratch cells written by j=2, so `scratch2` (from j=2) is
+    chained directly into `scratch0`. -/
+@[irreducible]
+def loopN2CallMaxCallSourceFinalPostNoX1 (sp base : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 raVal scratchMem : Word) :
+    Assertion :=
+  let r2 := r2CCCN2V4 v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  let r1 := r1TMTN2V4 v0 v1 v2 v3 u0Orig1 u0 u1 u2 u3 uTop
+  let qHat0 := divKTrialCallV4QHat r1.2.2.1 r1.2.1 v1
+  let dLo0 := divKTrialCallV4DLo v1
+  let divUn00 := divKTrialCallV4Un0 r1.2.1
+  let scratch2 := divKTrialCallV4ScratchOut u2 u1 v1 scratchMem
+  let scratch0 := divKTrialCallV4ScratchOut r1.2.2.1 r1.2.1 v1 scratch2
+  let uBase2 := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
+  let qAddr2 := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
+  let uBase1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+  let qAddr1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+  ((loopIterPostN2CallScratchNoX1 sp base (0 : Word)
+    qHat0 dLo0 divUn00 scratch0
+    v0 v1 v2 v3 u0Orig0 r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 **
+    (.x1 ↦ᵣ raVal)) **
+    (((uBase1 + signExtend12 4064 ↦ₘ r1.2.2.2.2.2) **
+      (qAddr1 ↦ₘ r1.1)) **
+     ((uBase2 + signExtend12 4064 ↦ₘ r2.2.2.2.2.2) **
+      (qAddr2 ↦ₘ r2.1))))
+
+theorem loopN2CallMaxCallSourceFinalPostNoX1_unfold (sp base : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 raVal scratchMem : Word) :
+    loopN2CallMaxCallSourceFinalPostNoX1 sp base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 raVal scratchMem =
+    (let r2 := r2CCCN2V4 v0 v1 v2 v3 u0 u1 u2 u3 uTop
+     let r1 := r1TMTN2V4 v0 v1 v2 v3 u0Orig1 u0 u1 u2 u3 uTop
+     let qHat0 := divKTrialCallV4QHat r1.2.2.1 r1.2.1 v1
+     let dLo0 := divKTrialCallV4DLo v1
+     let divUn00 := divKTrialCallV4Un0 r1.2.1
+     let scratch2 := divKTrialCallV4ScratchOut u2 u1 v1 scratchMem
+     let scratch0 := divKTrialCallV4ScratchOut r1.2.2.1 r1.2.1 v1 scratch2
+     let uBase2 := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
+     let qAddr2 := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
+     let uBase1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+     let qAddr1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+     ((loopIterPostN2CallScratchNoX1 sp base (0 : Word)
+       qHat0 dLo0 divUn00 scratch0
+       v0 v1 v2 v3 u0Orig0 r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 **
+       (.x1 ↦ᵣ raVal)) **
+       (((uBase1 + signExtend12 4064 ↦ₘ r1.2.2.2.2.2) **
+         (qAddr1 ↦ₘ r1.1)) **
+        ((uBase2 + signExtend12 4064 ↦ₘ r2.2.2.2.2.2) **
+         (qAddr2 ↦ₘ r2.1))))) := by
+  delta loopN2CallMaxCallSourceFinalPostNoX1
+  rfl
+
+/-- Branch/runtime conditions for the n=2 v4/no-NOP source path whose j=2
+    iteration takes call, j=1 takes max, and j=0 takes call. -/
+@[irreducible]
+def loopN2CallMaxCallSourceConds
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 : Word) : Prop :=
+  let r2 := r2CCCN2V4 v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  let r1 := r1TMTN2V4 v0 v1 v2 v3 u0Orig1 u0 u1 u2 u3 uTop
+  BitVec.ult u2 v1 ∧
+  loopBodyN2CallAddbackCarry2NzV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop ∧
+  ¬BitVec.ult r2.2.2.1 v1 ∧
+  isAddbackCarry2NzN2Max v0 v1 v2 v3
+    u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1 ∧
+  BitVec.ult r1.2.2.1 v1 ∧
+  loopBodyN2CallAddbackCarry2NzV4 v0 v1 v2 v3
+    u0Orig0 r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+
+theorem loopN2CallMaxCallSourceConds_unfold
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 : Word) :
+    loopN2CallMaxCallSourceConds
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 =
+    (let r2 := r2CCCN2V4 v0 v1 v2 v3 u0 u1 u2 u3 uTop
+     let r1 := r1TMTN2V4 v0 v1 v2 v3 u0Orig1 u0 u1 u2 u3 uTop
+     BitVec.ult u2 v1 ∧
+     loopBodyN2CallAddbackCarry2NzV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop ∧
+     ¬BitVec.ult r2.2.2.1 v1 ∧
+     isAddbackCarry2NzN2Max v0 v1 v2 v3
+       u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1 ∧
+     BitVec.ult r1.2.2.1 v1 ∧
+     loopBodyN2CallAddbackCarry2NzV4 v0 v1 v2 v3
+       u0Orig0 r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1) := by
+  delta loopN2CallMaxCallSourceConds
+  rfl
+
+/-- The n=2 v4/no-NOP source path whose j=2 iteration takes the callable
+    trial-division path, j=1 takes the max-trial branch, and j=0 takes the
+    callable trial-division path again.  The j=1 max iteration leaves the v4
+    scratch cells (written by the j=2 call) intact, so `scratch2` chains
+    directly into `scratch0`. -/
+theorem divK_loop_n2_call_max_call_from_source_exact_loopIterScratch_v4_noNop
+    (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hconds :
+      loopN2CallMaxCallSourceConds v0 v1 v2 v3 u0 u1 u2 u3 uTop
+        u0Orig1 u0Orig0) :
+    cpsTripleWithin (224 + 152 + 224) (base + loopBodyOff) (base + denormOff)
+      (divCode_noNop_v4 base)
+      (loopN2PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopN2CallMaxCallSourceFinalPostNoX1 sp base
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 raVal scratchMem) := by
+  rw [loopN2CallMaxCallSourceConds_unfold] at hconds
+  simp only [r2CCCN2V4_eq, r1TMTN2V4_eq] at hconds
+  obtain ⟨hbltu_2, hcarry2_nz_2, hbltu_1, hcarry2_nz_1, hbltu_0, hcarry2_nz_0⟩ := hconds
+  -- j=2 call + j=1 max composed source theorem.
+  have JCM := divK_loop_n2_call_max_from_source_exact_loopIterScratch_v4_noNop
+    sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old raVal
+    retMem dMem dloMem scratchUn0 scratchMem
+    halign hbltu_2 hcarry2_nz_2 hbltu_1 hcarry2_nz_1
+  -- j=0 call body theorem at the j=1 max iteration result.
+  have J0 := divK_loop_body_n2_call_j0_exact_loopIterScratch_v4_noNop sp base
+    (1 : Word) ((1 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat)
+    (mulsubN4_c3
+      (signExtend12 4095 : Word)
+      v0 v1 v2 v3 u0Orig1
+      (iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1)
+    (iterN2Max v0 v1 v2 v3 u0Orig1
+      (iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).1
+    (iterN2Max v0 v1 v2 v3 u0Orig1
+      (iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.2.1
+    v0 v1 v2 v3 u0Orig0
+    (iterN2Max v0 v1 v2 v3 u0Orig1
+      (iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.1
+    (iterN2Max v0 v1 v2 v3 u0Orig1
+      (iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.1
+    (iterN2Max v0 v1 v2 v3 u0Orig1
+      (iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.1
+    (iterN2Max v0 v1 v2 v3 u0Orig1
+      (iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.2.1
+    q0Old raVal
+    (base + div128CallRetOff) v1
+    (divKTrialCallV4DLo v1)
+    (divKTrialCallV4Un0 u1)
+    (divKTrialCallV4ScratchOut u2 u1 v1 scratchMem)
+    halign hbltu_0 hcarry2_nz_0
+  -- Frame the j=0 call body with the j=1 and j=2 stored u4/q atoms.
+  have J0f := cpsTripleWithin_frameR
+    ((((sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 4064 ↦ₘ
+      (iterN2Max v0 v1 v2 v3 u0Orig1
+        (iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.2.2) **
+      ((sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ
+      (iterN2Max v0 v1 v2 v3 u0Orig1
+        (iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).1)) **
+     (((sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 4064 ↦ₘ
+      (iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.2) **
+      ((sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ
+        (iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+          v0 v1 v2 v3 u0 u1 u2 u3 uTop).1)))
+    (by pcFree) J0
+  -- Compose via the j=1 max -> j=0 call bridge that retains the j=2 frame.
+  have hcomp := cpsTripleWithin_seq_perm_same_cr
+    (loopIterPostN2MaxScratchX1_j1_to_call_j0_pre_with_j2_frame
+      sp (base + div128CallRetOff) v1 (divKTrialCallV4DLo v1)
+      (divKTrialCallV4Un0 u1)
+      (divKTrialCallV4ScratchOut u2 u1 v1 scratchMem)
+      v0 v1 v2 v3 u0Orig1
+      (iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
+      u0Orig0 q0Old raVal
+      (sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat)
+      (sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat)
+      (iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.2
+      (iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop).1)
+    JCM J0f
+  have hsteps : (224 + 152) + 224 = 224 + 152 + 224 := by decide
+  rw [hsteps] at hcomp
+  refine cpsTripleWithin_weaken (fun _ hp => hp) ?_ hcomp
+  intro h hp
+  rw [loopN2CallMaxCallSourceFinalPostNoX1_unfold]
+  simp only [r2CCCN2V4_eq, r1TMTN2V4_eq] at hp ⊢
+  xperm_hyp hp
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Adds `FullPathN2V4NoNopTMT.lean` proving `divK_loop_n2_call_max_call_from_source_exact_loopIterScratch_v4_noNop`
- Introduces `r1TMTN2V4` (opaque alias for j=1 `iterN2Max` result after j=2 call) and `loopN2CallMaxCallSourceFinalPostNoX1`
- Key insight: j=1 max does not update scratch cells 3944/3936, so `scratch2` from j=2 call chains directly into `scratch0` for j=0 call (no `scratch1` intermediary)
- Step count: 224 + 152 + 224 = 600

Refs #6059. Bead: evm-asm-9iqmw.2.1.1.2.

## Verification
- `lake build EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopTMT` — 1087 jobs, 1.2s
- `scripts/check-file-size.sh` — 796 files checked, all within cap
- `rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth'` — no matches
- `lake build` (full build pending CI)

Authored by @pirapira; implemented by Claude Code