### PR TITLE
docs(div): mark legacy v4 preloop carry wrappers

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNopPreloop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNopPreloop.lean
@@ -285,7 +285,11 @@ theorem evm_div_n2_to_loopSetup_spec_within_v4_noNop_exact_x1_scratch_frame
 /-- n=2 v4/no-NOP path from entry through the exact-x1 loop handoff.
     Mirrors `fullDivN3_preloop_loop_unified_exact_x1_scratch_v4_noNop`.
     Output: divModStackDispatchPreNoX1 + scratchMem ** (.x1 ↦ᵣ raVal) →
-    loopN2UnifiedPostV4NoX1 ** (.x1 ↦ᵣ raVal) ** frame_atoms over divCode_noNop_v4. -/
+    loopN2UnifiedPostV4NoX1 ** (.x1 ↦ᵣ raVal) ** frame_atoms over divCode_noNop_v4.
+
+    Legacy compatibility surface: this still consumes the raw normalized
+    `Carry2NzAll` package. Final/public v4 n=2 stack work should use the
+    selected-carry sibling below. -/
 theorem fullDivN2_preloop_loop_unified_exact_x1_scratch_v4_noNop
     (bltu_2 bltu_1 bltu_0 : Bool) (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old : Word)

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3V4NoNopPreloop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3V4NoNopPreloop.lean
@@ -267,7 +267,11 @@ theorem evm_div_n3_to_loopSetup_spec_within_v4_noNop_exact_x1_scratch_frame
     (fun h hq => by xperm_hyp hq)
     hFramed
 
-/-- n=3 v4/no-NOP path from entry through the exact-x1 loop handoff. -/
+/-- n=3 v4/no-NOP path from entry through the exact-x1 loop handoff.
+
+    Legacy compatibility surface: this still consumes the raw normalized
+    `Carry2NzAll` package. Final/public v4 n=3 stack work should use the
+    selected-carry/R1 siblings below. -/
 theorem fullDivN3_preloop_loop_unified_exact_x1_scratch_v4_noNop
     (bltu_1 bltu_0 : Bool) (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old : Word)


### PR DESCRIPTION
## Summary
- stack on PR #6777 and mark N2/N3 v4 no-NOP preloop wrappers that still consume raw normalized Carry2NzAll as legacy compatibility surfaces
- point final/public v4 N2/N3 stack work toward selected-carry preloop siblings instead
- no theorem statements or proofs changed

## Verification
- lake build EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopPreloop EvmAsm.Evm64.DivMod.Compose.FullPathN3V4NoNopPreloop
- git diff --check
- forbidden shortcut scan over touched files
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build EvmAsm.Evm64.DivMod
- lake build

Stacked on: #6777
Beads: evm-asm-9iqmw.7.1.6.2.1.1, evm-asm-9iqmw.7.1.6.3.1.1