### PR TITLE
refactor(div): add selected N2 iter branch equations

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNopLoopUnified.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNopLoopUnified.lean
@@ -148,6 +148,19 @@ def loopN2IterSelectedV4 (bltu : Bool)
   else
     iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
 
+@[simp] theorem loopN2IterSelectedV4_false
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
+    loopN2IterSelectedV4 false v0 v1 v2 v3 u0 u1 u2 u3 uTop =
+      iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+  rfl
+
+@[simp] theorem loopN2IterSelectedV4_true
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
+    loopN2IterSelectedV4 true v0 v1 v2 v3 u0 u1 u2 u3 uTop =
+      iterWithDoubleAddback (divKTrialCallV4QHat u2 u1 v1)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+  simp [loopN2IterSelectedV4]
+
 /-- Selected per-iteration carry facts for the normalized n=2 loop source.
 
     This is the compose-layer replacement shape for `Carry2NzAll`: it carries


### PR DESCRIPTION
## Summary
- add simp branch equations for loopN2IterSelectedV4 false/true
- keep the selected N2 loop carry package cheap to unfold case-by-case in the next lower-loop wrapper
- document the failed direct bridge path implicitly by avoiding a large selected-path-to-loop conversion at theorem boundary

## Verification
- lake build EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopLoopUnified
- rg "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNopLoopUnified.lean
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build EvmAsm.Evm64.DivMod
- lake build