### PR TITLE
fix(smod): change h_stack from sharedDivModCodeNoNop_v4 to modCode_noNop_v4

### DIFF
--- a/EvmAsm/Evm64/DivMod/CallableV4Mod.lean
+++ b/EvmAsm/Evm64/DivMod/CallableV4Mod.lean
@@ -275,6 +275,39 @@ theorem evm_mod_callable_v4_spec_from_noNop_preserving_x1_noX9
       (modStackDispatchPostCallable_pcFree sp a b) hRet
   exact cpsTripleWithin_seq_same_cr hStackCall hRetFramed
 
+/-- Like `evm_mod_callable_v4_spec_from_noNop_preserving_x1_noX9` but the
+    body proof is over `modCode_noNop_v4` (includes the MOD epilogue).
+    Used when the caller has only `modCode_noNop_v4` available (e.g., SMOD). -/
+theorem evm_mod_callable_v4_spec_from_modCode_noNop_noX9
+    (sp base raVal : Word)
+    (a b : EvmWord) (v2 v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (hStack :
+      cpsTripleWithin unifiedDivBound base (base + nopOff) (modCode_noNop_v4 base)
+        (divModStackDispatchPreCallable sp a b
+          raVal v2 v5 v6 v7 v10 v11
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+        (modStackDispatchPostCallable sp a b ** (.x1 ↦ᵣ raVal))) :
+    cpsTripleWithin (unifiedDivBound + 1) base (raVal &&& ~~~1)
+      (evm_mod_callable_code_v4 base)
+      (divModStackDispatchPreCallable sp a b
+        raVal v2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+      (modStackDispatchPostCallable sp a b ** (.x1 ↦ᵣ raVal)) := by
+  have hStackCall :=
+    cpsTripleWithin_extend_code
+      (hmono := modCode_noNop_v4_sub_mod_callable_code_v4) hStack
+  have hRet :=
+    cpsTripleWithin_extend_code (hmono := evm_mod_callable_code_v4_ret_sub (base := base))
+      (ret_spec_within' (base + nopOff) raVal)
+  have hRetFramed :=
+    cpsTripleWithin_frameL (modStackDispatchPostCallable sp a b)
+      (modStackDispatchPostCallable_pcFree sp a b) hRet
+  exact cpsTripleWithin_seq_same_cr hStackCall hRetFramed
+
 /-- v4 zero-divisor MOD callable wrapper with exact `x1` and no `x9` frame. -/
 theorem evm_mod_callable_bzero_v4_preserving_x1_noX9_spec (sp base raVal : Word)
     (a b : EvmWord) (v2 v5 v6 v7 v10 v11 : Word)

--- a/EvmAsm/Evm64/SMod/Compose/ModCallCallable.lean
+++ b/EvmAsm/Evm64/SMod/Compose/ModCallCallable.lean
@@ -40,6 +40,14 @@ theorem evm_mod_callable_code_v4_sub_smodCodeV4 {base : Word} :
     (by
       simpa [modCallableCodeV4] using hOfProg)
 
+/-- The v4 MOD no-NOP body code is a sub-region of `smodCodeV4`. -/
+theorem modCode_noNop_v4_sub_smodCodeV4 {base : Word} :
+    ∀ a i,
+      (EvmAsm.Evm64.modCode_noNop_v4 (base + wrapperEndOff)) a = some i →
+      (smodCodeV4 base) a = some i := fun a i h =>
+  evm_mod_callable_code_v4_sub_smodCodeV4
+    a i (EvmAsm.Evm64.modCode_noNop_v4_sub_mod_callable_code_v4 a i h)
+
 /-- The appended v4 unsigned MOD callable is a sub-region of the canonical
     production SMOD code handle. -/
 theorem evm_mod_callable_code_v4_sub_smodCodeCanonical {base : Word} :

--- a/EvmAsm/Evm64/SMod/Compose/ModCallGenericHandoff.lean
+++ b/EvmAsm/Evm64/SMod/Compose/ModCallGenericHandoff.lean
@@ -23,7 +23,7 @@ theorem saveRaAbsThenModCallDispatchReadyPost_callable_from_noNop_spec_in_smodCo
     (h_stack :
       cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
         (base + wrapperEndOff) ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
-        (EvmAsm.Evm64.sharedDivModCodeNoNop_v4 (base + wrapperEndOff))
+        (EvmAsm.Evm64.modCode_noNop_v4 (base + wrapperEndOff))
         (EvmAsm.Evm64.divModStackDispatchPreCallable sp
           (smodAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
           (smodAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
@@ -64,7 +64,7 @@ theorem saveRaAbsThenModCallDispatchReadyPost_callable_from_noNop_spec_in_smodCo
   have h_stack' :
       cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
         (base + wrapperEndOff) ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
-        (EvmAsm.Evm64.sharedDivModCodeNoNop_v4 (base + wrapperEndOff))
+        (EvmAsm.Evm64.modCode_noNop_v4 (base + wrapperEndOff))
         (EvmAsm.Evm64.divModStackDispatchPreCallable sp dividendAbsWord divisorAbsWord
           retAddr v2 v5 v6 divisorSum3 divisorMask divisorCarry3
           q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
@@ -84,7 +84,7 @@ theorem saveRaAbsThenModCallDispatchReadyPost_callable_from_noNop_spec_in_smodCo
         (EvmAsm.Evm64.modStackDispatchPostCallable sp dividendAbsWord divisorAbsWord **
           (.x1 ↦ᵣ retAddr)) := by
     exact
-      EvmAsm.Evm64.evm_mod_callable_v4_spec_from_noNop_preserving_x1_noX9
+      EvmAsm.Evm64.evm_mod_callable_v4_spec_from_modCode_noNop_noX9
         sp (base + wrapperEndOff) retAddr dividendAbsWord divisorAbsWord
         v2 v5 v6 divisorSum3 divisorMask divisorCarry3
         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7

--- a/EvmAsm/Evm64/SMod/Compose/ModCallResultSignFixGeneric.lean
+++ b/EvmAsm/Evm64/SMod/Compose/ModCallResultSignFixGeneric.lean
@@ -21,7 +21,7 @@ theorem saveRaAbsThenModCall_then_resultSignFix_from_noNop_spec_in_smodCodeV4
     (h_stack :
       EvmAsm.Rv64.cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
         (base + wrapperEndOff) ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
-        (EvmAsm.Evm64.sharedDivModCodeNoNop_v4 (base + wrapperEndOff))
+        (EvmAsm.Evm64.modCode_noNop_v4 (base + wrapperEndOff))
         (EvmAsm.Evm64.divModStackDispatchPreCallable sp
           (smodAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
           (smodAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)

--- a/EvmAsm/Evm64/SMod/Compose/ModCallResultSignFixNamedPost.lean
+++ b/EvmAsm/Evm64/SMod/Compose/ModCallResultSignFixNamedPost.lean
@@ -86,7 +86,7 @@ theorem saveRaAbsThenModCall_then_resultSignFix_named_post_from_noNop_spec_in_sm
     (h_stack :
       EvmAsm.Rv64.cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
         (base + wrapperEndOff) ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
-        (EvmAsm.Evm64.sharedDivModCodeNoNop_v4 (base + wrapperEndOff))
+        (EvmAsm.Evm64.modCode_noNop_v4 (base + wrapperEndOff))
         (EvmAsm.Evm64.divModStackDispatchPreCallable sp
           (smodAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
           (smodAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)

--- a/EvmAsm/Evm64/SMod/Compose/ModCallReturnGeneric.lean
+++ b/EvmAsm/Evm64/SMod/Compose/ModCallReturnGeneric.lean
@@ -24,7 +24,7 @@ theorem saveRaAbsThenModCall_then_return_from_noNop_spec_in_smodCodeV4
     (h_stack :
       EvmAsm.Rv64.cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
         (base + wrapperEndOff) ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
-        (EvmAsm.Evm64.sharedDivModCodeNoNop_v4 (base + wrapperEndOff))
+        (EvmAsm.Evm64.modCode_noNop_v4 (base + wrapperEndOff))
         (EvmAsm.Evm64.divModStackDispatchPreCallable sp
           (smodAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
           (smodAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)

--- a/EvmAsm/Evm64/SMod/Compose/ModCallReturnNamedPost.lean
+++ b/EvmAsm/Evm64/SMod/Compose/ModCallReturnNamedPost.lean
@@ -86,7 +86,7 @@ theorem saveRaAbsThenModCall_then_return_named_post_from_noNop_spec_in_smodCodeV
     (h_stack :
       EvmAsm.Rv64.cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
         (base + wrapperEndOff) ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
-        (EvmAsm.Evm64.sharedDivModCodeNoNop_v4 (base + wrapperEndOff))
+        (EvmAsm.Evm64.modCode_noNop_v4 (base + wrapperEndOff))
         (EvmAsm.Evm64.divModStackDispatchPreCallable sp
           (smodAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
           (smodAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)

--- a/EvmAsm/Evm64/SMod/Compose/ModCallReturnNormalized.lean
+++ b/EvmAsm/Evm64/SMod/Compose/ModCallReturnNormalized.lean
@@ -20,7 +20,7 @@ theorem saveRaAbsThenModCall_then_return_named_post_normalized_from_noNop_spec_i
     (h_stack :
       EvmAsm.Rv64.cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
         (base + wrapperEndOff) ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
-        (EvmAsm.Evm64.sharedDivModCodeNoNop_v4 (base + wrapperEndOff))
+        (EvmAsm.Evm64.modCode_noNop_v4 (base + wrapperEndOff))
         (EvmAsm.Evm64.divModStackDispatchPreCallable sp
           (smodAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
           (smodAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)

--- a/EvmAsm/Evm64/SMod/Spec.lean
+++ b/EvmAsm/Evm64/SMod/Spec.lean
@@ -134,7 +134,7 @@ theorem evm_smod_mod_call_return_stack_spec_within
     (h_stack :
       EvmAsm.Rv64.cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
         (base + wrapperEndOff) ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
-        (EvmAsm.Evm64.sharedDivModCodeNoNop_v4 (base + wrapperEndOff))
+        (EvmAsm.Evm64.modCode_noNop_v4 (base + wrapperEndOff))
         (EvmAsm.Evm64.divModStackDispatchPreCallable sp
           (smodAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
             (dividend.getLimbN 2) (dividend.getLimbN 3))
@@ -201,7 +201,7 @@ theorem evm_smod_canonical_mod_call_return_stack_spec_within
     (h_stack :
       EvmAsm.Rv64.cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
         (base + wrapperEndOff) ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
-        (EvmAsm.Evm64.sharedDivModCodeNoNop_v4 (base + wrapperEndOff))
+        (EvmAsm.Evm64.modCode_noNop_v4 (base + wrapperEndOff))
         (EvmAsm.Evm64.divModStackDispatchPreCallable sp
           (smodAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
             (dividend.getLimbN 2) (dividend.getLimbN 3))

--- a/EvmAsm/Evm64/SMod/SpecBzero.lean
+++ b/EvmAsm/Evm64/SMod/SpecBzero.lean
@@ -47,21 +47,23 @@ theorem evm_smod_canonical_bzero_mod_call_return_stack_spec_within
     dividendMaskOld dividendValueOld dividendCarryOld dividend divisor
     v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
     shiftMem nMem jMem retMem dMem dloMem scratchUn0 base h_base ?_
-  exact evm_mod_bzero_stack_spec_within_dispatch_noNop_v4_callable_x1_uni
-    sp (base + wrapperEndOff)
-    (smodAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
-      (dividend.getLimbN 2) (dividend.getLimbN 3))
-    (smodAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
-      (divisor.getLimbN 2) (divisor.getLimbN 3))
-    ((base + modCallOff) + 4)
-    v2 v5 v6
-    (smodAbsSum3 (divisor.getLimbN 0) (divisor.getLimbN 1)
-      (divisor.getLimbN 2) (divisor.getLimbN 3))
-    (smodAbsMask (divisor.getLimbN 3))
-    (smodAbsCarry3 (divisor.getLimbN 0) (divisor.getLimbN 1)
-      (divisor.getLimbN 2) (divisor.getLimbN 3))
-    q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-    nMem shiftMem jMem retMem dMem dloMem scratchUn0
-    ((smodAbsDivisorWord_eq_zero_iff divisor).mpr h_divisor_zero)
+  exact cpsTripleWithin_extend_code
+    (hmono := EvmAsm.Evm64.sharedDivModCodeNoNop_v4_sub_modCode_noNop_v4)
+    (evm_mod_bzero_stack_spec_within_dispatch_noNop_v4_callable_x1_uni
+      sp (base + wrapperEndOff)
+      (smodAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
+        (dividend.getLimbN 2) (dividend.getLimbN 3))
+      (smodAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
+        (divisor.getLimbN 2) (divisor.getLimbN 3))
+      ((base + modCallOff) + 4)
+      v2 v5 v6
+      (smodAbsSum3 (divisor.getLimbN 0) (divisor.getLimbN 1)
+        (divisor.getLimbN 2) (divisor.getLimbN 3))
+      (smodAbsMask (divisor.getLimbN 3))
+      (smodAbsCarry3 (divisor.getLimbN 0) (divisor.getLimbN 1)
+        (divisor.getLimbN 2) (divisor.getLimbN 3))
+      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      nMem shiftMem jMem retMem dMem dloMem scratchUn0
+      ((smodAbsDivisorWord_eq_zero_iff divisor).mpr h_divisor_zero))
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- The MOD nonzero path executes `divK_mod_epilogue` (at `epilogueOff=1008`) before reaching `nopOff=1068`. The epilogue is in `modCode_noNop_v4` but NOT in `sharedDivModCodeNoNop_v4`, so `h_stack` over the shared code surface is formally false for nonzero inputs.
- Add `evm_mod_callable_v4_spec_from_modCode_noNop_noX9` (parallel to `_from_noNop_preserving_x1_noX9` but using `modCode_noNop_v4`)
- Add `modCode_noNop_v4_sub_smodCodeV4` monotonicity lemma
- Update all SMOD `h_stack` signatures to use `modCode_noNop_v4`
- Extend bzero spec from shared to modCode in `SpecBzero` (valid since `sharedDivModCodeNoNop_v4 ⊆ modCode_noNop_v4`)

Refs #90. Bead: evm-asm-9iqmw.9.1.1.

## Verification
- lake build EvmAsm.Evm64.DivMod.CallableV4Mod
- lake build EvmAsm.Evm64.SMod
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" (no hits in changed files)
- lake build (2221 jobs, all pass)

Authored by @pirapira; implemented by Claude Code