### PR TITLE
refactor(div): route n1 remainder evidence through hdiv package

### DIFF
--- a/EvmAsm/Evm64/DivMod/CallableV4DivShape.lean
+++ b/EvmAsm/Evm64/DivMod/CallableV4DivShape.lean
@@ -650,6 +650,123 @@ theorem evm_div_callable_v4_n1_stack_pre_to_callable_post_scratch_shape_allTrueP
     hbnz hb3z hb2z hb1z hshift_nz halign
     (N1SelectedIfBorrowPathEvidence.ofAllTruePathEvidence hpath) hevidence
 
+/-- N1 selected-if-borrow shape wrapper that derives the all-true path
+    evidence from public n=1 shape plus one-word remainder bounds, then routes
+    through the selected input/hdiv package.
+
+    This removes the explicit selected/all-true path evidence package from this
+    callable boundary. The selected-if-borrow semantic evidence is still needed
+    because it carries the call/max/max/max branch facts. -/
+theorem evm_div_callable_v4_n1_stack_pre_to_callable_post_scratch_shape_remaindersSelectedIfBorrowSemanticEvidence_inputHdivRoute
+    (sp base : Word) (a b : EvmWord)
+    (v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (hbnz : b ≠ 0)
+    (hb3z : b.getLimbN 3 = 0) (hb2z : b.getLimbN 2 = 0)
+    (hb1z : b.getLimbN 1 = 0)
+    (hshift_nz : (clzResult (b.getLimbN 0)).1 ≠ 0)
+    (halign : fullDivN1CallMaxmaxmaxExactInputAligned sp base
+      jMem (1 : Word) (fullDivN1Shift (b.getLimbN 0))
+      (fullDivN1NormU (a.getLimbN 0) (a.getLimbN 1)
+        (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0)).1
+      (a.getLimbN 0 >>> ((fullDivN1AntiShift (b.getLimbN 0)).toNat % 64))
+      v11Old (fullDivN1AntiShift (b.getLimbN 0))
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+      (0 : Word) (0 : Word) (0 : Word) (0 : Word)
+      retMem dMem dloMem scratchUn0 scratchMem raVal)
+    (hr3_lt :
+      EvmWord.val256
+        (fullDivN1R3 true
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.1
+        (fullDivN1R3 true
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+        (fullDivN1R3 true
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2.1
+        (fullDivN1R3 true
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2.2.1 <
+      (fullDivN1NormV
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1.toNat)
+    (hr2_lt :
+      EvmWord.val256
+        (fullDivN1R2 true true
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.1
+        (fullDivN1R2 true true
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+        (fullDivN1R2 true true
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2.1
+        (fullDivN1R2 true true
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2.2.1 <
+      (fullDivN1NormV
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1.toNat)
+    (hr1_lt :
+      EvmWord.val256
+        (fullDivN1R1 true true true
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.1
+        (fullDivN1R1 true true true
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+        (fullDivN1R1 true true true
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2.1
+        (fullDivN1R1 true true true
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).2.2.2.2.1 <
+      (fullDivN1NormV
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1.toNat)
+    (hpath : N1AllTruePathCallback a b)
+    (hevidence : FullDivN1CallMaxmaxmaxSelectedIfBorrowSemanticEvidenceV4 sp base
+      jMem (1 : Word) (fullDivN1Shift (b.getLimbN 0))
+      (fullDivN1NormU (a.getLimbN 0) (a.getLimbN 1)
+        (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0)).1
+      (a.getLimbN 0 >>> ((fullDivN1AntiShift (b.getLimbN 0)).toNat % 64))
+      v11Old (fullDivN1AntiShift (b.getLimbN 0))
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+      (0 : Word) (0 : Word) (0 : Word) (0 : Word)
+      retMem dMem dloMem scratchUn0 scratchMem raVal) :
+    cpsTripleWithin (unifiedDivBound + 1) base (raVal &&& ~~~1)
+      (evm_div_callable_code_v4 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult (b.getLimbN 0)).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divStackDispatchPostCallableExactFrame sp a b raVal
+        (signExtend12 4095 : Word) **
+       memOwn (sp + signExtend12 3936)) := by
+  exact evm_div_callable_v4_n1_stack_pre_to_callable_post_scratch_shape_selectedIfBorrowEvidence_inputHdivRoute
+    sp base a b
+    v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+    hbnz hb3z hb2z hb1z hshift_nz halign
+    (N1CallableSelectedIfBorrowShapeEvidence.ofRemaindersLtSelectedIfBorrowSemanticEvidence
+      sp base
+      jMem (1 : Word) (fullDivN1Shift (b.getLimbN 0))
+      (fullDivN1NormU (a.getLimbN 0) (a.getLimbN 1)
+        (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0)).1
+      (a.getLimbN 0 >>> ((fullDivN1AntiShift (b.getLimbN 0)).toNat % 64))
+      v11Old (fullDivN1AntiShift (b.getLimbN 0))
+      a b
+      (0 : Word) (0 : Word) (0 : Word) (0 : Word)
+      retMem dMem dloMem scratchUn0 scratchMem raVal
+      ((EvmWord.ne_zero_iff_getLimbN_or).mp hbnz)
+      hb3z hb2z hb1z hshift_nz hr3_lt hr2_lt hr1_lt hpath hevidence)
+
 /-- N2 DIV v4 callable wrapper deriving divisor nonzero from the n=2 shape
     while consuming only selected carry evidence for the actual path. -/
 theorem evm_div_callable_v4_n2_stack_pre_to_callable_post_scratch_shape_selectedCarry


### PR DESCRIPTION
Refs #61\n\nBead: evm-asm-9iqmw.7.1.6.1.3.2.2\nStacked on: #6902\n\n## Summary\n- add a callable N1 shape wrapper that derives bundled selected-if-borrow evidence from public n=1 shape facts plus one-word remainder bounds\n- route the resulting evidence through the selected input/hdiv package wrapper\n- remove the explicit selected/all-true path evidence package from this callable boundary while preserving selected-if-borrow semantic evidence for the call/max/max/max branch facts\n\n## Verification\n- lake build EvmAsm.Evm64.DivMod.CallableV4DivShape\n- lake build EvmAsm.Evm64.DivMod\n- lake build\n- Lean LSP diagnostics on CallableV4DivShape.lean: no errors after LSP rebuild\n- scripts/check-file-size.sh EvmAsm/Evm64/DivMod/CallableV4DivShape.lean EvmAsm/Evm64/DivMod/Spec/N1CallableSelectedIfBorrowShapeEvidence.lean\n- scripts/check-unimported.sh\n- git diff --check\n- forbidden scan for conflict markers, sorry/admit, maxHeartbeats/maxRecDepth