### PR TITLE
feat(stateless): block_validate_block_hash_pair (PR-K212)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -4514,6 +4514,7 @@ def lookupProgram : String → Option BuildUnit
   | "zisk_block_hash_matches" => some ziskBlockHashMatchesProbeUnit
   | "zisk_header_extract_gas_used" => some ziskHeaderExtractGasUsedProbeUnit
   | "zisk_header_extract_gas_limit" => some ziskHeaderExtractGasLimitProbeUnit
+  | "zisk_block_validate_block_hash_pair" => some ziskBlockValidateBlockHashPairProbeUnit
   | "zisk_block_validate_2tx_full" => some ziskBlockValidate2txFullProbeUnit
   | "zisk_block_body_extract_2tx" => some ziskBlockBodyExtract2txProbeUnit
   | "zisk_block_validate_2tx_full_with_body" => some ziskBlockValidate2txFullWithBodyProbeUnit
@@ -4739,6 +4740,7 @@ def knownProgramNames : List String :=
    "zisk_block_hash_matches",
    "zisk_header_extract_gas_used",
    "zisk_header_extract_gas_limit",
+   "zisk_block_validate_block_hash_pair",
    "zisk_block_validate_2tx_full",
    "zisk_block_body_extract_2tx",
    "zisk_block_validate_2tx_full_with_body",

--- a/EvmAsm/Codegen/Programs/Header.lean
+++ b/EvmAsm/Codegen/Programs/Header.lean
@@ -4237,4 +4237,124 @@ def ziskHeaderExtractGasLimitProbeUnit : BuildUnit := {
   dataAsm     := ziskHeaderExtractGasLimitDataSection
 }
 
+/-! ## block_validate_block_hash_pair -- PR-K212
+
+    Compute both `parent_block_hash` and `child_block_hash`
+    AND verify `child.parent_hash == parent_block_hash`. Useful
+    for chain-commitment proofs that need both hashes alongside
+    the validity bit.
+
+    Composes K172 `block_hash_from_header` (parent + child) +
+    K20 `rlp_list_nth_item` (extract child.parent_hash).
+
+    Calling convention:
+      a0 (input)  : parent_rlp ptr
+      a1 (input)  : parent_rlp byte length
+      a2 (input)  : child_rlp ptr
+      a3 (input)  : child_rlp byte length
+      a4 (input)  : 32-byte output ptr (parent_block_hash)
+      a5 (input)  : 32-byte output ptr (child_block_hash)
+      a6 (input)  : u64 out (is_valid: 1 if child.parent_hash
+                              == parent_block_hash, else 0)
+      ra (input)  : return
+      a0 (output) :
+        0 : success -- both hashes + predicate written
+        1 : child RLP parse failure / field 0 missing
+        2 : child.parent_hash length != 32 -/
+def blockValidateBlockHashPairFunction : String :=
+  "block_validate_block_hash_pair:\n" ++
+  "  addi sp, sp, -64\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp)\n" ++
+  "  mv s0, a0; mv s1, a1                # parent\n" ++
+  "  mv s2, a2; mv s3, a3                # child\n" ++
+  "  mv s4, a4                            # parent_hash out\n" ++
+  "  mv s5, a5                            # child_hash out\n" ++
+  "  mv s6, a6                            # is_valid out\n" ++
+  "  sd zero, 0(s6)\n" ++
+  "  # 1. Compute parent block_hash -> s4\n" ++
+  "  mv a0, s0; mv a1, s1; mv a2, s4\n" ++
+  "  jal ra, block_hash_from_header\n" ++
+  "  # 2. Compute child block_hash -> s5\n" ++
+  "  mv a0, s2; mv a1, s3; mv a2, s5\n" ++
+  "  jal ra, block_hash_from_header\n" ++
+  "  # 3. Extract child.field[0] (parent_hash)\n" ++
+  "  mv a0, s2; mv a1, s3; li a2, 0\n" ++
+  "  la a3, bvhp_offset; la a4, bvhp_length\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lbvhp_parse_fail\n" ++
+  "  la t0, bvhp_length; ld t1, 0(t0)\n" ++
+  "  li t2, 32\n" ++
+  "  bne t1, t2, .Lbvhp_size_fail\n" ++
+  "  # 4. Compare child.parent_hash bytes against s4 (parent_hash)\n" ++
+  "  la t0, bvhp_offset; ld t1, 0(t0)\n" ++
+  "  add t3, s2, t1\n" ++
+  "  ld t4,  0(t3); ld t5,  0(s4); bne t4, t5, .Lbvhp_neq\n" ++
+  "  ld t4,  8(t3); ld t5,  8(s4); bne t4, t5, .Lbvhp_neq\n" ++
+  "  ld t4, 16(t3); ld t5, 16(s4); bne t4, t5, .Lbvhp_neq\n" ++
+  "  ld t4, 24(t3); ld t5, 24(s4); bne t4, t5, .Lbvhp_neq\n" ++
+  "  li t0, 1\n" ++
+  "  sd t0, 0(s6)\n" ++
+  ".Lbvhp_neq:\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lbvhp_ret\n" ++
+  ".Lbvhp_parse_fail:\n" ++
+  "  li a0, 1\n" ++
+  "  j .Lbvhp_ret\n" ++
+  ".Lbvhp_size_fail:\n" ++
+  "  li a0, 2\n" ++
+  ".Lbvhp_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp)\n" ++
+  "  addi sp, sp, 64\n" ++
+  "  ret"
+
+/-- `zisk_block_validate_block_hash_pair`: probe BuildUnit.
+    Input layout:
+      bytes  0.. 8 : parent_rlp_len
+      bytes  8..16 : child_rlp_len
+      bytes 16..   : parent_rlp || child_rlp
+    Output layout:
+      bytes  0.. 8 : status
+      bytes  8..16 : is_valid
+      bytes 16..48 : parent_block_hash
+      bytes 48..80 : child_block_hash -/
+def ziskBlockValidateBlockHashPairPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a7, 0x40000000\n" ++
+  "  ld a1, 8(a7)                # parent_len\n" ++
+  "  ld a3, 16(a7)               # child_len\n" ++
+  "  addi a0, a7, 24             # parent_rlp ptr\n" ++
+  "  add a2, a0, a1              # child_rlp ptr\n" ++
+  "  li a4, 0xa0010010           # parent_hash out\n" ++
+  "  li a5, 0xa0010030           # child_hash out\n" ++
+  "  li a6, 0xa0010008           # is_valid out\n" ++
+  "  jal ra, block_validate_block_hash_pair\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lbvhp_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  zkvmKeccak256Function ++ "\n" ++
+  blockHashFromHeaderFunction ++ "\n" ++
+  blockValidateBlockHashPairFunction ++ "\n" ++
+  ".Lbvhp_pdone:"
+
+def ziskBlockValidateBlockHashPairDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  "bvhp_offset:\n" ++
+  "  .zero 8\n" ++
+  "bvhp_length:\n" ++
+  "  .zero 8"
+
+def ziskBlockValidateBlockHashPairProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskBlockValidateBlockHashPairPrologue
+  dataAsm     := ziskBlockValidateBlockHashPairDataSection
+}
+
 end EvmAsm.Codegen

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **234**
-- ziskemu round-trip scripts: **224** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **235**
+- ziskemu round-trip scripts: **225** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ block-body helpers
 `block_hash_matches`,
 `header_extract_gas_used`,
 `header_extract_gas_limit`,
+`block_validate_block_hash_pair`,
 withdrawal RLP/hash, …), and address
 derivation (`address_compute_create`, `address_compute_create2`,
 `address_from_pubkey`). The catalogue is tracked under the

--- a/scripts/codegen-zisk-block-validate-block-hash-pair-check.sh
+++ b/scripts/codegen-zisk-block-validate-block-hash-pair-check.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# codegen-zisk-block-validate-block-hash-pair-check.sh -- PR-K212.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_block_validate_block_hash_pair ELF"
+lake exe codegen --program zisk_block_validate_block_hash_pair --halt linux93 \
+  -o gen-out/zisk_block_validate_block_hash_pair
+
+REPO_ROOT="$(pwd)"
+
+run_case() {
+  local name="$1" break_link="$2" exp_valid="$3"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_block_validate_block_hash_pair_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_block_validate_block_hash_pair_${name}.output"
+  local exp_hashes_file="$REPO_ROOT/gen-out/zisk_block_validate_block_hash_pair_${name}.expected.hex"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+try:
+    from Crypto.Hash import keccak
+    def keccak256(b):
+        h = keccak.new(digest_bits=256); h.update(b); return h.digest()
+except Exception:
+    import sha3
+    def keccak256(b): return sha3.keccak_256(b).digest()
+
+bad = $break_link == 1
+
+parent_fields = [
+    b'\\xa1'*32, b'\\xa2'*32, b'\\xa3'*20, b'\\xa4'*32, b'\\xa5'*32,
+    b'\\xa6'*32, b'\\x00'*256, b'', b'\\x01', b'\\x83\\xff\\xff\\xff',
+    b'', b'\\x83\\x01\\x02\\x03', b'', b'\\xa7'*32, b'\\x00'*8,
+]
+parent_rlp = rlp.encode(parent_fields)
+parent_hash = keccak256(parent_rlp)
+
+claimed = bytes([b ^ 0xff for b in parent_hash]) if bad else parent_hash
+
+child_fields = [
+    claimed, b'\\xb2'*32, b'\\xb3'*20, b'\\xb4'*32, b'\\xb5'*32,
+    b'\\xb6'*32, b'\\x00'*256, b'', b'\\x02', b'\\x83\\xff\\xff\\xff',
+    b'', b'\\x83\\x01\\x02\\x04', b'', b'\\xb7'*32, b'\\x00'*8,
+]
+child_rlp = rlp.encode(child_fields)
+child_hash = keccak256(child_rlp)
+
+with open(sys.argv[1], 'wb') as f:
+    record = struct.pack('<Q', len(parent_rlp)) + \
+             struct.pack('<Q', len(child_rlp)) + \
+             parent_rlp + child_rlp
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\x00' * pad)
+with open(sys.argv[2], 'w') as f:
+    f.write(parent_hash.hex() + ',' + child_hash.hex())
+" "$in_file" "$exp_hashes_file"
+
+  "$ZISKEMU" -e gen-out/zisk_block_validate_block_hash_pair.elf \
+    -i "$in_file" -o "$out_file" -n 2000000 \
+    >"$REPO_ROOT/gen-out/zisk_block_validate_block_hash_pair_${name}.emu.log" 2>&1 || true
+
+  local valid_le; valid_le="$(dd if="$out_file" bs=1 skip=8 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local parent_hash; parent_hash="$(dd if="$out_file" bs=1 skip=16 count=32 2>/dev/null | xxd -p | tr -d '\n')"
+  local child_hash;  child_hash="$( dd if="$out_file" bs=1 skip=48 count=32 2>/dev/null | xxd -p | tr -d '\n')"
+  local valid
+  valid="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$valid_le'))[0])")"
+  local exp_parent="$(cut -d, -f1 "$exp_hashes_file")"
+  local exp_child="$(cut -d, -f2 "$exp_hashes_file")"
+
+  if [[ "$valid" == "$exp_valid" && "$parent_hash" == "$exp_parent" && "$child_hash" == "$exp_child" ]]; then
+    printf "  %-26s OK   valid=%s parent=%s... child=%s...\n" "$name" "$valid" "${parent_hash:0:16}" "${child_hash:0:16}"
+    return 0
+  else
+    printf "  %-26s FAIL valid=%s/%s phash=%s/exp%s chash=%s/exp%s\n" \
+      "$name" "$valid" "$exp_valid" "$parent_hash" "$exp_parent" "$child_hash" "$exp_child"
+    return 1
+  fi
+}
+
+FAILED=0
+run_case "matching_link" 0 1 || FAILED=1
+run_case "broken_link"   1 0 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: block_validate_block_hash_pair outputs both hashes + validity"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Compute both `parent_block_hash` AND `child_block_hash` AND
verify `child.parent_hash == parent_block_hash`. Useful for
chain-commitment proofs that need both hashes alongside the
validity bit (e.g., chain anchoring, light-client headers).

## Test plan

2 ziskemu fixtures: matching link -> valid=1, bit-flipped claim
-> valid=0. Both fixtures also assert both block_hashes match
the Python keccak256 reference.

## Stack

Builds on #6031 (PR-K210 / K211).

🤖 Generated with [Claude Code](https://claude.com/claude-code)