### PR TITLE
feat(div): add v4 n=4 call+skip getLimbN bridge (n4_call_skip_div_mod_getLimbN_v4)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -10,6 +10,7 @@ import EvmAsm.Evm64.DivMod.Spec.CallSkip
 import EvmAsm.Evm64.DivMod.Spec.CallSkipExactX1
 import EvmAsm.Evm64.DivMod.Spec.CallSkipUnconditional
 import EvmAsm.Evm64.DivMod.Spec.CallSkipNoNop
+import EvmAsm.Evm64.DivMod.Spec.CallSkipV4
 import EvmAsm.Evm64.DivMod.Spec.CallAddbackPureNat
 import EvmAsm.Evm64.DivMod.Spec.CallAddback
 import EvmAsm.Evm64.DivMod.Spec.CallAddbackRuntime

--- a/EvmAsm/Evm64/DivMod/Spec/CallSkipV4.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/CallSkipV4.lean
@@ -1,0 +1,145 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.CallSkipV4
+
+  v4 analogues of the call+skip semantic predicate and `EvmWord.div`
+  getLimbN bridge originally proven for the v1 algorithm in
+  `Spec/CallSkip.lean`.
+
+  Provides:
+
+  * `n4CallSkipSemanticHoldsV4 a b : Prop` — Knuth-A lower bound at the
+    val256 level for the v4 trial quotient `div128Quot_v4` (mirror of
+    `n4CallSkipSemanticHolds`).
+  * `n4_call_skip_div_mod_getLimbN_v4` — under `hbnz`, `hshift_nz`, the
+    v4 skip-borrow runtime check `isSkipBorrowN4CallV4Evm`, and `hsem :=
+    n4CallSkipSemanticHoldsV4 a b`, identifies the four limbs of
+    `EvmWord.div a b` with the v4 trial quotient (low limb) and `0`
+    (upper three limbs).
+
+  Together with the no-overflow bound
+  `div128Quot_v4_call_skip_mul_val256_b_le_val256_a` (see
+  `EvmWordArith/Div128CallSkipCloseV4.lean`), the bridge sandwiches
+  `qHat_v4.toNat` to `val256(a)/val256(b)`.
+
+  The `hsem` precondition is left as an input here; its unconditional
+  discharge under runtime conditions (v4 Knuth-A) is tracked separately
+  by bead `evm-asm-9iqmw.7.1.3.1.1`.
+-/
+import EvmAsm.Evm64.DivMod.Spec.CallSkip
+import EvmAsm.Evm64.EvmWordArith.Div128CallSkipCloseV4
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64 EvmWord
+
+/-- **v4 algorithmic lower bound for `div128Quot_v4` at val256 level.**
+
+    Mirror of `n4CallSkipSemanticHolds` (Spec/CallSkip.lean:1067), with
+    the v1 trial `div128Quot` replaced by the v4 trial `div128Quot_v4`.
+
+    Packages Knuth Theorem A (normalized divisor version) for the v4
+    algorithm: `val256(a)/val256(b) ≤ qHat_v4`. The v4 algorithm with
+    classical 2-correction in both Phase-1b and Phase-2 satisfies this
+    bound (it computes the exact 128/64 quotient when `un21 < vTop`,
+    and the val256 Knuth-A follows). The discharge under runtime
+    conditions is left to a separate bead. -/
+def n4CallSkipSemanticHoldsV4 (a b : EvmWord) : Prop :=
+  let shift := (clzResult (b.getLimbN 3)).1.toNat % 64
+  let antiShift := (signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 3)).1).toNat % 64
+  let b3' := ((b.getLimbN 3) <<< shift) ||| ((b.getLimbN 2) >>> antiShift)
+  let u4 := (a.getLimbN 3) >>> antiShift
+  let u3 := ((a.getLimbN 3) <<< shift) ||| ((a.getLimbN 2) >>> antiShift)
+  val256 (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3) /
+      val256 (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) ≤
+    (div128Quot_v4 u4 u3 b3').toNat
+
+theorem n4CallSkipSemanticHoldsV4_def {a b : EvmWord} :
+    n4CallSkipSemanticHoldsV4 a b =
+    (let shift := (clzResult (b.getLimbN 3)).1.toNat % 64
+     let antiShift :=
+       (signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 3)).1).toNat % 64
+     let b3' := ((b.getLimbN 3) <<< shift) ||| ((b.getLimbN 2) >>> antiShift)
+     let u4 := (a.getLimbN 3) >>> antiShift
+     let u3 := ((a.getLimbN 3) <<< shift) ||| ((a.getLimbN 2) >>> antiShift)
+     val256 (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3) /
+         val256 (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) ≤
+       (div128Quot_v4 u4 u3 b3').toNat) :=
+  rfl
+
+/-- **v4 getLimbN bridge for the n=4 call+skip path.**
+
+    Mirror of `n4_call_skip_div_mod_getLimbN` (Spec/CallSkip.lean:1134),
+    with the v1 algorithm replaced by `div128Quot_v4` and the v1 borrow
+    predicate `isSkipBorrowN4CallEvm` replaced by its v4 counterpart
+    `isSkipBorrowN4CallV4Evm`.
+
+    Proof structure (transfers verbatim — qHat-agnostic sandwich):
+    1. From T3 (v4): `qHat.toNat * val256(b) ≤ val256(a)`.
+    2. From hsem (Knuth-A v4): `val256(a)/val256(b) ≤ qHat.toNat`.
+    3. Sandwich gives `qHat.toNat = a.toNat / b.toNat = (EvmWord.div a b).toNat`.
+    4. Since `qHat.toNat < 2^64`, only the low limb of `EvmWord.div a b` is
+       non-zero; the upper three limbs vanish. -/
+theorem n4_call_skip_div_mod_getLimbN_v4 (a b : EvmWord)
+    (hbnz : b ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (hborrow : isSkipBorrowN4CallV4Evm a b)
+    (hsem : n4CallSkipSemanticHoldsV4 a b) :
+    let shift := (clzResult (b.getLimbN 3)).1.toNat % 64
+    let antiShift :=
+      (signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 3)).1).toNat % 64
+    let b3' := ((b.getLimbN 3) <<< shift) ||| ((b.getLimbN 2) >>> antiShift)
+    let u4 := (a.getLimbN 3) >>> antiShift
+    let u3 := ((a.getLimbN 3) <<< shift) ||| ((a.getLimbN 2) >>> antiShift)
+    let qHat := div128Quot_v4 u4 u3 b3'
+    (EvmWord.div a b).getLimbN 0 = qHat ∧
+    (EvmWord.div a b).getLimbN 1 = 0 ∧
+    (EvmWord.div a b).getLimbN 2 = 0 ∧
+    (EvmWord.div a b).getLimbN 3 = 0 := by
+  intro shift antiShift b3' u4 u3 qHat
+  rw [isSkipBorrowN4CallV4Evm_def] at hborrow
+  rw [n4CallSkipSemanticHoldsV4_def] at hsem
+  have hT3 := div128Quot_v4_call_skip_mul_val256_b_le_val256_a
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+      hshift_nz hborrow
+  change qHat.toNat * val256 (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) ≤
+         val256 (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3) at hT3
+  change val256 (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3) /
+         val256 (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) ≤
+         qHat.toNat at hsem
+  have ha_val : val256 (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      = a.toNat := by
+    simp only [← EvmWord.getLimb_as_getLimbN_0, ← EvmWord.getLimb_as_getLimbN_1,
+               ← EvmWord.getLimb_as_getLimbN_2, ← EvmWord.getLimb_as_getLimbN_3]
+    exact EvmWord.val256_eq_toNat a
+  have hb_val : val256 (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+      = b.toNat := by
+    simp only [← EvmWord.getLimb_as_getLimbN_0, ← EvmWord.getLimb_as_getLimbN_1,
+               ← EvmWord.getLimb_as_getLimbN_2, ← EvmWord.getLimb_as_getLimbN_3]
+    exact EvmWord.val256_eq_toNat b
+  have hb_pos : 0 < b.toNat := by
+    rcases Nat.eq_zero_or_pos b.toNat with h | h
+    · exfalso; apply hbnz; exact BitVec.eq_of_toNat_eq (by simp [h])
+    · exact h
+  rw [ha_val, hb_val] at hT3 hsem
+  have hq_eq : qHat.toNat = a.toNat / b.toNat := by
+    have hle : qHat.toNat ≤ a.toNat / b.toNat :=
+      (Nat.le_div_iff_mul_le hb_pos).mpr hT3
+    omega
+  have hdiv_toNat : (EvmWord.div a b).toNat = a.toNat / b.toNat := by
+    unfold EvmWord.div
+    rw [if_neg hbnz]
+    exact BitVec.toNat_udiv
+  set q_target : EvmWord := EvmWord.fromLimbs fun i : Fin 4 =>
+    match i with | 0 => qHat | 1 => 0 | 2 => 0 | 3 => 0 with hq_target
+  have hq_target_toNat : q_target.toNat = qHat.toNat := by
+    simp [q_target, EvmWord.fromLimbs_toNat]
+  have hq_eq_div : q_target = EvmWord.div a b :=
+    BitVec.eq_of_toNat_eq (by omega)
+  refine ⟨?_, ?_, ?_, ?_⟩
+  · rw [← hq_eq_div]; exact EvmWord.getLimbN_fromLimbs_0
+  · rw [← hq_eq_div]; exact EvmWord.getLimbN_fromLimbs_1
+  · rw [← hq_eq_div]; exact EvmWord.getLimbN_fromLimbs_2
+  · rw [← hq_eq_div]; exact EvmWord.getLimbN_fromLimbs_3
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Adds `n4CallSkipSemanticHoldsV4` (Knuth-A lower bound for `div128Quot_v4`) and `n4_call_skip_div_mod_getLimbN_v4` (v4 getLimbN bridge) in new file `Spec/CallSkipV4.lean`.
- Mirror of `n4_call_skip_div_mod_getLimbN` (`Spec/CallSkip.lean:1134`); the qHat-agnostic sandwich argument transfers verbatim from the v1 proof.
- Consumes #5992's `div128Quot_v4_call_skip_mul_val256_b_le_val256_a` (T3, now on main) and takes `hsem := n4CallSkipSemanticHoldsV4 a b` as an input precondition.

Refs #61. Bead `evm-asm-9iqmw.7.1.3.1`.

The `hsem` precondition's unconditional discharge (v4 Knuth-A for `div128Quot_v4`) is real residual math content tracked separately as bead `evm-asm-9iqmw.7.1.3.1.1`. This PR is the structural plumbing that consumes the eventual discharge — once the lower bound theorem lands, the stack-level `evm_div_n4_call_skip_stack_spec_v4` can be assembled.

## Verification
- `lake build EvmAsm.Evm64.DivMod.Spec.CallSkipV4`
- `lake build` (full, 2233 jobs)
- `scripts/check-file-size.sh` (811 files, all within cap)
- `rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/Spec/CallSkipV4.lean` (no matches)

Authored by @pirapira; implemented by Claude Code