### PR TITLE
feat(divmod): lift n2 max addback loop to v4 code

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopIterN2AddbackV4NoNop.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN2AddbackV4NoNop.lean
@@ -568,4 +568,156 @@ theorem divK_loop_body_n2_call_addback_jgt0_beq_v4_spec_within_modCode (j : Word
       v5Old v6Old v7Old v10Old v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
       retMem dMem dloMem scratchUn0 scratchMem base halign hbltu hborrow hcarry2_nz)
 
+/-- DIV no-NOP v4 code-surface lift of the n=2 max+addback loop-body j=0 path. -/
+theorem divK_loop_body_n2_max_addback_j0_beq_v4_spec_within_divCode_noNop
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (base : Word)
+    (hbltu : ¬BitVec.ult u2 v1)
+    (hcarry2_nz : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
+    cpsTripleWithin 152 (base + loopBodyOff) (base + denormOff) (divCode_noNop_v4 base)
+      (loopBodyN2MaxSkipJ0Pre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld)
+      (loopBodyN2AddbackBeqPost sp (0 : Word) (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) :=
+  fun hborrow =>
+    cpsTripleWithin_extend_code
+      (hmono := sharedDivModCodeNoNop_v4_sub_divCode_noNop_v4)
+      (divK_loop_body_n2_max_addback_j0_beq_v4_spec_within_noNop sp jOld v5Old v6Old
+        v7Old v10Old v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base hbltu
+        hcarry2_nz hborrow)
+
+/-- MOD no-NOP v4 code-surface lift of the n=2 max+addback loop-body j=0 path. -/
+theorem divK_loop_body_n2_max_addback_j0_beq_v4_spec_within_modCode_noNop
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (base : Word)
+    (hbltu : ¬BitVec.ult u2 v1)
+    (hcarry2_nz : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
+    cpsTripleWithin 152 (base + loopBodyOff) (base + denormOff) (modCode_noNop_v4 base)
+      (loopBodyN2MaxSkipJ0Pre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld)
+      (loopBodyN2AddbackBeqPost sp (0 : Word) (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) :=
+  fun hborrow =>
+    cpsTripleWithin_extend_code
+      (hmono := sharedDivModCodeNoNop_v4_sub_modCode_noNop_v4)
+      (divK_loop_body_n2_max_addback_j0_beq_v4_spec_within_noNop sp jOld v5Old v6Old
+        v7Old v10Old v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base hbltu
+        hcarry2_nz hborrow)
+
+/-- Full DIV v4 code-surface lift of the n=2 max+addback loop-body j=0 path. -/
+theorem divK_loop_body_n2_max_addback_j0_beq_v4_spec_within_divCode
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (base : Word)
+    (hbltu : ¬BitVec.ult u2 v1)
+    (hcarry2_nz : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
+    cpsTripleWithin 152 (base + loopBodyOff) (base + denormOff) (divCode_v4 base)
+      (loopBodyN2MaxSkipJ0Pre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld)
+      (loopBodyN2AddbackBeqPost sp (0 : Word) (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) :=
+  fun hborrow =>
+    cpsTripleWithin_divCode_noNop_v4_to_divCode_v4
+      (divK_loop_body_n2_max_addback_j0_beq_v4_spec_within_divCode_noNop sp jOld v5Old
+        v6Old v7Old v10Old v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base
+        hbltu hcarry2_nz hborrow)
+
+/-- Full MOD v4 code-surface lift of the n=2 max+addback loop-body j=0 path. -/
+theorem divK_loop_body_n2_max_addback_j0_beq_v4_spec_within_modCode
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (base : Word)
+    (hbltu : ¬BitVec.ult u2 v1)
+    (hcarry2_nz : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
+    cpsTripleWithin 152 (base + loopBodyOff) (base + denormOff) (modCode_v4 base)
+      (loopBodyN2MaxSkipJ0Pre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld)
+      (loopBodyN2AddbackBeqPost sp (0 : Word) (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) :=
+  fun hborrow =>
+    cpsTripleWithin_modCode_noNop_v4_to_modCode_v4
+      (divK_loop_body_n2_max_addback_j0_beq_v4_spec_within_modCode_noNop sp jOld v5Old
+        v6Old v7Old v10Old v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base
+        hbltu hcarry2_nz hborrow)
+
+/-- DIV no-NOP v4 code-surface lift of the n=2 max+addback loop-body j>0 path. -/
+theorem divK_loop_body_n2_max_addback_jgt0_beq_v4_spec_within_divCode_noNop (j : Word)
+    (hpos : BitVec.slt (j + signExtend12 4095) 0 = false)
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (base : Word)
+    (hbltu : ¬BitVec.ult u2 v1)
+    (hcarry2_nz : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
+    cpsTripleWithin 152 (base + loopBodyOff) (base + loopBodyOff) (divCode_noNop_v4 base)
+      (loopBodyN2MaxJgt0Pre j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld)
+      (loopBodyN2AddbackBeqPost sp j (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) :=
+  fun hborrow =>
+    cpsTripleWithin_extend_code
+      (hmono := sharedDivModCodeNoNop_v4_sub_divCode_noNop_v4)
+      (divK_loop_body_n2_max_addback_jgt0_beq_v4_spec_within_noNop j hpos sp jOld v5Old
+        v6Old v7Old v10Old v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base
+        hbltu hcarry2_nz hborrow)
+
+/-- MOD no-NOP v4 code-surface lift of the n=2 max+addback loop-body j>0 path. -/
+theorem divK_loop_body_n2_max_addback_jgt0_beq_v4_spec_within_modCode_noNop (j : Word)
+    (hpos : BitVec.slt (j + signExtend12 4095) 0 = false)
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (base : Word)
+    (hbltu : ¬BitVec.ult u2 v1)
+    (hcarry2_nz : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
+    cpsTripleWithin 152 (base + loopBodyOff) (base + loopBodyOff) (modCode_noNop_v4 base)
+      (loopBodyN2MaxJgt0Pre j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld)
+      (loopBodyN2AddbackBeqPost sp j (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) :=
+  fun hborrow =>
+    cpsTripleWithin_extend_code
+      (hmono := sharedDivModCodeNoNop_v4_sub_modCode_noNop_v4)
+      (divK_loop_body_n2_max_addback_jgt0_beq_v4_spec_within_noNop j hpos sp jOld v5Old
+        v6Old v7Old v10Old v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base
+        hbltu hcarry2_nz hborrow)
+
+/-- Full DIV v4 code-surface lift of the n=2 max+addback loop-body j>0 path. -/
+theorem divK_loop_body_n2_max_addback_jgt0_beq_v4_spec_within_divCode (j : Word)
+    (hpos : BitVec.slt (j + signExtend12 4095) 0 = false)
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (base : Word)
+    (hbltu : ¬BitVec.ult u2 v1)
+    (hcarry2_nz : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
+    cpsTripleWithin 152 (base + loopBodyOff) (base + loopBodyOff) (divCode_v4 base)
+      (loopBodyN2MaxJgt0Pre j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld)
+      (loopBodyN2AddbackBeqPost sp j (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) :=
+  fun hborrow =>
+    cpsTripleWithin_divCode_noNop_v4_to_divCode_v4
+      (divK_loop_body_n2_max_addback_jgt0_beq_v4_spec_within_divCode_noNop j hpos sp jOld
+        v5Old v6Old v7Old v10Old v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
+        base hbltu hcarry2_nz hborrow)
+
+/-- Full MOD v4 code-surface lift of the n=2 max+addback loop-body j>0 path. -/
+theorem divK_loop_body_n2_max_addback_jgt0_beq_v4_spec_within_modCode (j : Word)
+    (hpos : BitVec.slt (j + signExtend12 4095) 0 = false)
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (base : Word)
+    (hbltu : ¬BitVec.ult u2 v1)
+    (hcarry2_nz : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
+    cpsTripleWithin 152 (base + loopBodyOff) (base + loopBodyOff) (modCode_v4 base)
+      (loopBodyN2MaxJgt0Pre j sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld)
+      (loopBodyN2AddbackBeqPost sp j (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) :=
+  fun hborrow =>
+    cpsTripleWithin_modCode_noNop_v4_to_modCode_v4
+      (divK_loop_body_n2_max_addback_jgt0_beq_v4_spec_within_modCode_noNop j hpos sp jOld
+        v5Old v6Old v7Old v10Old v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
+        base hbltu hcarry2_nz hborrow)
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcher.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcher.lean
@@ -55,6 +55,13 @@ def n4ShiftNzDispatcherRuntimeHighDivRawEvidence (a b : EvmWord) : Prop :=
     (n4CallAddbackBeqB3Prime b).toNat ≤
       n4CallAddbackBeqULoNormVal a b / n4CallAddbackBeqBNormVal b + 1
 
+/-- Runtime evidence for the n=4, shift-nonzero DIV v4 dispatcher with
+    packaged high-div addback evidence. -/
+def n4ShiftNzDispatcherRuntimeHighDivEvidence (a b : EvmWord) : Prop :=
+  n4CallSkipRuntimeBranchV4 a b ∧
+  isAddbackCarry2NzN4CallV4Evm a b ∧
+  n4CallAddbackBeqShiftHighDivEvidence a b
+
 /-- Explicit branch/bounds evidence for the n=4, shift-nonzero DIV v4
     dispatcher.
 
@@ -136,6 +143,13 @@ theorem n4ShiftNzDispatcherRuntimeHighDivRawEvidence_def {a b : EvmWord} :
            (n4CallAddbackBeqU3 a b).toNat) /
          (n4CallAddbackBeqB3Prime b).toNat ≤
            n4CallAddbackBeqULoNormVal a b / n4CallAddbackBeqBNormVal b + 1) :=
+  rfl
+
+theorem n4ShiftNzDispatcherRuntimeHighDivEvidence_def {a b : EvmWord} :
+    n4ShiftNzDispatcherRuntimeHighDivEvidence a b =
+      (n4CallSkipRuntimeBranchV4 a b ∧
+       isAddbackCarry2NzN4CallV4Evm a b ∧
+       n4CallAddbackBeqShiftHighDivEvidence a b) :=
   rfl
 
 theorem n4ShiftNzDispatcherBranchBoundsV4_def {a b : EvmWord} :
@@ -340,6 +354,43 @@ theorem n4ShiftNzDispatcherBranchRuntimeV4_of_high_div_raw_evidence {a b : EvmWo
   n4ShiftNzDispatcherBranchRuntimeV4_of_high_div_evidence
     hb3nz hshift_nz
     (n4ShiftNzDispatcherBranchHighDivEvidence_of_raw hevidence)
+
+theorem n4ShiftNzDispatcherRuntimeHighDivEvidence.of_parts {a b : EvmWord}
+    (hbranch : n4CallSkipRuntimeBranchV4 a b)
+    (hcarry2 : isAddbackCarry2NzN4CallV4Evm a b)
+    (hevidence : n4CallAddbackBeqShiftHighDivEvidence a b) :
+    n4ShiftNzDispatcherRuntimeHighDivEvidence a b := by
+  rw [n4ShiftNzDispatcherRuntimeHighDivEvidence_def]
+  exact ⟨hbranch, hcarry2, hevidence⟩
+
+theorem n4ShiftNzDispatcherRuntimeHighDivEvidence_of_raw {a b : EvmWord}
+    (hruntime : n4ShiftNzDispatcherRuntimeHighDivRawEvidence a b) :
+    n4ShiftNzDispatcherRuntimeHighDivEvidence a b := by
+  rw [n4ShiftNzDispatcherRuntimeHighDivRawEvidence_def] at hruntime
+  exact n4ShiftNzDispatcherRuntimeHighDivEvidence.of_parts
+    hruntime.1 hruntime.2.1
+    (n4CallAddbackBeqShiftHighDivEvidence.of_raw_parts
+      hruntime.2.2.1 hruntime.2.2.2.1 hruntime.2.2.2.2)
+
+theorem n4ShiftNzDispatcherBranchHighDivEvidence_of_runtime_high_div {a b : EvmWord}
+    (hruntime : n4ShiftNzDispatcherRuntimeHighDivEvidence a b) :
+    n4ShiftNzDispatcherBranchHighDivEvidence a b := by
+  rw [n4ShiftNzDispatcherRuntimeHighDivEvidence_def] at hruntime
+  cases isSkipBorrowN4CallV4Evm_or_isAddbackBorrowN4CallV4Evm a b with
+  | inl hskip =>
+      exact n4ShiftNzDispatcherBranchHighDivEvidence.skip hskip hruntime.1
+  | inr hadd =>
+      exact n4ShiftNzDispatcherBranchHighDivEvidence.addback
+        hadd hruntime.2.1 hruntime.2.2
+
+theorem n4ShiftNzDispatcherBranchRuntimeV4_of_runtime_high_div {a b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (hruntime : n4ShiftNzDispatcherRuntimeHighDivEvidence a b) :
+    n4ShiftNzDispatcherBranchRuntimeV4 a b :=
+  n4ShiftNzDispatcherBranchRuntimeV4_of_high_div_evidence
+    hb3nz hshift_nz
+    (n4ShiftNzDispatcherBranchHighDivEvidence_of_runtime_high_div hruntime)
 
 theorem n4ShiftNzDispatcherRuntimeHighDivRawEvidence.of_parts {a b : EvmWord}
     (hbranch : n4CallSkipRuntimeBranchV4 a b)
@@ -1062,6 +1113,56 @@ theorem evm_div_n4_shift_nz_stack_spec_noNop_of_high_div_raw_evidence
     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
     hb3nz hshift_nz halign
     (n4ShiftNzDispatcherBranchHighDivEvidence_of_raw hevidence)
+
+/-- Final named n=4, shift-nonzero DIV dispatcher surface from global
+    packaged high-div runtime evidence. -/
+theorem evm_div_n4_shift_nz_stack_spec_of_runtime_high_div_evidence
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hruntime : n4ShiftNzDispatcherRuntimeHighDivEvidence a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_of_high_div_evidence
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign
+    (n4ShiftNzDispatcherBranchHighDivEvidence_of_runtime_high_div hruntime)
+
+/-- Final named no-NOP n=4, shift-nonzero DIV dispatcher surface from global
+    packaged high-div runtime evidence. -/
+theorem evm_div_n4_shift_nz_stack_spec_noNop_of_runtime_high_div_evidence
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hruntime : n4ShiftNzDispatcherRuntimeHighDivEvidence a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_noNop_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_noNop_of_high_div_evidence
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign
+    (n4ShiftNzDispatcherBranchHighDivEvidence_of_runtime_high_div hruntime)
 
 /-- Final named n=4, shift-nonzero DIV dispatcher surface from global
     raw high-div runtime evidence. -/

--- a/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcher.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcher.lean
@@ -363,6 +363,57 @@ theorem n4ShiftNzDispatcherRuntimeHighDivEvidence.of_parts {a b : EvmWord}
   rw [n4ShiftNzDispatcherRuntimeHighDivEvidence_def]
   exact ⟨hbranch, hcarry2, hevidence⟩
 
+theorem n4ShiftNzDispatcherRuntimeHighDivEvidence.callSkipRuntimeBranch {a b : EvmWord}
+    (hruntime : n4ShiftNzDispatcherRuntimeHighDivEvidence a b) :
+    n4CallSkipRuntimeBranchV4 a b := by
+  rw [n4ShiftNzDispatcherRuntimeHighDivEvidence_def] at hruntime
+  exact hruntime.1
+
+theorem n4ShiftNzDispatcherRuntimeHighDivEvidence.addbackCarry2 {a b : EvmWord}
+    (hruntime : n4ShiftNzDispatcherRuntimeHighDivEvidence a b) :
+    isAddbackCarry2NzN4CallV4Evm a b := by
+  rw [n4ShiftNzDispatcherRuntimeHighDivEvidence_def] at hruntime
+  exact hruntime.2.1
+
+theorem n4ShiftNzDispatcherRuntimeHighDivEvidence.addbackHighDivEvidence {a b : EvmWord}
+    (hruntime : n4ShiftNzDispatcherRuntimeHighDivEvidence a b) :
+    n4CallAddbackBeqShiftHighDivEvidence a b := by
+  rw [n4ShiftNzDispatcherRuntimeHighDivEvidence_def] at hruntime
+  exact hruntime.2.2
+
+theorem n4ShiftNzDispatcherRuntimeHighDivEvidence.addbackRuntimeBounds {a b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (hruntime : n4ShiftNzDispatcherRuntimeHighDivEvidence a b)
+    (hadd : isAddbackBorrowN4CallV4Evm a b) :
+    n4CallAddbackBeqRuntimeBounds a b :=
+  n4CallAddbackBeqRuntimeBounds_of_shift_high_div_evidence_and_borrow
+    hb3nz hshift_nz
+    (n4ShiftNzDispatcherRuntimeHighDivEvidence.addbackHighDivEvidence hruntime)
+    hadd
+
+theorem n4ShiftNzDispatcherRuntimeHighDivEvidence.semanticHoldsV4 {a b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (hruntime : n4ShiftNzDispatcherRuntimeHighDivEvidence a b)
+    (hadd : isAddbackBorrowN4CallV4Evm a b) :
+    n4CallAddbackBeqSemanticHoldsV4 a b :=
+  n4CallAddbackBeqSemanticHoldsV4_of_shift_high_div_evidence_and_borrow
+    hb3nz hshift_nz
+    (n4ShiftNzDispatcherRuntimeHighDivEvidence.addbackHighDivEvidence hruntime)
+    hadd
+    (n4ShiftNzDispatcherRuntimeHighDivEvidence.addbackCarry2 hruntime)
+
+theorem n4ShiftNzDispatcherRuntimeHighDivEvidence.semanticHolds {a b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (hruntime : n4ShiftNzDispatcherRuntimeHighDivEvidence a b)
+    (hadd : isAddbackBorrowN4CallV4Evm a b) :
+    n4CallAddbackBeqSemanticHolds a b := by
+  simpa [n4CallAddbackBeqSemanticHolds_eq_v4] using
+    n4ShiftNzDispatcherRuntimeHighDivEvidence.semanticHoldsV4
+      hb3nz hshift_nz hruntime hadd
+
 theorem n4ShiftNzDispatcherRuntimeHighDivEvidence_of_raw {a b : EvmWord}
     (hruntime : n4ShiftNzDispatcherRuntimeHighDivRawEvidence a b) :
     n4ShiftNzDispatcherRuntimeHighDivEvidence a b := by

--- a/scripts/codegen-stateless-spec-output-check.sh
+++ b/scripts/codegen-stateless-spec-output-check.sh
@@ -362,6 +362,16 @@ run_fixture "chain1_act_both"       1                  0    ""           ""     
 # all three u64s of the entry.
 run_fixture "chain1_blob"           1                  0    ""           ""                  ""    ""           ""           "100:200:300" || fail=1
 
+# Triple cross-product: witness.codes + public_keys + block_number.
+# witness.codes shifts chain_config_addr forward, block_number
+# drives the variable-length encoder, and public_keys padding
+# pushes mem_end far enough past chain_config_end that the
+# encoder's trailing LBU reads stay in-bounds (see the [[ziskemu-
+# input-slack]] memory note). Without the PK padding this exact
+# witcode + actbn combo would panic ziskemu with "section not
+# found"; the PK trick recovers it.
+run_fixture "chain1_witcode_pk_actbn" 1                0    "deadbeef"   ""                  "04$(printf '%064d' 0)$(printf '%064d' 0)"    "1234567890" || fail=1
+
 if [[ "$fail" -eq 0 ]]; then
   echo "==> PASS: all spec-output fixtures match the new SSZ schema"
   exit 0


### PR DESCRIPTION
## Summary
- expose DIV/MOD no-NOP v4 code-surface wrappers for the n=2 max+addback j=0 and j>0 loop-body specs
- lift those wrappers to full divCode_v4 and modCode_v4 surfaces
- keep this as the final N2 addback public regOwn code-surface slice

## Stack
- Depends on #6887

## Bead
- evm-asm-9iqmw.4.3

## Verification
- lake build EvmAsm.Evm64.DivMod.LoopIterN2AddbackV4NoNop
- Lean LSP diagnostics for LoopIterN2AddbackV4NoNop: no errors
- rg -n "set_option maxHeartbeats|set_option maxRecDepth|sorry|admit" EvmAsm/Evm64/DivMod/LoopIterN2AddbackV4NoNop.lean EvmAsm/Evm64/DivMod/LoopIterN2CallV4NoNop.lean EvmAsm/Evm64/DivMod/LoopIterN3AddbackV4NoNop.lean EvmAsm/Evm64/DivMod/LoopIterN3CallV4NoNop.lean EvmAsm/Evm64/DivMod/LoopIterN4AddbackV4NoNop.lean EvmAsm/Evm64/DivMod/LoopIterN4CallV4NoNop.lean EvmAsm/Evm64/DivMod/LoopBody/TrialCall.lean (no matches)
- git diff --check
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- lake build EvmAsm.Evm64.DivMod
- lake build

Refs #61