### PR TITLE
feat(div): add n4 branch bounds constructors

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcher.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcher.lean
@@ -205,6 +205,14 @@ theorem n4ShiftNzDispatcherBranchBoundsV4.addbackRuntimeBounds {a b : EvmWord}
   rw [n4ShiftNzDispatcherBranchBoundsV4_def] at hevidence
   exact hevidence.2.2
 
+theorem n4ShiftNzDispatcherBranchBoundsV4.of_parts {a b : EvmWord}
+    (hbranch : n4CallSkipBranchV4 a b)
+    (hcarry2 : isAddbackCarry2NzN4CallV4Evm a b)
+    (h_bounds : n4CallAddbackBeqRuntimeBounds a b) :
+    n4ShiftNzDispatcherBranchBoundsV4 a b := by
+  rw [n4ShiftNzDispatcherBranchBoundsV4_def]
+  exact ⟨hbranch, hcarry2, h_bounds⟩
+
 theorem n4ShiftNzDispatcherBranchBoundsV4.of_runtime_pred {a b : EvmWord}
     (hruntime : n4ShiftNzDispatcherRuntimeV4 a b)
     (hbranch : n4CallSkipBranchV4 a b) :
@@ -276,6 +284,16 @@ theorem n4ShiftNzDispatcherBranchRuntimeV4_of_branch_bounds {a b : EvmWord}
     n4ShiftNzDispatcherBranchRuntimeV4 a b :=
   n4ShiftNzDispatcherBranchRuntimeV4_of_runtime_pred
     (n4ShiftNzDispatcherRuntimeV4.of_branch_bounds hevidence)
+
+theorem n4ShiftNzDispatcherBranchBoundsV4.toRuntimeV4 {a b : EvmWord}
+    (hevidence : n4ShiftNzDispatcherBranchBoundsV4 a b) :
+    n4ShiftNzDispatcherRuntimeV4 a b :=
+  n4ShiftNzDispatcherRuntimeV4.of_branch_bounds hevidence
+
+theorem n4ShiftNzDispatcherBranchBoundsV4.toBranchRuntime {a b : EvmWord}
+    (hevidence : n4ShiftNzDispatcherBranchBoundsV4 a b) :
+    n4ShiftNzDispatcherBranchRuntimeV4 a b :=
+  n4ShiftNzDispatcherBranchRuntimeV4_of_branch_bounds hevidence
 
 theorem n4ShiftNzDispatcherBranchHighDivEvidence.skip {a b : EvmWord}
     (hskip : isSkipBorrowN4CallV4Evm a b)


### PR DESCRIPTION
## Summary
- add n4ShiftNzDispatcherBranchBoundsV4.of_parts
- add method-style lowerings from branch-bounds evidence to runtime and branch-runtime evidence
- keep the n=4 shift_nz dispatcher evidence surfaces consistent with runtime constructors

## Beads
- evm-asm-9iqmw.7.1.3
- evm-asm-9iqmw.7.1.4.3

Part of #61.

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.N4V4ShiftNzDispatcher
- LSP diagnostics: no errors
- lake build EvmAsm.Evm64.DivMod.Spec
- lake build
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- forbidden-pattern scan on touched Lean files