### PR TITLE
feat(stateless): validate_empty_block_chain (PR-K184)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -5201,6 +5201,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_block_validate_empty_receipts_root" => some ziskBlockValidateEmptyReceiptsRootProbeUnit
   | "zisk_block_validate_empty_block" => some ziskBlockValidateEmptyBlockProbeUnit
   | "zisk_validate_empty_block_with_parent" => some ziskValidateEmptyBlockWithParentProbeUnit
+  | "zisk_validate_empty_block_chain" => some ziskValidateEmptyBlockChainProbeUnit
   | "zisk_block_logs_bloom_from_receipts_list" => some ziskBlockLogsBloomFromReceiptsListProbeUnit
   | "zisk_block_validate_logs_bloom" => some ziskBlockValidateLogsBloomProbeUnit
   | "zisk_header_root_is_empty_trie" => some ziskHeaderRootIsEmptyTrieProbeUnit
@@ -5398,6 +5399,7 @@ def knownProgramNames : List String :=
    "zisk_block_validate_empty_receipts_root",
    "zisk_block_validate_empty_block",
    "zisk_validate_empty_block_with_parent",
+   "zisk_validate_empty_block_chain",
    "zisk_block_logs_bloom_from_receipts_list",
    "zisk_block_validate_logs_bloom",
    "zisk_header_root_is_empty_trie",

--- a/EvmAsm/Codegen/Programs/Block.lean
+++ b/EvmAsm/Codegen/Programs/Block.lean
@@ -3064,4 +3064,189 @@ def ziskValidateEmptyBlockWithParentProbeUnit : BuildUnit := {
   dataAsm     := ziskValidateEmptyBlockWithParentDataSection
 }
 
+/-! ## validate_empty_block_chain -- PR-K184
+
+    Iterate `validate_empty_block_with_parent` (K183) over an
+    N-element chain of (header, body) pairs and verify every
+    link in the chain is a valid empty-block step. This is the
+    direct analogue of K175 `validate_header_chain` extended to
+    cover both header AND body sides; it is the natural
+    endpoint of stateless validation for the all-empty fast path.
+
+    Input layout (length-prefix tables + flat byte blob):
+
+      headers[0..N) -- N header RLPs concatenated
+      bodies[0..N)  -- N body  RLPs concatenated
+
+    The first header is the *parent* of headers[1]; we verify
+    `validate_empty_block_with_parent(headers[i], headers[i+1],
+                                       bodies[i+1])`
+    for i in 0..N-1, i.e. N-1 link checks. The first body is
+    not used (the parent's body is upstream); we only validate
+    the empty-block predicate against bodies[1..N).
+
+    Vacuous-true on N == 0 and N == 1 (no link to verify).
+
+    Calling convention:
+      a0 (input)  : N (block count)
+      a1 (input)  : header_lengths ptr (u64[N])
+      a2 (input)  : headers ptr (concatenated)
+      a3 (input)  : body_lengths ptr   (u64[N])
+      a4 (input)  : bodies ptr  (concatenated)
+      a5 (input)  : u64 out (is_valid)
+      a6 (input)  : u64 out (first_bad_index)
+      ra (input)  : return
+      a0 (output) :
+        0 : success -- predicate written
+        nonzero : propagated status from
+                  `validate_empty_block_with_parent` for the
+                  first failing pair -/
+def validateEmptyBlockChainFunction : String :=
+  "validate_empty_block_chain:\n" ++
+  "  addi sp, sp, -96\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp); sd s7, 64(sp)\n" ++
+  "  sd s8, 72(sp); sd s9, 80(sp); sd s10, 88(sp)\n" ++
+  "  mv s0, a0                   # N\n" ++
+  "  mv s1, a1                   # header_lengths ptr\n" ++
+  "  mv s2, a2                   # headers ptr\n" ++
+  "  mv s3, a3                   # body_lengths ptr\n" ++
+  "  mv s4, a4                   # bodies ptr\n" ++
+  "  mv s5, a5                   # is_valid out\n" ++
+  "  mv s6, a6                   # first_bad_index out\n" ++
+  "  sd zero, 0(s5)\n" ++
+  "  sd zero, 0(s6)\n" ++
+  "  # Vacuous-true for N == 0 or N == 1.\n" ++
+  "  li t0, 2\n" ++
+  "  bltu s0, t0, .Lvebc_vacuous\n" ++
+  "  # Walking pointers (all callee-saved across inner calls):\n" ++
+  "  #   s7 = parent header ptr\n" ++
+  "  #   s8 = child header ptr (computed each iter)\n" ++
+  "  #   s9 = i (current index)\n" ++
+  "  #   s10 = bodies running ptr (for body[i+1])\n" ++
+  "  mv s7, s2                   # parent header ptr = headers[0]\n" ++
+  "  mv s10, s4                  # bodies ptr starts at bodies[0]\n" ++
+  "  # Skip body[0] (parent's body, not used in this chain shape)\n" ++
+  "  ld t0, 0(s3)\n" ++
+  "  add s10, s10, t0\n" ++
+  "  li s9, 0                    # i = 0\n" ++
+  ".Lvebc_loop:\n" ++
+  "  addi t0, s9, 1\n" ++
+  "  beq t0, s0, .Lvebc_done\n" ++
+  "  # parent_len = header_lengths[i]; child_len = header_lengths[i+1]\n" ++
+  "  slli t1, s9, 3\n" ++
+  "  add t1, s1, t1\n" ++
+  "  ld a1, 0(t1)                # parent_len (callee passes through args)\n" ++
+  "  ld a3, 8(t1)                # child_len\n" ++
+  "  add s8, s7, a1              # child ptr = parent ptr + parent_len\n" ++
+  "  # body_len = body_lengths[i+1]\n" ++
+  "  slli t4, t0, 3\n" ++
+  "  add t4, s3, t4\n" ++
+  "  ld a5, 0(t4)                # body_len\n" ++
+  "  # Stash advance deltas in callee-saved s11 (parent_len already\n" ++
+  "  # consumed via a1) and reuse a1/a5 across the call -- they're\n" ++
+  "  # caller-saved but we re-derive them after the call below.\n" ++
+  "  mv a0, s7\n" ++
+  "  mv a2, s8\n" ++
+  "  mv a4, s10\n" ++
+  "  la a6, vebc_pair_valid\n" ++
+  "  jal ra, validate_empty_block_with_parent\n" ++
+  "  bnez a0, .Lvebc_status_fail\n" ++
+  "  la t0, vebc_pair_valid; ld t1, 0(t0)\n" ++
+  "  beqz t1, .Lvebc_pred_false\n" ++
+  "  # Advance to next pair -- re-derive parent_len and body_len\n" ++
+  "  # since t-regs and a-regs were clobbered by the call.\n" ++
+  "  slli t1, s9, 3\n" ++
+  "  add t1, s1, t1\n" ++
+  "  ld t2, 0(t1)                # parent_len[i]\n" ++
+  "  add s7, s7, t2              # parent ptr += parent_len\n" ++
+  "  addi t3, s9, 1\n" ++
+  "  slli t3, t3, 3\n" ++
+  "  add t3, s3, t3\n" ++
+  "  ld t4, 0(t3)                # body_len[i+1]\n" ++
+  "  add s10, s10, t4            # bodies ptr += body_len\n" ++
+  "  addi s9, s9, 1\n" ++
+  "  j .Lvebc_loop\n" ++
+  ".Lvebc_done:\n" ++
+  ".Lvebc_vacuous:\n" ++
+  "  li t0, 1\n" ++
+  "  sd t0, 0(s5)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lvebc_ret\n" ++
+  ".Lvebc_pred_false:\n" ++
+  "  sd zero, 0(s5)\n" ++
+  "  sd s9, 0(s6)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lvebc_ret\n" ++
+  ".Lvebc_status_fail:\n" ++
+  "  sd s9, 0(s6)\n" ++
+  ".Lvebc_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp); ld s7, 64(sp)\n" ++
+  "  ld s8, 72(sp); ld s9, 80(sp); ld s10, 88(sp)\n" ++
+  "  addi sp, sp, 96\n" ++
+  "  ret"
+
+/-- `zisk_validate_empty_block_chain`: probe BuildUnit.
+    Input layout:
+      bytes  0.. 8 : N
+      bytes  8..8+8N : header_lengths (u64[N])
+      bytes  8+8N..8+16N : body_lengths (u64[N])
+      bytes  8+16N.. : concatenated headers || concatenated bodies
+    Output layout:
+      bytes  0.. 8 : status
+      bytes  8..16 : is_valid
+      bytes 16..24 : first_bad_index -/
+def ziskValidateEmptyBlockChainPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a7, 0x40000000\n" ++
+  "  ld a0, 8(a7)                # N\n" ++
+  "  addi a1, a7, 16             # header_lengths ptr\n" ++
+  "  slli t0, a0, 3              # 8*N\n" ++
+  "  add a3, a1, t0              # body_lengths ptr\n" ++
+  "  add a2, a3, t0              # headers ptr = body_lengths + 8N\n" ++
+  "  # bodies ptr = headers + sum(header_lengths)\n" ++
+  "  mv a4, a2\n" ++
+  "  mv t1, a1                   # header_lengths cursor\n" ++
+  "  mv t2, a0                   # remaining\n" ++
+  ".Lvebc_sum:\n" ++
+  "  beqz t2, .Lvebc_sum_done\n" ++
+  "  ld t3, 0(t1)\n" ++
+  "  add a4, a4, t3\n" ++
+  "  addi t1, t1, 8\n" ++
+  "  addi t2, t2, -1\n" ++
+  "  j .Lvebc_sum\n" ++
+  ".Lvebc_sum_done:\n" ++
+  "  li a5, 0xa0010008           # is_valid out\n" ++
+  "  li a6, 0xa0010010           # first_bad_index out\n" ++
+  "  jal ra, validate_empty_block_chain\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lvebc_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpFieldToU64Function ++ "\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  blockHashFromHeaderFunction ++ "\n" ++
+  validateParentHashLinkFunction ++ "\n" ++
+  checkGasLimitFunction ++ "\n" ++
+  validateHeaderPairFunction ++ "\n" ++
+  blockBodyDecodeFunction ++ "\n" ++
+  blockValidateEmptyBlockFunction ++ "\n" ++
+  validateEmptyBlockWithParentFunction ++ "\n" ++
+  validateEmptyBlockChainFunction ++ "\n" ++
+  ".Lvebc_pdone:"
+
+def ziskValidateEmptyBlockChainDataSection : String :=
+  ziskValidateEmptyBlockWithParentDataSection ++ "\n" ++
+  "vebc_pair_valid:\n" ++
+  "  .zero 8"
+
+def ziskValidateEmptyBlockChainProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskValidateEmptyBlockChainPrologue
+  dataAsm     := ziskValidateEmptyBlockChainDataSection
+}
+
 end EvmAsm.Codegen

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **206**
-- ziskemu round-trip scripts: **199** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **207**
+- ziskemu round-trip scripts: **200** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/README.md
+++ b/README.md
@@ -269,7 +269,8 @@ and MPT primitives (`account_decode`, `account_at_address`,
 `block_validate_no_withdrawals_pair`,
 `block_validate_empty_receipts_root`,
 `block_validate_empty_block`,
-`validate_empty_block_with_parent`, withdrawal RLP/hash, …),
+`validate_empty_block_with_parent`,
+`validate_empty_block_chain`, withdrawal RLP/hash, …),
 and address
 derivation (`address_compute_create`, `address_compute_create2`,
 `address_from_pubkey`). The catalogue is tracked under the

--- a/scripts/codegen-zisk-validate-empty-block-chain-check.sh
+++ b/scripts/codegen-zisk-validate-empty-block-chain-check.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# codegen-zisk-validate-empty-block-chain-check.sh -- PR-K184.
+#
+# Iterate validate_empty_block_with_parent over an N-element chain
+# of (header, body) pairs.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_validate_empty_block_chain ELF"
+lake exe codegen --program zisk_validate_empty_block_chain --halt linux93 \
+  -o gen-out/zisk_validate_empty_block_chain
+
+REPO_ROOT="$(pwd)"
+
+EMPTY_TRIE_ROOT="56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"
+EMPTY_OMMERS_HASH="1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+
+# run_case <name> <spec_py_expr> <exp_status> <exp_valid> <exp_first_bad>
+run_case() {
+  local name="$1" spec="$2" exp_status="$3" exp_valid="$4" exp_bad="$5"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_validate_empty_block_chain_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_validate_empty_block_chain_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+try:
+    from Crypto.Hash import keccak
+    def keccak256(b):
+        h = keccak.new(digest_bits=256); h.update(b); return h.digest()
+except Exception:
+    import sha3
+    def keccak256(b): return sha3.keccak_256(b).digest()
+
+def u_be(n):
+    if n == 0: return b''
+    return n.to_bytes((n.bit_length() + 7) // 8, 'big')
+
+EMPTY_TRIE_ROOT = bytes.fromhex('$EMPTY_TRIE_ROOT')
+EMPTY_OMMERS_HASH = bytes.fromhex('$EMPTY_OMMERS_HASH')
+BAD = b'\\xff'*32
+
+def make_header(parent_hash, num, ts, gl, tx_root=EMPTY_TRIE_ROOT):
+    return rlp.encode([
+        parent_hash, EMPTY_OMMERS_HASH, b'\\xb3'*20, b'\\xb4'*32, tx_root,
+        EMPTY_TRIE_ROOT, b'\\x00'*256, b'', u_be(num), u_be(gl),
+        b'\\x82\\x02\\x00', u_be(ts), b'', b'\\xb7'*32, b'\\x00'*8,
+        b'\\x82\\x12\\x34', EMPTY_TRIE_ROOT,
+    ])
+
+def make_empty_body():
+    return rlp.encode([[], [], []])
+
+def make_body_with_tx():
+    return rlp.encode([[b'\\xaa'*10], [], []])
+
+# spec: list of (num, ts, gl, tx_root_override_or_None, body_kind: 'empty'|'with_tx')
+# Chain: each header's parent_hash = keccak256(prev_rlp). Body[0] is ignored.
+spec = $spec
+headers = []
+bodies = []
+prev_hash = b'\\x00'*32
+for n, ts, gl, override, body_kind in spec:
+    tr = override if override is not None else EMPTY_TRIE_ROOT
+    h = make_header(prev_hash, n, ts, gl, tx_root=tr)
+    headers.append(h)
+    bodies.append(make_body_with_tx() if body_kind == 'with_tx' else make_empty_body())
+    prev_hash = keccak256(h)
+
+N = len(headers)
+header_lengths = b''.join(struct.pack('<Q', len(h)) for h in headers)
+body_lengths   = b''.join(struct.pack('<Q', len(b)) for b in bodies)
+flat_h = b''.join(headers)
+flat_b = b''.join(bodies)
+
+with open(sys.argv[1], 'wb') as f:
+    record = struct.pack('<Q', N) + header_lengths + body_lengths + flat_h + flat_b
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_validate_empty_block_chain.elf \
+    -i "$in_file" -o "$out_file" -n 20000000 \
+    >"$REPO_ROOT/gen-out/zisk_validate_empty_block_chain_${name}.emu.log" 2>&1 || true
+
+  local status_le; status_le="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local valid_le;  valid_le="$( dd if="$out_file" bs=1 skip=8  count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local bad_le;    bad_le="$(   dd if="$out_file" bs=1 skip=16 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local status valid bad
+  status="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$status_le'))[0])")"
+  valid="$( python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$valid_le'))[0])")"
+  bad="$(   python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$bad_le'))[0])")"
+
+  if [[ "$status" == "$exp_status" && "$valid" == "$exp_valid" && "$bad" == "$exp_bad" ]]; then
+    printf "  %-30s OK   status=%s valid=%s bad=%s\n" "$name" "$status" "$valid" "$bad"
+    return 0
+  else
+    printf "  %-30s FAIL status=%s/%s valid=%s/%s bad=%s/%s\n" \
+      "$name" "$status" "$exp_status" "$valid" "$exp_valid" "$bad" "$exp_bad"
+    return 1
+  fi
+}
+
+FAILED=0
+run_case "vacuous_empty" "[]" 0 1 0 || FAILED=1
+run_case "vacuous_single" "[(100,1000,30000000,None,'empty')]" 0 1 0 || FAILED=1
+run_case "two_block_chain_ok" "[
+    (100,1000,30000000,None,'empty'),
+    (101,1001,30000000,None,'empty'),
+]" 0 1 0 || FAILED=1
+run_case "three_block_chain_ok" "[
+    (100,1000,30000000,None,'empty'),
+    (101,1001,30000000,None,'empty'),
+    (102,1002,30000000,None,'empty'),
+]" 0 1 0 || FAILED=1
+run_case "fail_at_index_1_tx_root" "[
+    (100,1000,30000000,None,'empty'),
+    (101,1001,30000000,None,'empty'),
+    (102,1002,30000000,bytes.fromhex('ff'*32),'empty'),
+]" 0 0 1 || FAILED=1
+run_case "fail_at_index_0_body" "[
+    (100,1000,30000000,None,'empty'),
+    (101,1001,30000000,None,'with_tx'),
+]" 0 0 0 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: validate_empty_block_chain walks N-chain and reports first bad index"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Iterate `validate_empty_block_with_parent` (K183) over an N-element
chain of (header, body) pairs. Direct analogue of K175
`validate_header_chain` extended to cover both header AND body
sides; the natural endpoint of stateless validation for the
all-empty fast path.

Reports the **first** failing index back to the caller; vacuous-true
on `N == 0` and `N == 1`. The first body is unused (the parent's
body is upstream); we only validate the empty-block predicate
against `bodies[1..N)`.

## Input layout

```
bytes  0..  8         : N (block count)
bytes  8..8+8N        : header_lengths (u64[N])
bytes  8+8N..8+16N    : body_lengths   (u64[N])
bytes  8+16N..        : concatenated headers || concatenated bodies
```

## Bug caught during testing

The loop initially stashed `body_len` in `t5`, which is caller-saved
and clobbered by the inner `validate_empty_block_with_parent` call.
Fixed by keeping all walking state in callee-saved registers
(`s7..s10`) and re-deriving caller-saved values after every call.

## Test plan

6 ziskemu fixtures:

- [x] `vacuous_empty` -- N=0 -> valid=1
- [x] `vacuous_single` -- N=1 -> valid=1
- [x] `two_block_chain_ok` -- N=2, all empty -> valid=1
- [x] `three_block_chain_ok` -- N=3, all empty -> valid=1
- [x] `fail_at_index_1_tx_root` -- N=3, tx_root mismatch at link 1 -> bad=1
- [x] `fail_at_index_0_body` -- N=2, body[1] has 1 tx -> bad=0

## Stack

Builds on #5981 (PR-K183 `validate_empty_block_with_parent`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)