### PR TITLE
test(stateless): variety -- chain_id = 2^32 (seam edge case)

### DIFF
--- a/scripts/codegen-stateless-spec-output-check.sh
+++ b/scripts/codegen-stateless-spec-output-check.sh
@@ -161,6 +161,19 @@ run_fixture "chain_max_u64"         0xFFFFFFFFFFFFFFFF      || fail=1
 # topmost non-zero chain_id byte.
 run_fixture "chain_sepolia"         11155111                || fail=1
 
+# Edge: chain_id = 2^32 = 0x100000000. LE bytes
+# 00 00 00 00 01 00 00 00. The encoder's chain_id split
+# places the LOW 3 bytes at OUTPUT[37..40) and the HIGH 5 at
+# OUTPUT[40..45). With 2^32, low 3 = 00 00 00 (zeros), high 5
+# = 00 01 00 00 00 -- the lone non-zero byte 0x01 sits at
+# OUTPUT[41], exactly the SECOND byte of the second SD's
+# region. Tests the encoder's SRLI .x10 24 + OR' .x5
+# (= 0xc0000000000) packing when the chain_id has zero bytes
+# in the low 24 bits and a non-zero byte at exactly bit
+# position 32..40 (i.e. shifted into the lowest byte of x7
+# after SRLI 24).
+run_fixture "chain_2pow32"          0x100000000             || fail=1
+
 # Non-zero fork fixture -- exercises active_fork.fork passthrough.
 # One fixture suffices: the encoder pipes the raw u64 from x12 to
 # OUTPUT[49..57) without inspecting its value.


### PR DESCRIPTION
## Summary

- Add fixture \`chain_2pow32\` with chain_id = \`2^32 = 0x100000000\`.
- LE bytes \`00 00 00 00 01 00 00 00\` — single non-zero byte at index 4.
- Encoder's chain_id split places \`low 3 bytes\` at \`OUTPUT[37..40)\` and \`high 5 bytes\` at \`OUTPUT[40..45)\`. With \`2^32\`, the lone \`0x01\` lands at \`OUTPUT[41]\` — exactly the second byte of the second SD's region.

Tests the encoder's \`SRLI .x10 24\` + \`OR\` packing when chain_id has zero bytes in the low 24 bits and a non-zero byte at exactly bit position 32..40 (i.e. shifted into the lowest byte of x7 after SRLI 24). Catches off-by-one bugs in the shift amount or packing constants.

Variety dimension: power-of-2 chain_id values that span exactly one byte position at a chunk seam.

## Test plan

- [x] \`scripts/codegen-stateless-spec-output-check.sh\` — all fixtures pass.
- [x] Verified byte 41 of \`gen-out/stateless_guest-spec-chain_2pow32.output\` = \`01\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)