### PR TITLE
refactor(div): project n1 full-div witnesses

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N1TrialWitnesses.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N1TrialWitnesses.lean
@@ -527,6 +527,48 @@ theorem N1TrialWitnesses.exists_quotient_word_of_mulsub_remainder_lt
       fullDivN1Harith_of_mulsub_remainder_lt
         bltu_3 bltu_2 bltu_1 bltu_0 hbnz hpair.1 hpair.2)
 
+/-- Shape-specialized n=1 quotient-word package from raw mulsub plus
+    final-remainder facts. -/
+theorem n1_shape_quotient_word_of_mulsub_remainder_lt
+    (a b : EvmWord)
+    (hbnz : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 |||
+      b.getLimbN 3 ≠ 0)
+    (hb3z : b.getLimbN 3 = 0) (hb2z : b.getLimbN 2 = 0)
+    (hb1z : b.getLimbN 1 = 0)
+    (hshift_nz : (clzResult (b.getLimbN 0)).1 ≠ 0)
+    (hpath : ∀ bltu_2 bltu_1 bltu_0,
+      isTrialN1_j3 true (a.getLimbN 3) (b.getLimbN 0) →
+      isTrialN1_j2 true bltu_2
+        (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
+      isTrialN1_j1 true bltu_2 bltu_1
+        (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
+      isTrialN1_j0 true bltu_2 bltu_1 bltu_0
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
+      fullDivN1MulSubEq true bltu_2 bltu_1 bltu_0
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) ∧
+        fullDivN1RemainderLt true bltu_2 bltu_1 bltu_0
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)) :
+    ∃ bltu_2 bltu_1 bltu_0,
+      fullDivN1QuotientWord true bltu_2 bltu_1 bltu_0
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) =
+          EvmWord.div a b := by
+  obtain ⟨bltu_2, bltu_1, bltu_0,
+      hbltu_3, hbltu_2, hbltu_1, hbltu_0⟩ :=
+    n1_trial_witnesses_call_first_of_getLimbN_shape_shift_nz
+      a b hbnz hb3z hb2z hb1z hshift_nz
+  obtain ⟨hmulsub, hrem_lt⟩ :=
+    hpath bltu_2 bltu_1 bltu_0 hbltu_3 hbltu_2 hbltu_1 hbltu_0
+  have hdivWord :=
+    fullDivN1QuotientWord_eq_div_of_getLimbN_mulsub_remainder_lt
+      true bltu_2 bltu_1 bltu_0 hbnz hmulsub hrem_lt
+  exact ⟨bltu_2, bltu_1, bltu_0, hdivWord⟩
+
 /-- Shape-specialized n=1 hdiv witnesses from raw mulsub plus final-remainder
     facts, with the forced first branch recorded as `true`. -/
 theorem n1_shape_hdivs_of_mulsub_remainder_lt
@@ -702,10 +744,16 @@ theorem n1_full_div_getLimbN_of_mulsub_overestimate
         (fullDivN1R3 true
           (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
           (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1 := by
-  obtain ⟨bltu_2, bltu_1, bltu_0, _, _, _, _, hdiv0, hdiv1, hdiv2, hdiv3⟩ :=
-    n1_shape_hdivs_of_mulsub_overestimate
+  obtain ⟨bltu_2, bltu_1, bltu_0, hdivWord⟩ :=
+    n1_shape_quotient_word_of_mulsub_overestimate
       a b hbnz hb3z hb2z hb1z hshift_nz hpath
-  exact ⟨bltu_2, bltu_1, bltu_0, hdiv0, hdiv1, hdiv2, hdiv3⟩
+  have hdivs :=
+    fullDivN1_hdivs_of_word_eq true bltu_2 bltu_1 bltu_0
+      a b
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+      hdivWord
+  exact ⟨bltu_2, bltu_1, bltu_0, hdivs⟩
 
 /-- Acceptance-shaped n=1 full division limb theorem from raw mulsub plus
     final-remainder facts. The remaining unconditional step is to discharge
@@ -751,9 +799,15 @@ theorem n1_full_div_getLimbN_of_mulsub_remainder_lt
         (fullDivN1R3 true
           (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
           (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1 := by
-  obtain ⟨bltu_2, bltu_1, bltu_0, _, _, _, _, hdiv0, hdiv1, hdiv2, hdiv3⟩ :=
-    n1_shape_hdivs_of_mulsub_remainder_lt
+  obtain ⟨bltu_2, bltu_1, bltu_0, hdivWord⟩ :=
+    n1_shape_quotient_word_of_mulsub_remainder_lt
       a b hbnz hb3z hb2z hb1z hshift_nz hpath
-  exact ⟨bltu_2, bltu_1, bltu_0, hdiv0, hdiv1, hdiv2, hdiv3⟩
+  have hdivs :=
+    fullDivN1_hdivs_of_word_eq true bltu_2 bltu_1 bltu_0
+      a b
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+      hdivWord
+  exact ⟨bltu_2, bltu_1, bltu_0, hdivs⟩
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add a shape-specialized N1 quotient-word helper for the final-remainder path
- refactor N1 acceptance-shaped full-div limb witness wrappers to project from quotient-word equalities
- keep public theorem statements unchanged while reducing direct dependence on packed hdiv witness unpacking

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.N1TrialWitnesses
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/Spec/N1TrialWitnesses.lean
- lake build