### PR TITLE
feat(div): route n4 runtime high-div through branch semantic

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcherSemanticParts.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcherSemanticParts.lean
@@ -774,4 +774,131 @@ theorem evm_div_n4_shift_nz_stack_spec_v4_noNop_of_branch_high_div_raw_semantic
       hb3nz hshift_nz hevidence)
 
 
+/-- Packaged runtime high-div evidence lowers to branch-semantic dispatcher
+    evidence through its branch high-div projection. -/
+theorem n4ShiftNzDispatcherRuntimeHighDivEvidence.toBranchSemanticV4 {a b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (hruntime : n4ShiftNzDispatcherRuntimeHighDivEvidence a b) :
+    n4ShiftNzDispatcherBranchSemanticV4 a b :=
+  n4ShiftNzDispatcherBranchHighDivEvidence.toBranchSemanticV4
+    hb3nz hshift_nz
+    (n4ShiftNzDispatcherRuntimeHighDivEvidence.toBranchHighDivEvidence hruntime)
+
+/-- Raw runtime high-div evidence lowers to branch-semantic dispatcher evidence
+    through its raw branch high-div projection. -/
+theorem n4ShiftNzDispatcherRuntimeHighDivRawEvidence.toBranchSemanticV4 {a b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (hruntime : n4ShiftNzDispatcherRuntimeHighDivRawEvidence a b) :
+    n4ShiftNzDispatcherBranchSemanticV4 a b :=
+  n4ShiftNzDispatcherBranchHighDivRawEvidence.toBranchSemanticV4
+    hb3nz hshift_nz
+    (n4ShiftNzDispatcherRuntimeHighDivRawEvidence.toBranchHighDivRawEvidence hruntime)
+
+/-- Packaged runtime high-div evidence stack surface routed through the repaired
+    branch-semantic dispatcher package. -/
+theorem evm_div_n4_shift_nz_stack_spec_v4_of_runtime_high_div_semantic
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hruntime : n4ShiftNzDispatcherRuntimeHighDivEvidence a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_v4_of_branch_semantic
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign
+    (n4ShiftNzDispatcherRuntimeHighDivEvidence.toBranchSemanticV4
+      hb3nz hshift_nz hruntime)
+
+/-- No-NOP packaged runtime high-div evidence stack surface routed through the
+    repaired branch-semantic dispatcher package. -/
+theorem evm_div_n4_shift_nz_stack_spec_v4_noNop_of_runtime_high_div_semantic
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hruntime : n4ShiftNzDispatcherRuntimeHighDivEvidence a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_noNop_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_v4_noNop_of_branch_semantic
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign
+    (n4ShiftNzDispatcherRuntimeHighDivEvidence.toBranchSemanticV4
+      hb3nz hshift_nz hruntime)
+
+/-- Raw runtime high-div evidence stack surface routed through the repaired
+    branch-semantic dispatcher package. -/
+theorem evm_div_n4_shift_nz_stack_spec_v4_of_runtime_high_div_raw_semantic
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hruntime : n4ShiftNzDispatcherRuntimeHighDivRawEvidence a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_v4_of_branch_semantic
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign
+    (n4ShiftNzDispatcherRuntimeHighDivRawEvidence.toBranchSemanticV4
+      hb3nz hshift_nz hruntime)
+
+/-- No-NOP raw runtime high-div evidence stack surface routed through the repaired
+    branch-semantic dispatcher package. -/
+theorem evm_div_n4_shift_nz_stack_spec_v4_noNop_of_runtime_high_div_raw_semantic
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hruntime : n4ShiftNzDispatcherRuntimeHighDivRawEvidence a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_noNop_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_v4_noNop_of_branch_semantic
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign
+    (n4ShiftNzDispatcherRuntimeHighDivRawEvidence.toBranchSemanticV4
+      hb3nz hshift_nz hruntime)
+
+
 end EvmAsm.Evm64


### PR DESCRIPTION
Part of #61. Beads: evm-asm-9iqmw.7.1.3, evm-asm-9iqmw.7.1.4.3.\n\nSummary:\n- Add packaged and raw runtime high-div lowerings into n4ShiftNzDispatcherBranchSemanticV4.\n- Add NOP/no-NOP stack wrappers for packaged runtime high-div evidence via the repaired branch-semantic package.\n- Add NOP/no-NOP stack wrappers for raw runtime high-div evidence via the same package.\n- This lets global high-div runtime evidence feed stack composition without exposing compact RuntimeBounds.\n\nVerification:\n- lake build EvmAsm.Evm64.DivMod.Spec.N4V4ShiftNzDispatcherSemanticParts\n- Lean LSP diagnostics on N4V4ShiftNzDispatcherSemanticParts.lean: no errors\n- lake build EvmAsm.Evm64.DivMod.Spec\n- lake build EvmAsm.Evm64.DivMod\n- lake build\n- scripts/check-file-size.sh\n- scripts/check-unimported.sh\n- git diff --check\n- forbidden scan on N4V4ShiftNzDispatcherSemanticParts.lean