### PR TITLE
test(stateless): cover decoder offset chasing with non-empty witness.codes

### DIFF
--- a/scripts/codegen-stateless-spec-output-check.sh
+++ b/scripts/codegen-stateless-spec-output-check.sh
@@ -31,9 +31,11 @@
 # non-empty payloads will switch this stamp to a real computation.
 #
 # Fixtures: 5 chain_id values (1, 0x1234567890ABCDEF, 0, max-u32,
-# max-u64) at the default fork=0, plus one fork=1 case
+# max-u64) at the default fork=0; one fork=1 case
 # (`chain1_fork1`) exercising the `active_fork.fork` passthrough
-# from input through to OUTPUT[49..57).
+# from input through to OUTPUT[49..57); and one non-empty
+# `witness.codes` case (`chain1_witcode`) exercising the decoder's
+# outer-offset walk under input-layout drift.
 #
 # Exit:
 #   0 -- all fixtures match
@@ -71,6 +73,7 @@ run_fixture() {
   local label="$1"
   local cid="$2"
   local fork="${3:-0}"
+  local witness_code_hex="${4:-}"
 
   local safe="${label//[^0-9A-Za-z_]/_}"
   local input_file="$REPO_ROOT/gen-out/stateless_guest-spec-${safe}.input"
@@ -78,10 +81,12 @@ run_fixture() {
   local spec_exp_file="$REPO_ROOT/gen-out/stateless_guest-spec-${safe}.spec-expected"
   local log_file="$REPO_ROOT/gen-out/stateless_guest-spec-${safe}.emu.log"
 
-  echo "==> [$label] gen new-schema SSZ input + spec expected (chain_id=$cid, fork=$fork)"
+  echo "==> [$label] gen new-schema SSZ input + spec expected (chain_id=$cid, fork=$fork, code=${witness_code_hex:-empty})"
   uv run --directory execution-specs --quiet python3 -c "
 import struct, sys
 from ethereum.forks.amsterdam.stateless_ssz import (
+    MAX_BYTES_PER_CODE,
+    MAX_WITNESS_CODES,
     STATELESS_INPUT_SCHEMA_ID_BYTES,
     SszChainConfig,
     SszExecutionWitness,
@@ -94,13 +99,18 @@ from ethereum.forks.amsterdam.stateless_ssz import (
 )
 from ethereum.forks.amsterdam.stateless_guest import run_stateless_guest
 from remerkleable.basic import uint64
+from remerkleable.byte_arrays import ByteList
+from remerkleable.complex import List as SszList
 
 cid = int(sys.argv[1], 0)
 fork_idx = int(sys.argv[4], 0)
+code_hex = sys.argv[5]
 
 # Build the new-schema StatelessInput: empty new_payload_request,
-# empty witness, chain_config(cid, SszForkConfig(fork=fork_idx,
-# empty activation, empty blob_schedule)), empty public_keys.
+# witness whose 'state' and 'headers' lists are empty but whose
+# 'codes' list contains zero or one element (controlled by the
+# fixture), chain_config(cid, SszForkConfig(fork=fork_idx, empty
+# activation, empty blob_schedule)), empty public_keys.
 empty_activation = SszForkActivation(
     block_number=SszOptionalForkActivationValue(),
     timestamp=SszOptionalForkActivationValue(),
@@ -111,9 +121,17 @@ fork_cfg = SszForkConfig(
     blob_schedule=SszOptionalBlobSchedule(),
 )
 cc = SszChainConfig(chain_id=uint64(cid), active_fork=fork_cfg)
+
+CodeBL = ByteList[MAX_BYTES_PER_CODE]
+CodesList = SszList[CodeBL, MAX_WITNESS_CODES]
+codes_arg = ()
+if code_hex:
+    codes_arg = (CodeBL(bytes.fromhex(code_hex)),)
+witness = SszExecutionWitness(codes=CodesList(*codes_arg))
+
 ssz_input = SszStatelessInput(
     new_payload_request=SszNewPayloadRequest(),
-    witness=SszExecutionWitness(),
+    witness=witness,
     chain_config=cc,
     public_keys=(),
 )
@@ -134,7 +152,7 @@ spec_bytes = bytes(run_stateless_guest(input_bytes))
 assert len(spec_bytes) == 73, f'spec: expected 73, got {len(spec_bytes)}'
 with open(sys.argv[3], 'w') as f:
     f.write(spec_bytes.hex())
-" "$cid" "$input_file" "$spec_exp_file" "$fork"
+" "$cid" "$input_file" "$spec_exp_file" "$fork" "$witness_code_hex"
 
   echo "==> [$label] ziskemu run"
   "$ZISKEMU" -e gen-out/stateless_guest.elf -i "$input_file" \
@@ -185,6 +203,16 @@ run_fixture "chain_max_u64"         0xFFFFFFFFFFFFFFFF      || fail=1
 # One fixture suffices: the encoder pipes the raw u64 from x12 to
 # OUTPUT[49..57) without inspecting its value.
 run_fixture "chain1_fork1"          1                  1    || fail=1
+
+# Non-empty witness.codes -- exercises the decoder's outer-offset
+# walk on a non-trivial input layout. The witness section grows by
+# one ByteList entry; the outer `chain_config` offset (read by
+# `read_chain_id` from SSZ_BASE+8) shifts accordingly. ELF output
+# is unchanged (chain_config echoed, valid=False as for empty
+# witness), so this verifies that `read_chain_id` /
+# `read_active_fork` still land on the correct `chain_config_addr`
+# under input-layout drift. Code blob is 4 deterministic bytes.
+run_fixture "chain1_witcode"        1                  0    "deadbeef" || fail=1
 
 if [[ "$fail" -eq 0 ]]; then
   echo "==> PASS: all spec-output fixtures match the new SSZ schema"


### PR DESCRIPTION
## Summary
Add fixture \`chain1_witcode\` to \`codegen-stateless-spec-output-check.sh\` that ships an \`SszStatelessInput\` whose \`witness.codes\` list holds a single 4-byte \`ByteList\` (\`deadbeef\`). The witness section grows; the outer container's \`chain_config\` offset shifts; \`chain_config_addr\` lands at a different absolute address than in the empty-witness fixtures.

\`read_chain_id\` and \`read_active_fork\` chase the outer + inner offsets unchanged, so the ELF still echoes the same \`chain_config\`. The fixture locks down the decoder's offset walk against input-layout drift without requiring any encoder change.

## Test plan
- [x] \`scripts/codegen-stateless-spec-output-check.sh\` — all 7 fixtures (5 chain_id sweep + 1 fork passthrough + new \`chain1_witcode\`) match \`run_stateless_guest(input_bytes)\` byte-for-byte.

Stacks on #6734; follows the alignment-rule docs in #6748.

🤖 Generated with [Claude Code](https://claude.com/claude-code)