### PR TITLE
feat(stateless): mpt_branch_node_keccak (PR-K169)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -5186,6 +5186,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_nibbles_common_prefix_len" => some ziskNibblesCommonPrefixLenProbeUnit
   | "zisk_mpt_branch_payload_two_slots" => some ziskMptBranchPayloadTwoSlotsProbeUnit
   | "zisk_mpt_leaf_node_encode_from_nibbles" => some ziskMptLeafNodeEncodeFromNibblesProbeUnit
+  | "zisk_mpt_branch_node_keccak" => some ziskMptBranchNodeKeccakProbeUnit
   | "zisk_block_logs_bloom_from_receipts_list" => some ziskBlockLogsBloomFromReceiptsListProbeUnit
   | "zisk_block_validate_logs_bloom" => some ziskBlockValidateLogsBloomProbeUnit
   | "zisk_header_root_is_empty_trie" => some ziskHeaderRootIsEmptyTrieProbeUnit
@@ -5368,6 +5369,7 @@ def knownProgramNames : List String :=
    "zisk_nibbles_common_prefix_len",
    "zisk_mpt_branch_payload_two_slots",
    "zisk_mpt_leaf_node_encode_from_nibbles",
+   "zisk_mpt_branch_node_keccak",
    "zisk_block_logs_bloom_from_receipts_list",
    "zisk_block_validate_logs_bloom",
    "zisk_header_root_is_empty_trie",

--- a/EvmAsm/Codegen/Programs/Mpt.lean
+++ b/EvmAsm/Codegen/Programs/Mpt.lean
@@ -3744,5 +3744,102 @@ def ziskMptLeafNodeEncodeFromNibblesProbeUnit : BuildUnit := {
   dataAsm     := ziskMptLeafNodeEncodeFromNibblesDataSection
 }
 
+/-! ## mpt_branch_node_keccak -- PR-K169
+
+    Compose PR-K165 `mpt_branch_node_encode` with
+    `zkvm_keccak256`: given a pre-concatenated 17-slot payload,
+    produce the 32-byte keccak256 of the branch-node RLP.
+
+    Direct primitive for the trie root when the trie's root *is*
+    a branch node. This is the common case for 2-entry indexed
+    tries (transactions / receipts / withdrawals) when the two
+    keys diverge at the first nibble:
+
+      * `rlp(0) = 0x80` (nibbles `[8, 0]`)
+      * `rlp(1) = 0x01` (nibbles `[0, 1]`)
+
+    The shared prefix is empty (cpl = 0; cf. PR-K166), so the
+    root is directly `keccak256(branch_node_rlp)` with the two
+    leaves' parent-slot encodings sitting at slots 0 and 8 (and
+    the rest empty, per K167's payload-assembler).
+
+    Composes:
+      - PR-K165 `mpt_branch_node_encode`  for the outer wrap
+      - `zkvm_keccak256` (HashBridge)     for the root hash
+
+    Calling convention:
+      a0 (input)  : slot_payload ptr (pre-concatenated 17-slot
+                    bytes; caller's responsibility to put the
+                    slots in nibble order and end with the value
+                    slot)
+      a1 (input)  : slot_payload byte length
+      a2 (input)  : 32-byte output root ptr
+      ra (input)  : return
+      a0 (output) : 0 (always succeeds).
+
+    Uses a 16 KiB `.data` scratch buffer for the branch-node RLP
+    bytes between the K165 emit step and the keccak step. -/
+def mptBranchNodeKeccakFunction : String :=
+  "mpt_branch_node_keccak:\n" ++
+  "  addi sp, sp, -32\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp)\n" ++
+  "  mv s0, a0                   # slot_payload ptr\n" ++
+  "  mv s1, a1                   # slot_payload len\n" ++
+  "  mv s2, a2                   # output root ptr\n" ++
+  "  # ---- Step 1: emit branch-node RLP to mbnk_node_buf ----\n" ++
+  "  mv a0, s0; mv a1, s1\n" ++
+  "  la a2, mbnk_node_buf\n" ++
+  "  la a3, mbnk_node_len\n" ++
+  "  jal ra, mpt_branch_node_encode\n" ++
+  "  # ---- Step 2: keccak256(mbnk_node_buf, mbnk_node_len) ----\n" ++
+  "  la a0, mbnk_node_buf\n" ++
+  "  la t0, mbnk_node_len; ld a1, 0(t0)\n" ++
+  "  mv a2, s2\n" ++
+  "  jal ra, zkvm_keccak256\n" ++
+  "  li a0, 0\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp)\n" ++
+  "  addi sp, sp, 32\n" ++
+  "  ret"
+
+/-- `zisk_mpt_branch_node_keccak`: probe BuildUnit.
+    Input layout:
+      bytes  0.. 8 : slot_payload_len
+      bytes  8..   : slot_payload bytes
+    Output layout:
+      bytes  0..32 : 32-byte branch-node keccak256 root -/
+def ziskMptBranchNodeKeccakPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a3, 0x40000000\n" ++
+  "  ld a1, 8(a3)                # slot_payload_len\n" ++
+  "  addi a0, a3, 16             # slot_payload ptr\n" ++
+  "  li a2, 0xa0010000           # output root ptr (32 B)\n" ++
+  "  jal ra, mpt_branch_node_keccak\n" ++
+  "  j .Lmbnk_pdone\n" ++
+  rlpEncodeListPrefixFunction ++ "\n" ++
+  mptBranchNodeEncodeFunction ++ "\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  mptBranchNodeKeccakFunction ++ "\n" ++
+  ".Lmbnk_pdone:"
+
+def ziskMptBranchNodeKeccakDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  "mbne_field_len:\n" ++
+  "  .zero 8\n" ++
+  "mbnk_node_len:\n" ++
+  "  .zero 8\n" ++
+  "mbnk_node_buf:\n" ++
+  "  .zero 16384"
+
+def ziskMptBranchNodeKeccakProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskMptBranchNodeKeccakPrologue
+  dataAsm     := ziskMptBranchNodeKeccakDataSection
+}
+
 
 end EvmAsm.Codegen

--- a/scripts/codegen-zisk-mpt-branch-node-keccak-check.sh
+++ b/scripts/codegen-zisk-mpt-branch-node-keccak-check.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# codegen-zisk-mpt-branch-node-keccak-check.sh -- PR-K169.
+#
+# Compute keccak256(rlp(branch_payload)) for a pre-concatenated
+# 17-slot payload.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_mpt_branch_node_keccak ELF"
+lake exe codegen --program zisk_mpt_branch_node_keccak --halt linux93 \
+  -o gen-out/zisk_mpt_branch_node_keccak
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <slot_payload_hex>
+# slot_payload is the pre-concatenated 17-slot bytes.
+run_case() {
+  local name="$1" payload="$2"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_mpt_branch_node_keccak_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_mpt_branch_node_keccak_${name}.output"
+  local exp_hex_file="$REPO_ROOT/gen-out/zisk_mpt_branch_node_keccak_${name}.expected.hex"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys
+try:
+    from Crypto.Hash import keccak
+    def keccak256(b):
+        h = keccak.new(digest_bits=256); h.update(b); return h.digest()
+except Exception:
+    import sha3
+    def keccak256(b): return sha3.keccak_256(b).digest()
+
+payload = bytes.fromhex('$payload')
+n = len(payload)
+if n < 56:
+    prefix = bytes([0xc0 + n])
+else:
+    n_bytes = n.to_bytes((n.bit_length() + 7) // 8, 'big')
+    prefix = bytes([0xf7 + len(n_bytes)]) + n_bytes
+branch_node_rlp = prefix + payload
+expected = keccak256(branch_node_rlp)
+
+with open(sys.argv[1], 'wb') as f:
+    f.write(struct.pack('<Q', n))
+    f.write(payload)
+    pad = (-(8 + n)) % 8
+    if pad: f.write(b'\x00' * pad)
+with open(sys.argv[2], 'w') as f:
+    f.write(expected.hex())
+" "$in_file" "$exp_hex_file"
+
+  "$ZISKEMU" -e gen-out/zisk_mpt_branch_node_keccak.elf \
+    -i "$in_file" -o "$out_file" -n 5000000 \
+    >"$REPO_ROOT/gen-out/zisk_mpt_branch_node_keccak_${name}.emu.log" 2>&1 || true
+
+  local actual; actual="$(xxd -p -l 32 "$out_file" | tr -d '\n')"
+  local expected; expected="$(cat "$exp_hex_file")"
+
+  if [[ "$actual" == "$expected" ]]; then
+    printf "  %-30s OK   root=%s...\n" "$name" "${actual:0:16}"
+    return 0
+  else
+    printf "  %-30s FAIL\n" "$name"
+    printf "      actual:   %s\n" "$actual"
+    printf "      expected: %s\n" "$expected"
+    return 1
+  fi
+}
+
+# Helper: construct a 17-slot payload string.
+ALL_EMPTY="$(python3 -c "print('80' * 17)")"
+
+# Hashed entry at slot 0 (33-byte 0xa0 + 32B hash), rest empty.
+HASH32_A="a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0"
+HASH32_B="b0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecf"
+ONE_HASH_AT_0="$(python3 -c "
+import json
+slots = ['80']*17
+slots[0] = 'a0' + '$HASH32_A'
+print(''.join(slots))
+")"
+
+# Realistic 2-tx-block divergence: slots 0 and 8 hashed.
+TWO_TX_DIVERGENCE="$(python3 -c "
+slots = ['80']*17
+slots[0] = 'a0' + '$HASH32_A'
+slots[8] = 'a0' + '$HASH32_B'
+print(''.join(slots))
+")"
+
+INLINE_AT_3="$(python3 -c "
+slots = ['80']*17
+slots[3] = 'c4820080'
+print(''.join(slots))
+")"
+
+FAILED=0
+run_case "all_empty_branch"       "$ALL_EMPTY"           || FAILED=1
+run_case "one_hashed_slot0"       "$ONE_HASH_AT_0"       || FAILED=1
+run_case "two_tx_divergence"      "$TWO_TX_DIVERGENCE"   || FAILED=1
+run_case "inline_at_3"            "$INLINE_AT_3"         || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: mpt_branch_node_keccak matches keccak256(rlp(branch_payload))"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- \`mpt_branch_node_keccak\`: compose PR-K165 \`mpt_branch_node_encode\` with \`zkvm_keccak256\` — given a pre-concatenated 17-slot payload, produce the 32-byte keccak256 of the branch-node RLP.
- **Direct primitive for the trie root when the root *is* a branch node** — the common case for 2-entry indexed tries (transactions / receipts / withdrawals) where the two keys diverge at the first nibble (cpl = 0 from PR-K166).
- Composes PR-K165 + \`zkvm_keccak256\`. Lives in \`Programs/Mpt.lean\`.

### Calling convention

| reg | role |
|---|---|
| a0 | slot_payload ptr (pre-concatenated 17-slot bytes) |
| a1 | slot_payload byte length |
| a2 | 32-byte output root ptr |
| a0 (out) | 0 (always succeeds) |

Uses a 16 KiB \`.data\` scratch buffer for the branch-node RLP bytes between the K165 emit step and the keccak step.

## Stacking

Base = \`feat/stateless-mpt-leaf-node-encode-from-nibbles\` (PR #5959).

## Test plan

- [x] \`lake build\` clean
- [x] \`scripts/codegen-zisk-mpt-branch-node-keccak-check.sh\` — 4/4 fixtures pass against Python \`keccak256(rlp(branch_payload))\`:
  - \`all_empty_branch\`: degenerate
  - \`one_hashed_slot0\`: single hashed child
  - \`two_tx_divergence\`: realistic 2-tx-block shape
  - \`inline_at_3\`: inline child at slot 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)