### PR TITLE
docs(div): mark legacy N2 trial witness carry helpers

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N2TrialWitnesses.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2TrialWitnesses.lean
@@ -2,6 +2,12 @@
   EvmAsm.Evm64.DivMod.Spec.N2TrialWitnesses
 
   Mechanical branch-boolean witnesses for the n=2 DIV path.
+
+  Legacy note:
+  Helpers below whose names end in `_of_path_conditions` still consume the old
+  `fullDivN2Carry2NzV4` package. They are compatibility shims only. New v4
+  stack/callable work should use the `_of_selected_path_conditions` helpers,
+  which consume selected per-iteration carry evidence for the reachable path.
 -/
 
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2LoopUnified
@@ -165,11 +171,13 @@ theorem N2V4TrialWitnesses.exists {a b : EvmWord}
   | mk bltu_2 bltu_1 bltu_0 hbltu_2 hbltu_1 hbltu_0 =>
       exact ⟨bltu_2, bltu_1, bltu_0, hbltu_2, hbltu_1, hbltu_0⟩
 
-/-- Assemble an existential bundled N2 V4 path predicate from the mechanical
+/-- Legacy: assemble an existential bundled N2 V4 path predicate from the mechanical
     trial witness bundle plus the remaining carry/arithmetic obligations.
 
     The arithmetic continuation receives the concrete branch booleans and
-    their defining equalities from `htrial`. -/
+    their defining equalities from `htrial`. This still consumes
+    `fullDivN2Carry2NzV4`; prefer
+    `N2V4TrialWitnesses.exists_selected_path_conditions` for new v4 work. -/
 theorem N2V4TrialWitnesses.exists_path_conditions
     {a b : EvmWord}
     (htrial : N2V4TrialWitnesses a b)
@@ -247,8 +255,11 @@ theorem N2V4TrialWitnesses.exists_selected_path_conditions
         hcarry bltu_2' bltu_1' bltu_0' hbltu_2 hbltu_1 hbltu_0,
         hmulsub, hover⟩
 
-/-- Assemble a V4 quotient-word equality from an `N2V4TrialWitnesses` bundle
-    plus the remaining path-condition obligations. -/
+/-- Legacy: assemble a V4 quotient-word equality from an `N2V4TrialWitnesses`
+    bundle plus the remaining path-condition obligations.
+
+    This still consumes `fullDivN2Carry2NzV4`; prefer the selected-path
+    variant for new v4 stack/callable work. -/
 theorem N2V4TrialWitnesses.exists_quotient_word_of_path_conditions
     {a b : EvmWord}
     (htrial : N2V4TrialWitnesses a b)
@@ -707,11 +718,13 @@ theorem N2V4TrialWitnesses.exists_hdivs_of_path_conditions_ne_zero
         (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
         hdivWord⟩
 
-/-- Auto-trial form of
+/-- Legacy auto-trial form of
     `N2V4TrialWitnesses.exists_quotient_word_of_path_conditions`.
 
     This constructs the mechanical V4 trial branch witnesses internally, so
-    callers only provide the remaining carry and arithmetic path obligations. -/
+    callers only provide the remaining carry and arithmetic path obligations.
+    It still uses `fullDivN2Carry2NzV4`; prefer
+    `n2V4_exists_quotient_word_of_selected_path_conditions`. -/
 theorem n2V4_exists_quotient_word_of_path_conditions
     {a b : EvmWord}
     (hbnz : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 |||
@@ -807,10 +820,11 @@ theorem n2V4_exists_quotient_word_of_selected_path_conditions
   N2V4TrialWitnesses.exists_quotient_word_of_selected_path_conditions
     (n2V4TrialWitnesses_of_getLimbN a b) hbnz hcarry harith
 
-/-- Slim auto-trial n=2 V4 quotient-word package.
+/-- Legacy slim auto-trial n=2 V4 quotient-word package.
 
     This keeps the selected branch booleans but drops their mechanical proof
-    witnesses from the conclusion. -/
+    witnesses from the conclusion. It still consumes `fullDivN2Carry2NzV4`;
+    prefer selected-path quotient helpers for new v4 work. -/
 theorem n2V4_quotient_word_of_path_conditions
     {a b : EvmWord}
     (hbnz : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 |||
@@ -960,10 +974,13 @@ theorem n2V4_shape_quotient_word_of_path_conditions_of_hb1nz
     a b (n2_limb_or_ne_zero_of_limb1_ne_zero hb1nz)
     _hb3z _hb2z hb1nz _hshift_nz hcarry2 harith
 
-/-- Auto-trial form of `N2V4TrialWitnesses.exists_hdivs_of_path_conditions`.
+/-- Legacy auto-trial form of
+    `N2V4TrialWitnesses.exists_hdivs_of_path_conditions`.
 
     This is the pure witness package needed by n=2 unconditional wrappers once
-    carry and arithmetic path obligations are available. -/
+    carry and arithmetic path obligations are available, but still consumes
+    `fullDivN2Carry2NzV4`. Prefer the selected-path hdiv helper for new v4
+    wrappers. -/
 theorem n2V4_exists_hdivs_of_path_conditions
     {a b : EvmWord}
     (hbnz : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 |||
@@ -1077,11 +1094,13 @@ theorem n2V4_exists_hdivs_of_selected_path_conditions
   N2V4TrialWitnesses.exists_hdivs_of_selected_path_conditions
     (n2V4TrialWitnesses_of_getLimbN a b) hbnz hcarry harith
 
-/-- Slim auto-trial n=2 V4 quotient-limb package.
+/-- Legacy slim auto-trial n=2 V4 quotient-limb package.
 
     This is the consumer-facing form of
     `n2V4_exists_hdivs_of_path_conditions`: it keeps the selected branch
-    booleans but drops their mechanical proof witnesses from the conclusion. -/
+    booleans but drops their mechanical proof witnesses from the conclusion.
+    It still consumes `fullDivN2Carry2NzV4`; prefer selected-path hdiv helpers
+    for new v4 wrappers. -/
 theorem n2V4_full_div_getLimbN_of_path_conditions
     {a b : EvmWord}
     (hbnz : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 |||


### PR DESCRIPTION
## Summary
- mark N2TrialWitnesses helpers that consume fullDivN2Carry2NzV4 as legacy compatibility shims
- point new v4 stack/callable work at the selected-path trial witness helpers
- leave theorem statements and proof behavior unchanged

Note: the working tree had an unrelated execution-specs submodule pointer difference after fetch; this PR only commits EvmAsm/Evm64/DivMod/Spec/N2TrialWitnesses.lean.

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.N2TrialWitnesses
- git diff --check
- rg -n "\\b(sorry|admit)\\b|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/Spec/N2TrialWitnesses.lean
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build EvmAsm.Evm64.DivMod
- lake build