### PR TITLE
K238 stateless: chain_compute_min_gas_used

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -3075,6 +3075,7 @@ def lookupProgramTail : String → Option BuildUnit
   | "zisk_account_validate_storage_root_empty" => some ziskAccountValidateStorageRootEmptyProbeUnit
   | "zisk_chain_compute_max_gas_used" => some ziskChainComputeMaxGasUsedProbeUnit
   | "zisk_chain_compute_max_blob_gas_used" => some ziskChainComputeMaxBlobGasUsedProbeUnit
+  | "zisk_chain_compute_min_gas_used" => some ziskChainComputeMinGasUsedProbeUnit
   | "zisk_block_validate_2tx_full" => some ziskBlockValidate2txFullProbeUnit
   | "zisk_block_body_extract_2tx" => some ziskBlockBodyExtract2txProbeUnit
   | "zisk_block_validate_2tx_full_with_body" => some ziskBlockValidate2txFullWithBodyProbeUnit
@@ -3486,6 +3487,7 @@ def knownProgramNames : List String :=
    "zisk_account_validate_storage_root_empty",
    "zisk_chain_compute_max_gas_used",
    "zisk_chain_compute_max_blob_gas_used",
+   "zisk_chain_compute_min_gas_used",
    "zisk_block_validate_2tx_full",
    "zisk_block_body_extract_2tx",
    "zisk_block_validate_2tx_full_with_body",

--- a/EvmAsm/Codegen/Programs/Chain.lean
+++ b/EvmAsm/Codegen/Programs/Chain.lean
@@ -1069,4 +1069,106 @@ def ziskChainComputeMaxBlobGasUsedProbeUnit : BuildUnit := {
   dataAsm     := ziskChainComputeMaxBlobGasUsedDataSection
 }
 
+/-! ## chain_compute_min_gas_used -- PR-K238
+
+    Find min(header.gas_used) (field 10) across an N-element
+    header chain. Lowest-throughput / liveness monitor that
+    complements K236 chain_compute_max_gas_used (max) and K196
+    chain_compute_total_gas_used (sum).
+
+    Vacuous on empty chain: min = 0.
+
+    Calling convention:
+      a0 (input)  : N
+      a1 (input)  : header_lengths ptr (N u64 LE)
+      a2 (input)  : flat headers ptr
+      a3 (input)  : u64 out (min)
+      ra (input)  : return
+      a0 (output) :
+        0 : success
+        1 : RLP parse fail (in any header)
+        2 : gas_used field > 8 bytes BE -/
+def chainComputeMinGasUsedFunction : String :=
+  "chain_compute_min_gas_used:\n" ++
+  "  addi sp, sp, -48\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp); sd s4, 40(sp)\n" ++
+  "  mv s0, a0; mv s1, a1; mv s2, a2; mv s3, a3\n" ++
+  "  sd zero, 0(s3)\n" ++
+  "  li s4, 0\n" ++
+  "  beqz s0, .Lccming_done\n" ++
+  ".Lccming_loop:\n" ++
+  "  beq s4, s0, .Lccming_done\n" ++
+  "  slli t0, s4, 3\n" ++
+  "  add t0, s1, t0\n" ++
+  "  ld a1, 0(t0)\n" ++
+  "  mv a0, s2; li a2, 10\n" ++
+  "  la a3, ccming_field\n" ++
+  "  jal ra, rlp_field_to_u64\n" ++
+  "  li t0, 1\n" ++
+  "  beq a0, t0, .Lccming_parse_fail\n" ++
+  "  li t0, 2\n" ++
+  "  beq a0, t0, .Lccming_size_fail\n" ++
+  "  la t0, ccming_field; ld t1, 0(t0)\n" ++
+  "  beqz s4, .Lccming_first\n" ++
+  "  ld t2, 0(s3)\n" ++
+  "  bgeu t1, t2, .Lccming_no_update\n" ++
+  ".Lccming_first:\n" ++
+  "  sd t1, 0(s3)\n" ++
+  ".Lccming_no_update:\n" ++
+  "  slli t0, s4, 3\n" ++
+  "  add t0, s1, t0\n" ++
+  "  ld t1, 0(t0)\n" ++
+  "  add s2, s2, t1\n" ++
+  "  addi s4, s4, 1\n" ++
+  "  j .Lccming_loop\n" ++
+  ".Lccming_done:\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lccming_ret\n" ++
+  ".Lccming_parse_fail:\n" ++
+  "  li a0, 1\n" ++
+  "  j .Lccming_ret\n" ++
+  ".Lccming_size_fail:\n" ++
+  "  li a0, 2\n" ++
+  ".Lccming_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp); ld s4, 40(sp)\n" ++
+  "  addi sp, sp, 48\n" ++
+  "  ret"
+
+def ziskChainComputeMinGasUsedPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a7, 0x40000000\n" ++
+  "  ld a0, 8(a7)\n" ++
+  "  addi a1, a7, 16\n" ++
+  "  slli t0, a0, 3\n" ++
+  "  add a2, a1, t0\n" ++
+  "  li a3, 0xa0010010\n" ++
+  "  jal ra, chain_compute_min_gas_used\n" ++
+  "  li t0, 0xa0010008\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lccming_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpFieldToU64Function ++ "\n" ++
+  chainComputeMinGasUsedFunction ++ "\n" ++
+  ".Lccming_pdone:"
+
+def ziskChainComputeMinGasUsedDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  "rfu_offset:\n" ++
+  "  .zero 8\n" ++
+  "rfu_length:\n" ++
+  "  .zero 8\n" ++
+  "ccming_field:\n" ++
+  "  .zero 8"
+
+def ziskChainComputeMinGasUsedProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskChainComputeMinGasUsedPrologue
+  dataAsm     := ziskChainComputeMinGasUsedDataSection
+}
+
 end EvmAsm.Codegen

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **260**
-- ziskemu round-trip scripts: **250** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **261**
+- ziskemu round-trip scripts: **251** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-chain-compute-min-gas-used-check.sh
+++ b/scripts/codegen-zisk-chain-compute-min-gas-used-check.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# codegen-zisk-chain-compute-min-gas-used-check.sh -- PR-K238.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_chain_compute_min_gas_used ELF"
+lake exe codegen --program zisk_chain_compute_min_gas_used --halt linux93 \
+  -o gen-out/zisk_chain_compute_min_gas_used
+
+REPO_ROOT="$(pwd)"
+
+run_case() {
+  local name="$1" gas_useds="$2" exp_status="$3" exp_min="$4"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_chain_compute_min_gas_used_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_chain_compute_min_gas_used_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+def u_be(n):
+    if n == 0: return b''
+    return n.to_bytes((n.bit_length() + 7) // 8, 'big')
+
+def make_header(gas_used):
+    return rlp.encode([
+        b'\\xa1'*32, b'\\xa2'*32, b'\\xa3'*20, b'\\xa4'*32, b'\\xa5'*32,
+        b'\\xa6'*32, b'\\x00'*256, b'', b'\\x01', b'\\x83\\xff\\xff\\xff',
+        u_be(gas_used), b'\\x83\\x01\\x02\\x03', b'', b'\\xa7'*32,
+        b'\\x00'*8, b'\\x82\\x01\\x00',
+    ])
+
+vals = $gas_useds
+headers = [make_header(v) for v in vals]
+N = len(headers)
+lengths = b''.join(struct.pack('<Q', len(h)) for h in headers)
+flat = b''.join(headers)
+with open(sys.argv[1], 'wb') as f:
+    record = struct.pack('<Q', N) + lengths + flat
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_chain_compute_min_gas_used.elf \
+    -i "$in_file" -o "$out_file" -n 5000000 \
+    >"$REPO_ROOT/gen-out/zisk_chain_compute_min_gas_used_${name}.emu.log" 2>&1 || true
+
+  local s_le; s_le="$(dd if="$out_file" bs=1 skip=8  count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local m_le; m_le="$(dd if="$out_file" bs=1 skip=16 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local status mn
+  status="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$s_le'))[0])")"
+  mn="$(    python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$m_le'))[0])")"
+
+  if [[ "$status" == "$exp_status" && "$mn" == "$exp_min" ]]; then
+    printf "  %-26s OK   status=%s min=%s\n" "$name" "$status" "$mn"
+    return 0
+  else
+    printf "  %-26s FAIL status=%s/%s min=%s/%s\n" "$name" "$status" "$exp_status" "$mn" "$exp_min"
+    return 1
+  fi
+}
+
+FAILED=0
+run_case "empty"          "[]"                       0 0           || FAILED=1
+run_case "single_zero"    "[0]"                      0 0           || FAILED=1
+run_case "single_some"    "[21000]"                  0 21000       || FAILED=1
+run_case "increasing"     "[10000,20000,30000]"      0 10000       || FAILED=1
+run_case "decreasing"     "[30000,20000,10000]"      0 10000       || FAILED=1
+run_case "low_in_middle"  "[20000,5000,30000]"       0 5000        || FAILED=1
+run_case "all_equal"      "[15000,15000,15000]"      0 15000       || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: chain_compute_min_gas_used returns min(header.gas_used) across N"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Adds `chain_compute_min_gas_used`: finds `min(header.gas_used)` across an N-element header chain.
- Liveness / lowest-throughput monitor; complements K236 `chain_compute_max_gas_used` (max) and K196 `chain_compute_total_gas_used` (sum).
- Lives in `Programs/Chain.lean`.
- Vacuous on empty chain: min = 0. First header initialises the accumulator; subsequent headers update only when smaller.

## Test plan
- [x] `lake build codegen` clean
- [x] `scripts/codegen-zisk-chain-compute-min-gas-used-check.sh` all 7 fixtures pass:
  - `empty (N=0)`: min=0 ✓
  - `single_zero ([0])`: min=0 ✓
  - `single_some ([21000])`: min=21000 ✓
  - `increasing ([10000,20000,30000])`: min=10000 ✓
  - `decreasing ([30000,20000,10000])`: min=10000 ✓
  - `low_in_middle ([20000,5000,30000])`: min=5000 ✓
  - `all_equal ([15000,15000,15000])`: min=15000 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)