### PR TITLE
docs(div): clarify n1 selected evidence boundary

### DIFF
--- a/EvmAsm/Evm64/DivMod/CallableV4DivShape.lean
+++ b/EvmAsm/Evm64/DivMod/CallableV4DivShape.lean
@@ -440,7 +440,12 @@ theorem evm_div_callable_v4_n1_stack_pre_to_callable_post_scratch_shape_selected
 
 /-- N1 selected-if-borrow shape wrapper for callers that still carry the
     all-true path package, while deriving the selected callable evidence from
-    the selected semantic package internally. -/
+    the selected semantic package internally.
+
+    This still requires selected-if-borrow semantic evidence: all-true
+    remainder-bound witnesses select the all-call route, and do not provide the
+    `¬ BitVec.ult ...` max-branch facts needed by the call/max/max/max
+    selected-if-borrow path. -/
 theorem evm_div_callable_v4_n1_stack_pre_to_callable_post_scratch_shape_allTruePathSelectedIfBorrowSemanticEvidence
     (sp base : Word) (a b : EvmWord)
     (v5 v6 v7 v10 v11Old : Word)


### PR DESCRIPTION
## Summary
- document why the all-true N1 remainder-bound witness cannot populate the selected-if-borrow call/max/max/max evidence boundary
- keep the current all-true adapter constrained to selected-if-borrow semantic evidence instead of implying a false derivation from remainder bounds

## Verification
- lake build EvmAsm.Evm64.DivMod.CallableV4DivShape
- git diff --check
- rg -n '\b(sorry|admit)\b|set_option maxHeartbeats|set_option maxRecDepth' EvmAsm/Evm64/DivMod/CallableV4DivShape.lean (no matches)
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build EvmAsm.Evm64.DivMod
- lake build