### PR TITLE
feat(stateless): mpt_leaf_node_encode_from_nibbles (PR-K168)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -5185,6 +5185,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_mpt_branch_node_encode" => some ziskMptBranchNodeEncodeProbeUnit
   | "zisk_nibbles_common_prefix_len" => some ziskNibblesCommonPrefixLenProbeUnit
   | "zisk_mpt_branch_payload_two_slots" => some ziskMptBranchPayloadTwoSlotsProbeUnit
+  | "zisk_mpt_leaf_node_encode_from_nibbles" => some ziskMptLeafNodeEncodeFromNibblesProbeUnit
   | "zisk_block_logs_bloom_from_receipts_list" => some ziskBlockLogsBloomFromReceiptsListProbeUnit
   | "zisk_block_validate_logs_bloom" => some ziskBlockValidateLogsBloomProbeUnit
   | "zisk_header_root_is_empty_trie" => some ziskHeaderRootIsEmptyTrieProbeUnit
@@ -5366,6 +5367,7 @@ def knownProgramNames : List String :=
    "zisk_mpt_branch_node_encode",
    "zisk_nibbles_common_prefix_len",
    "zisk_mpt_branch_payload_two_slots",
+   "zisk_mpt_leaf_node_encode_from_nibbles",
    "zisk_block_logs_bloom_from_receipts_list",
    "zisk_block_validate_logs_bloom",
    "zisk_header_root_is_empty_trie",

--- a/EvmAsm/Codegen/Programs/Mpt.lean
+++ b/EvmAsm/Codegen/Programs/Mpt.lean
@@ -3601,5 +3601,148 @@ def ziskMptBranchPayloadTwoSlotsProbeUnit : BuildUnit := {
   dataAsm     := ziskMptBranchPayloadTwoSlotsDataSection
 }
 
+/-! ## mpt_leaf_node_encode_from_nibbles -- PR-K168
+
+    Encode an MPT leaf node directly from a *nibble* path (one
+    byte per nibble, low 4 bits) and a raw value, without the
+    bytes-to-nibbles expansion step. Mirrors PR-K162
+    `mpt_leaf_node_encode` but skips the path-bytes-to-nibbles
+    front:
+
+      hp_path     = hp_encode_nibbles(path_nibbles, is_leaf=true)
+      leaf_node   = rlp([hp_path, value])
+
+    The bytes-input variant (K162) is the right helper when the
+    path comes from a raw key (e.g., `rlp(i)` for a
+    transactions-trie key). The nibbles-input variant (this PR)
+    is the right helper for multi-leaf MPT construction where
+    the leaf path is a *suffix of nibbles* produced by walking
+    down from a shared prefix.
+
+    Composes:
+      - PR-K32  `hp_encode_nibbles` with is_leaf=true
+      - PR-K128 `rlp_encode_bytes`  for hp_path / value
+      - PR-K129 `rlp_encode_list_prefix` for the outer list
+
+    Calling convention:
+      a0 (input)  : path_nibbles ptr (one byte per nibble,
+                    low 4 bits)
+      a1 (input)  : nibble count
+      a2 (input)  : value ptr
+      a3 (input)  : value byte length
+      a4 (input)  : output buffer ptr (caller-supplied)
+      a5 (input)  : u64 out length ptr (total bytes written)
+      ra (input)  : return
+      a0 (output) : 0 (always succeeds). -/
+def mptLeafNodeEncodeFromNibblesFunction : String :=
+  "mpt_leaf_node_encode_from_nibbles:\n" ++
+  "  addi sp, sp, -64\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp)\n" ++
+  "  mv s0, a0                   # path_nibbles ptr\n" ++
+  "  mv s1, a1                   # nibble count\n" ++
+  "  mv s2, a2                   # value ptr\n" ++
+  "  mv s3, a3                   # value len\n" ++
+  "  mv s4, a4                   # output ptr\n" ++
+  "  mv s5, a5                   # out_length ptr\n" ++
+  "  # ---- Step 1: HP-encode (leaf=true) ----\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 1\n" ++
+  "  la a3, mlnen_hp_buf\n" ++
+  "  jal ra, hp_encode_nibbles\n" ++
+  "  la t0, mlnen_hp_len; sd a0, 0(t0)\n" ++
+  "  # ---- Step 2: RLP-encode hp_path into payload_buf ----\n" ++
+  "  la a0, mlnen_hp_buf\n" ++
+  "  la t0, mlnen_hp_len; ld a1, 0(t0)\n" ++
+  "  la a2, mlnen_payload_buf\n" ++
+  "  la a3, mlnen_field_len\n" ++
+  "  jal ra, rlp_encode_bytes\n" ++
+  "  la t0, mlnen_field_len; ld t1, 0(t0)\n" ++
+  "  la t0, mlnen_cursor; sd t1, 0(t0)\n" ++
+  "  # ---- Step 3: RLP-encode value at payload[cursor..] ----\n" ++
+  "  la t0, mlnen_cursor; ld t1, 0(t0)\n" ++
+  "  mv a0, s2; mv a1, s3\n" ++
+  "  la a2, mlnen_payload_buf; add a2, a2, t1\n" ++
+  "  la a3, mlnen_field_len\n" ++
+  "  jal ra, rlp_encode_bytes\n" ++
+  "  la t0, mlnen_field_len; ld t1, 0(t0)\n" ++
+  "  la t0, mlnen_cursor; ld t2, 0(t0)\n" ++
+  "  add t2, t2, t1\n" ++
+  "  la t0, mlnen_total_payload; sd t2, 0(t0)\n" ++
+  "  # ---- Step 4: outer list prefix to output[0..] ----\n" ++
+  "  mv a0, t2; mv a1, s4\n" ++
+  "  la a2, mlnen_field_len\n" ++
+  "  jal ra, rlp_encode_list_prefix\n" ++
+  "  la t0, mlnen_field_len; ld t1, 0(t0)\n" ++
+  "  la t0, mlnen_total_payload; ld t2, 0(t0)\n" ++
+  "  # ---- Step 5: copy payload after prefix ----\n" ++
+  "  add t3, s4, t1\n" ++
+  "  la t4, mlnen_payload_buf\n" ++
+  "  mv t5, t2\n" ++
+  ".Lmlnen_cp:\n" ++
+  "  beqz t5, .Lmlnen_cp_done\n" ++
+  "  lbu t6, 0(t4)\n" ++
+  "  sb t6, 0(t3)\n" ++
+  "  addi t3, t3, 1\n" ++
+  "  addi t4, t4, 1\n" ++
+  "  addi t5, t5, -1\n" ++
+  "  j .Lmlnen_cp\n" ++
+  ".Lmlnen_cp_done:\n" ++
+  "  add t1, t1, t2\n" ++
+  "  sd t1, 0(s5)\n" ++
+  "  li a0, 0\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp)\n" ++
+  "  addi sp, sp, 64\n" ++
+  "  ret"
+
+/-- `zisk_mpt_leaf_node_encode_from_nibbles`: probe BuildUnit.
+    Input layout:
+      bytes  0.. 8 : nibble_count
+      bytes  8..16 : value_len
+      bytes 16..16+nibble_count: path_nibbles
+      bytes (16+nibble_count)..: value -/
+def ziskMptLeafNodeEncodeFromNibblesPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a6, 0x40000000\n" ++
+  "  ld a1, 8(a6)                # nibble_count\n" ++
+  "  ld a3, 16(a6)               # value_len\n" ++
+  "  addi a0, a6, 24             # path_nibbles ptr\n" ++
+  "  add a2, a0, a1              # value ptr\n" ++
+  "  li a4, 0xa0010010           # output buffer ptr\n" ++
+  "  li a5, 0xa0010008           # out_length ptr\n" ++
+  "  jal ra, mpt_leaf_node_encode_from_nibbles\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lmlnen_pdone\n" ++
+  hpEncodeNibblesFunction ++ "\n" ++
+  rlpEncodeBytesFunction ++ "\n" ++
+  rlpEncodeListPrefixFunction ++ "\n" ++
+  mptLeafNodeEncodeFromNibblesFunction ++ "\n" ++
+  ".Lmlnen_pdone:"
+
+def ziskMptLeafNodeEncodeFromNibblesDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "mlnen_field_len:\n" ++
+  "  .zero 8\n" ++
+  "mlnen_hp_len:\n" ++
+  "  .zero 8\n" ++
+  "mlnen_cursor:\n" ++
+  "  .zero 8\n" ++
+  "mlnen_total_payload:\n" ++
+  "  .zero 8\n" ++
+  "mlnen_hp_buf:\n" ++
+  "  .zero 1024\n" ++
+  "mlnen_payload_buf:\n" ++
+  "  .zero 16384"
+
+def ziskMptLeafNodeEncodeFromNibblesProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskMptLeafNodeEncodeFromNibblesPrologue
+  dataAsm     := ziskMptLeafNodeEncodeFromNibblesDataSection
+}
+
 
 end EvmAsm.Codegen

--- a/scripts/codegen-zisk-mpt-leaf-node-encode-from-nibbles-check.sh
+++ b/scripts/codegen-zisk-mpt-leaf-node-encode-from-nibbles-check.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# codegen-zisk-mpt-leaf-node-encode-from-nibbles-check.sh -- PR-K168.
+#
+# Encode an MPT leaf node from nibble-input path + raw value.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_mpt_leaf_node_encode_from_nibbles ELF"
+lake exe codegen --program zisk_mpt_leaf_node_encode_from_nibbles --halt linux93 \
+  -o gen-out/zisk_mpt_leaf_node_encode_from_nibbles
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <nibbles_hex> <value_hex>
+# nibbles_hex: one byte per nibble (low 4 bits)
+run_case() {
+  local name="$1" nibs="$2" val="$3"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_mpt_leaf_node_encode_from_nibbles_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_mpt_leaf_node_encode_from_nibbles_${name}.output"
+  local exp_hex_file="$REPO_ROOT/gen-out/zisk_mpt_leaf_node_encode_from_nibbles_${name}.expected.hex"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+nibbles_bytes = bytes.fromhex('$nibs')
+nibbles = list(nibbles_bytes)
+val = bytes.fromhex('$val')
+
+# HP-encode with is_leaf=true.
+flag = 2 + (len(nibbles) & 1)
+hp = bytearray()
+if len(nibbles) % 2 == 1:
+    hp.append((flag << 4) | nibbles[0])
+    i = 1
+else:
+    hp.append(flag << 4)
+    i = 0
+while i < len(nibbles):
+    hp.append((nibbles[i] << 4) | nibbles[i+1])
+    i += 2
+leaf_node_rlp = rlp.encode([bytes(hp), val])
+
+with open(sys.argv[1], 'wb') as f:
+    f.write(struct.pack('<Q', len(nibbles)))
+    f.write(struct.pack('<Q', len(val)))
+    f.write(bytes(nibbles))
+    f.write(val)
+    pad = (-(16 + len(nibbles) + len(val))) % 8
+    if pad: f.write(b'\x00' * pad)
+with open(sys.argv[2], 'w') as f:
+    f.write(leaf_node_rlp.hex())
+" "$in_file" "$exp_hex_file"
+
+  "$ZISKEMU" -e gen-out/zisk_mpt_leaf_node_encode_from_nibbles.elf \
+    -i "$in_file" -o "$out_file" -n 1000000 \
+    >"$REPO_ROOT/gen-out/zisk_mpt_leaf_node_encode_from_nibbles_${name}.emu.log" 2>&1 || true
+
+  local actual_status; actual_status="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local actual_len_le; actual_len_le="$(dd if="$out_file" bs=1 skip=8 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local actual_len; actual_len="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$actual_len_le'))[0])")"
+  local expected_hex; expected_hex="$(cat "$exp_hex_file")"
+  local expected_len; expected_len=$(( ${#expected_hex} / 2 ))
+  local cmp_len=$expected_len
+  if [[ $cmp_len -gt 240 ]]; then cmp_len=240; fi
+  local actual_hex; actual_hex="$(dd if="$out_file" bs=1 skip=16 count="$cmp_len" 2>/dev/null | xxd -p | tr -d '\n')"
+  local expected_prefix="${expected_hex:0:$((2 * cmp_len))}"
+
+  if [[ "$actual_status" == "0000000000000000" \
+       && "$actual_len" == "$expected_len" \
+       && "$actual_hex" == "$expected_prefix" ]]; then
+    printf "  %-30s OK   nibs=%d len=%d\n" "$name" $(( ${#nibs} / 2 )) "$expected_len"
+    return 0
+  else
+    printf "  %-30s FAIL status=0x%s actual_len=%d expected_len=%d\n" "$name" "$actual_status" "$actual_len" "$expected_len"
+    printf "      actual:   %s...\n" "${actual_hex:0:80}"
+    printf "      expected: %s...\n" "${expected_prefix:0:80}"
+    return 1
+  fi
+}
+
+FAILED=0
+# Even-count nibbles
+run_case "even_2nib"          "0008" "deadbeef" || FAILED=1
+# Odd-count nibbles
+run_case "odd_1nib"           "08"   "deadbeef" || FAILED=1
+# Empty path (degenerate but legal)
+run_case "empty_path"         ""     "cafebabe" || FAILED=1
+# Mirror of K162 tx_index_0 case (nibbles [8,0] = bytes_to_nibbles(0x80))
+run_case "tx_index_0_suffix"  "0800" "f8500184ee6b280082520894aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa881bc16d674ec80000801ba01111111111111111111111111111111111111111111111111111111111111111a02222222222222222222222222222222222222222222222222222222222222222" || FAILED=1
+# Single-nibble suffix (typical for divergence-leaf inside a branch)
+run_case "single_nibble_leaf" "01"   "63"       || FAILED=1
+# 63-nibble path (state-trie depth minus shared prefix)
+run_case "long_path"          "$(python3 -c "print('0a' * 63)")" "deadbeef" || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: mpt_leaf_node_encode_from_nibbles matches rlp + HP-encode (nibble input)"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- \`mpt_leaf_node_encode_from_nibbles\`: encode an MPT leaf node directly from a *nibble* path (one byte per nibble, low 4 bits) and a raw value. Mirrors PR-K162 \`mpt_leaf_node_encode\` but skips the K25 bytes-to-nibbles front.
- **Use case differentiation**:
  - K162 (bytes input): right helper when the path comes from a raw key (e.g., \`rlp(i)\` for a transactions-trie key).
  - K168 (nibbles input): right helper for multi-leaf MPT construction where the leaf path is a *suffix of nibbles* produced by walking down from a shared prefix.
- Composes K32 + K128 + K129. Lives in \`Programs/Mpt.lean\`.

### Calling convention

| reg | role |
|---|---|
| a0 | path_nibbles ptr (one byte per nibble, low 4 bits) |
| a1 | nibble count |
| a2 | value ptr |
| a3 | value byte length |
| a4 | output buffer ptr |
| a5 | u64 out length ptr |
| a0 (out) | 0 (always succeeds) |

## Stacking

Base = \`feat/stateless-mpt-branch-payload-two-slots\` (PR #5958).

## Test plan

- [x] \`lake build\` clean
- [x] \`scripts/codegen-zisk-mpt-leaf-node-encode-from-nibbles-check.sh\` — 6/6 fixtures pass against Python rlp + HP-encode:
  - \`even_2nib\`, \`odd_1nib\`: parity coverage
  - \`empty_path\`: degenerate but legal
  - \`tx_index_0_suffix\`: real legacy-tx value (mirror of K162's tx_index_0 leaf)
  - \`single_nibble_leaf\`: typical divergence-leaf in a 2-leaf trie
  - \`long_path\`: 63-nibble path (state-trie depth minus shared)

🤖 Generated with [Claude Code](https://claude.com/claude-code)