### PR TITLE
feat(div): record n1 normalized divisor nonzero

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N1QuotientStackBridge.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N1QuotientStackBridge.lean
@@ -19,6 +19,32 @@ theorem fullDivN1NormV_limb0_eq
   unfold fullDivN1NormV
   simp
 
+/-- A nonzero n=1 divisor has a nonzero low normalized divisor limb. -/
+theorem fullDivN1NormV_limb0_ne_zero_of_b0_ne_zero
+    (b0 b1 b2 b3 : Word) (hb0nz : b0 ≠ 0) :
+    (fullDivN1NormV b0 b1 b2 b3).1 ≠ 0 := by
+  intro h_zero
+  have h_ge : (b0 <<< ((clzResult b0).1.toNat % 64)).toNat ≥ 2^63 :=
+    b3_shifted_ge_pow63 hb0nz
+  have h_limb0 := fullDivN1NormV_limb0_eq b0 b1 b2 b3
+  unfold fullDivN1Shift at h_limb0
+  have h_nat : (b0 <<< ((clzResult b0).1.toNat % 64)).toNat = 0 := by
+    rw [← h_limb0, h_zero]
+    rfl
+  omega
+
+/-- Nonzero shape needed by the `v3 = 0` n=1 conservation lemma. -/
+theorem fullDivN1NormV_low3_or_zero_ne_zero_of_b0_ne_zero
+    (b0 b1 b2 b3 : Word) (hb0nz : b0 ≠ 0) :
+    (fullDivN1NormV b0 b1 b2 b3).1 |||
+        (fullDivN1NormV b0 b1 b2 b3).2.1 |||
+        (fullDivN1NormV b0 b1 b2 b3).2.2.1 ||| (0 : Word) ≠ 0 := by
+  intro h_zero
+  have h_limb0_ne :=
+    fullDivN1NormV_limb0_ne_zero_of_b0_ne_zero b0 b1 b2 b3 hb0nz
+  apply h_limb0_ne
+  bv_decide
+
 /-- Under the n=1 divisor shape, normalized limb 1 is the low limb's
     anti-shift spill. -/
 theorem fullDivN1NormV_limb1_eq_of_shape

--- a/EvmAsm/Evm64/DivMod/Spec/N1QuotientStackBridge.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N1QuotientStackBridge.lean
@@ -11,6 +11,42 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 
+/-- The low normalized n=1 divisor limb is the shifted original low limb. -/
+theorem fullDivN1NormV_limb0_eq
+    (b0 b1 b2 b3 : Word) :
+    (fullDivN1NormV b0 b1 b2 b3).1 =
+      b0 <<< ((fullDivN1Shift b0).toNat % 64) := by
+  unfold fullDivN1NormV
+  simp
+
+/-- Under the n=1 divisor shape, normalized limb 1 is the low limb's
+    anti-shift spill. -/
+theorem fullDivN1NormV_limb1_eq_of_shape
+    (b0 b1 b2 b3 : Word) (hb1z : b1 = 0) :
+    (fullDivN1NormV b0 b1 b2 b3).2.1 =
+      b0 >>> ((fullDivN1AntiShift b0).toNat % 64) := by
+  subst b1
+  unfold fullDivN1NormV
+  simp
+
+/-- Under the n=1 divisor shape, the second high normalized divisor limb is zero. -/
+theorem fullDivN1NormV_limb2_eq_zero_of_shape
+    (b0 b1 b2 b3 : Word) (hb1z : b1 = 0) (hb2z : b2 = 0) :
+    (fullDivN1NormV b0 b1 b2 b3).2.2.1 = 0 := by
+  subst b1
+  subst b2
+  unfold fullDivN1NormV
+  simp
+
+/-- Under the n=1 divisor shape, the high normalized divisor limb is zero. -/
+theorem fullDivN1NormV_limb3_eq_zero_of_shape
+    (b0 b1 b2 b3 : Word) (hb2z : b2 = 0) (hb3z : b3 = 0) :
+    (fullDivN1NormV b0 b1 b2 b3).2.2.2 = 0 := by
+  subst b2
+  subst b3
+  unfold fullDivN1NormV
+  simp
+
 /-- n=1 quotient bridge specialized to branch constructors that store
     `a`/`b` as `EvmWord`s and refer to their limbs directly. -/
 theorem fullDivN1QuotientWord_eq_div_of_getLimbN_mulsub_overestimate


### PR DESCRIPTION
## Summary
- add a low-limb nonzero lemma for the normalized n=1 divisor from b0 != 0
- add the OR-chain nonzero fact needed by the existing v3=0 n=1 conservation lemma

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.N1QuotientStackBridge
- lake build EvmAsm.Evm64.DivMod.Spec
- git diff --check
- scripts/check-file-size.sh EvmAsm/Evm64/DivMod/Spec/N1QuotientStackBridge.lean
- rg -n "set_option maxHeartbeats|set_option maxRecDepth|sorry|admit|\t" EvmAsm/Evm64/DivMod/Spec/N1QuotientStackBridge.lean