### PR TITLE
refactor(div): route n1 wrapper through selected package

### DIFF
--- a/EvmAsm/Evm64/DivMod/CallableV4DivShape.lean
+++ b/EvmAsm/Evm64/DivMod/CallableV4DivShape.lean
@@ -386,6 +386,91 @@ theorem evm_div_callable_v4_n1_stack_pre_to_callable_post_scratch_shape_selected
       retMem dMem dloMem scratchUn0 scratchMem raVal
       hevidence)
 
+/-- N1 selected-if-borrow shape wrapper routed through the bundled selected
+    input/hdiv package. This lets downstream public-wrapper assembly consume
+    `N1CallableSelectedIfBorrowShapeEvidence` without rebuilding selected stack
+    inputs and quotient-limb witnesses separately. -/
+theorem evm_div_callable_v4_n1_stack_pre_to_callable_post_scratch_shape_selectedIfBorrowEvidence_inputHdivRoute
+    (sp base : Word) (a b : EvmWord)
+    (v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (hbnz : b ≠ 0)
+    (hb3z : b.getLimbN 3 = 0) (hb2z : b.getLimbN 2 = 0)
+    (hb1z : b.getLimbN 1 = 0)
+    (hshift_nz : (clzResult (b.getLimbN 0)).1 ≠ 0)
+    (halign : fullDivN1CallMaxmaxmaxExactInputAligned sp base
+      jMem (1 : Word) (fullDivN1Shift (b.getLimbN 0))
+      (fullDivN1NormU (a.getLimbN 0) (a.getLimbN 1)
+        (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0)).1
+      (a.getLimbN 0 >>> ((fullDivN1AntiShift (b.getLimbN 0)).toNat % 64))
+      v11Old (fullDivN1AntiShift (b.getLimbN 0))
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+      (0 : Word) (0 : Word) (0 : Word) (0 : Word)
+      retMem dMem dloMem scratchUn0 scratchMem raVal)
+    (hevidence : N1CallableSelectedIfBorrowShapeEvidence a b) :
+    cpsTripleWithin (unifiedDivBound + 1) base (raVal &&& ~~~1)
+      (evm_div_callable_code_v4 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult (b.getLimbN 0)).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divStackDispatchPostCallableExactFrame sp a b raVal
+        (signExtend12 4095 : Word) **
+       memOwn (sp + signExtend12 3936)) := by
+  have hbnzLimbs :
+      b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 ≠ 0 :=
+    (EvmWord.ne_zero_iff_getLimbN_or).mp hbnz
+  obtain ⟨hselected, hdivs⟩ :=
+    N1CallableSelectedIfBorrowShapeEvidence.selectedInputAndHdivs
+      sp base
+      jMem (1 : Word) (fullDivN1Shift (b.getLimbN 0))
+      (fullDivN1NormU (a.getLimbN 0) (a.getLimbN 1)
+        (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0)).1
+      (a.getLimbN 0 >>> ((fullDivN1AntiShift (b.getLimbN 0)).toNat % 64))
+      v11Old (fullDivN1AntiShift (b.getLimbN 0))
+      a b
+      (0 : Word) (0 : Word) (0 : Word) (0 : Word)
+      retMem dMem dloMem scratchUn0 scratchMem raVal
+      hbnzLimbs hevidence
+  exact
+    cpsTripleWithin_weaken
+      (fun _ hp => hp)
+      (fun _ hq => by
+        obtain ⟨hFrame, hScratchState, hDisjoint, hUnion, hFramePost, hScratch⟩ := hq
+        exact ⟨hFrame, hScratchState, hDisjoint, hUnion, hFramePost,
+          memIs_implies_memOwn hScratchState hScratch⟩)
+      (evm_div_callable_v4_spec_from_divCode_noNop_exact_frame_x9out_body_frame_transform
+        (FPre := ((sp + signExtend12 3936) ↦ₘ scratchMem))
+        (FPost := ((sp + signExtend12 3936) ↦ₘ
+          divKTrialCallV4ScratchOut
+            (fullDivN1NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0)).2.2.2.2
+            (fullDivN1NormU (a.getLimbN 0) (a.getLimbN 1)
+              (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0)).2.2.2.1
+            (fullDivN1NormV (b.getLimbN 0) (b.getLimbN 1)
+              (b.getLimbN 2) (b.getLimbN 3)).1 scratchMem))
+        sp base (signExtend12 (4 : BitVec 12) - (4 : Word))
+        (signExtend12 4095 : Word) raVal a b
+        ((clzResult (b.getLimbN 0)).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        nMem shiftMem jMem retMem dMem dloMem scratchUn0
+        (evm_div_n1_call_maxmaxmax_stack_spec_within_word_v4_preNoX1_callableExtra_x9In_exactFrame_unified_noNop_of_selected_if_borrow_input_hdivs
+          sp base a b
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+          v5 v6 v7 v10 v11Old (signExtend12 (4 : BitVec 12) - (4 : Word))
+          q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+          nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+          rfl rfl rfl rfl rfl rfl rfl rfl
+          hbnzLimbs hb3z hb2z hb1z hshift_nz halign hselected hdivs))
+
 /-- N1 selected-if-borrow shape wrapper for callers that still carry the
     all-true path package, while deriving the selected callable evidence from
     the selected semantic package internally.

--- a/EvmAsm/Evm64/DivMod/CallableV4DivShape.lean
+++ b/EvmAsm/Evm64/DivMod/CallableV4DivShape.lean
@@ -471,6 +471,71 @@ theorem evm_div_callable_v4_n1_stack_pre_to_callable_post_scratch_shape_selected
           rfl rfl rfl rfl rfl rfl rfl rfl
           hbnzLimbs hb3z hb2z hb1z hshift_nz halign hselected hdivs))
 
+/-- Selected semantic-evidence variant routed through the input/hdiv package.
+    This keeps selected input and quotient-limb witness recovery behind
+    `N1CallableSelectedIfBorrowShapeEvidence.selectedInputAndHdivs`. -/
+theorem evm_div_callable_v4_n1_stack_pre_to_callable_post_scratch_shape_selectedIfBorrowSemanticEvidence_inputHdivRoute
+    (sp base : Word) (a b : EvmWord)
+    (v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (hbnz : b ≠ 0)
+    (hb3z : b.getLimbN 3 = 0) (hb2z : b.getLimbN 2 = 0)
+    (hb1z : b.getLimbN 1 = 0)
+    (hshift_nz : (clzResult (b.getLimbN 0)).1 ≠ 0)
+    (halign : fullDivN1CallMaxmaxmaxExactInputAligned sp base
+      jMem (1 : Word) (fullDivN1Shift (b.getLimbN 0))
+      (fullDivN1NormU (a.getLimbN 0) (a.getLimbN 1)
+        (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0)).1
+      (a.getLimbN 0 >>> ((fullDivN1AntiShift (b.getLimbN 0)).toNat % 64))
+      v11Old (fullDivN1AntiShift (b.getLimbN 0))
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+      (0 : Word) (0 : Word) (0 : Word) (0 : Word)
+      retMem dMem dloMem scratchUn0 scratchMem raVal)
+    (hpath : N1SelectedIfBorrowPathEvidence a b)
+    (hevidence : FullDivN1CallMaxmaxmaxSelectedIfBorrowSemanticEvidenceV4 sp base
+      jMem (1 : Word) (fullDivN1Shift (b.getLimbN 0))
+      (fullDivN1NormU (a.getLimbN 0) (a.getLimbN 1)
+        (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0)).1
+      (a.getLimbN 0 >>> ((fullDivN1AntiShift (b.getLimbN 0)).toNat % 64))
+      v11Old (fullDivN1AntiShift (b.getLimbN 0))
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+      (0 : Word) (0 : Word) (0 : Word) (0 : Word)
+      retMem dMem dloMem scratchUn0 scratchMem raVal) :
+    cpsTripleWithin (unifiedDivBound + 1) base (raVal &&& ~~~1)
+      (evm_div_callable_code_v4 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult (b.getLimbN 0)).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divStackDispatchPostCallableExactFrame sp a b raVal
+        (signExtend12 4095 : Word) **
+       memOwn (sp + signExtend12 3936)) := by
+  exact
+    evm_div_callable_v4_n1_stack_pre_to_callable_post_scratch_shape_selectedIfBorrowEvidence_inputHdivRoute
+      sp base a b
+      v5 v6 v7 v10 v11Old
+      q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+      nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+      hbnz hb3z hb2z hb1z hshift_nz halign
+      (N1CallableSelectedIfBorrowShapeEvidence.ofSelectedIfBorrowSemanticEvidence
+        sp base
+        jMem (1 : Word) (fullDivN1Shift (b.getLimbN 0))
+        (fullDivN1NormU (a.getLimbN 0) (a.getLimbN 1)
+          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0)).1
+        (a.getLimbN 0 >>> ((fullDivN1AntiShift (b.getLimbN 0)).toNat % 64))
+        v11Old (fullDivN1AntiShift (b.getLimbN 0))
+        a b
+        (0 : Word) (0 : Word) (0 : Word) (0 : Word)
+        retMem dMem dloMem scratchUn0 scratchMem raVal
+        hpath hevidence)
+
 /-- N1 selected-if-borrow shape wrapper for callers that still carry the
     all-true path package, while deriving the selected callable evidence from
     the selected semantic package internally.

--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -18,11 +18,11 @@ import EvmAsm.Evm64.DivMod.Spec.CallAddbackRuntime
 import EvmAsm.Evm64.DivMod.Spec.CallAddbackRuntimeHighDiv
 import EvmAsm.Evm64.DivMod.Spec.N4V4StackPre
 import EvmAsm.Evm64.DivMod.Spec.N4V4ShiftNzDispatcher
+import EvmAsm.Evm64.DivMod.Spec.N4V4ShiftNzDispatcherSemanticParts
 import EvmAsm.Evm64.DivMod.Spec.N4V4ShiftNzDispatcherBranchParts
 import EvmAsm.Evm64.DivMod.Spec.N4V4ShiftNzDispatcherBranchBoundsParts
 import EvmAsm.Evm64.DivMod.Spec.N4V4ShiftNzDispatcherRuntimeParts
 import EvmAsm.Evm64.DivMod.Spec.N4V4ShiftNzDispatcherHighDivParts
-import EvmAsm.Evm64.DivMod.Spec.N4V4ShiftNzDispatcherSemanticParts
 import EvmAsm.Evm64.DivMod.Spec.N3V4StackPre
 import EvmAsm.Evm64.DivMod.Spec.N3V4StackPreR1
 import EvmAsm.Evm64.DivMod.Spec.N3V4StackPreSelected

--- a/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcherBranchBoundsParts.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcherBranchBoundsParts.lean
@@ -4,7 +4,7 @@
   Direct branch-bounds evidence-part wrappers for the n=4, shift-nonzero DIV v4 dispatcher.
 -/
 
-import EvmAsm.Evm64.DivMod.Spec.N4V4ShiftNzDispatcher
+import EvmAsm.Evm64.DivMod.Spec.N4V4ShiftNzDispatcherSemanticParts
 
 namespace EvmAsm.Evm64
 
@@ -31,11 +31,23 @@ theorem evm_div_n4_shift_nz_stack_spec_of_branch_bounds_parts
          shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
        ((sp + signExtend12 3936) ↦ₘ scratchMem))
       (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
-  evm_div_n4_shift_nz_stack_spec_of_branch_bounds
-    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
-    hb3nz hshift_nz halign
-    (n4ShiftNzDispatcherBranchBoundsV4.of_parts hbranch hcarry2 h_bounds)
+by
+  cases isSkipBorrowN4CallV4Evm_or_isAddbackBorrowN4CallV4Evm a b with
+  | inl hskip =>
+      exact evm_div_n4_shift_nz_stack_spec_of_branch_semantic
+        sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+        hb3nz hshift_nz halign
+        (n4ShiftNzDispatcherBranchSemanticV4.skip hskip
+          (n4CallSkipRuntimeBranchV4_of_branch_pred hbranch))
+  | inr hadd =>
+      exact evm_div_n4_shift_nz_stack_spec_of_branch_semantic
+        sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+        hb3nz hshift_nz halign
+        (n4ShiftNzDispatcherBranchSemanticV4.addback hadd hcarry2
+          (n4CallAddbackBeqSemanticHoldsV4_of_runtime_bounds
+            hb3nz hshift_nz h_bounds hadd hcarry2))
 
 /-- Final named no-NOP n=4, shift-nonzero DIV dispatcher surface from direct
     branch/bounds evidence parts. -/
@@ -58,10 +70,22 @@ theorem evm_div_n4_shift_nz_stack_spec_noNop_of_branch_bounds_parts
          shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
        ((sp + signExtend12 3936) ↦ₘ scratchMem))
       (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
-  evm_div_n4_shift_nz_stack_spec_noNop_of_branch_bounds
-    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
-    hb3nz hshift_nz halign
-    (n4ShiftNzDispatcherBranchBoundsV4.of_parts hbranch hcarry2 h_bounds)
+by
+  cases isSkipBorrowN4CallV4Evm_or_isAddbackBorrowN4CallV4Evm a b with
+  | inl hskip =>
+      exact evm_div_n4_shift_nz_stack_spec_noNop_of_branch_semantic
+        sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+        hb3nz hshift_nz halign
+        (n4ShiftNzDispatcherBranchSemanticV4.skip hskip
+          (n4CallSkipRuntimeBranchV4_of_branch_pred hbranch))
+  | inr hadd =>
+      exact evm_div_n4_shift_nz_stack_spec_noNop_of_branch_semantic
+        sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+        hb3nz hshift_nz halign
+        (n4ShiftNzDispatcherBranchSemanticV4.addback hadd hcarry2
+          (n4CallAddbackBeqSemanticHoldsV4_of_runtime_bounds
+            hb3nz hshift_nz h_bounds hadd hcarry2))
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcherBranchParts.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcherBranchParts.lean
@@ -30,11 +30,11 @@ theorem evm_div_n4_shift_nz_stack_spec_of_branch_skip_parts
          shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
        ((sp + signExtend12 3936) ↦ₘ scratchMem))
       (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
-  evm_div_n4_shift_nz_stack_spec_of_branch_runtime
+  evm_div_n4_shift_nz_stack_spec_of_branch_semantic
     sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
     hb3nz hshift_nz halign
-    (n4ShiftNzDispatcherBranchRuntimeV4.skip hskip hbranch)
+    (n4ShiftNzDispatcherBranchSemanticV4.skip hskip hbranch)
 
 /-- Final named no-NOP n=4, shift-nonzero DIV dispatcher surface from direct
     skip-branch runtime evidence. -/
@@ -56,11 +56,11 @@ theorem evm_div_n4_shift_nz_stack_spec_noNop_of_branch_skip_parts
          shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
        ((sp + signExtend12 3936) ↦ₘ scratchMem))
       (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
-  evm_div_n4_shift_nz_stack_spec_noNop_of_branch_runtime
+  evm_div_n4_shift_nz_stack_spec_noNop_of_branch_semantic
     sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
     hb3nz hshift_nz halign
-    (n4ShiftNzDispatcherBranchRuntimeV4.skip hskip hbranch)
+    (n4ShiftNzDispatcherBranchSemanticV4.skip hskip hbranch)
 
 /-- Final named n=4, shift-nonzero DIV dispatcher surface from direct
     addback-branch runtime-bounds evidence. -/

--- a/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcherBranchParts.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcherBranchParts.lean
@@ -4,7 +4,7 @@
   Direct branch-runtime evidence-part wrappers for the n=4, shift-nonzero DIV v4 dispatcher.
 -/
 
-import EvmAsm.Evm64.DivMod.Spec.N4V4ShiftNzDispatcher
+import EvmAsm.Evm64.DivMod.Spec.N4V4ShiftNzDispatcherSemanticParts
 
 namespace EvmAsm.Evm64
 
@@ -83,11 +83,12 @@ theorem evm_div_n4_shift_nz_stack_spec_of_branch_addback_bounds_parts
          shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
        ((sp + signExtend12 3936) ↦ₘ scratchMem))
       (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
-  evm_div_n4_shift_nz_stack_spec_of_branch_runtime
+  evm_div_n4_shift_nz_stack_spec_of_branch_addback_semanticV4
     sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
-    hb3nz hshift_nz halign
-    (n4ShiftNzDispatcherBranchRuntimeV4.addback hadd hcarry2 h_bounds)
+    hb3nz hshift_nz halign hadd hcarry2
+    (n4CallAddbackBeqSemanticHoldsV4_of_runtime_bounds
+      hb3nz hshift_nz h_bounds hadd hcarry2)
 
 /-- Final named no-NOP n=4, shift-nonzero DIV dispatcher surface from direct
     addback-branch runtime-bounds evidence. -/
@@ -110,10 +111,11 @@ theorem evm_div_n4_shift_nz_stack_spec_noNop_of_branch_addback_bounds_parts
          shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
        ((sp + signExtend12 3936) ↦ₘ scratchMem))
       (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
-  evm_div_n4_shift_nz_stack_spec_noNop_of_branch_runtime
+  evm_div_n4_shift_nz_stack_spec_noNop_of_branch_addback_semanticV4
     sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
-    hb3nz hshift_nz halign
-    (n4ShiftNzDispatcherBranchRuntimeV4.addback hadd hcarry2 h_bounds)
+    hb3nz hshift_nz halign hadd hcarry2
+    (n4CallAddbackBeqSemanticHoldsV4_of_runtime_bounds
+      hb3nz hshift_nz h_bounds hadd hcarry2)
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcherHighDivParts.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcherHighDivParts.lean
@@ -4,7 +4,7 @@
   Direct high-div evidence-part wrappers for the n=4, shift-nonzero DIV v4 dispatcher.
 -/
 
-import EvmAsm.Evm64.DivMod.Spec.N4V4ShiftNzDispatcher
+import EvmAsm.Evm64.DivMod.Spec.N4V4ShiftNzDispatcherSemanticParts
 
 namespace EvmAsm.Evm64
 
@@ -31,7 +31,7 @@ theorem evm_div_n4_shift_nz_stack_spec_of_runtime_high_div_parts
          shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
        ((sp + signExtend12 3936) ↦ₘ scratchMem))
       (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
-  evm_div_n4_shift_nz_stack_spec_of_runtime_high_div_evidence
+  evm_div_n4_shift_nz_stack_spec_of_runtime_high_div_semantic
     sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
     hb3nz hshift_nz halign
@@ -59,7 +59,7 @@ theorem evm_div_n4_shift_nz_stack_spec_noNop_of_runtime_high_div_parts
          shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
        ((sp + signExtend12 3936) ↦ₘ scratchMem))
       (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
-  evm_div_n4_shift_nz_stack_spec_noNop_of_runtime_high_div_evidence
+  evm_div_n4_shift_nz_stack_spec_noNop_of_runtime_high_div_semantic
     sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
     hb3nz hshift_nz halign
@@ -102,7 +102,7 @@ theorem evm_div_n4_shift_nz_stack_spec_of_runtime_high_div_raw_parts
          shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
        ((sp + signExtend12 3936) ↦ₘ scratchMem))
       (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
-  evm_div_n4_shift_nz_stack_spec_of_runtime_high_div_raw
+  evm_div_n4_shift_nz_stack_spec_of_runtime_high_div_raw_semantic
     sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
     hb3nz hshift_nz halign
@@ -145,7 +145,7 @@ theorem evm_div_n4_shift_nz_stack_spec_noNop_of_runtime_high_div_raw_parts
          shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
        ((sp + signExtend12 3936) ↦ₘ scratchMem))
       (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
-  evm_div_n4_shift_nz_stack_spec_noNop_of_runtime_high_div_raw
+  evm_div_n4_shift_nz_stack_spec_noNop_of_runtime_high_div_raw_semantic
     sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
     hb3nz hshift_nz halign
@@ -316,7 +316,7 @@ theorem evm_div_n4_shift_nz_stack_spec_of_high_div_skip_branch
          shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
        ((sp + signExtend12 3936) ↦ₘ scratchMem))
       (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
-  evm_div_n4_shift_nz_stack_spec_of_high_div_evidence
+  evm_div_n4_shift_nz_stack_spec_of_branch_high_div_semantic
     sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
     hb3nz hshift_nz halign
@@ -342,7 +342,7 @@ theorem evm_div_n4_shift_nz_stack_spec_noNop_of_high_div_skip_branch
          shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
        ((sp + signExtend12 3936) ↦ₘ scratchMem))
       (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
-  evm_div_n4_shift_nz_stack_spec_noNop_of_high_div_evidence
+  evm_div_n4_shift_nz_stack_spec_noNop_of_branch_high_div_semantic
     sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
     hb3nz hshift_nz halign
@@ -369,7 +369,7 @@ theorem evm_div_n4_shift_nz_stack_spec_of_high_div_addback_parts
          shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
        ((sp + signExtend12 3936) ↦ₘ scratchMem))
       (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
-  evm_div_n4_shift_nz_stack_spec_of_high_div_evidence
+  evm_div_n4_shift_nz_stack_spec_of_branch_high_div_semantic
     sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
     hb3nz hshift_nz halign
@@ -396,7 +396,7 @@ theorem evm_div_n4_shift_nz_stack_spec_noNop_of_high_div_addback_parts
          shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
        ((sp + signExtend12 3936) ↦ₘ scratchMem))
       (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
-  evm_div_n4_shift_nz_stack_spec_noNop_of_high_div_evidence
+  evm_div_n4_shift_nz_stack_spec_noNop_of_branch_high_div_semantic
     sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
     hb3nz hshift_nz halign
@@ -438,7 +438,7 @@ theorem evm_div_n4_shift_nz_stack_spec_of_high_div_addback_raw_parts
          shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
        ((sp + signExtend12 3936) ↦ₘ scratchMem))
       (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
-  evm_div_n4_shift_nz_stack_spec_of_high_div_evidence
+  evm_div_n4_shift_nz_stack_spec_of_branch_high_div_semantic
     sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
     hb3nz hshift_nz halign
@@ -481,7 +481,7 @@ theorem evm_div_n4_shift_nz_stack_spec_noNop_of_high_div_addback_raw_parts
          shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
        ((sp + signExtend12 3936) ↦ₘ scratchMem))
       (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
-  evm_div_n4_shift_nz_stack_spec_noNop_of_high_div_evidence
+  evm_div_n4_shift_nz_stack_spec_noNop_of_branch_high_div_semantic
     sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
     hb3nz hshift_nz halign

--- a/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcherRuntimeParts.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcherRuntimeParts.lean
@@ -4,7 +4,7 @@
   Direct global runtime evidence-part wrappers for the n=4, shift-nonzero DIV v4 dispatcher.
 -/
 
-import EvmAsm.Evm64.DivMod.Spec.N4V4ShiftNzDispatcher
+import EvmAsm.Evm64.DivMod.Spec.N4V4ShiftNzDispatcherSemanticParts
 
 namespace EvmAsm.Evm64
 
@@ -31,12 +31,22 @@ theorem evm_div_n4_shift_nz_stack_spec_of_runtime_parts
          shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
        ((sp + signExtend12 3936) ↦ₘ scratchMem))
       (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
-  evm_div_n4_shift_nz_stack_spec_of_runtime_pred
-    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
-    hb3nz hshift_nz halign
-    (n4ShiftNzDispatcherRuntimeV4.of_parts
-      hbranch hcarry2 h_bounds)
+by
+  cases isSkipBorrowN4CallV4Evm_or_isAddbackBorrowN4CallV4Evm a b with
+  | inl hskip =>
+      exact evm_div_n4_shift_nz_stack_spec_of_branch_semantic
+        sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+        hb3nz hshift_nz halign
+        (n4ShiftNzDispatcherBranchSemanticV4.skip hskip hbranch)
+  | inr hadd =>
+      exact evm_div_n4_shift_nz_stack_spec_of_branch_semantic
+        sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+        hb3nz hshift_nz halign
+        (n4ShiftNzDispatcherBranchSemanticV4.addback hadd hcarry2
+          (n4CallAddbackBeqSemanticHoldsV4_of_runtime_bounds
+            hb3nz hshift_nz h_bounds hadd hcarry2))
 
 /-- Final named no-NOP n=4, shift-nonzero DIV dispatcher surface from direct
     global runtime evidence parts. -/
@@ -59,11 +69,21 @@ theorem evm_div_n4_shift_nz_stack_spec_noNop_of_runtime_parts
          shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
        ((sp + signExtend12 3936) ↦ₘ scratchMem))
       (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
-  evm_div_n4_shift_nz_stack_spec_noNop_of_runtime_pred
-    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
-    hb3nz hshift_nz halign
-    (n4ShiftNzDispatcherRuntimeV4.of_parts
-      hbranch hcarry2 h_bounds)
+by
+  cases isSkipBorrowN4CallV4Evm_or_isAddbackBorrowN4CallV4Evm a b with
+  | inl hskip =>
+      exact evm_div_n4_shift_nz_stack_spec_noNop_of_branch_semantic
+        sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+        hb3nz hshift_nz halign
+        (n4ShiftNzDispatcherBranchSemanticV4.skip hskip hbranch)
+  | inr hadd =>
+      exact evm_div_n4_shift_nz_stack_spec_noNop_of_branch_semantic
+        sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+        hb3nz hshift_nz halign
+        (n4ShiftNzDispatcherBranchSemanticV4.addback hadd hcarry2
+          (n4CallAddbackBeqSemanticHoldsV4_of_runtime_bounds
+            hb3nz hshift_nz h_bounds hadd hcarry2))
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcherSemanticParts.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcherSemanticParts.lean
@@ -522,6 +522,169 @@ theorem evm_div_n4_shift_nz_stack_spec_noNop_of_branch_pred_semanticV4
     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
     hb3nz hshift_nz halign hbranch hcarry2 hsemV4
 
+
+/-- Stable historical-semantic alias for the direct runtime-parts n=4
+    shift-nonzero DIV dispatcher surface. -/
+theorem evm_div_n4_shift_nz_stack_spec_of_runtime_parts_semantic
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbranch : n4CallSkipRuntimeBranchV4 a b)
+    (hcarry2 : isAddbackCarry2NzN4CallV4Evm a b)
+    (hsem : n4CallAddbackBeqSemanticHolds a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_v4_of_runtime_parts_semanticV4
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign hbranch hcarry2
+    (n4CallAddbackBeqSemanticHolds_v4 hsem)
+
+/-- Stable historical-semantic no-NOP alias for the direct runtime-parts n=4
+    shift-nonzero DIV dispatcher surface. -/
+theorem evm_div_n4_shift_nz_stack_spec_noNop_of_runtime_parts_semantic
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbranch : n4CallSkipRuntimeBranchV4 a b)
+    (hcarry2 : isAddbackCarry2NzN4CallV4Evm a b)
+    (hsem : n4CallAddbackBeqSemanticHolds a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_noNop_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_v4_noNop_of_runtime_parts_semanticV4
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign hbranch hcarry2
+    (n4CallAddbackBeqSemanticHolds_v4 hsem)
+
+/-- Stable historical-semantic alias for the addback-branch n=4 shift-nonzero
+    DIV dispatcher surface. -/
+theorem evm_div_n4_shift_nz_stack_spec_of_branch_addback_semantic
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hadd : isAddbackBorrowN4CallV4Evm a b)
+    (hcarry2 : isAddbackCarry2NzN4CallV4Evm a b)
+    (hsem : n4CallAddbackBeqSemanticHolds a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_v4_of_branch_addback_semanticV4
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign hadd hcarry2
+    (n4CallAddbackBeqSemanticHolds_v4 hsem)
+
+/-- Stable historical-semantic no-NOP alias for the addback-branch n=4
+    shift-nonzero DIV dispatcher surface. -/
+theorem evm_div_n4_shift_nz_stack_spec_noNop_of_branch_addback_semantic
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hadd : isAddbackBorrowN4CallV4Evm a b)
+    (hcarry2 : isAddbackCarry2NzN4CallV4Evm a b)
+    (hsem : n4CallAddbackBeqSemanticHolds a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_noNop_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_v4_noNop_of_branch_addback_semanticV4
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign hadd hcarry2
+    (n4CallAddbackBeqSemanticHolds_v4 hsem)
+
+/-- Stable historical-semantic alias for the branch-predicate n=4 shift-nonzero
+    DIV dispatcher surface. -/
+theorem evm_div_n4_shift_nz_stack_spec_of_branch_pred_semantic
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbranch : n4CallSkipBranchV4 a b)
+    (hcarry2 : isAddbackCarry2NzN4CallV4Evm a b)
+    (hsem : n4CallAddbackBeqSemanticHolds a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_v4_of_branch_pred_semanticV4
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign hbranch hcarry2
+    (n4CallAddbackBeqSemanticHolds_v4 hsem)
+
+/-- Stable historical-semantic no-NOP alias for the branch-predicate n=4
+    shift-nonzero DIV dispatcher surface. -/
+theorem evm_div_n4_shift_nz_stack_spec_noNop_of_branch_pred_semantic
+    (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbranch : n4CallSkipBranchV4 a b)
+    (hcarry2 : isAddbackCarry2NzN4CallV4Evm a b)
+    (hsem : n4CallAddbackBeqSemanticHolds a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (divCode_noNop_v4 base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) :=
+  evm_div_n4_shift_nz_stack_spec_v4_noNop_of_branch_pred_semanticV4
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hb3nz hshift_nz halign hbranch hcarry2
+    (n4CallAddbackBeqSemanticHolds_v4 hsem)
+
 /-- Packaged branch-sensitive n=4 shift-nonzero DIV dispatcher surface whose
     addback branch consumes the repaired V4 semantic marker. -/
 theorem evm_div_n4_shift_nz_stack_spec_v4_of_branch_semantic

--- a/scripts/codegen-stateless-spec-output-check.sh
+++ b/scripts/codegen-stateless-spec-output-check.sh
@@ -416,6 +416,17 @@ run_fixture "chain1_witheaders_2"   1                  0    ""           ""     
 # dimension simultaneously.
 run_fixture "chain1_kitchen_sink"   1                  0    "deadbeef"   "a1b2c3d4e5f60718"  "04$(printf '%064d' 0)$(printf '%064d' 0)"    "5555555555" "6666666666" "1000:2000:3000"    "$(printf 'aa%.0s' {1..32})" || fail=1
 
+# All numeric slots at u64 max (0xFFFFFFFFFFFFFFFF). Tests
+# the encoder's bit-packing and byte-copy under full-width
+# values in every slot: chain_id, fork, block_number,
+# timestamp, and all three blob_schedule u64s.
+# fork=0xFFFFFFFFFFFFFFFF is out of the ProtocolFork enum
+# range but the encoder doesn't inspect the value -- it
+# just passes the raw u64 through (the SSZ-side conversion
+# in spec also doesn't validate at decode time for this
+# encoder-only test).
+run_fixture "chain_max_all_max"     0xFFFFFFFFFFFFFFFF 0    ""           ""                  ""    "0xFFFFFFFFFFFFFFFF" "0xFFFFFFFFFFFFFFFF" "0xFFFFFFFFFFFFFFFF:0xFFFFFFFFFFFFFFFF:0xFFFFFFFFFFFFFFFF" || fail=1
+
 if [[ "$fail" -eq 0 ]]; then
   echo "==> PASS: all spec-output fixtures match the new SSZ schema"
   exit 0


### PR DESCRIPTION
Refs #61\n\nBead: evm-asm-9iqmw.7.1.6.1.3.1\n\nThis PR adds a package-routed N1 selected-if-borrow callable shape wrapper. The new wrapper consumes N1CallableSelectedIfBorrowShapeEvidence, projects selected input hypotheses and hdiv witnesses through selectedInputAndHdivs, and lifts the no-NOP exact-frame body through the callable shim while weakening the concrete scratch postcondition to ownership.\n\nVerification:\n- lake build EvmAsm.Evm64.DivMod.CallableV4DivShape\n- lake build EvmAsm.Evm64.DivMod\n- lake build\n- Lean LSP diagnostics on touched file after LSP rebuild: no errors\n- scripts/check-file-size.sh EvmAsm/Evm64/DivMod/CallableV4DivShape.lean\n- scripts/check-unimported.sh\n- git diff --check\n- forbidden scan for sorry/admit/maxHeartbeats/maxRecDepth in touched file