### PR TITLE
refactor(div): name N1 normalized path callbacks

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N1TrialWitnessesNormalized.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N1TrialWitnessesNormalized.lean
@@ -11,6 +11,48 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 
+/-- Selected-branch callback for normalized n=1 mulsub plus final-remainder
+    facts. -/
+abbrev N1NormalizedRemainderLtPathCallback (a b : EvmWord) : Prop :=
+  ∀ bltu_2 bltu_1 bltu_0,
+    isTrialN1_j3 true (a.getLimbN 3) (b.getLimbN 0) →
+    isTrialN1_j2 true bltu_2
+      (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
+    isTrialN1_j1 true bltu_2 bltu_1
+      (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
+    isTrialN1_j0 true bltu_2 bltu_1 bltu_0
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
+    fullDivN1NormalizedMulSubEq true bltu_2 bltu_1 bltu_0
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) ∧
+      fullDivN1NormalizedRemainderLt true bltu_2 bltu_1 bltu_0
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+
+/-- Selected-branch callback for normalized n=1 mulsub plus quotient
+    overestimate facts. -/
+abbrev N1NormalizedOverestimatePathCallback (a b : EvmWord) : Prop :=
+  ∀ bltu_2 bltu_1 bltu_0,
+    isTrialN1_j3 true (a.getLimbN 3) (b.getLimbN 0) →
+    isTrialN1_j2 true bltu_2
+      (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
+    isTrialN1_j1 true bltu_2 bltu_1
+      (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
+    isTrialN1_j0 true bltu_2 bltu_1 bltu_0
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
+    fullDivN1NormalizedMulSubEq true bltu_2 bltu_1 bltu_0
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) ∧
+      fullDivN1QuotientOverestimate true bltu_2 bltu_1 bltu_0
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+
 /-- GetLimb-specialized normalized n=1 quotient bridge. This is the shape
     produced by the trial-witness wrappers, before projecting the quotient word
     into individual hdiv witnesses. -/
@@ -191,23 +233,7 @@ theorem n1_shape_hdivs_of_normalized_mulsub_remainder_lt
     (hb3z : b.getLimbN 3 = 0) (hb2z : b.getLimbN 2 = 0)
     (hb1z : b.getLimbN 1 = 0)
     (hshift_nz : (clzResult (b.getLimbN 0)).1 ≠ 0)
-    (hpath : ∀ bltu_2 bltu_1 bltu_0,
-      isTrialN1_j3 true (a.getLimbN 3) (b.getLimbN 0) →
-      isTrialN1_j2 true bltu_2
-        (a.getLimbN 2) (a.getLimbN 3)
-        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
-      isTrialN1_j1 true bltu_2 bltu_1
-        (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
-      isTrialN1_j0 true bltu_2 bltu_1 bltu_0
-        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
-      fullDivN1NormalizedMulSubEq true bltu_2 bltu_1 bltu_0
-          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) ∧
-        fullDivN1NormalizedRemainderLt true bltu_2 bltu_1 bltu_0
-          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)) :
+    (hpath : N1NormalizedRemainderLtPathCallback a b) :
     ∃ bltu_2 bltu_1 bltu_0,
       isTrialN1_j3 true (a.getLimbN 3) (b.getLimbN 0) ∧
       isTrialN1_j2 true bltu_2
@@ -263,23 +289,7 @@ theorem n1_shape_hdivs_of_normalized_mulsub_overestimate
     (hb3z : b.getLimbN 3 = 0) (hb2z : b.getLimbN 2 = 0)
     (hb1z : b.getLimbN 1 = 0)
     (hshift_nz : (clzResult (b.getLimbN 0)).1 ≠ 0)
-    (hpath : ∀ bltu_2 bltu_1 bltu_0,
-      isTrialN1_j3 true (a.getLimbN 3) (b.getLimbN 0) →
-      isTrialN1_j2 true bltu_2
-        (a.getLimbN 2) (a.getLimbN 3)
-        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
-      isTrialN1_j1 true bltu_2 bltu_1
-        (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
-      isTrialN1_j0 true bltu_2 bltu_1 bltu_0
-        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
-      fullDivN1NormalizedMulSubEq true bltu_2 bltu_1 bltu_0
-          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) ∧
-        fullDivN1QuotientOverestimate true bltu_2 bltu_1 bltu_0
-          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)) :
+    (hpath : N1NormalizedOverestimatePathCallback a b) :
     ∃ bltu_2 bltu_1 bltu_0,
       isTrialN1_j3 true (a.getLimbN 3) (b.getLimbN 0) ∧
       isTrialN1_j2 true bltu_2
@@ -325,23 +335,7 @@ theorem n1_full_div_getLimbN_of_normalized_mulsub_remainder_lt
     (hb3z : b.getLimbN 3 = 0) (hb2z : b.getLimbN 2 = 0)
     (hb1z : b.getLimbN 1 = 0)
     (hshift_nz : (clzResult (b.getLimbN 0)).1 ≠ 0)
-    (hpath : ∀ bltu_2 bltu_1 bltu_0,
-      isTrialN1_j3 true (a.getLimbN 3) (b.getLimbN 0) →
-      isTrialN1_j2 true bltu_2
-        (a.getLimbN 2) (a.getLimbN 3)
-        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
-      isTrialN1_j1 true bltu_2 bltu_1
-        (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
-      isTrialN1_j0 true bltu_2 bltu_1 bltu_0
-        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
-      fullDivN1NormalizedMulSubEq true bltu_2 bltu_1 bltu_0
-          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) ∧
-        fullDivN1NormalizedRemainderLt true bltu_2 bltu_1 bltu_0
-          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)) :
+    (hpath : N1NormalizedRemainderLtPathCallback a b) :
     ∃ bltu_2 bltu_1 bltu_0,
       (EvmWord.div a b).getLimbN 0 =
         (fullDivN1R0 true bltu_2 bltu_1 bltu_0
@@ -373,23 +367,7 @@ theorem n1_full_div_getLimbN_of_normalized_mulsub_overestimate
     (hb3z : b.getLimbN 3 = 0) (hb2z : b.getLimbN 2 = 0)
     (hb1z : b.getLimbN 1 = 0)
     (hshift_nz : (clzResult (b.getLimbN 0)).1 ≠ 0)
-    (hpath : ∀ bltu_2 bltu_1 bltu_0,
-      isTrialN1_j3 true (a.getLimbN 3) (b.getLimbN 0) →
-      isTrialN1_j2 true bltu_2
-        (a.getLimbN 2) (a.getLimbN 3)
-        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
-      isTrialN1_j1 true bltu_2 bltu_1
-        (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
-      isTrialN1_j0 true bltu_2 bltu_1 bltu_0
-        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
-      fullDivN1NormalizedMulSubEq true bltu_2 bltu_1 bltu_0
-          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) ∧
-        fullDivN1QuotientOverestimate true bltu_2 bltu_1 bltu_0
-          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)) :
+    (hpath : N1NormalizedOverestimatePathCallback a b) :
     ∃ bltu_2 bltu_1 bltu_0,
       (EvmWord.div a b).getLimbN 0 =
         (fullDivN1R0 true bltu_2 bltu_1 bltu_0


### PR DESCRIPTION
## Summary
- add named callback aliases for normalized n=1 selected-path remainder and overestimate facts
- reuse those aliases across the normalized trial-witness hdiv/getLimb wrappers

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.N1TrialWitnessesNormalized
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/Spec/N1TrialWitnessesNormalized.lean
- lake build