### PR TITLE
refactor(mod): name n4 addback getlimb obligation

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/ModN4V4StackPre.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/ModN4V4StackPre.lean
@@ -554,6 +554,107 @@ theorem n4CallAddbackBeqModSlotPostV4_eq_evmWordIs_of_getLimbN
   exact (evmWordIs_sp32_limbs_eq sp (EvmWord.mod a b) _ _ _ _
     hmod0 hmod1 hmod2 hmod3).symm
 
+
+
+/-- Named four-limb MOD output obligation for the n=4 v4 call+addback path.
+    This packages the long denormalized remainder expression so downstream
+    stack wrappers do not expose or re-normalize the full let-chain. -/
+@[irreducible]
+def n4CallAddbackBeqModGetLimbNPostV4 (a b : EvmWord) : Prop :=
+  let shift := (clzResult (b.getLimbN 3)).1
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b.getLimbN 3 <<< (shift.toNat % 64)) |||
+    (b.getLimbN 2 >>> (antiShift.toNat % 64))
+  let b2' := (b.getLimbN 2 <<< (shift.toNat % 64)) |||
+    (b.getLimbN 1 >>> (antiShift.toNat % 64))
+  let b1' := (b.getLimbN 1 <<< (shift.toNat % 64)) |||
+    (b.getLimbN 0 >>> (antiShift.toNat % 64))
+  let b0' := b.getLimbN 0 <<< (shift.toNat % 64)
+  let u4 := a.getLimbN 3 >>> (antiShift.toNat % 64)
+  let u3 := (a.getLimbN 3 <<< (shift.toNat % 64)) |||
+    (a.getLimbN 2 >>> (antiShift.toNat % 64))
+  let u2 := (a.getLimbN 2 <<< (shift.toNat % 64)) |||
+    (a.getLimbN 1 >>> (antiShift.toNat % 64))
+  let u1 := (a.getLimbN 1 <<< (shift.toNat % 64)) |||
+    (a.getLimbN 0 >>> (antiShift.toNat % 64))
+  let u0 := a.getLimbN 0 <<< (shift.toNat % 64)
+  let qHat := div128Quot_v4 u4 u3 b3'
+  let ms := mulsubN4 qHat b0' b1' b2' b3' u0 u1 u2 u3
+  let c3 := ms.2.2.2.2
+  let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 b0' b1' b2' b3'
+  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1
+    (u4 - c3) b0' b1' b2' b3'
+  let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1
+    ab.2.2.2.2 b0' b1' b2' b3'
+  let un0Out := if carry = 0 then ab'.1 else ab.1
+  let un1Out := if carry = 0 then ab'.2.1 else ab.2.1
+  let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
+  let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
+  let u0' := (un0Out >>> (shift.toNat % 64)) |||
+    (un1Out <<< (antiShift.toNat % 64))
+  let u1' := (un1Out >>> (shift.toNat % 64)) |||
+    (un2Out <<< (antiShift.toNat % 64))
+  let u2' := (un2Out >>> (shift.toNat % 64)) |||
+    (un3Out <<< (antiShift.toNat % 64))
+  let u3' := un3Out >>> (shift.toNat % 64)
+  (EvmWord.mod a b).getLimbN 0 = u0' ∧
+  (EvmWord.mod a b).getLimbN 1 = u1' ∧
+  (EvmWord.mod a b).getLimbN 2 = u2' ∧
+  (EvmWord.mod a b).getLimbN 3 = u3'
+
+/-- Named val256-level arithmetic target for the n=4 v4 call+addback MOD
+    getLimb bridge. A later arithmetic slice can prove this from
+    `n4CallAddbackBeqSemanticHolds` plus runtime bounds, then use it to close
+    `n4CallAddbackBeqModGetLimbNPostV4`. -/
+@[irreducible]
+def n4CallAddbackBeqModDenormVal256EqV4 (a b : EvmWord) : Prop :=
+  let shift := (clzResult (b.getLimbN 3)).1
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b.getLimbN 3 <<< (shift.toNat % 64)) |||
+    (b.getLimbN 2 >>> (antiShift.toNat % 64))
+  let b2' := (b.getLimbN 2 <<< (shift.toNat % 64)) |||
+    (b.getLimbN 1 >>> (antiShift.toNat % 64))
+  let b1' := (b.getLimbN 1 <<< (shift.toNat % 64)) |||
+    (b.getLimbN 0 >>> (antiShift.toNat % 64))
+  let b0' := b.getLimbN 0 <<< (shift.toNat % 64)
+  let u4 := a.getLimbN 3 >>> (antiShift.toNat % 64)
+  let u3 := (a.getLimbN 3 <<< (shift.toNat % 64)) |||
+    (a.getLimbN 2 >>> (antiShift.toNat % 64))
+  let u2 := (a.getLimbN 2 <<< (shift.toNat % 64)) |||
+    (a.getLimbN 1 >>> (antiShift.toNat % 64))
+  let u1 := (a.getLimbN 1 <<< (shift.toNat % 64)) |||
+    (a.getLimbN 0 >>> (antiShift.toNat % 64))
+  let u0 := a.getLimbN 0 <<< (shift.toNat % 64)
+  let qHat := div128Quot_v4 u4 u3 b3'
+  let ms := mulsubN4 qHat b0' b1' b2' b3' u0 u1 u2 u3
+  let c3 := ms.2.2.2.2
+  let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 b0' b1' b2' b3'
+  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1
+    (u4 - c3) b0' b1' b2' b3'
+  let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1
+    ab.2.2.2.2 b0' b1' b2' b3'
+  let un0Out := if carry = 0 then ab'.1 else ab.1
+  let un1Out := if carry = 0 then ab'.2.1 else ab.2.1
+  let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
+  let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
+  EvmWord.val256 un0Out un1Out un2Out un3Out =
+    EvmWord.val256 (a.getLimbN 0) (a.getLimbN 1)
+      (a.getLimbN 2) (a.getLimbN 3) %
+      EvmWord.val256 (b.getLimbN 0) (b.getLimbN 1)
+        (b.getLimbN 2) (b.getLimbN 3) *
+    2 ^ (shift.toNat % 64)
+
+/-- Named-predicate variant of
+    `n4CallAddbackBeqModSlotPostV4_eq_evmWordIs_of_getLimbN`. -/
+theorem n4CallAddbackBeqModSlotPostV4_eq_evmWordIs_of_getLimbNPost
+    (sp : Word) (a b : EvmWord)
+    (hmod : n4CallAddbackBeqModGetLimbNPostV4 a b) :
+    n4CallAddbackBeqModSlotPostV4 sp a b =
+      evmWordIs (sp + 32) (EvmWord.mod a b) := by
+  exact n4CallAddbackBeqModSlotPostV4_eq_evmWordIs_of_getLimbN sp a b (by
+    delta n4CallAddbackBeqModGetLimbNPostV4 at hmod
+    exact hmod)
+
 /-- Bundled variant of
     `evm_mod_n4_full_call_addback_beq_stack_pre_spec_within_v4`: takes the
     precondition as a single `modN4StackPreCall` atom plus the v4 scratch cell. -/
@@ -705,5 +806,33 @@ theorem evm_mod_n4_call_addback_beq_stack_spec_within_v4_of_getLimbN (sp base : 
     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
     hbnz hb3nz hshift_nz halign hbltu hcarry2_nz hborrow
     (n4CallAddbackBeqModSlotPostV4_eq_evmWordIs_of_getLimbN sp a b hmod)
+
+/-- Named-predicate variant of
+    `evm_mod_n4_call_addback_beq_stack_spec_within_v4_of_getLimbN`. -/
+theorem evm_mod_n4_call_addback_beq_stack_spec_within_v4_of_getLimbNPost (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (hbnz : b ≠ 0)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hbltu : isCallTrialN4Evm a b)
+    (hcarry2_nz : isAddbackCarry2NzN4CallV4Evm a b)
+    (hborrow : isAddbackBorrowN4CallV4Evm a b)
+    (hmod : n4CallAddbackBeqModGetLimbNPostV4 a b) :
+    cpsTripleWithin (8 + 21 + 24 + 4 + 21 + 21 + 4 + 224 + 2 + 23 + 10)
+      base (base + nopOff) (modCode_v4 base)
+      (modN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       (sp + signExtend12 3936 ↦ₘ scratchMem))
+      (modN4CallSkipStackPost sp a b ** memOwn (sp + signExtend12 3936)) := by
+  exact evm_mod_n4_call_addback_beq_stack_spec_within_v4_of_slot_post
+    sp base a b v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem
+    hbnz hb3nz hshift_nz halign hbltu hcarry2_nz hborrow
+    (n4CallAddbackBeqModSlotPostV4_eq_evmWordIs_of_getLimbNPost sp a b hmod)
 
 end EvmAsm.Evm64


### PR DESCRIPTION
Refs #61.

Bead: evm-asm-9iqmw.7.2.1

Summary:
- Adds n4CallAddbackBeqModGetLimbNPostV4 to name the long denormalized MOD getLimb obligation for the n=4 v4 call+addback path.
- Adds n4CallAddbackBeqModDenormVal256EqV4 as the smaller val256 arithmetic target for the remaining bridge.
- Adds named-predicate wrappers for the slot-post adapter and stack theorem so downstream work can consume the packaged getLimb obligation without re-normalizing the let-chain.

Verification:
- lake build EvmAsm.Evm64.DivMod.Spec.ModN4V4StackPre
- lake build EvmAsm.Evm64.DivMod
- lake build
- scripts/check-file-size.sh EvmAsm/Evm64/DivMod/Spec/ModN4V4StackPre.lean
- scripts/check-unimported.sh
- git diff --check
- Lean LSP diagnostics: no errors in ModN4V4StackPre.lean