### PR TITLE
refactor(div): add full selected N2 auto-trial wrapper

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N2V4CallableExactSelected.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2V4CallableExactSelected.lean
@@ -478,4 +478,67 @@ theorem evm_div_n2_stack_spec_v4_preNoX1_callableExactFrame_autoTrialSelectedLoo
       nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
       hbnz hb3z hb2z hb1nz hshift_nz halign hcarry harith hloop
 
+/-- Full-code form of
+    `evm_div_n2_stack_spec_noNop_v4_preNoX1_callableExactFrame_autoTrialSelectedCarry_uni`. -/
+theorem evm_div_n2_stack_spec_v4_preNoX1_callableExactFrame_autoTrialSelectedCarry_uni
+    (sp base : Word)
+    (a b : EvmWord)
+    (v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (hbnz : b ≠ 0)
+    (hb3z : b.getLimbN 3 = 0) (hb2z : b.getLimbN 2 = 0)
+    (hb1nz : b.getLimbN 1 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 1)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hcarry : ∀ bltu_2 bltu_1 bltu_0,
+      isTrialN2V4_j2 bltu_2
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
+      isTrialN2V4_j1 bltu_2 bltu_1
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
+      isTrialN2V4_j0 bltu_2 bltu_1 bltu_0
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
+      fullDivN2SelectedCarryV4 bltu_2 bltu_1 bltu_0
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3))
+    (harith : ∀ bltu_2 bltu_1 bltu_0,
+      isTrialN2V4_j2 bltu_2
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
+      isTrialN2V4_j1 bltu_2 bltu_1
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
+      isTrialN2V4_j0 bltu_2 bltu_1 bltu_0
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
+      fullDivN2MulSubEqV4 bltu_2 bltu_1 bltu_0
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) ∧
+        fullDivN2QuotientOverestimateV4 bltu_2 bltu_1 bltu_0
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)) :
+    cpsTripleWithin unifiedDivBound base (base + nopOff) (divCode_v4 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult (b.getLimbN 1)).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divStackDispatchPostCallableExactFrame sp a b raVal
+        (signExtend12 4095 : Word) **
+       memOwn (sp + signExtend12 3936)) := by
+  exact cpsTripleWithin_divCode_noNop_v4_to_divCode_v4 <|
+    evm_div_n2_stack_spec_noNop_v4_preNoX1_callableExactFrame_autoTrialSelectedCarry_uni
+      sp base a b
+      v5 v6 v7 v10 v11Old
+      q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+      nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+      hbnz hb3z hb2z hb1nz hshift_nz halign hcarry harith
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add the divCode_v4 lift of the selected N2 auto-trial callable wrapper
- keep the full-code wrapper free of an explicit hloop parameter
- route through the selected path carry bridge instead of fullDivN2Carry2NzV4

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.N2V4CallableExactSelected
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/Spec/N2V4CallableExactSelected.lean
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build EvmAsm.Evm64.DivMod
- lake build