### PR TITLE
test(stateless): cross-product fixture (public_keys + blob_schedule)

### DIFF
--- a/scripts/codegen-stateless-spec-output-check.sh
+++ b/scripts/codegen-stateless-spec-output-check.sh
@@ -362,6 +362,16 @@ run_fixture "chain1_act_both"       1                  0    ""           ""     
 # all three u64s of the entry.
 run_fixture "chain1_blob"           1                  0    ""           ""                  ""    ""           ""           "100:200:300" || fail=1
 
+# Cross-product: non-empty public_keys AND non-empty
+# blob_schedule. Both fields shift only `offsets[3]`
+# (public_keys_offset) and the SSZ blob total length; neither
+# affects chain_config_offset. The encoder's full byte-copy of
+# active_fork[16..64) (covering the entire blob_schedule
+# entry) must produce 97 bytes that match spec. PK padding
+# gives plenty of mem slack so the byte-copy never reads past
+# ziskemu's input section.
+run_fixture "chain1_pk_blob"        1                  0    ""           ""                  "04$(printf '%064d' 0)$(printf '%064d' 0)"    ""           ""           "100:200:300" || fail=1
+
 if [[ "$fail" -eq 0 ]]; then
   echo "==> PASS: all spec-output fixtures match the new SSZ schema"
   exit 0


### PR DESCRIPTION
## Summary
Add fixture \`chain1_pk_blob\` combining a 65-byte \`public_keys\` entry with a non-empty \`blob_schedule\` entry. Both fields shift only \`offsets[3]\` (\`public_keys_offset\`) and the SSZ blob total length; neither affects \`chain_config_offset\`. The encoder's full byte-copy of \`active_fork[16..64)\` (covering the entire \`blob_schedule\` entry, from #6811) produces 97 bytes that match the spec.

PK padding provides the encoder ~35 bytes of mem slack between \`chain_config_end\` and ziskemu's input-region boundary, so the trailing \`LBU\` reads never trip the \"section not found\" panic documented in the alignment + slack memory notes.

## Test plan
- [x] \`scripts/codegen-stateless-spec-output-check.sh\` — all 18 fixtures pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)