### PR TITLE
feat(stateless): header_extract_ommers_hash + prev_randao (PR-K206 / K207)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -4508,6 +4508,8 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_header_extract_receipts_root" => some ziskHeaderExtractReceiptsRootProbeUnit
   | "zisk_header_extract_transactions_root" => some ziskHeaderExtractTransactionsRootProbeUnit
   | "zisk_header_extract_withdrawals_root" => some ziskHeaderExtractWithdrawalsRootProbeUnit
+  | "zisk_header_extract_ommers_hash" => some ziskHeaderExtractOmmersHashProbeUnit
+  | "zisk_header_extract_prev_randao" => some ziskHeaderExtractPrevRandaoProbeUnit
   | "zisk_block_validate_2tx_full" => some ziskBlockValidate2txFullProbeUnit
   | "zisk_block_body_extract_2tx" => some ziskBlockBodyExtract2txProbeUnit
   | "zisk_block_validate_2tx_full_with_body" => some ziskBlockValidate2txFullWithBodyProbeUnit
@@ -4727,6 +4729,8 @@ def knownProgramNames : List String :=
    "zisk_header_extract_receipts_root",
    "zisk_header_extract_transactions_root",
    "zisk_header_extract_withdrawals_root",
+   "zisk_header_extract_ommers_hash",
+   "zisk_header_extract_prev_randao",
    "zisk_block_validate_2tx_full",
    "zisk_block_body_extract_2tx",
    "zisk_block_validate_2tx_full_with_body",

--- a/EvmAsm/Codegen/Programs/Header.lean
+++ b/EvmAsm/Codegen/Programs/Header.lean
@@ -3827,4 +3827,142 @@ def ziskHeaderExtractWithdrawalsRootProbeUnit : BuildUnit := {
   dataAsm     := ziskHeaderExtractWithdrawalsRootDataSection
 }
 
+/-! ## header_extract_ommers_hash -- PR-K206
+
+    Extract `ommers_hash` (field 1, 32 bytes) -- post-merge
+    always equal to `keccak256(rlp([])) = 0x1dcc4de8...`. Tight
+    standalone analogue of K201..K205. -/
+def headerExtractOmmersHashFunction : String :=
+  "header_extract_ommers_hash:\n" ++
+  "  addi sp, sp, -32\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp)\n" ++
+  "  mv s0, a0\n" ++
+  "  mv s1, a1\n" ++
+  "  mv s2, a2\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 1\n" ++
+  "  la a3, heoh_offset; la a4, heoh_length\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lheoh_parse_fail\n" ++
+  "  la t0, heoh_length; ld t1, 0(t0)\n" ++
+  "  li t2, 32\n" ++
+  "  bne t1, t2, .Lheoh_size_fail\n" ++
+  "  la t0, heoh_offset; ld t1, 0(t0)\n" ++
+  "  add t3, s0, t1\n" ++
+  "  ld t4,  0(t3); sd t4,  0(s2)\n" ++
+  "  ld t4,  8(t3); sd t4,  8(s2)\n" ++
+  "  ld t4, 16(t3); sd t4, 16(s2)\n" ++
+  "  ld t4, 24(t3); sd t4, 24(s2)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lheoh_ret\n" ++
+  ".Lheoh_parse_fail:\n" ++
+  "  li a0, 1\n" ++
+  "  j .Lheoh_ret\n" ++
+  ".Lheoh_size_fail:\n" ++
+  "  li a0, 2\n" ++
+  ".Lheoh_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp)\n" ++
+  "  addi sp, sp, 32\n" ++
+  "  ret"
+
+def ziskHeaderExtractOmmersHashPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a7, 0x40000000\n" ++
+  "  ld a1, 8(a7)\n" ++
+  "  addi a0, a7, 16\n" ++
+  "  li a2, 0xa0010008\n" ++
+  "  jal ra, header_extract_ommers_hash\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lheoh_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  headerExtractOmmersHashFunction ++ "\n" ++
+  ".Lheoh_pdone:"
+
+def ziskHeaderExtractOmmersHashDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  "heoh_offset:\n" ++
+  "  .zero 8\n" ++
+  "heoh_length:\n" ++
+  "  .zero 8"
+
+def ziskHeaderExtractOmmersHashProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskHeaderExtractOmmersHashPrologue
+  dataAsm     := ziskHeaderExtractOmmersHashDataSection
+}
+
+/-! ## header_extract_prev_randao -- PR-K207
+
+    Extract `prev_randao` (field 13, 32 bytes; was `mix_hash`
+    pre-merge). Source of post-merge randomness. Tight
+    standalone analogue of the field-1/3/5 extractors. -/
+def headerExtractPrevRandaoFunction : String :=
+  "header_extract_prev_randao:\n" ++
+  "  addi sp, sp, -32\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp)\n" ++
+  "  mv s0, a0\n" ++
+  "  mv s1, a1\n" ++
+  "  mv s2, a2\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 13\n" ++
+  "  la a3, hepr_offset; la a4, hepr_length\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lhepr_parse_fail\n" ++
+  "  la t0, hepr_length; ld t1, 0(t0)\n" ++
+  "  li t2, 32\n" ++
+  "  bne t1, t2, .Lhepr_size_fail\n" ++
+  "  la t0, hepr_offset; ld t1, 0(t0)\n" ++
+  "  add t3, s0, t1\n" ++
+  "  ld t4,  0(t3); sd t4,  0(s2)\n" ++
+  "  ld t4,  8(t3); sd t4,  8(s2)\n" ++
+  "  ld t4, 16(t3); sd t4, 16(s2)\n" ++
+  "  ld t4, 24(t3); sd t4, 24(s2)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lhepr_ret\n" ++
+  ".Lhepr_parse_fail:\n" ++
+  "  li a0, 1\n" ++
+  "  j .Lhepr_ret\n" ++
+  ".Lhepr_size_fail:\n" ++
+  "  li a0, 2\n" ++
+  ".Lhepr_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp)\n" ++
+  "  addi sp, sp, 32\n" ++
+  "  ret"
+
+def ziskHeaderExtractPrevRandaoPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a7, 0x40000000\n" ++
+  "  ld a1, 8(a7)\n" ++
+  "  addi a0, a7, 16\n" ++
+  "  li a2, 0xa0010008\n" ++
+  "  jal ra, header_extract_prev_randao\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lhepr_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  headerExtractPrevRandaoFunction ++ "\n" ++
+  ".Lhepr_pdone:"
+
+def ziskHeaderExtractPrevRandaoDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  "hepr_offset:\n" ++
+  "  .zero 8\n" ++
+  "hepr_length:\n" ++
+  "  .zero 8"
+
+def ziskHeaderExtractPrevRandaoProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskHeaderExtractPrevRandaoPrologue
+  dataAsm     := ziskHeaderExtractPrevRandaoDataSection
+}
+
 end EvmAsm.Codegen

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **228**
-- ziskemu round-trip scripts: **220** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **230**
+- ziskemu round-trip scripts: **221** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/README.md
+++ b/README.md
@@ -291,6 +291,8 @@ block-body helpers
 `header_extract_receipts_root`,
 `header_extract_transactions_root`,
 `header_extract_withdrawals_root`,
+`header_extract_ommers_hash`,
+`header_extract_prev_randao`,
 withdrawal RLP/hash, …), and address
 derivation (`address_compute_create`, `address_compute_create2`,
 `address_from_pubkey`). The catalogue is tracked under the

--- a/scripts/codegen-zisk-header-extract-ommers-prev-randao-check.sh
+++ b/scripts/codegen-zisk-header-extract-ommers-prev-randao-check.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# codegen-zisk-header-extract-ommers-prev-randao-check.sh -- PR-K206 + K207.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+REPO_ROOT="$(pwd)"
+
+run_program() {
+  local prog="$1" field_index="$2" value="$3"
+  local in_file="$REPO_ROOT/gen-out/${prog}.input"
+  local out_file="$REPO_ROOT/gen-out/${prog}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+v = bytes.fromhex('$value')
+idx = $field_index
+base = [
+    b'\\x11'*32, b'\\x22'*32, b'\\x33'*20, b'\\x44'*32, b'\\x55'*32,
+    b'\\x66'*32, b'\\x00'*256, b'', b'\\x01', b'\\x83\\xff\\xff\\xff',
+    b'', b'\\x83\\x01\\x02\\x03', b'', b'\\x77'*32, b'\\x00'*8,
+    b'\\x82\\x12\\x34', b'\\x99'*32,
+]
+base[idx] = v
+header_rlp = rlp.encode(base)
+with open(sys.argv[1], 'wb') as f:
+    record = struct.pack('<Q', len(header_rlp)) + header_rlp
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/${prog}.elf -i "$in_file" -o "$out_file" -n 1000000 \
+    >"$REPO_ROOT/gen-out/${prog}.emu.log" 2>&1 || true
+
+  local actual; actual="$(dd if="$out_file" bs=1 skip=8 count=32 2>/dev/null | xxd -p | tr -d '\n')"
+  if [[ "$actual" == "$value" ]]; then
+    printf "  %-44s OK   field=%s...\n" "$prog" "${actual:0:16}"
+    return 0
+  else
+    printf "  %-44s FAIL actual=%s expected=%s\n" "$prog" "$actual" "$value"
+    return 1
+  fi
+}
+
+FAILED=0
+echo "==> emit zisk_header_extract_ommers_hash ELF"
+lake exe codegen --program zisk_header_extract_ommers_hash --halt linux93 \
+  -o gen-out/zisk_header_extract_ommers_hash
+run_program "zisk_header_extract_ommers_hash" 1 \
+  "1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347" || FAILED=1
+
+echo "==> emit zisk_header_extract_prev_randao ELF"
+lake exe codegen --program zisk_header_extract_prev_randao --halt linux93 \
+  -o gen-out/zisk_header_extract_prev_randao
+run_program "zisk_header_extract_prev_randao" 13 \
+  "deadbeefcafe1234deadbeefcafe1234deadbeefcafe1234deadbeefcafe1234" || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: ommers_hash (field 1) and prev_randao (field 13) extractors match"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Two more single-32B-field extractors:

- **K206** `header_extract_ommers_hash`  (field 1)
- **K207** `header_extract_prev_randao`  (field 13)

Each mirrors the K201 shape verbatim. Tested with a combined
ziskemu fixture.

## Stack

Builds on #6014.

🤖 Generated with [Claude Code](https://claude.com/claude-code)