### PR TITLE
refactor(div): add selected N3 quotient callable wrapper

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N3V4CallableExact.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3V4CallableExact.lean
@@ -483,6 +483,153 @@ theorem evm_div_n3_stack_spec_v4_preNoX1_callableExactFrame_selectedCarry_uni
       hbnz hb3z hb2nz hshift_nz halign hbltu_1 hbltu_0
       hcarry2_j1 hcarry2_j0 hdivWord
 
+/-- No-NOP callable wrapper using the selected path package for quotient
+    correctness while keeping the two selected carry facts explicit. -/
+theorem evm_div_n3_stack_spec_noNop_v4_preNoX1_callableExactFrame_selectedPathQuotient_uni
+    (bltu_1 bltu_0 : Bool) (sp base : Word)
+    (a b : EvmWord)
+    (v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (hbnz : b ≠ 0)
+    (hb3z : b.getLimbN 3 = 0) (hb2nz : b.getLimbN 2 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 2)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hcarry2_j0 :
+      match bltu_1 with
+      | false =>
+        let r1 := iterN3Max
+          (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1
+          (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.1
+          (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+          (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+          (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+            (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.1
+          (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+            (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.1
+          (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+            (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.1
+          (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+            (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+          (0 : Word)
+        if bltu_0 then
+          loopBodyN3CallAddbackCarry2NzV4
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).1
+            r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+        else
+          isAddbackCarry2NzN3Max
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).1
+            r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+      | true =>
+        let r1 := iterWithDoubleAddback
+          (divKTrialCallV4QHat
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.1)
+          (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1
+          (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.1
+          (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+          (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+          (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+            (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.1
+          (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+            (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.1
+          (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+            (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.1
+          (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+            (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+          (0 : Word)
+        if bltu_0 then
+          loopBodyN3CallAddbackCarry2NzV4
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).1
+            r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+        else
+          isAddbackCarry2NzN3Max
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).1
+            r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1)
+    (hcarry2_j1 :
+      if bltu_1 then
+        loopBodyN3CallAddbackCarry2NzV4
+          (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1
+          (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.1
+          (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+          (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+          (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+            (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.1
+          (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+            (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.1
+          (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+            (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.1
+          (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+            (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+          (0 : Word)
+      else
+        isAddbackCarry2NzN3Max
+          (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1
+          (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.1
+          (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+          (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+          (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+            (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.1
+          (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+            (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.1
+          (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+            (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.1
+          (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+            (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+          (0 : Word))
+    (hpath : fullDivN3SelectedPathConditionsWordV4 bltu_1 bltu_0 a b) :
+    cpsTripleWithin unifiedDivBound base (base + nopOff) (divCode_noNop_v4 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult (b.getLimbN 2)).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divStackDispatchPostCallableExactFrame sp a b raVal
+        (signExtend12 4095 : Word) **
+       memOwn (sp + signExtend12 3936)) := by
+  have hbltu_1 := fullDivN3SelectedPathConditionsWordV4_trial_j1
+    bltu_1 bltu_0 a b hpath
+  have hbltu_0 := fullDivN3SelectedPathConditionsWordV4_trial_j0
+    bltu_1 bltu_0 a b hpath
+  exact evm_div_n3_stack_spec_noNop_v4_preNoX1_callableExactFrame_selectedCarry_uni
+    sp base a b
+    v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+    hbnz hb3z hb2nz hshift_nz halign hbltu_1
+    (by cases bltu_1 <;> simpa [isTrialN3V4_j0] using hbltu_0)
+    hcarry2_j1 hcarry2_j0
+    (fullDivN3QuotientWordV4_eq_div_of_selected_word_path_conditions_ne_zero
+      bltu_1 bltu_0 a b hbnz hpath)
+
 /-- Unified-bound n=3 DIV v4 body spec over `divCode_noNop_v4` with exact
     caller-framed `x1` and `x9` in the postcondition.  The v4 trial-call
     scratch cell at `sp + signExtend12 3936` is existentially closed in the


### PR DESCRIPTION
## Summary
- add a no-NOP N3 callable exact-frame wrapper that consumes the selected path package for quotient correctness
- keep the two branch-local selected carry facts explicit, with j0 ordered before j1 so the carry fact stays independent of the j1 proof
- compose through the existing selected-carry callable wrapper instead of attempting the blocked selected-package j0 carry conversion

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.N3V4CallableExact
- rg -n '\b(sorry|admit)\b|set_option maxHeartbeats|set_option maxRecDepth' EvmAsm/Evm64/DivMod/Spec/N3V4CallableExact.lean
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build EvmAsm.Evm64.DivMod
- lake build