### PR TITLE
feat(div): DivisorLimbCase constructor → NkShapeIs projections

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -56,6 +56,7 @@ import EvmAsm.Evm64.DivMod.Spec.N3DivStackSpec
 import EvmAsm.Evm64.DivMod.Spec.Unified
 import EvmAsm.Evm64.DivMod.Spec.UnifiedDivisorCases
 import EvmAsm.Evm64.DivMod.Spec.DivisorShapeNamed
+import EvmAsm.Evm64.DivMod.Spec.DivisorLimbCaseToShape
 import EvmAsm.Evm64.DivMod.Spec.DivisorLimbCaseHelpers
 import EvmAsm.Evm64.DivMod.Spec.DivisorFullDomainShape
 import EvmAsm.Evm64.DivMod.Spec.UnifiedN1Normalized

--- a/EvmAsm/Evm64/DivMod/Spec/DivisorLimbCaseToShape.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/DivisorLimbCaseToShape.lean
@@ -1,0 +1,54 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.DivisorLimbCaseToShape
+
+  Projections from `DivisorLimbCase` constructors to the named `NkShapeIs`
+  predicates. Each non-bzero constructor of `DivisorLimbCase` carries the
+  facts needed to assemble the corresponding `NkShapeIs`.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.UnifiedDivisorCases
+import EvmAsm.Evm64.DivMod.Spec.DivisorShapeNamed
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64 EvmWord
+
+/-- A `DivisorLimbCase.n1` constructor implies `N1ShapeIs`. -/
+theorem DivisorLimbCase.n1_implies_N1ShapeIs
+    {b : EvmWord}
+    (hbnz : b ≠ 0)
+    (_hbnzOr : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 ≠ 0)
+    (hb3z : b.getLimbN 3 = 0) (hb2z : b.getLimbN 2 = 0)
+    (hb1z : b.getLimbN 1 = 0) (hb0nz : b.getLimbN 0 ≠ 0) :
+    N1ShapeIs b :=
+  ⟨hbnz, hb3z, hb2z, hb1z, hb0nz⟩
+
+/-- A `DivisorLimbCase.n2` constructor implies `N2ShapeIs`. -/
+theorem DivisorLimbCase.n2_implies_N2ShapeIs
+    {b : EvmWord}
+    (hbnz : b ≠ 0)
+    (_hbnzOr : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 ≠ 0)
+    (hb3z : b.getLimbN 3 = 0) (hb2z : b.getLimbN 2 = 0)
+    (hb1nz : b.getLimbN 1 ≠ 0) :
+    N2ShapeIs b :=
+  ⟨hbnz, hb3z, hb2z, hb1nz⟩
+
+/-- A `DivisorLimbCase.n3` constructor implies `N3ShapeIs`. -/
+theorem DivisorLimbCase.n3_implies_N3ShapeIs
+    {b : EvmWord}
+    (hbnz : b ≠ 0)
+    (_hbnzOr : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 ≠ 0)
+    (hb3z : b.getLimbN 3 = 0) (hb2nz : b.getLimbN 2 ≠ 0) :
+    N3ShapeIs b :=
+  ⟨hbnz, hb3z, hb2nz⟩
+
+/-- A `DivisorLimbCase.n4` constructor implies `N4ShapeIs`. -/
+theorem DivisorLimbCase.n4_implies_N4ShapeIs
+    {b : EvmWord}
+    (hbnz : b ≠ 0)
+    (_hbnzOr : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 ≠ 0)
+    (hb3nz : b.getLimbN 3 ≠ 0) :
+    N4ShapeIs b :=
+  ⟨hbnz, hb3nz⟩
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/DivisorLimbCaseToShape.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/DivisorLimbCaseToShape.lean
@@ -17,7 +17,6 @@ open EvmAsm.Rv64 EvmWord
 theorem DivisorLimbCase.n1_implies_N1ShapeIs
     {b : EvmWord}
     (hbnz : b ≠ 0)
-    (_hbnzOr : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 ≠ 0)
     (hb3z : b.getLimbN 3 = 0) (hb2z : b.getLimbN 2 = 0)
     (hb1z : b.getLimbN 1 = 0) (hb0nz : b.getLimbN 0 ≠ 0) :
     N1ShapeIs b :=
@@ -27,7 +26,6 @@ theorem DivisorLimbCase.n1_implies_N1ShapeIs
 theorem DivisorLimbCase.n2_implies_N2ShapeIs
     {b : EvmWord}
     (hbnz : b ≠ 0)
-    (_hbnzOr : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 ≠ 0)
     (hb3z : b.getLimbN 3 = 0) (hb2z : b.getLimbN 2 = 0)
     (hb1nz : b.getLimbN 1 ≠ 0) :
     N2ShapeIs b :=
@@ -37,7 +35,6 @@ theorem DivisorLimbCase.n2_implies_N2ShapeIs
 theorem DivisorLimbCase.n3_implies_N3ShapeIs
     {b : EvmWord}
     (hbnz : b ≠ 0)
-    (_hbnzOr : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 ≠ 0)
     (hb3z : b.getLimbN 3 = 0) (hb2nz : b.getLimbN 2 ≠ 0) :
     N3ShapeIs b :=
   ⟨hbnz, hb3z, hb2nz⟩
@@ -46,7 +43,6 @@ theorem DivisorLimbCase.n3_implies_N3ShapeIs
 theorem DivisorLimbCase.n4_implies_N4ShapeIs
     {b : EvmWord}
     (hbnz : b ≠ 0)
-    (_hbnzOr : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 ≠ 0)
     (hb3nz : b.getLimbN 3 ≠ 0) :
     N4ShapeIs b :=
   ⟨hbnz, hb3nz⟩


### PR DESCRIPTION
## Summary
- Stacked on #6983 (NkShapeIs).
- Add four projection lemmas DivisorLimbCase.{n1,n2,n3,n4}_implies_N{1,2,3,4}ShapeIs.

Refs #61. Bead: evm-asm-9iqmw.7.1.6.5.2.

Authored by @pirapira; implemented by Claude Code