### PR TITLE
refactor(div): force n1 j1 branch from remainder bound

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N1TrialWitnesses.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N1TrialWitnesses.lean
@@ -311,6 +311,251 @@ theorem isTrialN1_j1_true_of_fullDivN1R2_remainder_lt
     rw [EvmWord.ult_iff]
     exact h_ult]
 
+/-- A one-word bound on the third n=1 remainder forces the final trial branch
+    to be the call branch. -/
+theorem isTrialN1_j0_true_of_fullDivN1R1_remainder_lt
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hr1_lt :
+      EvmWord.val256
+        (fullDivN1R1 true true true a0 a1 a2 a3 b0 b1 b2 b3).2.1
+        (fullDivN1R1 true true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.1
+        (fullDivN1R1 true true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1
+        (fullDivN1R1 true true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1 <
+      (fullDivN1NormV b0 b1 b2 b3).1.toNat) :
+    isTrialN1_j0 true true true true a0 a1 a2 a3 b0 b1 b2 b3 := by
+  unfold isTrialN1_j0
+  unfold fullDivN1R1 fullDivN1R2 fullDivN1R3 fullDivN1NormV fullDivN1NormU
+    fullDivN1Shift fullDivN1AntiShift at hr1_lt
+  dsimp only at hr1_lt ⊢
+  have h_ult := val256_limb0_lt_of_lt_word _ _ _ _
+    (b0 <<< ((clzResult b0).1.toNat % 64)) hr1_lt
+  unfold fullDivN1Shift at h_ult
+  rw [show BitVec.ult
+      (iterN1 true (b0 <<< ((clzResult b0).1.toNat % 64))
+            (b1 <<< ((clzResult b0).1.toNat % 64) |||
+              b0 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+            (b2 <<< ((clzResult b0).1.toNat % 64) |||
+              b1 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+            (b3 <<< ((clzResult b0).1.toNat % 64) |||
+              b2 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+            (a1 <<< ((clzResult b0).1.toNat % 64) |||
+              a0 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+            (iterN1 true (b0 <<< ((clzResult b0).1.toNat % 64))
+              (b1 <<< ((clzResult b0).1.toNat % 64) |||
+                b0 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+              (b2 <<< ((clzResult b0).1.toNat % 64) |||
+                b1 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+              (b3 <<< ((clzResult b0).1.toNat % 64) |||
+                b2 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+              (a2 <<< ((clzResult b0).1.toNat % 64) |||
+                a1 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+              (iterN1 true (b0 <<< ((clzResult b0).1.toNat % 64))
+                (b1 <<< ((clzResult b0).1.toNat % 64) |||
+                  b0 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (b2 <<< ((clzResult b0).1.toNat % 64) |||
+                  b1 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (b3 <<< ((clzResult b0).1.toNat % 64) |||
+                  b2 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (a3 <<< ((clzResult b0).1.toNat % 64) |||
+                  a2 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (a3 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                0 0 0).2.1
+              (iterN1 true (b0 <<< ((clzResult b0).1.toNat % 64))
+                (b1 <<< ((clzResult b0).1.toNat % 64) |||
+                  b0 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (b2 <<< ((clzResult b0).1.toNat % 64) |||
+                  b1 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (b3 <<< ((clzResult b0).1.toNat % 64) |||
+                  b2 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (a3 <<< ((clzResult b0).1.toNat % 64) |||
+                  a2 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (a3 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                0 0 0).2.2.1
+              (iterN1 true (b0 <<< ((clzResult b0).1.toNat % 64))
+                (b1 <<< ((clzResult b0).1.toNat % 64) |||
+                  b0 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (b2 <<< ((clzResult b0).1.toNat % 64) |||
+                  b1 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (b3 <<< ((clzResult b0).1.toNat % 64) |||
+                  b2 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (a3 <<< ((clzResult b0).1.toNat % 64) |||
+                  a2 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (a3 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                0 0 0).2.2.2.1
+              (iterN1 true (b0 <<< ((clzResult b0).1.toNat % 64))
+                (b1 <<< ((clzResult b0).1.toNat % 64) |||
+                  b0 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (b2 <<< ((clzResult b0).1.toNat % 64) |||
+                  b1 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (b3 <<< ((clzResult b0).1.toNat % 64) |||
+                  b2 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (a3 <<< ((clzResult b0).1.toNat % 64) |||
+                  a2 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (a3 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                0 0 0).2.2.2.2.1).2.1
+            (iterN1 true (b0 <<< ((clzResult b0).1.toNat % 64))
+              (b1 <<< ((clzResult b0).1.toNat % 64) |||
+                b0 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+              (b2 <<< ((clzResult b0).1.toNat % 64) |||
+                b1 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+              (b3 <<< ((clzResult b0).1.toNat % 64) |||
+                b2 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+              (a2 <<< ((clzResult b0).1.toNat % 64) |||
+                a1 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+              (iterN1 true (b0 <<< ((clzResult b0).1.toNat % 64))
+                (b1 <<< ((clzResult b0).1.toNat % 64) |||
+                  b0 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (b2 <<< ((clzResult b0).1.toNat % 64) |||
+                  b1 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (b3 <<< ((clzResult b0).1.toNat % 64) |||
+                  b2 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (a3 <<< ((clzResult b0).1.toNat % 64) |||
+                  a2 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (a3 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                0 0 0).2.1
+              (iterN1 true (b0 <<< ((clzResult b0).1.toNat % 64))
+                (b1 <<< ((clzResult b0).1.toNat % 64) |||
+                  b0 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (b2 <<< ((clzResult b0).1.toNat % 64) |||
+                  b1 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (b3 <<< ((clzResult b0).1.toNat % 64) |||
+                  b2 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (a3 <<< ((clzResult b0).1.toNat % 64) |||
+                  a2 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (a3 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                0 0 0).2.2.1
+              (iterN1 true (b0 <<< ((clzResult b0).1.toNat % 64))
+                (b1 <<< ((clzResult b0).1.toNat % 64) |||
+                  b0 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (b2 <<< ((clzResult b0).1.toNat % 64) |||
+                  b1 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (b3 <<< ((clzResult b0).1.toNat % 64) |||
+                  b2 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (a3 <<< ((clzResult b0).1.toNat % 64) |||
+                  a2 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (a3 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                0 0 0).2.2.2.1
+              (iterN1 true (b0 <<< ((clzResult b0).1.toNat % 64))
+                (b1 <<< ((clzResult b0).1.toNat % 64) |||
+                  b0 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (b2 <<< ((clzResult b0).1.toNat % 64) |||
+                  b1 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (b3 <<< ((clzResult b0).1.toNat % 64) |||
+                  b2 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (a3 <<< ((clzResult b0).1.toNat % 64) |||
+                  a2 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (a3 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                0 0 0).2.2.2.2.1).2.2.1
+            (iterN1 true (b0 <<< ((clzResult b0).1.toNat % 64))
+              (b1 <<< ((clzResult b0).1.toNat % 64) |||
+                b0 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+              (b2 <<< ((clzResult b0).1.toNat % 64) |||
+                b1 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+              (b3 <<< ((clzResult b0).1.toNat % 64) |||
+                b2 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+              (a2 <<< ((clzResult b0).1.toNat % 64) |||
+                a1 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+              (iterN1 true (b0 <<< ((clzResult b0).1.toNat % 64))
+                (b1 <<< ((clzResult b0).1.toNat % 64) |||
+                  b0 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (b2 <<< ((clzResult b0).1.toNat % 64) |||
+                  b1 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (b3 <<< ((clzResult b0).1.toNat % 64) |||
+                  b2 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (a3 <<< ((clzResult b0).1.toNat % 64) |||
+                  a2 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (a3 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                0 0 0).2.1
+              (iterN1 true (b0 <<< ((clzResult b0).1.toNat % 64))
+                (b1 <<< ((clzResult b0).1.toNat % 64) |||
+                  b0 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (b2 <<< ((clzResult b0).1.toNat % 64) |||
+                  b1 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (b3 <<< ((clzResult b0).1.toNat % 64) |||
+                  b2 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (a3 <<< ((clzResult b0).1.toNat % 64) |||
+                  a2 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (a3 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                0 0 0).2.2.1
+              (iterN1 true (b0 <<< ((clzResult b0).1.toNat % 64))
+                (b1 <<< ((clzResult b0).1.toNat % 64) |||
+                  b0 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (b2 <<< ((clzResult b0).1.toNat % 64) |||
+                  b1 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (b3 <<< ((clzResult b0).1.toNat % 64) |||
+                  b2 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (a3 <<< ((clzResult b0).1.toNat % 64) |||
+                  a2 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (a3 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                0 0 0).2.2.2.1
+              (iterN1 true (b0 <<< ((clzResult b0).1.toNat % 64))
+                (b1 <<< ((clzResult b0).1.toNat % 64) |||
+                  b0 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (b2 <<< ((clzResult b0).1.toNat % 64) |||
+                  b1 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (b3 <<< ((clzResult b0).1.toNat % 64) |||
+                  b2 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (a3 <<< ((clzResult b0).1.toNat % 64) |||
+                  a2 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (a3 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                0 0 0).2.2.2.2.1).2.2.2.1
+            (iterN1 true (b0 <<< ((clzResult b0).1.toNat % 64))
+              (b1 <<< ((clzResult b0).1.toNat % 64) |||
+                b0 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+              (b2 <<< ((clzResult b0).1.toNat % 64) |||
+                b1 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+              (b3 <<< ((clzResult b0).1.toNat % 64) |||
+                b2 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+              (a2 <<< ((clzResult b0).1.toNat % 64) |||
+                a1 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+              (iterN1 true (b0 <<< ((clzResult b0).1.toNat % 64))
+                (b1 <<< ((clzResult b0).1.toNat % 64) |||
+                  b0 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (b2 <<< ((clzResult b0).1.toNat % 64) |||
+                  b1 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (b3 <<< ((clzResult b0).1.toNat % 64) |||
+                  b2 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (a3 <<< ((clzResult b0).1.toNat % 64) |||
+                  a2 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (a3 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                0 0 0).2.1
+              (iterN1 true (b0 <<< ((clzResult b0).1.toNat % 64))
+                (b1 <<< ((clzResult b0).1.toNat % 64) |||
+                  b0 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (b2 <<< ((clzResult b0).1.toNat % 64) |||
+                  b1 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (b3 <<< ((clzResult b0).1.toNat % 64) |||
+                  b2 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (a3 <<< ((clzResult b0).1.toNat % 64) |||
+                  a2 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (a3 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                0 0 0).2.2.1
+              (iterN1 true (b0 <<< ((clzResult b0).1.toNat % 64))
+                (b1 <<< ((clzResult b0).1.toNat % 64) |||
+                  b0 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (b2 <<< ((clzResult b0).1.toNat % 64) |||
+                  b1 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (b3 <<< ((clzResult b0).1.toNat % 64) |||
+                  b2 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (a3 <<< ((clzResult b0).1.toNat % 64) |||
+                  a2 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (a3 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                0 0 0).2.2.2.1
+              (iterN1 true (b0 <<< ((clzResult b0).1.toNat % 64))
+                (b1 <<< ((clzResult b0).1.toNat % 64) |||
+                  b0 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (b2 <<< ((clzResult b0).1.toNat % 64) |||
+                  b1 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (b3 <<< ((clzResult b0).1.toNat % 64) |||
+                  b2 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (a3 <<< ((clzResult b0).1.toNat % 64) |||
+                  a2 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                (a3 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+                0 0 0).2.2.2.2.1).2.2.2.2.1).2.1
+      (b0 <<< ((clzResult b0).1.toNat % 64)) = true by
+    rw [EvmWord.ult_iff]
+    exact h_ult]
+
 /-- Bundled public-surface n=1 branch witnesses from the dispatcher shape
     hypotheses, with the forced first branch recorded as `true`. -/
 theorem n1TrialWitnesses_of_getLimbN_shape_shift_nz

--- a/EvmAsm/Evm64/DivMod/Spec/N1TrialWitnesses.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N1TrialWitnesses.lean
@@ -234,6 +234,83 @@ theorem isTrialN1_j2_true_of_fullDivN1R3_remainder_lt
     rw [EvmWord.ult_iff]
     exact h_ult]
 
+/-- A one-word bound on the second n=1 remainder forces the next trial branch
+    to be the call branch. -/
+theorem isTrialN1_j1_true_of_fullDivN1R2_remainder_lt
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hr2_lt :
+      EvmWord.val256
+        (fullDivN1R2 true true a0 a1 a2 a3 b0 b1 b2 b3).2.1
+        (fullDivN1R2 true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.1
+        (fullDivN1R2 true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1
+        (fullDivN1R2 true true a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1 <
+      (fullDivN1NormV b0 b1 b2 b3).1.toNat) :
+    isTrialN1_j1 true true true a1 a2 a3 b0 b1 b2 b3 := by
+  unfold isTrialN1_j1
+  unfold fullDivN1R2 fullDivN1R3 fullDivN1NormV fullDivN1NormU
+    fullDivN1Shift fullDivN1AntiShift at hr2_lt
+  dsimp only at hr2_lt ⊢
+  have h_ult := val256_limb0_lt_of_lt_word _ _ _ _
+    (b0 <<< ((clzResult b0).1.toNat % 64)) hr2_lt
+  unfold fullDivN1Shift at h_ult
+  rw [show BitVec.ult
+      (iterN1 true (b0 <<< ((clzResult b0).1.toNat % 64))
+            (b1 <<< ((clzResult b0).1.toNat % 64) |||
+              b0 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+            (b2 <<< ((clzResult b0).1.toNat % 64) |||
+              b1 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+            (b3 <<< ((clzResult b0).1.toNat % 64) |||
+              b2 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+            (a2 <<< ((clzResult b0).1.toNat % 64) |||
+              a1 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+            (iterN1 true (b0 <<< ((clzResult b0).1.toNat % 64))
+              (b1 <<< ((clzResult b0).1.toNat % 64) |||
+                b0 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+              (b2 <<< ((clzResult b0).1.toNat % 64) |||
+                b1 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+              (b3 <<< ((clzResult b0).1.toNat % 64) |||
+                b2 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+              (a3 <<< ((clzResult b0).1.toNat % 64) |||
+                a2 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+              (a3 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+              0 0 0).2.1
+            (iterN1 true (b0 <<< ((clzResult b0).1.toNat % 64))
+              (b1 <<< ((clzResult b0).1.toNat % 64) |||
+                b0 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+              (b2 <<< ((clzResult b0).1.toNat % 64) |||
+                b1 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+              (b3 <<< ((clzResult b0).1.toNat % 64) |||
+                b2 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+              (a3 <<< ((clzResult b0).1.toNat % 64) |||
+                a2 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+              (a3 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+              0 0 0).2.2.1
+            (iterN1 true (b0 <<< ((clzResult b0).1.toNat % 64))
+              (b1 <<< ((clzResult b0).1.toNat % 64) |||
+                b0 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+              (b2 <<< ((clzResult b0).1.toNat % 64) |||
+                b1 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+              (b3 <<< ((clzResult b0).1.toNat % 64) |||
+                b2 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+              (a3 <<< ((clzResult b0).1.toNat % 64) |||
+                a2 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+              (a3 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+              0 0 0).2.2.2.1
+            (iterN1 true (b0 <<< ((clzResult b0).1.toNat % 64))
+              (b1 <<< ((clzResult b0).1.toNat % 64) |||
+                b0 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+              (b2 <<< ((clzResult b0).1.toNat % 64) |||
+                b1 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+              (b3 <<< ((clzResult b0).1.toNat % 64) |||
+                b2 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+              (a3 <<< ((clzResult b0).1.toNat % 64) |||
+                a2 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+              (a3 >>> ((signExtend12 0 - (clzResult b0).1).toNat % 64))
+              0 0 0).2.2.2.2.1).2.1
+      (b0 <<< ((clzResult b0).1.toNat % 64)) = true by
+    rw [EvmWord.ult_iff]
+    exact h_ult]
+
 /-- Bundled public-surface n=1 branch witnesses from the dispatcher shape
     hypotheses, with the forced first branch recorded as `true`. -/
 theorem n1TrialWitnesses_of_getLimbN_shape_shift_nz


### PR DESCRIPTION
## Summary
- prove the n=1 R2 one-word remainder bound forces the following j1 trial branch to be true
- continue the branch-forcing chain needed to align runtime trial witnesses with the all-call true/true/true/true arithmetic wrappers

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.N1TrialWitnesses
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/Spec/N1TrialWitnesses.lean
- lake build