### PR TITLE
feat(div): divisor full-domain Or-shape disjunction

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -56,6 +56,7 @@ import EvmAsm.Evm64.DivMod.Spec.N3DivStackSpec
 import EvmAsm.Evm64.DivMod.Spec.Unified
 import EvmAsm.Evm64.DivMod.Spec.UnifiedDivisorCases
 import EvmAsm.Evm64.DivMod.Spec.DivisorLimbCaseHelpers
+import EvmAsm.Evm64.DivMod.Spec.DivisorFullDomainShape
 import EvmAsm.Evm64.DivMod.Spec.UnifiedN1Normalized
 import EvmAsm.Evm64.DivMod.Spec.UnifiedN1NormalizedRemainder
 import EvmAsm.Evm64.DivMod.Spec.UnifiedN1StepPath

--- a/EvmAsm/Evm64/DivMod/Spec/DivisorFullDomainShape.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/DivisorFullDomainShape.lean
@@ -1,0 +1,33 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.DivisorFullDomainShape
+
+  Full-domain Or-shape disjunction for `EvmWord`: every divisor falls into
+  exactly one of five cases (bzero, n1, n2, n3, n4). Complements
+  `nonzero_divisor_limb_shape` (PR #6972) with the bzero case included.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.DivisorLimbCaseHelpers
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64 EvmWord
+
+/-- Every divisor `b : EvmWord` falls into exactly one of five disjoint
+    shape cases: `b = 0`, n1 (only limb 0 nonzero), n2 (limb 1 highest
+    nonzero), n3 (limb 2 highest nonzero), n4 (limb 3 nonzero). -/
+theorem divisor_full_domain_shape (b : EvmWord) :
+    b = 0 ∨
+    (b ≠ 0 ∧ b.getLimbN 3 = 0 ∧ b.getLimbN 2 = 0 ∧ b.getLimbN 1 = 0 ∧ b.getLimbN 0 ≠ 0) ∨
+    (b ≠ 0 ∧ b.getLimbN 3 = 0 ∧ b.getLimbN 2 = 0 ∧ b.getLimbN 1 ≠ 0) ∨
+    (b ≠ 0 ∧ b.getLimbN 3 = 0 ∧ b.getLimbN 2 ≠ 0) ∨
+    (b ≠ 0 ∧ b.getLimbN 3 ≠ 0) := by
+  by_cases hbz : b = 0
+  · left; exact hbz
+  · rcases nonzero_divisor_limb_shape b hbz with
+      ⟨hb3z, hb2z, hb1z, hb0nz⟩ | ⟨hb3z, hb2z, hb1nz⟩ | ⟨hb3z, hb2nz⟩ | hb3nz
+    · right; left; exact ⟨hbz, hb3z, hb2z, hb1z, hb0nz⟩
+    · right; right; left; exact ⟨hbz, hb3z, hb2z, hb1nz⟩
+    · right; right; right; left; exact ⟨hbz, hb3z, hb2nz⟩
+    · right; right; right; right; exact ⟨hbz, hb3nz⟩
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Stacked on #6972 (nonzero_divisor_limb_shape).
- Add divisor_full_domain_shape: every b : EvmWord falls into exactly one of five disjoint cases (b = 0, n1, n2, n3, n4) as a Prop disjunction.

Refs #61. Bead: evm-asm-9iqmw.7.1.7.4.

Authored by @pirapira; implemented by Claude Code