### PR TITLE
docs(div): mark legacy loop unified carry wrappers

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopUnifiedN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopUnifiedN2.lean
@@ -12,6 +12,10 @@
      Compose j=2 (max or call) with the two-iteration intermediate.
   3. `divK_loop_n2_unified_spec_within (bltu_2 bltu_1 bltu_0 : Bool)`:
      Full three-iteration — dispatches to the above via cases on bltu_2.
+
+  These generic unified-loop surfaces still consume the legacy universal
+  Carry2NzAll package. New v4 n=2 work should use the selected/reachable
+  carry wrappers in Compose/FullPathN2V4NoNopLoopSelected.lean instead.
 -/
 
 import EvmAsm.Evm64.DivMod.LoopComposeN2

--- a/EvmAsm/Evm64/DivMod/LoopUnifiedN3.lean
+++ b/EvmAsm/Evm64/DivMod/LoopUnifiedN3.lean
@@ -10,6 +10,10 @@
 
   The proofs delegate to the existing per-path theorems in LoopComposeN3.lean
   via `cases bltu`, then bridge the pre/postconditions to the unified forms.
+
+  These generic unified-loop surfaces still consume the legacy universal
+  Carry2NzAll package. New v4 n=3 work should use selected/reachable carry
+  wrappers instead of this raw-carry route.
 -/
 
 import EvmAsm.Evm64.DivMod.LoopComposeN3


### PR DESCRIPTION
## Summary
- mark generic N2/N3 unified-loop surfaces as legacy Carry2NzAll compatibility routes
- point new v4 N2 work at the selected-carry replacement module and new N3 work at selected/reachable carry wrappers
- no theorem statements or proofs changed

## Verification
- lake build EvmAsm.Evm64.DivMod.LoopUnifiedN2
- lake build EvmAsm.Evm64.DivMod.LoopUnifiedN3
- git diff --check
- forbidden scan over touched files
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build EvmAsm.Evm64.DivMod
- lake build