### PR TITLE
test(stateless): variety -- InactiveForkConfigError spec path

### DIFF
--- a/scripts/codegen-stateless-spec-output-check.sh
+++ b/scripts/codegen-stateless-spec-output-check.sh
@@ -330,6 +330,21 @@ run_fixture "chain1_blob"           1                  0    ""           ""     
 # byte-for-byte against the spec.
 run_fixture "chain1_blob_realistic" 1                  0    ""           ""                  ""    ""           ""           "14:21:11684671" || fail=1
 
+# Spec InactiveForkConfigError path. Identical to the
+# fork=4 + Amsterdam-blob fixture except activation.bn=[1]
+# (instead of [0]). _is_activation_active gets:
+#   activation.block_number = Uint(1) (not None)
+#   execution_payload.block_number = 0 (empty default)
+#   0 < 1 -> True -> returns False -> spec raises
+#   InactiveForkConfigError. The exception is caught at
+#   verify_stateless_new_payload, successful_validation=False.
+# Variety dimension: SPEC code path = InactiveForkConfigError
+# inside validate_chain_config. Until this fixture, every
+# fork=4 + Amsterdam-blob input hit
+# _is_activation_active's success branch (bn=[0] passes the
+# 0 < 0 check). This fixture exercises the False return.
+run_fixture "chain1_fork4_inactive_bn" 1               4    ""           ""                  ""    "1"          ""           "14:21:11684671" || fail=1
+
 # Valid post-merge header with REALISTIC non-zero values for
 # every K-PR-IGNORED field (parent_hash, coinbase, state_root,
 # transactions_root, receipt_root, bloom, prev_randao,


### PR DESCRIPTION
## Summary

Add fixture \`chain1_fork4_inactive_bn\`: drives the spec into the **\`InactiveForkConfigError\`** branch of \`validate_chain_config\` — a spec code path not exercised by any prior fixture.

Configuration (identical to PR #7067 except \`activation.bn=[1]\` instead of \`[0]\`):

| field | value |
| ----- | ----- |
| chain_id | 1 |
| fork | 4 (Amsterdam) |
| \`activation.block_number\` | \`[1]\` ← was \`[0]\` |
| \`blob_schedule\` | \`(14, 21, 11684671)\` |
| headers | empty |

## Spec flow

1. \`_is_activation_active(activation, execution_payload)\`:
   - \`activation.block_number = Uint(1)\` (not None)
   - \`execution_payload.block_number = 0\` (empty default)
   - \`0 < 1\` → True → \`_is_activation_active\` returns **False**
2. \`validate_chain_config\` raises \`InactiveForkConfigError\`
3. caught at \`verify_stateless_new_payload\` → \`successful_validation = False\`

Until this fixture, every \`fork=4 + Amsterdam-blob\` input hit \`_is_activation_active\`'s success branch (PR #7067 used \`activation.bn=[0]\`, so \`0 < 0\` was False → returned True). This fixture exercises the inverse: activation set high enough that the empty \`execution_payload\` fails the active check.

## Variety dimension

Spec error path coverage. \`InactiveForkConfigError\` joins the previously-exercised errors (\`InvalidForkActivationError\` from empty activation; \`UnsupportedForkConfigError\` from wrong fork or blob_schedule).

From the ELF's perspective the 73-byte output is identical (\`empty_npr_root\` + \`valid=False\` + chain_config echo), so the fixture passes. The fixture locks in byte-output for this distinct spec branch before the RISC-V implementation grows real activation checks.

## Test plan

- [x] \`scripts/codegen-stateless-spec-output-check.sh\` — all fixtures pass, including the new \`chain1_fork4_inactive_bn\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)