### PR TITLE
feat(smod): update h_stack type to divModStackDispatchPreNoX1 + regOwn .x9

### DIFF
--- a/EvmAsm/Evm64/SMod.lean
+++ b/EvmAsm/Evm64/SMod.lean
@@ -22,3 +22,4 @@ import EvmAsm.Evm64.SMod.AddrNorm
 import EvmAsm.Evm64.SMod.Compose.Base
 import EvmAsm.Evm64.SMod.Spec
 import EvmAsm.Evm64.SMod.SpecBzero
+import EvmAsm.Evm64.SMod.SpecAllCase

--- a/EvmAsm/Evm64/SMod/Compose/ModCallGenericHandoff.lean
+++ b/EvmAsm/Evm64/SMod/Compose/ModCallGenericHandoff.lean
@@ -3,10 +3,14 @@
 
   Generic handoff from the SMOD wrapper's normalized dispatch-ready frame into
   the appended unsigned MOD callable, parameterized by the no-NOP body proof.
+  h_stack uses divModStackDispatchPreNoX1 (with explicit x9=divisorSign) and
+  includes regOwn .x9 in the postcondition, matching the nonzero callable's
+  actual register behaviour.
 -/
 
 import EvmAsm.Evm64.SMod.Compose.BaseTopLevel
 import EvmAsm.Evm64.SMod.Compose.ModCallPost
+import EvmAsm.Evm64.DivMod.CallableV4Mod
 
 namespace EvmAsm.Evm64.SMod.Compose
 
@@ -24,9 +28,10 @@ theorem saveRaAbsThenModCallDispatchReadyPost_callable_from_noNop_spec_in_smodCo
       cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
         (base + wrapperEndOff) ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
         (EvmAsm.Evm64.modCode_noNop_v4 (base + wrapperEndOff))
-        (EvmAsm.Evm64.divModStackDispatchPreCallable sp
+        (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp
           (smodAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
           (smodAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          (smodAbsSign divisorTop)
           ((base + modCallOff) + 4)
           v2 v5 v6
           (smodAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
@@ -37,7 +42,8 @@ theorem saveRaAbsThenModCallDispatchReadyPost_callable_from_noNop_spec_in_smodCo
         (EvmAsm.Evm64.modStackDispatchPostCallable sp
           (smodAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
           (smodAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) **
-          (.x1 ↦ᵣ ((base + modCallOff) + 4)))) :
+          (.x1 ↦ᵣ ((base + modCallOff) + 4)) **
+          EvmAsm.Rv64.regOwn .x9)) :
     cpsTripleWithin (EvmAsm.Evm64.unifiedDivBound + 1)
       (base + wrapperEndOff) (base + resultSignFixOff) (smodCodeV4 base)
       (saveRaAbsThenModCallDispatchReadyPost vRa sp base
@@ -60,62 +66,72 @@ theorem saveRaAbsThenModCallDispatchReadyPost_callable_from_noNop_spec_in_smodCo
   let divisorAbsWord : EvmWord :=
     smodAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
   let retAddr := (base + modCallOff) + 4
-  -- New: 2-arg privateFrame (no x9). Frame x9 separately for the callable.
-  -- x9 is placed first so that frameWithX9 is right-associative after unfolding.
   let privateFrame := smodModCallPrivateFrame vRa dividendTop
-  let frameWithX9 : EvmAsm.Rv64.Assertion :=
-    (.x9 ↦ᵣ divisorSign) ** privateFrame
   have h_stack' :
       cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
         (base + wrapperEndOff) ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
         (EvmAsm.Evm64.modCode_noNop_v4 (base + wrapperEndOff))
-        (EvmAsm.Evm64.divModStackDispatchPreCallable sp dividendAbsWord divisorAbsWord
-          retAddr v2 v5 v6 divisorSum3 divisorMask divisorCarry3
+        (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp dividendAbsWord divisorAbsWord
+          divisorSign retAddr v2 v5 v6 divisorSum3 divisorMask divisorCarry3
           q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0)
         (EvmAsm.Evm64.modStackDispatchPostCallable sp dividendAbsWord divisorAbsWord **
-          (.x1 ↦ᵣ retAddr)) := by
-    simpa [dividendAbsWord, divisorAbsWord, retAddr, divisorSum3, divisorMask,
-      divisorCarry3] using h_stack
+          (.x1 ↦ᵣ retAddr) ** EvmAsm.Rv64.regOwn .x9) := by
+    simpa [dividendAbsWord, divisorAbsWord, divisorSign, retAddr, divisorSum3,
+      divisorMask, divisorCarry3] using h_stack
+  -- Extend body from modCode_noNop_v4 to evm_mod_callable_code_v4
+  have h_body_call := cpsTripleWithin_extend_code
+    EvmAsm.Evm64.modCode_noNop_v4_sub_mod_callable_code_v4 h_stack'
+  -- Return instruction: JALR is a pure read of .x1, so .x1 ↦ retAddr is preserved
+  have h_ret := cpsTripleWithin_extend_code
+    (EvmAsm.Evm64.evm_mod_callable_code_v4_ret_sub (base := base + wrapperEndOff))
+    (ret_spec_within' ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff) retAddr)
+  -- Frame (PostCallable ** regOwn .x9) around return; ret pre/post is (.x1 ↦ retAddr)
+  have h_ret_framed := cpsTripleWithin_frameL
+    (EvmAsm.Evm64.modStackDispatchPostCallable sp dividendAbsWord divisorAbsWord **
+      EvmAsm.Rv64.regOwn .x9)
+    (by
+      rw [EvmAsm.Evm64.modStackDispatchPostCallable_unfold,
+        EvmAsm.Evm64.divScratchOwnCallNoX1_unfold, EvmAsm.Evm64.divScratchOwn_unfold]
+      pcFree)
+    h_ret
+  -- Sequence body → ret (with xperm to bridge post-of-body to pre-of-ret)
   have h_callable_raw :
       cpsTripleWithin (EvmAsm.Evm64.unifiedDivBound + 1)
         (base + wrapperEndOff) (retAddr &&& ~~~(1 : Word))
         (EvmAsm.Evm64.evm_mod_callable_code_v4 (base + wrapperEndOff))
-        (EvmAsm.Evm64.divModStackDispatchPreCallable sp dividendAbsWord divisorAbsWord
-          retAddr v2 v5 v6 divisorSum3 divisorMask divisorCarry3
+        (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp dividendAbsWord divisorAbsWord
+          divisorSign retAddr v2 v5 v6 divisorSum3 divisorMask divisorCarry3
           q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0)
         (EvmAsm.Evm64.modStackDispatchPostCallable sp dividendAbsWord divisorAbsWord **
-          (.x1 ↦ᵣ retAddr)) := by
-    exact
-      EvmAsm.Evm64.evm_mod_callable_v4_spec_from_modCode_noNop_noX9
-        sp (base + wrapperEndOff) retAddr dividendAbsWord divisorAbsWord
-        v2 v5 v6 divisorSum3 divisorMask divisorCarry3
-        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-        nMem shiftMem jMem retMem dMem dloMem scratchUn0
-        h_stack'
+          (.x1 ↦ᵣ retAddr) ** EvmAsm.Rv64.regOwn .x9) :=
+    cpsTripleWithin_weaken (fun _ hp => hp) (fun _ hp => by xperm_hyp hp)
+      (cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp)
+        h_body_call h_ret_framed)
+  -- Extend to smodCodeV4
   have h_callable_code :
       cpsTripleWithin (EvmAsm.Evm64.unifiedDivBound + 1)
         (base + wrapperEndOff) (retAddr &&& ~~~(1 : Word)) (smodCodeV4 base)
-        (EvmAsm.Evm64.divModStackDispatchPreCallable sp dividendAbsWord divisorAbsWord
-          retAddr v2 v5 v6 divisorSum3 divisorMask divisorCarry3
+        (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp dividendAbsWord divisorAbsWord
+          divisorSign retAddr v2 v5 v6 divisorSum3 divisorMask divisorCarry3
           q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
           shiftMem nMem jMem retMem dMem dloMem scratchUn0)
         (EvmAsm.Evm64.modStackDispatchPostCallable sp dividendAbsWord divisorAbsWord **
-          (.x1 ↦ᵣ retAddr)) := by
-    exact cpsTripleWithin_extend_code evm_mod_callable_code_v4_sub_smodCodeV4 h_callable_raw
-  -- Frame with frameWithX9 = (.x9 ↦ divisorSign) ** privateFrame
+          (.x1 ↦ᵣ retAddr) ** EvmAsm.Rv64.regOwn .x9) :=
+    cpsTripleWithin_extend_code evm_mod_callable_code_v4_sub_smodCodeV4 h_callable_raw
+  -- Frame with privateFrame (x8 ** x13 ** x18, no x9)
   have h_callable_framed :
       cpsTripleWithin (EvmAsm.Evm64.unifiedDivBound + 1)
         (base + wrapperEndOff) (retAddr &&& ~~~(1 : Word)) (smodCodeV4 base)
-        (EvmAsm.Evm64.divModStackDispatchPreCallable sp dividendAbsWord divisorAbsWord
-          retAddr v2 v5 v6 divisorSum3 divisorMask divisorCarry3
+        (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp dividendAbsWord divisorAbsWord
+          divisorSign retAddr v2 v5 v6 divisorSum3 divisorMask divisorCarry3
           q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-          shiftMem nMem jMem retMem dMem dloMem scratchUn0 ** frameWithX9)
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0 ** privateFrame)
         ((EvmAsm.Evm64.modStackDispatchPostCallable sp dividendAbsWord divisorAbsWord **
-          (.x1 ↦ᵣ retAddr)) ** frameWithX9) := by
-    exact cpsTripleWithin_frameR frameWithX9 (by
-      dsimp only [frameWithX9]
+          (.x1 ↦ᵣ retAddr) ** EvmAsm.Rv64.regOwn .x9) ** privateFrame) := by
+    exact cpsTripleWithin_frameR privateFrame (by
+      dsimp only [privateFrame]
       pcFree) h_callable_code
   rw [show retAddr &&& ~~~(1 : Word) = base + resultSignFixOff by
     dsimp [retAddr]
@@ -123,54 +139,37 @@ theorem saveRaAbsThenModCallDispatchReadyPost_callable_from_noNop_spec_in_smodCo
   exact
     cpsTripleWithin_weaken
       (fun h hp => by
+        -- Pre-weakener: saveRaAbsThenModCallDispatchReadyPost = PreNoX1 ** (x8 ** x13 ** x18)
+        -- Target: PreNoX1 ** privateFrame = PreNoX1 ** (x8 ** x13 ** x18) - same atoms
         rw [saveRaAbsThenModCallDispatchReadyPost_unfold_smod_components] at hp
         dsimp only at hp
-        rw [EvmAsm.Evm64.divModStackDispatchPreCallable_unfold]
-        dsimp only [frameWithX9, privateFrame]
+        rw [EvmAsm.Evm64.divModStackDispatchPreNoX1_unfold]
+        dsimp only [privateFrame]
         rw [smodModCallPrivateFrame_unfold]
         dsimp only
         rw [EvmAsm.Evm64.divModStackDispatchPreNoX1_unfold] at hp
-        -- frameWithX9 = (.x9 ↦ divisorSign) ** privateFrame is already right-assoc
         change
-          (((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ retAddr) ** (.x2 ↦ᵣ v2) **
+          (((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ divisorSign) ** (.x1 ↦ᵣ retAddr) ** (.x2 ↦ᵣ v2) **
             (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ divisorSum3) **
             (.x10 ↦ᵣ divisorMask) ** (.x11 ↦ᵣ divisorCarry3) **
             (.x0 ↦ᵣ (0 : Word)) ** evmWordIs sp dividendAbsWord **
             evmWordIs (sp + (32 : Word)) divisorAbsWord **
             EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
               shiftMem nMem jMem retMem dMem dloMem scratchUn0) **
-            (.x9 ↦ᵣ smodAbsSign divisorTop) **
             (.x8 ↦ᵣ smodAbsSign dividendTop) ** (.x13 ↦ᵣ smodAbsSign dividendTop) **
             (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))) h
         xperm_hyp hp)
       (fun h hp => by
+        -- Post-weakener: (PostCallable ** .x1 ** regOwn .x9) ** privateFrame
+        -- → saveRaAbsThenModCallCallablePost = PostCallable ** .x1 ** regOwn .x9 ** privateFrame
         rw [saveRaAbsThenModCallCallablePost_unfold]
         dsimp only
         rw [smodModCallPrivateFrame_unfold]
         dsimp only
-        dsimp only [frameWithX9, privateFrame] at hp
+        dsimp only [privateFrame] at hp
         rw [smodModCallPrivateFrame_unfold] at hp
         dsimp only at hp
-        -- hp : ((moddispatch ** .x1) ** ((.x9 ↦ divisorSign) ** (x8 ** x13 ** x18))) h
-        obtain ⟨hAB, hX9C, hd1, hu1, hAB_h, hX9C_h⟩ := hp
-        obtain ⟨hX9, hC, hd3, hu3, hX9_h, hC_h⟩ := hX9C_h
-        have hregown := regIs_implies_regOwn .x9 hX9 hX9_h
-        have h_inner : (EvmAsm.Rv64.regOwn .x9 **
-            ((.x8 ↦ᵣ smodAbsSign dividendTop) ** (.x13 ↦ᵣ smodAbsSign dividendTop) **
-             (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12))))) (hX9.union hC) :=
-          ⟨hX9, hC, hd3, rfl, hregown, hC_h⟩
-        have h_new_disjoint : hAB.Disjoint (hX9.union hC) := by
-          rw [hu3]; exact hd1
-        have h_new_union : hAB.union (hX9.union hC) = h := by
-          rw [hu3]; exact hu1
-        have hp' : ((EvmAsm.Evm64.modStackDispatchPostCallable sp dividendAbsWord divisorAbsWord **
-                     (.x1 ↦ᵣ retAddr)) **
-                    (EvmAsm.Rv64.regOwn .x9 **
-                     ((.x8 ↦ᵣ smodAbsSign dividendTop) ** (.x13 ↦ᵣ smodAbsSign dividendTop) **
-                      (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))))) h :=
-          ⟨hAB, hX9.union hC, h_new_disjoint, h_new_union, hAB_h, h_inner⟩
-        rw [sepConj_assoc] at hp'
-        exact hp')
+        xperm_hyp hp)
       h_callable_framed
 
 end EvmAsm.Evm64.SMod.Compose

--- a/EvmAsm/Evm64/SMod/Compose/ModCallGenericHandoff.lean
+++ b/EvmAsm/Evm64/SMod/Compose/ModCallGenericHandoff.lean
@@ -148,16 +148,6 @@ theorem saveRaAbsThenModCallDispatchReadyPost_callable_from_noNop_spec_in_smodCo
         rw [smodModCallPrivateFrame_unfold]
         dsimp only
         rw [EvmAsm.Evm64.divModStackDispatchPreNoX1_unfold] at hp
-        change
-          (((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ divisorSign) ** (.x1 ↦ᵣ retAddr) ** (.x2 ↦ᵣ v2) **
-            (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ divisorSum3) **
-            (.x10 ↦ᵣ divisorMask) ** (.x11 ↦ᵣ divisorCarry3) **
-            (.x0 ↦ᵣ (0 : Word)) ** evmWordIs sp dividendAbsWord **
-            evmWordIs (sp + (32 : Word)) divisorAbsWord **
-            EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-              shiftMem nMem jMem retMem dMem dloMem scratchUn0) **
-            (.x8 ↦ᵣ smodAbsSign dividendTop) ** (.x13 ↦ᵣ smodAbsSign dividendTop) **
-            (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))) h
         xperm_hyp hp)
       (fun h hp => by
         -- Post-weakener: (PostCallable ** .x1 ** regOwn .x9) ** privateFrame

--- a/EvmAsm/Evm64/SMod/Compose/ModCallResultSignFixGeneric.lean
+++ b/EvmAsm/Evm64/SMod/Compose/ModCallResultSignFixGeneric.lean
@@ -22,9 +22,10 @@ theorem saveRaAbsThenModCall_then_resultSignFix_from_noNop_spec_in_smodCodeV4
       EvmAsm.Rv64.cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
         (base + wrapperEndOff) ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
         (EvmAsm.Evm64.modCode_noNop_v4 (base + wrapperEndOff))
-        (EvmAsm.Evm64.divModStackDispatchPreCallable sp
+        (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp
           (smodAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
           (smodAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          (smodAbsSign divisorTop)
           ((base + modCallOff) + 4)
           v2 v5 v6
           (smodAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
@@ -35,7 +36,8 @@ theorem saveRaAbsThenModCall_then_resultSignFix_from_noNop_spec_in_smodCodeV4
         (EvmAsm.Evm64.modStackDispatchPostCallable sp
           (smodAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
           (smodAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) **
-          (.x1 ↦ᵣ ((base + modCallOff) + 4)))) :
+          (.x1 ↦ᵣ ((base + modCallOff) + 4)) **
+          EvmAsm.Rv64.regOwn .x9)) :
     EvmAsm.Rv64.cpsTripleWithin ((EvmAsm.Evm64.unifiedDivBound + 1) + 21)
       (base + wrapperEndOff) ((base + resultSignFixOff) + 84) (smodCodeV4 base)
       (saveRaAbsThenModCallDispatchReadyPost vRa sp base

--- a/EvmAsm/Evm64/SMod/Compose/ModCallResultSignFixNamedPost.lean
+++ b/EvmAsm/Evm64/SMod/Compose/ModCallResultSignFixNamedPost.lean
@@ -87,9 +87,10 @@ theorem saveRaAbsThenModCall_then_resultSignFix_named_post_from_noNop_spec_in_sm
       EvmAsm.Rv64.cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
         (base + wrapperEndOff) ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
         (EvmAsm.Evm64.modCode_noNop_v4 (base + wrapperEndOff))
-        (EvmAsm.Evm64.divModStackDispatchPreCallable sp
+        (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp
           (smodAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
           (smodAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          (smodAbsSign divisorTop)
           ((base + modCallOff) + 4)
           v2 v5 v6
           (smodAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
@@ -100,7 +101,8 @@ theorem saveRaAbsThenModCall_then_resultSignFix_named_post_from_noNop_spec_in_sm
         (EvmAsm.Evm64.modStackDispatchPostCallable sp
           (smodAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
           (smodAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) **
-          (.x1 ↦ᵣ ((base + modCallOff) + 4)))) :
+          (.x1 ↦ᵣ ((base + modCallOff) + 4)) **
+          EvmAsm.Rv64.regOwn .x9)) :
     EvmAsm.Rv64.cpsTripleWithin ((EvmAsm.Evm64.unifiedDivBound + 1) + 21)
       (base + wrapperEndOff) ((base + resultSignFixOff) + 84) (smodCodeV4 base)
       (saveRaAbsThenModCallDispatchReadyPost vRa sp base

--- a/EvmAsm/Evm64/SMod/Compose/ModCallReturnGeneric.lean
+++ b/EvmAsm/Evm64/SMod/Compose/ModCallReturnGeneric.lean
@@ -25,9 +25,10 @@ theorem saveRaAbsThenModCall_then_return_from_noNop_spec_in_smodCodeV4
       EvmAsm.Rv64.cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
         (base + wrapperEndOff) ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
         (EvmAsm.Evm64.modCode_noNop_v4 (base + wrapperEndOff))
-        (EvmAsm.Evm64.divModStackDispatchPreCallable sp
+        (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp
           (smodAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
           (smodAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          (smodAbsSign divisorTop)
           ((base + modCallOff) + 4)
           v2 v5 v6
           (smodAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
@@ -38,7 +39,8 @@ theorem saveRaAbsThenModCall_then_return_from_noNop_spec_in_smodCodeV4
         (EvmAsm.Evm64.modStackDispatchPostCallable sp
           (smodAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
           (smodAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) **
-          (.x1 ↦ᵣ ((base + modCallOff) + 4)))) :
+          (.x1 ↦ᵣ ((base + modCallOff) + 4)) **
+          EvmAsm.Rv64.regOwn .x9)) :
     EvmAsm.Rv64.cpsTripleWithin (((EvmAsm.Evm64.unifiedDivBound + 1) + 21) + 1)
       (base + wrapperEndOff)
       (((vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)) +

--- a/EvmAsm/Evm64/SMod/Compose/ModCallReturnNamedPost.lean
+++ b/EvmAsm/Evm64/SMod/Compose/ModCallReturnNamedPost.lean
@@ -87,9 +87,10 @@ theorem saveRaAbsThenModCall_then_return_named_post_from_noNop_spec_in_smodCodeV
       EvmAsm.Rv64.cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
         (base + wrapperEndOff) ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
         (EvmAsm.Evm64.modCode_noNop_v4 (base + wrapperEndOff))
-        (EvmAsm.Evm64.divModStackDispatchPreCallable sp
+        (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp
           (smodAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
           (smodAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          (smodAbsSign divisorTop)
           ((base + modCallOff) + 4)
           v2 v5 v6
           (smodAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
@@ -100,7 +101,8 @@ theorem saveRaAbsThenModCall_then_return_named_post_from_noNop_spec_in_smodCodeV
         (EvmAsm.Evm64.modStackDispatchPostCallable sp
           (smodAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
           (smodAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) **
-          (.x1 ↦ᵣ ((base + modCallOff) + 4)))) :
+          (.x1 ↦ᵣ ((base + modCallOff) + 4)) **
+          EvmAsm.Rv64.regOwn .x9)) :
     EvmAsm.Rv64.cpsTripleWithin (((EvmAsm.Evm64.unifiedDivBound + 1) + 21) + 1)
       (base + wrapperEndOff)
       (((vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)) +

--- a/EvmAsm/Evm64/SMod/Compose/ModCallReturnNormalized.lean
+++ b/EvmAsm/Evm64/SMod/Compose/ModCallReturnNormalized.lean
@@ -21,9 +21,10 @@ theorem saveRaAbsThenModCall_then_return_named_post_normalized_from_noNop_spec_i
       EvmAsm.Rv64.cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
         (base + wrapperEndOff) ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
         (EvmAsm.Evm64.modCode_noNop_v4 (base + wrapperEndOff))
-        (EvmAsm.Evm64.divModStackDispatchPreCallable sp
+        (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp
           (smodAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
           (smodAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
+          (smodAbsSign divisorTop)
           ((base + modCallOff) + 4)
           v2 v5 v6
           (smodAbsSum3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
@@ -34,7 +35,8 @@ theorem saveRaAbsThenModCall_then_return_named_post_normalized_from_noNop_spec_i
         (EvmAsm.Evm64.modStackDispatchPostCallable sp
           (smodAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
           (smodAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) **
-          (.x1 ↦ᵣ ((base + modCallOff) + 4)))) :
+          (.x1 ↦ᵣ ((base + modCallOff) + 4)) **
+          EvmAsm.Rv64.regOwn .x9)) :
     EvmAsm.Rv64.cpsTripleWithin (((EvmAsm.Evm64.unifiedDivBound + 1) + 21) + 1)
       (base + wrapperEndOff) (vRa &&& ~~~(1 : Word)) (smodCodeV4 base)
       (saveRaAbsThenModCallDispatchReadyPost vRa sp base

--- a/EvmAsm/Evm64/SMod/Spec.lean
+++ b/EvmAsm/Evm64/SMod/Spec.lean
@@ -135,11 +135,12 @@ theorem evm_smod_mod_call_return_stack_spec_within
       EvmAsm.Rv64.cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
         (base + wrapperEndOff) ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
         (EvmAsm.Evm64.modCode_noNop_v4 (base + wrapperEndOff))
-        (EvmAsm.Evm64.divModStackDispatchPreCallable sp
+        (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp
           (smodAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
             (dividend.getLimbN 2) (dividend.getLimbN 3))
           (smodAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
             (divisor.getLimbN 2) (divisor.getLimbN 3))
+          (smodAbsSign (divisor.getLimbN 3))
           ((base + modCallOff) + 4)
           v2 v5 v6
           (smodAbsSum3 (divisor.getLimbN 0) (divisor.getLimbN 1)
@@ -154,7 +155,8 @@ theorem evm_smod_mod_call_return_stack_spec_within
             (dividend.getLimbN 2) (dividend.getLimbN 3))
           (smodAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
             (divisor.getLimbN 2) (divisor.getLimbN 3)) **
-          (.x1 ↦ᵣ ((base + modCallOff) + 4)))) :
+          (.x1 ↦ᵣ ((base + modCallOff) + 4)) **
+          EvmAsm.Rv64.regOwn .x9)) :
     EvmAsm.Rv64.cpsTripleWithin
       (49 + (((EvmAsm.Evm64.unifiedDivBound + 1) + 21) + 1))
       base (vRa &&& ~~~(1 : Word)) (smodCodeV4 base)
@@ -202,11 +204,12 @@ theorem evm_smod_canonical_mod_call_return_stack_spec_within
       EvmAsm.Rv64.cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
         (base + wrapperEndOff) ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
         (EvmAsm.Evm64.modCode_noNop_v4 (base + wrapperEndOff))
-        (EvmAsm.Evm64.divModStackDispatchPreCallable sp
+        (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp
           (smodAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
             (dividend.getLimbN 2) (dividend.getLimbN 3))
           (smodAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
             (divisor.getLimbN 2) (divisor.getLimbN 3))
+          (smodAbsSign (divisor.getLimbN 3))
           ((base + modCallOff) + 4)
           v2 v5 v6
           (smodAbsSum3 (divisor.getLimbN 0) (divisor.getLimbN 1)
@@ -221,7 +224,8 @@ theorem evm_smod_canonical_mod_call_return_stack_spec_within
             (dividend.getLimbN 2) (dividend.getLimbN 3))
           (smodAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
             (divisor.getLimbN 2) (divisor.getLimbN 3)) **
-          (.x1 ↦ᵣ ((base + modCallOff) + 4)))) :
+          (.x1 ↦ᵣ ((base + modCallOff) + 4)) **
+          EvmAsm.Rv64.regOwn .x9)) :
     EvmAsm.Rv64.cpsTripleWithin
       (49 + (((EvmAsm.Evm64.unifiedDivBound + 1) + 21) + 1))
       base (vRa &&& ~~~(1 : Word)) (smodCodeCanonical base)

--- a/EvmAsm/Evm64/SMod/SpecAllCase.lean
+++ b/EvmAsm/Evm64/SMod/SpecAllCase.lean
@@ -1,0 +1,90 @@
+/-
+  EvmAsm.Evm64.SMod.SpecAllCase
+
+  All-case SMOD v4 stack spec: case-splits on whether the absolute divisor is
+  zero and dispatches to the bzero or nonzero wrapper as appropriate.
+
+  GH #90 (bead evm-asm-9iqmw.9.2).
+-/
+
+import EvmAsm.Evm64.SMod.Spec
+import EvmAsm.Evm64.SMod.SpecBzero
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmAsm.Evm64.SMod.Compose
+
+/-- All-case SMOD v4 canonical stack spec.  The unsigned-MOD callable proof for
+    the nonzero divisor path remains an explicit parameter; the zero-divisor
+    path is discharged internally via the v4 bzero theorem.
+
+    Case split: if `divisor = 0` use the bzero wrapper;
+                otherwise use the nonzero wrapper with the supplied `h_stack`. -/
+theorem evm_smod_canonical_all_case_mod_call_return_stack_spec_within
+    (vRa vSavedOld sp sDividendOld x13Old sDivisorOld
+      dividendMaskOld dividendValueOld dividendCarryOld : Word)
+    (dividend divisor : EvmWord)
+    (v2 v5 v6 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
+    (base : Word) (h_base : base &&& 1 = 0)
+    (h_stack :
+      EvmAsm.Rv64.cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
+        (base + wrapperEndOff) ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff)
+        (EvmAsm.Evm64.modCode_noNop_v4 (base + wrapperEndOff))
+        (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp
+          (smodAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
+            (dividend.getLimbN 2) (dividend.getLimbN 3))
+          (smodAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
+            (divisor.getLimbN 2) (divisor.getLimbN 3))
+          (smodAbsSign (divisor.getLimbN 3))
+          ((base + modCallOff) + 4)
+          v2 v5 v6
+          (smodAbsSum3 (divisor.getLimbN 0) (divisor.getLimbN 1)
+            (divisor.getLimbN 2) (divisor.getLimbN 3))
+          (smodAbsMask (divisor.getLimbN 3))
+          (smodAbsCarry3 (divisor.getLimbN 0) (divisor.getLimbN 1)
+            (divisor.getLimbN 2) (divisor.getLimbN 3))
+          q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+        (EvmAsm.Evm64.modStackDispatchPostCallable sp
+          (smodAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
+            (dividend.getLimbN 2) (dividend.getLimbN 3))
+          (smodAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
+            (divisor.getLimbN 2) (divisor.getLimbN 3)) **
+          (.x1 ↦ᵣ ((base + modCallOff) + 4)) **
+          EvmAsm.Rv64.regOwn .x9)) :
+    EvmAsm.Rv64.cpsTripleWithin
+      (49 + (((EvmAsm.Evm64.unifiedDivBound + 1) + 21) + 1))
+      base (vRa &&& ~~~(1 : Word)) (smodCodeCanonical base)
+      (((((.x1 ↦ᵣ vRa) ** (.x18 ↦ᵣ vSavedOld)) **
+        ((.x12 ↦ᵣ sp) ** (.x8 ↦ᵣ sDividendOld) ** (.x13 ↦ᵣ x13Old) **
+          (.x9 ↦ᵣ sDivisorOld) ** (.x0 ↦ᵣ (0 : Word)) **
+          (.x10 ↦ᵣ dividendMaskOld) ** (.x7 ↦ᵣ dividendValueOld) **
+          (.x11 ↦ᵣ dividendCarryOld))) **
+        evmStackIs sp [dividend, divisor]) **
+        ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
+          EvmAsm.Evm64.divScratchValuesCallNoX1 sp
+            q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+            shiftMem nMem jMem retMem dMem dloMem scratchUn0))
+      (saveRaAbsThenModCallReturnPost vRa sp base
+        (dividend.getLimbN 0) (dividend.getLimbN 1)
+        (dividend.getLimbN 2) (dividend.getLimbN 3)
+        (divisor.getLimbN 0) (divisor.getLimbN 1)
+        (divisor.getLimbN 2) (divisor.getLimbN 3)) := by
+  rcases Classical.em (divisor = 0) with h_zero | h_nz
+  · -- Zero divisor: use bzero spec
+    exact evm_smod_canonical_bzero_mod_call_return_stack_spec_within
+      vRa vSavedOld sp sDividendOld x13Old sDivisorOld
+      dividendMaskOld dividendValueOld dividendCarryOld dividend divisor
+      v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 base h_base h_zero
+  · -- Nonzero divisor: use canonical spec with h_stack
+    exact evm_smod_canonical_mod_call_return_stack_spec_within
+      vRa vSavedOld sp sDividendOld x13Old sDivisorOld
+      dividendMaskOld dividendValueOld dividendCarryOld dividend divisor
+      v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 base h_base h_stack
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/SMod/SpecBzero.lean
+++ b/EvmAsm/Evm64/SMod/SpecBzero.lean
@@ -77,14 +77,6 @@ theorem evm_smod_canonical_bzero_mod_call_return_stack_spec_within
       -- PreNoX1 → (PreCallable ** (.x9 ↦ divisorSign)): same atoms, just AC
       rw [EvmAsm.Evm64.divModStackDispatchPreNoX1_unfold] at hp
       rw [EvmAsm.Evm64.divModStackDispatchPreCallable_unfold]
-      change
-        (((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ retAddr) ** (.x2 ↦ᵣ v2) **
-          (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
-          (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) ** (.x0 ↦ᵣ (0 : Word)) **
-          evmWordIs sp a ** evmWordIs (sp + (32 : Word)) b **
-          EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-            shiftMem nMem jMem retMem dMem dloMem scratchUn0) **
-          (.x9 ↦ᵣ divisorSign)) h
       xperm_hyp hp)
     (fun h hp => by
       -- (PostCallable ** .x1 ** .x9) → (PostCallable ** .x1 ** regOwn .x9)

--- a/EvmAsm/Evm64/SMod/SpecBzero.lean
+++ b/EvmAsm/Evm64/SMod/SpecBzero.lean
@@ -42,28 +42,61 @@ theorem evm_smod_canonical_bzero_mod_call_return_stack_spec_within
         (dividend.getLimbN 2) (dividend.getLimbN 3)
         (divisor.getLimbN 0) (divisor.getLimbN 1)
         (divisor.getLimbN 2) (divisor.getLimbN 3)) := by
+  let divisorSign := smodAbsSign (divisor.getLimbN 3)
+  let a : EvmWord :=
+    smodAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
+      (dividend.getLimbN 2) (dividend.getLimbN 3)
+  let b : EvmWord :=
+    smodAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
+      (divisor.getLimbN 2) (divisor.getLimbN 3)
+  let v7 := smodAbsSum3 (divisor.getLimbN 0) (divisor.getLimbN 1)
+    (divisor.getLimbN 2) (divisor.getLimbN 3)
+  let v10 := smodAbsMask (divisor.getLimbN 3)
+  let v11 := smodAbsCarry3 (divisor.getLimbN 0) (divisor.getLimbN 1)
+    (divisor.getLimbN 2) (divisor.getLimbN 3)
+  let retAddr := (base + modCallOff) + 4
   refine evm_smod_canonical_mod_call_return_stack_spec_within
     vRa vSavedOld sp sDividendOld x13Old sDivisorOld
     dividendMaskOld dividendValueOld dividendCarryOld dividend divisor
     v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
     shiftMem nMem jMem retMem dMem dloMem scratchUn0 base h_base ?_
-  exact cpsTripleWithin_extend_code
-    (hmono := EvmAsm.Evm64.sharedDivModCodeNoNop_v4_sub_modCode_noNop_v4)
-    (evm_mod_bzero_stack_spec_within_dispatch_noNop_v4_callable_x1_uni
-      sp (base + wrapperEndOff)
-      (smodAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
-        (dividend.getLimbN 2) (dividend.getLimbN 3))
-      (smodAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
-        (divisor.getLimbN 2) (divisor.getLimbN 3))
-      ((base + modCallOff) + 4)
-      v2 v5 v6
-      (smodAbsSum3 (divisor.getLimbN 0) (divisor.getLimbN 1)
-        (divisor.getLimbN 2) (divisor.getLimbN 3))
-      (smodAbsMask (divisor.getLimbN 3))
-      (smodAbsCarry3 (divisor.getLimbN 0) (divisor.getLimbN 1)
-        (divisor.getLimbN 2) (divisor.getLimbN 3))
-      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-      nMem shiftMem jMem retMem dMem dloMem scratchUn0
-      ((smodAbsDivisorWord_eq_zero_iff divisor).mpr h_divisor_zero))
+  -- Adapt bzero spec to new h_stack type (PreNoX1 → PostCallable ** .x1 ** regOwn .x9)
+  have h_bzero_raw :=
+    cpsTripleWithin_extend_code
+      (hmono := EvmAsm.Evm64.sharedDivModCodeNoNop_v4_sub_modCode_noNop_v4)
+      (evm_mod_bzero_stack_spec_within_dispatch_noNop_v4_callable_x1_uni
+        sp (base + wrapperEndOff) a b retAddr v2 v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        nMem shiftMem jMem retMem dMem dloMem scratchUn0
+        (by simpa [b] using (smodAbsDivisorWord_eq_zero_iff divisor).mpr h_divisor_zero))
+  -- Frame .x9 ↦ divisorSign around bzero (bzero doesn't touch x9)
+  have h_bzero_framed := cpsTripleWithin_frameR (.x9 ↦ᵣ divisorSign) (by pcFree) h_bzero_raw
+  -- Weaken to new h_stack type
+  exact cpsTripleWithin_weaken
+    (fun h hp => by
+      -- PreNoX1 → (PreCallable ** (.x9 ↦ divisorSign)): same atoms, just AC
+      rw [EvmAsm.Evm64.divModStackDispatchPreNoX1_unfold] at hp
+      rw [EvmAsm.Evm64.divModStackDispatchPreCallable_unfold]
+      change
+        (((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ retAddr) ** (.x2 ↦ᵣ v2) **
+          (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+          (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) ** (.x0 ↦ᵣ (0 : Word)) **
+          evmWordIs sp a ** evmWordIs (sp + (32 : Word)) b **
+          EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+            shiftMem nMem jMem retMem dMem dloMem scratchUn0) **
+          (.x9 ↦ᵣ divisorSign)) h
+      xperm_hyp hp)
+    (fun h hp => by
+      -- (PostCallable ** .x1 ** .x9) → (PostCallable ** .x1 ** regOwn .x9)
+      -- HP: ((PostCallable ** .x1) ** (.x9 ↦ divisorSign)) h
+      obtain ⟨hAB, hX9, hd1, hu1, hAB_h, hX9_h⟩ := hp
+      have hregown := regIs_implies_regOwn .x9 hX9 hX9_h
+      have hp' : ((EvmAsm.Evm64.modStackDispatchPostCallable sp a b **
+                   (.x1 ↦ᵣ retAddr)) **
+                  EvmAsm.Rv64.regOwn .x9) h :=
+        ⟨hAB, hX9, hd1, hu1, hAB_h, hregown⟩
+      rw [sepConj_assoc] at hp'
+      exact hp')
+    h_bzero_framed
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Changes the SMOD generic handoff's `h_stack` parameter to use `divModStackDispatchPreNoX1` (with explicit x9=divisorSign) as pre and `modStackDispatchPostCallable ** .x1 ** regOwn .x9` as post
- The old `divModStackDispatchPreCallable` type (no x9) is unprovable for nonzero callable inputs since the loop body modifies x9 (loop counter)
- `GenericHandoff.lean` proof reconstructed inline: body `extend_code` → JALR `ret_spec` framed → `cpsTripleWithin_seq_perm_same_cr`
- `SpecBzero.lean` adapted: bzero spec (PreCallable) is framed with `.x9 ↦ divisorSign`, then weakened to PreNoX1 + regOwn .x9
- 6 wrapper files updated (ResultSignFixGeneric, ReturnGeneric, ResultSignFixNamedPost, ReturnNamedPost, ReturnNormalized, Spec.lean)

Stacked on #5960. Refs #9. Bead: evm-asm-9iqmw.9.1.2.3.

## Verification
- lake build EvmAsm.Evm64.SMod.Compose.ModCallGenericHandoff
- lake build EvmAsm.Evm64.SMod
- scripts/check-file-size.sh
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SMod/
- lake build

Authored by @pirapira; implemented by Claude Code