### PR TITLE
feat(divmod): lift n4 addback loop to v4 code

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopIterN4AddbackV4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN4AddbackV4NoNop.lean
@@ -142,4 +142,83 @@ theorem divK_loop_body_n4_call_addback_j0_beq_v4_spec_within_noNop
       xperm_hyp hp)
     full
 
+/-- DIV no-NOP v4 code-surface lift of the n=4 call+addback loop-body path. -/
+theorem divK_loop_body_n4_call_addback_j0_beq_v4_spec_within_divCode_noNop
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : BitVec.ult uTop v3)
+    (hborrow : loopBodyN4CallAddbackBorrowV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hcarry2_nz : loopBodyN4CallAddbackCarry2NzV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 224 (base + loopBodyOff) (base + denormOff) (divCode_noNop_v4 base)
+      (loopBodyN4CallSkipJ0PreV4 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem)
+      (loopBodyN4CallAddbackJ0PostV4 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem) :=
+  cpsTripleWithin_extend_code
+    (hmono := sharedDivModCodeNoNop_v4_sub_divCode_noNop_v4)
+    (divK_loop_body_n4_call_addback_j0_beq_v4_spec_within_noNop sp jOld v5Old v6Old v7Old
+      v10Old v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem
+      scratchUn0 scratchMem base halign hbltu hborrow hcarry2_nz)
+
+/-- MOD no-NOP v4 code-surface lift of the n=4 call+addback loop-body path. -/
+theorem divK_loop_body_n4_call_addback_j0_beq_v4_spec_within_modCode_noNop
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : BitVec.ult uTop v3)
+    (hborrow : loopBodyN4CallAddbackBorrowV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hcarry2_nz : loopBodyN4CallAddbackCarry2NzV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 224 (base + loopBodyOff) (base + denormOff) (modCode_noNop_v4 base)
+      (loopBodyN4CallSkipJ0PreV4 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem)
+      (loopBodyN4CallAddbackJ0PostV4 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem) :=
+  cpsTripleWithin_extend_code
+    (hmono := sharedDivModCodeNoNop_v4_sub_modCode_noNop_v4)
+    (divK_loop_body_n4_call_addback_j0_beq_v4_spec_within_noNop sp jOld v5Old v6Old v7Old
+      v10Old v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem
+      scratchUn0 scratchMem base halign hbltu hborrow hcarry2_nz)
+
+/-- Full DIV v4 code-surface lift of the n=4 call+addback loop-body path. -/
+theorem divK_loop_body_n4_call_addback_j0_beq_v4_spec_within_divCode
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : BitVec.ult uTop v3)
+    (hborrow : loopBodyN4CallAddbackBorrowV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hcarry2_nz : loopBodyN4CallAddbackCarry2NzV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 224 (base + loopBodyOff) (base + denormOff) (divCode_v4 base)
+      (loopBodyN4CallSkipJ0PreV4 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem)
+      (loopBodyN4CallAddbackJ0PostV4 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem) :=
+  cpsTripleWithin_divCode_noNop_v4_to_divCode_v4
+    (divK_loop_body_n4_call_addback_j0_beq_v4_spec_within_divCode_noNop sp jOld v5Old
+      v6Old v7Old v10Old v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem
+      dMem dloMem scratchUn0 scratchMem base halign hbltu hborrow hcarry2_nz)
+
+/-- Full MOD v4 code-surface lift of the n=4 call+addback loop-body path. -/
+theorem divK_loop_body_n4_call_addback_j0_beq_v4_spec_within_modCode
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : BitVec.ult uTop v3)
+    (hborrow : loopBodyN4CallAddbackBorrowV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hcarry2_nz : loopBodyN4CallAddbackCarry2NzV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 224 (base + loopBodyOff) (base + denormOff) (modCode_v4 base)
+      (loopBodyN4CallSkipJ0PreV4 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem)
+      (loopBodyN4CallAddbackJ0PostV4 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem) :=
+  cpsTripleWithin_modCode_noNop_v4_to_modCode_v4
+    (divK_loop_body_n4_call_addback_j0_beq_v4_spec_within_modCode_noNop sp jOld v5Old
+      v6Old v7Old v10Old v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem
+      dMem dloMem scratchUn0 scratchMem base halign hbltu hborrow hcarry2_nz)
+
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/CallSkipV4NoWrap.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/CallSkipV4NoWrap.lean
@@ -94,6 +94,23 @@ theorem n4CallSkipBranchV4_def {a b : EvmWord} :
       (n4CallSkipRhatddHiZeroV4 a b ∨ n4CallSkipNoWrapLeV4 a b) :=
   rfl
 
+theorem n4CallSkipNoWrapV4_of_no_wrap_le {a b : EvmWord}
+    (h_no_wrap_le : n4CallSkipNoWrapLeV4 a b) :
+    n4CallSkipNoWrapV4 a b := by
+  rw [n4CallSkipNoWrapLeV4_def] at h_no_wrap_le
+  rw [n4CallSkipNoWrapV4_def]
+  exact h_no_wrap_le.1
+
+theorem n4CallSkipRuntimeBranchV4_of_branch_pred {a b : EvmWord}
+    (hbranch : n4CallSkipBranchV4 a b) :
+    n4CallSkipRuntimeBranchV4 a b := by
+  rw [n4CallSkipBranchV4_def] at hbranch
+  rw [n4CallSkipRuntimeBranchV4_def]
+  cases hbranch with
+  | inl hrhat => exact Or.inl hrhat
+  | inr h_no_wrap_le =>
+      exact Or.inr (n4CallSkipNoWrapV4_of_no_wrap_le h_no_wrap_le)
+
 /-- Predicate-packaged v4 call-skip semantic lower bound in the runtime
     no-wrap branch, without a separate 128/64 upper-bound premise. -/
 theorem n4CallSkipSemanticHoldsV4_of_no_wrap_pred (a b : EvmWord)

--- a/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcher.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcher.lean
@@ -91,6 +91,13 @@ theorem n4ShiftNzDispatcherBranchBoundsV4.of_runtime_pred {a b : EvmWord}
   rw [n4ShiftNzDispatcherBranchBoundsV4_def]
   exact ⟨hbranch, hruntime.2.1, hruntime.2.2⟩
 
+theorem n4ShiftNzDispatcherRuntimeV4.of_branch_bounds {a b : EvmWord}
+    (hevidence : n4ShiftNzDispatcherBranchBoundsV4 a b) :
+    n4ShiftNzDispatcherRuntimeV4 a b := by
+  rw [n4ShiftNzDispatcherBranchBoundsV4_def] at hevidence
+  rw [n4ShiftNzDispatcherRuntimeV4_def]
+  exact ⟨n4CallSkipRuntimeBranchV4_of_branch_pred hevidence.1, hevidence.2.1, hevidence.2.2⟩
+
 theorem n4ShiftNzDispatcherBranchRuntimeV4_of_runtime_pred {a b : EvmWord}
     (hruntime : n4ShiftNzDispatcherRuntimeV4 a b) :
     n4ShiftNzDispatcherBranchRuntimeV4 a b := by

--- a/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcher.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcher.lean
@@ -187,6 +187,33 @@ theorem evm_div_n4_shift_nz_stack_spec_v4_of_runtime_bounds
         nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
         hbnz hb3nz hshift_nz halign hbltu hadd hcarry2 hsem
 
+/-- n=4, shift-nonzero DIV v4 dispatcher from packaged branch/bounds
+    evidence. -/
+theorem evm_div_n4_shift_nz_stack_spec_v4_of_branch_bounds
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hevidence : n4ShiftNzDispatcherBranchBoundsV4 a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_v4_of_runtime_bounds
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign
+    (n4ShiftNzDispatcherBranchBoundsV4.callSkipBranch hevidence)
+    (n4ShiftNzDispatcherBranchBoundsV4.addbackCarry2 hevidence)
+    (n4ShiftNzDispatcherBranchBoundsV4.addbackRuntimeBounds hevidence)
+
 /-- n=4, shift-nonzero DIV v4 dispatcher from the packaged runtime evidence
     predicate. -/
 theorem evm_div_n4_shift_nz_stack_spec_v4_of_runtime_pred
@@ -344,6 +371,33 @@ theorem evm_div_n4_shift_nz_stack_spec_v4_noNop_of_runtime_bounds
         sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
         nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
         hbnz hb3nz hshift_nz halign hbltu hadd hcarry2 hsem
+
+/-- No-NOP n=4, shift-nonzero DIV v4 dispatcher from packaged
+    branch/bounds evidence. -/
+theorem evm_div_n4_shift_nz_stack_spec_v4_noNop_of_branch_bounds
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hevidence : n4ShiftNzDispatcherBranchBoundsV4 a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_noNop_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_v4_noNop_of_runtime_bounds
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign
+    (n4ShiftNzDispatcherBranchBoundsV4.callSkipBranch hevidence)
+    (n4ShiftNzDispatcherBranchBoundsV4.addbackCarry2 hevidence)
+    (n4ShiftNzDispatcherBranchBoundsV4.addbackRuntimeBounds hevidence)
 
 /-- No-NOP n=4, shift-nonzero DIV v4 dispatcher from packaged runtime evidence. -/
 theorem evm_div_n4_shift_nz_stack_spec_v4_noNop_of_runtime_pred
@@ -648,13 +702,10 @@ theorem evm_div_n4_shift_nz_stack_spec_of_branch_bounds
          shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
        ((sp + signExtend12 3936) ↦ₘ scratchMem))
       (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
-  evm_div_n4_shift_nz_stack_spec_of_runtime_bounds
+  evm_div_n4_shift_nz_stack_spec_v4_of_branch_bounds
     sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
-    hb3nz hshift_nz halign
-    (n4ShiftNzDispatcherBranchBoundsV4.callSkipBranch hevidence)
-    (n4ShiftNzDispatcherBranchBoundsV4.addbackCarry2 hevidence)
-    (n4ShiftNzDispatcherBranchBoundsV4.addbackRuntimeBounds hevidence)
+    hb3nz hshift_nz halign hevidence
 
 /-- Final named no-NOP n=4, shift-nonzero DIV dispatcher surface from packaged
     branch/bounds evidence. -/
@@ -675,12 +726,9 @@ theorem evm_div_n4_shift_nz_stack_spec_noNop_of_branch_bounds
          shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
        ((sp + signExtend12 3936) ↦ₘ scratchMem))
       (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
-  evm_div_n4_shift_nz_stack_spec_noNop_of_runtime_bounds
+  evm_div_n4_shift_nz_stack_spec_v4_noNop_of_branch_bounds
     sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
-    hb3nz hshift_nz halign
-    (n4ShiftNzDispatcherBranchBoundsV4.callSkipBranch hevidence)
-    (n4ShiftNzDispatcherBranchBoundsV4.addbackCarry2 hevidence)
-    (n4ShiftNzDispatcherBranchBoundsV4.addbackRuntimeBounds hevidence)
+    hb3nz hshift_nz halign hevidence
 
 end EvmAsm.Evm64

--- a/scripts/codegen-stateless-spec-output-check.sh
+++ b/scripts/codegen-stateless-spec-output-check.sh
@@ -362,6 +362,19 @@ run_fixture "chain1_act_both"       1                  0    ""           ""     
 # all three u64s of the entry.
 run_fixture "chain1_blob"           1                  0    ""           ""                  ""    ""           ""           "100:200:300" || fail=1
 
+# Cross-product: non-empty public_keys AND non-empty
+# block_number. The decoder's outer-offset chase
+# (SSZ_BASE+8 -> chain_config_addr) must land correctly under
+# input-layout drift, AND the encoder's variable-length byte-
+# copy must produce the 81-byte block_number passthrough.
+# public_keys (65 bytes) sits AFTER chain_config in the outer
+# SSZ blob, so it doesn't shift chain_config_offset; it does
+# extend the input file enough that the encoder's trailing
+# byte-copy reads stay within ziskemu's mapped input region
+# (cross-products with witness.codes/state would land 0..few
+# bytes of mem slack -- too tight, would panic).
+run_fixture "chain1_pk_actbn"       1                  0    ""           ""                  "04$(printf '%064d' 0)$(printf '%064d' 0)"    "1234567890" || fail=1
+
 if [[ "$fail" -eq 0 ]]; then
   echo "==> PASS: all spec-output fixtures match the new SSZ schema"
   exit 0


### PR DESCRIPTION
## Summary
- add DIV no-NOP and full-code v4 wrappers for the n=4 call-addback loop-body theorem
- add matching MOD no-NOP and full-code v4 wrappers
- stack on #6880 so downstream full-path/stack-spec migration can target divCode_v4 and modCode_v4 surfaces directly

Refs #61
Bead: evm-asm-9iqmw.4.3
Depends on: #6880

## Verification
- lake build EvmAsm.Evm64.DivMod.LoopIterN4AddbackV4NoNop
- Lean LSP diagnostics on EvmAsm/Evm64/DivMod/LoopIterN4AddbackV4NoNop.lean
- lake build EvmAsm.Evm64.DivMod
- rg forbidden-options/sorry/admit check on touched stacked files
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build