### PR TITLE
test(stateless): exercise non-empty witness.headers field

### DIFF
--- a/scripts/codegen-stateless-spec-output-check.sh
+++ b/scripts/codegen-stateless-spec-output-check.sh
@@ -79,6 +79,7 @@ run_fixture() {
   local block_number="${7:-}"
   local timestamp="${8:-}"
   local blob_schedule="${9:-}"
+  local witness_headers_hex="${10:-}"
 
   local safe="${label//[^0-9A-Za-z_]/_}"
   local input_file="$REPO_ROOT/gen-out/stateless_guest-spec-${safe}.input"
@@ -86,14 +87,16 @@ run_fixture() {
   local spec_exp_file="$REPO_ROOT/gen-out/stateless_guest-spec-${safe}.spec-expected"
   local log_file="$REPO_ROOT/gen-out/stateless_guest-spec-${safe}.emu.log"
 
-  echo "==> [$label] gen new-schema SSZ input + spec expected (chain_id=$cid, fork=$fork, code=${witness_code_hex:-empty}, state=${witness_state_hex:-empty}, pk=${public_key_hex:-empty}, bn=${block_number:-empty}, ts=${timestamp:-empty}, blob=${blob_schedule:-empty})"
+  echo "==> [$label] gen new-schema SSZ input + spec expected (chain_id=$cid, fork=$fork, code=${witness_code_hex:-empty}, state=${witness_state_hex:-empty}, pk=${public_key_hex:-empty}, bn=${block_number:-empty}, ts=${timestamp:-empty}, blob=${blob_schedule:-empty}, hdr=${witness_headers_hex:-empty})"
   uv run --directory execution-specs --quiet python3 -c "
 import struct, sys
 from ethereum.forks.amsterdam.stateless_ssz import (
     MAX_BYTES_PER_CODE,
+    MAX_BYTES_PER_HEADER,
     MAX_BYTES_PER_WITNESS_NODE,
     MAX_PUBLIC_KEYS,
     MAX_WITNESS_CODES,
+    MAX_WITNESS_HEADERS,
     MAX_WITNESS_NODES,
     PUBLIC_KEY_BYTES,
     STATELESS_INPUT_SCHEMA_ID_BYTES,
@@ -120,6 +123,7 @@ pk_hex = sys.argv[7]
 bn_str = sys.argv[8]
 ts_str = sys.argv[9]
 blob_str = sys.argv[10]
+hdr_hex = sys.argv[11]
 
 # Build the new-schema StatelessInput: empty new_payload_request,
 # witness whose 'state'/'codes' lists each hold zero or more
@@ -168,9 +172,17 @@ if state_hex:
     state_entries = state_hex.split(':')
     state_arg = tuple(NodeBL(bytes.fromhex(s)) for s in state_entries)
 
+HeaderBL = ByteList[MAX_BYTES_PER_HEADER]
+HeadersList = SszList[HeaderBL, MAX_WITNESS_HEADERS]
+hdr_arg = ()
+if hdr_hex:
+    hdr_entries = hdr_hex.split(':')
+    hdr_arg = tuple(HeaderBL(bytes.fromhex(h)) for h in hdr_entries)
+
 witness = SszExecutionWitness(
     state=NodesList(*state_arg),
     codes=CodesList(*codes_arg),
+    headers=HeadersList(*hdr_arg),
 )
 
 PkBV = ByteVector[PUBLIC_KEY_BYTES]
@@ -202,7 +214,7 @@ with open(sys.argv[2], 'wb') as f:
 spec_bytes = bytes(run_stateless_guest(input_bytes))
 with open(sys.argv[3], 'w') as f:
     f.write(spec_bytes.hex())
-" "$cid" "$input_file" "$spec_exp_file" "$fork" "$witness_code_hex" "$witness_state_hex" "$public_key_hex" "$block_number" "$timestamp" "$blob_schedule"
+" "$cid" "$input_file" "$spec_exp_file" "$fork" "$witness_code_hex" "$witness_state_hex" "$public_key_hex" "$block_number" "$timestamp" "$blob_schedule" "$witness_headers_hex"
 
   echo "==> [$label] ziskemu run"
   "$ZISKEMU" -e gen-out/stateless_guest.elf -i "$input_file" \
@@ -371,6 +383,15 @@ run_fixture "chain1_witcode_actbn_unbounded" 1   0    "deadbeef"   ""           
 # "section not found". The bounded loop in PR #6843 stops at
 # chain_config_end so the combination passes.
 run_fixture "chain1_witboth_actbn_unbounded" 1   0    "deadbeef"   "a1b2c3d4e5f60718"  ""    "1234567890" || fail=1
+
+# Non-empty witness.headers -- exercises the THIRD inner witness
+# field, which the decoder's `decode_header_count` stub leaves
+# inert (x16 = 0) so the validator pipeline takes the N=0 fast
+# path. Spec's `validate_headers([bogus])` raises -> valid=False,
+# matching the ELF's x11=0 stub. Adding a 32-byte arbitrary
+# header tests that the decoder's outer-offset chase is robust
+# even when witness.headers is non-empty.
+run_fixture "chain1_witheaders"     1                  0    ""           ""                  ""    ""           ""           ""    "$(printf 'aa%.0s' {1..32})" || fail=1
 
 if [[ "$fail" -eq 0 ]]; then
   echo "==> PASS: all spec-output fixtures match the new SSZ schema"


### PR DESCRIPTION
## Summary
Add fixture \`chain1_witheaders\` and extend \`run_fixture\` to accept an optional 10th \`witness_headers_hex\` argument.

Non-empty \`witness.headers\` is the THIRD inner field of \`SszExecutionWitness\` — the only one not exercised by prior fixtures (state + codes covered in #6749 / #6760 / #6764). The decoder's \`decode_header_count\` stub leaves \`x16 = 0\` regardless, so the validator pipeline takes the N=0 fast path and the ELF output stays the 73-byte valid=False template. Spec's \`validate_headers([bogus])\` raises → caught → \`valid=False\` with chain_config echo. Both match.

The fixture exercises the encoder's bounded byte-copy under a new input layout (chain_config_offset shifted by witness.headers content).

## Test plan
- [x] \`scripts/codegen-stateless-spec-output-check.sh\` — all fixtures pass.

Stacks on #6848 (and indirectly on #6843).

🤖 Generated with [Claude Code](https://claude.com/claude-code)