### PR TITLE
K234 stateless: account_validate_code_hash_empty

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -4379,6 +4379,7 @@ def lookupProgramTail : String → Option BuildUnit
   | "zisk_chain_compute_total_blob_gas" => some ziskChainComputeTotalBlobGasProbeUnit
   | "zisk_header_extract_timestamp" => some ziskHeaderExtractTimestampProbeUnit
   | "zisk_header_extract_number" => some ziskHeaderExtractNumberProbeUnit
+  | "zisk_account_validate_code_hash_empty" => some ziskAccountValidateCodeHashEmptyProbeUnit
   | "zisk_block_validate_2tx_full" => some ziskBlockValidate2txFullProbeUnit
   | "zisk_block_body_extract_2tx" => some ziskBlockBodyExtract2txProbeUnit
   | "zisk_block_validate_2tx_full_with_body" => some ziskBlockValidate2txFullWithBodyProbeUnit
@@ -4786,6 +4787,7 @@ def knownProgramNames : List String :=
    "zisk_chain_compute_total_blob_gas",
    "zisk_header_extract_timestamp",
    "zisk_header_extract_number",
+   "zisk_account_validate_code_hash_empty",
    "zisk_block_validate_2tx_full",
    "zisk_block_body_extract_2tx",
    "zisk_block_validate_2tx_full_with_body",

--- a/EvmAsm/Codegen/Programs/Account.lean
+++ b/EvmAsm/Codegen/Programs/Account.lean
@@ -347,4 +347,98 @@ def ziskAccountIsEmptyProbeUnit : BuildUnit := {
   dataAsm     := ziskAccountIsEmptyDataSection
 }
 
+/-! ## account_validate_code_hash_empty -- PR-K234
+
+    Predicate: `account.code_hash == EMPTY_CODE_HASH` where
+    `EMPTY_CODE_HASH = keccak256(b'') =
+        0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470`
+
+    This is the "is EOA / contract has no code" check. Useful
+    as a standalone predicate without the balance/nonce
+    constraints of K123 `account_is_empty` — e.g., to decide
+    whether to skip the EVM call into a contract during static
+    analysis, or to test the EIP-7702 delegation-clear path.
+
+    Calling convention:
+      a0 (input)  : account_rlp ptr
+      a1 (input)  : account_rlp byte length
+      a2 (input)  : u64 out (1 if code_hash == EMPTY_CODE_HASH)
+      ra (input)  : return
+      a0 (output) :
+        0 : success — predicate written
+        1 : RLP parse failure / field 3 missing
+        2 : field 3 length != 32 -/
+def accountValidateCodeHashEmptyFunction : String :=
+  "account_validate_code_hash_empty:\n" ++
+  "  addi sp, sp, -32\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp)\n" ++
+  "  mv s0, a0                   # account_ptr\n" ++
+  "  mv s1, a1                   # account_len\n" ++
+  "  mv s2, a2                   # out u64 ptr\n" ++
+  "  sd zero, 0(s2)\n" ++
+  "  mv a0, s0; mv a1, s1\n" ++
+  "  li a2, 3\n" ++
+  "  la a3, avche_offset; la a4, avche_length\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lavche_parse_fail\n" ++
+  "  la t0, avche_length; ld t1, 0(t0)\n" ++
+  "  li t2, 32\n" ++
+  "  bne t1, t2, .Lavche_size_fail\n" ++
+  "  la t0, avche_offset; ld t3, 0(t0); add t3, s0, t3\n" ++
+  "  la t4, avche_empty_code_hash\n" ++
+  "  ld t5,  0(t3); ld t6,  0(t4); bne t5, t6, .Lavche_not_empty\n" ++
+  "  ld t5,  8(t3); ld t6,  8(t4); bne t5, t6, .Lavche_not_empty\n" ++
+  "  ld t5, 16(t3); ld t6, 16(t4); bne t5, t6, .Lavche_not_empty\n" ++
+  "  ld t5, 24(t3); ld t6, 24(t4); bne t5, t6, .Lavche_not_empty\n" ++
+  "  li t0, 1\n" ++
+  "  sd t0, 0(s2)\n" ++
+  ".Lavche_not_empty:\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lavche_ret\n" ++
+  ".Lavche_parse_fail:\n" ++
+  "  li a0, 1\n" ++
+  "  j .Lavche_ret\n" ++
+  ".Lavche_size_fail:\n" ++
+  "  li a0, 2\n" ++
+  ".Lavche_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp)\n" ++
+  "  addi sp, sp, 32\n" ++
+  "  ret"
+
+def ziskAccountValidateCodeHashEmptyPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a3, 0x40000000\n" ++
+  "  ld a1, 8(a3)\n" ++
+  "  addi a0, a3, 16\n" ++
+  "  li a2, 0xa0010008\n" ++
+  "  jal ra, account_validate_code_hash_empty\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lavche_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  accountValidateCodeHashEmptyFunction ++ "\n" ++
+  ".Lavche_pdone:"
+
+def ziskAccountValidateCodeHashEmptyDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "avche_offset:\n" ++
+  "  .zero 8\n" ++
+  "avche_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "avche_empty_code_hash:\n" ++
+  "  .byte 0xc5, 0xd2, 0x46, 0x01, 0x86, 0xf7, 0x23, 0x3c\n" ++
+  "  .byte 0x92, 0x7e, 0x7d, 0xb2, 0xdc, 0xc7, 0x03, 0xc0\n" ++
+  "  .byte 0xe5, 0x00, 0xb6, 0x53, 0xca, 0x82, 0x27, 0x3b\n" ++
+  "  .byte 0x7b, 0xfa, 0xd8, 0x04, 0x5d, 0x85, 0xa4, 0x70"
+
+def ziskAccountValidateCodeHashEmptyProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskAccountValidateCodeHashEmptyPrologue
+  dataAsm     := ziskAccountValidateCodeHashEmptyDataSection
+}
+
 end EvmAsm.Codegen

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **256**
-- ziskemu round-trip scripts: **246** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **257**
+- ziskemu round-trip scripts: **247** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-account-validate-code-hash-empty-check.sh
+++ b/scripts/codegen-zisk-account-validate-code-hash-empty-check.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# codegen-zisk-account-validate-code-hash-empty-check.sh -- PR-K234.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_account_validate_code_hash_empty ELF"
+lake exe codegen --program zisk_account_validate_code_hash_empty --halt linux93 \
+  -o gen-out/zisk_account_validate_code_hash_empty
+
+REPO_ROOT="$(pwd)"
+
+EMPTY_HASH_HEX="c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"
+
+run_case() {
+  local name="$1" code_hash_hex="$2" exp_empty="$3"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_account_validate_code_hash_empty_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_account_validate_code_hash_empty_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+def u_be(n):
+    if n == 0: return b''
+    return n.to_bytes((n.bit_length() + 7) // 8, 'big')
+
+code_hash = bytes.fromhex('$code_hash_hex')
+account = rlp.encode([
+    u_be(7),               # nonce
+    u_be(10**18),          # balance (1 ETH)
+    b'\\xaa'*32,           # storage_root (irrelevant)
+    code_hash,
+])
+with open(sys.argv[1], 'wb') as f:
+    record = struct.pack('<Q', len(account)) + account
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_account_validate_code_hash_empty.elf \
+    -i "$in_file" -o "$out_file" -n 1000000 \
+    >"$REPO_ROOT/gen-out/zisk_account_validate_code_hash_empty_${name}.emu.log" 2>&1 || true
+
+  local v_le; v_le="$(dd if="$out_file" bs=1 skip=8 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local actual; actual="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$v_le'))[0])")"
+
+  if [[ "$actual" == "$exp_empty" ]]; then
+    printf "  %-26s OK   is_empty=%s\n" "$name" "$actual"
+    return 0
+  else
+    printf "  %-26s FAIL actual=%s expected=%s\n" "$name" "$actual" "$exp_empty"
+    return 1
+  fi
+}
+
+FAILED=0
+run_case "eoa_empty"     "$EMPTY_HASH_HEX"                                                  1 || FAILED=1
+run_case "contract_a"    "0000000000000000000000000000000000000000000000000000000000000001" 0 || FAILED=1
+run_case "contract_b"    "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef" 0 || FAILED=1
+run_case "all_ff"        "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff" 0 || FAILED=1
+run_case "near_empty"    "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a471" 0 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: account_validate_code_hash_empty matches code_hash == EMPTY_CODE_HASH"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Adds `account_validate_code_hash_empty`: predicate `code_hash == EMPTY_CODE_HASH = keccak256(b'')`.
- The standalone "is EOA / contract has no code" check, without the balance/nonce constraints of K123 `account_is_empty`.
- Lives in the new `Programs/Account.lean` (stacked on #6201).

## Test plan
- [x] `lake build codegen` clean
- [x] `scripts/codegen-zisk-account-validate-code-hash-empty-check.sh` all 5 fixtures pass:
  - `eoa_empty (code_hash = EMPTY)`: is_empty=1 ✓
  - `contract_a (0x00..01)`: is_empty=0 ✓
  - `contract_b (random 32B)`: is_empty=0 ✓
  - `all_ff (0xff..ff)`: is_empty=0 ✓
  - `near_empty (EMPTY off-by-one in last byte)`: is_empty=0 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)