### PR TITLE
refactor(div): project N1 selected branch facts

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N1ExactV4PathEvidence.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N1ExactV4PathEvidence.lean
@@ -96,6 +96,73 @@ theorem FullDivN1CallMaxmaxmaxSelectedSemanticEvidenceV4_of_path_evidence_getLim
       (N1AllTruePathEvidence.selectedCarryFacts hpath)
       hfacts
 
+/-- Project the explicit call/max/max/max branch facts from selected semantic
+    evidence. -/
+theorem FullDivN1CallMaxmaxmaxSelectedSemanticEvidenceV4_branchFacts
+    (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (q3Old q2Old q1Old q0Old retMem dMem dloMem scratchUn0 scratchMem raVal : Word)
+    (hevidence : FullDivN1CallMaxmaxmaxSelectedSemanticEvidenceV4 sp base
+      jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      a0 a1 a2 a3 b0 b1 b2 b3
+      q3Old q2Old q1Old q0Old retMem dMem dloMem scratchUn0 scratchMem raVal) :
+    isTrialN1_j3 true a3 b0 ∧
+    ¬BitVec.ult
+      (loopN1CallMaxmaxmaxR3
+        (fullDivN1NormV b0 b1 b2 b3).1
+        (fullDivN1NormV b0 b1 b2 b3).2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.2
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
+        0 0 0).2.1
+      (fullDivN1NormV b0 b1 b2 b3).1 ∧
+    ¬BitVec.ult
+      (loopN1CallMaxmaxmaxR2
+        (fullDivN1NormV b0 b1 b2 b3).1
+        (fullDivN1NormV b0 b1 b2 b3).2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.2
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
+        0 0 0
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.1).2.1
+      (fullDivN1NormV b0 b1 b2 b3).1 ∧
+    ¬BitVec.ult
+      (loopN1CallMaxmaxmaxR1
+        (fullDivN1NormV b0 b1 b2 b3).1
+        (fullDivN1NormV b0 b1 b2 b3).2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.2
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
+        0 0 0
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.1
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.1).2.1
+      (fullDivN1NormV b0 b1 b2 b3).1 := by
+  exact ⟨
+    fullDivN1CallMaxmaxmaxSelectedInputHypotheses_isTrial_j3
+      sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      a0 a1 a2 a3 b0 b1 b2 b3
+      q3Old q2Old q1Old q0Old retMem dMem dloMem scratchUn0 scratchMem raVal
+      hevidence.1,
+    fullDivN1CallMaxmaxmaxSelectedInputHypotheses_hbltu2
+      sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      a0 a1 a2 a3 b0 b1 b2 b3
+      q3Old q2Old q1Old q0Old retMem dMem dloMem scratchUn0 scratchMem raVal
+      hevidence.1,
+    fullDivN1CallMaxmaxmaxSelectedInputHypotheses_hbltu1
+      sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      a0 a1 a2 a3 b0 b1 b2 b3
+      q3Old q2Old q1Old q0Old retMem dMem dloMem scratchUn0 scratchMem raVal
+      hevidence.1,
+    fullDivN1CallMaxmaxmaxSelectedInputHypotheses_hbltu0
+      sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      a0 a1 a2 a3 b0 b1 b2 b3
+      q3Old q2Old q1Old q0Old retMem dMem dloMem scratchUn0 scratchMem raVal
+      hevidence.1⟩
+
 /-- Full-v4 N1 stack wrapper consuming all-true N1 path evidence plus the
     selected quotient-word equality, avoiding the heavier semantic-facts
     package at this layer. -/


### PR DESCRIPTION
Summary:
- add FullDivN1CallMaxmaxmaxSelectedSemanticEvidenceV4_branchFacts
- recover the explicit call/max/max/max branch facts from selected semantic evidence
- keep the projection in N1ExactV4PathEvidence instead of growing N1ExactV4

Verification:
- lake build EvmAsm.Evm64.DivMod.Spec.N1ExactV4PathEvidence
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth' touched Lean files (no matches)
- lake build EvmAsm.Evm64.DivMod
- lake build