### PR TITLE
feat(stateless): u256_lt_be (PR-K160)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -11586,6 +11586,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_header_validate_post_merge" => some ziskHeaderValidatePostMergeProbeUnit
   | "zisk_header_validate_extra_data_length" => some ziskHeaderValidateExtraDataLengthProbeUnit
   | "zisk_u256_add_be"          => some ziskU256AddBeProbeUnit
+  | "zisk_u256_lt_be"           => some ziskU256LtBeProbeUnit
   | "zisk_u256_sub_be"          => some ziskU256SubBeProbeUnit
   | "zisk_u256_eq"              => some ziskU256EqProbeUnit
   | "zisk_u256_mul_u64_be"      => some ziskU256MulU64BeProbeUnit
@@ -11759,6 +11760,7 @@ def knownProgramNames : List String :=
    "zisk_header_validate_post_merge",
    "zisk_header_validate_extra_data_length",
    "zisk_u256_add_be",
+   "zisk_u256_lt_be",
    "zisk_u256_sub_be",
    "zisk_u256_eq",
    "zisk_u256_mul_u64_be",

--- a/EvmAsm/Codegen/Programs/Tx.lean
+++ b/EvmAsm/Codegen/Programs/Tx.lean
@@ -2656,6 +2656,102 @@ def ziskU256AddBeProbeUnit : BuildUnit := {
   dataAsm     := ziskU256AddBeDataSection
 }
 
+/-! ## u256_lt_be -- PR-K160
+
+    The missing companion to PR-K53 `u256_eq` and PR-K52
+    `u256_sub_be`. Earlier helpers in the u256 family reference
+    "PR-K50 `u256_lt`" in their doc-comments, but the function
+    was never actually shipped; this PR finally pins the
+    primitive into the registry.
+
+    Compare two 32-byte big-endian u256 buffers and return the
+    verdict `a < b` as a u64 (1 if strictly less, 0 otherwise).
+
+    Pure byte-walk from MSB to LSB: on the first differing byte,
+    return early based on the byte ordering; on full match,
+    return 0. Constant-cycle on a per-buffer basis (no early
+    exit) keeps the helper friendly to gas-cost modelling --
+    but a typical caller wants the early-exit (cheaper); since
+    this is a register-level helper we go with early exit.
+
+    Use cases:
+      * sender balance check (`account.balance >= cost`):
+        `u256_lt_be(account_balance, cost, &is_less);
+         assert is_less == 0`.
+      * EVM LT/GT opcode dispatch (after sign-handling).
+      * U256 min / max where K59 / K60's "pick smaller of two"
+        callers explicitly call this primitive.
+
+    Companion to:
+      - PR-K53 `u256_eq`         -- equality
+      - PR-K52 `u256_sub_be`     -- modular subtraction
+      - PR-K59 `u256_min`        -- already does its own compare;
+                                   could be refactored to use this
+
+    Calling convention:
+      a0 (input)  : a ptr (32 bytes, BE)
+      a1 (input)  : b ptr (32 bytes, BE)
+      a2 (input)  : u64 out ptr (1 if a < b, 0 otherwise)
+      ra (input)  : return
+      a0 (output) : 0 (always succeeds). -/
+def u256LtBeFunction : String :=
+  "u256_lt_be:\n" ++
+  "  li t0, 32                  # byte counter (MSB-first)\n" ++
+  "  mv t1, a0                  # a cursor\n" ++
+  "  mv t2, a1                  # b cursor\n" ++
+  ".Lulb_loop:\n" ++
+  "  beqz t0, .Lulb_equal\n" ++
+  "  lbu t3, 0(t1)\n" ++
+  "  lbu t4, 0(t2)\n" ++
+  "  bltu t3, t4, .Lulb_less\n" ++
+  "  bltu t4, t3, .Lulb_greater\n" ++
+  "  addi t1, t1, 1\n" ++
+  "  addi t2, t2, 1\n" ++
+  "  addi t0, t0, -1\n" ++
+  "  j .Lulb_loop\n" ++
+  ".Lulb_less:\n" ++
+  "  li t5, 1\n" ++
+  "  sd t5, 0(a2)\n" ++
+  "  li a0, 0\n" ++
+  "  ret\n" ++
+  ".Lulb_greater:\n" ++
+  ".Lulb_equal:\n" ++
+  "  sd zero, 0(a2)\n" ++
+  "  li a0, 0\n" ++
+  "  ret"
+
+/-- `zisk_u256_lt_be`: probe BuildUnit.
+    Input layout (after host shift):
+      bytes  0.. 8 : padding
+      bytes  8..40 : a (32 B BE)
+      bytes 40..72 : b (32 B BE)
+    Output layout:
+      bytes  0.. 8 : status (always 0)
+      bytes  8..16 : is_less (1 if a < b, else 0) -/
+def ziskU256LtBePrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a3, 0x40000000\n" ++
+  "  addi a0, a3, 16             # a ptr\n" ++
+  "  addi a1, a3, 48             # b ptr (a + 32)\n" ++
+  "  li a2, 0xa0010008           # is_less out\n" ++
+  "  jal ra, u256_lt_be\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lulb_pdone\n" ++
+  u256LtBeFunction ++ "\n" ++
+  ".Lulb_pdone:"
+
+def ziskU256LtBeDataSection : String :=
+  ".section .data\n" ++
+  "ulb_pad:\n" ++
+  "  .zero 8"
+
+def ziskU256LtBeProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskU256LtBePrologue
+  dataAsm     := ziskU256LtBeDataSection
+}
+
 /-! ## u256_sub_be -- PR-K52 modular subtraction on BE u256 buffers
 
     Compute `(a - b) mod 2^256` over two 32-byte big-endian

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **182**
-- ziskemu round-trip scripts: **175** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **183**
+- ziskemu round-trip scripts: **176** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-u256-lt-be-check.sh
+++ b/scripts/codegen-zisk-u256-lt-be-check.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# codegen-zisk-u256-lt-be-check.sh -- PR-K160.
+#
+# Compare two 32-byte BE u256 buffers: return 1 if a < b, else 0.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_u256_lt_be ELF"
+lake exe codegen --program zisk_u256_lt_be --halt linux93 \
+  -o gen-out/zisk_u256_lt_be
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <a_hex_32B> <b_hex_32B> <expected_is_less>
+run_case() {
+  local name="$1" a="$2" b="$3" exp="$4"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_u256_lt_be_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_u256_lt_be_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys
+a = bytes.fromhex('$a')
+b = bytes.fromhex('$b')
+assert len(a) == 32 and len(b) == 32
+with open(sys.argv[1], 'wb') as f:
+    f.write(struct.pack('<Q', 0))
+    f.write(a + b)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_u256_lt_be.elf \
+    -i "$in_file" -o "$out_file" -n 100000 \
+    >"$REPO_ROOT/gen-out/zisk_u256_lt_be_${name}.emu.log" 2>&1 || true
+
+  local actual_status; actual_status="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local actual_lt_le; actual_lt_le="$(dd if="$out_file" bs=1 skip=8 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local actual_lt; actual_lt="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$actual_lt_le'))[0])")"
+
+  if [[ "$actual_status" == "0000000000000000" && "$actual_lt" == "$exp" ]]; then
+    printf "  %-30s OK   is_less=%d\n" "$name" "$exp"
+    return 0
+  else
+    printf "  %-30s FAIL status=0x%s is_less=%d expected=%d\n" "$name" "$actual_status" "$actual_lt" "$exp"
+    return 1
+  fi
+}
+
+zero() { python3 -c "print('00' * 32)"; }
+one() { python3 -c "print('00' * 31 + '01')"; }
+maxu() { python3 -c "print('ff' * 32)"; }
+hi_byte() { python3 -c "print('01' + '00' * 31)"; }
+mid() { python3 -c "print('00' * 16 + '01' + '00' * 15)"; }
+
+FAILED=0
+# Reflexive: a == a -> not less
+run_case "zero_eq_zero"        "$(zero)"   "$(zero)"   0 || FAILED=1
+run_case "max_eq_max"          "$(maxu)"   "$(maxu)"   0 || FAILED=1
+run_case "one_eq_one"          "$(one)"    "$(one)"    0 || FAILED=1
+# Strict ordering
+run_case "zero_lt_one"         "$(zero)"   "$(one)"    1 || FAILED=1
+run_case "one_lt_max"          "$(one)"    "$(maxu)"   1 || FAILED=1
+run_case "zero_lt_max"         "$(zero)"   "$(maxu)"   1 || FAILED=1
+# Greater (not less)
+run_case "one_not_lt_zero"     "$(one)"    "$(zero)"   0 || FAILED=1
+run_case "max_not_lt_zero"     "$(maxu)"   "$(zero)"   0 || FAILED=1
+run_case "max_not_lt_one"      "$(maxu)"   "$(one)"    0 || FAILED=1
+# MSB-driven decisions (the byte where they first differ is high)
+run_case "msb_one_lt_msb_one"  "$(hi_byte)" "$(hi_byte)" 0 || FAILED=1
+run_case "zero_lt_hi_byte"     "$(zero)"   "$(hi_byte)" 1 || FAILED=1
+run_case "lo_byte_lt_hi_byte"  "$(one)"    "$(hi_byte)" 1 || FAILED=1
+run_case "hi_byte_not_lt_max_no" "$(hi_byte)" "$(mid)"  0 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: u256_lt_be matches strict byte-BE comparison"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- \`u256_lt_be\`: the missing companion to PR-K53 \`u256_eq\` and PR-K52 \`u256_sub_be\`. Multiple earlier helpers in the u256 family reference "PR-K50 \`u256_lt\`" in their doc-comments, but the function was never actually shipped; this PR finally pins the primitive into the registry.
- Compare two 32-byte big-endian u256 buffers and return the verdict \`a < b\` as a u64 (1 if strictly less, 0 otherwise). Pure byte-walk from MSB to LSB, early-exit on first differing byte. Leaf-callable, no scratch memory.

### Use cases

- Sender-balance check (\`account.balance >= cost\`): \`u256_lt_be(account_balance, cost, &is_less); assert is_less == 0\`.
- EVM LT / GT opcode dispatch (after sign-handling).
- U256 min / max where K59 / K60's "pick smaller" callers explicitly call this primitive.

### Calling convention

| reg | role |
|---|---|
| a0 | a ptr (32 B, BE) |
| a1 | b ptr (32 B, BE) |
| a2 | u64 out (1 if a < b, 0 otherwise) |
| a0 (out) | 0 (always succeeds) |

Lives in \`Programs/Tx.lean\` alongside the rest of the u256 family.

## Test plan

- [x] \`lake build\` clean
- [x] \`scripts/codegen-zisk-u256-lt-be-check.sh\` — 13/13 fixtures pass:
  - Reflexive: \`zero_eq_zero\`, \`max_eq_max\`, \`one_eq_one\`
  - Strict ordering: \`zero_lt_one\`, \`one_lt_max\`, \`zero_lt_max\`
  - Greater not less: \`one_not_lt_zero\`, \`max_not_lt_zero\`, \`max_not_lt_one\`
  - MSB-driven boundary: \`zero_lt_hi_byte\`, \`lo_byte_lt_hi_byte\`, \`hi_byte_not_lt_max_no\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)