### PR TITLE
feat(div): add v4 q0d lower-bound wrappers

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith.lean
+++ b/EvmAsm/Evm64/EvmWordArith.lean
@@ -55,4 +55,5 @@ import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV4.Phase2bNoFireBound
 import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV4.Phase2bFireBound
 import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV4.Phase1bBound
 import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV4.Un21Bound
+import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV4.QuotientBounds
 import EvmAsm.Evm64.EvmWordArith.Div128CallSkipCloseV4

--- a/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/QuotientBounds.lean
+++ b/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/QuotientBounds.lean
@@ -1,0 +1,78 @@
+/-
+  EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV4.QuotientBounds
+
+  Word-to-Nat bridge wrappers for the v4 trial-call quotient digits.
+  These keep downstream exact-quotient proofs phrased in terms of the
+  source-of-truth `divKTrialCallV4*` definitions while reusing the generic
+  Knuth lower-bound lemmas.
+-/
+
+import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV4.Algorithm
+import EvmAsm.Evm64.EvmWordArith.Div128KnuthLower
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Phase 2 first-correction lower bound, wrapped for the v4 trial-call
+    definitions.
+
+    This is the v4 analogue of `algorithmQ0Prime_ge_q_true_0`: under
+    `un21 < dHi * 2^32`, the first-corrected second quotient digit `Q0d`
+    is at least the true second Knuth digit. -/
+theorem divKTrialCallV4Q0d_ge_q_true_0_of_un21_lt_dHi_mul_pow32
+    (uHi uLo vTop : Word)
+    (hdHi_ge : (divKTrialCallV4DHi vTop).toNat ≥ 2^31)
+    (hdHi_lt : (divKTrialCallV4DHi vTop).toNat < 2^32)
+    (hdLo_lt : (divKTrialCallV4DLo vTop).toNat < 2^32)
+    (hUn21_lt_dHi_pow32 :
+      (divKTrialCallV4Un21 uHi uLo vTop).toNat <
+        (divKTrialCallV4DHi vTop).toNat * 2^32)
+    (hUn21_lt_vTop :
+      (divKTrialCallV4Un21 uHi uLo vTop).toNat <
+        (divKTrialCallV4DHi vTop).toNat * 2^32 +
+          (divKTrialCallV4DLo vTop).toNat) :
+    ((divKTrialCallV4Un21 uHi uLo vTop).toNat * 2^32 +
+        (divKTrialCallV4Un0 uLo).toNat) /
+      ((divKTrialCallV4DHi vTop).toNat * 2^32 +
+        (divKTrialCallV4DLo vTop).toNat) ≤
+    (divKTrialCallV4Q0d uHi uLo vTop).toNat := by
+  unfold divKTrialCallV4Q0d divKTrialCallV4Q0c divKTrialCallV4Rhat2c divKTrialCallV4Un0
+  exact
+    div128Quot_q0_prime_ge_q_true_0_of_un21_lt_dHi_mul_pow32
+      (divKTrialCallV4Un21 uHi uLo vTop)
+      (divKTrialCallV4DHi vTop)
+      (divKTrialCallV4DLo vTop)
+      uLo
+      hdHi_ge hdHi_lt hdLo_lt hUn21_lt_dHi_pow32 hUn21_lt_vTop
+
+/-- Phase 2 first-correction lower bound, wrapped for the v4 trial-call
+    definitions.
+
+    Variant for the complementary easy hypothesis `un21 < 2^63`, matching
+    the generic KB-LB8 theorem. -/
+theorem divKTrialCallV4Q0d_ge_q_true_0_of_un21_lt_pow63
+    (uHi uLo vTop : Word)
+    (hdHi_ge : (divKTrialCallV4DHi vTop).toNat ≥ 2^31)
+    (hdHi_lt : (divKTrialCallV4DHi vTop).toNat < 2^32)
+    (hdLo_lt : (divKTrialCallV4DLo vTop).toNat < 2^32)
+    (hUn21_lt_pow63 : (divKTrialCallV4Un21 uHi uLo vTop).toNat < 2^63)
+    (hUn21_lt_vTop :
+      (divKTrialCallV4Un21 uHi uLo vTop).toNat <
+        (divKTrialCallV4DHi vTop).toNat * 2^32 +
+          (divKTrialCallV4DLo vTop).toNat) :
+    ((divKTrialCallV4Un21 uHi uLo vTop).toNat * 2^32 +
+        (divKTrialCallV4Un0 uLo).toNat) /
+      ((divKTrialCallV4DHi vTop).toNat * 2^32 +
+        (divKTrialCallV4DLo vTop).toNat) ≤
+    (divKTrialCallV4Q0d uHi uLo vTop).toNat := by
+  unfold divKTrialCallV4Q0d divKTrialCallV4Q0c divKTrialCallV4Rhat2c divKTrialCallV4Un0
+  exact
+    div128Quot_q0_prime_ge_q_true_0_of_un21_lt_pow63
+      (divKTrialCallV4Un21 uHi uLo vTop)
+      (divKTrialCallV4DHi vTop)
+      (divKTrialCallV4DLo vTop)
+      uLo
+      hdHi_ge hdHi_lt hdLo_lt hUn21_lt_pow63 hUn21_lt_vTop
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add V4 QuotientBounds wrappers for Q0d lower bounds under un21 < dHi*2^32 and un21 < 2^63
- import the new wrapper module from EvmWordArith

## Notes
- This is a prep slice for evm-asm-9iqmw.7.1.3.1.1.3; it does not close the exact-quotient bead yet.
- The remaining step is preserving the lower bound across the V4 second correction to Q0dd, then composing with the existing Q1dd exactness and half-word identity.

## Verification
- lake build EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV4.QuotientBounds
- lake build EvmAsm.Evm64.EvmWordArith
- git diff --check
- scripts/check-file-size.sh EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/QuotientBounds.lean EvmAsm/Evm64/EvmWordArith.lean
- scripts/check-unimported.sh
- rg -n "set_option maxHeartbeats|set_option maxRecDepth|sorry|admit" EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/QuotientBounds.lean