### PR TITLE
feat(div): add n4 raw runtime semantic bridges

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/CallAddbackRuntimeHighDiv.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/CallAddbackRuntimeHighDiv.lean
@@ -607,6 +607,131 @@ theorem n4CallAddbackBeqSemanticHolds_of_shift_runtime_high_div_evidence
     n4CallAddbackBeqSemanticHoldsV4_of_shift_runtime_high_div_evidence
       hb3nz hshift_nz h_evidence h_borrow h_carry2
 
+/-- Call-path semantic bridge from raw high-div evidence parts. This names the
+    route from concrete arithmetic facts into the packaged runtime semantic
+    bridge, keeping the final runtime-only path off the compact `RuntimeBounds`
+    predicate. -/
+theorem n4CallAddbackBeqSemanticHoldsV4_of_call_runtime_high_div_raw_parts
+    {a b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (hcall : isCallTrialN4Evm a b)
+    (h_rhat_hi_zero :
+      divKTrialCallV4Rhatdd
+          (n4CallAddbackBeqU4 a b)
+          (n4CallAddbackBeqU3 a b)
+          (n4CallAddbackBeqB3Prime b) >>> (32 : BitVec 6).toNat =
+        (0 : Word))
+    (h_qhat_le_high_div :
+      (n4CallAddbackBeqQHatV4 a b).toNat ≤
+        ((n4CallAddbackBeqU4 a b).toNat * 2^64 +
+            (n4CallAddbackBeqU3 a b).toNat) /
+          (n4CallAddbackBeqB3Prime b).toNat)
+    (h_high_div_le_norm_plus_one :
+      ((n4CallAddbackBeqU4 a b).toNat * 2^64 +
+          (n4CallAddbackBeqU3 a b).toNat) /
+        (n4CallAddbackBeqB3Prime b).toNat ≤
+          n4CallAddbackBeqULoNormVal a b / n4CallAddbackBeqBNormVal b + 1)
+    (h_borrow : isAddbackBorrowN4CallV4Evm a b)
+    (h_carry2 : isAddbackCarry2NzN4CallV4Evm a b) :
+    n4CallAddbackBeqSemanticHoldsV4 a b :=
+  n4CallAddbackBeqSemanticHoldsV4_of_call_runtime_high_div_evidence
+    hb3nz hshift_nz hcall
+    (n4CallAddbackBeqShiftHighDivEvidence.of_raw_parts
+      h_rhat_hi_zero h_qhat_le_high_div h_high_div_le_norm_plus_one)
+    h_borrow h_carry2
+
+/-- Historical spelling of
+    `n4CallAddbackBeqSemanticHoldsV4_of_call_runtime_high_div_raw_parts`. -/
+theorem n4CallAddbackBeqSemanticHolds_of_call_runtime_high_div_raw_parts
+    {a b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (hcall : isCallTrialN4Evm a b)
+    (h_rhat_hi_zero :
+      divKTrialCallV4Rhatdd
+          (n4CallAddbackBeqU4 a b)
+          (n4CallAddbackBeqU3 a b)
+          (n4CallAddbackBeqB3Prime b) >>> (32 : BitVec 6).toNat =
+        (0 : Word))
+    (h_qhat_le_high_div :
+      (n4CallAddbackBeqQHatV4 a b).toNat ≤
+        ((n4CallAddbackBeqU4 a b).toNat * 2^64 +
+            (n4CallAddbackBeqU3 a b).toNat) /
+          (n4CallAddbackBeqB3Prime b).toNat)
+    (h_high_div_le_norm_plus_one :
+      ((n4CallAddbackBeqU4 a b).toNat * 2^64 +
+          (n4CallAddbackBeqU3 a b).toNat) /
+        (n4CallAddbackBeqB3Prime b).toNat ≤
+          n4CallAddbackBeqULoNormVal a b / n4CallAddbackBeqBNormVal b + 1)
+    (h_borrow : isAddbackBorrowN4CallV4Evm a b)
+    (h_carry2 : isAddbackCarry2NzN4CallV4Evm a b) :
+    n4CallAddbackBeqSemanticHolds a b := by
+  simpa [n4CallAddbackBeqSemanticHolds_eq_v4] using
+    n4CallAddbackBeqSemanticHoldsV4_of_call_runtime_high_div_raw_parts
+      hb3nz hshift_nz hcall h_rhat_hi_zero h_qhat_le_high_div
+      h_high_div_le_norm_plus_one h_borrow h_carry2
+
+/-- Shift-nonzero semantic bridge from raw high-div evidence parts, deriving
+    the call-trial premise internally. -/
+theorem n4CallAddbackBeqSemanticHoldsV4_of_shift_runtime_high_div_raw_parts
+    {a b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (h_rhat_hi_zero :
+      divKTrialCallV4Rhatdd
+          (n4CallAddbackBeqU4 a b)
+          (n4CallAddbackBeqU3 a b)
+          (n4CallAddbackBeqB3Prime b) >>> (32 : BitVec 6).toNat =
+        (0 : Word))
+    (h_qhat_le_high_div :
+      (n4CallAddbackBeqQHatV4 a b).toNat ≤
+        ((n4CallAddbackBeqU4 a b).toNat * 2^64 +
+            (n4CallAddbackBeqU3 a b).toNat) /
+          (n4CallAddbackBeqB3Prime b).toNat)
+    (h_high_div_le_norm_plus_one :
+      ((n4CallAddbackBeqU4 a b).toNat * 2^64 +
+          (n4CallAddbackBeqU3 a b).toNat) /
+        (n4CallAddbackBeqB3Prime b).toNat ≤
+          n4CallAddbackBeqULoNormVal a b / n4CallAddbackBeqBNormVal b + 1)
+    (h_borrow : isAddbackBorrowN4CallV4Evm a b)
+    (h_carry2 : isAddbackCarry2NzN4CallV4Evm a b) :
+    n4CallAddbackBeqSemanticHoldsV4 a b :=
+  n4CallAddbackBeqSemanticHoldsV4_of_call_runtime_high_div_raw_parts
+    hb3nz hshift_nz (isCallTrialN4Evm_of_shift_nz a b hb3nz hshift_nz)
+    h_rhat_hi_zero h_qhat_le_high_div h_high_div_le_norm_plus_one
+    h_borrow h_carry2
+
+/-- Historical spelling of
+    `n4CallAddbackBeqSemanticHoldsV4_of_shift_runtime_high_div_raw_parts`. -/
+theorem n4CallAddbackBeqSemanticHolds_of_shift_runtime_high_div_raw_parts
+    {a b : EvmWord}
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (h_rhat_hi_zero :
+      divKTrialCallV4Rhatdd
+          (n4CallAddbackBeqU4 a b)
+          (n4CallAddbackBeqU3 a b)
+          (n4CallAddbackBeqB3Prime b) >>> (32 : BitVec 6).toNat =
+        (0 : Word))
+    (h_qhat_le_high_div :
+      (n4CallAddbackBeqQHatV4 a b).toNat ≤
+        ((n4CallAddbackBeqU4 a b).toNat * 2^64 +
+            (n4CallAddbackBeqU3 a b).toNat) /
+          (n4CallAddbackBeqB3Prime b).toNat)
+    (h_high_div_le_norm_plus_one :
+      ((n4CallAddbackBeqU4 a b).toNat * 2^64 +
+          (n4CallAddbackBeqU3 a b).toNat) /
+        (n4CallAddbackBeqB3Prime b).toNat ≤
+          n4CallAddbackBeqULoNormVal a b / n4CallAddbackBeqBNormVal b + 1)
+    (h_borrow : isAddbackBorrowN4CallV4Evm a b)
+    (h_carry2 : isAddbackCarry2NzN4CallV4Evm a b) :
+    n4CallAddbackBeqSemanticHolds a b := by
+  simpa [n4CallAddbackBeqSemanticHolds_eq_v4] using
+    n4CallAddbackBeqSemanticHoldsV4_of_shift_runtime_high_div_raw_parts
+      hb3nz hshift_nz h_rhat_hi_zero h_qhat_le_high_div
+      h_high_div_le_norm_plus_one h_borrow h_carry2
+
 /-- Runtime-bounds bridge from packaged shift/high-div evidence. -/
 theorem n4CallAddbackBeqRuntimeBounds_of_shift_high_div_evidence_and_borrow
     {a b : EvmWord}
@@ -709,11 +834,9 @@ theorem n4CallAddbackBeqSemanticHoldsV4_of_shift_high_div_raw_parts_and_borrow
     (h_borrow : isAddbackBorrowN4CallV4Evm a b)
     (h_carry2 : isAddbackCarry2NzN4CallV4Evm a b) :
     n4CallAddbackBeqSemanticHoldsV4 a b :=
-  n4CallAddbackBeqSemanticHoldsV4_of_shift_high_div_evidence_and_borrow
-    hb3nz hshift_nz
-    (n4CallAddbackBeqShiftHighDivEvidence.of_raw_parts
-      h_rhat_hi_zero h_qhat_le_high_div h_high_div_le_norm_plus_one)
-    h_borrow h_carry2
+  n4CallAddbackBeqSemanticHoldsV4_of_shift_runtime_high_div_raw_parts
+    hb3nz hshift_nz h_rhat_hi_zero h_qhat_le_high_div
+    h_high_div_le_norm_plus_one h_borrow h_carry2
 
 /-- Historical non-`V4` spelling of
     `n4CallAddbackBeqSemanticHoldsV4_of_shift_high_div_raw_parts_and_borrow`. -/

--- a/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcher.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcher.lean
@@ -545,10 +545,11 @@ theorem n4ShiftNzDispatcherRuntimeHighDivRawEvidence.semanticHoldsV4 {a b : EvmW
     (hruntime : n4ShiftNzDispatcherRuntimeHighDivRawEvidence a b)
     (hadd : isAddbackBorrowN4CallV4Evm a b) :
     n4CallAddbackBeqSemanticHoldsV4 a b :=
-  n4ShiftNzDispatcherRuntimeHighDivEvidence.semanticHoldsV4
-    hb3nz hshift_nz
-    (n4ShiftNzDispatcherRuntimeHighDivEvidence_of_raw hruntime)
-    hadd
+by
+  rw [n4ShiftNzDispatcherRuntimeHighDivRawEvidence_def] at hruntime
+  exact n4CallAddbackBeqSemanticHoldsV4_of_shift_runtime_high_div_raw_parts
+    hb3nz hshift_nz hruntime.2.2.1 hruntime.2.2.2.1 hruntime.2.2.2.2
+    hadd hruntime.2.1
 
 theorem n4ShiftNzDispatcherRuntimeHighDivRawEvidence.semanticHolds {a b : EvmWord}
     (hb3nz : b.getLimbN 3 ≠ 0)

--- a/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcherSemanticParts.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N4V4ShiftNzDispatcherSemanticParts.lean
@@ -174,7 +174,7 @@ theorem n4ShiftNzDispatcherBranchHighDivRawEvidence.semanticHoldsV4_of_addback_p
         (n4CallAddbackBeqB3Prime b).toNat ≤
           n4CallAddbackBeqULoNormVal a b / n4CallAddbackBeqBNormVal b + 1) :
     n4CallAddbackBeqSemanticHoldsV4 a b :=
-  n4CallAddbackBeqSemanticHoldsV4_of_shift_high_div_raw_parts_and_borrow
+  n4CallAddbackBeqSemanticHoldsV4_of_shift_runtime_high_div_raw_parts
     hb3nz hshift_nz h_rhat_hi_zero h_qhat_le_high_div
     h_high_div_le_norm_plus_one hadd hcarry2
 


### PR DESCRIPTION
Refs #61.\n\nBead: evm-asm-9iqmw.7.1.4.3.2\n\nSummary:\n- add call-path and shift-nonzero N4 semantic bridges from raw high-div evidence parts\n- route the existing raw semantic theorem through the new runtime raw bridge alias\n- route raw dispatcher semantic projections through the new stable raw bridge path\n\nNote: this advances evm-asm-9iqmw.7.1.4.3 but does not claim the final n4CallAddbackBeqSemanticHoldsV4_of_runtime_only theorem; high-div/Knuth-A facts are still explicit.\n\nVerification:\n- lake build EvmAsm.Evm64.DivMod.Spec.CallAddbackRuntimeHighDiv\n- lake build EvmAsm.Evm64.DivMod.Spec.N4V4ShiftNzDispatcher EvmAsm.Evm64.DivMod.Spec.N4V4ShiftNzDispatcherSemanticParts\n- lake build EvmAsm.Evm64.DivMod\n- Lean LSP full build and diagnostics for touched files\n- scripts/check-file-size.sh touched files\n- scripts/check-unimported.sh\n- git diff --check\n- forbidden placeholder/options scan over touched files