### PR TITLE
feat(div): add v4 callskip shift no-wrap wrappers

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/CallSkipV4.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/CallSkipV4.lean
@@ -1133,6 +1133,84 @@ theorem evm_div_n4_call_skip_stack_pre_spec_bundled_v4_noNop_of_runtime_no_wrap_
     (fun _ hq => hq)
     h
 
+/-- Bundled v4 call+skip stack wrapper in the no-wrap branch, with
+    call-trial discharged from `shift ≠ 0`. -/
+theorem evm_div_n4_call_skip_stack_pre_spec_bundled_v4_of_shift_nz_no_wrap_of_le
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hborrow : isSkipBorrowN4CallV4Evm a b) :
+    let shift := (clzResult (b.getLimbN 3)).1.toNat % 64
+    let antiShift :=
+      (signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 3)).1).toNat % 64
+    let b3' := ((b.getLimbN 3) <<< shift) ||| ((b.getLimbN 2) >>> antiShift)
+    let u4Top := (a.getLimbN 3) >>> antiShift
+    let u3Top := ((a.getLimbN 3) <<< shift) ||| ((a.getLimbN 2) >>> antiShift)
+    (divKTrialCallV4Q1dd u4Top u3Top b3').toNat *
+        (divKTrialCallV4DLo b3').toNat ≤
+      ((divKTrialCallV4Rhatdd u4Top u3Top b3').toNat % 2^32) * 2^32 +
+        (divKTrialCallV4Un1 u3Top).toNat →
+    (div128Quot_v4 u4Top u3Top b3').toNat ≤
+      (u4Top.toNat * 2^64 + u3Top.toNat) / b3'.toNat →
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 148 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) := by
+  intro shift antiShift b3' u4Top u3Top h_no_wrap h_le
+  have hbltu : isCallTrialN4Evm a b :=
+    isCallTrialN4Evm_of_shift_nz a b hb3nz hshift_nz
+  exact evm_div_n4_call_skip_stack_pre_spec_bundled_v4_of_runtime_no_wrap_of_le
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign hbltu hborrow h_no_wrap h_le
+
+/-- Bundled no-NOP v4 call+skip stack wrapper in the no-wrap branch, with
+    call-trial discharged from `shift ≠ 0`. -/
+theorem evm_div_n4_call_skip_stack_pre_spec_bundled_v4_noNop_of_shift_nz_no_wrap_of_le
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hborrow : isSkipBorrowN4CallV4Evm a b) :
+    let shift := (clzResult (b.getLimbN 3)).1.toNat % 64
+    let antiShift :=
+      (signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 3)).1).toNat % 64
+    let b3' := ((b.getLimbN 3) <<< shift) ||| ((b.getLimbN 2) >>> antiShift)
+    let u4Top := (a.getLimbN 3) >>> antiShift
+    let u3Top := ((a.getLimbN 3) <<< shift) ||| ((a.getLimbN 2) >>> antiShift)
+    (divKTrialCallV4Q1dd u4Top u3Top b3').toNat *
+        (divKTrialCallV4DLo b3').toNat ≤
+      ((divKTrialCallV4Rhatdd u4Top u3Top b3').toNat % 2^32) * 2^32 +
+        (divKTrialCallV4Un1 u3Top).toNat →
+    (div128Quot_v4 u4Top u3Top b3').toNat ≤
+      (u4Top.toNat * 2^64 + u3Top.toNat) / b3'.toNat →
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 148 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_noNop_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) := by
+  intro shift antiShift b3' u4Top u3Top h_no_wrap h_le
+  have hbltu : isCallTrialN4Evm a b :=
+    isCallTrialN4Evm_of_shift_nz a b hb3nz hshift_nz
+  exact evm_div_n4_call_skip_stack_pre_spec_bundled_v4_noNop_of_runtime_no_wrap_of_le
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign hbltu hborrow h_no_wrap h_le
+
 /-- Bundled v4 call+skip stack wrapper in the rhat-zero branch, with
     call-trial discharged from `shift ≠ 0`. -/
 theorem evm_div_n4_call_skip_stack_pre_spec_bundled_v4_of_shift_nz_rhatdd_hi_zero


### PR DESCRIPTION
## Summary
- add bundled v4 call+skip no-wrap wrappers that derive call-trial from shift-nonzero evidence
- cover both NOP and no-NOP code paths

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.CallSkipV4
- lake build EvmAsm.Evm64.DivMod.Spec
- lake build
- git diff --check
- scripts/check-file-size.sh
- rg -n "set_option maxHeartbeats|set_option maxRecDepth|sorry|admit|\t" EvmAsm/Evm64/DivMod/Spec/CallSkipV4.lean