### PR TITLE
feat(stateless): validate_parent_hash_link (PR-K173)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -5190,6 +5190,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_mpt_two_leaf_root_indexed" => some ziskMptTwoLeafRootIndexedProbeUnit
   | "zisk_block_validate_transactions_root_two_tx" => some ziskBlockValidateTransactionsRootTwoTxProbeUnit
   | "zisk_block_hash_from_header" => some ziskBlockHashFromHeaderProbeUnit
+  | "zisk_validate_parent_hash_link" => some ziskValidateParentHashLinkProbeUnit
   | "zisk_block_logs_bloom_from_receipts_list" => some ziskBlockLogsBloomFromReceiptsListProbeUnit
   | "zisk_block_validate_logs_bloom" => some ziskBlockValidateLogsBloomProbeUnit
   | "zisk_header_root_is_empty_trie" => some ziskHeaderRootIsEmptyTrieProbeUnit
@@ -5376,6 +5377,7 @@ def knownProgramNames : List String :=
    "zisk_mpt_two_leaf_root_indexed",
    "zisk_block_validate_transactions_root_two_tx",
    "zisk_block_hash_from_header",
+   "zisk_validate_parent_hash_link",
    "zisk_block_logs_bloom_from_receipts_list",
    "zisk_block_validate_logs_bloom",
    "zisk_header_root_is_empty_trie",

--- a/EvmAsm/Codegen/Programs/Header.lean
+++ b/EvmAsm/Codegen/Programs/Header.lean
@@ -1972,4 +1972,137 @@ def ziskBlockHashFromHeaderProbeUnit : BuildUnit := {
   dataAsm     := ziskBlockHashFromHeaderDataSection
 }
 
+/-! ## validate_parent_hash_link -- PR-K173
+
+    Given a parent header (parent_rlp) and a child header
+    (child_rlp), verify that
+    `child.parent_hash == keccak256(parent_rlp)`.
+
+    This is the per-step check inside `validate_headers`: each
+    pair of consecutive headers in the chain must satisfy this
+    invariant; the full chain follows by induction.
+
+    Algorithm:
+      1. K20 extract field 0 (parent_hash) from child_rlp.
+         Verify field length == 32.
+      2. K172 `block_hash_from_header(parent_rlp)` ->
+         computed_hash.
+      3. 32-byte memcmp(claimed, computed).
+      4. Write verdict (1 = matches, 0 = mismatch); status
+         disambiguates parse vs. size vs. predicate failure.
+
+    Calling convention:
+      a0 (input)  : parent_rlp ptr
+      a1 (input)  : parent_rlp byte length
+      a2 (input)  : child_rlp ptr
+      a3 (input)  : child_rlp byte length
+      a4 (input)  : u64 out (is_valid: 1 if links, else 0)
+      ra (input)  : return
+      a0 (output) :
+        0 : success -- predicate written
+        1 : child RLP parse failure / field 0 missing
+        2 : child.parent_hash length != 32 -/
+def validateParentHashLinkFunction : String :=
+  "validate_parent_hash_link:\n" ++
+  "  addi sp, sp, -48\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp); sd s4, 40(sp)\n" ++
+  "  mv s0, a0                   # parent_rlp ptr\n" ++
+  "  mv s1, a1                   # parent_rlp len\n" ++
+  "  mv s2, a2                   # child_rlp ptr\n" ++
+  "  mv s3, a3                   # child_rlp len\n" ++
+  "  mv s4, a4                   # is_valid out\n" ++
+  "  sd zero, 0(s4)\n" ++
+  "  # ---- Extract child.parent_hash (field 0) ----\n" ++
+  "  mv a0, s2; mv a1, s3; li a2, 0\n" ++
+  "  la a3, vphl_offset; la a4, vphl_length\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lvphl_parse_fail\n" ++
+  "  la t0, vphl_length; ld t1, 0(t0)\n" ++
+  "  li t2, 32\n" ++
+  "  bne t1, t2, .Lvphl_size_fail\n" ++
+  "  # Copy claimed parent_hash into vphl_claimed\n" ++
+  "  la t0, vphl_offset; ld t1, 0(t0)\n" ++
+  "  add t3, s2, t1                              # &child[off]\n" ++
+  "  la t4, vphl_claimed\n" ++
+  "  ld t5,  0(t3); sd t5,  0(t4)\n" ++
+  "  ld t5,  8(t3); sd t5,  8(t4)\n" ++
+  "  ld t5, 16(t3); sd t5, 16(t4)\n" ++
+  "  ld t5, 24(t3); sd t5, 24(t4)\n" ++
+  "  # ---- Compute keccak256(parent_rlp) ----\n" ++
+  "  mv a0, s0; mv a1, s1\n" ++
+  "  la a2, vphl_computed\n" ++
+  "  jal ra, block_hash_from_header\n" ++
+  "  # ---- 32-byte compare ----\n" ++
+  "  la t0, vphl_claimed\n" ++
+  "  la t1, vphl_computed\n" ++
+  "  ld t2,  0(t0); ld t3,  0(t1); bne t2, t3, .Lvphl_neq\n" ++
+  "  ld t2,  8(t0); ld t3,  8(t1); bne t2, t3, .Lvphl_neq\n" ++
+  "  ld t2, 16(t0); ld t3, 16(t1); bne t2, t3, .Lvphl_neq\n" ++
+  "  ld t2, 24(t0); ld t3, 24(t1); bne t2, t3, .Lvphl_neq\n" ++
+  "  li t0, 1\n" ++
+  "  sd t0, 0(s4)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lvphl_ret\n" ++
+  ".Lvphl_neq:\n" ++
+  "  sd zero, 0(s4)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lvphl_ret\n" ++
+  ".Lvphl_parse_fail:\n" ++
+  "  li a0, 1\n" ++
+  "  j .Lvphl_ret\n" ++
+  ".Lvphl_size_fail:\n" ++
+  "  li a0, 2\n" ++
+  ".Lvphl_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp); ld s4, 40(sp)\n" ++
+  "  addi sp, sp, 48\n" ++
+  "  ret"
+
+/-- `zisk_validate_parent_hash_link`: probe BuildUnit.
+    Input layout:
+      bytes  0.. 8 : parent_rlp_len
+      bytes  8..16 : child_rlp_len
+      bytes 16..   : parent_rlp || child_rlp
+    Output layout:
+      bytes  0.. 8 : status (0=ok, 1=child parse, 2=size fail)
+      bytes  8..16 : is_valid (1 if links, else 0) -/
+def ziskValidateParentHashLinkPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a7, 0x40000000\n" ++
+  "  ld a1, 8(a7)                # parent_rlp_len\n" ++
+  "  ld a3, 16(a7)               # child_rlp_len\n" ++
+  "  addi a0, a7, 24             # parent_rlp ptr\n" ++
+  "  add a2, a0, a1              # child_rlp ptr = parent_rlp + parent_len\n" ++
+  "  li a4, 0xa0010008           # is_valid out\n" ++
+  "  jal ra, validate_parent_hash_link\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lvphl_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  blockHashFromHeaderFunction ++ "\n" ++
+  validateParentHashLinkFunction ++ "\n" ++
+  ".Lvphl_pdone:"
+
+def ziskValidateParentHashLinkDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  "vphl_offset:\n" ++
+  "  .zero 8\n" ++
+  "vphl_length:\n" ++
+  "  .zero 8\n" ++
+  "vphl_claimed:\n" ++
+  "  .zero 32\n" ++
+  "vphl_computed:\n" ++
+  "  .zero 32"
+
+def ziskValidateParentHashLinkProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskValidateParentHashLinkPrologue
+  dataAsm     := ziskValidateParentHashLinkDataSection
+}
+
 end EvmAsm.Codegen

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **195**
-- ziskemu round-trip scripts: **188** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **196**
+- ziskemu round-trip scripts: **189** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/README.md
+++ b/README.md
@@ -261,8 +261,8 @@ and MPT primitives (`account_decode`, `account_at_address`,
 `mpt_two_leaf_root_indexed`, …), block-body helpers
 (`block_body_decode`, `block_count_transactions`,
 `block_validate_transactions_root_two_tx`,
-`block_hash_from_header`, withdrawal RLP/hash, …),
-and address
+`block_hash_from_header`, `validate_parent_hash_link`,
+withdrawal RLP/hash, …), and address
 derivation (`address_compute_create`, `address_compute_create2`,
 `address_from_pubkey`). The catalogue is tracked under the
 `PR-K*` series in [`PLAN.md`](PLAN.md).

--- a/scripts/codegen-zisk-validate-parent-hash-link-check.sh
+++ b/scripts/codegen-zisk-validate-parent-hash-link-check.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# codegen-zisk-validate-parent-hash-link-check.sh -- PR-K173.
+#
+# Validate that child.parent_hash == keccak256(parent_rlp). Per-step
+# check inside `validate_headers`.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_validate_parent_hash_link ELF"
+lake exe codegen --program zisk_validate_parent_hash_link --halt linux93 \
+  -o gen-out/zisk_validate_parent_hash_link
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <parent_phash_override_or_empty> <make_child_garbage 0/1>
+#                <make_child_short_field0 0/1> <exp_status> <exp_valid>
+#
+# parent_phash_override_or_empty:
+#   ""              -- child.parent_hash = keccak(parent_rlp) (matching)
+#   "<32B hex>"     -- splice an explicit value into child.field[0]
+run_case() {
+  local name="$1" pho="$2" garbage="$3" shortf0="$4" exp_status="$5" exp_valid="$6"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_validate_parent_hash_link_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_validate_parent_hash_link_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+try:
+    from Crypto.Hash import keccak
+    def keccak256(b):
+        h = keccak.new(digest_bits=256); h.update(b); return h.digest()
+except Exception:
+    import sha3
+    def keccak256(b): return sha3.keccak_256(b).digest()
+
+pho = '$pho'
+garbage_child = $garbage == 1
+short_f0 = $shortf0 == 1
+
+# Build a representative parent header (London-ish, 16 fields).
+parent_fields = [
+    b'\\xa1'*32, b'\\xa2'*32, b'\\xa3'*20, b'\\xa4'*32, b'\\xa5'*32,
+    b'\\xa6'*32, b'\\x00'*256, b'', b'\\x83\\xa0\\x00\\x00', b'\\x83\\xff\\xff\\xff',
+    b'\\x82\\x02\\x00', b'\\x83\\x01\\x02\\x03', b'', b'\\xa7'*32, b'\\x00'*8,
+    b'\\x82\\x12\\x34',
+]
+parent_rlp = rlp.encode(parent_fields)
+expected_block_hash = keccak256(parent_rlp)
+
+if pho == '':
+    claimed = expected_block_hash
+else:
+    claimed = bytes.fromhex(pho)
+
+if short_f0:
+    field0 = b'\\xc1' * 16    # 16-byte 'parent_hash' -> wrong size
+else:
+    field0 = claimed
+
+child_fields = [
+    field0,                # field 0 = parent_hash
+    b'\\xb2'*32,             # ommers_hash
+    b'\\xb3'*20,             # beneficiary
+    b'\\xb4'*32,             # state_root
+    b'\\xb5'*32,             # transactions_root
+    b'\\xb6'*32,             # receipts_root
+    b'\\x00'*256,            # logs_bloom
+    b'',                    # difficulty
+    b'\\x83\\xa0\\x00\\x01',  # number = parent.number + 1
+    b'\\x83\\xff\\xff\\xff',  # gas_limit
+    b'\\x82\\x02\\x00',       # gas_used
+    b'\\x83\\x01\\x02\\x04',  # timestamp
+    b'',                    # extra_data
+    b'\\xb7'*32,             # prev_randao
+    b'\\x00'*8,              # nonce
+    b'\\x82\\x12\\x34',       # base_fee
+]
+
+if garbage_child:
+    child_rlp = b'\\x00'       # not a valid RLP list -- parse_fail
+else:
+    child_rlp = rlp.encode(child_fields)
+
+with open(sys.argv[1], 'wb') as f:
+    record = struct.pack('<Q', len(parent_rlp)) + \
+             struct.pack('<Q', len(child_rlp)) + \
+             parent_rlp + child_rlp
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_validate_parent_hash_link.elf \
+    -i "$in_file" -o "$out_file" -n 5000000 \
+    >"$REPO_ROOT/gen-out/zisk_validate_parent_hash_link_${name}.emu.log" 2>&1 || true
+
+  local status_le; status_le="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local valid_le;  valid_le="$( dd if="$out_file" bs=1 skip=8 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local status valid
+  status="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$status_le'))[0])")"
+  valid="$( python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$valid_le'))[0])")"
+
+  if [[ "$status" == "$exp_status" && "$valid" == "$exp_valid" ]]; then
+    printf "  %-30s OK   status=%s valid=%s\n" "$name" "$status" "$valid"
+    return 0
+  else
+    printf "  %-30s FAIL status=%s (exp %s) valid=%s (exp %s)\n" \
+      "$name" "$status" "$exp_status" "$valid" "$exp_valid"
+    return 1
+  fi
+}
+
+WRONG="ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100"
+
+FAILED=0
+# Correct parent_hash -> valid=1
+run_case "match"               ""        0 0 0 1 || FAILED=1
+# Wrong parent_hash spliced in -> valid=0
+run_case "mismatch_wrong_hash" "$WRONG"  0 0 0 0 || FAILED=1
+# Short parent_hash (16 bytes) -> size_fail
+run_case "size_fail_short_f0"  ""        0 1 2 0 || FAILED=1
+# Garbage child RLP -> parse_fail
+run_case "parse_fail_garbage"  ""        1 0 1 0 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: validate_parent_hash_link accepts matching parent_hash, rejects mismatches"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Per-step parent-hash check inside `validate_headers`: given a parent
header and a child header, verify that
`child.parent_hash == keccak256(parent_rlp)`. Composes K20 + K172.

Algorithm:

1. Extract child's field 0 (`parent_hash`) via K20 `rlp_list_nth_item`;
   verify length == 32.
2. Compute `keccak256(parent_rlp)` via K172 `block_hash_from_header`.
3. 32-byte memcmp.

The child's number / state_root / etc. are **not** checked here -- this
is purely the hash-chain step. Composing K173 over a 2-header chain is
the natural N=2 instance of `validate_headers`; the chain version
follows by induction.

## Calling convention

`a0/a1` parent_rlp ptr+len, `a2/a3` child_rlp ptr+len, `a4` u64 out
(is_valid). Returns status in `a0` (0 ok / 1 parse failure / 2 size).

## Test plan

4 ziskemu fixtures against the Python `keccak256` reference:

- [x] `match` -- correct parent_hash spliced into child.field[0]
- [x] `mismatch_wrong_hash` -- explicit wrong hash spliced in
- [x] `size_fail_short_f0` -- 16-byte parent_hash -> status=2
- [x] `parse_fail_garbage` -- malformed child RLP -> status=1

## Stack

Builds on #5966 (PR-K172 `block_hash_from_header`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)