### PR TITLE
refactor(div): bridge n1 branch facts to callable evidence

### DIFF
--- a/EvmAsm/Evm64/DivMod/CallableV4DivShape.lean
+++ b/EvmAsm/Evm64/DivMod/CallableV4DivShape.lean
@@ -696,6 +696,55 @@ theorem evm_div_callable_v4_n1_stack_pre_to_callable_post_scratch_shape_callable
     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
     hbnz hb3z hb2z hb1z hshift_nz halign hevidence
 
+
+/-- N1 callable wrapper deriving the private callable evidence bundle from
+    selected branch facts, all-true path evidence, and semantic facts. -/
+theorem evm_div_callable_v4_n1_stack_pre_to_callable_post_scratch_shape_branchFactsAllTruePathSemanticFacts_inputHdivRoute
+    (sp base : Word) (a b : EvmWord)
+    (v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (hbnz : b ≠ 0)
+    (hb3z : b.getLimbN 3 = 0) (hb2z : b.getLimbN 2 = 0)
+    (hb1z : b.getLimbN 1 = 0)
+    (hshift_nz : (clzResult (b.getLimbN 0)).1 ≠ 0)
+    (halign : fullDivN1CallMaxmaxmaxExactInputAligned sp base
+      jMem (1 : Word) (fullDivN1Shift (b.getLimbN 0))
+      (fullDivN1NormU (a.getLimbN 0) (a.getLimbN 1)
+        (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 0)).1
+      (a.getLimbN 0 >>> ((fullDivN1AntiShift (b.getLimbN 0)).toNat % 64))
+      v11Old (fullDivN1AntiShift (b.getLimbN 0))
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+      (0 : Word) (0 : Word) (0 : Word) (0 : Word)
+      retMem dMem dloMem scratchUn0 scratchMem raVal)
+    (hbranches : N1CallableSelectedIfBorrowBranchFacts a b)
+    (hpath : N1AllTruePathEvidence a b)
+    (hfacts : FullDivN1CallMaxmaxmaxSemanticFactsV4
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)) :
+    cpsTripleWithin (unifiedDivBound + 1) base (raVal &&& ~~~1)
+      (evm_div_callable_code_v4 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult (b.getLimbN 0)).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divStackDispatchPostCallableExactFrame sp a b raVal
+        (signExtend12 4095 : Word) **
+       memOwn (sp + signExtend12 3936)) := by
+  exact evm_div_callable_v4_n1_stack_pre_to_callable_post_scratch_shape_callableEvidence_inputHdivRoute
+    sp base a b
+    v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+    hbnz hb3z hb2z hb1z hshift_nz halign
+    (N1CallableSelectedIfBorrowShapeEvidence.ofBranchFactsAllTruePathSemanticFacts
+      hbranches hpath hfacts)
+
 /-- N1 selected-if-borrow shape wrapper that derives the all-true path
     evidence from public n=1 shape plus one-word remainder bounds, then routes
     through the selected input/hdiv package.

--- a/EvmAsm/Evm64/DivMod/Spec/N1CallableSelectedIfBorrowShapeEvidence.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N1CallableSelectedIfBorrowShapeEvidence.lean
@@ -151,6 +151,24 @@ theorem N1CallableSelectedIfBorrowShapeEvidence.of_parts {a b : EvmWord}
   rcases hbranches with ⟨hbltu3, hbltu2, hbltu1, hbltu0⟩
   exact ⟨hbltu3, hbltu2, hbltu1, hbltu0, hpath, hfacts⟩
 
+/-- Build bundled callable evidence from explicit selected branch facts,
+    all-true path evidence, and arithmetic semantic facts.
+
+    This removes the selected semantic evidence package from the caller
+    boundary; branch-fact discharge is left to the public wrapper layer. -/
+theorem N1CallableSelectedIfBorrowShapeEvidence.ofBranchFactsAllTruePathSemanticFacts
+    {a b : EvmWord}
+    (hbranches : N1CallableSelectedIfBorrowBranchFacts a b)
+    (hpath : N1AllTruePathEvidence a b)
+    (hfacts : FullDivN1CallMaxmaxmaxSemanticFactsV4
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)) :
+    N1CallableSelectedIfBorrowShapeEvidence a b := by
+  exact N1CallableSelectedIfBorrowShapeEvidence.of_parts hbranches
+    (N1SelectedIfBorrowPathEvidence.ofAllTruePathEvidence hpath)
+    hfacts
+
+
 theorem N1CallableSelectedIfBorrowShapeEvidence.ofSelectedIfBorrowSemanticEvidence
     (sp base : Word)
     (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)


### PR DESCRIPTION
Refs #61\n\nBead: evm-asm-9iqmw.7.1.6.1.3.2.2\n\nStacked on: #6909\n\nSummary:\n- add N1CallableSelectedIfBorrowShapeEvidence.ofBranchFactsAllTruePathSemanticFacts\n- add evm_div_callable_v4_n1_stack_pre_to_callable_post_scratch_shape_branchFactsAllTruePathSemanticFacts_inputHdivRoute\n- remove selected semantic evidence packages from this intermediate callable boundary; branch/path facts remain explicit for the next public-discharge slice\n\nVerification:\n- lake build EvmAsm.Evm64.DivMod.Spec.N1CallableSelectedIfBorrowShapeEvidence\n- lake build EvmAsm.Evm64.DivMod.CallableV4DivShape\n- lake build EvmAsm.Evm64.DivMod\n- lake build\n- Lean LSP diagnostics clean for edited files after lean_build\n- scripts/check-file-size.sh edited files\n- scripts/check-unimported.sh\n- git diff --check\n- rg conflict/sorry/forbidden-option scan on edited files