### PR TITLE
refactor(div): reuse N1 R3 phase q0 bound

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N1CarryZeroReducers.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N1CarryZeroReducers.lean
@@ -885,17 +885,9 @@ theorem fullDivN1R3_div128Quot_toNat_eq_strict_of_shape_phase_no_wrap
     (div128Quot uHi uLo vTop).toNat = q1'.toNat * 2^32 + q0'.toNat := by
   intro uHi uLo vTop h_inv dHi dLo div_un1 div_un0 q1 rhat hi1 q1c rhatc qDlo
     rhatUn1 q1' rhat' cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0'
-  have h_un21_lt :
-      un21.toNat < dHi.toNat * 2^32 + dLo.toNat :=
-    Div128PhaseNoWrapInv.un21Lt h_inv
   have hq0 : q0'.toNat < 2^32 :=
-    div128Quot_q0_prime_lt_pow32 un21 dHi dLo uLo
-      (by
-        simpa [vTop, dHi] using
-          fullDivN1NormV_limb0_dHi_ge_pow31_of_shape b0 b1 b2 b3 hbnz hb1z hb2z hb3z)
-      (by simpa [vTop, dHi] using fullDivN1NormV_limb0_dHi_lt_pow32 b0 b1 b2 b3)
-      (by simpa [vTop, dLo] using fullDivN1NormV_limb0_dLo_lt_pow32 b0 b1 b2 b3)
-      h_un21_lt
+    fullDivN1R3_q0_prime_lt_pow32_of_shape_phase_no_wrap
+      a0 a1 a2 a3 b0 b1 b2 b3 hbnz hb1z hb2z hb3z h_inv
   exact div128Quot_toNat_eq_strict uHi uLo vTop
     (by
       simpa [vTop] using


### PR DESCRIPTION
## Summary
- route the strict N1 R3 quotient expansion through fullDivN1R3_q0_prime_lt_pow32_of_shape_phase_no_wrap
- remove the inline reconstruction of the q0-prime bound from the strict quotient theorem
- keep the active N1 selected-path proof route using named no-wrap sub-obligations

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.N1CarryZeroReducers
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/Spec/N1CarryZeroReducers.lean
- lake build EvmAsm.Evm64.DivMod
- lake build