### PR TITLE
feat(divmod): lift n2 addback loop to v4 code

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopIterN2AddbackV4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN2AddbackV4NoNop.lean
@@ -408,4 +408,164 @@ theorem divK_loop_body_n2_call_addback_jgt0_beq_v4_spec_within_noNop (j : Word)
       xperm_hyp hp)
     full
 
+/-- DIV no-NOP v4 code-surface lift of the n=2 call+addback loop-body j=0 path. -/
+theorem divK_loop_body_n2_call_addback_j0_beq_v4_spec_within_divCode_noNop
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : BitVec.ult u2 v1)
+    (hborrow : loopBodyN2CallAddbackBorrowV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hcarry2_nz : loopBodyN2CallAddbackCarry2NzV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 224 (base + loopBodyOff) (base + denormOff) (divCode_noNop_v4 base)
+      (loopBodyN2CallSkipJ0PreV4 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem)
+      (loopBodyN2CallAddbackJ0PostV4 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem) :=
+  cpsTripleWithin_extend_code
+    (hmono := sharedDivModCodeNoNop_v4_sub_divCode_noNop_v4)
+    (divK_loop_body_n2_call_addback_j0_beq_v4_spec_within_noNop sp jOld v5Old v6Old v7Old
+      v10Old v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem
+      scratchUn0 scratchMem base halign hbltu hborrow hcarry2_nz)
+
+/-- MOD no-NOP v4 code-surface lift of the n=2 call+addback loop-body j=0 path. -/
+theorem divK_loop_body_n2_call_addback_j0_beq_v4_spec_within_modCode_noNop
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : BitVec.ult u2 v1)
+    (hborrow : loopBodyN2CallAddbackBorrowV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hcarry2_nz : loopBodyN2CallAddbackCarry2NzV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 224 (base + loopBodyOff) (base + denormOff) (modCode_noNop_v4 base)
+      (loopBodyN2CallSkipJ0PreV4 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem)
+      (loopBodyN2CallAddbackJ0PostV4 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem) :=
+  cpsTripleWithin_extend_code
+    (hmono := sharedDivModCodeNoNop_v4_sub_modCode_noNop_v4)
+    (divK_loop_body_n2_call_addback_j0_beq_v4_spec_within_noNop sp jOld v5Old v6Old v7Old
+      v10Old v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem
+      scratchUn0 scratchMem base halign hbltu hborrow hcarry2_nz)
+
+/-- Full DIV v4 code-surface lift of the n=2 call+addback loop-body j=0 path. -/
+theorem divK_loop_body_n2_call_addback_j0_beq_v4_spec_within_divCode
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : BitVec.ult u2 v1)
+    (hborrow : loopBodyN2CallAddbackBorrowV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hcarry2_nz : loopBodyN2CallAddbackCarry2NzV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 224 (base + loopBodyOff) (base + denormOff) (divCode_v4 base)
+      (loopBodyN2CallSkipJ0PreV4 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem)
+      (loopBodyN2CallAddbackJ0PostV4 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem) :=
+  cpsTripleWithin_divCode_noNop_v4_to_divCode_v4
+    (divK_loop_body_n2_call_addback_j0_beq_v4_spec_within_divCode_noNop sp jOld v5Old
+      v6Old v7Old v10Old v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem
+      dMem dloMem scratchUn0 scratchMem base halign hbltu hborrow hcarry2_nz)
+
+/-- Full MOD v4 code-surface lift of the n=2 call+addback loop-body j=0 path. -/
+theorem divK_loop_body_n2_call_addback_j0_beq_v4_spec_within_modCode
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : BitVec.ult u2 v1)
+    (hborrow : loopBodyN2CallAddbackBorrowV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hcarry2_nz : loopBodyN2CallAddbackCarry2NzV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 224 (base + loopBodyOff) (base + denormOff) (modCode_v4 base)
+      (loopBodyN2CallSkipJ0PreV4 sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem)
+      (loopBodyN2CallAddbackJ0PostV4 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem) :=
+  cpsTripleWithin_modCode_noNop_v4_to_modCode_v4
+    (divK_loop_body_n2_call_addback_j0_beq_v4_spec_within_modCode_noNop sp jOld v5Old
+      v6Old v7Old v10Old v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem
+      dMem dloMem scratchUn0 scratchMem base halign hbltu hborrow hcarry2_nz)
+
+/-- DIV no-NOP v4 code-surface lift of the n=2 call+addback loop-body j>0 path. -/
+theorem divK_loop_body_n2_call_addback_jgt0_beq_v4_spec_within_divCode_noNop (j : Word)
+    (hpos : BitVec.slt (j + signExtend12 4095) 0 = false)
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : BitVec.ult u2 v1)
+    (hborrow : loopBodyN2CallAddbackBorrowV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hcarry2_nz : loopBodyN2CallAddbackCarry2NzV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 224 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop_v4 base)
+      (loopBodyN2CallAddbackJgt0PreV4 j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem)
+      (loopBodyN2CallAddbackJgt0PostV4 sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem) :=
+  cpsTripleWithin_extend_code
+    (hmono := sharedDivModCodeNoNop_v4_sub_divCode_noNop_v4)
+    (divK_loop_body_n2_call_addback_jgt0_beq_v4_spec_within_noNop j hpos sp jOld v5Old
+      v6Old v7Old v10Old v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem
+      dMem dloMem scratchUn0 scratchMem base halign hbltu hborrow hcarry2_nz)
+
+/-- MOD no-NOP v4 code-surface lift of the n=2 call+addback loop-body j>0 path. -/
+theorem divK_loop_body_n2_call_addback_jgt0_beq_v4_spec_within_modCode_noNop (j : Word)
+    (hpos : BitVec.slt (j + signExtend12 4095) 0 = false)
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : BitVec.ult u2 v1)
+    (hborrow : loopBodyN2CallAddbackBorrowV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hcarry2_nz : loopBodyN2CallAddbackCarry2NzV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 224 (base + loopBodyOff) (base + loopBodyOff) (modCode_noNop_v4 base)
+      (loopBodyN2CallAddbackJgt0PreV4 j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem)
+      (loopBodyN2CallAddbackJgt0PostV4 sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem) :=
+  cpsTripleWithin_extend_code
+    (hmono := sharedDivModCodeNoNop_v4_sub_modCode_noNop_v4)
+    (divK_loop_body_n2_call_addback_jgt0_beq_v4_spec_within_noNop j hpos sp jOld v5Old
+      v6Old v7Old v10Old v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem
+      dMem dloMem scratchUn0 scratchMem base halign hbltu hborrow hcarry2_nz)
+
+/-- Full DIV v4 code-surface lift of the n=2 call+addback loop-body j>0 path. -/
+theorem divK_loop_body_n2_call_addback_jgt0_beq_v4_spec_within_divCode (j : Word)
+    (hpos : BitVec.slt (j + signExtend12 4095) 0 = false)
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : BitVec.ult u2 v1)
+    (hborrow : loopBodyN2CallAddbackBorrowV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hcarry2_nz : loopBodyN2CallAddbackCarry2NzV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 224 (base + loopBodyOff) (base + loopBodyOff) (divCode_v4 base)
+      (loopBodyN2CallAddbackJgt0PreV4 j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem)
+      (loopBodyN2CallAddbackJgt0PostV4 sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem) :=
+  cpsTripleWithin_divCode_noNop_v4_to_divCode_v4
+    (divK_loop_body_n2_call_addback_jgt0_beq_v4_spec_within_divCode_noNop j hpos sp jOld
+      v5Old v6Old v7Old v10Old v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
+      retMem dMem dloMem scratchUn0 scratchMem base halign hbltu hborrow hcarry2_nz)
+
+/-- Full MOD v4 code-surface lift of the n=2 call+addback loop-body j>0 path. -/
+theorem divK_loop_body_n2_call_addback_jgt0_beq_v4_spec_within_modCode (j : Word)
+    (hpos : BitVec.slt (j + signExtend12 4095) 0 = false)
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (base : Word)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu : BitVec.ult u2 v1)
+    (hborrow : loopBodyN2CallAddbackBorrowV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hcarry2_nz : loopBodyN2CallAddbackCarry2NzV4 v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    cpsTripleWithin 224 (base + loopBodyOff) (base + loopBodyOff) (modCode_v4 base)
+      (loopBodyN2CallAddbackJgt0PreV4 j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratchUn0 scratchMem)
+      (loopBodyN2CallAddbackJgt0PostV4 sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop scratchMem) :=
+  cpsTripleWithin_modCode_noNop_v4_to_modCode_v4
+    (divK_loop_body_n2_call_addback_jgt0_beq_v4_spec_within_modCode_noNop j hpos sp jOld
+      v5Old v6Old v7Old v10Old v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
+      retMem dMem dloMem scratchUn0 scratchMem base halign hbltu hborrow hcarry2_nz)
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/CallAddbackRuntimeHighDiv.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/CallAddbackRuntimeHighDiv.lean
@@ -176,6 +176,43 @@ theorem n4CallAddbackBeqQHatHighDivBound.of_floor_eq {a b : EvmWord}
     n4CallAddbackBeqHighDivVal_def]
   omega
 
+theorem n4CallAddbackBeqShiftHighDivEvidence.of_floor_parts {a b : EvmWord}
+    (h_rhat_hi_zero : n4CallAddbackBeqRhatddHiZero a b)
+    (h_floor :
+      (n4CallAddbackBeqQHatV4 a b).toNat =
+        ((n4CallAddbackBeqU4 a b).toNat * 2^64 +
+            (n4CallAddbackBeqU3 a b).toNat) /
+          (n4CallAddbackBeqB3Prime b).toNat)
+    (h_high_div : n4CallAddbackBeqHighDivKnuthABound a b) :
+    n4CallAddbackBeqShiftHighDivEvidence a b :=
+  n4CallAddbackBeqShiftHighDivEvidence.of_parts
+    h_rhat_hi_zero
+    (n4CallAddbackBeqQHatHighDivBound.of_floor_eq h_floor)
+    h_high_div
+
+theorem n4CallAddbackBeqShiftHighDivEvidence.of_floor_raw_parts {a b : EvmWord}
+    (h_rhat_hi_zero :
+      divKTrialCallV4Rhatdd
+          (n4CallAddbackBeqU4 a b)
+          (n4CallAddbackBeqU3 a b)
+          (n4CallAddbackBeqB3Prime b) >>> (32 : BitVec 6).toNat =
+        (0 : Word))
+    (h_floor :
+      (n4CallAddbackBeqQHatV4 a b).toNat =
+        ((n4CallAddbackBeqU4 a b).toNat * 2^64 +
+            (n4CallAddbackBeqU3 a b).toNat) /
+          (n4CallAddbackBeqB3Prime b).toNat)
+    (h_high_div_le_norm_plus_one :
+      ((n4CallAddbackBeqU4 a b).toNat * 2^64 +
+          (n4CallAddbackBeqU3 a b).toNat) /
+        (n4CallAddbackBeqB3Prime b).toNat ≤
+          n4CallAddbackBeqULoNormVal a b / n4CallAddbackBeqBNormVal b + 1) :
+    n4CallAddbackBeqShiftHighDivEvidence a b :=
+  n4CallAddbackBeqShiftHighDivEvidence.of_floor_parts
+    (n4CallAddbackBeqRhatddHiZero.of_eq h_rhat_hi_zero)
+    h_floor
+    (n4CallAddbackBeqHighDivKnuthABound.of_le h_high_div_le_norm_plus_one)
+
 theorem n4CallAddbackBeqQHatHighDivBound.floor_eq_of_call_rhatdd_hi_zero
     {a b : EvmWord}
     (hb3nz : b.getLimbN 3 ≠ 0)
@@ -552,6 +589,95 @@ theorem n4CallAddbackBeqSemanticHolds_of_shift_high_div_evidence_and_borrow
   simpa [n4CallAddbackBeqSemanticHolds_eq_v4] using
     n4CallAddbackBeqSemanticHoldsV4_of_shift_high_div_evidence_and_borrow
       hb3nz hshift_nz h_evidence h_borrow h_carry2
+
+/-- Runtime-bounds bridge from raw shift/high-div evidence. -/
+theorem n4CallAddbackBeqRuntimeBounds_of_shift_high_div_raw_parts_and_borrow
+    {a b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (h_rhat_hi_zero :
+      divKTrialCallV4Rhatdd
+          (n4CallAddbackBeqU4 a b)
+          (n4CallAddbackBeqU3 a b)
+          (n4CallAddbackBeqB3Prime b) >>> (32 : BitVec 6).toNat =
+        (0 : Word))
+    (h_qhat_le_high_div :
+      (n4CallAddbackBeqQHatV4 a b).toNat ≤
+        ((n4CallAddbackBeqU4 a b).toNat * 2^64 +
+            (n4CallAddbackBeqU3 a b).toNat) /
+          (n4CallAddbackBeqB3Prime b).toNat)
+    (h_high_div_le_norm_plus_one :
+      ((n4CallAddbackBeqU4 a b).toNat * 2^64 +
+          (n4CallAddbackBeqU3 a b).toNat) /
+        (n4CallAddbackBeqB3Prime b).toNat ≤
+          n4CallAddbackBeqULoNormVal a b / n4CallAddbackBeqBNormVal b + 1)
+    (h_borrow : isAddbackBorrowN4CallV4Evm a b) :
+    n4CallAddbackBeqRuntimeBounds a b :=
+  n4CallAddbackBeqRuntimeBounds_of_shift_high_div_evidence_and_borrow
+    hb3nz hshift_nz
+    (n4CallAddbackBeqShiftHighDivEvidence.of_raw_parts
+      h_rhat_hi_zero h_qhat_le_high_div h_high_div_le_norm_plus_one)
+    h_borrow
+
+/-- Runtime semantic bridge from raw shift/high-div evidence. -/
+theorem n4CallAddbackBeqSemanticHoldsV4_of_shift_high_div_raw_parts_and_borrow
+    {a b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (h_rhat_hi_zero :
+      divKTrialCallV4Rhatdd
+          (n4CallAddbackBeqU4 a b)
+          (n4CallAddbackBeqU3 a b)
+          (n4CallAddbackBeqB3Prime b) >>> (32 : BitVec 6).toNat =
+        (0 : Word))
+    (h_qhat_le_high_div :
+      (n4CallAddbackBeqQHatV4 a b).toNat ≤
+        ((n4CallAddbackBeqU4 a b).toNat * 2^64 +
+            (n4CallAddbackBeqU3 a b).toNat) /
+          (n4CallAddbackBeqB3Prime b).toNat)
+    (h_high_div_le_norm_plus_one :
+      ((n4CallAddbackBeqU4 a b).toNat * 2^64 +
+          (n4CallAddbackBeqU3 a b).toNat) /
+        (n4CallAddbackBeqB3Prime b).toNat ≤
+          n4CallAddbackBeqULoNormVal a b / n4CallAddbackBeqBNormVal b + 1)
+    (h_borrow : isAddbackBorrowN4CallV4Evm a b)
+    (h_carry2 : isAddbackCarry2NzN4CallV4Evm a b) :
+    n4CallAddbackBeqSemanticHoldsV4 a b :=
+  n4CallAddbackBeqSemanticHoldsV4_of_shift_high_div_evidence_and_borrow
+    hb3nz hshift_nz
+    (n4CallAddbackBeqShiftHighDivEvidence.of_raw_parts
+      h_rhat_hi_zero h_qhat_le_high_div h_high_div_le_norm_plus_one)
+    h_borrow h_carry2
+
+/-- Historical non-`V4` spelling of
+    `n4CallAddbackBeqSemanticHoldsV4_of_shift_high_div_raw_parts_and_borrow`. -/
+theorem n4CallAddbackBeqSemanticHolds_of_shift_high_div_raw_parts_and_borrow
+    {a b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (h_rhat_hi_zero :
+      divKTrialCallV4Rhatdd
+          (n4CallAddbackBeqU4 a b)
+          (n4CallAddbackBeqU3 a b)
+          (n4CallAddbackBeqB3Prime b) >>> (32 : BitVec 6).toNat =
+        (0 : Word))
+    (h_qhat_le_high_div :
+      (n4CallAddbackBeqQHatV4 a b).toNat ≤
+        ((n4CallAddbackBeqU4 a b).toNat * 2^64 +
+            (n4CallAddbackBeqU3 a b).toNat) /
+          (n4CallAddbackBeqB3Prime b).toNat)
+    (h_high_div_le_norm_plus_one :
+      ((n4CallAddbackBeqU4 a b).toNat * 2^64 +
+          (n4CallAddbackBeqU3 a b).toNat) /
+        (n4CallAddbackBeqB3Prime b).toNat ≤
+          n4CallAddbackBeqULoNormVal a b / n4CallAddbackBeqBNormVal b + 1)
+    (h_borrow : isAddbackBorrowN4CallV4Evm a b)
+    (h_carry2 : isAddbackCarry2NzN4CallV4Evm a b) :
+    n4CallAddbackBeqSemanticHolds a b := by
+  simpa [n4CallAddbackBeqSemanticHolds_eq_v4] using
+    n4CallAddbackBeqSemanticHoldsV4_of_shift_high_div_raw_parts_and_borrow
+      hb3nz hshift_nz h_rhat_hi_zero h_qhat_le_high_div
+      h_high_div_le_norm_plus_one h_borrow h_carry2
 
 /-- Runtime-bounds package from a direct qhat high-divisor bound, the weakened
     Knuth-A `+1` denominator bridge, and the runtime borrow predicate. -/

--- a/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcher.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcher.lean
@@ -44,6 +44,31 @@ def n4ShiftNzDispatcherBranchBoundsV4 (a b : EvmWord) : Prop :=
   isAddbackCarry2NzN4CallV4Evm a b ∧
   n4CallAddbackBeqRuntimeBounds a b
 
+/-- Raw branch-sensitive high-div evidence for the n=4, shift-nonzero DIV
+    v4 dispatcher.
+
+    This is the arithmetic-facing form of
+    `n4ShiftNzDispatcherBranchHighDivEvidence`: the addback branch carries the
+    concrete `rhatdd` high-half-zero fact, the qhat/high-div inequality, and
+    the surviving Knuth-A `+1` high-div bound directly. -/
+def n4ShiftNzDispatcherBranchHighDivRawEvidence (a b : EvmWord) : Prop :=
+  (isSkipBorrowN4CallV4Evm a b ∧ n4CallSkipRuntimeBranchV4 a b) ∨
+  (isAddbackBorrowN4CallV4Evm a b ∧
+   isAddbackCarry2NzN4CallV4Evm a b ∧
+   divKTrialCallV4Rhatdd
+       (n4CallAddbackBeqU4 a b)
+       (n4CallAddbackBeqU3 a b)
+       (n4CallAddbackBeqB3Prime b) >>> (32 : BitVec 6).toNat =
+     (0 : Word) ∧
+   (n4CallAddbackBeqQHatV4 a b).toNat ≤
+     ((n4CallAddbackBeqU4 a b).toNat * 2^64 +
+         (n4CallAddbackBeqU3 a b).toNat) /
+       (n4CallAddbackBeqB3Prime b).toNat ∧
+   ((n4CallAddbackBeqU4 a b).toNat * 2^64 +
+       (n4CallAddbackBeqU3 a b).toNat) /
+     (n4CallAddbackBeqB3Prime b).toNat ≤
+       n4CallAddbackBeqULoNormVal a b / n4CallAddbackBeqBNormVal b + 1)
+
 /-- Branch-sensitive high-div evidence for the n=4, shift-nonzero DIV v4
     dispatcher.
 
@@ -85,6 +110,26 @@ theorem n4ShiftNzDispatcherBranchHighDivEvidence_def {a b : EvmWord} :
        (isAddbackBorrowN4CallV4Evm a b ∧
         isAddbackCarry2NzN4CallV4Evm a b ∧
         n4CallAddbackBeqShiftHighDivEvidence a b)) :=
+  rfl
+
+theorem n4ShiftNzDispatcherBranchHighDivRawEvidence_def {a b : EvmWord} :
+    n4ShiftNzDispatcherBranchHighDivRawEvidence a b =
+      ((isSkipBorrowN4CallV4Evm a b ∧ n4CallSkipRuntimeBranchV4 a b) ∨
+       (isAddbackBorrowN4CallV4Evm a b ∧
+        isAddbackCarry2NzN4CallV4Evm a b ∧
+        divKTrialCallV4Rhatdd
+            (n4CallAddbackBeqU4 a b)
+            (n4CallAddbackBeqU3 a b)
+            (n4CallAddbackBeqB3Prime b) >>> (32 : BitVec 6).toNat =
+          (0 : Word) ∧
+        (n4CallAddbackBeqQHatV4 a b).toNat ≤
+          ((n4CallAddbackBeqU4 a b).toNat * 2^64 +
+              (n4CallAddbackBeqU3 a b).toNat) /
+            (n4CallAddbackBeqB3Prime b).toNat ∧
+        ((n4CallAddbackBeqU4 a b).toNat * 2^64 +
+            (n4CallAddbackBeqU3 a b).toNat) /
+          (n4CallAddbackBeqB3Prime b).toNat ≤
+            n4CallAddbackBeqULoNormVal a b / n4CallAddbackBeqBNormVal b + 1)) :=
   rfl
 
 theorem n4ShiftNzDispatcherBranchBoundsV4.callSkipBranch {a b : EvmWord}
@@ -203,6 +248,57 @@ theorem n4ShiftNzDispatcherBranchRuntimeV4_of_high_div_evidence {a b : EvmWord}
       exact n4ShiftNzDispatcherBranchRuntimeV4.addback hadd.1 hadd.2.1
         (n4CallAddbackBeqRuntimeBounds_of_shift_high_div_evidence_and_borrow
           hb3nz hshift_nz hadd.2.2 hadd.1)
+
+theorem n4ShiftNzDispatcherBranchHighDivRawEvidence.skip {a b : EvmWord}
+    (hskip : isSkipBorrowN4CallV4Evm a b)
+    (hbranch : n4CallSkipRuntimeBranchV4 a b) :
+    n4ShiftNzDispatcherBranchHighDivRawEvidence a b := by
+  rw [n4ShiftNzDispatcherBranchHighDivRawEvidence_def]
+  exact Or.inl ⟨hskip, hbranch⟩
+
+theorem n4ShiftNzDispatcherBranchHighDivRawEvidence.addback {a b : EvmWord}
+    (hadd : isAddbackBorrowN4CallV4Evm a b)
+    (hcarry2 : isAddbackCarry2NzN4CallV4Evm a b)
+    (h_rhat_hi_zero :
+      divKTrialCallV4Rhatdd
+          (n4CallAddbackBeqU4 a b)
+          (n4CallAddbackBeqU3 a b)
+          (n4CallAddbackBeqB3Prime b) >>> (32 : BitVec 6).toNat =
+        (0 : Word))
+    (h_qhat_le_high_div :
+      (n4CallAddbackBeqQHatV4 a b).toNat ≤
+        ((n4CallAddbackBeqU4 a b).toNat * 2^64 +
+            (n4CallAddbackBeqU3 a b).toNat) /
+          (n4CallAddbackBeqB3Prime b).toNat)
+    (h_high_div_le_norm_plus_one :
+      ((n4CallAddbackBeqU4 a b).toNat * 2^64 +
+          (n4CallAddbackBeqU3 a b).toNat) /
+        (n4CallAddbackBeqB3Prime b).toNat ≤
+          n4CallAddbackBeqULoNormVal a b / n4CallAddbackBeqBNormVal b + 1) :
+    n4ShiftNzDispatcherBranchHighDivRawEvidence a b := by
+  rw [n4ShiftNzDispatcherBranchHighDivRawEvidence_def]
+  exact Or.inr
+    ⟨hadd, hcarry2, h_rhat_hi_zero, h_qhat_le_high_div, h_high_div_le_norm_plus_one⟩
+
+theorem n4ShiftNzDispatcherBranchHighDivEvidence_of_raw {a b : EvmWord}
+    (hevidence : n4ShiftNzDispatcherBranchHighDivRawEvidence a b) :
+    n4ShiftNzDispatcherBranchHighDivEvidence a b := by
+  rw [n4ShiftNzDispatcherBranchHighDivRawEvidence_def] at hevidence
+  cases hevidence with
+  | inl hskip =>
+      exact n4ShiftNzDispatcherBranchHighDivEvidence.skip hskip.1 hskip.2
+  | inr hadd =>
+      exact n4ShiftNzDispatcherBranchHighDivEvidence.addbackRaw
+        hadd.1 hadd.2.1 hadd.2.2.1 hadd.2.2.2.1 hadd.2.2.2.2
+
+theorem n4ShiftNzDispatcherBranchRuntimeV4_of_high_div_raw_evidence {a b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (hevidence : n4ShiftNzDispatcherBranchHighDivRawEvidence a b) :
+    n4ShiftNzDispatcherBranchRuntimeV4 a b :=
+  n4ShiftNzDispatcherBranchRuntimeV4_of_high_div_evidence
+    hb3nz hshift_nz
+    (n4ShiftNzDispatcherBranchHighDivEvidence_of_raw hevidence)
 
 /-- n=4, shift-nonzero DIV v4 dispatcher over the call branch.
 
@@ -832,6 +928,56 @@ theorem evm_div_n4_shift_nz_stack_spec_noNop_of_high_div_evidence
     hb3nz hshift_nz halign
     (n4ShiftNzDispatcherBranchRuntimeV4_of_high_div_evidence
       hb3nz hshift_nz hevidence)
+
+/-- Final named n=4, shift-nonzero DIV dispatcher surface from raw
+    branch-sensitive high-div evidence. -/
+theorem evm_div_n4_shift_nz_stack_spec_of_high_div_raw_evidence
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hevidence : n4ShiftNzDispatcherBranchHighDivRawEvidence a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_of_high_div_evidence
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign
+    (n4ShiftNzDispatcherBranchHighDivEvidence_of_raw hevidence)
+
+/-- Final named no-NOP n=4, shift-nonzero DIV dispatcher surface from raw
+    branch-sensitive high-div evidence. -/
+theorem evm_div_n4_shift_nz_stack_spec_noNop_of_high_div_raw_evidence
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hevidence : n4ShiftNzDispatcherBranchHighDivRawEvidence a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_noNop_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_noNop_of_high_div_evidence
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign
+    (n4ShiftNzDispatcherBranchHighDivEvidence_of_raw hevidence)
 
 /-- Final named n=4, shift-nonzero DIV dispatcher surface from packaged
     branch/bounds evidence. -/

--- a/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcher.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcher.lean
@@ -33,6 +33,28 @@ def n4ShiftNzDispatcherBranchRuntimeV4 (a b : EvmWord) : Prop :=
    isAddbackCarry2NzN4CallV4Evm a b ∧
    n4CallAddbackBeqRuntimeBounds a b)
 
+/-- Raw runtime evidence for the n=4, shift-nonzero DIV v4 dispatcher.
+
+    This is the arithmetic-facing counterpart of `n4ShiftNzDispatcherRuntimeV4`:
+    the call+skip runtime certificate is global, while the addback side keeps
+    the concrete high-div facts instead of a prebuilt runtime-bounds package. -/
+def n4ShiftNzDispatcherRuntimeHighDivRawEvidence (a b : EvmWord) : Prop :=
+  n4CallSkipRuntimeBranchV4 a b ∧
+  isAddbackCarry2NzN4CallV4Evm a b ∧
+  divKTrialCallV4Rhatdd
+      (n4CallAddbackBeqU4 a b)
+      (n4CallAddbackBeqU3 a b)
+      (n4CallAddbackBeqB3Prime b) >>> (32 : BitVec 6).toNat =
+    (0 : Word) ∧
+  (n4CallAddbackBeqQHatV4 a b).toNat ≤
+    ((n4CallAddbackBeqU4 a b).toNat * 2^64 +
+        (n4CallAddbackBeqU3 a b).toNat) /
+      (n4CallAddbackBeqB3Prime b).toNat ∧
+  ((n4CallAddbackBeqU4 a b).toNat * 2^64 +
+      (n4CallAddbackBeqU3 a b).toNat) /
+    (n4CallAddbackBeqB3Prime b).toNat ≤
+      n4CallAddbackBeqULoNormVal a b / n4CallAddbackBeqBNormVal b + 1
+
 /-- Explicit branch/bounds evidence for the n=4, shift-nonzero DIV v4
     dispatcher.
 
@@ -95,6 +117,25 @@ theorem n4ShiftNzDispatcherBranchRuntimeV4_def {a b : EvmWord} :
        (isAddbackBorrowN4CallV4Evm a b ∧
         isAddbackCarry2NzN4CallV4Evm a b ∧
         n4CallAddbackBeqRuntimeBounds a b)) :=
+  rfl
+
+theorem n4ShiftNzDispatcherRuntimeHighDivRawEvidence_def {a b : EvmWord} :
+    n4ShiftNzDispatcherRuntimeHighDivRawEvidence a b =
+      (n4CallSkipRuntimeBranchV4 a b ∧
+       isAddbackCarry2NzN4CallV4Evm a b ∧
+       divKTrialCallV4Rhatdd
+           (n4CallAddbackBeqU4 a b)
+           (n4CallAddbackBeqU3 a b)
+           (n4CallAddbackBeqB3Prime b) >>> (32 : BitVec 6).toNat =
+         (0 : Word) ∧
+       (n4CallAddbackBeqQHatV4 a b).toNat ≤
+         ((n4CallAddbackBeqU4 a b).toNat * 2^64 +
+             (n4CallAddbackBeqU3 a b).toNat) /
+           (n4CallAddbackBeqB3Prime b).toNat ∧
+       ((n4CallAddbackBeqU4 a b).toNat * 2^64 +
+           (n4CallAddbackBeqU3 a b).toNat) /
+         (n4CallAddbackBeqB3Prime b).toNat ≤
+           n4CallAddbackBeqULoNormVal a b / n4CallAddbackBeqBNormVal b + 1) :=
   rfl
 
 theorem n4ShiftNzDispatcherBranchBoundsV4_def {a b : EvmWord} :
@@ -299,6 +340,49 @@ theorem n4ShiftNzDispatcherBranchRuntimeV4_of_high_div_raw_evidence {a b : EvmWo
   n4ShiftNzDispatcherBranchRuntimeV4_of_high_div_evidence
     hb3nz hshift_nz
     (n4ShiftNzDispatcherBranchHighDivEvidence_of_raw hevidence)
+
+theorem n4ShiftNzDispatcherRuntimeHighDivRawEvidence.of_parts {a b : EvmWord}
+    (hbranch : n4CallSkipRuntimeBranchV4 a b)
+    (hcarry2 : isAddbackCarry2NzN4CallV4Evm a b)
+    (h_rhat_hi_zero :
+      divKTrialCallV4Rhatdd
+          (n4CallAddbackBeqU4 a b)
+          (n4CallAddbackBeqU3 a b)
+          (n4CallAddbackBeqB3Prime b) >>> (32 : BitVec 6).toNat =
+        (0 : Word))
+    (h_qhat_le_high_div :
+      (n4CallAddbackBeqQHatV4 a b).toNat ≤
+        ((n4CallAddbackBeqU4 a b).toNat * 2^64 +
+            (n4CallAddbackBeqU3 a b).toNat) /
+          (n4CallAddbackBeqB3Prime b).toNat)
+    (h_high_div_le_norm_plus_one :
+      ((n4CallAddbackBeqU4 a b).toNat * 2^64 +
+          (n4CallAddbackBeqU3 a b).toNat) /
+        (n4CallAddbackBeqB3Prime b).toNat ≤
+          n4CallAddbackBeqULoNormVal a b / n4CallAddbackBeqBNormVal b + 1) :
+    n4ShiftNzDispatcherRuntimeHighDivRawEvidence a b := by
+  rw [n4ShiftNzDispatcherRuntimeHighDivRawEvidence_def]
+  exact ⟨hbranch, hcarry2, h_rhat_hi_zero, h_qhat_le_high_div, h_high_div_le_norm_plus_one⟩
+
+theorem n4ShiftNzDispatcherBranchHighDivRawEvidence_of_runtime_raw {a b : EvmWord}
+    (hruntime : n4ShiftNzDispatcherRuntimeHighDivRawEvidence a b) :
+    n4ShiftNzDispatcherBranchHighDivRawEvidence a b := by
+  rw [n4ShiftNzDispatcherRuntimeHighDivRawEvidence_def] at hruntime
+  cases isSkipBorrowN4CallV4Evm_or_isAddbackBorrowN4CallV4Evm a b with
+  | inl hskip =>
+      exact n4ShiftNzDispatcherBranchHighDivRawEvidence.skip hskip hruntime.1
+  | inr hadd =>
+      exact n4ShiftNzDispatcherBranchHighDivRawEvidence.addback
+        hadd hruntime.2.1 hruntime.2.2.1 hruntime.2.2.2.1 hruntime.2.2.2.2
+
+theorem n4ShiftNzDispatcherBranchRuntimeV4_of_runtime_high_div_raw {a b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (hruntime : n4ShiftNzDispatcherRuntimeHighDivRawEvidence a b) :
+    n4ShiftNzDispatcherBranchRuntimeV4 a b :=
+  n4ShiftNzDispatcherBranchRuntimeV4_of_high_div_raw_evidence
+    hb3nz hshift_nz
+    (n4ShiftNzDispatcherBranchHighDivRawEvidence_of_runtime_raw hruntime)
 
 /-- n=4, shift-nonzero DIV v4 dispatcher over the call branch.
 
@@ -978,6 +1062,56 @@ theorem evm_div_n4_shift_nz_stack_spec_noNop_of_high_div_raw_evidence
     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
     hb3nz hshift_nz halign
     (n4ShiftNzDispatcherBranchHighDivEvidence_of_raw hevidence)
+
+/-- Final named n=4, shift-nonzero DIV dispatcher surface from global
+    raw high-div runtime evidence. -/
+theorem evm_div_n4_shift_nz_stack_spec_of_runtime_high_div_raw
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hruntime : n4ShiftNzDispatcherRuntimeHighDivRawEvidence a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_of_high_div_raw_evidence
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign
+    (n4ShiftNzDispatcherBranchHighDivRawEvidence_of_runtime_raw hruntime)
+
+/-- Final named no-NOP n=4, shift-nonzero DIV dispatcher surface from global
+    raw high-div runtime evidence. -/
+theorem evm_div_n4_shift_nz_stack_spec_noNop_of_runtime_high_div_raw
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hruntime : n4ShiftNzDispatcherRuntimeHighDivRawEvidence a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_noNop_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_noNop_of_high_div_raw_evidence
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign
+    (n4ShiftNzDispatcherBranchHighDivRawEvidence_of_runtime_raw hruntime)
 
 /-- Final named n=4, shift-nonzero DIV dispatcher surface from packaged
     branch/bounds evidence. -/

--- a/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcher.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcher.lean
@@ -4,6 +4,7 @@
   Dispatcher-level n=4, shift-nonzero DIV v4 wrapper.
 -/
 
+import EvmAsm.Evm64.DivMod.Spec.CallAddbackRuntimeHighDiv
 import EvmAsm.Evm64.DivMod.Spec.CallSkipUnconditional
 import EvmAsm.Evm64.DivMod.Spec.CallSkipV4NoWrap
 import EvmAsm.Evm64.DivMod.Spec.N4V4StackPre
@@ -43,6 +44,19 @@ def n4ShiftNzDispatcherBranchBoundsV4 (a b : EvmWord) : Prop :=
   isAddbackCarry2NzN4CallV4Evm a b ∧
   n4CallAddbackBeqRuntimeBounds a b
 
+/-- Branch-sensitive high-div evidence for the n=4, shift-nonzero DIV v4
+    dispatcher.
+
+    The skip branch carries the runtime call+skip certificate directly; the
+    addback branch carries the surviving high-div `+1` evidence package, which
+    can be lowered to `n4CallAddbackBeqRuntimeBounds` once the runtime borrow
+    branch is known. -/
+def n4ShiftNzDispatcherBranchHighDivEvidence (a b : EvmWord) : Prop :=
+  (isSkipBorrowN4CallV4Evm a b ∧ n4CallSkipRuntimeBranchV4 a b) ∨
+  (isAddbackBorrowN4CallV4Evm a b ∧
+   isAddbackCarry2NzN4CallV4Evm a b ∧
+   n4CallAddbackBeqShiftHighDivEvidence a b)
+
 theorem n4ShiftNzDispatcherRuntimeV4_def {a b : EvmWord} :
     n4ShiftNzDispatcherRuntimeV4 a b =
       (n4CallSkipRuntimeBranchV4 a b ∧
@@ -63,6 +77,14 @@ theorem n4ShiftNzDispatcherBranchBoundsV4_def {a b : EvmWord} :
       (n4CallSkipBranchV4 a b ∧
        isAddbackCarry2NzN4CallV4Evm a b ∧
        n4CallAddbackBeqRuntimeBounds a b) :=
+  rfl
+
+theorem n4ShiftNzDispatcherBranchHighDivEvidence_def {a b : EvmWord} :
+    n4ShiftNzDispatcherBranchHighDivEvidence a b =
+      ((isSkipBorrowN4CallV4Evm a b ∧ n4CallSkipRuntimeBranchV4 a b) ∨
+       (isAddbackBorrowN4CallV4Evm a b ∧
+        isAddbackCarry2NzN4CallV4Evm a b ∧
+        n4CallAddbackBeqShiftHighDivEvidence a b)) :=
   rfl
 
 theorem n4ShiftNzDispatcherBranchBoundsV4.callSkipBranch {a b : EvmWord}
@@ -128,6 +150,59 @@ theorem n4ShiftNzDispatcherBranchRuntimeV4_of_branch_bounds {a b : EvmWord}
     n4ShiftNzDispatcherBranchRuntimeV4 a b :=
   n4ShiftNzDispatcherBranchRuntimeV4_of_runtime_pred
     (n4ShiftNzDispatcherRuntimeV4.of_branch_bounds hevidence)
+
+theorem n4ShiftNzDispatcherBranchHighDivEvidence.skip {a b : EvmWord}
+    (hskip : isSkipBorrowN4CallV4Evm a b)
+    (hbranch : n4CallSkipRuntimeBranchV4 a b) :
+    n4ShiftNzDispatcherBranchHighDivEvidence a b := by
+  rw [n4ShiftNzDispatcherBranchHighDivEvidence_def]
+  exact Or.inl ⟨hskip, hbranch⟩
+
+theorem n4ShiftNzDispatcherBranchHighDivEvidence.addback {a b : EvmWord}
+    (hadd : isAddbackBorrowN4CallV4Evm a b)
+    (hcarry2 : isAddbackCarry2NzN4CallV4Evm a b)
+    (hevidence : n4CallAddbackBeqShiftHighDivEvidence a b) :
+    n4ShiftNzDispatcherBranchHighDivEvidence a b := by
+  rw [n4ShiftNzDispatcherBranchHighDivEvidence_def]
+  exact Or.inr ⟨hadd, hcarry2, hevidence⟩
+
+theorem n4ShiftNzDispatcherBranchHighDivEvidence.addbackRaw {a b : EvmWord}
+    (hadd : isAddbackBorrowN4CallV4Evm a b)
+    (hcarry2 : isAddbackCarry2NzN4CallV4Evm a b)
+    (h_rhat_hi_zero :
+      divKTrialCallV4Rhatdd
+          (n4CallAddbackBeqU4 a b)
+          (n4CallAddbackBeqU3 a b)
+          (n4CallAddbackBeqB3Prime b) >>> (32 : BitVec 6).toNat =
+        (0 : Word))
+    (h_qhat_le_high_div :
+      (n4CallAddbackBeqQHatV4 a b).toNat ≤
+        ((n4CallAddbackBeqU4 a b).toNat * 2^64 +
+            (n4CallAddbackBeqU3 a b).toNat) /
+          (n4CallAddbackBeqB3Prime b).toNat)
+    (h_high_div_le_norm_plus_one :
+      ((n4CallAddbackBeqU4 a b).toNat * 2^64 +
+          (n4CallAddbackBeqU3 a b).toNat) /
+        (n4CallAddbackBeqB3Prime b).toNat ≤
+          n4CallAddbackBeqULoNormVal a b / n4CallAddbackBeqBNormVal b + 1) :
+    n4ShiftNzDispatcherBranchHighDivEvidence a b :=
+  n4ShiftNzDispatcherBranchHighDivEvidence.addback hadd hcarry2
+    (n4CallAddbackBeqShiftHighDivEvidence.of_raw_parts
+      h_rhat_hi_zero h_qhat_le_high_div h_high_div_le_norm_plus_one)
+
+theorem n4ShiftNzDispatcherBranchRuntimeV4_of_high_div_evidence {a b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (hevidence : n4ShiftNzDispatcherBranchHighDivEvidence a b) :
+    n4ShiftNzDispatcherBranchRuntimeV4 a b := by
+  rw [n4ShiftNzDispatcherBranchHighDivEvidence_def] at hevidence
+  cases hevidence with
+  | inl hskip =>
+      exact n4ShiftNzDispatcherBranchRuntimeV4.skip hskip.1 hskip.2
+  | inr hadd =>
+      exact n4ShiftNzDispatcherBranchRuntimeV4.addback hadd.1 hadd.2.1
+        (n4CallAddbackBeqRuntimeBounds_of_shift_high_div_evidence_and_borrow
+          hb3nz hshift_nz hadd.2.2 hadd.1)
 
 /-- n=4, shift-nonzero DIV v4 dispatcher over the call branch.
 
@@ -705,6 +780,58 @@ theorem evm_div_n4_shift_nz_stack_spec_noNop_of_runtime_bounds
     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
     hb3nz hshift_nz halign hbranch hcarry2 h_bounds
 
+
+/-- Final named n=4, shift-nonzero DIV dispatcher surface from
+    branch-sensitive high-div evidence. -/
+theorem evm_div_n4_shift_nz_stack_spec_of_high_div_evidence
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hevidence : n4ShiftNzDispatcherBranchHighDivEvidence a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_v4_of_branch_runtime
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign
+    (n4ShiftNzDispatcherBranchRuntimeV4_of_high_div_evidence
+      hb3nz hshift_nz hevidence)
+
+/-- Final named no-NOP n=4, shift-nonzero DIV dispatcher surface from
+    branch-sensitive high-div evidence. -/
+theorem evm_div_n4_shift_nz_stack_spec_noNop_of_high_div_evidence
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hevidence : n4ShiftNzDispatcherBranchHighDivEvidence a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_noNop_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_v4_noNop_of_branch_runtime
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign
+    (n4ShiftNzDispatcherBranchRuntimeV4_of_high_div_evidence
+      hb3nz hshift_nz hevidence)
 
 /-- Final named n=4, shift-nonzero DIV dispatcher surface from packaged
     branch/bounds evidence. -/


### PR DESCRIPTION
## Summary
- expose DIV/MOD no-NOP v4 code-surface wrappers for the n=2 call+addback j=0 and j>0 loop-body specs
- lift those wrappers to full divCode_v4 and modCode_v4 surfaces
- keep max-addback wrapper surfaces for a later focused slice

## Stack
- Depends on #6885

## Bead
- evm-asm-9iqmw.4.3

## Verification
- lake build EvmAsm.Evm64.DivMod.LoopIterN2AddbackV4NoNop
- Lean LSP diagnostics for LoopIterN2AddbackV4NoNop: no errors
- rg -n "set_option maxHeartbeats|set_option maxRecDepth|sorry|admit" EvmAsm/Evm64/DivMod/LoopIterN2AddbackV4NoNop.lean EvmAsm/Evm64/DivMod/LoopIterN2CallV4NoNop.lean EvmAsm/Evm64/DivMod/LoopIterN3AddbackV4NoNop.lean EvmAsm/Evm64/DivMod/LoopIterN3CallV4NoNop.lean EvmAsm/Evm64/DivMod/LoopIterN4AddbackV4NoNop.lean EvmAsm/Evm64/DivMod/LoopIterN4CallV4NoNop.lean EvmAsm/Evm64/DivMod/LoopBody/TrialCall.lean (no matches)
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build EvmAsm.Evm64.DivMod
- lake build

Refs #61