### PR TITLE
feat(stateless): validate_block_hash_chain_match (PR-K195)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -4872,6 +4872,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_validate_header_pair" => some ziskValidateHeaderPairProbeUnit
   | "zisk_validate_header_chain" => some ziskValidateHeaderChainProbeUnit
   | "zisk_block_hash_array_from_chain" => some ziskBlockHashArrayFromChainProbeUnit
+  | "zisk_validate_block_hash_chain_match" => some ziskValidateBlockHashChainMatchProbeUnit
   | "zisk_block_validate_2tx_full" => some ziskBlockValidate2txFullProbeUnit
   | "zisk_block_body_extract_2tx" => some ziskBlockBodyExtract2txProbeUnit
   | "zisk_block_validate_2tx_full_with_body" => some ziskBlockValidate2txFullWithBodyProbeUnit
@@ -5080,6 +5081,7 @@ def knownProgramNames : List String :=
    "zisk_validate_header_pair",
    "zisk_validate_header_chain",
    "zisk_block_hash_array_from_chain",
+   "zisk_validate_block_hash_chain_match",
    "zisk_block_validate_2tx_full",
    "zisk_block_body_extract_2tx",
    "zisk_block_validate_2tx_full_with_body",

--- a/EvmAsm/Codegen/Programs/Header.lean
+++ b/EvmAsm/Codegen/Programs/Header.lean
@@ -2646,4 +2646,196 @@ def ziskBlockHashArrayFromChainProbeUnit : BuildUnit := {
   dataAsm     := ziskBlockHashArrayFromChainDataSection
 }
 
+/-! ## validate_block_hash_chain_match -- PR-K195
+
+    Validate an N-element header chain (K175 invariants) AND
+    check that the block_hash of each header (K172) matches a
+    caller-supplied claim array. This is the natural primitive
+    for chain-anchor proofs: \"the prover claims these are
+    block_hashes B[0..N) for blocks H[0..N); verify both that
+    the chain is well-formed and that the claimed hashes are
+    correct\".
+
+    The two checks (chain validity + hash match) are returned
+    via a single is_valid u64; a status code distinguishes
+    structural-fail (chain links broken) from hash-mismatch.
+
+    Calling convention:
+      a0 (input)  : N (header count)
+      a1 (input)  : header_lengths ptr (u64[N])
+      a2 (input)  : headers ptr (concatenated)
+      a3 (input)  : claimed_hashes ptr (32*N bytes)
+      a4 (input)  : u64 out (is_valid)
+      a5 (input)  : u64 out (first_bad_index)
+      ra (input)  : return
+      a0 (output) :
+        0 : success -- predicate written
+        nonzero : propagated status from validate_header_pair
+                  for the first failing link -/
+def validateBlockHashChainMatchFunction : String :=
+  "validate_block_hash_chain_match:\n" ++
+  "  addi sp, sp, -96\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp); sd s7, 64(sp)\n" ++
+  "  sd s8, 72(sp); sd s9, 80(sp); sd s10, 88(sp)\n" ++
+  "  mv s0, a0                   # N\n" ++
+  "  mv s1, a1                   # header_lengths ptr\n" ++
+  "  mv s2, a2                   # headers ptr\n" ++
+  "  mv s3, a3                   # claimed_hashes ptr (32*N)\n" ++
+  "  mv s4, a4                   # is_valid out\n" ++
+  "  mv s5, a5                   # first_bad_index out\n" ++
+  "  li t0, 1\n" ++
+  "  sd t0, 0(s4)\n" ++
+  "  sd zero, 0(s5)\n" ++
+  "  beqz s0, .Lvbhcm_done       # N==0: vacuous true\n" ++
+  "  # ---- Verify block_hash[0] matches ----\n" ++
+  "  ld a1, 0(s1)                # header_lengths[0]\n" ++
+  "  mv a0, s2                   # header_rlp[0]\n" ++
+  "  la a2, vbhcm_hash_buf\n" ++
+  "  jal ra, block_hash_from_header\n" ++
+  "  la t0, vbhcm_hash_buf; mv t1, s3\n" ++
+  "  ld t2,  0(t0); ld t3,  0(t1); bne t2, t3, .Lvbhcm_pred_false\n" ++
+  "  ld t2,  8(t0); ld t3,  8(t1); bne t2, t3, .Lvbhcm_pred_false\n" ++
+  "  ld t2, 16(t0); ld t3, 16(t1); bne t2, t3, .Lvbhcm_pred_false\n" ++
+  "  ld t2, 24(t0); ld t3, 24(t1); bne t2, t3, .Lvbhcm_pred_false\n" ++
+  "  li t0, 1\n" ++
+  "  beq s0, t0, .Lvbhcm_done    # N==1: just hash check, no chain\n" ++
+  "  # ---- Walk chain ----\n" ++
+  "  mv s6, s2                   # parent_ptr = headers[0]\n" ++
+  "  li s7, 0                    # i = 0\n" ++
+  "  addi s8, s3, 32             # next claimed_hash slot\n" ++
+  ".Lvbhcm_loop:\n" ++
+  "  addi t0, s7, 1\n" ++
+  "  beq t0, s0, .Lvbhcm_done\n" ++
+  "  slli t1, s7, 3\n" ++
+  "  add t1, s1, t1\n" ++
+  "  ld a1, 0(t1)                # parent_len\n" ++
+  "  ld a3, 8(t1)                # child_len\n" ++
+  "  add t2, s6, a1              # child_ptr\n" ++
+  "  mv a0, s6\n" ++
+  "  mv a2, t2\n" ++
+  "  la a4, vbhcm_pair_valid\n" ++
+  "  jal ra, validate_header_pair\n" ++
+  "  bnez a0, .Lvbhcm_status_fail\n" ++
+  "  la t0, vbhcm_pair_valid; ld t1, 0(t0)\n" ++
+  "  beqz t1, .Lvbhcm_pred_false\n" ++
+  "  # Hash child and compare to claimed\n" ++
+  "  slli t1, s7, 3\n" ++
+  "  add t1, s1, t1\n" ++
+  "  ld t2, 0(t1)                # parent_len\n" ++
+  "  ld t3, 8(t1)                # child_len\n" ++
+  "  add t4, s6, t2              # child_ptr\n" ++
+  "  mv a0, t4; mv a1, t3\n" ++
+  "  la a2, vbhcm_hash_buf\n" ++
+  "  jal ra, block_hash_from_header\n" ++
+  "  la t0, vbhcm_hash_buf; mv t1, s8\n" ++
+  "  ld t2,  0(t0); ld t3,  0(t1); bne t2, t3, .Lvbhcm_pred_false\n" ++
+  "  ld t2,  8(t0); ld t3,  8(t1); bne t2, t3, .Lvbhcm_pred_false\n" ++
+  "  ld t2, 16(t0); ld t3, 16(t1); bne t2, t3, .Lvbhcm_pred_false\n" ++
+  "  ld t2, 24(t0); ld t3, 24(t1); bne t2, t3, .Lvbhcm_pred_false\n" ++
+  "  # Advance\n" ++
+  "  slli t1, s7, 3\n" ++
+  "  add t1, s1, t1\n" ++
+  "  ld t2, 0(t1)\n" ++
+  "  add s6, s6, t2\n" ++
+  "  addi s8, s8, 32\n" ++
+  "  addi s7, s7, 1\n" ++
+  "  j .Lvbhcm_loop\n" ++
+  ".Lvbhcm_pred_false:\n" ++
+  "  sd zero, 0(s4)\n" ++
+  "  sd s7, 0(s5)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lvbhcm_ret\n" ++
+  ".Lvbhcm_status_fail:\n" ++
+  "  sd zero, 0(s4)\n" ++
+  "  sd s7, 0(s5)\n" ++
+  "  j .Lvbhcm_ret\n" ++
+  ".Lvbhcm_done:\n" ++
+  "  li a0, 0\n" ++
+  ".Lvbhcm_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp); ld s7, 64(sp)\n" ++
+  "  ld s8, 72(sp); ld s9, 80(sp); ld s10, 88(sp)\n" ++
+  "  addi sp, sp, 96\n" ++
+  "  ret"
+
+/-- `zisk_validate_block_hash_chain_match`: probe BuildUnit.
+    Input layout:
+      bytes  0.. 8 : N
+      bytes  8..8+8N        : header_lengths
+      bytes  8+8N..8+8N+32N : claimed_hashes (32 B each)
+      bytes  8+40N..        : concatenated header RLPs
+    Output layout:
+      bytes  0.. 8 : status
+      bytes  8..16 : is_valid
+      bytes 16..24 : first_bad_index -/
+def ziskValidateBlockHashChainMatchPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a7, 0x40000000\n" ++
+  "  ld a0, 8(a7)                # N\n" ++
+  "  addi a1, a7, 16             # header_lengths ptr\n" ++
+  "  slli t0, a0, 3              # 8*N\n" ++
+  "  add a3, a1, t0              # claimed_hashes ptr\n" ++
+  "  slli t1, a0, 5              # 32*N\n" ++
+  "  add a2, a3, t1              # headers ptr\n" ++
+  "  li a4, 0xa0010008           # is_valid out\n" ++
+  "  li a5, 0xa0010010           # first_bad_index out\n" ++
+  "  jal ra, validate_block_hash_chain_match\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lvbhcm_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpFieldToU64Function ++ "\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  blockHashFromHeaderFunction ++ "\n" ++
+  validateParentHashLinkFunction ++ "\n" ++
+  checkGasLimitFunction ++ "\n" ++
+  validateHeaderPairFunction ++ "\n" ++
+  validateBlockHashChainMatchFunction ++ "\n" ++
+  ".Lvbhcm_pdone:"
+
+def ziskValidateBlockHashChainMatchDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  "rfu_offset:\n" ++
+  "  .zero 8\n" ++
+  "rfu_length:\n" ++
+  "  .zero 8\n" ++
+  "vphl_offset:\n" ++
+  "  .zero 8\n" ++
+  "vphl_length:\n" ++
+  "  .zero 8\n" ++
+  "vphl_claimed:\n" ++
+  "  .zero 32\n" ++
+  "vphl_computed:\n" ++
+  "  .zero 32\n" ++
+  "vhp_link_valid:\n" ++
+  "  .zero 8\n" ++
+  "vhp_parent_number:\n" ++
+  "  .zero 8\n" ++
+  "vhp_parent_timestamp:\n" ++
+  "  .zero 8\n" ++
+  "vhp_parent_gas_limit:\n" ++
+  "  .zero 8\n" ++
+  "vhp_child_number:\n" ++
+  "  .zero 8\n" ++
+  "vhp_child_timestamp:\n" ++
+  "  .zero 8\n" ++
+  "vhp_child_gas_limit:\n" ++
+  "  .zero 8\n" ++
+  "vbhcm_pair_valid:\n" ++
+  "  .zero 8\n" ++
+  "vbhcm_hash_buf:\n" ++
+  "  .zero 32"
+
+def ziskValidateBlockHashChainMatchProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskValidateBlockHashChainMatchPrologue
+  dataAsm     := ziskValidateBlockHashChainMatchDataSection
+}
+
 end EvmAsm.Codegen

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **217**
-- ziskemu round-trip scripts: **210** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **218**
+- ziskemu round-trip scripts: **211** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/README.md
+++ b/README.md
@@ -279,8 +279,9 @@ block-body helpers
 `block_validate_empty_block`,
 `validate_empty_block_with_parent`,
 `validate_empty_block_chain`,
-`block_hash_array_from_chain`, withdrawal RLP/hash, …),
-and address
+`block_hash_array_from_chain`,
+`validate_block_hash_chain_match`,
+withdrawal RLP/hash, …), and address
 derivation (`address_compute_create`, `address_compute_create2`,
 `address_from_pubkey`). The catalogue is tracked under the
 `PR-K*` series in [`PLAN.md`](PLAN.md).

--- a/scripts/codegen-zisk-validate-block-hash-chain-match-check.sh
+++ b/scripts/codegen-zisk-validate-block-hash-chain-match-check.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# codegen-zisk-validate-block-hash-chain-match-check.sh -- PR-K195.
+#
+# Validate chain + check computed block_hash matches a caller claim.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_validate_block_hash_chain_match ELF"
+lake exe codegen --program zisk_validate_block_hash_chain_match --halt linux93 \
+  -o gen-out/zisk_validate_block_hash_chain_match
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <spec_py> <break_claim_index_or_-1> <exp_status> <exp_valid> <exp_first_bad>
+run_case() {
+  local name="$1" spec="$2" break_idx="$3" exp_status="$4" exp_valid="$5" exp_bad="$6"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_validate_block_hash_chain_match_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_validate_block_hash_chain_match_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+try:
+    from Crypto.Hash import keccak
+    def keccak256(b):
+        h = keccak.new(digest_bits=256); h.update(b); return h.digest()
+except Exception:
+    import sha3
+    def keccak256(b): return sha3.keccak_256(b).digest()
+
+def u_be(n):
+    if n == 0: return b''
+    return n.to_bytes((n.bit_length() + 7) // 8, 'big')
+
+def make_header(parent_hash, num, ts, gl):
+    return rlp.encode([
+        parent_hash, b'\\xb2'*32, b'\\xb3'*20, b'\\xb4'*32, b'\\xb5'*32,
+        b'\\xb6'*32, b'\\x00'*256, b'', u_be(num), u_be(gl),
+        b'\\x82\\x02\\x00', u_be(ts), b'', b'\\xb7'*32, b'\\x00'*8,
+        b'\\x82\\x12\\x34',
+    ])
+
+spec = $spec
+break_idx = $break_idx
+
+headers = []
+hashes = []
+prev_hash = b'\\x00'*32
+for n, ts, gl in spec:
+    h = make_header(prev_hash, n, ts, gl)
+    headers.append(h)
+    hashes.append(keccak256(h))
+    prev_hash = keccak256(h)
+
+if break_idx >= 0:
+    hashes[break_idx] = bytes([b ^ 0xff for b in hashes[break_idx]])
+
+N = len(headers)
+lengths = b''.join(struct.pack('<Q', len(h)) for h in headers)
+claimed = b''.join(hashes)
+flat = b''.join(headers)
+
+with open(sys.argv[1], 'wb') as f:
+    record = struct.pack('<Q', N) + lengths + claimed + flat
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_validate_block_hash_chain_match.elf \
+    -i "$in_file" -o "$out_file" -n 20000000 \
+    >"$REPO_ROOT/gen-out/zisk_validate_block_hash_chain_match_${name}.emu.log" 2>&1 || true
+
+  local status_le; status_le="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local valid_le;  valid_le="$( dd if="$out_file" bs=1 skip=8  count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local bad_le;    bad_le="$(   dd if="$out_file" bs=1 skip=16 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local status valid bad
+  status="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$status_le'))[0])")"
+  valid="$( python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$valid_le'))[0])")"
+  bad="$(   python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$bad_le'))[0])")"
+
+  if [[ "$status" == "$exp_status" && "$valid" == "$exp_valid" && "$bad" == "$exp_bad" ]]; then
+    printf "  %-30s OK   status=%s valid=%s bad=%s\n" "$name" "$status" "$valid" "$bad"
+    return 0
+  else
+    printf "  %-30s FAIL status=%s/%s valid=%s/%s bad=%s/%s\n" \
+      "$name" "$status" "$exp_status" "$valid" "$exp_valid" "$bad" "$exp_bad"
+    return 1
+  fi
+}
+
+FAILED=0
+run_case "vacuous_empty" "[]" -1 0 1 0 || FAILED=1
+run_case "single_hash_match" "[(100,1000,30000000)]" -1 0 1 0 || FAILED=1
+run_case "single_hash_mismatch" "[(100,1000,30000000)]" 0 0 0 0 || FAILED=1
+run_case "three_chain_all_match" "[
+    (100,1000,30000000),
+    (101,1001,30000000),
+    (102,1002,30000000),
+]" -1 0 1 0 || FAILED=1
+# fail_hash_at_index_2: hash[2] is broken; failure caught during link i=1
+# (where we hash headers[2] and compare). bad_index reports the LINK index
+# at which we noticed the mismatch, not the broken-hash absolute index.
+run_case "fail_hash_at_index_2" "[
+    (100,1000,30000000),
+    (101,1001,30000000),
+    (102,1002,30000000),
+]" 2 0 0 1 || FAILED=1
+run_case "fail_chain_link_at_index_1" "[
+    (100,1000,30000000),
+    (101,1001,30000000),
+    (103,1002,30000000),
+]" -1 0 0 1 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: validate_block_hash_chain_match verifies both chain links and hash claims"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Validate an N-element header chain (K175 invariants) **and**
check that the block_hash of each header (K172) matches a
caller-supplied claim array. Returns `is_valid` +
`first_bad_index`.

Natural primitive for chain-anchor proofs:
> "the prover claims these are block_hashes B[0..N) for blocks
> H[0..N); verify both that the chain is well-formed and that
> the claimed hashes are correct."

## Semantics

- Block[0]'s hash is checked before the chain loop.
- For each link `i in [0, N-1)`, validate pair(`i`, `i+1`) and
  check the hash of the child header matches `claimed_hashes[i+1]`.
- On any failure, `first_bad_index` reports the LINK index at which
  the mismatch was discovered (not the absolute header index of the
  broken claim).

## Calling convention

`a0` N, `a1` header_lengths, `a2` headers, `a3` claimed_hashes (32*N),
`a4` is_valid, `a5` first_bad_index.

## Test plan

6 ziskemu fixtures:

- [x] `vacuous_empty` -- N=0 -> valid=1
- [x] `single_hash_match` -- N=1 correct -> valid=1
- [x] `single_hash_mismatch` -- N=1 wrong claim -> valid=0
- [x] `three_chain_all_match` -- N=3 all correct -> valid=1
- [x] `fail_hash_at_index_2` -- hash[2] broken; caught at link 1 -> bad=1
- [x] `fail_chain_link_at_index_1` -- broken chain link 1 -> bad=1

## Note

Branch name (`feat/stateless-mpt-three-leaf-root-indexed`) is a
hold-over from initial scoping (I planned an N=3 MPT root but
pivoted to this chain validator). The actual content is the chain
hash-match validator described above.

## Stack

Builds on #5997 (PR-K194 `block_validate_receipts_root_two_receipts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)