### PR TITLE
feat(stateless): extend byte-copy to cover max SszForkConfig (all slots populated)

### DIFF
--- a/EvmAsm/Stateless/SSZ/Encode/Program.lean
+++ b/EvmAsm/Stateless/SSZ/Encode/Program.lean
@@ -223,6 +223,32 @@ def serialize_stateless_output : Program :=
   LBU .x7 .x13 57 ;; SB .x6 .x7 94 ;;
   LBU .x7 .x13 58 ;; SB .x6 .x7 95 ;;
   LBU .x7 .x13 59 ;; SB .x6 .x7 96 ;;
+  -- bytes [97..113): byte-copy active_fork[48..64) from input.
+  -- Covers the blob_schedule entry when activation is non-empty
+  -- (then activation pushes blob_schedule forward by 8/16 bytes,
+  -- so the entry's bytes land at active_fork[48..72) -- the
+  -- first 16 bytes of which fall in this range). The MAX
+  -- active_fork = 64 bytes (16 fc-header + 24 activation + 24
+  -- blob_schedule) so OUTPUT[97..113) is the tail of spec
+  -- output. For smaller active_fork shapes, the range is past
+  -- the actual section; ziskemu zero-fills and the test
+  -- framework ignores bytes past len(spec).
+  LBU .x7 .x13 60 ;; SB .x6 .x7 97 ;;
+  LBU .x7 .x13 61 ;; SB .x6 .x7 98 ;;
+  LBU .x7 .x13 62 ;; SB .x6 .x7 99 ;;
+  LBU .x7 .x13 63 ;; SB .x6 .x7 100 ;;
+  LBU .x7 .x13 64 ;; SB .x6 .x7 101 ;;
+  LBU .x7 .x13 65 ;; SB .x6 .x7 102 ;;
+  LBU .x7 .x13 66 ;; SB .x6 .x7 103 ;;
+  LBU .x7 .x13 67 ;; SB .x6 .x7 104 ;;
+  LBU .x7 .x13 68 ;; SB .x6 .x7 105 ;;
+  LBU .x7 .x13 69 ;; SB .x6 .x7 106 ;;
+  LBU .x7 .x13 70 ;; SB .x6 .x7 107 ;;
+  LBU .x7 .x13 71 ;; SB .x6 .x7 108 ;;
+  LBU .x7 .x13 72 ;; SB .x6 .x7 109 ;;
+  LBU .x7 .x13 73 ;; SB .x6 .x7 110 ;;
+  LBU .x7 .x13 74 ;; SB .x6 .x7 111 ;;
+  LBU .x7 .x13 75 ;; SB .x6 .x7 112 ;;
   -- byte 64: high byte of offset_blob_schedule (always 0 since
   -- the value fits in 1 byte).
   SB .x6 .x0 64

--- a/scripts/codegen-stateless-spec-output-check.sh
+++ b/scripts/codegen-stateless-spec-output-check.sh
@@ -346,6 +346,14 @@ run_fixture "chain1_act_both"       1                  0    ""           ""     
 # all three u64s of the entry.
 run_fixture "chain1_blob"           1                  0    ""           ""                  ""    ""           ""           "100:200:300" || fail=1
 
+# Cross-product corner: bn=[B], ts=[T], blob=[entry] all
+# populated simultaneously. MAX active_fork = 64 bytes (16
+# fc-header + 24 activation body + 24 blob_schedule), so spec
+# emits 113 bytes -- the largest spec output the new-schema
+# SszForkConfig can produce. offset_blob_schedule = 40
+# (= 0x28); still fits in 1 byte.
+run_fixture "chain1_act_blob_all"   1                  0    ""           ""                  ""    "3333333333" "4444444444" "500:600:700" || fail=1
+
 if [[ "$fail" -eq 0 ]]; then
   echo "==> PASS: all spec-output fixtures match the new SSZ schema"
   exit 0


### PR DESCRIPTION
## Summary
Extend the \`active_fork\` byte-copy range from \`[16..48)\` (#6807) to the full \`[16..64)\` so the encoder can produce the MAX 113-byte output when ALL three SszForkConfig variable slots are populated: \`block_number = [B]\`, \`timestamp = [T]\`, AND \`blob_schedule = [entry]\`. With activation = 24 bytes (8 offsets + 8 bn + 8 ts) and blob_schedule = 24 bytes, active_fork reaches its maximum 64 bytes.

16 new \`LBU + SB\` pairs copy \`active_fork[48..64)\` into \`OUTPUT[97..113)\`. For shapes with shorter active_fork, the range lies past the actual section; ziskemu zero-fills and the test framework only compares the first \`len(spec)\` bytes.

\`offset_blob_schedule\` becomes 40 (= 0x28) in the max case; still fits in 1 byte so the existing single-byte \`LBU+SB\` at \`OUTPUT[61]\` handles it.

New fixture \`chain1_act_blob_all\` (\`block_number=3333333333\`, \`timestamp=4444444444\`, \`blob=[target=500, max=600, base_fee=700]\`) drives the new path — this is the largest spec output the amsterdam-schema SszForkConfig can produce.

## Test plan
- [x] \`scripts/codegen-stateless-spec-output-check.sh\` — all 17 fixtures pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)