### PR TITLE
refactor(div): add auto-trial N3 callable R1 wrapper

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNopLoopUnified.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNopLoopUnified.lean
@@ -135,6 +135,100 @@ def loopN2UnifiedPostV4NoX1 (bltu_2 bltu_1 bltu_0 : Bool)
     (((uBase1 + signExtend12 4064 ↦ₘ r1.2.2.2.2.2) ** (qAddr1 ↦ₘ r1.1)) **
      ((uBase2 + signExtend12 4064 ↦ₘ r2.2.2.2.2.2) ** (qAddr2 ↦ₘ r2.1)))
 
+/-- Branch-selected n=2 v4 loop iteration, local to the lower loop layer.
+
+    This duplicates the branch shape of `iterN2V4` without importing the
+    higher full-path family module, which depends on this lower loop module. -/
+def loopN2IterSelectedV4 (bltu : Bool)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
+    Word × Word × Word × Word × Word × Word :=
+  if bltu then
+    iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  else
+    iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+
+/-- Selected per-iteration carry facts for the normalized n=2 loop source.
+
+    This is the compose-layer replacement shape for `Carry2NzAll`: it carries
+    only the facts selected by the actual branch booleans and names the
+    intermediate states through `loopN2IterSelectedV4`.  Downstream
+    loop/preloop wrappers can consume this without exposing the false
+    universal carry package. -/
+@[irreducible]
+def loopN2SelectedCarryV4 (bltu_2 bltu_1 bltu_0 : Bool)
+    (v0 v1 v2 v3 u2S u3S u4S u1S u0S : Word) : Prop :=
+  let r2 := loopN2IterSelectedV4 bltu_2 v0 v1 v2 v3 u2S u3S u4S (0 : Word) (0 : Word)
+  let r1 := loopN2IterSelectedV4 bltu_1 v0 v1 v2 v3
+    u1S r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
+  (if bltu_2 then
+    loopBodyN2CallAddbackCarry2NzV4 v0 v1 v2 v3
+      u2S u3S u4S (0 : Word) (0 : Word)
+   else
+    isAddbackCarry2NzN2Max v0 v1 v2 v3
+      u2S u3S u4S (0 : Word) (0 : Word)) ∧
+  (if bltu_1 then
+    loopBodyN2CallAddbackCarry2NzV4 v0 v1 v2 v3
+      u1S r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
+   else
+    isAddbackCarry2NzN2Max v0 v1 v2 v3
+      u1S r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1) ∧
+  (if bltu_0 then
+    loopBodyN2CallAddbackCarry2NzV4 v0 v1 v2 v3
+      u0S r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+   else
+    isAddbackCarry2NzN2Max v0 v1 v2 v3
+      u0S r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1)
+
+/-- First selected n=2 normalized-loop carry component, for `j=2`. -/
+theorem loopN2SelectedCarryV4_j2
+    (bltu_2 bltu_1 bltu_0 : Bool)
+    (v0 v1 v2 v3 u2S u3S u4S u1S u0S : Word)
+    (hcarry : loopN2SelectedCarryV4 bltu_2 bltu_1 bltu_0
+      v0 v1 v2 v3 u2S u3S u4S u1S u0S) :
+    if bltu_2 then
+      loopBodyN2CallAddbackCarry2NzV4 v0 v1 v2 v3
+        u2S u3S u4S (0 : Word) (0 : Word)
+    else
+      isAddbackCarry2NzN2Max v0 v1 v2 v3
+        u2S u3S u4S (0 : Word) (0 : Word) := by
+  rw [loopN2SelectedCarryV4] at hcarry
+  exact hcarry.1
+
+/-- Second selected n=2 normalized-loop carry component, for `j=1`. -/
+theorem loopN2SelectedCarryV4_j1
+    (bltu_2 bltu_1 bltu_0 : Bool)
+    (v0 v1 v2 v3 u2S u3S u4S u1S u0S : Word)
+    (hcarry : loopN2SelectedCarryV4 bltu_2 bltu_1 bltu_0
+      v0 v1 v2 v3 u2S u3S u4S u1S u0S) :
+    let r2 := loopN2IterSelectedV4 bltu_2 v0 v1 v2 v3 u2S u3S u4S (0 : Word) (0 : Word)
+    if bltu_1 then
+      loopBodyN2CallAddbackCarry2NzV4 v0 v1 v2 v3
+        u1S r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
+    else
+      isAddbackCarry2NzN2Max v0 v1 v2 v3
+        u1S r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1 := by
+  rw [loopN2SelectedCarryV4] at hcarry
+  exact hcarry.2.1
+
+/-- Third selected n=2 normalized-loop carry component, for `j=0`. -/
+theorem loopN2SelectedCarryV4_j0
+    (bltu_2 bltu_1 bltu_0 : Bool)
+    (v0 v1 v2 v3 u2S u3S u4S u1S u0S : Word)
+    (hcarry : loopN2SelectedCarryV4 bltu_2 bltu_1 bltu_0
+      v0 v1 v2 v3 u2S u3S u4S u1S u0S) :
+    let r2 := loopN2IterSelectedV4 bltu_2 v0 v1 v2 v3 u2S u3S u4S (0 : Word) (0 : Word)
+    let r1 := loopN2IterSelectedV4 bltu_1 v0 v1 v2 v3
+      u1S r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
+    if bltu_0 then
+      loopBodyN2CallAddbackCarry2NzV4 v0 v1 v2 v3
+        u0S r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+    else
+      isAddbackCarry2NzN2Max v0 v1 v2 v3
+        u0S r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 := by
+  rw [loopN2SelectedCarryV4] at hcarry
+  exact hcarry.2.2
+
 /-- Unified n=2 v4 no-NOP loop source theorem, dispatching to the 8 per-case
     proofs via `bltu_2 × bltu_1 × bltu_0`.  Preserves caller-owned exact `x1`.
     The 672-step bound accommodates the worst-case (all-call) path; lighter paths

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNopLoopUnified.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNopLoopUnified.lean
@@ -148,6 +148,19 @@ def loopN2IterSelectedV4 (bltu : Bool)
   else
     iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
 
+@[simp] theorem loopN2IterSelectedV4_false
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
+    loopN2IterSelectedV4 false v0 v1 v2 v3 u0 u1 u2 u3 uTop =
+      iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+  rfl
+
+@[simp] theorem loopN2IterSelectedV4_true
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
+    loopN2IterSelectedV4 true v0 v1 v2 v3 u0 u1 u2 u3 uTop =
+      iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+  simp [loopN2IterSelectedV4]
+
 /-- Selected per-iteration carry facts for the normalized n=2 loop source.
 
     This is the compose-layer replacement shape for `Carry2NzAll`: it carries

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNopLoopUnified.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNopLoopUnified.lean
@@ -157,75 +157,75 @@ def loopN2IterSelectedV4 (bltu : Bool)
     universal carry package. -/
 @[irreducible]
 def loopN2SelectedCarryV4 (bltu_2 bltu_1 bltu_0 : Bool)
-    (v0 v1 v2 v3 u2S u3S u4S u1S u0S : Word) : Prop :=
-  let r2 := loopN2IterSelectedV4 bltu_2 v0 v1 v2 v3 u2S u3S u4S (0 : Word) (0 : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 : Word) : Prop :=
+  let r2 := loopN2IterSelectedV4 bltu_2 v0 v1 v2 v3 u0 u1 u2 u3 uTop
   let r1 := loopN2IterSelectedV4 bltu_1 v0 v1 v2 v3
-    u1S r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
+    u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
   (if bltu_2 then
     loopBodyN2CallAddbackCarry2NzV4 v0 v1 v2 v3
-      u2S u3S u4S (0 : Word) (0 : Word)
+      u0 u1 u2 u3 uTop
    else
     isAddbackCarry2NzN2Max v0 v1 v2 v3
-      u2S u3S u4S (0 : Word) (0 : Word)) ∧
+      u0 u1 u2 u3 uTop) ∧
   (if bltu_1 then
     loopBodyN2CallAddbackCarry2NzV4 v0 v1 v2 v3
-      u1S r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
+      u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
    else
     isAddbackCarry2NzN2Max v0 v1 v2 v3
-      u1S r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1) ∧
+      u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1) ∧
   (if bltu_0 then
     loopBodyN2CallAddbackCarry2NzV4 v0 v1 v2 v3
-      u0S r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+      u0Orig0 r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
    else
     isAddbackCarry2NzN2Max v0 v1 v2 v3
-      u0S r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1)
+      u0Orig0 r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1)
 
 /-- First selected n=2 normalized-loop carry component, for `j=2`. -/
 theorem loopN2SelectedCarryV4_j2
     (bltu_2 bltu_1 bltu_0 : Bool)
-    (v0 v1 v2 v3 u2S u3S u4S u1S u0S : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 : Word)
     (hcarry : loopN2SelectedCarryV4 bltu_2 bltu_1 bltu_0
-      v0 v1 v2 v3 u2S u3S u4S u1S u0S) :
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0) :
     if bltu_2 then
       loopBodyN2CallAddbackCarry2NzV4 v0 v1 v2 v3
-        u2S u3S u4S (0 : Word) (0 : Word)
+        u0 u1 u2 u3 uTop
     else
       isAddbackCarry2NzN2Max v0 v1 v2 v3
-        u2S u3S u4S (0 : Word) (0 : Word) := by
+        u0 u1 u2 u3 uTop := by
   rw [loopN2SelectedCarryV4] at hcarry
   exact hcarry.1
 
 /-- Second selected n=2 normalized-loop carry component, for `j=1`. -/
 theorem loopN2SelectedCarryV4_j1
     (bltu_2 bltu_1 bltu_0 : Bool)
-    (v0 v1 v2 v3 u2S u3S u4S u1S u0S : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 : Word)
     (hcarry : loopN2SelectedCarryV4 bltu_2 bltu_1 bltu_0
-      v0 v1 v2 v3 u2S u3S u4S u1S u0S) :
-    let r2 := loopN2IterSelectedV4 bltu_2 v0 v1 v2 v3 u2S u3S u4S (0 : Word) (0 : Word)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0) :
+    let r2 := loopN2IterSelectedV4 bltu_2 v0 v1 v2 v3 u0 u1 u2 u3 uTop
     if bltu_1 then
       loopBodyN2CallAddbackCarry2NzV4 v0 v1 v2 v3
-        u1S r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
+        u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
     else
       isAddbackCarry2NzN2Max v0 v1 v2 v3
-        u1S r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1 := by
+        u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1 := by
   rw [loopN2SelectedCarryV4] at hcarry
   exact hcarry.2.1
 
 /-- Third selected n=2 normalized-loop carry component, for `j=0`. -/
 theorem loopN2SelectedCarryV4_j0
     (bltu_2 bltu_1 bltu_0 : Bool)
-    (v0 v1 v2 v3 u2S u3S u4S u1S u0S : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0 : Word)
     (hcarry : loopN2SelectedCarryV4 bltu_2 bltu_1 bltu_0
-      v0 v1 v2 v3 u2S u3S u4S u1S u0S) :
-    let r2 := loopN2IterSelectedV4 bltu_2 v0 v1 v2 v3 u2S u3S u4S (0 : Word) (0 : Word)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig1 u0Orig0) :
+    let r2 := loopN2IterSelectedV4 bltu_2 v0 v1 v2 v3 u0 u1 u2 u3 uTop
     let r1 := loopN2IterSelectedV4 bltu_1 v0 v1 v2 v3
-      u1S r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
+      u0Orig1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
     if bltu_0 then
       loopBodyN2CallAddbackCarry2NzV4 v0 v1 v2 v3
-        u0S r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+        u0Orig0 r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
     else
       isAddbackCarry2NzN2Max v0 v1 v2 v3
-        u0S r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 := by
+        u0Orig0 r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 := by
   rw [loopN2SelectedCarryV4] at hcarry
   exact hcarry.2.2
 

--- a/EvmAsm/Evm64/DivMod/Spec/N3V4CallableExactR1.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3V4CallableExactR1.lean
@@ -86,4 +86,118 @@ theorem evm_div_n3_stack_spec_v4_preNoX1_callableExactFrame_selectedPathR1_uni
       nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
       hbnz hb3z hb2nz hshift_nz halign hpath
 
+/-- No-NOP N3 callable wrapper that constructs the mechanical selected path
+    internally and then uses the R1-shaped selected-path body. -/
+theorem evm_div_n3_stack_spec_noNop_v4_preNoX1_callableExactFrame_autoTrialSelectedR1_uni
+    (sp base : Word)
+    (a b : EvmWord)
+    (v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (hbnz : b ≠ 0)
+    (hb3z : b.getLimbN 3 = 0) (hb2nz : b.getLimbN 2 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 2)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hcarry : ∀ bltu_1 bltu_0,
+      isTrialN3V4_j1 bltu_1
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
+      isTrialN3V4_j0 bltu_1 bltu_0
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
+      fullDivN3SelectedCarryV4 bltu_1 bltu_0
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3))
+    (harith : ∀ bltu_1 bltu_0,
+      isTrialN3V4_j1 bltu_1
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
+      isTrialN3V4_j0 bltu_1 bltu_0
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
+      fullDivN3MulSubEqV4 bltu_1 bltu_0
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) ∧
+        fullDivN3QuotientOverestimateV4 bltu_1 bltu_0
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)) :
+    cpsTripleWithin unifiedDivBound base (base + nopOff) (divCode_noNop_v4 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult (b.getLimbN 2)).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divStackDispatchPostCallableExactFrame sp a b raVal
+        (signExtend12 4095 : Word) **
+       memOwn (sp + signExtend12 3936)) := by
+  obtain ⟨bltu_1, bltu_0, hpath⟩ :=
+    N3V4TrialWitnesses.exists_selected_path_conditions
+      (n3V4TrialWitnesses_of_getLimbN a b) hcarry harith
+  exact evm_div_n3_stack_spec_noNop_v4_preNoX1_callableExactFrame_selectedPathR1_uni
+    bltu_1 bltu_0 sp base a b
+    v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+    hbnz hb3z hb2nz hshift_nz halign hpath
+
+/-- Full-code form of
+    `evm_div_n3_stack_spec_noNop_v4_preNoX1_callableExactFrame_autoTrialSelectedR1_uni`. -/
+theorem evm_div_n3_stack_spec_v4_preNoX1_callableExactFrame_autoTrialSelectedR1_uni
+    (sp base : Word)
+    (a b : EvmWord)
+    (v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (hbnz : b ≠ 0)
+    (hb3z : b.getLimbN 3 = 0) (hb2nz : b.getLimbN 2 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 2)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hcarry : ∀ bltu_1 bltu_0,
+      isTrialN3V4_j1 bltu_1
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
+      isTrialN3V4_j0 bltu_1 bltu_0
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
+      fullDivN3SelectedCarryV4 bltu_1 bltu_0
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3))
+    (harith : ∀ bltu_1 bltu_0,
+      isTrialN3V4_j1 bltu_1
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
+      isTrialN3V4_j0 bltu_1 bltu_0
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
+      fullDivN3MulSubEqV4 bltu_1 bltu_0
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) ∧
+        fullDivN3QuotientOverestimateV4 bltu_1 bltu_0
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)) :
+    cpsTripleWithin unifiedDivBound base (base + nopOff) (divCode_v4 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult (b.getLimbN 2)).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divStackDispatchPostCallableExactFrame sp a b raVal
+        (signExtend12 4095 : Word) **
+       memOwn (sp + signExtend12 3936)) :=
+  cpsTripleWithin_divCode_noNop_v4_to_divCode_v4 <|
+    evm_div_n3_stack_spec_noNop_v4_preNoX1_callableExactFrame_autoTrialSelectedR1_uni
+      sp base a b
+      v5 v6 v7 v10 v11Old
+      q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+      nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+      hbnz hb3z hb2nz hshift_nz halign hcarry harith
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add no-NOP/full N3 callable auto-trial wrappers in the R1 selected-path split module
- construct the selected branch internally from mechanical trial witnesses and route directly through the R1 selected-path callable theorem
- avoid reintroducing fullDivN3Carry2NzV4/Carry2NzAll at this callable surface

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.N3V4CallableExactR1
- rg "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/Spec/N3V4CallableExactR1.lean
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build EvmAsm.Evm64.DivMod
- lake build