### PR TITLE
feat(stateless): nibbles_common_prefix_len (PR-K166)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -5471,6 +5471,92 @@ def ziskMptBranchNodeEncodeProbeUnit : BuildUnit := {
   dataAsm     := ziskMptBranchNodeEncodeDataSection
 }
 
+/-! ## nibbles_common_prefix_len -- PR-K166
+
+    Walk two nibble arrays (one byte per nibble, low 4 bits) from
+    the start and return the length of their shared prefix. Stops
+    at the first differing nibble or at the end of the shorter
+    array, whichever comes first.
+
+    Direct building block for multi-leaf MPT root computation:
+    given two leaf paths in nibble form, the depth at which they
+    diverge tells the constructor whether to emit an extension
+    node (for the shared prefix) followed by a branch (at the
+    divergence point), or just a branch directly (if cpl == 0).
+
+    Example: for sequential indices 0 and 1 in an indexed trie,
+    `rlp(0) = 0x80` and `rlp(1) = 0x01` expand to nibbles
+    `[0x8, 0x0]` and `[0x0, 0x1]`; their common prefix is empty
+    (cpl == 0), so the root is a branch.
+
+    Pure register arithmetic, leaf-callable, no scratch.
+
+    Calling convention:
+      a0 (input)  : nibbles_a ptr (1 byte per nibble)
+      a1 (input)  : nibbles_a count
+      a2 (input)  : nibbles_b ptr
+      a3 (input)  : nibbles_b count
+      a4 (input)  : u64 out ptr (common prefix length, in nibbles)
+      ra (input)  : return
+      a0 (output) : 0 (always succeeds). -/
+def nibblesCommonPrefixLenFunction : String :=
+  "nibbles_common_prefix_len:\n" ++
+  "  # min(a_count, b_count)\n" ++
+  "  bltu a1, a3, .Lncpl_min_ok\n" ++
+  "  mv a1, a3\n" ++
+  ".Lncpl_min_ok:\n" ++
+  "  li t0, 0                   # cpl accumulator\n" ++
+  "  mv t1, a0                  # a cursor\n" ++
+  "  mv t2, a2                  # b cursor\n" ++
+  ".Lncpl_loop:\n" ++
+  "  bge t0, a1, .Lncpl_done\n" ++
+  "  lbu t3, 0(t1)\n" ++
+  "  lbu t4, 0(t2)\n" ++
+  "  bne t3, t4, .Lncpl_done\n" ++
+  "  addi t1, t1, 1\n" ++
+  "  addi t2, t2, 1\n" ++
+  "  addi t0, t0, 1\n" ++
+  "  j .Lncpl_loop\n" ++
+  ".Lncpl_done:\n" ++
+  "  sd t0, 0(a4)\n" ++
+  "  li a0, 0\n" ++
+  "  ret"
+
+/-- `zisk_nibbles_common_prefix_len`: probe BuildUnit.
+    Input layout:
+      bytes  0.. 8 : a_count
+      bytes  8..16 : b_count
+      bytes 16..16+a_count: nibbles_a
+      bytes (16+a_count)..: nibbles_b
+    Output layout:
+      bytes  0.. 8 : status
+      bytes  8..16 : common prefix length -/
+def ziskNibblesCommonPrefixLenPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a5, 0x40000000\n" ++
+  "  ld a1, 8(a5)                # a_count\n" ++
+  "  ld a3, 16(a5)               # b_count\n" ++
+  "  addi a0, a5, 24             # nibbles_a ptr\n" ++
+  "  add a2, a0, a1              # nibbles_b ptr\n" ++
+  "  li a4, 0xa0010008           # cpl out\n" ++
+  "  jal ra, nibbles_common_prefix_len\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lncpl_pdone\n" ++
+  nibblesCommonPrefixLenFunction ++ "\n" ++
+  ".Lncpl_pdone:"
+
+def ziskNibblesCommonPrefixLenDataSection : String :=
+  ".section .data\n" ++
+  "ncpl_pad:\n" ++
+  "  .zero 8"
+
+def ziskNibblesCommonPrefixLenProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskNibblesCommonPrefixLenPrologue
+  dataAsm     := ziskNibblesCommonPrefixLenDataSection
+}
+
 /-! ## block-level bloom composites K158-K159 — moved to `Programs/Bloom.lean` (file-size hard cap). -/
 
 /-! ## header_root_is_empty_trie -- PR-K161
@@ -6136,6 +6222,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_mpt_node_slot_encode" => some ziskMptNodeSlotEncodeProbeUnit
   | "zisk_mpt_extension_node_encode" => some ziskMptExtensionNodeEncodeProbeUnit
   | "zisk_mpt_branch_node_encode" => some ziskMptBranchNodeEncodeProbeUnit
+  | "zisk_nibbles_common_prefix_len" => some ziskNibblesCommonPrefixLenProbeUnit
   | "zisk_block_logs_bloom_from_receipts_list" => some ziskBlockLogsBloomFromReceiptsListProbeUnit
   | "zisk_block_validate_logs_bloom" => some ziskBlockValidateLogsBloomProbeUnit
   | "zisk_header_root_is_empty_trie" => some ziskHeaderRootIsEmptyTrieProbeUnit
@@ -6315,6 +6402,7 @@ def knownProgramNames : List String :=
    "zisk_mpt_node_slot_encode",
    "zisk_mpt_extension_node_encode",
    "zisk_mpt_branch_node_encode",
+   "zisk_nibbles_common_prefix_len",
    "zisk_block_logs_bloom_from_receipts_list",
    "zisk_block_validate_logs_bloom",
    "zisk_header_root_is_empty_trie",

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **188**
-- ziskemu round-trip scripts: **181** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **189**
+- ziskemu round-trip scripts: **182** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-nibbles-common-prefix-len-check.sh
+++ b/scripts/codegen-zisk-nibbles-common-prefix-len-check.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# codegen-zisk-nibbles-common-prefix-len-check.sh -- PR-K166.
+#
+# Common prefix length of two nibble arrays.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_nibbles_common_prefix_len ELF"
+lake exe codegen --program zisk_nibbles_common_prefix_len --halt linux93 \
+  -o gen-out/zisk_nibbles_common_prefix_len
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <nibbles_a_hex> <nibbles_b_hex> <expected_cpl>
+# nibbles_*_hex: each byte = one nibble (low 4 bits)
+run_case() {
+  local name="$1" a="$2" b="$3" exp="$4"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_nibbles_common_prefix_len_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_nibbles_common_prefix_len_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys
+a = bytes.fromhex('$a')
+b = bytes.fromhex('$b')
+with open(sys.argv[1], 'wb') as f:
+    f.write(struct.pack('<Q', len(a)))
+    f.write(struct.pack('<Q', len(b)))
+    f.write(a + b)
+    pad = (-(16 + len(a) + len(b))) % 8
+    if pad: f.write(b'\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_nibbles_common_prefix_len.elf \
+    -i "$in_file" -o "$out_file" -n 100000 \
+    >"$REPO_ROOT/gen-out/zisk_nibbles_common_prefix_len_${name}.emu.log" 2>&1 || true
+
+  local actual_status; actual_status="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local actual_cpl_le; actual_cpl_le="$(dd if="$out_file" bs=1 skip=8 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local actual_cpl; actual_cpl="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$actual_cpl_le'))[0])")"
+
+  if [[ "$actual_status" == "0000000000000000" && "$actual_cpl" == "$exp" ]]; then
+    printf "  %-30s OK   cpl=%d\n" "$name" "$exp"
+    return 0
+  else
+    printf "  %-30s FAIL status=0x%s cpl=%d expected=%d\n" "$name" "$actual_status" "$actual_cpl" "$exp"
+    return 1
+  fi
+}
+
+FAILED=0
+# Identical short
+run_case "identical_2nib"       "0a0b"             "0a0b"             2 || FAILED=1
+# Identical longer
+run_case "identical_8nib"       "0102030405060708" "0102030405060708" 8 || FAILED=1
+# All different (cpl = 0)
+run_case "all_different"        "0a0b"             "0c0d"             0 || FAILED=1
+# rlp(0)=0x80 vs rlp(1)=0x01 nibble shape -> cpl=0
+run_case "rlp0_vs_rlp1"         "0800"             "0001"             0 || FAILED=1
+# rlp(2)=0x02 vs rlp(3)=0x03 nibble shape -> cpl=1 (both start with 0x0)
+run_case "rlp2_vs_rlp3"         "0002"             "0003"             1 || FAILED=1
+# Same nibbles up to mid then diverge
+run_case "diverge_mid"          "0a0b0c0d0e"       "0a0b0c0f0e"       3 || FAILED=1
+# One is empty
+run_case "empty_a"              ""                 "0a0b"             0 || FAILED=1
+run_case "empty_b"              "0a0b"             ""                 0 || FAILED=1
+run_case "both_empty"           ""                 ""                 0 || FAILED=1
+# One is a prefix of the other
+run_case "a_prefix_of_b"        "0a0b"             "0a0b0c0d"         2 || FAILED=1
+run_case "b_prefix_of_a"        "0a0b0c0d"         "0a0b"             2 || FAILED=1
+# Long shared prefix (state-trie depth)
+run_case "long_shared_prefix"   "$(python3 -c "print('0a' * 32)")" "$(python3 -c "print('0a' * 31 + '0b')")" 31 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: nibbles_common_prefix_len matches expected lengths"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- \`nibbles_common_prefix_len\`: walk two nibble arrays and return the length of their shared prefix. Stops at the first differing nibble or end of the shorter array.
- Building block for **multi-leaf MPT root computation**: given two leaf paths in nibble form, the divergence point tells the constructor whether to emit an extension node (for the shared prefix) followed by a branch (at the divergence), or just a branch directly (if cpl == 0).
- Pure register arithmetic, leaf-callable, no scratch. Atomic primitive of ~20 lines of asm.

### Example use

For sequential indices 0 and 1 in an indexed trie, \`rlp(0) = 0x80\` and \`rlp(1) = 0x01\` expand to nibbles \`[0x8, 0x0]\` and \`[0x0, 0x1]\`; their common prefix is empty (cpl == 0), so the root is a branch directly. For indices 2 and 3 (\`rlp(2) = 0x02\`, \`rlp(3) = 0x03\`), nibbles \`[0x0, 0x2]\` and \`[0x0, 0x3]\` share their first nibble — cpl = 1.

### Calling convention

| reg | role |
|---|---|
| a0 | nibbles_a ptr |
| a1 | nibbles_a count |
| a2 | nibbles_b ptr |
| a3 | nibbles_b count |
| a4 | u64 out ptr (common prefix length, in nibbles) |
| a0 (out) | 0 (always succeeds) |

## Test plan

- [x] \`lake build\` clean
- [x] \`scripts/codegen-zisk-nibbles-common-prefix-len-check.sh\` — 12/12 fixtures pass:
  - Identity (\`identical_2nib\`, \`identical_8nib\`)
  - Divergence at position 0 (\`all_different\`, \`rlp0_vs_rlp1\`)
  - Divergence at position 1 (\`rlp2_vs_rlp3\`)
  - Divergence mid-string (\`diverge_mid\`)
  - Empty inputs (\`empty_a\`, \`empty_b\`, \`both_empty\`)
  - Prefix-of-the-other (\`a_prefix_of_b\`, \`b_prefix_of_a\`)
  - 31-nibble shared prefix (\`long_shared_prefix\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)