### PR TITLE
feat(stateless): block_validate_2tx_full (PR-K176)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -5193,6 +5193,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_validate_parent_hash_link" => some ziskValidateParentHashLinkProbeUnit
   | "zisk_validate_header_pair" => some ziskValidateHeaderPairProbeUnit
   | "zisk_validate_header_chain" => some ziskValidateHeaderChainProbeUnit
+  | "zisk_block_validate_2tx_full" => some ziskBlockValidate2txFullProbeUnit
   | "zisk_block_logs_bloom_from_receipts_list" => some ziskBlockLogsBloomFromReceiptsListProbeUnit
   | "zisk_block_validate_logs_bloom" => some ziskBlockValidateLogsBloomProbeUnit
   | "zisk_header_root_is_empty_trie" => some ziskHeaderRootIsEmptyTrieProbeUnit
@@ -5382,6 +5383,7 @@ def knownProgramNames : List String :=
    "zisk_validate_parent_hash_link",
    "zisk_validate_header_pair",
    "zisk_validate_header_chain",
+   "zisk_block_validate_2tx_full",
    "zisk_block_logs_bloom_from_receipts_list",
    "zisk_block_validate_logs_bloom",
    "zisk_header_root_is_empty_trie",

--- a/EvmAsm/Codegen/Programs/Block.lean
+++ b/EvmAsm/Codegen/Programs/Block.lean
@@ -30,6 +30,8 @@ import EvmAsm.Codegen.Layout
 import EvmAsm.Codegen.Programs.HashBridge
 import EvmAsm.Codegen.Programs.RlpRead
 import EvmAsm.Codegen.Programs.Tx
+import EvmAsm.Codegen.Programs.Mpt
+import EvmAsm.Codegen.Programs.Header
 
 namespace EvmAsm.Codegen
 
@@ -1769,6 +1771,256 @@ def ziskBlockComputeTxHashesProbeUnit : BuildUnit := {
   body        := NOP
   prologueAsm := ziskBlockComputeTxHashesPrologue
   dataAsm     := ziskBlockComputeTxHashesDataSection
+}
+
+/-! ## block_validate_2tx_full -- PR-K176
+
+    Full validation of a 2-tx Ethereum block: combines the
+    per-header chain check (K174) with the
+    `transactions_root` MPT match (K171) into a single
+    end-to-end predicate. Calling this on `(parent_rlp,
+    header_rlp, tx0, tx1)` returns `is_valid = 1` iff both:
+
+      1. validate_header_pair(parent, header) accepts:
+         child.parent_hash == keccak(parent),
+         child.number == parent.number + 1,
+         child.timestamp > parent.timestamp,
+         check_gas_limit(child, parent) == 0
+      2. block_validate_transactions_root_two_tx(header, tx0, tx1)
+         accepts: header.transactions_root matches the trie
+         root of the two-tx MPT.
+
+    This composition is the per-block invariant for a 2-tx block
+    in the chain (modulo the body-side checks ECRECOVER / EVM
+    execution still gates).
+
+    Calling convention:
+      a0 (input)  : parent_rlp ptr
+      a1 (input)  : parent_rlp byte length
+      a2 (input)  : header_rlp ptr  (the child header)
+      a3 (input)  : header_rlp byte length
+      a4 (input)  : tx0 ptr
+      a5 (input)  : tx0 byte length
+      a6 (input)  : tx1 ptr
+      a7 (input)  : tx1 byte length
+      ra (input)  : return
+      (out via shadow regs)  : caller passes the is_valid u64
+                                output pointer via memory; see
+                                prologue for the wiring.
+      a0 (output) :
+        0 : success -- predicate written
+        nonzero : propagated status code:
+          1   header-pair child parse failure
+          2   header-pair child.parent_hash size mismatch
+          3   header-pair parent field-extract failure
+          4   header-pair child field-extract failure
+          11  tx-root header parse failure
+          12  tx-root header.transactions_root size mismatch
+
+    The is_valid output pointer is read from `bv2f_out_ptr`
+    (an indirection slot in `.data`) to keep the calling
+    convention within the 8 a-register limit. The prologue
+    initializes this slot to `0xa0010008`. -/
+def blockValidate2txFullFunction : String :=
+  "block_validate_2tx_full:\n" ++
+  "  addi sp, sp, -80\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp); sd s7, 64(sp)\n" ++
+  "  sd s8, 72(sp)\n" ++
+  "  mv s0, a0; mv s1, a1                # parent\n" ++
+  "  mv s2, a2; mv s3, a3                # header (child)\n" ++
+  "  mv s4, a4; mv s5, a5                # tx0\n" ++
+  "  mv s6, a6; mv s7, a7                # tx1\n" ++
+  "  la t0, bv2f_out_ptr; ld s8, 0(t0)   # is_valid u64 out\n" ++
+  "  sd zero, 0(s8)\n" ++
+  "  # ---- (A) Header pair check ----\n" ++
+  "  mv a0, s0; mv a1, s1\n" ++
+  "  mv a2, s2; mv a3, s3\n" ++
+  "  la a4, bv2f_pair_valid\n" ++
+  "  jal ra, validate_header_pair\n" ++
+  "  beqz a0, .Lbv2f_pair_status_ok\n" ++
+  "  # Propagate pair status (1..4) to caller; keep same numbering.\n" ++
+  "  j .Lbv2f_ret\n" ++
+  ".Lbv2f_pair_status_ok:\n" ++
+  "  la t0, bv2f_pair_valid; ld t1, 0(t0)\n" ++
+  "  beqz t1, .Lbv2f_pred_false\n" ++
+  "  # ---- (B) Transactions-root MPT check ----\n" ++
+  "  mv a0, s2; mv a1, s3                # header (child)\n" ++
+  "  mv a2, s4; mv a3, s5                # tx0\n" ++
+  "  mv a4, s6; mv a5, s7                # tx1\n" ++
+  "  la a6, bv2f_tx_root_valid\n" ++
+  "  jal ra, block_validate_transactions_root_two_tx\n" ++
+  "  beqz a0, .Lbv2f_tx_root_status_ok\n" ++
+  "  # Remap K171 status (1=parse, 2=size) into 11/12 to keep\n" ++
+  "  # distinguishable from K174 codes.\n" ++
+  "  addi a0, a0, 10\n" ++
+  "  j .Lbv2f_ret\n" ++
+  ".Lbv2f_tx_root_status_ok:\n" ++
+  "  la t0, bv2f_tx_root_valid; ld t1, 0(t0)\n" ++
+  "  beqz t1, .Lbv2f_pred_false\n" ++
+  "  # Both invariants hold.\n" ++
+  "  li t0, 1\n" ++
+  "  sd t0, 0(s8)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lbv2f_ret\n" ++
+  ".Lbv2f_pred_false:\n" ++
+  "  sd zero, 0(s8)\n" ++
+  "  li a0, 0\n" ++
+  ".Lbv2f_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp); ld s7, 64(sp)\n" ++
+  "  ld s8, 72(sp)\n" ++
+  "  addi sp, sp, 80\n" ++
+  "  ret"
+
+/-- `zisk_block_validate_2tx_full`: probe BuildUnit.
+    Input layout:
+      bytes  0.. 8 : parent_rlp_len
+      bytes  8..16 : header_rlp_len
+      bytes 16..24 : tx0_len
+      bytes 24..32 : tx1_len
+      bytes 32..   : parent_rlp || header_rlp || tx0 || tx1
+    Output layout:
+      bytes  0.. 8 : status (0=ok, 1..4 pair, 11..12 tx-root)
+      bytes  8..16 : is_valid (1 if both invariants hold) -/
+def ziskBlockValidate2txFullPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li t6, 0xa0010008\n" ++
+  "  la t5, bv2f_out_ptr\n" ++
+  "  sd t6, 0(t5)\n" ++
+  "  li a7, 0x40000000\n" ++
+  "  ld a1,  8(a7)              # parent_rlp_len\n" ++
+  "  ld a3, 16(a7)              # header_rlp_len\n" ++
+  "  ld a5, 24(a7)              # tx0_len\n" ++
+  "  ld t0, 32(a7)              # tx1_len\n" ++
+  "  la t1, bv2f_tx1_len; sd t0, 0(t1)\n" ++
+  "  addi a0, a7, 40            # parent_rlp ptr\n" ++
+  "  add a2, a0, a1             # header_rlp ptr\n" ++
+  "  add a4, a2, a3             # tx0 ptr\n" ++
+  "  add a6, a4, a5             # tx1 ptr\n" ++
+  "  la t1, bv2f_tx1_len; ld t0, 0(t1)\n" ++
+  "  mv a7, t0                  # tx1_len\n" ++
+  "  jal ra, block_validate_2tx_full\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lbv2f_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpFieldToU64Function ++ "\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  hpEncodeNibblesFunction ++ "\n" ++
+  rlpEncodeBytesFunction ++ "\n" ++
+  rlpEncodeListPrefixFunction ++ "\n" ++
+  mptLeafNodeEncodeFromNibblesFunction ++ "\n" ++
+  mptNodeSlotEncodeFunction ++ "\n" ++
+  mptBranchPayloadTwoSlotsFunction ++ "\n" ++
+  mptBranchNodeEncodeFunction ++ "\n" ++
+  mptBranchNodeKeccakFunction ++ "\n" ++
+  mptTwoLeafRootIndexedFunction ++ "\n" ++
+  blockHashFromHeaderFunction ++ "\n" ++
+  validateParentHashLinkFunction ++ "\n" ++
+  checkGasLimitFunction ++ "\n" ++
+  validateHeaderPairFunction ++ "\n" ++
+  blockValidateTransactionsRootTwoTxFunction ++ "\n" ++
+  blockValidate2txFullFunction ++ "\n" ++
+  ".Lbv2f_pdone:"
+
+def ziskBlockValidate2txFullDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  "rfu_offset:\n" ++
+  "  .zero 8\n" ++
+  "rfu_length:\n" ++
+  "  .zero 8\n" ++
+  "vphl_offset:\n" ++
+  "  .zero 8\n" ++
+  "vphl_length:\n" ++
+  "  .zero 8\n" ++
+  "vphl_claimed:\n" ++
+  "  .zero 32\n" ++
+  "vphl_computed:\n" ++
+  "  .zero 32\n" ++
+  "vhp_link_valid:\n" ++
+  "  .zero 8\n" ++
+  "vhp_parent_number:\n" ++
+  "  .zero 8\n" ++
+  "vhp_parent_timestamp:\n" ++
+  "  .zero 8\n" ++
+  "vhp_parent_gas_limit:\n" ++
+  "  .zero 8\n" ++
+  "vhp_child_number:\n" ++
+  "  .zero 8\n" ++
+  "vhp_child_timestamp:\n" ++
+  "  .zero 8\n" ++
+  "vhp_child_gas_limit:\n" ++
+  "  .zero 8\n" ++
+  "mlnen_field_len:\n" ++
+  "  .zero 8\n" ++
+  "mlnen_hp_len:\n" ++
+  "  .zero 8\n" ++
+  "mlnen_cursor:\n" ++
+  "  .zero 8\n" ++
+  "mlnen_total_payload:\n" ++
+  "  .zero 8\n" ++
+  "mlnen_hp_buf:\n" ++
+  "  .zero 1024\n" ++
+  "mlnen_payload_buf:\n" ++
+  "  .zero 16384\n" ++
+  "mbne_field_len:\n" ++
+  "  .zero 8\n" ++
+  "mbnk_node_len:\n" ++
+  "  .zero 8\n" ++
+  "mbnk_node_buf:\n" ++
+  "  .zero 16384\n" ++
+  "mtlri_nib0:\n" ++
+  "  .zero 1\n" ++
+  "mtlri_nib1:\n" ++
+  "  .zero 1\n" ++
+  ".balign 8\n" ++
+  "mtlri_leaf_0_len:\n" ++
+  "  .zero 8\n" ++
+  "mtlri_leaf_0_buf:\n" ++
+  "  .zero 16384\n" ++
+  "mtlri_leaf_1_len:\n" ++
+  "  .zero 8\n" ++
+  "mtlri_leaf_1_buf:\n" ++
+  "  .zero 16384\n" ++
+  "mtlri_slot_0_len:\n" ++
+  "  .zero 8\n" ++
+  "mtlri_slot_0_buf:\n" ++
+  "  .zero 16384\n" ++
+  "mtlri_slot_1_len:\n" ++
+  "  .zero 8\n" ++
+  "mtlri_slot_1_buf:\n" ++
+  "  .zero 16384\n" ++
+  "mtlri_branch_payload_len:\n" ++
+  "  .zero 8\n" ++
+  "mtlri_branch_payload:\n" ++
+  "  .zero 16384\n" ++
+  "bvtr_offset:\n" ++
+  "  .zero 8\n" ++
+  "bvtr_length:\n" ++
+  "  .zero 8\n" ++
+  "bvtr_claimed_root:\n" ++
+  "  .zero 32\n" ++
+  "bvtr_computed_root:\n" ++
+  "  .zero 32\n" ++
+  "bv2f_out_ptr:\n" ++
+  "  .zero 8\n" ++
+  "bv2f_pair_valid:\n" ++
+  "  .zero 8\n" ++
+  "bv2f_tx_root_valid:\n" ++
+  "  .zero 8\n" ++
+  "bv2f_tx1_len:\n" ++
+  "  .zero 8"
+
+def ziskBlockValidate2txFullProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskBlockValidate2txFullPrologue
+  dataAsm     := ziskBlockValidate2txFullDataSection
 }
 
 end EvmAsm.Codegen

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **198**
-- ziskemu round-trip scripts: **191** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **199**
+- ziskemu round-trip scripts: **192** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/README.md
+++ b/README.md
@@ -263,7 +263,8 @@ and MPT primitives (`account_decode`, `account_at_address`,
 `block_validate_transactions_root_two_tx`,
 `block_hash_from_header`, `validate_parent_hash_link`,
 `validate_header_pair`, `validate_header_chain`,
-withdrawal RLP/hash, …), and address
+`block_validate_2tx_full`, withdrawal RLP/hash, …), and
+address
 derivation (`address_compute_create`, `address_compute_create2`,
 `address_from_pubkey`). The catalogue is tracked under the
 `PR-K*` series in [`PLAN.md`](PLAN.md).

--- a/scripts/codegen-zisk-block-validate-2tx-full-check.sh
+++ b/scripts/codegen-zisk-block-validate-2tx-full-check.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# codegen-zisk-block-validate-2tx-full-check.sh -- PR-K176.
+#
+# Full validation of a 2-tx block: parent_hash + number+1 + ts +
+# gas_limit (K174) AND transactions_root MPT match (K171).
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_block_validate_2tx_full ELF"
+lake exe codegen --program zisk_block_validate_2tx_full --halt linux93 \
+  -o gen-out/zisk_block_validate_2tx_full
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <break_pair 0/1> <break_tx_root 0/1> <exp_status> <exp_valid>
+run_case() {
+  local name="$1" break_pair="$2" break_tx_root="$3" exp_status="$4" exp_valid="$5"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_block_validate_2tx_full_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_block_validate_2tx_full_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+try:
+    from Crypto.Hash import keccak
+    def keccak256(b):
+        h = keccak.new(digest_bits=256); h.update(b); return h.digest()
+except Exception:
+    import sha3
+    def keccak256(b): return sha3.keccak_256(b).digest()
+
+def u_be(n):
+    if n == 0: return b''
+    return n.to_bytes((n.bit_length() + 7) // 8, 'big')
+
+break_pair = $break_pair == 1
+break_tx_root = $break_tx_root == 1
+
+tx0 = bytes.fromhex('f8500184ee6b280082520894aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa881bc16d674ec80000801ba01111111111111111111111111111111111111111111111111111111111111111a02222222222222222222222222222222222222222222222222222222222222222')
+tx1 = bytes.fromhex('f8500284ee6b280082520894bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb881bc16d674ec80000801ba03333333333333333333333333333333333333333333333333333333333333333a04444444444444444444444444444444444444444444444444444444444444444')
+
+# Compute the correct transactions_root for these 2 txs.
+def hp_leaf(nibbles, value):
+    flag = 2 + (len(nibbles) & 1)
+    hp = bytearray()
+    if len(nibbles) % 2 == 1:
+        hp.append((flag << 4) | nibbles[0]); i = 1
+    else:
+        hp.append(flag << 4); i = 0
+    while i < len(nibbles):
+        hp.append((nibbles[i] << 4) | nibbles[i+1]); i += 2
+    return rlp.encode([bytes(hp), value])
+
+def slot_ref(node_rlp):
+    if len(node_rlp) < 32:
+        return node_rlp
+    return b'\\xa0' + keccak256(node_rlp)
+
+leaf_0 = hp_leaf([0], tx0)
+leaf_1 = hp_leaf([1], tx1)
+slots = [b'\\x80'] * 17
+slots[8] = slot_ref(leaf_0)
+slots[0] = slot_ref(leaf_1)
+payload = b''.join(slots)
+n = len(payload)
+if n < 56:
+    prefix = bytes([0xc0 + n])
+else:
+    nb = n.to_bytes((n.bit_length() + 7) // 8, 'big')
+    prefix = bytes([0xf7 + len(nb)]) + nb
+correct_tx_root = keccak256(prefix + payload)
+
+# Make parent first; child's parent_hash is computed from keccak(parent_rlp).
+parent_fields = [
+    b'\\xa1'*32, b'\\xa2'*32, b'\\xa3'*20, b'\\xa4'*32, b'\\xa5'*32,
+    b'\\xa6'*32, b'\\x00'*256, b'', u_be(100), u_be(30000000),
+    b'\\x82\\x02\\x00', u_be(1000), b'', b'\\xa7'*32, b'\\x00'*8,
+    b'\\x82\\x12\\x34',
+]
+parent_rlp = rlp.encode(parent_fields)
+parent_hash = keccak256(parent_rlp)
+
+if break_tx_root:
+    field4 = b'\\xff' * 32
+else:
+    field4 = correct_tx_root
+
+# Break pair by skipping number (child.number = parent.number + 2).
+if break_pair:
+    child_num = 102
+else:
+    child_num = 101
+
+child_fields = [
+    parent_hash, b'\\xb2'*32, b'\\xb3'*20, b'\\xb4'*32, field4,
+    b'\\xb6'*32, b'\\x00'*256, b'', u_be(child_num), u_be(30000000),
+    b'\\x82\\x02\\x00', u_be(1001), b'', b'\\xb7'*32, b'\\x00'*8,
+    b'\\x82\\x12\\x34',
+]
+child_rlp = rlp.encode(child_fields)
+
+with open(sys.argv[1], 'wb') as f:
+    record = struct.pack('<Q', len(parent_rlp)) + \
+             struct.pack('<Q', len(child_rlp)) + \
+             struct.pack('<Q', len(tx0)) + \
+             struct.pack('<Q', len(tx1)) + \
+             parent_rlp + child_rlp + tx0 + tx1
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_block_validate_2tx_full.elf \
+    -i "$in_file" -o "$out_file" -n 10000000 \
+    >"$REPO_ROOT/gen-out/zisk_block_validate_2tx_full_${name}.emu.log" 2>&1 || true
+
+  local status_le; status_le="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local valid_le;  valid_le="$( dd if="$out_file" bs=1 skip=8 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local status valid
+  status="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$status_le'))[0])")"
+  valid="$( python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$valid_le'))[0])")"
+
+  if [[ "$status" == "$exp_status" && "$valid" == "$exp_valid" ]]; then
+    printf "  %-28s OK   status=%s valid=%s\n" "$name" "$status" "$valid"
+    return 0
+  else
+    printf "  %-28s FAIL status=%s/exp%s valid=%s/exp%s\n" \
+      "$name" "$status" "$exp_status" "$valid" "$exp_valid"
+    return 1
+  fi
+}
+
+FAILED=0
+# Everything correct -> valid=1
+run_case "all_match"             0 0 0 1 || FAILED=1
+# Pair check fails (number skip) -> valid=0
+run_case "fail_pair_number_skip" 1 0 0 0 || FAILED=1
+# Tx-root check fails -> valid=0
+run_case "fail_tx_root_mismatch" 0 1 0 0 || FAILED=1
+# Both broken -> still valid=0 (pair check fires first)
+run_case "fail_both"             1 1 0 0 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: block_validate_2tx_full enforces pair + tx_root invariants"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

End-to-end validator for a 2-tx Ethereum block: combines the
per-pair header invariants (K174) and the `transactions_root` MPT
match (K171) into one call. Returns `is_valid = 1` iff both checks
pass:

1. `validate_header_pair(parent, header)` accepts (parent_hash link,
   number+1, timestamp >, gas_limit within ±1/1024).
2. `block_validate_transactions_root_two_tx(header, tx0, tx1)` accepts
   (header.transactions_root == MPT root of the 2-leaf trie).

This is the per-block invariant for a 2-tx block, modulo the
body-side checks (ECRECOVER / EVM execution) that remain gated.
Status codes remap K174's `1..4` and K171's `1..2` (shifted into
`11..12`) so the caller can tell which sub-check failed.

## Calling convention

8 a-registers: `a0/a1` parent ptr+len, `a2/a3` child header ptr+len,
`a4/a5` tx0 ptr+len, `a6/a7` tx1 ptr+len. The `is_valid` output ptr
lives in a `.data` indirection slot (`bv2f_out_ptr`) so the
calling convention stays within the eight a-register limit.

## Test plan

4 ziskemu fixtures:

- [x] `all_match` -- all invariants hold -> valid=1
- [x] `fail_pair_number_skip` -- child.number = parent.number + 2 -> valid=0
- [x] `fail_tx_root_mismatch` -- header field 4 swapped for `\xff*32` -> valid=0
- [x] `fail_both` -- both broken -> valid=0

## Notes

`Block.lean` now imports `Programs.Mpt` and `Programs.Header` so the
helpers from K171 and K174 are in scope.

## Stack

Builds on #5970 (PR-K175 `validate_header_chain`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)