### PR TITLE
feat(div): add N2 selected package eliminators

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N2SelectedQuotientHdivs.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2SelectedQuotientHdivs.lean
@@ -65,4 +65,54 @@ theorem FullDivN2SelectedQuotientHdivs.of_evidence
   exact ⟨bltu2, bltu1, bltu0, hbltu2, hbltu1, hbltu0,
     hdivWord, hdiv0, hdiv1, hdiv2, hdiv3⟩
 
+/-- Build the selected N2 quotient/hdiv package from the public n=2 divisor
+    shape plus bundled selected evidence. -/
+theorem FullDivN2SelectedQuotientHdivs.of_shape_evidence
+    {a b : EvmWord}
+    (_hb3z : b.getLimbN 3 = 0) (_hb2z : b.getLimbN 2 = 0)
+    (hb1nz : b.getLimbN 1 ≠ 0)
+    (hevidence : N2CallableSelectedShapeEvidence a b) :
+    FullDivN2SelectedQuotientHdivs a b := by
+  exact FullDivN2SelectedQuotientHdivs.of_evidence
+    ((EvmWord.ne_zero_iff_getLimbN_or).mpr
+      (n2_limb_or_ne_zero_of_limb1_ne_zero hb1nz))
+    hevidence
+
+/-- Eliminate the selected N2 quotient/hdiv package into the explicit branch,
+    quotient-word, and quotient-limb facts consumed by wrapper plumbing. -/
+theorem FullDivN2SelectedQuotientHdivs.exists
+    {a b : EvmWord}
+    (hpkg : FullDivN2SelectedQuotientHdivs a b) :
+    ∃ bltu2 bltu1 bltu0,
+      isTrialN2V4_j2 bltu2
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) ∧
+      isTrialN2V4_j1 bltu2 bltu1
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) ∧
+      isTrialN2V4_j0 bltu2 bltu1 bltu0
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) ∧
+      fullDivN2QuotientWordV4 bltu2 bltu1 bltu0
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) =
+          EvmWord.div a b ∧
+      (EvmWord.div a b).getLimbN 0 =
+        (fullDivN2R0V4 bltu2 bltu1 bltu0
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1 ∧
+      (EvmWord.div a b).getLimbN 1 =
+        (fullDivN2R1V4 bltu2 bltu1
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1 ∧
+      (EvmWord.div a b).getLimbN 2 =
+        (fullDivN2R2V4 bltu2
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1 ∧
+      (EvmWord.div a b).getLimbN 3 = (0 : Word) := by
+  cases hpkg with
+  | mk bltu2 bltu1 bltu0 hbltu2 hbltu1 hbltu0 hdivWord hdiv0 hdiv1 hdiv2 hdiv3 =>
+      exact ⟨bltu2, bltu1, bltu0,
+        hbltu2, hbltu1, hbltu0, hdivWord, hdiv0, hdiv1, hdiv2, hdiv3⟩
+
 end EvmAsm.Evm64


### PR DESCRIPTION
Summary:
- add FullDivN2SelectedQuotientHdivs.of_shape_evidence to derive the selected quotient package from public N2 divisor shape plus selected evidence
- add FullDivN2SelectedQuotientHdivs.exists to expose branch witnesses, quotient-word equality, and hdiv limb facts for final wrapper plumbing

Verification:
- lake build EvmAsm.Evm64.DivMod.Spec.N2SelectedQuotientHdivs
- lake build EvmAsm.Evm64.DivMod
- Lean LSP diagnostics for EvmAsm/Evm64/DivMod/Spec/N2SelectedQuotientHdivs.lean
- scripts/check-unimported.sh
- scripts/check-file-size.sh
- git diff --check
- touched-file scan for conflict markers, sorry/admit, heartbeat/recDepth overrides, and legacy Carry2NzAll/fullDivN2Carry2NzV4 mentions

Refs #61.
Bead: evm-asm-9iqmw.7.1.6.2.3.1