### PR TITLE
feat(div): add v4 algorithm bundle aliases

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/Algorithm.lean
+++ b/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/Algorithm.lean
@@ -28,6 +28,80 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 
+/-- The v4 algorithm's `un21` output as a function of `(uHi, uLo, vTop)`.
+
+    This is a named bundle alias for the existing source-of-truth v4
+    trial-call definition. It mirrors `algorithmUn21` from the v2 lower-bound
+    development while preserving the single implementation in
+    `DivMod.LoopBody.TrialCall`. -/
+@[irreducible]
+def algorithmUn21V4 (uHi uLo vTop : Word) : Word :=
+  divKTrialCallV4Un21 uHi uLo vTop
+
+/-- Named unfold for `algorithmUn21V4`. -/
+theorem algorithmUn21V4_unfold (uHi uLo vTop : Word) :
+    algorithmUn21V4 uHi uLo vTop =
+      (let un1 := divKTrialCallV4Un1 uLo
+       let q1'' := divKTrialCallV4Q1dd uHi uLo vTop
+       let rhat'' := divKTrialCallV4Rhatdd uHi uLo vTop
+       let cu_rhat_un1 := (rhat'' <<< (32 : BitVec 6).toNat) ||| un1
+       let cu_q1_dlo := q1'' * divKTrialCallV4DLo vTop
+       cu_rhat_un1 - cu_q1_dlo) := by
+  delta algorithmUn21V4
+  delta divKTrialCallV4Un21
+  rfl
+
+/-- The v4 algorithm's Phase-1b output `q1''`.
+
+    Named bundle alias for `divKTrialCallV4Q1dd`, matching the role of
+    `algorithmQ1Prime` in the v2 proof chain. -/
+@[irreducible]
+def algorithmQ1PrimeV4 (uHi uLo vTop : Word) : Word :=
+  divKTrialCallV4Q1dd uHi uLo vTop
+
+/-- Named unfold for `algorithmQ1PrimeV4`. -/
+theorem algorithmQ1PrimeV4_unfold (uHi uLo vTop : Word) :
+    algorithmQ1PrimeV4 uHi uLo vTop =
+      (let dHi := divKTrialCallV4DHi vTop
+       let dLo := divKTrialCallV4DLo vTop
+       let un1 := divKTrialCallV4Un1 uLo
+       let q1 := rv64_divu uHi dHi
+       let rhat := uHi - q1 * dHi
+       let hi1 := q1 >>> (32 : BitVec 6).toNat
+       let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
+       let rhatc := if hi1 = 0 then rhat else rhat + dHi
+       let qDlo := q1c * dLo
+       let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
+       let q1' := if BitVec.ult rhatUn1 qDlo then q1c + signExtend12 4095 else q1c
+       let rhat' := if BitVec.ult rhatUn1 qDlo then rhatc + dHi else rhatc
+       let rhatHi2 := rhat' >>> (32 : BitVec 6).toNat
+       let qDlo2 := q1' * dLo
+       let rhatUn1' := (rhat' <<< (32 : BitVec 6).toNat) ||| un1
+       if rhatHi2 = 0 ∧ BitVec.ult rhatUn1' qDlo2 then q1' + signExtend12 4095 else q1') := by
+  delta algorithmQ1PrimeV4
+  delta divKTrialCallV4Q1dd
+  rfl
+
+/-- The v4 algorithm's Phase-2 output `q0''`.
+
+    Named bundle alias for `divKTrialCallV4Q0dd`, matching the role of
+    `algorithmQ0Prime` in the v2 proof chain. -/
+@[irreducible]
+def algorithmQ0PrimeV4 (uHi uLo vTop : Word) : Word :=
+  divKTrialCallV4Q0dd uHi uLo vTop
+
+/-- Named unfold for `algorithmQ0PrimeV4`. -/
+theorem algorithmQ0PrimeV4_unfold (uHi uLo vTop : Word) :
+    algorithmQ0PrimeV4 uHi uLo vTop =
+      div128Quot_phase2b_q0'
+        (divKTrialCallV4Q0d uHi uLo vTop)
+        (divKTrialCallV4Rhat2d uHi uLo vTop)
+        (divKTrialCallV4DLo vTop)
+        (divKTrialCallV4Un0 uLo) := by
+  delta algorithmQ0PrimeV4
+  delta divKTrialCallV4Q0dd
+  rfl
+
 /-- Named unfold for `divKTrialCallV4Q1dd`: q1'' after Knuth's classical
     2-correction in Phase-1b. The full 14-step let-chain:
     Phase-1a (`q1`, `rhat`, `hi1`), Phase-1a correction (`q1c`, `rhatc`),


### PR DESCRIPTION
## Summary
- add irreducible aliases algorithmUn21V4, algorithmQ1PrimeV4, and algorithmQ0PrimeV4
- add named unfold lemmas for the aliases, backed by the existing v4 trial-call source definitions
- keep existing divKTrialCallV4*_unfold lemmas intact for downstream Knuth-A proofs

## Verification
- lake build EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV4.Algorithm
- lake build EvmAsm.Evm64.EvmWordArith
- lake build EvmAsm.Evm64
- git diff --check
- scripts/check-file-size.sh EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/Algorithm.lean
- forbidden proof-escape scan on touched file

Refs evm-asm-9iqmw.7.1.3.1.1.1.