### PR TITLE
feat(div): package n1 trial witnesses

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -24,6 +24,7 @@ import EvmAsm.Evm64.DivMod.Spec.N3RemainderWordV4
 import EvmAsm.Evm64.DivMod.Spec.Dispatcher
 import EvmAsm.Evm64.DivMod.Spec.DispatcherPcFree
 import EvmAsm.Evm64.DivMod.Spec.CallablePost
+import EvmAsm.Evm64.DivMod.Spec.N1TrialWitnesses
 import EvmAsm.Evm64.DivMod.Spec.N1QuotientWord
 import EvmAsm.Evm64.DivMod.Spec.N2QuotientWord
 import EvmAsm.Evm64.DivMod.Spec.N2DivStackSpec

--- a/EvmAsm/Evm64/DivMod/Spec/CallSkipV4.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/CallSkipV4.lean
@@ -421,6 +421,49 @@ theorem n4_call_skip_div_mod_getLimbN_v4_of_rhatdd_hi_zero_pred (a b : EvmWord)
   exact n4_call_skip_div_mod_getLimbN_v4_of_runtime_rhatdd_hi_zero a b
     hbnz hb3nz hshift_nz hborrow hrhat
 
+/-- Runtime rhat-zero getLimbN bridge with `b ≠ 0` discharged from `hb3nz`. -/
+theorem n4_call_skip_div_mod_getLimbN_v4_of_runtime_rhatdd_hi_zero_hb3nz
+    (a b : EvmWord)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (hborrow : isSkipBorrowN4CallV4Evm a b) :
+    let shift := (clzResult (b.getLimbN 3)).1.toNat % 64
+    let antiShift :=
+      (signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 3)).1).toNat % 64
+    let b3' := ((b.getLimbN 3) <<< shift) ||| ((b.getLimbN 2) >>> antiShift)
+    let u4 := (a.getLimbN 3) >>> antiShift
+    let u3 := ((a.getLimbN 3) <<< shift) ||| ((a.getLimbN 2) >>> antiShift)
+    let qHat := div128Quot_v4 u4 u3 b3'
+    divKTrialCallV4Rhatdd u4 u3 b3' >>> (32 : BitVec 6).toNat = (0 : Word) →
+    (EvmWord.div a b).getLimbN 0 = qHat ∧
+    (EvmWord.div a b).getLimbN 1 = 0 ∧
+    (EvmWord.div a b).getLimbN 2 = 0 ∧
+    (EvmWord.div a b).getLimbN 3 = 0 := by
+  exact n4_call_skip_div_mod_getLimbN_v4_of_runtime_rhatdd_hi_zero a b
+    (evmWord_ne_zero_of_getLimbN_3_ne_zero hb3nz) hb3nz hshift_nz hborrow
+
+/-- Predicate-packaged rhat-zero getLimbN bridge with `b ≠ 0` discharged
+    from `hb3nz`. -/
+theorem n4_call_skip_div_mod_getLimbN_v4_of_rhatdd_hi_zero_pred_hb3nz
+    (a b : EvmWord)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (hborrow : isSkipBorrowN4CallV4Evm a b)
+    (hrhat : n4CallSkipRhatddHiZeroV4 a b) :
+    let shift := (clzResult (b.getLimbN 3)).1.toNat % 64
+    let antiShift :=
+      (signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 3)).1).toNat % 64
+    let b3' := ((b.getLimbN 3) <<< shift) ||| ((b.getLimbN 2) >>> antiShift)
+    let u4 := (a.getLimbN 3) >>> antiShift
+    let u3 := ((a.getLimbN 3) <<< shift) ||| ((a.getLimbN 2) >>> antiShift)
+    let qHat := div128Quot_v4 u4 u3 b3'
+    (EvmWord.div a b).getLimbN 0 = qHat ∧
+    (EvmWord.div a b).getLimbN 1 = 0 ∧
+    (EvmWord.div a b).getLimbN 2 = 0 ∧
+    (EvmWord.div a b).getLimbN 3 = 0 := by
+  exact n4_call_skip_div_mod_getLimbN_v4_of_rhatdd_hi_zero_pred a b
+    (evmWord_ne_zero_of_getLimbN_3_ne_zero hb3nz) hb3nz hshift_nz hborrow hrhat
+
 /-- **EvmWord-form wrapper of `evm_div_n4_full_call_skip_spec_v4`.**
     Mirror of `evm_div_n4_full_call_skip_stack_pre_spec` (the v1 wrapper
     at `Spec/CallSkip.lean:323`), adapted for the v4 surface:
@@ -650,6 +693,79 @@ theorem evm_div_n4_call_skip_stack_pre_spec_v4_noNop_of_runtime_rhatdd_hi_zero
   rw [divScratchValuesCall_unfold, divScratchValues_unfold]
   rw [word_add_zero] at hq
   xperm_hyp hq
+
+/-- Runtime rhat-zero stack-pre wrapper with `b ≠ 0` discharged from `hb3nz`. -/
+theorem evm_div_n4_call_skip_stack_pre_spec_v4_of_runtime_rhatdd_hi_zero_hb3nz
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu : isCallTrialN4Evm a b)
+    (hborrow : isSkipBorrowN4CallV4Evm a b) :
+    let shift := (clzResult (b.getLimbN 3)).1.toNat % 64
+    let antiShift :=
+      (signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 3)).1).toNat % 64
+    let b3' := ((b.getLimbN 3) <<< shift) ||| ((b.getLimbN 2) >>> antiShift)
+    let u4 := (a.getLimbN 3) >>> antiShift
+    let u3 := ((a.getLimbN 3) <<< shift) ||| ((a.getLimbN 2) >>> antiShift)
+    divKTrialCallV4Rhatdd u4 u3 b3' >>> (32 : BitVec 6).toNat = (0 : Word) →
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 148 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_v4 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+       (.x2 ↦ᵣ (clzResult (b.getLimbN 3)).2 >>> (63 : Nat)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x11 ↦ᵣ v11Old) **
+       evmWordIs sp a ** evmWordIs (sp + 32) b **
+       divScratchValuesCall sp q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old
+         u5 u6 u7 shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) := by
+  exact evm_div_n4_call_skip_stack_pre_spec_v4_of_runtime_rhatdd_hi_zero
+    sp base a b v5 v6 v7 v10 v11Old q0 q1 q2 q3 u0Old u1Old u2Old u3Old
+    u4Old u5 u6 u7 nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    (evmWord_ne_zero_of_getLimbN_3_ne_zero hb3nz) hb3nz hshift_nz halign hbltu hborrow
+
+/-- No-NOP runtime rhat-zero stack-pre wrapper with `b ≠ 0` discharged
+    from `hb3nz`. -/
+theorem evm_div_n4_call_skip_stack_pre_spec_v4_noNop_of_runtime_rhatdd_hi_zero_hb3nz
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu : isCallTrialN4Evm a b)
+    (hborrow : isSkipBorrowN4CallV4Evm a b) :
+    let shift := (clzResult (b.getLimbN 3)).1.toNat % 64
+    let antiShift :=
+      (signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 3)).1).toNat % 64
+    let b3' := ((b.getLimbN 3) <<< shift) ||| ((b.getLimbN 2) >>> antiShift)
+    let u4 := (a.getLimbN 3) >>> antiShift
+    let u3 := ((a.getLimbN 3) <<< shift) ||| ((a.getLimbN 2) >>> antiShift)
+    divKTrialCallV4Rhatdd u4 u3 b3' >>> (32 : BitVec 6).toNat = (0 : Word) →
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 148 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_noNop_v4 base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+       (.x2 ↦ᵣ (clzResult (b.getLimbN 3)).2 >>> (63 : Nat)) **
+       (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x11 ↦ᵣ v11Old) **
+       evmWordIs sp a ** evmWordIs (sp + 32) b **
+       divScratchValuesCall sp q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old
+         u5 u6 u7 shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) := by
+  exact evm_div_n4_call_skip_stack_pre_spec_v4_noNop_of_runtime_rhatdd_hi_zero
+    sp base a b v5 v6 v7 v10 v11Old q0 q1 q2 q3 u0Old u1Old u2Old u3Old
+    u4Old u5 u6 u7 nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    (evmWord_ne_zero_of_getLimbN_3_ne_zero hb3nz) hb3nz hshift_nz halign hbltu hborrow
 
 /-- Bundled variant of
     `evm_div_n4_call_skip_stack_pre_spec_v4_of_runtime_rhatdd_hi_zero`. -/

--- a/EvmAsm/Evm64/DivMod/Spec/CallSkipV4.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/CallSkipV4.lean
@@ -203,6 +203,13 @@ theorem n4CallSkipSemanticHoldsV4_of_rhatdd_hi_zero_pred (a b : EvmWord)
   exact n4CallSkipSemanticHoldsV4_of_runtime_rhatdd_hi_zero a b
     hb3nz hshift_nz hrhat
 
+/-- A nonzero top limb witnesses that the full EVM word is nonzero. -/
+theorem evmWord_ne_zero_of_getLimbN_3_ne_zero {b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0) : b ≠ 0 := by
+  apply (EvmWord.ne_zero_iff_getLimbN_or).mpr
+  intro h_or_zero
+  exact hb3nz (EvmWord.or_eq_zero_imp_right h_or_zero)
+
 /-- Tight v4 call-skip equality in the final Phase-1b high-half-zero branch. -/
 theorem div128Quot_v4_call_skip_eq_val256_div_of_rhatdd_hi_zero
     (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
@@ -847,5 +854,54 @@ theorem evm_div_n4_call_skip_stack_pre_spec_bundled_v4_noNop_of_rhatdd_hi_zero_p
     sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
     hbnz hb3nz hshift_nz halign hborrow hrhat
+
+/-- Predicate-packaged variant with `b ≠ 0` discharged from the nonzero top limb. -/
+theorem evm_div_n4_call_skip_stack_pre_spec_bundled_v4_of_rhatdd_hi_zero_pred_hb3nz
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hborrow : isSkipBorrowN4CallV4Evm a b)
+    (hrhat : n4CallSkipRhatddHiZeroV4 a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 148 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) := by
+  exact evm_div_n4_call_skip_stack_pre_spec_bundled_v4_of_rhatdd_hi_zero_pred
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    (evmWord_ne_zero_of_getLimbN_3_ne_zero hb3nz) hb3nz hshift_nz halign hborrow hrhat
+
+/-- Predicate-packaged no-NOP variant with `b ≠ 0` discharged from the
+    nonzero top limb. -/
+theorem evm_div_n4_call_skip_stack_pre_spec_bundled_v4_noNop_of_rhatdd_hi_zero_pred_hb3nz
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hborrow : isSkipBorrowN4CallV4Evm a b)
+    (hrhat : n4CallSkipRhatddHiZeroV4 a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 148 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_noNop_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) := by
+  exact evm_div_n4_call_skip_stack_pre_spec_bundled_v4_noNop_of_rhatdd_hi_zero_pred
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    (evmWord_ne_zero_of_getLimbN_3_ne_zero hb3nz) hb3nz hshift_nz halign hborrow hrhat
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N1TrialWitnesses.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N1TrialWitnesses.lean
@@ -1,0 +1,50 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N1TrialWitnesses
+
+  Mechanical branch-boolean witnesses for the n=1 DIV path.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN1LoopUnified
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- The four n=1 trial-branch booleans always have canonical witnesses.
+
+    This packages the mechanical branch-enumeration part needed by
+    unconditional n=1 stack wrappers. The remaining non-mechanical
+    obligations are the carry/addback and semantic division witnesses. -/
+theorem n1_trial_witnesses (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    ∃ bltu_3 bltu_2 bltu_1 bltu_0,
+      isTrialN1_j3 bltu_3 a3 b0 ∧
+      isTrialN1_j2 bltu_3 bltu_2 a2 a3 b0 b1 b2 b3 ∧
+      isTrialN1_j1 bltu_3 bltu_2 bltu_1 a1 a2 a3 b0 b1 b2 b3 ∧
+      isTrialN1_j0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3 := by
+  let shift := (clzResult b0).1
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let v0' := b0 <<< (shift.toNat % 64)
+  let v1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+  let v2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let v3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let u1S := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
+  let u2S := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u3S := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u4_s := a3 >>> (antiShift.toNat % 64)
+  let bltu_3 := BitVec.ult u4_s v0'
+  let r3 := iterN1 bltu_3 v0' v1' v2' v3' u3S u4_s (0 : Word) (0 : Word) (0 : Word)
+  let bltu_2 := BitVec.ult r3.2.1 v0'
+  let r2 := iterN1 bltu_2 v0' v1' v2' v3' u2S r3.2.1 r3.2.2.1 r3.2.2.2.1 r3.2.2.2.2.1
+  let bltu_1 := BitVec.ult r2.2.1 v0'
+  let r1 := iterN1 bltu_1 v0' v1' v2' v3' u1S r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
+  let bltu_0 := BitVec.ult r1.2.1 v0'
+  refine ⟨bltu_3, bltu_2, bltu_1, bltu_0, ?_, ?_, ?_, ?_⟩
+  · simp [isTrialN1_j3, bltu_3, v0', u4_s, shift, antiShift]
+  · simp [isTrialN1_j2, bltu_2, bltu_3, r3, v0', v1', v2', v3', u3S, u4_s,
+      shift, antiShift]
+  · simp [isTrialN1_j1, bltu_1, bltu_2, bltu_3, r2, r3, v0', v1', v2', v3',
+      u2S, u3S, u4_s, shift, antiShift]
+  · simp [isTrialN1_j0, bltu_0, bltu_1, bltu_2, bltu_3, r1, r2, r3, v0', v1',
+      v2', v3', u1S, u2S, u3S, u4_s, shift, antiShift]
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add a small N1TrialWitnesses module for canonical n=1 trial branch booleans
- expose n1_trial_witnesses through the DivMod spec umbrella
- keep the oversized compose file unchanged to satisfy the file-size guardrail

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.N1TrialWitnesses
- lake build EvmAsm.Evm64.DivMod.Spec
- git diff --check
- scripts/check-file-size.sh EvmAsm/Evm64/DivMod/Spec/N1TrialWitnesses.lean EvmAsm/Evm64/DivMod/Spec.lean
- scripts/check-unimported.sh
- rg -n "set_option maxHeartbeats|set_option maxRecDepth|sorry|admit" EvmAsm/Evm64/DivMod/Spec/N1TrialWitnesses.lean EvmAsm/Evm64/DivMod/Spec.lean