### PR TITLE
feat(div): bridge n4 high-div call bounds

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/CallAddbackRuntimeHighDiv.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/CallAddbackRuntimeHighDiv.lean
@@ -206,6 +206,79 @@ theorem n4CallAddbackBeqSemanticHolds_of_floor_eq_high_div_bound_and_borrow
     n4CallAddbackBeqSemanticHoldsV4_of_floor_eq_high_div_bound_and_borrow
       hb3nz hshift_nz h_floor h_high_div h_borrow h_carry2
 
+/-- Runtime-bounds package from the call-path exact-floor bridge and the
+    named Knuth-A high-divisor bridge. -/
+theorem n4CallAddbackBeqRuntimeBounds_of_call_high_div_bound_and_borrow
+    {a b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (hcall : isCallTrialN4 (a.getLimbN 3) (b.getLimbN 2) (b.getLimbN 3))
+    (h_rhat_hi_zero :
+      divKTrialCallV4Rhatdd
+          (n4CallAddbackBeqU4 a b)
+          (n4CallAddbackBeqU3 a b)
+          (n4CallAddbackBeqB3Prime b) >>> (32 : BitVec 6).toNat =
+        (0 : Word))
+    (h_qhat_high : n4CallAddbackBeqQHatHighDivBound a b)
+    (h_high_div : n4CallAddbackBeqHighDivKnuthABound a b)
+    (h_borrow : isAddbackBorrowN4CallV4Evm a b) :
+    n4CallAddbackBeqRuntimeBounds a b :=
+  n4CallAddbackBeqRuntimeBounds_of_floor_eq_high_div_bound_and_borrow
+    hb3nz
+    (by
+      simpa [n4CallAddbackBeqHighDivVal_def] using
+        n4CallAddbackBeqQHatHighDivBound.floor_eq_of_call_rhatdd_hi_zero
+          hb3nz hshift_nz hcall h_rhat_hi_zero h_qhat_high)
+    h_high_div h_borrow
+
+/-- Runtime semantic bridge from the call-path exact-floor bridge and the
+    named Knuth-A high-divisor bridge. -/
+theorem n4CallAddbackBeqSemanticHoldsV4_of_call_high_div_bound_and_borrow
+    {a b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (hcall : isCallTrialN4 (a.getLimbN 3) (b.getLimbN 2) (b.getLimbN 3))
+    (h_rhat_hi_zero :
+      divKTrialCallV4Rhatdd
+          (n4CallAddbackBeqU4 a b)
+          (n4CallAddbackBeqU3 a b)
+          (n4CallAddbackBeqB3Prime b) >>> (32 : BitVec 6).toNat =
+        (0 : Word))
+    (h_qhat_high : n4CallAddbackBeqQHatHighDivBound a b)
+    (h_high_div : n4CallAddbackBeqHighDivKnuthABound a b)
+    (h_borrow : isAddbackBorrowN4CallV4Evm a b)
+    (h_carry2 : isAddbackCarry2NzN4CallV4Evm a b) :
+    n4CallAddbackBeqSemanticHoldsV4 a b :=
+  n4CallAddbackBeqSemanticHoldsV4_of_floor_eq_high_div_bound_and_borrow
+    hb3nz hshift_nz
+    (by
+      simpa [n4CallAddbackBeqHighDivVal_def] using
+        n4CallAddbackBeqQHatHighDivBound.floor_eq_of_call_rhatdd_hi_zero
+          hb3nz hshift_nz hcall h_rhat_hi_zero h_qhat_high)
+    h_high_div h_borrow h_carry2
+
+/-- Historical non-`V4` spelling of
+    `n4CallAddbackBeqSemanticHoldsV4_of_call_high_div_bound_and_borrow`. -/
+theorem n4CallAddbackBeqSemanticHolds_of_call_high_div_bound_and_borrow
+    {a b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (hcall : isCallTrialN4 (a.getLimbN 3) (b.getLimbN 2) (b.getLimbN 3))
+    (h_rhat_hi_zero :
+      divKTrialCallV4Rhatdd
+          (n4CallAddbackBeqU4 a b)
+          (n4CallAddbackBeqU3 a b)
+          (n4CallAddbackBeqB3Prime b) >>> (32 : BitVec 6).toNat =
+        (0 : Word))
+    (h_qhat_high : n4CallAddbackBeqQHatHighDivBound a b)
+    (h_high_div : n4CallAddbackBeqHighDivKnuthABound a b)
+    (h_borrow : isAddbackBorrowN4CallV4Evm a b)
+    (h_carry2 : isAddbackCarry2NzN4CallV4Evm a b) :
+    n4CallAddbackBeqSemanticHolds a b := by
+  simpa [n4CallAddbackBeqSemanticHolds_eq_v4] using
+    n4CallAddbackBeqSemanticHoldsV4_of_call_high_div_bound_and_borrow
+      hb3nz hshift_nz hcall h_rhat_hi_zero h_qhat_high h_high_div h_borrow h_carry2
+
 /-- Runtime-bounds package from a direct qhat high-divisor bound, the weakened
     Knuth-A `+1` denominator bridge, and the runtime borrow predicate. -/
 theorem n4CallAddbackBeqRuntimeBounds_of_qhat_high_div_le_norm_plus_one_and_borrow


### PR DESCRIPTION
## Summary
- add call-path runtime-bounds bridge for named n4 high-divisor evidence
- add V4 and historical semantic bridge endpoints from call/rhatdd-high-zero evidence plus n4CallAddbackBeqHighDivKnuthABound
- keep the raw floor arithmetic hidden behind the named qhat/high-div evidence surface

Stacked on #6825.

Bead: evm-asm-9iqmw.7.1.4.3
Refs: #61

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.CallAddbackRuntimeHighDiv
- Lean LSP diagnostics for CallAddbackRuntimeHighDiv: no errors
- lake build EvmAsm.Evm64.DivMod.Spec
- lake build
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- rg forbidden scan on touched file