### PR TITLE
refactor(div): name n1 selected branch facts

### DIFF
--- a/EvmAsm/Evm64/DivMod/CallableV4DivShape.lean
+++ b/EvmAsm/Evm64/DivMod/CallableV4DivShape.lean
@@ -386,6 +386,91 @@ theorem evm_div_callable_v4_n1_stack_pre_to_callable_post_scratch_shape_selected
       retMem dMem dloMem scratchUn0 scratchMem raVal
       hevidence)
 
+/-- N1 selected-if-borrow shape wrapper routed through the bundled selected
+    input/hdiv package. This lets downstream public-wrapper assembly consume
+    `N1CallableSelectedIfBorrowShapeEvidence` without rebuilding selected stack
+    inputs and quotient-limb witnesses separately. -/
+theorem evm_div_callable_v4_n1_stack_pre_to_callable_post_scratch_shape_selectedIfBorrowEvidence_inputHdivRoute
+    (sp base : Word) (a b : EvmWord)
+    (v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (hbnz : b ≠ 0)
+    (hb3z : b.getLimbN 3 = 0) (hb2z : b.getLimbN 2 = 0)
+    (hb1z : b.getLimbN 1 = 0)
+    (hshift_nz : (clzResult (b.getLimbN 0)).1 ≠ 0)
+    (halign : fullDivN1CallMaxmaxmaxExactInputAligned sp base
+      jMem (1 : Word) (fullDivN1Shift (b.getLimbN 0))
+      (fullDivN1NormU (a.getLimbN 0) (a.getLimbN 1)
+        (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0)).1
+      (a.getLimbN 0 >>> ((fullDivN1AntiShift (b.getLimbN 0)).toNat % 64))
+      v11Old (fullDivN1AntiShift (b.getLimbN 0))
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+      (0 : Word) (0 : Word) (0 : Word) (0 : Word)
+      retMem dMem dloMem scratchUn0 scratchMem raVal)
+    (hevidence : N1CallableSelectedIfBorrowShapeEvidence a b) :
+    cpsTripleWithin (unifiedDivBound + 1) base (raVal &&& ~~~1)
+      (evm_div_callable_code_v4 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult (b.getLimbN 0)).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divStackDispatchPostCallableExactFrame sp a b raVal
+        (signExtend12 4095 : Word) **
+       memOwn (sp + signExtend12 3936)) := by
+  have hbnzLimbs :
+      b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 ≠ 0 :=
+    (EvmWord.ne_zero_iff_getLimbN_or).mp hbnz
+  obtain ⟨hselected, hdivs⟩ :=
+    N1CallableSelectedIfBorrowShapeEvidence.selectedInputAndHdivs
+      sp base
+      jMem (1 : Word) (fullDivN1Shift (b.getLimbN 0))
+      (fullDivN1NormU (a.getLimbN 0) (a.getLimbN 1)
+        (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0)).1
+      (a.getLimbN 0 >>> ((fullDivN1AntiShift (b.getLimbN 0)).toNat % 64))
+      v11Old (fullDivN1AntiShift (b.getLimbN 0))
+      a b
+      (0 : Word) (0 : Word) (0 : Word) (0 : Word)
+      retMem dMem dloMem scratchUn0 scratchMem raVal
+      hbnzLimbs hevidence
+  exact
+    cpsTripleWithin_weaken
+      (fun _ hp => hp)
+      (fun _ hq => by
+        obtain ⟨hFrame, hScratchState, hDisjoint, hUnion, hFramePost, hScratch⟩ := hq
+        exact ⟨hFrame, hScratchState, hDisjoint, hUnion, hFramePost,
+          memIs_implies_memOwn hScratchState hScratch⟩)
+      (evm_div_callable_v4_spec_from_divCode_noNop_exact_frame_x9out_body_frame_transform
+        (FPre := ((sp + signExtend12 3936) ↦ₘ scratchMem))
+        (FPost := ((sp + signExtend12 3936) ↦ₘ
+          divKTrialCallV4ScratchOut
+            (fullDivN1NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0)).2.2.2.2
+            (fullDivN1NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0)).2.2.2.1
+            (fullDivN1NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).1 scratchMem))
+        sp base (signExtend12 (4 : BitVec 12) - (4 : Word))
+        (signExtend12 4095 : Word) raVal a b
+        ((clzResult (b.getLimbN 0)).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        nMem shiftMem jMem retMem dMem dloMem scratchUn0
+        (evm_div_n1_call_maxmaxmax_stack_spec_within_word_v4_preNoX1_callableExtra_x9In_exactFrame_unified_noNop_of_selected_if_borrow_input_hdivs
+          sp base a b
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+          v5 v6 v7 v10 v11Old (signExtend12 (4 : BitVec 12) - (4 : Word))
+          q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+          nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+          rfl rfl rfl rfl rfl rfl rfl rfl
+          hbnzLimbs hb3z hb2z hb1z hshift_nz halign hselected hdivs))
+
 /-- N1 selected-if-borrow shape wrapper for callers that still carry the
     all-true path package, while deriving the selected callable evidence from
     the selected semantic package internally.

--- a/EvmAsm/Evm64/DivMod/CallableV4DivShape.lean
+++ b/EvmAsm/Evm64/DivMod/CallableV4DivShape.lean
@@ -596,6 +596,60 @@ theorem evm_div_callable_v4_n1_stack_pre_to_callable_post_scratch_shape_allTrueP
     hbnz hb3z hb2z hb1z hshift_nz halign
     (N1SelectedIfBorrowPathEvidence.ofAllTruePathEvidence hpath) hevidence
 
+/-- All-true-path selected semantic-evidence wrapper routed through the
+    selected input/hdiv package. This is the all-true compatibility surface for
+    the input/hdiv route used by final N1 wiring. -/
+theorem evm_div_callable_v4_n1_stack_pre_to_callable_post_scratch_shape_allTruePathSelectedIfBorrowSemanticEvidence_inputHdivRoute
+    (sp base : Word) (a b : EvmWord)
+    (v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (hbnz : b ≠ 0)
+    (hb3z : b.getLimbN 3 = 0) (hb2z : b.getLimbN 2 = 0)
+    (hb1z : b.getLimbN 1 = 0)
+    (hshift_nz : (clzResult (b.getLimbN 0)).1 ≠ 0)
+    (halign : fullDivN1CallMaxmaxmaxExactInputAligned sp base
+      jMem (1 : Word) (fullDivN1Shift (b.getLimbN 0))
+      (fullDivN1NormU (a.getLimbN 0) (a.getLimbN 1)
+        (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0)).1
+      (a.getLimbN 0 >>> ((fullDivN1AntiShift (b.getLimbN 0)).toNat % 64))
+      v11Old (fullDivN1AntiShift (b.getLimbN 0))
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+      (0 : Word) (0 : Word) (0 : Word) (0 : Word)
+      retMem dMem dloMem scratchUn0 scratchMem raVal)
+    (hpath : N1AllTruePathEvidence a b)
+    (hevidence : FullDivN1CallMaxmaxmaxSelectedIfBorrowSemanticEvidenceV4 sp base
+      jMem (1 : Word) (fullDivN1Shift (b.getLimbN 0))
+      (fullDivN1NormU (a.getLimbN 0) (a.getLimbN 1)
+        (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0)).1
+      (a.getLimbN 0 >>> ((fullDivN1AntiShift (b.getLimbN 0)).toNat % 64))
+      v11Old (fullDivN1AntiShift (b.getLimbN 0))
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+      (0 : Word) (0 : Word) (0 : Word) (0 : Word)
+      retMem dMem dloMem scratchUn0 scratchMem raVal) :
+    cpsTripleWithin (unifiedDivBound + 1) base (raVal &&& ~~~1)
+      (evm_div_callable_code_v4 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult (b.getLimbN 0)).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divStackDispatchPostCallableExactFrame sp a b raVal
+        (signExtend12 4095 : Word) **
+       memOwn (sp + signExtend12 3936)) := by
+  exact evm_div_callable_v4_n1_stack_pre_to_callable_post_scratch_shape_selectedIfBorrowSemanticEvidence_inputHdivRoute
+    sp base a b
+    v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+    hbnz hb3z hb2z hb1z hshift_nz halign
+    (N1SelectedIfBorrowPathEvidence.ofAllTruePathEvidence hpath) hevidence
+
 /-- N2 DIV v4 callable wrapper deriving divisor nonzero from the n=2 shape
     while consuming only selected carry evidence for the actual path. -/
 theorem evm_div_callable_v4_n2_stack_pre_to_callable_post_scratch_shape_selectedCarry

--- a/EvmAsm/Evm64/DivMod/CallableV4DivShape.lean
+++ b/EvmAsm/Evm64/DivMod/CallableV4DivShape.lean
@@ -471,6 +471,71 @@ theorem evm_div_callable_v4_n1_stack_pre_to_callable_post_scratch_shape_selected
           rfl rfl rfl rfl rfl rfl rfl rfl
           hbnzLimbs hb3z hb2z hb1z hshift_nz halign hselected hdivs))
 
+/-- Selected semantic-evidence variant routed through the input/hdiv package.
+    This keeps selected input and quotient-limb witness recovery behind
+    `N1CallableSelectedIfBorrowShapeEvidence.selectedInputAndHdivs`. -/
+theorem evm_div_callable_v4_n1_stack_pre_to_callable_post_scratch_shape_selectedIfBorrowSemanticEvidence_inputHdivRoute
+    (sp base : Word) (a b : EvmWord)
+    (v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (hbnz : b ≠ 0)
+    (hb3z : b.getLimbN 3 = 0) (hb2z : b.getLimbN 2 = 0)
+    (hb1z : b.getLimbN 1 = 0)
+    (hshift_nz : (clzResult (b.getLimbN 0)).1 ≠ 0)
+    (halign : fullDivN1CallMaxmaxmaxExactInputAligned sp base
+      jMem (1 : Word) (fullDivN1Shift (b.getLimbN 0))
+      (fullDivN1NormU (a.getLimbN 0) (a.getLimbN 1)
+        (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0)).1
+      (a.getLimbN 0 >>> ((fullDivN1AntiShift (b.getLimbN 0)).toNat % 64))
+      v11Old (fullDivN1AntiShift (b.getLimbN 0))
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+      (0 : Word) (0 : Word) (0 : Word) (0 : Word)
+      retMem dMem dloMem scratchUn0 scratchMem raVal)
+    (hpath : N1SelectedIfBorrowPathEvidence a b)
+    (hevidence : FullDivN1CallMaxmaxmaxSelectedIfBorrowSemanticEvidenceV4 sp base
+      jMem (1 : Word) (fullDivN1Shift (b.getLimbN 0))
+      (fullDivN1NormU (a.getLimbN 0) (a.getLimbN 1)
+        (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0)).1
+      (a.getLimbN 0 >>> ((fullDivN1AntiShift (b.getLimbN 0)).toNat % 64))
+      v11Old (fullDivN1AntiShift (b.getLimbN 0))
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+      (0 : Word) (0 : Word) (0 : Word) (0 : Word)
+      retMem dMem dloMem scratchUn0 scratchMem raVal) :
+    cpsTripleWithin (unifiedDivBound + 1) base (raVal &&& ~~~1)
+      (evm_div_callable_code_v4 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult (b.getLimbN 0)).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divStackDispatchPostCallableExactFrame sp a b raVal
+        (signExtend12 4095 : Word) **
+       memOwn (sp + signExtend12 3936)) := by
+  exact
+    evm_div_callable_v4_n1_stack_pre_to_callable_post_scratch_shape_selectedIfBorrowEvidence_inputHdivRoute
+      sp base a b
+      v5 v6 v7 v10 v11Old
+      q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+      nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+      hbnz hb3z hb2z hb1z hshift_nz halign
+      (N1CallableSelectedIfBorrowShapeEvidence.ofSelectedIfBorrowSemanticEvidence
+        sp base
+        jMem (1 : Word) (fullDivN1Shift (b.getLimbN 0))
+        (fullDivN1NormU (a.getLimbN 0) (a.getLimbN 1)
+          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0)).1
+        (a.getLimbN 0 >>> ((fullDivN1AntiShift (b.getLimbN 0)).toNat % 64))
+        v11Old (fullDivN1AntiShift (b.getLimbN 0))
+        a b
+        (0 : Word) (0 : Word) (0 : Word) (0 : Word)
+        retMem dMem dloMem scratchUn0 scratchMem raVal
+        hpath hevidence)
+
 /-- N1 selected-if-borrow shape wrapper for callers that still carry the
     all-true path package, while deriving the selected callable evidence from
     the selected semantic package internally.

--- a/EvmAsm/Evm64/DivMod/CallableV4DivShape.lean
+++ b/EvmAsm/Evm64/DivMod/CallableV4DivShape.lean
@@ -331,6 +331,61 @@ theorem evm_div_callable_v4_n1_stack_pre_to_callable_post_scratch_shape_selected
       retMem dMem dloMem scratchUn0 scratchMem raVal
       hpath hevidence)
 
+/-- N1 selected-if-borrow shape wrapper routed entirely through the bundled
+    selected semantic evidence projection. This keeps the single private
+    evidence object as the consumer-facing boundary for final N1 wiring. -/
+theorem evm_div_callable_v4_n1_stack_pre_to_callable_post_scratch_shape_selectedIfBorrowEvidence_semanticRoute
+    (sp base : Word) (a b : EvmWord)
+    (v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (hbnz : b ≠ 0)
+    (hb3z : b.getLimbN 3 = 0) (hb2z : b.getLimbN 2 = 0)
+    (hb1z : b.getLimbN 1 = 0)
+    (hshift_nz : (clzResult (b.getLimbN 0)).1 ≠ 0)
+    (halign : fullDivN1CallMaxmaxmaxExactInputAligned sp base
+      jMem (1 : Word) (fullDivN1Shift (b.getLimbN 0))
+      (fullDivN1NormU (a.getLimbN 0) (a.getLimbN 1)
+        (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0)).1
+      (a.getLimbN 0 >>> ((fullDivN1AntiShift (b.getLimbN 0)).toNat % 64))
+      v11Old (fullDivN1AntiShift (b.getLimbN 0))
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+      (0 : Word) (0 : Word) (0 : Word) (0 : Word)
+      retMem dMem dloMem scratchUn0 scratchMem raVal)
+    (hevidence : N1CallableSelectedIfBorrowShapeEvidence a b) :
+    cpsTripleWithin (unifiedDivBound + 1) base (raVal &&& ~~~1)
+      (evm_div_callable_code_v4 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult (b.getLimbN 0)).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divStackDispatchPostCallableExactFrame sp a b raVal
+        (signExtend12 4095 : Word) **
+       memOwn (sp + signExtend12 3936)) := by
+  exact evm_div_callable_v4_n1_stack_pre_to_callable_post_scratch_shape_selectedIfBorrowSemanticEvidence
+    sp base a b
+    v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+    hbnz hb3z hb2z hb1z hshift_nz halign
+    (N1CallableSelectedIfBorrowShapeEvidence.selectedPath hevidence)
+    (N1CallableSelectedIfBorrowShapeEvidence.selectedIfBorrowSemanticEvidence
+      sp base
+      jMem (1 : Word) (fullDivN1Shift (b.getLimbN 0))
+      (fullDivN1NormU (a.getLimbN 0) (a.getLimbN 1)
+        (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0)).1
+      (a.getLimbN 0 >>> ((fullDivN1AntiShift (b.getLimbN 0)).toNat % 64))
+      v11Old (fullDivN1AntiShift (b.getLimbN 0))
+      a b
+      (0 : Word) (0 : Word) (0 : Word) (0 : Word)
+      retMem dMem dloMem scratchUn0 scratchMem raVal
+      hevidence)
+
 /-- N1 selected-if-borrow shape wrapper for callers that still carry the
     all-true path package, while deriving the selected callable evidence from
     the selected semantic package internally.

--- a/EvmAsm/Evm64/DivMod/Spec/N1CallableSelectedIfBorrowShapeEvidence.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N1CallableSelectedIfBorrowShapeEvidence.lean
@@ -251,6 +251,57 @@ theorem N1CallableSelectedIfBorrowShapeEvidence.hdivs
       a b q3Old q2Old q1Old q0Old retMem dMem dloMem scratchUn0 scratchMem raVal
       hevidence)
 
+/-- Project the selected-if-borrow input hypotheses from the bundled N1
+    callable shape evidence. This pairs with `hdivs` so downstream wrappers can
+    consume one private evidence object at the selected path boundary. -/
+theorem N1CallableSelectedIfBorrowShapeEvidence.selectedInput
+    (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (a b : EvmWord)
+    (q3Old q2Old q1Old q0Old retMem dMem dloMem scratchUn0 scratchMem raVal : Word)
+    (hevidence : N1CallableSelectedIfBorrowShapeEvidence a b) :
+    fullDivN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses sp base
+      jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+      q3Old q2Old q1Old q0Old retMem dMem dloMem scratchUn0 scratchMem raVal := by
+  exact FullDivN1CallMaxmaxmaxSelectedIfBorrowSemanticEvidenceV4_selectedInput
+    sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+    q3Old q2Old q1Old q0Old retMem dMem dloMem scratchUn0 scratchMem raVal
+    (N1CallableSelectedIfBorrowShapeEvidence.selectedIfBorrowSemanticEvidence
+      sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      a b q3Old q2Old q1Old q0Old retMem dMem dloMem scratchUn0 scratchMem raVal
+      hevidence)
+
+/-- Recover both selected-if-borrow stack inputs and hdiv witnesses from the
+    bundled N1 callable shape evidence. -/
+theorem N1CallableSelectedIfBorrowShapeEvidence.selectedInputAndHdivs
+    (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (a b : EvmWord)
+    (q3Old q2Old q1Old q0Old retMem dMem dloMem scratchUn0 scratchMem raVal : Word)
+    (hbnz : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 ≠ 0)
+    (hevidence : N1CallableSelectedIfBorrowShapeEvidence a b) :
+    fullDivN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses sp base
+      jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+      q3Old q2Old q1Old q0Old retMem dMem dloMem scratchUn0 scratchMem raVal ∧
+    FullDivN1CallMaxmaxmaxHdivs a b
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) := by
+  exact ⟨
+    N1CallableSelectedIfBorrowShapeEvidence.selectedInput
+      sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      a b q3Old q2Old q1Old q0Old retMem dMem dloMem scratchUn0 scratchMem raVal
+      hevidence,
+    N1CallableSelectedIfBorrowShapeEvidence.hdivs
+      sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      a b q3Old q2Old q1Old q0Old retMem dMem dloMem scratchUn0 scratchMem raVal
+      hbnz hevidence⟩
+
 theorem N1CallableSelectedIfBorrowShapeEvidence.ofAllTruePathSelectedIfBorrowSemanticEvidence
     (sp base : Word)
     (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)

--- a/EvmAsm/Evm64/DivMod/Spec/N1CallableSelectedIfBorrowShapeEvidence.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N1CallableSelectedIfBorrowShapeEvidence.lean
@@ -226,6 +226,31 @@ theorem N1CallableSelectedIfBorrowShapeEvidence.selectedIfBorrowSemanticEvidence
       (N1CallableSelectedIfBorrowShapeEvidence.selectedPath hevidence))
     (N1CallableSelectedIfBorrowShapeEvidence.semanticFacts hevidence)
 
+/-- Project the named selected-path hdiv package from the bundled N1
+    callable shape evidence. This gives later N1 public-wrapper wiring a single
+    private evidence object from which to recover the quotient-limb witnesses. -/
+theorem N1CallableSelectedIfBorrowShapeEvidence.hdivs
+    (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (a b : EvmWord)
+    (q3Old q2Old q1Old q0Old retMem dMem dloMem scratchUn0 scratchMem raVal : Word)
+    (hbnz : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 ≠ 0)
+    (hevidence : N1CallableSelectedIfBorrowShapeEvidence a b) :
+    FullDivN1CallMaxmaxmaxHdivs a b
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) := by
+  exact FullDivN1CallMaxmaxmaxHdivs_of_selected_if_borrow_semantic_evidence
+    sp base a b
+    jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+    q3Old q2Old q1Old q0Old retMem dMem dloMem scratchUn0 scratchMem raVal
+    rfl rfl rfl rfl rfl rfl rfl rfl hbnz
+    (N1CallableSelectedIfBorrowShapeEvidence.selectedIfBorrowSemanticEvidence
+      sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      a b q3Old q2Old q1Old q0Old retMem dMem dloMem scratchUn0 scratchMem raVal
+      hevidence)
+
 theorem N1CallableSelectedIfBorrowShapeEvidence.ofAllTruePathSelectedIfBorrowSemanticEvidence
     (sp base : Word)
     (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)

--- a/EvmAsm/Evm64/DivMod/Spec/N1CallableSelectedIfBorrowShapeEvidence.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N1CallableSelectedIfBorrowShapeEvidence.lean
@@ -78,6 +78,79 @@ abbrev N1CallableSelectedIfBorrowShapeEvidence (a b : EvmWord) : Prop :=
     (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
     (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
 
+/-- Branch facts carried by `N1CallableSelectedIfBorrowShapeEvidence`.
+    Keeping this shape named lets later wrappers assemble the private evidence
+    bundle without re-copying the long call/max/max/max branch predicate. -/
+abbrev N1CallableSelectedIfBorrowBranchFacts (a b : EvmWord) : Prop :=
+  isTrialN1_j3 true (a.getLimbN 3) (b.getLimbN 0) ∧
+  ¬BitVec.ult
+    (loopN1CallMaxmaxmaxR3
+      (fullDivN1NormV (b.getLimbN 0) (b.getLimbN 1)
+        (b.getLimbN 2) (b.getLimbN 3)).1
+      (fullDivN1NormV (b.getLimbN 0) (b.getLimbN 1)
+        (b.getLimbN 2) (b.getLimbN 3)).2.1
+      (fullDivN1NormV (b.getLimbN 0) (b.getLimbN 1)
+        (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+      (fullDivN1NormV (b.getLimbN 0) (b.getLimbN 1)
+        (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+      (fullDivN1NormU (a.getLimbN 0) (a.getLimbN 1)
+        (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0)).2.2.2.1
+      (fullDivN1NormU (a.getLimbN 0) (a.getLimbN 1)
+        (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0)).2.2.2.2
+      0 0 0).2.1
+    (fullDivN1NormV (b.getLimbN 0) (b.getLimbN 1)
+      (b.getLimbN 2) (b.getLimbN 3)).1 ∧
+  ¬BitVec.ult
+    (loopN1CallMaxmaxmaxR2
+      (fullDivN1NormV (b.getLimbN 0) (b.getLimbN 1)
+        (b.getLimbN 2) (b.getLimbN 3)).1
+      (fullDivN1NormV (b.getLimbN 0) (b.getLimbN 1)
+        (b.getLimbN 2) (b.getLimbN 3)).2.1
+      (fullDivN1NormV (b.getLimbN 0) (b.getLimbN 1)
+        (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+      (fullDivN1NormV (b.getLimbN 0) (b.getLimbN 1)
+        (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+      (fullDivN1NormU (a.getLimbN 0) (a.getLimbN 1)
+        (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0)).2.2.2.1
+      (fullDivN1NormU (a.getLimbN 0) (a.getLimbN 1)
+        (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0)).2.2.2.2
+      0 0 0
+      (fullDivN1NormU (a.getLimbN 0) (a.getLimbN 1)
+        (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0)).2.2.1).2.1
+    (fullDivN1NormV (b.getLimbN 0) (b.getLimbN 1)
+      (b.getLimbN 2) (b.getLimbN 3)).1 ∧
+  ¬BitVec.ult
+    (loopN1CallMaxmaxmaxR1
+      (fullDivN1NormV (b.getLimbN 0) (b.getLimbN 1)
+        (b.getLimbN 2) (b.getLimbN 3)).1
+      (fullDivN1NormV (b.getLimbN 0) (b.getLimbN 1)
+        (b.getLimbN 2) (b.getLimbN 3)).2.1
+      (fullDivN1NormV (b.getLimbN 0) (b.getLimbN 1)
+        (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+      (fullDivN1NormV (b.getLimbN 0) (b.getLimbN 1)
+        (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+      (fullDivN1NormU (a.getLimbN 0) (a.getLimbN 1)
+        (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0)).2.2.2.1
+      (fullDivN1NormU (a.getLimbN 0) (a.getLimbN 1)
+        (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0)).2.2.2.2
+      0 0 0
+      (fullDivN1NormU (a.getLimbN 0) (a.getLimbN 1)
+        (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0)).2.2.1
+      (fullDivN1NormU (a.getLimbN 0) (a.getLimbN 1)
+        (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0)).2.1).2.1
+    (fullDivN1NormV (b.getLimbN 0) (b.getLimbN 1)
+      (b.getLimbN 2) (b.getLimbN 3)).1
+
+theorem N1CallableSelectedIfBorrowShapeEvidence.of_parts {a b : EvmWord}
+    (hbranches : N1CallableSelectedIfBorrowBranchFacts a b)
+    (hpath : N1SelectedIfBorrowPathEvidence a b)
+    (hfacts : FullDivN1CallMaxmaxmaxSemanticFactsV4
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)) :
+    N1CallableSelectedIfBorrowShapeEvidence a b := by
+  rcases hbranches with ⟨hbltu3, hbltu2, hbltu1, hbltu0⟩
+  exact ⟨hbltu3, hbltu2, hbltu1, hbltu0, hpath, hfacts⟩
+
 theorem N1CallableSelectedIfBorrowShapeEvidence.ofSelectedIfBorrowSemanticEvidence
     (sp base : Word)
     (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
@@ -109,64 +182,7 @@ theorem N1CallableSelectedIfBorrowShapeEvidence.ofSelectedIfBorrowSemanticEviden
 /-- Project the selected branch facts from the bundled N1 callable evidence. -/
 theorem N1CallableSelectedIfBorrowShapeEvidence.branchFacts {a b : EvmWord}
     (hevidence : N1CallableSelectedIfBorrowShapeEvidence a b) :
-    isTrialN1_j3 true (a.getLimbN 3) (b.getLimbN 0) ∧
-    ¬BitVec.ult
-      (loopN1CallMaxmaxmaxR3
-        (fullDivN1NormV (b.getLimbN 0) (b.getLimbN 1)
-          (b.getLimbN 2) (b.getLimbN 3)).1
-        (fullDivN1NormV (b.getLimbN 0) (b.getLimbN 1)
-          (b.getLimbN 2) (b.getLimbN 3)).2.1
-        (fullDivN1NormV (b.getLimbN 0) (b.getLimbN 1)
-          (b.getLimbN 2) (b.getLimbN 3)).2.2.1
-        (fullDivN1NormV (b.getLimbN 0) (b.getLimbN 1)
-          (b.getLimbN 2) (b.getLimbN 3)).2.2.2
-        (fullDivN1NormU (a.getLimbN 0) (a.getLimbN 1)
-          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0)).2.2.2.1
-        (fullDivN1NormU (a.getLimbN 0) (a.getLimbN 1)
-          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0)).2.2.2.2
-        0 0 0).2.1
-      (fullDivN1NormV (b.getLimbN 0) (b.getLimbN 1)
-        (b.getLimbN 2) (b.getLimbN 3)).1 ∧
-    ¬BitVec.ult
-      (loopN1CallMaxmaxmaxR2
-        (fullDivN1NormV (b.getLimbN 0) (b.getLimbN 1)
-          (b.getLimbN 2) (b.getLimbN 3)).1
-        (fullDivN1NormV (b.getLimbN 0) (b.getLimbN 1)
-          (b.getLimbN 2) (b.getLimbN 3)).2.1
-        (fullDivN1NormV (b.getLimbN 0) (b.getLimbN 1)
-          (b.getLimbN 2) (b.getLimbN 3)).2.2.1
-        (fullDivN1NormV (b.getLimbN 0) (b.getLimbN 1)
-          (b.getLimbN 2) (b.getLimbN 3)).2.2.2
-        (fullDivN1NormU (a.getLimbN 0) (a.getLimbN 1)
-          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0)).2.2.2.1
-        (fullDivN1NormU (a.getLimbN 0) (a.getLimbN 1)
-          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0)).2.2.2.2
-        0 0 0
-        (fullDivN1NormU (a.getLimbN 0) (a.getLimbN 1)
-          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0)).2.2.1).2.1
-      (fullDivN1NormV (b.getLimbN 0) (b.getLimbN 1)
-        (b.getLimbN 2) (b.getLimbN 3)).1 ∧
-    ¬BitVec.ult
-      (loopN1CallMaxmaxmaxR1
-        (fullDivN1NormV (b.getLimbN 0) (b.getLimbN 1)
-          (b.getLimbN 2) (b.getLimbN 3)).1
-        (fullDivN1NormV (b.getLimbN 0) (b.getLimbN 1)
-          (b.getLimbN 2) (b.getLimbN 3)).2.1
-        (fullDivN1NormV (b.getLimbN 0) (b.getLimbN 1)
-          (b.getLimbN 2) (b.getLimbN 3)).2.2.1
-        (fullDivN1NormV (b.getLimbN 0) (b.getLimbN 1)
-          (b.getLimbN 2) (b.getLimbN 3)).2.2.2
-        (fullDivN1NormU (a.getLimbN 0) (a.getLimbN 1)
-          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0)).2.2.2.1
-        (fullDivN1NormU (a.getLimbN 0) (a.getLimbN 1)
-          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0)).2.2.2.2
-        0 0 0
-        (fullDivN1NormU (a.getLimbN 0) (a.getLimbN 1)
-          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0)).2.2.1
-        (fullDivN1NormU (a.getLimbN 0) (a.getLimbN 1)
-          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0)).2.1).2.1
-      (fullDivN1NormV (b.getLimbN 0) (b.getLimbN 1)
-        (b.getLimbN 2) (b.getLimbN 3)).1 := by
+    N1CallableSelectedIfBorrowBranchFacts a b := by
   rcases hevidence with ⟨hbltu3, hbltu2, hbltu1, hbltu0, _hpath, _hfacts⟩
   exact ⟨hbltu3, hbltu2, hbltu1, hbltu0⟩
 


### PR DESCRIPTION
Refs #61.\n\nBead: evm-asm-9iqmw.7.1.6.1.1\n\nThis PR stacks on #6873 and keeps moving the N1 selected/reachable evidence route toward the final DIV stack-level spec.\n\nChanges:\n- names the branch-facts component of N1CallableSelectedIfBorrowShapeEvidence as N1CallableSelectedIfBorrowBranchFacts\n- adds N1CallableSelectedIfBorrowShapeEvidence.of_parts so later wrappers can assemble the private evidence bundle from branch facts, selected path evidence, and semantic facts without repeating the expanded branch predicate\n- routes the existing branchFacts projection through the named branch-facts shape\n\nVerification:\n- lake build EvmAsm.Evm64.DivMod.Spec.N1CallableSelectedIfBorrowShapeEvidence\n- Lean LSP diagnostics: no errors for N1CallableSelectedIfBorrowShapeEvidence.lean\n- lake build EvmAsm.Evm64.DivMod.Spec\n- lake build EvmAsm.Evm64.DivMod\n- lake build\n- git diff --check\n- scripts/check-file-size.sh EvmAsm/Evm64/DivMod/Spec/N1CallableSelectedIfBorrowShapeEvidence.lean\n- scripts/check-unimported.sh\n- forbidden scan for sorry/admit/maxHeartbeats/maxRecDepth on the touched file: no matches