### PR TITLE
refactor(div): name selected N3 j0 carry shapes

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V4.lean
@@ -155,6 +155,42 @@ def fullDivN3R1V4 (bltu_1 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
   iterN3V4 bltu_1 v.1 v.2.1 v.2.2.1 v.2.2.2
     u.2.1 u.2.2.1 u.2.2.2.1 u.2.2.2.2 (0 : Word)
 
+@[simp]
+theorem fullDivN3R1V4_false (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    fullDivN3R1V4 false a0 a1 a2 a3 b0 b1 b2 b3 =
+      iterN3Max
+        (fullDivN3NormV b0 b1 b2 b3).1
+        (fullDivN3NormV b0 b1 b2 b3).2.1
+        (fullDivN3NormV b0 b1 b2 b3).2.2.1
+        (fullDivN3NormV b0 b1 b2 b3).2.2.2
+        (fullDivN3NormU a0 a1 a2 a3 b2).2.1
+        (fullDivN3NormU a0 a1 a2 a3 b2).2.2.1
+        (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.1
+        (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.2
+        (0 : Word) := by
+  rw [fullDivN3R1V4, iterN3V4]
+  simp
+
+@[simp]
+theorem fullDivN3R1V4_true (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    fullDivN3R1V4 true a0 a1 a2 a3 b0 b1 b2 b3 =
+      iterWithDoubleAddback
+        (divKTrialCallV4QHat
+          (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.2
+          (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.1
+          (fullDivN3NormV b0 b1 b2 b3).2.2.1)
+        (fullDivN3NormV b0 b1 b2 b3).1
+        (fullDivN3NormV b0 b1 b2 b3).2.1
+        (fullDivN3NormV b0 b1 b2 b3).2.2.1
+        (fullDivN3NormV b0 b1 b2 b3).2.2.2
+        (fullDivN3NormU a0 a1 a2 a3 b2).2.1
+        (fullDivN3NormU a0 a1 a2 a3 b2).2.2.1
+        (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.1
+        (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.2
+        (0 : Word) := by
+  rw [fullDivN3R1V4, iterN3V4]
+  simp
+
 @[irreducible]
 def fullDivN3R0V4 (bltu_1 bltu_0 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
     Word × Word × Word × Word × Word × Word :=

--- a/EvmAsm/Evm64/DivMod/Spec/N3QuotientStackBridge.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3QuotientStackBridge.lean
@@ -284,6 +284,104 @@ theorem fullDivN3SelectedPathConditionsWordV4_carry_j0
     (fullDivN3SelectedPathConditionsWordV4_selectedCarry
       bltu_1 bltu_0 a b hpath)
 
+/-- Expanded selected n=3 carry component for the `j=0` loop iteration.
+    This is the older stack-wrapper shape, where the `j=1` intermediate state
+    is exposed by case-splitting on the first trial branch. -/
+abbrev fullDivN3SelectedCarryJ0ExpandedWordV4
+    (bltu_1 bltu_0 : Bool) (a b : EvmWord) : Prop :=
+  match bltu_1 with
+  | false =>
+    let r1 := iterN3Max
+      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1
+      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.1
+      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+      (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+        (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.1
+      (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+        (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.1
+      (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+        (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.1
+      (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+        (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+      (0 : Word)
+    if bltu_0 then
+      loopBodyN3CallAddbackCarry2NzV4
+        (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1
+        (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.1
+        (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+        (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+        (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).1
+        r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+    else
+      isAddbackCarry2NzN3Max
+        (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1
+        (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.1
+        (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+        (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+        (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).1
+        r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+  | true =>
+    let r1 := iterWithDoubleAddback
+      (divKTrialCallV4QHat
+        (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+        (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.1
+        (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1)
+      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1
+      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.1
+      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+      (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+      (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+        (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.1
+      (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+        (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.1
+      (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+        (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.1
+      (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+        (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+      (0 : Word)
+    if bltu_0 then
+      loopBodyN3CallAddbackCarry2NzV4
+        (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1
+        (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.1
+        (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+        (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+        (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).1
+        r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+    else
+      isAddbackCarry2NzN3Max
+        (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1
+        (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.1
+        (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+        (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+        (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).1
+        r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+
+/-- `fullDivN3R1V4`-shaped selected n=3 carry component for the `j=0`
+    loop iteration. This is the shape projected from the selected path
+    package. -/
+abbrev fullDivN3SelectedCarryJ0R1WordV4
+    (bltu_1 bltu_0 : Bool) (a b : EvmWord) : Prop :=
+  let v := fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+    (b.getLimbN 2) (b.getLimbN 3)
+  let u := fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+    (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)
+  let r1 := fullDivN3R1V4 bltu_1
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+  if bltu_0 then
+    loopBodyN3CallAddbackCarry2NzV4 v.1 v.2.1 v.2.2.1 v.2.2.2
+      u.1 r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+  else
+    isAddbackCarry2NzN3Max v.1 v.2.1 v.2.2.1 v.2.2.2
+      u.1 r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+
 /-- Project the first v4 N3 trial-branch witness from the selected-carry word path. -/
 theorem fullDivN3SelectedPathConditionsWordV4_trial_j1
     (bltu_1 bltu_0 : Bool) (a b : EvmWord)


### PR DESCRIPTION
## Summary
- add branch equations for fullDivN3R1V4 false and fullDivN3R1V4 true
- name the expanded stack-wrapper and fullDivN3R1V4 selected N3 j0 carry shapes
- prepare the N3 selected-path package adapter work without adding a costly direct conversion theorem

## Notes
- I retried the direct polymorphic adapter from fullDivN3SelectedCarryJ0R1WordV4 to fullDivN3SelectedCarryJ0ExpandedWordV4; it still timed out at whnf on the theorem boundary / simplification under the default heartbeat limit. This PR keeps the cheap, reusable setup only.

## Verification
- lake build EvmAsm.Evm64.DivMod.Compose.FullPathN3V4
- lake build EvmAsm.Evm64.DivMod.Spec.N3QuotientStackBridge
- forbidden shortcut scan on touched files
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build EvmAsm.Evm64.DivMod
- lake build