### PR TITLE
docs(div): mark legacy unified carry wrappers

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/Unified.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/Unified.lean
@@ -19,6 +19,13 @@
   Pre/post are unchanged; the proof is a single `cpsTripleWithin_mono_nSteps`
   application with `by decide` for the bound inequality.
 
+  Legacy carry note:
+  The n=2 and n=3 `_uni` wrappers in this file still thread the old universal
+  `Carry2NzAll` package through the dispatcher stack surface. Those wrappers
+  are compatibility shims for the pre-selected-carry proof path. New final v4
+  stack work should use selected-carry wrappers instead of extending these raw
+  `Carry2NzAll` surfaces.
+
   Authored by @pirapira; implemented by Hermes-bot (evm-hermes).
 
   Refs: GH #61, beads `evm-asm-unta` (parent `evm-asm-4keh`, grandparent


### PR DESCRIPTION
## Summary
- add a legacy carry note to Spec.Unified for N2/N3 _uni wrappers
- clarify those wrappers still thread raw Carry2NzAll and should not be extended for final v4 stack work

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.Unified
- git diff --check
- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth" EvmAsm/Evm64/DivMod/Spec/Unified.lean
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build EvmAsm.Evm64.DivMod
- lake build