### PR TITLE
feat(stateless): validate_header_pair (PR-K174)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -5191,6 +5191,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_block_validate_transactions_root_two_tx" => some ziskBlockValidateTransactionsRootTwoTxProbeUnit
   | "zisk_block_hash_from_header" => some ziskBlockHashFromHeaderProbeUnit
   | "zisk_validate_parent_hash_link" => some ziskValidateParentHashLinkProbeUnit
+  | "zisk_validate_header_pair" => some ziskValidateHeaderPairProbeUnit
   | "zisk_block_logs_bloom_from_receipts_list" => some ziskBlockLogsBloomFromReceiptsListProbeUnit
   | "zisk_block_validate_logs_bloom" => some ziskBlockValidateLogsBloomProbeUnit
   | "zisk_header_root_is_empty_trie" => some ziskHeaderRootIsEmptyTrieProbeUnit
@@ -5378,6 +5379,7 @@ def knownProgramNames : List String :=
    "zisk_block_validate_transactions_root_two_tx",
    "zisk_block_hash_from_header",
    "zisk_validate_parent_hash_link",
+   "zisk_validate_header_pair",
    "zisk_block_logs_bloom_from_receipts_list",
    "zisk_block_validate_logs_bloom",
    "zisk_header_root_is_empty_trie",

--- a/EvmAsm/Codegen/Programs/Header.lean
+++ b/EvmAsm/Codegen/Programs/Header.lean
@@ -2105,4 +2105,189 @@ def ziskValidateParentHashLinkProbeUnit : BuildUnit := {
   dataAsm     := ziskValidateParentHashLinkDataSection
 }
 
+/-! ## validate_header_pair -- PR-K174
+
+    Per-step pair validator inside `validate_headers`: given a
+    parent header and a child header, verify the four
+    invariants the EELS `validate_header` function checks
+    between consecutive headers:
+
+      1. child.parent_hash == keccak256(parent_rlp)         (K173)
+      2. child.number == parent.number + 1
+      3. child.timestamp > parent.timestamp
+      4. check_gas_limit(child.gas_limit, parent.gas_limit) == 0
+         (gas_limit >= 5000 and |new - parent| < parent/1024)
+
+    Per-header field-shape checks (`validate_header_basic`,
+    `validate_header_post_merge`, etc.) live in their own
+    helpers; this primitive is the **pair** check only.
+
+    Calling convention:
+      a0 (input)  : parent_rlp ptr
+      a1 (input)  : parent_rlp byte length
+      a2 (input)  : child_rlp ptr
+      a3 (input)  : child_rlp byte length
+      a4 (input)  : u64 out (is_valid: 1 if all 4 invariants hold)
+      ra (input)  : return
+      a0 (output) :
+        0 : success -- predicate written
+        1 : child RLP parse failure
+        2 : child.parent_hash length != 32
+        3 : parent number/timestamp/gas_limit field parse failure
+        4 : child number/timestamp/gas_limit field parse failure -/
+def validateHeaderPairFunction : String :=
+  "validate_header_pair:\n" ++
+  "  addi sp, sp, -48\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp); sd s4, 40(sp)\n" ++
+  "  mv s0, a0                   # parent_rlp ptr\n" ++
+  "  mv s1, a1                   # parent_rlp len\n" ++
+  "  mv s2, a2                   # child_rlp ptr\n" ++
+  "  mv s3, a3                   # child_rlp len\n" ++
+  "  mv s4, a4                   # is_valid out\n" ++
+  "  sd zero, 0(s4)\n" ++
+  "  # ---- (1) Parent-hash link ----\n" ++
+  "  mv a0, s0; mv a1, s1\n" ++
+  "  mv a2, s2; mv a3, s3\n" ++
+  "  la a4, vhp_link_valid\n" ++
+  "  jal ra, validate_parent_hash_link\n" ++
+  "  beqz a0, .Lvhp_link_ok\n" ++
+  "  li t0, 1\n" ++
+  "  beq a0, t0, .Lvhp_child_parse_fail\n" ++
+  "  j .Lvhp_size_fail\n" ++
+  ".Lvhp_link_ok:\n" ++
+  "  la t0, vhp_link_valid; ld t1, 0(t0)\n" ++
+  "  beqz t1, .Lvhp_pred_false\n" ++
+  "  # ---- (2/3/4) Extract parent number/timestamp/gas_limit ----\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 8\n" ++
+  "  la a3, vhp_parent_number\n" ++
+  "  jal ra, rlp_field_to_u64\n" ++
+  "  bnez a0, .Lvhp_parent_field_fail\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 11\n" ++
+  "  la a3, vhp_parent_timestamp\n" ++
+  "  jal ra, rlp_field_to_u64\n" ++
+  "  bnez a0, .Lvhp_parent_field_fail\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 9\n" ++
+  "  la a3, vhp_parent_gas_limit\n" ++
+  "  jal ra, rlp_field_to_u64\n" ++
+  "  bnez a0, .Lvhp_parent_field_fail\n" ++
+  "  # ---- Extract child number/timestamp/gas_limit ----\n" ++
+  "  mv a0, s2; mv a1, s3; li a2, 8\n" ++
+  "  la a3, vhp_child_number\n" ++
+  "  jal ra, rlp_field_to_u64\n" ++
+  "  bnez a0, .Lvhp_child_field_fail\n" ++
+  "  mv a0, s2; mv a1, s3; li a2, 11\n" ++
+  "  la a3, vhp_child_timestamp\n" ++
+  "  jal ra, rlp_field_to_u64\n" ++
+  "  bnez a0, .Lvhp_child_field_fail\n" ++
+  "  mv a0, s2; mv a1, s3; li a2, 9\n" ++
+  "  la a3, vhp_child_gas_limit\n" ++
+  "  jal ra, rlp_field_to_u64\n" ++
+  "  bnez a0, .Lvhp_child_field_fail\n" ++
+  "  # (2) child.number == parent.number + 1\n" ++
+  "  la t0, vhp_parent_number; ld t1, 0(t0)\n" ++
+  "  la t0, vhp_child_number;  ld t2, 0(t0)\n" ++
+  "  addi t1, t1, 1\n" ++
+  "  bne t1, t2, .Lvhp_pred_false\n" ++
+  "  # (3) child.timestamp > parent.timestamp\n" ++
+  "  la t0, vhp_parent_timestamp; ld t1, 0(t0)\n" ++
+  "  la t0, vhp_child_timestamp;  ld t2, 0(t0)\n" ++
+  "  bgeu t1, t2, .Lvhp_pred_false\n" ++
+  "  # (4) check_gas_limit(child, parent) == 0\n" ++
+  "  la t0, vhp_child_gas_limit;  ld a0, 0(t0)\n" ++
+  "  la t0, vhp_parent_gas_limit; ld a1, 0(t0)\n" ++
+  "  jal ra, check_gas_limit\n" ++
+  "  bnez a0, .Lvhp_pred_false\n" ++
+  "  li t0, 1\n" ++
+  "  sd t0, 0(s4)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lvhp_ret\n" ++
+  ".Lvhp_pred_false:\n" ++
+  "  sd zero, 0(s4)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lvhp_ret\n" ++
+  ".Lvhp_child_parse_fail:\n" ++
+  "  li a0, 1\n" ++
+  "  j .Lvhp_ret\n" ++
+  ".Lvhp_size_fail:\n" ++
+  "  li a0, 2\n" ++
+  "  j .Lvhp_ret\n" ++
+  ".Lvhp_parent_field_fail:\n" ++
+  "  li a0, 3\n" ++
+  "  j .Lvhp_ret\n" ++
+  ".Lvhp_child_field_fail:\n" ++
+  "  li a0, 4\n" ++
+  ".Lvhp_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp); ld s4, 40(sp)\n" ++
+  "  addi sp, sp, 48\n" ++
+  "  ret"
+
+/-- `zisk_validate_header_pair`: probe BuildUnit.
+    Input layout:
+      bytes  0.. 8 : parent_rlp_len
+      bytes  8..16 : child_rlp_len
+      bytes 16..   : parent_rlp || child_rlp
+    Output layout:
+      bytes  0.. 8 : status code (0..4)
+      bytes  8..16 : is_valid (1 if all four invariants hold) -/
+def ziskValidateHeaderPairPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a7, 0x40000000\n" ++
+  "  ld a1, 8(a7)                # parent_rlp_len\n" ++
+  "  ld a3, 16(a7)               # child_rlp_len\n" ++
+  "  addi a0, a7, 24             # parent_rlp ptr\n" ++
+  "  add a2, a0, a1              # child_rlp ptr\n" ++
+  "  li a4, 0xa0010008           # is_valid out\n" ++
+  "  jal ra, validate_header_pair\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lvhp_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpFieldToU64Function ++ "\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  blockHashFromHeaderFunction ++ "\n" ++
+  validateParentHashLinkFunction ++ "\n" ++
+  checkGasLimitFunction ++ "\n" ++
+  validateHeaderPairFunction ++ "\n" ++
+  ".Lvhp_pdone:"
+
+def ziskValidateHeaderPairDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  "rfu_offset:\n" ++
+  "  .zero 8\n" ++
+  "rfu_length:\n" ++
+  "  .zero 8\n" ++
+  "vphl_offset:\n" ++
+  "  .zero 8\n" ++
+  "vphl_length:\n" ++
+  "  .zero 8\n" ++
+  "vphl_claimed:\n" ++
+  "  .zero 32\n" ++
+  "vphl_computed:\n" ++
+  "  .zero 32\n" ++
+  "vhp_link_valid:\n" ++
+  "  .zero 8\n" ++
+  "vhp_parent_number:\n" ++
+  "  .zero 8\n" ++
+  "vhp_parent_timestamp:\n" ++
+  "  .zero 8\n" ++
+  "vhp_parent_gas_limit:\n" ++
+  "  .zero 8\n" ++
+  "vhp_child_number:\n" ++
+  "  .zero 8\n" ++
+  "vhp_child_timestamp:\n" ++
+  "  .zero 8\n" ++
+  "vhp_child_gas_limit:\n" ++
+  "  .zero 8"
+
+def ziskValidateHeaderPairProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskValidateHeaderPairPrologue
+  dataAsm     := ziskValidateHeaderPairDataSection
+}
+
 end EvmAsm.Codegen

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **196**
-- ziskemu round-trip scripts: **189** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **197**
+- ziskemu round-trip scripts: **190** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ and MPT primitives (`account_decode`, `account_at_address`,
 (`block_body_decode`, `block_count_transactions`,
 `block_validate_transactions_root_two_tx`,
 `block_hash_from_header`, `validate_parent_hash_link`,
-withdrawal RLP/hash, …), and address
+`validate_header_pair`, withdrawal RLP/hash, …), and address
 derivation (`address_compute_create`, `address_compute_create2`,
 `address_from_pubkey`). The catalogue is tracked under the
 `PR-K*` series in [`PLAN.md`](PLAN.md).

--- a/scripts/codegen-zisk-validate-header-pair-check.sh
+++ b/scripts/codegen-zisk-validate-header-pair-check.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# codegen-zisk-validate-header-pair-check.sh -- PR-K174.
+#
+# Full pair validator: parent_hash link + number+1 + timestamp > +
+# gas_limit ratio. Composes K173 + rlp_field_to_u64 + check_gas_limit.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_validate_header_pair ELF"
+lake exe codegen --program zisk_validate_header_pair --halt linux93 \
+  -o gen-out/zisk_validate_header_pair
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <parent_num> <parent_ts> <parent_gl>
+#                 <child_num>  <child_ts>  <child_gl>
+#                 <wrong_phash 0/1>
+#                 <exp_status> <exp_valid>
+run_case() {
+  local name="$1" pn="$2" pt="$3" pg="$4" cn="$5" ct="$6" cg="$7" wrong="$8" exp_status="$9" exp_valid="${10}"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_validate_header_pair_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_validate_header_pair_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+try:
+    from Crypto.Hash import keccak
+    def keccak256(b):
+        h = keccak.new(digest_bits=256); h.update(b); return h.digest()
+except Exception:
+    import sha3
+    def keccak256(b): return sha3.keccak_256(b).digest()
+
+def u_be(n):
+    if n == 0: return b''
+    nb = n.bit_length()
+    return n.to_bytes((nb + 7) // 8, 'big')
+
+pn, pt, pg = $pn, $pt, $pg
+cn, ct, cg = $cn, $ct, $cg
+wrong_phash = $wrong == 1
+
+parent_fields = [
+    b'\\xa1'*32, b'\\xa2'*32, b'\\xa3'*20, b'\\xa4'*32, b'\\xa5'*32,
+    b'\\xa6'*32, b'\\x00'*256, b'', u_be(pn), u_be(pg),
+    b'\\x82\\x02\\x00', u_be(pt), b'', b'\\xa7'*32, b'\\x00'*8,
+    b'\\x82\\x12\\x34',
+]
+parent_rlp = rlp.encode(parent_fields)
+correct_phash = keccak256(parent_rlp)
+
+if wrong_phash:
+    phash = bytes([b ^ 0xff for b in correct_phash])
+else:
+    phash = correct_phash
+
+child_fields = [
+    phash, b'\\xb2'*32, b'\\xb3'*20, b'\\xb4'*32, b'\\xb5'*32,
+    b'\\xb6'*32, b'\\x00'*256, b'', u_be(cn), u_be(cg),
+    b'\\x82\\x02\\x00', u_be(ct), b'', b'\\xb7'*32, b'\\x00'*8,
+    b'\\x82\\x12\\x34',
+]
+child_rlp = rlp.encode(child_fields)
+
+with open(sys.argv[1], 'wb') as f:
+    record = struct.pack('<Q', len(parent_rlp)) + \
+             struct.pack('<Q', len(child_rlp)) + \
+             parent_rlp + child_rlp
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_validate_header_pair.elf \
+    -i "$in_file" -o "$out_file" -n 5000000 \
+    >"$REPO_ROOT/gen-out/zisk_validate_header_pair_${name}.emu.log" 2>&1 || true
+
+  local status_le; status_le="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local valid_le;  valid_le="$( dd if="$out_file" bs=1 skip=8 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local status valid
+  status="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$status_le'))[0])")"
+  valid="$( python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$valid_le'))[0])")"
+
+  if [[ "$status" == "$exp_status" && "$valid" == "$exp_valid" ]]; then
+    printf "  %-36s OK   status=%s valid=%s\n" "$name" "$status" "$valid"
+    return 0
+  else
+    printf "  %-36s FAIL status=%s (exp %s) valid=%s (exp %s)\n" \
+      "$name" "$status" "$exp_status" "$valid" "$exp_valid"
+    return 1
+  fi
+}
+
+FAILED=0
+# All 4 invariants hold.
+run_case "match_all_invariants" \
+   100  1000  30000000   101  1001  30000000   0   0 1 || FAILED=1
+# Number off-by-one (child.number == parent.number + 2)
+run_case "fail_number_skip" \
+   100  1000  30000000   102  1001  30000000   0   0 0 || FAILED=1
+# Timestamp not strictly increasing
+run_case "fail_timestamp_equal" \
+   100  1000  30000000   101  1000  30000000   0   0 0 || FAILED=1
+# Gas-limit too far (> parent/1024)
+run_case "fail_gas_limit_too_far" \
+   100  1000  30000000   101  1001  60000000   0   0 0 || FAILED=1
+# Wrong parent_hash spliced in
+run_case "fail_wrong_parent_hash" \
+   100  1000  30000000   101  1001  30000000   1   0 0 || FAILED=1
+# Edge: gas_limit just inside the +1/1024 window (parent/1024 = 29296,
+# delta = 29295 < 29296 is allowed).
+run_case "edge_gas_limit_within_window" \
+   100  1000  30000000   101  1001  30029295   0   0 1 || FAILED=1
+# Edge: gas_limit at +1/1024 boundary (delta = 29296 = /1024 -> rejected
+# by `>=` compare in check_gas_limit).
+run_case "edge_gas_limit_at_boundary" \
+   100  1000  30000000   101  1001  30029296   0   0 0 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: validate_header_pair enforces all 4 invariants jointly"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Per-step pair validator inside `validate_headers`: verifies the four
invariants that must hold between two consecutive headers in the
chain, in one shot:

1. `child.parent_hash == keccak256(parent_rlp)` (via K173)
2. `child.number == parent.number + 1`
3. `child.timestamp > parent.timestamp`
4. `check_gas_limit(child.gas_limit, parent.gas_limit) == 0`
   -- enforces `gas_limit >= 5000` and `|new - parent| < parent/1024`

Per-header field-shape checks (`validate_header_basic`,
`validate_header_post_merge`, etc.) remain in their own helpers --
this primitive is the **pair** check only. Iterating K174 over a
header chain is the natural shape of `validate_headers`.

## Calling convention

`a0/a1` parent_rlp ptr+len, `a2/a3` child_rlp ptr+len, `a4` u64 out
(is_valid). Returns status in `a0`: 0 ok / 1 child parse failure /
2 child.parent_hash size != 32 / 3 parent field-extract failure /
4 child field-extract failure.

## Test plan

7 ziskemu fixtures cover the positive case, each invariant breaking
individually, and the ±1/1024 gas_limit window boundary:

- [x] `match_all_invariants` -- all four hold -> valid=1
- [x] `fail_number_skip` -- child.number = parent.number + 2 -> valid=0
- [x] `fail_timestamp_equal` -- timestamps equal -> valid=0
- [x] `fail_gas_limit_too_far` -- delta > /1024 -> valid=0
- [x] `fail_wrong_parent_hash` -- bit-flipped parent_hash -> valid=0
- [x] `edge_gas_limit_within_window` -- delta = /1024 - 1 -> valid=1
- [x] `edge_gas_limit_at_boundary` -- delta = /1024 -> valid=0

## Stack

Builds on #5968 (PR-K173 `validate_parent_hash_link`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)