### PR TITLE
fix(divmod): replace native_decide/bv_decide with kernel-checkable tactics

### DIFF
--- a/EvmAsm/Evm64/DivMod/Counterexamples.lean
+++ b/EvmAsm/Evm64/DivMod/Counterexamples.lean
@@ -149,7 +149,7 @@ theorem div128Quot_v4_counterexampleA_within_two_addbacks :
 theorem n4CallAddbackBeqSemanticHolds_counterexampleA_v4 :
     n4CallAddbackBeqSemanticHolds ceA_a ceA_b := by
   rw [n4CallAddbackBeqSemantic_unfold]
-  native_decide
+  decide
 
 /-- Per-counterexample regression pin: the executable DIV body is on the v4
     path, and the normalized trial quotient for counterexample A has the v4

--- a/EvmAsm/Evm64/DivMod/Spec/CallAddbackRuntime.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/CallAddbackRuntime.lean
@@ -124,8 +124,8 @@ theorem n4CallAddbackBeqNormalizedDivisor_ne_zero {b : EvmWord}
     n4CallAddbackBeqB0Prime b ||| n4CallAddbackBeqB1Prime b |||
         n4CallAddbackBeqB2Prime b ||| n4CallAddbackBeqB3Prime b ≠ 0 := by
   intro h_zero
-  have h_b3_zero : n4CallAddbackBeqB3Prime b = 0 := by
-    bv_decide
+  have h_b3_zero : n4CallAddbackBeqB3Prime b = 0 :=
+    (BitVec.or_eq_zero_iff.mp h_zero).2
   have h_top_ge := n4CallAddbackBeqB3Prime_ge_pow63 hb3nz
   rw [h_b3_zero] at h_top_ge
   have h_zero_toNat : (0 : Word).toNat = 0 := by decide


### PR DESCRIPTION
## Summary
- `Counterexamples.lean`: replace `native_decide` with `decide` in `n4CallAddbackBeqSemanticHolds_counterexampleA_v4` — `ceA_a` and `ceA_b` are concrete values, so `decide` is both correct and fast
- `CallAddbackRuntime.lean`: replace `bv_decide` with `(BitVec.or_eq_zero_iff.mp h_zero).2` to extract `n4CallAddbackBeqB3Prime b = 0` from the OR-equals-zero hypothesis (direct, no heartbeat pressure)

Both replacements satisfy CLAUDE.md's "no native_decide or bv_decide" policy and are kernel-checkable.

Refs #6059. Bead: evm-asm-9iqmw.4.

## Verification
- `lake build EvmAsm.Evm64.DivMod.Counterexamples` — 1.1s, green
- `lake build EvmAsm.Evm64.DivMod.Spec.CallAddbackRuntime` — 1.2s, green
- `scripts/check-file-size.sh` — 800 files checked, all within cap
- `rg -n 'sorry|admit|native_decide|bv_decide|set_option maxHeartbeats|set_option maxRecDepth'` — no matches
- `lake build` (full build pending CI)

Authored by @pirapira; implemented by Claude Code