### PR TITLE
test(stateless): variety -- "headers not contiguous" spec path

### DIFF
--- a/scripts/codegen-stateless-spec-output-check.sh
+++ b/scripts/codegen-stateless-spec-output-check.sh
@@ -330,6 +330,34 @@ run_fixture "chain1_blob"           1                  0    ""           ""     
 # byte-for-byte against the spec.
 run_fixture "chain1_blob_realistic" 1                  0    ""           ""                  ""    ""           ""           "14:21:11684671" || fail=1
 
+# Spec "Witness headers are not contiguous" path.
+# Configuration:
+#   chain_id        = 1
+#   fork            = 4 (Amsterdam -- passes validate_chain_config)
+#   activation.bn   = [0]
+#   blob_schedule   = (14, 21, 11684671)  [amsterdam expected]
+#   witness.headers = VALID_TWO
+#     (N=2 NON-chained -- h0.parent_hash=zero, h1.parent_hash=
+#      zero; the parent_hash chain through keccak256(rlp(h0))
+#      is broken because h1.parent_hash != keccak(h0))
+# Spec flow:
+#   validate_chain_config(...) -> SUCCESS
+#   validate_headers([h0, h1]):
+#     decode h0, h1 (RLP OK)
+#     block_hashes = [keccak(h0), keccak(h1)]
+#     for i=1: headers[1].parent_hash (= zero) !=
+#              block_hashes[0] (= keccak(h0))
+#     -> raises Exception("Witness headers are not contiguous")
+#   caught at verify_stateless_new_payload -> False.
+# Variety dimension: spec error path
+# "Witness headers are not contiguous" -- distinct from the
+# validate_chain_config errors and from the empty-headers
+# IndexError. All prior fork=4 + Amsterdam fixtures either
+# had empty headers (IndexError) or chained headers (success).
+# This is the first fixture exercising the contiguity-failure
+# branch of validate_headers.
+run_fixture "chain1_fork4_noncontig"   1               4    ""           ""                  ""    "0"          ""           "14:21:11684671" "VALID_TWO" || fail=1
+
 # Valid post-merge header with REALISTIC non-zero values for
 # every K-PR-IGNORED field (parent_hash, coinbase, state_root,
 # transactions_root, receipt_root, bloom, prev_randao,


### PR DESCRIPTION
## Summary

Add fixture \`chain1_fork4_noncontig\`: drives the spec into the \`validate_headers\` **"Witness headers are not contiguous"** branch — a spec error path distinct from the \`validate_chain_config\` errors and from the empty-headers \`IndexError\`.

| field | value |
| ----- | ----- |
| chain_id | 1 |
| fork | 4 (Amsterdam — passes \`validate_chain_config\`) |
| \`activation.block_number\` | \`[0]\` |
| \`blob_schedule\` | \`(14, 21, 11684671)\` |
| \`witness.headers\` | \`VALID_TWO\` (N=2 **non-chained**: both \`parent_hash\` = zero; the chain through \`keccak256(rlp(h0))\` is broken) |

## Spec flow

1. \`validate_chain_config(...)\` → SUCCESS
2. \`validate_headers([h0, h1])\`:
   - decode h0, h1 (RLP OK)
   - \`block_hashes = [keccak(h0), keccak(h1)]\`
   - for i=1: \`headers[1].parent_hash (= zero) != block_hashes[0] (= keccak(h0))\`
   - → raises \`Exception("Witness headers are not contiguous")\`
3. caught at \`verify_stateless_new_payload\` → \`successful_validation = False\`

## Why this matters

Until this fixture, every \`fork=4 + Amsterdam-blob\` fixture either:
- had empty \`witness.headers\` (\`validate_headers\` returned \`[]\`, later \`IndexError\` on \`parent_header = headers[-1]\`), or
- had chained headers via \`keccak256\` (\`VALID_THREE\` in PR #7068).

This is the first fixture exercising the contiguity-failure branch of \`validate_headers\`.

## Variety dimension

Distinct spec error path — **"Witness headers are not contiguous"** — exercised for the first time. The byte output is identical (\`empty_npr_root\` + \`valid=False\` + chain_config echo), so the fixture passes; it locks in byte-output for this branch before the RISC-V implementation grows a real \`parent_hash\` chain validator (a K-PR that doesn't exist yet — K229/K230 cover timestamps/numbers, not parent_hash linkage).

## Test plan

- [x] \`scripts/codegen-stateless-spec-output-check.sh\` — all fixtures pass, including the new \`chain1_fork4_noncontig\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)