### PR TITLE
refactor(div): route N1 selected wrapper through evidence

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N1ExactV4.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N1ExactV4.lean
@@ -1387,16 +1387,21 @@ theorem evm_div_n1_call_maxmaxmax_stack_spec_within_word_v4_preNoX1_callableExtr
           (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
           (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1
           (fullDivN1NormV b0 b1 b2 b3).1 scratchMem)) := by
-  exact evm_div_n1_call_maxmaxmax_stack_spec_within_word_v4_preNoX1_callableExtra_x9In_exactFrame_unified_of_selected_carry_word
+  exact evm_div_n1_call_maxmaxmax_stack_spec_within_word_v4_preNoX1_callableExtra_x9In_exactFrame_unified_of_selected_semantic_evidence
     sp base a b
     a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old x9In
     q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
     raVal
     ha0 ha1 ha2 ha3 hb0 hb1 hb2 hb3 hbnz hb3z hb2z hb1z
-    hshift_nz halign hbltu3 hbltu2 hbltu1 hbltu0 hselectedCarry
-    (fullDivN1CallMaxmaxmaxQuotientWordV4_eq_div_of_semantic_facts_word
-      a b a0 a1 a2 a3 b0 b1 b2 b3
-      ha0 ha1 ha2 ha3 hb0 hb1 hb2 hb3 hbnz hfacts)
+    hshift_nz halign
+    (FullDivN1CallMaxmaxmaxSelectedSemanticEvidenceV4_of_bltu_selected
+      sp base
+      jMem (1 : Word) (fullDivN1Shift b0) (fullDivN1NormU a0 a1 a2 a3 b0).1
+      (a0 >>> ((fullDivN1AntiShift b0).toNat % 64)) v11Old (fullDivN1AntiShift b0)
+      a0 a1 a2 a3 b0 b1 b2 b3
+      (0 : Word) (0 : Word) (0 : Word) (0 : Word)
+      retMem dMem dloMem scratchUn0 scratchMem raVal
+      hbltu3 hbltu2 hbltu1 hbltu0 hselectedCarry hfacts)
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- route the branch-and-selected-carry semantic-facts N1 stack wrapper through FullDivN1CallMaxmaxmaxSelectedSemanticEvidenceV4
- use the new evidence constructor as the common selected path package assembly point

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.N1ExactV4
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/Spec/N1ExactV4.lean
- lake build EvmAsm.Evm64.DivMod
- lake build