### PR TITLE
refactor(div): name N1 all-phases path callback

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N1AllPhasesNonzero.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N1AllPhasesNonzero.lean
@@ -112,6 +112,50 @@ abbrev N1StepOverestimatePathCallback (a b : EvmWord) : Prop :=
     (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
     (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
 
+/-- Variable-branch n=1 path evidence where the R3 call provides the
+    all-phases no-wrap invariant used to derive the R3 carry-zero fact. -/
+abbrev N1AllPhasesOverestimatePathCallback (a b : EvmWord) : Prop :=
+  ∀ bltu_2 bltu_1 bltu_0,
+  isTrialN1_j3 true (a.getLimbN 3) (b.getLimbN 0) →
+  isTrialN1_j2 true bltu_2
+    (a.getLimbN 2) (a.getLimbN 3)
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
+  isTrialN1_j1 true bltu_2 bltu_1
+    (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
+  isTrialN1_j0 true bltu_2 bltu_1 bltu_0
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
+  Carry2NzAll
+    (b.getLimbN 0 <<< (((clzResult (b.getLimbN 0)).1).toNat % 64))
+    ((b.getLimbN 1 <<< (((clzResult (b.getLimbN 0)).1).toNat % 64)) |||
+      (b.getLimbN 0 >>>
+        ((signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 0)).1).toNat % 64)))
+    ((b.getLimbN 2 <<< (((clzResult (b.getLimbN 0)).1).toNat % 64)) |||
+      (b.getLimbN 1 >>>
+        ((signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 0)).1).toNat % 64)))
+    ((b.getLimbN 3 <<< (((clzResult (b.getLimbN 0)).1).toNat % 64)) |||
+      (b.getLimbN 2 >>>
+        ((signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 0)).1).toNat % 64))) ∧
+  Div128AllPhasesNoWrapInv
+    (fullDivN1NormU
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0)).2.2.2.2
+    (fullDivN1NormU
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0)).2.2.2.1
+    (fullDivN1NormV
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1 ∧
+  fullDivN1R2CarryZero true bltu_2
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) ∧
+  fullDivN1R1CarryZero true bltu_2 bltu_1
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) ∧
+  fullDivN1QuotientOverestimate true bltu_2 bltu_1 bltu_0
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+
 /-- `b ≠ 0` and named-callback surface for the all-call n=1 path-level
     quotient-limb wrapper. -/
 theorem n1_full_div_getLimbN_true_true_true_true_of_path_remainders_lt_all_phases_no_wrap_ne_zero

--- a/EvmAsm/Evm64/DivMod/Spec/UnifiedN1StepPath.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/UnifiedN1StepPath.lean
@@ -71,46 +71,7 @@ theorem evm_div_n1_stack_spec_within_word_noNop_preNoX1_callableOwnPost_shape_st
     (hshift_nz : (clzResult (b.getLimbN 0)).1 ≠ 0)
     (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&&
         ~~~(1 : Word) = base + div128CallRetOff)
-    (hpath : ∀ bltu_2 bltu_1 bltu_0,
-      isTrialN1_j3 true (a.getLimbN 3) (b.getLimbN 0) →
-      isTrialN1_j2 true bltu_2
-        (a.getLimbN 2) (a.getLimbN 3)
-        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
-      isTrialN1_j1 true bltu_2 bltu_1
-        (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
-      isTrialN1_j0 true bltu_2 bltu_1 bltu_0
-        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
-      Carry2NzAll
-        (b.getLimbN 0 <<< (((clzResult (b.getLimbN 0)).1).toNat % 64))
-        ((b.getLimbN 1 <<< (((clzResult (b.getLimbN 0)).1).toNat % 64)) |||
-          (b.getLimbN 0 >>>
-            ((signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 0)).1).toNat % 64)))
-        ((b.getLimbN 2 <<< (((clzResult (b.getLimbN 0)).1).toNat % 64)) |||
-          (b.getLimbN 1 >>>
-            ((signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 0)).1).toNat % 64)))
-        ((b.getLimbN 3 <<< (((clzResult (b.getLimbN 0)).1).toNat % 64)) |||
-          (b.getLimbN 2 >>>
-            ((signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 0)).1).toNat % 64))) ∧
-      Div128AllPhasesNoWrapInv
-        (fullDivN1NormU
-          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-          (b.getLimbN 0)).2.2.2.2
-        (fullDivN1NormU
-          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-          (b.getLimbN 0)).2.2.2.1
-        (fullDivN1NormV
-          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1 ∧
-      fullDivN1R2CarryZero true bltu_2
-        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) ∧
-      fullDivN1R1CarryZero true bltu_2 bltu_1
-        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) ∧
-      fullDivN1QuotientOverestimate true bltu_2 bltu_1 bltu_0
-        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)) :
+    (hpath : N1AllPhasesOverestimatePathCallback a b) :
     cpsTripleWithin unifiedDivBound base (base + nopOff) (divCode_noNop base)
       (divModStackDispatchPreNoX1 sp a b
         (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal


### PR DESCRIPTION
## Summary
- add `N1AllPhasesOverestimatePathCallback` for the variable-branch all-phases N1 overestimate path surface
- refactor the first no-NOP all-phases step-conservation wrapper to consume the named callback
- keep proof behavior unchanged while reducing duplicated path callback structure

## Verification
- `lake build EvmAsm.Evm64.DivMod.Spec.N1AllPhasesNonzero`
- `lake build EvmAsm.Evm64.DivMod.Spec.UnifiedN1StepPath`
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `git diff --check`
- `rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/Spec/N1AllPhasesNonzero.lean EvmAsm/Evm64/DivMod/Spec/UnifiedN1StepPath.lean` (no matches)
- `lake build`
