### PR TITLE
refactor(div): expose v4 callskip val256 branch bound

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/CallSkipV4NoWrap.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/CallSkipV4NoWrap.lean
@@ -121,6 +121,52 @@ theorem n4CallSkipSemanticHoldsV4_of_runtime_branch_pred (a b : EvmWord)
       exact n4CallSkipSemanticHoldsV4_of_no_wrap_pred a b
         hb3nz hshift_nz h_no_wrap
 
+
+/-- Val256 lower-bound surface for the runtime no-wrap branch, phrased
+    directly over the canonical `getLimbN` normalized 128/64 quotient. -/
+theorem div128Quot_v4_call_skip_ge_val256_div_of_no_wrap_pred_getLimbN
+    (a b : EvmWord)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (h_no_wrap : n4CallSkipNoWrapV4 a b) :
+    let shift := (clzResult (b.getLimbN 3)).1.toNat % 64
+    let antiShift :=
+      (signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 3)).1).toNat % 64
+    let b3prime := ((b.getLimbN 3) <<< shift) ||| ((b.getLimbN 2) >>> antiShift)
+    let u4 := (a.getLimbN 3) >>> antiShift
+    let u3 := ((a.getLimbN 3) <<< shift) ||| ((a.getLimbN 2) >>> antiShift)
+    val256 (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3) /
+        val256 (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) ≤
+      (div128Quot_v4 u4 u3 b3prime).toNat := by
+  intro shift antiShift b3prime u4 u3
+  have hsem := n4CallSkipSemanticHoldsV4_of_no_wrap_pred a b
+    hb3nz hshift_nz h_no_wrap
+  rw [n4CallSkipSemanticHoldsV4_def] at hsem
+  exact hsem
+
+/-- Val256 lower-bound surface for the final runtime Phase-1b branch split.
+    This is the explicit normalized-quotient form of
+    `n4CallSkipSemanticHoldsV4_of_runtime_branch_pred`. -/
+theorem div128Quot_v4_call_skip_ge_val256_div_of_runtime_branch_pred_getLimbN
+    (a b : EvmWord)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (hbranch : n4CallSkipRuntimeBranchV4 a b) :
+    let shift := (clzResult (b.getLimbN 3)).1.toNat % 64
+    let antiShift :=
+      (signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 3)).1).toNat % 64
+    let b3prime := ((b.getLimbN 3) <<< shift) ||| ((b.getLimbN 2) >>> antiShift)
+    let u4 := (a.getLimbN 3) >>> antiShift
+    let u3 := ((a.getLimbN 3) <<< shift) ||| ((a.getLimbN 2) >>> antiShift)
+    val256 (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3) /
+        val256 (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) ≤
+      (div128Quot_v4 u4 u3 b3prime).toNat := by
+  intro shift antiShift b3prime u4 u3
+  have hsem := n4CallSkipSemanticHoldsV4_of_runtime_branch_pred a b
+    hb3nz hshift_nz hbranch
+  rw [n4CallSkipSemanticHoldsV4_def] at hsem
+  exact hsem
+
 /-- Predicate-packaged v4 call-skip semantic lower bound in the no-wrap branch. -/
 theorem n4CallSkipSemanticHoldsV4_of_no_wrap_le_pred (a b : EvmWord)
     (hb3nz : b.getLimbN 3 ≠ 0)


### PR DESCRIPTION
Summary:
- Add explicit getLimbN val256 lower-bound wrappers for v4 call-skip no-wrap and runtime branch predicates.
- Keep the proofs as thin projections from the existing semantic predicate package for later stack-level composition.

Verification:
- lake build EvmAsm.Evm64.DivMod.Spec.CallSkipV4NoWrap
- lake build EvmAsm.Evm64.DivMod.Spec
- lake build
- git diff --check
- scripts/check-file-size.sh EvmAsm/Evm64/DivMod/Spec/CallSkipV4NoWrap.lean
- rg -n 'sorry|admit|set_option maxHeartbeats|set_option maxRecDepth' EvmAsm/Evm64/DivMod/Spec/CallSkipV4NoWrap.lean (no matches)

Bead: evm-asm-9iqmw.7.1.3.1.1
Issue: #61