### PR TITLE
feat(stateless): bounded byte-copy loop replaces unrolled LBU+SB block

### DIFF
--- a/EvmAsm/Stateless/SSZ/Encode/Program.lean
+++ b/EvmAsm/Stateless/SSZ/Encode/Program.lean
@@ -156,12 +156,50 @@ def serialize_stateless_output : Program :=
   LI .x5 0x180000001000 ;;
   OR' .x7 .x7 .x5 ;;
   SD .x6 .x7 56 ;;
-  -- Override output[61] with input's offset_blob_schedule LSB
-  -- (= chain_config[24] = active_fork[12]). Always <= 64 for the
-  -- amsterdam schema (one MAX_OPTIONAL_FORK_ACTIVATION_VALUES slot
-  -- + one MAX_BLOB_SCHEDULES_PER_FORK slot), so 1 byte suffices.
-  LBU .x7 .x13 24 ;;
-  SB .x6 .x7 61 ;;
+  -- Bounded byte-copy from chain_config[24..len) to OUTPUT[61..49+len)
+  -- where `len = chain_config_length` is derived from the outer
+  -- SSZ offset table: outer.offsets[3] - outer.offsets[2]. We
+  -- equivalently compute `chain_config_end_addr = SSZ_BASE +
+  -- outer.offsets[3]` and stop when the source pointer reaches it.
+  --
+  -- The previous unrolled implementation (PRs #6793 / #6802 /
+  -- #6807 / #6811) read chain_config[24..76) UNCONDITIONALLY and
+  -- relied on ziskemu's per-fixture mem slack. Cross-product
+  -- fixtures with witness content + active_fork content could
+  -- panic ziskemu with "section not found" when chain_config_end
+  -- landed at or past mem_end; the [[ziskemu-input-slack]] memory
+  -- note documents this. The bounded loop eliminates that
+  -- constraint entirely.
+  --
+  -- Range covers: offset_blob_schedule (chain_config[24..28)),
+  -- activation header (chain_config[28..36)), activation body
+  -- (chain_config[36..N)), blob_schedule (chain_config[..len)).
+  -- The previous separate LBU+SB at OUTPUT[61] (for
+  -- offset_blob_schedule LSB) and SB at OUTPUT[64] (high byte of
+  -- offset_activation = 0) are subsumed -- the loop writes
+  -- chain_config[24] to OUTPUT[61], chain_config[27] (always 0)
+  -- to OUTPUT[64], etc.
+  --
+  -- Register usage: x18=chain_config_end_addr, x19=src cursor,
+  -- x20=dst cursor, x7=byte temp. x13=chain_config_addr and
+  -- x17=SSZ_BASE are preserved from the decoder.
+  LWU .x18 .x17 12 ;;             -- offsets[3] (= chain_config_end_offset)
+  ADD .x18 .x17 .x18 ;;           -- chain_config_end_addr
+  ADDI .x19 .x13 24 ;;            -- src = chain_config + 24
+  ADDI .x20 .x6 61 ;;             -- dst = output + 61
+  -- Loop: BGEU exit forward 24 bytes (skip 6 instructions: BGEU
+  -- itself + the 5 body instructions). Otherwise: LBU + SB + bump
+  -- cursors + JAL back 20 bytes to the BGEU.
+  BGEU .x19 .x18 24 ;;
+  LBU .x7 .x19 0 ;;
+  SB .x20 .x7 0 ;;
+  ADDI .x19 .x19 1 ;;
+  ADDI .x20 .x20 1 ;;
+  JAL .x0 (-20 : BitVec 21)
+  -- Old unrolled byte-copy (chain_config[28..76) -> OUTPUT[65..113))
+  -- and the standalone byte 64 zero-fill removed; the loop above
+  -- subsumes both.
+  /-
   -- bytes [65..81): byte-copy active_fork[16..32) from input.
   -- active_fork[16..24) = activation header (offset_block_number,
   --   offset_timestamp); same shape regardless of emptiness:
@@ -248,9 +286,7 @@ def serialize_stateless_output : Program :=
   LBU .x7 .x13 72 ;; SB .x6 .x7 109 ;;
   LBU .x7 .x13 73 ;; SB .x6 .x7 110 ;;
   LBU .x7 .x13 74 ;; SB .x6 .x7 111 ;;
-  LBU .x7 .x13 75 ;; SB .x6 .x7 112 ;;
-  -- byte 64: high byte of offset_blob_schedule (always 0 since
-  -- the value fits in 1 byte).
-  SB .x6 .x0 64
+  LBU .x7 .x13 75 ;; SB .x6 .x7 112
+  -/
 
 end EvmAsm.Stateless.SSZ.Encode

--- a/scripts/codegen-stateless-spec-output-check.sh
+++ b/scripts/codegen-stateless-spec-output-check.sh
@@ -354,6 +354,15 @@ run_fixture "chain1_blob"           1                  0    ""           ""     
 # (= 0x28); still fits in 1 byte.
 run_fixture "chain1_act_blob_all"   1                  0    ""           ""                  ""    "3333333333" "4444444444" "500:600:700" || fail=1
 
+# Previously-blocked cross-product witness.codes + block_number
+# (no PK padding), now passing thanks to the bounded byte-copy.
+# Without the bound, this combo's mem slack between
+# chain_config_end and ziskemu's input-region boundary is 0
+# bytes, so the prior unrolled LBUs at chain_config + 28..76
+# panicked with "section not found". The bounded loop stops at
+# chain_config_end, never reaching the unmapped page.
+run_fixture "chain1_witcode_actbn_unbounded" 1   0    "deadbeef"   ""                  ""    "1234567890" || fail=1
+
 if [[ "$fail" -eq 0 ]]; then
   echo "==> PASS: all spec-output fixtures match the new SSZ schema"
   exit 0


### PR DESCRIPTION
## Summary
Replace the encoder's 100+ unrolled \`LBU + SB\` pairs (covering \`chain_config[24..76)\` → \`OUTPUT[61..113)\`) with a 10-instruction bounded loop:

\`\`\`
LWU .x18 .x17 12          -- offsets[3] (chain_config_end_offset)
ADD .x18 .x17 .x18        -- chain_config_end_addr
ADDI .x19 .x13 24         -- src cursor = chain_config + 24
ADDI .x20 .x6 61          -- dst cursor = output + 61
BGEU .x19 .x18 24         -- exit if src >= end
LBU .x7 .x19 0
SB .x20 .x7 0
ADDI .x19 .x19 1
ADDI .x20 .x20 1
JAL .x0 -20               -- back to BGEU
\`\`\`

The loop reads \`chain_config_length\` from the outer SSZ offset table (offsets[3] - offsets[2]) and stops exactly at \`chain_config_end\`. The previous unrolled implementation read \`chain_config[24..76)\` unconditionally and could panic ziskemu with \"section not found\" when the input layout placed \`chain_config_end\` at or past ziskemu's mapped input region.

The two ad-hoc fixups are subsumed:
- Standalone \`LBU+SB\` writing offset_blob_schedule LSB at \`OUTPUT[61]\` — loop's first iteration writes \`chain_config[24]\` there.
- Standalone \`SB\` writing 0 at \`OUTPUT[64]\` — loop's fourth iteration writes \`chain_config[27]\` which is always 0 (high byte of \`offset_activation = 16\`).

New fixture \`chain1_witcode_actbn_unbounded\` proves the constraint is gone: this combination has 0 bytes of mem slack and panicked under the old encoder. Now passes byte-for-byte.

## Test plan
- [x] \`scripts/codegen-stateless-spec-output-check.sh\` — all 18 fixtures pass.

Stacks on #6811.

🤖 Generated with [Claude Code](https://claude.com/claude-code)