### PR TITLE
K242 stateless: account_validate_nonce_zero

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -581,8 +581,6 @@ def ziskKeccak256FromInputProbeUnit : BuildUnit := {
   dataAsm     := ziskKeccak256FromInputDataSection
 }
 
-/-! ## K19 witness_lookup_by_hash — moved to `Programs/Mpt.lean` (file-size hard cap). -/
-
 /-! ## account_validate_code_hash -- PR-K98
 
     Verify that an account's `code_hash` field matches the
@@ -2424,6 +2422,7 @@ def lookupProgramTail : String → Option BuildUnit
   | "zisk_chain_extract_timestamp_range" => some ziskChainExtractTimestampRangeProbeUnit
   | "zisk_chain_validate_gas_used_under_limit" => some ziskChainValidateGasUsedUnderLimitProbeUnit
   | "zisk_header_extract_blob_gas_used" => some ziskHeaderExtractBlobGasUsedProbeUnit
+  | "zisk_account_validate_nonce_zero" => some ziskAccountValidateNonceZeroProbeUnit
   | "zisk_block_validate_2tx_full" => some ziskBlockValidate2txFullProbeUnit
   | "zisk_block_body_extract_2tx" => some ziskBlockBodyExtract2txProbeUnit
   | "zisk_block_validate_2tx_full_with_body" => some ziskBlockValidate2txFullWithBodyProbeUnit
@@ -2839,6 +2838,7 @@ def knownProgramNames : List String :=
    "zisk_chain_extract_timestamp_range",
    "zisk_chain_validate_gas_used_under_limit",
    "zisk_header_extract_blob_gas_used",
+   "zisk_account_validate_nonce_zero",
    "zisk_block_validate_2tx_full",
    "zisk_block_body_extract_2tx",
    "zisk_block_validate_2tx_full_with_body",

--- a/EvmAsm/Codegen/Programs/Account.lean
+++ b/EvmAsm/Codegen/Programs/Account.lean
@@ -534,4 +534,74 @@ def ziskAccountValidateStorageRootEmptyProbeUnit : BuildUnit := {
   dataAsm     := ziskAccountValidateStorageRootEmptyDataSection
 }
 
+/-! ## account_validate_nonce_zero -- PR-K242
+
+    Predicate: `account.nonce == 0`. RLP canonical zero is the
+    empty byte string, so this is the predicate
+    `length(field 0) == 0`. Useful for fresh-account / dust-prune
+    detection; complements K234 (code_hash empty) and K235
+    (storage_root empty).
+
+    Calling convention:
+      a0 (input)  : account_rlp ptr
+      a1 (input)  : account_rlp byte length
+      a2 (input)  : u64 out (1 if nonce == 0)
+      ra (input)  : return
+      a0 (output) :
+        0 : success — predicate written
+        1 : RLP parse failure / field 0 missing -/
+def accountValidateNonceZeroFunction : String :=
+  "account_validate_nonce_zero:\n" ++
+  "  addi sp, sp, -16\n" ++
+  "  sd ra, 0(sp)\n" ++
+  "  sd s0, 8(sp)\n" ++
+  "  mv s0, a2                      # is_valid out\n" ++
+  "  sd zero, 0(s0)\n" ++
+  "  li a2, 0                       # field 0 = nonce\n" ++
+  "  la a3, avnz_offset; la a4, avnz_length\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lavnz_parse_fail\n" ++
+  "  la t0, avnz_length; ld t1, 0(t0)\n" ++
+  "  bnez t1, .Lavnz_nonzero\n" ++
+  "  li t0, 1\n" ++
+  "  sd t0, 0(s0)\n" ++
+  ".Lavnz_nonzero:\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lavnz_ret\n" ++
+  ".Lavnz_parse_fail:\n" ++
+  "  li a0, 1\n" ++
+  ".Lavnz_ret:\n" ++
+  "  ld ra, 0(sp)\n" ++
+  "  ld s0, 8(sp)\n" ++
+  "  addi sp, sp, 16\n" ++
+  "  ret"
+
+def ziskAccountValidateNonceZeroPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a3, 0x40000000\n" ++
+  "  ld a1, 8(a3)\n" ++
+  "  addi a0, a3, 16\n" ++
+  "  li a2, 0xa0010008\n" ++
+  "  jal ra, account_validate_nonce_zero\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lavnz_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  accountValidateNonceZeroFunction ++ "\n" ++
+  ".Lavnz_pdone:"
+
+def ziskAccountValidateNonceZeroDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "avnz_offset:\n" ++
+  "  .zero 8\n" ++
+  "avnz_length:\n" ++
+  "  .zero 8"
+
+def ziskAccountValidateNonceZeroProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskAccountValidateNonceZeroPrologue
+  dataAsm     := ziskAccountValidateNonceZeroDataSection
+}
+
 end EvmAsm.Codegen

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -251,8 +251,8 @@ This is the verified gas-cost surrogate.
 
 ## D — Codegen reach
 
-- Programs in `EvmAsm/Codegen/Programs.lean` registry: **264**
-- ziskemu round-trip scripts: **254** under `scripts/codegen-*.sh`
+- Programs in `EvmAsm/Codegen/Programs.lean` registry: **265**
+- ziskemu round-trip scripts: **255** under `scripts/codegen-*.sh`
 - Milestones (CODEGEN.md):
 
 | Milestone | Status |

--- a/scripts/codegen-zisk-account-validate-nonce-zero-check.sh
+++ b/scripts/codegen-zisk-account-validate-nonce-zero-check.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# codegen-zisk-account-validate-nonce-zero-check.sh -- PR-K242.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_account_validate_nonce_zero ELF"
+lake exe codegen --program zisk_account_validate_nonce_zero --halt linux93 \
+  -o gen-out/zisk_account_validate_nonce_zero
+
+REPO_ROOT="$(pwd)"
+
+run_case() {
+  local name="$1" nonce="$2" exp_zero="$3"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_account_validate_nonce_zero_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_account_validate_nonce_zero_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+def u_be(n):
+    if n == 0: return b''
+    return n.to_bytes((n.bit_length() + 7) // 8, 'big')
+n = $nonce
+account = rlp.encode([
+    u_be(n),               # nonce
+    u_be(10**18),          # balance
+    b'\\xaa'*32,           # storage_root
+    b'\\xbb'*32,           # code_hash
+])
+with open(sys.argv[1], 'wb') as f:
+    record = struct.pack('<Q', len(account)) + account
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_account_validate_nonce_zero.elf \
+    -i "$in_file" -o "$out_file" -n 1000000 \
+    >"$REPO_ROOT/gen-out/zisk_account_validate_nonce_zero_${name}.emu.log" 2>&1 || true
+
+  local v_le; v_le="$(dd if="$out_file" bs=1 skip=8 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local actual; actual="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$v_le'))[0])")"
+
+  if [[ "$actual" == "$exp_zero" ]]; then
+    printf "  %-26s OK   is_zero=%s\n" "$name" "$actual"
+    return 0
+  else
+    printf "  %-26s FAIL actual=%s expected=%s\n" "$name" "$actual" "$exp_zero"
+    return 1
+  fi
+}
+
+FAILED=0
+run_case "zero_nonce"   0          1 || FAILED=1
+run_case "one_nonce"    1          0 || FAILED=1
+run_case "small_nonce"  42         0 || FAILED=1
+run_case "big_nonce"    9999999999 0 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: account_validate_nonce_zero matches nonce == 0"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Adds `account_validate_nonce_zero`: predicate `account.nonce == 0`. In RLP, canonical zero is the empty byte string, so this is `length(field 0) == 0`.
- Useful for fresh-account / dust-prune detection; complements K234 (code_hash empty) and K235 (storage_root empty).
- Lives in `Programs/Account.lean`.
- Drops one stale "moved to" comment from `Programs.lean` to make room under the new tight cap.

## Test plan
- [x] `lake build codegen` clean
- [x] `scripts/codegen-zisk-account-validate-nonce-zero-check.sh` all 4 fixtures pass:
  - `zero_nonce (n=0)`: is_zero=1 ✓
  - `one_nonce (n=1)`: is_zero=0 ✓
  - `small_nonce (n=42)`: is_zero=0 ✓
  - `big_nonce (n=9999999999)`: is_zero=0 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)