### PR TITLE
feat(stateless): header_extract_state_root (PR-K201)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -4878,6 +4878,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_header_extract_basefee" => some ziskHeaderExtractBasefeeProbeUnit
   | "zisk_chain_extract_basefee_range" => some ziskChainExtractBasefeeRangeProbeUnit
   | "zisk_chain_block_hashes_commitment" => some ziskChainBlockHashesCommitmentProbeUnit
+  | "zisk_header_extract_state_root" => some ziskHeaderExtractStateRootProbeUnit
   | "zisk_block_validate_2tx_full" => some ziskBlockValidate2txFullProbeUnit
   | "zisk_block_body_extract_2tx" => some ziskBlockBodyExtract2txProbeUnit
   | "zisk_block_validate_2tx_full_with_body" => some ziskBlockValidate2txFullWithBodyProbeUnit
@@ -5092,6 +5093,7 @@ def knownProgramNames : List String :=
    "zisk_header_extract_basefee",
    "zisk_chain_extract_basefee_range",
    "zisk_chain_block_hashes_commitment",
+   "zisk_header_extract_state_root",
    "zisk_block_validate_2tx_full",
    "zisk_block_body_extract_2tx",
    "zisk_block_validate_2tx_full_with_body",

--- a/EvmAsm/Codegen/Programs/Header.lean
+++ b/EvmAsm/Codegen/Programs/Header.lean
@@ -3415,4 +3415,94 @@ def ziskChainBlockHashesCommitmentProbeUnit : BuildUnit := {
   dataAsm     := ziskChainBlockHashesCommitmentDataSection
 }
 
+/-! ## header_extract_state_root -- PR-K201
+
+    Extract `state_root` (field 3, 32 bytes) from a header RLP
+    and copy it to a caller-supplied 32-byte output buffer.
+
+    `header_minimal_decode` already extracts state_root as part
+    of a 4-field bundle (parent_hash + state_root + number +
+    timestamp); this primitive is the tight standalone variant
+    for callers that only need the state_root.
+
+    Calling convention:
+      a0 (input)  : header_rlp ptr
+      a1 (input)  : header_rlp byte length
+      a2 (input)  : 32-byte output ptr
+      ra (input)  : return
+      a0 (output) :
+        0 : success
+        1 : RLP parse failure / field 3 missing
+        2 : field 3 length != 32 -/
+def headerExtractStateRootFunction : String :=
+  "header_extract_state_root:\n" ++
+  "  addi sp, sp, -32\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp)\n" ++
+  "  mv s0, a0\n" ++
+  "  mv s1, a1\n" ++
+  "  mv s2, a2\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 3\n" ++
+  "  la a3, hesr_offset; la a4, hesr_length\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lhesr_parse_fail\n" ++
+  "  la t0, hesr_length; ld t1, 0(t0)\n" ++
+  "  li t2, 32\n" ++
+  "  bne t1, t2, .Lhesr_size_fail\n" ++
+  "  la t0, hesr_offset; ld t1, 0(t0)\n" ++
+  "  add t3, s0, t1\n" ++
+  "  ld t4,  0(t3); sd t4,  0(s2)\n" ++
+  "  ld t4,  8(t3); sd t4,  8(s2)\n" ++
+  "  ld t4, 16(t3); sd t4, 16(s2)\n" ++
+  "  ld t4, 24(t3); sd t4, 24(s2)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lhesr_ret\n" ++
+  ".Lhesr_parse_fail:\n" ++
+  "  li a0, 1\n" ++
+  "  j .Lhesr_ret\n" ++
+  ".Lhesr_size_fail:\n" ++
+  "  li a0, 2\n" ++
+  ".Lhesr_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp)\n" ++
+  "  addi sp, sp, 32\n" ++
+  "  ret"
+
+/-- `zisk_header_extract_state_root`: probe BuildUnit.
+    Input layout:
+      bytes 0..8 : header_rlp_len
+      bytes 8..  : header_rlp
+    Output layout:
+      bytes  0.. 8 : status
+      bytes  8..40 : 32-byte state_root -/
+def ziskHeaderExtractStateRootPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a7, 0x40000000\n" ++
+  "  ld a1, 8(a7)                # header_rlp_len\n" ++
+  "  addi a0, a7, 16             # header_rlp ptr\n" ++
+  "  li a2, 0xa0010008           # 32 B output\n" ++
+  "  jal ra, header_extract_state_root\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lhesr_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  headerExtractStateRootFunction ++ "\n" ++
+  ".Lhesr_pdone:"
+
+def ziskHeaderExtractStateRootDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  "hesr_offset:\n" ++
+  "  .zero 8\n" ++
+  "hesr_length:\n" ++
+  "  .zero 8"
+
+def ziskHeaderExtractStateRootProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskHeaderExtractStateRootPrologue
+  dataAsm     := ziskHeaderExtractStateRootDataSection
+}
+
 end EvmAsm.Codegen

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **222**
-- ziskemu round-trip scripts: **215** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **224**
+- ziskemu round-trip scripts: **217** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ block-body helpers
 `header_extract_basefee`,
 `chain_extract_basefee_range`,
 `chain_block_hashes_commitment`,
+`header_extract_state_root`,
 withdrawal RLP/hash, …), and address
 derivation (`address_compute_create`, `address_compute_create2`,
 `address_from_pubkey`). The catalogue is tracked under the

--- a/scripts/codegen-zisk-header-extract-state-root-check.sh
+++ b/scripts/codegen-zisk-header-extract-state-root-check.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# codegen-zisk-header-extract-state-root-check.sh -- PR-K201.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_header_extract_state_root ELF"
+lake exe codegen --program zisk_header_extract_state_root --halt linux93 \
+  -o gen-out/zisk_header_extract_state_root
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <state_root_hex_or_special> <exp_status> <exp_root_hex>
+run_case() {
+  local name="$1" sr="$2" exp_status="$3" exp_root="$4"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_header_extract_state_root_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_header_extract_state_root_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+sr = '$sr'
+if sr == 'garbage':
+    header_rlp = b'\\x00'
+else:
+    if sr == 'short':
+        state_root = b'\\xaa'*16
+    else:
+        state_root = bytes.fromhex(sr)
+    fields = [
+        b'\\x11'*32, b'\\x22'*32, b'\\x33'*20, state_root, b'\\x55'*32,
+        b'\\x66'*32, b'\\x00'*256, b'', b'\\x01', b'\\x83\\xff\\xff\\xff',
+        b'', b'\\x83\\x01\\x02\\x03', b'', b'\\x77'*32, b'\\x00'*8,
+    ]
+    header_rlp = rlp.encode(fields)
+with open(sys.argv[1], 'wb') as f:
+    record = struct.pack('<Q', len(header_rlp)) + header_rlp
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_header_extract_state_root.elf \
+    -i "$in_file" -o "$out_file" -n 1000000 \
+    >"$REPO_ROOT/gen-out/zisk_header_extract_state_root_${name}.emu.log" 2>&1 || true
+
+  local status_le; status_le="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local actual_root; actual_root="$(dd if="$out_file" bs=1 skip=8 count=32 2>/dev/null | xxd -p | tr -d '\n')"
+  local status
+  status="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$status_le'))[0])")"
+
+  if [[ "$status" == "$exp_status" && "$actual_root" == "$exp_root" ]]; then
+    printf "  %-26s OK   status=%s root=%s...\n" "$name" "$status" "${actual_root:0:16}"
+    return 0
+  else
+    printf "  %-26s FAIL status=%s/%s root=%s/%s\n" \
+      "$name" "$status" "$exp_status" "$actual_root" "$exp_root"
+    return 1
+  fi
+}
+
+ZERO_32="0000000000000000000000000000000000000000000000000000000000000000"
+
+FAILED=0
+run_case "match_typical"      "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789" 0 "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789" || FAILED=1
+run_case "match_zero_root"    "$ZERO_32" 0 "$ZERO_32" || FAILED=1
+run_case "fail_short_field"   "short"    2 "$ZERO_32" || FAILED=1
+run_case "fail_garbage"       "garbage"  1 "$ZERO_32" || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: header_extract_state_root copies field 3 to output"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Extract `state_root` (field 3, 32 bytes) from a header RLP and copy it
to a caller-supplied 32-byte output buffer.

`header_minimal_decode` (K38) already returns state_root bundled with
parent_hash + number + timestamp; this primitive is the tight
standalone variant for callers that only need state_root.

## Status codes

- `0` success
- `1` RLP parse failure / field 3 missing
- `2` field 3 length != 32

## Test plan

4 ziskemu fixtures:

- [x] `match_typical` -- arbitrary 32B root copied verbatim
- [x] `match_zero_root` -- all-zero root
- [x] `fail_short_field` -- 16B field 3 -> status=2
- [x] `fail_garbage` -- single 0x00 header -> status=1

## Stack

Builds on #6006 (PR-K200 `chain_block_hashes_commitment`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)