### PR TITLE
feat(stateless): mpt_one_leaf_root_indexed (PR-K185)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -5188,6 +5188,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_mpt_leaf_node_encode_from_nibbles" => some ziskMptLeafNodeEncodeFromNibblesProbeUnit
   | "zisk_mpt_branch_node_keccak" => some ziskMptBranchNodeKeccakProbeUnit
   | "zisk_mpt_two_leaf_root_indexed" => some ziskMptTwoLeafRootIndexedProbeUnit
+  | "zisk_mpt_one_leaf_root_indexed" => some ziskMptOneLeafRootIndexedProbeUnit
   | "zisk_block_validate_transactions_root_two_tx" => some ziskBlockValidateTransactionsRootTwoTxProbeUnit
   | "zisk_block_hash_from_header" => some ziskBlockHashFromHeaderProbeUnit
   | "zisk_validate_parent_hash_link" => some ziskValidateParentHashLinkProbeUnit
@@ -5386,6 +5387,7 @@ def knownProgramNames : List String :=
    "zisk_mpt_leaf_node_encode_from_nibbles",
    "zisk_mpt_branch_node_keccak",
    "zisk_mpt_two_leaf_root_indexed",
+   "zisk_mpt_one_leaf_root_indexed",
    "zisk_block_validate_transactions_root_two_tx",
    "zisk_block_hash_from_header",
    "zisk_validate_parent_hash_link",

--- a/EvmAsm/Codegen/Programs/Mpt.lean
+++ b/EvmAsm/Codegen/Programs/Mpt.lean
@@ -4227,5 +4227,117 @@ def ziskBlockValidateTransactionsRootTwoTxProbeUnit : BuildUnit := {
   dataAsm     := ziskBlockValidateTransactionsRootTwoTxDataSection
 }
 
+/-! ## mpt_one_leaf_root_indexed -- PR-K185
+
+    MPT root for the N=1 case of `transactions_root` /
+    `receipts_root` / `withdrawals_root`: the trie has one
+    entry at key `rlp(0) = 0x80` (which encodes to nibbles
+    `[8, 0]`). With only one entry, the entire trie collapses
+    to a single leaf node:
+
+      leaf = rlp([hp([8, 0], leaf=true), value])
+      root = keccak256(leaf)               -- if len(leaf) >= 32
+      root = inline leaf                    -- if len(leaf) < 32
+                                              (but as a 32B root
+                                               it must be hashed
+                                               for header field)
+
+    For Ethereum header roots the result is ALWAYS a 32-byte
+    keccak256 hash, regardless of leaf size, because the spec
+    pre-pads short trie roots: `if len < 32: keccak256(leaf)
+    anyway`. So we unconditionally take the keccak.
+
+    Composes:
+      - PR-K168 `mpt_leaf_node_encode_from_nibbles`
+      - keccak256 sponge (zkvm_keccak256)
+
+    Calling convention:
+      a0 (input)  : value ptr (the single tx / receipt / withdrawal)
+      a1 (input)  : value byte length
+      a2 (input)  : 32-byte output root ptr
+      ra (input)  : return -/
+def mptOneLeafRootIndexedFunction : String :=
+  "mpt_one_leaf_root_indexed:\n" ++
+  "  addi sp, sp, -32\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp)\n" ++
+  "  mv s0, a0                   # value ptr\n" ++
+  "  mv s1, a1                   # value len\n" ++
+  "  mv s2, a2                   # output root ptr\n" ++
+  "  # Build path = [8, 0] (rlp(0)=0x80 -> nibbles [8,0])\n" ++
+  "  la t0, mtoli_nibbles\n" ++
+  "  li t1, 8; sb t1, 0(t0)\n" ++
+  "  li t1, 0; sb t1, 1(t0)\n" ++
+  "  # ---- Encode leaf node ----\n" ++
+  "  la a0, mtoli_nibbles\n" ++
+  "  li a1, 2\n" ++
+  "  mv a2, s0; mv a3, s1\n" ++
+  "  la a4, mtoli_leaf_buf\n" ++
+  "  la a5, mtoli_leaf_len\n" ++
+  "  jal ra, mpt_leaf_node_encode_from_nibbles\n" ++
+  "  # ---- keccak256 the leaf ----\n" ++
+  "  la a0, mtoli_leaf_buf\n" ++
+  "  la t0, mtoli_leaf_len; ld a1, 0(t0)\n" ++
+  "  mv a2, s2\n" ++
+  "  jal ra, zkvm_keccak256\n" ++
+  "  li a0, 0\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp)\n" ++
+  "  addi sp, sp, 32\n" ++
+  "  ret"
+
+/-- `zisk_mpt_one_leaf_root_indexed`: probe BuildUnit.
+    Input layout:
+      bytes 0..8 : value_len
+      bytes 8..  : value
+    Output layout:
+      bytes 0..32 : 32-byte trie root -/
+def ziskMptOneLeafRootIndexedPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a5, 0x40000000\n" ++
+  "  ld a1, 8(a5)                # value_len\n" ++
+  "  addi a0, a5, 16             # value ptr\n" ++
+  "  li a2, 0xa0010000           # output root ptr (32 B)\n" ++
+  "  jal ra, mpt_one_leaf_root_indexed\n" ++
+  "  j .Lmtoli_pdone\n" ++
+  hpEncodeNibblesFunction ++ "\n" ++
+  rlpEncodeBytesFunction ++ "\n" ++
+  rlpEncodeListPrefixFunction ++ "\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  mptLeafNodeEncodeFromNibblesFunction ++ "\n" ++
+  mptOneLeafRootIndexedFunction ++ "\n" ++
+  ".Lmtoli_pdone:"
+
+def ziskMptOneLeafRootIndexedDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  "mlnen_field_len:\n" ++
+  "  .zero 8\n" ++
+  "mlnen_hp_len:\n" ++
+  "  .zero 8\n" ++
+  "mlnen_cursor:\n" ++
+  "  .zero 8\n" ++
+  "mlnen_total_payload:\n" ++
+  "  .zero 8\n" ++
+  "mlnen_hp_buf:\n" ++
+  "  .zero 1024\n" ++
+  "mlnen_payload_buf:\n" ++
+  "  .zero 16384\n" ++
+  "mtoli_nibbles:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "mtoli_leaf_len:\n" ++
+  "  .zero 8\n" ++
+  "mtoli_leaf_buf:\n" ++
+  "  .zero 16384"
+
+def ziskMptOneLeafRootIndexedProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskMptOneLeafRootIndexedPrologue
+  dataAsm     := ziskMptOneLeafRootIndexedDataSection
+}
+
 
 end EvmAsm.Codegen

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **207**
-- ziskemu round-trip scripts: **200** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **208**
+- ziskemu round-trip scripts: **201** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/README.md
+++ b/README.md
@@ -258,7 +258,8 @@ field accessors (legacy / EIP-1559 / EIP-2930 / EIP-4844 / EIP-7702
 decoders, intrinsic-gas helpers, signature extraction, …), account
 and MPT primitives (`account_decode`, `account_at_address`,
 `account_extract_*`, `mpt_walk`, `mpt_branch_*`, `mpt_compact_*`,
-`mpt_two_leaf_root_indexed`, …), block-body helpers
+`mpt_two_leaf_root_indexed`, `mpt_one_leaf_root_indexed`, …),
+block-body helpers
 (`block_body_decode`, `block_count_transactions`,
 `block_validate_transactions_root_two_tx`,
 `block_hash_from_header`, `validate_parent_hash_link`,

--- a/scripts/codegen-zisk-mpt-one-leaf-root-indexed-check.sh
+++ b/scripts/codegen-zisk-mpt-one-leaf-root-indexed-check.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# codegen-zisk-mpt-one-leaf-root-indexed-check.sh -- PR-K185.
+#
+# MPT root for an indexed 1-entry trie (key rlp(0)=0x80).
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_mpt_one_leaf_root_indexed ELF"
+lake exe codegen --program zisk_mpt_one_leaf_root_indexed --halt linux93 \
+  -o gen-out/zisk_mpt_one_leaf_root_indexed
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <value_hex>
+run_case() {
+  local name="$1" v="$2"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_mpt_one_leaf_root_indexed_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_mpt_one_leaf_root_indexed_${name}.output"
+  local exp_hex_file="$REPO_ROOT/gen-out/zisk_mpt_one_leaf_root_indexed_${name}.expected.hex"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+try:
+    from Crypto.Hash import keccak
+    def keccak256(b):
+        h = keccak.new(digest_bits=256); h.update(b); return h.digest()
+except Exception:
+    import sha3
+    def keccak256(b): return sha3.keccak_256(b).digest()
+
+v = bytes.fromhex('$v')
+
+# Single-leaf MPT: key=rlp(0)=0x80 -> nibbles [8, 0]; suffix = full nibble seq
+def hp_leaf(nibbles, value):
+    flag = 2 + (len(nibbles) & 1)
+    hp = bytearray()
+    if len(nibbles) % 2 == 1:
+        hp.append((flag << 4) | nibbles[0]); i = 1
+    else:
+        hp.append(flag << 4); i = 0
+    while i < len(nibbles):
+        hp.append((nibbles[i] << 4) | nibbles[i+1]); i += 2
+    return rlp.encode([bytes(hp), value])
+
+leaf = hp_leaf([8, 0], v)
+expected = keccak256(leaf)
+
+with open(sys.argv[1], 'wb') as f:
+    f.write(struct.pack('<Q', len(v)))
+    f.write(v)
+    pad = (-(8 + len(v))) % 8
+    if pad: f.write(b'\x00' * pad)
+with open(sys.argv[2], 'w') as f:
+    f.write(expected.hex())
+" "$in_file" "$exp_hex_file"
+
+  "$ZISKEMU" -e gen-out/zisk_mpt_one_leaf_root_indexed.elf \
+    -i "$in_file" -o "$out_file" -n 2000000 \
+    >"$REPO_ROOT/gen-out/zisk_mpt_one_leaf_root_indexed_${name}.emu.log" 2>&1 || true
+
+  local actual; actual="$(xxd -p -l 32 "$out_file" | tr -d '\n')"
+  local expected; expected="$(cat "$exp_hex_file")"
+
+  if [[ "$actual" == "$expected" ]]; then
+    printf "  %-30s OK   root=%s...\n" "$name" "${actual:0:16}"
+    return 0
+  else
+    printf "  %-30s FAIL\n" "$name"
+    printf "      actual:   %s\n" "$actual"
+    printf "      expected: %s\n" "$expected"
+    return 1
+  fi
+}
+
+TX_LEGACY="f8500184ee6b280082520894aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa881bc16d674ec80000801ba01111111111111111111111111111111111111111111111111111111111111111a02222222222222222222222222222222222222222222222222222222222222222"
+
+FAILED=0
+run_case "single_legacy_tx"   "$TX_LEGACY"  || FAILED=1
+run_case "single_short_value" "01"          || FAILED=1
+run_case "single_empty_value" ""            || FAILED=1
+run_case "single_32B_value"   "$(printf 'aa%.0s' {1..32})" || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: mpt_one_leaf_root_indexed matches Python keccak256(rlp(leaf))"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

MPT root for the N=1 case of `transactions_root` / `receipts_root` /
`withdrawals_root`: the trie has a single entry at key `rlp(0) = 0x80`
(which encodes to nibbles `[8, 0]`). With only one entry, the entire
trie collapses to a single leaf node:

```
leaf = rlp([hp([8, 0], leaf=true), value])
root = keccak256(leaf)
```

The leaf is hashed regardless of length (header root fields are
always 32 B by spec). Composes K168
`mpt_leaf_node_encode_from_nibbles` + `zkvm_keccak256`.

## Calling convention

`a0` value ptr, `a1` value len, `a2` 32-byte output root ptr.

## Test plan

4 ziskemu fixtures against the Python `rlp` + `keccak256` reference:

- [x] `single_legacy_tx` -- a 109-byte legacy transaction
- [x] `single_short_value` -- single byte `0x01`
- [x] `single_empty_value` -- empty bytes
- [x] `single_32B_value` -- 32-byte value (boundary case)

Building block for 1-tx block validators (the N=1 analogue of K171's
2-tx shape).

## Stack

Builds on #5982 (PR-K184 `validate_empty_block_chain`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)