### PR TITLE
feat(div): add addback runtime bounds semantic wrapper

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/CallAddbackRuntime.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/CallAddbackRuntime.lean
@@ -667,6 +667,19 @@ theorem n4CallAddbackBeqSemanticHoldsV4_of_runtime_bounds
   n4CallAddbackBeqSemanticHoldsV4_of_runtime_conditions_compact
     hb3nz hshift_nz h_bounds.1 h_borrow h_carry2 h_bounds.2
 
+/-- Historical non-`V4` spelling of
+    `n4CallAddbackBeqSemanticHoldsV4_of_runtime_bounds`. -/
+theorem n4CallAddbackBeqSemanticHolds_of_runtime_bounds
+    {a b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (h_bounds : n4CallAddbackBeqRuntimeBounds a b)
+    (h_borrow : isAddbackBorrowN4CallV4Evm a b)
+    (h_carry2 : isAddbackCarry2NzN4CallV4Evm a b) :
+    n4CallAddbackBeqSemanticHolds a b := by
+  simpa [n4CallAddbackBeqSemanticHolds_eq_v4] using
+    n4CallAddbackBeqSemanticHoldsV4_of_runtime_bounds
+      hb3nz hshift_nz h_bounds h_borrow h_carry2
 
 /-- **n4 call+addback (shift≠0) getLimbN bridge.**
     Under `n4CallAddbackBeqSemanticHolds a b` (the algorithm's q_out equals the

--- a/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcher.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcher.lean
@@ -106,9 +106,8 @@ theorem evm_div_n4_shift_nz_stack_spec_v4_of_runtime_bounds
           hb3nz hshift_nz halign hskip hbranch)
   | inr hadd =>
       have hsem : n4CallAddbackBeqSemanticHolds a b := by
-        simpa [n4CallAddbackBeqSemanticHolds_eq_v4] using
-          n4CallAddbackBeqSemanticHoldsV4_of_runtime_bounds
-            hb3nz hshift_nz h_bounds hadd hcarry2
+        exact n4CallAddbackBeqSemanticHolds_of_runtime_bounds
+          hb3nz hshift_nz h_bounds hadd hcarry2
       exact evm_div_n4_call_addback_beq_stack_spec
         sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
         nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem


### PR DESCRIPTION
## Summary
- add historical non-V4 n4CallAddbackBeqSemanticHolds_of_runtime_bounds wrapper
- update the n=4 v4 shift dispatcher runtime-bounds path to use that wrapper directly

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.CallAddbackRuntime
- lake build EvmAsm.Evm64.DivMod.Spec.N4V4ShiftNzDispatcher
- lake build EvmAsm.Evm64.DivMod.Spec
- lake build
- git diff --check
- scripts/check-file-size.sh
- forbidden-pattern scan over edited files