### PR TITLE
feat(stateless): header_extract_transactions_root + withdrawals_root (PR-K204 / K205)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -4506,6 +4506,8 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_header_extract_state_root" => some ziskHeaderExtractStateRootProbeUnit
   | "zisk_header_extract_parent_hash" => some ziskHeaderExtractParentHashProbeUnit
   | "zisk_header_extract_receipts_root" => some ziskHeaderExtractReceiptsRootProbeUnit
+  | "zisk_header_extract_transactions_root" => some ziskHeaderExtractTransactionsRootProbeUnit
+  | "zisk_header_extract_withdrawals_root" => some ziskHeaderExtractWithdrawalsRootProbeUnit
   | "zisk_block_validate_2tx_full" => some ziskBlockValidate2txFullProbeUnit
   | "zisk_block_body_extract_2tx" => some ziskBlockBodyExtract2txProbeUnit
   | "zisk_block_validate_2tx_full_with_body" => some ziskBlockValidate2txFullWithBodyProbeUnit
@@ -4723,6 +4725,8 @@ def knownProgramNames : List String :=
    "zisk_header_extract_state_root",
    "zisk_header_extract_parent_hash",
    "zisk_header_extract_receipts_root",
+   "zisk_header_extract_transactions_root",
+   "zisk_header_extract_withdrawals_root",
    "zisk_block_validate_2tx_full",
    "zisk_block_body_extract_2tx",
    "zisk_block_validate_2tx_full_with_body",

--- a/EvmAsm/Codegen/Programs/Header.lean
+++ b/EvmAsm/Codegen/Programs/Header.lean
@@ -3668,4 +3668,163 @@ def ziskHeaderExtractReceiptsRootProbeUnit : BuildUnit := {
   dataAsm     := ziskHeaderExtractReceiptsRootDataSection
 }
 
+/-! ## header_extract_transactions_root -- PR-K204
+
+    Extract `transactions_root` (field 4, 32 bytes) from a
+    header RLP. Tight standalone analogue of K201 / K202 / K203.
+
+    Calling convention:
+      a0 (input)  : header_rlp ptr
+      a1 (input)  : header_rlp byte length
+      a2 (input)  : 32-byte output ptr
+      ra (input)  : return
+      a0 (output) :
+        0 : success
+        1 : RLP parse failure / field 4 missing
+        2 : field 4 length != 32 -/
+def headerExtractTransactionsRootFunction : String :=
+  "header_extract_transactions_root:\n" ++
+  "  addi sp, sp, -32\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp)\n" ++
+  "  mv s0, a0\n" ++
+  "  mv s1, a1\n" ++
+  "  mv s2, a2\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 4\n" ++
+  "  la a3, hetr_offset; la a4, hetr_length\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lhetr_parse_fail\n" ++
+  "  la t0, hetr_length; ld t1, 0(t0)\n" ++
+  "  li t2, 32\n" ++
+  "  bne t1, t2, .Lhetr_size_fail\n" ++
+  "  la t0, hetr_offset; ld t1, 0(t0)\n" ++
+  "  add t3, s0, t1\n" ++
+  "  ld t4,  0(t3); sd t4,  0(s2)\n" ++
+  "  ld t4,  8(t3); sd t4,  8(s2)\n" ++
+  "  ld t4, 16(t3); sd t4, 16(s2)\n" ++
+  "  ld t4, 24(t3); sd t4, 24(s2)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lhetr_ret\n" ++
+  ".Lhetr_parse_fail:\n" ++
+  "  li a0, 1\n" ++
+  "  j .Lhetr_ret\n" ++
+  ".Lhetr_size_fail:\n" ++
+  "  li a0, 2\n" ++
+  ".Lhetr_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp)\n" ++
+  "  addi sp, sp, 32\n" ++
+  "  ret"
+
+/-- `zisk_header_extract_transactions_root`: probe BuildUnit. -/
+def ziskHeaderExtractTransactionsRootPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a7, 0x40000000\n" ++
+  "  ld a1, 8(a7)\n" ++
+  "  addi a0, a7, 16\n" ++
+  "  li a2, 0xa0010008\n" ++
+  "  jal ra, header_extract_transactions_root\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lhetr_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  headerExtractTransactionsRootFunction ++ "\n" ++
+  ".Lhetr_pdone:"
+
+def ziskHeaderExtractTransactionsRootDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  "hetr_offset:\n" ++
+  "  .zero 8\n" ++
+  "hetr_length:\n" ++
+  "  .zero 8"
+
+def ziskHeaderExtractTransactionsRootProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskHeaderExtractTransactionsRootPrologue
+  dataAsm     := ziskHeaderExtractTransactionsRootDataSection
+}
+
+/-! ## header_extract_withdrawals_root -- PR-K205
+
+    Extract `withdrawals_root` (field 16, 32 bytes) from a
+    Shanghai+ header RLP. Tight standalone analogue of K201..
+    K204 for the post-Shanghai field 16.
+
+    Calling convention:
+      a0 (input)  : header_rlp ptr
+      a1 (input)  : header_rlp byte length
+      a2 (input)  : 32-byte output ptr
+      ra (input)  : return
+      a0 (output) :
+        0 : success
+        1 : RLP parse failure / field 16 missing (pre-Shanghai)
+        2 : field 16 length != 32 -/
+def headerExtractWithdrawalsRootFunction : String :=
+  "header_extract_withdrawals_root:\n" ++
+  "  addi sp, sp, -32\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp)\n" ++
+  "  mv s0, a0\n" ++
+  "  mv s1, a1\n" ++
+  "  mv s2, a2\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 16\n" ++
+  "  la a3, hewr_offset; la a4, hewr_length\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lhewr_parse_fail\n" ++
+  "  la t0, hewr_length; ld t1, 0(t0)\n" ++
+  "  li t2, 32\n" ++
+  "  bne t1, t2, .Lhewr_size_fail\n" ++
+  "  la t0, hewr_offset; ld t1, 0(t0)\n" ++
+  "  add t3, s0, t1\n" ++
+  "  ld t4,  0(t3); sd t4,  0(s2)\n" ++
+  "  ld t4,  8(t3); sd t4,  8(s2)\n" ++
+  "  ld t4, 16(t3); sd t4, 16(s2)\n" ++
+  "  ld t4, 24(t3); sd t4, 24(s2)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lhewr_ret\n" ++
+  ".Lhewr_parse_fail:\n" ++
+  "  li a0, 1\n" ++
+  "  j .Lhewr_ret\n" ++
+  ".Lhewr_size_fail:\n" ++
+  "  li a0, 2\n" ++
+  ".Lhewr_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp)\n" ++
+  "  addi sp, sp, 32\n" ++
+  "  ret"
+
+/-- `zisk_header_extract_withdrawals_root`: probe BuildUnit. -/
+def ziskHeaderExtractWithdrawalsRootPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a7, 0x40000000\n" ++
+  "  ld a1, 8(a7)\n" ++
+  "  addi a0, a7, 16\n" ++
+  "  li a2, 0xa0010008\n" ++
+  "  jal ra, header_extract_withdrawals_root\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lhewr_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  headerExtractWithdrawalsRootFunction ++ "\n" ++
+  ".Lhewr_pdone:"
+
+def ziskHeaderExtractWithdrawalsRootDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  "hewr_offset:\n" ++
+  "  .zero 8\n" ++
+  "hewr_length:\n" ++
+  "  .zero 8"
+
+def ziskHeaderExtractWithdrawalsRootProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskHeaderExtractWithdrawalsRootPrologue
+  dataAsm     := ziskHeaderExtractWithdrawalsRootDataSection
+}
+
 end EvmAsm.Codegen

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **226**
-- ziskemu round-trip scripts: **219** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **228**
+- ziskemu round-trip scripts: **220** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/README.md
+++ b/README.md
@@ -289,6 +289,8 @@ block-body helpers
 `header_extract_state_root`,
 `header_extract_parent_hash`,
 `header_extract_receipts_root`,
+`header_extract_transactions_root`,
+`header_extract_withdrawals_root`,
 withdrawal RLP/hash, …), and address
 derivation (`address_compute_create`, `address_compute_create2`,
 `address_from_pubkey`). The catalogue is tracked under the

--- a/scripts/codegen-zisk-header-extract-root-pair-check.sh
+++ b/scripts/codegen-zisk-header-extract-root-pair-check.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# codegen-zisk-header-extract-root-pair-check.sh -- PR-K204 + K205.
+# Tests both transactions_root (field 4) and withdrawals_root (field 16).
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+run_program() {
+  local prog="$1" name="$2" field_index="$3" value="$4"
+  local in_file="$REPO_ROOT/gen-out/${prog}_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/${prog}_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+v = bytes.fromhex('$value')
+idx = $field_index
+# Always emit a Shanghai-era 17-field header.
+base = [
+    b'\\x11'*32, b'\\x22'*32, b'\\x33'*20, b'\\x44'*32, b'\\x55'*32,
+    b'\\x66'*32, b'\\x00'*256, b'', b'\\x01', b'\\x83\\xff\\xff\\xff',
+    b'', b'\\x83\\x01\\x02\\x03', b'', b'\\x77'*32, b'\\x00'*8,
+    b'\\x82\\x12\\x34',                # base_fee (field 15)
+    b'\\x99'*32,                        # withdrawals_root (field 16)
+]
+base[idx] = v
+header_rlp = rlp.encode(base)
+with open(sys.argv[1], 'wb') as f:
+    record = struct.pack('<Q', len(header_rlp)) + header_rlp
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/${prog}.elf -i "$in_file" -o "$out_file" -n 1000000 \
+    >"$REPO_ROOT/gen-out/${prog}_${name}.emu.log" 2>&1 || true
+
+  local actual; actual="$(dd if="$out_file" bs=1 skip=8 count=32 2>/dev/null | xxd -p | tr -d '\n')"
+  if [[ "$actual" == "$value" ]]; then
+    printf "  %-40s OK   root=%s...\n" "${prog}_${name}" "${actual:0:16}"
+    return 0
+  else
+    printf "  %-40s FAIL actual=%s expected=%s\n" "${prog}_${name}" "$actual" "$value"
+    return 1
+  fi
+}
+
+REPO_ROOT="$(pwd)"
+FAILED=0
+
+echo "==> emit zisk_header_extract_transactions_root ELF"
+lake exe codegen --program zisk_header_extract_transactions_root --halt linux93 \
+  -o gen-out/zisk_header_extract_transactions_root
+run_program "zisk_header_extract_transactions_root" "field4_matches" 4 \
+  "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899" || FAILED=1
+
+echo "==> emit zisk_header_extract_withdrawals_root ELF"
+lake exe codegen --program zisk_header_extract_withdrawals_root --halt linux93 \
+  -o gen-out/zisk_header_extract_withdrawals_root
+run_program "zisk_header_extract_withdrawals_root" "field16_matches" 16 \
+  "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef" || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: both transactions_root (field 4) and withdrawals_root (field 16) extractors work"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Two more tight standalone field extractors, completing the
"single-32B-field copy out" family started by K201 / K202 / K203:

- **K204** `header_extract_transactions_root` (field 4)
- **K205** `header_extract_withdrawals_root`  (field 16, Shanghai+)

Each mirrors the K201 shape verbatim.

## Test plan

Combined ziskemu fixture verifying both extractors against a
Shanghai-shape 17-field header.

## Stack

Builds on #6012 (PR-K203 `header_extract_receipts_root`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)