### PR TITLE
feat(div): add v4 val256 lower bound from no-wrap evidence

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/ExactQuotient.lean
+++ b/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/ExactQuotient.lean
@@ -139,4 +139,45 @@ theorem div128Quot_v4_call_skip_ge_val256_div_of_un21_eq_r1_of_le
   exact div128Quot_v4_call_skip_ge_val256_div_of_floor
     a0 a1 a2 a3 b0 b1 b2 b3 hb3nz hshift_nz h_floor
 
+/-- V4 call-skip val256 lower bound from the Phase-1 low-half no-wrap
+    condition and a supplied 128/64 upper bound. -/
+theorem div128Quot_v4_call_skip_ge_val256_div_of_no_wrap_of_le
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hb3nz : b3 ≠ 0)
+    (hshift_nz : (clzResult b3).1 ≠ 0)
+    (hcall : isCallTrialN4 a3 b2 b3) :
+    let shift := (clzResult b3).1.toNat % 64
+    let antiShift := (signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64
+    let b3' := (b3 <<< shift) ||| (b2 >>> antiShift)
+    let u4 := a3 >>> antiShift
+    let u3 := (a3 <<< shift) ||| (a2 >>> antiShift)
+    (divKTrialCallV4Un21 u4 u3 b3').toNat < b3'.toNat →
+    (divKTrialCallV4Q1dd u4 u3 b3').toNat *
+        (divKTrialCallV4DLo b3').toNat ≤
+      ((divKTrialCallV4Rhatdd u4 u3 b3').toNat % 2^32) * 2^32 +
+        (divKTrialCallV4Un1 u3).toNat →
+    (div128Quot_v4 u4 u3 b3').toNat ≤
+      (u4.toNat * 2^64 + u3.toNat) / b3'.toNat →
+    val256 a0 a1 a2 a3 / val256 b0 b1 b2 b3 ≤
+      (div128Quot_v4 u4 u3 b3').toNat := by
+  intro shift antiShift b3' u4 u3 hUn21_lt_vTop h_no_wrap h_le
+  have hb3'_ge : b3'.toNat ≥ 2^63 :=
+    b3_prime_ge_pow63 b3 b2 hb3nz _
+  have hu4_lt_b3' : u4.toNat < b3'.toNat :=
+    isCallTrialN4_toNat_lt a3 b2 b3 hcall
+  have h_shift_pos : 1 ≤ (clzResult b3).1.toNat := by
+    rcases Nat.eq_zero_or_pos (clzResult b3).1.toNat with h_zero | h_pos
+    · exfalso
+      apply hshift_nz
+      exact BitVec.eq_of_toNat_eq (by simp [h_zero])
+    · exact h_pos
+  have hu4_lt_pow63 : u4.toNat < 2^63 :=
+    u_top_lt_pow63_of_shift_nz a3 (clzResult b3).1 h_shift_pos
+      (clzResult_fst_toNat_le b3)
+  have h_floor := div128Quot_v4_eq_floor_of_no_wrap_of_le
+    u4 u3 b3' hb3'_ge hu4_lt_b3' hu4_lt_pow63
+    hUn21_lt_vTop h_no_wrap h_le
+  exact div128Quot_v4_call_skip_ge_val256_div_of_floor
+    a0 a1 a2 a3 b0 b1 b2 b3 hb3nz hshift_nz h_floor
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add div128Quot_v4_call_skip_ge_val256_div_of_no_wrap_of_le
- compose the no-wrap exact-quotient wrapper with the V4 val256 floor bridge
- keep runtime normalization/u4 side conditions discharged from hb3nz, shift_nz, and isCallTrialN4

## Verification
- lake build EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV4.ExactQuotient
- lake build EvmAsm.Evm64.EvmWordArith
- lake build
- git diff --check
- scripts/check-file-size.sh
- rg -n "set_option maxHeartbeats|set_option maxRecDepth|sorry|admit|\t" EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/ExactQuotient.lean