### PR TITLE
feat(div): N2 hdivs-at-canonical variant taking N2CanonicalPointedEvidence

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -87,6 +87,7 @@ import EvmAsm.Evm64.DivMod.Spec.N2CallableSelectedShapeEvidenceCanonicalIff
 import EvmAsm.Evm64.DivMod.Spec.N2CanonicalPointedEvidence
 import EvmAsm.Evm64.DivMod.Spec.N2SelectedQuotientHdivsExistsCanonical
 import EvmAsm.Evm64.DivMod.Spec.N2HdivsAtCanonical
+import EvmAsm.Evm64.DivMod.Spec.N2HdivsAtCanonicalPointedEvidence
 import EvmAsm.Evm64.DivMod.Spec.BzeroV4ExactCallable
 import EvmAsm.Evm64.DivMod.Spec.ModBzeroV4Callable
 import EvmAsm.Evm64.DivMod.Spec.BzeroV4ExactFrame

--- a/EvmAsm/Evm64/DivMod/Spec/N2HdivsAtCanonicalPointedEvidence.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2HdivsAtCanonicalPointedEvidence.lean
@@ -1,0 +1,46 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N2HdivsAtCanonicalPointedEvidence
+
+  Bundled variant of `n2HdivsAtCanonical_of_shape` (PR #6958) that takes
+  the `N2CanonicalPointedEvidence` abbreviation (PR #6963) directly,
+  projects via `.selectedCarry` and `.arithmetic`, and delegates to the
+  existing two-predicate composition.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.N2HdivsAtCanonical
+import EvmAsm.Evm64.DivMod.Spec.N2CanonicalPointedEvidence
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- N2 hdiv equations at the canonical bltu triple, derived from bundled
+    `N2CanonicalPointedEvidence` and the n=2 divisor shape. -/
+theorem n2HdivsAtCanonical_of_shape_pointedEvidence
+    {a b : EvmWord}
+    (hb3z : b.getLimbN 3 = 0) (hb2z : b.getLimbN 2 = 0)
+    (hb1nz : b.getLimbN 1 ≠ 0)
+    (hevidence : N2CanonicalPointedEvidence a b) :
+    fullDivN2QuotientWordV4
+        (n2V4CanonicalBltu2 a b) (n2V4CanonicalBltu1 a b) (n2V4CanonicalBltu0 a b)
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) =
+        EvmWord.div a b ∧
+      (EvmWord.div a b).getLimbN 0 =
+        (fullDivN2R0V4 (n2V4CanonicalBltu2 a b) (n2V4CanonicalBltu1 a b) (n2V4CanonicalBltu0 a b)
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1 ∧
+      (EvmWord.div a b).getLimbN 1 =
+        (fullDivN2R1V4 (n2V4CanonicalBltu2 a b) (n2V4CanonicalBltu1 a b)
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1 ∧
+      (EvmWord.div a b).getLimbN 2 =
+        (fullDivN2R2V4 (n2V4CanonicalBltu2 a b)
+          (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).1 ∧
+      (EvmWord.div a b).getLimbN 3 = (0 : Word) :=
+  n2HdivsAtCanonical_of_shape hb3z hb2z hb1nz
+    (N2CanonicalPointedEvidence.selectedCarry hevidence)
+    (N2CanonicalPointedEvidence.arithmetic hevidence)
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Stacked on #6963 (N2CanonicalPointedEvidence); main brings in #6958 (N2HdivsAtCanonical).
- Add n2HdivsAtCanonical_of_shape_pointedEvidence taking the bundled N2CanonicalPointedEvidence directly.
- Internally projects via .selectedCarry / .arithmetic and delegates to PR #6958's two-predicate composition.

Refs #61. Bead: evm-asm-9iqmw.7.1.6.2.3.11.

Authored by @pirapira; implemented by Claude Code