### PR TITLE
feat(stateless): header_extract_receipts_root (PR-K203)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -4505,6 +4505,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_chain_block_hashes_commitment" => some ziskChainBlockHashesCommitmentProbeUnit
   | "zisk_header_extract_state_root" => some ziskHeaderExtractStateRootProbeUnit
   | "zisk_header_extract_parent_hash" => some ziskHeaderExtractParentHashProbeUnit
+  | "zisk_header_extract_receipts_root" => some ziskHeaderExtractReceiptsRootProbeUnit
   | "zisk_block_validate_2tx_full" => some ziskBlockValidate2txFullProbeUnit
   | "zisk_block_body_extract_2tx" => some ziskBlockBodyExtract2txProbeUnit
   | "zisk_block_validate_2tx_full_with_body" => some ziskBlockValidate2txFullWithBodyProbeUnit
@@ -4721,6 +4722,7 @@ def knownProgramNames : List String :=
    "zisk_chain_block_hashes_commitment",
    "zisk_header_extract_state_root",
    "zisk_header_extract_parent_hash",
+   "zisk_header_extract_receipts_root",
    "zisk_block_validate_2tx_full",
    "zisk_block_body_extract_2tx",
    "zisk_block_validate_2tx_full_with_body",

--- a/EvmAsm/Codegen/Programs/Header.lean
+++ b/EvmAsm/Codegen/Programs/Header.lean
@@ -3586,4 +3586,86 @@ def ziskHeaderExtractParentHashProbeUnit : BuildUnit := {
   dataAsm     := ziskHeaderExtractParentHashDataSection
 }
 
+/-! ## header_extract_receipts_root -- PR-K203
+
+    Extract `receipts_root` (field 5, 32 bytes) from a header
+    RLP and copy it to a caller-supplied 32-byte output buffer.
+
+    Tight standalone analogue of K201 (state_root, field 3)
+    and K202 (parent_hash, field 0).
+
+    Calling convention:
+      a0 (input)  : header_rlp ptr
+      a1 (input)  : header_rlp byte length
+      a2 (input)  : 32-byte output ptr
+      ra (input)  : return
+      a0 (output) :
+        0 : success
+        1 : RLP parse failure / field 5 missing
+        2 : field 5 length != 32 -/
+def headerExtractReceiptsRootFunction : String :=
+  "header_extract_receipts_root:\n" ++
+  "  addi sp, sp, -32\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp)\n" ++
+  "  mv s0, a0\n" ++
+  "  mv s1, a1\n" ++
+  "  mv s2, a2\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 5\n" ++
+  "  la a3, herr_offset; la a4, herr_length\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lherr_parse_fail\n" ++
+  "  la t0, herr_length; ld t1, 0(t0)\n" ++
+  "  li t2, 32\n" ++
+  "  bne t1, t2, .Lherr_size_fail\n" ++
+  "  la t0, herr_offset; ld t1, 0(t0)\n" ++
+  "  add t3, s0, t1\n" ++
+  "  ld t4,  0(t3); sd t4,  0(s2)\n" ++
+  "  ld t4,  8(t3); sd t4,  8(s2)\n" ++
+  "  ld t4, 16(t3); sd t4, 16(s2)\n" ++
+  "  ld t4, 24(t3); sd t4, 24(s2)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lherr_ret\n" ++
+  ".Lherr_parse_fail:\n" ++
+  "  li a0, 1\n" ++
+  "  j .Lherr_ret\n" ++
+  ".Lherr_size_fail:\n" ++
+  "  li a0, 2\n" ++
+  ".Lherr_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp)\n" ++
+  "  addi sp, sp, 32\n" ++
+  "  ret"
+
+/-- `zisk_header_extract_receipts_root`: probe BuildUnit. -/
+def ziskHeaderExtractReceiptsRootPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a7, 0x40000000\n" ++
+  "  ld a1, 8(a7)\n" ++
+  "  addi a0, a7, 16\n" ++
+  "  li a2, 0xa0010008\n" ++
+  "  jal ra, header_extract_receipts_root\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lherr_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  headerExtractReceiptsRootFunction ++ "\n" ++
+  ".Lherr_pdone:"
+
+def ziskHeaderExtractReceiptsRootDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  "herr_offset:\n" ++
+  "  .zero 8\n" ++
+  "herr_length:\n" ++
+  "  .zero 8"
+
+def ziskHeaderExtractReceiptsRootProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskHeaderExtractReceiptsRootPrologue
+  dataAsm     := ziskHeaderExtractReceiptsRootDataSection
+}
+
 end EvmAsm.Codegen

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **225**
-- ziskemu round-trip scripts: **218** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **226**
+- ziskemu round-trip scripts: **219** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ block-body helpers
 `chain_block_hashes_commitment`,
 `header_extract_state_root`,
 `header_extract_parent_hash`,
+`header_extract_receipts_root`,
 withdrawal RLP/hash, …), and address
 derivation (`address_compute_create`, `address_compute_create2`,
 `address_from_pubkey`). The catalogue is tracked under the

--- a/scripts/codegen-zisk-header-extract-receipts-root-check.sh
+++ b/scripts/codegen-zisk-header-extract-receipts-root-check.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# codegen-zisk-header-extract-receipts-root-check.sh -- PR-K203.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_header_extract_receipts_root ELF"
+lake exe codegen --program zisk_header_extract_receipts_root --halt linux93 \
+  -o gen-out/zisk_header_extract_receipts_root
+
+REPO_ROOT="$(pwd)"
+
+run_case() {
+  local name="$1" rr="$2" exp_status="$3" exp_root="$4"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_header_extract_receipts_root_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_header_extract_receipts_root_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+rr = '$rr'
+if rr == 'garbage':
+    header_rlp = b'\\x00'
+else:
+    if rr == 'short':
+        rcpts = b'\\xaa'*16
+    else:
+        rcpts = bytes.fromhex(rr)
+    fields = [
+        b'\\x11'*32, b'\\x22'*32, b'\\x33'*20, b'\\x44'*32, b'\\x55'*32,
+        rcpts, b'\\x00'*256, b'', b'\\x01', b'\\x83\\xff\\xff\\xff',
+        b'', b'\\x83\\x01\\x02\\x03', b'', b'\\x77'*32, b'\\x00'*8,
+    ]
+    header_rlp = rlp.encode(fields)
+with open(sys.argv[1], 'wb') as f:
+    record = struct.pack('<Q', len(header_rlp)) + header_rlp
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_header_extract_receipts_root.elf \
+    -i "$in_file" -o "$out_file" -n 1000000 \
+    >"$REPO_ROOT/gen-out/zisk_header_extract_receipts_root_${name}.emu.log" 2>&1 || true
+
+  local status_le; status_le="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local actual; actual="$(dd if="$out_file" bs=1 skip=8 count=32 2>/dev/null | xxd -p | tr -d '\n')"
+  local status
+  status="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$status_le'))[0])")"
+
+  if [[ "$status" == "$exp_status" && "$actual" == "$exp_root" ]]; then
+    printf "  %-26s OK   status=%s root=%s...\n" "$name" "$status" "${actual:0:16}"
+    return 0
+  else
+    printf "  %-26s FAIL status=%s/%s root=%s/%s\n" "$name" "$status" "$exp_status" "$actual" "$exp_root"
+    return 1
+  fi
+}
+
+ZERO="0000000000000000000000000000000000000000000000000000000000000000"
+
+FAILED=0
+run_case "match_typical" "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789" 0 "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789" || FAILED=1
+run_case "match_zero"    "$ZERO"   0 "$ZERO"   || FAILED=1
+run_case "fail_short"    "short"   2 "$ZERO"   || FAILED=1
+run_case "fail_garbage"  "garbage" 1 "$ZERO"   || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: header_extract_receipts_root copies field 5 to output"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Tight standalone extractor for `receipts_root` (field 5,
32 bytes) -- the field-5 analogue of K201 (state_root) and K202
(parent_hash). Useful for callers that only need receipts_root
without bundled state_root / number / timestamp.

## Status codes

- `0` success
- `1` RLP parse failure / field 5 missing
- `2` field 5 length != 32

## Test plan

4 ziskemu fixtures: typical, all-zero, short field, garbage.

## Stack

Builds on #6011 (refactor: extract address cluster).

🤖 Generated with [Claude Code](https://claude.com/claude-code)