### PR TITLE
refactor(div): move n3 callable shape wrapper

### DIFF
--- a/EvmAsm/Evm64/DivMod/CallableV4Div.lean
+++ b/EvmAsm/Evm64/DivMod/CallableV4Div.lean
@@ -1385,53 +1385,6 @@ theorem evm_div_callable_v4_n3_stack_pre_to_callable_post_scratch_limbNz
     ((EvmWord.ne_zero_iff_getLimbN_or).mpr hbnz)
     hb3z hb2nz hshift_nz halign hcarry2 harith
 
-/-- N3 DIV v4 callable wrapper deriving divisor nonzero from the n=3 shape. -/
-theorem evm_div_callable_v4_n3_stack_pre_to_callable_post_scratch_shape
-    (sp base : Word) (a b : EvmWord)
-    (v5 v6 v7 v10 v11Old : Word)
-    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
-     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
-    (raVal : Word)
-    (hb3z : b.getLimbN 3 = 0) (hb2nz : b.getLimbN 2 ≠ 0)
-    (hshift_nz : (clzResult (b.getLimbN 2)).1 ≠ 0)
-    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
-      base + div128CallRetOff)
-    (hcarry2 : fullDivN3Carry2NzV4
-      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3))
-    (harith : ∀ bltu_1 bltu_0,
-      isTrialN3V4_j1 bltu_1
-        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
-      isTrialN3V4_j0 bltu_1 bltu_0
-        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
-      fullDivN3MulSubEqV4 bltu_1 bltu_0
-          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) ∧
-        fullDivN3QuotientOverestimateV4 bltu_1 bltu_0
-          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)) :
-    cpsTripleWithin (unifiedDivBound + 1) base (raVal &&& ~~~1)
-      (evm_div_callable_code_v4 base)
-      (divModStackDispatchPreNoX1 sp a b
-        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
-        ((clzResult (b.getLimbN 2)).2 >>> (63 : Nat))
-        v5 v6 v7 v10 v11Old
-        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
-        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
-       ((sp + signExtend12 3936) ↦ₘ scratchMem))
-      (divStackDispatchPostCallableExactFrame sp a b raVal
-        (signExtend12 4095 : Word) **
-       memOwn (sp + signExtend12 3936)) := by
-  have hbnz : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 ≠ 0 :=
-    n3_limb_or_ne_zero_of_limb2_ne_zero hb2nz
-  exact evm_div_callable_v4_n3_stack_pre_to_callable_post_scratch_limbNz
-    sp base a b
-    v5 v6 v7 v10 v11Old
-    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
-    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
-    hbnz hb3z hb2nz hshift_nz halign hcarry2 harith
-
 /-- Arithmetic-assumption version of
     `evm_div_callable_v4_n3_stack_pre_to_callable_post_scratch_word`. -/
 theorem evm_div_callable_v4_n3_stack_pre_to_callable_post_scratch_of_mulsub_overestimate

--- a/EvmAsm/Evm64/DivMod/CallableV4DivShape.lean
+++ b/EvmAsm/Evm64/DivMod/CallableV4DivShape.lean
@@ -56,4 +56,51 @@ theorem evm_div_callable_v4_n2_stack_pre_to_callable_post_scratch_shape
     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
     hbnz hb3z hb2z hb1nz hshift_nz halign hcarry2 harith
 
+/-- N3 DIV v4 callable wrapper deriving divisor nonzero from the n=3 shape. -/
+theorem evm_div_callable_v4_n3_stack_pre_to_callable_post_scratch_shape
+    (sp base : Word) (a b : EvmWord)
+    (v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (hb3z : b.getLimbN 3 = 0) (hb2nz : b.getLimbN 2 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 2)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hcarry2 : fullDivN3Carry2NzV4
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3))
+    (harith : ∀ bltu_1 bltu_0,
+      isTrialN3V4_j1 bltu_1
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
+      isTrialN3V4_j0 bltu_1 bltu_0
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
+      fullDivN3MulSubEqV4 bltu_1 bltu_0
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) ∧
+        fullDivN3QuotientOverestimateV4 bltu_1 bltu_0
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)) :
+    cpsTripleWithin (unifiedDivBound + 1) base (raVal &&& ~~~1)
+      (evm_div_callable_code_v4 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult (b.getLimbN 2)).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divStackDispatchPostCallableExactFrame sp a b raVal
+        (signExtend12 4095 : Word) **
+       memOwn (sp + signExtend12 3936)) := by
+  have hbnz : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 ≠ 0 :=
+    n3_limb_or_ne_zero_of_limb2_ne_zero hb2nz
+  exact evm_div_callable_v4_n3_stack_pre_to_callable_post_scratch_limbNz
+    sp base a b
+    v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+    hbnz hb3z hb2nz hshift_nz halign hcarry2 harith
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- move evm_div_callable_v4_n3_stack_pre_to_callable_post_scratch_shape into CallableV4DivShape.lean alongside the n2 shape wrapper
- preserve the theorem name and namespace while reducing CallableV4Div.lean from 1480 to 1433 lines
- keep the DivMod umbrella import path unchanged from the prior shape-leaf PR

## Verification
- lake build EvmAsm.Evm64.DivMod.CallableV4DivShape
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/CallableV4Div.lean EvmAsm/Evm64/DivMod/CallableV4DivShape.lean
- lake build