### PR TITLE
K240 stateless: chain_validate_gas_used_under_limit

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -3079,6 +3079,7 @@ def lookupProgramTail : String → Option BuildUnit
   | "zisk_chain_compute_max_blob_gas_used" => some ziskChainComputeMaxBlobGasUsedProbeUnit
   | "zisk_chain_compute_min_gas_used" => some ziskChainComputeMinGasUsedProbeUnit
   | "zisk_chain_extract_timestamp_range" => some ziskChainExtractTimestampRangeProbeUnit
+  | "zisk_chain_validate_gas_used_under_limit" => some ziskChainValidateGasUsedUnderLimitProbeUnit
   | "zisk_block_validate_2tx_full" => some ziskBlockValidate2txFullProbeUnit
   | "zisk_block_body_extract_2tx" => some ziskBlockBodyExtract2txProbeUnit
   | "zisk_block_validate_2tx_full_with_body" => some ziskBlockValidate2txFullWithBodyProbeUnit
@@ -3492,6 +3493,7 @@ def knownProgramNames : List String :=
    "zisk_chain_compute_max_blob_gas_used",
    "zisk_chain_compute_min_gas_used",
    "zisk_chain_extract_timestamp_range",
+   "zisk_chain_validate_gas_used_under_limit",
    "zisk_block_validate_2tx_full",
    "zisk_block_body_extract_2tx",
    "zisk_block_validate_2tx_full_with_body",

--- a/EvmAsm/Codegen/Programs/Chain.lean
+++ b/EvmAsm/Codegen/Programs/Chain.lean
@@ -1274,4 +1274,125 @@ def ziskChainExtractTimestampRangeProbeUnit : BuildUnit := {
   dataAsm     := ziskChainExtractTimestampRangeDataSection
 }
 
+/-! ## chain_validate_gas_used_under_limit -- PR-K240
+
+    Per-header invariant: `gas_used <= gas_limit` (header fields
+    10 and 9 respectively). The block validator already enforces
+    `gas_used <= gas_limit` in K72 `check_gas_limit` for adjacent
+    pairs; K240 lifts the standalone per-block constraint to an
+    N-element chain.
+
+    Vacuous on empty chain: valid=1, bad_index=0.
+
+    Calling convention:
+      a0 (input)  : N
+      a1 (input)  : header_lengths ptr (N u64 LE)
+      a2 (input)  : flat headers ptr
+      a3 (input)  : u64 out (valid: 1 = all OK)
+      a4 (input)  : u64 out (bad_index = first violator, else 0)
+      ra (input)  : return
+      a0 (output) :
+        0 : success — predicate written
+        1 : RLP parse fail on some header
+        2 : gas_used or gas_limit field > 8 bytes BE -/
+def chainValidateGasUsedUnderLimitFunction : String :=
+  "chain_validate_gas_used_under_limit:\n" ++
+  "  addi sp, sp, -56\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp)\n" ++
+  "  mv s0, a0; mv s1, a1; mv s2, a2; mv s3, a3; mv s4, a4\n" ++
+  "  li t0, 1\n" ++
+  "  sd t0, 0(s3); sd zero, 0(s4)\n" ++
+  "  li s5, 0\n" ++
+  ".Lcvgul_loop:\n" ++
+  "  beq s5, s0, .Lcvgul_done\n" ++
+  "  la t0, cvgul_iter_ptr; sd s2, 0(t0)\n" ++
+  "  la t0, cvgul_iter_i;   sd s5, 0(t0)\n" ++
+  "  slli t3, s5, 3\n" ++
+  "  add t3, s1, t3\n" ++
+  "  ld a1, 0(t3)\n" ++
+  "  mv a0, s2; li a2, 10\n" ++
+  "  la a3, cvgul_gas_used\n" ++
+  "  jal ra, rlp_field_to_u64\n" ++
+  "  bnez a0, .Lcvgul_propagate\n" ++
+  "  la t0, cvgul_iter_ptr; ld s2, 0(t0)\n" ++
+  "  la t0, cvgul_iter_i;   ld s5, 0(t0)\n" ++
+  "  slli t3, s5, 3\n" ++
+  "  add t3, s1, t3\n" ++
+  "  ld a1, 0(t3)\n" ++
+  "  mv a0, s2; li a2, 9\n" ++
+  "  la a3, cvgul_gas_limit\n" ++
+  "  jal ra, rlp_field_to_u64\n" ++
+  "  bnez a0, .Lcvgul_propagate\n" ++
+  "  la t0, cvgul_iter_ptr; ld s2, 0(t0)\n" ++
+  "  la t0, cvgul_iter_i;   ld s5, 0(t0)\n" ++
+  "  la t0, cvgul_gas_used;  ld t1, 0(t0)\n" ++
+  "  la t0, cvgul_gas_limit; ld t2, 0(t0)\n" ++
+  "  bgtu t1, t2, .Lcvgul_violation\n" ++
+  "  slli t3, s5, 3\n" ++
+  "  add t3, s1, t3\n" ++
+  "  ld t4, 0(t3)\n" ++
+  "  add s2, s2, t4\n" ++
+  "  addi s5, s5, 1\n" ++
+  "  j .Lcvgul_loop\n" ++
+  ".Lcvgul_violation:\n" ++
+  "  sd zero, 0(s3)\n" ++
+  "  sd s5, 0(s4)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lcvgul_ret\n" ++
+  ".Lcvgul_propagate:\n" ++
+  "  sd s5, 0(s4)\n" ++
+  "  j .Lcvgul_ret\n" ++
+  ".Lcvgul_done:\n" ++
+  "  li a0, 0\n" ++
+  ".Lcvgul_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp)\n" ++
+  "  addi sp, sp, 56\n" ++
+  "  ret"
+
+def ziskChainValidateGasUsedUnderLimitPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a7, 0x40000000\n" ++
+  "  ld a0, 8(a7)\n" ++
+  "  addi a1, a7, 16\n" ++
+  "  slli t0, a0, 3\n" ++
+  "  add a2, a1, t0\n" ++
+  "  li a3, 0xa0010008\n" ++
+  "  li a4, 0xa0010010\n" ++
+  "  jal ra, chain_validate_gas_used_under_limit\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lcvgul_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpFieldToU64Function ++ "\n" ++
+  chainValidateGasUsedUnderLimitFunction ++ "\n" ++
+  ".Lcvgul_pdone:"
+
+def ziskChainValidateGasUsedUnderLimitDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  "rfu_offset:\n" ++
+  "  .zero 8\n" ++
+  "rfu_length:\n" ++
+  "  .zero 8\n" ++
+  "cvgul_gas_used:\n" ++
+  "  .zero 8\n" ++
+  "cvgul_gas_limit:\n" ++
+  "  .zero 8\n" ++
+  "cvgul_iter_ptr:\n" ++
+  "  .zero 8\n" ++
+  "cvgul_iter_i:\n" ++
+  "  .zero 8"
+
+def ziskChainValidateGasUsedUnderLimitProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskChainValidateGasUsedUnderLimitPrologue
+  dataAsm     := ziskChainValidateGasUsedUnderLimitDataSection
+}
+
 end EvmAsm.Codegen

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **262**
-- ziskemu round-trip scripts: **252** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **263**
+- ziskemu round-trip scripts: **253** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-chain-validate-gas-used-under-limit-check.sh
+++ b/scripts/codegen-zisk-chain-validate-gas-used-under-limit-check.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# codegen-zisk-chain-validate-gas-used-under-limit-check.sh -- PR-K240.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_chain_validate_gas_used_under_limit ELF"
+lake exe codegen --program zisk_chain_validate_gas_used_under_limit --halt linux93 \
+  -o gen-out/zisk_chain_validate_gas_used_under_limit
+
+REPO_ROOT="$(pwd)"
+
+run_case() {
+  local name="$1" pairs="$2" exp_valid="$3" exp_bad="$4"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_chain_validate_gas_used_under_limit_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_chain_validate_gas_used_under_limit_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+def u_be(n):
+    if n == 0: return b''
+    return n.to_bytes((n.bit_length() + 7) // 8, 'big')
+
+def make_header(gas_used, gas_limit):
+    return rlp.encode([
+        b'\\xa1'*32, b'\\xa2'*32, b'\\xa3'*20, b'\\xa4'*32, b'\\xa5'*32,
+        b'\\xa6'*32, b'\\x00'*256, b'', b'\\x01', u_be(gas_limit),
+        u_be(gas_used), b'\\x83\\x01\\x02\\x03', b'', b'\\xa7'*32,
+        b'\\x00'*8, b'\\x82\\x01\\x00',
+    ])
+
+pairs = $pairs
+headers = [make_header(g, l) for (g, l) in pairs]
+N = len(headers)
+lengths = b''.join(struct.pack('<Q', len(h)) for h in headers)
+flat = b''.join(headers)
+with open(sys.argv[1], 'wb') as f:
+    record = struct.pack('<Q', N) + lengths + flat
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_chain_validate_gas_used_under_limit.elf \
+    -i "$in_file" -o "$out_file" -n 5000000 \
+    >"$REPO_ROOT/gen-out/zisk_chain_validate_gas_used_under_limit_${name}.emu.log" 2>&1 || true
+
+  local v_le; v_le="$(dd if="$out_file" bs=1 skip=8 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local b_le; b_le="$(dd if="$out_file" bs=1 skip=16 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local valid bad
+  valid="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$v_le'))[0])")"
+  bad="$(  python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$b_le'))[0])")"
+
+  if [[ "$valid" == "$exp_valid" && "$bad" == "$exp_bad" ]]; then
+    printf "  %-26s OK   valid=%s bad=%s\n" "$name" "$valid" "$bad"
+    return 0
+  else
+    printf "  %-26s FAIL valid=%s/%s bad=%s/%s\n" "$name" "$valid" "$exp_valid" "$bad" "$exp_bad"
+    return 1
+  fi
+}
+
+FAILED=0
+run_case "vacuous_empty"     "[]"                                       1 0 || FAILED=1
+run_case "single_ok"         "[(21000, 30000000)]"                      1 0 || FAILED=1
+run_case "single_equal"      "[(30000000, 30000000)]"                   1 0 || FAILED=1
+run_case "single_over"       "[(40000000, 30000000)]"                   0 0 || FAILED=1
+run_case "two_ok"            "[(21000, 30000000), (50000, 30000000)]"   1 0 || FAILED=1
+run_case "two_violation_at_1" "[(21000, 30000000), (40000000, 30000000)]" 0 1 || FAILED=1
+run_case "three_violation_at_2" "[(21000,30000000),(50000,30000000),(35000000,30000000)]" 0 2 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: chain_validate_gas_used_under_limit enforces gas_used <= gas_limit per header"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Adds `chain_validate_gas_used_under_limit`: per-header invariant `gas_used <= gas_limit` (header fields 10 and 9) across an N-element chain, with `bad_index` of the first violator.
- Lifts the standalone block constraint (K72 check_gas_limit handles adjacent pairs) to a chain-level predicate.
- Lives in `Programs/Chain.lean`.

## Test plan
- [x] `lake build codegen` clean
- [x] `scripts/codegen-zisk-chain-validate-gas-used-under-limit-check.sh` all 7 fixtures pass:
  - `vacuous_empty (N=0)`: valid=1 ✓
  - `single_ok ([(21000,30000000)])`: valid=1 ✓
  - `single_equal ([(30000000,30000000)])`: valid=1 ✓
  - `single_over ([(40000000,30000000)])`: valid=0 bad=0 ✓
  - `two_ok`: valid=1 ✓
  - `two_violation_at_1`: valid=0 bad=1 ✓
  - `three_violation_at_2`: valid=0 bad=2 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)