### PR TITLE
feat(div): divisor case eliminator using named shape predicates

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -56,6 +56,7 @@ import EvmAsm.Evm64.DivMod.Spec.N3DivStackSpec
 import EvmAsm.Evm64.DivMod.Spec.Unified
 import EvmAsm.Evm64.DivMod.Spec.UnifiedDivisorCases
 import EvmAsm.Evm64.DivMod.Spec.DivisorShapeNamed
+import EvmAsm.Evm64.DivMod.Spec.DivisorCasesNamedElim
 import EvmAsm.Evm64.DivMod.Spec.DivisorLimbCaseHelpers
 import EvmAsm.Evm64.DivMod.Spec.DivisorFullDomainShape
 import EvmAsm.Evm64.DivMod.Spec.UnifiedN1Normalized

--- a/EvmAsm/Evm64/DivMod/Spec/DivisorCasesNamedElim.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/DivisorCasesNamedElim.lean
@@ -1,0 +1,38 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.DivisorCasesNamedElim
+
+  Case eliminator over `EvmWord` using the named shape predicates
+  `NkShapeIs`. Convenient downstream pattern for proving any motive in five
+  cases: bzero, N1, N2, N3, N4.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.UnifiedDivisorCases
+import EvmAsm.Evm64.DivMod.Spec.DivisorShapeNamed
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64 EvmWord
+
+/-- Case eliminator: any motive `P : EvmWord → Sort _` is established for
+    every `b` if it holds in each of the five disjoint cases. -/
+theorem DivisorLimbCase.elim_named
+    {P : EvmWord → Prop}
+    (b : EvmWord)
+    (hbzero : b = 0 → P b)
+    (hn1 : N1ShapeIs b → P b)
+    (hn2 : N2ShapeIs b → P b)
+    (hn3 : N3ShapeIs b → P b)
+    (hn4 : N4ShapeIs b → P b) :
+    P b := by
+  cases divisorLimbCase b with
+  | bzero hbz => exact hbzero hbz
+  | n1 hbnz _ hb3z hb2z hb1z hb0nz =>
+      exact hn1 ⟨hbnz, hb3z, hb2z, hb1z, hb0nz⟩
+  | n2 hbnz _ hb3z hb2z hb1nz =>
+      exact hn2 ⟨hbnz, hb3z, hb2z, hb1nz⟩
+  | n3 hbnz _ hb3z hb2nz =>
+      exact hn3 ⟨hbnz, hb3z, hb2nz⟩
+  | n4 hbnz _ hb3nz =>
+      exact hn4 ⟨hbnz, hb3nz⟩
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Builds on #6983 (NkShapeIs, merged to main).
- Add DivisorLimbCase.elim_named: case eliminator over EvmWord that proves any motive by five-case split (bzero, N1, N2, N3, N4) using the named NkShapeIs predicates.

Refs #61. Bead: evm-asm-9iqmw.7.1.6.5.8.

Authored by @pirapira; implemented by Claude Code