### PR TITLE
docs(div): mark legacy N2 callable post carry wrapper

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNopCallablePost.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2V4NoNopCallablePost.lean
@@ -363,7 +363,11 @@ theorem loopN2UnifiedPostV4NoX1_to_fullDivN2DenormPreV4_frame_TTT
 -- ============================================================================
 
 /-- Compose the n=2 v4 stack preloop+loop path through denormalization to the
-    v4 final no-`x1` post, preserving the exact caller `x1`. -/
+    v4 final no-`x1` post, preserving the exact caller `x1`.
+
+    Legacy compatibility surface: this still consumes the raw normalized
+    `Carry2NzAll` package. Final/public v4 n=2 stack work should use
+    `evm_div_n2_stack_pre_to_unified_post_v4_noNop_selectedCarry`. -/
 theorem evm_div_n2_stack_pre_to_unified_post_v4_noNop (sp base : Word)
     (a b : EvmWord)
     (v5 v6 v7 v10 v11Old : Word)


### PR DESCRIPTION
## Summary
- stack on PR #6779 and merge current origin/main into the new branch before the edit
- mark the raw Carry2NzAll N2 v4/no-NOP callable-post wrapper in FullPathN2V4NoNopCallablePost as a legacy compatibility surface
- point final/public v4 N2 stack work toward the selected-carry callable-post sibling
- no theorem statements or proofs changed

## Verification
- lake build EvmAsm.Evm64.DivMod.Compose.FullPathN2V4NoNopCallablePost
- git diff --check
- forbidden shortcut scan over touched file
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build EvmAsm.Evm64.DivMod
- lake build

Stacked on: #6779
Beads: evm-asm-9iqmw.7.1.6.2.1.1