### PR TITLE
feat(stateless): mpt_two_leaf_root_indexed (PR-K170)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -5187,6 +5187,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_mpt_branch_payload_two_slots" => some ziskMptBranchPayloadTwoSlotsProbeUnit
   | "zisk_mpt_leaf_node_encode_from_nibbles" => some ziskMptLeafNodeEncodeFromNibblesProbeUnit
   | "zisk_mpt_branch_node_keccak" => some ziskMptBranchNodeKeccakProbeUnit
+  | "zisk_mpt_two_leaf_root_indexed" => some ziskMptTwoLeafRootIndexedProbeUnit
   | "zisk_block_logs_bloom_from_receipts_list" => some ziskBlockLogsBloomFromReceiptsListProbeUnit
   | "zisk_block_validate_logs_bloom" => some ziskBlockValidateLogsBloomProbeUnit
   | "zisk_header_root_is_empty_trie" => some ziskHeaderRootIsEmptyTrieProbeUnit
@@ -5370,6 +5371,7 @@ def knownProgramNames : List String :=
    "zisk_mpt_branch_payload_two_slots",
    "zisk_mpt_leaf_node_encode_from_nibbles",
    "zisk_mpt_branch_node_keccak",
+   "zisk_mpt_two_leaf_root_indexed",
    "zisk_block_logs_bloom_from_receipts_list",
    "zisk_block_validate_logs_bloom",
    "zisk_header_root_is_empty_trie",

--- a/EvmAsm/Codegen/Programs/Mpt.lean
+++ b/EvmAsm/Codegen/Programs/Mpt.lean
@@ -3841,5 +3841,192 @@ def ziskMptBranchNodeKeccakProbeUnit : BuildUnit := {
   dataAsm     := ziskMptBranchNodeKeccakDataSection
 }
 
+/-! ## mpt_two_leaf_root_indexed -- PR-K170
+
+    Compute the MPT root for an **indexed** trie containing
+    exactly two entries at keys `rlp(0) = 0x80` and
+    `rlp(1) = 0x01`. This is the common case for blocks with
+    exactly two transactions / receipts / withdrawals, where the
+    trie is `transactions_root` / `receipts_root` /
+    `withdrawals_root`.
+
+    Why a specialised helper: for the two indexed keys the
+    structure is fully determined and the same regardless of the
+    values:
+
+      * `rlp(0) = 0x80` nibbles `[8, 0]`
+      * `rlp(1) = 0x01` nibbles `[0, 1]`
+
+    The shared prefix is empty (PR-K166 would return cpl=0 here),
+    so the root is a branch whose only non-empty slots are:
+
+      * slot 0 : leaf with path `[1]` and value `value_1`
+      * slot 8 : leaf with path `[0]` and value `value_0`
+      * slot 16 (value) and all others : empty (`0x80`)
+
+      root = keccak256(rlp([slot_0, slot_1, ..., slot_15, value]))
+
+    Composes:
+      - PR-K168 `mpt_leaf_node_encode_from_nibbles`  × 2
+      - PR-K163 `mpt_node_slot_encode`               × 2
+      - PR-K167 `mpt_branch_payload_two_slots`
+      - PR-K169 `mpt_branch_node_keccak`
+
+    Callers that need the same for tries with > 2 entries, or
+    with arbitrary non-indexed keys, must use the lower-level
+    primitives directly.
+
+    Calling convention:
+      a0 (input)  : value_0 ptr (for key `rlp(0) = 0x80`)
+      a1 (input)  : value_0 byte length
+      a2 (input)  : value_1 ptr (for key `rlp(1) = 0x01`)
+      a3 (input)  : value_1 byte length
+      a4 (input)  : 32-byte output root ptr
+      ra (input)  : return
+      a0 (output) : 0 (always succeeds). -/
+def mptTwoLeafRootIndexedFunction : String :=
+  "mpt_two_leaf_root_indexed:\n" ++
+  "  addi sp, sp, -48\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp)\n" ++
+  "  mv s0, a0                   # value_0 ptr\n" ++
+  "  mv s1, a1                   # value_0 len\n" ++
+  "  mv s2, a2                   # value_1 ptr\n" ++
+  "  mv s3, a3                   # value_1 len\n" ++
+  "  mv s4, a4                   # output root ptr\n" ++
+  "  # ---- Build leaf_0 RLP from nibbles=[0], value_0 ----\n" ++
+  "  la t0, mtlri_nib0; sb zero, 0(t0)\n" ++
+  "  mv a0, t0; li a1, 1\n" ++
+  "  mv a2, s0; mv a3, s1\n" ++
+  "  la a4, mtlri_leaf_0_buf\n" ++
+  "  la a5, mtlri_leaf_0_len\n" ++
+  "  jal ra, mpt_leaf_node_encode_from_nibbles\n" ++
+  "  # ---- Build leaf_1 RLP from nibbles=[1], value_1 ----\n" ++
+  "  la t0, mtlri_nib1; li t1, 1; sb t1, 0(t0)\n" ++
+  "  mv a0, t0; li a1, 1\n" ++
+  "  mv a2, s2; mv a3, s3\n" ++
+  "  la a4, mtlri_leaf_1_buf\n" ++
+  "  la a5, mtlri_leaf_1_len\n" ++
+  "  jal ra, mpt_leaf_node_encode_from_nibbles\n" ++
+  "  # ---- Wrap leaf_0 in parent-slot bytes (K163) ----\n" ++
+  "  la a0, mtlri_leaf_0_buf\n" ++
+  "  la t0, mtlri_leaf_0_len; ld a1, 0(t0)\n" ++
+  "  la a2, mtlri_slot_0_buf\n" ++
+  "  la a3, mtlri_slot_0_len\n" ++
+  "  jal ra, mpt_node_slot_encode\n" ++
+  "  # ---- Wrap leaf_1 in parent-slot bytes ----\n" ++
+  "  la a0, mtlri_leaf_1_buf\n" ++
+  "  la t0, mtlri_leaf_1_len; ld a1, 0(t0)\n" ++
+  "  la a2, mtlri_slot_1_buf\n" ++
+  "  la a3, mtlri_slot_1_len\n" ++
+  "  jal ra, mpt_node_slot_encode\n" ++
+  "  # ---- Assemble 17-slot payload (slot 8 = leaf_0, slot 0 = leaf_1) ----\n" ++
+  "  li a0, 8\n" ++
+  "  la a1, mtlri_slot_0_buf\n" ++
+  "  la t0, mtlri_slot_0_len; ld a2, 0(t0)\n" ++
+  "  li a3, 0\n" ++
+  "  la a4, mtlri_slot_1_buf\n" ++
+  "  la t0, mtlri_slot_1_len; ld a5, 0(t0)\n" ++
+  "  la a6, mtlri_branch_payload\n" ++
+  "  la a7, mtlri_branch_payload_len\n" ++
+  "  jal ra, mpt_branch_payload_two_slots\n" ++
+  "  # ---- keccak256(rlp(branch_payload)) -> root ----\n" ++
+  "  la a0, mtlri_branch_payload\n" ++
+  "  la t0, mtlri_branch_payload_len; ld a1, 0(t0)\n" ++
+  "  mv a2, s4\n" ++
+  "  jal ra, mpt_branch_node_keccak\n" ++
+  "  li a0, 0\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp)\n" ++
+  "  addi sp, sp, 48\n" ++
+  "  ret"
+
+/-- `zisk_mpt_two_leaf_root_indexed`: probe BuildUnit.
+    Input layout:
+      bytes  0.. 8 : value_0_len
+      bytes  8..16 : value_1_len
+      bytes 16..16+value_0_len: value_0 bytes
+      bytes (16+value_0_len)..: value_1 bytes
+    Output layout:
+      bytes  0..32 : 32-byte trie root -/
+def ziskMptTwoLeafRootIndexedPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a5, 0x40000000\n" ++
+  "  ld a1, 8(a5)                # value_0_len\n" ++
+  "  ld a3, 16(a5)               # value_1_len\n" ++
+  "  addi a0, a5, 24             # value_0 ptr\n" ++
+  "  add a2, a0, a1              # value_1 ptr\n" ++
+  "  li a4, 0xa0010000           # output root ptr (32 B)\n" ++
+  "  jal ra, mpt_two_leaf_root_indexed\n" ++
+  "  j .Lmtlri_pdone\n" ++
+  hpEncodeNibblesFunction ++ "\n" ++
+  rlpEncodeBytesFunction ++ "\n" ++
+  rlpEncodeListPrefixFunction ++ "\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  mptLeafNodeEncodeFromNibblesFunction ++ "\n" ++
+  mptNodeSlotEncodeFunction ++ "\n" ++
+  mptBranchPayloadTwoSlotsFunction ++ "\n" ++
+  mptBranchNodeEncodeFunction ++ "\n" ++
+  mptBranchNodeKeccakFunction ++ "\n" ++
+  mptTwoLeafRootIndexedFunction ++ "\n" ++
+  ".Lmtlri_pdone:"
+
+def ziskMptTwoLeafRootIndexedDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  "mlnen_field_len:\n" ++
+  "  .zero 8\n" ++
+  "mlnen_hp_len:\n" ++
+  "  .zero 8\n" ++
+  "mlnen_cursor:\n" ++
+  "  .zero 8\n" ++
+  "mlnen_total_payload:\n" ++
+  "  .zero 8\n" ++
+  "mlnen_hp_buf:\n" ++
+  "  .zero 1024\n" ++
+  "mlnen_payload_buf:\n" ++
+  "  .zero 16384\n" ++
+  "mbne_field_len:\n" ++
+  "  .zero 8\n" ++
+  "mbnk_node_len:\n" ++
+  "  .zero 8\n" ++
+  "mbnk_node_buf:\n" ++
+  "  .zero 16384\n" ++
+  "mtlri_nib0:\n" ++
+  "  .zero 1\n" ++
+  "mtlri_nib1:\n" ++
+  "  .zero 1\n" ++
+  ".balign 8\n" ++
+  "mtlri_leaf_0_len:\n" ++
+  "  .zero 8\n" ++
+  "mtlri_leaf_0_buf:\n" ++
+  "  .zero 16384\n" ++
+  "mtlri_leaf_1_len:\n" ++
+  "  .zero 8\n" ++
+  "mtlri_leaf_1_buf:\n" ++
+  "  .zero 16384\n" ++
+  "mtlri_slot_0_len:\n" ++
+  "  .zero 8\n" ++
+  "mtlri_slot_0_buf:\n" ++
+  "  .zero 16384\n" ++
+  "mtlri_slot_1_len:\n" ++
+  "  .zero 8\n" ++
+  "mtlri_slot_1_buf:\n" ++
+  "  .zero 16384\n" ++
+  "mtlri_branch_payload_len:\n" ++
+  "  .zero 8\n" ++
+  "mtlri_branch_payload:\n" ++
+  "  .zero 16384"
+
+def ziskMptTwoLeafRootIndexedProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskMptTwoLeafRootIndexedPrologue
+  dataAsm     := ziskMptTwoLeafRootIndexedDataSection
+}
+
 
 end EvmAsm.Codegen

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **192**
-- ziskemu round-trip scripts: **185** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **193**
+- ziskemu round-trip scripts: **186** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-mpt-two-leaf-root-indexed-check.sh
+++ b/scripts/codegen-zisk-mpt-two-leaf-root-indexed-check.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# codegen-zisk-mpt-two-leaf-root-indexed-check.sh -- PR-K170.
+#
+# MPT root for an indexed 2-entry trie (keys rlp(0), rlp(1)).
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_mpt_two_leaf_root_indexed ELF"
+lake exe codegen --program zisk_mpt_two_leaf_root_indexed --halt linux93 \
+  -o gen-out/zisk_mpt_two_leaf_root_indexed
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <value_0_hex> <value_1_hex>
+run_case() {
+  local name="$1" v0="$2" v1="$3"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_mpt_two_leaf_root_indexed_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_mpt_two_leaf_root_indexed_${name}.output"
+  local exp_hex_file="$REPO_ROOT/gen-out/zisk_mpt_two_leaf_root_indexed_${name}.expected.hex"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+try:
+    from Crypto.Hash import keccak
+    def keccak256(b):
+        h = keccak.new(digest_bits=256); h.update(b); return h.digest()
+except Exception:
+    import sha3
+    def keccak256(b): return sha3.keccak_256(b).digest()
+
+v0 = bytes.fromhex('$v0')
+v1 = bytes.fromhex('$v1')
+
+# Build the MPT root by walking the standard algorithm.
+# Inline the logic here for portability (rather than depending on
+# execution-specs' Python trie module).
+import rlp as _rlp
+
+# Each leaf: HP-encode(suffix nibbles, is_leaf=True) + value.
+def hp_leaf(nibbles, value):
+    flag = 2 + (len(nibbles) & 1)
+    hp = bytearray()
+    if len(nibbles) % 2 == 1:
+        hp.append((flag << 4) | nibbles[0])
+        i = 1
+    else:
+        hp.append(flag << 4)
+        i = 0
+    while i < len(nibbles):
+        hp.append((nibbles[i] << 4) | nibbles[i+1])
+        i += 2
+    return _rlp.encode([bytes(hp), value])
+
+def slot_ref(node_rlp):
+    if len(node_rlp) < 32:
+        return node_rlp
+    return b'\\xa0' + keccak256(node_rlp)
+
+# rlp(0)=0x80 -> nibbles [8, 0]; suffix after cpl=0 is [0]
+leaf_0 = hp_leaf([0], v0)
+# rlp(1)=0x01 -> nibbles [0, 1]; suffix after cpl=0 is [1]
+leaf_1 = hp_leaf([1], v1)
+
+slot_0 = slot_ref(leaf_0)  # goes at branch slot 8
+slot_1 = slot_ref(leaf_1)  # goes at branch slot 0
+
+slots = [b'\\x80'] * 17
+slots[8] = slot_0
+slots[0] = slot_1
+branch_rlp = _rlp.encode([s for s in slots])  # 17-list
+
+# Actually rlp.encode([...]) treats each entry as an item -- but
+# our slots are already RLP items (some are raw RLP, some are
+# 0xa0|hash strings, some are 0x80 empty). For the encode to work,
+# we wrap each slot as either a bytes object or pre-RLP'd item.
+# Hand-build the encoding instead to avoid double-wrapping:
+payload = b''.join(slots)
+n = len(payload)
+if n < 56:
+    prefix = bytes([0xc0 + n])
+else:
+    n_bytes = n.to_bytes((n.bit_length() + 7) // 8, 'big')
+    prefix = bytes([0xf7 + len(n_bytes)]) + n_bytes
+branch_node_rlp = prefix + payload
+expected = keccak256(branch_node_rlp)
+
+with open(sys.argv[1], 'wb') as f:
+    f.write(struct.pack('<Q', len(v0)))
+    f.write(struct.pack('<Q', len(v1)))
+    f.write(v0)
+    f.write(v1)
+    pad = (-(16 + len(v0) + len(v1))) % 8
+    if pad: f.write(b'\x00' * pad)
+with open(sys.argv[2], 'w') as f:
+    f.write(expected.hex())
+" "$in_file" "$exp_hex_file"
+
+  "$ZISKEMU" -e gen-out/zisk_mpt_two_leaf_root_indexed.elf \
+    -i "$in_file" -o "$out_file" -n 5000000 \
+    >"$REPO_ROOT/gen-out/zisk_mpt_two_leaf_root_indexed_${name}.emu.log" 2>&1 || true
+
+  local actual; actual="$(xxd -p -l 32 "$out_file" | tr -d '\n')"
+  local expected; expected="$(cat "$exp_hex_file")"
+
+  if [[ "$actual" == "$expected" ]]; then
+    printf "  %-30s OK   root=%s...\n" "$name" "${actual:0:16}"
+    return 0
+  else
+    printf "  %-30s FAIL\n" "$name"
+    printf "      actual:   %s\n" "$actual"
+    printf "      expected: %s\n" "$expected"
+    return 1
+  fi
+}
+
+# Standard legacy tx (>= 32 bytes; will be hashed in the trie).
+TX_LEGACY="f8500184ee6b280082520894aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa881bc16d674ec80000801ba01111111111111111111111111111111111111111111111111111111111111111a02222222222222222222222222222222222222222222222222222222222222222"
+# A second legacy tx
+TX_LEGACY_2="f8500284ee6b280082520894bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb881bc16d674ec80000801ba03333333333333333333333333333333333333333333333333333333333333333a04444444444444444444444444444444444444444444444444444444444444444"
+
+FAILED=0
+# Two minimal tx values (small, hashed)
+run_case "two_legacy_txs"      "$TX_LEGACY"  "$TX_LEGACY_2" || FAILED=1
+# Two minimal short values (inline path)
+run_case "two_short_values"    "01"          "02"           || FAILED=1
+# Mix: short value + long value
+run_case "short_and_long"      "01"          "$TX_LEGACY"   || FAILED=1
+# Two empty values
+run_case "two_empty_values"    ""            ""             || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: mpt_two_leaf_root_indexed matches Python keccak256(rlp(branch([slot0,...])))"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- \`mpt_two_leaf_root_indexed\`: full composite for the MPT root of an *indexed* trie with exactly two entries (keys \`rlp(0)=0x80\` and \`rlp(1)=0x01\`).
- Common-case helper for 2-tx-block / 2-receipt-block / 2-withdrawal-block \`transactions_root\` / \`receipts_root\` / \`withdrawals_root\`. The structure is fully determined by the two indexed keys:

| | nibbles | suffix after cpl=0 |
|---|---|---|
| rlp(0) = 0x80 | [8, 0] | [0] |
| rlp(1) = 0x01 | [0, 1] | [1] |

Branch with slot 0 = leaf([1], value_1) and slot 8 = leaf([0], value_0); other slots and value slot empty.

\`\`\`
root = keccak256(rlp([slot_0, slot_1, ..., slot_15, value_slot]))
\`\`\`

Composes K168 + K163 + K167 + K169 (and transitively K32 + K128 + K129 + K165 + zkvm_keccak256).

### Calling convention

| reg | role |
|---|---|
| a0 | value_0 ptr (for key rlp(0) = 0x80) |
| a1 | value_0 byte length |
| a2 | value_1 ptr (for key rlp(1) = 0x01) |
| a3 | value_1 byte length |
| a4 | 32-byte output root ptr |
| a0 (out) | 0 (always succeeds) |

## Stacking

Base = \`feat/stateless-mpt-branch-node-keccak\` (PR #5961).

## Test plan

- [x] \`lake build\` clean
- [x] \`scripts/codegen-zisk-mpt-two-leaf-root-indexed-check.sh\` — 4/4 fixtures pass against Python keccak256 + rlp.encode:
  - \`two_legacy_txs\`: both values ≥ 32 B → hashed children
  - \`two_short_values\`: both values 1 byte → inline children
  - \`short_and_long\`: mixed inline + hashed
  - \`two_empty_values\`: degenerate empty-value

🤖 Generated with [Claude Code](https://claude.com/claude-code)