### PR TITLE
docs(div): mark legacy N3 AnyX9 carry wrappers

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N3V4StackPreAnyX9.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3V4StackPreAnyX9.lean
@@ -77,8 +77,9 @@ theorem evm_mod_n3_to_loopSetup_stack_pre_spec_v4_noNop_anyX9 (sp base : Word)
       (by pcFree)
       hraw)
 
-/-- Generalization of `evm_mod_n3_preloop_loop_stack_pre_spec_v4_noNop`
-    allowing any initial `x9` value. -/
+/-- Legacy raw-carry generalization of
+    `evm_mod_n3_preloop_loop_stack_pre_spec_v4_noNop`, allowing any initial
+    `x9` value. Prefer selected-carry wrappers for new v4 work. -/
 theorem evm_mod_n3_preloop_loop_stack_pre_spec_v4_noNop_anyX9 (sp base : Word)
     (x9Init : Word)
     (a b : EvmWord)
@@ -229,8 +230,9 @@ theorem evm_mod_n3_preloop_loop_stack_pre_spec_v4_noNop_anyX9 (sp base : Word)
       v11Old jMem retMem dMem dloMem scratchUn0 scratchMem raVal)
     hSetup hLoopF
 
-/-- Generalization of `evm_mod_n3_stack_pre_to_unified_post_v4_noNop`
-    allowing any initial `x9` value. -/
+/-- Legacy raw-carry generalization of
+    `evm_mod_n3_stack_pre_to_unified_post_v4_noNop`, allowing any initial
+    `x9` value. Prefer selected-carry wrappers for new v4 work. -/
 theorem evm_mod_n3_stack_pre_to_unified_post_v4_noNop_anyX9 (sp base : Word)
     (x9Init : Word)
     (a b : EvmWord)


### PR DESCRIPTION
## Summary
- mark the N3 AnyX9 MOD wrappers that expose raw Carry2NzAll as legacy compatibility surfaces
- direct new v4 work toward selected-carry wrappers
- keep theorem statements and proof behavior unchanged

Note: the working tree still has an unrelated unstaged execution-specs submodule pointer change; it is not part of this PR.

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.N3V4StackPreAnyX9
- git diff --check
- rg -n "\b(sorry|admit)\b|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/Spec/N3V4StackPreAnyX9.lean
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build EvmAsm.Evm64.DivMod
- lake build