### PR TITLE
feat(div): expose n4 runtime parts wrappers

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -19,6 +19,7 @@ import EvmAsm.Evm64.DivMod.Spec.CallAddbackRuntimeHighDiv
 import EvmAsm.Evm64.DivMod.Spec.N4V4StackPre
 import EvmAsm.Evm64.DivMod.Spec.N4V4ShiftNzDispatcher
 import EvmAsm.Evm64.DivMod.Spec.N4V4ShiftNzDispatcherBranchParts
+import EvmAsm.Evm64.DivMod.Spec.N4V4ShiftNzDispatcherRuntimeParts
 import EvmAsm.Evm64.DivMod.Spec.N4V4ShiftNzDispatcherHighDivParts
 import EvmAsm.Evm64.DivMod.Spec.N3V4StackPre
 import EvmAsm.Evm64.DivMod.Spec.N3V4StackPreR1

--- a/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcherRuntimeParts.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcherRuntimeParts.lean
@@ -1,0 +1,71 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N4V4ShiftNzDispatcherRuntimeParts
+
+  Direct global runtime evidence-part wrappers for the n=4, shift-nonzero DIV v4 dispatcher.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.N4V4ShiftNzDispatcher
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64 EvmWord
+
+/-- Final named n=4, shift-nonzero DIV dispatcher surface from direct
+    global runtime evidence parts. -/
+theorem evm_div_n4_shift_nz_stack_spec_of_runtime_parts
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbranch : n4CallSkipRuntimeBranchV4 a b)
+    (hcarry2 : isAddbackCarry2NzN4CallV4Evm a b)
+    (h_bounds : n4CallAddbackBeqRuntimeBounds a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_of_runtime_pred
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign
+    (by
+      rw [n4ShiftNzDispatcherRuntimeV4_def]
+      exact ⟨hbranch, hcarry2, h_bounds⟩)
+
+/-- Final named no-NOP n=4, shift-nonzero DIV dispatcher surface from direct
+    global runtime evidence parts. -/
+theorem evm_div_n4_shift_nz_stack_spec_noNop_of_runtime_parts
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbranch : n4CallSkipRuntimeBranchV4 a b)
+    (hcarry2 : isAddbackCarry2NzN4CallV4Evm a b)
+    (h_bounds : n4CallAddbackBeqRuntimeBounds a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_noNop_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_noNop_of_runtime_pred
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign
+    (by
+      rw [n4ShiftNzDispatcherRuntimeV4_def]
+      exact ⟨hbranch, hcarry2, h_bounds⟩)
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add a split n4 shift-nonzero dispatcher runtime-parts wrapper module
- expose direct stack-spec wrappers from callskip runtime branch evidence, addback carry2, and addback runtime bounds
- include normal and no-NOP variants

## Beads
- evm-asm-9iqmw.7.1.3
- evm-asm-9iqmw.7.1.4.3

Part of #61.

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.N4V4ShiftNzDispatcherRuntimeParts
- LSP diagnostics: no errors
- lake build EvmAsm.Evm64.DivMod.Spec
- lake build
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- forbidden-pattern scan on touched Lean files