### PR TITLE
test(stateless): variety -- INVALID_GAS_AT_1 (K240 iteration coverage)

### DIFF
--- a/scripts/codegen-stateless-gen-fixture.py
+++ b/scripts/codegen-stateless-gen-fixture.py
@@ -114,7 +114,7 @@ if state_hex:
 HeaderBL = ByteList[MAX_BYTES_PER_HEADER]
 HeadersList = SszList[HeaderBL, MAX_WITNESS_HEADERS]
 hdr_arg = ()
-if hdr_hex in ('INVALID_TS', 'INVALID_NM', 'VALID_TWO', 'VALID_THREE', 'INVALID_DIFF_AT_1', 'INVALID_EXTRA_AT_2', 'INVALID_TS_AT_2', 'INVALID_NM_AT_2', 'VALID_TS_HIBIT', 'VALID_REALISTIC_TWO', 'VALID_EIGHT'):
+if hdr_hex in ('INVALID_TS', 'INVALID_NM', 'VALID_TWO', 'VALID_THREE', 'INVALID_DIFF_AT_1', 'INVALID_EXTRA_AT_2', 'INVALID_TS_AT_2', 'INVALID_NM_AT_2', 'VALID_TS_HIBIT', 'VALID_REALISTIC_TWO', 'VALID_EIGHT', 'INVALID_GAS_AT_1'):
     # Multi-header fixtures (N=2 or N=3) exercising K229 and
     # K230 in their accept and reject branches. Each header
     # individually passes K290 / K291 / K240 / K278 / K277.
@@ -210,6 +210,45 @@ if hdr_hex in ('INVALID_TS', 'INVALID_NM', 'VALID_TWO', 'VALID_THREE', 'INVALID_
             )
         h0 = mk_diff(1, 1234, 0)
         h1 = mk_diff(2, 2000, 1)  # difficulty != 0 at index 1
+        hdr_arg = (HeaderBL(rlp.encode(h0)), HeaderBL(rlp.encode(h1)))
+    elif hdr_hex == 'INVALID_GAS_AT_1':
+        # First header valid (gas_used <= gas_limit), second
+        # header has gas_used > gas_limit. K240 iterates: first
+        # header passes the BGTU check, SECOND fails. Tests
+        # K240's per-header iteration loop body actually checks
+        # every header (closes the iteration-coverage gap for
+        # K240 that INVALID_DIFF_AT_1 covers for K290 and
+        # INVALID_EXTRA_AT_2 covers for K291). Earlier K-PRs
+        # (K290, K291) pass on both headers; the failure is
+        # only at K240 on index 1.
+        def mk_gas(number, timestamp, gas_used, gas_limit):
+            return Header(
+                parent_hash=Hash32(b'\x00' * 32),
+                ommers_hash=EMPTY_OMMER_HASH,
+                coinbase=b'\x00' * 20,
+                state_root=Hash32(b'\x00' * 32),
+                transactions_root=Hash32(b'\x00' * 32),
+                receipt_root=Hash32(b'\x00' * 32),
+                bloom=b'\x00' * 256,
+                difficulty=Uint(0),
+                number=Uint(number),
+                gas_limit=Uint(gas_limit),
+                gas_used=Uint(gas_used),
+                timestamp=U256(timestamp),
+                extra_data=Bytes(b''),
+                prev_randao=Bytes32(b'\x00' * 32),
+                nonce=Bytes8(b'\x00' * 8),
+                base_fee_per_gas=Uint(0),
+                withdrawals_root=Hash32(b'\x00' * 32),
+                blob_gas_used=U64t(0),
+                excess_blob_gas=U64t(0),
+                parent_beacon_block_root=Hash32(b'\x00' * 32),
+                requests_hash=Hash32(b'\x00' * 32),
+                block_access_list_hash=Hash32(b'\x00' * 32),
+                slot_number=U64t(0),
+            )
+        h0 = mk_gas(1, 1234, gas_used=0,       gas_limit=1000000)
+        h1 = mk_gas(2, 2000, gas_used=1000001, gas_limit=1000000)
         hdr_arg = (HeaderBL(rlp.encode(h0)), HeaderBL(rlp.encode(h1)))
     elif hdr_hex == 'INVALID_EXTRA_AT_2':
         # Three headers: 0 and 1 valid, header[2] has

--- a/scripts/codegen-stateless-spec-output-check.sh
+++ b/scripts/codegen-stateless-spec-output-check.sh
@@ -621,6 +621,19 @@ run_fixture "chain1_valid_gas_hibit" 1                 0    ""           ""     
 # reached on the second loop iteration rather than the first.
 run_fixture "chain1_invalid_diff_at_1" 1               0    ""           ""                  ""    ""           ""           ""    "INVALID_DIFF_AT_1" || fail=1
 
+# Two headers: first valid (gas_used=0 <= gas_limit=1e6),
+# second has gas_used > gas_limit. K290 and K291 iterate
+# 2 times each (both pass on both headers); K240 iterates
+# 2 times -- passes on header 0 (0 <= 1e6), FAILS on
+# header 1 (1000001 > 1000000). Closes the K240 iteration
+# coverage gap: existing INVALID_DIFF_AT_1 covers K290's
+# per-header loop body at the LAST index, and
+# INVALID_EXTRA_AT_2 covers K291's, but K240's per-header
+# iteration was only ever exercised at index 0 via
+# INVALID_GAS. This fixture exercises K240's loop body
+# beyond the first iteration.
+run_fixture "chain1_invalid_gas_at_1"  1               0    ""           ""                  ""    ""           ""           ""    "INVALID_GAS_AT_1" || fail=1
+
 # Three headers: 0 and 1 valid, header[2] has extra_data
 # length 33. K290 iterates 3 times (all pass); K291 iterates
 # 3 times -- passes on 0 and 1, FAILS on 2. Tests K-PR


### PR DESCRIPTION
## Summary

Add fixture \`chain1_invalid_gas_at_1\`: N=2 headers where the first is valid (\`gas_used=0\` <= \`gas_limit=1_000_000\`) and the second has \`gas_used=1_000_001\` > \`gas_limit=1_000_000\`.

- K290 iterates twice, both pass (difficulty=0, nonce=zero, ommers=EMPTY on both).
- K291 iterates twice, both pass (empty extra_data).
- K240 iterates twice — passes on header 0, **fails on header 1**.

## Why this matters

Closes the K240 per-header iteration coverage gap:

| K-PR | per-header iteration coverage at non-zero index |
| ---- | ----------------------------------------------- |
| K290 | \`INVALID_DIFF_AT_1\` (existing)              |
| K291 | \`INVALID_EXTRA_AT_2\` (existing)             |
| K240 | \`INVALID_GAS_AT_1\` (**this PR** — previously missing) |
| K278 | (still missing — follow-up)                    |
| K277 | (still missing — follow-up)                    |
| K229 | \`INVALID_TS_AT_2\` (existing)                |
| K230 | \`INVALID_NM_AT_2\` (existing)                |

## Variety dimension

K-PR validator iteration coverage at non-first index. Verifies K240's loop body actually checks every header rather than short-circuiting on the first. A bug like "compute first-header verdict then return" would fail \`INVALID_GAS\` (index 0 fails) but pass this fixture — this fixture catches it.

## Test plan

- [x] \`scripts/codegen-stateless-spec-output-check.sh\` — all fixtures pass, including the new \`chain1_invalid_gas_at_1\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)