### PR TITLE
feat(stateless): chain_validate_difficulty_zero (PR-K287)

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -339,6 +339,7 @@ def lookupProgramTail : String → Option BuildUnit
   | "zisk_chain_extract_first_last_requests_hash" => some ziskChainExtractFirstLastRequestsHashProbeUnit
   | "zisk_chain_compute_max_blob_count" => some ziskChainComputeMaxBlobCountProbeUnit
   | "zisk_chain_compute_min_blob_count" => some ziskChainComputeMinBlobCountProbeUnit
+  | "zisk_chain_validate_difficulty_zero" => some ziskChainValidateDifficultyZeroProbeUnit
   | "zisk_chain_extract_first_last_state_root" => some ziskChainExtractFirstLastStateRootProbeUnit
   | "zisk_chain_extract_first_last_block_hash" => some ziskChainExtractFirstLastBlockHashProbeUnit
   | "zisk_chain_extract_first_last_receipts_root" => some ziskChainExtractFirstLastReceiptsRootProbeUnit
@@ -799,6 +800,7 @@ def knownProgramNames : List String :=
    "zisk_chain_extract_first_last_requests_hash",
    "zisk_chain_compute_max_blob_count",
    "zisk_chain_compute_min_blob_count",
+   "zisk_chain_validate_difficulty_zero",
    "zisk_chain_extract_first_last_state_root",
    "zisk_chain_extract_first_last_block_hash",
    "zisk_chain_extract_first_last_receipts_root",

--- a/EvmAsm/Codegen/Programs/ChainValidate.lean
+++ b/EvmAsm/Codegen/Programs/ChainValidate.lean
@@ -1167,4 +1167,117 @@ def ziskChainValidateGasLimitNonIncreasingProbeUnit : BuildUnit := {
   dataAsm     := ziskChainValidateGasLimitNonIncreasingDataSection
 }
 
+/-! ## chain_validate_difficulty_zero -- PR-K287
+
+    Per-header invariant: `difficulty == 0` (field 7). EIP-3675
+    (the Merge) deprecated PoW and forced `difficulty = 0` for
+    every post-merge block. Useful as a `is-post-merge-segment`
+    predicate for analytics windows.
+
+    Note: when `difficulty == 0`, RLP encodes the integer as an
+    empty byte string; `rlp_field_to_u64` returns 0. Any nonzero
+    value (whether single-byte or multi-byte BE encoding) flags
+    a violation.
+
+    Vacuous-true on N = 0.
+
+    Calling convention:
+      a0 (input)  : N (header count)
+      a1 (input)  : header_lengths ptr
+      a2 (input)  : headers ptr (concatenated)
+      a3 (input)  : u64 out (is_valid)
+      a4 (input)  : u64 out (first_bad_index)
+      ra (input)  : return
+      a0 (output) :
+        0 : success
+        1 : RLP parse failure on some header
+        2 : difficulty field > 8 bytes BE on some header -/
+def chainValidateDifficultyZeroFunction : String :=
+  "chain_validate_difficulty_zero:\n" ++
+  "  addi sp, sp, -56\n" ++
+  "  sd ra,  0(sp)\n" ++
+  "  sd s0,  8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  sd s4, 40(sp); sd s5, 48(sp)\n" ++
+  "  mv s0, a0; mv s1, a1; mv s2, a2; mv s3, a3; mv s4, a4\n" ++
+  "  li t0, 1\n" ++
+  "  sd t0, 0(s3); sd zero, 0(s4)\n" ++
+  "  li s5, 0\n" ++
+  ".Lcvdz_loop:\n" ++
+  "  beq s5, s0, .Lcvdz_done\n" ++
+  "  la t0, cvdz_iter_ptr; sd s2, 0(t0)\n" ++
+  "  la t0, cvdz_iter_i;   sd s5, 0(t0)\n" ++
+  "  slli t3, s5, 3\n" ++
+  "  add t3, s1, t3\n" ++
+  "  ld a1, 0(t3)\n" ++
+  "  mv a0, s2; li a2, 7\n" ++
+  "  la a3, cvdz_field\n" ++
+  "  jal ra, rlp_field_to_u64\n" ++
+  "  bnez a0, .Lcvdz_propagate\n" ++
+  "  la t0, cvdz_iter_ptr; ld s2, 0(t0)\n" ++
+  "  la t0, cvdz_iter_i;   ld s5, 0(t0)\n" ++
+  "  la t0, cvdz_field;    ld t1, 0(t0)\n" ++
+  "  bnez t1, .Lcvdz_violation\n" ++
+  "  slli t3, s5, 3\n" ++
+  "  add t3, s1, t3\n" ++
+  "  ld t4, 0(t3)\n" ++
+  "  add s2, s2, t4\n" ++
+  "  addi s5, s5, 1\n" ++
+  "  j .Lcvdz_loop\n" ++
+  ".Lcvdz_violation:\n" ++
+  "  sd zero, 0(s3)\n" ++
+  "  sd s5, 0(s4)\n" ++
+  "  li a0, 0\n" ++
+  "  j .Lcvdz_ret\n" ++
+  ".Lcvdz_propagate:\n" ++
+  "  sd s5, 0(s4)\n" ++
+  "  j .Lcvdz_ret\n" ++
+  ".Lcvdz_done:\n" ++
+  "  li a0, 0\n" ++
+  ".Lcvdz_ret:\n" ++
+  "  ld ra,  0(sp)\n" ++
+  "  ld s0,  8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
+  "  ld s4, 40(sp); ld s5, 48(sp)\n" ++
+  "  addi sp, sp, 56\n" ++
+  "  ret"
+
+def ziskChainValidateDifficultyZeroPrologue : String :=
+  "  li sp, 0xa0050000\n" ++
+  "  li a7, 0x40000000\n" ++
+  "  ld a0, 8(a7)\n" ++
+  "  addi a1, a7, 16\n" ++
+  "  slli t0, a0, 3\n" ++
+  "  add a2, a1, t0\n" ++
+  "  li a3, 0xa0010008\n" ++
+  "  li a4, 0xa0010010\n" ++
+  "  jal ra, chain_validate_difficulty_zero\n" ++
+  "  li t0, 0xa0010000\n" ++
+  "  sd a0, 0(t0)\n" ++
+  "  j .Lcvdz_pdone\n" ++
+  rlpListNthItemFunction ++ "\n" ++
+  rlpFieldToU64Function ++ "\n" ++
+  chainValidateDifficultyZeroFunction ++ "\n" ++
+  ".Lcvdz_pdone:"
+
+def ziskChainValidateDifficultyZeroDataSection : String :=
+  ".section .data\n" ++
+  ".balign 8\n" ++
+  "zk3_state:\n" ++
+  "  .zero 200\n" ++
+  "rfu_offset:\n" ++
+  "  .zero 8\n" ++
+  "rfu_length:\n" ++
+  "  .zero 8\n" ++
+  "cvdz_field:\n" ++
+  "  .zero 8\n" ++
+  "cvdz_iter_ptr:\n" ++
+  "  .zero 8\n" ++
+  "cvdz_iter_i:\n" ++
+  "  .zero 8"
+
+def ziskChainValidateDifficultyZeroProbeUnit : BuildUnit := {
+  body        := NOP
+  prologueAsm := ziskChainValidateDifficultyZeroPrologue
+  dataAsm     := ziskChainValidateDifficultyZeroDataSection
+}
+
 end EvmAsm.Codegen

--- a/scripts/codegen-zisk-chain-validate-difficulty-zero-check.sh
+++ b/scripts/codegen-zisk-chain-validate-difficulty-zero-check.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# codegen-zisk-chain-validate-difficulty-zero-check.sh -- PR-K287.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ZISKEMU="${ZISKEMU:-}"
+if [[ -z "$ZISKEMU" ]]; then
+  if command -v ziskemu >/dev/null 2>&1; then
+    ZISKEMU="$(command -v ziskemu)"
+  elif [[ -x "$HOME/.zisk/bin/ziskemu" ]]; then
+    ZISKEMU="$HOME/.zisk/bin/ziskemu"
+  else
+    echo "ziskemu not found -- install via ziskup or set ZISKEMU=..." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p gen-out
+
+echo "==> lake build codegen"
+lake build codegen
+
+echo "==> emit zisk_chain_validate_difficulty_zero ELF"
+lake exe codegen --program zisk_chain_validate_difficulty_zero --halt linux93 \
+  -o gen-out/zisk_chain_validate_difficulty_zero
+
+REPO_ROOT="$(pwd)"
+
+run_case() {
+  local name="$1" difficulties="$2" exp_status="$3" exp_valid="$4" exp_bad_index="$5"
+
+  local in_file="$REPO_ROOT/gen-out/zisk_chain_validate_difficulty_zero_${name}.input"
+  local out_file="$REPO_ROOT/gen-out/zisk_chain_validate_difficulty_zero_${name}.output"
+
+  uv run --directory execution-specs --quiet python3 -c "
+import struct, sys, rlp
+def u_be(n):
+    if n == 0: return b''
+    return n.to_bytes((n.bit_length() + 7) // 8, 'big')
+
+def make_header(difficulty):
+    return rlp.encode([
+        b'\\xa1'*32, b'\\xa2'*32, b'\\xa3'*20, b'\\xa4'*32, b'\\xa5'*32,
+        b'\\xa6'*32, b'\\x00'*256, u_be(difficulty), b'\\x01', b'\\x83\\xff\\xff\\xff',
+        b'', b'\\x83\\x01\\x02\\x03', b'', b'\\xa7'*32, b'\\x00'*8,
+    ])
+
+vals = $difficulties
+headers = [make_header(v) for v in vals]
+N = len(headers)
+lengths = b''.join(struct.pack('<Q', len(h)) for h in headers)
+flat = b''.join(headers)
+with open(sys.argv[1], 'wb') as f:
+    record = struct.pack('<Q', N) + lengths + flat
+    f.write(record)
+    pad = (-len(record)) % 8
+    if pad: f.write(b'\x00' * pad)
+" "$in_file"
+
+  "$ZISKEMU" -e gen-out/zisk_chain_validate_difficulty_zero.elf \
+    -i "$in_file" -o "$out_file" -n 5000000 \
+    >"$REPO_ROOT/gen-out/zisk_chain_validate_difficulty_zero_${name}.emu.log" 2>&1 || true
+
+  local s_le; s_le="$(dd if="$out_file" bs=1 skip=0  count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local v_le; v_le="$(dd if="$out_file" bs=1 skip=8  count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local b_le; b_le="$(dd if="$out_file" bs=1 skip=16 count=8 2>/dev/null | xxd -p | tr -d '\n')"
+  local status valid bad_index
+  status="$(   python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$s_le'))[0])")"
+  valid="$(    python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$v_le'))[0])")"
+  bad_index="$(python3 -c "import struct; print(struct.unpack('<Q', bytes.fromhex('$b_le'))[0])")"
+
+  if [[ "$status" == "$exp_status" && "$valid" == "$exp_valid" && "$bad_index" == "$exp_bad_index" ]]; then
+    printf "  %-32s OK   status=%s valid=%s bad_index=%s\n" "$name" "$status" "$valid" "$bad_index"
+    return 0
+  else
+    printf "  %-32s FAIL status=%s/%s valid=%s/%s bad_index=%s/%s\n" "$name" "$status" "$exp_status" "$valid" "$exp_valid" "$bad_index" "$exp_bad_index"
+    return 1
+  fi
+}
+
+FAILED=0
+run_case "empty"              "[]"                    0 1 0 || FAILED=1
+run_case "single_zero"        "[0]"                   0 1 0 || FAILED=1
+run_case "single_nonzero"     "[1]"                   0 0 0 || FAILED=1
+run_case "three_all_zero"     "[0, 0, 0]"             0 1 0 || FAILED=1
+run_case "three_bad_at_1"     "[0, 12345, 0]"         0 0 1 || FAILED=1
+run_case "three_bad_at_2"     "[0, 0, 999]"           0 0 2 || FAILED=1
+run_case "five_all_post_merge" "[0, 0, 0, 0, 0]"      0 1 0 || FAILED=1
+
+echo
+if [[ $FAILED -eq 0 ]]; then
+  echo "==> PASS: chain_validate_difficulty_zero enforces post-merge invariant"
+  exit 0
+else
+  echo "==> FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- New chain-level predicate `chain_validate_difficulty_zero` verifies every header has `difficulty == 0` (field 7), the EIP-3675 post-merge invariant.
- Useful as a `is-post-merge-segment` predicate for analytics windows.

## Test plan
- [x] `scripts/codegen-zisk-chain-validate-difficulty-zero-check.sh` — 7 fixtures pass.
- [x] `lake build codegen` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)