### PR TITLE
refactor(div): construct N1 selected semantic evidence

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N1ExactV4.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N1ExactV4.lean
@@ -193,6 +193,73 @@ abbrev FullDivN1CallMaxmaxmaxSelectedSemanticEvidenceV4 (sp base : Word)
     q3Old q2Old q1Old q0Old retMem dMem dloMem scratchUn0 scratchMem raVal ∧
   FullDivN1CallMaxmaxmaxSemanticFactsV4 a0 a1 a2 a3 b0 b1 b2 b3
 
+/-- Build the selected-path semantic evidence package from explicit selected
+    branch/carry facts plus the semantic facts. -/
+theorem FullDivN1CallMaxmaxmaxSelectedSemanticEvidenceV4_of_bltu_selected
+    (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (q3Old q2Old q1Old q0Old retMem dMem dloMem scratchUn0 scratchMem raVal : Word)
+    (hbltu3 : isTrialN1_j3 true a3 b0)
+    (hbltu2 : ¬BitVec.ult
+      (loopN1CallMaxmaxmaxR3
+        (fullDivN1NormV b0 b1 b2 b3).1
+        (fullDivN1NormV b0 b1 b2 b3).2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.2
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
+        0 0 0).2.1
+      (fullDivN1NormV b0 b1 b2 b3).1)
+    (hbltu1 : ¬BitVec.ult
+      (loopN1CallMaxmaxmaxR2
+        (fullDivN1NormV b0 b1 b2 b3).1
+        (fullDivN1NormV b0 b1 b2 b3).2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.2
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
+        0 0 0
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.1).2.1
+      (fullDivN1NormV b0 b1 b2 b3).1)
+    (hbltu0 : ¬BitVec.ult
+      (loopN1CallMaxmaxmaxR1
+        (fullDivN1NormV b0 b1 b2 b3).1
+        (fullDivN1NormV b0 b1 b2 b3).2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.2
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
+        0 0 0
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.1
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.1).2.1
+      (fullDivN1NormV b0 b1 b2 b3).1)
+    (hselected : loopN1CallMaxmaxmaxSelectedCarryFacts
+      (fullDivN1NormV b0 b1 b2 b3).1
+      (fullDivN1NormV b0 b1 b2 b3).2.1
+      (fullDivN1NormV b0 b1 b2 b3).2.2.1
+      (fullDivN1NormV b0 b1 b2 b3).2.2.2
+      (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1
+      (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
+      (0 : Word) (0 : Word) (0 : Word)
+      (fullDivN1NormU a0 a1 a2 a3 b0).2.2.1
+      (fullDivN1NormU a0 a1 a2 a3 b0).2.1
+      (fullDivN1NormU a0 a1 a2 a3 b0).1)
+    (hfacts : FullDivN1CallMaxmaxmaxSemanticFactsV4
+      a0 a1 a2 a3 b0 b1 b2 b3) :
+    FullDivN1CallMaxmaxmaxSelectedSemanticEvidenceV4 sp base
+      jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      a0 a1 a2 a3 b0 b1 b2 b3
+      q3Old q2Old q1Old q0Old retMem dMem dloMem scratchUn0 scratchMem raVal := by
+  exact ⟨
+    fullDivN1CallMaxmaxmaxSelectedInputHypotheses_of_bltu_selected
+      sp base
+      jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      a0 a1 a2 a3 b0 b1 b2 b3
+      q3Old q2Old q1Old q0Old retMem dMem dloMem scratchUn0 scratchMem raVal
+      hbltu3 hbltu2 hbltu1 hbltu0 hselected,
+    hfacts⟩
+
 theorem fullDivN1CallMaxmaxmaxHdivs_of_word_eq
     (a b : EvmWord) (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
     (hdiv : fullDivN1CallMaxmaxmaxQuotientWordV4


### PR DESCRIPTION
## Summary
- add FullDivN1CallMaxmaxmaxSelectedSemanticEvidenceV4_of_bltu_selected
- centralize construction of the selected path semantic evidence package from explicit branch/carry facts plus semantic facts

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.N1ExactV4
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/Spec/N1ExactV4.lean
- lake build EvmAsm.Evm64.DivMod
- lake build