### PR TITLE
feat(stateless): bloom_or_into (PR-K151)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -9692,6 +9692,87 @@ def ziskLogsListBloomAddProbeUnit : BuildUnit := {
   dataAsm     := ziskLogsListBloomAddDataSection
 }
 
+/-! ## bloom_or_into -- PR-K151
+
+    In-place 256-byte bitwise OR: `dst[i] |= src[i]` for
+    `i in 0..256`. Used to accumulate one bloom filter into
+    another -- in particular, to fold each receipt's `logs_bloom`
+    into the block-level `block.logs_bloom` field.
+
+    A natural complement to:
+      * PR-K148 `bloom_add_value`     -- single-value add
+      * PR-K149 `log_bloom_add`       -- per-log accumulation
+      * PR-K150 `logs_list_bloom_add` -- per-receipt accumulation
+      * PR-K151 (this PR) `bloom_or_into` -- per-block accumulation
+
+    Pure register arithmetic; processes 8 bytes per iteration
+    (32 iterations total) using `ld` + `or` + `sd`. No external
+    function calls.
+
+    Calling convention:
+      a0 (input)  : dst bloom ptr (256 bytes, mutable, in-place OR)
+      a1 (input)  : src bloom ptr (256 bytes, read-only)
+      ra (input)  : return
+      a0 (output) : 0 (always succeeds). -/
+def bloomOrIntoFunction : String :=
+  "bloom_or_into:\n" ++
+  "  li t0, 32                  # 256 bytes / 8 bytes per word\n" ++
+  "  mv t1, a0                  # dst cursor\n" ++
+  "  mv t2, a1                  # src cursor\n" ++
+  ".Lboi_loop:\n" ++
+  "  beqz t0, .Lboi_done\n" ++
+  "  ld t3, 0(t1)\n" ++
+  "  ld t4, 0(t2)\n" ++
+  "  or t3, t3, t4\n" ++
+  "  sd t3, 0(t1)\n" ++
+  "  addi t1, t1, 8\n" ++
+  "  addi t2, t2, 8\n" ++
+  "  addi t0, t0, -1\n" ++
+  "  j .Lboi_loop\n" ++
+  ".Lboi_done:\n" ++
+  "  li a0, 0\n" ++
+  "  ret"
+
+/-- `zisk_bloom_or_into`: probe BuildUnit.
+    Input layout (after the host header):
+      bytes  0..256 : src bloom
+      bytes 256..512: dst bloom (will be OR-mutated)
+    The probe runs `bloom_or_into(dst, src)` and emits the
+    resulting dst bloom (256 bytes) as the output. -/
+def ziskBloomOrIntoPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a3, 0x40000000\n" ++
+  "  addi a1, a3, 16             # src bloom ptr (after host header)\n" ++
+  "  addi a2, a3, 272            # dst bloom ptr (src + 256)\n" ++
+  "  # Copy dst into the output region first, then OR src into it.\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  li t1, 32\n" ++
+  ".Lboi_cp:\n" ++
+  "  beqz t1, .Lboi_cp_done\n" ++
+  "  ld t2, 0(a2)\n" ++
+  "  sd t2, 0(t0)\n" ++
+  "  addi a2, a2, 8\n" ++
+  "  addi t0, t0, 8\n" ++
+  "  addi t1, t1, -1\n" ++
+  "  j .Lboi_cp\n" ++
+  ".Lboi_cp_done:\n" ++
+  "  li a0, 0xa0010000           # dst = output region\n" ++
+  "  jal ra, bloom_or_into\n" ++
+  "  j .Lboi_pdone\n" ++
+  bloomOrIntoFunction ++ "\n" ++
+  ".Lboi_pdone:"
+
+def ziskBloomOrIntoDataSection : String :=
+  ".section .data\n" ++
+  "boi_pad:\n" ++
+  "  .zero 8"
+
+def ziskBloomOrIntoProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskBloomOrIntoPrologue
+  dataAsm     := ziskBloomOrIntoDataSection
+}
+
 /-! ## calldata_byte_counts -- PR-K105
 
     Count zero and non-zero bytes in an arbitrary byte buffer.
@@ -10459,6 +10540,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_bloom_add_value" => some ziskBloomAddValueProbeUnit
   | "zisk_log_bloom_add" => some ziskLogBloomAddProbeUnit
   | "zisk_logs_list_bloom_add" => some ziskLogsListBloomAddProbeUnit
+  | "zisk_bloom_or_into" => some ziskBloomOrIntoProbeUnit
   | "zisk_calldata_byte_counts" => some ziskCalldataByteCountsProbeUnit
   | "zisk_intrinsic_gas_calldata_floor_eip7623" => some ziskIntrinsicGasCalldataFloorEip7623ProbeUnit
   | "zisk_init_code_cost"       => some ziskInitCodeCostProbeUnit
@@ -10623,6 +10705,7 @@ def knownProgramNames : List String :=
    "zisk_bloom_add_value",
    "zisk_log_bloom_add",
    "zisk_logs_list_bloom_add",
+   "zisk_bloom_or_into",
    "zisk_calldata_byte_counts",
    "zisk_intrinsic_gas_calldata_floor_eip7623",
    "zisk_init_code_cost",

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **173**
-- ziskemu round-trip scripts: **166** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **174**
+- ziskemu round-trip scripts: **167** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-bloom-or-into-check.sh
+++ b/scripts/codegen-zisk-bloom-or-into-check.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# codegen-zisk-bloom-or-into-check.sh -- PR-K151.
+#
+# In-place 256-byte bitwise OR: dst[i] |= src[i].
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_bloom_or_into ELF"
+lake exe codegen --program zisk_bloom_or_into --halt linux93 \
+  -o gen-out/zisk_bloom_or_into
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <src_hex_256B> <dst_hex_256B>
+run_case() {
+  local name="$1" src="$2" dst="$3"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_bloom_or_into_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_bloom_or_into_${name}.output"
+  local exp_hex_file="$REPO_ROOT/gen-out/zisk_bloom_or_into_${name}.expected.hex"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys
+src = bytes.fromhex('$src')
+dst = bytes.fromhex('$dst')
+assert len(src) == 256 and len(dst) == 256, f'sizes: src={len(src)} dst={len(dst)}'
+with open(sys.argv[1], 'wb') as f:
+    # 8-byte placeholder at offset 0 (ziskemu shifts user data by 8 bytes),
+    # then src bloom (256 B), then dst bloom (256 B).
+    f.write(struct.pack('<Q', 0))
+    f.write(src + dst)
+expected = bytes(s | d for s, d in zip(src, dst))
+with open(sys.argv[2], 'w') as f:
+    f.write(expected.hex())
+" "$in_file" "$exp_hex_file"
+
+  "$ZISKEMU" -e gen-out/zisk_bloom_or_into.elf \
+    -i "$in_file" -o "$out_file" -n 100000 \
+    >"$REPO_ROOT/gen-out/zisk_bloom_or_into_${name}.emu.log" 2>&1 || true
+
+  local actual; actual="$(xxd -p -c 256 "$out_file" | tr -d '\n')"
+  local expected; expected="$(cat "$exp_hex_file")"
+
+  if [[ "$actual" == "$expected" ]]; then
+    local nbits; nbits="$(python3 -c "print(bin(int('$actual', 16)).count('1'))")"
+    printf "  %-30s OK   bits_set=%d\n" "$name" "$nbits"
+    return 0
+  else
+    printf "  %-30s FAIL\n" "$name"
+    printf "      actual:   %s...\n" "${actual:0:80}"
+    printf "      expected: %s...\n" "${expected:0:80}"
+    return 1
+  fi
+}
+
+ZERO256="$(python3 -c "print('00' * 256)")"
+ALL_FF256="$(python3 -c "print('ff' * 256)")"
+ONES_LO="$(python3 -c "print(('80' + '00' * 7) * 32)")"  # MSB of each byte
+ONES_HI="$(python3 -c "print(('01' + '00' * 7) * 32)")"
+
+FAILED=0
+# src=0, dst=0 → 0
+run_case "zero_or_zero"     "$ZERO256" "$ZERO256" || FAILED=1
+# src=0, dst=FF → FF
+run_case "zero_or_ones"     "$ZERO256" "$ALL_FF256" || FAILED=1
+# src=FF, dst=0 → FF
+run_case "ones_or_zero"     "$ALL_FF256" "$ZERO256" || FAILED=1
+# src=FF, dst=FF → FF
+run_case "ones_or_ones"     "$ALL_FF256" "$ALL_FF256" || FAILED=1
+# Disjoint bits: 0x80 high bits OR 0x01 low bits → 0x81
+run_case "disjoint_bits"    "$ONES_LO" "$ONES_HI" || FAILED=1
+# Random-ish patterns
+RAND_A="$(python3 -c "import os; print(os.urandom(256).hex())")"
+RAND_B="$(python3 -c "import os; print(os.urandom(256).hex())")"
+run_case "random_a"         "$RAND_A" "$RAND_B" || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: bloom_or_into performs in-place 256-byte OR"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- \`bloom_or_into\`: in-place 256-byte bitwise OR — \`dst[i] |= src[i]\` for \`i in 0..256\`.
- Per-receipt → per-block accumulator: each receipt's \`logs_bloom\` is OR'd into the block-level \`block.logs_bloom\`. Completes the bloom-construction family (K148 add_value, K149 add_log, K150 add_logs_list, K151 OR-into).
- Pure register arithmetic, 32 iterations of 8-byte \`ld\` + \`or\` + \`sd\`. No external calls, no scratch memory, leaf-callable.

### Family at a glance

| PR | Helper | Scope |
|---|---|---|
| K148 | \`bloom_add_value\` | single value (address or topic) |
| K149 | \`log_bloom_add\` | one log (address + topics) |
| K150 | \`logs_list_bloom_add\` | one receipt's logs |
| **K151** | **\`bloom_or_into\`** | **fold receipt blooms into block bloom** |

### Calling convention

| reg | role |
|---|---|
| a0 | dst bloom ptr (256 B, mutable, in-place OR) |
| a1 | src bloom ptr (256 B, read-only) |
| a0 (out) | 0 (always succeeds) |

## Test plan

- [x] \`lake build\` clean
- [x] \`scripts/codegen-zisk-bloom-or-into-check.sh\` — 6/6 fixtures pass against Python's \`|\` operator:
  - \`zero_or_zero\`: 0 bits
  - \`zero_or_ones\`, \`ones_or_zero\`, \`ones_or_ones\`: all 2048 bits
  - \`disjoint_bits\`: MSB-only OR LSB-only patterns → 64 bits (no collisions)
  - \`random_a\`: random 256-byte patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)