### PR TITLE
feat(stateless): chain_validate_constant_gas_limit (PR-K266)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -315,6 +315,7 @@ def lookupProgramTail : String → Option BuildUnit
   | "zisk_chain_compute_min_gas_limit" => some ziskChainComputeMinGasLimitProbeUnit
   | "zisk_chain_compute_total_gas_limit" => some ziskChainComputeTotalGasLimitProbeUnit
   | "zisk_chain_extract_gas_limit_first_last" => some ziskChainExtractGasLimitFirstLastProbeUnit
+  | "zisk_chain_validate_constant_gas_limit" => some ziskChainValidateConstantGasLimitProbeUnit
   | "zisk_chain_extract_first_last_state_root" => some ziskChainExtractFirstLastStateRootProbeUnit
   | "zisk_chain_extract_first_last_block_hash" => some ziskChainExtractFirstLastBlockHashProbeUnit
   | "zisk_chain_extract_first_last_receipts_root" => some ziskChainExtractFirstLastReceiptsRootProbeUnit
@@ -754,6 +755,7 @@ def knownProgramNames : List String :=
    "zisk_chain_compute_min_gas_limit",
    "zisk_chain_compute_total_gas_limit",
    "zisk_chain_extract_gas_limit_first_last",
+   "zisk_chain_validate_constant_gas_limit",
    "zisk_chain_extract_first_last_state_root",
    "zisk_chain_extract_first_last_block_hash",
    "zisk_chain_extract_first_last_receipts_root",

--- a/EvmAsm/Codegen/Programs/ChainValidate.lean
+++ b/EvmAsm/Codegen/Programs/ChainValidate.lean
@@ -525,4 +525,129 @@ def ziskChainValidateNoBlobTxsProbeUnit : BuildUnit := {
   dataAsm     := ziskChainValidateNoBlobTxsDataSection
 }
 
+/-! ## chain_validate_constant_gas_limit -- PR-K266
+
+    Per-chain invariant: all headers share the same `gas_limit`
+    (field 9). Useful as a sanity check for analytics windows
+    over a stable-network segment; the EIP-1559 elastic-cap rule
+    permits ±1/1024 drift per block, so this predicate flags any
+    capacity change inside the window.
+
+    Vacuous-true on N <= 1.
+
+    Calling convention:
+      a0 (input)  : N (header count)
+      a1 (input)  : header_lengths ptr
+      a2 (input)  : headers ptr (concatenated)
+      a3 (input)  : u64 out (is_valid)
+      a4 (input)  : u64 out (first_bad_index)
+      ra (input)  : return
+      a0 (output) :
+        0 : success
+        1 : RLP parse failure on some header
+        2 : gas_limit field > 8 bytes BE on some header -/
+def chainValidateConstantGasLimitFunction : String :=
+  "chain_validate_constant_gas_limit:\n" ++
+  "  addi sp, sp, -56\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp)\n" ++
+  "  mv s0, a0; mv s1, a1; mv s2, a2; mv s3, a3; mv s4, a4\n" ++
+  "  li t0, 1\n" ++
+  "  sd t0, 0(s3); sd zero, 0(s4)\n" ++
+  "  li t0, 2\n" ++
+  "  bltu s0, t0, .Lcvcgl_done\n" ++
+  "  # Extract headers[0].gas_limit into s5 (anchor)\n" ++
+  "  ld a1, 0(s1)\n" ++
+  "  mv a0, s2\n" ++
+  "  li a2, 9\n" ++
+  "  la a3, cvcgl_field\n" ++
+  "  jal ra, rlp_field_to_u64\n" ++
+  "  bnez a0, .Lcvcgl_propagate\n" ++
+  "  la t0, cvcgl_field; ld s5, 0(t0)\n" ++
+  "  # Walk: child_ptr = headers[1]; i = 1\n" ++
+  "  ld t0, 0(s1)\n" ++
+  "  add t1, s2, t0\n" ++
+  "  li t2, 1\n" ++
+  ".Lcvcgl_loop:\n" ++
+  "  beq t2, s0, .Lcvcgl_done\n" ++
+  "  la t0, cvcgl_iter_child; sd t1, 0(t0)\n" ++
+  "  la t0, cvcgl_iter_i;     sd t2, 0(t0)\n" ++
+  "  slli t3, t2, 3\n" ++
+  "  add t3, s1, t3\n" ++
+  "  ld a1, 0(t3)\n" ++
+  "  mv a0, t1\n" ++
+  "  li a2, 9\n" ++
+  "  la a3, cvcgl_field\n" ++
+  "  jal ra, rlp_field_to_u64\n" ++
+  "  bnez a0, .Lcvcgl_propagate\n" ++
+  "  la t0, cvcgl_field; ld t3, 0(t0)\n" ++
+  "  bne t3, s5, .Lcvcgl_pred_false\n" ++
+  "  la t0, cvcgl_iter_child; ld t1, 0(t0)\n" ++
+  "  la t0, cvcgl_iter_i;     ld t2, 0(t0)\n" ++
+  "  slli t5, t2, 3\n" ++
+  "  add t5, s1, t5\n" ++
+  "  ld t6, 0(t5)\n" ++
+  "  add t1, t1, t6\n" ++
+  "  addi t2, t2, 1\n" ++
+  "  j .Lcvcgl_loop\n" ++
+  ".Lcvcgl_pred_false:\n" ++
+  "  sd zero, 0(s3)\n" ++
+  "  la t0, cvcgl_iter_i; ld t1, 0(t0)\n" ++
+  "  sd t1, 0(s4)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lcvcgl_ret\n" ++
+  ".Lcvcgl_propagate:\n" ++
+  "  la t0, cvcgl_iter_i; ld t1, 0(t0)\n" ++
+  "  sd t1, 0(s4)\n" ++
+  "  j .Lcvcgl_ret\n" ++
+  ".Lcvcgl_done:\n" ++
+  "  li a0, 0\n" ++
+  ".Lcvcgl_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp)\n" ++
+  "  addi sp, sp, 56\n" ++
+  "  ret"
+
+def ziskChainValidateConstantGasLimitPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a7, 0x40000000\n" ++
+  "  ld a0, 8(a7)\n" ++
+  "  addi a1, a7, 16\n" ++
+  "  slli t0, a0, 3\n" ++
+  "  add a2, a1, t0\n" ++
+  "  li a3, 0xa0010008\n" ++
+  "  li a4, 0xa0010010\n" ++
+  "  jal ra, chain_validate_constant_gas_limit\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lcvcgl_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpFieldToU64Function ++ "\n" ++
+  chainValidateConstantGasLimitFunction ++ "\n" ++
+  ".Lcvcgl_pdone:"
+
+def ziskChainValidateConstantGasLimitDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  "rfu_offset:\n" ++
+  "  .zero 8\n" ++
+  "rfu_length:\n" ++
+  "  .zero 8\n" ++
+  "cvcgl_field:\n" ++
+  "  .zero 8\n" ++
+  "cvcgl_iter_child:\n" ++
+  "  .zero 8\n" ++
+  "cvcgl_iter_i:\n" ++
+  "  .zero 8"
+
+def ziskChainValidateConstantGasLimitProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskChainValidateConstantGasLimitPrologue
+  dataAsm     := ziskChainValidateConstantGasLimitDataSection
+}
+
 end EvmAsm.Codegen

--- a/scripts/codegen-zisk-chain-validate-constant-gas-limit-check.sh
+++ b/scripts/codegen-zisk-chain-validate-constant-gas-limit-check.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# codegen-zisk-chain-validate-constant-gas-limit-check.sh -- PR-K266.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_chain_validate_constant_gas_limit ELF"
+lake exe codegen --program zisk_chain_validate_constant_gas_limit --halt linux93 \
+  -o gen-out/zisk_chain_validate_constant_gas_limit
+
+REPO_ROOT="$(pwd)"
+
+run_case() {
+  local name="$1" gas_limits="$2" exp_status="$3" exp_valid="$4" exp_bad_index="$5"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_chain_validate_constant_gas_limit_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_chain_validate_constant_gas_limit_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+def u_be(n):
+    if n == 0: return b''
+    return n.to_bytes((n.bit_length() + 7) // 8, 'big')
+
+def make_header(gas_limit):
+    return rlp.encode([
+        b'\\xa1'*32, b'\\xa2'*32, b'\\xa3'*20, b'\\xa4'*32, b'\\xa5'*32,
+        b'\\xa6'*32, b'\\x00'*256, b'', b'\\x01', u_be(gas_limit),
+        b'', b'\\x83\\x01\\x02\\x03', b'', b'\\xa7'*32, b'\\x00'*8,
+    ])
+
+vals = $gas_limits
+headers = [make_header(v) for v in vals]
+N = len(headers)
+lengths = b''.join(struct.pack('<Q', len(h)) for h in headers)
+flat = b''.join(headers)
+with open(sys.argv[1], 'wb') as f:
+    record = struct.pack('<Q', N) + lengths + flat
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_chain_validate_constant_gas_limit.elf \
+    -i "$in_file" -o "$out_file" -n 5000000 \
+    >"$REPO_ROOT/gen-out/zisk_chain_validate_constant_gas_limit_${name}.emu.log" 2>&1 || true
+
+  local s_le; s_le="$(dd if="$out_file" bs=1 skip=0  count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local v_le; v_le="$(dd if="$out_file" bs=1 skip=8  count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local b_le; b_le="$(dd if="$out_file" bs=1 skip=16 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local status valid bad_index
+  status="$(   python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$s_le'))[0])")"
+  valid="$(    python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$v_le'))[0])")"
+  bad_index="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$b_le'))[0])")"
+
+  if [[ "$status" == "$exp_status" && "$valid" == "$exp_valid" && "$bad_index" == "$exp_bad_index" ]]; then
+    printf "  %-26s OK   status=%s valid=%s bad_index=%s\n" "$name" "$status" "$valid" "$bad_index"
+    return 0
+  else
+    printf "  %-26s FAIL status=%s/%s valid=%s/%s bad_index=%s/%s\n" "$name" "$status" "$exp_status" "$valid" "$exp_valid" "$bad_index" "$exp_bad_index"
+    return 1
+  fi
+}
+
+FAILED=0
+run_case "empty"              "[]"                                  0 1 0 || FAILED=1
+run_case "single"             "[30000000]"                          0 1 0 || FAILED=1
+run_case "three_same"         "[30000000,30000000,30000000]"        0 1 0 || FAILED=1
+run_case "three_bumped_at_1"  "[30000000,30001000,30000000]"        0 0 1 || FAILED=1
+run_case "three_bumped_at_2"  "[30000000,30000000,30001000]"        0 0 2 || FAILED=1
+run_case "five_same"          "[5000,5000,5000,5000,5000]"          0 1 0 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: chain_validate_constant_gas_limit predicate matches"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- New chain-level predicate `chain_validate_constant_gas_limit` verifies all headers in an N-element chain share the same `gas_limit` (field 9).
- Mirrors K229 / K230 / K240 chain-validator structure: writes `(is_valid, first_bad_index)` to two output slots.
- Vacuous-true on N <= 1.

## Test plan
- [x] `scripts/codegen-zisk-chain-validate-constant-gas-limit-check.sh` — 6 fixtures (empty / single / three_same / two violation cases / five_same) all pass.
- [x] `lake build codegen` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)