### PR TITLE
refactor(div): route n4 branch bounds parts through semantics

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcherBranchBoundsParts.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcherBranchBoundsParts.lean
@@ -4,7 +4,7 @@
   Direct branch-bounds evidence-part wrappers for the n=4, shift-nonzero DIV v4 dispatcher.
 -/
 
-import EvmAsm.Evm64.DivMod.Spec.N4V4ShiftNzDispatcher
+import EvmAsm.Evm64.DivMod.Spec.N4V4ShiftNzDispatcherSemanticParts
 
 namespace EvmAsm.Evm64
 
@@ -31,11 +31,23 @@ theorem evm_div_n4_shift_nz_stack_spec_of_branch_bounds_parts
          shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
        ((sp + signExtend12 3936) ↦ₘ scratchMem))
       (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
-  evm_div_n4_shift_nz_stack_spec_of_branch_bounds
-    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
-    hb3nz hshift_nz halign
-    (n4ShiftNzDispatcherBranchBoundsV4.of_parts hbranch hcarry2 h_bounds)
+by
+  cases isSkipBorrowN4CallV4Evm_or_isAddbackBorrowN4CallV4Evm a b with
+  | inl hskip =>
+      exact evm_div_n4_shift_nz_stack_spec_of_branch_semantic
+        sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+        hb3nz hshift_nz halign
+        (n4ShiftNzDispatcherBranchSemanticV4.skip hskip
+          (n4CallSkipRuntimeBranchV4_of_branch_pred hbranch))
+  | inr hadd =>
+      exact evm_div_n4_shift_nz_stack_spec_of_branch_semantic
+        sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+        hb3nz hshift_nz halign
+        (n4ShiftNzDispatcherBranchSemanticV4.addback hadd hcarry2
+          (n4CallAddbackBeqSemanticHoldsV4_of_runtime_bounds
+            hb3nz hshift_nz h_bounds hadd hcarry2))
 
 /-- Final named no-NOP n=4, shift-nonzero DIV dispatcher surface from direct
     branch/bounds evidence parts. -/
@@ -58,10 +70,22 @@ theorem evm_div_n4_shift_nz_stack_spec_noNop_of_branch_bounds_parts
          shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
        ((sp + signExtend12 3936) ↦ₘ scratchMem))
       (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
-  evm_div_n4_shift_nz_stack_spec_noNop_of_branch_bounds
-    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
-    hb3nz hshift_nz halign
-    (n4ShiftNzDispatcherBranchBoundsV4.of_parts hbranch hcarry2 h_bounds)
+by
+  cases isSkipBorrowN4CallV4Evm_or_isAddbackBorrowN4CallV4Evm a b with
+  | inl hskip =>
+      exact evm_div_n4_shift_nz_stack_spec_noNop_of_branch_semantic
+        sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+        hb3nz hshift_nz halign
+        (n4ShiftNzDispatcherBranchSemanticV4.skip hskip
+          (n4CallSkipRuntimeBranchV4_of_branch_pred hbranch))
+  | inr hadd =>
+      exact evm_div_n4_shift_nz_stack_spec_noNop_of_branch_semantic
+        sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+        hb3nz hshift_nz halign
+        (n4ShiftNzDispatcherBranchSemanticV4.addback hadd hcarry2
+          (n4CallAddbackBeqSemanticHoldsV4_of_runtime_bounds
+            hb3nz hshift_nz h_bounds hadd hcarry2))
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- switch the n=4 branch-bounds parts wrapper module to import the repaired semantic dispatcher surface
- case-split skip/addback locally and construct n4ShiftNzDispatcherBranchSemanticV4 directly
- keep public branch-bounds parts theorem names and signatures stable while routing through semantic stack wrappers

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.N4V4ShiftNzDispatcherBranchBoundsParts
- Lean LSP diagnostics for N4V4ShiftNzDispatcherBranchBoundsParts.lean: no errors
- lake build EvmAsm.Evm64.DivMod.Spec
- lake build EvmAsm.Evm64.DivMod
- lake build
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- rg forbidden scan on touched file: no matches

Refs #61
Beads: evm-asm-9iqmw.7.1.3, evm-asm-9iqmw.7.1.4.3