### PR TITLE
refactor(div): bundle n2 selected shape evidence

### DIFF
--- a/EvmAsm/Evm64/DivMod/CallableV4DivShape.lean
+++ b/EvmAsm/Evm64/DivMod/CallableV4DivShape.lean
@@ -605,6 +605,78 @@ theorem evm_div_callable_v4_n1_stack_pre_to_callable_post_scratch_shape_allTrueP
     hbnz hb3z hb2z hb1z hshift_nz halign
     (N1SelectedIfBorrowPathEvidence.ofAllTruePathEvidence hpath) hevidence
 
+/-- Bundled selected/reachable evidence for the N2 callable shape route.
+
+    This keeps the selected carry and arithmetic callbacks together, avoiding
+    any public dependency on the old universal `Carry2NzAll` package. -/
+abbrev N2CallableSelectedShapeEvidence (a b : EvmWord) : Prop :=
+  (∀ bltu_2 bltu_1 bltu_0,
+    isTrialN2V4_j2 bltu_2
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
+    isTrialN2V4_j1 bltu_2 bltu_1
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
+    isTrialN2V4_j0 bltu_2 bltu_1 bltu_0
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
+    fullDivN2SelectedCarryV4 bltu_2 bltu_1 bltu_0
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)) ∧
+  (∀ bltu_2 bltu_1 bltu_0,
+    isTrialN2V4_j2 bltu_2
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
+    isTrialN2V4_j1 bltu_2 bltu_1
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
+    isTrialN2V4_j0 bltu_2 bltu_1 bltu_0
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
+    fullDivN2MulSubEqV4 bltu_2 bltu_1 bltu_0
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) ∧
+      fullDivN2QuotientOverestimateV4 bltu_2 bltu_1 bltu_0
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3))
+
+theorem N2CallableSelectedShapeEvidence.selectedCarry {a b : EvmWord}
+    (hevidence : N2CallableSelectedShapeEvidence a b) :
+    ∀ bltu_2 bltu_1 bltu_0,
+      isTrialN2V4_j2 bltu_2
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
+      isTrialN2V4_j1 bltu_2 bltu_1
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
+      isTrialN2V4_j0 bltu_2 bltu_1 bltu_0
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
+      fullDivN2SelectedCarryV4 bltu_2 bltu_1 bltu_0
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) :=
+  hevidence.1
+
+theorem N2CallableSelectedShapeEvidence.arithmetic {a b : EvmWord}
+    (hevidence : N2CallableSelectedShapeEvidence a b) :
+    ∀ bltu_2 bltu_1 bltu_0,
+      isTrialN2V4_j2 bltu_2
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
+      isTrialN2V4_j1 bltu_2 bltu_1
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
+      isTrialN2V4_j0 bltu_2 bltu_1 bltu_0
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) →
+      fullDivN2MulSubEqV4 bltu_2 bltu_1 bltu_0
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) ∧
+        fullDivN2QuotientOverestimateV4 bltu_2 bltu_1 bltu_0
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) :=
+  hevidence.2
+
 /-- N2 DIV v4 callable wrapper deriving divisor nonzero from the n=2 shape
     while consuming only selected carry evidence for the actual path. -/
 theorem evm_div_callable_v4_n2_stack_pre_to_callable_post_scratch_shape_selectedCarry
@@ -666,6 +738,40 @@ theorem evm_div_callable_v4_n2_stack_pre_to_callable_post_scratch_shape_selected
     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
     (n2_limb_or_ne_zero_of_limb1_ne_zero hb1nz)
     hb3z hb2z hb1nz hshift_nz halign hcarry harith
+
+/-- N2 DIV v4 callable wrapper over bundled selected/reachable shape evidence. -/
+theorem evm_div_callable_v4_n2_stack_pre_to_callable_post_scratch_shape_selectedEvidence
+    (sp base : Word) (a b : EvmWord)
+    (v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (hb3z : b.getLimbN 3 = 0) (hb2z : b.getLimbN 2 = 0)
+    (hb1nz : b.getLimbN 1 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 1)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hevidence : N2CallableSelectedShapeEvidence a b) :
+    cpsTripleWithin (unifiedDivBound + 1) base (raVal &&& ~~~1)
+      (evm_div_callable_code_v4 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult (b.getLimbN 1)).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divStackDispatchPostCallableExactFrame sp a b raVal
+        (signExtend12 4095 : Word) **
+       memOwn (sp + signExtend12 3936)) :=
+  evm_div_callable_v4_n2_stack_pre_to_callable_post_scratch_shape_selectedCarry
+    sp base a b
+    v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+    hb3z hb2z hb1nz hshift_nz halign
+    (N2CallableSelectedShapeEvidence.selectedCarry hevidence)
+    (N2CallableSelectedShapeEvidence.arithmetic hevidence)
 
 /-- N3 DIV v4 callable wrapper deriving divisor nonzero from the n=3 shape
     while consuming only selected carry evidence for the actual path. -/


### PR DESCRIPTION
## Summary
- add N2CallableSelectedShapeEvidence for the n=2 callable shape route
- expose projections for selected carry and arithmetic evidence
- add an N2 shape callable wrapper that consumes the bundled selected evidence instead of separate callback surfaces

## Verification
- lake build EvmAsm.Evm64.DivMod.CallableV4DivShape
- lake build EvmAsm.Evm64.DivMod
- lake build
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- Lean LSP diagnostics for CallableV4DivShape.lean

Bead: evm-asm-9iqmw.7.1.6.2.1.1
Issue: #61