### PR TITLE
docs(div): mark legacy N2 callable path wrapper

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N2V4CallableExact.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2V4CallableExact.lean
@@ -332,9 +332,9 @@ theorem evm_div_n2_stack_spec_v4_preNoX1_callableExactFrame_autoTrialSelectedBod
       nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
       hbnz hcarry harith hbody
 
-/-- Path-bundled N2 DIV v4 callable wrapper.
+/-- Legacy path-bundled N2 DIV v4 callable wrapper.
 
-    This consumes the bundled v4 path predicate, derives the branch/carry
+    This consumes the bundled raw-carry v4 path predicate, derives the branch/carry
     obligations for the body proof and the quotient-word equality for the
     callable exact-frame bridge, then closes the trial-call scratch cell as
     `memOwn`. -/


### PR DESCRIPTION
## Summary
- mark the N2 path-bundled callable wrapper over fullDivN2PathConditionsWordV4 as a legacy compatibility surface
- clarify that the wrapper consumes the bundled raw-carry v4 path predicate
- keep theorem statements and proof behavior unchanged

Note: the working tree still has an unrelated unstaged execution-specs submodule pointer change; it is not part of this PR.

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.N2V4CallableExact
- git diff --check
- rg -n "\b(sorry|admit)\b|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/Spec/N2V4CallableExact.lean
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build EvmAsm.Evm64.DivMod
- lake build