### PR TITLE
refactor(div): use n1 path quotient nonzero shim

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N1AllPhasesGetLimb.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N1AllPhasesGetLimb.lean
@@ -993,8 +993,8 @@ theorem n1_quotient_word_true_true_true_true_of_path_remainders_lt_all_phases_no
       a b hbnz hb3z hb2z hb1z hshift_nz hr3_lt hr2_lt hr1_lt
   obtain ⟨hcarry2, hr3_inv, hr2_inv, hr1_inv, hfinal_inv, hrem_lt⟩ :=
     hpath hbltu_3 hbltu_2 hbltu_1 hbltu_0
-  exact n1_quotient_word_true_true_true_true_of_remainders_lt_all_phases_no_wrap
-    a b hbnz hb3z hb2z hb1z hshift_nz hcarry2
+  exact n1_quotient_word_true_true_true_true_of_remainders_lt_all_phases_no_wrap_ne_zero
+    a b ((EvmWord.ne_zero_iff_getLimbN_or).mpr hbnz) hb3z hb2z hb1z hshift_nz hcarry2
     hr3_lt hr2_lt hr1_lt hr3_inv hr2_inv hr1_inv hfinal_inv hrem_lt
 
 /-- Path-surface variant of


### PR DESCRIPTION
Summary:
- route the all-true n=1 path-level quotient wrapper through the b ≠ 0 quotient shim
- keep the existing limb-OR branch witness derivation unchanged
- exercise the new nonzero quotient surface without changing theorem statements

Verification:
- lake build EvmAsm.Evm64.DivMod.Spec.N1AllPhasesGetLimb
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/Spec/N1AllPhasesGetLimb.lean
- lake build