### PR TITLE
feat(stateless): chain_compute_min_blob_count (PR-K286)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -338,6 +338,7 @@ def lookupProgramTail : String → Option BuildUnit
   | "zisk_header_extract_requests_hash" => some ziskHeaderExtractRequestsHashProbeUnit
   | "zisk_chain_extract_first_last_requests_hash" => some ziskChainExtractFirstLastRequestsHashProbeUnit
   | "zisk_chain_compute_max_blob_count" => some ziskChainComputeMaxBlobCountProbeUnit
+  | "zisk_chain_compute_min_blob_count" => some ziskChainComputeMinBlobCountProbeUnit
   | "zisk_chain_extract_first_last_state_root" => some ziskChainExtractFirstLastStateRootProbeUnit
   | "zisk_chain_extract_first_last_block_hash" => some ziskChainExtractFirstLastBlockHashProbeUnit
   | "zisk_chain_extract_first_last_receipts_root" => some ziskChainExtractFirstLastReceiptsRootProbeUnit
@@ -797,6 +798,7 @@ def knownProgramNames : List String :=
    "zisk_header_extract_requests_hash",
    "zisk_chain_extract_first_last_requests_hash",
    "zisk_chain_compute_max_blob_count",
+   "zisk_chain_compute_min_blob_count",
    "zisk_chain_extract_first_last_state_root",
    "zisk_chain_extract_first_last_block_hash",
    "zisk_chain_extract_first_last_receipts_root",

--- a/EvmAsm/Codegen/Programs/Chain.lean
+++ b/EvmAsm/Codegen/Programs/Chain.lean
@@ -1180,4 +1180,109 @@ def ziskChainComputeMaxBlobCountProbeUnit : BuildUnit := {
   dataAsm     := ziskChainComputeMaxBlobCountDataSection
 }
 
+/-! ## chain_compute_min_blob_count -- PR-K286
+
+    Find the minimum blob count per block across an N-element
+    header chain (header field 17 / GAS_PER_BLOB). Min counter-
+    part to K285 chain_compute_max_blob_count; useful for
+    spotting blob-fee lulls in a chain segment.
+
+    Pre-Cancun headers (<18 fields) yield parse-failure status
+    and the min is the partial accumulator. Vacuous on empty
+    chain: min = 0.
+
+    Calling convention:
+      a0 (input)  : N
+      a1 (input)  : header_lengths ptr (N u64 LE)
+      a2 (input)  : flat headers ptr
+      a3 (input)  : u64 out (min blob_count)
+      ra (input)  : return
+      a0 (output) :
+        0 : success
+        1 : RLP parse fail (pre-Cancun header in chain)
+        2 : blob_gas_used field > 8 bytes BE -/
+def chainComputeMinBlobCountFunction : String :=
+  "chain_compute_min_blob_count:\n" ++
+  "  addi sp, sp, -48\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp); sd s4, 40(sp)\n" ++
+  "  mv s0, a0; mv s1, a1; mv s2, a2; mv s3, a3\n" ++
+  "  sd zero, 0(s3)\n" ++
+  "  li s4, 0\n" ++
+  "  beqz s0, .Lccminbc_done\n" ++
+  ".Lccminbc_loop:\n" ++
+  "  beq s4, s0, .Lccminbc_done\n" ++
+  "  slli t0, s4, 3\n" ++
+  "  add t0, s1, t0\n" ++
+  "  ld a1, 0(t0)\n" ++
+  "  mv a0, s2; li a2, 17\n" ++
+  "  la a3, ccminbc_field\n" ++
+  "  jal ra, rlp_field_to_u64\n" ++
+  "  li t0, 1\n" ++
+  "  beq a0, t0, .Lccminbc_parse_fail\n" ++
+  "  li t0, 2\n" ++
+  "  beq a0, t0, .Lccminbc_size_fail\n" ++
+  "  la t0, ccminbc_field; ld t1, 0(t0)\n" ++
+  "  srli t1, t1, 17            # blob_count = blob_gas_used >> 17\n" ++
+  "  beqz s4, .Lccminbc_first\n" ++
+  "  ld t2, 0(s3)\n" ++
+  "  bgeu t1, t2, .Lccminbc_no_update\n" ++
+  ".Lccminbc_first:\n" ++
+  "  sd t1, 0(s3)\n" ++
+  ".Lccminbc_no_update:\n" ++
+  "  slli t0, s4, 3\n" ++
+  "  add t0, s1, t0\n" ++
+  "  ld t1, 0(t0)\n" ++
+  "  add s2, s2, t1\n" ++
+  "  addi s4, s4, 1\n" ++
+  "  j .Lccminbc_loop\n" ++
+  ".Lccminbc_done:\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lccminbc_ret\n" ++
+  ".Lccminbc_parse_fail:\n" ++
+  "  li a0, 1\n" ++
+  "  j .Lccminbc_ret\n" ++
+  ".Lccminbc_size_fail:\n" ++
+  "  li a0, 2\n" ++
+  ".Lccminbc_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp); ld s4, 40(sp)\n" ++
+  "  addi sp, sp, 48\n" ++
+  "  ret"
+
+def ziskChainComputeMinBlobCountPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a7, 0x40000000\n" ++
+  "  ld a0, 8(a7)\n" ++
+  "  addi a1, a7, 16\n" ++
+  "  slli t0, a0, 3\n" ++
+  "  add a2, a1, t0\n" ++
+  "  li a3, 0xa0010010\n" ++
+  "  jal ra, chain_compute_min_blob_count\n" ++
+  "  li t0, 0xa0010008\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lccminbc_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpFieldToU64Function ++ "\n" ++
+  chainComputeMinBlobCountFunction ++ "\n" ++
+  ".Lccminbc_pdone:"
+
+def ziskChainComputeMinBlobCountDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  "rfu_offset:\n" ++
+  "  .zero 8\n" ++
+  "rfu_length:\n" ++
+  "  .zero 8\n" ++
+  "ccminbc_field:\n" ++
+  "  .zero 8"
+
+def ziskChainComputeMinBlobCountProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskChainComputeMinBlobCountPrologue
+  dataAsm     := ziskChainComputeMinBlobCountDataSection
+}
+
 end EvmAsm.Codegen

--- a/scripts/codegen-zisk-chain-compute-min-blob-count-check.sh
+++ b/scripts/codegen-zisk-chain-compute-min-blob-count-check.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# codegen-zisk-chain-compute-min-blob-count-check.sh -- PR-K286.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_chain_compute_min_blob_count ELF"
+lake exe codegen --program zisk_chain_compute_min_blob_count --halt linux93 \
+  -o gen-out/zisk_chain_compute_min_blob_count
+
+REPO_ROOT="$(pwd)"
+
+run_case() {
+  local name="$1" blob_counts="$2" exp_status="$3" exp_min="$4"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_chain_compute_min_blob_count_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_chain_compute_min_blob_count_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+GAS_PER_BLOB = 131072
+def u_be(n):
+    if n == 0: return b''
+    return n.to_bytes((n.bit_length() + 7) // 8, 'big')
+
+def make_header(blob_count):
+    blob_gas_used = blob_count * GAS_PER_BLOB
+    return rlp.encode([
+        b'\\xa1'*32, b'\\xa2'*32, b'\\xa3'*20, b'\\xa4'*32, b'\\xa5'*32,
+        b'\\xa6'*32, b'\\x00'*256, b'', b'\\x01', b'\\x83\\xff\\xff\\xff',
+        b'', b'\\x83\\x01\\x02\\x03', b'', b'\\xa7'*32, b'\\x00'*8,
+        b'\\x84\\x05\\xf5\\xe1\\x00', b'\\xa8'*32, u_be(blob_gas_used),
+        b'', b'\\xa9'*32,
+    ])
+
+vals = $blob_counts
+headers = [make_header(v) for v in vals]
+N = len(headers)
+lengths = b''.join(struct.pack('<Q', len(h)) for h in headers)
+flat = b''.join(headers)
+with open(sys.argv[1], 'wb') as f:
+    record = struct.pack('<Q', N) + lengths + flat
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_chain_compute_min_blob_count.elf \
+    -i "$in_file" -o "$out_file" -n 5000000 \
+    >"$REPO_ROOT/gen-out/zisk_chain_compute_min_blob_count_${name}.emu.log" 2>&1 || true
+
+  local s_le; s_le="$(dd if="$out_file" bs=1 skip=8  count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local m_le; m_le="$(dd if="$out_file" bs=1 skip=16 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local status mn
+  status="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$s_le'))[0])")"
+  mn="$(    python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$m_le'))[0])")"
+
+  if [[ "$status" == "$exp_status" && "$mn" == "$exp_min" ]]; then
+    printf "  %-26s OK   status=%s min=%s\n" "$name" "$status" "$mn"
+    return 0
+  else
+    printf "  %-26s FAIL status=%s/%s min=%s/%s\n" "$name" "$status" "$exp_status" "$mn" "$exp_min"
+    return 1
+  fi
+}
+
+FAILED=0
+run_case "empty"        "[]"                  0 0 || FAILED=1
+run_case "single_zero"  "[0]"                 0 0 || FAILED=1
+run_case "single_6"     "[6]"                 0 6 || FAILED=1
+run_case "three_inc"    "[1, 2, 3]"           0 1 || FAILED=1
+run_case "three_mixed"  "[3, 1, 2]"           0 1 || FAILED=1
+run_case "five_minimal" "[6, 4, 2, 6, 1]"     0 1 || FAILED=1
+run_case "all_full"     "[6, 6, 6]"           0 6 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: chain_compute_min_blob_count finds min blob count"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- New aggregator `chain_compute_min_blob_count` returns `min(blob_gas_used / GAS_PER_BLOB)` across an N-element header chain (field 17, Cancun+).
- Min counterpart to K285 `chain_compute_max_blob_count`.

## Test plan
- [x] `scripts/codegen-zisk-chain-compute-min-blob-count-check.sh` — 7 fixtures pass.
- [x] `lake build codegen` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)