### PR TITLE
feat(div): N2 selected quotient/hdiv from canonical-bltu pointed evidence

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -72,6 +72,7 @@ import EvmAsm.Evm64.DivMod.Spec.N2CallableSelectedShapeEvidence
 import EvmAsm.Evm64.DivMod.Spec.N2V4CallableExactSelectedEvidence
 import EvmAsm.Evm64.DivMod.Spec.N2SelectedQuotientHdivs
 import EvmAsm.Evm64.DivMod.Spec.N2CallableSelectedShapeEvidenceCanonical
+import EvmAsm.Evm64.DivMod.Spec.N2SelectedQuotientHdivsCanonical
 import EvmAsm.Evm64.DivMod.Spec.BzeroV4ExactCallable
 import EvmAsm.Evm64.DivMod.Spec.ModBzeroV4Callable
 import EvmAsm.Evm64.DivMod.Spec.BzeroV4ExactFrame

--- a/EvmAsm/Evm64/DivMod/Spec/N2SelectedQuotientHdivsCanonical.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2SelectedQuotientHdivsCanonical.lean
@@ -1,0 +1,40 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N2SelectedQuotientHdivsCanonical
+
+  Convenience constructor for `FullDivN2SelectedQuotientHdivs` that takes
+  pointed canonical-bltu evidence (selected carry plus mulsub ∧ overestimate
+  at the canonical bltu triple) plus the n=2 divisor-shape facts, and routes
+  through `N2CallableSelectedShapeEvidence.of_canonical` followed by
+  `FullDivN2SelectedQuotientHdivs.of_shape_evidence`.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.N2SelectedQuotientHdivs
+import EvmAsm.Evm64.DivMod.Spec.N2CallableSelectedShapeEvidenceCanonical
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Build the selected N2 quotient/hdiv package directly from pointed
+    canonical-bltu evidence and the n=2 shape facts. -/
+theorem FullDivN2SelectedQuotientHdivs.of_canonical
+    {a b : EvmWord}
+    (hb3z : b.getLimbN 3 = 0) (hb2z : b.getLimbN 2 = 0)
+    (hb1nz : b.getLimbN 1 ≠ 0)
+    (hcarry : fullDivN2SelectedCarryV4
+      (n2V4CanonicalBltu2 a b) (n2V4CanonicalBltu1 a b) (n2V4CanonicalBltu0 a b)
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3))
+    (harith : fullDivN2MulSubEqV4
+        (n2V4CanonicalBltu2 a b) (n2V4CanonicalBltu1 a b) (n2V4CanonicalBltu0 a b)
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) ∧
+      fullDivN2QuotientOverestimateV4
+        (n2V4CanonicalBltu2 a b) (n2V4CanonicalBltu1 a b) (n2V4CanonicalBltu0 a b)
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)) :
+    FullDivN2SelectedQuotientHdivs a b :=
+  FullDivN2SelectedQuotientHdivs.of_shape_evidence hb3z hb2z hb1nz
+    (N2CallableSelectedShapeEvidence.of_canonical hcarry harith)
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Add FullDivN2SelectedQuotientHdivs.of_canonical which takes pointed canonical-bltu evidence (fullDivN2SelectedCarryV4 and mulsub ∧ overestimate at n2V4CanonicalBltu{2,1,0}) plus n=2 shape facts and directly produces the quotient/hdiv package.
- Internally composes N2CallableSelectedShapeEvidence.of_canonical (from merged PR #6945) with FullDivN2SelectedQuotientHdivs.of_shape_evidence.

Downstream proofs of the public N2 wrapper now have a single-call entry point to the quotient/hdiv package from pointed canonical evidence — no Selected bundle and no universal callbacks needed.

Refs #61. Bead: evm-asm-9iqmw.7.1.6.2.3.4.

Authored by @pirapira; implemented by Claude Code