### PR TITLE
docs(div): mark legacy N2 N3 loop carry lifts

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2Loop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2Loop.lean
@@ -7,6 +7,10 @@
   - Loop: divK_loop_n2_unified_spec_within (base+448 → base+904)
 
   Follows the pattern of FullPathN3Loop.lean but for n=2.
+
+  Legacy carry note: this lift module still exposes the raw `Carry2NzAll`
+  package. It is a compatibility surface for older full-path composition;
+  final/public v4 n=2 stack work should use selected/reachable carry wrappers.
 -/
 
 -- `FullPathN4Loop` (5-hop) transitively reaches `FullPathN2` via
@@ -100,7 +104,10 @@ theorem loopExitPostN2_j0_eq (sp q_f c3 un0F un1F un2F un3F u4F
 -- Lift unified n=2  loop from sharedDivModCode to divCode
 -- ============================================================================
 
-/-- Lift the unified n=2 3-iteration  loop spec from sharedDivModCode to divCode. -/
+/-- Lift the unified n=2 3-iteration loop spec from sharedDivModCode to divCode.
+
+    Legacy compatibility surface: this still consumes the raw `Carry2NzAll`
+    package. New v4 n=2 work should route through selected carry evidence. -/
 theorem divK_loop_n2_unified_divCode (bltu_2 bltu_1 bltu_0 : Bool)
     (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3Loop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3Loop.lean
@@ -4,6 +4,10 @@
   Lifts n=3 two-iteration loop compositions from sharedDivModCode to divCode,
   and composes with the pre-loop (base → base+448) to produce
   preloop+loop specs (base → base+904).
+
+  Legacy carry note: this lift module still exposes the raw `Carry2NzAll`
+  package. It is a compatibility surface for older full-path composition;
+  final/public v4 n=3 stack work should use selected/reachable carry wrappers.
 -/
 
 -- `LoopUnifiedN3` transitively imports `LoopComposeN3`.
@@ -64,7 +68,10 @@ theorem n3_qa0 {sp : Word} :
 -- Lift unified n=3  loop from sharedDivModCode to divCode
 -- ============================================================================
 
-/-- Lift the unified n=3 2-iteration  loop spec from sharedDivModCode to divCode. -/
+/-- Lift the unified n=3 2-iteration loop spec from sharedDivModCode to divCode.
+
+    Legacy compatibility surface: this still consumes the raw `Carry2NzAll`
+    package. New v4 n=3 work should route through selected carry evidence. -/
 theorem divK_loop_n3_unified_divCode (bltu_1 bltu_0 : Bool)
     (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old : Word)
@@ -88,7 +95,10 @@ theorem divK_loop_n3_unified_divCode (bltu_1 bltu_0 : Bool)
       retMem dMem dloMem scratch_un0 base halign
       hbltu_1 hbltu_0 hcarry2)
 
-/-- No-NOP variant of `divK_loop_n3_unified_divCode`. -/
+/-- No-NOP variant of `divK_loop_n3_unified_divCode`.
+
+    Legacy compatibility surface: this still consumes the raw `Carry2NzAll`
+    package. New v4 n=3 work should route through selected carry evidence. -/
 theorem divK_loop_n3_unified_divCode_noNop (bltu_1 bltu_0 : Bool)
     (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old : Word)


### PR DESCRIPTION
## Summary
- stack on PR #6773 and mark FullPathN2Loop / FullPathN3Loop raw Carry2NzAll lift wrappers as legacy compatibility surfaces
- point final/public v4 N2/N3 work toward selected/reachable carry wrappers
- no theorem statements or proofs changed

## Verification
- lake build EvmAsm.Evm64.DivMod.Compose.FullPathN2Loop EvmAsm.Evm64.DivMod.Compose.FullPathN3Loop
- git diff --check
- forbidden shortcut scan over touched files
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build EvmAsm.Evm64.DivMod
- lake build

Stacked on: #6773
Beads: evm-asm-9iqmw.7.1.6.2.1.1, evm-asm-9iqmw.7.1.6.3.1.1