### PR TITLE
feat(div): bridge v4 q0d product check

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/QuotientBounds.lean
+++ b/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/QuotientBounds.lean
@@ -231,4 +231,45 @@ theorem divKTrialCallV4Q0dd_ge_q_true_0_of_q0d_gt_of_fire
   rw [h_dec]
   omega
 
+/-- Nat-level product-check bridge for the v4 Phase-2 second digit.
+
+    This specializes the generic product-check implication to the v4 names:
+    once `Q0d` and `Rhat2d` satisfy the Euclidean relation against `un21`,
+    a strict product-check failure means `Q0d` is strictly above the true
+    second Knuth digit. The remaining Word-level fire case only has to
+    convert `BLTU ((Rhat2d << 32) | un0) (Q0d*dLo)` into `hProd_gt`. -/
+theorem divKTrialCallV4Q0d_gt_q_true_0_of_prod_gt
+    (uHi uLo vTop : Word)
+    (hDen_pos :
+      0 < (divKTrialCallV4DHi vTop).toNat * 2^32 +
+        (divKTrialCallV4DLo vTop).toNat)
+    (hRhat_eq :
+      (divKTrialCallV4Rhat2d uHi uLo vTop).toNat =
+        (divKTrialCallV4Un21 uHi uLo vTop).toNat -
+          (divKTrialCallV4Q0d uHi uLo vTop).toNat *
+            (divKTrialCallV4DHi vTop).toNat)
+    (hQ0d_mul :
+      (divKTrialCallV4Q0d uHi uLo vTop).toNat *
+          (divKTrialCallV4DHi vTop).toNat ≤
+        (divKTrialCallV4Un21 uHi uLo vTop).toNat)
+    (hProd_gt :
+      (divKTrialCallV4Q0d uHi uLo vTop).toNat *
+          (divKTrialCallV4DLo vTop).toNat >
+        (divKTrialCallV4Rhat2d uHi uLo vTop).toNat * 2^32 +
+          (divKTrialCallV4Un0 uLo).toNat) :
+    ((divKTrialCallV4Un21 uHi uLo vTop).toNat * 2^32 +
+        (divKTrialCallV4Un0 uLo).toNat) /
+      ((divKTrialCallV4DHi vTop).toNat * 2^32 +
+        (divKTrialCallV4DLo vTop).toNat) <
+    (divKTrialCallV4Q0d uHi uLo vTop).toNat := by
+  exact EvmWord.product_check_gt_imp_overestimate
+    (divKTrialCallV4Un21 uHi uLo vTop).toNat
+    (divKTrialCallV4Un0 uLo).toNat
+    (divKTrialCallV4DHi vTop).toNat
+    (divKTrialCallV4DLo vTop).toNat
+    (divKTrialCallV4Q0d uHi uLo vTop).toNat
+    (divKTrialCallV4Rhat2d uHi uLo vTop).toNat
+    (2^32)
+    hDen_pos hRhat_eq hQ0d_mul hProd_gt
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add a Nat-level V4 product-check bridge for Q0d/Rhat2d
- specialize product_check_gt_imp_overestimate to the V4 Phase-2 second digit names

## Notes
- This is a prep slice for evm-asm-9iqmw.7.1.3.1.1.3; it does not close the exact-quotient bead yet.
- Remaining work: convert the Word BLTU fire guard into the Nat product inequality and provide the Q0d/Rhat2d Euclidean facts, then assemble the Q0dd lower-bound split.

## Verification
- lake build EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV4.QuotientBounds
- lake build EvmAsm.Evm64.EvmWordArith
- git diff --check
- scripts/check-file-size.sh EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/QuotientBounds.lean
- scripts/check-unimported.sh
- rg -n "set_option maxHeartbeats|set_option maxRecDepth|sorry|admit" EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/QuotientBounds.lean