### PR TITLE
refactor(div): package N1 selected path semantics

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N1ExactV4.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N1ExactV4.lean
@@ -179,6 +179,20 @@ abbrev FullDivN1CallMaxmaxmaxSemanticFactsV4
   FullDivN1CallMaxmaxmaxMulSubEqV4 a0 a1 a2 a3 b0 b1 b2 b3 ∧
   FullDivN1CallMaxmaxmaxQuotientOverestimateV4 a0 a1 a2 a3 b0 b1 b2 b3
 
+/-- Selected path evidence plus semantic facts for the canonical full-DIV N1
+    v4 call/max/max/max route. This is the package later wrappers can target
+    without exposing hdiv limbs or quotient-word equality. -/
+abbrev FullDivN1CallMaxmaxmaxSelectedSemanticEvidenceV4 (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (q3Old q2Old q1Old q0Old retMem dMem dloMem scratchUn0 scratchMem raVal : Word) :
+    Prop :=
+  fullDivN1CallMaxmaxmaxSelectedInputHypotheses sp base
+    jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    a0 a1 a2 a3 b0 b1 b2 b3
+    q3Old q2Old q1Old q0Old retMem dMem dloMem scratchUn0 scratchMem raVal ∧
+  FullDivN1CallMaxmaxmaxSemanticFactsV4 a0 a1 a2 a3 b0 b1 b2 b3
+
 theorem fullDivN1CallMaxmaxmaxHdivs_of_word_eq
     (a b : EvmWord) (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
     (hdiv : fullDivN1CallMaxmaxmaxQuotientWordV4
@@ -1083,6 +1097,55 @@ theorem evm_div_n1_call_maxmaxmax_stack_spec_within_word_v4_preNoX1_callableExtr
     (fullDivN1CallMaxmaxmaxQuotientWordV4_eq_div_of_semantic_facts_word
       a b a0 a1 a2 a3 b0 b1 b2 b3
       ha0 ha1 ha2 ha3 hb0 hb1 hb2 hb3 hbnz hfacts)
+
+/-- Full-v4 N1 stack wrapper consuming a single selected-path semantic evidence
+    package. -/
+theorem evm_div_n1_call_maxmaxmax_stack_spec_within_word_v4_preNoX1_callableExtra_x9In_exactFrame_unified_of_selected_semantic_evidence
+    (sp base : Word) (a b : EvmWord)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old x9In : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (ha0 : a.getLimbN 0 = a0) (ha1 : a.getLimbN 1 = a1)
+    (ha2 : a.getLimbN 2 = a2) (ha3 : a.getLimbN 3 = a3)
+    (hb0 : b.getLimbN 0 = b0) (hb1 : b.getLimbN 1 = b1)
+    (hb2 : b.getLimbN 2 = b2) (hb3 : b.getLimbN 3 = b3)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1z : b1 = 0)
+    (hshift_nz : (clzResult b0).1 ≠ 0)
+    (halign : fullDivN1CallMaxmaxmaxExactInputAligned sp base
+      jMem (1 : Word) (fullDivN1Shift b0) (fullDivN1NormU a0 a1 a2 a3 b0).1
+      (a0 >>> ((fullDivN1AntiShift b0).toNat % 64)) v11Old (fullDivN1AntiShift b0)
+      a0 a1 a2 a3 b0 b1 b2 b3
+      (0 : Word) (0 : Word) (0 : Word) (0 : Word)
+      retMem dMem dloMem scratchUn0 scratchMem raVal)
+    (hevidence : FullDivN1CallMaxmaxmaxSelectedSemanticEvidenceV4 sp base
+      jMem (1 : Word) (fullDivN1Shift b0) (fullDivN1NormU a0 a1 a2 a3 b0).1
+      (a0 >>> ((fullDivN1AntiShift b0).toNat % 64)) v11Old (fullDivN1AntiShift b0)
+      a0 a1 a2 a3 b0 b1 b2 b3
+      (0 : Word) (0 : Word) (0 : Word) (0 : Word)
+      retMem dMem dloMem scratchUn0 scratchMem raVal) :
+    cpsTripleWithin unifiedDivBound base (base + nopOff) (divCode_v4 base)
+      (divModStackDispatchPreNoX1 sp a b x9In raVal
+        ((clzResult b0).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divStackDispatchPostCallableExactFrame sp a b raVal (signExtend12 4095 : Word) **
+       ((sp + signExtend12 3936) ↦ₘ
+        divKTrialCallV4ScratchOut
+          (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
+          (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1
+          (fullDivN1NormV b0 b1 b2 b3).1 scratchMem)) := by
+  exact evm_div_n1_call_maxmaxmax_stack_spec_within_word_v4_preNoX1_callableExtra_x9In_exactFrame_unified_of_selected_semantic_facts
+    sp base a b
+    a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old x9In
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    raVal
+    ha0 ha1 ha2 ha3 hb0 hb1 hb2 hb3 hbnz hb3z hb2z hb1z
+    hshift_nz halign hevidence.1 hevidence.2
 
 /-- Branch-and-selected-carry full-v4 N1 stack wrapper consuming selected
     quotient-word equality instead of an already-expanded hdiv package. -/


### PR DESCRIPTION
## Summary
- add FullDivN1CallMaxmaxmaxSelectedSemanticEvidenceV4, bundling selected path hypotheses with selected semantic facts
- add a stack wrapper that consumes the single evidence package for the N1 call/max/max/max v4 path

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.N1ExactV4
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/Spec/N1ExactV4.lean
- lake build EvmAsm.Evm64.DivMod
- lake build