### PR TITLE
feat(stateless): bloom_add_value (PR-K148)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -9279,6 +9279,122 @@ def ziskBlockComputeTxHashesProbeUnit : BuildUnit := {
   dataAsm     := ziskBlockComputeTxHashesDataSection
 }
 
+/-! ## bloom_add_value -- PR-K148
+
+    Add a single value to a 2048-bit (256-byte) Ethereum log
+    bloom filter, following the yellow-paper / EIP-2718
+    definition:
+
+      1. h = keccak256(value)
+      2. for idx in {0, 2, 4}:
+           raw     = u16(h[idx..idx+2]) & 0x7FF      -- low 11 bits
+           bit     = 0x7FF - raw                     -- inverted
+           byte_i  = bit / 8
+           bit_pos = 7 - (bit mod 8)                 -- MSB-first in byte
+           bloom[byte_i] |= 1 << bit_pos
+
+    Called twice for each log:
+      * once with `value = log.address` (20 bytes)
+      * once per topic with `value = topic` (32 bytes)
+
+    Building block for `logs_bloom` construction in receipt
+    encoding, which in turn feeds `block.bloom` (the per-block
+    bloom = OR of every receipt's bloom). Used by:
+      * `apply_body` when assembling each tx's receipt.
+      * `block_validate_logs_bloom` to recompute the header's
+        bloom field from receipts.
+
+    Composes:
+      - `zkvm_keccak256` (HashBridge) — hashes the value.
+
+    Calling convention:
+      a0 (input)  : bloom ptr (256 bytes, mutable, in-place OR)
+      a1 (input)  : value ptr
+      a2 (input)  : value byte length
+      ra (input)  : return
+      a0 (output) : 0 (always succeeds).
+
+    Bloom is mutated in place; the caller owns the buffer and
+    is responsible for zero-initialising it before the first
+    `bloom_add_value` call of a logs sequence. -/
+def bloomAddValueFunction : String :=
+  "bloom_add_value:\n" ++
+  "  addi sp, sp, -32\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp)\n" ++
+  "  mv s0, a0                   # bloom ptr\n" ++
+  "  mv s1, a1                   # value ptr\n" ++
+  "  mv s2, a2                   # value len\n" ++
+  "  # ---- Compute keccak256(value) → bav_hash ----\n" ++
+  "  mv a0, s1; mv a1, s2\n" ++
+  "  la a2, bav_hash\n" ++
+  "  jal ra, zkvm_keccak256\n" ++
+  "  # ---- Set three bits derived from h[0..6] ----\n" ++
+  "  la t0, bav_hash\n" ++
+  "  li t1, 0                    # idx loop counter (0, 2, 4)\n" ++
+  ".Lbav_loop:\n" ++
+  "  li t2, 6\n" ++
+  "  bge t1, t2, .Lbav_done\n" ++
+  "  add t3, t0, t1\n" ++
+  "  lbu t4, 0(t3)               # hi byte\n" ++
+  "  lbu t5, 1(t3)               # lo byte\n" ++
+  "  slli t4, t4, 8\n" ++
+  "  or  t4, t4, t5              # raw_word\n" ++
+  "  li  t5, 0x7ff\n" ++
+  "  and t4, t4, t5              # raw_bit (0..2047)\n" ++
+  "  sub t4, t5, t4              # bit_index = 0x7ff - raw_bit\n" ++
+  "  srli t5, t4, 3              # byte_index = bit_index / 8\n" ++
+  "  andi t6, t4, 7              # bit_index mod 8\n" ++
+  "  li  t4, 7\n" ++
+  "  sub t6, t4, t6              # bit_pos = 7 - (bit_index mod 8)\n" ++
+  "  li  t4, 1\n" ++
+  "  sll t6, t4, t6              # bit_mask = 1 << bit_pos\n" ++
+  "  add t5, s0, t5              # &bloom[byte_index]\n" ++
+  "  lbu t4, 0(t5)\n" ++
+  "  or  t4, t4, t6\n" ++
+  "  sb  t4, 0(t5)\n" ++
+  "  addi t1, t1, 2\n" ++
+  "  j .Lbav_loop\n" ++
+  ".Lbav_done:\n" ++
+  "  li a0, 0\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp)\n" ++
+  "  addi sp, sp, 32\n" ++
+  "  ret"
+
+/-- `zisk_bloom_add_value`: probe BuildUnit.
+    Input layout:
+      bytes  0.. 8 : value_len
+      bytes  8..   : value bytes
+    Output layout:
+      bytes  0..256 : zero-initialised bloom, then bloom_add_value
+                      run once on the supplied value. -/
+def ziskBloomAddValuePrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a3, 0x40000000\n" ++
+  "  ld a2, 8(a3)                # value_len\n" ++
+  "  addi a1, a3, 16             # value ptr\n" ++
+  "  li a0, 0xa0010000           # output bloom ptr\n" ++
+  "  jal ra, bloom_add_value\n" ++
+  "  j .Lbav_pdone\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  bloomAddValueFunction ++ "\n" ++
+  ".Lbav_pdone:"
+
+def ziskBloomAddValueDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  "bav_hash:\n" ++
+  "  .zero 32"
+
+def ziskBloomAddValueProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskBloomAddValuePrologue
+  dataAsm     := ziskBloomAddValueDataSection
+}
+
 /-! ## calldata_byte_counts -- PR-K105
 
     Count zero and non-zero bytes in an arbitrary byte buffer.
@@ -10043,6 +10159,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_block_count_transactions" => some ziskBlockCountTransactionsProbeUnit
   | "zisk_block_summary"        => some ziskBlockSummaryProbeUnit
   | "zisk_block_compute_tx_hashes" => some ziskBlockComputeTxHashesProbeUnit
+  | "zisk_bloom_add_value" => some ziskBloomAddValueProbeUnit
   | "zisk_calldata_byte_counts" => some ziskCalldataByteCountsProbeUnit
   | "zisk_intrinsic_gas_calldata_floor_eip7623" => some ziskIntrinsicGasCalldataFloorEip7623ProbeUnit
   | "zisk_init_code_cost"       => some ziskInitCodeCostProbeUnit
@@ -10204,6 +10321,7 @@ def knownProgramNames : List String :=
    "zisk_block_count_transactions",
    "zisk_block_summary",
    "zisk_block_compute_tx_hashes",
+   "zisk_bloom_add_value",
    "zisk_calldata_byte_counts",
    "zisk_intrinsic_gas_calldata_floor_eip7623",
    "zisk_init_code_cost",

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **170**
-- ziskemu round-trip scripts: **163** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **171**
+- ziskemu round-trip scripts: **164** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-bloom-add-value-check.sh
+++ b/scripts/codegen-zisk-bloom-add-value-check.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# codegen-zisk-bloom-add-value-check.sh -- PR-K148.
+#
+# Add a single value (log address or topic) to a 256-byte Ethereum
+# log bloom filter, per yellow paper / EIP-2718.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_bloom_add_value ELF"
+lake exe codegen --program zisk_bloom_add_value --halt linux93 \
+  -o gen-out/zisk_bloom_add_value
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <value_hex>
+# ziskemu output cap = 256 bytes, the bloom is exactly that size.
+# The first run is `add_value(zero_bloom, value)`, so we only check
+# the result of adding one value at a time against the Python ref.
+run_case() {
+  local name="$1" value_hex="$2"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_bloom_add_value_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_bloom_add_value_${name}.output"
+  local exp_hex_file="$REPO_ROOT/gen-out/zisk_bloom_add_value_${name}.expected.hex"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+try:
+    from Crypto.Hash import keccak
+    def keccak256(b):
+        h = keccak.new(digest_bits=256); h.update(b); return h.digest()
+except Exception:
+    import sha3
+    def keccak256(b): return sha3.keccak_256(b).digest()
+
+value = bytes.fromhex('$value_hex')
+bloom = bytearray(256)
+h = keccak256(value)
+for idx in (0, 2, 4):
+    raw_bit = int.from_bytes(h[idx:idx+2], 'big') & 0x07FF
+    bit_index = 0x07FF - raw_bit
+    byte_index = bit_index // 8
+    bit_value = 1 << (7 - (bit_index % 8))
+    bloom[byte_index] |= bit_value
+
+with open(sys.argv[1], 'wb') as f:
+    f.write(struct.pack('<Q', len(value)))
+    f.write(value)
+    pad = (-(8 + len(value))) % 8
+    if pad: f.write(b'\x00' * pad)
+with open(sys.argv[2], 'w') as f:
+    f.write(bytes(bloom).hex())
+" "$in_file" "$exp_hex_file"
+
+  "$ZISKEMU" -e gen-out/zisk_bloom_add_value.elf \
+    -i "$in_file" -o "$out_file" -n 5000000 \
+    >"$REPO_ROOT/gen-out/zisk_bloom_add_value_${name}.emu.log" 2>&1 || true
+
+  # ziskemu writes the entire 256-byte bloom buffer.
+  local actual; actual="$(xxd -p -c 256 "$out_file" | tr -d '\n')"
+  local expected; expected="$(cat "$exp_hex_file")"
+
+  if [[ "$actual" == "$expected" ]]; then
+    # Count bits set as a sanity check.
+    local nbits; nbits="$(python3 -c "print(bin(int('$actual', 16)).count('1'))")"
+    printf "  %-30s OK   value=%s... bits_set=%d\n" "$name" "${value_hex:0:16}" "$nbits"
+    return 0
+  else
+    printf "  %-30s FAIL\n" "$name"
+    printf "      actual:   %s...\n" "${actual:0:80}"
+    printf "      expected: %s...\n" "${expected:0:80}"
+    return 1
+  fi
+}
+
+FAILED=0
+# 20-byte address typical
+run_case "address_aa"     "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" || FAILED=1
+run_case "address_bb"     "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" || FAILED=1
+run_case "address_zero"   "0000000000000000000000000000000000000000" || FAILED=1
+# 32-byte topic typical
+run_case "topic_32B"      "1111111111111111111111111111111111111111111111111111111111111111" || FAILED=1
+# Empty data (degenerate, keccak256(b'') is well-known)
+run_case "empty_value"    "" || FAILED=1
+# Long-ish bytestring (e.g. some hashed log data)
+run_case "longer_input"   "$(python3 -c "print('cafebabe' * 16)")" || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: bloom_add_value matches yellow-paper bloom encoding"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- \`bloom_add_value\`: log bloom-filter primitive. Hashes a value and ORs in the 3 EIP-derived bits at the right positions of a 2048-bit (256-byte) bloom.
- Called twice per log: once with the log's address (20 bytes) and once per topic (32 bytes). Direct building block for \`logs_bloom\` (receipt-level) and \`block.bloom\` (header-level, the OR of every receipt's bloom).
- Pure narrow primitive — bloom is mutated in place, caller is responsible for zero-init before the first call.

### Algorithm (yellow paper / EIP-2718)

\`\`\`
1. h = keccak256(value)
2. for idx in {0, 2, 4}:
     raw     = u16(h[idx..idx+2]) & 0x7FF      # low 11 bits
     bit     = 0x7FF - raw                     # inverted
     byte_i  = bit / 8
     bit_pos = 7 - (bit mod 8)                 # MSB-first within byte
     bloom[byte_i] |= 1 << bit_pos
\`\`\`

Each call sets exactly 3 bits (or fewer if any of the 3 collide).

### Calling convention

| reg | role |
|---|---|
| a0 | bloom ptr (256 bytes, mutable, in-place OR) |
| a1 | value ptr |
| a2 | value byte length |
| a0 (out) | 0 (always succeeds) |

Composes \`zkvm_keccak256\` (HashBridge).

### Why it's needed

\`apply_body\` builds a per-tx logs bloom by iterating each log's \`(address, topics)\` and calling \`bloom_add_value\` on each. The block's \`logs_bloom\` field is then the OR-accumulation of all receipt blooms; \`block_validate_logs_bloom\` (future) recomputes that and compares against the header field.

## Test plan

- [x] \`lake build\` clean
- [x] \`scripts/codegen-zisk-bloom-add-value-check.sh\` — 6/6 fixtures pass against Python reference:
  - 20-byte addresses (\`address_aa\`, \`address_bb\`, \`address_zero\`)
  - 32-byte topic (\`topic_32B\`)
  - Empty value (\`empty_value\`; uses \`keccak256(b'')\`)
  - 64-byte data (\`longer_input\`)
  - All produce exactly 3 set bits as the spec requires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)