### PR TITLE
feat(div): add n1 getlimb step remainder

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -28,6 +28,7 @@ import EvmAsm.Evm64.DivMod.Spec.N1TrialWitnesses
 import EvmAsm.Evm64.DivMod.Spec.N2TrialWitnesses
 import EvmAsm.Evm64.DivMod.Spec.N3TrialWitnesses
 import EvmAsm.Evm64.DivMod.Spec.N1QuotientWord
+import EvmAsm.Evm64.DivMod.Spec.N1QuotientStackBridgeGetLimbStep
 import EvmAsm.Evm64.DivMod.Spec.N2QuotientWord
 import EvmAsm.Evm64.DivMod.Spec.N2DivStackSpec
 import EvmAsm.Evm64.DivMod.Spec.N2ModBridge

--- a/EvmAsm/Evm64/DivMod/Spec/N1QuotientStackBridgeGetLimbStep.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N1QuotientStackBridgeGetLimbStep.lean
@@ -1,0 +1,63 @@
+import EvmAsm.Evm64.DivMod.Spec.N1QuotientStackBridge
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- n=1 four-limb division witness specialized to `getLimbN` call sites
+    from raw step-conservation witnesses plus the normalized final-remainder
+    bound. -/
+theorem fullDivN1_getLimbN_of_getLimbN_step_conservation_remainder_lt
+    (bltu_3 bltu_2 bltu_1 bltu_0 : Bool) {a b : EvmWord}
+    (hbnz : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 ≠ 0)
+    (hb1z : b.getLimbN 1 = 0) (hb2z : b.getLimbN 2 = 0)
+    (hb3z : b.getLimbN 3 = 0)
+    (hshift_nz : (clzResult (b.getLimbN 0)).1 ≠ 0)
+    (hcarry2 : Carry2NzAll
+      (b.getLimbN 0 <<< (((clzResult (b.getLimbN 0)).1).toNat % 64))
+      ((b.getLimbN 1 <<< (((clzResult (b.getLimbN 0)).1).toNat % 64)) |||
+        (b.getLimbN 0 >>> ((signExtend12 (0 : BitVec 12) -
+          (clzResult (b.getLimbN 0)).1).toNat % 64)))
+      ((b.getLimbN 2 <<< (((clzResult (b.getLimbN 0)).1).toNat % 64)) |||
+        (b.getLimbN 1 >>> ((signExtend12 (0 : BitVec 12) -
+          (clzResult (b.getLimbN 0)).1).toNat % 64)))
+      ((b.getLimbN 3 <<< (((clzResult (b.getLimbN 0)).1).toNat % 64)) |||
+        (b.getLimbN 2 >>> ((signExtend12 (0 : BitVec 12) -
+          (clzResult (b.getLimbN 0)).1).toNat % 64))))
+    (hr3_zero : fullDivN1R3CarryZero bltu_3
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3))
+    (hr2_zero : fullDivN1R2CarryZero bltu_3 bltu_2
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3))
+    (hr1_zero : fullDivN1R1CarryZero bltu_3 bltu_2 bltu_1
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3))
+    (hfinal_zero : fullDivN1FinalCarryZero bltu_3 bltu_2 bltu_1 bltu_0
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3))
+    (hrem_lt : fullDivN1NormalizedRemainderLt bltu_3 bltu_2 bltu_1 bltu_0
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)) :
+    (EvmWord.div a b).getLimbN 0 =
+      (fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1 ∧
+    (EvmWord.div a b).getLimbN 1 =
+      (fullDivN1R1 bltu_3 bltu_2 bltu_1
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1 ∧
+    (EvmWord.div a b).getLimbN 2 =
+      (fullDivN1R2 bltu_3 bltu_2
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1 ∧
+    (EvmWord.div a b).getLimbN 3 =
+      (fullDivN1R3 bltu_3
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1 := by
+  exact fullDivN1_getLimbN_of_step_conservation_remainder_lt
+    bltu_3 bltu_2 bltu_1 bltu_0 rfl rfl rfl rfl rfl rfl rfl rfl
+    hbnz hb1z hb2z hb3z hshift_nz hcarry2
+    hr3_zero hr2_zero hr1_zero hfinal_zero hrem_lt
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add split N1QuotientStackBridgeGetLimbStep module to keep bridge files under the line cap
- expose fullDivN1_getLimbN_of_getLimbN_step_conservation_remainder_lt for getLimbN call sites from raw step-conservation witnesses plus normalized final remainder bound

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.N1QuotientStackBridgeGetLimbStep
- lake build EvmAsm.Evm64.DivMod.Spec
- git diff --check
- scripts/check-file-size.sh
- rg -n "set_option maxHeartbeats|set_option maxRecDepth|sorry|admit|\t" EvmAsm/Evm64/DivMod/Spec/N1QuotientStackBridge.lean EvmAsm/Evm64/DivMod/Spec/N1QuotientStackBridgeGetLimbStep.lean EvmAsm/Evm64/DivMod/Spec.lean