### PR TITLE
refactor(div): add R1-shaped N3 stack-pre wrapper

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -18,6 +18,7 @@ import EvmAsm.Evm64.DivMod.Spec.CallAddbackRuntime
 import EvmAsm.Evm64.DivMod.Spec.N4V4StackPre
 import EvmAsm.Evm64.DivMod.Spec.N4V4ShiftNzDispatcher
 import EvmAsm.Evm64.DivMod.Spec.N3V4StackPre
+import EvmAsm.Evm64.DivMod.Spec.N3V4StackPreR1
 import EvmAsm.Evm64.DivMod.Spec.N3V4StackPreSelected
 import EvmAsm.Evm64.DivMod.Spec.DivMaxSkipV4
 import EvmAsm.Evm64.DivMod.Spec.ModN4V4StackPre

--- a/EvmAsm/Evm64/DivMod/Spec/N3V4StackPreR1.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3V4StackPreR1.lean
@@ -1,0 +1,175 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N3V4StackPreR1
+
+  R1-shaped selected-carry stack-pre wrappers for n=3 DIV v4 paths.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.N3V4StackPre
+import EvmAsm.Rv64.AddrNorm
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (word_add_zero)
+
+/-- R1-shaped selected-carry variant of
+    `evm_div_n3_preloop_loop_stack_pre_spec_v4_noNop_selectedCarry`.
+    The `j=0` carry premise is the opaque preloop R1 predicate, matching the
+    selected path package shape without exposing the expanded match form. -/
+theorem evm_div_n3_preloop_loop_stack_pre_spec_v4_noNop_selectedCarryR1
+    (sp base : Word) (a b : EvmWord) (v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word) (hbnz : b ≠ 0) (hb3z : b.getLimbN 3 = 0) (hb2nz : b.getLimbN 2 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 2)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu_1 : bltu_1 =
+      BitVec.ult (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+        (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).2.2.1)
+    (hbltu_0 : bltu_0 =
+      match bltu_1, hbltu_1 with
+      | false, _ =>
+        BitVec.ult
+          (iterN3Max
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+            (0 : Word)).2.2.2.1
+          (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+            (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+      | true, _ =>
+        BitVec.ult
+          (iterWithDoubleAddback
+            (divKTrialCallV4QHat
+              (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+                (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+              (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+                (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.1
+              (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+                (b.getLimbN 2) (b.getLimbN 3)).2.2.1)
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+            (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.1
+            (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+            (0 : Word)).2.2.2.1
+          (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1)
+            (b.getLimbN 2) (b.getLimbN 3)).2.2.1)
+    (hcarry2_j1 :
+      if bltu_1 then
+        loopBodyN3CallAddbackCarry2NzV4
+          (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1
+          (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.1
+          (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+          (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+          (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+            (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.1
+          (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+            (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.1
+          (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+            (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.1
+          (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+            (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+          (0 : Word)
+      else
+        isAddbackCarry2NzN3Max
+          (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1
+          (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.1
+          (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+          (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+          (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+            (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.1
+          (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+            (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.1
+          (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+            (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.1
+          (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1)
+            (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 2)).2.2.2.2
+          (0 : Word))
+    (hcarry2_j0 :
+      fullDivN3PreloopSelectedCarryJ0R1V4 bltu_1 bltu_0
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 448)
+      base (base + denormOff) (divCode_noNop_v4 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult (b.getLimbN 2)).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      ((loopN3UnifiedPostV4NoX1 bltu_1 bltu_0 sp base
+        (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1
+        (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.1
+        (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+        (fullDivN3NormV (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+        (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 2)).2.1
+        (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 2)).2.2.1
+        (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 2)).2.2.2.1
+        (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 2)).2.2.2.2
+        (0 : Word)
+        (fullDivN3NormU (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 2)).1
+        retMem dMem dloMem scratchUn0 scratchMem **
+        (.x1 ↦ᵣ raVal)) **
+       (((sp + 0) ↦ₘ a.getLimbN 0) ** ((sp + 8) ↦ₘ a.getLimbN 1) **
+        ((sp + 16) ↦ₘ a.getLimbN 2) ** ((sp + 24) ↦ₘ a.getLimbN 3) **
+        ((sp + signExtend12 4072) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+        ((sp + signExtend12 3992) ↦ₘ (clzResult (b.getLimbN 2)).1))) := by
+  have hbnz' : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 ≠ 0 :=
+    (EvmWord.ne_zero_iff_getLimbN_or).mp hbnz
+  have hrawNoNop :=
+    fullDivN3_preloop_loop_unified_exact_x1_scratch_v4_noNop_selectedCarryR1
+      bltu_1 bltu_0 sp base
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) v5 v6 v7 v10 v11Old
+      q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+      hbnz' hb3z hb2nz hshift_nz halign hbltu_1
+      (by cases bltu_1 <;> simpa using hbltu_0) hcarry2_j1 hcarry2_j0
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by
+      rw [divModStackDispatchPreNoX1_unfold, divScratchValuesCallNoX1_unfold] at hp
+      rw [evmWordIs_sp_limbs_eq sp a _ _ _ _ rfl rfl rfl rfl,
+          evmWordIs_sp32_limbs_eq sp b _ _ _ _ rfl rfl rfl rfl,
+          divScratchValues_unfold] at hp
+      rw [word_add_zero]
+      xperm_hyp hp)
+    (fun _ hq => hq)
+    hrawNoNop
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add Spec/N3V4StackPreR1.lean with evm_div_n3_preloop_loop_stack_pre_spec_v4_noNop_selectedCarryR1
- lift the opaque R1-shaped N3 j=0 selected-carry predicate from raw preloop composition to the word-level stack-pre body
- import the new split module from the DivMod Spec umbrella without growing N3V4StackPre.lean past the file-size guard

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.N3V4StackPreR1
- rg "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" touched files
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build EvmAsm.Evm64.DivMod
- lake build