### PR TITLE
feat(div): prove v4 q0dd pow63 lower bound

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/QuotientBounds.lean
+++ b/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/QuotientBounds.lean
@@ -470,4 +470,55 @@ theorem divKTrialCallV4Q0d_gt_q_true_0_of_ult
   exact divKTrialCallV4Q0d_gt_q_true_0_of_prod_gt uHi uLo vTop
     hDen_pos h_bridge.1 h_bridge.2 hProd_gt
 
+/-- V4 second-correction lower bound in the `un21 < 2^63` range.
+
+    This combines the first-correction lower bound with the full second
+    correction branch split. If the second product check fires, the `ult`
+    bridge proves the strict-overestimate witness needed to preserve the
+    lower bound through the decrement. -/
+theorem divKTrialCallV4Q0dd_ge_q_true_0_of_un21_lt_pow63
+    (uHi uLo vTop : Word)
+    (hdHi_ge : (divKTrialCallV4DHi vTop).toNat ≥ 2^31)
+    (hdHi_lt : (divKTrialCallV4DHi vTop).toNat < 2^32)
+    (hdLo_lt : (divKTrialCallV4DLo vTop).toNat < 2^32)
+    (hUn21_lt_pow63 : (divKTrialCallV4Un21 uHi uLo vTop).toNat < 2^63)
+    (hUn21_lt_vTop :
+      (divKTrialCallV4Un21 uHi uLo vTop).toNat <
+        (divKTrialCallV4DHi vTop).toNat * 2^32 +
+          (divKTrialCallV4DLo vTop).toNat) :
+    ((divKTrialCallV4Un21 uHi uLo vTop).toNat * 2^32 +
+        (divKTrialCallV4Un0 uLo).toNat) /
+      ((divKTrialCallV4DHi vTop).toNat * 2^32 +
+        (divKTrialCallV4DLo vTop).toNat) ≤
+    (divKTrialCallV4Q0dd uHi uLo vTop).toNat := by
+  have hQ0d_ge :
+      ((divKTrialCallV4Un21 uHi uLo vTop).toNat * 2^32 +
+          (divKTrialCallV4Un0 uLo).toNat) /
+        ((divKTrialCallV4DHi vTop).toNat * 2^32 +
+          (divKTrialCallV4DLo vTop).toNat) ≤
+      (divKTrialCallV4Q0d uHi uLo vTop).toNat :=
+    divKTrialCallV4Q0d_ge_q_true_0_of_un21_lt_pow63 uHi uLo vTop
+      hdHi_ge hdHi_lt hdLo_lt hUn21_lt_pow63 hUn21_lt_vTop
+  by_cases hRhat2d_hi_zero :
+      divKTrialCallV4Rhat2d uHi uLo vTop >>> (32 : BitVec 6).toNat = 0
+  · by_cases hUlt :
+        BitVec.ult
+          ((divKTrialCallV4Rhat2d uHi uLo vTop <<< (32 : BitVec 6).toNat) |||
+            divKTrialCallV4Un0 uLo)
+          (divKTrialCallV4Q0d uHi uLo vTop * divKTrialCallV4DLo vTop)
+    · have hQ0d_gt :
+          ((divKTrialCallV4Un21 uHi uLo vTop).toNat * 2^32 +
+              (divKTrialCallV4Un0 uLo).toNat) /
+            ((divKTrialCallV4DHi vTop).toNat * 2^32 +
+              (divKTrialCallV4DLo vTop).toNat) <
+          (divKTrialCallV4Q0d uHi uLo vTop).toNat :=
+        divKTrialCallV4Q0d_gt_q_true_0_of_ult uHi uLo vTop
+          hdHi_ge hdHi_lt hdLo_lt hUn21_lt_vTop hRhat2d_hi_zero hUlt
+      exact divKTrialCallV4Q0dd_ge_q_true_0_of_q0d_gt_of_fire uHi uLo vTop
+        hQ0d_gt hRhat2d_hi_zero hUlt
+    · exact divKTrialCallV4Q0dd_ge_q_true_0_of_q0d_ge_of_rhat2d_hi_eq_zero_of_no_ult
+        uHi uLo vTop hQ0d_ge hRhat2d_hi_zero hUlt
+  · exact divKTrialCallV4Q0dd_ge_q_true_0_of_q0d_ge_of_rhat2d_hi_ne
+      uHi uLo vTop hQ0d_ge hRhat2d_hi_zero
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/QuotientBounds.lean
+++ b/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/QuotientBounds.lean
@@ -421,4 +421,53 @@ theorem divKTrialCallV4Q0d_Rhat2d_bridge
   have h_post := divKTrialCallV4Q0d_Rhat2d_post uHi uLo vTop hdHi_ge hdHi_lt
   constructor <;> omega
 
+/-- Full v4 Phase-2 low-limb product-check bridge.
+
+    Under the standard digit bounds, a fired `BLTU` guard for `Q0d * DLo`
+    proves that `Q0d` is strictly larger than the true second quotient digit. -/
+theorem divKTrialCallV4Q0d_gt_q_true_0_of_ult
+    (uHi uLo vTop : Word)
+    (hdHi_ge : (divKTrialCallV4DHi vTop).toNat ≥ 2^31)
+    (hdHi_lt : (divKTrialCallV4DHi vTop).toNat < 2^32)
+    (hdLo_lt : (divKTrialCallV4DLo vTop).toNat < 2^32)
+    (hUn21_lt_vTop :
+      (divKTrialCallV4Un21 uHi uLo vTop).toNat <
+        (divKTrialCallV4DHi vTop).toNat * 2^32 +
+          (divKTrialCallV4DLo vTop).toNat)
+    (hRhat2d_hi_zero :
+      divKTrialCallV4Rhat2d uHi uLo vTop >>> (32 : BitVec 6).toNat = 0)
+    (hUlt :
+      BitVec.ult
+        ((divKTrialCallV4Rhat2d uHi uLo vTop <<< (32 : BitVec 6).toNat) |||
+          divKTrialCallV4Un0 uLo)
+        (divKTrialCallV4Q0d uHi uLo vTop * divKTrialCallV4DLo vTop)) :
+    ((divKTrialCallV4Un21 uHi uLo vTop).toNat * 2^32 +
+        (divKTrialCallV4Un0 uLo).toNat) /
+      ((divKTrialCallV4DHi vTop).toNat * 2^32 +
+        (divKTrialCallV4DLo vTop).toNat) <
+    (divKTrialCallV4Q0d uHi uLo vTop).toNat := by
+  have hDen_pos :
+      0 < (divKTrialCallV4DHi vTop).toNat * 2^32 +
+        (divKTrialCallV4DLo vTop).toNat := by
+    nlinarith
+  have hUn0_lt : (divKTrialCallV4Un0 uLo).toNat < 2^32 :=
+    divKTrialCallV4Un0_lt_pow32 uLo
+  have hProd_no_wrap :
+      (divKTrialCallV4Q0d uHi uLo vTop *
+          divKTrialCallV4DLo vTop).toNat =
+        (divKTrialCallV4Q0d uHi uLo vTop).toNat *
+          (divKTrialCallV4DLo vTop).toNat :=
+    divKTrialCallV4Q0d_mul_DLo_no_wrap uHi uLo vTop
+      hdHi_ge hdHi_lt hdLo_lt hUn21_lt_vTop
+  have hProd_gt :
+      (divKTrialCallV4Q0d uHi uLo vTop).toNat *
+          (divKTrialCallV4DLo vTop).toNat >
+        (divKTrialCallV4Rhat2d uHi uLo vTop).toNat * 2^32 +
+          (divKTrialCallV4Un0 uLo).toNat :=
+    divKTrialCallV4Q0d_prod_gt_of_ult uHi uLo vTop
+      hRhat2d_hi_zero hUn0_lt hProd_no_wrap hUlt
+  have h_bridge := divKTrialCallV4Q0d_Rhat2d_bridge uHi uLo vTop hdHi_ge hdHi_lt
+  exact divKTrialCallV4Q0d_gt_q_true_0_of_prod_gt uHi uLo vTop
+    hDen_pos h_bridge.1 h_bridge.2 hProd_gt
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/QuotientBounds.lean
+++ b/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/QuotientBounds.lean
@@ -405,4 +405,20 @@ theorem divKTrialCallV4Q0d_Rhat2d_post
       h_post
       h_rhat2c_lt
 
+/-- Consequences of `divKTrialCallV4Q0d_Rhat2d_post` in the shape consumed
+    by the product-check bridge. -/
+theorem divKTrialCallV4Q0d_Rhat2d_bridge
+    (uHi uLo vTop : Word)
+    (hdHi_ge : (divKTrialCallV4DHi vTop).toNat ≥ 2^31)
+    (hdHi_lt : (divKTrialCallV4DHi vTop).toNat < 2^32) :
+    (divKTrialCallV4Rhat2d uHi uLo vTop).toNat =
+        (divKTrialCallV4Un21 uHi uLo vTop).toNat -
+          (divKTrialCallV4Q0d uHi uLo vTop).toNat *
+            (divKTrialCallV4DHi vTop).toNat ∧
+      (divKTrialCallV4Q0d uHi uLo vTop).toNat *
+          (divKTrialCallV4DHi vTop).toNat ≤
+        (divKTrialCallV4Un21 uHi uLo vTop).toNat := by
+  have h_post := divKTrialCallV4Q0d_Rhat2d_post uHi uLo vTop hdHi_ge hdHi_lt
+  constructor <;> omega
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add divKTrialCallV4Q0dd_ge_q_true_0_of_un21_lt_pow63
- combine the q0d lower bound with the q0dd branch split
- use the q0d ult bridge in the correction-fire branch to preserve the lower bound after decrement

## Verification
- lake build EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV4.QuotientBounds
- lake build EvmAsm.Evm64.EvmWordArith
- git diff --check
- scripts/check-file-size.sh EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/QuotientBounds.lean
- rg -n "set_option maxHeartbeats|set_option maxRecDepth|sorry|admit" EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/QuotientBounds.lean

Bead: evm-asm-9iqmw.7.1.3.1.1.3