### PR TITLE
test(stateless): three witness.headers entries exercise validator-loop iteration

### DIFF
--- a/scripts/codegen-stateless-spec-output-check.sh
+++ b/scripts/codegen-stateless-spec-output-check.sh
@@ -402,6 +402,17 @@ run_fixture "chain1_witheaders"     1                  0    ""           ""     
 # under maximum-witness-headers byte-budget.
 run_fixture "chain1_witheaders_2"   1                  0    ""           ""                  ""    ""           ""           ""    "$(printf 'aa%.0s' {1..32}):$(printf 'bb%.0s' {1..32})" || fail=1
 
+# Three witness.headers entries -- exercises the validator
+# pipeline's `.Lsg_bl` loop building sg_header_lengths for
+# N=3, and the K-PR iteration over 3 headers. Since the
+# decoder is now real (PR #6878), this fixture activates the
+# pipeline with s2=3; the lengths loop runs 3 times, then the
+# first validator (chain_validate_post_merge_full) fails RLP
+# parse on the first bogus header and falls through to
+# .Lsg_hash. Spec returns valid=False with chain_config echo;
+# ELF matches.
+run_fixture "chain1_witheaders_3"   1                  0    ""           ""                  ""    ""           ""           ""    "$(printf 'aa%.0s' {1..32}):$(printf 'bb%.0s' {1..32}):$(printf 'cc%.0s' {1..32})" || fail=1
+
 # Kitchen-sink fixture -- every input slot populated
 # simultaneously. All three inner witness fields (state +
 # codes + headers) carry one entry each; public_keys has one


### PR DESCRIPTION
## Summary
Add fixture \`chain1_witheaders_3\` with three 32-byte arbitrary \`witness.headers\` entries. With the real \`decode_header_count\` from #6878, this fixture activates the validator pipeline at \`s2=N=3\`:

1. \`.Lsg_bl\` loop iterates 3 times to build the \`sg_header_lengths\` u64 array from N u32 inner-offset deltas. Tests the loop counter logic at non-trivial N.
2. First validator (\`chain_validate_post_merge_full\` = K290) attempts to parse the first bogus header's RLP, returns status != 0.
3. Pipeline hits \`.Lsg_fail_rlp\` → \`.Lsg_unimpl\` (now \`j .Lsg_hash\` post-#6878) → halts.

Output: 73-byte SSZ with valid=False, chain_config echo, empty NPR root. Spec's \`validate_headers([bogus, bogus, bogus])\` raises in \`_decode_header\`, caught by \`verify_stateless_new_payload\`, returns the same shape. Match.

## Test plan
- [x] \`scripts/codegen-stateless-spec-output-check.sh\` — all fixtures pass.

Stacks on #6878.

🤖 Generated with [Claude Code](https://claude.com/claude-code)