### PR TITLE
feat(div): N3 selected quotient/hdiv canonical-bltu exists variant

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -67,6 +67,7 @@ import EvmAsm.Evm64.DivMod.Spec.N3V4CallableExactR1
 import EvmAsm.Evm64.DivMod.Spec.N3CallableSelectedShapeEvidence
 import EvmAsm.Evm64.DivMod.Spec.N3CallableSelectedShapeEvidenceCanonical
 import EvmAsm.Evm64.DivMod.Spec.N3SelectedQuotientHdivs
+import EvmAsm.Evm64.DivMod.Spec.N3SelectedQuotientHdivsExistsCanonical
 import EvmAsm.Evm64.DivMod.Spec.N3V4CallableExactSelectedEvidenceCanonical
 import EvmAsm.Evm64.DivMod.Spec.N2V4ConcretePostBridge
 import EvmAsm.Evm64.DivMod.Spec.N2V4CallableExact

--- a/EvmAsm/Evm64/DivMod/Spec/N3SelectedQuotientHdivsExistsCanonical.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3SelectedQuotientHdivsExistsCanonical.lean
@@ -1,0 +1,48 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N3SelectedQuotientHdivsExistsCanonical
+
+  Canonical-bltu eliminator for `FullDivN3SelectedQuotientHdivs`: any package
+  must have its `bltu1` and `bltu0` equal to the canonical values, so the
+  derived hdiv facts hold at `n3V4CanonicalBltu{1,0}` directly.
+
+  Downstream callers can use this to extract hdiv equations at the canonical
+  bltu pair without going through an existential indirection.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.N3SelectedQuotientHdivs
+import EvmAsm.Evm64.DivMod.Spec.N3CallableSelectedShapeEvidenceCanonical
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- The bltu values inside a `FullDivN3SelectedQuotientHdivs` package equal
+    `n3V4CanonicalBltu{1,0}`. Stated as a non-existential variant of `.exists`
+    that fixes the witnesses. -/
+theorem FullDivN3SelectedQuotientHdivs.exists_canonical
+    {a b : EvmWord}
+    (hpkg : FullDivN3SelectedQuotientHdivs a b) :
+    fullDivN3QuotientWordV4
+        (n3V4CanonicalBltu1 a b) (n3V4CanonicalBltu0 a b)
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) =
+        EvmWord.div a b ∧
+      (EvmWord.div a b).getLimbN 0 =
+        (fullDivN3R0V4 (n3V4CanonicalBltu1 a b) (n3V4CanonicalBltu0 a b)
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1 ∧
+      (EvmWord.div a b).getLimbN 1 =
+        (fullDivN3R1V4 (n3V4CanonicalBltu1 a b)
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1 ∧
+      (EvmWord.div a b).getLimbN 2 = (0 : Word) ∧
+      (EvmWord.div a b).getLimbN 3 = (0 : Word) := by
+  cases hpkg with
+  | mk bltu1 bltu0 hbltu1 hbltu0 hdivWord hdiv0 hdiv1 hdiv2 hdiv3 =>
+      unfold isTrialN3V4_j1 at hbltu1
+      unfold isTrialN3V4_j0 at hbltu0
+      subst hbltu1
+      subst hbltu0
+      exact ⟨hdivWord, hdiv0, hdiv1, hdiv2, hdiv3⟩
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Add FullDivN3SelectedQuotientHdivs.exists_canonical: any package's bltu1 and bltu0 must equal n3V4CanonicalBltu{1,0} via trial-witness uniqueness (proven by subst on the trial-witness equalities).
- The quotient-word equality and the four hdiv equations therefore hold at the canonical bltu pair directly, without an existential indirection.

Gives downstream callers a way to extract hdiv equations at the canonical bltu pair.

Refs #61. Bead: evm-asm-9iqmw.7.1.6.3.7.

Authored by @pirapira; implemented by Claude Code