### PR TITLE
K239 stateless: chain_extract_timestamp_range

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -3077,6 +3077,7 @@ def lookupProgramTail : String → Option BuildUnit
   | "zisk_chain_compute_max_gas_used" => some ziskChainComputeMaxGasUsedProbeUnit
   | "zisk_chain_compute_max_blob_gas_used" => some ziskChainComputeMaxBlobGasUsedProbeUnit
   | "zisk_chain_compute_min_gas_used" => some ziskChainComputeMinGasUsedProbeUnit
+  | "zisk_chain_extract_timestamp_range" => some ziskChainExtractTimestampRangeProbeUnit
   | "zisk_block_validate_2tx_full" => some ziskBlockValidate2txFullProbeUnit
   | "zisk_block_body_extract_2tx" => some ziskBlockBodyExtract2txProbeUnit
   | "zisk_block_validate_2tx_full_with_body" => some ziskBlockValidate2txFullWithBodyProbeUnit
@@ -3489,6 +3490,7 @@ def knownProgramNames : List String :=
    "zisk_chain_compute_max_gas_used",
    "zisk_chain_compute_max_blob_gas_used",
    "zisk_chain_compute_min_gas_used",
+   "zisk_chain_extract_timestamp_range",
    "zisk_block_validate_2tx_full",
    "zisk_block_body_extract_2tx",
    "zisk_block_validate_2tx_full_with_body",

--- a/EvmAsm/Codegen/Programs/Chain.lean
+++ b/EvmAsm/Codegen/Programs/Chain.lean
@@ -1171,4 +1171,107 @@ def ziskChainComputeMinGasUsedProbeUnit : BuildUnit := {
   dataAsm     := ziskChainComputeMinGasUsedDataSection
 }
 
+/-! ## chain_extract_timestamp_range -- PR-K239
+
+    Extract `(first_timestamp, last_timestamp)` from an N-element
+    header chain. With K229 increasing-timestamps validated, the
+    pair is monotonically non-decreasing; callers can use the
+    range as a chain-segment duration or epoch identifier. The
+    timestamp counterpart to K197 chain_extract_number_range.
+
+    Calling convention:
+      a0 (input)  : N (header count, must be >= 1)
+      a1 (input)  : header_lengths ptr
+      a2 (input)  : headers ptr
+      a3 (input)  : u64 out (first_timestamp)
+      a4 (input)  : u64 out (last_timestamp)
+      ra (input)  : return
+      a0 (output) :
+        0 : success
+        1 : empty chain (N == 0)
+        2 : RLP parse failure on some header
+        3 : a header's timestamp field exceeds 8 bytes BE -/
+def chainExtractTimestampRangeFunction : String :=
+  "chain_extract_timestamp_range:\n" ++
+  "  addi sp, sp, -48\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp); sd s4, 40(sp)\n" ++
+  "  mv s0, a0                   # N\n" ++
+  "  mv s1, a1                   # header_lengths\n" ++
+  "  mv s2, a2                   # headers\n" ++
+  "  mv s3, a3                   # first out\n" ++
+  "  mv s4, a4                   # last out\n" ++
+  "  beqz s0, .Lcetr_empty\n" ++
+  "  # first = headers[0].timestamp\n" ++
+  "  ld a1, 0(s1)\n" ++
+  "  mv a0, s2\n" ++
+  "  li a2, 11                   # field 11 = timestamp\n" ++
+  "  mv a3, s3\n" ++
+  "  jal ra, rlp_field_to_u64\n" ++
+  "  bnez a0, .Lcetr_propagate\n" ++
+  "  # Advance to last header\n" ++
+  "  mv t1, s2\n" ++
+  "  mv t2, s1\n" ++
+  "  addi t3, s0, -1\n" ++
+  ".Lcetr_skip:\n" ++
+  "  beqz t3, .Lcetr_at_last\n" ++
+  "  ld t4, 0(t2)\n" ++
+  "  add t1, t1, t4\n" ++
+  "  addi t2, t2, 8\n" ++
+  "  addi t3, t3, -1\n" ++
+  "  j .Lcetr_skip\n" ++
+  ".Lcetr_at_last:\n" ++
+  "  ld a1, 0(t2)\n" ++
+  "  mv a0, t1\n" ++
+  "  li a2, 11\n" ++
+  "  mv a3, s4\n" ++
+  "  jal ra, rlp_field_to_u64\n" ++
+  "  bnez a0, .Lcetr_propagate\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lcetr_ret\n" ++
+  ".Lcetr_empty:\n" ++
+  "  li a0, 1\n" ++
+  "  j .Lcetr_ret\n" ++
+  ".Lcetr_propagate:\n" ++
+  "  addi a0, a0, 1\n" ++
+  ".Lcetr_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp); ld s4, 40(sp)\n" ++
+  "  addi sp, sp, 48\n" ++
+  "  ret"
+
+def ziskChainExtractTimestampRangePrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a7, 0x40000000\n" ++
+  "  ld a0, 8(a7)\n" ++
+  "  addi a1, a7, 16\n" ++
+  "  slli t0, a0, 3\n" ++
+  "  add a2, a1, t0\n" ++
+  "  li a3, 0xa0010008\n" ++
+  "  li a4, 0xa0010010\n" ++
+  "  jal ra, chain_extract_timestamp_range\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lcetr_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpFieldToU64Function ++ "\n" ++
+  chainExtractTimestampRangeFunction ++ "\n" ++
+  ".Lcetr_pdone:"
+
+def ziskChainExtractTimestampRangeDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  "rfu_offset:\n" ++
+  "  .zero 8\n" ++
+  "rfu_length:\n" ++
+  "  .zero 8"
+
+def ziskChainExtractTimestampRangeProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskChainExtractTimestampRangePrologue
+  dataAsm     := ziskChainExtractTimestampRangeDataSection
+}
+
 end EvmAsm.Codegen

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **261**
-- ziskemu round-trip scripts: **251** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **262**
+- ziskemu round-trip scripts: **252** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-chain-extract-timestamp-range-check.sh
+++ b/scripts/codegen-zisk-chain-extract-timestamp-range-check.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# codegen-zisk-chain-extract-timestamp-range-check.sh -- PR-K239.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_chain_extract_timestamp_range ELF"
+lake exe codegen --program zisk_chain_extract_timestamp_range --halt linux93 \
+  -o gen-out/zisk_chain_extract_timestamp_range
+
+REPO_ROOT="$(pwd)"
+
+run_case() {
+  local name="$1" timestamps="$2" exp_status="$3" exp_first="$4" exp_last="$5"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_chain_extract_timestamp_range_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_chain_extract_timestamp_range_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+def u_be(n):
+    if n == 0: return b''
+    return n.to_bytes((n.bit_length() + 7) // 8, 'big')
+
+def make_header(ts):
+    return rlp.encode([
+        b'\\xa1'*32, b'\\xa2'*32, b'\\xa3'*20, b'\\xa4'*32, b'\\xa5'*32,
+        b'\\xa6'*32, b'\\x00'*256, b'', b'\\x01', b'\\x83\\xff\\xff\\xff',
+        b'', u_be(ts), b'', b'\\xa7'*32, b'\\x00'*8,
+    ])
+
+vals = $timestamps
+headers = [make_header(t) for t in vals]
+N = len(headers)
+lengths = b''.join(struct.pack('<Q', len(h)) for h in headers)
+flat = b''.join(headers)
+with open(sys.argv[1], 'wb') as f:
+    record = struct.pack('<Q', N) + lengths + flat
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_chain_extract_timestamp_range.elf \
+    -i "$in_file" -o "$out_file" -n 5000000 \
+    >"$REPO_ROOT/gen-out/zisk_chain_extract_timestamp_range_${name}.emu.log" 2>&1 || true
+
+  local s_le; s_le="$(dd if="$out_file" bs=1 skip=0  count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local f_le; f_le="$(dd if="$out_file" bs=1 skip=8  count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local l_le; l_le="$(dd if="$out_file" bs=1 skip=16 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local status first last
+  status="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$s_le'))[0])")"
+  first="$( python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$f_le'))[0])")"
+  last="$(  python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$l_le'))[0])")"
+
+  if [[ "$status" == "$exp_status" && "$first" == "$exp_first" && "$last" == "$exp_last" ]]; then
+    printf "  %-26s OK   status=%s first=%s last=%s\n" "$name" "$status" "$first" "$last"
+    return 0
+  else
+    printf "  %-26s FAIL status=%s/%s first=%s/%s last=%s/%s\n" "$name" "$status" "$exp_status" "$first" "$exp_first" "$last" "$exp_last"
+    return 1
+  fi
+}
+
+FAILED=0
+run_case "empty"        "[]"                   1 0 0                  || FAILED=1
+run_case "single"       "[1700000000]"         0 1700000000 1700000000 || FAILED=1
+run_case "three_blocks" "[1000,1100,1200]"     0 1000 1200            || FAILED=1
+run_case "large_gap"    "[1700000000,1700100000,1700200000]" 0 1700000000 1700200000 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: chain_extract_timestamp_range returns (first, last) timestamps"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Adds `chain_extract_timestamp_range`: extracts `(first_timestamp, last_timestamp)` from an N-element header chain.
- Timestamp counterpart to K197 `chain_extract_number_range`. With K229 increasing-timestamps validated, the pair is monotonically non-decreasing — useful as a chain-segment duration or epoch identifier.
- Lives in `Programs/Chain.lean`.

## Test plan
- [x] `lake build codegen` clean
- [x] `scripts/codegen-zisk-chain-extract-timestamp-range-check.sh` all 4 fixtures pass:
  - `empty (N=0)`: status=1 ✓
  - `single ([1700000000])`: first=last=1700000000 ✓
  - `three_blocks ([1000,1100,1200])`: first=1000 last=1200 ✓
  - `large_gap ([1700000000,1700100000,1700200000])`: first=1700000000 last=1700200000 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)