### PR TITLE
feat(smod): add scratchMem to h_stack throughout SMOD wrapper chain

### DIFF
--- a/EvmAsm/Evm64/SMod/Compose/ModCallGenericHandoff.lean
+++ b/EvmAsm/Evm64/SMod/Compose/ModCallGenericHandoff.lean
@@ -4,8 +4,9 @@
   Generic handoff from the SMOD wrapper's normalized dispatch-ready frame into
   the appended unsigned MOD callable, parameterized by the no-NOP body proof.
   h_stack uses divModStackDispatchPreNoX1 (with explicit x9=divisorSign) and
-  includes regOwn .x9 in the postcondition, matching the nonzero callable's
-  actual register behaviour.
+  includes regOwn .x9 and memOwn of the div128 scratch cell in the postcondition.
+  The scratch cell at sp + signExtend12 3936 is used by the n=3/n=2 div128 trial-call
+  and must be owned by the caller.
 -/
 
 import EvmAsm.Evm64.SMod.Compose.BaseTopLevel
@@ -22,7 +23,7 @@ theorem saveRaAbsThenModCallDispatchReadyPost_callable_from_noNop_spec_in_smodCo
       divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word)
     (v2 v5 v6 : Word)
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-      shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
     (h_base : base &&& 1 = 0)
     (h_stack :
       cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
@@ -38,22 +39,26 @@ theorem saveRaAbsThenModCallDispatchReadyPost_callable_from_noNop_spec_in_smodCo
           (smodAbsMask divisorTop)
           (smodAbsCarry3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
           q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+          (sp + signExtend12 (3936 : BitVec 12)) ↦ₘ scratchMem)
         (EvmAsm.Evm64.modStackDispatchPostCallable sp
           (smodAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
           (smodAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) **
           (.x1 ↦ᵣ ((base + modCallOff) + 4)) **
-          EvmAsm.Rv64.regOwn .x9)) :
+          EvmAsm.Rv64.regOwn .x9 **
+          memOwn (sp + signExtend12 (3936 : BitVec 12)))) :
     cpsTripleWithin (EvmAsm.Evm64.unifiedDivBound + 1)
       (base + wrapperEndOff) (base + resultSignFixOff) (smodCodeV4 base)
       (saveRaAbsThenModCallDispatchReadyPost vRa sp base
         dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
         divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
         v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-        shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       (sp + signExtend12 (3936 : BitVec 12)) ↦ₘ scratchMem)
       (saveRaAbsThenModCallCallablePost vRa sp base
         dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) := by
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
+       memOwn (sp + signExtend12 (3936 : BitVec 12))) := by
   let dividendSign := smodAbsSign dividendTop
   let divisorSign := smodAbsSign divisorTop
   let divisorMask := smodAbsMask divisorTop
@@ -74,9 +79,11 @@ theorem saveRaAbsThenModCallDispatchReadyPost_callable_from_noNop_spec_in_smodCo
         (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp dividendAbsWord divisorAbsWord
           divisorSign retAddr v2 v5 v6 divisorSum3 divisorMask divisorCarry3
           q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+          (sp + signExtend12 (3936 : BitVec 12)) ↦ₘ scratchMem)
         (EvmAsm.Evm64.modStackDispatchPostCallable sp dividendAbsWord divisorAbsWord **
-          (.x1 ↦ᵣ retAddr) ** EvmAsm.Rv64.regOwn .x9) := by
+          (.x1 ↦ᵣ retAddr) ** EvmAsm.Rv64.regOwn .x9 **
+          memOwn (sp + signExtend12 (3936 : BitVec 12))) := by
     simpa [dividendAbsWord, divisorAbsWord, divisorSign, retAddr, divisorSum3,
       divisorMask, divisorCarry3] using h_stack
   -- Extend body from modCode_noNop_v4 to evm_mod_callable_code_v4
@@ -86,10 +93,10 @@ theorem saveRaAbsThenModCallDispatchReadyPost_callable_from_noNop_spec_in_smodCo
   have h_ret := cpsTripleWithin_extend_code
     (EvmAsm.Evm64.evm_mod_callable_code_v4_ret_sub (base := base + wrapperEndOff))
     (ret_spec_within' ((base + wrapperEndOff) + EvmAsm.Evm64.nopOff) retAddr)
-  -- Frame (PostCallable ** regOwn .x9) around return; ret pre/post is (.x1 ↦ retAddr)
+  -- Frame (PostCallable ** regOwn .x9 ** memOwn (sp+3936)) around return
   have h_ret_framed := cpsTripleWithin_frameL
     (EvmAsm.Evm64.modStackDispatchPostCallable sp dividendAbsWord divisorAbsWord **
-      EvmAsm.Rv64.regOwn .x9)
+      EvmAsm.Rv64.regOwn .x9 ** memOwn (sp + signExtend12 (3936 : BitVec 12)))
     (by
       rw [EvmAsm.Evm64.modStackDispatchPostCallable_unfold,
         EvmAsm.Evm64.divScratchOwnCallNoX1_unfold, EvmAsm.Evm64.divScratchOwn_unfold]
@@ -103,9 +110,11 @@ theorem saveRaAbsThenModCallDispatchReadyPost_callable_from_noNop_spec_in_smodCo
         (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp dividendAbsWord divisorAbsWord
           divisorSign retAddr v2 v5 v6 divisorSum3 divisorMask divisorCarry3
           q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+          (sp + signExtend12 (3936 : BitVec 12)) ↦ₘ scratchMem)
         (EvmAsm.Evm64.modStackDispatchPostCallable sp dividendAbsWord divisorAbsWord **
-          (.x1 ↦ᵣ retAddr) ** EvmAsm.Rv64.regOwn .x9) :=
+          (.x1 ↦ᵣ retAddr) ** EvmAsm.Rv64.regOwn .x9 **
+          memOwn (sp + signExtend12 (3936 : BitVec 12))) :=
     cpsTripleWithin_weaken (fun _ hp => hp) (fun _ hp => by xperm_hyp hp)
       (cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp)
         h_body_call h_ret_framed)
@@ -116,20 +125,24 @@ theorem saveRaAbsThenModCallDispatchReadyPost_callable_from_noNop_spec_in_smodCo
         (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp dividendAbsWord divisorAbsWord
           divisorSign retAddr v2 v5 v6 divisorSum3 divisorMask divisorCarry3
           q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+          (sp + signExtend12 (3936 : BitVec 12)) ↦ₘ scratchMem)
         (EvmAsm.Evm64.modStackDispatchPostCallable sp dividendAbsWord divisorAbsWord **
-          (.x1 ↦ᵣ retAddr) ** EvmAsm.Rv64.regOwn .x9) :=
+          (.x1 ↦ᵣ retAddr) ** EvmAsm.Rv64.regOwn .x9 **
+          memOwn (sp + signExtend12 (3936 : BitVec 12))) :=
     cpsTripleWithin_extend_code evm_mod_callable_code_v4_sub_smodCodeV4 h_callable_raw
-  -- Frame with privateFrame (x8 ** x13 ** x18, no x9)
+  -- Frame with privateFrame (x8 ** x13 ** x18, no x9); scratchMem is inside h_stack
   have h_callable_framed :
       cpsTripleWithin (EvmAsm.Evm64.unifiedDivBound + 1)
         (base + wrapperEndOff) (retAddr &&& ~~~(1 : Word)) (smodCodeV4 base)
-        (EvmAsm.Evm64.divModStackDispatchPreNoX1 sp dividendAbsWord divisorAbsWord
+        ((EvmAsm.Evm64.divModStackDispatchPreNoX1 sp dividendAbsWord divisorAbsWord
           divisorSign retAddr v2 v5 v6 divisorSum3 divisorMask divisorCarry3
           q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-          shiftMem nMem jMem retMem dMem dloMem scratchUn0 ** privateFrame)
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+          ((sp + signExtend12 (3936 : BitVec 12)) ↦ₘ scratchMem)) ** privateFrame)
         ((EvmAsm.Evm64.modStackDispatchPostCallable sp dividendAbsWord divisorAbsWord **
-          (.x1 ↦ᵣ retAddr) ** EvmAsm.Rv64.regOwn .x9) ** privateFrame) := by
+          (.x1 ↦ᵣ retAddr) ** EvmAsm.Rv64.regOwn .x9 **
+          memOwn (sp + signExtend12 (3936 : BitVec 12))) ** privateFrame) := by
     exact cpsTripleWithin_frameR privateFrame (by
       dsimp only [privateFrame]
       pcFree) h_callable_code
@@ -139,8 +152,7 @@ theorem saveRaAbsThenModCallDispatchReadyPost_callable_from_noNop_spec_in_smodCo
   exact
     cpsTripleWithin_weaken
       (fun h hp => by
-        -- Pre-weakener: saveRaAbsThenModCallDispatchReadyPost = PreNoX1 ** (x8 ** x13 ** x18)
-        -- Target: PreNoX1 ** privateFrame = PreNoX1 ** (x8 ** x13 ** x18) - same atoms
+        -- Pre-weakener: dispatch-ready ** scratchMem → PreNoX1 ** scratchMem ** privateFrame
         rw [saveRaAbsThenModCallDispatchReadyPost_unfold_smod_components] at hp
         dsimp only at hp
         rw [EvmAsm.Evm64.divModStackDispatchPreNoX1_unfold]
@@ -149,26 +161,26 @@ theorem saveRaAbsThenModCallDispatchReadyPost_callable_from_noNop_spec_in_smodCo
         dsimp only
         rw [EvmAsm.Evm64.divModStackDispatchPreNoX1_unfold] at hp
         change
-          (((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ divisorSign) ** (.x1 ↦ᵣ retAddr) ** (.x2 ↦ᵣ v2) **
-            (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ divisorSum3) **
-            (.x10 ↦ᵣ divisorMask) ** (.x11 ↦ᵣ divisorCarry3) **
-            (.x0 ↦ᵣ (0 : Word)) ** evmWordIs sp dividendAbsWord **
-            evmWordIs (sp + (32 : Word)) divisorAbsWord **
-            EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-              shiftMem nMem jMem retMem dMem dloMem scratchUn0) **
+          ((((.x12 ↦ᵣ sp) ** (.x9 ↦ᵣ divisorSign) ** (.x1 ↦ᵣ retAddr) ** (.x2 ↦ᵣ v2) **
+             (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ divisorSum3) **
+             (.x10 ↦ᵣ divisorMask) ** (.x11 ↦ᵣ divisorCarry3) **
+             (.x0 ↦ᵣ (0 : Word)) ** evmWordIs sp dividendAbsWord **
+             evmWordIs (sp + (32 : Word)) divisorAbsWord **
+             EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+               shiftMem nMem jMem retMem dMem dloMem scratchUn0) **
+            (sp + signExtend12 (3936 : BitVec 12)) ↦ₘ scratchMem) **
             (.x8 ↦ᵣ smodAbsSign dividendTop) ** (.x13 ↦ᵣ smodAbsSign dividendTop) **
             (.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)))) h
         xperm_hyp hp)
       (fun h hp => by
-        -- Post-weakener: (PostCallable ** .x1 ** regOwn .x9) ** privateFrame
-        -- → saveRaAbsThenModCallCallablePost = PostCallable ** .x1 ** regOwn .x9 ** privateFrame
+        -- Post-weakener: (PostCallable ** .x1 ** regOwn .x9 ** memOwn) ** privateFrame
+        -- → saveRaAbsThenModCallCallablePost ** memOwn (sp + 3936)
         rw [saveRaAbsThenModCallCallablePost_unfold]
         dsimp only
         rw [smodModCallPrivateFrame_unfold]
         dsimp only
         dsimp only [privateFrame] at hp
         rw [smodModCallPrivateFrame_unfold] at hp
-        dsimp only at hp
         xperm_hyp hp)
       h_callable_framed
 

--- a/EvmAsm/Evm64/SMod/Compose/ModCallResultSignFix.lean
+++ b/EvmAsm/Evm64/SMod/Compose/ModCallResultSignFix.lean
@@ -16,7 +16,7 @@ theorem saveRaAbsThenModCall_then_resultSignFix_of_callable_post_spec_in_smodCod
       divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word)
     (v2 v5 v6 : Word)
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-      shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
     (hCallable :
       EvmAsm.Rv64.cpsTripleWithin nSteps
         (base + wrapperEndOff) (base + resultSignFixOff) (smodCodeV4 base)
@@ -24,17 +24,20 @@ theorem saveRaAbsThenModCall_then_resultSignFix_of_callable_post_spec_in_smodCod
           dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
           divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
           v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+          (sp + EvmAsm.Rv64.signExtend12 (3936 : BitVec 12)) ↦ₘ scratchMem)
         (saveRaAbsThenModCallCallablePost vRa sp base
           dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-          divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)) :
+          divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
+          EvmAsm.Rv64.memOwn (sp + EvmAsm.Rv64.signExtend12 (3936 : BitVec 12)))) :
     EvmAsm.Rv64.cpsTripleWithin (nSteps + 21)
       (base + wrapperEndOff) ((base + resultSignFixOff) + 84) (smodCodeV4 base)
       (saveRaAbsThenModCallDispatchReadyPost vRa sp base
         dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
         divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
         v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-        shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+        (sp + EvmAsm.Rv64.signExtend12 (3936 : BitVec 12)) ↦ₘ scratchMem)
       (let dividendAbsWord : EvmWord :=
          smodAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
        let divisorAbsWord : EvmWord :=
@@ -45,7 +48,8 @@ theorem saveRaAbsThenModCall_then_resultSignFix_of_callable_post_spec_in_smodCod
          (modWord.getLimbN 0) (modWord.getLimbN 1)
          (modWord.getLimbN 2) (modWord.getLimbN 3) **
        smodModCallResultSignFixFrame vRa sp base dividendTop
-         dividendAbsWord) := by
+         dividendAbsWord **
+       EvmAsm.Rv64.memOwn (sp + EvmAsm.Rv64.signExtend12 (3936 : BitVec 12))) := by
   let dividendAbsWord : EvmWord :=
     smodAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
   let divisorAbsWord : EvmWord :=
@@ -53,10 +57,11 @@ theorem saveRaAbsThenModCall_then_resultSignFix_of_callable_post_spec_in_smodCod
   let modWord := EvmWord.mod dividendAbsWord divisorAbsWord
   let resultSign := smodAbsSign dividendTop
   let frame := smodModCallResultSignFixFrame vRa sp base dividendTop
-    dividendAbsWord
+    dividendAbsWord ** EvmAsm.Rv64.memOwn (sp + EvmAsm.Rv64.signExtend12 (3936 : BitVec 12))
   have hFramePc : frame.pcFree := by
     dsimp [frame]
-    exact smodModCallResultSignFixFrame_pcFree
+    exact EvmAsm.Rv64.pcFree_sepConj
+      smodModCallResultSignFixFrame_pcFree EvmAsm.Rv64.pcFree_memOwn
   have hFix :
       EvmAsm.Rv64.cpsTripleWithin 21 (base + resultSignFixOff)
         ((base + resultSignFixOff) + 84) (smodCodeV4 base)
@@ -74,8 +79,9 @@ theorem saveRaAbsThenModCall_then_resultSignFix_of_callable_post_spec_in_smodCod
   exact EvmAsm.Rv64.cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by
       rw [saveRaAbsThenModCallCallablePost_smodResultSignFixPreOwnScratch] at hp
-      dsimp [dividendAbsWord, divisorAbsWord, modWord, resultSign, frame] at hp
-      exact hp)
+      dsimp only [dividendAbsWord, divisorAbsWord, modWord, resultSign] at hp
+      dsimp only [frame]
+      xperm_hyp hp)
     hCallable hFix
 
 end EvmAsm.Evm64.SMod.Compose

--- a/EvmAsm/Evm64/SMod/Compose/ModCallResultSignFixGeneric.lean
+++ b/EvmAsm/Evm64/SMod/Compose/ModCallResultSignFixGeneric.lean
@@ -16,7 +16,7 @@ theorem saveRaAbsThenModCall_then_resultSignFix_from_noNop_spec_in_smodCodeV4
       divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word)
     (v2 v5 v6 : Word)
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-      shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
     (h_base : base &&& 1 = 0)
     (h_stack :
       EvmAsm.Rv64.cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
@@ -32,19 +32,22 @@ theorem saveRaAbsThenModCall_then_resultSignFix_from_noNop_spec_in_smodCodeV4
           (smodAbsMask divisorTop)
           (smodAbsCarry3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
           q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+          (sp + EvmAsm.Rv64.signExtend12 (3936 : BitVec 12)) ↦ₘ scratchMem)
         (EvmAsm.Evm64.modStackDispatchPostCallable sp
           (smodAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
           (smodAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) **
           (.x1 ↦ᵣ ((base + modCallOff) + 4)) **
-          EvmAsm.Rv64.regOwn .x9)) :
+          EvmAsm.Rv64.regOwn .x9 **
+          EvmAsm.Rv64.memOwn (sp + EvmAsm.Rv64.signExtend12 (3936 : BitVec 12)))) :
     EvmAsm.Rv64.cpsTripleWithin ((EvmAsm.Evm64.unifiedDivBound + 1) + 21)
       (base + wrapperEndOff) ((base + resultSignFixOff) + 84) (smodCodeV4 base)
       (saveRaAbsThenModCallDispatchReadyPost vRa sp base
         dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
         divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
         v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-        shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+        (sp + EvmAsm.Rv64.signExtend12 (3936 : BitVec 12)) ↦ₘ scratchMem)
       (let dividendAbsWord : EvmWord :=
          smodAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
        let divisorAbsWord : EvmWord :=
@@ -55,14 +58,15 @@ theorem saveRaAbsThenModCall_then_resultSignFix_from_noNop_spec_in_smodCodeV4
          (modWord.getLimbN 0) (modWord.getLimbN 1)
          (modWord.getLimbN 2) (modWord.getLimbN 3) **
        smodModCallResultSignFixFrame vRa sp base dividendTop
-         dividendAbsWord) := by
+         dividendAbsWord **
+       EvmAsm.Rv64.memOwn (sp + EvmAsm.Rv64.signExtend12 (3936 : BitVec 12))) := by
   have hCallable :=
     saveRaAbsThenModCallDispatchReadyPost_callable_from_noNop_spec_in_smodCodeV4
       vRa sp base
       dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
       divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
       v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-      shiftMem nMem jMem retMem dMem dloMem scratchUn0
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 scratchMem
       h_base h_stack
   exact
     saveRaAbsThenModCall_then_resultSignFix_of_callable_post_spec_in_smodCodeV4
@@ -70,7 +74,7 @@ theorem saveRaAbsThenModCall_then_resultSignFix_from_noNop_spec_in_smodCodeV4
       dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
       divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
       v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-      shiftMem nMem jMem retMem dMem dloMem scratchUn0
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 scratchMem
       hCallable
 
 end EvmAsm.Evm64.SMod.Compose

--- a/EvmAsm/Evm64/SMod/Compose/ModCallResultSignFixNamedPost.lean
+++ b/EvmAsm/Evm64/SMod/Compose/ModCallResultSignFixNamedPost.lean
@@ -81,7 +81,7 @@ theorem saveRaAbsThenModCall_then_resultSignFix_named_post_from_noNop_spec_in_sm
       divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word)
     (v2 v5 v6 : Word)
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-      shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
     (h_base : base &&& 1 = 0)
     (h_stack :
       EvmAsm.Rv64.cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
@@ -97,35 +97,39 @@ theorem saveRaAbsThenModCall_then_resultSignFix_named_post_from_noNop_spec_in_sm
           (smodAbsMask divisorTop)
           (smodAbsCarry3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
           q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+          (sp + EvmAsm.Rv64.signExtend12 (3936 : BitVec 12)) ↦ₘ scratchMem)
         (EvmAsm.Evm64.modStackDispatchPostCallable sp
           (smodAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
           (smodAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) **
           (.x1 ↦ᵣ ((base + modCallOff) + 4)) **
-          EvmAsm.Rv64.regOwn .x9)) :
+          EvmAsm.Rv64.regOwn .x9 **
+          EvmAsm.Rv64.memOwn (sp + EvmAsm.Rv64.signExtend12 (3936 : BitVec 12)))) :
     EvmAsm.Rv64.cpsTripleWithin ((EvmAsm.Evm64.unifiedDivBound + 1) + 21)
       (base + wrapperEndOff) ((base + resultSignFixOff) + 84) (smodCodeV4 base)
       (saveRaAbsThenModCallDispatchReadyPost vRa sp base
         dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
         divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
         v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-        shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+        (sp + EvmAsm.Rv64.signExtend12 (3936 : BitVec 12)) ↦ₘ scratchMem)
       (saveRaAbsThenModCallResultSignFixPost vRa sp base
         dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) := by
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
+       EvmAsm.Rv64.memOwn (sp + EvmAsm.Rv64.signExtend12 (3936 : BitVec 12))) := by
   exact EvmAsm.Rv64.cpsTripleWithin_weaken
     (fun _ hp => hp)
     (fun _ hq => by
       rw [saveRaAbsThenModCallResultSignFixPost_unfold]
       dsimp only
       rw [← smodResultSignFixPost_smodResultSign_word]
-      exact hq)
+      xperm_hyp hq)
     (saveRaAbsThenModCall_then_resultSignFix_from_noNop_spec_in_smodCodeV4
       vRa sp base
       dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
       divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
       v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-      shiftMem nMem jMem retMem dMem dloMem scratchUn0
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 scratchMem
       h_base h_stack)
 
 end EvmAsm.Evm64.SMod.Compose

--- a/EvmAsm/Evm64/SMod/Compose/ModCallReturnGeneric.lean
+++ b/EvmAsm/Evm64/SMod/Compose/ModCallReturnGeneric.lean
@@ -19,7 +19,7 @@ theorem saveRaAbsThenModCall_then_return_from_noNop_spec_in_smodCodeV4
       divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word)
     (v2 v5 v6 : Word)
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-      shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
     (h_base : base &&& 1 = 0)
     (h_stack :
       EvmAsm.Rv64.cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
@@ -35,12 +35,14 @@ theorem saveRaAbsThenModCall_then_return_from_noNop_spec_in_smodCodeV4
           (smodAbsMask divisorTop)
           (smodAbsCarry3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
           q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+          (sp + EvmAsm.Rv64.signExtend12 (3936 : BitVec 12)) ↦ₘ scratchMem)
         (EvmAsm.Evm64.modStackDispatchPostCallable sp
           (smodAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
           (smodAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) **
           (.x1 ↦ᵣ ((base + modCallOff) + 4)) **
-          EvmAsm.Rv64.regOwn .x9)) :
+          EvmAsm.Rv64.regOwn .x9 **
+          EvmAsm.Rv64.memOwn (sp + EvmAsm.Rv64.signExtend12 (3936 : BitVec 12)))) :
     EvmAsm.Rv64.cpsTripleWithin (((EvmAsm.Evm64.unifiedDivBound + 1) + 21) + 1)
       (base + wrapperEndOff)
       (((vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)) +
@@ -50,7 +52,8 @@ theorem saveRaAbsThenModCall_then_return_from_noNop_spec_in_smodCodeV4
         dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
         divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
         v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-        shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+        (sp + EvmAsm.Rv64.signExtend12 (3936 : BitVec 12)) ↦ₘ scratchMem)
       (let dividendAbsWord : EvmWord :=
          smodAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
        let divisorAbsWord : EvmWord :=
@@ -61,7 +64,8 @@ theorem saveRaAbsThenModCall_then_return_from_noNop_spec_in_smodCodeV4
        (smodResultSignFixPost (sp + 32) resultSign
          (modWord.getLimbN 0) (modWord.getLimbN 1)
          (modWord.getLimbN 2) (modWord.getLimbN 3) **
-        smodSavedRaRetFrame sp base dividendTop dividendAbsWord)) := by
+        smodSavedRaRetFrame sp base dividendTop dividendAbsWord) **
+       EvmAsm.Rv64.memOwn (sp + EvmAsm.Rv64.signExtend12 (3936 : BitVec 12))) := by
   let dividendAbsWord : EvmWord :=
     smodAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
   let divisorAbsWord : EvmWord :=
@@ -74,20 +78,22 @@ theorem saveRaAbsThenModCall_then_return_from_noNop_spec_in_smodCodeV4
       dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
       divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
       v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-      shiftMem nMem jMem retMem dMem dloMem scratchUn0
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 scratchMem
       h_base h_stack
   have hRetFramePc :
-      (smodResultSignFixPost (sp + 32) resultSign
+      ((smodResultSignFixPost (sp + 32) resultSign
         (modWord.getLimbN 0) (modWord.getLimbN 1)
         (modWord.getLimbN 2) (modWord.getLimbN 3) **
-       smodSavedRaRetFrame sp base dividendTop dividendAbsWord).pcFree := by
+       smodSavedRaRetFrame sp base dividendTop dividendAbsWord) **
+       EvmAsm.Rv64.memOwn (sp + EvmAsm.Rv64.signExtend12 (3936 : BitVec 12))).pcFree := by
     pcFree
   have hRetFramed :=
     EvmAsm.Rv64.cpsTripleWithin_frameR
-      (smodResultSignFixPost (sp + 32) resultSign
+      ((smodResultSignFixPost (sp + 32) resultSign
         (modWord.getLimbN 0) (modWord.getLimbN 1)
         (modWord.getLimbN 2) (modWord.getLimbN 3) **
-       smodSavedRaRetFrame sp base dividendTop dividendAbsWord)
+       smodSavedRaRetFrame sp base dividendTop dividendAbsWord) **
+       EvmAsm.Rv64.memOwn (sp + EvmAsm.Rv64.signExtend12 (3936 : BitVec 12)))
       hRetFramePc
       (savedRaRet_spec_in_smodCodeV4
         (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)) base)
@@ -101,15 +107,17 @@ theorem saveRaAbsThenModCall_then_return_from_noNop_spec_in_smodCodeV4
           EvmAsm.Rv64.signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word))
         (smodCodeV4 base)
         ((.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12))) **
-         (smodResultSignFixPost (sp + 32) resultSign
+         ((smodResultSignFixPost (sp + 32) resultSign
           (modWord.getLimbN 0) (modWord.getLimbN 1)
           (modWord.getLimbN 2) (modWord.getLimbN 3) **
-          smodSavedRaRetFrame sp base dividendTop dividendAbsWord))
+          smodSavedRaRetFrame sp base dividendTop dividendAbsWord) **
+          EvmAsm.Rv64.memOwn (sp + EvmAsm.Rv64.signExtend12 (3936 : BitVec 12))))
         ((.x18 ↦ᵣ (vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12))) **
-         (smodResultSignFixPost (sp + 32) resultSign
+         ((smodResultSignFixPost (sp + 32) resultSign
           (modWord.getLimbN 0) (modWord.getLimbN 1)
           (modWord.getLimbN 2) (modWord.getLimbN 3) **
-          smodSavedRaRetFrame sp base dividendTop dividendAbsWord)) := by
+          smodSavedRaRetFrame sp base dividendTop dividendAbsWord) **
+          EvmAsm.Rv64.memOwn (sp + EvmAsm.Rv64.signExtend12 (3936 : BitVec 12)))) := by
     rw [hFall]
     exact hRetFramed
   exact EvmAsm.Rv64.cpsTripleWithin_seq_perm_same_cr

--- a/EvmAsm/Evm64/SMod/Compose/ModCallReturnNamedPost.lean
+++ b/EvmAsm/Evm64/SMod/Compose/ModCallReturnNamedPost.lean
@@ -81,7 +81,7 @@ theorem saveRaAbsThenModCall_then_return_named_post_from_noNop_spec_in_smodCodeV
       divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word)
     (v2 v5 v6 : Word)
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-      shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
     (h_base : base &&& 1 = 0)
     (h_stack :
       EvmAsm.Rv64.cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
@@ -97,12 +97,14 @@ theorem saveRaAbsThenModCall_then_return_named_post_from_noNop_spec_in_smodCodeV
           (smodAbsMask divisorTop)
           (smodAbsCarry3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
           q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+          (sp + EvmAsm.Rv64.signExtend12 (3936 : BitVec 12)) ↦ₘ scratchMem)
         (EvmAsm.Evm64.modStackDispatchPostCallable sp
           (smodAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
           (smodAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) **
           (.x1 ↦ᵣ ((base + modCallOff) + 4)) **
-          EvmAsm.Rv64.regOwn .x9)) :
+          EvmAsm.Rv64.regOwn .x9 **
+          EvmAsm.Rv64.memOwn (sp + EvmAsm.Rv64.signExtend12 (3936 : BitVec 12)))) :
     EvmAsm.Rv64.cpsTripleWithin (((EvmAsm.Evm64.unifiedDivBound + 1) + 21) + 1)
       (base + wrapperEndOff)
       (((vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)) +
@@ -112,23 +114,25 @@ theorem saveRaAbsThenModCall_then_return_named_post_from_noNop_spec_in_smodCodeV
         dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
         divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
         v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-        shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+        (sp + EvmAsm.Rv64.signExtend12 (3936 : BitVec 12)) ↦ₘ scratchMem)
       (saveRaAbsThenModCallReturnPost vRa sp base
         dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) := by
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
+       EvmAsm.Rv64.memOwn (sp + EvmAsm.Rv64.signExtend12 (3936 : BitVec 12))) := by
   exact EvmAsm.Rv64.cpsTripleWithin_weaken
     (fun _ hp => hp)
     (fun _ hq => by
       rw [saveRaAbsThenModCallReturnPost_unfold]
       dsimp only
       rw [← smodResultSignFixPost_smodResultSign_word]
-      exact hq)
+      xperm_hyp hq)
     (saveRaAbsThenModCall_then_return_from_noNop_spec_in_smodCodeV4
       vRa sp base
       dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
       divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
       v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-      shiftMem nMem jMem retMem dMem dloMem scratchUn0
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 scratchMem
       h_base h_stack)
 
 end EvmAsm.Evm64.SMod.Compose

--- a/EvmAsm/Evm64/SMod/Compose/ModCallReturnNormalized.lean
+++ b/EvmAsm/Evm64/SMod/Compose/ModCallReturnNormalized.lean
@@ -15,7 +15,7 @@ theorem saveRaAbsThenModCall_then_return_named_post_normalized_from_noNop_spec_i
       divisorLimb0 divisorLimb1 divisorLimb2 divisorTop : Word)
     (v2 v5 v6 : Word)
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-      shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
     (h_base : base &&& 1 = 0)
     (h_stack :
       EvmAsm.Rv64.cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
@@ -31,22 +31,26 @@ theorem saveRaAbsThenModCall_then_return_named_post_normalized_from_noNop_spec_i
           (smodAbsMask divisorTop)
           (smodAbsCarry3 divisorLimb0 divisorLimb1 divisorLimb2 divisorTop)
           q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+          (sp + EvmAsm.Rv64.signExtend12 (3936 : BitVec 12)) ↦ₘ scratchMem)
         (EvmAsm.Evm64.modStackDispatchPostCallable sp
           (smodAbsDividendWord dividendLimb0 dividendLimb1 dividendLimb2 dividendTop)
           (smodAbsDivisorWord divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) **
           (.x1 ↦ᵣ ((base + modCallOff) + 4)) **
-          EvmAsm.Rv64.regOwn .x9)) :
+          EvmAsm.Rv64.regOwn .x9 **
+          EvmAsm.Rv64.memOwn (sp + EvmAsm.Rv64.signExtend12 (3936 : BitVec 12)))) :
     EvmAsm.Rv64.cpsTripleWithin (((EvmAsm.Evm64.unifiedDivBound + 1) + 21) + 1)
       (base + wrapperEndOff) (vRa &&& ~~~(1 : Word)) (smodCodeV4 base)
       (saveRaAbsThenModCallDispatchReadyPost vRa sp base
         dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
         divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
         v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-        shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+        (sp + EvmAsm.Rv64.signExtend12 (3936 : BitVec 12)) ↦ₘ scratchMem)
       (saveRaAbsThenModCallReturnPost vRa sp base
         dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
-        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop) := by
+        divisorLimb0 divisorLimb1 divisorLimb2 divisorTop **
+       EvmAsm.Rv64.memOwn (sp + EvmAsm.Rv64.signExtend12 (3936 : BitVec 12))) := by
   have hExit :
       (((vRa + EvmAsm.Rv64.signExtend12 (0 : BitVec 12)) +
         EvmAsm.Rv64.signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word)) =
@@ -59,7 +63,7 @@ theorem saveRaAbsThenModCall_then_return_named_post_normalized_from_noNop_spec_i
     dividendLimb0 dividendLimb1 dividendLimb2 dividendTop
     divisorLimb0 divisorLimb1 divisorLimb2 divisorTop
     v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-    shiftMem nMem jMem retMem dMem dloMem scratchUn0
+    shiftMem nMem jMem retMem dMem dloMem scratchUn0 scratchMem
     h_base h_stack
 
 end EvmAsm.Evm64.SMod.Compose

--- a/EvmAsm/Evm64/SMod/Spec.lean
+++ b/EvmAsm/Evm64/SMod/Spec.lean
@@ -129,7 +129,7 @@ theorem evm_smod_mod_call_return_stack_spec_within
     (dividend divisor : EvmWord)
     (v2 v5 v6 : Word)
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-      shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
     (base : Word) (h_base : base &&& 1 = 0)
     (h_stack :
       EvmAsm.Rv64.cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
@@ -149,14 +149,16 @@ theorem evm_smod_mod_call_return_stack_spec_within
           (smodAbsCarry3 (divisor.getLimbN 0) (divisor.getLimbN 1)
             (divisor.getLimbN 2) (divisor.getLimbN 3))
           q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+          (sp + EvmAsm.Rv64.signExtend12 (3936 : BitVec 12)) ↦ₘ scratchMem)
         (EvmAsm.Evm64.modStackDispatchPostCallable sp
           (smodAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
             (dividend.getLimbN 2) (dividend.getLimbN 3))
           (smodAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
             (divisor.getLimbN 2) (divisor.getLimbN 3)) **
           (.x1 ↦ᵣ ((base + modCallOff) + 4)) **
-          EvmAsm.Rv64.regOwn .x9)) :
+          EvmAsm.Rv64.regOwn .x9 **
+          EvmAsm.Rv64.memOwn (sp + EvmAsm.Rv64.signExtend12 (3936 : BitVec 12)))) :
     EvmAsm.Rv64.cpsTripleWithin
       (49 + (((EvmAsm.Evm64.unifiedDivBound + 1) + 21) + 1))
       base (vRa &&& ~~~(1 : Word)) (smodCodeV4 base)
@@ -169,18 +171,32 @@ theorem evm_smod_mod_call_return_stack_spec_within
         ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
           EvmAsm.Evm64.divScratchValuesCallNoX1 sp
             q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-            shiftMem nMem jMem retMem dMem dloMem scratchUn0))
+            shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+          (sp + EvmAsm.Rv64.signExtend12 (3936 : BitVec 12)) ↦ₘ scratchMem))
       (saveRaAbsThenModCallReturnPost vRa sp base
         (dividend.getLimbN 0) (dividend.getLimbN 1)
         (dividend.getLimbN 2) (dividend.getLimbN 3)
         (divisor.getLimbN 0) (divisor.getLimbN 1)
-        (divisor.getLimbN 2) (divisor.getLimbN 3)) := by
-  exact EvmAsm.Rv64.cpsTripleWithin_seq_same_cr
-    (evm_smod_prefix_mod_call_dispatch_ready_stack_spec_within
-      vRa vSavedOld sp sDividendOld x13Old sDivisorOld
-      dividendMaskOld dividendValueOld dividendCarryOld dividend divisor
-      v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-      shiftMem nMem jMem retMem dMem dloMem scratchUn0 base)
+        (divisor.getLimbN 2) (divisor.getLimbN 3) **
+       EvmAsm.Rv64.memOwn (sp + EvmAsm.Rv64.signExtend12 (3936 : BitVec 12))) := by
+  -- Frame scratchMem cell around the prefix triple (prefix doesn't touch sp+3936)
+  have hPrefixFramed :=
+    EvmAsm.Rv64.cpsTripleWithin_frameR
+      ((sp + EvmAsm.Rv64.signExtend12 (3936 : BitVec 12)) ↦ₘ scratchMem) (by pcFree)
+      (evm_smod_prefix_mod_call_dispatch_ready_stack_spec_within
+        vRa vSavedOld sp sDividendOld x13Old sDivisorOld
+        dividendMaskOld dividendValueOld dividendCarryOld dividend divisor
+        v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 base)
+  -- hPrefixFramed: prefix_pre ** (sp+3936↦scratchMem) → dispatch_ready_post ** (sp+3936↦scratchMem)
+  -- The seq_perm bridges: (overall_pre → hPrefixFramed.pre) via AC-perm of atoms,
+  -- then (dispatch_ready_post ** scratchCell → normalized.pre) via AC-perm.
+  exact EvmAsm.Rv64.cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by xperm_hyp hp)
+    (EvmAsm.Rv64.cpsTripleWithin_weaken
+      (fun _ hp => by xperm_hyp hp)
+      (fun _ hp => hp)
+      hPrefixFramed)
     (saveRaAbsThenModCall_then_return_named_post_normalized_from_noNop_spec_in_smodCodeV4
       vRa sp base
       (dividend.getLimbN 0) (dividend.getLimbN 1)
@@ -188,7 +204,7 @@ theorem evm_smod_mod_call_return_stack_spec_within
       (divisor.getLimbN 0) (divisor.getLimbN 1)
       (divisor.getLimbN 2) (divisor.getLimbN 3)
       v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-      shiftMem nMem jMem retMem dMem dloMem scratchUn0 h_base h_stack)
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 scratchMem h_base h_stack)
 
 /-- Canonical production-code spelling of
     `evm_smod_mod_call_return_stack_spec_within`. -/
@@ -198,7 +214,7 @@ theorem evm_smod_canonical_mod_call_return_stack_spec_within
     (dividend divisor : EvmWord)
     (v2 v5 v6 : Word)
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-      shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
     (base : Word) (h_base : base &&& 1 = 0)
     (h_stack :
       EvmAsm.Rv64.cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
@@ -218,14 +234,16 @@ theorem evm_smod_canonical_mod_call_return_stack_spec_within
           (smodAbsCarry3 (divisor.getLimbN 0) (divisor.getLimbN 1)
             (divisor.getLimbN 2) (divisor.getLimbN 3))
           q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+          (sp + EvmAsm.Rv64.signExtend12 (3936 : BitVec 12)) ↦ₘ scratchMem)
         (EvmAsm.Evm64.modStackDispatchPostCallable sp
           (smodAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
             (dividend.getLimbN 2) (dividend.getLimbN 3))
           (smodAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
             (divisor.getLimbN 2) (divisor.getLimbN 3)) **
           (.x1 ↦ᵣ ((base + modCallOff) + 4)) **
-          EvmAsm.Rv64.regOwn .x9)) :
+          EvmAsm.Rv64.regOwn .x9 **
+          EvmAsm.Rv64.memOwn (sp + EvmAsm.Rv64.signExtend12 (3936 : BitVec 12)))) :
     EvmAsm.Rv64.cpsTripleWithin
       (49 + (((EvmAsm.Evm64.unifiedDivBound + 1) + 21) + 1))
       base (vRa &&& ~~~(1 : Word)) (smodCodeCanonical base)
@@ -238,18 +256,20 @@ theorem evm_smod_canonical_mod_call_return_stack_spec_within
         ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
           EvmAsm.Evm64.divScratchValuesCallNoX1 sp
             q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-            shiftMem nMem jMem retMem dMem dloMem scratchUn0))
+            shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+          (sp + EvmAsm.Rv64.signExtend12 (3936 : BitVec 12)) ↦ₘ scratchMem))
       (saveRaAbsThenModCallReturnPost vRa sp base
         (dividend.getLimbN 0) (dividend.getLimbN 1)
         (dividend.getLimbN 2) (dividend.getLimbN 3)
         (divisor.getLimbN 0) (divisor.getLimbN 1)
-        (divisor.getLimbN 2) (divisor.getLimbN 3)) := by
+        (divisor.getLimbN 2) (divisor.getLimbN 3) **
+       EvmAsm.Rv64.memOwn (sp + EvmAsm.Rv64.signExtend12 (3936 : BitVec 12))) := by
   simpa [smodCodeCanonical] using
     evm_smod_mod_call_return_stack_spec_within
       vRa vSavedOld sp sDividendOld x13Old sDivisorOld
       dividendMaskOld dividendValueOld dividendCarryOld dividend divisor
       v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-      shiftMem nMem jMem retMem dMem dloMem scratchUn0 base h_base h_stack
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 scratchMem base h_base h_stack
 
 -- Placeholder: final `evm_smod_stack_spec_within` lands after the remaining
 -- callable-return and semantic-handler bridges are collapsed into one theorem.

--- a/EvmAsm/Evm64/SMod/SpecAllCase.lean
+++ b/EvmAsm/Evm64/SMod/SpecAllCase.lean
@@ -27,7 +27,7 @@ theorem evm_smod_canonical_all_case_mod_call_return_stack_spec_within
     (dividend divisor : EvmWord)
     (v2 v5 v6 : Word)
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-      shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
     (base : Word) (h_base : base &&& 1 = 0)
     (h_stack :
       EvmAsm.Rv64.cpsTripleWithin EvmAsm.Evm64.unifiedDivBound
@@ -47,14 +47,16 @@ theorem evm_smod_canonical_all_case_mod_call_return_stack_spec_within
           (smodAbsCarry3 (divisor.getLimbN 0) (divisor.getLimbN 1)
             (divisor.getLimbN 2) (divisor.getLimbN 3))
           q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-          shiftMem nMem jMem retMem dMem dloMem scratchUn0)
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+          (sp + EvmAsm.Rv64.signExtend12 (3936 : BitVec 12)) ↦ₘ scratchMem)
         (EvmAsm.Evm64.modStackDispatchPostCallable sp
           (smodAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
             (dividend.getLimbN 2) (dividend.getLimbN 3))
           (smodAbsDivisorWord (divisor.getLimbN 0) (divisor.getLimbN 1)
             (divisor.getLimbN 2) (divisor.getLimbN 3)) **
           (.x1 ↦ᵣ ((base + modCallOff) + 4)) **
-          EvmAsm.Rv64.regOwn .x9)) :
+          EvmAsm.Rv64.regOwn .x9 **
+          EvmAsm.Rv64.memOwn (sp + EvmAsm.Rv64.signExtend12 (3936 : BitVec 12)))) :
     EvmAsm.Rv64.cpsTripleWithin
       (49 + (((EvmAsm.Evm64.unifiedDivBound + 1) + 21) + 1))
       base (vRa &&& ~~~(1 : Word)) (smodCodeCanonical base)
@@ -67,24 +69,26 @@ theorem evm_smod_canonical_all_case_mod_call_return_stack_spec_within
         ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
           EvmAsm.Evm64.divScratchValuesCallNoX1 sp
             q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-            shiftMem nMem jMem retMem dMem dloMem scratchUn0))
+            shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+          (sp + EvmAsm.Rv64.signExtend12 (3936 : BitVec 12)) ↦ₘ scratchMem))
       (saveRaAbsThenModCallReturnPost vRa sp base
         (dividend.getLimbN 0) (dividend.getLimbN 1)
         (dividend.getLimbN 2) (dividend.getLimbN 3)
         (divisor.getLimbN 0) (divisor.getLimbN 1)
-        (divisor.getLimbN 2) (divisor.getLimbN 3)) := by
+        (divisor.getLimbN 2) (divisor.getLimbN 3) **
+       EvmAsm.Rv64.memOwn (sp + EvmAsm.Rv64.signExtend12 (3936 : BitVec 12))) := by
   rcases Classical.em (divisor = 0) with h_zero | h_nz
   · -- Zero divisor: use bzero spec
     exact evm_smod_canonical_bzero_mod_call_return_stack_spec_within
       vRa vSavedOld sp sDividendOld x13Old sDivisorOld
       dividendMaskOld dividendValueOld dividendCarryOld dividend divisor
       v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-      shiftMem nMem jMem retMem dMem dloMem scratchUn0 base h_base h_zero
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 scratchMem base h_base h_zero
   · -- Nonzero divisor: use canonical spec with h_stack
     exact evm_smod_canonical_mod_call_return_stack_spec_within
       vRa vSavedOld sp sDividendOld x13Old sDivisorOld
       dividendMaskOld dividendValueOld dividendCarryOld dividend divisor
       v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-      shiftMem nMem jMem retMem dMem dloMem scratchUn0 base h_base h_stack
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 scratchMem base h_base h_stack
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/SMod/SpecBzero.lean
+++ b/EvmAsm/Evm64/SMod/SpecBzero.lean
@@ -21,7 +21,7 @@ theorem evm_smod_canonical_bzero_mod_call_return_stack_spec_within
     (dividend divisor : EvmWord)
     (v2 v5 v6 : Word)
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-      shiftMem nMem jMem retMem dMem dloMem scratchUn0 : Word)
+      shiftMem nMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
     (base : Word) (h_base : base &&& 1 = 0)
     (h_divisor_zero : divisor = 0) :
     EvmAsm.Rv64.cpsTripleWithin
@@ -36,12 +36,14 @@ theorem evm_smod_canonical_bzero_mod_call_return_stack_spec_within
         ((.x2 ↦ᵣ v2) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
           EvmAsm.Evm64.divScratchValuesCallNoX1 sp
             q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-            shiftMem nMem jMem retMem dMem dloMem scratchUn0))
+            shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+          (sp + EvmAsm.Rv64.signExtend12 (3936 : BitVec 12)) ↦ₘ scratchMem))
       (saveRaAbsThenModCallReturnPost vRa sp base
         (dividend.getLimbN 0) (dividend.getLimbN 1)
         (dividend.getLimbN 2) (dividend.getLimbN 3)
         (divisor.getLimbN 0) (divisor.getLimbN 1)
-        (divisor.getLimbN 2) (divisor.getLimbN 3)) := by
+        (divisor.getLimbN 2) (divisor.getLimbN 3) **
+       EvmAsm.Rv64.memOwn (sp + EvmAsm.Rv64.signExtend12 (3936 : BitVec 12))) := by
   let divisorSign := smodAbsSign (divisor.getLimbN 3)
   let a : EvmWord :=
     smodAbsDividendWord (dividend.getLimbN 0) (dividend.getLimbN 1)
@@ -55,12 +57,13 @@ theorem evm_smod_canonical_bzero_mod_call_return_stack_spec_within
   let v11 := smodAbsCarry3 (divisor.getLimbN 0) (divisor.getLimbN 1)
     (divisor.getLimbN 2) (divisor.getLimbN 3)
   let retAddr := (base + modCallOff) + 4
+  let scratchCell := (sp + EvmAsm.Rv64.signExtend12 (3936 : BitVec 12)) ↦ₘ scratchMem
   refine evm_smod_canonical_mod_call_return_stack_spec_within
     vRa vSavedOld sp sDividendOld x13Old sDivisorOld
     dividendMaskOld dividendValueOld dividendCarryOld dividend divisor
     v2 v5 v6 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-    shiftMem nMem jMem retMem dMem dloMem scratchUn0 base h_base ?_
-  -- Adapt bzero spec to new h_stack type (PreNoX1 → PostCallable ** .x1 ** regOwn .x9)
+    shiftMem nMem jMem retMem dMem dloMem scratchUn0 scratchMem base h_base ?_
+  -- Adapt bzero spec to new h_stack type (PreNoX1 ** scratchCell → PostCallable ** .x1 ** regOwn .x9 ** memOwn)
   have h_bzero_raw :=
     cpsTripleWithin_extend_code
       (hmono := EvmAsm.Evm64.sharedDivModCodeNoNop_v4_sub_modCode_noNop_v4)
@@ -69,12 +72,15 @@ theorem evm_smod_canonical_bzero_mod_call_return_stack_spec_within
         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
         nMem shiftMem jMem retMem dMem dloMem scratchUn0
         (by simpa [b] using (smodAbsDivisorWord_eq_zero_iff divisor).mpr h_divisor_zero))
-  -- Frame .x9 ↦ divisorSign around bzero (bzero doesn't touch x9)
-  have h_bzero_framed := cpsTripleWithin_frameR (.x9 ↦ᵣ divisorSign) (by pcFree) h_bzero_raw
+  -- Frame .x9 ↦ divisorSign and scratchCell around bzero (bzero doesn't touch x9 or sp+3936)
+  have h_bzero_framed :=
+    cpsTripleWithin_frameR
+      ((.x9 ↦ᵣ divisorSign) ** scratchCell)
+      (by pcFree) h_bzero_raw
   -- Weaken to new h_stack type
   exact cpsTripleWithin_weaken
     (fun h hp => by
-      -- PreNoX1 → (PreCallable ** (.x9 ↦ divisorSign)): same atoms, just AC
+      -- PreNoX1 ** scratchCell → (PreCallable ** (.x9 ↦ divisorSign)) ** scratchCell: AC
       rw [EvmAsm.Evm64.divModStackDispatchPreNoX1_unfold] at hp
       rw [EvmAsm.Evm64.divModStackDispatchPreCallable_unfold]
       change
@@ -84,19 +90,22 @@ theorem evm_smod_canonical_bzero_mod_call_return_stack_spec_within
           evmWordIs sp a ** evmWordIs (sp + (32 : Word)) b **
           EvmAsm.Evm64.divScratchValuesCallNoX1 sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
             shiftMem nMem jMem retMem dMem dloMem scratchUn0) **
-          (.x9 ↦ᵣ divisorSign)) h
+          (.x9 ↦ᵣ divisorSign) ** scratchCell) h
       xperm_hyp hp)
     (fun h hp => by
-      -- (PostCallable ** .x1 ** .x9) → (PostCallable ** .x1 ** regOwn .x9)
-      -- HP: ((PostCallable ** .x1) ** (.x9 ↦ divisorSign)) h
-      obtain ⟨hAB, hX9, hd1, hu1, hAB_h, hX9_h⟩ := hp
-      have hregown := regIs_implies_regOwn .x9 hX9 hX9_h
-      have hp' : ((EvmAsm.Evm64.modStackDispatchPostCallable sp a b **
-                   (.x1 ↦ᵣ retAddr)) **
-                  EvmAsm.Rv64.regOwn .x9) h :=
-        ⟨hAB, hX9, hd1, hu1, hAB_h, hregown⟩
-      rw [sepConj_assoc] at hp'
-      exact hp')
+      -- hp : ((PostCallable sp a b ** .x1 ↦ retAddr) ** (.x9 ↦ divisorSign ** scratchCell)) h
+      -- goal: (PostCallable sp a b ** .x1 ↦ retAddr ** regOwn .x9 ** memOwn (sp+3936)) h
+      -- Use sepConj_mono to weaken (.x9 ↦ divisorSign) → regOwn .x9
+      -- and scratchCell → memOwn (sp+3936)
+      have hp2 :=
+        EvmAsm.Rv64.sepConj_mono_right
+          (EvmAsm.Rv64.sepConj_mono
+            (fun h' hr => regIs_implies_regOwn .x9 h' hr)
+            (fun h' hm => EvmAsm.Rv64.memIs_implies_memOwn h' hm))
+          h hp
+      -- hp2 : ((PostCallable ** .x1) ** (regOwn .x9 ** memOwn)) h
+      -- goal: (PostCallable ** .x1 ** regOwn .x9 ** memOwn) h = (PostCallable ** (.x1 ** (regOwn ** memOwn))) h
+      xperm_hyp hp2)
     h_bzero_framed
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Adds `scratchMem : Word` parameter to `saveRaAbsThenModCallDispatchReadyPost_callable_from_noNop_spec_in_smodCodeV4` (GenericHandoff) and all downstream theorems
- h_stack PRE now includes `** ((sp + signExtend12 3936) ↦ₘ scratchMem)` — the div128_v4 trial-call scratch cell
- h_stack POST now includes `** memOwn (sp + signExtend12 3936)` — existentially closed after callable runs
- Propagates through 8 wrapper files + Spec.lean + SpecBzero.lean + SpecAllCase.lean
- SpecBzero frames `(sp + 3936) ↦ₘ scratchMem` around the bzero callable (which preserves it)
- Stacked on #5963 → #5962 → #5960

This makes the n>=2 nonzero h_stack PROVABLE: callers can now supply `evm_mod_n3_stack_pre_to_unified_post_v4_noNop_anyX9` (which needs sp+3936) as the h_stack.

Refs #9. Bead: evm-asm-9iqmw.9.1.2.3.2.1.

## Verification
- lake build EvmAsm.Evm64.SMod.Compose.ModCallGenericHandoff
- lake build EvmAsm.Evm64.SMod
- scripts/check-file-size.sh
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/SMod/
- lake build

Authored by @pirapira; implemented by Claude Code