### PR TITLE
feat(stateless): block_body_extract_1tx (PR-K188)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -5201,6 +5201,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_block_validate_2tx_full_with_body" => some ziskBlockValidate2txFullWithBodyProbeUnit
   | "zisk_block_validate_empty_ommers_hash" => some ziskBlockValidateEmptyOmmersHashProbeUnit
   | "zisk_block_validate_no_withdrawals_pair" => some ziskBlockValidateNoWithdrawalsPairProbeUnit
+  | "zisk_block_body_extract_1tx" => some ziskBlockBodyExtract1txProbeUnit
   | "zisk_block_validate_empty_receipts_root" => some ziskBlockValidateEmptyReceiptsRootProbeUnit
   | "zisk_block_validate_empty_block" => some ziskBlockValidateEmptyBlockProbeUnit
   | "zisk_validate_empty_block_with_parent" => some ziskValidateEmptyBlockWithParentProbeUnit
@@ -5402,6 +5403,7 @@ def knownProgramNames : List String :=
    "zisk_block_validate_2tx_full_with_body",
    "zisk_block_validate_empty_ommers_hash",
    "zisk_block_validate_no_withdrawals_pair",
+   "zisk_block_body_extract_1tx",
    "zisk_block_validate_empty_receipts_root",
    "zisk_block_validate_empty_block",
    "zisk_validate_empty_block_with_parent",

--- a/EvmAsm/Codegen/Programs/Block.lean
+++ b/EvmAsm/Codegen/Programs/Block.lean
@@ -2588,6 +2588,128 @@ def ziskBlockValidateNoWithdrawalsPairProbeUnit : BuildUnit := {
   dataAsm     := ziskBlockValidateNoWithdrawalsPairDataSection
 }
 
+/-! ## block_body_extract_1tx -- PR-K188
+
+    Body-side primitive for 1-tx blocks: decode a 3-field body
+    (`[transactions, ommers, withdrawals]`), assert exactly one
+    transaction and the empty ommers list (post-merge invariant),
+    and return `(tx0 off+len)` in body-relative coordinates.
+
+    Analogue of K177 `block_body_extract_2tx` for N=1.
+
+    Output struct (16 bytes):
+       0..  8  tx0_offset (in body_rlp)
+       8.. 16  tx0_length
+
+    Calling convention:
+      a0 (input)  : body_rlp ptr
+      a1 (input)  : body_rlp byte length
+      a2 (input)  : 16-byte output struct ptr
+      ra (input)  : return
+      a0 (output) :
+        0 : success
+        1 : body RLP parse failure
+        2 : ommers not the empty list
+        3 : transactions list count != 1
+        4 : transactions list item extraction failure -/
+def blockBodyExtract1txFunction : String :=
+  "block_body_extract_1tx:\n" ++
+  "  addi sp, sp, -48\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp); sd s4, 40(sp)\n" ++
+  "  mv s0, a0                   # body_rlp ptr\n" ++
+  "  mv s1, a1                   # body_rlp len\n" ++
+  "  mv s2, a2                   # output struct\n" ++
+  "  # (1) Decode body\n" ++
+  "  mv a0, s0; mv a1, s1\n" ++
+  "  la a2, bbe1_body_struct\n" ++
+  "  jal ra, block_body_decode\n" ++
+  "  bnez a0, .Lbbe1_parse_fail\n" ++
+  "  # (2) Verify ommers == 0xc0\n" ++
+  "  la t0, bbe1_body_struct; ld t1, 16(t0)\n" ++
+  "  ld t2, 24(t0)\n" ++
+  "  li t3, 1\n" ++
+  "  bne t2, t3, .Lbbe1_ommers_fail\n" ++
+  "  add t1, s0, t1; lbu t4, 0(t1); li t5, 0xc0; bne t4, t5, .Lbbe1_ommers_fail\n" ++
+  "  # (3) Count tx list\n" ++
+  "  la t0, bbe1_body_struct; ld s3, 0(t0); ld s4, 8(t0)\n" ++
+  "  add a0, s0, s3; mv a1, s4\n" ++
+  "  la a2, bbe1_tx_count\n" ++
+  "  jal ra, rlp_list_count_items\n" ++
+  "  bnez a0, .Lbbe1_txs_fail\n" ++
+  "  la t0, bbe1_tx_count; ld t1, 0(t0)\n" ++
+  "  li t2, 1\n" ++
+  "  bne t1, t2, .Lbbe1_count_fail\n" ++
+  "  # (4) Extract tx0\n" ++
+  "  add a0, s0, s3; mv a1, s4; li a2, 0\n" ++
+  "  la a3, bbe1_item_off; la a4, bbe1_item_len\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lbbe1_txs_fail\n" ++
+  "  la t0, bbe1_item_off; ld t1, 0(t0)\n" ++
+  "  add t1, t1, s3; sd t1, 0(s2)\n" ++
+  "  la t0, bbe1_item_len; ld t1, 0(t0); sd t1, 8(s2)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lbbe1_ret\n" ++
+  ".Lbbe1_parse_fail:\n" ++
+  "  li a0, 1\n" ++
+  "  j .Lbbe1_ret\n" ++
+  ".Lbbe1_ommers_fail:\n" ++
+  "  li a0, 2\n" ++
+  "  j .Lbbe1_ret\n" ++
+  ".Lbbe1_count_fail:\n" ++
+  "  li a0, 3\n" ++
+  "  j .Lbbe1_ret\n" ++
+  ".Lbbe1_txs_fail:\n" ++
+  "  li a0, 4\n" ++
+  ".Lbbe1_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp); ld s4, 40(sp)\n" ++
+  "  addi sp, sp, 48\n" ++
+  "  ret"
+
+/-- `zisk_block_body_extract_1tx`: probe BuildUnit.
+    Input layout:
+      bytes 0..8 : body_rlp_len
+      bytes 8..  : body_rlp
+    Output layout:
+      bytes  0.. 8 : status (0..4)
+      bytes  8..24 : 16-byte struct (tx0 off+len) -/
+def ziskBlockBodyExtract1txPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a7, 0x40000000\n" ++
+  "  ld a1, 8(a7)                # body_rlp_len\n" ++
+  "  addi a0, a7, 16             # body_rlp ptr\n" ++
+  "  li a2, 0xa0010008           # output struct\n" ++
+  "  jal ra, block_body_extract_1tx\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lbbe1_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpListCountItemsFunction ++ "\n" ++
+  blockBodyDecodeFunction ++ "\n" ++
+  blockBodyExtract1txFunction ++ "\n" ++
+  ".Lbbe1_pdone:"
+
+def ziskBlockBodyExtract1txDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  "bbe1_body_struct:\n" ++
+  "  .zero 48\n" ++
+  "bbe1_tx_count:\n" ++
+  "  .zero 8\n" ++
+  "bbe1_item_off:\n" ++
+  "  .zero 8\n" ++
+  "bbe1_item_len:\n" ++
+  "  .zero 8"
+
+def ziskBlockBodyExtract1txProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskBlockBodyExtract1txPrologue
+  dataAsm     := ziskBlockBodyExtract1txDataSection
+}
+
 /-! ## block_validate_empty_receipts_root -- PR-K181
 
     Header field 5 (`receipts_root`) equals `EMPTY_TRIE_ROOT`

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **210**
-- ziskemu round-trip scripts: **203** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **211**
+- ziskemu round-trip scripts: **204** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ block-body helpers
 `block_validate_transactions_root_one_tx`,
 `block_hash_from_header`, `validate_parent_hash_link`,
 `validate_header_pair`, `validate_header_chain`,
-`block_validate_2tx_full`, `block_body_extract_2tx`,
+`block_validate_2tx_full`, `block_body_extract_2tx`, `block_body_extract_1tx`,
 `block_validate_2tx_full_with_body`,
 `block_validate_empty_ommers_hash`,
 `block_validate_no_withdrawals_pair`,

--- a/scripts/codegen-zisk-block-body-extract-1tx-check.sh
+++ b/scripts/codegen-zisk-block-body-extract-1tx-check.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# codegen-zisk-block-body-extract-1tx-check.sh -- PR-K188.
+#
+# Body-side primitive for 1-tx blocks.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_block_body_extract_1tx ELF"
+lake exe codegen --program zisk_block_body_extract_1tx --halt linux93 \
+  -o gen-out/zisk_block_body_extract_1tx
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <body_build_py> <exp_status> <exp_tx0_off> <exp_tx0_len>
+run_case() {
+  local name="$1" body_expr="$2" exp_status="$3" exp_t0o="$4" exp_t0l="$5"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_block_body_extract_1tx_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_block_body_extract_1tx_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+body_rlp = $body_expr
+with open(sys.argv[1], 'wb') as f:
+    record = struct.pack('<Q', len(body_rlp)) + body_rlp
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_block_body_extract_1tx.elf \
+    -i "$in_file" -o "$out_file" -n 2000000 \
+    >"$REPO_ROOT/gen-out/zisk_block_body_extract_1tx_${name}.emu.log" 2>&1 || true
+
+  local status_le; status_le="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local t0o_le;    t0o_le="$(   dd if="$out_file" bs=1 skip=8  count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local t0l_le;    t0l_le="$(   dd if="$out_file" bs=1 skip=16 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local status t0o t0l
+  status="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$status_le'))[0])")"
+  t0o="$(   python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$t0o_le'))[0])")"
+  t0l="$(   python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$t0l_le'))[0])")"
+
+  if [[ "$status" == "$exp_status" && "$t0o" == "$exp_t0o" && "$t0l" == "$exp_t0l" ]]; then
+    printf "  %-26s OK   status=%s tx0=(%s,%s)\n" "$name" "$status" "$t0o" "$t0l"
+    return 0
+  else
+    printf "  %-26s FAIL status=%s/%s tx0=(%s,%s)/(%s,%s)\n" \
+      "$name" "$status" "$exp_status" "$t0o" "$t0l" "$exp_t0o" "$exp_t0l"
+    return 1
+  fi
+}
+
+TX_A="f8500184ee6b280082520894aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa881bc16d674ec80000801ba01111111111111111111111111111111111111111111111111111111111111111a02222222222222222222222222222222222222222222222222222222222222222"
+
+# Compute expected tx0 offset/len in the body for the single legacy tx.
+# Body = rlp([[tx0], [], []])
+# - outer prefix: 1 byte (short list) OR 2..3 bytes for long
+# - inner txs list prefix: 1..3 bytes
+# For our 109-byte tx0: inner txs list = 1 + (1 + 109) = 111 bytes total
+#   inner_prefix = 1 byte (since 110 fits in short-list? 110 > 55, so long-list 2 bytes)
+# Actually: txs payload = tx0 wrapped = (rlp_prefix_for_tx_string) + tx0_bytes
+# But tx0 is already wire-format -- it gets re-wrapped as a byte-string by rlp.encode([tx0,...])
+# For tx0 of len 109 (>55), wrap = 0xb8 0x6d + 109 bytes = 111 bytes total
+# txs list payload = 111 bytes -> long-list, prefix = 0xf8 0x6f (2 bytes)
+# Total txs list = 113 bytes
+# ommers + withdrawals: 0xc0 0xc0 (2 bytes)
+# body payload = 115 bytes -> long-list, prefix = 0xf8 0x73 (2 bytes)
+# Total body = 117 bytes
+# tx0 wrapped string starts at offset 2+2 = 4 (outer prefix + txs prefix)
+# K20 returns content offset for byte-string items: 4 + 2 (tx0 prefix) = 6
+# K20 returns content length: 109
+EXPECTED_OFF=6
+EXPECTED_LEN=109
+
+FAILED=0
+run_case "one_legacy" "rlp.encode([[bytes.fromhex('$TX_A')], [], []])" 0 $EXPECTED_OFF $EXPECTED_LEN || FAILED=1
+run_case "fail_two_txs" \
+  "rlp.encode([[bytes.fromhex('$TX_A'), bytes.fromhex('$TX_A')], [], []])" 3 0 0 || FAILED=1
+run_case "fail_zero_txs" \
+  "rlp.encode([[], [], []])" 3 0 0 || FAILED=1
+run_case "fail_nonempty_ommers" \
+  "rlp.encode([[bytes.fromhex('$TX_A')], [bytes.fromhex('$TX_A')], []])" 2 0 0 || FAILED=1
+run_case "fail_two_field_body" \
+  "rlp.encode([[bytes.fromhex('$TX_A')], []])" 1 0 0 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: block_body_extract_1tx returns correct (off,len) and rejects misshaped bodies"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Body-side primitive for 1-tx blocks: decode a 3-field body
(`[transactions, ommers, withdrawals]`), assert exactly **one**
transaction and the empty ommers list (post-merge invariant),
and return `(tx0 off+len)` in body-relative coordinates.

Analogue of K177 `block_body_extract_2tx` for N=1. Output struct
is 16 bytes (vs. K177's 32-byte struct).

## Status codes

| code | meaning |
|---:|---|
| 0 | success |
| 1 | body RLP parse failure (not a 3-item list) |
| 2 | ommers not the empty list |
| 3 | transactions list count != 1 |
| 4 | transactions list item extraction failure |

## Test plan

5 ziskemu fixtures:

- [x] `one_legacy` -- 1-tx body -> status=0, tx0=(6, 109)
- [x] `fail_two_txs` -- 2 txs -> status=3
- [x] `fail_zero_txs` -- 0 txs -> status=3
- [x] `fail_nonempty_ommers` -- non-empty ommers -> status=2
- [x] `fail_two_field_body` -- 2-field body -> status=1

## Stack

Builds on #5985 (PR-K187 `block_hash_array_from_chain`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)