### PR TITLE
refactor(div): route N1 quotient through conjunct callback

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N1AllPhasesGetLimb.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N1AllPhasesGetLimb.lean
@@ -957,6 +957,25 @@ theorem n1_quotient_word_of_step_conservation_path_r3_all_phases
       hbnz hb1z hb2z hb3z hshift_nz hr3_inv
   exact ⟨hcarry2, hr3_zero, hr2_zero, hr1_zero, hge⟩
 
+/-- Quotient-word path wrapper whose callback provides the selected R3
+    all-phases invariant as its three local no-wrap conjuncts. -/
+theorem n1_quotient_word_of_step_conservation_path_r3_conjuncts
+    (a b : EvmWord)
+    (hbnz : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 |||
+      b.getLimbN 3 ≠ 0)
+    (hb3z : b.getLimbN 3 = 0) (hb2z : b.getLimbN 2 = 0)
+    (hb1z : b.getLimbN 1 = 0)
+    (hshift_nz : (clzResult (b.getLimbN 0)).1 ≠ 0)
+    (hpath : N1AllPhasesConjunctOverestimatePathCallback a b) :
+    ∃ bltu_2 bltu_1 bltu_0,
+      fullDivN1QuotientWord true bltu_2 bltu_1 bltu_0
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) =
+          EvmWord.div a b := by
+  exact n1_quotient_word_of_step_conservation_path_r3_all_phases
+    a b hbnz hb3z hb2z hb1z hshift_nz
+    (N1AllPhasesConjunctOverestimatePathCallback.toAllPhasesOverestimatePathCallback hpath)
+
 /-- Quotient-word package wrapper whose callback provides the R3 all-phases
     invariant instead of the R3 carry-zero proof. -/
 theorem n1_quotient_word_package_of_step_conservation_path_r3_all_phases


### PR DESCRIPTION
## Summary
- add n1_quotient_word_of_step_conservation_path_r3_conjuncts
- let the quotient-word path consume N1AllPhasesConjunctOverestimatePathCallback directly
- route through the named conjunct-to-all-phases callback converter added in the previous slice

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.N1AllPhasesGetLimb
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/Spec/N1AllPhasesGetLimb.lean (no matches)
- lake build EvmAsm.Evm64.DivMod
- lake build