### PR TITLE
test(stateless): exercise decoder with two public_keys entries

### DIFF
--- a/scripts/codegen-stateless-spec-output-check.sh
+++ b/scripts/codegen-stateless-spec-output-check.sh
@@ -276,6 +276,14 @@ run_fixture "chain1_witboth"        1                  0    "deadbeef"   "a1b2c3
 # (04 || 32 zeros || 32 zeros = SEC1 uncompressed-marker prefix).
 run_fixture "chain1_pk"             1                  0    ""           ""                  "04$(printf '%064d' 0)$(printf '%064d' 0)" || fail=1
 
+# Two public_keys entries -- exercises a 2-element SSZ list of
+# fixed-size ByteVectors. Unlike SszList[ByteList, N] (variable-
+# size elements, requires an inner offset table), this list has
+# NO inner offset table; the 130-byte payload is just the two
+# 65-byte entries concatenated. Doubles the public_keys
+# byte-budget. Decoder's outer-offset chase is unaffected.
+run_fixture "chain1_pk_2"           1                  0    ""           ""                  "04$(printf '%064d' 0)$(printf '%064d' 0):04$(printf '%064d' 1)$(printf '%064d' 1)" || fail=1
+
 if [[ "$fail" -eq 0 ]]; then
   echo "==> PASS: all spec-output fixtures match the new SSZ schema"
   exit 0


### PR DESCRIPTION
## Summary
Add fixture \`chain1_pk_2\` whose \`public_keys\` list holds two 65-byte \`ByteVector[PUBLIC_KEY_BYTES]\` entries. Unlike \`SszList[ByteList, N]\` (variable-size elements, requires an inner offset table), this list has NO inner offset table — the 130-byte payload is just the two 65-byte entries concatenated. Doubles the \`public_keys\` byte-budget vs the single-entry case in #6772.

Decoder's outer-offset chase at \`SSZ_BASE+8\` is unaffected by \`public_keys\` content (\`offsets[3]\` is the only outer offset that shifts here, and the decoder never reads it).

## Test plan
- [x] \`scripts/codegen-stateless-spec-output-check.sh\` — all 12 fixtures pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)