### PR TITLE
feat(stateless): validate_header_chain (PR-K175)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -5192,6 +5192,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_block_hash_from_header" => some ziskBlockHashFromHeaderProbeUnit
   | "zisk_validate_parent_hash_link" => some ziskValidateParentHashLinkProbeUnit
   | "zisk_validate_header_pair" => some ziskValidateHeaderPairProbeUnit
+  | "zisk_validate_header_chain" => some ziskValidateHeaderChainProbeUnit
   | "zisk_block_logs_bloom_from_receipts_list" => some ziskBlockLogsBloomFromReceiptsListProbeUnit
   | "zisk_block_validate_logs_bloom" => some ziskBlockValidateLogsBloomProbeUnit
   | "zisk_header_root_is_empty_trie" => some ziskHeaderRootIsEmptyTrieProbeUnit
@@ -5380,6 +5381,7 @@ def knownProgramNames : List String :=
    "zisk_block_hash_from_header",
    "zisk_validate_parent_hash_link",
    "zisk_validate_header_pair",
+   "zisk_validate_header_chain",
    "zisk_block_logs_bloom_from_receipts_list",
    "zisk_block_validate_logs_bloom",
    "zisk_header_root_is_empty_trie",

--- a/EvmAsm/Codegen/Programs/Header.lean
+++ b/EvmAsm/Codegen/Programs/Header.lean
@@ -2290,4 +2290,175 @@ def ziskValidateHeaderPairProbeUnit : BuildUnit := {
   dataAsm     := ziskValidateHeaderPairDataSection
 }
 
+/-! ## validate_header_chain -- PR-K175
+
+    Iterate `validate_header_pair` (K174) over N consecutive
+    headers (parent, child) and verify every link in the
+    chain. This is the EELS `validate_headers` function: walk
+    the witness list and assert each successive pair of
+    headers satisfies the four pair invariants:
+
+      1. child.parent_hash == keccak256(parent)
+      2. child.number == parent.number + 1
+      3. child.timestamp > parent.timestamp
+      4. check_gas_limit(child, parent) == 0
+
+    Stops on the first failing pair and reports the failing
+    index. Empty (N == 0) and singleton (N == 1) chains are
+    accepted vacuously -- there is no pair to check.
+
+    Header layout (one length-prefix table + flat byte blob):
+      headers[0] starts at headers_ptr + offsets[0]
+      headers[i] has length lengths[i]
+      offsets[i+1] = offsets[i] + lengths[i]
+    The caller supplies `lengths` (a `u64[N]`); offsets are
+    computed inline.
+
+    Calling convention:
+      a0 (input)  : header count N
+      a1 (input)  : lengths ptr (u64[N], byte lengths)
+      a2 (input)  : headers ptr (flat concatenated RLPs)
+      a3 (input)  : u64 out (is_valid: 1 if every link OK)
+      a4 (input)  : u64 out (first_bad_index: index of the
+                    failing pair; 0 if all pairs pass)
+      ra (input)  : return
+      a0 (output) :
+        0 : success -- predicate written
+        nonzero : propagated status from validate_header_pair
+                  for the first failing pair (1..4) -/
+def validateHeaderChainFunction : String :=
+  "validate_header_chain:\n" ++
+  "  addi sp, sp, -64\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp)\n" ++
+  "  mv s0, a0                   # N\n" ++
+  "  mv s1, a1                   # lengths ptr\n" ++
+  "  mv s2, a2                   # headers ptr\n" ++
+  "  mv s3, a3                   # is_valid out\n" ++
+  "  mv s4, a4                   # first_bad_index out\n" ++
+  "  sd zero, 0(s3)\n" ++
+  "  sd zero, 0(s4)\n" ++
+  "  # Vacuous-true for N == 0 or N == 1.\n" ++
+  "  li t0, 2\n" ++
+  "  bltu s0, t0, .Lvhc_vacuous\n" ++
+  "  # parent ptr/len start (i = 0)\n" ++
+  "  mv s5, s2                   # current parent ptr\n" ++
+  "  li s6, 0                    # current index i\n" ++
+  ".Lvhc_loop:\n" ++
+  "  # Pre-compute child index = i + 1\n" ++
+  "  addi t0, s6, 1\n" ++
+  "  beq t0, s0, .Lvhc_done       # i+1 == N -> finished\n" ++
+  "  # parent_len = lengths[i], child_len = lengths[i+1]\n" ++
+  "  slli t1, s6, 3\n" ++
+  "  add t1, s1, t1                              # &lengths[i]\n" ++
+  "  ld t2, 0(t1)                                # parent_len\n" ++
+  "  ld t3, 8(t1)                                # child_len\n" ++
+  "  add t4, s5, t2                              # child_ptr = parent_ptr + parent_len\n" ++
+  "  mv a0, s5; mv a1, t2\n" ++
+  "  mv a2, t4; mv a3, t3\n" ++
+  "  la a4, vhc_pair_valid\n" ++
+  "  jal ra, validate_header_pair\n" ++
+  "  bnez a0, .Lvhc_pair_status_fail\n" ++
+  "  la t0, vhc_pair_valid; ld t1, 0(t0)\n" ++
+  "  beqz t1, .Lvhc_pred_false\n" ++
+  "  # Advance: parent <- child\n" ++
+  "  slli t1, s6, 3\n" ++
+  "  add t1, s1, t1\n" ++
+  "  ld t2, 0(t1)                                # parent_len (just used)\n" ++
+  "  add s5, s5, t2                              # parent_ptr += parent_len\n" ++
+  "  addi s6, s6, 1\n" ++
+  "  j .Lvhc_loop\n" ++
+  ".Lvhc_done:\n" ++
+  ".Lvhc_vacuous:\n" ++
+  "  li t0, 1\n" ++
+  "  sd t0, 0(s3)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lvhc_ret\n" ++
+  ".Lvhc_pred_false:\n" ++
+  "  sd zero, 0(s3)\n" ++
+  "  sd s6, 0(s4)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lvhc_ret\n" ++
+  ".Lvhc_pair_status_fail:\n" ++
+  "  sd s6, 0(s4)\n" ++
+  ".Lvhc_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp)\n" ++
+  "  addi sp, sp, 64\n" ++
+  "  ret"
+
+/-- `zisk_validate_header_chain`: probe BuildUnit.
+    Input layout:
+      bytes  0..  8 : N (header count)
+      bytes  8..  8 + 8*N : lengths (u64[N])
+      bytes  8 + 8*N .. : concatenated header RLPs
+    Output layout:
+      bytes  0.. 8 : status code
+      bytes  8..16 : is_valid (1 if every link OK)
+      bytes 16..24 : first_bad_index -/
+def ziskValidateHeaderChainPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a7, 0x40000000\n" ++
+  "  ld a0, 8(a7)                # N\n" ++
+  "  addi a1, a7, 16             # lengths ptr\n" ++
+  "  slli t0, a0, 3              # 8*N\n" ++
+  "  add a2, a1, t0              # headers ptr\n" ++
+  "  li a3, 0xa0010008           # is_valid out\n" ++
+  "  li a4, 0xa0010010           # first_bad_index out\n" ++
+  "  jal ra, validate_header_chain\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lvhc_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpFieldToU64Function ++ "\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  blockHashFromHeaderFunction ++ "\n" ++
+  validateParentHashLinkFunction ++ "\n" ++
+  checkGasLimitFunction ++ "\n" ++
+  validateHeaderPairFunction ++ "\n" ++
+  validateHeaderChainFunction ++ "\n" ++
+  ".Lvhc_pdone:"
+
+def ziskValidateHeaderChainDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  "rfu_offset:\n" ++
+  "  .zero 8\n" ++
+  "rfu_length:\n" ++
+  "  .zero 8\n" ++
+  "vphl_offset:\n" ++
+  "  .zero 8\n" ++
+  "vphl_length:\n" ++
+  "  .zero 8\n" ++
+  "vphl_claimed:\n" ++
+  "  .zero 32\n" ++
+  "vphl_computed:\n" ++
+  "  .zero 32\n" ++
+  "vhp_link_valid:\n" ++
+  "  .zero 8\n" ++
+  "vhp_parent_number:\n" ++
+  "  .zero 8\n" ++
+  "vhp_parent_timestamp:\n" ++
+  "  .zero 8\n" ++
+  "vhp_parent_gas_limit:\n" ++
+  "  .zero 8\n" ++
+  "vhp_child_number:\n" ++
+  "  .zero 8\n" ++
+  "vhp_child_timestamp:\n" ++
+  "  .zero 8\n" ++
+  "vhp_child_gas_limit:\n" ++
+  "  .zero 8\n" ++
+  "vhc_pair_valid:\n" ++
+  "  .zero 8"
+
+def ziskValidateHeaderChainProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskValidateHeaderChainPrologue
+  dataAsm     := ziskValidateHeaderChainDataSection
+}
+
 end EvmAsm.Codegen

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **197**
-- ziskemu round-trip scripts: **190** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **198**
+- ziskemu round-trip scripts: **191** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/README.md
+++ b/README.md
@@ -262,7 +262,8 @@ and MPT primitives (`account_decode`, `account_at_address`,
 (`block_body_decode`, `block_count_transactions`,
 `block_validate_transactions_root_two_tx`,
 `block_hash_from_header`, `validate_parent_hash_link`,
-`validate_header_pair`, withdrawal RLP/hash, …), and address
+`validate_header_pair`, `validate_header_chain`,
+withdrawal RLP/hash, …), and address
 derivation (`address_compute_create`, `address_compute_create2`,
 `address_from_pubkey`). The catalogue is tracked under the
 `PR-K*` series in [`PLAN.md`](PLAN.md).

--- a/scripts/codegen-zisk-validate-header-chain-check.sh
+++ b/scripts/codegen-zisk-validate-header-chain-check.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# codegen-zisk-validate-header-chain-check.sh -- PR-K175.
+#
+# Iterate `validate_header_pair` over an N-element header chain.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_validate_header_chain ELF"
+lake exe codegen --program zisk_validate_header_chain --halt linux93 \
+  -o gen-out/zisk_validate_header_chain
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <build_chain_py_expr_yielding_list_of_header_rlps>
+#         <exp_status> <exp_valid> <exp_first_bad>
+run_case() {
+  local name="$1" build_expr="$2" exp_status="$3" exp_valid="$4" exp_bad="$5"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_validate_header_chain_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_validate_header_chain_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+try:
+    from Crypto.Hash import keccak
+    def keccak256(b):
+        h = keccak.new(digest_bits=256); h.update(b); return h.digest()
+except Exception:
+    import sha3
+    def keccak256(b): return sha3.keccak_256(b).digest()
+
+def u_be(n):
+    if n == 0: return b''
+    return n.to_bytes((n.bit_length() + 7) // 8, 'big')
+
+def make_header(parent_hash, num, ts, gas_limit, salt=0):
+    salt_b = salt.to_bytes(2, 'big') if salt else b''
+    return rlp.encode([
+        parent_hash, (b'\\xb2' if salt == 0 else (salt & 0xff).to_bytes(1,'big')*32),
+        b'\\xb3'*20, b'\\xb4'*32, b'\\xb5'*32, b'\\xb6'*32, b'\\x00'*256,
+        b'', u_be(num), u_be(gas_limit), b'\\x82\\x02\\x00', u_be(ts),
+        b'', b'\\xb7'*32, b'\\x00'*8, b'\\x82\\x12\\x34',
+    ])
+
+# Build a chain: each header's parent_hash = keccak256(prev_rlp).
+# The build_expr is a Python expression returning a list of
+# (number, timestamp, gas_limit, override_parent_hash_or_None)
+# tuples; the script links them into a chain.
+spec = $build_expr
+headers = []
+prev_hash = b'\\x00'*32
+for i, (n, ts, gl, override) in enumerate(spec):
+    ph = override if override is not None else prev_hash
+    h = make_header(ph, n, ts, gl, salt=i+1)
+    headers.append(h)
+    prev_hash = keccak256(h)
+
+N = len(headers)
+lengths = b''.join(struct.pack('<Q', len(h)) for h in headers)
+flat = b''.join(headers)
+
+with open(sys.argv[1], 'wb') as f:
+    record = struct.pack('<Q', N) + lengths + flat
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_validate_header_chain.elf \
+    -i "$in_file" -o "$out_file" -n 20000000 \
+    >"$REPO_ROOT/gen-out/zisk_validate_header_chain_${name}.emu.log" 2>&1 || true
+
+  local status_le; status_le="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local valid_le;  valid_le="$( dd if="$out_file" bs=1 skip=8  count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local bad_le;    bad_le="$(   dd if="$out_file" bs=1 skip=16 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local status valid bad
+  status="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$status_le'))[0])")"
+  valid="$( python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$valid_le'))[0])")"
+  bad="$(   python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$bad_le'))[0])")"
+
+  if [[ "$status" == "$exp_status" && "$valid" == "$exp_valid" && "$bad" == "$exp_bad" ]]; then
+    printf "  %-32s OK   status=%s valid=%s bad=%s\n" "$name" "$status" "$valid" "$bad"
+    return 0
+  else
+    printf "  %-32s FAIL status=%s/exp%s valid=%s/exp%s bad=%s/exp%s\n" \
+      "$name" "$status" "$exp_status" "$valid" "$exp_valid" "$bad" "$exp_bad"
+    return 1
+  fi
+}
+
+FAILED=0
+# Vacuous: N == 0
+run_case "vacuous_empty" "[]" 0 1 0 || FAILED=1
+# Vacuous: N == 1
+run_case "vacuous_single" "[(100, 1000, 30000000, None)]" 0 1 0 || FAILED=1
+# 2-element chain, all OK
+run_case "two_link_ok" "[
+    (100, 1000, 30000000, None),
+    (101, 1001, 30000000, None),
+]" 0 1 0 || FAILED=1
+# 3-element chain, all OK
+run_case "three_link_ok" "[
+    (100, 1000, 30000000, None),
+    (101, 1001, 30000000, None),
+    (102, 1002, 30000000, None),
+]" 0 1 0 || FAILED=1
+# 4-element chain, all OK
+run_case "four_link_ok" "[
+    (100, 1000, 30000000, None),
+    (101, 1001, 30000000, None),
+    (102, 1002, 30000000, None),
+    (103, 1003, 30000000, None),
+]" 0 1 0 || FAILED=1
+# 3 headers, bad number on the second-to-third link (index 1)
+run_case "fail_at_index_1_number" "[
+    (100, 1000, 30000000, None),
+    (101, 1001, 30000000, None),
+    (103, 1002, 30000000, None),
+]" 0 0 1 || FAILED=1
+# 3 headers, broken parent_hash on the second link (index 1):
+#   override the 3rd header's parent_hash to something wrong.
+run_case "fail_at_index_1_phash" "[
+    (100, 1000, 30000000, None),
+    (101, 1001, 30000000, None),
+    (102, 1002, 30000000, b'\\xff'*32),
+]" 0 0 1 || FAILED=1
+# 3 headers, broken parent_hash on the first link (index 0)
+run_case "fail_at_index_0_phash" "[
+    (100, 1000, 30000000, None),
+    (101, 1001, 30000000, b'\\xff'*32),
+    (102, 1002, 30000000, None),
+]" 0 0 0 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: validate_header_chain walks N-element chains and reports the failing index"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Iterate `validate_header_pair` (K174) over N consecutive headers and
verify every link in the chain -- the EELS `validate_headers` shape.
Reports the **first** failing index back to the caller; vacuous-true
on `N == 0` and `N == 1`.

## Input layout

A length-prefix table + flat byte blob:

```
bytes  0..  8 : N (u64 header count)
bytes  8..  8 + 8*N : lengths (u64[N], header byte lengths)
bytes  8 + 8*N .. : concatenated header RLPs
```

The function walks `parent <- child` by advancing
`parent_ptr += parent_len`, calling
`validate_header_pair(parent, child)` for each consecutive pair.

## Test plan

8 ziskemu fixtures:

- [x] `vacuous_empty` -- N=0 -> valid=1
- [x] `vacuous_single` -- N=1 -> valid=1
- [x] `two_link_ok` -- N=2, valid chain
- [x] `three_link_ok` -- N=3, valid chain
- [x] `four_link_ok` -- N=4, valid chain
- [x] `fail_at_index_1_number` -- N=3, number-skip at link 1 -> bad=1
- [x] `fail_at_index_1_phash` -- N=3, broken parent_hash at link 1 -> bad=1
- [x] `fail_at_index_0_phash` -- N=3, broken parent_hash at link 0 -> bad=0

## Stack

Builds on #5969 (PR-K174 `validate_header_pair`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)