### PR TITLE
feat(div): bridge v4 floor quotient to val256 lower bound

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/ExactQuotient.lean
+++ b/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/ExactQuotient.lean
@@ -8,10 +8,12 @@
 -/
 
 import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV4.QuotientBounds
+import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV2
 
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
+open EvmWord (val256)
 
 /-- Exact v4 128/64 floor quotient when `un21` is the first-step
     mathematical remainder and the matching upper bound has been supplied. -/
@@ -73,5 +75,29 @@ theorem div128Quot_v4_eq_floor_of_rhatdd_hi_zero_of_le
       (uHi.toNat * 2^64 + uLo.toNat) / vTop.toNat :=
   div128Quot_v4_eq_q_true_of_rhatdd_hi_zero_of_le uHi uLo vTop
     hvTop_ge huHi_lt_vTop huHi_lt_pow63 hUn21_lt_vTop h_rhat_hi_zero h_le
+
+/-- V4 call-skip val256 lower bound from an exact 128/64 floor equality.
+
+    This is the qHat-agnostic §B normalization bridge from v1 composed with
+    a supplied exactness fact for `div128Quot_v4`. -/
+theorem div128Quot_v4_call_skip_ge_val256_div_of_floor
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hb3nz : b3 ≠ 0)
+    (hshift_nz : (clzResult b3).1 ≠ 0) :
+    let shift := (clzResult b3).1.toNat % 64
+    let antiShift := (signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64
+    let b3' := (b3 <<< shift) ||| (b2 >>> antiShift)
+    let u4 := a3 >>> antiShift
+    let u3 := (a3 <<< shift) ||| (a2 >>> antiShift)
+    (div128Quot_v4 u4 u3 b3').toNat =
+        (u4.toNat * 2^64 + u3.toNat) / b3'.toNat →
+    val256 a0 a1 a2 a3 / val256 b0 b1 b2 b3 ≤
+      (div128Quot_v4 u4 u3 b3').toNat := by
+  intro shift antiShift b3' u4 u3 h_floor
+  have h_bridge := q_true_triple_bridge_to_val256_norm
+    a0 a1 a2 a3 b0 b1 b2 b3 hshift_nz hb3nz
+  simp only [] at h_bridge
+  rw [h_floor]
+  exact h_bridge
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- import the qHat-agnostic v1 normalization bridge into the V4 ExactQuotient split module
- add div128Quot_v4_call_skip_ge_val256_div_of_floor, composing a supplied exact 128/64 floor equality with the val256-level lower-bound bridge

## Verification
- lake build EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV4.ExactQuotient
- lake build EvmAsm.Evm64.EvmWordArith
- lake build
- git diff --check
- scripts/check-file-size.sh
- rg -n "set_option maxHeartbeats|set_option maxRecDepth|sorry|admit|\t" EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/ExactQuotient.lean