### PR TITLE
feat(div): DivisorLimbCase shape disjunction helper

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -55,6 +55,7 @@ import EvmAsm.Evm64.DivMod.Spec.N3QuotientWord
 import EvmAsm.Evm64.DivMod.Spec.N3DivStackSpec
 import EvmAsm.Evm64.DivMod.Spec.Unified
 import EvmAsm.Evm64.DivMod.Spec.UnifiedDivisorCases
+import EvmAsm.Evm64.DivMod.Spec.DivisorLimbCaseHelpers
 import EvmAsm.Evm64.DivMod.Spec.UnifiedN1Normalized
 import EvmAsm.Evm64.DivMod.Spec.UnifiedN1NormalizedRemainder
 import EvmAsm.Evm64.DivMod.Spec.UnifiedN1StepPath

--- a/EvmAsm/Evm64/DivMod/Spec/DivisorLimbCaseHelpers.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/DivisorLimbCaseHelpers.lean
@@ -1,0 +1,40 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.DivisorLimbCaseHelpers
+
+  Small convenience helpers around `DivisorLimbCase` for use by the final
+  top-level public DIV wrapper assembly.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.UnifiedDivisorCases
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64 EvmWord
+
+/-- For a nonzero divisor, the divisor limbs satisfy exactly one of the four
+    shape disjuncts (n1, n2, n3, n4). Stated as a four-way disjunction over
+    the shape predicates so callers can pattern-match without going through
+    the inductive `DivisorLimbCase`. -/
+theorem nonzero_divisor_limb_shape (b : EvmWord) (hbnz : b ≠ 0) :
+    (b.getLimbN 3 = 0 ∧ b.getLimbN 2 = 0 ∧ b.getLimbN 1 = 0 ∧ b.getLimbN 0 ≠ 0) ∨
+    (b.getLimbN 3 = 0 ∧ b.getLimbN 2 = 0 ∧ b.getLimbN 1 ≠ 0) ∨
+    (b.getLimbN 3 = 0 ∧ b.getLimbN 2 ≠ 0) ∨
+    (b.getLimbN 3 ≠ 0) := by
+  have hbnzOr : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 ≠ 0 :=
+    (EvmWord.ne_zero_iff_getLimbN_or).mp hbnz
+  by_cases hb3z : b.getLimbN 3 = 0
+  · by_cases hb2z : b.getLimbN 2 = 0
+    · by_cases hb1z : b.getLimbN 1 = 0
+      · left
+        refine ⟨hb3z, hb2z, hb1z, ?_⟩
+        intro hb0z
+        apply hbnzOr
+        simp [hb0z, hb1z, hb2z, hb3z]
+      · right; left
+        exact ⟨hb3z, hb2z, hb1z⟩
+    · right; right; left
+      exact ⟨hb3z, hb2z⟩
+  · right; right; right
+    exact hb3z
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Add nonzero_divisor_limb_shape: for b ≠ 0, the divisor limbs satisfy exactly one of the four shape disjuncts (n1, n2, n3, n4) as a Prop disjunction.
- Lets callers pattern-match the shape without going through the inductive DivisorLimbCase constructors.

Refs #61. Bead: evm-asm-9iqmw.7.1.7.3.

Authored by @pirapira; implemented by Claude Code