### PR TITLE
feat(stateless): block_validate_receipts_root_one_receipt (PR-K193)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -4864,6 +4864,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_block_validate_transactions_root_one_tx" => some ziskBlockValidateTransactionsRootOneTxProbeUnit
   | "zisk_block_validate_withdrawals_root_one_w" => some ziskBlockValidateWithdrawalsRootOneWProbeUnit
   | "zisk_block_validate_withdrawals_root_two_w" => some ziskBlockValidateWithdrawalsRootTwoWProbeUnit
+  | "zisk_block_validate_receipts_root_one_receipt" => some ziskBlockValidateReceiptsRootOneReceiptProbeUnit
   | "zisk_block_validate_transactions_root_two_tx" => some ziskBlockValidateTransactionsRootTwoTxProbeUnit
   | "zisk_block_hash_from_header" => some ziskBlockHashFromHeaderProbeUnit
   | "zisk_validate_parent_hash_link" => some ziskValidateParentHashLinkProbeUnit
@@ -5070,6 +5071,7 @@ def knownProgramNames : List String :=
    "zisk_block_validate_transactions_root_one_tx",
    "zisk_block_validate_withdrawals_root_one_w",
    "zisk_block_validate_withdrawals_root_two_w",
+   "zisk_block_validate_receipts_root_one_receipt",
    "zisk_block_validate_transactions_root_two_tx",
    "zisk_block_hash_from_header",
    "zisk_validate_parent_hash_link",

--- a/EvmAsm/Codegen/Programs/Mpt.lean
+++ b/EvmAsm/Codegen/Programs/Mpt.lean
@@ -4778,5 +4778,152 @@ def ziskBlockValidateWithdrawalsRootTwoWProbeUnit : BuildUnit := {
   dataAsm     := ziskBlockValidateWithdrawalsRootTwoWDataSection
 }
 
+/-! ## block_validate_receipts_root_one_receipt -- PR-K193
+
+    End-to-end `receipts_root` validation for blocks with
+    exactly one receipt. Field 5 variant of K186 / K191:
+
+      claimed_root = header.field[5]              -- via K20
+      computed_root = mpt_one_leaf_root_indexed(  -- K185
+                          receipt_rlp)
+      is_valid = (claimed_root == computed_root)
+
+    The receipt is supplied as its already-encoded payload --
+    typically the output of K156 `receipt_encode`, which yields
+    `rlp([status, cum_gas, bloom, logs])` for legacy receipts
+    and `tx_type || rlp([...])` for typed receipts (EIP-2718).
+
+    Calling convention:
+      a0 (input)  : header_rlp ptr
+      a1 (input)  : header_rlp byte length
+      a2 (input)  : receipt_rlp ptr (pre-encoded payload)
+      a3 (input)  : receipt_rlp byte length
+      a4 (input)  : u64 out (is_valid)
+      ra (input)  : return
+      a0 (output) :
+        0 : success -- predicate written
+        1 : header RLP parse failure / field 5 missing
+        2 : header.receipts_root length != 32 -/
+def blockValidateReceiptsRootOneReceiptFunction : String :=
+  "block_validate_receipts_root_one_receipt:\n" ++
+  "  addi sp, sp, -48\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp); sd s4, 40(sp)\n" ++
+  "  mv s0, a0; mv s1, a1                # header\n" ++
+  "  mv s2, a2; mv s3, a3                # receipt\n" ++
+  "  mv s4, a4                            # is_valid out\n" ++
+  "  sd zero, 0(s4)\n" ++
+  "  # ---- Extract header.receipts_root (field 5) ----\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 5\n" ++
+  "  la a3, bvrr1_offset; la a4, bvrr1_length\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lbvrr1_parse_fail\n" ++
+  "  la t0, bvrr1_length; ld t1, 0(t0)\n" ++
+  "  li t2, 32\n" ++
+  "  bne t1, t2, .Lbvrr1_size_fail\n" ++
+  "  la t0, bvrr1_offset; ld t1, 0(t0)\n" ++
+  "  add t3, s0, t1\n" ++
+  "  la t4, bvrr1_claimed_root\n" ++
+  "  ld t5,  0(t3); sd t5,  0(t4)\n" ++
+  "  ld t5,  8(t3); sd t5,  8(t4)\n" ++
+  "  ld t5, 16(t3); sd t5, 16(t4)\n" ++
+  "  ld t5, 24(t3); sd t5, 24(t4)\n" ++
+  "  mv a0, s2; mv a1, s3\n" ++
+  "  la a2, bvrr1_computed_root\n" ++
+  "  jal ra, mpt_one_leaf_root_indexed\n" ++
+  "  la t0, bvrr1_claimed_root\n" ++
+  "  la t1, bvrr1_computed_root\n" ++
+  "  ld t2,  0(t0); ld t3,  0(t1); bne t2, t3, .Lbvrr1_neq\n" ++
+  "  ld t2,  8(t0); ld t3,  8(t1); bne t2, t3, .Lbvrr1_neq\n" ++
+  "  ld t2, 16(t0); ld t3, 16(t1); bne t2, t3, .Lbvrr1_neq\n" ++
+  "  ld t2, 24(t0); ld t3, 24(t1); bne t2, t3, .Lbvrr1_neq\n" ++
+  "  li t0, 1\n" ++
+  "  sd t0, 0(s4)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lbvrr1_ret\n" ++
+  ".Lbvrr1_neq:\n" ++
+  "  sd zero, 0(s4)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lbvrr1_ret\n" ++
+  ".Lbvrr1_parse_fail:\n" ++
+  "  li a0, 1\n" ++
+  "  j .Lbvrr1_ret\n" ++
+  ".Lbvrr1_size_fail:\n" ++
+  "  li a0, 2\n" ++
+  ".Lbvrr1_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp); ld s4, 40(sp)\n" ++
+  "  addi sp, sp, 48\n" ++
+  "  ret"
+
+/-- `zisk_block_validate_receipts_root_one_receipt`: probe BuildUnit.
+    Input layout:
+      bytes 0..8  : header_rlp_len
+      bytes 8..16 : receipt_rlp_len
+      bytes 16..  : header_rlp || receipt_rlp
+    Output layout:
+      bytes 0..8  : status
+      bytes 8..16 : is_valid -/
+def ziskBlockValidateReceiptsRootOneReceiptPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a7, 0x40000000\n" ++
+  "  ld a1, 8(a7)                # header_rlp_len\n" ++
+  "  ld a3, 16(a7)               # receipt_rlp_len\n" ++
+  "  addi a0, a7, 24             # header_rlp ptr\n" ++
+  "  add a2, a0, a1              # receipt_rlp ptr\n" ++
+  "  li a4, 0xa0010008           # is_valid out\n" ++
+  "  jal ra, block_validate_receipts_root_one_receipt\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lbvrr1_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  hpEncodeNibblesFunction ++ "\n" ++
+  rlpEncodeBytesFunction ++ "\n" ++
+  rlpEncodeListPrefixFunction ++ "\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  mptLeafNodeEncodeFromNibblesFunction ++ "\n" ++
+  mptOneLeafRootIndexedFunction ++ "\n" ++
+  blockValidateReceiptsRootOneReceiptFunction ++ "\n" ++
+  ".Lbvrr1_pdone:"
+
+def ziskBlockValidateReceiptsRootOneReceiptDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  "mlnen_field_len:\n" ++
+  "  .zero 8\n" ++
+  "mlnen_hp_len:\n" ++
+  "  .zero 8\n" ++
+  "mlnen_cursor:\n" ++
+  "  .zero 8\n" ++
+  "mlnen_total_payload:\n" ++
+  "  .zero 8\n" ++
+  "mlnen_hp_buf:\n" ++
+  "  .zero 1024\n" ++
+  "mlnen_payload_buf:\n" ++
+  "  .zero 16384\n" ++
+  "mtoli_nibbles:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "mtoli_leaf_len:\n" ++
+  "  .zero 8\n" ++
+  "mtoli_leaf_buf:\n" ++
+  "  .zero 16384\n" ++
+  "bvrr1_offset:\n" ++
+  "  .zero 8\n" ++
+  "bvrr1_length:\n" ++
+  "  .zero 8\n" ++
+  "bvrr1_claimed_root:\n" ++
+  "  .zero 32\n" ++
+  "bvrr1_computed_root:\n" ++
+  "  .zero 32"
+
+def ziskBlockValidateReceiptsRootOneReceiptProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskBlockValidateReceiptsRootOneReceiptPrologue
+  dataAsm     := ziskBlockValidateReceiptsRootOneReceiptDataSection
+}
+
 
 end EvmAsm.Codegen

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **215**
-- ziskemu round-trip scripts: **208** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **216**
+- ziskemu round-trip scripts: **209** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ block-body helpers
 `block_validate_transactions_root_one_tx`,
 `block_validate_withdrawals_root_one_w`,
 `block_validate_withdrawals_root_two_w`,
+`block_validate_receipts_root_one_receipt`,
 `block_hash_from_header`, `validate_parent_hash_link`,
 `validate_header_pair`, `validate_header_chain`,
 `block_validate_2tx_full`, `block_validate_1tx_full`,

--- a/scripts/codegen-zisk-block-validate-receipts-root-one-receipt-check.sh
+++ b/scripts/codegen-zisk-block-validate-receipts-root-one-receipt-check.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# codegen-zisk-block-validate-receipts-root-one-receipt-check.sh -- PR-K193.
+#
+# N=1 variant for receipts_root.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_block_validate_receipts_root_one_receipt ELF"
+lake exe codegen --program zisk_block_validate_receipts_root_one_receipt --halt linux93 \
+  -o gen-out/zisk_block_validate_receipts_root_one_receipt
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <receipt_py_expr> <override_or_special> <exp_status> <exp_valid>
+run_case() {
+  local name="$1" r_expr="$2" override="$3" exp_status="$4" exp_valid="$5"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_block_validate_receipts_root_one_receipt_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_block_validate_receipts_root_one_receipt_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+try:
+    from Crypto.Hash import keccak
+    def keccak256(b):
+        h = keccak.new(digest_bits=256); h.update(b); return h.digest()
+except Exception:
+    import sha3
+    def keccak256(b): return sha3.keccak_256(b).digest()
+
+receipt_rlp = $r_expr
+override = '$override'
+
+def hp_leaf(nibbles, value):
+    flag = 2 + (len(nibbles) & 1)
+    hp = bytearray()
+    if len(nibbles) % 2 == 1:
+        hp.append((flag << 4) | nibbles[0]); i = 1
+    else:
+        hp.append(flag << 4); i = 0
+    while i < len(nibbles):
+        hp.append((nibbles[i] << 4) | nibbles[i+1]); i += 2
+    return rlp.encode([bytes(hp), value])
+
+correct_root = keccak256(hp_leaf([8, 0], receipt_rlp))
+
+if override == 'garbage':
+    header_rlp = b'\\x00'
+else:
+    if override == '':
+        field5 = correct_root
+    elif override == 'short':
+        field5 = b'\\xaa'*16
+    else:
+        field5 = bytes.fromhex(override)
+    fields = [
+        b'\\x11'*32, b'\\x22'*32, b'\\x33'*20, b'\\x44'*32, b'\\x55'*32,
+        field5, b'\\x00'*256, b'', b'\\x01', b'\\x83\\xff\\xff\\xff',
+        b'', b'\\x83\\x01\\x02\\x03', b'', b'\\x77'*32, b'\\x00'*8,
+    ]
+    header_rlp = rlp.encode(fields)
+
+with open(sys.argv[1], 'wb') as f:
+    record = struct.pack('<Q', len(header_rlp)) + \
+             struct.pack('<Q', len(receipt_rlp)) + \
+             header_rlp + receipt_rlp
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_block_validate_receipts_root_one_receipt.elf \
+    -i "$in_file" -o "$out_file" -n 5000000 \
+    >"$REPO_ROOT/gen-out/zisk_block_validate_receipts_root_one_receipt_${name}.emu.log" 2>&1 || true
+
+  local status_le; status_le="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local valid_le;  valid_le="$( dd if="$out_file" bs=1 skip=8 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local status valid
+  status="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$status_le'))[0])")"
+  valid="$( python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$valid_le'))[0])")"
+
+  if [[ "$status" == "$exp_status" && "$valid" == "$exp_valid" ]]; then
+    printf "  %-28s OK   status=%s valid=%s\n" "$name" "$status" "$valid"
+    return 0
+  else
+    printf "  %-28s FAIL status=%s/%s valid=%s/%s\n" \
+      "$name" "$status" "$exp_status" "$valid" "$exp_valid"
+    return 1
+  fi
+}
+
+# Legacy receipt: rlp([status, cum_gas_used, bloom, logs])
+RECEIPT="rlp.encode([b'\\x01', b'\\x83\\x52\\x08', b'\\x00'*256, []])"
+WRONG="ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100"
+
+FAILED=0
+run_case "match_one_receipt"     "$RECEIPT" ""        0 1 || FAILED=1
+run_case "mismatch_wrong_root"   "$RECEIPT" "$WRONG"  0 0 || FAILED=1
+run_case "size_fail_short_f5"    "$RECEIPT" "short"   2 0 || FAILED=1
+run_case "parse_fail_garbage"    "$RECEIPT" "garbage" 1 0 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: block_validate_receipts_root_one_receipt accepts matching root, rejects others"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

End-to-end `receipts_root` validation for blocks with exactly one
receipt -- field 5 variant of K186 (tx_root) / K191 (withdrawals).
Completes the `{tx, receipt, withdrawal}` root-validator trinity
for N=1.

The receipt is supplied as its already-encoded payload (the output
of K156 `receipt_encode` upstream): `rlp([status, cum_gas, bloom,
logs])` for legacy receipts, `tx_type || rlp([...])` for typed
receipts.

## Calling convention

`a0/a1` header_rlp ptr+len, `a2/a3` receipt_rlp ptr+len, `a4` u64
out (is_valid). Status: 0 ok / 1 header parse / 2 size != 32.

## Test plan

4 ziskemu fixtures:

- [x] `match_one_receipt` -- correct root -> valid=1
- [x] `mismatch_wrong_root` -- wrong root -> valid=0
- [x] `size_fail_short_f5` -- 16-byte field 5 -> status=2
- [x] `parse_fail_garbage` -- garbage header -> status=1

## Stack

Builds on #5994 (refactor: extract K130/K132 to Programs/Withdrawal.lean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)