### PR TITLE
refactor(div): reuse N1 selected facts hdiv projection

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N1ExactV4IfBorrow.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N1ExactV4IfBorrow.lean
@@ -918,7 +918,7 @@ theorem evm_div_n1_call_maxmaxmax_stack_spec_within_word_v4_preNoX1_callableExtr
         retMem dMem dloMem scratchUn0 scratchMem raVal
         hevidence)
   have hdivs :=
-    FullDivN1CallMaxmaxmaxHdivs_of_selected_semantic_facts_if_borrow
+    FullDivN1CallMaxmaxmaxHdivs_of_selected_semantic_facts_if_borrow_projections
       sp base a b
       jMem (1 : Word) (fullDivN1Shift b0) (fullDivN1NormU a0 a1 a2 a3 b0).1
       (a0 >>> ((fullDivN1AntiShift b0).toNat % 64)) v11Old (fullDivN1AntiShift b0)


### PR DESCRIPTION
## Summary
- update the N1 selected semantic-facts stack wrapper to consume the projection-first hdiv adapter
- keep the wrapper surface unchanged while routing hdiv construction through the named projection layer

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.N1ExactV4IfBorrow
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/Spec/N1ExactV4IfBorrow.lean
- lake build EvmAsm.Evm64.DivMod
- lake build