### PR TITLE
test(stateless): cross-product fixture (public_keys + block_number)

### DIFF
--- a/scripts/codegen-stateless-spec-output-check.sh
+++ b/scripts/codegen-stateless-spec-output-check.sh
@@ -362,6 +362,19 @@ run_fixture "chain1_act_both"       1                  0    ""           ""     
 # all three u64s of the entry.
 run_fixture "chain1_blob"           1                  0    ""           ""                  ""    ""           ""           "100:200:300" || fail=1
 
+# Cross-product: non-empty public_keys AND non-empty
+# block_number. The decoder's outer-offset chase
+# (SSZ_BASE+8 -> chain_config_addr) must land correctly under
+# input-layout drift, AND the encoder's variable-length byte-
+# copy must produce the 81-byte block_number passthrough.
+# public_keys (65 bytes) sits AFTER chain_config in the outer
+# SSZ blob, so it doesn't shift chain_config_offset; it does
+# extend the input file enough that the encoder's trailing
+# byte-copy reads stay within ziskemu's mapped input region
+# (cross-products with witness.codes/state would land 0..few
+# bytes of mem slack -- too tight, would panic).
+run_fixture "chain1_pk_actbn"       1                  0    ""           ""                  "04$(printf '%064d' 0)$(printf '%064d' 0)"    "1234567890" || fail=1
+
 if [[ "$fail" -eq 0 ]]; then
   echo "==> PASS: all spec-output fixtures match the new SSZ schema"
   exit 0


### PR DESCRIPTION
## Summary
Add fixture \`chain1_pk_actbn\` combining a 65-byte public_keys entry with \`block_number = [N]\` — exercises the decoder's outer-offset chase (chain_config_offset stays put because public_keys sits AFTER chain_config) AND the encoder's variable-length byte-copy from #6793 (81-byte block_number passthrough).

## Implementation note
A naive \`witness.codes + bn=[N]\` cross-product was tried first but landed at ~0 bytes of slack between chain_config_end and ziskemu's input-region boundary, causing the encoder's trailing LBU reads to panic with \"section not found\". The public_keys variant has 35 bytes of slack — plenty for the unconditional \`active_fork[16..32)\` byte-copy.

## Test plan
- [x] \`scripts/codegen-stateless-spec-output-check.sh\` — all 17 fixtures pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)