### PR TITLE
feat(stateless): header_extract_gas_used + gas_limit (PR-K210 / K211)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -4512,6 +4512,8 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_header_extract_prev_randao" => some ziskHeaderExtractPrevRandaoProbeUnit
   | "zisk_header_extract_beneficiary" => some ziskHeaderExtractBeneficiaryProbeUnit
   | "zisk_block_hash_matches" => some ziskBlockHashMatchesProbeUnit
+  | "zisk_header_extract_gas_used" => some ziskHeaderExtractGasUsedProbeUnit
+  | "zisk_header_extract_gas_limit" => some ziskHeaderExtractGasLimitProbeUnit
   | "zisk_block_validate_2tx_full" => some ziskBlockValidate2txFullProbeUnit
   | "zisk_block_body_extract_2tx" => some ziskBlockBodyExtract2txProbeUnit
   | "zisk_block_validate_2tx_full_with_body" => some ziskBlockValidate2txFullWithBodyProbeUnit
@@ -4735,6 +4737,8 @@ def knownProgramNames : List String :=
    "zisk_header_extract_prev_randao",
    "zisk_header_extract_beneficiary",
    "zisk_block_hash_matches",
+   "zisk_header_extract_gas_used",
+   "zisk_header_extract_gas_limit",
    "zisk_block_validate_2tx_full",
    "zisk_block_body_extract_2tx",
    "zisk_block_validate_2tx_full_with_body",

--- a/EvmAsm/Codegen/Programs/Header.lean
+++ b/EvmAsm/Codegen/Programs/Header.lean
@@ -4132,4 +4132,109 @@ def ziskBlockHashMatchesProbeUnit : BuildUnit := {
   dataAsm     := ziskBlockHashMatchesDataSection
 }
 
+/-! ## header_extract_gas_used / header_extract_gas_limit -- PR-K210 / K211
+
+    Two more u64 header-field extractors, completing the
+    `header_extract_*` u64 family alongside K198
+    (base_fee_per_gas):
+
+      K210  header_extract_gas_used   (field 10)
+      K211  header_extract_gas_limit  (field 9)
+
+    Each thin-wraps `rlp_field_to_u64` for the specific field
+    index. Useful for chain monitoring / fee-market analysis.
+
+    Calling convention (both):
+      a0 (input)  : header_rlp ptr
+      a1 (input)  : header_rlp byte length
+      a2 (input)  : u64 out ptr
+      ra (input)  : return
+      a0 (output) :
+        0 : success
+        1 : RLP parse failure / field missing
+        2 : field exceeds 8 bytes BE -/
+def headerExtractGasUsedFunction : String :=
+  "header_extract_gas_used:\n" ++
+  "  addi sp, sp, -16\n" ++
+  "  sd ra, 0(sp)\n" ++
+  "  mv a3, a2\n" ++
+  "  li a2, 10\n" ++
+  "  jal ra, rlp_field_to_u64\n" ++
+  "  ld ra, 0(sp)\n" ++
+  "  addi sp, sp, 16\n" ++
+  "  ret"
+
+def ziskHeaderExtractGasUsedPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a7, 0x40000000\n" ++
+  "  ld a1, 8(a7)\n" ++
+  "  addi a0, a7, 16\n" ++
+  "  li a2, 0xa0010008\n" ++
+  "  jal ra, header_extract_gas_used\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lhegu_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpFieldToU64Function ++ "\n" ++
+  headerExtractGasUsedFunction ++ "\n" ++
+  ".Lhegu_pdone:"
+
+def ziskHeaderExtractGasUsedDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  "rfu_offset:\n" ++
+  "  .zero 8\n" ++
+  "rfu_length:\n" ++
+  "  .zero 8"
+
+def ziskHeaderExtractGasUsedProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskHeaderExtractGasUsedPrologue
+  dataAsm     := ziskHeaderExtractGasUsedDataSection
+}
+
+def headerExtractGasLimitFunction : String :=
+  "header_extract_gas_limit:\n" ++
+  "  addi sp, sp, -16\n" ++
+  "  sd ra, 0(sp)\n" ++
+  "  mv a3, a2\n" ++
+  "  li a2, 9\n" ++
+  "  jal ra, rlp_field_to_u64\n" ++
+  "  ld ra, 0(sp)\n" ++
+  "  addi sp, sp, 16\n" ++
+  "  ret"
+
+def ziskHeaderExtractGasLimitPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a7, 0x40000000\n" ++
+  "  ld a1, 8(a7)\n" ++
+  "  addi a0, a7, 16\n" ++
+  "  li a2, 0xa0010008\n" ++
+  "  jal ra, header_extract_gas_limit\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lhegl_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpFieldToU64Function ++ "\n" ++
+  headerExtractGasLimitFunction ++ "\n" ++
+  ".Lhegl_pdone:"
+
+def ziskHeaderExtractGasLimitDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  "rfu_offset:\n" ++
+  "  .zero 8\n" ++
+  "rfu_length:\n" ++
+  "  .zero 8"
+
+def ziskHeaderExtractGasLimitProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskHeaderExtractGasLimitPrologue
+  dataAsm     := ziskHeaderExtractGasLimitDataSection
+}
+
 end EvmAsm.Codegen

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **232**
-- ziskemu round-trip scripts: **223** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **234**
+- ziskemu round-trip scripts: **224** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/README.md
+++ b/README.md
@@ -295,6 +295,8 @@ block-body helpers
 `header_extract_prev_randao`,
 `header_extract_beneficiary`,
 `block_hash_matches`,
+`header_extract_gas_used`,
+`header_extract_gas_limit`,
 withdrawal RLP/hash, …), and address
 derivation (`address_compute_create`, `address_compute_create2`,
 `address_from_pubkey`). The catalogue is tracked under the

--- a/scripts/codegen-zisk-header-extract-gas-u64s-check.sh
+++ b/scripts/codegen-zisk-header-extract-gas-u64s-check.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# codegen-zisk-header-extract-gas-u64s-check.sh -- PR-K210 / K211.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+REPO_ROOT="$(pwd)"
+
+run_program() {
+  local prog="$1" field_index="$2" value="$3"
+  local in_file="$REPO_ROOT/gen-out/${prog}.input"
+  local out_file="$REPO_ROOT/gen-out/${prog}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+v = $value
+idx = $field_index
+def u_be(n):
+    if n == 0: return b''
+    return n.to_bytes((n.bit_length() + 7) // 8, 'big')
+base = [
+    b'\\xa1'*32, b'\\xa2'*32, b'\\xa3'*20, b'\\xa4'*32, b'\\xa5'*32,
+    b'\\xa6'*32, b'\\x00'*256, b'', b'\\x01', b'\\x83\\xff\\xff\\xff',
+    b'', b'\\x83\\x01\\x02\\x03', b'', b'\\xa7'*32, b'\\x00'*8,
+]
+base[idx] = u_be(v)
+header_rlp = rlp.encode(base)
+with open(sys.argv[1], 'wb') as f:
+    record = struct.pack('<Q', len(header_rlp)) + header_rlp
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/${prog}.elf -i "$in_file" -o "$out_file" -n 1000000 \
+    >"$REPO_ROOT/gen-out/${prog}.emu.log" 2>&1 || true
+
+  local v_le; v_le="$(dd if="$out_file" bs=1 skip=8 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local actual
+  actual="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$v_le'))[0])")"
+  if [[ "$actual" == "$value" ]]; then
+    printf "  %-40s OK   value=%s\n" "$prog" "$actual"
+    return 0
+  else
+    printf "  %-40s FAIL actual=%s expected=%s\n" "$prog" "$actual" "$value"
+    return 1
+  fi
+}
+
+FAILED=0
+echo "==> emit zisk_header_extract_gas_used ELF"
+lake exe codegen --program zisk_header_extract_gas_used --halt linux93 \
+  -o gen-out/zisk_header_extract_gas_used
+run_program "zisk_header_extract_gas_used" 10 12345678 || FAILED=1
+
+echo "==> emit zisk_header_extract_gas_limit ELF"
+lake exe codegen --program zisk_header_extract_gas_limit --halt linux93 \
+  -o gen-out/zisk_header_extract_gas_limit
+run_program "zisk_header_extract_gas_limit" 9 30000000 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: gas_used / gas_limit u64 extractors match"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Two more u64 header-field extractors, completing the
`header_extract_*` u64 family alongside K198 (`base_fee_per_gas`):

- **K210** `header_extract_gas_used`  (field 10)
- **K211** `header_extract_gas_limit` (field 9)

Each thin-wraps `rlp_field_to_u64` for the specific field index.

## Test plan

2 ziskemu fixtures (one per extractor).

## Stack

Builds on #6026 (PR-K209 `block_hash_matches`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)