### PR TITLE
refactor(div): mark n4 addback mod post irreducible

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/ModN4V4StackPre.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/ModN4V4StackPre.lean
@@ -460,6 +460,7 @@ This isolates the arithmetic bridge still needed to turn the denormalized
 addback remainder into `EvmWord.mod a b`: callers can prove this assertion
 equals `evmWordIs (sp + 32) (EvmWord.mod a b)` once the remainder arithmetic
 is discharged. -/
+@[irreducible]
 def n4CallAddbackBeqModSlotPostV4
     (sp : Word) (a b : EvmWord) : Assertion :=
   let shift := (clzResult (b.getLimbN 3)).1


### PR DESCRIPTION
Refs #61\n\nBead: evm-asm-cw2fq\n\nSummary:\n- mark n4CallAddbackBeqModSlotPostV4 as @[irreducible] to keep the heavy MOD n=4 addback postcondition from unfolding accidentally\n\nVerification:\n- lake build EvmAsm.Evm64.DivMod.Spec.ModN4V4StackPre\n- lake build EvmAsm.Evm64.DivMod\n- lake build\n- Lean LSP diagnostics: no errors for EvmAsm/Evm64/DivMod/Spec/ModN4V4StackPre.lean\n- scripts/check-file-size.sh EvmAsm/Evm64/DivMod/Spec/ModN4V4StackPre.lean\n- scripts/check-unimported.sh\n- git diff --check\n- rg conflict/sorry/forbidden-option scan on edited file