### PR TITLE
feat(stateless): block_validate_no_withdrawals_pair (PR-K180)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -5197,6 +5197,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_block_body_extract_2tx" => some ziskBlockBodyExtract2txProbeUnit
   | "zisk_block_validate_2tx_full_with_body" => some ziskBlockValidate2txFullWithBodyProbeUnit
   | "zisk_block_validate_empty_ommers_hash" => some ziskBlockValidateEmptyOmmersHashProbeUnit
+  | "zisk_block_validate_no_withdrawals_pair" => some ziskBlockValidateNoWithdrawalsPairProbeUnit
   | "zisk_block_logs_bloom_from_receipts_list" => some ziskBlockLogsBloomFromReceiptsListProbeUnit
   | "zisk_block_validate_logs_bloom" => some ziskBlockValidateLogsBloomProbeUnit
   | "zisk_header_root_is_empty_trie" => some ziskHeaderRootIsEmptyTrieProbeUnit
@@ -5390,6 +5391,7 @@ def knownProgramNames : List String :=
    "zisk_block_body_extract_2tx",
    "zisk_block_validate_2tx_full_with_body",
    "zisk_block_validate_empty_ommers_hash",
+   "zisk_block_validate_no_withdrawals_pair",
    "zisk_block_logs_bloom_from_receipts_list",
    "zisk_block_validate_logs_bloom",
    "zisk_header_root_is_empty_trie",

--- a/EvmAsm/Codegen/Programs/Block.lean
+++ b/EvmAsm/Codegen/Programs/Block.lean
@@ -2451,4 +2451,141 @@ def ziskBlockValidateEmptyOmmersHashProbeUnit : BuildUnit := {
   dataAsm     := ziskBlockValidateEmptyOmmersHashDataSection
 }
 
+/-! ## block_validate_no_withdrawals_pair -- PR-K180
+
+    Pair check for blocks with no withdrawals: confirm both
+    sides claim it.
+
+      Header side: `header.withdrawals_root == EMPTY_TRIE_ROOT`
+                   (= keccak256(rlp(b''))
+                    = 0x56e81f17...3b421)
+        via K161 `header_root_is_empty_trie` with field index 16.
+
+      Body side: `block_body.field[2] (withdrawals) == rlp([])`
+                 == `0xc0` (the empty-list RLP encoding).
+        via K83 `block_body_decode` + 1-byte check.
+
+    Both must hold; mismatch on either side fails the pair.
+
+    Calling convention:
+      a0 (input)  : header_rlp ptr
+      a1 (input)  : header_rlp byte length
+      a2 (input)  : body_rlp ptr
+      a3 (input)  : body_rlp byte length
+      a4 (input)  : u64 out (is_valid: 1 iff both predicates hold)
+      ra (input)  : return
+      a0 (output) :
+        0 : success -- predicate written
+        1 : body parse failure (not 3-item list)
+        2 : header parse failure / field 16 missing
+        3 : header field 16 length != 32 -/
+def blockValidateNoWithdrawalsPairFunction : String :=
+  "block_validate_no_withdrawals_pair:\n" ++
+  "  addi sp, sp, -48\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp); sd s4, 40(sp)\n" ++
+  "  mv s0, a0; mv s1, a1                # header\n" ++
+  "  mv s2, a2; mv s3, a3                # body\n" ++
+  "  mv s4, a4                            # is_valid out\n" ++
+  "  sd zero, 0(s4)\n" ++
+  "  # ---- Body side: withdrawals (field 2) == 0xc0 ----\n" ++
+  "  mv a0, s2; mv a1, s3\n" ++
+  "  la a2, bvnw_body_struct\n" ++
+  "  jal ra, block_body_decode\n" ++
+  "  bnez a0, .Lbvnw_body_fail\n" ++
+  "  la t0, bvnw_body_struct\n" ++
+  "  ld t1, 32(t0)                       # withdrawals_offset\n" ++
+  "  ld t2, 40(t0)                       # withdrawals_length\n" ++
+  "  li t3, 1\n" ++
+  "  bne t2, t3, .Lbvnw_pred_false\n" ++
+  "  add t1, s2, t1\n" ++
+  "  lbu t4, 0(t1)\n" ++
+  "  li t5, 0xc0\n" ++
+  "  bne t4, t5, .Lbvnw_pred_false\n" ++
+  "  # ---- Header side: withdrawals_root (field 16) == EMPTY_TRIE_ROOT ----\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 16\n" ++
+  "  la a3, bvnw_field_off; la a4, bvnw_field_len\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lbvnw_header_parse_fail\n" ++
+  "  la t0, bvnw_field_len; ld t1, 0(t0)\n" ++
+  "  li t2, 32\n" ++
+  "  bne t1, t2, .Lbvnw_header_size_fail\n" ++
+  "  la t0, bvnw_field_off; ld t1, 0(t0)\n" ++
+  "  add t3, s0, t1                              # &header.withdrawals_root\n" ++
+  "  la t4, bvnw_empty_trie_root\n" ++
+  "  ld t5,  0(t3); ld t6,  0(t4); bne t5, t6, .Lbvnw_pred_false\n" ++
+  "  ld t5,  8(t3); ld t6,  8(t4); bne t5, t6, .Lbvnw_pred_false\n" ++
+  "  ld t5, 16(t3); ld t6, 16(t4); bne t5, t6, .Lbvnw_pred_false\n" ++
+  "  ld t5, 24(t3); ld t6, 24(t4); bne t5, t6, .Lbvnw_pred_false\n" ++
+  "  li t0, 1\n" ++
+  "  sd t0, 0(s4)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lbvnw_ret\n" ++
+  ".Lbvnw_pred_false:\n" ++
+  "  sd zero, 0(s4)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lbvnw_ret\n" ++
+  ".Lbvnw_body_fail:\n" ++
+  "  li a0, 1\n" ++
+  "  j .Lbvnw_ret\n" ++
+  ".Lbvnw_header_parse_fail:\n" ++
+  "  li a0, 2\n" ++
+  "  j .Lbvnw_ret\n" ++
+  ".Lbvnw_header_size_fail:\n" ++
+  "  li a0, 3\n" ++
+  ".Lbvnw_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp); ld s4, 40(sp)\n" ++
+  "  addi sp, sp, 48\n" ++
+  "  ret"
+
+/-- `zisk_block_validate_no_withdrawals_pair`: probe BuildUnit.
+    Input layout:
+      bytes  0.. 8 : header_rlp_len
+      bytes  8..16 : body_rlp_len
+      bytes 16..   : header_rlp || body_rlp
+    Output layout:
+      bytes  0.. 8 : status (0..3)
+      bytes  8..16 : is_valid -/
+def ziskBlockValidateNoWithdrawalsPairPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a7, 0x40000000\n" ++
+  "  ld a1,  8(a7)                # header_rlp_len\n" ++
+  "  ld a3, 16(a7)                # body_rlp_len\n" ++
+  "  addi a0, a7, 24              # header_rlp ptr\n" ++
+  "  add a2, a0, a1               # body_rlp ptr\n" ++
+  "  li a4, 0xa0010008            # is_valid out\n" ++
+  "  jal ra, block_validate_no_withdrawals_pair\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lbvnw_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  blockBodyDecodeFunction ++ "\n" ++
+  blockValidateNoWithdrawalsPairFunction ++ "\n" ++
+  ".Lbvnw_pdone:"
+
+def ziskBlockValidateNoWithdrawalsPairDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  "bvnw_body_struct:\n" ++
+  "  .zero 48\n" ++
+  "bvnw_field_off:\n" ++
+  "  .zero 8\n" ++
+  "bvnw_field_len:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "bvnw_empty_trie_root:\n" ++
+  "  .byte 0x56, 0xe8, 0x1f, 0x17, 0x1b, 0xcc, 0x55, 0xa6\n" ++
+  "  .byte 0xff, 0x83, 0x45, 0xe6, 0x92, 0xc0, 0xf8, 0x6e\n" ++
+  "  .byte 0x5b, 0x48, 0xe0, 0x1b, 0x99, 0x6c, 0xad, 0xc0\n" ++
+  "  .byte 0x01, 0x62, 0x2f, 0xb5, 0xe3, 0x63, 0xb4, 0x21"
+
+def ziskBlockValidateNoWithdrawalsPairProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskBlockValidateNoWithdrawalsPairPrologue
+  dataAsm     := ziskBlockValidateNoWithdrawalsPairDataSection
+}
+
 end EvmAsm.Codegen

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **202**
-- ziskemu round-trip scripts: **195** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **203**
+- ziskemu round-trip scripts: **196** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/README.md
+++ b/README.md
@@ -265,7 +265,8 @@ and MPT primitives (`account_decode`, `account_at_address`,
 `validate_header_pair`, `validate_header_chain`,
 `block_validate_2tx_full`, `block_body_extract_2tx`,
 `block_validate_2tx_full_with_body`,
-`block_validate_empty_ommers_hash`, withdrawal RLP/hash, …),
+`block_validate_empty_ommers_hash`,
+`block_validate_no_withdrawals_pair`, withdrawal RLP/hash, …),
 and address
 derivation (`address_compute_create`, `address_compute_create2`,
 `address_from_pubkey`). The catalogue is tracked under the

--- a/scripts/codegen-zisk-block-validate-no-withdrawals-pair-check.sh
+++ b/scripts/codegen-zisk-block-validate-no-withdrawals-pair-check.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# codegen-zisk-block-validate-no-withdrawals-pair-check.sh -- PR-K180.
+#
+# Verify header.withdrawals_root == EMPTY_TRIE_ROOT AND
+# body.field[2] == 0xc0 (empty withdrawals list).
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_block_validate_no_withdrawals_pair ELF"
+lake exe codegen --program zisk_block_validate_no_withdrawals_pair --halt linux93 \
+  -o gen-out/zisk_block_validate_no_withdrawals_pair
+
+REPO_ROOT="$(pwd)"
+
+EMPTY_TRIE_ROOT="56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"
+
+# run_case <name> <header_wroot_hex_or_special> <body_withdrawal_count>
+#                 <exp_status> <exp_valid>
+run_case() {
+  local name="$1" wroot="$2" wcount="$3" exp_status="$4" exp_valid="$5"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_block_validate_no_withdrawals_pair_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_block_validate_no_withdrawals_pair_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+wroot = '$wroot'
+wcount = $wcount
+
+if wroot == 'short':
+    field16 = b'\\xaa'*16
+elif wroot == 'garbage':
+    # We'll emit a malformed header below
+    field16 = b'\\x00'*32
+else:
+    field16 = bytes.fromhex(wroot)
+
+fields = [
+    b'\\x11'*32, b'\\x22'*32, b'\\x33'*20, b'\\x44'*32, b'\\x55'*32,
+    b'\\x66'*32, b'\\x00'*256, b'', b'\\x01', b'\\x83\\xff\\xff\\xff',
+    b'', b'\\x83\\x01\\x02\\x03', b'', b'\\x77'*32, b'\\x00'*8,
+    b'\\x82\\x12\\x34', field16,
+]
+if wroot == 'garbage':
+    header_rlp = b'\\x00'
+else:
+    header_rlp = rlp.encode(fields)
+
+withdrawals = []
+for i in range(wcount):
+    # Each withdrawal: [index, validator_index, address (20B), amount]
+    withdrawals.append([i.to_bytes(2, 'big'), i.to_bytes(4, 'big'),
+                        b'\\xee'*20, (i*1000).to_bytes(4, 'big')])
+body_rlp = rlp.encode([[], [], withdrawals])
+
+with open(sys.argv[1], 'wb') as f:
+    record = struct.pack('<Q', len(header_rlp)) + \
+             struct.pack('<Q', len(body_rlp)) + \
+             header_rlp + body_rlp
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_block_validate_no_withdrawals_pair.elf \
+    -i "$in_file" -o "$out_file" -n 1000000 \
+    >"$REPO_ROOT/gen-out/zisk_block_validate_no_withdrawals_pair_${name}.emu.log" 2>&1 || true
+
+  local status_le; status_le="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local valid_le;  valid_le="$( dd if="$out_file" bs=1 skip=8 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local status valid
+  status="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$status_le'))[0])")"
+  valid="$( python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$valid_le'))[0])")"
+
+  if [[ "$status" == "$exp_status" && "$valid" == "$exp_valid" ]]; then
+    printf "  %-30s OK   status=%s valid=%s\n" "$name" "$status" "$valid"
+    return 0
+  else
+    printf "  %-30s FAIL status=%s/exp%s valid=%s/exp%s\n" \
+      "$name" "$status" "$exp_status" "$valid" "$exp_valid"
+    return 1
+  fi
+}
+
+FAILED=0
+# Both sides agree: empty withdrawals
+run_case "both_empty"           "$EMPTY_TRIE_ROOT" 0 0 1 || FAILED=1
+# Header claims empty, body has withdrawals
+run_case "body_has_withdrawals" "$EMPTY_TRIE_ROOT" 2 0 0 || FAILED=1
+# Header has non-empty root, body empty
+run_case "header_nonempty_root" "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff" 0 0 0 || FAILED=1
+# Header has all-zero root, body empty
+run_case "header_zero_root"     "0000000000000000000000000000000000000000000000000000000000000000" 0 0 0 || FAILED=1
+# Header field 16 too short
+run_case "header_size_fail"     "short"            0 3 0 || FAILED=1
+# Header is garbage
+run_case "header_parse_fail"    "garbage"          0 2 0 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: block_validate_no_withdrawals_pair enforces both sides"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Pair check for blocks with no withdrawals -- both sides must agree:

- **Header side**: `header.withdrawals_root` (field 16) equals
  `EMPTY_TRIE_ROOT = keccak256(rlp(b'')) = 0x56e81f17...3b421`.
- **Body side**: `block_body.field[2]` (withdrawals) equals
  `rlp([]) = 0xc0` (the empty-list RLP encoding).

Composes K83 `block_body_decode` for the body decode plus K20
`rlp_list_nth_item` on the header for the field-16 extract.
The `EMPTY_TRIE_ROOT` constant is inlined as a `.byte` literal
(K161 lives in `Programs.lean` and isn't exposed as a callable
from sub-modules yet -- the cost of inlining is one 32-byte
constant per consumer).

## Status codes

| code | meaning |
|---:|---|
| 0 | success -- predicate written |
| 1 | body parse failure |
| 2 | header parse failure / field 16 missing |
| 3 | header field 16 length != 32 |

## Test plan

6 ziskemu fixtures:

- [x] `both_empty` -- both sides agree empty -> valid=1
- [x] `body_has_withdrawals` -- body has 2 withdrawals -> valid=0
- [x] `header_nonempty_root` -- header field 16 = 0xff*32 -> valid=0
- [x] `header_zero_root` -- header field 16 = 0x00*32 -> valid=0
- [x] `header_size_fail` -- header field 16 is 16 bytes -> status=3
- [x] `header_parse_fail` -- header is single 0x00 byte -> status=2

## Stack

Builds on #5975 (PR-K179 `block_validate_empty_ommers_hash`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)