### PR TITLE
feat(div): add n1 selected-if-borrow stack wrapper

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N1ExactV4IfBorrowSelectedPath.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N1ExactV4IfBorrowSelectedPath.lean
@@ -1,4 +1,4 @@
-import EvmAsm.Evm64.DivMod.Spec.N1ExactV4IfBorrow
+import EvmAsm.Evm64.DivMod.Spec.N1ExactV4IfBorrowPathWord
 
 namespace EvmAsm.Evm64
 
@@ -171,5 +171,154 @@ theorem FullDivN1CallMaxmaxmaxHdivs_of_selected_path_evidence_getLimbN
       sp base a b jOld v5Old v6Old v7Old v10Old v11Old v2Old
       q3Old q2Old q1Old q0Old retMem dMem dloMem scratchUn0 scratchMem raVal
       hbltu3 hbltu2 hbltu1 hbltu0 hpath hfacts)
+
+/-- No-NOP N1 selected-if-borrow stack wrapper consuming selected path
+    evidence directly, without exposing the older all-true `Carry2NzAll`
+    package at this boundary. -/
+theorem evm_div_n1_call_maxmaxmax_stack_spec_within_word_v4_preNoX1_callableExactFrame_unified_noNop_of_selected_if_borrow_selected_path_semantic_facts_ne_zero_getLimbN
+    (sp base : Word) (a b : EvmWord)
+    (v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (hbnz : b ≠ 0)
+    (hb3z : b.getLimbN 3 = 0) (hb2z : b.getLimbN 2 = 0)
+    (hb1z : b.getLimbN 1 = 0)
+    (hshift_nz : (clzResult (b.getLimbN 0)).1 ≠ 0)
+    (halign : fullDivN1CallMaxmaxmaxExactInputAligned sp base
+      jMem (1 : Word) (fullDivN1Shift (b.getLimbN 0))
+      (fullDivN1NormU (a.getLimbN 0) (a.getLimbN 1)
+        (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0)).1
+      (a.getLimbN 0 >>> ((fullDivN1AntiShift (b.getLimbN 0)).toNat % 64))
+      v11Old (fullDivN1AntiShift (b.getLimbN 0))
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+      (0 : Word) (0 : Word) (0 : Word) (0 : Word)
+      retMem dMem dloMem scratchUn0 scratchMem raVal)
+    (hbltu3 : isTrialN1_j3 true (a.getLimbN 3) (b.getLimbN 0))
+    (hbltu2 : ¬BitVec.ult
+      (loopN1CallMaxmaxmaxR3
+        (fullDivN1NormV (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).1
+        (fullDivN1NormV (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).2.1
+        (fullDivN1NormV (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+        (fullDivN1NormV (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+        (fullDivN1NormU (a.getLimbN 0) (a.getLimbN 1)
+          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0)).2.2.2.1
+        (fullDivN1NormU (a.getLimbN 0) (a.getLimbN 1)
+          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0)).2.2.2.2
+        0 0 0).2.1
+      (fullDivN1NormV (b.getLimbN 0) (b.getLimbN 1)
+        (b.getLimbN 2) (b.getLimbN 3)).1)
+    (hbltu1 : ¬BitVec.ult
+      (loopN1CallMaxmaxmaxR2
+        (fullDivN1NormV (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).1
+        (fullDivN1NormV (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).2.1
+        (fullDivN1NormV (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+        (fullDivN1NormV (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+        (fullDivN1NormU (a.getLimbN 0) (a.getLimbN 1)
+          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0)).2.2.2.1
+        (fullDivN1NormU (a.getLimbN 0) (a.getLimbN 1)
+          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0)).2.2.2.2
+        0 0 0
+        (fullDivN1NormU (a.getLimbN 0) (a.getLimbN 1)
+          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0)).2.2.1).2.1
+      (fullDivN1NormV (b.getLimbN 0) (b.getLimbN 1)
+        (b.getLimbN 2) (b.getLimbN 3)).1)
+    (hbltu0 : ¬BitVec.ult
+      (loopN1CallMaxmaxmaxR1
+        (fullDivN1NormV (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).1
+        (fullDivN1NormV (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).2.1
+        (fullDivN1NormV (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+        (fullDivN1NormV (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+        (fullDivN1NormU (a.getLimbN 0) (a.getLimbN 1)
+          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0)).2.2.2.1
+        (fullDivN1NormU (a.getLimbN 0) (a.getLimbN 1)
+          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0)).2.2.2.2
+        0 0 0
+        (fullDivN1NormU (a.getLimbN 0) (a.getLimbN 1)
+          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0)).2.2.1
+        (fullDivN1NormU (a.getLimbN 0) (a.getLimbN 1)
+          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0)).2.1).2.1
+      (fullDivN1NormV (b.getLimbN 0) (b.getLimbN 1)
+        (b.getLimbN 2) (b.getLimbN 3)).1)
+    (hpath : N1SelectedIfBorrowPathEvidence a b)
+    (hfacts : FullDivN1CallMaxmaxmaxSemanticFactsV4
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)) :
+    cpsTripleWithin unifiedDivBound base (base + nopOff) (divCode_noNop_v4 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult (b.getLimbN 0)).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divStackDispatchPostCallableExactFrame sp a b raVal (signExtend12 4095 : Word) **
+       ((sp + signExtend12 3936) ↦ₘ
+        divKTrialCallV4ScratchOut
+          (fullDivN1NormU (a.getLimbN 0) (a.getLimbN 1)
+            (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0)).2.2.2.2
+          (fullDivN1NormU (a.getLimbN 0) (a.getLimbN 1)
+            (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0)).2.2.2.1
+          (fullDivN1NormV (b.getLimbN 0) (b.getLimbN 1)
+            (b.getLimbN 2) (b.getLimbN 3)).1 scratchMem)) := by
+  have hevidence :=
+    FullDivN1CallMaxmaxmaxSelectedIfBorrowSemanticEvidenceV4_of_selected_path_evidence_getLimbN
+      sp base a b
+      jMem (1 : Word) (fullDivN1Shift (b.getLimbN 0))
+      (fullDivN1NormU (a.getLimbN 0) (a.getLimbN 1)
+        (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0)).1
+      (a.getLimbN 0 >>> ((fullDivN1AntiShift (b.getLimbN 0)).toNat % 64))
+      v11Old (fullDivN1AntiShift (b.getLimbN 0))
+      (0 : Word) (0 : Word) (0 : Word) (0 : Word)
+      retMem dMem dloMem scratchUn0 scratchMem raVal
+      hbltu3 hbltu2 hbltu1 hbltu0 hpath hfacts
+  have hselected :=
+    FullDivN1CallMaxmaxmaxSelectedIfBorrowSemanticEvidenceV4_selectedInput
+      sp base
+      jMem (1 : Word) (fullDivN1Shift (b.getLimbN 0))
+      (fullDivN1NormU (a.getLimbN 0) (a.getLimbN 1)
+        (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0)).1
+      (a.getLimbN 0 >>> ((fullDivN1AntiShift (b.getLimbN 0)).toNat % 64))
+      v11Old (fullDivN1AntiShift (b.getLimbN 0))
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+      (0 : Word) (0 : Word) (0 : Word) (0 : Word)
+      retMem dMem dloMem scratchUn0 scratchMem raVal
+      hevidence
+  have hdivs :=
+    FullDivN1CallMaxmaxmaxHdivs_of_selected_path_evidence_getLimbN
+      sp base a b
+      jMem (1 : Word) (fullDivN1Shift (b.getLimbN 0))
+      (fullDivN1NormU (a.getLimbN 0) (a.getLimbN 1)
+        (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0)).1
+      (a.getLimbN 0 >>> ((fullDivN1AntiShift (b.getLimbN 0)).toNat % 64))
+      v11Old (fullDivN1AntiShift (b.getLimbN 0))
+      (0 : Word) (0 : Word) (0 : Word) (0 : Word)
+      retMem dMem dloMem scratchUn0 scratchMem raVal
+      ((EvmWord.ne_zero_iff_getLimbN_or).mp hbnz)
+      hbltu3 hbltu2 hbltu1 hbltu0 hpath hfacts
+  exact evm_div_n1_call_maxmaxmax_stack_spec_within_word_v4_preNoX1_callableExtra_x9In_exactFrame_unified_noNop_of_selected_if_borrow_input_hdivs
+    sp base a b
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+    v5 v6 v7 v10 v11Old (signExtend12 (4 : BitVec 12) - (4 : Word))
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+    rfl rfl rfl rfl rfl rfl rfl rfl
+    ((EvmWord.ne_zero_iff_getLimbN_or).mp hbnz) hb3z hb2z hb1z
+    hshift_nz halign hselected hdivs
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- stack on PR #6762 and add the no-NOP N1 selected-if-borrow stack wrapper that consumes N1SelectedIfBorrowPathEvidence directly
- build selected input and hdiv packages from selected path evidence instead of the older all-true Carry2NzAll package boundary

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.N1ExactV4IfBorrowSelectedPath
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- forbidden shortcut scan over touched file
- lake build EvmAsm.Evm64.DivMod
- lake build

Stacked on: #6762
Bead: evm-asm-9iqmw.7.1.6.1.1