### PR TITLE
refactor(div): add R1-shaped N3 loop instantiation

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V4NoNopMaxCall.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V4NoNopMaxCall.lean
@@ -748,6 +748,53 @@ theorem evm_div_n3_loop_unified_inst_noNop_exact_x1_v4_selectedCarry
       retMem dMem dloMem scratchUn0 scratchMem
       halign hbltu_1 hbltu_0 hcarry2_j1 hcarry2_j0
 
+/-- R1-shaped selected-carry instantiation helper for the v4 no-NOP exact-`x1`
+    n=3 loop. This keeps the `j=0` carry premise in the same `iterN3V4`
+    shape used by the selected path package. -/
+theorem evm_div_n3_loop_unified_inst_noNop_exact_x1_v4_selectedCarryR1
+    (bltu_1 bltu_0 : Bool) (sp base : Word)
+    (shift antiShift b0' b1' b2' b3' u0 u1 u2 u3 u4 : Word)
+    (v10Old v11Old jMem : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem raVal : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_1 : bltu_1 = BitVec.ult u4 b2')
+    (hbltu_0 : bltu_0 =
+      match bltu_1 with
+      | false => BitVec.ult (iterN3Max b0' b1' b2' b3' u1 u2 u3 u4 (0 : Word)).2.2.2.1 b2'
+      | true =>
+        BitVec.ult
+          (iterWithDoubleAddback (divKTrialCallV4QHat u4 u3 b2')
+            b0' b1' b2' b3' u1 u2 u3 u4 (0 : Word)).2.2.2.1 b2')
+    (hcarry2_j1 :
+      if bltu_1 then
+        loopBodyN3CallAddbackCarry2NzV4 b0' b1' b2' b3' u1 u2 u3 u4 (0 : Word)
+      else
+        isAddbackCarry2NzN3Max b0' b1' b2' b3' u1 u2 u3 u4 (0 : Word))
+    (hcarry2_j0 :
+      let r1 := iterN3V4 bltu_1 b0' b1' b2' b3' u1 u2 u3 u4 (0 : Word)
+      if bltu_0 then
+        loopBodyN3CallAddbackCarry2NzV4 b0' b1' b2' b3'
+          u0 r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+      else
+        isAddbackCarry2NzN3Max b0' b1' b2' b3'
+          u0 r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1) :
+    cpsTripleWithin 448 (base + loopBodyOff) (base + denormOff) (divCode_noNop_v4 base)
+      (loopN3PreWithScratchV4NoX1 sp jMem (3 : Word) shift u0 v10Old v11Old antiShift
+        b0' b1' b2' b3' u1 u2 u3 u4 (0 : Word) u0 (0 : Word) (0 : Word)
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal))
+      (loopN3UnifiedPostV4NoX1 bltu_1 bltu_0 sp base
+        b0' b1' b2' b3' u1 u2 u3 u4 (0 : Word) u0
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal)) :=
+  divK_loop_n3_unified_from_source_exact_loopIterScratch_v4_noNop_selectedCarryR1
+    bltu_1 bltu_0 sp base
+    jMem (3 : Word) shift u0 v10Old v11Old antiShift
+    b0' b1' b2' b3' u1 u2 u3 u4 (0 : Word) u0 (0 : Word) (0 : Word) raVal
+    retMem dMem dloMem scratchUn0 scratchMem
+    halign hbltu_1 hbltu_0 hcarry2_j1 hcarry2_j0
+
 /-- Handoff from the n=3 preloop postcondition to the v4 no-`x1` loop source,
     preserving caller-owned `x1` and the v4 div128 scratch cell. -/
 theorem loopSetupPost_to_loopN3PreWithScratchV4NoX1_framed


### PR DESCRIPTION
## Summary
- add evm_div_n3_loop_unified_inst_noNop_exact_x1_v4_selectedCarryR1
- keep the j0 carry premise in iterN3V4/R1 shape at the explicit-normalized loop-instantiation layer
- compose through the lower selectedCarryR1 loop wrapper from the parent branch

## Verification
- lake build EvmAsm.Evm64.DivMod.Compose.FullPathN3V4NoNopMaxCall
- forbidden shortcut scan on touched file
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build EvmAsm.Evm64.DivMod
- lake build