### PR TITLE
refactor(div): route N1 selected facts stack projections

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N1ExactV4IfBorrow.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N1ExactV4IfBorrow.lean
@@ -858,15 +858,56 @@ theorem evm_div_n1_call_maxmaxmax_stack_spec_within_word_v4_preNoX1_callableExtr
           (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
           (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1
           (fullDivN1NormV b0 b1 b2 b3).1 scratchMem)) := by
-  exact evm_div_n1_call_maxmaxmax_stack_spec_within_word_v4_preNoX1_callableExtra_x9In_exactFrame_unified_of_selected_semantic_evidence_if_borrow
+  have hevidence : FullDivN1CallMaxmaxmaxSelectedSemanticEvidenceV4 sp base
+      jMem (1 : Word) (fullDivN1Shift b0) (fullDivN1NormU a0 a1 a2 a3 b0).1
+      (a0 >>> ((fullDivN1AntiShift b0).toNat % 64)) v11Old (fullDivN1AntiShift b0)
+      a0 a1 a2 a3 b0 b1 b2 b3
+      (0 : Word) (0 : Word) (0 : Word) (0 : Word)
+      retMem dMem dloMem scratchUn0 scratchMem raVal :=
+    ⟨hselected, hfacts⟩
+  obtain ⟨hbltu3, hbltu2, hbltu1, hbltu0⟩ :=
+    FullDivN1CallMaxmaxmaxSelectedSemanticEvidenceV4_branchFacts_if_borrow
+      sp base
+      jMem (1 : Word) (fullDivN1Shift b0) (fullDivN1NormU a0 a1 a2 a3 b0).1
+      (a0 >>> ((fullDivN1AntiShift b0).toNat % 64)) v11Old (fullDivN1AntiShift b0)
+      a0 a1 a2 a3 b0 b1 b2 b3
+      (0 : Word) (0 : Word) (0 : Word) (0 : Word)
+      retMem dMem dloMem scratchUn0 scratchMem raVal
+      hevidence
+  have hselectedInput :=
+    fullDivN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses_of_bltu_selected
+      sp base
+      jMem (1 : Word) (fullDivN1Shift b0) (fullDivN1NormU a0 a1 a2 a3 b0).1
+      (a0 >>> ((fullDivN1AntiShift b0).toNat % 64)) v11Old (fullDivN1AntiShift b0)
+      a0 a1 a2 a3 b0 b1 b2 b3
+      (0 : Word) (0 : Word) (0 : Word) (0 : Word)
+      retMem dMem dloMem scratchUn0 scratchMem raVal
+      hbltu3 hbltu2 hbltu1 hbltu0
+      (FullDivN1CallMaxmaxmaxSelectedSemanticEvidenceV4_selectedCarry_if_borrow
+        sp base
+        jMem (1 : Word) (fullDivN1Shift b0) (fullDivN1NormU a0 a1 a2 a3 b0).1
+        (a0 >>> ((fullDivN1AntiShift b0).toNat % 64)) v11Old (fullDivN1AntiShift b0)
+        a0 a1 a2 a3 b0 b1 b2 b3
+        (0 : Word) (0 : Word) (0 : Word) (0 : Word)
+        retMem dMem dloMem scratchUn0 scratchMem raVal
+        hevidence)
+  have hdivs :=
+    FullDivN1CallMaxmaxmaxHdivs_of_selected_semantic_facts_if_borrow
+      sp base a b
+      jMem (1 : Word) (fullDivN1Shift b0) (fullDivN1NormU a0 a1 a2 a3 b0).1
+      (a0 >>> ((fullDivN1AntiShift b0).toNat % 64)) v11Old (fullDivN1AntiShift b0)
+      a0 a1 a2 a3 b0 b1 b2 b3
+      (0 : Word) (0 : Word) (0 : Word) (0 : Word)
+      retMem dMem dloMem scratchUn0 scratchMem raVal
+      ha0 ha1 ha2 ha3 hb0 hb1 hb2 hb3 hbnz hselected hfacts
+  exact evm_div_n1_call_maxmaxmax_stack_spec_within_word_v4_preNoX1_callableExtra_x9In_exactFrame_unified_of_selected_if_borrow_input_hdivs
     sp base a b
     a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old x9In
     q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
     raVal
     ha0 ha1 ha2 ha3 hb0 hb1 hb2 hb3 hbnz hb3z hb2z hb1z
-    hshift_nz halign
-    ⟨hselected, hfacts⟩
+    hshift_nz halign hselectedInput hdivs
 
 /-- Full-v4 N1 stack wrapper from explicit branch facts, conditional selected
     carry facts, and semantic facts. -/


### PR DESCRIPTION
## Summary
- refactor the N1 selected-input plus semantic-facts stack wrapper to build selected-if-borrow input through named branch/carry projections
- delegate directly to the selected-if-borrow input+hdiv stack wrapper after constructing the hdiv package

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.N1ExactV4IfBorrow
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/Spec/N1ExactV4IfBorrow.lean
- lake build EvmAsm.Evm64.DivMod
- lake build