### PR TITLE
feat(stateless): block_validate_empty_block (PR-K182)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -5199,6 +5199,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_block_validate_empty_ommers_hash" => some ziskBlockValidateEmptyOmmersHashProbeUnit
   | "zisk_block_validate_no_withdrawals_pair" => some ziskBlockValidateNoWithdrawalsPairProbeUnit
   | "zisk_block_validate_empty_receipts_root" => some ziskBlockValidateEmptyReceiptsRootProbeUnit
+  | "zisk_block_validate_empty_block" => some ziskBlockValidateEmptyBlockProbeUnit
   | "zisk_block_logs_bloom_from_receipts_list" => some ziskBlockLogsBloomFromReceiptsListProbeUnit
   | "zisk_block_validate_logs_bloom" => some ziskBlockValidateLogsBloomProbeUnit
   | "zisk_header_root_is_empty_trie" => some ziskHeaderRootIsEmptyTrieProbeUnit
@@ -5394,6 +5395,7 @@ def knownProgramNames : List String :=
    "zisk_block_validate_empty_ommers_hash",
    "zisk_block_validate_no_withdrawals_pair",
    "zisk_block_validate_empty_receipts_root",
+   "zisk_block_validate_empty_block",
    "zisk_block_logs_bloom_from_receipts_list",
    "zisk_block_validate_logs_bloom",
    "zisk_header_root_is_empty_trie",

--- a/EvmAsm/Codegen/Programs/Block.lean
+++ b/EvmAsm/Codegen/Programs/Block.lean
@@ -2694,4 +2694,210 @@ def ziskBlockValidateEmptyReceiptsRootProbeUnit : BuildUnit := {
   dataAsm     := ziskBlockValidateEmptyReceiptsRootDataSection
 }
 
+/-! ## block_validate_empty_block -- PR-K182
+
+    Validator for a *completely empty* post-merge block:
+    zero transactions, empty ommers, no withdrawals. Used as a
+    fast-path or smoke-test entry point for stateless inputs
+    that promise no body execution.
+
+    Predicates checked (all must hold):
+
+      Header side:
+        H1. transactions_root  == EMPTY_TRIE_ROOT     (K171-style constant)
+        H2. ommers_hash        == EMPTY_OMMERS_HASH   (K179)
+        H3. receipts_root      == EMPTY_TRIE_ROOT     (K181)
+        H4. withdrawals_root   == EMPTY_TRIE_ROOT     (K180 header side)
+      Body side:
+        B1. body has 3 fields  [txs, ommers, withdrawals]
+        B2. txs        == rlp([]) == 0xc0
+        B3. ommers     == rlp([]) == 0xc0
+        B4. withdrawals == rlp([]) == 0xc0
+
+    All eight checks compose into a single is_valid u64.
+
+    Calling convention:
+      a0 (input)  : header_rlp ptr
+      a1 (input)  : header_rlp byte length
+      a2 (input)  : body_rlp ptr
+      a3 (input)  : body_rlp byte length
+      a4 (input)  : u64 out (is_valid)
+      ra (input)  : return
+      a0 (output) :
+        0 : success -- predicate written
+        1 : body parse failure
+        2 : header parse failure
+        3 : header field-size mismatch (some 32-byte root field
+            had length != 32) -/
+def blockValidateEmptyBlockFunction : String :=
+  "block_validate_empty_block:\n" ++
+  "  addi sp, sp, -64\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp); sd s4, 40(sp)\n" ++
+  "  mv s0, a0; mv s1, a1                # header\n" ++
+  "  mv s2, a2; mv s3, a3                # body\n" ++
+  "  mv s4, a4                            # is_valid out\n" ++
+  "  sd zero, 0(s4)\n" ++
+  "  # ---- Body side: 3 fields, all empty ----\n" ++
+  "  mv a0, s2; mv a1, s3\n" ++
+  "  la a2, beb_body_struct\n" ++
+  "  jal ra, block_body_decode\n" ++
+  "  bnez a0, .Lbeb_body_fail\n" ++
+  "  # B2..B4: each field length must be 1 and the byte 0xc0\n" ++
+  "  la t0, beb_body_struct\n" ++
+  "  li t6, 0xc0\n" ++
+  "  ld t1,  0(t0); ld t2,  8(t0)        # txs (off, len)\n" ++
+  "  li t3, 1; bne t2, t3, .Lbeb_pred_false\n" ++
+  "  add t1, s2, t1; lbu t4, 0(t1); bne t4, t6, .Lbeb_pred_false\n" ++
+  "  ld t1, 16(t0); ld t2, 24(t0)        # ommers (off, len)\n" ++
+  "  li t3, 1; bne t2, t3, .Lbeb_pred_false\n" ++
+  "  add t1, s2, t1; lbu t4, 0(t1); bne t4, t6, .Lbeb_pred_false\n" ++
+  "  ld t1, 32(t0); ld t2, 40(t0)        # withdrawals (off, len)\n" ++
+  "  li t3, 1; bne t2, t3, .Lbeb_pred_false\n" ++
+  "  add t1, s2, t1; lbu t4, 0(t1); bne t4, t6, .Lbeb_pred_false\n" ++
+  "  # ---- Header side: 4 root checks ----\n" ++
+  "  # H1: transactions_root (field 4) == EMPTY_TRIE_ROOT\n" ++
+  "  li a0, 4\n" ++
+  "  la a1, beb_empty_trie_root\n" ++
+  "  jal ra, beb_check_header_field_32B\n" ++
+  "  beqz a0, .Lbeb_pred_false\n" ++
+  "  bltz a0, .Lbeb_header_size_fail\n" ++
+  "  li t0, 2; beq a0, t0, .Lbeb_header_parse_fail\n" ++
+  "  # H2: ommers_hash (field 1) == EMPTY_OMMERS_HASH\n" ++
+  "  li a0, 1\n" ++
+  "  la a1, beb_empty_ommers_hash\n" ++
+  "  jal ra, beb_check_header_field_32B\n" ++
+  "  beqz a0, .Lbeb_pred_false\n" ++
+  "  li t0, 3; beq a0, t0, .Lbeb_header_size_fail\n" ++
+  "  li t0, 2; beq a0, t0, .Lbeb_header_parse_fail\n" ++
+  "  # H3: receipts_root (field 5) == EMPTY_TRIE_ROOT\n" ++
+  "  li a0, 5\n" ++
+  "  la a1, beb_empty_trie_root\n" ++
+  "  jal ra, beb_check_header_field_32B\n" ++
+  "  beqz a0, .Lbeb_pred_false\n" ++
+  "  li t0, 3; beq a0, t0, .Lbeb_header_size_fail\n" ++
+  "  li t0, 2; beq a0, t0, .Lbeb_header_parse_fail\n" ++
+  "  # H4: withdrawals_root (field 16) == EMPTY_TRIE_ROOT\n" ++
+  "  li a0, 16\n" ++
+  "  la a1, beb_empty_trie_root\n" ++
+  "  jal ra, beb_check_header_field_32B\n" ++
+  "  beqz a0, .Lbeb_pred_false\n" ++
+  "  li t0, 3; beq a0, t0, .Lbeb_header_size_fail\n" ++
+  "  li t0, 2; beq a0, t0, .Lbeb_header_parse_fail\n" ++
+  "  # All eight checks passed.\n" ++
+  "  li t0, 1\n" ++
+  "  sd t0, 0(s4)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lbeb_ret\n" ++
+  ".Lbeb_pred_false:\n" ++
+  "  sd zero, 0(s4)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lbeb_ret\n" ++
+  ".Lbeb_body_fail:\n" ++
+  "  li a0, 1\n" ++
+  "  j .Lbeb_ret\n" ++
+  ".Lbeb_header_parse_fail:\n" ++
+  "  li a0, 2\n" ++
+  "  j .Lbeb_ret\n" ++
+  ".Lbeb_header_size_fail:\n" ++
+  "  li a0, 3\n" ++
+  ".Lbeb_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp); ld s4, 40(sp)\n" ++
+  "  addi sp, sp, 64\n" ++
+  "  ret\n" ++
+  "\n" ++
+  "# Helper: check header[a0 = field_idx] is a 32B value equal to\n" ++
+  "# the constant at a1 (32B ptr). Reads s0/s1 = header_rlp ptr/len.\n" ++
+  "# Returns a0: 1 = match, 0 = predicate false, 2 = parse fail,\n" ++
+  "# 3 = size fail.\n" ++
+  "beb_check_header_field_32B:\n" ++
+  "  addi sp, sp, -16\n" ++
+  "  sd ra, 0(sp)\n" ++
+  "  sd a1, 8(sp)                          # save constant ptr\n" ++
+  "  mv a2, a0\n" ++
+  "  mv a0, s0; mv a1, s1\n" ++
+  "  la a3, beb_off; la a4, beb_len\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lbeb_chk_parse\n" ++
+  "  la t0, beb_len; ld t1, 0(t0)\n" ++
+  "  li t2, 32\n" ++
+  "  bne t1, t2, .Lbeb_chk_size\n" ++
+  "  la t0, beb_off; ld t1, 0(t0)\n" ++
+  "  add t3, s0, t1\n" ++
+  "  ld t4, 8(sp)                          # constant ptr\n" ++
+  "  ld t5,  0(t3); ld t6,  0(t4); bne t5, t6, .Lbeb_chk_neq\n" ++
+  "  ld t5,  8(t3); ld t6,  8(t4); bne t5, t6, .Lbeb_chk_neq\n" ++
+  "  ld t5, 16(t3); ld t6, 16(t4); bne t5, t6, .Lbeb_chk_neq\n" ++
+  "  ld t5, 24(t3); ld t6, 24(t4); bne t5, t6, .Lbeb_chk_neq\n" ++
+  "  li a0, 1\n" ++
+  "  j .Lbeb_chk_ret\n" ++
+  ".Lbeb_chk_neq:\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lbeb_chk_ret\n" ++
+  ".Lbeb_chk_parse:\n" ++
+  "  li a0, 2\n" ++
+  "  j .Lbeb_chk_ret\n" ++
+  ".Lbeb_chk_size:\n" ++
+  "  li a0, 3\n" ++
+  ".Lbeb_chk_ret:\n" ++
+  "  ld ra, 0(sp)\n" ++
+  "  addi sp, sp, 16\n" ++
+  "  ret"
+
+/-- `zisk_block_validate_empty_block`: probe BuildUnit.
+    Input layout:
+      bytes  0.. 8 : header_rlp_len
+      bytes  8..16 : body_rlp_len
+      bytes 16..   : header_rlp || body_rlp
+    Output layout:
+      bytes  0.. 8 : status
+      bytes  8..16 : is_valid -/
+def ziskBlockValidateEmptyBlockPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a7, 0x40000000\n" ++
+  "  ld a1,  8(a7)                # header_rlp_len\n" ++
+  "  ld a3, 16(a7)                # body_rlp_len\n" ++
+  "  addi a0, a7, 24              # header_rlp ptr\n" ++
+  "  add a2, a0, a1               # body_rlp ptr\n" ++
+  "  li a4, 0xa0010008            # is_valid out\n" ++
+  "  jal ra, block_validate_empty_block\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lbeb_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  blockBodyDecodeFunction ++ "\n" ++
+  blockValidateEmptyBlockFunction ++ "\n" ++
+  ".Lbeb_pdone:"
+
+def ziskBlockValidateEmptyBlockDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  "beb_body_struct:\n" ++
+  "  .zero 48\n" ++
+  "beb_off:\n" ++
+  "  .zero 8\n" ++
+  "beb_len:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "beb_empty_trie_root:\n" ++
+  "  .byte 0x56, 0xe8, 0x1f, 0x17, 0x1b, 0xcc, 0x55, 0xa6\n" ++
+  "  .byte 0xff, 0x83, 0x45, 0xe6, 0x92, 0xc0, 0xf8, 0x6e\n" ++
+  "  .byte 0x5b, 0x48, 0xe0, 0x1b, 0x99, 0x6c, 0xad, 0xc0\n" ++
+  "  .byte 0x01, 0x62, 0x2f, 0xb5, 0xe3, 0x63, 0xb4, 0x21\n" ++
+  ".balign 8\n" ++
+  "beb_empty_ommers_hash:\n" ++
+  "  .byte 0x1d, 0xcc, 0x4d, 0xe8, 0xde, 0xc7, 0x5d, 0x7a\n" ++
+  "  .byte 0xab, 0x85, 0xb5, 0x67, 0xb6, 0xcc, 0xd4, 0x1a\n" ++
+  "  .byte 0xd3, 0x12, 0x45, 0x1b, 0x94, 0x8a, 0x74, 0x13\n" ++
+  "  .byte 0xf0, 0xa1, 0x42, 0xfd, 0x40, 0xd4, 0x93, 0x47"
+
+def ziskBlockValidateEmptyBlockProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskBlockValidateEmptyBlockPrologue
+  dataAsm     := ziskBlockValidateEmptyBlockDataSection
+}
+
 end EvmAsm.Codegen

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **204**
-- ziskemu round-trip scripts: **197** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **205**
+- ziskemu round-trip scripts: **198** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ and MPT primitives (`account_decode`, `account_at_address`,
 `block_validate_empty_ommers_hash`,
 `block_validate_no_withdrawals_pair`,
 `block_validate_empty_receipts_root`,
-withdrawal RLP/hash, …), and address
+`block_validate_empty_block`, withdrawal RLP/hash, …), and address
 derivation (`address_compute_create`, `address_compute_create2`,
 `address_from_pubkey`). The catalogue is tracked under the
 `PR-K*` series in [`PLAN.md`](PLAN.md).

--- a/scripts/codegen-zisk-block-validate-empty-block-check.sh
+++ b/scripts/codegen-zisk-block-validate-empty-block-check.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# codegen-zisk-block-validate-empty-block-check.sh -- PR-K182.
+#
+# Validate that a block is completely empty post-merge: 4 root
+# fields equal their canonical empty constants, and the body has
+# 3 empty fields.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_block_validate_empty_block ELF"
+lake exe codegen --program zisk_block_validate_empty_block --halt linux93 \
+  -o gen-out/zisk_block_validate_empty_block
+
+REPO_ROOT="$(pwd)"
+
+EMPTY_TRIE_ROOT="56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"
+EMPTY_OMMERS_HASH="1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+
+# run_case <name> <break: 'none' | 'tx_root' | 'ommers_hash' | 'rcpts_root' |
+#                          'wdraws_root' | 'tx_body' | 'ommers_body' |
+#                          'wdraws_body' >
+#         <exp_status> <exp_valid>
+run_case() {
+  local name="$1" brk="$2" exp_status="$3" exp_valid="$4"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_block_validate_empty_block_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_block_validate_empty_block_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+brk = '$brk'
+EMPTY_TRIE_ROOT = bytes.fromhex('$EMPTY_TRIE_ROOT')
+EMPTY_OMMERS_HASH = bytes.fromhex('$EMPTY_OMMERS_HASH')
+BAD = b'\\xff'*32
+
+ommers_hash      = BAD if brk == 'ommers_hash' else EMPTY_OMMERS_HASH
+tx_root          = BAD if brk == 'tx_root'     else EMPTY_TRIE_ROOT
+rcpts_root       = BAD if brk == 'rcpts_root'  else EMPTY_TRIE_ROOT
+wdraws_root      = BAD if brk == 'wdraws_root' else EMPTY_TRIE_ROOT
+
+fields = [
+    b'\\x11'*32, ommers_hash, b'\\x33'*20, b'\\x44'*32, tx_root,
+    rcpts_root, b'\\x00'*256, b'', b'\\x01', b'\\x83\\xff\\xff\\xff',
+    b'', b'\\x83\\x01\\x02\\x03', b'', b'\\x77'*32, b'\\x00'*8,
+    b'\\x82\\x12\\x34', wdraws_root,
+]
+header_rlp = rlp.encode(fields)
+
+# Body: each field defaults empty, possibly broken
+tx_body     = [b'\\xaa'*10] if brk == 'tx_body'     else []
+ommers_body = [[]]            if brk == 'ommers_body' else []
+wdraws_body = [[b'\\x01', b'\\x02', b'\\xee'*20, b'\\x03']] if brk == 'wdraws_body' else []
+body_rlp = rlp.encode([tx_body, ommers_body, wdraws_body])
+
+with open(sys.argv[1], 'wb') as f:
+    record = struct.pack('<Q', len(header_rlp)) + \
+             struct.pack('<Q', len(body_rlp)) + \
+             header_rlp + body_rlp
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_block_validate_empty_block.elf \
+    -i "$in_file" -o "$out_file" -n 2000000 \
+    >"$REPO_ROOT/gen-out/zisk_block_validate_empty_block_${name}.emu.log" 2>&1 || true
+
+  local status_le; status_le="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local valid_le;  valid_le="$( dd if="$out_file" bs=1 skip=8 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local status valid
+  status="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$status_le'))[0])")"
+  valid="$( python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$valid_le'))[0])")"
+
+  if [[ "$status" == "$exp_status" && "$valid" == "$exp_valid" ]]; then
+    printf "  %-32s OK   status=%s valid=%s\n" "$name" "$status" "$valid"
+    return 0
+  else
+    printf "  %-32s FAIL status=%s/exp%s valid=%s/exp%s\n" \
+      "$name" "$status" "$exp_status" "$valid" "$exp_valid"
+    return 1
+  fi
+}
+
+FAILED=0
+run_case "all_empty"              "none"        0 1 || FAILED=1
+run_case "bad_tx_root"            "tx_root"     0 0 || FAILED=1
+run_case "bad_ommers_hash"        "ommers_hash" 0 0 || FAILED=1
+run_case "bad_rcpts_root"         "rcpts_root"  0 0 || FAILED=1
+run_case "bad_wdraws_root"        "wdraws_root" 0 0 || FAILED=1
+run_case "body_has_tx"            "tx_body"     0 0 || FAILED=1
+run_case "body_has_ommers"        "ommers_body" 0 0 || FAILED=1
+run_case "body_has_withdrawal"    "wdraws_body" 0 0 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: block_validate_empty_block enforces all 8 empty-block invariants"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Validator for a *completely empty* post-merge block: zero
transactions, empty ommers, no withdrawals. Composes all the
empty-side checks (K179, K180-style header check, K181, K177's
body shape) into a single `is_valid` u64.

## Predicates

**Header side**:
1. `transactions_root  == EMPTY_TRIE_ROOT`
2. `ommers_hash        == EMPTY_OMMERS_HASH`
3. `receipts_root      == EMPTY_TRIE_ROOT`
4. `withdrawals_root   == EMPTY_TRIE_ROOT`

**Body side**:
5. body decodes to a 3-item list `[txs, ommers, withdrawals]`
6. `txs        == 0xc0`  (rlp([]))
7. `ommers     == 0xc0`
8. `withdrawals == 0xc0`

All eight must hold. Uses an inlined helper
`beb_check_header_field_32B` to factor the 32B-field-equals-constant
check across the four header predicates. The two canonical constants
(`EMPTY_TRIE_ROOT`, `EMPTY_OMMERS_HASH`) live as `.byte` literals in
`.data`.

## Status codes

| code | meaning |
|---:|---|
| 0 | success -- predicate written |
| 1 | body parse failure |
| 2 | header parse failure (any field) |
| 3 | header field-size mismatch (some 32B field had len != 32) |

## Test plan

8 ziskemu fixtures covering the positive case + each invariant
broken individually:

- [x] `all_empty` -- all 8 predicates hold -> valid=1
- [x] `bad_tx_root` -- transactions_root != EMPTY_TRIE_ROOT -> valid=0
- [x] `bad_ommers_hash` -- ommers_hash != EMPTY_OMMERS_HASH -> valid=0
- [x] `bad_rcpts_root` -- receipts_root != EMPTY_TRIE_ROOT -> valid=0
- [x] `bad_wdraws_root` -- withdrawals_root != EMPTY_TRIE_ROOT -> valid=0
- [x] `body_has_tx` -- body has 1 tx -> valid=0
- [x] `body_has_ommers` -- body has 1 uncle -> valid=0
- [x] `body_has_withdrawal` -- body has 1 withdrawal -> valid=0

## Stack

Builds on #5978 (PR-K181 `block_validate_empty_receipts_root`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)