### PR TITLE
feat(div): generalise N2 max-path overestimate to nonzero u3

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/DivN2MaxOverestimate.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivN2MaxOverestimate.lean
@@ -91,24 +91,20 @@ private theorem core_overestimate_step
   have hkey : (B - 3) * V0 ≤ 3 * V1 * B := by linarith
   linarith
 
-/-- N2 max-path local quotient bound.  If the divisor's high two limbs are
-    zero, the second limb `v1` is normalised (top bit set), and the carry-in
-    `u2` is at least `v1`, then `2^64 - 1` is within the local quotient plus
-    the double-addback slack of `+2`.
-
-    Concrete math: with `v = v0 + v1·2^64` and `u = u0 + u1·2^64 + u2·2^128`,
-    we show `u / v + 2 ≥ 2^64 − 1` whenever `v1 ≥ 2^63` and `u2 ≥ v1`.  The
-    bound is tight at `v0 = 2^64 − 1`, `v1 = 2^63`, `u0 = u1 = 0`, `u2 = v1`,
-    where `u / v = 2^64 − 2`. -/
-theorem max_trial_local_overestimate_n2_of_not_ult
-    (v0 v1 u0 u1 u2 : Word)
+/-- General N2 max-path local quotient bound (allowing nonzero `u3`).  If the
+    divisor's high two limbs are zero, the second limb `v1` is normalised (top
+    bit set), and the carry-in `u2` is at least `v1`, then `2^64 - 1` is within
+    the local quotient plus the double-addback slack of `+2`. -/
+theorem max_trial_local_overestimate_n2_of_not_ult_general
+    (v0 v1 u0 u1 u2 u3 : Word)
     (hv1_msb : 2^63 ≤ v1.toNat)
     (hbltu : ¬ BitVec.ult u2 v1) :
     (signExtend12 (4095 : BitVec 12) : Word).toNat ≤
-      val256 u0 u1 u2 0 / val256 v0 v1 0 0 + 2 := by
+      val256 u0 u1 u2 u3 / val256 v0 v1 0 0 + 2 := by
   rw [signExtend12_4095_toNat]
-  rw [EvmWord.val256_zero_upper_2, EvmWord.val256_zero_upper_1]
-  -- Powers of two used; folded back through `hB_eq`.
+  rw [EvmWord.val256_zero_upper_2]
+  unfold EvmWord.val256
+  -- Powers of two; folded back through `hB_eq`.
   have hB_eq : (2:Nat)^128 = 2^64 * 2^64 := by ring
   have hBhalf : (2:Nat)^63 + 2^63 = 2^64 := by ring
   have hV1_pos : 0 < v1.toNat := by
@@ -123,16 +119,45 @@ theorem max_trial_local_overestimate_n2_of_not_ult
   have hv_pos : 0 < v0.toNat + v1.toNat * 2^64 := by
     have : 0 < v1.toNat * 2^64 := Nat.mul_pos hV1_pos hB_pos
     omega
-  -- Reduce goal to (2^64 - 3) * v ≤ u, then apply the Nat-level core.
-  suffices h : (2^64 - 3 : Nat) ≤
-      (u0.toNat + u1.toNat * 2^64 + u2.toNat * 2^128) /
-        (v0.toNat + v1.toNat * 2^64) by
+  -- Goal after val256 unfolds (LHS sum):
+  --   u0 + u1*2^64 + u2*2^128 + u3*2^192.
+  -- Step: u/v ≥ (u0+u1*2^64+u2*2^128)/v, and the latter is ≥ 2^64 - 3.
+  -- So it suffices to bound the smaller sum.
+  set U_lo : Nat := u0.toNat + u1.toNat * 2^64 + u2.toNat * 2^128 with hU_lo
+  set U_full : Nat := U_lo + u3.toNat * 2^192 with hU_full
+  set V : Nat := v0.toNat + v1.toNat * 2^64 with hV
+  have hU_le : U_lo ≤ U_full := by
+    show U_lo ≤ U_lo + u3.toNat * 2^192
+    have : 0 ≤ u3.toNat * 2^192 := Nat.zero_le _
+    linarith
+  -- u/v monotone: U_lo/V ≤ U_full/V.
+  have hdiv_mono : U_lo / V ≤ U_full / V := Nat.div_le_div_right hU_le
+  -- Reduce to (2^64 - 3) * V ≤ U_lo via core_overestimate_step.
+  suffices h : (2^64 - 3 : Nat) ≤ U_lo / V by
     have hB_ge3 : (3:Nat) ≤ 2^64 := by norm_num
+    show 2^64 - 1 ≤ U_full / V + 2
     omega
   rw [Nat.le_div_iff_mul_le hv_pos]
+  show (2^64 - 3 : Nat) * V ≤ U_lo
+  show (2^64 - 3 : Nat) * (v0.toNat + v1.toNat * 2^64) ≤
+       u0.toNat + u1.toNat * 2^64 + u2.toNat * 2^128
   rw [hB_eq]
   exact core_overestimate_step (2^64) v0.toNat v1.toNat u0.toNat u1.toNat u2.toNat
     hBhalf hV0_lt hv1_msb hle
+
+/-- N2 max-path local quotient bound (j=2 specialisation with `u3 = 0`).
+
+    Concrete math: with `v = v0 + v1·2^64` and `u = u0 + u1·2^64 + u2·2^128`,
+    we show `u / v + 2 ≥ 2^64 − 1` whenever `v1 ≥ 2^63` and `u2 ≥ v1`.  The
+    bound is tight at `v0 = 2^64 − 1`, `v1 = 2^63`, `u0 = u1 = 0`, `u2 = v1`,
+    where `u / v = 2^64 − 2`. -/
+theorem max_trial_local_overestimate_n2_of_not_ult
+    (v0 v1 u0 u1 u2 : Word)
+    (hv1_msb : 2^63 ≤ v1.toNat)
+    (hbltu : ¬ BitVec.ult u2 v1) :
+    (signExtend12 (4095 : BitVec 12) : Word).toNat ≤
+      val256 u0 u1 u2 0 / val256 v0 v1 0 0 + 2 :=
+  max_trial_local_overestimate_n2_of_not_ult_general v0 v1 u0 u1 u2 0 hv1_msb hbltu
 
 /-- N2 max-path specialization of the generic double-addback progress bridge.
     With a 2-limb divisor (`v2 = v3 = 0`), `v1` normalised, and the selected
@@ -144,7 +169,6 @@ theorem isAddbackCarry2NzN2Max_of_not_ult_c3_one_of_carry_zero
     (hv1_msb : 2^63 ≤ v1.toNat)
     (hv2z : v2 = 0)
     (hv3z : v3 = 0)
-    (hu3z : u3 = 0)
     (hc3_one_of_carry_zero :
       addbackN4_carry
         (mulsubN4 (signExtend12 4095) v0 v1 v2 v3 u0 u1 u2 u3).1
@@ -166,8 +190,9 @@ theorem isAddbackCarry2NzN2Max_of_not_ult_c3_one_of_carry_zero
     have hv1_zero : v1.toNat = 0 := by rw [hv1]; decide
     have hpos : (0:Nat) < 2^63 := by positivity
     omega
-  · subst v2; subst v3; subst u3
-    exact max_trial_local_overestimate_n2_of_not_ult v0 v1 u0 u1 u2 hv1_msb hbltu
+  · subst v2; subst v3
+    exact max_trial_local_overestimate_n2_of_not_ult_general v0 v1 u0 u1 u2 u3
+      hv1_msb hbltu
   · exact hc3_one_of_carry_zero
 
 end EvmAsm.Evm64


### PR DESCRIPTION
Stacked on PR #6998. Generalises max_trial_local_overestimate_n2 to allow nonzero u3, making the same isAddbackCarry2NzN2Max bridge close BOTH j=2 MAX (.1.1.2) and j=1 MAX (.1.2.2) branches. Refs #61. Bead: evm-asm-9iqmw.7.1.6.2.3.2.1.2.2. Authored by @pirapira; implemented by Claude Code