### PR TITLE
feat(div): prove v4 callskip rhat-zero exact quotient

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/CallSkipV4.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/CallSkipV4.lean
@@ -203,6 +203,81 @@ theorem n4CallSkipSemanticHoldsV4_of_rhatdd_hi_zero_pred (a b : EvmWord)
   exact n4CallSkipSemanticHoldsV4_of_runtime_rhatdd_hi_zero a b
     hb3nz hshift_nz hrhat
 
+/-- Tight v4 call-skip equality in the final Phase-1b high-half-zero branch. -/
+theorem div128Quot_v4_call_skip_eq_val256_div_of_rhatdd_hi_zero
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hb3nz : b3 ≠ 0)
+    (hshift_nz : (clzResult b3).1 ≠ 0)
+    (hcall : isCallTrialN4 a3 b2 b3)
+    (hskip : isSkipBorrowN4CallV4Ab a0 a1 a2 a3 b0 b1 b2 b3) :
+    let shift := (clzResult b3).1.toNat % 64
+    let antiShift := (signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64
+    let b3' := (b3 <<< shift) ||| (b2 >>> antiShift)
+    let u4 := a3 >>> antiShift
+    let u3 := (a3 <<< shift) ||| (a2 >>> antiShift)
+    (divKTrialCallV4Un21 u4 u3 b3').toNat < b3'.toNat →
+    divKTrialCallV4Rhatdd u4 u3 b3' >>> (32 : BitVec 6).toNat = (0 : Word) →
+    (div128Quot_v4 u4 u3 b3').toNat =
+      val256 a0 a1 a2 a3 / val256 b0 b1 b2 b3 := by
+  intro shift antiShift b3' u4 u3 hUn21_lt_vTop h_rhat_hi_zero
+  have h_le := div128Quot_v4_call_skip_le_val256_div
+    a0 a1 a2 a3 b0 b1 b2 b3 hb3nz hshift_nz hskip
+  have h_ge := div128Quot_v4_call_skip_ge_val256_div_of_rhatdd_hi_zero
+    a0 a1 a2 a3 b0 b1 b2 b3 hb3nz hshift_nz hcall
+    hUn21_lt_vTop h_rhat_hi_zero
+  simp only [] at h_le h_ge
+  exact Nat.le_antisymm h_le h_ge
+
+/-- EvmWord-level tight v4 call-skip equality in the high-half-zero branch,
+    with the `un21 < vTop` invariant discharged from the call path. -/
+theorem n4CallSkipExactQuotientV4_of_runtime_rhatdd_hi_zero (a b : EvmWord)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (hskip : isSkipBorrowN4CallV4Evm a b) :
+    let shift := (clzResult (b.getLimbN 3)).1.toNat % 64
+    let antiShift :=
+      (signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 3)).1).toNat % 64
+    let b3' := ((b.getLimbN 3) <<< shift) ||| ((b.getLimbN 2) >>> antiShift)
+    let u4 := (a.getLimbN 3) >>> antiShift
+    let u3 := ((a.getLimbN 3) <<< shift) ||| ((a.getLimbN 2) >>> antiShift)
+    divKTrialCallV4Rhatdd u4 u3 b3' >>> (32 : BitVec 6).toNat = (0 : Word) →
+    (div128Quot_v4 u4 u3 b3').toNat =
+      val256 (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3) /
+        val256 (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) := by
+  intro shift antiShift b3' u4 u3 h_rhat_hi_zero
+  rw [isSkipBorrowN4CallV4Evm_def] at hskip
+  have hcall : isCallTrialN4 (a.getLimbN 3) (b.getLimbN 2) (b.getLimbN 3) :=
+    isCallTrialN4_of_shift_nz (a.getLimbN 3) (b.getLimbN 2) (b.getLimbN 3)
+      hb3nz hshift_nz
+  have hUn21_lt_vTop :
+      (divKTrialCallV4Un21 u4 u3 b3').toNat < b3'.toNat := by
+    have h := un21V4_lt_vTop_of_call (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 2) (b.getLimbN 3) hb3nz hshift_nz hcall
+    simpa [algorithmUn21V4, shift, antiShift, b3', u4, u3] using h
+  exact div128Quot_v4_call_skip_eq_val256_div_of_rhatdd_hi_zero
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+    hb3nz hshift_nz hcall hskip hUn21_lt_vTop h_rhat_hi_zero
+
+/-- Predicate-packaged tight v4 call-skip equality in the high-half-zero branch. -/
+theorem n4CallSkipExactQuotientV4_of_rhatdd_hi_zero_pred (a b : EvmWord)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (hskip : isSkipBorrowN4CallV4Evm a b)
+    (hrhat : n4CallSkipRhatddHiZeroV4 a b) :
+    let shift := (clzResult (b.getLimbN 3)).1.toNat % 64
+    let antiShift :=
+      (signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 3)).1).toNat % 64
+    let b3' := ((b.getLimbN 3) <<< shift) ||| ((b.getLimbN 2) >>> antiShift)
+    let u4 := (a.getLimbN 3) >>> antiShift
+    let u3 := ((a.getLimbN 3) <<< shift) ||| ((a.getLimbN 2) >>> antiShift)
+    (div128Quot_v4 u4 u3 b3').toNat =
+      val256 (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3) /
+        val256 (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) := by
+  rw [n4CallSkipRhatddHiZeroV4_def] at hrhat
+  exact n4CallSkipExactQuotientV4_of_runtime_rhatdd_hi_zero a b
+    hb3nz hshift_nz hskip hrhat
+
 theorem n4CallSkipSemanticHoldsV4_def {a b : EvmWord} :
     n4CallSkipSemanticHoldsV4 a b =
     (let shift := (clzResult (b.getLimbN 3)).1.toNat % 64

--- a/EvmAsm/Evm64/DivMod/Spec/CallSkipV4.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/CallSkipV4.lean
@@ -684,6 +684,41 @@ theorem evm_div_n4_call_skip_stack_pre_spec_bundled_v4_of_shift_nz_rhatdd_hi_zer
     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
     hbnz hb3nz hshift_nz halign hbltu hborrow h_rhat_hi_zero
 
+/-- Bundled no-NOP v4 call+skip stack wrapper in the rhat-zero branch, with
+    call-trial discharged from `shift ≠ 0`. -/
+theorem evm_div_n4_call_skip_stack_pre_spec_bundled_v4_noNop_of_shift_nz_rhatdd_hi_zero
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hbnz : b ≠ 0)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hborrow : isSkipBorrowN4CallV4Evm a b) :
+    let shift := (clzResult (b.getLimbN 3)).1.toNat % 64
+    let antiShift :=
+      (signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 3)).1).toNat % 64
+    let b3' := ((b.getLimbN 3) <<< shift) ||| ((b.getLimbN 2) >>> antiShift)
+    let u4Top := (a.getLimbN 3) >>> antiShift
+    let u3Top := ((a.getLimbN 3) <<< shift) ||| ((a.getLimbN 2) >>> antiShift)
+    divKTrialCallV4Rhatdd u4Top u3Top b3' >>> (32 : BitVec 6).toNat = (0 : Word) →
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 148 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_noNop_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) := by
+  intro shift antiShift b3' u4Top u3Top h_rhat_hi_zero
+  have hbltu : isCallTrialN4Evm a b :=
+    isCallTrialN4Evm_of_shift_nz a b hb3nz hshift_nz
+  exact evm_div_n4_call_skip_stack_pre_spec_bundled_v4_noNop_of_runtime_rhatdd_hi_zero
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hbnz hb3nz hshift_nz halign hbltu hborrow h_rhat_hi_zero
+
 /-- Predicate-packaged variant of
     `evm_div_n4_call_skip_stack_pre_spec_bundled_v4_of_shift_nz_rhatdd_hi_zero`. -/
 theorem evm_div_n4_call_skip_stack_pre_spec_bundled_v4_of_rhatdd_hi_zero_pred
@@ -707,6 +742,33 @@ theorem evm_div_n4_call_skip_stack_pre_spec_bundled_v4_of_rhatdd_hi_zero_pred
       (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) := by
   rw [n4CallSkipRhatddHiZeroV4_def] at hrhat
   exact evm_div_n4_call_skip_stack_pre_spec_bundled_v4_of_shift_nz_rhatdd_hi_zero
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hbnz hb3nz hshift_nz halign hborrow hrhat
+
+/-- Predicate-packaged no-NOP variant of
+    `evm_div_n4_call_skip_stack_pre_spec_bundled_v4_noNop_of_shift_nz_rhatdd_hi_zero`. -/
+theorem evm_div_n4_call_skip_stack_pre_spec_bundled_v4_noNop_of_rhatdd_hi_zero_pred
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hbnz : b ≠ 0)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hborrow : isSkipBorrowN4CallV4Evm a b)
+    (hrhat : n4CallSkipRhatddHiZeroV4 a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 148 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_noNop_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) := by
+  rw [n4CallSkipRhatddHiZeroV4_def] at hrhat
+  exact evm_div_n4_call_skip_stack_pre_spec_bundled_v4_noNop_of_shift_nz_rhatdd_hi_zero
     sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
     hbnz hb3nz hshift_nz halign hborrow hrhat


### PR DESCRIPTION
## Summary
- combine the existing v4 call-skip upper bound with the rhat-zero lower bound into a tight val256 quotient equality
- add EvmWord runtime and predicate-packaged wrappers for the rhat-zero branch

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.CallSkipV4
- lake build EvmAsm.Evm64.DivMod.Spec
- git diff --check
- scripts/check-file-size.sh EvmAsm/Evm64/DivMod/Spec/CallSkipV4.lean
- rg -n "set_option maxHeartbeats|set_option maxRecDepth|sorry|admit" EvmAsm/Evm64/DivMod/Spec/CallSkipV4.lean