### PR TITLE
refactor(div): adapt calladdback to floor upper bound

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/CallAddbackRuntime.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/CallAddbackRuntime.lean
@@ -7,6 +7,7 @@
 import EvmAsm.Evm64.DivMod.Spec.CallAddback
 import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV4.Un21Bound
 import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV4.UpperBound
+import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV4.ExactQuotient
 
 namespace EvmAsm.Evm64
 
@@ -377,6 +378,47 @@ theorem n4CallAddbackBeqQHatV4_le_128_div_plus_one_of_call_rhatdd_hi_zero
         (n4CallAddbackBeqB3Prime b).toNat + 1 :=
   n4CallAddbackBeqQHatV4_le_128_div_plus_one_of_shift_nz_rhatdd_hi_zero
     hb3nz hshift_nz hcall hUn21_lt_pow63
+    (n4CallAddbackBeqUn21_lt_b3prime_of_call hb3nz hshift_nz hcall)
+    h_rhat_hi_zero
+
+/-- Marker-name adapter for the floor-shaped v4 128/64 `+1` upper bound
+    in the call-path, final high-half-zero branch. This is the same numeric
+    bound as the older `128_div` adapter, but routed through the floor-named
+    surface consumed by the Knuth-A/qhat path. -/
+theorem n4CallAddbackBeqQHatV4_le_floor_plus_one_of_call_rhatdd_hi_zero
+    {a b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (hcall : isCallTrialN4 (a.getLimbN 3) (b.getLimbN 2) (b.getLimbN 3))
+    (hUn21_lt_pow63 :
+      (divKTrialCallV4Un21
+        (n4CallAddbackBeqU4 a b)
+        (n4CallAddbackBeqU3 a b)
+        (n4CallAddbackBeqB3Prime b)).toNat < 2^63)
+    (h_rhat_hi_zero :
+      divKTrialCallV4Rhatdd
+          (n4CallAddbackBeqU4 a b)
+          (n4CallAddbackBeqU3 a b)
+          (n4CallAddbackBeqB3Prime b) >>> (32 : BitVec 6).toNat =
+        (0 : Word)) :
+    (n4CallAddbackBeqQHatV4 a b).toNat ≤
+      ((n4CallAddbackBeqU4 a b).toNat * 2^64 +
+          (n4CallAddbackBeqU3 a b).toNat) /
+        (n4CallAddbackBeqB3Prime b).toNat + 1 := by
+  rw [n4CallAddbackBeqQHatV4_eq_normalized]
+  have hu4_lt_b3prime :
+      (n4CallAddbackBeqU4 a b).toNat < (n4CallAddbackBeqB3Prime b).toNat := by
+    have h_decomp := n4CallAddbackBeqU4_lt_vTop_of_call hcall
+    rw [div128Quot_vTop_decomp (n4CallAddbackBeqB3Prime b)]
+    simpa [divKTrialCallV4DHi, divKTrialCallV4DLo] using h_decomp
+  exact div128Quot_v4_le_floor_plus_one_of_rhatdd_hi_zero
+    (n4CallAddbackBeqU4 a b)
+    (n4CallAddbackBeqU3 a b)
+    (n4CallAddbackBeqB3Prime b)
+    (n4CallAddbackBeqB3Prime_ge_pow63 hb3nz)
+    hu4_lt_b3prime
+    (n4CallAddbackBeqU4_lt_pow63_of_shift_nz hshift_nz)
+    hUn21_lt_pow63
     (n4CallAddbackBeqUn21_lt_b3prime_of_call hb3nz hshift_nz hcall)
     h_rhat_hi_zero
 


### PR DESCRIPTION
## Summary
- add a marker-level N4 call-addback adapter over the floor-shaped div128Quot_v4 +1 upper-bound surface from the parent branch
- expose n4CallAddbackBeqQHatV4_le_floor_plus_one_of_call_rhatdd_hi_zero for the qhat/Knuth-A runtime path
- branch is stacked on feat/div-v4-floor-upper-bound and merged current origin/main when cut

## Beads / Issues
- Beads: evm-asm-9iqmw.7.1.4.1
- GH issue: #61

## Verification
- Lean LSP diagnostics on edited CallAddbackRuntime region: clean
- lake build EvmAsm.Evm64.DivMod.Spec.CallAddbackRuntime
- git diff --check
- rg forbidden scan on touched/relevant files
- scripts/check-file-size.sh EvmAsm/Evm64/DivMod/Spec/CallAddbackRuntime.lean EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/ExactQuotient.lean
- scripts/check-unimported.sh
- lake build EvmAsm.Evm64.DivMod
- lake build