### PR TITLE
test(stateless): variety -- VALID_GAS_HIBIT (K240 unsigned-comparison guard)

### DIFF
--- a/scripts/codegen-stateless-gen-fixture.py
+++ b/scripts/codegen-stateless-gen-fixture.py
@@ -417,6 +417,7 @@ elif hdr_hex in (
     'INVALID_OMMERS',
     'VALID_REALISTIC',
     'VALID_ALL_BOUNDARY',
+    'VALID_GAS_HIBIT',
 ):
     # Construct a (mostly) valid post-merge header. Variants:
     #   VALID_POST_MERGE       -- passes all 7 K-PR validators.
@@ -449,13 +450,25 @@ elif hdr_hex in (
         extra = Bytes(b'\\xab' * 32)
     else:
         extra = Bytes(b'')
-    gas_limit_v = 1000000
-    if hdr_hex == 'INVALID_GAS':
-        gas_used_v = 1000001
-    elif hdr_hex in ('VALID_GAS_BOUNDARY', 'VALID_ALL_BOUNDARY'):
-        gas_used_v = 1000000  # == gas_limit, boundary accept
+    if hdr_hex == 'VALID_GAS_HIBIT':
+        # Regression guard for K240's unsigned comparison.
+        # gas_used = 2^63 - 1 (max positive i64); gas_limit
+        # = 2^63 (INT64_MIN if interpreted signed).
+        # Unsigned: gas_used < gas_limit -> K240 BGTU correctly
+        # accepts. Signed: gas_used (INT64_MAX) > gas_limit
+        # (INT64_MIN) -> a buggy BGT swap would reject. The
+        # fixture locks in the unsigned-ness of the gas check
+        # before the REASON-code surface is reintroduced.
+        gas_limit_v = 1 << 63
+        gas_used_v = (1 << 63) - 1
     else:
-        gas_used_v = 0
+        gas_limit_v = 1000000
+        if hdr_hex == 'INVALID_GAS':
+            gas_used_v = 1000001
+        elif hdr_hex in ('VALID_GAS_BOUNDARY', 'VALID_ALL_BOUNDARY'):
+            gas_used_v = 1000000  # == gas_limit, boundary accept
+        else:
+            gas_used_v = 0
     if hdr_hex == 'INVALID_BLOB_MISALIGN':
         blob_gas_used_v = 1
     elif hdr_hex == 'INVALID_BLOB_OVERMAX':

--- a/scripts/codegen-stateless-spec-output-check.sh
+++ b/scripts/codegen-stateless-spec-output-check.sh
@@ -600,6 +600,19 @@ run_fixture "chain1_invalid_nonce"  1                  0    ""           ""     
 # in-K-PR code path.
 run_fixture "chain1_invalid_ommers" 1                  0    ""           ""                  ""    ""           ""           ""    "INVALID_OMMERS" || fail=1
 
+# Regression guard for K240's unsigned (BGTU) comparison.
+# Single header with gas_used = 2^63 - 1 = 0x7FFFFFFFFFFFFFFF
+# (max positive i64) and gas_limit = 2^63 = 0x8000000000000000
+# (INT64_MIN if interpreted signed).
+# Unsigned: gas_used < gas_limit -> K240 BGTU accepts.
+# Signed:   gas_used > gas_limit -> a buggy BGT swap rejects.
+# Today both paths land at valid=False via .Lsg_hash so the
+# output is byte-identical, but this fixture locks in the
+# unsigned-ness of the gas comparator before the REASON
+# surface is reintroduced -- sister to chain1_valid_ts_hibit
+# for the K229 timestamp comparator.
+run_fixture "chain1_valid_gas_hibit" 1                 0    ""           ""                  ""    ""           ""           ""    "VALID_GAS_HIBIT" || fail=1
+
 # Two headers: first valid, second has difficulty=1. K290
 # (chain_validate_post_merge_full) iterates: first header
 # passes, SECOND fails. Verifies the per-header iteration


### PR DESCRIPTION
## Summary

Add fixture \`chain1_valid_gas_hibit\` with a single valid post-merge header whose gas fields straddle the u64 sign-bit boundary:

| field     | value |
| --------- | ----- |
| gas_used  | \`2^63 - 1\` = \`0x7FFFFFFFFFFFFFFF\` (max positive i64) |
| gas_limit | \`2^63\` = \`0x8000000000000000\` (INT64_MIN signed) |

Unsigned: \`gas_used < gas_limit\` → K240's \`BGTU\` correctly accepts.

Signed: \`gas_used > gas_limit\` → a buggy \`BGT\` swap would incorrectly reject.

## Why this is useful

K240 uses \`bgtu\` (\`EvmAsm/Codegen/Programs/ChainValidate.lean:344\`). Once the K-PR pipeline reintroduces \`unimplemented_exit\` with REASON codes, a regression that swaps \`BGTU → BGT\` would produce a different output stream than the spec — and this fixture would catch it at the integration layer without requiring a unit-script change.

Today both paths land at \`valid=False\` via the \`.Lsg_hash\` fall-through, so the output is byte-identical either way; the fixture's value is locking in the contract before the REASON surface comes back online.

## Variety dimension

Extends the u64 sign-bit boundary regression guard to a second K-PR validator. Sister to \`chain1_valid_ts_hibit\` (PR #7035) for the K229 timestamp comparator. Same shape, different comparator (K240 \`BGTU\` vs K229 \`BGEU\`).

## Test plan

- [x] \`scripts/codegen-stateless-spec-output-check.sh\` — all fixtures pass, including the new \`chain1_valid_gas_hibit\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)