### PR TITLE
K235 stateless: account_validate_storage_root_empty + Receipt extract

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -58,6 +58,7 @@ import EvmAsm.Codegen.Programs.BlockRoots
 import EvmAsm.Codegen.Programs.Header
 import EvmAsm.Codegen.Programs.HeaderFields
 import EvmAsm.Codegen.Programs.HeaderU64
+import EvmAsm.Codegen.Programs.Receipt
 import EvmAsm.Codegen.Programs.Withdrawal
 import EvmAsm.Codegen.Programs.Address
 
@@ -3509,313 +3510,6 @@ def ziskStateRootSingleAccountProbeUnit : BuildUnit := {
 
 /-! ## bloom atoms K148-K154 — moved to `Programs/Bloom.lean` (file-size hard cap). -/
 
-/-! ## rlp_encode_u64 -- PR-K155
-
-    Encode a `u64` register value as canonical RLP. A convenience
-    wrapper that takes the integer directly rather than the BE
-    byte buffer that PR-K30 `rlp_encode_uint_be` requires:
-
-      value == 0       -> 0x80                       (1 byte)
-      value < 0x80     -> single byte = value        (1 byte)
-      else             -> 0x80 + effective_len + BE bytes
-                          (effective_len in 1..8)    (2..9 bytes)
-
-    Pure register arithmetic, leaf-callable, no scratch memory.
-    Use cases where K30 with a stack-allocated BE buffer is
-    awkward boilerplate -- typical example is receipt encoding:
-
-      rlp_encode_u64(status, buf + cursor, &written); cursor += written
-      rlp_encode_u64(cumulative_gas, buf + cursor, &written); cursor += written
-      ...
-
-    Calling convention:
-      a0 (input)  : value (u64)
-      a1 (input)  : output buffer ptr (caller supplies >= 9 bytes)
-      a2 (input)  : u64 out length ptr (bytes written; 1..9)
-      ra (input)  : return
-      a0 (output) : 0 (always succeeds). -/
-def rlpEncodeU64Function : String :=
-  "rlp_encode_u64:\n" ++
-  "  beqz a0, .Lreu64_zero\n" ++
-  "  li t0, 0x80\n" ++
-  "  bgeu a0, t0, .Lreu64_multi\n" ++
-  "  # Single-byte form (value in 0x01..0x7f).\n" ++
-  "  sb a0, 0(a1)\n" ++
-  "  li t1, 1\n" ++
-  "  sd t1, 0(a2)\n" ++
-  "  li a0, 0\n" ++
-  "  ret\n" ++
-  ".Lreu64_zero:\n" ++
-  "  li t0, 0x80\n" ++
-  "  sb t0, 0(a1)\n" ++
-  "  li t1, 1\n" ++
-  "  sd t1, 0(a2)\n" ++
-  "  li a0, 0\n" ++
-  "  ret\n" ++
-  ".Lreu64_multi:\n" ++
-  "  # Compute effective byte length (1..8) by finding the top non-zero byte.\n" ++
-  "  # We already know value >= 0x80, so len >= 1.\n" ++
-  "  li t0, 1                   # effective_len candidate\n" ++
-  "  li t1, 0x100\n" ++
-  "  bltu a0, t1, .Lreu64_have_len\n" ++
-  "  li t0, 2\n" ++
-  "  slli t1, t1, 8\n" ++
-  "  bltu a0, t1, .Lreu64_have_len\n" ++
-  "  li t0, 3\n" ++
-  "  slli t1, t1, 8\n" ++
-  "  bltu a0, t1, .Lreu64_have_len\n" ++
-  "  li t0, 4\n" ++
-  "  slli t1, t1, 8\n" ++
-  "  bltu a0, t1, .Lreu64_have_len\n" ++
-  "  li t0, 5\n" ++
-  "  slli t1, t1, 8\n" ++
-  "  bltu a0, t1, .Lreu64_have_len\n" ++
-  "  li t0, 6\n" ++
-  "  slli t1, t1, 8\n" ++
-  "  bltu a0, t1, .Lreu64_have_len\n" ++
-  "  li t0, 7\n" ++
-  "  slli t1, t1, 8\n" ++
-  "  bltu a0, t1, .Lreu64_have_len\n" ++
-  "  li t0, 8\n" ++
-  ".Lreu64_have_len:\n" ++
-  "  # Write prefix 0x80 + effective_len.\n" ++
-  "  addi t2, t0, 0x80\n" ++
-  "  sb t2, 0(a1)\n" ++
-  "  # Write effective_len BE bytes of value into a1+1..a1+1+len.\n" ++
-  "  addi t3, a1, 1                 # dst cursor\n" ++
-  "  addi t4, t0, -1                # shift_byte_index = len - 1\n" ++
-  ".Lreu64_emit:\n" ++
-  "  bltz t4, .Lreu64_done\n" ++
-  "  slli t5, t4, 3                 # bit shift = 8 * byte_index\n" ++
-  "  srl t6, a0, t5\n" ++
-  "  sb t6, 0(t3)\n" ++
-  "  addi t3, t3, 1\n" ++
-  "  addi t4, t4, -1\n" ++
-  "  j .Lreu64_emit\n" ++
-  ".Lreu64_done:\n" ++
-  "  addi t1, t0, 1                 # bytes_written = 1 + effective_len\n" ++
-  "  sd t1, 0(a2)\n" ++
-  "  li a0, 0\n" ++
-  "  ret"
-
-/-- `zisk_rlp_encode_u64`: probe BuildUnit.
-    Input layout:
-      bytes  0.. 8 : value (u64)
-    Output layout:
-      bytes  0.. 8 : status (always 0)
-      bytes  8..16 : bytes_written
-      bytes 16..25 : encoded RLP (up to 9 bytes) -/
-def ziskRlpEncodeU64Prologue : String :=
-  "  li sp, 0xa0050000\n" ++
-  "  li a3, 0x40000000\n" ++
-  "  ld a0, 8(a3)                # value\n" ++
-  "  li a1, 0xa0010010           # output buffer ptr\n" ++
-  "  li a2, 0xa0010008           # out length ptr\n" ++
-  "  jal ra, rlp_encode_u64\n" ++
-  "  li t0, 0xa0010000\n" ++
-  "  sd a0, 0(t0)\n" ++
-  "  j .Lreu64_pdone\n" ++
-  rlpEncodeU64Function ++ "\n" ++
-  ".Lreu64_pdone:"
-
-def ziskRlpEncodeU64DataSection : String :=
-  ".section .data\n" ++
-  "reu64_pad:\n" ++
-  "  .zero 8"
-
-def ziskRlpEncodeU64ProbeUnit : BuildUnit := {
-  body        := NOP
-  prologueAsm := ziskRlpEncodeU64Prologue
-  dataAsm     := ziskRlpEncodeU64DataSection
-}
-
-/-! ## receipt_encode -- PR-K156
-
-    Encode an Ethereum tx receipt as RLP:
-
-      receipt = rlp([status, cumulative_gas_used,
-                     logs_bloom (256 B), logs])
-
-    This is the encoder side of PR-K152 `receipt_extract_logs_bloom`,
-    and the input to receipts-trie / receipts-root computation.
-    For typed receipts (EIP-2718), the caller prepends the
-    `0x<type>` byte to the output of this helper; the wire-format
-    typed receipt is `type_byte || rlp(inner)`.
-
-    Algorithm:
-      1. Write status (u64) at receipt_pl_buf[0..]    via K155.
-      2. Write cumulative_gas (u64) at next slot      via K155.
-      3. Write logs_bloom (256 B as RLP string) at
-         next slot                                    via K128.
-      4. Copy logs_rlp (pre-encoded list) verbatim    (memcpy).
-      5. Compute total payload length.
-      6. Write outer list prefix to output[0..]       via K129.
-      7. Copy receipt_pl_buf[..total_payload] to
-         output[prefix_len..].
-
-    Composes:
-      - PR-K155 `rlp_encode_u64`        -- status / gas
-      - PR-K128 `rlp_encode_bytes`      -- logs_bloom
-      - PR-K129 `rlp_encode_list_prefix`-- outer list prefix
-
-    Calling convention:
-      a0 (input)  : status (u64)
-      a1 (input)  : cumulative_gas_used (u64)
-      a2 (input)  : logs_bloom ptr (exactly 256 bytes)
-      a3 (input)  : logs_rlp ptr (pre-encoded list, copied verbatim)
-      a4 (input)  : logs_rlp byte length
-      a5 (input)  : output buffer ptr
-      a6 (input)  : u64 out length ptr (total bytes written)
-      ra (input)  : return
-      a0 (output) : 0 (always succeeds).
-
-    Uses a 16 KiB scratch buffer `re_payload_buf` in `.data` for
-    the intermediate payload. Should comfortably hold mainnet
-    receipt payloads (logs_bloom is 257 RLP bytes, status/gas
-    add <= 18 bytes, logs section is variable but typically
-    KBs at most). -/
-def receiptEncodeFunction : String :=
-  "receipt_encode:\n" ++
-  "  addi sp, sp, -64\n" ++
-  "  sd ra,  0(sp)\n" ++
-  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
-  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp)\n" ++
-  "  mv s0, a0                   # status\n" ++
-  "  mv s1, a1                   # cumulative_gas\n" ++
-  "  mv s2, a2                   # bloom ptr\n" ++
-  "  mv s3, a3                   # logs_rlp ptr\n" ++
-  "  mv s4, a4                   # logs_rlp len\n" ++
-  "  mv s5, a5                   # output ptr\n" ++
-  "  mv s6, a6                   # out_length ptr\n" ++
-  "  # The running cursor (payload offset within re_payload_buf) is\n" ++
-  "  # stashed to `re_cursor` across `jal` calls since t-registers are\n" ++
-  "  # caller-saved and the encode helpers clobber them.\n" ++
-  "  la t0, re_cursor; sd zero, 0(t0)\n" ++
-  "  # ---- Step 1: encode status into re_payload_buf[0..] ----\n" ++
-  "  mv a0, s0\n" ++
-  "  la a1, re_payload_buf\n" ++
-  "  la a2, re_field_len\n" ++
-  "  jal ra, rlp_encode_u64\n" ++
-  "  la t0, re_field_len; ld t1, 0(t0)         # status_len\n" ++
-  "  la t0, re_cursor; sd t1, 0(t0)            # cursor = status_len\n" ++
-  "  # ---- Step 2: encode cumulative_gas at re_payload_buf[cursor] ----\n" ++
-  "  la t0, re_cursor; ld t2, 0(t0)\n" ++
-  "  mv a0, s1\n" ++
-  "  la a1, re_payload_buf; add a1, a1, t2\n" ++
-  "  la a2, re_field_len\n" ++
-  "  jal ra, rlp_encode_u64\n" ++
-  "  la t0, re_field_len; ld t1, 0(t0)         # gas_len\n" ++
-  "  la t0, re_cursor; ld t2, 0(t0)\n" ++
-  "  add t2, t2, t1\n" ++
-  "  la t0, re_cursor; sd t2, 0(t0)\n" ++
-  "  # ---- Step 3: encode bloom (256 B) ----\n" ++
-  "  mv a0, s2; li a1, 256\n" ++
-  "  la a2, re_payload_buf; add a2, a2, t2\n" ++
-  "  la a3, re_field_len\n" ++
-  "  jal ra, rlp_encode_bytes\n" ++
-  "  la t0, re_field_len; ld t1, 0(t0)         # bloom_enc_len\n" ++
-  "  la t0, re_cursor; ld t2, 0(t0)\n" ++
-  "  add t2, t2, t1\n" ++
-  "  # ---- Step 4: copy logs_rlp verbatim ----\n" ++
-  "  la t3, re_payload_buf; add t3, t3, t2     # dst\n" ++
-  "  mv t4, s3                                 # src\n" ++
-  "  mv t5, s4                                 # remaining bytes\n" ++
-  ".Lre_logs_cp:\n" ++
-  "  beqz t5, .Lre_logs_done\n" ++
-  "  lbu t6, 0(t4)\n" ++
-  "  sb t6, 0(t3)\n" ++
-  "  addi t3, t3, 1\n" ++
-  "  addi t4, t4, 1\n" ++
-  "  addi t5, t5, -1\n" ++
-  "  j .Lre_logs_cp\n" ++
-  ".Lre_logs_done:\n" ++
-  "  add t2, t2, s4                            # total payload len\n" ++
-  "  # Stash total_payload before the next jal clobbers caller-saved t2.\n" ++
-  "  la t0, re_total_payload; sd t2, 0(t0)\n" ++
-  "  # ---- Step 5: write outer list prefix at output[0..] ----\n" ++
-  "  mv a0, t2; mv a1, s5\n" ++
-  "  la a2, re_field_len\n" ++
-  "  jal ra, rlp_encode_list_prefix\n" ++
-  "  la t0, re_field_len; ld t1, 0(t0)        # outer_prefix_len\n" ++
-  "  # ---- Step 6: copy re_payload_buf[..total_payload] to output[prefix_len..] ----\n" ++
-  "  # Total payload was last stashed in t2; restore via .data\n" ++
-  "  # Actually we lost t2 across jal. Re-derive: total_payload =\n" ++
-  "  # bytes_written - bytes_p, but cleaner to re-compute it from\n" ++
-  "  # re_payload_buf metadata. Save total_payload before jal next time.\n" ++
-  "  # Use the stashed value: we'll save t2 to .data BEFORE the\n" ++
-  "  # rlp_encode_list_prefix call.\n" ++
-  "  # (Fixed by re-reading the saved payload total below.)\n" ++
-  "  la t0, re_total_payload; ld t2, 0(t0)\n" ++
-  "  add t3, s5, t1                            # dst = output + prefix_len\n" ++
-  "  la t4, re_payload_buf                     # src\n" ++
-  "  mv t5, t2                                 # remaining\n" ++
-  ".Lre_body_cp:\n" ++
-  "  beqz t5, .Lre_body_done\n" ++
-  "  lbu t6, 0(t4)\n" ++
-  "  sb t6, 0(t3)\n" ++
-  "  addi t3, t3, 1\n" ++
-  "  addi t4, t4, 1\n" ++
-  "  addi t5, t5, -1\n" ++
-  "  j .Lre_body_cp\n" ++
-  ".Lre_body_done:\n" ++
-  "  # total_written = outer_prefix_len + total_payload\n" ++
-  "  add t1, t1, t2\n" ++
-  "  sd t1, 0(s6)\n" ++
-  "  li a0, 0\n" ++
-  "  ld ra,  0(sp)\n" ++
-  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
-  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp)\n" ++
-  "  addi sp, sp, 64\n" ++
-  "  ret"
-
-/-- `zisk_receipt_encode`: probe BuildUnit.
-    Input layout:
-      bytes  0.. 8 : status (u64 LE)
-      bytes  8..16 : cumulative_gas (u64 LE)
-      bytes 16..272: logs_bloom (256 bytes)
-      bytes 272..280: logs_rlp_len (u64 LE)
-      bytes 280..   : logs_rlp
-    Output layout (256 B ziskemu cap):
-      bytes  0.. 8 : status (always 0)
-      bytes  8..16 : encoded receipt total length
-      bytes 16..   : encoded receipt bytes (truncated to fit) -/
-def ziskReceiptEncodePrologue : String :=
-  "  li sp, 0xa0050000\n" ++
-  "  li a7, 0x40000000\n" ++
-  "  ld a0, 8(a7)                # status\n" ++
-  "  ld a1, 16(a7)               # cumulative_gas\n" ++
-  "  addi a2, a7, 24             # logs_bloom ptr (256 B)\n" ++
-  "  ld a4, 280(a7)              # logs_rlp_len\n" ++
-  "  addi a3, a7, 288            # logs_rlp ptr\n" ++
-  "  li a5, 0xa0010010           # output ptr\n" ++
-  "  li a6, 0xa0010008           # out length ptr\n" ++
-  "  jal ra, receipt_encode\n" ++
-  "  li t0, 0xa0010000\n" ++
-  "  sd a0, 0(t0)\n" ++
-  "  j .Lre_pdone\n" ++
-  rlpEncodeU64Function ++ "\n" ++
-  rlpEncodeBytesFunction ++ "\n" ++
-  rlpEncodeListPrefixFunction ++ "\n" ++
-  receiptEncodeFunction ++ "\n" ++
-  ".Lre_pdone:"
-
-def ziskReceiptEncodeDataSection : String :=
-  ".section .data\n" ++
-  ".balign 8\n" ++
-  "re_field_len:\n" ++
-  "  .zero 8\n" ++
-  "re_cursor:\n" ++
-  "  .zero 8\n" ++
-  "re_total_payload:\n" ++
-  "  .zero 8\n" ++
-  "re_payload_buf:\n" ++
-  "  .zero 16384"
-
-def ziskReceiptEncodeProbeUnit : BuildUnit := {
-  body        := NOP
-  prologueAsm := ziskReceiptEncodePrologue
-  dataAsm     := ziskReceiptEncodeDataSection
-}
 
 /-! ## MPT encoders K157/K162-K167 — moved to `Programs/Mpt.lean` (file-size hard cap). -/
 
@@ -4381,6 +4075,7 @@ def lookupProgramTail : String → Option BuildUnit
   | "zisk_header_extract_timestamp" => some ziskHeaderExtractTimestampProbeUnit
   | "zisk_header_extract_number" => some ziskHeaderExtractNumberProbeUnit
   | "zisk_account_validate_code_hash_empty" => some ziskAccountValidateCodeHashEmptyProbeUnit
+  | "zisk_account_validate_storage_root_empty" => some ziskAccountValidateStorageRootEmptyProbeUnit
   | "zisk_block_validate_2tx_full" => some ziskBlockValidate2txFullProbeUnit
   | "zisk_block_body_extract_2tx" => some ziskBlockBodyExtract2txProbeUnit
   | "zisk_block_validate_2tx_full_with_body" => some ziskBlockValidate2txFullWithBodyProbeUnit
@@ -4789,6 +4484,7 @@ def knownProgramNames : List String :=
    "zisk_header_extract_timestamp",
    "zisk_header_extract_number",
    "zisk_account_validate_code_hash_empty",
+   "zisk_account_validate_storage_root_empty",
    "zisk_block_validate_2tx_full",
    "zisk_block_body_extract_2tx",
    "zisk_block_validate_2tx_full_with_body",
@@ -4862,7 +4558,7 @@ end EvmAsm.Codegen
     Runs at elaboration time via `#eval`; adds zero runtime cost. -/
 
 #eval show IO Unit from do
-  let hardCap := 4897
+  let hardCap := 4804
   let paths := [
     "EvmAsm/Codegen/Programs.lean",
     "EvmAsm/Codegen/Programs/Account.lean",
@@ -4876,6 +4572,7 @@ end EvmAsm.Codegen
     "EvmAsm/Codegen/Programs/HeaderFields.lean",
     "EvmAsm/Codegen/Programs/HeaderU64.lean",
     "EvmAsm/Codegen/Programs/Mpt.lean",
+    "EvmAsm/Codegen/Programs/Receipt.lean",
     "EvmAsm/Codegen/Programs/RlpRead.lean",
     "EvmAsm/Codegen/Programs/Ssz.lean",
     "EvmAsm/Codegen/Programs/Tx.lean",

--- a/EvmAsm/Codegen/Programs/Account.lean
+++ b/EvmAsm/Codegen/Programs/Account.lean
@@ -441,4 +441,97 @@ def ziskAccountValidateCodeHashEmptyProbeUnit : BuildUnit := {
   dataAsm     := ziskAccountValidateCodeHashEmptyDataSection
 }
 
+/-! ## account_validate_storage_root_empty -- PR-K235
+
+    Predicate: `account.storage_root == EMPTY_TRIE_ROOT` where
+    `EMPTY_TRIE_ROOT = keccak256(rlp(b'')) =
+        0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421`
+
+    The "account has no storage" check. Used as a constituent
+    of "fresh account / dust prune" decisions and as a quick
+    skip predicate when iterating accounts for state-root
+    recomputation.
+
+    Calling convention:
+      a0 (input)  : account_rlp ptr
+      a1 (input)  : account_rlp byte length
+      a2 (input)  : u64 out (1 if storage_root == EMPTY_TRIE_ROOT)
+      ra (input)  : return
+      a0 (output) :
+        0 : success — predicate written
+        1 : RLP parse failure / field 2 missing
+        2 : field 2 length != 32 -/
+def accountValidateStorageRootEmptyFunction : String :=
+  "account_validate_storage_root_empty:\n" ++
+  "  addi sp, sp, -32\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp)\n" ++
+  "  mv s0, a0                   # account_ptr\n" ++
+  "  mv s1, a1                   # account_len\n" ++
+  "  mv s2, a2                   # out u64 ptr\n" ++
+  "  sd zero, 0(s2)\n" ++
+  "  mv a0, s0; mv a1, s1\n" ++
+  "  li a2, 2\n" ++
+  "  la a3, avsre_offset; la a4, avsre_length\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lavsre_parse_fail\n" ++
+  "  la t0, avsre_length; ld t1, 0(t0)\n" ++
+  "  li t2, 32\n" ++
+  "  bne t1, t2, .Lavsre_size_fail\n" ++
+  "  la t0, avsre_offset; ld t3, 0(t0); add t3, s0, t3\n" ++
+  "  la t4, avsre_empty_trie_root\n" ++
+  "  ld t5,  0(t3); ld t6,  0(t4); bne t5, t6, .Lavsre_not_empty\n" ++
+  "  ld t5,  8(t3); ld t6,  8(t4); bne t5, t6, .Lavsre_not_empty\n" ++
+  "  ld t5, 16(t3); ld t6, 16(t4); bne t5, t6, .Lavsre_not_empty\n" ++
+  "  ld t5, 24(t3); ld t6, 24(t4); bne t5, t6, .Lavsre_not_empty\n" ++
+  "  li t0, 1\n" ++
+  "  sd t0, 0(s2)\n" ++
+  ".Lavsre_not_empty:\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lavsre_ret\n" ++
+  ".Lavsre_parse_fail:\n" ++
+  "  li a0, 1\n" ++
+  "  j .Lavsre_ret\n" ++
+  ".Lavsre_size_fail:\n" ++
+  "  li a0, 2\n" ++
+  ".Lavsre_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp)\n" ++
+  "  addi sp, sp, 32\n" ++
+  "  ret"
+
+def ziskAccountValidateStorageRootEmptyPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a3, 0x40000000\n" ++
+  "  ld a1, 8(a3)\n" ++
+  "  addi a0, a3, 16\n" ++
+  "  li a2, 0xa0010008\n" ++
+  "  jal ra, account_validate_storage_root_empty\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lavsre_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  accountValidateStorageRootEmptyFunction ++ "\n" ++
+  ".Lavsre_pdone:"
+
+def ziskAccountValidateStorageRootEmptyDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "avsre_offset:\n" ++
+  "  .zero 8\n" ++
+  "avsre_length:\n" ++
+  "  .zero 8\n" ++
+  ".balign 8\n" ++
+  "avsre_empty_trie_root:\n" ++
+  "  .byte 0x56, 0xe8, 0x1f, 0x17, 0x1b, 0xcc, 0x55, 0xa6\n" ++
+  "  .byte 0xff, 0x83, 0x45, 0xe6, 0x92, 0xc0, 0xf8, 0x6e\n" ++
+  "  .byte 0x5b, 0x48, 0xe0, 0x1b, 0x99, 0x6c, 0xad, 0xc0\n" ++
+  "  .byte 0x01, 0x62, 0x2f, 0xb5, 0xe3, 0x63, 0xb4, 0x21"
+
+def ziskAccountValidateStorageRootEmptyProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskAccountValidateStorageRootEmptyPrologue
+  dataAsm     := ziskAccountValidateStorageRootEmptyDataSection
+}
+
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/Receipt.lean
+++ b/EvmAsm/Codegen/Programs/Receipt.lean
@@ -1,0 +1,334 @@
+/-
+  EvmAsm.Codegen.Programs.Receipt
+
+  Receipt encoding + the supporting RLP helper carved out of
+  `EvmAsm.Codegen.Programs` per the file-size hard cap. Hosts:
+
+    K155  rlp_encode_u64
+    K156  receipt_encode
+
+  Depends on `Programs/RlpRead.lean` for the
+  `rlpEncodeListPrefixFunction` helper inlined by
+  receipt_encode's `zisk_*` probe prologue.
+
+  No proofs yet -- these are codegen `String` defs only.
+-/
+
+import EvmAsm.Rv64.Program
+import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Programs.RlpRead
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.Program
+
+/-! ## rlp_encode_u64 -- PR-K155
+
+    Encode a `u64` register value as canonical RLP. A convenience
+    wrapper that takes the integer directly rather than the BE
+    byte buffer that PR-K30 `rlp_encode_uint_be` requires:
+
+      value == 0       -> 0x80                       (1 byte)
+      value < 0x80     -> single byte = value        (1 byte)
+      else             -> 0x80 + effective_len + BE bytes
+                          (effective_len in 1..8)    (2..9 bytes)
+
+    Pure register arithmetic, leaf-callable, no scratch memory.
+    Use cases where K30 with a stack-allocated BE buffer is
+    awkward boilerplate -- typical example is receipt encoding:
+
+      rlp_encode_u64(status, buf + cursor, &written); cursor += written
+      rlp_encode_u64(cumulative_gas, buf + cursor, &written); cursor += written
+      ...
+
+    Calling convention:
+      a0 (input)  : value (u64)
+      a1 (input)  : output buffer ptr (caller supplies >= 9 bytes)
+      a2 (input)  : u64 out length ptr (bytes written; 1..9)
+      ra (input)  : return
+      a0 (output) : 0 (always succeeds). -/
+def rlpEncodeU64Function : String :=
+  "rlp_encode_u64:\n" ++
+  "  beqz a0, .Lreu64_zero\n" ++
+  "  li t0, 0x80\n" ++
+  "  bgeu a0, t0, .Lreu64_multi\n" ++
+  "  # Single-byte form (value in 0x01..0x7f).\n" ++
+  "  sb a0, 0(a1)\n" ++
+  "  li t1, 1\n" ++
+  "  sd t1, 0(a2)\n" ++
+  "  li a0, 0\n" ++
+  "  ret\n" ++
+  ".Lreu64_zero:\n" ++
+  "  li t0, 0x80\n" ++
+  "  sb t0, 0(a1)\n" ++
+  "  li t1, 1\n" ++
+  "  sd t1, 0(a2)\n" ++
+  "  li a0, 0\n" ++
+  "  ret\n" ++
+  ".Lreu64_multi:\n" ++
+  "  # Compute effective byte length (1..8) by finding the top non-zero byte.\n" ++
+  "  # We already know value >= 0x80, so len >= 1.\n" ++
+  "  li t0, 1                   # effective_len candidate\n" ++
+  "  li t1, 0x100\n" ++
+  "  bltu a0, t1, .Lreu64_have_len\n" ++
+  "  li t0, 2\n" ++
+  "  slli t1, t1, 8\n" ++
+  "  bltu a0, t1, .Lreu64_have_len\n" ++
+  "  li t0, 3\n" ++
+  "  slli t1, t1, 8\n" ++
+  "  bltu a0, t1, .Lreu64_have_len\n" ++
+  "  li t0, 4\n" ++
+  "  slli t1, t1, 8\n" ++
+  "  bltu a0, t1, .Lreu64_have_len\n" ++
+  "  li t0, 5\n" ++
+  "  slli t1, t1, 8\n" ++
+  "  bltu a0, t1, .Lreu64_have_len\n" ++
+  "  li t0, 6\n" ++
+  "  slli t1, t1, 8\n" ++
+  "  bltu a0, t1, .Lreu64_have_len\n" ++
+  "  li t0, 7\n" ++
+  "  slli t1, t1, 8\n" ++
+  "  bltu a0, t1, .Lreu64_have_len\n" ++
+  "  li t0, 8\n" ++
+  ".Lreu64_have_len:\n" ++
+  "  # Write prefix 0x80 + effective_len.\n" ++
+  "  addi t2, t0, 0x80\n" ++
+  "  sb t2, 0(a1)\n" ++
+  "  # Write effective_len BE bytes of value into a1+1..a1+1+len.\n" ++
+  "  addi t3, a1, 1                 # dst cursor\n" ++
+  "  addi t4, t0, -1                # shift_byte_index = len - 1\n" ++
+  ".Lreu64_emit:\n" ++
+  "  bltz t4, .Lreu64_done\n" ++
+  "  slli t5, t4, 3                 # bit shift = 8 * byte_index\n" ++
+  "  srl t6, a0, t5\n" ++
+  "  sb t6, 0(t3)\n" ++
+  "  addi t3, t3, 1\n" ++
+  "  addi t4, t4, -1\n" ++
+  "  j .Lreu64_emit\n" ++
+  ".Lreu64_done:\n" ++
+  "  addi t1, t0, 1                 # bytes_written = 1 + effective_len\n" ++
+  "  sd t1, 0(a2)\n" ++
+  "  li a0, 0\n" ++
+  "  ret"
+
+/-- `zisk_rlp_encode_u64`: probe BuildUnit.
+    Input layout:
+      bytes  0.. 8 : value (u64)
+    Output layout:
+      bytes  0.. 8 : status (always 0)
+      bytes  8..16 : bytes_written
+      bytes 16..25 : encoded RLP (up to 9 bytes) -/
+def ziskRlpEncodeU64Prologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a3, 0x40000000\n" ++
+  "  ld a0, 8(a3)                # value\n" ++
+  "  li a1, 0xa0010010           # output buffer ptr\n" ++
+  "  li a2, 0xa0010008           # out length ptr\n" ++
+  "  jal ra, rlp_encode_u64\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lreu64_pdone\n" ++
+  rlpEncodeU64Function ++ "\n" ++
+  ".Lreu64_pdone:"
+
+def ziskRlpEncodeU64DataSection : String :=
+  ".section .data\n" ++
+  "reu64_pad:\n" ++
+  "  .zero 8"
+
+def ziskRlpEncodeU64ProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskRlpEncodeU64Prologue
+  dataAsm     := ziskRlpEncodeU64DataSection
+}
+
+/-! ## receipt_encode -- PR-K156
+
+    Encode an Ethereum tx receipt as RLP:
+
+      receipt = rlp([status, cumulative_gas_used,
+                     logs_bloom (256 B), logs])
+
+    This is the encoder side of PR-K152 `receipt_extract_logs_bloom`,
+    and the input to receipts-trie / receipts-root computation.
+    For typed receipts (EIP-2718), the caller prepends the
+    `0x<type>` byte to the output of this helper; the wire-format
+    typed receipt is `type_byte || rlp(inner)`.
+
+    Algorithm:
+      1. Write status (u64) at receipt_pl_buf[0..]    via K155.
+      2. Write cumulative_gas (u64) at next slot      via K155.
+      3. Write logs_bloom (256 B as RLP string) at
+         next slot                                    via K128.
+      4. Copy logs_rlp (pre-encoded list) verbatim    (memcpy).
+      5. Compute total payload length.
+      6. Write outer list prefix to output[0..]       via K129.
+      7. Copy receipt_pl_buf[..total_payload] to
+         output[prefix_len..].
+
+    Composes:
+      - PR-K155 `rlp_encode_u64`        -- status / gas
+      - PR-K128 `rlp_encode_bytes`      -- logs_bloom
+      - PR-K129 `rlp_encode_list_prefix`-- outer list prefix
+
+    Calling convention:
+      a0 (input)  : status (u64)
+      a1 (input)  : cumulative_gas_used (u64)
+      a2 (input)  : logs_bloom ptr (exactly 256 bytes)
+      a3 (input)  : logs_rlp ptr (pre-encoded list, copied verbatim)
+      a4 (input)  : logs_rlp byte length
+      a5 (input)  : output buffer ptr
+      a6 (input)  : u64 out length ptr (total bytes written)
+      ra (input)  : return
+      a0 (output) : 0 (always succeeds).
+
+    Uses a 16 KiB scratch buffer `re_payload_buf` in `.data` for
+    the intermediate payload. Should comfortably hold mainnet
+    receipt payloads (logs_bloom is 257 RLP bytes, status/gas
+    add <= 18 bytes, logs section is variable but typically
+    KBs at most). -/
+def receiptEncodeFunction : String :=
+  "receipt_encode:\n" ++
+  "  addi sp, sp, -64\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp)\n" ++
+  "  mv s0, a0                   # status\n" ++
+  "  mv s1, a1                   # cumulative_gas\n" ++
+  "  mv s2, a2                   # bloom ptr\n" ++
+  "  mv s3, a3                   # logs_rlp ptr\n" ++
+  "  mv s4, a4                   # logs_rlp len\n" ++
+  "  mv s5, a5                   # output ptr\n" ++
+  "  mv s6, a6                   # out_length ptr\n" ++
+  "  # The running cursor (payload offset within re_payload_buf) is\n" ++
+  "  # stashed to `re_cursor` across `jal` calls since t-registers are\n" ++
+  "  # caller-saved and the encode helpers clobber them.\n" ++
+  "  la t0, re_cursor; sd zero, 0(t0)\n" ++
+  "  # ---- Step 1: encode status into re_payload_buf[0..] ----\n" ++
+  "  mv a0, s0\n" ++
+  "  la a1, re_payload_buf\n" ++
+  "  la a2, re_field_len\n" ++
+  "  jal ra, rlp_encode_u64\n" ++
+  "  la t0, re_field_len; ld t1, 0(t0)         # status_len\n" ++
+  "  la t0, re_cursor; sd t1, 0(t0)            # cursor = status_len\n" ++
+  "  # ---- Step 2: encode cumulative_gas at re_payload_buf[cursor] ----\n" ++
+  "  la t0, re_cursor; ld t2, 0(t0)\n" ++
+  "  mv a0, s1\n" ++
+  "  la a1, re_payload_buf; add a1, a1, t2\n" ++
+  "  la a2, re_field_len\n" ++
+  "  jal ra, rlp_encode_u64\n" ++
+  "  la t0, re_field_len; ld t1, 0(t0)         # gas_len\n" ++
+  "  la t0, re_cursor; ld t2, 0(t0)\n" ++
+  "  add t2, t2, t1\n" ++
+  "  la t0, re_cursor; sd t2, 0(t0)\n" ++
+  "  # ---- Step 3: encode bloom (256 B) ----\n" ++
+  "  mv a0, s2; li a1, 256\n" ++
+  "  la a2, re_payload_buf; add a2, a2, t2\n" ++
+  "  la a3, re_field_len\n" ++
+  "  jal ra, rlp_encode_bytes\n" ++
+  "  la t0, re_field_len; ld t1, 0(t0)         # bloom_enc_len\n" ++
+  "  la t0, re_cursor; ld t2, 0(t0)\n" ++
+  "  add t2, t2, t1\n" ++
+  "  # ---- Step 4: copy logs_rlp verbatim ----\n" ++
+  "  la t3, re_payload_buf; add t3, t3, t2     # dst\n" ++
+  "  mv t4, s3                                 # src\n" ++
+  "  mv t5, s4                                 # remaining bytes\n" ++
+  ".Lre_logs_cp:\n" ++
+  "  beqz t5, .Lre_logs_done\n" ++
+  "  lbu t6, 0(t4)\n" ++
+  "  sb t6, 0(t3)\n" ++
+  "  addi t3, t3, 1\n" ++
+  "  addi t4, t4, 1\n" ++
+  "  addi t5, t5, -1\n" ++
+  "  j .Lre_logs_cp\n" ++
+  ".Lre_logs_done:\n" ++
+  "  add t2, t2, s4                            # total payload len\n" ++
+  "  # Stash total_payload before the next jal clobbers caller-saved t2.\n" ++
+  "  la t0, re_total_payload; sd t2, 0(t0)\n" ++
+  "  # ---- Step 5: write outer list prefix at output[0..] ----\n" ++
+  "  mv a0, t2; mv a1, s5\n" ++
+  "  la a2, re_field_len\n" ++
+  "  jal ra, rlp_encode_list_prefix\n" ++
+  "  la t0, re_field_len; ld t1, 0(t0)        # outer_prefix_len\n" ++
+  "  # ---- Step 6: copy re_payload_buf[..total_payload] to output[prefix_len..] ----\n" ++
+  "  # Total payload was last stashed in t2; restore via .data\n" ++
+  "  # Actually we lost t2 across jal. Re-derive: total_payload =\n" ++
+  "  # bytes_written - bytes_p, but cleaner to re-compute it from\n" ++
+  "  # re_payload_buf metadata. Save total_payload before jal next time.\n" ++
+  "  # Use the stashed value: we'll save t2 to .data BEFORE the\n" ++
+  "  # rlp_encode_list_prefix call.\n" ++
+  "  # (Fixed by re-reading the saved payload total below.)\n" ++
+  "  la t0, re_total_payload; ld t2, 0(t0)\n" ++
+  "  add t3, s5, t1                            # dst = output + prefix_len\n" ++
+  "  la t4, re_payload_buf                     # src\n" ++
+  "  mv t5, t2                                 # remaining\n" ++
+  ".Lre_body_cp:\n" ++
+  "  beqz t5, .Lre_body_done\n" ++
+  "  lbu t6, 0(t4)\n" ++
+  "  sb t6, 0(t3)\n" ++
+  "  addi t3, t3, 1\n" ++
+  "  addi t4, t4, 1\n" ++
+  "  addi t5, t5, -1\n" ++
+  "  j .Lre_body_cp\n" ++
+  ".Lre_body_done:\n" ++
+  "  # total_written = outer_prefix_len + total_payload\n" ++
+  "  add t1, t1, t2\n" ++
+  "  sd t1, 0(s6)\n" ++
+  "  li a0, 0\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp)\n" ++
+  "  addi sp, sp, 64\n" ++
+  "  ret"
+
+/-- `zisk_receipt_encode`: probe BuildUnit.
+    Input layout:
+      bytes  0.. 8 : status (u64 LE)
+      bytes  8..16 : cumulative_gas (u64 LE)
+      bytes 16..272: logs_bloom (256 bytes)
+      bytes 272..280: logs_rlp_len (u64 LE)
+      bytes 280..   : logs_rlp
+    Output layout (256 B ziskemu cap):
+      bytes  0.. 8 : status (always 0)
+      bytes  8..16 : encoded receipt total length
+      bytes 16..   : encoded receipt bytes (truncated to fit) -/
+def ziskReceiptEncodePrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a7, 0x40000000\n" ++
+  "  ld a0, 8(a7)                # status\n" ++
+  "  ld a1, 16(a7)               # cumulative_gas\n" ++
+  "  addi a2, a7, 24             # logs_bloom ptr (256 B)\n" ++
+  "  ld a4, 280(a7)              # logs_rlp_len\n" ++
+  "  addi a3, a7, 288            # logs_rlp ptr\n" ++
+  "  li a5, 0xa0010010           # output ptr\n" ++
+  "  li a6, 0xa0010008           # out length ptr\n" ++
+  "  jal ra, receipt_encode\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lre_pdone\n" ++
+  rlpEncodeU64Function ++ "\n" ++
+  rlpEncodeBytesFunction ++ "\n" ++
+  rlpEncodeListPrefixFunction ++ "\n" ++
+  receiptEncodeFunction ++ "\n" ++
+  ".Lre_pdone:"
+
+def ziskReceiptEncodeDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "re_field_len:\n" ++
+  "  .zero 8\n" ++
+  "re_cursor:\n" ++
+  "  .zero 8\n" ++
+  "re_total_payload:\n" ++
+  "  .zero 8\n" ++
+  "re_payload_buf:\n" ++
+  "  .zero 16384"
+
+def ziskReceiptEncodeProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskReceiptEncodePrologue
+  dataAsm     := ziskReceiptEncodeDataSection
+}
+
+end EvmAsm.Codegen

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **257**
-- ziskemu round-trip scripts: **247** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **258**
+- ziskemu round-trip scripts: **248** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-account-validate-storage-root-empty-check.sh
+++ b/scripts/codegen-zisk-account-validate-storage-root-empty-check.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# codegen-zisk-account-validate-storage-root-empty-check.sh -- PR-K235.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_account_validate_storage_root_empty ELF"
+lake exe codegen --program zisk_account_validate_storage_root_empty --halt linux93 \
+  -o gen-out/zisk_account_validate_storage_root_empty
+
+REPO_ROOT="$(pwd)"
+
+EMPTY_TRIE_HEX="56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"
+
+run_case() {
+  local name="$1" storage_root_hex="$2" exp_empty="$3"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_account_validate_storage_root_empty_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_account_validate_storage_root_empty_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+def u_be(n):
+    if n == 0: return b''
+    return n.to_bytes((n.bit_length() + 7) // 8, 'big')
+
+storage_root = bytes.fromhex('$storage_root_hex')
+account = rlp.encode([
+    u_be(3),               # nonce
+    u_be(10**18),          # balance (1 ETH)
+    storage_root,
+    b'\\xbb'*32,           # code_hash (irrelevant)
+])
+with open(sys.argv[1], 'wb') as f:
+    record = struct.pack('<Q', len(account)) + account
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_account_validate_storage_root_empty.elf \
+    -i "$in_file" -o "$out_file" -n 1000000 \
+    >"$REPO_ROOT/gen-out/zisk_account_validate_storage_root_empty_${name}.emu.log" 2>&1 || true
+
+  local v_le; v_le="$(dd if="$out_file" bs=1 skip=8 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local actual; actual="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$v_le'))[0])")"
+
+  if [[ "$actual" == "$exp_empty" ]]; then
+    printf "  %-26s OK   is_empty=%s\n" "$name" "$actual"
+    return 0
+  else
+    printf "  %-26s FAIL actual=%s expected=%s\n" "$name" "$actual" "$exp_empty"
+    return 1
+  fi
+}
+
+FAILED=0
+run_case "empty_trie"     "$EMPTY_TRIE_HEX"                                                  1 || FAILED=1
+run_case "some_storage"   "0000000000000000000000000000000000000000000000000000000000000001" 0 || FAILED=1
+run_case "all_ff"         "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff" 0 || FAILED=1
+run_case "random_root"    "deadbeef1234567890abcdef1234567890abcdef1234567890abcdef00112233" 0 || FAILED=1
+run_case "near_empty"     "56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b422" 0 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: account_validate_storage_root_empty matches storage_root == EMPTY_TRIE_ROOT"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Adds `account_validate_storage_root_empty`: predicate `storage_root == EMPTY_TRIE_ROOT = keccak256(rlp(b''))`. Mirror of K234 `account_validate_code_hash_empty`; the "account has no storage" check.
- Extracts K155 `rlp_encode_u64` + K156 `receipt_encode` from `Programs.lean` into a new `Programs/Receipt.lean` submodule. Frees 307 lines from `Programs.lean` (4894 → 4593); `hardCap` drops 4897 → 4804 (93-line step; further cuts blocked by `Tx.lean` at 4803).

## Test plan
- [x] `lake build codegen` clean
- [x] `scripts/codegen-zisk-account-validate-storage-root-empty-check.sh` all 5 fixtures pass:
  - `empty_trie (root=EMPTY)`: is_empty=1 ✓
  - `some_storage (0x00..01)`: is_empty=0 ✓
  - `all_ff`: is_empty=0 ✓
  - `random_root`: is_empty=0 ✓
  - `near_empty (off-by-one)`: is_empty=0 ✓
- [x] `scripts/codegen-zisk-receipt-encode-check.sh` all 5 fixtures pass post-extract

🤖 Generated with [Claude Code](https://claude.com/claude-code)