### PR TITLE
feat(stateless): block_validate_transactions_root_two_tx (PR-K171)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -5188,6 +5188,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_mpt_leaf_node_encode_from_nibbles" => some ziskMptLeafNodeEncodeFromNibblesProbeUnit
   | "zisk_mpt_branch_node_keccak" => some ziskMptBranchNodeKeccakProbeUnit
   | "zisk_mpt_two_leaf_root_indexed" => some ziskMptTwoLeafRootIndexedProbeUnit
+  | "zisk_block_validate_transactions_root_two_tx" => some ziskBlockValidateTransactionsRootTwoTxProbeUnit
   | "zisk_block_logs_bloom_from_receipts_list" => some ziskBlockLogsBloomFromReceiptsListProbeUnit
   | "zisk_block_validate_logs_bloom" => some ziskBlockValidateLogsBloomProbeUnit
   | "zisk_header_root_is_empty_trie" => some ziskHeaderRootIsEmptyTrieProbeUnit
@@ -5372,6 +5373,7 @@ def knownProgramNames : List String :=
    "zisk_mpt_leaf_node_encode_from_nibbles",
    "zisk_mpt_branch_node_keccak",
    "zisk_mpt_two_leaf_root_indexed",
+   "zisk_block_validate_transactions_root_two_tx",
    "zisk_block_logs_bloom_from_receipts_list",
    "zisk_block_validate_logs_bloom",
    "zisk_header_root_is_empty_trie",

--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -5189,6 +5189,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_mpt_branch_node_keccak" => some ziskMptBranchNodeKeccakProbeUnit
   | "zisk_mpt_two_leaf_root_indexed" => some ziskMptTwoLeafRootIndexedProbeUnit
   | "zisk_block_validate_transactions_root_two_tx" => some ziskBlockValidateTransactionsRootTwoTxProbeUnit
+  | "zisk_block_hash_from_header" => some ziskBlockHashFromHeaderProbeUnit
   | "zisk_block_logs_bloom_from_receipts_list" => some ziskBlockLogsBloomFromReceiptsListProbeUnit
   | "zisk_block_validate_logs_bloom" => some ziskBlockValidateLogsBloomProbeUnit
   | "zisk_header_root_is_empty_trie" => some ziskHeaderRootIsEmptyTrieProbeUnit
@@ -5374,6 +5375,7 @@ def knownProgramNames : List String :=
    "zisk_mpt_branch_node_keccak",
    "zisk_mpt_two_leaf_root_indexed",
    "zisk_block_validate_transactions_root_two_tx",
+   "zisk_block_hash_from_header",
    "zisk_block_logs_bloom_from_receipts_list",
    "zisk_block_validate_logs_bloom",
    "zisk_header_root_is_empty_trie",

--- a/EvmAsm/Codegen/Programs/Header.lean
+++ b/EvmAsm/Codegen/Programs/Header.lean
@@ -1907,4 +1907,69 @@ def ziskValidateHeaderFullProbeUnit : BuildUnit := {
   dataAsm     := ziskValidateHeaderFullDataSection
 }
 
+/-! ## block_hash_from_header -- PR-K172
+
+    Compute the block hash of an Ethereum block header:
+    `block_hash = keccak256(header_rlp_bytes)`.
+
+    The header RLP is the canonical wire encoding of the
+    15-or-16-field header list (parent_hash, ommers_hash,
+    beneficiary, state_root, transactions_root, receipts_root,
+    logs_bloom, difficulty, number, gas_limit, gas_used,
+    timestamp, extra_data, prev_randao, nonce, [base_fee, ...
+    withdrawals_root, blob_gas_used, excess_blob_gas,
+    parent_beacon_block_root]).
+
+    The block hash is identified by `parent_hash` in the next
+    header in the chain, so this primitive is the natural
+    building block for `validate_headers` (which walks the
+    chain and checks each `header[i].parent_hash ==
+    block_hash_from_header(header[i-1])`).
+
+    Calling convention:
+      a0 (input)  : header_rlp ptr
+      a1 (input)  : header_rlp byte length
+      a2 (input)  : 32-byte output ptr (block_hash lands here)
+      ra (input)  : return
+      (no output register; result is in memory at `a2`) -/
+def blockHashFromHeaderFunction : String :=
+  "block_hash_from_header:\n" ++
+  "  addi sp, sp, -16\n" ++
+  "  sd ra, 0(sp)\n" ++
+  "  # zkvm_keccak256(a0=header, a1=len, a2=out)\n" ++
+  "  jal ra, zkvm_keccak256\n" ++
+  "  ld ra, 0(sp)\n" ++
+  "  addi sp, sp, 16\n" ++
+  "  ret"
+
+/-- `zisk_block_hash_from_header`: probe BuildUnit.
+    Input layout:
+      bytes 0..8  : header_rlp byte length
+      bytes 8..   : header_rlp
+    Output layout:
+      bytes 0..32 : block_hash -/
+def ziskBlockHashFromHeaderPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a7, 0x40000000\n" ++
+  "  ld a1, 8(a7)                # header_rlp_len\n" ++
+  "  addi a0, a7, 16             # header_rlp ptr\n" ++
+  "  li a2, 0xa0010000           # output block_hash ptr (32 B)\n" ++
+  "  jal ra, block_hash_from_header\n" ++
+  "  j .Lbhfh_pdone\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  blockHashFromHeaderFunction ++ "\n" ++
+  ".Lbhfh_pdone:"
+
+def ziskBlockHashFromHeaderDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200"
+
+def ziskBlockHashFromHeaderProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskBlockHashFromHeaderPrologue
+  dataAsm     := ziskBlockHashFromHeaderDataSection
+}
+
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/Mpt.lean
+++ b/EvmAsm/Codegen/Programs/Mpt.lean
@@ -4028,5 +4028,204 @@ def ziskMptTwoLeafRootIndexedProbeUnit : BuildUnit := {
   dataAsm     := ziskMptTwoLeafRootIndexedDataSection
 }
 
+/-! ## block_validate_transactions_root_two_tx -- PR-K171
+
+    End-to-end validation: given a block header RLP and the two
+    transactions of a 2-tx block, recompute the expected
+    `transactions_root` and check it byte-equals the header's
+    claimed value.
+
+      claimed_root = header.field[4]              -- via K20
+      computed_root = mpt_two_leaf_root_indexed(  -- K170
+                          tx0, tx1)
+      is_valid = (claimed_root == computed_root)
+
+    Single-call entry point. The verdict lands in the
+    caller-supplied u64 (1 if matches, 0 if not); `a0` returns
+    the error code (header-parse failure / size mismatch
+    distinct from "predicate is false").
+
+    Composes:
+      - PR-K20  `rlp_list_nth_item` on header field 4
+      - PR-K170 `mpt_two_leaf_root_indexed`
+        (which in turn composes K168 / K163 / K167 / K169)
+
+    Calling convention:
+      a0 (input)  : header_rlp ptr
+      a1 (input)  : header_rlp byte length
+      a2 (input)  : tx0 ptr  (wire-format -- typed envelope or
+                              legacy RLP -- used as the value
+                              for key rlp(0) in the trie)
+      a3 (input)  : tx0 byte length
+      a4 (input)  : tx1 ptr  (value for key rlp(1))
+      a5 (input)  : tx1 byte length
+      a6 (input)  : u64 out (is_valid: 1 if root matches, else 0)
+      ra (input)  : return
+      a0 (output) :
+        0 : success -- predicate written
+        1 : header RLP parse failure / field 4 missing
+        2 : header.transactions_root length != 32 -/
+def blockValidateTransactionsRootTwoTxFunction : String :=
+  "block_validate_transactions_root_two_tx:\n" ++
+  "  addi sp, sp, -64\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp)\n" ++
+  "  mv s0, a0                   # header_rlp ptr\n" ++
+  "  mv s1, a1                   # header_rlp len\n" ++
+  "  mv s2, a2                   # tx0 ptr\n" ++
+  "  mv s3, a3                   # tx0 len\n" ++
+  "  mv s4, a4                   # tx1 ptr\n" ++
+  "  mv s5, a5                   # tx1 len\n" ++
+  "  mv s6, a6                   # is_valid out\n" ++
+  "  sd zero, 0(s6)\n" ++
+  "  # ---- Extract header.transactions_root (field 4) ----\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 4\n" ++
+  "  la a3, bvtr_offset; la a4, bvtr_length\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lbvtr_parse_fail\n" ++
+  "  la t0, bvtr_length; ld t1, 0(t0)\n" ++
+  "  li t2, 32\n" ++
+  "  bne t1, t2, .Lbvtr_size_fail\n" ++
+  "  # Copy claimed root into bvtr_claimed_root\n" ++
+  "  la t0, bvtr_offset; ld t1, 0(t0)\n" ++
+  "  add t3, s0, t1                              # &header[off]\n" ++
+  "  la t4, bvtr_claimed_root\n" ++
+  "  ld t5,  0(t3); sd t5,  0(t4)\n" ++
+  "  ld t5,  8(t3); sd t5,  8(t4)\n" ++
+  "  ld t5, 16(t3); sd t5, 16(t4)\n" ++
+  "  ld t5, 24(t3); sd t5, 24(t4)\n" ++
+  "  # ---- Compute the 2-leaf trie root from (tx0, tx1) ----\n" ++
+  "  mv a0, s2; mv a1, s3\n" ++
+  "  mv a2, s4; mv a3, s5\n" ++
+  "  la a4, bvtr_computed_root\n" ++
+  "  jal ra, mpt_two_leaf_root_indexed\n" ++
+  "  # ---- 32-byte compare (claimed vs computed) ----\n" ++
+  "  la t0, bvtr_claimed_root\n" ++
+  "  la t1, bvtr_computed_root\n" ++
+  "  ld t2,  0(t0); ld t3,  0(t1); bne t2, t3, .Lbvtr_neq\n" ++
+  "  ld t2,  8(t0); ld t3,  8(t1); bne t2, t3, .Lbvtr_neq\n" ++
+  "  ld t2, 16(t0); ld t3, 16(t1); bne t2, t3, .Lbvtr_neq\n" ++
+  "  ld t2, 24(t0); ld t3, 24(t1); bne t2, t3, .Lbvtr_neq\n" ++
+  "  li t0, 1\n" ++
+  "  sd t0, 0(s6)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lbvtr_ret\n" ++
+  ".Lbvtr_neq:\n" ++
+  "  sd zero, 0(s6)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lbvtr_ret\n" ++
+  ".Lbvtr_parse_fail:\n" ++
+  "  li a0, 1\n" ++
+  "  j .Lbvtr_ret\n" ++
+  ".Lbvtr_size_fail:\n" ++
+  "  li a0, 2\n" ++
+  ".Lbvtr_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp)\n" ++
+  "  addi sp, sp, 64\n" ++
+  "  ret"
+
+/-- `zisk_block_validate_transactions_root_two_tx`: probe BuildUnit.
+    Input layout:
+      bytes  0.. 8 : header_rlp_len
+      bytes  8..16 : tx0_len
+      bytes 16..24 : tx1_len
+      bytes 24..   : header_rlp || tx0 || tx1
+    Output layout:
+      bytes  0.. 8 : status (0=ok, 1=header parse, 2=size fail)
+      bytes  8..16 : is_valid (1 if root matches, else 0) -/
+def ziskBlockValidateTransactionsRootTwoTxPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a7, 0x40000000\n" ++
+  "  ld a1, 8(a7)                # header_rlp_len\n" ++
+  "  ld a3, 16(a7)               # tx0_len\n" ++
+  "  ld a5, 24(a7)               # tx1_len\n" ++
+  "  addi a0, a7, 32             # header_rlp ptr\n" ++
+  "  add a2, a0, a1              # tx0 ptr = header_rlp + header_len\n" ++
+  "  add a4, a2, a3              # tx1 ptr = tx0 + tx0_len\n" ++
+  "  li a6, 0xa0010008           # is_valid out\n" ++
+  "  jal ra, block_validate_transactions_root_two_tx\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lbvtr_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  hpEncodeNibblesFunction ++ "\n" ++
+  rlpEncodeBytesFunction ++ "\n" ++
+  rlpEncodeListPrefixFunction ++ "\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  mptLeafNodeEncodeFromNibblesFunction ++ "\n" ++
+  mptNodeSlotEncodeFunction ++ "\n" ++
+  mptBranchPayloadTwoSlotsFunction ++ "\n" ++
+  mptBranchNodeEncodeFunction ++ "\n" ++
+  mptBranchNodeKeccakFunction ++ "\n" ++
+  mptTwoLeafRootIndexedFunction ++ "\n" ++
+  blockValidateTransactionsRootTwoTxFunction ++ "\n" ++
+  ".Lbvtr_pdone:"
+
+def ziskBlockValidateTransactionsRootTwoTxDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  "mlnen_field_len:\n" ++
+  "  .zero 8\n" ++
+  "mlnen_hp_len:\n" ++
+  "  .zero 8\n" ++
+  "mlnen_cursor:\n" ++
+  "  .zero 8\n" ++
+  "mlnen_total_payload:\n" ++
+  "  .zero 8\n" ++
+  "mlnen_hp_buf:\n" ++
+  "  .zero 1024\n" ++
+  "mlnen_payload_buf:\n" ++
+  "  .zero 16384\n" ++
+  "mbne_field_len:\n" ++
+  "  .zero 8\n" ++
+  "mbnk_node_len:\n" ++
+  "  .zero 8\n" ++
+  "mbnk_node_buf:\n" ++
+  "  .zero 16384\n" ++
+  "mtlri_nib0:\n" ++
+  "  .zero 1\n" ++
+  "mtlri_nib1:\n" ++
+  "  .zero 1\n" ++
+  ".balign 8\n" ++
+  "mtlri_leaf_0_len:\n" ++
+  "  .zero 8\n" ++
+  "mtlri_leaf_0_buf:\n" ++
+  "  .zero 16384\n" ++
+  "mtlri_leaf_1_len:\n" ++
+  "  .zero 8\n" ++
+  "mtlri_leaf_1_buf:\n" ++
+  "  .zero 16384\n" ++
+  "mtlri_slot_0_len:\n" ++
+  "  .zero 8\n" ++
+  "mtlri_slot_0_buf:\n" ++
+  "  .zero 16384\n" ++
+  "mtlri_slot_1_len:\n" ++
+  "  .zero 8\n" ++
+  "mtlri_slot_1_buf:\n" ++
+  "  .zero 16384\n" ++
+  "mtlri_branch_payload_len:\n" ++
+  "  .zero 8\n" ++
+  "mtlri_branch_payload:\n" ++
+  "  .zero 16384\n" ++
+  "bvtr_offset:\n" ++
+  "  .zero 8\n" ++
+  "bvtr_length:\n" ++
+  "  .zero 8\n" ++
+  "bvtr_claimed_root:\n" ++
+  "  .zero 32\n" ++
+  "bvtr_computed_root:\n" ++
+  "  .zero 32"
+
+def ziskBlockValidateTransactionsRootTwoTxProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskBlockValidateTransactionsRootTwoTxPrologue
+  dataAsm     := ziskBlockValidateTransactionsRootTwoTxDataSection
+}
+
 
 end EvmAsm.Codegen

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **193**
-- ziskemu round-trip scripts: **186** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **195**
+- ziskemu round-trip scripts: **188** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/README.md
+++ b/README.md
@@ -260,7 +260,8 @@ and MPT primitives (`account_decode`, `account_at_address`,
 `account_extract_*`, `mpt_walk`, `mpt_branch_*`, `mpt_compact_*`,
 `mpt_two_leaf_root_indexed`, …), block-body helpers
 (`block_body_decode`, `block_count_transactions`,
-`block_validate_transactions_root_two_tx`, withdrawal RLP/hash, …),
+`block_validate_transactions_root_two_tx`,
+`block_hash_from_header`, withdrawal RLP/hash, …),
 and address
 derivation (`address_compute_create`, `address_compute_create2`,
 `address_from_pubkey`). The catalogue is tracked under the

--- a/README.md
+++ b/README.md
@@ -258,8 +258,10 @@ field accessors (legacy / EIP-1559 / EIP-2930 / EIP-4844 / EIP-7702
 decoders, intrinsic-gas helpers, signature extraction, …), account
 and MPT primitives (`account_decode`, `account_at_address`,
 `account_extract_*`, `mpt_walk`, `mpt_branch_*`, `mpt_compact_*`,
-…), block-body helpers (`block_body_decode`,
-`block_count_transactions`, withdrawal RLP/hash, …), and address
+`mpt_two_leaf_root_indexed`, …), block-body helpers
+(`block_body_decode`, `block_count_transactions`,
+`block_validate_transactions_root_two_tx`, withdrawal RLP/hash, …),
+and address
 derivation (`address_compute_create`, `address_compute_create2`,
 `address_from_pubkey`). The catalogue is tracked under the
 `PR-K*` series in [`PLAN.md`](PLAN.md).

--- a/scripts/codegen-zisk-block-hash-from-header-check.sh
+++ b/scripts/codegen-zisk-block-hash-from-header-check.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# codegen-zisk-block-hash-from-header-check.sh -- PR-K172.
+#
+# Block hash = keccak256(header_rlp_bytes). Verifies the one-shot
+# header-hash primitive against the Python keccak256 reference for a
+# few representative header shapes.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_block_hash_from_header ELF"
+lake exe codegen --program zisk_block_hash_from_header --halt linux93 \
+  -o gen-out/zisk_block_hash_from_header
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <python expression returning a list of 15+ field bytes>
+run_case() {
+  local name="$1" field_expr="$2"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_block_hash_from_header_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_block_hash_from_header_${name}.output"
+  local exp_hex_file="$REPO_ROOT/gen-out/zisk_block_hash_from_header_${name}.expected.hex"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+try:
+    from Crypto.Hash import keccak
+    def keccak256(b):
+        h = keccak.new(digest_bits=256); h.update(b); return h.digest()
+except Exception:
+    import sha3
+    def keccak256(b): return sha3.keccak_256(b).digest()
+
+fields = $field_expr
+header_rlp = rlp.encode(fields)
+block_hash = keccak256(header_rlp)
+
+with open(sys.argv[1], 'wb') as f:
+    record = struct.pack('<Q', len(header_rlp)) + header_rlp
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\x00' * pad)
+with open(sys.argv[2], 'w') as f:
+    f.write(block_hash.hex())
+" "$in_file" "$exp_hex_file"
+
+  "$ZISKEMU" -e gen-out/zisk_block_hash_from_header.elf \
+    -i "$in_file" -o "$out_file" -n 1000000 \
+    >"$REPO_ROOT/gen-out/zisk_block_hash_from_header_${name}.emu.log" 2>&1 || true
+
+  local actual; actual="$(xxd -p -l 32 "$out_file" | tr -d '\n')"
+  local expected; expected="$(cat "$exp_hex_file")"
+
+  if [[ "$actual" == "$expected" ]]; then
+    printf "  %-30s OK   hash=%s...\n" "$name" "${actual:0:16}"
+    return 0
+  else
+    printf "  %-30s FAIL\n" "$name"
+    printf "      actual:   %s\n" "$actual"
+    printf "      expected: %s\n" "$expected"
+    return 1
+  fi
+}
+
+FAILED=0
+# Minimal pre-London header: 15 fields, no base_fee.
+run_case "pre_london_15_fields" "[
+    b'\\x11'*32, b'\\x22'*32, b'\\x33'*20, b'\\x44'*32, b'\\x55'*32,
+    b'\\x66'*32, b'\\x00'*256, b'', b'\\x01', b'\\x83\\xff\\xff\\xff',
+    b'', b'\\x83\\x01\\x02\\x03', b'', b'\\x77'*32, b'\\x00'*8,
+]" || FAILED=1
+# London header: 16 fields (+ base_fee).
+run_case "london_16_fields" "[
+    b'\\xaa'*32, b'\\xbb'*32, b'\\xcc'*20, b'\\xdd'*32, b'\\xee'*32,
+    b'\\xff'*32, b'\\x00'*256, b'', b'\\x80\\x00', b'\\x84\\x01\\x02\\x03\\x04',
+    b'\\x82\\x02\\x00', b'\\x83\\x05\\x06\\x07', b'\\x88abcdefgh', b'\\x88'*32, b'\\x00'*8,
+    b'\\x82\\x12\\x34',
+]" || FAILED=1
+# Shanghai-style header: 17 fields (+ withdrawals_root).
+run_case "shanghai_17_fields" "[
+    b'\\x01'*32, b'\\x02'*32, b'\\x03'*20, b'\\x04'*32, b'\\x05'*32,
+    b'\\x06'*32, b'\\x00'*256, b'', b'\\x83\\x10\\x00\\x00', b'\\x83\\xff\\xff\\xff',
+    b'', b'\\x83\\x01\\x02\\x03', b'', b'\\x07'*32, b'\\x00'*8,
+    b'\\x82\\xab\\xcd', b'\\x08'*32,
+]" || FAILED=1
+# Cancun-style header: 20 fields (+ blob_gas_used, excess_blob_gas, parent_beacon_block_root).
+run_case "cancun_20_fields" "[
+    b'\\x1a'*32, b'\\x2b'*32, b'\\x3c'*20, b'\\x4d'*32, b'\\x5e'*32,
+    b'\\x6f'*32, b'\\x00'*256, b'', b'\\x84\\x12\\x34\\x56\\x78', b'\\x83\\xff\\xff\\xff',
+    b'', b'\\x83\\x01\\x02\\x03', b'', b'\\x9a'*32, b'\\x00'*8,
+    b'\\x82\\xab\\xcd', b'\\xab'*32, b'\\x82\\x00\\x01', b'\\x82\\x00\\x02', b'\\xbc'*32,
+]" || FAILED=1
+# Empty extra_data + non-zero number/timestamp shape (smoke-test for short fields).
+run_case "small_numbers" "[
+    b'\\x00'*32, b'\\x00'*32, b'\\x00'*20, b'\\x00'*32, b'\\x00'*32,
+    b'\\x00'*32, b'\\x00'*256, b'\\x01', b'\\x02', b'\\x03',
+    b'\\x04', b'\\x05', b'', b'\\x00'*32, b'\\x00'*8,
+]" || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: block_hash_from_header matches Python keccak256(header_rlp)"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi

--- a/scripts/codegen-zisk-block-validate-transactions-root-two-tx-check.sh
+++ b/scripts/codegen-zisk-block-validate-transactions-root-two-tx-check.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# codegen-zisk-block-validate-transactions-root-two-tx-check.sh -- PR-K171.
+#
+# End-to-end transactions_root validation for 2-tx blocks: extract
+# header.field[4] (via K20), recompute the expected root via K170
+# (mpt_two_leaf_root_indexed), and compare 32 B.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_block_validate_transactions_root_two_tx ELF"
+lake exe codegen --program zisk_block_validate_transactions_root_two_tx --halt linux93 \
+  -o gen-out/zisk_block_validate_transactions_root_two_tx
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <tx0_hex> <tx1_hex> <override_root_hex_or_empty> <expected_status> <expected_valid>
+#
+# override_root_hex_or_empty:
+#   ""              -- use the correct computed root in the header
+#   "<32B hex>"     -- splice that into the header's field 4 instead
+#   "shortroot"     -- splice a 16-byte value into field 4 to trigger size_fail
+#   "garbage"       -- emit a malformed RLP header (single 0x00 byte) for parse_fail
+run_case() {
+  local name="$1" tx0="$2" tx1="$3" override="$4"
+  local exp_status="$5" exp_valid="$6"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_block_validate_transactions_root_two_tx_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_block_validate_transactions_root_two_tx_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+try:
+    from Crypto.Hash import keccak
+    def keccak256(b):
+        h = keccak.new(digest_bits=256); h.update(b); return h.digest()
+except Exception:
+    import sha3
+    def keccak256(b): return sha3.keccak_256(b).digest()
+
+tx0 = bytes.fromhex('$tx0')
+tx1 = bytes.fromhex('$tx1')
+override = '$override'
+
+# --- Compute correct transactions_root with the same algorithm K170 uses.
+def hp_leaf(nibbles, value):
+    flag = 2 + (len(nibbles) & 1)
+    hp = bytearray()
+    if len(nibbles) % 2 == 1:
+        hp.append((flag << 4) | nibbles[0]); i = 1
+    else:
+        hp.append(flag << 4); i = 0
+    while i < len(nibbles):
+        hp.append((nibbles[i] << 4) | nibbles[i+1]); i += 2
+    return rlp.encode([bytes(hp), value])
+
+def slot_ref(node_rlp):
+    if len(node_rlp) < 32:
+        return node_rlp
+    return b'\\xa0' + keccak256(node_rlp)
+
+leaf_0 = hp_leaf([0], tx0)   # key rlp(0)=0x80 -> nibbles [8,0]
+leaf_1 = hp_leaf([1], tx1)   # key rlp(1)=0x01 -> nibbles [0,1]
+slots = [b'\\x80'] * 17
+slots[8] = slot_ref(leaf_0)
+slots[0] = slot_ref(leaf_1)
+payload = b''.join(slots)
+n = len(payload)
+if n < 56:
+    prefix = bytes([0xc0 + n])
+else:
+    nb = n.to_bytes((n.bit_length() + 7) // 8, 'big')
+    prefix = bytes([0xf7 + len(nb)]) + nb
+branch_node_rlp = prefix + payload
+correct_root = keccak256(branch_node_rlp)
+
+# --- Build a synthetic block header with the chosen field 4 contents.
+parent_hash    = b'\\x11' * 32
+ommers_hash    = b'\\x22' * 32
+beneficiary    = b'\\x33' * 20
+state_root     = b'\\x44' * 32
+receipts_root  = b'\\x66' * 32
+logs_bloom     = b'\\x00' * 256
+difficulty     = b''
+number         = b'\\x01'
+gas_limit      = b'\\x83\\xff\\xff\\xff'  # 0x83ffffff (24-bit) is just an example
+gas_used       = b''
+timestamp      = b'\\x83\\x01\\x02\\x03'  # arbitrary
+extra_data     = b''
+prev_randao    = b'\\x77' * 32
+nonce          = b'\\x00' * 8
+
+if override == 'garbage':
+    header_rlp = b'\\x00'   # not a valid RLP list -- triggers parse_fail
+else:
+    if override == '':
+        field4 = correct_root
+    elif override == 'shortroot':
+        field4 = b'\\x55' * 16
+    else:
+        field4 = bytes.fromhex(override)
+    header_fields = [
+        parent_hash, ommers_hash, beneficiary, state_root,
+        field4, receipts_root, logs_bloom,
+        difficulty, number, gas_limit, gas_used, timestamp,
+        extra_data, prev_randao, nonce,
+    ]
+    header_rlp = rlp.encode(header_fields)
+
+with open(sys.argv[1], 'wb') as f:
+    # ziskemu maps file bytes to INPUT_ADDR+8; prologue reads
+    # header_rlp_len from offset 8 (= file byte 0), tx0_len from
+    # offset 16, tx1_len from offset 24, and the payload from
+    # offset 32 onward.
+    record = struct.pack('<Q', len(header_rlp)) + \
+             struct.pack('<Q', len(tx0)) + \
+             struct.pack('<Q', len(tx1)) + \
+             header_rlp + tx0 + tx1
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_block_validate_transactions_root_two_tx.elf \
+    -i "$in_file" -o "$out_file" -n 5000000 \
+    >"$REPO_ROOT/gen-out/zisk_block_validate_transactions_root_two_tx_${name}.emu.log" 2>&1 || true
+
+  local status_le; status_le="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local valid_le;  valid_le="$( dd if="$out_file" bs=1 skip=8 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local status valid
+  status="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$status_le'))[0])")"
+  valid="$( python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$valid_le'))[0])")"
+
+  if [[ "$status" == "$exp_status" && "$valid" == "$exp_valid" ]]; then
+    printf "  %-30s OK   status=%s valid=%s\n" "$name" "$status" "$valid"
+    return 0
+  else
+    printf "  %-30s FAIL status=%s (exp %s) valid=%s (exp %s)\n" \
+      "$name" "$status" "$exp_status" "$valid" "$exp_valid"
+    return 1
+  fi
+}
+
+TX_A="f8500184ee6b280082520894aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa881bc16d674ec80000801ba01111111111111111111111111111111111111111111111111111111111111111a02222222222222222222222222222222222222222222222222222222222222222"
+TX_B="f8500284ee6b280082520894bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb881bc16d674ec80000801ba03333333333333333333333333333333333333333333333333333333333333333a04444444444444444444444444444444444444444444444444444444444444444"
+
+WRONG_ROOT="ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100"
+
+FAILED=0
+# Correct claimed root + 2 long-tx leaves -> is_valid=1
+run_case "match_two_legacy"     "$TX_A" "$TX_B" ""           0 1 || FAILED=1
+# Correct claimed root + 2 short values (inline slot ref path)
+run_case "match_two_short"      "01"    "02"    ""           0 1 || FAILED=1
+# Wrong claimed root + correct 2-tx -> is_valid=0 (no error code)
+run_case "mismatch_wrong_root"  "$TX_A" "$TX_B" "$WRONG_ROOT" 0 0 || FAILED=1
+# Header has a 16-byte field 4 -> size_fail (status=2, valid=0)
+run_case "size_fail_short"      "$TX_A" "$TX_B" "shortroot"  2 0 || FAILED=1
+# Header is a single 0x00 byte -> parse_fail (status=1, valid=0)
+run_case "parse_fail_garbage"   "$TX_A" "$TX_B" "garbage"    1 0 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: block_validate_transactions_root_two_tx accepts matching roots and rejects others"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

End-to-end validation of a block header's `transactions_root` against
the trie root computed from the block's two transactions:

1. Extract field 4 (`transactions_root`) of the header RLP via K20
   `rlp_list_nth_item`; verify length == 32.
2. Recompute the expected MPT root via K170 `mpt_two_leaf_root_indexed`
   from `(tx0, tx1)` (each indexed by `rlp(0)` / `rlp(1)`).
3. 32-byte memcmp of claimed vs. computed root; write a single u64
   verdict (1 = match, 0 = mismatch) plus a 3-valued status (0 ok,
   1 header parse failure, 2 wrong field-4 size).

This is the first **end-to-end block-level** validator built on top of
the K-series MPT encoders -- it closes the gap between K166–K170 (the
2-leaf trie root primitives) and the actual block-validation surface
the stateless guest needs.

## Calling convention

`a0` header_rlp ptr, `a1` header_rlp len, `a2/a3` tx0 ptr+len,
`a4/a5` tx1 ptr+len, `a6` u64 out (is_valid). Returns status in `a0`.

## Test plan

`scripts/codegen-zisk-block-validate-transactions-root-two-tx-check.sh`
covers 5 ziskemu fixtures against the Python `rlp` + `keccak256`
reference:

- [x] `match_two_legacy` — two long legacy tx leaves, correct claimed root → valid=1
- [x] `match_two_short` — two short inline-slot values, correct root → valid=1
- [x] `mismatch_wrong_root` — header claims wrong root → status=0, valid=0
- [x] `size_fail_short` — header field 4 is 16 bytes → status=2, valid=0
- [x] `parse_fail_garbage` — header is a single 0x00 byte → status=1, valid=0

## Stack

Builds on top of #5964 (PR-K170 `mpt_two_leaf_root_indexed`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)