### PR TITLE
feat(divmod): N2 V4 iteration family (R0V4/R1V4/R2V4/DenormPreV4/etc.)

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -81,6 +81,8 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopMTT
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopMTM
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopMMT
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopLoopUnified
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopPreloop
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4Families
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1V4NoNop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1V4

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4Families.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4Families.lean
@@ -1,0 +1,262 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN2V4Families
+
+  N2 V4 iteration family: R0V4/R1V4/R2V4/C3V4/DenormPreV4/etc.
+  Mirrors FullPathN3V4.lean (lines 141-275) for n=2.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopPreloop
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)
+
+open EvmAsm.Rv64.Tactics
+
+-- ============================================================================
+-- V4 iteration intermediates
+-- ============================================================================
+
+@[irreducible]
+def iterN2V4 (bltu : Bool) (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
+    Word × Word × Word × Word × Word × Word :=
+  if bltu then
+    iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  else
+    iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+
+@[irreducible]
+def fullDivN2R2V4 (bltu_2 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    Word × Word × Word × Word × Word × Word :=
+  let v := fullDivN2NormV b0 b1 b2 b3
+  let u := fullDivN2NormU a0 a1 a2 a3 b1
+  iterN2V4 bltu_2 v.1 v.2.1 v.2.2.1 v.2.2.2
+    u.2.2.1 u.2.2.2.1 u.2.2.2.2 (0 : Word) (0 : Word)
+
+@[irreducible]
+def fullDivN2R1V4 (bltu_2 bltu_1 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    Word × Word × Word × Word × Word × Word :=
+  let v := fullDivN2NormV b0 b1 b2 b3
+  let u := fullDivN2NormU a0 a1 a2 a3 b1
+  let r2 := fullDivN2R2V4 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3
+  iterN2V4 bltu_1 v.1 v.2.1 v.2.2.1 v.2.2.2 u.2.1
+    r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
+
+@[irreducible]
+def fullDivN2R0V4 (bltu_2 bltu_1 bltu_0 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    Word × Word × Word × Word × Word × Word :=
+  let v := fullDivN2NormV b0 b1 b2 b3
+  let u := fullDivN2NormU a0 a1 a2 a3 b1
+  let r1 := fullDivN2R1V4 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+  iterN2V4 bltu_0 v.1 v.2.1 v.2.2.1 v.2.2.2 u.1
+    r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+
+@[irreducible]
+def fullDivN2C3V4 (bltu_2 bltu_1 bltu_0 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    Word :=
+  let v := fullDivN2NormV b0 b1 b2 b3
+  let u := fullDivN2NormU a0 a1 a2 a3 b1
+  let r1 := fullDivN2R1V4 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+  if bltu_0 then
+    (mulsubN4 (divKTrialCallV4QHat r1.2.2.1 r1.2.1 v.2.1)
+      v.1 v.2.1 v.2.2.1 v.2.2.2 u.1 r1.2.1 r1.2.2.1 r1.2.2.2.1).2.2.2.2
+  else
+    (mulsubN4 (signExtend12 4095 : Word)
+      v.1 v.2.1 v.2.2.1 v.2.2.2 u.1 r1.2.1 r1.2.2.1 r1.2.2.2.1).2.2.2.2
+
+-- ============================================================================
+-- V4 denorm pre/post
+-- ============================================================================
+
+@[irreducible]
+def fullDivN2DenormPreV4 (bltu_2 bltu_1 bltu_0 : Bool)
+    (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
+  let shift := fullDivN2Shift b1
+  let v := fullDivN2NormV b0 b1 b2 b3
+  let r2 := fullDivN2R2V4 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3
+  let r1 := fullDivN2R1V4 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+  let r0 := fullDivN2R0V4 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+  ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ sp + signExtend12 4056) ** (.x0 ↦ᵣ (0 : Word)) **
+   (.x5 ↦ᵣ (0 : Word)) ** (.x7 ↦ᵣ sp + signExtend12 4088) **
+   (.x2 ↦ᵣ r0.2.2.2.2.1) **
+   (.x10 ↦ᵣ fullDivN2C3V4 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3) **
+   ((sp + signExtend12 3992) ↦ₘ shift) **
+   ((sp + signExtend12 4056) ↦ₘ r0.2.1) **
+   ((sp + signExtend12 4048) ↦ₘ r0.2.2.1) **
+   ((sp + signExtend12 4040) ↦ₘ r0.2.2.2.1) **
+   ((sp + signExtend12 4032) ↦ₘ r0.2.2.2.2.1) **
+   ((sp + signExtend12 4088) ↦ₘ r0.1) **
+   ((sp + signExtend12 4080) ↦ₘ r1.1) **
+   ((sp + signExtend12 4072) ↦ₘ r2.1) **
+   ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+   ((sp + signExtend12 32) ↦ₘ v.1) **
+   ((sp + signExtend12 40) ↦ₘ v.2.1) **
+   ((sp + signExtend12 48) ↦ₘ v.2.2.1) **
+   ((sp + signExtend12 56) ↦ₘ v.2.2.2))
+
+@[irreducible]
+def fullDivN2DenormPostV4 (bltu_2 bltu_1 bltu_0 : Bool)
+    (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
+  let shift := fullDivN2Shift b1
+  let r2 := fullDivN2R2V4 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3
+  let r1 := fullDivN2R1V4 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+  let r0 := fullDivN2R0V4 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+  denormDivPost sp shift r0.2.1 r0.2.2.1 r0.2.2.2.1 r0.2.2.2.2.1
+    r0.1 r1.1 r2.1 (0 : Word) **
+  ((sp + signExtend12 3992) ↦ₘ shift)
+
+-- ============================================================================
+-- V4 scratch, frame, unified post
+-- ============================================================================
+
+@[irreducible]
+def fullDivN2ScratchMemV4 (bltu_2 bltu_1 bltu_0 : Bool)
+    (a0 a1 a2 a3 b0 b1 b2 b3 scratchMem : Word) : Word :=
+  let v := fullDivN2NormV b0 b1 b2 b3
+  let u := fullDivN2NormU a0 a1 a2 a3 b1
+  let scratch2 := if bltu_2 then
+      divKTrialCallV4ScratchOut u.2.2.2.2 u.2.2.2.1 v.2.1 scratchMem
+    else scratchMem
+  let r2 := fullDivN2R2V4 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3
+  let scratch1 := if bltu_1 then
+      divKTrialCallV4ScratchOut r2.2.2.1 r2.2.1 v.2.1 scratch2
+    else scratch2
+  let r1 := fullDivN2R1V4 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+  if bltu_0 then
+    divKTrialCallV4ScratchOut r1.2.2.1 r1.2.1 v.2.1 scratch1
+  else scratch1
+
+@[irreducible]
+def fullDivN2ScratchNoX1V4 (bltu_2 bltu_1 bltu_0 : Bool)
+    (sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 : Word) :
+    Assertion :=
+  let v := fullDivN2NormV b0 b1 b2 b3
+  let u := fullDivN2NormU a0 a1 a2 a3 b1
+  let r2 := fullDivN2R2V4 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3
+  let scratchRet2 := if bltu_2 then (base + div128CallRetOff) else retMem
+  let scratchD2 := if bltu_2 then v.2.1 else dMem
+  let scratchDLo2 := if bltu_2 then divKTrialCallV4DLo v.2.1 else dloMem
+  let scratchUn02 := if bltu_2 then divKTrialCallV4Un0 u.2.2.2.1 else scratchUn0
+  let scratchRet1 := if bltu_1 then (base + div128CallRetOff) else scratchRet2
+  let scratchD1 := if bltu_1 then v.2.1 else scratchD2
+  let scratchDLo1 := if bltu_1 then divKTrialCallV4DLo v.2.1 else scratchDLo2
+  let scratchUn01 := if bltu_1 then divKTrialCallV4Un0 r2.2.1 else scratchUn02
+  let r1 := fullDivN2R1V4 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+  (sp + signExtend12 3968 ↦ₘ (if bltu_0 then (base + div128CallRetOff) else scratchRet1)) **
+  (sp + signExtend12 3960 ↦ₘ (if bltu_0 then v.2.1 else scratchD1)) **
+  (sp + signExtend12 3952 ↦ₘ (if bltu_0 then divKTrialCallV4DLo v.2.1 else scratchDLo1)) **
+  (sp + signExtend12 3944 ↦ₘ (if bltu_0 then divKTrialCallV4Un0 r1.2.1 else scratchUn01))
+
+@[irreducible]
+def fullDivN2FrameNoX1V4 (bltu_2 bltu_1 bltu_0 : Bool)
+    (sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 : Word) :
+    Assertion :=
+  let r2 := fullDivN2R2V4 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3
+  let r1 := fullDivN2R1V4 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+  let r0 := fullDivN2R0V4 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+  ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+  ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+  ((sp + signExtend12 4024) ↦ₘ r0.2.2.2.2.2) **
+  ((sp + signExtend12 4016) ↦ₘ r1.2.2.2.2.2) **
+  ((sp + signExtend12 4008) ↦ₘ r2.2.2.2.2.2) **
+  ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+  (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
+  (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
+  (.x9 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ r0.1) **
+  fullDivN2ScratchNoX1V4 bltu_2 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
+    retMem dMem dloMem scratchUn0
+
+@[irreducible]
+def fullDivN2UnifiedPostNoX1V4 (bltu_2 bltu_1 bltu_0 : Bool)
+    (sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 scratchMem : Word) :
+    Assertion :=
+  fullDivN2DenormPostV4 bltu_2 bltu_1 bltu_0 sp a0 a1 a2 a3 b0 b1 b2 b3 **
+  fullDivN2FrameNoX1V4 bltu_2 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
+    retMem dMem dloMem scratchUn0 **
+  ((sp + signExtend12 3936) ↦ₘ
+    fullDivN2ScratchMemV4 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3 scratchMem)
+
+-- ============================================================================
+-- Quotient word
+-- ============================================================================
+
+@[irreducible]
+def fullDivN2QuotientWordV4 (bltu_2 bltu_1 bltu_0 : Bool)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word) : EvmWord :=
+  EvmWord.fromLimbs (fun i : Fin 4 =>
+    match i with
+    | 0 => (fullDivN2R0V4 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).1
+    | 1 => (fullDivN2R1V4 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1
+    | 2 => (fullDivN2R2V4 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).1
+    | 3 => (0 : Word))
+
+-- ============================================================================
+-- V4 denorm epilogue
+-- ============================================================================
+
+theorem evm_div_n2_denorm_epilogue_bundled_spec_noNop_v4Final
+    (bltu_2 bltu_1 bltu_0 : Bool)
+    (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hshift_nz : fullDivN2Shift b1 ≠ 0) :
+    cpsTripleWithin (2 + 23 + 10) (base + denormOff) (base + nopOff) (divCode_noNop_v4 base)
+      (fullDivN2DenormPreV4 bltu_2 bltu_1 bltu_0 sp a0 a1 a2 a3 b0 b1 b2 b3)
+      (fullDivN2DenormPostV4 bltu_2 bltu_1 bltu_0 sp a0 a1 a2 a3 b0 b1 b2 b3) := by
+  let shift := fullDivN2Shift b1
+  let v := fullDivN2NormV b0 b1 b2 b3
+  let r2 := fullDivN2R2V4 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3
+  let r1 := fullDivN2R1V4 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+  let r0 := fullDivN2R0V4 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+  let c3 := fullDivN2C3V4 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+  have h := evm_div_preamble_denorm_epilogue_spec_v4_noNop sp base
+    r0.2.1 r0.2.2.1 r0.2.2.2.1 r0.2.2.2.2.1 shift
+    r0.2.2.2.2.1 (0 : Word) (sp + signExtend12 4056) (sp + signExtend12 4088)
+    c3 r0.1 r1.1 r2.1 (0 : Word)
+    v.1 v.2.1 v.2.2.1 v.2.2.2 hshift_nz
+  exact cpsTripleWithin_weaken
+    (fun h hp => by
+      subst shift; subst v; subst r2; subst r1; subst r0; subst c3
+      delta fullDivN2DenormPreV4 at hp
+      simp only [se12_32, se12_40, se12_48, se12_56] at hp
+      xperm_hyp hp)
+    (fun h hq => by
+      subst shift; subst r2; subst r1; subst r0
+      delta fullDivN2DenormPostV4
+      xperm_hyp hq)
+    h
+
+theorem evm_div_n2_denorm_epilogue_bundled_spec_noNop_v4Final_exact_x1_frame
+    (bltu_2 bltu_1 bltu_0 : Bool)
+    (sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 scratchMem raVal : Word)
+    (hshift_nz : fullDivN2Shift b1 ≠ 0) :
+    cpsTripleWithin (2 + 23 + 10) (base + denormOff) (base + nopOff)
+      (divCode_noNop_v4 base)
+      (fullDivN2DenormPreV4 bltu_2 bltu_1 bltu_0 sp a0 a1 a2 a3 b0 b1 b2 b3 **
+       fullDivN2FrameNoX1V4 bltu_2 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
+         retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ
+         fullDivN2ScratchMemV4 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3 scratchMem) **
+       (.x1 ↦ᵣ raVal))
+      (fullDivN2UnifiedPostNoX1V4 bltu_2 bltu_1 bltu_0 sp base
+        a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 scratchMem **
+       (.x1 ↦ᵣ raVal)) := by
+  have hDenorm := evm_div_n2_denorm_epilogue_bundled_spec_noNop_v4Final
+    bltu_2 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3 hshift_nz
+  have hFramed := cpsTripleWithin_frameR
+    (fullDivN2FrameNoX1V4 bltu_2 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
+       retMem dMem dloMem scratchUn0 **
+     ((sp + signExtend12 3936) ↦ₘ
+       fullDivN2ScratchMemV4 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3 scratchMem) **
+     (.x1 ↦ᵣ raVal))
+    (by
+      delta fullDivN2FrameNoX1V4 fullDivN2ScratchNoX1V4
+      pcFree) hDenorm
+  exact cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by
+      delta fullDivN2UnifiedPostNoX1V4
+      xperm_hyp hq)
+    hFramed
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNopPreloop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNopPreloop.lean
@@ -1,0 +1,285 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopPreloop
+
+  Preloop setup wrappers for the n=2 v4/no-NOP full DIV path.
+  Mirrors FullPathN3V4NoNopPreloop.lean for the n=2 case (b3=b2=0, b1≠0).
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopLoopUnified
+import EvmAsm.Evm64.DivMod.Compose.PhaseABV4NoNop
+import EvmAsm.Evm64.DivMod.Compose.CLZ
+import EvmAsm.Evm64.DivMod.Compose.Norm
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)
+
+/-- PhaseAB(n=2) + CLZ over `divCode_noNop_v4`.
+    base → base+312. b1 is the top non-zero limb (b2=b3=0, b1≠0). -/
+theorem evm_div_phaseAB_n2_clz_spec_within_v4_noNop (sp base : Word)
+    (b0 b1 b2 b3 v5 v6 v7 v10 : Word)
+    (q0 q1 q2 q3 u5 u6 u7 nMem : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0) :
+    cpsTripleWithin (8 + 21 + 24) base (base + phaseC2Off) (divCode_noNop_v4 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem))
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (clzResult b1).2) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ (clzResult b1).1) ** (.x7 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (2 : Word))) := by
+  have hA := evm_div_phaseA_ntaken_spec_within_v4_noNop sp base b0 b1 b2 b3 v5 v10 hbnz
+  have hAf := cpsTripleWithin_frameR
+    ((.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+     ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+     ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+     ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+     ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem))
+    (by pcFree) hA
+  have hB := evm_div_phaseB_n2_spec_within_v4_noNop sp base b1 b2 b3
+    (b0 ||| b1 ||| b2 ||| b3) v6 v7 q0 q1 q2 q3 u5 u6 u7 nMem
+    hb3z hb2z hb1nz
+  have hBf := cpsTripleWithin_frameR
+    (((sp + 32) ↦ₘ b0))
+    (by pcFree) hB
+  have hAB := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hAf hBf
+  have hCLZ := divK_clz_spec_within_v4_noNop b1 b1 b2 base
+  have hCLZf := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ b3) **
+     ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+     ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (2 : Word)))
+    (by pcFree) hCLZ
+  have hABCLZ := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hAB hCLZf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    hABCLZ
+
+/-- PhaseAB(n=2) + CLZ + PhaseC2(shift≠0) + NormB over `divCode_noNop_v4`. -/
+theorem evm_div_n2_to_normB_spec_within_v4_noNop (sp base : Word)
+    (b0 b1 b2 b3 v5 v6 v7 v10 : Word)
+    (q0 q1 q2 q3 u5 u6 u7 nMem shiftMem : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0)
+    (hshift_nz : (clzResult b1).1 ≠ 0) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21) base (base + normAOff) (divCode_noNop_v4 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
+      (normBPost sp (2 : Word) (clzResult b1).1 b0 b1 b2 b3) := by
+  let shift := (clzResult b1).1
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  have hABCLZ := evm_div_phaseAB_n2_clz_spec_within_v4_noNop sp base b0 b1 b2 b3
+    v5 v6 v7 v10 q0 q1 q2 q3 u5 u6 u7 nMem hbnz hb3z hb2z hb1nz
+  have hABCLZf := cpsTripleWithin_frameR
+    ((.x2 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
+     ((sp + signExtend12 3992) ↦ₘ shiftMem))
+    (by pcFree) hABCLZ
+  have hC2 := divK_phaseC2_ntaken_spec_within_v4_noNop sp shift ((clzResult b1).2 >>> (63 : Nat))
+    shiftMem base hshift_nz
+  have hC2f := cpsTripleWithin_frameR
+    ((.x5 ↦ᵣ (clzResult b1).2) ** (.x10 ↦ᵣ b3) **
+     (.x7 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
+     ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+     ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (2 : Word)))
+    (by pcFree) hC2
+  have hABC2 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hABCLZf hC2f
+  have hNB := divK_normB_full_spec_within_v4_noNop sp b0 b1 b2 b3
+    (clzResult b1).2 ((clzResult b1).2 >>> (63 : Nat))
+    shift antiShift base
+  simp only [normBFullPost_unfold] at hNB
+  have hNBf := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (2 : Word)) **
+     ((sp + signExtend12 3992) ↦ₘ shift))
+    (by pcFree) hNB
+  have hFull := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hABC2 hNBf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by delta normBPost; xperm_hyp hq)
+    hFull
+
+/-- n=2 preloop entry-to-loopSetup over `divCode_noNop_v4`. -/
+theorem evm_div_n2_to_loopSetup_spec_within_v4_noNop (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0)
+    (hshift_nz : (clzResult b1).1 ≠ 0) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4) base (base + loopBodyOff) (divCode_noNop_v4 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+       ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+       ((sp + signExtend12 4024) ↦ₘ u4Old) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
+      (loopSetupPost sp (2 : Word) (clzResult b1).1 a0 a1 a2 a3 b0 b1 b2 b3) := by
+  let shift := (clzResult b1).1
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+  let b0' := b0 <<< (shift.toNat % 64)
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
+  let u0 := a0 <<< (shift.toNat % 64)
+  have hNB := evm_div_n2_to_normB_spec_within_v4_noNop sp base b0 b1 b2 b3 v5 v6 v7 v10
+    q0 q1 q2 q3 u5 u6 u7 nMem shiftMem hbnz hb3z hb2z hb1nz hshift_nz
+  have hNBf := cpsTripleWithin_frameR
+    ((.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+     ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+     ((sp + signExtend12 4024) ↦ₘ u4Old))
+    (by pcFree) hNB
+  have hNormA := divK_normA_full_spec_within_v4_noNop sp a0 a1 a2 a3
+    b0' (b0 >>> (antiShift.toNat % 64)) b3 shift antiShift
+    u0Old u1Old u2Old u3Old u4Old base
+  rw [divKNormAFullPreNoNop_unfold] at hNormA
+  simp only [normAFullPost_unfold] at hNormA
+  have hNormAf := cpsTripleWithin_frameR
+    ((.x0 ↦ᵣ (0 : Word)) **
+     (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
+     ((sp + 48) ↦ₘ ((b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64)))) **
+     ((sp + 56) ↦ₘ ((b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64)))) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (2 : Word)) **
+     ((sp + signExtend12 3992) ↦ₘ shift))
+    (by pcFree) hNormA
+  have hNA := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by delta normBPost at hp; xperm_hyp hp) hNBf hNormAf
+  have hLS := divK_loopSetup_ntaken_spec_within_v4_noNop sp (2 : Word)
+    (signExtend12 (4 : BitVec 12) - (4 : Word)) u1 base
+    (by decide)
+  simp only [divKLoopSetupNtakenPreNoNop_unfold,
+      divKLoopSetupNtakenPostNoNop_unfold] at hLS
+  have hLSf := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ (a0 >>> (antiShift.toNat % 64))) **
+     (.x6 ↦ᵣ shift) ** (.x7 ↦ᵣ u0) ** (.x2 ↦ᵣ antiShift) **
+     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
+     ((sp + 48) ↦ₘ ((b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64)))) **
+     ((sp + 56) ↦ₘ ((b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64)))) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
+     ((sp + signExtend12 4040) ↦ₘ u2) **
+     ((sp + signExtend12 4032) ↦ₘ (a3 <<< (shift.toNat % 64) ||| a2 >>> (antiShift.toNat % 64))) **
+     ((sp + signExtend12 4024) ↦ₘ (a3 >>> (antiShift.toNat % 64))) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3992) ↦ₘ shift))
+    (by pcFree) hLS
+  have hFull := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hNA hLSf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by delta loopSetupPost; xperm_hyp hq)
+    hFull
+
+/-- Framed exact-x1 wrapper for the n=2 v4/no-NOP preloop. -/
+theorem evm_div_n2_to_loopSetup_spec_within_v4_noNop_exact_x1_scratch_frame
+    (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem : Word)
+    (jMem retMem dMem dloMem scratchUn0 scratchMem raVal : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0)
+    (hshift_nz : (clzResult b1).1 ≠ 0) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4) base (base + loopBodyOff)
+      (divCode_noNop_v4 base)
+      (((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
+        (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+        ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+        ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+        ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+        ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+        ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+        ((sp + signExtend12 4024) ↦ₘ u4Old) **
+        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+        ((sp + signExtend12 3992) ↦ₘ shiftMem)) **
+       ((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal)))
+      (loopSetupPost sp (2 : Word) (clzResult b1).1 a0 a1 a2 a3 b0 b1 b2 b3 **
+       ((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal))) := by
+  have hPre :=
+    evm_div_n2_to_loopSetup_spec_within_v4_noNop sp base a0 a1 a2 a3 b0 b1 b2 b3
+      v5 v6 v7 v10 q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem
+      hbnz hb3z hb2z hb1nz hshift_nz
+  have hFramed := cpsTripleWithin_frameR
+    (((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
+      (sp + signExtend12 3968 ↦ₘ retMem) **
+      (sp + signExtend12 3960 ↦ₘ dMem) **
+      (sp + signExtend12 3952 ↦ₘ dloMem) **
+      (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+      (sp + signExtend12 3936 ↦ₘ scratchMem) **
+      (.x1 ↦ᵣ raVal)))
+    (by pcFree) hPre
+  exact cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    hFramed
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNopPreloop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNopPreloop.lean
@@ -282,4 +282,373 @@ theorem evm_div_n2_to_loopSetup_spec_within_v4_noNop_exact_x1_scratch_frame
     (fun h hq => by xperm_hyp hq)
     hFramed
 
+/-- n=2 v4/no-NOP path from entry through the exact-x1 loop handoff.
+    Mirrors `fullDivN3_preloop_loop_unified_exact_x1_scratch_v4_noNop`.
+    Output: divModStackDispatchPreNoX1 + scratchMem ** (.x1 ↦ᵣ raVal) →
+    loopN2UnifiedPostV4NoX1 ** (.x1 ↦ᵣ raVal) ** frame_atoms over divCode_noNop_v4. -/
+theorem fullDivN2_preloop_loop_unified_exact_x1_scratch_v4_noNop
+    (bltu_2 bltu_1 bltu_0 : Bool) (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem : Word)
+    (jMem retMem dMem dloMem scratchUn0 scratchMem raVal : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0)
+    (hshift_nz : (clzResult b1).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_2 : bltu_2 =
+      BitVec.ult (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+        (fullDivN2NormV b0 b1 b2 b3).2.1)
+    (hbltu_1 : bltu_1 =
+      match bltu_2 with
+      | false =>
+        BitVec.ult (iterN2Max (fullDivN2NormV b0 b1 b2 b3).1
+          (fullDivN2NormV b0 b1 b2 b3).2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.2.2
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+          (0 : Word) (0 : Word)).2.2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.1
+      | true =>
+        BitVec.ult (iterWithDoubleAddback
+          (divKTrialCallV4QHat
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.1)
+          (fullDivN2NormV b0 b1 b2 b3).1
+          (fullDivN2NormV b0 b1 b2 b3).2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.2.2
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+          (0 : Word) (0 : Word)).2.2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.1)
+    (hbltu_0 : bltu_0 =
+      match bltu_2, bltu_1 with
+      | false, false =>
+        BitVec.ult (iterN2Max (fullDivN2NormV b0 b1 b2 b3).1
+          (fullDivN2NormV b0 b1 b2 b3).2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.2.2
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.1
+          (iterN2Max (fullDivN2NormV b0 b1 b2 b3).1
+            (fullDivN2NormV b0 b1 b2 b3).2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.2
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+            (0 : Word) (0 : Word)).2.1
+          (iterN2Max (fullDivN2NormV b0 b1 b2 b3).1
+            (fullDivN2NormV b0 b1 b2 b3).2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.2
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+            (0 : Word) (0 : Word)).2.2.1
+          (iterN2Max (fullDivN2NormV b0 b1 b2 b3).1
+            (fullDivN2NormV b0 b1 b2 b3).2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.2
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+            (0 : Word) (0 : Word)).2.2.2.1
+          (iterN2Max (fullDivN2NormV b0 b1 b2 b3).1
+            (fullDivN2NormV b0 b1 b2 b3).2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.2
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+            (0 : Word) (0 : Word)).2.2.2.2.1).2.2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.1
+      | false, true =>
+        BitVec.ult (iterWithDoubleAddback
+          (divKTrialCallV4QHat
+            (iterN2Max (fullDivN2NormV b0 b1 b2 b3).1
+              (fullDivN2NormV b0 b1 b2 b3).2.1
+              (fullDivN2NormV b0 b1 b2 b3).2.2.1
+              (fullDivN2NormV b0 b1 b2 b3).2.2.2
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+              (0 : Word) (0 : Word)).2.2.1
+            (iterN2Max (fullDivN2NormV b0 b1 b2 b3).1
+              (fullDivN2NormV b0 b1 b2 b3).2.1
+              (fullDivN2NormV b0 b1 b2 b3).2.2.1
+              (fullDivN2NormV b0 b1 b2 b3).2.2.2
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+              (0 : Word) (0 : Word)).2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.1)
+          (fullDivN2NormV b0 b1 b2 b3).1
+          (fullDivN2NormV b0 b1 b2 b3).2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.2.2
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.1
+          (iterN2Max (fullDivN2NormV b0 b1 b2 b3).1
+            (fullDivN2NormV b0 b1 b2 b3).2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.2
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+            (0 : Word) (0 : Word)).2.1
+          (iterN2Max (fullDivN2NormV b0 b1 b2 b3).1
+            (fullDivN2NormV b0 b1 b2 b3).2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.2
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+            (0 : Word) (0 : Word)).2.2.1
+          (iterN2Max (fullDivN2NormV b0 b1 b2 b3).1
+            (fullDivN2NormV b0 b1 b2 b3).2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.2
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+            (0 : Word) (0 : Word)).2.2.2.1
+          (iterN2Max (fullDivN2NormV b0 b1 b2 b3).1
+            (fullDivN2NormV b0 b1 b2 b3).2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.2
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+            (0 : Word) (0 : Word)).2.2.2.2.1).2.2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.1
+      | true, false =>
+        BitVec.ult (iterN2Max (fullDivN2NormV b0 b1 b2 b3).1
+          (fullDivN2NormV b0 b1 b2 b3).2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.2.2
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.1
+          (iterWithDoubleAddback (divKTrialCallV4QHat
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+              (fullDivN2NormV b0 b1 b2 b3).2.1)
+            (fullDivN2NormV b0 b1 b2 b3).1
+            (fullDivN2NormV b0 b1 b2 b3).2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.2
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+            (0 : Word) (0 : Word)).2.1
+          (iterWithDoubleAddback (divKTrialCallV4QHat
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+              (fullDivN2NormV b0 b1 b2 b3).2.1)
+            (fullDivN2NormV b0 b1 b2 b3).1
+            (fullDivN2NormV b0 b1 b2 b3).2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.2
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+            (0 : Word) (0 : Word)).2.2.1
+          (iterWithDoubleAddback (divKTrialCallV4QHat
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+              (fullDivN2NormV b0 b1 b2 b3).2.1)
+            (fullDivN2NormV b0 b1 b2 b3).1
+            (fullDivN2NormV b0 b1 b2 b3).2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.2
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+            (0 : Word) (0 : Word)).2.2.2.1
+          (iterWithDoubleAddback (divKTrialCallV4QHat
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+              (fullDivN2NormV b0 b1 b2 b3).2.1)
+            (fullDivN2NormV b0 b1 b2 b3).1
+            (fullDivN2NormV b0 b1 b2 b3).2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.2
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+            (0 : Word) (0 : Word)).2.2.2.2.1).2.2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.1
+      | true, true =>
+        BitVec.ult (iterWithDoubleAddback
+          (divKTrialCallV4QHat
+            (iterWithDoubleAddback (divKTrialCallV4QHat
+                (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+                (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+                (fullDivN2NormV b0 b1 b2 b3).2.1)
+              (fullDivN2NormV b0 b1 b2 b3).1
+              (fullDivN2NormV b0 b1 b2 b3).2.1
+              (fullDivN2NormV b0 b1 b2 b3).2.2.1
+              (fullDivN2NormV b0 b1 b2 b3).2.2.2
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+              (0 : Word) (0 : Word)).2.2.1
+            (iterWithDoubleAddback (divKTrialCallV4QHat
+                (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+                (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+                (fullDivN2NormV b0 b1 b2 b3).2.1)
+              (fullDivN2NormV b0 b1 b2 b3).1
+              (fullDivN2NormV b0 b1 b2 b3).2.1
+              (fullDivN2NormV b0 b1 b2 b3).2.2.1
+              (fullDivN2NormV b0 b1 b2 b3).2.2.2
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+              (0 : Word) (0 : Word)).2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.1)
+          (fullDivN2NormV b0 b1 b2 b3).1
+          (fullDivN2NormV b0 b1 b2 b3).2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.2.2
+          (fullDivN2NormU a0 a1 a2 a3 b1).2.1
+          (iterWithDoubleAddback (divKTrialCallV4QHat
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+              (fullDivN2NormV b0 b1 b2 b3).2.1)
+            (fullDivN2NormV b0 b1 b2 b3).1
+            (fullDivN2NormV b0 b1 b2 b3).2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.2
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+            (0 : Word) (0 : Word)).2.1
+          (iterWithDoubleAddback (divKTrialCallV4QHat
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+              (fullDivN2NormV b0 b1 b2 b3).2.1)
+            (fullDivN2NormV b0 b1 b2 b3).1
+            (fullDivN2NormV b0 b1 b2 b3).2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.2
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+            (0 : Word) (0 : Word)).2.2.1
+          (iterWithDoubleAddback (divKTrialCallV4QHat
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+              (fullDivN2NormV b0 b1 b2 b3).2.1)
+            (fullDivN2NormV b0 b1 b2 b3).1
+            (fullDivN2NormV b0 b1 b2 b3).2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.2
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+            (0 : Word) (0 : Word)).2.2.2.1
+          (iterWithDoubleAddback (divKTrialCallV4QHat
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+              (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+              (fullDivN2NormV b0 b1 b2 b3).2.1)
+            (fullDivN2NormV b0 b1 b2 b3).1
+            (fullDivN2NormV b0 b1 b2 b3).2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.1
+            (fullDivN2NormV b0 b1 b2 b3).2.2.2
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+            (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+            (0 : Word) (0 : Word)).2.2.2.2.1).2.2.1
+          (fullDivN2NormV b0 b1 b2 b3).2.1)
+    (hcarry2 : Carry2NzAll
+      (fullDivN2NormV b0 b1 b2 b3).1
+      (fullDivN2NormV b0 b1 b2 b3).2.1
+      (fullDivN2NormV b0 b1 b2 b3).2.2.1
+      (fullDivN2NormV b0 b1 b2 b3).2.2.2) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 672) base (base + denormOff)
+      (divCode_noNop_v4 base)
+      (((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
+        (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+        ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+        ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+        ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+        ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+        ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+        ((sp + signExtend12 4024) ↦ₘ u4Old) **
+        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+        ((sp + signExtend12 3992) ↦ₘ shiftMem)) **
+       ((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal)))
+      ((loopN2UnifiedPostV4NoX1 bltu_2 bltu_1 bltu_0 sp base
+        (fullDivN2NormV b0 b1 b2 b3).1
+        (fullDivN2NormV b0 b1 b2 b3).2.1
+        (fullDivN2NormV b0 b1 b2 b3).2.2.1
+        (fullDivN2NormV b0 b1 b2 b3).2.2.2
+        (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+        (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+        (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+        (0 : Word) (0 : Word)
+        (fullDivN2NormU a0 a1 a2 a3 b1).2.1
+        (fullDivN2NormU a0 a1 a2 a3 b1).1
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal)) **
+       (((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+        ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 3992) ↦ₘ (clzResult b1).1))) := by
+  have hPre := evm_div_n2_to_loopSetup_spec_within_v4_noNop_exact_x1_scratch_frame
+    sp base a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem
+    jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+    hbnz hb3z hb2z hb1nz hshift_nz
+  have hLoop := evm_div_n2_loop_unified_inst_noNop_exact_x1_v4
+    bltu_2 bltu_1 bltu_0 sp base
+    (fullDivN2Shift b1) (fullDivN2AntiShift b1)
+    (fullDivN2NormV b0 b1 b2 b3).1
+    (fullDivN2NormV b0 b1 b2 b3).2.1
+    (fullDivN2NormV b0 b1 b2 b3).2.2.1
+    (fullDivN2NormV b0 b1 b2 b3).2.2.2
+    (fullDivN2NormU a0 a1 a2 a3 b1).1
+    (fullDivN2NormU a0 a1 a2 a3 b1).2.1
+    (fullDivN2NormU a0 a1 a2 a3 b1).2.2.1
+    (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+    (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.2
+    (a0 >>> ((fullDivN2AntiShift b1).toNat % 64)) v11Old jMem
+    retMem dMem dloMem scratchUn0 scratchMem raVal
+    halign hbltu_2 (by cases bltu_2 <;> simpa using hbltu_1)
+    (by cases bltu_2 <;> cases bltu_1 <;> simpa using hbltu_0) hcarry2
+  have hLoopf := cpsTripleWithin_frameR
+    ((((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+      ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+      ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+      ((sp + signExtend12 3992) ↦ₘ (clzResult b1).1)))
+    (by pcFree) hLoop
+  have hBridge := loopSetupPost_to_loopN2PreWithScratchV4NoX1_framed
+    sp a0 a1 a2 a3 b0 b1 b2 b3 v11Old
+    jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+  have hPre' := cpsTripleWithin_weaken
+    (fun h hp => hp)
+    hBridge
+    hPre
+  have hFull := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hPre' hLoopf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => hp)
+    (fun h hq => hq)
+    hFull
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/PhaseABV4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/PhaseABV4NoNop.lean
@@ -37,6 +37,9 @@ private theorem phB_t_20_v4 {base : Word} :
 private theorem divK_phaseB_n1_nm1_x8_v4 :
     ((1 : Word) + signExtend12 (4095 : BitVec 12)) <<< (3 : BitVec 6).toNat = (0 : Word) := by
   decide
+private theorem divK_phaseB_n2_nm1_x8_v4 :
+    ((2 : Word) + signExtend12 (4095 : BitVec 12)) <<< (3 : BitVec 6).toNat = (8 : Word) := by
+  decide
 private theorem divK_phaseB_n3_nm1_x8_v4 :
     ((3 : Word) + signExtend12 (4095 : BitVec 12)) <<< (3 : BitVec 6).toNat = (16 : Word) := by
   decide
@@ -45,6 +48,9 @@ private theorem divK_phaseB_n4_nm1_x8_v4 :
   decide
 private theorem phB_sp0_32_v4 {sp : Word} :
     (sp + (0 : Word) + (32 : Word)) = sp + 32 := by
+  bv_addr
+private theorem phB_sp8_32_v4 {sp : Word} :
+    (sp + (8 : Word) + (32 : Word)) = sp + 40 := by
   bv_addr
 private theorem phB_sp16_32_v4 {sp : Word} :
     (sp + (16 : Word) + (32 : Word)) = sp + 48 := by
@@ -687,5 +693,168 @@ theorem evm_div_phaseAB_n1_spec_within_v4_noNop (sp base : Word)
     (fun h hp => by xperm_chunked hp)
     (fun h hq => by xperm_chunked hq)
     hAB
+
+/-- PhaseB for n=2 (b3=0, b2=0, b1≠0) over `divCode_noNop_v4`.
+    The third BNE (x6≠0) is taken, leaving x5=2. -/
+theorem evm_div_phaseB_n2_spec_within_v4_noNop (sp base : Word)
+    (b1 b2 b3 : Word) (v5 v6 v7 : Word)
+    (q0 q1 q2 q3 u5 u6 u7 nMem : Word)
+    (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0) :
+    cpsTripleWithin 21 (base + phaseBOff) (base + clzOff) (divCode_noNop_v4 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+       ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) **
+       ((sp + signExtend12 3984) ↦ₘ nMem))
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b1) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
+       ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 3984) ↦ₘ (2 : Word))) := by
+  have hinit1_raw := divK_phaseB_init1_spec_within sp (base + phaseBOff) q0 q1 q2 q3 u5 u6 u7
+  simp only [phB_off_28] at hinit1_raw
+  have hinit1 := cpsTripleWithin_extend_code divK_phaseB_init1_code_sub_divCode_noNop_v4 hinit1_raw
+  have hinit1f := cpsTripleWithin_frameR
+    ((.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+     ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 3984) ↦ₘ nMem))
+    (by pcFree) hinit1
+  have hinit2_raw := divK_phaseB_init2_spec_within sp (base + phaseBInit2Off) b1 b2 v6 v7
+  simp only [phB_i2_8_v4] at hinit2_raw
+  have hinit2 := cpsTripleWithin_extend_code divK_phaseB_init2_code_sub_divCode_noNop_v4 hinit2_raw
+  have hinit2f := cpsTripleWithin_frameR
+    ((.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
+     ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3984) ↦ₘ nMem))
+    (by pcFree) hinit2
+  have h12 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hinit1f hinit2f
+  have haddi0_raw := addi_x0_spec_gen_within .x5 v5 4 (base + phaseBStep0Off) (by nofun)
+  simp only [phB_addi_4_v4, signExtend12_4] at haddi0_raw
+  have haddi0 := cpsTripleWithin_extend_code addi_x5_singleton_sub_divCode_noNop_v4 haddi0_raw
+  have haddi0f := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ b3) ** (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
+     ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3984) ↦ₘ nMem))
+    (by pcFree) haddi0
+  have h123 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) h12 haddi0f
+  have hbne0_raw := bne_spec_gen_within .x10 .x0 24 b3 (0 : Word) (base + phaseBBneOff)
+  rw [show (base + phaseBBneOff : Word) + signExtend13 24 = base + phaseBTailOff from by
+        rv64_addr, phB_bne_4_v4] at hbne0_raw
+  have hbne0_clean := cpsBranchWithin_ntakenStripPure2 hbne0_raw
+    (fun hp hQt => by
+      obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
+      exact absurd hb3z ((sepConj_pure_right _).mp h_rest).2)
+  have hbne0 := cpsTripleWithin_extend_code bne_x10_singleton_sub_divCode_noNop_v4 hbne0_clean
+  have hbne0f := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (4 : Word)) ** (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
+     ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3984) ↦ₘ nMem))
+    (by pcFree) hbne0
+  have h1234 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) h123 hbne0f
+  have haddi1_raw := addi_x0_spec_gen_within .x5 (4 : Word) 3 (base + phaseBStep1Off) (by nofun)
+  simp only [phB_step1_4_v4, signExtend12_3] at haddi1_raw
+  have haddi1 := cpsTripleWithin_extend_code addi_x5_3_sub_divCode_noNop_v4 haddi1_raw
+  have haddi1f := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ b3) ** (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
+     ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3984) ↦ₘ nMem))
+    (by pcFree) haddi1
+  have h12345 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) h1234 haddi1f
+  have hbne1_raw := bne_spec_gen_within .x7 .x0 16 b2 (0 : Word) (base + phaseBBne2Off)
+  rw [show (base + phaseBBne2Off : Word) + signExtend13 16 = base + phaseBTailOff from by
+        rv64_addr, phB_step1_8_v4] at hbne1_raw
+  have hbne1_clean := cpsBranchWithin_ntakenStripPure2 hbne1_raw
+    (fun hp hQt => by
+      obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
+      exact absurd hb2z ((sepConj_pure_right _).mp h_rest).2)
+  have hbne1 := cpsTripleWithin_extend_code bne_x7_16_sub_divCode_noNop_v4 hbne1_clean
+  have hbne1f := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (3 : Word)) ** (.x10 ↦ᵣ b3) ** (.x6 ↦ᵣ b1) **
+     ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3984) ↦ₘ nMem))
+    (by pcFree) hbne1
+  have h123456 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) h12345 hbne1f
+  have haddi2_raw := addi_x0_spec_gen_within .x5 (3 : Word) 2 (base + phaseBStep2Off) (by nofun)
+  simp only [phB_step2_4_v4, signExtend12_2] at haddi2_raw
+  have haddi2 := cpsTripleWithin_extend_code addi_x5_2_sub_divCode_noNop_v4 haddi2_raw
+  have haddi2f := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ b3) ** (.x7 ↦ᵣ b2) ** (.x6 ↦ᵣ b1) **
+     ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3984) ↦ₘ nMem))
+    (by pcFree) haddi2
+  have h1234567 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_chunked hp) h123456 haddi2f
+  have hbne2_raw := bne_spec_gen_within .x6 .x0 8 b1 (0 : Word) (base + phaseBBne3Off)
+  rw [show (base + phaseBBne3Off : Word) + signExtend13 8 = base + phaseBTailOff from by
+        rv64_addr, phB_step2_8_v4] at hbne2_raw
+  have hbne2_clean := cpsBranchWithin_takenStripPure2 hbne2_raw
+    (fun hp hQf => by
+      obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
+      exact absurd ((sepConj_pure_right _).mp h_rest).2 hb1nz)
+  have hbne2 := cpsTripleWithin_extend_code bne_x6_8_sub_divCode_noNop_v4 hbne2_clean
+  have hbne2f := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (2 : Word)) ** (.x10 ↦ᵣ b3) ** (.x7 ↦ᵣ b2) **
+     ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3984) ↦ₘ nMem))
+    (by pcFree) hbne2
+  have h12345678 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_chunked hp) h1234567 hbne2f
+  have htail_raw := divK_phaseB_tail_spec_within sp (2 : Word) b1 nMem (base + phaseBTailOff)
+  simp only [divK_phaseB_tail_pre_unfold, divK_phaseB_tail_post_unfold,
+             phB_t_20_v4, divK_phaseB_n2_nm1_x8_v4, signExtend12_32, phB_sp8_32_v4] at htail_raw
+  have htail := cpsTripleWithin_extend_code divK_phaseB_tail_code_sub_divCode_noNop_v4 htail_raw
+  have htailf := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) ** (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
+     ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)))
+    (by pcFree) htail
+  have hphaseB := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) h12345678 htailf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    hphaseB
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Adds `FullPathN2V4Families.lean` with the N2 V4 iteration family, mirroring `FullPathN3V4.lean` (lines 141-275) for n=2
- Defines `iterN2V4`, `fullDivN2R{0,1,2}V4`, `fullDivN2C3V4`, `fullDivN2DenormPreV4/PostV4`, `fullDivN2ScratchMemV4/NoX1V4`, `fullDivN2FrameNoX1V4`, `fullDivN2UnifiedPostNoX1V4`, `fullDivN2QuotientWordV4`
- Proves `evm_div_n2_denorm_epilogue_bundled_spec_noNop_v4Final` (V4 denorm over `divCode_noNop_v4`) and the exact-x1 frame variant

**Why needed:** `loopN2UnifiedPostV4NoX1` uses `div128Quot_v4` while `fullDivN2DenormPre` expects `div128Quot` (V1). The V4 family bridges this gap, exactly as N3 has `fullDivN3R0V4/R1V4/DenormPreV4`.

Stacked on PR #5939. Prerequisite for bead evm-asm-9iqmw.2.1.1.11 (loop-to-denorm bridge).

Refs #6059. Bead: evm-asm-9iqmw.2.1.1.12.

## Verification
- `lake build EvmAsm.Evm64.DivMod.Compose.FullPathN2V4Families` — 1106 jobs, 1.2s
- `scripts/check-file-size.sh` — 803 files checked, all within cap
- `rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth'` — no matches

Authored by @pirapira; implemented by Claude Code