### PR TITLE
feat(stateless): chain_extract_first_last_requests_hash (PR-K284)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -336,6 +336,7 @@ def lookupProgramTail : String → Option BuildUnit
   | "zisk_header_extract_parent_beacon_block_root" => some ziskHeaderExtractParentBeaconBlockRootProbeUnit
   | "zisk_chain_extract_first_last_parent_beacon_block_root" => some ziskChainExtractFirstLastParentBeaconBlockRootProbeUnit
   | "zisk_header_extract_requests_hash" => some ziskHeaderExtractRequestsHashProbeUnit
+  | "zisk_chain_extract_first_last_requests_hash" => some ziskChainExtractFirstLastRequestsHashProbeUnit
   | "zisk_chain_extract_first_last_state_root" => some ziskChainExtractFirstLastStateRootProbeUnit
   | "zisk_chain_extract_first_last_block_hash" => some ziskChainExtractFirstLastBlockHashProbeUnit
   | "zisk_chain_extract_first_last_receipts_root" => some ziskChainExtractFirstLastReceiptsRootProbeUnit
@@ -793,6 +794,7 @@ def knownProgramNames : List String :=
    "zisk_header_extract_parent_beacon_block_root",
    "zisk_chain_extract_first_last_parent_beacon_block_root",
    "zisk_header_extract_requests_hash",
+   "zisk_chain_extract_first_last_requests_hash",
    "zisk_chain_extract_first_last_state_root",
    "zisk_chain_extract_first_last_block_hash",
    "zisk_chain_extract_first_last_receipts_root",

--- a/EvmAsm/Codegen/Programs/ChainEndpoints.lean
+++ b/EvmAsm/Codegen/Programs/ChainEndpoints.lean
@@ -820,4 +820,106 @@ def ziskChainExtractFirstLastParentBeaconBlockRootProbeUnit : BuildUnit := {
   dataAsm     := ziskChainExtractFirstLastParentBeaconBlockRootDataSection
 }
 
+/-! ## chain_extract_first_last_requests_hash -- PR-K284
+
+    Extract `(headers[0].requests_hash, headers[N-1].requests_hash)`
+    from an N-element header chain. EIP-7685 / Prague+
+    endpoint: useful for proving execution-layer request bundles
+    are referenced at both ends of a chain segment.
+
+    Composes K283 `header_extract_requests_hash`
+    (HeaderFields.lean) at the head and tail headers; mirrors
+    K282 `chain_extract_first_last_parent_beacon_block_root` in
+    shape.
+
+    Pre-Prague headers (<21 fields) raise parse-failure status.
+
+    Calling convention:
+      a0 (input)  : N (header count, must be >= 1)
+      a1 (input)  : header_lengths ptr
+      a2 (input)  : headers ptr
+      a3 (input)  : 32-byte out (first_requests_hash)
+      a4 (input)  : 32-byte out (last_requests_hash)
+      ra (input)  : return
+      a0 (output) :
+        0 : success
+        1 : empty chain (N == 0)
+        2 : RLP parse fail at head or tail header -/
+def chainExtractFirstLastRequestsHashFunction : String :=
+  "chain_extract_first_last_requests_hash:\n" ++
+  "  addi sp, sp, -48\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp); sd s4, 40(sp)\n" ++
+  "  mv s0, a0; mv s1, a1; mv s2, a2; mv s3, a3; mv s4, a4\n" ++
+  "  beqz s0, .Lceflrh_empty\n" ++
+  "  # first = headers[0].requests_hash\n" ++
+  "  ld a1, 0(s1)\n" ++
+  "  mv a0, s2\n" ++
+  "  mv a2, s3\n" ++
+  "  jal ra, header_extract_requests_hash\n" ++
+  "  bnez a0, .Lceflrh_parse_fail\n" ++
+  "  # Advance to last header\n" ++
+  "  mv t1, s2\n" ++
+  "  mv t2, s1\n" ++
+  "  addi t3, s0, -1\n" ++
+  ".Lceflrh_skip:\n" ++
+  "  beqz t3, .Lceflrh_at_last\n" ++
+  "  ld t4, 0(t2)\n" ++
+  "  add t1, t1, t4\n" ++
+  "  addi t2, t2, 8\n" ++
+  "  addi t3, t3, -1\n" ++
+  "  j .Lceflrh_skip\n" ++
+  ".Lceflrh_at_last:\n" ++
+  "  ld a1, 0(t2)\n" ++
+  "  mv a0, t1\n" ++
+  "  mv a2, s4\n" ++
+  "  jal ra, header_extract_requests_hash\n" ++
+  "  bnez a0, .Lceflrh_parse_fail\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lceflrh_ret\n" ++
+  ".Lceflrh_empty:\n" ++
+  "  li a0, 1\n" ++
+  "  j .Lceflrh_ret\n" ++
+  ".Lceflrh_parse_fail:\n" ++
+  "  li a0, 2\n" ++
+  ".Lceflrh_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp); ld s4, 40(sp)\n" ++
+  "  addi sp, sp, 48\n" ++
+  "  ret"
+
+def ziskChainExtractFirstLastRequestsHashPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a7, 0x40000000\n" ++
+  "  ld a0, 8(a7)\n" ++
+  "  addi a1, a7, 16\n" ++
+  "  slli t0, a0, 3\n" ++
+  "  add a2, a1, t0\n" ++
+  "  li a3, 0xa0010008\n" ++
+  "  li a4, 0xa0010028\n" ++
+  "  jal ra, chain_extract_first_last_requests_hash\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lceflrh_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  headerExtractRequestsHashFunction ++ "\n" ++
+  chainExtractFirstLastRequestsHashFunction ++ "\n" ++
+  ".Lceflrh_pdone:"
+
+def ziskChainExtractFirstLastRequestsHashDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  "herh_offset:\n" ++
+  "  .zero 8\n" ++
+  "herh_length:\n" ++
+  "  .zero 8"
+
+def ziskChainExtractFirstLastRequestsHashProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskChainExtractFirstLastRequestsHashPrologue
+  dataAsm     := ziskChainExtractFirstLastRequestsHashDataSection
+}
+
 end EvmAsm.Codegen

--- a/scripts/codegen-zisk-chain-extract-first-last-requests-hash-check.sh
+++ b/scripts/codegen-zisk-chain-extract-first-last-requests-hash-check.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# codegen-zisk-chain-extract-first-last-requests-hash-check.sh -- PR-K284.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_chain_extract_first_last_requests_hash ELF"
+lake exe codegen --program zisk_chain_extract_first_last_requests_hash --halt linux93 \
+  -o gen-out/zisk_chain_extract_first_last_requests_hash
+
+REPO_ROOT="$(pwd)"
+
+run_case() {
+  local name="$1" rhs_list="$2" exp_status="$3" exp_first_hex="$4" exp_last_hex="$5"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_chain_extract_first_last_requests_hash_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_chain_extract_first_last_requests_hash_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+rhs = $rhs_list
+def make_header(rh_hex):
+    rh = bytes.fromhex(rh_hex)
+    return rlp.encode([
+        b'\\xa1'*32, b'\\xa2'*32, b'\\xa3'*20, b'\\xa4'*32, b'\\xa5'*32,
+        b'\\xa6'*32, b'\\x00'*256, b'', b'\\x01', b'\\x83\\xff\\xff\\xff',
+        b'', b'\\x83\\x01\\x02\\x03', b'', b'\\xa7'*32, b'\\x00'*8,
+        b'\\x84\\x05\\xf5\\xe1\\x00', b'\\xa8'*32, b'',
+        b'\\x83\\x00\\x10\\x00', b'\\xab'*32, rh,
+    ])
+
+headers = [make_header(p) for p in rhs]
+N = len(headers)
+lengths = b''.join(struct.pack('<Q', len(h)) for h in headers)
+flat = b''.join(headers)
+with open(sys.argv[1], 'wb') as f:
+    record = struct.pack('<Q', N) + lengths + flat
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_chain_extract_first_last_requests_hash.elf \
+    -i "$in_file" -o "$out_file" -n 5000000 \
+    >"$REPO_ROOT/gen-out/zisk_chain_extract_first_last_requests_hash_${name}.emu.log" 2>&1 || true
+
+  local s_le; s_le="$(dd if="$out_file" bs=1 skip=0  count=8  2>/dev/null | xxd -p | tr -d '\n')"
+  local actual_first; actual_first="$(dd if="$out_file" bs=1 skip=8 count=32  2>/dev/null | xxd -p | tr -d '\n')"
+  local actual_last;  actual_last="$( dd if="$out_file" bs=1 skip=40 count=32 2>/dev/null | xxd -p | tr -d '\n')"
+  local status
+  status="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$s_le'))[0])")"
+
+  if [[ "$status" == "$exp_status" && "$actual_first" == "$exp_first_hex" && "$actual_last" == "$exp_last_hex" ]]; then
+    printf "  %-32s OK   status=%s\n" "$name" "$status"
+    return 0
+  else
+    printf "  %-32s FAIL status=%s/%s first=%s/%s last=%s/%s\n" "$name" "$status" "$exp_status" "$actual_first" "$exp_first_hex" "$actual_last" "$exp_last_hex"
+    return 1
+  fi
+}
+
+ZERO32="$(python3 -c "print('00'*32)")"
+A32="$(python3 -c "print('dd'*32)")"
+B32="$(python3 -c "print('ee'*32)")"
+C32="$(python3 -c "print('ff'*32)")"
+
+FAILED=0
+run_case "empty"        "[]"                       1 "$ZERO32" "$ZERO32" || FAILED=1
+run_case "single"       "['$A32']"                 0 "$A32"    "$A32"    || FAILED=1
+run_case "two"          "['$A32', '$B32']"         0 "$A32"    "$B32"    || FAILED=1
+run_case "three"        "['$A32', '$B32', '$C32']" 0 "$A32"    "$C32"    || FAILED=1
+run_case "single_zero"  "['$ZERO32']"              0 "$ZERO32" "$ZERO32" || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: chain_extract_first_last_requests_hash returns (first, last)"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- New chain-level extractor `chain_extract_first_last_requests_hash` returns `(headers[0].requests_hash, headers[N-1].requests_hash)` (field 20, Prague+, EIP-7685).
- Composes K283 `header_extract_requests_hash`; mirrors K282 in shape.
- Pre-Prague headers raise parse-failure.

## Test plan
- [x] `scripts/codegen-zisk-chain-extract-first-last-requests-hash-check.sh` — 5 fixtures pass.
- [x] `lake build codegen` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)