### PR TITLE
refactor(div): add n3 concrete trial wrapper

### DIFF
--- a/EvmAsm/Evm64/DivMod/CallableV4DivConcrete.lean
+++ b/EvmAsm/Evm64/DivMod/CallableV4DivConcrete.lean
@@ -314,4 +314,62 @@ theorem evm_div_callable_v4_n3_stack_pre_to_callable_post_scratch_path_shape
     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
     hbnz hb3z hb2nz hshift_nz halign hpath
 
+/-- Trial-bundled N3 DIV v4 callable wrapper preserving the concrete v4
+    trial-call scratch value.
+
+    The branch booleans remain existential because the concrete scratch value
+    is indexed by them. Carry and arithmetic obligations are still explicit. -/
+theorem evm_div_callable_v4_n3_stack_pre_to_callable_post_scratch_trial_exists
+    (sp base : Word) (a b : EvmWord)
+    (v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (hb3z : b.getLimbN 3 = 0) (hb2nz : b.getLimbN 2 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 2)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (htrial : N3V4TrialWitnesses a b)
+    (hcarry2 : fullDivN3Carry2NzV4
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3))
+    (harith : ∀ bltu_1 bltu_0,
+      isTrialN3V4_j1 bltu_1
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
+      isTrialN3V4_j0 bltu_1 bltu_0
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
+      fullDivN3MulSubEqV4 bltu_1 bltu_0
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) ∧
+        fullDivN3QuotientOverestimateV4 bltu_1 bltu_0
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)) :
+    ∃ bltu_1 bltu_0,
+      cpsTripleWithin (unifiedDivBound + 1) base (raVal &&& ~~~1)
+        (evm_div_callable_code_v4 base)
+        (divModStackDispatchPreNoX1 sp a b
+          (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+          ((clzResult (b.getLimbN 2)).2 >>> (63 : Nat))
+          v5 v6 v7 v10 v11Old
+          q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+         ((sp + signExtend12 3936) ↦ₘ scratchMem))
+        (divStackDispatchPostCallableExactFrame sp a b raVal
+          (signExtend12 4095 : Word) **
+         ((sp + signExtend12 3936) ↦ₘ
+          fullDivN3ScratchMemV4 bltu_1 bltu_0
+            (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+            (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+            scratchMem)) := by
+  obtain ⟨bltu_1, bltu_0, hpath⟩ :=
+    N3V4TrialWitnesses.exists_path_conditions htrial hcarry2 harith
+  exact ⟨bltu_1, bltu_0,
+    evm_div_callable_v4_n3_stack_pre_to_callable_post_scratch_path_shape
+      bltu_1 bltu_0 sp base a b
+      v5 v6 v7 v10 v11Old
+      q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+      nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+      hb3z hb2nz hshift_nz halign hpath⟩
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add evm_div_callable_v4_n3_stack_pre_to_callable_post_scratch_trial_exists
- internalize N3 V4 trial branch witnesses via N3V4TrialWitnesses.exists_path_conditions
- preserve the concrete fullDivN3ScratchMemV4 postcondition by returning the branch booleans existentially

## Verification
- lake build EvmAsm.Evm64.DivMod.CallableV4DivConcrete
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/CallableV4DivConcrete.lean
- lake build