### PR TITLE
feat(stateless): block_validate_1tx_full_with_body (PR-K190)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -5203,6 +5203,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_block_validate_no_withdrawals_pair" => some ziskBlockValidateNoWithdrawalsPairProbeUnit
   | "zisk_block_body_extract_1tx" => some ziskBlockBodyExtract1txProbeUnit
   | "zisk_block_validate_1tx_full" => some ziskBlockValidate1txFullProbeUnit
+  | "zisk_block_validate_1tx_full_with_body" => some ziskBlockValidate1txFullWithBodyProbeUnit
   | "zisk_block_validate_empty_receipts_root" => some ziskBlockValidateEmptyReceiptsRootProbeUnit
   | "zisk_block_validate_empty_block" => some ziskBlockValidateEmptyBlockProbeUnit
   | "zisk_validate_empty_block_with_parent" => some ziskValidateEmptyBlockWithParentProbeUnit
@@ -5406,6 +5407,7 @@ def knownProgramNames : List String :=
    "zisk_block_validate_no_withdrawals_pair",
    "zisk_block_body_extract_1tx",
    "zisk_block_validate_1tx_full",
+   "zisk_block_validate_1tx_full_with_body",
    "zisk_block_validate_empty_receipts_root",
    "zisk_block_validate_empty_block",
    "zisk_validate_empty_block_with_parent",

--- a/EvmAsm/Codegen/Programs/Block.lean
+++ b/EvmAsm/Codegen/Programs/Block.lean
@@ -2893,6 +2893,136 @@ def ziskBlockValidate1txFullProbeUnit : BuildUnit := {
   dataAsm     := ziskBlockValidate1txFullDataSection
 }
 
+/-! ## block_validate_1tx_full_with_body -- PR-K190
+
+    Body-aware single-call validator for a 1-tx block: takes
+    `(parent_rlp, header_rlp, body_rlp)`, returns `is_valid`.
+    Composes K188 (body extract) + K189 (header pair + tx_root).
+
+    Algorithm:
+      1. K188 `block_body_extract_1tx(body)` -- assert body shape
+         (3 fields, empty ommers, exactly 1 tx); return tx0 ptr+len.
+      2. K189 `block_validate_1tx_full(parent, header, tx0)` --
+         verify pair invariants + tx_root match.
+
+    Calling convention:
+      a0 (input)  : parent_rlp ptr
+      a1 (input)  : parent_rlp byte length
+      a2 (input)  : header_rlp ptr
+      a3 (input)  : header_rlp byte length
+      a4 (input)  : body_rlp ptr
+      a5 (input)  : body_rlp byte length
+      a6 (input)  : u64 out (is_valid)
+      ra (input)  : return
+      a0 (output) :
+        0        success
+        1..4     body-extract status (K188)
+        11..14   pair status (K174 / K189 codes 1..4 + 10)
+        21..22   tx-root status (K186 / K189 codes 11..12 + 10) -/
+def blockValidate1txFullWithBodyFunction : String :=
+  "block_validate_1tx_full_with_body:\n" ++
+  "  addi sp, sp, -64\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp)\n" ++
+  "  mv s0, a0; mv s1, a1                # parent\n" ++
+  "  mv s2, a2; mv s3, a3                # header\n" ++
+  "  mv s4, a4; mv s5, a5                # body\n" ++
+  "  mv s6, a6                            # is_valid out\n" ++
+  "  sd zero, 0(s6)\n" ++
+  "  # (A) Extract tx0 from body\n" ++
+  "  mv a0, s4; mv a1, s5\n" ++
+  "  la a2, bv1fb_struct\n" ++
+  "  jal ra, block_body_extract_1tx\n" ++
+  "  beqz a0, .Lbv1fb_body_ok\n" ++
+  "  j .Lbv1fb_ret               # propagate body status 1..4\n" ++
+  ".Lbv1fb_body_ok:\n" ++
+  "  la t0, bv1fb_struct; ld t1, 0(t0); ld t2, 8(t0)\n" ++
+  "  add t1, s4, t1              # tx0 ptr = body + off\n" ++
+  "  # (B) K189 1-tx full validator\n" ++
+  "  mv a0, s0; mv a1, s1\n" ++
+  "  mv a2, s2; mv a3, s3\n" ++
+  "  mv a4, t1; mv a5, t2\n" ++
+  "  mv a6, s6\n" ++
+  "  jal ra, block_validate_1tx_full\n" ++
+  "  beqz a0, .Lbv1fb_ret\n" ++
+  "  # K189 status 1..4 (pair) -> remap to 11..14\n" ++
+  "  # K189 status 11..12 (tx_root) -> remap to 21..22\n" ++
+  "  li t0, 5\n" ++
+  "  bltu a0, t0, .Lbv1fb_remap_pair\n" ++
+  "  addi a0, a0, 10\n" ++
+  "  j .Lbv1fb_ret\n" ++
+  ".Lbv1fb_remap_pair:\n" ++
+  "  addi a0, a0, 10\n" ++
+  ".Lbv1fb_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp)\n" ++
+  "  addi sp, sp, 64\n" ++
+  "  ret"
+
+/-- `zisk_block_validate_1tx_full_with_body`: probe BuildUnit.
+    Input layout:
+      bytes  0.. 8 : parent_rlp_len
+      bytes  8..16 : header_rlp_len
+      bytes 16..24 : body_rlp_len
+      bytes 24..   : parent_rlp || header_rlp || body_rlp
+    Output layout:
+      bytes  0.. 8 : status
+      bytes  8..16 : is_valid -/
+def ziskBlockValidate1txFullWithBodyPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a7, 0x40000000\n" ++
+  "  ld a1,  8(a7)                # parent_rlp_len\n" ++
+  "  ld a3, 16(a7)                # header_rlp_len\n" ++
+  "  ld a5, 24(a7)                # body_rlp_len\n" ++
+  "  addi a0, a7, 32              # parent_rlp ptr\n" ++
+  "  add a2, a0, a1               # header_rlp ptr\n" ++
+  "  add a4, a2, a3               # body_rlp ptr\n" ++
+  "  li a6, 0xa0010008            # is_valid out\n" ++
+  "  jal ra, block_validate_1tx_full_with_body\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lbv1fb_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpListCountItemsFunction ++ "\n" ++
+  rlpFieldToU64Function ++ "\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  hpEncodeNibblesFunction ++ "\n" ++
+  rlpEncodeBytesFunction ++ "\n" ++
+  rlpEncodeListPrefixFunction ++ "\n" ++
+  mptLeafNodeEncodeFromNibblesFunction ++ "\n" ++
+  mptOneLeafRootIndexedFunction ++ "\n" ++
+  blockHashFromHeaderFunction ++ "\n" ++
+  validateParentHashLinkFunction ++ "\n" ++
+  checkGasLimitFunction ++ "\n" ++
+  validateHeaderPairFunction ++ "\n" ++
+  blockValidateTransactionsRootOneTxFunction ++ "\n" ++
+  blockValidate1txFullFunction ++ "\n" ++
+  blockBodyDecodeFunction ++ "\n" ++
+  blockBodyExtract1txFunction ++ "\n" ++
+  blockValidate1txFullWithBodyFunction ++ "\n" ++
+  ".Lbv1fb_pdone:"
+
+def ziskBlockValidate1txFullWithBodyDataSection : String :=
+  ziskBlockValidate1txFullDataSection ++ "\n" ++
+  "bv1fb_struct:\n" ++
+  "  .zero 16\n" ++
+  "bbe1_body_struct:\n" ++
+  "  .zero 48\n" ++
+  "bbe1_tx_count:\n" ++
+  "  .zero 8\n" ++
+  "bbe1_item_off:\n" ++
+  "  .zero 8\n" ++
+  "bbe1_item_len:\n" ++
+  "  .zero 8"
+
+def ziskBlockValidate1txFullWithBodyProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskBlockValidate1txFullWithBodyPrologue
+  dataAsm     := ziskBlockValidate1txFullWithBodyDataSection
+}
+
 /-! ## block_validate_empty_receipts_root -- PR-K181
 
     Header field 5 (`receipts_root`) equals `EMPTY_TRIE_ROOT`

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **212**
-- ziskemu round-trip scripts: **205** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **213**
+- ziskemu round-trip scripts: **206** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ block-body helpers
 `block_hash_from_header`, `validate_parent_hash_link`,
 `validate_header_pair`, `validate_header_chain`,
 `block_validate_2tx_full`, `block_validate_1tx_full`,
+`block_validate_1tx_full_with_body`,
 `block_body_extract_2tx`, `block_body_extract_1tx`,
 `block_validate_2tx_full_with_body`,
 `block_validate_empty_ommers_hash`,

--- a/scripts/codegen-zisk-block-validate-1tx-full-with-body-check.sh
+++ b/scripts/codegen-zisk-block-validate-1tx-full-with-body-check.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# codegen-zisk-block-validate-1tx-full-with-body-check.sh -- PR-K190.
+#
+# Body-aware single-call validator for 1-tx blocks.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_block_validate_1tx_full_with_body ELF"
+lake exe codegen --program zisk_block_validate_1tx_full_with_body --halt linux93 \
+  -o gen-out/zisk_block_validate_1tx_full_with_body
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <break_pair 0/1> <break_tx_root 0/1> <break_body 0/1>
+#                 <exp_status> <exp_valid>
+run_case() {
+  local name="$1" bp="$2" btr="$3" bb="$4" exp_status="$5" exp_valid="$6"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_block_validate_1tx_full_with_body_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_block_validate_1tx_full_with_body_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+try:
+    from Crypto.Hash import keccak
+    def keccak256(b):
+        h = keccak.new(digest_bits=256); h.update(b); return h.digest()
+except Exception:
+    import sha3
+    def keccak256(b): return sha3.keccak_256(b).digest()
+
+def u_be(n):
+    if n == 0: return b''
+    return n.to_bytes((n.bit_length() + 7) // 8, 'big')
+
+bp = $bp == 1
+btr = $btr == 1
+bb = $bb == 1
+
+tx0 = bytes.fromhex('f8500184ee6b280082520894aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa881bc16d674ec80000801ba01111111111111111111111111111111111111111111111111111111111111111a02222222222222222222222222222222222222222222222222222222222222222')
+
+def hp_leaf(nibbles, value):
+    flag = 2 + (len(nibbles) & 1)
+    hp = bytearray()
+    if len(nibbles) % 2 == 1:
+        hp.append((flag << 4) | nibbles[0]); i = 1
+    else:
+        hp.append(flag << 4); i = 0
+    while i < len(nibbles):
+        hp.append((nibbles[i] << 4) | nibbles[i+1]); i += 2
+    return rlp.encode([bytes(hp), value])
+
+correct_tx_root = keccak256(hp_leaf([8, 0], tx0))
+
+parent_rlp = rlp.encode([
+    b'\\xa1'*32, b'\\xa2'*32, b'\\xa3'*20, b'\\xa4'*32, b'\\xa5'*32,
+    b'\\xa6'*32, b'\\x00'*256, b'', u_be(100), u_be(30000000),
+    b'\\x82\\x02\\x00', u_be(1000), b'', b'\\xa7'*32, b'\\x00'*8,
+    b'\\x82\\x12\\x34',
+])
+parent_hash = keccak256(parent_rlp)
+
+field4 = b'\\xff'*32 if btr else correct_tx_root
+child_num = 102 if bp else 101
+child_rlp = rlp.encode([
+    parent_hash, b'\\xb2'*32, b'\\xb3'*20, b'\\xb4'*32, field4,
+    b'\\xb6'*32, b'\\x00'*256, b'', u_be(child_num), u_be(30000000),
+    b'\\x82\\x02\\x00', u_be(1001), b'', b'\\xb7'*32, b'\\x00'*8,
+    b'\\x82\\x12\\x34',
+])
+
+if bb:
+    body_rlp = rlp.encode([[tx0, tx0], [], []])  # 2 txs -> count fail
+else:
+    body_rlp = rlp.encode([[tx0], [], []])
+
+with open(sys.argv[1], 'wb') as f:
+    record = struct.pack('<Q', len(parent_rlp)) + \
+             struct.pack('<Q', len(child_rlp)) + \
+             struct.pack('<Q', len(body_rlp)) + \
+             parent_rlp + child_rlp + body_rlp
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_block_validate_1tx_full_with_body.elf \
+    -i "$in_file" -o "$out_file" -n 10000000 \
+    >"$REPO_ROOT/gen-out/zisk_block_validate_1tx_full_with_body_${name}.emu.log" 2>&1 || true
+
+  local status_le; status_le="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local valid_le;  valid_le="$( dd if="$out_file" bs=1 skip=8 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local status valid
+  status="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$status_le'))[0])")"
+  valid="$( python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$valid_le'))[0])")"
+
+  if [[ "$status" == "$exp_status" && "$valid" == "$exp_valid" ]]; then
+    printf "  %-28s OK   status=%s valid=%s\n" "$name" "$status" "$valid"
+    return 0
+  else
+    printf "  %-28s FAIL status=%s/%s valid=%s/%s\n" \
+      "$name" "$status" "$exp_status" "$valid" "$exp_valid"
+    return 1
+  fi
+}
+
+FAILED=0
+run_case "all_match"          0 0 0  0 1 || FAILED=1
+run_case "fail_pair"          1 0 0  0 0 || FAILED=1
+run_case "fail_tx_root"       0 1 0  0 0 || FAILED=1
+run_case "fail_body_count"    0 0 1  3 0 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: block_validate_1tx_full_with_body validates body + header + tx_root"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Body-aware single-call validator for 1-tx Ethereum blocks: takes
`(parent_rlp, header_rlp, body_rlp)` and returns one `is_valid` u64.
Composes K188 + K189 -- the N=1 analogue of K178
`block_validate_2tx_full_with_body`.

1. K188 `block_body_extract_1tx(body)` -- assert body shape
   (3 fields, empty ommers, exactly 1 tx); return tx0 ptr+len.
2. K189 `block_validate_1tx_full(parent, header, tx0)` --
   verify pair invariants + tx_root match.

## Status codes

- `0` success
- `1..4` body-extract status (K188)
- `11..14` pair status (K174 codes 1..4 shifted)
- `21..22` tx-root status (K186 codes 1..2 shifted)

## Test plan

4 ziskemu fixtures:

- [x] `all_match` -- valid 1-tx block -> valid=1
- [x] `fail_pair` -- pair number-skip -> valid=0
- [x] `fail_tx_root` -- header tx_root wrong -> valid=0
- [x] `fail_body_count` -- body has 2 txs -> status=3

## Stack

Builds on #5987 (PR-K189 `block_validate_1tx_full`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)