### PR TITLE
test(stateless): variety -- UnsupportedForkConfigError via blob mismatch

### DIFF
--- a/scripts/codegen-stateless-spec-output-check.sh
+++ b/scripts/codegen-stateless-spec-output-check.sh
@@ -330,6 +330,25 @@ run_fixture "chain1_blob"           1                  0    ""           ""     
 # byte-for-byte against the spec.
 run_fixture "chain1_blob_realistic" 1                  0    ""           ""                  ""    ""           ""           "14:21:11684671" || fail=1
 
+# UnsupportedForkConfigError via blob_schedule mismatch.
+# Configuration:
+#   chain_id      = 1
+#   fork          = 4 (Amsterdam -- passes the fork check)
+#   activation.bn = [0] (passes _is_activation_active)
+#   blob_schedule = (15, 21, 11684671)  <-- target off by 1
+#                                           (Amsterdam expects 14)
+# Spec flow:
+#   _is_activation_active(...)      -> True
+#   active_fork.fork == Amsterdam   -> True
+#   blob_schedule != amsterdam exp  -> raises
+#     UnsupportedForkConfigError("...blob_schedule does not
+#     match Amsterdam"). Caught -> successful_validation=False.
+# Distinct sub-branch of UnsupportedForkConfigError. The
+# OTHER UnsupportedForkConfigError ("Amsterdam stateless guest
+# cannot execute X") is exercised by every fork=0/1 fixture;
+# the blob-mismatch sub-branch was uncovered until now.
+run_fixture "chain1_fork4_wrong_blob"  1               4    ""           ""                  ""    "0"          ""           "15:21:11684671" || fail=1
+
 # Valid post-merge header with REALISTIC non-zero values for
 # every K-PR-IGNORED field (parent_hash, coinbase, state_root,
 # transactions_root, receipt_root, bloom, prev_randao,


### PR DESCRIPTION
## Summary

Add fixture \`chain1_fork4_wrong_blob\`: drives the spec into the **blob_schedule sub-branch** of \`UnsupportedForkConfigError\` — distinct from the **fork sub-branch** that every prior \`fork=0\`/\`fork=1\` fixture exercises.

| field | value |
| ----- | ----- |
| chain_id | 1 |
| fork | 4 (Amsterdam — **passes** the fork check) |
| \`activation.block_number\` | \`[0]\` (passes \`_is_activation_active\`) |
| \`blob_schedule\` | \`(15, 21, 11684671)\` — **target off by 1** (Amsterdam expects 14) |

## Spec flow

1. \`_is_activation_active(...)\` → True
2. \`active_fork.fork == ProtocolFork.Amsterdam\` → True
3. \`blob_schedule != _expected_amsterdam_blob_schedule()\` → raises \`UnsupportedForkConfigError("ChainConfig active_fork blob_schedule does not match Amsterdam")\`
4. caught at \`verify_stateless_new_payload\` → \`successful_validation = False\`

## Why this matters

\`UnsupportedForkConfigError\` has TWO sub-branches in \`validate_chain_config\` (\`stateless.py:331..339\`):

| sub-branch | message | prior coverage |
| ---------- | ------- | -------------- |
| fork != Amsterdam | \`"cannot execute X"\` | every \`fork=0\`/\`fork=1\` fixture (already covered) |
| blob_schedule != amsterdam | \`"blob_schedule does not match Amsterdam"\` | **this PR** (previously uncovered) |

The two errors have different message strings; before this PR, no fixture exercised message branch 2.

## Variety dimension

Spec error message coverage — \`UnsupportedForkConfigError\` blob-mismatch sub-branch. The byte output is identical (\`empty_npr_root\` + \`valid=False\` + chain_config echo with the wrong blob_schedule echoed back), so the fixture passes; it locks in byte-output for this distinct spec branch before the RISC-V implementation grows real blob_schedule validation.

## Test plan

- [x] \`scripts/codegen-stateless-spec-output-check.sh\` — all fixtures pass, including the new \`chain1_fork4_wrong_blob\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)