### PR TITLE
test(stateless): extreme fixture (kitchen-sink + all max values)

### DIFF
--- a/scripts/codegen-stateless-spec-output-check.sh
+++ b/scripts/codegen-stateless-spec-output-check.sh
@@ -427,6 +427,17 @@ run_fixture "chain1_kitchen_sink"   1                  0    "deadbeef"   "a1b2c3
 # encoder-only test).
 run_fixture "chain_max_all_max"     0xFFFFFFFFFFFFFFFF 0    ""           ""                  ""    "0xFFFFFFFFFFFFFFFF" "0xFFFFFFFFFFFFFFFF" "0xFFFFFFFFFFFFFFFF:0xFFFFFFFFFFFFFFFF:0xFFFFFFFFFFFFFFFF" || fail=1
 
+# Absolute extreme: kitchen-sink + max-values combined.
+# Every input slot is populated AND every numeric value is at
+# u64 max. Tests the encoder under simultaneous extremes:
+# maximum-shape SszForkConfig (113-byte output), maximum
+# byte-budget for chain_config_offset shift (full witness +
+# pk), and all-1 bits flowing through the bit-packed bytes
+# [32..48) and the bounded byte-copy [49..113). If any path
+# has a subtle bug with 0xFF bytes under input-layout drift,
+# this fixture catches it.
+run_fixture "chain_extreme"         0xFFFFFFFFFFFFFFFF 0    "deadbeef"   "a1b2c3d4e5f60718"  "04$(printf '%064d' 0)$(printf '%064d' 0)"    "0xFFFFFFFFFFFFFFFF" "0xFFFFFFFFFFFFFFFF" "0xFFFFFFFFFFFFFFFF:0xFFFFFFFFFFFFFFFF:0xFFFFFFFFFFFFFFFF"    "$(printf 'aa%.0s' {1..32})" || fail=1
+
 if [[ "$fail" -eq 0 ]]; then
   echo "==> PASS: all spec-output fixtures match the new SSZ schema"
   exit 0


### PR DESCRIPTION
## Summary
Add fixture \`chain_extreme\` combining the kitchen-sink shape (every input slot populated) with all numeric values at \`u64\` max (\`0xFFFFFFFFFFFFFFFF\`). Tests the encoder under simultaneous extremes:

- Maximum-shape SszForkConfig (113-byte output) — exercises the bounded byte-copy at its upper iteration count.
- Maximum byte-budget for chain_config_offset shift (full witness contents + 65-byte public_key) — exercises the outer-offset chase under heavy input-layout drift.
- All-1 bits flowing through bit-packed bytes [32..48) AND the bounded byte-copy [49..113).

If any encoder path has a subtle bug with 0xFF bytes under input-layout drift, this fixture catches it.

## Test plan
- [x] \`scripts/codegen-stateless-spec-output-check.sh\` — all fixtures pass.

Stacks on #6869.

🤖 Generated with [Claude Code](https://claude.com/claude-code)