### PR TITLE
feat(div): prove v4 rhat-zero lower bound

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/QuotientBounds.lean
+++ b/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/QuotientBounds.lean
@@ -1341,4 +1341,24 @@ theorem div128Quot_v4_ge_q_true_of_no_wrap
   exact div128Quot_v4_ge_q_true_of_un21_eq_r1 uHi uLo vTop
     hvTop_ge huHi_lt_vTop huHi_lt_pow63 hUn21_lt_vTop hUn21_eq_r1
 
+/-- Full v4 128/64 lower bound when the final Phase-1b remainder has zero
+    high half. In this branch the low-half subtraction no-wrap condition
+    follows from the existing Phase-1b bound. -/
+theorem div128Quot_v4_ge_q_true_of_rhatdd_hi_zero
+    (uHi uLo vTop : Word)
+    (hvTop_ge : vTop.toNat ≥ 2^63)
+    (huHi_lt_vTop : uHi.toNat < vTop.toNat)
+    (huHi_lt_pow63 : uHi.toNat < 2^63)
+    (hUn21_lt_vTop :
+      (divKTrialCallV4Un21 uHi uLo vTop).toNat < vTop.toNat)
+    (h_rhat_hi_zero :
+      divKTrialCallV4Rhatdd uHi uLo vTop >>> (32 : BitVec 6).toNat = (0 : Word)) :
+    (uHi.toNat * 2^64 + uLo.toNat) / vTop.toNat ≤
+      (div128Quot_v4 uHi uLo vTop).toNat := by
+  have h_no_wrap :=
+    divKTrialCallV4Un21_low_no_wrap_of_rhatdd_hi_zero
+      uHi uLo vTop hvTop_ge huHi_lt_vTop h_rhat_hi_zero
+  exact div128Quot_v4_ge_q_true_of_no_wrap uHi uLo vTop
+    hvTop_ge huHi_lt_vTop huHi_lt_pow63 hUn21_lt_vTop h_no_wrap
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- prove div128Quot_v4_ge_q_true_of_rhatdd_hi_zero
- use divKTrialCallV4Un21_low_no_wrap_of_rhatdd_hi_zero to discharge the no-wrap premise from the previous lower-bound wrapper
- cover the final Phase-1b remainder high-half-zero branch toward exact V4 128/64 quotient equality

Bead: evm-asm-9iqmw.7.1.3.1.1.3

## Verification
- lake build EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV4.QuotientBounds
- lake build EvmAsm.Evm64.EvmWordArith
- git diff --check
- scripts/check-file-size.sh EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/QuotientBounds.lean
- rg -n "set_option maxHeartbeats|set_option maxRecDepth|sorry|admit" EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/QuotientBounds.lean