### PR TITLE
feat(div): Decidable instances for NkShapeIs predicates

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -56,6 +56,7 @@ import EvmAsm.Evm64.DivMod.Spec.N3DivStackSpec
 import EvmAsm.Evm64.DivMod.Spec.Unified
 import EvmAsm.Evm64.DivMod.Spec.UnifiedDivisorCases
 import EvmAsm.Evm64.DivMod.Spec.DivisorShapeNamed
+import EvmAsm.Evm64.DivMod.Spec.DivisorShapeDecidable
 import EvmAsm.Evm64.DivMod.Spec.DivisorLimbCaseHelpers
 import EvmAsm.Evm64.DivMod.Spec.DivisorFullDomainShape
 import EvmAsm.Evm64.DivMod.Spec.UnifiedN1Normalized

--- a/EvmAsm/Evm64/DivMod/Spec/DivisorShapeDecidable.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/DivisorShapeDecidable.lean
@@ -1,0 +1,27 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.DivisorShapeDecidable
+
+  Explicit `Decidable` instances for the named `NkShapeIs` predicates so
+  downstream code can use `decide` / `by_cases` on them directly without
+  manual case analysis.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.DivisorShapeNamed
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64 EvmWord
+
+instance N1ShapeIs.decidable (b : EvmWord) : Decidable (N1ShapeIs b) := by
+  unfold N1ShapeIs; exact inferInstance
+
+instance N2ShapeIs.decidable (b : EvmWord) : Decidable (N2ShapeIs b) := by
+  unfold N2ShapeIs; exact inferInstance
+
+instance N3ShapeIs.decidable (b : EvmWord) : Decidable (N3ShapeIs b) := by
+  unfold N3ShapeIs; exact inferInstance
+
+instance N4ShapeIs.decidable (b : EvmWord) : Decidable (N4ShapeIs b) := by
+  unfold N4ShapeIs; exact inferInstance
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Stacked on #6983 (NkShapeIs).
- Add explicit Decidable instances for N{1,2,3,4}ShapeIs so downstream code can use decide / by_cases on them directly.

Refs #61. Bead: evm-asm-9iqmw.7.1.6.5.3.

Authored by @pirapira; implemented by Claude Code