### PR TITLE
feat(stateless): block_validate_withdrawals_root_two_w (PR-K192)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -5191,6 +5191,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_mpt_one_leaf_root_indexed" => some ziskMptOneLeafRootIndexedProbeUnit
   | "zisk_block_validate_transactions_root_one_tx" => some ziskBlockValidateTransactionsRootOneTxProbeUnit
   | "zisk_block_validate_withdrawals_root_one_w" => some ziskBlockValidateWithdrawalsRootOneWProbeUnit
+  | "zisk_block_validate_withdrawals_root_two_w" => some ziskBlockValidateWithdrawalsRootTwoWProbeUnit
   | "zisk_block_validate_transactions_root_two_tx" => some ziskBlockValidateTransactionsRootTwoTxProbeUnit
   | "zisk_block_hash_from_header" => some ziskBlockHashFromHeaderProbeUnit
   | "zisk_validate_parent_hash_link" => some ziskValidateParentHashLinkProbeUnit
@@ -5396,6 +5397,7 @@ def knownProgramNames : List String :=
    "zisk_mpt_one_leaf_root_indexed",
    "zisk_block_validate_transactions_root_one_tx",
    "zisk_block_validate_withdrawals_root_one_w",
+   "zisk_block_validate_withdrawals_root_two_w",
    "zisk_block_validate_transactions_root_two_tx",
    "zisk_block_hash_from_header",
    "zisk_validate_parent_hash_link",

--- a/EvmAsm/Codegen/Programs/Mpt.lean
+++ b/EvmAsm/Codegen/Programs/Mpt.lean
@@ -4638,5 +4638,145 @@ def ziskBlockValidateWithdrawalsRootOneWProbeUnit : BuildUnit := {
   dataAsm     := ziskBlockValidateWithdrawalsRootOneWDataSection
 }
 
+/-! ## block_validate_withdrawals_root_two_w -- PR-K192
+
+    End-to-end `withdrawals_root` validation for blocks with
+    exactly two withdrawals. Field 16 variant of K171
+    `block_validate_transactions_root_two_tx` -- same 2-leaf
+    MPT shape (slots 0 and 8) but rooted at withdrawals
+    instead of transactions.
+
+      claimed_root = header.field[16]             -- via K20
+      computed_root = mpt_two_leaf_root_indexed(  -- K170
+                          w0_rlp, w1_rlp)
+      is_valid = (claimed_root == computed_root)
+
+    Both withdrawals are supplied pre-RLP-encoded (typically
+    via K130 `withdrawal_rlp_encode` upstream).
+
+    Calling convention:
+      a0 (input)  : header_rlp ptr
+      a1 (input)  : header_rlp byte length
+      a2 (input)  : w0_rlp ptr
+      a3 (input)  : w0_rlp byte length
+      a4 (input)  : w1_rlp ptr
+      a5 (input)  : w1_rlp byte length
+      a6 (input)  : u64 out (is_valid)
+      ra (input)  : return
+      a0 (output) :
+        0 : success -- predicate written
+        1 : header RLP parse failure / field 16 missing
+        2 : header.withdrawals_root length != 32 -/
+def blockValidateWithdrawalsRootTwoWFunction : String :=
+  "block_validate_withdrawals_root_two_w:\n" ++
+  "  addi sp, sp, -64\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp)\n" ++
+  "  mv s0, a0; mv s1, a1                # header\n" ++
+  "  mv s2, a2; mv s3, a3                # w0\n" ++
+  "  mv s4, a4; mv s5, a5                # w1\n" ++
+  "  mv s6, a6                            # is_valid out\n" ++
+  "  sd zero, 0(s6)\n" ++
+  "  # ---- Extract header.withdrawals_root (field 16) ----\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 16\n" ++
+  "  la a3, bvwr2_offset; la a4, bvwr2_length\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lbvwr2_parse_fail\n" ++
+  "  la t0, bvwr2_length; ld t1, 0(t0)\n" ++
+  "  li t2, 32\n" ++
+  "  bne t1, t2, .Lbvwr2_size_fail\n" ++
+  "  la t0, bvwr2_offset; ld t1, 0(t0)\n" ++
+  "  add t3, s0, t1\n" ++
+  "  la t4, bvwr2_claimed_root\n" ++
+  "  ld t5,  0(t3); sd t5,  0(t4)\n" ++
+  "  ld t5,  8(t3); sd t5,  8(t4)\n" ++
+  "  ld t5, 16(t3); sd t5, 16(t4)\n" ++
+  "  ld t5, 24(t3); sd t5, 24(t4)\n" ++
+  "  # ---- Compute 2-leaf MPT root ----\n" ++
+  "  mv a0, s2; mv a1, s3\n" ++
+  "  mv a2, s4; mv a3, s5\n" ++
+  "  la a4, bvwr2_computed_root\n" ++
+  "  jal ra, mpt_two_leaf_root_indexed\n" ++
+  "  la t0, bvwr2_claimed_root\n" ++
+  "  la t1, bvwr2_computed_root\n" ++
+  "  ld t2,  0(t0); ld t3,  0(t1); bne t2, t3, .Lbvwr2_neq\n" ++
+  "  ld t2,  8(t0); ld t3,  8(t1); bne t2, t3, .Lbvwr2_neq\n" ++
+  "  ld t2, 16(t0); ld t3, 16(t1); bne t2, t3, .Lbvwr2_neq\n" ++
+  "  ld t2, 24(t0); ld t3, 24(t1); bne t2, t3, .Lbvwr2_neq\n" ++
+  "  li t0, 1\n" ++
+  "  sd t0, 0(s6)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lbvwr2_ret\n" ++
+  ".Lbvwr2_neq:\n" ++
+  "  sd zero, 0(s6)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lbvwr2_ret\n" ++
+  ".Lbvwr2_parse_fail:\n" ++
+  "  li a0, 1\n" ++
+  "  j .Lbvwr2_ret\n" ++
+  ".Lbvwr2_size_fail:\n" ++
+  "  li a0, 2\n" ++
+  ".Lbvwr2_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp)\n" ++
+  "  addi sp, sp, 64\n" ++
+  "  ret"
+
+/-- `zisk_block_validate_withdrawals_root_two_w`: probe BuildUnit.
+    Input layout:
+      bytes  0.. 8 : header_rlp_len
+      bytes  8..16 : w0_rlp_len
+      bytes 16..24 : w1_rlp_len
+      bytes 24..   : header_rlp || w0_rlp || w1_rlp
+    Output layout:
+      bytes  0.. 8 : status (0..2)
+      bytes  8..16 : is_valid -/
+def ziskBlockValidateWithdrawalsRootTwoWPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a7, 0x40000000\n" ++
+  "  ld a1, 8(a7)                # header_rlp_len\n" ++
+  "  ld a3, 16(a7)               # w0_rlp_len\n" ++
+  "  ld a5, 24(a7)               # w1_rlp_len\n" ++
+  "  addi a0, a7, 32             # header_rlp ptr\n" ++
+  "  add a2, a0, a1              # w0_rlp ptr\n" ++
+  "  add a4, a2, a3              # w1_rlp ptr\n" ++
+  "  li a6, 0xa0010008           # is_valid out\n" ++
+  "  jal ra, block_validate_withdrawals_root_two_w\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lbvwr2_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  hpEncodeNibblesFunction ++ "\n" ++
+  rlpEncodeBytesFunction ++ "\n" ++
+  rlpEncodeListPrefixFunction ++ "\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  mptLeafNodeEncodeFromNibblesFunction ++ "\n" ++
+  mptNodeSlotEncodeFunction ++ "\n" ++
+  mptBranchPayloadTwoSlotsFunction ++ "\n" ++
+  mptBranchNodeEncodeFunction ++ "\n" ++
+  mptBranchNodeKeccakFunction ++ "\n" ++
+  mptTwoLeafRootIndexedFunction ++ "\n" ++
+  blockValidateWithdrawalsRootTwoWFunction ++ "\n" ++
+  ".Lbvwr2_pdone:"
+
+def ziskBlockValidateWithdrawalsRootTwoWDataSection : String :=
+  ziskBlockValidateTransactionsRootTwoTxDataSection ++ "\n" ++
+  "bvwr2_offset:\n" ++
+  "  .zero 8\n" ++
+  "bvwr2_length:\n" ++
+  "  .zero 8\n" ++
+  "bvwr2_claimed_root:\n" ++
+  "  .zero 32\n" ++
+  "bvwr2_computed_root:\n" ++
+  "  .zero 32"
+
+def ziskBlockValidateWithdrawalsRootTwoWProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskBlockValidateWithdrawalsRootTwoWPrologue
+  dataAsm     := ziskBlockValidateWithdrawalsRootTwoWDataSection
+}
+
 
 end EvmAsm.Codegen

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **214**
-- ziskemu round-trip scripts: **207** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **215**
+- ziskemu round-trip scripts: **208** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ block-body helpers
 `block_validate_transactions_root_two_tx`,
 `block_validate_transactions_root_one_tx`,
 `block_validate_withdrawals_root_one_w`,
+`block_validate_withdrawals_root_two_w`,
 `block_hash_from_header`, `validate_parent_hash_link`,
 `validate_header_pair`, `validate_header_chain`,
 `block_validate_2tx_full`, `block_validate_1tx_full`,

--- a/scripts/codegen-zisk-block-validate-withdrawals-root-two-w-check.sh
+++ b/scripts/codegen-zisk-block-validate-withdrawals-root-two-w-check.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# codegen-zisk-block-validate-withdrawals-root-two-w-check.sh -- PR-K192.
+#
+# N=2 variant for withdrawals_root.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_block_validate_withdrawals_root_two_w ELF"
+lake exe codegen --program zisk_block_validate_withdrawals_root_two_w --halt linux93 \
+  -o gen-out/zisk_block_validate_withdrawals_root_two_w
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <w0_py> <w1_py> <override_or_special> <exp_status> <exp_valid>
+run_case() {
+  local name="$1" w0="$2" w1="$3" override="$4" exp_status="$5" exp_valid="$6"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_block_validate_withdrawals_root_two_w_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_block_validate_withdrawals_root_two_w_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+try:
+    from Crypto.Hash import keccak
+    def keccak256(b):
+        h = keccak.new(digest_bits=256); h.update(b); return h.digest()
+except Exception:
+    import sha3
+    def keccak256(b): return sha3.keccak_256(b).digest()
+
+w0 = $w0
+w1 = $w1
+override = '$override'
+
+def hp_leaf(nibbles, value):
+    flag = 2 + (len(nibbles) & 1)
+    hp = bytearray()
+    if len(nibbles) % 2 == 1:
+        hp.append((flag << 4) | nibbles[0]); i = 1
+    else:
+        hp.append(flag << 4); i = 0
+    while i < len(nibbles):
+        hp.append((nibbles[i] << 4) | nibbles[i+1]); i += 2
+    return rlp.encode([bytes(hp), value])
+
+def slot_ref(node_rlp):
+    if len(node_rlp) < 32:
+        return node_rlp
+    return b'\\xa0' + keccak256(node_rlp)
+
+leaf_0 = hp_leaf([0], w0)
+leaf_1 = hp_leaf([1], w1)
+slots = [b'\\x80'] * 17
+slots[8] = slot_ref(leaf_0)
+slots[0] = slot_ref(leaf_1)
+payload = b''.join(slots)
+n = len(payload)
+if n < 56:
+    prefix = bytes([0xc0 + n])
+else:
+    nb = n.to_bytes((n.bit_length() + 7) // 8, 'big')
+    prefix = bytes([0xf7 + len(nb)]) + nb
+correct_root = keccak256(prefix + payload)
+
+if override == 'garbage':
+    header_rlp = b'\\x00'
+else:
+    if override == '':
+        field16 = correct_root
+    elif override == 'short':
+        field16 = b'\\xaa'*16
+    else:
+        field16 = bytes.fromhex(override)
+    fields = [
+        b'\\x11'*32, b'\\x22'*32, b'\\x33'*20, b'\\x44'*32, b'\\x55'*32,
+        b'\\x66'*32, b'\\x00'*256, b'', b'\\x01', b'\\x83\\xff\\xff\\xff',
+        b'', b'\\x83\\x01\\x02\\x03', b'', b'\\x77'*32, b'\\x00'*8,
+        b'\\x82\\x12\\x34', field16,
+    ]
+    header_rlp = rlp.encode(fields)
+
+with open(sys.argv[1], 'wb') as f:
+    record = struct.pack('<Q', len(header_rlp)) + \
+             struct.pack('<Q', len(w0)) + \
+             struct.pack('<Q', len(w1)) + \
+             header_rlp + w0 + w1
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_block_validate_withdrawals_root_two_w.elf \
+    -i "$in_file" -o "$out_file" -n 5000000 \
+    >"$REPO_ROOT/gen-out/zisk_block_validate_withdrawals_root_two_w_${name}.emu.log" 2>&1 || true
+
+  local status_le; status_le="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local valid_le;  valid_le="$( dd if="$out_file" bs=1 skip=8 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local status valid
+  status="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$status_le'))[0])")"
+  valid="$( python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$valid_le'))[0])")"
+
+  if [[ "$status" == "$exp_status" && "$valid" == "$exp_valid" ]]; then
+    printf "  %-28s OK   status=%s valid=%s\n" "$name" "$status" "$valid"
+    return 0
+  else
+    printf "  %-28s FAIL status=%s/%s valid=%s/%s\n" \
+      "$name" "$status" "$exp_status" "$valid" "$exp_valid"
+    return 1
+  fi
+}
+
+W0="rlp.encode([b'\\x01', b'\\x12\\x34', b'\\xee'*20, b'\\x83\\x0f\\x42\\x40'])"
+W1="rlp.encode([b'\\x02', b'\\x56\\x78', b'\\xff'*20, b'\\x83\\x1e\\x84\\x80'])"
+WRONG="ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100"
+
+FAILED=0
+run_case "match_two_withdrawals"  "$W0" "$W1" ""        0 1 || FAILED=1
+run_case "mismatch_wrong_root"    "$W0" "$W1" "$WRONG"  0 0 || FAILED=1
+run_case "size_fail_short_f16"    "$W0" "$W1" "short"   2 0 || FAILED=1
+run_case "parse_fail_garbage"     "$W0" "$W1" "garbage" 1 0 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: block_validate_withdrawals_root_two_w accepts matching root, rejects others"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

N=2 variant for `withdrawals_root`: validates `header.field[16]`
matches the 2-leaf MPT root of two pre-RLP-encoded withdrawals.
Field 16 variant of K171 with the same 2-leaf MPT shape (K170)
applied to withdrawal payloads.

Both withdrawals are supplied pre-RLP-encoded (typically via K130
`withdrawal_rlp_encode` upstream).

## Calling convention

`a0/a1` header_rlp ptr+len, `a2/a3` w0_rlp ptr+len, `a4/a5` w1_rlp
ptr+len, `a6` u64 out (is_valid). Status: 0 ok / 1 header parse /
2 size != 32.

## Test plan

4 ziskemu fixtures:

- [x] `match_two_withdrawals` -- correct root -> valid=1
- [x] `mismatch_wrong_root` -- wrong root -> valid=0
- [x] `size_fail_short_f16` -- 16-byte field 16 -> status=2
- [x] `parse_fail_garbage` -- garbage header -> status=1

## Stack

Builds on #5989 (PR-K191 `block_validate_withdrawals_root_one_w`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)