### PR TITLE
feat(div): add v4 callskip branch stack spec aliases

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/CallSkipV4NoWrap.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/CallSkipV4NoWrap.lean
@@ -243,4 +243,55 @@ theorem evm_div_n4_call_skip_stack_pre_spec_bundled_v4_noNop_of_branch_pred_hb3n
         nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
         hb3nz hshift_nz halign hborrow h_no_wrap_le
 
+/-- Final-API named v4 call+skip stack spec under the explicit branch
+    certificate. The remaining unconditional work is to discharge
+    `n4CallSkipBranchV4` from runtime facts. -/
+theorem evm_div_n4_call_skip_stack_spec_v4_of_branch_pred_hb3nz
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hborrow : isSkipBorrowN4CallV4Evm a b)
+    (hbranch : n4CallSkipBranchV4 a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 148 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_call_skip_stack_pre_spec_bundled_v4_of_branch_pred_hb3nz
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign hborrow hbranch
+
+/-- No-NOP final-API named v4 call+skip stack spec under the explicit branch
+    certificate. -/
+theorem evm_div_n4_call_skip_stack_spec_v4_noNop_of_branch_pred_hb3nz
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hborrow : isSkipBorrowN4CallV4Evm a b)
+    (hbranch : n4CallSkipBranchV4 a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 148 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_noNop_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_call_skip_stack_pre_spec_bundled_v4_noNop_of_branch_pred_hb3nz
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign hborrow hbranch
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add final-API named v4 call+skip stack spec aliases under the explicit branch predicate
- cover both NOP and no-NOP divCode_v4 paths
- keep the remaining runtime discharge visible as n4CallSkipBranchV4

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.CallSkipV4NoWrap
- lake build EvmAsm.Evm64.DivMod.Spec
- lake build
- git diff --check
- scripts/check-file-size.sh
- forbidden-pattern scan over EvmAsm/Evm64/DivMod/Spec/CallSkipV4NoWrap.lean