### PR TITLE
feat(stateless): validate_empty_block_with_parent (PR-K183)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -5200,6 +5200,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_block_validate_no_withdrawals_pair" => some ziskBlockValidateNoWithdrawalsPairProbeUnit
   | "zisk_block_validate_empty_receipts_root" => some ziskBlockValidateEmptyReceiptsRootProbeUnit
   | "zisk_block_validate_empty_block" => some ziskBlockValidateEmptyBlockProbeUnit
+  | "zisk_validate_empty_block_with_parent" => some ziskValidateEmptyBlockWithParentProbeUnit
   | "zisk_block_logs_bloom_from_receipts_list" => some ziskBlockLogsBloomFromReceiptsListProbeUnit
   | "zisk_block_validate_logs_bloom" => some ziskBlockValidateLogsBloomProbeUnit
   | "zisk_header_root_is_empty_trie" => some ziskHeaderRootIsEmptyTrieProbeUnit
@@ -5396,6 +5397,7 @@ def knownProgramNames : List String :=
    "zisk_block_validate_no_withdrawals_pair",
    "zisk_block_validate_empty_receipts_root",
    "zisk_block_validate_empty_block",
+   "zisk_validate_empty_block_with_parent",
    "zisk_block_logs_bloom_from_receipts_list",
    "zisk_block_validate_logs_bloom",
    "zisk_header_root_is_empty_trie",

--- a/EvmAsm/Codegen/Programs/Block.lean
+++ b/EvmAsm/Codegen/Programs/Block.lean
@@ -2900,4 +2900,168 @@ def ziskBlockValidateEmptyBlockProbeUnit : BuildUnit := {
   dataAsm     := ziskBlockValidateEmptyBlockDataSection
 }
 
+/-! ## validate_empty_block_with_parent -- PR-K183
+
+    Full validator for an empty post-merge block linked to a
+    parent: composes K174 `validate_header_pair` (4 pair
+    invariants between parent and child header) with K182
+    `block_validate_empty_block` (4 header empty-root checks +
+    4 body emptiness checks).
+
+    Per-block predicate (all 12 must hold):
+
+      A. validate_header_pair(parent, child) accepts:
+         child.parent_hash == keccak256(parent_rlp)
+         child.number == parent.number + 1
+         child.timestamp > parent.timestamp
+         check_gas_limit(child, parent) == 0
+      B. block_validate_empty_block(child, body) accepts:
+         child.transactions_root  == EMPTY_TRIE_ROOT
+         child.ommers_hash        == EMPTY_OMMERS_HASH
+         child.receipts_root      == EMPTY_TRIE_ROOT
+         child.withdrawals_root   == EMPTY_TRIE_ROOT
+         body.txs                 == 0xc0
+         body.ommers              == 0xc0
+         body.withdrawals         == 0xc0
+
+    The is_valid u64 is 1 iff all 12 predicates hold.
+
+    Calling convention:
+      a0 (input)  : parent_rlp ptr
+      a1 (input)  : parent_rlp byte length
+      a2 (input)  : child_rlp ptr
+      a3 (input)  : child_rlp byte length
+      a4 (input)  : body_rlp ptr
+      a5 (input)  : body_rlp byte length
+      a6 (input)  : u64 out (is_valid)
+      ra (input)  : return
+      a0 (output) :
+        0       : success -- predicate written
+        1..4    : propagated from validate_header_pair
+                  (1 child parse, 2 phash size, 3 parent field,
+                   4 child field)
+        11..13  : propagated from block_validate_empty_block
+                  (11 body parse, 12 header parse, 13 header size) -/
+def validateEmptyBlockWithParentFunction : String :=
+  "validate_empty_block_with_parent:\n" ++
+  "  addi sp, sp, -64\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp)\n" ++
+  "  mv s0, a0; mv s1, a1                # parent\n" ++
+  "  mv s2, a2; mv s3, a3                # child header\n" ++
+  "  mv s4, a4; mv s5, a5                # body\n" ++
+  "  mv s6, a6                            # is_valid out\n" ++
+  "  sd zero, 0(s6)\n" ++
+  "  # ---- (A) Pair check ----\n" ++
+  "  mv a0, s0; mv a1, s1\n" ++
+  "  mv a2, s2; mv a3, s3\n" ++
+  "  la a4, vebwp_pair_valid\n" ++
+  "  jal ra, validate_header_pair\n" ++
+  "  beqz a0, .Lvebwp_pair_status_ok\n" ++
+  "  # Propagate K174 status (1..4) unchanged.\n" ++
+  "  j .Lvebwp_ret\n" ++
+  ".Lvebwp_pair_status_ok:\n" ++
+  "  la t0, vebwp_pair_valid; ld t1, 0(t0)\n" ++
+  "  beqz t1, .Lvebwp_pred_false\n" ++
+  "  # ---- (B) Empty-block check ----\n" ++
+  "  mv a0, s2; mv a1, s3\n" ++
+  "  mv a2, s4; mv a3, s5\n" ++
+  "  la a4, vebwp_empty_valid\n" ++
+  "  jal ra, block_validate_empty_block\n" ++
+  "  beqz a0, .Lvebwp_empty_status_ok\n" ++
+  "  # K182 returns 1..3 -- shift to 11..13.\n" ++
+  "  addi a0, a0, 10\n" ++
+  "  j .Lvebwp_ret\n" ++
+  ".Lvebwp_empty_status_ok:\n" ++
+  "  la t0, vebwp_empty_valid; ld t1, 0(t0)\n" ++
+  "  beqz t1, .Lvebwp_pred_false\n" ++
+  "  li t0, 1\n" ++
+  "  sd t0, 0(s6)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lvebwp_ret\n" ++
+  ".Lvebwp_pred_false:\n" ++
+  "  sd zero, 0(s6)\n" ++
+  "  li a0, 0\n" ++
+  ".Lvebwp_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp)\n" ++
+  "  addi sp, sp, 64\n" ++
+  "  ret"
+
+/-- `zisk_validate_empty_block_with_parent`: probe BuildUnit.
+    Input layout:
+      bytes  0.. 8 : parent_rlp_len
+      bytes  8..16 : child_rlp_len
+      bytes 16..24 : body_rlp_len
+      bytes 24..   : parent_rlp || child_rlp || body_rlp
+    Output layout:
+      bytes  0.. 8 : status
+      bytes  8..16 : is_valid -/
+def ziskValidateEmptyBlockWithParentPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a7, 0x40000000\n" ++
+  "  ld a1,  8(a7)                # parent_rlp_len\n" ++
+  "  ld a3, 16(a7)                # child_rlp_len\n" ++
+  "  ld a5, 24(a7)                # body_rlp_len\n" ++
+  "  addi a0, a7, 32              # parent_rlp ptr\n" ++
+  "  add a2, a0, a1               # child_rlp ptr\n" ++
+  "  add a4, a2, a3               # body_rlp ptr\n" ++
+  "  li a6, 0xa0010008            # is_valid out\n" ++
+  "  jal ra, validate_empty_block_with_parent\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lvebwp_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpFieldToU64Function ++ "\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  blockHashFromHeaderFunction ++ "\n" ++
+  validateParentHashLinkFunction ++ "\n" ++
+  checkGasLimitFunction ++ "\n" ++
+  validateHeaderPairFunction ++ "\n" ++
+  blockBodyDecodeFunction ++ "\n" ++
+  blockValidateEmptyBlockFunction ++ "\n" ++
+  validateEmptyBlockWithParentFunction ++ "\n" ++
+  ".Lvebwp_pdone:"
+
+def ziskValidateEmptyBlockWithParentDataSection : String :=
+  ziskBlockValidateEmptyBlockDataSection ++ "\n" ++
+  "rfu_offset:\n" ++
+  "  .zero 8\n" ++
+  "rfu_length:\n" ++
+  "  .zero 8\n" ++
+  "vphl_offset:\n" ++
+  "  .zero 8\n" ++
+  "vphl_length:\n" ++
+  "  .zero 8\n" ++
+  "vphl_claimed:\n" ++
+  "  .zero 32\n" ++
+  "vphl_computed:\n" ++
+  "  .zero 32\n" ++
+  "vhp_link_valid:\n" ++
+  "  .zero 8\n" ++
+  "vhp_parent_number:\n" ++
+  "  .zero 8\n" ++
+  "vhp_parent_timestamp:\n" ++
+  "  .zero 8\n" ++
+  "vhp_parent_gas_limit:\n" ++
+  "  .zero 8\n" ++
+  "vhp_child_number:\n" ++
+  "  .zero 8\n" ++
+  "vhp_child_timestamp:\n" ++
+  "  .zero 8\n" ++
+  "vhp_child_gas_limit:\n" ++
+  "  .zero 8\n" ++
+  "vebwp_pair_valid:\n" ++
+  "  .zero 8\n" ++
+  "vebwp_empty_valid:\n" ++
+  "  .zero 8"
+
+def ziskValidateEmptyBlockWithParentProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskValidateEmptyBlockWithParentPrologue
+  dataAsm     := ziskValidateEmptyBlockWithParentDataSection
+}
+
 end EvmAsm.Codegen

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **205**
-- ziskemu round-trip scripts: **198** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **206**
+- ziskemu round-trip scripts: **199** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/README.md
+++ b/README.md
@@ -268,7 +268,9 @@ and MPT primitives (`account_decode`, `account_at_address`,
 `block_validate_empty_ommers_hash`,
 `block_validate_no_withdrawals_pair`,
 `block_validate_empty_receipts_root`,
-`block_validate_empty_block`, withdrawal RLP/hash, …), and address
+`block_validate_empty_block`,
+`validate_empty_block_with_parent`, withdrawal RLP/hash, …),
+and address
 derivation (`address_compute_create`, `address_compute_create2`,
 `address_from_pubkey`). The catalogue is tracked under the
 `PR-K*` series in [`PLAN.md`](PLAN.md).

--- a/scripts/codegen-zisk-validate-empty-block-with-parent-check.sh
+++ b/scripts/codegen-zisk-validate-empty-block-with-parent-check.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# codegen-zisk-validate-empty-block-with-parent-check.sh -- PR-K183.
+#
+# Composite: header-pair invariants (K174) + empty-block check (K182).
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_validate_empty_block_with_parent ELF"
+lake exe codegen --program zisk_validate_empty_block_with_parent --halt linux93 \
+  -o gen-out/zisk_validate_empty_block_with_parent
+
+REPO_ROOT="$(pwd)"
+
+EMPTY_TRIE_ROOT="56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"
+EMPTY_OMMERS_HASH="1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+
+# run_case <name> <break: 'none' | 'pair_number' | 'tx_root' | 'body_tx'>
+#         <exp_status> <exp_valid>
+run_case() {
+  local name="$1" brk="$2" exp_status="$3" exp_valid="$4"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_validate_empty_block_with_parent_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_validate_empty_block_with_parent_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+try:
+    from Crypto.Hash import keccak
+    def keccak256(b):
+        h = keccak.new(digest_bits=256); h.update(b); return h.digest()
+except Exception:
+    import sha3
+    def keccak256(b): return sha3.keccak_256(b).digest()
+
+def u_be(n):
+    if n == 0: return b''
+    return n.to_bytes((n.bit_length() + 7) // 8, 'big')
+
+brk = '$brk'
+EMPTY_TRIE_ROOT = bytes.fromhex('$EMPTY_TRIE_ROOT')
+EMPTY_OMMERS_HASH = bytes.fromhex('$EMPTY_OMMERS_HASH')
+BAD = b'\\xff'*32
+
+# Parent: arbitrary, with empty-block-style root fields too.
+parent_fields = [
+    b'\\xa1'*32, EMPTY_OMMERS_HASH, b'\\xa3'*20, b'\\xa4'*32, EMPTY_TRIE_ROOT,
+    EMPTY_TRIE_ROOT, b'\\x00'*256, b'', u_be(100), u_be(30000000),
+    b'\\x82\\x02\\x00', u_be(1000), b'', b'\\xa7'*32, b'\\x00'*8,
+    b'\\x82\\x12\\x34', EMPTY_TRIE_ROOT,
+]
+parent_rlp = rlp.encode(parent_fields)
+parent_hash = keccak256(parent_rlp)
+
+# Child: empty block by default, broken per <brk>
+child_num = 101 if brk != 'pair_number' else 102
+tx_root  = BAD if brk == 'tx_root' else EMPTY_TRIE_ROOT
+
+child_fields = [
+    parent_hash, EMPTY_OMMERS_HASH, b'\\xb3'*20, b'\\xb4'*32, tx_root,
+    EMPTY_TRIE_ROOT, b'\\x00'*256, b'', u_be(child_num), u_be(30000000),
+    b'\\x82\\x02\\x00', u_be(1001), b'', b'\\xb7'*32, b'\\x00'*8,
+    b'\\x82\\x12\\x34', EMPTY_TRIE_ROOT,
+]
+child_rlp = rlp.encode(child_fields)
+
+tx_body = [b'\\xaa'*10] if brk == 'body_tx' else []
+body_rlp = rlp.encode([tx_body, [], []])
+
+with open(sys.argv[1], 'wb') as f:
+    record = struct.pack('<Q', len(parent_rlp)) + \
+             struct.pack('<Q', len(child_rlp)) + \
+             struct.pack('<Q', len(body_rlp)) + \
+             parent_rlp + child_rlp + body_rlp
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_validate_empty_block_with_parent.elf \
+    -i "$in_file" -o "$out_file" -n 5000000 \
+    >"$REPO_ROOT/gen-out/zisk_validate_empty_block_with_parent_${name}.emu.log" 2>&1 || true
+
+  local status_le; status_le="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local valid_le;  valid_le="$( dd if="$out_file" bs=1 skip=8 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local status valid
+  status="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$status_le'))[0])")"
+  valid="$( python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$valid_le'))[0])")"
+
+  if [[ "$status" == "$exp_status" && "$valid" == "$exp_valid" ]]; then
+    printf "  %-30s OK   status=%s valid=%s\n" "$name" "$status" "$valid"
+    return 0
+  else
+    printf "  %-30s FAIL status=%s/exp%s valid=%s/exp%s\n" \
+      "$name" "$status" "$exp_status" "$valid" "$exp_valid"
+    return 1
+  fi
+}
+
+FAILED=0
+run_case "all_match"              "none"        0 1 || FAILED=1
+run_case "fail_pair_number"       "pair_number" 0 0 || FAILED=1
+run_case "fail_empty_tx_root"     "tx_root"     0 0 || FAILED=1
+run_case "fail_body_has_tx"       "body_tx"     0 0 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: validate_empty_block_with_parent enforces pair + empty invariants jointly"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Full validator for an empty post-merge block linked to a parent:
composes K174 `validate_header_pair` (4 pair invariants between
parent and child) with K182 `block_validate_empty_block` (4 header
empty-root checks + 4 body emptiness checks). `is_valid = 1` iff
all 12 predicates hold.

## Predicates

**Pair (A):**
1. `child.parent_hash == keccak256(parent_rlp)`
2. `child.number == parent.number + 1`
3. `child.timestamp > parent.timestamp`
4. `check_gas_limit(child, parent) == 0`

**Empty-block (B):**
5. `child.transactions_root == EMPTY_TRIE_ROOT`
6. `child.ommers_hash == EMPTY_OMMERS_HASH`
7. `child.receipts_root == EMPTY_TRIE_ROOT`
8. `child.withdrawals_root == EMPTY_TRIE_ROOT`
9. body decodes as 3-item list
10. `body.txs == 0xc0`
11. `body.ommers == 0xc0`
12. `body.withdrawals == 0xc0`

## Status codes

- `0` success
- `1..4` propagated from `validate_header_pair`
- `11..13` shifted from `block_validate_empty_block`

## Test plan

4 ziskemu fixtures:

- [x] `all_match` -- all 12 predicates hold -> valid=1
- [x] `fail_pair_number` -- child.number = parent.number + 2 -> valid=0
- [x] `fail_empty_tx_root` -- header.tx_root = 0xff*32 -> valid=0
- [x] `fail_body_has_tx` -- body has 1 tx item -> valid=0

The natural endpoint for the no-execution / fast-path validator
stack. With ECRECOVER and EVM dispatch still gated, this is the
strongest "this block is correctly attached to its parent" claim
we can make today.

## Stack

Builds on #5979 (PR-K182 `block_validate_empty_block`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)