### PR TITLE
feat(divmod): lift n3 addback loop to v4 code

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopIterN3AddbackV4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN3AddbackV4NoNop.lean
@@ -631,4 +631,164 @@ theorem divK_loop_body_n3_call_addback_jgt0_beq_v4_spec_within_noNop_exact_x1 (j
       xperm_hyp hp)
     full
 
+/-- DIV no-NOP v4 code-surface lift of the n=3 call+addback loop-body j=0 path. -/
+theorem divK_loop_body_n3_call_addback_j0_beq_v4_spec_within_divCode_noNop
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : BitVec.ult u3 v2)
+    (hborrow : loopBodyN3CallAddbackBorrowV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hcarry2_nz : loopBodyN3CallAddbackCarry2NzV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 224 (base + loopBodyOff) (base + denormOff) (divCode_noNop_v4 base)
+      (loopBodyN3CallSkipJ0PreV4 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem)
+      (loopBodyN3CallAddbackJ0PostV4 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem) :=
+  cpsTripleWithin_extend_code
+    (hmono := sharedDivModCodeNoNop_v4_sub_divCode_noNop_v4)
+    (divK_loop_body_n3_call_addback_j0_beq_v4_spec_within_noNop sp jOld v5Old v6Old v7Old
+      v10Old v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem
+      scratchUn0 scratchMem base halign hbltu hborrow hcarry2_nz)
+
+/-- MOD no-NOP v4 code-surface lift of the n=3 call+addback loop-body j=0 path. -/
+theorem divK_loop_body_n3_call_addback_j0_beq_v4_spec_within_modCode_noNop
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : BitVec.ult u3 v2)
+    (hborrow : loopBodyN3CallAddbackBorrowV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hcarry2_nz : loopBodyN3CallAddbackCarry2NzV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 224 (base + loopBodyOff) (base + denormOff) (modCode_noNop_v4 base)
+      (loopBodyN3CallSkipJ0PreV4 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem)
+      (loopBodyN3CallAddbackJ0PostV4 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem) :=
+  cpsTripleWithin_extend_code
+    (hmono := sharedDivModCodeNoNop_v4_sub_modCode_noNop_v4)
+    (divK_loop_body_n3_call_addback_j0_beq_v4_spec_within_noNop sp jOld v5Old v6Old v7Old
+      v10Old v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem
+      scratchUn0 scratchMem base halign hbltu hborrow hcarry2_nz)
+
+/-- Full DIV v4 code-surface lift of the n=3 call+addback loop-body j=0 path. -/
+theorem divK_loop_body_n3_call_addback_j0_beq_v4_spec_within_divCode
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : BitVec.ult u3 v2)
+    (hborrow : loopBodyN3CallAddbackBorrowV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hcarry2_nz : loopBodyN3CallAddbackCarry2NzV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 224 (base + loopBodyOff) (base + denormOff) (divCode_v4 base)
+      (loopBodyN3CallSkipJ0PreV4 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem)
+      (loopBodyN3CallAddbackJ0PostV4 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem) :=
+  cpsTripleWithin_divCode_noNop_v4_to_divCode_v4
+    (divK_loop_body_n3_call_addback_j0_beq_v4_spec_within_divCode_noNop sp jOld v5Old
+      v6Old v7Old v10Old v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem
+      dMem dloMem scratchUn0 scratchMem base halign hbltu hborrow hcarry2_nz)
+
+/-- Full MOD v4 code-surface lift of the n=3 call+addback loop-body j=0 path. -/
+theorem divK_loop_body_n3_call_addback_j0_beq_v4_spec_within_modCode
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : BitVec.ult u3 v2)
+    (hborrow : loopBodyN3CallAddbackBorrowV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hcarry2_nz : loopBodyN3CallAddbackCarry2NzV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 224 (base + loopBodyOff) (base + denormOff) (modCode_v4 base)
+      (loopBodyN3CallSkipJ0PreV4 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem)
+      (loopBodyN3CallAddbackJ0PostV4 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem) :=
+  cpsTripleWithin_modCode_noNop_v4_to_modCode_v4
+    (divK_loop_body_n3_call_addback_j0_beq_v4_spec_within_modCode_noNop sp jOld v5Old
+      v6Old v7Old v10Old v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem
+      dMem dloMem scratchUn0 scratchMem base halign hbltu hborrow hcarry2_nz)
+
+/-- DIV no-NOP v4 code-surface lift of the n=3 call+addback loop-body j>0 path. -/
+theorem divK_loop_body_n3_call_addback_jgt0_beq_v4_spec_within_divCode_noNop (j : Word)
+    (hpos : BitVec.slt (j + signExtend12 4095) 0 = false)
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : BitVec.ult u3 v2)
+    (hborrow : loopBodyN3CallAddbackBorrowV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hcarry2_nz : loopBodyN3CallAddbackCarry2NzV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 224 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop_v4 base)
+      (loopBodyN3CallAddbackJgt0PreV4 j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem)
+      (loopBodyN3CallAddbackJgt0PostV4 sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem) :=
+  cpsTripleWithin_extend_code
+    (hmono := sharedDivModCodeNoNop_v4_sub_divCode_noNop_v4)
+    (divK_loop_body_n3_call_addback_jgt0_beq_v4_spec_within_noNop j hpos sp jOld v5Old
+      v6Old v7Old v10Old v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem
+      dMem dloMem scratchUn0 scratchMem base halign hbltu hborrow hcarry2_nz)
+
+/-- MOD no-NOP v4 code-surface lift of the n=3 call+addback loop-body j>0 path. -/
+theorem divK_loop_body_n3_call_addback_jgt0_beq_v4_spec_within_modCode_noNop (j : Word)
+    (hpos : BitVec.slt (j + signExtend12 4095) 0 = false)
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : BitVec.ult u3 v2)
+    (hborrow : loopBodyN3CallAddbackBorrowV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hcarry2_nz : loopBodyN3CallAddbackCarry2NzV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 224 (base + loopBodyOff) (base + loopBodyOff) (modCode_noNop_v4 base)
+      (loopBodyN3CallAddbackJgt0PreV4 j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem)
+      (loopBodyN3CallAddbackJgt0PostV4 sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem) :=
+  cpsTripleWithin_extend_code
+    (hmono := sharedDivModCodeNoNop_v4_sub_modCode_noNop_v4)
+    (divK_loop_body_n3_call_addback_jgt0_beq_v4_spec_within_noNop j hpos sp jOld v5Old
+      v6Old v7Old v10Old v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem
+      dMem dloMem scratchUn0 scratchMem base halign hbltu hborrow hcarry2_nz)
+
+/-- Full DIV v4 code-surface lift of the n=3 call+addback loop-body j>0 path. -/
+theorem divK_loop_body_n3_call_addback_jgt0_beq_v4_spec_within_divCode (j : Word)
+    (hpos : BitVec.slt (j + signExtend12 4095) 0 = false)
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : BitVec.ult u3 v2)
+    (hborrow : loopBodyN3CallAddbackBorrowV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hcarry2_nz : loopBodyN3CallAddbackCarry2NzV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 224 (base + loopBodyOff) (base + loopBodyOff) (divCode_v4 base)
+      (loopBodyN3CallAddbackJgt0PreV4 j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem)
+      (loopBodyN3CallAddbackJgt0PostV4 sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem) :=
+  cpsTripleWithin_divCode_noNop_v4_to_divCode_v4
+    (divK_loop_body_n3_call_addback_jgt0_beq_v4_spec_within_divCode_noNop j hpos sp jOld
+      v5Old v6Old v7Old v10Old v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
+      retMem dMem dloMem scratchUn0 scratchMem base halign hbltu hborrow hcarry2_nz)
+
+/-- Full MOD v4 code-surface lift of the n=3 call+addback loop-body j>0 path. -/
+theorem divK_loop_body_n3_call_addback_jgt0_beq_v4_spec_within_modCode (j : Word)
+    (hpos : BitVec.slt (j + signExtend12 4095) 0 = false)
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : BitVec.ult u3 v2)
+    (hborrow : loopBodyN3CallAddbackBorrowV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hcarry2_nz : loopBodyN3CallAddbackCarry2NzV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 224 (base + loopBodyOff) (base + loopBodyOff) (modCode_v4 base)
+      (loopBodyN3CallAddbackJgt0PreV4 j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem)
+      (loopBodyN3CallAddbackJgt0PostV4 sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem) :=
+  cpsTripleWithin_modCode_noNop_v4_to_modCode_v4
+    (divK_loop_body_n3_call_addback_jgt0_beq_v4_spec_within_modCode_noNop j hpos sp jOld
+      v5Old v6Old v7Old v10Old v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
+      retMem dMem dloMem scratchUn0 scratchMem base halign hbltu hborrow hcarry2_nz)
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/CallAddbackRuntimeHighDiv.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/CallAddbackRuntimeHighDiv.lean
@@ -69,6 +69,36 @@ theorem n4CallAddbackBeqHighDivKnuthABound.of_le {a b : EvmWord}
   rwa [n4CallAddbackBeqHighDivKnuthABound_def,
     n4CallAddbackBeqHighDivVal_def]
 
+theorem n4CallAddbackBeqQHatHighDivBound.of_floor_eq {a b : EvmWord}
+    (h_floor :
+      (n4CallAddbackBeqQHatV4 a b).toNat =
+        ((n4CallAddbackBeqU4 a b).toNat * 2^64 +
+            (n4CallAddbackBeqU3 a b).toNat) /
+          (n4CallAddbackBeqB3Prime b).toNat) :
+    n4CallAddbackBeqQHatHighDivBound a b := by
+  rw [n4CallAddbackBeqQHatHighDivBound_def,
+    n4CallAddbackBeqHighDivVal_def]
+  omega
+
+theorem n4CallAddbackBeqQHatHighDivBound.floor_eq_of_call_rhatdd_hi_zero
+    {a b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (hcall : isCallTrialN4 (a.getLimbN 3) (b.getLimbN 2) (b.getLimbN 3))
+    (h_rhat_hi_zero :
+      divKTrialCallV4Rhatdd
+          (n4CallAddbackBeqU4 a b)
+          (n4CallAddbackBeqU3 a b)
+          (n4CallAddbackBeqB3Prime b) >>> (32 : BitVec 6).toNat =
+        (0 : Word))
+    (h_qhat_high : n4CallAddbackBeqQHatHighDivBound a b) :
+    (n4CallAddbackBeqQHatV4 a b).toNat = n4CallAddbackBeqHighDivVal a b := by
+  rw [n4CallAddbackBeqHighDivVal_def]
+  rw [n4CallAddbackBeqQHatHighDivBound_def,
+    n4CallAddbackBeqHighDivVal_def] at h_qhat_high
+  exact n4CallAddbackBeqQHatV4_eq_floor_of_call_rhatdd_hi_zero_of_le
+    hb3nz hshift_nz hcall h_rhat_hi_zero h_qhat_high
+
 /-- Runtime-bounds package from the named high-divisor qhat and Knuth-A
     bridge predicates. -/
 theorem n4CallAddbackBeqRuntimeBounds_of_high_div_bounds_and_borrow
@@ -116,6 +146,65 @@ theorem n4CallAddbackBeqSemanticHolds_of_high_div_bounds_and_borrow
   simpa [n4CallAddbackBeqSemanticHolds_eq_v4] using
     n4CallAddbackBeqSemanticHoldsV4_of_high_div_bounds_and_borrow
       hb3nz hshift_nz h_qhat_high h_high_div h_borrow h_carry2
+
+/-- Runtime-bounds package from exact-floor qhat evidence and the named
+    Knuth-A high-divisor bridge. -/
+theorem n4CallAddbackBeqRuntimeBounds_of_floor_eq_high_div_bound_and_borrow
+    {a b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (h_floor :
+      (n4CallAddbackBeqQHatV4 a b).toNat =
+        ((n4CallAddbackBeqU4 a b).toNat * 2^64 +
+            (n4CallAddbackBeqU3 a b).toNat) /
+          (n4CallAddbackBeqB3Prime b).toNat)
+    (h_high_div : n4CallAddbackBeqHighDivKnuthABound a b)
+    (h_borrow : isAddbackBorrowN4CallV4Evm a b) :
+    n4CallAddbackBeqRuntimeBounds a b :=
+  n4CallAddbackBeqRuntimeBounds_of_high_div_bounds_and_borrow
+    hb3nz
+    (n4CallAddbackBeqQHatHighDivBound.of_floor_eq h_floor)
+    h_high_div
+    h_borrow
+
+/-- Runtime semantic bridge from exact-floor qhat evidence and the named
+    Knuth-A high-divisor bridge. -/
+theorem n4CallAddbackBeqSemanticHoldsV4_of_floor_eq_high_div_bound_and_borrow
+    {a b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (h_floor :
+      (n4CallAddbackBeqQHatV4 a b).toNat =
+        ((n4CallAddbackBeqU4 a b).toNat * 2^64 +
+            (n4CallAddbackBeqU3 a b).toNat) /
+          (n4CallAddbackBeqB3Prime b).toNat)
+    (h_high_div : n4CallAddbackBeqHighDivKnuthABound a b)
+    (h_borrow : isAddbackBorrowN4CallV4Evm a b)
+    (h_carry2 : isAddbackCarry2NzN4CallV4Evm a b) :
+    n4CallAddbackBeqSemanticHoldsV4 a b :=
+  n4CallAddbackBeqSemanticHoldsV4_of_high_div_bounds_and_borrow
+    hb3nz hshift_nz
+    (n4CallAddbackBeqQHatHighDivBound.of_floor_eq h_floor)
+    h_high_div
+    h_borrow h_carry2
+
+/-- Historical non-`V4` spelling of
+    `n4CallAddbackBeqSemanticHoldsV4_of_floor_eq_high_div_bound_and_borrow`. -/
+theorem n4CallAddbackBeqSemanticHolds_of_floor_eq_high_div_bound_and_borrow
+    {a b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (h_floor :
+      (n4CallAddbackBeqQHatV4 a b).toNat =
+        ((n4CallAddbackBeqU4 a b).toNat * 2^64 +
+            (n4CallAddbackBeqU3 a b).toNat) /
+          (n4CallAddbackBeqB3Prime b).toNat)
+    (h_high_div : n4CallAddbackBeqHighDivKnuthABound a b)
+    (h_borrow : isAddbackBorrowN4CallV4Evm a b)
+    (h_carry2 : isAddbackCarry2NzN4CallV4Evm a b) :
+    n4CallAddbackBeqSemanticHolds a b := by
+  simpa [n4CallAddbackBeqSemanticHolds_eq_v4] using
+    n4CallAddbackBeqSemanticHoldsV4_of_floor_eq_high_div_bound_and_borrow
+      hb3nz hshift_nz h_floor h_high_div h_borrow h_carry2
 
 /-- Runtime-bounds package from a direct qhat high-divisor bound, the weakened
     Knuth-A `+1` denominator bridge, and the runtime borrow predicate. -/

--- a/EvmAsm/Evm64/DivMod/Spec/CallAddbackRuntimeHighDiv.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/CallAddbackRuntimeHighDiv.lean
@@ -11,6 +11,112 @@ namespace EvmAsm.Evm64
 
 namespace EvmWord
 
+/-- High 128/64 quotient used by the n=4 call-addback Knuth-A bridge. -/
+def n4CallAddbackBeqHighDivVal (a b : EvmWord) : Nat :=
+  ((n4CallAddbackBeqU4 a b).toNat * 2^64 +
+      (n4CallAddbackBeqU3 a b).toNat) /
+    (n4CallAddbackBeqB3Prime b).toNat
+
+/-- The v4 call-addback qhat is no larger than the high 128/64 quotient. -/
+def n4CallAddbackBeqQHatHighDivBound (a b : EvmWord) : Prop :=
+  (n4CallAddbackBeqQHatV4 a b).toNat ≤
+    n4CallAddbackBeqHighDivVal a b
+
+/-- Knuth-A denominator bridge for the n=4 call-addback path.
+
+    The v4 counterexample invalidated the stronger `≤ normDiv` target; this is
+    the surviving `+1` shape used by the runtime-bounds bridge. -/
+def n4CallAddbackBeqHighDivKnuthABound (a b : EvmWord) : Prop :=
+  n4CallAddbackBeqHighDivVal a b ≤
+    n4CallAddbackBeqULoNormVal a b / n4CallAddbackBeqBNormVal b + 1
+
+theorem n4CallAddbackBeqHighDivVal_def {a b : EvmWord} :
+    n4CallAddbackBeqHighDivVal a b =
+      ((n4CallAddbackBeqU4 a b).toNat * 2^64 +
+          (n4CallAddbackBeqU3 a b).toNat) /
+        (n4CallAddbackBeqB3Prime b).toNat :=
+  rfl
+
+theorem n4CallAddbackBeqQHatHighDivBound_def {a b : EvmWord} :
+    n4CallAddbackBeqQHatHighDivBound a b =
+      ((n4CallAddbackBeqQHatV4 a b).toNat ≤
+        n4CallAddbackBeqHighDivVal a b) :=
+  rfl
+
+theorem n4CallAddbackBeqHighDivKnuthABound_def {a b : EvmWord} :
+    n4CallAddbackBeqHighDivKnuthABound a b =
+      (n4CallAddbackBeqHighDivVal a b ≤
+        n4CallAddbackBeqULoNormVal a b / n4CallAddbackBeqBNormVal b + 1) :=
+  rfl
+
+theorem n4CallAddbackBeqQHatHighDivBound.of_le {a b : EvmWord}
+    (h_qhat_le_high_div :
+      (n4CallAddbackBeqQHatV4 a b).toNat ≤
+        ((n4CallAddbackBeqU4 a b).toNat * 2^64 +
+            (n4CallAddbackBeqU3 a b).toNat) /
+          (n4CallAddbackBeqB3Prime b).toNat) :
+    n4CallAddbackBeqQHatHighDivBound a b := by
+  rwa [n4CallAddbackBeqQHatHighDivBound_def,
+    n4CallAddbackBeqHighDivVal_def]
+
+theorem n4CallAddbackBeqHighDivKnuthABound.of_le {a b : EvmWord}
+    (h_high_div_le_norm_plus_one :
+      ((n4CallAddbackBeqU4 a b).toNat * 2^64 +
+          (n4CallAddbackBeqU3 a b).toNat) /
+        (n4CallAddbackBeqB3Prime b).toNat ≤
+          n4CallAddbackBeqULoNormVal a b / n4CallAddbackBeqBNormVal b + 1) :
+    n4CallAddbackBeqHighDivKnuthABound a b := by
+  rwa [n4CallAddbackBeqHighDivKnuthABound_def,
+    n4CallAddbackBeqHighDivVal_def]
+
+/-- Runtime-bounds package from the named high-divisor qhat and Knuth-A
+    bridge predicates. -/
+theorem n4CallAddbackBeqRuntimeBounds_of_high_div_bounds_and_borrow
+    {a b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (h_qhat_high : n4CallAddbackBeqQHatHighDivBound a b)
+    (h_high_div : n4CallAddbackBeqHighDivKnuthABound a b)
+    (h_borrow : isAddbackBorrowN4CallV4Evm a b) :
+    n4CallAddbackBeqRuntimeBounds a b := by
+  rw [n4CallAddbackBeqQHatHighDivBound_def,
+    n4CallAddbackBeqHighDivVal_def] at h_qhat_high
+  rw [n4CallAddbackBeqHighDivKnuthABound_def,
+    n4CallAddbackBeqHighDivVal_def] at h_high_div
+  exact n4CallAddbackBeqRuntimeBounds_of_qhat_bound_and_borrow
+    hb3nz (le_trans h_qhat_high h_high_div) h_borrow
+
+/-- Runtime semantic bridge from the named high-divisor qhat and Knuth-A
+    bridge predicates. -/
+theorem n4CallAddbackBeqSemanticHoldsV4_of_high_div_bounds_and_borrow
+    {a b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (h_qhat_high : n4CallAddbackBeqQHatHighDivBound a b)
+    (h_high_div : n4CallAddbackBeqHighDivKnuthABound a b)
+    (h_borrow : isAddbackBorrowN4CallV4Evm a b)
+    (h_carry2 : isAddbackCarry2NzN4CallV4Evm a b) :
+    n4CallAddbackBeqSemanticHoldsV4 a b :=
+  n4CallAddbackBeqSemanticHoldsV4_of_runtime_bounds
+    hb3nz hshift_nz
+    (n4CallAddbackBeqRuntimeBounds_of_high_div_bounds_and_borrow
+      hb3nz h_qhat_high h_high_div h_borrow)
+    h_borrow h_carry2
+
+/-- Historical non-`V4` spelling of
+    `n4CallAddbackBeqSemanticHoldsV4_of_high_div_bounds_and_borrow`. -/
+theorem n4CallAddbackBeqSemanticHolds_of_high_div_bounds_and_borrow
+    {a b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (h_qhat_high : n4CallAddbackBeqQHatHighDivBound a b)
+    (h_high_div : n4CallAddbackBeqHighDivKnuthABound a b)
+    (h_borrow : isAddbackBorrowN4CallV4Evm a b)
+    (h_carry2 : isAddbackCarry2NzN4CallV4Evm a b) :
+    n4CallAddbackBeqSemanticHolds a b := by
+  simpa [n4CallAddbackBeqSemanticHolds_eq_v4] using
+    n4CallAddbackBeqSemanticHoldsV4_of_high_div_bounds_and_borrow
+      hb3nz hshift_nz h_qhat_high h_high_div h_borrow h_carry2
+
 /-- Runtime-bounds package from a direct qhat high-divisor bound, the weakened
     Knuth-A `+1` denominator bridge, and the runtime borrow predicate. -/
 theorem n4CallAddbackBeqRuntimeBounds_of_qhat_high_div_le_norm_plus_one_and_borrow
@@ -28,9 +134,10 @@ theorem n4CallAddbackBeqRuntimeBounds_of_qhat_high_div_le_norm_plus_one_and_borr
           n4CallAddbackBeqULoNormVal a b / n4CallAddbackBeqBNormVal b + 1)
     (h_borrow : isAddbackBorrowN4CallV4Evm a b) :
     n4CallAddbackBeqRuntimeBounds a b :=
-  n4CallAddbackBeqRuntimeBounds_of_qhat_bound_and_borrow
+  n4CallAddbackBeqRuntimeBounds_of_high_div_bounds_and_borrow
     hb3nz
-    (le_trans h_qhat_le_high_div h_high_div_le_norm_plus_one)
+    (n4CallAddbackBeqQHatHighDivBound.of_le h_qhat_le_high_div)
+    (n4CallAddbackBeqHighDivKnuthABound.of_le h_high_div_le_norm_plus_one)
     h_borrow
 
 /-- Runtime semantic bridge from a direct qhat high-divisor bound and the

--- a/EvmAsm/Evm64/DivMod/Spec/CallAddbackRuntimeHighDiv.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/CallAddbackRuntimeHighDiv.lean
@@ -279,6 +279,71 @@ theorem n4CallAddbackBeqSemanticHolds_of_call_high_div_bound_and_borrow
     n4CallAddbackBeqSemanticHoldsV4_of_call_high_div_bound_and_borrow
       hb3nz hshift_nz hcall h_rhat_hi_zero h_qhat_high h_high_div h_borrow h_carry2
 
+/-- EVM-word spelling of
+    `n4CallAddbackBeqRuntimeBounds_of_call_high_div_bound_and_borrow`. -/
+theorem n4CallAddbackBeqRuntimeBounds_of_call_evm_high_div_bound_and_borrow
+    {a b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (hcall : isCallTrialN4Evm a b)
+    (h_rhat_hi_zero :
+      divKTrialCallV4Rhatdd
+          (n4CallAddbackBeqU4 a b)
+          (n4CallAddbackBeqU3 a b)
+          (n4CallAddbackBeqB3Prime b) >>> (32 : BitVec 6).toNat =
+        (0 : Word))
+    (h_qhat_high : n4CallAddbackBeqQHatHighDivBound a b)
+    (h_high_div : n4CallAddbackBeqHighDivKnuthABound a b)
+    (h_borrow : isAddbackBorrowN4CallV4Evm a b) :
+    n4CallAddbackBeqRuntimeBounds a b := by
+  rw [isCallTrialN4Evm_def] at hcall
+  exact n4CallAddbackBeqRuntimeBounds_of_call_high_div_bound_and_borrow
+    hb3nz hshift_nz hcall h_rhat_hi_zero h_qhat_high h_high_div h_borrow
+
+/-- EVM-word spelling of
+    `n4CallAddbackBeqSemanticHoldsV4_of_call_high_div_bound_and_borrow`. -/
+theorem n4CallAddbackBeqSemanticHoldsV4_of_call_evm_high_div_bound_and_borrow
+    {a b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (hcall : isCallTrialN4Evm a b)
+    (h_rhat_hi_zero :
+      divKTrialCallV4Rhatdd
+          (n4CallAddbackBeqU4 a b)
+          (n4CallAddbackBeqU3 a b)
+          (n4CallAddbackBeqB3Prime b) >>> (32 : BitVec 6).toNat =
+        (0 : Word))
+    (h_qhat_high : n4CallAddbackBeqQHatHighDivBound a b)
+    (h_high_div : n4CallAddbackBeqHighDivKnuthABound a b)
+    (h_borrow : isAddbackBorrowN4CallV4Evm a b)
+    (h_carry2 : isAddbackCarry2NzN4CallV4Evm a b) :
+    n4CallAddbackBeqSemanticHoldsV4 a b := by
+  rw [isCallTrialN4Evm_def] at hcall
+  exact n4CallAddbackBeqSemanticHoldsV4_of_call_high_div_bound_and_borrow
+    hb3nz hshift_nz hcall h_rhat_hi_zero h_qhat_high h_high_div h_borrow h_carry2
+
+/-- Historical non-`V4` spelling of
+    `n4CallAddbackBeqSemanticHoldsV4_of_call_evm_high_div_bound_and_borrow`. -/
+theorem n4CallAddbackBeqSemanticHolds_of_call_evm_high_div_bound_and_borrow
+    {a b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (hcall : isCallTrialN4Evm a b)
+    (h_rhat_hi_zero :
+      divKTrialCallV4Rhatdd
+          (n4CallAddbackBeqU4 a b)
+          (n4CallAddbackBeqU3 a b)
+          (n4CallAddbackBeqB3Prime b) >>> (32 : BitVec 6).toNat =
+        (0 : Word))
+    (h_qhat_high : n4CallAddbackBeqQHatHighDivBound a b)
+    (h_high_div : n4CallAddbackBeqHighDivKnuthABound a b)
+    (h_borrow : isAddbackBorrowN4CallV4Evm a b)
+    (h_carry2 : isAddbackCarry2NzN4CallV4Evm a b) :
+    n4CallAddbackBeqSemanticHolds a b := by
+  simpa [n4CallAddbackBeqSemanticHolds_eq_v4] using
+    n4CallAddbackBeqSemanticHoldsV4_of_call_evm_high_div_bound_and_borrow
+      hb3nz hshift_nz hcall h_rhat_hi_zero h_qhat_high h_high_div h_borrow h_carry2
+
 /-- Runtime-bounds package from a direct qhat high-divisor bound, the weakened
     Knuth-A `+1` denominator bridge, and the runtime borrow predicate. -/
 theorem n4CallAddbackBeqRuntimeBounds_of_qhat_high_div_le_norm_plus_one_and_borrow

--- a/EvmAsm/Evm64/DivMod/Spec/CallAddbackRuntimeHighDiv.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/CallAddbackRuntimeHighDiv.lean
@@ -206,6 +206,79 @@ theorem n4CallAddbackBeqSemanticHolds_of_floor_eq_high_div_bound_and_borrow
     n4CallAddbackBeqSemanticHoldsV4_of_floor_eq_high_div_bound_and_borrow
       hb3nz hshift_nz h_floor h_high_div h_borrow h_carry2
 
+/-- Runtime-bounds package from the call-path exact-floor bridge and the
+    named Knuth-A high-divisor bridge. -/
+theorem n4CallAddbackBeqRuntimeBounds_of_call_high_div_bound_and_borrow
+    {a b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (hcall : isCallTrialN4 (a.getLimbN 3) (b.getLimbN 2) (b.getLimbN 3))
+    (h_rhat_hi_zero :
+      divKTrialCallV4Rhatdd
+          (n4CallAddbackBeqU4 a b)
+          (n4CallAddbackBeqU3 a b)
+          (n4CallAddbackBeqB3Prime b) >>> (32 : BitVec 6).toNat =
+        (0 : Word))
+    (h_qhat_high : n4CallAddbackBeqQHatHighDivBound a b)
+    (h_high_div : n4CallAddbackBeqHighDivKnuthABound a b)
+    (h_borrow : isAddbackBorrowN4CallV4Evm a b) :
+    n4CallAddbackBeqRuntimeBounds a b :=
+  n4CallAddbackBeqRuntimeBounds_of_floor_eq_high_div_bound_and_borrow
+    hb3nz
+    (by
+      simpa [n4CallAddbackBeqHighDivVal_def] using
+        n4CallAddbackBeqQHatHighDivBound.floor_eq_of_call_rhatdd_hi_zero
+          hb3nz hshift_nz hcall h_rhat_hi_zero h_qhat_high)
+    h_high_div h_borrow
+
+/-- Runtime semantic bridge from the call-path exact-floor bridge and the
+    named Knuth-A high-divisor bridge. -/
+theorem n4CallAddbackBeqSemanticHoldsV4_of_call_high_div_bound_and_borrow
+    {a b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (hcall : isCallTrialN4 (a.getLimbN 3) (b.getLimbN 2) (b.getLimbN 3))
+    (h_rhat_hi_zero :
+      divKTrialCallV4Rhatdd
+          (n4CallAddbackBeqU4 a b)
+          (n4CallAddbackBeqU3 a b)
+          (n4CallAddbackBeqB3Prime b) >>> (32 : BitVec 6).toNat =
+        (0 : Word))
+    (h_qhat_high : n4CallAddbackBeqQHatHighDivBound a b)
+    (h_high_div : n4CallAddbackBeqHighDivKnuthABound a b)
+    (h_borrow : isAddbackBorrowN4CallV4Evm a b)
+    (h_carry2 : isAddbackCarry2NzN4CallV4Evm a b) :
+    n4CallAddbackBeqSemanticHoldsV4 a b :=
+  n4CallAddbackBeqSemanticHoldsV4_of_floor_eq_high_div_bound_and_borrow
+    hb3nz hshift_nz
+    (by
+      simpa [n4CallAddbackBeqHighDivVal_def] using
+        n4CallAddbackBeqQHatHighDivBound.floor_eq_of_call_rhatdd_hi_zero
+          hb3nz hshift_nz hcall h_rhat_hi_zero h_qhat_high)
+    h_high_div h_borrow h_carry2
+
+/-- Historical non-`V4` spelling of
+    `n4CallAddbackBeqSemanticHoldsV4_of_call_high_div_bound_and_borrow`. -/
+theorem n4CallAddbackBeqSemanticHolds_of_call_high_div_bound_and_borrow
+    {a b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (hcall : isCallTrialN4 (a.getLimbN 3) (b.getLimbN 2) (b.getLimbN 3))
+    (h_rhat_hi_zero :
+      divKTrialCallV4Rhatdd
+          (n4CallAddbackBeqU4 a b)
+          (n4CallAddbackBeqU3 a b)
+          (n4CallAddbackBeqB3Prime b) >>> (32 : BitVec 6).toNat =
+        (0 : Word))
+    (h_qhat_high : n4CallAddbackBeqQHatHighDivBound a b)
+    (h_high_div : n4CallAddbackBeqHighDivKnuthABound a b)
+    (h_borrow : isAddbackBorrowN4CallV4Evm a b)
+    (h_carry2 : isAddbackCarry2NzN4CallV4Evm a b) :
+    n4CallAddbackBeqSemanticHolds a b := by
+  simpa [n4CallAddbackBeqSemanticHolds_eq_v4] using
+    n4CallAddbackBeqSemanticHoldsV4_of_call_high_div_bound_and_borrow
+      hb3nz hshift_nz hcall h_rhat_hi_zero h_qhat_high h_high_div h_borrow h_carry2
+
 /-- Runtime-bounds package from a direct qhat high-divisor bound, the weakened
     Knuth-A `+1` denominator bridge, and the runtime borrow predicate. -/
 theorem n4CallAddbackBeqRuntimeBounds_of_qhat_high_div_le_norm_plus_one_and_borrow

--- a/scripts/codegen-stateless-spec-output-check.sh
+++ b/scripts/codegen-stateless-spec-output-check.sh
@@ -362,6 +362,16 @@ run_fixture "chain1_act_both"       1                  0    ""           ""     
 # all three u64s of the entry.
 run_fixture "chain1_blob"           1                  0    ""           ""                  ""    ""           ""           "100:200:300" || fail=1
 
+# Cross-product: non-empty public_keys AND non-empty
+# blob_schedule. Both fields shift only `offsets[3]`
+# (public_keys_offset) and the SSZ blob total length; neither
+# affects chain_config_offset. The encoder's full byte-copy of
+# active_fork[16..64) (covering the entire blob_schedule
+# entry) must produce 97 bytes that match spec. PK padding
+# gives plenty of mem slack so the byte-copy never reads past
+# ziskemu's input section.
+run_fixture "chain1_pk_blob"        1                  0    ""           ""                  "04$(printf '%064d' 0)$(printf '%064d' 0)"    ""           ""           "100:200:300" || fail=1
+
 if [[ "$fail" -eq 0 ]]; then
   echo "==> PASS: all spec-output fixtures match the new SSZ schema"
   exit 0


### PR DESCRIPTION
## Summary
- expose DIV/MOD no-NOP v4 code-surface wrappers for the n=3 call+addback j=0 and j>0 loop-body specs
- lift those wrappers to full divCode_v4 and modCode_v4 surfaces
- keep max-addback and exact-x1 wrapper surfaces for later focused slices

## Stack
- Depends on #6883

## Bead
- evm-asm-9iqmw.4.3

## Verification
- lake build EvmAsm.Evm64.DivMod.LoopIterN3AddbackV4NoNop
- Lean LSP diagnostics for LoopIterN3AddbackV4NoNop: no errors
- rg -n "set_option maxHeartbeats|set_option maxRecDepth|sorry|admit" EvmAsm/Evm64/DivMod/LoopIterN3AddbackV4NoNop.lean EvmAsm/Evm64/DivMod/LoopIterN3CallV4NoNop.lean EvmAsm/Evm64/DivMod/LoopIterN4AddbackV4NoNop.lean EvmAsm/Evm64/DivMod/LoopIterN4CallV4NoNop.lean EvmAsm/Evm64/DivMod/LoopBody/TrialCall.lean (no matches)
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build EvmAsm.Evm64.DivMod
- lake build

Refs #61