### PR TITLE
feat(div): N3 canonical-bltu iff for N3CallableSelectedShapeEvidence

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -66,6 +66,7 @@ import EvmAsm.Evm64.DivMod.Spec.N3V4CallableExact
 import EvmAsm.Evm64.DivMod.Spec.N3V4CallableExactR1
 import EvmAsm.Evm64.DivMod.Spec.N3CallableSelectedShapeEvidence
 import EvmAsm.Evm64.DivMod.Spec.N3CallableSelectedShapeEvidenceCanonical
+import EvmAsm.Evm64.DivMod.Spec.N3CallableSelectedShapeEvidenceCanonicalIff
 import EvmAsm.Evm64.DivMod.Spec.N3SelectedQuotientHdivs
 import EvmAsm.Evm64.DivMod.Spec.N3V4CallableExactSelectedEvidenceCanonical
 import EvmAsm.Evm64.DivMod.Spec.N2V4ConcretePostBridge

--- a/EvmAsm/Evm64/DivMod/Spec/N3CallableSelectedShapeEvidenceCanonicalIff.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3CallableSelectedShapeEvidenceCanonicalIff.lean
@@ -1,0 +1,66 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N3CallableSelectedShapeEvidenceCanonicalIff
+
+  Equivalence between the universal-callback bundle
+  `N3CallableSelectedShapeEvidence` and its pointed canonical-bltu form.
+  Mirrors `N2CallableSelectedShapeEvidenceCanonicalIff` for the n=3 lane.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.N3CallableSelectedShapeEvidenceCanonical
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Specialize the universal `selectedCarry` callback at the canonical
+    bltu pair. -/
+theorem N3CallableSelectedShapeEvidence.selectedCarry_canonical {a b : EvmWord}
+    (hevidence : N3CallableSelectedShapeEvidence a b) :
+    fullDivN3SelectedCarryV4
+      (n3V4CanonicalBltu1 a b) (n3V4CanonicalBltu0 a b)
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) :=
+  N3CallableSelectedShapeEvidence.selectedCarry hevidence
+    (n3V4CanonicalBltu1 a b) (n3V4CanonicalBltu0 a b)
+    (isTrialN3V4_j1_n3V4CanonicalBltu1 a b)
+    (isTrialN3V4_j0_n3V4CanonicalBltu0 a b)
+
+/-- Specialize the universal arithmetic callback at the canonical bltu pair. -/
+theorem N3CallableSelectedShapeEvidence.arithmetic_canonical {a b : EvmWord}
+    (hevidence : N3CallableSelectedShapeEvidence a b) :
+    fullDivN3MulSubEqV4
+        (n3V4CanonicalBltu1 a b) (n3V4CanonicalBltu0 a b)
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) ∧
+      fullDivN3QuotientOverestimateV4
+        (n3V4CanonicalBltu1 a b) (n3V4CanonicalBltu0 a b)
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) :=
+  N3CallableSelectedShapeEvidence.arithmetic hevidence
+    (n3V4CanonicalBltu1 a b) (n3V4CanonicalBltu0 a b)
+    (isTrialN3V4_j1_n3V4CanonicalBltu1 a b)
+    (isTrialN3V4_j0_n3V4CanonicalBltu0 a b)
+
+/-- The `N3CallableSelectedShapeEvidence` bundle is logically equivalent to
+    the pair of pointed proofs at the canonical bltu pair. -/
+theorem N3CallableSelectedShapeEvidence_iff_canonical {a b : EvmWord} :
+    N3CallableSelectedShapeEvidence a b ↔
+      (fullDivN3SelectedCarryV4
+        (n3V4CanonicalBltu1 a b) (n3V4CanonicalBltu0 a b)
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) ∧
+      (fullDivN3MulSubEqV4
+          (n3V4CanonicalBltu1 a b) (n3V4CanonicalBltu0 a b)
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) ∧
+        fullDivN3QuotientOverestimateV4
+          (n3V4CanonicalBltu1 a b) (n3V4CanonicalBltu0 a b)
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3))) :=
+  ⟨fun h =>
+    ⟨N3CallableSelectedShapeEvidence.selectedCarry_canonical h,
+     N3CallableSelectedShapeEvidence.arithmetic_canonical h⟩,
+   fun ⟨hcarry, harith⟩ =>
+    N3CallableSelectedShapeEvidence.of_canonical hcarry harith⟩
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Mirror of PR #6954 for the n=3 lane.
- Add N3CallableSelectedShapeEvidence.selectedCarry_canonical and .arithmetic_canonical: specialize the universal callbacks at the canonical bltu pair via the proven trial-witness predicates.
- Add N3CallableSelectedShapeEvidence_iff_canonical closing the loop with .of_canonical (merged in #6946).

Refs #61. Bead: evm-asm-9iqmw.7.1.6.3.6.

Authored by @pirapira; implemented by Claude Code