### PR TITLE
feat(div): N2 j=2 BLT-branch shape-only closure

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -128,3 +128,4 @@ import EvmAsm.Evm64.DivMod.Spec.N3MaxBranchFromInvariant
 import EvmAsm.Evm64.DivMod.Spec.N2MaxBranchFromInvariant
 import EvmAsm.Evm64.DivMod.Spec.N3MaxBranchShapeOnly
 import EvmAsm.Evm64.DivMod.Spec.N2MaxBranchShapeOnly
+import EvmAsm.Evm64.DivMod.Spec.N2BltBranchShapeOnly

--- a/EvmAsm/Evm64/DivMod/Spec/N2BltBranchShapeOnly.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2BltBranchShapeOnly.lean
@@ -1,0 +1,117 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N2BltBranchShapeOnly
+
+  Shape-only closure form for the N2 j=2 BLT-branch predicate, obtained
+  by composing the BLT predicate bridge in `DivBltBridgeSpecializations`
+  with an inline derivation of the divisor-nonzero fact from N2 shape
+  (using `fullDivN2NormV_msb_of_b1_ne_zero` from `DivN2NormVStructure`).
+
+  Mirrors `N3BltBranchShapeOnly` for the n=2 lane.
+-/
+
+import EvmAsm.Evm64.EvmWordArith.DivBltBridgeSpecializations
+import EvmAsm.Evm64.EvmWordArith.DivN2NormVStructure
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.Base
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- From N2 shape (`b1 ≠ 0`), the normalised v has a nonzero limb (because
+    its second limb has MSB set, hence is positive). -/
+private theorem fullDivN2NormV_or_ne_zero_of_b1_ne_zero
+    (b0 b1 b2 b3 : Word) (hb1nz : b1 ≠ 0) :
+    (fullDivN2NormV b0 b1 b2 b3).1 |||
+      (fullDivN2NormV b0 b1 b2 b3).2.1 |||
+      (fullDivN2NormV b0 b1 b2 b3).2.2.1 |||
+      (fullDivN2NormV b0 b1 b2 b3).2.2.2 ≠ 0 := by
+  have h_msb := fullDivN2NormV_msb_of_b1_ne_zero b0 b1 b2 b3 hb1nz
+  have hv1_pos : 0 < (fullDivN2NormV b0 b1 b2 b3).2.1.toNat := by
+    have : (0:Nat) < 2^63 := by positivity
+    omega
+  -- If the full OR is zero, then v1 in particular is zero.
+  intro h
+  have h1 : (fullDivN2NormV b0 b1 b2 b3).1 ||| (fullDivN2NormV b0 b1 b2 b3).2.1 |||
+      (fullDivN2NormV b0 b1 b2 b3).2.2.1 = 0 := (BitVec.or_eq_zero_iff.mp h).1
+  have h2 : (fullDivN2NormV b0 b1 b2 b3).1 ||| (fullDivN2NormV b0 b1 b2 b3).2.1 = 0 :=
+    (BitVec.or_eq_zero_iff.mp h1).1
+  have hv1 : (fullDivN2NormV b0 b1 b2 b3).2.1 = 0 :=
+    (BitVec.or_eq_zero_iff.mp h2).2
+  rw [hv1] at hv1_pos
+  exact absurd hv1_pos (by decide)
+
+/-- N2 j=2 BLT-branch carry-2-nz at the canonical bltu_2 = true, from
+    n=2 shape facts, the v4 trial overestimate, and the named BLT c3
+    invariant. -/
+theorem loopBodyN2CallAddbackCarry2NzV4_at_canonical_bltu2_true_of_shape
+    (a b : EvmWord)
+    (hb1nz : b.getLimbN 1 ≠ 0)
+    (hq_over :
+      (divKTrialCallV4QHat
+        (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.2
+        (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.1
+        (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).2.1).toNat ≤
+      EvmWord.val256
+        (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.1
+        (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.1
+        (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+          (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.2
+        (0 : Word) /
+      EvmWord.val256
+        (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).1
+        (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).2.1
+        (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+        (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+          (b.getLimbN 2) (b.getLimbN 3)).2.2.2 + 2)
+    (hc3 : MulsubBltC3OneOfCarryZero
+      (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+        (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.2
+      (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+        (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.1
+      (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+        (b.getLimbN 2) (b.getLimbN 3)).2.1
+      (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+        (b.getLimbN 2) (b.getLimbN 3)).1
+      (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+        (b.getLimbN 2) (b.getLimbN 3)).2.1
+      (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+        (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+      (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+        (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+      (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+        (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.1
+      (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+        (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.1
+      (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+        (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.2
+      (0 : Word)) :
+    loopBodyN2CallAddbackCarry2NzV4
+      (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+        (b.getLimbN 2) (b.getLimbN 3)).1
+      (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+        (b.getLimbN 2) (b.getLimbN 3)).2.1
+      (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+        (b.getLimbN 2) (b.getLimbN 3)).2.2.1
+      (fullDivN2NormV (b.getLimbN 0) (b.getLimbN 1)
+        (b.getLimbN 2) (b.getLimbN 3)).2.2.2
+      (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+        (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.1
+      (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+        (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.1
+      (fullDivN2NormU (a.getLimbN 0) (a.getLimbN 1)
+        (a.getLimbN 2) (a.getLimbN 3) (b.getLimbN 1)).2.2.2.2
+      (0 : Word) (0 : Word) := by
+  have hbnz_limbs := fullDivN2NormV_or_ne_zero_of_b1_ne_zero
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) hb1nz
+  exact loopBodyN2CallAddbackCarry2NzV4_of_overestimate_c3 _ _ _ _ _ _ _ _ _
+    hbnz_limbs hq_over hc3
+
+end EvmAsm.Evm64


### PR DESCRIPTION
Stacked on PR #7018. Mirrors the N3 BLT shape-only closure for n=2. Includes a private fullDivN2NormV_or_ne_zero_of_b1_ne_zero helper. Refs #61. Bead: evm-asm-9iqmw.7.1.6.2.3.2.1.2.1. Authored by @pirapira; implemented by Claude Code