### PR TITLE
feat(div): NkShapeIs pairwise disjointness lemmas

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -56,6 +56,7 @@ import EvmAsm.Evm64.DivMod.Spec.N3DivStackSpec
 import EvmAsm.Evm64.DivMod.Spec.Unified
 import EvmAsm.Evm64.DivMod.Spec.UnifiedDivisorCases
 import EvmAsm.Evm64.DivMod.Spec.DivisorShapeNamed
+import EvmAsm.Evm64.DivMod.Spec.DivisorShapeDisjoint
 import EvmAsm.Evm64.DivMod.Spec.DivisorLimbCaseHelpers
 import EvmAsm.Evm64.DivMod.Spec.DivisorFullDomainShape
 import EvmAsm.Evm64.DivMod.Spec.UnifiedN1Normalized

--- a/EvmAsm/Evm64/DivMod/Spec/DivisorShapeDisjoint.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/DivisorShapeDisjoint.lean
@@ -1,0 +1,45 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.DivisorShapeDisjoint
+
+  Pairwise disjointness lemmas for the four `NkShapeIs` predicates. Any two
+  distinct shape predicates are mutually exclusive: the per-limb facts each
+  carries contradict the others.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.DivisorShapeNamed
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+theorem N1ShapeIs.not_N2ShapeIs {b : EvmWord} (h1 : N1ShapeIs b) :
+    ¬ N2ShapeIs b := by
+  intro h2
+  exact absurd h1.2.2.2.1 h2.2.2.2
+
+theorem N1ShapeIs.not_N3ShapeIs {b : EvmWord} (h1 : N1ShapeIs b) :
+    ¬ N3ShapeIs b := by
+  intro h3
+  exact absurd h1.2.2.1 h3.2.2
+
+theorem N1ShapeIs.not_N4ShapeIs {b : EvmWord} (h1 : N1ShapeIs b) :
+    ¬ N4ShapeIs b := by
+  intro h4
+  exact absurd h1.2.1 h4.2
+
+theorem N2ShapeIs.not_N3ShapeIs {b : EvmWord} (h2 : N2ShapeIs b) :
+    ¬ N3ShapeIs b := by
+  intro h3
+  exact absurd h2.2.2.1 h3.2.2
+
+theorem N2ShapeIs.not_N4ShapeIs {b : EvmWord} (h2 : N2ShapeIs b) :
+    ¬ N4ShapeIs b := by
+  intro h4
+  exact absurd h2.2.1 h4.2
+
+theorem N3ShapeIs.not_N4ShapeIs {b : EvmWord} (h3 : N3ShapeIs b) :
+    ¬ N4ShapeIs b := by
+  intro h4
+  exact absurd h3.2.1 h4.2
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Stacked on #6983 (NkShapeIs).
- Add six pairwise disjointness lemmas: any two distinct NkShapeIs predicates are mutually exclusive.

Refs #61. Bead: evm-asm-9iqmw.7.1.6.5.6.

Authored by @pirapira; implemented by Claude Code