### PR TITLE
feat(div): add n4 shift branch bounds v4 aliases

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcher.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcher.lean
@@ -187,6 +187,33 @@ theorem evm_div_n4_shift_nz_stack_spec_v4_of_runtime_bounds
         nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
         hbnz hb3nz hshift_nz halign hbltu hadd hcarry2 hsem
 
+/-- n=4, shift-nonzero DIV v4 dispatcher from packaged branch/bounds
+    evidence. -/
+theorem evm_div_n4_shift_nz_stack_spec_v4_of_branch_bounds
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hevidence : n4ShiftNzDispatcherBranchBoundsV4 a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_v4_of_runtime_bounds
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign
+    (n4ShiftNzDispatcherBranchBoundsV4.callSkipBranch hevidence)
+    (n4ShiftNzDispatcherBranchBoundsV4.addbackCarry2 hevidence)
+    (n4ShiftNzDispatcherBranchBoundsV4.addbackRuntimeBounds hevidence)
+
 /-- n=4, shift-nonzero DIV v4 dispatcher from the packaged runtime evidence
     predicate. -/
 theorem evm_div_n4_shift_nz_stack_spec_v4_of_runtime_pred
@@ -344,6 +371,33 @@ theorem evm_div_n4_shift_nz_stack_spec_v4_noNop_of_runtime_bounds
         sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
         nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
         hbnz hb3nz hshift_nz halign hbltu hadd hcarry2 hsem
+
+/-- No-NOP n=4, shift-nonzero DIV v4 dispatcher from packaged
+    branch/bounds evidence. -/
+theorem evm_div_n4_shift_nz_stack_spec_v4_noNop_of_branch_bounds
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hevidence : n4ShiftNzDispatcherBranchBoundsV4 a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_noNop_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_v4_noNop_of_runtime_bounds
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign
+    (n4ShiftNzDispatcherBranchBoundsV4.callSkipBranch hevidence)
+    (n4ShiftNzDispatcherBranchBoundsV4.addbackCarry2 hevidence)
+    (n4ShiftNzDispatcherBranchBoundsV4.addbackRuntimeBounds hevidence)
 
 /-- No-NOP n=4, shift-nonzero DIV v4 dispatcher from packaged runtime evidence. -/
 theorem evm_div_n4_shift_nz_stack_spec_v4_noNop_of_runtime_pred
@@ -648,13 +702,10 @@ theorem evm_div_n4_shift_nz_stack_spec_of_branch_bounds
          shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
        ((sp + signExtend12 3936) ↦ₘ scratchMem))
       (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
-  evm_div_n4_shift_nz_stack_spec_of_runtime_bounds
+  evm_div_n4_shift_nz_stack_spec_v4_of_branch_bounds
     sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
-    hb3nz hshift_nz halign
-    (n4ShiftNzDispatcherBranchBoundsV4.callSkipBranch hevidence)
-    (n4ShiftNzDispatcherBranchBoundsV4.addbackCarry2 hevidence)
-    (n4ShiftNzDispatcherBranchBoundsV4.addbackRuntimeBounds hevidence)
+    hb3nz hshift_nz halign hevidence
 
 /-- Final named no-NOP n=4, shift-nonzero DIV dispatcher surface from packaged
     branch/bounds evidence. -/
@@ -675,12 +726,9 @@ theorem evm_div_n4_shift_nz_stack_spec_noNop_of_branch_bounds
          shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
        ((sp + signExtend12 3936) ↦ₘ scratchMem))
       (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
-  evm_div_n4_shift_nz_stack_spec_noNop_of_runtime_bounds
+  evm_div_n4_shift_nz_stack_spec_v4_noNop_of_branch_bounds
     sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
-    hb3nz hshift_nz halign
-    (n4ShiftNzDispatcherBranchBoundsV4.callSkipBranch hevidence)
-    (n4ShiftNzDispatcherBranchBoundsV4.addbackCarry2 hevidence)
-    (n4ShiftNzDispatcherBranchBoundsV4.addbackRuntimeBounds hevidence)
+    hb3nz hshift_nz halign hevidence
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add versioned evm_div_n4_shift_nz_stack_spec_v4_of_branch_bounds
- add versioned evm_div_n4_shift_nz_stack_spec_v4_noNop_of_branch_bounds
- route the final branch/bounds aliases through those versioned surfaces

Stacked on #6816. Part of evm-asm-9iqmw.7.1.3 / #61.

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.N4V4ShiftNzDispatcher
- Lean LSP diagnostics for N4V4ShiftNzDispatcher.lean: no errors
- lake build EvmAsm.Evm64.DivMod.Spec
- lake build
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- rg -n set_option maxHeartbeats|set_option maxRecDepth|sorry|admit EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcher.lean