### PR TITLE
feat(stateless): chain_compute_total_excess_blob_gas (PR-K276)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -327,6 +327,7 @@ def lookupProgramTail : String → Option BuildUnit
   | "zisk_chain_compute_min_excess_blob_gas" => some ziskChainComputeMinExcessBlobGasProbeUnit
   | "zisk_chain_validate_excess_blob_gas_non_decreasing" => some ziskChainValidateExcessBlobGasNonDecreasingProbeUnit
   | "zisk_chain_validate_excess_blob_gas_non_increasing" => some ziskChainValidateExcessBlobGasNonIncreasingProbeUnit
+  | "zisk_chain_compute_total_excess_blob_gas" => some ziskChainComputeTotalExcessBlobGasProbeUnit
   | "zisk_chain_extract_first_last_state_root" => some ziskChainExtractFirstLastStateRootProbeUnit
   | "zisk_chain_extract_first_last_block_hash" => some ziskChainExtractFirstLastBlockHashProbeUnit
   | "zisk_chain_extract_first_last_receipts_root" => some ziskChainExtractFirstLastReceiptsRootProbeUnit
@@ -776,6 +777,7 @@ def knownProgramNames : List String :=
    "zisk_chain_compute_min_excess_blob_gas",
    "zisk_chain_validate_excess_blob_gas_non_decreasing",
    "zisk_chain_validate_excess_blob_gas_non_increasing",
+   "zisk_chain_compute_total_excess_blob_gas",
    "zisk_chain_extract_first_last_state_root",
    "zisk_chain_extract_first_last_block_hash",
    "zisk_chain_extract_first_last_receipts_root",

--- a/EvmAsm/Codegen/Programs/ChainExcessBlobGas.lean
+++ b/EvmAsm/Codegen/Programs/ChainExcessBlobGas.lean
@@ -243,4 +243,109 @@ def ziskChainComputeMinExcessBlobGasProbeUnit : BuildUnit := {
   dataAsm     := ziskChainComputeMinExcessBlobGasDataSection
 }
 
+/-! ## chain_compute_total_excess_blob_gas -- PR-K276
+
+    Sum `excess_blob_gas` (header field 18, Cancun+) across an
+    N-element header chain. Sum counterpart to K272/K273
+    (max/min excess_blob_gas); mirrors K231
+    chain_compute_total_blob_gas (field 17) and K249
+    chain_compute_total_basefee (field 15).
+
+    Useful as a time-integrated blob-fee pressure metric:
+    dividing by N gives the average excess_blob_gas across the
+    window.
+
+    Pre-Cancun headers (<19 fields) yield parse-failure status
+    and the sum is the partial accumulator.
+
+    Vacuous on empty chain: sum = 0.
+
+    Calling convention:
+      a0 (input)  : N
+      a1 (input)  : header_lengths ptr (N u64 LE)
+      a2 (input)  : flat headers ptr
+      a3 (input)  : u64 out (total excess_blob_gas)
+      ra (input)  : return
+      a0 (output) :
+        0 : success
+        1 : RLP parse fail (pre-Cancun header in chain)
+        2 : excess_blob_gas field > 8 bytes BE -/
+def chainComputeTotalExcessBlobGasFunction : String :=
+  "chain_compute_total_excess_blob_gas:\n" ++
+  "  addi sp, sp, -48\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp); sd s4, 40(sp)\n" ++
+  "  mv s0, a0; mv s1, a1; mv s2, a2; mv s3, a3\n" ++
+  "  sd zero, 0(s3)\n" ++
+  "  li s4, 0\n" ++
+  "  beqz s0, .Lcctebg_done\n" ++
+  ".Lcctebg_loop:\n" ++
+  "  beq s4, s0, .Lcctebg_done\n" ++
+  "  slli t0, s4, 3\n" ++
+  "  add t0, s1, t0\n" ++
+  "  ld a1, 0(t0)\n" ++
+  "  mv a0, s2; li a2, 18\n" ++
+  "  la a3, cctebg_field\n" ++
+  "  jal ra, rlp_field_to_u64\n" ++
+  "  li t0, 1\n" ++
+  "  beq a0, t0, .Lcctebg_parse_fail\n" ++
+  "  li t0, 2\n" ++
+  "  beq a0, t0, .Lcctebg_size_fail\n" ++
+  "  la t0, cctebg_field; ld t1, 0(t0)\n" ++
+  "  ld t2, 0(s3); add t2, t2, t1; sd t2, 0(s3)\n" ++
+  "  slli t0, s4, 3\n" ++
+  "  add t0, s1, t0\n" ++
+  "  ld t1, 0(t0)\n" ++
+  "  add s2, s2, t1\n" ++
+  "  addi s4, s4, 1\n" ++
+  "  j .Lcctebg_loop\n" ++
+  ".Lcctebg_done:\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lcctebg_ret\n" ++
+  ".Lcctebg_parse_fail:\n" ++
+  "  li a0, 1\n" ++
+  "  j .Lcctebg_ret\n" ++
+  ".Lcctebg_size_fail:\n" ++
+  "  li a0, 2\n" ++
+  ".Lcctebg_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp); ld s4, 40(sp)\n" ++
+  "  addi sp, sp, 48\n" ++
+  "  ret"
+
+def ziskChainComputeTotalExcessBlobGasPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a7, 0x40000000\n" ++
+  "  ld a0, 8(a7)\n" ++
+  "  addi a1, a7, 16\n" ++
+  "  slli t0, a0, 3\n" ++
+  "  add a2, a1, t0\n" ++
+  "  li a3, 0xa0010010\n" ++
+  "  jal ra, chain_compute_total_excess_blob_gas\n" ++
+  "  li t0, 0xa0010008\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lcctebg_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpFieldToU64Function ++ "\n" ++
+  chainComputeTotalExcessBlobGasFunction ++ "\n" ++
+  ".Lcctebg_pdone:"
+
+def ziskChainComputeTotalExcessBlobGasDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  "rfu_offset:\n" ++
+  "  .zero 8\n" ++
+  "rfu_length:\n" ++
+  "  .zero 8\n" ++
+  "cctebg_field:\n" ++
+  "  .zero 8"
+
+def ziskChainComputeTotalExcessBlobGasProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskChainComputeTotalExcessBlobGasPrologue
+  dataAsm     := ziskChainComputeTotalExcessBlobGasDataSection
+}
+
 end EvmAsm.Codegen

--- a/scripts/codegen-zisk-chain-compute-total-excess-blob-gas-check.sh
+++ b/scripts/codegen-zisk-chain-compute-total-excess-blob-gas-check.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# codegen-zisk-chain-compute-total-excess-blob-gas-check.sh -- PR-K276.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_chain_compute_total_excess_blob_gas ELF"
+lake exe codegen --program zisk_chain_compute_total_excess_blob_gas --halt linux93 \
+  -o gen-out/zisk_chain_compute_total_excess_blob_gas
+
+REPO_ROOT="$(pwd)"
+
+run_case() {
+  local name="$1" vals="$2" exp_status="$3" exp_total="$4"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_chain_compute_total_excess_blob_gas_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_chain_compute_total_excess_blob_gas_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+def u_be(n):
+    if n == 0: return b''
+    return n.to_bytes((n.bit_length() + 7) // 8, 'big')
+
+def make_header(excess_blob_gas):
+    return rlp.encode([
+        b'\\xa1'*32, b'\\xa2'*32, b'\\xa3'*20, b'\\xa4'*32, b'\\xa5'*32,
+        b'\\xa6'*32, b'\\x00'*256, b'', b'\\x01', b'\\x83\\xff\\xff\\xff',
+        b'', b'\\x83\\x01\\x02\\x03', b'', b'\\xa7'*32, b'\\x00'*8,
+        b'\\x84\\x05\\xf5\\xe1\\x00', b'\\xa8'*32, b'',
+        u_be(excess_blob_gas), b'\\xa9'*32,
+    ])
+
+vals = $vals
+headers = [make_header(v) for v in vals]
+N = len(headers)
+lengths = b''.join(struct.pack('<Q', len(h)) for h in headers)
+flat = b''.join(headers)
+with open(sys.argv[1], 'wb') as f:
+    record = struct.pack('<Q', N) + lengths + flat
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_chain_compute_total_excess_blob_gas.elf \
+    -i "$in_file" -o "$out_file" -n 5000000 \
+    >"$REPO_ROOT/gen-out/zisk_chain_compute_total_excess_blob_gas_${name}.emu.log" 2>&1 || true
+
+  local s_le; s_le="$(dd if="$out_file" bs=1 skip=8  count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local t_le; t_le="$(dd if="$out_file" bs=1 skip=16 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local status total
+  status="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$s_le'))[0])")"
+  total="$( python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$t_le'))[0])")"
+
+  if [[ "$status" == "$exp_status" && "$total" == "$exp_total" ]]; then
+    printf "  %-26s OK   status=%s total=%s\n" "$name" "$status" "$total"
+    return 0
+  else
+    printf "  %-26s FAIL status=%s/%s total=%s/%s\n" "$name" "$status" "$exp_status" "$total" "$exp_total"
+    return 1
+  fi
+}
+
+FAILED=0
+run_case "empty"        "[]"                                 0 0       || FAILED=1
+run_case "single_zero"  "[0]"                                0 0       || FAILED=1
+run_case "single"       "[7864320]"                          0 7864320 || FAILED=1
+run_case "three_same"   "[1000, 1000, 1000]"                 0 3000    || FAILED=1
+run_case "three_mixed"  "[100, 200, 300]"                    0 600     || FAILED=1
+run_case "five_small"   "[100, 200, 300, 400, 500]"          0 1500    || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: chain_compute_total_excess_blob_gas sums excess_blob_gas across N"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- New aggregator `chain_compute_total_excess_blob_gas` sums `excess_blob_gas` (header field 18, Cancun+) across an N-element header chain.
- Sum counterpart to K272/K273 (max/min); mirrors K231/K249 by field.
- Lives in `Programs/ChainExcessBlobGas.lean`.

## Test plan
- [x] `scripts/codegen-zisk-chain-compute-total-excess-blob-gas-check.sh` — 6 fixtures pass.
- [x] `lake build codegen` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)