### PR TITLE
feat(div): add n4_call_addback_beq_div_getLimbN getLimbN bridge theorem

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/CallAddbackRuntime.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/CallAddbackRuntime.lean
@@ -724,7 +724,7 @@ theorem n4_call_addback_beq_div_getLimbN (a b : EvmWord)
   set target := EvmWord.fromLimbs (fun i : Fin 4 =>
     match i with | 0 => q | 1 => 0 | 2 => 0 | 3 => 0) with htarget_def
   have htarget_toNat : target.toNat = q.toNat := by
-    simp [target, htarget_def, EvmWord.fromLimbs_toNat]
+    simp [htarget_def, EvmWord.fromLimbs_toNat]
   have htarget_eq_div : target = EvmWord.div a b :=
     BitVec.eq_of_toNat_eq (by omega)
   refine ⟨?_, ?_, ?_, ?_⟩

--- a/EvmAsm/Evm64/DivMod/Spec/CallAddbackRuntime.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/CallAddbackRuntime.lean
@@ -667,6 +667,72 @@ theorem n4CallAddbackBeqSemanticHoldsV4_of_runtime_bounds
   n4CallAddbackBeqSemanticHoldsV4_of_runtime_conditions_compact
     hb3nz hshift_nz h_bounds.1 h_borrow h_carry2 h_bounds.2
 
+
+/-- **n4 call+addback (shift≠0) getLimbN bridge.**
+    Under `n4CallAddbackBeqSemanticHolds a b` (the algorithm's q_out equals the
+    true quotient) and `b.getLimbN 3 ≠ 0` (n=4, so val256(b) ≥ 2^192 and the
+    quotient fits in one 64-bit limb), the DIV result has
+    `getLimbN 0 = n4CallAddbackBeqQOutV4 a b` and all upper limbs zero.
+
+    Used to bridge `evm_div_n4_full_call_addback_beq_spec_noNop`'s output
+    (which gives `fullDivN4CallAddbackBeqPost`) toward the public EVM-stack post
+    with `EvmWord.div a b` in the quotient slot. -/
+theorem n4_call_addback_beq_div_getLimbN (a b : EvmWord)
+    (hbnz : b ≠ 0)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hsem : n4CallAddbackBeqSemanticHolds a b) :
+    (EvmWord.div a b).getLimbN 0 = n4CallAddbackBeqQOutV4 a b ∧
+    (EvmWord.div a b).getLimbN 1 = 0 ∧
+    (EvmWord.div a b).getLimbN 2 = 0 ∧
+    (EvmWord.div a b).getLimbN 3 = 0 := by
+  -- Step 1: Convert SemanticHolds to V4 form: QOutV4.toNat = QTrue = val256(a)/val256(b)
+  have hsemV4 := n4CallAddbackBeqSemanticHolds_v4 hsem
+  unfold n4CallAddbackBeqSemanticHoldsV4 n4CallAddbackBeqQTrue at hsemV4
+  -- Step 2: Connect val256 to toNat
+  have ha_val : val256 (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3) = a.toNat := by
+    simp only [← getLimb_as_getLimbN_0, ← getLimb_as_getLimbN_1,
+               ← getLimb_as_getLimbN_2, ← getLimb_as_getLimbN_3]
+    exact val256_eq_toNat a
+  have hb_val : val256 (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) = b.toNat := by
+    simp only [← getLimb_as_getLimbN_0, ← getLimb_as_getLimbN_1,
+               ← getLimb_as_getLimbN_2, ← getLimb_as_getLimbN_3]
+    exact val256_eq_toNat b
+  rw [ha_val, hb_val] at hsemV4
+  -- Step 3: EvmWord.div a b = a.toNat / b.toNat
+  have hdiv_toNat : (EvmWord.div a b).toNat = a.toNat / b.toNat := by
+    unfold EvmWord.div; rw [if_neg hbnz]; exact BitVec.toNat_udiv
+  -- Step 4: QOutV4.toNat = (EvmWord.div a b).toNat
+  have hq_toNat : (n4CallAddbackBeqQOutV4 a b).toNat = (EvmWord.div a b).toNat := by omega
+  -- Step 5: Quotient fits in one limb since b.getLimbN 3 ≠ 0 → b ≥ 2^192
+  have hb_gt : 0 < b.toNat := by
+    rcases Nat.eq_zero_or_pos b.toNat with h | h
+    · exact absurd (BitVec.eq_of_toNat_eq (by simp [h])) hbnz
+    · exact h
+  have hb3_val : val256 (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) ≥ 2^192 :=
+    val256_ge_pow192_of_limb3 _ _ _ _ hb3nz
+  rw [hb_val] at hb3_val
+  have hqlt : (n4CallAddbackBeqQOutV4 a b).toNat < 2^64 := by
+    rw [hq_toNat, hdiv_toNat]
+    have hbnd := val256_bound (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+    rw [ha_val] at hbnd
+    calc a.toNat / b.toNat ≤ (2^256 - 1) / b.toNat := Nat.div_le_div_right (by omega)
+      _ ≤ (2^256 - 1) / 2^192 := Nat.div_le_div_left hb3_val (by omega)
+      _ = 2^64 - 1 := by norm_num
+      _ < 2^64 := by omega
+  -- Step 6: Build the target EvmWord (QOutV4 in limb 0, zeros elsewhere) = EvmWord.div a b
+  set q := n4CallAddbackBeqQOutV4 a b with hq_def
+  set target := EvmWord.fromLimbs (fun i : Fin 4 =>
+    match i with | 0 => q | 1 => 0 | 2 => 0 | 3 => 0) with htarget_def
+  have htarget_toNat : target.toNat = q.toNat := by
+    simp [target, htarget_def, EvmWord.fromLimbs_toNat]
+  have htarget_eq_div : target = EvmWord.div a b :=
+    BitVec.eq_of_toNat_eq (by omega)
+  refine ⟨?_, ?_, ?_, ?_⟩
+  · rw [← htarget_eq_div]; exact getLimbN_fromLimbs_0
+  · rw [← htarget_eq_div]; exact getLimbN_fromLimbs_1
+  · rw [← htarget_eq_div]; exact getLimbN_fromLimbs_2
+  · rw [← htarget_eq_div]; exact getLimbN_fromLimbs_3
+
 end EvmWord
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Adds `n4_call_addback_beq_div_getLimbN` to `CallAddbackRuntime.lean`
- Under `n4CallAddbackBeqSemanticHolds a b` + `hb3nz : b.getLimbN 3 ≠ 0`, proves `(EvmWord.div a b).getLimbN 0 = n4CallAddbackBeqQOutV4 a b` and upper limbs = 0
- Key insight: b.getLimbN 3 ≠ 0 implies b ≥ 2^192, so val256(a)/val256(b) < 2^64 (fits in single 64-bit limb)
- Follows `n4_call_skip_div_mod_getLimbN` pattern using `fromLimbs` construction
- Directly unblocks the n=4 call+addback (shift≠0) DIV stack spec needed for `evm_div_stack_spec_unconditional`

Refs #61. Bead: evm-asm-9iqmw.7.1.1.

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.CallAddbackRuntime
- scripts/check-file-size.sh
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/Spec/CallAddbackRuntime.lean
- lake build

Authored by @pirapira; implemented by Claude Code