### PR TITLE
feat(stateless): real decode_header_count + pipeline falls through on validator failure

### DIFF
--- a/EvmAsm/Codegen/Programs.lean
+++ b/EvmAsm/Codegen/Programs.lean
@@ -166,7 +166,9 @@ def statelessGuestValidatorPipeline : String :=
   "  # PR-integration: header-validator pipeline\n" ++
   "  li sp, 0xa0050000\n" ++
   "  mv s2, x16                  # s2 = N\n" ++
-  "  mv s3, x17                  # s3 = section_ptr\n" ++
+  "  mv s3, x21                  # s3 = section_ptr (now from decoder's x21,\n" ++
+  "                              # which holds headers_addr; x17 is kept as\n" ++
+  "                              # SSZ_BASE for the encoder's bounded byte-copy)\n" ++
   "  mv s4, x14                  # s4 = section_len\n" ++
   "  beqz s2, .Lsg_all_pass      # N=0: skip validators\n" ++
   "  # Build sg_header_lengths[N]: convert N u32 inner-offset deltas\n" ++
@@ -255,12 +257,16 @@ def statelessGuestValidatorPipeline : String :=
   ".Lsg_fail_nm:   li a0, 0x16; j .Lsg_unimpl\n" ++
   ".Lsg_fail_rlp:  li a0, 0x17\n" ++
   ".Lsg_unimpl:\n" ++
-  "  li t0, 0xa0010000           # OUTPUT_ADDR\n" ++
-  "  li t1, 0xFEFEFEFEFEFEFEFE\n" ++
-  "  sd t1, 0(t0)\n" ++
-  "  sd a0, 8(t0)\n" ++
-  "  li t0, 0\n" ++
-  "  ecall                       # HALT (linux93 stub would also work)"
+  "  # Previously this block wrote the 0xFEFEFEFEFEFEFEFE unimplemented-\n" ++
+  "  # exit marker at OUTPUT[0..8) plus the REASON code at OUTPUT[8..16),\n" ++
+  "  # then halted with ECALL. That diverged from the spec's behaviour\n" ++
+  "  # for the same input shape (spec catches the validator exception\n" ++
+  "  # and returns valid=False with chain_config echo + empty NPR root).\n" ++
+  "  # Falling through to .Lsg_hash matches the spec: the encoder's\n" ++
+  "  # x11=0 writes valid=False to OUTPUT[32], .Lsg_hash stamps the\n" ++
+  "  # empty_npr_root constant at OUTPUT[0..32), and the codegen halt\n" ++
+  "  # stub takes over.\n" ++
+  "  j .Lsg_hash"
 
 def statelessGuestEpilogue : String :=
   statelessGuestValidatorPipeline ++ "\n" ++

--- a/EvmAsm/Stateless/SSZ/Decode/Program.lean
+++ b/EvmAsm/Stateless/SSZ/Decode/Program.lean
@@ -140,36 +140,68 @@ def read_chain_id : Program :=
   ADD .x13 .x12 .x13 ;;
   LD .x10 .x13 0
 
-/-- Stub: leave `x11 = 0` (the validator pipeline downstream sets
-    OUTPUT[32] := 1 if all checks pass; for the new-schema decode
-    we don't yet walk `witness.headers`, so we set `x11 = 0` and
-    let the downstream override decide).
+/-- Walk the SSZ outer offset table + witness inner offsets to
+    locate the `witness.headers` section. Leaves three registers
+    set up for the validator-pipeline epilogue:
 
-    Also stub the headers-section pointers so the validator
-    pipeline takes the N=0 fast path:
+      x14 = headers_section_length (in bytes)
+      x21 = headers_addr (start of the headers list in memory)
+      x17 = SSZ_BASE (preserved for the encoder's bounded
+            byte-copy, which reads outer.offsets[3] there).
 
-      x14 = 0 (headers_byte_length)
-      x16 = 0 (header_count)  [set by `decode_header_count`]
-      x17 = INPUT_BASE + INPUT_DATA_OFFSET + SCHEMA_ID_SIZE
-            (harmless: validator skips when x16 == 0)
+    Also sets `x11 = 0` (the legacy validation-bit stub; the
+    pipeline downstream may overwrite OUTPUT[32] independently if
+    a validator chooses to set the success flag).
 
-    Walking the new-schema 4-offset outer table + variable witness
-    section's headers list is a follow-up. Clobbers `x11`, `x14`,
-    `x15`, `x17` (preserves `x12` so the fork value carried over
-    from `read_active_fork` survives into the encoder). -/
+    The witness section starts at `SSZ_BASE + outer.offsets[1]`
+    and ends at `SSZ_BASE + outer.offsets[2]` (= chain_config
+    start). Its first 12 bytes are the inner u32 offsets for the
+    `state`, `codes`, `headers` lists; the third (`+8`) is
+    `headers_offset_in_witness`. Headers section length is
+    therefore `witness_length - headers_offset_in_witness`. For
+    empty witness (all 3 lists empty) the headers section is
+    empty (length 0).
+
+    Clobbers `x11`, `x14`, `x15`, `x17`, `x21`, `x22`, `x23`. -/
 def decode_validation_bit : Program :=
   ADDI .x11 .x0 0 ;;
-  ADDI .x14 .x0 0 ;;
   LI .x15 INPUT_BASE ;;
-  ADDI .x17 .x15 (INPUT_DATA_OFFSET + SCHEMA_ID_SIZE)
+  ADDI .x17 .x15 (INPUT_DATA_OFFSET + SCHEMA_ID_SIZE) ;;
+  -- x22 = witness_addr = SSZ_BASE + outer.offsets[1]
+  LWU .x22 .x17 4 ;;
+  ADD .x22 .x17 .x22 ;;
+  -- x23 = witness_end_addr = SSZ_BASE + outer.offsets[2]
+  LWU .x23 .x17 8 ;;
+  ADD .x23 .x17 .x23 ;;
+  -- x14 = witness_length (temporary use)
+  SUB .x14 .x23 .x22 ;;
+  -- x21 = headers_offset_in_witness (third inner u32 of witness)
+  LWU .x21 .x22 8 ;;
+  -- x14 = headers_section_length = witness_length - headers_offset
+  SUB .x14 .x14 .x21 ;;
+  -- x21 = headers_addr = witness_addr + headers_offset_in_witness
+  ADD .x21 .x22 .x21
 
-/-- Stub: leaves `x16 = 0`. The validator pipeline downstream
-    treats N=0 as vacuous-pass.
+/-- Compute `N = number of headers` from the witness.headers
+    list and leave it in `x16`. Reads the first u32 of the
+    headers section: for a non-empty list, the first inner
+    offset equals `4 * N` (each subsequent entry's start byte
+    offset, with the first at byte 4 in a 1-element list, byte
+    8 in a 2-element list, etc.). For an empty list the section
+    is 0 bytes long, so we test `x14 == 0` first and short-
+    circuit to `N = 0`.
 
-    The real header-count walk through the new-schema variable
-    witness layout is a follow-up. -/
+    Preconditions (left by `decode_validation_bit`):
+      x14 = headers_section_length
+      x21 = headers_addr
+
+    Clobbers `x16`. -/
 def decode_header_count : Program :=
-  ADDI .x16 .x0 0
+  BEQ .x14 .x0 16 ;;           -- empty: jump to ADDI x16 0
+  LWU .x16 .x21 0 ;;           -- first inner u32 (= 4*N)
+  SRLI .x16 .x16 2 ;;          -- N = first/4
+  JAL .x0 8 ;;                 -- non-empty done: skip past empty case
+  ADDI .x16 .x0 0              -- empty case: N=0
 
 /-- Byte offset of `offset_active_fork` (u32 LE) within
     `SszChainConfig`. `SszChainConfig` is the variable-size


### PR DESCRIPTION
## Summary
Replace the \`decode_validation_bit\` + \`decode_header_count\` stubs with real implementations that walk the witness section of the SSZ blob and leave:

\`\`\`
x14 = headers_section_length (in bytes)
x16 = N (header count, derived from first inner u32 / 4)
x21 = headers_addr (start of headers list in input memory)
\`\`\`

\`x17\` is preserved as \`SSZ_BASE\` for the encoder's bounded byte-copy (#6843). The validator-pipeline asm in the epilogue now reads \`s3\` from \`x21\` instead of \`x17\`.

## Pipeline change
Collapse \`.Lsg_unimpl\` into a single \`j .Lsg_hash\`. Previously, every validator-failure path (\`.Lsg_fail_pm\`, \`.Lsg_fail_ed\`, …, \`.Lsg_fail_rlp\`) jumped to \`.Lsg_unimpl\` which wrote the 0xFE marker + REASON code and halted. That diverged from the spec — which catches the validator exception and returns \`valid=False\` with chain_config echo + empty NPR root.

The new pipeline falls through to \`.Lsg_hash\` on any failure: the encoder's \`x11=0\` already wrote \`valid=False\` to OUTPUT[32], \`.Lsg_hash\` stamps the empty_npr_root constant, and the codegen halt stub takes over. Result: 73-byte SSZ output matching the spec.

## Impact on existing fixtures
\`chain1_witheaders\` and \`chain1_witheaders_2\` now actually exercise the validator pipeline (N>0, validators run on bogus 32-byte header data, fail at \`rlp_list_nth_item\`, hit \`.Lsg_fail_rlp\` → \`.Lsg_unimpl\` → \`.Lsg_hash\`). Output is byte-for-byte identical to the previous N=0 stub path because the encoder writes the same template either way.

## Test plan
- [x] \`scripts/codegen-stateless-spec-output-check.sh\` — all fixtures pass.

Stacks on #6874.

🤖 Generated with [Claude Code](https://claude.com/claude-code)