### PR TITLE
feat(div): add v4 phase1b no-fire dLo bridges

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/Phase1bBound.lean
+++ b/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/Phase1bBound.lean
@@ -166,6 +166,18 @@ theorem phase1b_q1_prime_toNat_of_fire
   rw [show q1c.toNat + (2^64 - 1) = (q1c.toNat - 1) + 2^64 from by omega,
       Nat.add_mod_right, Nat.mod_eq_of_lt h_q1c_lt_word]
 
+/-- If the first Phase-1b correction fires and the pre-correction quotient is
+    at most `qTrue + 2`, the corrected quotient is at most `qTrue + 1`. -/
+theorem phase1b_q1_prime_le_qtrue_plus_one_of_fire
+    (q1c dLo rhatUn1 : Word)
+    (qTrue : Nat)
+    (h_q1c_le : q1c.toNat ≤ qTrue + 2)
+    (h_fire : BitVec.ult rhatUn1 (q1c * dLo)) :
+    (if BitVec.ult rhatUn1 (q1c * dLo) then q1c + signExtend12 4095 else q1c).toNat ≤
+      qTrue + 1 := by
+  rw [phase1b_q1_prime_toNat_of_fire q1c dLo rhatUn1 h_fire]
+  omega
+
 /-- In the wide-`uHi` regime, the Phase-1a corrected quotient is `q1 - 1`. -/
 theorem divKTrialCallV4Q1c_toNat_of_dHi_pow32_le_uHi
     (uHi vTop : Word)
@@ -294,6 +306,40 @@ theorem algorithmQ1dV4_le_pow32_of_dHi_pow32_le_uHi
     simpa [dHi, dLo, un1, q1, rhat, hi1, q1c, rhatc, rhatUn1,
       divKTrialCallV4DHi, divKTrialCallV4DLo, divKTrialCallV4Un1] using h
   exact le_trans h_prime_le h_q1c_le
+
+/-- If the first Phase-1b correction fires, the V4 pre-second-correction
+    quotient satisfies the Knuth-style `qTrue + 1` upper bound. -/
+theorem algorithmQ1dV4_le_qtrue_plus_one_of_phase1b_fire
+    (uHi uLo vTop : Word)
+    (hvTop_ge : vTop.toNat ≥ 2^63)
+    (huHi_lt_vTop : uHi.toNat < vTop.toNat) :
+    let dHi := divKTrialCallV4DHi vTop
+    let dLo := divKTrialCallV4DLo vTop
+    let un1 := divKTrialCallV4Un1 uLo
+    let q1 := rv64_divu uHi dHi
+    let rhat := uHi - q1 * dHi
+    let hi1 := q1 >>> (32 : BitVec 6).toNat
+    let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
+    let rhatc := if hi1 = 0 then rhat else rhat + dHi
+    let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
+    BitVec.ult rhatUn1 (q1c * dLo) →
+      (algorithmQ1dV4 uHi uLo vTop).toNat ≤
+        (uHi.toNat * 2^32 + (divKTrialCallV4Un1 uLo).toNat) / vTop.toNat + 1 := by
+  intro dHi dLo un1 q1 rhat hi1 q1c rhatc rhatUn1 h_fire
+  have h_q1c_le0 := algorithmQ1Prime_step3_q1c_le_q_true_1_plus_two
+    uHi uLo vTop hvTop_ge huHi_lt_vTop
+  have h_q1c_le : q1c.toNat ≤
+      (uHi.toNat * 2^32 + un1.toNat) / vTop.toNat + 2 := by
+    simpa [dHi, dLo, un1, q1, hi1, q1c, divKTrialCallV4DHi,
+      divKTrialCallV4DLo, divKTrialCallV4Un1] using h_q1c_le0
+  have h_prime_le := phase1b_q1_prime_le_qtrue_plus_one_of_fire
+    q1c dLo rhatUn1
+    ((uHi.toNat * 2^32 + un1.toNat) / vTop.toNat)
+    h_q1c_le h_fire
+  rw [algorithmQ1dV4_unfold]
+  unfold algorithmQ1Prime
+  simpa [dHi, dLo, un1, q1, rhat, hi1, q1c, rhatc, rhatUn1,
+    divKTrialCallV4DHi, divKTrialCallV4DLo, divKTrialCallV4Un1] using h_prime_le
 
 /-- V4 spelling of the generic Phase-1b upper bound `q1' ≤ 2^32 + 1`. -/
 theorem algorithmQ1dV4_le_pow32_plus_one
@@ -445,6 +491,36 @@ theorem algorithmQ1dV4_dLo_overshoot_le_vTop_of_q_le_qtrue_plus_one
     rw [h_vTop_decomp]
     ring
   nlinarith
+
+/-- First-Phase-1b-fire overshoot discharge for the V4
+    pre-second-correction pair. -/
+theorem algorithmQ1dV4_dLo_overshoot_le_vTop_of_phase1b_fire
+    (uHi uLo vTop : Word)
+    (hvTop_ge : vTop.toNat ≥ 2^63)
+    (huHi_lt_vTop : uHi.toNat < vTop.toNat) :
+    let dHi := divKTrialCallV4DHi vTop
+    let dLo := divKTrialCallV4DLo vTop
+    let un1 := divKTrialCallV4Un1 uLo
+    let q1 := rv64_divu uHi dHi
+    let rhat := uHi - q1 * dHi
+    let hi1 := q1 >>> (32 : BitVec 6).toNat
+    let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
+    let rhatc := if hi1 = 0 then rhat else rhat + dHi
+    let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
+    BitVec.ult rhatUn1 (q1c * dLo) →
+      (algorithmQ1dV4 uHi uLo vTop).toNat * (divKTrialCallV4DLo vTop).toNat ≤
+        (algorithmRhatdV4 uHi uLo vTop).toNat * 2^32 +
+          (divKTrialCallV4Un1 uLo).toNat +
+          (divKTrialCallV4DHi vTop).toNat * 2^32 +
+          (divKTrialCallV4DLo vTop).toNat := by
+  intro dHi dLo un1 q1 rhat hi1 q1c rhatc rhatUn1 h_fire
+  have h_q_le := algorithmQ1dV4_le_qtrue_plus_one_of_phase1b_fire
+    uHi uLo vTop hvTop_ge huHi_lt_vTop
+  simp only [] at h_q_le
+  exact algorithmQ1dV4_dLo_overshoot_le_vTop_of_q_le_qtrue_plus_one
+    uHi uLo vTop
+    (h_q_le h_fire)
+    (algorithmQ1dV4_rhatd_post uHi uLo vTop hvTop_ge)
 
 /-- Narrow-call Phase-1b overshoot bound for the pre-second-correction pair.
 

--- a/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/Phase1bBound.lean
+++ b/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/Phase1bBound.lean
@@ -522,6 +522,50 @@ theorem algorithmQ1dV4_dLo_overshoot_le_vTop_of_phase1b_fire
     (h_q_le h_fire)
     (algorithmQ1dV4_rhatd_post uHi uLo vTop hvTop_ge)
 
+/-- If the first Phase-1b correction does not fire because `rhatc` already
+    has a nonzero high half, the dLo multiplication check is automatically
+    bounded at the Nat level. -/
+theorem phase1b_no_fire_dLo_bound_of_rhat_hi_nonzero
+    (q1c rhatc dLo un1 : Word)
+    (h_q1c_le : q1c.toNat ≤ 2^32)
+    (h_dLo_lt : dLo.toNat < 2^32)
+    (h_rhat_hi_ne : rhatc >>> (32 : BitVec 6).toNat ≠ (0 : Word)) :
+    q1c.toNat * dLo.toNat ≤ rhatc.toNat * 2^32 + un1.toNat := by
+  have h_rhat_ge : rhatc.toNat ≥ 2^32 := by
+    have h := (ushiftRight_ne_zero_iff (val := rhatc) ((32 : BitVec 6).toNat)).mp
+      h_rhat_hi_ne
+    simpa using h
+  have h_dLo_le : dLo.toNat ≤ 2^32 - 1 := by omega
+  have h_prod_le : q1c.toNat * dLo.toNat ≤ 2^32 * (2^32 - 1) :=
+    Nat.mul_le_mul h_q1c_le h_dLo_le
+  nlinarith
+
+/-- If the first Phase-1b correction does not fire while `rhatc` has zero
+    high half, the failed unsigned comparison is exactly the Nat-level dLo
+    bound. -/
+theorem phase1b_no_fire_dLo_bound_of_rhat_hi_zero
+    (q1c rhatc dLo un1 : Word)
+    (h_rhat_hi_zero : rhatc >>> (32 : BitVec 6).toNat = (0 : Word))
+    (h_un_lt : un1.toNat < 2^32)
+    (h_qdlo_no_wrap : (q1c * dLo).toNat = q1c.toNat * dLo.toNat)
+    (h_no_fire :
+      ¬ BitVec.ult ((rhatc <<< (32 : BitVec 6).toNat) ||| un1) (q1c * dLo)) :
+    q1c.toNat * dLo.toNat ≤ rhatc.toNat * 2^32 + un1.toNat := by
+  have h_rhat_lt : rhatc.toNat < 2^32 := by
+    have h := (ushiftRight_eq_zero_iff (val := rhatc) ((32 : BitVec 6).toNat)).mp
+      h_rhat_hi_zero
+    simpa using h
+  have h_le :
+      (q1c * dLo).toNat ≤ ((rhatc <<< (32 : BitVec 6).toNat) ||| un1).toNat := by
+    have h_not_lt := mt (EvmWord.ult_iff).mpr h_no_fire
+    omega
+  have h_combine :
+      ((rhatc <<< (32 : BitVec 6).toNat) ||| un1).toNat =
+        rhatc.toNat * 2^32 + un1.toNat := by
+    rw [show ((32 : BitVec 6).toNat : Nat) = 32 from by rfl]
+    exact halfword_combine rhatc un1 h_rhat_lt h_un_lt
+  omega
+
 /-- Narrow-call Phase-1b overshoot bound for the pre-second-correction pair.
 
     This discharges the `h_overshoot_le_vTop` argument of


### PR DESCRIPTION
Summary:
- adds `phase1b_no_fire_dLo_bound_of_rhat_hi_nonzero`
- adds `phase1b_no_fire_dLo_bound_of_rhat_hi_zero`
- factors the first Phase-1b no-fire dLo comparison into reusable generic Nat bridges for the remaining V4 wrapper proof

Verification:
- `lake build EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV4.Phase1bBound`
- `lake build EvmAsm.Evm64`
- `git diff --check`
- `scripts/check-file-size.sh EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/Phase1bBound.lean`
- `rg -n "sorry|admit|axiom|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/Phase1bBound.lean`