### PR TITLE
refactor(div): route n4 branch addback parts through semantics

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcherBranchParts.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcherBranchParts.lean
@@ -4,7 +4,7 @@
   Direct branch-runtime evidence-part wrappers for the n=4, shift-nonzero DIV v4 dispatcher.
 -/
 
-import EvmAsm.Evm64.DivMod.Spec.N4V4ShiftNzDispatcher
+import EvmAsm.Evm64.DivMod.Spec.N4V4ShiftNzDispatcherSemanticParts
 
 namespace EvmAsm.Evm64
 
@@ -83,11 +83,12 @@ theorem evm_div_n4_shift_nz_stack_spec_of_branch_addback_bounds_parts
          shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
        ((sp + signExtend12 3936) ↦ₘ scratchMem))
       (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
-  evm_div_n4_shift_nz_stack_spec_of_branch_runtime
+  evm_div_n4_shift_nz_stack_spec_of_branch_addback_semanticV4
     sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
-    hb3nz hshift_nz halign
-    (n4ShiftNzDispatcherBranchRuntimeV4.addback hadd hcarry2 h_bounds)
+    hb3nz hshift_nz halign hadd hcarry2
+    (n4CallAddbackBeqSemanticHoldsV4_of_runtime_bounds
+      hb3nz hshift_nz h_bounds hadd hcarry2)
 
 /-- Final named no-NOP n=4, shift-nonzero DIV dispatcher surface from direct
     addback-branch runtime-bounds evidence. -/
@@ -110,10 +111,11 @@ theorem evm_div_n4_shift_nz_stack_spec_noNop_of_branch_addback_bounds_parts
          shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
        ((sp + signExtend12 3936) ↦ₘ scratchMem))
       (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
-  evm_div_n4_shift_nz_stack_spec_noNop_of_branch_runtime
+  evm_div_n4_shift_nz_stack_spec_noNop_of_branch_addback_semanticV4
     sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
-    hb3nz hshift_nz halign
-    (n4ShiftNzDispatcherBranchRuntimeV4.addback hadd hcarry2 h_bounds)
+    hb3nz hshift_nz halign hadd hcarry2
+    (n4CallAddbackBeqSemanticHoldsV4_of_runtime_bounds
+      hb3nz hshift_nz h_bounds hadd hcarry2)
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- switch the n=4 branch-parts wrapper module to import the repaired semantic dispatcher surface
- route addback runtime-bounds branch wrappers by deriving n4CallAddbackBeqSemanticHoldsV4 and calling the semantic addback wrappers
- keep public branch-parts theorem names and signatures stable

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.N4V4ShiftNzDispatcherBranchParts
- Lean LSP diagnostics for N4V4ShiftNzDispatcherBranchParts.lean: no errors
- lake build EvmAsm.Evm64.DivMod.Spec
- lake build EvmAsm.Evm64.DivMod
- lake build
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- rg forbidden scan on touched file: no matches

Note: an initial parallel DivMod/full-build run produced a transient missing .olean output race; the serial rerun of lake build EvmAsm.Evm64.DivMod passed.

Refs #61
Beads: evm-asm-9iqmw.7.1.3, evm-asm-9iqmw.7.1.4.3