### PR TITLE
feat(stateless): bloom_eq (PR-K154)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -10006,6 +10006,100 @@ def ziskHeaderExtractLogsBloomProbeUnit : BuildUnit := {
   dataAsm     := ziskHeaderExtractLogsBloomDataSection
 }
 
+/-! ## bloom_eq -- PR-K154
+
+    Byte-equal check between two 256-byte bloom filters. The
+    final compare step in block-level bloom validation:
+
+      assert bloom_eq(header.logs_bloom, computed_block_bloom)
+
+    Returns the verdict as a u64 (1 if equal, 0 if not). The
+    return code in `a0` is always 0 (the predicate result lives
+    in the out pointer, not the status), so the caller can
+    distinguish "predicate is false" from "the call itself
+    failed" -- though here the call can never fail since there
+    are no parse / boundary conditions to honour.
+
+    Together with PR-K151 `bloom_or_into`, PR-K152
+    `receipt_extract_logs_bloom`, and PR-K153
+    `header_extract_logs_bloom`, this closes the
+    block-level bloom-validation pipeline:
+
+      header_extract_logs_bloom(header_rlp, header_bloom)
+      bzero(computed_bloom)
+      for receipt in receipts:
+        receipt_extract_logs_bloom(receipt, scratch)
+        bloom_or_into(computed_bloom, scratch)
+      bloom_eq(header_bloom, computed_bloom, is_equal_out)
+      assert is_equal_out == 1
+
+    Pure register arithmetic; processes 8 bytes per iteration
+    (32 iterations total) using `ld` + `xor` + `or`. Early-exit
+    on first mismatch is intentionally avoided to keep the
+    cycle count constant (256-byte compare is cheap and timing
+    invariance is friendlier to gas-cost modeling).
+
+    Calling convention:
+      a0 (input)  : bloom_a ptr (256 bytes, read-only)
+      a1 (input)  : bloom_b ptr (256 bytes, read-only)
+      a2 (input)  : u64 out ptr (1 if equal, 0 if not)
+      ra (input)  : return
+      a0 (output) : 0 (always succeeds). -/
+def bloomEqFunction : String :=
+  "bloom_eq:\n" ++
+  "  li t0, 32                  # 256 bytes / 8 bytes per word\n" ++
+  "  mv t1, a0\n" ++
+  "  mv t2, a1\n" ++
+  "  li t5, 0                   # diff_accumulator\n" ++
+  ".Lbeq_loop:\n" ++
+  "  beqz t0, .Lbeq_done\n" ++
+  "  ld t3, 0(t1)\n" ++
+  "  ld t4, 0(t2)\n" ++
+  "  xor t3, t3, t4\n" ++
+  "  or  t5, t5, t3             # accumulate any nonzero diff\n" ++
+  "  addi t1, t1, 8\n" ++
+  "  addi t2, t2, 8\n" ++
+  "  addi t0, t0, -1\n" ++
+  "  j .Lbeq_loop\n" ++
+  ".Lbeq_done:\n" ++
+  "  # is_equal = (diff_accumulator == 0)\n" ++
+  "  seqz t5, t5\n" ++
+  "  sd t5, 0(a2)\n" ++
+  "  li a0, 0\n" ++
+  "  ret"
+
+/-- `zisk_bloom_eq`: probe BuildUnit.
+    Input layout:
+      bytes  0.. 8 : pad
+      bytes  8..264: bloom_a
+      bytes 264..520: bloom_b
+    Output layout:
+      bytes  0.. 8 : status (always 0)
+      bytes  8..16 : is_equal (u64; 1 if equal, 0 if not) -/
+def ziskBloomEqPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a3, 0x40000000\n" ++
+  "  addi a0, a3, 16             # bloom_a ptr (after 8B host-shift + 8B placeholder)\n" ++
+  "  addi a1, a3, 272            # bloom_b ptr (a0 + 256)\n" ++
+  "  li a2, 0xa0010008           # is_equal out\n" ++
+  "  jal ra, bloom_eq\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lbeq_pdone\n" ++
+  bloomEqFunction ++ "\n" ++
+  ".Lbeq_pdone:"
+
+def ziskBloomEqDataSection : String :=
+  ".section .data\n" ++
+  "beq_pad:\n" ++
+  "  .zero 8"
+
+def ziskBloomEqProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskBloomEqPrologue
+  dataAsm     := ziskBloomEqDataSection
+}
+
 /-! ## calldata_byte_counts -- PR-K105
 
     Count zero and non-zero bytes in an arbitrary byte buffer.
@@ -10776,6 +10870,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_bloom_or_into" => some ziskBloomOrIntoProbeUnit
   | "zisk_receipt_extract_logs_bloom" => some ziskReceiptExtractLogsBloomProbeUnit
   | "zisk_header_extract_logs_bloom" => some ziskHeaderExtractLogsBloomProbeUnit
+  | "zisk_bloom_eq" => some ziskBloomEqProbeUnit
   | "zisk_calldata_byte_counts" => some ziskCalldataByteCountsProbeUnit
   | "zisk_intrinsic_gas_calldata_floor_eip7623" => some ziskIntrinsicGasCalldataFloorEip7623ProbeUnit
   | "zisk_init_code_cost"       => some ziskInitCodeCostProbeUnit
@@ -10943,6 +11038,7 @@ def knownProgramNames : List String :=
    "zisk_bloom_or_into",
    "zisk_receipt_extract_logs_bloom",
    "zisk_header_extract_logs_bloom",
+   "zisk_bloom_eq",
    "zisk_calldata_byte_counts",
    "zisk_intrinsic_gas_calldata_floor_eip7623",
    "zisk_init_code_cost",

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **176**
-- ziskemu round-trip scripts: **169** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **177**
+- ziskemu round-trip scripts: **170** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-bloom-eq-check.sh
+++ b/scripts/codegen-zisk-bloom-eq-check.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# codegen-zisk-bloom-eq-check.sh -- PR-K154.
+#
+# Byte-equal check between two 256-byte blooms.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_bloom_eq ELF"
+lake exe codegen --program zisk_bloom_eq --halt linux93 \
+  -o gen-out/zisk_bloom_eq
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <bloom_a_hex> <bloom_b_hex> <expected_eq>
+run_case() {
+  local name="$1" a="$2" b="$3" exp="$4"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_bloom_eq_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_bloom_eq_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys
+a = bytes.fromhex('$a')
+b = bytes.fromhex('$b')
+assert len(a) == 256 and len(b) == 256
+with open(sys.argv[1], 'wb') as f:
+    f.write(struct.pack('<Q', 0))
+    f.write(a + b)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_bloom_eq.elf \
+    -i "$in_file" -o "$out_file" -n 100000 \
+    >"$REPO_ROOT/gen-out/zisk_bloom_eq_${name}.emu.log" 2>&1 || true
+
+  local actual_status; actual_status="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local actual_eq_le; actual_eq_le="$(dd if="$out_file" bs=1 skip=8 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local actual_eq; actual_eq="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$actual_eq_le'))[0])")"
+
+  if [[ "$actual_status" == "0000000000000000" && "$actual_eq" == "$exp" ]]; then
+    printf "  %-30s OK   is_equal=%d\n" "$name" "$exp"
+    return 0
+  else
+    printf "  %-30s FAIL status=0x%s is_equal=%d expected=%d\n" "$name" "$actual_status" "$actual_eq" "$exp"
+    return 1
+  fi
+}
+
+ZERO="$(python3 -c "print('00' * 256)")"
+ONES="$(python3 -c "print('ff' * 256)")"
+RAND="$(python3 -c "import os; print(os.urandom(256).hex())")"
+# Same as RAND but with one bit flipped in the last byte.
+RAND_FLIP="$(python3 -c "import os; r=bytearray.fromhex('$RAND'); r[255] ^= 1; print(bytes(r).hex())")"
+# Same as RAND but with one bit flipped in the first byte (different word).
+RAND_FLIP_FIRST="$(python3 -c "r=bytearray.fromhex('$RAND'); r[0] ^= 0x80; print(bytes(r).hex())")"
+
+FAILED=0
+# Positive: both equal
+run_case "zero_eq_zero"     "$ZERO" "$ZERO" 1 || FAILED=1
+run_case "ones_eq_ones"     "$ONES" "$ONES" 1 || FAILED=1
+run_case "random_eq_self"   "$RAND" "$RAND" 1 || FAILED=1
+# Negative: differ
+run_case "zero_neq_ones"    "$ZERO" "$ONES" 0 || FAILED=1
+run_case "ones_neq_zero"    "$ONES" "$ZERO" 0 || FAILED=1
+run_case "diff_last_byte"   "$RAND" "$RAND_FLIP" 0 || FAILED=1
+run_case "diff_first_byte"  "$RAND" "$RAND_FLIP_FIRST" 0 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: bloom_eq distinguishes byte-equal from byte-differing 256-byte blooms"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- \`bloom_eq\`: byte-equal check between two 256-byte bloom filters. Returns the verdict via an out pointer (1 if equal, 0 if not); return code is always 0.
- **Closes the block-level bloom-validation pipeline** with PR-K151, K152, K153:

\`\`\`
header_extract_logs_bloom(header_rlp, header_bloom)
bzero(computed_bloom)
for receipt in receipts:
    receipt_extract_logs_bloom(receipt, scratch)
    bloom_or_into(computed_bloom, scratch)
bloom_eq(header_bloom, computed_bloom, is_equal_out)
assert is_equal_out == 1
\`\`\`

- Pure register arithmetic — 32 iterations of \`ld\` + \`xor\` + \`or\`, no early exit (constant cycle count for gas-cost modeling).

### Calling convention

| reg | role |
|---|---|
| a0 | bloom_a ptr (256 B, read-only) |
| a1 | bloom_b ptr (256 B, read-only) |
| a2 | u64 out ptr (1 if equal, 0 if not) |
| a0 (out) | 0 (always succeeds) |

## Stacking

Base = \`feat/stateless-header-extract-logs-bloom\` (PR #5933).

## Test plan

- [x] \`lake build\` clean
- [x] \`scripts/codegen-zisk-bloom-eq-check.sh\` — 7/7 fixtures pass:
  - Positive: \`zero_eq_zero\`, \`ones_eq_ones\`, \`random_eq_self\`
  - Negative: \`zero_neq_ones\`, \`ones_neq_zero\`
  - Single-bit-flip boundary cases at byte 0 and byte 255

🤖 Generated with [Claude Code](https://claude.com/claude-code)