### PR TITLE
test(stateless): exercise decoder under all three non-chain_config outer fields populated

### DIFF
--- a/scripts/codegen-stateless-spec-output-check.sh
+++ b/scripts/codegen-stateless-spec-output-check.sh
@@ -276,6 +276,14 @@ run_fixture "chain1_witboth"        1                  0    "deadbeef"   "a1b2c3
 # (04 || 32 zeros || 32 zeros = SEC1 uncompressed-marker prefix).
 run_fixture "chain1_pk"             1                  0    ""           ""                  "04$(printf '%064d' 0)$(printf '%064d' 0)" || fail=1
 
+# All three non-chain_config outer slots populated simultaneously
+# -- witness.state + witness.codes + public_keys -- the largest
+# input-layout complexity that still keeps spec output unchanged
+# (chain_config echoed, valid=False). Verifies the decoder's
+# outer-offset read at SSZ_BASE+8 is robust under the maximum
+# byte-budget shift this fixture set produces.
+run_fixture "chain1_all_outer"      1                  0    "deadbeef"   "a1b2c3d4e5f60718"  "04$(printf '%064d' 0)$(printf '%064d' 0)" || fail=1
+
 if [[ "$fail" -eq 0 ]]; then
   echo "==> PASS: all spec-output fixtures match the new SSZ schema"
   exit 0


### PR DESCRIPTION
## Summary
Add fixture \`chain1_all_outer\` — the cross-product corner where \`witness.state\`, \`witness.codes\`, AND \`public_keys\` are all non-empty simultaneously. Largest input-layout complexity that still keeps spec output unchanged (chain_config echoed, valid=False).

Prior fixtures exercise one or two of these slots at a time (#6749 / #6754 / #6760 / #6764 / #6772). This one verifies the decoder's outer-offset read at \`SSZ_BASE+8\` lands on the correct \`chain_config_addr\` when *all* of NPR (always large), witness, and public_keys contribute byte-budget shift simultaneously.

ELF output is identical to the all-empty case because the decoder only reads outer \`offsets[2]\` (chain_config) and never touches \`offsets[0]\`, \`[1]\`, or \`[3]\`.

## Test plan
- [x] \`scripts/codegen-stateless-spec-output-check.sh\` — all 12 fixtures pass.

Stacks on #6772.

🤖 Generated with [Claude Code](https://claude.com/claude-code)