### PR TITLE
refactor(div): add selected N3 stack path R1 wrapper

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N3V4StackPreSelected.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3V4StackPreSelected.lean
@@ -5,6 +5,7 @@
 -/
 
 import EvmAsm.Evm64.DivMod.Spec.N3V4StackPre
+import EvmAsm.Evm64.DivMod.Spec.N3V4StackPreR1
 
 namespace EvmAsm.Evm64
 
@@ -206,6 +207,91 @@ theorem evm_div_n3_stack_pre_to_unified_post_v4_noNop_selectedCarry (sp base : W
     q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
     hbnz hb3z hb2nz hshift_nz halign hbltu_1 hbltu_0 hcarry2_j1 hcarry2_j0
+  have hshift_nz' : fullDivN3Shift (b.getLimbN 2) ≠ 0 := by
+    rw [fullDivN3Shift_unfold]
+    exact hshift_nz
+  have hBNoNop := evm_div_n3_denorm_epilogue_bundled_spec_v4_noNop_v4Final_exact_x1_scratch_frame
+    bltu_1 bltu_0 sp base
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+    retMem dMem dloMem scratchUn0 scratchMem raVal hshift_nz'
+  have hFull := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by
+      cases bltu_1 <;> cases bltu_0
+      · exact loopN3UnifiedPostV4NoX1_to_fullDivN3DenormPreV4_frame_FF
+          sp base (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+          retMem dMem dloMem scratchUn0 scratchMem raVal h hp
+      · exact loopN3UnifiedPostV4NoX1_to_fullDivN3DenormPreV4_frame_FT
+          sp base (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+          retMem dMem dloMem scratchUn0 scratchMem raVal h hp
+      · exact loopN3UnifiedPostV4NoX1_to_fullDivN3DenormPreV4_frame_TF
+          sp base (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+          retMem dMem dloMem scratchUn0 scratchMem raVal h hp
+      · exact loopN3UnifiedPostV4NoX1_to_fullDivN3DenormPreV4_frame_TT
+          sp base (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+          retMem dMem dloMem scratchUn0 scratchMem raVal h hp)
+    hA hBNoNop
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => hp)
+    (fun h hq => hq)
+    hFull
+
+/-- Selected-path variant of
+    `evm_div_n3_stack_pre_to_unified_post_v4_noNop_selectedCarry` using the
+    R1-shaped `j=0` carry surface.  Both selected carry facts are projected
+    from the selected path package. -/
+theorem evm_div_n3_stack_pre_to_unified_post_v4_noNop_selectedPathR1 (sp base : Word)
+    (a b : EvmWord)
+    (v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (hbnz : b ≠ 0)
+    (hb3z : b.getLimbN 3 = 0) (hb2nz : b.getLimbN 2 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 2)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hpath : fullDivN3SelectedPathConditionsWordV4 bltu_1 bltu_0 a b) :
+    cpsTripleWithin ((8 + 21 + 24 + 4 + 21 + 21 + 4 + 448) + (2 + 23 + 10))
+      base (base + nopOff) (divCode_noNop_v4 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult (b.getLimbN 2)).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (fullDivN3UnifiedPostNoX1V4 bltu_1 bltu_0 sp base
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+        retMem dMem dloMem scratchUn0 scratchMem **
+       (.x1 ↦ᵣ raVal)) := by
+  have hbltu_1 := fullDivN3SelectedPathConditionsWordV4_trial_j1
+    bltu_1 bltu_0 a b hpath
+  have hbltu_0 := fullDivN3SelectedPathConditionsWordV4_trial_j0
+    bltu_1 bltu_0 a b hpath
+  have hcarry2_j1 := fullDivN3SelectedPathConditionsWordV4_carry_j1
+    bltu_1 bltu_0 a b hpath
+  have hcarry2_j0_pkg := fullDivN3SelectedPathConditionsWordV4_carry_j0
+    bltu_1 bltu_0 a b hpath
+  have hcarry2_j0 :
+      fullDivN3PreloopSelectedCarryJ0R1V4 bltu_1 bltu_0
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) := by
+    rw [fullDivN3PreloopSelectedCarryJ0R1V4]
+    rw [fullDivN3R1V4] at hcarry2_j0_pkg
+    exact hcarry2_j0_pkg
+  have hA := evm_div_n3_preloop_loop_stack_pre_spec_v4_noNop_selectedCarryR1
+    sp base a b v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+    hbnz hb3z hb2nz hshift_nz halign hbltu_1
+    (by cases bltu_1 <;> simpa [isTrialN3V4_j0] using hbltu_0)
+    hcarry2_j1 hcarry2_j0
   have hshift_nz' : fullDivN3Shift (b.getLimbN 2) ≠ 0 := by
     rw [fullDivN3Shift_unfold]
     exact hshift_nz


### PR DESCRIPTION
## Summary
- import the R1 stack-pre wrapper into N3V4StackPreSelected
- add evm_div_n3_stack_pre_to_unified_post_v4_noNop_selectedPathR1
- derive both selected carry facts from fullDivN3SelectedPathConditionsWordV4, converting the j=0 projection into the opaque R1 preloop predicate locally

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.N3V4StackPreSelected
- rg "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/Spec/N3V4StackPreSelected.lean
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build EvmAsm.Evm64.DivMod
- lake build