### PR TITLE
feat(stateless): mpt_branch_node_encode (PR-K165) + Mpt cluster move

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -1461,93 +1461,8 @@ def ziskAddressComputeCreateProbeUnit : BuildUnit := {
   dataAsm     := ziskAddressComputeCreateDataSection
 }
 
-/-! ## mpt_account_path_nibbles -- PR-K100
+/-! ## K100 mpt_account_path_nibbles — moved to `Programs/Mpt.lean` (file-size hard cap). -/
 
-    Compute the state trie's path for a given 20-byte address:
-
-      digest   = keccak256(address)         # 32 bytes
-      nibbles  = unpack_high_low(digest)    # 64 nibbles
-
-    The MPT walks paths in nibble units (each byte = two
-    consecutive nibbles, high first). Account lookups in the state
-    trie use `keccak256(address)` as the path key, expressed as 64
-    nibbles. PR-K24 `mpt_walk` consumes such a nibble array; this
-    helper produces it from an address in one call.
-
-    Storage slots use the analogous `keccak256(slot_key_BE)` path;
-    K100 also handles that case directly when callers feed in a
-    32-byte slot key (see calling convention).
-
-    Composes PR-K3 `zkvm_keccak256`. Uses 32 bytes of `.data`
-    scratch (`mapn_digest`).
-
-    Calling convention:
-      a0 (input)  : address (or slot key) ptr
-      a1 (input)  : input length (20 for address, 32 for slot key)
-      a2 (input)  : 64-byte nibble output ptr
-      ra (input)  : return
-      a0 (output) : 0 (always succeeds). -/
-def mptAccountPathNibblesFunction : String :=
-  "mpt_account_path_nibbles:\n" ++
-  "  addi sp, sp, -16\n" ++
-  "  sd ra,  0(sp)\n" ++
-  "  sd s0,  8(sp)\n" ++
-  "  mv s0, a2                   # nibble output ptr (stash)\n" ++
-  "  # keccak256(input, len) → mapn_digest\n" ++
-  "  la a2, mapn_digest\n" ++
-  "  jal ra, zkvm_keccak256\n" ++
-  "  # Unpack 32 bytes → 64 nibbles.\n" ++
-  "  la t0, mapn_digest\n" ++
-  "  mv t1, s0                   # cursor over output\n" ++
-  "  li t2, 32                   # remaining bytes\n" ++
-  ".Lmapn_loop:\n" ++
-  "  beqz t2, .Lmapn_done\n" ++
-  "  lbu t3, 0(t0)\n" ++
-  "  srli t4, t3, 4              # high nibble\n" ++
-  "  andi t5, t3, 15             # low nibble\n" ++
-  "  sb t4, 0(t1)\n" ++
-  "  sb t5, 1(t1)\n" ++
-  "  addi t0, t0, 1\n" ++
-  "  addi t1, t1, 2\n" ++
-  "  addi t2, t2, -1\n" ++
-  "  j .Lmapn_loop\n" ++
-  ".Lmapn_done:\n" ++
-  "  li a0, 0\n" ++
-  "  ld ra,  0(sp)\n" ++
-  "  ld s0,  8(sp)\n" ++
-  "  addi sp, sp, 16\n" ++
-  "  ret"
-
-/-- `zisk_mpt_account_path_nibbles`: probe BuildUnit. Reads
-    (input_len, input_bytes) from host input, writes (status, 64
-    nibbles) to OUTPUT (72 bytes total). -/
-def ziskMptAccountPathNibblesPrologue : String :=
-  "  li sp, 0xa0050000\n" ++
-  "  li a3, 0x40000000\n" ++
-  "  ld a1, 8(a3)                # input length\n" ++
-  "  addi a0, a3, 16             # input ptr\n" ++
-  "  li a2, 0xa0010008           # 64-byte nibble output\n" ++
-  "  jal ra, mpt_account_path_nibbles\n" ++
-  "  li t0, 0xa0010000\n" ++
-  "  sd a0, 0(t0)\n" ++
-  "  j .Lmapn_pdone\n" ++
-  zkvmKeccak256Function ++ "\n" ++
-  mptAccountPathNibblesFunction ++ "\n" ++
-  ".Lmapn_pdone:"
-
-def ziskMptAccountPathNibblesDataSection : String :=
-  ".section .data\n" ++
-  "zk3_state:\n" ++
-  "  .zero 200\n" ++
-  ".balign 8\n" ++
-  "mapn_digest:\n" ++
-  "  .zero 32"
-
-def ziskMptAccountPathNibblesProbeUnit : BuildUnit := {
-  body        := NOP
-  prologueAsm := ziskMptAccountPathNibblesPrologue
-  dataAsm     := ziskMptAccountPathNibblesDataSection
-}
 
 /-! ## headers_validate_chain -- PR-K18 parent_hash chain check
 
@@ -1686,184 +1601,7 @@ def ziskHeadersValidateChainProbeUnit : BuildUnit := {
   dataAsm     := ziskHeadersValidateChainDataSection
 }
 
-/-! ## witness_lookup_by_hash -- PR-K19 (linear-scan flavour)
-
-    Find the entry in an SSZ list section whose keccak256 digest
-    matches a caller-supplied target hash. Returns the matched
-    entry's (offset, length) within the section, or status=1 on
-    miss.
-
-    Calling convention:
-      a0 (input)  : SSZ list section ptr (witness.state /
-                    witness.codes shape)
-      a1 (input)  : section_len (0 ⇒ guaranteed miss)
-      a2 (input)  : 32-byte target hash ptr
-      a3 (input)  : u64 out ptr (matched entry's byte offset
-                    within the section; meaningful only on hit)
-      a4 (input)  : u64 out ptr (matched entry's byte length;
-                    meaningful only on hit)
-      ra (input)  : return
-      a0 (output) : 0 on hit, 1 on miss
-
-    Walks every element computing `keccak256(element_bytes)`
-    until either a match is found or the list is exhausted.
-    O(N) per call; PR-K20+ will replace with a pre-built bucket
-    table for O(1) average lookups. -/
-def witnessLookupByHashFunction : String :=
-  "witness_lookup_by_hash:\n" ++
-  "  addi sp, sp, -64\n" ++
-  "  sd ra,  0(sp)\n" ++
-  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp)\n" ++
-  "  sd s3, 32(sp); sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp)\n" ++
-  "  mv s0, a0                  # section ptr\n" ++
-  "  mv s1, a1                  # section_len\n" ++
-  "  mv s2, a2                  # target_hash ptr\n" ++
-  "  mv s3, a3                  # out_offset ptr\n" ++
-  "  mv s4, a4                  # out_length ptr\n" ++
-  "  beqz s1, .Lwlh_miss        # empty section ⇒ miss\n" ++
-  "  lwu t0, 0(s0)              # first inner offset = 4 * N\n" ++
-  "  srli s5, t0, 2             # s5 = N\n" ++
-  "  li s6, 0                   # s6 = i\n" ++
-  ".Lwlh_loop:\n" ++
-  "  beq s6, s5, .Lwlh_miss\n" ++
-  "  # Compute element i bounds.\n" ++
-  "  slli t0, s6, 2             # 4*i\n" ++
-  "  add t1, s0, t0\n" ++
-  "  lwu t2, 0(t1)              # inner_off_i\n" ++
-  "  add a0, s0, t2             # el_i_start\n" ++
-  "  addi t3, s6, 1\n" ++
-  "  beq t3, s5, .Lwlh_use_end\n" ++
-  "  slli t3, t3, 2             # 4*(i+1)\n" ++
-  "  add t3, s0, t3\n" ++
-  "  lwu t4, 0(t3)\n" ++
-  "  add t4, s0, t4             # el_i_end\n" ++
-  "  j .Lwlh_have_end\n" ++
-  ".Lwlh_use_end:\n" ++
-  "  add t4, s0, s1             # el_i_end = section_end\n" ++
-  ".Lwlh_have_end:\n" ++
-  "  sub a1, t4, a0             # el_i_len\n" ++
-  "  la a2, wlh_scratch_hash\n" ++
-  "  jal ra, zkvm_keccak256\n" ++
-  "  # Compare scratch_hash vs target_hash.\n" ++
-  "  la t0, wlh_scratch_hash\n" ++
-  "  mv t1, s2\n" ++
-  "  ld t2,  0(t0); ld t3,  0(t1); bne t2, t3, .Lwlh_no_match\n" ++
-  "  ld t2,  8(t0); ld t3,  8(t1); bne t2, t3, .Lwlh_no_match\n" ++
-  "  ld t2, 16(t0); ld t3, 16(t1); bne t2, t3, .Lwlh_no_match\n" ++
-  "  ld t2, 24(t0); ld t3, 24(t1); bne t2, t3, .Lwlh_no_match\n" ++
-  "  # Match. Recompute (offset, length) from i (clobbered above).\n" ++
-  "  slli t0, s6, 2\n" ++
-  "  add t1, s0, t0\n" ++
-  "  lwu t2, 0(t1)              # inner_off_i\n" ++
-  "  sd t2, 0(s3)               # *out_offset = inner_off_i\n" ++
-  "  addi t3, s6, 1\n" ++
-  "  beq t3, s5, .Lwlh_last_len\n" ++
-  "  slli t3, t3, 2\n" ++
-  "  add t3, s0, t3\n" ++
-  "  lwu t4, 0(t3)\n" ++
-  "  sub t4, t4, t2             # length = inner_off_{i+1} - inner_off_i\n" ++
-  "  j .Lwlh_store_len\n" ++
-  ".Lwlh_last_len:\n" ++
-  "  sub t4, s1, t2             # length = section_len - inner_off_i\n" ++
-  ".Lwlh_store_len:\n" ++
-  "  sd t4, 0(s4)\n" ++
-  "  li a0, 0                   # hit\n" ++
-  "  j .Lwlh_ret\n" ++
-  ".Lwlh_no_match:\n" ++
-  "  addi s6, s6, 1\n" ++
-  "  j .Lwlh_loop\n" ++
-  ".Lwlh_miss:\n" ++
-  "  li a0, 1                   # miss\n" ++
-  ".Lwlh_ret:\n" ++
-  "  ld ra,  0(sp)\n" ++
-  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp)\n" ++
-  "  ld s3, 32(sp); ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp)\n" ++
-  "  addi sp, sp, 64\n" ++
-  "  ret"
-
-/-- `zisk_witness_lookup_by_hash`: probe BuildUnit. Reads
-    (section_len, target_hash, section_bytes) from host input,
-    writes (status, offset, length) to OUTPUT.
-    Input layout:
-      bytes  0.. 8 : section_len (u64)
-      bytes  8..40 : target_hash (32 bytes)
-      bytes 40..   : SSZ list section bytes
-    Output layout:
-      bytes  0.. 8 : status (u64; 0 hit, 1 miss)
-      bytes  8..16 : matched entry offset within section (u64)
-      bytes 16..24 : matched entry length (u64) -/
-def ziskWitnessLookupByHashPrologue : String :=
-  "  li sp, 0xa0050000\n" ++
-  "  li a5, 0x40000000\n" ++
-  "  ld a1, 8(a5)                # section_len\n" ++
-  "  addi a2, a5, 16             # target_hash ptr\n" ++
-  "  addi a0, a5, 48             # section ptr\n" ++
-  "  li a3, 0xa0010008           # out_offset (OUTPUT + 8)\n" ++
-  "  li a4, 0xa0010010           # out_length (OUTPUT + 16)\n" ++
-  "  # Pre-zero offset/length so a miss surfaces as zeros.\n" ++
-  "  sd zero, 0(a3)\n" ++
-  "  sd zero, 0(a4)\n" ++
-  "  jal ra, witness_lookup_by_hash\n" ++
-  "  li t0, 0xa0010000\n" ++
-  "  sd a0, 0(t0)                # status at OUTPUT + 0\n" ++
-  "  j .Lwlh_pdone\n" ++
-  zkvmKeccak256Function ++ "\n" ++
-  witnessLookupByHashFunction ++ "\n" ++
-  ".Lwlh_pdone:"
-
-def ziskWitnessLookupByHashDataSection : String :=
-  ".section .data\n" ++
-  ".balign 8\n" ++
-  "zk3_state:\n" ++
-  "  .zero 200\n" ++
-  ".balign 32\n" ++
-  "wlh_scratch_hash:\n" ++
-  "  .zero 32"
-
-def ziskWitnessLookupByHashProbeUnit : BuildUnit := {
-  body        := NOP
-  prologueAsm := ziskWitnessLookupByHashPrologue
-  dataAsm     := ziskWitnessLookupByHashDataSection
-}
-
-
-/-- `zisk_rlp_list_nth_item`: probe BuildUnit. Reads
-    (list_len, N, list_bytes) from host input, writes
-    (status, offset, length) to OUTPUT.
-    Input layout:
-      bytes  0.. 8 : list_len (u64)
-      bytes  8..16 : N (u64)
-      bytes 16..   : RLP list bytes
-    Output layout:
-      bytes  0.. 8 : status (0 hit / 1 miss)
-      bytes  8..16 : content offset (u64)
-      bytes 16..24 : content length (u64) -/
-def ziskRlpListNthItemPrologue : String :=
-  "  li sp, 0xa0050000\n" ++
-  "  li a5, 0x40000000\n" ++
-  "  ld a1, 8(a5)                # list_len\n" ++
-  "  ld a2, 16(a5)               # N\n" ++
-  "  addi a0, a5, 24             # list ptr\n" ++
-  "  li a3, 0xa0010008\n" ++
-  "  li a4, 0xa0010010\n" ++
-  "  sd zero, 0(a3); sd zero, 0(a4)\n" ++
-  "  jal ra, rlp_list_nth_item\n" ++
-  "  li t0, 0xa0010000\n" ++
-  "  sd a0, 0(t0)\n" ++
-  "  j .Lrln_pdone\n" ++
-  rlpListNthItemFunction ++ "\n" ++
-  ".Lrln_pdone:"
-
-def ziskRlpListNthItemDataSection : String :=
-  ".section .data\n" ++
-  "rln_scratch:\n" ++
-  "  .zero 8"
-
-def ziskRlpListNthItemProbeUnit : BuildUnit := {
-  body        := NOP
-  prologueAsm := ziskRlpListNthItemPrologue
-  dataAsm     := ziskRlpListNthItemDataSection
-}
+/-! ## K19 witness_lookup_by_hash — moved to `Programs/Mpt.lean` (file-size hard cap). -/
 
 /-! ## account_validate_code_hash -- PR-K98
 
@@ -3115,981 +2853,7 @@ def ziskAccessListCountProbeUnit : BuildUnit := {
 
 /-! ## K64 blob_gas_used_from_versioned_hashes — moved to `Programs/Tx.lean` (file-size hard cap). -/
 
-/-! ## mpt_node_kind -- PR-K21 classifier
-
-    Determines whether an RLP-encoded MPT node is a leaf,
-    extension, or branch by:
-      1. Probing whether item 2 exists (presence = 17-item
-         branch list).
-      2. If absent, reading item 0's first byte and inspecting
-         the high nibble (HP encoding flag: 0/1 → extension,
-         2/3 → leaf).
-
-    Calling convention:
-      a0 (input)  : node bytes ptr
-      a1 (input)  : node byte length
-      ra (input)  : return
-      a0 (output) : 0 branch / 1 extension / 2 leaf / 3 parse fail
-
-    Calls `rlp_list_nth_item` twice. Uses four 8-byte `.data`
-    scratches (`mnk_dummy_offset`, `mnk_dummy_length`,
-    `mnk_path_offset`, `mnk_path_length`) for the temporary
-    returns. -/
-def mptNodeKindFunction : String :=
-  "mpt_node_kind:\n" ++
-  "  addi sp, sp, -32\n" ++
-  "  sd ra,  0(sp)\n" ++
-  "  sd s0,  8(sp); sd s1, 16(sp)\n" ++
-  "  mv s0, a0                  # node ptr\n" ++
-  "  mv s1, a1                  # node_len\n" ++
-  "  # Probe item 2 (index 2). If found ⇒ 17-item branch list.\n" ++
-  "  li a2, 2\n" ++
-  "  la a3, mnk_dummy_offset\n" ++
-  "  la a4, mnk_dummy_length\n" ++
-  "  jal ra, rlp_list_nth_item\n" ++
-  "  beqz a0, .Lmnk_branch\n" ++
-  "  # Item 2 absent ⇒ 2-item list (leaf or extension).\n" ++
-  "  # Get item 0 to read path's first byte.\n" ++
-  "  mv a0, s0\n" ++
-  "  mv a1, s1\n" ++
-  "  li a2, 0\n" ++
-  "  la a3, mnk_path_offset\n" ++
-  "  la a4, mnk_path_length\n" ++
-  "  jal ra, rlp_list_nth_item\n" ++
-  "  bnez a0, .Lmnk_fail        # item 0 missing ⇒ parse fail\n" ++
-  "  la t0, mnk_path_offset\n" ++
-  "  ld t1, 0(t0)               # path content offset\n" ++
-  "  la t0, mnk_path_length\n" ++
-  "  ld t2, 0(t0)               # path content length\n" ++
-  "  beqz t2, .Lmnk_fail        # empty path ⇒ malformed HP\n" ++
-  "  add t3, s0, t1             # path byte ptr\n" ++
-  "  lbu t4, 0(t3)\n" ++
-  "  srli t4, t4, 4             # high nibble\n" ++
-  "  li t5, 2\n" ++
-  "  bltu t4, t5, .Lmnk_extension  # 0,1 → extension\n" ++
-  "  li t5, 4\n" ++
-  "  bltu t4, t5, .Lmnk_leaf       # 2,3 → leaf\n" ++
-  "  j .Lmnk_fail                   # ≥ 4 → invalid HP\n" ++
-  ".Lmnk_branch:\n" ++
-  "  li a0, 0\n" ++
-  "  j .Lmnk_ret\n" ++
-  ".Lmnk_extension:\n" ++
-  "  li a0, 1\n" ++
-  "  j .Lmnk_ret\n" ++
-  ".Lmnk_leaf:\n" ++
-  "  li a0, 2\n" ++
-  "  j .Lmnk_ret\n" ++
-  ".Lmnk_fail:\n" ++
-  "  li a0, 3\n" ++
-  ".Lmnk_ret:\n" ++
-  "  ld ra,  0(sp)\n" ++
-  "  ld s0,  8(sp); ld s1, 16(sp)\n" ++
-  "  addi sp, sp, 32\n" ++
-  "  ret"
-
-/-- `zisk_mpt_node_kind`: probe BuildUnit. Reads
-    (node_len, node_bytes) from host input, writes
-    classification result to OUTPUT.
-    Input layout:
-      bytes  0.. 8 : node_len (u64)
-      bytes  8..   : node bytes
-    Output layout:
-      bytes  0.. 8 : kind (u64; 0 branch / 1 ext / 2 leaf / 3 fail) -/
-def ziskMptNodeKindPrologue : String :=
-  "  li sp, 0xa0050000\n" ++
-  "  li a3, 0x40000000\n" ++
-  "  ld a1, 8(a3)                # node_len\n" ++
-  "  addi a0, a3, 16             # node ptr\n" ++
-  "  jal ra, mpt_node_kind\n" ++
-  "  li t0, 0xa0010000\n" ++
-  "  sd a0, 0(t0)                # write kind\n" ++
-  "  j .Lmnk_pdone\n" ++
-  rlpListNthItemFunction ++ "\n" ++
-  mptNodeKindFunction ++ "\n" ++
-  ".Lmnk_pdone:"
-
-def ziskMptNodeKindDataSection : String :=
-  ".section .data\n" ++
-  ".balign 8\n" ++
-  "mnk_dummy_offset:\n" ++
-  "  .zero 8\n" ++
-  "mnk_dummy_length:\n" ++
-  "  .zero 8\n" ++
-  "mnk_path_offset:\n" ++
-  "  .zero 8\n" ++
-  "mnk_path_length:\n" ++
-  "  .zero 8"
-
-def ziskMptNodeKindProbeUnit : BuildUnit := {
-  body        := NOP
-  prologueAsm := ziskMptNodeKindPrologue
-  dataAsm     := ziskMptNodeKindDataSection
-}
-
-/-! ## mpt_branch_child -- PR-K22 extract i-th child of a branch
-
-    Wraps `rlp_list_nth_item` with a branch-shape-aware
-    interpretation of the returned content. Ethereum MPT branch
-    nodes have items 0..15 each being one of:
-
-      * 32-byte hash       (Bytes32: 0xa0 + 32 raw bytes)
-      * empty bytes        (RLP 0x80)
-      * inlined RLP node   (variable bytes, < 32 bytes total)
-
-    Calling convention:
-      a0 (input)  : branch node bytes ptr
-      a1 (input)  : node byte length
-      a2 (input)  : nibble (0..15)
-      a3 (input)  : 32-byte output buffer ptr
-      ra (input)  : return
-      a0 (output) :
-        0 = hash slot (32 bytes copied to *a3)
-        1 = empty slot (output buffer zeroed)
-        2 = inlined RLP node (output buffer holds first ≤ 32
-            bytes of the inlined form, zero-padded)
-        3 = parse failure (nibble out of range or node
-            malformed)
-
-    Does NOT verify the caller has actually given a branch
-    node; if applied to a 2-item leaf/extension, items 0 and 1
-    are returned according to the same length-driven rules but
-    the semantics aren't branch-children. -/
-def mptBranchChildFunction : String :=
-  "mpt_branch_child:\n" ++
-  "  addi sp, sp, -48\n" ++
-  "  sd ra,  0(sp)\n" ++
-  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
-  "  mv s0, a0                  # node ptr\n" ++
-  "  mv s1, a1                  # node_len\n" ++
-  "  mv s2, a2                  # nibble\n" ++
-  "  mv s3, a3                  # out ptr\n" ++
-  "  li t0, 16\n" ++
-  "  bgeu s2, t0, .Lmbc_fail    # nibble ≥ 16 → out of range\n" ++
-  "  # Call rlp_list_nth_item(node, len, nibble, &mbc_offset, &mbc_length).\n" ++
-  "  mv a0, s0; mv a1, s1; mv a2, s2\n" ++
-  "  la a3, mbc_offset\n" ++
-  "  la a4, mbc_length\n" ++
-  "  jal ra, rlp_list_nth_item\n" ++
-  "  bnez a0, .Lmbc_fail\n" ++
-  "  la t0, mbc_length\n" ++
-  "  ld t1, 0(t0)\n" ++
-  "  beqz t1, .Lmbc_empty       # length 0 ⇒ empty slot\n" ++
-  "  li t0, 32\n" ++
-  "  bne t1, t0, .Lmbc_inlined  # length != 32 ⇒ inlined\n" ++
-  "  # Hash slot: copy 32 bytes from node + offset to out.\n" ++
-  "  la t0, mbc_offset\n" ++
-  "  ld t2, 0(t0)\n" ++
-  "  add t2, s0, t2             # src\n" ++
-  "  ld t3,  0(t2); sd t3,  0(s3)\n" ++
-  "  ld t3,  8(t2); sd t3,  8(s3)\n" ++
-  "  ld t3, 16(t2); sd t3, 16(s3)\n" ++
-  "  ld t3, 24(t2); sd t3, 24(s3)\n" ++
-  "  li a0, 0\n" ++
-  "  j .Lmbc_ret\n" ++
-  ".Lmbc_empty:\n" ++
-  "  sd zero,  0(s3); sd zero,  8(s3)\n" ++
-  "  sd zero, 16(s3); sd zero, 24(s3)\n" ++
-  "  li a0, 1\n" ++
-  "  j .Lmbc_ret\n" ++
-  ".Lmbc_inlined:\n" ++
-  "  # Length 1..31. Zero the output, then byte-copy `length` bytes.\n" ++
-  "  sd zero,  0(s3); sd zero,  8(s3)\n" ++
-  "  sd zero, 16(s3); sd zero, 24(s3)\n" ++
-  "  la t0, mbc_offset\n" ++
-  "  ld t2, 0(t0)\n" ++
-  "  add t2, s0, t2             # src cursor\n" ++
-  "  mv t3, s3                  # dst cursor\n" ++
-  ".Lmbc_inline_cp:\n" ++
-  "  beqz t1, .Lmbc_inline_done\n" ++
-  "  lbu t4, 0(t2)\n" ++
-  "  sb  t4, 0(t3)\n" ++
-  "  addi t2, t2, 1\n" ++
-  "  addi t3, t3, 1\n" ++
-  "  addi t1, t1, -1\n" ++
-  "  j .Lmbc_inline_cp\n" ++
-  ".Lmbc_inline_done:\n" ++
-  "  li a0, 2\n" ++
-  "  j .Lmbc_ret\n" ++
-  ".Lmbc_fail:\n" ++
-  "  sd zero,  0(s3); sd zero,  8(s3)\n" ++
-  "  sd zero, 16(s3); sd zero, 24(s3)\n" ++
-  "  li a0, 3\n" ++
-  ".Lmbc_ret:\n" ++
-  "  ld ra,  0(sp)\n" ++
-  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
-  "  addi sp, sp, 48\n" ++
-  "  ret"
-
-/-- `zisk_mpt_branch_child`: probe BuildUnit. Reads
-    (node_len, nibble, node_bytes) from host input, writes
-    (status, 32-byte content) to OUTPUT.
-    Input layout:
-      bytes  0.. 8 : node_len (u64)
-      bytes  8..16 : nibble (u64)
-      bytes 16..   : node bytes
-    Output layout:
-      bytes  0.. 8 : status (0 hash / 1 empty / 2 inlined / 3 fail)
-      bytes  8..40 : 32-byte content (hash, zeros, or inlined bytes) -/
-def ziskMptBranchChildPrologue : String :=
-  "  li sp, 0xa0050000\n" ++
-  "  li a4, 0x40000000\n" ++
-  "  ld a1, 8(a4)                # node_len\n" ++
-  "  ld a2, 16(a4)               # nibble\n" ++
-  "  addi a0, a4, 24             # node ptr\n" ++
-  "  li a3, 0xa0010008           # 32-byte out at OUTPUT + 8\n" ++
-  "  jal ra, mpt_branch_child\n" ++
-  "  li t0, 0xa0010000\n" ++
-  "  sd a0, 0(t0)                # status\n" ++
-  "  j .Lmbc_pdone\n" ++
-  rlpListNthItemFunction ++ "\n" ++
-  mptBranchChildFunction ++ "\n" ++
-  ".Lmbc_pdone:"
-
-def ziskMptBranchChildDataSection : String :=
-  ".section .data\n" ++
-  ".balign 8\n" ++
-  "mbc_offset:\n" ++
-  "  .zero 8\n" ++
-  "mbc_length:\n" ++
-  "  .zero 8"
-
-def ziskMptBranchChildProbeUnit : BuildUnit := {
-  body        := NOP
-  prologueAsm := ziskMptBranchChildPrologue
-  dataAsm     := ziskMptBranchChildDataSection
-}
-
-/-! ## hp_decode_nibbles -- PR-K23 HP-encoded path → nibble array
-
-    Decode the HP-encoded first item of a leaf/extension MPT
-    node into an array of one-nibble bytes (each ∈ [0..15]).
-    Also returns whether the node is a leaf or extension.
-
-    HP encoding cheat-sheet (input byte 0):
-      high nibble  meaning
-      ----------   -------
-         0         extension, even path length (low nibble must be 0)
-         1         extension, odd path length (low nibble is first path nibble)
-         2         leaf, even path length (low nibble must be 0)
-         3         leaf, odd path length (low nibble is first path nibble)
-      anything else → invalid
-
-    Remaining input bytes hold 2 nibbles each (high, then low),
-    contributing to the output starting at the next slot.
-
-    Calling convention:
-      a0 (input)  : HP-encoded path bytes ptr
-      a1 (input)  : path byte length
-      a2 (input)  : output nibble buffer (caller-allocated;
-                    holds up to 2 * (a1 - 1) + 1 bytes,
-                    one byte per nibble)
-      a3 (input)  : u64 out ptr (number of nibbles emitted)
-      a4 (input)  : u64 out ptr (is_leaf flag: 0 = ext, 1 = leaf)
-      ra (input)  : return
-      a0 (output) : 0 success, 1 parse failure (empty input,
-                    high nibble ≥ 4, or even path with non-zero
-                    low nibble of byte 0).
-
-    Each output byte holds one nibble in its low 4 bits; the
-    high 4 bits are zero. This is the format consumed by future
-    `mpt_walk` (PR-K24) which compares one byte per nibble. -/
-def hpDecodeNibblesFunction : String :=
-  "hp_decode_nibbles:\n" ++
-  "  addi sp, sp, -48\n" ++
-  "  sd ra,  0(sp)\n" ++
-  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp)\n" ++
-  "  sd s3, 32(sp); sd s4, 40(sp)\n" ++
-  "  mv s0, a0                  # path_bytes ptr\n" ++
-  "  mv s1, a1                  # len\n" ++
-  "  mv s2, a2                  # out nibble buf\n" ++
-  "  mv s3, a3                  # out count ptr\n" ++
-  "  mv s4, a4                  # out is_leaf ptr\n" ++
-  "  beqz s1, .Lhp_fail\n" ++
-  "  lbu t0, 0(s0)              # b0\n" ++
-  "  srli t1, t0, 4             # high nibble\n" ++
-  "  andi t2, t0, 0xf           # low nibble\n" ++
-  "  li t3, 4\n" ++
-  "  bgeu t1, t3, .Lhp_fail     # high ≥ 4 → invalid\n" ++
-  "  # is_leaf = (high & 2) >> 1\n" ++
-  "  andi t3, t1, 2\n" ++
-  "  srli t3, t3, 1\n" ++
-  "  sd t3, 0(s4)\n" ++
-  "  # is_odd = high & 1\n" ++
-  "  andi t1, t1, 1\n" ++
-  "  beqz t1, .Lhp_even\n" ++
-  "  # Odd: write low as first output nibble.\n" ++
-  "  sb t2, 0(s2)\n" ++
-  "  li t5, 1                   # nibble count so far\n" ++
-  "  addi t6, s2, 1             # output cursor\n" ++
-  "  j .Lhp_loop_init\n" ++
-  ".Lhp_even:\n" ++
-  "  bnez t2, .Lhp_fail         # even but low nibble != 0\n" ++
-  "  li t5, 0\n" ++
-  "  mv t6, s2\n" ++
-  ".Lhp_loop_init:\n" ++
-  "  li t0, 1                   # i = 1\n" ++
-  ".Lhp_loop:\n" ++
-  "  bgeu t0, s1, .Lhp_done\n" ++
-  "  add t1, s0, t0\n" ++
-  "  lbu t2, 0(t1)\n" ++
-  "  srli t3, t2, 4\n" ++
-  "  andi t4, t2, 0xf\n" ++
-  "  sb t3, 0(t6)\n" ++
-  "  sb t4, 1(t6)\n" ++
-  "  addi t6, t6, 2\n" ++
-  "  addi t5, t5, 2\n" ++
-  "  addi t0, t0, 1\n" ++
-  "  j .Lhp_loop\n" ++
-  ".Lhp_done:\n" ++
-  "  sd t5, 0(s3)\n" ++
-  "  li a0, 0\n" ++
-  "  j .Lhp_ret\n" ++
-  ".Lhp_fail:\n" ++
-  "  li a0, 1\n" ++
-  ".Lhp_ret:\n" ++
-  "  ld ra,  0(sp)\n" ++
-  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp)\n" ++
-  "  ld s3, 32(sp); ld s4, 40(sp)\n" ++
-  "  addi sp, sp, 48\n" ++
-  "  ret"
-
-/-- `zisk_hp_decode_nibbles`: probe BuildUnit. Reads
-    (path_len, path_bytes) from host input, writes
-    (status, count, is_leaf, nibbles...) to OUTPUT.
-    Input layout:
-      bytes  0.. 8 : path_len (u64)
-      bytes  8..   : HP-encoded path bytes
-    Output layout:
-      bytes  0.. 8 : status (u64; 0 ok, 1 fail)
-      bytes  8..16 : nibble count (u64)
-      bytes 16..24 : is_leaf (u64)
-      bytes 24..   : nibble bytes (count bytes; each in [0..15]) -/
-def ziskHpDecodeNibblesPrologue : String :=
-  "  li sp, 0xa0050000\n" ++
-  "  li a4, 0x40000000\n" ++
-  "  ld a1, 8(a4)                # path_len\n" ++
-  "  addi a0, a4, 16             # path bytes ptr\n" ++
-  "  li a2, 0xa0010018           # nibble buf at OUTPUT + 24\n" ++
-  "  li a3, 0xa0010008           # count ptr at OUTPUT + 8\n" ++
-  "  li a4, 0xa0010010           # is_leaf ptr at OUTPUT + 16\n" ++
-  "  jal ra, hp_decode_nibbles\n" ++
-  "  li t0, 0xa0010000\n" ++
-  "  sd a0, 0(t0)                # status at OUTPUT + 0\n" ++
-  "  j .Lhp_pdone\n" ++
-  hpDecodeNibblesFunction ++ "\n" ++
-  ".Lhp_pdone:"
-
-def ziskHpDecodeNibblesDataSection : String :=
-  ".section .data\n" ++
-  "hp_pad:\n" ++
-  "  .zero 8"
-
-def ziskHpDecodeNibblesProbeUnit : BuildUnit := {
-  body        := NOP
-  prologueAsm := ziskHpDecodeNibblesPrologue
-  dataAsm     := ziskHpDecodeNibblesDataSection
-}
-
-/-! ## mpt_walk -- PR-K24 end-to-end MPT lookup
-
-    Compose every K-stack primitive into a single
-    `mpt_walk(root, witness, path) → value` entry. Walks the
-    branch / extension / leaf chain following nibble path
-    elements.
-
-    Calling convention:
-      a0 (input)  : root_hash ptr (32 bytes)
-      a1 (input)  : witness.state SSZ list section ptr
-      a2 (input)  : witness section_len
-      a3 (input)  : path_nibbles ptr (one byte per nibble)
-      a4 (input)  : path_nibbles_len
-      a5 (input)  : value output buffer ptr (256 bytes)
-      a6 (input)  : u64 out ptr (matched value byte length)
-      ra (input)  : return
-      a0 (output) : 0 (found) / 1 (not found) / 2 (parse error)
-
-    Calls itself transitively via PR-K19..K23 primitives.
-    Uses a 256-byte mw_value_buf for the output and ~200 B of
-    additional scratch state. -/
-def mptWalkFunction : String :=
-  "mpt_walk:\n" ++
-  "  addi sp, sp, -80\n" ++
-  "  sd ra,  0(sp)\n" ++
-  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
-  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp); sd s7, 64(sp)\n" ++
-  "  sd s8, 72(sp)\n" ++
-  "  mv s0, a1                   # s0 = witness ptr\n" ++
-  "  mv s1, a2                   # s1 = witness_len\n" ++
-  "  mv s2, a3                   # s2 = path_nibbles ptr\n" ++
-  "  mv s3, a4                   # s3 = path_nibbles_len\n" ++
-  "  mv s4, a5                   # s4 = value out buf\n" ++
-  "  mv s5, a6                   # s5 = value_len out ptr\n" ++
-  "  # Copy root_hash to mw_lookup_hash for the first lookup.\n" ++
-  "  la t0, mw_lookup_hash\n" ++
-  "  ld t1,  0(a0); sd t1,  0(t0)\n" ++
-  "  ld t1,  8(a0); sd t1,  8(t0)\n" ++
-  "  ld t1, 16(a0); sd t1, 16(t0)\n" ++
-  "  ld t1, 24(a0); sd t1, 24(t0)\n" ++
-  "  # First lookup of root_hash in witness.\n" ++
-  "  mv a0, s0\n" ++
-  "  mv a1, s1\n" ++
-  "  la a2, mw_lookup_hash\n" ++
-  "  la a3, mw_lookup_offset\n" ++
-  "  la a4, mw_lookup_length\n" ++
-  "  jal ra, witness_lookup_by_hash\n" ++
-  "  bnez a0, .Lmw_not_found\n" ++
-  "  # s7 = current node ptr; s8 = current node len; s6 = consumed nibbles.\n" ++
-  "  la t0, mw_lookup_offset; ld t1, 0(t0); add s7, s0, t1\n" ++
-  "  la t0, mw_lookup_length; ld s8, 0(t0)\n" ++
-  "  li s6, 0\n" ++
-  ".Lmw_loop:\n" ++
-  "  mv a0, s7\n" ++
-  "  mv a1, s8\n" ++
-  "  jal ra, mpt_node_kind\n" ++
-  "  beqz a0, .Lmw_branch\n" ++
-  "  li t0, 1; beq a0, t0, .Lmw_extension\n" ++
-  "  li t0, 2; beq a0, t0, .Lmw_leaf\n" ++
-  "  j .Lmw_parse_fail\n" ++
-  ".Lmw_branch:\n" ++
-  "  beq s6, s3, .Lmw_branch_end\n" ++
-  "  # Get child slot via rlp_list_nth_item (bypass mpt_branch_child so we\n" ++
-  "  # can keep the actual inlined byte count, not zero-padded to 32).\n" ++
-  "  add t0, s2, s6              # &path[consumed]\n" ++
-  "  lbu t1, 0(t0)\n" ++
-  "  mv a0, s7\n" ++
-  "  mv a1, s8\n" ++
-  "  mv a2, t1                   # nibble (item index)\n" ++
-  "  la a3, mw_child_offset\n" ++
-  "  la a4, mw_child_length\n" ++
-  "  jal ra, rlp_list_nth_item\n" ++
-  "  addi s6, s6, 1\n" ++
-  "  bnez a0, .Lmw_parse_fail\n" ++
-  "  la t0, mw_child_length; ld t1, 0(t0)\n" ++
-  "  beqz t1, .Lmw_not_found      # empty slot\n" ++
-  "  li t2, 32\n" ++
-  "  beq t1, t2, .Lmw_branch_hash\n" ++
-  "  # Inlined (length 1..31): set node to (s7 + child_offset, child_length).\n" ++
-  "  la t0, mw_child_offset; ld t2, 0(t0)\n" ++
-  "  add s7, s7, t2\n" ++
-  "  mv s8, t1\n" ++
-  "  j .Lmw_loop\n" ++
-  ".Lmw_branch_hash:\n" ++
-  "  # 32-byte hash: copy to mw_lookup_hash then lookup.\n" ++
-  "  la t0, mw_child_offset; ld t1, 0(t0)\n" ++
-  "  add t2, s7, t1\n" ++
-  "  la t3, mw_lookup_hash\n" ++
-  "  ld t4,  0(t2); sd t4,  0(t3)\n" ++
-  "  ld t4,  8(t2); sd t4,  8(t3)\n" ++
-  "  ld t4, 16(t2); sd t4, 16(t3)\n" ++
-  "  ld t4, 24(t2); sd t4, 24(t3)\n" ++
-  "  mv a0, s0\n" ++
-  "  mv a1, s1\n" ++
-  "  la a2, mw_lookup_hash\n" ++
-  "  la a3, mw_lookup_offset\n" ++
-  "  la a4, mw_lookup_length\n" ++
-  "  jal ra, witness_lookup_by_hash\n" ++
-  "  bnez a0, .Lmw_not_found\n" ++
-  "  la t0, mw_lookup_offset; ld t1, 0(t0); add s7, s0, t1\n" ++
-  "  la t0, mw_lookup_length; ld s8, 0(t0)\n" ++
-  "  j .Lmw_loop\n" ++
-  ".Lmw_branch_end:\n" ++
-  "  mv a0, s7\n" ++
-  "  mv a1, s8\n" ++
-  "  li a2, 16\n" ++
-  "  la a3, mw_value_offset\n" ++
-  "  la a4, mw_value_length\n" ++
-  "  jal ra, rlp_list_nth_item\n" ++
-  "  bnez a0, .Lmw_parse_fail\n" ++
-  "  la t0, mw_value_length; ld t1, 0(t0)\n" ++
-  "  beqz t1, .Lmw_not_found     # empty value slot\n" ++
-  "  j .Lmw_copy_value\n" ++
-  ".Lmw_extension:\n" ++
-  "  mv a0, s7\n" ++
-  "  mv a1, s8\n" ++
-  "  li a2, 0\n" ++
-  "  la a3, mw_path_offset\n" ++
-  "  la a4, mw_path_length\n" ++
-  "  jal ra, rlp_list_nth_item\n" ++
-  "  bnez a0, .Lmw_parse_fail\n" ++
-  "  la t0, mw_path_offset; ld t1, 0(t0); add a0, s7, t1\n" ++
-  "  la t0, mw_path_length; ld a1, 0(t0)\n" ++
-  "  la a2, mw_nibble_buf\n" ++
-  "  la a3, mw_nibble_count\n" ++
-  "  la a4, mw_is_leaf\n" ++
-  "  jal ra, hp_decode_nibbles\n" ++
-  "  bnez a0, .Lmw_parse_fail\n" ++
-  "  la t0, mw_is_leaf; ld t1, 0(t0)\n" ++
-  "  bnez t1, .Lmw_parse_fail    # node kind said extension; HP says leaf\n" ++
-  "  la t0, mw_nibble_count; ld t1, 0(t0)\n" ++
-  "  add t2, s6, t1\n" ++
-  "  bgtu t2, s3, .Lmw_not_found # consumed + nib_count > path_len\n" ++
-  "  # Compare nibbles\n" ++
-  "  la t2, mw_nibble_buf\n" ++
-  "  add t3, s2, s6\n" ++
-  "  mv t4, t1\n" ++
-  ".Lmw_ext_cmp:\n" ++
-  "  beqz t4, .Lmw_ext_cmp_done\n" ++
-  "  lbu t5, 0(t2)\n" ++
-  "  lbu t6, 0(t3)\n" ++
-  "  bne t5, t6, .Lmw_not_found\n" ++
-  "  addi t2, t2, 1\n" ++
-  "  addi t3, t3, 1\n" ++
-  "  addi t4, t4, -1\n" ++
-  "  j .Lmw_ext_cmp\n" ++
-  ".Lmw_ext_cmp_done:\n" ++
-  "  add s6, s6, t1\n" ++
-  "  # Get item 1 (child ref).\n" ++
-  "  mv a0, s7\n" ++
-  "  mv a1, s8\n" ++
-  "  li a2, 1\n" ++
-  "  la a3, mw_child_offset\n" ++
-  "  la a4, mw_child_length\n" ++
-  "  jal ra, rlp_list_nth_item\n" ++
-  "  bnez a0, .Lmw_parse_fail\n" ++
-  "  la t0, mw_child_length; ld t1, 0(t0)\n" ++
-  "  la t0, mw_child_offset; ld t2, 0(t0)\n" ++
-  "  add t3, s7, t2\n" ++
-  "  li t4, 32\n" ++
-  "  beq t1, t4, .Lmw_ext_hash\n" ++
-  "  # Inline child: t3 is its ptr, t1 is its length.\n" ++
-  "  mv s7, t3\n" ++
-  "  mv s8, t1\n" ++
-  "  j .Lmw_loop\n" ++
-  ".Lmw_ext_hash:\n" ++
-  "  la t4, mw_lookup_hash\n" ++
-  "  ld t5,  0(t3); sd t5,  0(t4)\n" ++
-  "  ld t5,  8(t3); sd t5,  8(t4)\n" ++
-  "  ld t5, 16(t3); sd t5, 16(t4)\n" ++
-  "  ld t5, 24(t3); sd t5, 24(t4)\n" ++
-  "  mv a0, s0\n" ++
-  "  mv a1, s1\n" ++
-  "  la a2, mw_lookup_hash\n" ++
-  "  la a3, mw_lookup_offset\n" ++
-  "  la a4, mw_lookup_length\n" ++
-  "  jal ra, witness_lookup_by_hash\n" ++
-  "  bnez a0, .Lmw_not_found\n" ++
-  "  la t0, mw_lookup_offset; ld t1, 0(t0); add s7, s0, t1\n" ++
-  "  la t0, mw_lookup_length; ld s8, 0(t0)\n" ++
-  "  j .Lmw_loop\n" ++
-  ".Lmw_leaf:\n" ++
-  "  mv a0, s7\n" ++
-  "  mv a1, s8\n" ++
-  "  li a2, 0\n" ++
-  "  la a3, mw_path_offset\n" ++
-  "  la a4, mw_path_length\n" ++
-  "  jal ra, rlp_list_nth_item\n" ++
-  "  bnez a0, .Lmw_parse_fail\n" ++
-  "  la t0, mw_path_offset; ld t1, 0(t0); add a0, s7, t1\n" ++
-  "  la t0, mw_path_length; ld a1, 0(t0)\n" ++
-  "  la a2, mw_nibble_buf\n" ++
-  "  la a3, mw_nibble_count\n" ++
-  "  la a4, mw_is_leaf\n" ++
-  "  jal ra, hp_decode_nibbles\n" ++
-  "  bnez a0, .Lmw_parse_fail\n" ++
-  "  la t0, mw_is_leaf; ld t1, 0(t0)\n" ++
-  "  li t2, 1\n" ++
-  "  bne t1, t2, .Lmw_parse_fail\n" ++
-  "  la t0, mw_nibble_count; ld t1, 0(t0)\n" ++
-  "  sub t2, s3, s6              # remaining nibbles\n" ++
-  "  bne t1, t2, .Lmw_not_found  # length mismatch\n" ++
-  "  la t2, mw_nibble_buf\n" ++
-  "  add t3, s2, s6\n" ++
-  "  mv t4, t1\n" ++
-  ".Lmw_leaf_cmp:\n" ++
-  "  beqz t4, .Lmw_leaf_match\n" ++
-  "  lbu t5, 0(t2)\n" ++
-  "  lbu t6, 0(t3)\n" ++
-  "  bne t5, t6, .Lmw_not_found\n" ++
-  "  addi t2, t2, 1\n" ++
-  "  addi t3, t3, 1\n" ++
-  "  addi t4, t4, -1\n" ++
-  "  j .Lmw_leaf_cmp\n" ++
-  ".Lmw_leaf_match:\n" ++
-  "  mv a0, s7\n" ++
-  "  mv a1, s8\n" ++
-  "  li a2, 1\n" ++
-  "  la a3, mw_value_offset\n" ++
-  "  la a4, mw_value_length\n" ++
-  "  jal ra, rlp_list_nth_item\n" ++
-  "  bnez a0, .Lmw_parse_fail\n" ++
-  ".Lmw_copy_value:\n" ++
-  "  # Write value_len, then byte-copy at most 256 bytes from\n" ++
-  "  # (s7 + mw_value_offset) to s4.\n" ++
-  "  la t0, mw_value_length; ld t1, 0(t0)\n" ++
-  "  sd t1, 0(s5)\n" ++
-  "  la t0, mw_value_offset; ld t2, 0(t0); add t2, s7, t2\n" ++
-  "  mv t3, s4                   # dst\n" ++
-  "  li t4, 256\n" ++
-  "  bgtu t1, t4, .Lmw_copy_set_cap\n" ++
-  "  j .Lmw_copy_loop\n" ++
-  ".Lmw_copy_set_cap:\n" ++
-  "  mv t1, t4\n" ++
-  ".Lmw_copy_loop:\n" ++
-  "  beqz t1, .Lmw_found\n" ++
-  "  lbu t0, 0(t2)\n" ++
-  "  sb  t0, 0(t3)\n" ++
-  "  addi t2, t2, 1\n" ++
-  "  addi t3, t3, 1\n" ++
-  "  addi t1, t1, -1\n" ++
-  "  j .Lmw_copy_loop\n" ++
-  ".Lmw_found:\n" ++
-  "  li a0, 0\n" ++
-  "  j .Lmw_ret\n" ++
-  ".Lmw_not_found:\n" ++
-  "  li a0, 1\n" ++
-  "  sd zero, 0(s5)              # value_len = 0\n" ++
-  "  j .Lmw_ret\n" ++
-  ".Lmw_parse_fail:\n" ++
-  "  li a0, 2\n" ++
-  "  sd zero, 0(s5)\n" ++
-  ".Lmw_ret:\n" ++
-  "  ld ra,  0(sp)\n" ++
-  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
-  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp); ld s7, 64(sp)\n" ++
-  "  ld s8, 72(sp)\n" ++
-  "  addi sp, sp, 80\n" ++
-  "  ret"
-
-/-- `zisk_mpt_walk`: probe BuildUnit. Reads
-    (witness_len, path_len, root_hash, path_nibbles,
-     witness_bytes) from host input, writes
-    (status, value_len, value_bytes) to OUTPUT.
-    Input layout:
-      bytes   0..  8 : witness_len (u64)
-      bytes   8.. 16 : path_len (u64)
-      bytes  16.. 48 : root_hash (32 bytes)
-      bytes  48..   : path_nibbles bytes (path_len of them)
-      bytes  48 + path_len .. : witness section bytes
-    Output layout:
-      bytes   0.. 8 : status (0 found / 1 not / 2 fail)
-      bytes   8..16 : value_len
-      bytes  16..   : value bytes (up to 256 - 16 = 240) -/
-def ziskMptWalkPrologue : String :=
-  "  li sp, 0xa0050000\n" ++
-  "  li a7, 0x40000000\n" ++
-  "  ld t6, 8(a7)                # witness_len\n" ++
-  "  ld t5, 16(a7)               # path_len\n" ++
-  "  addi a0, a7, 24             # root_hash ptr (offset 16 from start of file)\n" ++
-  "  addi a3, a7, 56             # path_nibbles ptr (offset 48)\n" ++
-  "  # witness ptr = path_nibbles + path_len.\n" ++
-  "  add a1, a3, t5\n" ++
-  "  mv a2, t6                   # witness_len\n" ++
-  "  mv a4, t5                   # path_len\n" ++
-  "  li a5, 0xa0010010           # value buf at OUTPUT + 16\n" ++
-  "  li a6, 0xa0010008           # value_len ptr at OUTPUT + 8\n" ++
-  "  jal ra, mpt_walk\n" ++
-  "  li t0, 0xa0010000\n" ++
-  "  sd a0, 0(t0)                # status at OUTPUT + 0\n" ++
-  "  j .Lmw_pdone\n" ++
-  zkvmKeccak256Function ++ "\n" ++
-  witnessLookupByHashFunction ++ "\n" ++
-  rlpListNthItemFunction ++ "\n" ++
-  mptNodeKindFunction ++ "\n" ++
-  mptBranchChildFunction ++ "\n" ++
-  hpDecodeNibblesFunction ++ "\n" ++
-  mptWalkFunction ++ "\n" ++
-  ".Lmw_pdone:"
-
-def ziskMptWalkDataSection : String :=
-  ".section .data\n" ++
-  ".balign 32\n" ++
-  "zk3_state:\n" ++
-  "  .zero 200\n" ++
-  ".balign 32\n" ++
-  "wlh_scratch_hash:\n" ++
-  "  .zero 32\n" ++
-  ".balign 8\n" ++
-  "mnk_dummy_offset:\n" ++
-  "  .zero 8\n" ++
-  "mnk_dummy_length:\n" ++
-  "  .zero 8\n" ++
-  "mnk_path_offset:\n" ++
-  "  .zero 8\n" ++
-  "mnk_path_length:\n" ++
-  "  .zero 8\n" ++
-  ".balign 8\n" ++
-  "mbc_offset:\n" ++
-  "  .zero 8\n" ++
-  "mbc_length:\n" ++
-  "  .zero 8\n" ++
-  ".balign 32\n" ++
-  "mw_lookup_hash:\n" ++
-  "  .zero 32\n" ++
-  ".balign 8\n" ++
-  "mw_lookup_offset:\n" ++
-  "  .zero 8\n" ++
-  "mw_lookup_length:\n" ++
-  "  .zero 8\n" ++
-  ".balign 32\n" ++
-  "mw_child_buf:\n" ++
-  "  .zero 32\n" ++
-  ".balign 8\n" ++
-  "mw_path_offset:\n" ++
-  "  .zero 8\n" ++
-  "mw_path_length:\n" ++
-  "  .zero 8\n" ++
-  ".balign 8\n" ++
-  "mw_child_offset:\n" ++
-  "  .zero 8\n" ++
-  "mw_child_length:\n" ++
-  "  .zero 8\n" ++
-  ".balign 8\n" ++
-  "mw_value_offset:\n" ++
-  "  .zero 8\n" ++
-  "mw_value_length:\n" ++
-  "  .zero 8\n" ++
-  ".balign 8\n" ++
-  "mw_nibble_count:\n" ++
-  "  .zero 8\n" ++
-  "mw_is_leaf:\n" ++
-  "  .zero 8\n" ++
-  ".balign 32\n" ++
-  "mw_nibble_buf:\n" ++
-  "  .zero 128"
-
-def ziskMptWalkProbeUnit : BuildUnit := {
-  body        := NOP
-  prologueAsm := ziskMptWalkPrologue
-  dataAsm     := ziskMptWalkDataSection
-}
-
-/-! ## bytes_to_nibbles -- PR-K25 byte → nibble array expansion
-
-    Convert N bytes into 2N nibbles (one byte per nibble, in
-    [0..15]). Each input byte writes 2 output bytes: high nibble
-    then low nibble. The output format matches what `mpt_walk`
-    (PR-K24) consumes as its path argument.
-
-    Composes with `zkvm_keccak256` to derive the standard MPT
-    path from a state-trie or storage-trie key:
-
-        keccak256(address)   -- 32 bytes
-        bytes_to_nibbles     -- 64 nibbles
-        mpt_walk(...)        -- account / slot lookup
-
-    Calling convention:
-      a0 (input)  : src bytes ptr
-      a1 (input)  : src byte length
-      a2 (input)  : dst nibble buf ptr (2 * a1 bytes)
-      ra (input)  : return
-      a0 (output) : 2 * a1 (number of nibbles emitted)
-
-    Pure register arithmetic, no scratch memory, leaf-callable. -/
-def bytesToNibblesFunction : String :=
-  "bytes_to_nibbles:\n" ++
-  "  mv t0, a0                  # src cursor\n" ++
-  "  mv t1, a2                  # dst cursor\n" ++
-  "  mv t2, a1                  # remaining\n" ++
-  "  li t6, 0                   # emitted count\n" ++
-  ".Lbtn_loop:\n" ++
-  "  beqz t2, .Lbtn_done\n" ++
-  "  lbu t3, 0(t0)\n" ++
-  "  srli t4, t3, 4\n" ++
-  "  andi t5, t3, 0xf\n" ++
-  "  sb t4, 0(t1)\n" ++
-  "  sb t5, 1(t1)\n" ++
-  "  addi t0, t0, 1\n" ++
-  "  addi t1, t1, 2\n" ++
-  "  addi t2, t2, -1\n" ++
-  "  addi t6, t6, 2\n" ++
-  "  j .Lbtn_loop\n" ++
-  ".Lbtn_done:\n" ++
-  "  mv a0, t6\n" ++
-  "  ret"
-
-/-- `zisk_bytes_to_nibbles`: probe BuildUnit. Reads
-    (src_len, src_bytes) from host input, writes
-    (nibble_count, nibbles) to OUTPUT.
-    Input layout:
-      bytes  0.. 8 : src_len (u64)
-      bytes  8..   : src bytes
-    Output layout:
-      bytes  0.. 8 : nibble_count (u64 = 2 * src_len)
-      bytes  8..   : nibble bytes -/
-def ziskBytesToNibblesPrologue : String :=
-  "  li sp, 0xa0050000\n" ++
-  "  li a3, 0x40000000\n" ++
-  "  ld a1, 8(a3)                # src_len\n" ++
-  "  addi a0, a3, 16             # src bytes ptr\n" ++
-  "  li a2, 0xa0010008           # nibble buf at OUTPUT + 8\n" ++
-  "  jal ra, bytes_to_nibbles\n" ++
-  "  li t0, 0xa0010000\n" ++
-  "  sd a0, 0(t0)                # nibble_count at OUTPUT + 0\n" ++
-  "  j .Lbtn_pdone\n" ++
-  bytesToNibblesFunction ++ "\n" ++
-  ".Lbtn_pdone:"
-
-def ziskBytesToNibblesDataSection : String :=
-  ".section .data\n" ++
-  "btn_pad:\n" ++
-  "  .zero 8"
-
-def ziskBytesToNibblesProbeUnit : BuildUnit := {
-  body        := NOP
-  prologueAsm := ziskBytesToNibblesPrologue
-  dataAsm     := ziskBytesToNibblesDataSection
-}
-
-/-! ## mpt_lookup_by_key -- PR-K26 keccak + nibbles + mpt_walk
-
-    Compose the lookup chain that turns a raw key (address or
-    storage slot index) into a value via Ethereum's standard
-    `keccak256(key) -> path -> mpt_walk(...)` shape.
-
-    Both Ethereum state and storage tries use this same shape;
-    only the value semantics differ (account RLP vs 32-byte
-    storage word).
-
-    Calling convention:
-      a0 (input)  : key bytes ptr (20-byte address or 32-byte
-                    storage slot index, big-endian)
-      a1 (input)  : key byte length
-      a2 (input)  : root_hash ptr (32 bytes)
-      a3 (input)  : witness section ptr
-      a4 (input)  : witness section_len
-      a5 (input)  : value output buffer ptr (256 bytes)
-      a6 (input)  : u64 out ptr (matched value byte length)
-      ra (input)  : return
-      a0 (output) : 0 found / 1 not found / 2 parse error
-                    (mirrors mpt_walk return codes).
-
-    Internal scratch buffers:
-      mlk_keccak_buf : 32 bytes (keccak256 output)
-      mlk_nibble_buf : 64 bytes (one nibble per byte) -/
-def mptLookupByKeyFunction : String :=
-  "mpt_lookup_by_key:\n" ++
-  "  addi sp, sp, -64\n" ++
-  "  sd ra,  0(sp)\n" ++
-  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp); sd s4, 40(sp)\n" ++
-  "  mv s0, a2                   # s0 = root_hash ptr\n" ++
-  "  mv s1, a3                   # s1 = witness ptr\n" ++
-  "  mv s2, a4                   # s2 = witness_len\n" ++
-  "  mv s3, a5                   # s3 = value out\n" ++
-  "  mv s4, a6                   # s4 = value_len out\n" ++
-  "  # Step 1: keccak(key) -> mlk_keccak_buf.\n" ++
-  "  la a2, mlk_keccak_buf\n" ++
-  "  jal ra, zkvm_keccak256\n" ++
-  "  # Step 2: bytes_to_nibbles(mlk_keccak_buf, 32, mlk_nibble_buf).\n" ++
-  "  la a0, mlk_keccak_buf\n" ++
-  "  li a1, 32\n" ++
-  "  la a2, mlk_nibble_buf\n" ++
-  "  jal ra, bytes_to_nibbles\n" ++
-  "  # Step 3: mpt_walk(root, witness, witness_len, path, 64, val_out, val_len).\n" ++
-  "  mv a0, s0\n" ++
-  "  mv a1, s1\n" ++
-  "  mv a2, s2\n" ++
-  "  la a3, mlk_nibble_buf\n" ++
-  "  li a4, 64\n" ++
-  "  mv a5, s3\n" ++
-  "  mv a6, s4\n" ++
-  "  jal ra, mpt_walk\n" ++
-  "  # a0 already holds mpt_walk's status.\n" ++
-  "  ld ra,  0(sp)\n" ++
-  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp); ld s4, 40(sp)\n" ++
-  "  addi sp, sp, 64\n" ++
-  "  ret"
-
-/-- `zisk_mpt_lookup_by_key`: probe BuildUnit. Reads
-    (witness_len, key_len, root_hash, key, witness) from host
-    input and writes (status, value_len, value_bytes) to OUTPUT.
-    Input layout:
-      bytes   0.. 8 : witness_len (u64)
-      bytes   8..16 : key_len (u64)
-      bytes  16..48 : root_hash (32 bytes)
-      bytes  48..   : key bytes (key_len)
-      bytes  48+key_len.. : witness section bytes
-    Output: same as PR-K24 mpt_walk. -/
-def ziskMptLookupByKeyPrologue : String :=
-  "  li sp, 0xa0050000\n" ++
-  "  li a7, 0x40000000\n" ++
-  "  ld t6, 8(a7)                # witness_len\n" ++
-  "  ld t5, 16(a7)               # key_len\n" ++
-  "  addi a2, a7, 24             # root_hash ptr (input offset 16)\n" ++
-  "  addi a0, a7, 56             # key ptr (input offset 48)\n" ++
-  "  mv a1, t5                   # key_len\n" ++
-  "  add a3, a0, t5              # witness ptr = key + key_len\n" ++
-  "  mv a4, t6                   # witness_len\n" ++
-  "  li a5, 0xa0010010           # value buf at OUTPUT + 16\n" ++
-  "  li a6, 0xa0010008           # value_len at OUTPUT + 8\n" ++
-  "  jal ra, mpt_lookup_by_key\n" ++
-  "  li t0, 0xa0010000\n" ++
-  "  sd a0, 0(t0)                # status at OUTPUT + 0\n" ++
-  "  j .Lmlk_pdone\n" ++
-  zkvmKeccak256Function ++ "\n" ++
-  witnessLookupByHashFunction ++ "\n" ++
-  rlpListNthItemFunction ++ "\n" ++
-  mptNodeKindFunction ++ "\n" ++
-  mptBranchChildFunction ++ "\n" ++
-  hpDecodeNibblesFunction ++ "\n" ++
-  bytesToNibblesFunction ++ "\n" ++
-  mptWalkFunction ++ "\n" ++
-  mptLookupByKeyFunction ++ "\n" ++
-  ".Lmlk_pdone:"
-
-def ziskMptLookupByKeyDataSection : String :=
-  ".section .data\n" ++
-  ".balign 32\n" ++
-  "zk3_state:\n" ++
-  "  .zero 200\n" ++
-  ".balign 32\n" ++
-  "wlh_scratch_hash:\n" ++
-  "  .zero 32\n" ++
-  ".balign 8\n" ++
-  "mnk_dummy_offset:\n" ++
-  "  .zero 8\n" ++
-  "mnk_dummy_length:\n" ++
-  "  .zero 8\n" ++
-  "mnk_path_offset:\n" ++
-  "  .zero 8\n" ++
-  "mnk_path_length:\n" ++
-  "  .zero 8\n" ++
-  "mbc_offset:\n" ++
-  "  .zero 8\n" ++
-  "mbc_length:\n" ++
-  "  .zero 8\n" ++
-  ".balign 32\n" ++
-  "mw_lookup_hash:\n" ++
-  "  .zero 32\n" ++
-  ".balign 8\n" ++
-  "mw_lookup_offset:\n" ++
-  "  .zero 8\n" ++
-  "mw_lookup_length:\n" ++
-  "  .zero 8\n" ++
-  ".balign 32\n" ++
-  "mw_child_buf:\n" ++
-  "  .zero 32\n" ++
-  ".balign 8\n" ++
-  "mw_path_offset:\n" ++
-  "  .zero 8\n" ++
-  "mw_path_length:\n" ++
-  "  .zero 8\n" ++
-  "mw_child_offset:\n" ++
-  "  .zero 8\n" ++
-  "mw_child_length:\n" ++
-  "  .zero 8\n" ++
-  "mw_value_offset:\n" ++
-  "  .zero 8\n" ++
-  "mw_value_length:\n" ++
-  "  .zero 8\n" ++
-  "mw_nibble_count:\n" ++
-  "  .zero 8\n" ++
-  "mw_is_leaf:\n" ++
-  "  .zero 8\n" ++
-  ".balign 32\n" ++
-  "mw_nibble_buf:\n" ++
-  "  .zero 128\n" ++
-  ".balign 32\n" ++
-  "mlk_keccak_buf:\n" ++
-  "  .zero 32\n" ++
-  ".balign 32\n" ++
-  "mlk_nibble_buf:\n" ++
-  "  .zero 64"
-
-def ziskMptLookupByKeyProbeUnit : BuildUnit := {
-  body        := NOP
-  prologueAsm := ziskMptLookupByKeyPrologue
-  dataAsm     := ziskMptLookupByKeyDataSection
-}
+/-! ## MPT helpers K21-K26 — moved to `Programs/Mpt.lean` (file-size hard cap). -/
 
 /-! ## account_decode -- PR-K27 RLP splitter for Account records
 
@@ -6600,6 +5364,113 @@ def ziskMptExtensionNodeEncodeProbeUnit : BuildUnit := {
   dataAsm     := ziskMptExtensionNodeEncodeDataSection
 }
 
+/-! ## mpt_branch_node_encode -- PR-K165
+
+    Encode an MPT *branch* node as RLP, given a pre-concatenated
+    17-slot payload:
+
+      branch_node = rlp([slot_0, slot_1, ..., slot_15, value])
+
+    Each of the 17 slots is one RLP item, already encoded by the
+    caller in one of three forms:
+      * empty: `0x80`              (1 byte)
+      * inline child: `child_rlp`  (variable; len < 32)
+      * hashed child: `0xa0 || keccak256(child_rlp)` (33 bytes)
+      * value slot: `0x80` if no value lives at this prefix, else
+        the RLP-encoded value bytes.
+
+    The caller arranges all 17 slot encodings in order and passes
+    the concatenated payload; this helper just emits the outer
+    list prefix for that payload length, then copies the payload.
+    Use PR-K163 `mpt_node_slot_encode` to produce each child
+    slot's bytes.
+
+    Composes:
+      - PR-K129 `rlp_encode_list_prefix` for the outer prefix
+
+    Calling convention:
+      a0 (input)  : slot_payload ptr (pre-concatenated 17-slot
+                    bytes; caller's responsibility to put the
+                    slots in nibble order and end with the value
+                    slot)
+      a1 (input)  : slot_payload byte length
+      a2 (input)  : output buffer ptr
+                    (caller supplies >= 9 + a1 bytes)
+      a3 (input)  : u64 out length ptr (total bytes written:
+                    prefix_len + payload_len)
+      ra (input)  : return
+      a0 (output) : 0 (always succeeds). -/
+def mptBranchNodeEncodeFunction : String :=
+  "mpt_branch_node_encode:\n" ++
+  "  addi sp, sp, -48\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  mv s0, a0                   # slot_payload ptr\n" ++
+  "  mv s1, a1                   # slot_payload len\n" ++
+  "  mv s2, a2                   # output ptr\n" ++
+  "  mv s3, a3                   # out_length ptr\n" ++
+  "  # ---- Write outer list prefix at output[0..] ----\n" ++
+  "  mv a0, s1; mv a1, s2\n" ++
+  "  la a2, mbne_field_len\n" ++
+  "  jal ra, rlp_encode_list_prefix\n" ++
+  "  la t0, mbne_field_len; ld t1, 0(t0)         # prefix_len\n" ++
+  "  # ---- Copy payload after prefix ----\n" ++
+  "  add t2, s2, t1                                # dst = output + prefix_len\n" ++
+  "  mv t3, s0                                     # src\n" ++
+  "  mv t4, s1                                     # remaining\n" ++
+  ".Lmbne_cp:\n" ++
+  "  beqz t4, .Lmbne_cp_done\n" ++
+  "  lbu t5, 0(t3)\n" ++
+  "  sb t5, 0(t2)\n" ++
+  "  addi t2, t2, 1\n" ++
+  "  addi t3, t3, 1\n" ++
+  "  addi t4, t4, -1\n" ++
+  "  j .Lmbne_cp\n" ++
+  ".Lmbne_cp_done:\n" ++
+  "  add t1, t1, s1                                # total written\n" ++
+  "  sd t1, 0(s3)\n" ++
+  "  li a0, 0\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  addi sp, sp, 48\n" ++
+  "  ret"
+
+/-- `zisk_mpt_branch_node_encode`: probe BuildUnit.
+    Input layout:
+      bytes  0.. 8 : slot_payload_len
+      bytes  8..   : slot_payload (pre-concatenated 17-slot bytes)
+    Output layout:
+      bytes  0.. 8 : status
+      bytes  8..16 : branch-node RLP length
+      bytes 16..   : branch-node RLP bytes (truncated to ziskemu
+                     cap if oversized) -/
+def ziskMptBranchNodeEncodePrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a4, 0x40000000\n" ++
+  "  ld a1, 8(a4)                # slot_payload_len\n" ++
+  "  addi a0, a4, 16             # slot_payload ptr\n" ++
+  "  li a2, 0xa0010010           # output buffer ptr\n" ++
+  "  li a3, 0xa0010008           # out_length ptr\n" ++
+  "  jal ra, mpt_branch_node_encode\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lmbne_pdone\n" ++
+  rlpEncodeListPrefixFunction ++ "\n" ++
+  mptBranchNodeEncodeFunction ++ "\n" ++
+  ".Lmbne_pdone:"
+
+def ziskMptBranchNodeEncodeDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "mbne_field_len:\n" ++
+  "  .zero 8"
+
+def ziskMptBranchNodeEncodeProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskMptBranchNodeEncodePrologue
+  dataAsm     := ziskMptBranchNodeEncodeDataSection
+}
+
 /-! ## block-level bloom composites K158-K159 — moved to `Programs/Bloom.lean` (file-size hard cap). -/
 
 /-! ## header_root_is_empty_trie -- PR-K161
@@ -6971,253 +5842,7 @@ def ziskInitCodeCostProbeUnit : BuildUnit := {
 }
 
 
-/-! ## mpt_branch_used_count -- PR-K117
-
-    Count the number of non-empty child slots in an MPT branch
-    node's `[c0, c1, …, c15, value]` head. A child slot is
-    "non-empty" iff its RLP byte-length is > 0 (empty children
-    serialise as the empty RLP string `0x80`, len 0).
-
-    Used by state-root recomputation to detect *single-child*
-    branches that can collapse into an extension after a delete
-    operation: the trie invariant says a branch must always have
-    ≥ 2 children or be replaced by an extension/leaf.
-
-    The `value` field (item 16) is **not** counted; only the 16
-    nibble-indexed children. A branch where the value slot is the
-    only non-empty entry still returns 0 here (and is itself a
-    consensus violation under the standard trie invariants).
--/
-/-! ## mpt_branch_first_used_index -- PR-K118
-
-    Find the lowest-indexed non-empty child slot in an MPT branch
-    node's `[c0, c1, …, c15, value]` head. Returns the index in
-    `[0, 15]` of the first child whose RLP byte-length is > 0, or
-    `16` (sentinel "none") when every child slot is empty.
-
-    Used by state-root recomputation in the *trie-collapse* path:
-    when PR-K117 `mpt_branch_used_count` reports exactly one
-    surviving child, this helper tells the rewriter *which* child
-    to inline into the parent's path.
-
-    The `value` field (item 16) is **not** scanned. A branch where
-    the value slot is the only non-empty entry still returns the
-    `16` sentinel.
-
-    Composes:
-      - PR-K47 `rlp_list_count_items` — sanity-check 17 items
-      - PR-K20 `rlp_list_nth_item`    — per-child length probe
-
-    Calling convention:
-      a0 (input)  : branch_rlp ptr
-      a1 (input)  : branch_rlp byte length
-      a2 (input)  : u64 out ptr (used_count, 0..16)
-      ra (input)  : return
-      a0 (output) :
-        0 : success
-        1 : not a 17-item list (or RLP parse failure)
-        2 : mid-list nth_item failure -/
-def mptBranchUsedCountFunction : String :=
-  "mpt_branch_used_count:\n" ++
-  "  addi sp, sp, -48\n" ++
-  "  sd ra,  0(sp)\n" ++
-  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp); sd s4, 40(sp)\n" ++
-  "  mv s0, a0                   # branch ptr\n" ++
-  "  mv s1, a1                   # branch len\n" ++
-  "  mv s2, a2                   # used_count out\n" ++
-  "  sd zero, 0(s2)\n" ++
-  "  # Verify 17-item list.\n" ++
-  "  mv a0, s0; mv a1, s1\n" ++
-  "  la a2, mbuc_count\n" ++
-  "  jal ra, rlp_list_count_items\n" ++
-  "  bnez a0, .Lmbuc_not_branch\n" ++
-  "  la t0, mbuc_count; ld t1, 0(t0)\n" ++
-  "  li t2, 17\n" ++
-  "  bne t1, t2, .Lmbuc_not_branch\n" ++
-  "  li s3, 0                    # i = 0\n" ++
-  "  li s4, 0                    # used = 0\n" ++
-  ".Lmbuc_loop:\n" ++
-  "  li t0, 16\n" ++
-  "  beq s3, t0, .Lmbuc_done\n" ++
-  "  mv a0, s0; mv a1, s1\n" ++
-  "  mv a2, s3\n" ++
-  "  la a3, mbuc_off; la a4, mbuc_len\n" ++
-  "  jal ra, rlp_list_nth_item\n" ++
-  "  bnez a0, .Lmbuc_nth_fail\n" ++
-  "  la t0, mbuc_len; ld t1, 0(t0)\n" ++
-  "  beqz t1, .Lmbuc_step\n" ++
-  "  addi s4, s4, 1\n" ++
-  ".Lmbuc_step:\n" ++
-  "  addi s3, s3, 1\n" ++
-  "  j .Lmbuc_loop\n" ++
-  ".Lmbuc_done:\n" ++
-  "  sd s4, 0(s2)\n" ++
-  "  li a0, 0\n" ++
-  "  j .Lmbuc_ret\n" ++
-  ".Lmbuc_not_branch:\n" ++
-  "  li a0, 1\n" ++
-  "  j .Lmbuc_ret\n" ++
-  ".Lmbuc_nth_fail:\n" ++
-  "  li a0, 2\n" ++
-  ".Lmbuc_ret:\n" ++
-  "  ld ra,  0(sp)\n" ++
-  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp); ld s4, 40(sp)\n" ++
-  "  addi sp, sp, 48\n" ++
-  "  ret"
-def mptBranchFirstUsedIndexFunction : String :=
-  "mpt_branch_first_used_index:\n" ++
-  "  addi sp, sp, -48\n" ++
-  "  sd ra,  0(sp)\n" ++
-  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp); sd s4, 40(sp)\n" ++
-  "  mv s0, a0                   # branch ptr\n" ++
-  "  mv s1, a1                   # branch len\n" ++
-  "  mv s2, a2                   # used_count out\n" ++
-  "  sd zero, 0(s2)\n" ++
-  "  # Verify 17-item list.\n" ++
-  "  mv a0, s0; mv a1, s1\n" ++
-  "  la a2, mbuc_count\n" ++
-  "  jal ra, rlp_list_count_items\n" ++
-  "  bnez a0, .Lmbuc_not_branch\n" ++
-  "  la t0, mbuc_count; ld t1, 0(t0)\n" ++
-  "  li t2, 17\n" ++
-  "  bne t1, t2, .Lmbuc_not_branch\n" ++
-  "  li s3, 0                    # i = 0\n" ++
-  "  li s4, 0                    # used = 0\n" ++
-  ".Lmbuc_loop:\n" ++
-  "  li t0, 16\n" ++
-  "  beq s3, t0, .Lmbuc_done\n" ++
-  "  mv a0, s0; mv a1, s1\n" ++
-  "  mv a2, s3\n" ++
-  "  la a3, mbuc_off; la a4, mbuc_len\n" ++
-  "  jal ra, rlp_list_nth_item\n" ++
-  "  bnez a0, .Lmbuc_nth_fail\n" ++
-  "  la t0, mbuc_len; ld t1, 0(t0)\n" ++
-  "  beqz t1, .Lmbuc_step\n" ++
-  "  addi s4, s4, 1\n" ++
-  ".Lmbuc_step:\n" ++
-  "  addi s3, s3, 1\n" ++
-  "  j .Lmbuc_loop\n" ++
-  ".Lmbuc_done:\n" ++
-  "  sd s4, 0(s2)\n" ++
-  "  li a0, 0\n" ++
-  "  j .Lmbuc_ret\n" ++
-  ".Lmbuc_not_branch:\n" ++
-  "  li a0, 1\n" ++
-  "  j .Lmbuc_ret\n" ++
-  ".Lmbuc_nth_fail:\n" ++
-  "  li a0, 2\n" ++
-  ".Lmbuc_ret:\n" ++
-  "  mv s2, a2                   # first_index out\n" ++
-  "  li t0, 16\n" ++
-  "  sd t0, 0(s2)                # default = 16 (none)\n" ++
-  "  # Verify 17-item list.\n" ++
-  "  mv a0, s0; mv a1, s1\n" ++
-  "  la a2, mbfui_count\n" ++
-  "  jal ra, rlp_list_count_items\n" ++
-  "  bnez a0, .Lmbfui_not_branch\n" ++
-  "  la t0, mbfui_count; ld t1, 0(t0)\n" ++
-  "  li t2, 17\n" ++
-  "  bne t1, t2, .Lmbfui_not_branch\n" ++
-  "  li s3, 0                    # i = 0\n" ++
-  ".Lmbfui_loop:\n" ++
-  "  li t0, 16\n" ++
-  "  beq s3, t0, .Lmbfui_done\n" ++
-  "  mv a0, s0; mv a1, s1\n" ++
-  "  mv a2, s3\n" ++
-  "  la a3, mbfui_off; la a4, mbfui_len\n" ++
-  "  jal ra, rlp_list_nth_item\n" ++
-  "  bnez a0, .Lmbfui_nth_fail\n" ++
-  "  la t0, mbfui_len; ld t1, 0(t0)\n" ++
-  "  beqz t1, .Lmbfui_step\n" ++
-  "  # Found first non-empty child.\n" ++
-  "  sd s3, 0(s2)\n" ++
-  "  li a0, 0\n" ++
-  "  j .Lmbfui_ret\n" ++
-  ".Lmbfui_step:\n" ++
-  "  addi s3, s3, 1\n" ++
-  "  j .Lmbfui_loop\n" ++
-  ".Lmbfui_done:\n" ++
-  "  # No non-empty children; output stays at sentinel 16.\n" ++
-  "  li a0, 0\n" ++
-  "  j .Lmbfui_ret\n" ++
-  ".Lmbfui_not_branch:\n" ++
-  "  li a0, 1\n" ++
-  "  j .Lmbfui_ret\n" ++
-  ".Lmbfui_nth_fail:\n" ++
-  "  li a0, 2\n" ++
-  ".Lmbfui_ret:\n" ++
-  "  ld ra,  0(sp)\n" ++
-  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp); ld s4, 40(sp)\n" ++
-  "  addi sp, sp, 48\n" ++
-  "  ret"
-
-/-- `zisk_mpt_branch_used_count`: probe BuildUnit. Reads
-    (branch_len, branch_bytes), writes (status, used_count) to
-    OUTPUT (16 bytes). -/
-def ziskMptBranchUsedCountPrologue : String :=
-  "  li sp, 0xa0050000\n" ++
-  "  li a3, 0x40000000\n" ++
-  "  ld a1, 8(a3)                # branch length\n" ++
-  "  addi a0, a3, 16             # branch ptr\n" ++
-  "  li a2, 0xa0010008           # used_count out\n" ++
-  "  jal ra, mpt_branch_used_count\n" ++
-  "  li t0, 0xa0010000\n" ++
-  "  sd a0, 0(t0)\n" ++
-  "  j .Lmbuc_pdone\n" ++
-  rlpListNthItemFunction ++ "\n" ++
-  rlpListCountItemsFunction ++ "\n" ++
-  mptBranchUsedCountFunction ++ "\n" ++
-  ".Lmbuc_pdone:"
-
-def ziskMptBranchUsedCountDataSection : String :=
-  ".section .data\n" ++
-  ".balign 8\n" ++
-  "mbuc_count:\n" ++
-  "  .zero 8\n" ++
-  "mbuc_off:\n" ++
-  "  .zero 8\n" ++
-  "mbuc_len:\n" ++
-  "  .zero 8"
-
-def ziskMptBranchUsedCountProbeUnit : BuildUnit := {
-  body        := NOP
-  prologueAsm := ziskMptBranchUsedCountPrologue
-  dataAsm     := ziskMptBranchUsedCountDataSection
-}
-
-/-- `zisk_mpt_branch_first_used_index`: probe BuildUnit. Reads
-    (branch_len, branch_bytes), writes (status, first_index) to
-    OUTPUT (16 bytes). -/
-def ziskMptBranchFirstUsedIndexPrologue : String :=
-  "  li sp, 0xa0050000\n" ++
-  "  li a3, 0x40000000\n" ++
-  "  ld a1, 8(a3)                # branch length\n" ++
-  "  addi a0, a3, 16             # branch ptr\n" ++
-  "  li a2, 0xa0010008           # first_index out\n" ++
-  "  jal ra, mpt_branch_first_used_index\n" ++
-  "  li t0, 0xa0010000\n" ++
-  "  sd a0, 0(t0)\n" ++
-  "  j .Lmbfui_pdone\n" ++
-  rlpListNthItemFunction ++ "\n" ++
-  rlpListCountItemsFunction ++ "\n" ++
-  mptBranchFirstUsedIndexFunction ++ "\n" ++
-  ".Lmbfui_pdone:"
-
-def ziskMptBranchFirstUsedIndexDataSection : String :=
-  ".section .data\n" ++
-  ".balign 8\n" ++
-  "mbfui_count:\n" ++
-  "  .zero 8\n" ++
-  "mbfui_off:\n" ++
-  "  .zero 8\n" ++
-  "mbfui_len:\n" ++
-  "  .zero 8"
-
-def ziskMptBranchFirstUsedIndexProbeUnit : BuildUnit := {
-  body        := NOP
-  prologueAsm := ziskMptBranchFirstUsedIndexPrologue
-  dataAsm     := ziskMptBranchFirstUsedIndexDataSection
-}
+/-! ## MPT branch helpers K117 / K118 — moved to `Programs/Mpt.lean` (file-size hard cap). -/
 
 /-! ## stateless_guest body — PR-K5 keccak hash field
 
@@ -7510,6 +6135,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_mpt_leaf_node_encode" => some ziskMptLeafNodeEncodeProbeUnit
   | "zisk_mpt_node_slot_encode" => some ziskMptNodeSlotEncodeProbeUnit
   | "zisk_mpt_extension_node_encode" => some ziskMptExtensionNodeEncodeProbeUnit
+  | "zisk_mpt_branch_node_encode" => some ziskMptBranchNodeEncodeProbeUnit
   | "zisk_block_logs_bloom_from_receipts_list" => some ziskBlockLogsBloomFromReceiptsListProbeUnit
   | "zisk_block_validate_logs_bloom" => some ziskBlockValidateLogsBloomProbeUnit
   | "zisk_header_root_is_empty_trie" => some ziskHeaderRootIsEmptyTrieProbeUnit
@@ -7688,6 +6314,7 @@ def knownProgramNames : List String :=
    "zisk_mpt_leaf_node_encode",
    "zisk_mpt_node_slot_encode",
    "zisk_mpt_extension_node_encode",
+   "zisk_mpt_branch_node_encode",
    "zisk_block_logs_bloom_from_receipts_list",
    "zisk_block_validate_logs_bloom",
    "zisk_header_root_is_empty_trie",
@@ -7743,7 +6370,7 @@ end EvmAsm.Codegen
     Runs at elaboration time via `#eval`; adds zero runtime cost. -/
 
 #eval show IO Unit from do
-  let hardCap := 7800
+  let hardCap := 6600
   let paths := [
     "EvmAsm/Codegen/Programs.lean",
     "EvmAsm/Codegen/Programs/Block.lean",

--- a/EvmAsm/Codegen/Programs/Mpt.lean
+++ b/EvmAsm/Codegen/Programs/Mpt.lean
@@ -24,6 +24,146 @@ namespace EvmAsm.Codegen
 
 open EvmAsm.Rv64
 
+/-! ## witness_lookup_by_hash -- PR-K19 (linear-scan flavour)
+
+    Find the entry in an SSZ list section whose keccak256 digest
+    matches a caller-supplied target hash. Returns the matched
+    entry's (offset, length) within the section, or status=1 on
+    miss.
+
+    Calling convention:
+      a0 (input)  : SSZ list section ptr (witness.state /
+                    witness.codes shape)
+      a1 (input)  : section_len (0 ⇒ guaranteed miss)
+      a2 (input)  : 32-byte target hash ptr
+      a3 (input)  : u64 out ptr (matched entry's byte offset
+                    within the section; meaningful only on hit)
+      a4 (input)  : u64 out ptr (matched entry's byte length;
+                    meaningful only on hit)
+      ra (input)  : return
+      a0 (output) : 0 on hit, 1 on miss
+
+    Walks every element computing `keccak256(element_bytes)`
+    until either a match is found or the list is exhausted.
+    O(N) per call; PR-K20+ will replace with a pre-built bucket
+    table for O(1) average lookups. -/
+def witnessLookupByHashFunction : String :=
+  "witness_lookup_by_hash:\n" ++
+  "  addi sp, sp, -64\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp)\n" ++
+  "  sd s3, 32(sp); sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp)\n" ++
+  "  mv s0, a0                  # section ptr\n" ++
+  "  mv s1, a1                  # section_len\n" ++
+  "  mv s2, a2                  # target_hash ptr\n" ++
+  "  mv s3, a3                  # out_offset ptr\n" ++
+  "  mv s4, a4                  # out_length ptr\n" ++
+  "  beqz s1, .Lwlh_miss        # empty section ⇒ miss\n" ++
+  "  lwu t0, 0(s0)              # first inner offset = 4 * N\n" ++
+  "  srli s5, t0, 2             # s5 = N\n" ++
+  "  li s6, 0                   # s6 = i\n" ++
+  ".Lwlh_loop:\n" ++
+  "  beq s6, s5, .Lwlh_miss\n" ++
+  "  # Compute element i bounds.\n" ++
+  "  slli t0, s6, 2             # 4*i\n" ++
+  "  add t1, s0, t0\n" ++
+  "  lwu t2, 0(t1)              # inner_off_i\n" ++
+  "  add a0, s0, t2             # el_i_start\n" ++
+  "  addi t3, s6, 1\n" ++
+  "  beq t3, s5, .Lwlh_use_end\n" ++
+  "  slli t3, t3, 2             # 4*(i+1)\n" ++
+  "  add t3, s0, t3\n" ++
+  "  lwu t4, 0(t3)\n" ++
+  "  add t4, s0, t4             # el_i_end\n" ++
+  "  j .Lwlh_have_end\n" ++
+  ".Lwlh_use_end:\n" ++
+  "  add t4, s0, s1             # el_i_end = section_end\n" ++
+  ".Lwlh_have_end:\n" ++
+  "  sub a1, t4, a0             # el_i_len\n" ++
+  "  la a2, wlh_scratch_hash\n" ++
+  "  jal ra, zkvm_keccak256\n" ++
+  "  # Compare scratch_hash vs target_hash.\n" ++
+  "  la t0, wlh_scratch_hash\n" ++
+  "  mv t1, s2\n" ++
+  "  ld t2,  0(t0); ld t3,  0(t1); bne t2, t3, .Lwlh_no_match\n" ++
+  "  ld t2,  8(t0); ld t3,  8(t1); bne t2, t3, .Lwlh_no_match\n" ++
+  "  ld t2, 16(t0); ld t3, 16(t1); bne t2, t3, .Lwlh_no_match\n" ++
+  "  ld t2, 24(t0); ld t3, 24(t1); bne t2, t3, .Lwlh_no_match\n" ++
+  "  # Match. Recompute (offset, length) from i (clobbered above).\n" ++
+  "  slli t0, s6, 2\n" ++
+  "  add t1, s0, t0\n" ++
+  "  lwu t2, 0(t1)              # inner_off_i\n" ++
+  "  sd t2, 0(s3)               # *out_offset = inner_off_i\n" ++
+  "  addi t3, s6, 1\n" ++
+  "  beq t3, s5, .Lwlh_last_len\n" ++
+  "  slli t3, t3, 2\n" ++
+  "  add t3, s0, t3\n" ++
+  "  lwu t4, 0(t3)\n" ++
+  "  sub t4, t4, t2             # length = inner_off_{i+1} - inner_off_i\n" ++
+  "  j .Lwlh_store_len\n" ++
+  ".Lwlh_last_len:\n" ++
+  "  sub t4, s1, t2             # length = section_len - inner_off_i\n" ++
+  ".Lwlh_store_len:\n" ++
+  "  sd t4, 0(s4)\n" ++
+  "  li a0, 0                   # hit\n" ++
+  "  j .Lwlh_ret\n" ++
+  ".Lwlh_no_match:\n" ++
+  "  addi s6, s6, 1\n" ++
+  "  j .Lwlh_loop\n" ++
+  ".Lwlh_miss:\n" ++
+  "  li a0, 1                   # miss\n" ++
+  ".Lwlh_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp)\n" ++
+  "  ld s3, 32(sp); ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp)\n" ++
+  "  addi sp, sp, 64\n" ++
+  "  ret"
+
+/-- `zisk_witness_lookup_by_hash`: probe BuildUnit. Reads
+    (section_len, target_hash, section_bytes) from host input,
+    writes (status, offset, length) to OUTPUT.
+    Input layout:
+      bytes  0.. 8 : section_len (u64)
+      bytes  8..40 : target_hash (32 bytes)
+      bytes 40..   : SSZ list section bytes
+    Output layout:
+      bytes  0.. 8 : status (u64; 0 hit, 1 miss)
+      bytes  8..16 : matched entry offset within section (u64)
+      bytes 16..24 : matched entry length (u64) -/
+def ziskWitnessLookupByHashPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a5, 0x40000000\n" ++
+  "  ld a1, 8(a5)                # section_len\n" ++
+  "  addi a2, a5, 16             # target_hash ptr\n" ++
+  "  addi a0, a5, 48             # section ptr\n" ++
+  "  li a3, 0xa0010008           # out_offset (OUTPUT + 8)\n" ++
+  "  li a4, 0xa0010010           # out_length (OUTPUT + 16)\n" ++
+  "  # Pre-zero offset/length so a miss surfaces as zeros.\n" ++
+  "  sd zero, 0(a3)\n" ++
+  "  sd zero, 0(a4)\n" ++
+  "  jal ra, witness_lookup_by_hash\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)                # status at OUTPUT + 0\n" ++
+  "  j .Lwlh_pdone\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  witnessLookupByHashFunction ++ "\n" ++
+  ".Lwlh_pdone:"
+
+def ziskWitnessLookupByHashDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  ".balign 32\n" ++
+  "wlh_scratch_hash:\n" ++
+  "  .zero 32"
+
+def ziskWitnessLookupByHashProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskWitnessLookupByHashPrologue
+  dataAsm     := ziskWitnessLookupByHashDataSection
+}
+
 /-! ## mpt_nibbles_to_compact -- PR-K109
 
     Pack a nibble-list into the MPT compact (hex-prefix) encoding
@@ -1060,5 +1200,1362 @@ def ziskMptExtensionExtractProbeUnit : BuildUnit := {
   prologueAsm := ziskMptExtensionExtractPrologue
   dataAsm     := ziskMptExtensionExtractDataSection
 }
+
+
+/-! ## mpt_account_path_nibbles -- PR-K100
+
+    Compute the state trie's path for a given 20-byte address:
+
+      digest   = keccak256(address)         # 32 bytes
+      nibbles  = unpack_high_low(digest)    # 64 nibbles
+
+    The MPT walks paths in nibble units (each byte = two
+    consecutive nibbles, high first). Account lookups in the state
+    trie use `keccak256(address)` as the path key, expressed as 64
+    nibbles. PR-K24 `mpt_walk` consumes such a nibble array; this
+    helper produces it from an address in one call.
+
+    Storage slots use the analogous `keccak256(slot_key_BE)` path;
+    K100 also handles that case directly when callers feed in a
+    32-byte slot key (see calling convention).
+
+    Composes PR-K3 `zkvm_keccak256`. Uses 32 bytes of `.data`
+    scratch (`mapn_digest`).
+
+    Calling convention:
+      a0 (input)  : address (or slot key) ptr
+      a1 (input)  : input length (20 for address, 32 for slot key)
+      a2 (input)  : 64-byte nibble output ptr
+      ra (input)  : return
+      a0 (output) : 0 (always succeeds). -/
+def mptAccountPathNibblesFunction : String :=
+  "mpt_account_path_nibbles:\n" ++
+  "  addi sp, sp, -16\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp)\n" ++
+  "  mv s0, a2                   # nibble output ptr (stash)\n" ++
+  "  # keccak256(input, len) → mapn_digest\n" ++
+  "  la a2, mapn_digest\n" ++
+  "  jal ra, zkvm_keccak256\n" ++
+  "  # Unpack 32 bytes → 64 nibbles.\n" ++
+  "  la t0, mapn_digest\n" ++
+  "  mv t1, s0                   # cursor over output\n" ++
+  "  li t2, 32                   # remaining bytes\n" ++
+  ".Lmapn_loop:\n" ++
+  "  beqz t2, .Lmapn_done\n" ++
+  "  lbu t3, 0(t0)\n" ++
+  "  srli t4, t3, 4              # high nibble\n" ++
+  "  andi t5, t3, 15             # low nibble\n" ++
+  "  sb t4, 0(t1)\n" ++
+  "  sb t5, 1(t1)\n" ++
+  "  addi t0, t0, 1\n" ++
+  "  addi t1, t1, 2\n" ++
+  "  addi t2, t2, -1\n" ++
+  "  j .Lmapn_loop\n" ++
+  ".Lmapn_done:\n" ++
+  "  li a0, 0\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp)\n" ++
+  "  addi sp, sp, 16\n" ++
+  "  ret"
+
+/-- `zisk_mpt_account_path_nibbles`: probe BuildUnit. Reads
+    (input_len, input_bytes) from host input, writes (status, 64
+    nibbles) to OUTPUT (72 bytes total). -/
+def ziskMptAccountPathNibblesPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a3, 0x40000000\n" ++
+  "  ld a1, 8(a3)                # input length\n" ++
+  "  addi a0, a3, 16             # input ptr\n" ++
+  "  li a2, 0xa0010008           # 64-byte nibble output\n" ++
+  "  jal ra, mpt_account_path_nibbles\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lmapn_pdone\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  mptAccountPathNibblesFunction ++ "\n" ++
+  ".Lmapn_pdone:"
+
+def ziskMptAccountPathNibblesDataSection : String :=
+  ".section .data\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  ".balign 8\n" ++
+  "mapn_digest:\n" ++
+  "  .zero 32"
+
+def ziskMptAccountPathNibblesProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskMptAccountPathNibblesPrologue
+  dataAsm     := ziskMptAccountPathNibblesDataSection
+}
+
+/-! ## mpt_node_kind -- PR-K21 classifier
+
+    Determines whether an RLP-encoded MPT node is a leaf,
+    extension, or branch by:
+      1. Probing whether item 2 exists (presence = 17-item
+         branch list).
+      2. If absent, reading item 0's first byte and inspecting
+         the high nibble (HP encoding flag: 0/1 → extension,
+         2/3 → leaf).
+
+    Calling convention:
+      a0 (input)  : node bytes ptr
+      a1 (input)  : node byte length
+      ra (input)  : return
+      a0 (output) : 0 branch / 1 extension / 2 leaf / 3 parse fail
+
+    Calls `rlp_list_nth_item` twice. Uses four 8-byte `.data`
+    scratches (`mnk_dummy_offset`, `mnk_dummy_length`,
+    `mnk_path_offset`, `mnk_path_length`) for the temporary
+    returns. -/
+def mptNodeKindFunction : String :=
+  "mpt_node_kind:\n" ++
+  "  addi sp, sp, -32\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp)\n" ++
+  "  mv s0, a0                  # node ptr\n" ++
+  "  mv s1, a1                  # node_len\n" ++
+  "  # Probe item 2 (index 2). If found ⇒ 17-item branch list.\n" ++
+  "  li a2, 2\n" ++
+  "  la a3, mnk_dummy_offset\n" ++
+  "  la a4, mnk_dummy_length\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  beqz a0, .Lmnk_branch\n" ++
+  "  # Item 2 absent ⇒ 2-item list (leaf or extension).\n" ++
+  "  # Get item 0 to read path's first byte.\n" ++
+  "  mv a0, s0\n" ++
+  "  mv a1, s1\n" ++
+  "  li a2, 0\n" ++
+  "  la a3, mnk_path_offset\n" ++
+  "  la a4, mnk_path_length\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lmnk_fail        # item 0 missing ⇒ parse fail\n" ++
+  "  la t0, mnk_path_offset\n" ++
+  "  ld t1, 0(t0)               # path content offset\n" ++
+  "  la t0, mnk_path_length\n" ++
+  "  ld t2, 0(t0)               # path content length\n" ++
+  "  beqz t2, .Lmnk_fail        # empty path ⇒ malformed HP\n" ++
+  "  add t3, s0, t1             # path byte ptr\n" ++
+  "  lbu t4, 0(t3)\n" ++
+  "  srli t4, t4, 4             # high nibble\n" ++
+  "  li t5, 2\n" ++
+  "  bltu t4, t5, .Lmnk_extension  # 0,1 → extension\n" ++
+  "  li t5, 4\n" ++
+  "  bltu t4, t5, .Lmnk_leaf       # 2,3 → leaf\n" ++
+  "  j .Lmnk_fail                   # ≥ 4 → invalid HP\n" ++
+  ".Lmnk_branch:\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lmnk_ret\n" ++
+  ".Lmnk_extension:\n" ++
+  "  li a0, 1\n" ++
+  "  j .Lmnk_ret\n" ++
+  ".Lmnk_leaf:\n" ++
+  "  li a0, 2\n" ++
+  "  j .Lmnk_ret\n" ++
+  ".Lmnk_fail:\n" ++
+  "  li a0, 3\n" ++
+  ".Lmnk_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp)\n" ++
+  "  addi sp, sp, 32\n" ++
+  "  ret"
+
+/-- `zisk_mpt_node_kind`: probe BuildUnit. Reads
+    (node_len, node_bytes) from host input, writes
+    classification result to OUTPUT.
+    Input layout:
+      bytes  0.. 8 : node_len (u64)
+      bytes  8..   : node bytes
+    Output layout:
+      bytes  0.. 8 : kind (u64; 0 branch / 1 ext / 2 leaf / 3 fail) -/
+def ziskMptNodeKindPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a3, 0x40000000\n" ++
+  "  ld a1, 8(a3)                # node_len\n" ++
+  "  addi a0, a3, 16             # node ptr\n" ++
+  "  jal ra, mpt_node_kind\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)                # write kind\n" ++
+  "  j .Lmnk_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  mptNodeKindFunction ++ "\n" ++
+  ".Lmnk_pdone:"
+
+def ziskMptNodeKindDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "mnk_dummy_offset:\n" ++
+  "  .zero 8\n" ++
+  "mnk_dummy_length:\n" ++
+  "  .zero 8\n" ++
+  "mnk_path_offset:\n" ++
+  "  .zero 8\n" ++
+  "mnk_path_length:\n" ++
+  "  .zero 8"
+
+def ziskMptNodeKindProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskMptNodeKindPrologue
+  dataAsm     := ziskMptNodeKindDataSection
+}
+
+/-! ## mpt_branch_child -- PR-K22 extract i-th child of a branch
+
+    Wraps `rlp_list_nth_item` with a branch-shape-aware
+    interpretation of the returned content. Ethereum MPT branch
+    nodes have items 0..15 each being one of:
+
+      * 32-byte hash       (Bytes32: 0xa0 + 32 raw bytes)
+      * empty bytes        (RLP 0x80)
+      * inlined RLP node   (variable bytes, < 32 bytes total)
+
+    Calling convention:
+      a0 (input)  : branch node bytes ptr
+      a1 (input)  : node byte length
+      a2 (input)  : nibble (0..15)
+      a3 (input)  : 32-byte output buffer ptr
+      ra (input)  : return
+      a0 (output) :
+        0 = hash slot (32 bytes copied to *a3)
+        1 = empty slot (output buffer zeroed)
+        2 = inlined RLP node (output buffer holds first ≤ 32
+            bytes of the inlined form, zero-padded)
+        3 = parse failure (nibble out of range or node
+            malformed)
+
+    Does NOT verify the caller has actually given a branch
+    node; if applied to a 2-item leaf/extension, items 0 and 1
+    are returned according to the same length-driven rules but
+    the semantics aren't branch-children. -/
+def mptBranchChildFunction : String :=
+  "mpt_branch_child:\n" ++
+  "  addi sp, sp, -48\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  mv s0, a0                  # node ptr\n" ++
+  "  mv s1, a1                  # node_len\n" ++
+  "  mv s2, a2                  # nibble\n" ++
+  "  mv s3, a3                  # out ptr\n" ++
+  "  li t0, 16\n" ++
+  "  bgeu s2, t0, .Lmbc_fail    # nibble ≥ 16 → out of range\n" ++
+  "  # Call rlp_list_nth_item(node, len, nibble, &mbc_offset, &mbc_length).\n" ++
+  "  mv a0, s0; mv a1, s1; mv a2, s2\n" ++
+  "  la a3, mbc_offset\n" ++
+  "  la a4, mbc_length\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lmbc_fail\n" ++
+  "  la t0, mbc_length\n" ++
+  "  ld t1, 0(t0)\n" ++
+  "  beqz t1, .Lmbc_empty       # length 0 ⇒ empty slot\n" ++
+  "  li t0, 32\n" ++
+  "  bne t1, t0, .Lmbc_inlined  # length != 32 ⇒ inlined\n" ++
+  "  # Hash slot: copy 32 bytes from node + offset to out.\n" ++
+  "  la t0, mbc_offset\n" ++
+  "  ld t2, 0(t0)\n" ++
+  "  add t2, s0, t2             # src\n" ++
+  "  ld t3,  0(t2); sd t3,  0(s3)\n" ++
+  "  ld t3,  8(t2); sd t3,  8(s3)\n" ++
+  "  ld t3, 16(t2); sd t3, 16(s3)\n" ++
+  "  ld t3, 24(t2); sd t3, 24(s3)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lmbc_ret\n" ++
+  ".Lmbc_empty:\n" ++
+  "  sd zero,  0(s3); sd zero,  8(s3)\n" ++
+  "  sd zero, 16(s3); sd zero, 24(s3)\n" ++
+  "  li a0, 1\n" ++
+  "  j .Lmbc_ret\n" ++
+  ".Lmbc_inlined:\n" ++
+  "  # Length 1..31. Zero the output, then byte-copy `length` bytes.\n" ++
+  "  sd zero,  0(s3); sd zero,  8(s3)\n" ++
+  "  sd zero, 16(s3); sd zero, 24(s3)\n" ++
+  "  la t0, mbc_offset\n" ++
+  "  ld t2, 0(t0)\n" ++
+  "  add t2, s0, t2             # src cursor\n" ++
+  "  mv t3, s3                  # dst cursor\n" ++
+  ".Lmbc_inline_cp:\n" ++
+  "  beqz t1, .Lmbc_inline_done\n" ++
+  "  lbu t4, 0(t2)\n" ++
+  "  sb  t4, 0(t3)\n" ++
+  "  addi t2, t2, 1\n" ++
+  "  addi t3, t3, 1\n" ++
+  "  addi t1, t1, -1\n" ++
+  "  j .Lmbc_inline_cp\n" ++
+  ".Lmbc_inline_done:\n" ++
+  "  li a0, 2\n" ++
+  "  j .Lmbc_ret\n" ++
+  ".Lmbc_fail:\n" ++
+  "  sd zero,  0(s3); sd zero,  8(s3)\n" ++
+  "  sd zero, 16(s3); sd zero, 24(s3)\n" ++
+  "  li a0, 3\n" ++
+  ".Lmbc_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  addi sp, sp, 48\n" ++
+  "  ret"
+
+/-- `zisk_mpt_branch_child`: probe BuildUnit. Reads
+    (node_len, nibble, node_bytes) from host input, writes
+    (status, 32-byte content) to OUTPUT.
+    Input layout:
+      bytes  0.. 8 : node_len (u64)
+      bytes  8..16 : nibble (u64)
+      bytes 16..   : node bytes
+    Output layout:
+      bytes  0.. 8 : status (0 hash / 1 empty / 2 inlined / 3 fail)
+      bytes  8..40 : 32-byte content (hash, zeros, or inlined bytes) -/
+def ziskMptBranchChildPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a4, 0x40000000\n" ++
+  "  ld a1, 8(a4)                # node_len\n" ++
+  "  ld a2, 16(a4)               # nibble\n" ++
+  "  addi a0, a4, 24             # node ptr\n" ++
+  "  li a3, 0xa0010008           # 32-byte out at OUTPUT + 8\n" ++
+  "  jal ra, mpt_branch_child\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)                # status\n" ++
+  "  j .Lmbc_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  mptBranchChildFunction ++ "\n" ++
+  ".Lmbc_pdone:"
+
+def ziskMptBranchChildDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "mbc_offset:\n" ++
+  "  .zero 8\n" ++
+  "mbc_length:\n" ++
+  "  .zero 8"
+
+def ziskMptBranchChildProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskMptBranchChildPrologue
+  dataAsm     := ziskMptBranchChildDataSection
+}
+
+/-! ## hp_decode_nibbles -- PR-K23 HP-encoded path → nibble array
+
+    Decode the HP-encoded first item of a leaf/extension MPT
+    node into an array of one-nibble bytes (each ∈ [0..15]).
+    Also returns whether the node is a leaf or extension.
+
+    HP encoding cheat-sheet (input byte 0):
+      high nibble  meaning
+      ----------   -------
+         0         extension, even path length (low nibble must be 0)
+         1         extension, odd path length (low nibble is first path nibble)
+         2         leaf, even path length (low nibble must be 0)
+         3         leaf, odd path length (low nibble is first path nibble)
+      anything else → invalid
+
+    Remaining input bytes hold 2 nibbles each (high, then low),
+    contributing to the output starting at the next slot.
+
+    Calling convention:
+      a0 (input)  : HP-encoded path bytes ptr
+      a1 (input)  : path byte length
+      a2 (input)  : output nibble buffer (caller-allocated;
+                    holds up to 2 * (a1 - 1) + 1 bytes,
+                    one byte per nibble)
+      a3 (input)  : u64 out ptr (number of nibbles emitted)
+      a4 (input)  : u64 out ptr (is_leaf flag: 0 = ext, 1 = leaf)
+      ra (input)  : return
+      a0 (output) : 0 success, 1 parse failure (empty input,
+                    high nibble ≥ 4, or even path with non-zero
+                    low nibble of byte 0).
+
+    Each output byte holds one nibble in its low 4 bits; the
+    high 4 bits are zero. This is the format consumed by future
+    `mpt_walk` (PR-K24) which compares one byte per nibble. -/
+def hpDecodeNibblesFunction : String :=
+  "hp_decode_nibbles:\n" ++
+  "  addi sp, sp, -48\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp)\n" ++
+  "  sd s3, 32(sp); sd s4, 40(sp)\n" ++
+  "  mv s0, a0                  # path_bytes ptr\n" ++
+  "  mv s1, a1                  # len\n" ++
+  "  mv s2, a2                  # out nibble buf\n" ++
+  "  mv s3, a3                  # out count ptr\n" ++
+  "  mv s4, a4                  # out is_leaf ptr\n" ++
+  "  beqz s1, .Lhp_fail\n" ++
+  "  lbu t0, 0(s0)              # b0\n" ++
+  "  srli t1, t0, 4             # high nibble\n" ++
+  "  andi t2, t0, 0xf           # low nibble\n" ++
+  "  li t3, 4\n" ++
+  "  bgeu t1, t3, .Lhp_fail     # high ≥ 4 → invalid\n" ++
+  "  # is_leaf = (high & 2) >> 1\n" ++
+  "  andi t3, t1, 2\n" ++
+  "  srli t3, t3, 1\n" ++
+  "  sd t3, 0(s4)\n" ++
+  "  # is_odd = high & 1\n" ++
+  "  andi t1, t1, 1\n" ++
+  "  beqz t1, .Lhp_even\n" ++
+  "  # Odd: write low as first output nibble.\n" ++
+  "  sb t2, 0(s2)\n" ++
+  "  li t5, 1                   # nibble count so far\n" ++
+  "  addi t6, s2, 1             # output cursor\n" ++
+  "  j .Lhp_loop_init\n" ++
+  ".Lhp_even:\n" ++
+  "  bnez t2, .Lhp_fail         # even but low nibble != 0\n" ++
+  "  li t5, 0\n" ++
+  "  mv t6, s2\n" ++
+  ".Lhp_loop_init:\n" ++
+  "  li t0, 1                   # i = 1\n" ++
+  ".Lhp_loop:\n" ++
+  "  bgeu t0, s1, .Lhp_done\n" ++
+  "  add t1, s0, t0\n" ++
+  "  lbu t2, 0(t1)\n" ++
+  "  srli t3, t2, 4\n" ++
+  "  andi t4, t2, 0xf\n" ++
+  "  sb t3, 0(t6)\n" ++
+  "  sb t4, 1(t6)\n" ++
+  "  addi t6, t6, 2\n" ++
+  "  addi t5, t5, 2\n" ++
+  "  addi t0, t0, 1\n" ++
+  "  j .Lhp_loop\n" ++
+  ".Lhp_done:\n" ++
+  "  sd t5, 0(s3)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lhp_ret\n" ++
+  ".Lhp_fail:\n" ++
+  "  li a0, 1\n" ++
+  ".Lhp_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp)\n" ++
+  "  ld s3, 32(sp); ld s4, 40(sp)\n" ++
+  "  addi sp, sp, 48\n" ++
+  "  ret"
+
+/-- `zisk_hp_decode_nibbles`: probe BuildUnit. Reads
+    (path_len, path_bytes) from host input, writes
+    (status, count, is_leaf, nibbles...) to OUTPUT.
+    Input layout:
+      bytes  0.. 8 : path_len (u64)
+      bytes  8..   : HP-encoded path bytes
+    Output layout:
+      bytes  0.. 8 : status (u64; 0 ok, 1 fail)
+      bytes  8..16 : nibble count (u64)
+      bytes 16..24 : is_leaf (u64)
+      bytes 24..   : nibble bytes (count bytes; each in [0..15]) -/
+def ziskHpDecodeNibblesPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a4, 0x40000000\n" ++
+  "  ld a1, 8(a4)                # path_len\n" ++
+  "  addi a0, a4, 16             # path bytes ptr\n" ++
+  "  li a2, 0xa0010018           # nibble buf at OUTPUT + 24\n" ++
+  "  li a3, 0xa0010008           # count ptr at OUTPUT + 8\n" ++
+  "  li a4, 0xa0010010           # is_leaf ptr at OUTPUT + 16\n" ++
+  "  jal ra, hp_decode_nibbles\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)                # status at OUTPUT + 0\n" ++
+  "  j .Lhp_pdone\n" ++
+  hpDecodeNibblesFunction ++ "\n" ++
+  ".Lhp_pdone:"
+
+def ziskHpDecodeNibblesDataSection : String :=
+  ".section .data\n" ++
+  "hp_pad:\n" ++
+  "  .zero 8"
+
+def ziskHpDecodeNibblesProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskHpDecodeNibblesPrologue
+  dataAsm     := ziskHpDecodeNibblesDataSection
+}
+
+/-! ## mpt_walk -- PR-K24 end-to-end MPT lookup
+
+    Compose every K-stack primitive into a single
+    `mpt_walk(root, witness, path) → value` entry. Walks the
+    branch / extension / leaf chain following nibble path
+    elements.
+
+    Calling convention:
+      a0 (input)  : root_hash ptr (32 bytes)
+      a1 (input)  : witness.state SSZ list section ptr
+      a2 (input)  : witness section_len
+      a3 (input)  : path_nibbles ptr (one byte per nibble)
+      a4 (input)  : path_nibbles_len
+      a5 (input)  : value output buffer ptr (256 bytes)
+      a6 (input)  : u64 out ptr (matched value byte length)
+      ra (input)  : return
+      a0 (output) : 0 (found) / 1 (not found) / 2 (parse error)
+
+    Calls itself transitively via PR-K19..K23 primitives.
+    Uses a 256-byte mw_value_buf for the output and ~200 B of
+    additional scratch state. -/
+def mptWalkFunction : String :=
+  "mpt_walk:\n" ++
+  "  addi sp, sp, -80\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp); sd s7, 64(sp)\n" ++
+  "  sd s8, 72(sp)\n" ++
+  "  mv s0, a1                   # s0 = witness ptr\n" ++
+  "  mv s1, a2                   # s1 = witness_len\n" ++
+  "  mv s2, a3                   # s2 = path_nibbles ptr\n" ++
+  "  mv s3, a4                   # s3 = path_nibbles_len\n" ++
+  "  mv s4, a5                   # s4 = value out buf\n" ++
+  "  mv s5, a6                   # s5 = value_len out ptr\n" ++
+  "  # Copy root_hash to mw_lookup_hash for the first lookup.\n" ++
+  "  la t0, mw_lookup_hash\n" ++
+  "  ld t1,  0(a0); sd t1,  0(t0)\n" ++
+  "  ld t1,  8(a0); sd t1,  8(t0)\n" ++
+  "  ld t1, 16(a0); sd t1, 16(t0)\n" ++
+  "  ld t1, 24(a0); sd t1, 24(t0)\n" ++
+  "  # First lookup of root_hash in witness.\n" ++
+  "  mv a0, s0\n" ++
+  "  mv a1, s1\n" ++
+  "  la a2, mw_lookup_hash\n" ++
+  "  la a3, mw_lookup_offset\n" ++
+  "  la a4, mw_lookup_length\n" ++
+  "  jal ra, witness_lookup_by_hash\n" ++
+  "  bnez a0, .Lmw_not_found\n" ++
+  "  # s7 = current node ptr; s8 = current node len; s6 = consumed nibbles.\n" ++
+  "  la t0, mw_lookup_offset; ld t1, 0(t0); add s7, s0, t1\n" ++
+  "  la t0, mw_lookup_length; ld s8, 0(t0)\n" ++
+  "  li s6, 0\n" ++
+  ".Lmw_loop:\n" ++
+  "  mv a0, s7\n" ++
+  "  mv a1, s8\n" ++
+  "  jal ra, mpt_node_kind\n" ++
+  "  beqz a0, .Lmw_branch\n" ++
+  "  li t0, 1; beq a0, t0, .Lmw_extension\n" ++
+  "  li t0, 2; beq a0, t0, .Lmw_leaf\n" ++
+  "  j .Lmw_parse_fail\n" ++
+  ".Lmw_branch:\n" ++
+  "  beq s6, s3, .Lmw_branch_end\n" ++
+  "  # Get child slot via rlp_list_nth_item (bypass mpt_branch_child so we\n" ++
+  "  # can keep the actual inlined byte count, not zero-padded to 32).\n" ++
+  "  add t0, s2, s6              # &path[consumed]\n" ++
+  "  lbu t1, 0(t0)\n" ++
+  "  mv a0, s7\n" ++
+  "  mv a1, s8\n" ++
+  "  mv a2, t1                   # nibble (item index)\n" ++
+  "  la a3, mw_child_offset\n" ++
+  "  la a4, mw_child_length\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  addi s6, s6, 1\n" ++
+  "  bnez a0, .Lmw_parse_fail\n" ++
+  "  la t0, mw_child_length; ld t1, 0(t0)\n" ++
+  "  beqz t1, .Lmw_not_found      # empty slot\n" ++
+  "  li t2, 32\n" ++
+  "  beq t1, t2, .Lmw_branch_hash\n" ++
+  "  # Inlined (length 1..31): set node to (s7 + child_offset, child_length).\n" ++
+  "  la t0, mw_child_offset; ld t2, 0(t0)\n" ++
+  "  add s7, s7, t2\n" ++
+  "  mv s8, t1\n" ++
+  "  j .Lmw_loop\n" ++
+  ".Lmw_branch_hash:\n" ++
+  "  # 32-byte hash: copy to mw_lookup_hash then lookup.\n" ++
+  "  la t0, mw_child_offset; ld t1, 0(t0)\n" ++
+  "  add t2, s7, t1\n" ++
+  "  la t3, mw_lookup_hash\n" ++
+  "  ld t4,  0(t2); sd t4,  0(t3)\n" ++
+  "  ld t4,  8(t2); sd t4,  8(t3)\n" ++
+  "  ld t4, 16(t2); sd t4, 16(t3)\n" ++
+  "  ld t4, 24(t2); sd t4, 24(t3)\n" ++
+  "  mv a0, s0\n" ++
+  "  mv a1, s1\n" ++
+  "  la a2, mw_lookup_hash\n" ++
+  "  la a3, mw_lookup_offset\n" ++
+  "  la a4, mw_lookup_length\n" ++
+  "  jal ra, witness_lookup_by_hash\n" ++
+  "  bnez a0, .Lmw_not_found\n" ++
+  "  la t0, mw_lookup_offset; ld t1, 0(t0); add s7, s0, t1\n" ++
+  "  la t0, mw_lookup_length; ld s8, 0(t0)\n" ++
+  "  j .Lmw_loop\n" ++
+  ".Lmw_branch_end:\n" ++
+  "  mv a0, s7\n" ++
+  "  mv a1, s8\n" ++
+  "  li a2, 16\n" ++
+  "  la a3, mw_value_offset\n" ++
+  "  la a4, mw_value_length\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lmw_parse_fail\n" ++
+  "  la t0, mw_value_length; ld t1, 0(t0)\n" ++
+  "  beqz t1, .Lmw_not_found     # empty value slot\n" ++
+  "  j .Lmw_copy_value\n" ++
+  ".Lmw_extension:\n" ++
+  "  mv a0, s7\n" ++
+  "  mv a1, s8\n" ++
+  "  li a2, 0\n" ++
+  "  la a3, mw_path_offset\n" ++
+  "  la a4, mw_path_length\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lmw_parse_fail\n" ++
+  "  la t0, mw_path_offset; ld t1, 0(t0); add a0, s7, t1\n" ++
+  "  la t0, mw_path_length; ld a1, 0(t0)\n" ++
+  "  la a2, mw_nibble_buf\n" ++
+  "  la a3, mw_nibble_count\n" ++
+  "  la a4, mw_is_leaf\n" ++
+  "  jal ra, hp_decode_nibbles\n" ++
+  "  bnez a0, .Lmw_parse_fail\n" ++
+  "  la t0, mw_is_leaf; ld t1, 0(t0)\n" ++
+  "  bnez t1, .Lmw_parse_fail    # node kind said extension; HP says leaf\n" ++
+  "  la t0, mw_nibble_count; ld t1, 0(t0)\n" ++
+  "  add t2, s6, t1\n" ++
+  "  bgtu t2, s3, .Lmw_not_found # consumed + nib_count > path_len\n" ++
+  "  # Compare nibbles\n" ++
+  "  la t2, mw_nibble_buf\n" ++
+  "  add t3, s2, s6\n" ++
+  "  mv t4, t1\n" ++
+  ".Lmw_ext_cmp:\n" ++
+  "  beqz t4, .Lmw_ext_cmp_done\n" ++
+  "  lbu t5, 0(t2)\n" ++
+  "  lbu t6, 0(t3)\n" ++
+  "  bne t5, t6, .Lmw_not_found\n" ++
+  "  addi t2, t2, 1\n" ++
+  "  addi t3, t3, 1\n" ++
+  "  addi t4, t4, -1\n" ++
+  "  j .Lmw_ext_cmp\n" ++
+  ".Lmw_ext_cmp_done:\n" ++
+  "  add s6, s6, t1\n" ++
+  "  # Get item 1 (child ref).\n" ++
+  "  mv a0, s7\n" ++
+  "  mv a1, s8\n" ++
+  "  li a2, 1\n" ++
+  "  la a3, mw_child_offset\n" ++
+  "  la a4, mw_child_length\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lmw_parse_fail\n" ++
+  "  la t0, mw_child_length; ld t1, 0(t0)\n" ++
+  "  la t0, mw_child_offset; ld t2, 0(t0)\n" ++
+  "  add t3, s7, t2\n" ++
+  "  li t4, 32\n" ++
+  "  beq t1, t4, .Lmw_ext_hash\n" ++
+  "  # Inline child: t3 is its ptr, t1 is its length.\n" ++
+  "  mv s7, t3\n" ++
+  "  mv s8, t1\n" ++
+  "  j .Lmw_loop\n" ++
+  ".Lmw_ext_hash:\n" ++
+  "  la t4, mw_lookup_hash\n" ++
+  "  ld t5,  0(t3); sd t5,  0(t4)\n" ++
+  "  ld t5,  8(t3); sd t5,  8(t4)\n" ++
+  "  ld t5, 16(t3); sd t5, 16(t4)\n" ++
+  "  ld t5, 24(t3); sd t5, 24(t4)\n" ++
+  "  mv a0, s0\n" ++
+  "  mv a1, s1\n" ++
+  "  la a2, mw_lookup_hash\n" ++
+  "  la a3, mw_lookup_offset\n" ++
+  "  la a4, mw_lookup_length\n" ++
+  "  jal ra, witness_lookup_by_hash\n" ++
+  "  bnez a0, .Lmw_not_found\n" ++
+  "  la t0, mw_lookup_offset; ld t1, 0(t0); add s7, s0, t1\n" ++
+  "  la t0, mw_lookup_length; ld s8, 0(t0)\n" ++
+  "  j .Lmw_loop\n" ++
+  ".Lmw_leaf:\n" ++
+  "  mv a0, s7\n" ++
+  "  mv a1, s8\n" ++
+  "  li a2, 0\n" ++
+  "  la a3, mw_path_offset\n" ++
+  "  la a4, mw_path_length\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lmw_parse_fail\n" ++
+  "  la t0, mw_path_offset; ld t1, 0(t0); add a0, s7, t1\n" ++
+  "  la t0, mw_path_length; ld a1, 0(t0)\n" ++
+  "  la a2, mw_nibble_buf\n" ++
+  "  la a3, mw_nibble_count\n" ++
+  "  la a4, mw_is_leaf\n" ++
+  "  jal ra, hp_decode_nibbles\n" ++
+  "  bnez a0, .Lmw_parse_fail\n" ++
+  "  la t0, mw_is_leaf; ld t1, 0(t0)\n" ++
+  "  li t2, 1\n" ++
+  "  bne t1, t2, .Lmw_parse_fail\n" ++
+  "  la t0, mw_nibble_count; ld t1, 0(t0)\n" ++
+  "  sub t2, s3, s6              # remaining nibbles\n" ++
+  "  bne t1, t2, .Lmw_not_found  # length mismatch\n" ++
+  "  la t2, mw_nibble_buf\n" ++
+  "  add t3, s2, s6\n" ++
+  "  mv t4, t1\n" ++
+  ".Lmw_leaf_cmp:\n" ++
+  "  beqz t4, .Lmw_leaf_match\n" ++
+  "  lbu t5, 0(t2)\n" ++
+  "  lbu t6, 0(t3)\n" ++
+  "  bne t5, t6, .Lmw_not_found\n" ++
+  "  addi t2, t2, 1\n" ++
+  "  addi t3, t3, 1\n" ++
+  "  addi t4, t4, -1\n" ++
+  "  j .Lmw_leaf_cmp\n" ++
+  ".Lmw_leaf_match:\n" ++
+  "  mv a0, s7\n" ++
+  "  mv a1, s8\n" ++
+  "  li a2, 1\n" ++
+  "  la a3, mw_value_offset\n" ++
+  "  la a4, mw_value_length\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lmw_parse_fail\n" ++
+  ".Lmw_copy_value:\n" ++
+  "  # Write value_len, then byte-copy at most 256 bytes from\n" ++
+  "  # (s7 + mw_value_offset) to s4.\n" ++
+  "  la t0, mw_value_length; ld t1, 0(t0)\n" ++
+  "  sd t1, 0(s5)\n" ++
+  "  la t0, mw_value_offset; ld t2, 0(t0); add t2, s7, t2\n" ++
+  "  mv t3, s4                   # dst\n" ++
+  "  li t4, 256\n" ++
+  "  bgtu t1, t4, .Lmw_copy_set_cap\n" ++
+  "  j .Lmw_copy_loop\n" ++
+  ".Lmw_copy_set_cap:\n" ++
+  "  mv t1, t4\n" ++
+  ".Lmw_copy_loop:\n" ++
+  "  beqz t1, .Lmw_found\n" ++
+  "  lbu t0, 0(t2)\n" ++
+  "  sb  t0, 0(t3)\n" ++
+  "  addi t2, t2, 1\n" ++
+  "  addi t3, t3, 1\n" ++
+  "  addi t1, t1, -1\n" ++
+  "  j .Lmw_copy_loop\n" ++
+  ".Lmw_found:\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lmw_ret\n" ++
+  ".Lmw_not_found:\n" ++
+  "  li a0, 1\n" ++
+  "  sd zero, 0(s5)              # value_len = 0\n" ++
+  "  j .Lmw_ret\n" ++
+  ".Lmw_parse_fail:\n" ++
+  "  li a0, 2\n" ++
+  "  sd zero, 0(s5)\n" ++
+  ".Lmw_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp); ld s7, 64(sp)\n" ++
+  "  ld s8, 72(sp)\n" ++
+  "  addi sp, sp, 80\n" ++
+  "  ret"
+
+/-- `zisk_mpt_walk`: probe BuildUnit. Reads
+    (witness_len, path_len, root_hash, path_nibbles,
+     witness_bytes) from host input, writes
+    (status, value_len, value_bytes) to OUTPUT.
+    Input layout:
+      bytes   0..  8 : witness_len (u64)
+      bytes   8.. 16 : path_len (u64)
+      bytes  16.. 48 : root_hash (32 bytes)
+      bytes  48..   : path_nibbles bytes (path_len of them)
+      bytes  48 + path_len .. : witness section bytes
+    Output layout:
+      bytes   0.. 8 : status (0 found / 1 not / 2 fail)
+      bytes   8..16 : value_len
+      bytes  16..   : value bytes (up to 256 - 16 = 240) -/
+def ziskMptWalkPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a7, 0x40000000\n" ++
+  "  ld t6, 8(a7)                # witness_len\n" ++
+  "  ld t5, 16(a7)               # path_len\n" ++
+  "  addi a0, a7, 24             # root_hash ptr (offset 16 from start of file)\n" ++
+  "  addi a3, a7, 56             # path_nibbles ptr (offset 48)\n" ++
+  "  # witness ptr = path_nibbles + path_len.\n" ++
+  "  add a1, a3, t5\n" ++
+  "  mv a2, t6                   # witness_len\n" ++
+  "  mv a4, t5                   # path_len\n" ++
+  "  li a5, 0xa0010010           # value buf at OUTPUT + 16\n" ++
+  "  li a6, 0xa0010008           # value_len ptr at OUTPUT + 8\n" ++
+  "  jal ra, mpt_walk\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)                # status at OUTPUT + 0\n" ++
+  "  j .Lmw_pdone\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  witnessLookupByHashFunction ++ "\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  mptNodeKindFunction ++ "\n" ++
+  mptBranchChildFunction ++ "\n" ++
+  hpDecodeNibblesFunction ++ "\n" ++
+  mptWalkFunction ++ "\n" ++
+  ".Lmw_pdone:"
+
+def ziskMptWalkDataSection : String :=
+  ".section .data\n" ++
+  ".balign 32\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  ".balign 32\n" ++
+  "wlh_scratch_hash:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "mnk_dummy_offset:\n" ++
+  "  .zero 8\n" ++
+  "mnk_dummy_length:\n" ++
+  "  .zero 8\n" ++
+  "mnk_path_offset:\n" ++
+  "  .zero 8\n" ++
+  "mnk_path_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "mbc_offset:\n" ++
+  "  .zero 8\n" ++
+  "mbc_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "mw_lookup_hash:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "mw_lookup_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_lookup_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "mw_child_buf:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "mw_path_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_path_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "mw_child_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_child_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "mw_value_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_value_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "mw_nibble_count:\n" ++
+  "  .zero 8\n" ++
+  "mw_is_leaf:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "mw_nibble_buf:\n" ++
+  "  .zero 128"
+
+def ziskMptWalkProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskMptWalkPrologue
+  dataAsm     := ziskMptWalkDataSection
+}
+
+/-! ## bytes_to_nibbles -- PR-K25 byte → nibble array expansion
+
+    Convert N bytes into 2N nibbles (one byte per nibble, in
+    [0..15]). Each input byte writes 2 output bytes: high nibble
+    then low nibble. The output format matches what `mpt_walk`
+    (PR-K24) consumes as its path argument.
+
+    Composes with `zkvm_keccak256` to derive the standard MPT
+    path from a state-trie or storage-trie key:
+
+        keccak256(address)   -- 32 bytes
+        bytes_to_nibbles     -- 64 nibbles
+        mpt_walk(...)        -- account / slot lookup
+
+    Calling convention:
+      a0 (input)  : src bytes ptr
+      a1 (input)  : src byte length
+      a2 (input)  : dst nibble buf ptr (2 * a1 bytes)
+      ra (input)  : return
+      a0 (output) : 2 * a1 (number of nibbles emitted)
+
+    Pure register arithmetic, no scratch memory, leaf-callable. -/
+def bytesToNibblesFunction : String :=
+  "bytes_to_nibbles:\n" ++
+  "  mv t0, a0                  # src cursor\n" ++
+  "  mv t1, a2                  # dst cursor\n" ++
+  "  mv t2, a1                  # remaining\n" ++
+  "  li t6, 0                   # emitted count\n" ++
+  ".Lbtn_loop:\n" ++
+  "  beqz t2, .Lbtn_done\n" ++
+  "  lbu t3, 0(t0)\n" ++
+  "  srli t4, t3, 4\n" ++
+  "  andi t5, t3, 0xf\n" ++
+  "  sb t4, 0(t1)\n" ++
+  "  sb t5, 1(t1)\n" ++
+  "  addi t0, t0, 1\n" ++
+  "  addi t1, t1, 2\n" ++
+  "  addi t2, t2, -1\n" ++
+  "  addi t6, t6, 2\n" ++
+  "  j .Lbtn_loop\n" ++
+  ".Lbtn_done:\n" ++
+  "  mv a0, t6\n" ++
+  "  ret"
+
+/-- `zisk_bytes_to_nibbles`: probe BuildUnit. Reads
+    (src_len, src_bytes) from host input, writes
+    (nibble_count, nibbles) to OUTPUT.
+    Input layout:
+      bytes  0.. 8 : src_len (u64)
+      bytes  8..   : src bytes
+    Output layout:
+      bytes  0.. 8 : nibble_count (u64 = 2 * src_len)
+      bytes  8..   : nibble bytes -/
+def ziskBytesToNibblesPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a3, 0x40000000\n" ++
+  "  ld a1, 8(a3)                # src_len\n" ++
+  "  addi a0, a3, 16             # src bytes ptr\n" ++
+  "  li a2, 0xa0010008           # nibble buf at OUTPUT + 8\n" ++
+  "  jal ra, bytes_to_nibbles\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)                # nibble_count at OUTPUT + 0\n" ++
+  "  j .Lbtn_pdone\n" ++
+  bytesToNibblesFunction ++ "\n" ++
+  ".Lbtn_pdone:"
+
+def ziskBytesToNibblesDataSection : String :=
+  ".section .data\n" ++
+  "btn_pad:\n" ++
+  "  .zero 8"
+
+def ziskBytesToNibblesProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskBytesToNibblesPrologue
+  dataAsm     := ziskBytesToNibblesDataSection
+}
+
+/-! ## mpt_lookup_by_key -- PR-K26 keccak + nibbles + mpt_walk
+
+    Compose the lookup chain that turns a raw key (address or
+    storage slot index) into a value via Ethereum's standard
+    `keccak256(key) -> path -> mpt_walk(...)` shape.
+
+    Both Ethereum state and storage tries use this same shape;
+    only the value semantics differ (account RLP vs 32-byte
+    storage word).
+
+    Calling convention:
+      a0 (input)  : key bytes ptr (20-byte address or 32-byte
+                    storage slot index, big-endian)
+      a1 (input)  : key byte length
+      a2 (input)  : root_hash ptr (32 bytes)
+      a3 (input)  : witness section ptr
+      a4 (input)  : witness section_len
+      a5 (input)  : value output buffer ptr (256 bytes)
+      a6 (input)  : u64 out ptr (matched value byte length)
+      ra (input)  : return
+      a0 (output) : 0 found / 1 not found / 2 parse error
+                    (mirrors mpt_walk return codes).
+
+    Internal scratch buffers:
+      mlk_keccak_buf : 32 bytes (keccak256 output)
+      mlk_nibble_buf : 64 bytes (one nibble per byte) -/
+def mptLookupByKeyFunction : String :=
+  "mpt_lookup_by_key:\n" ++
+  "  addi sp, sp, -64\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp); sd s4, 40(sp)\n" ++
+  "  mv s0, a2                   # s0 = root_hash ptr\n" ++
+  "  mv s1, a3                   # s1 = witness ptr\n" ++
+  "  mv s2, a4                   # s2 = witness_len\n" ++
+  "  mv s3, a5                   # s3 = value out\n" ++
+  "  mv s4, a6                   # s4 = value_len out\n" ++
+  "  # Step 1: keccak(key) -> mlk_keccak_buf.\n" ++
+  "  la a2, mlk_keccak_buf\n" ++
+  "  jal ra, zkvm_keccak256\n" ++
+  "  # Step 2: bytes_to_nibbles(mlk_keccak_buf, 32, mlk_nibble_buf).\n" ++
+  "  la a0, mlk_keccak_buf\n" ++
+  "  li a1, 32\n" ++
+  "  la a2, mlk_nibble_buf\n" ++
+  "  jal ra, bytes_to_nibbles\n" ++
+  "  # Step 3: mpt_walk(root, witness, witness_len, path, 64, val_out, val_len).\n" ++
+  "  mv a0, s0\n" ++
+  "  mv a1, s1\n" ++
+  "  mv a2, s2\n" ++
+  "  la a3, mlk_nibble_buf\n" ++
+  "  li a4, 64\n" ++
+  "  mv a5, s3\n" ++
+  "  mv a6, s4\n" ++
+  "  jal ra, mpt_walk\n" ++
+  "  # a0 already holds mpt_walk's status.\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp); ld s4, 40(sp)\n" ++
+  "  addi sp, sp, 64\n" ++
+  "  ret"
+
+/-- `zisk_mpt_lookup_by_key`: probe BuildUnit. Reads
+    (witness_len, key_len, root_hash, key, witness) from host
+    input and writes (status, value_len, value_bytes) to OUTPUT.
+    Input layout:
+      bytes   0.. 8 : witness_len (u64)
+      bytes   8..16 : key_len (u64)
+      bytes  16..48 : root_hash (32 bytes)
+      bytes  48..   : key bytes (key_len)
+      bytes  48+key_len.. : witness section bytes
+    Output: same as PR-K24 mpt_walk. -/
+def ziskMptLookupByKeyPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a7, 0x40000000\n" ++
+  "  ld t6, 8(a7)                # witness_len\n" ++
+  "  ld t5, 16(a7)               # key_len\n" ++
+  "  addi a2, a7, 24             # root_hash ptr (input offset 16)\n" ++
+  "  addi a0, a7, 56             # key ptr (input offset 48)\n" ++
+  "  mv a1, t5                   # key_len\n" ++
+  "  add a3, a0, t5              # witness ptr = key + key_len\n" ++
+  "  mv a4, t6                   # witness_len\n" ++
+  "  li a5, 0xa0010010           # value buf at OUTPUT + 16\n" ++
+  "  li a6, 0xa0010008           # value_len at OUTPUT + 8\n" ++
+  "  jal ra, mpt_lookup_by_key\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)                # status at OUTPUT + 0\n" ++
+  "  j .Lmlk_pdone\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  witnessLookupByHashFunction ++ "\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  mptNodeKindFunction ++ "\n" ++
+  mptBranchChildFunction ++ "\n" ++
+  hpDecodeNibblesFunction ++ "\n" ++
+  bytesToNibblesFunction ++ "\n" ++
+  mptWalkFunction ++ "\n" ++
+  mptLookupByKeyFunction ++ "\n" ++
+  ".Lmlk_pdone:"
+
+def ziskMptLookupByKeyDataSection : String :=
+  ".section .data\n" ++
+  ".balign 32\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  ".balign 32\n" ++
+  "wlh_scratch_hash:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "mnk_dummy_offset:\n" ++
+  "  .zero 8\n" ++
+  "mnk_dummy_length:\n" ++
+  "  .zero 8\n" ++
+  "mnk_path_offset:\n" ++
+  "  .zero 8\n" ++
+  "mnk_path_length:\n" ++
+  "  .zero 8\n" ++
+  "mbc_offset:\n" ++
+  "  .zero 8\n" ++
+  "mbc_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "mw_lookup_hash:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "mw_lookup_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_lookup_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "mw_child_buf:\n" ++
+  "  .zero 32\n" ++
+  ".balign 8\n" ++
+  "mw_path_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_path_length:\n" ++
+  "  .zero 8\n" ++
+  "mw_child_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_child_length:\n" ++
+  "  .zero 8\n" ++
+  "mw_value_offset:\n" ++
+  "  .zero 8\n" ++
+  "mw_value_length:\n" ++
+  "  .zero 8\n" ++
+  "mw_nibble_count:\n" ++
+  "  .zero 8\n" ++
+  "mw_is_leaf:\n" ++
+  "  .zero 8\n" ++
+  ".balign 32\n" ++
+  "mw_nibble_buf:\n" ++
+  "  .zero 128\n" ++
+  ".balign 32\n" ++
+  "mlk_keccak_buf:\n" ++
+  "  .zero 32\n" ++
+  ".balign 32\n" ++
+  "mlk_nibble_buf:\n" ++
+  "  .zero 64"
+
+def ziskMptLookupByKeyProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskMptLookupByKeyPrologue
+  dataAsm     := ziskMptLookupByKeyDataSection
+}
+
+
+/-! ## mpt_branch_used_count -- PR-K117
+
+    Count the number of non-empty child slots in an MPT branch
+    node's `[c0, c1, …, c15, value]` head. A child slot is
+    "non-empty" iff its RLP byte-length is > 0 (empty children
+    serialise as the empty RLP string `0x80`, len 0).
+
+    Used by state-root recomputation to detect *single-child*
+    branches that can collapse into an extension after a delete
+    operation: the trie invariant says a branch must always have
+    ≥ 2 children or be replaced by an extension/leaf.
+
+    The `value` field (item 16) is **not** counted; only the 16
+    nibble-indexed children. A branch where the value slot is the
+    only non-empty entry still returns 0 here (and is itself a
+    consensus violation under the standard trie invariants).
+-/
+/-! ## mpt_branch_first_used_index -- PR-K118
+
+    Find the lowest-indexed non-empty child slot in an MPT branch
+    node's `[c0, c1, …, c15, value]` head. Returns the index in
+    `[0, 15]` of the first child whose RLP byte-length is > 0, or
+    `16` (sentinel "none") when every child slot is empty.
+
+    Used by state-root recomputation in the *trie-collapse* path:
+    when PR-K117 `mpt_branch_used_count` reports exactly one
+    surviving child, this helper tells the rewriter *which* child
+    to inline into the parent's path.
+
+    The `value` field (item 16) is **not** scanned. A branch where
+    the value slot is the only non-empty entry still returns the
+    `16` sentinel.
+
+    Composes:
+      - PR-K47 `rlp_list_count_items` — sanity-check 17 items
+      - PR-K20 `rlp_list_nth_item`    — per-child length probe
+
+    Calling convention:
+      a0 (input)  : branch_rlp ptr
+      a1 (input)  : branch_rlp byte length
+      a2 (input)  : u64 out ptr (used_count, 0..16)
+      ra (input)  : return
+      a0 (output) :
+        0 : success
+        1 : not a 17-item list (or RLP parse failure)
+        2 : mid-list nth_item failure -/
+def mptBranchUsedCountFunction : String :=
+  "mpt_branch_used_count:\n" ++
+  "  addi sp, sp, -48\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp); sd s4, 40(sp)\n" ++
+  "  mv s0, a0                   # branch ptr\n" ++
+  "  mv s1, a1                   # branch len\n" ++
+  "  mv s2, a2                   # used_count out\n" ++
+  "  sd zero, 0(s2)\n" ++
+  "  # Verify 17-item list.\n" ++
+  "  mv a0, s0; mv a1, s1\n" ++
+  "  la a2, mbuc_count\n" ++
+  "  jal ra, rlp_list_count_items\n" ++
+  "  bnez a0, .Lmbuc_not_branch\n" ++
+  "  la t0, mbuc_count; ld t1, 0(t0)\n" ++
+  "  li t2, 17\n" ++
+  "  bne t1, t2, .Lmbuc_not_branch\n" ++
+  "  li s3, 0                    # i = 0\n" ++
+  "  li s4, 0                    # used = 0\n" ++
+  ".Lmbuc_loop:\n" ++
+  "  li t0, 16\n" ++
+  "  beq s3, t0, .Lmbuc_done\n" ++
+  "  mv a0, s0; mv a1, s1\n" ++
+  "  mv a2, s3\n" ++
+  "  la a3, mbuc_off; la a4, mbuc_len\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lmbuc_nth_fail\n" ++
+  "  la t0, mbuc_len; ld t1, 0(t0)\n" ++
+  "  beqz t1, .Lmbuc_step\n" ++
+  "  addi s4, s4, 1\n" ++
+  ".Lmbuc_step:\n" ++
+  "  addi s3, s3, 1\n" ++
+  "  j .Lmbuc_loop\n" ++
+  ".Lmbuc_done:\n" ++
+  "  sd s4, 0(s2)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lmbuc_ret\n" ++
+  ".Lmbuc_not_branch:\n" ++
+  "  li a0, 1\n" ++
+  "  j .Lmbuc_ret\n" ++
+  ".Lmbuc_nth_fail:\n" ++
+  "  li a0, 2\n" ++
+  ".Lmbuc_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp); ld s4, 40(sp)\n" ++
+  "  addi sp, sp, 48\n" ++
+  "  ret"
+def mptBranchFirstUsedIndexFunction : String :=
+  "mpt_branch_first_used_index:\n" ++
+  "  addi sp, sp, -48\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp); sd s4, 40(sp)\n" ++
+  "  mv s0, a0                   # branch ptr\n" ++
+  "  mv s1, a1                   # branch len\n" ++
+  "  mv s2, a2                   # used_count out\n" ++
+  "  sd zero, 0(s2)\n" ++
+  "  # Verify 17-item list.\n" ++
+  "  mv a0, s0; mv a1, s1\n" ++
+  "  la a2, mbuc_count\n" ++
+  "  jal ra, rlp_list_count_items\n" ++
+  "  bnez a0, .Lmbuc_not_branch\n" ++
+  "  la t0, mbuc_count; ld t1, 0(t0)\n" ++
+  "  li t2, 17\n" ++
+  "  bne t1, t2, .Lmbuc_not_branch\n" ++
+  "  li s3, 0                    # i = 0\n" ++
+  "  li s4, 0                    # used = 0\n" ++
+  ".Lmbuc_loop:\n" ++
+  "  li t0, 16\n" ++
+  "  beq s3, t0, .Lmbuc_done\n" ++
+  "  mv a0, s0; mv a1, s1\n" ++
+  "  mv a2, s3\n" ++
+  "  la a3, mbuc_off; la a4, mbuc_len\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lmbuc_nth_fail\n" ++
+  "  la t0, mbuc_len; ld t1, 0(t0)\n" ++
+  "  beqz t1, .Lmbuc_step\n" ++
+  "  addi s4, s4, 1\n" ++
+  ".Lmbuc_step:\n" ++
+  "  addi s3, s3, 1\n" ++
+  "  j .Lmbuc_loop\n" ++
+  ".Lmbuc_done:\n" ++
+  "  sd s4, 0(s2)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lmbuc_ret\n" ++
+  ".Lmbuc_not_branch:\n" ++
+  "  li a0, 1\n" ++
+  "  j .Lmbuc_ret\n" ++
+  ".Lmbuc_nth_fail:\n" ++
+  "  li a0, 2\n" ++
+  ".Lmbuc_ret:\n" ++
+  "  mv s2, a2                   # first_index out\n" ++
+  "  li t0, 16\n" ++
+  "  sd t0, 0(s2)                # default = 16 (none)\n" ++
+  "  # Verify 17-item list.\n" ++
+  "  mv a0, s0; mv a1, s1\n" ++
+  "  la a2, mbfui_count\n" ++
+  "  jal ra, rlp_list_count_items\n" ++
+  "  bnez a0, .Lmbfui_not_branch\n" ++
+  "  la t0, mbfui_count; ld t1, 0(t0)\n" ++
+  "  li t2, 17\n" ++
+  "  bne t1, t2, .Lmbfui_not_branch\n" ++
+  "  li s3, 0                    # i = 0\n" ++
+  ".Lmbfui_loop:\n" ++
+  "  li t0, 16\n" ++
+  "  beq s3, t0, .Lmbfui_done\n" ++
+  "  mv a0, s0; mv a1, s1\n" ++
+  "  mv a2, s3\n" ++
+  "  la a3, mbfui_off; la a4, mbfui_len\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lmbfui_nth_fail\n" ++
+  "  la t0, mbfui_len; ld t1, 0(t0)\n" ++
+  "  beqz t1, .Lmbfui_step\n" ++
+  "  # Found first non-empty child.\n" ++
+  "  sd s3, 0(s2)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lmbfui_ret\n" ++
+  ".Lmbfui_step:\n" ++
+  "  addi s3, s3, 1\n" ++
+  "  j .Lmbfui_loop\n" ++
+  ".Lmbfui_done:\n" ++
+  "  # No non-empty children; output stays at sentinel 16.\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lmbfui_ret\n" ++
+  ".Lmbfui_not_branch:\n" ++
+  "  li a0, 1\n" ++
+  "  j .Lmbfui_ret\n" ++
+  ".Lmbfui_nth_fail:\n" ++
+  "  li a0, 2\n" ++
+  ".Lmbfui_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp); ld s4, 40(sp)\n" ++
+  "  addi sp, sp, 48\n" ++
+  "  ret"
+
+/-- `zisk_mpt_branch_used_count`: probe BuildUnit. Reads
+    (branch_len, branch_bytes), writes (status, used_count) to
+    OUTPUT (16 bytes). -/
+def ziskMptBranchUsedCountPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a3, 0x40000000\n" ++
+  "  ld a1, 8(a3)                # branch length\n" ++
+  "  addi a0, a3, 16             # branch ptr\n" ++
+  "  li a2, 0xa0010008           # used_count out\n" ++
+  "  jal ra, mpt_branch_used_count\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lmbuc_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpListCountItemsFunction ++ "\n" ++
+  mptBranchUsedCountFunction ++ "\n" ++
+  ".Lmbuc_pdone:"
+
+def ziskMptBranchUsedCountDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "mbuc_count:\n" ++
+  "  .zero 8\n" ++
+  "mbuc_off:\n" ++
+  "  .zero 8\n" ++
+  "mbuc_len:\n" ++
+  "  .zero 8"
+
+def ziskMptBranchUsedCountProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskMptBranchUsedCountPrologue
+  dataAsm     := ziskMptBranchUsedCountDataSection
+}
+
+/-- `zisk_mpt_branch_first_used_index`: probe BuildUnit. Reads
+    (branch_len, branch_bytes), writes (status, first_index) to
+    OUTPUT (16 bytes). -/
+def ziskMptBranchFirstUsedIndexPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a3, 0x40000000\n" ++
+  "  ld a1, 8(a3)                # branch length\n" ++
+  "  addi a0, a3, 16             # branch ptr\n" ++
+  "  li a2, 0xa0010008           # first_index out\n" ++
+  "  jal ra, mpt_branch_first_used_index\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lmbfui_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpListCountItemsFunction ++ "\n" ++
+  mptBranchFirstUsedIndexFunction ++ "\n" ++
+  ".Lmbfui_pdone:"
+
+def ziskMptBranchFirstUsedIndexDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "mbfui_count:\n" ++
+  "  .zero 8\n" ++
+  "mbfui_off:\n" ++
+  "  .zero 8\n" ++
+  "mbfui_len:\n" ++
+  "  .zero 8"
+
+def ziskMptBranchFirstUsedIndexProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskMptBranchFirstUsedIndexPrologue
+  dataAsm     := ziskMptBranchFirstUsedIndexDataSection
+}
+
+
+
+
+
+/-- `zisk_rlp_list_nth_item`: probe BuildUnit. Reads
+    (list_len, N, list_bytes) from host input, writes
+    (status, offset, length) to OUTPUT.
+    Input layout:
+      bytes  0.. 8 : list_len (u64)
+      bytes  8..16 : N (u64)
+      bytes 16..   : RLP list bytes
+    Output layout:
+      bytes  0.. 8 : status (0 hit / 1 miss)
+      bytes  8..16 : content offset (u64)
+      bytes 16..24 : content length (u64) -/
+def ziskRlpListNthItemPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a5, 0x40000000\n" ++
+  "  ld a1, 8(a5)                # list_len\n" ++
+  "  ld a2, 16(a5)               # N\n" ++
+  "  addi a0, a5, 24             # list ptr\n" ++
+  "  li a3, 0xa0010008\n" ++
+  "  li a4, 0xa0010010\n" ++
+  "  sd zero, 0(a3); sd zero, 0(a4)\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lrln_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  ".Lrln_pdone:"
+
+def ziskRlpListNthItemDataSection : String :=
+  ".section .data\n" ++
+  "rln_scratch:\n" ++
+  "  .zero 8"
+
+def ziskRlpListNthItemProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskRlpListNthItemPrologue
+  dataAsm     := ziskRlpListNthItemDataSection
+}
+
 
 end EvmAsm.Codegen

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **187**
-- ziskemu round-trip scripts: **180** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **188**
+- ziskemu round-trip scripts: **181** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-mpt-branch-node-encode-check.sh
+++ b/scripts/codegen-zisk-mpt-branch-node-encode-check.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# codegen-zisk-mpt-branch-node-encode-check.sh -- PR-K165.
+#
+# Wrap a pre-concatenated 17-slot payload into the branch-node RLP.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_mpt_branch_node_encode ELF"
+lake exe codegen --program zisk_mpt_branch_node_encode --halt linux93 \
+  -o gen-out/zisk_mpt_branch_node_encode
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <slots_json>
+# slots_json: JSON list of 17 hex strings (each is the RLP-encoded slot,
+# already including any RLP prefix bytes -- e.g. "80" for empty, the
+# 33-byte "a0..." string for hashed children, or the inline RLP for
+# small children).
+run_case() {
+  local name="$1" slots="$2"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_mpt_branch_node_encode_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_mpt_branch_node_encode_${name}.output"
+  local exp_hex_file="$REPO_ROOT/gen-out/zisk_mpt_branch_node_encode_${name}.expected.hex"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import json, struct, sys
+slots = json.loads('''$slots''')
+assert len(slots) == 17, f'expected 17 slots, got {len(slots)}'
+payload = b''.join(bytes.fromhex(s) for s in slots)
+
+n = len(payload)
+if n < 56:
+    prefix = bytes([0xc0 + n])
+else:
+    n_bytes = n.to_bytes((n.bit_length() + 7) // 8, 'big')
+    prefix = bytes([0xf7 + len(n_bytes)]) + n_bytes
+expected = prefix + payload
+
+with open(sys.argv[1], 'wb') as f:
+    f.write(struct.pack('<Q', n))
+    f.write(payload)
+    pad = (-(8 + n)) % 8
+    if pad: f.write(b'\x00' * pad)
+with open(sys.argv[2], 'w') as f:
+    f.write(expected.hex())
+" "$in_file" "$exp_hex_file"
+
+  "$ZISKEMU" -e gen-out/zisk_mpt_branch_node_encode.elf \
+    -i "$in_file" -o "$out_file" -n 1000000 \
+    >"$REPO_ROOT/gen-out/zisk_mpt_branch_node_encode_${name}.emu.log" 2>&1 || true
+
+  local actual_status; actual_status="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local actual_len_le; actual_len_le="$(dd if="$out_file" bs=1 skip=8 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local actual_len; actual_len="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$actual_len_le'))[0])")"
+  local expected_hex; expected_hex="$(cat "$exp_hex_file")"
+  local expected_len; expected_len=$(( ${#expected_hex} / 2 ))
+  local cmp_len=$expected_len
+  if [[ $cmp_len -gt 240 ]]; then cmp_len=240; fi
+  local actual_hex; actual_hex="$(dd if="$out_file" bs=1 skip=16 count="$cmp_len" 2>/dev/null | xxd -p | tr -d '\n')"
+  local expected_prefix="${expected_hex:0:$((2 * cmp_len))}"
+
+  if [[ "$actual_status" == "0000000000000000" \
+       && "$actual_len" == "$expected_len" \
+       && "$actual_hex" == "$expected_prefix" ]]; then
+    printf "  %-30s OK   len=%d\n" "$name" "$expected_len"
+    return 0
+  else
+    printf "  %-30s FAIL status=0x%s actual_len=%d expected_len=%d\n" "$name" "$actual_status" "$actual_len" "$expected_len"
+    printf "      actual:   %s...\n" "${actual_hex:0:80}"
+    printf "      expected: %s...\n" "${expected_prefix:0:80}"
+    return 1
+  fi
+}
+
+HASH32="a0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebf"
+HASHED_SLOT="\"a0$HASH32\""
+EMPTY_SLOT='"80"'
+
+FAILED=0
+# All-empty branch (all 17 slots = 0x80)
+SLOTS_ALL_EMPTY="$(python3 -c "import json; print(json.dumps(['80']*17))")"
+run_case "all_empty"             "$SLOTS_ALL_EMPTY" || FAILED=1
+
+# Single hashed child at slot 0, rest empty
+python3 -c "
+import json
+slots = ['80']*17
+slots[0] = 'a0' + '$HASH32'
+print(json.dumps(slots))
+" > /tmp/mbne_slots_one.json
+run_case "one_hashed_slot0"      "$(cat /tmp/mbne_slots_one.json)" || FAILED=1
+
+# Two hashed children at slot 0 and 8 (the rlp(0)/rlp(1) divergence shape)
+python3 -c "
+import json
+slots = ['80']*17
+slots[0] = 'a0' + '$HASH32'
+slots[8] = 'a0' + 'b0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecf'
+print(json.dumps(slots))
+" > /tmp/mbne_slots_two.json
+run_case "two_hashed_slots"      "$(cat /tmp/mbne_slots_two.json)" || FAILED=1
+
+# All-hashed (all 16 children + value)
+python3 -c "
+import json
+slots = ['a0' + bytes([i] * 32).hex() for i in range(17)]
+print(json.dumps(slots))
+" > /tmp/mbne_slots_all_hashed.json
+run_case "all_hashed"            "$(cat /tmp/mbne_slots_all_hashed.json)" || FAILED=1
+
+# Inline child mix (some inline, some hashed, some empty)
+python3 -c "
+import json
+slots = ['80']*17
+slots[3] = 'c4820080'             # short inline list
+slots[5] = 'a0' + '11'*32          # hashed
+slots[15] = '85deadbeef00'         # short inline string
+slots[16] = '80'                   # value empty
+print(json.dumps(slots))
+" > /tmp/mbne_slots_mixed.json
+run_case "inline_hashed_mixed"   "$(cat /tmp/mbne_slots_mixed.json)" || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: mpt_branch_node_encode wraps the 17-slot payload with correct outer prefix"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Bundles K165 with the policy-mandated MPT cluster move into the existing \`Programs/Mpt.lean\`.

### PR-K165 — \`mpt_branch_node_encode\`

Wrap a pre-concatenated 17-slot payload into the branch-node RLP:

\`\`\`
branch_node = rlp([slot_0, slot_1, ..., slot_15, value])
\`\`\`

Each slot is one RLP item, already encoded by the caller (typically via PR-K163 \`mpt_node_slot_encode\`). Composes PR-K129 only.

### Refactor — MPT cluster move

K165's addition pushed \`Programs.lean\` to 7880 lines (hardCap=7800). Moved into the existing \`Programs/Mpt.lean\`:

| PR | Helper |
|---|---|
| K19 | \`witness_lookup_by_hash\` (placed at top of Mpt.lean so K24 mpt_walk can reference it) |
| K21 | \`mpt_node_kind\` |
| K22 | \`mpt_branch_child\` |
| K23 | \`hp_decode_nibbles\` |
| K24 | \`mpt_walk\` |
| K25 | \`bytes_to_nibbles\` |
| K26 | \`mpt_lookup_by_key\` |
| K100 | \`mpt_account_path_nibbles\` |
| K117 | \`mpt_branch_used_count\` |
| K118 | \`mpt_branch_first_used_index\` |

Programs.lean drops to ~6397 lines (was 7880). Mpt.lean grows to ~2561.

\`hardCap\` lowered: **7800 → 6600**.

### File sizes after this PR

\`\`\`
6494 EvmAsm/Codegen/Programs/Tx.lean
6397 EvmAsm/Codegen/Programs.lean
2561 EvmAsm/Codegen/Programs/Mpt.lean
1910 EvmAsm/Codegen/Programs/Header.lean
1774 EvmAsm/Codegen/Programs/Block.lean
1144 EvmAsm/Codegen/Programs/Bloom.lean
1094 EvmAsm/Codegen/Programs/Ssz.lean
1006 EvmAsm/Codegen/Programs/Evm.lean
 502 EvmAsm/Codegen/Programs/RlpRead.lean
 202 EvmAsm/Codegen/Programs/HashBridge.lean
\`\`\`

All under the new 6600-line hardCap.

## Test plan

- [x] \`lake build\` clean (2456 jobs)
- [x] \`scripts/codegen-zisk-mpt-branch-node-encode-check.sh\` — 5/5 fixtures pass against Python reference:
  - \`all_empty\`: 17 × 0x80 slots
  - \`one_hashed_slot0\`: single hashed child
  - \`two_hashed_slots\`: divergence shape (slots 0 + 8)
  - \`all_hashed\`: every slot hashed (564-byte branch RLP)
  - \`inline_hashed_mixed\`: inline + hashed + empty mix

🤖 Generated with [Claude Code](https://claude.com/claude-code)