### PR TITLE
refactor(div): expose v4 floor upper bounds

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/ExactQuotient.lean
+++ b/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/ExactQuotient.lean
@@ -9,6 +9,7 @@
 
 import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV4.QuotientBounds
 import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV4.Un21Bound
+import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV4.UpperBound
 import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV2
 
 namespace EvmAsm.Evm64
@@ -32,6 +33,66 @@ theorem div128Quot_v4_ge_floor_of_un21_eq_r1
       (div128Quot_v4 uHi uLo vTop).toNat :=
   div128Quot_v4_ge_q_true_of_un21_eq_r1 uHi uLo vTop
     hvTop_ge huHi_lt_vTop huHi_lt_pow63 hUn21_lt_vTop hUn21_eq_r1
+
+/-- V4 128/64 floor `+1` upper bound when `un21` is the first-step
+    mathematical remainder. This is the floor-shaped surface used by the
+    Knuth-A/qhat path. -/
+theorem div128Quot_v4_le_floor_plus_one_of_un21_eq_r1
+    (uHi uLo vTop : Word)
+    (hvTop_ge : vTop.toNat ≥ 2^63)
+    (huHi_lt_vTop : uHi.toNat < vTop.toNat)
+    (hUn21_lt_pow63 :
+      (divKTrialCallV4Un21 uHi uLo vTop).toNat < 2^63)
+    (hUn21_lt_vTop :
+      (divKTrialCallV4Un21 uHi uLo vTop).toNat < vTop.toNat)
+    (hUn21_eq_r1 :
+      (divKTrialCallV4Un21 uHi uLo vTop).toNat =
+        (uHi.toNat * 2^32 + (divKTrialCallV4Un1 uLo).toNat) % vTop.toNat) :
+    (div128Quot_v4 uHi uLo vTop).toNat ≤
+      (uHi.toNat * 2^64 + uLo.toNat) / vTop.toNat + 1 :=
+  div128Quot_v4_le_q_true_plus_one_of_un21_eq_r1 uHi uLo vTop
+    hvTop_ge huHi_lt_vTop hUn21_lt_pow63 hUn21_lt_vTop hUn21_eq_r1
+
+/-- V4 128/64 floor `+1` upper bound from the Phase-1 low-half no-wrap
+    condition. -/
+theorem div128Quot_v4_le_floor_plus_one_of_no_wrap
+    (uHi uLo vTop : Word)
+    (hvTop_ge : vTop.toNat ≥ 2^63)
+    (huHi_lt_vTop : uHi.toNat < vTop.toNat)
+    (huHi_lt_pow63 : uHi.toNat < 2^63)
+    (hUn21_lt_pow63 :
+      (divKTrialCallV4Un21 uHi uLo vTop).toNat < 2^63)
+    (hUn21_lt_vTop :
+      (divKTrialCallV4Un21 uHi uLo vTop).toNat < vTop.toNat)
+    (h_no_wrap :
+      (divKTrialCallV4Q1dd uHi uLo vTop).toNat *
+          (divKTrialCallV4DLo vTop).toNat ≤
+        ((divKTrialCallV4Rhatdd uHi uLo vTop).toNat % 2^32) * 2^32 +
+          (divKTrialCallV4Un1 uLo).toNat) :
+    (div128Quot_v4 uHi uLo vTop).toNat ≤
+      (uHi.toNat * 2^64 + uLo.toNat) / vTop.toNat + 1 :=
+  div128Quot_v4_le_q_true_plus_one_of_no_wrap uHi uLo vTop
+    hvTop_ge huHi_lt_vTop huHi_lt_pow63
+    hUn21_lt_pow63 hUn21_lt_vTop h_no_wrap
+
+/-- V4 128/64 floor `+1` upper bound in the final Phase-1b high-half-zero
+    branch. -/
+theorem div128Quot_v4_le_floor_plus_one_of_rhatdd_hi_zero
+    (uHi uLo vTop : Word)
+    (hvTop_ge : vTop.toNat ≥ 2^63)
+    (huHi_lt_vTop : uHi.toNat < vTop.toNat)
+    (huHi_lt_pow63 : uHi.toNat < 2^63)
+    (hUn21_lt_pow63 :
+      (divKTrialCallV4Un21 uHi uLo vTop).toNat < 2^63)
+    (hUn21_lt_vTop :
+      (divKTrialCallV4Un21 uHi uLo vTop).toNat < vTop.toNat)
+    (h_rhat_hi_zero :
+      divKTrialCallV4Rhatdd uHi uLo vTop >>> (32 : BitVec 6).toNat = (0 : Word)) :
+    (div128Quot_v4 uHi uLo vTop).toNat ≤
+      (uHi.toNat * 2^64 + uLo.toNat) / vTop.toNat + 1 :=
+  div128Quot_v4_le_q_true_plus_one_of_rhatdd_hi_zero uHi uLo vTop
+    hvTop_ge huHi_lt_vTop huHi_lt_pow63
+    hUn21_lt_pow63 hUn21_lt_vTop h_rhat_hi_zero
 
 /-- Exact v4 128/64 floor quotient when `un21` is the first-step
     mathematical remainder and the matching upper bound has been supplied. -/


### PR DESCRIPTION
## Summary
- add floor-shaped wrappers for the existing div128Quot_v4 +1 upper-bound results
- expose un21=r1, no-wrap, and rhatdd-high-zero variants under floor naming
- make the N4 Knuth-A/qhat path consume the upper-bound surface without depending on lower-level q_true names

## Beads / Issues
- Beads: evm-asm-9iqmw.7.1.4.1
- GH issue: #61

## Verification
- Lean LSP diagnostics on edited ExactQuotient region: clean
- lake build EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV4.ExactQuotient
- git diff --check
- rg forbidden scan on touched file
- scripts/check-file-size.sh EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/ExactQuotient.lean
- scripts/check-unimported.sh
- lake build EvmAsm.Evm64.DivMod
- lake build