### PR TITLE
feat(stateless): block_validate_logs_bloom (PR-K159)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -10722,6 +10722,153 @@ def ziskBlockLogsBloomFromReceiptsListProbeUnit : BuildUnit := {
   dataAsm     := ziskBlockLogsBloomFromReceiptsListDataSection
 }
 
+/-! ## block_validate_logs_bloom -- PR-K159
+
+    End-to-end block-level `logs_bloom` validation: given the
+    header RLP and the RLP list of receipts, recompute the
+    block's bloom from receipts and check it byte-equals the
+    header's claimed bloom.
+
+      header_bloom = header_extract_logs_bloom(header_rlp)
+      computed_bloom = block_logs_bloom_from_receipts_list(receipts)
+      is_valid = bloom_eq(header_bloom, computed_bloom)
+
+    Single-call entry point for callers that want the verdict
+    without managing the scratch buffers themselves. The verdict
+    is returned via an out pointer (1 if valid, 0 if not).
+
+    Composes:
+      - PR-K153 `header_extract_logs_bloom`        -- read header
+      - PR-K158 `block_logs_bloom_from_receipts_list` -- recompute
+      - PR-K154 `bloom_eq`                          -- compare
+
+    Calling convention:
+      a0 (input)  : header_rlp ptr
+      a1 (input)  : header_rlp byte length
+      a2 (input)  : receipts_rlp_list ptr
+      a3 (input)  : receipts_rlp_list byte length
+      a4 (input)  : u64 out ptr (is_valid: 1 if matches, 0 if not)
+      ra (input)  : return
+      a0 (output) :
+        0 : helpers succeeded -- predicate written
+        1 : header parse failure / bloom field width != 256
+        2 : receipts-list parse failure or receipt size failure
+            (child status from PR-K158 propagated unchanged) -/
+def blockValidateLogsBloomFunction : String :=
+  "block_validate_logs_bloom:\n" ++
+  "  addi sp, sp, -48\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp)\n" ++
+  "  mv s0, a0                   # header_rlp ptr\n" ++
+  "  mv s1, a1                   # header_rlp len\n" ++
+  "  mv s2, a2                   # receipts list ptr\n" ++
+  "  mv s3, a3                   # receipts list len\n" ++
+  "  mv s4, a4                   # is_valid out\n" ++
+  "  # ---- Extract header.logs_bloom into bvlb_header_bloom ----\n" ++
+  "  mv a0, s0; mv a1, s1\n" ++
+  "  la a2, bvlb_header_bloom\n" ++
+  "  jal ra, header_extract_logs_bloom\n" ++
+  "  bnez a0, .Lbvlb_header_fail\n" ++
+  "  # ---- Zero bvlb_computed_bloom (256 B) ----\n" ++
+  "  la t0, bvlb_computed_bloom\n" ++
+  "  li t1, 32\n" ++
+  ".Lbvlb_zero:\n" ++
+  "  beqz t1, .Lbvlb_zero_done\n" ++
+  "  sd zero, 0(t0)\n" ++
+  "  addi t0, t0, 8\n" ++
+  "  addi t1, t1, -1\n" ++
+  "  j .Lbvlb_zero\n" ++
+  ".Lbvlb_zero_done:\n" ++
+  "  # ---- Compute block bloom from receipts list ----\n" ++
+  "  mv a0, s2; mv a1, s3\n" ++
+  "  la a2, bvlb_computed_bloom\n" ++
+  "  jal ra, block_logs_bloom_from_receipts_list\n" ++
+  "  bnez a0, .Lbvlb_receipts_fail\n" ++
+  "  # ---- Compare the two blooms ----\n" ++
+  "  la a0, bvlb_header_bloom\n" ++
+  "  la a1, bvlb_computed_bloom\n" ++
+  "  mv a2, s4\n" ++
+  "  jal ra, bloom_eq\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lbvlb_ret\n" ++
+  ".Lbvlb_header_fail:\n" ++
+  "  sd zero, 0(s4)\n" ++
+  "  li a0, 1\n" ++
+  "  j .Lbvlb_ret\n" ++
+  ".Lbvlb_receipts_fail:\n" ++
+  "  sd zero, 0(s4)\n" ++
+  "  li a0, 2\n" ++
+  ".Lbvlb_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp)\n" ++
+  "  addi sp, sp, 48\n" ++
+  "  ret"
+
+/-- `zisk_block_validate_logs_bloom`: probe BuildUnit.
+    Input layout:
+      bytes  0.. 8 : header_rlp_len
+      bytes  8..16 : receipts_list_rlp_len
+      bytes 16..   : header_rlp || receipts_list_rlp
+        (the script appends them with no padding between; the
+         prologue computes the second pointer from the first
+         length).
+    Output layout:
+      bytes  0.. 8 : status (0=ok, 1=header fail, 2=receipts fail)
+      bytes  8..16 : is_valid (1 if bloom matches, 0 otherwise) -/
+def ziskBlockValidateLogsBloomPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a5, 0x40000000\n" ++
+  "  ld a1, 8(a5)                # header_rlp_len\n" ++
+  "  ld a3, 16(a5)               # receipts_list_rlp_len\n" ++
+  "  addi a0, a5, 24             # header_rlp ptr\n" ++
+  "  add a2, a0, a1              # receipts_list_rlp ptr\n" ++
+  "  li a4, 0xa0010008           # is_valid out\n" ++
+  "  jal ra, block_validate_logs_bloom\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lbvlb_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpListCountItemsFunction ++ "\n" ++
+  headerExtractLogsBloomFunction ++ "\n" ++
+  receiptExtractLogsBloomFunction ++ "\n" ++
+  bloomOrIntoFunction ++ "\n" ++
+  bloomEqFunction ++ "\n" ++
+  blockLogsBloomFromReceiptsListFunction ++ "\n" ++
+  blockValidateLogsBloomFunction ++ "\n" ++
+  ".Lbvlb_pdone:"
+
+def ziskBlockValidateLogsBloomDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "helb_offset:\n" ++
+  "  .zero 8\n" ++
+  "helb_length:\n" ++
+  "  .zero 8\n" ++
+  "relb_offset:\n" ++
+  "  .zero 8\n" ++
+  "relb_length:\n" ++
+  "  .zero 8\n" ++
+  "blbr_count:\n" ++
+  "  .zero 8\n" ++
+  "blbr_offset:\n" ++
+  "  .zero 8\n" ++
+  "blbr_length:\n" ++
+  "  .zero 8\n" ++
+  "blbr_scratch_bloom:\n" ++
+  "  .zero 256\n" ++
+  "bvlb_header_bloom:\n" ++
+  "  .zero 256\n" ++
+  "bvlb_computed_bloom:\n" ++
+  "  .zero 256"
+
+def ziskBlockValidateLogsBloomProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskBlockValidateLogsBloomPrologue
+  dataAsm     := ziskBlockValidateLogsBloomDataSection
+}
+
 /-! ## calldata_byte_counts -- PR-K105
 
     Count zero and non-zero bytes in an arbitrary byte buffer.
@@ -11497,6 +11644,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_receipt_encode" => some ziskReceiptEncodeProbeUnit
   | "zisk_single_leaf_trie_root" => some ziskSingleLeafTrieRootProbeUnit
   | "zisk_block_logs_bloom_from_receipts_list" => some ziskBlockLogsBloomFromReceiptsListProbeUnit
+  | "zisk_block_validate_logs_bloom" => some ziskBlockValidateLogsBloomProbeUnit
   | "zisk_calldata_byte_counts" => some ziskCalldataByteCountsProbeUnit
   | "zisk_intrinsic_gas_calldata_floor_eip7623" => some ziskIntrinsicGasCalldataFloorEip7623ProbeUnit
   | "zisk_init_code_cost"       => some ziskInitCodeCostProbeUnit
@@ -11669,6 +11817,7 @@ def knownProgramNames : List String :=
    "zisk_receipt_encode",
    "zisk_single_leaf_trie_root",
    "zisk_block_logs_bloom_from_receipts_list",
+   "zisk_block_validate_logs_bloom",
    "zisk_calldata_byte_counts",
    "zisk_intrinsic_gas_calldata_floor_eip7623",
    "zisk_init_code_cost",

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **181**
-- ziskemu round-trip scripts: **174** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **182**
+- ziskemu round-trip scripts: **175** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-block-validate-logs-bloom-check.sh
+++ b/scripts/codegen-zisk-block-validate-logs-bloom-check.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# codegen-zisk-block-validate-logs-bloom-check.sh -- PR-K159.
+#
+# End-to-end block-level logs_bloom validation:
+#   1. Extract header.logs_bloom
+#   2. Compute block bloom from receipts list
+#   3. Compare; return is_valid
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_block_validate_logs_bloom ELF"
+lake exe codegen --program zisk_block_validate_logs_bloom --halt linux93 \
+  -o gen-out/zisk_block_validate_logs_bloom
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <bloom_in_header_hex> <receipts_json> <expected_status> <expected_is_valid>
+run_case() {
+  local name="$1" header_bloom="$2" receipts="$3" exp_status="$4" exp_valid="$5"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_block_validate_logs_bloom_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_block_validate_logs_bloom_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import json, struct, sys, rlp
+header_bloom = bytes.fromhex('$header_bloom')
+assert len(header_bloom) == 256
+raw_receipts = json.loads('''$receipts''')
+receipts = []
+for r in raw_receipts:
+    receipts.append([r['status'], r['gas'], bytes.fromhex(r['bloom']), []])
+receipts_list_rlp = rlp.encode(receipts)
+
+# Build a minimal post-merge header with our bloom at field 6.
+H32 = bytes([0xaa] * 32)
+ADDR = bytes([0xbb] * 20)
+hdr = [
+    H32,                                # parent_hash
+    bytes.fromhex('1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347'),
+    ADDR,                               # coinbase
+    H32, H32, H32,                      # state, tx, receipts roots
+    header_bloom,                       # field 6
+    0, 18000000, 30000000, 21000,
+    1700000000, b'', H32, b'\\x00' * 8,
+    7 * 10**9, H32,
+]
+header_rlp = rlp.encode(hdr)
+
+with open(sys.argv[1], 'wb') as f:
+    f.write(struct.pack('<Q', len(header_rlp)))
+    f.write(struct.pack('<Q', len(receipts_list_rlp)))
+    f.write(header_rlp + receipts_list_rlp)
+    pad = (-(16 + len(header_rlp) + len(receipts_list_rlp))) % 8
+    if pad: f.write(b'\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_block_validate_logs_bloom.elf \
+    -i "$in_file" -o "$out_file" -n 5000000 \
+    >"$REPO_ROOT/gen-out/zisk_block_validate_logs_bloom_${name}.emu.log" 2>&1 || true
+
+  local actual_status; actual_status="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local actual_valid_le; actual_valid_le="$(dd if="$out_file" bs=1 skip=8 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local actual_status_dec; actual_status_dec="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$actual_status'))[0])")"
+  local actual_valid; actual_valid="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$actual_valid_le'))[0])")"
+
+  if [[ "$actual_status_dec" == "$exp_status" && "$actual_valid" == "$exp_valid" ]]; then
+    printf "  %-30s OK   status=%d is_valid=%d\n" "$name" "$exp_status" "$exp_valid"
+    return 0
+  else
+    printf "  %-30s FAIL status=%d (expected %d) is_valid=%d (expected %d)\n" "$name" "$actual_status_dec" "$exp_status" "$actual_valid" "$exp_valid"
+    return 1
+  fi
+}
+
+ZERO_BLOOM="$(python3 -c "print('00' * 256)")"
+B_BIT0="$(python3 -c "b=bytearray(256); b[0]=0x80; print(bytes(b).hex())")"
+B_BIT1="$(python3 -c "b=bytearray(256); b[1]=0x40; print(bytes(b).hex())")"
+B_BIT0_BIT1="$(python3 -c "b=bytearray(256); b[0]=0x80; b[1]=0x40; print(bytes(b).hex())")"
+
+FAILED=0
+# Match: empty receipts list, zero bloom in header.
+run_case "match_empty_zero"     "$ZERO_BLOOM"    "[]" 0 1 || FAILED=1
+# Match: single receipt's bloom equals header bloom.
+run_case "match_single"         "$B_BIT0"        "[{\"status\":1,\"gas\":21000,\"bloom\":\"$B_BIT0\"}]" 0 1 || FAILED=1
+# Match: two receipts OR'd into header bloom.
+run_case "match_two_or"         "$B_BIT0_BIT1"   "[{\"status\":1,\"gas\":21000,\"bloom\":\"$B_BIT0\"}, {\"status\":1,\"gas\":42000,\"bloom\":\"$B_BIT1\"}]" 0 1 || FAILED=1
+# Mismatch: header bloom doesn't match computed.
+run_case "mismatch_wrong_bit"   "$B_BIT1"        "[{\"status\":1,\"gas\":21000,\"bloom\":\"$B_BIT0\"}]" 0 0 || FAILED=1
+# Mismatch: header says zero but receipts contribute bits.
+run_case "mismatch_underreport" "$ZERO_BLOOM"    "[{\"status\":1,\"gas\":21000,\"bloom\":\"$B_BIT0\"}]" 0 0 || FAILED=1
+# Mismatch: header has extra bits.
+run_case "mismatch_overreport"  "$B_BIT0"        "[]" 0 0 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: block_validate_logs_bloom predicate matches Python OR-accumulation"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- \`block_validate_logs_bloom\`: end-to-end block-level \`logs_bloom\` validation. Given the header RLP and the receipts list, recompute the bloom from receipts and check it byte-equals the header's claimed bloom.
- **Closes the 9-helper bloom-validation family** (K148–K151, K152, K153, K154, K158, K159) — single-call entry point so callers don't have to chain three helpers and manage scratch buffers themselves.

### Algorithm

\`\`\`
header_bloom = header_extract_logs_bloom(header_rlp)      # K153
computed_bloom = block_logs_bloom_from_receipts_list(    # K158
    receipts_rlp_list)
is_valid = bloom_eq(header_bloom, computed_bloom)         # K154
\`\`\`

The verdict is returned via an out pointer (1 if matches, 0 if not). Error codes in \`a0\` distinguish header-parse vs receipts-parse failures.

### Calling convention

| reg | role |
|---|---|
| a0 | header_rlp ptr |
| a1 | header_rlp byte length |
| a2 | receipts_rlp_list ptr |
| a3 | receipts_rlp_list byte length |
| a4 | u64 out (is_valid: 1/0) |
| a0 (out) | 0 ok / 1 header parse fail / 2 receipts parse fail |

## Test plan

- [x] \`lake build\` clean
- [x] \`scripts/codegen-zisk-block-validate-logs-bloom-check.sh\` — 6/6 fixtures pass:
  - \`match_empty_zero\`, \`match_single\`, \`match_two_or\`: positive cases
  - \`mismatch_wrong_bit\`, \`mismatch_underreport\`, \`mismatch_overreport\`: negative cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)