### PR TITLE
refactor(div): route N1 callmax tail through selected carries

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1V4NoNopCallMaxInput.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1V4NoNopCallMaxInput.lean
@@ -61,6 +61,16 @@ theorem divK_loop_n1_call_j3_exact_x1_framed_v4_noNop_input
     (isAddbackCarry2NzN1CallV4_raw I.v0 I.v1 I.v2 I.v3 I.u0 I.u1 I.u2 I.u3 I.uTop
       (loopN1CallMaxmaxmaxExactInputHypotheses_carry2Call I hh))
 
+theorem loopN1CallMaxmaxmaxExactInputHypotheses_selectedCarry
+    (I : LoopN1CallMaxmaxmaxExactInputs)
+    (h : loopN1CallMaxmaxmaxExactInputHypotheses I) :
+    loopN1CallMaxmaxmaxSelectedCarryFacts
+      I.v0 I.v1 I.v2 I.v3 I.u0 I.u1 I.u2 I.u3 I.uTop
+      I.u0Orig2 I.u0Orig1 I.u0Orig0 := by
+  unfold loopN1CallMaxmaxmaxExactInputHypotheses at h
+  unfold loopN1CallMaxmaxmaxExactHypotheses at h
+  exact h.2.2.2
+
 /-- Bundled statement for the j=2/j=1/j=0 all-max tail after the first
     j=3 call-body step in the N1 call/max/max/max exact path. -/
 @[irreducible]
@@ -88,7 +98,10 @@ theorem divK_loop_n1_call_iter210_exact_x1_framed_v4_noNop_input
     loopN1CallMaxmaxmaxIter210ExactInputSpec I := by
   unfold loopN1CallMaxmaxmaxIter210ExactInputSpec
   let r3 := loopN1CallMaxmaxmaxR3 I.v0 I.v1 I.v2 I.v3 I.u0 I.u1 I.u2 I.u3 I.uTop
-  exact divK_loop_n1_iter210_maxmaxmax_exact_x1_v4_noNop I.sp I.base
+  have hselected := loopN1CallMaxmaxmaxExactInputHypotheses_selectedCarry I hh
+  unfold loopN1CallMaxmaxmaxSelectedCarryFacts at hselected
+  obtain ⟨_hcall, hcarry2_j2, hcarry2_j1, hcarry2_j0⟩ := hselected
+  exact divK_loop_n1_iter210_maxmaxmax_exact_x1_v4_noNop_selected_carry I.sp I.base
     I.jOld I.v5Old I.v6Old I.v7Old I.v10Old I.v11Old I.v2Old
     I.v0 I.v1 I.v2 I.v3
     I.u0Orig2 r3.2.1 r3.2.2.1 r3.2.2.2.1 r3.2.2.2.2.1
@@ -109,7 +122,18 @@ theorem divK_loop_n1_call_iter210_exact_x1_framed_v4_noNop_input
       unfold loopN1CallMaxmaxmaxR1 at h
       unfold loopN1CallMaxmaxmaxR2 at h
       exact h)
-    (loopN1CallMaxmaxmaxExactInputHypotheses_carry2 I hh)
+    (by
+      dsimp only [r3]
+      exact hcarry2_j2)
+    (by
+      dsimp only [r3]
+      unfold loopN1CallMaxmaxmaxR2 at hcarry2_j1
+      exact hcarry2_j1)
+    (by
+      dsimp only [r3]
+      unfold loopN1CallMaxmaxmaxR1 at hcarry2_j0
+      unfold loopN1CallMaxmaxmaxR2 at hcarry2_j0
+      exact hcarry2_j0)
 
 /-- Actual assertion produced by the bundled j=3 call-body step, including
     the cells framed for the following all-max tail. -/


### PR DESCRIPTION
## Summary
- add a bundled projection for the N1 call/max selected-carry package
- route the j=2/j=1/j=0 all-max tail through the selected-carry iter210 theorem
- avoid the Carry2NzAll compatibility wrapper in the bundled tail proof

## Verification
- lake build EvmAsm.Evm64.DivMod.Compose.FullPathN1V4NoNopCallMaxInput
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth' EvmAsm/Evm64/DivMod/Compose/FullPathN1V4NoNopCallMaxInput.lean (no matches)
- lake build EvmAsm.Evm64.DivMod
- lake build