### PR TITLE
feat(div): prove v4 q0c tail lower bound

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/QuotientBounds.lean
+++ b/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/QuotientBounds.lean
@@ -86,6 +86,107 @@ theorem divKTrialCallV4Q0d_ge_q_true_0_of_un21_lt_pow63
       uLo
       hdHi_ge hdHi_lt hdLo_lt hUn21_lt_pow63 hUn21_lt_vTop
 
+/-- In the Phase-2 tail range, the true second quotient digit is still a
+    32-bit half-word. -/
+theorem divKTrialCallV4Q0_true_0_lt_pow32_of_un21_lt_vTop
+    (uHi uLo vTop : Word)
+    (hdHi_ge : (divKTrialCallV4DHi vTop).toNat ≥ 2^31)
+    (hUn21_lt_vTop :
+      (divKTrialCallV4Un21 uHi uLo vTop).toNat <
+        (divKTrialCallV4DHi vTop).toNat * 2^32 +
+          (divKTrialCallV4DLo vTop).toNat) :
+    ((divKTrialCallV4Un21 uHi uLo vTop).toNat * 2^32 +
+        (divKTrialCallV4Un0 uLo).toNat) /
+      ((divKTrialCallV4DHi vTop).toNat * 2^32 +
+        (divKTrialCallV4DLo vTop).toNat) < 2^32 := by
+  have hDen_pos :
+      0 < (divKTrialCallV4DHi vTop).toNat * 2^32 +
+        (divKTrialCallV4DLo vTop).toNat := by
+    nlinarith
+  have hUn0_lt : (divKTrialCallV4Un0 uLo).toNat < 2^32 :=
+    divKTrialCallV4Un0_lt_pow32 uLo
+  have h_num_lt :
+      (divKTrialCallV4Un21 uHi uLo vTop).toNat * 2^32 +
+          (divKTrialCallV4Un0 uLo).toNat <
+        2^32 * ((divKTrialCallV4DHi vTop).toNat * 2^32 +
+          (divKTrialCallV4DLo vTop).toNat) := by
+    nlinarith
+  exact (Nat.div_lt_iff_lt_mul hDen_pos).mpr h_num_lt
+
+/-- In the Phase-2 tail range `DHi * 2^32 ≤ un21`, the Phase-2a corrected
+    digit `Q0c` is at least the maximal half-word value. -/
+theorem divKTrialCallV4Q0c_ge_pow32_sub_one_of_dHi_mul_pow32_le_un21
+    (uHi uLo vTop : Word)
+    (hdHi_ge : (divKTrialCallV4DHi vTop).toNat ≥ 2^31)
+    (hUn21_ge_dHi_pow32 :
+      (divKTrialCallV4DHi vTop).toNat * 2^32 ≤
+        (divKTrialCallV4Un21 uHi uLo vTop).toNat) :
+    2^32 - 1 ≤ (divKTrialCallV4Q0c uHi uLo vTop).toNat := by
+  let dHi := divKTrialCallV4DHi vTop
+  let un21 := divKTrialCallV4Un21 uHi uLo vTop
+  let q0 := rv64_divu un21 dHi
+  have hdHi_ne : dHi ≠ 0 := by
+    intro h_eq
+    have h_zero : dHi.toNat = 0 := by rw [h_eq]; rfl
+    have h_ge : dHi.toNat ≥ 2^31 := by
+      simpa [dHi] using hdHi_ge
+    omega
+  have hq0_ge : 2^32 ≤ q0.toNat := by
+    change 2^32 ≤ (rv64_divu un21 dHi).toNat
+    rw [rv64_divu_toNat un21 dHi hdHi_ne]
+    apply (Nat.le_div_iff_mul_le ?_).mpr
+    · have h_ge : dHi.toNat * 2^32 ≤ un21.toNat := by
+        simpa [dHi, un21] using hUn21_ge_dHi_pow32
+      nlinarith
+    · have : 0 < dHi.toNat := by
+        have h_ne : dHi.toNat ≠ 0 := by
+          intro h_zero
+          exact hdHi_ne (BitVec.eq_of_toNat_eq h_zero)
+        omega
+      exact this
+  have hq0_hi_ne : q0 >>> (32 : BitVec 6).toNat ≠ (0 : Word) := by
+    intro h_zero
+    have hq0_lt : q0.toNat < 2^32 := by
+      have h := (ushiftRight_eq_zero_iff (val := q0) ((32 : BitVec 6).toNat)).mp h_zero
+      simpa using h
+    omega
+  unfold divKTrialCallV4Q0c
+  change (if q0 >>> (32 : BitVec 6).toNat = 0 then q0 else q0 + signExtend12 4095).toNat ≥
+    2^32 - 1
+  rw [if_neg hq0_hi_ne]
+  have h_se_toNat : (signExtend12 4095 : Word).toNat = 2^64 - 1 := by decide
+  have h_dec : (q0 + signExtend12 4095).toNat = q0.toNat - 1 := by
+    rw [BitVec.toNat_add, h_se_toNat]
+    have hq0_lt : q0.toNat < 2^64 := q0.isLt
+    omega
+  rw [h_dec]
+  omega
+
+/-- In the Phase-2 tail range, `Q0c` is a lower bound for the true second
+    quotient digit. -/
+theorem divKTrialCallV4Q0c_ge_q_true_0_of_dHi_mul_pow32_le_un21
+    (uHi uLo vTop : Word)
+    (hdHi_ge : (divKTrialCallV4DHi vTop).toNat ≥ 2^31)
+    (hUn21_ge_dHi_pow32 :
+      (divKTrialCallV4DHi vTop).toNat * 2^32 ≤
+        (divKTrialCallV4Un21 uHi uLo vTop).toNat)
+    (hUn21_lt_vTop :
+      (divKTrialCallV4Un21 uHi uLo vTop).toNat <
+        (divKTrialCallV4DHi vTop).toNat * 2^32 +
+          (divKTrialCallV4DLo vTop).toNat) :
+    ((divKTrialCallV4Un21 uHi uLo vTop).toNat * 2^32 +
+        (divKTrialCallV4Un0 uLo).toNat) /
+      ((divKTrialCallV4DHi vTop).toNat * 2^32 +
+        (divKTrialCallV4DLo vTop).toNat) ≤
+    (divKTrialCallV4Q0c uHi uLo vTop).toNat := by
+  have h_true_lt :=
+    divKTrialCallV4Q0_true_0_lt_pow32_of_un21_lt_vTop
+      uHi uLo vTop hdHi_ge hUn21_lt_vTop
+  have h_q0c_ge :=
+    divKTrialCallV4Q0c_ge_pow32_sub_one_of_dHi_mul_pow32_le_un21
+      uHi uLo vTop hdHi_ge hUn21_ge_dHi_pow32
+  omega
+
 /-- Phase 2 first-correction upper bound, wrapped for the v4 trial-call
     definitions.
 


### PR DESCRIPTION
## Summary
- add tail-range Phase-2 starting facts for v4 exact quotient work
- prove the true low quotient digit is < 2^32 under un21 < vTop
- prove Q0c >= 2^32 - 1 when DHi*2^32 <= un21, hence Q0c bounds the true low digit in the remaining tail range

## Verification
- lake build EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV4.QuotientBounds
- lake build EvmAsm.Evm64.EvmWordArith
- git diff --check
- scripts/check-file-size.sh EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/QuotientBounds.lean
- rg -n "set_option maxHeartbeats|set_option maxRecDepth|sorry|admit" EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/QuotientBounds.lean

Bead: evm-asm-9iqmw.7.1.3.1.1.3