### PR TITLE
refactor(div): thread conditional carry through N1 maxmaxmax

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -90,6 +90,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN2V4
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1V4NoNop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1V4
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1V4CallMaxSelected
+import EvmAsm.Evm64.DivMod.Compose.FullPathN1V4CallMaxSelectedIfBorrow
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1V4PreloopCallMax
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN2LoopUnified
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3LoopUnified

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1V4CallMaxSelected.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1V4CallMaxSelected.lean
@@ -504,6 +504,24 @@ theorem divK_loop_n1_call_iter210_framed_exact_x1_v4_input_of_selected
     (loopN1CallMaxmaxmaxIter210FramedPostInput_to_scratchPost I)
     (divK_loop_n1_call_iter210_framed_prepost_exact_x1_v4_input_of_selected I hh)
 
+/-- Framed all-max tail from the actual bundled j=3 post to the final N1
+    call/max/max/max scratch post over the full `divCode_v4` bundle, from
+    selected-only input hypotheses, using conditional max carry evidence for
+    taken addback branches. -/
+theorem divK_loop_n1_call_iter210_framed_exact_x1_v4_input_of_selected_if_borrow
+    (I : LoopN1CallMaxmaxmaxExactInputs)
+    (hh : loopN1CallMaxmaxmaxSelectedInputHypotheses I) :
+    cpsTripleWithin 556 (I.base + loopBodyOff) (I.base + denormOff)
+      (divCode_v4 I.base)
+      (loopN1CallMaxmaxmaxJ3PostInput I)
+      (loopN1CallMaxmaxmaxScratchPostNoX1 I.sp I.base
+        I.v0 I.v1 I.v2 I.v3 I.u0 I.u1 I.u2 I.u3 I.uTop
+        I.u0Orig2 I.u0Orig1 I.u0Orig0 I.scratchMem ** (.x1 ↦ᵣ I.raVal)) := by
+  exact cpsTripleWithin_weaken
+    (loopN1CallMaxmaxmaxJ3PostInput_to_iter210FramedPre I)
+    (loopN1CallMaxmaxmaxIter210FramedPostInput_to_scratchPost I)
+    (divK_loop_n1_call_iter210_framed_prepost_exact_x1_v4_input_of_selected_if_borrow I hh)
+
 /-- Full bundled N1 call/max/max/max exact path over the full `divCode_v4`
     bundle, using selected-only input hypotheses. -/
 theorem divK_loop_n1_call_maxmaxmax_exact_x1_scratch_input_v4_of_selected

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1V4CallMaxSelected.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1V4CallMaxSelected.lean
@@ -425,6 +425,68 @@ theorem divK_loop_n1_call_iter210_framed_prepost_exact_x1_v4_input_of_selected
     (loopN1CallMaxmaxmaxIter210FrameInput I) (by pcFree) H210
   exact H210f
 
+/-- Bundled framed all-max tail pre/post over the full `divCode_v4` bundle,
+    from selected-only input hypotheses, using conditional max carry evidence
+    for taken addback branches. -/
+theorem divK_loop_n1_call_iter210_framed_prepost_exact_x1_v4_input_of_selected_if_borrow
+    (I : LoopN1CallMaxmaxmaxExactInputs)
+    (hh : loopN1CallMaxmaxmaxSelectedInputHypotheses I) :
+    cpsTripleWithin 556 (I.base + loopBodyOff) (I.base + denormOff)
+      (divCode_v4 I.base)
+      (loopN1CallMaxmaxmaxIter210FramedPreInput I)
+      (loopN1CallMaxmaxmaxIter210FramedPostInput I) := by
+  unfold loopN1CallMaxmaxmaxIter210FramedPreInput
+    loopN1CallMaxmaxmaxIter210FramedPostInput
+  let r3 := loopN1CallMaxmaxmaxR3 I.v0 I.v1 I.v2 I.v3 I.u0 I.u1 I.u2 I.u3 I.uTop
+  let c3 := (mulsubN4 (divKTrialCallV4QHat I.u1 I.u0 I.v0)
+    I.v0 I.v1 I.v2 I.v3 I.u0 I.u1 I.u2 I.u3).2.2.2.2
+  let uBase3 := I.sp + signExtend12 4056 - (3 : Word) <<< (3 : BitVec 6).toNat
+  let qAddr3 := I.sp + signExtend12 4088 - (3 : Word) <<< (3 : BitVec 6).toNat
+  have H210 := cpsTripleWithin_divCode_noNop_v4_to_divCode_v4
+    (divK_loop_n1_iter210_maxmaxmax_exact_x1_v4_noNop_selected_carry_if_borrow I.sp I.base
+    (3 : Word) ((3 : Word) <<< (3 : BitVec 6).toNat) uBase3 qAddr3 c3 r3.1
+    r3.2.2.2.2.1
+    I.v0 I.v1 I.v2 I.v3
+    I.u0Orig2 r3.2.1 r3.2.2.1 r3.2.2.2.1 r3.2.2.2.2.1
+    I.u0Orig1 I.u0Orig0 I.q2Old I.q1Old I.q0Old
+    (I.base + div128CallRetOff) I.v0 (divKTrialCallV4DLo I.v0)
+    (divKTrialCallV4Un0 I.u0) I.raVal
+    (by
+      dsimp only [r3]
+      exact loopN1CallMaxmaxmaxSelectedInputHypotheses_hbltu2 I hh)
+    (by
+      dsimp only [r3]
+      have h := loopN1CallMaxmaxmaxSelectedInputHypotheses_hbltu1 I hh
+      unfold loopN1CallMaxmaxmaxR2 at h
+      exact h)
+    (by
+      dsimp only [r3]
+      have h := loopN1CallMaxmaxmaxSelectedInputHypotheses_hbltu0 I hh
+      unfold loopN1CallMaxmaxmaxR1 at h
+      unfold loopN1CallMaxmaxmaxR2 at h
+      exact h)
+    (by
+      dsimp only [r3]
+      have h := loopN1CallMaxmaxmaxSelectedInputHypotheses_carryIfBorrowMax2 I hh
+      unfold selectedN1MaxCarryIfBorrow at h
+      exact h)
+    (by
+      dsimp only [r3]
+      have h := loopN1CallMaxmaxmaxSelectedInputHypotheses_carryIfBorrowMax1 I hh
+      unfold loopN1CallMaxmaxmaxR2 at h
+      unfold selectedN1MaxCarryIfBorrow at h
+      exact h)
+    (by
+      dsimp only [r3]
+      have h := loopN1CallMaxmaxmaxSelectedInputHypotheses_carryIfBorrowMax0 I hh
+      unfold loopN1CallMaxmaxmaxR1 at h
+      unfold loopN1CallMaxmaxmaxR2 at h
+      unfold selectedN1MaxCarryIfBorrow at h
+      exact h))
+  have H210f := cpsTripleWithin_frameR
+    (loopN1CallMaxmaxmaxIter210FrameInput I) (by pcFree) H210
+  exact H210f
+
 /-- Framed all-max tail from the actual bundled j=3 post to the final N1
     call/max/max/max scratch post over the full `divCode_v4` bundle, from
     selected-only input hypotheses. -/

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1V4CallMaxSelected.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1V4CallMaxSelected.lean
@@ -539,6 +539,24 @@ theorem divK_loop_n1_call_maxmaxmax_exact_x1_scratch_input_v4_of_selected
       exact hp)
     J3 Htail
 
+/-- Full bundled N1 call/max/max/max exact path over the full `divCode_v4`
+    bundle, using selected-only input hypotheses and conditional max carry
+    evidence for taken addback branches. -/
+theorem divK_loop_n1_call_maxmaxmax_exact_x1_scratch_input_v4_of_selected_if_borrow
+    (I : LoopN1CallMaxmaxmaxExactInputs)
+    (halign : loopN1CallMaxmaxmaxExactInputAligned I)
+    (hh : loopN1CallMaxmaxmaxSelectedInputHypotheses I) :
+    loopN1CallMaxmaxmaxExactInputSpecV4 I := by
+  unfold loopN1CallMaxmaxmaxExactInputSpecV4
+  have J3 := divK_loop_n1_call_j3_exact_x1_framed_v4_input_of_selected I halign hh
+  unfold loopN1CallMaxmaxmaxJ3ExactInputSpecV4 at J3
+  have Htail := divK_loop_n1_call_iter210_framed_exact_x1_v4_input_of_selected_if_borrow I hh
+  exact cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by
+      unfold loopN1CallMaxmaxmaxJ3PostInput
+      exact hp)
+    J3 Htail
+
 /-- Bundled first j=3 call-body step over the full `divCode_v4` bundle,
     using the selected call carry from the bundled path facts. -/
 theorem divK_loop_n1_call_j3_exact_x1_framed_v4_input_selected_carry

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1V4CallMaxSelected.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1V4CallMaxSelected.lean
@@ -318,6 +318,56 @@ theorem divK_loop_n1_call_iter210_exact_x1_framed_v4_input_of_selected
       unfold loopN1CallMaxmaxmaxR2 at h
       exact h))
 
+/-- Bundled all-max tail after the first j=3 call-body step over the full
+    `divCode_v4` bundle, from selected-only input hypotheses, using
+    conditional max carry evidence for taken addback branches. -/
+theorem divK_loop_n1_call_iter210_exact_x1_framed_v4_input_of_selected_if_borrow
+    (I : LoopN1CallMaxmaxmaxExactInputs)
+    (hh : loopN1CallMaxmaxmaxSelectedInputHypotheses I) :
+    loopN1CallMaxmaxmaxIter210ExactInputSpecV4 I := by
+  unfold loopN1CallMaxmaxmaxIter210ExactInputSpecV4
+  let r3 := loopN1CallMaxmaxmaxR3 I.v0 I.v1 I.v2 I.v3 I.u0 I.u1 I.u2 I.u3 I.uTop
+  exact cpsTripleWithin_divCode_noNop_v4_to_divCode_v4
+    (divK_loop_n1_iter210_maxmaxmax_exact_x1_v4_noNop_selected_carry_if_borrow I.sp I.base
+    I.jOld I.v5Old I.v6Old I.v7Old I.v10Old I.v11Old I.v2Old
+    I.v0 I.v1 I.v2 I.v3
+    I.u0Orig2 r3.2.1 r3.2.2.1 r3.2.2.2.1 r3.2.2.2.2.1
+    I.u0Orig1 I.u0Orig0 I.q2Old I.q1Old I.q0Old
+    (I.base + div128CallRetOff) I.v0 (divKTrialCallV4DLo I.v0)
+    (divKTrialCallV4Un0 I.u0) I.raVal
+    (by
+      dsimp only [r3]
+      exact loopN1CallMaxmaxmaxSelectedInputHypotheses_hbltu2 I hh)
+    (by
+      dsimp only [r3]
+      have h := loopN1CallMaxmaxmaxSelectedInputHypotheses_hbltu1 I hh
+      unfold loopN1CallMaxmaxmaxR2 at h
+      exact h)
+    (by
+      dsimp only [r3]
+      have h := loopN1CallMaxmaxmaxSelectedInputHypotheses_hbltu0 I hh
+      unfold loopN1CallMaxmaxmaxR1 at h
+      unfold loopN1CallMaxmaxmaxR2 at h
+      exact h)
+    (by
+      dsimp only [r3]
+      have h := loopN1CallMaxmaxmaxSelectedInputHypotheses_carryIfBorrowMax2 I hh
+      unfold selectedN1MaxCarryIfBorrow at h
+      exact h)
+    (by
+      dsimp only [r3]
+      have h := loopN1CallMaxmaxmaxSelectedInputHypotheses_carryIfBorrowMax1 I hh
+      unfold loopN1CallMaxmaxmaxR2 at h
+      unfold selectedN1MaxCarryIfBorrow at h
+      exact h)
+    (by
+      dsimp only [r3]
+      have h := loopN1CallMaxmaxmaxSelectedInputHypotheses_carryIfBorrowMax0 I hh
+      unfold loopN1CallMaxmaxmaxR1 at h
+      unfold loopN1CallMaxmaxmaxR2 at h
+      unfold selectedN1MaxCarryIfBorrow at h
+      exact h))
+
 /-- Bundled framed all-max tail pre/post over the full `divCode_v4` bundle,
     from selected-only input hypotheses. -/
 theorem divK_loop_n1_call_iter210_framed_prepost_exact_x1_v4_input_of_selected

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1V4CallMaxSelected.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1V4CallMaxSelected.lean
@@ -1160,4 +1160,34 @@ theorem fullDivN1_call_maxmaxmax_exact_x1_scratch_v4_of_selected
       q3Old q2Old q1Old q0Old retMem dMem dloMem scratchUn0 scratchMem raVal)
     halign hh
 
+/-- Final exact path for the canonical full-DIV n=1 call/max/max/max
+    bundled inputs over the full `divCode_v4` bundle, using selected-only
+    hypotheses and conditional max carry evidence for taken addback branches. -/
+theorem fullDivN1_call_maxmaxmax_exact_x1_scratch_v4_of_selected_if_borrow
+    (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (q3Old q2Old q1Old q0Old retMem dMem dloMem scratchUn0 scratchMem raVal : Word)
+    (halign : fullDivN1CallMaxmaxmaxExactInputAligned sp base
+      jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      a0 a1 a2 a3 b0 b1 b2 b3
+      q3Old q2Old q1Old q0Old retMem dMem dloMem scratchUn0 scratchMem raVal)
+    (hh : fullDivN1CallMaxmaxmaxSelectedInputHypotheses sp base
+      jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      a0 a1 a2 a3 b0 b1 b2 b3
+      q3Old q2Old q1Old q0Old retMem dMem dloMem scratchUn0 scratchMem raVal) :
+    fullDivN1CallMaxmaxmaxExactInputSpecV4 sp base
+      jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      a0 a1 a2 a3 b0 b1 b2 b3
+      q3Old q2Old q1Old q0Old retMem dMem dloMem scratchUn0 scratchMem raVal := by
+  unfold fullDivN1CallMaxmaxmaxExactInputSpecV4
+  unfold fullDivN1CallMaxmaxmaxExactInputAligned at halign
+  unfold fullDivN1CallMaxmaxmaxSelectedInputHypotheses at hh
+  exact divK_loop_n1_call_maxmaxmax_exact_x1_scratch_input_v4_of_selected_if_borrow
+    (fullDivN1CallMaxmaxmaxExactInputs sp base
+      jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      a0 a1 a2 a3 b0 b1 b2 b3
+      q3Old q2Old q1Old q0Old retMem dMem dloMem scratchUn0 scratchMem raVal)
+    halign hh
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1V4CallMaxSelectedIfBorrow.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1V4CallMaxSelectedIfBorrow.lean
@@ -186,4 +186,53 @@ theorem divK_loop_n1_call_j3_exact_x1_framed_v4_input_of_selected_if_borrow
     (isAddbackCarry2NzN1CallV4_raw I.v0 I.v1 I.v2 I.v3 I.u0 I.u1 I.u2 I.u3 I.uTop
       (loopN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses_carryIfBorrowCall I hh))
 
+/-- Bundled all-max tail after the first j=3 call-body step over the full
+    `divCode_v4` bundle, using selected-if-borrow input hypotheses. -/
+theorem divK_loop_n1_call_iter210_exact_x1_framed_v4_input_of_selected_if_borrow_input
+    (I : LoopN1CallMaxmaxmaxExactInputs)
+    (hh : loopN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses I) :
+    loopN1CallMaxmaxmaxIter210ExactInputSpecV4 I := by
+  unfold loopN1CallMaxmaxmaxIter210ExactInputSpecV4
+  let r3 := loopN1CallMaxmaxmaxR3 I.v0 I.v1 I.v2 I.v3 I.u0 I.u1 I.u2 I.u3 I.uTop
+  exact cpsTripleWithin_divCode_noNop_v4_to_divCode_v4
+    (divK_loop_n1_iter210_maxmaxmax_exact_x1_v4_noNop_selected_carry_if_borrow I.sp I.base
+    I.jOld I.v5Old I.v6Old I.v7Old I.v10Old I.v11Old I.v2Old
+    I.v0 I.v1 I.v2 I.v3
+    I.u0Orig2 r3.2.1 r3.2.2.1 r3.2.2.2.1 r3.2.2.2.2.1
+    I.u0Orig1 I.u0Orig0 I.q2Old I.q1Old I.q0Old
+    (I.base + div128CallRetOff) I.v0 (divKTrialCallV4DLo I.v0)
+    (divKTrialCallV4Un0 I.u0) I.raVal
+    (by
+      dsimp only [r3]
+      exact loopN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses_hbltu2 I hh)
+    (by
+      dsimp only [r3]
+      have h := loopN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses_hbltu1 I hh
+      unfold loopN1CallMaxmaxmaxR2 at h
+      exact h)
+    (by
+      dsimp only [r3]
+      have h := loopN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses_hbltu0 I hh
+      unfold loopN1CallMaxmaxmaxR1 at h
+      unfold loopN1CallMaxmaxmaxR2 at h
+      exact h)
+    (by
+      dsimp only [r3]
+      have h := loopN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses_carryIfBorrowMax2 I hh
+      unfold selectedN1MaxCarryIfBorrow at h
+      exact h)
+    (by
+      dsimp only [r3]
+      have h := loopN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses_carryIfBorrowMax1 I hh
+      unfold loopN1CallMaxmaxmaxR2 at h
+      unfold selectedN1MaxCarryIfBorrow at h
+      exact h)
+    (by
+      dsimp only [r3]
+      have h := loopN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses_carryIfBorrowMax0 I hh
+      unfold loopN1CallMaxmaxmaxR1 at h
+      unfold loopN1CallMaxmaxmaxR2 at h
+      unfold selectedN1MaxCarryIfBorrow at h
+      exact h))
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1V4CallMaxSelectedIfBorrow.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1V4CallMaxSelectedIfBorrow.lean
@@ -1,0 +1,171 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN1V4CallMaxSelectedIfBorrow
+
+  Selected-if-borrow input hypotheses for the n=1 v4 call/max/max/max path.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN1V4CallMaxSelected
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Selected-if-borrow assumptions for the bundled N1 call/max/max/max input
+    path. This package replaces unconditional max carry facts with facts
+    needed only when each max step takes the addback branch. -/
+@[irreducible]
+def loopN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses
+    (I : LoopN1CallMaxmaxmaxExactInputs) : Prop :=
+  BitVec.ult I.u1 I.v0 ∧
+  loopN1CallMaxmaxmaxBranchFacts
+    I.v0 I.v1 I.v2 I.v3 I.u0 I.u1 I.u2 I.u3 I.uTop I.u0Orig2 I.u0Orig1 ∧
+  loopN1CallMaxmaxmaxSelectedCarryIfBorrowFacts
+    I.v0 I.v1 I.v2 I.v3 I.u0 I.u1 I.u2 I.u3 I.uTop
+    I.u0Orig2 I.u0Orig1 I.u0Orig0
+
+/-- Compatibility projection from selected-only inputs to selected-if-borrow
+    inputs. -/
+theorem loopN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses_of_selected
+    (I : LoopN1CallMaxmaxmaxExactInputs)
+    (hh : loopN1CallMaxmaxmaxSelectedInputHypotheses I) :
+    loopN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses I := by
+  unfold loopN1CallMaxmaxmaxSelectedInputHypotheses at hh
+  unfold loopN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses
+  exact ⟨hh.1, hh.2.1,
+    loopN1CallMaxmaxmaxSelectedCarryIfBorrowFacts_of_selected
+      I.v0 I.v1 I.v2 I.v3 I.u0 I.u1 I.u2 I.u3 I.uTop
+      I.u0Orig2 I.u0Orig1 I.u0Orig0 hh.2.2⟩
+
+/-- Build selected-if-borrow bundled N1 call/max/max/max hypotheses from
+    bundled branch facts and conditional selected carry facts. -/
+theorem loopN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses_of_branches
+    (I : LoopN1CallMaxmaxmaxExactInputs)
+    (hbltu3 : BitVec.ult I.u1 I.v0)
+    (hbranches : loopN1CallMaxmaxmaxBranchFacts
+      I.v0 I.v1 I.v2 I.v3 I.u0 I.u1 I.u2 I.u3 I.uTop I.u0Orig2 I.u0Orig1)
+    (hselected : loopN1CallMaxmaxmaxSelectedCarryIfBorrowFacts
+      I.v0 I.v1 I.v2 I.v3 I.u0 I.u1 I.u2 I.u3 I.uTop
+      I.u0Orig2 I.u0Orig1 I.u0Orig0) :
+    loopN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses I := by
+  unfold loopN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses
+  exact ⟨hbltu3, hbranches, hselected⟩
+
+theorem loopN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses_hbltu3
+    (I : LoopN1CallMaxmaxmaxExactInputs)
+    (hh : loopN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses I) :
+    BitVec.ult I.u1 I.v0 := by
+  unfold loopN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses at hh
+  exact hh.1
+
+theorem loopN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses_branches
+    (I : LoopN1CallMaxmaxmaxExactInputs)
+    (hh : loopN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses I) :
+    loopN1CallMaxmaxmaxBranchFacts
+      I.v0 I.v1 I.v2 I.v3 I.u0 I.u1 I.u2 I.u3 I.uTop I.u0Orig2 I.u0Orig1 := by
+  unfold loopN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses at hh
+  exact hh.2.1
+
+theorem loopN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses_hbltu2
+    (I : LoopN1CallMaxmaxmaxExactInputs)
+    (hh : loopN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses I) :
+    ¬BitVec.ult
+      (loopN1CallMaxmaxmaxR3 I.v0 I.v1 I.v2 I.v3 I.u0 I.u1 I.u2 I.u3 I.uTop).2.1
+      I.v0 := by
+  exact loopN1CallMaxmaxmaxBranchFacts_hbltu2
+    I.v0 I.v1 I.v2 I.v3 I.u0 I.u1 I.u2 I.u3 I.uTop I.u0Orig2 I.u0Orig1
+    (loopN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses_branches I hh)
+
+theorem loopN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses_hbltu1
+    (I : LoopN1CallMaxmaxmaxExactInputs)
+    (hh : loopN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses I) :
+    ¬BitVec.ult
+      (loopN1CallMaxmaxmaxR2 I.v0 I.v1 I.v2 I.v3 I.u0 I.u1 I.u2 I.u3
+        I.uTop I.u0Orig2).2.1 I.v0 := by
+  exact loopN1CallMaxmaxmaxBranchFacts_hbltu1
+    I.v0 I.v1 I.v2 I.v3 I.u0 I.u1 I.u2 I.u3 I.uTop I.u0Orig2 I.u0Orig1
+    (loopN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses_branches I hh)
+
+theorem loopN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses_hbltu0
+    (I : LoopN1CallMaxmaxmaxExactInputs)
+    (hh : loopN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses I) :
+    ¬BitVec.ult
+      (loopN1CallMaxmaxmaxR1 I.v0 I.v1 I.v2 I.v3 I.u0 I.u1 I.u2 I.u3
+        I.uTop I.u0Orig2 I.u0Orig1).2.1 I.v0 := by
+  exact loopN1CallMaxmaxmaxBranchFacts_hbltu0
+    I.v0 I.v1 I.v2 I.v3 I.u0 I.u1 I.u2 I.u3 I.uTop I.u0Orig2 I.u0Orig1
+    (loopN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses_branches I hh)
+
+theorem loopN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses_selectedCarryIfBorrow
+    (I : LoopN1CallMaxmaxmaxExactInputs)
+    (hh : loopN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses I) :
+    loopN1CallMaxmaxmaxSelectedCarryIfBorrowFacts
+      I.v0 I.v1 I.v2 I.v3 I.u0 I.u1 I.u2 I.u3 I.uTop
+      I.u0Orig2 I.u0Orig1 I.u0Orig0 := by
+  unfold loopN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses at hh
+  exact hh.2.2
+
+theorem loopN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses_carryIfBorrowCall
+    (I : LoopN1CallMaxmaxmaxExactInputs)
+    (hh : loopN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses I) :
+    isAddbackCarry2NzN1CallV4
+      I.v0 I.v1 I.v2 I.v3 I.u0 I.u1 I.u2 I.u3 I.uTop := by
+  exact loopN1CallMaxmaxmaxSelectedCarryIfBorrowFacts_call
+    I.v0 I.v1 I.v2 I.v3 I.u0 I.u1 I.u2 I.u3 I.uTop
+    I.u0Orig2 I.u0Orig1 I.u0Orig0
+    (loopN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses_selectedCarryIfBorrow I hh)
+
+theorem loopN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses_carryIfBorrowMax2
+    (I : LoopN1CallMaxmaxmaxExactInputs)
+    (hh : loopN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses I) :
+    selectedN1MaxCarryIfBorrow
+      I.v0 I.v1 I.v2 I.v3 I.u0Orig2
+      (loopN1CallMaxmaxmaxR3 I.v0 I.v1 I.v2 I.v3 I.u0 I.u1 I.u2 I.u3
+        I.uTop).2.1
+      (loopN1CallMaxmaxmaxR3 I.v0 I.v1 I.v2 I.v3 I.u0 I.u1 I.u2 I.u3
+        I.uTop).2.2.1
+      (loopN1CallMaxmaxmaxR3 I.v0 I.v1 I.v2 I.v3 I.u0 I.u1 I.u2 I.u3
+        I.uTop).2.2.2.1
+      (loopN1CallMaxmaxmaxR3 I.v0 I.v1 I.v2 I.v3 I.u0 I.u1 I.u2 I.u3
+        I.uTop).2.2.2.2.1 := by
+  exact loopN1CallMaxmaxmaxSelectedCarryIfBorrowFacts_max2
+    I.v0 I.v1 I.v2 I.v3 I.u0 I.u1 I.u2 I.u3 I.uTop
+    I.u0Orig2 I.u0Orig1 I.u0Orig0
+    (loopN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses_selectedCarryIfBorrow I hh)
+
+theorem loopN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses_carryIfBorrowMax1
+    (I : LoopN1CallMaxmaxmaxExactInputs)
+    (hh : loopN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses I) :
+    selectedN1MaxCarryIfBorrow
+      I.v0 I.v1 I.v2 I.v3 I.u0Orig1
+      (loopN1CallMaxmaxmaxR2 I.v0 I.v1 I.v2 I.v3 I.u0 I.u1 I.u2 I.u3
+        I.uTop I.u0Orig2).2.1
+      (loopN1CallMaxmaxmaxR2 I.v0 I.v1 I.v2 I.v3 I.u0 I.u1 I.u2 I.u3
+        I.uTop I.u0Orig2).2.2.1
+      (loopN1CallMaxmaxmaxR2 I.v0 I.v1 I.v2 I.v3 I.u0 I.u1 I.u2 I.u3
+        I.uTop I.u0Orig2).2.2.2.1
+      (loopN1CallMaxmaxmaxR2 I.v0 I.v1 I.v2 I.v3 I.u0 I.u1 I.u2 I.u3
+        I.uTop I.u0Orig2).2.2.2.2.1 := by
+  exact loopN1CallMaxmaxmaxSelectedCarryIfBorrowFacts_max1
+    I.v0 I.v1 I.v2 I.v3 I.u0 I.u1 I.u2 I.u3 I.uTop
+    I.u0Orig2 I.u0Orig1 I.u0Orig0
+    (loopN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses_selectedCarryIfBorrow I hh)
+
+theorem loopN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses_carryIfBorrowMax0
+    (I : LoopN1CallMaxmaxmaxExactInputs)
+    (hh : loopN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses I) :
+    selectedN1MaxCarryIfBorrow
+      I.v0 I.v1 I.v2 I.v3 I.u0Orig0
+      (loopN1CallMaxmaxmaxR1 I.v0 I.v1 I.v2 I.v3 I.u0 I.u1 I.u2 I.u3
+        I.uTop I.u0Orig2 I.u0Orig1).2.1
+      (loopN1CallMaxmaxmaxR1 I.v0 I.v1 I.v2 I.v3 I.u0 I.u1 I.u2 I.u3
+        I.uTop I.u0Orig2 I.u0Orig1).2.2.1
+      (loopN1CallMaxmaxmaxR1 I.v0 I.v1 I.v2 I.v3 I.u0 I.u1 I.u2 I.u3
+        I.uTop I.u0Orig2 I.u0Orig1).2.2.2.1
+      (loopN1CallMaxmaxmaxR1 I.v0 I.v1 I.v2 I.v3 I.u0 I.u1 I.u2 I.u3
+        I.uTop I.u0Orig2 I.u0Orig1).2.2.2.2.1 := by
+  exact loopN1CallMaxmaxmaxSelectedCarryIfBorrowFacts_max0
+    I.v0 I.v1 I.v2 I.v3 I.u0 I.u1 I.u2 I.u3 I.uTop
+    I.u0Orig2 I.u0Orig1 I.u0Orig0
+    (loopN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses_selectedCarryIfBorrow I hh)
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1V4CallMaxSelectedIfBorrow.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1V4CallMaxSelectedIfBorrow.lean
@@ -235,4 +235,65 @@ theorem divK_loop_n1_call_iter210_exact_x1_framed_v4_input_of_selected_if_borrow
       unfold selectedN1MaxCarryIfBorrow at h
       exact h))
 
+/-- Bundled framed all-max tail pre/post over the full `divCode_v4` bundle,
+    using selected-if-borrow input hypotheses. -/
+theorem divK_loop_n1_call_iter210_framed_prepost_exact_x1_v4_input_of_selected_if_borrow_input
+    (I : LoopN1CallMaxmaxmaxExactInputs)
+    (hh : loopN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses I) :
+    cpsTripleWithin 556 (I.base + loopBodyOff) (I.base + denormOff)
+      (divCode_v4 I.base)
+      (loopN1CallMaxmaxmaxIter210FramedPreInput I)
+      (loopN1CallMaxmaxmaxIter210FramedPostInput I) := by
+  unfold loopN1CallMaxmaxmaxIter210FramedPreInput
+    loopN1CallMaxmaxmaxIter210FramedPostInput
+  let r3 := loopN1CallMaxmaxmaxR3 I.v0 I.v1 I.v2 I.v3 I.u0 I.u1 I.u2 I.u3 I.uTop
+  let c3 := (mulsubN4 (divKTrialCallV4QHat I.u1 I.u0 I.v0)
+    I.v0 I.v1 I.v2 I.v3 I.u0 I.u1 I.u2 I.u3).2.2.2.2
+  let uBase3 := I.sp + signExtend12 4056 - (3 : Word) <<< (3 : BitVec 6).toNat
+  let qAddr3 := I.sp + signExtend12 4088 - (3 : Word) <<< (3 : BitVec 6).toNat
+  have H210 := cpsTripleWithin_divCode_noNop_v4_to_divCode_v4
+    (divK_loop_n1_iter210_maxmaxmax_exact_x1_v4_noNop_selected_carry_if_borrow I.sp I.base
+    (3 : Word) ((3 : Word) <<< (3 : BitVec 6).toNat) uBase3 qAddr3 c3 r3.1
+    r3.2.2.2.2.1
+    I.v0 I.v1 I.v2 I.v3
+    I.u0Orig2 r3.2.1 r3.2.2.1 r3.2.2.2.1 r3.2.2.2.2.1
+    I.u0Orig1 I.u0Orig0 I.q2Old I.q1Old I.q0Old
+    (I.base + div128CallRetOff) I.v0 (divKTrialCallV4DLo I.v0)
+    (divKTrialCallV4Un0 I.u0) I.raVal
+    (by
+      dsimp only [r3]
+      exact loopN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses_hbltu2 I hh)
+    (by
+      dsimp only [r3]
+      have h := loopN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses_hbltu1 I hh
+      unfold loopN1CallMaxmaxmaxR2 at h
+      exact h)
+    (by
+      dsimp only [r3]
+      have h := loopN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses_hbltu0 I hh
+      unfold loopN1CallMaxmaxmaxR1 at h
+      unfold loopN1CallMaxmaxmaxR2 at h
+      exact h)
+    (by
+      dsimp only [r3]
+      have h := loopN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses_carryIfBorrowMax2 I hh
+      unfold selectedN1MaxCarryIfBorrow at h
+      exact h)
+    (by
+      dsimp only [r3]
+      have h := loopN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses_carryIfBorrowMax1 I hh
+      unfold loopN1CallMaxmaxmaxR2 at h
+      unfold selectedN1MaxCarryIfBorrow at h
+      exact h)
+    (by
+      dsimp only [r3]
+      have h := loopN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses_carryIfBorrowMax0 I hh
+      unfold loopN1CallMaxmaxmaxR1 at h
+      unfold loopN1CallMaxmaxmaxR2 at h
+      unfold selectedN1MaxCarryIfBorrow at h
+      exact h))
+  have H210f := cpsTripleWithin_frameR
+    (loopN1CallMaxmaxmaxIter210FrameInput I) (by pcFree) H210
+  exact H210f
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1V4CallMaxSelectedIfBorrow.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1V4CallMaxSelectedIfBorrow.lean
@@ -168,4 +168,22 @@ theorem loopN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses_carryIfBorrowMax0
     I.u0Orig2 I.u0Orig1 I.u0Orig0
     (loopN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses_selectedCarryIfBorrow I hh)
 
+/-- Bundled first j=3 call-body step over the full `divCode_v4` bundle,
+    using selected-if-borrow input hypotheses. -/
+theorem divK_loop_n1_call_j3_exact_x1_framed_v4_input_of_selected_if_borrow
+    (I : LoopN1CallMaxmaxmaxExactInputs)
+    (halign : loopN1CallMaxmaxmaxExactInputAligned I)
+    (hh : loopN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses I) :
+    loopN1CallMaxmaxmaxJ3ExactInputSpecV4 I := by
+  unfold loopN1CallMaxmaxmaxJ3ExactInputSpecV4
+  exact divK_loop_n1_call_j3_exact_x1_framed_v4 I.sp I.base
+    I.jOld I.v5Old I.v6Old I.v7Old I.v10Old I.v11Old I.v2Old
+    I.v0 I.v1 I.v2 I.v3 I.u0 I.u1 I.u2 I.u3 I.uTop
+    I.u0Orig2 I.u0Orig1 I.u0Orig0 I.q3Old I.q2Old I.q1Old I.q0Old
+    I.retMem I.dMem I.dloMem I.scratchUn0 I.scratchMem I.raVal
+    (loopN1CallMaxmaxmaxExactInputAligned_raw I halign)
+    (loopN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses_hbltu3 I hh)
+    (isAddbackCarry2NzN1CallV4_raw I.v0 I.v1 I.v2 I.v3 I.u0 I.u1 I.u2 I.u3 I.uTop
+      (loopN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses_carryIfBorrowCall I hh))
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1V4NoNopLoopBodyConditional.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1V4NoNopLoopBodyConditional.lean
@@ -12,7 +12,7 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)
-open EvmAsm.Evm64.DivMod.AddrNorm (jpred_1 slt_jpos_1)
+open EvmAsm.Evm64.DivMod.AddrNorm (jpred_1 jpred_2 slt_jpos_1 slt_jpos_2)
 
 /-- Loop body n=1, max path, j>0 over `divCode_noNop_v4`, requiring the
     double-addback progress fact only when the addback branch is taken. -/
@@ -242,6 +242,111 @@ theorem divK_loop_n1_iter10_maxmax_exact_x1_v4_noNop_selected_carry_if_borrow (s
     (fun h hp => by
       delta loopN1Iter10PostNoX1 loopIterPostN1NoX1 loopIterPostN1Max at hp ⊢
       simp only [iterN1_false, sepConj_emp_right'] at hp ⊢
+      rw [sepConj_assoc'] at hp
+      xperm_hyp hp)
+    full
+
+/-- Exact-`x1` N1 three-iteration all-max path over `divCode_noNop_v4`,
+    threading max carry evidence only through taken addback branches. -/
+theorem divK_loop_n1_iter210_maxmaxmax_exact_x1_v4_noNop_selected_carry_if_borrow (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 q2Old q1Old q0Old : Word)
+    (retMem dMem dloMem scratch_un0 raVal : Word)
+    (hbltu_2 : ¬BitVec.ult u1 v0)
+    (hbltu_1 : ¬BitVec.ult (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v0)
+    (hbltu_0 : ¬BitVec.ult
+      (iterN1Max v0 v1 v2 v3 u0Orig1
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.1 v0)
+    (hcarry2_j2 : isAddbackCarry2NzN1MaxIfBorrow v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hcarry2_j1 : isAddbackCarry2NzN1MaxIfBorrow v0 v1 v2 v3 u0Orig1
+      (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1)
+    (hcarry2_j0 : isAddbackCarry2NzN1MaxIfBorrow v0 v1 v2 v3 u0Orig0
+      (iterN1Max v0 v1 v2 v3 u0Orig1
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.1
+      (iterN1Max v0 v1 v2 v3 u0Orig1
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.1
+      (iterN1Max v0 v1 v2 v3 u0Orig1
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.1
+      (iterN1Max v0 v1 v2 v3 u0Orig1
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.2.1) :
+    cpsTripleWithin 556 (base + loopBodyOff) (base + denormOff) (divCode_noNop_v4 base)
+      (loopN1Iter210PreWithScratchNoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop
+        u0Orig1 u0Orig0 q2Old q1Old q0Old
+        retMem dMem dloMem scratch_un0 ** (.x1 ↦ᵣ raVal))
+      (loopN1Iter210PostNoX1 false false false sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop
+        u0Orig1 u0Orig0 retMem dMem dloMem scratch_un0 ** (.x1 ↦ᵣ raVal)) := by
+  let r2 := iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  let u_base_2 := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
+  let u_base_1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+  let q_addr_2 := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
+  let q_addr_1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+  let u_base_0 := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+  let q_addr_0 := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
+  have J2 := divK_loop_body_n1_max_jgt0_exact_loopIter_v4_noNop_if_borrow
+    (2 : Word) sp base slt_jpos_2
+    jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop q2Old raVal hbltu_2
+    hcarry2_j2
+  have J2f := cpsTripleWithin_frameR
+    (((u_base_1 + signExtend12 0) ↦ₘ u0Orig1) ** (q_addr_1 ↦ₘ q1Old) **
+     ((u_base_0 + signExtend12 0) ↦ₘ u0Orig0) ** (q_addr_0 ↦ₘ q0Old) **
+     (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
+     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+    (by pcFree) J2
+  have H10 := divK_loop_n1_iter10_maxmax_exact_x1_v4_noNop_selected_carry_if_borrow
+    sp base (2 : Word) ((2 : Word) <<< (3 : BitVec 6).toNat) u_base_2 q_addr_2
+    ((mulsubN4 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2)
+    r2.1 r2.2.2.2.2.1
+    v0 v1 v2 v3
+    u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
+    u0Orig0 q1Old q0Old
+    retMem dMem dloMem scratch_un0 raVal hbltu_1 hbltu_0 hcarry2_j1 hcarry2_j0
+  have H10f := cpsTripleWithin_frameR
+    (((u_base_2 + signExtend12 4064) ↦ₘ r2.2.2.2.2.2) ** (q_addr_2 ↦ₘ r2.1))
+    (by pcFree) H10
+  have full := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by
+      delta loopIterPostN1Max loopExitPostN1 loopExitPost at hp
+      delta loopN1Iter10PreWithScratchNoX1 loopN1Iter10Pre at ⊢
+      simp only [] at hp ⊢
+      have hj' := jpred_2
+      rw [hj', u_n1_j2_0_eq_j1_4088, u_n1_j2_4088_eq_j1_4080,
+          u_n1_j2_4080_eq_j1_4072, u_n1_j2_4072_eq_j1_4064] at hp
+      dsimp only [u_base_0, u_base_1, u_base_2, q_addr_0, q_addr_1, q_addr_2] at hp ⊢
+      simp only [se12_32, se12_40, se12_48, se12_56] at hp ⊢
+      rw [sepConj_assoc'] at hp
+      xperm_hyp hp)
+    J2f H10f
+  exact cpsTripleWithin_weaken
+    (fun h hp => by
+      delta loopN1Iter210PreWithScratchNoX1 loopN1Iter210Pre at hp
+      delta loopBodyN1MaxSkipJgt0NormPreV4 at ⊢
+      dsimp only [u_base_0, u_base_1, u_base_2, q_addr_0, q_addr_1, q_addr_2] at hp ⊢
+      simp only [se12_32, se12_40, se12_48, se12_56] at hp ⊢
+      xperm_hyp hp)
+    (fun h hp => by
+      delta loopN1Iter210PostNoX1 loopN1Iter10PostNoX1
+        loopIterPostN1NoX1 loopIterPostN1Max at hp ⊢
+      simp only [iterN1_false, Bool.false_eq_true, if_false, sepConj_emp_right'] at hp ⊢
       rw [sepConj_assoc'] at hp
       xperm_hyp hp)
     full

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1V4NoNopLoopBodyConditional.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1V4NoNopLoopBodyConditional.lean
@@ -12,7 +12,8 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)
-open EvmAsm.Evm64.DivMod.AddrNorm (jpred_1 jpred_2 slt_jpos_1 slt_jpos_2)
+open EvmAsm.Evm64.DivMod.AddrNorm
+  (jpred_1 jpred_2 jpred_3 slt_jpos_1 slt_jpos_2 slt_jpos_3)
 
 /-- Loop body n=1, max path, j>0 over `divCode_noNop_v4`, requiring the
     double-addback progress fact only when the addback branch is taken. -/
@@ -345,6 +346,227 @@ theorem divK_loop_n1_iter210_maxmaxmax_exact_x1_v4_noNop_selected_carry_if_borro
       xperm_hyp hp)
     (fun h hp => by
       delta loopN1Iter210PostNoX1 loopN1Iter10PostNoX1
+        loopIterPostN1NoX1 loopIterPostN1Max at hp ⊢
+      simp only [iterN1_false, Bool.false_eq_true, if_false, sepConj_emp_right'] at hp ⊢
+      rw [sepConj_assoc'] at hp
+      xperm_hyp hp)
+    full
+
+/-- Exact-`x1` N1 four-iteration all-max path over `divCode_noNop_v4`,
+    threading max carry evidence only through taken addback branches. -/
+theorem divK_loop_n1_maxmaxmaxmax_exact_x1_v4_noNop_selected_carry_if_borrow (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop
+     u0Orig2 u0Orig1 u0Orig0 q3Old q2Old q1Old q0Old : Word)
+    (retMem dMem dloMem scratch_un0 raVal : Word)
+    (hbltu_3 : ¬BitVec.ult u1 v0)
+    (hbltu_2 : ¬BitVec.ult (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v0)
+    (hbltu_1 : ¬BitVec.ult
+      (iterN1Max v0 v1 v2 v3 u0Orig2
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.1 v0)
+    (hbltu_0 : ¬BitVec.ult
+      (iterN1Max v0 v1 v2 v3 u0Orig1
+        (iterN1Max v0 v1 v2 v3 u0Orig2
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.1
+        (iterN1Max v0 v1 v2 v3 u0Orig2
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.1
+        (iterN1Max v0 v1 v2 v3 u0Orig2
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.1
+        (iterN1Max v0 v1 v2 v3 u0Orig2
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.2.1).2.1 v0)
+    (hcarry2_j3 : isAddbackCarry2NzN1MaxIfBorrow v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hcarry2_j2 : isAddbackCarry2NzN1MaxIfBorrow v0 v1 v2 v3 u0Orig2
+      (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1)
+    (hcarry2_j1 : isAddbackCarry2NzN1MaxIfBorrow v0 v1 v2 v3 u0Orig1
+      (iterN1Max v0 v1 v2 v3 u0Orig2
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.1
+      (iterN1Max v0 v1 v2 v3 u0Orig2
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.1
+      (iterN1Max v0 v1 v2 v3 u0Orig2
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.1
+      (iterN1Max v0 v1 v2 v3 u0Orig2
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.2.1)
+    (hcarry2_j0 : isAddbackCarry2NzN1MaxIfBorrow v0 v1 v2 v3 u0Orig0
+      (iterN1Max v0 v1 v2 v3 u0Orig1
+        (iterN1Max v0 v1 v2 v3 u0Orig2
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.1
+        (iterN1Max v0 v1 v2 v3 u0Orig2
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.1
+        (iterN1Max v0 v1 v2 v3 u0Orig2
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.1
+        (iterN1Max v0 v1 v2 v3 u0Orig2
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.2.1).2.1
+      (iterN1Max v0 v1 v2 v3 u0Orig1
+        (iterN1Max v0 v1 v2 v3 u0Orig2
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.1
+        (iterN1Max v0 v1 v2 v3 u0Orig2
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.1
+        (iterN1Max v0 v1 v2 v3 u0Orig2
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.1
+        (iterN1Max v0 v1 v2 v3 u0Orig2
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.2.1).2.2.1
+      (iterN1Max v0 v1 v2 v3 u0Orig1
+        (iterN1Max v0 v1 v2 v3 u0Orig2
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.1
+        (iterN1Max v0 v1 v2 v3 u0Orig2
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.1
+        (iterN1Max v0 v1 v2 v3 u0Orig2
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.1
+        (iterN1Max v0 v1 v2 v3 u0Orig2
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.2.1).2.2.2.1
+      (iterN1Max v0 v1 v2 v3 u0Orig1
+        (iterN1Max v0 v1 v2 v3 u0Orig2
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.1
+        (iterN1Max v0 v1 v2 v3 u0Orig2
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.1
+        (iterN1Max v0 v1 v2 v3 u0Orig2
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.1
+        (iterN1Max v0 v1 v2 v3 u0Orig2
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+          (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.2.1).2.2.2.2.1) :
+    cpsTripleWithin 758 (base + loopBodyOff) (base + denormOff) (divCode_noNop_v4 base)
+      (loopN1PreWithScratchNoX1 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop
+        u0Orig2 u0Orig1 u0Orig0 q3Old q2Old q1Old q0Old
+        retMem dMem dloMem scratch_un0 ** (.x1 ↦ᵣ raVal))
+      (loopN1UnifiedPostNoX1 false false false false sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop
+        u0Orig2 u0Orig1 u0Orig0 retMem dMem dloMem scratch_un0 ** (.x1 ↦ᵣ raVal)) := by
+  let r3 := iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  let r2 := iterN1Max v0 v1 v2 v3 u0Orig2 r3.2.1 r3.2.2.1 r3.2.2.2.1 r3.2.2.2.2.1
+  let r1 := iterN1Max v0 v1 v2 v3 u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
+  let u_base_3 := sp + signExtend12 4056 - (3 : Word) <<< (3 : BitVec 6).toNat
+  let u_base_2 := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
+  let q_addr_3 := sp + signExtend12 4088 - (3 : Word) <<< (3 : BitVec 6).toNat
+  let q_addr_2 := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
+  let u_base_1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+  let q_addr_1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+  let u_base_0 := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+  let q_addr_0 := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
+  have J3 := divK_loop_body_n1_max_jgt0_exact_loopIter_v4_noNop_if_borrow
+    (3 : Word) sp base slt_jpos_3
+    jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop q3Old raVal hbltu_3
+    hcarry2_j3
+  have J3f := cpsTripleWithin_frameR
+    (((u_base_2 + signExtend12 0) ↦ₘ u0Orig2) ** (q_addr_2 ↦ₘ q2Old) **
+     ((u_base_1 + signExtend12 0) ↦ₘ u0Orig1) ** (q_addr_1 ↦ₘ q1Old) **
+     ((u_base_0 + signExtend12 0) ↦ₘ u0Orig0) ** (q_addr_0 ↦ₘ q0Old) **
+     (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
+     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+    (by pcFree) J3
+  have H210 := divK_loop_n1_iter210_maxmaxmax_exact_x1_v4_noNop_selected_carry_if_borrow
+    sp base (3 : Word) ((3 : Word) <<< (3 : BitVec 6).toNat) u_base_3 q_addr_3
+    ((mulsubN4 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2)
+    r3.1 r3.2.2.2.2.1
+    v0 v1 v2 v3
+    u0Orig2 r3.2.1 r3.2.2.1 r3.2.2.2.1 r3.2.2.2.2.1
+    u0Orig1 u0Orig0 q2Old q1Old q0Old
+    retMem dMem dloMem scratch_un0 raVal hbltu_2 hbltu_1 hbltu_0
+    hcarry2_j2 hcarry2_j1 hcarry2_j0
+  have H210f := cpsTripleWithin_frameR
+    (((u_base_3 + signExtend12 4064) ↦ₘ r3.2.2.2.2.2) ** (q_addr_3 ↦ₘ r3.1))
+    (by pcFree) H210
+  have full := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by
+      delta loopIterPostN1Max loopExitPostN1 loopExitPost at hp
+      delta loopN1Iter210PreWithScratchNoX1 loopN1Iter210Pre at ⊢
+      simp only [] at hp ⊢
+      have hj' := jpred_3
+      rw [hj', u_n1_j3_0_eq_j2_4088, u_n1_j3_4088_eq_j2_4080,
+          u_n1_j3_4080_eq_j2_4072, u_n1_j3_4072_eq_j2_4064] at hp
+      dsimp only [u_base_0, u_base_1, u_base_2, u_base_3,
+        q_addr_0, q_addr_1, q_addr_2, q_addr_3] at hp ⊢
+      simp only [se12_32, se12_40, se12_48, se12_56] at hp ⊢
+      rw [sepConj_assoc'] at hp
+      xperm_hyp hp)
+    J3f H210f
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by
+      delta loopN1PreWithScratchNoX1 loopN1Pre at hp
+      delta loopBodyN1MaxSkipJgt0NormPreV4 at ⊢
+      dsimp only [u_base_0, u_base_1, u_base_2, u_base_3,
+        q_addr_0, q_addr_1, q_addr_2, q_addr_3] at hp ⊢
+      simp only [se12_32, se12_40, se12_48, se12_56] at hp ⊢
+      xperm_hyp hp)
+    (fun h hp => by
+      delta loopN1UnifiedPostNoX1 loopN1Iter210PostNoX1 loopN1Iter10PostNoX1
         loopIterPostN1NoX1 loopIterPostN1Max at hp ⊢
       simp only [iterN1_false, Bool.false_eq_true, if_false, sepConj_emp_right'] at hp ⊢
       rw [sepConj_assoc'] at hp

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1V4PreloopCallMax.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1V4PreloopCallMax.lean
@@ -459,6 +459,107 @@ theorem fullDivN1_preloop_call_maxmaxmax_denorm_epilogue_exact_x1_v4_x9In_of_sel
     hA hB
 
 /-- Full-code full-DIV n=1 preloop, call/max/max/max loop path, and
+    denormalization+DIV epilogue, generalized over the incoming `x9` value,
+    using selected-only hypotheses and conditional max carry evidence. -/
+theorem fullDivN1_preloop_call_maxmaxmax_denorm_epilogue_exact_x1_v4_x9In_of_selected_if_borrow
+    (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old x9In : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem : Word)
+    (jMem retMem dMem dloMem scratchUn0 scratchMem raVal : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1z : b1 = 0)
+    (hshift_nz : (clzResult b0).1 ≠ 0)
+    (halign : fullDivN1CallMaxmaxmaxExactInputAligned sp base
+      jMem (1 : Word) (fullDivN1Shift b0) (fullDivN1NormU a0 a1 a2 a3 b0).1
+      (a0 >>> ((fullDivN1AntiShift b0).toNat % 64)) v11Old (fullDivN1AntiShift b0)
+      a0 a1 a2 a3 b0 b1 b2 b3
+      (0 : Word) (0 : Word) (0 : Word) (0 : Word)
+      retMem dMem dloMem scratchUn0 scratchMem raVal)
+    (hselected : fullDivN1CallMaxmaxmaxSelectedInputHypotheses sp base
+      jMem (1 : Word) (fullDivN1Shift b0) (fullDivN1NormU a0 a1 a2 a3 b0).1
+      (a0 >>> ((fullDivN1AntiShift b0).toNat % 64)) v11Old (fullDivN1AntiShift b0)
+      a0 a1 a2 a3 b0 b1 b2 b3
+      (0 : Word) (0 : Word) (0 : Word) (0 : Word)
+      retMem dMem dloMem scratchUn0 scratchMem raVal) :
+    cpsTripleWithin ((8 + 21 + 24 + 4 + 21 + 21 + 4 + 780) + (2 + 23 + 10))
+      base (base + nopOff) (divCode_v4 base)
+      ((((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+         (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b0).2 >>> (63 : Nat)) **
+         (.x9 ↦ᵣ x9In) **
+         ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+         ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+         ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+         ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+         ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+         ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+         ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+         ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+         ((sp + signExtend12 4024) ↦ₘ u4Old) **
+         ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+         ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+         ((sp + signExtend12 3992) ↦ₘ shiftMem)) **
+        ((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
+         (sp + signExtend12 3968 ↦ₘ retMem) **
+         (sp + signExtend12 3960 ↦ₘ dMem) **
+         (sp + signExtend12 3952 ↦ₘ dloMem) **
+         (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+         (sp + signExtend12 3936 ↦ₘ scratchMem) **
+         (.x1 ↦ᵣ raVal))))
+      (fullDivN1CallMaxmaxmaxUnifiedPostNoX1 sp base (clzResult b0).1
+        a0 a1 a2 a3
+        (fullDivN1NormV b0 b1 b2 b3).1
+        (fullDivN1NormV b0 b1 b2 b3).2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.2
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
+        (0 : Word) (0 : Word) (0 : Word)
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.1
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.1
+        (fullDivN1NormU a0 a1 a2 a3 b0).1
+        scratchMem **
+       (.x1 ↦ᵣ raVal)) := by
+  have hA := fullDivN1_preloop_call_maxmaxmax_exact_x1_scratch_v4_x9In_of_selected_if_borrow
+    sp base
+    a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old x9In
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem
+    jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+    hbnz hb3z hb2z hb1z hshift_nz halign hselected
+  unfold fullDivN1PreloopCallMaxmaxmaxExactSpecV4X9In at hA
+  have hB := evm_div_n1_call_maxmaxmax_denorm_epilogue_spec_v4_exact_x1
+    sp base (clzResult b0).1
+    a0 a1 a2 a3
+    (fullDivN1NormV b0 b1 b2 b3).1
+    (fullDivN1NormV b0 b1 b2 b3).2.1
+    (fullDivN1NormV b0 b1 b2 b3).2.2.1
+    (fullDivN1NormV b0 b1 b2 b3).2.2.2
+    (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1
+    (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
+    (0 : Word) (0 : Word) (0 : Word)
+    (fullDivN1NormU a0 a1 a2 a3 b0).2.2.1
+    (fullDivN1NormU a0 a1 a2 a3 b0).2.1
+    (fullDivN1NormU a0 a1 a2 a3 b0).1
+    scratchMem raVal hshift_nz
+  exact cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by
+      have hpBridge := loopN1CallMaxmaxmaxScratchPostNoX1_to_denormPre_frame
+        sp base
+        a0 a1 a2 a3
+        (fullDivN1NormV b0 b1 b2 b3).1
+        (fullDivN1NormV b0 b1 b2 b3).2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.2
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
+        (0 : Word) (0 : Word) (0 : Word)
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.1
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.1
+        (fullDivN1NormU a0 a1 a2 a3 b0).1
+        scratchMem (clzResult b0).1 raVal h hp
+      xperm_hyp hpBridge)
+    hA hB
+
+/-- Full-code full-DIV n=1 preloop, call/max/max/max loop path, and
     denormalization+DIV epilogue, with caller `x1` retained exactly, using
     the selected-only loop hypothesis surface. -/
 theorem fullDivN1_preloop_call_maxmaxmax_denorm_epilogue_exact_x1_v4_of_selected
@@ -520,6 +621,75 @@ theorem fullDivN1_preloop_call_maxmaxmax_denorm_epilogue_exact_x1_v4_of_selected
         scratchMem **
        (.x1 ↦ᵣ raVal)) := by
   exact fullDivN1_preloop_call_maxmaxmax_denorm_epilogue_exact_x1_v4_x9In_of_selected
+    sp base
+    a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old
+    (signExtend12 (4 : BitVec 12) - (4 : Word))
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem
+    jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+    hbnz hb3z hb2z hb1z hshift_nz halign hselected
+
+/-- Full-code full-DIV n=1 preloop, call/max/max/max loop path, and
+    denormalization+DIV epilogue, with caller `x1` retained exactly, using
+    selected-only hypotheses and conditional max carry evidence. -/
+theorem fullDivN1_preloop_call_maxmaxmax_denorm_epilogue_exact_x1_v4_of_selected_if_borrow
+    (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem : Word)
+    (jMem retMem dMem dloMem scratchUn0 scratchMem raVal : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1z : b1 = 0)
+    (hshift_nz : (clzResult b0).1 ≠ 0)
+    (halign : fullDivN1CallMaxmaxmaxExactInputAligned sp base
+      jMem (1 : Word) (fullDivN1Shift b0) (fullDivN1NormU a0 a1 a2 a3 b0).1
+      (a0 >>> ((fullDivN1AntiShift b0).toNat % 64)) v11Old (fullDivN1AntiShift b0)
+      a0 a1 a2 a3 b0 b1 b2 b3
+      (0 : Word) (0 : Word) (0 : Word) (0 : Word)
+      retMem dMem dloMem scratchUn0 scratchMem raVal)
+    (hselected : fullDivN1CallMaxmaxmaxSelectedInputHypotheses sp base
+      jMem (1 : Word) (fullDivN1Shift b0) (fullDivN1NormU a0 a1 a2 a3 b0).1
+      (a0 >>> ((fullDivN1AntiShift b0).toNat % 64)) v11Old (fullDivN1AntiShift b0)
+      a0 a1 a2 a3 b0 b1 b2 b3
+      (0 : Word) (0 : Word) (0 : Word) (0 : Word)
+      retMem dMem dloMem scratchUn0 scratchMem raVal) :
+    cpsTripleWithin ((8 + 21 + 24 + 4 + 21 + 21 + 4 + 780) + (2 + 23 + 10))
+      base (base + nopOff) (divCode_v4 base)
+      ((((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+         (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b0).2 >>> (63 : Nat)) **
+         (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+         ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+         ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+         ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+         ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+         ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+         ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+         ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+         ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+         ((sp + signExtend12 4024) ↦ₘ u4Old) **
+         ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+         ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+         ((sp + signExtend12 3992) ↦ₘ shiftMem)) **
+        ((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
+         (sp + signExtend12 3968 ↦ₘ retMem) **
+         (sp + signExtend12 3960 ↦ₘ dMem) **
+         (sp + signExtend12 3952 ↦ₘ dloMem) **
+         (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+         (sp + signExtend12 3936 ↦ₘ scratchMem) **
+         (.x1 ↦ᵣ raVal))))
+      (fullDivN1CallMaxmaxmaxUnifiedPostNoX1 sp base (clzResult b0).1
+        a0 a1 a2 a3
+        (fullDivN1NormV b0 b1 b2 b3).1
+        (fullDivN1NormV b0 b1 b2 b3).2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.2
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
+        (0 : Word) (0 : Word) (0 : Word)
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.1
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.1
+        (fullDivN1NormU a0 a1 a2 a3 b0).1
+        scratchMem **
+       (.x1 ↦ᵣ raVal)) := by
+  exact fullDivN1_preloop_call_maxmaxmax_denorm_epilogue_exact_x1_v4_x9In_of_selected_if_borrow
     sp base
     a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old
     (signExtend12 (4 : BitVec 12) - (4 : Word))

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1V4PreloopCallMax.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1V4PreloopCallMax.lean
@@ -199,6 +199,63 @@ theorem fullDivN1_preloop_call_maxmaxmax_exact_x1_scratch_v4_x9In_of_selected
         jMem retMem dMem dloMem scratchUn0 scratchMem raVal h hp)
     hPre hLoopF
 
+/-- Full-DIV n=1 preloop with arbitrary incoming `x9`, composed with the
+    call/max/max/max loop path over the full `divCode_v4` bundle using the
+    selected-only loop hypothesis surface and conditional max carry evidence. -/
+theorem fullDivN1_preloop_call_maxmaxmax_exact_x1_scratch_v4_x9In_of_selected_if_borrow
+    (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old x9In : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem : Word)
+    (jMem retMem dMem dloMem scratchUn0 scratchMem raVal : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1z : b1 = 0)
+    (hshift_nz : (clzResult b0).1 ≠ 0)
+    (halign : fullDivN1CallMaxmaxmaxExactInputAligned sp base
+      jMem (1 : Word) (fullDivN1Shift b0) (fullDivN1NormU a0 a1 a2 a3 b0).1
+      (a0 >>> ((fullDivN1AntiShift b0).toNat % 64)) v11Old (fullDivN1AntiShift b0)
+      a0 a1 a2 a3 b0 b1 b2 b3
+      (0 : Word) (0 : Word) (0 : Word) (0 : Word)
+      retMem dMem dloMem scratchUn0 scratchMem raVal)
+    (hselected : fullDivN1CallMaxmaxmaxSelectedInputHypotheses sp base
+      jMem (1 : Word) (fullDivN1Shift b0) (fullDivN1NormU a0 a1 a2 a3 b0).1
+      (a0 >>> ((fullDivN1AntiShift b0).toNat % 64)) v11Old (fullDivN1AntiShift b0)
+      a0 a1 a2 a3 b0 b1 b2 b3
+      (0 : Word) (0 : Word) (0 : Word) (0 : Word)
+      retMem dMem dloMem scratchUn0 scratchMem raVal) :
+    fullDivN1PreloopCallMaxmaxmaxExactSpecV4X9In sp base
+      a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old x9In
+      q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem
+      jMem retMem dMem dloMem scratchUn0 scratchMem raVal := by
+  unfold fullDivN1PreloopCallMaxmaxmaxExactSpecV4X9In
+  have hPre := evm_div_n1_to_loopSetup_spec_v4_x9In_exact_x1_scratch_frame
+    sp base a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old x9In
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem
+    jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+    hbnz hb3z hb2z hb1z hshift_nz
+  have hLoop := fullDivN1_call_maxmaxmax_exact_x1_scratch_v4_of_selected_if_borrow
+    sp base
+    jMem (1 : Word) (fullDivN1Shift b0) (fullDivN1NormU a0 a1 a2 a3 b0).1
+    (a0 >>> ((fullDivN1AntiShift b0).toNat % 64)) v11Old (fullDivN1AntiShift b0)
+    a0 a1 a2 a3 b0 b1 b2 b3
+    (0 : Word) (0 : Word) (0 : Word) (0 : Word)
+    retMem dMem dloMem scratchUn0 scratchMem raVal
+    halign hselected
+  unfold fullDivN1CallMaxmaxmaxExactInputSpecV4 at hLoop
+  unfold loopN1CallMaxmaxmaxExactInputSpecV4 at hLoop
+  unfold fullDivN1CallMaxmaxmaxExactInputs at hLoop
+  dsimp only at hLoop
+  have hLoopF := cpsTripleWithin_frameR
+    (((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 3992) ↦ₘ (clzResult b0).1))
+    (by pcFree) hLoop
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by
+      exact loopSetupPost_to_fullDivN1CallMaxmaxmaxScratchPreNoX1_framed
+        sp a0 a1 a2 a3 b0 b1 b2 b3 v11Old
+        jMem retMem dMem dloMem scratchUn0 scratchMem raVal h hp)
+    hPre hLoopF
+
 /-- Full-code full-DIV n=1 preloop, call/max/max/max loop path, and
     denormalization+DIV epilogue, with caller `x1` retained exactly. -/
 theorem fullDivN1_preloop_call_maxmaxmax_denorm_epilogue_exact_x1_v4_of_bltu


### PR DESCRIPTION
## Summary
- add a selected-carry-if-borrow wrapper for the N1 three-iteration max/max/max path
- compose the conditional j=2 body wrapper with the conditional two-iteration tail
- continue replacing false unconditional max carry obligations with control-flow-shaped addback-branch evidence

## Verification
- lake build EvmAsm.Evm64.DivMod.Compose.FullPathN1V4NoNopLoopBodyConditional
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/Compose/FullPathN1V4NoNopLoopBodyConditional.lean
- lake build EvmAsm.Evm64.DivMod
- lake build