### PR TITLE
feat(div): add n1 getlimb quotient final bridge

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N1FinalCarryZero.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N1FinalCarryZero.lean
@@ -470,6 +470,69 @@ theorem fullDivN1QuotientWord_eq_div_of_limbs_step_conservation_overestimate_fin
     · exact EvmWord.fromLimbs_match_getLimbN_id a
     · exact EvmWord.fromLimbs_match_getLimbN_id b)
 
+/-- GetLimb-level n=1 quotient bridge from raw step-conservation witnesses
+    plus the legacy quotient overestimate, deriving the final carry-zero and
+    normalized remainder facts internally. -/
+theorem fullDivN1QuotientWord_eq_div_of_getLimbN_step_conservation_overestimate_final
+    (bltu_3 bltu_2 bltu_1 bltu_0 : Bool) {a b : EvmWord}
+    (hbnz : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 ≠ 0)
+    (hb1z : b.getLimbN 1 = 0) (hb2z : b.getLimbN 2 = 0)
+    (hb3z : b.getLimbN 3 = 0)
+    (hshift_nz : (clzResult (b.getLimbN 0)).1 ≠ 0)
+    (hcarry2 : Carry2NzAll
+      (b.getLimbN 0 <<< (((clzResult (b.getLimbN 0)).1).toNat % 64))
+      ((b.getLimbN 1 <<< (((clzResult (b.getLimbN 0)).1).toNat % 64)) |||
+        (b.getLimbN 0 >>> ((signExtend12 (0 : BitVec 12) -
+          (clzResult (b.getLimbN 0)).1).toNat % 64)))
+      ((b.getLimbN 2 <<< (((clzResult (b.getLimbN 0)).1).toNat % 64)) |||
+        (b.getLimbN 1 >>> ((signExtend12 (0 : BitVec 12) -
+          (clzResult (b.getLimbN 0)).1).toNat % 64)))
+      ((b.getLimbN 3 <<< (((clzResult (b.getLimbN 0)).1).toNat % 64)) |||
+        (b.getLimbN 2 >>> ((signExtend12 (0 : BitVec 12) -
+          (clzResult (b.getLimbN 0)).1).toNat % 64))))
+    (hr3_zero : fullDivN1R3CarryZero bltu_3
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3))
+    (hr2_zero : fullDivN1R2CarryZero bltu_3 bltu_2
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3))
+    (hr1_zero : fullDivN1R1CarryZero bltu_3 bltu_2 bltu_1
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3))
+    (hge :
+      EvmWord.val256 (a.getLimbN 0) (a.getLimbN 1)
+          (a.getLimbN 2) (a.getLimbN 3) /
+        EvmWord.val256 (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3) ≤
+        ((fullDivN1R3 bltu_3
+              (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3)
+              (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).1).toNat * 2 ^ 192 +
+          ((fullDivN1R2 bltu_3 bltu_2
+              (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3)
+              (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).1).toNat * 2 ^ 128 +
+          ((fullDivN1R1 bltu_3 bltu_2 bltu_1
+              (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3)
+              (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).1).toNat * 2 ^ 64 +
+          ((fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0
+              (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3)
+              (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).1).toNat) :
+    fullDivN1QuotientWord bltu_3 bltu_2 bltu_1 bltu_0
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) =
+        EvmWord.div a b := by
+  exact fullDivN1QuotientWord_eq_div_of_limbs_step_conservation_overestimate_final
+    bltu_3 bltu_2 bltu_1 bltu_0 rfl rfl rfl rfl rfl rfl rfl rfl
+    hbnz hb1z hb2z hb3z hshift_nz hcarry2
+    hr3_zero hr2_zero hr1_zero hge
+
 /-- GetLimb-level n=1 hdiv witness from raw step conservation plus the
     legacy quotient overestimate, deriving the final carry-zero fact
     internally. -/


### PR DESCRIPTION
## Summary
- add fullDivN1QuotientWord_eq_div_of_getLimbN_step_conservation_overestimate_final
- expose the getLimb-level N1 quotient bridge from raw step-conservation plus quotient overestimate
- derive final carry-zero, normalized mulsub, and normalized remainder internally via the explicit-limb bridge

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.N1FinalCarryZero
- lake build EvmAsm.Evm64.DivMod.Spec
- lake build
- git diff --check
- scripts/check-file-size.sh
- rg -n "set_option maxHeartbeats|set_option maxRecDepth|sorry|admit|\t" EvmAsm/Evm64/DivMod/Spec/N1FinalCarryZero.lean