### PR TITLE
test(stateless): variety -- INVALID_BLOB_OVERMAX_AT_1 (K277 iteration coverage)

### DIFF
--- a/scripts/codegen-stateless-gen-fixture.py
+++ b/scripts/codegen-stateless-gen-fixture.py
@@ -114,7 +114,7 @@ if state_hex:
 HeaderBL = ByteList[MAX_BYTES_PER_HEADER]
 HeadersList = SszList[HeaderBL, MAX_WITNESS_HEADERS]
 hdr_arg = ()
-if hdr_hex in ('INVALID_TS', 'INVALID_NM', 'VALID_TWO', 'VALID_THREE', 'INVALID_DIFF_AT_1', 'INVALID_EXTRA_AT_2', 'INVALID_TS_AT_2', 'INVALID_NM_AT_2', 'VALID_TS_HIBIT', 'VALID_REALISTIC_TWO', 'VALID_EIGHT'):
+if hdr_hex in ('INVALID_TS', 'INVALID_NM', 'VALID_TWO', 'VALID_THREE', 'INVALID_DIFF_AT_1', 'INVALID_EXTRA_AT_2', 'INVALID_TS_AT_2', 'INVALID_NM_AT_2', 'VALID_TS_HIBIT', 'VALID_REALISTIC_TWO', 'VALID_EIGHT', 'INVALID_BLOB_OVERMAX_AT_1'):
     # Multi-header fixtures (N=2 or N=3) exercising K229 and
     # K230 in their accept and reject branches. Each header
     # individually passes K290 / K291 / K240 / K278 / K277.
@@ -210,6 +210,49 @@ if hdr_hex in ('INVALID_TS', 'INVALID_NM', 'VALID_TWO', 'VALID_THREE', 'INVALID_
             )
         h0 = mk_diff(1, 1234, 0)
         h1 = mk_diff(2, 2000, 1)  # difficulty != 0 at index 1
+        hdr_arg = (HeaderBL(rlp.encode(h0)), HeaderBL(rlp.encode(h1)))
+    elif hdr_hex == 'INVALID_BLOB_OVERMAX_AT_1':
+        # First header valid (blob_gas_used=0), second has
+        # blob_gas_used = 7 * 131072 = 917504. The value is a
+        # multiple of GAS_PER_BLOB=131072 (so K278 passes) but
+        # exceeds MAX_BLOB_GAS_PER_BLOCK = 6 * 131072 = 786432
+        # (so K277 rejects). K290 / K291 / K240 / K278 pass on
+        # both headers; K277 iterates -- passes on header 0
+        # (0 <= 786432), FAILS on header 1 (917504 > 786432).
+        # Closes the K277 iteration coverage gap, completing
+        # the per-K-PR iteration matrix begun by
+        # INVALID_DIFF_AT_1 (K290), INVALID_EXTRA_AT_2 (K291),
+        # INVALID_GAS_AT_1 (K240),
+        # INVALID_BLOB_MISALIGN_AT_1 (K278), INVALID_TS_AT_2
+        # (K229), INVALID_NM_AT_2 (K230).
+        def mk_blob_max(number, timestamp, blob_gas_used):
+            return Header(
+                parent_hash=Hash32(b'\x00' * 32),
+                ommers_hash=EMPTY_OMMER_HASH,
+                coinbase=b'\x00' * 20,
+                state_root=Hash32(b'\x00' * 32),
+                transactions_root=Hash32(b'\x00' * 32),
+                receipt_root=Hash32(b'\x00' * 32),
+                bloom=b'\x00' * 256,
+                difficulty=Uint(0),
+                number=Uint(number),
+                gas_limit=Uint(1000000),
+                gas_used=Uint(0),
+                timestamp=U256(timestamp),
+                extra_data=Bytes(b''),
+                prev_randao=Bytes32(b'\x00' * 32),
+                nonce=Bytes8(b'\x00' * 8),
+                base_fee_per_gas=Uint(0),
+                withdrawals_root=Hash32(b'\x00' * 32),
+                blob_gas_used=U64t(blob_gas_used),
+                excess_blob_gas=U64t(0),
+                parent_beacon_block_root=Hash32(b'\x00' * 32),
+                requests_hash=Hash32(b'\x00' * 32),
+                block_access_list_hash=Hash32(b'\x00' * 32),
+                slot_number=U64t(0),
+            )
+        h0 = mk_blob_max(1, 1234, blob_gas_used=0)
+        h1 = mk_blob_max(2, 2000, blob_gas_used=7 * 131072)  # 917504 > MAX
         hdr_arg = (HeaderBL(rlp.encode(h0)), HeaderBL(rlp.encode(h1)))
     elif hdr_hex == 'INVALID_EXTRA_AT_2':
         # Three headers: 0 and 1 valid, header[2] has

--- a/scripts/codegen-stateless-spec-output-check.sh
+++ b/scripts/codegen-stateless-spec-output-check.sh
@@ -621,6 +621,18 @@ run_fixture "chain1_valid_gas_hibit" 1                 0    ""           ""     
 # reached on the second loop iteration rather than the first.
 run_fixture "chain1_invalid_diff_at_1" 1               0    ""           ""                  ""    ""           ""           ""    "INVALID_DIFF_AT_1" || fail=1
 
+# Two headers: first valid (blob_gas_used=0), second has
+# blob_gas_used = 7 * 131072 = 917504. The value is a
+# multiple of GAS_PER_BLOB so K278 passes, but exceeds
+# MAX_BLOB_GAS_PER_BLOCK = 6 * 131072 = 786432 so K277
+# rejects. K290 / K291 / K240 / K278 iterate twice (all
+# pass); K277 iterates twice -- passes on header 0
+# (0 <= 786432), FAILS on header 1 (917504 > 786432).
+# Closes the K277 iteration coverage gap and (together with
+# the sister K240/K278 AT_1 fixtures) completes the per-K-PR
+# iteration matrix at the non-zero index.
+run_fixture "chain1_invalid_blob_overmax_at_1" 1       0    ""           ""                  ""    ""           ""           ""    "INVALID_BLOB_OVERMAX_AT_1" || fail=1
+
 # Three headers: 0 and 1 valid, header[2] has extra_data
 # length 33. K290 iterates 3 times (all pass); K291 iterates
 # 3 times -- passes on 0 and 1, FAILS on 2. Tests K-PR


### PR DESCRIPTION
## Summary

Add fixture \`chain1_invalid_blob_overmax_at_1\`: N=2 headers, first valid (\`blob_gas_used=0\`), second has \`blob_gas_used = 7 * 131072 = 917504\`. The value IS a multiple of \`GAS_PER_BLOB\` (so K278 accepts) but exceeds \`MAX_BLOB_GAS_PER_BLOCK = 6 * 131072 = 786432\` (so K277 rejects).

- K290 / K291 / K240 / K278 iterate twice, all pass.
- K277 iterates twice — passes on header 0, **fails on header 1**.

## Why this matters

Closes the K277 iteration coverage gap and (together with sister PRs) **completes the per-K-PR iteration matrix** at the non-zero index:

| K-PR | per-header iteration at non-zero index |
| ---- | -------------------------------------- |
| K290 | \`INVALID_DIFF_AT_1\` (existing)      |
| K291 | \`INVALID_EXTRA_AT_2\` (existing)     |
| K240 | \`INVALID_GAS_AT_1\` (sister PR)      |
| K278 | \`INVALID_BLOB_MISALIGN_AT_1\` (sister PR) |
| K277 | \`INVALID_BLOB_OVERMAX_AT_1\` (**this PR**) |
| K229 | \`INVALID_TS_AT_2\` (existing)        |
| K230 | \`INVALID_NM_AT_2\` (existing)        |

After all three \`at_1\` fixtures land, every K-PR validator has a regression fixture that catches a "short-circuit on first header" bug.

## Variety dimension

K277 validator iteration coverage at non-first index. A bug that returned after only examining the first header would pass this fixture incorrectly because the first header satisfies K277 — this fixture catches such a short-circuit.

## Test plan

- [x] \`scripts/codegen-stateless-spec-output-check.sh\` — all fixtures pass, including the new \`chain1_invalid_blob_overmax_at_1\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)