### PR TITLE
feat(div): N2 selected quotient/hdiv canonical-bltu exists variant

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -77,6 +77,7 @@ import EvmAsm.Evm64.DivMod.Spec.N2SelectedQuotientHdivs
 import EvmAsm.Evm64.DivMod.Spec.N2CallableSelectedShapeEvidenceCanonical
 import EvmAsm.Evm64.DivMod.Spec.N2V4CallableExactSelectedEvidenceCanonical
 import EvmAsm.Evm64.DivMod.Spec.N2SelectedQuotientHdivsCanonical
+import EvmAsm.Evm64.DivMod.Spec.N2SelectedQuotientHdivsExistsCanonical
 import EvmAsm.Evm64.DivMod.Spec.BzeroV4ExactCallable
 import EvmAsm.Evm64.DivMod.Spec.ModBzeroV4Callable
 import EvmAsm.Evm64.DivMod.Spec.BzeroV4ExactFrame

--- a/EvmAsm/Evm64/DivMod/Spec/N2SelectedQuotientHdivsExistsCanonical.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2SelectedQuotientHdivsExistsCanonical.lean
@@ -1,0 +1,55 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N2SelectedQuotientHdivsExistsCanonical
+
+  Canonical-bltu eliminator for `FullDivN2SelectedQuotientHdivs`: any package
+  must have its `bltu2`, `bltu1`, and `bltu0` equal to the canonical values,
+  so the derived hdiv facts hold at `n2V4CanonicalBltu{2,1,0}` directly.
+
+  Downstream callers can use this to extract hdiv equations at the canonical
+  bltu triple without going through an existential indirection.
+
+  Mirrors `N3SelectedQuotientHdivsExistsCanonical` for the n=2 lane.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.N2SelectedQuotientHdivs
+import EvmAsm.Evm64.DivMod.Spec.N2CallableSelectedShapeEvidenceCanonical
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- The bltu values inside a `FullDivN2SelectedQuotientHdivs` package equal
+    `n2V4CanonicalBltu{2,1,0}`. Stated as a non-existential variant of `.exists`
+    that fixes the witnesses. -/
+theorem FullDivN2SelectedQuotientHdivs.exists_canonical
+    {a b : EvmWord}
+    (hpkg : FullDivN2SelectedQuotientHdivs a b) :
+    fullDivN2QuotientWordV4
+        (n2V4CanonicalBltu2 a b) (n2V4CanonicalBltu1 a b) (n2V4CanonicalBltu0 a b)
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) =
+        EvmWord.div a b ∧
+      (EvmWord.div a b).getLimbN 0 =
+        (fullDivN2R0V4 (n2V4CanonicalBltu2 a b) (n2V4CanonicalBltu1 a b) (n2V4CanonicalBltu0 a b)
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1 ∧
+      (EvmWord.div a b).getLimbN 1 =
+        (fullDivN2R1V4 (n2V4CanonicalBltu2 a b) (n2V4CanonicalBltu1 a b)
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1 ∧
+      (EvmWord.div a b).getLimbN 2 =
+        (fullDivN2R2V4 (n2V4CanonicalBltu2 a b)
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1 ∧
+      (EvmWord.div a b).getLimbN 3 = (0 : Word) := by
+  cases hpkg with
+  | mk bltu2 bltu1 bltu0 hbltu2 hbltu1 hbltu0 hdivWord hdiv0 hdiv1 hdiv2 hdiv3 =>
+      unfold isTrialN2V4_j2 at hbltu2
+      unfold isTrialN2V4_j1 at hbltu1
+      unfold isTrialN2V4_j0 at hbltu0
+      subst hbltu2
+      subst hbltu1
+      subst hbltu0
+      exact ⟨hdivWord, hdiv0, hdiv1, hdiv2, hdiv3⟩
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Mirror of PR #6956 for the n=2 lane.
- Add FullDivN2SelectedQuotientHdivs.exists_canonical: any package's bltu values must equal n2V4CanonicalBltu{2,1,0} via trial-witness uniqueness, so the quotient-word equality and the four hdiv equations hold at the canonical bltu triple directly without an existential indirection.

Refs #61. Bead: evm-asm-9iqmw.7.1.6.2.3.5.

Authored by @pirapira; implemented by Claude Code