### PR TITLE
test(stateless): cover decoder under simultaneously-populated witness.state + witness.codes

### DIFF
--- a/scripts/codegen-stateless-spec-output-check.sh
+++ b/scripts/codegen-stateless-spec-output-check.sh
@@ -247,6 +247,13 @@ run_fixture "chain1_witcode_2"      1                  0    "deadbeef:cafef00d" 
 # witness field is non-empty. State entry is one arbitrary node.
 run_fixture "chain1_witstate"       1                  0    ""           "a1b2c3d4e5f60718" || fail=1
 
+# Both witness.state AND witness.codes non-empty simultaneously --
+# the inner-witness offset table now has three pairwise-distinct
+# offsets (state_offset < codes_offset < headers_offset), pushing
+# the outer chain_config offset further than any single-field case.
+# Decoder still chases SSZ_BASE+8 -> chain_config_addr correctly.
+run_fixture "chain1_witboth"        1                  0    "deadbeef"   "a1b2c3d4e5f60718" || fail=1
+
 if [[ "$fail" -eq 0 ]]; then
   echo "==> PASS: all spec-output fixtures match the new SSZ schema"
   exit 0


### PR DESCRIPTION
## Summary
Add fixture \`chain1_witboth\` whose \`witness.state\` carries one node (\`a1b2c3d4e5f60718\`) and \`witness.codes\` carries one byte-list (\`deadbeef\`). The inner-witness offset table now has three pairwise-distinct u32 offsets (state_offset < codes_offset < headers_offset).

This is the cross-product corner of the previous single-field fixtures (#6749, #6754, #6760, all merged) — verifies the decoder's outer-offset chase doesn't accidentally depend on having at most one inner witness field populated.

## Test plan
- [x] \`scripts/codegen-stateless-spec-output-check.sh\` — all 10 fixtures pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)