### PR TITLE
feat(smod): remove divisorTop from smodModCallPrivateFrame; use regOwn .x9 in callable post

### DIFF
--- a/EvmAsm/Evm64/SMod/Compose/ModCallBzeroHandoff.lean
+++ b/EvmAsm/Evm64/SMod/Compose/ModCallBzeroHandoff.lean
@@ -44,7 +44,11 @@ theorem saveRaAbsThenModCallDispatchReadyPost_bzero_callable_spec_in_smodCodeV4
   let divisorAbsWord : EvmWord :=
     smodAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
   let retAddr := (base + modCallOff) + 4
-  let privateFrame := smodModCallPrivateFrame vRa dividendTop divisorTop
+  -- New: 2-arg privateFrame (no x9). Frame x9 separately for the bzero callable.
+  -- x9 is placed first so that frameWithX9 is right-associative after unfolding.
+  let privateFrame := smodModCallPrivateFrame vRa dividendTop
+  let frameWithX9 : EvmAsm.Rv64.Assertion :=
+    (.x9 ↦ᵣ divisorSign) ** privateFrame
   have h_callable_raw :
       cpsTripleWithin (EvmAsm.Evm64.unifiedDivBound + 1)
         (base + wrapperEndOff) (retAddr &&& ~~~(1 : Word))
@@ -72,18 +76,19 @@ theorem saveRaAbsThenModCallDispatchReadyPost_bzero_callable_spec_in_smodCodeV4
         (EvmAsm.Evm64.modStackDispatchPostCallable sp dividendAbsWord divisorAbsWord **
           (.x1 ↦ᵣ retAddr)) := by
     exact cpsTripleWithin_extend_code evm_mod_callable_code_v4_sub_smodCodeV4 h_callable_raw
+  -- Frame with frameWithX9 = (.x9 ↦ divisorSign) ** privateFrame
   have h_callable_framed :
       cpsTripleWithin (EvmAsm.Evm64.unifiedDivBound + 1)
         (base + wrapperEndOff) (retAddr &&& ~~~(1 : Word)) (smodCodeV4 base)
         (EvmAsm.Evm64.divModStackDispatchPreCallable sp dividendAbsWord divisorAbsWord
           retAddr v2 v5 v6 divisorSum3 divisorMask divisorCarry3
           q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-          shiftMem nMem jMem retMem dMem dloMem scratchUn0 ** privateFrame)
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0 ** frameWithX9)
         ((EvmAsm.Evm64.modStackDispatchPostCallable sp dividendAbsWord divisorAbsWord **
-          (.x1 ↦ᵣ retAddr)) ** privateFrame) := by
-    exact cpsTripleWithin_frameR privateFrame (by
-      dsimp [privateFrame]
-      exact smodModCallPrivateFrame_pcFree) h_callable_code
+          (.x1 ↦ᵣ retAddr)) ** frameWithX9) := by
+    exact cpsTripleWithin_frameR frameWithX9 (by
+      dsimp only [frameWithX9]
+      pcFree) h_callable_code
   rw [show retAddr &&& ~~~(1 : Word) = base + resultSignFixOff by
     dsimp [retAddr]
     exact modCall_return_andn_one_eq_resultSignFixOff base h_base] at h_callable_framed
@@ -93,10 +98,11 @@ theorem saveRaAbsThenModCallDispatchReadyPost_bzero_callable_spec_in_smodCodeV4
         rw [saveRaAbsThenModCallDispatchReadyPost_unfold_smod_components] at hp
         dsimp only at hp
         rw [EvmAsm.Evm64.divModStackDispatchPreCallable_unfold]
-        dsimp [privateFrame]
+        dsimp only [frameWithX9, privateFrame]
         rw [smodModCallPrivateFrame_unfold]
         dsimp only
         rw [EvmAsm.Evm64.divModStackDispatchPreNoX1_unfold] at hp
+        -- frameWithX9 = (.x9 ↦ divisorSign) ** privateFrame is already right-assoc
         change
           (((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ retAddr) ** (.x2 ↦ᵣ v2) **
             (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ divisorSum3) **
@@ -114,10 +120,36 @@ theorem saveRaAbsThenModCallDispatchReadyPost_bzero_callable_spec_in_smodCodeV4
         dsimp only
         rw [smodModCallPrivateFrame_unfold]
         dsimp only
-        dsimp [privateFrame] at hp
+        -- Unfold frameWithX9 and privateFrame in hp
+        dsimp only [frameWithX9, privateFrame] at hp
         rw [smodModCallPrivateFrame_unfold] at hp
         dsimp only at hp
-        xperm_hyp hp)
+        -- hp : ((moddispatch ** .x1) ** ((.x9 ↦ divisorSign) ** (x8 ** x13 ** x18))) h
+        -- Decompose to extract x9 and weaken to regOwn .x9
+        obtain ⟨hAB, hX9C, hd1, hu1, hAB_h, hX9C_h⟩ := hp
+        -- hX9C_h : ((.x9 ↦ divisorSign) ** (x8 ** x13 ** x18)) hX9C
+        obtain ⟨hX9, hC, hd3, hu3, hX9_h, hC_h⟩ := hX9C_h
+        have hregown := regIs_implies_regOwn .x9 hX9 hX9_h
+        -- Build (regOwn .x9 ** (x8 ** x13 ** x18)) (hX9 ∪ hC)
+        have h_inner : (EvmAsm.Rv64.regOwn .x9 **
+            ((.x8 ↦ᵣ smodAbsSign dividendTop) ** (.x13 ↦ᵣ smodAbsSign dividendTop) **
+             (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12))))) (hX9.union hC) :=
+          ⟨hX9, hC, hd3, rfl, hregown, hC_h⟩
+        -- hAB.Disjoint (hX9 ∪ hC) follows directly from hu3 and hd1
+        have h_new_disjoint : hAB.Disjoint (hX9.union hC) := by
+          rw [hu3]; exact hd1
+        have h_new_union : hAB.union (hX9.union hC) = h := by
+          rw [hu3]; exact hu1
+        -- Construct hp' with weakened x9
+        have hp' : ((EvmAsm.Evm64.modStackDispatchPostCallable sp dividendAbsWord divisorAbsWord **
+                     (.x1 ↦ᵣ retAddr)) **
+                    (EvmAsm.Rv64.regOwn .x9 **
+                     ((.x8 ↦ᵣ smodAbsSign dividendTop) ** (.x13 ↦ᵣ smodAbsSign dividendTop) **
+                      (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))))) h :=
+          ⟨hAB, hX9.union hC, h_new_disjoint, h_new_union, hAB_h, h_inner⟩
+        -- re-associate from ((A ** B) ** (C ** D)) to A ** (B ** (C ** D)) then exact
+        rw [sepConj_assoc] at hp'
+        exact hp')
       h_callable_framed
 
 end EvmAsm.Evm64.SMod.Compose

--- a/EvmAsm/Evm64/SMod/Compose/ModCallGenericHandoff.lean
+++ b/EvmAsm/Evm64/SMod/Compose/ModCallGenericHandoff.lean
@@ -60,7 +60,11 @@ theorem saveRaAbsThenModCallDispatchReadyPost_callable_from_noNop_spec_in_smodCo
   let divisorAbsWord : EvmWord :=
     smodAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
   let retAddr := (base + modCallOff) + 4
-  let privateFrame := smodModCallPrivateFrame vRa dividendTop divisorTop
+  -- New: 2-arg privateFrame (no x9). Frame x9 separately for the callable.
+  -- x9 is placed first so that frameWithX9 is right-associative after unfolding.
+  let privateFrame := smodModCallPrivateFrame vRa dividendTop
+  let frameWithX9 : EvmAsm.Rv64.Assertion :=
+    (.x9 ↦ᵣ divisorSign) ** privateFrame
   have h_stack' :
       cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
         (base + wrapperEndOff) ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
@@ -100,18 +104,19 @@ theorem saveRaAbsThenModCallDispatchReadyPost_callable_from_noNop_spec_in_smodCo
         (EvmAsm.Evm64.modStackDispatchPostCallable sp dividendAbsWord divisorAbsWord **
           (.x1 ↦ᵣ retAddr)) := by
     exact cpsTripleWithin_extend_code evm_mod_callable_code_v4_sub_smodCodeV4 h_callable_raw
+  -- Frame with frameWithX9 = (.x9 ↦ divisorSign) ** privateFrame
   have h_callable_framed :
       cpsTripleWithin (EvmAsm.Evm64.unifiedDivBound + 1)
         (base + wrapperEndOff) (retAddr &&& ~~~(1 : Word)) (smodCodeV4 base)
         (EvmAsm.Evm64.divModStackDispatchPreCallable sp dividendAbsWord divisorAbsWord
           retAddr v2 v5 v6 divisorSum3 divisorMask divisorCarry3
           q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-          shiftMem nMem jMem retMem dMem dloMem scratchUn0 ** privateFrame)
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0 ** frameWithX9)
         ((EvmAsm.Evm64.modStackDispatchPostCallable sp dividendAbsWord divisorAbsWord **
-          (.x1 ↦ᵣ retAddr)) ** privateFrame) := by
-    exact cpsTripleWithin_frameR privateFrame (by
-      dsimp [privateFrame]
-      exact smodModCallPrivateFrame_pcFree) h_callable_code
+          (.x1 ↦ᵣ retAddr)) ** frameWithX9) := by
+    exact cpsTripleWithin_frameR frameWithX9 (by
+      dsimp only [frameWithX9]
+      pcFree) h_callable_code
   rw [show retAddr &&& ~~~(1 : Word) = base + resultSignFixOff by
     dsimp [retAddr]
     exact modCall_return_andn_one_eq_resultSignFixOff base h_base] at h_callable_framed
@@ -121,10 +126,11 @@ theorem saveRaAbsThenModCallDispatchReadyPost_callable_from_noNop_spec_in_smodCo
         rw [saveRaAbsThenModCallDispatchReadyPost_unfold_smod_components] at hp
         dsimp only at hp
         rw [EvmAsm.Evm64.divModStackDispatchPreCallable_unfold]
-        dsimp [privateFrame]
+        dsimp only [frameWithX9, privateFrame]
         rw [smodModCallPrivateFrame_unfold]
         dsimp only
         rw [EvmAsm.Evm64.divModStackDispatchPreNoX1_unfold] at hp
+        -- frameWithX9 = (.x9 ↦ divisorSign) ** privateFrame is already right-assoc
         change
           (((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ retAddr) ** (.x2 ↦ᵣ v2) **
             (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ divisorSum3) **
@@ -142,10 +148,29 @@ theorem saveRaAbsThenModCallDispatchReadyPost_callable_from_noNop_spec_in_smodCo
         dsimp only
         rw [smodModCallPrivateFrame_unfold]
         dsimp only
-        dsimp [privateFrame] at hp
+        dsimp only [frameWithX9, privateFrame] at hp
         rw [smodModCallPrivateFrame_unfold] at hp
         dsimp only at hp
-        xperm_hyp hp)
+        -- hp : ((moddispatch ** .x1) ** ((.x9 ↦ divisorSign) ** (x8 ** x13 ** x18))) h
+        obtain ⟨hAB, hX9C, hd1, hu1, hAB_h, hX9C_h⟩ := hp
+        obtain ⟨hX9, hC, hd3, hu3, hX9_h, hC_h⟩ := hX9C_h
+        have hregown := regIs_implies_regOwn .x9 hX9 hX9_h
+        have h_inner : (EvmAsm.Rv64.regOwn .x9 **
+            ((.x8 ↦ᵣ smodAbsSign dividendTop) ** (.x13 ↦ᵣ smodAbsSign dividendTop) **
+             (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12))))) (hX9.union hC) :=
+          ⟨hX9, hC, hd3, rfl, hregown, hC_h⟩
+        have h_new_disjoint : hAB.Disjoint (hX9.union hC) := by
+          rw [hu3]; exact hd1
+        have h_new_union : hAB.union (hX9.union hC) = h := by
+          rw [hu3]; exact hu1
+        have hp' : ((EvmAsm.Evm64.modStackDispatchPostCallable sp dividendAbsWord divisorAbsWord **
+                     (.x1 ↦ᵣ retAddr)) **
+                    (EvmAsm.Rv64.regOwn .x9 **
+                     ((.x8 ↦ᵣ smodAbsSign dividendTop) ** (.x13 ↦ᵣ smodAbsSign dividendTop) **
+                      (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))))) h :=
+          ⟨hAB, hX9.union hC, h_new_disjoint, h_new_union, hAB_h, h_inner⟩
+        rw [sepConj_assoc] at hp'
+        exact hp')
       h_callable_framed
 
 end EvmAsm.Evm64.SMod.Compose

--- a/EvmAsm/Evm64/SMod/Compose/ModCallPost.lean
+++ b/EvmAsm/Evm64/SMod/Compose/ModCallPost.lean
@@ -10,44 +10,44 @@ import EvmAsm.Evm64.SMod.Compose.DispatchReadyView
 namespace EvmAsm.Evm64.SMod.Compose
 
 /-- SMOD-private frame carried across the unsigned MOD callable. The callable
-    owns the normalized stack/scratch state, while SMOD keeps the divisor sign
-    in `x9`, the dividend/result sign in `x8` and `x13`, and the original
-    return address in `x18`. -/
+    owns the normalized stack/scratch state. SMOD keeps the dividend/result
+    sign in `x8` and `x13`, and the original return address in `x18`.
+    `x9` is NOT carried here because it is consumed by `divModStackDispatchPreNoX1`
+    and returned as `regOwn .x9` after the callable body. -/
 @[irreducible]
 def smodModCallPrivateFrame
-    (vRa dividendTop divisorTop : Word) : EvmAsm.Rv64.Assertion :=
+    (vRa dividendTop : Word) : EvmAsm.Rv64.Assertion :=
   let dividendSign := smodAbsSign dividendTop
-  let divisorSign := smodAbsSign divisorTop
-  (.x9 ↦ᵣ divisorSign) **
-    ((.x8 ↦ᵣ dividendSign) ** (.x13 ↦ᵣ dividendSign) **
-      (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12))))
+  (.x8 ↦ᵣ dividendSign) ** (.x13 ↦ᵣ dividendSign) **
+    (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))
 
 theorem smodModCallPrivateFrame_unfold
-    {vRa dividendTop divisorTop : Word} :
-    smodModCallPrivateFrame vRa dividendTop divisorTop =
+    {vRa dividendTop : Word} :
+    smodModCallPrivateFrame vRa dividendTop =
       (let dividendSign := smodAbsSign dividendTop
-       let divisorSign := smodAbsSign divisorTop
-       (.x9 ↦ᵣ divisorSign) **
-         ((.x8 ↦ᵣ dividendSign) ** (.x13 ↦ᵣ dividendSign) **
-           (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12))))) := by
+       (.x8 ↦ᵣ dividendSign) ** (.x13 ↦ᵣ dividendSign) **
+         (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))) := by
   delta smodModCallPrivateFrame
   rfl
 
 theorem smodModCallPrivateFrame_pcFree
-    {vRa dividendTop divisorTop : Word} :
-    (smodModCallPrivateFrame vRa dividendTop divisorTop).pcFree := by
+    {vRa dividendTop : Word} :
+    (smodModCallPrivateFrame vRa dividendTop).pcFree := by
   rw [smodModCallPrivateFrame_unfold]
   dsimp
   pcFree
 
 instance pcFreeInst_smodModCallPrivateFrame
-    (vRa dividendTop divisorTop : Word) :
+    (vRa dividendTop : Word) :
     EvmAsm.Rv64.Assertion.PCFree
-      (smodModCallPrivateFrame vRa dividendTop divisorTop) :=
+      (smodModCallPrivateFrame vRa dividendTop) :=
   ⟨smodModCallPrivateFrame_pcFree⟩
 
 /-- Postcondition after the unsigned MOD callable returns to the SMOD wrapper:
-    the normalized MOD callable post plus the private SMOD sign/return frame. -/
+    the normalized MOD callable post, the owned (but value-unknown) x9 register
+    returned by the callable body, and the private SMOD sign/return frame.
+    x9 is `regOwn` because the callable body modifies it (divisorSign is consumed
+    by `divModStackDispatchPreNoX1`; the body writes the loop counter to x9). -/
 @[irreducible]
 def saveRaAbsThenModCallCallablePost
     (vRa sp base : Word)
@@ -60,7 +60,8 @@ def saveRaAbsThenModCallCallablePost
     smodAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
   EvmAsm.Evm64.modStackDispatchPostCallable sp dividendAbsWord divisorAbsWord **
     (.x1 ↦ᵣ ((base + modCallOff) + 4)) **
-    smodModCallPrivateFrame vRa dividendTop divisorTop
+    EvmAsm.Rv64.regOwn .x9 **
+    smodModCallPrivateFrame vRa dividendTop
 
 theorem saveRaAbsThenModCallCallablePost_unfold
     {vRa sp base : Word}
@@ -75,7 +76,8 @@ theorem saveRaAbsThenModCallCallablePost_unfold
          smodAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
        EvmAsm.Evm64.modStackDispatchPostCallable sp dividendAbsWord divisorAbsWord **
          (.x1 ↦ᵣ ((base + modCallOff) + 4)) **
-         smodModCallPrivateFrame vRa dividendTop divisorTop) := by
+         EvmAsm.Rv64.regOwn .x9 **
+         smodModCallPrivateFrame vRa dividendTop) := by
   delta saveRaAbsThenModCallCallablePost
   rfl
 
@@ -89,6 +91,8 @@ theorem saveRaAbsThenModCallCallablePost_pcFree
   dsimp
   rw [EvmAsm.Evm64.modStackDispatchPostCallable_unfold]
   rw [EvmAsm.Evm64.divScratchOwnCallNoX1_unfold, EvmAsm.Evm64.divScratchOwn_unfold]
+  rw [smodModCallPrivateFrame_unfold]
+  dsimp
   pcFree
 
 instance pcFreeInst_saveRaAbsThenModCallCallablePost

--- a/EvmAsm/Evm64/SMod/Compose/ModCallResultSignFix.lean
+++ b/EvmAsm/Evm64/SMod/Compose/ModCallResultSignFix.lean
@@ -44,7 +44,7 @@ theorem saveRaAbsThenModCall_then_resultSignFix_of_callable_post_spec_in_smodCod
        smodResultSignFixPost (sp + 32) resultSign
          (modWord.getLimbN 0) (modWord.getLimbN 1)
          (modWord.getLimbN 2) (modWord.getLimbN 3) **
-       smodModCallResultSignFixFrame vRa sp base dividendTop divisorTop
+       smodModCallResultSignFixFrame vRa sp base dividendTop
          dividendAbsWord) := by
   let dividendAbsWord : EvmWord :=
     smodAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
@@ -52,7 +52,7 @@ theorem saveRaAbsThenModCall_then_resultSignFix_of_callable_post_spec_in_smodCod
     smodAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
   let modWord := EvmWord.mod dividendAbsWord divisorAbsWord
   let resultSign := smodAbsSign dividendTop
-  let frame := smodModCallResultSignFixFrame vRa sp base dividendTop divisorTop
+  let frame := smodModCallResultSignFixFrame vRa sp base dividendTop
     dividendAbsWord
   have hFramePc : frame.pcFree := by
     dsimp [frame]

--- a/EvmAsm/Evm64/SMod/Compose/ModCallResultSignFixGeneric.lean
+++ b/EvmAsm/Evm64/SMod/Compose/ModCallResultSignFixGeneric.lean
@@ -52,7 +52,7 @@ theorem saveRaAbsThenModCall_then_resultSignFix_from_noNop_spec_in_smodCodeV4
        smodResultSignFixPost (sp + 32) resultSign
          (modWord.getLimbN 0) (modWord.getLimbN 1)
          (modWord.getLimbN 2) (modWord.getLimbN 3) **
-       smodModCallResultSignFixFrame vRa sp base dividendTop divisorTop
+       smodModCallResultSignFixFrame vRa sp base dividendTop
          dividendAbsWord) := by
   have hCallable :=
     saveRaAbsThenModCallDispatchReadyPost_callable_from_noNop_spec_in_smodCodeV4

--- a/EvmAsm/Evm64/SMod/Compose/ModCallResultSignFixNamedPost.lean
+++ b/EvmAsm/Evm64/SMod/Compose/ModCallResultSignFixNamedPost.lean
@@ -38,7 +38,7 @@ def saveRaAbsThenModCallResultSignFixPost
       (smodResultSignFixedWord dividendTop
         (modWord.getLimbN 0) (modWord.getLimbN 1)
         (modWord.getLimbN 2) (modWord.getLimbN 3))) **
-    smodModCallResultSignFixFrame vRa sp base dividendTop divisorTop
+    smodModCallResultSignFixFrame vRa sp base dividendTop
       dividendAbsWord
 
 theorem saveRaAbsThenModCallResultSignFixPost_unfold
@@ -70,7 +70,7 @@ theorem saveRaAbsThenModCallResultSignFixPost_unfold
            (smodResultSignFixedWord dividendTop
              (modWord.getLimbN 0) (modWord.getLimbN 1)
              (modWord.getLimbN 2) (modWord.getLimbN 3))) **
-         smodModCallResultSignFixFrame vRa sp base dividendTop divisorTop
+         smodModCallResultSignFixFrame vRa sp base dividendTop
            dividendAbsWord) := by
   delta saveRaAbsThenModCallResultSignFixPost
   rfl

--- a/EvmAsm/Evm64/SMod/Compose/ModCallResultSignFixPost.lean
+++ b/EvmAsm/Evm64/SMod/Compose/ModCallResultSignFixPost.lean
@@ -15,25 +15,22 @@ open EvmAsm.Rv64.Tactics
 
 @[irreducible]
 def smodModCallResultSignFixFrame
-    (vRa sp base dividendTop divisorTop : Word) (dividendAbsWord : EvmWord) :
+    (vRa sp base dividendTop : Word) (dividendAbsWord : EvmWord) :
     EvmAsm.Rv64.Assertion :=
   let dividendSign := smodAbsSign dividendTop
-  let divisorSign := smodAbsSign divisorTop
   (.x1 ↦ᵣ ((base + modCallOff) + 4)) **
-    (.x9 ↦ᵣ divisorSign) ** (.x8 ↦ᵣ dividendSign) **
+    EvmAsm.Rv64.regOwn .x9 ** (.x8 ↦ᵣ dividendSign) **
     (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12))) **
     EvmAsm.Rv64.regOwn .x2 ** EvmAsm.Rv64.regOwn .x5 **
     EvmAsm.Rv64.regOwn .x6 ** evmWordIs sp dividendAbsWord **
     EvmAsm.Evm64.divScratchOwnCallNoX1 sp
 
 theorem smodModCallResultSignFixFrame_unfold
-    {vRa sp base dividendTop divisorTop : Word} {dividendAbsWord : EvmWord} :
-    smodModCallResultSignFixFrame vRa sp base dividendTop divisorTop
-        dividendAbsWord =
+    {vRa sp base dividendTop : Word} {dividendAbsWord : EvmWord} :
+    smodModCallResultSignFixFrame vRa sp base dividendTop dividendAbsWord =
       (let dividendSign := smodAbsSign dividendTop
-       let divisorSign := smodAbsSign divisorTop
        (.x1 ↦ᵣ ((base + modCallOff) + 4)) **
-         (.x9 ↦ᵣ divisorSign) ** (.x8 ↦ᵣ dividendSign) **
+         EvmAsm.Rv64.regOwn .x9 ** (.x8 ↦ᵣ dividendSign) **
          (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12))) **
          EvmAsm.Rv64.regOwn .x2 ** EvmAsm.Rv64.regOwn .x5 **
          EvmAsm.Rv64.regOwn .x6 ** evmWordIs sp dividendAbsWord **
@@ -42,9 +39,8 @@ theorem smodModCallResultSignFixFrame_unfold
   rfl
 
 theorem smodModCallResultSignFixFrame_pcFree
-    {vRa sp base dividendTop divisorTop : Word} {dividendAbsWord : EvmWord} :
-    (smodModCallResultSignFixFrame vRa sp base dividendTop divisorTop
-      dividendAbsWord).pcFree := by
+    {vRa sp base dividendTop : Word} {dividendAbsWord : EvmWord} :
+    (smodModCallResultSignFixFrame vRa sp base dividendTop dividendAbsWord).pcFree := by
   rw [smodModCallResultSignFixFrame_unfold,
     EvmAsm.Evm64.divScratchOwnCallNoX1_unfold,
     EvmAsm.Evm64.divScratchOwn_unfold]
@@ -52,10 +48,9 @@ theorem smodModCallResultSignFixFrame_pcFree
   pcFree
 
 instance pcFreeInst_smodModCallResultSignFixFrame
-    (vRa sp base dividendTop divisorTop : Word) (dividendAbsWord : EvmWord) :
+    (vRa sp base dividendTop : Word) (dividendAbsWord : EvmWord) :
     EvmAsm.Rv64.Assertion.PCFree
-      (smodModCallResultSignFixFrame vRa sp base dividendTop divisorTop
-        dividendAbsWord) :=
+      (smodModCallResultSignFixFrame vRa sp base dividendTop dividendAbsWord) :=
   ⟨smodModCallResultSignFixFrame_pcFree⟩
 
 theorem saveRaAbsThenModCallCallablePost_smodResultSignFixPreOwnScratch
@@ -74,8 +69,7 @@ theorem saveRaAbsThenModCallCallablePost_smodResultSignFixPreOwnScratch
        smodResultSignFixPreOwnScratch (sp + 32) resultSign
          (modWord.getLimbN 0) (modWord.getLimbN 1)
          (modWord.getLimbN 2) (modWord.getLimbN 3) **
-       smodModCallResultSignFixFrame vRa sp base dividendTop divisorTop
-         dividendAbsWord) := by
+       smodModCallResultSignFixFrame vRa sp base dividendTop dividendAbsWord) := by
   dsimp only
   rw [saveRaAbsThenModCallCallablePost_unfold]
   dsimp only

--- a/EvmAsm/Evm64/SMod/Compose/ModCallReturnGeneric.lean
+++ b/EvmAsm/Evm64/SMod/Compose/ModCallReturnGeneric.lean
@@ -59,7 +59,7 @@ theorem saveRaAbsThenModCall_then_return_from_noNop_spec_in_smodCodeV4
        (smodResultSignFixPost (sp + 32) resultSign
          (modWord.getLimbN 0) (modWord.getLimbN 1)
          (modWord.getLimbN 2) (modWord.getLimbN 3) **
-        smodSavedRaRetFrame sp base dividendTop divisorTop dividendAbsWord)) := by
+        smodSavedRaRetFrame sp base dividendTop dividendAbsWord)) := by
   let dividendAbsWord : EvmWord :=
     smodAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
   let divisorAbsWord : EvmWord :=
@@ -78,14 +78,14 @@ theorem saveRaAbsThenModCall_then_return_from_noNop_spec_in_smodCodeV4
       (smodResultSignFixPost (sp + 32) resultSign
         (modWord.getLimbN 0) (modWord.getLimbN 1)
         (modWord.getLimbN 2) (modWord.getLimbN 3) **
-       smodSavedRaRetFrame sp base dividendTop divisorTop dividendAbsWord).pcFree := by
+       smodSavedRaRetFrame sp base dividendTop dividendAbsWord).pcFree := by
     pcFree
   have hRetFramed :=
     EvmAsm.Rv64.cpsTripleWithin_frameR
       (smodResultSignFixPost (sp + 32) resultSign
         (modWord.getLimbN 0) (modWord.getLimbN 1)
         (modWord.getLimbN 2) (modWord.getLimbN 3) **
-       smodSavedRaRetFrame sp base dividendTop divisorTop dividendAbsWord)
+       smodSavedRaRetFrame sp base dividendTop dividendAbsWord)
       hRetFramePc
       (savedRaRet_spec_in_smodCodeV4
         (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)) base)
@@ -102,12 +102,12 @@ theorem saveRaAbsThenModCall_then_return_from_noNop_spec_in_smodCodeV4
          (smodResultSignFixPost (sp + 32) resultSign
           (modWord.getLimbN 0) (modWord.getLimbN 1)
           (modWord.getLimbN 2) (modWord.getLimbN 3) **
-          smodSavedRaRetFrame sp base dividendTop divisorTop dividendAbsWord))
+          smodSavedRaRetFrame sp base dividendTop dividendAbsWord))
         ((.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12))) **
          (smodResultSignFixPost (sp + 32) resultSign
           (modWord.getLimbN 0) (modWord.getLimbN 1)
           (modWord.getLimbN 2) (modWord.getLimbN 3) **
-          smodSavedRaRetFrame sp base dividendTop divisorTop dividendAbsWord)) := by
+          smodSavedRaRetFrame sp base dividendTop dividendAbsWord)) := by
     rw [hFall]
     exact hRetFramed
   exact EvmAsm.Rv64.cpsTripleWithin_seq_perm_same_cr

--- a/EvmAsm/Evm64/SMod/Compose/ModCallReturnNamedPost.lean
+++ b/EvmAsm/Evm64/SMod/Compose/ModCallReturnNamedPost.lean
@@ -39,7 +39,7 @@ def saveRaAbsThenModCallReturnPost
         (smodResultSignFixedWord dividendTop
           (modWord.getLimbN 0) (modWord.getLimbN 1)
           (modWord.getLimbN 2) (modWord.getLimbN 3))) **
-      smodSavedRaRetFrame sp base dividendTop divisorTop dividendAbsWord)
+      smodSavedRaRetFrame sp base dividendTop dividendAbsWord)
 
 theorem saveRaAbsThenModCallReturnPost_unfold
     {vRa sp base : Word}
@@ -71,7 +71,7 @@ theorem saveRaAbsThenModCallReturnPost_unfold
              (smodResultSignFixedWord dividendTop
                (modWord.getLimbN 0) (modWord.getLimbN 1)
                (modWord.getLimbN 2) (modWord.getLimbN 3))) **
-           smodSavedRaRetFrame sp base dividendTop divisorTop dividendAbsWord)) := by
+           smodSavedRaRetFrame sp base dividendTop dividendAbsWord)) := by
   delta saveRaAbsThenModCallReturnPost
   rfl
 

--- a/EvmAsm/Evm64/SMod/Compose/SavedRaRetFrame.lean
+++ b/EvmAsm/Evm64/SMod/Compose/SavedRaRetFrame.lean
@@ -12,26 +12,25 @@ namespace EvmAsm.Evm64.SMod.Compose
 
 open EvmAsm.Rv64.Tactics
 
-/-- Frame remaining after exposing `x18` for the saved-RA return. -/
+/-- Frame remaining after exposing `x18` for the saved-RA return.
+    x9 is `regOwn` since the callable body modifies it (divisorSign is consumed). -/
 @[irreducible]
 def smodSavedRaRetFrame
-    (sp base dividendTop divisorTop : Word) (dividendAbsWord : EvmWord) :
+    (sp base dividendTop : Word) (dividendAbsWord : EvmWord) :
     EvmAsm.Rv64.Assertion :=
   let dividendSign := smodAbsSign dividendTop
-  let divisorSign := smodAbsSign divisorTop
   (.x1 ↦ᵣ ((base + modCallOff) + 4)) **
-    (.x9 ↦ᵣ divisorSign) ** (.x8 ↦ᵣ dividendSign) **
+    EvmAsm.Rv64.regOwn .x9 ** (.x8 ↦ᵣ dividendSign) **
     EvmAsm.Rv64.regOwn .x2 ** EvmAsm.Rv64.regOwn .x5 **
     EvmAsm.Rv64.regOwn .x6 ** evmWordIs sp dividendAbsWord **
     EvmAsm.Evm64.divScratchOwnCallNoX1 sp
 
 theorem smodSavedRaRetFrame_unfold
-    {sp base dividendTop divisorTop : Word} {dividendAbsWord : EvmWord} :
-    smodSavedRaRetFrame sp base dividendTop divisorTop dividendAbsWord =
+    {sp base dividendTop : Word} {dividendAbsWord : EvmWord} :
+    smodSavedRaRetFrame sp base dividendTop dividendAbsWord =
       (let dividendSign := smodAbsSign dividendTop
-       let divisorSign := smodAbsSign divisorTop
        (.x1 ↦ᵣ ((base + modCallOff) + 4)) **
-         (.x9 ↦ᵣ divisorSign) ** (.x8 ↦ᵣ dividendSign) **
+         EvmAsm.Rv64.regOwn .x9 ** (.x8 ↦ᵣ dividendSign) **
          EvmAsm.Rv64.regOwn .x2 ** EvmAsm.Rv64.regOwn .x5 **
          EvmAsm.Rv64.regOwn .x6 ** evmWordIs sp dividendAbsWord **
          EvmAsm.Evm64.divScratchOwnCallNoX1 sp) := by
@@ -39,8 +38,8 @@ theorem smodSavedRaRetFrame_unfold
   rfl
 
 theorem smodSavedRaRetFrame_pcFree
-    {sp base dividendTop divisorTop : Word} {dividendAbsWord : EvmWord} :
-    (smodSavedRaRetFrame sp base dividendTop divisorTop dividendAbsWord).pcFree := by
+    {sp base dividendTop : Word} {dividendAbsWord : EvmWord} :
+    (smodSavedRaRetFrame sp base dividendTop dividendAbsWord).pcFree := by
   rw [smodSavedRaRetFrame_unfold,
     EvmAsm.Evm64.divScratchOwnCallNoX1_unfold,
     EvmAsm.Evm64.divScratchOwn_unfold]
@@ -48,18 +47,18 @@ theorem smodSavedRaRetFrame_pcFree
   pcFree
 
 instance pcFreeInst_smodSavedRaRetFrame
-    (sp base dividendTop divisorTop : Word) (dividendAbsWord : EvmWord) :
+    (sp base dividendTop : Word) (dividendAbsWord : EvmWord) :
     EvmAsm.Rv64.Assertion.PCFree
-      (smodSavedRaRetFrame sp base dividendTop divisorTop dividendAbsWord) :=
+      (smodSavedRaRetFrame sp base dividendTop dividendAbsWord) :=
   ⟨smodSavedRaRetFrame_pcFree⟩
 
 /-- Expose the saved return address atom from the SMOD result-sign-fix frame,
     leaving the rest as an explicit return frame. -/
 theorem smodModCallResultSignFixFrame_to_savedRaRet
-    {vRa sp base dividendTop divisorTop : Word} {dividendAbsWord : EvmWord} :
-    smodModCallResultSignFixFrame vRa sp base dividendTop divisorTop dividendAbsWord =
+    {vRa sp base dividendTop : Word} {dividendAbsWord : EvmWord} :
+    smodModCallResultSignFixFrame vRa sp base dividendTop dividendAbsWord =
       ((.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12))) **
-       smodSavedRaRetFrame sp base dividendTop divisorTop dividendAbsWord) := by
+       smodSavedRaRetFrame sp base dividendTop dividendAbsWord) := by
   rw [smodModCallResultSignFixFrame_unfold, smodSavedRaRetFrame_unfold]
   xperm
 


### PR DESCRIPTION
## Summary
- `smodModCallPrivateFrame` now takes `(vRa dividendTop : Word)` only; `divisorTop`/`divisorSign` removed from private frame
- `saveRaAbsThenModCallCallablePost` includes `regOwn .x9` instead of `.x9 ↦ divisorSign`, since the callable body modifies x9
- `smodModCallResultSignFixFrame` and `smodSavedRaRetFrame` updated to use `regOwn .x9` and drop `divisorTop`
- Handoff proofs (bzero and generic) frame x9 separately as `(.x9 ↦ divisorSign) ** privateFrame` and weaken to `regOwn .x9` in the post via `regIs_implies_regOwn` + `sepConj_assoc`
- All dependent compose files updated

Refs #9. Bead: evm-asm-9iqmw.9.1.2.3.1.

## Verification
- lake build EvmAsm.Evm64.SMod.Compose.ModCallBzeroHandoff
- lake build EvmAsm.Evm64.SMod.Compose.ModCallGenericHandoff
- scripts/check-file-size.sh
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SMod/Compose/
- lake build

Authored by @pirapira; implemented by Claude Code