### PR TITLE
test(stateless): variety -- VALID_TS_HIBIT (K229 unsigned-comparison guard)

### DIFF
--- a/scripts/codegen-stateless-gen-fixture.py
+++ b/scripts/codegen-stateless-gen-fixture.py
@@ -114,7 +114,7 @@ if state_hex:
 HeaderBL = ByteList[MAX_BYTES_PER_HEADER]
 HeadersList = SszList[HeaderBL, MAX_WITNESS_HEADERS]
 hdr_arg = ()
-if hdr_hex in ('INVALID_TS', 'INVALID_NM', 'VALID_TWO', 'VALID_THREE', 'INVALID_DIFF_AT_1', 'INVALID_EXTRA_AT_2', 'INVALID_TS_AT_2', 'INVALID_NM_AT_2'):
+if hdr_hex in ('INVALID_TS', 'INVALID_NM', 'VALID_TWO', 'VALID_THREE', 'INVALID_DIFF_AT_1', 'INVALID_EXTRA_AT_2', 'INVALID_TS_AT_2', 'INVALID_NM_AT_2', 'VALID_TS_HIBIT'):
     # Multi-header fixtures (N=2 or N=3) exercising K229 and
     # K230 in their accept and reject branches. Each header
     # individually passes K290 / K291 / K240 / K278 / K277.
@@ -267,6 +267,52 @@ if hdr_hex in ('INVALID_TS', 'INVALID_NM', 'VALID_TWO', 'VALID_THREE', 'INVALID_
         h0 = mk(1, 1234); h1 = mk(2, 2000); h2 = mk(4, 3000)
         hdr_arg = (HeaderBL(rlp.encode(h0)), HeaderBL(rlp.encode(h1)),
                    HeaderBL(rlp.encode(h2)))
+    elif hdr_hex == 'VALID_TS_HIBIT':
+        # N=2 chained valid post-merge headers with timestamps
+        # that STRADDLE the u64 sign-bit boundary:
+        #   ts[0] = 2^63 - 1 = 0x7FFFFFFFFFFFFFFF (max positive
+        #                       i64; all bits set except MSB)
+        #   ts[1] = 2^63     = 0x8000000000000000 (MSB-only;
+        #                       INT64_MIN if interpreted signed)
+        # Unsigned: ts[1] > ts[0], so K229 accepts (uses BGEU).
+        # Signed:   ts[1] < ts[0], so a buggy BGE swap would
+        # incorrectly reject. Regression-guards the timestamp
+        # comparator's unsigned-ness.
+        # Numbers 1 -> 2 (consecutive), parent_hash chained
+        # (keccak256 of RLP(h0)) so spec's validate_headers
+        # also succeeds. All other K-PRs pass on both headers.
+        from ethereum.crypto.hash import keccak256
+        def mk_hibit(number, timestamp, parent_hash):
+            return Header(
+                parent_hash=parent_hash,
+                ommers_hash=EMPTY_OMMER_HASH,
+                coinbase=b'\x00' * 20,
+                state_root=Hash32(b'\x00' * 32),
+                transactions_root=Hash32(b'\x00' * 32),
+                receipt_root=Hash32(b'\x00' * 32),
+                bloom=b'\x00' * 256,
+                difficulty=Uint(0),
+                number=Uint(number),
+                gas_limit=Uint(1000000),
+                gas_used=Uint(0),
+                timestamp=U256(timestamp),
+                extra_data=Bytes(b''),
+                prev_randao=Bytes32(b'\x00' * 32),
+                nonce=Bytes8(b'\x00' * 8),
+                base_fee_per_gas=Uint(0),
+                withdrawals_root=Hash32(b'\x00' * 32),
+                blob_gas_used=U64t(0),
+                excess_blob_gas=U64t(0),
+                parent_beacon_block_root=Hash32(b'\x00' * 32),
+                requests_hash=Hash32(b'\x00' * 32),
+                block_access_list_hash=Hash32(b'\x00' * 32),
+                slot_number=U64t(0),
+            )
+        h0 = mk_hibit(1, (1 << 63) - 1, Hash32(b'\x00' * 32))
+        h0_bytes = rlp.encode(h0)
+        h1 = mk_hibit(2, (1 << 63), keccak256(h0_bytes))
+        h1_bytes = rlp.encode(h1)
+        hdr_arg = (HeaderBL(h0_bytes), HeaderBL(h1_bytes))
     else:  # VALID_THREE
         # Three chained valid post-merge headers. parent_hash
         # chain so spec's validate_headers ALSO accepts

--- a/scripts/codegen-stateless-spec-output-check.sh
+++ b/scripts/codegen-stateless-spec-output-check.sh
@@ -642,6 +642,20 @@ run_fixture "chain1_invalid_nm_at_2"    1              0    ""           ""     
 # NPR -> valid=False. ELF: valid=False from x11 stub. Match.
 run_fixture "chain1_valid_three"    1                  0    ""           ""                  ""    ""           ""           ""    "VALID_THREE" || fail=1
 
+# Regression guard for K229's unsigned timestamp comparison.
+# N=2 chained valid post-merge headers with timestamps that
+# straddle the u64 sign-bit boundary:
+#   ts[0] = 2^63 - 1 = 0x7FFFFFFFFFFFFFFF (max positive i64)
+#   ts[1] = 2^63     = 0x8000000000000000 (INT64_MIN signed)
+# Unsigned: ts[1] > ts[0] -> K229 accepts (uses BGEU). A
+# buggy BGE swap would interpret ts[1] as a large negative,
+# reject incorrectly, and -- once the K-PR pipeline surfaces
+# REASON codes -- diverge from spec. Today both paths land at
+# valid=False via the .Lsg_hash fall-through; the fixture
+# locks in the unsigned-ness of the comparator before that
+# surface is reintroduced.
+run_fixture "chain1_valid_ts_hibit" 1                  0    ""           ""                  ""    ""           ""           ""    "VALID_TS_HIBIT" || fail=1
+
 # Kitchen-sink fixture -- every input slot populated
 # simultaneously. All three inner witness fields (state +
 # codes + headers) carry one entry each; public_keys has one


### PR DESCRIPTION
## Summary

Add fixture \`chain1_valid_ts_hibit\` with N=2 chained valid post-merge headers whose timestamps straddle the u64 sign-bit boundary:

| field    | header 0                  | header 1                  |
| -------- | ------------------------- | ------------------------- |
| number   | 1                         | 2                         |
| timestamp| \`2^63 - 1\` (\`0x7FFFFFFFFFFFFFFF\`) | \`2^63\` (\`0x8000000000000000\`) |
| parent_hash | zero                   | \`keccak256(rlp(h0))\`    |
| (all other K-PR-relevant fields zero / EMPTY_OMMER_HASH) |

Unsigned interpretation: \`ts[1] > ts[0]\` — K229's BGEU correctly accepts.

Signed interpretation: \`ts[1] < ts[0]\` — a buggy BGE swap would incorrectly reject.

## Why this is useful

K229 currently uses BGEU (\`EvmAsm/Codegen/Programs/ChainValidate.lean:89\`). Once the K-PR pipeline reintroduces \`unimplemented_exit\` with REASON codes, a regression that swaps BGEU→BGE would produce a different output byte stream than the spec — and this fixture would catch it at the integration layer without requiring a unit-script change.

Today both paths land at \`valid=False\` via the \`.Lsg_hash\` fall-through, so the output is byte-identical either way; the fixture's value is locking in the contract before the REASON surface comes back online.

## Variety dimension

The u64 sign-bit boundary in monotonicity comparisons — a class of bug that signed/unsigned-mixup introduces in low-level chain validators. Distinct from prior fixtures which focused on encoder seams, K-PR boundaries, header field cohorts, and chained-header iteration.

## Test plan

- [x] \`scripts/codegen-stateless-spec-output-check.sh\` — all fixtures pass, including the new \`chain1_valid_ts_hibit\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)