### PR TITLE
refactor(div): add N1 conjunct quotient package

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N1AllPhasesGetLimb.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N1AllPhasesGetLimb.lean
@@ -1026,6 +1026,46 @@ theorem n1_quotient_word_package_of_step_conservation_path_r3_all_phases
       hbnz hb1z hb2z hb3z hshift_nz hr3_inv
   exact ⟨hcarry2, hr3_zero, hr2_zero, hr1_zero, hge⟩
 
+/-- Quotient-word package wrapper whose callback provides the selected R3
+    all-phases invariant as its three local no-wrap conjuncts. -/
+theorem n1_quotient_word_package_of_step_conservation_path_r3_conjuncts
+    (a b : EvmWord)
+    (hbnz : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 |||
+      b.getLimbN 3 ≠ 0)
+    (hb3z : b.getLimbN 3 = 0) (hb2z : b.getLimbN 2 = 0)
+    (hb1z : b.getLimbN 1 = 0)
+    (hshift_nz : (clzResult (b.getLimbN 0)).1 ≠ 0)
+    (hpath : N1AllPhasesConjunctOverestimatePathCallback a b) :
+    ∃ bltu_2 bltu_1 bltu_0,
+      isTrialN1_j3 true (a.getLimbN 3) (b.getLimbN 0) ∧
+      isTrialN1_j2 true bltu_2
+        (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) ∧
+      isTrialN1_j1 true bltu_2 bltu_1
+        (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) ∧
+      isTrialN1_j0 true bltu_2 bltu_1 bltu_0
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) ∧
+      Carry2NzAll
+        (b.getLimbN 0 <<< (((clzResult (b.getLimbN 0)).1).toNat % 64))
+        ((b.getLimbN 1 <<< (((clzResult (b.getLimbN 0)).1).toNat % 64)) |||
+          (b.getLimbN 0 >>>
+            ((signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 0)).1).toNat % 64)))
+        ((b.getLimbN 2 <<< (((clzResult (b.getLimbN 0)).1).toNat % 64)) |||
+          (b.getLimbN 1 >>>
+            ((signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 0)).1).toNat % 64)))
+        ((b.getLimbN 3 <<< (((clzResult (b.getLimbN 0)).1).toNat % 64)) |||
+          (b.getLimbN 2 >>>
+            ((signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 0)).1).toNat % 64))) ∧
+      fullDivN1QuotientWord true bltu_2 bltu_1 bltu_0
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) =
+          EvmWord.div a b := by
+  exact n1_quotient_word_package_of_step_conservation_path_r3_all_phases
+    a b hbnz hb3z hb2z hb1z hshift_nz
+    (N1AllPhasesConjunctOverestimatePathCallback.toAllPhasesOverestimatePathCallback hpath)
+
 /-- Normalized arithmetic package wrapper whose callback provides the R3
     all-phases invariant instead of the R3 carry-zero proof. This matches the
     package consumed by n=1 stack wrappers while reducing one arithmetic


### PR DESCRIPTION
## Summary
- add n1_quotient_word_package_of_step_conservation_path_r3_conjuncts
- let the quotient-word package path consume N1AllPhasesConjunctOverestimatePathCallback directly
- route through the named conjunct-to-all-phases callback converter

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.N1AllPhasesGetLimb
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/Spec/N1AllPhasesGetLimb.lean (no matches)
- lake build EvmAsm.Evm64.DivMod
- lake build