### PR TITLE
feat(div): n=3 v4 unified noNop callableExactFrame theorem

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -34,6 +34,7 @@ import EvmAsm.Evm64.DivMod.Spec.N3DivStackSpec
 import EvmAsm.Evm64.DivMod.Spec.Unified
 import EvmAsm.Evm64.DivMod.Spec.UnifiedExactNoNop
 import EvmAsm.Evm64.DivMod.Spec.UnifiedExactNoNopCallableFrame
+import EvmAsm.Evm64.DivMod.Spec.N3V4CallableExact
 import EvmAsm.Evm64.DivMod.Spec.BzeroV4ExactCallable
 import EvmAsm.Evm64.DivMod.Spec.ModBzeroV4Callable
 import EvmAsm.Evm64.DivMod.Spec.BzeroV4ExactFrame

--- a/EvmAsm/Evm64/DivMod/Spec/N3V4CallableExact.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3V4CallableExact.lean
@@ -1,0 +1,132 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N3V4CallableExact
+
+  Unified-bound n=3 DIV v4 exact-frame callable wrapper over `divCode_noNop_v4`.
+
+  `evm_div_n3_stack_spec_noNop_v4_preNoX1_callableExactFrame_uni` mirrors
+  `evm_div_n3_stack_pre_to_callable_post_v4_scratch_word` (N3V4StackPre) but:
+  - stays in `divCode_noNop_v4` (does not lift to `divCode_v4`),
+  - weakens the scratch cell in the post to `memOwn`, and
+  - lifts the step count to `unifiedDivBound`.
+
+  Used as a building block toward `evm_div_stack_spec_unconditional` (bead .7.1).
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.N3V4StackPre
+import EvmAsm.Evm64.DivMod.Spec.UnifiedBzero
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Unified-bound n=3 DIV v4 body spec over `divCode_noNop_v4` with exact
+    caller-framed `x1` and `x9` in the postcondition.  The v4 trial-call
+    scratch cell at `sp + signExtend12 3936` is existentially closed in the
+    postcondition (`memOwn`), since its computed value is not needed by the
+    dispatcher consumer. -/
+theorem evm_div_n3_stack_spec_noNop_v4_preNoX1_callableExactFrame_uni
+    (bltu_1 bltu_0 : Bool) (sp base : Word)
+    (a b : EvmWord)
+    (v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (hbnz : b ≠ 0)
+    (hb3z : b.getLimbN 3 = 0) (hb2nz : b.getLimbN 2 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 2)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_1 : bltu_1 =
+      BitVec.ult (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+        (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).2.2.1)
+    (hbltu_0 : bltu_0 =
+      match bltu_1, hbltu_1 with
+      | false, _ =>
+        BitVec.ult
+          (iterN3Max
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+            (0 : Word)).2.2.2.1
+          (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+            (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+      | true, _ =>
+        BitVec.ult
+          (iterWithDoubleAddback
+            (divKTrialCallV4QHat
+              (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+                (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+              (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+                (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.1
+              (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+                (b.getLimbN 2) (b.getLimbN 3)).2.2.1)
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+            (0 : Word)).2.2.2.1
+          (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+            (b.getLimbN 2) (b.getLimbN 3)).2.2.1)
+    (hcarry2 : fullDivN3Carry2NzV4
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3))
+    (hdivWord : fullDivN3QuotientWordV4 bltu_1 bltu_0
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) =
+        EvmWord.div a b) :
+    cpsTripleWithin unifiedDivBound base (base + nopOff) (divCode_noNop_v4 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult (b.getLimbN 2)).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divStackDispatchPostCallableExactFrame sp a b raVal
+        (signExtend12 4095 : Word) **
+       memOwn (sp + signExtend12 3936)) := by
+  exact cpsTripleWithin_mono_nSteps (by unfold unifiedDivBound; decide) <|
+    cpsTripleWithin_weaken
+      (fun _ hp => hp)
+      (fun _ hq => by
+        obtain ⟨h1, h2, hd, hu, hframe, hscratch⟩ := hq
+        exact ⟨h1, h2, hd, hu, hframe, memIs_implies_memOwn h2 hscratch⟩)
+      (cpsTripleWithin_weaken
+        (fun _ hp => hp)
+        (fun h hq =>
+          fullDivN3UnifiedPostNoX1V4_frame_to_divStackDispatchPostCallableExactFrame_scratch_word
+            bltu_1 bltu_0 sp base a b
+            retMem dMem dloMem scratchUn0 scratchMem raVal hdivWord h hq)
+        (evm_div_n3_stack_pre_to_unified_post_v4_noNop
+          sp base a b v5 v6 v7 v10 v11Old
+          q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+          nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+          hbnz hb3z hb2nz hshift_nz halign hbltu_1 hbltu_0 hcarry2))
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Add `evm_div_n3_stack_spec_noNop_v4_preNoX1_callableExactFrame_uni` to new `Spec/N3V4CallableExact.lean`
- Proves unified-bound (946 steps) n=3 DIV v4 body spec over `divCode_noNop_v4` with exact caller-framed `x1`/`x9` in postcondition
- The v4 scratch cell at `sp + 3936` is existentially closed as `memOwn` (value not tracked by caller)
- Wire into `DivMod/Spec.lean` re-export surface

Refs #61. Bead: evm-asm-9iqmw.2.2.

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.N3V4CallableExact
- lake build EvmAsm.Evm64.DivMod.Spec
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/Spec/N3V4CallableExact.lean EvmAsm/Evm64/DivMod/Spec.lean
- lake build

Authored by @pirapira; implemented by Claude Code