### PR TITLE
feat(stateless): block_hash_array_from_chain (PR-K187)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -5195,6 +5195,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_validate_parent_hash_link" => some ziskValidateParentHashLinkProbeUnit
   | "zisk_validate_header_pair" => some ziskValidateHeaderPairProbeUnit
   | "zisk_validate_header_chain" => some ziskValidateHeaderChainProbeUnit
+  | "zisk_block_hash_array_from_chain" => some ziskBlockHashArrayFromChainProbeUnit
   | "zisk_block_validate_2tx_full" => some ziskBlockValidate2txFullProbeUnit
   | "zisk_block_body_extract_2tx" => some ziskBlockBodyExtract2txProbeUnit
   | "zisk_block_validate_2tx_full_with_body" => some ziskBlockValidate2txFullWithBodyProbeUnit
@@ -5395,6 +5396,7 @@ def knownProgramNames : List String :=
    "zisk_validate_parent_hash_link",
    "zisk_validate_header_pair",
    "zisk_validate_header_chain",
+   "zisk_block_hash_array_from_chain",
    "zisk_block_validate_2tx_full",
    "zisk_block_body_extract_2tx",
    "zisk_block_validate_2tx_full_with_body",

--- a/EvmAsm/Codegen/Programs/Header.lean
+++ b/EvmAsm/Codegen/Programs/Header.lean
@@ -2461,4 +2461,189 @@ def ziskValidateHeaderChainProbeUnit : BuildUnit := {
   dataAsm     := ziskValidateHeaderChainDataSection
 }
 
+/-! ## block_hash_array_from_chain -- PR-K187
+
+    Validate an N-element header chain (K175) and, for each
+    header, output its block_hash (K172) into a 32*N-byte
+    output buffer. Combined output the caller can use to feed
+    downstream chain-state machinery (block_hash precompile
+    inputs, witness mapping, etc.).
+
+    Iterates over the chain twice in spirit but only once in
+    practice: walks `parent <- child` pairs, and for each
+    header writes `keccak256(header_rlp)` to the corresponding
+    32-byte slot.
+
+    Calling convention:
+      a0 (input)  : N (header count)
+      a1 (input)  : header_lengths ptr (u64[N])
+      a2 (input)  : headers ptr (concatenated)
+      a3 (input)  : block_hash_out ptr (32*N bytes)
+      a4 (input)  : u64 out (is_valid: 1 if chain accepts)
+      a5 (input)  : u64 out (first_bad_index)
+      ra (input)  : return
+      a0 (output) :
+        0 : success -- predicate + block_hashes written
+        nonzero : propagated status from validate_header_pair
+                  for the first failing link (block_hashes for
+                  headers up to and including the failure point
+                  are still written)
+
+    Special: for N == 0, write nothing and report is_valid=1.
+    For N == 1, validate trivially and write only block_hash[0]. -/
+def blockHashArrayFromChainFunction : String :=
+  "block_hash_array_from_chain:\n" ++
+  "  addi sp, sp, -80\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp); sd s7, 64(sp)\n" ++
+  "  sd s8, 72(sp)\n" ++
+  "  mv s0, a0                   # N\n" ++
+  "  mv s1, a1                   # header_lengths ptr\n" ++
+  "  mv s2, a2                   # headers ptr\n" ++
+  "  mv s3, a3                   # block_hash_out ptr\n" ++
+  "  mv s4, a4                   # is_valid out\n" ++
+  "  mv s5, a5                   # first_bad_index out\n" ++
+  "  li t0, 1\n" ++
+  "  sd t0, 0(s4)                # default is_valid = 1\n" ++
+  "  sd zero, 0(s5)\n" ++
+  "  beqz s0, .Lbhac_done\n" ++
+  "  # Write block_hash[0]\n" ++
+  "  ld a1, 0(s1)\n" ++
+  "  mv a0, s2; mv a2, s3\n" ++
+  "  jal ra, block_hash_from_header\n" ++
+  "  li t0, 1\n" ++
+  "  beq s0, t0, .Lbhac_done     # N == 1 -> trivially valid\n" ++
+  "  # Walk the chain, validating each link and writing block_hashes.\n" ++
+  "  mv s6, s2                   # parent ptr = headers[0]\n" ++
+  "  li s7, 0                    # i = 0\n" ++
+  "  addi s8, s3, 32             # next block_hash slot = block_hash_out + 32\n" ++
+  ".Lbhac_loop:\n" ++
+  "  addi t0, s7, 1\n" ++
+  "  beq t0, s0, .Lbhac_done\n" ++
+  "  # parent_len = header_lengths[i]; child_len = header_lengths[i+1]\n" ++
+  "  slli t1, s7, 3\n" ++
+  "  add t1, s1, t1\n" ++
+  "  ld a1, 0(t1)                # parent_len\n" ++
+  "  ld a3, 8(t1)                # child_len\n" ++
+  "  add t2, s6, a1              # child ptr\n" ++
+  "  mv a0, s6\n" ++
+  "  mv a2, t2\n" ++
+  "  la a4, bhac_pair_valid\n" ++
+  "  jal ra, validate_header_pair\n" ++
+  "  bnez a0, .Lbhac_status_fail\n" ++
+  "  la t0, bhac_pair_valid; ld t1, 0(t0)\n" ++
+  "  beqz t1, .Lbhac_pred_false\n" ++
+  "  # Write block_hash[i+1]\n" ++
+  "  slli t1, s7, 3\n" ++
+  "  add t1, s1, t1\n" ++
+  "  ld t2, 0(t1)                # parent_len[i]\n" ++
+  "  ld t3, 8(t1)                # child_len[i+1] (= header[i+1] len)\n" ++
+  "  add t4, s6, t2              # child ptr\n" ++
+  "  mv a0, t4; mv a1, t3; mv a2, s8\n" ++
+  "  jal ra, block_hash_from_header\n" ++
+  "  # Advance\n" ++
+  "  slli t1, s7, 3\n" ++
+  "  add t1, s1, t1\n" ++
+  "  ld t2, 0(t1)\n" ++
+  "  add s6, s6, t2              # parent ptr += parent_len\n" ++
+  "  addi s8, s8, 32             # next block_hash slot\n" ++
+  "  addi s7, s7, 1\n" ++
+  "  j .Lbhac_loop\n" ++
+  ".Lbhac_pred_false:\n" ++
+  "  sd zero, 0(s4)\n" ++
+  "  sd s7, 0(s5)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lbhac_ret\n" ++
+  ".Lbhac_status_fail:\n" ++
+  "  sd zero, 0(s4)\n" ++
+  "  sd s7, 0(s5)\n" ++
+  "  j .Lbhac_ret\n" ++
+  ".Lbhac_done:\n" ++
+  "  li a0, 0\n" ++
+  ".Lbhac_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp); ld s7, 64(sp)\n" ++
+  "  ld s8, 72(sp)\n" ++
+  "  addi sp, sp, 80\n" ++
+  "  ret"
+
+/-- `zisk_block_hash_array_from_chain`: probe BuildUnit.
+    Input layout:
+      bytes  0.. 8 : N
+      bytes  8..8+8N : header_lengths (u64[N])
+      bytes  8+8N.. : concatenated header RLPs
+    Output layout:
+      bytes  0.. 8 : status
+      bytes  8..16 : is_valid
+      bytes 16..24 : first_bad_index
+      bytes 24..   : block_hash[0], block_hash[1], ... (32*N B)
+    Caveat: ziskemu output is capped at 256 B, so this probe
+    test is meaningful only for N <= 7 (status+valid+bad = 24,
+    remaining 232 B fits 7 hashes). -/
+def ziskBlockHashArrayFromChainPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a7, 0x40000000\n" ++
+  "  ld a0, 8(a7)                # N\n" ++
+  "  addi a1, a7, 16             # header_lengths ptr\n" ++
+  "  slli t0, a0, 3              # 8*N\n" ++
+  "  add a2, a1, t0              # headers ptr\n" ++
+  "  li a3, 0xa0010018           # block_hash_out at OUTPUT + 24\n" ++
+  "  li a4, 0xa0010008           # is_valid\n" ++
+  "  li a5, 0xa0010010           # first_bad_index\n" ++
+  "  jal ra, block_hash_array_from_chain\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lbhac_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpFieldToU64Function ++ "\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  blockHashFromHeaderFunction ++ "\n" ++
+  validateParentHashLinkFunction ++ "\n" ++
+  checkGasLimitFunction ++ "\n" ++
+  validateHeaderPairFunction ++ "\n" ++
+  blockHashArrayFromChainFunction ++ "\n" ++
+  ".Lbhac_pdone:"
+
+def ziskBlockHashArrayFromChainDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  "rfu_offset:\n" ++
+  "  .zero 8\n" ++
+  "rfu_length:\n" ++
+  "  .zero 8\n" ++
+  "vphl_offset:\n" ++
+  "  .zero 8\n" ++
+  "vphl_length:\n" ++
+  "  .zero 8\n" ++
+  "vphl_claimed:\n" ++
+  "  .zero 32\n" ++
+  "vphl_computed:\n" ++
+  "  .zero 32\n" ++
+  "vhp_link_valid:\n" ++
+  "  .zero 8\n" ++
+  "vhp_parent_number:\n" ++
+  "  .zero 8\n" ++
+  "vhp_parent_timestamp:\n" ++
+  "  .zero 8\n" ++
+  "vhp_parent_gas_limit:\n" ++
+  "  .zero 8\n" ++
+  "vhp_child_number:\n" ++
+  "  .zero 8\n" ++
+  "vhp_child_timestamp:\n" ++
+  "  .zero 8\n" ++
+  "vhp_child_gas_limit:\n" ++
+  "  .zero 8\n" ++
+  "bhac_pair_valid:\n" ++
+  "  .zero 8"
+
+def ziskBlockHashArrayFromChainProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskBlockHashArrayFromChainPrologue
+  dataAsm     := ziskBlockHashArrayFromChainDataSection
+}
+
 end EvmAsm.Codegen

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **209**
-- ziskemu round-trip scripts: **202** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **210**
+- ziskemu round-trip scripts: **203** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/README.md
+++ b/README.md
@@ -272,7 +272,8 @@ block-body helpers
 `block_validate_empty_receipts_root`,
 `block_validate_empty_block`,
 `validate_empty_block_with_parent`,
-`validate_empty_block_chain`, withdrawal RLP/hash, …),
+`validate_empty_block_chain`,
+`block_hash_array_from_chain`, withdrawal RLP/hash, …),
 and address
 derivation (`address_compute_create`, `address_compute_create2`,
 `address_from_pubkey`). The catalogue is tracked under the

--- a/scripts/codegen-zisk-block-hash-array-from-chain-check.sh
+++ b/scripts/codegen-zisk-block-hash-array-from-chain-check.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# codegen-zisk-block-hash-array-from-chain-check.sh -- PR-K187.
+#
+# Validate a header chain and output the block_hash for each header.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_block_hash_array_from_chain ELF"
+lake exe codegen --program zisk_block_hash_array_from_chain --halt linux93 \
+  -o gen-out/zisk_block_hash_array_from_chain
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <spec_py> <exp_status> <exp_valid> <exp_first_bad>
+run_case() {
+  local name="$1" spec="$2" exp_status="$3" exp_valid="$4" exp_bad="$5"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_block_hash_array_from_chain_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_block_hash_array_from_chain_${name}.output"
+  local exp_hashes_file="$REPO_ROOT/gen-out/zisk_block_hash_array_from_chain_${name}.expected_hashes.txt"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+try:
+    from Crypto.Hash import keccak
+    def keccak256(b):
+        h = keccak.new(digest_bits=256); h.update(b); return h.digest()
+except Exception:
+    import sha3
+    def keccak256(b): return sha3.keccak_256(b).digest()
+
+def u_be(n):
+    if n == 0: return b''
+    return n.to_bytes((n.bit_length() + 7) // 8, 'big')
+
+def make_header(parent_hash, num, ts, gl):
+    return rlp.encode([
+        parent_hash, b'\\xb2'*32, b'\\xb3'*20, b'\\xb4'*32, b'\\xb5'*32,
+        b'\\xb6'*32, b'\\x00'*256, b'', u_be(num), u_be(gl),
+        b'\\x82\\x02\\x00', u_be(ts), b'', b'\\xb7'*32, b'\\x00'*8,
+        b'\\x82\\x12\\x34',
+    ])
+
+spec = $spec
+headers = []
+expected_hashes = []
+prev_hash = b'\\x00'*32
+for n, ts, gl, override in spec:
+    ph = override if override is not None else prev_hash
+    h = make_header(ph, n, ts, gl)
+    headers.append(h)
+    expected_hashes.append(keccak256(h))
+    prev_hash = keccak256(h)
+
+N = len(headers)
+lengths = b''.join(struct.pack('<Q', len(h)) for h in headers)
+flat = b''.join(headers)
+
+with open(sys.argv[1], 'wb') as f:
+    record = struct.pack('<Q', N) + lengths + flat
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\x00' * pad)
+with open(sys.argv[2], 'w') as f:
+    for h in expected_hashes:
+        f.write(h.hex() + '\n')
+" "$in_file" "$exp_hashes_file"
+
+  "$ZISKEMU" -e gen-out/zisk_block_hash_array_from_chain.elf \
+    -i "$in_file" -o "$out_file" -n 20000000 \
+    >"$REPO_ROOT/gen-out/zisk_block_hash_array_from_chain_${name}.emu.log" 2>&1 || true
+
+  local status_le; status_le="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local valid_le;  valid_le="$( dd if="$out_file" bs=1 skip=8  count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local bad_le;    bad_le="$(   dd if="$out_file" bs=1 skip=16 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local status valid bad
+  status="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$status_le'))[0])")"
+  valid="$( python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$valid_le'))[0])")"
+  bad="$(   python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$bad_le'))[0])")"
+
+  # Check the first <= N hashes against expected (limited by 256 B output cap).
+  local hashes_ok=1
+  if [[ "$exp_valid" == "1" ]]; then
+    local i=0
+    while IFS= read -r exp_hex; do
+      [[ $i -ge 7 ]] && break  # output cap: 256B/32 = 8 hashes - 1 (header area)
+      local offset=$((24 + i*32))
+      local actual; actual="$(dd if="$out_file" bs=1 skip=$offset count=32 2>/dev/null | xxd -p | tr -d '\n')"
+      if [[ "$actual" != "$exp_hex" ]]; then
+        printf "  %-28s FAIL hash[%d] actual=%s exp=%s\n" "$name" "$i" "$actual" "$exp_hex"
+        hashes_ok=0
+        break
+      fi
+      i=$((i+1))
+    done < "$exp_hashes_file"
+  fi
+
+  if [[ "$status" == "$exp_status" && "$valid" == "$exp_valid" && "$bad" == "$exp_bad" && "$hashes_ok" == 1 ]]; then
+    printf "  %-28s OK   status=%s valid=%s bad=%s\n" "$name" "$status" "$valid" "$bad"
+    return 0
+  else
+    printf "  %-28s FAIL status=%s/%s valid=%s/%s bad=%s/%s hashes_ok=%s\n" \
+      "$name" "$status" "$exp_status" "$valid" "$exp_valid" "$bad" "$exp_bad" "$hashes_ok"
+    return 1
+  fi
+}
+
+FAILED=0
+run_case "vacuous_empty" "[]" 0 1 0 || FAILED=1
+run_case "vacuous_single" "[(100,1000,30000000,None)]" 0 1 0 || FAILED=1
+run_case "three_chain_ok" "[
+    (100,1000,30000000,None),
+    (101,1001,30000000,None),
+    (102,1002,30000000,None),
+]" 0 1 0 || FAILED=1
+run_case "fail_at_index_1" "[
+    (100,1000,30000000,None),
+    (101,1001,30000000,None),
+    (103,1002,30000000,None),
+]" 0 0 1 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: block_hash_array_from_chain validates chain and writes block_hashes"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Validate an N-element header chain (K175-style) and output the
`block_hash` of every header (K172) into a `32*N`-byte buffer.

Useful for downstream chain-state machinery -- block_hash
precompile inputs, witness mapping, validator commitments --
that needs a verifiable array of recently-validated block hashes.

Iterates the chain once: writes `block_hash[0]` before the loop,
then for each successful pair check writes `block_hash[i+1]`.
Stops on the first failing pair and reports the failing index;
partial `block_hashes` up to the failure point remain in the
output buffer (the caller can choose whether to trust them).

## Calling convention

`a0` N, `a1` header_lengths, `a2` headers, `a3` block_hash_out
(32*N), `a4` is_valid, `a5` first_bad_index.

## Test plan

4 ziskemu fixtures:

- [x] `vacuous_empty` -- N=0 -> valid=1, no hashes
- [x] `vacuous_single` -- N=1 -> valid=1, single hash matches Python
- [x] `three_chain_ok` -- N=3, hashes verified against keccak256
- [x] `fail_at_index_1` -- N=3, broken number at link 1 -> bad=1

## Stack

Builds on #5984 (PR-K186 `block_validate_transactions_root_one_tx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)