### PR TITLE
feat(div): derive n1 mulsub final carry

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N1FinalCarryZero.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N1FinalCarryZero.lean
@@ -179,6 +179,88 @@ theorem fullDivN1FinalCarryZero_of_raw_step_conservation_overestimate
     hbnz hb1z hb2z hb3z hshift_nz hcarry2Norm
     hr3_zero hr2_zero hr1_zero hge
 
+/-- Step-conservation bridge to the normalized n=1 Euclidean equation,
+    deriving the final carry-zero witness internally from the legacy quotient
+    overestimate. -/
+theorem fullDivN1NormalizedMulSubEq_of_step_conservation_overestimate_final
+    (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb1z : b1 = 0) (hb2z : b2 = 0) (hb3z : b3 = 0)
+    (hshift_nz : (clzResult b0).1 ≠ 0)
+    (hcarry2 : Carry2NzAll
+      (fullDivN1NormV b0 b1 b2 b3).1
+      (fullDivN1NormV b0 b1 b2 b3).2.1
+      (fullDivN1NormV b0 b1 b2 b3).2.2.1
+      (fullDivN1NormV b0 b1 b2 b3).2.2.2)
+    (hr3_zero : fullDivN1R3CarryZero bltu_3 a0 a1 a2 a3 b0 b1 b2 b3)
+    (hr2_zero : fullDivN1R2CarryZero bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3)
+    (hr1_zero : fullDivN1R1CarryZero bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3)
+    (hge :
+      EvmWord.val256 a0 a1 a2 a3 / EvmWord.val256 b0 b1 b2 b3 ≤
+        ((fullDivN1R3 bltu_3 a0 a1 a2 a3 b0 b1 b2 b3).1).toNat * 2 ^ 192 +
+          ((fullDivN1R2 bltu_3 bltu_2
+              a0 a1 a2 a3 b0 b1 b2 b3).1).toNat * 2 ^ 128 +
+          ((fullDivN1R1 bltu_3 bltu_2 bltu_1
+              a0 a1 a2 a3 b0 b1 b2 b3).1).toNat * 2 ^ 64 +
+          ((fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0
+              a0 a1 a2 a3 b0 b1 b2 b3).1).toNat) :
+    fullDivN1NormalizedMulSubEq bltu_3 bltu_2 bltu_1 bltu_0
+      a0 a1 a2 a3 b0 b1 b2 b3 := by
+  have hfinal_zero : fullDivN1FinalCarryZero bltu_3 bltu_2 bltu_1 bltu_0
+      a0 a1 a2 a3 b0 b1 b2 b3 :=
+    fullDivN1FinalCarryZero_of_step_conservation_overestimate
+      bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+      hbnz hb1z hb2z hb3z hshift_nz hcarry2
+      hr3_zero hr2_zero hr1_zero hge
+  exact fullDivN1NormalizedMulSubEq_of_step_conservation
+    bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+    hbnz hb1z hb2z hb3z hshift_nz hcarry2
+    hr3_zero hr2_zero hr1_zero hfinal_zero
+
+/-- Raw dispatcher-surface carry form of
+    `fullDivN1NormalizedMulSubEq_of_step_conservation_overestimate_final`. -/
+theorem fullDivN1NormalizedMulSubEq_of_raw_step_conservation_overestimate_final
+    (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb1z : b1 = 0) (hb2z : b2 = 0) (hb3z : b3 = 0)
+    (hshift_nz : (clzResult b0).1 ≠ 0)
+    (hcarry2 : Carry2NzAll (b0 <<< (((clzResult b0).1).toNat % 64))
+      ((b1 <<< (((clzResult b0).1).toNat % 64)) |||
+        (b0 >>> ((signExtend12 (0 : BitVec 12) -
+          (clzResult b0).1).toNat % 64)))
+      ((b2 <<< (((clzResult b0).1).toNat % 64)) |||
+        (b1 >>> ((signExtend12 (0 : BitVec 12) -
+          (clzResult b0).1).toNat % 64)))
+      ((b3 <<< (((clzResult b0).1).toNat % 64)) |||
+        (b2 >>> ((signExtend12 (0 : BitVec 12) -
+          (clzResult b0).1).toNat % 64))))
+    (hr3_zero : fullDivN1R3CarryZero bltu_3 a0 a1 a2 a3 b0 b1 b2 b3)
+    (hr2_zero : fullDivN1R2CarryZero bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3)
+    (hr1_zero : fullDivN1R1CarryZero bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3)
+    (hge :
+      EvmWord.val256 a0 a1 a2 a3 / EvmWord.val256 b0 b1 b2 b3 ≤
+        ((fullDivN1R3 bltu_3 a0 a1 a2 a3 b0 b1 b2 b3).1).toNat * 2 ^ 192 +
+          ((fullDivN1R2 bltu_3 bltu_2
+              a0 a1 a2 a3 b0 b1 b2 b3).1).toNat * 2 ^ 128 +
+          ((fullDivN1R1 bltu_3 bltu_2 bltu_1
+              a0 a1 a2 a3 b0 b1 b2 b3).1).toNat * 2 ^ 64 +
+          ((fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0
+              a0 a1 a2 a3 b0 b1 b2 b3).1).toNat) :
+    fullDivN1NormalizedMulSubEq bltu_3 bltu_2 bltu_1 bltu_0
+      a0 a1 a2 a3 b0 b1 b2 b3 := by
+  have hfinal_zero : fullDivN1FinalCarryZero bltu_3 bltu_2 bltu_1 bltu_0
+      a0 a1 a2 a3 b0 b1 b2 b3 :=
+    fullDivN1FinalCarryZero_of_raw_step_conservation_overestimate
+      bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+      hbnz hb1z hb2z hb3z hshift_nz hcarry2
+      hr3_zero hr2_zero hr1_zero hge
+  exact fullDivN1NormalizedMulSubEq_of_raw_step_conservation
+    bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+    hbnz hb1z hb2z hb3z hshift_nz hcarry2
+    hr3_zero hr2_zero hr1_zero hfinal_zero
+
 /-- GetLimb-level n=1 hdiv witness from raw step conservation plus the
     legacy quotient overestimate, deriving the final carry-zero fact
     internally. -/


### PR DESCRIPTION
## Summary
- add normalized and raw step-conservation bridges that derive hfinal_zero internally
- expose fullDivN1NormalizedMulSubEq_of_step_conservation_overestimate_final
- expose fullDivN1NormalizedMulSubEq_of_raw_step_conservation_overestimate_final

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.N1FinalCarryZero
- lake build EvmAsm.Evm64.DivMod.Spec
- lake build
- git diff --check
- scripts/check-file-size.sh
- rg -n "set_option maxHeartbeats|set_option maxRecDepth|sorry|admit|\t" EvmAsm/Evm64/DivMod/Spec/N1FinalCarryZero.lean