### PR TITLE
feat(div): MAX c3 invariant discharge from +2 overestimate + two unreachability frontiers

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith.lean
+++ b/EvmAsm/Evm64/EvmWordArith.lean
@@ -48,6 +48,7 @@ import EvmAsm.Evm64.EvmWordArith.ModBridgeAssemble
 import EvmAsm.Evm64.EvmWordArith.DivN4Lemmas
 import EvmAsm.Evm64.EvmWordArith.SkipBorrowExtract
 import EvmAsm.Evm64.EvmWordArith.DivN4DoubleAddback
+import EvmAsm.Evm64.EvmWordArith.DivMulsubC3LeTwo
 import EvmAsm.Evm64.EvmWordArith.DivN3MaxOverestimate
 import EvmAsm.Evm64.EvmWordArith.DivN2MaxOverestimate
 import EvmAsm.Evm64.EvmWordArith.DivBltC3Invariant

--- a/EvmAsm/Evm64/EvmWordArith.lean
+++ b/EvmAsm/Evm64/EvmWordArith.lean
@@ -54,6 +54,7 @@ import EvmAsm.Evm64.EvmWordArith.DivN2MaxOverestimate
 import EvmAsm.Evm64.EvmWordArith.DivBltC3Invariant
 import EvmAsm.Evm64.EvmWordArith.DivMaxC3Invariant
 import EvmAsm.Evm64.EvmWordArith.DivC3InvariantUnifiedCase
+import EvmAsm.Evm64.EvmWordArith.DivC3InvariantPlusTwoCase
 import EvmAsm.Evm64.EvmWordArith.DivN3NormVStructure
 import EvmAsm.Evm64.EvmWordArith.DivN2NormVStructure
 import EvmAsm.Evm64.EvmWordArith.DivBltBridge

--- a/EvmAsm/Evm64/EvmWordArith/DivC3InvariantPlusTwoCase.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivC3InvariantPlusTwoCase.lean
@@ -1,0 +1,89 @@
+/-
+  EvmAsm.Evm64.EvmWordArith.DivC3InvariantPlusTwoCase
+
+  Discharges `MulsubMaxC3OneOfCarryZero` under a `+2` val256-level
+  overestimate (the natural shape-specific form from
+  `max_trial_local_overestimate_n{2,3}_of_not_ult`) given two named
+  unreachability frontiers:
+    1. `MulsubMaxC3UnreachableCarryZeroC3Zero`: (carry = 0 ∧ c3 = 0)
+       does not occur on the selected path,
+    2. `MulsubMaxC3UnreachableCarryZeroC3Two`: (carry = 0 ∧ c3 = 2)
+       does not occur on the selected path.
+
+  Together with `mulsubN4_c3_le_two`, this reduces the MAX-side c3
+  invariant under `+2` to exactly two sharp reachability obligations.
+-/
+
+import EvmAsm.Evm64.EvmWordArith.DivMaxC3Invariant
+import EvmAsm.Evm64.EvmWordArith.DivMulsubC3LeTwo
+import EvmAsm.Evm64.EvmWordArith.DivC3InvariantUnifiedCase
+
+namespace EvmAsm.Evm64
+
+open EvmWord EvmAsm.Rv64
+
+/-- Frontier predicate: under the saturated MAX trial, `c3 = 2` with
+    first-addback carry `= 0` does not occur on the selected path.
+
+    Companion to `MulsubMaxC3UnreachableCarryZeroC3Zero` for the `+2`
+    case. -/
+def MulsubMaxC3UnreachableCarryZeroC3Two (v0 v1 v2 v3 u0 u1 u2 u3 : Word) : Prop :=
+  ¬ (addbackN4_carry
+        (mulsubN4 (signExtend12 4095) v0 v1 v2 v3 u0 u1 u2 u3).1
+        (mulsubN4 (signExtend12 4095) v0 v1 v2 v3 u0 u1 u2 u3).2.1
+        (mulsubN4 (signExtend12 4095) v0 v1 v2 v3 u0 u1 u2 u3).2.2.1
+        (mulsubN4 (signExtend12 4095) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.1
+        v0 v1 v2 v3 = 0 ∧
+      (mulsubN4 (signExtend12 4095) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2.toNat = 2)
+
+/-- `MulsubMaxC3OneOfCarryZero` from a `+2` val256-level overestimate
+    and the unreachability of both `c3 = 0` and `c3 = 2` cases
+    (under `carry = 0`). -/
+theorem MulsubMaxC3OneOfCarryZero_of_plus_two_and_unreach
+    (v0 v1 v2 v3 u0 u1 u2 u3 : Word)
+    (hbnz : v0 ||| v1 ||| v2 ||| v3 ≠ 0)
+    (hq_over : (signExtend12 (4095 : BitVec 12) : Word).toNat ≤
+      val256 u0 u1 u2 u3 / val256 v0 v1 v2 v3 + 2) :
+    MulsubMaxC3UnreachableCarryZeroC3Zero v0 v1 v2 v3 u0 u1 u2 u3 →
+    MulsubMaxC3UnreachableCarryZeroC3Two v0 v1 v2 v3 u0 u1 u2 u3 →
+    MulsubMaxC3OneOfCarryZero v0 v1 v2 v3 u0 u1 u2 u3 := by
+  intro h_unreach0 h_unreach2
+  unfold MulsubMaxC3OneOfCarryZero
+  intro h_carry_zero
+  unfold MulsubMaxC3UnreachableCarryZeroC3Zero at h_unreach0
+  unfold MulsubMaxC3UnreachableCarryZeroC3Two at h_unreach2
+  have h_c3_le_two := mulsubN4_c3_le_two hbnz hq_over
+  -- c3 ∈ {0, 1, 2}.  Under carry = 0:
+  --   c3 = 0 → contradicts h_unreach0
+  --   c3 = 2 → contradicts h_unreach2 (after .toNat = 2)
+  --   c3 = 1 → conclusion holds.
+  apply BitVec.eq_of_toNat_eq
+  rcases Nat.lt_or_ge
+      (mulsubN4 (signExtend12 4095) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2.toNat 1
+      with h_lt1 | h_ge1
+  · -- c3 < 1, so c3 = 0 → unreachable
+    exfalso
+    have h_c3_zero :
+        (mulsubN4 (signExtend12 4095) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2 = 0 := by
+      apply BitVec.eq_of_toNat_eq
+      have h_zero :
+          (mulsubN4 (signExtend12 4095) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2.toNat = 0 := by
+        omega
+      rw [h_zero]; rfl
+    exact h_unreach0 ⟨h_carry_zero, h_c3_zero⟩
+  · -- c3 ≥ 1.  Then c3 ∈ {1, 2}.
+    rcases Nat.lt_or_ge
+        (mulsubN4 (signExtend12 4095) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2.toNat 2
+        with h_lt2 | h_ge2
+    · -- c3 = 1
+      have h_eq : (mulsubN4 (signExtend12 4095) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2.toNat = 1 := by
+        omega
+      rw [h_eq]; rfl
+    · -- c3 = 2 → unreachable
+      exfalso
+      have h_c3_two_toNat :
+          (mulsubN4 (signExtend12 4095) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2.toNat = 2 := by
+        omega
+      exact h_unreach2 ⟨h_carry_zero, h_c3_two_toNat⟩
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/EvmWordArith/DivMulsubC3LeTwo.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivMulsubC3LeTwo.lean
@@ -1,0 +1,58 @@
+/-
+  EvmAsm.Evm64.EvmWordArith.DivMulsubC3LeTwo
+
+  `mulsubN4_c3_le_two`: the analog of the existing `mulsubN4_c3_le_one`
+  (from `DivN4Overestimate`) under a `+2` (rather than `+1`) val256-level
+  trial overestimate.
+
+  This is the natural bound for the saturated trial `signExtend12 4095`
+  under the n=2/n=3 MAX path conditions (where the existing
+  `max_trial_local_overestimate_n{2,3}_of_not_ult` lemmas provide `+2`).
+-/
+
+import EvmAsm.Evm64.EvmWordArith.DivN4Overestimate
+
+namespace EvmAsm.Evm64
+
+open EvmWord EvmAsm.Rv64
+
+/-- When the trial quotient overestimates by at most 2 (q ≤ ⌊u/v⌋ + 2),
+    the mulsub borrow `c3` is at most 2.
+
+    Proof structure mirrors `mulsubN4_c3_le_one`: from
+    `mulsubN4_val256_eq`, `c3 * 2^256 = val256(un) + q*val256(v) - val256(u)`.
+    With `q*val256(v) ≤ val256(u) + 2*val256(v)`, we get
+    `c3 * 2^256 ≤ val256(un) + 2*val256(v) < 2^256 + 2*2^256 = 3*2^256`,
+    hence `c3 ≤ 2`. -/
+theorem mulsubN4_c3_le_two {q v0 v1 v2 v3 u0 u1 u2 u3 : Word}
+    (hbnz : v0 ||| v1 ||| v2 ||| v3 ≠ 0)
+    (hq_over : q.toNat ≤ val256 u0 u1 u2 u3 / val256 v0 v1 v2 v3 + 2) :
+    (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2.toNat ≤ 2 := by
+  let ms := mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3
+  let c3 := ms.2.2.2.2
+  have hmulsub := mulsubN4_val256_eq q v0 v1 v2 v3 u0 u1 u2 u3
+  simp only [] at hmulsub
+  have := val256_bound u0 u1 u2 u3
+  have := val256_bound ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1
+  have := val256_bound v0 v1 v2 v3
+  have := val256_pos_of_or_ne_zero hbnz
+  have hdiv_mul_le : val256 u0 u1 u2 u3 / val256 v0 v1 v2 v3 *
+      val256 v0 v1 v2 v3 ≤ val256 u0 u1 u2 u3 :=
+    Nat.div_mul_le_self _ _
+  have hqv_le : q.toNat * val256 v0 v1 v2 v3 ≤
+      val256 u0 u1 u2 u3 + 2 * val256 v0 v1 v2 v3 := by
+    calc q.toNat * val256 v0 v1 v2 v3
+        ≤ (val256 u0 u1 u2 u3 / val256 v0 v1 v2 v3 + 2) * val256 v0 v1 v2 v3 :=
+          Nat.mul_le_mul_right _ hq_over
+      _ = val256 u0 u1 u2 u3 / val256 v0 v1 v2 v3 * val256 v0 v1 v2 v3 +
+          2 * val256 v0 v1 v2 v3 := by ring
+      _ ≤ val256 u0 u1 u2 u3 + 2 * val256 v0 v1 v2 v3 :=
+          Nat.add_le_add_right hdiv_mul_le _
+  have hc3_bound : c3.toNat * 2^256 < 3 * 2^256 := by
+    nlinarith
+  show c3.toNat ≤ 2
+  have h256_pos : (0 : Nat) < 2^256 := by positivity
+  have : c3.toNat < 3 := (Nat.mul_lt_mul_right h256_pos).mp hc3_bound
+  omega
+
+end EvmAsm.Evm64


### PR DESCRIPTION
Stacked on PR #7041. Names MulsubMaxC3UnreachableCarryZeroC3Two and discharges MulsubMaxC3OneOfCarryZero from +2 overestimate + unreachability of c3 ∈ {0, 2}. Natural form for saturated trial under n=2/n=3 MAX normalisation. Refs #61. Authored by @pirapira; implemented by Claude Code