### PR TITLE
feat(div): package n1 call-first witnesses

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N1TrialWitnesses.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N1TrialWitnesses.lean
@@ -47,4 +47,35 @@ theorem n1_trial_witnesses (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
   · simp [isTrialN1_j0, bltu_0, bltu_1, bltu_2, bltu_3, r1, r2, r3, v0', v1',
       v2', v3', u1S, u2S, u3S, u4_s, shift, antiShift]
 
+/-- The first n=1 trial branch is forced true when the single divisor limb
+    normalizes with a positive shift.
+
+    This discharges the first branch certificate needed by unconditional n=1
+    stack wrappers: the normalized top dividend fragment is below `2^63`,
+    while the normalized divisor limb is at least `2^63`. -/
+theorem isTrialN1_j3_true_of_shift_nz (a3 b0 : Word)
+    (hb0nz : b0 ≠ 0)
+    (hshift_nz : (clzResult b0).1 ≠ 0) :
+    isTrialN1_j3 true a3 b0 := by
+  unfold isTrialN1_j3
+  have h_shift_pos : 1 ≤ (clzResult b0).1.toNat := by
+    rcases Nat.eq_zero_or_pos (clzResult b0).1.toNat with h | h
+    · exfalso
+      apply hshift_nz
+      exact BitVec.eq_of_toNat_eq (by simp [h])
+    · exact h
+  have h_u4_lt_pow63 :
+      (a3 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b0).1).toNat % 64)).toNat <
+        2^63 :=
+    u_top_lt_pow63_of_shift_nz a3 (clzResult b0).1 h_shift_pos
+      (clzResult_fst_toNat_le b0)
+  have h_b0_ge_pow63 :
+      (b0 <<< ((clzResult b0).1.toNat % 64)).toNat ≥ 2^63 :=
+    b3_shifted_ge_pow63 hb0nz
+  have h_lt :
+      (a3 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b0).1).toNat % 64)).toNat <
+        (b0 <<< ((clzResult b0).1.toNat % 64)).toNat :=
+    Nat.lt_of_lt_of_le h_u4_lt_pow63 h_b0_ge_pow63
+  exact Eq.symm ((EvmWord.ult_iff).mpr h_lt)
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N1TrialWitnesses.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N1TrialWitnesses.lean
@@ -78,4 +78,43 @@ theorem isTrialN1_j3_true_of_shift_nz (a3 b0 : Word)
     Nat.lt_of_lt_of_le h_u4_lt_pow63 h_b0_ge_pow63
   exact Eq.symm ((EvmWord.ult_iff).mpr h_lt)
 
+/-- Branch-witness package for the n=1 call-first path.
+
+    Under the n=1 nonzero/positive-shift conditions, the first trial branch is
+    forced to `true`; the remaining branch booleans are chosen by their exact
+    runtime comparisons. -/
+theorem n1_trial_witnesses_call_first_of_shift_nz
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hb0nz : b0 ≠ 0)
+    (hshift_nz : (clzResult b0).1 ≠ 0) :
+    ∃ bltu_2 bltu_1 bltu_0,
+      isTrialN1_j3 true a3 b0 ∧
+      isTrialN1_j2 true bltu_2 a2 a3 b0 b1 b2 b3 ∧
+      isTrialN1_j1 true bltu_2 bltu_1 a1 a2 a3 b0 b1 b2 b3 ∧
+      isTrialN1_j0 true bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3 := by
+  let shift := (clzResult b0).1
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let v0' := b0 <<< (shift.toNat % 64)
+  let v1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+  let v2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let v3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let u1S := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
+  let u2S := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u3S := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u4_s := a3 >>> (antiShift.toNat % 64)
+  let r3 := iterN1 true v0' v1' v2' v3' u3S u4_s (0 : Word) (0 : Word) (0 : Word)
+  let bltu_2 := BitVec.ult r3.2.1 v0'
+  let r2 := iterN1 bltu_2 v0' v1' v2' v3' u2S r3.2.1 r3.2.2.1 r3.2.2.2.1 r3.2.2.2.2.1
+  let bltu_1 := BitVec.ult r2.2.1 v0'
+  let r1 := iterN1 bltu_1 v0' v1' v2' v3' u1S r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
+  let bltu_0 := BitVec.ult r1.2.1 v0'
+  refine ⟨bltu_2, bltu_1, bltu_0, ?_, ?_, ?_, ?_⟩
+  · exact isTrialN1_j3_true_of_shift_nz a3 b0 hb0nz hshift_nz
+  · simp [isTrialN1_j2, bltu_2, r3, v0', v1', v2', v3', u3S, u4_s,
+      shift, antiShift]
+  · simp [isTrialN1_j1, bltu_1, bltu_2, r2, r3, v0', v1', v2', v3',
+      u2S, u3S, u4_s, shift, antiShift]
+  · simp [isTrialN1_j0, bltu_0, bltu_1, bltu_2, r1, r2, r3, v0', v1', v2',
+      v3', u1S, u2S, u3S, u4_s, shift, antiShift]
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add theorem n1_trial_witnesses_call_first_of_shift_nz
- fix the first n=1 trial branch to true under nonzero b0 and positive shift, while existentially packaging the remaining runtime branch booleans

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.N1TrialWitnesses
- lake build EvmAsm.Evm64.DivMod.Spec
- git diff --check
- scripts/check-file-size.sh EvmAsm/Evm64/DivMod/Spec/N1TrialWitnesses.lean EvmAsm/Evm64/DivMod/Spec.lean
- rg -n "set_option maxHeartbeats|set_option maxRecDepth|sorry|admit" EvmAsm/Evm64/DivMod/Spec/N1TrialWitnesses.lean