### PR TITLE
feat(div): NkShapeIs.ne_zero projections

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -56,6 +56,7 @@ import EvmAsm.Evm64.DivMod.Spec.N3DivStackSpec
 import EvmAsm.Evm64.DivMod.Spec.Unified
 import EvmAsm.Evm64.DivMod.Spec.UnifiedDivisorCases
 import EvmAsm.Evm64.DivMod.Spec.DivisorShapeNamed
+import EvmAsm.Evm64.DivMod.Spec.DivisorShapeNeZero
 import EvmAsm.Evm64.DivMod.Spec.DivisorLimbCaseHelpers
 import EvmAsm.Evm64.DivMod.Spec.DivisorFullDomainShape
 import EvmAsm.Evm64.DivMod.Spec.UnifiedN1Normalized

--- a/EvmAsm/Evm64/DivMod/Spec/DivisorShapeNeZero.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/DivisorShapeNeZero.lean
@@ -1,0 +1,23 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.DivisorShapeNeZero
+
+  Trivial projections: each `NkShapeIs` predicate implies `b ≠ 0`. Useful
+  for downstream code that has only the shape predicate and needs the
+  nonzero fact for lower-level wrappers.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.DivisorShapeNamed
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+theorem N1ShapeIs.ne_zero {b : EvmWord} (h : N1ShapeIs b) : b ≠ 0 := h.1
+
+theorem N2ShapeIs.ne_zero {b : EvmWord} (h : N2ShapeIs b) : b ≠ 0 := h.1
+
+theorem N3ShapeIs.ne_zero {b : EvmWord} (h : N3ShapeIs b) : b ≠ 0 := h.1
+
+theorem N4ShapeIs.ne_zero {b : EvmWord} (h : N4ShapeIs b) : b ≠ 0 := h.1
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Stacked on #6983 (NkShapeIs).
- Add four trivial projections N{1,2,3,4}ShapeIs.ne_zero: each named shape predicate implies b ≠ 0.

Refs #61. Bead: evm-asm-9iqmw.7.1.6.5.4.

Authored by @pirapira; implemented by Claude Code