### PR TITLE
feat(stateless): header_extract_logs_bloom (PR-K153)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -9890,6 +9890,122 @@ def ziskReceiptExtractLogsBloomProbeUnit : BuildUnit := {
   dataAsm     := ziskReceiptExtractLogsBloomDataSection
 }
 
+/-! ## header_extract_logs_bloom -- PR-K153
+
+    Extract the 256-byte `logs_bloom` field (field 6, 0-indexed)
+    from a block header RLP. Header field layout from genesis on:
+
+      [parent_hash, ommers_hash, coinbase,
+       state_root, transactions_root, receipts_root,
+       logs_bloom,                                   <-- field 6
+       difficulty, number, gas_limit, gas_used,
+       timestamp, extra_data, prev_randao / mix_hash,
+       nonce, base_fee_per_gas?, withdrawals_root?,
+       blob_gas_used?, excess_blob_gas?,
+       parent_beacon_block_root?, requests_hash?]
+
+    The bloom's position at field 6 is invariant across every
+    fork from Frontier through Amsterdam; later forks only
+    append new fields after it.
+
+    Direct counterpart to PR-K152 `receipt_extract_logs_bloom`.
+    Together with PR-K151 `bloom_or_into`, the verifier's
+    `block_validate_logs_bloom` check becomes:
+
+      header_extract_logs_bloom(header_rlp, header_bloom)
+      bzero(computed_bloom)
+      for receipt in receipts:
+        receipt_extract_logs_bloom(receipt, scratch)
+        bloom_or_into(computed_bloom, scratch)
+      assert memcmp(header_bloom, computed_bloom) == 0
+
+    Composes:
+      - PR-K20 `rlp_list_nth_item` on field 6
+
+    Calling convention:
+      a0 (input)  : header_rlp ptr
+      a1 (input)  : header_rlp byte length
+      a2 (input)  : 256-byte output bloom ptr
+      ra (input)  : return
+      a0 (output) :
+        0 : success
+        1 : RLP parse failure / fewer than 7 fields
+        2 : logs_bloom field length != 256 -/
+def headerExtractLogsBloomFunction : String :=
+  "header_extract_logs_bloom:\n" ++
+  "  addi sp, sp, -32\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp)\n" ++
+  "  mv s0, a0                   # header_rlp ptr\n" ++
+  "  mv s1, a1                   # header_rlp len\n" ++
+  "  mv s2, a2                   # output bloom ptr\n" ++
+  "  # ---- Field 6: logs_bloom (must be 256 bytes) ----\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 6\n" ++
+  "  la a3, helb_offset; la a4, helb_length\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lhelb_fail\n" ++
+  "  la t0, helb_length; ld t1, 0(t0)\n" ++
+  "  li t2, 256\n" ++
+  "  bne t1, t2, .Lhelb_size_fail\n" ++
+  "  la t0, helb_offset; ld t1, 0(t0)\n" ++
+  "  add t3, s0, t1                              # src ptr\n" ++
+  "  mv t4, s2                                   # dst ptr\n" ++
+  "  li t5, 32                                   # 256 / 8 = 32 words\n" ++
+  ".Lhelb_loop:\n" ++
+  "  beqz t5, .Lhelb_done\n" ++
+  "  ld t6, 0(t3)\n" ++
+  "  sd t6, 0(t4)\n" ++
+  "  addi t3, t3, 8\n" ++
+  "  addi t4, t4, 8\n" ++
+  "  addi t5, t5, -1\n" ++
+  "  j .Lhelb_loop\n" ++
+  ".Lhelb_done:\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lhelb_ret\n" ++
+  ".Lhelb_fail:\n" ++
+  "  li a0, 1\n" ++
+  "  j .Lhelb_ret\n" ++
+  ".Lhelb_size_fail:\n" ++
+  "  li a0, 2\n" ++
+  ".Lhelb_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp)\n" ++
+  "  addi sp, sp, 32\n" ++
+  "  ret"
+
+/-- `zisk_header_extract_logs_bloom`: probe BuildUnit.
+    Input layout:
+      bytes  0.. 8 : header_rlp_len
+      bytes  8..   : header_rlp
+    Output layout (256 B, full ziskemu cap):
+      bytes  0..256 : 256-byte logs_bloom on success;
+                       caller-zeroed buffer on failure. -/
+def ziskHeaderExtractLogsBloomPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a3, 0x40000000\n" ++
+  "  ld a1, 8(a3)                # header_rlp_len\n" ++
+  "  addi a0, a3, 16             # header_rlp ptr\n" ++
+  "  li a2, 0xa0010000           # output bloom ptr (256 B)\n" ++
+  "  jal ra, header_extract_logs_bloom\n" ++
+  "  j .Lhelb_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  headerExtractLogsBloomFunction ++ "\n" ++
+  ".Lhelb_pdone:"
+
+def ziskHeaderExtractLogsBloomDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "helb_offset:\n" ++
+  "  .zero 8\n" ++
+  "helb_length:\n" ++
+  "  .zero 8"
+
+def ziskHeaderExtractLogsBloomProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskHeaderExtractLogsBloomPrologue
+  dataAsm     := ziskHeaderExtractLogsBloomDataSection
+}
+
 /-! ## calldata_byte_counts -- PR-K105
 
     Count zero and non-zero bytes in an arbitrary byte buffer.
@@ -10659,6 +10775,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_logs_list_bloom_add" => some ziskLogsListBloomAddProbeUnit
   | "zisk_bloom_or_into" => some ziskBloomOrIntoProbeUnit
   | "zisk_receipt_extract_logs_bloom" => some ziskReceiptExtractLogsBloomProbeUnit
+  | "zisk_header_extract_logs_bloom" => some ziskHeaderExtractLogsBloomProbeUnit
   | "zisk_calldata_byte_counts" => some ziskCalldataByteCountsProbeUnit
   | "zisk_intrinsic_gas_calldata_floor_eip7623" => some ziskIntrinsicGasCalldataFloorEip7623ProbeUnit
   | "zisk_init_code_cost"       => some ziskInitCodeCostProbeUnit
@@ -10825,6 +10942,7 @@ def knownProgramNames : List String :=
    "zisk_logs_list_bloom_add",
    "zisk_bloom_or_into",
    "zisk_receipt_extract_logs_bloom",
+   "zisk_header_extract_logs_bloom",
    "zisk_calldata_byte_counts",
    "zisk_intrinsic_gas_calldata_floor_eip7623",
    "zisk_init_code_cost",

--- a/scripts/codegen-zisk-header-extract-logs-bloom-check.sh
+++ b/scripts/codegen-zisk-header-extract-logs-bloom-check.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# codegen-zisk-header-extract-logs-bloom-check.sh -- PR-K153.
+#
+# Extract the 256-byte logs_bloom field (field 6) from a block header RLP.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_header_extract_logs_bloom ELF"
+lake exe codegen --program zisk_header_extract_logs_bloom --halt linux93 \
+  -o gen-out/zisk_header_extract_logs_bloom
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <fork_tag> <bloom_hex_256B>
+# fork_tag selects which fields are present:
+#   "merge"     -> 15 fields, post-merge, no base_fee
+#   "london"    -> 16 fields, base_fee_per_gas
+#   "shanghai"  -> 17 fields, withdrawals_root
+#   "cancun"    -> 20 fields, blob_gas_used + excess + beacon_root
+#   "prague"    -> 21 fields, +requests_hash
+run_case() {
+  local name="$1" fork="$2" bloom="$3"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_header_extract_logs_bloom_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_header_extract_logs_bloom_${name}.output"
+  local exp_hex_file="$REPO_ROOT/gen-out/zisk_header_extract_logs_bloom_${name}.expected.hex"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+fork = '$fork'
+bloom = bytes.fromhex('$bloom')
+assert len(bloom) == 256
+H32 = bytes([0xaa] * 32)
+ADDR = bytes([0xbb] * 20)
+# Common pre-bloom fields (0..5).
+hdr = [
+    H32,                                        # parent_hash
+    bytes.fromhex('1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347'),  # ommers_hash (empty)
+    ADDR,                                       # coinbase
+    H32,                                        # state_root
+    H32,                                        # transactions_root
+    H32,                                        # receipts_root
+    bloom,                                      # field 6: logs_bloom
+    0,                                          # difficulty
+    18000000,                                   # number
+    30000000,                                   # gas_limit
+    21000,                                      # gas_used
+    1700000000,                                 # timestamp
+    b'',                                        # extra_data
+    H32,                                        # prev_randao
+    b'\\x00' * 8,                                # nonce
+]
+if fork in ('london', 'shanghai', 'cancun', 'prague'):
+    hdr.append(7 * 10**9)                       # base_fee_per_gas
+if fork in ('shanghai', 'cancun', 'prague'):
+    hdr.append(H32)                             # withdrawals_root
+if fork in ('cancun', 'prague'):
+    hdr += [131072, 786432, H32]                # blob_gas_used, excess_blob_gas, beacon_root
+if fork == 'prague':
+    hdr.append(H32)                             # requests_hash
+
+header_rlp = rlp.encode(hdr)
+with open(sys.argv[1], 'wb') as f:
+    f.write(struct.pack('<Q', len(header_rlp)))
+    f.write(header_rlp)
+    pad = (-(8 + len(header_rlp))) % 8
+    if pad: f.write(b'\x00' * pad)
+with open(sys.argv[2], 'w') as f:
+    f.write(bloom.hex())
+" "$in_file" "$exp_hex_file"
+
+  "$ZISKEMU" -e gen-out/zisk_header_extract_logs_bloom.elf \
+    -i "$in_file" -o "$out_file" -n 1000000 \
+    >"$REPO_ROOT/gen-out/zisk_header_extract_logs_bloom_${name}.emu.log" 2>&1 || true
+
+  local actual; actual="$(xxd -p -c 256 "$out_file" | tr -d '\n')"
+  local expected; expected="$(cat "$exp_hex_file")"
+
+  if [[ "$actual" == "$expected" ]]; then
+    local nbits; nbits="$(python3 -c "print(bin(int('$actual', 16)).count('1'))")"
+    printf "  %-30s OK   fork=%s bits_set=%d\n" "$name" "$fork" "$nbits"
+    return 0
+  else
+    printf "  %-30s FAIL fork=%s\n" "$name" "$fork"
+    printf "      actual:   %s...\n" "${actual:0:80}"
+    printf "      expected: %s...\n" "${expected:0:80}"
+    return 1
+  fi
+}
+
+ZERO_BLOOM="$(python3 -c "print('00' * 256)")"
+ALL_FF_BLOOM="$(python3 -c "print('ff' * 256)")"
+RAND_BLOOM="$(python3 -c "import os; print(os.urandom(256).hex())")"
+
+FAILED=0
+run_case "merge_zero_bloom"    merge    "$ZERO_BLOOM"   || FAILED=1
+run_case "london_zero_bloom"   london   "$ZERO_BLOOM"   || FAILED=1
+run_case "shanghai_random"     shanghai "$RAND_BLOOM"   || FAILED=1
+run_case "cancun_random"       cancun   "$RAND_BLOOM"   || FAILED=1
+run_case "prague_random"       prague   "$RAND_BLOOM"   || FAILED=1
+run_case "cancun_all_ones"     cancun   "$ALL_FF_BLOOM" || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: header_extract_logs_bloom finds the field across all fork shapes"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- \`header_extract_logs_bloom\`: extract the 256-byte \`logs_bloom\` field (field 6, 0-indexed) from a block header RLP.
- Direct counterpart to PR-K152 \`receipt_extract_logs_bloom\`. With PR-K151 \`bloom_or_into\`, the verifier's \`block_validate_logs_bloom\` check now composes in 4 lines:

\`\`\`
header_extract_logs_bloom(header_rlp, header_bloom)
bzero(computed_bloom)
for receipt in receipts:
    receipt_extract_logs_bloom(receipt, scratch)
    bloom_or_into(computed_bloom, scratch)
assert memcmp(header_bloom, computed_bloom) == 0
\`\`\`

- Composes PR-K20 \`rlp_list_nth_item\` on field 6.

### Position invariance

The bloom's position at field 6 is invariant across every fork from Frontier through Amsterdam; later forks only append new fields after it. Fixtures cover merge → london → shanghai → cancun → prague header shapes.

### Calling convention

| reg | role |
|---|---|
| a0 | header_rlp ptr |
| a1 | header_rlp byte length |
| a2 | 256-byte output bloom ptr |
| a0 (out) | 0 ok / 1 parse fail / 2 bloom != 256 B |

## Stacking

Base = \`feat/stateless-receipt-extract-logs-bloom\` (PR #5932); GitHub auto-retargets through the chain once K151/K152 merge.

## Test plan

- [x] \`lake build\` clean
- [x] \`scripts/codegen-zisk-header-extract-logs-bloom-check.sh\` — 6/6 fixtures pass:
  - \`merge_zero_bloom\`, \`london_zero_bloom\`, \`shanghai_random\`, \`cancun_random\`, \`prague_random\`: one per fork shape, field-6 position confirmed invariant
  - \`cancun_all_ones\`: 0xff..ff bloom corner

🤖 Generated with [Claude Code](https://claude.com/claude-code)