### PR TITLE
test(stateless): cover decoder offset walk under non-empty witness.state

### DIFF
--- a/scripts/codegen-stateless-spec-output-check.sh
+++ b/scripts/codegen-stateless-spec-output-check.sh
@@ -74,6 +74,7 @@ run_fixture() {
   local cid="$2"
   local fork="${3:-0}"
   local witness_code_hex="${4:-}"
+  local witness_state_hex="${5:-}"
 
   local safe="${label//[^0-9A-Za-z_]/_}"
   local input_file="$REPO_ROOT/gen-out/stateless_guest-spec-${safe}.input"
@@ -81,12 +82,14 @@ run_fixture() {
   local spec_exp_file="$REPO_ROOT/gen-out/stateless_guest-spec-${safe}.spec-expected"
   local log_file="$REPO_ROOT/gen-out/stateless_guest-spec-${safe}.emu.log"
 
-  echo "==> [$label] gen new-schema SSZ input + spec expected (chain_id=$cid, fork=$fork, code=${witness_code_hex:-empty})"
+  echo "==> [$label] gen new-schema SSZ input + spec expected (chain_id=$cid, fork=$fork, code=${witness_code_hex:-empty}, state=${witness_state_hex:-empty})"
   uv run --directory execution-specs --quiet python3 -c "
 import struct, sys
 from ethereum.forks.amsterdam.stateless_ssz import (
     MAX_BYTES_PER_CODE,
+    MAX_BYTES_PER_WITNESS_NODE,
     MAX_WITNESS_CODES,
+    MAX_WITNESS_NODES,
     STATELESS_INPUT_SCHEMA_ID_BYTES,
     SszChainConfig,
     SszExecutionWitness,
@@ -105,12 +108,13 @@ from remerkleable.complex import List as SszList
 cid = int(sys.argv[1], 0)
 fork_idx = int(sys.argv[4], 0)
 code_hex = sys.argv[5]
+state_hex = sys.argv[6]
 
 # Build the new-schema StatelessInput: empty new_payload_request,
-# witness whose 'state' and 'headers' lists are empty but whose
-# 'codes' list contains zero or one element (controlled by the
-# fixture), chain_config(cid, SszForkConfig(fork=fork_idx, empty
-# activation, empty blob_schedule)), empty public_keys.
+# witness whose 'state'/'codes' lists each hold zero or more
+# entries (controlled by the fixture), 'headers' empty,
+# chain_config(cid, SszForkConfig(fork=fork_idx, empty activation,
+# empty blob_schedule)), empty public_keys.
 empty_activation = SszForkActivation(
     block_number=SszOptionalForkActivationValue(),
     timestamp=SszOptionalForkActivationValue(),
@@ -129,7 +133,18 @@ if code_hex:
     # Multiple entries separated by ':', each is a hex blob.
     code_entries = code_hex.split(':')
     codes_arg = tuple(CodeBL(bytes.fromhex(c)) for c in code_entries)
-witness = SszExecutionWitness(codes=CodesList(*codes_arg))
+
+NodeBL = ByteList[MAX_BYTES_PER_WITNESS_NODE]
+NodesList = SszList[NodeBL, MAX_WITNESS_NODES]
+state_arg = ()
+if state_hex:
+    state_entries = state_hex.split(':')
+    state_arg = tuple(NodeBL(bytes.fromhex(s)) for s in state_entries)
+
+witness = SszExecutionWitness(
+    state=NodesList(*state_arg),
+    codes=CodesList(*codes_arg),
+)
 
 ssz_input = SszStatelessInput(
     new_payload_request=SszNewPayloadRequest(),
@@ -154,7 +169,7 @@ spec_bytes = bytes(run_stateless_guest(input_bytes))
 assert len(spec_bytes) == 73, f'spec: expected 73, got {len(spec_bytes)}'
 with open(sys.argv[3], 'w') as f:
     f.write(spec_bytes.hex())
-" "$cid" "$input_file" "$spec_exp_file" "$fork" "$witness_code_hex"
+" "$cid" "$input_file" "$spec_exp_file" "$fork" "$witness_code_hex" "$witness_state_hex"
 
   echo "==> [$label] ziskemu run"
   "$ZISKEMU" -e gen-out/stateless_guest.elf -i "$input_file" \
@@ -222,6 +237,15 @@ run_fixture "chain1_witcode"        1                  0    "deadbeef" || fail=1
 # `chain_config` offset shifts further than the single-entry case,
 # and the decoder must still chase it correctly.
 run_fixture "chain1_witcode_2"      1                  0    "deadbeef:cafef00d" || fail=1
+
+# Non-empty witness.state -- parallel to witness.codes but exercises
+# the FIRST inner field of `SszExecutionWitness` (state nodes). The
+# inner offset table inside the witness section now has state_offset
+# strictly less than codes_offset, but the outer-offset chase the
+# decoder performs (SSZ_BASE+8 -> chain_config_addr) is identical:
+# we verify the decoder doesn't accidentally depend on which inner
+# witness field is non-empty. State entry is one arbitrary node.
+run_fixture "chain1_witstate"       1                  0    ""           "a1b2c3d4e5f60718" || fail=1
 
 if [[ "$fail" -eq 0 ]]; then
   echo "==> PASS: all spec-output fixtures match the new SSZ schema"


### PR DESCRIPTION
## Summary
Add fixture \`chain1_witstate\` that ships an \`SszStatelessInput\` whose \`witness.state\` list contains one \`ByteList[MAX_BYTES_PER_WITNESS_NODE]\` entry (8 bytes: \`a1b2c3d4e5f60718\`). The inner-witness offset table now has \`state_offset\` strictly less than \`codes_offset\`. The outer-offset chase the decoder performs (SSZ_BASE+8 → chain_config_addr) is unchanged, so the ELF still echoes the same chain_config.

Complements \`chain1_witcode\` / \`chain1_witcode_2\` by exercising the FIRST inner field of \`SszExecutionWitness\` rather than the SECOND — locks down that the decoder doesn't accidentally depend on which inner witness field is non-empty.

## Test plan
- [x] \`scripts/codegen-stateless-spec-output-check.sh\` — all 9 fixtures pass.

Stacks on #6754.

🤖 Generated with [Claude Code](https://claude.com/claude-code)