### PR TITLE
feat(stateless): logs_list_bloom_add (PR-K150)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -9555,6 +9555,143 @@ def ziskLogBloomAddProbeUnit : BuildUnit := {
   dataAsm     := ziskLogBloomAddDataSection
 }
 
+/-! ## logs_list_bloom_add -- PR-K150
+
+    OR every log's bloom contribution from an RLP-encoded `logs`
+    list into a 256-byte bloom buffer. This is what
+    `apply_body` calls on each receipt's logs to compute the
+    receipt's `logs_bloom` field, and what
+    `block_compute_logs_bloom` (future) calls to assemble the
+    block-level bloom from receipts (via repeated OR).
+
+    Input list shape:
+
+      logs = rlp([log_0, log_1, ..., log_{n-1}])
+      log_i = rlp([address, topics, data])
+
+    For each log_i, `logs_list_bloom_add` invokes K149
+    `log_bloom_add` (which itself loops K148 `bloom_add_value`).
+    Empty `logs` list (`0xc0`) is a valid input → bloom unchanged.
+
+    Composes:
+      - PR-K20 `rlp_list_nth_item`    -- walk each log_i
+      - PR-K47 `rlp_list_count_items` -- list cardinality
+      - PR-K149 `log_bloom_add`       -- per-log accumulation
+      - PR-K148 `bloom_add_value`     -- (via K149)
+      - `zkvm_keccak256`              -- (via K148)
+
+    Calling convention:
+      a0 (input)  : bloom ptr (256 bytes, mutable, in-place OR;
+                    caller zero-inits before first call)
+      a1 (input)  : logs_rlp ptr (RLP list of log entries)
+      a2 (input)  : logs_rlp byte length
+      ra (input)  : return
+      a0 (output) :
+        0 : success
+        1 : RLP parse failure (logs_rlp not a list)
+        2 : a log address field length != 20 (per K149)
+        3 : a log topic field length != 32 (per K149) -/
+def logsListBloomAddFunction : String :=
+  "logs_list_bloom_add:\n" ++
+  "  addi sp, sp, -48\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp)\n" ++
+  "  mv s0, a0                   # bloom ptr\n" ++
+  "  mv s1, a1                   # logs_rlp ptr\n" ++
+  "  mv s2, a2                   # logs_rlp len\n" ++
+  "  # ---- Count logs ----\n" ++
+  "  mv a0, s1; mv a1, s2\n" ++
+  "  la a2, llba_count\n" ++
+  "  jal ra, rlp_list_count_items\n" ++
+  "  bnez a0, .Lllba_parse_fail\n" ++
+  "  la t0, llba_count; ld s3, 0(t0)              # n_logs\n" ++
+  "  li s4, 0                                     # i\n" ++
+  ".Lllba_loop:\n" ++
+  "  bge s4, s3, .Lllba_done\n" ++
+  "  # Extract log_i bounds (full encoded item).\n" ++
+  "  mv a0, s1; mv a1, s2; mv a2, s4\n" ++
+  "  la a3, llba_offset; la a4, llba_length\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lllba_parse_fail\n" ++
+  "  la t0, llba_offset; ld t1, 0(t0)\n" ++
+  "  la t0, llba_length; ld t2, 0(t0)\n" ++
+  "  add a1, s1, t1                                # &log_i bytes\n" ++
+  "  mv a2, t2                                     # log_i len\n" ++
+  "  mv a0, s0                                     # bloom\n" ++
+  "  jal ra, log_bloom_add\n" ++
+  "  bnez a0, .Lllba_log_err                       # propagate child status\n" ++
+  "  addi s4, s4, 1\n" ++
+  "  j .Lllba_loop\n" ++
+  ".Lllba_done:\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lllba_ret\n" ++
+  ".Lllba_parse_fail:\n" ++
+  "  li a0, 1\n" ++
+  "  j .Lllba_ret\n" ++
+  ".Lllba_log_err:\n" ++
+  "  # a0 already carries the child status (2 = address size, 3 = topic size,\n" ++
+  "  # 1 = parse fail). Pass through unchanged.\n" ++
+  ".Lllba_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp)\n" ++
+  "  addi sp, sp, 48\n" ++
+  "  ret"
+
+/-- `zisk_logs_list_bloom_add`: probe BuildUnit.
+    Input layout:
+      bytes  0.. 8 : logs_rlp_len
+      bytes  8..   : logs_rlp
+    Output layout:
+      bytes  0..256 : zero-initialised bloom, then
+                      logs_list_bloom_add applied once. -/
+def ziskLogsListBloomAddPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a3, 0x40000000\n" ++
+  "  ld a2, 8(a3)                # logs_rlp_len\n" ++
+  "  addi a1, a3, 16             # logs_rlp ptr\n" ++
+  "  li a0, 0xa0010000           # output bloom ptr\n" ++
+  "  jal ra, logs_list_bloom_add\n" ++
+  "  j .Lllba_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpListCountItemsFunction ++ "\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  bloomAddValueFunction ++ "\n" ++
+  logBloomAddFunction ++ "\n" ++
+  logsListBloomAddFunction ++ "\n" ++
+  ".Lllba_pdone:"
+
+def ziskLogsListBloomAddDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  "bav_hash:\n" ++
+  "  .zero 32\n" ++
+  "lba_offset:\n" ++
+  "  .zero 8\n" ++
+  "lba_length:\n" ++
+  "  .zero 8\n" ++
+  "lba_topics_offset:\n" ++
+  "  .zero 8\n" ++
+  "lba_topics_length:\n" ++
+  "  .zero 8\n" ++
+  "lba_topic_count:\n" ++
+  "  .zero 8\n" ++
+  "llba_offset:\n" ++
+  "  .zero 8\n" ++
+  "llba_length:\n" ++
+  "  .zero 8\n" ++
+  "llba_count:\n" ++
+  "  .zero 8"
+
+def ziskLogsListBloomAddProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskLogsListBloomAddPrologue
+  dataAsm     := ziskLogsListBloomAddDataSection
+}
+
 /-! ## calldata_byte_counts -- PR-K105
 
     Count zero and non-zero bytes in an arbitrary byte buffer.
@@ -10321,6 +10458,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_block_compute_tx_hashes" => some ziskBlockComputeTxHashesProbeUnit
   | "zisk_bloom_add_value" => some ziskBloomAddValueProbeUnit
   | "zisk_log_bloom_add" => some ziskLogBloomAddProbeUnit
+  | "zisk_logs_list_bloom_add" => some ziskLogsListBloomAddProbeUnit
   | "zisk_calldata_byte_counts" => some ziskCalldataByteCountsProbeUnit
   | "zisk_intrinsic_gas_calldata_floor_eip7623" => some ziskIntrinsicGasCalldataFloorEip7623ProbeUnit
   | "zisk_init_code_cost"       => some ziskInitCodeCostProbeUnit
@@ -10484,6 +10622,7 @@ def knownProgramNames : List String :=
    "zisk_block_compute_tx_hashes",
    "zisk_bloom_add_value",
    "zisk_log_bloom_add",
+   "zisk_logs_list_bloom_add",
    "zisk_calldata_byte_counts",
    "zisk_intrinsic_gas_calldata_floor_eip7623",
    "zisk_init_code_cost",

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **172**
-- ziskemu round-trip scripts: **165** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **173**
+- ziskemu round-trip scripts: **166** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-logs-list-bloom-add-check.sh
+++ b/scripts/codegen-zisk-logs-list-bloom-add-check.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# codegen-zisk-logs-list-bloom-add-check.sh -- PR-K150.
+#
+# OR every log's bloom contribution from an RLP-encoded logs list
+# into a 256-byte bloom buffer.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_logs_list_bloom_add ELF"
+lake exe codegen --program zisk_logs_list_bloom_add --halt linux93 \
+  -o gen-out/zisk_logs_list_bloom_add
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <logs_json>
+# logs_json: list of [address_hex, topics_list_hex, data_hex]
+run_case() {
+  local name="$1" logs="$2"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_logs_list_bloom_add_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_logs_list_bloom_add_${name}.output"
+  local exp_hex_file="$REPO_ROOT/gen-out/zisk_logs_list_bloom_add_${name}.expected.hex"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import json, struct, sys, rlp
+try:
+    from Crypto.Hash import keccak
+    def keccak256(b):
+        h = keccak.new(digest_bits=256); h.update(b); return h.digest()
+except Exception:
+    import sha3
+    def keccak256(b): return sha3.keccak_256(b).digest()
+
+raw_logs = json.loads('''$logs''')
+logs = []
+for addr_hex, topic_hexes, data_hex in raw_logs:
+    addr = bytes.fromhex(addr_hex)
+    topics = [bytes.fromhex(t) for t in topic_hexes]
+    data = bytes.fromhex(data_hex)
+    logs.append([addr, topics, data])
+logs_rlp = rlp.encode(logs)
+
+bloom = bytearray(256)
+def add(b, v):
+    h = keccak256(v)
+    for idx in (0, 2, 4):
+        raw = int.from_bytes(h[idx:idx+2], 'big') & 0x07FF
+        bit = 0x07FF - raw
+        b[bit // 8] |= 1 << (7 - (bit % 8))
+for addr, topics, _data in logs:
+    add(bloom, addr)
+    for t in topics:
+        add(bloom, t)
+
+with open(sys.argv[1], 'wb') as f:
+    f.write(struct.pack('<Q', len(logs_rlp)))
+    f.write(logs_rlp)
+    pad = (-(8 + len(logs_rlp))) % 8
+    if pad: f.write(b'\x00' * pad)
+with open(sys.argv[2], 'w') as f:
+    f.write(bytes(bloom).hex())
+" "$in_file" "$exp_hex_file"
+
+  "$ZISKEMU" -e gen-out/zisk_logs_list_bloom_add.elf \
+    -i "$in_file" -o "$out_file" -n 10000000 \
+    >"$REPO_ROOT/gen-out/zisk_logs_list_bloom_add_${name}.emu.log" 2>&1 || true
+
+  local actual; actual="$(xxd -p -c 256 "$out_file" | tr -d '\n')"
+  local expected; expected="$(cat "$exp_hex_file")"
+
+  if [[ "$actual" == "$expected" ]]; then
+    local nbits; nbits="$(python3 -c "print(bin(int('$actual', 16)).count('1'))")"
+    local n_logs; n_logs="$(python3 -c "import json; print(len(json.loads('''$logs''')))")"
+    printf "  %-30s OK   n_logs=%d bits_set=%d\n" "$name" "$n_logs" "$nbits"
+    return 0
+  else
+    printf "  %-30s FAIL\n" "$name"
+    printf "      actual:   %s...\n" "${actual:0:80}"
+    printf "      expected: %s...\n" "${expected:0:80}"
+    return 1
+  fi
+}
+
+A1="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+A2="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+A3="cccccccccccccccccccccccccccccccccccccccc"
+T0="1111111111111111111111111111111111111111111111111111111111111111"
+T1="2222222222222222222222222222222222222222222222222222222222222222"
+T2="3333333333333333333333333333333333333333333333333333333333333333"
+
+FAILED=0
+# Empty logs list: bloom unchanged (still zero).
+run_case "empty"        "[]" || FAILED=1
+# Single log, no topics.
+run_case "one_log_log0" "[[\"$A1\", [], \"deadbeef\"]]" || FAILED=1
+# Single log, one topic.
+run_case "one_log_log1" "[[\"$A1\", [\"$T0\"], \"\"]]" || FAILED=1
+# Multiple logs.
+run_case "three_logs"   "[[\"$A1\", [\"$T0\"], \"\"], [\"$A2\", [\"$T0\", \"$T1\"], \"deadbeef\"], [\"$A3\", [], \"00\"]]" || FAILED=1
+# Many logs with topics (stress).
+run_case "five_logs_mixed" \
+  "[[\"$A1\", [\"$T0\", \"$T1\", \"$T2\"], \"\"], [\"$A2\", [], \"\"], [\"$A3\", [\"$T0\"], \"\"], [\"$A1\", [\"$T1\", \"$T2\"], \"\"], [\"$A2\", [\"$T0\", \"$T1\", \"$T2\"], \"cafebabe\"]]" || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: logs_list_bloom_add accumulates every log's bloom contribution"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- \`logs_list_bloom_add\`: OR every log's bloom contribution from an RLP-encoded \`logs\` list into a 256-byte bloom buffer.
- One layer above PR-K149 \`log_bloom_add\` — what \`apply_body\` calls on each receipt's \`logs\` field to compute the receipt's \`logs_bloom\`; what \`block_compute_logs_bloom\` (future) calls to assemble the block bloom.
- Composes K20 + K47 + K149 (which composes K148 + \`zkvm_keccak256\`).

### Input shape

\`\`\`
logs    = rlp([log_0, log_1, ..., log_{n-1}])
log_i   = rlp([address, topics, data])
\`\`\`

Empty \`logs\` list (\`0xc0\`) is valid → bloom unchanged.

### Calling convention

| reg | role |
|---|---|
| a0 | bloom ptr (256 B, mutable; caller zero-inits) |
| a1 | logs_rlp ptr (RLP list) |
| a2 | logs_rlp byte length |
| a0 (out) | 0 ok / 1 parse fail / 2 address != 20 B / 3 topic != 32 B |

Child status from K149 propagates unchanged so callers can diagnose which constraint a malformed log violated.

## Stacking

Base = \`feat/stateless-log-bloom-add\` (PR #5927); GitHub auto-retargets to \`main\` once K149 merges.

## Test plan

- [x] \`lake build\` clean
- [x] \`scripts/codegen-zisk-logs-list-bloom-add-check.sh\` — 5/5 fixtures pass against Python reference:
  - \`empty\`: zero-length logs list → bloom stays zero
  - \`one_log_log0\`: single log without topics → 3 bits
  - \`one_log_log1\`: single log with one topic → 6 bits
  - \`three_logs\`: typical receipt shape → 15 bits
  - \`five_logs_mixed\`: 5 logs, mixed topic counts → 18 bits

🤖 Generated with [Claude Code](https://claude.com/claude-code)