### PR TITLE
feat(div): divisor_full_domain_shape restated using NkShapeIs

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -58,6 +58,7 @@ import EvmAsm.Evm64.DivMod.Spec.UnifiedDivisorCases
 import EvmAsm.Evm64.DivMod.Spec.DivisorShapeNamed
 import EvmAsm.Evm64.DivMod.Spec.DivisorLimbCaseHelpers
 import EvmAsm.Evm64.DivMod.Spec.DivisorFullDomainShape
+import EvmAsm.Evm64.DivMod.Spec.DivisorFullDomainShapeNamed
 import EvmAsm.Evm64.DivMod.Spec.UnifiedN1Normalized
 import EvmAsm.Evm64.DivMod.Spec.UnifiedN1NormalizedRemainder
 import EvmAsm.Evm64.DivMod.Spec.UnifiedN1StepPath

--- a/EvmAsm/Evm64/DivMod/Spec/DivisorFullDomainShapeNamed.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/DivisorFullDomainShapeNamed.lean
@@ -1,0 +1,21 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.DivisorFullDomainShapeNamed
+
+  `divisor_full_domain_shape` restated using the named `NkShapeIs` predicates
+  from `DivisorShapeNamed`. Identical content, cleaner naming for downstream
+  consumption.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.DivisorFullDomainShape
+import EvmAsm.Evm64.DivMod.Spec.DivisorShapeNamed
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64 EvmWord
+
+/-- Restatement of `divisor_full_domain_shape` using `NkShapeIs`. -/
+theorem divisor_full_domain_shape_named (b : EvmWord) :
+    b = 0 ∨ N1ShapeIs b ∨ N2ShapeIs b ∨ N3ShapeIs b ∨ N4ShapeIs b :=
+  divisor_full_domain_shape b
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Stacked on #6983 (NkShapeIs).
- Add divisor_full_domain_shape_named: same content as divisor_full_domain_shape (#6973), but using the named NkShapeIs predicates.

Refs #61. Bead: evm-asm-9iqmw.7.1.6.5.1.

Authored by @pirapira; implemented by Claude Code