### PR TITLE
feat(divmod): prove n=2 max-max-call source path (MMT)

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -79,6 +79,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopTMT
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopTMM
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopMTT
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopMTM
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopMMT
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1V4NoNop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1V4

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNopMMT.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNopMMT.lean
@@ -1,0 +1,248 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopMMT
+
+  Three-iteration max-max-call composition for the n=2 v4/no-NOP source path.
+  j=2 and j=1 take the max-trial branch; j=0 takes the callable trial-division
+  (call) path.
+  Conditions: bltu_2=false (max), bltu_1=false (max), bltu_0=true (call).
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopFinalPost
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Opaque alias for the j=2 `iterN2Max` result in the n=2 max-max-call path. -/
+@[irreducible]
+def r2MMTN2V4 (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
+    Word × Word × Word × Word × Word × Word :=
+  iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+
+theorem r2MMTN2V4_eq (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
+    r2MMTN2V4 v0 v1 v2 v3 u0 u1 u2 u3 uTop =
+      iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+  delta r2MMTN2V4; rfl
+
+/-- Opaque alias for the j=1 `iterN2Max` result in the n=2 max-max-call path,
+    parameterized on `r2 := r2MMTN2V4 ...`. -/
+@[irreducible]
+def r1MMTN2V4 (v0 v1 v2 v3 u0Orig1 u0 u1 u2 u3 uTop : Word) :
+    Word × Word × Word × Word × Word × Word :=
+  let r2 := r2MMTN2V4 v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  iterN2Max v0 v1 v2 v3 u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
+
+theorem r1MMTN2V4_eq (v0 v1 v2 v3 u0Orig1 u0 u1 u2 u3 uTop : Word) :
+    r1MMTN2V4 v0 v1 v2 v3 u0Orig1 u0 u1 u2 u3 uTop =
+      (let r2 := r2MMTN2V4 v0 v1 v2 v3 u0 u1 u2 u3 uTop
+       iterN2Max v0 v1 v2 v3 u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1) := by
+  delta r1MMTN2V4; rfl
+
+/-- Compact postcondition for the n=2 v4/no-NOP source path whose j=2 and j=1
+    iterations take the max-trial branch and j=0 takes the callable trial-division
+    path.  Neither max iteration touches the v4 scratch cells, so the j=0 call
+    writes them fresh using the original `scratchMem` value. -/
+@[irreducible]
+def loopN2MaxMaxCallSourceFinalPostNoX1 (sp base : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 raVal scratchMem : Word) :
+    Assertion :=
+  let r2 := r2MMTN2V4 v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  let r1 := r1MMTN2V4 v0 v1 v2 v3 u0Orig1 u0 u1 u2 u3 uTop
+  let qHat0 := divKTrialCallV4QHat r1.2.2.1 r1.2.1 v1
+  let dLo0 := divKTrialCallV4DLo v1
+  let divUn00 := divKTrialCallV4Un0 r1.2.1
+  let scratch0 := divKTrialCallV4ScratchOut r1.2.2.1 r1.2.1 v1 scratchMem
+  let uBase2 := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
+  let qAddr2 := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
+  let uBase1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+  let qAddr1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+  ((loopIterPostN2CallScratchNoX1 sp base (0 : Word)
+    qHat0 dLo0 divUn00 scratch0
+    v0 v1 v2 v3 u0Orig0 r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 **
+    (.x1 ↦ᵣ raVal)) **
+    (((uBase1 + signExtend12 4064 ↦ₘ r1.2.2.2.2.2) **
+      (qAddr1 ↦ₘ r1.1)) **
+     ((uBase2 + signExtend12 4064 ↦ₘ r2.2.2.2.2.2) **
+      (qAddr2 ↦ₘ r2.1))))
+
+theorem loopN2MaxMaxCallSourceFinalPostNoX1_unfold (sp base : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 raVal scratchMem : Word) :
+    loopN2MaxMaxCallSourceFinalPostNoX1 sp base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 raVal scratchMem =
+    (let r2 := r2MMTN2V4 v0 v1 v2 v3 u0 u1 u2 u3 uTop
+     let r1 := r1MMTN2V4 v0 v1 v2 v3 u0Orig1 u0 u1 u2 u3 uTop
+     let qHat0 := divKTrialCallV4QHat r1.2.2.1 r1.2.1 v1
+     let dLo0 := divKTrialCallV4DLo v1
+     let divUn00 := divKTrialCallV4Un0 r1.2.1
+     let scratch0 := divKTrialCallV4ScratchOut r1.2.2.1 r1.2.1 v1 scratchMem
+     let uBase2 := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
+     let qAddr2 := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
+     let uBase1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+     let qAddr1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+     ((loopIterPostN2CallScratchNoX1 sp base (0 : Word)
+       qHat0 dLo0 divUn00 scratch0
+       v0 v1 v2 v3 u0Orig0 r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 **
+       (.x1 ↦ᵣ raVal)) **
+       (((uBase1 + signExtend12 4064 ↦ₘ r1.2.2.2.2.2) **
+         (qAddr1 ↦ₘ r1.1)) **
+        ((uBase2 + signExtend12 4064 ↦ₘ r2.2.2.2.2.2) **
+         (qAddr2 ↦ₘ r2.1))))) := by
+  delta loopN2MaxMaxCallSourceFinalPostNoX1
+  rfl
+
+/-- Branch/runtime conditions for the n=2 v4/no-NOP source path whose j=2/j=1
+    take max and j=0 takes call. -/
+@[irreducible]
+def loopN2MaxMaxCallSourceConds
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 : Word) : Prop :=
+  let r2 := r2MMTN2V4 v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  let r1 := r1MMTN2V4 v0 v1 v2 v3 u0Orig1 u0 u1 u2 u3 uTop
+  ¬BitVec.ult u2 v1 ∧
+  isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop ∧
+  ¬BitVec.ult r2.2.2.1 v1 ∧
+  isAddbackCarry2NzN2Max v0 v1 v2 v3
+    u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1 ∧
+  BitVec.ult r1.2.2.1 v1 ∧
+  loopBodyN2CallAddbackCarry2NzV4 v0 v1 v2 v3
+    u0Orig0 r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+
+theorem loopN2MaxMaxCallSourceConds_unfold
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 : Word) :
+    loopN2MaxMaxCallSourceConds
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 =
+    (let r2 := r2MMTN2V4 v0 v1 v2 v3 u0 u1 u2 u3 uTop
+     let r1 := r1MMTN2V4 v0 v1 v2 v3 u0Orig1 u0 u1 u2 u3 uTop
+     ¬BitVec.ult u2 v1 ∧
+     isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop ∧
+     ¬BitVec.ult r2.2.2.1 v1 ∧
+     isAddbackCarry2NzN2Max v0 v1 v2 v3
+       u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1 ∧
+     BitVec.ult r1.2.2.1 v1 ∧
+     loopBodyN2CallAddbackCarry2NzV4 v0 v1 v2 v3
+       u0Orig0 r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1) := by
+  delta loopN2MaxMaxCallSourceConds
+  rfl
+
+/-- The n=2 v4/no-NOP source path whose j=2 and j=1 iterations take the
+    max-trial branch and j=0 takes the callable trial-division path.  The two
+    max iterations leave the v4 scratch cells untouched, so j=0 call writes them
+    fresh using the original `scratchMem`. -/
+theorem divK_loop_n2_max_max_call_from_source_exact_loopIterScratch_v4_noNop
+    (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old raVal : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hconds :
+      loopN2MaxMaxCallSourceConds v0 v1 v2 v3 u0 u1 u2 u3 uTop
+        u0Orig1 u0Orig0) :
+    cpsTripleWithin (152 + 152 + 224) (base + loopBodyOff) (base + denormOff)
+      (divCode_noNop_v4 base)
+      (loopN2PreWithScratchV4NoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopN2MaxMaxCallSourceFinalPostNoX1 sp base
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 raVal scratchMem) := by
+  rw [loopN2MaxMaxCallSourceConds_unfold] at hconds
+  simp only [r2MMTN2V4_eq, r1MMTN2V4_eq] at hconds
+  obtain ⟨hbltu_2, hcarry2_nz_2, hbltu_1, hcarry2_nz_1, hbltu_0, hcarry2_nz_0⟩ := hconds
+  -- j=2 max + j=1 max composed source theorem.
+  have JMM := divK_loop_n2_max_max_from_source_exact_loopIterScratch_v4_noNop
+    sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old raVal
+    retMem dMem dloMem scratchUn0 scratchMem
+    hbltu_2 hcarry2_nz_2 hbltu_1 hcarry2_nz_1
+  -- j=0 call body theorem at the j=1 max iteration result.
+  have J0 := divK_loop_body_n2_call_j0_exact_loopIterScratch_v4_noNop sp base
+    (1 : Word) ((1 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat)
+    (sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat)
+    (mulsubN4_c3
+      (signExtend12 4095 : Word)
+      v0 v1 v2 v3 u0Orig1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1)
+    (iterN2Max v0 v1 v2 v3 u0Orig1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).1
+    (iterN2Max v0 v1 v2 v3 u0Orig1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.2.1
+    v0 v1 v2 v3 u0Orig0
+    (iterN2Max v0 v1 v2 v3 u0Orig1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.1
+    (iterN2Max v0 v1 v2 v3 u0Orig1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.1
+    (iterN2Max v0 v1 v2 v3 u0Orig1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.1
+    (iterN2Max v0 v1 v2 v3 u0Orig1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.2.1
+    q0Old raVal
+    retMem dMem dloMem scratchUn0 scratchMem
+    halign hbltu_0 hcarry2_nz_0
+  -- Frame the j=0 call body with the j=1 and j=2 stored u4/q atoms.
+  have J0f := cpsTripleWithin_frameR
+    ((((sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 4064 ↦ₘ
+      (iterN2Max v0 v1 v2 v3 u0Orig1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.2.2) **
+      ((sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ
+      (iterN2Max v0 v1 v2 v3 u0Orig1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).1)) **
+     (((sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat) +
+      signExtend12 4064 ↦ₘ
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.2) **
+      ((sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat) ↦ₘ
+        (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).1)))
+    (by pcFree) J0
+  -- Compose via the j=1 max -> j=0 call bridge that retains the j=2 frame.
+  have hcomp := cpsTripleWithin_seq_perm_same_cr
+    (loopIterPostN2MaxScratchX1_j1_to_call_j0_pre_with_j2_frame
+      sp retMem dMem dloMem scratchUn0 scratchMem
+      v0 v1 v2 v3 u0Orig1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
+      u0Orig0 q0Old raVal
+      (sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat)
+      (sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat)
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.2
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).1)
+    JMM J0f
+  have hsteps : (152 + 152) + 224 = 152 + 152 + 224 := by decide
+  rw [hsteps] at hcomp
+  refine cpsTripleWithin_weaken (fun _ hp => hp) ?_ hcomp
+  intro h hp
+  rw [loopN2MaxMaxCallSourceFinalPostNoX1_unfold]
+  simp only [r2MMTN2V4_eq, r1MMTN2V4_eq] at hp ⊢
+  xperm_hyp hp
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Adds `FullPathN2V4NoNopMMT.lean` proving `divK_loop_n2_max_max_call_from_source_exact_loopIterScratch_v4_noNop`
- Introduces `r2MMTN2V4` and `r1MMTN2V4` (both `iterN2Max`, j=2 and j=1 max)
- j=2/j=1 max leave v4 scratch cells untouched; j=0 call writes them fresh using the original `scratchMem`
- Step count: 152 + 152 + 224 = 528

Refs #6059. Bead: evm-asm-9iqmw.2.1.1.6.

## Verification
- `lake build EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopMMT` — 1.2s, green
- `scripts/check-file-size.sh` — 800 files checked, all within cap
- `rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth'` — no matches
- `lake build` (full build pending CI)

Authored by @pirapira; implemented by Claude Code