### PR TITLE
feat(stateless): block_validate_2tx_full_with_body (PR-K178)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -5195,6 +5195,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_validate_header_chain" => some ziskValidateHeaderChainProbeUnit
   | "zisk_block_validate_2tx_full" => some ziskBlockValidate2txFullProbeUnit
   | "zisk_block_body_extract_2tx" => some ziskBlockBodyExtract2txProbeUnit
+  | "zisk_block_validate_2tx_full_with_body" => some ziskBlockValidate2txFullWithBodyProbeUnit
   | "zisk_block_logs_bloom_from_receipts_list" => some ziskBlockLogsBloomFromReceiptsListProbeUnit
   | "zisk_block_validate_logs_bloom" => some ziskBlockValidateLogsBloomProbeUnit
   | "zisk_header_root_is_empty_trie" => some ziskHeaderRootIsEmptyTrieProbeUnit
@@ -5386,6 +5387,7 @@ def knownProgramNames : List String :=
    "zisk_validate_header_chain",
    "zisk_block_validate_2tx_full",
    "zisk_block_body_extract_2tx",
+   "zisk_block_validate_2tx_full_with_body",
    "zisk_block_logs_bloom_from_receipts_list",
    "zisk_block_validate_logs_bloom",
    "zisk_header_root_is_empty_trie",

--- a/EvmAsm/Codegen/Programs/Block.lean
+++ b/EvmAsm/Codegen/Programs/Block.lean
@@ -2178,4 +2178,165 @@ def ziskBlockBodyExtract2txProbeUnit : BuildUnit := {
   dataAsm     := ziskBlockBodyExtract2txDataSection
 }
 
+/-! ## block_validate_2tx_full_with_body -- PR-K178
+
+    Single-call end-to-end validator for a 2-tx Ethereum block,
+    taking `(parent_rlp, header_rlp, body_rlp)` and returning
+    one is_valid u64. Composes K177 + K176:
+
+      1. K177 `block_body_extract_2tx(body_rlp)` decodes the
+         body, verifies `[txs, ommers, withdrawals]` shape with
+         exactly two transactions and empty ommers, and returns
+         `(tx0_off, tx0_len, tx1_off, tx1_len)` in body-relative
+         coordinates.
+      2. K176 `block_validate_2tx_full(parent, header, tx0, tx1)`
+         verifies all four header-pair invariants plus the
+         transactions_root MPT match using the extracted tx
+         slices.
+
+    This is the body-aware shape of `validate_block` for 2-tx
+    blocks; it is the natural endpoint of the K-series chain
+    once both the header and body sides are covered.
+
+    Calling convention:
+      a0 (input)  : parent_rlp ptr
+      a1 (input)  : parent_rlp byte length
+      a2 (input)  : header_rlp ptr
+      a3 (input)  : header_rlp byte length
+      a4 (input)  : body_rlp ptr
+      a5 (input)  : body_rlp byte length
+      a6 (input)  : u64 out (is_valid)
+      ra (input)  : return
+      a0 (output) :
+        0  success -- predicate written
+        1..4   propagated from `block_body_extract_2tx`
+              (1 parse, 2 ommers, 3 count, 4 inner extract)
+        11..14 propagated from `block_validate_2tx_full`
+              (11..14 == pair codes 1..4)
+        21..22 propagated from K171 inside K176
+              (tx-root parse / size codes 11..12 + 10) -/
+def blockValidate2txFullWithBodyFunction : String :=
+  "block_validate_2tx_full_with_body:\n" ++
+  "  addi sp, sp, -64\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp)\n" ++
+  "  mv s0, a0; mv s1, a1          # parent\n" ++
+  "  mv s2, a2; mv s3, a3          # header\n" ++
+  "  mv s4, a4; mv s5, a5          # body\n" ++
+  "  mv s6, a6                     # is_valid out\n" ++
+  "  sd zero, 0(s6)\n" ++
+  "  # ---- (A) Extract tx0 / tx1 from body ----\n" ++
+  "  mv a0, s4; mv a1, s5\n" ++
+  "  la a2, bv2fb_struct\n" ++
+  "  jal ra, block_body_extract_2tx\n" ++
+  "  beqz a0, .Lbv2fb_body_ok\n" ++
+  "  # Propagate body status (1..4) unchanged.\n" ++
+  "  j .Lbv2fb_ret\n" ++
+  ".Lbv2fb_body_ok:\n" ++
+  "  # Resolve tx0 / tx1 pointers in body address space.\n" ++
+  "  la t0, bv2fb_struct\n" ++
+  "  ld t1,  0(t0)                # tx0_off (in body)\n" ++
+  "  ld t2,  8(t0)                # tx0_len\n" ++
+  "  ld t3, 16(t0)                # tx1_off\n" ++
+  "  ld t4, 24(t0)                # tx1_len\n" ++
+  "  add t1, s4, t1               # tx0 ptr\n" ++
+  "  add t3, s4, t3               # tx1 ptr\n" ++
+  "  la t5, bv2f_out_ptr; sd s6, 0(t5)   # wire is_valid out through indirection\n" ++
+  "  # K176 takes 8 a-regs; the is_valid out is read from\n" ++
+  "  # bv2f_out_ptr (already set above).\n" ++
+  "  mv a0, s0; mv a1, s1\n" ++
+  "  mv a2, s2; mv a3, s3\n" ++
+  "  mv a4, t1; mv a5, t2\n" ++
+  "  mv a6, t3; mv a7, t4\n" ++
+  "  jal ra, block_validate_2tx_full\n" ++
+  "  beqz a0, .Lbv2fb_check_pred\n" ++
+  "  # K176 status: 1..4 pair, 11..12 tx-root. Remap to\n" ++
+  "  # 11..14 and 21..22 so callers can distinguish from\n" ++
+  "  # body-extract codes (1..4).\n" ++
+  "  li t0, 5\n" ++
+  "  bltu a0, t0, .Lbv2fb_remap_pair\n" ++
+  "  # K176 a0 in {11, 12} -> {21, 22}\n" ++
+  "  addi a0, a0, 10\n" ++
+  "  j .Lbv2fb_ret\n" ++
+  ".Lbv2fb_remap_pair:\n" ++
+  "  # K176 a0 in {1..4} -> {11..14}\n" ++
+  "  addi a0, a0, 10\n" ++
+  "  j .Lbv2fb_ret\n" ++
+  ".Lbv2fb_check_pred:\n" ++
+  "  # K176 already wrote is_valid via the indirection slot.\n" ++
+  "  li a0, 0\n" ++
+  ".Lbv2fb_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp)\n" ++
+  "  addi sp, sp, 64\n" ++
+  "  ret"
+
+/-- `zisk_block_validate_2tx_full_with_body`: probe BuildUnit.
+    Input layout:
+      bytes  0.. 8 : parent_rlp_len
+      bytes  8..16 : header_rlp_len
+      bytes 16..24 : body_rlp_len
+      bytes 24..   : parent_rlp || header_rlp || body_rlp
+    Output layout:
+      bytes  0.. 8 : status
+      bytes  8..16 : is_valid -/
+def ziskBlockValidate2txFullWithBodyPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a7, 0x40000000\n" ++
+  "  ld a1,  8(a7)                # parent_rlp_len\n" ++
+  "  ld a3, 16(a7)                # header_rlp_len\n" ++
+  "  ld a5, 24(a7)                # body_rlp_len\n" ++
+  "  addi a0, a7, 32              # parent_rlp ptr\n" ++
+  "  add a2, a0, a1               # header_rlp ptr\n" ++
+  "  add a4, a2, a3               # body_rlp ptr\n" ++
+  "  li a6, 0xa0010008            # is_valid out\n" ++
+  "  jal ra, block_validate_2tx_full_with_body\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lbv2fb_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpListCountItemsFunction ++ "\n" ++
+  rlpFieldToU64Function ++ "\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  hpEncodeNibblesFunction ++ "\n" ++
+  rlpEncodeBytesFunction ++ "\n" ++
+  rlpEncodeListPrefixFunction ++ "\n" ++
+  mptLeafNodeEncodeFromNibblesFunction ++ "\n" ++
+  mptNodeSlotEncodeFunction ++ "\n" ++
+  mptBranchPayloadTwoSlotsFunction ++ "\n" ++
+  mptBranchNodeEncodeFunction ++ "\n" ++
+  mptBranchNodeKeccakFunction ++ "\n" ++
+  mptTwoLeafRootIndexedFunction ++ "\n" ++
+  blockHashFromHeaderFunction ++ "\n" ++
+  validateParentHashLinkFunction ++ "\n" ++
+  checkGasLimitFunction ++ "\n" ++
+  validateHeaderPairFunction ++ "\n" ++
+  blockValidateTransactionsRootTwoTxFunction ++ "\n" ++
+  blockValidate2txFullFunction ++ "\n" ++
+  blockBodyDecodeFunction ++ "\n" ++
+  blockBodyExtract2txFunction ++ "\n" ++
+  blockValidate2txFullWithBodyFunction ++ "\n" ++
+  ".Lbv2fb_pdone:"
+
+def ziskBlockValidate2txFullWithBodyDataSection : String :=
+  ziskBlockValidate2txFullDataSection ++ "\n" ++
+  "bv2fb_struct:\n" ++
+  "  .zero 32\n" ++
+  "bbe_body_struct:\n" ++
+  "  .zero 48\n" ++
+  "bbe_tx_count:\n" ++
+  "  .zero 8\n" ++
+  "bbe_item_off:\n" ++
+  "  .zero 8\n" ++
+  "bbe_item_len:\n" ++
+  "  .zero 8"
+
+def ziskBlockValidate2txFullWithBodyProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskBlockValidate2txFullWithBodyPrologue
+  dataAsm     := ziskBlockValidate2txFullWithBodyDataSection
+}
+
 end EvmAsm.Codegen

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **200**
-- ziskemu round-trip scripts: **193** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **201**
+- ziskemu round-trip scripts: **194** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/README.md
+++ b/README.md
@@ -264,7 +264,8 @@ and MPT primitives (`account_decode`, `account_at_address`,
 `block_hash_from_header`, `validate_parent_hash_link`,
 `validate_header_pair`, `validate_header_chain`,
 `block_validate_2tx_full`, `block_body_extract_2tx`,
-withdrawal RLP/hash, …), and address
+`block_validate_2tx_full_with_body`, withdrawal RLP/hash, …),
+and address
 derivation (`address_compute_create`, `address_compute_create2`,
 `address_from_pubkey`). The catalogue is tracked under the
 `PR-K*` series in [`PLAN.md`](PLAN.md).

--- a/scripts/codegen-zisk-block-validate-2tx-full-with-body-check.sh
+++ b/scripts/codegen-zisk-block-validate-2tx-full-with-body-check.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# codegen-zisk-block-validate-2tx-full-with-body-check.sh -- PR-K178.
+#
+# Body-aware shape of `validate_block` for 2-tx blocks: takes
+# (parent_rlp, header_rlp, body_rlp) and returns is_valid.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_block_validate_2tx_full_with_body ELF"
+lake exe codegen --program zisk_block_validate_2tx_full_with_body --halt linux93 \
+  -o gen-out/zisk_block_validate_2tx_full_with_body
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <break_pair 0/1> <break_tx_root 0/1> <break_body 0/1>
+#                 <exp_status> <exp_valid>
+run_case() {
+  local name="$1" break_pair="$2" break_tx_root="$3" break_body="$4"
+  local exp_status="$5" exp_valid="$6"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_block_validate_2tx_full_with_body_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_block_validate_2tx_full_with_body_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+try:
+    from Crypto.Hash import keccak
+    def keccak256(b):
+        h = keccak.new(digest_bits=256); h.update(b); return h.digest()
+except Exception:
+    import sha3
+    def keccak256(b): return sha3.keccak_256(b).digest()
+
+def u_be(n):
+    if n == 0: return b''
+    return n.to_bytes((n.bit_length() + 7) // 8, 'big')
+
+break_pair = $break_pair == 1
+break_tx_root = $break_tx_root == 1
+break_body = $break_body == 1
+
+tx0 = bytes.fromhex('f8500184ee6b280082520894aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa881bc16d674ec80000801ba01111111111111111111111111111111111111111111111111111111111111111a02222222222222222222222222222222222222222222222222222222222222222')
+tx1 = bytes.fromhex('f8500284ee6b280082520894bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb881bc16d674ec80000801ba03333333333333333333333333333333333333333333333333333333333333333a04444444444444444444444444444444444444444444444444444444444444444')
+
+def hp_leaf(nibbles, value):
+    flag = 2 + (len(nibbles) & 1)
+    hp = bytearray()
+    if len(nibbles) % 2 == 1:
+        hp.append((flag << 4) | nibbles[0]); i = 1
+    else:
+        hp.append(flag << 4); i = 0
+    while i < len(nibbles):
+        hp.append((nibbles[i] << 4) | nibbles[i+1]); i += 2
+    return rlp.encode([bytes(hp), value])
+
+def slot_ref(node_rlp):
+    if len(node_rlp) < 32:
+        return node_rlp
+    return b'\\xa0' + keccak256(node_rlp)
+
+leaf_0 = hp_leaf([0], tx0)
+leaf_1 = hp_leaf([1], tx1)
+slots = [b'\\x80'] * 17
+slots[8] = slot_ref(leaf_0)
+slots[0] = slot_ref(leaf_1)
+payload = b''.join(slots)
+n = len(payload)
+if n < 56:
+    prefix = bytes([0xc0 + n])
+else:
+    nb = n.to_bytes((n.bit_length() + 7) // 8, 'big')
+    prefix = bytes([0xf7 + len(nb)]) + nb
+correct_tx_root = keccak256(prefix + payload)
+
+parent_fields = [
+    b'\\xa1'*32, b'\\xa2'*32, b'\\xa3'*20, b'\\xa4'*32, b'\\xa5'*32,
+    b'\\xa6'*32, b'\\x00'*256, b'', u_be(100), u_be(30000000),
+    b'\\x82\\x02\\x00', u_be(1000), b'', b'\\xa7'*32, b'\\x00'*8,
+    b'\\x82\\x12\\x34',
+]
+parent_rlp = rlp.encode(parent_fields)
+parent_hash = keccak256(parent_rlp)
+
+if break_tx_root:
+    field4 = b'\\xff' * 32
+else:
+    field4 = correct_tx_root
+
+if break_pair:
+    child_num = 102
+else:
+    child_num = 101
+
+child_fields = [
+    parent_hash, b'\\xb2'*32, b'\\xb3'*20, b'\\xb4'*32, field4,
+    b'\\xb6'*32, b'\\x00'*256, b'', u_be(child_num), u_be(30000000),
+    b'\\x82\\x02\\x00', u_be(1001), b'', b'\\xb7'*32, b'\\x00'*8,
+    b'\\x82\\x12\\x34',
+]
+header_rlp = rlp.encode(child_fields)
+
+if break_body:
+    body_rlp = rlp.encode([[tx0, tx1, tx0], [], []])  # 3 txs -> count fail
+else:
+    body_rlp = rlp.encode([[tx0, tx1], [], []])
+
+with open(sys.argv[1], 'wb') as f:
+    record = struct.pack('<Q', len(parent_rlp)) + \
+             struct.pack('<Q', len(header_rlp)) + \
+             struct.pack('<Q', len(body_rlp)) + \
+             parent_rlp + header_rlp + body_rlp
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_block_validate_2tx_full_with_body.elf \
+    -i "$in_file" -o "$out_file" -n 10000000 \
+    >"$REPO_ROOT/gen-out/zisk_block_validate_2tx_full_with_body_${name}.emu.log" 2>&1 || true
+
+  local status_le; status_le="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local valid_le;  valid_le="$( dd if="$out_file" bs=1 skip=8 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local status valid
+  status="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$status_le'))[0])")"
+  valid="$( python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$valid_le'))[0])")"
+
+  if [[ "$status" == "$exp_status" && "$valid" == "$exp_valid" ]]; then
+    printf "  %-26s OK   status=%s valid=%s\n" "$name" "$status" "$valid"
+    return 0
+  else
+    printf "  %-26s FAIL status=%s/exp%s valid=%s/exp%s\n" \
+      "$name" "$status" "$exp_status" "$valid" "$exp_valid"
+    return 1
+  fi
+}
+
+FAILED=0
+run_case "all_match"          0 0 0  0 1 || FAILED=1
+run_case "fail_pair_number"   1 0 0  0 0 || FAILED=1
+run_case "fail_tx_root"       0 1 0  0 0 || FAILED=1
+run_case "fail_body_count"    0 0 1  3 0 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: block_validate_2tx_full_with_body validates body + header + tx_root jointly"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Body-aware shape of `validate_block` for 2-tx Ethereum blocks: takes
`(parent_rlp, header_rlp, body_rlp)` and returns one `is_valid` u64.
Composes K177 + K176:

1. K177 `block_body_extract_2tx(body_rlp)` -- decodes the body,
   asserts `[transactions, ommers, withdrawals]` shape with exactly
   two txs and empty ommers, returns body-relative tx slice ptrs.
2. K176 `block_validate_2tx_full(parent, header, tx0, tx1)` --
   verifies the four header-pair invariants AND the
   `transactions_root` MPT match against the extracted tx slices.

The natural endpoint of the K171..K177 chain: validates a complete
2-tx block from its three RLP buffers, modulo the body-side checks
(ECRECOVER / EVM execution) that remain gated.

## Status codes

- `0` success
- `1..4` propagated from K177 body-extract (parse / ommers / count / inner-extract)
- `11..14` remapped from K176 pair codes (1..4)
- `21..22` remapped from K171 tx-root codes (11..12)

## Test plan

4 ziskemu fixtures:

- [x] `all_match` -- everything correct -> valid=1
- [x] `fail_pair_number` -- child.number = parent.number + 2 -> valid=0
- [x] `fail_tx_root` -- header field 4 swapped for `\xff*32` -> valid=0
- [x] `fail_body_count` -- 3 txs in body -> status=3 valid=0

## Stack

Builds on #5973 (PR-K177 `block_body_extract_2tx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)