### PR TITLE
feat(div): N3 canonical-bltu uniqueness lemmas

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -70,6 +70,7 @@ import EvmAsm.Evm64.DivMod.Spec.N3CallableSelectedShapeEvidence
 import EvmAsm.Evm64.DivMod.Spec.N3CallableSelectedShapeEvidenceCanonical
 import EvmAsm.Evm64.DivMod.Spec.N3CanonicalBltuEq
 import EvmAsm.Evm64.DivMod.Spec.N3CanonicalBltu0Branches
+import EvmAsm.Evm64.DivMod.Spec.N3CanonicalBltuUnique
 import EvmAsm.Evm64.DivMod.Spec.N3CanonicalTrialWitnessAll
 import EvmAsm.Evm64.DivMod.Spec.N3CallableSelectedShapeEvidenceCanonicalIff
 import EvmAsm.Evm64.DivMod.Spec.N3CanonicalPointedEvidence

--- a/EvmAsm/Evm64/DivMod/Spec/N3CanonicalBltuUnique.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3CanonicalBltuUnique.lean
@@ -1,0 +1,30 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N3CanonicalBltuUnique
+
+  Uniqueness lemmas for the canonical N3 bltu values. Mirrors
+  `N2CanonicalBltuUnique` for the n=3 lane.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.N3CallableSelectedShapeEvidenceCanonical
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Any `bltu_1` satisfying `isTrialN3V4_j1` at `(a, b)` equals the
+    canonical value. -/
+theorem n3V4CanonicalBltu1_unique {a b : EvmWord} {bltu_1 : Bool}
+    (h : isTrialN3V4_j1 bltu_1
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)) :
+    bltu_1 = n3V4CanonicalBltu1 a b := h
+
+/-- Any `bltu_0` satisfying `isTrialN3V4_j0` at `(a, b)` with the canonical
+    `bltu_1` equals the canonical `bltu_0`. -/
+theorem n3V4CanonicalBltu0_unique {a b : EvmWord} {bltu_0 : Bool}
+    (h : isTrialN3V4_j0 (n3V4CanonicalBltu1 a b) bltu_0
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)) :
+    bltu_0 = n3V4CanonicalBltu0 a b := h
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Mirror of PR #6981 for n=3.
- Add n3V4CanonicalBltu{1,0}_unique uniqueness lemmas.

Refs #61. Bead: evm-asm-9iqmw.7.1.6.3.15.

Authored by @pirapira; implemented by Claude Code