### PR TITLE
feat(stateless): chain_extract_number_range (PR-K197)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -4874,6 +4874,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_block_hash_array_from_chain" => some ziskBlockHashArrayFromChainProbeUnit
   | "zisk_validate_block_hash_chain_match" => some ziskValidateBlockHashChainMatchProbeUnit
   | "zisk_chain_compute_total_gas_used" => some ziskChainComputeTotalGasUsedProbeUnit
+  | "zisk_chain_extract_number_range" => some ziskChainExtractNumberRangeProbeUnit
   | "zisk_block_validate_2tx_full" => some ziskBlockValidate2txFullProbeUnit
   | "zisk_block_body_extract_2tx" => some ziskBlockBodyExtract2txProbeUnit
   | "zisk_block_validate_2tx_full_with_body" => some ziskBlockValidate2txFullWithBodyProbeUnit
@@ -5084,6 +5085,7 @@ def knownProgramNames : List String :=
    "zisk_block_hash_array_from_chain",
    "zisk_validate_block_hash_chain_match",
    "zisk_chain_compute_total_gas_used",
+   "zisk_chain_extract_number_range",
    "zisk_block_validate_2tx_full",
    "zisk_block_body_extract_2tx",
    "zisk_block_validate_2tx_full_with_body",

--- a/EvmAsm/Codegen/Programs/Header.lean
+++ b/EvmAsm/Codegen/Programs/Header.lean
@@ -2960,4 +2960,118 @@ def ziskChainComputeTotalGasUsedProbeUnit : BuildUnit := {
   dataAsm     := ziskChainComputeTotalGasUsedDataSection
 }
 
+/-! ## chain_extract_number_range -- PR-K197
+
+    Extract `(min_number, max_number)` from an N-element header
+    chain. With K175 validated parent-hash invariants, the chain
+    has strictly increasing numbers, so this is simply
+    `(headers[0].number, headers[N-1].number)`. We return both
+    edges so callers can verify `max - min + 1 == N` (the chain
+    is dense) or directly use the range as a chain-segment
+    identifier.
+
+    Calling convention:
+      a0 (input)  : N (header count, must be >= 1)
+      a1 (input)  : header_lengths ptr
+      a2 (input)  : headers ptr
+      a3 (input)  : u64 out (min_number)
+      a4 (input)  : u64 out (max_number)
+      ra (input)  : return
+      a0 (output) :
+        0 : success
+        1 : empty chain (N == 0)
+        2 : RLP parse failure on some header
+        3 : a header's number field exceeds 8 bytes BE -/
+def chainExtractNumberRangeFunction : String :=
+  "chain_extract_number_range:\n" ++
+  "  addi sp, sp, -48\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp); sd s4, 40(sp)\n" ++
+  "  mv s0, a0                   # N\n" ++
+  "  mv s1, a1                   # header_lengths\n" ++
+  "  mv s2, a2                   # headers\n" ++
+  "  mv s3, a3                   # min out\n" ++
+  "  mv s4, a4                   # max out\n" ++
+  "  beqz s0, .Lcenr_empty\n" ++
+  "  # min = headers[0].number\n" ++
+  "  ld a1, 0(s1)\n" ++
+  "  mv a0, s2\n" ++
+  "  li a2, 8                    # field 8 = number\n" ++
+  "  mv a3, s3\n" ++
+  "  jal ra, rlp_field_to_u64\n" ++
+  "  bnez a0, .Lcenr_propagate\n" ++
+  "  # Advance to last header: skip the first (N-1) headers\n" ++
+  "  mv t1, s2\n" ++
+  "  mv t2, s1\n" ++
+  "  addi t3, s0, -1             # iterations = N-1\n" ++
+  ".Lcenr_skip:\n" ++
+  "  beqz t3, .Lcenr_at_last\n" ++
+  "  ld t4, 0(t2)\n" ++
+  "  add t1, t1, t4\n" ++
+  "  addi t2, t2, 8\n" ++
+  "  addi t3, t3, -1\n" ++
+  "  j .Lcenr_skip\n" ++
+  ".Lcenr_at_last:\n" ++
+  "  ld a1, 0(t2)                # length of last header\n" ++
+  "  mv a0, t1\n" ++
+  "  li a2, 8\n" ++
+  "  mv a3, s4\n" ++
+  "  jal ra, rlp_field_to_u64\n" ++
+  "  bnez a0, .Lcenr_propagate\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lcenr_ret\n" ++
+  ".Lcenr_empty:\n" ++
+  "  li a0, 1\n" ++
+  "  j .Lcenr_ret\n" ++
+  ".Lcenr_propagate:\n" ++
+  "  addi a0, a0, 1              # remap rlp_field_to_u64 1/2 -> 2/3\n" ++
+  ".Lcenr_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp); ld s4, 40(sp)\n" ++
+  "  addi sp, sp, 48\n" ++
+  "  ret"
+
+/-- `zisk_chain_extract_number_range`: probe BuildUnit.
+    Input layout:
+      bytes  0.. 8 : N
+      bytes  8..8+8N : header_lengths
+      bytes  8+8N.. : concatenated headers
+    Output layout:
+      bytes  0.. 8 : status
+      bytes  8..16 : min_number
+      bytes 16..24 : max_number -/
+def ziskChainExtractNumberRangePrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a7, 0x40000000\n" ++
+  "  ld a0, 8(a7)                # N\n" ++
+  "  addi a1, a7, 16             # header_lengths\n" ++
+  "  slli t0, a0, 3\n" ++
+  "  add a2, a1, t0              # headers\n" ++
+  "  li a3, 0xa0010008           # min out\n" ++
+  "  li a4, 0xa0010010           # max out\n" ++
+  "  jal ra, chain_extract_number_range\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lcenr_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpFieldToU64Function ++ "\n" ++
+  chainExtractNumberRangeFunction ++ "\n" ++
+  ".Lcenr_pdone:"
+
+def ziskChainExtractNumberRangeDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  "rfu_offset:\n" ++
+  "  .zero 8\n" ++
+  "rfu_length:\n" ++
+  "  .zero 8"
+
+def ziskChainExtractNumberRangeProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskChainExtractNumberRangePrologue
+  dataAsm     := ziskChainExtractNumberRangeDataSection
+}
+
 end EvmAsm.Codegen

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **219**
-- ziskemu round-trip scripts: **212** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **220**
+- ziskemu round-trip scripts: **213** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ block-body helpers
 `block_hash_array_from_chain`,
 `validate_block_hash_chain_match`,
 `chain_compute_total_gas_used`,
+`chain_extract_number_range`,
 withdrawal RLP/hash, …), and address
 derivation (`address_compute_create`, `address_compute_create2`,
 `address_from_pubkey`). The catalogue is tracked under the

--- a/scripts/codegen-zisk-chain-extract-number-range-check.sh
+++ b/scripts/codegen-zisk-chain-extract-number-range-check.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# codegen-zisk-chain-extract-number-range-check.sh -- PR-K197.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_chain_extract_number_range ELF"
+lake exe codegen --program zisk_chain_extract_number_range --halt linux93 \
+  -o gen-out/zisk_chain_extract_number_range
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <numbers_list_py> <exp_status> <exp_min> <exp_max>
+run_case() {
+  local name="$1" nums="$2" exp_status="$3" exp_min="$4" exp_max="$5"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_chain_extract_number_range_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_chain_extract_number_range_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+
+def u_be(n):
+    if n == 0: return b''
+    return n.to_bytes((n.bit_length() + 7) // 8, 'big')
+
+def make_header(num):
+    return rlp.encode([
+        b'\\xa1'*32, b'\\xa2'*32, b'\\xa3'*20, b'\\xa4'*32, b'\\xa5'*32,
+        b'\\xa6'*32, b'\\x00'*256, b'', u_be(num), b'\\x83\\xff\\xff\\xff',
+        b'\\x82\\x02\\x00', b'\\x83\\x01\\x02\\x03', b'', b'\\xa7'*32, b'\\x00'*8,
+    ])
+
+nums = $nums
+headers = [make_header(n) for n in nums]
+N = len(headers)
+lengths = b''.join(struct.pack('<Q', len(h)) for h in headers)
+flat = b''.join(headers)
+
+with open(sys.argv[1], 'wb') as f:
+    record = struct.pack('<Q', N) + lengths + flat
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_chain_extract_number_range.elf \
+    -i "$in_file" -o "$out_file" -n 5000000 \
+    >"$REPO_ROOT/gen-out/zisk_chain_extract_number_range_${name}.emu.log" 2>&1 || true
+
+  local status_le; status_le="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local min_le;    min_le="$(   dd if="$out_file" bs=1 skip=8  count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local max_le;    max_le="$(   dd if="$out_file" bs=1 skip=16 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local status min max
+  status="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$status_le'))[0])")"
+  min="$(   python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$min_le'))[0])")"
+  max="$(   python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$max_le'))[0])")"
+
+  if [[ "$status" == "$exp_status" && "$min" == "$exp_min" && "$max" == "$exp_max" ]]; then
+    printf "  %-26s OK   status=%s min=%s max=%s\n" "$name" "$status" "$min" "$max"
+    return 0
+  else
+    printf "  %-26s FAIL status=%s/%s min=%s/%s max=%s/%s\n" \
+      "$name" "$status" "$exp_status" "$min" "$exp_min" "$max" "$exp_max"
+    return 1
+  fi
+}
+
+FAILED=0
+run_case "single"        "[42]"                      0 42 42 || FAILED=1
+run_case "three_dense"   "[100, 101, 102]"           0 100 102 || FAILED=1
+run_case "five_sparse"   "[1000, 2000, 3000, 4000, 5000]" 0 1000 5000 || FAILED=1
+run_case "empty"         "[]"                        1 0 0 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: chain_extract_number_range returns the right (min, max)"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Extract `(min_number, max_number)` from an N-element header chain.
With K175-validated parent-hash invariants the chain has strictly
increasing numbers, so this is simply `(headers[0].number,
headers[N-1].number)`. Returning both edges lets callers verify
`max - min + 1 == N` (the chain is dense) or directly use the
range as a chain-segment identifier.

## Status codes

- `0` success
- `1` empty chain (N == 0)
- `2` RLP parse failure on some header
- `3` number field exceeds 8 bytes BE

## Test plan

4 ziskemu fixtures:

- [x] `single` -- N=1 -> min=max=42
- [x] `three_dense` -- 100, 101, 102 -> 100, 102
- [x] `five_sparse` -- 1000, 2000, 3000, 4000, 5000 -> 1000, 5000
- [x] `empty` -- N=0 -> status=1

## Stack

Builds on #6000 (PR-K196 `chain_compute_total_gas_used`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)