### PR TITLE
refactor(div): expose selected conditional max tail

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1V4CallMaxSelected.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1V4CallMaxSelected.lean
@@ -318,6 +318,56 @@ theorem divK_loop_n1_call_iter210_exact_x1_framed_v4_input_of_selected
       unfold loopN1CallMaxmaxmaxR2 at h
       exact h))
 
+/-- Bundled all-max tail after the first j=3 call-body step over the full
+    `divCode_v4` bundle, from selected-only input hypotheses, using
+    conditional max carry evidence for taken addback branches. -/
+theorem divK_loop_n1_call_iter210_exact_x1_framed_v4_input_of_selected_if_borrow
+    (I : LoopN1CallMaxmaxmaxExactInputs)
+    (hh : loopN1CallMaxmaxmaxSelectedInputHypotheses I) :
+    loopN1CallMaxmaxmaxIter210ExactInputSpecV4 I := by
+  unfold loopN1CallMaxmaxmaxIter210ExactInputSpecV4
+  let r3 := loopN1CallMaxmaxmaxR3 I.v0 I.v1 I.v2 I.v3 I.u0 I.u1 I.u2 I.u3 I.uTop
+  exact cpsTripleWithin_divCode_noNop_v4_to_divCode_v4
+    (divK_loop_n1_iter210_maxmaxmax_exact_x1_v4_noNop_selected_carry_if_borrow I.sp I.base
+    I.jOld I.v5Old I.v6Old I.v7Old I.v10Old I.v11Old I.v2Old
+    I.v0 I.v1 I.v2 I.v3
+    I.u0Orig2 r3.2.1 r3.2.2.1 r3.2.2.2.1 r3.2.2.2.2.1
+    I.u0Orig1 I.u0Orig0 I.q2Old I.q1Old I.q0Old
+    (I.base + div128CallRetOff) I.v0 (divKTrialCallV4DLo I.v0)
+    (divKTrialCallV4Un0 I.u0) I.raVal
+    (by
+      dsimp only [r3]
+      exact loopN1CallMaxmaxmaxSelectedInputHypotheses_hbltu2 I hh)
+    (by
+      dsimp only [r3]
+      have h := loopN1CallMaxmaxmaxSelectedInputHypotheses_hbltu1 I hh
+      unfold loopN1CallMaxmaxmaxR2 at h
+      exact h)
+    (by
+      dsimp only [r3]
+      have h := loopN1CallMaxmaxmaxSelectedInputHypotheses_hbltu0 I hh
+      unfold loopN1CallMaxmaxmaxR1 at h
+      unfold loopN1CallMaxmaxmaxR2 at h
+      exact h)
+    (by
+      dsimp only [r3]
+      have h := loopN1CallMaxmaxmaxSelectedInputHypotheses_carryIfBorrowMax2 I hh
+      unfold selectedN1MaxCarryIfBorrow at h
+      exact h)
+    (by
+      dsimp only [r3]
+      have h := loopN1CallMaxmaxmaxSelectedInputHypotheses_carryIfBorrowMax1 I hh
+      unfold loopN1CallMaxmaxmaxR2 at h
+      unfold selectedN1MaxCarryIfBorrow at h
+      exact h)
+    (by
+      dsimp only [r3]
+      have h := loopN1CallMaxmaxmaxSelectedInputHypotheses_carryIfBorrowMax0 I hh
+      unfold loopN1CallMaxmaxmaxR1 at h
+      unfold loopN1CallMaxmaxmaxR2 at h
+      unfold selectedN1MaxCarryIfBorrow at h
+      exact h))
+
 /-- Bundled framed all-max tail pre/post over the full `divCode_v4` bundle,
     from selected-only input hypotheses. -/
 theorem divK_loop_n1_call_iter210_framed_prepost_exact_x1_v4_input_of_selected


### PR DESCRIPTION
## Summary
- add a selected-call tail wrapper that uses conditional max carry evidence
- route selected `carryIfBorrow` projections into the conditional no-NOP max/max/max adapter
- keep the existing unconditional selected wrapper intact while preparing the framed/full selected-call path to switch over

## Verification
- lake build EvmAsm.Evm64.DivMod.Compose.FullPathN1V4CallMaxSelected
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/Compose/FullPathN1V4CallMaxSelected.lean
- lake build EvmAsm.Evm64.DivMod
- lake build