### PR TITLE
feat(stateless): receipt_encode (PR-K156)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -10220,6 +10220,194 @@ def ziskRlpEncodeU64ProbeUnit : BuildUnit := {
   dataAsm     := ziskRlpEncodeU64DataSection
 }
 
+/-! ## receipt_encode -- PR-K156
+
+    Encode an Ethereum tx receipt as RLP:
+
+      receipt = rlp([status, cumulative_gas_used,
+                     logs_bloom (256 B), logs])
+
+    This is the encoder side of PR-K152 `receipt_extract_logs_bloom`,
+    and the input to receipts-trie / receipts-root computation.
+    For typed receipts (EIP-2718), the caller prepends the
+    `0x<type>` byte to the output of this helper; the wire-format
+    typed receipt is `type_byte || rlp(inner)`.
+
+    Algorithm:
+      1. Write status (u64) at receipt_pl_buf[0..]    via K155.
+      2. Write cumulative_gas (u64) at next slot      via K155.
+      3. Write logs_bloom (256 B as RLP string) at
+         next slot                                    via K128.
+      4. Copy logs_rlp (pre-encoded list) verbatim    (memcpy).
+      5. Compute total payload length.
+      6. Write outer list prefix to output[0..]       via K129.
+      7. Copy receipt_pl_buf[..total_payload] to
+         output[prefix_len..].
+
+    Composes:
+      - PR-K155 `rlp_encode_u64`        -- status / gas
+      - PR-K128 `rlp_encode_bytes`      -- logs_bloom
+      - PR-K129 `rlp_encode_list_prefix`-- outer list prefix
+
+    Calling convention:
+      a0 (input)  : status (u64)
+      a1 (input)  : cumulative_gas_used (u64)
+      a2 (input)  : logs_bloom ptr (exactly 256 bytes)
+      a3 (input)  : logs_rlp ptr (pre-encoded list, copied verbatim)
+      a4 (input)  : logs_rlp byte length
+      a5 (input)  : output buffer ptr
+      a6 (input)  : u64 out length ptr (total bytes written)
+      ra (input)  : return
+      a0 (output) : 0 (always succeeds).
+
+    Uses a 16 KiB scratch buffer `re_payload_buf` in `.data` for
+    the intermediate payload. Should comfortably hold mainnet
+    receipt payloads (logs_bloom is 257 RLP bytes, status/gas
+    add <= 18 bytes, logs section is variable but typically
+    KBs at most). -/
+def receiptEncodeFunction : String :=
+  "receipt_encode:\n" ++
+  "  addi sp, sp, -64\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp)\n" ++
+  "  mv s0, a0                   # status\n" ++
+  "  mv s1, a1                   # cumulative_gas\n" ++
+  "  mv s2, a2                   # bloom ptr\n" ++
+  "  mv s3, a3                   # logs_rlp ptr\n" ++
+  "  mv s4, a4                   # logs_rlp len\n" ++
+  "  mv s5, a5                   # output ptr\n" ++
+  "  mv s6, a6                   # out_length ptr\n" ++
+  "  # The running cursor (payload offset within re_payload_buf) is\n" ++
+  "  # stashed to `re_cursor` across `jal` calls since t-registers are\n" ++
+  "  # caller-saved and the encode helpers clobber them.\n" ++
+  "  la t0, re_cursor; sd zero, 0(t0)\n" ++
+  "  # ---- Step 1: encode status into re_payload_buf[0..] ----\n" ++
+  "  mv a0, s0\n" ++
+  "  la a1, re_payload_buf\n" ++
+  "  la a2, re_field_len\n" ++
+  "  jal ra, rlp_encode_u64\n" ++
+  "  la t0, re_field_len; ld t1, 0(t0)         # status_len\n" ++
+  "  la t0, re_cursor; sd t1, 0(t0)            # cursor = status_len\n" ++
+  "  # ---- Step 2: encode cumulative_gas at re_payload_buf[cursor] ----\n" ++
+  "  la t0, re_cursor; ld t2, 0(t0)\n" ++
+  "  mv a0, s1\n" ++
+  "  la a1, re_payload_buf; add a1, a1, t2\n" ++
+  "  la a2, re_field_len\n" ++
+  "  jal ra, rlp_encode_u64\n" ++
+  "  la t0, re_field_len; ld t1, 0(t0)         # gas_len\n" ++
+  "  la t0, re_cursor; ld t2, 0(t0)\n" ++
+  "  add t2, t2, t1\n" ++
+  "  la t0, re_cursor; sd t2, 0(t0)\n" ++
+  "  # ---- Step 3: encode bloom (256 B) ----\n" ++
+  "  mv a0, s2; li a1, 256\n" ++
+  "  la a2, re_payload_buf; add a2, a2, t2\n" ++
+  "  la a3, re_field_len\n" ++
+  "  jal ra, rlp_encode_bytes\n" ++
+  "  la t0, re_field_len; ld t1, 0(t0)         # bloom_enc_len\n" ++
+  "  la t0, re_cursor; ld t2, 0(t0)\n" ++
+  "  add t2, t2, t1\n" ++
+  "  # ---- Step 4: copy logs_rlp verbatim ----\n" ++
+  "  la t3, re_payload_buf; add t3, t3, t2     # dst\n" ++
+  "  mv t4, s3                                 # src\n" ++
+  "  mv t5, s4                                 # remaining bytes\n" ++
+  ".Lre_logs_cp:\n" ++
+  "  beqz t5, .Lre_logs_done\n" ++
+  "  lbu t6, 0(t4)\n" ++
+  "  sb t6, 0(t3)\n" ++
+  "  addi t3, t3, 1\n" ++
+  "  addi t4, t4, 1\n" ++
+  "  addi t5, t5, -1\n" ++
+  "  j .Lre_logs_cp\n" ++
+  ".Lre_logs_done:\n" ++
+  "  add t2, t2, s4                            # total payload len\n" ++
+  "  # Stash total_payload before the next jal clobbers caller-saved t2.\n" ++
+  "  la t0, re_total_payload; sd t2, 0(t0)\n" ++
+  "  # ---- Step 5: write outer list prefix at output[0..] ----\n" ++
+  "  mv a0, t2; mv a1, s5\n" ++
+  "  la a2, re_field_len\n" ++
+  "  jal ra, rlp_encode_list_prefix\n" ++
+  "  la t0, re_field_len; ld t1, 0(t0)        # outer_prefix_len\n" ++
+  "  # ---- Step 6: copy re_payload_buf[..total_payload] to output[prefix_len..] ----\n" ++
+  "  # Total payload was last stashed in t2; restore via .data\n" ++
+  "  # Actually we lost t2 across jal. Re-derive: total_payload =\n" ++
+  "  # bytes_written - bytes_p, but cleaner to re-compute it from\n" ++
+  "  # re_payload_buf metadata. Save total_payload before jal next time.\n" ++
+  "  # Use the stashed value: we'll save t2 to .data BEFORE the\n" ++
+  "  # rlp_encode_list_prefix call.\n" ++
+  "  # (Fixed by re-reading the saved payload total below.)\n" ++
+  "  la t0, re_total_payload; ld t2, 0(t0)\n" ++
+  "  add t3, s5, t1                            # dst = output + prefix_len\n" ++
+  "  la t4, re_payload_buf                     # src\n" ++
+  "  mv t5, t2                                 # remaining\n" ++
+  ".Lre_body_cp:\n" ++
+  "  beqz t5, .Lre_body_done\n" ++
+  "  lbu t6, 0(t4)\n" ++
+  "  sb t6, 0(t3)\n" ++
+  "  addi t3, t3, 1\n" ++
+  "  addi t4, t4, 1\n" ++
+  "  addi t5, t5, -1\n" ++
+  "  j .Lre_body_cp\n" ++
+  ".Lre_body_done:\n" ++
+  "  # total_written = outer_prefix_len + total_payload\n" ++
+  "  add t1, t1, t2\n" ++
+  "  sd t1, 0(s6)\n" ++
+  "  li a0, 0\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp)\n" ++
+  "  addi sp, sp, 64\n" ++
+  "  ret"
+
+/-- `zisk_receipt_encode`: probe BuildUnit.
+    Input layout:
+      bytes  0.. 8 : status (u64 LE)
+      bytes  8..16 : cumulative_gas (u64 LE)
+      bytes 16..272: logs_bloom (256 bytes)
+      bytes 272..280: logs_rlp_len (u64 LE)
+      bytes 280..   : logs_rlp
+    Output layout (256 B ziskemu cap):
+      bytes  0.. 8 : status (always 0)
+      bytes  8..16 : encoded receipt total length
+      bytes 16..   : encoded receipt bytes (truncated to fit) -/
+def ziskReceiptEncodePrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a7, 0x40000000\n" ++
+  "  ld a0, 8(a7)                # status\n" ++
+  "  ld a1, 16(a7)               # cumulative_gas\n" ++
+  "  addi a2, a7, 24             # logs_bloom ptr (256 B)\n" ++
+  "  ld a4, 280(a7)              # logs_rlp_len\n" ++
+  "  addi a3, a7, 288            # logs_rlp ptr\n" ++
+  "  li a5, 0xa0010010           # output ptr\n" ++
+  "  li a6, 0xa0010008           # out length ptr\n" ++
+  "  jal ra, receipt_encode\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lre_pdone\n" ++
+  rlpEncodeU64Function ++ "\n" ++
+  rlpEncodeBytesFunction ++ "\n" ++
+  rlpEncodeListPrefixFunction ++ "\n" ++
+  receiptEncodeFunction ++ "\n" ++
+  ".Lre_pdone:"
+
+def ziskReceiptEncodeDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "re_field_len:\n" ++
+  "  .zero 8\n" ++
+  "re_cursor:\n" ++
+  "  .zero 8\n" ++
+  "re_total_payload:\n" ++
+  "  .zero 8\n" ++
+  "re_payload_buf:\n" ++
+  "  .zero 16384"
+
+def ziskReceiptEncodeProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskReceiptEncodePrologue
+  dataAsm     := ziskReceiptEncodeDataSection
+}
+
 /-! ## calldata_byte_counts -- PR-K105
 
     Count zero and non-zero bytes in an arbitrary byte buffer.
@@ -10992,6 +11180,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_header_extract_logs_bloom" => some ziskHeaderExtractLogsBloomProbeUnit
   | "zisk_bloom_eq" => some ziskBloomEqProbeUnit
   | "zisk_rlp_encode_u64" => some ziskRlpEncodeU64ProbeUnit
+  | "zisk_receipt_encode" => some ziskReceiptEncodeProbeUnit
   | "zisk_calldata_byte_counts" => some ziskCalldataByteCountsProbeUnit
   | "zisk_intrinsic_gas_calldata_floor_eip7623" => some ziskIntrinsicGasCalldataFloorEip7623ProbeUnit
   | "zisk_init_code_cost"       => some ziskInitCodeCostProbeUnit
@@ -11161,6 +11350,7 @@ def knownProgramNames : List String :=
    "zisk_header_extract_logs_bloom",
    "zisk_bloom_eq",
    "zisk_rlp_encode_u64",
+   "zisk_receipt_encode",
    "zisk_calldata_byte_counts",
    "zisk_intrinsic_gas_calldata_floor_eip7623",
    "zisk_init_code_cost",

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **177**
-- ziskemu round-trip scripts: **170** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **179**
+- ziskemu round-trip scripts: **172** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-receipt-encode-check.sh
+++ b/scripts/codegen-zisk-receipt-encode-check.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# codegen-zisk-receipt-encode-check.sh -- PR-K156.
+#
+# Encode a tx receipt as RLP: rlp([status, cumulative_gas, logs_bloom, logs])
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_receipt_encode ELF"
+lake exe codegen --program zisk_receipt_encode --halt linux93 \
+  -o gen-out/zisk_receipt_encode
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <status> <cumulative_gas> <bloom_hex_256B> <logs_json>
+# Note: ziskemu output cap is 256 B; very short receipts work.
+run_case() {
+  local name="$1" status="$2" gas="$3" bloom="$4" logs="$5"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_receipt_encode_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_receipt_encode_${name}.output"
+  local exp_hex_file="$REPO_ROOT/gen-out/zisk_receipt_encode_${name}.expected.hex"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import json, struct, sys, rlp
+status = $status
+gas = $gas
+bloom = bytes.fromhex('$bloom')
+assert len(bloom) == 256
+raw_logs = json.loads('''$logs''')
+logs = []
+for addr_hex, topic_hexes, data_hex in raw_logs:
+    addr = bytes.fromhex(addr_hex)
+    topics = [bytes.fromhex(t) for t in topic_hexes]
+    data = bytes.fromhex(data_hex)
+    logs.append([addr, topics, data])
+logs_rlp = rlp.encode(logs)
+receipt_rlp = rlp.encode([status, gas, bloom, logs])
+
+with open(sys.argv[1], 'wb') as f:
+    f.write(struct.pack('<Q', status))
+    f.write(struct.pack('<Q', gas))
+    f.write(bloom)
+    f.write(struct.pack('<Q', len(logs_rlp)))
+    f.write(logs_rlp)
+    pad = (-(280 + len(logs_rlp))) % 8
+    if pad: f.write(b'\x00' * pad)
+with open(sys.argv[2], 'w') as f:
+    f.write(receipt_rlp.hex())
+" "$in_file" "$exp_hex_file"
+
+  "$ZISKEMU" -e gen-out/zisk_receipt_encode.elf \
+    -i "$in_file" -o "$out_file" -n 5000000 \
+    >"$REPO_ROOT/gen-out/zisk_receipt_encode_${name}.emu.log" 2>&1 || true
+
+  local actual_status; actual_status="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local actual_len_le; actual_len_le="$(dd if="$out_file" bs=1 skip=8 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local actual_len; actual_len="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$actual_len_le'))[0])")"
+  local expected_hex; expected_hex="$(cat "$exp_hex_file")"
+  local expected_len; expected_len=$(( ${#expected_hex} / 2 ))
+  # Output cap = 256 B; we have 8B status + 8B length + up to 240 B of encoded bytes.
+  # For receipts longer than 240 B we only compare the first 240 bytes.
+  local cmp_len=$expected_len
+  if [[ $cmp_len -gt 240 ]]; then cmp_len=240; fi
+  local actual_hex; actual_hex="$(dd if="$out_file" bs=1 skip=16 count="$cmp_len" 2>/dev/null | xxd -p | tr -d '\n')"
+  local expected_prefix; expected_prefix="${expected_hex:0:$((2 * cmp_len))}"
+
+  if [[ "$actual_status" == "0000000000000000" \
+       && "$actual_len" == "$expected_len" \
+       && "$actual_hex" == "$expected_prefix" ]]; then
+    printf "  %-30s OK   len=%d (compared %d B)\n" "$name" "$expected_len" "$cmp_len"
+    return 0
+  else
+    printf "  %-30s FAIL status=0x%s actual_len=%d expected_len=%d\n" "$name" "$actual_status" "$actual_len" "$expected_len"
+    printf "      actual:   %s...\n" "${actual_hex:0:80}"
+    printf "      expected: %s...\n" "${expected_prefix:0:80}"
+    return 1
+  fi
+}
+
+ZERO_BLOOM="$(python3 -c "print('00' * 256)")"
+RAND_BLOOM="$(python3 -c "import os; print(os.urandom(256).hex())")"
+
+A1="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+T0="1111111111111111111111111111111111111111111111111111111111111111"
+
+FAILED=0
+# Empty receipt (no logs)
+run_case "empty_logs_zero_bloom" 1 21000 "$ZERO_BLOOM" "[]" || FAILED=1
+# Failed-tx receipt (status=0)
+run_case "failed_tx"             0 50000 "$ZERO_BLOOM" "[]" || FAILED=1
+# Receipt with random bloom but no logs
+run_case "random_bloom_no_logs"  1 30000 "$RAND_BLOOM" "[]" || FAILED=1
+# Receipt with one log (small data) and zero bloom
+run_case "one_log_small"         1 70000 "$ZERO_BLOOM" "[[\"$A1\", [\"$T0\"], \"\"]]" || FAILED=1
+# Cumulative gas > 24 bits (multi-byte RLP)
+run_case "large_gas"             1 30000000 "$ZERO_BLOOM" "[]" || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: receipt_encode matches Python rlp.encode([status, gas, bloom, logs])"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- \`receipt_encode\`: encode an Ethereum tx receipt as RLP — \`rlp([status, cumulative_gas, logs_bloom, logs])\`.
- The encoder side of PR-K152 \`receipt_extract_logs_bloom\`. Direct input to receipts-trie / receipts-root computation inside \`apply_body\`. For typed (EIP-2718) receipts, the caller prepends the \`0x<type>\` byte to this helper's output.
- Composes PR-K155 \`rlp_encode_u64\` (status / cumulative_gas), PR-K128 \`rlp_encode_bytes\` (256-byte logs_bloom), and PR-K129 \`rlp_encode_list_prefix\` (outer list prefix).

### Calling convention

| reg | role |
|---|---|
| a0 | status (u64) |
| a1 | cumulative_gas_used (u64) |
| a2 | logs_bloom ptr (exactly 256 bytes) |
| a3 | logs_rlp ptr (pre-encoded list, copied verbatim) |
| a4 | logs_rlp byte length |
| a5 | output buffer ptr |
| a6 | u64 out length ptr |
| a0 (out) | 0 (always succeeds) |

Uses a 16 KiB scratch buffer for the intermediate payload and a \`.data\` cursor slot to stash the running offset across \`jal\` calls (t-registers are caller-saved).

## Stacking

Base = \`feat/stateless-rlp-encode-u64\` (PR #5937).

## Test plan

- [x] \`lake build\` clean
- [x] \`scripts/codegen-zisk-receipt-encode-check.sh\` — 5/5 fixtures pass against Python \`rlp.encode\`:
  - \`empty_logs_zero_bloom\`: minimal receipt
  - \`failed_tx\`: status=0
  - \`random_bloom_no_logs\`: random 256-byte bloom field
  - \`one_log_small\`: receipt with one LOG1
  - \`large_gas\`: cumulative_gas = 30M (multi-byte RLP)

Note: ziskemu output cap is 256 B, so the fixture compares only the first 240 bytes of the encoded receipt (after a 16-byte status + length header in the output). For real-world receipts that exceed 240 bytes the host would need a wider output region — purely a fixture limitation, not a helper limitation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)