### PR TITLE
feat(stateless): block_validate_empty_ommers_hash (PR-K179)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -5196,6 +5196,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_block_validate_2tx_full" => some ziskBlockValidate2txFullProbeUnit
   | "zisk_block_body_extract_2tx" => some ziskBlockBodyExtract2txProbeUnit
   | "zisk_block_validate_2tx_full_with_body" => some ziskBlockValidate2txFullWithBodyProbeUnit
+  | "zisk_block_validate_empty_ommers_hash" => some ziskBlockValidateEmptyOmmersHashProbeUnit
   | "zisk_block_logs_bloom_from_receipts_list" => some ziskBlockLogsBloomFromReceiptsListProbeUnit
   | "zisk_block_validate_logs_bloom" => some ziskBlockValidateLogsBloomProbeUnit
   | "zisk_header_root_is_empty_trie" => some ziskHeaderRootIsEmptyTrieProbeUnit
@@ -5388,6 +5389,7 @@ def knownProgramNames : List String :=
    "zisk_block_validate_2tx_full",
    "zisk_block_body_extract_2tx",
    "zisk_block_validate_2tx_full_with_body",
+   "zisk_block_validate_empty_ommers_hash",
    "zisk_block_logs_bloom_from_receipts_list",
    "zisk_block_validate_logs_bloom",
    "zisk_header_root_is_empty_trie",

--- a/EvmAsm/Codegen/Programs/Block.lean
+++ b/EvmAsm/Codegen/Programs/Block.lean
@@ -2339,4 +2339,116 @@ def ziskBlockValidate2txFullWithBodyProbeUnit : BuildUnit := {
   dataAsm     := ziskBlockValidate2txFullWithBodyDataSection
 }
 
+/-! ## block_validate_empty_ommers_hash -- PR-K179
+
+    Extract the header's `ommers_hash` field (field 1, 32
+    bytes) and verify it equals the post-merge constant
+    `EMPTY_OMMERS_HASH = keccak256(rlp([]))`:
+
+      0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347
+
+    Post-merge, all blocks have an empty ommers list (per EIP-3675),
+    so this is the canonical per-header check that complements
+    K177's body-side ommers-empty assertion. Pre-merge headers
+    fail this trivially.
+
+    The 32-byte constant is materialized as a `.data` blob and
+    compared 4 × `ld`/`bne` against the field-1 content.
+
+    Calling convention:
+      a0 (input)  : header_rlp ptr
+      a1 (input)  : header_rlp byte length
+      a2 (input)  : u64 out (is_valid: 1 if matches the constant)
+      ra (input)  : return
+      a0 (output) :
+        0 : success -- predicate written
+        1 : header parse failure
+        2 : field 1 length != 32 bytes -/
+def blockValidateEmptyOmmersHashFunction : String :=
+  "block_validate_empty_ommers_hash:\n" ++
+  "  addi sp, sp, -32\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp)\n" ++
+  "  mv s0, a0                   # header_rlp ptr\n" ++
+  "  mv s1, a1                   # header_rlp len\n" ++
+  "  mv s2, a2                   # is_valid out\n" ++
+  "  sd zero, 0(s2)\n" ++
+  "  # ---- Extract header.ommers_hash (field 1) ----\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 1\n" ++
+  "  la a3, bveoh_offset; la a4, bveoh_length\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lbveoh_parse_fail\n" ++
+  "  la t0, bveoh_length; ld t1, 0(t0)\n" ++
+  "  li t2, 32\n" ++
+  "  bne t1, t2, .Lbveoh_size_fail\n" ++
+  "  # 32-byte compare against the post-merge constant.\n" ++
+  "  la t0, bveoh_offset; ld t1, 0(t0)\n" ++
+  "  add t3, s0, t1                                  # &header[off]\n" ++
+  "  la t4, bveoh_empty_ommers_hash\n" ++
+  "  ld t5,  0(t3); ld t6,  0(t4); bne t5, t6, .Lbveoh_neq\n" ++
+  "  ld t5,  8(t3); ld t6,  8(t4); bne t5, t6, .Lbveoh_neq\n" ++
+  "  ld t5, 16(t3); ld t6, 16(t4); bne t5, t6, .Lbveoh_neq\n" ++
+  "  ld t5, 24(t3); ld t6, 24(t4); bne t5, t6, .Lbveoh_neq\n" ++
+  "  li t0, 1\n" ++
+  "  sd t0, 0(s2)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lbveoh_ret\n" ++
+  ".Lbveoh_neq:\n" ++
+  "  sd zero, 0(s2)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lbveoh_ret\n" ++
+  ".Lbveoh_parse_fail:\n" ++
+  "  li a0, 1\n" ++
+  "  j .Lbveoh_ret\n" ++
+  ".Lbveoh_size_fail:\n" ++
+  "  li a0, 2\n" ++
+  ".Lbveoh_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp)\n" ++
+  "  addi sp, sp, 32\n" ++
+  "  ret"
+
+/-- `zisk_block_validate_empty_ommers_hash`: probe BuildUnit.
+    Input layout:
+      bytes 0..8  : header_rlp_len
+      bytes 8..   : header_rlp
+    Output layout:
+      bytes  0.. 8 : status (0..2)
+      bytes  8..16 : is_valid (1 if matches the constant) -/
+def ziskBlockValidateEmptyOmmersHashPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a7, 0x40000000\n" ++
+  "  ld a1, 8(a7)                # header_rlp_len\n" ++
+  "  addi a0, a7, 16             # header_rlp ptr\n" ++
+  "  li a2, 0xa0010008           # is_valid out\n" ++
+  "  jal ra, block_validate_empty_ommers_hash\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lbveoh_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  blockValidateEmptyOmmersHashFunction ++ "\n" ++
+  ".Lbveoh_pdone:"
+
+def ziskBlockValidateEmptyOmmersHashDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  "bveoh_offset:\n" ++
+  "  .zero 8\n" ++
+  "bveoh_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "bveoh_empty_ommers_hash:\n" ++
+  "  .byte 0x1d, 0xcc, 0x4d, 0xe8, 0xde, 0xc7, 0x5d, 0x7a\n" ++
+  "  .byte 0xab, 0x85, 0xb5, 0x67, 0xb6, 0xcc, 0xd4, 0x1a\n" ++
+  "  .byte 0xd3, 0x12, 0x45, 0x1b, 0x94, 0x8a, 0x74, 0x13\n" ++
+  "  .byte 0xf0, 0xa1, 0x42, 0xfd, 0x40, 0xd4, 0x93, 0x47"
+
+def ziskBlockValidateEmptyOmmersHashProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskBlockValidateEmptyOmmersHashPrologue
+  dataAsm     := ziskBlockValidateEmptyOmmersHashDataSection
+}
+
 end EvmAsm.Codegen

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **201**
-- ziskemu round-trip scripts: **194** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **202**
+- ziskemu round-trip scripts: **195** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/README.md
+++ b/README.md
@@ -264,7 +264,8 @@ and MPT primitives (`account_decode`, `account_at_address`,
 `block_hash_from_header`, `validate_parent_hash_link`,
 `validate_header_pair`, `validate_header_chain`,
 `block_validate_2tx_full`, `block_body_extract_2tx`,
-`block_validate_2tx_full_with_body`, withdrawal RLP/hash, …),
+`block_validate_2tx_full_with_body`,
+`block_validate_empty_ommers_hash`, withdrawal RLP/hash, …),
 and address
 derivation (`address_compute_create`, `address_compute_create2`,
 `address_from_pubkey`). The catalogue is tracked under the

--- a/scripts/codegen-zisk-block-validate-empty-ommers-hash-check.sh
+++ b/scripts/codegen-zisk-block-validate-empty-ommers-hash-check.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# codegen-zisk-block-validate-empty-ommers-hash-check.sh -- PR-K179.
+#
+# Extract header.field[1] (ommers_hash) and check it equals the
+# post-merge constant keccak256(rlp([])).
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_block_validate_empty_ommers_hash ELF"
+lake exe codegen --program zisk_block_validate_empty_ommers_hash --halt linux93 \
+  -o gen-out/zisk_block_validate_empty_ommers_hash
+
+REPO_ROOT="$(pwd)"
+
+EMPTY_OMMERS_HASH="1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+
+# run_case <name> <ommers_hash_hex_or_'short'_or_'garbage'> <exp_status> <exp_valid>
+run_case() {
+  local name="$1" oh="$2" exp_status="$3" exp_valid="$4"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_block_validate_empty_ommers_hash_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_block_validate_empty_ommers_hash_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+oh = '$oh'
+fields = [
+    b'\\x11'*32, None,                # field 1 = ommers_hash; placeholder
+    b'\\x33'*20, b'\\x44'*32, b'\\x55'*32, b'\\x66'*32, b'\\x00'*256,
+    b'', b'\\x01', b'\\x83\\xff\\xff\\xff', b'', b'\\x83\\x01\\x02\\x03',
+    b'', b'\\x77'*32, b'\\x00'*8,
+]
+if oh == 'garbage':
+    header_rlp = b'\\x00'
+else:
+    if oh == 'short':
+        fields[1] = b'\\xaa'*16
+    else:
+        fields[1] = bytes.fromhex(oh)
+    header_rlp = rlp.encode(fields)
+with open(sys.argv[1], 'wb') as f:
+    record = struct.pack('<Q', len(header_rlp)) + header_rlp
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_block_validate_empty_ommers_hash.elf \
+    -i "$in_file" -o "$out_file" -n 1000000 \
+    >"$REPO_ROOT/gen-out/zisk_block_validate_empty_ommers_hash_${name}.emu.log" 2>&1 || true
+
+  local status_le; status_le="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local valid_le;  valid_le="$( dd if="$out_file" bs=1 skip=8 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local status valid
+  status="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$status_le'))[0])")"
+  valid="$( python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$valid_le'))[0])")"
+
+  if [[ "$status" == "$exp_status" && "$valid" == "$exp_valid" ]]; then
+    printf "  %-28s OK   status=%s valid=%s\n" "$name" "$status" "$valid"
+    return 0
+  else
+    printf "  %-28s FAIL status=%s/exp%s valid=%s/exp%s\n" \
+      "$name" "$status" "$exp_status" "$valid" "$exp_valid"
+    return 1
+  fi
+}
+
+FAILED=0
+run_case "match_empty_ommers"     "$EMPTY_OMMERS_HASH"                                              0 1 || FAILED=1
+run_case "mismatch_nonempty_hash" "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff" 0 0 || FAILED=1
+run_case "mismatch_zero_hash"     "0000000000000000000000000000000000000000000000000000000000000000" 0 0 || FAILED=1
+run_case "fail_short_field"       "short"                                                            2 0 || FAILED=1
+run_case "fail_garbage_header"    "garbage"                                                          1 0 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: block_validate_empty_ommers_hash accepts the post-merge constant and rejects others"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Extract a header's `ommers_hash` (field 1) and verify it equals the
post-merge constant `keccak256(rlp([]))`:

```
0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347
```

Post-merge (EIP-3675), all Ethereum blocks have an empty ommers
list, so every header **must** have this exact ommers_hash value.
This check complements K177's body-side ommers-empty assertion --
K179 is the header-side counterpart.

The 32-byte constant lives as a `.byte` literal in `.data`; the
compare is 4 × `ld`/`bne` against the extracted field.

## Status codes

| code | meaning |
|---:|---|
| 0 | success -- predicate written |
| 1 | header parse failure |
| 2 | field 1 length != 32 |

## Test plan

5 ziskemu fixtures:

- [x] `match_empty_ommers` -- constant matches -> valid=1
- [x] `mismatch_nonempty_hash` -- all-0xff hash -> valid=0
- [x] `mismatch_zero_hash` -- all-zero hash -> valid=0
- [x] `fail_short_field` -- 16-byte field 1 -> status=2
- [x] `fail_garbage_header` -- single 0x00 byte -> status=1

## Stack

Builds on #5974 (PR-K178 `block_validate_2tx_full_with_body`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)