### PR TITLE
refactor(div): use n1 step path helper in wrappers

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/UnifiedN1StepPath.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/UnifiedN1StepPath.lean
@@ -157,29 +157,10 @@ theorem evm_div_n1_stack_spec_within_word_noNop_shape_step_conservation_overesti
         b.getLimbN 3 ≠ 0 :=
     (EvmWord.ne_zero_iff_getLimbN_or).mp hbnz
   obtain ⟨bltu_2, bltu_1, bltu_0,
-      hbltu_3, hbltu_2, hbltu_1, hbltu_0⟩ :=
-    n1_trial_witnesses_call_first_of_getLimbN_shape_shift_nz
-      a b hbnzGet hb3z hb2z hb1z hshift_nz
-  obtain ⟨hcarry2, hr3_zero, hr2_zero, hr1_zero, hge⟩ :=
-    hpath bltu_2 bltu_1 bltu_0 hbltu_3 hbltu_2 hbltu_1 hbltu_0
-  have hfinal_zero : fullDivN1FinalCarryZero true bltu_2 bltu_1 bltu_0
-      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) :=
-    fullDivN1FinalCarryZero_of_raw_step_conservation_overestimate
-      true bltu_2 bltu_1 bltu_0
-      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
-      hbnzGet hb1z hb2z hb3z hshift_nz hcarry2
-      hr3_zero hr2_zero hr1_zero hge
-  have hmulsub : fullDivN1NormalizedMulSubEq true bltu_2 bltu_1 bltu_0
-      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) :=
-    fullDivN1NormalizedMulSubEq_of_raw_step_conservation
-      true bltu_2 bltu_1 bltu_0
-      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
-      hbnzGet hb1z hb2z hb3z hshift_nz hcarry2
-      hr3_zero hr2_zero hr1_zero hfinal_zero
+      hbltu_3, hbltu_2, hbltu_1, hbltu_0,
+      hcarry2, hmulsub, hge⟩ :=
+    n1_normalized_mulsub_overestimate_of_step_conservation_path
+      a b hbnzGet hb3z hb2z hb1z hshift_nz hpath
   exact evm_div_n1_stack_spec_within_word_noNop_uni_of_normalized_mulsub_overestimate
     true bltu_2 bltu_1 bltu_0 sp base a b
     (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
@@ -251,29 +232,10 @@ theorem evm_div_n1_stack_spec_within_word_exact_x1_noNop_shape_step_conservation
         b.getLimbN 3 ≠ 0 :=
     (EvmWord.ne_zero_iff_getLimbN_or).mp hbnz
   obtain ⟨bltu_2, bltu_1, bltu_0,
-      hbltu_3, hbltu_2, hbltu_1, hbltu_0⟩ :=
-    n1_trial_witnesses_call_first_of_getLimbN_shape_shift_nz
-      a b hbnzGet hb3z hb2z hb1z hshift_nz
-  obtain ⟨hcarry2, hr3_zero, hr2_zero, hr1_zero, hge⟩ :=
-    hpath bltu_2 bltu_1 bltu_0 hbltu_3 hbltu_2 hbltu_1 hbltu_0
-  have hfinal_zero : fullDivN1FinalCarryZero true bltu_2 bltu_1 bltu_0
-      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) :=
-    fullDivN1FinalCarryZero_of_raw_step_conservation_overestimate
-      true bltu_2 bltu_1 bltu_0
-      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
-      hbnzGet hb1z hb2z hb3z hshift_nz hcarry2
-      hr3_zero hr2_zero hr1_zero hge
-  have hmulsub : fullDivN1NormalizedMulSubEq true bltu_2 bltu_1 bltu_0
-      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) :=
-    fullDivN1NormalizedMulSubEq_of_raw_step_conservation
-      true bltu_2 bltu_1 bltu_0
-      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
-      hbnzGet hb1z hb2z hb3z hshift_nz hcarry2
-      hr3_zero hr2_zero hr1_zero hfinal_zero
+      hbltu_3, hbltu_2, hbltu_1, hbltu_0,
+      hcarry2, hmulsub, hge⟩ :=
+    n1_normalized_mulsub_overestimate_of_step_conservation_path
+      a b hbnzGet hb3z hb2z hb1z hshift_nz hpath
   exact evm_div_n1_stack_spec_within_word_exact_x1_noNop_uni_of_normalized_mulsub_overestimate
     true bltu_2 bltu_1 bltu_0 sp base a b
     (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
@@ -345,29 +307,10 @@ theorem evm_div_n1_stack_spec_within_word_exact_x1_shape_step_conservation_overe
         b.getLimbN 3 ≠ 0 :=
     (EvmWord.ne_zero_iff_getLimbN_or).mp hbnz
   obtain ⟨bltu_2, bltu_1, bltu_0,
-      hbltu_3, hbltu_2, hbltu_1, hbltu_0⟩ :=
-    n1_trial_witnesses_call_first_of_getLimbN_shape_shift_nz
-      a b hbnzGet hb3z hb2z hb1z hshift_nz
-  obtain ⟨hcarry2, hr3_zero, hr2_zero, hr1_zero, hge⟩ :=
-    hpath bltu_2 bltu_1 bltu_0 hbltu_3 hbltu_2 hbltu_1 hbltu_0
-  have hfinal_zero : fullDivN1FinalCarryZero true bltu_2 bltu_1 bltu_0
-      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) :=
-    fullDivN1FinalCarryZero_of_raw_step_conservation_overestimate
-      true bltu_2 bltu_1 bltu_0
-      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
-      hbnzGet hb1z hb2z hb3z hshift_nz hcarry2
-      hr3_zero hr2_zero hr1_zero hge
-  have hmulsub : fullDivN1NormalizedMulSubEq true bltu_2 bltu_1 bltu_0
-      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) :=
-    fullDivN1NormalizedMulSubEq_of_raw_step_conservation
-      true bltu_2 bltu_1 bltu_0
-      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
-      hbnzGet hb1z hb2z hb3z hshift_nz hcarry2
-      hr3_zero hr2_zero hr1_zero hfinal_zero
+      hbltu_3, hbltu_2, hbltu_1, hbltu_0,
+      hcarry2, hmulsub, hge⟩ :=
+    n1_normalized_mulsub_overestimate_of_step_conservation_path
+      a b hbnzGet hb3z hb2z hb1z hshift_nz hpath
   exact evm_div_n1_stack_spec_within_word_exact_x1_uni_of_normalized_mulsub_overestimate
     true bltu_2 bltu_1 bltu_0 sp base a b
     (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
@@ -438,29 +381,10 @@ theorem evm_div_n1_stack_spec_within_word_shape_step_conservation_overestimate_u
         b.getLimbN 3 ≠ 0 :=
     (EvmWord.ne_zero_iff_getLimbN_or).mp hbnz
   obtain ⟨bltu_2, bltu_1, bltu_0,
-      hbltu_3, hbltu_2, hbltu_1, hbltu_0⟩ :=
-    n1_trial_witnesses_call_first_of_getLimbN_shape_shift_nz
-      a b hbnzGet hb3z hb2z hb1z hshift_nz
-  obtain ⟨hcarry2, hr3_zero, hr2_zero, hr1_zero, hge⟩ :=
-    hpath bltu_2 bltu_1 bltu_0 hbltu_3 hbltu_2 hbltu_1 hbltu_0
-  have hfinal_zero : fullDivN1FinalCarryZero true bltu_2 bltu_1 bltu_0
-      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) :=
-    fullDivN1FinalCarryZero_of_raw_step_conservation_overestimate
-      true bltu_2 bltu_1 bltu_0
-      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
-      hbnzGet hb1z hb2z hb3z hshift_nz hcarry2
-      hr3_zero hr2_zero hr1_zero hge
-  have hmulsub : fullDivN1NormalizedMulSubEq true bltu_2 bltu_1 bltu_0
-      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) :=
-    fullDivN1NormalizedMulSubEq_of_raw_step_conservation
-      true bltu_2 bltu_1 bltu_0
-      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
-      hbnzGet hb1z hb2z hb3z hshift_nz hcarry2
-      hr3_zero hr2_zero hr1_zero hfinal_zero
+      hbltu_3, hbltu_2, hbltu_1, hbltu_0,
+      hcarry2, hmulsub, hge⟩ :=
+    n1_normalized_mulsub_overestimate_of_step_conservation_path
+      a b hbnzGet hb3z hb2z hb1z hshift_nz hpath
   exact evm_div_n1_stack_spec_within_word_uni_of_normalized_mulsub_overestimate
     true bltu_2 bltu_1 bltu_0 sp base a b
     (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)


### PR DESCRIPTION
## Summary
- refactor UnifiedN1StepPath standard/exact wrappers to consume n1_normalized_mulsub_overestimate_of_step_conservation_path
- remove repeated local derivations of final carry-zero and normalized mulsub
- leave callable quotient-word wrapper unchanged because it needs the quotient-word equality directly

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.UnifiedN1StepPath
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- rg -n "set_option maxHeartbeats|set_option maxRecDepth|sorry|admit" EvmAsm/Evm64/DivMod/Spec/UnifiedN1StepPath.lean
- git diff --check
- lake build