### PR TITLE
test(stateless): bail out loudly if spec generator or emulator output is missing

### DIFF
--- a/scripts/codegen-stateless-spec-output-check.sh
+++ b/scripts/codegen-stateless-spec-output-check.sh
@@ -479,9 +479,25 @@ with open(sys.argv[3], 'w') as f:
     f.write(spec_bytes.hex())
 " "$cid" "$input_file" "$spec_exp_file" "$fork" "$witness_code_hex" "$witness_state_hex" "$public_key_hex" "$block_number" "$timestamp" "$blob_schedule" "$witness_headers_hex"
 
+  # Guard against silent fail: if the spec generator crashed
+  # (Python syntax error in the heredoc, missing import, etc.)
+  # both $spec_exp_file and $out_file would be missing or empty,
+  # and the later "actual == spec_expected" string compare would
+  # see "" == "" and report PASS. Bail out loudly here instead.
+  if [[ ! -s "$spec_exp_file" ]]; then
+    echo "    FAIL: spec-expected file is missing or empty -- spec generator crashed" >&2
+    return 1
+  fi
+
   echo "==> [$label] ziskemu run"
   "$ZISKEMU" -e gen-out/stateless_guest.elf -i "$input_file" \
     -o "$out_file" -n 500000 >"$log_file" 2>&1
+
+  if [[ ! -s "$out_file" ]]; then
+    echo "    FAIL: ziskemu output file is missing or empty -- emulator crashed" >&2
+    sed -n '$p' "$log_file" >&2 || true
+    return 1
+  fi
 
   local actual spec_expected spec_len
   spec_expected="$(cat "$spec_exp_file")"


### PR DESCRIPTION
## Summary
Fix a silent-PASS blind spot in \`codegen-stateless-spec-output-check.sh\` caught during PR #6944 development. When the Python heredoc that generates \`\$spec_exp_file\` crashes (e.g. a SyntaxError in the multi-header sentinel chain), the script previously reported PASS:

\`\`\`bash
spec_expected=\"\$(cat \"\$spec_exp_file\")\"   # cat fails, \"\" assigned
actual=\"\$(xxd -p -l \"\$spec_len\" \"\$out_file\" | tr -d '\\n')\"
                                              # xxd fails, \"\" assigned
[[ \"\$actual\" == \"\$spec_expected\" ]]        # \"\" == \"\" -> true -> PASS
\`\`\`

Same blind spot if ziskemu crashes before writing \`\$out_file\`.

Add two guards:
- Right after the spec generator: if \`\$spec_exp_file\` is missing or empty, FAIL with a \"spec generator crashed\" message before ziskemu runs.
- Right after ziskemu: if \`\$out_file\` is missing or empty, FAIL with the last line of the emu log as a hint.

## Test plan
- [x] Full suite — all currently-merged fixtures still PASS (guards are tight enough not to false-positive).
- [x] Manually tested with an empty \`\$spec_exp_file\`; the guard fires and returns 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)