### PR TITLE
feat(div): add n4 addback semantic stack wrappers

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcherSemanticParts.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcherSemanticParts.lean
@@ -333,6 +333,119 @@ theorem evm_div_n4_shift_nz_stack_spec_noNop_of_runtime_parts_semanticV4
     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
     hb3nz hshift_nz halign hbranch hcarry2 hsemV4
 
+/-- Addback-branch n=4 shift-nonzero DIV dispatcher surface consuming the
+    repaired V4 addback semantic marker directly. This branch-local wrapper does
+    not require skip-branch evidence or the compact runtime-bounds package. -/
+theorem evm_div_n4_shift_nz_stack_spec_v4_of_branch_addback_semanticV4
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hadd : isAddbackBorrowN4CallV4Evm a b)
+    (hcarry2 : isAddbackCarry2NzN4CallV4Evm a b)
+    (hsemV4 : n4CallAddbackBeqSemanticHoldsV4 a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_call_addback_beq_stack_spec
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    (evmWord_ne_zero_of_getLimbN_3_ne_zero hb3nz)
+    hb3nz hshift_nz halign
+    (isCallTrialN4Evm_of_shift_nz a b hb3nz hshift_nz)
+    hadd hcarry2
+    (n4CallAddbackBeqSemanticHolds_of_v4 hsemV4)
+
+/-- No-NOP addback-branch n=4 shift-nonzero DIV dispatcher surface consuming
+    the repaired V4 addback semantic marker directly. -/
+theorem evm_div_n4_shift_nz_stack_spec_v4_noNop_of_branch_addback_semanticV4
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hadd : isAddbackBorrowN4CallV4Evm a b)
+    (hcarry2 : isAddbackCarry2NzN4CallV4Evm a b)
+    (hsemV4 : n4CallAddbackBeqSemanticHoldsV4 a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_noNop_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_call_addback_beq_stack_spec_noNop
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    (evmWord_ne_zero_of_getLimbN_3_ne_zero hb3nz)
+    hb3nz hshift_nz halign
+    (isCallTrialN4Evm_of_shift_nz a b hb3nz hshift_nz)
+    hadd hcarry2
+    (n4CallAddbackBeqSemanticHolds_of_v4 hsemV4)
+
+/-- Historical alias for the V4-semantic addback-branch n=4 shift-nonzero DIV
+    dispatcher surface. -/
+theorem evm_div_n4_shift_nz_stack_spec_of_branch_addback_semanticV4
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hadd : isAddbackBorrowN4CallV4Evm a b)
+    (hcarry2 : isAddbackCarry2NzN4CallV4Evm a b)
+    (hsemV4 : n4CallAddbackBeqSemanticHoldsV4 a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_v4_of_branch_addback_semanticV4
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign hadd hcarry2 hsemV4
+
+/-- Historical no-NOP alias for the V4-semantic addback-branch n=4
+    shift-nonzero DIV dispatcher surface. -/
+theorem evm_div_n4_shift_nz_stack_spec_noNop_of_branch_addback_semanticV4
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hadd : isAddbackBorrowN4CallV4Evm a b)
+    (hcarry2 : isAddbackCarry2NzN4CallV4Evm a b)
+    (hsemV4 : n4CallAddbackBeqSemanticHoldsV4 a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_noNop_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_v4_noNop_of_branch_addback_semanticV4
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign hadd hcarry2 hsemV4
+
 /-- Historical alias for the V4-semantic n=4 shift-nonzero DIV dispatcher
     surface. -/
 theorem evm_div_n4_shift_nz_stack_spec_of_branch_pred_semanticV4


### PR DESCRIPTION
Part of #61. Beads: evm-asm-9iqmw.7, evm-asm-9iqmw.7.1.3, evm-asm-9iqmw.7.1.4.3.\n\nSummary:\n- Add NOP and no-NOP n4 shift-nonzero addback-branch stack wrappers that consume n4CallAddbackBeqSemanticHoldsV4 directly.\n- Add historical alias names matching the surrounding semantic wrapper API.\n- This gives branch-local addback composition a repaired-semantic target without skip-branch evidence or the compact RuntimeBounds package.\n\nVerification:\n- lake build EvmAsm.Evm64.DivMod.Spec.N4V4ShiftNzDispatcherSemanticParts\n- Lean LSP diagnostics on N4V4ShiftNzDispatcherSemanticParts.lean: no errors\n- lake build EvmAsm.Evm64.DivMod.Spec\n- lake build EvmAsm.Evm64.DivMod\n- lake build\n- scripts/check-file-size.sh\n- scripts/check-unimported.sh\n- git diff --check\n- forbidden scan on N4V4ShiftNzDispatcherSemanticParts.lean