### PR TITLE
feat(div): package n4 shift branch bounds evidence

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcher.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcher.lean
@@ -32,6 +32,17 @@ def n4ShiftNzDispatcherBranchRuntimeV4 (a b : EvmWord) : Prop :=
    isAddbackCarry2NzN4CallV4Evm a b ∧
    n4CallAddbackBeqRuntimeBounds a b)
 
+/-- Explicit branch/bounds evidence for the n=4, shift-nonzero DIV v4
+    dispatcher.
+
+    This is the lightweight shape produced by the arithmetic side of the n=4
+    stack assembly before it has been upgraded to the runtime call+skip branch
+    certificate. -/
+def n4ShiftNzDispatcherBranchBoundsV4 (a b : EvmWord) : Prop :=
+  n4CallSkipBranchV4 a b ∧
+  isAddbackCarry2NzN4CallV4Evm a b ∧
+  n4CallAddbackBeqRuntimeBounds a b
+
 theorem n4ShiftNzDispatcherRuntimeV4_def {a b : EvmWord} :
     n4ShiftNzDispatcherRuntimeV4 a b =
       (n4CallSkipRuntimeBranchV4 a b ∧
@@ -46,6 +57,39 @@ theorem n4ShiftNzDispatcherBranchRuntimeV4_def {a b : EvmWord} :
         isAddbackCarry2NzN4CallV4Evm a b ∧
         n4CallAddbackBeqRuntimeBounds a b)) :=
   rfl
+
+theorem n4ShiftNzDispatcherBranchBoundsV4_def {a b : EvmWord} :
+    n4ShiftNzDispatcherBranchBoundsV4 a b =
+      (n4CallSkipBranchV4 a b ∧
+       isAddbackCarry2NzN4CallV4Evm a b ∧
+       n4CallAddbackBeqRuntimeBounds a b) :=
+  rfl
+
+theorem n4ShiftNzDispatcherBranchBoundsV4.callSkipBranch {a b : EvmWord}
+    (hevidence : n4ShiftNzDispatcherBranchBoundsV4 a b) :
+    n4CallSkipBranchV4 a b := by
+  rw [n4ShiftNzDispatcherBranchBoundsV4_def] at hevidence
+  exact hevidence.1
+
+theorem n4ShiftNzDispatcherBranchBoundsV4.addbackCarry2 {a b : EvmWord}
+    (hevidence : n4ShiftNzDispatcherBranchBoundsV4 a b) :
+    isAddbackCarry2NzN4CallV4Evm a b := by
+  rw [n4ShiftNzDispatcherBranchBoundsV4_def] at hevidence
+  exact hevidence.2.1
+
+theorem n4ShiftNzDispatcherBranchBoundsV4.addbackRuntimeBounds {a b : EvmWord}
+    (hevidence : n4ShiftNzDispatcherBranchBoundsV4 a b) :
+    n4CallAddbackBeqRuntimeBounds a b := by
+  rw [n4ShiftNzDispatcherBranchBoundsV4_def] at hevidence
+  exact hevidence.2.2
+
+theorem n4ShiftNzDispatcherBranchBoundsV4.of_runtime_pred {a b : EvmWord}
+    (hruntime : n4ShiftNzDispatcherRuntimeV4 a b)
+    (hbranch : n4CallSkipBranchV4 a b) :
+    n4ShiftNzDispatcherBranchBoundsV4 a b := by
+  rw [n4ShiftNzDispatcherRuntimeV4_def] at hruntime
+  rw [n4ShiftNzDispatcherBranchBoundsV4_def]
+  exact ⟨hbranch, hruntime.2.1, hruntime.2.2⟩
 
 theorem n4ShiftNzDispatcherBranchRuntimeV4_of_runtime_pred {a b : EvmWord}
     (hruntime : n4ShiftNzDispatcherRuntimeV4 a b) :
@@ -583,5 +627,60 @@ theorem evm_div_n4_shift_nz_stack_spec_noNop_of_runtime_bounds
     sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
     hb3nz hshift_nz halign hbranch hcarry2 h_bounds
+
+
+/-- Final named n=4, shift-nonzero DIV dispatcher surface from packaged
+    branch/bounds evidence. -/
+theorem evm_div_n4_shift_nz_stack_spec_of_branch_bounds
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hevidence : n4ShiftNzDispatcherBranchBoundsV4 a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_of_runtime_bounds
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign
+    (n4ShiftNzDispatcherBranchBoundsV4.callSkipBranch hevidence)
+    (n4ShiftNzDispatcherBranchBoundsV4.addbackCarry2 hevidence)
+    (n4ShiftNzDispatcherBranchBoundsV4.addbackRuntimeBounds hevidence)
+
+/-- Final named no-NOP n=4, shift-nonzero DIV dispatcher surface from packaged
+    branch/bounds evidence. -/
+theorem evm_div_n4_shift_nz_stack_spec_noNop_of_branch_bounds
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hevidence : n4ShiftNzDispatcherBranchBoundsV4 a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_noNop_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_noNop_of_runtime_bounds
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign
+    (n4ShiftNzDispatcherBranchBoundsV4.callSkipBranch hevidence)
+    (n4ShiftNzDispatcherBranchBoundsV4.addbackCarry2 hevidence)
+    (n4ShiftNzDispatcherBranchBoundsV4.addbackRuntimeBounds hevidence)
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add n4ShiftNzDispatcherBranchBoundsV4 as the explicit branch/bounds evidence package for n=4 shift-nonzero DIV
- add projection lemmas for callskip branch, addback carry2, and addback runtime bounds
- add final NOP and no-NOP dispatcher aliases consuming the packaged evidence

Stacked on #6815. Part of evm-asm-9iqmw.7.1 / #61.

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.N4V4ShiftNzDispatcher
- Lean LSP diagnostics for N4V4ShiftNzDispatcher.lean: no errors
- lake build EvmAsm.Evm64.DivMod.Spec
- lake build
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- rg -n set_option maxHeartbeats|set_option maxRecDepth|sorry|admit EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcher.lean