### PR TITLE
feat(stateless): chain_extract_basefee_range (PR-K199)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -4876,6 +4876,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_chain_compute_total_gas_used" => some ziskChainComputeTotalGasUsedProbeUnit
   | "zisk_chain_extract_number_range" => some ziskChainExtractNumberRangeProbeUnit
   | "zisk_header_extract_basefee" => some ziskHeaderExtractBasefeeProbeUnit
+  | "zisk_chain_extract_basefee_range" => some ziskChainExtractBasefeeRangeProbeUnit
   | "zisk_block_validate_2tx_full" => some ziskBlockValidate2txFullProbeUnit
   | "zisk_block_body_extract_2tx" => some ziskBlockBodyExtract2txProbeUnit
   | "zisk_block_validate_2tx_full_with_body" => some ziskBlockValidate2txFullWithBodyProbeUnit
@@ -5088,6 +5089,7 @@ def knownProgramNames : List String :=
    "zisk_chain_compute_total_gas_used",
    "zisk_chain_extract_number_range",
    "zisk_header_extract_basefee",
+   "zisk_chain_extract_basefee_range",
    "zisk_block_validate_2tx_full",
    "zisk_block_body_extract_2tx",
    "zisk_block_validate_2tx_full_with_body",

--- a/EvmAsm/Codegen/Programs/Header.lean
+++ b/EvmAsm/Codegen/Programs/Header.lean
@@ -3146,4 +3146,153 @@ def ziskHeaderExtractBasefeeProbeUnit : BuildUnit := {
   dataAsm     := ziskHeaderExtractBasefeeDataSection
 }
 
+/-! ## chain_extract_basefee_range -- PR-K199
+
+    Walk an N-element header chain and compute `(min, max)` of
+    `base_fee_per_gas` (field 15). London+ only. Useful for
+    chain-level base_fee bounds analysis.
+
+    Returns vacuous `(0, 0)` on N == 0.
+
+    Calling convention:
+      a0 (input)  : N (header count)
+      a1 (input)  : header_lengths ptr
+      a2 (input)  : headers ptr
+      a3 (input)  : u64 out (min)
+      a4 (input)  : u64 out (max)
+      ra (input)  : return
+      a0 (output) :
+        0 : success
+        1 : a header parse failure (e.g., pre-London header)
+        2 : a base_fee field exceeds 8 bytes BE -/
+def chainExtractBasefeeRangeFunction : String :=
+  "chain_extract_basefee_range:\n" ++
+  "  addi sp, sp, -48\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp); sd s4, 40(sp)\n" ++
+  "  mv s0, a0                   # N\n" ++
+  "  mv s1, a1                   # header_lengths\n" ++
+  "  mv s2, a2                   # headers\n" ++
+  "  mv s3, a3                   # min out\n" ++
+  "  mv s4, a4                   # max out\n" ++
+  "  sd zero, 0(s3)\n" ++
+  "  sd zero, 0(s4)\n" ++
+  "  beqz s0, .Lcebr_done\n" ++
+  "  # Initialize min/max with headers[0].basefee\n" ++
+  "  ld a1, 0(s1)\n" ++
+  "  mv a0, s2\n" ++
+  "  mv a2, s3\n" ++
+  "  jal ra, header_extract_basefee\n" ++
+  "  bnez a0, .Lcebr_ret\n" ++
+  "  ld t0, 0(s3)\n" ++
+  "  sd t0, 0(s4)                # max = min = first value\n" ++
+  "  # Walk remaining headers\n" ++
+  "  ld t1, 0(s1)\n" ++
+  "  add t2, s2, t1              # next header ptr\n" ++
+  "  addi t3, s1, 8              # next length ptr\n" ++
+  "  li t4, 1                    # i\n" ++
+  ".Lcebr_loop:\n" ++
+  "  beq t4, s0, .Lcebr_done\n" ++
+  "  ld a1, 0(t3)\n" ++
+  "  mv a0, t2\n" ++
+  "  la a2, cebr_cur\n" ++
+  "  # Stash t2/t3/t4 in s-regs since rlp_field_to_u64 will\n" ++
+  "  # save/restore s0..s4 around it; pin them here.\n" ++
+  "  # Actually simpler: keep t2/t3/t4 across the call by\n" ++
+  "  # using callee-saved regs. We'll re-derive them after.\n" ++
+  "  jal ra, header_extract_basefee\n" ++
+  "  bnez a0, .Lcebr_ret\n" ++
+  "  # cur < min -> update min; cur > max -> update max\n" ++
+  "  la t0, cebr_cur; ld t1, 0(t0)\n" ++
+  "  ld t5, 0(s3)\n" ++
+  "  bgeu t1, t5, .Lcebr_skip_min\n" ++
+  "  sd t1, 0(s3)\n" ++
+  ".Lcebr_skip_min:\n" ++
+  "  ld t5, 0(s4)\n" ++
+  "  bleu t1, t5, .Lcebr_skip_max\n" ++
+  "  sd t1, 0(s4)\n" ++
+  ".Lcebr_skip_max:\n" ++
+  "  # Re-derive iteration state. Since we don't have callee-\n" ++
+  "  # saved scratch left (s0..s4 all used), maintain t-regs\n" ++
+  "  # before the call by stashing on .data.\n" ++
+  "  la t0, cebr_i; ld t4, 0(t0)\n" ++
+  "  la t0, cebr_hdr_ptr; ld t2, 0(t0)\n" ++
+  "  la t0, cebr_len_ptr; ld t3, 0(t0)\n" ++
+  "  ld t1, 0(t3)\n" ++
+  "  add t2, t2, t1\n" ++
+  "  addi t3, t3, 8\n" ++
+  "  addi t4, t4, 1\n" ++
+  "  la t0, cebr_i;        sd t4, 0(t0)\n" ++
+  "  la t0, cebr_hdr_ptr;  sd t2, 0(t0)\n" ++
+  "  la t0, cebr_len_ptr;  sd t3, 0(t0)\n" ++
+  "  j .Lcebr_loop\n" ++
+  ".Lcebr_done:\n" ++
+  "  li a0, 0\n" ++
+  ".Lcebr_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp); ld s4, 40(sp)\n" ++
+  "  addi sp, sp, 48\n" ++
+  "  ret"
+
+/-- `zisk_chain_extract_basefee_range`: probe BuildUnit.
+    Input layout:
+      bytes  0.. 8 : N
+      bytes  8..8+8N : header_lengths
+      bytes  8+8N.. : concatenated headers
+    Output layout:
+      bytes  0.. 8 : status
+      bytes  8..16 : min_basefee
+      bytes 16..24 : max_basefee -/
+def ziskChainExtractBasefeeRangePrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a7, 0x40000000\n" ++
+  "  ld a0, 8(a7)                # N\n" ++
+  "  addi a1, a7, 16\n" ++
+  "  slli t0, a0, 3\n" ++
+  "  add a2, a1, t0\n" ++
+  "  # Pre-init iteration scratch only when N > 0.\n" ++
+  "  beqz a0, .Lcebr_skip_init\n" ++
+  "  ld t1, 0(a1)                # first header_len\n" ++
+  "  add t2, a2, t1              # second header ptr\n" ++
+  "  addi t3, a1, 8\n" ++
+  "  la t0, cebr_hdr_ptr; sd t2, 0(t0)\n" ++
+  "  la t0, cebr_len_ptr; sd t3, 0(t0)\n" ++
+  "  la t0, cebr_i; li t4, 1; sd t4, 0(t0)\n" ++
+  ".Lcebr_skip_init:\n" ++
+  "  li a3, 0xa0010008\n" ++
+  "  li a4, 0xa0010010\n" ++
+  "  jal ra, chain_extract_basefee_range\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lcebr_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpFieldToU64Function ++ "\n" ++
+  headerExtractBasefeeFunction ++ "\n" ++
+  chainExtractBasefeeRangeFunction ++ "\n" ++
+  ".Lcebr_pdone:"
+
+def ziskChainExtractBasefeeRangeDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  "rfu_offset:\n" ++
+  "  .zero 8\n" ++
+  "rfu_length:\n" ++
+  "  .zero 8\n" ++
+  "cebr_cur:\n" ++
+  "  .zero 8\n" ++
+  "cebr_hdr_ptr:\n" ++
+  "  .zero 8\n" ++
+  "cebr_len_ptr:\n" ++
+  "  .zero 8\n" ++
+  "cebr_i:\n" ++
+  "  .zero 8"
+
+def ziskChainExtractBasefeeRangeProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskChainExtractBasefeeRangePrologue
+  dataAsm     := ziskChainExtractBasefeeRangeDataSection
+}
+
 end EvmAsm.Codegen

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **221**
-- ziskemu round-trip scripts: **214** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **222**
+- ziskemu round-trip scripts: **215** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ block-body helpers
 `chain_compute_total_gas_used`,
 `chain_extract_number_range`,
 `header_extract_basefee`,
+`chain_extract_basefee_range`,
 withdrawal RLP/hash, …), and address
 derivation (`address_compute_create`, `address_compute_create2`,
 `address_from_pubkey`). The catalogue is tracked under the

--- a/scripts/codegen-zisk-chain-extract-basefee-range-check.sh
+++ b/scripts/codegen-zisk-chain-extract-basefee-range-check.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# codegen-zisk-chain-extract-basefee-range-check.sh -- PR-K199.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_chain_extract_basefee_range ELF"
+lake exe codegen --program zisk_chain_extract_basefee_range --halt linux93 \
+  -o gen-out/zisk_chain_extract_basefee_range
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <basefees_list_py> <exp_status> <exp_min> <exp_max>
+run_case() {
+  local name="$1" bfs="$2" exp_status="$3" exp_min="$4" exp_max="$5"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_chain_extract_basefee_range_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_chain_extract_basefee_range_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+
+def u_be(n):
+    if n == 0: return b''
+    return n.to_bytes((n.bit_length() + 7) // 8, 'big')
+
+def make_header(bf):
+    return rlp.encode([
+        b'\\xa1'*32, b'\\xa2'*32, b'\\xa3'*20, b'\\xa4'*32, b'\\xa5'*32,
+        b'\\xa6'*32, b'\\x00'*256, b'', b'\\x01', b'\\x83\\xff\\xff\\xff',
+        b'', b'\\x83\\x01\\x02\\x03', b'', b'\\xa7'*32, b'\\x00'*8,
+        u_be(bf),
+    ])
+
+bfs = $bfs
+headers = [make_header(b) for b in bfs]
+N = len(headers)
+lengths = b''.join(struct.pack('<Q', len(h)) for h in headers)
+flat = b''.join(headers)
+
+with open(sys.argv[1], 'wb') as f:
+    record = struct.pack('<Q', N) + lengths + flat
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_chain_extract_basefee_range.elf \
+    -i "$in_file" -o "$out_file" -n 5000000 \
+    >"$REPO_ROOT/gen-out/zisk_chain_extract_basefee_range_${name}.emu.log" 2>&1 || true
+
+  local status_le; status_le="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local min_le;    min_le="$(   dd if="$out_file" bs=1 skip=8  count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local max_le;    max_le="$(   dd if="$out_file" bs=1 skip=16 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local status mn mx
+  status="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$status_le'))[0])")"
+  mn="$(    python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$min_le'))[0])")"
+  mx="$(    python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$max_le'))[0])")"
+
+  if [[ "$status" == "$exp_status" && "$mn" == "$exp_min" && "$mx" == "$exp_max" ]]; then
+    printf "  %-28s OK   status=%s min=%s max=%s\n" "$name" "$status" "$mn" "$mx"
+    return 0
+  else
+    printf "  %-28s FAIL status=%s/%s min=%s/%s max=%s/%s\n" \
+      "$name" "$status" "$exp_status" "$mn" "$exp_min" "$mx" "$exp_max"
+    return 1
+  fi
+}
+
+FAILED=0
+run_case "single"           "[1000000000]"                     0 1000000000 1000000000 || FAILED=1
+run_case "ascending"        "[1000, 2000, 3000]"               0 1000 3000 || FAILED=1
+run_case "descending"       "[5000, 3000, 1000]"               0 1000 5000 || FAILED=1
+run_case "five_arbitrary"   "[10, 50, 30, 5, 100]"             0 5 100 || FAILED=1
+run_case "empty"            "[]"                                0 0 0 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: chain_extract_basefee_range returns the right (min, max)"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Walk an N-element header chain and compute `(min, max)` of
`base_fee_per_gas` (field 15). London+ only -- pre-London headers
yield a parse-failure status. Useful for chain-level base_fee
bounds analysis.

Returns vacuous `(0, 0)` on `N == 0`. Iteration state lives in
`.data` slots since the loop calls `header_extract_basefee`
internally, which clobbers t-regs.

## Status codes

- `0` success
- `1` a header parse failure (e.g., pre-London header in the chain)
- `2` a base_fee field exceeds 8 bytes BE

## Test plan

5 ziskemu fixtures:

- [x] `single` -- 1 gwei base_fee -> min=max
- [x] `ascending` -- 1k, 2k, 3k -> (1k, 3k)
- [x] `descending` -- 5k, 3k, 1k -> (1k, 5k)
- [x] `five_arbitrary` -- 10, 50, 30, 5, 100 -> (5, 100)
- [x] `empty` -- N=0 -> (0, 0)

## Stack

Builds on #6003 (PR-K198 `header_extract_basefee`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)