### PR TITLE
test(stateless): variety -- rlp.DecodingError spec path

### DIFF
--- a/scripts/codegen-stateless-spec-output-check.sh
+++ b/scripts/codegen-stateless-spec-output-check.sh
@@ -330,6 +330,28 @@ run_fixture "chain1_blob"           1                  0    ""           ""     
 # byte-for-byte against the spec.
 run_fixture "chain1_blob_realistic" 1                  0    ""           ""                  ""    ""           ""           "14:21:11684671" || fail=1
 
+# Spec rlp.DecodingError path inside validate_headers.
+# Configuration:
+#   chain_id        = 1
+#   fork            = 4 (Amsterdam, passes validate_chain_config)
+#   activation.bn   = [0]
+#   blob_schedule   = (14, 21, 11684671)  [amsterdam expected]
+#   witness.headers = single 32-byte 0xAA blob (not RLP-valid)
+# Spec flow:
+#   validate_chain_config(...) -> SUCCESS
+#   validate_headers([0xAA * 32]):
+#     _decode_header tries rlp.decode_to(Header, ...) -> fails
+#       (the blob doesn't have the Header RLP shape)
+#     tries rlp.decode_to(PreviousForkHeader, ...) -> also fails
+#     -> raises rlp.DecodingError
+#   caught at verify_stateless_new_payload -> False.
+# Variety dimension: spec error path = rlp.DecodingError
+# inside _decode_header (validate_headers's RLP-parse step).
+# Distinct from the "not contiguous" path (PR #7071) which
+# exercises VALID RLP that fails parent_hash linkage, and
+# from the IndexError path (empty headers).
+run_fixture "chain1_fork4_bad_rlp_header" 1            4    ""           ""                  ""    "0"          ""           "14:21:11684671" "$(printf 'aa%.0s' {1..32})" || fail=1
+
 # Valid post-merge header with REALISTIC non-zero values for
 # every K-PR-IGNORED field (parent_hash, coinbase, state_root,
 # transactions_root, receipt_root, bloom, prev_randao,


### PR DESCRIPTION
## Summary

Add fixture \`chain1_fork4_bad_rlp_header\`: drives the spec into the \`rlp.DecodingError\` branch of \`validate_headers\`'s \`_decode_header\` — a spec error path distinct from the "not contiguous" branch (PR #7071) and the empty-headers \`IndexError\`.

| field | value |
| ----- | ----- |
| chain_id | 1 |
| fork | 4 (Amsterdam, passes \`validate_chain_config\`) |
| \`activation.block_number\` | \`[0]\` |
| \`blob_schedule\` | \`(14, 21, 11684671)\` |
| \`witness.headers\` | single 32-byte \`0xAA\` blob (not RLP-valid as either \`Header\` or \`PreviousForkHeader\`) |

## Spec flow

1. \`validate_chain_config(...)\` → SUCCESS
2. \`validate_headers([0xAA × 32])\`:
   - \`_decode_header\` tries \`rlp.decode_to(Header, ...)\` → fails (the blob has no leading list-prefix matching a Header)
   - tries \`rlp.decode_to(PreviousForkHeader, ...)\` → also fails
   - → raises \`rlp.DecodingError\`
3. caught at \`verify_stateless_new_payload\` → \`successful_validation = False\`

## Why this matters

The three \`validate_headers\` failure modes are now distinguished:

| Failure | Exercised by |
| ------- | ------------ |
| Empty list → \`IndexError\` | every empty-headers fixture |
| Bad RLP → \`DecodingError\` | **this PR** |
| Contiguity → \`Exception("not contiguous")\` | PR #7071 |

## Variety dimension

Spec error path coverage = \`rlp.DecodingError\` inside \`_decode_header\`. The byte output is identical (\`empty_npr_root\` + \`valid=False\` + chain_config echo), so the fixture passes. It locks in byte-output for this distinct spec branch before the RISC-V implementation grows a real \`Header\`-RLP-parse step in the witness validation pipeline.

## Test plan

- [x] \`scripts/codegen-stateless-spec-output-check.sh\` — all fixtures pass, including the new \`chain1_fork4_bad_rlp_header\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)