### PR TITLE
feat(div): N1PointedEvidence_iff_callable rewrite target

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N1PointedEvidence.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N1PointedEvidence.lean
@@ -96,4 +96,11 @@ theorem N1PointedEvidence_iff_parts {a b : EvmWord} :
    fun ⟨hbranches, hpath, hword⟩ =>
     N1PointedEvidence.of_parts hbranches hpath hword⟩
 
+/-- `N1PointedEvidence` is by definition `N1CallableSelectedIfBorrowWordEvidence`,
+    so the iff is `Iff.rfl`. Stated explicitly so downstream callers can use
+    it as a rewrite target without remembering the underlying abbrev. -/
+theorem N1PointedEvidence_iff_callable {a b : EvmWord} :
+    N1PointedEvidence a b ↔ N1CallableSelectedIfBorrowWordEvidence a b :=
+  Iff.rfl
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Stacked on #6979.
- Add N1PointedEvidence_iff_callable = Iff.rfl as an explicit rewrite target for swapping between N1PointedEvidence and N1CallableSelectedIfBorrowWordEvidence without remembering the underlying abbrev.

Refs #61. Bead: evm-asm-9iqmw.7.1.6.1.3.2.7.

Authored by @pirapira; implemented by Claude Code