### PR TITLE
feat(stateless): chain_compute_total_gas_used (PR-K196)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -4873,6 +4873,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_validate_header_chain" => some ziskValidateHeaderChainProbeUnit
   | "zisk_block_hash_array_from_chain" => some ziskBlockHashArrayFromChainProbeUnit
   | "zisk_validate_block_hash_chain_match" => some ziskValidateBlockHashChainMatchProbeUnit
+  | "zisk_chain_compute_total_gas_used" => some ziskChainComputeTotalGasUsedProbeUnit
   | "zisk_block_validate_2tx_full" => some ziskBlockValidate2txFullProbeUnit
   | "zisk_block_body_extract_2tx" => some ziskBlockBodyExtract2txProbeUnit
   | "zisk_block_validate_2tx_full_with_body" => some ziskBlockValidate2txFullWithBodyProbeUnit
@@ -5082,6 +5083,7 @@ def knownProgramNames : List String :=
    "zisk_validate_header_chain",
    "zisk_block_hash_array_from_chain",
    "zisk_validate_block_hash_chain_match",
+   "zisk_chain_compute_total_gas_used",
    "zisk_block_validate_2tx_full",
    "zisk_block_body_extract_2tx",
    "zisk_block_validate_2tx_full_with_body",

--- a/EvmAsm/Codegen/Programs/Header.lean
+++ b/EvmAsm/Codegen/Programs/Header.lean
@@ -2838,4 +2838,126 @@ def ziskValidateBlockHashChainMatchProbeUnit : BuildUnit := {
   dataAsm     := ziskValidateBlockHashChainMatchDataSection
 }
 
+/-! ## chain_compute_total_gas_used -- PR-K196
+
+    Aggregate `gas_used` (header field 10) across an N-element
+    header chain into a single u64 sum. Useful for chain-state
+    commitments and protocol-level invariants such as
+    \"this chain segment burned at most G gas total\".
+
+    No chain validation is performed here -- the caller is
+    responsible for combining this with K175 (or K195) for
+    chain integrity. K196 is purely an aggregator over the
+    headers; the inputs and accumulator math are kept in plain
+    u64, so the sum saturates / wraps modulo 2^64 like any
+    RISC-V add.
+
+    For real mainnet blocks, gas_used <= ~30M and N <= ~256 in
+    a single witness; the sum stays well below 2^64.
+
+    Calling convention:
+      a0 (input)  : N (header count)
+      a1 (input)  : header_lengths ptr (u64[N])
+      a2 (input)  : headers ptr (concatenated)
+      a3 (input)  : u64 out (total_gas_used; running sum)
+      ra (input)  : return
+      a0 (output) :
+        0 : success
+        1 : RLP parse error on some header (sum is partial,
+            up to the failing header)
+        2 : a header's gas_used field exceeds 8 bytes BE -/
+def chainComputeTotalGasUsedFunction : String :=
+  "chain_compute_total_gas_used:\n" ++
+  "  addi sp, sp, -48\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp); sd s4, 40(sp)\n" ++
+  "  mv s0, a0                   # N\n" ++
+  "  mv s1, a1                   # header_lengths ptr\n" ++
+  "  mv s2, a2                   # headers ptr\n" ++
+  "  mv s3, a3                   # out ptr\n" ++
+  "  sd zero, 0(s3)\n" ++
+  "  li s4, 0                    # i = 0\n" ++
+  "  beqz s0, .Lccgu_done\n" ++
+  ".Lccgu_loop:\n" ++
+  "  beq s4, s0, .Lccgu_done\n" ++
+  "  slli t0, s4, 3\n" ++
+  "  add t0, s1, t0\n" ++
+  "  ld a1, 0(t0)                # header_len\n" ++
+  "  mv a0, s2                   # header_ptr\n" ++
+  "  li a2, 10                   # field 10 = gas_used\n" ++
+  "  la a3, ccgu_field\n" ++
+  "  jal ra, rlp_field_to_u64\n" ++
+  "  li t0, 1\n" ++
+  "  beq a0, t0, .Lccgu_parse_fail\n" ++
+  "  li t0, 2\n" ++
+  "  beq a0, t0, .Lccgu_size_fail\n" ++
+  "  # Accumulate\n" ++
+  "  la t0, ccgu_field; ld t1, 0(t0)\n" ++
+  "  ld t2, 0(s3)\n" ++
+  "  add t2, t2, t1\n" ++
+  "  sd t2, 0(s3)\n" ++
+  "  # Advance to next header\n" ++
+  "  slli t0, s4, 3\n" ++
+  "  add t0, s1, t0\n" ++
+  "  ld t1, 0(t0)\n" ++
+  "  add s2, s2, t1\n" ++
+  "  addi s4, s4, 1\n" ++
+  "  j .Lccgu_loop\n" ++
+  ".Lccgu_done:\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lccgu_ret\n" ++
+  ".Lccgu_parse_fail:\n" ++
+  "  li a0, 1\n" ++
+  "  j .Lccgu_ret\n" ++
+  ".Lccgu_size_fail:\n" ++
+  "  li a0, 2\n" ++
+  ".Lccgu_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp); ld s4, 40(sp)\n" ++
+  "  addi sp, sp, 48\n" ++
+  "  ret"
+
+/-- `zisk_chain_compute_total_gas_used`: probe BuildUnit.
+    Input layout:
+      bytes  0.. 8 : N
+      bytes  8..8+8N : header_lengths
+      bytes  8+8N.. : concatenated header RLPs
+    Output layout:
+      bytes  0.. 8 : status
+      bytes  8..16 : total_gas_used -/
+def ziskChainComputeTotalGasUsedPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a7, 0x40000000\n" ++
+  "  ld a0, 8(a7)                # N\n" ++
+  "  addi a1, a7, 16             # header_lengths ptr\n" ++
+  "  slli t0, a0, 3              # 8*N\n" ++
+  "  add a2, a1, t0              # headers ptr\n" ++
+  "  li a3, 0xa0010008           # total_gas_used out\n" ++
+  "  jal ra, chain_compute_total_gas_used\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lccgu_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpFieldToU64Function ++ "\n" ++
+  chainComputeTotalGasUsedFunction ++ "\n" ++
+  ".Lccgu_pdone:"
+
+def ziskChainComputeTotalGasUsedDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  "rfu_offset:\n" ++
+  "  .zero 8\n" ++
+  "rfu_length:\n" ++
+  "  .zero 8\n" ++
+  "ccgu_field:\n" ++
+  "  .zero 8"
+
+def ziskChainComputeTotalGasUsedProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskChainComputeTotalGasUsedPrologue
+  dataAsm     := ziskChainComputeTotalGasUsedDataSection
+}
+
 end EvmAsm.Codegen

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **218**
-- ziskemu round-trip scripts: **211** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **219**
+- ziskemu round-trip scripts: **212** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ block-body helpers
 `validate_empty_block_chain`,
 `block_hash_array_from_chain`,
 `validate_block_hash_chain_match`,
+`chain_compute_total_gas_used`,
 withdrawal RLP/hash, …), and address
 derivation (`address_compute_create`, `address_compute_create2`,
 `address_from_pubkey`). The catalogue is tracked under the

--- a/scripts/codegen-zisk-chain-compute-total-gas-used-check.sh
+++ b/scripts/codegen-zisk-chain-compute-total-gas-used-check.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# codegen-zisk-chain-compute-total-gas-used-check.sh -- PR-K196.
+#
+# Sum header.gas_used across an N-header chain.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_chain_compute_total_gas_used ELF"
+lake exe codegen --program zisk_chain_compute_total_gas_used --halt linux93 \
+  -o gen-out/zisk_chain_compute_total_gas_used
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <gas_used_list_py> <exp_status> <exp_sum>
+run_case() {
+  local name="$1" gus="$2" exp_status="$3" exp_sum="$4"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_chain_compute_total_gas_used_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_chain_compute_total_gas_used_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+
+def u_be(n):
+    if n == 0: return b''
+    return n.to_bytes((n.bit_length() + 7) // 8, 'big')
+
+def make_header(gas_used):
+    return rlp.encode([
+        b'\\xa1'*32, b'\\xa2'*32, b'\\xa3'*20, b'\\xa4'*32, b'\\xa5'*32,
+        b'\\xa6'*32, b'\\x00'*256, b'', b'\\x01', b'\\x83\\xff\\xff\\xff',
+        u_be(gas_used), b'\\x83\\x01\\x02\\x03', b'', b'\\xa7'*32, b'\\x00'*8,
+    ])
+
+gus = $gus  # list of gas_used per header
+headers = [make_header(g) for g in gus]
+N = len(headers)
+lengths = b''.join(struct.pack('<Q', len(h)) for h in headers)
+flat = b''.join(headers)
+
+with open(sys.argv[1], 'wb') as f:
+    record = struct.pack('<Q', N) + lengths + flat
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_chain_compute_total_gas_used.elf \
+    -i "$in_file" -o "$out_file" -n 5000000 \
+    >"$REPO_ROOT/gen-out/zisk_chain_compute_total_gas_used_${name}.emu.log" 2>&1 || true
+
+  local status_le; status_le="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local sum_le;    sum_le="$(   dd if="$out_file" bs=1 skip=8 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local status sum
+  status="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$status_le'))[0])")"
+  sum="$(   python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$sum_le'))[0])")"
+
+  if [[ "$status" == "$exp_status" && "$sum" == "$exp_sum" ]]; then
+    printf "  %-28s OK   status=%s sum=%s\n" "$name" "$status" "$sum"
+    return 0
+  else
+    printf "  %-28s FAIL status=%s/%s sum=%s/%s\n" \
+      "$name" "$status" "$exp_status" "$sum" "$exp_sum"
+    return 1
+  fi
+}
+
+FAILED=0
+run_case "empty_chain"      "[]"                  0 0       || FAILED=1
+run_case "single_block"     "[21000]"             0 21000   || FAILED=1
+run_case "three_blocks"     "[21000, 50000, 30000]" 0 101000 || FAILED=1
+run_case "five_blocks_big"  "[1000000, 2000000, 3000000, 4000000, 5000000]" 0 15000000 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: chain_compute_total_gas_used aggregates header.gas_used correctly"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Aggregate `gas_used` (header field 10) across an N-element header
chain into a single u64 sum. Useful for chain-state commitments
and protocol-level invariants like "this chain segment burned at
most G gas total".

No chain validation is performed here -- pure aggregator. Callers
are responsible for combining with K175 (or K195) for chain
integrity. The accumulator math is plain u64 (saturates / wraps
mod 2^64); mainnet blocks have `gas_used <= ~30M`, so even N=256
stays well below 2^64.

## Status codes

- `0` success
- `1` RLP parse error on some header
- `2` a header's gas_used field exceeds 8 bytes BE

## Test plan

4 ziskemu fixtures:

- [x] `empty_chain` -- N=0 -> sum=0
- [x] `single_block` -- gas_used=21000 -> sum=21000
- [x] `three_blocks` -- [21000, 50000, 30000] -> sum=101000
- [x] `five_blocks_big` -- [1M..5M] -> sum=15M

## Stack

Builds on #5998 (PR-K195 `validate_block_hash_chain_match`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)