### PR TITLE
refactor(div): project N1 selected facts hdivs

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N1ExactV4PathEvidence.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N1ExactV4PathEvidence.lean
@@ -191,6 +191,33 @@ theorem FullDivN1CallMaxmaxmaxHdivs_of_selected_semantic_evidence
   exact fullDivN1CallMaxmaxmaxHdivs_of_word_eq
     a b a0 a1 a2 a3 b0 b1 b2 b3 hword
 
+/-- Hdiv projection from selected input evidence plus semantic facts, keeping
+    consumers on the named hdiv package surface. -/
+theorem FullDivN1CallMaxmaxmaxHdivs_of_selected_semantic_facts
+    (sp base : Word) (a b : EvmWord)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (q3Old q2Old q1Old q0Old retMem dMem dloMem scratchUn0 scratchMem raVal : Word)
+    (ha0 : a.getLimbN 0 = a0) (ha1 : a.getLimbN 1 = a1)
+    (ha2 : a.getLimbN 2 = a2) (ha3 : a.getLimbN 3 = a3)
+    (hb0 : b.getLimbN 0 = b0) (hb1 : b.getLimbN 1 = b1)
+    (hb2 : b.getLimbN 2 = b2) (hb3 : b.getLimbN 3 = b3)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hselected : fullDivN1CallMaxmaxmaxSelectedInputHypotheses sp base
+      jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      a0 a1 a2 a3 b0 b1 b2 b3
+      q3Old q2Old q1Old q0Old retMem dMem dloMem scratchUn0 scratchMem raVal)
+    (hfacts : FullDivN1CallMaxmaxmaxSemanticFactsV4
+      a0 a1 a2 a3 b0 b1 b2 b3) :
+    FullDivN1CallMaxmaxmaxHdivs a b a0 a1 a2 a3 b0 b1 b2 b3 := by
+  exact FullDivN1CallMaxmaxmaxHdivs_of_selected_semantic_evidence
+    sp base a b
+    jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    a0 a1 a2 a3 b0 b1 b2 b3
+    q3Old q2Old q1Old q0Old retMem dMem dloMem scratchUn0 scratchMem raVal
+    ha0 ha1 ha2 ha3 hb0 hb1 hb2 hb3 hbnz
+    ⟨hselected, hfacts⟩
+
 /-- Project the named hdiv package from canonical limb inputs and reachable N1
     path evidence. -/
 theorem FullDivN1CallMaxmaxmaxHdivs_of_path_evidence_getLimbN


### PR DESCRIPTION
## Summary
- add a non-if-borrow hdiv projection for selected input evidence plus FullDivN1CallMaxmaxmaxSemanticFactsV4
- keep downstream consumers on the named FullDivN1CallMaxmaxmaxHdivs package surface

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.N1ExactV4PathEvidence
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/Spec/N1ExactV4PathEvidence.lean
- lake build EvmAsm.Evm64.DivMod
- lake build