### PR TITLE
refactor(div): project n1 selected evidence hdivs

### DIFF
--- a/EvmAsm/Evm64/DivMod/CallableV4DivShape.lean
+++ b/EvmAsm/Evm64/DivMod/CallableV4DivShape.lean
@@ -331,6 +331,61 @@ theorem evm_div_callable_v4_n1_stack_pre_to_callable_post_scratch_shape_selected
       retMem dMem dloMem scratchUn0 scratchMem raVal
       hpath hevidence)
 
+/-- N1 selected-if-borrow shape wrapper routed entirely through the bundled
+    selected semantic evidence projection. This keeps the single private
+    evidence object as the consumer-facing boundary for final N1 wiring. -/
+theorem evm_div_callable_v4_n1_stack_pre_to_callable_post_scratch_shape_selectedIfBorrowEvidence_semanticRoute
+    (sp base : Word) (a b : EvmWord)
+    (v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (hbnz : b ≠ 0)
+    (hb3z : b.getLimbN 3 = 0) (hb2z : b.getLimbN 2 = 0)
+    (hb1z : b.getLimbN 1 = 0)
+    (hshift_nz : (clzResult (b.getLimbN 0)).1 ≠ 0)
+    (halign : fullDivN1CallMaxmaxmaxExactInputAligned sp base
+      jMem (1 : Word) (fullDivN1Shift (b.getLimbN 0))
+      (fullDivN1NormU (a.getLimbN 0) (a.getLimbN 1)
+        (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0)).1
+      (a.getLimbN 0 >>> ((fullDivN1AntiShift (b.getLimbN 0)).toNat % 64))
+      v11Old (fullDivN1AntiShift (b.getLimbN 0))
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+      (0 : Word) (0 : Word) (0 : Word) (0 : Word)
+      retMem dMem dloMem scratchUn0 scratchMem raVal)
+    (hevidence : N1CallableSelectedIfBorrowShapeEvidence a b) :
+    cpsTripleWithin (unifiedDivBound + 1) base (raVal &&& ~~~1)
+      (evm_div_callable_code_v4 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult (b.getLimbN 0)).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divStackDispatchPostCallableExactFrame sp a b raVal
+        (signExtend12 4095 : Word) **
+       memOwn (sp + signExtend12 3936)) := by
+  exact evm_div_callable_v4_n1_stack_pre_to_callable_post_scratch_shape_selectedIfBorrowSemanticEvidence
+    sp base a b
+    v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+    hbnz hb3z hb2z hb1z hshift_nz halign
+    (N1CallableSelectedIfBorrowShapeEvidence.selectedPath hevidence)
+    (N1CallableSelectedIfBorrowShapeEvidence.selectedIfBorrowSemanticEvidence
+      sp base
+      jMem (1 : Word) (fullDivN1Shift (b.getLimbN 0))
+      (fullDivN1NormU (a.getLimbN 0) (a.getLimbN 1)
+        (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0)).1
+      (a.getLimbN 0 >>> ((fullDivN1AntiShift (b.getLimbN 0)).toNat % 64))
+      v11Old (fullDivN1AntiShift (b.getLimbN 0))
+      a b
+      (0 : Word) (0 : Word) (0 : Word) (0 : Word)
+      retMem dMem dloMem scratchUn0 scratchMem raVal
+      hevidence)
+
 /-- N1 selected-if-borrow shape wrapper for callers that still carry the
     all-true path package, while deriving the selected callable evidence from
     the selected semantic package internally.

--- a/EvmAsm/Evm64/DivMod/Counterexamples.lean
+++ b/EvmAsm/Evm64/DivMod/Counterexamples.lean
@@ -9,12 +9,14 @@ import EvmAsm.Evm64.DivMod.Callable
 import EvmAsm.Evm64.DivMod.Program
 import EvmAsm.Evm64.DivMod.LoopDefs.IterV4
 import EvmAsm.Evm64.DivMod.Spec.CallAddback
+import EvmAsm.Evm64.DivMod.Spec.CallAddbackRuntime
 import EvmAsm.Evm64.DivMod.Spec.N2QuotientStackBridge
 import EvmAsm.Evm64.DivMod.Spec.N3QuotientStackBridge
 
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
+open EvmWord
 
 namespace DivModCounterexamples
 
@@ -175,6 +177,101 @@ theorem n4CallAddbackBeqSemanticHolds_counterexampleA_v4 :
     n4CallAddbackBeqSemanticHolds ceA_a ceA_b := by
   rw [n4CallAddbackBeqSemantic_unfold]
   decide
+
+/-- Counterexample A satisfies the runtime-only premise shape targeted by the
+    final n=4 call-addback semantic discharger. -/
+theorem ceA_runtime_only_premises :
+    ceA_b.getLimbN 3 ≠ 0 ∧
+    (clzResult (ceA_b.getLimbN 3)).1 ≠ 0 ∧
+    isCallTrialN4Evm ceA_a ceA_b ∧
+    isAddbackBorrowN4CallV4Evm ceA_a ceA_b ∧
+    isAddbackCarry2NzN4CallV4Evm ceA_a ceA_b := by
+  constructor
+  · native_decide
+  constructor
+  · native_decide
+  constructor
+  · rw [isCallTrialN4Evm_def]
+    unfold isCallTrialN4
+    native_decide
+  constructor
+  · rw [isAddbackBorrowN4CallV4Evm_def]
+    unfold isAddbackBorrowN4CallV4Ab loopBodyN4CallAddbackBorrowV4
+    native_decide
+  · rw [isAddbackCarry2NzN4CallV4Evm_def]
+    unfold isAddbackCarry2NzN4CallV4Ab loopBodyN4CallAddbackCarry2NzV4
+    native_decide
+
+/-- Counterexample A also satisfies the repaired semantic marker. This keeps the
+    runtime-only target honest: the remaining work is proving the semantic
+    marker directly, not routing through the stronger compact bounds package. -/
+theorem ceA_n4CallAddbackBeqSemanticHoldsV4 :
+    n4CallAddbackBeqSemanticHoldsV4 ceA_a ceA_b := by
+  rw [n4CallAddbackBeqSemanticHoldsV4]
+  native_decide
+
+/-- Counterexample A satisfies the corrected-remainder half of the compact
+    runtime-bounds package. -/
+theorem ceA_n4CallAddbackBeqIterRNormVal_lt :
+    n4CallAddbackBeqIterRNormVal ceA_a ceA_b < n4CallAddbackBeqBNormVal ceA_b := by
+  rw [n4CallAddbackBeqIterRNormVal, n4CallAddbackBeqBNormVal]
+  native_decide
+
+/-- Counterexample A fails the compact qhat upper-bound conjunct. This is the
+    precise part of the old runtime-bounds package that the repaired semantic
+    route must not assume from runtime predicates alone. -/
+theorem ceA_n4CallAddbackBeqQHat_compact_bound_false :
+    ¬ ((n4CallAddbackBeqQHatV4 ceA_a ceA_b).toNat ≤
+        n4CallAddbackBeqULoNormVal ceA_a ceA_b / n4CallAddbackBeqBNormVal ceA_b + 1) := by
+  rw [n4CallAddbackBeqULoNormVal, n4CallAddbackBeqBNormVal]
+  native_decide
+
+/-- Counterexample A does not satisfy the current compact runtime-bounds package.
+    Therefore the final runtime-only discharger cannot soundly close by deriving
+    `n4CallAddbackBeqRuntimeBounds` from only the call/addback runtime predicates. -/
+theorem ceA_n4CallAddbackBeqRuntimeBounds_false :
+    ¬ n4CallAddbackBeqRuntimeBounds ceA_a ceA_b := by
+  rw [n4CallAddbackBeqRuntimeBounds]
+  native_decide
+
+/-- The runtime-only premise shape alone is not enough to recover the compact
+    runtime-bounds package used by older semantic bridges. -/
+theorem runtime_only_premises_do_not_imply_runtime_bounds :
+    ∃ a b : EvmWord,
+      b.getLimbN 3 ≠ 0 ∧
+      (clzResult (b.getLimbN 3)).1 ≠ 0 ∧
+      isCallTrialN4Evm a b ∧
+      isAddbackBorrowN4CallV4Evm a b ∧
+      isAddbackCarry2NzN4CallV4Evm a b ∧
+      ¬ n4CallAddbackBeqRuntimeBounds a b :=
+  ⟨ceA_a, ceA_b,
+    ceA_runtime_only_premises.1,
+    ceA_runtime_only_premises.2.1,
+    ceA_runtime_only_premises.2.2.1,
+    ceA_runtime_only_premises.2.2.2.1,
+    ceA_runtime_only_premises.2.2.2.2,
+    ceA_n4CallAddbackBeqRuntimeBounds_false⟩
+
+/-- Even adding the repaired semantic marker to the runtime-only premise shape does
+    not recover the old compact runtime-bounds package. The repaired marker is
+    therefore a replacement target, not a route back through that package. -/
+theorem runtime_only_semantic_do_not_imply_runtime_bounds :
+    ∃ a b : EvmWord,
+      b.getLimbN 3 ≠ 0 ∧
+      (clzResult (b.getLimbN 3)).1 ≠ 0 ∧
+      isCallTrialN4Evm a b ∧
+      isAddbackBorrowN4CallV4Evm a b ∧
+      isAddbackCarry2NzN4CallV4Evm a b ∧
+      n4CallAddbackBeqSemanticHoldsV4 a b ∧
+      ¬ n4CallAddbackBeqRuntimeBounds a b :=
+  ⟨ceA_a, ceA_b,
+    ceA_runtime_only_premises.1,
+    ceA_runtime_only_premises.2.1,
+    ceA_runtime_only_premises.2.2.1,
+    ceA_runtime_only_premises.2.2.2.1,
+    ceA_runtime_only_premises.2.2.2.2,
+    ceA_n4CallAddbackBeqSemanticHoldsV4,
+    ceA_n4CallAddbackBeqRuntimeBounds_false⟩
 
 /-- Per-counterexample regression pin: the executable DIV body is on the v4
     path, and the normalized trial quotient for counterexample A has the v4

--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -22,6 +22,7 @@ import EvmAsm.Evm64.DivMod.Spec.N4V4ShiftNzDispatcherBranchParts
 import EvmAsm.Evm64.DivMod.Spec.N4V4ShiftNzDispatcherBranchBoundsParts
 import EvmAsm.Evm64.DivMod.Spec.N4V4ShiftNzDispatcherRuntimeParts
 import EvmAsm.Evm64.DivMod.Spec.N4V4ShiftNzDispatcherHighDivParts
+import EvmAsm.Evm64.DivMod.Spec.N4V4ShiftNzDispatcherSemanticParts
 import EvmAsm.Evm64.DivMod.Spec.N3V4StackPre
 import EvmAsm.Evm64.DivMod.Spec.N3V4StackPreR1
 import EvmAsm.Evm64.DivMod.Spec.N3V4StackPreSelected

--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -19,6 +19,7 @@ import EvmAsm.Evm64.DivMod.Spec.CallAddbackRuntimeHighDiv
 import EvmAsm.Evm64.DivMod.Spec.N4V4StackPre
 import EvmAsm.Evm64.DivMod.Spec.N4V4ShiftNzDispatcher
 import EvmAsm.Evm64.DivMod.Spec.N4V4ShiftNzDispatcherBranchParts
+import EvmAsm.Evm64.DivMod.Spec.N4V4ShiftNzDispatcherBranchBoundsParts
 import EvmAsm.Evm64.DivMod.Spec.N4V4ShiftNzDispatcherRuntimeParts
 import EvmAsm.Evm64.DivMod.Spec.N4V4ShiftNzDispatcherHighDivParts
 import EvmAsm.Evm64.DivMod.Spec.N3V4StackPre

--- a/EvmAsm/Evm64/DivMod/Spec/N1CallableSelectedIfBorrowShapeEvidence.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N1CallableSelectedIfBorrowShapeEvidence.lean
@@ -251,6 +251,57 @@ theorem N1CallableSelectedIfBorrowShapeEvidence.hdivs
       a b q3Old q2Old q1Old q0Old retMem dMem dloMem scratchUn0 scratchMem raVal
       hevidence)
 
+/-- Project the selected-if-borrow input hypotheses from the bundled N1
+    callable shape evidence. This pairs with `hdivs` so downstream wrappers can
+    consume one private evidence object at the selected path boundary. -/
+theorem N1CallableSelectedIfBorrowShapeEvidence.selectedInput
+    (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (a b : EvmWord)
+    (q3Old q2Old q1Old q0Old retMem dMem dloMem scratchUn0 scratchMem raVal : Word)
+    (hevidence : N1CallableSelectedIfBorrowShapeEvidence a b) :
+    fullDivN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses sp base
+      jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+      q3Old q2Old q1Old q0Old retMem dMem dloMem scratchUn0 scratchMem raVal := by
+  exact FullDivN1CallMaxmaxmaxSelectedIfBorrowSemanticEvidenceV4_selectedInput
+    sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+    q3Old q2Old q1Old q0Old retMem dMem dloMem scratchUn0 scratchMem raVal
+    (N1CallableSelectedIfBorrowShapeEvidence.selectedIfBorrowSemanticEvidence
+      sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      a b q3Old q2Old q1Old q0Old retMem dMem dloMem scratchUn0 scratchMem raVal
+      hevidence)
+
+/-- Recover both selected-if-borrow stack inputs and hdiv witnesses from the
+    bundled N1 callable shape evidence. -/
+theorem N1CallableSelectedIfBorrowShapeEvidence.selectedInputAndHdivs
+    (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (a b : EvmWord)
+    (q3Old q2Old q1Old q0Old retMem dMem dloMem scratchUn0 scratchMem raVal : Word)
+    (hbnz : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 ≠ 0)
+    (hevidence : N1CallableSelectedIfBorrowShapeEvidence a b) :
+    fullDivN1CallMaxmaxmaxSelectedIfBorrowInputHypotheses sp base
+      jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+      q3Old q2Old q1Old q0Old retMem dMem dloMem scratchUn0 scratchMem raVal ∧
+    FullDivN1CallMaxmaxmaxHdivs a b
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) := by
+  exact ⟨
+    N1CallableSelectedIfBorrowShapeEvidence.selectedInput
+      sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      a b q3Old q2Old q1Old q0Old retMem dMem dloMem scratchUn0 scratchMem raVal
+      hevidence,
+    N1CallableSelectedIfBorrowShapeEvidence.hdivs
+      sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      a b q3Old q2Old q1Old q0Old retMem dMem dloMem scratchUn0 scratchMem raVal
+      hbnz hevidence⟩
+
 theorem N1CallableSelectedIfBorrowShapeEvidence.ofAllTruePathSelectedIfBorrowSemanticEvidence
     (sp base : Word)
     (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)

--- a/EvmAsm/Evm64/DivMod/Spec/N1CallableSelectedIfBorrowShapeEvidence.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N1CallableSelectedIfBorrowShapeEvidence.lean
@@ -226,6 +226,31 @@ theorem N1CallableSelectedIfBorrowShapeEvidence.selectedIfBorrowSemanticEvidence
       (N1CallableSelectedIfBorrowShapeEvidence.selectedPath hevidence))
     (N1CallableSelectedIfBorrowShapeEvidence.semanticFacts hevidence)
 
+/-- Project the named selected-path hdiv package from the bundled N1
+    callable shape evidence. This gives later N1 public-wrapper wiring a single
+    private evidence object from which to recover the quotient-limb witnesses. -/
+theorem N1CallableSelectedIfBorrowShapeEvidence.hdivs
+    (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (a b : EvmWord)
+    (q3Old q2Old q1Old q0Old retMem dMem dloMem scratchUn0 scratchMem raVal : Word)
+    (hbnz : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 ≠ 0)
+    (hevidence : N1CallableSelectedIfBorrowShapeEvidence a b) :
+    FullDivN1CallMaxmaxmaxHdivs a b
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) := by
+  exact FullDivN1CallMaxmaxmaxHdivs_of_selected_if_borrow_semantic_evidence
+    sp base a b
+    jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+    q3Old q2Old q1Old q0Old retMem dMem dloMem scratchUn0 scratchMem raVal
+    rfl rfl rfl rfl rfl rfl rfl rfl hbnz
+    (N1CallableSelectedIfBorrowShapeEvidence.selectedIfBorrowSemanticEvidence
+      sp base jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      a b q3Old q2Old q1Old q0Old retMem dMem dloMem scratchUn0 scratchMem raVal
+      hevidence)
+
 theorem N1CallableSelectedIfBorrowShapeEvidence.ofAllTruePathSelectedIfBorrowSemanticEvidence
     (sp base : Word)
     (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)

--- a/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcher.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcher.lean
@@ -228,6 +228,32 @@ theorem n4ShiftNzDispatcherBranchRuntimeV4.addback {a b : EvmWord}
   rw [n4ShiftNzDispatcherBranchRuntimeV4_def]
   exact Or.inr ⟨hadd, hcarry2, h_bounds⟩
 
+theorem n4ShiftNzDispatcherRuntimeV4.of_parts {a b : EvmWord}
+    (hbranch : n4CallSkipRuntimeBranchV4 a b)
+    (hcarry2 : isAddbackCarry2NzN4CallV4Evm a b)
+    (h_bounds : n4CallAddbackBeqRuntimeBounds a b) :
+    n4ShiftNzDispatcherRuntimeV4 a b := by
+  rw [n4ShiftNzDispatcherRuntimeV4_def]
+  exact ⟨hbranch, hcarry2, h_bounds⟩
+
+theorem n4ShiftNzDispatcherRuntimeV4.callSkipRuntimeBranch {a b : EvmWord}
+    (hruntime : n4ShiftNzDispatcherRuntimeV4 a b) :
+    n4CallSkipRuntimeBranchV4 a b := by
+  rw [n4ShiftNzDispatcherRuntimeV4_def] at hruntime
+  exact hruntime.1
+
+theorem n4ShiftNzDispatcherRuntimeV4.addbackCarry2 {a b : EvmWord}
+    (hruntime : n4ShiftNzDispatcherRuntimeV4 a b) :
+    isAddbackCarry2NzN4CallV4Evm a b := by
+  rw [n4ShiftNzDispatcherRuntimeV4_def] at hruntime
+  exact hruntime.2.1
+
+theorem n4ShiftNzDispatcherRuntimeV4.addbackRuntimeBounds {a b : EvmWord}
+    (hruntime : n4ShiftNzDispatcherRuntimeV4 a b) :
+    n4CallAddbackBeqRuntimeBounds a b := by
+  rw [n4ShiftNzDispatcherRuntimeV4_def] at hruntime
+  exact hruntime.2.2
+
 theorem n4ShiftNzDispatcherRuntimeV4.of_branch_bounds {a b : EvmWord}
     (hevidence : n4ShiftNzDispatcherBranchBoundsV4 a b) :
     n4ShiftNzDispatcherRuntimeV4 a b := by

--- a/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcher.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcher.lean
@@ -205,6 +205,14 @@ theorem n4ShiftNzDispatcherBranchBoundsV4.addbackRuntimeBounds {a b : EvmWord}
   rw [n4ShiftNzDispatcherBranchBoundsV4_def] at hevidence
   exact hevidence.2.2
 
+theorem n4ShiftNzDispatcherBranchBoundsV4.of_parts {a b : EvmWord}
+    (hbranch : n4CallSkipBranchV4 a b)
+    (hcarry2 : isAddbackCarry2NzN4CallV4Evm a b)
+    (h_bounds : n4CallAddbackBeqRuntimeBounds a b) :
+    n4ShiftNzDispatcherBranchBoundsV4 a b := by
+  rw [n4ShiftNzDispatcherBranchBoundsV4_def]
+  exact ⟨hbranch, hcarry2, h_bounds⟩
+
 theorem n4ShiftNzDispatcherBranchBoundsV4.of_runtime_pred {a b : EvmWord}
     (hruntime : n4ShiftNzDispatcherRuntimeV4 a b)
     (hbranch : n4CallSkipBranchV4 a b) :
@@ -276,6 +284,16 @@ theorem n4ShiftNzDispatcherBranchRuntimeV4_of_branch_bounds {a b : EvmWord}
     n4ShiftNzDispatcherBranchRuntimeV4 a b :=
   n4ShiftNzDispatcherBranchRuntimeV4_of_runtime_pred
     (n4ShiftNzDispatcherRuntimeV4.of_branch_bounds hevidence)
+
+theorem n4ShiftNzDispatcherBranchBoundsV4.toRuntimeV4 {a b : EvmWord}
+    (hevidence : n4ShiftNzDispatcherBranchBoundsV4 a b) :
+    n4ShiftNzDispatcherRuntimeV4 a b :=
+  n4ShiftNzDispatcherRuntimeV4.of_branch_bounds hevidence
+
+theorem n4ShiftNzDispatcherBranchBoundsV4.toBranchRuntime {a b : EvmWord}
+    (hevidence : n4ShiftNzDispatcherBranchBoundsV4 a b) :
+    n4ShiftNzDispatcherBranchRuntimeV4 a b :=
+  n4ShiftNzDispatcherBranchRuntimeV4_of_branch_bounds hevidence
 
 theorem n4ShiftNzDispatcherBranchHighDivEvidence.skip {a b : EvmWord}
     (hskip : isSkipBorrowN4CallV4Evm a b)

--- a/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcherBranchBoundsParts.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcherBranchBoundsParts.lean
@@ -1,0 +1,67 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N4V4ShiftNzDispatcherBranchBoundsParts
+
+  Direct branch-bounds evidence-part wrappers for the n=4, shift-nonzero DIV v4 dispatcher.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.N4V4ShiftNzDispatcher
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64 EvmWord
+
+/-- Final named n=4, shift-nonzero DIV dispatcher surface from direct
+    branch/bounds evidence parts. -/
+theorem evm_div_n4_shift_nz_stack_spec_of_branch_bounds_parts
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbranch : n4CallSkipBranchV4 a b)
+    (hcarry2 : isAddbackCarry2NzN4CallV4Evm a b)
+    (h_bounds : n4CallAddbackBeqRuntimeBounds a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_of_branch_bounds
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign
+    (n4ShiftNzDispatcherBranchBoundsV4.of_parts hbranch hcarry2 h_bounds)
+
+/-- Final named no-NOP n=4, shift-nonzero DIV dispatcher surface from direct
+    branch/bounds evidence parts. -/
+theorem evm_div_n4_shift_nz_stack_spec_noNop_of_branch_bounds_parts
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbranch : n4CallSkipBranchV4 a b)
+    (hcarry2 : isAddbackCarry2NzN4CallV4Evm a b)
+    (h_bounds : n4CallAddbackBeqRuntimeBounds a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_noNop_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_noNop_of_branch_bounds
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign
+    (n4ShiftNzDispatcherBranchBoundsV4.of_parts hbranch hcarry2 h_bounds)
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcherHighDivParts.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcherHighDivParts.lean
@@ -154,6 +154,149 @@ theorem evm_div_n4_shift_nz_stack_spec_noNop_of_runtime_high_div_raw_parts
 
 
 /-- Final named n=4, shift-nonzero DIV dispatcher surface from direct
+    branch-predicate packaged high-div evidence parts. -/
+theorem evm_div_n4_shift_nz_stack_spec_of_branch_high_div_parts
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbranch : n4CallSkipBranchV4 a b)
+    (hcarry2 : isAddbackCarry2NzN4CallV4Evm a b)
+    (hevidence : n4CallAddbackBeqShiftHighDivEvidence a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_of_runtime_high_div_parts
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign
+    (n4CallSkipRuntimeBranchV4_of_branch_pred hbranch)
+    hcarry2 hevidence
+
+/-- Final named no-NOP n=4, shift-nonzero DIV dispatcher surface from direct
+    branch-predicate packaged high-div evidence parts. -/
+theorem evm_div_n4_shift_nz_stack_spec_noNop_of_branch_high_div_parts
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbranch : n4CallSkipBranchV4 a b)
+    (hcarry2 : isAddbackCarry2NzN4CallV4Evm a b)
+    (hevidence : n4CallAddbackBeqShiftHighDivEvidence a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_noNop_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_noNop_of_runtime_high_div_parts
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign
+    (n4CallSkipRuntimeBranchV4_of_branch_pred hbranch)
+    hcarry2 hevidence
+
+/-- Final named n=4, shift-nonzero DIV dispatcher surface from direct
+    branch-predicate raw high-div evidence parts. -/
+theorem evm_div_n4_shift_nz_stack_spec_of_branch_high_div_raw_parts
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbranch : n4CallSkipBranchV4 a b)
+    (hcarry2 : isAddbackCarry2NzN4CallV4Evm a b)
+    (h_rhat_hi_zero :
+      divKTrialCallV4Rhatdd
+          (n4CallAddbackBeqU4 a b)
+          (n4CallAddbackBeqU3 a b)
+          (n4CallAddbackBeqB3Prime b) >>> (32 : BitVec 6).toNat =
+        (0 : Word))
+    (h_qhat_le_high_div :
+      (n4CallAddbackBeqQHatV4 a b).toNat ≤
+        ((n4CallAddbackBeqU4 a b).toNat * 2^64 +
+            (n4CallAddbackBeqU3 a b).toNat) /
+          (n4CallAddbackBeqB3Prime b).toNat)
+    (h_high_div_le_norm_plus_one :
+      ((n4CallAddbackBeqU4 a b).toNat * 2^64 +
+          (n4CallAddbackBeqU3 a b).toNat) /
+        (n4CallAddbackBeqB3Prime b).toNat ≤
+          n4CallAddbackBeqULoNormVal a b / n4CallAddbackBeqBNormVal b + 1) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_of_runtime_high_div_raw_parts
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign
+    (n4CallSkipRuntimeBranchV4_of_branch_pred hbranch)
+    hcarry2 h_rhat_hi_zero h_qhat_le_high_div h_high_div_le_norm_plus_one
+
+/-- Final named no-NOP n=4, shift-nonzero DIV dispatcher surface from direct
+    branch-predicate raw high-div evidence parts. -/
+theorem evm_div_n4_shift_nz_stack_spec_noNop_of_branch_high_div_raw_parts
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbranch : n4CallSkipBranchV4 a b)
+    (hcarry2 : isAddbackCarry2NzN4CallV4Evm a b)
+    (h_rhat_hi_zero :
+      divKTrialCallV4Rhatdd
+          (n4CallAddbackBeqU4 a b)
+          (n4CallAddbackBeqU3 a b)
+          (n4CallAddbackBeqB3Prime b) >>> (32 : BitVec 6).toNat =
+        (0 : Word))
+    (h_qhat_le_high_div :
+      (n4CallAddbackBeqQHatV4 a b).toNat ≤
+        ((n4CallAddbackBeqU4 a b).toNat * 2^64 +
+            (n4CallAddbackBeqU3 a b).toNat) /
+          (n4CallAddbackBeqB3Prime b).toNat)
+    (h_high_div_le_norm_plus_one :
+      ((n4CallAddbackBeqU4 a b).toNat * 2^64 +
+          (n4CallAddbackBeqU3 a b).toNat) /
+        (n4CallAddbackBeqB3Prime b).toNat ≤
+          n4CallAddbackBeqULoNormVal a b / n4CallAddbackBeqBNormVal b + 1) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_noNop_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_noNop_of_runtime_high_div_raw_parts
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign
+    (n4CallSkipRuntimeBranchV4_of_branch_pred hbranch)
+    hcarry2 h_rhat_hi_zero h_qhat_le_high_div h_high_div_le_norm_plus_one
+
+
+/-- Final named n=4, shift-nonzero DIV dispatcher surface from direct
     skip-branch high-div evidence. -/
 theorem evm_div_n4_shift_nz_stack_spec_of_high_div_skip_branch
     (sp base : Word)

--- a/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcherRuntimeParts.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcherRuntimeParts.lean
@@ -35,9 +35,8 @@ theorem evm_div_n4_shift_nz_stack_spec_of_runtime_parts
     sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
     hb3nz hshift_nz halign
-    (by
-      rw [n4ShiftNzDispatcherRuntimeV4_def]
-      exact ⟨hbranch, hcarry2, h_bounds⟩)
+    (n4ShiftNzDispatcherRuntimeV4.of_parts
+      hbranch hcarry2 h_bounds)
 
 /-- Final named no-NOP n=4, shift-nonzero DIV dispatcher surface from direct
     global runtime evidence parts. -/
@@ -64,8 +63,7 @@ theorem evm_div_n4_shift_nz_stack_spec_noNop_of_runtime_parts
     sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
     hb3nz hshift_nz halign
-    (by
-      rw [n4ShiftNzDispatcherRuntimeV4_def]
-      exact ⟨hbranch, hcarry2, h_bounds⟩)
+    (n4ShiftNzDispatcherRuntimeV4.of_parts
+      hbranch hcarry2 h_bounds)
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcherSemanticParts.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcherSemanticParts.lean
@@ -147,4 +147,111 @@ theorem n4ShiftNzDispatcherBranchHighDivRawEvidence.semanticHolds_of_addback_par
       hb3nz hshift_nz hadd hcarry2 h_rhat_hi_zero
       h_qhat_le_high_div h_high_div_le_norm_plus_one
 
+
+/-- n=4 shift-nonzero DIV dispatcher surface consuming the repaired V4 addback
+    semantic marker directly. -/
+theorem evm_div_n4_shift_nz_stack_spec_v4_of_branch_pred_semanticV4
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbranch : n4CallSkipBranchV4 a b)
+    (hcarry2 : isAddbackCarry2NzN4CallV4Evm a b)
+    (hsemV4 : n4CallAddbackBeqSemanticHoldsV4 a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_v4_of_branch_pred
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign hbranch hcarry2
+    (n4CallAddbackBeqSemanticHolds_of_v4 hsemV4)
+
+/-- No-NOP n=4 shift-nonzero DIV dispatcher surface consuming the repaired V4
+    addback semantic marker directly. -/
+theorem evm_div_n4_shift_nz_stack_spec_v4_noNop_of_branch_pred_semanticV4
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbranch : n4CallSkipBranchV4 a b)
+    (hcarry2 : isAddbackCarry2NzN4CallV4Evm a b)
+    (hsemV4 : n4CallAddbackBeqSemanticHoldsV4 a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_noNop_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_v4_noNop_of_branch_pred
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign hbranch hcarry2
+    (n4CallAddbackBeqSemanticHolds_of_v4 hsemV4)
+
+/-- Historical alias for the V4-semantic n=4 shift-nonzero DIV dispatcher
+    surface. -/
+theorem evm_div_n4_shift_nz_stack_spec_of_branch_pred_semanticV4
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbranch : n4CallSkipBranchV4 a b)
+    (hcarry2 : isAddbackCarry2NzN4CallV4Evm a b)
+    (hsemV4 : n4CallAddbackBeqSemanticHoldsV4 a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_v4_of_branch_pred_semanticV4
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign hbranch hcarry2 hsemV4
+
+/-- Historical no-NOP alias for the V4-semantic n=4 shift-nonzero DIV
+    dispatcher surface. -/
+theorem evm_div_n4_shift_nz_stack_spec_noNop_of_branch_pred_semanticV4
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbranch : n4CallSkipBranchV4 a b)
+    (hcarry2 : isAddbackCarry2NzN4CallV4Evm a b)
+    (hsemV4 : n4CallAddbackBeqSemanticHoldsV4 a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_noNop_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_v4_noNop_of_branch_pred_semanticV4
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign hbranch hcarry2 hsemV4
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcherSemanticParts.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcherSemanticParts.lean
@@ -333,6 +333,119 @@ theorem evm_div_n4_shift_nz_stack_spec_noNop_of_runtime_parts_semanticV4
     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
     hb3nz hshift_nz halign hbranch hcarry2 hsemV4
 
+/-- Addback-branch n=4 shift-nonzero DIV dispatcher surface consuming the
+    repaired V4 addback semantic marker directly. This branch-local wrapper does
+    not require skip-branch evidence or the compact runtime-bounds package. -/
+theorem evm_div_n4_shift_nz_stack_spec_v4_of_branch_addback_semanticV4
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hadd : isAddbackBorrowN4CallV4Evm a b)
+    (hcarry2 : isAddbackCarry2NzN4CallV4Evm a b)
+    (hsemV4 : n4CallAddbackBeqSemanticHoldsV4 a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_call_addback_beq_stack_spec
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    (evmWord_ne_zero_of_getLimbN_3_ne_zero hb3nz)
+    hb3nz hshift_nz halign
+    (isCallTrialN4Evm_of_shift_nz a b hb3nz hshift_nz)
+    hadd hcarry2
+    (n4CallAddbackBeqSemanticHolds_of_v4 hsemV4)
+
+/-- No-NOP addback-branch n=4 shift-nonzero DIV dispatcher surface consuming
+    the repaired V4 addback semantic marker directly. -/
+theorem evm_div_n4_shift_nz_stack_spec_v4_noNop_of_branch_addback_semanticV4
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hadd : isAddbackBorrowN4CallV4Evm a b)
+    (hcarry2 : isAddbackCarry2NzN4CallV4Evm a b)
+    (hsemV4 : n4CallAddbackBeqSemanticHoldsV4 a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_noNop_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_call_addback_beq_stack_spec_noNop
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    (evmWord_ne_zero_of_getLimbN_3_ne_zero hb3nz)
+    hb3nz hshift_nz halign
+    (isCallTrialN4Evm_of_shift_nz a b hb3nz hshift_nz)
+    hadd hcarry2
+    (n4CallAddbackBeqSemanticHolds_of_v4 hsemV4)
+
+/-- Historical alias for the V4-semantic addback-branch n=4 shift-nonzero DIV
+    dispatcher surface. -/
+theorem evm_div_n4_shift_nz_stack_spec_of_branch_addback_semanticV4
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hadd : isAddbackBorrowN4CallV4Evm a b)
+    (hcarry2 : isAddbackCarry2NzN4CallV4Evm a b)
+    (hsemV4 : n4CallAddbackBeqSemanticHoldsV4 a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_v4_of_branch_addback_semanticV4
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign hadd hcarry2 hsemV4
+
+/-- Historical no-NOP alias for the V4-semantic addback-branch n=4
+    shift-nonzero DIV dispatcher surface. -/
+theorem evm_div_n4_shift_nz_stack_spec_noNop_of_branch_addback_semanticV4
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hadd : isAddbackBorrowN4CallV4Evm a b)
+    (hcarry2 : isAddbackCarry2NzN4CallV4Evm a b)
+    (hsemV4 : n4CallAddbackBeqSemanticHoldsV4 a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_noNop_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_v4_noNop_of_branch_addback_semanticV4
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign hadd hcarry2 hsemV4
+
 /-- Historical alias for the V4-semantic n=4 shift-nonzero DIV dispatcher
     surface. -/
 theorem evm_div_n4_shift_nz_stack_spec_of_branch_pred_semanticV4

--- a/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcherSemanticParts.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcherSemanticParts.lean
@@ -1,0 +1,150 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N4V4ShiftNzDispatcherSemanticParts
+
+  Addback semantic projections for the n=4, shift-nonzero DIV v4 dispatcher.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.N4V4ShiftNzDispatcher
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64 EvmWord
+
+/-- Addback semantic bridge from packaged n=4 shift-nonzero runtime evidence. -/
+theorem n4ShiftNzDispatcherRuntimeV4.semanticHoldsV4 {a b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (hruntime : n4ShiftNzDispatcherRuntimeV4 a b)
+    (hadd : isAddbackBorrowN4CallV4Evm a b) :
+    n4CallAddbackBeqSemanticHoldsV4 a b :=
+  n4CallAddbackBeqSemanticHoldsV4_of_runtime_bounds
+    hb3nz hshift_nz
+    (n4ShiftNzDispatcherRuntimeV4.addbackRuntimeBounds hruntime)
+    hadd
+    (n4ShiftNzDispatcherRuntimeV4.addbackCarry2 hruntime)
+
+/-- Historical non-V4 semantic bridge from packaged n=4 shift-nonzero runtime
+    evidence. -/
+theorem n4ShiftNzDispatcherRuntimeV4.semanticHolds {a b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (hruntime : n4ShiftNzDispatcherRuntimeV4 a b)
+    (hadd : isAddbackBorrowN4CallV4Evm a b) :
+    n4CallAddbackBeqSemanticHolds a b := by
+  simpa [n4CallAddbackBeqSemanticHolds_eq_v4] using
+    n4ShiftNzDispatcherRuntimeV4.semanticHoldsV4
+      hb3nz hshift_nz hruntime hadd
+
+/-- Addback semantic bridge from branch/bounds n=4 shift-nonzero dispatcher
+    evidence. -/
+theorem n4ShiftNzDispatcherBranchBoundsV4.semanticHoldsV4 {a b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (hevidence : n4ShiftNzDispatcherBranchBoundsV4 a b)
+    (hadd : isAddbackBorrowN4CallV4Evm a b) :
+    n4CallAddbackBeqSemanticHoldsV4 a b :=
+  n4CallAddbackBeqSemanticHoldsV4_of_runtime_bounds
+    hb3nz hshift_nz
+    (n4ShiftNzDispatcherBranchBoundsV4.addbackRuntimeBounds hevidence)
+    hadd
+    (n4ShiftNzDispatcherBranchBoundsV4.addbackCarry2 hevidence)
+
+/-- Historical non-V4 addback semantic bridge from branch/bounds n=4
+    shift-nonzero dispatcher evidence. -/
+theorem n4ShiftNzDispatcherBranchBoundsV4.semanticHolds {a b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (hevidence : n4ShiftNzDispatcherBranchBoundsV4 a b)
+    (hadd : isAddbackBorrowN4CallV4Evm a b) :
+    n4CallAddbackBeqSemanticHolds a b := by
+  simpa [n4CallAddbackBeqSemanticHolds_eq_v4] using
+    n4ShiftNzDispatcherBranchBoundsV4.semanticHoldsV4
+      hb3nz hshift_nz hevidence hadd
+
+/-- Addback semantic bridge from direct packaged high-div evidence parts at the
+    n=4 shift-nonzero dispatcher surface. -/
+theorem n4ShiftNzDispatcherBranchHighDivEvidence.semanticHoldsV4_of_addback_parts
+    {a b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (hadd : isAddbackBorrowN4CallV4Evm a b)
+    (hcarry2 : isAddbackCarry2NzN4CallV4Evm a b)
+    (hevidence : n4CallAddbackBeqShiftHighDivEvidence a b) :
+    n4CallAddbackBeqSemanticHoldsV4 a b :=
+  n4CallAddbackBeqSemanticHoldsV4_of_shift_high_div_evidence_and_borrow
+    hb3nz hshift_nz hevidence hadd hcarry2
+
+/-- Historical non-V4 addback semantic bridge from direct packaged high-div
+    evidence parts at the n=4 shift-nonzero dispatcher surface. -/
+theorem n4ShiftNzDispatcherBranchHighDivEvidence.semanticHolds_of_addback_parts
+    {a b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (hadd : isAddbackBorrowN4CallV4Evm a b)
+    (hcarry2 : isAddbackCarry2NzN4CallV4Evm a b)
+    (hevidence : n4CallAddbackBeqShiftHighDivEvidence a b) :
+    n4CallAddbackBeqSemanticHolds a b := by
+  simpa [n4CallAddbackBeqSemanticHolds_eq_v4] using
+    n4ShiftNzDispatcherBranchHighDivEvidence.semanticHoldsV4_of_addback_parts
+      hb3nz hshift_nz hadd hcarry2 hevidence
+
+/-- Addback semantic bridge from direct raw high-div evidence parts at the n=4
+    shift-nonzero dispatcher surface. -/
+theorem n4ShiftNzDispatcherBranchHighDivRawEvidence.semanticHoldsV4_of_addback_parts
+    {a b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (hadd : isAddbackBorrowN4CallV4Evm a b)
+    (hcarry2 : isAddbackCarry2NzN4CallV4Evm a b)
+    (h_rhat_hi_zero :
+      divKTrialCallV4Rhatdd
+          (n4CallAddbackBeqU4 a b)
+          (n4CallAddbackBeqU3 a b)
+          (n4CallAddbackBeqB3Prime b) >>> (32 : BitVec 6).toNat =
+        (0 : Word))
+    (h_qhat_le_high_div :
+      (n4CallAddbackBeqQHatV4 a b).toNat ≤
+        ((n4CallAddbackBeqU4 a b).toNat * 2^64 +
+            (n4CallAddbackBeqU3 a b).toNat) /
+          (n4CallAddbackBeqB3Prime b).toNat)
+    (h_high_div_le_norm_plus_one :
+      ((n4CallAddbackBeqU4 a b).toNat * 2^64 +
+          (n4CallAddbackBeqU3 a b).toNat) /
+        (n4CallAddbackBeqB3Prime b).toNat ≤
+          n4CallAddbackBeqULoNormVal a b / n4CallAddbackBeqBNormVal b + 1) :
+    n4CallAddbackBeqSemanticHoldsV4 a b :=
+  n4CallAddbackBeqSemanticHoldsV4_of_shift_high_div_raw_parts_and_borrow
+    hb3nz hshift_nz h_rhat_hi_zero h_qhat_le_high_div
+    h_high_div_le_norm_plus_one hadd hcarry2
+
+/-- Historical non-V4 addback semantic bridge from direct raw high-div evidence
+    parts at the n=4 shift-nonzero dispatcher surface. -/
+theorem n4ShiftNzDispatcherBranchHighDivRawEvidence.semanticHolds_of_addback_parts
+    {a b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (hadd : isAddbackBorrowN4CallV4Evm a b)
+    (hcarry2 : isAddbackCarry2NzN4CallV4Evm a b)
+    (h_rhat_hi_zero :
+      divKTrialCallV4Rhatdd
+          (n4CallAddbackBeqU4 a b)
+          (n4CallAddbackBeqU3 a b)
+          (n4CallAddbackBeqB3Prime b) >>> (32 : BitVec 6).toNat =
+        (0 : Word))
+    (h_qhat_le_high_div :
+      (n4CallAddbackBeqQHatV4 a b).toNat ≤
+        ((n4CallAddbackBeqU4 a b).toNat * 2^64 +
+            (n4CallAddbackBeqU3 a b).toNat) /
+          (n4CallAddbackBeqB3Prime b).toNat)
+    (h_high_div_le_norm_plus_one :
+      ((n4CallAddbackBeqU4 a b).toNat * 2^64 +
+          (n4CallAddbackBeqU3 a b).toNat) /
+        (n4CallAddbackBeqB3Prime b).toNat ≤
+          n4CallAddbackBeqULoNormVal a b / n4CallAddbackBeqBNormVal b + 1) :
+    n4CallAddbackBeqSemanticHolds a b := by
+  simpa [n4CallAddbackBeqSemanticHolds_eq_v4] using
+    n4ShiftNzDispatcherBranchHighDivRawEvidence.semanticHoldsV4_of_addback_parts
+      hb3nz hshift_nz hadd hcarry2 h_rhat_hi_zero
+      h_qhat_le_high_div h_high_div_le_norm_plus_one
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcherSemanticParts.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcherSemanticParts.lean
@@ -202,6 +202,137 @@ theorem evm_div_n4_shift_nz_stack_spec_v4_noNop_of_branch_pred_semanticV4
     hb3nz hshift_nz halign hbranch hcarry2
     (n4CallAddbackBeqSemanticHolds_of_v4 hsemV4)
 
+/-- n=4 shift-nonzero DIV dispatcher surface consuming direct runtime
+    branch evidence, addback carry evidence, and the repaired V4 addback semantic
+    marker. This is the stack-facing target for the final runtime-only semantic
+    discharger, without routing through the compact runtime-bounds package. -/
+theorem evm_div_n4_shift_nz_stack_spec_v4_of_runtime_parts_semanticV4
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbranch : n4CallSkipRuntimeBranchV4 a b)
+    (hcarry2 : isAddbackCarry2NzN4CallV4Evm a b)
+    (hsemV4 : n4CallAddbackBeqSemanticHoldsV4 a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) := by
+  have hbnz : b ≠ 0 := evmWord_ne_zero_of_getLimbN_3_ne_zero hb3nz
+  have hbltu : isCallTrialN4Evm a b :=
+    isCallTrialN4Evm_of_shift_nz a b hb3nz hshift_nz
+  cases isSkipBorrowN4CallV4Evm_or_isAddbackBorrowN4CallV4Evm a b with
+  | inl hskip =>
+      exact cpsTripleWithin_mono_nSteps (by decide)
+        (evm_div_n4_call_skip_stack_spec_v4_of_runtime_branch_pred_hb3nz
+          sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+          hb3nz hshift_nz halign hskip hbranch)
+  | inr hadd =>
+      exact evm_div_n4_call_addback_beq_stack_spec
+        sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+        hbnz hb3nz hshift_nz halign hbltu hadd hcarry2
+        (n4CallAddbackBeqSemanticHolds_of_v4 hsemV4)
+
+/-- No-NOP n=4 shift-nonzero DIV dispatcher surface consuming direct runtime
+    branch evidence, addback carry evidence, and the repaired V4 addback semantic
+    marker. -/
+theorem evm_div_n4_shift_nz_stack_spec_v4_noNop_of_runtime_parts_semanticV4
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbranch : n4CallSkipRuntimeBranchV4 a b)
+    (hcarry2 : isAddbackCarry2NzN4CallV4Evm a b)
+    (hsemV4 : n4CallAddbackBeqSemanticHoldsV4 a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_noNop_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) := by
+  have hbnz : b ≠ 0 := evmWord_ne_zero_of_getLimbN_3_ne_zero hb3nz
+  have hbltu : isCallTrialN4Evm a b :=
+    isCallTrialN4Evm_of_shift_nz a b hb3nz hshift_nz
+  cases isSkipBorrowN4CallV4Evm_or_isAddbackBorrowN4CallV4Evm a b with
+  | inl hskip =>
+      exact cpsTripleWithin_mono_nSteps (by decide)
+        (evm_div_n4_call_skip_stack_spec_v4_noNop_of_runtime_branch_pred_hb3nz
+          sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+          hb3nz hshift_nz halign hskip hbranch)
+  | inr hadd =>
+      exact evm_div_n4_call_addback_beq_stack_spec_noNop
+        sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+        hbnz hb3nz hshift_nz halign hbltu hadd hcarry2
+        (n4CallAddbackBeqSemanticHolds_of_v4 hsemV4)
+
+/-- Historical alias for the V4-semantic runtime-parts n=4 shift-nonzero
+    DIV dispatcher surface. -/
+theorem evm_div_n4_shift_nz_stack_spec_of_runtime_parts_semanticV4
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbranch : n4CallSkipRuntimeBranchV4 a b)
+    (hcarry2 : isAddbackCarry2NzN4CallV4Evm a b)
+    (hsemV4 : n4CallAddbackBeqSemanticHoldsV4 a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_v4_of_runtime_parts_semanticV4
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign hbranch hcarry2 hsemV4
+
+/-- Historical no-NOP alias for the V4-semantic runtime-parts n=4
+    shift-nonzero DIV dispatcher surface. -/
+theorem evm_div_n4_shift_nz_stack_spec_noNop_of_runtime_parts_semanticV4
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbranch : n4CallSkipRuntimeBranchV4 a b)
+    (hcarry2 : isAddbackCarry2NzN4CallV4Evm a b)
+    (hsemV4 : n4CallAddbackBeqSemanticHoldsV4 a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_noNop_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_v4_noNop_of_runtime_parts_semanticV4
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign hbranch hcarry2 hsemV4
+
 /-- Historical alias for the V4-semantic n=4 shift-nonzero DIV dispatcher
     surface. -/
 theorem evm_div_n4_shift_nz_stack_spec_of_branch_pred_semanticV4

--- a/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcherSemanticParts.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcherSemanticParts.lean
@@ -636,5 +636,142 @@ theorem evm_div_n4_shift_nz_stack_spec_noNop_of_branch_semantic
     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
     hb3nz hshift_nz halign hevidence
 
+/-- Packaged high-div branch evidence lowers to branch-semantic dispatcher
+    evidence by deriving the repaired V4 semantic marker on the addback side. -/
+theorem n4ShiftNzDispatcherBranchHighDivEvidence.toBranchSemanticV4 {a b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (hevidence : n4ShiftNzDispatcherBranchHighDivEvidence a b) :
+    n4ShiftNzDispatcherBranchSemanticV4 a b := by
+  rw [n4ShiftNzDispatcherBranchHighDivEvidence_def] at hevidence
+  cases hevidence with
+  | inl hskip =>
+      exact n4ShiftNzDispatcherBranchSemanticV4.skip hskip.1 hskip.2
+  | inr hadd =>
+      exact n4ShiftNzDispatcherBranchSemanticV4.addback hadd.1 hadd.2.1
+        (n4ShiftNzDispatcherBranchHighDivEvidence.semanticHoldsV4_of_addback_parts
+          hb3nz hshift_nz hadd.1 hadd.2.1 hadd.2.2)
+
+/-- Raw high-div branch evidence lowers to branch-semantic dispatcher evidence by
+    deriving the repaired V4 semantic marker on the addback side. -/
+theorem n4ShiftNzDispatcherBranchHighDivRawEvidence.toBranchSemanticV4 {a b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (hevidence : n4ShiftNzDispatcherBranchHighDivRawEvidence a b) :
+    n4ShiftNzDispatcherBranchSemanticV4 a b := by
+  rw [n4ShiftNzDispatcherBranchHighDivRawEvidence_def] at hevidence
+  cases hevidence with
+  | inl hskip =>
+      exact n4ShiftNzDispatcherBranchSemanticV4.skip hskip.1 hskip.2
+  | inr hadd =>
+      exact n4ShiftNzDispatcherBranchSemanticV4.addback hadd.1 hadd.2.1
+        (n4ShiftNzDispatcherBranchHighDivRawEvidence.semanticHoldsV4_of_addback_parts
+          hb3nz hshift_nz hadd.1 hadd.2.1 hadd.2.2.1 hadd.2.2.2.1
+          hadd.2.2.2.2)
+
+/-- Packaged high-div branch evidence stack surface routed through the repaired
+    branch-semantic dispatcher package. -/
+theorem evm_div_n4_shift_nz_stack_spec_v4_of_branch_high_div_semantic
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hevidence : n4ShiftNzDispatcherBranchHighDivEvidence a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_v4_of_branch_semantic
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign
+    (n4ShiftNzDispatcherBranchHighDivEvidence.toBranchSemanticV4
+      hb3nz hshift_nz hevidence)
+
+/-- No-NOP packaged high-div branch evidence stack surface routed through the
+    repaired branch-semantic dispatcher package. -/
+theorem evm_div_n4_shift_nz_stack_spec_v4_noNop_of_branch_high_div_semantic
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hevidence : n4ShiftNzDispatcherBranchHighDivEvidence a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_noNop_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_v4_noNop_of_branch_semantic
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign
+    (n4ShiftNzDispatcherBranchHighDivEvidence.toBranchSemanticV4
+      hb3nz hshift_nz hevidence)
+
+/-- Raw high-div branch evidence stack surface routed through the repaired
+    branch-semantic dispatcher package. -/
+theorem evm_div_n4_shift_nz_stack_spec_v4_of_branch_high_div_raw_semantic
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hevidence : n4ShiftNzDispatcherBranchHighDivRawEvidence a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_v4_of_branch_semantic
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign
+    (n4ShiftNzDispatcherBranchHighDivRawEvidence.toBranchSemanticV4
+      hb3nz hshift_nz hevidence)
+
+/-- No-NOP raw high-div branch evidence stack surface routed through the repaired
+    branch-semantic dispatcher package. -/
+theorem evm_div_n4_shift_nz_stack_spec_v4_noNop_of_branch_high_div_raw_semantic
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hevidence : n4ShiftNzDispatcherBranchHighDivRawEvidence a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_noNop_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_v4_noNop_of_branch_semantic
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign
+    (n4ShiftNzDispatcherBranchHighDivRawEvidence.toBranchSemanticV4
+      hb3nz hshift_nz hevidence)
+
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcherSemanticParts.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcherSemanticParts.lean
@@ -774,4 +774,131 @@ theorem evm_div_n4_shift_nz_stack_spec_v4_noNop_of_branch_high_div_raw_semantic
       hb3nz hshift_nz hevidence)
 
 
+/-- Packaged runtime high-div evidence lowers to branch-semantic dispatcher
+    evidence through its branch high-div projection. -/
+theorem n4ShiftNzDispatcherRuntimeHighDivEvidence.toBranchSemanticV4 {a b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (hruntime : n4ShiftNzDispatcherRuntimeHighDivEvidence a b) :
+    n4ShiftNzDispatcherBranchSemanticV4 a b :=
+  n4ShiftNzDispatcherBranchHighDivEvidence.toBranchSemanticV4
+    hb3nz hshift_nz
+    (n4ShiftNzDispatcherRuntimeHighDivEvidence.toBranchHighDivEvidence hruntime)
+
+/-- Raw runtime high-div evidence lowers to branch-semantic dispatcher evidence
+    through its raw branch high-div projection. -/
+theorem n4ShiftNzDispatcherRuntimeHighDivRawEvidence.toBranchSemanticV4 {a b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (hruntime : n4ShiftNzDispatcherRuntimeHighDivRawEvidence a b) :
+    n4ShiftNzDispatcherBranchSemanticV4 a b :=
+  n4ShiftNzDispatcherBranchHighDivRawEvidence.toBranchSemanticV4
+    hb3nz hshift_nz
+    (n4ShiftNzDispatcherRuntimeHighDivRawEvidence.toBranchHighDivRawEvidence hruntime)
+
+/-- Packaged runtime high-div evidence stack surface routed through the repaired
+    branch-semantic dispatcher package. -/
+theorem evm_div_n4_shift_nz_stack_spec_v4_of_runtime_high_div_semantic
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hruntime : n4ShiftNzDispatcherRuntimeHighDivEvidence a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_v4_of_branch_semantic
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign
+    (n4ShiftNzDispatcherRuntimeHighDivEvidence.toBranchSemanticV4
+      hb3nz hshift_nz hruntime)
+
+/-- No-NOP packaged runtime high-div evidence stack surface routed through the
+    repaired branch-semantic dispatcher package. -/
+theorem evm_div_n4_shift_nz_stack_spec_v4_noNop_of_runtime_high_div_semantic
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hruntime : n4ShiftNzDispatcherRuntimeHighDivEvidence a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_noNop_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_v4_noNop_of_branch_semantic
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign
+    (n4ShiftNzDispatcherRuntimeHighDivEvidence.toBranchSemanticV4
+      hb3nz hshift_nz hruntime)
+
+/-- Raw runtime high-div evidence stack surface routed through the repaired
+    branch-semantic dispatcher package. -/
+theorem evm_div_n4_shift_nz_stack_spec_v4_of_runtime_high_div_raw_semantic
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hruntime : n4ShiftNzDispatcherRuntimeHighDivRawEvidence a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_v4_of_branch_semantic
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign
+    (n4ShiftNzDispatcherRuntimeHighDivRawEvidence.toBranchSemanticV4
+      hb3nz hshift_nz hruntime)
+
+/-- No-NOP raw runtime high-div evidence stack surface routed through the repaired
+    branch-semantic dispatcher package. -/
+theorem evm_div_n4_shift_nz_stack_spec_v4_noNop_of_runtime_high_div_raw_semantic
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hruntime : n4ShiftNzDispatcherRuntimeHighDivRawEvidence a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_noNop_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_v4_noNop_of_branch_semantic
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign
+    (n4ShiftNzDispatcherRuntimeHighDivRawEvidence.toBranchSemanticV4
+      hb3nz hshift_nz hruntime)
+
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcherSemanticParts.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcherSemanticParts.lean
@@ -901,4 +901,189 @@ theorem evm_div_n4_shift_nz_stack_spec_v4_noNop_of_runtime_high_div_raw_semantic
       hb3nz hshift_nz hruntime)
 
 
+/-- Historical alias for the packaged high-div branch evidence stack surface. -/
+theorem evm_div_n4_shift_nz_stack_spec_of_branch_high_div_semantic
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hevidence : n4ShiftNzDispatcherBranchHighDivEvidence a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_v4_of_branch_high_div_semantic
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign hevidence
+
+/-- Historical no-NOP alias for the packaged high-div branch evidence stack surface. -/
+theorem evm_div_n4_shift_nz_stack_spec_noNop_of_branch_high_div_semantic
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hevidence : n4ShiftNzDispatcherBranchHighDivEvidence a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_noNop_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_v4_noNop_of_branch_high_div_semantic
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign hevidence
+
+/-- Historical alias for the raw high-div branch evidence stack surface. -/
+theorem evm_div_n4_shift_nz_stack_spec_of_branch_high_div_raw_semantic
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hevidence : n4ShiftNzDispatcherBranchHighDivRawEvidence a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_v4_of_branch_high_div_raw_semantic
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign hevidence
+
+/-- Historical no-NOP alias for the raw high-div branch evidence stack surface. -/
+theorem evm_div_n4_shift_nz_stack_spec_noNop_of_branch_high_div_raw_semantic
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hevidence : n4ShiftNzDispatcherBranchHighDivRawEvidence a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_noNop_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_v4_noNop_of_branch_high_div_raw_semantic
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign hevidence
+
+/-- Historical alias for the packaged runtime high-div evidence stack surface. -/
+theorem evm_div_n4_shift_nz_stack_spec_of_runtime_high_div_semantic
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hruntime : n4ShiftNzDispatcherRuntimeHighDivEvidence a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_v4_of_runtime_high_div_semantic
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign hruntime
+
+/-- Historical no-NOP alias for the packaged runtime high-div evidence stack surface. -/
+theorem evm_div_n4_shift_nz_stack_spec_noNop_of_runtime_high_div_semantic
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hruntime : n4ShiftNzDispatcherRuntimeHighDivEvidence a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_noNop_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_v4_noNop_of_runtime_high_div_semantic
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign hruntime
+
+/-- Historical alias for the raw runtime high-div evidence stack surface. -/
+theorem evm_div_n4_shift_nz_stack_spec_of_runtime_high_div_raw_semantic
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hruntime : n4ShiftNzDispatcherRuntimeHighDivRawEvidence a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_v4_of_runtime_high_div_raw_semantic
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign hruntime
+
+/-- Historical no-NOP alias for the raw runtime high-div evidence stack surface. -/
+theorem evm_div_n4_shift_nz_stack_spec_noNop_of_runtime_high_div_raw_semantic
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hruntime : n4ShiftNzDispatcherRuntimeHighDivRawEvidence a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_noNop_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_v4_noNop_of_runtime_high_div_raw_semantic
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign hruntime
+
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcherSemanticParts.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcherSemanticParts.lean
@@ -10,6 +10,30 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64 EvmWord
 
+/-- Branch-sensitive n=4 shift-nonzero dispatcher evidence whose addback branch
+    carries the repaired V4 semantic marker instead of the compact runtime-bounds
+    package. -/
+def n4ShiftNzDispatcherBranchSemanticV4 (a b : EvmWord) : Prop :=
+  (isSkipBorrowN4CallV4Evm a b ∧ n4CallSkipRuntimeBranchV4 a b) ∨
+    (isAddbackBorrowN4CallV4Evm a b ∧
+      isAddbackCarry2NzN4CallV4Evm a b ∧
+      n4CallAddbackBeqSemanticHoldsV4 a b)
+
+theorem n4ShiftNzDispatcherBranchSemanticV4.skip {a b : EvmWord}
+    (hskip : isSkipBorrowN4CallV4Evm a b)
+    (hbranch : n4CallSkipRuntimeBranchV4 a b) :
+    n4ShiftNzDispatcherBranchSemanticV4 a b := by
+  rw [n4ShiftNzDispatcherBranchSemanticV4]
+  exact Or.inl ⟨hskip, hbranch⟩
+
+theorem n4ShiftNzDispatcherBranchSemanticV4.addback {a b : EvmWord}
+    (hadd : isAddbackBorrowN4CallV4Evm a b)
+    (hcarry2 : isAddbackCarry2NzN4CallV4Evm a b)
+    (hsemV4 : n4CallAddbackBeqSemanticHoldsV4 a b) :
+    n4ShiftNzDispatcherBranchSemanticV4 a b := by
+  rw [n4ShiftNzDispatcherBranchSemanticV4]
+  exact Or.inr ⟨hadd, hcarry2, hsemV4⟩
+
 /-- Addback semantic bridge from packaged n=4 shift-nonzero runtime evidence. -/
 theorem n4ShiftNzDispatcherRuntimeV4.semanticHoldsV4 {a b : EvmWord}
     (hb3nz : b.getLimbN 3 ≠ 0)
@@ -497,5 +521,120 @@ theorem evm_div_n4_shift_nz_stack_spec_noNop_of_branch_pred_semanticV4
     sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
     hb3nz hshift_nz halign hbranch hcarry2 hsemV4
+
+/-- Packaged branch-sensitive n=4 shift-nonzero DIV dispatcher surface whose
+    addback branch consumes the repaired V4 semantic marker. -/
+theorem evm_div_n4_shift_nz_stack_spec_v4_of_branch_semantic
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hevidence : n4ShiftNzDispatcherBranchSemanticV4 a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) := by
+  rw [n4ShiftNzDispatcherBranchSemanticV4] at hevidence
+  cases hevidence with
+  | inl hskip =>
+      exact cpsTripleWithin_mono_nSteps (by decide)
+        (evm_div_n4_call_skip_stack_spec_v4_of_runtime_branch_pred_hb3nz
+          sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+          hb3nz hshift_nz halign hskip.1 hskip.2)
+  | inr hadd =>
+      exact evm_div_n4_shift_nz_stack_spec_v4_of_branch_addback_semanticV4
+        sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+        hb3nz hshift_nz halign hadd.1 hadd.2.1 hadd.2.2
+
+/-- No-NOP packaged branch-sensitive n=4 shift-nonzero DIV dispatcher surface
+    whose addback branch consumes the repaired V4 semantic marker. -/
+theorem evm_div_n4_shift_nz_stack_spec_v4_noNop_of_branch_semantic
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hevidence : n4ShiftNzDispatcherBranchSemanticV4 a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_noNop_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) := by
+  rw [n4ShiftNzDispatcherBranchSemanticV4] at hevidence
+  cases hevidence with
+  | inl hskip =>
+      exact cpsTripleWithin_mono_nSteps (by decide)
+        (evm_div_n4_call_skip_stack_spec_v4_noNop_of_runtime_branch_pred_hb3nz
+          sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+          nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+          hb3nz hshift_nz halign hskip.1 hskip.2)
+  | inr hadd =>
+      exact evm_div_n4_shift_nz_stack_spec_v4_noNop_of_branch_addback_semanticV4
+        sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+        hb3nz hshift_nz halign hadd.1 hadd.2.1 hadd.2.2
+
+/-- Historical alias for the packaged branch-sensitive V4-semantic n=4
+    shift-nonzero DIV dispatcher surface. -/
+theorem evm_div_n4_shift_nz_stack_spec_of_branch_semantic
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hevidence : n4ShiftNzDispatcherBranchSemanticV4 a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_v4_of_branch_semantic
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign hevidence
+
+/-- Historical no-NOP alias for the packaged branch-sensitive V4-semantic n=4
+    shift-nonzero DIV dispatcher surface. -/
+theorem evm_div_n4_shift_nz_stack_spec_noNop_of_branch_semantic
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hevidence : n4ShiftNzDispatcherBranchSemanticV4 a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_noNop_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_v4_noNop_of_branch_semantic
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign hevidence
+
 
 end EvmAsm.Evm64

--- a/scripts/codegen-stateless-spec-output-check.sh
+++ b/scripts/codegen-stateless-spec-output-check.sh
@@ -402,6 +402,20 @@ run_fixture "chain1_witheaders"     1                  0    ""           ""     
 # under maximum-witness-headers byte-budget.
 run_fixture "chain1_witheaders_2"   1                  0    ""           ""                  ""    ""           ""           ""    "$(printf 'aa%.0s' {1..32}):$(printf 'bb%.0s' {1..32})" || fail=1
 
+# Kitchen-sink fixture -- every input slot populated
+# simultaneously. All three inner witness fields (state +
+# codes + headers) carry one entry each; public_keys has one
+# 65-byte entry; chain_config.active_fork has bn=[N] +
+# ts=[T] + blob=[entry] = MAX active_fork (64 bytes). Spec
+# emits 113 bytes (the maximum-shape SszForkConfig echo).
+# Stress test for the bounded byte-copy under maximum input
+# byte-budget (witness ~68 bytes + chain_config 76 bytes +
+# pk 65 bytes + npr 596 bytes), validating that the
+# decoder's outer-offset chase and the encoder's bounded
+# loop work together at the upper end of every variable
+# dimension simultaneously.
+run_fixture "chain1_kitchen_sink"   1                  0    "deadbeef"   "a1b2c3d4e5f60718"  "04$(printf '%064d' 0)$(printf '%064d' 0)"    "5555555555" "6666666666" "1000:2000:3000"    "$(printf 'aa%.0s' {1..32})" || fail=1
+
 if [[ "$fail" -eq 0 ]]; then
   echo "==> PASS: all spec-output fixtures match the new SSZ schema"
   exit 0

--- a/scripts/codegen-stateless-spec-output-check.sh
+++ b/scripts/codegen-stateless-spec-output-check.sh
@@ -363,6 +363,15 @@ run_fixture "chain1_act_blob_all"   1                  0    ""           ""     
 # chain_config_end, never reaching the unmapped page.
 run_fixture "chain1_witcode_actbn_unbounded" 1   0    "deadbeef"   ""                  ""    "1234567890" || fail=1
 
+# Stronger stress for the bounded byte-copy: BOTH witness
+# fields populated AND non-empty block_number, no PK padding.
+# Under the old unrolled encoder, chain_config_end lands close
+# enough to ziskemu's input-region boundary that the trailing
+# unconditional LBUs at chain_config + 28..76 panic with
+# "section not found". The bounded loop in PR #6843 stops at
+# chain_config_end so the combination passes.
+run_fixture "chain1_witboth_actbn_unbounded" 1   0    "deadbeef"   "a1b2c3d4e5f60718"  ""    "1234567890" || fail=1
+
 if [[ "$fail" -eq 0 ]]; then
   echo "==> PASS: all spec-output fixtures match the new SSZ schema"
   exit 0

--- a/scripts/codegen-stateless-spec-output-check.sh
+++ b/scripts/codegen-stateless-spec-output-check.sh
@@ -79,6 +79,7 @@ run_fixture() {
   local block_number="${7:-}"
   local timestamp="${8:-}"
   local blob_schedule="${9:-}"
+  local witness_headers_hex="${10:-}"
 
   local safe="${label//[^0-9A-Za-z_]/_}"
   local input_file="$REPO_ROOT/gen-out/stateless_guest-spec-${safe}.input"
@@ -86,14 +87,16 @@ run_fixture() {
   local spec_exp_file="$REPO_ROOT/gen-out/stateless_guest-spec-${safe}.spec-expected"
   local log_file="$REPO_ROOT/gen-out/stateless_guest-spec-${safe}.emu.log"
 
-  echo "==> [$label] gen new-schema SSZ input + spec expected (chain_id=$cid, fork=$fork, code=${witness_code_hex:-empty}, state=${witness_state_hex:-empty}, pk=${public_key_hex:-empty}, bn=${block_number:-empty}, ts=${timestamp:-empty}, blob=${blob_schedule:-empty})"
+  echo "==> [$label] gen new-schema SSZ input + spec expected (chain_id=$cid, fork=$fork, code=${witness_code_hex:-empty}, state=${witness_state_hex:-empty}, pk=${public_key_hex:-empty}, bn=${block_number:-empty}, ts=${timestamp:-empty}, blob=${blob_schedule:-empty}, hdr=${witness_headers_hex:-empty})"
   uv run --directory execution-specs --quiet python3 -c "
 import struct, sys
 from ethereum.forks.amsterdam.stateless_ssz import (
     MAX_BYTES_PER_CODE,
+    MAX_BYTES_PER_HEADER,
     MAX_BYTES_PER_WITNESS_NODE,
     MAX_PUBLIC_KEYS,
     MAX_WITNESS_CODES,
+    MAX_WITNESS_HEADERS,
     MAX_WITNESS_NODES,
     PUBLIC_KEY_BYTES,
     STATELESS_INPUT_SCHEMA_ID_BYTES,
@@ -120,6 +123,7 @@ pk_hex = sys.argv[7]
 bn_str = sys.argv[8]
 ts_str = sys.argv[9]
 blob_str = sys.argv[10]
+hdr_hex = sys.argv[11]
 
 # Build the new-schema StatelessInput: empty new_payload_request,
 # witness whose 'state'/'codes' lists each hold zero or more
@@ -168,9 +172,17 @@ if state_hex:
     state_entries = state_hex.split(':')
     state_arg = tuple(NodeBL(bytes.fromhex(s)) for s in state_entries)
 
+HeaderBL = ByteList[MAX_BYTES_PER_HEADER]
+HeadersList = SszList[HeaderBL, MAX_WITNESS_HEADERS]
+hdr_arg = ()
+if hdr_hex:
+    hdr_entries = hdr_hex.split(':')
+    hdr_arg = tuple(HeaderBL(bytes.fromhex(h)) for h in hdr_entries)
+
 witness = SszExecutionWitness(
     state=NodesList(*state_arg),
     codes=CodesList(*codes_arg),
+    headers=HeadersList(*hdr_arg),
 )
 
 PkBV = ByteVector[PUBLIC_KEY_BYTES]
@@ -202,7 +214,7 @@ with open(sys.argv[2], 'wb') as f:
 spec_bytes = bytes(run_stateless_guest(input_bytes))
 with open(sys.argv[3], 'w') as f:
     f.write(spec_bytes.hex())
-" "$cid" "$input_file" "$spec_exp_file" "$fork" "$witness_code_hex" "$witness_state_hex" "$public_key_hex" "$block_number" "$timestamp" "$blob_schedule"
+" "$cid" "$input_file" "$spec_exp_file" "$fork" "$witness_code_hex" "$witness_state_hex" "$public_key_hex" "$block_number" "$timestamp" "$blob_schedule" "$witness_headers_hex"
 
   echo "==> [$label] ziskemu run"
   "$ZISKEMU" -e gen-out/stateless_guest.elf -i "$input_file" \
@@ -371,6 +383,15 @@ run_fixture "chain1_witcode_actbn_unbounded" 1   0    "deadbeef"   ""           
 # "section not found". The bounded loop in PR #6843 stops at
 # chain_config_end so the combination passes.
 run_fixture "chain1_witboth_actbn_unbounded" 1   0    "deadbeef"   "a1b2c3d4e5f60718"  ""    "1234567890" || fail=1
+
+# Non-empty witness.headers -- exercises the THIRD inner witness
+# field, which the decoder's `decode_header_count` stub leaves
+# inert (x16 = 0) so the validator pipeline takes the N=0 fast
+# path. Spec's `validate_headers([bogus])` raises -> valid=False,
+# matching the ELF's x11=0 stub. Adding a 32-byte arbitrary
+# header tests that the decoder's outer-offset chase is robust
+# even when witness.headers is non-empty.
+run_fixture "chain1_witheaders"     1                  0    ""           ""                  ""    ""           ""           ""    "$(printf 'aa%.0s' {1..32})" || fail=1
 
 if [[ "$fail" -eq 0 ]]; then
   echo "==> PASS: all spec-output fixtures match the new SSZ schema"

--- a/scripts/codegen-stateless-spec-output-check.sh
+++ b/scripts/codegen-stateless-spec-output-check.sh
@@ -393,6 +393,15 @@ run_fixture "chain1_witboth_actbn_unbounded" 1   0    "deadbeef"   "a1b2c3d4e5f6
 # even when witness.headers is non-empty.
 run_fixture "chain1_witheaders"     1                  0    ""           ""                  ""    ""           ""           ""    "$(printf 'aa%.0s' {1..32})" || fail=1
 
+# Two witness.headers entries -- exercises the SSZ list inner
+# offset table (2 u32 offsets prefix the headers section)
+# parallel to chain1_witcode_2 / chain1_witstate_2. The decoder
+# still leaves x16=0 from the stub so the validator pipeline
+# takes the N=0 fast path; ELF output stays the 73-byte
+# valid=False template. Stress test for the bounded byte-copy
+# under maximum-witness-headers byte-budget.
+run_fixture "chain1_witheaders_2"   1                  0    ""           ""                  ""    ""           ""           ""    "$(printf 'aa%.0s' {1..32}):$(printf 'bb%.0s' {1..32})" || fail=1
+
 if [[ "$fail" -eq 0 ]]; then
   echo "==> PASS: all spec-output fixtures match the new SSZ schema"
   exit 0


### PR DESCRIPTION
Refs #61.\n\nBead: evm-asm-9iqmw.7.1.6.1.2\n\nThis PR stacks on #6890 and continues the N1 selected/reachable evidence path toward the DIV stack-level spec.\n\nChanges:\n- adds N1CallableSelectedIfBorrowShapeEvidence.hdivs\n- projects the selected call/max/max/max FullDivN1CallMaxmaxmaxHdivs package from the bundled private evidence object\n- keeps Carry2NzAll and branch/path callback packages out of this consumer-facing hdiv projection\n\nVerification:\n- lake build EvmAsm.Evm64.DivMod.Spec.N1CallableSelectedIfBorrowShapeEvidence\n- Lean LSP diagnostics: no errors for N1CallableSelectedIfBorrowShapeEvidence.lean\n- lake build EvmAsm.Evm64.DivMod.Spec\n- lake build EvmAsm.Evm64.DivMod\n- lake build\n- git diff --check\n- scripts/check-file-size.sh EvmAsm/Evm64/DivMod/Spec/N1CallableSelectedIfBorrowShapeEvidence.lean\n- scripts/check-unimported.sh\n- forbidden scan for sorry/admit/maxHeartbeats/maxRecDepth on the touched file: no matches