### PR TITLE
feat(div): name n4 runtime high-div semantic bridge

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/CallAddbackRuntimeHighDiv.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/CallAddbackRuntimeHighDiv.lean
@@ -541,6 +541,72 @@ theorem n4CallAddbackBeqSemanticHolds_of_shift_nz_high_div_bound_and_borrow
     n4CallAddbackBeqSemanticHoldsV4_of_shift_nz_high_div_bound_and_borrow
       hb3nz hshift_nz h_rhat_hi_zero h_qhat_high h_high_div h_borrow h_carry2
 
+/-- Call-path semantic bridge from packaged high-div evidence.
+    This is the call-local runtime wrapper shape needed by the final
+    runtime-only discharger: the old `hq_over` and `h_rem_lt` obligations are
+    hidden behind the named high-div evidence package. -/
+theorem n4CallAddbackBeqSemanticHoldsV4_of_call_runtime_high_div_evidence
+    {a b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (hcall : isCallTrialN4Evm a b)
+    (h_evidence : n4CallAddbackBeqShiftHighDivEvidence a b)
+    (h_borrow : isAddbackBorrowN4CallV4Evm a b)
+    (h_carry2 : isAddbackCarry2NzN4CallV4Evm a b) :
+    n4CallAddbackBeqSemanticHoldsV4 a b :=
+  n4CallAddbackBeqSemanticHoldsV4_of_call_evm_high_div_bound_and_borrow
+    hb3nz hshift_nz hcall
+    (by
+      simpa [n4CallAddbackBeqRhatddHiZero_def] using
+        n4CallAddbackBeqShiftHighDivEvidence.rhatddHiZero h_evidence)
+    (n4CallAddbackBeqShiftHighDivEvidence.qhatHighDiv h_evidence)
+    (n4CallAddbackBeqShiftHighDivEvidence.knuthA h_evidence)
+    h_borrow h_carry2
+
+/-- Historical spelling of
+    `n4CallAddbackBeqSemanticHoldsV4_of_call_runtime_high_div_evidence`. -/
+theorem n4CallAddbackBeqSemanticHolds_of_call_runtime_high_div_evidence
+    {a b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (hcall : isCallTrialN4Evm a b)
+    (h_evidence : n4CallAddbackBeqShiftHighDivEvidence a b)
+    (h_borrow : isAddbackBorrowN4CallV4Evm a b)
+    (h_carry2 : isAddbackCarry2NzN4CallV4Evm a b) :
+    n4CallAddbackBeqSemanticHolds a b := by
+  simpa [n4CallAddbackBeqSemanticHolds_eq_v4] using
+    n4CallAddbackBeqSemanticHoldsV4_of_call_runtime_high_div_evidence
+      hb3nz hshift_nz hcall h_evidence h_borrow h_carry2
+
+/-- Shift-nonzero semantic bridge from packaged high-div evidence. It derives
+    the call-trial premise internally from the n=4 top-limb and shift facts,
+    while still keeping the named high-div evidence explicit. -/
+theorem n4CallAddbackBeqSemanticHoldsV4_of_shift_runtime_high_div_evidence
+    {a b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (h_evidence : n4CallAddbackBeqShiftHighDivEvidence a b)
+    (h_borrow : isAddbackBorrowN4CallV4Evm a b)
+    (h_carry2 : isAddbackCarry2NzN4CallV4Evm a b) :
+    n4CallAddbackBeqSemanticHoldsV4 a b :=
+  n4CallAddbackBeqSemanticHoldsV4_of_call_runtime_high_div_evidence
+    hb3nz hshift_nz (isCallTrialN4Evm_of_shift_nz a b hb3nz hshift_nz)
+    h_evidence h_borrow h_carry2
+
+/-- Historical spelling of
+    `n4CallAddbackBeqSemanticHoldsV4_of_shift_runtime_high_div_evidence`. -/
+theorem n4CallAddbackBeqSemanticHolds_of_shift_runtime_high_div_evidence
+    {a b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (h_evidence : n4CallAddbackBeqShiftHighDivEvidence a b)
+    (h_borrow : isAddbackBorrowN4CallV4Evm a b)
+    (h_carry2 : isAddbackCarry2NzN4CallV4Evm a b) :
+    n4CallAddbackBeqSemanticHolds a b := by
+  simpa [n4CallAddbackBeqSemanticHolds_eq_v4] using
+    n4CallAddbackBeqSemanticHoldsV4_of_shift_runtime_high_div_evidence
+      hb3nz hshift_nz h_evidence h_borrow h_carry2
+
 /-- Runtime-bounds bridge from packaged shift/high-div evidence. -/
 theorem n4CallAddbackBeqRuntimeBounds_of_shift_high_div_evidence_and_borrow
     {a b : EvmWord}

--- a/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcher.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcher.lean
@@ -442,7 +442,7 @@ theorem n4ShiftNzDispatcherRuntimeHighDivEvidence.semanticHoldsV4 {a b : EvmWord
     (hruntime : n4ShiftNzDispatcherRuntimeHighDivEvidence a b)
     (hadd : isAddbackBorrowN4CallV4Evm a b) :
     n4CallAddbackBeqSemanticHoldsV4 a b :=
-  n4CallAddbackBeqSemanticHoldsV4_of_shift_high_div_evidence_and_borrow
+  n4CallAddbackBeqSemanticHoldsV4_of_shift_runtime_high_div_evidence
     hb3nz hshift_nz
     (n4ShiftNzDispatcherRuntimeHighDivEvidence.addbackHighDivEvidence hruntime)
     hadd

--- a/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcherSemanticParts.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcherSemanticParts.lean
@@ -132,7 +132,7 @@ theorem n4ShiftNzDispatcherBranchHighDivEvidence.semanticHoldsV4_of_addback_part
     (hcarry2 : isAddbackCarry2NzN4CallV4Evm a b)
     (hevidence : n4CallAddbackBeqShiftHighDivEvidence a b) :
     n4CallAddbackBeqSemanticHoldsV4 a b :=
-  n4CallAddbackBeqSemanticHoldsV4_of_shift_high_div_evidence_and_borrow
+  n4CallAddbackBeqSemanticHoldsV4_of_shift_runtime_high_div_evidence
     hb3nz hshift_nz hevidence hadd hcarry2
 
 /-- Historical non-V4 addback semantic bridge from direct packaged high-div


### PR DESCRIPTION
Refs #61.\n\nBead: evm-asm-9iqmw.7.1.4.3\n\nSummary:\n- add call-path and shift-nonzero N4 semantic bridges from packaged high-div evidence\n- keep hq_over, h_rem_lt, and compact RuntimeBounds hidden behind n4CallAddbackBeqShiftHighDivEvidence\n- route dispatcher-facing semantic projections through the new stable runtime high-div bridge name\n\nNote: this does not close the exact raw runtime-only theorem yet; the surviving high-div evidence package remains explicit.\n\nVerification:\n- lake build EvmAsm.Evm64.DivMod.Spec.CallAddbackRuntimeHighDiv\n- lake build EvmAsm.Evm64.DivMod.Spec.N4V4ShiftNzDispatcher EvmAsm.Evm64.DivMod.Spec.N4V4ShiftNzDispatcherSemanticParts\n- lake build EvmAsm.Evm64.DivMod\n- Lean LSP diagnostics for touched files\n- scripts/check-file-size.sh touched files\n- scripts/check-unimported.sh\n- git diff --check\n- forbidden placeholder/options scan over touched files