### PR TITLE
feat(div): N3 callable wrapper consuming N3CanonicalPointedEvidence

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -68,6 +68,7 @@ import EvmAsm.Evm64.DivMod.Spec.N3CallableSelectedShapeEvidence
 import EvmAsm.Evm64.DivMod.Spec.N3CallableSelectedShapeEvidenceCanonical
 import EvmAsm.Evm64.DivMod.Spec.N3CallableSelectedShapeEvidenceCanonicalIff
 import EvmAsm.Evm64.DivMod.Spec.N3CanonicalPointedEvidence
+import EvmAsm.Evm64.DivMod.Spec.N3V4CallableExactPointedEvidence
 import EvmAsm.Evm64.DivMod.Spec.N3SelectedQuotientHdivs
 import EvmAsm.Evm64.DivMod.Spec.N3SelectedQuotientHdivsExistsCanonical
 import EvmAsm.Evm64.DivMod.Spec.N3V4CallableExactSelectedEvidenceCanonical

--- a/EvmAsm/Evm64/DivMod/Spec/N3V4CallableExactPointedEvidence.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3V4CallableExactPointedEvidence.lean
@@ -1,0 +1,53 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N3V4CallableExactPointedEvidence
+
+  Callable-shape wrapper that takes the bundled `N3CanonicalPointedEvidence`
+  abbreviation (PR #6964) directly, projects via `.selectedCarry` and
+  `.arithmetic`, and delegates to the existing `_canonicalEvidence` wrapper
+  from `N3V4CallableExactSelectedEvidenceCanonical` (PR #6949).
+
+  Mirrors `N2V4CallableExactPointedEvidence` for the n=3 lane.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.N3V4CallableExactSelectedEvidenceCanonical
+import EvmAsm.Evm64.DivMod.Spec.N3CanonicalPointedEvidence
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- N3 DIV v4 callable wrapper consuming the `N3CanonicalPointedEvidence`
+    bundle directly. -/
+theorem evm_div_callable_v4_n3_stack_pre_to_callable_post_scratch_shape_pointedEvidence
+    (sp base : Word) (a b : EvmWord)
+    (v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem : Word)
+    (raVal : Word)
+    (hb3z : b.getLimbN 3 = 0) (hb2nz : b.getLimbN 2 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 2)).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) =
+      base + div128CallRetOff)
+    (hevidence : N3CanonicalPointedEvidence a b) :
+    cpsTripleWithin (unifiedDivBound + 1) base (raVal &&& ~~~1)
+      (evm_div_callable_code_v4 base)
+      (divModStackDispatchPreNoX1 sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word)) raVal
+        ((clzResult (b.getLimbN 2)).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratchUn0 **
+       ((sp + signExtend12 3936) ↦ₘ scratchMem))
+      (divStackDispatchPostCallableExactFrame sp a b raVal
+        (signExtend12 4095 : Word) **
+       memOwn (sp + signExtend12 3936)) :=
+  evm_div_callable_v4_n3_stack_pre_to_callable_post_scratch_shape_canonicalEvidence
+    sp base a b
+    v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratchUn0 scratchMem raVal
+    hb3z hb2nz hshift_nz halign
+    (N3CanonicalPointedEvidence.selectedCarry hevidence)
+    (N3CanonicalPointedEvidence.arithmetic hevidence)
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Mirror of PR #6965 for the n=3 lane.
- Stacked on #6964 (N3CanonicalPointedEvidence).
- Add evm_div_callable_v4_n3_stack_pre_to_callable_post_scratch_shape_pointedEvidence taking the bundled N3CanonicalPointedEvidence directly.

Refs #61. Bead: evm-asm-9iqmw.7.1.6.3.11.

Authored by @pirapira; implemented by Claude Code