### PR TITLE
feat(stateless): header_extract_basefee (PR-K198)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -4875,6 +4875,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_validate_block_hash_chain_match" => some ziskValidateBlockHashChainMatchProbeUnit
   | "zisk_chain_compute_total_gas_used" => some ziskChainComputeTotalGasUsedProbeUnit
   | "zisk_chain_extract_number_range" => some ziskChainExtractNumberRangeProbeUnit
+  | "zisk_header_extract_basefee" => some ziskHeaderExtractBasefeeProbeUnit
   | "zisk_block_validate_2tx_full" => some ziskBlockValidate2txFullProbeUnit
   | "zisk_block_body_extract_2tx" => some ziskBlockBodyExtract2txProbeUnit
   | "zisk_block_validate_2tx_full_with_body" => some ziskBlockValidate2txFullWithBodyProbeUnit
@@ -5086,6 +5087,7 @@ def knownProgramNames : List String :=
    "zisk_validate_block_hash_chain_match",
    "zisk_chain_compute_total_gas_used",
    "zisk_chain_extract_number_range",
+   "zisk_header_extract_basefee",
    "zisk_block_validate_2tx_full",
    "zisk_block_body_extract_2tx",
    "zisk_block_validate_2tx_full_with_body",

--- a/EvmAsm/Codegen/Programs/Header.lean
+++ b/EvmAsm/Codegen/Programs/Header.lean
@@ -3074,4 +3074,76 @@ def ziskChainExtractNumberRangeProbeUnit : BuildUnit := {
   dataAsm     := ziskChainExtractNumberRangeDataSection
 }
 
+/-! ## header_extract_basefee -- PR-K198
+
+    Extract `base_fee_per_gas` (field 15, present from London
+    onwards) from a header RLP. Returns the value as a u64; the
+    EIP-1559 base_fee is bounded by `2^256-1` in principle but
+    in practice never exceeds u64 in any chain we care about.
+    Callers that need the full uint256 form should use the more
+    general `rlp_field_to_u256` (not yet implemented) instead.
+
+    Field index 15 is the **first** post-London field; on
+    pre-London headers (`len(fields) <= 15`) the call yields
+    a parse-failure status.
+
+    Calling convention:
+      a0 (input)  : header_rlp ptr
+      a1 (input)  : header_rlp byte length
+      a2 (input)  : u64 out (base_fee_per_gas)
+      ra (input)  : return
+      a0 (output) :
+        0 : success
+        1 : RLP parse failure / field 15 missing (pre-London)
+        2 : base_fee field exceeds 8 bytes BE -/
+def headerExtractBasefeeFunction : String :=
+  "header_extract_basefee:\n" ++
+  "  addi sp, sp, -16\n" ++
+  "  sd ra, 0(sp)\n" ++
+  "  # rlp_field_to_u64(a0=header_ptr, a1=len, a2=15, a3=output_ptr)\n" ++
+  "  mv a3, a2                   # output ptr (caller-supplied) -> a3\n" ++
+  "  li a2, 15                   # field index = 15 (base_fee)\n" ++
+  "  jal ra, rlp_field_to_u64\n" ++
+  "  ld ra, 0(sp)\n" ++
+  "  addi sp, sp, 16\n" ++
+  "  ret"
+
+/-- `zisk_header_extract_basefee`: probe BuildUnit.
+    Input layout:
+      bytes 0..8  : header_rlp_len
+      bytes 8..   : header_rlp
+    Output layout:
+      bytes 0..8  : status
+      bytes 8..16 : base_fee_per_gas -/
+def ziskHeaderExtractBasefeePrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a7, 0x40000000\n" ++
+  "  ld a1, 8(a7)                # header_rlp_len\n" ++
+  "  addi a0, a7, 16             # header_rlp ptr\n" ++
+  "  li a2, 0xa0010008           # base_fee out\n" ++
+  "  jal ra, header_extract_basefee\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lheb_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpFieldToU64Function ++ "\n" ++
+  headerExtractBasefeeFunction ++ "\n" ++
+  ".Lheb_pdone:"
+
+def ziskHeaderExtractBasefeeDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  "rfu_offset:\n" ++
+  "  .zero 8\n" ++
+  "rfu_length:\n" ++
+  "  .zero 8"
+
+def ziskHeaderExtractBasefeeProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskHeaderExtractBasefeePrologue
+  dataAsm     := ziskHeaderExtractBasefeeDataSection
+}
+
 end EvmAsm.Codegen

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **220**
-- ziskemu round-trip scripts: **213** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **221**
+- ziskemu round-trip scripts: **214** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ block-body helpers
 `validate_block_hash_chain_match`,
 `chain_compute_total_gas_used`,
 `chain_extract_number_range`,
+`header_extract_basefee`,
 withdrawal RLP/hash, …), and address
 derivation (`address_compute_create`, `address_compute_create2`,
 `address_from_pubkey`). The catalogue is tracked under the

--- a/scripts/codegen-zisk-header-extract-basefee-check.sh
+++ b/scripts/codegen-zisk-header-extract-basefee-check.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# codegen-zisk-header-extract-basefee-check.sh -- PR-K198.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_header_extract_basefee ELF"
+lake exe codegen --program zisk_header_extract_basefee --halt linux93 \
+  -o gen-out/zisk_header_extract_basefee
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <basefee_int_or_-1> <pre_london 0/1> <exp_status> <exp_basefee>
+run_case() {
+  local name="$1" bf="$2" pre_london="$3" exp_status="$4" exp_basefee="$5"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_header_extract_basefee_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_header_extract_basefee_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+
+def u_be(n):
+    if n == 0: return b''
+    return n.to_bytes((n.bit_length() + 7) // 8, 'big')
+
+bf = $bf
+pre_london = $pre_london == 1
+
+# Pre-London = 15 fields, no base_fee. London+ = 16 fields with base_fee.
+base_fields = [
+    b'\\xa1'*32, b'\\xa2'*32, b'\\xa3'*20, b'\\xa4'*32, b'\\xa5'*32,
+    b'\\xa6'*32, b'\\x00'*256, b'', b'\\x01', b'\\x83\\xff\\xff\\xff',
+    b'', b'\\x83\\x01\\x02\\x03', b'', b'\\xa7'*32, b'\\x00'*8,
+]
+if pre_london:
+    header_rlp = rlp.encode(base_fields)
+else:
+    header_rlp = rlp.encode(base_fields + [u_be(bf)])
+
+with open(sys.argv[1], 'wb') as f:
+    record = struct.pack('<Q', len(header_rlp)) + header_rlp
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_header_extract_basefee.elf \
+    -i "$in_file" -o "$out_file" -n 1000000 \
+    >"$REPO_ROOT/gen-out/zisk_header_extract_basefee_${name}.emu.log" 2>&1 || true
+
+  local status_le; status_le="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local bf_le;     bf_le="$(   dd if="$out_file" bs=1 skip=8 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local status basefee
+  status="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$status_le'))[0])")"
+  basefee="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$bf_le'))[0])")"
+
+  if [[ "$status" == "$exp_status" && "$basefee" == "$exp_basefee" ]]; then
+    printf "  %-26s OK   status=%s base_fee=%s\n" "$name" "$status" "$basefee"
+    return 0
+  else
+    printf "  %-26s FAIL status=%s/%s base_fee=%s/%s\n" \
+      "$name" "$status" "$exp_status" "$basefee" "$exp_basefee"
+    return 1
+  fi
+}
+
+FAILED=0
+run_case "london_30_gwei"   "$((30 * 10**9))"  0 0 30000000000 || FAILED=1
+run_case "london_zero"      "0"                 0 0 0           || FAILED=1
+run_case "london_1234"      "1234"              0 0 1234        || FAILED=1
+run_case "pre_london"       "-1"                1 1 0           || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: header_extract_basefee returns the right field 15 value"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Extract `base_fee_per_gas` (field 15, present from London onwards)
from a header RLP. Returns the value as a u64.

## Status codes

- `0` success
- `1` RLP parse failure / field 15 missing (pre-London)
- `2` base_fee field exceeds 8 bytes BE

## Test plan

4 ziskemu fixtures:

- [x] `london_30_gwei` -- 30e9 -> 30000000000
- [x] `london_zero` -- 0 -> 0
- [x] `london_1234` -- 1234 -> 1234
- [x] `pre_london` -- 15-field header -> status=1

## Stack

Builds on #6001 (PR-K197 `chain_extract_number_range`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)