### PR TITLE
refactor(div): project N1 R3 phase-one no-wrap

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N1CarryZeroReducers.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N1CarryZeroReducers.lean
@@ -847,6 +847,32 @@ theorem fullDivN1R3_q0_prime_lt_pow32_of_shape_phase_no_wrap
     a0 a1 a2 a3 b0 b1 b2 b3 hbnz hb1z hb2z hb3z
     (Div128PhaseNoWrapInv.un21Lt h_inv)
 
+/-- N1 R3-specific Phase-1 product no-wrap projection from the selected
+    `Div128PhaseNoWrapInv`. This names the second Phase-1 conjunct in the
+    local R3 trial-call vocabulary. -/
+theorem fullDivN1R3_phase1_no_wrap_of_phase_no_wrap
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    let uHi := (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
+    let uLo := (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1
+    let vTop := (fullDivN1NormV b0 b1 b2 b3).1
+    Div128PhaseNoWrapInv uHi uLo vTop →
+    let dHi := vTop >>> (32 : BitVec 6).toNat
+    let dLo := (vTop <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+    let div_un1 := uLo >>> (32 : BitVec 6).toNat
+    let q1 := rv64_divu uHi dHi
+    let rhat := uHi - q1 * dHi
+    let hi1 := q1 >>> (32 : BitVec 6).toNat
+    let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
+    let rhatc := if hi1 = 0 then rhat else rhat + dHi
+    let qDlo := q1c * dLo
+    let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
+    let q1' := if BitVec.ult rhatUn1 qDlo then q1c + signExtend12 4095 else q1c
+    let rhat' := if BitVec.ult rhatUn1 qDlo then rhatc + dHi else rhatc
+    q1'.toNat * dLo.toNat ≤ (rhat'.toNat % 2^32) * 2^32 + div_un1.toNat := by
+  intro uHi uLo vTop h_inv dHi dLo div_un1 q1 rhat hi1 q1c rhatc qDlo
+    rhatUn1 q1' rhat'
+  exact Div128PhaseNoWrapInv.phase1NoWrap h_inv
+
 /-- Strict first n=1 R3 trial quotient expansion under the generic
     `Div128PhaseNoWrapInv` for the selected 128/64 call. This packages the
     local `un21 < vTop` extraction and the `q0' < 2^32` reducer into the


### PR DESCRIPTION
## Summary
- add an N1 R3-specific projection for the Phase-1 product no-wrap conjunct
- expose the selected R3 call vocabulary for Div128PhaseNoWrapInv.phase1NoWrap
- prepare the R3 all-phases constructor path with named un21, Phase-1, and q0 sub-obligations

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.N1CarryZeroReducers
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/Spec/N1CarryZeroReducers.lean
- lake build EvmAsm.Evm64.DivMod
- lake build