### PR TITLE
feat(div): add n4 runtime evidence constructors

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcher.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcher.lean
@@ -228,6 +228,32 @@ theorem n4ShiftNzDispatcherBranchRuntimeV4.addback {a b : EvmWord}
   rw [n4ShiftNzDispatcherBranchRuntimeV4_def]
   exact Or.inr ⟨hadd, hcarry2, h_bounds⟩
 
+theorem n4ShiftNzDispatcherRuntimeV4.of_parts {a b : EvmWord}
+    (hbranch : n4CallSkipRuntimeBranchV4 a b)
+    (hcarry2 : isAddbackCarry2NzN4CallV4Evm a b)
+    (h_bounds : n4CallAddbackBeqRuntimeBounds a b) :
+    n4ShiftNzDispatcherRuntimeV4 a b := by
+  rw [n4ShiftNzDispatcherRuntimeV4_def]
+  exact ⟨hbranch, hcarry2, h_bounds⟩
+
+theorem n4ShiftNzDispatcherRuntimeV4.callSkipRuntimeBranch {a b : EvmWord}
+    (hruntime : n4ShiftNzDispatcherRuntimeV4 a b) :
+    n4CallSkipRuntimeBranchV4 a b := by
+  rw [n4ShiftNzDispatcherRuntimeV4_def] at hruntime
+  exact hruntime.1
+
+theorem n4ShiftNzDispatcherRuntimeV4.addbackCarry2 {a b : EvmWord}
+    (hruntime : n4ShiftNzDispatcherRuntimeV4 a b) :
+    isAddbackCarry2NzN4CallV4Evm a b := by
+  rw [n4ShiftNzDispatcherRuntimeV4_def] at hruntime
+  exact hruntime.2.1
+
+theorem n4ShiftNzDispatcherRuntimeV4.addbackRuntimeBounds {a b : EvmWord}
+    (hruntime : n4ShiftNzDispatcherRuntimeV4 a b) :
+    n4CallAddbackBeqRuntimeBounds a b := by
+  rw [n4ShiftNzDispatcherRuntimeV4_def] at hruntime
+  exact hruntime.2.2
+
 theorem n4ShiftNzDispatcherRuntimeV4.of_branch_bounds {a b : EvmWord}
     (hevidence : n4ShiftNzDispatcherBranchBoundsV4 a b) :
     n4ShiftNzDispatcherRuntimeV4 a b := by

--- a/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcherRuntimeParts.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcherRuntimeParts.lean
@@ -35,9 +35,8 @@ theorem evm_div_n4_shift_nz_stack_spec_of_runtime_parts
     sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
     hb3nz hshift_nz halign
-    (by
-      rw [n4ShiftNzDispatcherRuntimeV4_def]
-      exact ⟨hbranch, hcarry2, h_bounds⟩)
+    (n4ShiftNzDispatcherRuntimeV4.of_parts
+      hbranch hcarry2 h_bounds)
 
 /-- Final named no-NOP n=4, shift-nonzero DIV dispatcher surface from direct
     global runtime evidence parts. -/
@@ -64,8 +63,7 @@ theorem evm_div_n4_shift_nz_stack_spec_noNop_of_runtime_parts
     sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
     hb3nz hshift_nz halign
-    (by
-      rw [n4ShiftNzDispatcherRuntimeV4_def]
-      exact ⟨hbranch, hcarry2, h_bounds⟩)
+    (n4ShiftNzDispatcherRuntimeV4.of_parts
+      hbranch hcarry2 h_bounds)
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add n4ShiftNzDispatcherRuntimeV4.of_parts
- add projections for callskip runtime branch, addback carry2, and addback runtime bounds
- route the runtime-parts stack wrappers through the named constructor

## Beads
- evm-asm-9iqmw.7.1.3
- evm-asm-9iqmw.7.1.4.3

Part of #61.

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.N4V4ShiftNzDispatcher
- lake build EvmAsm.Evm64.DivMod.Spec.N4V4ShiftNzDispatcherRuntimeParts
- LSP diagnostics: no errors after LSP build/restart
- lake build EvmAsm.Evm64.DivMod.Spec
- lake build
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- forbidden-pattern scan on touched Lean files