### PR TITLE
docs(div): mark legacy v4 N2 N3 loop carry wrappers

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNopLoopUnified.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNopLoopUnified.lean
@@ -457,7 +457,11 @@ theorem loopN2CallCallCallSourceConds_of_selectedCarryV4
 /-- Unified n=2 v4 no-NOP loop source theorem, dispatching to the 8 per-case
     proofs via `bltu_2 × bltu_1 × bltu_0`.  Preserves caller-owned exact `x1`.
     The 672-step bound accommodates the worst-case (all-call) path; lighter paths
-    use `cpsTripleWithin_mono_nSteps` to fit. -/
+    use `cpsTripleWithin_mono_nSteps` to fit.
+
+    Legacy compatibility surface: this still consumes the raw `Carry2NzAll`
+    package. New v4 n=2 work should use the selected-carry sibling in
+    `FullPathN2V4NoNopLoopSelected`. -/
 theorem divK_loop_n2_unified_from_source_exact_loopIterScratch_v4_noNop
     (bltu_2 bltu_1 bltu_0 : Bool) (sp base : Word)
     (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
@@ -911,7 +915,10 @@ theorem divK_loop_n2_unified_from_source_exact_loopIterScratch_v4_noNop
 
 /-- Instantiate the v4/no-NOP n=2 unified loop with explicit normalized values.
     Separates loop application from preloop composition for heartbeat budgeting.
-    Parameters match `evm_div_n2_loop_unified_inst_noNop` plus `scratchMem` and `raVal`. -/
+    Parameters match `evm_div_n2_loop_unified_inst_noNop` plus `scratchMem` and `raVal`.
+
+    Legacy compatibility surface: this still consumes the raw `Carry2NzAll`
+    package. New v4 n=2 work should use the selected-carry sibling. -/
 theorem evm_div_n2_loop_unified_inst_noNop_exact_x1_v4
     (bltu_2 bltu_1 bltu_0 : Bool) (sp base : Word)
     (shift antiShift v0' v1' v2' v3' u0S u1S u2S u3S u4_s : Word)

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V4NoNopMaxCall.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V4NoNopMaxCall.lean
@@ -291,7 +291,10 @@ theorem divK_loop_n3_max_call_from_source_exact_loopIterScratch_v4_noNop (sp bas
 
 /-- Unified n=3 v4 no-NOP loop path from the callable-ready no-`x1` source,
     selecting the max/call branch for both iterations and preserving concrete
-    caller `x1`. -/
+    caller `x1`.
+
+    Legacy compatibility surface: this still consumes the raw `Carry2NzAll`
+    package. New v4 n=3 work should use the selected-carry/R1 siblings below. -/
 theorem divK_loop_n3_unified_from_source_exact_loopIterScratch_v4_noNop
     (bltu_1 bltu_0 : Bool) (sp base : Word)
     (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
@@ -638,7 +641,10 @@ theorem divK_loop_n3_unified_from_source_exact_loopIterScratch_v4_noNop_selected
 /-- Helper: instantiate the v4 no-NOP exact-`x1` n=3 loop with explicit
     normalized values. This is the callable-ready analogue of
     `evm_div_n3_loop_unified_inst_noNop`, with the v4 div128 scratch cell and
-    caller-owned `x1` split out of the loop source. -/
+    caller-owned `x1` split out of the loop source.
+
+    Legacy compatibility surface: this still consumes the raw `Carry2NzAll`
+    package. New v4 n=3 work should use the selected-carry/R1 sibling. -/
 theorem evm_div_n3_loop_unified_inst_noNop_exact_x1_v4
     (bltu_1 bltu_0 : Bool) (sp base : Word)
     (shift antiShift b0' b1' b2' b3' u0 u1 u2 u3 u4 : Word)


### PR DESCRIPTION
## Summary
- stack on PR #6774 and mark raw Carry2NzAll v4 no-NOP loop wrappers as legacy compatibility surfaces
- point final/public v4 N2/N3 work toward selected/reachable carry siblings in FullPathN2V4NoNopLoopSelected and FullPathN3V4NoNopMaxCall
- no theorem statements or proofs changed

## Verification
- lake build EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopLoopUnified EvmAsm.Evm64.DivMod.Compose.FullPathN3V4NoNopMaxCall
- git diff --check
- forbidden shortcut scan over touched files
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build EvmAsm.Evm64.DivMod
- lake build

Stacked on: #6774
Beads: evm-asm-9iqmw.7.1.6.2.1.1, evm-asm-9iqmw.7.1.6.3.1.1