### PR TITLE
feat(div): add phase2b_q0' unified no-fire bound (combines cases a + b)

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/Phase2bNoFireBound.lean
+++ b/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/Phase2bNoFireBound.lean
@@ -114,4 +114,47 @@ theorem div128Quot_phase2b_q0'_dLo_bound_no_fire_case_a
       omega
     omega
 
+/-- **Phase-2b no-fire combined bound.** Unified wrapper over case-a
+    (`rhat ≥ 2^32`, outer guard fails) and case-b (`rhat < 2^32 ∧
+    ¬ult`, inner guard fails).
+
+    Takes the full set of size preconditions plus the algorithm-level
+    "no-fire" condition `h_no_fire : ¬ (rhat >>> 32 = 0 ∧ ult)` (the
+    negation of the `phase2b_q0'` correction guard). Dispatches via
+    case-split on `rhat.toNat < 2^32 ∨ ¬ult` and invokes the
+    appropriate sub-case helper.
+
+    This is the form callers of bead 7.1.3.1.1.2 use to discharge the
+    Phase-1b 2-correction post-condition's "no-fire" branch in one
+    shot. -/
+theorem div128Quot_phase2b_q0'_dLo_bound_no_fire
+    (q rhat dLo un : Word)
+    (h_q_le : q.toNat ≤ 2^32 + 1)
+    (h_dLo_lt : dLo.toNat < 2^32)
+    (h_un_lt : un.toNat < 2^32)
+    (h_no_wrap : (q * dLo).toNat = q.toNat * dLo.toNat)
+    (h_no_fire :
+      ¬ (rhat >>> (32 : BitVec 6).toNat = (0 : Word) ∧
+        BitVec.ult ((rhat <<< (32 : BitVec 6).toNat) ||| un) (q * dLo))) :
+    div128Quot_phase2b_q0' q rhat dLo un = q ∧
+    q.toNat * dLo.toNat ≤ rhat.toNat * 2^32 + un.toNat := by
+  by_cases h_rhat_lt : rhat.toNat < 2^32
+  · -- Case-b: rhat < 2^32 ⇒ rhat >>> 32 = 0 ⇒ no-fire forces ¬ult.
+    have h_rhat_hi_zero : rhat >>> (32 : BitVec 6).toNat = (0 : Word) := by
+      apply BitVec.eq_of_toNat_eq
+      show (rhat >>> (32 : BitVec 6).toNat).toNat = (0 : Word).toNat
+      rw [BitVec.toNat_ushiftRight, EvmAsm.Rv64.AddrNorm.bv6_toNat_32,
+          Nat.shiftRight_eq_div_pow]
+      rw [Nat.div_eq_of_lt h_rhat_lt]
+      rfl
+    have h_no_ult :
+        ¬ BitVec.ult ((rhat <<< (32 : BitVec 6).toNat) ||| un) (q * dLo) := by
+      intro h_ult; exact h_no_fire ⟨h_rhat_hi_zero, h_ult⟩
+    exact div128Quot_phase2b_q0'_dLo_bound_no_fire_case_b
+      q rhat dLo un h_rhat_lt h_un_lt h_no_wrap h_no_ult
+  · -- Case-a: rhat ≥ 2^32.
+    have h_rhat_ge : rhat.toNat ≥ 2^32 := by omega
+    exact div128Quot_phase2b_q0'_dLo_bound_no_fire_case_a
+      q rhat dLo un h_q_le h_dLo_lt h_rhat_ge h_no_wrap
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Adds `div128Quot_phase2b_q0'_dLo_bound_no_fire` to `Phase2bNoFireBound.lean` — the unified Phase-1b 2-correction no-fire wrapper that takes the negation of the full correction guard `¬(rhat >>> 32 = 0 ∧ ult rhatUn1 (q*dLo))` and dispatches internally to case-a (rhat ≥ 2^32) or case-b (rhat < 2^32 ∧ ¬ult).
- Convenience form for callers of the Phase-1b 2-correction post-condition: discharges "didn't fire" in one shot.

Stacked on #6005. Refs #61. Bead `evm-asm-9iqmw.7.1.3.1.1.2.1`.

## Status of the full Phase-1b 2-correction bound
- ✓ Case-b (`rhat < 2^32 ∧ ¬ult`) — #6002 (merged).
- ✓ Case-a (`rhat ≥ 2^32`) — #6005 (pending).
- ✓ Unified no-fire wrapper — this PR.
- ⏳ Correction-fires case (`rhat < 2^32 ∧ ult`) — the hard residual; needs Knuth-D3 1-correction invariant chain.

## Verification
- `lake build EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV4.Phase2bNoFireBound`
- `lake build` (full, 2236 jobs)
- `scripts/check-file-size.sh` (813 files, all within cap)
- `rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth"` (no matches)

Authored by @pirapira; implemented by Claude Code