### PR TITLE
feat(stateless): block_hash_matches (PR-K209)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -4511,6 +4511,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_header_extract_ommers_hash" => some ziskHeaderExtractOmmersHashProbeUnit
   | "zisk_header_extract_prev_randao" => some ziskHeaderExtractPrevRandaoProbeUnit
   | "zisk_header_extract_beneficiary" => some ziskHeaderExtractBeneficiaryProbeUnit
+  | "zisk_block_hash_matches" => some ziskBlockHashMatchesProbeUnit
   | "zisk_block_validate_2tx_full" => some ziskBlockValidate2txFullProbeUnit
   | "zisk_block_body_extract_2tx" => some ziskBlockBodyExtract2txProbeUnit
   | "zisk_block_validate_2tx_full_with_body" => some ziskBlockValidate2txFullWithBodyProbeUnit
@@ -4733,6 +4734,7 @@ def knownProgramNames : List String :=
    "zisk_header_extract_ommers_hash",
    "zisk_header_extract_prev_randao",
    "zisk_header_extract_beneficiary",
+   "zisk_block_hash_matches",
    "zisk_block_validate_2tx_full",
    "zisk_block_body_extract_2tx",
    "zisk_block_validate_2tx_full_with_body",

--- a/EvmAsm/Codegen/Programs/Header.lean
+++ b/EvmAsm/Codegen/Programs/Header.lean
@@ -4050,4 +4050,86 @@ def ziskHeaderExtractBeneficiaryProbeUnit : BuildUnit := {
   dataAsm     := ziskHeaderExtractBeneficiaryDataSection
 }
 
+/-! ## block_hash_matches -- PR-K209
+
+    Given a header RLP and a caller-supplied claimed 32-byte
+    `block_hash`, verify that
+    `keccak256(header_rlp) == claimed_block_hash`. Returns the
+    predicate via the `is_valid` output.
+
+    Useful for light-client / bridge proofs where the caller
+    has a trusted block_hash from elsewhere and wants to confirm
+    the locally-held header RLP matches.
+
+    Calling convention:
+      a0 (input)  : header_rlp ptr
+      a1 (input)  : header_rlp byte length
+      a2 (input)  : claimed_block_hash ptr (32 bytes)
+      a3 (input)  : u64 out (is_valid: 1 if matches, else 0)
+      ra (input)  : return
+      a0 (output) : 0 (always succeeds; predicate is in is_valid) -/
+def blockHashMatchesFunction : String :=
+  "block_hash_matches:\n" ++
+  "  addi sp, sp, -32\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp)\n" ++
+  "  mv s0, a2                   # claimed_hash ptr\n" ++
+  "  mv s1, a3                   # is_valid out\n" ++
+  "  sd zero, 0(s1)\n" ++
+  "  # Compute keccak256(header_rlp) into bhm_computed\n" ++
+  "  la a2, bhm_computed\n" ++
+  "  jal ra, block_hash_from_header\n" ++
+  "  # Compare 32 bytes (4 × 8B)\n" ++
+  "  la t0, bhm_computed\n" ++
+  "  ld t2,  0(t0); ld t3,  0(s0); bne t2, t3, .Lbhm_neq\n" ++
+  "  ld t2,  8(t0); ld t3,  8(s0); bne t2, t3, .Lbhm_neq\n" ++
+  "  ld t2, 16(t0); ld t3, 16(s0); bne t2, t3, .Lbhm_neq\n" ++
+  "  ld t2, 24(t0); ld t3, 24(s0); bne t2, t3, .Lbhm_neq\n" ++
+  "  li t0, 1\n" ++
+  "  sd t0, 0(s1)\n" ++
+  ".Lbhm_neq:\n" ++
+  "  li a0, 0\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp)\n" ++
+  "  addi sp, sp, 32\n" ++
+  "  ret"
+
+/-- `zisk_block_hash_matches`: probe BuildUnit.
+    Input layout:
+      bytes  0.. 8 : header_rlp_len
+      bytes  8..40 : claimed_block_hash (32 B)
+      bytes 40..   : header_rlp
+    Output layout:
+      bytes  0.. 8 : status (always 0)
+      bytes  8..16 : is_valid -/
+def ziskBlockHashMatchesPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a7, 0x40000000\n" ++
+  "  ld a1, 8(a7)                # header_rlp_len\n" ++
+  "  addi a2, a7, 16             # claimed_hash ptr\n" ++
+  "  addi a0, a7, 48             # header_rlp ptr\n" ++
+  "  li a3, 0xa0010008           # is_valid out\n" ++
+  "  jal ra, block_hash_matches\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lbhm_pdone\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  blockHashFromHeaderFunction ++ "\n" ++
+  blockHashMatchesFunction ++ "\n" ++
+  ".Lbhm_pdone:"
+
+def ziskBlockHashMatchesDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  "bhm_computed:\n" ++
+  "  .zero 32"
+
+def ziskBlockHashMatchesProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskBlockHashMatchesPrologue
+  dataAsm     := ziskBlockHashMatchesDataSection
+}
+
 end EvmAsm.Codegen

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **231**
-- ziskemu round-trip scripts: **222** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **232**
+- ziskemu round-trip scripts: **223** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ block-body helpers
 `header_extract_ommers_hash`,
 `header_extract_prev_randao`,
 `header_extract_beneficiary`,
+`block_hash_matches`,
 withdrawal RLP/hash, …), and address
 derivation (`address_compute_create`, `address_compute_create2`,
 `address_from_pubkey`). The catalogue is tracked under the

--- a/scripts/codegen-zisk-block-hash-matches-check.sh
+++ b/scripts/codegen-zisk-block-hash-matches-check.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# codegen-zisk-block-hash-matches-check.sh -- PR-K209.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_block_hash_matches ELF"
+lake exe codegen --program zisk_block_hash_matches --halt linux93 \
+  -o gen-out/zisk_block_hash_matches
+
+REPO_ROOT="$(pwd)"
+
+# run_case <name> <break_claim 0/1> <exp_valid>
+run_case() {
+  local name="$1" break_claim="$2" exp_valid="$3"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_block_hash_matches_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_block_hash_matches_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+try:
+    from Crypto.Hash import keccak
+    def keccak256(b):
+        h = keccak.new(digest_bits=256); h.update(b); return h.digest()
+except Exception:
+    import sha3
+    def keccak256(b): return sha3.keccak_256(b).digest()
+
+bad = $break_claim == 1
+
+fields = [
+    b'\\x11'*32, b'\\x22'*32, b'\\x33'*20, b'\\x44'*32, b'\\x55'*32,
+    b'\\x66'*32, b'\\x00'*256, b'', b'\\x01', b'\\x83\\xff\\xff\\xff',
+    b'', b'\\x83\\x01\\x02\\x03', b'', b'\\x77'*32, b'\\x00'*8,
+]
+header_rlp = rlp.encode(fields)
+real = keccak256(header_rlp)
+claimed = bytes([b ^ 0xff for b in real]) if bad else real
+
+with open(sys.argv[1], 'wb') as f:
+    record = struct.pack('<Q', len(header_rlp)) + claimed + header_rlp
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_block_hash_matches.elf \
+    -i "$in_file" -o "$out_file" -n 1000000 \
+    >"$REPO_ROOT/gen-out/zisk_block_hash_matches_${name}.emu.log" 2>&1 || true
+
+  local status_le; status_le="$(xxd -p -l 8 "$out_file" | tr -d '\n')"
+  local valid_le;  valid_le="$( dd if="$out_file" bs=1 skip=8 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local valid
+  valid="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$valid_le'))[0])")"
+
+  if [[ "$valid" == "$exp_valid" ]]; then
+    printf "  %-26s OK   valid=%s\n" "$name" "$valid"
+    return 0
+  else
+    printf "  %-26s FAIL valid=%s/%s\n" "$name" "$valid" "$exp_valid"
+    return 1
+  fi
+}
+
+FAILED=0
+run_case "match"      0 1 || FAILED=1
+run_case "mismatch"   1 0 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: block_hash_matches verifies keccak256(header) == claim"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Given a header RLP and a caller-supplied claimed 32-byte
`block_hash`, verify that `keccak256(header_rlp) == claimed_hash`.
Returns the predicate via the `is_valid` output.

Useful for light-client / bridge proofs where the caller has a
trusted block_hash from elsewhere and wants to confirm the
locally-held header RLP matches.

## Test plan

2 ziskemu fixtures:

- [x] `match` -- correct hash -> valid=1
- [x] `mismatch` -- bit-flipped hash -> valid=0

## Stack

Builds on #6021 (PR-K208 `header_extract_beneficiary`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)