### PR TITLE
feat(stateless): mpt_node_slot_encode (PR-K163)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -8196,6 +8196,117 @@ def ziskMptLeafNodeEncodeProbeUnit : BuildUnit := {
   dataAsm     := ziskMptLeafNodeEncodeDataSection
 }
 
+/-! ## mpt_node_slot_encode -- PR-K163
+
+    Given a child MPT node's RLP, produce the bytes that go
+    *verbatim* into a parent node's child-slot when assembling
+    the parent's outer RLP list.
+
+      if len(node_rlp) < 32:
+        slot_bytes = node_rlp                  -- inline embed
+      else:
+        slot_bytes = 0xa0 || keccak256(node_rlp)  -- 32-byte
+                                                -- string item
+
+    This is the parent-side complement of PR-K112
+    `mpt_encode_internal_node`. K112 returns the *raw reference*
+    (either RLP bytes verbatim or just the 32-byte hash); K163
+    wraps the hashed case with the 0xa0 RLP string-prefix so the
+    output is ready to splice into the parent's RLP payload.
+
+    Building block for `mpt_branch_node_encode` (future) and
+    `mpt_extension_node_encode` (future).
+
+    Composes:
+      - `zkvm_keccak256` (HashBridge) when node_rlp_len >= 32
+
+    Calling convention:
+      a0 (input)  : node_rlp ptr
+      a1 (input)  : node_rlp byte length
+      a2 (input)  : output bytes ptr
+                    (caller supplies max(node_rlp_len, 33) bytes)
+      a3 (input)  : u64 out length ptr
+                    (33 when hashed, node_rlp_len when inline)
+      ra (input)  : return
+      a0 (output) : 0 (always succeeds). -/
+def mptNodeSlotEncodeFunction : String :=
+  "mpt_node_slot_encode:\n" ++
+  "  addi sp, sp, -32\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp)\n" ++
+  "  mv s0, a2                   # output ptr\n" ++
+  "  mv s1, a3                   # out_length ptr\n" ++
+  "  li t0, 32\n" ++
+  "  bltu a1, t0, .Lmnse_inline\n" ++
+  "  # Hash path: out[0] = 0xa0; keccak256(node_rlp) -> out[1..33].\n" ++
+  "  li t1, 0xa0\n" ++
+  "  sb t1, 0(s0)\n" ++
+  "  mv s2, a0                   # node_rlp ptr stashed\n" ++
+  "  # zkvm_keccak256(node_rlp, len, out + 1).\n" ++
+  "  addi a2, s0, 1\n" ++
+  "  jal ra, zkvm_keccak256\n" ++
+  "  li t0, 33\n" ++
+  "  sd t0, 0(s1)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lmnse_ret\n" ++
+  ".Lmnse_inline:\n" ++
+  "  # Inline path: copy node_rlp bytes to out.\n" ++
+  "  mv t0, a0                   # src cursor\n" ++
+  "  mv t1, s0                   # dst cursor\n" ++
+  "  mv t2, a1                   # remaining\n" ++
+  ".Lmnse_cp:\n" ++
+  "  beqz t2, .Lmnse_cp_done\n" ++
+  "  lbu t3, 0(t0)\n" ++
+  "  sb  t3, 0(t1)\n" ++
+  "  addi t0, t0, 1\n" ++
+  "  addi t1, t1, 1\n" ++
+  "  addi t2, t2, -1\n" ++
+  "  j .Lmnse_cp\n" ++
+  ".Lmnse_cp_done:\n" ++
+  "  sd a1, 0(s1)\n" ++
+  "  li a0, 0\n" ++
+  ".Lmnse_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp)\n" ++
+  "  addi sp, sp, 32\n" ++
+  "  ret"
+
+/-- `zisk_mpt_node_slot_encode`: probe BuildUnit.
+    Input layout:
+      bytes  0.. 8 : node_rlp_len
+      bytes  8..   : node_rlp
+    Output layout:
+      bytes  0.. 8 : status
+      bytes  8..16 : out_length
+      bytes 16..   : slot_bytes (up to 33 bytes for hash; up to
+                      ziskemu cap minus 16 for inline) -/
+def ziskMptNodeSlotEncodePrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a4, 0x40000000\n" ++
+  "  ld a1, 8(a4)                # node_rlp_len\n" ++
+  "  addi a0, a4, 16             # node_rlp ptr\n" ++
+  "  li a2, 0xa0010010           # output slot ptr\n" ++
+  "  li a3, 0xa0010008           # out_length ptr\n" ++
+  "  jal ra, mpt_node_slot_encode\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lmnse_pdone\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  mptNodeSlotEncodeFunction ++ "\n" ++
+  ".Lmnse_pdone:"
+
+def ziskMptNodeSlotEncodeDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200"
+
+def ziskMptNodeSlotEncodeProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskMptNodeSlotEncodePrologue
+  dataAsm     := ziskMptNodeSlotEncodeDataSection
+}
+
 /-! ## block-level bloom composites K158-K159 — moved to `Programs/Bloom.lean` (file-size hard cap). -/
 
 /-! ## header_root_is_empty_trie -- PR-K161
@@ -9104,6 +9215,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_receipt_encode" => some ziskReceiptEncodeProbeUnit
   | "zisk_single_leaf_trie_root" => some ziskSingleLeafTrieRootProbeUnit
   | "zisk_mpt_leaf_node_encode" => some ziskMptLeafNodeEncodeProbeUnit
+  | "zisk_mpt_node_slot_encode" => some ziskMptNodeSlotEncodeProbeUnit
   | "zisk_block_logs_bloom_from_receipts_list" => some ziskBlockLogsBloomFromReceiptsListProbeUnit
   | "zisk_block_validate_logs_bloom" => some ziskBlockValidateLogsBloomProbeUnit
   | "zisk_header_root_is_empty_trie" => some ziskHeaderRootIsEmptyTrieProbeUnit
@@ -9280,6 +9392,7 @@ def knownProgramNames : List String :=
    "zisk_receipt_encode",
    "zisk_single_leaf_trie_root",
    "zisk_mpt_leaf_node_encode",
+   "zisk_mpt_node_slot_encode",
    "zisk_block_logs_bloom_from_receipts_list",
    "zisk_block_validate_logs_bloom",
    "zisk_header_root_is_empty_trie",

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **185**
-- ziskemu round-trip scripts: **178** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **186**
+- ziskemu round-trip scripts: **179** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-mpt-node-slot-encode-check.sh
+++ b/scripts/codegen-zisk-mpt-node-slot-encode-check.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# codegen-zisk-mpt-node-slot-encode-check.sh -- PR-K163.
+#
+# Given a child MPT node's RLP, produce the parent-slot bytes:
+#   inline (len < 32): node_rlp verbatim
+#   hashed (len >= 32): 0xa0 || keccak256(node_rlp)
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_mpt_node_slot_encode ELF"
+lake exe codegen --program zisk_mpt_node_slot_encode --halt linux93 \
+  -o gen-out/zisk_mpt_node_slot_encode
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <node_rlp_hex>
+run_case() {
+  local name="$1" node_rlp="$2"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_mpt_node_slot_encode_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_mpt_node_slot_encode_${name}.output"
+  local exp_hex_file="$REPO_ROOT/gen-out/zisk_mpt_node_slot_encode_${name}.expected.hex"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys
+try:
+    from Crypto.Hash import keccak
+    def keccak256(b):
+        h = keccak.new(digest_bits=256); h.update(b); return h.digest()
+except Exception:
+    import sha3
+    def keccak256(b): return sha3.keccak_256(b).digest()
+
+node_rlp = bytes.fromhex('$node_rlp')
+if len(node_rlp) < 32:
+    expected = node_rlp
+else:
+    expected = b'\\xa0' + keccak256(node_rlp)
+
+with open(sys.argv[1], 'wb') as f:
+    f.write(struct.pack('<Q', len(node_rlp)))
+    f.write(node_rlp)
+    pad = (-(8 + len(node_rlp))) % 8
+    if pad: f.write(b'\x00' * pad)
+with open(sys.argv[2], 'w') as f:
+    f.write(expected.hex())
+" "$in_file" "$exp_hex_file"
+
+  "$ZISKEMU" -e gen-out/zisk_mpt_node_slot_encode.elf \
+    -i "$in_file" -o "$out_file" -n 1000000 \
+    >"$REPO_ROOT/gen-out/zisk_mpt_node_slot_encode_${name}.emu.log" 2>&1 || true
+
+  local actual_status; actual_status="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local actual_len_le; actual_len_le="$(dd if="$out_file" bs=1 skip=8 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local actual_len; actual_len="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$actual_len_le'))[0])")"
+  local expected_hex; expected_hex="$(cat "$exp_hex_file")"
+  local expected_len; expected_len=$(( ${#expected_hex} / 2 ))
+  local actual_hex; actual_hex="$(dd if="$out_file" bs=1 skip=16 count="$expected_len" 2>/dev/null | xxd -p | tr -d '\n')"
+
+  if [[ "$actual_status" == "0000000000000000" \
+       && "$actual_len" == "$expected_len" \
+       && "$actual_hex" == "$expected_hex" ]]; then
+    local mode="inline"
+    [[ "$expected_len" == "33" ]] && mode="hashed"
+    printf "  %-30s OK   mode=%s len=%d\n" "$name" "$mode" "$expected_len"
+    return 0
+  else
+    printf "  %-30s FAIL status=0x%s actual_len=%d expected_len=%d\n" "$name" "$actual_status" "$actual_len" "$expected_len"
+    printf "      actual:   %s\n" "$actual_hex"
+    printf "      expected: %s\n" "$expected_hex"
+    return 1
+  fi
+}
+
+FAILED=0
+# Inline cases (len < 32)
+run_case "empty_string"        "80"                       || FAILED=1
+run_case "short_5b"            "85deadbeef00"             || FAILED=1
+run_case "ten_byte_list"       "c401020304"               || FAILED=1
+run_case "len_31"              "$(python3 -c "print('9f' + 'ab'*30)")" || FAILED=1
+# Boundary: len == 32 -> hashed
+run_case "len_32"              "$(python3 -c "print('ab' * 32)")"     || FAILED=1
+# Hashed cases
+run_case "hashed_64b"          "$(python3 -c "print('cd' * 64)")"     || FAILED=1
+run_case "hashed_128b"         "$(python3 -c "print('ef' * 128)")"    || FAILED=1
+# Realistic short leaf node (from K162 fixtures)
+run_case "single_leaf_short"   "c4820080"                              || FAILED=1
+# Realistic long leaf node
+run_case "tx_index_0_leaf"     "f8550184ee6b280082520894aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa881bc16d674ec80000801ba01111111111111111111111111111111111111111111111111111111111111111a02222222222222222222222222222222222222222222222222222222222222222" || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: mpt_node_slot_encode picks inline / hashed correctly per spec"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- \`mpt_node_slot_encode\`: given a child MPT node's RLP, produce the bytes that go *verbatim* into a parent node's child-slot when assembling the parent's outer RLP list.

\`\`\`
if len(node_rlp) < 32:
    slot_bytes = node_rlp                       # inline embed
else:
    slot_bytes = 0xa0 || keccak256(node_rlp)    # 32-byte string item
\`\`\`

- Parent-side complement of PR-K112 \`mpt_encode_internal_node\`. K112 returns the raw reference (RLP bytes verbatim or just the 32-byte hash); K163 wraps the hashed case with the \`0xa0\` RLP string-prefix so the output is ready to splice into the parent's RLP payload.
- Building block for \`mpt_branch_node_encode\` (future) and \`mpt_extension_node_encode\` (future) — both will iterate this helper across their child slots.

### Calling convention

| reg | role |
|---|---|
| a0 | node_rlp ptr |
| a1 | node_rlp byte length |
| a2 | output bytes ptr (≥ max(node_rlp_len, 33) bytes) |
| a3 | u64 out length ptr |
| a0 (out) | 0 (always succeeds) |

Composes \`zkvm_keccak256\` (HashBridge) when \`node_rlp_len ≥ 32\`.

## Test plan

- [x] \`lake build\` clean
- [x] \`scripts/codegen-zisk-mpt-node-slot-encode-check.sh\` — 9/9 fixtures pass against Python reference:
  - Inline cases: \`empty_string\`, \`short_5b\`, \`ten_byte_list\`, \`len_31\`
  - Boundary: \`len_32\` (first byte to trigger hash path)
  - Hashed cases: \`hashed_64b\`, \`hashed_128b\`
  - Realistic: \`single_leaf_short\` (inline), \`tx_index_0_leaf\` (hashed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)