### PR TITLE
refactor(div): inline trial hdiv packages

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N2TrialWitnesses.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2TrialWitnesses.lean
@@ -299,14 +299,13 @@ theorem N2V4TrialWitnesses.exists_hdivs_of_path_conditions
       hbltu_2, hbltu_1, hbltu_0, hdivWord⟩ :=
     N2V4TrialWitnesses.exists_quotient_word_of_path_conditions
       htrial hbnz hcarry2 harith
-  have hdivs :=
+  exact ⟨bltu_2, bltu_1, bltu_0,
+    hbltu_2, hbltu_1, hbltu_0,
     fullDivN2V4_hdivs_of_word_eq bltu_2 bltu_1 bltu_0
       a b
       (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
       (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
-      hdivWord
-  exact ⟨bltu_2, bltu_1, bltu_0,
-    hbltu_2, hbltu_1, hbltu_0, hdivs⟩
+      hdivWord⟩
 
 /-- Nonzero-surface quotient-word witnesses from an `N2V4TrialWitnesses`
     bundle. -/
@@ -407,14 +406,13 @@ theorem N2V4TrialWitnesses.exists_hdivs_of_path_conditions_ne_zero
         hbltu_2, hbltu_1, hbltu_0, hdivWord⟩ :=
       N2V4TrialWitnesses.exists_quotient_word_of_path_conditions_ne_zero
         htrial hbnz hcarry2 harith
-    have hdivs :=
+    exact ⟨bltu_2, bltu_1, bltu_0,
+      hbltu_2, hbltu_1, hbltu_0,
       fullDivN2V4_hdivs_of_word_eq bltu_2 bltu_1 bltu_0
         a b
         (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
         (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
-        hdivWord
-    exact ⟨bltu_2, bltu_1, bltu_0,
-      hbltu_2, hbltu_1, hbltu_0, hdivs⟩
+        hdivWord⟩
 
 /-- Auto-trial form of
     `N2V4TrialWitnesses.exists_quotient_word_of_path_conditions`.
@@ -708,13 +706,12 @@ theorem n2V4_full_div_getLimbN_of_path_conditions
       (EvmWord.div a b).getLimbN 3 = (0 : Word) := by
   obtain ⟨bltu_2, bltu_1, bltu_0, hdivWord⟩ :=
     n2V4_quotient_word_of_path_conditions hbnz hcarry2 harith
-  have hdivs :=
+  exact ⟨bltu_2, bltu_1, bltu_0,
     fullDivN2V4_hdivs_of_word_eq bltu_2 bltu_1 bltu_0
       a b
       (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
       (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
-      hdivWord
-  exact ⟨bltu_2, bltu_1, bltu_0, hdivs⟩
+      hdivWord⟩
 
 /-- Nonzero-surface n=2 V4 quotient-limb package.
 

--- a/EvmAsm/Evm64/DivMod/Spec/N3TrialWitnesses.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3TrialWitnesses.lean
@@ -278,14 +278,13 @@ theorem N3V4TrialWitnesses.exists_hdivs_of_path_conditions
   obtain ⟨bltu_1, bltu_0, hbltu_1, hbltu_0, hdivWord⟩ :=
     N3V4TrialWitnesses.exists_quotient_word_of_path_conditions
       htrial hbnz hcarry2 harith
-  have hdivs :=
+  exact ⟨bltu_1, bltu_0,
+    hbltu_1, hbltu_0,
     fullDivN3V4_hdivs_of_word_eq bltu_1 bltu_0
       a b
       (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
       (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
-      hdivWord
-  exact ⟨bltu_1, bltu_0,
-    hbltu_1, hbltu_0, hdivs⟩
+      hdivWord⟩
 
 /-- Nonzero-surface quotient-word witnesses from an `N3V4TrialWitnesses`
     bundle. -/
@@ -369,13 +368,12 @@ theorem N3V4TrialWitnesses.exists_hdivs_of_path_conditions_ne_zero
     obtain ⟨bltu_1, bltu_0, hbltu_1, hbltu_0, hdivWord⟩ :=
       N3V4TrialWitnesses.exists_quotient_word_of_path_conditions_ne_zero
         htrial hbnz hcarry2 harith
-    have hdivs :=
+    exact ⟨bltu_1, bltu_0, hbltu_1, hbltu_0,
       fullDivN3V4_hdivs_of_word_eq bltu_1 bltu_0
         a b
         (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
         (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
-        hdivWord
-    exact ⟨bltu_1, bltu_0, hbltu_1, hbltu_0, hdivs⟩
+        hdivWord⟩
 
 /-- Auto-trial form of
     `N3V4TrialWitnesses.exists_quotient_word_of_path_conditions`.
@@ -632,13 +630,12 @@ theorem n3V4_full_div_getLimbN_of_path_conditions
       (EvmWord.div a b).getLimbN 3 = (0 : Word) := by
   obtain ⟨bltu_1, bltu_0, hdivWord⟩ :=
     n3V4_quotient_word_of_path_conditions hbnz hcarry2 harith
-  have hdivs :=
+  exact ⟨bltu_1, bltu_0,
     fullDivN3V4_hdivs_of_word_eq bltu_1 bltu_0
       a b
       (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
       (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
-      hdivWord
-  exact ⟨bltu_1, bltu_0, hdivs⟩
+      hdivWord⟩
 
 /-- Nonzero-surface n=3 V4 quotient-limb package.
 


### PR DESCRIPTION
## Summary
- inline one-use N2/N3 hdiv packages in trial-witness quotient-limb helpers
- keep the hdiv helpers as direct projections from quotient-word witnesses

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.N2TrialWitnesses
- lake build EvmAsm.Evm64.DivMod.Spec.N3TrialWitnesses
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/Spec/N2TrialWitnesses.lean EvmAsm/Evm64/DivMod/Spec/N3TrialWitnesses.lean
- lake build