### PR TITLE
feat(div): add v4 phase1b bridge helpers

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith.lean
+++ b/EvmAsm/Evm64/EvmWordArith.lean
@@ -53,4 +53,5 @@ import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV2
 import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV4.Algorithm
 import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV4.Phase2bNoFireBound
 import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV4.Phase2bFireBound
+import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV4.Phase1bBound
 import EvmAsm.Evm64.EvmWordArith.Div128CallSkipCloseV4

--- a/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/Algorithm.lean
+++ b/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/Algorithm.lean
@@ -28,6 +28,80 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 
+/-- The v4 algorithm's `un21` output as a function of `(uHi, uLo, vTop)`.
+
+    This is a named bundle alias for the existing source-of-truth v4
+    trial-call definition. It mirrors `algorithmUn21` from the v2 lower-bound
+    development while preserving the single implementation in
+    `DivMod.LoopBody.TrialCall`. -/
+@[irreducible]
+def algorithmUn21V4 (uHi uLo vTop : Word) : Word :=
+  divKTrialCallV4Un21 uHi uLo vTop
+
+/-- Named unfold for `algorithmUn21V4`. -/
+theorem algorithmUn21V4_unfold (uHi uLo vTop : Word) :
+    algorithmUn21V4 uHi uLo vTop =
+      (let un1 := divKTrialCallV4Un1 uLo
+       let q1'' := divKTrialCallV4Q1dd uHi uLo vTop
+       let rhat'' := divKTrialCallV4Rhatdd uHi uLo vTop
+       let cu_rhat_un1 := (rhat'' <<< (32 : BitVec 6).toNat) ||| un1
+       let cu_q1_dlo := q1'' * divKTrialCallV4DLo vTop
+       cu_rhat_un1 - cu_q1_dlo) := by
+  delta algorithmUn21V4
+  delta divKTrialCallV4Un21
+  rfl
+
+/-- The v4 algorithm's Phase-1b output `q1''`.
+
+    Named bundle alias for `divKTrialCallV4Q1dd`, matching the role of
+    `algorithmQ1Prime` in the v2 proof chain. -/
+@[irreducible]
+def algorithmQ1PrimeV4 (uHi uLo vTop : Word) : Word :=
+  divKTrialCallV4Q1dd uHi uLo vTop
+
+/-- Named unfold for `algorithmQ1PrimeV4`. -/
+theorem algorithmQ1PrimeV4_unfold (uHi uLo vTop : Word) :
+    algorithmQ1PrimeV4 uHi uLo vTop =
+      (let dHi := divKTrialCallV4DHi vTop
+       let dLo := divKTrialCallV4DLo vTop
+       let un1 := divKTrialCallV4Un1 uLo
+       let q1 := rv64_divu uHi dHi
+       let rhat := uHi - q1 * dHi
+       let hi1 := q1 >>> (32 : BitVec 6).toNat
+       let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
+       let rhatc := if hi1 = 0 then rhat else rhat + dHi
+       let qDlo := q1c * dLo
+       let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
+       let q1' := if BitVec.ult rhatUn1 qDlo then q1c + signExtend12 4095 else q1c
+       let rhat' := if BitVec.ult rhatUn1 qDlo then rhatc + dHi else rhatc
+       let rhatHi2 := rhat' >>> (32 : BitVec 6).toNat
+       let qDlo2 := q1' * dLo
+       let rhatUn1' := (rhat' <<< (32 : BitVec 6).toNat) ||| un1
+       if rhatHi2 = 0 ∧ BitVec.ult rhatUn1' qDlo2 then q1' + signExtend12 4095 else q1') := by
+  delta algorithmQ1PrimeV4
+  delta divKTrialCallV4Q1dd
+  rfl
+
+/-- The v4 algorithm's Phase-2 output `q0''`.
+
+    Named bundle alias for `divKTrialCallV4Q0dd`, matching the role of
+    `algorithmQ0Prime` in the v2 proof chain. -/
+@[irreducible]
+def algorithmQ0PrimeV4 (uHi uLo vTop : Word) : Word :=
+  divKTrialCallV4Q0dd uHi uLo vTop
+
+/-- Named unfold for `algorithmQ0PrimeV4`. -/
+theorem algorithmQ0PrimeV4_unfold (uHi uLo vTop : Word) :
+    algorithmQ0PrimeV4 uHi uLo vTop =
+      div128Quot_phase2b_q0'
+        (divKTrialCallV4Q0d uHi uLo vTop)
+        (divKTrialCallV4Rhat2d uHi uLo vTop)
+        (divKTrialCallV4DLo vTop)
+        (divKTrialCallV4Un0 uLo) := by
+  delta algorithmQ0PrimeV4
+  delta divKTrialCallV4Q0dd
+  rfl
+
 /-- Named unfold for `divKTrialCallV4Q1dd`: q1'' after Knuth's classical
     2-correction in Phase-1b. The full 14-step let-chain:
     Phase-1a (`q1`, `rhat`, `hi1`), Phase-1a correction (`q1c`, `rhatc`),

--- a/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/Phase1bBound.lean
+++ b/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/Phase1bBound.lean
@@ -64,6 +64,53 @@ theorem algorithmQ1dV4_rhatd_post
   unfold divKTrialCallV4DHi divKTrialCallV4DLo divKTrialCallV4Un1
   simpa using h
 
+/-- V4 spelling of the Phase-1b no-wrap fact for the pre-second-correction
+    product `q1' * dLo`. -/
+theorem algorithmQ1dV4_dLo_no_wrap
+    (uHi uLo vTop : Word)
+    (hvTop_ge : vTop.toNat ≥ 2^63)
+    (huHi_lt_vTop : uHi.toNat < vTop.toNat) :
+    ((algorithmQ1dV4 uHi uLo vTop) * divKTrialCallV4DLo vTop).toNat =
+      (algorithmQ1dV4 uHi uLo vTop).toNat * (divKTrialCallV4DLo vTop).toNat := by
+  have h := algorithmUn21_L1b_q1_prime_dLo_no_wrap uHi uLo vTop hvTop_ge huHi_lt_vTop
+  rw [algorithmQ1dV4_unfold]
+  unfold algorithmQ1Prime divKTrialCallV4DLo
+  simpa using h
+
+/-- The V4 final Phase-1b quotient wrapper is the generic second-correction
+    quotient instantiated with the v4 pre-second-correction pair. -/
+theorem divKTrialCallV4Q1dd_eq_phase2b_algorithm
+    (uHi uLo vTop : Word) :
+    divKTrialCallV4Q1dd uHi uLo vTop =
+      div128Quot_phase2b_q0'
+        (algorithmQ1dV4 uHi uLo vTop)
+        (algorithmRhatdV4 uHi uLo vTop)
+        (divKTrialCallV4DLo vTop)
+        (divKTrialCallV4Un1 uLo) := by
+  rw [← div128Quot_phase2b_q0'_and_form]
+  rw [algorithmQ1dV4_unfold, algorithmRhatdV4_unfold]
+  unfold algorithmQ1Prime divKTrialCallV4Q1dd
+  unfold divKTrialCallV4DHi divKTrialCallV4DLo divKTrialCallV4Un1
+  rfl
+
+/-- The V4 final Phase-1b remainder wrapper is the generic second-correction
+    remainder update instantiated with the v4 pre-second-correction pair. -/
+theorem divKTrialCallV4Rhatdd_eq_phase2b_algorithm
+    (uHi uLo vTop : Word) :
+    divKTrialCallV4Rhatdd uHi uLo vTop =
+      (if (algorithmRhatdV4 uHi uLo vTop) >>> (32 : BitVec 6).toNat = (0 : Word) ∧
+          BitVec.ult
+            (((algorithmRhatdV4 uHi uLo vTop) <<< (32 : BitVec 6).toNat) |||
+              divKTrialCallV4Un1 uLo)
+            ((algorithmQ1dV4 uHi uLo vTop) * divKTrialCallV4DLo vTop) then
+        algorithmRhatdV4 uHi uLo vTop + divKTrialCallV4DHi vTop
+       else
+        algorithmRhatdV4 uHi uLo vTop) := by
+  rw [algorithmQ1dV4_unfold, algorithmRhatdV4_unfold]
+  unfold algorithmQ1Prime divKTrialCallV4Rhatdd
+  unfold divKTrialCallV4DHi divKTrialCallV4DLo divKTrialCallV4Un1
+  rfl
+
 /-- Narrow-call Phase-1b overshoot bound for the pre-second-correction pair.
 
     This discharges the `h_overshoot_le_vTop` argument of

--- a/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/Phase1bBound.lean
+++ b/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/Phase1bBound.lean
@@ -6,6 +6,7 @@
 
 import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV4.Algorithm
 import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV2.QuotientBounds
+import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV2.Un21Bridge
 
 namespace EvmAsm.Evm64
 
@@ -51,6 +52,17 @@ theorem algorithmRhatdV4_unfold (uHi uLo vTop : Word) :
        if BitVec.ult rhatUn1 qDlo then rhatc + dHi else rhatc) := by
   delta algorithmRhatdV4
   rfl
+
+/-- Phase-1b Euclidean identity for the v4 pre-second-correction pair. -/
+theorem algorithmQ1dV4_rhatd_post
+    (uHi uLo vTop : Word)
+    (hvTop_ge : vTop.toNat ≥ 2^63) :
+    (algorithmQ1dV4 uHi uLo vTop).toNat * (divKTrialCallV4DHi vTop).toNat +
+      (algorithmRhatdV4 uHi uLo vTop).toNat = uHi.toNat := by
+  have h := algorithmUn21_L2a_wrapped uHi uLo vTop hvTop_ge
+  rw [algorithmQ1dV4_unfold, algorithmRhatdV4_unfold]
+  unfold divKTrialCallV4DHi divKTrialCallV4DLo divKTrialCallV4Un1
+  simpa using h
 
 /-- Narrow-call Phase-1b overshoot bound for the pre-second-correction pair.
 
@@ -107,5 +119,22 @@ theorem algorithmQ1dV4_dLo_overshoot_le_vTop_of_uHi_lt_dHi_pow32
     rw [h_vTop_decomp]
     ring
   nlinarith
+
+/-- Narrow-call Phase-1b overshoot bound, with the Phase-1b Euclidean identity
+    discharged internally. -/
+theorem algorithmQ1dV4_dLo_overshoot_le_vTop_of_uHi_lt_dHi_pow32_closed
+    (uHi uLo vTop : Word)
+    (hvTop_ge : vTop.toNat ≥ 2^63)
+    (huHi_lt_vTop : uHi.toNat < vTop.toNat)
+    (huHi_lt_dHi_pow32 :
+      uHi.toNat < (divKTrialCallV4DHi vTop).toNat * 2^32) :
+    (algorithmQ1dV4 uHi uLo vTop).toNat * (divKTrialCallV4DLo vTop).toNat ≤
+      (algorithmRhatdV4 uHi uLo vTop).toNat * 2^32 +
+        (divKTrialCallV4Un1 uLo).toNat +
+        (divKTrialCallV4DHi vTop).toNat * 2^32 +
+        (divKTrialCallV4DLo vTop).toNat := by
+  exact algorithmQ1dV4_dLo_overshoot_le_vTop_of_uHi_lt_dHi_pow32
+    uHi uLo vTop hvTop_ge huHi_lt_vTop huHi_lt_dHi_pow32
+    (algorithmQ1dV4_rhatd_post uHi uLo vTop hvTop_ge)
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/Phase1bBound.lean
+++ b/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/Phase1bBound.lean
@@ -1,0 +1,111 @@
+/-
+  EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV4.Phase1bBound
+
+  Algorithm-level Phase-1b facts for the v4 2-correction proof.
+-/
+
+import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV4.Algorithm
+import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV2.QuotientBounds
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64 EvmWord
+
+/-- The pre-second-correction Phase-1b quotient `q1'` used by v4. -/
+@[irreducible]
+def algorithmQ1dV4 (uHi uLo vTop : Word) : Word :=
+  algorithmQ1Prime uHi uLo vTop
+
+/-- The pre-second-correction Phase-1b remainder `rhat'` used by v4. -/
+@[irreducible]
+def algorithmRhatdV4 (uHi uLo vTop : Word) : Word :=
+  let dHi := divKTrialCallV4DHi vTop
+  let dLo := divKTrialCallV4DLo vTop
+  let un1 := divKTrialCallV4Un1 uLo
+  let q1 := rv64_divu uHi dHi
+  let rhat := uHi - q1 * dHi
+  let hi1 := q1 >>> (32 : BitVec 6).toNat
+  let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
+  let rhatc := if hi1 = 0 then rhat else rhat + dHi
+  let qDlo := q1c * dLo
+  let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
+  if BitVec.ult rhatUn1 qDlo then rhatc + dHi else rhatc
+
+theorem algorithmQ1dV4_unfold (uHi uLo vTop : Word) :
+    algorithmQ1dV4 uHi uLo vTop = algorithmQ1Prime uHi uLo vTop := by
+  delta algorithmQ1dV4
+  rfl
+
+theorem algorithmRhatdV4_unfold (uHi uLo vTop : Word) :
+    algorithmRhatdV4 uHi uLo vTop =
+      (let dHi := divKTrialCallV4DHi vTop
+       let dLo := divKTrialCallV4DLo vTop
+       let un1 := divKTrialCallV4Un1 uLo
+       let q1 := rv64_divu uHi dHi
+       let rhat := uHi - q1 * dHi
+       let hi1 := q1 >>> (32 : BitVec 6).toNat
+       let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
+       let rhatc := if hi1 = 0 then rhat else rhat + dHi
+       let qDlo := q1c * dLo
+       let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
+       if BitVec.ult rhatUn1 qDlo then rhatc + dHi else rhatc) := by
+  delta algorithmRhatdV4
+  rfl
+
+/-- Narrow-call Phase-1b overshoot bound for the pre-second-correction pair.
+
+    This discharges the `h_overshoot_le_vTop` argument of
+    `div128Quot_phase2b_q0'_dLo_bound_fire_case` in the
+    `uHi < dHi * 2^32` sub-regime. -/
+theorem algorithmQ1dV4_dLo_overshoot_le_vTop_of_uHi_lt_dHi_pow32
+    (uHi uLo vTop : Word)
+    (hvTop_ge : vTop.toNat ≥ 2^63)
+    (huHi_lt_vTop : uHi.toNat < vTop.toNat)
+    (huHi_lt_dHi_pow32 :
+      uHi.toNat < (divKTrialCallV4DHi vTop).toNat * 2^32)
+    (h_phase1b_post :
+      (algorithmQ1dV4 uHi uLo vTop).toNat * (divKTrialCallV4DHi vTop).toNat +
+        (algorithmRhatdV4 uHi uLo vTop).toNat = uHi.toNat) :
+    (algorithmQ1dV4 uHi uLo vTop).toNat * (divKTrialCallV4DLo vTop).toNat ≤
+      (algorithmRhatdV4 uHi uLo vTop).toNat * 2^32 +
+        (divKTrialCallV4Un1 uLo).toNat +
+        (divKTrialCallV4DHi vTop).toNat * 2^32 +
+        (divKTrialCallV4DLo vTop).toNat := by
+  have h_vTop_decomp : vTop.toNat =
+      (divKTrialCallV4DHi vTop).toNat * 2^32 +
+        (divKTrialCallV4DLo vTop).toNat := by
+    unfold divKTrialCallV4DHi divKTrialCallV4DLo
+    exact div128Quot_vTop_decomp vTop
+  have h_q_le0 := algorithmQ1Prime_le_q_true_1_plus_one uHi uLo vTop
+    hvTop_ge huHi_lt_vTop (by simpa [divKTrialCallV4DHi] using huHi_lt_dHi_pow32)
+  have h_q_le :
+      (algorithmQ1dV4 uHi uLo vTop).toNat ≤
+        (uHi.toNat * 2^32 + (divKTrialCallV4Un1 uLo).toNat) / vTop.toNat + 1 := by
+    rw [algorithmQ1dV4_unfold]
+    unfold divKTrialCallV4Un1
+    simpa using h_q_le0
+  have h_vTop_pos : 0 < vTop.toNat := by omega
+  have h_qV_le :
+      (algorithmQ1dV4 uHi uLo vTop).toNat * vTop.toNat ≤
+        (uHi.toNat * 2^32 + (divKTrialCallV4Un1 uLo).toNat) + vTop.toNat := by
+    have h_mul := Nat.mul_le_mul_right vTop.toNat h_q_le
+    have h_div_mul :=
+      Nat.div_mul_le_self
+        (uHi.toNat * 2^32 + (divKTrialCallV4Un1 uLo).toNat) vTop.toNat
+    nlinarith
+  have h_u_decomp : uHi.toNat * 2^32 =
+      (algorithmQ1dV4 uHi uLo vTop).toNat * (divKTrialCallV4DHi vTop).toNat * 2^32 +
+        (algorithmRhatdV4 uHi uLo vTop).toNat * 2^32 := by
+    have h := congrArg (fun x => x * 2^32) h_phase1b_post
+    nlinarith [Nat.add_mul
+      ((algorithmQ1dV4 uHi uLo vTop).toNat * (divKTrialCallV4DHi vTop).toNat)
+      (algorithmRhatdV4 uHi uLo vTop).toNat (2^32)]
+  have h_qV_expand :
+      (algorithmQ1dV4 uHi uLo vTop).toNat * vTop.toNat =
+        (algorithmQ1dV4 uHi uLo vTop).toNat * (divKTrialCallV4DHi vTop).toNat * 2^32 +
+          (algorithmQ1dV4 uHi uLo vTop).toNat * (divKTrialCallV4DLo vTop).toNat := by
+    rw [h_vTop_decomp]
+    ring
+  nlinarith
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add V4-facing no-wrap adapter for the Phase-1b pre-second-correction q1' * dLo product
- bridge divKTrialCallV4Q1dd to the generic div128Quot_phase2b_q0' helper
- bridge divKTrialCallV4Rhatdd to the matching generic second-correction remainder update

## Verification
- lake build EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV4.Phase1bBound
- lake build EvmAsm.Evm64
- git diff --check
- scripts/check-file-size.sh EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/Phase1bBound.lean
- rg -n "sorry|admit|axiom|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/Phase1bBound.lean