### PR TITLE
feat(stateless): block_validate_receipts_root_two_receipts (PR-K194)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -4865,6 +4865,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_block_validate_withdrawals_root_one_w" => some ziskBlockValidateWithdrawalsRootOneWProbeUnit
   | "zisk_block_validate_withdrawals_root_two_w" => some ziskBlockValidateWithdrawalsRootTwoWProbeUnit
   | "zisk_block_validate_receipts_root_one_receipt" => some ziskBlockValidateReceiptsRootOneReceiptProbeUnit
+  | "zisk_block_validate_receipts_root_two_receipts" => some ziskBlockValidateReceiptsRootTwoReceiptsProbeUnit
   | "zisk_block_validate_transactions_root_two_tx" => some ziskBlockValidateTransactionsRootTwoTxProbeUnit
   | "zisk_block_hash_from_header" => some ziskBlockHashFromHeaderProbeUnit
   | "zisk_validate_parent_hash_link" => some ziskValidateParentHashLinkProbeUnit
@@ -5072,6 +5073,7 @@ def knownProgramNames : List String :=
    "zisk_block_validate_withdrawals_root_one_w",
    "zisk_block_validate_withdrawals_root_two_w",
    "zisk_block_validate_receipts_root_one_receipt",
+   "zisk_block_validate_receipts_root_two_receipts",
    "zisk_block_validate_transactions_root_two_tx",
    "zisk_block_hash_from_header",
    "zisk_validate_parent_hash_link",

--- a/EvmAsm/Codegen/Programs/Mpt.lean
+++ b/EvmAsm/Codegen/Programs/Mpt.lean
@@ -4925,5 +4925,137 @@ def ziskBlockValidateReceiptsRootOneReceiptProbeUnit : BuildUnit := {
   dataAsm     := ziskBlockValidateReceiptsRootOneReceiptDataSection
 }
 
+/-! ## block_validate_receipts_root_two_receipts -- PR-K194
+
+    N=2 variant for `receipts_root`: validates `header.field[5]`
+    matches the 2-leaf MPT root of two pre-encoded receipts.
+    Field 5 variant of K171 / K192 -- completes the
+    `{tx, receipt, withdrawal}` root-validator trinity for N=2.
+
+    Both receipts are supplied pre-encoded (the output of K156
+    `receipt_encode` upstream).
+
+    Calling convention:
+      a0 (input)  : header_rlp ptr
+      a1 (input)  : header_rlp byte length
+      a2 (input)  : r0_rlp ptr
+      a3 (input)  : r0_rlp byte length
+      a4 (input)  : r1_rlp ptr
+      a5 (input)  : r1_rlp byte length
+      a6 (input)  : u64 out (is_valid)
+      ra (input)  : return
+      a0 (output) :
+        0 : success
+        1 : header parse failure / field 5 missing
+        2 : header.receipts_root length != 32 -/
+def blockValidateReceiptsRootTwoReceiptsFunction : String :=
+  "block_validate_receipts_root_two_receipts:\n" ++
+  "  addi sp, sp, -64\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp)\n" ++
+  "  mv s0, a0; mv s1, a1                # header\n" ++
+  "  mv s2, a2; mv s3, a3                # r0\n" ++
+  "  mv s4, a4; mv s5, a5                # r1\n" ++
+  "  mv s6, a6                            # is_valid out\n" ++
+  "  sd zero, 0(s6)\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 5\n" ++
+  "  la a3, bvrr2_offset; la a4, bvrr2_length\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lbvrr2_parse_fail\n" ++
+  "  la t0, bvrr2_length; ld t1, 0(t0)\n" ++
+  "  li t2, 32\n" ++
+  "  bne t1, t2, .Lbvrr2_size_fail\n" ++
+  "  la t0, bvrr2_offset; ld t1, 0(t0)\n" ++
+  "  add t3, s0, t1\n" ++
+  "  la t4, bvrr2_claimed_root\n" ++
+  "  ld t5,  0(t3); sd t5,  0(t4)\n" ++
+  "  ld t5,  8(t3); sd t5,  8(t4)\n" ++
+  "  ld t5, 16(t3); sd t5, 16(t4)\n" ++
+  "  ld t5, 24(t3); sd t5, 24(t4)\n" ++
+  "  mv a0, s2; mv a1, s3\n" ++
+  "  mv a2, s4; mv a3, s5\n" ++
+  "  la a4, bvrr2_computed_root\n" ++
+  "  jal ra, mpt_two_leaf_root_indexed\n" ++
+  "  la t0, bvrr2_claimed_root\n" ++
+  "  la t1, bvrr2_computed_root\n" ++
+  "  ld t2,  0(t0); ld t3,  0(t1); bne t2, t3, .Lbvrr2_neq\n" ++
+  "  ld t2,  8(t0); ld t3,  8(t1); bne t2, t3, .Lbvrr2_neq\n" ++
+  "  ld t2, 16(t0); ld t3, 16(t1); bne t2, t3, .Lbvrr2_neq\n" ++
+  "  ld t2, 24(t0); ld t3, 24(t1); bne t2, t3, .Lbvrr2_neq\n" ++
+  "  li t0, 1\n" ++
+  "  sd t0, 0(s6)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lbvrr2_ret\n" ++
+  ".Lbvrr2_neq:\n" ++
+  "  sd zero, 0(s6)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lbvrr2_ret\n" ++
+  ".Lbvrr2_parse_fail:\n" ++
+  "  li a0, 1\n" ++
+  "  j .Lbvrr2_ret\n" ++
+  ".Lbvrr2_size_fail:\n" ++
+  "  li a0, 2\n" ++
+  ".Lbvrr2_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp)\n" ++
+  "  addi sp, sp, 64\n" ++
+  "  ret"
+
+/-- `zisk_block_validate_receipts_root_two_receipts`: probe BuildUnit.
+    Input layout:
+      bytes  0.. 8 : header_rlp_len
+      bytes  8..16 : r0_rlp_len
+      bytes 16..24 : r1_rlp_len
+      bytes 24..   : header_rlp || r0_rlp || r1_rlp
+    Output layout:
+      bytes  0.. 8 : status
+      bytes  8..16 : is_valid -/
+def ziskBlockValidateReceiptsRootTwoReceiptsPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a7, 0x40000000\n" ++
+  "  ld a1, 8(a7)                # header_rlp_len\n" ++
+  "  ld a3, 16(a7)               # r0_rlp_len\n" ++
+  "  ld a5, 24(a7)               # r1_rlp_len\n" ++
+  "  addi a0, a7, 32             # header_rlp ptr\n" ++
+  "  add a2, a0, a1              # r0_rlp ptr\n" ++
+  "  add a4, a2, a3              # r1_rlp ptr\n" ++
+  "  li a6, 0xa0010008           # is_valid out\n" ++
+  "  jal ra, block_validate_receipts_root_two_receipts\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lbvrr2_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  hpEncodeNibblesFunction ++ "\n" ++
+  rlpEncodeBytesFunction ++ "\n" ++
+  rlpEncodeListPrefixFunction ++ "\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  mptLeafNodeEncodeFromNibblesFunction ++ "\n" ++
+  mptNodeSlotEncodeFunction ++ "\n" ++
+  mptBranchPayloadTwoSlotsFunction ++ "\n" ++
+  mptBranchNodeEncodeFunction ++ "\n" ++
+  mptBranchNodeKeccakFunction ++ "\n" ++
+  mptTwoLeafRootIndexedFunction ++ "\n" ++
+  blockValidateReceiptsRootTwoReceiptsFunction ++ "\n" ++
+  ".Lbvrr2_pdone:"
+
+def ziskBlockValidateReceiptsRootTwoReceiptsDataSection : String :=
+  ziskBlockValidateTransactionsRootTwoTxDataSection ++ "\n" ++
+  "bvrr2_offset:\n" ++
+  "  .zero 8\n" ++
+  "bvrr2_length:\n" ++
+  "  .zero 8\n" ++
+  "bvrr2_claimed_root:\n" ++
+  "  .zero 32\n" ++
+  "bvrr2_computed_root:\n" ++
+  "  .zero 32"
+
+def ziskBlockValidateReceiptsRootTwoReceiptsProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskBlockValidateReceiptsRootTwoReceiptsPrologue
+  dataAsm     := ziskBlockValidateReceiptsRootTwoReceiptsDataSection
+}
+
 
 end EvmAsm.Codegen

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **216**
-- ziskemu round-trip scripts: **209** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **217**
+- ziskemu round-trip scripts: **210** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ block-body helpers
 `block_validate_withdrawals_root_one_w`,
 `block_validate_withdrawals_root_two_w`,
 `block_validate_receipts_root_one_receipt`,
+`block_validate_receipts_root_two_receipts`,
 `block_hash_from_header`, `validate_parent_hash_link`,
 `validate_header_pair`, `validate_header_chain`,
 `block_validate_2tx_full`, `block_validate_1tx_full`,

--- a/scripts/codegen-zisk-block-validate-receipts-root-two-receipts-check.sh
+++ b/scripts/codegen-zisk-block-validate-receipts-root-two-receipts-check.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# codegen-zisk-block-validate-receipts-root-two-receipts-check.sh -- PR-K194.
+#
+# N=2 variant for receipts_root.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_block_validate_receipts_root_two_receipts ELF"
+lake exe codegen --program zisk_block_validate_receipts_root_two_receipts --halt linux93 \
+  -o gen-out/zisk_block_validate_receipts_root_two_receipts
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <r0_py> <r1_py> <override_or_special> <exp_status> <exp_valid>
+run_case() {
+  local name="$1" r0="$2" r1="$3" override="$4" exp_status="$5" exp_valid="$6"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_block_validate_receipts_root_two_receipts_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_block_validate_receipts_root_two_receipts_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+try:
+    from Crypto.Hash import keccak
+    def keccak256(b):
+        h = keccak.new(digest_bits=256); h.update(b); return h.digest()
+except Exception:
+    import sha3
+    def keccak256(b): return sha3.keccak_256(b).digest()
+
+r0 = $r0
+r1 = $r1
+override = '$override'
+
+def hp_leaf(nibbles, value):
+    flag = 2 + (len(nibbles) & 1)
+    hp = bytearray()
+    if len(nibbles) % 2 == 1:
+        hp.append((flag << 4) | nibbles[0]); i = 1
+    else:
+        hp.append(flag << 4); i = 0
+    while i < len(nibbles):
+        hp.append((nibbles[i] << 4) | nibbles[i+1]); i += 2
+    return rlp.encode([bytes(hp), value])
+
+def slot_ref(node_rlp):
+    if len(node_rlp) < 32:
+        return node_rlp
+    return b'\\xa0' + keccak256(node_rlp)
+
+leaf_0 = hp_leaf([0], r0)
+leaf_1 = hp_leaf([1], r1)
+slots = [b'\\x80'] * 17
+slots[8] = slot_ref(leaf_0)
+slots[0] = slot_ref(leaf_1)
+payload = b''.join(slots)
+n = len(payload)
+if n < 56:
+    prefix = bytes([0xc0 + n])
+else:
+    nb = n.to_bytes((n.bit_length() + 7) // 8, 'big')
+    prefix = bytes([0xf7 + len(nb)]) + nb
+correct_root = keccak256(prefix + payload)
+
+if override == 'garbage':
+    header_rlp = b'\\x00'
+else:
+    if override == '':
+        field5 = correct_root
+    elif override == 'short':
+        field5 = b'\\xaa'*16
+    else:
+        field5 = bytes.fromhex(override)
+    fields = [
+        b'\\x11'*32, b'\\x22'*32, b'\\x33'*20, b'\\x44'*32, b'\\x55'*32,
+        field5, b'\\x00'*256, b'', b'\\x01', b'\\x83\\xff\\xff\\xff',
+        b'', b'\\x83\\x01\\x02\\x03', b'', b'\\x77'*32, b'\\x00'*8,
+    ]
+    header_rlp = rlp.encode(fields)
+
+with open(sys.argv[1], 'wb') as f:
+    record = struct.pack('<Q', len(header_rlp)) + \
+             struct.pack('<Q', len(r0)) + \
+             struct.pack('<Q', len(r1)) + \
+             header_rlp + r0 + r1
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_block_validate_receipts_root_two_receipts.elf \
+    -i "$in_file" -o "$out_file" -n 5000000 \
+    >"$REPO_ROOT/gen-out/zisk_block_validate_receipts_root_two_receipts_${name}.emu.log" 2>&1 || true
+
+  local status_le; status_le="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local valid_le;  valid_le="$( dd if="$out_file" bs=1 skip=8 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local status valid
+  status="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$status_le'))[0])")"
+  valid="$( python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$valid_le'))[0])")"
+
+  if [[ "$status" == "$exp_status" && "$valid" == "$exp_valid" ]]; then
+    printf "  %-28s OK   status=%s valid=%s\n" "$name" "$status" "$valid"
+    return 0
+  else
+    printf "  %-28s FAIL status=%s/%s valid=%s/%s\n" \
+      "$name" "$status" "$exp_status" "$valid" "$exp_valid"
+    return 1
+  fi
+}
+
+R0="rlp.encode([b'\\x01', b'\\x83\\x52\\x08', b'\\x00'*256, []])"
+R1="rlp.encode([b'\\x01', b'\\x83\\xa4\\x10', b'\\x00'*256, []])"
+WRONG="ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100"
+
+FAILED=0
+run_case "match_two_receipts"    "$R0" "$R1" ""        0 1 || FAILED=1
+run_case "mismatch_wrong_root"   "$R0" "$R1" "$WRONG"  0 0 || FAILED=1
+run_case "size_fail_short_f5"    "$R0" "$R1" "short"   2 0 || FAILED=1
+run_case "parse_fail_garbage"    "$R0" "$R1" "garbage" 1 0 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: block_validate_receipts_root_two_receipts accepts matching root, rejects others"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

N=2 variant for `receipts_root`: validates `header.field[5]`
matches the 2-leaf MPT root of two pre-encoded receipts.
Field 5 variant of K171 / K192 -- completes the
`{tx, receipt, withdrawal}` root-validator trinity for N=2.

With this PR, all three header trie-roots (`transactions_root`,
`receipts_root`, `withdrawals_root`) have N=1 and N=2 validators
end-to-end.

## Test plan

4 ziskemu fixtures:

- [x] `match_two_receipts` -- correct root -> valid=1
- [x] `mismatch_wrong_root` -- wrong root -> valid=0
- [x] `size_fail_short_f5` -- 16-byte field 5 -> status=2
- [x] `parse_fail_garbage` -- garbage header -> status=1

## Stack

Builds on #5996 (PR-K193 `block_validate_receipts_root_one_receipt`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)