### PR TITLE
test(stateless): variety -- deepest spec path (validate_chain_config + validate_headers succeed)

### DIFF
--- a/scripts/codegen-stateless-spec-output-check.sh
+++ b/scripts/codegen-stateless-spec-output-check.sh
@@ -655,6 +655,32 @@ run_fixture "chain1_invalid_nm_at_2"    1              0    ""           ""     
 # NPR -> valid=False. ELF: valid=False from x11 stub. Match.
 run_fixture "chain1_valid_three"    1                  0    ""           ""                  ""    ""           ""           ""    "VALID_THREE" || fail=1
 
+# Deepest spec path so far -- BOTH validate_chain_config AND
+# validate_headers reach their success branches:
+#   chain_id      = 1
+#   fork          = 4 (Amsterdam)
+#   activation.bn = [0]
+#   blob_schedule = (14, 21, 11684671)  [== amsterdam expected]
+#   witness.headers = VALID_THREE
+#     (3 chained valid post-merge headers, parent_hash linked
+#      via keccak256(rlp(h_i)))
+# Spec flow:
+#   validate_chain_config(...) -> RETURNS active_fork
+#   validate_headers([h0,h1,h2]) -> returns (decoded, hashes)
+#                                   [contiguity OK]
+#   parent_header = h2
+#   chain_context, pre_state built
+#   execute_new_payload_request(EMPTY_NPR, ...) -> raises
+#     (execution_payload has zero block_hash etc.; doesn't
+#      match the parent_hash chain we just built) -> caught
+#     at verify_stateless_new_payload -> False.
+# All earlier fixtures bailed at validate_chain_config OR
+# validate_headers; this fixture is the first to drive the
+# spec past both checks into execute_new_payload_request.
+# Variety dimension: spec code path coverage at the deepest
+# pre-execution layer.
+run_fixture "chain1_fork4_valid_chain" 1               4    ""           ""                  ""    "0"          ""           "14:21:11684671" "VALID_THREE" || fail=1
+
 # N=8 chained valid post-merge headers. Extends K-PR
 # iteration depth past the previous N=3 ceiling:
 #   K229 performs 7 strict-increase timestamp pair comparisons


### PR DESCRIPTION
## Summary

Add fixture \`chain1_fork4_valid_chain\`: the deepest spec code path exercised so far. **Both** \`validate_chain_config\` **and** \`validate_headers\` reach their success branches.

| field | value |
| ----- | ----- |
| chain_id | 1 |
| fork | 4 (Amsterdam) |
| \`activation.block_number\` | \`[0]\` |
| \`blob_schedule\` | \`(14, 21, 11684671)\` (== amsterdam expected) |
| \`witness.headers\` | \`VALID_THREE\` (3 chained valid post-merge headers, parent_hash linked via \`keccak256(rlp(h_i))\`) |

## Spec flow

1. \`validate_chain_config(...)\` → **returns** \`active_fork\` (sister to PR #7067).
2. \`validate_headers([h0, h1, h2])\` → **returns** \`(decoded, hashes)\` — contiguity OK because the parent_hash chain is correctly keccak-computed.
3. \`parent_header = h2\`; chain_context + pre_state built.
4. \`execute_new_payload_request(empty_NPR, pre_state, ctx, [])\` → raises (\`execution_payload\` has zero block_hash etc., doesn't match the parent_hash chain we just built) → caught → \`successful_validation = False\`.

Until this fixture, every prior fixture's spec bailed out at \`validate_chain_config\` or at \`validate_headers\`. This is the **first input** that drives the spec past both checks into \`execute_new_payload_request\`.

## Variety dimension

Spec code path coverage at the pre-execution layer. Distinct from PR #7067 which passed only \`validate_chain_config\`; this passes both that **and** \`validate_headers\`. From the ELF's perspective the 73-byte output is identical (\`empty_npr_root\` + \`valid=False\` + chain_config echo), so the fixture passes; the fixture exists to lock in the byte-output at this deepest path before the RISC-V implementation grows real header-validation + STF logic.

## Test plan

- [x] \`scripts/codegen-stateless-spec-output-check.sh\` — all fixtures pass, including the new \`chain1_fork4_valid_chain\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)