### PR TITLE
docs(div): clarify legacy mod stack carry surfaces

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N2ModStackSpec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2ModStackSpec.lean
@@ -28,7 +28,9 @@ open EvmAsm.Rv64.AddrNorm (word_add_zero)
 
 Composes `evm_mod_n2_full_unified_spec` with the limb-shaped pre and post
 bridges (`divModStackDispatchPre` ↔ raw cells, and
-`fullModN2UnifiedPost_to_modStackDispatchPost`). -/
+`fullModN2UnifiedPost_to_modStackDispatchPost`). New v4 stack/callable work
+should use selected/reachable carry wrappers instead of extending this raw
+`Carry2NzAll` surface. -/
 theorem evm_mod_n2_stack_spec_within
     (bltu_2 bltu_1 bltu_0 : Bool) (sp base : Word)
     (a b : EvmWord)
@@ -98,10 +100,12 @@ theorem evm_mod_n2_stack_spec_within
         ha0 ha1 ha2 ha3 hmod0 hmod1 hmod2 hmod3 h hq)
     hFull
 
-/-- Legacy raw-carry `_word` form: mirror of `evm_mod_n1_stack_spec_within_word`. Takes a
-single `EvmWord`-valued equality `fullModN2RemainderWord ... = EvmWord.mod a b`
-and projects it into the four per-limb hypotheses via
-`fullModN2_hmods_of_word_eq`. -/
+/-- Legacy raw-carry `_word` form: mirror of `evm_mod_n1_stack_spec_within_word`.
+Takes a single `EvmWord`-valued equality
+`fullModN2RemainderWord ... = EvmWord.mod a b` and projects it into the four
+per-limb hypotheses via `fullModN2_hmods_of_word_eq`. New v4 stack/callable work
+should use selected/reachable carry wrappers instead of this raw `Carry2NzAll`
+surface. -/
 theorem evm_mod_n2_stack_spec_within_word
     (bltu_2 bltu_1 bltu_0 : Bool) (sp base : Word)
     (a b : EvmWord)

--- a/EvmAsm/Evm64/DivMod/Spec/N3ModBridge.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3ModBridge.lean
@@ -114,7 +114,9 @@ theorem fullModN3UnifiedPost_to_modStackDispatchPost
 /-- Legacy raw-carry N=3 MOD stack-level entry point: mirrors `evm_mod_n2_stack_spec_within`
 (Spec/N2ModBridge.lean) and `evm_div_n3_stack_spec_within`
 (Spec/Dispatcher.lean). Composes `evm_mod_n3_full_unified_spec` with
-`fullModN3UnifiedPost_to_modStackDispatchPost`. The step count `542` matches
+`fullModN3UnifiedPost_to_modStackDispatchPost`. New v4 stack/callable work
+should use selected/reachable carry wrappers instead of extending this raw
+`Carry2NzAll` surface. The step count `542` matches
 `evm_mod_n3_full_unified_spec`. -/
 theorem evm_mod_n3_stack_spec_within
     (bltu_1 bltu_0 : Bool) (sp base : Word)
@@ -185,7 +187,9 @@ theorem evm_mod_n3_stack_spec_within
 
 /-- Legacy raw-carry `_word` form of `evm_mod_n3_stack_spec_within`: takes a packed
 `fullModN3RemainderWord` equality with `EvmWord.mod a b` and unpacks it into
-the four per-limb equations. Mirrors `evm_mod_n2_stack_spec_within_word`. -/
+the four per-limb equations. Mirrors `evm_mod_n2_stack_spec_within_word`. New
+v4 stack/callable work should use selected/reachable carry wrappers instead of
+this raw `Carry2NzAll` surface. -/
 theorem evm_mod_n3_stack_spec_within_word
     (bltu_1 bltu_0 : Bool) (sp base : Word)
     (a b : EvmWord)


### PR DESCRIPTION
## Summary
- clarify that N2/N3 MOD stack raw-carry entry points are legacy Carry2NzAll compatibility surfaces
- point new v4 stack/callable work toward selected/reachable carry wrappers

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.N2ModStackSpec
- lake build EvmAsm.Evm64.DivMod.Spec.N3ModBridge
- git diff --check
- rg -n '\b(sorry|admit)\b|set_option maxHeartbeats|set_option maxRecDepth' EvmAsm/Evm64/DivMod/Spec/N2ModStackSpec.lean EvmAsm/Evm64/DivMod/Spec/N3ModBridge.lean
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build EvmAsm.Evm64.DivMod
- lake build