### PR TITLE
feat(stateless): block_validate_empty_receipts_root (PR-K181)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -5198,6 +5198,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_block_validate_2tx_full_with_body" => some ziskBlockValidate2txFullWithBodyProbeUnit
   | "zisk_block_validate_empty_ommers_hash" => some ziskBlockValidateEmptyOmmersHashProbeUnit
   | "zisk_block_validate_no_withdrawals_pair" => some ziskBlockValidateNoWithdrawalsPairProbeUnit
+  | "zisk_block_validate_empty_receipts_root" => some ziskBlockValidateEmptyReceiptsRootProbeUnit
   | "zisk_block_logs_bloom_from_receipts_list" => some ziskBlockLogsBloomFromReceiptsListProbeUnit
   | "zisk_block_validate_logs_bloom" => some ziskBlockValidateLogsBloomProbeUnit
   | "zisk_header_root_is_empty_trie" => some ziskHeaderRootIsEmptyTrieProbeUnit
@@ -5392,6 +5393,7 @@ def knownProgramNames : List String :=
    "zisk_block_validate_2tx_full_with_body",
    "zisk_block_validate_empty_ommers_hash",
    "zisk_block_validate_no_withdrawals_pair",
+   "zisk_block_validate_empty_receipts_root",
    "zisk_block_logs_bloom_from_receipts_list",
    "zisk_block_validate_logs_bloom",
    "zisk_header_root_is_empty_trie",

--- a/EvmAsm/Codegen/Programs/Block.lean
+++ b/EvmAsm/Codegen/Programs/Block.lean
@@ -2588,4 +2588,110 @@ def ziskBlockValidateNoWithdrawalsPairProbeUnit : BuildUnit := {
   dataAsm     := ziskBlockValidateNoWithdrawalsPairDataSection
 }
 
+/-! ## block_validate_empty_receipts_root -- PR-K181
+
+    Header field 5 (`receipts_root`) equals `EMPTY_TRIE_ROOT`
+    iff the block has zero transactions (since receipts only
+    arise from txs -- withdrawals do not generate receipts).
+    This primitive checks the predicate directly.
+
+    Used by:
+      * Empty-block validators (composed with K179 + K161 + K177).
+      * Sanity-check on stateless inputs that claim zero txs.
+
+    Calling convention:
+      a0 (input)  : header_rlp ptr
+      a1 (input)  : header_rlp byte length
+      a2 (input)  : u64 out (is_valid: 1 if root matches the constant)
+      ra (input)  : return
+      a0 (output) :
+        0 : success -- predicate written
+        1 : header parse failure / field 5 missing
+        2 : field 5 length != 32 -/
+def blockValidateEmptyReceiptsRootFunction : String :=
+  "block_validate_empty_receipts_root:\n" ++
+  "  addi sp, sp, -32\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp)\n" ++
+  "  mv s0, a0                   # header_rlp ptr\n" ++
+  "  mv s1, a1                   # header_rlp len\n" ++
+  "  mv s2, a2                   # is_valid out\n" ++
+  "  sd zero, 0(s2)\n" ++
+  "  # ---- Extract header.receipts_root (field 5) ----\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 5\n" ++
+  "  la a3, bverr_offset; la a4, bverr_length\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lbverr_parse_fail\n" ++
+  "  la t0, bverr_length; ld t1, 0(t0)\n" ++
+  "  li t2, 32\n" ++
+  "  bne t1, t2, .Lbverr_size_fail\n" ++
+  "  la t0, bverr_offset; ld t1, 0(t0)\n" ++
+  "  add t3, s0, t1\n" ++
+  "  la t4, bverr_empty_trie_root\n" ++
+  "  ld t5,  0(t3); ld t6,  0(t4); bne t5, t6, .Lbverr_neq\n" ++
+  "  ld t5,  8(t3); ld t6,  8(t4); bne t5, t6, .Lbverr_neq\n" ++
+  "  ld t5, 16(t3); ld t6, 16(t4); bne t5, t6, .Lbverr_neq\n" ++
+  "  ld t5, 24(t3); ld t6, 24(t4); bne t5, t6, .Lbverr_neq\n" ++
+  "  li t0, 1\n" ++
+  "  sd t0, 0(s2)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lbverr_ret\n" ++
+  ".Lbverr_neq:\n" ++
+  "  sd zero, 0(s2)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lbverr_ret\n" ++
+  ".Lbverr_parse_fail:\n" ++
+  "  li a0, 1\n" ++
+  "  j .Lbverr_ret\n" ++
+  ".Lbverr_size_fail:\n" ++
+  "  li a0, 2\n" ++
+  ".Lbverr_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp)\n" ++
+  "  addi sp, sp, 32\n" ++
+  "  ret"
+
+/-- `zisk_block_validate_empty_receipts_root`: probe BuildUnit.
+    Input layout:
+      bytes 0..8 : header_rlp_len
+      bytes 8..  : header_rlp
+    Output layout:
+      bytes 0..8  : status (0..2)
+      bytes 8..16 : is_valid -/
+def ziskBlockValidateEmptyReceiptsRootPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a7, 0x40000000\n" ++
+  "  ld a1, 8(a7)                # header_rlp_len\n" ++
+  "  addi a0, a7, 16             # header_rlp ptr\n" ++
+  "  li a2, 0xa0010008           # is_valid out\n" ++
+  "  jal ra, block_validate_empty_receipts_root\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lbverr_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  blockValidateEmptyReceiptsRootFunction ++ "\n" ++
+  ".Lbverr_pdone:"
+
+def ziskBlockValidateEmptyReceiptsRootDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  "bverr_offset:\n" ++
+  "  .zero 8\n" ++
+  "bverr_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "bverr_empty_trie_root:\n" ++
+  "  .byte 0x56, 0xe8, 0x1f, 0x17, 0x1b, 0xcc, 0x55, 0xa6\n" ++
+  "  .byte 0xff, 0x83, 0x45, 0xe6, 0x92, 0xc0, 0xf8, 0x6e\n" ++
+  "  .byte 0x5b, 0x48, 0xe0, 0x1b, 0x99, 0x6c, 0xad, 0xc0\n" ++
+  "  .byte 0x01, 0x62, 0x2f, 0xb5, 0xe3, 0x63, 0xb4, 0x21"
+
+def ziskBlockValidateEmptyReceiptsRootProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskBlockValidateEmptyReceiptsRootPrologue
+  dataAsm     := ziskBlockValidateEmptyReceiptsRootDataSection
+}
+
 end EvmAsm.Codegen

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **203**
-- ziskemu round-trip scripts: **196** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **204**
+- ziskemu round-trip scripts: **197** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/README.md
+++ b/README.md
@@ -266,8 +266,9 @@ and MPT primitives (`account_decode`, `account_at_address`,
 `block_validate_2tx_full`, `block_body_extract_2tx`,
 `block_validate_2tx_full_with_body`,
 `block_validate_empty_ommers_hash`,
-`block_validate_no_withdrawals_pair`, withdrawal RLP/hash, …),
-and address
+`block_validate_no_withdrawals_pair`,
+`block_validate_empty_receipts_root`,
+withdrawal RLP/hash, …), and address
 derivation (`address_compute_create`, `address_compute_create2`,
 `address_from_pubkey`). The catalogue is tracked under the
 `PR-K*` series in [`PLAN.md`](PLAN.md).

--- a/scripts/codegen-zisk-block-validate-empty-receipts-root-check.sh
+++ b/scripts/codegen-zisk-block-validate-empty-receipts-root-check.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# codegen-zisk-block-validate-empty-receipts-root-check.sh -- PR-K181.
+#
+# Verify header.field[5] (receipts_root) == EMPTY_TRIE_ROOT.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_block_validate_empty_receipts_root ELF"
+lake exe codegen --program zisk_block_validate_empty_receipts_root --halt linux93 \
+  -o gen-out/zisk_block_validate_empty_receipts_root
+
+REPO_ROOT="$(pwd)"
+
+EMPTY_TRIE_ROOT="56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"
+
+# run_case <name> <receipts_root_hex_or_special> <exp_status> <exp_valid>
+run_case() {
+  local name="$1" rr="$2" exp_status="$3" exp_valid="$4"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_block_validate_empty_receipts_root_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_block_validate_empty_receipts_root_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+rr = '$rr'
+if rr == 'garbage':
+    header_rlp = b'\\x00'
+else:
+    if rr == 'short':
+        field5 = b'\\xaa'*16
+    else:
+        field5 = bytes.fromhex(rr)
+    fields = [
+        b'\\x11'*32, b'\\x22'*32, b'\\x33'*20, b'\\x44'*32, b'\\x55'*32,
+        field5, b'\\x00'*256, b'', b'\\x01', b'\\x83\\xff\\xff\\xff',
+        b'', b'\\x83\\x01\\x02\\x03', b'', b'\\x77'*32, b'\\x00'*8,
+    ]
+    header_rlp = rlp.encode(fields)
+with open(sys.argv[1], 'wb') as f:
+    record = struct.pack('<Q', len(header_rlp)) + header_rlp
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_block_validate_empty_receipts_root.elf \
+    -i "$in_file" -o "$out_file" -n 1000000 \
+    >"$REPO_ROOT/gen-out/zisk_block_validate_empty_receipts_root_${name}.emu.log" 2>&1 || true
+
+  local status_le; status_le="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local valid_le;  valid_le="$( dd if="$out_file" bs=1 skip=8 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local status valid
+  status="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$status_le'))[0])")"
+  valid="$( python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$valid_le'))[0])")"
+
+  if [[ "$status" == "$exp_status" && "$valid" == "$exp_valid" ]]; then
+    printf "  %-28s OK   status=%s valid=%s\n" "$name" "$status" "$valid"
+    return 0
+  else
+    printf "  %-28s FAIL status=%s/exp%s valid=%s/exp%s\n" \
+      "$name" "$status" "$exp_status" "$valid" "$exp_valid"
+    return 1
+  fi
+}
+
+FAILED=0
+run_case "match_empty"        "$EMPTY_TRIE_ROOT"                                              0 1 || FAILED=1
+run_case "mismatch_ff"        "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff" 0 0 || FAILED=1
+run_case "mismatch_zero"      "0000000000000000000000000000000000000000000000000000000000000000" 0 0 || FAILED=1
+run_case "fail_short_field"   "short"                                                            2 0 || FAILED=1
+run_case "fail_garbage"       "garbage"                                                          1 0 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: block_validate_empty_receipts_root accepts EMPTY_TRIE_ROOT and rejects others"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Header field 5 (`receipts_root`) equals `EMPTY_TRIE_ROOT` iff the
block has zero transactions (receipts only arise from txs;
withdrawals do not generate receipts).

Mirrors the K179 / K180 shape: extract field 5 via K20 and
compare 4 × `ld`/`bne` against the inlined `EMPTY_TRIE_ROOT`
constant (`keccak256(rlp(b'')) = 0x56e81f17...3b421`).

## Status codes

| code | meaning |
|---:|---|
| 0 | success -- predicate written |
| 1 | header parse failure |
| 2 | field 5 length != 32 |

## Test plan

5 ziskemu fixtures:

- [x] `match_empty` -- constant matches -> valid=1
- [x] `mismatch_ff` -- all-0xff -> valid=0
- [x] `mismatch_zero` -- all-zero -> valid=0
- [x] `fail_short_field` -- 16-byte field 5 -> status=2
- [x] `fail_garbage` -- single 0x00 byte -> status=1

Building block for the upcoming empty-block (no-tx) composite
validator that combines K179 + K180 + K181 with K177's body-side
empty check.

## Stack

Builds on #5976 (PR-K180 `block_validate_no_withdrawals_pair`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)