### PR TITLE
test(stateless): exercise decoder with two witness.state entries

### DIFF
--- a/scripts/codegen-stateless-spec-output-check.sh
+++ b/scripts/codegen-stateless-spec-output-check.sh
@@ -258,6 +258,14 @@ run_fixture "chain1_witcode_2"      1                  0    "deadbeef:cafef00d" 
 # witness field is non-empty. State entry is one arbitrary node.
 run_fixture "chain1_witstate"       1                  0    ""           "a1b2c3d4e5f60718" || fail=1
 
+# Two witness.state entries -- parallel to chain1_witcode_2 but on
+# the FIRST inner witness field. The state list is variable-size
+# elements (ByteList[MAX_BYTES_PER_WITNESS_NODE]), so a 2-element
+# list ships its own u32 inner offset table prefix. Completes the
+# 1-vs-2 entries matrix across all three list-type SSZ slots
+# (codes, state, public_keys).
+run_fixture "chain1_witstate_2"     1                  0    ""           "a1b2c3d4e5f60718:9988776655443322" || fail=1
+
 # Both witness.state AND witness.codes non-empty simultaneously --
 # the inner-witness offset table now has three pairwise-distinct
 # offsets (state_offset < codes_offset < headers_offset), pushing


### PR DESCRIPTION
## Summary
Add fixture \`chain1_witstate_2\` whose \`witness.state\` list holds two \`ByteList[MAX_BYTES_PER_WITNESS_NODE]\` entries (\`a1b2c3d4e5f60718\` and \`9988776655443322\`). The state list is variable-size elements, so a 2-element list ships its own u32 inner offset table prefix.

Completes the 1-vs-2-entries matrix across all three list-type slots:
- \`witness.codes\` — 1 entry (\`chain1_witcode\`), 2 entries (\`chain1_witcode_2\`)
- \`witness.state\` — 1 entry (\`chain1_witstate\`), 2 entries (\`chain1_witstate_2\`, this PR)
- \`public_keys\` — 1 entry (\`chain1_pk\`), 2 entries (\`chain1_pk_2\`, #6784)

The decoder's outer-offset chase at \`SSZ_BASE+8\` is unaffected; ELF output stays the 73-byte SSZ result.

## Test plan
- [x] \`scripts/codegen-stateless-spec-output-check.sh\` — new fixture passes alongside all currently-merged fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)