### PR TITLE
refactor(div): add n2 concrete auto-trial wrapper

### DIFF
--- a/EvmAsm/Evm64/DivMod/CallableV4DivConcrete.lean
+++ b/EvmAsm/Evm64/DivMod/CallableV4DivConcrete.lean
@@ -238,6 +238,67 @@ theorem evm_div_callable_v4_n2_stack_pre_to_callable_post_scratch_trial_exists
       nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
       hb3z hb2z hb1nz hshift_nz halign hpath⟩
 
+/-- Auto-trial N2 DIV v4 callable wrapper preserving the concrete v4
+    trial-call scratch value.
+
+    This constructs the mechanical trial witnesses internally. The branch
+    booleans remain existential because the concrete scratch value is indexed
+    by them. -/
+theorem evm_div_callable_v4_n2_stack_pre_to_callable_post_scratch_autoTrial_exists
+    (sp base : Word) (a b : EvmWord)
+    (v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (hb3z : b.getLimbN 3 = 0) (hb2z : b.getLimbN 2 = 0)
+    (hb1nz : b.getLimbN 1 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 1)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hcarry2 : fullDivN2Carry2NzV4
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3))
+    (harith : ∀ bltu_2 bltu_1 bltu_0,
+      isTrialN2V4_j2 bltu_2
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
+      isTrialN2V4_j1 bltu_2 bltu_1
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
+      isTrialN2V4_j0 bltu_2 bltu_1 bltu_0
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
+      fullDivN2MulSubEqV4 bltu_2 bltu_1 bltu_0
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) ∧
+        fullDivN2QuotientOverestimateV4 bltu_2 bltu_1 bltu_0
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)) :
+    ∃ bltu_2 bltu_1 bltu_0,
+      cpsTripleWithin (unifiedDivBound + 1) base (raVal &&& ~~~1)
+        (evm_div_callable_code_v4 base)
+        (divModStackDispatchPreNoX1 sp a b
+          (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+          ((clzResult (b.getLimbN 1)).2 >>> (63 : Nat))
+          v5 v6 v7 v10 v11Old
+          q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+          shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+         ((sp + signExtend12 3936) ↦ₘ scratchMem))
+        (divStackDispatchPostCallableExactFrame sp a b raVal
+          (signExtend12 4095 : Word) **
+         ((sp + signExtend12 3936) ↦ₘ
+          fullDivN2ScratchMemV4 bltu_2 bltu_1 bltu_0
+            (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+            (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+            scratchMem)) := by
+  exact
+    evm_div_callable_v4_n2_stack_pre_to_callable_post_scratch_trial_exists
+      sp base a b
+      v5 v6 v7 v10 v11Old
+      q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+      nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+      hb3z hb2z hb1nz hshift_nz halign
+      (n2V4TrialWitnesses_of_getLimbN a b) hcarry2 harith
+
 /-- Path-bundled N3 DIV v4 callable wrapper preserving the concrete v4
     trial-call scratch value, with dispatcher-style limb-or nonzero input. -/
 theorem evm_div_callable_v4_n3_stack_pre_to_callable_post_scratch_path_limbNz


### PR DESCRIPTION
## Summary
- add evm_div_callable_v4_n2_stack_pre_to_callable_post_scratch_autoTrial_exists
- construct N2V4TrialWitnesses internally for the concrete scratch-preserving callable wrapper
- keep carry2 and arithmetic obligations explicit while returning branch booleans existentially for fullDivN2ScratchMemV4

## Verification
- lake build EvmAsm.Evm64.DivMod.CallableV4DivConcrete
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/CallableV4DivConcrete.lean
- lake build