### PR TITLE
feat(stateless): header_extract_requests_hash (PR-K283)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -335,6 +335,7 @@ def lookupProgramTail : String → Option BuildUnit
   | "zisk_chain_compute_min_timestamp_gap" => some ziskChainComputeMinTimestampGapProbeUnit
   | "zisk_header_extract_parent_beacon_block_root" => some ziskHeaderExtractParentBeaconBlockRootProbeUnit
   | "zisk_chain_extract_first_last_parent_beacon_block_root" => some ziskChainExtractFirstLastParentBeaconBlockRootProbeUnit
+  | "zisk_header_extract_requests_hash" => some ziskHeaderExtractRequestsHashProbeUnit
   | "zisk_chain_extract_first_last_state_root" => some ziskChainExtractFirstLastStateRootProbeUnit
   | "zisk_chain_extract_first_last_block_hash" => some ziskChainExtractFirstLastBlockHashProbeUnit
   | "zisk_chain_extract_first_last_receipts_root" => some ziskChainExtractFirstLastReceiptsRootProbeUnit
@@ -791,6 +792,7 @@ def knownProgramNames : List String :=
    "zisk_chain_compute_min_timestamp_gap",
    "zisk_header_extract_parent_beacon_block_root",
    "zisk_chain_extract_first_last_parent_beacon_block_root",
+   "zisk_header_extract_requests_hash",
    "zisk_chain_extract_first_last_state_root",
    "zisk_chain_extract_first_last_block_hash",
    "zisk_chain_extract_first_last_receipts_root",

--- a/EvmAsm/Codegen/Programs/HeaderFields.lean
+++ b/EvmAsm/Codegen/Programs/HeaderFields.lean
@@ -977,4 +977,88 @@ def ziskHeaderExtractParentBeaconBlockRootProbeUnit : BuildUnit := {
   dataAsm     := ziskHeaderExtractParentBeaconBlockRootDataSection
 }
 
+/-! ## header_extract_requests_hash -- PR-K283
+
+    Extract `requests_hash` (header field 20, Prague+, 32 bytes)
+    from a header RLP and copy it to a caller-supplied 32-byte
+    output buffer. Per EIP-7685, this field commits to the
+    keccak256(sha256(req_0_data) ++ sha256(req_1_data) ++ ...)
+    of the per-request lists (deposits, withdrawals,
+    consolidations).
+
+    Pre-Prague headers (<21 fields) raise parse-failure status.
+
+    Calling convention:
+      a0 (input)  : header_rlp ptr
+      a1 (input)  : header_rlp byte length
+      a2 (input)  : 32-byte output ptr
+      ra (input)  : return
+      a0 (output) :
+        0 : success
+        1 : RLP parse failure / field 20 missing
+        2 : field 20 length != 32 -/
+def headerExtractRequestsHashFunction : String :=
+  "header_extract_requests_hash:\n" ++
+  "  addi sp, sp, -32\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp)\n" ++
+  "  mv s0, a0\n" ++
+  "  mv s1, a1\n" ++
+  "  mv s2, a2\n" ++
+  "  mv a0, s0; mv a1, s1; li a2, 20\n" ++
+  "  la a3, herh_offset; la a4, herh_length\n" ++
+  "  jal ra, rlp_list_nth_item\n" ++
+  "  bnez a0, .Lherh_parse_fail\n" ++
+  "  la t0, herh_length; ld t1, 0(t0)\n" ++
+  "  li t2, 32\n" ++
+  "  bne t1, t2, .Lherh_size_fail\n" ++
+  "  la t0, herh_offset; ld t1, 0(t0)\n" ++
+  "  add t3, s0, t1\n" ++
+  "  ld t4,  0(t3); sd t4,  0(s2)\n" ++
+  "  ld t4,  8(t3); sd t4,  8(s2)\n" ++
+  "  ld t4, 16(t3); sd t4, 16(s2)\n" ++
+  "  ld t4, 24(t3); sd t4, 24(s2)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lherh_ret\n" ++
+  ".Lherh_parse_fail:\n" ++
+  "  li a0, 1\n" ++
+  "  j .Lherh_ret\n" ++
+  ".Lherh_size_fail:\n" ++
+  "  li a0, 2\n" ++
+  ".Lherh_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp)\n" ++
+  "  addi sp, sp, 32\n" ++
+  "  ret"
+
+def ziskHeaderExtractRequestsHashPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a7, 0x40000000\n" ++
+  "  ld a1, 8(a7)                # header_rlp_len\n" ++
+  "  addi a0, a7, 16             # header_rlp ptr\n" ++
+  "  li a2, 0xa0010008           # 32 B output\n" ++
+  "  jal ra, header_extract_requests_hash\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lherh_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  headerExtractRequestsHashFunction ++ "\n" ++
+  ".Lherh_pdone:"
+
+def ziskHeaderExtractRequestsHashDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  "herh_offset:\n" ++
+  "  .zero 8\n" ++
+  "herh_length:\n" ++
+  "  .zero 8"
+
+def ziskHeaderExtractRequestsHashProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskHeaderExtractRequestsHashPrologue
+  dataAsm     := ziskHeaderExtractRequestsHashDataSection
+}
+
 end EvmAsm.Codegen

--- a/scripts/codegen-zisk-header-extract-requests-hash-check.sh
+++ b/scripts/codegen-zisk-header-extract-requests-hash-check.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# codegen-zisk-header-extract-requests-hash-check.sh -- PR-K283.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_header_extract_requests_hash ELF"
+lake exe codegen --program zisk_header_extract_requests_hash --halt linux93 \
+  -o gen-out/zisk_header_extract_requests_hash
+
+REPO_ROOT="$(pwd)"
+
+run_case() {
+  local name="$1" fields_count="$2" rh_hex="$3" exp_status="$4" exp_rh_hex="$5"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_header_extract_requests_hash_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_header_extract_requests_hash_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+fields_count = $fields_count
+rh_hex = '$rh_hex'
+rh = bytes.fromhex(rh_hex) if rh_hex else b''
+all_fields = [
+    b'\\xa1'*32, b'\\xa2'*32, b'\\xa3'*20, b'\\xa4'*32, b'\\xa5'*32,
+    b'\\xa6'*32, b'\\x00'*256, b'', b'\\x01', b'\\x83\\xff\\xff\\xff',
+    b'', b'\\x83\\x01\\x02\\x03', b'', b'\\xa7'*32, b'\\x00'*8,
+    b'\\x84\\x05\\xf5\\xe1\\x00', b'\\xa8'*32, b'',
+    b'\\x83\\x00\\x10\\x00', b'\\xab'*32, rh,
+][:fields_count]
+header = rlp.encode(all_fields)
+with open(sys.argv[1], 'wb') as f:
+    record = struct.pack('<Q', len(header)) + header
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_header_extract_requests_hash.elf \
+    -i "$in_file" -o "$out_file" -n 5000000 \
+    >"$REPO_ROOT/gen-out/zisk_header_extract_requests_hash_${name}.emu.log" 2>&1 || true
+
+  local s_le; s_le="$(dd if="$out_file" bs=1 skip=0 count=8  2>/dev/null | xxd -p | tr -d '\n')"
+  local actual_rh; actual_rh="$(dd if="$out_file" bs=1 skip=8 count=32 2>/dev/null | xxd -p | tr -d '\n')"
+  local status
+  status="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$s_le'))[0])")"
+
+  if [[ "$status" == "$exp_status" && "$actual_rh" == "$exp_rh_hex" ]]; then
+    printf "  %-32s OK   status=%s\n" "$name" "$status"
+    return 0
+  else
+    printf "  %-32s FAIL status=%s/%s rh=%s/%s\n" "$name" "$status" "$exp_status" "$actual_rh" "$exp_rh_hex"
+    return 1
+  fi
+}
+
+ZERO32="$(python3 -c "print('00'*32)")"
+NONZERO="$(python3 -c "print('dd'*32)")"
+MIXED="$(python3 -c "print('22'*16 + 'ee'*16)")"
+
+FAILED=0
+run_case "zero_rh"             21 "$ZERO32"  0 "$ZERO32"  || FAILED=1
+run_case "nonzero_rh"          21 "$NONZERO" 0 "$NONZERO" || FAILED=1
+run_case "mixed_rh"            21 "$MIXED"   0 "$MIXED"   || FAILED=1
+run_case "pre_prague_20"       20 "$ZERO32"  1 "$ZERO32"  || FAILED=1
+run_case "pre_prague_15"       15 "$ZERO32"  1 "$ZERO32"  || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: header_extract_requests_hash reads field 20"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- New extractor `header_extract_requests_hash` returns the 32-byte field 20 (Prague+, EIP-7685) from a header RLP.
- Pre-Prague headers raise parse-failure status.

## Test plan
- [x] `scripts/codegen-zisk-header-extract-requests-hash-check.sh` — 5 fixtures pass.
- [x] `lake build codegen` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)