### PR TITLE
refactor(div): project N1 selected carry if-borrow

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N1ExactV4IfBorrow.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N1ExactV4IfBorrow.lean
@@ -248,6 +248,38 @@ theorem FullDivN1CallMaxmaxmaxSelectedIfBorrowSemanticEvidenceV4_of_selected
       hselected
   · exact hevidence.2
 
+/-- Compatibility projection: conditional selected-carry facts from the
+    existing selected semantic evidence package. -/
+theorem FullDivN1CallMaxmaxmaxSelectedSemanticEvidenceV4_selectedCarry_if_borrow
+    (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (q3Old q2Old q1Old q0Old retMem dMem dloMem scratchUn0 scratchMem raVal : Word)
+    (hevidence : FullDivN1CallMaxmaxmaxSelectedSemanticEvidenceV4 sp base
+      jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      a0 a1 a2 a3 b0 b1 b2 b3
+      q3Old q2Old q1Old q0Old retMem dMem dloMem scratchUn0 scratchMem raVal) :
+    loopN1CallMaxmaxmaxSelectedCarryIfBorrowFacts
+      (fullDivN1NormV b0 b1 b2 b3).1
+      (fullDivN1NormV b0 b1 b2 b3).2.1
+      (fullDivN1NormV b0 b1 b2 b3).2.2.1
+      (fullDivN1NormV b0 b1 b2 b3).2.2.2
+      (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1
+      (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
+      (0 : Word) (0 : Word) (0 : Word)
+      (fullDivN1NormU a0 a1 a2 a3 b0).2.2.1
+      (fullDivN1NormU a0 a1 a2 a3 b0).2.1
+      (fullDivN1NormU a0 a1 a2 a3 b0).1 := by
+  exact FullDivN1CallMaxmaxmaxSelectedIfBorrowSemanticEvidenceV4_selectedCarry
+    sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    a0 a1 a2 a3 b0 b1 b2 b3
+    q3Old q2Old q1Old q0Old retMem dMem dloMem scratchUn0 scratchMem raVal
+    (FullDivN1CallMaxmaxmaxSelectedIfBorrowSemanticEvidenceV4_of_selected
+      sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      a0 a1 a2 a3 b0 b1 b2 b3
+      q3Old q2Old q1Old q0Old retMem dMem dloMem scratchUn0 scratchMem raVal
+      hevidence)
+
 /-- Project the named hdiv package from existing selected semantic evidence,
     routing through the selected-if-borrow evidence bridge. -/
 theorem FullDivN1CallMaxmaxmaxHdivs_of_selected_semantic_evidence_if_borrow


### PR DESCRIPTION
## Summary
- add a compatibility projection from existing selected semantic evidence to conditional selected-if-borrow carry facts
- route through the selected-if-borrow semantic evidence bridge so old selected producers can expose the new carry surface

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.N1ExactV4IfBorrow
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/Spec/N1ExactV4IfBorrow.lean
- lake build EvmAsm.Evm64.DivMod
- lake build