### PR TITLE
feat(div): expose v4 exact floor quotient surfaces

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith.lean
+++ b/EvmAsm/Evm64/EvmWordArith.lean
@@ -56,4 +56,5 @@ import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV4.Phase2bFireBound
 import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV4.Phase1bBound
 import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV4.Un21Bound
 import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV4.QuotientBounds
+import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV4.ExactQuotient
 import EvmAsm.Evm64.EvmWordArith.Div128CallSkipCloseV4

--- a/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/ExactQuotient.lean
+++ b/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/ExactQuotient.lean
@@ -1,0 +1,77 @@
+/-
+  EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV4.ExactQuotient
+
+  Floor-shaped exact quotient surfaces for the v4 128/64 trial quotient.
+  The heavier lower-bound arithmetic lives in `QuotientBounds`; this split
+  module keeps those declarations available under names that match the final
+  exact-quotient target without growing the near-cap source file.
+-/
+
+import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV4.QuotientBounds
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Exact v4 128/64 floor quotient when `un21` is the first-step
+    mathematical remainder and the matching upper bound has been supplied. -/
+theorem div128Quot_v4_eq_floor_of_un21_eq_r1_of_le
+    (uHi uLo vTop : Word)
+    (hvTop_ge : vTop.toNat ≥ 2^63)
+    (huHi_lt_vTop : uHi.toNat < vTop.toNat)
+    (huHi_lt_pow63 : uHi.toNat < 2^63)
+    (hUn21_lt_vTop :
+      (divKTrialCallV4Un21 uHi uLo vTop).toNat < vTop.toNat)
+    (hUn21_eq_r1 :
+      (divKTrialCallV4Un21 uHi uLo vTop).toNat =
+        (uHi.toNat * 2^32 + (divKTrialCallV4Un1 uLo).toNat) % vTop.toNat)
+    (h_le :
+      (div128Quot_v4 uHi uLo vTop).toNat ≤
+        (uHi.toNat * 2^64 + uLo.toNat) / vTop.toNat) :
+    (div128Quot_v4 uHi uLo vTop).toNat =
+      (uHi.toNat * 2^64 + uLo.toNat) / vTop.toNat :=
+  div128Quot_v4_eq_q_true_of_un21_eq_r1_of_le uHi uLo vTop
+    hvTop_ge huHi_lt_vTop huHi_lt_pow63 hUn21_lt_vTop hUn21_eq_r1 h_le
+
+/-- Exact v4 128/64 floor quotient from the Phase-1 low-half no-wrap
+    condition and the matching upper bound. -/
+theorem div128Quot_v4_eq_floor_of_no_wrap_of_le
+    (uHi uLo vTop : Word)
+    (hvTop_ge : vTop.toNat ≥ 2^63)
+    (huHi_lt_vTop : uHi.toNat < vTop.toNat)
+    (huHi_lt_pow63 : uHi.toNat < 2^63)
+    (hUn21_lt_vTop :
+      (divKTrialCallV4Un21 uHi uLo vTop).toNat < vTop.toNat)
+    (h_no_wrap :
+      (divKTrialCallV4Q1dd uHi uLo vTop).toNat *
+          (divKTrialCallV4DLo vTop).toNat ≤
+        ((divKTrialCallV4Rhatdd uHi uLo vTop).toNat % 2^32) * 2^32 +
+          (divKTrialCallV4Un1 uLo).toNat)
+    (h_le :
+      (div128Quot_v4 uHi uLo vTop).toNat ≤
+        (uHi.toNat * 2^64 + uLo.toNat) / vTop.toNat) :
+    (div128Quot_v4 uHi uLo vTop).toNat =
+      (uHi.toNat * 2^64 + uLo.toNat) / vTop.toNat :=
+  div128Quot_v4_eq_q_true_of_no_wrap_of_le uHi uLo vTop
+    hvTop_ge huHi_lt_vTop huHi_lt_pow63 hUn21_lt_vTop h_no_wrap h_le
+
+/-- Exact v4 128/64 floor quotient in the final Phase-1b high-half-zero
+    branch, assuming the matching upper bound has been supplied. -/
+theorem div128Quot_v4_eq_floor_of_rhatdd_hi_zero_of_le
+    (uHi uLo vTop : Word)
+    (hvTop_ge : vTop.toNat ≥ 2^63)
+    (huHi_lt_vTop : uHi.toNat < vTop.toNat)
+    (huHi_lt_pow63 : uHi.toNat < 2^63)
+    (hUn21_lt_vTop :
+      (divKTrialCallV4Un21 uHi uLo vTop).toNat < vTop.toNat)
+    (h_rhat_hi_zero :
+      divKTrialCallV4Rhatdd uHi uLo vTop >>> (32 : BitVec 6).toNat = (0 : Word))
+    (h_le :
+      (div128Quot_v4 uHi uLo vTop).toNat ≤
+        (uHi.toNat * 2^64 + uLo.toNat) / vTop.toNat) :
+    (div128Quot_v4 uHi uLo vTop).toNat =
+      (uHi.toNat * 2^64 + uLo.toNat) / vTop.toNat :=
+  div128Quot_v4_eq_q_true_of_rhatdd_hi_zero_of_le uHi uLo vTop
+    hvTop_ge huHi_lt_vTop huHi_lt_pow63 hUn21_lt_vTop h_rhat_hi_zero h_le
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add split CallSkipLowerBoundV4.ExactQuotient module to avoid growing the near-cap QuotientBounds file
- expose floor-shaped exact V4 128/64 quotient wrappers for un21=remainder, no-wrap, and rhatdd-high-zero branches
- wire the new module into EvmWordArith.lean so downstream proofs can import it through the umbrella

## Verification
- lake build EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV4.ExactQuotient
- lake build EvmAsm.Evm64.EvmWordArith
- lake build
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- rg -n "set_option maxHeartbeats|set_option maxRecDepth|sorry|admit|\t" EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/ExactQuotient.lean EvmAsm/Evm64/EvmWordArith.lean