### PR TITLE
feat(stateless): block_hash_from_header (PR-K172)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -5189,6 +5189,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_mpt_branch_node_keccak" => some ziskMptBranchNodeKeccakProbeUnit
   | "zisk_mpt_two_leaf_root_indexed" => some ziskMptTwoLeafRootIndexedProbeUnit
   | "zisk_block_validate_transactions_root_two_tx" => some ziskBlockValidateTransactionsRootTwoTxProbeUnit
+  | "zisk_block_hash_from_header" => some ziskBlockHashFromHeaderProbeUnit
   | "zisk_block_logs_bloom_from_receipts_list" => some ziskBlockLogsBloomFromReceiptsListProbeUnit
   | "zisk_block_validate_logs_bloom" => some ziskBlockValidateLogsBloomProbeUnit
   | "zisk_header_root_is_empty_trie" => some ziskHeaderRootIsEmptyTrieProbeUnit
@@ -5374,6 +5375,7 @@ def knownProgramNames : List String :=
    "zisk_mpt_branch_node_keccak",
    "zisk_mpt_two_leaf_root_indexed",
    "zisk_block_validate_transactions_root_two_tx",
+   "zisk_block_hash_from_header",
    "zisk_block_logs_bloom_from_receipts_list",
    "zisk_block_validate_logs_bloom",
    "zisk_header_root_is_empty_trie",

--- a/EvmAsm/Codegen/Programs/Header.lean
+++ b/EvmAsm/Codegen/Programs/Header.lean
@@ -1907,4 +1907,69 @@ def ziskValidateHeaderFullProbeUnit : BuildUnit := {
   dataAsm     := ziskValidateHeaderFullDataSection
 }
 
+/-! ## block_hash_from_header -- PR-K172
+
+    Compute the block hash of an Ethereum block header:
+    `block_hash = keccak256(header_rlp_bytes)`.
+
+    The header RLP is the canonical wire encoding of the
+    15-or-16-field header list (parent_hash, ommers_hash,
+    beneficiary, state_root, transactions_root, receipts_root,
+    logs_bloom, difficulty, number, gas_limit, gas_used,
+    timestamp, extra_data, prev_randao, nonce, [base_fee, ...
+    withdrawals_root, blob_gas_used, excess_blob_gas,
+    parent_beacon_block_root]).
+
+    The block hash is identified by `parent_hash` in the next
+    header in the chain, so this primitive is the natural
+    building block for `validate_headers` (which walks the
+    chain and checks each `header[i].parent_hash ==
+    block_hash_from_header(header[i-1])`).
+
+    Calling convention:
+      a0 (input)  : header_rlp ptr
+      a1 (input)  : header_rlp byte length
+      a2 (input)  : 32-byte output ptr (block_hash lands here)
+      ra (input)  : return
+      (no output register; result is in memory at `a2`) -/
+def blockHashFromHeaderFunction : String :=
+  "block_hash_from_header:\n" ++
+  "  addi sp, sp, -16\n" ++
+  "  sd ra, 0(sp)\n" ++
+  "  # zkvm_keccak256(a0=header, a1=len, a2=out)\n" ++
+  "  jal ra, zkvm_keccak256\n" ++
+  "  ld ra, 0(sp)\n" ++
+  "  addi sp, sp, 16\n" ++
+  "  ret"
+
+/-- `zisk_block_hash_from_header`: probe BuildUnit.
+    Input layout:
+      bytes 0..8  : header_rlp byte length
+      bytes 8..   : header_rlp
+    Output layout:
+      bytes 0..32 : block_hash -/
+def ziskBlockHashFromHeaderPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a7, 0x40000000\n" ++
+  "  ld a1, 8(a7)                # header_rlp_len\n" ++
+  "  addi a0, a7, 16             # header_rlp ptr\n" ++
+  "  li a2, 0xa0010000           # output block_hash ptr (32 B)\n" ++
+  "  jal ra, block_hash_from_header\n" ++
+  "  j .Lbhfh_pdone\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  blockHashFromHeaderFunction ++ "\n" ++
+  ".Lbhfh_pdone:"
+
+def ziskBlockHashFromHeaderDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200"
+
+def ziskBlockHashFromHeaderProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskBlockHashFromHeaderPrologue
+  dataAsm     := ziskBlockHashFromHeaderDataSection
+}
+
 end EvmAsm.Codegen

--- a/README.md
+++ b/README.md
@@ -260,7 +260,8 @@ and MPT primitives (`account_decode`, `account_at_address`,
 `account_extract_*`, `mpt_walk`, `mpt_branch_*`, `mpt_compact_*`,
 `mpt_two_leaf_root_indexed`, …), block-body helpers
 (`block_body_decode`, `block_count_transactions`,
-`block_validate_transactions_root_two_tx`, withdrawal RLP/hash, …),
+`block_validate_transactions_root_two_tx`,
+`block_hash_from_header`, withdrawal RLP/hash, …),
 and address
 derivation (`address_compute_create`, `address_compute_create2`,
 `address_from_pubkey`). The catalogue is tracked under the

--- a/scripts/codegen-zisk-block-hash-from-header-check.sh
+++ b/scripts/codegen-zisk-block-hash-from-header-check.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# codegen-zisk-block-hash-from-header-check.sh -- PR-K172.
+#
+# Block hash = keccak256(header_rlp_bytes). Verifies the one-shot
+# header-hash primitive against the Python keccak256 reference for a
+# few representative header shapes.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_block_hash_from_header ELF"
+lake exe codegen --program zisk_block_hash_from_header --halt linux93 \
+  -o gen-out/zisk_block_hash_from_header
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <python expression returning a list of 15+ field bytes>
+run_case() {
+  local name="$1" field_expr="$2"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_block_hash_from_header_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_block_hash_from_header_${name}.output"
+  local exp_hex_file="$REPO_ROOT/gen-out/zisk_block_hash_from_header_${name}.expected.hex"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+try:
+    from Crypto.Hash import keccak
+    def keccak256(b):
+        h = keccak.new(digest_bits=256); h.update(b); return h.digest()
+except Exception:
+    import sha3
+    def keccak256(b): return sha3.keccak_256(b).digest()
+
+fields = $field_expr
+header_rlp = rlp.encode(fields)
+block_hash = keccak256(header_rlp)
+
+with open(sys.argv[1], 'wb') as f:
+    record = struct.pack('<Q', len(header_rlp)) + header_rlp
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\x00' * pad)
+with open(sys.argv[2], 'w') as f:
+    f.write(block_hash.hex())
+" "$in_file" "$exp_hex_file"
+
+  "$ZISKEMU" -e gen-out/zisk_block_hash_from_header.elf \
+    -i "$in_file" -o "$out_file" -n 1000000 \
+    >"$REPO_ROOT/gen-out/zisk_block_hash_from_header_${name}.emu.log" 2>&1 || true
+
+  local actual; actual="$(xxd -p -l 32 "$out_file" | tr -d '\n')"
+  local expected; expected="$(cat "$exp_hex_file")"
+
+  if [[ "$actual" == "$expected" ]]; then
+    printf "  %-30s OK   hash=%s...\n" "$name" "${actual:0:16}"
+    return 0
+  else
+    printf "  %-30s FAIL\n" "$name"
+    printf "      actual:   %s\n" "$actual"
+    printf "      expected: %s\n" "$expected"
+    return 1
+  fi
+}
+
+FAILED=0
+# Minimal pre-London header: 15 fields, no base_fee.
+run_case "pre_london_15_fields" "[
+    b'\\x11'*32, b'\\x22'*32, b'\\x33'*20, b'\\x44'*32, b'\\x55'*32,
+    b'\\x66'*32, b'\\x00'*256, b'', b'\\x01', b'\\x83\\xff\\xff\\xff',
+    b'', b'\\x83\\x01\\x02\\x03', b'', b'\\x77'*32, b'\\x00'*8,
+]" || FAILED=1
+# London header: 16 fields (+ base_fee).
+run_case "london_16_fields" "[
+    b'\\xaa'*32, b'\\xbb'*32, b'\\xcc'*20, b'\\xdd'*32, b'\\xee'*32,
+    b'\\xff'*32, b'\\x00'*256, b'', b'\\x80\\x00', b'\\x84\\x01\\x02\\x03\\x04',
+    b'\\x82\\x02\\x00', b'\\x83\\x05\\x06\\x07', b'\\x88abcdefgh', b'\\x88'*32, b'\\x00'*8,
+    b'\\x82\\x12\\x34',
+]" || FAILED=1
+# Shanghai-style header: 17 fields (+ withdrawals_root).
+run_case "shanghai_17_fields" "[
+    b'\\x01'*32, b'\\x02'*32, b'\\x03'*20, b'\\x04'*32, b'\\x05'*32,
+    b'\\x06'*32, b'\\x00'*256, b'', b'\\x83\\x10\\x00\\x00', b'\\x83\\xff\\xff\\xff',
+    b'', b'\\x83\\x01\\x02\\x03', b'', b'\\x07'*32, b'\\x00'*8,
+    b'\\x82\\xab\\xcd', b'\\x08'*32,
+]" || FAILED=1
+# Cancun-style header: 20 fields (+ blob_gas_used, excess_blob_gas, parent_beacon_block_root).
+run_case "cancun_20_fields" "[
+    b'\\x1a'*32, b'\\x2b'*32, b'\\x3c'*20, b'\\x4d'*32, b'\\x5e'*32,
+    b'\\x6f'*32, b'\\x00'*256, b'', b'\\x84\\x12\\x34\\x56\\x78', b'\\x83\\xff\\xff\\xff',
+    b'', b'\\x83\\x01\\x02\\x03', b'', b'\\x9a'*32, b'\\x00'*8,
+    b'\\x82\\xab\\xcd', b'\\xab'*32, b'\\x82\\x00\\x01', b'\\x82\\x00\\x02', b'\\xbc'*32,
+]" || FAILED=1
+# Empty extra_data + non-zero number/timestamp shape (smoke-test for short fields).
+run_case "small_numbers" "[
+    b'\\x00'*32, b'\\x00'*32, b'\\x00'*20, b'\\x00'*32, b'\\x00'*32,
+    b'\\x00'*32, b'\\x00'*256, b'\\x01', b'\\x02', b'\\x03',
+    b'\\x04', b'\\x05', b'', b'\\x00'*32, b'\\x00'*8,
+]" || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: block_hash_from_header matches Python keccak256(header_rlp)"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Compute `block_hash = keccak256(header_rlp_bytes)` -- the canonical
Ethereum block hash. One-shot primitive that wraps the ziskemu keccak
intrinsic against an arbitrary-length header RLP buffer.

This is the natural building block for `validate_headers`, which walks
the chain and checks each
`header[i].parent_hash == block_hash_from_header(header[i-1])`.

## Calling convention

`a0` header_rlp ptr, `a1` header_rlp byte length, `a2` 32-byte output
ptr. No status register (the result is always the keccak; failure
modes belong to higher-level validators).

## Test plan

5 ziskemu fixtures against `Crypto.Hash.keccak`:

- [x] `pre_london_15_fields` -- 15-field minimal header
- [x] `london_16_fields` -- 16 fields (+base_fee)
- [x] `shanghai_17_fields` -- 17 fields (+withdrawals_root)
- [x] `cancun_20_fields` -- 20 fields (+blob_gas_used / excess_blob_gas / parent_beacon_block_root)
- [x] `small_numbers` -- smoke-test for short integer fields

## Stack

Builds on #5965 (PR-K171 `block_validate_transactions_root_two_tx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)