### PR TITLE
refactor(div): add R1-shaped N3 preloop wrapper

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V4NoNopPreloop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V4NoNopPreloop.lean
@@ -696,4 +696,253 @@ theorem fullDivN3_preloop_loop_unified_exact_x1_scratch_v4_noNop_selectedCarry
     (fun h hq => hq)
     hFull
 
+/-- Opaque preloop-level `j=0` selected-carry premise in the same R1 shape as
+    `fullDivN3R1V4`.  Keeping this proposition irreducible avoids theorem-type
+    normalization of the full expanded normalized-DIV expression. -/
+@[irreducible] def fullDivN3PreloopSelectedCarryJ0R1V4
+    (bltu_1 bltu_0 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Prop :=
+  let r1 := iterN3V4 bltu_1
+    (fullDivN3NormV b0 b1 b2 b3).1
+    (fullDivN3NormV b0 b1 b2 b3).2.1
+    (fullDivN3NormV b0 b1 b2 b3).2.2.1
+    (fullDivN3NormV b0 b1 b2 b3).2.2.2
+    (fullDivN3NormU a0 a1 a2 a3 b2).2.1
+    (fullDivN3NormU a0 a1 a2 a3 b2).2.2.1
+    (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.1
+    (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.2
+    (0 : Word)
+  if bltu_0 then
+    loopBodyN3CallAddbackCarry2NzV4
+      (fullDivN3NormV b0 b1 b2 b3).1
+      (fullDivN3NormV b0 b1 b2 b3).2.1
+      (fullDivN3NormV b0 b1 b2 b3).2.2.1
+      (fullDivN3NormV b0 b1 b2 b3).2.2.2
+      (fullDivN3NormU a0 a1 a2 a3 b2).1
+      r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+  else
+    isAddbackCarry2NzN3Max
+      (fullDivN3NormV b0 b1 b2 b3).1
+      (fullDivN3NormV b0 b1 b2 b3).2.1
+      (fullDivN3NormV b0 b1 b2 b3).2.2.1
+      (fullDivN3NormV b0 b1 b2 b3).2.2.2
+      (fullDivN3NormU a0 a1 a2 a3 b2).1
+      r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+
+/-- R1-shaped selected-carry variant of
+    `fullDivN3_preloop_loop_unified_exact_x1_scratch_v4_noNop_selectedCarry`.
+    This keeps the `j=0` carry premise in the same `iterN3V4` shape used by
+    `fullDivN3R1V4`, avoiding the expanded match-shaped theorem boundary. -/
+theorem fullDivN3_preloop_loop_unified_exact_x1_scratch_v4_noNop_selectedCarryR1
+    (bltu_1 bltu_0 : Bool) (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem : Word)
+    (jMem retMem dMem dloMem scratchUn0 scratchMem raVal : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2nz : b2 ≠ 0)
+    (hshift_nz : (clzResult b2).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_1 : bltu_1 =
+      BitVec.ult (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.2
+        (fullDivN3NormV b0 b1 b2 b3).2.2.1)
+    (hbltu_0 : bltu_0 =
+      match bltu_1, hbltu_1 with
+      | false, _ =>
+        BitVec.ult
+          (iterN3Max (fullDivN3NormV b0 b1 b2 b3).1
+            (fullDivN3NormV b0 b1 b2 b3).2.1
+            (fullDivN3NormV b0 b1 b2 b3).2.2.1
+            (fullDivN3NormV b0 b1 b2 b3).2.2.2
+            (fullDivN3NormU a0 a1 a2 a3 b2).2.1
+            (fullDivN3NormU a0 a1 a2 a3 b2).2.2.1
+            (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.1
+            (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.2
+            (0 : Word)).2.2.2.1
+          (fullDivN3NormV b0 b1 b2 b3).2.2.1
+      | true, _ =>
+        BitVec.ult
+          (iterWithDoubleAddback
+            (divKTrialCallV4QHat
+              (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.2
+              (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.1
+              (fullDivN3NormV b0 b1 b2 b3).2.2.1)
+            (fullDivN3NormV b0 b1 b2 b3).1
+            (fullDivN3NormV b0 b1 b2 b3).2.1
+            (fullDivN3NormV b0 b1 b2 b3).2.2.1
+            (fullDivN3NormV b0 b1 b2 b3).2.2.2
+            (fullDivN3NormU a0 a1 a2 a3 b2).2.1
+            (fullDivN3NormU a0 a1 a2 a3 b2).2.2.1
+            (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.1
+            (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.2
+            (0 : Word)).2.2.2.1
+          (fullDivN3NormV b0 b1 b2 b3).2.2.1)
+    (hcarry2_j1 :
+      if bltu_1 then
+        loopBodyN3CallAddbackCarry2NzV4
+          (fullDivN3NormV b0 b1 b2 b3).1
+          (fullDivN3NormV b0 b1 b2 b3).2.1
+          (fullDivN3NormV b0 b1 b2 b3).2.2.1
+          (fullDivN3NormV b0 b1 b2 b3).2.2.2
+          (fullDivN3NormU a0 a1 a2 a3 b2).2.1
+          (fullDivN3NormU a0 a1 a2 a3 b2).2.2.1
+          (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.1
+          (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.2
+          (0 : Word)
+      else
+        isAddbackCarry2NzN3Max
+          (fullDivN3NormV b0 b1 b2 b3).1
+          (fullDivN3NormV b0 b1 b2 b3).2.1
+          (fullDivN3NormV b0 b1 b2 b3).2.2.1
+          (fullDivN3NormV b0 b1 b2 b3).2.2.2
+          (fullDivN3NormU a0 a1 a2 a3 b2).2.1
+          (fullDivN3NormU a0 a1 a2 a3 b2).2.2.1
+          (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.1
+          (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.2
+          (0 : Word))
+    (hcarry2_j0 :
+      fullDivN3PreloopSelectedCarryJ0R1V4 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 448) base (base + denormOff)
+      (divCode_noNop_v4 base)
+      (((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
+        (.x9 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+        ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+        ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+        ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+        ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+        ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+        ((sp + signExtend12 4024) ↦ₘ u4Old) **
+        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+        ((sp + signExtend12 3992) ↦ₘ shiftMem)) **
+       ((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
+        (sp + signExtend12 3968 ↦ₘ retMem) **
+        (sp + signExtend12 3960 ↦ₘ dMem) **
+        (sp + signExtend12 3952 ↦ₘ dloMem) **
+        (sp + signExtend12 3944 ↦ₘ scratchUn0) **
+        (sp + signExtend12 3936 ↦ₘ scratchMem) **
+        (.x1 ↦ᵣ raVal)))
+      ((loopN3UnifiedPostV4NoX1 bltu_1 bltu_0 sp base
+        (fullDivN3NormV b0 b1 b2 b3).1
+        (fullDivN3NormV b0 b1 b2 b3).2.1
+        (fullDivN3NormV b0 b1 b2 b3).2.2.1
+        (fullDivN3NormV b0 b1 b2 b3).2.2.2
+        (fullDivN3NormU a0 a1 a2 a3 b2).2.1
+        (fullDivN3NormU a0 a1 a2 a3 b2).2.2.1
+        (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.1
+        (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.2
+        (0 : Word)
+        (fullDivN3NormU a0 a1 a2 a3 b2).1
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal)) **
+       (((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+        ((sp + signExtend12 4072) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 3992) ↦ₘ (clzResult b2).1))) := by
+  have hPre := evm_div_n3_to_loopSetup_spec_within_v4_noNop_exact_x1_scratch_frame
+    sp base a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem
+    jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+    hbnz hb3z hb2nz hshift_nz
+  have hcarry2_j0' :
+      let r1 := iterN3V4 bltu_1
+        (fullDivN3NormV b0 b1 b2 b3).1
+        (fullDivN3NormV b0 b1 b2 b3).2.1
+        (fullDivN3NormV b0 b1 b2 b3).2.2.1
+        (fullDivN3NormV b0 b1 b2 b3).2.2.2
+        (fullDivN3NormU a0 a1 a2 a3 b2).2.1
+        (fullDivN3NormU a0 a1 a2 a3 b2).2.2.1
+        (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.1
+        (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.2
+        (0 : Word)
+      if bltu_0 then
+        loopBodyN3CallAddbackCarry2NzV4
+          (fullDivN3NormV b0 b1 b2 b3).1
+          (fullDivN3NormV b0 b1 b2 b3).2.1
+          (fullDivN3NormV b0 b1 b2 b3).2.2.1
+          (fullDivN3NormV b0 b1 b2 b3).2.2.2
+          (fullDivN3NormU a0 a1 a2 a3 b2).1
+          r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+      else
+        isAddbackCarry2NzN3Max
+          (fullDivN3NormV b0 b1 b2 b3).1
+          (fullDivN3NormV b0 b1 b2 b3).2.1
+          (fullDivN3NormV b0 b1 b2 b3).2.2.1
+          (fullDivN3NormV b0 b1 b2 b3).2.2.2
+          (fullDivN3NormU a0 a1 a2 a3 b2).1
+          r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 := by
+    rw [fullDivN3PreloopSelectedCarryJ0R1V4] at hcarry2_j0
+    exact hcarry2_j0
+  have hLoop :
+      cpsTripleWithin 448 (base + loopBodyOff) (base + denormOff) (divCode_noNop_v4 base)
+        (loopN3PreWithScratchV4NoX1 sp jMem (3 : Word)
+          (fullDivN3Shift b2) (fullDivN3NormU a0 a1 a2 a3 b2).1
+          (a0 >>> ((fullDivN3AntiShift b2).toNat % 64)) v11Old (fullDivN3AntiShift b2)
+          (fullDivN3NormV b0 b1 b2 b3).1
+          (fullDivN3NormV b0 b1 b2 b3).2.1
+          (fullDivN3NormV b0 b1 b2 b3).2.2.1
+          (fullDivN3NormV b0 b1 b2 b3).2.2.2
+          (fullDivN3NormU a0 a1 a2 a3 b2).2.1
+          (fullDivN3NormU a0 a1 a2 a3 b2).2.2.1
+          (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.1
+          (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.2
+          (0 : Word) (fullDivN3NormU a0 a1 a2 a3 b2).1
+          (0 : Word) (0 : Word) retMem dMem dloMem scratchUn0 scratchMem **
+          (.x1 ↦ᵣ raVal))
+        (loopN3UnifiedPostV4NoX1 bltu_1 bltu_0 sp base
+          (fullDivN3NormV b0 b1 b2 b3).1
+          (fullDivN3NormV b0 b1 b2 b3).2.1
+          (fullDivN3NormV b0 b1 b2 b3).2.2.1
+          (fullDivN3NormV b0 b1 b2 b3).2.2.2
+          (fullDivN3NormU a0 a1 a2 a3 b2).2.1
+          (fullDivN3NormU a0 a1 a2 a3 b2).2.2.1
+          (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.1
+          (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.2
+          (0 : Word) (fullDivN3NormU a0 a1 a2 a3 b2).1
+          retMem dMem dloMem scratchUn0 scratchMem **
+          (.x1 ↦ᵣ raVal)) :=
+    evm_div_n3_loop_unified_inst_noNop_exact_x1_v4_selectedCarryR1
+      bltu_1 bltu_0 sp base
+      (fullDivN3Shift b2) (fullDivN3AntiShift b2)
+      (fullDivN3NormV b0 b1 b2 b3).1
+      (fullDivN3NormV b0 b1 b2 b3).2.1
+      (fullDivN3NormV b0 b1 b2 b3).2.2.1
+      (fullDivN3NormV b0 b1 b2 b3).2.2.2
+      (fullDivN3NormU a0 a1 a2 a3 b2).1
+      (fullDivN3NormU a0 a1 a2 a3 b2).2.1
+      (fullDivN3NormU a0 a1 a2 a3 b2).2.2.1
+      (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.1
+      (fullDivN3NormU a0 a1 a2 a3 b2).2.2.2.2
+      (a0 >>> ((fullDivN3AntiShift b2).toNat % 64)) v11Old jMem
+      retMem dMem dloMem scratchUn0 scratchMem raVal
+      halign hbltu_1 (by cases bltu_1 <;> simpa using hbltu_0) hcarry2_j1 hcarry2_j0'
+  have hLoopf := cpsTripleWithin_frameR
+    ((((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+      ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+      ((sp + signExtend12 4072) ↦ₘ (0 : Word)) **
+      ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+      ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+      ((sp + signExtend12 3992) ↦ₘ (clzResult b2).1)))
+    (by pcFree) hLoop
+  have hBridge := loopSetupPost_to_loopN3PreWithScratchV4NoX1_framed
+    sp a0 a1 a2 a3 b0 b1 b2 b3 v11Old
+    jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+  have hPre' := cpsTripleWithin_weaken
+    (fun h hp => hp)
+    hBridge
+    hPre
+  have hFull := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hPre' hLoopf
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => hp)
+    (fun h hq => hq)
+    hFull
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add an irreducible preloop-level R1-shaped selected-carry predicate for N3 j=0
- add fullDivN3_preloop_loop_unified_exact_x1_scratch_v4_noNop_selectedCarryR1, composing through the lower R1 selected loop instantiation
- keep the selected-path j0 carry premise in fullDivN3R1V4/iterN3V4 shape instead of exposing the expanded match-shaped proposition at the preloop boundary

## Verification
- lake build EvmAsm.Evm64.DivMod.Compose.FullPathN3V4NoNopPreloop
- rg "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" touched DivMod files
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build EvmAsm.Evm64.DivMod
- lake build