### PR TITLE
feat(div): bridge n4 shift branch bounds to runtime

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/CallSkipV4NoWrap.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/CallSkipV4NoWrap.lean
@@ -94,6 +94,23 @@ theorem n4CallSkipBranchV4_def {a b : EvmWord} :
       (n4CallSkipRhatddHiZeroV4 a b ∨ n4CallSkipNoWrapLeV4 a b) :=
   rfl
 
+theorem n4CallSkipNoWrapV4_of_no_wrap_le {a b : EvmWord}
+    (h_no_wrap_le : n4CallSkipNoWrapLeV4 a b) :
+    n4CallSkipNoWrapV4 a b := by
+  rw [n4CallSkipNoWrapLeV4_def] at h_no_wrap_le
+  rw [n4CallSkipNoWrapV4_def]
+  exact h_no_wrap_le.1
+
+theorem n4CallSkipRuntimeBranchV4_of_branch_pred {a b : EvmWord}
+    (hbranch : n4CallSkipBranchV4 a b) :
+    n4CallSkipRuntimeBranchV4 a b := by
+  rw [n4CallSkipBranchV4_def] at hbranch
+  rw [n4CallSkipRuntimeBranchV4_def]
+  cases hbranch with
+  | inl hrhat => exact Or.inl hrhat
+  | inr h_no_wrap_le =>
+      exact Or.inr (n4CallSkipNoWrapV4_of_no_wrap_le h_no_wrap_le)
+
 /-- Predicate-packaged v4 call-skip semantic lower bound in the runtime
     no-wrap branch, without a separate 128/64 upper-bound premise. -/
 theorem n4CallSkipSemanticHoldsV4_of_no_wrap_pred (a b : EvmWord)

--- a/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcher.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcher.lean
@@ -91,6 +91,13 @@ theorem n4ShiftNzDispatcherBranchBoundsV4.of_runtime_pred {a b : EvmWord}
   rw [n4ShiftNzDispatcherBranchBoundsV4_def]
   exact ⟨hbranch, hruntime.2.1, hruntime.2.2⟩
 
+theorem n4ShiftNzDispatcherRuntimeV4.of_branch_bounds {a b : EvmWord}
+    (hevidence : n4ShiftNzDispatcherBranchBoundsV4 a b) :
+    n4ShiftNzDispatcherRuntimeV4 a b := by
+  rw [n4ShiftNzDispatcherBranchBoundsV4_def] at hevidence
+  rw [n4ShiftNzDispatcherRuntimeV4_def]
+  exact ⟨n4CallSkipRuntimeBranchV4_of_branch_pred hevidence.1, hevidence.2.1, hevidence.2.2⟩
+
 theorem n4ShiftNzDispatcherBranchRuntimeV4_of_runtime_pred {a b : EvmWord}
     (hruntime : n4ShiftNzDispatcherRuntimeV4 a b) :
     n4ShiftNzDispatcherBranchRuntimeV4 a b := by


### PR DESCRIPTION
## Summary
- add n4CallSkipNoWrapV4_of_no_wrap_le to project the runtime no-wrap certificate from the stronger branch certificate
- add n4CallSkipRuntimeBranchV4_of_branch_pred
- add n4ShiftNzDispatcherRuntimeV4.of_branch_bounds for dispatcher evidence packaging

Stacked on #6818. Part of evm-asm-9iqmw.7.1.3 / #61.

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.CallSkipV4NoWrap
- lake build EvmAsm.Evm64.DivMod.Spec.N4V4ShiftNzDispatcher
- Lean LSP diagnostics for touched files: no errors after LSP rebuild
- lake build EvmAsm.Evm64.DivMod.Spec
- lake build
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- rg -n set_option maxHeartbeats|set_option maxRecDepth|sorry|admit EvmAsm/Evm64/DivMod/Spec/CallSkipV4NoWrap.lean EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcher.lean