### PR TITLE
docs(agents): require aligned memory accesses in RV64 ops

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,19 @@ When adding or modifying proofs:
   3. Breaking up large `have`s into separate lemmas so the core composition step has fewer atoms to permute.
 - **Exception for Shift composition files**: `set_option maxHeartbeats` up to 6400000 is acceptable for body/path composition proofs (Section 4+) which are bottlenecked by `xperm_hyp` permutation on large atom chains. Subsumption lemmas (Section 2) should NOT need heartbeat overrides — they use structural `unionAll` reasoning.
 
+- **All memory accesses must be aligned.** The verified RV64 operational semantics in `EvmAsm/Rv64/Basic.lean` defines `isValidDwordAccess = isValidMemAddr && isAligned8` and `isValidMemAccess = isValidMemAddr && isAligned4` — i.e. an `LD`/`SD` has no semantics unless its address is a multiple of 8, and `LW`/`LWU`/`SW` likewise need a multiple of 4. Per-width requirements:
+
+  | Op            | Width | Required alignment |
+  |---------------|-------|--------------------|
+  | `LD`, `SD`    | 8 B   | `addr % 8 == 0`    |
+  | `LW`, `LWU`, `SW` | 4 B   | `addr % 4 == 0`    |
+  | `LH`, `LHU`, `SH` | 2 B   | `addr % 2 == 0`    |
+  | `LB`, `LBU`, `SB` | 1 B   | any                |
+
+  Proofs that reach an unaligned access cannot close — `isValidDwordAccess`/`isValidMemAccess` evaluate to `false`. Ziskemu may tolerate unaligned reads at runtime, but the verified subset does not, so do **not** rely on runtime tolerance when writing new RV64 snippets.
+
+  When the natural source/dest address is unaligned (e.g. SSZ blob base at `INPUT_BASE + 18 = 0x40000012`, mod 4 = 2), pick accesses whose alignment still works (`LBU`/`SB` always do; `LH`/`LHU` at mod 2 = 0; `LWU` at mod 4 = 0; `LD`/`SD` at mod 8 = 0) and reconstruct wider values by shift/OR packing. Pre-existing unaligned reads in `EvmAsm/Stateless/SSZ/Decode/Program.lean` are debt, not a precedent.
+
 ## Common Pitfalls
 
 1. **Notation issues**: Custom notations (like `↦ᵣ ?`) may not parse correctly; use functions directly


### PR DESCRIPTION
## Summary
Add an explicit \`Critical Rules\` entry documenting the alignment requirement enforced by the verified RV64 operational semantics in \`EvmAsm/Rv64/Basic.lean\` (\`isValidDwordAccess\`, \`isValidMemAccess\`). LD/SD need addr%8==0; LW/LWU/SW need addr%4==0; LH/LHU/SH need addr%2==0; byte ops have no constraint. Ziskemu tolerates unaligned reads but proofs cannot close on them.

## Why now
A byte-copy encoder I tried in \`EvmAsm/Stateless/SSZ/Encode/Program.lean\` reached unaligned LDs (\`chain_config_addr + 19\` etc., with chain_config_addr mod 8 = 6) and panicked ziskemu on inputs large enough to push the trailing LD past the input section. Pre-existing unaligned \`LWU\` in \`Stateless/SSZ/Decode/Program.lean:read_chain_id\` is called out as debt, not precedent.

## Test plan
- [x] Docs-only change; no build impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)