### PR TITLE
refactor(div): route n4 branch bounds through branch runtime

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcher.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcher.lean
@@ -241,31 +241,6 @@ theorem evm_div_n4_shift_nz_stack_spec_v4_of_runtime_pred
         nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
         hbnz hb3nz hshift_nz halign hbltu haddRuntime.1 haddRuntime.2.1 hsem
 
-/-- n=4, shift-nonzero DIV v4 dispatcher from packaged branch/bounds
-    evidence. -/
-theorem evm_div_n4_shift_nz_stack_spec_v4_of_branch_bounds
-    (sp base : Word)
-    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
-    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
-    (hb3nz : b.getLimbN 3 ≠ 0)
-    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
-    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
-      base + div128CallRetOff)
-    (hevidence : n4ShiftNzDispatcherBranchBoundsV4 a b) :
-    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
-      base (base + nopOff) (divCode_v4 base)
-      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
-         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
-       ((sp + signExtend12 3936) ↦ₘ scratchMem))
-      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
-  evm_div_n4_shift_nz_stack_spec_v4_of_runtime_pred
-    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
-    hb3nz hshift_nz halign
-    (n4ShiftNzDispatcherRuntimeV4.of_branch_bounds hevidence)
-
 /-- n=4, shift-nonzero DIV v4 dispatcher from branch-sensitive runtime
     evidence. This surface avoids requiring addback-only arithmetic evidence
     when the runtime borrow split is already known to take the call+skip path. -/
@@ -306,6 +281,31 @@ theorem evm_div_n4_shift_nz_stack_spec_v4_of_branch_runtime
         nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
         hbnz hb3nz hshift_nz halign hbltu haddRuntime.1 haddRuntime.2.1 hsem
 
+
+/-- n=4, shift-nonzero DIV v4 dispatcher from packaged branch/bounds
+    evidence. -/
+theorem evm_div_n4_shift_nz_stack_spec_v4_of_branch_bounds
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hevidence : n4ShiftNzDispatcherBranchBoundsV4 a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_v4_of_branch_runtime
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign
+    (n4ShiftNzDispatcherBranchRuntimeV4_of_branch_bounds hevidence)
 
 /-- No-NOP n=4, shift-nonzero DIV v4 dispatcher over the call branch. -/
 theorem evm_div_n4_shift_nz_stack_spec_v4_noNop_of_branch_pred
@@ -423,31 +423,6 @@ theorem evm_div_n4_shift_nz_stack_spec_v4_noNop_of_runtime_pred
         nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
         hbnz hb3nz hshift_nz halign hbltu haddRuntime.1 haddRuntime.2.1 hsem
 
-/-- No-NOP n=4, shift-nonzero DIV v4 dispatcher from packaged
-    branch/bounds evidence. -/
-theorem evm_div_n4_shift_nz_stack_spec_v4_noNop_of_branch_bounds
-    (sp base : Word)
-    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
-    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
-    (hb3nz : b.getLimbN 3 ≠ 0)
-    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
-    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
-      base + div128CallRetOff)
-    (hevidence : n4ShiftNzDispatcherBranchBoundsV4 a b) :
-    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
-      base (base + nopOff) (divCode_noNop_v4 base)
-      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
-         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
-       ((sp + signExtend12 3936) ↦ₘ scratchMem))
-      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
-  evm_div_n4_shift_nz_stack_spec_v4_noNop_of_runtime_pred
-    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
-    hb3nz hshift_nz halign
-    (n4ShiftNzDispatcherRuntimeV4.of_branch_bounds hevidence)
-
 /-- No-NOP n=4, shift-nonzero DIV v4 dispatcher from branch-sensitive runtime
     evidence. -/
 theorem evm_div_n4_shift_nz_stack_spec_v4_noNop_of_branch_runtime
@@ -487,6 +462,31 @@ theorem evm_div_n4_shift_nz_stack_spec_v4_noNop_of_branch_runtime
         nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
         hbnz hb3nz hshift_nz halign hbltu haddRuntime.1 haddRuntime.2.1 hsem
 
+
+/-- No-NOP n=4, shift-nonzero DIV v4 dispatcher from packaged
+    branch/bounds evidence. -/
+theorem evm_div_n4_shift_nz_stack_spec_v4_noNop_of_branch_bounds
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hevidence : n4ShiftNzDispatcherBranchBoundsV4 a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_noNop_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_v4_noNop_of_branch_runtime
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign
+    (n4ShiftNzDispatcherBranchRuntimeV4_of_branch_bounds hevidence)
 
 /-- Final named n=4, shift-nonzero DIV dispatcher surface over `divCode_v4`.
     This is the branch-predicate API consumed by later n=4 stack assembly. -/


### PR DESCRIPTION
## Summary
- route NOP and no-NOP branch/bounds dispatcher surfaces through branch-sensitive runtime dispatcher theorems
- move branch/bounds dispatcher declarations after the branch-runtime surfaces they now consume
- use n4ShiftNzDispatcherBranchRuntimeV4_of_branch_bounds as the canonical evidence bridge

Stacked on #6820. Part of evm-asm-9iqmw.7.1.3 / #61.

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.N4V4ShiftNzDispatcher
- Lean LSP diagnostics for N4V4ShiftNzDispatcher.lean: no errors
- lake build EvmAsm.Evm64.DivMod.Spec
- lake build
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- rg -n set_option maxHeartbeats|set_option maxRecDepth|sorry|admit EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcher.lean