### PR TITLE
feat(div): package n4 branch semantic evidence

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcherSemanticParts.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcherSemanticParts.lean
@@ -10,6 +10,30 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64 EvmWord
 
+/-- Branch-sensitive n=4 shift-nonzero dispatcher evidence whose addback branch
+    carries the repaired V4 semantic marker instead of the compact runtime-bounds
+    package. -/
+def n4ShiftNzDispatcherBranchSemanticV4 (a b : EvmWord) : Prop :=
+  (isSkipBorrowN4CallV4Evm a b ∧ n4CallSkipRuntimeBranchV4 a b) ∨
+    (isAddbackBorrowN4CallV4Evm a b ∧
+      isAddbackCarry2NzN4CallV4Evm a b ∧
+      n4CallAddbackBeqSemanticHoldsV4 a b)
+
+theorem n4ShiftNzDispatcherBranchSemanticV4.skip {a b : EvmWord}
+    (hskip : isSkipBorrowN4CallV4Evm a b)
+    (hbranch : n4CallSkipRuntimeBranchV4 a b) :
+    n4ShiftNzDispatcherBranchSemanticV4 a b := by
+  rw [n4ShiftNzDispatcherBranchSemanticV4]
+  exact Or.inl ⟨hskip, hbranch⟩
+
+theorem n4ShiftNzDispatcherBranchSemanticV4.addback {a b : EvmWord}
+    (hadd : isAddbackBorrowN4CallV4Evm a b)
+    (hcarry2 : isAddbackCarry2NzN4CallV4Evm a b)
+    (hsemV4 : n4CallAddbackBeqSemanticHoldsV4 a b) :
+    n4ShiftNzDispatcherBranchSemanticV4 a b := by
+  rw [n4ShiftNzDispatcherBranchSemanticV4]
+  exact Or.inr ⟨hadd, hcarry2, hsemV4⟩
+
 /-- Addback semantic bridge from packaged n=4 shift-nonzero runtime evidence. -/
 theorem n4ShiftNzDispatcherRuntimeV4.semanticHoldsV4 {a b : EvmWord}
     (hb3nz : b.getLimbN 3 ≠ 0)
@@ -497,5 +521,120 @@ theorem evm_div_n4_shift_nz_stack_spec_noNop_of_branch_pred_semanticV4
     sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
     hb3nz hshift_nz halign hbranch hcarry2 hsemV4
+
+/-- Packaged branch-sensitive n=4 shift-nonzero DIV dispatcher surface whose
+    addback branch consumes the repaired V4 semantic marker. -/
+theorem evm_div_n4_shift_nz_stack_spec_v4_of_branch_semantic
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hevidence : n4ShiftNzDispatcherBranchSemanticV4 a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) := by
+  rw [n4ShiftNzDispatcherBranchSemanticV4] at hevidence
+  cases hevidence with
+  | inl hskip =>
+      exact cpsTripleWithin_mono_nSteps (by decide)
+        (evm_div_n4_call_skip_stack_spec_v4_of_runtime_branch_pred_hb3nz
+          sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+          hb3nz hshift_nz halign hskip.1 hskip.2)
+  | inr hadd =>
+      exact evm_div_n4_shift_nz_stack_spec_v4_of_branch_addback_semanticV4
+        sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+        hb3nz hshift_nz halign hadd.1 hadd.2.1 hadd.2.2
+
+/-- No-NOP packaged branch-sensitive n=4 shift-nonzero DIV dispatcher surface
+    whose addback branch consumes the repaired V4 semantic marker. -/
+theorem evm_div_n4_shift_nz_stack_spec_v4_noNop_of_branch_semantic
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hevidence : n4ShiftNzDispatcherBranchSemanticV4 a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_noNop_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) := by
+  rw [n4ShiftNzDispatcherBranchSemanticV4] at hevidence
+  cases hevidence with
+  | inl hskip =>
+      exact cpsTripleWithin_mono_nSteps (by decide)
+        (evm_div_n4_call_skip_stack_spec_v4_noNop_of_runtime_branch_pred_hb3nz
+          sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+          hb3nz hshift_nz halign hskip.1 hskip.2)
+  | inr hadd =>
+      exact evm_div_n4_shift_nz_stack_spec_v4_noNop_of_branch_addback_semanticV4
+        sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+        hb3nz hshift_nz halign hadd.1 hadd.2.1 hadd.2.2
+
+/-- Historical alias for the packaged branch-sensitive V4-semantic n=4
+    shift-nonzero DIV dispatcher surface. -/
+theorem evm_div_n4_shift_nz_stack_spec_of_branch_semantic
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hevidence : n4ShiftNzDispatcherBranchSemanticV4 a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_v4_of_branch_semantic
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign hevidence
+
+/-- Historical no-NOP alias for the packaged branch-sensitive V4-semantic n=4
+    shift-nonzero DIV dispatcher surface. -/
+theorem evm_div_n4_shift_nz_stack_spec_noNop_of_branch_semantic
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hevidence : n4ShiftNzDispatcherBranchSemanticV4 a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_noNop_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_v4_noNop_of_branch_semantic
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign hevidence
+
 
 end EvmAsm.Evm64


### PR DESCRIPTION
Part of #61. Beads: evm-asm-9iqmw, evm-asm-9iqmw.7, evm-asm-9iqmw.7.1.3, evm-asm-9iqmw.7.1.4.3.\n\nSummary:\n- Add n4ShiftNzDispatcherBranchSemanticV4 with skip/addback constructors.\n- Package skip evidence as skip borrow plus callskip runtime branch evidence.\n- Package addback evidence as addback borrow plus carry2 plus the repaired V4 addback semantic marker.\n- Add NOP/no-NOP stack wrappers and historical aliases consuming the packaged branch-semantic evidence.\n\nVerification:\n- lake build EvmAsm.Evm64.DivMod.Spec.N4V4ShiftNzDispatcherSemanticParts\n- Lean LSP diagnostics on N4V4ShiftNzDispatcherSemanticParts.lean: no errors\n- lake build EvmAsm.Evm64.DivMod.Spec\n- lake build EvmAsm.Evm64.DivMod\n- lake build\n- scripts/check-file-size.sh\n- scripts/check-unimported.sh\n- git diff --check\n- forbidden scan on N4V4ShiftNzDispatcherSemanticParts.lean