### PR TITLE
refactor(div): use path projections in callable wrappers

### DIFF
--- a/EvmAsm/Evm64/DivMod/CallableV4Div.lean
+++ b/EvmAsm/Evm64/DivMod/CallableV4Div.lean
@@ -1415,8 +1415,12 @@ theorem evm_div_callable_v4_n3_stack_pre_to_callable_post_scratch_of_mulsub_over
           (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
           (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
           scratchMem)) := by
-  have hpath' := hpath
-  obtain ⟨hbltu_1, hbltu_0, hcarry2, _, _⟩ := hpath'
+  have hbltu_1 := fullDivN3PathConditionsWordV4_trial_j1
+    bltu_1 bltu_0 a b hpath
+  have hbltu_0 := fullDivN3PathConditionsWordV4_trial_j0
+    bltu_1 bltu_0 a b hpath
+  have hcarry2 := fullDivN3PathConditionsWordV4_carry2
+    bltu_1 bltu_0 a b hpath
   have hdivWord :=
     fullDivN3QuotientWordV4_eq_div_of_word_path_conditions_ne_zero
       bltu_1 bltu_0 a b hbnz hpath

--- a/EvmAsm/Evm64/DivMod/CallableV4DivConcrete.lean
+++ b/EvmAsm/Evm64/DivMod/CallableV4DivConcrete.lean
@@ -35,8 +35,14 @@ theorem evm_div_callable_v4_n2_stack_pre_to_callable_post_scratch_path_word
           (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
           (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
           scratchMem)) := by
-  have hpath' := hpath
-  obtain ⟨hbltu_2, hbltu_1, hbltu_0, hcarry2, _, _⟩ := hpath'
+  have hbltu_2 := fullDivN2PathConditionsWordV4_trial_j2
+    bltu_2 bltu_1 bltu_0 a b hpath
+  have hbltu_1 := fullDivN2PathConditionsWordV4_trial_j1
+    bltu_2 bltu_1 bltu_0 a b hpath
+  have hbltu_0 := fullDivN2PathConditionsWordV4_trial_j0
+    bltu_2 bltu_1 bltu_0 a b hpath
+  have hcarry2 := fullDivN2PathConditionsWordV4_carry2
+    bltu_2 bltu_1 bltu_0 a b hpath
   have hdivWord :=
     fullDivN2QuotientWordV4_eq_div_of_word_path_conditions_ne_zero
       bltu_2 bltu_1 bltu_0 a b hbnz hpath

--- a/EvmAsm/Evm64/DivMod/Spec/N2V4CallableExact.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2V4CallableExact.lean
@@ -115,8 +115,14 @@ theorem evm_div_n2_stack_spec_noNop_v4_preNoX1_callableExactFrame_path_uni
       (divStackDispatchPostCallableExactFrame sp a b raVal
         (signExtend12 4095 : Word) **
        memOwn (sp + signExtend12 3936)) := by
-  have hpath' := hpath
-  obtain ⟨hbltu_2, hbltu_1, hbltu_0, hcarry2, _, _⟩ := hpath'
+  have hbltu_2 := fullDivN2PathConditionsWordV4_trial_j2
+    bltu_2 bltu_1 bltu_0 a b hpath
+  have hbltu_1 := fullDivN2PathConditionsWordV4_trial_j1
+    bltu_2 bltu_1 bltu_0 a b hpath
+  have hbltu_0 := fullDivN2PathConditionsWordV4_trial_j0
+    bltu_2 bltu_1 bltu_0 a b hpath
+  have hcarry2 := fullDivN2PathConditionsWordV4_carry2
+    bltu_2 bltu_1 bltu_0 a b hpath
   have hdivWord :=
     fullDivN2QuotientWordV4_eq_div_of_word_path_conditions_ne_zero
       bltu_2 bltu_1 bltu_0 a b hbnz hpath

--- a/EvmAsm/Evm64/DivMod/Spec/N3V4CallableExact.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3V4CallableExact.lean
@@ -160,8 +160,12 @@ theorem evm_div_n3_stack_spec_noNop_v4_preNoX1_callableExactFrame_path_uni
       (divStackDispatchPostCallableExactFrame sp a b raVal
         (signExtend12 4095 : Word) **
        memOwn (sp + signExtend12 3936)) := by
-  have hpath' := hpath
-  obtain ⟨hbltu_1, hbltu_0, hcarry2, _, _⟩ := hpath'
+  have hbltu_1 := fullDivN3PathConditionsWordV4_trial_j1
+    bltu_1 bltu_0 a b hpath
+  have hbltu_0 := fullDivN3PathConditionsWordV4_trial_j0
+    bltu_1 bltu_0 a b hpath
+  have hcarry2 := fullDivN3PathConditionsWordV4_carry2
+    bltu_1 bltu_0 a b hpath
   have hdivWord :=
     fullDivN3QuotientWordV4_eq_div_of_word_path_conditions_ne_zero
       bltu_1 bltu_0 a b hbnz hpath


### PR DESCRIPTION
## Summary
- use fullDivN2/3 path projection lemmas in callable path wrappers
- avoid copying/destructing bundled path predicates just to preserve hpath for quotient helpers

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.N2V4CallableExact
- lake build EvmAsm.Evm64.DivMod.Spec.N3V4CallableExact
- lake build EvmAsm.Evm64.DivMod.CallableV4Div
- lake build EvmAsm.Evm64.DivMod.CallableV4DivConcrete
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/CallableV4Div.lean EvmAsm/Evm64/DivMod/CallableV4DivConcrete.lean EvmAsm/Evm64/DivMod/Spec/N2V4CallableExact.lean EvmAsm/Evm64/DivMod/Spec/N3V4CallableExact.lean
- lake build