### PR TITLE
feat(div): N2 callable wrapper consuming N2CanonicalPointedEvidence

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -83,6 +83,7 @@ import EvmAsm.Evm64.DivMod.Spec.N2SelectedQuotientHdivsCanonical
 import EvmAsm.Evm64.DivMod.Spec.N2CallableCodeV4SelectedEvidenceCanonical
 import EvmAsm.Evm64.DivMod.Spec.N2CallableSelectedShapeEvidenceCanonicalIff
 import EvmAsm.Evm64.DivMod.Spec.N2CanonicalPointedEvidence
+import EvmAsm.Evm64.DivMod.Spec.N2V4CallableExactPointedEvidence
 import EvmAsm.Evm64.DivMod.Spec.N2SelectedQuotientHdivsExistsCanonical
 import EvmAsm.Evm64.DivMod.Spec.BzeroV4ExactCallable
 import EvmAsm.Evm64.DivMod.Spec.ModBzeroV4Callable

--- a/EvmAsm/Evm64/DivMod/Spec/N2V4CallableExactPointedEvidence.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2V4CallableExactPointedEvidence.lean
@@ -1,0 +1,87 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N2V4CallableExactPointedEvidence
+
+  Callable-shape wrapper that takes the bundled `N2CanonicalPointedEvidence`
+  abbreviation (PR #6963) directly, projects via `.selectedCarry` and
+  `.arithmetic`, and delegates to the existing `_canonicalEvidence_uni`
+  wrappers from `N2V4CallableExactSelectedEvidenceCanonical` (PR #6948).
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.N2V4CallableExactSelectedEvidenceCanonical
+import EvmAsm.Evm64.DivMod.Spec.N2CanonicalPointedEvidence
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- No-NOP N2 DIV v4 callable-exact wrapper consuming the
+    `N2CanonicalPointedEvidence` bundle directly. -/
+theorem evm_div_n2_stack_spec_noNop_v4_preNoX1_callableExactFrame_shape_pointedEvidence_uni
+    (sp base : Word)
+    (a b : EvmWord)
+    (v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (hb3z : b.getLimbN 3 = 0) (hb2z : b.getLimbN 2 = 0)
+    (hb1nz : b.getLimbN 1 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 1)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hevidence : N2CanonicalPointedEvidence a b) :
+    cpsTripleWithin unifiedDivBound base (base + nopOff) (divCode_noNop_v4 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult (b.getLimbN 1)).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divStackDispatchPostCallableExactFrame sp a b raVal
+        (signExtend12 4095 : Word) **
+       memOwn (sp + signExtend12 3936)) :=
+  evm_div_n2_stack_spec_noNop_v4_preNoX1_callableExactFrame_shape_canonicalEvidence_uni
+    sp base a b
+    v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+    hb3z hb2z hb1nz hshift_nz halign
+    (N2CanonicalPointedEvidence.selectedCarry hevidence)
+    (N2CanonicalPointedEvidence.arithmetic hevidence)
+
+/-- Full-code N2 DIV v4 callable-exact wrapper consuming the
+    `N2CanonicalPointedEvidence` bundle directly. -/
+theorem evm_div_n2_stack_spec_v4_preNoX1_callableExactFrame_shape_pointedEvidence_uni
+    (sp base : Word)
+    (a b : EvmWord)
+    (v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (hb3z : b.getLimbN 3 = 0) (hb2z : b.getLimbN 2 = 0)
+    (hb1nz : b.getLimbN 1 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 1)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hevidence : N2CanonicalPointedEvidence a b) :
+    cpsTripleWithin unifiedDivBound base (base + nopOff) (divCode_v4 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult (b.getLimbN 1)).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divStackDispatchPostCallableExactFrame sp a b raVal
+        (signExtend12 4095 : Word) **
+       memOwn (sp + signExtend12 3936)) :=
+  evm_div_n2_stack_spec_v4_preNoX1_callableExactFrame_shape_canonicalEvidence_uni
+    sp base a b
+    v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+    hb3z hb2z hb1nz hshift_nz halign
+    (N2CanonicalPointedEvidence.selectedCarry hevidence)
+    (N2CanonicalPointedEvidence.arithmetic hevidence)
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Stacked on #6963 (N2CanonicalPointedEvidence).
- Add NOP and full-code variants of evm_div_n2_stack_spec_(noNop_)v4_preNoX1_callableExactFrame_shape_pointedEvidence_uni taking the bundled abbreviation directly.
- Internally projects via .selectedCarry / .arithmetic and delegates to the existing _canonicalEvidence_uni wrappers from #6948.

Downstream callers thread a single bundled hypothesis through the callable boundary instead of unpacking the pair at each call site.

Refs #61. Bead: evm-asm-9iqmw.7.1.6.2.3.10.

Authored by @pirapira; implemented by Claude Code