### PR TITLE
docs(div): mark legacy mod compose carry wrappers

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPathN2LoopUnified.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPathN2LoopUnified.lean
@@ -2,6 +2,9 @@
   EvmAsm.Evm64.DivMod.Compose.ModFullPathN2LoopUnified
 
   MOD n=2 full-path composition using the shared N2 bundled loop bridge.
+  These wrappers still thread the legacy universal Carry2NzAll package and
+  should be treated as compatibility surfaces only. New v4 stack/callable work
+  should use selected/reachable carry evidence instead.
 -/
 
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.Full

--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPathN3LoopUnified.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPathN3LoopUnified.lean
@@ -2,6 +2,9 @@
   EvmAsm.Evm64.DivMod.Compose.ModFullPathN3LoopUnified
 
   MOD n=3 full-path composition using the shared N3 unified loop post bundle.
+  These wrappers still thread the legacy universal Carry2NzAll package and
+  should be treated as compatibility surfaces only. New v4 stack/callable work
+  should use selected/reachable carry evidence instead.
 -/
 
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3LoopUnified

--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPathN3V4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPathN3V4NoNop.lean
@@ -1041,9 +1041,11 @@ theorem divK_loop_n3_call_max_mod_v4_from_source_exact_loopIterScratch_noNop (sp
       v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q0Old raVal)
     J1 J0f
 
-/-- Unified n=3 v4 no-NOP loop path over `modCode_noNop_v4` from the
+/-- Legacy unified n=3 v4 no-NOP loop path over `modCode_noNop_v4` from the
     callable-ready no-`x1` source, selecting the max/call branch for both
-    iterations and preserving concrete caller `x1`. -/
+    iterations and preserving concrete caller `x1`. This wrapper still exposes
+    the raw `Carry2NzAll` package; selected/reachable carry wrappers should be
+    preferred for new v4 stack/callable work. -/
 theorem divK_loop_n3_unified_from_source_exact_loopIterScratch_mod_v4_noNop
     (bltu_1 bltu_0 : Bool) (sp base : Word)
     (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)

--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPathN3V4NoNopPreloop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPathN3V4NoNopPreloop.lean
@@ -12,9 +12,11 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 
-/-- Helper: instantiate the MOD v4 no-NOP exact-`x1` n=3 loop with explicit
-    normalized values, keeping the v4 div128 scratch cell and caller-owned
-    `x1` split out of the loop source. -/
+/-- Legacy helper: instantiate the MOD v4 no-NOP exact-`x1` n=3 loop with
+    explicit normalized values, keeping the v4 div128 scratch cell and
+    caller-owned `x1` split out of the loop source. This wrapper still exposes
+    the raw `Carry2NzAll` package; selected/reachable carry wrappers should be
+    preferred for new v4 stack/callable work. -/
 theorem evm_mod_n3_loop_unified_inst_noNop_exact_x1_v4
     (bltu_1 bltu_0 : Bool) (sp base : Word)
     (shift antiShift b0' b1' b2' b3' u0 u1 u2 u3 u4 : Word)


### PR DESCRIPTION
## Summary
- mark N2/N3 MOD compose raw Carry2NzAll routes as legacy compatibility surfaces
- document that new v4 stack/callable work should prefer selected/reachable carry wrappers
- no theorem statements or proofs changed

## Verification
- lake build EvmAsm.Evm64.DivMod.Compose.ModFullPathN2LoopUnified
- lake build EvmAsm.Evm64.DivMod.Compose.ModFullPathN3LoopUnified
- lake build EvmAsm.Evm64.DivMod.Compose.ModFullPathN3V4NoNopPreloop
- lake build EvmAsm.Evm64.DivMod.Compose.ModFullPathN3V4NoNop
- git diff --check
- forbidden scan over touched files
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build EvmAsm.Evm64.DivMod
- lake build