### PR TITLE
feat(stateless): rlp_encode_u64 (PR-K155)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -10100,6 +10100,126 @@ def ziskBloomEqProbeUnit : BuildUnit := {
   dataAsm     := ziskBloomEqDataSection
 }
 
+/-! ## rlp_encode_u64 -- PR-K155
+
+    Encode a `u64` register value as canonical RLP. A convenience
+    wrapper that takes the integer directly rather than the BE
+    byte buffer that PR-K30 `rlp_encode_uint_be` requires:
+
+      value == 0       -> 0x80                       (1 byte)
+      value < 0x80     -> single byte = value        (1 byte)
+      else             -> 0x80 + effective_len + BE bytes
+                          (effective_len in 1..8)    (2..9 bytes)
+
+    Pure register arithmetic, leaf-callable, no scratch memory.
+    Use cases where K30 with a stack-allocated BE buffer is
+    awkward boilerplate -- typical example is receipt encoding:
+
+      rlp_encode_u64(status, buf + cursor, &written); cursor += written
+      rlp_encode_u64(cumulative_gas, buf + cursor, &written); cursor += written
+      ...
+
+    Calling convention:
+      a0 (input)  : value (u64)
+      a1 (input)  : output buffer ptr (caller supplies >= 9 bytes)
+      a2 (input)  : u64 out length ptr (bytes written; 1..9)
+      ra (input)  : return
+      a0 (output) : 0 (always succeeds). -/
+def rlpEncodeU64Function : String :=
+  "rlp_encode_u64:\n" ++
+  "  beqz a0, .Lreu64_zero\n" ++
+  "  li t0, 0x80\n" ++
+  "  bgeu a0, t0, .Lreu64_multi\n" ++
+  "  # Single-byte form (value in 0x01..0x7f).\n" ++
+  "  sb a0, 0(a1)\n" ++
+  "  li t1, 1\n" ++
+  "  sd t1, 0(a2)\n" ++
+  "  li a0, 0\n" ++
+  "  ret\n" ++
+  ".Lreu64_zero:\n" ++
+  "  li t0, 0x80\n" ++
+  "  sb t0, 0(a1)\n" ++
+  "  li t1, 1\n" ++
+  "  sd t1, 0(a2)\n" ++
+  "  li a0, 0\n" ++
+  "  ret\n" ++
+  ".Lreu64_multi:\n" ++
+  "  # Compute effective byte length (1..8) by finding the top non-zero byte.\n" ++
+  "  # We already know value >= 0x80, so len >= 1.\n" ++
+  "  li t0, 1                   # effective_len candidate\n" ++
+  "  li t1, 0x100\n" ++
+  "  bltu a0, t1, .Lreu64_have_len\n" ++
+  "  li t0, 2\n" ++
+  "  slli t1, t1, 8\n" ++
+  "  bltu a0, t1, .Lreu64_have_len\n" ++
+  "  li t0, 3\n" ++
+  "  slli t1, t1, 8\n" ++
+  "  bltu a0, t1, .Lreu64_have_len\n" ++
+  "  li t0, 4\n" ++
+  "  slli t1, t1, 8\n" ++
+  "  bltu a0, t1, .Lreu64_have_len\n" ++
+  "  li t0, 5\n" ++
+  "  slli t1, t1, 8\n" ++
+  "  bltu a0, t1, .Lreu64_have_len\n" ++
+  "  li t0, 6\n" ++
+  "  slli t1, t1, 8\n" ++
+  "  bltu a0, t1, .Lreu64_have_len\n" ++
+  "  li t0, 7\n" ++
+  "  slli t1, t1, 8\n" ++
+  "  bltu a0, t1, .Lreu64_have_len\n" ++
+  "  li t0, 8\n" ++
+  ".Lreu64_have_len:\n" ++
+  "  # Write prefix 0x80 + effective_len.\n" ++
+  "  addi t2, t0, 0x80\n" ++
+  "  sb t2, 0(a1)\n" ++
+  "  # Write effective_len BE bytes of value into a1+1..a1+1+len.\n" ++
+  "  addi t3, a1, 1                 # dst cursor\n" ++
+  "  addi t4, t0, -1                # shift_byte_index = len - 1\n" ++
+  ".Lreu64_emit:\n" ++
+  "  bltz t4, .Lreu64_done\n" ++
+  "  slli t5, t4, 3                 # bit shift = 8 * byte_index\n" ++
+  "  srl t6, a0, t5\n" ++
+  "  sb t6, 0(t3)\n" ++
+  "  addi t3, t3, 1\n" ++
+  "  addi t4, t4, -1\n" ++
+  "  j .Lreu64_emit\n" ++
+  ".Lreu64_done:\n" ++
+  "  addi t1, t0, 1                 # bytes_written = 1 + effective_len\n" ++
+  "  sd t1, 0(a2)\n" ++
+  "  li a0, 0\n" ++
+  "  ret"
+
+/-- `zisk_rlp_encode_u64`: probe BuildUnit.
+    Input layout:
+      bytes  0.. 8 : value (u64)
+    Output layout:
+      bytes  0.. 8 : status (always 0)
+      bytes  8..16 : bytes_written
+      bytes 16..25 : encoded RLP (up to 9 bytes) -/
+def ziskRlpEncodeU64Prologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a3, 0x40000000\n" ++
+  "  ld a0, 8(a3)                # value\n" ++
+  "  li a1, 0xa0010010           # output buffer ptr\n" ++
+  "  li a2, 0xa0010008           # out length ptr\n" ++
+  "  jal ra, rlp_encode_u64\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lreu64_pdone\n" ++
+  rlpEncodeU64Function ++ "\n" ++
+  ".Lreu64_pdone:"
+
+def ziskRlpEncodeU64DataSection : String :=
+  ".section .data\n" ++
+  "reu64_pad:\n" ++
+  "  .zero 8"
+
+def ziskRlpEncodeU64ProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskRlpEncodeU64Prologue
+  dataAsm     := ziskRlpEncodeU64DataSection
+}
+
 /-! ## calldata_byte_counts -- PR-K105
 
     Count zero and non-zero bytes in an arbitrary byte buffer.
@@ -10871,6 +10991,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_receipt_extract_logs_bloom" => some ziskReceiptExtractLogsBloomProbeUnit
   | "zisk_header_extract_logs_bloom" => some ziskHeaderExtractLogsBloomProbeUnit
   | "zisk_bloom_eq" => some ziskBloomEqProbeUnit
+  | "zisk_rlp_encode_u64" => some ziskRlpEncodeU64ProbeUnit
   | "zisk_calldata_byte_counts" => some ziskCalldataByteCountsProbeUnit
   | "zisk_intrinsic_gas_calldata_floor_eip7623" => some ziskIntrinsicGasCalldataFloorEip7623ProbeUnit
   | "zisk_init_code_cost"       => some ziskInitCodeCostProbeUnit
@@ -11039,6 +11160,7 @@ def knownProgramNames : List String :=
    "zisk_receipt_extract_logs_bloom",
    "zisk_header_extract_logs_bloom",
    "zisk_bloom_eq",
+   "zisk_rlp_encode_u64",
    "zisk_calldata_byte_counts",
    "zisk_intrinsic_gas_calldata_floor_eip7623",
    "zisk_init_code_cost",

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **177**
-- ziskemu round-trip scripts: **170** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **178**
+- ziskemu round-trip scripts: **171** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-rlp-encode-u64-check.sh
+++ b/scripts/codegen-zisk-rlp-encode-u64-check.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# codegen-zisk-rlp-encode-u64-check.sh -- PR-K155.
+#
+# Encode a u64 directly as canonical RLP (convenience wrapper).
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_rlp_encode_u64 ELF"
+lake exe codegen --program zisk_rlp_encode_u64 --halt linux93 \
+  -o gen-out/zisk_rlp_encode_u64
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <value_u64>
+run_case() {
+  local name="$1" v="$2"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_rlp_encode_u64_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_rlp_encode_u64_${name}.output"
+  local exp_hex_file="$REPO_ROOT/gen-out/zisk_rlp_encode_u64_${name}.expected.hex"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+v = $v
+encoded = rlp.encode(v)
+with open(sys.argv[1], 'wb') as f:
+    f.write(struct.pack('<Q', v))
+with open(sys.argv[2], 'w') as f:
+    f.write(encoded.hex())
+" "$in_file" "$exp_hex_file"
+
+  "$ZISKEMU" -e gen-out/zisk_rlp_encode_u64.elf \
+    -i "$in_file" -o "$out_file" -n 100000 \
+    >"$REPO_ROOT/gen-out/zisk_rlp_encode_u64_${name}.emu.log" 2>&1 || true
+
+  local actual_status; actual_status="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local actual_len_le; actual_len_le="$(dd if="$out_file" bs=1 skip=8 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local actual_len; actual_len="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$actual_len_le'))[0])")"
+  local expected_hex; expected_hex="$(cat "$exp_hex_file")"
+  local expected_len; expected_len=$(( ${#expected_hex} / 2 ))
+  local actual_hex; actual_hex="$(dd if="$out_file" bs=1 skip=16 count="$expected_len" 2>/dev/null | xxd -p | tr -d '\n')"
+
+  if [[ "$actual_status" == "0000000000000000" \
+       && "$actual_len" == "$expected_len" \
+       && "$actual_hex" == "$expected_hex" ]]; then
+    printf "  %-30s OK   v=%s len=%d enc=%s\n" "$name" "$v" "$expected_len" "$expected_hex"
+    return 0
+  else
+    printf "  %-30s FAIL status=0x%s actual_len=%d expected_len=%d\n" "$name" "$actual_status" "$actual_len" "$expected_len"
+    printf "      actual:   %s\n" "$actual_hex"
+    printf "      expected: %s\n" "$expected_hex"
+    return 1
+  fi
+}
+
+FAILED=0
+# Single-byte form boundary cases
+run_case "zero"               0          || FAILED=1
+run_case "one"                1          || FAILED=1
+run_case "max_single_byte"    127        || FAILED=1
+# Multi-byte boundary (128 needs 0x81 0x80)
+run_case "128_boundary"       128        || FAILED=1
+run_case "255"                255        || FAILED=1
+run_case "256_boundary"       256        || FAILED=1
+# Typical values
+run_case "42"                 42         || FAILED=1
+run_case "10_thousand"        10000      || FAILED=1
+run_case "1_million"          1000000    || FAILED=1
+# Each byte-count tier
+run_case "3_bytes"            65536      || FAILED=1                       # 0x010000
+run_case "4_bytes"            16777216   || FAILED=1                       # 0x01000000
+run_case "5_bytes"            4294967296 || FAILED=1                       # 0x0100000000
+run_case "6_bytes"            1099511627776  || FAILED=1                   # 2^40
+run_case "7_bytes"            281474976710656 || FAILED=1                  # 2^48
+run_case "8_bytes"            72057594037927936 || FAILED=1                # 2^56
+# Max u64
+run_case "max_u64m1"          18446744073709551614 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: rlp_encode_u64 matches Python rlp.encode for all boundaries"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- \`rlp_encode_u64\`: encode a \`u64\` register value as canonical RLP, directly from the integer (no caller-allocated BE byte buffer needed). Convenience wrapper around the same canonical-form logic as PR-K30 \`rlp_encode_uint_be\`.
- Use case: receipt / authorization / transaction encoders that need to splice a u64 field into a byte buffer in one call without preparing a BE source buffer:

\`\`\`
rlp_encode_u64(status, buf + cursor, &written); cursor += written
rlp_encode_u64(cumulative_gas, buf + cursor, &written); cursor += written
...
\`\`\`

- Pure register arithmetic, leaf-callable, no scratch memory.

### Encoding rules

| value | bytes |
|---|---|
| 0 | \`0x80\` (1 B) |
| 1..127 | single byte = value (1 B) |
| 128..(2^N-1) | \`0x80 + N + BE bytes\` (1 + N B), N in 1..8 |

### Calling convention

| reg | role |
|---|---|
| a0 | value (u64) |
| a1 | output buffer ptr (≥ 9 bytes) |
| a2 | u64 out length ptr (bytes written; 1..9) |
| a0 (out) | 0 (always succeeds) |

## Test plan

- [x] \`lake build\` clean
- [x] \`scripts/codegen-zisk-rlp-encode-u64-check.sh\` — 16/16 fixtures pass against Python \`rlp.encode\`:
  - Boundaries: 0, 1, 127 (single-byte end), 128 (multi-byte start), 255, 256
  - Typical: 42, 10 000, 1 000 000
  - One per byte-count tier (3B…8B)
  - \`max_u64m1\` → 9-byte encoding

🤖 Generated with [Claude Code](https://claude.com/claude-code)