### PR TITLE
feat(div): n=2 V4 unfold lemmas + concrete post bridge

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4Families.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4Families.lean
@@ -179,6 +179,75 @@ def fullDivN2UnifiedPostNoX1V4 (bltu_2 bltu_1 bltu_0 : Bool)
     fullDivN2ScratchMemV4 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3 scratchMem)
 
 -- ============================================================================
+-- _unfold lemmas for the @[irreducible] V4 assertion bundles
+-- ============================================================================
+
+theorem fullDivN2DenormPostV4_unfold {bltu_2 bltu_1 bltu_0 : Bool}
+    {sp a0 a1 a2 a3 b0 b1 b2 b3 : Word} :
+    fullDivN2DenormPostV4 bltu_2 bltu_1 bltu_0 sp a0 a1 a2 a3 b0 b1 b2 b3 =
+    (let shift := fullDivN2Shift b1
+     let r2 := fullDivN2R2V4 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3
+     let r1 := fullDivN2R1V4 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+     let r0 := fullDivN2R0V4 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+     denormDivPost sp shift r0.2.1 r0.2.2.1 r0.2.2.2.1 r0.2.2.2.2.1
+       r0.1 r1.1 r2.1 (0 : Word) **
+     ((sp + signExtend12 3992) ↦ₘ shift)) := by
+  delta fullDivN2DenormPostV4; rfl
+
+theorem fullDivN2ScratchNoX1V4_unfold {bltu_2 bltu_1 bltu_0 : Bool}
+    {sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 : Word} :
+    fullDivN2ScratchNoX1V4 bltu_2 bltu_1 bltu_0 sp base
+      a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 =
+    (let v := fullDivN2NormV b0 b1 b2 b3
+     let u := fullDivN2NormU a0 a1 a2 a3 b1
+     let r2 := fullDivN2R2V4 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3
+     let scratchRet2 := if bltu_2 then (base + div128CallRetOff) else retMem
+     let scratchD2 := if bltu_2 then v.2.1 else dMem
+     let scratchDLo2 := if bltu_2 then divKTrialCallV4DLo v.2.1 else dloMem
+     let scratchUn02 := if bltu_2 then divKTrialCallV4Un0 u.2.2.2.1 else scratchUn0
+     let scratchRet1 := if bltu_1 then (base + div128CallRetOff) else scratchRet2
+     let scratchD1 := if bltu_1 then v.2.1 else scratchD2
+     let scratchDLo1 := if bltu_1 then divKTrialCallV4DLo v.2.1 else scratchDLo2
+     let scratchUn01 := if bltu_1 then divKTrialCallV4Un0 r2.2.1 else scratchUn02
+     let r1 := fullDivN2R1V4 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+     (sp + signExtend12 3968 ↦ₘ (if bltu_0 then (base + div128CallRetOff) else scratchRet1)) **
+     (sp + signExtend12 3960 ↦ₘ (if bltu_0 then v.2.1 else scratchD1)) **
+     (sp + signExtend12 3952 ↦ₘ (if bltu_0 then divKTrialCallV4DLo v.2.1 else scratchDLo1)) **
+     (sp + signExtend12 3944 ↦ₘ (if bltu_0 then divKTrialCallV4Un0 r1.2.1 else scratchUn01))) := by
+  delta fullDivN2ScratchNoX1V4; rfl
+
+theorem fullDivN2FrameNoX1V4_unfold {bltu_2 bltu_1 bltu_0 : Bool}
+    {sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 : Word} :
+    fullDivN2FrameNoX1V4 bltu_2 bltu_1 bltu_0 sp base
+      a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 =
+    (let r2 := fullDivN2R2V4 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3
+     let r1 := fullDivN2R1V4 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+     let r0 := fullDivN2R0V4 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 4024) ↦ₘ r0.2.2.2.2.2) **
+     ((sp + signExtend12 4016) ↦ₘ r1.2.2.2.2.2) **
+     ((sp + signExtend12 4008) ↦ₘ r2.2.2.2.2.2) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
+     (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
+     (.x9 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ r0.1) **
+     fullDivN2ScratchNoX1V4 bltu_2 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
+       retMem dMem dloMem scratchUn0) := by
+  delta fullDivN2FrameNoX1V4; rfl
+
+theorem fullDivN2UnifiedPostNoX1V4_unfold {bltu_2 bltu_1 bltu_0 : Bool}
+    {sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 scratchMem : Word} :
+    fullDivN2UnifiedPostNoX1V4 bltu_2 bltu_1 bltu_0 sp base
+      a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 scratchMem =
+    (fullDivN2DenormPostV4 bltu_2 bltu_1 bltu_0 sp a0 a1 a2 a3 b0 b1 b2 b3 **
+     fullDivN2FrameNoX1V4 bltu_2 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
+       retMem dMem dloMem scratchUn0 **
+     ((sp + signExtend12 3936) ↦ₘ
+       fullDivN2ScratchMemV4 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3 scratchMem)) := by
+  delta fullDivN2UnifiedPostNoX1V4; rfl
+
+-- ============================================================================
 -- Quotient word
 -- ============================================================================
 

--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -35,6 +35,7 @@ import EvmAsm.Evm64.DivMod.Spec.Unified
 import EvmAsm.Evm64.DivMod.Spec.UnifiedExactNoNop
 import EvmAsm.Evm64.DivMod.Spec.UnifiedExactNoNopCallableFrame
 import EvmAsm.Evm64.DivMod.Spec.N3V4CallableExact
+import EvmAsm.Evm64.DivMod.Spec.N2V4ConcretePostBridge
 import EvmAsm.Evm64.DivMod.Spec.BzeroV4ExactCallable
 import EvmAsm.Evm64.DivMod.Spec.ModBzeroV4Callable
 import EvmAsm.Evm64.DivMod.Spec.BzeroV4ExactFrame

--- a/EvmAsm/Evm64/DivMod/Spec/N2V4ConcretePostBridge.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2V4ConcretePostBridge.lean
@@ -1,0 +1,105 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N2V4ConcretePostBridge
+
+  N=2 V4 bridge from `fullDivN2UnifiedPostNoX1V4` (with exact caller `x1`)
+  to `divConcretePostNoX1ExactRegsFrame` plus the v4 scratch cell.
+
+  Mirrors `fullDivN3UnifiedPostNoX1V4_frame_to_divConcretePostNoX1ExactRegsFrame_scratch`
+  in N3V4StackPre.lean:721–836 for the n=2 case.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4Families
+import EvmAsm.Evm64.DivMod.Spec.CallablePost
+import EvmAsm.Evm64.DivMod.Spec.Dispatcher
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (word_add_zero)
+
+theorem fullDivN2UnifiedPostNoX1V4_frame_to_divConcretePostNoX1ExactRegsFrame_scratch
+    (bltu_2 bltu_1 bltu_0 : Bool)
+    (sp base : Word) (a b : EvmWord)
+    (a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (ha0 : a.getLimbN 0 = a0) (ha1 : a.getLimbN 1 = a1)
+    (ha2 : a.getLimbN 2 = a2) (ha3 : a.getLimbN 3 = a3)
+    (hdiv0 : (EvmWord.div a b).getLimbN 0 =
+      (fullDivN2R0V4 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).1)
+    (hdiv1 : (EvmWord.div a b).getLimbN 1 =
+      (fullDivN2R1V4 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1)
+    (hdiv2 : (EvmWord.div a b).getLimbN 2 =
+      (fullDivN2R2V4 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).1)
+    (hdiv3 : (EvmWord.div a b).getLimbN 3 = (0 : Word)) :
+    ∀ h,
+      (fullDivN2UnifiedPostNoX1V4 bltu_2 bltu_1 bltu_0 sp base
+        a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal)) h →
+      (divConcretePostNoX1ExactRegsFrame sp a b
+        (signExtend12 4095) raVal
+        (signExtend12 (0 : BitVec 12) - fullDivN2Shift b1)
+        (fullDivN2R0V4 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).1
+        (fullDivN2R1V4 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1
+        (fullDivN2R2V4 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).1
+        (0 : Word)
+        (fullDivN2R0V4 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).1
+        (fullDivN2R0V4 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).1
+        (fullDivN2R1V4 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1
+        (fullDivN2R2V4 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).1
+        (0 : Word)
+        (((fullDivN2R0V4 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.1 >>>
+            ((fullDivN2Shift b1).toNat % 64)) |||
+          ((fullDivN2R0V4 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 <<<
+            (((signExtend12 (0 : BitVec 12) - fullDivN2Shift b1).toNat) % 64)))
+        (((fullDivN2R0V4 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 >>>
+            ((fullDivN2Shift b1).toNat % 64)) |||
+          ((fullDivN2R0V4 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1 <<<
+            (((signExtend12 (0 : BitVec 12) - fullDivN2Shift b1).toNat) % 64)))
+        (((fullDivN2R0V4 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1 >>>
+            ((fullDivN2Shift b1).toNat % 64)) |||
+          ((fullDivN2R0V4 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1 <<<
+            (((signExtend12 (0 : BitVec 12) - fullDivN2Shift b1).toNat) % 64)))
+        ((fullDivN2R0V4 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1 >>>
+          ((fullDivN2Shift b1).toNat % 64))
+        (fullDivN2R0V4 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.2
+        (fullDivN2R1V4 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.2
+        (fullDivN2R2V4 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.2
+        (0 : Word)
+        (fullDivN2Shift b1) (2 : Word) (0 : Word)
+        (if bltu_0 then (base + div128CallRetOff)
+          else if bltu_1 then (base + div128CallRetOff)
+          else if bltu_2 then (base + div128CallRetOff) else retMem)
+        (if bltu_0 then (fullDivN2NormV b0 b1 b2 b3).2.1
+          else if bltu_1 then (fullDivN2NormV b0 b1 b2 b3).2.1
+          else if bltu_2 then (fullDivN2NormV b0 b1 b2 b3).2.1 else dMem)
+        (if bltu_0 then divKTrialCallV4DLo (fullDivN2NormV b0 b1 b2 b3).2.1
+          else if bltu_1 then divKTrialCallV4DLo (fullDivN2NormV b0 b1 b2 b3).2.1
+          else if bltu_2 then divKTrialCallV4DLo (fullDivN2NormV b0 b1 b2 b3).2.1 else dloMem)
+        (if bltu_0 then
+            divKTrialCallV4Un0 (fullDivN2R1V4 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.1
+          else if bltu_1 then
+            divKTrialCallV4Un0 (fullDivN2R2V4 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.1
+          else if bltu_2 then
+            divKTrialCallV4Un0 (fullDivN2NormU a0 a1 a2 a3 b1).2.2.2.1
+          else scratchUn0) **
+       ((sp + signExtend12 3936) ↦ₘ
+        fullDivN2ScratchMemV4 bltu_2 bltu_1 bltu_0
+          a0 a1 a2 a3 b0 b1 b2 b3 scratchMem)) h := by
+  intro h hq
+  -- Normalize hq: expand all @[irreducible] V4 bundles and inline let-bindings.
+  simp (config := { zeta := true }) only [fullDivN2UnifiedPostNoX1V4_unfold,
+    fullDivN2DenormPostV4_unfold, fullDivN2FrameNoX1V4_unfold,
+    fullDivN2ScratchNoX1V4_unfold, denormDivPost_unfold] at hq
+  rw [word_add_zero] at hq
+  -- Normalize goal: unfold all bundles in one simp pass.
+  rw [divConcretePostNoX1ExactRegsFrame_unfold,
+      evmWordIs_sp_limbs_eq sp a a0 a1 a2 a3 ha0 ha1 ha2 ha3,
+      evmWordIs_sp32_limbs_eq sp (EvmWord.div a b)
+        (fullDivN2R0V4 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).1
+        (fullDivN2R1V4 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1
+        (fullDivN2R2V4 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).1
+        (0 : Word) hdiv0 hdiv1 hdiv2 hdiv3,
+      divScratchValuesCallNoX1_unfold, divScratchValues_unfold]
+  xperm_hyp hq
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Add `_unfold` lemmas for the four `@[irreducible]` N2 V4 assertion bundles in `FullPathN2V4Families.lean` (needed so `simp (zeta)` can inline them before `xperm_hyp`)
- Add `fullDivN2UnifiedPostNoX1V4_frame_to_divConcretePostNoX1ExactRegsFrame_scratch` in new `N2V4ConcretePostBridge.lean` — n=2 analogue of the n=3 bridge in `N3V4StackPre.lean:721`

Key: the `rw [evmWordIs_sp32_limbs_eq ...]` required explicit args (not underscores) to match the elaborated goal form; diagnosed via `lean_goal` LSP.

Refs #61. Bead: evm-asm-9iqmw.2.3.1.

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.N2V4ConcretePostBridge
- lake build EvmAsm.Evm64.DivMod.Spec
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/Spec/N2V4ConcretePostBridge.lean EvmAsm/Evm64/DivMod/Compose/FullPathN2V4Families.lean
- lake build

Authored by @pirapira; implemented by Claude Code