### PR TITLE
feat(div): n=2 V4 callableExactFrame theorem + bridge helpers

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -36,6 +36,7 @@ import EvmAsm.Evm64.DivMod.Spec.UnifiedExactNoNop
 import EvmAsm.Evm64.DivMod.Spec.UnifiedExactNoNopCallableFrame
 import EvmAsm.Evm64.DivMod.Spec.N3V4CallableExact
 import EvmAsm.Evm64.DivMod.Spec.N2V4ConcretePostBridge
+import EvmAsm.Evm64.DivMod.Spec.N2V4CallableExact
 import EvmAsm.Evm64.DivMod.Spec.BzeroV4ExactCallable
 import EvmAsm.Evm64.DivMod.Spec.ModBzeroV4Callable
 import EvmAsm.Evm64.DivMod.Spec.BzeroV4ExactFrame

--- a/EvmAsm/Evm64/DivMod/Spec/N2V4CallableExact.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2V4CallableExact.lean
@@ -1,0 +1,85 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N2V4CallableExact
+
+  Unified-bound n=2 DIV v4 exact-frame callable wrapper over `divCode_noNop_v4`.
+
+  `evm_div_n2_stack_spec_noNop_v4_preNoX1_callableExactFrame_uni` mirrors
+  `evm_div_n3_stack_spec_noNop_v4_preNoX1_callableExactFrame_uni` (N3V4CallableExact)
+  for the n=2 divisor case.
+
+  The theorem takes the unified-post body proof as a hypothesis (rather than
+  inlining the complex `hbltu_0` condition, which spans ~250 lines).  Callers
+  first invoke `evm_div_n2_stack_pre_to_unified_post_v4_noNop` to obtain the
+  body, then pass it here.
+
+  The v4 trial-call scratch cell at `sp + signExtend12 3936` is existentially
+  closed in the postcondition (`memOwn`), since its computed value is not needed
+  by the dispatcher consumer.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.N2V4ConcretePostBridge
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopCallablePost
+import EvmAsm.Evm64.DivMod.Spec.UnifiedBzero
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Unified-bound n=2 DIV v4 body spec over `divCode_noNop_v4` with exact
+    caller-framed `x1` and `x9` in the postcondition.  The v4 trial-call
+    scratch cell at `sp + signExtend12 3936` is existentially closed (`memOwn`).
+
+    `hbody` should be produced by `evm_div_n2_stack_pre_to_unified_post_v4_noNop`.
+    This wrapper applies the bridge to convert the unified post to the callable
+    exact frame, weakens the scratch cell, and lifts to `unifiedDivBound`. -/
+theorem evm_div_n2_stack_spec_noNop_v4_preNoX1_callableExactFrame_uni
+    (bltu_2 bltu_1 bltu_0 : Bool) (sp base : Word)
+    (a b : EvmWord)
+    (v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (hdivWord : fullDivN2QuotientWordV4 bltu_2 bltu_1 bltu_0
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) =
+        EvmWord.div a b)
+    (hbody : cpsTripleWithin ((8 + 21 + 24 + 4 + 21 + 21 + 4 + 672) + (2 + 23 + 10))
+      base (base + nopOff) (divCode_noNop_v4 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult (b.getLimbN 1)).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (fullDivN2UnifiedPostNoX1V4 bltu_2 bltu_1 bltu_0 sp base
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+        retMem dMem dloMem scratchUn0 scratchMem **
+       (.x1 ↦ᵣ raVal))) :
+    cpsTripleWithin unifiedDivBound base (base + nopOff) (divCode_noNop_v4 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult (b.getLimbN 1)).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divStackDispatchPostCallableExactFrame sp a b raVal
+        (signExtend12 4095 : Word) **
+       memOwn (sp + signExtend12 3936)) :=
+  cpsTripleWithin_mono_nSteps (by unfold unifiedDivBound; decide) <|
+    cpsTripleWithin_weaken
+      (fun _ hp => hp)
+      (fun _ hq => by
+        obtain ⟨h1, h2, hd, hu, hframe, hscratch⟩ := hq
+        exact ⟨h1, h2, hd, hu, hframe, memIs_implies_memOwn h2 hscratch⟩)
+      (cpsTripleWithin_weaken
+        (fun _ hp => hp)
+        (fun h hq =>
+          fullDivN2UnifiedPostNoX1V4_frame_to_divStackDispatchPostCallableExactFrame_scratch_word
+            bltu_2 bltu_1 bltu_0 sp base a b
+            retMem dMem dloMem scratchUn0 scratchMem raVal hdivWord h hq)
+        hbody)
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N2V4ConcretePostBridge.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2V4ConcretePostBridge.lean
@@ -102,4 +102,96 @@ theorem fullDivN2UnifiedPostNoX1V4_frame_to_divConcretePostNoX1ExactRegsFrame_sc
       divScratchValuesCallNoX1_unfold, divScratchValues_unfold]
   xperm_hyp hq
 
+/-- Derive per-limb V4 quotient conditions from the word equality. -/
+theorem fullDivN2_hdivs_v4_of_word_eq
+    (bltu_2 bltu_1 bltu_0 : Bool)
+    (a b : EvmWord) (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hdiv : fullDivN2QuotientWordV4 bltu_2 bltu_1 bltu_0
+      a0 a1 a2 a3 b0 b1 b2 b3 = EvmWord.div a b) :
+    (EvmWord.div a b).getLimbN 0 =
+      (fullDivN2R0V4 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).1 ∧
+    (EvmWord.div a b).getLimbN 1 =
+      (fullDivN2R1V4 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1 ∧
+    (EvmWord.div a b).getLimbN 2 =
+      (fullDivN2R2V4 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).1 ∧
+    (EvmWord.div a b).getLimbN 3 = (0 : Word) := by
+  refine ⟨?_, ?_, ?_, ?_⟩
+  · rw [← hdiv]; delta fullDivN2QuotientWordV4; exact EvmWord.getLimbN_fromLimbs_0
+  · rw [← hdiv]; delta fullDivN2QuotientWordV4; exact EvmWord.getLimbN_fromLimbs_1
+  · rw [← hdiv]; delta fullDivN2QuotientWordV4; exact EvmWord.getLimbN_fromLimbs_2
+  · rw [← hdiv]; delta fullDivN2QuotientWordV4; exact EvmWord.getLimbN_fromLimbs_3
+
+/-- Named callable-frame bridge for n=2: converts `fullDivN2UnifiedPostNoX1V4`
+    plus exact `x1` to `divStackDispatchPostCallableExactFrame` plus the v4
+    scratch cell. Mirrors `fullDivN3UnifiedPostNoX1V4_frame_to_divStack…_scratch`
+    in N3V4StackPre.lean:840. -/
+theorem fullDivN2UnifiedPostNoX1V4_frame_to_divStackDispatchPostCallableExactFrame_scratch
+    (bltu_2 bltu_1 bltu_0 : Bool)
+    (sp base : Word) (a b : EvmWord)
+    (a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (ha0 : a.getLimbN 0 = a0) (ha1 : a.getLimbN 1 = a1)
+    (ha2 : a.getLimbN 2 = a2) (ha3 : a.getLimbN 3 = a3)
+    (hdiv0 : (EvmWord.div a b).getLimbN 0 =
+      (fullDivN2R0V4 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).1)
+    (hdiv1 : (EvmWord.div a b).getLimbN 1 =
+      (fullDivN2R1V4 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1)
+    (hdiv2 : (EvmWord.div a b).getLimbN 2 =
+      (fullDivN2R2V4 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).1)
+    (hdiv3 : (EvmWord.div a b).getLimbN 3 = (0 : Word)) :
+    ∀ h,
+      (fullDivN2UnifiedPostNoX1V4 bltu_2 bltu_1 bltu_0 sp base
+        a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal)) h →
+      (divStackDispatchPostCallableExactFrame sp a b raVal
+        (signExtend12 4095 : Word) **
+       ((sp + signExtend12 3936) ↦ₘ
+        fullDivN2ScratchMemV4 bltu_2 bltu_1 bltu_0
+          a0 a1 a2 a3 b0 b1 b2 b3 scratchMem)) h := by
+  intro h hp
+  rw [divStackDispatchPostCallableExactFrame_unfold]
+  exact sepConj_mono_left
+    (fun h hp => divConcretePostNoX1ExactRegs_weaken_callable_frame sp a b h hp)
+    h
+    (fullDivN2UnifiedPostNoX1V4_frame_to_divConcretePostNoX1ExactRegsFrame_scratch
+      bltu_2 bltu_1 bltu_0 sp base a b
+      a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratchUn0 scratchMem
+      raVal ha0 ha1 ha2 ha3 hdiv0 hdiv1 hdiv2 hdiv3 h hp)
+
+/-- Word-quotient form: from `hdivWord : fullDivN2QuotientWordV4 ... = EvmWord.div a b`
+    directly. Mirrors `fullDivN3…_scratch_word` in N3V4StackPre.lean:875. -/
+theorem fullDivN2UnifiedPostNoX1V4_frame_to_divStackDispatchPostCallableExactFrame_scratch_word
+    (bltu_2 bltu_1 bltu_0 : Bool)
+    (sp base : Word) (a b : EvmWord)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (hdivWord : fullDivN2QuotientWordV4 bltu_2 bltu_1 bltu_0
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) =
+        EvmWord.div a b) :
+    ∀ h,
+      (fullDivN2UnifiedPostNoX1V4 bltu_2 bltu_1 bltu_0 sp base
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal)) h →
+      (divStackDispatchPostCallableExactFrame sp a b raVal
+        (signExtend12 4095 : Word) **
+       ((sp + signExtend12 3936) ↦ₘ
+        fullDivN2ScratchMemV4 bltu_2 bltu_1 bltu_0
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+          scratchMem)) h := by
+  obtain ⟨hdiv0, hdiv1, hdiv2, hdiv3⟩ :=
+    fullDivN2_hdivs_v4_of_word_eq bltu_2 bltu_1 bltu_0 a b
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+      hdivWord
+  exact fullDivN2UnifiedPostNoX1V4_frame_to_divStackDispatchPostCallableExactFrame_scratch
+    bltu_2 bltu_1 bltu_0 sp base a b
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+    retMem dMem dloMem scratchUn0 scratchMem raVal
+    rfl rfl rfl rfl hdiv0 hdiv1 hdiv2 hdiv3
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Extend `N2V4ConcretePostBridge.lean` with helper lemmas: per-limb derivation from `hdivWord`, combined bridge to `divStackDispatchPostCallableExactFrame`, word-quotient form
- Add `N2V4CallableExact.lean` with `evm_div_n2_stack_spec_noNop_v4_preNoX1_callableExactFrame_uni`: unified-bound n=2 DIV v4 body spec over `divCode_noNop_v4` with exact x1/x9 in post and `memOwn` for scratch

Theorem takes unified-post body (`hbody`) directly rather than exposing the ~250-line 4-case `hbltu_0` condition to avoid heartbeat timeouts.

Refs #61. Bead: evm-asm-9iqmw.2.3.

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.N2V4CallableExact
- lake build EvmAsm.Evm64.DivMod.Spec.N2V4ConcretePostBridge
- lake build EvmAsm.Evm64.DivMod.Spec
- lake build

Authored by @pirapira; implemented by Claude Code