### PR TITLE
feat(div): preserve v4 q0dd lower bound on outer guard

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/QuotientBounds.lean
+++ b/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/QuotientBounds.lean
@@ -130,4 +130,29 @@ theorem divKTrialCallV4Q0d_le_q_true_0_plus_one_of_un21_lt_pow63
         (divKTrialCallV4DHi vTop)
         hdHi_ne hUn21_lt_pow63 hdHi_ge hdHi_lt
 
+/-- V4 second-correction outer-guard no-fire preservation.
+
+    If the high half of `Rhat2d` is nonzero, the second correction in
+    `Q0dd` does not run and `Q0dd = Q0d`. Any lower bound already proved
+    for `Q0d` therefore transfers unchanged to `Q0dd`. -/
+theorem divKTrialCallV4Q0dd_ge_q_true_0_of_q0d_ge_of_rhat2d_hi_ne
+    (uHi uLo vTop : Word)
+    (hQ0d_ge :
+      ((divKTrialCallV4Un21 uHi uLo vTop).toNat * 2^32 +
+          (divKTrialCallV4Un0 uLo).toNat) /
+        ((divKTrialCallV4DHi vTop).toNat * 2^32 +
+          (divKTrialCallV4DLo vTop).toNat) ≤
+      (divKTrialCallV4Q0d uHi uLo vTop).toNat)
+    (hRhat2d_hi_ne :
+      divKTrialCallV4Rhat2d uHi uLo vTop >>> (32 : BitVec 6).toNat ≠ 0) :
+    ((divKTrialCallV4Un21 uHi uLo vTop).toNat * 2^32 +
+        (divKTrialCallV4Un0 uLo).toNat) /
+      ((divKTrialCallV4DHi vTop).toNat * 2^32 +
+        (divKTrialCallV4DLo vTop).toNat) ≤
+    (divKTrialCallV4Q0dd uHi uLo vTop).toNat := by
+  rw [divKTrialCallV4Q0dd_unfold]
+  unfold div128Quot_phase2b_q0'
+  rw [if_neg hRhat2d_hi_ne]
+  exact hQ0d_ge
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add a V4 Q0dd lower-bound preservation wrapper for the outer-guard no-fire case
- when Rhat2d >>> 32 is nonzero, Q0dd unfolds to Q0d, so any Q0d lower bound transfers directly

## Notes
- This is a prep slice for evm-asm-9iqmw.7.1.3.1.1.3; it does not close the exact-quotient bead yet.
- Remaining work: handle the inner product-check branch when Rhat2d >>> 32 = 0, then compose the full 128/64 exact quotient theorem.

## Verification
- lake build EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV4.QuotientBounds
- lake build EvmAsm.Evm64.EvmWordArith
- git diff --check
- scripts/check-file-size.sh EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/QuotientBounds.lean
- scripts/check-unimported.sh
- rg -n "set_option maxHeartbeats|set_option maxRecDepth|sorry|admit" EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/QuotientBounds.lean