### PR TITLE
docs(div): mark legacy exact no-nop carry wrappers

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/UnifiedExactNoNop.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/UnifiedExactNoNop.lean
@@ -3,6 +3,11 @@
 
   Unified-bound exact-x1 no-NOP DIV branch wrappers split out from
   `Spec.Unified` to keep the public dispatcher file under the size cap.
+
+  Legacy carry note: these wrappers still thread the raw normalized
+  `Carry2NzAll` package through exact no-NOP stack surfaces. N2/N3 final v4
+  stack work should use selected/reachable carry wrappers instead of extending
+  these compatibility surfaces.
 -/
 
 import EvmAsm.Evm64.DivMod.Spec.N1ExactNoNop


### PR DESCRIPTION
## Summary
- stack on PR #6776 and mark UnifiedExactNoNop raw Carry2NzAll wrappers as legacy compatibility surfaces
- point N2/N3 final v4 stack work toward selected/reachable carry wrappers instead of extending these exact no-NOP surfaces
- no theorem statements or proofs changed

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.UnifiedExactNoNop
- git diff --check
- forbidden shortcut scan over touched file
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build EvmAsm.Evm64.DivMod
- lake build

Stacked on: #6776
Beads: evm-asm-9iqmw.7.1.6.2.1.1, evm-asm-9iqmw.7.1.6.3.1.1