### PR TITLE
docs(div): mark legacy loop compose carry wrappers

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopComposeN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopComposeN2.lean
@@ -12,6 +12,10 @@
   This file provides:
   1. Address linking lemmas for j=2 → j=1 transition
   2. Unified max-path per-iteration specs for j=2, j=1, and j=0
+
+  The compose surfaces in this file still thread the legacy universal
+  Carry2NzAll package. They are compatibility surfaces for older callers; new
+  v4 N2 stack/callable work should use selected/reachable carry wrappers.
 -/
 
 import EvmAsm.Evm64.DivMod.LoopIterN2

--- a/EvmAsm/Evm64/DivMod/LoopComposeN3.lean
+++ b/EvmAsm/Evm64/DivMod/LoopComposeN3.lean
@@ -7,6 +7,10 @@
   For n=3, the loop runs 2 iterations. The j=1 iteration modifies u[1]..u[4]
   and stores q[1]. The j=0 iteration reads u[0]..u[4] (where u[1]..u[4]
   are the updated values from j=1) and stores q[0].
+
+  The compose surfaces in this file still thread the legacy universal
+  Carry2NzAll package. They are compatibility surfaces for older callers; new
+  v4 N3 stack/callable work should use selected/reachable carry wrappers.
 -/
 
 import EvmAsm.Evm64.DivMod.LoopIterN3NoNop


### PR DESCRIPTION
## Summary
- mark generic N2/N3 loop-compose surfaces as legacy Carry2NzAll compatibility routes
- direct new v4 N2/N3 stack/callable work to selected/reachable carry wrappers
- no theorem statements or proofs changed

## Verification
- lake build EvmAsm.Evm64.DivMod.LoopComposeN2
- lake build EvmAsm.Evm64.DivMod.LoopComposeN3
- git diff --check
- forbidden scan over touched files
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build EvmAsm.Evm64.DivMod
- lake build