### PR TITLE
K241 stateless: header_extract_blob_gas_used

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -3081,6 +3081,7 @@ def lookupProgramTail : String → Option BuildUnit
   | "zisk_chain_compute_min_gas_used" => some ziskChainComputeMinGasUsedProbeUnit
   | "zisk_chain_extract_timestamp_range" => some ziskChainExtractTimestampRangeProbeUnit
   | "zisk_chain_validate_gas_used_under_limit" => some ziskChainValidateGasUsedUnderLimitProbeUnit
+  | "zisk_header_extract_blob_gas_used" => some ziskHeaderExtractBlobGasUsedProbeUnit
   | "zisk_block_validate_2tx_full" => some ziskBlockValidate2txFullProbeUnit
   | "zisk_block_body_extract_2tx" => some ziskBlockBodyExtract2txProbeUnit
   | "zisk_block_validate_2tx_full_with_body" => some ziskBlockValidate2txFullWithBodyProbeUnit
@@ -3495,6 +3496,7 @@ def knownProgramNames : List String :=
    "zisk_chain_compute_min_gas_used",
    "zisk_chain_extract_timestamp_range",
    "zisk_chain_validate_gas_used_under_limit",
+   "zisk_header_extract_blob_gas_used",
    "zisk_block_validate_2tx_full",
    "zisk_block_body_extract_2tx",
    "zisk_block_validate_2tx_full_with_body",

--- a/EvmAsm/Codegen/Programs/HeaderU64.lean
+++ b/EvmAsm/Codegen/Programs/HeaderU64.lean
@@ -595,4 +595,64 @@ def ziskChainComputeMaxGasUsedProbeUnit : BuildUnit := {
   dataAsm     := ziskChainComputeMaxGasUsedDataSection
 }
 
+/-! ## header_extract_blob_gas_used -- PR-K241
+
+    Extract `blob_gas_used` (header field 17, u64 BE) from a
+    Cancun+ header RLP. The single-field counterpart to K90
+    `header_extract_blob_gas_pair` (which extracts the (used,
+    excess) tuple); useful when only one of the two is needed.
+
+    Pre-Cancun headers (<18 fields) return parse-failure status.
+
+    Calling convention:
+      a0 (input)  : header_rlp ptr
+      a1 (input)  : header_rlp byte length
+      a2 (input)  : u64 out ptr
+      ra (input)  : return
+      a0 (output) :
+        0 : success
+        1 : RLP parse failure (pre-Cancun header)
+        2 : field 17 exceeds 8 bytes BE -/
+def headerExtractBlobGasUsedFunction : String :=
+  "header_extract_blob_gas_used:\n" ++
+  "  addi sp, sp, -16\n" ++
+  "  sd ra, 0(sp)\n" ++
+  "  mv a3, a2\n" ++
+  "  li a2, 17\n" ++
+  "  jal ra, rlp_field_to_u64\n" ++
+  "  ld ra, 0(sp)\n" ++
+  "  addi sp, sp, 16\n" ++
+  "  ret"
+
+def ziskHeaderExtractBlobGasUsedPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a7, 0x40000000\n" ++
+  "  ld a1, 8(a7)\n" ++
+  "  addi a0, a7, 16\n" ++
+  "  li a2, 0xa0010008\n" ++
+  "  jal ra, header_extract_blob_gas_used\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lhebgu_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpFieldToU64Function ++ "\n" ++
+  headerExtractBlobGasUsedFunction ++ "\n" ++
+  ".Lhebgu_pdone:"
+
+def ziskHeaderExtractBlobGasUsedDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  "rfu_offset:\n" ++
+  "  .zero 8\n" ++
+  "rfu_length:\n" ++
+  "  .zero 8"
+
+def ziskHeaderExtractBlobGasUsedProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskHeaderExtractBlobGasUsedPrologue
+  dataAsm     := ziskHeaderExtractBlobGasUsedDataSection
+}
+
 end EvmAsm.Codegen

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **263**
-- ziskemu round-trip scripts: **253** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **264**
+- ziskemu round-trip scripts: **254** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-header-extract-blob-gas-used-check.sh
+++ b/scripts/codegen-zisk-header-extract-blob-gas-used-check.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# codegen-zisk-header-extract-blob-gas-used-check.sh -- PR-K241.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_header_extract_blob_gas_used ELF"
+lake exe codegen --program zisk_header_extract_blob_gas_used --halt linux93 \
+  -o gen-out/zisk_header_extract_blob_gas_used
+
+REPO_ROOT="$(pwd)"
+
+run_case() {
+  local name="$1" blob_gas_used="$2"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_header_extract_blob_gas_used_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_header_extract_blob_gas_used_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+def u_be(n):
+    if n == 0: return b''
+    return n.to_bytes((n.bit_length() + 7) // 8, 'big')
+g = $blob_gas_used
+fields = [
+    b'\\xa1'*32, b'\\xa2'*32, b'\\xa3'*20, b'\\xa4'*32, b'\\xa5'*32,
+    b'\\xa6'*32, b'\\x00'*256, b'', b'\\x01', b'\\x83\\xff\\xff\\xff',
+    b'', b'\\x83\\x01\\x02\\x03', b'', b'\\xa7'*32, b'\\x00'*8,
+    b'\\x82\\x01\\x00', b'\\xa8'*32, u_be(g), u_be(0),
+]
+header_rlp = rlp.encode(fields)
+with open(sys.argv[1], 'wb') as f:
+    record = struct.pack('<Q', len(header_rlp)) + header_rlp
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_header_extract_blob_gas_used.elf \
+    -i "$in_file" -o "$out_file" -n 1000000 \
+    >"$REPO_ROOT/gen-out/zisk_header_extract_blob_gas_used_${name}.emu.log" 2>&1 || true
+
+  local v_le; v_le="$(dd if="$out_file" bs=1 skip=8 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local actual; actual="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$v_le'))[0])")"
+
+  if [[ "$actual" == "$blob_gas_used" ]]; then
+    printf "  %-26s OK   blob_gas_used=%s\n" "$name" "$actual"
+    return 0
+  else
+    printf "  %-26s FAIL actual=%s expected=%s\n" "$name" "$actual" "$blob_gas_used"
+    return 1
+  fi
+}
+
+FAILED=0
+run_case "zero"          0      || FAILED=1
+run_case "one_blob"      131072 || FAILED=1
+run_case "six_blobs"     786432 || FAILED=1
+run_case "nine_blobs"    1179648 || FAILED=1
+run_case "max_u32"       4294967295 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: header_extract_blob_gas_used returns field 17"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Adds `header_extract_blob_gas_used`: standalone u64 extractor for header field 17 (EIP-4844 Cancun+ `blob_gas_used`).
- Single-field counterpart to K90 `header_extract_blob_gas_pair` (which extracts the `(used, excess)` tuple); useful when only one of the two is needed.
- Pre-Cancun headers (<18 fields) return parse-failure status.
- Lives in `Programs/HeaderU64.lean`.

## Test plan
- [x] `lake build codegen` clean
- [x] `scripts/codegen-zisk-header-extract-blob-gas-used-check.sh` all 5 fixtures pass:
  - `zero`: blob_gas_used=0 ✓
  - `one_blob`: blob_gas_used=131072 ✓
  - `six_blobs`: blob_gas_used=786432 ✓
  - `nine_blobs`: blob_gas_used=1179648 ✓
  - `max_u32`: blob_gas_used=4294967295 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)