### PR TITLE
feat(div): add n4 shift dispatcher aliases

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcher.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcher.lean
@@ -380,4 +380,57 @@ theorem evm_div_n4_shift_nz_stack_spec_v4_noNop_of_branch_runtime
         nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
         hbnz hb3nz hshift_nz halign hbltu haddRuntime.1 haddRuntime.2.1 hsem
 
+
+/-- Final named n=4, shift-nonzero DIV dispatcher surface over `divCode_v4`.
+    This is the branch-predicate API consumed by later n=4 stack assembly. -/
+theorem evm_div_n4_shift_nz_stack_spec
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbranch : n4CallSkipBranchV4 a b)
+    (hcarry2 : isAddbackCarry2NzN4CallV4Evm a b)
+    (hsem : n4CallAddbackBeqSemanticHolds a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_v4_of_branch_pred
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign hbranch hcarry2 hsem
+
+/-- Final named no-NOP n=4, shift-nonzero DIV dispatcher surface over
+    `divCode_noNop_v4`. -/
+theorem evm_div_n4_shift_nz_stack_spec_noNop
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbranch : n4CallSkipBranchV4 a b)
+    (hcarry2 : isAddbackCarry2NzN4CallV4Evm a b)
+    (hsem : n4CallAddbackBeqSemanticHolds a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_noNop_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_v4_noNop_of_branch_pred
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign hbranch hcarry2 hsem
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add final named evm_div_n4_shift_nz_stack_spec alias over the v4 branch-predicate dispatcher
- add final named evm_div_n4_shift_nz_stack_spec_noNop alias over the no-NOP branch-predicate dispatcher
- keep the existing runtime/branch-runtime helper surfaces available for later unconditional n4 assembly

Stacked on #6812.

Bead: evm-asm-9iqmw.7.1
Issue: #61

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.N4V4ShiftNzDispatcher
- LSP diagnostics for N4V4ShiftNzDispatcher: no errors
- lake build EvmAsm.Evm64.DivMod.Spec
- lake build
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- rg set_option maxHeartbeats|set_option maxRecDepth|sorry|admit on touched file