### PR TITLE
feat(stateless): chain_block_hashes_commitment (PR-K200)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -4877,6 +4877,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_chain_extract_number_range" => some ziskChainExtractNumberRangeProbeUnit
   | "zisk_header_extract_basefee" => some ziskHeaderExtractBasefeeProbeUnit
   | "zisk_chain_extract_basefee_range" => some ziskChainExtractBasefeeRangeProbeUnit
+  | "zisk_chain_block_hashes_commitment" => some ziskChainBlockHashesCommitmentProbeUnit
   | "zisk_block_validate_2tx_full" => some ziskBlockValidate2txFullProbeUnit
   | "zisk_block_body_extract_2tx" => some ziskBlockBodyExtract2txProbeUnit
   | "zisk_block_validate_2tx_full_with_body" => some ziskBlockValidate2txFullWithBodyProbeUnit
@@ -5090,6 +5091,7 @@ def knownProgramNames : List String :=
    "zisk_chain_extract_number_range",
    "zisk_header_extract_basefee",
    "zisk_chain_extract_basefee_range",
+   "zisk_chain_block_hashes_commitment",
    "zisk_block_validate_2tx_full",
    "zisk_block_body_extract_2tx",
    "zisk_block_validate_2tx_full_with_body",

--- a/EvmAsm/Codegen/Programs/Header.lean
+++ b/EvmAsm/Codegen/Programs/Header.lean
@@ -3295,4 +3295,124 @@ def ziskChainExtractBasefeeRangeProbeUnit : BuildUnit := {
   dataAsm     := ziskChainExtractBasefeeRangeDataSection
 }
 
+/-! ## chain_block_hashes_commitment -- PR-K200
+
+    Compute a 32-byte commitment over the block_hashes of an
+    N-element header chain:
+
+      commitment = keccak256( H[0] || H[1] || ... || H[N-1] )
+
+    where `H[i] = keccak256(headers[i])`. This is the natural
+    succinct commitment to a chain of block hashes, useful for
+    bridges, light clients, and inter-prover commitments.
+
+    For N == 0 the commitment is `keccak256("")` (the empty-
+    string hash), which equals
+    `0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470`.
+
+    Calling convention:
+      a0 (input)  : N (header count)
+      a1 (input)  : header_lengths ptr
+      a2 (input)  : headers ptr
+      a3 (input)  : 32-byte output ptr (commitment)
+      ra (input)  : return
+      a0 (output) :
+        0 : success
+
+    Uses a scratch buffer (`cbhc_concat_buf`) of size 32*MAX_N
+    bytes for the intermediate concatenation. MAX_N is fixed
+    at 64 in this implementation (sufficient for typical
+    stateless witnesses of ~32 headers). -/
+def chainBlockHashesCommitmentFunction : String :=
+  "chain_block_hashes_commitment:\n" ++
+  "  addi sp, sp, -48\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp); sd s4, 40(sp)\n" ++
+  "  mv s0, a0                   # N\n" ++
+  "  mv s1, a1                   # header_lengths\n" ++
+  "  mv s2, a2                   # headers\n" ++
+  "  mv s3, a3                   # output ptr\n" ++
+  "  la s4, cbhc_concat_buf      # concat buffer start\n" ++
+  "  # Walk and hash each header into the concat buffer.\n" ++
+  "  li t6, 0                    # i = 0\n" ++
+  "  mv t5, s2                   # current header ptr\n" ++
+  "  la t4, cbhc_concat_buf\n" ++
+  ".Lcbhc_loop:\n" ++
+  "  beq t6, s0, .Lcbhc_done\n" ++
+  "  # Stash iteration state into .data\n" ++
+  "  la t0, cbhc_i; sd t6, 0(t0)\n" ++
+  "  la t0, cbhc_hdr_ptr; sd t5, 0(t0)\n" ++
+  "  la t0, cbhc_concat_cursor; sd t4, 0(t0)\n" ++
+  "  slli t0, t6, 3\n" ++
+  "  add t0, s1, t0\n" ++
+  "  ld a1, 0(t0)                # header_len\n" ++
+  "  mv a0, t5\n" ++
+  "  mv a2, t4                   # write into concat buf\n" ++
+  "  jal ra, block_hash_from_header\n" ++
+  "  # Reload iteration state\n" ++
+  "  la t0, cbhc_i; ld t6, 0(t0)\n" ++
+  "  la t0, cbhc_hdr_ptr; ld t5, 0(t0)\n" ++
+  "  la t0, cbhc_concat_cursor; ld t4, 0(t0)\n" ++
+  "  # Advance: concat += 32; header += header_len; i += 1\n" ++
+  "  slli t0, t6, 3\n" ++
+  "  add t0, s1, t0\n" ++
+  "  ld t1, 0(t0)\n" ++
+  "  add t5, t5, t1\n" ++
+  "  addi t4, t4, 32\n" ++
+  "  addi t6, t6, 1\n" ++
+  "  j .Lcbhc_loop\n" ++
+  ".Lcbhc_done:\n" ++
+  "  # commit = keccak256(concat buf, 32*N) -> output\n" ++
+  "  la a0, cbhc_concat_buf\n" ++
+  "  slli a1, s0, 5              # 32*N\n" ++
+  "  mv a2, s3\n" ++
+  "  jal ra, zkvm_keccak256\n" ++
+  "  li a0, 0\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp); ld s4, 40(sp)\n" ++
+  "  addi sp, sp, 48\n" ++
+  "  ret"
+
+/-- `zisk_chain_block_hashes_commitment`: probe BuildUnit.
+    Input layout:
+      bytes  0.. 8 : N
+      bytes  8..8+8N : header_lengths
+      bytes  8+8N.. : concatenated headers
+    Output layout:
+      bytes 0..32 : 32-byte commitment -/
+def ziskChainBlockHashesCommitmentPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a7, 0x40000000\n" ++
+  "  ld a0, 8(a7)                # N\n" ++
+  "  addi a1, a7, 16\n" ++
+  "  slli t0, a0, 3\n" ++
+  "  add a2, a1, t0\n" ++
+  "  li a3, 0xa0010000           # 32 B commitment out\n" ++
+  "  jal ra, chain_block_hashes_commitment\n" ++
+  "  j .Lcbhc_pdone\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  blockHashFromHeaderFunction ++ "\n" ++
+  chainBlockHashesCommitmentFunction ++ "\n" ++
+  ".Lcbhc_pdone:"
+
+def ziskChainBlockHashesCommitmentDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  "cbhc_concat_buf:\n" ++
+  "  .zero 2048                  # 32 * 64 = 2048\n" ++
+  "cbhc_i:\n" ++
+  "  .zero 8\n" ++
+  "cbhc_hdr_ptr:\n" ++
+  "  .zero 8\n" ++
+  "cbhc_concat_cursor:\n" ++
+  "  .zero 8"
+
+def ziskChainBlockHashesCommitmentProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskChainBlockHashesCommitmentPrologue
+  dataAsm     := ziskChainBlockHashesCommitmentDataSection
+}
+
 end EvmAsm.Codegen

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **222**
-- ziskemu round-trip scripts: **215** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **223**
+- ziskemu round-trip scripts: **216** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ block-body helpers
 `chain_extract_number_range`,
 `header_extract_basefee`,
 `chain_extract_basefee_range`,
+`chain_block_hashes_commitment`,
 withdrawal RLP/hash, …), and address
 derivation (`address_compute_create`, `address_compute_create2`,
 `address_from_pubkey`). The catalogue is tracked under the

--- a/scripts/codegen-zisk-chain-block-hashes-commitment-check.sh
+++ b/scripts/codegen-zisk-chain-block-hashes-commitment-check.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# codegen-zisk-chain-block-hashes-commitment-check.sh -- PR-K200.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_chain_block_hashes_commitment ELF"
+lake exe codegen --program zisk_chain_block_hashes_commitment --halt linux93 \
+  -o gen-out/zisk_chain_block_hashes_commitment
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <numbers_list_py>
+run_case() {
+  local name="$1" nums="$2"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_chain_block_hashes_commitment_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_chain_block_hashes_commitment_${name}.output"
+  local exp_hex_file="$REPO_ROOT/gen-out/zisk_chain_block_hashes_commitment_${name}.expected.hex"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+try:
+    from Crypto.Hash import keccak
+    def keccak256(b):
+        h = keccak.new(digest_bits=256); h.update(b); return h.digest()
+except Exception:
+    import sha3
+    def keccak256(b): return sha3.keccak_256(b).digest()
+
+def u_be(n):
+    if n == 0: return b''
+    return n.to_bytes((n.bit_length() + 7) // 8, 'big')
+
+def make_header(num):
+    return rlp.encode([
+        b'\\xa1'*32, b'\\xa2'*32, b'\\xa3'*20, b'\\xa4'*32, b'\\xa5'*32,
+        b'\\xa6'*32, b'\\x00'*256, b'', u_be(num), b'\\x83\\xff\\xff\\xff',
+        b'\\x82\\x02\\x00', b'\\x83\\x01\\x02\\x03', b'', b'\\xa7'*32, b'\\x00'*8,
+    ])
+
+nums = $nums
+headers = [make_header(n) for n in nums]
+hashes = [keccak256(h) for h in headers]
+commit = keccak256(b''.join(hashes))
+
+N = len(headers)
+lengths = b''.join(struct.pack('<Q', len(h)) for h in headers)
+flat = b''.join(headers)
+
+with open(sys.argv[1], 'wb') as f:
+    record = struct.pack('<Q', N) + lengths + flat
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\x00' * pad)
+with open(sys.argv[2], 'w') as f:
+    f.write(commit.hex())
+" "$in_file" "$exp_hex_file"
+
+  "$ZISKEMU" -e gen-out/zisk_chain_block_hashes_commitment.elf \
+    -i "$in_file" -o "$out_file" -n 20000000 \
+    >"$REPO_ROOT/gen-out/zisk_chain_block_hashes_commitment_${name}.emu.log" 2>&1 || true
+
+  local actual; actual="$(xxd -p -l 32 "$out_file" | tr -d '\n')"
+  local expected; expected="$(cat "$exp_hex_file")"
+
+  if [[ "$actual" == "$expected" ]]; then
+    printf "  %-26s OK   commit=%s...\n" "$name" "${actual:0:16}"
+    return 0
+  else
+    printf "  %-26s FAIL\n" "$name"
+    printf "      actual:   %s\n" "$actual"
+    printf "      expected: %s\n" "$expected"
+    return 1
+  fi
+}
+
+FAILED=0
+run_case "empty"           "[]" || FAILED=1
+run_case "single"          "[100]" || FAILED=1
+run_case "three"           "[100, 101, 102]" || FAILED=1
+run_case "five"            "[10, 20, 30, 40, 50]" || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: chain_block_hashes_commitment matches Python keccak256(concat(block_hashes))"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Compute a 32-byte commitment over the block_hashes of an
N-element header chain:

```
commitment = keccak256( H[0] || H[1] || ... || H[N-1] )
```

where `H[i] = keccak256(headers[i])`. Natural succinct commitment
to a chain of block hashes for bridges, light clients, and
inter-prover commitments.

For `N == 0` the commitment is `keccak256("")` (the empty-string
hash).

Uses a 2048-byte scratch buffer (MAX_N = 64); typical stateless
witnesses ship ~32 headers.

## Test plan

4 ziskemu fixtures match Python `keccak256(concat(block_hashes))`:

- [x] `empty` -- N=0 -> `keccak256("")`
- [x] `single` -- 1 header
- [x] `three` -- 3 headers
- [x] `five` -- 5 headers

## Stack

Builds on #6004 (PR-K199 `chain_extract_basefee_range`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)